### PR TITLE
fix(azure-ai): PATCH merge, deployment raiPolicy/versionUpgradeOption, endpoint customSubDomain, regenerateKey validation

### DIFF
--- a/docs/coverage/azure/ai.md
+++ b/docs/coverage/azure/ai.md
@@ -97,8 +97,8 @@ Azure's `azureai` service · portable interface `driver.AzureAI` · [Azure index
 | `ScoreOnlineEndpoint` | AML online-endpoint scoring. |
 | `StartCompute` |  |
 | `StopCompute` |  |
-| `UpdateAccountTags` |  |
-| `UpdateMLWorkspaceTags` |  |
+| `UpdateAccount` |  |
+| `UpdateMLWorkspace` |  |
 
 ## Optional capabilities
 
@@ -140,7 +140,7 @@ CognitiveServices is the Microsoft.CognitiveServices control-plane surface.
 | `ListRaiPolicies` |  |
 | `PutPrivateEndpointConnection` | Private-endpoint connections (accounts/privateEndpointConnections). |
 | `RegenerateAccountKey` |  |
-| `UpdateAccountTags` |  |
+| `UpdateAccount` |  |
 
 ### DataPlane
 
@@ -215,7 +215,7 @@ MachineLearning is the Microsoft.MachineLearningServices control-plane
 | `RestartCompute` |  |
 | `StartCompute` |  |
 | `StopCompute` |  |
-| `UpdateMLWorkspaceTags` |  |
+| `UpdateMLWorkspace` |  |
 
 ## Not in scope
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -352,10 +352,10 @@
         "name": "StopCompute"
       },
       {
-        "name": "UpdateAccountTags"
+        "name": "UpdateAccount"
       },
       {
-        "name": "UpdateMLWorkspaceTags"
+        "name": "UpdateMLWorkspace"
       }
     ],
     "optionalCapabilities": [
@@ -460,7 +460,7 @@
             "name": "RegenerateAccountKey"
           },
           {
-            "name": "UpdateAccountTags"
+            "name": "UpdateAccount"
           }
         ]
       },
@@ -667,7 +667,7 @@
             "name": "StopCompute"
           },
           {
-            "name": "UpdateMLWorkspaceTags"
+            "name": "UpdateMLWorkspace"
           }
         ]
       }

--- a/providers/azure/ai/ai.go
+++ b/providers/azure/ai/ai.go
@@ -145,8 +145,19 @@ func csOrDefaultSKU(name string) string {
 	return name
 }
 
