### PR TITLE
fix(azure-dns): round-trip editable SOA timing fields, PATCH on zones+record sets, 200-on-update record set

### DIFF
--- a/providers/azure/dns/dns.go
+++ b/providers/azure/dns/dns.go
@@ -200,6 +200,7 @@ func (m *Mock) CreateRecord(_ context.Context, cfg driver.RecordConfig) (*driver
 		Values: values,
 		Weight: weight,
 		SetID:  cfg.SetID,
+		SOA:    copySOA(cfg.SOA),
 	}
 
 	m.records.Set(key, rec)
@@ -361,6 +362,7 @@ func (m *Mock) UpdateRecord(_ context.Context, cfg driver.RecordConfig) (*driver
 		Values: values,
 		Weight: weight,
 		SetID:  cfg.SetID,
+		SOA:    copySOA(cfg.SOA),
 	}
 
 	m.records.Set(key, rec)
@@ -376,6 +378,18 @@ func copyWeight(w *int) *int {
 	}
 
 	v := *w
+
+	return &v
+}
+
+// copySOA returns a deep copy of an SOA carrier so a stored record never aliases
+// the caller's struct.
+func copySOA(s *driver.SOARecord) *driver.SOARecord {
+	if s == nil {
+		return nil
+	}
+
+	v := *s
 
 	return &v
 }

--- a/server/azure/dns/handler.go
+++ b/server/azure/dns/handler.go
@@ -19,11 +19,13 @@
 // Coverage:
 //
 //	PUT    .../dnsZones/{z}                              — Zones.CreateOrUpdate
+//	PATCH  .../dnsZones/{z}                              — Zones.Update (tags merge)
 //	GET    .../dnsZones/{z}                              — Zones.Get
 //	DELETE .../dnsZones/{z}                              — Zones.Delete (LRO, completes inline)
 //	GET    .../providers/Microsoft.Network/dnsZones      — Zones.List (subscription scope)
 //	GET    .../resourceGroups/{rg}/…/dnsZones            — Zones.ListByResourceGroup
 //	PUT    .../dnsZones/{z}/{type}/{name}                — RecordSets.CreateOrUpdate
+//	PATCH  .../dnsZones/{z}/{type}/{name}                — RecordSets.Update (merge supplied)
 //	GET    .../dnsZones/{z}/{type}/{name}                — RecordSets.Get
 //	DELETE .../dnsZones/{z}/{type}/{name}                — RecordSets.Delete
 //	GET    .../dnsZones/{z}/recordsets|all               — RecordSets.ListByDnsZone / ListAllByDnsZone
