### PR TITLE
fix(aws-ec2): reflect ENI/volume/EIP attachments on DescribeInstances; clean them up on terminate

### DIFF
--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -756,6 +756,17 @@ func (m *Mock) releasePrimaryENI(ctx context.Context, instanceID string) {
 	_ = m.networking.ReleaseInstanceNetworkInterfaces(ctx, instanceID)
 }
 
+// disassociateInstanceAddresses asks the networking mock to disassociate (not
+// release) any elastic IP bound to the terminated instance, so the address
+// survives as allocated-but-unassociated. A no-op until wired.
+func (m *Mock) disassociateInstanceAddresses(ctx context.Context, instanceID string) {
+	if m.networking == nil {
+		return
+	}
+
+	_ = m.networking.DisassociateInstanceAddresses(ctx, instanceID)
+}
+
 // allocatePrivateIP hands out the next private IPv4 inside the subnet's CIDR
 // (AWS allocates from the target subnet, e.g. 10.0.1.0/24 -> 10.0.1.x). It falls
 // back to the global 10.0.<n> pool when there is no subnet CIDR to draw from.
@@ -919,6 +930,7 @@ func (m *Mock) TerminateInstances(ctx context.Context, instanceIDs []string) err
 	// terminated instance must no longer hold them.
 	for _, id := range instanceIDs {
 		m.releasePrimaryENI(ctx, id)
+		m.disassociateInstanceAddresses(ctx, id)
 	}
 
 	// Tear down the real backing for any engine-backed instances. Every id is now

--- a/providers/aws/ec2/networking.go
+++ b/providers/aws/ec2/networking.go
@@ -10,6 +10,11 @@ import "context"
 type Networking interface {
 	CreatePrimaryNetworkInterface(ctx context.Context, instanceID, subnetID string, groups []string) error
 	ReleaseInstanceNetworkInterfaces(ctx context.Context, instanceID string) error
+	// DisassociateInstanceAddresses clears the association of any elastic IP
+	// bound to the instance on terminate, leaving the address allocated but
+	// unassociated — matching real EC2, which disassociates (does not release)
+	// an instance's EIPs when it is terminated.
+	DisassociateInstanceAddresses(ctx context.Context, instanceID string) error
 }
 
 // SetNetworking wires the networking mock in. Without it an instance launches

--- a/providers/aws/vpc/elastic_ip.go
+++ b/providers/aws/vpc/elastic_ip.go
@@ -150,6 +150,29 @@ func (m *Mock) DisassociateAddress(
 	)
 }
 
