### PR TITLE
fix(gcp-firestore): subcollection namespaces, preserve user id field, atomic batch commit, orderBy excludes missing-field docs

### DIFF
--- a/server/gcp/firestore/firestore_atomic_commit_test.go
+++ b/server/gcp/firestore/firestore_atomic_commit_test.go
@@ -1,0 +1,48 @@
+package firestore_test
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/codes"
+)
+
+// TestFirestoreBatchAtomicOnPreconditionFailure proves a batch commit is
+// atomic: when a later write fails its precondition, the earlier writes in the
+// same batch are NOT persisted. Previously each write applied immediately, so a
+// failure left preceding writes committed.
+func TestFirestoreBatchAtomicOnPreconditionFailure(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "accounts")
+
+	coll := client.Collection("accounts")
+
+	// Seed an existing document so a later Create (exists=false precondition)
+	// in the batch is guaranteed to fail.
+	if _, err := coll.Doc("existing").Set(ctx, map[string]any{"v": "seed"}); err != nil {
+		t.Fatalf("seed existing: %v", err)
+	}
+
+	// write1 would create a fresh document; write2 Creates over an existing
+	// document and must fail with ALREADY_EXISTS, aborting the whole commit.
+	batch := client.Batch()
+	batch.Set(coll.Doc("fresh"), map[string]any{"v": "one"})
+	batch.Create(coll.Doc("existing"), map[string]any{"v": "two"})
+
+	if _, err := batch.Commit(ctx); dbSDKCode(err) != codes.AlreadyExists {
+		t.Fatalf("batch Commit: code=%v err=%v, want AlreadyExists", dbSDKCode(err), err)
+	}
+
+	// The first write must NOT have been persisted (atomic rollback).
+	if _, err := coll.Doc("fresh").Get(ctx); dbSDKCode(err) != codes.NotFound {
+		t.Errorf("doc 'fresh' should not exist after failed batch, got err=%v", err)
+	}
+
+	// The pre-existing document must be untouched by the failed Create.
+	snap, err := coll.Doc("existing").Get(ctx)
+	if err != nil {
+		t.Fatalf("Get existing: %v", err)
+	}
+
+	if snap.Data()["v"] != "seed" {
+		t.Errorf("existing doc mutated by failed batch: v=%v, want seed", snap.Data()["v"])
+	}
+}

--- a/server/gcp/firestore/firestore_lifecycle_test.go
+++ b/server/gcp/firestore/firestore_lifecycle_test.go
@@ -54,7 +54,9 @@ func newDBClient(t *testing.T, colls ...string) (context.Context, *gcpfirestore.
 	cloudP := cloudemu.NewGCP()
 
 	for _, c := range colls {
-		if err := cloudP.Firestore.CreateTable(ctx, dbdriver.TableConfig{Name: c, PartitionKey: "id"}); err != nil {
+		// Partition key mirrors the handler's reserved doc-id key ("\x00id"),
+		// so a user field literally named "id" never collides with it.
+		if err := cloudP.Firestore.CreateTable(ctx, dbdriver.TableConfig{Name: c, PartitionKey: "\x00id"}); err != nil {
 			t.Fatalf("CreateTable(%s): %v", c, err)
 		}
 	}

--- a/server/gcp/firestore/firestore_orderby_test.go
+++ b/server/gcp/firestore/firestore_orderby_test.go
@@ -1,0 +1,38 @@
+package firestore_test
+
+import (
+	"sort"
+	"testing"
+
+	gcpfirestore "cloud.google.com/go/firestore"
+)
+
+// TestFirestoreOrderByExcludesMissingField proves an orderBy query excludes
+// documents that lack the ordered field, matching Firestore (a missing field
+// means the document is not part of the ordered result set) rather than sorting
+// the missing values first and returning them.
+func TestFirestoreOrderByExcludesMissingField(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "players")
+
+	coll := client.Collection("players")
+
+	// Two documents carry "score"; one does not.
+	if _, err := coll.Doc("a").Set(ctx, map[string]any{"score": 10}); err != nil {
+		t.Fatalf("Set a: %v", err)
+	}
+
+	if _, err := coll.Doc("b").Set(ctx, map[string]any{"score": 20}); err != nil {
+		t.Fatalf("Set b: %v", err)
+	}
+
+	if _, err := coll.Doc("c").Set(ctx, map[string]any{"name": "no-score"}); err != nil {
+		t.Fatalf("Set c: %v", err)
+	}
+
+	ids := collectDocIDs(t, coll.OrderBy("score", gcpfirestore.Asc).Documents(ctx))
+	sort.Strings(ids)
+
+	if len(ids) != 2 || ids[0] != "a" || ids[1] != "b" {
+		t.Errorf("orderBy(score) = %v, want [a b] (doc without score must be excluded)", ids)
+	}
+}

--- a/server/gcp/firestore/firestore_reserved_field_test.go
+++ b/server/gcp/firestore/firestore_reserved_field_test.go
@@ -1,0 +1,55 @@
+package firestore_test
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/api/iterator"
+)
+
+// TestFirestoreUserIDFieldRoundTrips proves a user document field literally
+// named "id" survives storage instead of being clobbered by the handler's
+// internal document-id bookkeeping (a data-loss bug: the reserved key collided
+// with the driver partition key). The field must round-trip on read and be
+// queryable, while the document's own id stays independent.
+func TestFirestoreUserIDFieldRoundTrips(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "records")
+
+	coll := client.Collection("records")
+
+	if _, err := coll.Doc("doc1").Set(ctx, map[string]any{
+		"id":   "user-supplied-id",
+		"name": "Alice",
+	}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	snap, err := coll.Doc("doc1").Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got := snap.Data()["id"]; got != "user-supplied-id" {
+		t.Errorf("data[id] = %v, want user-supplied-id (user field was dropped)", got)
+	}
+
+	if snap.Ref.ID != "doc1" {
+		t.Errorf("Ref.ID = %q, want doc1 (document id must stay independent of the field)", snap.Ref.ID)
+	}
+
+	// The user field must be queryable by its own name.
+	it := coll.Where("id", "==", "user-supplied-id").Documents(ctx)
+
+	found, err := it.Next()
+	if err != nil {
+		t.Fatalf("query where id==user-supplied-id: %v", err)
+	}
+
+	if found.Ref.ID != "doc1" {
+		t.Errorf("query matched %q, want doc1", found.Ref.ID)
+	}
+
+	if _, err := it.Next(); !errors.Is(err, iterator.Done) {
+		t.Errorf("query returned extra results, want exactly one: err=%v", err)
+	}
+}

