### PR TITLE
fix(gcp-secretmanager): round-trip userManaged replication, secret fields, and payload CRC32C

### DIFF
--- a/docs/coverage/aws/secretsmanager.md
+++ b/docs/coverage/aws/secretsmanager.md
@@ -29,7 +29,7 @@ GCPSecrets is the GCP Secret Manager-specific surface kept off the shared
 | `DisableSecretVersion` | DisableSecretVersion moves a version to DISABLED. It fails on a DESTROYED |
 | `EnableSecretVersion` | EnableSecretVersion moves a version to ENABLED. It is idempotent on an |
 | `GetSecretIAMPolicy` | GetSecretIAMPolicy returns the secret's stored IAM policy (an empty |
-| `PatchSecret` | PatchSecret applies a partial update (labels) to a secret's metadata. |
+| `PatchSecret` | PatchSecret applies a partial update (labels, annotations, topics, version |
 | `SetSecretIAMPolicy` | SetSecretIAMPolicy stores the secret's IAM policy and returns it with a |
 | `TestSecretIAMPermissions` | TestSecretIAMPermissions returns the subset of permissions the caller |
 

--- a/docs/coverage/azure/keyvault.md
+++ b/docs/coverage/azure/keyvault.md
@@ -29,7 +29,7 @@ GCPSecrets is the GCP Secret Manager-specific surface kept off the shared
 | `DisableSecretVersion` | DisableSecretVersion moves a version to DISABLED. It fails on a DESTROYED |
 | `EnableSecretVersion` | EnableSecretVersion moves a version to ENABLED. It is idempotent on an |
 | `GetSecretIAMPolicy` | GetSecretIAMPolicy returns the secret's stored IAM policy (an empty |
-| `PatchSecret` | PatchSecret applies a partial update (labels) to a secret's metadata. |
+| `PatchSecret` | PatchSecret applies a partial update (labels, annotations, topics, version |
 | `SetSecretIAMPolicy` | SetSecretIAMPolicy stores the secret's IAM policy and returns it with a |
 | `TestSecretIAMPermissions` | TestSecretIAMPermissions returns the subset of permissions the caller |
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -9752,7 +9752,7 @@
           },
           {
             "name": "PatchSecret",
-            "doc": "PatchSecret applies a partial update (labels) to a secret's metadata."
+            "doc": "PatchSecret applies a partial update (labels, annotations, topics, version"
           },
           {
             "name": "SetSecretIAMPolicy",

--- a/docs/coverage/gcp/secretmanager.md
+++ b/docs/coverage/gcp/secretmanager.md
@@ -29,7 +29,7 @@ GCPSecrets is the GCP Secret Manager-specific surface kept off the shared
 | `DisableSecretVersion` | DisableSecretVersion moves a version to DISABLED. It fails on a DESTROYED |
 | `EnableSecretVersion` | EnableSecretVersion moves a version to ENABLED. It is idempotent on an |
 | `GetSecretIAMPolicy` | GetSecretIAMPolicy returns the secret's stored IAM policy (an empty |
-| `PatchSecret` | PatchSecret applies a partial update (labels) to a secret's metadata. |
+| `PatchSecret` | PatchSecret applies a partial update (labels, annotations, topics, version |
 | `SetSecretIAMPolicy` | SetSecretIAMPolicy stores the secret's IAM policy and returns it with a |
 | `TestSecretIAMPermissions` | TestSecretIAMPermissions returns the subset of permissions the caller |
 

--- a/providers/gcp/secretmanager/lifecycle.go
+++ b/providers/gcp/secretmanager/lifecycle.go
@@ -112,12 +112,32 @@ func (m *Mock) PatchSecret(_ context.Context, name string, patch driver.GCPSecre
 	defer sd.mu.Unlock()
 
 	if patch.SetLabels {
-		labels := make(map[string]string, len(patch.Labels))
-		for k, v := range patch.Labels {
-			labels[k] = v
+		sd.info.Tags = copyMap(patch.Labels)
+	}
+
+	if patch.SetAnnotations {
+		sd.info.Annotations = copyMap(patch.Annotations)
+	}
+
+	if patch.SetTopics {
+		sd.info.Topics = copySlice(patch.Topics)
+	}
+
+	if patch.SetVersionAliases {
+		sd.info.VersionAliases = copyMap(patch.VersionAliases)
+	}
+
+	if patch.SetRotation {
+		sd.info.Rotation = cloneRotation(patch.Rotation)
+	}
+
+	if patch.SetExpireTime {
+		expireTime, err := resolveExpiry(m.opts.Clock.Now().UTC(), patch.TTL, patch.ExpireTime)
+		if err != nil {
+			return nil, err
 		}
 
-		sd.info.Tags = labels
+		sd.info.ExpireTime = expireTime
 	}
 
 	sd.info.UpdatedAt = m.opts.Clock.Now().UTC().Format(time.RFC3339)

--- a/providers/gcp/secretmanager/secretmanager.go
+++ b/providers/gcp/secretmanager/secretmanager.go
@@ -30,6 +30,84 @@ func newEtag() string {
 	return idgen.GenerateID("etag-")
 }
 
+// resolveExpiry derives the RFC3339 expireTime from a ttl duration (e.g.
+// "3600s") relative to now, or echoes an explicit expireTime. ttl takes
+// precedence; an unparseable ttl is an invalid argument.
+func resolveExpiry(now time.Time, ttl, expireTime string) (string, error) {
+	if ttl != "" {
+		d, err := time.ParseDuration(ttl)
+		if err != nil {
+			return "", errors.Newf(errors.InvalidArgument, "invalid ttl %q", ttl)
+		}
+
+		return now.Add(d).Format(time.RFC3339), nil
+	}
+
+	return expireTime, nil
+}
+
+func copyMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+
+	return out
+}
+
+func copySlice(s []string) []string {
+	if s == nil {
+		return nil
+	}
+
+	out := make([]string, len(s))
+	copy(out, s)
+
+	return out
+}
+
+func cloneReplication(rep *driver.GCPReplication) *driver.GCPReplication {
+	if rep == nil {
+		return nil
+	}
+
+	out := &driver.GCPReplication{Automatic: rep.Automatic, AutomaticKMSKeyName: rep.AutomaticKMSKeyName}
+	if len(rep.UserManaged) > 0 {
+		out.UserManaged = make([]driver.GCPReplica, len(rep.UserManaged))
+		copy(out.UserManaged, rep.UserManaged)
+	}
+
+	return out
+}
+
+func cloneRotation(rot *driver.GCPRotation) *driver.GCPRotation {
+	if rot == nil {
+		return nil
+	}
+
+	clone := *rot
+
+	return &clone
+}
+
+// resolveAlias maps a version alias to its target version id, leaving numeric
+// ids and "" (current) untouched. Caller holds sd.mu.
+func resolveAlias(sd *secretData, versionID string) string {
+	if versionID == "" {
+		return versionID
+	}
+
+	if target, ok := sd.info.VersionAliases[versionID]; ok {
+		return target
+	}
+
+	return versionID
+}
+
 // Mock is an in-memory mock implementation of GCP Secret Manager.
 type Mock struct {
 	secrets *memstore.Store[*secretData]
@@ -62,15 +140,26 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 		tags[k] = v
 	}
 
+	expireTime, err := resolveExpiry(m.opts.Clock.Now().UTC(), cfg.TTL, cfg.ExpireTime)
+	if err != nil {
+		return nil, err
+	}
+
 	info := driver.SecretInfo{
-		ID:          idgen.GenerateID("secret-"),
-		Name:        cfg.Name,
-		ResourceID:  selfLink,
-		Description: cfg.Description,
-		CreatedAt:   now,
-		UpdatedAt:   now,
-		Tags:        tags,
-		Etag:        newEtag(),
+		ID:             idgen.GenerateID("secret-"),
+		Name:           cfg.Name,
+		ResourceID:     selfLink,
+		Description:    cfg.Description,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		Tags:           tags,
+		Etag:           newEtag(),
+		Replication:    cloneReplication(cfg.Replication),
+		Annotations:    copyMap(cfg.Annotations),
+		ExpireTime:     expireTime,
+		Rotation:       cloneRotation(cfg.Rotation),
+		Topics:         copySlice(cfg.Topics),
+		VersionAliases: copyMap(cfg.VersionAliases),
 	}
 
 	sd := &secretData{info: info}
@@ -190,6 +279,8 @@ func (m *Mock) GetSecretValue(_ context.Context, name, versionID string) (*drive
 
 	sd.mu.RLock()
 	defer sd.mu.RUnlock()
+
+	versionID = resolveAlias(sd, versionID)
 
 	for _, v := range sd.versions {
 		if versionID == "" && v.Current {

--- a/server/gcp/secretmanager/operations.go
+++ b/server/gcp/secretmanager/operations.go
@@ -1,6 +1,7 @@
 package secretmanager
 
 import (
+	"hash/crc32"
 	"net/http"
 	"strconv"
 	"strings"
@@ -11,20 +12,95 @@ import (
 	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
 )
 
-// maskContains reports whether a field-update mask names the given field. An
-// empty mask is treated as "update everything present in the body".
-func maskContains(mask, field string) bool {
+// castagnoli is the CRC32C polynomial table GCP Secret Manager checksums with.
+var castagnoli = crc32.MakeTable(crc32.Castagnoli) //nolint:gochecknoglobals // immutable lookup table
+
+// crc32c returns the Castagnoli CRC32C of data, as GCP Secret Manager reports it.
+func crc32c(data []byte) uint32 {
+	return crc32.Checksum(data, castagnoli)
+}
+
+// maskHas reports whether a field-update mask names any of the given field
+// aliases. An empty mask is treated as "update everything present in the body".
+func maskHas(mask string, fields ...string) bool {
 	if strings.TrimSpace(mask) == "" {
 		return true
 	}
 
 	for _, f := range strings.Split(mask, ",") {
-		if strings.TrimSpace(f) == field {
-			return true
+		f = strings.TrimSpace(f)
+		for _, want := range fields {
+			if f == want {
+				return true
+			}
 		}
 	}
 
 	return false
+}
+
+// filterSecrets applies a GCP list filter of the form "labels.<k>=<v>" (the
+// common case); an empty or unrecognized filter passes everything through.
+func filterSecrets(secrets []secretsdriver.SecretInfo, filter string) []secretsdriver.SecretInfo {
+	key, val, ok := parseLabelFilter(filter)
+	if !ok {
+		return secrets
+	}
+
+	out := make([]secretsdriver.SecretInfo, 0, len(secrets))
+
+	for i := range secrets {
+		if secrets[i].Tags[key] == val {
+			out = append(out, secrets[i])
+		}
+	}
+
+	return out
+}
+
+// parseLabelFilter parses a "labels.<key>=<value>" filter expression.
+func parseLabelFilter(filter string) (key, val string, ok bool) {
+	filter = strings.TrimSpace(filter)
+	if !strings.HasPrefix(filter, "labels.") {
+		return "", "", false
+	}
+
+	kv := strings.TrimPrefix(filter, "labels.")
+
+	k, v, found := strings.Cut(kv, "=")
+	if !found {
+		return "", "", false
+	}
+
+	return strings.TrimSpace(k), strings.Trim(strings.TrimSpace(v), `"`), true
+}
+
+// filterVersions applies a GCP version list filter. Only "state:<STATE>" (e.g.
+// "state:ENABLED") is recognized; other filters pass everything through.
+func filterVersions(versions []secretsdriver.SecretVersion, filter string) []secretsdriver.SecretVersion {
+	filter = strings.TrimSpace(filter)
+
+	state, ok := strings.CutPrefix(filter, "state:")
+	if !ok {
+		return versions
+	}
+
+	state = strings.ToUpper(strings.TrimSpace(state))
+
+	out := make([]secretsdriver.SecretVersion, 0, len(versions))
+
+	for _, v := range versions {
+		vs := v.State
+		if vs == "" {
+			vs = secretsdriver.VersionEnabled
+		}
+
+		if vs == state {
+			out = append(out, v)
+		}
+	}
+
+	return out
 }
 
 const (
@@ -70,11 +146,30 @@ func (h *Handler) createSecret(w http.ResponseWriter, r *http.Request, rt route)
 		return
 	}
 
+	// Real GCP requires a replication policy on create and rejects an empty
+	// user-managed replica list with INVALID_ARGUMENT.
+	if req.Replication == nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalidArgument", "replication is required")
+		return
+	}
+
+	if req.Replication.UserManaged != nil && len(req.Replication.UserManaged.Replicas) == 0 {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalidArgument", "userManaged replication requires at least one replica")
+		return
+	}
+
 	id := r.URL.Query().Get("secretId")
 
 	info, err := h.secrets.CreateSecret(r.Context(), secretsdriver.SecretConfig{
-		Name: id,
-		Tags: req.Labels,
+		Name:           id,
+		Tags:           req.Labels,
+		Replication:    replicationFromJSON(req.Replication),
+		Annotations:    req.Annotations,
+		TTL:            req.TTL,
+		ExpireTime:     req.ExpireTime,
+		Rotation:       rotationFromJSON(req.Rotation),
+		Topics:         topicsFromJSON(req.Topics),
+		VersionAliases: req.VersionAliases,
 	}, nil)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
@@ -82,6 +177,40 @@ func (h *Handler) createSecret(w http.ResponseWriter, r *http.Request, rt route)
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, toSecretJSON(rt.project, info))
+}
+
+// rotationFromJSON decodes a wire rotation policy into the driver model.
+func rotationFromJSON(rot *rotationJSON) *secretsdriver.GCPRotation {
+	if rot == nil {
+		return nil
+	}
+
+	return &secretsdriver.GCPRotation{RotationPeriod: rot.RotationPeriod, NextRotationTime: rot.NextRotationTime}
+}
+
+// topicsFromJSON flattens wire topics to their names.
+func topicsFromJSON(topics []topicJSON) []string {
+	if len(topics) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(topics))
+	for _, t := range topics {
+		out = append(out, t.Name)
+	}
+
+	return out
+}
+
+// secretReplication fetches the parent secret's replication policy for
+// rendering version replicationStatus; nil when the secret can't be read.
+func (h *Handler) secretReplication(r *http.Request, secret string) *secretsdriver.GCPReplication {
+	info, err := h.secrets.GetSecret(r.Context(), secret)
+	if err != nil {
+		return nil
+	}
+
+	return info.Replication
 }
 
 func (h *Handler) getSecret(w http.ResponseWriter, r *http.Request, rt route) {
@@ -100,6 +229,8 @@ func (h *Handler) listSecrets(w http.ResponseWriter, r *http.Request, rt route) 
 		gcprest.WriteCErr(w, err)
 		return
 	}
+
+	infos = filterSecrets(infos, r.URL.Query().Get("filter"))
 
 	// Stable order by secret name so offset page tokens stay meaningful across
 	// calls (ListSecrets iterates a map, which is unordered).
@@ -139,13 +270,27 @@ func (h *Handler) addVersion(w http.ResponseWriter, r *http.Request, rt route) {
 		return
 	}
 
+	// GCP rejects an empty payload, and verifies a client-supplied CRC32C
+	// (Castagnoli) checksum against the received data.
+	if len(req.Payload.Data) == 0 {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalidArgument", "payload data is required")
+		return
+	}
+
+	if req.Payload.DataCrc32c != 0 {
+		if got := int64(crc32c(req.Payload.Data)); got != req.Payload.DataCrc32c {
+			gcprest.WriteError(w, http.StatusBadRequest, "invalidArgument", "payload data corrupted: dataCrc32c mismatch")
+			return
+		}
+	}
+
 	ver, err := h.secrets.PutSecretValue(r.Context(), rt.secret, req.Payload.Data)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, toVersionJSON(rt.project, rt.secret, ver))
+	gcprest.WriteJSON(w, http.StatusOK, toVersionJSON(rt.project, rt.secret, ver, h.secretReplication(r, rt.secret)))
 }
 
 func (h *Handler) listVersions(w http.ResponseWriter, r *http.Request, rt route) {
@@ -154,6 +299,9 @@ func (h *Handler) listVersions(w http.ResponseWriter, r *http.Request, rt route)
 		gcprest.WriteCErr(w, err)
 		return
 	}
+
+	versions = filterVersions(versions, r.URL.Query().Get("filter"))
+	rep := h.secretReplication(r, rt.secret)
 
 	// Real GCP lists versions newest-first (descending version number).
 	page, err := pagination.PaginateSorted(versions,
@@ -166,7 +314,7 @@ func (h *Handler) listVersions(w http.ResponseWriter, r *http.Request, rt route)
 
 	out := make([]versionResourceJSON, 0, len(page.Items))
 	for i := range page.Items {
-		out = append(out, toVersionJSON(rt.project, rt.secret, &page.Items[i]))
+		out = append(out, toVersionJSON(rt.project, rt.secret, &page.Items[i], rep))
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, listVersionsResponse{
@@ -187,11 +335,44 @@ func (h *Handler) patchSecret(w http.ResponseWriter, r *http.Request, rt route) 
 		return
 	}
 
-	// The update mask names the fields to change; only labels are modeled.
+	// The update mask names the fields to change. GCP masks name JSON fields in
+	// camelCase; a few clients emit snake_case, so accept both.
+	mask := r.URL.Query().Get("updateMask")
 	patch := secretsdriver.GCPSecretPatch{}
-	if maskContains(r.URL.Query().Get("updateMask"), "labels") {
+
+	if maskHas(mask, "labels") {
 		patch.Labels = req.Labels
 		patch.SetLabels = true
+	}
+
+	if maskHas(mask, "annotations") {
+		patch.Annotations = req.Annotations
+		patch.SetAnnotations = true
+	}
+
+	if maskHas(mask, "topics") {
+		patch.Topics = topicsFromJSON(req.Topics)
+		patch.SetTopics = true
+	}
+
+	if maskHas(mask, "versionAliases", "version_aliases") {
+		patch.VersionAliases = req.VersionAliases
+		patch.SetVersionAliases = true
+	}
+
+	if maskHas(mask, "rotation") {
+		patch.Rotation = rotationFromJSON(req.Rotation)
+		patch.SetRotation = true
+	}
+
+	if maskHas(mask, "expireTime", "expire_time") {
+		patch.ExpireTime = req.ExpireTime
+		patch.SetExpireTime = true
+	}
+
+	if maskHas(mask, "ttl") {
+		patch.TTL = req.TTL
+		patch.SetExpireTime = true
 	}
 
 	info, err := h.gcp.PatchSecret(r.Context(), rt.secret, patch)
@@ -242,7 +423,7 @@ func (h *Handler) mutateVersion(w http.ResponseWriter, r *http.Request, rt route
 		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, toVersionJSON(rt.project, rt.secret, ver))
+	gcprest.WriteJSON(w, http.StatusOK, toVersionJSON(rt.project, rt.secret, ver, h.secretReplication(r, rt.secret)))
 }
 
 func (h *Handler) getVersion(w http.ResponseWriter, r *http.Request, rt route) {
@@ -252,7 +433,7 @@ func (h *Handler) getVersion(w http.ResponseWriter, r *http.Request, rt route) {
 		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, toVersionJSON(rt.project, rt.secret, ver))
+	gcprest.WriteJSON(w, http.StatusOK, toVersionJSON(rt.project, rt.secret, ver, h.secretReplication(r, rt.secret)))
 }
 
 func (h *Handler) accessVersion(w http.ResponseWriter, r *http.Request, rt route) {
@@ -272,6 +453,6 @@ func (h *Handler) accessVersion(w http.ResponseWriter, r *http.Request, rt route
 
 	gcprest.WriteJSON(w, http.StatusOK, accessResponse{
 		Name:    versionName(rt.project, rt.secret, ver.VersionID),
-		Payload: payloadJSON{Data: ver.Value},
+		Payload: payloadJSON{Data: ver.Value, DataCrc32c: int64(crc32c(ver.Value))},
 	})
 }

--- a/server/gcp/secretmanager/replication_fields_sdk_test.go
+++ b/server/gcp/secretmanager/replication_fields_sdk_test.go
@@ -1,0 +1,327 @@
+package secretmanager_test
+
+import (
+	"context"
+	"errors"
+	"hash/crc32"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+	sm "google.golang.org/api/secretmanager/v1"
+)
+
+// TestSDKUserManagedReplicationRoundTrip proves a create with user-managed
+// replication is echoed back faithfully (not silently rewritten to automatic)
+// on both the secret and its version's replicationStatus (audit: BUG1).
+func TestSDKUserManagedReplicationRoundTrip(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+
+	created, err := svc.Projects.Secrets.Create(testParent, &sm.Secret{
+		Replication: &sm.Replication{UserManaged: &sm.UserManaged{Replicas: []*sm.Replica{
+			{Location: "us-east1"},
+			{Location: "us-west1", CustomerManagedEncryption: &sm.CustomerManagedEncryption{
+				KmsKeyName: "projects/demo/locations/us-west1/keyRings/r/cryptoKeys/k",
+			}},
+		}}},
+	}).SecretId("um-secret").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	assertUserManaged := func(where string, rep *sm.Replication) {
+		if rep == nil || rep.UserManaged == nil {
+			t.Fatalf("%s replication = %+v, want userManaged", where, rep)
+		}
+
+		if rep.Automatic != nil {
+			t.Fatalf("%s replication rewritten to automatic: %+v", where, rep)
+		}
+
+		if len(rep.UserManaged.Replicas) != 2 {
+			t.Fatalf("%s replicas = %d, want 2", where, len(rep.UserManaged.Replicas))
+		}
+
+		if rep.UserManaged.Replicas[0].Location != "us-east1" {
+			t.Fatalf("%s replica[0] = %q, want us-east1", where, rep.UserManaged.Replicas[0].Location)
+		}
+
+		cmek := rep.UserManaged.Replicas[1].CustomerManagedEncryption
+		if cmek == nil || cmek.KmsKeyName == "" {
+			t.Fatalf("%s replica[1] CMEK not echoed: %+v", where, rep.UserManaged.Replicas[1])
+		}
+	}
+
+	assertUserManaged("create", created.Replication)
+
+	got, err := svc.Projects.Secrets.Get(created.Name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	assertUserManaged("get", got.Replication)
+
+	// The version's replicationStatus must also mirror user-managed replication.
+	v, err := svc.Projects.Secrets.AddVersion(created.Name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{Data: encode("payload")},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("AddVersion: %v", err)
+	}
+
+	if v.ReplicationStatus == nil || v.ReplicationStatus.UserManaged == nil {
+		t.Fatalf("version replicationStatus = %+v, want userManaged", v.ReplicationStatus)
+	}
+
+	if v.ReplicationStatus.Automatic != nil {
+		t.Fatalf("version replicationStatus rewritten to automatic: %+v", v.ReplicationStatus)
+	}
+
+	if len(v.ReplicationStatus.UserManaged.Replicas) != 2 {
+		t.Fatalf("version replica statuses = %d, want 2", len(v.ReplicationStatus.UserManaged.Replicas))
+	}
+}
+
+// TestSDKReplicationRequiredOnCreate proves a create without a replication
+// policy is rejected with 400 INVALID_ARGUMENT (audit: BUG1).
+func TestSDKReplicationRequiredOnCreate(t *testing.T) {
+	svc := newSMService(t)
+
+	_, err := svc.Projects.Secrets.Create(testParent, &sm.Secret{}).
+		SecretId("no-rep").Context(context.Background()).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 400 {
+		t.Fatalf("Create without replication: got %v, want 400", err)
+	}
+}
+
+// TestSDKAccessReturnsDataCrc32c proves accessSecretVersion returns the
+// Castagnoli CRC32C of the payload so client-side verification passes
+// (audit: BUG2).
+func TestSDKAccessReturnsDataCrc32c(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+	name := mustCreateSecret(t, svc, "crc-secret")
+
+	data := []byte("verify-me")
+	if _, err := svc.Projects.Secrets.AddVersion(name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{Data: encode(string(data))},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("AddVersion: %v", err)
+	}
+
+	got, err := svc.Projects.Secrets.Versions.Access(name + "/versions/latest").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Access: %v", err)
+	}
+
+	want := int64(crc32.Checksum(data, crc32.MakeTable(crc32.Castagnoli)))
+	if got.Payload.DataCrc32c != want {
+		t.Fatalf("dataCrc32c = %d, want %d", got.Payload.DataCrc32c, want)
+	}
+}
+
+// TestSDKAddVersionCrc32cMismatchRejected proves a wrong client-supplied
+// checksum is rejected with 400, and an empty payload is rejected (audit: BUG2).
+func TestSDKAddVersionCrc32cMismatchRejected(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+	name := mustCreateSecret(t, svc, "crc-reject")
+
+	_, err := svc.Projects.Secrets.AddVersion(name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{Data: encode("hello"), DataCrc32c: 12345},
+	}).Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 400 {
+		t.Fatalf("AddVersion(bad crc): got %v, want 400", err)
+	}
+
+	_, err = svc.Projects.Secrets.AddVersion(name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{},
+	}).Context(ctx).Do()
+	if !errors.As(err, &gerr) || gerr.Code != 400 {
+		t.Fatalf("AddVersion(empty): got %v, want 400", err)
+	}
+
+	// A correct checksum is accepted.
+	good := int64(crc32.Checksum([]byte("hello"), crc32.MakeTable(crc32.Castagnoli)))
+	if _, err := svc.Projects.Secrets.AddVersion(name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{Data: encode("hello"), DataCrc32c: good},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("AddVersion(good crc): %v", err)
+	}
+}
+
+// TestSDKSecretFieldsRoundTrip proves annotations, ttl->expireTime, rotation,
+// topics and versionAliases round-trip on create (audit: field round-trip).
+func TestSDKSecretFieldsRoundTrip(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+
+	created, err := svc.Projects.Secrets.Create(testParent, &sm.Secret{
+		Replication:    &sm.Replication{Automatic: &sm.Automatic{}},
+		Annotations:    map[string]string{"team": "core"},
+		Ttl:            "3600s",
+		Rotation:       &sm.Rotation{RotationPeriod: "86400s", NextRotationTime: "2099-01-01T00:00:00Z"},
+		Topics:         []*sm.Topic{{Name: "projects/demo/topics/rotate"}},
+		VersionAliases: map[string]string{"prod": "1"},
+	}).SecretId("fields").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Secrets.Get(created.Name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Annotations["team"] != "core" {
+		t.Fatalf("annotations = %v", got.Annotations)
+	}
+
+	if got.ExpireTime == "" {
+		t.Fatalf("expireTime not derived from ttl")
+	}
+
+	if got.Rotation == nil || got.Rotation.NextRotationTime != "2099-01-01T00:00:00Z" {
+		t.Fatalf("rotation = %+v", got.Rotation)
+	}
+
+	if len(got.Topics) != 1 || got.Topics[0].Name != "projects/demo/topics/rotate" {
+		t.Fatalf("topics = %+v", got.Topics)
+	}
+
+	if got.VersionAliases["prod"] != "1" {
+		t.Fatalf("versionAliases = %v", got.VersionAliases)
+	}
+}
+
+// TestSDKSecretFieldsPatch proves the same fields patch by update mask
+// (audit: field round-trip on patch).
+func TestSDKSecretFieldsPatch(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+	name := mustCreateSecret(t, svc, "patch-fields")
+
+	updated, err := svc.Projects.Secrets.Patch(name, &sm.Secret{
+		Annotations:    map[string]string{"owner": "sre"},
+		Topics:         []*sm.Topic{{Name: "projects/demo/topics/t"}},
+		VersionAliases: map[string]string{"stable": "1"},
+		Rotation:       &sm.Rotation{NextRotationTime: "2098-01-01T00:00:00Z", RotationPeriod: "7200s"},
+	}).UpdateMask("annotations,topics,versionAliases,rotation").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	if updated.Annotations["owner"] != "sre" {
+		t.Fatalf("annotations = %v", updated.Annotations)
+	}
+
+	got, err := svc.Projects.Secrets.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Annotations["owner"] != "sre" || len(got.Topics) != 1 ||
+		got.VersionAliases["stable"] != "1" || got.Rotation == nil {
+		t.Fatalf("patched fields not persisted: %+v", got)
+	}
+}
+
+// TestSDKAccessByVersionAlias proves GetSecretVersion and AccessSecretVersion
+// resolve a version by its alias (audit: versionAliases).
+func TestSDKAccessByVersionAlias(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+
+	created, err := svc.Projects.Secrets.Create(testParent, &sm.Secret{
+		Replication:    &sm.Replication{Automatic: &sm.Automatic{}},
+		VersionAliases: map[string]string{"prod": "1"},
+	}).SecretId("alias-secret").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if _, err := svc.Projects.Secrets.AddVersion(created.Name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{Data: encode("v1-data")},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("AddVersion: %v", err)
+	}
+
+	accessed, err := svc.Projects.Secrets.Versions.Access(created.Name + "/versions/prod").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Access(by alias): %v", err)
+	}
+
+	if accessed.Payload.Data != encode("v1-data") {
+		t.Fatalf("alias access data = %q, want %q", accessed.Payload.Data, encode("v1-data"))
+	}
+
+	meta, err := svc.Projects.Secrets.Versions.Get(created.Name + "/versions/prod").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get(by alias): %v", err)
+	}
+
+	if meta.Name != created.Name+"/versions/1" {
+		t.Fatalf("alias resolved to %q, want .../versions/1", meta.Name)
+	}
+}
+
+// TestSDKListFilters proves secrets.list and versions.list honor ?filter
+// (audit: BUG3).
+func TestSDKListFilters(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+
+	for _, s := range []struct {
+		id  string
+		env string
+	}{{"f-a", "prod"}, {"f-b", "dev"}, {"f-c", "prod"}} {
+		if _, err := svc.Projects.Secrets.Create(testParent, &sm.Secret{
+			Replication: &sm.Replication{Automatic: &sm.Automatic{}},
+			Labels:      map[string]string{"env": s.env},
+		}).SecretId(s.id).Context(ctx).Do(); err != nil {
+			t.Fatalf("Create(%s): %v", s.id, err)
+		}
+	}
+
+	list, err := svc.Projects.Secrets.List(testParent).Filter("labels.env=prod").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List(filter): %v", err)
+	}
+
+	if len(list.Secrets) != 2 {
+		t.Fatalf("filtered secrets = %d, want 2", len(list.Secrets))
+	}
+
+	// versions.list with a state filter.
+	name := testParent + "/secrets/f-a"
+	if _, err := svc.Projects.Secrets.AddVersion(name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{Data: encode("v1")},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("AddVersion: %v", err)
+	}
+
+	v2, err := svc.Projects.Secrets.AddVersion(name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{Data: encode("v2")},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("AddVersion: %v", err)
+	}
+
+	if _, err := svc.Projects.Secrets.Versions.Disable(v2.Name, &sm.DisableSecretVersionRequest{}).
+		Context(ctx).Do(); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+
+	enabled, err := svc.Projects.Secrets.Versions.List(name).Filter("state:ENABLED").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Versions.List(filter): %v", err)
+	}
+
+	if len(enabled.Versions) != 1 {
+		t.Fatalf("enabled versions = %d, want 1", len(enabled.Versions))
+	}
+}

--- a/server/gcp/secretmanager/types.go
+++ b/server/gcp/secretmanager/types.go
@@ -4,23 +4,66 @@ import (
 	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
 )
 
-type automaticJSON struct{}
-
-type replicationJSON struct {
-	Automatic *automaticJSON `json:"automatic,omitempty"`
+// customerManagedEncryptionJSON is the CMEK config on a replica / automatic
+// replication policy.
+type customerManagedEncryptionJSON struct {
+	KmsKeyName string `json:"kmsKeyName,omitempty"`
 }
 
-// replicationStatusJSON mirrors the automatic replication shape on a version.
+type automaticJSON struct {
+	CustomerManagedEncryption *customerManagedEncryptionJSON `json:"customerManagedEncryption,omitempty"`
+}
+
+// replicaJSON is one user-managed replica location.
+type replicaJSON struct {
+	Location                  string                         `json:"location,omitempty"`
+	CustomerManagedEncryption *customerManagedEncryptionJSON `json:"customerManagedEncryption,omitempty"`
+}
+
+type userManagedJSON struct {
+	Replicas []replicaJSON `json:"replicas,omitempty"`
+}
+
+type replicationJSON struct {
+	Automatic   *automaticJSON   `json:"automatic,omitempty"`
+	UserManaged *userManagedJSON `json:"userManaged,omitempty"`
+}
+
+// replicaStatusJSON mirrors a replica location on a version's status.
+type replicaStatusJSON struct {
+	Location string `json:"location,omitempty"`
+}
+
+type userManagedStatusJSON struct {
+	Replicas []replicaStatusJSON `json:"replicas,omitempty"`
+}
+
+// replicationStatusJSON mirrors the replication shape on a version.
 type replicationStatusJSON struct {
-	Automatic *automaticJSON `json:"automatic,omitempty"`
+	Automatic   *struct{}              `json:"automatic,omitempty"`
+	UserManaged *userManagedStatusJSON `json:"userManaged,omitempty"`
+}
+
+type rotationJSON struct {
+	RotationPeriod   string `json:"rotationPeriod,omitempty"`
+	NextRotationTime string `json:"nextRotationTime,omitempty"`
+}
+
+type topicJSON struct {
+	Name string `json:"name,omitempty"`
 }
 
 type secretJSON struct {
-	Name        string            `json:"name"`
-	Replication replicationJSON   `json:"replication"`
-	CreateTime  string            `json:"createTime,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Etag        string            `json:"etag,omitempty"`
+	Name           string            `json:"name"`
+	Replication    replicationJSON   `json:"replication"`
+	CreateTime     string            `json:"createTime,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty"`
+	Annotations    map[string]string `json:"annotations,omitempty"`
+	ExpireTime     string            `json:"expireTime,omitempty"`
+	Rotation       *rotationJSON     `json:"rotation,omitempty"`
+	Topics         []topicJSON       `json:"topics,omitempty"`
+	VersionAliases map[string]string `json:"versionAliases,omitempty"`
+	Etag           string            `json:"etag,omitempty"`
 }
 
 type versionResourceJSON struct {
@@ -33,18 +76,35 @@ type versionResourceJSON struct {
 }
 
 // payloadJSON carries the secret bytes; encoding/json renders []byte as the
-// std-base64 string the wire expects.
+// std-base64 string the wire expects. DataCrc32c is the Castagnoli CRC32C of
+// the payload, encoded as a string integer to match the SDK.
 type payloadJSON struct {
-	Data []byte `json:"data"`
+	Data       []byte `json:"data"`
+	DataCrc32c int64  `json:"dataCrc32c,omitempty,string"`
 }
 
+// createSecretRequest is the secrets.create body (the Secret resource).
 type createSecretRequest struct {
-	Labels map[string]string `json:"labels"`
+	Replication    *replicationJSON  `json:"replication"`
+	Labels         map[string]string `json:"labels"`
+	Annotations    map[string]string `json:"annotations"`
+	TTL            string            `json:"ttl"`
+	ExpireTime     string            `json:"expireTime"`
+	Rotation       *rotationJSON     `json:"rotation"`
+	Topics         []topicJSON       `json:"topics"`
+	VersionAliases map[string]string `json:"versionAliases"`
 }
 
-// patchSecretRequest is the body of secrets.patch; only labels are modeled.
+// patchSecretRequest is the body of secrets.patch; the update mask names which
+// fields to apply.
 type patchSecretRequest struct {
-	Labels map[string]string `json:"labels"`
+	Labels         map[string]string `json:"labels"`
+	Annotations    map[string]string `json:"annotations"`
+	TTL            string            `json:"ttl"`
+	ExpireTime     string            `json:"expireTime"`
+	Rotation       *rotationJSON     `json:"rotation"`
+	Topics         []topicJSON       `json:"topics"`
+	VersionAliases map[string]string `json:"versionAliases"`
 }
 
 type addVersionRequest struct {
@@ -113,17 +173,122 @@ func driverVersion(v string) string {
 	return v
 }
 
+// replicationToJSON renders a driver replication policy on the wire, defaulting
+// to automatic when unset (a secret always carries a replication policy).
+func replicationToJSON(rep *secretsdriver.GCPReplication) replicationJSON {
+	if rep == nil || (!rep.Automatic && len(rep.UserManaged) == 0) {
+		return replicationJSON{Automatic: &automaticJSON{}}
+	}
+
+	if len(rep.UserManaged) > 0 {
+		replicas := make([]replicaJSON, 0, len(rep.UserManaged))
+
+		for _, r := range rep.UserManaged {
+			rj := replicaJSON{Location: r.Location}
+			if r.KMSKeyName != "" {
+				rj.CustomerManagedEncryption = &customerManagedEncryptionJSON{KmsKeyName: r.KMSKeyName}
+			}
+
+			replicas = append(replicas, rj)
+		}
+
+		return replicationJSON{UserManaged: &userManagedJSON{Replicas: replicas}}
+	}
+
+	auto := &automaticJSON{}
+	if rep.AutomaticKMSKeyName != "" {
+		auto.CustomerManagedEncryption = &customerManagedEncryptionJSON{KmsKeyName: rep.AutomaticKMSKeyName}
+	}
+
+	return replicationJSON{Automatic: auto}
+}
+
+// replicationFromJSON decodes a wire replication policy into the driver model.
+// Returns nil when neither branch is present (caller enforces required-ness).
+func replicationFromJSON(rep *replicationJSON) *secretsdriver.GCPReplication {
+	if rep == nil {
+		return nil
+	}
+
+	if rep.UserManaged != nil {
+		replicas := make([]secretsdriver.GCPReplica, 0, len(rep.UserManaged.Replicas))
+
+		for _, r := range rep.UserManaged.Replicas {
+			rep := secretsdriver.GCPReplica{Location: r.Location}
+			if r.CustomerManagedEncryption != nil {
+				rep.KMSKeyName = r.CustomerManagedEncryption.KmsKeyName
+			}
+
+			replicas = append(replicas, rep)
+		}
+
+		return &secretsdriver.GCPReplication{UserManaged: replicas}
+	}
+
+	if rep.Automatic != nil {
+		out := &secretsdriver.GCPReplication{Automatic: true}
+		if rep.Automatic.CustomerManagedEncryption != nil {
+			out.AutomaticKMSKeyName = rep.Automatic.CustomerManagedEncryption.KmsKeyName
+		}
+
+		return out
+	}
+
+	return nil
+}
+
+// replicationStatusFor renders a version's replicationStatus mirroring the
+// parent secret's replication policy.
+func replicationStatusFor(rep *secretsdriver.GCPReplication) *replicationStatusJSON {
+	if rep != nil && len(rep.UserManaged) > 0 {
+		replicas := make([]replicaStatusJSON, 0, len(rep.UserManaged))
+		for _, r := range rep.UserManaged {
+			replicas = append(replicas, replicaStatusJSON{Location: r.Location})
+		}
+
+		return &replicationStatusJSON{UserManaged: &userManagedStatusJSON{Replicas: replicas}}
+	}
+
+	return &replicationStatusJSON{Automatic: &struct{}{}}
+}
+
+func rotationToJSON(rot *secretsdriver.GCPRotation) *rotationJSON {
+	if rot == nil {
+		return nil
+	}
+
+	return &rotationJSON{RotationPeriod: rot.RotationPeriod, NextRotationTime: rot.NextRotationTime}
+}
+
+func topicsToJSON(topics []string) []topicJSON {
+	if len(topics) == 0 {
+		return nil
+	}
+
+	out := make([]topicJSON, 0, len(topics))
+	for _, t := range topics {
+		out = append(out, topicJSON{Name: t})
+	}
+
+	return out
+}
+
 func toSecretJSON(project string, info *secretsdriver.SecretInfo) secretJSON {
 	return secretJSON{
-		Name:        secretName(project, info.Name),
-		Replication: replicationJSON{Automatic: &automaticJSON{}},
-		CreateTime:  info.CreatedAt,
-		Labels:      info.Tags,
-		Etag:        info.Etag,
+		Name:           secretName(project, info.Name),
+		Replication:    replicationToJSON(info.Replication),
+		CreateTime:     info.CreatedAt,
+		Labels:         info.Tags,
+		Annotations:    info.Annotations,
+		ExpireTime:     info.ExpireTime,
+		Rotation:       rotationToJSON(info.Rotation),
+		Topics:         topicsToJSON(info.Topics),
+		VersionAliases: info.VersionAliases,
+		Etag:           info.Etag,
 	}
 }
 
-func toVersionJSON(project, id string, ver *secretsdriver.SecretVersion) versionResourceJSON {
+func toVersionJSON(project, id string, ver *secretsdriver.SecretVersion, rep *secretsdriver.GCPReplication) versionResourceJSON {
 	state := ver.State
 	if state == "" {
 		state = secretsdriver.VersionEnabled
@@ -134,7 +299,7 @@ func toVersionJSON(project, id string, ver *secretsdriver.SecretVersion) version
 		CreateTime:        ver.CreatedAt,
 		DestroyTime:       ver.DestroyTime,
 		State:             state,
-		ReplicationStatus: &replicationStatusJSON{Automatic: &automaticJSON{}},
+		ReplicationStatus: replicationStatusFor(rep),
 		Etag:              ver.Etag,
 	}
 }

--- a/services/secrets/driver/driver.go
+++ b/services/secrets/driver/driver.go
@@ -16,6 +16,26 @@ type SecretConfig struct {
 	// the token as the VersionId, a UUID). Empty means the provider generates
 	// one. Ignored by Azure/GCP.
 	ClientRequestToken string
+	// Replication is the GCP Secret Manager replication policy (automatic or
+	// user-managed). Required by GCP's secrets.create; ignored by AWS/Azure.
+	Replication *GCPReplication
+	// Annotations is GCP Secret Manager custom metadata, distinct from labels.
+	// Ignored by AWS/Azure.
+	Annotations map[string]string
+	// TTL is the input-only GCP Secret Manager time-to-live (a duration such as
+	// "3600s"); the provider derives ExpireTime from it. Ignored by AWS/Azure.
+	TTL string
+	// ExpireTime is an explicit GCP Secret Manager RFC3339 expiry; an alternative
+	// to TTL. Ignored by AWS/Azure.
+	ExpireTime string
+	// Rotation is the GCP Secret Manager rotation policy. Ignored by AWS/Azure.
+	Rotation *GCPRotation
+	// Topics are the GCP Secret Manager Pub/Sub topic names notified on control
+	// plane operations. Ignored by AWS/Azure.
+	Topics []string
+	// VersionAliases maps GCP Secret Manager version aliases to version ids.
+	// Ignored by AWS/Azure.
+	VersionAliases map[string]string
 }
 
 // SecretInfo describes a secret.
@@ -34,6 +54,46 @@ type SecretInfo struct {
 	// Etag is an opaque optimistic-concurrency tag (GCP Secret Manager), echoed
 	// on the secret resource. Empty for providers that don't model it.
 	Etag string
+	// Replication is the GCP Secret Manager replication policy echoed on the
+	// secret resource. Nil for providers that don't model it.
+	Replication *GCPReplication
+	// Annotations is GCP Secret Manager custom metadata echoed on the secret.
+	// Nil for providers that don't model it.
+	Annotations map[string]string
+	// ExpireTime is the GCP Secret Manager RFC3339 expiry, always emitted on
+	// output when set (derived from TTL on input). Empty when unset.
+	ExpireTime string
+	// Rotation is the GCP Secret Manager rotation policy echoed on the secret.
+	// Nil for providers that don't model it.
+	Rotation *GCPRotation
+	// Topics are the GCP Secret Manager Pub/Sub topic names echoed on the secret.
+	// Nil for providers that don't model it.
+	Topics []string
+	// VersionAliases maps GCP Secret Manager version aliases to version ids,
+	// echoed on the secret and honored by GetSecretValue. Nil when unset.
+	VersionAliases map[string]string
+}
+
+// GCPReplica is one location a user-managed GCP secret replicates to, with an
+// optional customer-managed encryption key.
+type GCPReplica struct {
+	Location   string
+	KMSKeyName string
+}
+
+// GCPReplication is a GCP Secret Manager replication policy: automatic (with an
+// optional customer-managed key) or user-managed with an explicit replica list.
+type GCPReplication struct {
+	Automatic           bool
+	AutomaticKMSKeyName string
+	UserManaged         []GCPReplica
+}
+
+// GCPRotation is a GCP Secret Manager rotation policy. RotationPeriod is
+// input-only; NextRotationTime is echoed on output.
+type GCPRotation struct {
+	RotationPeriod   string
+	NextRotationTime string
 }
 
 // SecretVersion represents a specific version of a secret value.
@@ -78,11 +138,30 @@ const (
 )
 
 // GCPSecretPatch is the GCP Secret Manager secrets.patch payload. Only the
-// fields named in the update mask are applied; SetLabels true replaces the
-// label set with Labels (including clearing it when Labels is empty).
+// fields whose Set* flag is true (mapped from the update mask) are applied; a
+// Set* flag with an empty/nil value clears that field.
 type GCPSecretPatch struct {
 	Labels    map[string]string
 	SetLabels bool
+
+	Annotations    map[string]string
+	SetAnnotations bool
+
+	Topics    []string
+	SetTopics bool
+
+	VersionAliases    map[string]string
+	SetVersionAliases bool
+
+	Rotation    *GCPRotation
+	SetRotation bool
+
+	// ExpireTime / TTL carry the new expiry: TTL (a duration such as "3600s") is
+	// resolved against the provider clock, ExpireTime is an explicit RFC3339
+	// stamp. SetExpireTime true with both empty clears the expiry.
+	ExpireTime    string
+	TTL           string
+	SetExpireTime bool
 }
 
 // GCPIAMBinding binds an IAM role to a set of members.
@@ -111,7 +190,8 @@ type GCPSecrets interface {
 	// DestroySecretVersion moves a version to DESTROYED, wipes its payload, and
 	// stamps its destroyTime. It fails on an already-DESTROYED version.
 	DestroySecretVersion(ctx context.Context, name, versionID string) (*SecretVersion, error)
-	// PatchSecret applies a partial update (labels) to a secret's metadata.
+	// PatchSecret applies a partial update (labels, annotations, topics, version
+	// aliases, rotation, expiry) to a secret's metadata, honoring the update mask.
 	PatchSecret(ctx context.Context, name string, patch GCPSecretPatch) (*SecretInfo, error)
 	// GetSecretIAMPolicy returns the secret's stored IAM policy (an empty
 	// versioned policy when none has been set).


### PR DESCRIPTION
## Summary

Fixes GCP Secret Manager wire-protocol bugs surfaced by a real-SDK audit. Terraform's `google_secret_manager_secret` and the GCP quickstart CRC verify now behave against the emulator as they do against real GCP.

### BUG1 (HIGH, TF-breaking): userManaged replication silently rewritten to automatic
- `toSecretJSON` hardcoded `Replication: {Automatic: {}}` and `createSecretRequest` dropped the replication field, so a `user_managed { replicas ... }` secret came back as `automatic` -> "Provider produced inconsistent result after apply".
- Modeled replication (automatic | userManaged{replicas[{location, customerManagedEncryption?}]}) on `SecretConfig`/`SecretInfo`; decode it on create; render it faithfully on GET and on the version's `replicationStatus`.
- Replication is now **required** on create — absent -> 400 INVALID_ARGUMENT (empty userManaged replica list likewise).

### BUG2 (MED-LOW): accessSecretVersion never returned payload.dataCrc32c
- `access` now returns the Castagnoli CRC32C of the payload so client-side verification passes.
- `addVersion` validates a client-supplied `dataCrc32c` (mismatch -> 400) and rejects an empty payload.

### BUG3 (LOW): list endpoints ignored ?filter
- `secrets.list` honors `labels.<k>=<v>`; `versions.list` honors `state:<STATE>`.

### Field round-trip (TF drift)
- `annotations`, `ttl`->`expireTime`, `rotation{rotationPeriod,nextRotationTime}`, `topics`, `versionAliases` round-trip on create and on patch (updateMask-honoring).
- GET/`:access` resolve a version by its alias, not just "latest".

Existing SOLID behaviors (version state machine, destroy-wipes-payload, latest alias, access gating, IAM, hard delete) are unchanged.

## Tests
New real-SDK (`google.golang.org/api/secretmanager/v1` over httptest) coverage: userManaged replication round-trip, replication-required 400, dataCrc32c correctness + mismatch/empty rejection, annotations/ttl/rotation/topics/versionAliases round-trip on create and patch, access/get by version alias, and list filters.

## Gates
- `go build ./...`, `go vet`, scoped `go test` (server/providers/services + compat/gcp + resourcediscovery) green
- `go generate ./...` and `go run ./internal/compatgen` re-run: coverage doc reflects the updated PatchSecret comment; compat matrix zero-diff, exit 0
- gofmt clean; golangci-lint `--new-from-rev=origin/development` 0 new issues