### PR TITLE
fix(gcp-monitoring): deliver alert incidents to notification channels (webhook + pubsub)

### DIFF
--- a/providers/gcp/monitoring/incidentdelivery.go
+++ b/providers/gcp/monitoring/incidentdelivery.go
@@ -1,0 +1,241 @@
+package monitoring
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/monitoring/alarmeval"
+	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// webhookDeliveryTimeout bounds how long a single incident webhook POST waits
+// for the receiver so an unreachable channel cannot stall the breaching
+// PutMetricData indefinitely. It mirrors azure/monitor's webhookDeliveryTimeout.
+const webhookDeliveryTimeout = 10 * time.Second
+
+// WebhookDeliverer delivers an incident notification to a webhook channel's URL.
+// New() defaults it to a real-HTTP implementation (httpWebhookDeliverer), so a
+// breach that targets a webhook notification channel performs the real POST in
+// production — mirroring azure/monitor's WebhookDeliverer. SetWebhookDeliverer
+// is a test seam that swaps in a fake so a test can assert delivery without a
+// live receiver.
+type WebhookDeliverer interface {
+	Deliver(ctx context.Context, url, payload string) error
+}
+
+// PubSubPublisher publishes an incident to a Pub/Sub notification channel's
+// topic. Pub/Sub topic fanout (topic -> subscriptions) lives in the wire
+// handler, not the SQS-shaped message-queue driver, so this is wired at the
+// server layer (server/gcp/gcp.go) with an adapter over the Pub/Sub handler,
+// mirroring where #803 wired the Pub/Sub function-invoker. Nil (the library
+// path, which has no topic fanout) leaves Pub/Sub delivery record-only.
+type PubSubPublisher interface {
+	PublishIncident(ctx context.Context, topic string, data []byte)
+}
+
+// httpWebhookDeliverer is the production WebhookDeliverer: a best-effort real
+// HTTP POST of the incident payload to a webhook channel's URL. It mirrors
+// azure/monitor's httpWebhookDeliverer — a bounded http.Client, and errors are
+// surfaced to the caller (deliverWebhook), which swallows them so a breach /
+// PutMetricData never fails because a receiver is unreachable.
+type httpWebhookDeliverer struct {
+	client *http.Client
+}
+
+// newHTTPWebhookDeliverer builds the default deliverer with a bounded client,
+// matching azure/monitor's http.Client{Timeout: webhookDeliveryTimeout}.
+func newHTTPWebhookDeliverer() *httpWebhookDeliverer {
+	return &httpWebhookDeliverer{client: &http.Client{Timeout: webhookDeliveryTimeout}}
+}
+
+// Deliver POSTs the payload to url as the incident body, with the JSON
+// content-type real Cloud Monitoring webhook channels carry.
+func (d *httpWebhookDeliverer) Deliver(ctx context.Context, url, payload string) error {
+	reqCtx, cancel := context.WithTimeout(ctx, webhookDeliveryTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, url, strings.NewReader(payload))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	return nil
+}
+
+// SetWebhookDeliverer overrides the webhook deliverer. It is a test seam: tests
+// inject a fake to observe delivery. New() already installs a real-HTTP default,
+// so production never calls this. Nil leaves webhook delivery record-only.
+func (m *Mock) SetWebhookDeliverer(d WebhookDeliverer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.webhookDeliverer = d
+}
+
+// SetPubSubPublisher wires the Pub/Sub publisher so a breach that targets a
+// pubsub notification channel publishes the incident to the channel's topic.
+// It is wired at the server layer because topic fanout is wire-only; the
+// library path leaves it nil (record-only).
+func (m *Mock) SetPubSubPublisher(p PubSubPublisher) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.pubsubPublisher = p
+}
+
+// incidentEnvelope is the Cloud Monitoring notification body delivered to a
+// channel: a reasonable subset of the real incident schema, identical for the
+// webhook POST body and the Pub/Sub message data.
+type incidentEnvelope struct {
+	Incident incidentBody `json:"incident"`
+}
+
+type incidentBody struct {
+	IncidentID    string `json:"incident_id"`
+	ResourceID    string `json:"resource_id"`
+	PolicyName    string `json:"policy_name"`
+	ConditionName string `json:"condition_name"`
+	State         string `json:"state"` // open | closed
+	StartedAt     int64  `json:"started_at"`
+	Summary       string `json:"summary"`
+	URL           string `json:"url"`
+}
+
+// fireNotificationChannels delivers an alert policy's incident to each of its
+// referenced notification channels on an incident open (ALARM) or close (OK)
+// transition — real Cloud Monitoring notifies on both by default. Webhook
+// channels are POSTed; pubsub channels are published to their topic; email /
+// SMS / other channels are record-only (the emulator cannot send them). All
+// delivery is best-effort so a breach never fails on an unreachable channel.
+func (m *Mock) fireNotificationChannels(alarm *alarmData, newState string, now time.Time) {
+	if newState != alarmeval.StateAlarm && newState != alarmeval.StateOK {
+		return
+	}
+
+	body, err := json.Marshal(buildIncident(alarm, newState, now))
+	if err != nil {
+		return
+	}
+
+	m.mu.RLock()
+	webhook := m.webhookDeliverer
+	publisher := m.pubsubPublisher
+	m.mu.RUnlock()
+
+	for _, ref := range alarm.AlarmActions {
+		if ch := m.lookupChannel(ref); ch != nil {
+			deliverIncident(ch, webhook, publisher, body)
+		}
+	}
+}
+
+// deliverIncident delivers one incident to a single channel by type: webhook
+// channels are POSTed and pubsub channels are published; email / SMS / other
+// channels are record-only (the transition history is their record, and the
+// emulator cannot deliver them externally). Delivery is best-effort.
+func deliverIncident(
+	ch *driver.NotificationChannelInfo, webhook WebhookDeliverer, publisher PubSubPublisher, body []byte,
+) {
+	if ch.Endpoint == "" {
+		return
+	}
+
+	switch {
+	case isWebhookChannel(ch.Type):
+		if webhook != nil {
+			_ = webhook.Deliver(context.Background(), ch.Endpoint, string(body))
+		}
+	case ch.Type == channelTypePubSub:
+		if publisher != nil {
+			publisher.PublishIncident(context.Background(), ch.Endpoint, body)
+		}
+	}
+}
+
+const channelTypePubSub = "pubsub"
+
+// isWebhookChannel reports whether a channel type is one of Cloud Monitoring's
+// webhook variants (webhook_tokenauth / webhook_basicauth), or a bare "webhook".
+func isWebhookChannel(channelType string) bool {
+	return strings.Contains(channelType, "webhook")
+}
+
+// lookupChannel resolves an AlarmActions reference — a channel resource name
+// (projects/P/notificationChannels/ID) or a bare channel ID — to its stored
+// channel, or nil when it names no known channel.
+func (m *Mock) lookupChannel(ref string) *driver.NotificationChannelInfo {
+	ch, ok := m.channels.Get(lastSegment(ref))
+	if !ok {
+		return nil
+	}
+
+	return ch
+}
+
+// lastSegment returns the final path segment of a resource reference.
+func lastSegment(ref string) string {
+	if i := strings.LastIndex(ref, "/"); i >= 0 {
+		return ref[i+1:]
+	}
+
+	return ref
+}
+
+// buildIncident renders the incident envelope for a transition.
+func buildIncident(alarm *alarmData, newState string, now time.Time) incidentEnvelope {
+	id := idgen.GenerateID("incident-")
+	state := "open"
+
+	if newState == alarmeval.StateOK {
+		state = "closed"
+	}
+
+	return incidentEnvelope{Incident: incidentBody{
+		IncidentID:    id,
+		ResourceID:    incidentResourceID(alarm.Dimensions),
+		PolicyName:    alarm.Name,
+		ConditionName: alarm.MetricName,
+		State:         state,
+		StartedAt:     now.Unix(),
+		Summary:       alarm.Name + " is " + state + ": " + alarm.StateReason,
+		URL:           "https://console.cloud.google.com/monitoring/alerting/incidents/" + id,
+	}}
+}
+
+// incidentResourceID renders a deterministic resource id from an alert policy's
+// dimensions (the monitored resource the condition filters on).
+func incidentResourceID(dims map[string]string) string {
+	if len(dims) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(dims))
+	for k := range dims {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+dims[k])
+	}
+
+	return strings.Join(parts, ",")
+}

