### PR TITLE
fix(gcp-artifactregistry): union tags on same-digest re-push, uniform locking, content-addressed digest, single version/tag GET

### DIFF
--- a/providers/gcp/artifactregistry/artifactregistry.go
+++ b/providers/gcp/artifactregistry/artifactregistry.go
@@ -19,11 +19,10 @@ import (
 )
 
 const (
-	defaultMediaType     = "application/vnd.docker.distribution.manifest.v2+json"
-	mutableTag           = "MUTABLE"
-	immutableTag         = "IMMUTABLE"
-	scanStatusComplete   = "COMPLETE"
-	digestHashFormatByte = 8
+	defaultMediaType   = "application/vnd.docker.distribution.manifest.v2+json"
+	mutableTag         = "MUTABLE"
+	immutableTag       = "IMMUTABLE"
+	scanStatusComplete = "COMPLETE"
 )
 
 // Compile-time check that Mock implements driver.ContainerRegistry.
@@ -45,7 +44,7 @@ type repoData struct {
 
 // Mock is an in-memory mock implementation of the GCP Artifact Registry service.
 type Mock struct {
-	mu         sync.Mutex
+	mu         sync.RWMutex
 	repos      *memstore.Store[*repoData]
 	opts       *config.Options
 	monitoring mondriver.Monitoring
@@ -87,6 +86,9 @@ func (m *Mock) CreateRepository(_ context.Context, cfg driver.RepositoryConfig) 
 		return nil, errors.New(errors.InvalidArgument, "repository name is required")
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if m.repos.Has(cfg.Name) {
 		return nil, errors.Newf(errors.AlreadyExists, "repository %q already exists", cfg.Name)
 	}
@@ -127,6 +129,9 @@ func (m *Mock) CreateRepository(_ context.Context, cfg driver.RepositoryConfig) 
 
 // DeleteRepository deletes an Artifact Registry repository.
 func (m *Mock) DeleteRepository(_ context.Context, name string, force bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(name)
 	if !ok {
 		return errors.Newf(errors.NotFound, "repository %q not found", name)
@@ -143,6 +148,9 @@ func (m *Mock) DeleteRepository(_ context.Context, name string, force bool) erro
 
 // GetRepository retrieves information about an Artifact Registry repository.
 func (m *Mock) GetRepository(_ context.Context, name string) (*driver.Repository, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	rd, ok := m.repos.Get(name)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", name)
@@ -179,6 +187,9 @@ func (m *Mock) UpdateRepository(_ context.Context, name string, tags map[string]
 
 // ListRepositories lists all Artifact Registry repositories.
 func (m *Mock) ListRepositories(_ context.Context) ([]driver.Repository, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	all := m.repos.All()
 	repos := make([]driver.Repository, 0, len(all))
 
@@ -207,26 +218,8 @@ func (m *Mock) PutImage(ctx context.Context, manifest *driver.ImageManifest) (*d
 		return nil, err
 	}
 
-	digest := resolveDigest(manifest, m.opts.Clock.Now())
-	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
-	mediaType := resolveMediaType(manifest.MediaType)
-
-	detail := driver.ImageDetail{
-		RegistryID: m.opts.ProjectID,
-		Repository: manifest.Repository,
-		Digest:     digest,
-		Tags:       []string{manifest.Tag},
-		SizeBytes:  manifest.SizeBytes,
-		PushedAt:   now,
-		MediaType:  mediaType,
-	}
-
-	img := &imageData{detail: detail, layers: manifest.Layers}
-	rd.images.Set(digest, img)
-
-	if manifest.Tag != "" {
-		updateTagIndex(rd, digest, manifest.Tag)
-	}
+	digest := resolveDigest(manifest)
+	img := m.storeImage(rd, manifest, digest)
 
 	rd.info.ImageCount = rd.images.Len()
 
@@ -236,13 +229,46 @@ func (m *Mock) PutImage(ctx context.Context, manifest *driver.ImageManifest) (*d
 
 	m.emitMetric(ctx, "push_request_count", 1, map[string]string{"repository_name": manifest.Repository})
 
-	result := detail
+	result := img.detail
 
 	return &result, nil
 }
 
+// storeImage adds or updates the image identified by digest. An image is
+// identified by its digest and carries a SET of tags: re-pushing the same
+// manifest under a new tag accumulates the tag onto the existing manifest
+// (preserving its original push time) rather than replacing it, and the tag is
+// moved off any other manifest that currently holds it.
+func (m *Mock) storeImage(rd *repoData, manifest *driver.ImageManifest, digest string) *imageData {
+	img, ok := rd.images.Get(digest)
+	if !ok {
+		img = &imageData{
+			detail: driver.ImageDetail{
+				RegistryID: m.opts.ProjectID,
+				Repository: manifest.Repository,
+				Digest:     digest,
+				SizeBytes:  manifest.SizeBytes,
+				PushedAt:   m.opts.Clock.Now().UTC().Format(time.RFC3339),
+				MediaType:  resolveMediaType(manifest.MediaType),
+				Manifest:   manifest.Manifest,
+			},
+			layers: manifest.Layers,
+		}
+		rd.images.Set(digest, img)
+	}
+
+	if manifest.Tag != "" {
+		updateTagIndex(rd, digest, manifest.Tag)
+	}
+
+	return img
+}
+
 // GetImage retrieves image details by repository and reference.
 func (m *Mock) GetImage(ctx context.Context, repository, reference string) (*driver.ImageDetail, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -262,6 +288,9 @@ func (m *Mock) GetImage(ctx context.Context, repository, reference string) (*dri
 
 // ListImages lists all images in an Artifact Registry repository.
 func (m *Mock) ListImages(_ context.Context, repository string) ([]driver.ImageDetail, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -330,6 +359,9 @@ func (m *Mock) TagImage(_ context.Context, repository, sourceRef, targetTag stri
 
 // PutLifecyclePolicy sets a cleanup policy on an Artifact Registry repository.
 func (m *Mock) PutLifecyclePolicy(_ context.Context, repository string, policy driver.LifecyclePolicy) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -343,6 +375,9 @@ func (m *Mock) PutLifecyclePolicy(_ context.Context, repository string, policy d
 
 // GetLifecyclePolicy retrieves the cleanup policy for an Artifact Registry repository.
 func (m *Mock) GetLifecyclePolicy(_ context.Context, repository string) (*driver.LifecyclePolicy, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -360,6 +395,9 @@ func (m *Mock) GetLifecyclePolicy(_ context.Context, repository string) (*driver
 // DeleteLifecyclePolicy removes the cleanup policy from an Artifact Registry
 // repository and returns the policy that was deleted.
 func (m *Mock) DeleteLifecyclePolicy(_ context.Context, repository string) (*driver.LifecyclePolicy, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -377,6 +415,9 @@ func (m *Mock) DeleteLifecyclePolicy(_ context.Context, repository string) (*dri
 
 // EvaluateLifecyclePolicy evaluates the cleanup policy and returns digests to expire.
 func (m *Mock) EvaluateLifecyclePolicy(_ context.Context, repository string) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -393,6 +434,9 @@ func (m *Mock) EvaluateLifecyclePolicy(_ context.Context, repository string) ([]
 func (m *Mock) StartImageScan(
 	_ context.Context, repository, reference string,
 ) (*driver.ScanResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -415,6 +459,9 @@ func (m *Mock) StartImageScan(
 func (m *Mock) GetImageScanResults(
 	_ context.Context, repository, reference string,
 ) (*driver.ScanResult, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -477,16 +524,25 @@ func checkTagMutability(rd *repoData, tag string) error {
 	return nil
 }
 
-// resolveDigest generates a digest from the manifest if not provided.
-func resolveDigest(manifest *driver.ImageManifest, now time.Time) string {
+// resolveDigest returns the image digest. When the client supplies an explicit
+// digest it is respected; otherwise the digest is content-addressed as the full
+// sha256 of the manifest bytes, so identical manifest content yields the same
+// 64-hex digest regardless of tag or push time. When no manifest body is
+// supplied it falls back to a stable per-tag input so distinct tags remain
+// distinct images.
+func resolveDigest(manifest *driver.ImageManifest) string {
 	if manifest.Digest != "" {
 		return manifest.Digest
 	}
 
-	input := fmt.Sprintf("%s:%s:%s", manifest.Repository, manifest.Tag, now.String())
+	input := manifest.Manifest
+	if input == "" {
+		input = manifest.Repository + ":" + manifest.Tag
+	}
+
 	hash := sha256.Sum256([]byte(input))
 
-	return fmt.Sprintf("sha256:%x", hash[:digestHashFormatByte])
+	return fmt.Sprintf("sha256:%x", hash)
 }
 
 // updateTagIndex removes a tag from any existing image and adds it to the target digest.

--- a/providers/gcp/artifactregistry/artifactregistry_test.go
+++ b/providers/gcp/artifactregistry/artifactregistry_test.go
@@ -3,6 +3,7 @@ package artifactregistry
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -703,6 +704,93 @@ func TestImageScan(t *testing.T) {
 		_, err := m.StartImageScan(ctx, "nonexistent", "v1")
 		require.Error(t, err)
 	})
+}
+
+// TestPutImageSameDigestAccumulatesTags: pushing the same digest under a second
+// tag unions the tag onto the one manifest (preserving its original push time)
+// instead of blowing the stored entry away.
+func TestPutImageSameDigestAccumulatesTags(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+	createTestRepo(t, m, "repo")
+
+	const digest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+	first, err := m.PutImage(ctx, &driver.ImageManifest{Repository: "repo", Tag: "v1", Digest: digest, SizeBytes: 1024})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"v1"}, first.Tags)
+	firstPushedAt := first.PushedAt
+
+	fc.Advance(time.Hour) // a later re-push must not move PushedAt
+
+	second, err := m.PutImage(ctx, &driver.ImageManifest{Repository: "repo", Tag: "v2", Digest: digest, SizeBytes: 1024})
+	require.NoError(t, err)
+	assert.Equal(t, digest, second.Digest)
+	assert.ElementsMatch(t, []string{"v1", "v2"}, second.Tags)
+	assert.Equal(t, firstPushedAt, second.PushedAt, "original PushedAt must be preserved on re-push")
+
+	images, err := m.ListImages(ctx, "repo")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(images))
+	assert.ElementsMatch(t, []string{"v1", "v2"}, images[0].Tags)
+}
+
+// TestResolveDigestContentAddressed: an auto-generated digest is the full-width
+// (64-hex) sha256 of the manifest body, and identical content yields the same
+// digest so two pushes collapse to one manifest.
+func TestResolveDigestContentAddressed(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestRepo(t, m, "repo")
+
+	const body = `{"schemaVersion":2,"layers":[]}`
+
+	a, err := m.PutImage(ctx, &driver.ImageManifest{Repository: "repo", Tag: "v1", Manifest: body, SizeBytes: 512})
+	require.NoError(t, err)
+	assert.Len(t, a.Digest, len("sha256:")+64, "digest must be full-width 64-hex sha256")
+
+	b, err := m.PutImage(ctx, &driver.ImageManifest{Repository: "repo", Tag: "v2", Manifest: body, SizeBytes: 512})
+	require.NoError(t, err)
+	assert.Equal(t, a.Digest, b.Digest, "identical content must yield the same digest")
+
+	images, err := m.ListImages(ctx, "repo")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(images))
+	assert.ElementsMatch(t, []string{"v1", "v2"}, images[0].Tags)
+}
+
+// TestConcurrentReadWriteRace exercises reads and writes concurrently so the
+// race detector catches unsynchronized access to repository state.
+func TestConcurrentReadWriteRace(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestRepo(t, m, "repo")
+
+	var wg sync.WaitGroup
+
+	for i := range 20 {
+		wg.Add(1)
+
+		go func(n int) {
+			defer wg.Done()
+
+			_, _ = m.PutImage(ctx, &driver.ImageManifest{
+				Repository: "repo", Tag: fmt.Sprintf("v%d", n), SizeBytes: 1024,
+			})
+		}(i)
+
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			_, _ = m.ListImages(ctx, "repo")
+			_, _ = m.GetRepository(ctx, "repo")
+			_, _ = m.ListRepositories(ctx)
+		}()
+	}
+
+	wg.Wait()
 }
 
 func TestMetricsEmission(t *testing.T) {

--- a/server/gcp/artifactregistry/subcollections.go
+++ b/server/gcp/artifactregistry/subcollections.go
@@ -25,14 +25,58 @@ func (h *Handler) servePackages(w http.ResponseWriter, r *http.Request, rt *rout
 
 	switch rt.pkgSub {
 	case versionsSeg:
+		if rt.pkgSubID != "" {
+			h.getVersion(w, r, rt)
+			return
+		}
+
 		h.listVersions(w, r, rt)
 	case tagsSeg:
+		if rt.pkgSubID != "" {
+			h.getTag(w, r, rt)
+			return
+		}
+
 		h.listTags(w, r, rt)
 	case "":
 		h.getPackage(w, r, rt)
 	default:
 		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported package sub-collection "+rt.pkgSub)
 	}
+}
+
+// getVersion returns a single version (.../packages/{pkg}/versions/{version}).
+// The driver models one version per image, keyed by the digest, so the version
+// id must equal the package's digest.
+func (h *Handler) getVersion(w http.ResponseWriter, r *http.Request, rt *route) {
+	img, ok := h.findImage(w, r, rt)
+	if !ok {
+		return
+	}
+
+	if rt.pkgSubID != img.Digest {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "version "+rt.pkgSubID+" not found")
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toVersionJSON(rt, img))
+}
+
+// getTag returns a single tag (.../packages/{pkg}/tags/{tag}).
+func (h *Handler) getTag(w http.ResponseWriter, r *http.Request, rt *route) {
+	img, ok := h.findImage(w, r, rt)
+	if !ok {
+		return
+	}
+
+	for _, t := range img.Tags {
+		if t == rt.pkgSubID {
+			gcprest.WriteJSON(w, http.StatusOK, toTagJSON(rt, t, img.Digest))
+			return
+		}
+	}
+
+	gcprest.WriteError(w, http.StatusNotFound, "notFound", "tag "+rt.pkgSubID+" not found")
 }
 
 func (h *Handler) repoImages(w http.ResponseWriter, r *http.Request, rt *route) ([]crdriver.ImageDetail, bool) {

--- a/server/gcp/artifactregistry/subcollections_test.go
+++ b/server/gcp/artifactregistry/subcollections_test.go
@@ -80,3 +80,50 @@ func TestSDKArtifactRegistrySubCollections(t *testing.T) {
 		t.Fatalf("got %d files, want 2", len(files.Files))
 	}
 }
+
+// TestSDKArtifactRegistryGetSingleVersionAndTag guards that a GET of a single
+// version / tag returns just that one resource instead of leaking the whole
+// list (the sub-collection dispatcher previously ignored the trailing id).
+func TestSDKArtifactRegistryGetSingleVersionAndTag(t *testing.T) {
+	svc, reg := newARService(t)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{Format: "DOCKER"}).
+		RepositoryId("single").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if _, err := reg.PutImage(ctx, &crdriver.ImageManifest{
+		Repository: "single", Tag: "v1", Digest: "sha256:aaa", SizeBytes: 1024,
+		MediaType: "application/vnd.docker.distribution.manifest.v2+json",
+	}); err != nil {
+		t.Fatalf("seed PutImage: %v", err)
+	}
+
+	pkgParent := testParent + "/repositories/single/packages/sha256:aaa"
+
+	ver, err := svc.Projects.Locations.Repositories.Packages.Versions.
+		Get(pkgParent + "/versions/sha256:aaa").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Versions.Get: %v", err)
+	}
+
+	if !strings.HasSuffix(ver.Name, "/versions/sha256:aaa") {
+		t.Fatalf("Versions.Get returned wrong resource: %q", ver.Name)
+	}
+
+	tag, err := svc.Projects.Locations.Repositories.Packages.Tags.
+		Get(pkgParent + "/tags/v1").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Tags.Get: %v", err)
+	}
+
+	if !strings.HasSuffix(tag.Name, "/tags/v1") {
+		t.Fatalf("Tags.Get returned wrong resource: %q", tag.Name)
+	}
+
+	if _, err := svc.Projects.Locations.Repositories.Packages.Tags.
+		Get(pkgParent + "/tags/missing").Context(ctx).Do(); err == nil {
+		t.Fatalf("Tags.Get of a missing tag should 404")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes four real bugs in GCP Artifact Registry (`providers/gcp/artifactregistry/` + `server/gcp/artifactregistry/`), mirroring the correct AWS ECR implementation. No regression to the existing dockerConfig/cleanup/filter/updateMask behavior.

### BUG1 — data-loss: same-digest re-push destroyed accumulated tags (HIGH)
`PutImage` unconditionally built a fresh `ImageDetail{Tags:[]string{tag}, PushedAt:now}` and `Set` it, blowing away the existing entry (prior tags + original `PushedAt`) before `updateTagIndex` ran. Now factored into a `storeImage` helper (mirroring ECR `storeImage`): looks up the digest first, creates a fresh manifest only when absent, and otherwise keeps the stored manifest/`PushedAt` and only unions the new tag. Pushing digest D as `v1` then `v2` now yields `D` carrying `{v1,v2}` with the original push time preserved.

### BUG2 — concurrency: read/lifecycle methods took no lock (MED)
`GetRepository`, `ListRepositories`, `GetImage`, `ListImages`, `Get/Put/Delete/EvaluateLifecyclePolicy`, `StartImageScan`, `GetImageScanResults`, `CreateRepository`, `DeleteRepository` ran without `m.mu`, racing on `rd.info`/`rd.policy`. `mu` is now a `sync.RWMutex` acquired uniformly across all methods (RLock for reads, Lock for writes).

### BUG3 — digest not content-addressed, truncated to 8 bytes (LOW-MED)
`resolveDigest` hashed `repo:tag:now` truncated to 8 bytes. It now hashes the full manifest body as a 64-hex sha256 when a body is supplied (identical content → same digest), falling back to a stable per-tag input only when no body is present.

### BUG4 — GET of a single version/tag returned the whole list (LOW)
The `packages` sub-collection dispatcher ignored the trailing version/tag id. `servePackages` now routes `pkgSubID != ""` to new `getVersion` / `getTag` handlers that return the single resource (404 when absent).

## Deferred (not attempted)
- No `/v2/` docker registry push path
- Remote/virtual repository config

## Tests
- Same-digest re-push accumulates tags + preserves `PushedAt`
- `-race` clean under concurrent read + write
- Content-addressed digest full-width; identical content → same digest
- GET single version/tag returns one resource (+ 404 on missing tag)

Gates: build, vet, scoped `go test`, `-race`, gofmt, `golangci-lint --new-from-rev` (0 new); `go generate` + compatgen zero-diff.
