### PR TITLE
fix(azure-databricks): preserve tags on workspace PATCH with omitted tags, make workspace delete idempotent

### DIFF
--- a/providers/azure/databricks/databricks.go
+++ b/providers/azure/databricks/databricks.go
@@ -177,9 +177,13 @@ func (m *Mock) UpdateWorkspaceTags(_ context.Context, resourceGroup, name string
 	}
 
 	// Mutate a copy and swap it in rather than writing the shared struct in
-	// place, so concurrent readers never observe a torn update.
+	// place, so concurrent readers never observe a torn update. A nil tags map
+	// leaves the field unchanged (PATCH semantics); an explicit empty map clears.
 	updated := *ws
-	updated.Tags = copyMap(tags)
+	if tags != nil {
+		updated.Tags = copyMap(tags)
+	}
+
 	m.workspaces.Set(k, &updated)
 
 	return cloneWorkspace(&updated), nil

--- a/server/azure/databricks/arm_delete_idempotent_test.go
+++ b/server/azure/databricks/arm_delete_idempotent_test.go
@@ -30,6 +30,60 @@ func idempotentDeleteAC(t *testing.T, client *armdatabricks.AccessConnectorsClie
 	}
 }
 
+// idempotentDeleteWorkspace runs BeginDelete + PollUntilDone on a workspace and
+// fails the test if either step returns an error.
+func idempotentDeleteWorkspace(t *testing.T, client *armdatabricks.WorkspacesClient, rg, name string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	poller, err := client.BeginDelete(ctx, rg, name, nil)
+	if err != nil {
+		t.Fatalf("BeginDelete(%q): %v", name, err)
+	}
+
+	if _, err = poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("delete PollUntilDone(%q): %v", name, err)
+	}
+}
+
+func TestSDKWorkspaceDeleteIdempotent(t *testing.T) {
+	opts, sub := newARMOptions(t)
+
+	client, err := armdatabricks.NewWorkspacesClient(sub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("new workspaces client: %v", err)
+	}
+
+	ctx := context.Background()
+
+	const wsName = "ws-idempotent"
+
+	// Create a workspace so the first delete has a real target.
+	createPoller, err := client.BeginCreateOrUpdate(ctx, testRG, wsName, armdatabricks.Workspace{
+		Location: to.Ptr("eastus"),
+		SKU:      &armdatabricks.SKU{Name: to.Ptr("premium")},
+		Properties: &armdatabricks.WorkspaceProperties{
+			ManagedResourceGroupID: to.Ptr(managed),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err = createPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("create PollUntilDone: %v", err)
+	}
+
+	// First delete removes it, second delete on the now-missing workspace must
+	// still succeed (idempotent 204).
+	idempotentDeleteWorkspace(t, client, testRG, wsName)
+	idempotentDeleteWorkspace(t, client, testRG, wsName)
+
+	// Deleting a workspace that was never created must also succeed.
+	idempotentDeleteWorkspace(t, client, testRG, "never-existed")
+}
+
 func TestSDKAccessConnectorDeleteIdempotent(t *testing.T) {
 	opts, sub := newARMOptions(t)
 

--- a/server/azure/databricks/operations.go
+++ b/server/azure/databricks/operations.go
@@ -3,6 +3,7 @@ package databricks
 import (
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	dbxdriver "github.com/stackshy/cloudemu/v2/services/databricks/driver"
 )
@@ -68,13 +69,17 @@ func (h *Handler) updateWorkspace(w http.ResponseWriter, r *http.Request, rp *az
 }
 
 func (h *Handler) deleteWorkspace(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	if err := h.dbx.DeleteWorkspace(r.Context(), rp.ResourceGroup, rp.ResourceName); err != nil {
+	// ARM DELETE is idempotent: a missing resource is the caller's desired end
+	// state, so a NotFound from the driver still returns 204 (teardown retries
+	// and delete-then-delete must not fail on the second pass).
+	err := h.dbx.DeleteWorkspace(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil && !cerrors.IsNotFound(err) {
 		azurearm.WriteCErr(w, err)
 
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) listWorkspaces(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {

--- a/server/azure/databricks/workspace_patch_test.go
+++ b/server/azure/databricks/workspace_patch_test.go
@@ -1,0 +1,60 @@
+package databricks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks"
+)
+
+// TestSDKWorkspacePatchPreservesOmittedTags proves that a WorkspaceUpdate with
+// no Tags leaves the existing tags untouched (real ARM PATCH semantics), while a
+// WorkspaceUpdate carrying explicit tags replaces them.
+func TestSDKWorkspacePatchPreservesOmittedTags(t *testing.T) {
+	client := newWorkspacesClient(t)
+	ctx := context.Background()
+
+	// createWorkspace seeds the workspace with tag env=test.
+	createWorkspace(t, client)
+
+	// PATCH with omitted tags must not clobber the existing tags.
+	patchPoller, err := client.BeginUpdate(ctx, testRG, testWS, armdatabricks.WorkspaceUpdate{}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate (no tags): %v", err)
+	}
+
+	if _, err = patchPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("update PollUntilDone (no tags): %v", err)
+	}
+
+	got, err := client.Get(ctx, testRG, testWS, nil)
+	if err != nil {
+		t.Fatalf("Get after tagless patch: %v", err)
+	}
+
+	if got.Tags["env"] == nil || *got.Tags["env"] != "test" {
+		t.Fatalf("tagless PATCH clobbered tags: got %v, want env=test preserved", got.Tags)
+	}
+
+	// PATCH with explicit tags replaces the tag set (AC PATCH semantics).
+	replacePoller, err := client.BeginUpdate(ctx, testRG, testWS, armdatabricks.WorkspaceUpdate{
+		Tags: map[string]*string{"env": to.Ptr("prod"), "team": to.Ptr("data")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate (explicit tags): %v", err)
+	}
+
+	updated, err := replacePoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("update PollUntilDone (explicit tags): %v", err)
+	}
+
+	if updated.Tags["env"] == nil || *updated.Tags["env"] != "prod" {
+		t.Fatalf("explicit PATCH did not apply env=prod: got %v", updated.Tags)
+	}
+
+	if updated.Tags["team"] == nil || *updated.Tags["team"] != "data" {
+		t.Fatalf("explicit PATCH did not apply team=data: got %v", updated.Tags)
+	}
+}


### PR DESCRIPTION
## Summary

Two one-line divergences in the Azure Databricks **workspace** path, each mirroring its already-correct access-connector sibling in the same package.

### BUG1 — Workspace PATCH clobbered all tags (MED)
`WorkspacesClient.BeginUpdate(WorkspaceUpdate{})` (or `az databricks workspace update` without `--set tags`) wiped existing tags, because the wire layer passes `nil` body.Tags and `UpdateWorkspaceTags` unconditionally replaced the tag map. Real ARM PATCH leaves omitted tags **unchanged**.

Fix: guard the assignment with `if tags != nil` in `providers/azure/databricks/databricks.go` `UpdateWorkspaceTags`, matching the access-connector `UpdateAccessConnector` sibling. Omitted tags now preserve; an explicit `{}` still clears; explicit tags replace.

### BUG2 — Workspace DELETE not idempotent (LOW/MED)
`BeginDelete` + `PollUntilDone` on a missing/already-deleted workspace surfaced a 404 (breaking TF destroy retries and delete-then-delete). Real ARM DELETE on a missing resource returns 204.

Fix: `deleteWorkspace` in `server/azure/databricks/operations.go` now treats `cerrors.IsNotFound(err)` as success and returns 204 No Content, mirroring `deleteAccessConnector` / PEC / peering deletes.

Out of scope (separately tracked): unmodeled workspace parameters / encryption block; no SKU-on-PATCH modeling (the real `WorkspaceUpdate` carries only Tags).

## Tests
Real `armdatabricks` SDK over httptest:
- `TestSDKWorkspacePatchPreservesOmittedTags` — create with tags -> PATCH `WorkspaceUpdate{}` -> GET still has original tags; PATCH with explicit tags replaces.
- `TestSDKWorkspaceDeleteIdempotent` — extends `arm_delete_idempotent_test.go`; delete-then-delete and delete-never-created both succeed.

Both tests were confirmed to fail without the source fix.

## Gates
build ./..., vet, scoped `go test`, gofmt, `golangci-lint --new-from-rev` (0 new) all green. `go generate` and compatgen produced zero doc/compat diffs.