### PR TITLE
fix(gcp-clouddns): enforce delete-exact-match (412), validate additions before apply, validate zone dnsName/name

### DIFF
--- a/server/gcp/clouddns/delete_match_validation_test.go
+++ b/server/gcp/clouddns/delete_match_validation_test.go
@@ -1,0 +1,201 @@
+package clouddns_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	dns "google.golang.org/api/dns/v1"
+	"google.golang.org/api/googleapi"
+)
+
+// seedZoneWithRecord creates a zone and a single A record set in it, returning
+// the record set as stored so tests can build matching/mismatching deletions.
+func seedZoneWithRecord(t *testing.T, svc *dns.Service, ctx context.Context,
+	zone, dnsName string, rec *dns.ResourceRecordSet) {
+	t.Helper()
+
+	if _, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+		Name: zone, DnsName: dnsName,
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Create zone: %v", err)
+	}
+
+	if _, err := svc.Changes.Create(testProject, zone, &dns.Change{
+		Additions: []*dns.ResourceRecordSet{rec},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("seed record: %v", err)
+	}
+}
+
+// findRecord returns the stored A record set at name, or nil if absent.
+func findRecord(t *testing.T, svc *dns.Service, ctx context.Context, zone, name string) *dns.ResourceRecordSet {
+	t.Helper()
+
+	resp, err := svc.ResourceRecordSets.List(testProject, zone).Name(name).Type("A").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List rrsets: %v", err)
+	}
+
+	if len(resp.Rrsets) == 0 {
+		return nil
+	}
+
+	return resp.Rrsets[0]
+}
+
+// TestSDKCloudDNSDeleteWrongTTLRejected asserts a deletion whose TTL does not
+// match the stored record set is refused 412 conditionNotMet and deletes
+// nothing.
+func TestSDKCloudDNSDeleteWrongTTLRejected(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	name := "www.ttl.example.com."
+	seedZoneWithRecord(t, svc, ctx, "ttl-zone", "ttl.example.com.",
+		&dns.ResourceRecordSet{Name: name, Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1"}})
+
+	_, err := svc.Changes.Create(testProject, "ttl-zone", &dns.Change{
+		Deletions: []*dns.ResourceRecordSet{
+			{Name: name, Type: "A", Ttl: 600, Rrdatas: []string{"192.0.2.1"}},
+		},
+	}).Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 412 {
+		t.Fatalf("wrong-TTL delete: got %v, want 412", err)
+	}
+
+	if rec := findRecord(t, svc, ctx, "ttl-zone", name); rec == nil || rec.Ttl != 300 {
+		t.Fatalf("record must be untouched after rejected delete, got %+v", rec)
+	}
+}
+
+// TestSDKCloudDNSDeleteWrongRrdataRejected asserts a deletion whose rrdatas do
+// not match the stored record set is refused 412 and deletes nothing.
+func TestSDKCloudDNSDeleteWrongRrdataRejected(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	name := "www.rr.example.com."
+	seedZoneWithRecord(t, svc, ctx, "rr-zone", "rr.example.com.",
+		&dns.ResourceRecordSet{Name: name, Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1", "192.0.2.2"}})
+
+	_, err := svc.Changes.Create(testProject, "rr-zone", &dns.Change{
+		Deletions: []*dns.ResourceRecordSet{
+			{Name: name, Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.9"}},
+		},
+	}).Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 412 {
+		t.Fatalf("wrong-rrdata delete: got %v, want 412", err)
+	}
+
+	if rec := findRecord(t, svc, ctx, "rr-zone", name); rec == nil || len(rec.Rrdatas) != 2 {
+		t.Fatalf("record must be untouched after rejected delete, got %+v", rec)
+	}
+}
+
+// TestSDKCloudDNSDeleteExactMatch asserts a deletion that matches the stored
+// record set exactly (TTL + rrdatas, order-independent) succeeds and removes it.
+func TestSDKCloudDNSDeleteExactMatch(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	name := "www.ok.example.com."
+	seedZoneWithRecord(t, svc, ctx, "ok-zone", "ok.example.com.",
+		&dns.ResourceRecordSet{Name: name, Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1", "192.0.2.2"}})
+
+	// rrdatas listed in a different order still match — order-independent.
+	if _, err := svc.Changes.Create(testProject, "ok-zone", &dns.Change{
+		Deletions: []*dns.ResourceRecordSet{
+			{Name: name, Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.2", "192.0.2.1"}},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("exact-match delete: %v", err)
+	}
+
+	if rec := findRecord(t, svc, ctx, "ok-zone", name); rec != nil {
+		t.Fatalf("record should be deleted, still present: %+v", rec)
+	}
+}
+
+// TestSDKCloudDNSMalformedAdditionRejectedBeforeApply asserts a batch with a
+// malformed addition (no rrdatas) is rejected up front so its paired deletion
+// never lands — the zone is left unchanged.
+func TestSDKCloudDNSMalformedAdditionRejectedBeforeApply(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	name := "www.atomic.example.com."
+	seedZoneWithRecord(t, svc, ctx, "atomic-zone", "atomic.example.com.",
+		&dns.ResourceRecordSet{Name: name, Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1"}})
+
+	// Delete the existing record and add a malformed replacement in one batch.
+	_, err := svc.Changes.Create(testProject, "atomic-zone", &dns.Change{
+		Deletions: []*dns.ResourceRecordSet{
+			{Name: name, Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1"}},
+		},
+		Additions: []*dns.ResourceRecordSet{
+			{Name: name, Type: "A", Ttl: 300},
+		},
+	}).Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 400 {
+		t.Fatalf("malformed addition: got %v, want 400", err)
+	}
+
+	if rec := findRecord(t, svc, ctx, "atomic-zone", name); rec == nil || rec.Rrdatas[0] != "192.0.2.1" {
+		t.Fatalf("deletion must not have applied, record changed: %+v", rec)
+	}
+}
+
+// TestSDKCloudDNSCreateEmptyDNSNameRejected asserts a zone create with no
+// dnsName is refused 400 rather than silently defaulting to the zone name.
+func TestSDKCloudDNSCreateEmptyDNSNameRejected(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	_, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{Name: "no-dnsname"}).Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 400 {
+		t.Fatalf("empty dnsName: got %v, want 400", err)
+	}
+}
+
+// TestSDKCloudDNSCreateBadZoneNameRejected asserts a zone name that violates
+// Cloud DNS's [a-z]([-a-z0-9]*[a-z0-9])? grammar is refused 400.
+func TestSDKCloudDNSCreateBadZoneNameRejected(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	for _, bad := range []string{"Bad-Zone", "1zone", "zone-", "with_underscore"} {
+		_, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+			Name: bad, DnsName: "x.example.com.",
+		}).Context(ctx).Do()
+
+		var gerr *googleapi.Error
+		if !errors.As(err, &gerr) || gerr.Code != 400 {
+			t.Fatalf("bad zone name %q: got %v, want 400", bad, err)
+		}
+	}
+}
+
+// TestSDKCloudDNSCreateNonFQDNRejected asserts a dnsName without a trailing dot
+// is refused 400.
+func TestSDKCloudDNSCreateNonFQDNRejected(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	_, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+		Name: "nofqdn", DnsName: "example.com",
+	}).Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 400 {
+		t.Fatalf("non-FQDN dnsName: got %v, want 400", err)
+	}
+}

--- a/server/gcp/clouddns/operations.go
+++ b/server/gcp/clouddns/operations.go
@@ -2,7 +2,9 @@ package clouddns
 
 import (
 	"net/http"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -15,6 +17,10 @@ import (
 func (h *Handler) createZone(w http.ResponseWriter, r *http.Request, rt route) {
 	var req managedZoneJSON
 	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if !validateZoneCreate(w, &req) {
 		return
 	}
 
@@ -52,6 +58,50 @@ func (h *Handler) createZone(w http.ResponseWriter, r *http.Request, rt route) {
 	h.seedApexRecords(r, info)
 
 	gcprest.WriteJSON(w, http.StatusOK, toManagedZoneJSON(info))
+}
+
+// validateZoneCreate enforces Cloud DNS's managed-zone create constraints: the
+// zone name must match [a-z]([-a-z0-9]*[a-z0-9])?, and dnsName must be present
+// and a fully qualified name ending in a trailing dot. On a violation it writes
+// a 400 and returns false so the caller stops.
+func validateZoneCreate(w http.ResponseWriter, req *managedZoneJSON) bool {
+	if !isValidZoneName(req.Name) {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid",
+			"the managed zone name must match [a-z]([-a-z0-9]*[a-z0-9])?")
+		return false
+	}
+
+	if req.DNSName == "" || !strings.HasSuffix(req.DNSName, ".") {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid",
+			"dnsName is required and must be a fully qualified name ending with a dot")
+		return false
+	}
+
+	return true
+}
+
+// isValidZoneName reports whether name matches Cloud DNS's managed-zone name
+// grammar [a-z]([-a-z0-9]*[a-z0-9])?: a lowercase-letter start, lowercase
+// alphanumeric or hyphen body, and no trailing hyphen.
+func isValidZoneName(name string) bool {
+	if name == "" || name[0] < 'a' || name[0] > 'z' {
+		return false
+	}
+
+	for i := 1; i < len(name); i++ {
+		c := name[i]
+
+		isLower := c >= 'a' && c <= 'z'
+		isDigit := c >= '0' && c <= '9'
+
+		if !isLower && !isDigit && c != '-' {
+			return false
+		}
+	}
+
+	last := name[len(name)-1]
+
+	return last != '-'
 }
 
 // seedApexRecords creates the SOA and NS record sets Cloud DNS auto-provisions
@@ -340,8 +390,44 @@ func (h *Handler) checkDeletions(w http.ResponseWriter, r *http.Request, id, dns
 			return false
 		}
 
-		if _, gerr := h.dns.GetRecord(r.Context(), id, d.Name, d.Type); gerr != nil {
+		rec, gerr := h.dns.GetRecord(r.Context(), id, d.Name, d.Type)
+		if gerr != nil {
 			gcprest.WriteCErr(w, gerr)
+			return false
+		}
+
+		// Cloud DNS requires a deletion to name the record set exactly as it
+		// currently stands — same TTL and same rrdatas (order-independent). A
+		// mismatch is rejected 412 conditionNotMet and nothing is deleted.
+		if !rrsetDeletionMatches(rec, d) {
+			gcprest.WriteError(w, http.StatusPreconditionFailed, "conditionNotMet",
+				"the deletion for "+d.Name+" ("+d.Type+") does not match the existing record set")
+			return false
+		}
+	}
+
+	return true
+}
+
+// rrsetDeletionMatches reports whether a deletion's TTL and rrdatas match the
+// existing record set exactly, comparing rrdatas order-independently.
+func rrsetDeletionMatches(rec *dnsdriver.RecordInfo, d *resourceRecordSetJSON) bool {
+	if int64(rec.TTL) != d.TTL {
+		return false
+	}
+
+	if len(rec.Values) != len(d.Rrdatas) {
+		return false
+	}
+
+	got := append([]string(nil), rec.Values...)
+	want := append([]string(nil), d.Rrdatas...)
+
+	sort.Strings(got)
+	sort.Strings(want)
+
+	for i := range got {
+		if got[i] != want[i] {
 			return false
 		}
 	}
@@ -362,6 +448,17 @@ func (h *Handler) checkAdditions(w http.ResponseWriter, r *http.Request, id stri
 
 	for i := range req.Additions {
 		a := &req.Additions[i]
+
+		// Validate every addition's shape before any mutation applies. The driver
+		// has no batch primitive, so a malformed addition caught only at apply
+		// time would land after the deletions — reject it up front so the batch
+		// fails cleanly and the zone is left untouched.
+		if a.Name == "" || a.Type == "" || len(a.Rrdatas) == 0 {
+			gcprest.WriteError(w, http.StatusBadRequest, "invalid",
+				"an addition must have a name, type, and at least one rrdata")
+			return false
+		}
+
 		if deleting[rrsetKey(a.Name, a.Type)] {
 			continue
 		}


### PR DESCRIPTION
## Summary

Fixes three real-user parity bugs in GCP Cloud DNS (`server/gcp/clouddns`), reconciled against the real `google.golang.org/api/dns/v1` SDK.

### BUG1 — changes.create deletions must match the existing rrset exactly
A deletion previously only checked that the record set existed; it deleted by name+type and ignored the submitted TTL/rrdatas. Real Cloud DNS requires a deletion to reflect the current record set exactly (name, type, ttl, all rrdatas) or it returns **412 conditionNotMet** and deletes nothing. `checkDeletions` now compares the fetched TTL and (order-independent) rrdatas against the deletion and emits 412 on mismatch before any mutation.

### BUG2 — non-atomic half-apply on a malformed mid-batch addition
The driver has no batch primitive, so a malformed addition caught only at apply time would land **after** the deletions, leaving the zone half-mutated. `checkAdditions` now validates every addition's Name/Type/rrdatas up front, so a bad batch is rejected (400) before any delete/add applies.

### BUG3 — lax zone-create validation
`createZone` accepted an empty `dnsName` (silently falling back to the zone name) and did no zone-name/FQDN checks. It now requires `dnsName` present and a trailing-dot FQDN, and validates the zone name against `[a-z]([-a-z0-9]*[a-z0-9])?`, returning 400 on violation.

## Tests
Real-SDK (`dns/v1` over httptest) coverage: wrong-TTL and wrong-rrdata deletions → 412 with the record left intact; exact-match (order-independent) deletion succeeds; malformed addition rejected before its paired deletion applies (zone unchanged); empty dnsName → 400; bad zone name → 400; non-FQDN dnsName → 400.

## Gates
- `go build` / `go vet` / scoped `go test` green
- `gofmt` clean; `golangci-lint --new-from-rev=origin/development` 0 new issues
- `go generate ./...` and compatgen: zero diff (idempotent)

## Deferred (not attempted)
- RRSets write API and DNSSEC `defaultKeySpecs` remain deferred per scope.
- Clearing a zone `description` via patch: the request/response share one `managedZoneJSON` struct with `omitempty`, so distinguishing absent-vs-empty cleanly would ripple through response serialization — left out to avoid regressing the solid apex/DNSSEC round-trip.