+// DisassociateInstanceAddresses clears the association of every elastic IP bound
+// to instanceID, leaving each EIP allocated but unassociated. Real EC2
+// disassociates (does not release) an instance's EIPs on TerminateInstances, so
+// the address survives the instance and can be reassociated. It is a no-op when
+// the instance holds no EIP.
+func (m *Mock) DisassociateInstanceAddresses(_ context.Context, instanceID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, eip := range m.eips.All() {
+		if eip.InstanceID != instanceID {
+			continue
+		}
+
+		eip.AssociationID = ""
+		eip.InstanceID = ""
+		eip.NetworkInterfaceID = ""
+		eip.PrivateIP = ""
+	}
+
+	return nil
+}
+
 // sameEIPTarget reports whether the requested association points at the target
 // the EIP already holds, in which case a strict re-associate is idempotent.
 func sameEIPTarget(eip *eipData, in driver.AssociateAddressInput) bool {

--- a/providers/aws/vpc/network_interface.go
+++ b/providers/aws/vpc/network_interface.go
@@ -146,19 +146,37 @@ func (m *Mock) CreatePrimaryNetworkInterface(_ context.Context, instanceID, subn
 	return nil
 }
 
-// ReleaseInstanceNetworkInterfaces deletes the delete-on-termination interfaces
-// attached to instanceID — the primary ENIs CreatePrimaryNetworkInterface made.
-// Real EC2 releases these on TerminateInstances, which is what lets a subsequent
-// DeleteSubnet / DeleteSecurityGroup succeed. Standalone or managed interfaces
-// (deleteOnTermination false) are left untouched.
+// ReleaseInstanceNetworkInterfaces reconciles an instance's ENIs on terminate,
+// matching real EC2's delete-on-termination default per interface:
+//
+//   - delete-on-termination interfaces (the primary eth0 that
+//     CreatePrimaryNetworkInterface made) are deleted; releasing them is what
+//     lets a subsequent DeleteSubnet / DeleteSecurityGroup succeed.
+//   - other attached interfaces (secondary ENIs the user attached with
+//     AttachNetworkInterface, deleteOnTermination false) are detached back to
+//     `available` — not deleted — so they survive the instance and can be
+//     reattached, and no longer wedge a DeleteSubnet on a dead instance.
+//
+// Standalone/managed interfaces not attached to this instance are untouched.
 func (m *Mock) ReleaseInstanceNetworkInterfaces(_ context.Context, instanceID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	for id, eni := range m.enis.All() {
-		if eni.InstanceID == instanceID && eni.deleteOnTermination {
-			m.enis.Delete(id)
+		if eni.InstanceID != instanceID {
+			continue
 		}
+
+		if eni.deleteOnTermination {
+			m.enis.Delete(id)
+
+			continue
+		}
+
+		eni.AttachmentID = ""
+		eni.InstanceID = ""
+		eni.DeviceIndex = 0
+		eni.Status = ENIStatusAvailable
 	}
 
 	return nil

--- a/server/aws/ec2/operations.go
+++ b/server/aws/ec2/operations.go
@@ -13,6 +13,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
 // instanceAttributer is an AWS-specific optional capability for reading and
@@ -676,13 +677,97 @@ func copyTagMap(tags map[string]string) map[string]string {
 }
 
 // toInstanceXMLs converts driver instances to their XML wire form, resolving
-// security-group names once for the whole batch.
+// security-group names once for the whole batch and reading the ENI, volume and
+// elastic-IP stores once so each instance reflects its real attachments (the
+// authoritative attachment state lives in those stores, not on the instance's
+// own scalar fields).
 func (h *Handler) toInstanceXMLs(ctx context.Context, instances []computedriver.Instance) []instanceXML {
 	names := h.securityGroupNames(ctx, collectSecurityGroups(instances))
 
+	enisByInstance := h.enisByInstance(ctx)
+	volsByInstance := h.volumesByInstance(ctx)
+	eipByInstance := h.eipByInstance(ctx)
+
 	out := make([]instanceXML, 0, len(instances))
+
 	for i := range instances {
-		out = append(out, instanceXMLFor(&instances[i], names))
+		inst := &instances[i]
+		out = append(out, instanceXMLFor(inst, names, enisByInstance[inst.ID], volsByInstance[inst.ID], eipByInstance[inst.ID]))
+	}
+
+	return out
+}
+
+// enisByInstance groups every ENI in the networking store by the instance it is
+// attached to, so each instance's networkInterfaceSet reflects the real
+// interfaces (primary eth0 plus any AttachNetworkInterface secondaries). A
+// networking backend that does not model ENIs yields an empty map, and callers
+// fall back to the synthesized primary interface.
+func (h *Handler) enisByInstance(ctx context.Context) map[string][]netdriver.NetworkInterface {
+	store, ok := h.networkInterfaces()
+	if !ok {
+		return nil
+	}
+
+	enis, err := store.DescribeNetworkInterfaces(ctx, nil)
+	if err != nil {
+		return nil
+	}
+
+	out := make(map[string][]netdriver.NetworkInterface)
+
+	for i := range enis {
+		if id := enis[i].InstanceID; id != "" {
+			out[id] = append(out[id], enis[i])
+		}
+	}
+
+	return out
+}
+
+// volumesByInstance groups every attached EBS volume by the instance it is
+// attached to, so each instance's blockDeviceMapping reflects the volumes the
+// volume store says are attached to it.
+func (h *Handler) volumesByInstance(ctx context.Context) map[string][]computedriver.VolumeInfo {
+	if h.compute == nil {
+		return nil
+	}
+
+	vols, err := h.compute.DescribeVolumes(ctx, nil)
+	if err != nil {
+		return nil
+	}
+
+	out := make(map[string][]computedriver.VolumeInfo)
+
+	for i := range vols {
+		if id := vols[i].AttachedTo; id != "" {
+			out[id] = append(out[id], vols[i])
+		}
+	}
+
+	return out
+}
+
+// eipByInstance maps each instance to the elastic IP associated with it, so an
+// instance reports the public IP of its EIP (instances never carry one on their
+// own scalar fields).
+func (h *Handler) eipByInstance(ctx context.Context) map[string]*netdriver.ElasticIP {
+	if h.vpc == nil {
+		return nil
+	}
+
+	eips, err := h.vpc.DescribeAddresses(ctx, nil)
+	if err != nil {
+		return nil
+	}
+
+	out := make(map[string]*netdriver.ElasticIP)
+
+	for i := range eips {
+		if id := eips[i].InstanceID; id != "" {
+			out[id] = &eips[i]
+		}
 	}
 
 	return out
@@ -690,7 +775,18 @@ func (h *Handler) toInstanceXMLs(ctx context.Context, instances []computedriver.
 
 // instanceXMLFor builds the wire shape for one instance, including the static
 // facts and derived placement / DNS / primary-ENI fields real EC2 reports.
-func instanceXMLFor(inst *computedriver.Instance, names map[string]string) instanceXML {
+func instanceXMLFor(
+	inst *computedriver.Instance, names map[string]string,
+	enis []netdriver.NetworkInterface, vols []computedriver.VolumeInfo, eip *netdriver.ElasticIP,
+) instanceXML {
+	// An associated elastic IP is what gives an instance its public address;
+	// instances never carry one on their own scalar fields, so the EIP store is
+	// authoritative for the reported public IP / DNS name.
+	publicIP := inst.PublicIP
+	if eip != nil && eip.PublicIP != "" {
+		publicIP = eip.PublicIP
+	}
+
 	xi := instanceXML{
 		InstanceID:         inst.ID,
 		ImageID:            inst.ImageID,
@@ -700,9 +796,9 @@ func instanceXMLFor(inst *computedriver.Instance, names map[string]string) insta
 		SubnetID:           inst.SubnetID,
 		VPCID:              inst.VPCID,
 		PrivateIP:          inst.PrivateIP,
-		PublicIP:           inst.PublicIP,
+		PublicIP:           publicIP,
 		PrivateDNSName:     privateDNSName(inst.PrivateIP),
-		PublicDNSName:      publicDNSName(inst.PublicIP),
+		PublicDNSName:      publicDNSName(publicIP),
 		KeyName:            inst.KeyName,
 		AmiLaunchIndex:     0,
 		Architecture:       archX86,
@@ -719,9 +815,8 @@ func instanceXMLFor(inst *computedriver.Instance, names map[string]string) insta
 		xi.Groups = append(xi.Groups, groupItem{GroupID: sg, GroupName: names[sg]})
 	}
 
-	if eni := primaryENI(inst, xi.Groups); eni != nil {
-		xi.NetworkInterfaces = []instanceENIXML{*eni}
-	}
+	xi.NetworkInterfaces = instanceENIs(inst, xi.Groups, enis)
+	xi.BlockDeviceMappings = instanceBlockDevices(vols)
 
 	for k, v := range inst.Tags {
 		xi.Tags = append(xi.Tags, tagItem{Key: k, Value: v})
@@ -763,10 +858,63 @@ func metadataOptionsXMLFor(o *computedriver.MetadataOptions) *metadataOptionsXML
 	}
 }
 
-// primaryENI synthesizes the instance's single primary network interface from
-// its subnet/VPC/private-IP/security-groups, or nil when there is nothing to
-// describe (no subnet, VPC, or private IP).
-func primaryENI(inst *computedriver.Instance, groups []groupItem) *instanceENIXML {
+// instanceENIs renders the instance's network interfaces from the ENI store:
+// every interface attached to the instance (its primary eth0 plus any
+// AttachNetworkInterface secondaries), each carrying its real eni- id, MAC,
+// device index, private IP, subnet and attachment id. Interfaces are ordered by
+// device index so eth0 comes first.
+//
+// When the store holds no interface for the instance — a launch with no subnet,
+// or a networking backend that does not model ENIs — it falls back to a single
+// synthesized primary interface from the instance's own subnet/VPC/private-IP so
+// those instances still describe an interface.
+func instanceENIs(inst *computedriver.Instance, groups []groupItem, enis []netdriver.NetworkInterface) []instanceENIXML {
+	if len(enis) == 0 {
+		if eni := synthesizedPrimaryENI(inst, groups); eni != nil {
+			return []instanceENIXML{*eni}
+		}
+
+		return nil
+	}
+
+	sorted := append([]netdriver.NetworkInterface(nil), enis...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].DeviceIndex < sorted[j].DeviceIndex })
+
+	out := make([]instanceENIXML, 0, len(sorted))
+
+	for i := range sorted {
+		eni := &sorted[i]
+		// The primary interface carries the instance's security groups; a secondary
+		// ENI's own groups are not tracked on the attachment, so only eth0 reflects
+		// the instance-level group set here.
+		var itemGroups []groupItem
+		if eni.DeviceIndex == primaryDeviceIndex {
+			itemGroups = groups
+		}
+
+		out = append(out, instanceENIXML{
+			NetworkInterfaceID: eni.ID,
+			SubnetID:           eni.SubnetID,
+			VPCID:              eni.VPCID,
+			MacAddress:         eni.MacAddress,
+			PrivateIP:          eni.PrivateIP,
+			Status:             eni.Status,
+			Groups:             itemGroups,
+			Attachment: instanceENIAttachmentXML{
+				AttachmentID: eni.AttachmentID,
+				DeviceIndex:  eni.DeviceIndex,
+				Status:       eniAttachedStatus,
+			},
+		})
+	}
+
+	return out
+}
+
+// synthesizedPrimaryENI builds a best-effort primary interface from the
+// instance's own subnet/VPC/private-IP/security-groups, for instances the ENI
+// store does not model. Returns nil when there is nothing to describe.
+func synthesizedPrimaryENI(inst *computedriver.Instance, groups []groupItem) *instanceENIXML {
 	if inst.SubnetID == "" && inst.VPCID == "" && inst.PrivateIP == "" {
 		return nil
 	}
@@ -778,6 +926,35 @@ func primaryENI(inst *computedriver.Instance, groups []groupItem) *instanceENIXM
 		Groups:     groups,
 		Attachment: instanceENIAttachmentXML{DeviceIndex: primaryDeviceIndex, Status: eniAttachedStatus},
 	}
+}
+
+// instanceBlockDevices renders the EBS volumes attached to the instance as
+// blockDeviceMapping items. The volume store is authoritative for the linkage
+// (AttachVolume records AttachedTo/Device); the instance side only reflects it.
+func instanceBlockDevices(vols []computedriver.VolumeInfo) []instanceBlockDeviceXML {
+	if len(vols) == 0 {
+		return nil
+	}
+
+	sorted := append([]computedriver.VolumeInfo(nil), vols...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Device < sorted[j].Device })
+
+	out := make([]instanceBlockDeviceXML, 0, len(sorted))
+
+	for i := range sorted {
+		v := &sorted[i]
+		out = append(out, instanceBlockDeviceXML{
+			DeviceName: v.Device,
+			EBS: instanceEBSXML{
+				VolumeID:            v.ID,
+				Status:              eniAttachedStatus,
+				AttachTime:          v.CreatedAt,
+				DeleteOnTermination: false,
+			},
+		})
+	}
+
+	return out
 }
 
 // instanceZone returns the instance's availability zone, defaulting to a stable

--- a/server/aws/ec2/xml.go
+++ b/server/aws/ec2/xml.go
@@ -92,23 +92,44 @@ type iamInstanceProfileXML struct {
 	ID  string `xml:"id,omitempty"`
 }
 
-// instanceENIAttachmentXML is the primary ENI's <attachment> (deviceIndex 0).
+// instanceENIAttachmentXML is an instance ENI's <attachment>: the device index
+// (0 for eth0), the attachment id, and the attachment status.
 type instanceENIAttachmentXML struct {
-	DeviceIndex int    `xml:"deviceIndex"`
-	Status      string `xml:"status"`
+	AttachmentID string `xml:"attachmentId,omitempty"`
+	DeviceIndex  int    `xml:"deviceIndex"`
+	Status       string `xml:"status"`
 }
 
-// instanceENIXML is one <networkInterfaceSet><item> describing the instance's
-// primary elastic network interface, as embedded in a DescribeInstances item.
-// It is distinct from the standalone networkInterfaceXML (DescribeNetworkInterfaces)
-// because the embedded shape carries privateIpAddress, groupSet and deviceIndex.
+// instanceENIXML is one <networkInterfaceSet><item> describing one of the
+// instance's elastic network interfaces, as embedded in a DescribeInstances
+// item. It is distinct from the standalone networkInterfaceXML
+// (DescribeNetworkInterfaces) because the embedded shape carries
+// privateIpAddress, groupSet and the per-attachment deviceIndex.
 type instanceENIXML struct {
 	NetworkInterfaceID string                   `xml:"networkInterfaceId,omitempty"`
 	SubnetID           string                   `xml:"subnetId,omitempty"`
 	VPCID              string                   `xml:"vpcId,omitempty"`
+	MacAddress         string                   `xml:"macAddress,omitempty"`
 	PrivateIP          string                   `xml:"privateIpAddress,omitempty"`
+	Status             string                   `xml:"status,omitempty"`
 	Groups             []groupItem              `xml:"groupSet>item,omitempty"`
 	Attachment         instanceENIAttachmentXML `xml:"attachment"`
+}
+
+// instanceBlockDeviceXML is one <blockDeviceMapping><item> in a DescribeInstances
+// item: the device name plus the EBS volume attached at that device.
+type instanceBlockDeviceXML struct {
+	DeviceName string         `xml:"deviceName"`
+	EBS        instanceEBSXML `xml:"ebs"`
+}
+
+// instanceEBSXML is the <ebs> child of an instance block-device mapping,
+// carrying the attached volume's id and attachment state.
+type instanceEBSXML struct {
+	VolumeID            string `xml:"volumeId"`
+	Status              string `xml:"status"`
+	AttachTime          string `xml:"attachTime,omitempty"`
+	DeleteOnTermination bool   `xml:"deleteOnTermination"`
 }
 
 // operatorXML is the nested <operator> element carrying managed-resource
@@ -126,32 +147,33 @@ type operatorXML struct {
 // DescribeInstances responses. We populate only the fields the SDK reliably
 // consumes and real apps actually read; unused AWS fields are omitted.
 type instanceXML struct {
-	InstanceID         string                 `xml:"instanceId"`
-	ImageID            string                 `xml:"imageId"`
-	State              instanceState          `xml:"instanceState"`
-	InstanceType       string                 `xml:"instanceType"`
-	LaunchTime         string                 `xml:"launchTime,omitempty"`
-	SubnetID           string                 `xml:"subnetId,omitempty"`
-	VPCID              string                 `xml:"vpcId,omitempty"`
-	PrivateIP          string                 `xml:"privateIpAddress,omitempty"`
-	PublicIP           string                 `xml:"ipAddress,omitempty"`
-	PrivateDNSName     string                 `xml:"privateDnsName,omitempty"`
-	PublicDNSName      string                 `xml:"dnsName,omitempty"`
-	KeyName            string                 `xml:"keyName,omitempty"`
-	AmiLaunchIndex     int                    `xml:"amiLaunchIndex"`
-	Architecture       string                 `xml:"architecture,omitempty"`
-	RootDeviceType     string                 `xml:"rootDeviceType,omitempty"`
-	RootDeviceName     string                 `xml:"rootDeviceName,omitempty"`
-	VirtualizationType string                 `xml:"virtualizationType,omitempty"`
-	Hypervisor         string                 `xml:"hypervisor,omitempty"`
-	Placement          *placementXML          `xml:"placement,omitempty"`
-	Monitoring         *monitoringXML         `xml:"monitoring,omitempty"`
-	MetadataOptions    *metadataOptionsXML    `xml:"metadataOptions,omitempty"`
-	IamInstanceProfile *iamInstanceProfileXML `xml:"iamInstanceProfile,omitempty"`
-	Groups             []groupItem            `xml:"groupSet>item,omitempty"`
-	NetworkInterfaces  []instanceENIXML       `xml:"networkInterfaceSet>item,omitempty"`
-	Tags               []tagItem              `xml:"tagSet>item,omitempty"`
-	Operator           *operatorXML           `xml:"operator,omitempty"`
+	InstanceID          string                   `xml:"instanceId"`
+	ImageID             string                   `xml:"imageId"`
+	State               instanceState            `xml:"instanceState"`
+	InstanceType        string                   `xml:"instanceType"`
+	LaunchTime          string                   `xml:"launchTime,omitempty"`
+	SubnetID            string                   `xml:"subnetId,omitempty"`
+	VPCID               string                   `xml:"vpcId,omitempty"`
+	PrivateIP           string                   `xml:"privateIpAddress,omitempty"`
+	PublicIP            string                   `xml:"ipAddress,omitempty"`
+	PrivateDNSName      string                   `xml:"privateDnsName,omitempty"`
+	PublicDNSName       string                   `xml:"dnsName,omitempty"`
+	KeyName             string                   `xml:"keyName,omitempty"`
+	AmiLaunchIndex      int                      `xml:"amiLaunchIndex"`
+	Architecture        string                   `xml:"architecture,omitempty"`
+	RootDeviceType      string                   `xml:"rootDeviceType,omitempty"`
+	RootDeviceName      string                   `xml:"rootDeviceName,omitempty"`
+	VirtualizationType  string                   `xml:"virtualizationType,omitempty"`
+	Hypervisor          string                   `xml:"hypervisor,omitempty"`
+	Placement           *placementXML            `xml:"placement,omitempty"`
+	Monitoring          *monitoringXML           `xml:"monitoring,omitempty"`
+	MetadataOptions     *metadataOptionsXML      `xml:"metadataOptions,omitempty"`
+	IamInstanceProfile  *iamInstanceProfileXML   `xml:"iamInstanceProfile,omitempty"`
+	Groups              []groupItem              `xml:"groupSet>item,omitempty"`
+	NetworkInterfaces   []instanceENIXML         `xml:"networkInterfaceSet>item,omitempty"`
+	BlockDeviceMappings []instanceBlockDeviceXML `xml:"blockDeviceMapping>item,omitempty"`
+	Tags                []tagItem                `xml:"tagSet>item,omitempty"`
+	Operator            *operatorXML             `xml:"operator,omitempty"`
 }
 
 // runInstancesResponse is the XML body for RunInstances.

--- a/server/aws/ec2_attachment_reflection_sdk_test.go
+++ b/server/aws/ec2_attachment_reflection_sdk_test.go
@@ -1,0 +1,295 @@
+package aws_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// launchInstanceInSubnet creates a VPC + subnet and launches a single instance
+// into it, returning the client and the ids the reflection tests build on.
+func launchInstanceInSubnet(t *testing.T) (client *ec2.Client, instanceID, subnetID string) {
+	t.Helper()
+
+	client = newEC2Client(t)
+	ctx := context.Background()
+
+	vpc, err := client.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	require.NoError(t, err)
+
+	sub, err := client.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+		VpcId:            vpc.Vpc.VpcId,
+		CidrBlock:        aws.String("10.0.1.0/24"),
+		AvailabilityZone: aws.String("us-east-1a"),
+	})
+	require.NoError(t, err)
+	subnetID = aws.ToString(sub.Subnet.SubnetId)
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-12345"),
+		InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+		SubnetId:     aws.String(subnetID),
+	})
+	require.NoError(t, err)
+	require.Len(t, run.Instances, 1)
+
+	return client, aws.ToString(run.Instances[0].InstanceId), subnetID
+}
+
+// describeInstance returns the single instance with the given id.
+func describeInstance(t *testing.T, client *ec2.Client, instanceID string) ec2types.Instance {
+	t.Helper()
+
+	out, err := client.DescribeInstances(context.Background(), &ec2.DescribeInstancesInput{
+		InstanceIds: []string{instanceID},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Reservations, 1)
+	require.Len(t, out.Reservations[0].Instances, 1)
+
+	return out.Reservations[0].Instances[0]
+}
+
+// primaryENIID returns the id of the instance's eth0 (device index 0) interface
+// as reported by DescribeNetworkInterfaces, the authoritative ENI store.
+func primaryENIID(t *testing.T, client *ec2.Client, instanceID string) string {
+	t.Helper()
+
+	out, err := client.DescribeNetworkInterfaces(context.Background(), &ec2.DescribeNetworkInterfacesInput{})
+	require.NoError(t, err)
+
+	for i := range out.NetworkInterfaces {
+		ni := out.NetworkInterfaces[i]
+		if ni.Attachment != nil &&
+			aws.ToString(ni.Attachment.InstanceId) == instanceID &&
+			aws.ToInt32(ni.Attachment.DeviceIndex) == 0 {
+			return aws.ToString(ni.NetworkInterfaceId)
+		}
+	}
+
+	t.Fatalf("no primary ENI found for instance %q", instanceID)
+
+	return ""
+}
+
+// TestInstanceReflectsSecondaryENI covers BUG2/BUG4: a secondary ENI attached to
+// a running instance shows up in DescribeInstances alongside the primary, and
+// the primary carries its real eni- id (matching DescribeNetworkInterfaces).
+func TestInstanceReflectsSecondaryENI(t *testing.T) {
+	client, instanceID, subnetID := launchInstanceInSubnet(t)
+	ctx := context.Background()
+
+	wantPrimary := primaryENIID(t, client, instanceID)
+
+	eni, err := client.CreateNetworkInterface(ctx, &ec2.CreateNetworkInterfaceInput{
+		SubnetId: aws.String(subnetID),
+	})
+	require.NoError(t, err)
+	secondaryID := aws.ToString(eni.NetworkInterface.NetworkInterfaceId)
+
+	_, err = client.AttachNetworkInterface(ctx, &ec2.AttachNetworkInterfaceInput{
+		NetworkInterfaceId: aws.String(secondaryID),
+		InstanceId:         aws.String(instanceID),
+		DeviceIndex:        aws.Int32(1),
+	})
+	require.NoError(t, err)
+
+	inst := describeInstance(t, client, instanceID)
+	require.Len(t, inst.NetworkInterfaces, 2, "instance must reflect both primary and secondary ENIs")
+
+	byDevice := map[int32]ec2types.InstanceNetworkInterface{}
+	for i := range inst.NetworkInterfaces {
+		ni := inst.NetworkInterfaces[i]
+		require.NotNil(t, ni.Attachment)
+		byDevice[aws.ToInt32(ni.Attachment.DeviceIndex)] = ni
+	}
+
+	primary, ok := byDevice[0]
+	require.True(t, ok, "primary (device index 0) interface must be present")
+	// BUG2/BUG4: primary carries its real eni- id, matching the ENI store.
+	assert.Equal(t, wantPrimary, aws.ToString(primary.NetworkInterfaceId))
+	assert.NotEmpty(t, aws.ToString(primary.MacAddress))
+
+	secondary, ok := byDevice[1]
+	require.True(t, ok, "secondary (device index 1) interface must be present")
+	assert.Equal(t, secondaryID, aws.ToString(secondary.NetworkInterfaceId))
+	assert.Equal(t, ec2types.AttachmentStatusAttached, secondary.Attachment.Status)
+}
+
+// TestInstancePrimaryENIMatchesStore covers BUG4: an instance launched into a
+// subnet reports a non-empty primary networkInterfaceId equal to the id
+// DescribeNetworkInterfaces reports for its eth0.
+func TestInstancePrimaryENIMatchesStore(t *testing.T) {
+	client, instanceID, _ := launchInstanceInSubnet(t)
+
+	want := primaryENIID(t, client, instanceID)
+	require.NotEmpty(t, want)
+
+	inst := describeInstance(t, client, instanceID)
+	require.Len(t, inst.NetworkInterfaces, 1)
+	assert.Equal(t, want, aws.ToString(inst.NetworkInterfaces[0].NetworkInterfaceId))
+}
+
+// TestInstanceReflectsAttachedVolume covers BUG3: an attached EBS volume shows up
+// in the instance's BlockDeviceMappings with status attached.
+func TestInstanceReflectsAttachedVolume(t *testing.T) {
+	client, instanceID, _ := launchInstanceInSubnet(t)
+	ctx := context.Background()
+
+	vol, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(10),
+	})
+	require.NoError(t, err)
+	volumeID := aws.ToString(vol.VolumeId)
+
+	_, err = client.AttachVolume(ctx, &ec2.AttachVolumeInput{
+		VolumeId:   aws.String(volumeID),
+		InstanceId: aws.String(instanceID),
+		Device:     aws.String("/dev/sdf"),
+	})
+	require.NoError(t, err)
+
+	inst := describeInstance(t, client, instanceID)
+
+	var found *ec2types.InstanceBlockDeviceMapping
+	for i := range inst.BlockDeviceMappings {
+		if inst.BlockDeviceMappings[i].Ebs != nil &&
+			aws.ToString(inst.BlockDeviceMappings[i].Ebs.VolumeId) == volumeID {
+			found = &inst.BlockDeviceMappings[i]
+		}
+	}
+
+	require.NotNil(t, found, "attached volume must appear in BlockDeviceMappings")
+	assert.Equal(t, "/dev/sdf", aws.ToString(found.DeviceName))
+	assert.Equal(t, ec2types.AttachmentStatusAttached, found.Ebs.Status)
+}
+
+// TestInstanceReflectsElasticIP covers BUG1: associating an EIP to an instance
+// makes DescribeInstances report the EIP's public address, and disassociating
+// clears it.
+func TestInstanceReflectsElasticIP(t *testing.T) {
+	client, instanceID, _ := launchInstanceInSubnet(t)
+	ctx := context.Background()
+
+	addr, err := client.AllocateAddress(ctx, &ec2.AllocateAddressInput{Domain: ec2types.DomainTypeVpc})
+	require.NoError(t, err)
+	publicIP := aws.ToString(addr.PublicIp)
+	require.NotEmpty(t, publicIP)
+
+	assoc, err := client.AssociateAddress(ctx, &ec2.AssociateAddressInput{
+		AllocationId: addr.AllocationId,
+		InstanceId:   aws.String(instanceID),
+	})
+	require.NoError(t, err)
+
+	inst := describeInstance(t, client, instanceID)
+	assert.Equal(t, publicIP, aws.ToString(inst.PublicIpAddress), "instance must report the associated EIP")
+
+	_, err = client.DisassociateAddress(ctx, &ec2.DisassociateAddressInput{
+		AssociationId: assoc.AssociationId,
+	})
+	require.NoError(t, err)
+
+	inst = describeInstance(t, client, instanceID)
+	assert.Empty(t, aws.ToString(inst.PublicIpAddress), "public IP must clear on disassociate")
+}
+
+// TestTerminateCleansUpAttachments covers BUG1 + BUG2 terminate cleanup:
+// terminating an instance detaches its secondary ENI back to available (so it
+// can be deleted and the subnet drained), and disassociates its EIP while
+// leaving the address allocated.
+func TestTerminateCleansUpAttachments(t *testing.T) {
+	client, instanceID, subnetID := launchInstanceInSubnet(t)
+	ctx := context.Background()
+
+	// Secondary ENI attached to the instance.
+	eni, err := client.CreateNetworkInterface(ctx, &ec2.CreateNetworkInterfaceInput{
+		SubnetId: aws.String(subnetID),
+	})
+	require.NoError(t, err)
+	secondaryID := aws.ToString(eni.NetworkInterface.NetworkInterfaceId)
+
+	_, err = client.AttachNetworkInterface(ctx, &ec2.AttachNetworkInterfaceInput{
+		NetworkInterfaceId: aws.String(secondaryID),
+		InstanceId:         aws.String(instanceID),
+		DeviceIndex:        aws.Int32(1),
+	})
+	require.NoError(t, err)
+
+	// EIP associated to the instance.
+	addr, err := client.AllocateAddress(ctx, &ec2.AllocateAddressInput{Domain: ec2types.DomainTypeVpc})
+	require.NoError(t, err)
+	allocationID := aws.ToString(addr.AllocationId)
+
+	_, err = client.AssociateAddress(ctx, &ec2.AssociateAddressInput{
+		AllocationId: addr.AllocationId,
+		InstanceId:   aws.String(instanceID),
+	})
+	require.NoError(t, err)
+
+	_, err = client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+		InstanceIds: []string{instanceID},
+	})
+	require.NoError(t, err)
+
+	// The secondary ENI is detached back to available (not stuck in-use on the
+	// dead instance) — so it can be deleted, which then unwedges DeleteSubnet.
+	desc, err := client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		NetworkInterfaceIds: []string{secondaryID},
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.NetworkInterfaces, 1)
+	assert.Equal(t, ec2types.NetworkInterfaceStatusAvailable, desc.NetworkInterfaces[0].Status)
+	assert.Nil(t, desc.NetworkInterfaces[0].Attachment)
+
+	_, err = client.DeleteNetworkInterface(ctx, &ec2.DeleteNetworkInterfaceInput{
+		NetworkInterfaceId: aws.String(secondaryID),
+	})
+	require.NoError(t, err, "an available secondary ENI must be deletable after terminate")
+
+	_, err = client.DeleteSubnet(ctx, &ec2.DeleteSubnetInput{SubnetId: aws.String(subnetID)})
+	require.NoError(t, err, "subnet delete must no longer be wedged once the ENIs are drained")
+
+	// The EIP is disassociated but still allocated.
+	addrs, err := client.DescribeAddresses(ctx, &ec2.DescribeAddressesInput{
+		AllocationIds: []string{allocationID},
+	})
+	require.NoError(t, err)
+	require.Len(t, addrs.Addresses, 1)
+	assert.Empty(t, aws.ToString(addrs.Addresses[0].AssociationId), "EIP must be disassociated on terminate")
+	assert.Empty(t, aws.ToString(addrs.Addresses[0].InstanceId))
+}
+
+// TestAttachVolumeToTerminatedInstanceStillErrors is a regression guard: the EBS
+// attach state machine must keep rejecting an attach to a terminated instance
+// (IncorrectInstanceState), unaffected by the reflection changes.
+func TestAttachVolumeToTerminatedInstanceStillErrors(t *testing.T) {
+	client, instanceID, _ := launchInstanceInSubnet(t)
+	ctx := context.Background()
+
+	vol, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(10),
+	})
+	require.NoError(t, err)
+
+	_, err = client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+		InstanceIds: []string{instanceID},
+	})
+	require.NoError(t, err)
+
+	_, err = client.AttachVolume(ctx, &ec2.AttachVolumeInput{
+		VolumeId:   vol.VolumeId,
+		InstanceId: aws.String(instanceID),
+		Device:     aws.String("/dev/sdf"),
+	})
+	require.Error(t, err, "attaching to a terminated instance must still fail")
+}


