### PR TITLE
feat(aws-ec2): AssociateIamInstanceProfile/Describe/Replace/Disassociate for running instances

### DIFF
--- a/docs/coverage/aws/ec2.md
+++ b/docs/coverage/aws/ec2.md
@@ -94,6 +94,17 @@ ConsoleReader is an optional capability a Compute implementation may provide
 | --- | --- |
 | `GetConsoleOutput` |  |
 
+### IamInstanceProfileAssociator
+
+IamInstanceProfileAssociator is an optional AWS-only capability for attaching
+
+| Operation | Description |
+| --- | --- |
+| `AssociateIamInstanceProfile` |  |
+| `DescribeIamInstanceProfileAssociations` |  |
+| `DisassociateIamInstanceProfile` |  |
+| `ReplaceIamInstanceProfileAssociation` |  |
+
 ### ImageAttributeModifier
 
 ImageAttributeModifier is an optional AWS-only capability for the EC2 AMI

--- a/docs/coverage/azure/virtualmachines.md
+++ b/docs/coverage/azure/virtualmachines.md
@@ -94,6 +94,17 @@ ConsoleReader is an optional capability a Compute implementation may provide
 | --- | --- |
 | `GetConsoleOutput` |  |
 
+### IamInstanceProfileAssociator
+
+IamInstanceProfileAssociator is an optional AWS-only capability for attaching
+
+| Operation | Description |
+| --- | --- |
+| `AssociateIamInstanceProfile` |  |
+| `DescribeIamInstanceProfileAssociations` |  |
+| `DisassociateIamInstanceProfile` |  |
+| `ReplaceIamInstanceProfileAssociation` |  |
+
 ### ImageAttributeModifier
 
 ImageAttributeModifier is an optional AWS-only capability for the EC2 AMI

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -2082,6 +2082,24 @@
         ]
       },
       {
+        "name": "IamInstanceProfileAssociator",
+        "doc": "IamInstanceProfileAssociator is an optional AWS-only capability for attaching",
+        "operations": [
+          {
+            "name": "AssociateIamInstanceProfile"
+          },
+          {
+            "name": "DescribeIamInstanceProfileAssociations"
+          },
+          {
+            "name": "DisassociateIamInstanceProfile"
+          },
+          {
+            "name": "ReplaceIamInstanceProfileAssociation"
+          }
+        ]
+      },
+      {
         "name": "ImageAttributeModifier",
         "doc": "ImageAttributeModifier is an optional AWS-only capability for the EC2 AMI",
         "operations": [

--- a/docs/coverage/gcp/gce.md
+++ b/docs/coverage/gcp/gce.md
@@ -94,6 +94,17 @@ ConsoleReader is an optional capability a Compute implementation may provide
 | --- | --- |
 | `GetConsoleOutput` |  |
 
+### IamInstanceProfileAssociator
+
+IamInstanceProfileAssociator is an optional AWS-only capability for attaching
+
+| Operation | Description |
+| --- | --- |
+| `AssociateIamInstanceProfile` |  |
+| `DescribeIamInstanceProfileAssociations` |  |
+| `DisassociateIamInstanceProfile` |  |
+| `ReplaceIamInstanceProfileAssociation` |  |
+
 ### ImageAttributeModifier
 
 ImageAttributeModifier is an optional AWS-only capability for the EC2 AMI

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -270,15 +270,20 @@ type Mock struct {
 	// placementGroups holds EC2 placement groups keyed by group name. Placement
 	// groups are AWS-specific, so this store backs the PlacementGroups capability.
 	placementGroups *memstore.Store[*driver.PlacementGroup]
-	pgCounter       atomic.Int64
-	sm              *statemachine.Machine
-	opts            *config.Options
-	ipCounter       atomic.Int64
-	volCounter      atomic.Int64
-	snapCounter     atomic.Int64
-	amiCounter      atomic.Int64
-	keyCounter      atomic.Int64
-	monitoring      mondriver.Monitoring
+	// iamProfileAssociations holds IAM instance-profile associations keyed by
+	// association id (iip-assoc-...). Each launched-with-a-profile or post-launch
+	// AssociateIamInstanceProfile call records one here, backing the
+	// IamInstanceProfileAssociator capability. AWS-specific.
+	iamProfileAssociations *memstore.Store[*iamProfileAssociation]
+	pgCounter              atomic.Int64
+	sm                     *statemachine.Machine
+	opts                   *config.Options
+	ipCounter              atomic.Int64
+	volCounter             atomic.Int64
+	snapCounter            atomic.Int64
+	amiCounter             atomic.Int64
+	keyCounter             atomic.Int64
+	monitoring             mondriver.Monitoring
 	// subnetResolver derives an instance's VPC from its subnet at launch, so
 	// instances created with a --subnet-id carry the VPCID that connectivity
 	// analysis and VPC teardown depend on. nil until wired by the provider.
@@ -381,19 +386,20 @@ func (m *Mock) emitLifecycleMetrics(ctx context.Context, instanceID string, valu
 // New creates a new EC2 mock.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		instances:        memstore.New[*instanceData](),
-		asgs:             memstore.New[*asgData](),
-		spotRequests:     memstore.New[*driver.SpotInstanceRequest](),
-		templates:        memstore.New[*driver.LaunchTemplate](),
-		templateVersions: memstore.New[*driver.LaunchTemplateVersion](),
-		volumes:          memstore.New[*driver.VolumeInfo](),
-		volSettle:        memstore.New[settle.Window](),
-		snapshots:        memstore.New[*driver.SnapshotInfo](),
-		images:           memstore.New[*driver.ImageInfo](),
-		keyPairs:         memstore.New[*driver.KeyPairInfo](),
-		placementGroups:  memstore.New[*driver.PlacementGroup](),
-		sm:               statemachine.New(compute.VMTransitions()),
-		opts:             opts,
+		instances:              memstore.New[*instanceData](),
+		asgs:                   memstore.New[*asgData](),
+		spotRequests:           memstore.New[*driver.SpotInstanceRequest](),
+		templates:              memstore.New[*driver.LaunchTemplate](),
+		templateVersions:       memstore.New[*driver.LaunchTemplateVersion](),
+		volumes:                memstore.New[*driver.VolumeInfo](),
+		volSettle:              memstore.New[settle.Window](),
+		snapshots:              memstore.New[*driver.SnapshotInfo](),
+		images:                 memstore.New[*driver.ImageInfo](),
+		keyPairs:               memstore.New[*driver.KeyPairInfo](),
+		placementGroups:        memstore.New[*driver.PlacementGroup](),
+		iamProfileAssociations: memstore.New[*iamProfileAssociation](),
+		sm:                     statemachine.New(compute.VMTransitions()),
+		opts:                   opts,
 
 		managedResourceVisibility: visibilityVisible,
 		clientTokens:              make(map[string][]string),
@@ -682,6 +688,13 @@ func (m *Mock) launchInstances(ctx context.Context, cfg driver.InstanceConfig, c
 		results = append(results, toInstance(inst, hidden, m.opts.Clock.Now()))
 		created = append(created, inst)
 
+		// Record a backing profile association so DescribeIamInstanceProfileAssociations
+		// lists a launched-with-a-profile instance, matching real EC2 (each instance
+		// gets its own association id).
+		if iamProfile != nil {
+			m.recordProfileAssociation(id, iamProfile)
+		}
+
 		// Managed (service-owned) instances are hidden from Describe, so
 		// emitting instance-dimensioned CloudWatch metrics for them would leak
 		// their existence. Suppress metrics for managed instances.
@@ -815,6 +828,9 @@ func (m *Mock) rollbackInstances(ctx context.Context, created []*instanceData) {
 		// Drop the primary ENI this instance may have materialized, so a
 		// rolled-back launch leaves no orphaned interface holding its subnet.
 		m.releasePrimaryENI(ctx, inst.ID)
+		// Drop any backing profile association so a rolled-back launch leaves no
+		// orphaned association behind.
+		m.deleteAssociationsForInstance(inst.ID)
 	}
 }
 
@@ -911,6 +927,13 @@ func (m *Mock) TerminateInstances(ctx context.Context, instanceIDs []string) err
 	// Every attached EBS volume must be released, otherwise it stays in-use
 	// against a dead instance forever and can never be deleted (VolumeInUse).
 	m.detachTerminatedVolumes(instanceIDs)
+
+	// A terminated instance no longer holds its IAM instance profile, so drop any
+	// backing association (real EC2 removes it, and the id stops appearing in
+	// DescribeIamInstanceProfileAssociations).
+	for _, id := range instanceIDs {
+		m.deleteAssociationsForInstance(id)
+	}
 
 	// Release each instance's primary (eth0) ENI, matching real EC2's
 	// delete-on-termination default. Until this happens the interface keeps

--- a/providers/aws/ec2/instance_profile_association.go
+++ b/providers/aws/ec2/instance_profile_association.go
@@ -1,0 +1,251 @@
+package ec2
+
+import (
+	"context"
+	"sort"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+// iamAssocPrefix is the AWS association-id prefix for an IAM instance-profile
+// association (iip-assoc-...).
+const iamAssocPrefix = "iip-assoc-"
+
+// IAM instance-profile association lifecycle states. An association is stored in
+// its steady "associated" state; the transient "associating"/"disassociating"
+// states are reported only on the action that triggers the transition, matching
+// real EC2.
+const (
+	assocStateAssociating    = "associating"
+	assocStateAssociated     = "associated"
+	assocStateDisassociating = "disassociating"
+)
+
+// iamProfileAssociation is one association of an IAM instance profile with an
+// instance, keyed by ID in m.iamProfileAssociations. Fields are exported so the
+// association survives the JSON snapshot/restore round-trip.
+type iamProfileAssociation struct {
+	ID         string                     `json:"id"`
+	InstanceID string                     `json:"instanceId"`
+	Profile    *driver.IamInstanceProfile `json:"iamInstanceProfile,omitempty"`
+	State      string                     `json:"state,omitempty"`
+}
+
+// toDriver renders the association in the driver shape, reporting the supplied
+// state (which may be a transient action-state that differs from the stored one).
+func (a *iamProfileAssociation) toDriver(state string) *driver.IamInstanceProfileAssociation {
+	return &driver.IamInstanceProfileAssociation{
+		AssociationID: a.ID,
+		InstanceID:    a.InstanceID,
+		Profile:       cloneProfile(a.Profile),
+		State:         state,
+	}
+}
+
+// cloneProfile returns a defensive copy so a stored association never shares its
+// profile pointer with a caller or with an instance's stored profile.
+func cloneProfile(p *driver.IamInstanceProfile) *driver.IamInstanceProfile {
+	if p == nil {
+		return nil
+	}
+
+	c := *p
+
+	return &c
+}
+
+// AssociateIamInstanceProfile attaches an IAM instance profile to an already
+// running (or stopped) instance, the post-launch counterpart to
+// RunInstances{IamInstanceProfile}. The profile reference is resolved exactly as
+// launch-time does; an instance that already has an association is rejected
+// (real EC2 answers IncorrectState).
+func (m *Mock) AssociateIamInstanceProfile(
+	ctx context.Context, instanceID, profileARN, profileName string,
+) (*driver.IamInstanceProfileAssociation, error) {
+	inst, ok := m.instances.Get(instanceID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
+	}
+
+	profile, err := m.resolveProfileRef(ctx, profileARN, profileName)
+	if err != nil {
+		return nil, err
+	}
+
+	if profile == nil {
+		return nil, cerrors.New(cerrors.InvalidArgument,
+			"IamInstanceProfile.Arn or IamInstanceProfile.Name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.findAssociationByInstanceLocked(instanceID) != nil {
+		return nil, cerrors.Newf(cerrors.FailedPrecondition,
+			"There is an existing association for instance %s", instanceID)
+	}
+
+	assoc := &iamProfileAssociation{
+		ID:         idgen.GenerateID(iamAssocPrefix),
+		InstanceID: instanceID,
+		Profile:    cloneProfile(profile),
+		State:      assocStateAssociated,
+	}
+	m.iamProfileAssociations.Set(assoc.ID, assoc)
+	m.setInstanceProfile(inst, profile)
+
+	return assoc.toDriver(assocStateAssociating), nil
+}
+
+// DescribeIamInstanceProfileAssociations lists associations matching the supplied
+// association-id / instance-id / state filters (all optional), sorted by
+// association id so pagination is stable.
+func (m *Mock) DescribeIamInstanceProfileAssociations(
+	_ context.Context, in driver.DescribeIamInstanceProfileAssociationsInput,
+) ([]driver.IamInstanceProfileAssociation, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	all := m.iamProfileAssociations.All()
+	out := make([]driver.IamInstanceProfileAssociation, 0, len(all))
+
+	for _, a := range all {
+		if matchAssociation(a, in) {
+			out = append(out, *a.toDriver(a.State))
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].AssociationID < out[j].AssociationID })
+
+	return out, nil
+}
+
+// ReplaceIamInstanceProfileAssociation swaps the profile on an existing
+// association, reflecting the new profile on the instance. The association keeps
+// its id.
+func (m *Mock) ReplaceIamInstanceProfileAssociation(
+	ctx context.Context, associationID, profileARN, profileName string,
+) (*driver.IamInstanceProfileAssociation, error) {
+	profile, err := m.resolveProfileRef(ctx, profileARN, profileName)
+	if err != nil {
+		return nil, err
+	}
+
+	if profile == nil {
+		return nil, cerrors.New(cerrors.InvalidArgument,
+			"IamInstanceProfile.Arn or IamInstanceProfile.Name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	assoc, ok := m.iamProfileAssociations.Get(associationID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "association %q not found", associationID)
+	}
+
+	assoc.Profile = cloneProfile(profile)
+	m.iamProfileAssociations.Set(assoc.ID, assoc)
+
+	if inst, found := m.instances.Get(assoc.InstanceID); found {
+		m.setInstanceProfile(inst, profile)
+	}
+
+	return assoc.toDriver(assocStateAssociating), nil
+}
+
+// DisassociateIamInstanceProfile removes an association, clearing the instance's
+// profile.
+func (m *Mock) DisassociateIamInstanceProfile(
+	_ context.Context, associationID string,
+) (*driver.IamInstanceProfileAssociation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	assoc, ok := m.iamProfileAssociations.Get(associationID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "association %q not found", associationID)
+	}
+
+	m.iamProfileAssociations.Delete(associationID)
+
+	if inst, found := m.instances.Get(assoc.InstanceID); found {
+		m.setInstanceProfile(inst, nil)
+	}
+
+	return assoc.toDriver(assocStateDisassociating), nil
+}
+
+// recordProfileAssociation stores a backing association for an instance launched
+// with an IamInstanceProfile, so DescribeIamInstanceProfileAssociations lists it
+// (matching real EC2). The instance's own profile field is already set at launch.
+func (m *Mock) recordProfileAssociation(instanceID string, profile *driver.IamInstanceProfile) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	assoc := &iamProfileAssociation{
+		ID:         idgen.GenerateID(iamAssocPrefix),
+		InstanceID: instanceID,
+		Profile:    cloneProfile(profile),
+		State:      assocStateAssociated,
+	}
+	m.iamProfileAssociations.Set(assoc.ID, assoc)
+}
+
+// deleteAssociationsForInstance removes every association bound to an instance,
+// used when the instance is terminated or a launch is rolled back.
+func (m *Mock) deleteAssociationsForInstance(instanceID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for id, a := range m.iamProfileAssociations.All() {
+		if a.InstanceID == instanceID {
+			m.iamProfileAssociations.Delete(id)
+		}
+	}
+}
+
+// findAssociationByInstanceLocked returns the instance's current association, or
+// nil. The caller must hold m.mu.
+func (m *Mock) findAssociationByInstanceLocked(instanceID string) *iamProfileAssociation {
+	for _, a := range m.iamProfileAssociations.All() {
+		if a.InstanceID == instanceID {
+			return a
+		}
+	}
+
+	return nil
+}
+
+// setInstanceProfile reflects a profile (or nil to clear) on the stored instance
+// under its own lock, so DescribeInstances renders the current association.
+func (*Mock) setInstanceProfile(inst *instanceData, profile *driver.IamInstanceProfile) {
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+
+	inst.iamInstanceProfile = cloneProfile(profile)
+}
+
+// matchAssociation reports whether a satisfies every populated filter in in.
+func matchAssociation(a *iamProfileAssociation, in driver.DescribeIamInstanceProfileAssociationsInput) bool {
+	return containsOrEmpty(in.AssociationIDs, a.ID) &&
+		containsOrEmpty(in.InstanceIDs, a.InstanceID) &&
+		containsOrEmpty(in.States, a.State)
+}
+
+// containsOrEmpty reports whether want is empty (no filter) or contains value.
+func containsOrEmpty(want []string, value string) bool {
+	if len(want) == 0 {
+		return true
+	}
+
+	for _, w := range want {
+		if w == value {
+			return true
+		}
+	}
+
+	return false
+}

--- a/providers/aws/ec2/instance_profile_association_test.go
+++ b/providers/aws/ec2/instance_profile_association_test.go
@@ -1,0 +1,207 @@
+package ec2
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// fakeProfileResolver is an in-memory InstanceProfileResolver keyed by profile
+// name, so the association tests resolve a reference to a canonical ARN + id
+// exactly as the real IAM mock does.
+type fakeProfileResolver struct {
+	profiles map[string]*iamdriver.InstanceProfileInfo
+}
+
+func (f *fakeProfileResolver) GetInstanceProfile(_ context.Context, name string) (*iamdriver.InstanceProfileInfo, error) {
+	if p, ok := f.profiles[name]; ok {
+		return p, nil
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "instance profile %q not found", name)
+}
+
+func newMockWithProfiles(names ...string) *Mock {
+	m := newTestMock()
+	res := &fakeProfileResolver{profiles: make(map[string]*iamdriver.InstanceProfileInfo, len(names))}
+
+	for _, n := range names {
+		res.profiles[n] = &iamdriver.InstanceProfileInfo{
+			Name: n,
+			ID:   "AIPA" + n,
+			ARN:  "arn:aws:iam::123456789012:instance-profile/" + n,
+		}
+	}
+
+	m.SetInstanceProfileResolver(res)
+
+	return m
+}
+
+func TestAssociateIamInstanceProfileProvider(t *testing.T) {
+	ctx := context.Background()
+	m := newMockWithProfiles("web")
+
+	insts, err := m.RunInstances(ctx, defaultConfig(), 1)
+	requireNoError(t, err)
+
+	id := insts[0].ID
+
+	assoc, err := m.AssociateIamInstanceProfile(ctx, id, "", "web")
+	requireNoError(t, err)
+	assertEqual(t, "associating", assoc.State)
+	assertEqual(t, "arn:aws:iam::123456789012:instance-profile/web", assoc.Profile.ARN)
+	assertEqual(t, "AIPAweb", assoc.Profile.ID)
+	assertTrue(t, assoc.AssociationID != "", "association id should be set")
+
+	// The instance now reflects the profile.
+	got, err := m.DescribeInstances(ctx, []string{id}, nil, driver.DescribeInstancesOptions{})
+	requireNoError(t, err)
+	assertTrue(t, got[0].IamInstanceProfile != nil, "instance should reflect the profile")
+	assertEqual(t, "AIPAweb", got[0].IamInstanceProfile.ID)
+
+	// It is listed as associated.
+	list, err := m.DescribeIamInstanceProfileAssociations(ctx,
+		driver.DescribeIamInstanceProfileAssociationsInput{InstanceIDs: []string{id}})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(list))
+	assertEqual(t, "associated", list[0].State)
+	assertEqual(t, id, list[0].InstanceID)
+}
+
+func TestAssociateIamInstanceProfileAlreadyAssociatedProvider(t *testing.T) {
+	ctx := context.Background()
+	m := newMockWithProfiles("a", "b")
+
+	insts, err := m.RunInstances(ctx, defaultConfig(), 1)
+	requireNoError(t, err)
+
+	_, err = m.AssociateIamInstanceProfile(ctx, insts[0].ID, "", "a")
+	requireNoError(t, err)
+
+	_, err = m.AssociateIamInstanceProfile(ctx, insts[0].ID, "", "b")
+	assertError(t, err, true)
+	assertTrue(t, cerrors.IsFailedPrecondition(err), "already-associated should be FailedPrecondition")
+}
+
+func TestReplaceIamInstanceProfileAssociationProvider(t *testing.T) {
+	ctx := context.Background()
+	m := newMockWithProfiles("old", "new")
+
+	insts, err := m.RunInstances(ctx, defaultConfig(), 1)
+	requireNoError(t, err)
+
+	assoc, err := m.AssociateIamInstanceProfile(ctx, insts[0].ID, "", "old")
+	requireNoError(t, err)
+
+	replaced, err := m.ReplaceIamInstanceProfileAssociation(ctx, assoc.AssociationID, "", "new")
+	requireNoError(t, err)
+	assertEqual(t, assoc.AssociationID, replaced.AssociationID)
+	assertEqual(t, "AIPAnew", replaced.Profile.ID)
+
+	got, err := m.DescribeInstances(ctx, []string{insts[0].ID}, nil, driver.DescribeInstancesOptions{})
+	requireNoError(t, err)
+	assertEqual(t, "AIPAnew", got[0].IamInstanceProfile.ID)
+}
+
+func TestDisassociateIamInstanceProfileProvider(t *testing.T) {
+	ctx := context.Background()
+	m := newMockWithProfiles("web")
+
+	insts, err := m.RunInstances(ctx, defaultConfig(), 1)
+	requireNoError(t, err)
+
+	assoc, err := m.AssociateIamInstanceProfile(ctx, insts[0].ID, "", "web")
+	requireNoError(t, err)
+
+	dis, err := m.DisassociateIamInstanceProfile(ctx, assoc.AssociationID)
+	requireNoError(t, err)
+	assertEqual(t, "disassociating", dis.State)
+
+	got, err := m.DescribeInstances(ctx, []string{insts[0].ID}, nil, driver.DescribeInstancesOptions{})
+	requireNoError(t, err)
+	assertTrue(t, got[0].IamInstanceProfile == nil, "profile should be cleared after disassociate")
+
+	list, err := m.DescribeIamInstanceProfileAssociations(ctx,
+		driver.DescribeIamInstanceProfileAssociationsInput{})
+	requireNoError(t, err)
+	assertEqual(t, 0, len(list))
+}
+
+func TestAssociateIamInstanceProfileMissingInstanceProvider(t *testing.T) {
+	ctx := context.Background()
+	m := newMockWithProfiles("web")
+
+	_, err := m.AssociateIamInstanceProfile(ctx, "i-missing", "", "web")
+	assertError(t, err, true)
+	assertTrue(t, cerrors.IsNotFound(err), "missing instance should be NotFound")
+}
+
+func TestAssociateIamInstanceProfileInvalidProfileProvider(t *testing.T) {
+	ctx := context.Background()
+	m := newMockWithProfiles("web")
+
+	insts, err := m.RunInstances(ctx, defaultConfig(), 1)
+	requireNoError(t, err)
+
+	_, err = m.AssociateIamInstanceProfile(ctx, insts[0].ID, "", "nope")
+	assertError(t, err, true)
+	assertTrue(t, cerrors.IsInvalidArgument(err), "unresolvable profile should be InvalidArgument")
+}
+
+// TestLaunchTimeProfileRecordsAssociation confirms an instance launched WITH a
+// profile also gets a backing association that DescribeIamInstanceProfileAssociations
+// lists, matching real EC2.
+func TestLaunchTimeProfileRecordsAssociation(t *testing.T) {
+	ctx := context.Background()
+	m := newMockWithProfiles("web")
+
+	cfg := defaultConfig()
+	cfg.IamInstanceProfileName = "web"
+
+	insts, err := m.RunInstances(ctx, cfg, 2)
+	requireNoError(t, err)
+
+	list, err := m.DescribeIamInstanceProfileAssociations(ctx,
+		driver.DescribeIamInstanceProfileAssociationsInput{})
+	requireNoError(t, err)
+	assertEqual(t, 2, len(list)) // one per launched instance
+
+	// Terminating an instance removes its association.
+	requireNoError(t, m.TerminateInstances(ctx, []string{insts[0].ID}))
+
+	after, err := m.DescribeIamInstanceProfileAssociations(ctx,
+		driver.DescribeIamInstanceProfileAssociationsInput{})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(after))
+	assertEqual(t, insts[1].ID, after[0].InstanceID)
+}
+
+// TestProfileAssociationSnapshotRoundTrip confirms associations survive a
+// Snapshot/Restore cycle.
+func TestProfileAssociationSnapshotRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	m := newMockWithProfiles("web")
+
+	insts, err := m.RunInstances(ctx, defaultConfig(), 1)
+	requireNoError(t, err)
+
+	_, err = m.AssociateIamInstanceProfile(ctx, insts[0].ID, "", "web")
+	requireNoError(t, err)
+
+	data, err := m.Snapshot(ctx, false)
+	requireNoError(t, err)
+
+	restored := newMockWithProfiles("web")
+	requireNoError(t, restored.Restore(ctx, data))
+
+	list, err := restored.DescribeIamInstanceProfileAssociations(ctx,
+		driver.DescribeIamInstanceProfileAssociationsInput{})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(list))
+	assertEqual(t, insts[0].ID, list[0].InstanceID)
+	assertEqual(t, "AIPAweb", list[0].Profile.ID)
+}