@@ -116,6 +118,8 @@ func (h *Handler) serveZone(w http.ResponseWriter, r *http.Request, rp *azurearm
 	switch r.Method {
 	case http.MethodPut:
 		h.createOrUpdateZone(w, r, rp)
+	case http.MethodPatch:
+		h.patchZone(w, r, rp)
 	case http.MethodGet:
 		h.getZone(w, r, rp)
 	case http.MethodDelete:
@@ -146,6 +150,8 @@ func (h *Handler) serveRecordSet(w http.ResponseWriter, r *http.Request, rp *azu
 	switch r.Method {
 	case http.MethodPut:
 		h.createOrUpdateRecordSet(w, r, rp)
+	case http.MethodPatch:
+		h.patchRecordSet(w, r, rp)
 	case http.MethodGet:
 		h.getRecordSet(w, r, rp)
 	case http.MethodDelete:

--- a/server/azure/dns/operations.go
+++ b/server/azure/dns/operations.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"context"
+	"maps"
 	"net/http"
 	"strings"
 
@@ -172,25 +173,140 @@ func (h *Handler) createOrUpdateRecordSet(w http.ResponseWriter, r *http.Request
 		Type:   recordType,
 		TTL:    ttlOrDefault(body.Properties),
 		Values: recordValues(recordType, body.Properties),
+		SOA:    soaConfigFromProps(body.Properties),
 	}
 
-	info, err := h.upsertRecord(r, cfg)
+	info, created, err := h.upsertRecord(r, &cfg)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusCreated, toRecordSetJSON(rp, rp.ResourceName, info))
+	// Azure returns 201 Created when the record set is newly created and 200 OK
+	// when an existing one is updated (the zone path already distinguishes the
+	// two the same way).
+	status := http.StatusOK
+	if created {
+		status = http.StatusCreated
+	}
+
+	azurearm.WriteJSON(w, status, toRecordSetJSON(rp, rp.ResourceName, info))
 }
 
 // upsertRecord updates the record if it already exists, otherwise creates it —
-// Azure's RecordSets.CreateOrUpdate is upsert semantics.
-func (h *Handler) upsertRecord(r *http.Request, cfg dnsdriver.RecordConfig) (*dnsdriver.RecordInfo, error) {
+// Azure's RecordSets.CreateOrUpdate is upsert semantics. The bool reports
+// whether the record set was newly created (true) or updated in place (false),
+// so the caller can pick the 201/200 status Azure returns.
+func (h *Handler) upsertRecord(r *http.Request, cfg *dnsdriver.RecordConfig) (*dnsdriver.RecordInfo, bool, error) {
 	if _, err := h.dns.GetRecord(r.Context(), cfg.ZoneID, cfg.Name, cfg.Type); err == nil {
-		return h.dns.UpdateRecord(r.Context(), cfg)
+		info, uerr := h.dns.UpdateRecord(r.Context(), *cfg)
+		return info, false, uerr
 	}
 
-	return h.dns.CreateRecord(r.Context(), cfg)
+	info, cerr := h.dns.CreateRecord(r.Context(), *cfg)
+
+	return info, true, cerr
+}
+
+// patchZone backs Zones.Update: a PATCH that merges the supplied tags over the
+// zone's existing tags (existing tags the caller did not resend are preserved),
+// returning 200. Unmodeled zone properties are preserved by the server's overlay
+// middleware, which unions a PATCH's fresh unmodeled keys over the stored ones.
+func (h *Handler) patchZone(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body zoneJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	id, err := h.resolveZoneID(r.Context(), rp)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	existing, err := h.dns.GetZone(r.Context(), id)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	merged := maps.Clone(existing.Tags)
+	if merged == nil {
+		merged = make(map[string]string, len(body.Tags))
+	}
+
+	for k, v := range body.Tags {
+		merged[k] = v
+	}
+
+	info, err := h.dns.UpdateZone(r.Context(), dnsdriver.ZoneConfig{
+		Name:    rp.ResourceName,
+		Private: existing.Private,
+		Tags:    merged,
+		Scope:   scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
+	})
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toZoneJSON(rp, info))
+}
+
+// patchRecordSet backs RecordSets.Update: a PATCH that merges the supplied
+// fields (TTL, the record data for its type, and — for SOA — the editable timing
+// fields) over the existing record set, preserving any field the caller omitted
+// rather than nil-masking it. Metadata and other unmodeled properties are merged
+// by the server's overlay middleware. Returns 200.
+func (h *Handler) patchRecordSet(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body recordSetJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	zoneID, err := h.resolveZoneID(r.Context(), rp)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	recordType := recordTypeSegment(rp.SubResource)
+	name := rp.SubResourceName
+
+	existing, err := h.dns.GetRecord(r.Context(), zoneID, name, recordType)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	cfg := dnsdriver.RecordConfig{
+		ZoneID: zoneID,
+		Name:   name,
+		Type:   recordType,
+		TTL:    existing.TTL,
+		Values: existing.Values,
+		SOA:    existing.SOA,
+	}
+
+	if body.Properties != nil && body.Properties.TTL != nil {
+		cfg.TTL = int(*body.Properties.TTL)
+	}
+
+	if supplied := recordValues(recordType, body.Properties); len(supplied) > 0 {
+		cfg.Values = supplied
+	}
+
+	if recordType == recTypeSOA {
+		cfg.SOA = mergeSOAConfig(existing.SOA, soaConfigFromProps(body.Properties))
+	}
+
+	info, err := h.dns.UpdateRecord(r.Context(), cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toRecordSetJSON(rp, rp.ResourceName, info))
 }
 
 func (h *Handler) getRecordSet(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {

--- a/server/azure/dns/operations.go
+++ b/server/azure/dns/operations.go
@@ -292,12 +292,16 @@ func (h *Handler) patchRecordSet(w http.ResponseWriter, r *http.Request, rp *azu
 		cfg.TTL = int(*body.Properties.TTL)
 	}
 
-	if supplied := recordValues(recordType, body.Properties); len(supplied) > 0 {
-		cfg.Values = supplied
-	}
-
 	if recordType == recTypeSOA {
+		// SOA host (and email) are system-managed: recordValues yields [host,
+		// email], so a timing-only PATCH that omits them would blindly overwrite
+		// the stored values with empties and lose the host. Merge instead —
+		// preserve the existing host/email unless the PATCH supplies new ones —
+		// while the timing fields keep merging via the SOA carrier.
+		cfg.Values = mergeSOAValues(existing.Values, body.Properties)
 		cfg.SOA = mergeSOAConfig(existing.SOA, soaConfigFromProps(body.Properties))
+	} else if supplied := recordValues(recordType, body.Properties); len(supplied) > 0 {
+		cfg.Values = supplied
 	}
 
 	info, err := h.dns.UpdateRecord(r.Context(), cfg)

--- a/server/azure/dns/patch_soa_sdk_test.go
+++ b/server/azure/dns/patch_soa_sdk_test.go
@@ -1,0 +1,309 @@
+package dns_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// statusRecorder is a per-call ARM pipeline policy that remembers the HTTP
+// status code of the most recent response, so a test can assert on the exact
+// 200-vs-201 status the handler returned (the typed SDK responses do not expose
+// it).
+type statusRecorder struct{ last int }
+
+func (s *statusRecorder) Do(req *policy.Request) (*http.Response, error) {
+	resp, err := req.Next()
+	if resp != nil {
+		s.last = resp.StatusCode
+	}
+
+	return resp, err
+}
+
+func newDNSClientsWithStatus(t *testing.T) (*armdns.ZonesClient, *armdns.RecordSetsClient, *statusRecorder) {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{DNS: cloudP.DNS})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {
+				Endpoint: ts.URL,
+				Audience: "https://management.azure.com",
+			},
+		},
+	}
+
+	rec := &statusRecorder{}
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:           myCloud,
+			Transport:       ts.Client(),
+			Retry:           policy.RetryOptions{MaxRetries: -1},
+			PerCallPolicies: []policy.Policy{rec},
+		},
+	}
+
+	cf, err := armdns.NewClientFactory(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("armdns.NewClientFactory: %v", err)
+	}
+
+	return cf.NewZonesClient(), cf.NewRecordSetsClient(), rec
+}
+
+// TestSDKAzureDNSEditApexSOA is the BUG1 regression: a caller-edited apex SOA
+// record set must read back the edited timing fields (refreshTime, minimumTTL,
+// …) rather than being re-stamped with the platform defaults on every read.
+func TestSDKAzureDNSEditApexSOA(t *testing.T) {
+	zones, records, _ := newDNSClientsWithStatus(t)
+	ctx := context.Background()
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, "soa.com", armdns.Zone{
+		Location: to.Ptr("global"),
+	}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	// The auto-created apex SOA starts at Azure's platform defaults.
+	got, err := records.Get(ctx, testRG, "soa.com", "@", armdns.RecordTypeSOA, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.Get(SOA): %v", err)
+	}
+
+	soa := got.Properties.SoaRecord
+	if soa == nil || soa.RefreshTime == nil || *soa.RefreshTime != 3600 || soa.MinimumTTL == nil || *soa.MinimumTTL != 300 {
+		t.Fatalf("auto SOA = %+v, want default refreshTime=3600 minimumTTL=300", soa)
+	}
+
+	host := *soa.Host
+
+	// Edit the timing fields (real clients GET then PUT the whole record set).
+	if _, err := records.CreateOrUpdate(ctx, testRG, "soa.com", "@", armdns.RecordTypeSOA, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL: to.Ptr(int64(3600)),
+			SoaRecord: &armdns.SoaRecord{
+				Host:         to.Ptr(host),
+				RefreshTime:  to.Ptr(int64(7200)),
+				MinimumTTL:   to.Ptr(int64(600)),
+				ExpireTime:   to.Ptr(int64(1209600)),
+				SerialNumber: to.Ptr(int64(42)),
+			},
+		},
+	}, nil); err != nil {
+		t.Fatalf("RecordSets.CreateOrUpdate(SOA edit): %v", err)
+	}
+
+	edited, err := records.Get(ctx, testRG, "soa.com", "@", armdns.RecordTypeSOA, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.Get(SOA after edit): %v", err)
+	}
+
+	e := edited.Properties.SoaRecord
+	if e == nil || e.RefreshTime == nil || *e.RefreshTime != 7200 {
+		t.Fatalf("edited SOA refreshTime = %+v, want 7200", e)
+	}
+	if e.MinimumTTL == nil || *e.MinimumTTL != 600 {
+		t.Fatalf("edited SOA minimumTTL = %+v, want 600", e.MinimumTTL)
+	}
+	if e.ExpireTime == nil || *e.ExpireTime != 1209600 {
+		t.Fatalf("edited SOA expireTime = %+v, want 1209600", e.ExpireTime)
+	}
+	if e.SerialNumber == nil || *e.SerialNumber != 42 {
+		t.Fatalf("edited SOA serialNumber = %+v, want 42", e.SerialNumber)
+	}
+	// retryTime was not edited, so it must keep the platform default.
+	if e.RetryTime == nil || *e.RetryTime != 300 {
+		t.Fatalf("edited SOA retryTime = %+v, want default 300 (unedited)", e.RetryTime)
+	}
+	// host is read-only and must be unchanged.
+	if e.Host == nil || *e.Host != host {
+		t.Fatalf("edited SOA host = %+v, want unchanged %q", e.Host, host)
+	}
+}
+
+// TestSDKAzureDNSAutoSOADefaults asserts that a freshly-created zone's
+// auto-provisioned apex SOA still reads back Azure's platform defaults when it
+// has not been edited (the BUG1 fix must not disturb the default path).
+func TestSDKAzureDNSAutoSOADefaults(t *testing.T) {
+	zones, records, _ := newDNSClientsWithStatus(t)
+	ctx := context.Background()
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, "default-soa.com", armdns.Zone{
+		Location: to.Ptr("global"),
+	}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	got, err := records.Get(ctx, testRG, "default-soa.com", "@", armdns.RecordTypeSOA, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.Get(SOA): %v", err)
+	}
+
+	soa := got.Properties.SoaRecord
+	switch {
+	case soa == nil:
+		t.Fatalf("SOA record missing")
+	case *soa.RefreshTime != 3600:
+		t.Fatalf("refreshTime = %d, want 3600", *soa.RefreshTime)
+	case *soa.RetryTime != 300:
+		t.Fatalf("retryTime = %d, want 300", *soa.RetryTime)
+	case *soa.ExpireTime != 2419200:
+		t.Fatalf("expireTime = %d, want 2419200", *soa.ExpireTime)
+	case *soa.MinimumTTL != 300:
+		t.Fatalf("minimumTTL = %d, want 300", *soa.MinimumTTL)
+	case *soa.SerialNumber != 1:
+		t.Fatalf("serialNumber = %d, want 1", *soa.SerialNumber)
+	}
+}
+
+// TestSDKAzureDNSPatchZoneTagsMerge is the GAP-A regression for zones: a PATCH
+// (Zones.Update) must merge the supplied tags over the zone's existing tags,
+// preserving tags the caller did not resend, and return 200.
+func TestSDKAzureDNSPatchZoneTagsMerge(t *testing.T) {
+	zones, _, _ := newDNSClientsWithStatus(t)
+	ctx := context.Background()
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, "patchzone.com", armdns.Zone{
+		Location: to.Ptr("global"),
+		Tags:     map[string]*string{"env": to.Ptr("test")},
+	}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	updated, err := zones.Update(ctx, testRG, "patchzone.com", armdns.ZoneUpdate{
+		Tags: map[string]*string{"team": to.Ptr("blue")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Zones.Update: %v", err)
+	}
+
+	if updated.Tags["env"] == nil || *updated.Tags["env"] != "test" {
+		t.Fatalf("after PATCH tags = %v, want env=test preserved", updated.Tags)
+	}
+	if updated.Tags["team"] == nil || *updated.Tags["team"] != "blue" {
+		t.Fatalf("after PATCH tags = %v, want team=blue added", updated.Tags)
+	}
+
+	// A read-back confirms the merge persisted, not just the response body.
+	got, err := zones.Get(ctx, testRG, "patchzone.com", nil)
+	if err != nil {
+		t.Fatalf("Zones.Get: %v", err)
+	}
+	if got.Tags["env"] == nil || *got.Tags["env"] != "test" || got.Tags["team"] == nil || *got.Tags["team"] != "blue" {
+		t.Fatalf("read-back tags = %v, want env=test and team=blue", got.Tags)
+	}
+}
+
+// TestSDKAzureDNSPatchRecordSetPreservesOmitted is the GAP-A regression for
+// record sets: a PATCH (RecordSets.Update) must merge the supplied fields and
+// preserve any field the caller omitted (no nil-masking).
+func TestSDKAzureDNSPatchRecordSetPreservesOmitted(t *testing.T) {
+	zones, records, _ := newDNSClientsWithStatus(t)
+	ctx := context.Background()
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, "patchrec.com", armdns.Zone{
+		Location: to.Ptr("global"),
+	}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	if _, err := records.CreateOrUpdate(ctx, testRG, "patchrec.com", "www", armdns.RecordTypeA, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL: to.Ptr(int64(300)),
+			ARecords: []*armdns.ARecord{
+				{IPv4Address: to.Ptr("192.0.2.1")},
+				{IPv4Address: to.Ptr("192.0.2.2")},
+			},
+		},
+	}, nil); err != nil {
+		t.Fatalf("RecordSets.CreateOrUpdate: %v", err)
+	}
+
+	// PATCH only the TTL; the A records must be preserved.
+	patched, err := records.Update(ctx, testRG, "patchrec.com", "www", armdns.RecordTypeA, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{TTL: to.Ptr(int64(600))},
+	}, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.Update(ttl only): %v", err)
+	}
+
+	if patched.Properties.TTL == nil || *patched.Properties.TTL != 600 {
+		t.Fatalf("PATCH TTL = %+v, want 600", patched.Properties.TTL)
+	}
+	if len(patched.Properties.ARecords) != 2 {
+		t.Fatalf("PATCH dropped A records: %+v, want 2 preserved", patched.Properties.ARecords)
+	}
+
+	// PATCH only the records; the TTL just set must be preserved.
+	patched2, err := records.Update(ctx, testRG, "patchrec.com", "www", armdns.RecordTypeA, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			ARecords: []*armdns.ARecord{{IPv4Address: to.Ptr("203.0.113.7")}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.Update(records only): %v", err)
+	}
+
+	if patched2.Properties.TTL == nil || *patched2.Properties.TTL != 600 {
+		t.Fatalf("PATCH2 TTL = %+v, want 600 preserved", patched2.Properties.TTL)
+	}
+	if len(patched2.Properties.ARecords) != 1 || *patched2.Properties.ARecords[0].IPv4Address != "203.0.113.7" {
+		t.Fatalf("PATCH2 A records = %+v, want [203.0.113.7]", patched2.Properties.ARecords)
+	}
+}
+
+// TestSDKAzureDNSRecordSetCreateUpdateStatus is the BUG2 regression:
+// RecordSets.CreateOrUpdate returns 201 Created on first create and 200 OK when
+// updating an existing record set.
+func TestSDKAzureDNSRecordSetCreateUpdateStatus(t *testing.T) {
+	zones, records, rec := newDNSClientsWithStatus(t)
+	ctx := context.Background()
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, "status.com", armdns.Zone{
+		Location: to.Ptr("global"),
+	}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	if _, err := records.CreateOrUpdate(ctx, testRG, "status.com", "www", armdns.RecordTypeA, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL:      to.Ptr(int64(300)),
+			ARecords: []*armdns.ARecord{{IPv4Address: to.Ptr("192.0.2.1")}},
+		},
+	}, nil); err != nil {
+		t.Fatalf("RecordSets.CreateOrUpdate(create): %v", err)
+	}
+	if rec.last != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201", rec.last)
+	}
+
+	if _, err := records.CreateOrUpdate(ctx, testRG, "status.com", "www", armdns.RecordTypeA, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL:      to.Ptr(int64(600)),
+			ARecords: []*armdns.ARecord{{IPv4Address: to.Ptr("192.0.2.9")}},
+		},
+	}, nil); err != nil {
+		t.Fatalf("RecordSets.CreateOrUpdate(update): %v", err)
+	}
+	if rec.last != http.StatusOK {
+		t.Fatalf("update status = %d, want 200", rec.last)
+	}
+}