### PR DESCRIPTION
## Summary

DescribeInstances synthesized a single empty-id primary interface from the instance's own scalar fields and reported no block devices or public IP, so cross-resource attachments made against the authoritative stores were invisible. Terminate also left secondary ENIs stuck in-use on a dead instance and left EIPs associated. This fixes both seams: the wire renderer now reads the ENI/volume/EIP stores, and terminate reconciles those attachments.

### BUG2 + BUG4 — Instance NetworkInterfaces reflect the ENI store
`instanceXMLFor` now enumerates the ENI store (via the handler's existing networking reference) for interfaces attached to the instance and renders each as a `networkInterfaceSet` item with its real `eni-` id, MAC, device index, private IP, subnet, status and attachment id — ordered eth0 first. The primary carries its real id (fixing the empty-id BUG4). Falls back to the old synthesized primary when the store models no interface (no-subnet launch / networking not wired).

### BUG3 — Instance BlockDeviceMappings reflect attached volumes
Added `blockDeviceMapping>item` (with an `ebs` child) to `instanceXML`, populated from the volume store for volumes whose `AttachedTo == inst.ID`.

### BUG1 — EIP association reflects on the instance + terminate disassociates
The reported public IP/DNS is now read from the EIP store (store-read approach — no new aws.go wiring, so TestWiringParity is unaffected; the handler already holds a VPC reference). On terminate the instance's EIP is disassociated (not released) via a method added to EC2's existing `Networking` back-ref (wired through the existing `SetNetworking`).

### Terminate cleanup
`ReleaseInstanceNetworkInterfaces` now deletes delete-on-termination (primary) ENIs and detaches non-DOT secondary ENIs back to `available` (instead of deleting only the primary), so a secondary survives the instance and no longer wedges teardown. `TerminateInstances` also disassociates the instance's EIP, leaving it allocated.

## Tests
New real aws-sdk-go-v2 e2e (`server/aws/ec2_attachment_reflection_sdk_test.go`): secondary ENI reflection with device indexes; primary NI id == DescribeNetworkInterfaces; attached-volume block device; EIP associate/disassociate reflection; terminate detaches secondary ENI (deletable, subnet drainable) + disassociates EIP (still allocated); regression guard that EBS attach to a terminated instance still errors.

Gates: build, vet, gofmt, `golangci-lint --new-from-rev` (0 new), go generate + compatgen (zero diff), and the ec2/vpc/topology/ecs/server-aws + TestWiringParity/TestRealWorld suites all green.