### PR TITLE
fix(aws-sns): deliver Publish to Lambda-protocol subscriptions (wire SNS->Lambda invoker)

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -286,6 +286,9 @@ func New(opts ...config.Option) *Provider {
 	p.CloudWatch.SetSNSPublisher(p.SNS)
 	// SNS -> SQS fan-out: publishes deliver to SQS-protocol subscriptions.
 	p.SNS.SetSQSDeliverer(p.SQS)
+	// SNS -> Lambda fan-out: publishes invoke lambda-protocol subscriptions with
+	// the SNS Records event (reuses the shared InvokeExternal choke point).
+	p.SNS.SetLambdaInvoker(p.Lambda)
 	// EventBridge -> targets: matched rules deliver events to their first-class
 	// target types — SQS queues, Lambda functions (ASYNC), SNS topics, and Step
 	// Functions state machines (ASYNC). Lambda reuses the shared InvokeExternal

--- a/providers/aws/sns/lambda_delivery_test.go
+++ b/providers/aws/sns/lambda_delivery_test.go
@@ -1,0 +1,239 @@
+package sns_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	s3provider "github.com/stackshy/cloudemu/v2/providers/aws/s3"
+	snsprovider "github.com/stackshy/cloudemu/v2/providers/aws/sns"
+	sndriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+)
+
+// recordingInvoker captures SNS -> Lambda deliveries.
+type recordingInvoker struct {
+	arns     []string
+	payloads []string
+}
+
+func (i *recordingInvoker) InvokeExternal(_ context.Context, functionARN string, payload []byte) error {
+	i.arns = append(i.arns, functionARN)
+	i.payloads = append(i.payloads, string(payload))
+
+	return nil
+}
+
+// snsRecord decodes the first Records[].Sns envelope of an SNS -> Lambda payload.
+func snsRecord(t *testing.T, payload string) map[string]any {
+	t.Helper()
+
+	var event struct {
+		Records []struct {
+			EventSource          string         `json:"EventSource"`
+			EventVersion         string         `json:"EventVersion"`
+			EventSubscriptionArn string         `json:"EventSubscriptionArn"`
+			Sns                  map[string]any `json:"Sns"`
+		} `json:"Records"`
+	}
+
+	if err := json.Unmarshal([]byte(payload), &event); err != nil {
+		t.Fatalf("payload is not an SNS Records event: %v (%s)", err, payload)
+	}
+
+	if len(event.Records) != 1 {
+		t.Fatalf("expected exactly 1 record, got %d", len(event.Records))
+	}
+
+	r := event.Records[0]
+	if r.EventSource != "aws:sns" || r.EventVersion != "1.0" {
+		t.Fatalf("unexpected record framing: %+v", r)
+	}
+
+	if r.EventSubscriptionArn == "" {
+		t.Fatalf("record missing EventSubscriptionArn: %+v", r)
+	}
+
+	return r.Sns
+}
+
+// TestSNSToLambdaDelivery verifies that publishing to a topic with a
+// lambda-protocol subscription invokes the function with the SNS Records event,
+// and that Message/MessageAttributes/Subject survive the hop.
+func TestSNSToLambdaDelivery(t *testing.T) {
+	ctx := context.Background()
+	opts := config.NewOptions()
+
+	invoker := &recordingInvoker{}
+	sns := snsprovider.New(opts)
+	sns.SetLambdaInvoker(invoker)
+
+	topic, err := sns.CreateTopic(ctx, sndriver.TopicConfig{Name: "feed"})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	const fnARN = "arn:aws:lambda:us-east-1:000000000000:function:notify"
+
+	if _, err := sns.Subscribe(ctx, sndriver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "lambda", Endpoint: fnARN,
+	}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if _, err := sns.Publish(ctx, sndriver.PublishInput{
+		TopicID: topic.Name, Message: "hello", Subject: "hi",
+		Attributes: map[string]string{"env": "prod"},
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	if len(invoker.arns) != 1 || invoker.arns[0] != fnARN {
+		t.Fatalf("expected 1 invoke of %s, got %v", fnARN, invoker.arns)
+	}
+
+	envelope := snsRecord(t, invoker.payloads[0])
+	if envelope["Type"] != "Notification" || envelope["Message"] != "hello" ||
+		envelope["TopicArn"] != topic.ResourceID || envelope["Subject"] != "hi" {
+		t.Fatalf("unexpected Sns envelope: %+v", envelope)
+	}
+
+	attrs, ok := envelope["MessageAttributes"].(map[string]any)
+	if !ok {
+		t.Fatalf("Sns envelope missing MessageAttributes: %+v", envelope)
+	}
+
+	env, ok := attrs["env"].(map[string]any)
+	if !ok || env["Type"] != "String" || env["Value"] != "prod" {
+		t.Fatalf("unexpected MessageAttributes: %+v", attrs)
+	}
+}
+
+// TestSNSToLambdaFilterPolicy verifies a filter policy on a lambda-protocol
+// subscription gates delivery exactly like the SQS path.
+func TestSNSToLambdaFilterPolicy(t *testing.T) {
+	ctx := context.Background()
+	opts := config.NewOptions()
+
+	invoker := &recordingInvoker{}
+	sns := snsprovider.New(opts)
+	sns.SetLambdaInvoker(invoker)
+
+	topic, err := sns.CreateTopic(ctx, sndriver.TopicConfig{Name: "filtered"})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	const fnARN = "arn:aws:lambda:us-east-1:000000000000:function:filtered"
+
+	if _, err := sns.Subscribe(ctx, sndriver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "lambda", Endpoint: fnARN,
+		Attributes: map[string]string{"FilterPolicy": `{"env":["prod"]}`},
+	}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	// Non-matching publish is filtered out.
+	if _, err := sns.Publish(ctx, sndriver.PublishInput{
+		TopicID: topic.Name, Message: "dev-msg", Attributes: map[string]string{"env": "dev"},
+	}); err != nil {
+		t.Fatalf("Publish dev: %v", err)
+	}
+
+	if len(invoker.arns) != 0 {
+		t.Fatalf("expected filtered publish to be dropped, got %v", invoker.arns)
+	}
+
+	// Matching publish is delivered.
+	if _, err := sns.Publish(ctx, sndriver.PublishInput{
+		TopicID: topic.Name, Message: "prod-msg", Attributes: map[string]string{"env": "prod"},
+	}); err != nil {
+		t.Fatalf("Publish prod: %v", err)
+	}
+
+	if len(invoker.arns) != 1 {
+		t.Fatalf("expected exactly the matching publish delivered, got %v", invoker.arns)
+	}
+
+	if got := snsRecord(t, invoker.payloads[0])["Message"]; got != "prod-msg" {
+		t.Fatalf("delivered the wrong message: %v", got)
+	}
+}
+
+// TestS3ToSNSToLambdaTransitive verifies the transitive S3 -> SNS -> Lambda
+// chain: an object upload delivers to the topic, whose lambda subscriber is
+// invoked with the S3 event nested in the SNS Records envelope.
+func TestS3ToSNSToLambdaTransitive(t *testing.T) {
+	ctx := context.Background()
+	opts := config.NewOptions()
+
+	invoker := &recordingInvoker{}
+	sns := snsprovider.New(opts)
+	sns.SetLambdaInvoker(invoker)
+
+	s3 := s3provider.New(opts)
+	s3.SetSNSPublisher(sns)
+
+	topic, err := sns.CreateTopic(ctx, sndriver.TopicConfig{Name: "s3-topic"})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	const fnARN = "arn:aws:lambda:us-east-1:000000000000:function:s3fn"
+
+	if _, err := sns.Subscribe(ctx, sndriver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "lambda", Endpoint: fnARN,
+	}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if err := s3.CreateBucket(ctx, "uploads"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	if err := s3.PutBucketNotification(ctx, "uploads", []s3provider.BucketNotification{{
+		ID: "toSNS", Target: s3provider.NotifyTopic, ARN: topic.ResourceID,
+		Events: []string{"s3:ObjectCreated:*"},
+	}}); err != nil {
+		t.Fatalf("PutBucketNotification: %v", err)
+	}
+
+	if err := s3.PutObject(ctx, "uploads", "photo.jpg", []byte("data"), "image/jpeg", nil); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	if len(invoker.arns) != 1 || invoker.arns[0] != fnARN {
+		t.Fatalf("expected S3 -> SNS -> Lambda to invoke %s once, got %v", fnARN, invoker.arns)
+	}
+
+	// The SNS envelope's Message carries the S3 event JSON.
+	msg, _ := snsRecord(t, invoker.payloads[0])["Message"].(string)
+	if msg == "" || !json.Valid([]byte(msg)) {
+		t.Fatalf("expected the S3 event JSON in the SNS Message, got %q", msg)
+	}
+}
+
+// TestSNSPublishNilLambdaInvoker verifies Publish with a lambda subscription but
+// no wired invoker does not panic and delivers nothing.
+func TestSNSPublishNilLambdaInvoker(t *testing.T) {
+	ctx := context.Background()
+	opts := config.NewOptions()
+
+	sns := snsprovider.New(opts)
+
+	topic, err := sns.CreateTopic(ctx, sndriver.TopicConfig{Name: "nolambda"})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	if _, err := sns.Subscribe(ctx, sndriver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "lambda",
+		Endpoint: "arn:aws:lambda:us-east-1:000000000000:function:x",
+	}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if _, err := sns.Publish(ctx, sndriver.PublishInput{TopicID: topic.Name, Message: "hi"}); err != nil {
+		t.Fatalf("Publish must not fail with a nil invoker: %v", err)
+	}
+}

--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -32,7 +32,14 @@ const (
 	messageStructureJSON  = "json"
 	defaultProtocolKey    = "default"
 	protocolSQS           = "sqs"
+	protocolLambda        = "lambda"
 	messageAttrTypeString = "String"
+)
+
+// SNS delivery-outcome metric names.
+const (
+	metricNotificationsDelivered = "NumberOfNotificationsDelivered"
+	metricNotificationsFailed    = "NumberOfNotificationsFailed"
 )
 
 type publishedMessage struct {
@@ -95,12 +102,19 @@ type SQSDeliverer interface {
 	DeliverExternalFIFO(ctx context.Context, queueARN, body, groupID, dedupID string) error
 }
 
+// LambdaInvoker asynchronously invokes a Lambda function by ARN with an SNS event
+// payload. The Lambda mock satisfies this, enabling real SNS -> Lambda fan-out.
+type LambdaInvoker interface {
+	InvokeExternal(ctx context.Context, functionARN string, payload []byte) error
+}
+
 // Mock is an in-memory mock implementation of the AWS SNS service.
 type Mock struct {
 	topics     *memstore.Store[*topicData]
 	opts       *config.Options
 	monitoring mondriver.Monitoring
 	sqs        SQSDeliverer
+	lambda     LambdaInvoker
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -111,6 +125,12 @@ func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
 // SetSQSDeliverer wires the SQS backend so publishes fan out to SQS subscriptions.
 func (m *Mock) SetSQSDeliverer(d SQSDeliverer) {
 	m.sqs = d
+}
+
+// SetLambdaInvoker wires the Lambda backend so publishes fan out to
+// lambda-protocol subscriptions.
+func (m *Mock) SetLambdaInvoker(l LambdaInvoker) {
+	m.lambda = l
 }
 
 func (m *Mock) emitMetric(metricName string, value float64, unit string, dims map[string]string) {
@@ -391,6 +411,7 @@ func (m *Mock) Publish(ctx context.Context, input driver.PublishInput) (*driver.
 	td.mu.Unlock()
 
 	m.fanOutToSQS(ctx, td, msgID, &input)
+	m.fanOutToLambda(ctx, td, msgID, &input)
 
 	dims := map[string]string{"TopicName": input.TopicID}
 	m.emitMetric("NumberOfMessagesPublished", 1, "Count", dims)
@@ -520,6 +541,60 @@ func (m *Mock) fanOutToSQS(ctx context.Context, td *topicData, msgID string, inp
 	}
 }
 
+// fanOutToLambda invokes every lambda-protocol subscription on the topic,
+// wrapping the published message in the SNS -> Lambda Records event real AWS
+// delivers. A nil invoker skips delivery gracefully.
+func (m *Mock) fanOutToLambda(ctx context.Context, td *topicData, msgID string, input *driver.PublishInput) {
+	if m.lambda == nil {
+		return
+	}
+
+	message := resolveProtocolMessage(input, protocolLambda)
+
+	for _, sub := range td.subscriptions.All() {
+		if sub.Protocol != protocolLambda || sub.Endpoint == "" {
+			continue
+		}
+
+		// A filter policy gates delivery exactly as on the SQS path.
+		if !subscriptionAccepts(&sub, input) {
+			continue
+		}
+
+		event := map[string]any{
+			"Records": []any{
+				map[string]any{
+					"EventSource":          "aws:sns",
+					"EventVersion":         "1.0",
+					"EventSubscriptionArn": sub.ID,
+					"Sns":                  m.notificationEnvelopeMap(td, msgID, input, message, sub.ID),
+				},
+			},
+		}
+
+		payload, err := json.Marshal(event)
+		if err != nil {
+			continue
+		}
+
+		m.deliverToLambda(ctx, sub.Endpoint, payload, input)
+	}
+}
+
+// deliverToLambda invokes one lambda-protocol subscription, recording an SNS
+// delivery/failure metric so a broken target is observable rather than a silent
+// drop (mirrors deliverToSQS).
+func (m *Mock) deliverToLambda(ctx context.Context, functionARN string, payload []byte, input *driver.PublishInput) {
+	err := m.lambda.InvokeExternal(ctx, functionARN, payload)
+
+	metric := metricNotificationsDelivered
+	if err != nil {
+		metric = metricNotificationsFailed
+	}
+
+	m.emitMetric(metric, 1, "Count", map[string]string{"TopicName": input.TopicID})
+}
+
 // deliverToSQS fans one message out to a single SQS subscription, carrying the
 // publish's FIFO group/dedup ids so a FIFO queue accepts it. A delivery failure
 // is recorded as an SNS metric rather than swallowed, so a real misconfiguration
@@ -527,9 +602,9 @@ func (m *Mock) fanOutToSQS(ctx context.Context, td *topicData, msgID string, inp
 func (m *Mock) deliverToSQS(ctx context.Context, queueARN, body string, input *driver.PublishInput) {
 	err := m.sqs.DeliverExternalFIFO(ctx, queueARN, body, input.MessageGroupID, input.MessageDeduplicationID)
 
-	metric := "NumberOfNotificationsDelivered"
+	metric := metricNotificationsDelivered
 	if err != nil {
-		metric = "NumberOfNotificationsFailed"
+		metric = metricNotificationsFailed
 	}
 
 	m.emitMetric(metric, 1, "Count", map[string]string{"TopicName": input.TopicID})
@@ -540,6 +615,20 @@ func (m *Mock) deliverToSQS(ctx context.Context, queueARN, body string, input *d
 func (m *Mock) notificationEnvelope(
 	td *topicData, msgID string, input *driver.PublishInput, message, subARN string,
 ) (string, error) {
+	body, err := json.Marshal(m.notificationEnvelopeMap(td, msgID, input, message, subARN))
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+// notificationEnvelopeMap builds the SNS Notification object (Type=Notification,
+// MessageId, TopicArn, Message, Timestamp, optional Subject/MessageAttributes)
+// shared by the SQS envelope and the Sns field of the Lambda Records event.
+func (m *Mock) notificationEnvelopeMap(
+	td *topicData, msgID string, input *driver.PublishInput, message, subARN string,
+) map[string]any {
 	env := map[string]any{
 		"Type":             "Notification",
 		"MessageId":        msgID,
@@ -566,12 +655,7 @@ func (m *Mock) notificationEnvelope(
 		env["MessageAttributes"] = envelopeAttributes(input)
 	}
 
-	body, err := json.Marshal(env)
-	if err != nil {
-		return "", err
-	}
-
-	return string(body), nil
+	return env
 }
 
 // envelopeAttributes renders the publish's message attributes into the


### PR DESCRIPTION
## Summary

`Subscribe(protocol="lambda", endpoint=<fn-arn>)` was accepted and listed, but `Publish` only fanned out to SQS-protocol subscriptions — the Lambda subscriber silently never ran. This also broke every "-> SNS -> Lambda" chain (S3 -> SNS -> Lambda, EventBridge -> SNS -> Lambda, CloudWatch alarm -> SNS -> Lambda): the upstream trigger delivered to the topic fine, but the topic's Lambda subscriber was the broken hop.

## Fix

Mirrors the existing SNS -> SQS fan-out and the shared S3/DynamoDB/SQS/EventBridge `InvokeExternal` choke point.

- Add a `LambdaInvoker` interface (`InvokeExternal(ctx, functionARN string, payload []byte) error` — the same shape S3/EventBridge/CloudWatch Logs already use), an unexported `lambda` field, and a `SetLambdaInvoker` setter on the SNS mock.
- In `Publish`, fan out to every `lambda`-protocol subscription, building the real AWS SNS -> Lambda event: `{"Records":[{"EventSource":"aws:sns","EventVersion":"1.0","EventSubscriptionArn":...,"Sns":{<Notification envelope>}}]}`. The `Sns` object reuses the same envelope builder as the non-raw SQS path, so `Message` / `Subject` / `MessageAttributes` match exactly. Filter policies are honored via the shared `subscriptionAccepts`. A nil invoker skips delivery gracefully.
- Wire `p.SNS.SetLambdaInvoker(p.Lambda)` in `providers/aws/aws.go` next to `SetSQSDeliverer`.

## Tests

- SNS -> Lambda delivery: Publish invokes the function with the correct `Records[].Sns` envelope (Message + MessageAttributes + Subject).
- Filter policy on a lambda subscription filters non-matching publishes and delivers matching ones.
- Transitive S3 -> SNS -> Lambda end-to-end: an object upload invokes the topic's Lambda subscriber with the S3 event nested in the SNS envelope.
- Nil invoker: Publish with an unwired invoker does not panic and delivers nothing.
