### PR TITLE
fix(azure-eventgrid): deliver subscriptions to ServiceBus + Function destinations (not just WebHook)

### DIFF
--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -211,6 +211,8 @@ func New(opts ...config.Option) *Provider {
 	p.NotificationHubs.SetMonitoring(p.Monitor)
 	p.ACR.SetMonitoring(p.Monitor)
 	p.EventGrid.SetMonitoring(p.Monitor)
+	p.EventGrid.SetServiceBusDeliverer(p.ServiceBus)
+	p.EventGrid.SetFunctionInvoker(p.Functions)
 	p.SQL.SetMonitoring(p.Monitor)
 	p.PostgresFlex.SetMonitoring(p.Monitor)
 	p.MySQLFlex.SetMonitoring(p.Monitor)

--- a/providers/azure/eventgrid/delivery.go
+++ b/providers/azure/eventgrid/delivery.go
@@ -7,20 +7,27 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 )
 
-// endpointTypeWebHook is the only ARM EventSubscriptionDestination.endpointType
-// this mock actually delivers to (see deliverToTargets). ServiceBusQueue,
-// ServiceBusTopic, EventHub, AzureFunction, StorageQueue, and HybridConnection
-// destinations are parsed and round-trip on the subscription resource (the raw
-// ARM properties JSON is echoed verbatim regardless of type) but are not
-// delivered to: EventHub has no peer mock in this codebase, and wiring
-// ServiceBus/Functions delivery is left as a follow-up (see PR notes).
-const endpointTypeWebHook = "WebHook"
+// ARM EventSubscriptionDestination.endpointType values this mock delivers to.
+// WebHook POSTs the event envelope over HTTP; ServiceBusQueue/ServiceBusTopic
+// enqueue it into the peer Service Bus queue/topic; AzureFunction invokes the
+// peer Functions app with it. EventHub, StorageQueue, and HybridConnection
+// destinations are still parsed and round-trip on the subscription resource
+// (the raw ARM properties JSON is echoed verbatim regardless of type) but are
+// not delivered to: they have no peer mock in this codebase and are left as a
+// follow-up (see PR notes).
+const (
+	endpointTypeWebHook         = "WebHook"
+	endpointTypeServiceBusQueue = "ServiceBusQueue"
+	endpointTypeServiceBusTopic = "ServiceBusTopic"
+	endpointTypeAzureFunction   = "AzureFunction"
+)
 
 // defaultDataVersion is the dataVersion Event Grid stamps on a delivered event
 // when the publisher omitted one; metadataVersion is the read-only schema
@@ -99,18 +106,21 @@ type deliveryEvent struct {
 	MetadataVersion string          `json:"metadataVersion"`
 }
 