--- a/providers/aws/ec2/instance_profile_resolver.go
+++ b/providers/aws/ec2/instance_profile_resolver.go
@@ -35,23 +35,32 @@ func (m *Mock) SetInstanceProfileResolver(r InstanceProfileResolver) {
 // answers InvalidParameterValue rather than launching the instance with a
 // dangling/empty profile association.
 func (m *Mock) resolveInstanceProfile(ctx context.Context, cfg *driver.InstanceConfig) (*driver.IamInstanceProfile, error) {
-	name := cfg.IamInstanceProfileName
-	if name == "" {
-		name = instanceProfileNameFromARN(cfg.IamInstanceProfileARN)
+	return m.resolveProfileRef(ctx, cfg.IamInstanceProfileARN, cfg.IamInstanceProfileName)
+}
+
+// resolveProfileRef turns an IamInstanceProfile reference (arn and/or name) into
+// the resolved association (canonical ARN + ID). It is the shared core of
+// launch-time resolution and the post-launch Associate/Replace actions, so all
+// paths reject an unresolvable reference identically. It returns nil, nil when
+// neither arn nor name is supplied.
+func (m *Mock) resolveProfileRef(ctx context.Context, arn, name string) (*driver.IamInstanceProfile, error) {
+	lookup := name
+	if lookup == "" {
+		lookup = instanceProfileNameFromARN(arn)
 	}
 
-	if name == "" && cfg.IamInstanceProfileARN == "" {
+	if lookup == "" && arn == "" {
 		return nil, nil //nolint:nilnil // no profile referenced is not an error
 	}
 
-	if m.instanceProfileResolver == nil || name == "" {
-		return &driver.IamInstanceProfile{ARN: cfg.IamInstanceProfileARN}, nil
+	if m.instanceProfileResolver == nil || lookup == "" {
+		return &driver.IamInstanceProfile{ARN: arn}, nil
 	}
 
-	info, err := m.instanceProfileResolver.GetInstanceProfile(ctx, name)
+	info, err := m.instanceProfileResolver.GetInstanceProfile(ctx, lookup)
 	if err != nil {
 		if cerrors.IsNotFound(err) {
-			return nil, invalidInstanceProfileError(cfg)
+			return nil, invalidInstanceProfileError(arn, name)
 		}
 
 		return nil, err
@@ -61,21 +70,21 @@ func (m *Mock) resolveInstanceProfile(ctx context.Context, cfg *driver.InstanceC
 }
 
 // invalidInstanceProfileError reproduces the exact wording real EC2 returns
-// for RunInstances when IamInstanceProfile.Name/.Arn does not resolve to an
-// existing instance profile, e.g.:
+// when IamInstanceProfile.Name/.Arn does not resolve to an existing instance
+// profile, e.g.:
 //
 //	Value (my-profile) for parameter iamInstanceProfile.name is invalid.
 //	Invalid IAM Instance Profile name
-func invalidInstanceProfileError(cfg *driver.InstanceConfig) error {
-	if cfg.IamInstanceProfileName != "" {
+func invalidInstanceProfileError(arn, name string) error {
+	if name != "" {
 		return cerrors.Newf(cerrors.InvalidArgument,
 			"Value (%s) for parameter iamInstanceProfile.name is invalid. Invalid IAM Instance Profile name",
-			cfg.IamInstanceProfileName)
+			name)
 	}
 
 	return cerrors.Newf(cerrors.InvalidArgument,
 		"Value (%s) for parameter iamInstanceProfile.arn is invalid. Invalid IAM Instance Profile ARN",
-		cfg.IamInstanceProfileARN)
+		arn)
 }
 
 // instanceProfileNameFromARN extracts the profile name from an instance-profile

--- a/providers/aws/ec2/snapshot.go
+++ b/providers/aws/ec2/snapshot.go
@@ -28,6 +28,7 @@ type ec2Snapshot struct {
 	Templates         json.RawMessage              `json:"templates,omitempty"`
 	TemplateVersions  json.RawMessage              `json:"templateVersions,omitempty"`
 	PlacementGroups   json.RawMessage              `json:"placementGroups,omitempty"`
+	ProfileAssocs     json.RawMessage              `json:"iamProfileAssociations,omitempty"`
 	ASGs              map[string]*asgSnapshot      `json:"asgs,omitempty"`
 	ManagedVisibility string                       `json:"managedVisibility,omitempty"`
 	ClientTokens      map[string][]string          `json:"clientTokens,omitempty"`
@@ -144,6 +145,7 @@ func (m *Mock) snapshotStores(snap *ec2Snapshot) error {
 		{&snap.Templates, m.templates.Snapshot},
 		{&snap.TemplateVersions, m.templateVersions.Snapshot},
 		{&snap.PlacementGroups, m.placementGroups.Snapshot},
+		{&snap.ProfileAssocs, m.iamProfileAssociations.Snapshot},
 	}
 
 	for _, d := range dumps {
@@ -262,6 +264,7 @@ func (m *Mock) restoreStores(snap *ec2Snapshot) error {
 		{snap.Templates, m.templates.LoadSnapshot},
 		{snap.TemplateVersions, m.templateVersions.LoadSnapshot},
 		{snap.PlacementGroups, m.placementGroups.LoadSnapshot},
+		{snap.ProfileAssocs, m.iamProfileAssociations.LoadSnapshot},
 	}
 
 	for _, l := range loads {

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -113,6 +113,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.routeTags,
 		h.routeMetadata,
 		h.routeInstanceStatus,
+		h.routeIamInstanceProfileAssociations,
 	}
 	for _, route := range routes {
 		if route(w, r, action) {

--- a/server/aws/ec2/instance_profile_association.go
+++ b/server/aws/ec2/instance_profile_association.go
@@ -1,0 +1,205 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+// codeInvalidAssociationID is the EC2 error code for a request naming a
+// non-existent IAM instance-profile association id.
+const codeInvalidAssociationID = "InvalidAssociationID.NotFound"
+
+// Filter names DescribeIamInstanceProfileAssociations understands.
+const (
+	assocFilterInstanceID = "instance-id"
+	assocFilterState      = "state"
+)
+
+// iamAssociationXML is the nested <iamInstanceProfileAssociation> element carried
+// by the Associate/Replace/Disassociate responses and by each Describe item. The
+// child element names (associationId, instanceId, iamInstanceProfile>{arn,id},
+// state) match what the aws-sdk-go-v2 deserializer binds to
+// types.IamInstanceProfileAssociation.
+type iamAssociationXML struct {
+	AssociationID      string                 `xml:"associationId"`
+	InstanceID         string                 `xml:"instanceId"`
+	IamInstanceProfile *iamInstanceProfileXML `xml:"iamInstanceProfile,omitempty"`
+	State              string                 `xml:"state"`
+}
+
+// iamAssociationResponse is the single-association envelope shared by the
+// Associate/Replace/Disassociate responses; only the root element name differs,
+// carried in XMLName.
+type iamAssociationResponse struct {
+	XMLName     xml.Name
+	Xmlns       string             `xml:"xmlns,attr"`
+	RequestID   string             `xml:"requestId"`
+	Association *iamAssociationXML `xml:"iamInstanceProfileAssociation"`
+}
+
+type describeIamInstanceProfileAssociationsResponse struct {
+	XMLName      xml.Name            `xml:"DescribeIamInstanceProfileAssociationsResponse"`
+	Xmlns        string              `xml:"xmlns,attr"`
+	RequestID    string              `xml:"requestId"`
+	Associations []iamAssociationXML `xml:"iamInstanceProfileAssociationSet>item"`
+	NextToken    string              `xml:"nextToken,omitempty"`
+}
+
+// routeIamInstanceProfileAssociations dispatches the post-launch IAM
+// instance-profile association actions (the counterparts to
+// RunInstances{IamInstanceProfile}). Served by the AWS-only
+// IamInstanceProfileAssociator capability.
+func (h *Handler) routeIamInstanceProfileAssociations(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
+	case "AssociateIamInstanceProfile":
+		h.associateIamInstanceProfile(w, r)
+	case "DescribeIamInstanceProfileAssociations":
+		h.describeIamInstanceProfileAssociations(w, r)
+	case "ReplaceIamInstanceProfileAssociation":
+		h.replaceIamInstanceProfileAssociation(w, r)
+	case "DisassociateIamInstanceProfile":
+		h.disassociateIamInstanceProfile(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// iamProfileAssociator returns the association capability, writing an
+// Unimplemented error and false when the compute driver doesn't provide it.
+func (h *Handler) iamProfileAssociator(w http.ResponseWriter) (computedriver.IamInstanceProfileAssociator, bool) {
+	assoc, ok := h.compute.(computedriver.IamInstanceProfileAssociator)
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented,
+			"IAM instance profile associations are not supported"))
+
+		return nil, false
+	}
+
+	return assoc, true
+}
+
+func (h *Handler) associateIamInstanceProfile(w http.ResponseWriter, r *http.Request) {
+	associator, ok := h.iamProfileAssociator(w)
+	if !ok {
+		return
+	}
+
+	out, err := associator.AssociateIamInstanceProfile(r.Context(),
+		r.Form.Get("InstanceId"),
+		r.Form.Get("IamInstanceProfile.Arn"),
+		r.Form.Get("IamInstanceProfile.Name"))
+	writeAssociationResult(w, "AssociateIamInstanceProfileResponse", codeInvalidInstanceID, out, err)
+}
+
+func (h *Handler) replaceIamInstanceProfileAssociation(w http.ResponseWriter, r *http.Request) {
+	associator, ok := h.iamProfileAssociator(w)
+	if !ok {
+		return
+	}
+
+	out, err := associator.ReplaceIamInstanceProfileAssociation(r.Context(),
+		r.Form.Get("AssociationId"),
+		r.Form.Get("IamInstanceProfile.Arn"),
+		r.Form.Get("IamInstanceProfile.Name"))
+	writeAssociationResult(w, "ReplaceIamInstanceProfileAssociationResponse", codeInvalidAssociationID, out, err)
+}
+
+func (h *Handler) disassociateIamInstanceProfile(w http.ResponseWriter, r *http.Request) {
+	associator, ok := h.iamProfileAssociator(w)
+	if !ok {
+		return
+	}
+
+	out, err := associator.DisassociateIamInstanceProfile(r.Context(), r.Form.Get("AssociationId"))
+	writeAssociationResult(w, "DisassociateIamInstanceProfileResponse", codeInvalidAssociationID, out, err)
+}
+
+// writeAssociationResult writes the single-association response for an
+// Associate/Replace/Disassociate action, or the mapped EC2 error. notFoundCode
+// selects the resource-specific NotFound code (InvalidInstanceID.NotFound for
+// Associate, InvalidAssociationID.NotFound for Replace/Disassociate).
+func writeAssociationResult(
+	w http.ResponseWriter, root, notFoundCode string,
+	out *computedriver.IamInstanceProfileAssociation, err error,
+) {
+	if err != nil {
+		writeErrWithNotFound(w, err, notFoundCode, "IncorrectState")
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, iamAssociationResponse{
+		XMLName:     xml.Name{Local: root},
+		Xmlns:       awsquery.Namespace,
+		RequestID:   awsquery.RequestID,
+		Association: associationXML(out),
+	})
+}
+
+func (h *Handler) describeIamInstanceProfileAssociations(w http.ResponseWriter, r *http.Request) {
+	associator, ok := h.iamProfileAssociator(w)
+	if !ok {
+		return
+	}
+
+	input := computedriver.DescribeIamInstanceProfileAssociationsInput{
+		AssociationIDs: awsquery.ListStrings(r.Form, "AssociationId"),
+	}
+
+	for _, f := range awsquery.Filters(r.Form) {
+		switch f.Name {
+		case assocFilterInstanceID:
+			input.InstanceIDs = append(input.InstanceIDs, f.Values...)
+		case assocFilterState:
+			input.States = append(input.States, f.Values...)
+		}
+	}
+
+	assocs, err := associator.DescribeIamInstanceProfileAssociations(r.Context(), input)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	items := make([]iamAssociationXML, 0, len(assocs))
+	for i := range assocs {
+		items = append(items, *associationXML(&assocs[i]))
+	}
+
+	page, next := paginateXML(items, r.Form.Get("MaxResults"), r.Form.Get("NextToken"),
+		func(a iamAssociationXML) string { return a.AssociationID })
+
+	awsquery.WriteXMLResponse(w, describeIamInstanceProfileAssociationsResponse{
+		Xmlns:        awsquery.Namespace,
+		RequestID:    awsquery.RequestID,
+		Associations: page,
+		NextToken:    next,
+	})
+}
+
+// associationXML renders a driver association as its wire element.
+func associationXML(a *computedriver.IamInstanceProfileAssociation) *iamAssociationXML {
+	if a == nil {
+		return nil
+	}
+
+	out := &iamAssociationXML{
+		AssociationID: a.AssociationID,
+		InstanceID:    a.InstanceID,
+		State:         a.State,
+	}
+
+	if a.Profile != nil {
+		out.IamInstanceProfile = &iamInstanceProfileXML{
+			ARN: a.Profile.ARN,
+			ID:  a.Profile.ID,
+		}
+	}
+
+	return out
+}

--- a/server/aws/ec2/instance_profile_association_test.go
+++ b/server/aws/ec2/instance_profile_association_test.go
@@ -1,0 +1,335 @@
+package ec2_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	smithy "github.com/aws/smithy-go"
+)
+
+// createInstanceProfile creates an IAM role + instance profile pair and returns
+// the profile's ARN and id, so the association tests can reference a real,
+// resolvable profile exactly as launch-time does.
+func createInstanceProfile(t *testing.T, iamc *iam.Client, name string) (arn, id string) {
+	t.Helper()
+
+	ctx := context.Background()
+	roleName := name + "-role"
+
+	if _, err := iamc.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[]}`),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	profile, err := iamc.CreateInstanceProfile(ctx, &iam.CreateInstanceProfileInput{
+		InstanceProfileName: aws.String(name),
+	})
+	if err != nil {
+		t.Fatalf("CreateInstanceProfile: %v", err)
+	}
+
+	if _, err := iamc.AddRoleToInstanceProfile(ctx, &iam.AddRoleToInstanceProfileInput{
+		InstanceProfileName: aws.String(name),
+		RoleName:            aws.String(roleName),
+	}); err != nil {
+		t.Fatalf("AddRoleToInstanceProfile: %v", err)
+	}
+
+	return aws.ToString(profile.InstanceProfile.Arn), aws.ToString(profile.InstanceProfile.InstanceProfileId)
+}
+
+// runBareInstance launches one instance with no IAM profile and returns its id.
+func runBareInstance(t *testing.T, ec2c *ec2.Client) string {
+	t.Helper()
+
+	run, err := ec2c.RunInstances(context.Background(), &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-123"),
+		InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	return aws.ToString(run.Instances[0].InstanceId)
+}
+
+func instanceProfileARN(t *testing.T, ec2c *ec2.Client, id string) string {
+	t.Helper()
+
+	desc, err := ec2c.DescribeInstances(context.Background(), &ec2.DescribeInstancesInput{
+		InstanceIds: []string{id},
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	inst := desc.Reservations[0].Instances[0]
+	if inst.IamInstanceProfile == nil {
+		return ""
+	}
+
+	return aws.ToString(inst.IamInstanceProfile.Arn)
+}
+
+// TestAssociateIamInstanceProfileReflectedOnDescribe drives the real-user flow:
+// launch an instance with no profile, attach one post-launch, then confirm both
+// DescribeInstances (Arn + Id) and DescribeIamInstanceProfileAssociations reflect
+// the attachment.
+func TestAssociateIamInstanceProfileReflectedOnDescribe(t *testing.T) {
+	ctx := context.Background()
+	ec2c, iamc := newEC2AndIAMClients(t)
+
+	wantARN, wantID := createInstanceProfile(t, iamc, "attach-profile")
+	instanceID := runBareInstance(t, ec2c)
+
+	if arn := instanceProfileARN(t, ec2c, instanceID); arn != "" {
+		t.Fatalf("bare instance already has a profile %q, want none", arn)
+	}
+
+	assoc, err := ec2c.AssociateIamInstanceProfile(ctx, &ec2.AssociateIamInstanceProfileInput{
+		InstanceId: aws.String(instanceID),
+		IamInstanceProfile: &ec2types.IamInstanceProfileSpecification{
+			Name: aws.String("attach-profile"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("AssociateIamInstanceProfile: %v", err)
+	}
+
+	got := assoc.IamInstanceProfileAssociation
+	if got == nil {
+		t.Fatal("AssociateIamInstanceProfile returned no association")
+	}
+
+	associationID := aws.ToString(got.AssociationId)
+	if associationID == "" {
+		t.Fatal("AssociateIamInstanceProfile returned an empty association id")
+	}
+
+	if arn := aws.ToString(got.IamInstanceProfile.Arn); arn != wantARN {
+		t.Fatalf("association IamInstanceProfile.Arn = %q, want %q", arn, wantARN)
+	}
+
+	// DescribeInstances must now reflect the profile ARN and id.
+	if arn := instanceProfileARN(t, ec2c, instanceID); arn != wantARN {
+		t.Fatalf("DescribeInstances IamInstanceProfile.Arn = %q, want %q", arn, wantARN)
+	}
+
+	desc, err := ec2c.DescribeInstances(ctx, &ec2.DescribeInstancesInput{InstanceIds: []string{instanceID}})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	if gotID := aws.ToString(desc.Reservations[0].Instances[0].IamInstanceProfile.Id); gotID != wantID {
+		t.Fatalf("DescribeInstances IamInstanceProfile.Id = %q, want %q", gotID, wantID)
+	}
+
+	// DescribeIamInstanceProfileAssociations must list it as associated.
+	list, err := ec2c.DescribeIamInstanceProfileAssociations(ctx,
+		&ec2.DescribeIamInstanceProfileAssociationsInput{AssociationIds: []string{associationID}})
+	if err != nil {
+		t.Fatalf("DescribeIamInstanceProfileAssociations: %v", err)
+	}
+
+	if len(list.IamInstanceProfileAssociations) != 1 {
+		t.Fatalf("DescribeIamInstanceProfileAssociations returned %d, want 1",
+			len(list.IamInstanceProfileAssociations))
+	}
+
+	listed := list.IamInstanceProfileAssociations[0]
+	if aws.ToString(listed.InstanceId) != instanceID {
+		t.Fatalf("association InstanceId = %q, want %q", aws.ToString(listed.InstanceId), instanceID)
+	}
+
+	if listed.State != ec2types.IamInstanceProfileAssociationStateAssociated {
+		t.Fatalf("association state = %q, want associated", listed.State)
+	}
+}
+
+// TestAssociateIamInstanceProfileAlreadyAssociated confirms real EC2's rejection
+// of a second association on an instance that already has one.
+func TestAssociateIamInstanceProfileAlreadyAssociated(t *testing.T) {
+	ctx := context.Background()
+	ec2c, iamc := newEC2AndIAMClients(t)
+
+	createInstanceProfile(t, iamc, "first-profile")
+	createInstanceProfile(t, iamc, "second-profile")
+	instanceID := runBareInstance(t, ec2c)
+
+	if _, err := ec2c.AssociateIamInstanceProfile(ctx, &ec2.AssociateIamInstanceProfileInput{
+		InstanceId:         aws.String(instanceID),
+		IamInstanceProfile: &ec2types.IamInstanceProfileSpecification{Name: aws.String("first-profile")},
+	}); err != nil {
+		t.Fatalf("first AssociateIamInstanceProfile: %v", err)
+	}
+
+	_, err := ec2c.AssociateIamInstanceProfile(ctx, &ec2.AssociateIamInstanceProfileInput{
+		InstanceId:         aws.String(instanceID),
+		IamInstanceProfile: &ec2types.IamInstanceProfileSpecification{Name: aws.String("second-profile")},
+	})
+	if err == nil {
+		t.Fatal("second AssociateIamInstanceProfile succeeded, want IncorrectState")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %v, want an API error", err)
+	}
+
+	if apiErr.ErrorCode() != "IncorrectState" {
+		t.Fatalf("error code = %q, want IncorrectState", apiErr.ErrorCode())
+	}
+}
+
+// TestReplaceIamInstanceProfileAssociation swaps the profile on an existing
+// association and confirms the instance reflects the new profile.
+func TestReplaceIamInstanceProfileAssociation(t *testing.T) {
+	ctx := context.Background()
+	ec2c, iamc := newEC2AndIAMClients(t)
+
+	createInstanceProfile(t, iamc, "old-profile")
+	newARN, newID := createInstanceProfile(t, iamc, "new-profile")
+	instanceID := runBareInstance(t, ec2c)
+
+	assoc, err := ec2c.AssociateIamInstanceProfile(ctx, &ec2.AssociateIamInstanceProfileInput{
+		InstanceId:         aws.String(instanceID),
+		IamInstanceProfile: &ec2types.IamInstanceProfileSpecification{Name: aws.String("old-profile")},
+	})
+	if err != nil {
+		t.Fatalf("AssociateIamInstanceProfile: %v", err)
+	}
+
+	associationID := aws.ToString(assoc.IamInstanceProfileAssociation.AssociationId)
+
+	replaced, err := ec2c.ReplaceIamInstanceProfileAssociation(ctx, &ec2.ReplaceIamInstanceProfileAssociationInput{
+		AssociationId:      aws.String(associationID),
+		IamInstanceProfile: &ec2types.IamInstanceProfileSpecification{Name: aws.String("new-profile")},
+	})
+	if err != nil {
+		t.Fatalf("ReplaceIamInstanceProfileAssociation: %v", err)
+	}
+
+	if arn := aws.ToString(replaced.IamInstanceProfileAssociation.IamInstanceProfile.Arn); arn != newARN {
+		t.Fatalf("replaced association Arn = %q, want %q", arn, newARN)
+	}
+
+	if arn := instanceProfileARN(t, ec2c, instanceID); arn != newARN {
+		t.Fatalf("DescribeInstances IamInstanceProfile.Arn = %q, want %q (new profile)", arn, newARN)
+	}
+
+	desc, err := ec2c.DescribeInstances(ctx, &ec2.DescribeInstancesInput{InstanceIds: []string{instanceID}})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	if gotID := aws.ToString(desc.Reservations[0].Instances[0].IamInstanceProfile.Id); gotID != newID {
+		t.Fatalf("DescribeInstances IamInstanceProfile.Id = %q, want %q", gotID, newID)
+	}
+}
+
+// TestDisassociateIamInstanceProfile removes an association and confirms the
+// instance's profile is cleared and the association no longer lists.
+func TestDisassociateIamInstanceProfile(t *testing.T) {
+	ctx := context.Background()
+	ec2c, iamc := newEC2AndIAMClients(t)
+
+	createInstanceProfile(t, iamc, "detach-profile")
+	instanceID := runBareInstance(t, ec2c)
+
+	assoc, err := ec2c.AssociateIamInstanceProfile(ctx, &ec2.AssociateIamInstanceProfileInput{
+		InstanceId:         aws.String(instanceID),
+		IamInstanceProfile: &ec2types.IamInstanceProfileSpecification{Name: aws.String("detach-profile")},
+	})
+	if err != nil {
+		t.Fatalf("AssociateIamInstanceProfile: %v", err)
+	}
+
+	associationID := aws.ToString(assoc.IamInstanceProfileAssociation.AssociationId)
+
+	if _, err := ec2c.DisassociateIamInstanceProfile(ctx, &ec2.DisassociateIamInstanceProfileInput{
+		AssociationId: aws.String(associationID),
+	}); err != nil {
+		t.Fatalf("DisassociateIamInstanceProfile: %v", err)
+	}
+
+	if arn := instanceProfileARN(t, ec2c, instanceID); arn != "" {
+		t.Fatalf("DescribeInstances still reports profile %q after disassociate, want none", arn)
+	}
+
+	list, err := ec2c.DescribeIamInstanceProfileAssociations(ctx,
+		&ec2.DescribeIamInstanceProfileAssociationsInput{AssociationIds: []string{associationID}})
+	if err != nil {
+		t.Fatalf("DescribeIamInstanceProfileAssociations: %v", err)
+	}
+
+	if len(list.IamInstanceProfileAssociations) != 0 {
+		t.Fatalf("association still listed after disassociate: got %d", len(list.IamInstanceProfileAssociations))
+	}
+}
+
+// TestAssociateIamInstanceProfileMissingInstance confirms attaching to an
+// instance that does not exist answers InvalidInstanceID.NotFound.
+func TestAssociateIamInstanceProfileMissingInstance(t *testing.T) {
+	ctx := context.Background()
+	ec2c, iamc := newEC2AndIAMClients(t)
+
+	createInstanceProfile(t, iamc, "orphan-profile")
+
+	_, err := ec2c.AssociateIamInstanceProfile(ctx, &ec2.AssociateIamInstanceProfileInput{
+		InstanceId:         aws.String("i-doesnotexist"),
+		IamInstanceProfile: &ec2types.IamInstanceProfileSpecification{Name: aws.String("orphan-profile")},
+	})
+	if err == nil {
+		t.Fatal("AssociateIamInstanceProfile to a missing instance succeeded, want InvalidInstanceID.NotFound")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %v, want an API error", err)
+	}
+
+	if apiErr.ErrorCode() != "InvalidInstanceID.NotFound" {
+		t.Fatalf("error code = %q, want InvalidInstanceID.NotFound", apiErr.ErrorCode())
+	}
+}
+
+// TestAssociateIamInstanceProfileInvalidProfile confirms an unresolvable profile
+// reference is rejected exactly as launch-time is (InvalidParameterValue), and no
+// association is created.
+func TestAssociateIamInstanceProfileInvalidProfile(t *testing.T) {
+	ctx := context.Background()
+	ec2c, _ := newEC2AndIAMClients(t)
+
+	instanceID := runBareInstance(t, ec2c)
+
+	_, err := ec2c.AssociateIamInstanceProfile(ctx, &ec2.AssociateIamInstanceProfileInput{
+		InstanceId:         aws.String(instanceID),
+		IamInstanceProfile: &ec2types.IamInstanceProfileSpecification{Name: aws.String("never-created")},
+	})
+	if err == nil {
+		t.Fatal("AssociateIamInstanceProfile with a nonexistent profile succeeded, want InvalidParameterValue")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %v, want an API error", err)
+	}
+
+	if apiErr.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("error code = %q, want InvalidParameterValue", apiErr.ErrorCode())
+	}
+
+	// Nothing should have been recorded.
+	if arn := instanceProfileARN(t, ec2c, instanceID); arn != "" {
+		t.Fatalf("instance reflects profile %q after a failed associate, want none", arn)
+	}
+}

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -625,6 +625,48 @@ type InstanceMetadataModifier interface {
 	ModifyInstanceMetadataOptions(ctx context.Context, instanceID string, update MetadataOptions) (*MetadataOptions, error)
 }
 
+// IamInstanceProfileAssociation is one association of an IAM instance profile
+// with a running/stopped instance, as reported by the EC2
+// Associate/Describe/Replace/DisassociateIamInstanceProfile actions. State is
+// one of "associating", "associated", "disassociating", "disassociated".
+type IamInstanceProfileAssociation struct {
+	AssociationID string
+	InstanceID    string
+	Profile       *IamInstanceProfile
+	State         string
+}
+
+// DescribeIamInstanceProfileAssociationsInput filters a
+// DescribeIamInstanceProfileAssociations call. Empty slices mean "no filter on
+// this field"; an association matches when it satisfies every populated field.
+type DescribeIamInstanceProfileAssociationsInput struct {
+	AssociationIDs []string
+	InstanceIDs    []string
+	States         []string
+}
+
+// IamInstanceProfileAssociator is an optional AWS-only capability for attaching
+// an IAM instance profile to an already-running instance
+// (ec2:AssociateIamInstanceProfile and its Describe/Replace/Disassociate
+// counterparts), the post-launch equivalent of RunInstances{IamInstanceProfile}.
+// Discovered by type assertion. profileARN / profileName carry the
+// IamInstanceProfile reference; the implementation resolves it to the profile's
+// canonical ARN and ID exactly as launch-time does.
+type IamInstanceProfileAssociator interface {
+	AssociateIamInstanceProfile(
+		ctx context.Context, instanceID, profileARN, profileName string,
+	) (*IamInstanceProfileAssociation, error)
+	DescribeIamInstanceProfileAssociations(
+		ctx context.Context, input DescribeIamInstanceProfileAssociationsInput,
+	) ([]IamInstanceProfileAssociation, error)
+	ReplaceIamInstanceProfileAssociation(
+		ctx context.Context, associationID, profileARN, profileName string,
+	) (*IamInstanceProfileAssociation, error)
+	DisassociateIamInstanceProfile(
+		ctx context.Context, associationID string,
+	) (*IamInstanceProfileAssociation, error)
+}
+
 // AzureVMController is an optional Azure-only capability supporting the ARM
 // virtualMachines operations that have no AWS/GCP equivalent: the PowerOff vs
 // Deallocate distinction (PowerOff stops the guest but keeps the VM allocated;


### PR DESCRIPTION
## Summary

Adds the four post-launch IAM instance-profile association actions to AWS EC2, so a user can attach a role to an already-running instance (`aws_iam_instance_profile` + `AssociateIamInstanceProfile`). Previously these actions returned `InvalidAction: unknown action`. The launch-time path (`RunInstances{IamInstanceProfile}`) already resolved and reflected the profile; this mirrors that resolution for the runtime actions.

## What changed

- `AssociateIamInstanceProfile` — validates the instance exists (`InvalidInstanceID.NotFound`), resolves the profile via the existing instance-profile resolver, rejects a second association on the same instance (`IncorrectState`), and reflects `Arn`+`Id` on `DescribeInstances`.
- `DescribeIamInstanceProfileAssociations` — filters by `AssociationId` / `instance-id` / `state`, with standard EC2 pagination.
- `ReplaceIamInstanceProfileAssociation` — swaps the profile on an existing association and reflects it on the instance.
- `DisassociateIamInstanceProfile` — removes the association and clears the instance's profile.
- Launch-time `RunInstances{IamInstanceProfile}` now also records a backing association (one per instance) so `DescribeIamInstanceProfileAssociations` lists it, matching real AWS. Terminate and launch-rollback drop the association.
- Associations round-trip through snapshot/restore.

## Design

- New AWS-only optional capability `IamInstanceProfileAssociator` on the compute driver (type-asserted by the wire handler, like `InstanceMetadataModifier`); Azure/GCP unaffected.
- Provider stores associations in a `memstore` keyed by `iip-assoc-<hex>`; reuses the shared `resolveProfileRef` so launch-time and post-launch resolution are identical.

## Tests

Real `aws-sdk-go-v2` EC2 over `httptest` (server level) plus provider-level tests: associate-then-describe reflection, already-associated rejection, replace, disassociate, missing instance, invalid profile, launch-time backing association + terminate cleanup, and snapshot round-trip.

## Gates

`go build ./...`, `go vet`, `go test ./providers/... ./server/... ./services/compute/... .` green; `go generate ./...` + compat matrix regenerated (exit 0); `gofmt` clean; `golangci-lint --new-from-rev=origin/development` 0 new issues.