--- a/providers/gcp/monitoring/incidentdelivery_test.go
+++ b/providers/gcp/monitoring/incidentdelivery_test.go
@@ -1,0 +1,209 @@
+package monitoring
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// breachAlarm creates an alert policy that fires when a "gcp"/"metric" datum
+// exceeds 0 (the server-created driver alarm's shape) targeting the given
+// channel refs, then pushes a breaching datum.
+func breachAlarm(t *testing.T, m *Mock, name string, actions []string, value float64) {
+	t.Helper()
+
+	ctx := context.Background()
+	require.NoError(t, m.CreateAlarm(ctx, driver.AlarmConfig{
+		Name: name, Namespace: "gcp", MetricName: "metric",
+		ComparisonOperator: "GreaterThanThreshold", Threshold: 0,
+		Period: 60, EvaluationPeriods: 1, Stat: "Average",
+		AlarmActions: actions,
+	}))
+
+	require.NoError(t, m.PutMetricData(ctx, []driver.MetricDatum{{
+		Namespace: "gcp", MetricName: "metric", Value: value, Timestamp: m.opts.Clock.Now(),
+	}}))
+}
+
+func createChannel(t *testing.T, m *Mock, chType, endpoint string) string {
+	t.Helper()
+
+	info, err := m.CreateNotificationChannel(context.Background(), driver.NotificationChannelConfig{
+		Name: "ch", Type: chType, Endpoint: endpoint,
+	})
+	require.NoError(t, err)
+
+	return info.ID
+}
+
+// TestBreachDeliversWebhookIncident covers (a): a breach POSTs the incident to a
+// webhook channel's URL, and the payload carries the policy's incident.
+func TestBreachDeliversWebhookIncident(t *testing.T) {
+	m, _ := newTestMock()
+
+	var (
+		mu      sync.Mutex
+		bodies  [][]byte
+		gotType string
+	)
+
+	recv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		mu.Lock()
+		bodies = append(bodies, body)
+		gotType = r.Header.Get("Content-Type")
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(recv.Close)
+
+	id := createChannel(t, m, "webhook_tokenauth", recv.URL)
+	breachAlarm(t, m, "cpu-hot", []string{id}, 1)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, bodies, 1, "webhook must receive exactly one incident POST")
+	assert.Contains(t, gotType, "application/json")
+
+	var env incidentEnvelope
+	require.NoError(t, json.Unmarshal(bodies[0], &env))
+	assert.Equal(t, "cpu-hot", env.Incident.PolicyName)
+	assert.Equal(t, "metric", env.Incident.ConditionName)
+	assert.Equal(t, "open", env.Incident.State)
+	assert.NotEmpty(t, env.Incident.IncidentID)
+}
+
+// TestBreachSucceedsWhenWebhookUnreachable covers (a): an unreachable receiver
+// does not fail the breach — delivery is best-effort.
+func TestBreachSucceedsWhenWebhookUnreachable(t *testing.T) {
+	m, _ := newTestMock()
+
+	// A closed listener's URL is unreachable; the breach must still transition.
+	recv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := recv.URL
+	recv.Close()
+
+	id := createChannel(t, m, "webhook_tokenauth", url)
+	breachAlarm(t, m, "cpu-hot", []string{id}, 1)
+
+	alarms, err := m.DescribeAlarms(context.Background(), []string{"cpu-hot"})
+	require.NoError(t, err)
+	require.Len(t, alarms, 1)
+	assert.Equal(t, "ALARM", alarms[0].State, "breach must succeed even when the webhook is unreachable")
+}
+
+type fakePublisher struct {
+	mu     sync.Mutex
+	topics []string
+	datas  [][]byte
+}
+
+func (f *fakePublisher) PublishIncident(_ context.Context, topic string, data []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.topics = append(f.topics, topic)
+	f.datas = append(f.datas, append([]byte(nil), data...))
+}
+
+// TestBreachPublishesPubSubIncident covers (b): a breach publishes the incident
+// to a pubsub channel's topic via the wired publisher.
+func TestBreachPublishesPubSubIncident(t *testing.T) {
+	m, _ := newTestMock()
+
+	pub := &fakePublisher{}
+	m.SetPubSubPublisher(pub)
+
+	topic := "projects/test-project/topics/alerts"
+	id := createChannel(t, m, channelTypePubSub, topic)
+	breachAlarm(t, m, "cpu-hot", []string{id}, 1)
+
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	require.Len(t, pub.topics, 1, "pubsub channel must receive exactly one incident publish")
+	assert.Equal(t, topic, pub.topics[0])
+
+	var env incidentEnvelope
+	require.NoError(t, json.Unmarshal(pub.datas[0], &env))
+	assert.Equal(t, "cpu-hot", env.Incident.PolicyName)
+	assert.Equal(t, "open", env.Incident.State)
+}
+
+// TestBreachEmailChannelRecordOnly covers (c): an email (or other) channel is
+// fired and recorded (state + history) but performs no external delivery and
+// does not crash.
+func TestBreachEmailChannelRecordOnly(t *testing.T) {
+	m, _ := newTestMock()
+
+	pub := &fakePublisher{}
+	m.SetPubSubPublisher(pub)
+
+	id := createChannel(t, m, "email", "ops@example.com")
+	breachAlarm(t, m, "cpu-hot", []string{id}, 1)
+
+	ctx := context.Background()
+	alarms, err := m.DescribeAlarms(ctx, []string{"cpu-hot"})
+	require.NoError(t, err)
+	assert.Equal(t, "ALARM", alarms[0].State)
+
+	hist, err := m.GetAlarmHistory(ctx, "cpu-hot", 0)
+	require.NoError(t, err)
+	assert.NotEmpty(t, hist, "firing must still be recorded for an email channel")
+
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	assert.Empty(t, pub.topics, "email channel must not publish to pubsub")
+}
+
+// TestRecoveryDeliversClosedIncident covers open+close delivery: a breach then a
+// recovery each deliver, the second carrying a closed incident — and the state /
+// history transitions are unchanged (no regression).
+func TestRecoveryDeliversClosedIncident(t *testing.T) {
+	m, clk := newTestMock()
+
+	pub := &fakePublisher{}
+	m.SetPubSubPublisher(pub)
+
+	ctx := context.Background()
+	topic := "projects/test-project/topics/alerts"
+	id := createChannel(t, m, channelTypePubSub, topic)
+
+	require.NoError(t, m.CreateAlarm(ctx, driver.AlarmConfig{
+		Name: "cpu-hot", Namespace: "gcp", MetricName: "metric",
+		ComparisonOperator: "GreaterThanThreshold", Threshold: 0,
+		Period: 60, EvaluationPeriods: 1, Stat: "Average",
+		AlarmActions: []string{id},
+	}))
+
+	require.NoError(t, m.PutMetricData(ctx, []driver.MetricDatum{{
+		Namespace: "gcp", MetricName: "metric", Value: 1, Timestamp: clk.Now(),
+	}}))
+
+	clk.Advance(60e9) // 60s
+	require.NoError(t, m.PutMetricData(ctx, []driver.MetricDatum{{
+		Namespace: "gcp", MetricName: "metric", Value: 0, Timestamp: clk.Now(),
+	}}))
+
+	pub.mu.Lock()
+	states := make([]string, 0, len(pub.datas))
+	for _, d := range pub.datas {
+		var env incidentEnvelope
+		require.NoError(t, json.Unmarshal(d, &env))
+		states = append(states, env.Incident.State)
+	}
+	pub.mu.Unlock()
+
+	require.Equal(t, []string{"open", "closed"}, states, "must deliver on both incident open and close")
+
+	hist, err := m.GetAlarmHistory(ctx, "cpu-hot", 0)
+	require.NoError(t, err)
+	assert.Len(t, hist, 2, "history records both transitions, unchanged by delivery")
+}