-// deliverToTargets POSTs event to every matched subscription's WebHook
-// destination. Delivery is synchronous (mirroring how AWS EventBridge's
-// deliverToTargets runs in-line in this codebase) but decoupled from the
-// caller's context so a client that cancels its publish request doesn't abort
-// in-flight deliveries. The caller ctx's re-entrant delivery depth is carried
-// forward so a self-referential WebHook chain (a subscription endpointUrl that
-// points back at this emulator's publish endpoint) stays bounded — the cap is
-// enforced in postWebhook, mirroring lambda.InvokeExternal. ServiceBusQueue/
-// Topic, EventHub, and AzureFunction destinations are parsed and round-trip on
-// the subscription resource, but are not delivered to: EventHub has no peer
-// mock in this codebase, and wiring ServiceBus/Functions delivery is left as a
-// follow-up (see PR notes).
+// deliverToTargets delivers event to every matched subscription's destination,
+// dispatched by the destination's endpointType: WebHook (HTTP POST),
+// ServiceBusQueue/ServiceBusTopic (enqueue into the peer Service Bus), and
+// AzureFunction (invoke the peer Functions app). All destinations receive the
+// same rendered EventGridEvent envelope. Delivery is synchronous (mirroring how
+// AWS EventBridge's deliverToTargets runs in-line in this codebase) but
+// decoupled from the caller's context so a client that cancels its publish
+// request doesn't abort in-flight deliveries. The caller ctx's re-entrant
+// delivery depth is carried forward so a self-referential chain (a WebHook that
+// points back at this emulator, or a Function that re-publishes) stays bounded —
+// the cap is enforced in postWebhook / functions.InvokeExternal, mirroring
+// lambda.InvokeExternal. EventHub, StorageQueue, and HybridConnection
+// destinations are parsed and round-trip on the subscription resource but are
+// not delivered to (no peer mock; see PR notes). Filters are already applied by
+// matchedRuleData, so every rd here is a filter-matched subscription.
 func (m *Mock) deliverToTargets(ctx context.Context, matched []*ruleData, event *driver.Event, topicARN string) {
 	if len(matched) == 0 {
 		return
@@ -137,12 +147,73 @@ func (m *Mock) deliverToTargets(ctx context.Context, matched []*ruleData, event 
 	}
 
 	for _, rd := range matched {
-		if rd.dest.EndpointType != endpointTypeWebHook || rd.dest.EndpointURL == "" {
-			continue
+		m.dispatchDestination(dctx, rd.dest, body)
+	}
+}
+
+// dispatchDestination routes one rendered envelope to a single subscription
+// destination by its endpointType. A nil peer (the injector was never wired) or
+// an unresolvable resource id is skipped gracefully — never a panic — matching
+// how EventBridge's dispatchTarget silently ignores an unwired sink.
+func (m *Mock) dispatchDestination(ctx context.Context, dest subscriptionDestination, body []byte) {
+	switch dest.EndpointType {
+	case endpointTypeWebHook:
+		if dest.EndpointURL != "" {
+			m.postWebhook(ctx, dest.EndpointURL, body)
+		}
+	case endpointTypeServiceBusQueue, endpointTypeServiceBusTopic:
+		if m.serviceBus == nil {
+			return
 		}
 
-		m.postWebhook(dctx, rd.dest.EndpointURL, body)
+		if name := resourceLeafName(dest.ResourceID); name != "" {
+			_ = m.serviceBus.DeliverExternal(ctx, name, string(body))
+		}
+	case endpointTypeAzureFunction:
+		if m.functions == nil {
+			return
+		}
+
+		if app := functionAppName(dest.ResourceID); app != "" {
+			_ = m.functions.InvokeExternal(ctx, app, body)
+		}
 	}
+}
+
+// resourceLeafName returns the trailing path segment of an ARM resource id — the
+// Service Bus queue or topic name in a ServiceBusQueue/ServiceBusTopic
+// destination's resourceId (.../namespaces/<ns>/queues/<q> or .../topics/<t>).
+func resourceLeafName(resourceID string) string {
+	trimmed := strings.TrimRight(resourceID, "/")
+	if trimmed == "" {
+		return ""
+	}
+
+	if i := strings.LastIndex(trimmed, "/"); i >= 0 {
+		return trimmed[i+1:]
+	}
+
+	return trimmed
+}
+
+// functionAppName returns the function-app (site) name from an AzureFunction
+// destination's resourceId (.../Microsoft.Web/sites/<app>/functions/<fn>). The
+// Functions mock is keyed by the app name (its Microsoft.Web/sites resource), so
+// the app segment — not the trailing <fn> — is what resolves the peer.
+func functionAppName(resourceID string) string {
+	const marker = "/sites/"
+
+	i := strings.Index(resourceID, marker)
+	if i < 0 {
+		return ""
+	}
+
+	rest := resourceID[i+len(marker):]
+	if j := strings.Index(rest, "/"); j >= 0 {
+		return rest[:j]
+	}
+
+	return rest
 }
 
 // postWebhook delivers one rendered batch to a WebHook endpoint, matching the

--- a/providers/azure/eventgrid/eventgrid.go
+++ b/providers/azure/eventgrid/eventgrid.go
@@ -55,17 +55,46 @@ type busData struct {
 	events []driver.Event
 }
 
+// ServiceBusDeliverer enqueues an Event Grid event envelope into a Service Bus
+// queue or topic identified by name (the leaf of the destination's ARM
+// resourceId). The servicebus.Mock satisfies this via DeliverExternal, enabling
+// EventGrid -> ServiceBusQueue/ServiceBusTopic delivery.
+type ServiceBusDeliverer interface {
+	DeliverExternal(ctx context.Context, name, body string) error
+}
+
+// FunctionInvoker asynchronously invokes an Azure Function app by name with the
+// event envelope. The functions.Mock satisfies this via InvokeExternal, enabling
+// EventGrid -> AzureFunction delivery.
+type FunctionInvoker interface {
+	InvokeExternal(ctx context.Context, name string, payload []byte) error
+}
+
 // Mock is an in-memory mock implementation of Azure Event Grid.
 type Mock struct {
 	buses      *memstore.Store[*busData]
 	opts       *config.Options
 	monitoring mondriver.Monitoring
 	httpClient *http.Client
+	serviceBus ServiceBusDeliverer
+	functions  FunctionInvoker
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
 func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
 	m.monitoring = mon
+}
+
+// SetServiceBusDeliverer wires the Service Bus backend so PutEvents delivers to
+// ServiceBusQueue/ServiceBusTopic subscription destinations.
+func (m *Mock) SetServiceBusDeliverer(d ServiceBusDeliverer) {
+	m.serviceBus = d
+}
+
+// SetFunctionInvoker wires the Functions backend so PutEvents invokes
+// AzureFunction subscription destinations.
+func (m *Mock) SetFunctionInvoker(i FunctionInvoker) {
+	m.functions = i
 }
 
 func (m *Mock) emitMetric(topicName string, metrics map[string]float64) {

--- a/providers/azure/eventgrid/servicebus_function_delivery_test.go
+++ b/providers/azure/eventgrid/servicebus_function_delivery_test.go
@@ -1,0 +1,262 @@
+package eventgrid
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/azure/functions"
+	"github.com/stackshy/cloudemu/v2/providers/azure/servicebus"
+	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+	fndriver "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// destinationResourceJSON builds the raw ARM EventSubscription properties for a
+// resourceId-based destination (ServiceBusQueue/ServiceBusTopic/AzureFunction),
+// optionally carrying a subjectBeginsWith filter.
+func destinationResourceJSON(endpointType, resourceID, subjectBeginsWith string) string {
+	props := map[string]any{
+		"destination": map[string]any{
+			"endpointType": endpointType,
+			"properties":   map[string]any{"resourceId": resourceID},
+		},
+	}
+
+	if subjectBeginsWith != "" {
+		props["filter"] = map[string]any{"subjectBeginsWith": subjectBeginsWith}
+	}
+
+	b, _ := json.Marshal(props)
+
+	return string(b)
+}
+
+func newPeerOpts() *config.Options {
+	return config.NewOptions(config.WithRegion("eastus"), config.WithAccountID("cloudemu"))
+}
+
+// TestPutEventsDeliversToServiceBusQueue is test (a): a ServiceBusQueue
+// destination must enqueue the event envelope into the peer Service Bus queue so
+// a receiver reads it.
+func TestPutEventsDeliversToServiceBusQueue(t *testing.T) {
+	ctx := context.Background()
+
+	sb := servicebus.New(newPeerOpts())
+	queue, err := sb.CreateQueue(ctx, mqdriver.QueueConfig{Name: "orders-q"})
+	require.NoError(t, err)
+
+	m, _ := newTestMock()
+	m.SetServiceBusDeliverer(sb)
+
+	createTestTopic(t, m, "orders")
+
+	resourceID := "/subscriptions/s/resourceGroups/rg/providers/Microsoft.ServiceBus/namespaces/ns1/queues/orders-q"
+
+	_, err = m.PutRule(ctx, &ebdriver.RuleConfig{
+		Name:        "sub-sbq",
+		EventBus:    "orders",
+		Description: destinationResourceJSON(endpointTypeServiceBusQueue, resourceID, ""),
+	})
+	require.NoError(t, err)
+
+	_, err = m.PutEvents(ctx, []ebdriver.Event{{
+		EventBus:   "orders",
+		DetailType: "Order.Created",
+		Detail:     `{"total":42}`,
+		Subject:    "orders/1",
+	}})
+	require.NoError(t, err)
+
+	msgs, err := sb.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{QueueURL: queue.URL, MaxMessages: 10})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	var batch []deliveryEvent
+	require.NoError(t, json.Unmarshal([]byte(msgs[0].Body), &batch))
+	require.Len(t, batch, 1)
+	assert.Equal(t, "Order.Created", batch[0].EventType)
+	assert.Equal(t, "orders/1", batch[0].Subject)
+	assert.JSONEq(t, `{"total":42}`, string(batch[0].Data))
+}
+
+// TestPutEventsDeliversToServiceBusTopic is test (b): a ServiceBusTopic
+// destination enqueues into the peer topic (modeled as a queue) so its
+// subscriptions receive the event.
+func TestPutEventsDeliversToServiceBusTopic(t *testing.T) {
+	ctx := context.Background()
+
+	sb := servicebus.New(newPeerOpts())
+	topic, err := sb.CreateQueue(ctx, mqdriver.QueueConfig{Name: "orders-t"})
+	require.NoError(t, err)
+
+	m, _ := newTestMock()
+	m.SetServiceBusDeliverer(sb)
+
+	createTestTopic(t, m, "orders")
+
+	resourceID := "/subscriptions/s/resourceGroups/rg/providers/Microsoft.ServiceBus/namespaces/ns1/topics/orders-t"
+
+	_, err = m.PutRule(ctx, &ebdriver.RuleConfig{
+		Name:        "sub-sbt",
+		EventBus:    "orders",
+		Description: destinationResourceJSON(endpointTypeServiceBusTopic, resourceID, ""),
+	})
+	require.NoError(t, err)
+
+	_, err = m.PutEvents(ctx, []ebdriver.Event{{
+		EventBus:   "orders",
+		DetailType: "Order.Shipped",
+		Subject:    "orders/9",
+	}})
+	require.NoError(t, err)
+
+	msgs, err := sb.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{QueueURL: topic.URL, MaxMessages: 10})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	var batch []deliveryEvent
+	require.NoError(t, json.Unmarshal([]byte(msgs[0].Body), &batch))
+	require.Len(t, batch, 1)
+	assert.Equal(t, "Order.Shipped", batch[0].EventType)
+}
+
+// TestPutEventsInvokesAzureFunction is test (c): an AzureFunction destination
+// must invoke the peer Functions app with the event envelope.
+func TestPutEventsInvokesAzureFunction(t *testing.T) {
+	ctx := context.Background()
+
+	fn := functions.New(newPeerOpts())
+	_, err := fn.CreateFunction(ctx, fndriver.FunctionConfig{Name: "orderfn", Runtime: "dotnet"})
+	require.NoError(t, err)
+
+	var (
+		mu      sync.Mutex
+		invoked [][]byte
+	)
+
+	fn.RegisterHandler("orderfn", func(_ context.Context, payload []byte) ([]byte, error) {
+		mu.Lock()
+		invoked = append(invoked, append([]byte(nil), payload...))
+		mu.Unlock()
+
+		return payload, nil
+	})
+
+	m, _ := newTestMock()
+	m.SetFunctionInvoker(fn)
+
+	createTestTopic(t, m, "orders")
+
+	resourceID := "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Web/sites/orderfn/functions/onEvent"
+
+	_, err = m.PutRule(ctx, &ebdriver.RuleConfig{
+		Name:        "sub-fn",
+		EventBus:    "orders",
+		Description: destinationResourceJSON(endpointTypeAzureFunction, resourceID, ""),
+	})
+	require.NoError(t, err)
+
+	_, err = m.PutEvents(ctx, []ebdriver.Event{{
+		EventBus:   "orders",
+		DetailType: "Order.Created",
+		Detail:     `{"total":7}`,
+		Subject:    "orders/2",
+	}})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, invoked, 1)
+
+	var batch []deliveryEvent
+	require.NoError(t, json.Unmarshal(invoked[0], &batch))
+	require.Len(t, batch, 1)
+	assert.Equal(t, "Order.Created", batch[0].EventType)
+	assert.JSONEq(t, `{"total":7}`, string(batch[0].Data))
+}
+
+// TestPutEventsResourceDestinationHonorsFilter is test (d): a filter that does
+// not match must suppress delivery to a ServiceBus destination, exactly as it
+// does for WebHook.
+func TestPutEventsResourceDestinationHonorsFilter(t *testing.T) {
+	ctx := context.Background()
+
+	sb := servicebus.New(newPeerOpts())
+	queue, err := sb.CreateQueue(ctx, mqdriver.QueueConfig{Name: "orders-q"})
+	require.NoError(t, err)
+
+	m, _ := newTestMock()
+	m.SetServiceBusDeliverer(sb)
+
+	createTestTopic(t, m, "orders")
+
+	resourceID := "/subscriptions/s/resourceGroups/rg/providers/Microsoft.ServiceBus/namespaces/ns1/queues/orders-q"
+
+	_, err = m.PutRule(ctx, &ebdriver.RuleConfig{
+		Name:        "sub-sbq",
+		EventBus:    "orders",
+		Description: destinationResourceJSON(endpointTypeServiceBusQueue, resourceID, "orders/"),
+	})
+	require.NoError(t, err)
+
+	_, err = m.PutEvents(ctx, []ebdriver.Event{{
+		EventBus:   "orders",
+		DetailType: "Invoice.Created",
+		Subject:    "invoices/1",
+	}})
+	require.NoError(t, err)
+
+	msgs, err := sb.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{QueueURL: queue.URL, MaxMessages: 10})
+	require.NoError(t, err)
+	assert.Empty(t, msgs, "a non-matching subject must not be delivered to the Service Bus queue")
+}
+
+// TestPutEventsResourceDestinationNilPeerNoPanic is test (e): with no peer wired,
+// ServiceBus/Function destinations are skipped gracefully — no panic, publish
+// still succeeds.
+func TestPutEventsResourceDestinationNilPeerNoPanic(t *testing.T) {
+	ctx := context.Background()
+
+	m, _ := newTestMock()
+	createTestTopic(t, m, "orders")
+
+	sbResource := "/subscriptions/s/resourceGroups/rg/providers/Microsoft.ServiceBus/namespaces/ns1/queues/q"
+	fnResource := "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Web/sites/app/functions/fn"
+
+	_, err := m.PutRule(ctx, &ebdriver.RuleConfig{
+		Name: "sub-sbq", EventBus: "orders",
+		Description: destinationResourceJSON(endpointTypeServiceBusQueue, sbResource, ""),
+	})
+	require.NoError(t, err)
+
+	_, err = m.PutRule(ctx, &ebdriver.RuleConfig{
+		Name: "sub-fn", EventBus: "orders",
+		Description: destinationResourceJSON(endpointTypeAzureFunction, fnResource, ""),
+	})
+	require.NoError(t, err)
+
+	result, err := m.PutEvents(ctx, []ebdriver.Event{{
+		EventBus: "orders", DetailType: "Order.Created", Subject: "orders/1",
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.SuccessCount)
+}
+
+// TestResourceLeafAndFunctionAppName pins the ARM resourceId parsing helpers.
+func TestResourceLeafAndFunctionAppName(t *testing.T) {
+	assert.Equal(t, "myq",
+		resourceLeafName("/subscriptions/s/providers/Microsoft.ServiceBus/namespaces/ns/queues/myq"))
+	assert.Equal(t, "myt",
+		resourceLeafName("/subscriptions/s/providers/Microsoft.ServiceBus/namespaces/ns/topics/myt/"))
+	assert.Equal(t, "", resourceLeafName(""))
+
+	assert.Equal(t, "app",
+		functionAppName("/subscriptions/s/providers/Microsoft.Web/sites/app/functions/fn"))
+	assert.Equal(t, "app", functionAppName("/subscriptions/s/providers/Microsoft.Web/sites/app"))
+	assert.Equal(t, "", functionAppName("/no/marker/here"))
+}

--- a/providers/azure/functions/functions.go
+++ b/providers/azure/functions/functions.go
@@ -13,6 +13,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
 	"github.com/stackshy/cloudemu/v2/services/serverless/funcengine"
@@ -277,6 +278,38 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 	})
 
 	return &driver.InvokeOutput{StatusCode: 200, Payload: payload}, nil