--- a/server/azure/dns/patch_soa_sdk_test.go
+++ b/server/azure/dns/patch_soa_sdk_test.go
@@ -139,6 +139,65 @@ func TestSDKAzureDNSEditApexSOA(t *testing.T) {
 	}
 }
 
+// TestSDKAzureDNSPatchSOATimingPreservesHost is the residue regression: a PATCH
+// (RecordSets.Update) that supplies ONLY a timing field on the apex SOA — with
+// host and email omitted — must keep the system-managed host and email stable
+// (recordValues would otherwise yield ["",""] and wipe them) while applying the
+// new timing value.
+func TestSDKAzureDNSPatchSOATimingPreservesHost(t *testing.T) {
+	zones, records, _ := newDNSClientsWithStatus(t)
+	ctx := context.Background()
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, "soapatch.com", armdns.Zone{
+		Location: to.Ptr("global"),
+	}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	before, err := records.Get(ctx, testRG, "soapatch.com", "@", armdns.RecordTypeSOA, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.Get(SOA): %v", err)
+	}
+
+	host := *before.Properties.SoaRecord.Host
+	email := *before.Properties.SoaRecord.Email
+
+	// PATCH ONLY refreshTime; host and email are omitted from the body.
+	patched, err := records.Update(ctx, testRG, "soapatch.com", "@", armdns.RecordTypeSOA, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			SoaRecord: &armdns.SoaRecord{RefreshTime: to.Ptr(int64(9999))},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.Update(timing only): %v", err)
+	}
+
+	p := patched.Properties.SoaRecord
+	if p == nil || p.Host == nil || *p.Host != host {
+		t.Fatalf("PATCH timing-only SOA host = %+v, want unchanged %q", p, host)
+	}
+	if p.Email == nil || *p.Email != email {
+		t.Fatalf("PATCH timing-only SOA email = %+v, want unchanged %q", p.Email, email)
+	}
+	if p.RefreshTime == nil || *p.RefreshTime != 9999 {
+		t.Fatalf("PATCH timing-only SOA refreshTime = %+v, want 9999", p.RefreshTime)
+	}
+
+	// Read-back confirms the host/email survived the write, not just the response.
+	after, err := records.Get(ctx, testRG, "soapatch.com", "@", armdns.RecordTypeSOA, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.Get(SOA after patch): %v", err)
+	}
+
+	a := after.Properties.SoaRecord
+	if a.Host == nil || *a.Host != host || a.Email == nil || *a.Email != email {
+		t.Fatalf("read-back SOA host/email = %v/%v, want %q/%q", a.Host, a.Email, host, email)
+	}
+	if a.RefreshTime == nil || *a.RefreshTime != 9999 {
+		t.Fatalf("read-back SOA refreshTime = %+v, want 9999", a.RefreshTime)
+	}
+}
+
 // TestSDKAzureDNSAutoSOADefaults asserts that a freshly-created zone's
 // auto-provisioned apex SOA still reads back Azure's platform defaults when it
 // has not been edited (the BUG1 fix must not disturb the default path).

