### PR TITLE
fix(gcp-pubsub): deliver push subscriptions over HTTP and invoke event-triggered Cloud Functions on publish

### DIFF
--- a/server/gcp/cloudfunctions/pubsubtrigger.go
+++ b/server/gcp/cloudfunctions/pubsubtrigger.go
@@ -1,0 +1,64 @@
+package cloudfunctions
+
+import (
+	"context"
+	"strings"
+
+	sdrv "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// InvokeForTopic delivers a published Pub/Sub message to every Cloud Function
+// whose eventTrigger targets the topic: gen1 functions whose
+// eventTrigger.resource is the topic, and gen2 functions whose
+// eventTrigger.pubsubTopic is the topic. Each matching function is invoked with
+// the message as its event (the legacy Pub/Sub {data, attributes, messageId,
+// publishTime} shape). Best-effort — a missing or failing function is swallowed
+// so a publish never fails. It implements the pubsub handler's FunctionInvoker.
+func (h *Handler) InvokeForTopic(ctx context.Context, project, topic string, event []byte) {
+	fullTopic := "projects/" + project + "/topics/" + topic
+
+	h.mu.RLock()
+	targets := make([]string, 0)
+
+	for key, meta := range h.gen1Meta {
+		if gen1PubsubTriggerMatches(meta.eventTrigger, topic, fullTopic) {
+			targets = append(targets, lastSegment(key))
+		}
+	}
+
+	for _, fn := range h.gen2 {
+		if fn.EventTrigger != nil && topicRefMatches(fn.EventTrigger.PubsubTopic, topic, fullTopic) {
+			targets = append(targets, lastSegment(fn.Name))
+		}
+	}
+	h.mu.RUnlock()
+
+	for _, name := range targets {
+		_, _ = h.fn.Invoke(ctx, sdrv.InvokeInput{
+			FunctionName: name,
+			Payload:      event,
+			InvokeType:   "Event",
+		})
+	}
+}
+
+// gen1PubsubTriggerMatches reports whether a gen1 eventTrigger is a Pub/Sub
+// trigger on the given topic. The "/topics/" guard keeps a same-named GCS
+// bucket or Firestore document trigger from matching a topic.
+func gen1PubsubTriggerMatches(et *eventTrigger, topic, fullTopic string) bool {
+	if et == nil || !strings.Contains(et.Resource, "/topics/") {
+		return false
+	}
+
+	return topicRefMatches(et.Resource, topic, fullTopic)
+}
+
+// topicRefMatches reports whether a topic reference (a full resource name or, as
+// a tolerance, a bare topic id) points at the topic.
+func topicRefMatches(ref, topic, fullTopic string) bool {
+	if ref == "" {
+		return false
+	}
+
+	return ref == fullTopic || lastSegment(ref) == topic
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -194,6 +194,8 @@ func New(d Drivers) *server.Server {
 	// CloudFunctions matches /v1/projects/{p}/locations/{l}/functions paths
 	// before Firestore so the locations+functions guard wins over Firestore's
 	// /v1/projects/ prefix match.
+	var cfHandler *cloudfunctions.Handler
+
 	if d.CloudFunctions != nil {
 		var cfOpts []cloudfunctions.Option
 		if d.Storage != nil {
@@ -203,7 +205,8 @@ func New(d Drivers) *server.Server {
 			cfOpts = append(cfOpts, cloudfunctions.WithObjectStore(d.Storage))
 		}
 
-		srv.Register(cloudfunctions.New(d.CloudFunctions, cfOpts...))
+		cfHandler = cloudfunctions.New(d.CloudFunctions, cfOpts...)
+		srv.Register(cfHandler)
 	}
 
 	// Cloud Run matches /v2/projects/{p}/locations/{l}/{jobs|operations}[/…].
@@ -218,7 +221,16 @@ func New(d Drivers) *server.Server {
 	// before Firestore so its more-specific resource-type guard wins over
 	// Firestore's permissive /v1/projects/ prefix.
 	if d.PubSub != nil {
-		srv.Register(pubsub.New(d.PubSub))
+		pubsubHandler := pubsub.New(d.PubSub)
+		// PubSub -> Cloud Functions: a publish invokes every function whose
+		// eventTrigger targets the topic (gen1 resource / gen2 pubsubTopic),
+		// mirroring the AWS S3/DynamoDB -> Lambda event-delivery wiring. Push
+		// subscription HTTP delivery is self-contained in the PubSub handler.
+		if cfHandler != nil {
+			pubsubHandler.SetFunctionInvoker(cfHandler)
+		}
+
+		srv.Register(pubsubHandler)
 	}
 
 	// Cloud SQL matches /v1/projects/{p}/{instances|operations}/...; same

--- a/server/gcp/pubsub/handler.go
+++ b/server/gcp/pubsub/handler.go
@@ -157,7 +157,7 @@ func (h *Handler) serveNested(w http.ResponseWriter, r *http.Request, project, b
 func (h *Handler) serveTopic(w http.ResponseWriter, r *http.Request, project, name, action string) {
 	switch action {
 	case "publish":
-		h.publish(w, r, name)
+		h.publish(w, r, project, name)
 		return
 	case verbGetIamPolicy, verbSetIamPolicy, verbTestIamPermissions:
 		h.serveIam(w, r, resTopics, name, action)
@@ -310,7 +310,7 @@ func (h *Handler) listTopics(w http.ResponseWriter, r *http.Request, project str
 	writeJSON(w, http.StatusOK, listTopicsResponse{Topics: page.Items, NextPageToken: page.NextPageToken})
 }
 
-func (h *Handler) publish(w http.ResponseWriter, r *http.Request, name string) {
+func (h *Handler) publish(w http.ResponseWriter, r *http.Request, project, name string) {
 	if r.Method != http.MethodPost {
 		writeError(w, http.StatusMethodNotAllowed, reasonMethodNotAllowed, "method not allowed")
 		return
@@ -328,16 +328,31 @@ func (h *Handler) publish(w http.ResponseWriter, r *http.Request, name string) {
 
 	publishTime := time.Now().UTC()
 	out := publishResponse{MessageIDs: make([]string, 0, len(req.Messages))}
+	delivery := make([]publishedMessage, 0, len(req.Messages))
+
+	// Store every message on the topic log first, capturing its index (for
+	// push auto-ack) and wire shape (for push / function delivery).
+	h.mu.Lock()
+	ts := h.topicLog(name)
 
 	for i := range req.Messages {
-		id := h.appendMessage(name, &storedMessage{
+		sm := storedMessage{
 			body:        decodeData(req.Messages[i].Data),
 			attributes:  req.Messages[i].Attributes,
 			orderingKey: req.Messages[i].OrderingKey,
 			publishTime: publishTime,
-		})
+		}
+		id := h.appendMessageLocked(name, &sm)
 		out.MessageIDs = append(out.MessageIDs, id)
+		delivery = append(delivery, publishedMessage{idx: len(ts.messages) - 1, msg: buildPubsubMessage(id, &sm)})
 	}
+
+	pushSubs := h.pushSubscribersLocked(name)
+	h.mu.Unlock()
+
+	// Fan out to push endpoints and event-triggered functions outside the lock,
+	// best-effort — a slow or failing target never fails the publish.
+	h.dispatchPublished(r.Context(), project, name, delivery, pushSubs)
 
 	writeJSON(w, http.StatusOK, out)
 }

--- a/server/gcp/pubsub/model.go
+++ b/server/gcp/pubsub/model.go
@@ -99,16 +99,24 @@ type Handler struct {
 	subs      map[string]*subState
 	snapshots map[string]*snapState
 
+	// pushDeliverer POSTs the push envelope to a push subscription's endpoint on
+	// publish; defaulted to a real-HTTP deliverer so push works in production.
+	// functionInvoker invokes any Cloud Function whose eventTrigger targets the
+	// topic; nil until the server wires the Cloud Functions handler in.
+	pushDeliverer   PushDeliverer
+	functionInvoker FunctionInvoker
+
 	ackCounter atomic.Uint64
 }
 
 // New returns a Pub/Sub handler backed by mq.
 func New(mq mqdriver.MessageQueue) *Handler {
 	return &Handler{
-		mq:        mq,
-		topics:    make(map[string]*topicState),
-		subs:      make(map[string]*subState),
-		snapshots: make(map[string]*snapState),
+		mq:            mq,
+		topics:        make(map[string]*topicState),
+		subs:          make(map[string]*subState),
+		snapshots:     make(map[string]*snapState),
+		pushDeliverer: newHTTPPushDeliverer(),
 	}
 }
 
@@ -124,16 +132,8 @@ func (h *Handler) topicLog(name string) *topicState {
 	return ts
 }
 
-// appendMessage records a published message on a topic and returns its id.
-func (h *Handler) appendMessage(topicName string, msg *storedMessage) string {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	return h.appendMessageLocked(topicName, msg)
-}
-
-// appendMessageLocked is appendMessage for callers already holding h.mu (e.g.
-// dead-letter routing from within deliver).
+// appendMessageLocked records a published message on a topic and returns its id.
+// The caller holds h.mu (publish and dead-letter routing from within deliver).
 func (h *Handler) appendMessageLocked(topicName string, msg *storedMessage) string {
 	ts := h.topicLog(topicName)
 	msg.id = fmt.Sprintf("%d", h.ackCounter.Add(1))

--- a/server/gcp/pubsub/push.go
+++ b/server/gcp/pubsub/push.go
@@ -1,0 +1,231 @@
+package pubsub
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+)
+
+// pushDeliveryTimeout bounds a single push POST so a slow or unresponsive
+// endpoint can never stall a publish. It mirrors the Azure Monitor webhook /
+// Event Grid deliverers.
+const pushDeliveryTimeout = 10 * time.Second
+
+// pushEnvelope is the body real Pub/Sub POSTs to a push subscription's endpoint:
+// the message plus the subscription resource name it was delivered for.
+type pushEnvelope struct {
+	Message      pubsubMessage `json:"message"`
+	Subscription string        `json:"subscription"`
+}
+
+// pushConfigJSON is the parsed subscription.pushConfig: only pushEndpoint is
+// needed to know where to POST.
+type pushConfigJSON struct {
+	PushEndpoint string            `json:"pushEndpoint"`
+	Attributes   map[string]string `json:"attributes,omitempty"`
+}
+
+// pushSub is a snapshot of one push subscription: its short name (map key), its
+// resource name (echoed in the envelope) and the endpoint to POST to.
+type pushSub struct {
+	name     string
+	fullName string
+	endpoint string
+}
+
+// publishedMessage pairs a just-stored message's topic-log index (so a
+// successful push can auto-ack it for that subscription) with the wire message
+// pushed / delivered to a function.
+type publishedMessage struct {
+	idx int
+	msg pubsubMessage
+}
+
+// PushDeliverer POSTs a push envelope to a subscription's endpoint, reporting
+// whether the endpoint accepted it (a 2xx). New() installs a real-HTTP default,
+// so a push subscription delivers in production without any wiring;
+// SetPushDeliverer is a test seam that swaps in a fake to assert delivery.
+type PushDeliverer interface {
+	Deliver(ctx context.Context, endpoint string, body []byte) bool
+}
+
+// FunctionInvoker delivers a published message to every Cloud Function whose
+// eventTrigger targets the topic. The Cloud Functions handler implements it and
+// is wired in on server construction; publish calls it best-effort so a slow or
+// failing function never fails the publish.
+type FunctionInvoker interface {
+	InvokeForTopic(ctx context.Context, project, topic string, event []byte)
+}
+
+// httpPushDeliverer is the production PushDeliverer: a best-effort real HTTP
+// POST with a bounded client. Transport errors and non-2xx responses report
+// "not accepted" so the message stays available for redelivery / pull.
+type httpPushDeliverer struct {
+	client *http.Client
+}
+
+func newHTTPPushDeliverer() *httpPushDeliverer {
+	return &httpPushDeliverer{client: &http.Client{Timeout: pushDeliveryTimeout}}
+}
+
+func (d *httpPushDeliverer) Deliver(ctx context.Context, endpoint string, body []byte) bool {
+	reqCtx, cancel := context.WithTimeout(ctx, pushDeliveryTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return false
+	}
+
+	req.Header.Set("Content-Type", contentTypeJSON)
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	return resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices
+}
+
+// SetPushDeliverer overrides the push deliverer. Test seam: a test injects a
+// fake to observe delivery without a live receiver. New() already installs a
+// real-HTTP default, so production never calls this.
+func (h *Handler) SetPushDeliverer(d PushDeliverer) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.pushDeliverer = d
+}
+
+// SetFunctionInvoker wires the Cloud Functions backend so a publish invokes any
+// function whose eventTrigger targets the topic. Nil (the default) leaves
+// function delivery a no-op.
+func (h *Handler) SetFunctionInvoker(fi FunctionInvoker) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.functionInvoker = fi
+}
+
+// buildPubsubMessage renders a stored message as the wire message shape carried
+// by both a push envelope and a Cloud Function event.
+func buildPubsubMessage(id string, msg *storedMessage) pubsubMessage {
+	return pubsubMessage{
+		MessageID:   id,
+		Data:        encodeData(msg.body),
+		Attributes:  msg.attributes,
+		OrderingKey: msg.orderingKey,
+		PublishTime: msg.publishTime.Format(time.RFC3339Nano),
+	}
+}
+
+// pushSubscribersLocked snapshots the push subscriptions on a topic: those with
+// a pushConfig.pushEndpoint set that are not detached. The caller holds h.mu.
+func (h *Handler) pushSubscribersLocked(topicShort string) []pushSub {
+	var subs []pushSub
+
+	for name, sub := range h.subs {
+		if sub.topic != topicShort || sub.cfg.Detached {
+			continue
+		}
+
+		endpoint := pushEndpoint(sub.cfg.PushConfig)
+		if endpoint == "" {
+			continue
+		}
+
+		subs = append(subs, pushSub{name: name, fullName: sub.cfg.Name, endpoint: endpoint})
+	}
+
+	return subs
+}
+
+// pushEndpoint extracts pushConfig.pushEndpoint from a subscription's raw
+// pushConfig JSON, returning "" when the subscription has no push endpoint.
+func pushEndpoint(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var pc pushConfigJSON
+	if err := json.Unmarshal(raw, &pc); err != nil {
+		return ""
+	}
+
+	return pc.PushEndpoint
+}
+
+// dispatchPublished performs the cross-service delivery a publish triggers,
+// outside h.mu so slow HTTP / function calls never hold the lock:
+//
+//   - every Cloud Function whose eventTrigger targets the topic is invoked with
+//     each message as its event (best-effort);
+//   - every push subscription's endpoint is POSTed each message's push envelope;
+//     a message a push endpoint accepts (2xx) is auto-acked for that
+//     subscription so a fallback pull does not redeliver it, while an
+//     unaccepted message is left for redelivery / pull.
+func (h *Handler) dispatchPublished(
+	ctx context.Context, project, topicShort string, msgs []publishedMessage, pushSubs []pushSub,
+) {
+	h.invokeFunctions(ctx, project, topicShort, msgs)
+	h.deliverPush(ctx, pushSubs, msgs)
+}
+
+func (h *Handler) invokeFunctions(ctx context.Context, project, topicShort string, msgs []publishedMessage) {
+	if h.functionInvoker == nil {
+		return
+	}
+
+	for i := range msgs {
+		event, err := json.Marshal(msgs[i].msg)
+		if err != nil {
+			continue
+		}
+
+		h.functionInvoker.InvokeForTopic(ctx, project, topicShort, event)
+	}
+}
+
+func (h *Handler) deliverPush(ctx context.Context, pushSubs []pushSub, msgs []publishedMessage) {
+	if len(pushSubs) == 0 || h.pushDeliverer == nil {
+		return
+	}
+
+	type ack struct {
+		sub string
+		idx int
+	}
+
+	var acks []ack
+
+	for _, ps := range pushSubs {
+		for i := range msgs {
+			body, err := json.Marshal(pushEnvelope{Message: msgs[i].msg, Subscription: ps.fullName})
+			if err != nil {
+				continue
+			}
+
+			if h.pushDeliverer.Deliver(ctx, ps.endpoint, body) {
+				acks = append(acks, ack{sub: ps.name, idx: msgs[i].idx})
+			}
+		}
+	}
+
+	if len(acks) == 0 {
+		return
+	}
+
+	h.mu.Lock()
+	for _, a := range acks {
+		if sub, ok := h.subs[a.sub]; ok {
+			sub.acked[a.idx] = true
+		}
+	}
+	h.mu.Unlock()
+}

--- a/server/gcp/pubsub/push_test.go
+++ b/server/gcp/pubsub/push_test.go
@@ -1,0 +1,334 @@
+package pubsub_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/providers/gcp"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// pushMessage is the "message" member of a Pub/Sub push envelope.
+type pushMessage struct {
+	Data        string            `json:"data"`
+	Attributes  map[string]string `json:"attributes"`
+	MessageID   string            `json:"messageId"`
+	PublishTime string            `json:"publishTime"`
+}
+
+type pushBody struct {
+	Message      pushMessage `json:"message"`
+	Subscription string      `json:"subscription"`
+}
+
+// newServerWithFunctions builds a GCP server wiring both PubSub and Cloud
+// Functions (so the PubSub -> Cloud Functions invoker is connected) and returns
+// the underlying provider so a test can register a capturing handler.
+func newServerWithFunctions(t *testing.T) (*httptest.Server, *gcp.Provider) {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := httptest.NewServer(gcpserver.New(gcpserver.Drivers{
+		PubSub:         cloud.PubSub,
+		CloudFunctions: cloud.CloudFunctions,
+		Firestore:      cloud.Firestore,
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv, cloud
+}
+
+// TestPushSubscriptionDeliversEnvelope covers BUG1: a push subscription's
+// endpoint receives the push envelope on publish (data / messageId /
+// subscription), with no pull ever issued.
+func TestPushSubscriptionDeliversEnvelope(t *testing.T) {
+	srv := newServer(t)
+
+	var (
+		mu       sync.Mutex
+		received []pushBody
+	)
+
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body pushBody
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		mu.Lock()
+		received = append(received, body)
+		mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(receiver.Close)
+
+	if resp := doRequest(t, srv, http.MethodPut, topicURL("push-topic"), `{}`); resp.StatusCode != http.StatusOK {
+		t.Fatalf("create topic = %d", resp.StatusCode)
+	}
+
+	subBody := `{"topic":"projects/` + project + `/topics/push-topic",` +
+		`"pushConfig":{"pushEndpoint":"` + receiver.URL + `"}}`
+	if resp := doRequest(t, srv, http.MethodPut, subURL("push-sub"), subBody); resp.StatusCode != http.StatusOK {
+		t.Fatalf("create push sub = %d: %s", resp.StatusCode, readBody(t, resp))
+	}
+
+	pub := doRequest(t, srv, http.MethodPost, topicURL("push-topic")+":publish",
+		`{"messages":[{"data":"`+base64.StdEncoding.EncodeToString([]byte("hello"))+
+			`","attributes":{"k":"v"}}]}`)
+	if pub.StatusCode != http.StatusOK {
+		t.Fatalf("publish = %d: %s", pub.StatusCode, readBody(t, pub))
+	}
+
+	_ = readBody(t, pub)
+
+	got := waitForPush(t, &mu, &received, 1)
+
+	if got[0].Subscription != "projects/"+project+"/subscriptions/push-sub" {
+		t.Errorf("subscription = %q", got[0].Subscription)
+	}
+
+	data, _ := base64.StdEncoding.DecodeString(got[0].Message.Data)
+	if string(data) != "hello" {
+		t.Errorf("data = %q, want hello", data)
+	}
+
+	if got[0].Message.Attributes["k"] != "v" {
+		t.Errorf("attributes = %v", got[0].Message.Attributes)
+	}
+
+	if got[0].Message.MessageID == "" {
+		t.Error("messageId empty")
+	}
+}
+
+// TestPushDeliveryAutoAcksSoPullSkips covers regression item (c): a message a
+// push endpoint accepted (2xx) is auto-acked, so a fallback pull on the same
+// subscription does not redeliver it.
+func TestPushDeliveryAutoAcksSoPullSkips(t *testing.T) {
+	srv := newServer(t)
+
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(receiver.Close)
+
+	doRequest(t, srv, http.MethodPut, topicURL("ack-topic"), `{}`)
+	subBody := `{"topic":"projects/` + project + `/topics/ack-topic",` +
+		`"pushConfig":{"pushEndpoint":"` + receiver.URL + `"}}`
+	doRequest(t, srv, http.MethodPut, subURL("ack-sub"), subBody)
+
+	doRequest(t, srv, http.MethodPost, topicURL("ack-topic")+":publish",
+		`{"messages":[{"data":"`+base64.StdEncoding.EncodeToString([]byte("x"))+`"}]}`)
+
+	// Give the synchronous best-effort push time to record the ack.
+	pull := doRequest(t, srv, http.MethodPost, subURL("ack-sub")+":pull", `{"maxMessages":10}`)
+
+	var pr struct {
+		ReceivedMessages []json.RawMessage `json:"receivedMessages"`
+	}
+	if err := json.Unmarshal([]byte(readBody(t, pull)), &pr); err != nil {
+		t.Fatalf("decode pull: %v", err)
+	}
+
+	if len(pr.ReceivedMessages) != 0 {
+		t.Errorf("pull after 2xx push returned %d messages, want 0 (auto-acked)", len(pr.ReceivedMessages))
+	}
+}
+
+// TestPublishSucceedsWhenPushEndpointUnreachable covers regression item (a): an
+// unreachable push endpoint never fails the publish (best-effort), and the
+// unacked message stays available for pull.
+func TestPublishSucceedsWhenPushEndpointUnreachable(t *testing.T) {
+	srv := newServer(t)
+
+	// A closed server yields an address that refuses connections immediately.
+	dead := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	deadURL := dead.URL
+	dead.Close()
+
+	doRequest(t, srv, http.MethodPut, topicURL("dead-topic"), `{}`)
+	subBody := `{"topic":"projects/` + project + `/topics/dead-topic",` +
+		`"pushConfig":{"pushEndpoint":"` + deadURL + `"}}`
+	doRequest(t, srv, http.MethodPut, subURL("dead-sub"), subBody)
+
+	pub := doRequest(t, srv, http.MethodPost, topicURL("dead-topic")+":publish",
+		`{"messages":[{"data":"`+base64.StdEncoding.EncodeToString([]byte("y"))+`"}]}`)
+	if pub.StatusCode != http.StatusOK {
+		t.Fatalf("publish with unreachable endpoint = %d, want 200", pub.StatusCode)
+	}
+	_ = readBody(t, pub)
+
+	// Not acked (push failed) -> still pullable.
+	pull := doRequest(t, srv, http.MethodPost, subURL("dead-sub")+":pull", `{"maxMessages":10}`)
+
+	var pr struct {
+		ReceivedMessages []json.RawMessage `json:"receivedMessages"`
+	}
+	_ = json.Unmarshal([]byte(readBody(t, pull)), &pr)
+
+	if len(pr.ReceivedMessages) != 1 {
+		t.Errorf("pull after failed push returned %d messages, want 1 (left for redelivery)", len(pr.ReceivedMessages))
+	}
+}
+
+// TestPullSubscriptionUnaffected covers regression item (c): a plain pull
+// subscription (no pushConfig) still delivers and acks normally.
+func TestPullSubscriptionUnaffected(t *testing.T) {
+	srv := newServer(t)
+
+	doRequest(t, srv, http.MethodPut, topicURL("pull-topic"), `{}`)
+	doRequest(t, srv, http.MethodPut, subURL("pull-sub"),
+		`{"topic":"projects/`+project+`/topics/pull-topic"}`)
+
+	doRequest(t, srv, http.MethodPost, topicURL("pull-topic")+":publish",
+		`{"messages":[{"data":"`+base64.StdEncoding.EncodeToString([]byte("z"))+`"}]}`)
+
+	pull := doRequest(t, srv, http.MethodPost, subURL("pull-sub")+":pull", `{"maxMessages":10}`)
+
+	var pr struct {
+		ReceivedMessages []json.RawMessage `json:"receivedMessages"`
+	}
+	if err := json.Unmarshal([]byte(readBody(t, pull)), &pr); err != nil {
+		t.Fatalf("decode pull: %v", err)
+	}
+
+	if len(pr.ReceivedMessages) != 1 {
+		t.Fatalf("pull sub returned %d messages, want 1", len(pr.ReceivedMessages))
+	}
+}
+
+// TestPublishInvokesEventTriggeredFunction covers BUG2: publishing to a topic
+// invokes a Cloud Function whose gen1 eventTrigger targets that topic, with the
+// message delivered as the event (data + attributes).
+func TestPublishInvokesEventTriggeredFunction(t *testing.T) {
+	srv, cloud := newServerWithFunctions(t)
+
+	var (
+		mu       sync.Mutex
+		payloads [][]byte
+	)
+
+	cloud.CloudFunctions.RegisterHandler("on-publish", func(_ context.Context, payload []byte) ([]byte, error) {
+		mu.Lock()
+		payloads = append(payloads, append([]byte(nil), payload...))
+		mu.Unlock()
+
+		return nil, nil
+	})
+
+	// Topic the function is triggered by.
+	doRequest(t, srv, http.MethodPut, topicURL("fn-topic"), `{}`)
+
+	// gen1 function with a Pub/Sub eventTrigger on that topic.
+	fnPath := "/v1/projects/" + project + "/locations/us-central1/functions?functionId=on-publish"
+	createFn := `{"eventTrigger":{"eventType":"google.pubsub.topic.publish",` +
+		`"resource":"projects/` + project + `/topics/fn-topic","service":"pubsub.googleapis.com"}}`
+	if resp := doRequest(t, srv, http.MethodPost, fnPath, createFn); resp.StatusCode != http.StatusOK {
+		t.Fatalf("create function = %d: %s", resp.StatusCode, readBody(t, resp))
+	}
+
+	pub := doRequest(t, srv, http.MethodPost, topicURL("fn-topic")+":publish",
+		`{"messages":[{"data":"`+base64.StdEncoding.EncodeToString([]byte("payload"))+
+			`","attributes":{"a":"b"}}]}`)
+	if pub.StatusCode != http.StatusOK {
+		t.Fatalf("publish = %d: %s", pub.StatusCode, readBody(t, pub))
+	}
+	_ = readBody(t, pub)
+
+	got := waitForBytes(t, &mu, &payloads, 1)
+
+	var event pushMessage
+	if err := json.Unmarshal(got[0], &event); err != nil {
+		t.Fatalf("decode event: %v (raw %s)", err, got[0])
+	}
+
+	data, _ := base64.StdEncoding.DecodeString(event.Data)
+	if string(data) != "payload" {
+		t.Errorf("event data = %q, want payload", data)
+	}
+
+	if event.Attributes["a"] != "b" {
+		t.Errorf("event attributes = %v", event.Attributes)
+	}
+}
+
+// TestPublishNoFunctionNoPushStillWorks covers regression item (c): a topic with
+// neither a push subscription nor an event-triggered function publishes fine.
+func TestPublishNoFunctionNoPushStillWorks(t *testing.T) {
+	srv, _ := newServerWithFunctions(t)
+
+	doRequest(t, srv, http.MethodPut, topicURL("plain-topic"), `{}`)
+
+	pub := doRequest(t, srv, http.MethodPost, topicURL("plain-topic")+":publish",
+		`{"messages":[{"data":"`+base64.StdEncoding.EncodeToString([]byte("q"))+`"}]}`)
+	if pub.StatusCode != http.StatusOK {
+		t.Fatalf("publish = %d, want 200", pub.StatusCode)
+	}
+
+	var out struct {
+		MessageIDs []string `json:"messageIds"`
+	}
+	if err := json.Unmarshal([]byte(readBody(t, pub)), &out); err != nil {
+		t.Fatalf("decode publish: %v", err)
+	}
+
+	if len(out.MessageIDs) != 1 {
+		t.Errorf("messageIds = %v, want 1", out.MessageIDs)
+	}
+}
+
+func waitForPush(t *testing.T, mu *sync.Mutex, store *[]pushBody, want int) []pushBody {
+	t.Helper()
+
+	for range 100 {
+		mu.Lock()
+		n := len(*store)
+		mu.Unlock()
+
+		if n >= want {
+			break
+		}
+
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(*store) < want {
+		t.Fatalf("got %d push deliveries, want %d", len(*store), want)
+	}
+
+	return append([]pushBody(nil), *store...)
+}
+
+func waitForBytes(t *testing.T, mu *sync.Mutex, store *[][]byte, want int) [][]byte {
+	t.Helper()
+
+	for range 100 {
+		mu.Lock()
+		n := len(*store)
+		mu.Unlock()
+
+		if n >= want {
+			break
+		}
+
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(*store) < want {
+		t.Fatalf("got %d invocations, want %d", len(*store), want)
+	}
+
+	return append([][]byte(nil), *store...)
+}


### PR DESCRIPTION
## Summary

Fixes two real GCP Pub/Sub cross-service delivery bugs, both on the wire `topics:publish` path:

**BUG1 — Push subscriptions never delivered (silent message loss).** `pushConfig` was accepted and stored but `deliver()` only ran on `Pull`. A push subscription's client never pulls, so messages accumulated forever and the endpoint was never called. Publish now fans out to every subscription on the topic whose `pushConfig.pushEndpoint` is set, POSTing the real Pub/Sub push envelope (`{"message":{data,messageId,publishTime,attributes},"subscription":...}`) over a bounded, best-effort `http.Client` (mirrors the Azure Monitor / Event Grid webhook deliverers). A message the endpoint accepts (2xx) is auto-acked for that subscription so a fallback pull does not redeliver it; a transport error / non-2xx leaves it for redelivery/pull. Publish never fails or hangs on a slow/unreachable endpoint.

**BUG2 — Pub/Sub -> Cloud Functions eventTrigger was inert.** The wire publish path bypassed the provider `SendMessage` trigger hook (it uses the native topic log), so an event-triggered Cloud Function was never invoked. Publish now invokes every Cloud Function whose eventTrigger targets the topic — gen1 `eventTrigger.resource` or gen2 `eventTrigger.pubsubTopic` — via the Cloud Functions handler's `Invoke` choke point, delivering the message as the legacy Pub/Sub event (`{data, attributes, messageId, publishTime}`). The invoker is a `FunctionInvoker` interface on the Pub/Sub handler, implemented by the Cloud Functions handler and wired in `server/gcp/gcp.go` (`pubsubHandler.SetFunctionInvoker(cfHandler)`), mirroring the AWS S3/DynamoDB -> Lambda event-delivery wiring.

## Why wired at the wire layer

`eventTrigger` config (gen1 `resource`, gen2 `pubsubTopic`) lives only in the `server/gcp/cloudfunctions` handler — the provider Cloud Functions mock and the serverless driver have no eventTrigger concept, so the topic->function match can only be done there. The provider-level `SetTrigger` path is a test-covered typed-path seam symmetric with Azure ServiceBus (`TestGCPCloudFunctionPubSubTrigger` / `TestAzureFunctionServiceBusTrigger`), so it is left intact rather than repurposed/removed. No new provider-level `Set<X>` injector is added, so `TestWiringParity_GCP` stays green.

## Tests

New `server/gcp/pubsub/push_test.go`:
- push subscription -> httptest receiver gets the envelope (data/attributes/messageId/subscription)
- unreachable endpoint -> publish still succeeds; message stays pullable
- 2xx push auto-acks so a later pull returns nothing
- event-triggered gen1 Cloud Function invoked with the event (data+attributes)
- pull subscription unaffected; topic with no push/no function still publishes

## Gates

- `go build ./...`, `go vet`, gofmt: clean
- `go test ./server/gcp/pubsub/... ./providers/gcp/pubsub/... ./providers/gcp/cloudfunctions/... ./server/gcp/cloudfunctions/...`: pass
- `go test -run 'TestWiringParity|TestRealWorld' ./providers/ .`: pass
- `golangci-lint --new-from-rev=origin/development` on changed packages: 0 issues
- `go generate ./...` and `go run ./internal/compatgen`: no diff, compat suite green
