### PR TITLE
fix(azure-vm): reconcile NIC attach/detach on VM in-place update

### DIFF
--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -525,6 +525,103 @@ func (m *Mock) detachNICs(ctx context.Context, inst *instanceData) error {
 	return errors.Join(errs...)
 }
 
+// reconcileNICs brings inst's attached network interfaces into line with the
+// desired set a PUT CreateOrUpdate supplied in networkProfile.networkInterfaces
+// (Azure's full-replace on the network profile). NICs newly present in desired
+// are attached (setting their properties.virtualMachine back-reference); NICs
+// inst still holds but that are no longer desired are detached (clearing it, so
+// they return to Unattached and can be deleted); NICs in both are left as-is
+// (attach is idempotent on the same VM). New NICs are attached first — with
+// rollback of just those on failure — before any detach runs, so a failed
+// attach (e.g. a NIC already attached to another VM) leaves the VM's existing
+// attachments untouched. inst.NICRefs is then set to the desired set, whose
+// first entry stays the primary NIC. A no-op when no NICAttacher is wired.
+func (m *Mock) reconcileNICs(ctx context.Context, inst *instanceData, desired []driver.AzureNICRef) error {
+	if m.nicAttacher == nil {
+		return nil
+	}
+
+	vmID := m.armResourceID(inst)
+	desiredSet := nicRefSet(desired)
+
+	if err := m.attachNewNICs(ctx, vmID, nicRefSet(inst.NICRefs), desired); err != nil {
+		return err
+	}
+
+	if err := m.detachRemovedNICs(ctx, vmID, inst.NICRefs, desiredSet); err != nil {
+		return err
+	}
+
+	inst.NICRefs = append([]driver.AzureNICRef(nil), desired...)
+
+	return nil
+}
+
+// nicRefSet indexes a slice of NIC references as a set, for membership tests
+// during reconcile.
+func nicRefSet(refs []driver.AzureNICRef) map[driver.AzureNICRef]bool {
+	set := make(map[driver.AzureNICRef]bool, len(refs))
+	for _, ref := range refs {
+		set[ref] = true
+	}
+
+	return set
+}
+
+// attachNewNICs attaches every desired NIC not already present in current
+// (deduping repeats within desired), rolling back only the NICs it attached
+// during this call if one fails — so a failed attach leaves the VM's existing
+// attachments untouched.
+func (m *Mock) attachNewNICs(
+	ctx context.Context, vmID string, current map[driver.AzureNICRef]bool, desired []driver.AzureNICRef,
+) error {
+	seen := make(map[driver.AzureNICRef]bool, len(desired))
+	attached := make([]driver.AzureNICRef, 0, len(desired))
+
+	for _, ref := range desired {
+		if seen[ref] || current[ref] {
+			seen[ref] = true
+
+			continue
+		}
+
+		seen[ref] = true
+
+		if err := m.nicAttacher.AttachNetworkInterface(ctx, ref.ResourceGroup, ref.Name, vmID); err != nil {
+			for _, done := range attached {
+				_ = m.nicAttacher.DetachNetworkInterface(ctx, done.ResourceGroup, done.Name, vmID)
+			}
+
+			return err
+		}
+
+		attached = append(attached, ref)
+	}
+
+	return nil
+}
+
+// detachRemovedNICs detaches every currently-attached NIC absent from
+// desiredSet, best-effort: every removal is attempted so one failure doesn't
+// strand the rest still holding a stale back-reference.
+func (m *Mock) detachRemovedNICs(
+	ctx context.Context, vmID string, current []driver.AzureNICRef, desiredSet map[driver.AzureNICRef]bool,
+) error {
+	var errs []error
+
+	for _, ref := range current {
+		if desiredSet[ref] {
+			continue
+		}
+
+		if err := m.nicAttacher.DetachNetworkInterface(ctx, ref.ResourceGroup, ref.Name, vmID); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
 // rollbackInstances best-effort tears down instances already provisioned earlier
 // in a RunInstances batch that then failed: every NIC the instance attached at
 // launch is detached (so no NIC keeps a virtualMachine back-reference to a VM
@@ -633,52 +730,76 @@ func (m *Mock) Deallocate(ctx context.Context, instanceID string) error {
 // rather than provisioning a duplicate.
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
-func (m *Mock) UpdateInstance(_ context.Context, instanceID string, cfg driver.InstanceConfig) error {
-	ok := m.instances.Update(instanceID, func(inst *instanceData) *instanceData {
-		if cfg.InstanceType != "" {
-			inst.InstanceType = cfg.InstanceType
+func (m *Mock) UpdateInstance(ctx context.Context, instanceID string, cfg driver.InstanceConfig) error {
+	inst, found := m.instances.Get(instanceID)
+	if !found {
+		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
+	}
+
+	// Reconcile networkProfile.networkInterfaces before mutating the rest of the
+	// config, so an unattachable NIC (already attached to another VM) aborts the
+	// whole PUT rather than half-applying it. Only when the request actually
+	// supplied a networkProfile (>=1 NIC): an omitted/empty set on a PUT leaves
+	// the existing NICs untouched (no wipe), mirroring applyDataDisks'
+	// present-vs-omitted discriminator for data disks.
+	if len(cfg.NetworkInterfaces) > 0 {
+		if err := m.reconcileNICs(ctx, inst, cfg.NetworkInterfaces); err != nil {
+			return err
 		}
+	}
 
-		if cfg.ImageID != "" {
-			inst.ImageID = cfg.ImageID
-		}
-
-		if cfg.SubnetID != "" {
-			inst.SubnetID = cfg.SubnetID
-		}
-
-		if cfg.OSType != "" {
-			inst.OSType = cfg.OSType
-		}
-
-		inst.Priority = cfg.Priority
-		inst.LicenseType = cfg.LicenseType
-
-		if len(cfg.Zones) > 0 {
-			inst.Zones = append([]string(nil), cfg.Zones...)
-		}
-
-		if cfg.Region != "" {
-			inst.Region = cfg.Region
-		}
-
-		inst.Tags = copyTags(cfg.Tags)
-
-		// A nil cfg.Identity means the request omitted the identity block
-		// entirely (real Azure preserves the existing identity in that case);
-		// a non-nil one (including an explicit "None") replaces it.
-		if cfg.Identity != nil {
-			inst.Identity = resolveIdentity(cfg.Identity, instanceID)
-		}
+	if ok := m.instances.Update(instanceID, func(inst *instanceData) *instanceData {
+		applyMutableConfig(inst, cfg, instanceID)
 
 		return inst
-	})
-
-	if !ok {
+	}); !ok {
 		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
 	}
 
 	return nil
+}
+
+// applyMutableConfig overwrites inst's mutable fields from a PUT CreateOrUpdate
+// cfg (the whole-body replace UpdateInstance backs). Empty scalars leave the
+// corresponding field untouched; Priority/LicenseType and Tags are always
+// replaced. A nil cfg.Identity preserves the existing identity (the request
+// omitted the block); a non-nil one (including an explicit "None") replaces it.
+// NIC reconciliation is handled separately by reconcileNICs before this runs.
+//
+//nolint:gocritic // hugeParam: cfg mirrors the driver-interface config shape.
+func applyMutableConfig(inst *instanceData, cfg driver.InstanceConfig, instanceID string) {
+	if cfg.InstanceType != "" {
+		inst.InstanceType = cfg.InstanceType
+	}
+
+	if cfg.ImageID != "" {
+		inst.ImageID = cfg.ImageID
+	}
+
+	if cfg.SubnetID != "" {
+		inst.SubnetID = cfg.SubnetID
+	}
+
+	if cfg.OSType != "" {
+		inst.OSType = cfg.OSType
+	}
+
+	inst.Priority = cfg.Priority
+	inst.LicenseType = cfg.LicenseType
+
+	if len(cfg.Zones) > 0 {
+		inst.Zones = append([]string(nil), cfg.Zones...)
+	}
+
+	if cfg.Region != "" {
+		inst.Region = cfg.Region
+	}
+
+	inst.Tags = copyTags(cfg.Tags)
+
+	if cfg.Identity != nil {
+		inst.Identity = resolveIdentity(cfg.Identity, instanceID)
+	}
 }
 
 // PatchInstance applies an ARM PATCH Update (BeginUpdate) merge-patch to an

--- a/server/azure/virtualmachines/nic_reconcile_on_update_test.go
+++ b/server/azure/virtualmachines/nic_reconcile_on_update_test.go
@@ -1,0 +1,238 @@
+package virtualmachines_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// putVMWithNICs drives a PUT CreateOrUpdate against an existing VM whose
+// networkProfile references nicIDs (the first entry marked primary), through
+// the real armcompute SDK, and polls to completion. It backs the in-place
+// update path (repeat PUT to the same {rg,name}) that must reconcile NIC
+// attach/detach.
+func putVMWithNICs(
+	t *testing.T, client *armcompute.VirtualMachinesClient, name string, nicIDs ...string,
+) error {
+	t.Helper()
+
+	refs := make([]*armcompute.NetworkInterfaceReference, 0, len(nicIDs))
+
+	for i, id := range nicIDs {
+		refs = append(refs, &armcompute.NetworkInterfaceReference{
+			ID: to.Ptr(id),
+			Properties: &armcompute.NetworkInterfaceReferenceProperties{
+				Primary: to.Ptr(i == 0),
+			},
+		})
+	}
+
+	poller, err := client.BeginCreateOrUpdate(context.Background(), "rg-1", name,
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				StorageProfile: &armcompute.StorageProfile{
+					OSDisk: &armcompute.OSDisk{OSType: to.Ptr(armcompute.OperatingSystemTypesLinux)},
+				},
+				NetworkProfile: &armcompute.NetworkProfile{NetworkInterfaces: refs},
+			},
+		}, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = poller.PollUntilDone(context.Background(), &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+
+	return err
+}
+
+// nicVMRef returns the ARM id of the VM a NIC is currently attached to, or ""
+// when the NIC has no properties.virtualMachine back-reference.
+func nicVMRef(t *testing.T, nicClient *armnetwork.InterfacesClient, name string) string {
+	t.Helper()
+
+	got, err := nicClient.Get(context.Background(), "rg-1", name, nil)
+	if err != nil {
+		t.Fatalf("nic Get %s: %v", name, err)
+	}
+
+	if got.Properties == nil || got.Properties.VirtualMachine == nil || got.Properties.VirtualMachine.ID == nil {
+		return ""
+	}
+
+	return *got.Properties.VirtualMachine.ID
+}
+
+// newReconcileFixture stands up an Azure wire server with VM + networking
+// drivers wired and returns the VM and NIC SDK clients pointed at it.
+func newReconcileFixture(t *testing.T) (*armcompute.VirtualMachinesClient, *armnetwork.InterfacesClient) {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure(config.WithAccountID("sub-1"))
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloudP.VirtualMachines,
+		Network:         cloudP.VNet,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	nicClient, err := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, sdkClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return newSDKClient(t, ts), nicClient
+}
+
+// TestSDKVMUpdateReconcilesNICSwap covers the in-place-update NIC reconcile fix:
+// a VM created with NIC-A, then PUT again pointing at NIC-B, must move the
+// attachment — NIC-B gains the virtualMachine back-reference, NIC-A loses it —
+// and, having been detached, NIC-A can now be deleted (no longer InUse /
+// InUseNetworkInterfaceCannotBeDeleted). Before the fix UpdateInstance ignored
+// networkProfile.networkInterfaces, so NIC-B never attached and NIC-A stayed
+// permanently in use.
+func TestSDKVMUpdateReconcilesNICSwap(t *testing.T) {
+	vmClient, nicClient := newReconcileFixture(t)
+	ctx := context.Background()
+
+	nicA := createSDKNIC(t, nicClient, "nic-a", "10.0.1.10")
+	nicB := createSDKNIC(t, nicClient, "nic-b", "10.0.1.11")
+
+	vmID, err := createSDKVMWithNIC(t, vmClient, "vm-swap", nicA)
+	if err != nil {
+		t.Fatalf("create vm-swap: %v", err)
+	}
+
+	if ref := nicVMRef(t, nicClient, "nic-a"); ref != vmID {
+		t.Fatalf("nic-a back-ref=%q want %q after create", ref, vmID)
+	}
+
+	// (a) PUT the same VM pointing at NIC-B: the association moves to NIC-B.
+	if err := putVMWithNICs(t, vmClient, "vm-swap", nicB); err != nil {
+		t.Fatalf("PUT vm-swap with nic-b: %v", err)
+	}
+
+	if ref := nicVMRef(t, nicClient, "nic-b"); ref != vmID {
+		t.Errorf("nic-b back-ref=%q want %q after update", ref, vmID)
+	}
+
+	if ref := nicVMRef(t, nicClient, "nic-a"); ref != "" {
+		t.Errorf("nic-a back-ref=%q want cleared after update", ref)
+	}
+
+	// (b) NIC-A, now detached, is no longer InUse and can be deleted.
+	delPoller, err := nicClient.BeginDelete(ctx, "rg-1", "nic-a", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete nic-a: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("delete nic-a (should be detached, not InUse): %v", err)
+	}
+}
+
+// TestSDKVMPatchWithoutNetworkProfilePreservesNICs covers requirement (c): a
+// PATCH Update that carries no networkProfile must not drop the VM's NICs. The
+// PATCH routes through PatchInstance (merge-patch) and must leave the existing
+// attachment intact, matching ARM's RFC 7386 semantics.
+func TestSDKVMPatchWithoutNetworkProfilePreservesNICs(t *testing.T) {
+	vmClient, nicClient := newReconcileFixture(t)
+	ctx := context.Background()
+
+	nicA := createSDKNIC(t, nicClient, "nic-keep", "10.0.1.20")
+
+	vmID, err := createSDKVMWithNIC(t, vmClient, "vm-keep", nicA)
+	if err != nil {
+		t.Fatalf("create vm-keep: %v", err)
+	}
+
+	// PATCH resizing the VM (no network profile at all).
+	patchPoller, err := vmClient.BeginUpdate(ctx, "rg-1", "vm-keep",
+		armcompute.VirtualMachineUpdate{
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD4SV3),
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate vm-keep: %v", err)
+	}
+
+	if _, err := patchPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("patch poll vm-keep: %v", err)
+	}
+
+	if ref := nicVMRef(t, nicClient, "nic-keep"); ref != vmID {
+		t.Errorf("nic-keep back-ref=%q want %q preserved across PATCH (no wipe)", ref, vmID)
+	}
+}
+
+// TestSDKVMUpdateAddsSecondNIC covers requirement (d): a PUT that adds a second
+// NIC to a VM already holding one attaches both, each with the virtualMachine
+// back-reference, keeping the first-listed NIC primary. The previously attached
+// NIC is left attached (attach is idempotent on the same VM), not detached.
+func TestSDKVMUpdateAddsSecondNIC(t *testing.T) {
+	vmClient, nicClient := newReconcileFixture(t)
+
+	nic1 := createSDKNIC(t, nicClient, "nic-1", "10.0.1.30")
+	nic2 := createSDKNIC(t, nicClient, "nic-2", "10.0.1.31")
+
+	vmID, err := createSDKVMWithNIC(t, vmClient, "vm-multi", nic1)
+	if err != nil {
+		t.Fatalf("create vm-multi: %v", err)
+	}
+
+	// PUT with both NICs (nic-1 primary, nic-2 added).
+	if err := putVMWithNICs(t, vmClient, "vm-multi", nic1, nic2); err != nil {
+		t.Fatalf("PUT vm-multi with two NICs: %v", err)
+	}
+
+	if ref := nicVMRef(t, nicClient, "nic-1"); ref != vmID {
+		t.Errorf("nic-1 back-ref=%q want %q (primary, still attached)", ref, vmID)
+	}
+
+	if ref := nicVMRef(t, nicClient, "nic-2"); ref != vmID {
+		t.Errorf("nic-2 back-ref=%q want %q (newly attached)", ref, vmID)
+	}
+}
+
+// TestSDKVMUpdateMissingNICRejected covers requirement (e): a PUT whose
+// networkProfile references a NIC that does not exist is rejected with
+// NetworkInterfaceNotFound, exactly as the create path validates, and leaves the
+// VM's current attachment untouched.
+func TestSDKVMUpdateMissingNICRejected(t *testing.T) {
+	vmClient, nicClient := newReconcileFixture(t)
+
+	nicA := createSDKNIC(t, nicClient, "nic-present", "10.0.1.40")
+
+	vmID, err := createSDKVMWithNIC(t, vmClient, "vm-missing", nicA)
+	if err != nil {
+		t.Fatalf("create vm-missing: %v", err)
+	}
+
+	missing := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/networkInterfaces/nic-ghost"
+
+	if err := putVMWithNICs(t, vmClient, "vm-missing", missing); err == nil {
+		t.Fatal("expected PUT referencing a missing NIC to fail with NetworkInterfaceNotFound")
+	}
+
+	// The rejected update must not have disturbed the existing attachment.
+	if ref := nicVMRef(t, nicClient, "nic-present"); ref != vmID {
+		t.Errorf("nic-present back-ref=%q want %q unchanged after rejected update", ref, vmID)
+	}
+}


### PR DESCRIPTION
## Summary

A repeat `PUT virtualMachines/{name}` (ARM CreateOrUpdate) whose `networkProfile.networkInterfaces` points at a **different** NIC did not reconcile NIC attach/detach. The new NIC never gained its `properties.virtualMachine` back-reference, the old NIC kept a stale back-reference and stayed permanently `InUse` (`InUseNetworkInterfaceCannotBeDeleted`), and `inst.NICRefs` still listed the old NIC. NIC attachment only happened on `RunInstances`; the in-place update path (`UpdateInstance`) ignored `cfg.NetworkInterfaces`.

Real Azure updates the association on an in-place PUT and the NIC back-references follow.

## What changed

- `providers/azure/virtualmachines/vm.go`: `UpdateInstance` now reconciles `cfg.NetworkInterfaces` against the VM's current `NICRefs` via a new `reconcileNICs` helper — attaches newly-added NICs (with rollback of just those on failure), detaches NICs removed from the set (clearing their back-reference so they return to Unattached and can be deleted), and updates `inst.NICRefs` with the first entry staying primary. Reuses the existing NICAttacher attach/detach surface rather than duplicating logic. The field-application closure was extracted to `applyMutableConfig` to keep complexity in check.

### PUT-replace vs PATCH-merge

- **PUT** (CreateOrUpdate → `UpdateInstance`): reconciles NICs only when the request actually supplied a `networkProfile` with at least one NIC. An omitted/empty network profile leaves the existing NICs untouched (no wipe), mirroring the present-vs-omitted discriminator `applyDataDisks` already uses for data disks.
- **PATCH** (BeginUpdate → `PatchInstance`): never touches NICs, so a merge-patch that omits the network profile preserves them.
- A PUT referencing a missing NIC is still rejected with `NetworkInterfaceNotFound` by the existing `validateNICs` wire-layer check (which already runs for the update path).

## Tests

New real-`armcompute`/`armnetwork` SDK tests over `httptest` in `server/azure/virtualmachines/nic_reconcile_on_update_test.go`:

- NIC swap: create VM with NIC-A → PUT with NIC-B → NIC-B gains the back-ref, NIC-A loses it, and NIC-A can now be deleted (no longer InUse).
- PATCH without a network profile does not drop NICs.
- PUT adding a second NIC attaches both (first-listed primary).
- PUT referencing a missing NIC → `NetworkInterfaceNotFound`, existing attachment untouched.

Verified the new tests fail without the fix (reproducing `InUseNetworkInterfaceCannotBeDeleted` and the missing back-ref) and pass with it.

Gates: build, vet, gofmt, targeted `go test` (VM + vnet, provider + server), `golangci-lint --new-from-rev=origin/development` 0 new issues, `go generate` and compatgen zero-diff.
