### PR TITLE
feat(azure-vnet): serve Microsoft.Network/routeTables + subnet route-table association

### DIFF
--- a/docs/coverage/aws/vpc.md
+++ b/docs/coverage/aws/vpc.md
@@ -88,13 +88,16 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | --- | --- |
 | `DeleteAzureNSGMetadata` |  |
 | `DeleteAzureNSGRule` | DeleteAzureNSGRule removes a single custom security rule by name, leaving |
+| `DeleteAzureRouteTableMetadata` | DeleteAzureRouteTableMetadata drops the stored metadata for id (called when |
 | `DeleteAzureVNetMetadata` |  |
 | `DeleteAzureVNetPeering` | DeleteAzureVNetPeering removes a single peering by name, leaving every |
 | `GetAzureNSGMetadata` |  |
+| `GetAzureRouteTableMetadata` | GetAzureRouteTableMetadata returns the stored Azure route-table metadata for |
 | `GetAzureVNetMetadata` |  |
 | `GetAzureVNetPeering` | GetAzureVNetPeering returns one stored peering by name. |
 | `ListAzureVNetPeerings` | ListAzureVNetPeerings returns every peering stored for a VNet, ordered by |
 | `PutAzureNSGMetadata` |  |
+| `PutAzureRouteTableMetadata` | PutAzureRouteTableMetadata stores the Azure-only route-table fields (region, |
 | `PutAzureVNetMetadata` |  |
 | `SetAzureVNetPeeringState` | SetAzureVNetPeeringState atomically updates just the peeringState field of |
 | `UpdateAzureNATGateway` | UpdateAzureNATGateway re-applies the mutable fields of an existing NAT |

--- a/docs/coverage/azure/vnet.md
+++ b/docs/coverage/azure/vnet.md
@@ -88,13 +88,16 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | --- | --- |
 | `DeleteAzureNSGMetadata` |  |
 | `DeleteAzureNSGRule` | DeleteAzureNSGRule removes a single custom security rule by name, leaving |
+| `DeleteAzureRouteTableMetadata` | DeleteAzureRouteTableMetadata drops the stored metadata for id (called when |
 | `DeleteAzureVNetMetadata` |  |
 | `DeleteAzureVNetPeering` | DeleteAzureVNetPeering removes a single peering by name, leaving every |
 | `GetAzureNSGMetadata` |  |
+| `GetAzureRouteTableMetadata` | GetAzureRouteTableMetadata returns the stored Azure route-table metadata for |
 | `GetAzureVNetMetadata` |  |
 | `GetAzureVNetPeering` | GetAzureVNetPeering returns one stored peering by name. |
 | `ListAzureVNetPeerings` | ListAzureVNetPeerings returns every peering stored for a VNet, ordered by |
 | `PutAzureNSGMetadata` |  |
+| `PutAzureRouteTableMetadata` | PutAzureRouteTableMetadata stores the Azure-only route-table fields (region, |
 | `PutAzureVNetMetadata` |  |
 | `SetAzureVNetPeeringState` | SetAzureVNetPeeringState atomically updates just the peeringState field of |
 | `UpdateAzureNATGateway` | UpdateAzureNATGateway re-applies the mutable fields of an existing NAT |

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -6617,6 +6617,10 @@
             "doc": "DeleteAzureNSGRule removes a single custom security rule by name, leaving"
           },
           {
+            "name": "DeleteAzureRouteTableMetadata",
+            "doc": "DeleteAzureRouteTableMetadata drops the stored metadata for id (called when"
+          },
+          {
             "name": "DeleteAzureVNetMetadata"
           },
           {
@@ -6625,6 +6629,10 @@
           },
           {
             "name": "GetAzureNSGMetadata"
+          },
+          {
+            "name": "GetAzureRouteTableMetadata",
+            "doc": "GetAzureRouteTableMetadata returns the stored Azure route-table metadata for"
           },
           {
             "name": "GetAzureVNetMetadata"
@@ -6639,6 +6647,10 @@
           },
           {
             "name": "PutAzureNSGMetadata"
+          },
+          {
+            "name": "PutAzureRouteTableMetadata",
+            "doc": "PutAzureRouteTableMetadata stores the Azure-only route-table fields (region,"
           },
           {
             "name": "PutAzureVNetMetadata"

--- a/docs/coverage/gcp/vpc.md
+++ b/docs/coverage/gcp/vpc.md
@@ -88,13 +88,16 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | --- | --- |
 | `DeleteAzureNSGMetadata` |  |
 | `DeleteAzureNSGRule` | DeleteAzureNSGRule removes a single custom security rule by name, leaving |
+| `DeleteAzureRouteTableMetadata` | DeleteAzureRouteTableMetadata drops the stored metadata for id (called when |
 | `DeleteAzureVNetMetadata` |  |
 | `DeleteAzureVNetPeering` | DeleteAzureVNetPeering removes a single peering by name, leaving every |
 | `GetAzureNSGMetadata` |  |
+| `GetAzureRouteTableMetadata` | GetAzureRouteTableMetadata returns the stored Azure route-table metadata for |
 | `GetAzureVNetMetadata` |  |
 | `GetAzureVNetPeering` | GetAzureVNetPeering returns one stored peering by name. |
 | `ListAzureVNetPeerings` | ListAzureVNetPeerings returns every peering stored for a VNet, ordered by |
 | `PutAzureNSGMetadata` |  |
+| `PutAzureRouteTableMetadata` | PutAzureRouteTableMetadata stores the Azure-only route-table fields (region, |
 | `PutAzureVNetMetadata` |  |
 | `SetAzureVNetPeeringState` | SetAzureVNetPeeringState atomically updates just the peeringState field of |
 | `UpdateAzureNATGateway` | UpdateAzureNATGateway re-applies the mutable fields of an existing NAT |

--- a/docs/coverage/oci/vcn.md
+++ b/docs/coverage/oci/vcn.md
@@ -88,13 +88,16 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | --- | --- |
 | `DeleteAzureNSGMetadata` |  |
 | `DeleteAzureNSGRule` | DeleteAzureNSGRule removes a single custom security rule by name, leaving |
+| `DeleteAzureRouteTableMetadata` | DeleteAzureRouteTableMetadata drops the stored metadata for id (called when |
 | `DeleteAzureVNetMetadata` |  |
 | `DeleteAzureVNetPeering` | DeleteAzureVNetPeering removes a single peering by name, leaving every |
 | `GetAzureNSGMetadata` |  |
+| `GetAzureRouteTableMetadata` | GetAzureRouteTableMetadata returns the stored Azure route-table metadata for |
 | `GetAzureVNetMetadata` |  |
 | `GetAzureVNetPeering` | GetAzureVNetPeering returns one stored peering by name. |
 | `ListAzureVNetPeerings` | ListAzureVNetPeerings returns every peering stored for a VNet, ordered by |
 | `PutAzureNSGMetadata` |  |
+| `PutAzureRouteTableMetadata` | PutAzureRouteTableMetadata stores the Azure-only route-table fields (region, |
 | `PutAzureVNetMetadata` |  |
 | `SetAzureVNetPeeringState` | SetAzureVNetPeeringState atomically updates just the peeringState field of |
 | `UpdateAzureNATGateway` | UpdateAzureNATGateway re-applies the mutable fields of an existing NAT |

--- a/providers/azure/vnet/azure_network_metadata.go
+++ b/providers/azure/vnet/azure_network_metadata.go
@@ -130,6 +130,45 @@ func (m *Mock) DeleteAzureNSGRule(_ context.Context, id, ruleName string) error 
 	return nil
 }
 
+// PutAzureRouteTableMetadata stores the Azure-only route-table fields (region,
+// routes and user tags) for the route table with the given driver id, replacing
+// any previously stored metadata.
+func (m *Mock) PutAzureRouteTableMetadata(_ context.Context, id string, meta driver.AzureRouteTableMetadata) error {
+	m.azureRouteTableMeta.Set(id, cloneRouteTableMeta(meta))
+	return nil
+}
+
+// GetAzureRouteTableMetadata returns the stored Azure route-table metadata for id.
+func (m *Mock) GetAzureRouteTableMetadata(_ context.Context, id string) (driver.AzureRouteTableMetadata, bool) {
+	meta, ok := m.azureRouteTableMeta.Get(id)
+	if !ok {
+		return driver.AzureRouteTableMetadata{}, false
+	}
+
+	return cloneRouteTableMeta(meta), true
+}
+
+// DeleteAzureRouteTableMetadata drops the stored metadata for id (called when
+// the route table is deleted).
+func (m *Mock) DeleteAzureRouteTableMetadata(_ context.Context, id string) {
+	m.azureRouteTableMeta.Delete(id)
+}
+
+// cloneRouteTableMeta deep-copies the route slice and tag map so stored and
+// returned values never alias a caller's slice/map.
+func cloneRouteTableMeta(meta driver.AzureRouteTableMetadata) driver.AzureRouteTableMetadata {
+	out := driver.AzureRouteTableMetadata{Location: meta.Location}
+	if len(meta.Routes) > 0 {
+		out.Routes = append([]driver.AzureRoute(nil), meta.Routes...)
+	}
+
+	if len(meta.Tags) > 0 {
+		out.Tags = copyTags(meta.Tags)
+	}
+
+	return out
+}
+
 // cloneVNetMeta deep-copies the address-prefix slice so stored and returned
 // values never alias a caller's slice.
 func cloneVNetMeta(meta driver.AzureVNetMetadata) driver.AzureVNetMetadata {

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -69,6 +69,10 @@ type Mock struct {
 	// list, Azure security rules), keyed by the driver resource id.
 	azureVNetMeta *memstore.Store[driver.AzureVNetMetadata]
 	azureNSGMeta  *memstore.Store[driver.AzureNSGMetadata]
+	// azureRouteTableMeta holds the ARM-specific route-table fields (region,
+	// routes, user tags) the cross-cloud RouteTable model cannot represent, keyed
+	// by the driver route table id.
+	azureRouteTableMeta *memstore.Store[driver.AzureRouteTableMetadata]
 	// azureVNetPeerings holds the ARM-specific virtualNetworkPeerings
 	// sub-resources for each VNet, keyed by the VNet's driver id, separately
 	// from azureVNetMeta so a whole-VNet PUT's PutAzureVNetMetadata (which
@@ -85,23 +89,24 @@ type Mock struct {
 // New creates a new Azure Virtual Network mock.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		vpcs:              memstore.New[*vpcData](),
-		subnets:           memstore.New[*subnetData](),
-		securityGroups:    memstore.New[*sgData](),
-		peerings:          memstore.New[*peeringData](),
-		natGateways:       memstore.New[*natGatewayData](),
-		flowLogs:          memstore.New[*flowLogData](),
-		routeTables:       memstore.New[*routeTableData](),
-		networkACLs:       memstore.New[*networkACLData](),
-		igws:              memstore.New[*igwData](),
-		eips:              memstore.New[*eipData](),
-		rtAssocs:          memstore.New[*rtAssocData](),
-		endpoints:         memstore.New[*driver.VPCEndpoint](),
-		nics:              memstore.New[*nicData](),
-		azureVNetMeta:     memstore.New[driver.AzureVNetMetadata](),
-		azureNSGMeta:      memstore.New[driver.AzureNSGMetadata](),
-		azureVNetPeerings: memstore.New[[]driver.AzureVNetPeering](),
-		opts:              opts,
+		vpcs:                memstore.New[*vpcData](),
+		subnets:             memstore.New[*subnetData](),
+		securityGroups:      memstore.New[*sgData](),
+		peerings:            memstore.New[*peeringData](),
+		natGateways:         memstore.New[*natGatewayData](),
+		flowLogs:            memstore.New[*flowLogData](),
+		routeTables:         memstore.New[*routeTableData](),
+		networkACLs:         memstore.New[*networkACLData](),
+		igws:                memstore.New[*igwData](),
+		eips:                memstore.New[*eipData](),
+		rtAssocs:            memstore.New[*rtAssocData](),
+		endpoints:           memstore.New[*driver.VPCEndpoint](),
+		nics:                memstore.New[*nicData](),
+		azureVNetMeta:       memstore.New[driver.AzureVNetMetadata](),
+		azureNSGMeta:        memstore.New[driver.AzureNSGMetadata](),
+		azureRouteTableMeta: memstore.New[driver.AzureRouteTableMetadata](),
+		azureVNetPeerings:   memstore.New[[]driver.AzureVNetPeering](),
+		opts:                opts,
 	}
 }
 

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -12,6 +12,8 @@
 //	GET .../virtualNetworks/{vn}/subnets                 — list subnets
 //	PUT/GET/DELETE  .../networkSecurityGroups/{name}     — NSG CRUD
 //	GET .../networkSecurityGroups                        — list NSGs
+//	PUT/GET/DELETE  .../routeTables/{name}               — route table CRUD
+//	GET .../routeTables                                  — list route tables
 //	PUT/GET/DELETE  .../networkInterfaces/{name}         — NIC CRUD
 //	GET .../networkInterfaces                            — list NICs
 //	PUT/GET/DELETE  .../virtualNetworks/{vn}/virtualNetworkPeerings/{n} — peering CRUD
@@ -32,6 +34,7 @@ const (
 	providerName     = "Microsoft.Network"
 	typeVNet         = "virtualNetworks"
 	typeNSG          = "networkSecurityGroups"
+	typeRouteTable   = "routeTables"
 	typePublicIP     = "publicIPAddresses"
 	typeLocations    = "locations"
 	armNameTag       = "cloudemu:azureNetName"
@@ -57,7 +60,16 @@ const (
 	// armSubnetNSGTag stores the full ARM resource id of the network security
 	// group a subnet is associated with (set via the subnet's own
 	// networkSecurityGroup property), mirroring armSubnetNATTag.
-	armSubnetNSGTag     = "cloudemu:azureSubnetNSG"
+	armSubnetNSGTag = "cloudemu:azureSubnetNSG"
+	// armSubnetRouteTableTag stores the full ARM resource id of the route table a
+	// subnet is associated with (set via the subnet's own routeTable property),
+	// mirroring armSubnetNSGTag.
+	armSubnetRouteTableTag = "cloudemu:azureSubnetRouteTable"
+	// armRouteTableTag / armRouteTableRGTag record a route table's ARM name and
+	// resource group on its driver anchor so it is addressable by (rg, name), the
+	// same way armNSGTag / armNSGRGTag scope network security groups.
+	armRouteTableTag    = "cloudemu:azureRouteTableName"
+	armRouteTableRGTag  = "cloudemu:azureRouteTableResourceGroup"
 	defaultLoc          = "eastus"
 	subResSubnets       = "subnets"
 	subResSecurityRules = "securityRules"
@@ -89,7 +101,7 @@ func (*Handler) Matches(r *http.Request) bool {
 	}
 
 	switch rp.ResourceType {
-	case typeVNet, typeNSG, typePublicIP, typeNIC, typeNATGateway, typeLocations:
+	case typeVNet, typeNSG, typeRouteTable, typePublicIP, typeNIC, typeNATGateway, typeLocations:
 		return true
 	}
 
@@ -118,6 +130,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.routeVNet(w, r, rp)
 	case typeNSG:
 		h.routeNSG(w, r, rp)
+	case typeRouteTable:
+		h.routeRouteTable(w, r, rp)
 	case typePublicIP:
 		h.routePublicIP(w, r, rp)
 	case typeNIC:
@@ -420,8 +434,9 @@ func (h *Handler) updateInlineSubnet(
 
 	natID := inlineRefID(sub.Properties.NatGateway)
 	nsgID := inlineRefID(sub.Properties.NetworkSecurityGroup)
+	routeTableID := inlineRefID(sub.Properties.RouteTable)
 
-	_, err := h.updateExistingSubnet(ctx, existing, cidr, natID, nsgID)
+	_, err := h.updateExistingSubnet(ctx, existing, cidr, natID, nsgID, routeTableID)
 
 	return err
 }
@@ -447,6 +462,10 @@ func inlineSubnetTags(sub *subnetRequest) map[string]string {
 
 	if sub.Properties.NetworkSecurityGroup != nil {
 		tags = mergeTags(tags, armSubnetNSGTag, sub.Properties.NetworkSecurityGroup.ID)
+	}
+
+	if sub.Properties.RouteTable != nil {
+		tags = mergeTags(tags, armSubnetRouteTableTag, sub.Properties.RouteTable.ID)
 	}
 
 	return tags
@@ -580,6 +599,7 @@ func (h *Handler) PurgeResourceGroup(ctx context.Context, _, resourceGroup strin
 	recordErr(h.purgePublicIPs(ctx, resourceGroup))
 	recordErr(h.purgeVNets(ctx, resourceGroup))
 	recordErr(h.purgeNSGs(ctx, resourceGroup))
+	recordErr(h.purgeRouteTables(ctx, resourceGroup))
 
 	return firstErr
 }
@@ -790,12 +810,18 @@ func (h *Handler) createSubnet(w http.ResponseWriter, r *http.Request, rp azurea
 		return
 	}
 
+	routeTableID, ok := h.resolveSubnetRouteTable(w, r, req.Properties.RouteTable)
+	if !ok {
+		return
+	}
+
 	if verr := h.validateSubnetCIDR(r.Context(), vnet.ID, rp.SubResourceName, req.Properties.AddressPrefix); verr != nil {
 		writeSubnetValidationError(w, verr)
 		return
 	}
 
-	info, err := h.upsertSubnet(r.Context(), vnet.ID, rp.SubResourceName, req.Properties.AddressPrefix, natGatewayID, nsgID)
+	info, err := h.upsertSubnet(r.Context(), vnet.ID, rp.SubResourceName,
+		req.Properties.AddressPrefix, natGatewayID, nsgID, routeTableID)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -827,6 +853,19 @@ func (h *Handler) resolveSubnetNSG(w http.ResponseWriter, r *http.Request, ref *
 	return h.resolveSubnetRef(w, r, ref, typeNSG, "networkSecurityGroup",
 		func(ctx context.Context, rg, name string) error {
 			_, err := findNSGInGroup(ctx, h.net, rg, name)
+			return err
+		})
+}
+
+// resolveSubnetRouteTable validates and resolves an optional routeTable
+// reference on a subnet PUT body, writing the appropriate error response
+// itself. ok is false when a response was already written and the caller must
+// stop. The reference is resolved within its own resource group so a subnet
+// cannot associate a route table that only exists in a different group.
+func (h *Handler) resolveSubnetRouteTable(w http.ResponseWriter, r *http.Request, ref *armIDRef) (id string, ok bool) {
+	return h.resolveSubnetRef(w, r, ref, typeRouteTable, "routeTable",
+		func(ctx context.Context, rg, name string) error {
+			_, err := h.findRouteTableInGroup(ctx, rg, name)
 			return err
 		})
 }
@@ -865,9 +904,11 @@ func (*Handler) resolveSubnetRef(
 // from the request body so an omitted reference (empty id) CLEARS the existing
 // association. Both associations live on the subnet's own natGateway /
 // networkSecurityGroup properties.
-func (h *Handler) upsertSubnet(ctx context.Context, vpcID, name, cidr, natGatewayID, nsgID string) (*netdriver.SubnetInfo, error) {
+func (h *Handler) upsertSubnet(
+	ctx context.Context, vpcID, name, cidr, natGatewayID, nsgID, routeTableID string,
+) (*netdriver.SubnetInfo, error) {
 	if existing, err := findSubnetInVNet(ctx, h.net, vpcID, name); err == nil {
-		return h.updateExistingSubnet(ctx, existing, cidr, natGatewayID, nsgID)
+		return h.updateExistingSubnet(ctx, existing, cidr, natGatewayID, nsgID, routeTableID)
 	}
 
 	tags := mergeTags(nil, armSubnetTag, name)
@@ -877,6 +918,10 @@ func (h *Handler) upsertSubnet(ctx context.Context, vpcID, name, cidr, natGatewa
 
 	if nsgID != "" {
 		tags = mergeTags(tags, armSubnetNSGTag, nsgID)
+	}
+
+	if routeTableID != "" {
+		tags = mergeTags(tags, armSubnetRouteTableTag, routeTableID)
 	}
 
 	return h.net.CreateSubnet(ctx, netdriver.SubnetConfig{
@@ -891,7 +936,7 @@ func (h *Handler) upsertSubnet(ctx context.Context, vpcID, name, cidr, natGatewa
 // gateway associations from the request body (an omitted reference — empty id —
 // clears that association, matching ARM's full-replacement semantics).
 func (h *Handler) updateExistingSubnet(
-	ctx context.Context, existing *netdriver.SubnetInfo, cidr, natGatewayID, nsgID string,
+	ctx context.Context, existing *netdriver.SubnetInfo, cidr, natGatewayID, nsgID, routeTableID string,
 ) (*netdriver.SubnetInfo, error) {
 	if cidr != "" && cidr != existing.CIDRBlock {
 		if u, ok := h.net.(netdriver.SubnetCIDRUpdater); ok {
@@ -908,6 +953,10 @@ func (h *Handler) updateExistingSubnet(
 	}
 
 	if err := h.replaceSubnetAssociation(ctx, existing, armSubnetNATTag, natGatewayID); err != nil {
+		return nil, err
+	}
+
+	if err := h.replaceSubnetAssociation(ctx, existing, armSubnetRouteTableTag, routeTableID); err != nil {
 		return nil, err
 	}
 
@@ -1617,6 +1666,10 @@ func toSubnetResponse(info *netdriver.SubnetInfo, rp azurearm.ResourcePath) subn
 		out.Properties.NetworkSecurityGroup = &armIDRef{ID: nsgID}
 	}
 
+	if rtID := tagOr(info.Tags, armSubnetRouteTableTag, ""); rtID != "" {
+		out.Properties.RouteTable = &armIDRef{ID: rtID}
+	}
+
 	return out
 }
 
@@ -1659,6 +1712,14 @@ func (h *Handler) nsgResponse(ctx context.Context, info *netdriver.SecurityGroup
 // reference (armSubnetNSGTag) matching nsgARMID, the read-only back-reference
 // real ARM reports on a networkSecurityGroups GET.
 func (h *Handler) nsgAssociatedSubnets(ctx context.Context, nsgARMID string) []armIDRef {
+	return h.subnetsAssociatedByTag(ctx, armSubnetNSGTag, nsgARMID)
+}
+
+// subnetsAssociatedByTag scans every subnet for an association tag (tagKey)
+// whose value matches armID and returns the subnets' ARM ids — the read-only
+// back-reference an NSG / route table reports once a subnet points at it. armID
+// supplies the subscription/resource-group for the built subnet ids.
+func (h *Handler) subnetsAssociatedByTag(ctx context.Context, tagKey, armID string) []armIDRef {
 	subs, err := h.net.DescribeSubnets(ctx, nil)
 	if err != nil {
 		return nil
@@ -1669,7 +1730,7 @@ func (h *Handler) nsgAssociatedSubnets(ctx context.Context, nsgARMID string) []a
 	var out []armIDRef
 
 	for i := range subs {
-		if !strings.EqualFold(tagOr(subs[i].Tags, armSubnetNSGTag, ""), nsgARMID) {
+		if !strings.EqualFold(tagOr(subs[i].Tags, tagKey, ""), armID) {
 			continue
 		}
 
@@ -1684,7 +1745,7 @@ func (h *Handler) nsgAssociatedSubnets(ctx context.Context, nsgARMID string) []a
 			vnetNames[subs[i].VPCID] = vnetName
 		}
 
-		out = append(out, armIDRef{ID: subnetResourceID(nsgARMID, vnetName, tagOr(subs[i].Tags, armSubnetTag, ""))})
+		out = append(out, armIDRef{ID: subnetResourceID(armID, vnetName, tagOr(subs[i].Tags, armSubnetTag, ""))})
 	}
 
 	return out

--- a/server/azure/vnet/route_table.go
+++ b/server/azure/vnet/route_table.go
@@ -1,0 +1,307 @@
+package vnet
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// RouteTable operations (RouteTablesClient / azurerm_route_table). Mirrors the
+// networkSecurityGroups path: the cross-cloud RouteTable acts as an anchor
+// (addressable by (rg, name) via armRouteTableTag / armRouteTableRGTag) while
+// the ARM-specific fields (region, routes, user tags) round-trip through the
+// Azure route-table metadata store.
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) routeRouteTable(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.ResourceName == "" {
+		h.listRouteTables(w, r, rp)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createRouteTable(w, r, rp)
+	case http.MethodGet:
+		h.getRouteTable(w, r, rp)
+	case http.MethodDelete:
+		h.deleteRouteTable(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) createRouteTable(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	var req routeTableRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	info, err := h.upsertRouteTable(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	loc := req.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	if meta, ok := h.azureMeta(); ok {
+		_ = meta.PutAzureRouteTableMetadata(r.Context(), info.ID, netdriver.AzureRouteTableMetadata{
+			Location: loc,
+			Routes:   toAzureRoutes(req.Properties.Routes),
+			Tags:     req.Tags,
+		})
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "routetable-create-"+rp.ResourceName, h.routeTableResponse(r.Context(), info, rp))
+}
+
+// upsertRouteTable reuses an existing route table of the same name (idempotent
+// re-PUT) or creates one, anchoring the driver route table to any VNet
+// (creating a synthetic one when none exists, as the driver requires a VPC id).
+func (h *Handler) upsertRouteTable(ctx context.Context, rg, name string) (*netdriver.RouteTable, error) {
+	if existing, err := h.findRouteTableInGroup(ctx, rg, name); err == nil {
+		return existing, nil
+	}
+
+	vpcs, _ := h.net.DescribeVPCs(ctx, nil)
+
+	var anchor string
+
+	if len(vpcs) > 0 {
+		anchor = vpcs[0].ID
+	} else {
+		v, vErr := h.net.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		if vErr != nil {
+			return nil, vErr
+		}
+
+		anchor = v.ID
+	}
+
+	return h.net.CreateRouteTable(ctx, netdriver.RouteTableConfig{
+		VPCID: anchor,
+		Tags:  mergeTags(mergeTags(nil, armRouteTableTag, name), armRouteTableRGTag, rg),
+	})
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getRouteTable(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	info, err := h.findRouteTableInGroup(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, h.routeTableResponse(r.Context(), info, rp))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listRouteTables(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	infos, err := h.net.DescribeRouteTables(r.Context(), nil)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := routeTableListResponse{}
+
+	for i := range infos {
+		name := tagOr(infos[i].Tags, armRouteTableTag, "")
+		if name == "" {
+			continue // not an ARM-managed route table (no name anchor)
+		}
+
+		itemRG := tagOr(infos[i].Tags, armRouteTableRGTag, "")
+		if rp.ResourceGroup != "" && !strings.EqualFold(itemRG, rp.ResourceGroup) {
+			continue
+		}
+
+		scope := rp
+		scope.ResourceName = name
+
+		if scope.ResourceGroup == "" {
+			scope.ResourceGroup = itemRG
+		}
+
+		out.Value = append(out.Value, h.routeTableResponse(r.Context(), &infos[i], scope))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteRouteTable(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	info, err := h.findRouteTableInGroup(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if meta, ok := h.azureMeta(); ok {
+		meta.DeleteAzureRouteTableMetadata(r.Context(), info.ID)
+	}
+
+	if err := h.net.DeleteRouteTable(r.Context(), info.ID); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "routetable-delete-"+rp.ResourceName, nil)
+}
+
+// findRouteTableInGroup resolves a route table by both its ARM name and resource
+// group; see findNSGInGroup for the rg semantics.
+func (h *Handler) findRouteTableInGroup(ctx context.Context, rg, name string) (*netdriver.RouteTable, error) {
+	infos, err := h.net.DescribeRouteTables(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range infos {
+		if tagOr(infos[i].Tags, armRouteTableTag, "") != name {
+			continue
+		}
+
+		if rg != "" && !strings.EqualFold(tagOr(infos[i].Tags, armRouteTableRGTag, ""), rg) {
+			continue
+		}
+
+		return &infos[i], nil
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "routeTable %s not found", name)
+}
+
+// purgeRouteTables deletes every route table (with its metadata) in the resource
+// group, returning the first delete error encountered.
+//
+//nolint:dupl // mirrors purgeNSGs over a distinct resource type and store by design
+func (h *Handler) purgeRouteTables(ctx context.Context, resourceGroup string) error {
+	rts, err := h.net.DescribeRouteTables(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	var firstErr error
+
+	for i := range rts {
+		if !strings.EqualFold(tagOr(rts[i].Tags, armRouteTableRGTag, ""), resourceGroup) {
+			continue
+		}
+
+		if meta, ok := h.azureMeta(); ok {
+			meta.DeleteAzureRouteTableMetadata(ctx, rts[i].ID)
+		}
+
+		if derr := h.net.DeleteRouteTable(ctx, rts[i].ID); derr != nil && firstErr == nil {
+			firstErr = derr
+		}
+	}
+
+	return firstErr
+}
+
+// Response shaping.
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) routeTableResponse(ctx context.Context, info *netdriver.RouteTable, rp azurearm.ResourcePath) routeTableResponse {
+	location := defaultLoc
+
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeRouteTable, rp.ResourceName)
+
+	var (
+		routes []route
+		tags   map[string]string
+	)
+
+	if meta, ok := h.azureMeta(); ok {
+		if md, found := meta.GetAzureRouteTableMetadata(ctx, info.ID); found {
+			if md.Location != "" {
+				location = md.Location
+			}
+
+			routes = fromAzureRoutes(id, md.Routes)
+			tags = md.Tags
+		}
+	}
+
+	if routes == nil {
+		routes = []route{}
+	}
+
+	return routeTableResponse{
+		ID:       id,
+		Name:     rp.ResourceName,
+		Type:     providerName + "/" + typeRouteTable,
+		Location: location,
+		Etag:     etagOf(id),
+		Tags:     tags,
+		Properties: routeTableResponseProps{
+			ProvisioningState: provisioningSucceeded,
+			Routes:            routes,
+			Subnets:           h.routeTableAssociatedSubnets(ctx, id),
+		},
+	}
+}
+
+// routeTableAssociatedSubnets scans every subnet for a routeTable reference
+// (armSubnetRouteTableTag) matching rtARMID, the read-only back-reference real
+// ARM reports on a routeTables GET (mirrors nsgAssociatedSubnets).
+func (h *Handler) routeTableAssociatedSubnets(ctx context.Context, rtARMID string) []armIDRef {
+	return h.subnetsAssociatedByTag(ctx, armSubnetRouteTableTag, rtARMID)
+}
+
+// toAzureRoutes maps the wire route shape to the stored driver representation,
+// keeping empty fields verbatim so a Get round-trips exactly what was sent.
+func toAzureRoutes(in []route) []netdriver.AzureRoute {
+	out := make([]netdriver.AzureRoute, 0, len(in))
+
+	for i := range in {
+		p := in[i].Properties
+		out = append(out, netdriver.AzureRoute{
+			Name:             in[i].Name,
+			AddressPrefix:    p.AddressPrefix,
+			NextHopType:      p.NextHopType,
+			NextHopIPAddress: p.NextHopIPAddress,
+		})
+	}
+
+	return out
+}
+
+// fromAzureRoutes maps stored driver routes back to their wire shape, stamping
+// each route's ARM id and a terminal provisioning state.
+func fromAzureRoutes(routeTableID string, in []netdriver.AzureRoute) []route {
+	out := make([]route, 0, len(in))
+
+	for i := range in {
+		rt := in[i]
+		out = append(out, route{
+			Name: rt.Name,
+			ID:   routeTableID + "/routes/" + rt.Name,
+			Properties: routeProps{
+				AddressPrefix:     rt.AddressPrefix,
+				NextHopType:       rt.NextHopType,
+				NextHopIPAddress:  rt.NextHopIPAddress,
+				ProvisioningState: provisioningSucceeded,
+			},
+		})
+	}
+
+	return out
+}

--- a/server/azure/vnet/route_table_test.go
+++ b/server/azure/vnet/route_table_test.go
@@ -1,0 +1,245 @@
+package vnet_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+const rtSubID = "sub-1"
+
+func routeTableARMID(rg, name string) string {
+	return "/subscriptions/" + rtSubID + "/resourceGroups/" + rg +
+		"/providers/Microsoft.Network/routeTables/" + name
+}
+
+// TestSDKRouteTableRoundTrip drives the real armnetwork RouteTablesClient
+// through create (with two routes), get (routes echoed) and list — the
+// Microsoft.Network/routeTables wire handler that used to 501. Cases (a) + (e).
+func TestSDKRouteTableRoundTrip(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	client, err := armnetwork.NewRouteTablesClient(rtSubID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp, err := client.BeginCreateOrUpdate(ctx, "rg-1", "rt-1", armnetwork.RouteTable{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.RouteTablePropertiesFormat{
+			Routes: []*armnetwork.Route{
+				{
+					Name: to.Ptr("to-appliance"),
+					Properties: &armnetwork.RoutePropertiesFormat{
+						AddressPrefix:    to.Ptr("10.1.0.0/16"),
+						NextHopType:      to.Ptr(armnetwork.RouteNextHopTypeVirtualAppliance),
+						NextHopIPAddress: to.Ptr("10.0.0.4"),
+					},
+				},
+				{
+					Name: to.Ptr("to-internet"),
+					Properties: &armnetwork.RoutePropertiesFormat{
+						AddressPrefix: to.Ptr("0.0.0.0/0"),
+						NextHopType:   to.Ptr(armnetwork.RouteNextHopTypeInternet),
+					},
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	pollDone(t, cp)
+
+	got, err := client.Get(ctx, "rg-1", "rt-1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	assertRoutesRoundTrip(t, got.Properties)
+
+	// (e) list route tables in the resource group.
+	pager := client.NewListPager("rg-1", nil)
+
+	var names []string
+
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("list: %v", perr)
+		}
+
+		for _, rt := range page.Value {
+			names = append(names, *rt.Name)
+		}
+	}
+
+	if len(names) != 1 || names[0] != "rt-1" {
+		t.Fatalf("list names=%v want [rt-1]", names)
+	}
+}
+
+func assertRoutesRoundTrip(t *testing.T, props *armnetwork.RouteTablePropertiesFormat) {
+	t.Helper()
+
+	if props == nil || len(props.Routes) != 2 {
+		t.Fatalf("routes=%v want 2 entries", props)
+	}
+
+	byName := map[string]*armnetwork.RoutePropertiesFormat{}
+	for _, r := range props.Routes {
+		byName[*r.Name] = r.Properties
+	}
+
+	appl := byName["to-appliance"]
+	if appl == nil || *appl.AddressPrefix != "10.1.0.0/16" ||
+		*appl.NextHopType != armnetwork.RouteNextHopTypeVirtualAppliance || *appl.NextHopIPAddress != "10.0.0.4" {
+		t.Errorf("to-appliance route=%+v", appl)
+	}
+
+	inet := byName["to-internet"]
+	if inet == nil || *inet.AddressPrefix != "0.0.0.0/0" || *inet.NextHopType != armnetwork.RouteNextHopTypeInternet {
+		t.Errorf("to-internet route=%+v", inet)
+	}
+}
+
+// TestSDKSubnetRouteTableAssociation drives azurerm_subnet_route_table_association:
+// a subnet PUT carrying a routeTable id reflects it on GET (the route table
+// staying resolvable), and a subsequent PUT omitting it clears the association.
+// Cases (b) + (c).
+func TestSDKSubnetRouteTableAssociation(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	rtID := routeTableARMID("rg-1", "rt-assoc")
+	createRouteTable(t, ts, "rg-1", "rt-assoc")
+	createVNet(t, ts, "rg-1", "vnet-1", "10.0.0.0/16")
+
+	subnets, err := armnetwork.NewSubnetsClient(rtSubID, fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// (b) associate the route table via the subnet's own routeTable property.
+	sp, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-1", "snet-1", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix: to.Ptr("10.0.1.0/24"),
+			RouteTable:    &armnetwork.RouteTable{ID: to.Ptr(rtID)},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("subnet create: %v", err)
+	}
+
+	pollDone(t, sp)
+
+	got, err := subnets.Get(ctx, "rg-1", "vnet-1", "snet-1", nil)
+	if err != nil {
+		t.Fatalf("subnet get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.RouteTable == nil || *got.Properties.RouteTable.ID != rtID {
+		t.Fatalf("subnet routeTable=%v want %s", got.Properties, rtID)
+	}
+
+	// Route table still resolvable after the association.
+	rtClient, _ := armnetwork.NewRouteTablesClient(rtSubID, fakeCred{}, opts)
+	if _, gerr := rtClient.Get(ctx, "rg-1", "rt-assoc", nil); gerr != nil {
+		t.Fatalf("route table Get after assoc: %v", gerr)
+	}
+
+	// (c) disassociate: PUT the subnet again without a routeTable clears it.
+	cp, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-1", "snet-1", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix: to.Ptr("10.0.1.0/24"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("subnet update: %v", err)
+	}
+
+	pollDone(t, cp)
+
+	cleared, err := subnets.Get(ctx, "rg-1", "vnet-1", "snet-1", nil)
+	if err != nil {
+		t.Fatalf("subnet get after clear: %v", err)
+	}
+
+	if cleared.Properties != nil && cleared.Properties.RouteTable != nil {
+		t.Fatalf("routeTable still present after clear: %v", cleared.Properties.RouteTable)
+	}
+}
+
+// TestSDKSubnetRouteTableNotFound checks that a subnet referencing a route table
+// that does not exist is rejected (the NSG-analog 404 ResourceNotFound). Case (d).
+func TestSDKSubnetRouteTableNotFound(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	createVNet(t, ts, "rg-1", "vnet-nf", "10.0.0.0/16")
+
+	subnets, err := armnetwork.NewSubnetsClient(rtSubID, fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-nf", "snet-nf", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix: to.Ptr("10.0.1.0/24"),
+			RouteTable:    &armnetwork.RouteTable{ID: to.Ptr(routeTableARMID("rg-1", "ghost"))},
+		},
+	}, nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("want 404 for missing route table, got %v", err)
+	}
+}
+
+func createRouteTable(t *testing.T, ts *httptest.Server, rg, name string) {
+	t.Helper()
+
+	client, err := armnetwork.NewRouteTablesClient(rtSubID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := client.BeginCreateOrUpdate(context.Background(), rg, name, armnetwork.RouteTable{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create route table %s: %v", name, err)
+	}
+
+	pollDone(t, p)
+}
+
+func createVNet(t *testing.T, ts *httptest.Server, rg, name, prefix string) {
+	t.Helper()
+
+	client, err := armnetwork.NewVirtualNetworksClient(rtSubID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := client.BeginCreateOrUpdate(context.Background(), rg, name, armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr(prefix)}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create vnet %s: %v", name, err)
+	}
+
+	pollDone(t, p)
+}

--- a/server/azure/vnet/types.go
+++ b/server/azure/vnet/types.go
@@ -46,6 +46,7 @@ type subnetRequestProps struct {
 	AddressPrefix        string    `json:"addressPrefix,omitempty"`
 	NatGateway           *armIDRef `json:"natGateway,omitempty"`
 	NetworkSecurityGroup *armIDRef `json:"networkSecurityGroup,omitempty"`
+	RouteTable           *armIDRef `json:"routeTable,omitempty"`
 }
 
 type subnetResponse struct {
@@ -60,6 +61,7 @@ type subnetResponseProps struct {
 	AddressPrefix        string    `json:"addressPrefix,omitempty"`
 	NatGateway           *armIDRef `json:"natGateway,omitempty"`
 	NetworkSecurityGroup *armIDRef `json:"networkSecurityGroup,omitempty"`
+	RouteTable           *armIDRef `json:"routeTable,omitempty"`
 }
 
 type subnetListResponse struct {
@@ -243,4 +245,52 @@ type vnetPeeringResponseProps struct {
 
 type vnetPeeringListResponse struct {
 	Value []vnetPeeringResponse `json:"value"`
+}
+
+// RouteTables (RouteTablesClient / azurerm_route_table).
+
+type routeTableRequest struct {
+	Location   string                 `json:"location"`
+	Tags       map[string]string      `json:"tags,omitempty"`
+	Properties routeTableRequestProps `json:"properties,omitempty"`
+}
+
+type routeTableRequestProps struct {
+	Routes []route `json:"routes,omitempty"`
+}
+
+type route struct {
+	Name       string     `json:"name,omitempty"`
+	ID         string     `json:"id,omitempty"`
+	Properties routeProps `json:"properties,omitempty"`
+}
+
+type routeProps struct {
+	AddressPrefix     string `json:"addressPrefix,omitempty"`
+	NextHopType       string `json:"nextHopType,omitempty"`
+	NextHopIPAddress  string `json:"nextHopIpAddress,omitempty"`
+	ProvisioningState string `json:"provisioningState,omitempty"`
+}
+
+type routeTableResponse struct {
+	ID         string                  `json:"id"`
+	Name       string                  `json:"name"`
+	Type       string                  `json:"type"`
+	Location   string                  `json:"location"`
+	Etag       string                  `json:"etag,omitempty"`
+	Tags       map[string]string       `json:"tags,omitempty"`
+	Properties routeTableResponseProps `json:"properties"`
+}
+
+type routeTableResponseProps struct {
+	ProvisioningState string  `json:"provisioningState"`
+	Routes            []route `json:"routes"`
+	// Subnets is the read-only back-reference real ARM reports on a routeTables
+	// GET once the route table is associated with a subnet (mirrors
+	// nsgResponseProps.Subnets).
+	Subnets []armIDRef `json:"subnets,omitempty"`
+}
+
+type routeTableListResponse struct {
+	Value []routeTableResponse `json:"value"`
 }

--- a/services/networking/driver/azure_network_metadata.go
+++ b/services/networking/driver/azure_network_metadata.go
@@ -44,6 +44,29 @@ type AzureNSGMetadata struct {
 	SecurityRules []AzureNSGRule
 }
 
+// AzureRoute is one Azure route-table route, with the name / next-hop shape the
+// cross-cloud Route model (DestinationCIDR / TargetID / TargetType) cannot
+// represent. AddressPrefix and NextHopIPAddress are kept verbatim as the ARM
+// strings ("10.0.0.0/24", "10.0.1.4") so a Get round-trips exactly what the
+// caller sent. NextHopType is one of VirtualAppliance / VnetLocal / Internet /
+// VirtualNetworkGateway / None.
+type AzureRoute struct {
+	Name             string
+	AddressPrefix    string
+	NextHopType      string
+	NextHopIPAddress string
+}
+
+// AzureRouteTableMetadata holds the Azure-only route-table fields (region, the
+// caller's routes and user tags). The cross-cloud RouteTable model cannot carry
+// the ARM route shape, so it is stored alongside the driver route table and
+// keyed by that route table's driver id.
+type AzureRouteTableMetadata struct {
+	Location string
+	Routes   []AzureRoute
+	Tags     map[string]string
+}
+
 // Azure virtual-network peering states, matching Microsoft.Network's
 // VirtualNetworkPeeringState. A peering reports Initiated until its
 // reciprocal peering (a peering on the remote VNet pointing back at this
@@ -126,6 +149,18 @@ type AzureNetworkMetadata interface {
 	// duplicate. Its allocation id, address and any association are preserved.
 	// Returns NotFound when no public IP has that allocation id.
 	UpdateAzurePublicIP(ctx context.Context, allocationID string, cfg ElasticIPConfig) error
+
+	// PutAzureRouteTableMetadata stores the Azure-only route-table fields (region,
+	// routes and user tags) for the route table with the given driver id,
+	// replacing any previously stored metadata (a repeat ARM CreateOrUpdate PUT is
+	// a full replacement).
+	PutAzureRouteTableMetadata(ctx context.Context, id string, meta AzureRouteTableMetadata) error
+	// GetAzureRouteTableMetadata returns the stored Azure route-table metadata for
+	// id.
+	GetAzureRouteTableMetadata(ctx context.Context, id string) (AzureRouteTableMetadata, bool)
+	// DeleteAzureRouteTableMetadata drops the stored metadata for id (called when
+	// the route table is deleted).
+	DeleteAzureRouteTableMetadata(ctx context.Context, id string)
 
 	// UpdateAzureNATGateway re-applies the mutable fields of an existing NAT
 	// gateway (its bound public-IP allocation and tags), keyed by its id, so a


### PR DESCRIPTION
## Summary

Serves the last entirely-absent Azure network chain: `Microsoft.Network/routeTables` and the subnet <-> route-table association. Before this, `azurerm_route_table` and `azurerm_subnet_route_table_association` could not resolve or reflect because the route table resource type was never dispatched (501) and `subnet.properties.routeTable` was unmodeled.

The implementation mirrors the existing `networkSecurityGroups` subnet-association path exactly (NSG is the direct analog and already works end-to-end):

- **Route table CRUD wire handler** (`server/azure/vnet/route_table.go`): PUT/GET/DELETE/LIST `routeTables/{name}`, with nested `properties.routes[]` (name, addressPrefix, nextHopType, nextHopIpAddress) round-tripping on GET. Dispatch case registered in `handler.go`. The cross-cloud route table acts as an anchor (addressable by rg+name via tags) while ARM-specific fields round-trip through a new `AzureRouteTableMetadata` store — the same split NSG uses for its Azure security-rule metadata.
- **Subnet `properties.routeTable` ref**: added to subnet request/response props. A subnet PUT (standalone and inline under a vnet) validates the route table exists and reflects it on GET; omitting/nulling it clears the association — identical to the NSG path. Associated subnets also appear in the route table's read-only `subnets` back-reference.
- **Resource-group cascade**: `purgeRouteTables` wired into `PurgeResourceGroup`.
- **Delete-ordering**: no in-use guard, matching the NSG sibling (which does not guard subnet association either).

## Tests

Real `armnetwork` SDK over `httptest`:
- create route table with 2 routes -> GET echoes routes (addressPrefix/nextHopType/nextHopIpAddress)
- create subnet with routeTable id -> subnet GET reflects it; route table still resolvable
- subnet_route_table_association: PUT subnet with routeTable then clear -> reflected then gone
- subnet referencing a missing route table -> 404 (the NSG-analog ResourceNotFound)
- list route tables in the resource group

Coverage docs regenerated via `go generate ./...` (new metadata capability rows) and verified idempotent.

Gates: `go build ./...`, `go vet`, `go test` (azure server + providers + networking), gofmt, and `golangci-lint --new-from-rev=origin/development` (0 new) all green.