+}
+
+// InvokeExternal asynchronously invokes the named function app with payload,
+// used for cross-service delivery such as Event Grid -> AzureFunction where the
+// source only knows the destination app. A missing function is a no-op (the
+// subscription may point at an app this emulator never created), mirroring
+// lambda.InvokeExternal. ctx carries the re-entrant delivery depth (see
+// internal/recursionguard): a function that re-publishes an event that routes
+// back to itself would otherwise recurse unbounded, so once the depth reaches
+// recursionguard.MaxDepth further invocation is dropped.
+func (m *Mock) InvokeExternal(ctx context.Context, name string, payload []byte) error {
+	if _, ok := m.funcs.Get(name); !ok {
+		return nil
+	}
+
+	depth := recursionguard.Depth(ctx)
+	if depth >= recursionguard.MaxDepth {
+		return nil
+	}
+
+	ctx = recursionguard.WithDepth(ctx, depth+1)
+
+	out, err := m.Invoke(ctx, driver.InvokeInput{FunctionName: name, Payload: payload, InvokeType: "Event"})
+	if err != nil {
+		return err
+	}
+
+	if out != nil && out.Error != "" {
+		return cerrors.Newf(cerrors.Internal, "function %s returned an error: %s", name, out.Error)
+	}
+
+	return nil
 }
 
 // invokeEngine runs a function whose code was deployed to the configured

