### PR TITLE
fix(azure-storage): emit Blob Created/Deleted events into EventGrid system topic

### DIFF
--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -213,6 +213,7 @@ func New(opts ...config.Option) *Provider {
 	p.EventGrid.SetMonitoring(p.Monitor)
 	p.EventGrid.SetServiceBusDeliverer(p.ServiceBus)
 	p.EventGrid.SetFunctionInvoker(p.Functions)
+	p.BlobStorage.SetEventGridPublisher(p.EventGrid)
 	p.SQL.SetMonitoring(p.Monitor)
 	p.PostgresFlex.SetMonitoring(p.Monitor)
 	p.MySQLFlex.SetMonitoring(p.Monitor)

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -26,8 +27,12 @@ const (
 	blobDefaultSASExpiry = time.Hour
 	blobDefaultMaxKeys   = 1000
 	blobTimeFormat       = "2006-01-02T15:04:05Z"
-	blobAccountName      = "cloudemu"
-	blobHoursPerDay      = 24
+	// AccountName is the single storage account the blob data plane models. The
+	// blob URL host and the Event Grid system-topic routing key both derive from
+	// it, so a system-topic subscription created for this account (a bus of this
+	// name on the Event Grid mock) receives the account's Blob events.
+	AccountName     = "cloudemu"
+	blobHoursPerDay = 24
 )
 
 // Compile-time check that Mock implements driver.Bucket.
@@ -149,6 +154,14 @@ type Mock struct {
 	accountEncryption *memstore.Store[driver.AccountEncryption]
 	opts              *config.Options
 	monitoring        mondriver.Monitoring
+	// eventgrid, when wired, receives a Microsoft.Storage.BlobCreated/BlobDeleted
+	// event on every blob write/delete so an Event Grid system-topic subscription
+	// for this account can deliver it. nil in library/typed use, where blob writes
+	// simply skip event emission.
+	eventgrid EventGridPublisher
+	// blobEventSeq backs the monotonically increasing sequencer stamped on each
+	// emitted blob event (Event Grid's per-blob ordering token).
+	blobEventSeq atomic.Uint64
 }
 
 // Compile-time check that Mock satisfies the optional BucketAttributes
@@ -421,6 +434,7 @@ func (m *Mock) putBlockBlobInternal(
 	ctr.objects.Set(key, obj)
 
 	m.emitMetric(bucket, map[string]float64{"Transactions": 1, "Ingress": float64(size)})
+	m.emitBlobCreated(ctx, obj, bucket)
 
 	info := objectInfo(obj)
 
@@ -504,7 +518,8 @@ func (m *Mock) DeleteObject(ctx context.Context, bucket, key string) error {
 		return cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
 	}
 
-	if !ctr.objects.Has(key) {
+	obj, ok := ctr.objects.Get(key)
+	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "blob %q not found in container %q", key, bucket)
 	}
 
@@ -515,6 +530,7 @@ func (m *Mock) DeleteObject(ctx context.Context, bucket, key string) error {
 	_ = storageengine.Delete(ctx, m.opts.StorageEngine, config.StorageRef{Bucket: bucket, Key: key})
 
 	m.emitMetric(bucket, map[string]float64{"Transactions": 1})
+	m.emitBlobDeleted(ctx, obj, bucket)
 
 	return nil
 }
@@ -748,7 +764,7 @@ func (m *Mock) GeneratePresignedURL(_ context.Context, req driver.PresignedURLRe
 
 	url := fmt.Sprintf(
 		"https://%s.blob.core.windows.net/%s/%s?sv=2023-11-03&sig=%s&se=%s&sp=%s",
-		blobAccountName, req.Bucket, req.Key, sig,
+		AccountName, req.Bucket, req.Key, sig,
 		expiresAt.Format(blobTimeFormat), permissions,
 	)
 

--- a/providers/azure/blobstorage/eventgrid_events.go
+++ b/providers/azure/blobstorage/eventgrid_events.go
@@ -1,0 +1,156 @@
+package blobstorage
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+)
+
+// Blob event types and the api operation names real Azure Blob Storage stamps
+// on the events it emits into Event Grid.
+const (
+	eventTypeBlobCreated = "Microsoft.Storage.BlobCreated"
+	eventTypeBlobDeleted = "Microsoft.Storage.BlobDeleted"
+	blobEventAPICreate   = "PutBlob"
+	blobEventAPIDelete   = "DeleteBlob"
+	// blobEventDataVersion is the schema version real Azure Blob Storage stamps
+	// on its BlobCreated/BlobDeleted event data.
+	blobEventDataVersion = "2"
+	defaultBlobType      = "BlockBlob"
+	storageResourceType  = "storageAccounts"
+	storageProvider      = "Microsoft.Storage"
+	defaultResourceGroup = "default"
+)
+
+// EventGridPublisher is the subset of the Event Grid mock the blob data plane
+// uses to emit Blob Storage events. The eventgrid.Mock satisfies it via
+// PutEvents, so a blob write routes through Event Grid's existing subscription
+// matching + delivery pipeline rather than a parallel path.
+type EventGridPublisher interface {
+	PutEvents(ctx context.Context, events []ebdriver.Event) (*ebdriver.PublishResult, error)
+}
+
+// SetEventGridPublisher wires the Event Grid backend so blob writes/deletes emit
+// Microsoft.Storage.BlobCreated/BlobDeleted events into the account's system
+// topic. Best-effort: with no publisher set, blob operations proceed unchanged.
+func (m *Mock) SetEventGridPublisher(p EventGridPublisher) {
+	m.eventgrid = p
+}
+
+// blobEventFacts carries the blob-level values a Blob Storage event reports, so
+// the emit helper takes one value instead of a long positional parameter list.
+type blobEventFacts struct {
+	container     string
+	key           string
+	eTag          string
+	contentType   string
+	contentLength int64
+	blobType      string
+}
+
+// storageAccountID builds the ARM resource id of the storage account the blob
+// data plane models — the "topic" real Azure stamps on a Blob Storage event
+// (its source resource), distinct from the Event Grid topic the subscription
+// hangs off. The resource group comes from the account's ARM attributes when it
+// was created through the storage-account ARM surface, else a stable default.
+func (m *Mock) storageAccountID() string {
+	rg := defaultResourceGroup
+	if attrs, ok := m.bucketAttrs.Get(AccountName); ok && attrs.ResourceGroup != "" {
+		rg = attrs.ResourceGroup
+	}
+
+	return idgen.AzureID(m.opts.AccountID, rg, storageProvider, storageResourceType, AccountName)
+}
+
+// emitBlobCreated fires a Microsoft.Storage.BlobCreated event for a written blob.
+func (m *Mock) emitBlobCreated(ctx context.Context, obj *blobObject, container string) {
+	m.emitBlobEvent(ctx, eventTypeBlobCreated, blobEventAPICreate, &blobEventFacts{
+		container: container, key: obj.Key, eTag: obj.ETag,
+		contentType: obj.ContentType, contentLength: obj.Size, blobType: obj.BlobType,
+	})
+}
+
+// emitBlobDeleted fires a Microsoft.Storage.BlobDeleted event for a removed blob.
+func (m *Mock) emitBlobDeleted(ctx context.Context, obj *blobObject, container string) {
+	m.emitBlobEvent(ctx, eventTypeBlobDeleted, blobEventAPIDelete, &blobEventFacts{
+		container: container, key: obj.Key, eTag: obj.ETag,
+		contentType: obj.ContentType, contentLength: obj.Size, blobType: obj.BlobType,
+	})
+}
+
+// emitBlobEvent builds a Blob Storage Event Grid event and publishes it into the
+// account's system topic (a bus named for the account on the Event Grid mock).
+// No-op when no publisher is wired. Publish failures are swallowed: event
+// emission must never fail the blob operation, matching Azure's decoupled,
+// asynchronous eventing.
+func (m *Mock) emitBlobEvent(ctx context.Context, eventType, api string, f *blobEventFacts) {
+	if m.eventgrid == nil {
+		return
+	}
+
+	sequencer := fmt.Sprintf("%016X", m.blobEventSeq.Add(1))
+	accountID := m.storageAccountID()
+
+	event := ebdriver.Event{
+		Source:      accountID,
+		Topic:       accountID,
+		DetailType:  eventType,
+		Subject:     fmt.Sprintf("/blobServices/default/containers/%s/blobs/%s", f.container, f.key),
+		Detail:      m.blobEventData(eventType, api, sequencer, f),
+		DataVersion: blobEventDataVersion,
+		EventBus:    AccountName,
+		Time:        m.opts.Clock.Now().UTC(),
+	}
+
+	_, _ = m.eventgrid.PutEvents(ctx, []ebdriver.Event{event})
+}
+
+// blobEventData renders the "data" body of a Blob Storage event, matching real
+// Azure's schema. A BlobCreated event reports eTag/contentLength; a BlobDeleted
+// event omits them (the bytes are gone), the same distinction real Azure draws.
+func (m *Mock) blobEventData(eventType, api, sequencer string, f *blobEventFacts) string {
+	blobType := f.blobType
+	if blobType == "" {
+		blobType = defaultBlobType
+	}
+
+	requestID := m.blobEventRequestID(sequencer, f)
+
+	data := map[string]any{
+		"api":         api,
+		"requestId":   requestID,
+		"contentType": f.contentType,
+		"blobType":    blobType,
+		"url": fmt.Sprintf(
+			"https://%s.blob.core.windows.net/%s/%s", AccountName, f.container, f.key,
+		),
+		"sequencer":          sequencer,
+		"storageDiagnostics": map[string]any{"batchId": requestID},
+	}
+
+	if eventType == eventTypeBlobCreated {
+		data["eTag"] = f.eTag
+		data["contentLength"] = f.contentLength
+	}
+
+	b, err := json.Marshal(data)
+	if err != nil {
+		return "{}"
+	}
+
+	return string(b)
+}
+
+// blobEventRequestID derives a stable GUID-shaped request id for one blob event
+// from the account id, blob subject, and the event's sequencer.
+func (*Mock) blobEventRequestID(sequencer string, f *blobEventFacts) string {
+	sum := sha256.Sum256([]byte(f.container + "/" + f.key + ":" + sequencer))
+
+	return fmt.Sprintf(
+		"%x-%x-%x-%x-%x", sum[0:4], sum[4:6], sum[6:8], sum[8:10], sum[10:16],
+	)
+}

--- a/providers/azure/blobstorage/eventgrid_events_test.go
+++ b/providers/azure/blobstorage/eventgrid_events_test.go
@@ -1,0 +1,236 @@
+package blobstorage
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/azure/eventgrid"
+	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deliveredEvent mirrors the Event Grid schema envelope POSTed to a WebHook
+// subscriber, decoded from the blob event the producer emits.
+type deliveredEvent struct {
+	ID          string          `json:"id"`
+	Topic       string          `json:"topic"`
+	Subject     string          `json:"subject"`
+	EventType   string          `json:"eventType"`
+	Data        json.RawMessage `json:"data"`
+	DataVersion string          `json:"dataVersion"`
+}
+
+// blobWebhookReceiver records every Event Grid batch delivered to it.
+type blobWebhookReceiver struct {
+	*httptest.Server
+
+	mu    sync.Mutex
+	calls []deliveredEvent
+}
+
+func newBlobWebhookReceiver(t *testing.T) *blobWebhookReceiver {
+	t.Helper()
+
+	rc := &blobWebhookReceiver{}
+	rc.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var batch []deliveredEvent
+		if err := json.NewDecoder(r.Body).Decode(&batch); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		rc.mu.Lock()
+		rc.calls = append(rc.calls, batch...)
+		rc.mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(rc.Close)
+
+	return rc
+}
+
+func (rc *blobWebhookReceiver) events() []deliveredEvent {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+
+	out := make([]deliveredEvent, len(rc.calls))
+	copy(out, rc.calls)
+
+	return out
+}
+
+// blobSubscriptionProps builds the raw ARM EventSubscription properties JSON a
+// system-topic subscription carries: an optional filter plus a WebHook
+// destination pointing at the receiver.
+func blobSubscriptionProps(endpointURL string, filter map[string]any) string {
+	props := map[string]any{
+		"destination": map[string]any{
+			"endpointType": "WebHook",
+			"properties":   map[string]any{"endpointUrl": endpointURL},
+		},
+	}
+	if filter != nil {
+		props["filter"] = filter
+	}
+
+	b, _ := json.Marshal(props)
+
+	return string(b)
+}
+
+// newWiredMocks builds a blob mock wired to an Event Grid mock that share a
+// clock, plus a system topic (a bus named for the storage account) that blob
+// events route to.
+func newWiredMocks(t *testing.T) (*Mock, *eventgrid.Mock) {
+	t.Helper()
+
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithRegion("eastus"))
+
+	eg := eventgrid.New(opts)
+	bm := New(opts)
+	bm.SetEventGridPublisher(eg)
+
+	_, err := eg.CreateEventBus(context.Background(), ebdriver.EventBusConfig{Name: AccountName})
+	require.NoError(t, err)
+
+	return bm, eg
+}
+
+func subscribe(t *testing.T, eg *eventgrid.Mock, name, url string, filter map[string]any) {
+	t.Helper()
+
+	_, err := eg.PutRule(context.Background(), &ebdriver.RuleConfig{
+		Name:        name,
+		EventBus:    AccountName,
+		Description: blobSubscriptionProps(url, filter),
+	})
+	require.NoError(t, err)
+}
+
+// TestBlobCreatedEmitsToSubscriber covers case (a): a PUT delivers a
+// Microsoft.Storage.BlobCreated event to a system-topic subscriber with the
+// correct subject and data.
+func TestBlobCreatedEmitsToSubscriber(t *testing.T) {
+	receiver := newBlobWebhookReceiver(t)
+	bm, eg := newWiredMocks(t)
+	ctx := context.Background()
+
+	subscribe(t, eg, "sub1", receiver.URL, map[string]any{
+		"includedEventTypes": []string{eventTypeBlobCreated},
+	})
+
+	require.NoError(t, bm.CreateBucket(ctx, "images"))
+	require.NoError(t, bm.PutObject(ctx, "images", "cat.png", []byte("hello"), "image/png", nil))
+
+	got := receiver.events()
+	require.Len(t, got, 1)
+	assert.Equal(t, eventTypeBlobCreated, got[0].EventType)
+	assert.Equal(t, "/blobServices/default/containers/images/blobs/cat.png", got[0].Subject)
+	assert.Equal(t, blobEventDataVersion, got[0].DataVersion)
+
+	var data map[string]any
+	require.NoError(t, json.Unmarshal(got[0].Data, &data))
+	assert.Equal(t, blobEventAPICreate, data["api"])
+	assert.Equal(t, "BlockBlob", data["blobType"])
+	assert.Equal(t, "image/png", data["contentType"])
+	assert.EqualValues(t, 5, data["contentLength"])
+	assert.Equal(t, "https://cloudemu.blob.core.windows.net/images/cat.png", data["url"])
+	assert.NotEmpty(t, data["eTag"])
+	assert.NotEmpty(t, data["sequencer"])
+	// topic is the storage account's ARM id (the source resource), not the Event
+	// Grid topic the subscription hangs off.
+	assert.Contains(t, got[0].Topic, "/providers/Microsoft.Storage/storageAccounts/cloudemu")
+}
+
+// TestBlobDeletedEmitsToSubscriber covers case (b): a DELETE delivers a
+// Microsoft.Storage.BlobDeleted event.
+func TestBlobDeletedEmitsToSubscriber(t *testing.T) {
+	receiver := newBlobWebhookReceiver(t)
+	bm, eg := newWiredMocks(t)
+	ctx := context.Background()
+
+	subscribe(t, eg, "sub1", receiver.URL, map[string]any{
+		"includedEventTypes": []string{eventTypeBlobDeleted},
+	})
+
+	require.NoError(t, bm.CreateBucket(ctx, "docs"))
+	require.NoError(t, bm.PutObject(ctx, "docs", "a.txt", []byte("hi"), "text/plain", nil))
+	require.NoError(t, bm.DeleteObject(ctx, "docs", "a.txt"))
+
+	got := receiver.events()
+	require.Len(t, got, 1)
+	assert.Equal(t, eventTypeBlobDeleted, got[0].EventType)
+	assert.Equal(t, "/blobServices/default/containers/docs/blobs/a.txt", got[0].Subject)
+
+	var data map[string]any
+	require.NoError(t, json.Unmarshal(got[0].Data, &data))
+	assert.Equal(t, blobEventAPIDelete, data["api"])
+	// A delete omits eTag/contentLength (the bytes are gone), matching real Azure.
+	assert.NotContains(t, data, "eTag")
+	assert.NotContains(t, data, "contentLength")
+}
+
+// TestBlobEventSubjectPrefixFilterDropsOtherContainers covers case (c): a
+// subscription filtering on a container path prefix drops events from other
+// containers.
+func TestBlobEventSubjectPrefixFilterDropsOtherContainers(t *testing.T) {
+	receiver := newBlobWebhookReceiver(t)
+	bm, eg := newWiredMocks(t)
+	ctx := context.Background()
+
+	subscribe(t, eg, "sub1", receiver.URL, map[string]any{
+		"subjectBeginsWith": "/blobServices/default/containers/wanted/",
+	})
+
+	require.NoError(t, bm.CreateBucket(ctx, "wanted"))
+	require.NoError(t, bm.CreateBucket(ctx, "other"))
+	require.NoError(t, bm.PutObject(ctx, "other", "skip.txt", []byte("x"), "text/plain", nil))
+	require.NoError(t, bm.PutObject(ctx, "wanted", "keep.txt", []byte("y"), "text/plain", nil))
+
+	got := receiver.events()
+	require.Len(t, got, 1)
+	assert.Equal(t, "/blobServices/default/containers/wanted/blobs/keep.txt", got[0].Subject)
+}
+
+// TestBlobWriteSucceedsWithoutPublisher covers case (d): with no Event Grid
+// publisher wired, blob writes and deletes still succeed (no panic).
+func TestBlobWriteSucceedsWithoutPublisher(t *testing.T) {
+	bm := newTestMock() // no SetEventGridPublisher
+	ctx := context.Background()
+
+	require.NoError(t, bm.CreateBucket(ctx, "c"))
+	require.NoError(t, bm.PutObject(ctx, "c", "k", []byte("v"), "text/plain", nil))
+
+	obj, err := bm.GetObject(ctx, "c", "k")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("v"), obj.Data)
+	require.NoError(t, bm.DeleteObject(ctx, "c", "k"))
+}
+
+// TestBlobEventNoSubscriptionNoDelivery covers case (e) on the producer side:
+// with a wired publisher but no matching subscription, the blob write still
+// succeeds and nothing is delivered.
+func TestBlobEventNoSubscriptionNoDelivery(t *testing.T) {
+	receiver := newBlobWebhookReceiver(t)
+	bm, eg := newWiredMocks(t)
+	ctx := context.Background()
+
+	// Subscription only accepts BlobDeleted; a BlobCreated must not reach it.
+	subscribe(t, eg, "sub1", receiver.URL, map[string]any{
+		"includedEventTypes": []string{eventTypeBlobDeleted},
+	})
+
+	require.NoError(t, bm.CreateBucket(ctx, "c"))
+	require.NoError(t, bm.PutObject(ctx, "c", "k", []byte("v"), "text/plain", nil))
+
+	assert.Empty(t, receiver.events())
+}

