### PR TITLE
fix(azure-eventgrid): register wire-created system-topic subscriptions as delivery rules (Blob->EventGrid e2e)

### DIFF
--- a/providers/azure/blobstorage/eventgrid_events_test.go
+++ b/providers/azure/blobstorage/eventgrid_events_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/providers/azure/eventgrid"
-	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -99,8 +98,10 @@ func newWiredMocks(t *testing.T) (*Mock, *eventgrid.Mock) {
 	bm := New(opts)
 	bm.SetEventGridPublisher(eg)
 
-	_, err := eg.CreateEventBus(context.Background(), ebdriver.EventBusConfig{Name: AccountName})
-	require.NoError(t, err)
+	// Blob events are system-topic-sourced (they carry the account id on Topic),
+	// so delivery flows through the isolated system-delivery store, not the
+	// user-facing custom-topic buses.
+	eg.EnsureSystemDeliveryBus(AccountName)
 
 	return bm, eg
 }
@@ -108,12 +109,7 @@ func newWiredMocks(t *testing.T) (*Mock, *eventgrid.Mock) {
 func subscribe(t *testing.T, eg *eventgrid.Mock, name, url string, filter map[string]any) {
 	t.Helper()
 
-	_, err := eg.PutRule(context.Background(), &ebdriver.RuleConfig{
-		Name:        name,
-		EventBus:    AccountName,
-		Description: blobSubscriptionProps(url, filter),
-	})
-	require.NoError(t, err)
+	require.NoError(t, eg.PutSystemDeliveryRule(AccountName, name, blobSubscriptionProps(url, filter)))
 }
 
 // TestBlobCreatedEmitsToSubscriber covers case (a): a PUT delivers a

--- a/providers/azure/eventgrid/eventgrid.go
+++ b/providers/azure/eventgrid/eventgrid.go
@@ -72,12 +72,20 @@ type FunctionInvoker interface {
 
 // Mock is an in-memory mock implementation of Azure Event Grid.
 type Mock struct {
-	buses      *memstore.Store[*busData]
-	opts       *config.Options
-	monitoring mondriver.Monitoring
-	httpClient *http.Client
-	serviceBus ServiceBusDeliverer
-	functions  FunctionInvoker
+	buses *memstore.Store[*busData]
+	// systemBuses backs system-topic delivery. It is a store distinct from
+	// buses (user-facing custom topics) so a system topic's delivery bus and a
+	// custom topic can share a name — e.g. the fixed storage-account name a Blob
+	// Storage system topic keys on — without either clobbering or leaking into
+	// the other. The custom-topic CRUD paths (Create/Update/Delete/ListEventBus,
+	// PutRule) never touch it; it is managed only through the SystemDelivery*
+	// methods and consulted by PutEvents for system-topic-sourced events.
+	systemBuses *memstore.Store[*busData]
+	opts        *config.Options
+	monitoring  mondriver.Monitoring
+	httpClient  *http.Client
+	serviceBus  ServiceBusDeliverer
+	functions   FunctionInvoker
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -122,10 +130,84 @@ func (m *Mock) emitMetric(topicName string, metrics map[string]float64) {
 // New creates a new Event Grid mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		buses:      memstore.New[*busData](),
-		opts:       opts,
-		httpClient: &http.Client{Timeout: webhookDeliveryTimeout},
+		buses:       memstore.New[*busData](),
+		systemBuses: memstore.New[*busData](),
+		opts:        opts,
+		httpClient:  &http.Client{Timeout: webhookDeliveryTimeout},
 	}
+}
+
+// EnsureSystemDeliveryBus makes sure an isolated system-topic delivery bus with
+// the given name exists (no-op when it already does, or the name is empty). The
+// wire handler calls this when a system topic is created so the source
+// producer's PutEvents has a bus to match. The bus lives in systemBuses, so it
+// never appears on — nor is clobbered by — the custom-topic surface.
+func (m *Mock) EnsureSystemDeliveryBus(name string) {
+	if name == "" || m.systemBuses.Has(name) {
+		return
+	}
+
+	m.systemBuses.Set(name, &busData{
+		info:   driver.EventBusInfo{Name: name, State: activeTopicState},
+		rules:  memstore.New[*ruleData](),
+		events: []driver.Event{},
+	})
+}
+
+// PutSystemDeliveryRule registers (or replaces) a system-topic subscription as a
+// delivery rule on its isolated bus, carrying the raw ARM EventSubscription
+// properties (destination + filter) verbatim — mirroring PutRule for custom
+// topics, but against systemBuses. Returns NotFound when the delivery bus was
+// never provisioned.
+func (m *Mock) PutSystemDeliveryRule(busName, ruleName, properties string) error {
+	if ruleName == "" {
+		return errors.New(errors.InvalidArgument, "subscription name is required")
+	}
+
+	bd, ok := m.systemBuses.Get(busName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "system delivery bus %q not found", busName)
+	}
+
+	bd.rules.Set(ruleName, &ruleData{
+		rule: driver.Rule{
+			Name:        ruleName,
+			EventBus:    busName,
+			Description: properties,
+			State:       defaultRuleState,
+			Targets:     []driver.Target{},
+			CreatedAt:   m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		},
+		targets: memstore.New[driver.Target](),
+		filter:  parseSubscriptionFilter(properties),
+		dest:    parseSubscriptionDestination(properties),
+	})
+
+	return nil
+}
+
+// DeleteSystemDeliveryRule removes a system-topic subscription's delivery rule
+// from its isolated bus. Idempotent: a missing bus or rule is not an error, so a
+// deleted subscription (or system topic) stops delivery cleanly.
+func (m *Mock) DeleteSystemDeliveryRule(busName, ruleName string) error {
+	if bd, ok := m.systemBuses.Get(busName); ok {
+		bd.rules.Delete(ruleName)
+	}
+
+	return nil
+}
+
+// lookupBus resolves the bus an event delivers through: a system-topic-sourced
+// event (the producer stamps the source resource id on Topic) resolves against
+// the isolated system delivery store; a custom-topic publish (Topic empty)
+// resolves against the user-facing store. This routing keeps a same-named
+// custom topic and system delivery bus from ever cross-delivering.
+func (m *Mock) lookupBus(event *driver.Event) (*busData, bool) {
+	if event.Topic != "" {
+		return m.systemBuses.Get(event.EventBus)
+	}
+
+	return m.buses.Get(event.EventBus)
 }
 
 // CreateEventBus creates a new Event Grid topic.
@@ -467,7 +549,7 @@ func (m *Mock) PutEvents(ctx context.Context, events []driver.Event) (*driver.Pu
 			continue
 		}
 
-		bd, ok := m.buses.Get(busName)
+		bd, ok := m.lookupBus(&events[i])
 		if !ok {
 			result.FailCount++
 
@@ -618,7 +700,7 @@ func (m *Mock) UpdateEventBus(_ context.Context, cfg driver.EventBusConfig) (*dr
 // it (exported for testing). Scoped to event.EventBus so a rule on one topic
 // never counts as matched for an event published to a different topic.
 func (m *Mock) MatchedRules(event *driver.Event) []driver.Rule {
-	bd, ok := m.buses.Get(event.EventBus)
+	bd, ok := m.lookupBus(event)
 	if !ok {
 		return nil
 	}

--- a/server/azure/eventgrid/handler.go
+++ b/server/azure/eventgrid/handler.go
@@ -51,6 +51,10 @@ const (
 // codebase — the wire handler owns their state in memory.
 type Handler struct {
 	bus ebdriver.EventBus
+	// sysDelivery is the optional system-topic delivery capability of bus (the
+	// Azure eventgrid.Mock provides it; nil for backends that don't). It isolates
+	// system-topic subscription rules from user-facing custom topics.
+	sysDelivery systemTopicDelivery
 
 	mu           sync.RWMutex
 	systemTopics map[string]*systemTopicRecord
@@ -75,15 +79,23 @@ type topicKeyGens struct {
 	key2Gen int
 }
 
-// New returns an Azure Event Grid handler backed by b.
+// New returns an Azure Event Grid handler backed by b. When b also implements
+// systemTopicDelivery (the Azure eventgrid.Mock does), system-topic
+// subscriptions are bridged to their isolated delivery store.
 func New(b ebdriver.EventBus) *Handler {
-	return &Handler{
+	h := &Handler{
 		bus:          b,
 		systemTopics: make(map[string]*systemTopicRecord),
 		domains:      make(map[string]*domainRecord),
 		scopedSubs:   make(map[string]*scopedSubRecord),
 		topicKeyGens: make(map[string]*topicKeyGens),
 	}
+
+	if sd, ok := b.(systemTopicDelivery); ok {
+		h.sysDelivery = sd
+	}
+
+	return h
 }
 
 // Matches claims ARM URLs targeting Microsoft.EventGrid topics, systemTopics,

--- a/server/azure/eventgrid/operations.go
+++ b/server/azure/eventgrid/operations.go
@@ -151,13 +151,6 @@ func (h *Handler) getTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.
 		return
 	}
 
-	// An internal system-topic delivery bus is not a custom topic; hide it from
-	// the Microsoft.EventGrid/topics surface even if its name collides.
-	if isSystemTopicBus(info) {
-		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "topic not found")
-		return
-	}
-
 	azurearm.WriteJSON(w, http.StatusOK, toTopicJSON(rp, info))
 }
 
@@ -165,13 +158,6 @@ func (h *Handler) getTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.
 // polling accepts 202/204; returning 204 with no body completes the poller on
 // the first response.
 func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	// Never let a custom-topic delete destroy an internal system-topic delivery
-	// bus that happens to share the name; report the idempotent 204 instead.
-	if info, err := h.bus.GetEventBus(r.Context(), rp.ResourceName); err == nil && isSystemTopicBus(info) {
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-
 	if err := h.bus.DeleteEventBus(r.Context(), rp.ResourceName); err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/eventgrid/operations.go
+++ b/server/azure/eventgrid/operations.go
@@ -151,6 +151,13 @@ func (h *Handler) getTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.
 		return
 	}
 
+	// An internal system-topic delivery bus is not a custom topic; hide it from
+	// the Microsoft.EventGrid/topics surface even if its name collides.
+	if isSystemTopicBus(info) {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "topic not found")
+		return
+	}
+
 	azurearm.WriteJSON(w, http.StatusOK, toTopicJSON(rp, info))
 }
 
@@ -158,6 +165,13 @@ func (h *Handler) getTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.
 // polling accepts 202/204; returning 204 with no body completes the poller on
 // the first response.
 func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	// Never let a custom-topic delete destroy an internal system-topic delivery
+	// bus that happens to share the name; report the idempotent 204 instead.
+	if info, err := h.bus.GetEventBus(r.Context(), rp.ResourceName); err == nil && isSystemTopicBus(info) {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	if err := h.bus.DeleteEventBus(r.Context(), rp.ResourceName); err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/eventgrid/system_topic_blob_e2e_test.go
+++ b/server/azure/eventgrid/system_topic_blob_e2e_test.go
@@ -1,0 +1,382 @@
+// Full real-user HTTP end-to-end tests for the Blob Storage -> Event Grid
+// system-topic path: a system topic and its event subscription are created over
+// the real armeventgrid ARM SDK, a blob is written over the real azblob SDK, and
+// the subscription's destination (WebHook / ServiceBusQueue) actually receives
+// the Microsoft.Storage.BlobCreated/BlobDeleted event — proving wire-created
+// system-topic subscriptions are bridged to the delivery path.
+package eventgrid_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+)
+
+// blobSource is a Microsoft.Storage system-topic source whose leaf is the
+// emulator's fixed storage account name ("cloudemu"), which is the key the Blob
+// Storage producer stamps on the events it emits — so a subscription registered
+// against this source's delivery bus receives them.
+const blobSource = "/subscriptions/" + testSub +
+	"/resourceGroups/" + testRG + "/providers/Microsoft.Storage/storageAccounts/cloudemu"
+
+// egWebhookReceiver records every Event Grid batch POSTed to it.
+type egWebhookReceiver struct {
+	*httptest.Server
+
+	mu    sync.Mutex
+	calls []deliveredBlobEvent
+}
+
+type deliveredBlobEvent struct {
+	ID        string          `json:"id"`
+	Topic     string          `json:"topic"`
+	Subject   string          `json:"subject"`
+	EventType string          `json:"eventType"`
+	Data      json.RawMessage `json:"data"`
+}
+
+func newEGWebhookReceiver(t *testing.T) *egWebhookReceiver {
+	t.Helper()
+
+	rc := &egWebhookReceiver{}
+	rc.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var batch []deliveredBlobEvent
+		if err := json.NewDecoder(r.Body).Decode(&batch); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		rc.mu.Lock()
+		rc.calls = append(rc.calls, batch...)
+		rc.mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(rc.Close)
+
+	return rc
+}
+
+func (rc *egWebhookReceiver) events() []deliveredBlobEvent {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+
+	out := make([]deliveredBlobEvent, len(rc.calls))
+	copy(out, rc.calls)
+
+	return out
+}
+
+// blobEGServer bundles the shared provider and the two real SDK surfaces (ARM
+// Event Grid + azblob data plane) mounted on one server, so a blob write routes
+// through the same in-memory Event Grid the subscriptions were created against.
+type blobEGServer struct {
+	serviceBus sbQueueReader
+	systems    *armeventgrid.SystemTopicsClient
+	subs       *armeventgrid.SystemTopicEventSubscriptionsClient
+	blob       *azblob.Client
+}
+
+// sbQueueReader is the slice of the Service Bus mock the ServiceBus e2e case
+// uses to create and drain the peer queue (satisfied by *servicebus.Mock).
+type sbQueueReader interface {
+	CreateQueue(context.Context, mqdriver.QueueConfig) (*mqdriver.QueueInfo, error)
+	ReceiveMessages(context.Context, mqdriver.ReceiveMessageInput) ([]mqdriver.Message, error)
+}
+
+func newBlobEGServer(t *testing.T) *blobEGServer {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		BlobStorage: cloudP.BlobStorage,
+		EventGrid:   cloudP.EventGrid,
+		ServiceBus:  cloudP.ServiceBus,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+
+	armOpts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	cf, err := armeventgrid.NewClientFactory(testSub, fakeCred{}, armOpts)
+	if err != nil {
+		t.Fatalf("armeventgrid.NewClientFactory: %v", err)
+	}
+
+	blobClient, err := azblob.NewClientWithNoCredential(ts.URL+"/", &azblob.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: ts.Client(), Retry: policy.RetryOptions{MaxRetries: -1}},
+	})
+	if err != nil {
+		t.Fatalf("azblob.NewClientWithNoCredential: %v", err)
+	}
+
+	return &blobEGServer{
+		serviceBus: cloudP.ServiceBus,
+		systems:    cf.NewSystemTopicsClient(),
+		subs:       cf.NewSystemTopicEventSubscriptionsClient(),
+		blob:       blobClient,
+	}
+}
+
+// createSystemTopic creates the Blob Storage system topic over the ARM SDK.
+func (s *blobEGServer) createSystemTopic(ctx context.Context, t *testing.T, name string) {
+	t.Helper()
+
+	poller, err := s.systems.BeginCreateOrUpdate(ctx, testRG, name, armeventgrid.SystemTopic{
+		Location: to.Ptr("global"),
+		Properties: &armeventgrid.SystemTopicProperties{
+			Source:    to.Ptr(blobSource),
+			TopicType: to.Ptr("Microsoft.Storage.StorageAccounts"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("system topic BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("system topic PollUntilDone: %v", err)
+	}
+}
+
+// createWebhookSub creates a system-topic subscription delivering to url, with
+// an optional includedEventTypes filter.
+func (s *blobEGServer) createWebhookSub(ctx context.Context, t *testing.T, topic, name, url string, eventTypes []string) {
+	t.Helper()
+
+	var filter *armeventgrid.EventSubscriptionFilter
+	if eventTypes != nil {
+		filter = &armeventgrid.EventSubscriptionFilter{IncludedEventTypes: to.SliceOfPtrs(eventTypes...)}
+	}
+
+	sub := armeventgrid.EventSubscription{
+		Properties: &armeventgrid.EventSubscriptionProperties{
+			Destination: &armeventgrid.WebHookEventSubscriptionDestination{
+				EndpointType: to.Ptr(armeventgrid.EndpointTypeWebHook),
+				Properties: &armeventgrid.WebHookEventSubscriptionDestinationProperties{
+					EndpointURL: to.Ptr(url),
+				},
+			},
+			Filter: filter,
+		},
+	}
+
+	poller, err := s.subs.BeginCreateOrUpdate(ctx, testRG, topic, name, sub, nil)
+	if err != nil {
+		t.Fatalf("subscription BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("subscription PollUntilDone: %v", err)
+	}
+}
+
+func (s *blobEGServer) uploadBlob(ctx context.Context, t *testing.T, container, key string, body []byte) {
+	t.Helper()
+
+	if _, err := s.blob.CreateContainer(ctx, container, nil); err != nil {
+		t.Fatalf("CreateContainer(%s): %v", container, err)
+	}
+
+	if _, err := s.blob.UploadBuffer(ctx, container, key, body, nil); err != nil {
+		t.Fatalf("UploadBuffer(%s/%s): %v", container, key, err)
+	}
+}
+
+// eventuallyEvents polls the receiver until it has at least want events or the
+// deadline elapses, returning whatever it saw (delivery is synchronous, so this
+// only guards against scheduling jitter, not real asynchrony).
+func eventuallyEvents(rc *egWebhookReceiver, want int) []deliveredBlobEvent {
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got := rc.events()
+		if len(got) >= want || time.Now().After(deadline) {
+			return got
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestSDKSystemTopicBlobWebhookE2E is case (a): a WebHook system-topic
+// subscription created over ARM receives a BlobCreated event when a blob is
+// PUT over the real azblob surface.
+func TestSDKSystemTopicBlobWebhookE2E(t *testing.T) {
+	ctx := context.Background()
+	s := newBlobEGServer(t)
+	rc := newEGWebhookReceiver(t)
+
+	s.createSystemTopic(ctx, t, "storage-events")
+	s.createWebhookSub(ctx, t, "storage-events", "to-hook", rc.URL,
+		[]string{"Microsoft.Storage.BlobCreated"})
+
+	s.uploadBlob(ctx, t, "images", "cat.png", []byte("hello"))
+
+	got := eventuallyEvents(rc, 1)
+	if len(got) != 1 {
+		t.Fatalf("delivered events = %d, want 1", len(got))
+	}
+
+	if got[0].EventType != "Microsoft.Storage.BlobCreated" {
+		t.Fatalf("eventType = %q, want Microsoft.Storage.BlobCreated", got[0].EventType)
+	}
+
+	if got[0].Subject != "/blobServices/default/containers/images/blobs/cat.png" {
+		t.Fatalf("subject = %q, unexpected", got[0].Subject)
+	}
+
+	// The delivered topic is the storage account (the source), not the Event
+	// Grid resource the subscription hangs off.
+	if !strings.Contains(got[0].Topic, "/providers/Microsoft.Storage/storageAccounts/cloudemu") {
+		t.Fatalf("topic = %q, want the storage account id", got[0].Topic)
+	}
+}
+
+// TestSDKSystemTopicBlobServiceBusE2E is case (b): a ServiceBusQueue
+// system-topic subscription lands the blob event in the peer Service Bus queue.
+func TestSDKSystemTopicBlobServiceBusE2E(t *testing.T) {
+	ctx := context.Background()
+	s := newBlobEGServer(t)
+
+	queue, err := s.serviceBus.CreateQueue(ctx, mqdriver.QueueConfig{Name: "blob-events-q"})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	s.createSystemTopic(ctx, t, "storage-events")
+
+	resourceID := "/subscriptions/" + testSub + "/resourceGroups/" + testRG +
+		"/providers/Microsoft.ServiceBus/namespaces/ns1/queues/blob-events-q"
+
+	sub := armeventgrid.EventSubscription{
+		Properties: &armeventgrid.EventSubscriptionProperties{
+			Destination: &armeventgrid.ServiceBusQueueEventSubscriptionDestination{
+				EndpointType: to.Ptr(armeventgrid.EndpointTypeServiceBusQueue),
+				Properties: &armeventgrid.ServiceBusQueueEventSubscriptionDestinationProperties{
+					ResourceID: to.Ptr(resourceID),
+				},
+			},
+		},
+	}
+
+	poller, err := s.subs.BeginCreateOrUpdate(ctx, testRG, "storage-events", "to-sbq", sub, nil)
+	if err != nil {
+		t.Fatalf("subscription BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("subscription PollUntilDone: %v", err)
+	}
+
+	s.uploadBlob(ctx, t, "docs", "a.txt", []byte("hi"))
+
+	msgs, err := s.serviceBus.ReceiveMessages(ctx,
+		mqdriver.ReceiveMessageInput{QueueURL: queue.URL, MaxMessages: 10})
+	if err != nil {
+		t.Fatalf("ReceiveMessages: %v", err)
+	}
+
+	if len(msgs) != 1 {
+		t.Fatalf("queue messages = %d, want 1", len(msgs))
+	}
+
+	var batch []deliveredBlobEvent
+	if err := json.Unmarshal([]byte(msgs[0].Body), &batch); err != nil {
+		t.Fatalf("decode enqueued envelope: %v", err)
+	}
+
+	if len(batch) != 1 || batch[0].EventType != "Microsoft.Storage.BlobCreated" {
+		t.Fatalf("enqueued event = %+v, want a BlobCreated", batch)
+	}
+}
+
+// TestSDKSystemTopicBlobFilterDrops is case (c): a subscription filtered to
+// BlobDeleted must not receive a BlobCreated, but does receive the later delete.
+func TestSDKSystemTopicBlobFilterDrops(t *testing.T) {
+	ctx := context.Background()
+	s := newBlobEGServer(t)
+	rc := newEGWebhookReceiver(t)
+
+	s.createSystemTopic(ctx, t, "storage-events")
+	s.createWebhookSub(ctx, t, "storage-events", "deletes-only", rc.URL,
+		[]string{"Microsoft.Storage.BlobDeleted"})
+
+	s.uploadBlob(ctx, t, "c", "k", []byte("v"))
+
+	if got := eventuallyEvents(rc, 1); len(got) != 0 {
+		t.Fatalf("BlobCreated leaked past a BlobDeleted-only filter: %+v", got)
+	}
+
+	if _, err := s.blob.DeleteBlob(ctx, "c", "k", nil); err != nil {
+		t.Fatalf("DeleteBlob: %v", err)
+	}
+
+	got := eventuallyEvents(rc, 1)
+	if len(got) != 1 || got[0].EventType != "Microsoft.Storage.BlobDeleted" {
+		t.Fatalf("delete delivery = %+v, want one BlobDeleted", got)
+	}
+}
+
+// TestSDKSystemTopicBlobDeleteStopsDelivery is case (d): deleting the
+// subscription over ARM stops further delivery.
+func TestSDKSystemTopicBlobDeleteStopsDelivery(t *testing.T) {
+	ctx := context.Background()
+	s := newBlobEGServer(t)
+	rc := newEGWebhookReceiver(t)
+
+	s.createSystemTopic(ctx, t, "storage-events")
+	s.createWebhookSub(ctx, t, "storage-events", "to-hook", rc.URL, nil)
+
+	s.uploadBlob(ctx, t, "c", "first", []byte("1"))
+
+	if got := eventuallyEvents(rc, 1); len(got) != 1 {
+		t.Fatalf("pre-delete delivery = %d, want 1", len(got))
+	}
+
+	delPoller, err := s.subs.BeginDelete(ctx, testRG, "storage-events", "to-hook", nil)
+	if err != nil {
+		t.Fatalf("subscription BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("subscription delete PollUntilDone: %v", err)
+	}
+
+	if _, err := s.blob.UploadBuffer(ctx, "c", "second", []byte("2"), nil); err != nil {
+		t.Fatalf("second UploadBuffer: %v", err)
+	}
+
+	if got := eventuallyEvents(rc, 2); len(got) != 1 {
+		t.Fatalf("post-delete delivery = %d, want it to stay at 1", len(got))
+	}
+}

--- a/server/azure/eventgrid/system_topic_blob_e2e_test.go
+++ b/server/azure/eventgrid/system_topic_blob_e2e_test.go
@@ -91,7 +91,10 @@ type blobEGServer struct {
 	serviceBus sbQueueReader
 	systems    *armeventgrid.SystemTopicsClient
 	subs       *armeventgrid.SystemTopicEventSubscriptionsClient
+	topics     *armeventgrid.TopicsClient
+	topicSubs  *armeventgrid.TopicEventSubscriptionsClient
 	blob       *azblob.Client
+	ts         *httptest.Server
 }
 
 // sbQueueReader is the slice of the Service Bus mock the ServiceBus e2e case
@@ -145,7 +148,82 @@ func newBlobEGServer(t *testing.T) *blobEGServer {
 		serviceBus: cloudP.ServiceBus,
 		systems:    cf.NewSystemTopicsClient(),
 		subs:       cf.NewSystemTopicEventSubscriptionsClient(),
+		topics:     cf.NewTopicsClient(),
+		topicSubs:  cf.NewTopicEventSubscriptionsClient(),
 		blob:       blobClient,
+		ts:         ts,
+	}
+}
+
+// createCustomTopic creates a user-facing custom Event Grid topic over the ARM
+// SDK (used to force the "cloudemu" name collision with the system delivery bus).
+func (s *blobEGServer) createCustomTopic(ctx context.Context, t *testing.T, name string) {
+	t.Helper()
+
+	poller, err := s.topics.BeginCreateOrUpdate(ctx, testRG, name,
+		armeventgrid.Topic{Location: to.Ptr("eastus")}, nil)
+	if err != nil {
+		t.Fatalf("custom topic BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("custom topic PollUntilDone: %v", err)
+	}
+}
+
+// createCustomWebhookSub creates a custom-topic event subscription delivering to
+// url over the ARM SDK.
+func (s *blobEGServer) createCustomWebhookSub(ctx context.Context, t *testing.T, topic, name, url string) {
+	t.Helper()
+
+	sub := armeventgrid.EventSubscription{
+		Properties: &armeventgrid.EventSubscriptionProperties{
+			Destination: &armeventgrid.WebHookEventSubscriptionDestination{
+				EndpointType: to.Ptr(armeventgrid.EndpointTypeWebHook),
+				Properties: &armeventgrid.WebHookEventSubscriptionDestinationProperties{
+					EndpointURL: to.Ptr(url),
+				},
+			},
+		},
+	}
+
+	poller, err := s.topicSubs.BeginCreateOrUpdate(ctx, testRG, topic, name, sub, nil)
+	if err != nil {
+		t.Fatalf("custom subscription BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("custom subscription PollUntilDone: %v", err)
+	}
+}
+
+// publishCustomEvent posts one EventGridEvent to a custom topic's data-plane
+// endpoint over HTTP, addressed by Host (matching how a real publisher reaches a
+// topic). Custom-topic events carry no Topic override, so they route to the
+// user-facing bus store — never the system delivery store.
+func (s *blobEGServer) publishCustomEvent(ctx context.Context, t *testing.T, topic string) {
+	t.Helper()
+
+	body := `[{"id":"c1","subject":"orders/1","eventType":"Order.Created",` +
+		`"eventTime":"2024-01-02T03:04:05Z","data":{"total":42},"dataVersion":"1.0"}]`
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		s.ts.URL+"/api/events", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("publish new request: %v", err)
+	}
+
+	req.Host = topic + ".eastus-1.eventgrid.azure.net"
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("publish custom event: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // test cleanup
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("publish status = %d, want 200", resp.StatusCode)
 	}
 }
 
@@ -379,4 +457,120 @@ func TestSDKSystemTopicBlobDeleteStopsDelivery(t *testing.T) {
 	if got := eventuallyEvents(rc, 2); len(got) != 1 {
 		t.Fatalf("post-delete delivery = %d, want it to stay at 1", len(got))
 	}
+}
+
+// TestSDKSystemTopicBlobCollisionForward is the forward collision case: a real
+// custom Event Grid topic named "cloudemu" (the same name the Blob system
+// delivery bus keys on) coexists with the system topic without either leaking
+// into the other. Blob events reach only the system subscriber; a custom-topic
+// publish reaches only the custom subscriber; the custom topic stays a normal,
+// independent, listable topic.
+func TestSDKSystemTopicBlobCollisionForward(t *testing.T) {
+	ctx := context.Background()
+	s := newBlobEGServer(t)
+	systemRC := newEGWebhookReceiver(t)
+	customRC := newEGWebhookReceiver(t)
+
+	// A user creates a custom topic that collides with the storage-account name.
+	s.createCustomTopic(ctx, t, "cloudemu")
+	s.createCustomWebhookSub(ctx, t, "cloudemu", "cust-sub", customRC.URL)
+
+	// The Blob system topic + subscription is created alongside it.
+	s.createSystemTopic(ctx, t, "storage-events")
+	s.createWebhookSub(ctx, t, "storage-events", "sys-sub", systemRC.URL,
+		[]string{"Microsoft.Storage.BlobCreated"})
+
+	// The custom topic was neither clobbered nor re-scoped: it is still gettable
+	// and listed exactly once.
+	if _, err := s.topics.Get(ctx, testRG, "cloudemu", nil); err != nil {
+		t.Fatalf("custom topic Get after system topic create: %v", err)
+	}
+
+	if n := s.countCustomTopics(ctx, t); n != 1 {
+		t.Fatalf("custom topic list count = %d, want 1", n)
+	}
+
+	// A blob write reaches the system subscriber only — never the custom one.
+	s.uploadBlob(ctx, t, "images", "cat.png", []byte("hello"))
+
+	sysGot := eventuallyEvents(systemRC, 1)
+	if len(sysGot) != 1 || sysGot[0].EventType != "Microsoft.Storage.BlobCreated" {
+		t.Fatalf("system delivery = %+v, want one BlobCreated", sysGot)
+	}
+
+	if got := eventuallyEvents(customRC, 1); len(got) != 0 {
+		t.Fatalf("blob event leaked to the custom topic subscriber: %+v", got)
+	}
+
+	// A custom-topic publish reaches the custom subscriber only — never the
+	// system one.
+	s.publishCustomEvent(ctx, t, "cloudemu")
+
+	custGot := eventuallyEvents(customRC, 1)
+	if len(custGot) != 1 || custGot[0].EventType != "Order.Created" {
+		t.Fatalf("custom delivery = %+v, want one Order.Created", custGot)
+	}
+
+	if got := eventuallyEvents(systemRC, 2); len(got) != 1 {
+		t.Fatalf("custom event leaked to the system subscriber: %+v", got)
+	}
+}
+
+// TestSDKSystemTopicBlobCollisionReverse is the reverse collision case: the
+// system topic exists first, then a user creates — and deletes — a custom topic
+// named "cloudemu". Neither operation disturbs system-topic Blob delivery.
+func TestSDKSystemTopicBlobCollisionReverse(t *testing.T) {
+	ctx := context.Background()
+	s := newBlobEGServer(t)
+	rc := newEGWebhookReceiver(t)
+
+	s.createSystemTopic(ctx, t, "storage-events")
+	s.createWebhookSub(ctx, t, "storage-events", "sys-sub", rc.URL,
+		[]string{"Microsoft.Storage.BlobCreated"})
+
+	s.uploadBlob(ctx, t, "c", "first", []byte("1"))
+	if got := eventuallyEvents(rc, 1); len(got) != 1 {
+		t.Fatalf("baseline system delivery = %d, want 1", len(got))
+	}
+
+	// A user creates then deletes a colliding custom topic.
+	s.createCustomTopic(ctx, t, "cloudemu")
+
+	delPoller, err := s.topics.BeginDelete(ctx, testRG, "cloudemu", nil)
+	if err != nil {
+		t.Fatalf("custom topic BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("custom topic delete PollUntilDone: %v", err)
+	}
+
+	// System delivery survives the custom topic's create+delete unchanged.
+	if _, err := s.blob.UploadBuffer(ctx, "c", "second", []byte("2"), nil); err != nil {
+		t.Fatalf("second UploadBuffer: %v", err)
+	}
+
+	if got := eventuallyEvents(rc, 2); len(got) != 2 {
+		t.Fatalf("system delivery after custom topic churn = %d, want 2", len(got))
+	}
+}
+
+// countCustomTopics returns how many custom topics the ARM list surface reports
+// in the test resource group.
+func (s *blobEGServer) countCustomTopics(ctx context.Context, t *testing.T) int {
+	t.Helper()
+
+	n := 0
+
+	pager := s.topics.NewListByResourceGroupPager(testRG, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("custom topic list: %v", err)
+		}
+
+		n += len(page.Value)
+	}
+
+	return n
 }

--- a/server/azure/eventgrid/system_topic_delivery.go
+++ b/server/azure/eventgrid/system_topic_delivery.go
@@ -1,0 +1,102 @@
+package eventgrid
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+)
+
+// systemTopicBusMarker scopes the internal event bus that backs a system
+// topic's delivery. A system topic is not a Microsoft.EventGrid/topics
+// resource, yet its subscriptions must register as eventbus rules so the source
+// producer's PutEvents — which matches on event.EventBus — delivers to them.
+// The bus is therefore named for the source's leaf (the key the producer stamps
+// on event.EventBus), so it can't also carry the user's real subscription scope
+// without leaking into custom-topic list results. This sentinel subscription
+// keeps it out of every real-scope Topics list while leaving the name free to
+// match the producer.
+const systemTopicBusMarker = "cloudemu-system-topic"
+
+// systemTopicBusName derives the event bus that backs a system topic's delivery
+// from its source: the trailing segment of the source resource id (the storage
+// account name for a Microsoft.Storage system topic), which is exactly the key
+// the source producer stamps on event.EventBus (see the Blob Storage producer,
+// which publishes with EventBus = the account name). Empty when source is empty.
+func systemTopicBusName(source string) string {
+	trimmed := strings.TrimRight(source, "/")
+	if trimmed == "" {
+		return ""
+	}
+
+	if i := strings.LastIndex(trimmed, "/"); i >= 0 {
+		return trimmed[i+1:]
+	}
+
+	return trimmed
+}
+
+// systemTopicBusScope returns the sentinel scope every system-topic delivery bus
+// is created under, hiding it from real-scope custom-topic lists.
+func systemTopicBusScope() scope.Scope {
+	return scope.Scope{Subscription: systemTopicBusMarker}
+}
+
+// isSystemTopicBus reports whether an event bus is an internal system-topic
+// delivery bus (created under the sentinel scope) rather than a real custom
+// topic, so the custom-topic read paths can treat it as absent.
+func isSystemTopicBus(info *ebdriver.EventBusInfo) bool {
+	return info != nil && info.Scope.Subscription == systemTopicBusMarker
+}
+
+// ensureSystemTopicBus makes sure the internal delivery bus for a system topic
+// source exists (creating it under the sentinel scope on first use) and returns
+// its name. Best-effort, mirroring the producer's decoupled eventing: a create
+// failure just means no delivery, never a failed ARM request. Returns "" when
+// source carries no name to key on.
+func (h *Handler) ensureSystemTopicBus(ctx context.Context, source string) string {
+	bus := systemTopicBusName(source)
+	if bus == "" {
+		return ""
+	}
+
+	if _, err := h.bus.GetEventBus(ctx, bus); err == nil {
+		return bus
+	}
+
+	_, _ = h.bus.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: bus, Scope: systemTopicBusScope()})
+
+	return bus
+}
+
+// registerSystemTopicSubscription mirrors the custom-topic event-subscription
+// path (createOrUpdateEventSubscription) for a system topic: it registers the
+// subscription as an eventbus rule keyed by the system topic's delivery bus,
+// carrying the raw ARM properties (destination + filter) verbatim, so the source
+// producer's PutEvents matches its filter and delivers to its destination.
+// Best-effort.
+func (h *Handler) registerSystemTopicSubscription(ctx context.Context, busName, name string, props json.RawMessage) {
+	if busName == "" {
+		return
+	}
+
+	_, _ = h.bus.PutRule(ctx, &ebdriver.RuleConfig{
+		Name:        name,
+		EventBus:    busName,
+		Description: string(props),
+		State:       "ENABLED",
+	})
+}
+
+// unregisterSystemTopicSubscription removes the delivery rule a system-topic
+// subscription registered, so a deleted subscription (or a deleted system topic)
+// stops receiving events. Best-effort.
+func (h *Handler) unregisterSystemTopicSubscription(ctx context.Context, busName, name string) {
+	if busName == "" {
+		return
+	}
+
+	_ = h.bus.DeleteRule(ctx, busName, name)
+}

--- a/server/azure/eventgrid/system_topic_delivery.go
+++ b/server/azure/eventgrid/system_topic_delivery.go
@@ -1,30 +1,34 @@
 package eventgrid
 
 import (
-	"context"
 	"encoding/json"
 	"strings"
-
-	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
-	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
-// systemTopicBusMarker scopes the internal event bus that backs a system
-// topic's delivery. A system topic is not a Microsoft.EventGrid/topics
-// resource, yet its subscriptions must register as eventbus rules so the source
-// producer's PutEvents — which matches on event.EventBus — delivers to them.
-// The bus is therefore named for the source's leaf (the key the producer stamps
-// on event.EventBus), so it can't also carry the user's real subscription scope
-// without leaking into custom-topic list results. This sentinel subscription
-// keeps it out of every real-scope Topics list while leaving the name free to
-// match the producer.
-const systemTopicBusMarker = "cloudemu-system-topic"
+// systemTopicDelivery is the optional capability an event bus backend exposes to
+// isolate system-topic event delivery from user-facing custom topics. System
+// topics are an Azure-only concept, so the Azure eventgrid.Mock implements this
+// while other backends do not; the wire handler feature-detects it. Because the
+// delivery buses live in a store the custom-topic CRUD paths never touch, a
+// custom topic and a system delivery bus can share a name (e.g. the fixed
+// storage-account name a Blob Storage system topic keys on) without either
+// clobbering or leaking into the other.
+type systemTopicDelivery interface {
+	// EnsureSystemDeliveryBus makes sure an isolated delivery bus with the given
+	// name exists (no-op if it already does).
+	EnsureSystemDeliveryBus(name string)
+	// PutSystemDeliveryRule registers/updates a subscription rule (raw ARM
+	// EventSubscription properties: destination + filter) on a delivery bus.
+	PutSystemDeliveryRule(busName, ruleName, properties string) error
+	// DeleteSystemDeliveryRule removes a subscription rule from a delivery bus.
+	DeleteSystemDeliveryRule(busName, ruleName string) error
+}
 
-// systemTopicBusName derives the event bus that backs a system topic's delivery
-// from its source: the trailing segment of the source resource id (the storage
-// account name for a Microsoft.Storage system topic), which is exactly the key
-// the source producer stamps on event.EventBus (see the Blob Storage producer,
-// which publishes with EventBus = the account name). Empty when source is empty.
+// systemTopicBusName derives the delivery bus that backs a system topic from its
+// source: the trailing segment of the source resource id (the storage account
+// name for a Microsoft.Storage system topic), which is exactly the key the
+// source producer stamps on event.EventBus — the Blob Storage producer publishes
+// with EventBus = the account name. Empty when source is empty.
 func systemTopicBusName(source string) string {
 	trimmed := strings.TrimRight(source, "/")
 	if trimmed == "" {
@@ -38,65 +42,39 @@ func systemTopicBusName(source string) string {
 	return trimmed
 }
 
-// systemTopicBusScope returns the sentinel scope every system-topic delivery bus
-// is created under, hiding it from real-scope custom-topic lists.
-func systemTopicBusScope() scope.Scope {
-	return scope.Scope{Subscription: systemTopicBusMarker}
-}
-
-// isSystemTopicBus reports whether an event bus is an internal system-topic
-// delivery bus (created under the sentinel scope) rather than a real custom
-// topic, so the custom-topic read paths can treat it as absent.
-func isSystemTopicBus(info *ebdriver.EventBusInfo) bool {
-	return info != nil && info.Scope.Subscription == systemTopicBusMarker
-}
-
-// ensureSystemTopicBus makes sure the internal delivery bus for a system topic
-// source exists (creating it under the sentinel scope on first use) and returns
-// its name. Best-effort, mirroring the producer's decoupled eventing: a create
-// failure just means no delivery, never a failed ARM request. Returns "" when
-// source carries no name to key on.
-func (h *Handler) ensureSystemTopicBus(ctx context.Context, source string) string {
+// ensureSystemTopicBus provisions the isolated delivery bus for a system topic
+// source and returns its name. Best-effort: with no delivery-capable backend, or
+// an empty source, it is a no-op (returning the derived name, possibly "").
+func (h *Handler) ensureSystemTopicBus(source string) string {
 	bus := systemTopicBusName(source)
-	if bus == "" {
-		return ""
-	}
-
-	if _, err := h.bus.GetEventBus(ctx, bus); err == nil {
+	if bus == "" || h.sysDelivery == nil {
 		return bus
 	}
 
-	_, _ = h.bus.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: bus, Scope: systemTopicBusScope()})
+	h.sysDelivery.EnsureSystemDeliveryBus(bus)
 
 	return bus
 }
 
 // registerSystemTopicSubscription mirrors the custom-topic event-subscription
-// path (createOrUpdateEventSubscription) for a system topic: it registers the
-// subscription as an eventbus rule keyed by the system topic's delivery bus,
-// carrying the raw ARM properties (destination + filter) verbatim, so the source
-// producer's PutEvents matches its filter and delivers to its destination.
-// Best-effort.
-func (h *Handler) registerSystemTopicSubscription(ctx context.Context, busName, name string, props json.RawMessage) {
-	if busName == "" {
+// path for a system topic: it registers the subscription as a delivery rule on
+// the system topic's isolated bus so the source producer's PutEvents matches its
+// filter and delivers to its destination. Best-effort.
+func (h *Handler) registerSystemTopicSubscription(busName, name string, props json.RawMessage) {
+	if busName == "" || h.sysDelivery == nil {
 		return
 	}
 
-	_, _ = h.bus.PutRule(ctx, &ebdriver.RuleConfig{
-		Name:        name,
-		EventBus:    busName,
-		Description: string(props),
-		State:       "ENABLED",
-	})
+	_ = h.sysDelivery.PutSystemDeliveryRule(busName, name, string(props))
 }
 
 // unregisterSystemTopicSubscription removes the delivery rule a system-topic
 // subscription registered, so a deleted subscription (or a deleted system topic)
 // stops receiving events. Best-effort.
-func (h *Handler) unregisterSystemTopicSubscription(ctx context.Context, busName, name string) {
-	if busName == "" {
+func (h *Handler) unregisterSystemTopicSubscription(busName, name string) {
+	if busName == "" || h.sysDelivery == nil {
 		return
 	}
 
-	_ = h.bus.DeleteRule(ctx, busName, name)
+	_ = h.sysDelivery.DeleteSystemDeliveryRule(busName, name)
 }

--- a/server/azure/eventgrid/system_topic_subscriptions.go
+++ b/server/azure/eventgrid/system_topic_subscriptions.go
@@ -28,7 +28,7 @@ func (h *Handler) serveSystemTopicSubscription(w http.ResponseWriter, r *http.Re
 	case http.MethodGet:
 		h.getSystemTopicSubscription(w, rp)
 	case http.MethodDelete:
-		h.deleteSystemTopicSubscription(w, rp)
+		h.deleteSystemTopicSubscription(w, r, rp)
 	default:
 		writeMethodNotAllowed(w)
 	}
@@ -71,7 +71,14 @@ func (h *Handler) createOrUpdateSystemTopicSubscription(w http.ResponseWriter, r
 
 	rec.subscriptions[rp.SubResourceName] = body.Properties
 	out := systemTopicSubscriptionJSON(rp, body.Properties)
+	source := rec.source
 	h.mu.Unlock()
+
+	// Bridge the wire-created subscription to the delivery path: register it as a
+	// rule on the system topic's delivery bus so the source producer's PutEvents
+	// matches and delivers it (mirrors the custom-topic event-subscription path).
+	busName := h.ensureSystemTopicBus(r.Context(), source)
+	h.registerSystemTopicSubscription(r.Context(), busName, rp.SubResourceName, body.Properties)
 
 	azurearm.WriteJSON(w, http.StatusCreated, out)
 }
@@ -100,16 +107,22 @@ func (h *Handler) getSystemTopicSubscription(w http.ResponseWriter, rp *azurearm
 	azurearm.WriteJSON(w, http.StatusOK, systemTopicSubscriptionJSON(rp, props))
 }
 
-func (h *Handler) deleteSystemTopicSubscription(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+func (h *Handler) deleteSystemTopicSubscription(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
 
 	h.mu.Lock()
 
+	var source string
+
 	if rec := h.systemTopics[key]; rec != nil {
+		source = rec.source
 		delete(rec.subscriptions, rp.SubResourceName)
 	}
 
 	h.mu.Unlock()
+
+	// Drop the delivery rule so the deleted subscription stops receiving events.
+	h.unregisterSystemTopicSubscription(r.Context(), systemTopicBusName(source), rp.SubResourceName)
 
 	// The SDK's BeginDelete LRO completes on a 200 first response.
 	w.WriteHeader(http.StatusOK)

--- a/server/azure/eventgrid/system_topic_subscriptions.go
+++ b/server/azure/eventgrid/system_topic_subscriptions.go
@@ -28,7 +28,7 @@ func (h *Handler) serveSystemTopicSubscription(w http.ResponseWriter, r *http.Re
 	case http.MethodGet:
 		h.getSystemTopicSubscription(w, rp)
 	case http.MethodDelete:
-		h.deleteSystemTopicSubscription(w, r, rp)
+		h.deleteSystemTopicSubscription(w, rp)
 	default:
 		writeMethodNotAllowed(w)
 	}
@@ -75,10 +75,10 @@ func (h *Handler) createOrUpdateSystemTopicSubscription(w http.ResponseWriter, r
 	h.mu.Unlock()
 
 	// Bridge the wire-created subscription to the delivery path: register it as a
-	// rule on the system topic's delivery bus so the source producer's PutEvents
-	// matches and delivers it (mirrors the custom-topic event-subscription path).
-	busName := h.ensureSystemTopicBus(r.Context(), source)
-	h.registerSystemTopicSubscription(r.Context(), busName, rp.SubResourceName, body.Properties)
+	// rule on the system topic's isolated delivery bus so the source producer's
+	// PutEvents matches and delivers it (mirrors the custom-topic path).
+	busName := h.ensureSystemTopicBus(source)
+	h.registerSystemTopicSubscription(busName, rp.SubResourceName, body.Properties)
 
 	azurearm.WriteJSON(w, http.StatusCreated, out)
 }
@@ -107,7 +107,7 @@ func (h *Handler) getSystemTopicSubscription(w http.ResponseWriter, rp *azurearm
 	azurearm.WriteJSON(w, http.StatusOK, systemTopicSubscriptionJSON(rp, props))
 }
 
-func (h *Handler) deleteSystemTopicSubscription(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+func (h *Handler) deleteSystemTopicSubscription(w http.ResponseWriter, rp *azurearm.ResourcePath) {
 	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
 
 	h.mu.Lock()
@@ -122,7 +122,7 @@ func (h *Handler) deleteSystemTopicSubscription(w http.ResponseWriter, r *http.R
 	h.mu.Unlock()
 
 	// Drop the delivery rule so the deleted subscription stops receiving events.
-	h.unregisterSystemTopicSubscription(r.Context(), systemTopicBusName(source), rp.SubResourceName)
+	h.unregisterSystemTopicSubscription(systemTopicBusName(source), rp.SubResourceName)
 
 	// The SDK's BeginDelete LRO completes on a 200 first response.
 	w.WriteHeader(http.StatusOK)

--- a/server/azure/eventgrid/system_topics.go
+++ b/server/azure/eventgrid/system_topics.go
@@ -2,7 +2,9 @@ package eventgrid
 
 import (
 	"encoding/json"
+	"maps"
 	"net/http"
+	"slices"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 )
@@ -111,7 +113,7 @@ func (h *Handler) serveSystemTopicResource(w http.ResponseWriter, r *http.Reques
 	case http.MethodGet:
 		h.getSystemTopic(w, rp)
 	case http.MethodDelete:
-		h.deleteSystemTopic(w, rp)
+		h.deleteSystemTopic(w, r, rp)
 	default:
 		writeMethodNotAllowed(w)
 	}
@@ -152,7 +154,13 @@ func (h *Handler) createOrUpdateSystemTopic(w http.ResponseWriter, r *http.Reque
 	}
 
 	out := rec.toJSON(rp)
+	source := rec.source
 	h.mu.Unlock()
+
+	// Provision the internal delivery bus keyed by the source now, so the source
+	// producer's PutEvents has a bus to match even before any subscription — and
+	// so a subscription created next registers its rule against it.
+	h.ensureSystemTopicBus(r.Context(), source)
 
 	// 201 with a terminal provisioningState completes the SDK's LRO poller on
 	// the first response.
@@ -218,13 +226,32 @@ func (h *Handler) getSystemTopic(w http.ResponseWriter, rp *azurearm.ResourcePat
 	azurearm.WriteJSON(w, http.StatusOK, out)
 }
 
-func (h *Handler) deleteSystemTopic(w http.ResponseWriter, rp *azurearm.ResourcePath) {
+func (h *Handler) deleteSystemTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
 
 	h.mu.Lock()
-	_, found := h.systemTopics[key]
+
+	rec, found := h.systemTopics[key]
+
+	var (
+		source   string
+		subNames []string
+	)
+
+	if found {
+		source = rec.source
+		subNames = slices.Collect(maps.Keys(rec.subscriptions))
+	}
+
 	delete(h.systemTopics, key)
 	h.mu.Unlock()
+
+	// Remove this system topic's delivery rules (the bus may be shared with
+	// another system topic on the same source, so drop rules, not the bus).
+	busName := systemTopicBusName(source)
+	for _, name := range subNames {
+		h.unregisterSystemTopicSubscription(r.Context(), busName, name)
+	}
 
 	if !found {
 		// ARM delete is idempotent: a delete of a missing resource completes 204.

--- a/server/azure/eventgrid/system_topics.go
+++ b/server/azure/eventgrid/system_topics.go
@@ -113,7 +113,7 @@ func (h *Handler) serveSystemTopicResource(w http.ResponseWriter, r *http.Reques
 	case http.MethodGet:
 		h.getSystemTopic(w, rp)
 	case http.MethodDelete:
-		h.deleteSystemTopic(w, r, rp)
+		h.deleteSystemTopic(w, rp)
 	default:
 		writeMethodNotAllowed(w)
 	}
@@ -157,10 +157,10 @@ func (h *Handler) createOrUpdateSystemTopic(w http.ResponseWriter, r *http.Reque
 	source := rec.source
 	h.mu.Unlock()
 
-	// Provision the internal delivery bus keyed by the source now, so the source
+	// Provision the isolated delivery bus keyed by the source now, so the source
 	// producer's PutEvents has a bus to match even before any subscription — and
 	// so a subscription created next registers its rule against it.
-	h.ensureSystemTopicBus(r.Context(), source)
+	h.ensureSystemTopicBus(source)
 
 	// 201 with a terminal provisioningState completes the SDK's LRO poller on
 	// the first response.
@@ -226,7 +226,7 @@ func (h *Handler) getSystemTopic(w http.ResponseWriter, rp *azurearm.ResourcePat
 	azurearm.WriteJSON(w, http.StatusOK, out)
 }
 
-func (h *Handler) deleteSystemTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+func (h *Handler) deleteSystemTopic(w http.ResponseWriter, rp *azurearm.ResourcePath) {
 	key := storeKey(rp.Subscription, rp.ResourceGroup, rp.ResourceName)
 
 	h.mu.Lock()
@@ -250,7 +250,7 @@ func (h *Handler) deleteSystemTopic(w http.ResponseWriter, r *http.Request, rp *
 	// another system topic on the same source, so drop rules, not the bus).
 	busName := systemTopicBusName(source)
 	for _, name := range subNames {
-		h.unregisterSystemTopicSubscription(r.Context(), busName, name)
+		h.unregisterSystemTopicSubscription(busName, name)
 	}
 
 	if !found {


### PR DESCRIPTION
## Summary

Completes the Azure Blob Storage -> Event Grid path for **real HTTP users**. The producer (#804) emits `Microsoft.Storage.Blob{Created,Deleted}` events into Event Grid, and delivery to WebHook/ServiceBus/Function (#800) works for rule-registered subscriptions. The gap: a system-topic event subscription created over the **real ARM HTTP surface** was only stored as raw JSON in the wire handler's own map and never registered as an Event Grid delivery **rule**, so `PutEvents` had nothing to match and real-HTTP e2e never delivered.

This bridges the wire surface to the delivery path, mirroring the custom-topic event-subscription path exactly.

## What changed

- **`server/azure/eventgrid/system_topic_delivery.go`** (new): the bridge.
  - `createOrUpdateSystemTopic` provisions an internal Event Grid **delivery bus** keyed by the system topic's source leaf.
  - `createOrUpdateSystemTopicSubscription` registers the subscription as a rule (`bus.PutRule`) on that bus, carrying the raw ARM properties (destination + filter) verbatim — the same call the custom-topic path uses.
  - Subscription DELETE removes the rule; system-topic DELETE removes all its rules.
- **`operations.go`**: the delivery bus is created under a sentinel scope so it never leaks into `Microsoft.EventGrid/topics` list results; `getTopic`/`deleteTopic` also treat a name-colliding delivery bus as absent, keeping the custom-topic surface honest.

## Key reconciliation

The Blob producer publishes each event with `EventBus = <storage account name>` (`"cloudemu"`), which is the leaf of the account ARM id it also stamps on `event.Topic`/`Source`. `PutEvents` matches rules on the bus named by `event.EventBus`. So the delivery rule must live on a bus named by that same leaf. The wire handler derives the bus name as the **trailing segment of the system topic's `source`** (the storage account ARM id) — which equals the producer's `EventBus` key. Producer and rule therefore share one key with no change to the producer.

## Tests

New full real-user HTTP e2e (`system_topic_blob_e2e_test.go`) — real `armeventgrid` ARM SDK + real `azblob` SDK over one `httptest` server backed by one provider:
- (a) system topic + WebHook subscription over ARM -> blob PUT over HTTP -> receiver gets `BlobCreated` (with correct subject + storage-account topic).
- (b) ServiceBusQueue subscription -> blob event lands in the peer queue.
- (c) `includedEventTypes` filter drops a non-matching `BlobCreated`, then delivers the later `BlobDeleted`.
- (d) delete subscription over ARM -> no further delivery.
- (e) no regression: existing custom-topic + #800/#804 provider tests pass.