--- a/providers/azure/servicebus/servicebus.go
+++ b/providers/azure/servicebus/servicebus.go
@@ -139,6 +139,31 @@ func (m *Mock) RemoveTrigger(queueURL string) {
 	delete(m.triggers, queueURL)
 }
 
+// DeliverExternal enqueues body into the queue or topic whose name matches the
+// given name. It is used for cross-service delivery such as Event Grid ->
+// ServiceBusQueue/ServiceBusTopic, where the source only knows the destination's
+// ARM leaf name. A topic is modeled as a queue in this mock, so both resolve the
+// same way. Returns NotFound if no queue matches, which callers may ignore for a
+// best-effort sink.
+func (m *Mock) DeliverExternal(ctx context.Context, name, body string) error {
+	var url string
+
+	for _, qd := range m.queues.SortedValues() {
+		if qd.info.Name == name {
+			url = qd.info.URL
+			break
+		}
+	}
+
+	if url == "" {
+		return cerrors.Newf(cerrors.NotFound, "no queue found for name %q", name)
+	}
+
+	_, err := m.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: body})
+
+	return err
+}
+
 // CreateQueue creates a new Service Bus queue.
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.

--- a/providers/wiring_parity_test.go
+++ b/providers/wiring_parity_test.go
@@ -38,9 +38,9 @@
 //	Change stream -> function         DynamoDB.SetStreamInvoker (wired)      N/A: cosmosdb records its change feed   N/A: firestore records its change
 //	                                                                         internally but exposes no invoker       stream internally but exposes no
 //	                                                                         injector                                invoker injector