-// accountEndpoint derives the data-plane endpoint for an account from its kind.
-func accountEndpoint(name, kind string) string {
+// accountSubdomain is the endpoint host label: the customSubDomainName when set,
+// otherwise the account name (matching real Cognitive Services behavior).
+func accountSubdomain(customDomain, name string) string {
+	if customDomain != "" {
+		return customDomain
+	}
+
+	return name
+}
+
+// accountEndpoint derives the data-plane endpoint for an account from its
+// custom-subdomain (or name) and kind.
+func accountEndpoint(subdomain, kind string) string {
 	host := "cognitiveservices"
 	if strings.EqualFold(kind, "OpenAI") {
 		host = "openai"
@@ -154,7 +165,7 @@ func accountEndpoint(name, kind string) string {
 		host = "services.ai"
 	}
 
-	return "https://" + name + "." + host + ".azure.com/"
+	return "https://" + subdomain + "." + host + ".azure.com/"
 }
 
 // --- Accounts ---
@@ -191,8 +202,9 @@ func (m *Mock) CreateAccount(_ context.Context, cfg driver.AccountConfig) (*driv
 		updated.SKUName = csOrDefaultSKU(cfg.SKUName)
 		updated.Tags = copyMap(cfg.Tags)
 
-		if cfg.CustomDomain != "" {
+		if cfg.CustomDomain != "" && cfg.CustomDomain != updated.CustomDomain {
 			updated.CustomDomain = cfg.CustomDomain
+			updated.Endpoint = accountEndpoint(accountSubdomain(updated.CustomDomain, updated.Name), updated.Kind)
 		}
 
 		m.accounts.Set(k, &updated)
@@ -207,7 +219,7 @@ func (m *Mock) CreateAccount(_ context.Context, cfg driver.AccountConfig) (*driv
 		Location:          cfg.Location,
 		Kind:              kind,
 		SKUName:           csOrDefaultSKU(cfg.SKUName),
-		Endpoint:          accountEndpoint(cfg.Name, kind),
+		Endpoint:          accountEndpoint(accountSubdomain(cfg.CustomDomain, cfg.Name), kind),
 		CustomDomain:      cfg.CustomDomain,
 		ProvisioningState: driver.StateSucceeded,
 		Tags:              copyMap(cfg.Tags),
@@ -236,8 +248,11 @@ func (m *Mock) DeleteAccount(_ context.Context, resourceGroup, name string) erro
 	return nil
 }
 
-func (m *Mock) UpdateAccountTags(
-	_ context.Context, resourceGroup, name string, tags map[string]string,
+// UpdateAccount applies a PATCH: only fields present in upd change; omitted
+// fields (nil pointers) are preserved. Tags are merged into the existing set,
+// never wiped by an absent tags block.
+func (m *Mock) UpdateAccount(
+	_ context.Context, resourceGroup, name string, upd driver.AccountUpdate,
 ) (*driver.Account, error) {
 	k := key(resourceGroup, name)
 
@@ -247,7 +262,27 @@ func (m *Mock) UpdateAccountTags(
 	}
 
 	updated := *a
-	updated.Tags = copyMap(tags)
+	updated.Tags = copyMap(a.Tags)
+
+	if upd.Tags != nil {
+		if updated.Tags == nil {
+			updated.Tags = make(map[string]string, len(*upd.Tags))
+		}
+
+		for tk, tv := range *upd.Tags {
+			updated.Tags[tk] = tv
+		}
+	}
+
+	if upd.SKUName != nil {
+		updated.SKUName = csOrDefaultSKU(*upd.SKUName)
+	}
+
+	if upd.CustomDomain != nil && *upd.CustomDomain != updated.CustomDomain {
+		updated.CustomDomain = *upd.CustomDomain
+		updated.Endpoint = accountEndpoint(accountSubdomain(updated.CustomDomain, updated.Name), updated.Kind)
+	}
+
 	m.accounts.Set(k, &updated)
 
 	return cloneAccount(&updated), nil
@@ -304,15 +339,20 @@ func (m *Mock) RegenerateAccountKey(_ context.Context, resourceGroup, name, keyN
 		return nil, errors.Newf(errors.NotFound, "account %q not found", name)
 	}
 
+	isKey1 := strings.EqualFold(keyName, "Key1")
+	if !isKey1 && !strings.EqualFold(keyName, "Key2") {
+		return nil, errors.Newf(errors.InvalidArgument, "keyName must be Key1 or Key2, got %q", keyName)
+	}
+
 	keys := m.currentAccountKeys(resourceGroup, name)
 
 	// Salt the named key with a monotonic counter so the rotation is distinct
 	// and observable via a subsequent ListAccountKeys; the other key is stable.
 	salt := "regen-" + strconv.FormatInt(m.seq.Add(1), 16)
-	if strings.EqualFold(keyName, "Key2") {
-		keys.Key2 = deterministicKey(resourceGroup, name, salt)
-	} else {
+	if isKey1 {
 		keys.Key1 = deterministicKey(resourceGroup, name, salt)
+	} else {
+		keys.Key2 = deterministicKey(resourceGroup, name, salt)
 	}
 
 	m.accountKeys.Set(key(resourceGroup, name), keys)

--- a/providers/azure/ai/cognitive_services.go
+++ b/providers/azure/ai/cognitive_services.go
@@ -9,6 +9,10 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/azureai/driver"
 )
 
+// defaultVersionUpgradeOption is the Cognitive Services default when a
+// deployment omits versionUpgradeOption.
+const defaultVersionUpgradeOption = "OnceNewDefaultVersionAvailable"
+
 // subResourceID builds the ARM ID for a child resource of an account.
 func (m *Mock) subResourceID(resourceGroup, account, childType, name string) string {
 	return idgen.AzureID(m.opts.AccountID, resourceGroup, csProvider, "accounts", account) +
@@ -51,16 +55,23 @@ func (m *Mock) CreateDeployment(_ context.Context, cfg driver.DeploymentConfig) 
 		skuName = "Standard"
 	}
 
+	upgradeOption := cfg.VersionUpgradeOption
+	if upgradeOption == "" {
+		upgradeOption = defaultVersionUpgradeOption
+	}
+
 	d := &driver.Deployment{
-		ID:                m.subResourceID(cfg.ResourceGroup, cfg.Account, "deployments", cfg.Name),
-		Name:              cfg.Name,
-		ModelName:         cfg.ModelName,
-		ModelVersion:      cfg.ModelVersion,
-		ModelFormat:       cfg.ModelFormat,
-		SKUName:           skuName,
-		SKUCapacity:       cfg.SKUCapacity,
-		ProvisioningState: driver.StateSucceeded,
-		CreatedAt:         m.now(),
+		ID:                   m.subResourceID(cfg.ResourceGroup, cfg.Account, "deployments", cfg.Name),
+		Name:                 cfg.Name,
+		ModelName:            cfg.ModelName,
+		ModelVersion:         cfg.ModelVersion,
+		ModelFormat:          cfg.ModelFormat,
+		SKUName:              skuName,
+		SKUCapacity:          cfg.SKUCapacity,
+		RaiPolicyName:        cfg.RaiPolicyName,
+		VersionUpgradeOption: upgradeOption,
+		ProvisioningState:    driver.StateSucceeded,
+		CreatedAt:            m.now(),
 	}
 	m.deployments.Set(childKey(cfg.ResourceGroup, cfg.Account, "deployments", cfg.Name), d)
 	m.emitMetric("deployment/count", 1, map[string]string{"model": cfg.ModelName})

--- a/providers/azure/ai/machine_learning.go
+++ b/providers/azure/ai/machine_learning.go
@@ -104,8 +104,11 @@ func (m *Mock) DeleteMLWorkspace(_ context.Context, resourceGroup, name string) 
 	return nil
 }
 
-func (m *Mock) UpdateMLWorkspaceTags(
-	_ context.Context, resourceGroup, name string, tags map[string]string,
+// UpdateMLWorkspace applies a PATCH: only fields present in upd change; omitted
+// fields (nil pointers) are preserved. Tags are merged into the existing set,
+// never wiped by an absent tags block.
+func (m *Mock) UpdateMLWorkspace(
+	_ context.Context, resourceGroup, name string, upd driver.MLWorkspaceUpdate,
 ) (*driver.MLWorkspace, error) {
 	k := key(resourceGroup, name)
 
@@ -115,7 +118,26 @@ func (m *Mock) UpdateMLWorkspaceTags(
 	}
 
 	updated := *w
-	updated.Tags = copyMap(tags)
+	updated.Tags = copyMap(w.Tags)
+
+	if upd.Tags != nil {
+		if updated.Tags == nil {
+			updated.Tags = make(map[string]string, len(*upd.Tags))
+		}
+
+		for tk, tv := range *upd.Tags {
+			updated.Tags[tk] = tv
+		}
+	}
+
+	if upd.FriendlyName != nil {
+		updated.FriendlyName = *upd.FriendlyName
+	}
+
+	if upd.Description != nil {
+		updated.Description = *upd.Description
+	}
+
 	m.mlWorkspaces.Set(k, &updated)
 
 	return cloneMLWorkspace(&updated), nil

--- a/server/azure/ai/accounts.go
+++ b/server/azure/ai/accounts.go
@@ -81,15 +81,33 @@ func (h *CognitiveServicesHandler) getAccount(w http.ResponseWriter, r *http.Req
 }
 
 func (h *CognitiveServicesHandler) patchAccount(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	// Pointer fields distinguish "absent" (nil, leave unchanged) from "present",
+	// so a PATCH that omits tags never wipes them and a PATCH of another field is
+	// not a silent no-op.
 	var body struct {
-		Tags map[string]string `json:"tags"`
+		Tags *map[string]string `json:"tags"`
+		SKU  *struct {
+			Name string `json:"name"`
+		} `json:"sku"`
+		Properties *struct {
+			CustomSubDomainName *string `json:"customSubDomainName"`
+		} `json:"properties"`
 	}
 
 	if !azurearm.DecodeJSON(w, r, &body) {
 		return
 	}
 
-	a, err := h.svc.UpdateAccountTags(r.Context(), rp.ResourceGroup, rp.ResourceName, body.Tags)
+	upd := csdriver.AccountUpdate{Tags: body.Tags}
+	if body.SKU != nil {
+		upd.SKUName = &body.SKU.Name
+	}
+
+	if body.Properties != nil && body.Properties.CustomSubDomainName != nil {
+		upd.CustomDomain = body.Properties.CustomSubDomainName
+	}
+
+	a, err := h.svc.UpdateAccount(r.Context(), rp.ResourceGroup, rp.ResourceName, upd)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 

--- a/server/azure/ai/children.go
+++ b/server/azure/ai/children.go
@@ -39,7 +39,9 @@ func deploymentJSON(d *csdriver.Deployment) map[string]any {
 		"id": d.ID, "name": d.Name, "type": csProvider + "/accounts/deployments",
 		"sku": map[string]any{"name": d.SKUName, "capacity": d.SKUCapacity},
 		"properties": map[string]any{
-			"provisioningState": d.ProvisioningState,
+			"provisioningState":    d.ProvisioningState,
+			"raiPolicyName":        d.RaiPolicyName,
+			"versionUpgradeOption": d.VersionUpgradeOption,
 			"model": map[string]any{
 				"name": d.ModelName, "version": d.ModelVersion, "format": d.ModelFormat,
 			},
@@ -104,6 +106,8 @@ func (h *CognitiveServicesHandler) putChild(w http.ResponseWriter, r *http.Reque
 					Version string `json:"version"`
 					Format  string `json:"format"`
 				} `json:"model"`
+				RaiPolicyName        string `json:"raiPolicyName"`
+				VersionUpgradeOption string `json:"versionUpgradeOption"`
 			} `json:"properties"`
 		}
 
@@ -113,9 +117,11 @@ func (h *CognitiveServicesHandler) putChild(w http.ResponseWriter, r *http.Reque
 
 		cfg := csdriver.DeploymentConfig{
 			Account: account, ResourceGroup: rg, Name: name,
-			ModelName:    body.Properties.Model.Name,
-			ModelVersion: body.Properties.Model.Version,
-			ModelFormat:  body.Properties.Model.Format,
+			ModelName:            body.Properties.Model.Name,
+			ModelVersion:         body.Properties.Model.Version,
+			ModelFormat:          body.Properties.Model.Format,
+			RaiPolicyName:        body.Properties.RaiPolicyName,
+			VersionUpgradeOption: body.Properties.VersionUpgradeOption,
 		}
 		if body.SKU != nil {
 			cfg.SKUName = body.SKU.Name

--- a/server/azure/ai/cognitiveservices_update_test.go
+++ b/server/azure/ai/cognitiveservices_update_test.go
@@ -1,0 +1,200 @@
+package ai_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// newCSTLSServer starts an in-memory TLS server backed by the Azure AI mock.
+func newCSTLSServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{CognitiveServices: cloudP.AI})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+// newCSDeploymentsClient builds a DeploymentsClient pointed at ts.
+func newCSDeploymentsClient(t *testing.T, ts *httptest.Server) *armcognitiveservices.DeploymentsClient {
+	t.Helper()
+
+	c, err := armcognitiveservices.NewDeploymentsClient(sub, fakeCred{}, armClientOptions(ts))
+	require.NoError(t, err)
+
+	return c
+}
+
+// newCSAccountsClientOn builds an AccountsClient pointed at ts.
+func newCSAccountsClientOn(t *testing.T, ts *httptest.Server) *armcognitiveservices.AccountsClient {
+	t.Helper()
+
+	c, err := armcognitiveservices.NewAccountsClient(sub, fakeCred{}, armClientOptions(ts))
+	require.NoError(t, err)
+
+	return c
+}
+
+// postStatus issues a raw POST and returns the HTTP status code.
+func postStatus(t *testing.T, url string, body any) int {
+	t.Helper()
+
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	return resp.StatusCode
+}
+
+// TestSDKAccountPatchPreservesTags verifies a PATCH that changes a non-tag field
+// (sku) neither wipes existing tags (the nil-mask bug) nor is a silent no-op.
+func TestSDKAccountPatchPreservesTags(t *testing.T) {
+	c := newCSAccountsClientOn(t, newCSTLSServer(t))
+	ctx := context.Background()
+
+	createPoller, err := c.BeginCreate(ctx, rg, acct, armcognitiveservices.Account{
+		Location: to.Ptr("eastus"),
+		Kind:     to.Ptr("AIServices"),
+		SKU:      &armcognitiveservices.SKU{Name: to.Ptr("S0")},
+		Tags:     map[string]*string{"env": to.Ptr("test")},
+	}, nil)
+	require.NoError(t, err)
+	_, err = createPoller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	// PATCH the sku only; the Tags map is nil so the SDK omits it from the body.
+	upPoller, err := c.BeginUpdate(ctx, rg, acct, armcognitiveservices.Account{
+		SKU: &armcognitiveservices.SKU{Name: to.Ptr("S1")},
+	}, nil)
+	require.NoError(t, err)
+	_, err = upPoller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	got, err := c.Get(ctx, rg, acct, nil)
+	require.NoError(t, err)
+
+	require.Contains(t, got.Account.Tags, "env", "existing tags must survive a non-tag PATCH")
+	assert.Equal(t, "test", *got.Account.Tags["env"])
+	require.NotNil(t, got.Account.SKU)
+	assert.Equal(t, "S1", *got.Account.SKU.Name, "PATCH of sku must apply, not be a no-op")
+}
+
+// TestSDKDeploymentRaiPolicyRoundTrip verifies raiPolicyName and
+// versionUpgradeOption survive a create->get round trip.
+func TestSDKDeploymentRaiPolicyRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	ts := newCSTLSServer(t)
+	accClient := newCSAccountsClientOn(t, ts)
+	createPoller, err := accClient.BeginCreate(ctx, rg, acct, armcognitiveservices.Account{
+		Location: to.Ptr("eastus"), Kind: to.Ptr("OpenAI"),
+	}, nil)
+	require.NoError(t, err)
+	_, err = createPoller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	depClient := newCSDeploymentsClient(t, ts)
+
+	upgrade := armcognitiveservices.DeploymentModelVersionUpgradeOptionNoAutoUpgrade
+	depPoller, err := depClient.BeginCreateOrUpdate(ctx, rg, acct, "gpt4o", armcognitiveservices.Deployment{
+		SKU: &armcognitiveservices.SKU{Name: to.Ptr("Standard"), Capacity: to.Ptr[int32](10)},
+		Properties: &armcognitiveservices.DeploymentProperties{
+			Model: &armcognitiveservices.DeploymentModel{
+				Name: to.Ptr("gpt-4o"), Version: to.Ptr("2024-08-06"), Format: to.Ptr("OpenAI"),
+			},
+			RaiPolicyName:        to.Ptr("Microsoft.DefaultV2"),
+			VersionUpgradeOption: &upgrade,
+		},
+	}, nil)
+	require.NoError(t, err)
+	_, err = depPoller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	got, err := depClient.Get(ctx, rg, acct, "gpt4o", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.Deployment.Properties)
+	require.NotNil(t, got.Deployment.Properties.RaiPolicyName)
+	assert.Equal(t, "Microsoft.DefaultV2", *got.Deployment.Properties.RaiPolicyName)
+	require.NotNil(t, got.Deployment.Properties.VersionUpgradeOption)
+	assert.Equal(t, upgrade, *got.Deployment.Properties.VersionUpgradeOption)
+}
+
+// TestDeploymentVersionUpgradeOptionDefault verifies the default is applied when
+// the request omits versionUpgradeOption.
+func TestDeploymentVersionUpgradeOptionDefault(t *testing.T) {
+	url := newServer(t)
+	do(t, http.MethodPut, url+base()+"/"+acct, map[string]any{"location": "eastus", "kind": "OpenAI"})
+
+	dep := do(t, http.MethodPut, url+base()+"/"+acct+"/deployments/gpt4o", map[string]any{
+		"properties": map[string]any{"model": map[string]any{"name": "gpt-4o", "version": "2024-08-06", "format": "OpenAI"}},
+	})
+	assert.Equal(t, "OnceNewDefaultVersionAvailable", props(dep)["versionUpgradeOption"])
+}
+
+// TestSDKAccountCustomSubDomainEndpoint verifies the synthesized endpoint uses
+// the customSubDomainName rather than the account name.
+func TestSDKAccountCustomSubDomainEndpoint(t *testing.T) {
+	c := newCSAccountsClientOn(t, newCSTLSServer(t))
+	ctx := context.Background()
+
+	createPoller, err := c.BeginCreate(ctx, rg, acct, armcognitiveservices.Account{
+		Location: to.Ptr("eastus"),
+		Kind:     to.Ptr("OpenAI"),
+		Properties: &armcognitiveservices.AccountProperties{
+			CustomSubDomainName: to.Ptr("mycustomdomain"),
+		},
+	}, nil)
+	require.NoError(t, err)
+	_, err = createPoller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	got, err := c.Get(ctx, rg, acct, nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.Account.Properties)
+	require.NotNil(t, got.Account.Properties.Endpoint)
+	assert.Equal(t, "https://mycustomdomain.openai.azure.com/", *got.Account.Properties.Endpoint)
+	assert.NotContains(t, *got.Account.Properties.Endpoint, acct)
+}
+
+// TestRegenerateKeyBadKeyName verifies an invalid keyName is rejected with 400
+// rather than silently rotating Key1.
+func TestRegenerateKeyBadKeyName(t *testing.T) {
+	url := newServer(t)
+	do(t, http.MethodPut, url+base()+"/"+acct, map[string]any{"location": "eastus", "kind": "OpenAI"})
+
+	for _, keyName := range []string{"", "Key3", "primary"} {
+		status := postStatus(t, url+base()+"/"+acct+"/regenerateKey", map[string]any{"keyName": keyName})
+		assert.Equalf(t, http.StatusBadRequest, status, "keyName=%q must be rejected", keyName)
+	}
+}
+
+func TestRegenerateKeyKey2(t *testing.T) {
+	url := newServer(t)
+	do(t, http.MethodPut, url+base()+"/"+acct, map[string]any{"location": "eastus", "kind": "OpenAI"})
+
+	keys := do(t, http.MethodPost, url+base()+"/"+acct+"/listKeys", map[string]any{})
+	regen := do(t, http.MethodPost, url+base()+"/"+acct+"/regenerateKey", map[string]any{"keyName": "Key2"})
+	assert.NotEqual(t, keys["key2"], regen["key2"], "regenerated key2 must change")
+	assert.Equal(t, keys["key1"], regen["key1"], "key1 must be stable")
+}

--- a/server/azure/ai/machine_learning.go
+++ b/server/azure/ai/machine_learning.go
@@ -199,15 +199,27 @@ func (h *MachineLearningHandler) getWorkspace(w http.ResponseWriter, r *http.Req
 }
 
 func (h *MachineLearningHandler) patchWorkspace(w http.ResponseWriter, r *http.Request, p *mlPath, name string) {
+	// Pointer fields distinguish "absent" (leave unchanged) from "present", so a
+	// PATCH that omits tags never wipes them.
 	var body struct {
-		Tags map[string]string `json:"tags"`
+		Tags       *map[string]string `json:"tags"`
+		Properties *struct {
+			FriendlyName *string `json:"friendlyName"`
+			Description  *string `json:"description"`
+		} `json:"properties"`
 	}
 
 	if !azurearm.DecodeJSON(w, r, &body) {
 		return
 	}
 
-	ws, err := h.svc.UpdateMLWorkspaceTags(r.Context(), p.resourceGroup, name, body.Tags)
+	upd := mldriver.MLWorkspaceUpdate{Tags: body.Tags}
+	if body.Properties != nil {
+		upd.FriendlyName = body.Properties.FriendlyName
+		upd.Description = body.Properties.Description
+	}
+
+	ws, err := h.svc.UpdateMLWorkspace(r.Context(), p.resourceGroup, name, upd)
 	writeML(w, mlWorkspaceJSON, ws, err)
 }
 

--- a/services/azureai/driver/cognitive_services.go
+++ b/services/azureai/driver/cognitive_services.go
@@ -14,6 +14,15 @@ type AccountConfig struct {
 	Tags          map[string]string
 }
 
+// AccountUpdate carries the mutable fields of an account PATCH. A nil pointer
+// means "field absent from the request body" — leave it unchanged; a non-nil
+// pointer applies the value (an empty *Tags map still merges nothing).
+type AccountUpdate struct {
+	Tags         *map[string]string // nil = no change; non-nil = merge into existing tags
+	SKUName      *string            // nil = no change
+	CustomDomain *string            // nil = no change; recomputes the endpoint when set
+}
+
 // Account is a Microsoft.CognitiveServices/accounts resource.
 type Account struct {
 	ID                string
@@ -39,19 +48,24 @@ type DeploymentConfig struct {
 	ModelFormat   string // OpenAI | Microsoft | ...
 	SKUName       string // Standard | GlobalStandard | ProvisionedManaged | ...
 	SKUCapacity   int
+	RaiPolicyName string // content-filter policy attached to the deployment
+	// VersionUpgradeOption: OnceNewDefaultVersionAvailable | OnceCurrentVersionExpired | NoAutoUpgrade
+	VersionUpgradeOption string
 }
 
 // Deployment is a Microsoft.CognitiveServices/accounts/deployments resource.
 type Deployment struct {
-	ID                string
-	Name              string
-	ModelName         string
-	ModelVersion      string
-	ModelFormat       string
-	SKUName           string
-	SKUCapacity       int
-	ProvisioningState string
-	CreatedAt         string
+	ID                   string
+	Name                 string
+	ModelName            string
+	ModelVersion         string
+	ModelFormat          string
+	SKUName              string
+	SKUCapacity          int
+	RaiPolicyName        string
+	VersionUpgradeOption string
+	ProvisioningState    string
+	CreatedAt            string
 }
 
 // ProjectConfig describes an AI Foundry project under an account.
@@ -161,7 +175,7 @@ type CognitiveServices interface {
 	CreateAccount(ctx context.Context, cfg AccountConfig) (*Account, error)
 	GetAccount(ctx context.Context, resourceGroup, name string) (*Account, error)
 	DeleteAccount(ctx context.Context, resourceGroup, name string) error
-	UpdateAccountTags(ctx context.Context, resourceGroup, name string, tags map[string]string) (*Account, error)
+	UpdateAccount(ctx context.Context, resourceGroup, name string, upd AccountUpdate) (*Account, error)
 	ListAccountsByResourceGroup(ctx context.Context, resourceGroup string) ([]Account, error)
 	ListAccounts(ctx context.Context) ([]Account, error)
 	ListAccountKeys(ctx context.Context, resourceGroup, name string) (*AccountKeys, error)

--- a/services/azureai/driver/machine_learning.go
+++ b/services/azureai/driver/machine_learning.go
@@ -13,6 +13,14 @@ type MLWorkspaceConfig struct {
 	Tags          map[string]string
 }
 
+// MLWorkspaceUpdate carries the mutable fields of a workspace PATCH. A nil
+// pointer means "field absent from the request body" — leave it unchanged.
+type MLWorkspaceUpdate struct {
+	Tags         *map[string]string // nil = no change; non-nil = merge into existing tags
+	FriendlyName *string            // nil = no change
+	Description  *string            // nil = no change
+}
+
 // MLWorkspace is a Microsoft.MachineLearningServices/workspaces resource.
 type MLWorkspace struct {
 	ID                string
@@ -229,7 +237,7 @@ type MachineLearning interface {
 	CreateMLWorkspace(ctx context.Context, cfg MLWorkspaceConfig) (*MLWorkspace, error)
 	GetMLWorkspace(ctx context.Context, resourceGroup, name string) (*MLWorkspace, error)
 	DeleteMLWorkspace(ctx context.Context, resourceGroup, name string) error
-	UpdateMLWorkspaceTags(ctx context.Context, resourceGroup, name string, tags map[string]string) (*MLWorkspace, error)
+	UpdateMLWorkspace(ctx context.Context, resourceGroup, name string, upd MLWorkspaceUpdate) (*MLWorkspace, error)
 	ListMLWorkspacesByResourceGroup(ctx context.Context, resourceGroup string) ([]MLWorkspace, error)
 	ListMLWorkspaces(ctx context.Context) ([]MLWorkspace, error)
 

--- a/services/azureai/wrappers_cognitiveservices.go
+++ b/services/azureai/wrappers_cognitiveservices.go
@@ -19,9 +19,9 @@ func (a *AzureAI) DeleteAccount(ctx context.Context, rg, name string) error {
 	return a.act(ctx, "DeleteAccount", name, func() error { return a.drv.DeleteAccount(ctx, rg, name) })
 }
 
-func (a *AzureAI) UpdateAccountTags(ctx context.Context, rg, name string, tags map[string]string) (*driver.Account, error) {
-	return cast[*driver.Account](a.do(ctx, "UpdateAccountTags", name, func() (any, error) {
-		return a.drv.UpdateAccountTags(ctx, rg, name, tags)
+func (a *AzureAI) UpdateAccount(ctx context.Context, rg, name string, upd driver.AccountUpdate) (*driver.Account, error) {
+	return cast[*driver.Account](a.do(ctx, "UpdateAccount", name, func() (any, error) {
+		return a.drv.UpdateAccount(ctx, rg, name, upd)
 	}))
 }
 

--- a/services/azureai/wrappers_machinelearning.go
+++ b/services/azureai/wrappers_machinelearning.go
@@ -23,9 +23,11 @@ func (a *AzureAI) DeleteMLWorkspace(ctx context.Context, rg, name string) error 
 	return a.act(ctx, "DeleteMLWorkspace", name, func() error { return a.drv.DeleteMLWorkspace(ctx, rg, name) })
 }
 
-func (a *AzureAI) UpdateMLWorkspaceTags(ctx context.Context, rg, name string, tags map[string]string) (*driver.MLWorkspace, error) {
-	return cast[*driver.MLWorkspace](a.do(ctx, "UpdateMLWorkspaceTags", name, func() (any, error) {
-		return a.drv.UpdateMLWorkspaceTags(ctx, rg, name, tags)
+func (a *AzureAI) UpdateMLWorkspace(
+	ctx context.Context, rg, name string, upd driver.MLWorkspaceUpdate,
+) (*driver.MLWorkspace, error) {
+	return cast[*driver.MLWorkspace](a.do(ctx, "UpdateMLWorkspace", name, func() (any, error) {
+		return a.drv.UpdateMLWorkspace(ctx, rg, name, upd)
 	}))
 }
 


### PR DESCRIPTION
## Summary

Fixes four confirmed Azure AI / Cognitive Services bugs found in a real-SDK audit. All within `server/azure/ai/`, `providers/azure/ai/`, and `services/azureai/`.

### BUG1 — PATCH nil-mask wiped tags + ignored other mutable props
`patchAccount` / `patchWorkspace` decoded only `{tags}` and the driver did an unconditional replace, so a PATCH that omitted tags wiped them, and a PATCH of any other field was a silent no-op. Now the request body uses pointer fields (absent = no change), tags are **merged** into the existing set, and account PATCH passes through `sku` and `properties.customSubDomainName` (ML workspace passes through `friendlyName`/`description`). `UpdateAccountTags`→`UpdateAccount(AccountUpdate)` and `UpdateMLWorkspaceTags`→`UpdateMLWorkspace(MLWorkspaceUpdate)`.

### BUG2 — deployment dropped raiPolicyName + versionUpgradeOption
Added both to `DeploymentConfig`/`Deployment`, decode in `putChild`, store in `CreateDeployment`, emit in `deploymentJSON`. `versionUpgradeOption` defaults to `OnceNewDefaultVersionAvailable`. Fixes `azurerm_cognitive_deployment` perpetual drift.

### BUG3 — endpoint synthesis ignored customSubDomainName
`accountEndpoint` now uses the custom subdomain (fallback account name), e.g. `https://{customSubDomain}.openai.azure.com/`. Endpoint is recomputed on the update branch and in `UpdateAccount` when the custom domain changes.

### BUG4 — regenerateKey accepted empty/invalid keyName
`RegenerateAccountKey` now validates `keyName ∈ {Key1, Key2}` (case-insensitive) and returns `InvalidArgument` (HTTP 400) otherwise, instead of silently rotating Key1.

## Tests
New `server/azure/ai/cognitiveservices_update_test.go` (real `armcognitiveservices` SDK over httptest): PATCH of a non-tag field preserves existing tags and applies the field; deployment raiPolicyName/versionUpgradeOption round-trip + default; account with customSubDomainName yields the custom endpoint; regenerateKey with a bad keyName returns 400; Key2 rotation.

## Notes
Account `networkAcls`/`identity`/`disableLocalAuth` and ML-workspace associated-resources remain deferred feature-gaps (not attempted).

Coverage docs regenerated (`go generate`); compat matrix unchanged (compatgen green).
