### PR TITLE
fix(gcp-cloudfunctions): gen2 patch instance-count, gen1 eventTrigger round-trip, gen1 field round-trip, honor updateMask

### DIFF
--- a/server/gcp/cloudfunctions/gen1meta.go
+++ b/server/gcp/cloudfunctions/gen1meta.go
@@ -18,6 +18,18 @@ type gen1Meta struct {
 	dockerRegistry      string
 	buildID             string
 	versionID           int64
+	// The remaining fields are client-owned inputs a real gen1 client reads back
+	// from Get/List. They have no portable Serverless-driver equivalent, so the
+	// wire handler carries them here and echoes them from toCloudFunction.
+	description                string
+	eventTrigger               *eventTrigger
+	sourceRepository           *sourceRepository
+	sourceArchiveURL           string
+	sourceUploadURL            string
+	maxInstances               int
+	minInstances               int
+	vpcConnector               string
+	vpcConnectorEgressSettings string
 }
 
 // newGen1Meta builds the initial metadata for a freshly created v1 function,
@@ -25,11 +37,20 @@ type gen1Meta struct {
 // Cloud Functions assigns.
 func newGen1Meta(body *cloudFunction, project string) *gen1Meta {
 	m := &gen1Meta{
-		serviceAccountEmail: body.ServiceAccountEmail,
-		ingressSettings:     body.IngressSettings,
-		dockerRegistry:      body.DockerRegistry,
-		buildID:             newBuildID(),
-		versionID:           1,
+		serviceAccountEmail:        body.ServiceAccountEmail,
+		ingressSettings:            body.IngressSettings,
+		dockerRegistry:             body.DockerRegistry,
+		buildID:                    newBuildID(),
+		versionID:                  1,
+		description:                body.Description,
+		eventTrigger:               body.EventTrigger,
+		sourceRepository:           body.SourceRepository,
+		sourceArchiveURL:           body.SourceArchiveURL,
+		sourceUploadURL:            body.SourceUploadURL,
+		maxInstances:               body.MaxInstances,
+		minInstances:               body.MinInstances,
+		vpcConnector:               body.VPCConnector,
+		vpcConnectorEgressSettings: body.VPCConnectorEgressSettings,
 	}
 
 	applyGen1Defaults(m, project)
@@ -69,10 +90,11 @@ func (h *Handler) putGen1Meta(name string, m *gen1Meta) {
 }
 
 // bumpGen1Meta advances the deploy generation for an updated function: versionId
-// increments, a new build id is cut, and any gen1 metadata carried in the PATCH
-// body is applied. A function whose metadata is missing (created straight through
-// the portable API) is seeded first so the bump still lands on version 2.
-func (h *Handler) bumpGen1Meta(name string, body *cloudFunction, project string) {
+// increments, a new build id is cut, and the gen1 metadata carried in the PATCH
+// body is applied under the update mask. A function whose metadata is missing
+// (created straight through the portable API) is seeded first so the bump still
+// lands on version 2.
+func (h *Handler) bumpGen1Meta(name string, body *cloudFunction, project string, mask updateMask) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -82,6 +104,8 @@ func (h *Handler) bumpGen1Meta(name string, body *cloudFunction, project string)
 		applyGen1Defaults(m, project)
 	}
 
+	// serviceAccountEmail/ingressSettings/dockerRegistry are always server-defaulted
+	// in real gen1, so they are set when supplied but never cleared.
 	if body.ServiceAccountEmail != "" {
 		m.serviceAccountEmail = body.ServiceAccountEmail
 	}
@@ -94,9 +118,40 @@ func (h *Handler) bumpGen1Meta(name string, body *cloudFunction, project string)
 		m.dockerRegistry = body.DockerRegistry
 	}
 
+	applyGen1PatchFields(m, body, mask)
+
 	m.versionID++
 	m.buildID = newBuildID()
 	h.gen1Meta[name] = m
+}
+
+// applyGen1PatchFields applies the client-owned gen1 fields from a PATCH body
+// under the update mask: a masked field absent from the body is cleared, while an
+// unmasked (legacy) PATCH merges only non-zero values.
+func applyGen1PatchFields(m *gen1Meta, body *cloudFunction, mask updateMask) {
+	applyMaskedStr(mask, "description", &m.description, body.Description)
+	applyMaskedStr(mask, "vpcConnector", &m.vpcConnector, body.VPCConnector)
+	applyMaskedStr(mask, "vpcConnectorEgressSettings", &m.vpcConnectorEgressSettings, body.VPCConnectorEgressSettings)
+	applyMaskedInt(mask, "maxInstances", &m.maxInstances, body.MaxInstances)
+	applyMaskedInt(mask, "minInstances", &m.minInstances, body.MinInstances)
+
+	if mask.covers("eventTrigger") && (mask.explicit() || body.EventTrigger != nil) {
+		m.eventTrigger = body.EventTrigger
+	}
+
+	if mask.covers("sourceRepository") && (mask.explicit() || body.SourceRepository != nil) {
+		m.sourceRepository = body.SourceRepository
+	}
+
+	// A redeploy that carries a fresh source records it so Get echoes the current
+	// deploy source.
+	if body.SourceArchiveURL != "" {
+		m.sourceArchiveURL = body.SourceArchiveURL
+	}
+
+	if body.SourceUploadURL != "" {
+		m.sourceUploadURL = body.SourceUploadURL
+	}
 }
 
 // gen1MetaFor returns a copy of the stored metadata for name, or freshly

