### PR TITLE
fix(azure-monitor): deliver action-group webhook receivers on alert breach

### DIFF
--- a/providers/azure/monitor/actiongroups.go
+++ b/providers/azure/monitor/actiongroups.go
@@ -2,6 +2,8 @@ package monitor
 
 import (
 	"context"
+	"io"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -13,6 +15,11 @@ const (
 	receiverSMS           = "sms"
 	receiverAzureFunction = "azureFunction"
 )
+
+// webhookDeliveryTimeout bounds how long a single webhook POST waits for the
+// receiver to respond, so a dead endpoint can't hang an alarm evaluation /
+// PutMetricData indefinitely. It mirrors eventgrid's webhookDeliveryTimeout.
+const webhookDeliveryTimeout = 10 * time.Second
 
 // ActionGroupReceiver is one resolved receiver of an action group. Endpoint is
 // the receiver's address: the email address, webhook URI, phone number, or
@@ -46,16 +53,57 @@ type actionGroupData struct {
 }
 
 // WebhookDeliverer delivers an alert notification to a webhook receiver's URI.
-// It mirrors the AWS ActionPublisher wiring: nil (the default) records the
-// delivery without a network call, while a wired deliverer additionally
-// performs the real HTTP POST so an end-to-end webhook flow can be exercised.
+// New() defaults it to a real-HTTP implementation (httpWebhookDeliverer), so a
+// breach that targets an action group with webhook receivers performs the real
+// POST in production — mirroring how eventgrid.New wires a real httpClient and
+// POSTs to WebHook destinations. SetWebhookDeliverer is a test seam that swaps
+// in a fake so a test can assert delivery without a live receiver.
 type WebhookDeliverer interface {
 	Deliver(ctx context.Context, uri, payload string) error
 }
 
-// SetWebhookDeliverer wires a webhook deliverer so an alert breach that targets
-// an action group with webhook receivers performs the real HTTP POST in
-// addition to recording the delivery. Nil leaves webhook delivery record-only.
+// httpWebhookDeliverer is the production WebhookDeliverer: a best-effort real
+// HTTP POST of the alert payload to a webhook receiver's URI. It mirrors
+// eventgrid.Mock's postWebhook — a bounded http.Client, and errors are surfaced
+// to the caller (deliverWebhook), which swallows them so a breach / PutMetricData
+// never fails because a receiver is unreachable.
+type httpWebhookDeliverer struct {
+	client *http.Client
+}
+
+// newHTTPWebhookDeliverer builds the default deliverer with a bounded client,
+// matching eventgrid.New's http.Client{Timeout: webhookDeliveryTimeout}.
+func newHTTPWebhookDeliverer() *httpWebhookDeliverer {
+	return &httpWebhookDeliverer{client: &http.Client{Timeout: webhookDeliveryTimeout}}
+}
+
+// Deliver POSTs the payload to uri as the action-group webhook body, with the
+// JSON content-type real Azure action-group webhooks carry.
+func (d *httpWebhookDeliverer) Deliver(ctx context.Context, uri, payload string) error {
+	reqCtx, cancel := context.WithTimeout(ctx, webhookDeliveryTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, uri, strings.NewReader(payload))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	return nil
+}
+
+// SetWebhookDeliverer overrides the webhook deliverer. It is a test seam: tests
+// inject a fake to observe delivery. New() already installs a real-HTTP default,
+// so production never calls this. Nil leaves webhook delivery record-only.
 func (m *Mock) SetWebhookDeliverer(d WebhookDeliverer) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -93,8 +141,8 @@ func (m *Mock) ActionGroupDeliveries() []ActionGroupDelivery {
 
 // fireActionGroups delivers an alarm's action groups on a transition into
 // ALARM: each AlarmActions id is resolved against the registered action groups
-// and every receiver is recorded (and, for webhook receivers with a wired
-// deliverer, POSTed). A disabled action group delivers to none of its receivers.
+// and every receiver is recorded (and, for webhook receivers, POSTed by the
+// deliverer). A disabled action group delivers to none of its receivers.
 func (m *Mock) fireActionGroups(alarm *alarmData, newState string, now time.Time) {
 	for _, agID := range alarm.AlarmActions {
 		ag, ok := m.actionGroups.Get(strings.ToLower(agID))
@@ -118,8 +166,9 @@ func (m *Mock) fireActionGroups(alarm *alarmData, newState string, now time.Time
 	}
 }
 
-// deliverWebhook performs the real HTTP POST for a webhook receiver when a
-// deliverer is wired; it is a no-op for non-webhook receivers or when none is.
+// deliverWebhook performs the best-effort HTTP POST for a webhook receiver
+// using the wired deliverer (a real-HTTP one by default from New); it is a
+// no-op for non-webhook receivers, or when a test cleared the deliverer to nil.
 func (m *Mock) deliverWebhook(rcv ActionGroupReceiver, alarm *alarmData, newState string, now time.Time) {
 	if rcv.Type != receiverWebhook || rcv.Endpoint == "" {
 		return

--- a/providers/azure/monitor/monitor.go
+++ b/providers/azure/monitor/monitor.go
@@ -67,13 +67,18 @@ type Mock struct {
 }
 
 // New creates a new Azure Monitor mock with the given configuration options.
+// It installs a real-HTTP webhook deliverer by default so an alert breach that
+// fires an action group with webhook receivers actually POSTs to them in
+// production (mirroring eventgrid.New wiring a real httpClient). Tests may swap
+// it via SetWebhookDeliverer.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		metrics:      make(map[metricKey][]driver.MetricDatum),
-		alarms:       memstore.New[*alarmData](),
-		channels:     memstore.New[*driver.NotificationChannelInfo](),
-		actionGroups: memstore.New[*actionGroupData](),
-		opts:         opts,
+		metrics:          make(map[metricKey][]driver.MetricDatum),
+		alarms:           memstore.New[*alarmData](),
+		channels:         memstore.New[*driver.NotificationChannelInfo](),
+		actionGroups:     memstore.New[*actionGroupData](),
+		webhookDeliverer: newHTTPWebhookDeliverer(),
+		opts:             opts,
 	}
 }
 

--- a/providers/wiring_parity_test.go
+++ b/providers/wiring_parity_test.go
@@ -108,11 +108,12 @@ var azureExemptions = []exemption{
 	{
 		field:  "Monitor",
 		method: "SetWebhookDeliverer",
-		reason: "SetWebhookDeliverer is a test-injection seam for the metric-alert " +
-			"action-group webhook path: the Monitor uses a default real-HTTP " +
-			"deliverer internally, and tests inject a fake one to assert delivery. " +
-			"Production New() deliberately does not override the default deliverer, " +
-			"so this setter is intentionally not wired.",
+		reason: "monitor.New defaults webhookDeliverer to a real-HTTP deliverer " +
+			"(mirroring how eventgrid.New wires a real httpClient), so an alert " +
+			"breach that fires an action group with webhook receivers POSTs to " +
+			"them in production without any azure.go wiring. SetWebhookDeliverer " +
+			"is only a test override that swaps in a fake to assert delivery, so " +
+			"New deliberately does not call this setter.",
 	},
 }
 

--- a/server/azure/monitor/action_group_firing_test.go
+++ b/server/azure/monitor/action_group_firing_test.go
@@ -2,8 +2,10 @@ package monitor_test
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -205,6 +207,125 @@ func pushCPU(t *testing.T, mon *azmonitor.Mock, clock *config.FakeClock, resourc
 		Dimensions: map[string]string{"resourceId": resourceURI},
 	}}); err != nil {
 		t.Fatalf("PutMetricData: %v", err)
+	}
+}
+
+// createWebhookAlert creates, over the real armmonitor SDK, an action group with
+// a single webhook receiver at webhookURL and a Percentage CPU alert (threshold
+// 50) scoped to vm1 that links it. It returns the action group id.
+func createWebhookAlert(t *testing.T, ts *httptest.Server, webhookURL string) string {
+	t.Helper()
+
+	ctx := context.Background()
+
+	agClient, err := armmonitor.NewActionGroupsClient("sub-1", fakeCred{}, armClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := agClient.CreateOrUpdate(ctx, "rg-1", "ops-ag", armmonitor.ActionGroupResource{
+		Location: to.Ptr("global"),
+		Properties: &armmonitor.ActionGroup{
+			GroupShortName: to.Ptr("ops"),
+			Enabled:        to.Ptr(true),
+			WebhookReceivers: []*armmonitor.WebhookReceiver{
+				{Name: to.Ptr("hook"), ServiceURI: to.Ptr(webhookURL)},
+			},
+		},
+	}, nil); err != nil {
+		t.Fatalf("action group CreateOrUpdate: %v", err)
+	}
+
+	const agID = "/subscriptions/sub-1/resourceGroups/rg-1/providers/microsoft.insights/actionGroups/ops-ag"
+
+	alertClient, err := armmonitor.NewMetricAlertsClient("sub-1", fakeCred{}, armClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := alertClient.CreateOrUpdate(ctx, "rg-1", "cpu-hot", cpuAlert(vm1URI, agID, 50), nil); err != nil {
+		t.Fatalf("metric alert CreateOrUpdate: %v", err)
+	}
+
+	return agID
+}
+
+// TestSDKAlarmBreachDefaultDelivererPOSTsWebhook is the load-bearing regression
+// for the "webhook never delivered in production" finding: with NO deliverer
+// injected, the real-HTTP default installed by monitor.New must POST the alert
+// payload to an action group's webhook receiver on an OK->ALARM breach. The
+// action group and the alert are created through the real armmonitor SDK; only
+// the metric datapoint is injected via the driver, because Azure custom-metric
+// ingestion has no ARM wire path (unlike CloudWatch PutMetricData).
+func TestSDKAlarmBreachDefaultDelivererPOSTsWebhook(t *testing.T) {
+	clock := config.NewFakeClock(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	cloudP := cloudemu.NewAzure(config.WithClock(clock))
+	// Deliberately no SetWebhookDeliverer: the production default must deliver.
+
+	srv := azureserver.New(azureserver.Drivers{Monitor: cloudP.Monitor})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	var (
+		hits int32
+		body atomic.Value
+	)
+
+	webhookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		body.Store(string(b))
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(webhookSrv.Close)
+
+	createWebhookAlert(t, ts, webhookSrv.URL)
+
+	// Delivery is synchronous inside PutMetricData -> fireActionGroups, so the
+	// receiver is hit before PutMetricData returns.
+	pushCPU(t, cloudP.Monitor, clock, vm1URI, 95)
+
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("webhook receiver hits = %d, want 1 (default deliverer did not POST)", got)
+	}
+
+	payload, _ := body.Load().(string)
+	if !strings.Contains(payload, `"alertName":"cpu-hot"`) || !strings.Contains(payload, `"newState":"ALARM"`) {
+		t.Fatalf("webhook payload = %q, want alertName cpu-hot / newState ALARM", payload)
+	}
+}
+
+// TestSDKAlarmBreachUnreachableWebhookBestEffort covers the best-effort
+// contract: an unreachable webhook endpoint must not fail the breach.
+// PutMetricData returns no error, the alarm still transitions to ALARM, and the
+// delivery is still recorded even though the POST could not complete.
+func TestSDKAlarmBreachUnreachableWebhookBestEffort(t *testing.T) {
+	clock := config.NewFakeClock(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	cloudP := cloudemu.NewAzure(config.WithClock(clock))
+
+	srv := azureserver.New(azureserver.Drivers{Monitor: cloudP.Monitor})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	// Close the receiver immediately so its URL refuses connections — a fast,
+	// deterministic stand-in for an unreachable webhook endpoint.
+	dead := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	deadURL := dead.URL
+	dead.Close()
+
+	createWebhookAlert(t, ts, deadURL)
+
+	// pushCPU fatals if PutMetricData returns an error, so a surfaced delivery
+	// error would fail here — the breach must succeed regardless.
+	pushCPU(t, cloudP.Monitor, clock, vm1URI, 95)
+
+	if state := alarmState(t, cloudP.Monitor, "cpu-hot"); state != "ALARM" {
+		t.Fatalf("alarm state = %s, want ALARM (breach must succeed despite a dead webhook)", state)
+	}
+
+	deliveries := cloudP.Monitor.ActionGroupDeliveries()
+	if len(deliveries) != 1 || deliveries[0].ReceiverType != "webhook" {
+		t.Fatalf("deliveries = %+v, want 1 recorded webhook delivery", deliveries)
 	}
 }
 

--- a/server/azure/monitor/metric_alerts.go
+++ b/server/azure/monitor/metric_alerts.go
@@ -82,8 +82,9 @@ func singleScope(props map[string]any) (string, bool) {
 // actionGroupIDs extracts properties.actions[].actionGroupId — the action
 // group resource ids linked to a metric alert — and stores them on the alarm
 // so DescribeAlarms echoes the linkage back (mirroring the AWS CloudWatch
-// alarm's AlarmActions field). Actual delivery to the action group on a breach
-// is not simulated. Entries with no actionGroupId are skipped rather than
+// alarm's AlarmActions field). On a breach the alarm resolves these ids to the
+// registered action groups and delivers to their receivers (webhook receivers
+// are POSTed for real). Entries with no actionGroupId are skipped rather than
 // producing an empty AlarmActions entry.
 func actionGroupIDs(props map[string]any) []string {
 	actions, ok := props["actions"].([]any)


### PR DESCRIPTION
## Summary

Azure Monitor metric-alert -> action-group -> **webhook** receivers were never actually POSTed for a real SDK/Terraform user. A breach evaluated, transitioned OK->ALARM, fired the action group, and recorded deliveries (`ActionGroupDeliveries()`), but the HTTP webhook was never delivered because `monitor.New()` left `webhookDeliverer` nil and `SetWebhookDeliverer` was only ever called from a test. The whole action-group firing chain had zero observable effect in production.

## Fix

- `providers/azure/monitor/monitor.go` `New()` now defaults `webhookDeliverer` to a real-HTTP implementation (`httpWebhookDeliverer`), mirroring how `eventgrid.New` wires a real `http.Client` and POSTs to WebHook destinations. Delivery is best-effort: errors (unreachable endpoint, non-2xx) are swallowed by `deliverWebhook`, so a breach / `PutMetricData` never fails because a receiver is down. The POST carries the alert payload the recorder already assembles, with a JSON content-type.
- `SetWebhookDeliverer` stays a test-override seam (tests inject a fake). Defaulting in `New` is the correct locus (matching EventGrid); no `azure.go` setter call is added.
- Fixed the stale comments in `actiongroups.go` (nil-deliverer rationale) and `server/azure/monitor/metric_alerts.go` ("delivery ... is not simulated" — it is now).
- Corrected the `wiring_parity_test.go` Monitor/`SetWebhookDeliverer` exemption reason to accurately state the default-in-`New` design; the exemption remains valid because `New` still doesn't call the setter.

## Tests

- `TestSDKAlarmBreachDefaultDelivererPOSTsWebhook`: action group (webhook receiver -> local test server) + metric alert created via the real `armmonitor` SDK; breach with **no injected deliverer** asserts the local server received a POST carrying the alert payload — proving the production default delivers. (Azure custom-metric ingestion has no ARM wire path, so only the datapoint is injected via the driver.)
- `TestSDKAlarmBreachUnreachableWebhookBestEffort`: unreachable webhook endpoint -> breach still succeeds (no error surfaced), alarm reaches ALARM, delivery still recorded.
- Existing `TestSDKAlarmBreachFiresActionGroup` still passes (its injected fake deliverer overrides the default).