### PR TITLE
test(wiring-parity): exempt Monitor.SetWebhookDeliverer

### DIFF
--- a/providers/wiring_parity_test.go
+++ b/providers/wiring_parity_test.go
@@ -105,6 +105,15 @@ var azureExemptions = []exemption{
 			"Azure Monitor namespace, so ServiceBus (the real Service Bus " +
 			"instance) is wired and QueueStorage intentionally is not.",
 	},
+	{
+		field:  "Monitor",
+		method: "SetWebhookDeliverer",
+		reason: "SetWebhookDeliverer is a test-injection seam for the metric-alert " +
+			"action-group webhook path: the Monitor uses a default real-HTTP " +
+			"deliverer internally, and tests inject a fake one to assert delivery. " +
+			"Production New() deliberately does not override the default deliverer, " +
+			"so this setter is intentionally not wired.",
+	},
 }
 
 // exposedInjectors returns, sorted, the names of v's methods shaped like a


### PR DESCRIPTION
#778 (Azure Monitor action-group firing) added Monitor.SetWebhookDeliverer as a test-injection seam (Monitor uses a default real-HTTP deliverer; tests inject a fake). TestWiringParity_Azure flags any unwired SetX method, so it went red on development after #778 merged — blocking all CI Test.

Fix: add a commented exemption for Monitor.SetWebhookDeliverer (deliberate non-wiring — production New() uses the default deliverer). Test-only, verified TestWiringParity_Azure passes.