### PR TITLE
fix(aws-elbv2): round-trip weighted multi-target-group forwards; report unused health for unattached target groups

### DIFF
--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -36,6 +36,10 @@ const (
 	lbStateActive       = "active"
 )
 
+// targetStateInitial is the health state a target holds between registration and
+// its first successful health check.
+const targetStateInitial = "initial"
+
 // targetKey is the identity of a registered target within a target group.
 // AWS lets the same instance ID or IP be registered multiple times with
 // different port overrides (RegisterTargets docs, "Register targets by
@@ -434,24 +438,54 @@ func (m *Mock) checkTargetGroupNotInUse(arn string) error {
 	// copied per iteration.
 	listeners := m.listeners.All()
 	for key := range listeners {
-		for _, a := range listeners[key].DefaultActions {
-			if a.TargetGroupARN == arn {
-				return errors.Newf(errors.FailedPrecondition,
-					"target group %q is currently in use by a listener", arn)
-			}
+		if actionsReferenceTG(listeners[key].DefaultActions, arn) {
+			return errors.Newf(errors.FailedPrecondition,
+				"target group %q is currently in use by a listener", arn)
 		}
 	}
 
 	for _, r := range m.rules.All() {
-		for _, a := range r.Actions {
-			if a.TargetGroupARN == arn {
-				return errors.Newf(errors.FailedPrecondition,
-					"target group %q is currently in use by a rule", arn)
-			}
+		if actionsReferenceTG(r.Actions, arn) {
+			return errors.Newf(errors.FailedPrecondition,
+				"target group %q is currently in use by a rule", arn)
 		}
 	}
 
 	return nil
+}
+
+// actionsReferenceTG reports whether any action forwards to the given target
+// group, checking both the scalar TargetGroupARN and every weighted group in a
+// ForwardConfig so a secondary weighted group is not treated as unreferenced.
+func actionsReferenceTG(actions []driver.RuleAction, arn string) bool {
+	for i := range actions {
+		for _, ref := range actionTargetGroups(&actions[i]) {
+			if ref == arn {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// targetGroupReferenced reports whether any listener default action or rule
+// action across all listeners/rules forwards to the given target group.
+func (m *Mock) targetGroupReferenced(arn string) bool {
+	listeners := m.listeners.All()
+	for key := range listeners {
+		if actionsReferenceTG(listeners[key].DefaultActions, arn) {
+			return true
+		}
+	}
+
+	for _, r := range m.rules.All() {
+		if actionsReferenceTG(r.Actions, arn) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // DescribeTargetGroups returns target groups matching the given ARNs.
@@ -559,12 +593,47 @@ func cloneCertificates(certs []driver.Certificate) []driver.Certificate {
 	return append([]driver.Certificate(nil), certs...)
 }
 
+// actionTargetGroups returns every target-group ARN a forward action references:
+// the scalar TargetGroupARN (single-target case) plus each weighted group in a
+// multi-target ForwardConfig. It is the single source of truth for both
+// validation and in-use protection so a weighted secondary group is never missed.
+func actionTargetGroups(a *driver.RuleAction) []string {
+	arns := make([]string, 0, len(a.ForwardConfig)+1)
+	seen := make(map[string]struct{}, len(a.ForwardConfig)+1)
+
+	add := func(arn string) {
+		if arn == "" {
+			return
+		}
+
+		if _, ok := seen[arn]; ok {
+			return
+		}
+
+		seen[arn] = struct{}{}
+
+		arns = append(arns, arn)
+	}
+
+	add(a.TargetGroupARN)
+
+	for i := range a.ForwardConfig {
+		add(a.ForwardConfig[i].TargetGroupARN)
+	}
+
+	return arns
+}
+
 // validateForwardActions reports TargetGroupNotFound when any forward action
-// references a target group that does not exist.
+// references a target group that does not exist. Every group in a weighted
+// ForwardConfig is checked, not just the primary, so a bogus secondary group is
+// rejected the way real ELBv2 rejects it.
 func (m *Mock) validateForwardActions(actions []driver.RuleAction) error {
-	for _, a := range actions {
-		if a.TargetGroupARN != "" && !m.tgs.Has(a.TargetGroupARN) {
-			return errors.Newf(errors.NotFound, "target group %q not found", a.TargetGroupARN)
+	for i := range actions {
+		for _, arn := range actionTargetGroups(&actions[i]) {
+			if !m.tgs.Has(arn) {
+				return errors.Newf(errors.NotFound, "target group %q not found", arn)
+			}
 		}
 	}
 
@@ -619,12 +688,11 @@ func (m *Mock) CreateRule(_ context.Context, cfg driver.RuleConfig) (*driver.Rul
 		return nil, errors.Newf(errors.NotFound, "listener %q not found", cfg.ListenerARN)
 	}
 
-	// A forward action must reference an existing target group; real ELBv2
-	// rejects a bogus TargetGroupArn with TargetGroupNotFound.
-	for _, a := range cfg.Actions {
-		if a.TargetGroupARN != "" && !m.tgs.Has(a.TargetGroupARN) {
-			return nil, errors.Newf(errors.NotFound, "target group %q not found", a.TargetGroupARN)
-		}
+	// A forward action must reference existing target groups; real ELBv2 rejects
+	// a bogus TargetGroupArn (primary or weighted secondary) with
+	// TargetGroupNotFound.
+	if err := m.validateForwardActions(cfg.Actions); err != nil {
+		return nil, err
 	}
 
 	// A listener can't have two rules with the same priority; a reused priority
@@ -1115,7 +1183,7 @@ func (m *Mock) RegisterTargets(_ context.Context, targetGroupARN string, targets
 				ID:   t.ID,
 				Port: t.Port,
 			},
-			State:       "initial",
+			State:       targetStateInitial,
 			Reason:      "Elb.RegistrationInProgress",
 			Description: "Target registration is in progress",
 		}
@@ -1206,13 +1274,30 @@ func (m *Mock) DescribeTargetHealth(_ context.Context, targetGroupARN string) ([
 		return []driver.TargetHealth{}, nil
 	}
 
+	// A target group not forwarded to by any listener (default action or rule)
+	// on a load balancer reports every target as "unused" / Target.NotInUse and
+	// does not advance — real ELBv2 only begins health checks once a listener
+	// routes to the group. An explicitly set state (e.g. ECS SetTargetHealth) is
+	// left untouched; only the automatic initial->healthy progression is gated.
+	referenced := m.targetGroupReferenced(targetGroupARN)
+
 	results := make([]driver.TargetHealth, 0, len(tgHealth))
 	for _, th := range tgHealth {
+		if !referenced && th.State == targetStateInitial {
+			unused := *th
+			unused.State = "unused"
+			unused.Reason = "Target.NotInUse"
+			unused.Description = "Target group is not configured to receive traffic from the load balancer"
+			results = append(results, unused)
+
+			continue
+		}
+
 		results = append(results, *th)
 
 		// Advance after the state is captured so the caller sees "initial"
 		// once and "healthy" on the next poll.
-		if th.State == "initial" {
+		if th.State == targetStateInitial {
 			th.State = "healthy"
 			th.Reason = ""
 			th.Description = ""

--- a/providers/aws/elbv2/elb_test.go
+++ b/providers/aws/elbv2/elb_test.go
@@ -371,11 +371,14 @@ func TestDescribeTargetHealth(t *testing.T) {
 	tg := createTestTG(m)
 	_ = m.RegisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-1", Port: 80}})
 
-	t.Run("success", func(t *testing.T) {
+	t.Run("unused until a listener forwards to the TG", func(t *testing.T) {
+		// The TG here is attached to no load balancer, so real ELBv2 reports
+		// every target as unused / Target.NotInUse rather than advancing.
 		health, err := m.DescribeTargetHealth(ctx, tg.ARN)
 		requireNoError(t, err)
 		assertEqual(t, 1, len(health))
-		assertEqual(t, "initial", health[0].State)
+		assertEqual(t, "unused", health[0].State)
+		assertEqual(t, "Target.NotInUse", health[0].Reason)
 	})
 
 	t.Run("TG not found", func(t *testing.T) {

--- a/server/aws/elbv2/modify_test.go
+++ b/server/aws/elbv2/modify_test.go
@@ -12,6 +12,33 @@ import (
 	"github.com/aws/smithy-go"
 )
 
+// attachListener creates an application load balancer and a listener that
+// forwards to tgARN, so the target group is "in use" and its targets begin
+// advancing past the unused state.
+func attachListener(t *testing.T, client *elb.Client, ctx context.Context, lbName, tgARN string) {
+	t.Helper()
+
+	lbOut, err := client.CreateLoadBalancer(ctx, &elb.CreateLoadBalancerInput{
+		Name:    aws.String(lbName),
+		Subnets: []string{"subnet-a"},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer(%s): %v", lbName, err)
+	}
+
+	if _, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: lbOut.LoadBalancers[0].LoadBalancerArn,
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	}); err != nil {
+		t.Fatalf("CreateListener forwarding to %s: %v", tgARN, err)
+	}
+}
+
 // TestSDKLoadBalancerExtraFields locks in the Route53-alias-critical fields the
 // audit found missing from Create/DescribeLoadBalancers.
 func TestSDKLoadBalancerExtraFields(t *testing.T) {
@@ -441,6 +468,10 @@ func TestSDKTargetHealthAdvances(t *testing.T) {
 
 	tgARN := aws.ToString(tgOut.TargetGroups[0].TargetGroupArn)
 
+	// A target group only begins health checks once a listener forwards to it;
+	// attach one so the initial->healthy progression is exercised.
+	attachListener(t, client, ctx, "th-alb", tgARN)
+
 	if _, err := client.RegisterTargets(ctx, &elb.RegisterTargetsInput{
 		TargetGroupArn: aws.String(tgARN),
 		Targets:        []elbtypes.TargetDescription{{Id: aws.String("i-1"), Port: aws.Int32(80)}},
@@ -497,6 +528,9 @@ func TestSDKDescribeTargetHealthUnregisteredTarget(t *testing.T) {
 	}
 
 	tgARN := aws.ToString(tgOut.TargetGroups[0].TargetGroupArn)
+
+	// Attach a listener so the registered target advances past "unused".
+	attachListener(t, client, ctx, "nr-alb", tgARN)
 
 	if _, err := client.RegisterTargets(ctx, &elb.RegisterTargetsInput{
 		TargetGroupArn: aws.String(tgARN),

--- a/server/aws/elbv2/operations.go
+++ b/server/aws/elbv2/operations.go
@@ -516,20 +516,57 @@ func parseActions(form url.Values, prefix string) []lbdriver.RuleAction {
 
 // parseAction parses a single action at the given form prefix. Both the flat
 // TargetGroupArn field and the ForwardConfig.TargetGroups.member.N nesting are
-// accepted for forward actions.
+// accepted for forward actions; a multi-target-group (weighted) ForwardConfig is
+// preserved in full so canary / blue-green splits round-trip on Describe.
 func parseAction(form url.Values, base string) lbdriver.RuleAction {
+	forward := parseForwardConfig(form, base+".ForwardConfig")
+
 	tgARN := form.Get(base + ".TargetGroupArn")
-	if tgARN == "" {
-		tgARN = form.Get(base + ".ForwardConfig.TargetGroups.member.1.TargetGroupArn")
+	if tgARN == "" && len(forward) > 0 {
+		tgARN = forward[0].TargetGroupARN
 	}
 
 	return lbdriver.RuleAction{
 		Type:                typeOr(form.Get(base+".Type"), "forward"),
 		TargetGroupARN:      tgARN,
+		ForwardConfig:       forward,
 		Order:               formInt(form.Get(base + ".Order")),
 		RedirectConfig:      parseRedirectConfig(form, base+".RedirectConfig"),
 		FixedResponseConfig: parseFixedResponseConfig(form, base+".FixedResponseConfig"),
 	}
+}
+
+// parseForwardConfig parses a forward action's ForwardConfig.TargetGroups member
+// list into weighted target groups, returning nil when none are present. A
+// single-target forward carried only as the flat TargetGroupArn yields nil here;
+// the caller keeps the scalar field for that case.
+func parseForwardConfig(form url.Values, base string) []lbdriver.ForwardTargetGroup {
+	indices := awsquery.CollectIndices(form, base+".TargetGroups.member")
+	if len(indices) == 0 {
+		return nil
+	}
+
+	out := make([]lbdriver.ForwardTargetGroup, 0, len(indices))
+
+	for _, n := range indices {
+		member := base + ".TargetGroups.member." + strconv.Itoa(n)
+
+		arn := form.Get(member + ".TargetGroupArn")
+		if arn == "" {
+			continue
+		}
+
+		out = append(out, lbdriver.ForwardTargetGroup{
+			TargetGroupARN: arn,
+			Weight:         formInt32(form.Get(member + ".Weight")),
+		})
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
 }
 
 // parseRedirectConfig parses a RedirectConfig sub-structure, returning nil when
@@ -911,4 +948,19 @@ func formInt(v string) int {
 	}
 
 	return n
+}
+
+// formInt32 parses a form value as an int32, returning 0 for an empty or
+// malformed value. Used for the bounded Weight field of a weighted forward.
+func formInt32(v string) int32 {
+	if v == "" {
+		return 0
+	}
+
+	n, err := strconv.ParseInt(v, 10, 32)
+	if err != nil {
+		return 0
+	}
+
+	return int32(n)
 }

--- a/server/aws/elbv2/sdk_weighted_forward_test.go
+++ b/server/aws/elbv2/sdk_weighted_forward_test.go
@@ -1,0 +1,314 @@
+package elbv2_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+// mkTG is a small helper that creates a target group and returns its ARN.
+func mkTG(t *testing.T, client *elb.Client, name string) string {
+	t.Helper()
+
+	out, err := client.CreateTargetGroup(context.Background(), &elb.CreateTargetGroupInput{
+		Name:     aws.String(name),
+		Protocol: elbtypes.ProtocolEnumHttp,
+		Port:     aws.Int32(80),
+		VpcId:    aws.String("vpc-1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup(%s): %v", name, err)
+	}
+
+	return aws.ToString(out.TargetGroups[0].TargetGroupArn)
+}
+
+// mkALB creates an application load balancer and returns its ARN.
+func mkALB(t *testing.T, client *elb.Client, name string) string {
+	t.Helper()
+
+	out, err := client.CreateLoadBalancer(context.Background(), &elb.CreateLoadBalancerInput{
+		Name:    aws.String(name),
+		Subnets: []string{"subnet-a"},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer(%s): %v", name, err)
+	}
+
+	return aws.ToString(out.LoadBalancers[0].LoadBalancerArn)
+}
+
+// errorCode extracts the AWS API error code from an SDK error.
+func errorCode(err error) string {
+	var ae smithy.APIError
+	if errors.As(err, &ae) {
+		return ae.ErrorCode()
+	}
+
+	return ""
+}
+
+// TestSDKELBWeightedForwardRoundTrips proves a forward action that splits
+// traffic across two weighted target groups (canary / blue-green) survives a
+// create/describe cycle with both ARNs and weights intact, instead of collapsing
+// to the primary group (which would show a perpetual Terraform diff).
+func TestSDKELBWeightedForwardRoundTrips(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN := mkALB(t, client, "weighted-alb")
+	blueARN := mkTG(t, client, "blue-tg")
+	greenARN := mkTG(t, client, "green-tg")
+
+	_, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type: elbtypes.ActionTypeEnumForward,
+			ForwardConfig: &elbtypes.ForwardActionConfig{
+				TargetGroups: []elbtypes.TargetGroupTuple{
+					{TargetGroupArn: aws.String(blueARN), Weight: aws.Int32(90)},
+					{TargetGroupArn: aws.String(greenARN), Weight: aws.Int32(10)},
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener with weighted forward: %v", err)
+	}
+
+	desc, err := client.DescribeListeners(ctx, &elb.DescribeListenersInput{
+		LoadBalancerArn: aws.String(lbARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeListeners: %v", err)
+	}
+
+	if len(desc.Listeners) != 1 {
+		t.Fatalf("got %d listeners, want 1", len(desc.Listeners))
+	}
+
+	actions := desc.Listeners[0].DefaultActions
+	if len(actions) != 1 || actions[0].ForwardConfig == nil {
+		t.Fatalf("default action = %+v, want a forward with ForwardConfig", actions)
+	}
+
+	groups := actions[0].ForwardConfig.TargetGroups
+	if len(groups) != 2 {
+		t.Fatalf("ForwardConfig groups = %d, want 2", len(groups))
+	}
+
+	weights := map[string]int32{}
+	for _, g := range groups {
+		weights[aws.ToString(g.TargetGroupArn)] = aws.ToInt32(g.Weight)
+	}
+
+	if weights[blueARN] != 90 || weights[greenARN] != 10 {
+		t.Fatalf("weights = %v, want blue=90 green=10", weights)
+	}
+}
+
+// TestSDKELBWeightedSecondaryTGInUse proves that deleting a SECONDARY weighted
+// target group a listener still forwards to is rejected with ResourceInUse, so a
+// live weighted target is never orphaned.
+func TestSDKELBWeightedSecondaryTGInUse(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN := mkALB(t, client, "inuse-alb")
+	primaryARN := mkTG(t, client, "primary-tg")
+	secondaryARN := mkTG(t, client, "secondary-tg")
+
+	if _, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type: elbtypes.ActionTypeEnumForward,
+			ForwardConfig: &elbtypes.ForwardActionConfig{
+				TargetGroups: []elbtypes.TargetGroupTuple{
+					{TargetGroupArn: aws.String(primaryARN), Weight: aws.Int32(50)},
+					{TargetGroupArn: aws.String(secondaryARN), Weight: aws.Int32(50)},
+				},
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	_, err := client.DeleteTargetGroup(ctx, &elb.DeleteTargetGroupInput{
+		TargetGroupArn: aws.String(secondaryARN),
+	})
+	if err == nil {
+		t.Fatalf("DeleteTargetGroup on in-use secondary weighted TG succeeded, want ResourceInUse")
+	}
+
+	if code := errorCode(err); code != "ResourceInUse" {
+		t.Fatalf("DeleteTargetGroup error code = %q, want ResourceInUse", code)
+	}
+}
+
+// TestSDKELBWeightedMissingSecondaryTG proves a forward action referencing a
+// non-existent SECONDARY weighted target group is rejected with
+// TargetGroupNotFound, not silently accepted.
+func TestSDKELBWeightedMissingSecondaryTG(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN := mkALB(t, client, "missing-alb")
+	realARN := mkTG(t, client, "real-tg")
+	bogusARN := realARN + "-does-not-exist"
+
+	_, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type: elbtypes.ActionTypeEnumForward,
+			ForwardConfig: &elbtypes.ForwardActionConfig{
+				TargetGroups: []elbtypes.TargetGroupTuple{
+					{TargetGroupArn: aws.String(realARN), Weight: aws.Int32(50)},
+					{TargetGroupArn: aws.String(bogusARN), Weight: aws.Int32(50)},
+				},
+			},
+		}},
+	})
+	if err == nil {
+		t.Fatalf("CreateListener with bogus secondary TG succeeded, want TargetGroupNotFound")
+	}
+
+	if code := errorCode(err); code != "TargetGroupNotFound" {
+		t.Fatalf("CreateListener error code = %q, want TargetGroupNotFound", code)
+	}
+}
+
+// TestSDKELBUnusedHealthUntilAttached proves a target group with no listener
+// forwarding to it reports its targets as unused / Target.NotInUse, and only
+// begins advancing to healthy once a listener routes to it.
+func TestSDKELBUnusedHealthUntilAttached(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	tgARN := mkTG(t, client, "unattached-tg")
+
+	if _, err := client.RegisterTargets(ctx, &elb.RegisterTargetsInput{
+		TargetGroupArn: aws.String(tgARN),
+		Targets:        []elbtypes.TargetDescription{{Id: aws.String("i-1"), Port: aws.Int32(80)}},
+	}); err != nil {
+		t.Fatalf("RegisterTargets: %v", err)
+	}
+
+	// No listener forwards to this TG yet: unused / Target.NotInUse, and it must
+	// not advance no matter how many times it is polled.
+	for i := 0; i < 3; i++ {
+		health, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
+			TargetGroupArn: aws.String(tgARN),
+		})
+		if err != nil {
+			t.Fatalf("DescribeTargetHealth (unattached): %v", err)
+		}
+
+		if len(health.TargetHealthDescriptions) != 1 {
+			t.Fatalf("health entries = %d, want 1", len(health.TargetHealthDescriptions))
+		}
+
+		th := health.TargetHealthDescriptions[0].TargetHealth
+		if th.State != elbtypes.TargetHealthStateEnumUnused {
+			t.Fatalf("state = %q, want unused", th.State)
+		}
+
+		if th.Reason != elbtypes.TargetHealthReasonEnumNotInUse {
+			t.Fatalf("reason = %q, want Target.NotInUse", th.Reason)
+		}
+	}
+
+	// Attach a listener that forwards to the TG; now health checks begin and the
+	// target settles initial -> healthy.
+	lbARN := mkALB(t, client, "attach-alb")
+	if _, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	}); err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	// First poll after attach reports initial, next reports healthy.
+	first, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(tgARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeTargetHealth (attached, first): %v", err)
+	}
+
+	if s := first.TargetHealthDescriptions[0].TargetHealth.State; s != elbtypes.TargetHealthStateEnumInitial {
+		t.Fatalf("first attached state = %q, want initial", s)
+	}
+
+	second, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(tgARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeTargetHealth (attached, second): %v", err)
+	}
+
+	if s := second.TargetHealthDescriptions[0].TargetHealth.State; s != elbtypes.TargetHealthStateEnumHealthy {
+		t.Fatalf("second attached state = %q, want healthy", s)
+	}
+}
+
+// TestSDKELBSingleTGForwardStillWorks guards against regressing the single
+// target-group forward path: it must still round-trip on describe and still be
+// protected from deletion while a listener forwards to it.
+func TestSDKELBSingleTGForwardStillWorks(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN := mkALB(t, client, "single-alb")
+	tgARN := mkTG(t, client, "single-tg")
+
+	if _, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	}); err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	desc, err := client.DescribeListeners(ctx, &elb.DescribeListenersInput{
+		LoadBalancerArn: aws.String(lbARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeListeners: %v", err)
+	}
+
+	actions := desc.Listeners[0].DefaultActions
+	if len(actions) != 1 || aws.ToString(actions[0].TargetGroupArn) != tgARN {
+		t.Fatalf("single-TG default action = %+v, want forward to %s", actions, tgARN)
+	}
+
+	_, err = client.DeleteTargetGroup(ctx, &elb.DeleteTargetGroupInput{
+		TargetGroupArn: aws.String(tgARN),
+	})
+	if err == nil {
+		t.Fatalf("DeleteTargetGroup on in-use single TG succeeded, want ResourceInUse")
+	}
+
+	if code := errorCode(err); code != "ResourceInUse" {
+		t.Fatalf("DeleteTargetGroup error code = %q, want ResourceInUse", code)
+	}
+}

--- a/server/aws/elbv2/types.go
+++ b/server/aws/elbv2/types.go
@@ -163,10 +163,24 @@ type fixedResponseConfigXML struct {
 	MessageBody string `xml:"MessageBody,omitempty"`
 }
 
+type targetGroupTupleXML struct {
+	TargetGroupArn string `xml:"TargetGroupArn,omitempty"`
+	Weight         int32  `xml:"Weight"`
+}
+
+type targetGroupTuplesXML struct {
+	Member []targetGroupTupleXML `xml:"member,omitempty"`
+}
+
+type forwardConfigXML struct {
+	TargetGroups *targetGroupTuplesXML `xml:"TargetGroups,omitempty"`
+}
+
 type actionXML struct {
 	Type                string                  `xml:"Type"`
 	TargetGroupArn      string                  `xml:"TargetGroupArn,omitempty"`
 	Order               int                     `xml:"Order,omitempty"`
+	ForwardConfig       *forwardConfigXML       `xml:"ForwardConfig,omitempty"`
 	RedirectConfig      *redirectConfigXML      `xml:"RedirectConfig,omitempty"`
 	FixedResponseConfig *fixedResponseConfigXML `xml:"FixedResponseConfig,omitempty"`
 }
@@ -483,6 +497,18 @@ func toActionXML(a lbdriver.RuleAction) actionXML {
 		Type:           a.Type,
 		TargetGroupArn: a.TargetGroupARN,
 		Order:          a.Order,
+	}
+
+	if len(a.ForwardConfig) > 0 {
+		tuples := &targetGroupTuplesXML{Member: make([]targetGroupTupleXML, 0, len(a.ForwardConfig))}
+		for _, tg := range a.ForwardConfig {
+			tuples.Member = append(tuples.Member, targetGroupTupleXML{
+				TargetGroupArn: tg.TargetGroupARN,
+				Weight:         tg.Weight,
+			})
+		}
+
+		x.ForwardConfig = &forwardConfigXML{TargetGroups: tuples}
 	}
 
 	if rc := a.RedirectConfig; rc != nil {

--- a/services/loadbalancer/driver/driver.go
+++ b/services/loadbalancer/driver/driver.go
@@ -205,11 +205,23 @@ type HTTPRequestMethodConditionConfig struct {
 // forward, so the common HTTP->HTTPS redirect and custom fixed-response
 // patterns survive a create/describe cycle instead of being silently dropped.
 type RuleAction struct {
-	Type                string // "forward", "redirect", "fixed-response", "authenticate-cognito", "authenticate-oidc"
-	TargetGroupARN      string
+	Type           string // "forward", "redirect", "fixed-response", "authenticate-cognito", "authenticate-oidc"
+	TargetGroupARN string
+	// ForwardConfig holds the full weighted target-group set for a "forward"
+	// action (canary / blue-green). A single-target forward keeps only
+	// TargetGroupARN set; a multi-target forward fills ForwardConfig and sets
+	// TargetGroupARN to the primary (first) group, as real ELBv2 reports.
+	ForwardConfig       []ForwardTargetGroup
 	Order               int
 	RedirectConfig      *RedirectActionConfig
 	FixedResponseConfig *FixedResponseActionConfig
+}
+
+// ForwardTargetGroup is one weighted target group inside a forward action's
+// ForwardConfig.
+type ForwardTargetGroup struct {
+	TargetGroupARN string
+	Weight         int32
 }
 
 // RedirectActionConfig is the configuration of a "redirect" action. AWS requires


### PR DESCRIPTION
## Summary

Fixes two real AWS ELBv2 cross-resource bugs in the wire/provider layers.

### BUG1 — Weighted / multi-target-group forward actions collapsed to a single target group
A `forward` action carrying a `ForwardConfig` with 2+ weighted target groups (canary / blue-green) was stored as a single scalar `TargetGroupARN`, dropping every group after the first. This is now preserved end to end:

- **Driver**: `RuleAction` gains `ForwardConfig []ForwardTargetGroup` (ARN + Weight). The scalar `TargetGroupARN` is kept for the single-TG case and set to the primary (first) group for the multi-TG case, matching real ELBv2.
- **Parse**: `parseAction` reads every `ForwardConfig.TargetGroups.member.N` (ARN + Weight), not just member 1.
- **Round-trip**: `DescribeListeners` and `DescribeRules` echo the full `ForwardConfig` (each target group ARN + weight) via the shared `toActionsXML`, so weighted splits no longer show a perpetual Terraform diff.
- **Validation**: `validateForwardActions` (used by `CreateListener` and now `CreateRule`) validates *every* referenced target group, so a bogus secondary weighted TG raises `TargetGroupNotFound`.
- **In-use protection**: `checkTargetGroupNotInUse` scans the full `ForwardConfig` list across listener default actions and rule actions, so `DeleteTargetGroup` on a secondary weighted TG that a listener still forwards to correctly returns `ResourceInUse` instead of orphaning a live target.

### BUG2 — Target health advanced to healthy even when the target group was attached to no load balancer
`DescribeTargetHealth` unconditionally advanced targets `initial -> healthy`, ignoring whether any listener routed to the group. It now reports `State=unused` / `Reason=Target.NotInUse` while no listener default-action or rule-action (including weighted `ForwardConfig` members) references the target group, and only begins the `initial -> healthy` settle once a listener forwards to it. The existing `Target.NotRegistered` path and `SetTargetHealth` sticky states (used by ECS) are untouched.

## Tests

New real aws-sdk-go-v2 tests over `httptest`:
1. Listener with a weighted forward to 2 TGs — `DescribeListeners` echoes both ARNs + weights.
2. `DeleteTargetGroup` on the second weighted TG while a listener forwards to it — `ResourceInUse`.
3. Forward action referencing a missing secondary TG — `TargetGroupNotFound`.
4. `RegisterTargets` to a TG with no listener — health is `unused` / `Target.NotInUse`; after attaching a listener, targets progress `initial -> healthy`.
5. Single-TG forward still round-trips and single-TG in-use protection still holds (no regression).

Existing target-health SDK tests updated to attach a listener before asserting the advancement path.

## Gates
- `go build ./...`, `go vet`, gofmt clean
- `go test` green for `server/aws/elbv2`, `providers/aws/elbv2`, `services/loadbalancer`, and `providers/aws/ecs` (ECS registers into ELBv2 TGs)
- `golangci-lint --new-from-rev=origin/development` — 0 new issues
- `go generate ./...` + compatgen — zero diff