--- a/server/gcp/firestore/firestore_subcollection_test.go
+++ b/server/gcp/firestore/firestore_subcollection_test.go
@@ -1,0 +1,94 @@
+package firestore_test
+
+import (
+	"errors"
+	"sort"
+	"testing"
+
+	gcpfirestore "cloud.google.com/go/firestore"
+	"google.golang.org/api/iterator"
+)
+
+// collectDocIDs drains a DocumentIterator into a sorted slice of document ids.
+func collectDocIDs(t *testing.T, it *gcpfirestore.DocumentIterator) []string {
+	t.Helper()
+
+	var ids []string
+
+	for {
+		snap, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("iterator.Next: %v", err)
+		}
+
+		ids = append(ids, snap.Ref.ID)
+	}
+
+	sort.Strings(ids)
+
+	return ids
+}
+
+// TestFirestoreSubcollectionNamespaceIsolation proves a subcollection is modeled
+// as its own namespace: writing cities/SF/landmarks/{gg,bb} must NOT appear when
+// listing or querying the parent "cities" collection, and the "landmarks"
+// subcollection must list/query its own documents. This is the GCP audit
+// finding where a subcollection path collapsed into the top-level table,
+// contaminating the parent and 404ing the child.
+func TestFirestoreSubcollectionNamespaceIsolation(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "cities")
+
+	cities := client.Collection("cities")
+
+	// A top-level city document plus two landmarks under it.
+	if _, err := cities.Doc("SF").Set(ctx, map[string]any{"name": "San Francisco"}); err != nil {
+		t.Fatalf("Set cities/SF: %v", err)
+	}
+
+	landmarks := cities.Doc("SF").Collection("landmarks")
+	if _, err := landmarks.Doc("gg").Set(ctx, map[string]any{"name": "Golden Gate"}); err != nil {
+		t.Fatalf("Set landmarks/gg: %v", err)
+	}
+
+	if _, err := landmarks.Doc("bb").Set(ctx, map[string]any{"name": "Baker Beach"}); err != nil {
+		t.Fatalf("Set landmarks/bb: %v", err)
+	}
+
+	// Parent collection listing must contain ONLY the city document.
+	if got := collectDocIDs(t, cities.Documents(ctx)); len(got) != 1 || got[0] != "SF" {
+		t.Errorf("cities.Documents = %v, want [SF] (subcollection docs must not leak)", got)
+	}
+
+	// The subcollection lists exactly its own documents.
+	if got := collectDocIDs(t, landmarks.Documents(ctx)); len(got) != 2 || got[0] != "bb" || got[1] != "gg" {
+		t.Errorf("landmarks.Documents = %v, want [bb gg]", got)
+	}
+
+	// A runQuery scoped to the parent collection must also exclude subcollection
+	// docs (runQuery must scope by the request parent path, not just the
+	// trailing collection id).
+	parentQ := collectDocIDs(t, cities.Where("name", ">", "").Documents(ctx))
+	if len(parentQ) != 1 || parentQ[0] != "SF" {
+		t.Errorf("cities query = %v, want [SF]", parentQ)
+	}
+
+	// A runQuery scoped to the subcollection returns its documents.
+	subQ := collectDocIDs(t, landmarks.Where("name", ">", "").Documents(ctx))
+	if len(subQ) != 2 || subQ[0] != "bb" || subQ[1] != "gg" {
+		t.Errorf("landmarks query = %v, want [bb gg]", subQ)
+	}
+
+	// Direct-ref CRUD on a subcollection document still resolves correctly.
+	snap, err := landmarks.Doc("gg").Get(ctx)
+	if err != nil {
+		t.Fatalf("Get landmarks/gg: %v", err)
+	}
+
+	if snap.Data()["name"] != "Golden Gate" {
+		t.Errorf("landmarks/gg name = %v, want Golden Gate", snap.Data()["name"])
+	}
+}