--- a/providers/azure/eventgrid/delivery.go
+++ b/providers/azure/eventgrid/delivery.go
@@ -130,9 +130,17 @@ func (m *Mock) deliverToTargets(ctx context.Context, matched []*ruleData, event 
 	// the re-entrant delivery depth forward onto a background-rooted context.
 	dctx := recursionguard.WithDepth(context.Background(), recursionguard.Depth(ctx))
 
+	// A system-topic producer stamps the source resource id on event.Topic (real
+	// Azure delivers the storage account id, not the Event Grid topic resource);
+	// a custom-topic publish leaves it empty and delivery reports the bus's ARN.
+	topic := event.Topic
+	if topic == "" {
+		topic = topicARN
+	}
+
 	payload := deliveryEvent{
 		ID:              event.ID,
-		Topic:           topicARN,
+		Topic:           topic,
 		Subject:         event.Subject,
 		EventType:       event.DetailType,
 		EventTime:       event.Time.UTC().Format(time.RFC3339Nano),

--- a/services/eventbus/driver/driver.go
+++ b/services/eventbus/driver/driver.go
@@ -132,6 +132,13 @@ type Event struct {
 	// version the publisher declared. Empty for AWS and GCP, and for an Azure
 	// publisher that omitted it (delivery then defaults it to "1.0").
 	DataVersion string
+	// Topic overrides the delivered event's "topic" field (Azure Event Grid's
+	// fully-qualified topic resource id). A system-topic producer (e.g. Blob
+	// Storage) sets it to the source resource id — the storage account's ARM id —
+	// which is the topic real Azure stamps on the event, distinct from the Event
+	// Grid topic resource the subscription hangs off. Empty for AWS and GCP and
+	// for a custom-topic publish, where delivery falls back to the bus's own ARN.
+	Topic string
 }
 
 // PublishResult is the result of publishing events.


### PR DESCRIPTION
## Summary

Adds the **producer** side of Azure Blob Storage → Event Grid so a system-topic subscription for `Microsoft.Storage.BlobCreated`/`BlobDeleted` actually fires. EventGrid delivery to WebHook/ServiceBus/Function was fixed in #800; nothing fed those subscriptions. Now a blob PUT/DELETE emits a correctly-shaped Blob Storage event into the storage account's Event Grid system topic, which flows through the existing #800 subscription-matching + delivery path.

## What changed

- **`providers/azure/blobstorage/eventgrid_events.go`** (new): `EventGridPublisher` interface + `SetEventGridPublisher` injector on the blob mock, and the emit helpers. On blob write (`PutObject`/`PutBlockBlob`) it emits `Microsoft.Storage.BlobCreated`; on `DeleteObject` it emits `Microsoft.Storage.BlobDeleted`. Events carry the real Azure schema: `eventType`, `topic` = the storage account ARM id, `subject` = `/blobServices/default/containers/<c>/blobs/<b>`, `dataVersion` `"2"`, and `data` `{ api, requestId, eTag, contentType, contentLength, blobType, url, sequencer, storageDiagnostics }` (a delete omits `eTag`/`contentLength`, matching real Azure). Routing key = the account name (its system-topic bus); nil publisher is a no-op.
- **`providers/azure/blobstorage/blobstorage.go`**: emit hooks in the write/delete paths; exported `AccountName`; `eventgrid` field + sequencer counter.
- **`providers/azure/eventgrid/delivery.go`**: the delivered `topic` honors an event-supplied `Topic` (system topic's source resource), else falls back to the bus ARN — no change for custom-topic publishes.
- **`services/eventbus/driver/driver.go`**: optional `Event.Topic` field (Azure-only, like the existing `Subject`/`DataVersion`; empty for AWS/GCP).
- **`providers/azure/azure.go`**: wire `p.BlobStorage.SetEventGridPublisher(p.EventGrid)`.

## Tests

New `eventgrid_events_test.go` covers: (a) PUT → subscriber receives `BlobCreated` with correct subject/data; (b) DELETE → `BlobDeleted`; (c) container subject-prefix filter drops other containers; (d) nil publisher → blob write still succeeds; (e) non-matching subscription → no delivery, write succeeds. `TestWiringParity_Azure` passes with the new injector wired.

## Gates

`go build ./...`, `go vet`, targeted `go test -p=3`, `TestWiringParity`, `go generate` (no diff), compatgen (all green, no `docs/compat` diff), gofmt, and `golangci-lint --new-from-rev=origin/development` on touched packages (0 new) all pass.