--- a/server/gcp/cloudfunctions/gen2.go
+++ b/server/gcp/cloudfunctions/gen2.go
@@ -335,7 +335,7 @@ func (h *Handler) patchV2(w http.ResponseWriter, r *http.Request, p v2Path) {
 
 	fn.revisionSeq++
 
-	mergeGen2(fn, &body)
+	mergeGen2(fn, &body, parseUpdateMask(r.URL.Query()))
 	computeGen2Outputs(fn, p, false)
 
 	updated := cloneGen2(fn)
@@ -440,56 +440,69 @@ func (h *Handler) generateUploadURLV2(w http.ResponseWriter, r *http.Request, p 
 	})
 }
 
-// mergeGen2 applies the non-nil fields of a patch body onto the stored function.
-func mergeGen2(dst, src *gen2Function) {
-	if src.Description != "" {
-		dst.Description = src.Description
-	}
+// mergeGen2 applies a patch body onto the stored function under the update mask.
+// A partial buildConfig/serviceConfig patch merges sub-fields rather than
+// replacing the whole object, so a mask that touches one sub-field (or omits a
+// mask entirely) never wipes the runtime, entryPoint or scaling the client left
+// unset.
+func mergeGen2(dst, src *gen2Function, mask updateMask) {
+	applyMaskedStr(mask, "description", &dst.Description, src.Description)
 
-	if src.Labels != nil {
+	if mask.covers("labels") && (mask.explicit() || src.Labels != nil) {
 		dst.Labels = src.Labels
 	}
 
 	if src.BuildConfig != nil {
-		dst.BuildConfig = src.BuildConfig
+		mergeBuildConfig(dst, src.BuildConfig, mask)
 	}
 
 	if src.ServiceConfig != nil {
-		mergeServiceConfig(dst, src.ServiceConfig)
+		mergeServiceConfig(dst, src.ServiceConfig, mask)
 	}
 
-	if src.EventTrigger != nil {
+	if src.EventTrigger != nil && mask.covers("eventTrigger") {
 		dst.EventTrigger = src.EventTrigger
 	}
 }
 
-func mergeServiceConfig(dst *gen2Function, sc *gen2ServiceConfig) {
+// mergeBuildConfig merges the patch buildConfig sub-fields under the mask. The
+// build id is output-only (computeGen2Outputs recuts it) and is not merged here.
+func mergeBuildConfig(dst *gen2Function, bc *gen2BuildConfig, mask updateMask) {
+	if dst.BuildConfig == nil {
+		dst.BuildConfig = &gen2BuildConfig{}
+	}
+
+	d := dst.BuildConfig
+	applyMaskedStr(mask, "buildConfig.runtime", &d.Runtime, bc.Runtime)
+	applyMaskedStr(mask, "buildConfig.entryPoint", &d.EntryPoint, bc.EntryPoint)
+	applyMaskedStr(mask, "buildConfig.dockerRegistry", &d.DockerRegistry, bc.DockerRegistry)
+	applyMaskedStr(mask, "buildConfig.dockerRepository", &d.DockerRepository, bc.DockerRepository)
+
+	if mask.covers("buildConfig.environmentVariables") && (mask.explicit() || bc.EnvironmentVariables != nil) {
+		d.EnvironmentVariables = bc.EnvironmentVariables
+	}
+
+	if mask.covers("buildConfig.source") && bc.Source != nil {
+		d.Source = bc.Source
+	}
+}
+
+func mergeServiceConfig(dst *gen2Function, sc *gen2ServiceConfig, mask updateMask) {
 	if dst.ServiceConfig == nil {
 		dst.ServiceConfig = &gen2ServiceConfig{}
 	}
 
-	if sc.ServiceAccountEmail != "" {
-		dst.ServiceConfig.ServiceAccountEmail = sc.ServiceAccountEmail
-	}
+	d := dst.ServiceConfig
+	applyMaskedStr(mask, "serviceConfig.serviceAccountEmail", &d.ServiceAccountEmail, sc.ServiceAccountEmail)
+	applyMaskedStr(mask, "serviceConfig.availableMemory", &d.AvailableMemory, sc.AvailableMemory)
+	applyMaskedStr(mask, "serviceConfig.availableCpu", &d.AvailableCPU, sc.AvailableCPU)
+	applyMaskedInt(mask, "serviceConfig.timeoutSeconds", &d.TimeoutSeconds, sc.TimeoutSeconds)
+	applyMaskedStr(mask, "serviceConfig.ingressSettings", &d.IngressSettings, sc.IngressSettings)
+	applyMaskedInt(mask, "serviceConfig.maxInstanceCount", &d.MaxInstanceCount, sc.MaxInstanceCount)
+	applyMaskedInt(mask, "serviceConfig.minInstanceCount", &d.MinInstanceCount, sc.MinInstanceCount)
 
-	if sc.AvailableMemory != "" {
-		dst.ServiceConfig.AvailableMemory = sc.AvailableMemory
-	}
-
-	if sc.AvailableCPU != "" {
-		dst.ServiceConfig.AvailableCPU = sc.AvailableCPU
-	}
-
-	if sc.TimeoutSeconds != 0 {
-		dst.ServiceConfig.TimeoutSeconds = sc.TimeoutSeconds
-	}
-
-	if sc.IngressSettings != "" {
-		dst.ServiceConfig.IngressSettings = sc.IngressSettings
-	}
-
-	if sc.EnvironmentVariables != nil {
-		dst.ServiceConfig.EnvironmentVariables = sc.EnvironmentVariables
+	if mask.covers("serviceConfig.environmentVariables") && (mask.explicit() || sc.EnvironmentVariables != nil) {
+		d.EnvironmentVariables = sc.EnvironmentVariables
 	}
 }
 

--- a/server/gcp/cloudfunctions/handler.go
+++ b/server/gcp/cloudfunctions/handler.go
@@ -597,8 +597,9 @@ func (h *Handler) update(w http.ResponseWriter, r *http.Request, p functionPath)
 	}
 
 	// A deploy bumps versionId and cuts a fresh build, matching real Cloud
-	// Functions, and applies any changed gen1 metadata carried in the PATCH body.
-	h.bumpGen1Meta(p.fullName(), &body, p.project)
+	// Functions, and applies the gen1 metadata carried in the PATCH body under the
+	// request's update mask (so a masked field can be cleared).
+	h.bumpGen1Meta(p.fullName(), &body, p.project, parseUpdateMask(r.URL.Query()))
 
 	resource := h.toCloudFunction(info, p)
 	writeJSON(w, http.StatusOK, operation{
@@ -763,24 +764,38 @@ func (h *Handler) toCloudFunction(info *sdrv.FunctionInfo, p functionPath) cloud
 	meta := h.gen1MetaFor(scope.fullName(), p.project)
 
 	cf := cloudFunction{
-		Name:                scope.fullName(),
-		Status:              "ACTIVE",
-		Runtime:             info.Runtime,
-		EntryPoint:          info.Handler,
-		AvailableMemory:     info.Memory,
-		Labels:              info.Tags,
-		EnvVariables:        info.Environment,
-		UpdateTime:          info.LastModified,
-		VersionID:           strconv.FormatInt(meta.versionID, 10),
-		ServiceAccountEmail: meta.serviceAccountEmail,
-		IngressSettings:     meta.ingressSettings,
-		DockerRegistry:      meta.dockerRegistry,
-		BuildID:             meta.buildID,
-		// Real Cloud Functions always advertises the HTTPS trigger URL; clients
-		// read it to invoke the function.
-		HTTPSTrigger: &httpsTrigger{
+		Name:                       scope.fullName(),
+		Status:                     "ACTIVE",
+		Runtime:                    info.Runtime,
+		EntryPoint:                 info.Handler,
+		AvailableMemory:            info.Memory,
+		Labels:                     info.Tags,
+		EnvVariables:               info.Environment,
+		UpdateTime:                 info.LastModified,
+		VersionID:                  strconv.FormatInt(meta.versionID, 10),
+		ServiceAccountEmail:        meta.serviceAccountEmail,
+		IngressSettings:            meta.ingressSettings,
+		DockerRegistry:             meta.dockerRegistry,
+		BuildID:                    meta.buildID,
+		Description:                meta.description,
+		SourceArchiveURL:           meta.sourceArchiveURL,
+		SourceUploadURL:            meta.sourceUploadURL,
+		SourceRepository:           meta.sourceRepository,
+		MaxInstances:               meta.maxInstances,
+		MinInstances:               meta.minInstances,
+		VPCConnector:               meta.vpcConnector,
+		VPCConnectorEgressSettings: meta.vpcConnectorEgressSettings,
+	}
+
+	// gen1 functions carry exactly one trigger: an event-driven function created
+	// with an eventTrigger echoes it (and NO httpsTrigger); otherwise real Cloud
+	// Functions advertises the HTTPS trigger URL clients invoke through.
+	if meta.eventTrigger != nil {
+		cf.EventTrigger = meta.eventTrigger
+	} else {
+		cf.HTTPSTrigger = &httpsTrigger{
 			URL: "https://" + scope.location + "-" + scope.project + ".cloudfunctions.net/" + scope.name,
-		},
+		}
 	}
 
 	if info.Timeout > 0 {

--- a/server/gcp/cloudfunctions/patch_fields_sdk_test.go
+++ b/server/gcp/cloudfunctions/patch_fields_sdk_test.go
@@ -1,0 +1,223 @@
+package cloudfunctions_test
+
+import (
+	"context"
+	"testing"
+
+	cloudfunctions "google.golang.org/api/cloudfunctions/v1"
+	cloudfunctions2 "google.golang.org/api/cloudfunctions/v2"
+)
+
+// TestSDKGen2PatchInstanceCount reproduces the dropped-scaling finding: a gen2
+// PATCH of serviceConfig.maxInstanceCount must reflect on the next Get instead of
+// being silently discarded by the merge.
+func TestSDKGen2PatchInstanceCount(t *testing.T) {
+	svc := newGCPV2Service(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+	name := parent + "/functions/scale"
+
+	if _, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions2.Function{
+		BuildConfig: &cloudfunctions2.BuildConfig{Runtime: "go121", EntryPoint: "Hello"},
+		ServiceConfig: &cloudfunctions2.ServiceConfig{
+			MaxInstanceCount: 7,
+			MinInstanceCount: 1,
+		},
+	}).FunctionId("scale").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.ServiceConfig.MaxInstanceCount != 7 {
+		t.Fatalf("maxInstanceCount = %d at create, want 7", got.ServiceConfig.MaxInstanceCount)
+	}
+
+	if _, err := svc.Projects.Locations.Functions.Patch(name, &cloudfunctions2.Function{
+		ServiceConfig: &cloudfunctions2.ServiceConfig{MaxInstanceCount: 20},
+	}).UpdateMask("serviceConfig.maxInstanceCount").Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got2, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	if got2.ServiceConfig.MaxInstanceCount != 20 {
+		t.Fatalf("maxInstanceCount = %d after patch, want 20", got2.ServiceConfig.MaxInstanceCount)
+	}
+
+	// The unmasked minInstanceCount must survive the scaling patch.
+	if got2.ServiceConfig.MinInstanceCount != 1 {
+		t.Fatalf("minInstanceCount = %d after patch, want 1 preserved", got2.ServiceConfig.MinInstanceCount)
+	}
+}
+
+// TestSDKGen2PatchPartialBuildConfig reproduces the wholesale-buildConfig-replace
+// finding: a partial buildConfig PATCH must merge sub-fields, leaving the
+// unmasked runtime and entryPoint intact.
+func TestSDKGen2PatchPartialBuildConfig(t *testing.T) {
+	svc := newGCPV2Service(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+	name := parent + "/functions/build"
+
+	if _, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions2.Function{
+		BuildConfig: &cloudfunctions2.BuildConfig{Runtime: "go121", EntryPoint: "Hello"},
+	}).FunctionId("build").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Functions.Patch(name, &cloudfunctions2.Function{
+		BuildConfig: &cloudfunctions2.BuildConfig{
+			EnvironmentVariables: map[string]string{"K": "V"},
+		},
+	}).UpdateMask("buildConfig.environmentVariables").Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	if got.BuildConfig.Runtime != "go121" {
+		t.Fatalf("buildConfig.runtime = %q after partial patch, want go121 preserved", got.BuildConfig.Runtime)
+	}
+
+	if got.BuildConfig.EntryPoint != "Hello" {
+		t.Fatalf("buildConfig.entryPoint = %q after partial patch, want Hello preserved", got.BuildConfig.EntryPoint)
+	}
+
+	if got.BuildConfig.EnvironmentVariables["K"] != "V" {
+		t.Fatalf("buildConfig.environmentVariables = %v, want K=V applied", got.BuildConfig.EnvironmentVariables)
+	}
+}
+
+// TestSDKGen1EventTriggerRoundTrip reproduces the missing-eventTrigger finding: an
+// event-driven gen1 function must round-trip its eventTrigger and advertise NO
+// httpsTrigger (the two are mutually exclusive).
+func TestSDKGen1EventTriggerRoundTrip(t *testing.T) {
+	svc := newGCPSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+	name := parent + "/functions/onpublish"
+
+	if _, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions.CloudFunction{
+		Name:    name,
+		Runtime: "go121",
+		EventTrigger: &cloudfunctions.EventTrigger{
+			EventType: "google.pubsub.topic.publish",
+			Resource:  "projects/demo/topics/events",
+			Service:   "pubsub.googleapis.com",
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.EventTrigger == nil {
+		t.Fatal("eventTrigger missing, want it round-tripped")
+	}
+
+	if got.EventTrigger.EventType != "google.pubsub.topic.publish" {
+		t.Fatalf("eventType = %q, want google.pubsub.topic.publish", got.EventTrigger.EventType)
+	}
+
+	if got.EventTrigger.Resource != "projects/demo/topics/events" {
+		t.Fatalf("resource = %q, want the created topic", got.EventTrigger.Resource)
+	}
+
+	if got.HttpsTrigger != nil {
+		t.Fatalf("httpsTrigger = %+v, want nil for an event-driven function", got.HttpsTrigger)
+	}
+}
+
+// TestSDKGen1FieldRoundTrip reproduces the dropped-field finding: description and
+// vpcConnector supplied at create must round-trip through Get.
+func TestSDKGen1FieldRoundTrip(t *testing.T) {
+	svc := newGCPSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+	name := parent + "/functions/rich"
+
+	if _, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions.CloudFunction{
+		Name:         name,
+		Runtime:      "go121",
+		Description:  "handles orders",
+		VpcConnector: "projects/demo/locations/us-central1/connectors/vpc",
+		MaxInstances: 5,
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Description != "handles orders" {
+		t.Fatalf("description = %q, want 'handles orders'", got.Description)
+	}
+
+	if got.VpcConnector != "projects/demo/locations/us-central1/connectors/vpc" {
+		t.Fatalf("vpcConnector = %q, want the created connector", got.VpcConnector)
+	}
+
+	if got.MaxInstances != 5 {
+		t.Fatalf("maxInstances = %d, want 5", got.MaxInstances)
+	}
+}
+
+// TestSDKGen1UpdateMaskClears reproduces the ignored-updateMask finding: a masked
+// field must be CLEARED when the PATCH body omits it, and an unmasked field must
+// survive the same patch.
+func TestSDKGen1UpdateMaskClears(t *testing.T) {
+	svc := newGCPSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+	name := parent + "/functions/clearable"
+
+	if _, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions.CloudFunction{
+		Name:         name,
+		Runtime:      "go121",
+		Description:  "keep me",
+		VpcConnector: "projects/demo/locations/us-central1/connectors/vpc",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Mask names vpcConnector but the body omits it -> clear vpcConnector, while
+	// the unmasked description survives.
+	if _, err := svc.Projects.Locations.Functions.Patch(name, &cloudfunctions.CloudFunction{
+		Name: name,
+	}).UpdateMask("vpcConnector").Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	if got.VpcConnector != "" {
+		t.Fatalf("vpcConnector = %q after masked clear, want empty", got.VpcConnector)
+	}
+
+	if got.Description != "keep me" {
+		t.Fatalf("description = %q after unrelated patch, want 'keep me' preserved", got.Description)
+	}
+}

--- a/server/gcp/cloudfunctions/types.go
+++ b/server/gcp/cloudfunctions/types.go
@@ -3,28 +3,57 @@ package cloudfunctions
 // cloudFunction is the v1 GCP Cloud Functions resource shape returned by
 // Get / Create / Update.
 type cloudFunction struct {
-	Name                string            `json:"name"`
-	Description         string            `json:"description,omitempty"`
-	SourceArchiveURL    string            `json:"sourceArchiveUrl,omitempty"`
-	SourceUploadURL     string            `json:"sourceUploadUrl,omitempty"`
-	HTTPSTrigger        *httpsTrigger     `json:"httpsTrigger,omitempty"`
-	Status              string            `json:"status"`
-	EntryPoint          string            `json:"entryPoint,omitempty"`
-	Runtime             string            `json:"runtime,omitempty"`
-	Timeout             string            `json:"timeout,omitempty"`
-	AvailableMemory     int               `json:"availableMemoryMb,omitempty"`
-	Labels              map[string]string `json:"labels,omitempty"`
-	EnvVariables        map[string]string `json:"environmentVariables,omitempty"`
-	UpdateTime          string            `json:"updateTime,omitempty"`
-	VersionID           string            `json:"versionId,omitempty"`
-	ServiceAccountEmail string            `json:"serviceAccountEmail,omitempty"`
-	IngressSettings     string            `json:"ingressSettings,omitempty"`
-	DockerRegistry      string            `json:"dockerRegistry,omitempty"`
-	BuildID             string            `json:"buildId,omitempty"`
+	Name                       string            `json:"name"`
+	Description                string            `json:"description,omitempty"`
+	SourceArchiveURL           string            `json:"sourceArchiveUrl,omitempty"`
+	SourceUploadURL            string            `json:"sourceUploadUrl,omitempty"`
+	SourceRepository           *sourceRepository `json:"sourceRepository,omitempty"`
+	HTTPSTrigger               *httpsTrigger     `json:"httpsTrigger,omitempty"`
+	EventTrigger               *eventTrigger     `json:"eventTrigger,omitempty"`
+	Status                     string            `json:"status"`
+	EntryPoint                 string            `json:"entryPoint,omitempty"`
+	Runtime                    string            `json:"runtime,omitempty"`
+	Timeout                    string            `json:"timeout,omitempty"`
+	AvailableMemory            int               `json:"availableMemoryMb,omitempty"`
+	MaxInstances               int               `json:"maxInstances,omitempty"`
+	MinInstances               int               `json:"minInstances,omitempty"`
+	VPCConnector               string            `json:"vpcConnector,omitempty"`
+	VPCConnectorEgressSettings string            `json:"vpcConnectorEgressSettings,omitempty"`
+	Labels                     map[string]string `json:"labels,omitempty"`
+	EnvVariables               map[string]string `json:"environmentVariables,omitempty"`
+	UpdateTime                 string            `json:"updateTime,omitempty"`
+	VersionID                  string            `json:"versionId,omitempty"`
+	ServiceAccountEmail        string            `json:"serviceAccountEmail,omitempty"`
+	IngressSettings            string            `json:"ingressSettings,omitempty"`
+	DockerRegistry             string            `json:"dockerRegistry,omitempty"`
+	BuildID                    string            `json:"buildId,omitempty"`
 }
 
 type httpsTrigger struct {
 	URL string `json:"url"`
+}
+
+// eventTrigger is the v1 CloudFunction.eventTrigger: an event-driven function is
+// triggered by eventType on resource (via service) rather than over HTTP. gen1
+// functions carry exactly one of httpsTrigger or eventTrigger.
+type eventTrigger struct {
+	EventType     string         `json:"eventType,omitempty"`
+	Resource      string         `json:"resource,omitempty"`
+	Service       string         `json:"service,omitempty"`
+	FailurePolicy *failurePolicy `json:"failurePolicy,omitempty"`
+}
+
+// failurePolicy is the v1 eventTrigger.failurePolicy; a present retry object asks
+// Cloud Functions to retry a failed event-driven invocation.
+type failurePolicy struct {
+	Retry map[string]any `json:"retry,omitempty"`
+}
+
+// sourceRepository is the v1 CloudFunction.sourceRepository: a Cloud Source
+// Repositories deploy source. url is the input; deployedUrl is echoed back.
+type sourceRepository struct {
+	URL         string `json:"url,omitempty"`
+	DeployedURL string `json:"deployedUrl,omitempty"`
 }
 
 // listFunctionsResponse is the {functions: [...]} envelope returned by

--- a/server/gcp/cloudfunctions/updatemask.go
+++ b/server/gcp/cloudfunctions/updatemask.go
@@ -1,0 +1,96 @@
+package cloudfunctions
+
+import (
+	"net/url"
+	"strings"
+)
+
+// updateMask is the parsed FieldMask from a PATCH ?updateMask= query parameter.
+// A gen1/gen2 update sends a comma-separated list of field paths (for example
+// "description,serviceConfig.maxInstanceCount"); only the listed fields are
+// written, so a field named in the mask but absent from the body is CLEARED.
+//
+// When no updateMask is sent the mask is "all": the handler falls back to the
+// legacy merge-non-zero-fields behavior so an unmasked PATCH never blanks a
+// field the client didn't mention.
+type updateMask struct {
+	paths map[string]struct{}
+	all   bool
+}
+
+// parseUpdateMask reads the "updateMask" query parameter into an updateMask.
+func parseUpdateMask(q url.Values) updateMask {
+	raw := strings.TrimSpace(q.Get("updateMask"))
+	if raw == "" {
+		return updateMask{all: true}
+	}
+
+	paths := make(map[string]struct{})
+
+	for _, p := range strings.Split(raw, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			paths[p] = struct{}{}
+		}
+	}
+
+	if len(paths) == 0 {
+		return updateMask{all: true}
+	}
+
+	return updateMask{paths: paths}
+}
+
+// covers reports whether field should be written under this mask: either no mask
+// was sent (legacy all), the mask names the field exactly, or the mask names an
+// ancestor path (mask "serviceConfig" covers "serviceConfig.maxInstanceCount").
+func (m updateMask) covers(field string) bool {
+	if m.all {
+		return true
+	}
+
+	if _, ok := m.paths[field]; ok {
+		return true
+	}
+
+	for p := field; ; {
+		i := strings.LastIndex(p, ".")
+		if i < 0 {
+			return false
+		}
+
+		p = p[:i]
+		if _, ok := m.paths[p]; ok {
+			return true
+		}
+	}
+}
+
+// explicit reports whether a mask was actually sent. When true, a covered field
+// missing from the body is cleared; when false (legacy), only non-zero values
+// are applied.
+func (m updateMask) explicit() bool {
+	return !m.all
+}
+
+// applyMaskedStr writes val into cur when the mask covers field. With an explicit
+// mask an empty val clears cur; without one only a non-empty val is applied.
+func applyMaskedStr(m updateMask, field string, cur *string, val string) {
+	if !m.covers(field) {
+		return
+	}
+
+	if m.explicit() || val != "" {
+		*cur = val
+	}
+}
+
+// applyMaskedInt is applyMaskedStr for an int field, treating zero as empty.
+func applyMaskedInt(m updateMask, field string, cur *int, val int) {
+	if !m.covers(field) {
+		return
+	}
+
+	if m.explicit() || val != 0 {
+		*cur = val
+	}
+}


### PR DESCRIPTION
## Summary

Fixes four GCP Cloud Functions bugs found in a real-SDK audit (apiv1 + apiv2 over httptest). LRO/IAM/upload/pagination paths are untouched.

### BUG1 — gen2 PATCH dropped maxInstanceCount/minInstanceCount
`mergeServiceConfig` omitted both scaling fields, so a `serviceConfig.maxInstanceCount` PATCH never applied (create worked via the wholesale store). Added both to the service-config merge, driven by the update mask.

### BUG2 — gen1 eventTrigger was not modeled
Every gen1 function was returned HTTP-triggered because the v1 struct had no `eventTrigger` and `toCloudFunction` unconditionally attached `httpsTrigger`. Added an `eventTrigger` field to the v1 struct, persisted it in `gen1Meta`, and `toCloudFunction` now emits `httpsTrigger` XOR `eventTrigger` based on what was created.

### BUG3 — gen1 round-trip dropped fields
`description`, `maxInstances`/`minInstances`, `vpcConnector`/`vpcConnectorEgressSettings`, `sourceRepository`, and `sourceArchiveUrl`/`sourceUploadUrl` were accepted but never echoed. `cloudFunction` + `gen1Meta` now carry and echo them.

### BUG4 — updateMask never honored (gen1 + gen2)
Both the gen1 update handler and gen2 `patchV2` ignored the `updateMask` query param and used a non-zero merge, so masked fields could not be cleared; gen2 also replaced the whole `buildConfig` wholesale, wiping runtime/entryPoint on a partial PATCH. Added a shared `updateMask` parser that drives field-level apply/clear in both paths; a partial `buildConfig` mask now merges sub-fields instead of replacing the object.

## Tests

Real functions apiv1 + apiv2 SDK over httptest:
- gen2 PATCH `maxInstanceCount` 7 -> 20 reflects on GET (and unmasked `minInstanceCount` survives)
- gen2 partial `buildConfig` PATCH preserves runtime/entryPoint
- gen1 `eventTrigger` round-trips (GET returns `eventTrigger`, no `httpsTrigger`)
- gen1 `description`/`vpcConnector`/`maxInstances` round-trip
- gen1 `updateMask` clears a masked field while an unmasked field survives

## Notes / deferred

Event-trigger invocation wiring, `:call` code execution, and gen1 list scoping are out of scope and left for follow-up.