--- a/server/gcp/firestore/firestore_test.go
+++ b/server/gcp/firestore/firestore_test.go
@@ -25,8 +25,9 @@ func TestSDKFirestoreRoundTrip(t *testing.T) {
 	// has dynamic collection names, but our underlying driver wants tables
 	// pre-declared.
 	ctx := context.Background()
+	// Partition key mirrors the handler's reserved doc-id key ("\x00id").
 	_ = cloudP.Firestore.CreateTable(ctx, dbdriver.TableConfig{
-		Name: "users", PartitionKey: "id",
+		Name: "users", PartitionKey: "\x00id",
 	})
 
 	srv := gcpserver.New(gcpserver.Drivers{Firestore: cloudP.Firestore})

--- a/server/gcp/firestore/handler.go
+++ b/server/gcp/firestore/handler.go
@@ -58,10 +58,16 @@ const (
 // Reserved item keys the handler stores alongside user fields. The document id
 // is the driver partition key; createTime/updateTime carry stable commit
 // timestamps. None are surfaced as document fields.
+//
+// Each key is prefixed with a NUL byte so it cannot collide with a real
+// Firestore field name (field names are UTF-8 text and never contain NUL).
+// This lets a user field literally named "id" — or "__createTime__" /
+// "__updateTime__" — round-trip through storage instead of being clobbered by
+// the handler's bookkeeping.
 const (
-	fieldID         = "id"
-	fieldCreateTime = "__createTime__"
-	fieldUpdateTime = "__updateTime__"
+	fieldID         = "\x00id"
+	fieldCreateTime = "\x00createTime"
+	fieldUpdateTime = "\x00updateTime"
 )
 
 // isReservedKey reports whether k is a handler-internal item key that must not
@@ -253,10 +259,28 @@ type writeResult struct {
 	TransformResults []value `json:"transformResults,omitempty"`
 }
 
-// commit handles POST .../documents:commit — the batch-write endpoint the
-// REST SDK uses for Set / Update / Delete. A `transaction` field, when present,
-// is accepted and applied directly: the in-memory store has no isolation
-// levels, so the writes commit exactly as a non-transactional batch would.
+// stagedWrite is one document write held in the commit's working set before it
+// is persisted: a put carries the computed item; a delete carries only its
+// target. table is the full parent-path namespace.
+type stagedWrite struct {
+	table    string
+	id       string
+	item     map[string]any // the item to put; nil when isDelete
+	isDelete bool
+}
+
+// stageKey uniquely names a document across collections for the commit overlay.
+func stageKey(table, id string) string { return table + "\x00" + id }
+
+// commit handles POST .../documents:commit — the batch-write endpoint the REST
+// SDK uses for Set / Update / Delete. A `transaction` field, when present, is
+// accepted and applied directly: the in-memory store has no isolation levels.
+//
+// The batch is applied atomically. Phase 1 validates every write's precondition
+// against a working snapshot (an overlay reflecting earlier writes in the same
+// batch) and computes each resulting item WITHOUT persisting anything; phase 2
+// applies the staged writes. So a precondition failure on write N aborts the
+// whole commit with writes 1..N-1 left unpersisted, matching real Firestore.
 func (h *Handler) commit(w http.ResponseWriter, r *http.Request, _ string) {
 	var req commitRequest
 
@@ -268,56 +292,108 @@ func (h *Handler) commit(w http.ResponseWriter, r *http.Request, _ string) {
 	nowStr := now.Format(time.RFC3339Nano)
 	out := commitResponse{CommitTime: nowStr}
 
+	overlay := make(map[string]*stagedWrite, len(req.Writes))
+	order := make([]string, 0, len(req.Writes))
+
 	for i := range req.Writes {
 		op := &req.Writes[i]
 
 		switch {
 		case op.Update != nil:
-			transformResults, ok := h.commitUpdate(w, r, op, now)
+			sw, results, ok := h.stageUpdate(w, r, op, now, overlay)
 			if !ok {
 				return
 			}
 
+			order = trackStaged(order, overlay, sw)
 			out.WriteResults = append(out.WriteResults,
-				writeResult{UpdateTime: nowStr, TransformResults: transformResults})
+				writeResult{UpdateTime: nowStr, TransformResults: results})
 		case op.Delete != "":
-			if !h.commitDelete(w, r, op) {
+			sw, ok := h.stageDelete(w, r, op, overlay)
+			if !ok {
 				return
 			}
 
+			order = trackStaged(order, overlay, sw)
 			out.WriteResults = append(out.WriteResults, writeResult{UpdateTime: nowStr})
 		}
+	}
+
+	if err := h.applyStaged(r.Context(), order, overlay); err != nil {
+		writeErr(w, err)
+		return
 	}
 
 	writeJSON(w, http.StatusOK, out)
 }
 
-// commitUpdate applies one Update write. It returns the transform results and a
-// false ok when it has already written an error response and the caller must
-// stop.
+// trackStaged records sw in the overlay under its document key, appending the
+// key to order the first time it is seen so a later write to the same document
+// replaces the earlier one while preserving apply order.
+func trackStaged(order []string, overlay map[string]*stagedWrite, sw *stagedWrite) []string {
+	k := stageKey(sw.table, sw.id)
+	if _, seen := overlay[k]; !seen {
+		order = append(order, k)
+	}
+
+	overlay[k] = sw
+
+	return order
+}
+
+// stagedExisting resolves the current document state for a (table, id) as seen
+// within the batch: an earlier staged write in the overlay takes precedence
+// over the persisted store. A missing document (or collection) reports exists
+// false without error.
+func (h *Handler) stagedExisting(
+	ctx context.Context, overlay map[string]*stagedWrite, table, id string,
+) (item map[string]any, exists bool, err error) {
+	if sw, ok := overlay[stageKey(table, id)]; ok {
+		if sw.isDelete {
+			return nil, false, nil
+		}
+
+		return sw.item, true, nil
+	}
+
+	existing, gerr := h.db.GetItem(ctx, table, map[string]any{fieldID: id})
+	if gerr != nil {
+		if cerrors.IsNotFound(gerr) {
+			return nil, false, nil
+		}
+
+		return nil, false, gerr
+	}
+
+	return existing, true, nil
+}
+
+// stageUpdate validates and computes one Update write, returning the staged
+// write plus its transform results, or a false ok when it has already written
+// an error response and the caller must stop.
 //
 // A write that carries field transforms is always treated as a MERGE against the
 // stored document: a transform-only write (empty update.fields, empty mask) must
 // increment/append/stamp its target fields WITHOUT wiping the rest of the
 // document. Only a plain Set (no mask, no transforms) replaces wholesale.
-func (h *Handler) commitUpdate(w http.ResponseWriter, r *http.Request, op *writeOp, now time.Time) ([]value, bool) {
+func (h *Handler) stageUpdate(
+	w http.ResponseWriter, r *http.Request, op *writeOp, now time.Time, overlay map[string]*stagedWrite,
+) (*stagedWrite, []value, bool) {
 	p, id, err := splitDocumentName(op.Update.Name)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
-		return nil, false
+		return nil, nil, false
 	}
 
-	existing, gerr := h.db.GetItem(r.Context(), p.collection, map[string]any{fieldID: id})
-	if gerr != nil && !cerrors.IsNotFound(gerr) {
+	existing, exists, gerr := h.stagedExisting(r.Context(), overlay, p.collection, id)
+	if gerr != nil {
 		writeErr(w, gerr)
-		return nil, false
+		return nil, nil, false
 	}
-
-	exists := gerr == nil
 
 	updateTime := existingUpdateTime(existing)
 	if !checkPrecondition(w, op.CurrentDocument, exists, updateTime, op.Update.Name) {
-		return nil, false
+		return nil, nil, false
 	}
 
 	body := fieldsToMap(op.Update.Fields)
@@ -332,14 +408,45 @@ func (h *Handler) commitUpdate(w http.ResponseWriter, r *http.Request, op *write
 
 	stampTimes(item, existing, now)
 
-	h.ensureCollection(r.Context(), p.collection)
+	return &stagedWrite{table: p.collection, id: id, item: item}, results, true
+}
 
-	if perr := h.db.PutItem(r.Context(), p.collection, item); perr != nil {
-		writeErr(w, perr)
-		return nil, false
+// applyStaged persists the staged writes, grouped by collection so each
+// collection's puts and deletes land through the atomic TransactWriteItems.
+// Preconditions were already checked against the snapshot in phase 1, so the
+// apply cannot fail on a precondition.
+func (h *Handler) applyStaged(ctx context.Context, order []string, overlay map[string]*stagedWrite) error {
+	putsByTable := map[string][]map[string]any{}
+	delsByTable := map[string][]map[string]any{}
+
+	var tables []string
+
+	seen := map[string]bool{}
+
+	for _, k := range order {
+		sw := overlay[k]
+		if !seen[sw.table] {
+			seen[sw.table] = true
+
+			tables = append(tables, sw.table)
+		}
+
+		if sw.isDelete {
+			delsByTable[sw.table] = append(delsByTable[sw.table], map[string]any{fieldID: sw.id})
+		} else {
+			putsByTable[sw.table] = append(putsByTable[sw.table], sw.item)
+		}
 	}
 
-	return results, true
+	for _, table := range tables {
+		h.ensureCollection(ctx, table)
+
+		if err := h.db.TransactWriteItems(ctx, table, putsByTable[table], delsByTable[table]); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // mergeUpdateBase produces the item to write before transforms are applied.
@@ -358,36 +465,31 @@ func mergeUpdateBase(existing, body map[string]any, id string, op *writeOp) map[
 	}
 }
 
-// commitDelete applies one Delete write, returning false when an error
-// response has already been written. A currentDocument precondition is enforced
-// (a Delete guarded by exists=true on a missing document → NOT_FOUND, an
-// updateTime guard on a stale document → FAILED_PRECONDITION).
-func (h *Handler) commitDelete(w http.ResponseWriter, r *http.Request, op *writeOp) bool {
+// stageDelete validates one Delete write and stages it, returning false when an
+// error response has already been written. A currentDocument precondition is
+// enforced (a Delete guarded by exists=true on a missing document → NOT_FOUND,
+// an updateTime guard on a stale document → FAILED_PRECONDITION).
+func (h *Handler) stageDelete(
+	w http.ResponseWriter, r *http.Request, op *writeOp, overlay map[string]*stagedWrite,
+) (*stagedWrite, bool) {
 	p, id, err := splitDocumentName(op.Delete)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
-		return false
+		return nil, false
 	}
 
-	existing, gerr := h.db.GetItem(r.Context(), p.collection, map[string]any{fieldID: id})
-	if gerr != nil && !cerrors.IsNotFound(gerr) {
+	existing, exists, gerr := h.stagedExisting(r.Context(), overlay, p.collection, id)
+	if gerr != nil {
 		writeErr(w, gerr)
-		return false
+		return nil, false
 	}
-
-	exists := gerr == nil
 
 	updateTime := existingUpdateTime(existing)
 	if !checkPrecondition(w, op.CurrentDocument, exists, updateTime, op.Delete) {
-		return false
+		return nil, false
 	}
 
-	if derr := h.db.DeleteItem(r.Context(), p.collection, map[string]any{fieldID: id}); derr != nil {
-		writeErr(w, derr)
-		return false
-	}
-
-	return true
+	return &stagedWrite{table: p.collection, id: id, isDelete: true}, true
 }
 
 // existingUpdateTime reads the stored commit timestamp of a document, returning
@@ -830,11 +932,19 @@ func (h *Handler) runQuery(w http.ResponseWriter, r *http.Request, base string) 
 		return
 	}
 
-	collection := req.StructuredQuery.From[0].CollectionID
+	// runQuery's base path is the PARENT resource (the documents root or a
+	// specific document). The queried collection lives directly under it, so
+	// the driver table is the parent path joined with the from collection id —
+	// this scopes a subcollection query to its own namespace instead of the
+	// trailing collection id alone.
+	p, perr := parseFirestorePath(base)
+	if perr != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", perr.Error())
+		return
+	}
 
-	// Project + database from the base path.
-	p, _ := parseFirestorePath(base)
-	p.collection = collection
+	p.collection = joinPath(p.parentPath(), req.StructuredQuery.From[0].CollectionID)
+	p.documentID = ""
 
 	node, ferr := buildFilterNode(req.StructuredQuery.Where)
 	if ferr != nil {
@@ -843,9 +953,16 @@ func (h *Handler) runQuery(w http.ResponseWriter, r *http.Request, base string) 
 	}
 
 	// Fetch the full collection and evaluate the where clause here with full
-	// grammar fidelity (type-aware, AND/OR/NOT, IN/array-contains, unary).
-	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: collection, Limit: allResults})
+	// grammar fidelity (type-aware, AND/OR/NOT, IN/array-contains, unary). A
+	// never-written collection has no driver table; real Firestore returns an
+	// empty result set rather than an error, so treat NotFound as empty.
+	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: p.collection, Limit: allResults})
 	if err != nil {
+		if cerrors.IsNotFound(err) {
+			streamQueryResults(w, nil, p)
+			return
+		}
+
 		writeErr(w, err)
 		return
 	}
@@ -906,16 +1023,18 @@ func streamQueryResults(w http.ResponseWriter, items []map[string]any, p firesto
 	w.Write([]byte("]")) //nolint:errcheck // best-effort
 }
 
-// splitDocumentName parses "projects/{p}/databases/{db}/documents/{coll}/{id}"
-// into a firestorePath plus the document id.
+// splitDocumentName parses a fully-qualified document resource name
+// "projects/{p}/databases/{db}/documents/{coll...}/{id}" into a firestorePath
+// (whose collection is the full parent path, so subcollections keep their own
+// namespace) plus the document id. The segments after "documents" must form a
+// complete collection/document sequence (an even count ending at a document).
 func splitDocumentName(name string) (firestorePath, string, error) {
 	parts := strings.Split(name, "/")
 
 	const (
 		minParts                = 6
 		idxProject, idxDatabase = 1, 3
-		idxCollection           = 5
-		idxID                   = 6
+		idxFirstSeg             = 5
 	)
 
 	if len(parts) < minParts ||
@@ -925,17 +1044,18 @@ func splitDocumentName(name string) (firestorePath, string, error) {
 		return firestorePath{}, "", fmt.Errorf("%w: %s", errInvalidDocName, name)
 	}
 
+	segs := trimEmpty(parts[idxFirstSeg:])
+	if len(segs) == 0 || len(segs)%2 != 0 {
+		return firestorePath{}, "", fmt.Errorf("%w: %s", errMissingDocID, name)
+	}
+
 	p := firestorePath{
 		project:    parts[idxProject],
 		database:   parts[idxDatabase],
-		collection: parts[idxCollection],
+		collection: strings.Join(segs[:len(segs)-1], "/"),
 	}
 
-	if len(parts) <= idxID {
-		return p, "", fmt.Errorf("%w: %s", errMissingDocID, name)
-	}
-
-	return p, strings.Join(parts[idxID:], "/"), nil
+	return p, segs[len(segs)-1], nil
 }
 
 // firestorePath holds the components extracted from a Firestore URL.
@@ -946,23 +1066,49 @@ type firestorePath struct {
 	documentID string
 }
 
-// parseFirestorePath extracts the project, database, collection, and
-// optional document id from a Firestore REST path.
+// parentPath returns the resource path this location represents relative to the
+// documents root: the collection path, extended with the document id when the
+// path addresses a specific document. It is the prefix a child collection is
+// nested under.
+func (p firestorePath) parentPath() string {
+	return joinPath(p.collection, p.documentID)
+}
+
+// joinPath joins two path segments with "/", tolerating either being empty.
+func joinPath(a, b string) string {
+	switch {
+	case a == "":
+		return b
+	case b == "":
+		return a
+	default:
+		return a + "/" + b
+	}
+}
+
+// parseFirestorePath extracts the project, database, collection path, and
+// optional document id from a Firestore REST path. Everything after
+// "documents" is an alternating collection/document sequence, so a
+// subcollection is modeled as part of the collection key:
 //
-// /v1/projects/{p}/databases/{db}/documents/{collection}
-// /v1/projects/{p}/databases/{db}/documents/{collection}/{id}.
+//	.../documents                              → collection "",             doc ""
+//	.../documents/cities                       → collection "cities",       doc ""
+//	.../documents/cities/SF                     → collection "cities",       doc "SF"
+//	.../documents/cities/SF/landmarks           → collection "cities/SF/landmarks", doc ""
+//	.../documents/cities/SF/landmarks/gg        → collection "cities/SF/landmarks", doc "gg"
+//
+// The full parent path becomes the driver "table", so a subcollection lives in
+// its own namespace and never contaminates the parent collection.
 func parseFirestorePath(path string) (firestorePath, error) {
 	rest := strings.TrimPrefix(path, "/v1/")
 
 	parts := strings.Split(rest, "/")
 
 	const (
-		minParts      = 6 // projects/{p}/databases/{db}/documents/{collection}
-		fullDocParts  = 7 // ... + /{id}
-		idxProject    = 1
-		idxDatabase   = 3
-		idxCollection = 5
-		idxDocument   = 6
+		minParts    = 5 // projects/{p}/databases/{db}/documents
+		idxProject  = 1
+		idxDatabase = 3
+		idxFirstSeg = 5 // first collection segment
 	)
 
 	if len(parts) < minParts ||
@@ -973,16 +1119,39 @@ func parseFirestorePath(path string) (firestorePath, error) {
 	}
 
 	out := firestorePath{
-		project:    parts[idxProject],
-		database:   parts[idxDatabase],
-		collection: parts[idxCollection],
+		project:  parts[idxProject],
+		database: parts[idxDatabase],
 	}
 
-	if len(parts) >= fullDocParts {
-		out.documentID = strings.Join(parts[idxDocument:], "/")
-	}
+	segs := trimEmpty(parts[idxFirstSeg:])
+	out.collection, out.documentID = splitCollectionSegments(segs)
 
 	return out, nil
+}
+
+// splitCollectionSegments splits the alternating collection/document segments
+// after "documents" into the collection (parent) path and, when the path ends
+// at a document, its id. An odd count ends at a collection (no doc id); an even
+// count ends at a document whose id is the last segment.
+func splitCollectionSegments(segs []string) (collection, documentID string) {
+	if len(segs) == 0 {
+		return "", ""
+	}
+
+	if len(segs)%2 == 1 {
+		return strings.Join(segs, "/"), ""
+	}
+
+	return strings.Join(segs[:len(segs)-1], "/"), segs[len(segs)-1]
+}
+
+// trimEmpty drops a trailing empty segment produced by a trailing slash.
+func trimEmpty(segs []string) []string {
+	for len(segs) > 0 && segs[len(segs)-1] == "" {
+		segs = segs[:len(segs)-1]
+	}
+
+	return segs
 }
 
 func (h *Handler) createDocument(w http.ResponseWriter, r *http.Request, p firestorePath) {
@@ -1029,10 +1198,10 @@ func (h *Handler) createDocument(w http.ResponseWriter, r *http.Request, p fires
 }
 
 // ensureCollection lazily creates a Firestore collection (driver table keyed on
-// the document "id") so a first write doesn't fail with "collection not found".
-// An already-exists result is benign.
+// the reserved document-id field) so a first write doesn't fail with "collection
+// not found". An already-exists result is benign.
 func (h *Handler) ensureCollection(ctx context.Context, collection string) {
-	_ = h.db.CreateTable(ctx, dbdriver.TableConfig{Name: collection, PartitionKey: "id"})
+	_ = h.db.CreateTable(ctx, dbdriver.TableConfig{Name: collection, PartitionKey: fieldID})
 }
 
 func (h *Handler) getDocument(w http.ResponseWriter, r *http.Request, p firestorePath) {
@@ -1054,6 +1223,13 @@ func (h *Handler) listDocuments(w http.ResponseWriter, r *http.Request, p firest
 	// stays correct across page boundaries.
 	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: p.collection, Limit: allResults})
 	if err != nil {
+		// A never-written (sub)collection has no driver table; real Firestore
+		// lists it as empty rather than erroring.
+		if cerrors.IsNotFound(err) {
+			writeJSON(w, http.StatusOK, listDocumentsResponse{})
+			return
+		}
+
 		writeErr(w, err)
 		return
 	}

--- a/server/gcp/firestore/queryshape.go
+++ b/server/gcp/firestore/queryshape.go
@@ -8,10 +8,11 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
 )
 
-// docName is the field carrying the document id, addressable in a query as the
-// special __name__ path.
+// docName is the reserved item key carrying the document id, addressable in a
+// query as the special __name__ path. It aliases fieldID so the two stay in
+// lockstep with the handler's storage model.
 const (
-	docName    = "id"
+	docName    = fieldID
 	fieldName  = "__name__"
 	descending = "DESCENDING"
 )
@@ -27,6 +28,8 @@ type sortKey struct {
 // select projection.
 func shapeResults(items []map[string]any, q *structuredQuery) []map[string]any {
 	keys := effectiveSortKeys(q.OrderBy)
+
+	items = filterOrderByPresent(items, q.OrderBy)
 
 	applyOrderBy(items, keys)
 
@@ -66,6 +69,74 @@ func effectiveSortKeys(orderBy []orderByClause) []sortKey {
 }
 
 func isDescending(dir direction) bool { return strings.EqualFold(string(dir), descending) }
+
+// filterOrderByPresent drops documents that lack any explicit orderBy field.
+// Firestore only returns documents that have a value for every ordered field
+// (the implicit __name__ tiebreaker is always present and never filters), so a
+// document missing an ordered field is excluded rather than sorted first.
+func filterOrderByPresent(items []map[string]any, orderBy []orderByClause) []map[string]any {
+	if len(orderBy) == 0 {
+		return items
+	}
+
+	out := make([]map[string]any, 0, len(items))
+
+	for _, item := range items {
+		if orderByFieldsPresent(item, orderBy) {
+			out = append(out, item)
+		}
+	}
+
+	return out
+}
+
+// orderByFieldsPresent reports whether item has a value for every explicit
+// orderBy field path (the __name__ pseudo-field is always considered present).
+func orderByFieldsPresent(item map[string]any, orderBy []orderByClause) bool {
+	for _, ob := range orderBy {
+		if ob.Field.FieldPath == fieldName {
+			continue
+		}
+
+		if !fieldPresent(item, ob.Field.FieldPath) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// fieldPresent reports whether the dotted field path exists in item, walking
+// nested maps. Unlike resolveField it distinguishes an absent field from one
+// explicitly set to null: a present-but-null field is present.
+func fieldPresent(item map[string]any, path string) bool {
+	if path == fieldName {
+		return true
+	}
+
+	cur := item
+
+	segs := strings.Split(path, ".")
+	for i, seg := range segs {
+		v, ok := cur[seg]
+		if !ok {
+			return false
+		}
+
+		if i == len(segs)-1 {
+			return true
+		}
+
+		next, ok := v.(map[string]any)
+		if !ok {
+			return false
+		}
+
+		cur = next
+	}
+
+	return true
+}
 
 func applyOrderBy(items []map[string]any, keys []sortKey) {
 	sort.SliceStable(items, func(i, j int) bool {


### PR DESCRIPTION
## Summary

Fixes four confirmed GCP Firestore bugs in the wire handler and its storage model. All four are covered by new real-SDK (`cloud.google.com/go/firestore` over httptest) tests.

### BUG1 [HIGH] Subcollections modeled as separate namespaces
Previously `cities/SF/landmarks/gg` collapsed into the top-level `cities` table with id `SF/landmarks/gg`, so listing/querying the parent returned subcollection docs (contamination) and the subcollection query 404'd. Now the document's full parent path (`cities/SF/landmarks`) is the driver namespace: `parseFirestorePath`/`splitDocumentName` parse the alternating collection/document segments, and `runQuery`/`listDocuments` scope by the request's parent path (base) joined with the `from` collection id — not the trailing collection id alone. A never-written (sub)collection now lists/queries as empty (cloud-accurate) instead of erroring. Direct-ref CRUD is unchanged.

### BUG2 [HIGH, data-loss] User field named `id` preserved
The reserved doc-id/createTime/updateTime keys now use NUL-prefixed sentinels (`"\x00id"`, etc.) that cannot collide with real field names, and `mapToFields` no longer strips `id`. A user field literally named `id` (or `__createTime__`/`__updateTime__`) round-trips on read and is queryable, while the document id stays independent.

### BUG3 [MED, atomicity] Batch/transaction commit is atomic
`commit` is now two-phase: phase 1 validates every write's precondition against a working snapshot (an overlay reflecting earlier writes in the same batch) and computes each resulting item without persisting; phase 2 applies the staged writes per collection through the atomic `TransactWriteItems`. A precondition failure on write N leaves writes 1..N-1 unpersisted.

### BUG4 [MED-LOW] orderBy excludes docs missing the ordered field
`shapeResults` drops documents that lack any explicit orderBy field before sorting/cursoring (the implicit `__name__` tiebreaker never filters). A present-but-null field is still included.

## Tests
- Subcollection namespace isolation (parent list/query excludes subcol docs; subcol list/query returns its docs; direct-ref CRUD intact)
- User `id` field round-trips and is queryable; doc id independent
- Batch with a failing precondition persists nothing
- orderBy excludes a doc missing the ordered field

## Gates
build ./..., vet, `go test -p=3` (server+provider), `go test -race -p=3` (provider), gofmt, `golangci-lint --new-from-rev=origin/development` (0 new), `go generate ./...` + compatgen (zero diff) — all green.
