### PR TITLE
fix(gcp-compute): reject in-use disk/subnetwork deletes with resourceInUseByAnotherResource

### DIFF
--- a/server/gcp/compute/disks.go
+++ b/server/gcp/compute/disks.go
@@ -147,6 +147,20 @@ func (h *Handler) deleteDisk(w http.ResponseWriter, r *http.Request, rp gcprest.
 		return
 	}
 
+	// Real GCP refuses to delete a disk still attached to an instance, returning
+	// 400 resourceInUseByAnotherResource. attachDisk only records the disk in the
+	// instance's disks[] (it never flips the driver volume state), so reuse the
+	// same instance scan that populates users[] on a read and reject while any
+	// instance still references this disk. Delete succeeds once the disk detaches.
+	host := hostFromRequest(r)
+	if users := h.diskUsersByName(r.Context(), host, rp.Project); len(users[rp.ResourceName]) > 0 {
+		diskLink := gcprest.SelfLink(host, rp.Project, gcprest.ScopeZones, rp.ScopeName, "disks", rp.ResourceName)
+		gcprest.WriteError(w, http.StatusBadRequest, "resourceInUseByAnotherResource",
+			"The disk resource '"+diskLink+"' is already being used by '"+users[rp.ResourceName][0]+"'")
+
+		return
+	}
+
 	if err := h.compute.DeleteVolume(r.Context(), vol.ID); err != nil {
 		gcprest.WriteCErr(w, err)
 		return

--- a/server/gcp/compute/disks_delete_inuse_sdk_test.go
+++ b/server/gcp/compute/disks_delete_inuse_sdk_test.go
@@ -1,0 +1,118 @@
+package compute_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/compute/apiv1/computepb"
+)
+
+// TestSDKDeleteAttachedDiskRejected proves deleting a disk that is still
+// attached to an instance is rejected with 400 resourceInUseByAnotherResource
+// (real GCP behavior), and that the disk deletes cleanly once detached.
+func TestSDKDeleteAttachedDiskRejected(t *testing.T) {
+	ts := newGCPServer(t)
+	disks := newDisksSDKClient(t, ts)
+	instances := newSDKInstancesClient(t, ts)
+	ctx := context.Background()
+
+	insertDisk(t, disks, &computepb.Disk{Name: ptrStr("attached-disk"), SizeGb: ptrInt64(10)})
+
+	insOp, err := instances.Insert(ctx, &computepb.InsertInstanceRequest{
+		Project: testProject, Zone: testZone,
+		InstanceResource: &computepb.Instance{
+			Name:        ptrStr("disk-holder"),
+			MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+			NetworkInterfaces: []*computepb.NetworkInterface{
+				{Network: ptrStr("global/networks/default")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("instance Insert: %v", err)
+	}
+
+	if err := insOp.Wait(ctx); err != nil {
+		t.Fatalf("instance Insert wait: %v", err)
+	}
+
+	diskURL := "projects/" + testProject + "/zones/" + testZone + "/disks/attached-disk"
+
+	attachOp, err := instances.AttachDisk(ctx, &computepb.AttachDiskInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "disk-holder",
+		AttachedDiskResource: &computepb.AttachedDisk{
+			Source: ptrStr(diskURL), DeviceName: ptrStr("data"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("AttachDisk: %v", err)
+	}
+
+	if err := attachOp.Wait(ctx); err != nil {
+		t.Fatalf("AttachDisk wait: %v", err)
+	}
+
+	// Delete while attached must fail with resourceInUseByAnotherResource (400).
+	_, err = disks.Delete(ctx, &computepb.DeleteDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "attached-disk",
+	})
+	if err == nil {
+		t.Fatal("Delete of attached disk succeeded, want 400 resourceInUseByAnotherResource")
+	}
+
+	if !strings.Contains(err.Error(), "resourceInUseByAnotherResource") && !strings.Contains(err.Error(), "400") {
+		t.Errorf("Delete error = %v, want resourceInUseByAnotherResource/400", err)
+	}
+
+	// The disk survived the rejected delete.
+	if _, err := disks.Get(ctx, &computepb.GetDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "attached-disk",
+	}); err != nil {
+		t.Fatalf("Get after rejected delete: %v (disk should still exist)", err)
+	}
+
+	// Detach, then delete must succeed.
+	detachOp, err := instances.DetachDisk(ctx, &computepb.DetachDiskInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "disk-holder", DeviceName: "data",
+	})
+	if err != nil {
+		t.Fatalf("DetachDisk: %v", err)
+	}
+
+	if err := detachOp.Wait(ctx); err != nil {
+		t.Fatalf("DetachDisk wait: %v", err)
+	}
+
+	delOp, err := disks.Delete(ctx, &computepb.DeleteDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "attached-disk",
+	})
+	if err != nil {
+		t.Fatalf("Delete after detach: %v (should succeed)", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Fatalf("Delete after detach wait: %v", err)
+	}
+}
+
+// TestSDKDeleteUnattachedDiskSucceeds proves the in-use guard does not block a
+// plain, never-attached disk from being deleted.
+func TestSDKDeleteUnattachedDiskSucceeds(t *testing.T) {
+	ts := newGCPServer(t)
+	disks := newDisksSDKClient(t, ts)
+	ctx := context.Background()
+
+	insertDisk(t, disks, &computepb.Disk{Name: ptrStr("free-disk"), SizeGb: ptrInt64(10)})
+
+	delOp, err := disks.Delete(ctx, &computepb.DeleteDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "free-disk",
+	})
+	if err != nil {
+		t.Fatalf("Delete of unattached disk: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Fatalf("Delete wait: %v", err)
+	}
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -163,7 +163,9 @@ func New(d Drivers) *server.Server {
 	}
 
 	if d.Networking != nil {
-		srv.Register(vpc.New(d.Networking))
+		// d.Compute (may be nil) lets the subnetwork delete guard reject removing a
+		// subnet that still has instances.
+		srv.Register(vpc.New(d.Networking, d.Compute))
 	}
 
 	// Service Networking has no driver: a private-services connection is a

--- a/server/gcp/vpc/handler.go
+++ b/server/gcp/vpc/handler.go
@@ -36,6 +36,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
@@ -86,18 +87,33 @@ func nameMatches(filter, name string) bool { return gcprest.NameMatches(filter, 
 // maxResultsOf parses the maxResults query param, defaulting when absent/invalid.
 func maxResultsOf(raw string) int { return gcprest.MaxResults(raw) }
 
+// instanceLister is the minimal, optional compute-side lookup the subnetwork
+// delete guard needs: it lists instances so the handler can reject deleting a
+// subnet that still has instances attached. Kept as a local interface (satisfied
+// by the shared compute driver) so the VPC handler gains no hard dependency on
+// the compute package and stays usable when no compute driver is wired.
+type instanceLister interface {
+	DescribeInstances(
+		ctx context.Context, instanceIDs []string, filters []computedriver.DescribeFilter,
+		opts ...computedriver.DescribeInstancesOptions,
+	) ([]computedriver.Instance, error)
+}
+
 // Handler serves the GCP networking REST surface.
 type Handler struct {
 	net       netdriver.Networking
+	compute   instanceLister
 	routers   *routerStore
 	addresses *addressStore
 	routes    *routeStore
 }
 
-// New returns a networks handler.
-func New(n netdriver.Networking) *Handler {
+// New returns a networks handler. compute is optional (may be nil): when
+// provided, deleteSubnetwork rejects deleting a subnet that still has instances.
+func New(n netdriver.Networking, compute instanceLister) *Handler {
 	return &Handler{
 		net:       n,
+		compute:   compute,
 		routers:   newRouterStore(),
 		addresses: newAddressStore(),
 		routes:    newRouteStore(),
@@ -616,6 +632,22 @@ func (h *Handler) deleteSubnetwork(w http.ResponseWriter, r *http.Request, rp gc
 	s, err := findSubnetByName(r.Context(), h.net, rp.ResourceName, rp.ScopeName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	// Real GCP refuses to delete a subnetwork that still has instances in it,
+	// returning 400 resourceInUseByAnotherResource (mirrors the network delete
+	// guard against live subnets above). Scan instances whose networkInterfaces
+	// subnet references this subnet and reject; delete succeeds once empty.
+	host := hostOf(r)
+	if inst, scanErr := h.instanceInSubnet(r.Context(), host, rp.Project, rp.ResourceName, rp.ScopeName); scanErr != nil {
+		gcprest.WriteCErr(w, scanErr)
+		return
+	} else if inst != "" {
+		subnetLink := gcprest.SelfLink(host, rp.Project, gcprest.ScopeRegions, rp.ScopeName, "subnetworks", rp.ResourceName)
+		gcprest.WriteError(w, http.StatusBadRequest, "resourceInUseByAnotherResource",
+			"The subnetwork resource '"+subnetLink+"' is already being used by '"+inst+"'")
+
 		return
 	}
 
@@ -1157,6 +1189,61 @@ func (h *Handler) subnetOnNetwork(ctx context.Context, vpcID, netName string) (s
 	}
 
 	return "", nil
+}
+
+// These mirror the tag keys the compute wire handler stamps on each instance
+// (server/gcp/compute) so this handler can name an in-subnet instance in the
+// delete-in-use error without importing the compute server package.
+const (
+	instNameTag = "cloudemu:gcpName"
+	instZoneTag = "cloudemu:gcp:zone"
+)
+
+// instanceInSubnet returns the self-link of the first instance whose
+// networkInterfaces subnet references the given subnet (by name, scoped to the
+// subnet's region), or "" when none. It underpins the delete-in-use guard for
+// subnetworks. A nil compute driver (compute not wired) reports no users.
+func (h *Handler) instanceInSubnet(ctx context.Context, host, project, subnetName, region string) (string, error) {
+	if h.compute == nil {
+		return "", nil
+	}
+
+	instances, err := h.compute.DescribeInstances(ctx, nil, nil)
+	if err != nil {
+		return "", err
+	}
+
+	for i := range instances {
+		if !subnetRefMatches(instances[i].SubnetID, subnetName, region) {
+			continue
+		}
+
+		name := tagOr(instances[i].Tags, instNameTag, instances[i].ID)
+		zone := tagOr(instances[i].Tags, instZoneTag, "")
+
+		return gcprest.SelfLink(host, project, gcprest.ScopeZones, zone, "instances", name), nil
+	}
+
+	return "", nil
+}
+
+// subnetRefMatches reports whether a raw instance subnet reference (a bare name,
+// a relative path, or a full self-link of the form ".../regions/{r}/subnetworks/{n}")
+// points at the subnet identified by name and region. When the ref carries a
+// region segment it must match; a bare-name ref matches on name alone.
+func subnetRefMatches(ref, name, region string) bool {
+	if ref == "" || lastSegment(ref) != name {
+		return false
+	}
+
+	if idx := strings.Index(ref, "/regions/"); idx >= 0 {
+		rest := ref[idx+len("/regions/"):]
+		if slash := strings.Index(rest, "/"); slash >= 0 {
+			return rest[:slash] == region
+		}
+	}
+
+	return true
 }
 
 func findFirewallByName(ctx context.Context, n netdriver.Networking, name string) (*netdriver.SecurityGroupInfo, error) {

--- a/server/gcp/vpc/subnetworks_delete_inuse_test.go
+++ b/server/gcp/vpc/subnetworks_delete_inuse_test.go
@@ -1,0 +1,185 @@
+package vpc_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/option"
+)
+
+// zoneInRegion is a zone belonging to testRegion (us-central1); instances live
+// in zones while subnets are regional, so an in-region zone puts the instance in
+// the subnet under test.
+const zoneInRegion = "us-central1-a"
+
+func newSubnetsClient(t *testing.T, ts *httptest.Server) *gcpcompute.SubnetworksClient {
+	t.Helper()
+
+	c, err := gcpcompute.NewSubnetworksRESTClient(context.Background(),
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewSubnetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = c.Close() })
+
+	return c
+}
+
+func newInstancesClient(t *testing.T, ts *httptest.Server) *gcpcompute.InstancesClient {
+	t.Helper()
+
+	c, err := gcpcompute.NewInstancesRESTClient(context.Background(),
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewInstancesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = c.Close() })
+
+	return c
+}
+
+func newNetworksClient(t *testing.T, ts *httptest.Server) *gcpcompute.NetworksClient {
+	t.Helper()
+
+	c, err := gcpcompute.NewNetworksRESTClient(context.Background(),
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewNetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = c.Close() })
+
+	return c
+}
+
+func insertNetworkNamed(t *testing.T, ctx context.Context, c *gcpcompute.NetworksClient, name string) {
+	t.Helper()
+
+	op, err := c.Insert(ctx, &computepb.InsertNetworkRequest{
+		Project: testProject,
+		NetworkResource: &computepb.Network{
+			Name:                  ptrStr(name),
+			AutoCreateSubnetworks: func() *bool { b := false; return &b }(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("network Insert %s: %v", name, err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("network Insert wait %s: %v", name, err)
+	}
+}
+
+func insertInstanceInSubnet(t *testing.T, ctx context.Context, c *gcpcompute.InstancesClient, name, subnetRef string) {
+	t.Helper()
+
+	op, err := c.Insert(ctx, &computepb.InsertInstanceRequest{
+		Project: testProject, Zone: zoneInRegion,
+		InstanceResource: &computepb.Instance{
+			Name:        ptrStr(name),
+			MachineType: ptrStr("zones/" + zoneInRegion + "/machineTypes/n1-standard-1"),
+			NetworkInterfaces: []*computepb.NetworkInterface{
+				{Subnetwork: ptrStr(subnetRef)},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("instance Insert %s: %v", name, err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("instance Insert wait %s: %v", name, err)
+	}
+}
+
+// TestSDKDeleteSubnetInUseByInstanceRejected proves deleting a subnetwork that
+// still has an instance in it is rejected with 400
+// resourceInUseByAnotherResource, and that the delete succeeds once the instance
+// is gone.
+func TestSDKDeleteSubnetInUseByInstanceRejected(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	nets := newNetworksClient(t, ts)
+	subs := newSubnetsClient(t, ts)
+	instances := newInstancesClient(t, ts)
+
+	insertNetworkNamed(t, ctx, nets, "app-vpc")
+	insertSubnet2(t, ctx, subs, testRegion, "app-subnet", "app-vpc", "10.5.0.0/16")
+
+	subnetRef := "projects/" + testProject + "/regions/" + testRegion + "/subnetworks/app-subnet"
+	insertInstanceInSubnet(t, ctx, instances, "app-vm", subnetRef)
+
+	// Delete while an instance is in the subnet must fail.
+	_, err := subs.Delete(ctx, &computepb.DeleteSubnetworkRequest{
+		Project: testProject, Region: testRegion, Subnetwork: "app-subnet",
+	})
+	if err == nil {
+		t.Fatal("Delete of in-use subnet succeeded, want 400 resourceInUseByAnotherResource")
+	}
+
+	if !strings.Contains(err.Error(), "resourceInUseByAnotherResource") && !strings.Contains(err.Error(), "400") {
+		t.Errorf("Delete error = %v, want resourceInUseByAnotherResource/400", err)
+	}
+
+	// Subnet survived the rejected delete.
+	if _, err := subs.Get(ctx, &computepb.GetSubnetworkRequest{
+		Project: testProject, Region: testRegion, Subnetwork: "app-subnet",
+	}); err != nil {
+		t.Fatalf("Get after rejected delete: %v (subnet should still exist)", err)
+	}
+
+	// Remove the instance, then delete must succeed.
+	delInst, err := instances.Delete(ctx, &computepb.DeleteInstanceRequest{
+		Project: testProject, Zone: zoneInRegion, Instance: "app-vm",
+	})
+	if err != nil {
+		t.Fatalf("instance Delete: %v", err)
+	}
+
+	if err := delInst.Wait(ctx); err != nil {
+		t.Fatalf("instance Delete wait: %v", err)
+	}
+
+	delSub, err := subs.Delete(ctx, &computepb.DeleteSubnetworkRequest{
+		Project: testProject, Region: testRegion, Subnetwork: "app-subnet",
+	})
+	if err != nil {
+		t.Fatalf("Delete after instance removed: %v (should succeed)", err)
+	}
+
+	if err := delSub.Wait(ctx); err != nil {
+		t.Fatalf("Delete after instance removed wait: %v", err)
+	}
+}
+
+// TestSDKDeleteEmptySubnetSucceeds proves the in-use guard does not block an
+// empty subnet (no instances) from being deleted.
+func TestSDKDeleteEmptySubnetSucceeds(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	nets := newNetworksClient(t, ts)
+	subs := newSubnetsClient(t, ts)
+
+	insertNetworkNamed(t, ctx, nets, "empty-vpc")
+	insertSubnet2(t, ctx, subs, testRegion, "empty-subnet", "empty-vpc", "10.6.0.0/16")
+
+	op, err := subs.Delete(ctx, &computepb.DeleteSubnetworkRequest{
+		Project: testProject, Region: testRegion, Subnetwork: "empty-subnet",
+	})
+	if err != nil {
+		t.Fatalf("Delete of empty subnet: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("Delete wait: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Two GCP cross-resource delete guards were missing: deleting an in-use disk or an in-use subnetwork succeeded, whereas real GCP returns 400 `resourceInUseByAnotherResource`. This adds both guards at the wire layer.

### BUG1 — attached disk delete (HIGH)
`attachDisk` records the disk only in the instance's `disks[]` (it never flips the driver volume state to in-use), so the driver-level `DeleteVolume` in-use guard was unreachable over the wire and an attached disk deleted silently.

Fix: in `deleteDisk` (server/gcp/compute/disks.go), reuse the existing `diskUsersByName` instance scan (the same one that populates `users[]` on a GET) and reject with 400 `resourceInUseByAnotherResource` while any instance still references the disk. Delete succeeds once detached.

### BUG2 — subnetwork delete with live instances (MED)
`deleteSubnetwork` had no in-use scan (unlike `deleteNetwork`, which already blocks on live subnets), and the VPC handler held no compute reference.

Fix: give the GCP VPC wire handler an optional, minimal `instanceLister` interface (satisfied by the shared compute driver, no hard cross-package cycle) and wire `d.Compute` into `vpc.New` in `server/gcp/gcp.go`. `deleteSubnetwork` now scans instances whose `networkInterfaces` subnet references this subnet (matched by name, scoped to region) and rejects with 400 `resourceInUseByAnotherResource`. Delete succeeds once the subnet is empty. Reserved addresses / forwarding rules are out of scope for this change (instances are the common case).

## Tests (real google-cloud-go compute over httptest)
- Attach disk to instance -> `disks.delete` returns 400; detach -> delete succeeds; unattached disk still deletes.
- Create instance in subnet -> `subnetworks.delete` returns 400; delete the instance -> subnet delete succeeds; empty subnet still deletes.
- Existing `TestSDKDiskUsersReflectAttachment` (users[] GET reflection) still passes; network-with-subnets guard unchanged.

## Gates
build, vet, gofmt, targeted `go test` (server+providers gcp compute/vpc), `TestWiringParity`/`TestRealWorld`, `go generate` (no diff), compatgen (exit 0, no diff), golangci-lint `--new-from-rev=origin/development` (0 new issues) — all green.