--- a/providers/gcp/monitoring/monitoring.go
+++ b/providers/gcp/monitoring/monitoring.go
@@ -54,21 +54,27 @@ type alarmData struct {
 
 // Mock is an in-memory mock implementation of the GCP Cloud Monitoring service.
 type Mock struct {
-	mu       sync.RWMutex
-	metrics  map[metricKey][]driver.MetricDatum
-	alarms   *memstore.Store[*alarmData]
-	channels *memstore.Store[*driver.NotificationChannelInfo]
-	history  []driver.AlarmHistoryEntry
-	opts     *config.Options
+	mu               sync.RWMutex
+	metrics          map[metricKey][]driver.MetricDatum
+	alarms           *memstore.Store[*alarmData]
+	channels         *memstore.Store[*driver.NotificationChannelInfo]
+	history          []driver.AlarmHistoryEntry
+	opts             *config.Options
+	webhookDeliverer WebhookDeliverer
+	pubsubPublisher  PubSubPublisher
 }
 
 // New creates a new Cloud Monitoring mock with the given configuration options.
+// It defaults webhookDeliverer to a real-HTTP deliverer so a breach targeting a
+// webhook notification channel POSTs the incident in production without any
+// wiring, mirroring azure/monitor.New.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		metrics:  make(map[metricKey][]driver.MetricDatum),
-		alarms:   memstore.New[*alarmData](),
-		channels: memstore.New[*driver.NotificationChannelInfo](),
-		opts:     opts,
+		metrics:          make(map[metricKey][]driver.MetricDatum),
+		alarms:           memstore.New[*alarmData](),
+		channels:         memstore.New[*driver.NotificationChannelInfo](),
+		opts:             opts,
+		webhookDeliverer: newHTTPWebhookDeliverer(),
 	}
 }
 