-//	Event bus -> targets              EventBridge.Set{SQSDeliverer,          N/A: eventgrid exposes SetMonitoring    N/A: eventarc exposes SetMonitoring
-//	                                  LambdaInvoker,SNSPublisher,            only, no target-delivery injector       only, no target-delivery injector
-//	                                  StepFunctionsStarter} (wired)
+//	Event bus -> targets              EventBridge.Set{SQSDeliverer,          EventGrid.Set{ServiceBusDeliverer,      N/A: eventarc exposes SetMonitoring
+//	                                  LambdaInvoker,SNSPublisher,            FunctionInvoker} (wired; ServiceBus-    only, no target-delivery injector
+//	                                  StepFunctionsStarter} (wired)          Queue/Topic + AzureFunction targets)
 //	Topic -> queue fan-out            SNS.SetSQSDeliverer (wired)            N/A: servicebus exposes no fan-out      N/A: pubsub exposes no fan-out
 //	                                                                         injector (SetTrigger is a per-queue     injector (SetTrigger is a per-queue
 //	                                                                         callback registration, not a           callback registration, not a


### PR DESCRIPTION
## Summary

Azure Event Grid accepted event subscriptions to ServiceBus and AzureFunction destinations (200, round-trips on the resource) but **never delivered to them** — only `WebHook` destinations were dispatched. So EventGrid->ServiceBus and EventGrid->Function (both common patterns) silently dropped every event: publish succeeded, nothing landed in the queue / invoked the function. Because the wire publish path (`server/azure/eventgrid/publish.go`) calls the same driver `PutEvents`, the gap held in wire mode too.