--- a/server/azure/dns/types.go
+++ b/server/azure/dns/types.go
@@ -306,16 +306,18 @@ func toRecordSetProperties(rec *dnsdriver.RecordInfo) *recordSetProperties {
 			props.PtrRecords = append(props.PtrRecords, ptrRecordJSON{Ptrdname: v})
 		}
 	case recTypeSOA:
-		props.SoaRecord = toSOARecord(rec.Values)
+		props.SoaRecord = toSOARecord(rec)
 	}
 
 	return props
 }
 
-// toSOARecord rebuilds the Azure SOA body from the driver's flat values
-// ([host, email]), filling the timing fields with the platform defaults Azure
-// stamps on the auto-created apex SOA.
-func toSOARecord(values []string) *soaRecordJSON {
+// toSOARecord rebuilds the Azure SOA body from a driver record. host and email
+// come from the flat values ([host, email]); the timing fields start at the
+// platform defaults Azure stamps on the auto-created apex SOA and are overridden
+// by any caller-edited field carried on rec.SOA, so a user-edited SOA reads back
+// the edited values while an unedited one keeps Azure's defaults.
+func toSOARecord(rec *dnsdriver.RecordInfo) *soaRecordJSON {
 	soa := &soaRecordJSON{
 		Email:        soaEmail,
 		SerialNumber: soaSerial,
@@ -325,15 +327,111 @@ func toSOARecord(values []string) *soaRecordJSON {
 		MinimumTTL:   soaMinimumTTL,
 	}
 
-	if len(values) > 0 {
-		soa.Host = values[0]
+	if len(rec.Values) > 0 {
+		soa.Host = rec.Values[0]
 	}
 
-	if len(values) > 1 && values[1] != "" {
-		soa.Email = values[1]
+	if len(rec.Values) > 1 && rec.Values[1] != "" {
+		soa.Email = rec.Values[1]
 	}
+
+	applyEditedSOA(soa, rec.SOA)
 
 	return soa
+}
+
+// applyEditedSOA overrides the SOA body's editable timing/serial/email fields
+// with any non-zero value the caller edited (carried on the driver's SOA
+// carrier). host is read-only and never touched here.
+func applyEditedSOA(soa *soaRecordJSON, edited *dnsdriver.SOARecord) {
+	if edited == nil {
+		return
+	}
+
+	if edited.Email != "" {
+		soa.Email = edited.Email
+	}
+
+	if edited.SerialNumber != 0 {
+		soa.SerialNumber = edited.SerialNumber
+	}
+
+	if edited.RefreshTime != 0 {
+		soa.RefreshTime = edited.RefreshTime
+	}
+
+	if edited.RetryTime != 0 {
+		soa.RetryTime = edited.RetryTime
+	}
+
+	if edited.ExpireTime != 0 {
+		soa.ExpireTime = edited.ExpireTime
+	}
+
+	if edited.MinimumTTL != 0 {
+		soa.MinimumTTL = edited.MinimumTTL
+	}
+}
+
+// soaConfigFromProps extracts the editable SOA timing fields from a request
+// body's SOA record into the driver's typed carrier, or nil when the body
+// carries no SOA record. host stays in the flat values (read-only).
+func soaConfigFromProps(props *recordSetProperties) *dnsdriver.SOARecord {
+	if props == nil || props.SoaRecord == nil {
+		return nil
+	}
+
+	s := props.SoaRecord
+
+	return &dnsdriver.SOARecord{
+		Email:        s.Email,
+		SerialNumber: s.SerialNumber,
+		RefreshTime:  s.RefreshTime,
+		RetryTime:    s.RetryTime,
+		ExpireTime:   s.ExpireTime,
+		MinimumTTL:   s.MinimumTTL,
+	}
+}
+
+// mergeSOAConfig overlays a PATCH's supplied SOA fields onto the stored carrier,
+// preserving any field the PATCH left unset (zero). Used by the record-set PATCH
+// merge so a partial SOA edit keeps the fields it did not resend.
+func mergeSOAConfig(base, patch *dnsdriver.SOARecord) *dnsdriver.SOARecord {
+	if patch == nil {
+		return base
+	}
+
+	if base == nil {
+		return patch
+	}
+
+	out := *base
+
+	if patch.Email != "" {
+		out.Email = patch.Email
+	}
+
+	if patch.SerialNumber != 0 {
+		out.SerialNumber = patch.SerialNumber
+	}
+
+	if patch.RefreshTime != 0 {
+		out.RefreshTime = patch.RefreshTime
+	}
+
+	if patch.RetryTime != 0 {
+		out.RetryTime = patch.RetryTime
+	}
+
+	if patch.ExpireTime != 0 {
+		out.ExpireTime = patch.ExpireTime
+	}
+
+	if patch.MinimumTTL != 0 {
+		out.MinimumTTL = patch.MinimumTTL
+	}
+
+	return &out
 }
 
 // toRecordSetJSON converts a driver record into its ARM element.

--- a/server/azure/dns/types.go
+++ b/server/azure/dns/types.go
@@ -393,6 +393,35 @@ func soaConfigFromProps(props *recordSetProperties) *dnsdriver.SOARecord {
 	}
 }
 
+// mergeSOAValues overlays a PATCH's supplied SOA host/email onto the record's
+// existing flat values ([host, email]), preserving the existing (system-managed)
+// host and email when the PATCH omits them. Azure keeps the SOA host stable on a
+// timing-only update, so a PATCH that carries no host must never blank it.
+func mergeSOAValues(existing []string, props *recordSetProperties) []string {
+	out := []string{"", ""}
+	if len(existing) > 0 {
+		out[0] = existing[0]
+	}
+
+	if len(existing) > 1 {
+		out[1] = existing[1]
+	}
+
+	if props == nil || props.SoaRecord == nil {
+		return out
+	}
+
+	if props.SoaRecord.Host != "" {
+		out[0] = props.SoaRecord.Host
+	}
+
+	if props.SoaRecord.Email != "" {
+		out[1] = props.SoaRecord.Email
+	}
+
+	return out
+}
+
 // mergeSOAConfig overlays a PATCH's supplied SOA fields onto the stored carrier,
 // preserving any field the PATCH left unset (zero). Used by the record-set PATCH
 // merge so a partial SOA edit keeps the fields it did not resend.

--- a/services/dns/driver/driver.go
+++ b/services/dns/driver/driver.go
@@ -107,6 +107,20 @@ type GeoLocation struct {
 	SubdivisionCode string
 }
 
+// SOARecord carries the editable timing fields of an Azure DNS zone's apex SOA
+// record set. Azure lets a caller edit an SOA record set's refresh/retry/expire
+// times, minimum TTL, serial number and email; the host (authoritative name
+// server) is read-only. Other providers leave it nil, and the auto-created apex
+// SOA leaves it nil too so it reads back Azure's platform defaults.
+type SOARecord struct {
+	Email        string
+	SerialNumber int64
+	RefreshTime  int64
+	RetryTime    int64
+	ExpireTime   int64
+	MinimumTTL   int64
+}
+
 // RecordConfig describes a DNS record.
 type RecordConfig struct {
 	ZoneID string
@@ -125,6 +139,10 @@ type RecordConfig struct {
 	MultiValueAnswer *bool
 	GeoLocation      *GeoLocation
 	AliasTarget      *AliasTarget
+	// SOA carries the editable Azure SOA timing fields so a caller-edited apex
+	// SOA reads back the edited values. Nil for non-SOA records and for the
+	// auto-created apex SOA (which reads back platform defaults).
+	SOA *SOARecord
 }
 
 // RecordInfo describes a DNS record.
@@ -143,6 +161,9 @@ type RecordInfo struct {
 	MultiValueAnswer *bool
 	GeoLocation      *GeoLocation
 	AliasTarget      *AliasTarget
+	// SOA carries the editable Azure SOA timing fields as stored. Nil for
+	// non-SOA records and for the auto-created apex SOA.
+	SOA *SOARecord
 }
 
 // HealthCheckConfig describes a health check to create.


### PR DESCRIPTION
## Summary

Fixes three Azure DNS (`Microsoft.Network/dnsZones`) parity gaps a real `armdns` client hits, in one PR.

### BUG1 — editable SOA timing fields discarded on round-trip
The driver stored only `[host, email]` for an SOA record, so `toSOARecord` re-stamped the platform-default timing fields (`refreshTime`/`retryTime`/`expireTime`/`minimumTTL`/`serialNumber`) on every read. A caller editing the apex SOA (Terraform `azurerm_dns_zone{soa_record{}}`, `az network dns record-set soa update`) always drifted back to defaults.

Now the editable SOA sub-fields (refresh/retry/expire times, minimum TTL, serial number, email; host stays read-only) are carried through a typed `dnsdriver.SOARecord` carrier on `RecordConfig`/`RecordInfo`, persisted by the Azure DNS mock, and reflected on read. A user-edited SOA reads back the edited values; the auto-created apex SOA still reports Azure's defaults (3600/300/2419200/300, serial 1) when unedited.

### GAP-A — PATCH unsupported (405) on zones and record sets
`serveZone`/`serveRecordSet` routed only PUT/GET/DELETE, so `ZonesClient.Update`, `RecordSetsClient.Update` and `az ... update` (all PATCH) returned 405.

Added PATCH arms:
- **Zone**: merges supplied tags over existing tags (omitted tags preserved), returns 200.
- **Record set**: merges supplied TTL / record data / SOA timing fields, preserving fields the caller omitted (no nil-mask), returns 200. Unmodeled properties (e.g. record-set metadata) are preserved by the existing overlay's PATCH-merge path.

### BUG2 — record set CreateOrUpdate always 201
`createOrUpdateRecordSet` returned `201 Created` unconditionally. It now returns `200 OK` when the record set already existed and `201 Created` when newly created, matching the zone path and real Azure.

## Tests
Real `armdns` SDK over `httptest`: apex SOA edit echoes edited values; auto-created SOA keeps defaults; PATCH zone tags merge (existing preserved); PATCH record set updates supplied fields and preserves omitted ones; record-set update returns 200 while create returns 201.

Deferred (LOW, noted): If-Match/412 optimistic concurrency, static etag, multi-string TXT, overlay type-casing.