@@ -148,9 +154,10 @@ func (m *Mock) evaluateSingleAlarm(alarm *alarmData, namespace, metricName strin
 // transitionAlarm sets an alert policy's state and, only on a state change,
 // records a history entry — mirroring CloudWatch, where the history entry happens
 // on a state change whether it came from metric evaluation or a manual
-// SetAlarmState. Cloud Monitoring notification channels aren't delivered by the
-// emulator (no publisher is wired), so the state's actions are a no-op beyond the
-// recorded transition.
+// SetAlarmState. On an incident open (ALARM) or close (OK) transition it also
+// delivers the incident to the policy's referenced notification channels
+// (webhook POST / Pub/Sub publish; email / SMS / other are record-only),
+// matching real Cloud Monitoring which notifies on both open and close.
 func (m *Mock) transitionAlarm(alarm *alarmData, newState, reason string, now time.Time) {
 	oldState := alarm.State
 
@@ -161,6 +168,10 @@ func (m *Mock) transitionAlarm(alarm *alarmData, newState, reason string, now ti
 
 	alarm.State = newState
 	alarm.StateReason = reason
+
+	if oldState != newState {
+		m.fireNotificationChannels(alarm, newState, now)
+	}
 }
 
 // appendHistory records one alert policy state transition in the history log.

--- a/providers/wiring_parity_test.go
+++ b/providers/wiring_parity_test.go
@@ -117,6 +117,31 @@ var azureExemptions = []exemption{
 	},
 }
 
+// gcpExemptions lists GCP's deliberate non-wirings on the monitoring mock: both
+// notification-delivery injectors are defaulted (webhook) or wired at the server
+// layer (pubsub), not by the provider factory.
+var gcpExemptions = []exemption{
+	{
+		field:  "CloudMonitoring",
+		method: "SetWebhookDeliverer",
+		reason: "monitoring.New defaults webhookDeliverer to a real-HTTP deliverer " +
+			"(mirroring azure/monitor.New), so an alert-policy breach that targets " +
+			"a webhook notification channel POSTs the incident in production without " +
+			"any gcp.go wiring. SetWebhookDeliverer is only a test override that " +
+			"swaps in a fake to assert delivery, so New deliberately does not call it.",
+	},
+	{
+		field:  "CloudMonitoring",
+		method: "SetPubSubPublisher",
+		reason: "Pub/Sub topic fanout (topic -> subscriptions) lives in the wire " +
+			"handler, not the SQS-shaped message-queue driver, so a breach that " +
+			"targets a pubsub notification channel can only publish through the " +
+			"server layer. The publisher is wired in server/gcp/gcp.go as an adapter " +
+			"over the Pub/Sub handler (the same layer #803 wired the function-" +
+			"invoker at), so the provider factory deliberately does not call it.",
+	},
+}
+
 // exposedInjectors returns, sorted, the names of v's methods shaped like a
 // cross-service-wiring injector: Set<X> taking exactly one interface-typed
 // parameter. v must be the reflect.Value of an exported *Provider field.
@@ -325,5 +350,5 @@ func TestWiringParity_Azure(t *testing.T) {
 }
 
 func TestWiringParity_GCP(t *testing.T) {
-	checkWiringParity(t, gcp.New(), filepath.Join("gcp", "gcp.go"), nil)
+	checkWiringParity(t, gcp.New(), filepath.Join("gcp", "gcp.go"), gcpExemptions)
 }

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -8,6 +8,7 @@ package gcp
 
 import (
 	gkeprov "github.com/stackshy/cloudemu/v2/providers/gcp/gke"
+	gcpmon "github.com/stackshy/cloudemu/v2/providers/gcp/monitoring"
 	"github.com/stackshy/cloudemu/v2/server"
 	alloydbsrv "github.com/stackshy/cloudemu/v2/server/gcp/alloydb"
 	"github.com/stackshy/cloudemu/v2/server/gcp/artifactregistry"
@@ -230,6 +231,16 @@ func New(d Drivers) *server.Server {
 		// subscription HTTP delivery is self-contained in the PubSub handler.
 		if cfHandler != nil {
 			pubsubHandler.SetFunctionInvoker(cfHandler)
+		}
+
+		// Monitoring -> PubSub: an alert-policy breach publishes the incident to
+		// each pubsub notification channel's topic. Topic fanout is wire-only, so
+		// the publisher is wired here (not providers/gcp/gcp.go) as an adapter over
+		// the PubSub handler — the same layer #803 wired the function-invoker at.
+		if setter, ok := d.Monitoring.(interface {
+			SetPubSubPublisher(gcpmon.PubSubPublisher)
+		}); ok {
+			setter.SetPubSubPublisher(monitoringPubSubAdapter{h: pubsubHandler})
 		}
 
 		srv.Register(pubsubHandler)

--- a/server/gcp/monitoring/alertpolicies.go
+++ b/server/gcp/monitoring/alertpolicies.go
@@ -52,7 +52,9 @@ func (h *Handler) createPolicy(w http.ResponseWriter, r *http.Request, project s
 	id := strconv.FormatUint(h.seq.Add(1), 10)
 
 	// The driver alarm is only an existence marker; the full policy shape lives
-	// in the handler registry so conditions/combiner/labels round-trip.
+	// in the handler registry so conditions/combiner/labels round-trip. Its
+	// AlarmActions carry the policy's notificationChannels so a breach delivers
+	// the incident to each channel (webhook POST / Pub/Sub publish).
 	cfg := mondriver.AlarmConfig{
 		Name:               id,
 		Namespace:          "gcp",
@@ -62,6 +64,7 @@ func (h *Handler) createPolicy(w http.ResponseWriter, r *http.Request, project s
 		Period:             60,
 		EvaluationPeriods:  1,
 		Stat:               "Average",
+		AlarmActions:       body.NotificationChannels,
 	}
 
 	if err := h.mon.CreateAlarm(r.Context(), cfg); err != nil {

--- a/server/gcp/monitoringpubsub.go
+++ b/server/gcp/monitoringpubsub.go
@@ -1,0 +1,36 @@
+package gcp
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/gcp/pubsub"
+)
+
+// monitoringPubSubAdapter adapts the wire Pub/Sub handler to the monitoring
+// mock's PubSubPublisher: an alert-policy breach that targets a pubsub
+// notification channel publishes the incident to the channel's topic, fanning
+// out to the topic's subscriptions exactly as an API publish would.
+type monitoringPubSubAdapter struct {
+	h *pubsub.Handler
+}
+
+// PublishIncident publishes data to the channel's topic. topic is the channel's
+// stored topic reference (a projects/{p}/topics/{t} resource name, or a bare
+// topic id); a bare id publishes under an empty project, which still reaches the
+// topic's pull subscriptions (keyed by the short name).
+func (a monitoringPubSubAdapter) PublishIncident(ctx context.Context, topic string, data []byte) {
+	project, short := parseTopicRef(topic)
+	a.h.PublishMessage(ctx, project, short, data, nil)
+}
+
+// parseTopicRef splits a projects/{p}/topics/{t} reference into its project and
+// short topic name, tolerating a bare topic id (project empty).
+func parseTopicRef(ref string) (project, topic string) {
+	parts := strings.Split(ref, "/")
+	if len(parts) == 4 && parts[0] == "projects" && parts[2] == "topics" {
+		return parts[1], parts[3]
+	}
+
+	return "", ref
+}

--- a/server/gcp/pubsub/handler.go
+++ b/server/gcp/pubsub/handler.go
@@ -18,6 +18,7 @@
 package pubsub
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -355,6 +356,30 @@ func (h *Handler) publish(w http.ResponseWriter, r *http.Request, project, name 
 	h.dispatchPublished(r.Context(), project, name, delivery, pushSubs)
 
 	writeJSON(w, http.StatusOK, out)
+}
+
+// PublishMessage publishes one message to a topic programmatically, mirroring
+// the publish() HTTP path: the message is appended to the topic log (so pull
+// subscriptions receive it) and fanned out to push endpoints and event-
+// triggered functions. It backs cross-service publishers (e.g. a Cloud
+// Monitoring pubsub notification channel) that publish without an HTTP request.
+// Best-effort: it returns the assigned message id and never fails the caller.
+func (h *Handler) PublishMessage(
+	ctx context.Context, project, topic string, data []byte, attributes map[string]string,
+) string {
+	publishTime := time.Now().UTC()
+	sm := storedMessage{body: string(data), attributes: attributes, publishTime: publishTime}
+
+	h.mu.Lock()
+	ts := h.topicLog(topic)
+	id := h.appendMessageLocked(topic, &sm)
+	delivery := []publishedMessage{{idx: len(ts.messages) - 1, msg: buildPubsubMessage(id, &sm)}}
+	pushSubs := h.pushSubscribersLocked(topic)
+	h.mu.Unlock()
+
+	h.dispatchPublished(ctx, project, topic, delivery, pushSubs)
+
+	return id
 }
 
 // ---------- helpers ----------

--- a/server/gcp/pubsub/monitoring_delivery_test.go
+++ b/server/gcp/pubsub/monitoring_delivery_test.go
@@ -1,0 +1,95 @@
+package pubsub_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// TestMonitoringBreachPublishesToPubSubChannel is the end-to-end proof that an
+// alert-policy breach delivers its incident to a pubsub notification channel's
+// topic through the server-wired adapter: a pull subscription on that topic
+// receives the incident message.
+func TestMonitoringBreachPublishesToPubSubChannel(t *testing.T) {
+	cloud := cloudemu.NewGCP()
+	srv := httptest.NewServer(gcpserver.New(gcpserver.Drivers{
+		PubSub:     cloud.PubSub,
+		Monitoring: cloud.CloudMonitoring,
+	}))
+	t.Cleanup(srv.Close)
+
+	// Topic + pull subscription (created before publish so it is not backlog).
+	resp := doRequest(t, srv, http.MethodPut, topicURL("alerts"), `{}`)
+	resp.Body.Close()
+	subBody := `{"topic":"projects/` + project + `/topics/alerts"}`
+	doRequest(t, srv, http.MethodPut, subURL("alerts-sub"), subBody).Body.Close()
+
+	// Pub/Sub notification channel + alert policy referencing it.
+	chResp := doRequest(t, srv, http.MethodPost,
+		"/v3/projects/"+project+"/notificationChannels",
+		`{"type":"pubsub","displayName":"c","labels":{"topic":"projects/`+project+`/topics/alerts"}}`)
+
+	var ch struct {
+		Name string `json:"name"`
+	}
+	decodeResp(t, chResp, &ch)
+
+	if ch.Name == "" {
+		t.Fatal("notification channel create returned no name")
+	}
+
+	doRequest(t, srv, http.MethodPost,
+		"/v3/projects/"+project+"/alertPolicies",
+		`{"displayName":"p","notificationChannels":["`+ch.Name+`"]}`).Body.Close()
+
+	// Breach the (server-created) driver alarm: a "gcp"/"metric" datum above 0.
+	if err := cloud.CloudMonitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{{
+		Namespace: "gcp", MetricName: "metric", Value: 1, Timestamp: time.Now(),
+	}}); err != nil {
+		t.Fatalf("PutMetricData: %v", err)
+	}
+
+	// The incident must be pullable off the topic's subscription.
+	pull := doRequest(t, srv, http.MethodPost, subURL("alerts-sub")+":pull", `{"maxMessages":10}`)
+
+	var out struct {
+		ReceivedMessages []struct {
+			Message struct {
+				Data string `json:"data"`
+			} `json:"message"`
+		} `json:"receivedMessages"`
+	}
+	decodeResp(t, pull, &out)
+
+	if len(out.ReceivedMessages) != 1 {
+		t.Fatalf("want 1 pulled incident, got %d", len(out.ReceivedMessages))
+	}
+
+	data, err := base64.StdEncoding.DecodeString(out.ReceivedMessages[0].Message.Data)
+	if err != nil {
+		t.Fatalf("decode message data: %v", err)
+	}
+
+	if !strings.Contains(string(data), `"state":"open"`) || !strings.Contains(string(data), `"policy_name"`) {
+		t.Fatalf("pulled message is not the incident: %s", data)
+	}
+}
+
+func decodeResp(t *testing.T, resp *http.Response, v any) {
+	t.Helper()
+
+	defer resp.Body.Close()
+
+	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

A GCP Cloud Monitoring alert-policy breach transitioned state and recorded history but never delivered to its `notificationChannels` — the alert's actions were a no-op (an explicit comment in `providers/gcp/monitoring/monitoring.go` noted "no publisher is wired"). This closes that parity gap with AWS alarm->SNS and Azure Monitor webhook delivery: a breach now fires each referenced channel by type.

## What changed

- **Provider (`providers/gcp/monitoring`)**: `transitionAlarm` now delivers the incident on both open (ALARM) and close (OK) transitions — matching real Cloud Monitoring, which notifies on incident open and close by default.
  - **webhook** channels (`webhook_tokenauth` / `webhook_basicauth` / bare `webhook`): a best-effort real-HTTP POST via a `httpWebhookDeliverer` defaulted in `New` with a bounded 10s timeout — mirroring the Azure Monitor `httpWebhookDeliverer` exactly (same client shape/timeout).
  - **pubsub** channels: the incident is published to the channel's topic via an injected `PubSubPublisher`.
  - **email / SMS / other** channels: record-only (still fired/recorded; the emulator cannot send them).
  - Delivery is best-effort — an unreachable channel never fails the breaching `PutMetricData`.
- **Wire wiring (`server/gcp`)**: `alertPolicies.create` now carries the policy's `notificationChannels` into the driver alarm's actions. The Pub/Sub publisher is wired in `server/gcp/gcp.go` as an adapter over the Pub/Sub handler (topic fanout is wire-only, so this matches the layer #803 wired the function-invoker at). A new `PubSubHandler.PublishMessage` programmatic entrypoint mirrors the `publish()` HTTP path (topic log + push/function fanout).
- **Incident payload**: a reasonable subset of the real Cloud Monitoring notification schema (`incident{incident_id, resource_id, policy_name, condition_name, state, started_at, summary, url}`), identical for the webhook body and the Pub/Sub message data.
- Fixed the stale `monitoring.go` comment.

## Tests

- Webhook: breach POSTs the incident to a local receiver; unreachable receiver still transitions to ALARM (best-effort).
- Pub/Sub: breach publishes the incident to the channel's topic (provider-level fake publisher, plus an end-to-end server test that pulls the incident off a subscription through the wired adapter).
- Email/other: firing recorded (state + history), no external delivery, no crash.
- Recovery: open then close each deliver; history transitions unchanged.
- `TestWiringParity_GCP` green (both new injectors carry documented exemptions: webhook is defaulted in `New`, pubsub is server-wired).