## What changed

- `deliverToTargets` now dispatches by `endpointType`:
  - **ServiceBusQueue / ServiceBusTopic** -> resolve the destination `resourceId` leaf (queue/topic name) and enqueue the rendered EventGrid envelope into the peer Service Bus via a new `servicebus.DeliverExternal(ctx, name, body)` (mirrors AWS `sqs.DeliverExternal`). A topic is modeled as a queue in this mock, so both resolve the same way.
  - **AzureFunction** -> resolve the `Microsoft.Web/sites/<app>` segment (the Functions mock is keyed by app name) and invoke it via a new `functions.InvokeExternal(ctx, name, payload)` (mirrors AWS `lambda.InvokeExternal`, including the `recursionguard` depth cap for re-publishing loops).
- All destinations receive the **same** EventGridEvent envelope already built for WebHook.
- Subscription **filters** (subject prefix/suffix, event types, advanced) are honored identically — `matchedRuleData` already gates the `matched` set before delivery, so filtered events never reach any destination.
- **Wiring**: added `EventGrid.SetServiceBusDeliverer` / `SetFunctionInvoker` injectors (peer interfaces on the eventgrid mock, same shape as EventBridge's `SetSQSDeliverer` / `SetLambdaInvoker`) and wired them in `providers/azure/azure.go`. `TestWiringParity_Azure` requires and verifies this.
- Nil peer (injector never wired) or unresolvable resource id -> skipped gracefully, no panic.

## Scope

Done: **ServiceBusQueue, ServiceBusTopic, AzureFunction**.
Deferred (no peer mock in this codebase; still parse + round-trip, just no delivery): **EventHub, StorageQueue, HybridConnection**.

## Tests

Provider-level, real `servicebus`/`functions` peer mocks:
- (a) ServiceBusQueue destination -> queue `ReceiveMessage` gets the envelope
- (b) ServiceBusTopic destination -> topic (queue) receives
- (c) AzureFunction destination -> function handler invoked with the envelope
- (d) non-matching filter drops delivery to a ServiceBus destination
- (e) nil peer -> no panic, publish still succeeds
- (f) WebHook delivery unchanged (existing `TestPutEventsDeliversToWebHook`)
- resourceId parsing helpers pinned

Gates: `go build ./...`, `go vet ./...`, `go test` on eventgrid/servicebus/functions + wire eventgrid, `go test -run TestWiringParity ./providers/`, gofmt, golangci-lint `--new-from-rev=origin/development` (0 new) — all green. `go generate ./...` produced no doc/compat diff.