### PR TITLE
fix(gcp-lb): reject in-use backend-service/health-check deletes + validate healthChecks refs

### DIFF
--- a/server/gcp/loadbalancer/handler.go
+++ b/server/gcp/loadbalancer/handler.go
@@ -44,6 +44,11 @@ const (
 	resourceForwardingRules = "forwardingRules"
 )
 
+// reasonResourceInUse is the GCP error reason returned when a delete is rejected
+// because another resource still references the target. Real GCP answers such a
+// delete with HTTP 400 and this reason, so dependents are never orphaned.
+const reasonResourceInUse = "resourceInUseByAnotherResource"
+
 // Handler serves the GCP load-balancing REST surface.
 type Handler struct {
 	lb lbdriver.LoadBalancer

--- a/server/gcp/loadbalancer/operations.go
+++ b/server/gcp/loadbalancer/operations.go
@@ -36,6 +36,11 @@ func (h *Handler) insertBackendService(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
+	if err := h.validateHealthCheckRefs(r.Context(), rp, req.HealthChecks); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
 	tags := backendServiceTags(&req)
 	tags[bsCreationTag] = time.Now().UTC().Format(time.RFC3339)
 	tags[bsNameTag] = req.Name
@@ -77,6 +82,11 @@ func (h *Handler) patchBackendService(w http.ResponseWriter, r *http.Request, rp
 
 	var req backendServiceRequest
 	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.validateHealthCheckRefs(r.Context(), rp, req.HealthChecks); err != nil {
+		gcprest.WriteCErr(w, err)
 		return
 	}
 
@@ -168,6 +178,17 @@ func (h *Handler) deleteBackendService(w http.ResponseWriter, r *http.Request, r
 	tg, err := h.findTGByName(r.Context(), rp, rp.ResourceName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	// Real GCP refuses to delete a backend service still referenced by a
+	// forwarding rule or a url-map (400 resourceInUseByAnotherResource); deleting
+	// it here would orphan the dependent (a dangling listener, or a url-map whose
+	// service no longer resolves).
+	if ref := h.backendServiceInUse(r.Context(), rp, rp.ResourceName, tg.ARN); ref != "" {
+		gcprest.WriteError(w, http.StatusBadRequest, reasonResourceInUse,
+			"The backend_service resource '"+rp.ResourceName+"' is already being used by '"+ref+"'")
+
 		return
 	}
 
@@ -597,6 +618,140 @@ func backendServiceName(ref string) string {
 	}
 
 	return ref
+}
+
+// backendServiceInUse returns the name of a resource still referencing the
+// backend service, or "" when it is safe to delete. A forwarding rule (via its
+// linked listener) or a url-map (defaultService / pathMatchers) both pin it.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) backendServiceInUse(ctx context.Context, rp gcprest.ResourcePath, bsName, tgARN string) string {
+	if fr := h.forwardingRuleRefTG(ctx, tgARN); fr != "" {
+		return fr
+	}
+
+	return h.urlMapRefBackendService(ctx, rp, bsName)
+}
+
+// forwardingRuleRefTG returns the name of a forwarding rule whose listener
+// targets tgARN, or "" when none does.
+func (h *Handler) forwardingRuleRefTG(ctx context.Context, tgARN string) string {
+	lbs, err := h.lb.DescribeLoadBalancers(ctx, nil)
+	if err != nil {
+		return ""
+	}
+
+	for i := range lbs {
+		listeners, lerr := h.lb.DescribeListeners(ctx, lbs[i].ARN)
+		if lerr != nil {
+			continue
+		}
+
+		for j := range listeners {
+			if listeners[j].TargetGroupARN == tgARN {
+				return displayName(lbs[i].Tags, frNameTag, lbs[i].Name)
+			}
+		}
+	}
+
+	return ""
+}
+
+// urlMapRefBackendService returns the name of a same-scope url-map referencing
+// bsName (as defaultService or in a pathMatcher), or "" when none does.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) urlMapRefBackendService(ctx context.Context, rp gcprest.ResourcePath, bsName string) string {
+	store, ok := h.gcpStore()
+	if !ok {
+		return ""
+	}
+
+	maps, err := store.ListGCPResources(ctx, resourceURLMaps, scopeKeyOf(rp))
+	if err != nil {
+		return ""
+	}
+
+	for i := range maps {
+		if bodyRefsBackendService(maps[i].Body, bsName) {
+			return maps[i].Name
+		}
+	}
+
+	return ""
+}
+
+// bodyRefsBackendService walks an opaque url-map body for any "service" /
+// "defaultService" member whose reference resolves to bsName.
+func bodyRefsBackendService(v any, bsName string) bool {
+	switch t := v.(type) {
+	case map[string]any:
+		return mapRefsBackendService(t, bsName)
+	case []any:
+		for i := range t {
+			if bodyRefsBackendService(t[i], bsName) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// mapRefsBackendService checks one map node for a backend-service reference and
+// recurses into its members.
+func mapRefsBackendService(m map[string]any, bsName string) bool {
+	for k, val := range m {
+		if k == "service" || k == "defaultService" {
+			if s, ok := val.(string); ok && backendServiceName(s) == bsName {
+				return true
+			}
+		}
+
+		if bodyRefsBackendService(val, bsName) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// validateHealthCheckRefs rejects a create/patch whose healthChecks[] names a
+// health check that does not exist in the same scope, matching real GCP's
+// "Invalid value for field 'resource.healthChecks[N]'" rejection. It is a no-op
+// when the driver has no GCP resource store (the health checks can't be
+// resolved) so non-GCP drivers stay unaffected.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) validateHealthCheckRefs(ctx context.Context, rp gcprest.ResourcePath, refs []string) error {
+	if len(refs) == 0 {
+		return nil
+	}
+
+	store, ok := h.gcpStore()
+	if !ok {
+		return nil
+	}
+
+	scope := scopeKeyOf(rp)
+
+	for i, ref := range refs {
+		name := lastPathSegment(ref)
+
+		_, err := store.GetGCPResource(ctx, resourceHealthChecks, scope, name)
+		if err == nil {
+			continue
+		}
+
+		if cerrors.IsNotFound(err) {
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"Invalid value for field 'resource.healthChecks[%d]': '%s'. The referenced health check resource cannot be found.", i, ref)
+		}
+
+		return err
+	}
+
+	return nil
 }
 
 // firstPort parses the low end of a GCP portRange (e.g. "80" or "80-80").

--- a/server/gcp/loadbalancer/referenceintegrity_sdk_test.go
+++ b/server/gcp/loadbalancer/referenceintegrity_sdk_test.go
@@ -1,0 +1,313 @@
+package loadbalancer_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+)
+
+// newHealthChecksClient builds a HealthChecks REST client pointed at ts.
+func newHealthChecksClient(t *testing.T, ts *httptest.Server) *gcpcompute.HealthChecksClient {
+	t.Helper()
+
+	client, err := gcpcompute.NewHealthChecksRESTClient(context.Background(),
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewHealthChecksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+// insertHealthCheck creates a global HTTP health check named name.
+func insertHealthCheck(ctx context.Context, t *testing.T, ts *httptest.Server, name string) {
+	t.Helper()
+
+	client := newHealthChecksClient(t, ts)
+
+	op, err := client.Insert(ctx, &computepb.InsertHealthCheckRequest{
+		Project:             testProject,
+		HealthCheckResource: &computepb.HealthCheck{Name: ptrStr(name), Type: ptrStr("HTTP")},
+	})
+	if err != nil {
+		t.Fatalf("HealthCheck Insert %s: %v", name, err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("HealthCheck Insert %s wait: %v", name, err)
+	}
+}
+
+// hcRef renders a global health-check self-link reference.
+func hcRef(name string) string {
+	return "projects/" + testProject + "/global/healthChecks/" + name
+}
+
+// insertBSWithHC creates a backend service referencing the given health checks.
+func insertBSWithHC(ctx context.Context, t *testing.T, c *gcpcompute.BackendServicesClient, name string, hcs ...string) {
+	t.Helper()
+
+	op, err := c.Insert(ctx, &computepb.InsertBackendServiceRequest{
+		Project: testProject,
+		BackendServiceResource: &computepb.BackendService{
+			Name:         ptrStr(name),
+			Protocol:     ptrStr("HTTP"),
+			HealthChecks: hcs,
+		},
+	})
+	if err != nil {
+		t.Fatalf("BackendService Insert %s: %v", name, err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("BackendService Insert %s wait: %v", name, err)
+	}
+}
+
+// assertResourceInUse fails unless err is a 400 resourceInUseByAnotherResource.
+func assertResourceInUse(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("delete of in-use resource: want error, got nil")
+	}
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) {
+		t.Fatalf("error = %v, want a googleapi.Error", err)
+	}
+
+	if gerr.Code != 400 {
+		t.Errorf("error code = %d, want 400 (%v)", gerr.Code, err)
+	}
+
+	reason := gerr.Message
+	for _, item := range gerr.Errors {
+		if item.Reason != "" {
+			reason = item.Reason
+		}
+	}
+
+	if reason != "resourceInUseByAnotherResource" {
+		t.Errorf("reason = %q, want resourceInUseByAnotherResource (%v)", reason, err)
+	}
+}
+
+// TestSDKGCPBackendServiceInUseByForwardingRule covers B1(a): a backend service
+// still fronted by a forwarding rule cannot be deleted; once the forwarding rule
+// is gone, the backend service deletes cleanly.
+func TestSDKGCPBackendServiceInUseByForwardingRule(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	bs := newBackendServicesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+	fr := newForwardingRulesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+
+	insertHealthCheck(ctx, t, ts, "hc-a")
+	insertBSWithHC(ctx, t, bs, "bs-a", hcRef("hc-a"))
+
+	frOp, err := fr.Insert(ctx, &computepb.InsertGlobalForwardingRuleRequest{
+		Project: testProject,
+		ForwardingRuleResource: &computepb.ForwardingRule{
+			Name:           ptrStr("fr-a"),
+			IPProtocol:     ptrStr("TCP"),
+			PortRange:      ptrStr("80"),
+			BackendService: ptrStr("projects/" + testProject + "/global/backendServices/bs-a"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("ForwardingRule Insert: %v", err)
+	}
+
+	if err := frOp.Wait(ctx); err != nil {
+		t.Fatalf("ForwardingRule Insert wait: %v", err)
+	}
+
+	// Delete while referenced → rejected.
+	_, err = bs.Delete(ctx, &computepb.DeleteBackendServiceRequest{Project: testProject, BackendService: "bs-a"})
+	assertResourceInUse(t, err)
+
+	// Remove the forwarding rule, then the backend service deletes.
+	delFR, err := fr.Delete(ctx, &computepb.DeleteGlobalForwardingRuleRequest{Project: testProject, ForwardingRule: "fr-a"})
+	if err != nil {
+		t.Fatalf("ForwardingRule Delete: %v", err)
+	}
+
+	if err := delFR.Wait(ctx); err != nil {
+		t.Fatalf("ForwardingRule Delete wait: %v", err)
+	}
+
+	delBS, err := bs.Delete(ctx, &computepb.DeleteBackendServiceRequest{Project: testProject, BackendService: "bs-a"})
+	if err != nil {
+		t.Fatalf("BackendService Delete after unreference: %v", err)
+	}
+
+	if err := delBS.Wait(ctx); err != nil {
+		t.Fatalf("BackendService Delete wait: %v", err)
+	}
+}
+
+// TestSDKGCPBackendServiceInUseByURLMap covers the url-map arm of B1(a): a
+// backend service named as a url-map's defaultService cannot be deleted until
+// the url-map is gone.
+func TestSDKGCPBackendServiceInUseByURLMap(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	bs := newBackendServicesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+
+	um, err := gcpcompute.NewUrlMapsRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewUrlMapsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = um.Close() })
+
+	insertBS(ctx, t, bs, "bs-um")
+
+	umOp, err := um.Insert(ctx, &computepb.InsertUrlMapRequest{
+		Project: testProject,
+		UrlMapResource: &computepb.UrlMap{
+			Name:           ptrStr("map-1"),
+			DefaultService: ptrStr("projects/" + testProject + "/global/backendServices/bs-um"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("UrlMap Insert: %v", err)
+	}
+
+	if err := umOp.Wait(ctx); err != nil {
+		t.Fatalf("UrlMap Insert wait: %v", err)
+	}
+
+	_, err = bs.Delete(ctx, &computepb.DeleteBackendServiceRequest{Project: testProject, BackendService: "bs-um"})
+	assertResourceInUse(t, err)
+
+	delUM, err := um.Delete(ctx, &computepb.DeleteUrlMapRequest{Project: testProject, UrlMap: "map-1"})
+	if err != nil {
+		t.Fatalf("UrlMap Delete: %v", err)
+	}
+
+	if err := delUM.Wait(ctx); err != nil {
+		t.Fatalf("UrlMap Delete wait: %v", err)
+	}
+
+	delBS, err := bs.Delete(ctx, &computepb.DeleteBackendServiceRequest{Project: testProject, BackendService: "bs-um"})
+	if err != nil {
+		t.Fatalf("BackendService Delete after url-map gone: %v", err)
+	}
+
+	if err := delBS.Wait(ctx); err != nil {
+		t.Fatalf("BackendService Delete wait: %v", err)
+	}
+}
+
+// TestSDKGCPHealthCheckInUse covers B1(b): a health check referenced by a
+// backend service cannot be deleted; once the backend service is gone, it
+// deletes cleanly.
+func TestSDKGCPHealthCheckInUse(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	bs := newBackendServicesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+	hc := newHealthChecksClient(t, ts)
+
+	insertHealthCheck(ctx, t, ts, "hc-b")
+	insertBSWithHC(ctx, t, bs, "bs-b", hcRef("hc-b"))
+
+	// Referenced → delete rejected.
+	_, err := hc.Delete(ctx, &computepb.DeleteHealthCheckRequest{Project: testProject, HealthCheck: "hc-b"})
+	assertResourceInUse(t, err)
+
+	// Drop the referencing backend service, then the health check deletes.
+	delBS, err := bs.Delete(ctx, &computepb.DeleteBackendServiceRequest{Project: testProject, BackendService: "bs-b"})
+	if err != nil {
+		t.Fatalf("BackendService Delete: %v", err)
+	}
+
+	if err := delBS.Wait(ctx); err != nil {
+		t.Fatalf("BackendService Delete wait: %v", err)
+	}
+
+	delHC, err := hc.Delete(ctx, &computepb.DeleteHealthCheckRequest{Project: testProject, HealthCheck: "hc-b"})
+	if err != nil {
+		t.Fatalf("HealthCheck Delete after unreference: %v", err)
+	}
+
+	if err := delHC.Wait(ctx); err != nil {
+		t.Fatalf("HealthCheck Delete wait: %v", err)
+	}
+}
+
+// TestSDKGCPBackendServiceHealthCheckRefValidation covers B2(c): a backend
+// service whose healthChecks[] names a missing health check is rejected, while
+// one pointing at an existing health check succeeds.
+func TestSDKGCPBackendServiceHealthCheckRefValidation(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	bs := newBackendServicesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+
+	// Dangling reference → rejected.
+	badOp, err := bs.Insert(ctx, &computepb.InsertBackendServiceRequest{
+		Project: testProject,
+		BackendServiceResource: &computepb.BackendService{
+			Name:         ptrStr("bs-bad"),
+			Protocol:     ptrStr("HTTP"),
+			HealthChecks: []string{hcRef("ghost-hc")},
+		},
+	})
+	if err == nil {
+		err = badOp.Wait(ctx)
+	}
+
+	if err == nil {
+		t.Fatal("insert referencing missing health check: want error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "healthChecks") {
+		t.Errorf("error = %v, want a healthChecks[] validation error", err)
+	}
+
+	// Existing reference → accepted.
+	insertHealthCheck(ctx, t, ts, "real-hc")
+	insertBSWithHC(ctx, t, bs, "bs-good", hcRef("real-hc"))
+
+	got, err := bs.Get(ctx, &computepb.GetBackendServiceRequest{Project: testProject, BackendService: "bs-good"})
+	if err != nil {
+		t.Fatalf("Get bs-good: %v", err)
+	}
+
+	if len(got.GetHealthChecks()) != 1 {
+		t.Errorf("healthChecks = %v, want one entry", got.GetHealthChecks())
+	}
+}
+
+// TestSDKGCPBackendServiceDeleteNotInUse covers B1(d) no-regression: a backend
+// service with no dependents still deletes without a spurious in-use rejection.
+func TestSDKGCPBackendServiceDeleteNotInUse(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	bs := newBackendServicesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+	insertBS(ctx, t, bs, "bs-free")
+
+	del, err := bs.Delete(ctx, &computepb.DeleteBackendServiceRequest{Project: testProject, BackendService: "bs-free"})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if err := del.Wait(ctx); err != nil {
+		t.Fatalf("Delete wait: %v", err)
+	}
+}

--- a/server/gcp/loadbalancer/resources.go
+++ b/server/gcp/loadbalancer/resources.go
@@ -1,8 +1,10 @@
 package loadbalancer
 
 import (
+	"context"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/internal/pagination"
@@ -247,6 +249,20 @@ func (h *Handler) deleteGCPResource(w http.ResponseWriter, r *http.Request, rp g
 		return
 	}
 
+	// A health check referenced by a backend service's healthChecks[] cannot be
+	// deleted in real GCP (400 resourceInUseByAnotherResource); deleting it here
+	// would leave the backend service pointing at a health check that no longer
+	// exists. (url-maps are pinned only by target-proxies, which are
+	// unimplemented, so no url-map delete guard is reachable yet.)
+	if rp.ResourceType == resourceHealthChecks {
+		if bs := h.healthCheckInUse(r.Context(), rp); bs != "" {
+			gcprest.WriteError(w, http.StatusBadRequest, reasonResourceInUse,
+				"The health_check resource '"+rp.ResourceName+"' is already being used by '"+bs+"'")
+
+			return
+		}
+	}
+
 	if err := store.DeleteGCPResource(r.Context(), rp.ResourceType, scopeKeyOf(rp), rp.ResourceName); err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -283,6 +299,50 @@ func gcpResourceJSON(res *lbdriver.GCPResource, rp gcprest.ResourcePath, host st
 // adds on top of the stored body (kind, id, name, creationTimestamp, selfLink,
 // region).
 const internalFieldCount = 6
+
+// healthCheckInUse returns the name of a same-scope backend service whose
+// healthChecks[] references the health check being deleted, or "" when none
+// does.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) healthCheckInUse(ctx context.Context, rp gcprest.ResourcePath) string {
+	tgs, err := h.lb.DescribeTargetGroups(ctx, nil)
+	if err != nil {
+		return ""
+	}
+
+	scope := scopeKeyOf(rp)
+
+	for i := range tgs {
+		if tgs[i].Tags[bsScopeTag] != scope {
+			continue
+		}
+
+		refs := tgs[i].Tags[bsHealthChecksTag]
+		if refs == "" {
+			continue
+		}
+
+		for _, ref := range strings.Split(refs, ",") {
+			if lastPathSegment(ref) == rp.ResourceName {
+				return displayName(tgs[i].Tags, bsNameTag, tgs[i].Name)
+			}
+		}
+	}
+
+	return ""
+}
+
+// lastPathSegment returns the trailing name of a GCP self-link or relative
+// reference (e.g. ".../global/healthChecks/hc1" → "hc1"), or the input when it
+// has no separator.
+func lastPathSegment(ref string) string {
+	if idx := strings.LastIndex(ref, "/"); idx >= 0 {
+		return ref[idx+1:]
+	}
+
+	return ref
+}
 
 // listScopeSegment renders the scope path segment used in a list envelope's id.
 //

--- a/server/gcp/loadbalancer/sdk_roundtrip_test.go
+++ b/server/gcp/loadbalancer/sdk_roundtrip_test.go
@@ -49,6 +49,10 @@ func TestSDKGCPBackendServiceRoundTrip(t *testing.T) {
 
 	t.Cleanup(func() { _ = client.Close() })
 
+	// The backend service references hc1, which must exist first (real GCP
+	// rejects a healthChecks[] reference to a missing health check).
+	insertHealthCheck(ctx, t, ts, "hc1")
+
 	insertOp, err := client.Insert(ctx, &computepb.InsertBackendServiceRequest{
 		Project: testProject,
 		BackendServiceResource: &computepb.BackendService{


### PR DESCRIPTION
## Summary

Fixes GCP load-balancer reference-integrity bugs in the implemented surface so dependent resources are never orphaned, matching real GCP's `400 resourceInUseByAnotherResource`.

### B1 — delete-in-use now rejected (was: unconditional delete orphaning dependents)
- **backendServices.delete** is blocked (400 `resourceInUseByAnotherResource`) when a forwarding rule's listener still targets it, or a same-scope url-map references it as `defaultService` / in a `pathMatchers` `service`. Previously the target group was deleted unconditionally, leaving a dangling listener or an unresolvable url-map service.
- **healthChecks.delete** is blocked when any same-scope backend service's `healthChecks[]` references it. Previously deleted unconditionally, leaving the backend service pointing at a vanished health check.
- url-maps are pinned only by target-proxies, which are unimplemented, so no url-map delete guard is reachable yet (noted in code).

### B2 (checkable subset) — referential validation on create/patch
- **insertBackendService / patchBackendService** now reject a `healthChecks[]` entry naming a health check that does not exist in the same scope, mirroring real GCP's `Invalid value for field 'resource.healthChecks[N]'`. `backends[].group` is left unvalidated (instanceGroups unimplemented — recorded deferral).

The fwd-rule -> backend-service L4 link and all round-trips are unchanged. The existing backend-service round-trip test now seeds its referenced health check first (real GCP would reject it otherwise).

Scope note: L7 build-out (instanceGroups / targetProxies / getHealth) is explicitly out of scope.

## Tests (real google-cloud-go compute clients over httptest)
- in-use backend service (forwarding-rule arm and url-map arm) -> 400; unreference -> deletes
- in-use health check -> 400; unreference -> deletes
- backend service with missing healthChecks[] ref -> error; with existing -> ok
- no-regression: free backend service still deletes; existing round-trip / link suites green

## Gates
build, vet, gofmt clean; `go test ./server/gcp/loadbalancer/... ./providers/gcp/loadbalancer/...` and full `./server/gcp/...` green; `golangci-lint --new-from-rev=origin/development` 0 new; `go generate ./...` + compatgen zero diff.