### PR TITLE
feat(gcp-gcs): notificationConfigs + emit object events to Pub/Sub

### DIFF
--- a/docs/coverage/aws/s3.md
+++ b/docs/coverage/aws/s3.md
@@ -119,9 +119,13 @@ GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type
 | `BucketAttrsGCS` | BucketAttrsGCS returns the bucket's GCS-specific attributes. |
 | `BucketIAMPolicy` |  |
 | `ComposeObjectGCS` | ComposeObjectGCS concatenates the source objects' bytes (in order) into |
+| `CreateNotificationConfig` | CreateNotificationConfig registers a Pub/Sub notification config on a |
+| `DeleteNotificationConfig` | DeleteNotificationConfig removes a bucket's notification config by id |
 | `DeleteObjectGCS` | DeleteObjectGCS deletes an object honoring pre and optional generation |
+| `GetNotificationConfig` | GetNotificationConfig returns a bucket's notification config by id |
 | `GetObjectGCS` | GetObjectGCS returns an object's bytes+info, selecting a specific |
 | `HeadObjectGCS` | HeadObjectGCS returns an object's info, selecting a specific generation |
+| `ListNotificationConfigs` | ListNotificationConfigs returns every notification config on a bucket |
 | `ListObjectGenerations` | ListObjectGenerations returns every generation (current + archived) of the |
 | `PutObjectGCS` | PutObjectGCS writes an object honoring pre (a failed condition returns a |
 | `SetBucketAttrsGCS` | SetBucketAttrsGCS records the bucket's location and default storage class |

--- a/docs/coverage/azure/blobstorage.md
+++ b/docs/coverage/azure/blobstorage.md
@@ -119,9 +119,13 @@ GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type
 | `BucketAttrsGCS` | BucketAttrsGCS returns the bucket's GCS-specific attributes. |
 | `BucketIAMPolicy` |  |
 | `ComposeObjectGCS` | ComposeObjectGCS concatenates the source objects' bytes (in order) into |
+| `CreateNotificationConfig` | CreateNotificationConfig registers a Pub/Sub notification config on a |
+| `DeleteNotificationConfig` | DeleteNotificationConfig removes a bucket's notification config by id |
 | `DeleteObjectGCS` | DeleteObjectGCS deletes an object honoring pre and optional generation |
+| `GetNotificationConfig` | GetNotificationConfig returns a bucket's notification config by id |
 | `GetObjectGCS` | GetObjectGCS returns an object's bytes+info, selecting a specific |
 | `HeadObjectGCS` | HeadObjectGCS returns an object's info, selecting a specific generation |
+| `ListNotificationConfigs` | ListNotificationConfigs returns every notification config on a bucket |
 | `ListObjectGenerations` | ListObjectGenerations returns every generation (current + archived) of the |
 | `PutObjectGCS` | PutObjectGCS writes an object honoring pre (a failed condition returns a |
 | `SetBucketAttrsGCS` | SetBucketAttrsGCS records the bucket's location and default storage class |

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -10809,8 +10809,20 @@
             "doc": "ComposeObjectGCS concatenates the source objects' bytes (in order) into"
           },
           {
+            "name": "CreateNotificationConfig",
+            "doc": "CreateNotificationConfig registers a Pub/Sub notification config on a"
+          },
+          {
+            "name": "DeleteNotificationConfig",
+            "doc": "DeleteNotificationConfig removes a bucket's notification config by id"
+          },
+          {
             "name": "DeleteObjectGCS",
             "doc": "DeleteObjectGCS deletes an object honoring pre and optional generation"
+          },
+          {
+            "name": "GetNotificationConfig",
+            "doc": "GetNotificationConfig returns a bucket's notification config by id"
           },
           {
             "name": "GetObjectGCS",
@@ -10819,6 +10831,10 @@
           {
             "name": "HeadObjectGCS",
             "doc": "HeadObjectGCS returns an object's info, selecting a specific generation"
+          },
+          {
+            "name": "ListNotificationConfigs",
+            "doc": "ListNotificationConfigs returns every notification config on a bucket"
           },
           {
             "name": "ListObjectGenerations",

--- a/docs/coverage/gcp/gcs.md
+++ b/docs/coverage/gcp/gcs.md
@@ -119,9 +119,13 @@ GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type
 | `BucketAttrsGCS` | BucketAttrsGCS returns the bucket's GCS-specific attributes. |
 | `BucketIAMPolicy` |  |
 | `ComposeObjectGCS` | ComposeObjectGCS concatenates the source objects' bytes (in order) into |
+| `CreateNotificationConfig` | CreateNotificationConfig registers a Pub/Sub notification config on a |
+| `DeleteNotificationConfig` | DeleteNotificationConfig removes a bucket's notification config by id |
 | `DeleteObjectGCS` | DeleteObjectGCS deletes an object honoring pre and optional generation |
+| `GetNotificationConfig` | GetNotificationConfig returns a bucket's notification config by id |
 | `GetObjectGCS` | GetObjectGCS returns an object's bytes+info, selecting a specific |
 | `HeadObjectGCS` | HeadObjectGCS returns an object's info, selecting a specific generation |
+| `ListNotificationConfigs` | ListNotificationConfigs returns every notification config on a bucket |
 | `ListObjectGenerations` | ListObjectGenerations returns every generation (current + archived) of the |
 | `PutObjectGCS` | PutObjectGCS writes an object honoring pre (a failed condition returns a |
 | `SetBucketAttrsGCS` | SetBucketAttrsGCS records the bucket's location and default storage class |

--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -99,6 +99,9 @@ type bucketMeta struct {
 	// versions holds archived (non-current) object generations keyed by object
 	// key, oldest-first, populated on overwrite when versioning is enabled.
 	versions map[string][]*gcsObject
+	// notifications holds the bucket's Pub/Sub notification configs keyed by
+	// their minted numeric id, lazily created on first insert.
+	notifications map[string]driver.GCSNotificationConfig
 }
 
 // Mock is an in-memory mock implementation of Google Cloud Storage.
@@ -108,6 +111,9 @@ type Mock struct {
 	monitoring mondriver.Monitoring
 	// gen is the source of unique, monotonically increasing object generations.
 	gen atomic.Int64
+	// notifGen is the source of unique, monotonically increasing notification
+	// config ids (numeric strings, as real GCS mints).
+	notifGen atomic.Int64
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -1673,4 +1679,90 @@ func (m *Mock) BucketIAMPolicy(_ context.Context, bucket string) ([]byte, error)
 	}
 
 	return append([]byte(nil), bkt.iamPolicy...), nil
+}
+
+// CreateNotificationConfig registers a Pub/Sub notification config on the
+// bucket, minting a numeric id (also used as the etag) and returning the stored
+// config.
+func (m *Mock) CreateNotificationConfig(
+	_ context.Context, bucket string, cfg *driver.GCSNotificationConfig,
+) (driver.GCSNotificationConfig, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return driver.GCSNotificationConfig{}, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	stored := *cfg
+	id := fmt.Sprintf("%d", m.notifGen.Add(1))
+	stored.ID = id
+	stored.Etag = id
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	if bkt.notifications == nil {
+		bkt.notifications = make(map[string]driver.GCSNotificationConfig)
+	}
+
+	bkt.notifications[id] = stored
+
+	return stored, nil
+}
+
+// GetNotificationConfig returns a bucket's notification config by id.
+func (m *Mock) GetNotificationConfig(_ context.Context, bucket, id string) (driver.GCSNotificationConfig, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return driver.GCSNotificationConfig{}, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	cfg, ok := bkt.notifications[id]
+	if !ok {
+		return driver.GCSNotificationConfig{}, cerrors.Newf(cerrors.NotFound, "notification %q not found", id)
+	}
+
+	return cfg, nil
+}
+
+// ListNotificationConfigs returns every notification config on a bucket, sorted
+// by id for a stable listing.
+func (m *Mock) ListNotificationConfigs(_ context.Context, bucket string) ([]driver.GCSNotificationConfig, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	out := make([]driver.GCSNotificationConfig, 0, len(bkt.notifications))
+	for _, cfg := range bkt.notifications {
+		out = append(out, cfg)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+
+	return out, nil
+}
+
+// DeleteNotificationConfig removes a bucket's notification config by id.
+func (m *Mock) DeleteNotificationConfig(_ context.Context, bucket, id string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	if _, ok := bkt.notifications[id]; !ok {
+		return cerrors.Newf(cerrors.NotFound, "notification %q not found", id)
+	}
+
+	delete(bkt.notifications, id)
+
+	return nil
 }

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -222,8 +222,10 @@ func New(d Drivers) *server.Server {
 	// PubSub matches /v1/projects/{p}/{topics|subscriptions}/...; register
 	// before Firestore so its more-specific resource-type guard wins over
 	// Firestore's permissive /v1/projects/ prefix.
+	var pubsubHandler *pubsub.Handler
+
 	if d.PubSub != nil {
-		pubsubHandler := pubsub.New(d.PubSub)
+		pubsubHandler = pubsub.New(d.PubSub)
 		// PubSub -> Cloud Functions: a publish invokes every function whose
 		// eventTrigger targets the topic (gen1 resource / gen2 pubsubTopic),
 		// mirroring the AWS S3/DynamoDB -> Lambda event-delivery wiring. Push
@@ -359,7 +361,15 @@ func New(d Drivers) *server.Server {
 	}
 
 	if d.Storage != nil {
-		srv.Register(gcs.New(d.Storage))
+		gcsHandler := gcs.New(d.Storage)
+		// GCS -> Pub/Sub: an object finalize/delete emits an event to each
+		// matching bucket notificationConfig's topic, completing the
+		// GCS -> Pub/Sub -> Cloud Functions chain.
+		if pubsubHandler != nil {
+			gcsHandler.SetPublisher(pubsubHandler)
+		}
+
+		srv.Register(gcsHandler)
 	}
 
 	return srv

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -72,6 +72,8 @@ const (
 
 	// subresIAM is the /b/{bucket}/iam sub-collection segment.
 	subresIAM = "iam"
+	// subresNotificationConfigs is the /b/{bucket}/notificationConfigs segment.
+	subresNotificationConfigs = "notificationConfigs"
 	// defaultLocation / defaultStorageClass are the GCS defaults a bucket reads
 	// back when none was set at create.
 	defaultLocation     = "US"
@@ -85,6 +87,11 @@ type Handler struct {
 	// doesn't implement it), covering preconditions, generation, compose,
 	// object patch, versioned listing, and bucket location/IAM/metageneration.
 	ext storagedriver.GCSExtensions
+
+	// publisher emits object-change events to Pub/Sub for matching bucket
+	// notification configs. Nil (the default) makes object events a no-op, so
+	// object writes/deletes still succeed without Pub/Sub wired.
+	publisher TopicPublisher
 
 	// resumable holds in-progress resumable-upload sessions keyed by upload id.
 	// A session buffers the object's bytes as Content-Range chunks arrive over
@@ -206,16 +213,21 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			h.listObjects(w, r, parts[1])
 		case subresIAM:
 			h.bucketIAM(w, r, parts[1])
+		case subresNotificationConfigs:
+			h.notificationCollection(w, r, parts[1])
 		default:
 			writeError(w, http.StatusNotFound, "notFound", "unknown sub-collection")
 		}
 	default:
-		// /b/{bucket}/o/{obj}[/...] or /b/{bucket}/iam/testPermissions
+		// /b/{bucket}/o/{obj}[/...], /b/{bucket}/iam/testPermissions, or
+		// /b/{bucket}/notificationConfigs/{id}.
 		switch {
 		case parts[2] == "o":
 			h.objectOp(w, r, parts[1], strings.Join(parts[3:], "/"))
 		case parts[2] == subresIAM && parts[3] == "testPermissions":
 			h.testIAMPermissions(w, r, parts[1])
+		case parts[2] == subresNotificationConfigs:
+			h.notificationResourceOp(w, r, parts[1], parts[3])
 		default:
 			writeError(w, http.StatusNotFound, "notFound", "unknown sub-collection")
 		}
@@ -991,30 +1003,35 @@ func (h *Handler) storeObject(
 	w http.ResponseWriter, r *http.Request, bucket, name, contentType string,
 	data []byte, metadata map[string]string, attrs *storagedriver.GCSObjectAttrs,
 ) {
+	var (
+		info *storagedriver.ObjectInfo
+		err  error
+	)
+
 	if h.ext != nil {
-		info, err := h.ext.PutObjectGCS(r.Context(), bucket, name, data, contentType, metadata, attrs, parsePrecondition(r.URL.Query()))
+		info, err = h.ext.PutObjectGCS(r.Context(), bucket, name, data, contentType, metadata, attrs, parsePrecondition(r.URL.Query()))
 		if err != nil {
 			writePreconditionOrErr(w, err)
 			return
 		}
+	} else {
+		if putErr := h.bucket.PutObject(r.Context(), bucket, name, data, contentType, metadata); putErr != nil {
+			writeErr(w, putErr)
+			return
+		}
 
-		writeJSON(w, http.StatusOK, toObjectResource(info, bucket, r))
-
-		return
+		if info, err = h.bucket.HeadObject(r.Context(), bucket, name); err != nil {
+			writeErr(w, err)
+			return
+		}
 	}
 
-	if putErr := h.bucket.PutObject(r.Context(), bucket, name, data, contentType, metadata); putErr != nil {
-		writeErr(w, putErr)
-		return
-	}
+	resource := toObjectResource(info, bucket, r)
+	writeJSON(w, http.StatusOK, resource)
 
-	info, err := h.bucket.HeadObject(r.Context(), bucket, name)
-	if err != nil {
-		writeErr(w, err)
-		return
-	}
-
-	writeJSON(w, http.StatusOK, toObjectResource(info, bucket, r))
+	// A successful create/overwrite is an OBJECT_FINALIZE event; emit it to any
+	// matching bucket notification config (best-effort, never fails the write).
+	h.emitObjectEvent(r, bucket, &resource, eventTypeObjectFinalize)
 }
 
 func (h *Handler) uploadMedia(w http.ResponseWriter, r *http.Request, bucket, name string) {
@@ -1431,24 +1448,40 @@ func (h *Handler) fetchObject(r *http.Request, bucket, key string, gen *int64) (
 }
 
 func (h *Handler) deleteObject(w http.ResponseWriter, r *http.Request, bucket, key string) {
+	q := r.URL.Query()
+	gen := parseGeneration(q)
+
+	// Capture the object resource for the OBJECT_DELETE event before it is
+	// removed (best-effort: skip the event when it can't be read).
+	deletedRes, haveRes := h.objectResourceForEvent(r, bucket, key, gen)
+
 	if h.ext != nil {
-		q := r.URL.Query()
-		if err := h.ext.DeleteObjectGCS(r.Context(), bucket, key, parseGeneration(q), parsePrecondition(q)); err != nil {
+		if err := h.ext.DeleteObjectGCS(r.Context(), bucket, key, gen, parsePrecondition(q)); err != nil {
 			writePreconditionOrErr(w, err)
 			return
 		}
-
-		w.WriteHeader(http.StatusNoContent)
-
-		return
-	}
-
-	if err := h.bucket.DeleteObject(r.Context(), bucket, key); err != nil {
+	} else if err := h.bucket.DeleteObject(r.Context(), bucket, key); err != nil {
 		writeErr(w, err)
 		return
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+
+	if haveRes {
+		h.emitObjectEvent(r, bucket, &deletedRes, eventTypeObjectDelete)
+	}
+}
+
+// objectResourceForEvent reads the object's current metadata as an
+// objectResource for a notification event, returning ok=false when it can't be
+// read (a missing object or a driver without head support).
+func (h *Handler) objectResourceForEvent(r *http.Request, bucket, key string, gen *int64) (objectResource, bool) {
+	info, err := h.headObject(r, bucket, key, gen)
+	if err != nil || info == nil {
+		return objectResource{}, false
+	}
+
+	return toObjectResource(info, bucket, r), true
 }
 
 // directMedia handles direct /{bucket}/{object} URLs for media download.

--- a/server/gcp/gcs/notifications.go
+++ b/server/gcp/gcs/notifications.go
@@ -1,0 +1,270 @@
+package gcs
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+const (
+	// payloadFormatJSONAPIV1 attaches the object resource JSON as the message
+	// data; payloadFormatNone sends attributes only.
+	payloadFormatJSONAPIV1 = "JSON_API_V1"
+
+	// GCS object-change event types published to a notification config's topic.
+	eventTypeObjectFinalize = "OBJECT_FINALIZE"
+	eventTypeObjectDelete   = "OBJECT_DELETE"
+
+	// pubsubTopicPrefix is the leading form the storage SDK uses for a
+	// notification's topic: //pubsub.googleapis.com/projects/{p}/topics/{t}.
+	pubsubTopicPrefix = "//pubsub.googleapis.com/"
+)
+
+// TopicPublisher emits an object-change event to a Pub/Sub topic. The Pub/Sub
+// handler implements it; the GCS handler calls it best-effort so a slow or
+// missing target never fails an object operation. It mirrors the same fan-out
+// (push subscriptions + event-triggered Cloud Functions) the REST publish uses.
+type TopicPublisher interface {
+	PublishToTopic(ctx context.Context, project, topic string, data []byte, attributes map[string]string)
+}
+
+// SetPublisher wires the Pub/Sub backend so object changes on a bucket with a
+// matching notification config are delivered to the configured topic. Nil (the
+// default) leaves object-change notifications a no-op.
+func (h *Handler) SetPublisher(p TopicPublisher) {
+	h.publisher = p
+}
+
+// notificationResource is the storage#notification JSON shape. The snake_case
+// field names mirror the storage v1 API / Go storage SDK exactly.
+type notificationResource struct {
+	Kind             string            `json:"kind"`
+	ID               string            `json:"id,omitempty"`
+	Topic            string            `json:"topic,omitempty"`
+	PayloadFormat    string            `json:"payload_format,omitempty"`
+	EventTypes       []string          `json:"event_types,omitempty"`
+	CustomAttributes map[string]string `json:"custom_attributes,omitempty"`
+	ObjectNamePrefix string            `json:"object_name_prefix,omitempty"`
+	Etag             string            `json:"etag,omitempty"`
+	SelfLink         string            `json:"selfLink,omitempty"`
+}
+
+// notificationsListResponse is the storage#notifications list shape.
+type notificationsListResponse struct {
+	Kind  string                 `json:"kind"`
+	Items []notificationResource `json:"items"`
+}
+
+// notificationCollection serves /b/{bucket}/notificationConfigs — POST inserts
+// a config, GET lists them.
+func (h *Handler) notificationCollection(w http.ResponseWriter, r *http.Request, bucket string) {
+	if h.ext == nil {
+		writeError(w, http.StatusNotImplemented, "notImplemented", "notifications not supported")
+		return
+	}
+
+	if !h.bucketExists(r, bucket) {
+		writeError(w, http.StatusNotFound, "notFound", "bucket "+bucket+" not found")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPost:
+		h.createNotification(w, r, bucket)
+	case http.MethodGet:
+		h.listNotifications(w, r, bucket)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+	}
+}
+
+// notificationResourceOp serves /b/{bucket}/notificationConfigs/{id} — GET
+// fetches a config, DELETE removes it.
+func (h *Handler) notificationResourceOp(w http.ResponseWriter, r *http.Request, bucket, id string) {
+	if h.ext == nil {
+		writeError(w, http.StatusNotImplemented, "notImplemented", "notifications not supported")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getNotification(w, r, bucket, id)
+	case http.MethodDelete:
+		h.deleteNotification(w, r, bucket, id)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+	}
+}
+
+func (h *Handler) createNotification(w http.ResponseWriter, r *http.Request, bucket string) {
+	var body notificationResource
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	if body.Topic == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "topic required")
+		return
+	}
+
+	payloadFormat := body.PayloadFormat
+	if payloadFormat == "" {
+		payloadFormat = payloadFormatJSONAPIV1
+	}
+
+	cfg, err := h.ext.CreateNotificationConfig(r.Context(), bucket, &storagedriver.GCSNotificationConfig{
+		Topic:            body.Topic,
+		PayloadFormat:    payloadFormat,
+		EventTypes:       body.EventTypes,
+		CustomAttributes: body.CustomAttributes,
+		ObjectNamePrefix: body.ObjectNamePrefix,
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, notificationView(r, bucket, &cfg))
+}
+
+func (h *Handler) listNotifications(w http.ResponseWriter, r *http.Request, bucket string) {
+	cfgs, err := h.ext.ListNotificationConfigs(r.Context(), bucket)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := notificationsListResponse{Kind: "storage#notifications"}
+	for i := range cfgs {
+		out.Items = append(out.Items, notificationView(r, bucket, &cfgs[i]))
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) getNotification(w http.ResponseWriter, r *http.Request, bucket, id string) {
+	cfg, err := h.ext.GetNotificationConfig(r.Context(), bucket, id)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, notificationView(r, bucket, &cfg))
+}
+
+func (h *Handler) deleteNotification(w http.ResponseWriter, r *http.Request, bucket, id string) {
+	if err := h.ext.DeleteNotificationConfig(r.Context(), bucket, id); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// notificationView renders a stored config as the storage#notification wire
+// shape, filling in the kind and selfLink.
+func notificationView(r *http.Request, bucket string, cfg *storagedriver.GCSNotificationConfig) notificationResource {
+	return notificationResource{
+		Kind:             "storage#notification",
+		ID:               cfg.ID,
+		Topic:            cfg.Topic,
+		PayloadFormat:    cfg.PayloadFormat,
+		EventTypes:       cfg.EventTypes,
+		CustomAttributes: cfg.CustomAttributes,
+		ObjectNamePrefix: cfg.ObjectNamePrefix,
+		Etag:             cfg.Etag,
+		SelfLink:         selfLink(r, "/storage/v1/b/"+bucket+"/notificationConfigs/"+cfg.ID),
+	}
+}
+
+// emitObjectEvent publishes an object-change event to every bucket notification
+// config whose event-type filter and object-name prefix match. Best-effort: a
+// nil publisher, no configs, or a publish failure never affects the object op.
+func (h *Handler) emitObjectEvent(r *http.Request, bucket string, res *objectResource, eventType string) {
+	if h.publisher == nil || h.ext == nil {
+		return
+	}
+
+	cfgs, err := h.ext.ListNotificationConfigs(r.Context(), bucket)
+	if err != nil || len(cfgs) == 0 {
+		return
+	}
+
+	for i := range cfgs {
+		h.emitToConfig(r.Context(), bucket, res, eventType, &cfgs[i])
+	}
+}
+
+func (h *Handler) emitToConfig(
+	ctx context.Context, bucket string, res *objectResource, eventType string, cfg *storagedriver.GCSNotificationConfig,
+) {
+	if !eventTypeMatches(cfg.EventTypes, eventType) {
+		return
+	}
+
+	if cfg.ObjectNamePrefix != "" && !strings.HasPrefix(res.Name, cfg.ObjectNamePrefix) {
+		return
+	}
+
+	project, topic := parsePubsubTopic(cfg.Topic)
+	if topic == "" {
+		return
+	}
+
+	attrs := map[string]string{
+		"eventType":          eventType,
+		"objectId":           res.Name,
+		"bucketId":           bucket,
+		"objectGeneration":   res.Generation,
+		"payloadFormat":      cfg.PayloadFormat,
+		"notificationConfig": "projects/_/buckets/" + bucket + "/notificationConfigs/" + cfg.ID,
+		"eventTime":          time.Now().UTC().Format(time.RFC3339),
+	}
+
+	for k, v := range cfg.CustomAttributes {
+		attrs[k] = v
+	}
+
+	var data []byte
+	if cfg.PayloadFormat == payloadFormatJSONAPIV1 {
+		data, _ = json.Marshal(res)
+	}
+
+	h.publisher.PublishToTopic(ctx, project, topic, data, attrs)
+}
+
+// eventTypeMatches reports whether want is configured. An empty filter means
+// all event types fire (real GCS default).
+func eventTypeMatches(configured []string, want string) bool {
+	if len(configured) == 0 {
+		return true
+	}
+
+	for _, e := range configured {
+		if e == want {
+			return true
+		}
+	}
+
+	return false
+}
+
+// parsePubsubTopic extracts the project and topic short name from a
+// notification topic in the //pubsub.googleapis.com/projects/{p}/topics/{t}
+// form (also tolerating a bare projects/{p}/topics/{t}). Returns empty strings
+// when the topic is not a recognizable Pub/Sub topic reference.
+func parsePubsubTopic(topic string) (project, name string) {
+	t := strings.TrimPrefix(topic, pubsubTopicPrefix)
+	t = strings.TrimPrefix(t, "/")
+
+	parts := strings.Split(t, "/")
+	if len(parts) != 4 || parts[0] != "projects" || parts[2] != "topics" {
+		return "", ""
+	}
+
+	return parts[1], parts[3]
+}

--- a/server/gcp/gcs/notifications_test.go
+++ b/server/gcp/gcs/notifications_test.go
@@ -1,0 +1,461 @@
+package gcs_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/option"
+	pubsubv1 "google.golang.org/api/pubsub/v1"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpprov "github.com/stackshy/cloudemu/v2/providers/gcp"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+const notifProject = "p1"
+
+// notifEnv wires a GCP server with Storage + PubSub + CloudFunctions so the
+// GCS -> Pub/Sub -> Cloud Functions notification chain is fully connected.
+type notifEnv struct {
+	ts      *httptest.Server
+	cloud   *gcpprov.Provider
+	storage *storage.Client
+	pubsub  *pubsubv1.Service
+}
+
+func newNotifEnv(t *testing.T) *notifEnv {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	ts := httptest.NewServer(gcpserver.New(gcpserver.Drivers{
+		Storage:        cloud.GCS,
+		PubSub:         cloud.PubSub,
+		CloudFunctions: cloud.CloudFunctions,
+		Firestore:      cloud.Firestore,
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	sc, err := storage.NewClient(ctx,
+		option.WithEndpoint(ts.URL+"/storage/v1/"),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("storage.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = sc.Close() })
+
+	psvc, err := pubsubv1.NewService(ctx,
+		option.WithEndpoint(ts.URL+"/"),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("pubsubv1.NewService: %v", err)
+	}
+
+	return &notifEnv{ts: ts, cloud: cloud, storage: sc, pubsub: psvc}
+}
+
+func (e *notifEnv) createBucket(t *testing.T, name string) *storage.BucketHandle {
+	t.Helper()
+
+	b := e.storage.Bucket(name)
+	if err := b.Create(context.Background(), notifProject, nil); err != nil {
+		t.Fatalf("bucket.Create(%s): %v", name, err)
+	}
+
+	return b
+}
+
+func (e *notifEnv) createTopic(t *testing.T, id string) string {
+	t.Helper()
+
+	name := "projects/" + notifProject + "/topics/" + id
+	if _, err := e.pubsub.Projects.Topics.Create(name, &pubsubv1.Topic{}).Do(); err != nil {
+		t.Fatalf("topics.Create(%s): %v", id, err)
+	}
+
+	return name
+}
+
+func (e *notifEnv) createSubscription(t *testing.T, id, topic string) string {
+	t.Helper()
+
+	name := "projects/" + notifProject + "/subscriptions/" + id
+	if _, err := e.pubsub.Projects.Subscriptions.Create(name, &pubsubv1.Subscription{Topic: topic}).Do(); err != nil {
+		t.Fatalf("subscriptions.Create(%s): %v", id, err)
+	}
+
+	return name
+}
+
+// pullMessages polls a subscription until it has at least want messages or the
+// deadline lapses.
+func (e *notifEnv) pullMessages(t *testing.T, sub string, want int) []*pubsubv1.ReceivedMessage {
+	t.Helper()
+
+	var got []*pubsubv1.ReceivedMessage
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := e.pubsub.Projects.Subscriptions.Pull(sub, &pubsubv1.PullRequest{
+			MaxMessages: 10, ReturnImmediately: true,
+		}).Do()
+		if err != nil {
+			t.Fatalf("subscriptions.Pull: %v", err)
+		}
+
+		got = append(got, resp.ReceivedMessages...)
+		if len(got) >= want {
+			return got
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return got
+}
+
+func uploadObject(t *testing.T, b *storage.BucketHandle, key, content string) {
+	t.Helper()
+
+	w := b.Object(key).NewWriter(context.Background())
+	w.ContentType = "text/plain"
+
+	if _, err := io.Copy(w, strings.NewReader(content)); err != nil {
+		t.Fatalf("write %s: %v", key, err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close %s: %v", key, err)
+	}
+}
+
+// TestNotificationConfigCRUD covers (a): AddNotification is listed by
+// Notifications(); delete removes it.
+func TestNotificationConfigCRUD(t *testing.T) {
+	e := newNotifEnv(t)
+	b := e.createBucket(t, "b-crud")
+	e.createTopic(t, "t-crud")
+
+	ctx := context.Background()
+
+	created, err := b.AddNotification(ctx, &storage.Notification{
+		TopicProjectID:   notifProject,
+		TopicID:          "t-crud",
+		PayloadFormat:    storage.JSONPayload,
+		EventTypes:       []string{storage.ObjectFinalizeEvent},
+		ObjectNamePrefix: "logs/",
+		CustomAttributes: map[string]string{"team": "core"},
+	})
+	if err != nil {
+		t.Fatalf("AddNotification: %v", err)
+	}
+
+	if created.ID == "" {
+		t.Fatal("AddNotification returned empty ID")
+	}
+
+	list, err := b.Notifications(ctx)
+	if err != nil {
+		t.Fatalf("Notifications: %v", err)
+	}
+
+	got, ok := list[created.ID]
+	if !ok {
+		t.Fatalf("notification %s not listed (got %v)", created.ID, list)
+	}
+
+	if got.TopicID != "t-crud" || got.PayloadFormat != storage.JSONPayload {
+		t.Errorf("round-trip mismatch: topic=%q format=%q", got.TopicID, got.PayloadFormat)
+	}
+
+	if got.ObjectNamePrefix != "logs/" || got.CustomAttributes["team"] != "core" {
+		t.Errorf("prefix/attrs not round-tripped: %+v", got)
+	}
+
+	if err := b.DeleteNotification(ctx, created.ID); err != nil {
+		t.Fatalf("DeleteNotification: %v", err)
+	}
+
+	list, err = b.Notifications(ctx)
+	if err != nil {
+		t.Fatalf("Notifications after delete: %v", err)
+	}
+
+	if _, ok := list[created.ID]; ok {
+		t.Errorf("notification %s still present after delete", created.ID)
+	}
+}
+
+// TestNotificationFinalizeDelivered covers (b): an OBJECT_FINALIZE event with
+// JSON_API_V1 data lands on a subscription of the configured topic.
+func TestNotificationFinalizeDelivered(t *testing.T) {
+	e := newNotifEnv(t)
+	b := e.createBucket(t, "b-fin")
+	topic := e.createTopic(t, "t-fin")
+	sub := e.createSubscription(t, "s-fin", topic)
+
+	if _, err := b.AddNotification(context.Background(), &storage.Notification{
+		TopicProjectID: notifProject,
+		TopicID:        "t-fin",
+		PayloadFormat:  storage.JSONPayload,
+		EventTypes:     []string{storage.ObjectFinalizeEvent},
+	}); err != nil {
+		t.Fatalf("AddNotification: %v", err)
+	}
+
+	uploadObject(t, b, "file.txt", "hello")
+
+	msgs := e.pullMessages(t, sub, 1)
+	if len(msgs) == 0 {
+		t.Fatal("no OBJECT_FINALIZE message delivered")
+	}
+
+	m := msgs[0].Message
+	if m.Attributes["eventType"] != storage.ObjectFinalizeEvent {
+		t.Errorf("eventType = %q, want OBJECT_FINALIZE", m.Attributes["eventType"])
+	}
+
+	if m.Attributes["objectId"] != "file.txt" || m.Attributes["bucketId"] != "b-fin" {
+		t.Errorf("objectId/bucketId attrs = %v", m.Attributes)
+	}
+
+	if m.Attributes["payloadFormat"] != storage.JSONPayload {
+		t.Errorf("payloadFormat = %q", m.Attributes["payloadFormat"])
+	}
+
+	// JSON_API_V1 carries the object resource as the message data.
+	raw, err := base64.StdEncoding.DecodeString(m.Data)
+	if err != nil {
+		t.Fatalf("decode data: %v", err)
+	}
+
+	var obj struct {
+		Kind, Name, Bucket string
+	}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal object resource: %v (raw %s)", err, raw)
+	}
+
+	if obj.Kind != "storage#object" || obj.Name != "file.txt" || obj.Bucket != "b-fin" {
+		t.Errorf("object resource payload = %+v", obj)
+	}
+}
+
+// TestNotificationDeleteEvent covers (c): OBJECT_DELETE fires only when
+// configured.
+func TestNotificationDeleteEvent(t *testing.T) {
+	e := newNotifEnv(t)
+	b := e.createBucket(t, "b-del")
+	topic := e.createTopic(t, "t-del")
+	sub := e.createSubscription(t, "s-del", topic)
+
+	if _, err := b.AddNotification(context.Background(), &storage.Notification{
+		TopicProjectID: notifProject,
+		TopicID:        "t-del",
+		PayloadFormat:  storage.JSONPayload,
+		EventTypes:     []string{storage.ObjectDeleteEvent},
+	}); err != nil {
+		t.Fatalf("AddNotification: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Upload must NOT fire (only OBJECT_DELETE is configured).
+	uploadObject(t, b, "gone.txt", "bye")
+	if msgs := e.pullMessages(t, sub, 1); len(msgs) != 0 {
+		t.Fatalf("upload fired %d messages, want 0 (filter drops OBJECT_FINALIZE)", len(msgs))
+	}
+
+	if err := b.Object("gone.txt").Delete(ctx); err != nil {
+		t.Fatalf("Delete object: %v", err)
+	}
+
+	msgs := e.pullMessages(t, sub, 1)
+	if len(msgs) == 0 {
+		t.Fatal("no OBJECT_DELETE message delivered")
+	}
+
+	if et := msgs[0].Message.Attributes["eventType"]; et != storage.ObjectDeleteEvent {
+		t.Errorf("eventType = %q, want OBJECT_DELETE", et)
+	}
+}
+
+// TestNotificationPrefixFilter covers (c): object_name_prefix gates delivery.
+func TestNotificationPrefixFilter(t *testing.T) {
+	e := newNotifEnv(t)
+	b := e.createBucket(t, "b-pre")
+	topic := e.createTopic(t, "t-pre")
+	sub := e.createSubscription(t, "s-pre", topic)
+
+	if _, err := b.AddNotification(context.Background(), &storage.Notification{
+		TopicProjectID:   notifProject,
+		TopicID:          "t-pre",
+		PayloadFormat:    storage.NoPayload,
+		ObjectNamePrefix: "logs/",
+	}); err != nil {
+		t.Fatalf("AddNotification: %v", err)
+	}
+
+	uploadObject(t, b, "data/x.txt", "no")
+	if msgs := e.pullMessages(t, sub, 1); len(msgs) != 0 {
+		t.Fatalf("non-matching prefix fired %d messages, want 0", len(msgs))
+	}
+
+	uploadObject(t, b, "logs/y.txt", "yes")
+
+	msgs := e.pullMessages(t, sub, 1)
+	if len(msgs) == 0 {
+		t.Fatal("matching-prefix upload delivered no message")
+	}
+
+	if id := msgs[0].Message.Attributes["objectId"]; id != "logs/y.txt" {
+		t.Errorf("objectId = %q, want logs/y.txt", id)
+	}
+
+	// NONE payload => no data body.
+	if msgs[0].Message.Data != "" {
+		t.Errorf("NONE payload carried data: %q", msgs[0].Message.Data)
+	}
+}
+
+// TestNotificationInvokesFunction covers (d): the end-to-end
+// GCS -> Pub/Sub -> Cloud Function chain — an object upload invokes a function
+// event-triggered on the notification topic.
+func TestNotificationInvokesFunction(t *testing.T) {
+	e := newNotifEnv(t)
+	b := e.createBucket(t, "b-fn")
+	e.createTopic(t, "t-fn")
+
+	var (
+		mu       sync.Mutex
+		payloads [][]byte
+	)
+
+	e.cloud.CloudFunctions.RegisterHandler("on-object", func(_ context.Context, payload []byte) ([]byte, error) {
+		mu.Lock()
+		payloads = append(payloads, append([]byte(nil), payload...))
+		mu.Unlock()
+
+		return nil, nil
+	})
+
+	createEventFunction(t, e.ts, "on-object", "projects/"+notifProject+"/topics/t-fn")
+
+	if _, err := b.AddNotification(context.Background(), &storage.Notification{
+		TopicProjectID: notifProject,
+		TopicID:        "t-fn",
+		PayloadFormat:  storage.JSONPayload,
+		EventTypes:     []string{storage.ObjectFinalizeEvent},
+	}); err != nil {
+		t.Fatalf("AddNotification: %v", err)
+	}
+
+	uploadObject(t, b, "trigger.txt", "go")
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(payloads)
+		mu.Unlock()
+
+		if n >= 1 {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatal("cloud function was not invoked by object upload")
+}
+
+// TestNotificationNilPubSubStillUploads covers (e): a Storage-only server (no
+// Pub/Sub wired) still serves object CRUD without panicking. notificationConfigs
+// is still served (backed by the storage driver), just never delivered.
+func TestNotificationNilPubSubStillUploads(t *testing.T) {
+	cloud := cloudemu.NewGCP()
+	ts := httptest.NewServer(gcpserver.New(gcpserver.Drivers{Storage: cloud.GCS}))
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	sc, err := storage.NewClient(ctx,
+		option.WithEndpoint(ts.URL+"/storage/v1/"),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("storage.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = sc.Close() })
+
+	b := sc.Bucket("b-nil")
+	if err := b.Create(ctx, notifProject, nil); err != nil {
+		t.Fatalf("bucket.Create: %v", err)
+	}
+
+	// A notification config referencing a topic that will never deliver.
+	if _, err := b.AddNotification(ctx, &storage.Notification{
+		TopicProjectID: notifProject,
+		TopicID:        "ghost",
+		PayloadFormat:  storage.JSONPayload,
+	}); err != nil {
+		t.Fatalf("AddNotification: %v", err)
+	}
+
+	// Object CRUD must still succeed with no Pub/Sub publisher wired.
+	uploadObject(t, b, "safe.txt", "ok")
+
+	rd, err := b.Object("safe.txt").NewReader(ctx)
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	defer func() { _ = rd.Close() }()
+
+	body, err := io.ReadAll(rd)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	if string(body) != "ok" {
+		t.Errorf("body = %q, want ok", body)
+	}
+
+	if err := b.Object("safe.txt").Delete(ctx); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+// createEventFunction creates a gen1 Cloud Function with a Pub/Sub eventTrigger
+// on topic, via the Cloud Functions REST API.
+func createEventFunction(t *testing.T, ts *httptest.Server, name, topic string) {
+	t.Helper()
+
+	url := ts.URL + "/v1/projects/" + notifProject + "/locations/us-central1/functions?functionId=" + name
+	body := `{"eventTrigger":{"eventType":"google.pubsub.topic.publish",` +
+		`"resource":"` + topic + `","service":"pubsub.googleapis.com"}}`
+
+	resp, err := ts.Client().Post(url, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("create function: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create function = %d: %s", resp.StatusCode, b)
+	}
+}

--- a/server/gcp/pubsub/push.go
+++ b/server/gcp/pubsub/push.go
@@ -161,6 +161,30 @@ func pushEndpoint(raw json.RawMessage) string {
 	return pc.PushEndpoint
 }
 
+// PublishToTopic records one message on a topic's log and runs the same
+// cross-service fan-out (push subscriptions + event-triggered Cloud Functions)
+// as the REST publish path. It is the in-process entrypoint other producers —
+// notably GCS object-change notifications — use to emit into Pub/Sub. It is
+// best-effort: a topic that was never created still records the message so a
+// later pull sees it, and a nil data payload is delivered as an empty body.
+func (h *Handler) PublishToTopic(ctx context.Context, project, topicShort string, data []byte, attributes map[string]string) {
+	publishTime := time.Now().UTC()
+
+	h.mu.Lock()
+	sm := storedMessage{
+		body:        string(data),
+		attributes:  attributes,
+		publishTime: publishTime,
+	}
+	id := h.appendMessageLocked(topicShort, &sm)
+	ts := h.topicLog(topicShort)
+	msg := publishedMessage{idx: len(ts.messages) - 1, msg: buildPubsubMessage(id, &sm)}
+	pushSubs := h.pushSubscribersLocked(topicShort)
+	h.mu.Unlock()
+
+	h.dispatchPublished(ctx, project, topicShort, []publishedMessage{msg}, pushSubs)
+}
+
 // dispatchPublished performs the cross-service delivery a publish triggers,
 // outside h.mu so slow HTTP / function calls never hold the lock:
 //

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -854,4 +854,40 @@ type GCSExtensions interface {
 	// policy document verbatim (Buckets: setIamPolicy / getIamPolicy).
 	SetBucketIAMPolicy(ctx context.Context, bucket string, policyJSON []byte) error
 	BucketIAMPolicy(ctx context.Context, bucket string) ([]byte, error)
+
+	// CreateNotificationConfig registers a Pub/Sub notification config on a
+	// bucket (Notifications: insert), returning the stored config with its
+	// minted id and etag. GCS emits an event to the config's topic on matching
+	// object changes.
+	CreateNotificationConfig(ctx context.Context, bucket string, cfg *GCSNotificationConfig) (GCSNotificationConfig, error)
+	// GetNotificationConfig returns a bucket's notification config by id
+	// (Notifications: get).
+	GetNotificationConfig(ctx context.Context, bucket, id string) (GCSNotificationConfig, error)
+	// ListNotificationConfigs returns every notification config on a bucket
+	// (Notifications: list).
+	ListNotificationConfigs(ctx context.Context, bucket string) ([]GCSNotificationConfig, error)
+	// DeleteNotificationConfig removes a bucket's notification config by id
+	// (Notifications: delete).
+	DeleteNotificationConfig(ctx context.Context, bucket, id string) error
+}
+
+// GCSNotificationConfig is one bucket Pub/Sub notification configuration: which
+// Pub/Sub topic receives events, which object-change event types fire, and the
+// payload format + custom attributes attached to each message.
+type GCSNotificationConfig struct {
+	// ID is the server-minted numeric notification id (also the etag).
+	ID string
+	// Topic is the destination in the //pubsub.googleapis.com/projects/{p}/
+	// topics/{t} form the storage SDK sends and reads back.
+	Topic string
+	// PayloadFormat is JSON_API_V1 (object resource JSON as data) or NONE.
+	PayloadFormat string
+	// EventTypes filters which changes fire; empty means all event types.
+	EventTypes []string
+	// CustomAttributes are added verbatim to every published message.
+	CustomAttributes map[string]string
+	// ObjectNamePrefix fires only for objects whose name has this prefix.
+	ObjectNamePrefix string
+	// Etag mirrors the id, as real GCS returns.
+	Etag string
 }


### PR DESCRIPTION
## Summary

Implements GCP BUG3: GCS had no `notificationConfigs` endpoint (POST returned a hard 404 "unknown sub-collection") and object writes/deletes emitted no events. As a result `google_storage_notification` / `gsutil notification` / `BucketHandle.AddNotification` failed, and the GCS -> Pub/Sub -> Cloud Functions chain never fired.

This PR adds the GCS producer feeding Pub/Sub (the Pub/Sub publish + Pub/Sub -> Cloud Functions path was merged in #803).

## What changed

- **notificationConfigs sub-collection** on the GCS wire handler: POST (insert), GET (get by id), LIST, DELETE — returning the `storage#notification` shape (`id`, `topic`, `payload_format`, `event_types`, `custom_attributes`, `object_name_prefix`, `etag`, `selfLink`).
- **Notification-config store** on the storage driver / GCS provider (mirrors the existing bucket IAM-policy store), with 4 new `GCSExtensions` methods.
- **Object-event emission**: on object finalize (media/multipart/resumable upload) and delete, GCS publishes to each matching bucket notificationConfig's Pub/Sub topic with GCS event attributes (`eventType`, `objectId`, `bucketId`, `objectGeneration`, `payloadFormat`, `notificationConfig`, `eventTime`) plus the object resource JSON as data for `JSON_API_V1`. Honors the `event_types` filter and `object_name_prefix`.
- **Wiring**: the GCS handler reuses the same Pub/Sub publish entrypoint #803's fan-out uses. A new `PublishToTopic` method on the Pub/Sub handler records the message and runs the identical push-subscription + event-triggered-function fan-out; `server/gcp/gcp.go` wires the Pub/Sub handler into the GCS handler via `SetPublisher`. Best-effort: no topic / nil Pub/Sub leaves object ops succeeding with no panic.

This completes GCS -> Pub/Sub -> Cloud Functions (the function invocation is already wired by #803).

## Tests

Real `cloud.google.com/go/storage` + `google.golang.org/api/pubsub/v1` clients over `httptest`:
- notificationConfig CRUD (AddNotification -> Notifications() lists it -> DeleteNotification)
- object upload delivers `OBJECT_FINALIZE` (attributes + `JSON_API_V1` object-resource data) to a subscription on the topic
- object delete delivers `OBJECT_DELETE` only when configured; `event_types` filter drops non-configured types; `object_name_prefix` filters
- end-to-end GCS -> Pub/Sub -> Cloud Function: an event-triggered function is invoked on object upload
- Storage-only server (no Pub/Sub wired): object CRUD still succeeds

Coverage docs regenerated (`go generate ./...`); compat suite green (`go run ./internal/compatgen`, exit 0, no diff).
