### PR TITLE
fix(gcp-eventarc): dispatch matching triggers to their Cloud Run/Function destinations

### DIFF
--- a/providers/gcp/eventarc/dispatch.go
+++ b/providers/gcp/eventarc/dispatch.go
@@ -1,0 +1,312 @@
+package eventarc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	crdriver "github.com/stackshy/cloudemu/v2/services/cloudrun/driver"
+	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	sdrv "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// cloudRunDeliveryTimeout bounds how long a single Cloud Run destination
+// delivery waits before the CloudEvent POST is abandoned, so an unreachable
+// *.run.app URL can never hang a PutEvents call.
+const cloudRunDeliveryTimeout = 10 * time.Second
+
+// destinationTargetID mirrors the id the server/gcp/eventarc handler folds a
+// trigger's destination under on the driver rule. Keep the two in sync.
+const destinationTargetID = "destination"
+
+// cloudEventSpecVersion is the CloudEvents spec version Eventarc delivers with.
+const cloudEventSpecVersion = "1.0"
+
+// FunctionInvoker invokes a Cloud Function by its (short) name with the
+// CloudEvent payload. The cloudfunctions.Mock satisfies this via Invoke, so a
+// trigger whose destination is a Cloud Function fires the function on a matching
+// event — mirroring the Pub/Sub -> Cloud Functions delivery wired in #803.
+type FunctionInvoker interface {
+	Invoke(ctx context.Context, input sdrv.InvokeInput) (*sdrv.InvokeOutput, error)
+}
+
+// CloudRunResolver resolves a Cloud Run service by name so its serving URL can
+// be looked up for HTTP delivery. The cloudrun.Mock satisfies this via
+// GetService. Cloud Run has no in-process invoke seam (it models CRUD only), so
+// a Cloud Run destination is delivered to over HTTP at the service's URL.
+type CloudRunResolver interface {
+	GetService(ctx context.Context, name string) (*crdriver.Service, error)
+}
+
+// cloudRunDestination is the Cloud Run subset of a trigger destination.
+type cloudRunDestination struct {
+	Service string `json:"service,omitempty"`
+	Region  string `json:"region,omitempty"`
+	Path    string `json:"path,omitempty"`
+}
+
+// triggerDestination is the parsed form of the Eventarc destination the server
+// handler serializes into the driver Target's Input. It intentionally mirrors
+// server/gcp/eventarc.destinationJSON — the two packages can't share a type
+// (provider must not import server), so the wire-compatible subset is redefined
+// here.
+type triggerDestination struct {
+	CloudRun      *cloudRunDestination `json:"cloudRun,omitempty"`
+	CloudFunction string               `json:"cloudFunction,omitempty"`
+	Workflow      string               `json:"workflow,omitempty"`
+}
+
+// eventFilter is the Eventarc EventFilter shape the server handler serializes
+// into the driver rule's EventPattern (a JSON array). Redefined here for the
+// same reason as triggerDestination.
+type eventFilter struct {
+	Attribute string `json:"attribute,omitempty"`
+	Operator  string `json:"operator,omitempty"`
+	Value     string `json:"value,omitempty"`
+}
+
+// cloudEventEnvelope is the structured-mode CloudEvents 1.0 JSON delivered to a
+// trigger destination. Real Eventarc delivers gen2/Cloud Run destinations a
+// binary-mode HTTP request, but structured JSON carries the same attributes and
+// is what this mock delivers to both destination kinds.
+type cloudEventEnvelope struct {
+	SpecVersion string          `json:"specversion"`
+	ID          string          `json:"id"`
+	Source      string          `json:"source,omitempty"`
+	Type        string          `json:"type,omitempty"`
+	Subject     string          `json:"subject,omitempty"`
+	Time        string          `json:"time,omitempty"`
+	Data        json.RawMessage `json:"data,omitempty"`
+}
+
+// dispatchEvent delivers a stored event to every ENABLED trigger on the same
+// bus whose eventFilters match it. Best-effort: a nil peer, an unparseable
+// destination, or a failing delivery is swallowed so a publish never fails.
+func (m *Mock) dispatchEvent(ctx context.Context, bd *busData, event *ebdriver.Event) {
+	if m.functions == nil && m.cloudRun == nil {
+		return
+	}
+
+	var body []byte
+
+	for _, rd := range bd.rules.All() {
+		if rd.rule.State != defaultTriggerState {
+			continue
+		}
+
+		if !eventMatchesFilters(event, decodeFilters(rd.rule.EventPattern)) {
+			continue
+		}
+
+		dest := decodeDestination(rd.rule.Targets)
+		if dest == nil {
+			continue
+		}
+
+		if body == nil {
+			body = renderCloudEvent(event)
+		}
+
+		m.dispatchDestination(ctx, dest, body)
+	}
+}
+
+// dispatchDestination routes one rendered CloudEvent to a single trigger
+// destination. A nil peer is skipped gracefully.
+func (m *Mock) dispatchDestination(ctx context.Context, dest *triggerDestination, body []byte) {
+	switch {
+	case dest.CloudFunction != "":
+		if m.functions == nil {
+			return
+		}
+
+		name := lastSegment(dest.CloudFunction)
+		if name == "" {
+			return
+		}
+
+		_, _ = m.functions.Invoke(ctx, sdrv.InvokeInput{
+			FunctionName: name,
+			Payload:      body,
+			InvokeType:   "Event",
+		})
+	case dest.CloudRun != nil && dest.CloudRun.Service != "":
+		m.deliverCloudRun(ctx, dest.CloudRun, body)
+	}
+}
+
+// deliverCloudRun resolves the Cloud Run service's serving URL and POSTs the
+// CloudEvent to it (best-effort, bounded). Cloud Run models CRUD only, so
+// delivery is over HTTP at the service URL rather than an in-process invoke.
+func (m *Mock) deliverCloudRun(ctx context.Context, dest *cloudRunDestination, body []byte) {
+	if m.cloudRun == nil {
+		return
+	}
+
+	svc, err := m.cloudRun.GetService(ctx, dest.Service)
+	if err != nil || svc == nil || svc.URI == "" {
+		return
+	}
+
+	url := svc.URI + normalizePath(dest.Path)
+
+	reqCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cloudRunDeliveryTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/cloudevents+json; charset=utf-8")
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+}
+
+// renderCloudEvent builds the structured CloudEvents 1.0 envelope delivered to a
+// destination.
+func renderCloudEvent(event *ebdriver.Event) []byte {
+	env := cloudEventEnvelope{
+		SpecVersion: cloudEventSpecVersion,
+		ID:          event.ID,
+		Source:      event.Source,
+		Type:        event.DetailType,
+		Subject:     event.Subject,
+	}
+
+	if !event.Time.IsZero() {
+		env.Time = event.Time.UTC().Format(time.RFC3339Nano)
+	}
+
+	if event.Detail != "" && json.Valid([]byte(event.Detail)) {
+		env.Data = json.RawMessage(event.Detail)
+	}
+
+	body, err := json.Marshal(env)
+	if err != nil {
+		return []byte("{}")
+	}
+
+	return body
+}
+
+// eventMatchesFilters reports whether the event satisfies every eventFilter
+// (AND semantics, matching real Eventarc). An empty filter set matches all
+// events.
+func eventMatchesFilters(event *ebdriver.Event, filters []eventFilter) bool {
+	for i := range filters {
+		if filters[i].Attribute == "" {
+			continue
+		}
+
+		got, ok := eventAttribute(event, filters[i].Attribute)
+		if !ok || got != filters[i].Value {
+			return false
+		}
+	}
+
+	return true
+}
+
+// eventAttribute resolves a CloudEvent attribute value from the event. The core
+// attributes come from the event's own fields; any other attribute is looked up
+// as a top-level string field of the event's data (Detail).
+func eventAttribute(event *ebdriver.Event, attr string) (string, bool) {
+	switch attr {
+	case "type":
+		return event.DetailType, event.DetailType != ""
+	case "source":
+		return event.Source, event.Source != ""
+	case "subject":
+		return event.Subject, event.Subject != ""
+	}
+
+	return detailStringField(event.Detail, attr)
+}
+
+// detailStringField extracts a top-level string field from a JSON object.
+func detailStringField(detail, key string) (string, bool) {
+	if detail == "" {
+		return "", false
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(detail), &obj); err != nil {
+		return "", false
+	}
+
+	if v, ok := obj[key].(string); ok {
+		return v, true
+	}
+
+	return "", false
+}
+
+// decodeFilters deserializes the trigger's eventFilters from the rule's
+// EventPattern. Returns nil when the pattern is empty or not the Eventarc
+// filter-array shape.
+func decodeFilters(pattern string) []eventFilter {
+	if pattern == "" {
+		return nil
+	}
+
+	var filters []eventFilter
+	if err := json.Unmarshal([]byte(pattern), &filters); err != nil {
+		return nil
+	}
+
+	return filters
+}
+
+// decodeDestination reconstructs a trigger's destination from the driver rule's
+// targets. Returns nil when no destination target is stored.
+func decodeDestination(targets []ebdriver.Target) *triggerDestination {
+	for i := range targets {
+		if targets[i].ID != destinationTargetID || targets[i].Input == "" {
+			continue
+		}
+
+		var dest triggerDestination
+		if err := json.Unmarshal([]byte(targets[i].Input), &dest); err != nil {
+			return nil
+		}
+
+		return &dest
+	}
+
+	return nil
+}
+
+// lastSegment returns the trailing path segment of a resource name (or the input
+// itself when it has no "/").
+func lastSegment(name string) string {
+	trimmed := strings.TrimRight(name, "/")
+	if i := strings.LastIndex(trimmed, "/"); i >= 0 {
+		return trimmed[i+1:]
+	}
+
+	return trimmed
+}
+
+// normalizePath ensures a destination path is a leading-slash suffix (or empty).
+func normalizePath(path string) string {
+	if path == "" || path == "/" {
+		return ""
+	}
+
+	if !strings.HasPrefix(path, "/") {
+		return "/" + path
+	}
+
+	return path
+}

--- a/providers/gcp/eventarc/dispatch_test.go
+++ b/providers/gcp/eventarc/dispatch_test.go
@@ -1,0 +1,234 @@
+package eventarc
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	crdriver "github.com/stackshy/cloudemu/v2/services/cloudrun/driver"
+	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	sdrv "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeFunctionInvoker records the invocations a dispatch drove.
+type fakeFunctionInvoker struct {
+	mu    sync.Mutex
+	calls []sdrv.InvokeInput
+}
+
+func (f *fakeFunctionInvoker) Invoke(_ context.Context, input sdrv.InvokeInput) (*sdrv.InvokeOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.calls = append(f.calls, input)
+
+	return &sdrv.InvokeOutput{StatusCode: 200}, nil
+}
+
+func (f *fakeFunctionInvoker) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return len(f.calls)
+}
+
+// fakeCloudRunResolver returns a fixed service (or a not-found error).
+type fakeCloudRunResolver struct {
+	svc *crdriver.Service
+}
+
+func (f *fakeCloudRunResolver) GetService(_ context.Context, name string) (*crdriver.Service, error) {
+	if f.svc == nil || lastSegment(name) != f.svc.Name {
+		return nil, assert.AnError
+	}
+
+	return f.svc, nil
+}
+
+const pubsubEventType = "google.cloud.pubsub.topic.v1.messagePublished"
+
+func typeFilterPattern(t *testing.T, eventType string) string {
+	t.Helper()
+
+	b, err := json.Marshal([]eventFilter{{Attribute: "type", Value: eventType}})
+	require.NoError(t, err)
+
+	return string(b)
+}
+
+func setTrigger(t *testing.T, m *Mock, channel, name, pattern string, dest *triggerDestination) {
+	t.Helper()
+
+	_, err := m.PutRule(context.Background(), &driver.RuleConfig{
+		Name:         name,
+		EventBus:     channel,
+		EventPattern: pattern,
+	})
+	require.NoError(t, err)
+
+	if dest != nil {
+		input, err := json.Marshal(dest)
+		require.NoError(t, err)
+
+		err = m.PutTargets(context.Background(), channel, name, []driver.Target{
+			{ID: destinationTargetID, Input: string(input)},
+		})
+		require.NoError(t, err)
+	}
+}
+
+func TestDispatchToCloudFunctionDestination(t *testing.T) {
+	m, _ := newTestMock()
+	fn := &fakeFunctionInvoker{}
+	m.SetFunctionInvoker(fn)
+
+	createTestChannel(t, m, "eventarc-us-central1")
+	setTrigger(t, m, "eventarc-us-central1", "trg", typeFilterPattern(t, pubsubEventType),
+		&triggerDestination{CloudFunction: "projects/p/locations/l/functions/my-fn"})
+
+	_, err := m.PutEvents(context.Background(), []driver.Event{{
+		EventBus:   "eventarc-us-central1",
+		Source:     "//pubsub.googleapis.com/projects/p/topics/t",
+		DetailType: pubsubEventType,
+		Detail:     `{"message":{"data":"aGVsbG8="}}`,
+	}})
+	require.NoError(t, err)
+
+	require.Equal(t, 1, fn.count())
+	call := fn.calls[0]
+	assert.Equal(t, "my-fn", call.FunctionName)
+	assert.Equal(t, "Event", call.InvokeType)
+
+	var env cloudEventEnvelope
+	require.NoError(t, json.Unmarshal(call.Payload, &env))
+	assert.Equal(t, cloudEventSpecVersion, env.SpecVersion)
+	assert.Equal(t, pubsubEventType, env.Type)
+	assert.NotEmpty(t, env.ID)
+	assert.JSONEq(t, `{"message":{"data":"aGVsbG8="}}`, string(env.Data))
+}
+
+func TestDispatchSkipsNonMatchingEvent(t *testing.T) {
+	m, _ := newTestMock()
+	fn := &fakeFunctionInvoker{}
+	m.SetFunctionInvoker(fn)
+
+	createTestChannel(t, m, "eventarc-us-central1")
+	setTrigger(t, m, "eventarc-us-central1", "trg", typeFilterPattern(t, pubsubEventType),
+		&triggerDestination{CloudFunction: "projects/p/locations/l/functions/my-fn"})
+
+	_, err := m.PutEvents(context.Background(), []driver.Event{{
+		EventBus:   "eventarc-us-central1",
+		DetailType: "google.cloud.storage.object.v1.finalized",
+	}})
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, fn.count())
+}
+
+func TestDispatchDisabledTriggerNotInvoked(t *testing.T) {
+	m, _ := newTestMock()
+	fn := &fakeFunctionInvoker{}
+	m.SetFunctionInvoker(fn)
+
+	createTestChannel(t, m, "eventarc-us-central1")
+	setTrigger(t, m, "eventarc-us-central1", "trg", typeFilterPattern(t, pubsubEventType),
+		&triggerDestination{CloudFunction: "projects/p/locations/l/functions/my-fn"})
+	require.NoError(t, m.DisableRule(context.Background(), "eventarc-us-central1", "trg"))
+
+	_, err := m.PutEvents(context.Background(), []driver.Event{{
+		EventBus:   "eventarc-us-central1",
+		DetailType: pubsubEventType,
+	}})
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, fn.count())
+}
+
+func TestDispatchToCloudRunDestination(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		gotBody  []byte
+		gotPath  string
+		received bool
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+
+		mu.Lock()
+		received = true
+		gotBody = body
+		gotPath = r.URL.Path
+		mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m, _ := newTestMock()
+	m.SetCloudRunInvoker(&fakeCloudRunResolver{svc: &crdriver.Service{Name: "my-svc", URI: srv.URL}})
+
+	createTestChannel(t, m, "eventarc-us-central1")
+	setTrigger(t, m, "eventarc-us-central1", "trg", typeFilterPattern(t, pubsubEventType),
+		&triggerDestination{CloudRun: &cloudRunDestination{Service: "my-svc", Path: "/events"}})
+
+	_, err := m.PutEvents(context.Background(), []driver.Event{{
+		EventBus:   "eventarc-us-central1",
+		DetailType: pubsubEventType,
+		Detail:     `{"k":"v"}`,
+	}})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.True(t, received, "cloud run endpoint should have received the event")
+	assert.Equal(t, "/events", gotPath)
+
+	var env cloudEventEnvelope
+	require.NoError(t, json.Unmarshal(gotBody, &env))
+	assert.Equal(t, pubsubEventType, env.Type)
+}
+
+func TestDispatchNilPeersNoPanicStillStores(t *testing.T) {
+	m, _ := newTestMock() // no SetFunctionInvoker / SetCloudRunInvoker
+
+	createTestChannel(t, m, "eventarc-us-central1")
+	setTrigger(t, m, "eventarc-us-central1", "trg", typeFilterPattern(t, pubsubEventType),
+		&triggerDestination{CloudFunction: "projects/p/locations/l/functions/my-fn"})
+
+	res, err := m.PutEvents(context.Background(), []driver.Event{{
+		EventBus:   "eventarc-us-central1",
+		DetailType: pubsubEventType,
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.SuccessCount)
+
+	history, err := m.GetEventHistory(context.Background(), "eventarc-us-central1", 0)
+	require.NoError(t, err)
+	assert.Len(t, history, 1)
+}
+
+func TestDispatchTriggerWithoutDestinationStores(t *testing.T) {
+	m, _ := newTestMock()
+	fn := &fakeFunctionInvoker{}
+	m.SetFunctionInvoker(fn)
+
+	createTestChannel(t, m, "eventarc-us-central1")
+	// Trigger with a matching filter but no destination target.
+	setTrigger(t, m, "eventarc-us-central1", "trg", typeFilterPattern(t, pubsubEventType), nil)
+
+	res, err := m.PutEvents(context.Background(), []driver.Event{{
+		EventBus:   "eventarc-us-central1",
+		DetailType: pubsubEventType,
+	}})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, res.SuccessCount)
+	assert.Equal(t, 0, fn.count())
+}

--- a/providers/gcp/eventarc/eventarc.go
+++ b/providers/gcp/eventarc/eventarc.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"net/http"
 	"sync"
 	"time"
 
@@ -44,11 +45,28 @@ type Mock struct {
 	buses      *memstore.Store[*busData]
 	opts       *config.Options
 	monitoring mondriver.Monitoring
+	functions  FunctionInvoker
+	cloudRun   CloudRunResolver
+	httpClient *http.Client
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
 func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
 	m.monitoring = mon
+}
+
+// SetFunctionInvoker wires the Cloud Functions backend so a matching PutEvents
+// invokes every trigger whose destination is a Cloud Function. Nil (the default)
+// leaves Cloud Function delivery a graceful no-op.
+func (m *Mock) SetFunctionInvoker(fi FunctionInvoker) {
+	m.functions = fi
+}
+
+// SetCloudRunInvoker wires the Cloud Run backend so a matching PutEvents delivers
+// the CloudEvent over HTTP to every trigger whose destination is a Cloud Run
+// service. Nil (the default) leaves Cloud Run delivery a graceful no-op.
+func (m *Mock) SetCloudRunInvoker(r CloudRunResolver) {
+	m.cloudRun = r
 }
 
 func (m *Mock) emitMetric(ctx context.Context, metricName string, value float64, dims map[string]string) {
@@ -71,8 +89,9 @@ func (m *Mock) emitMetric(ctx context.Context, metricName string, value float64,
 // New creates a new Eventarc mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		buses: memstore.New[*busData](),
-		opts:  opts,
+		buses:      memstore.New[*busData](),
+		opts:       opts,
+		httpClient: &http.Client{Timeout: cloudRunDeliveryTimeout},
 	}
 }
 
@@ -397,6 +416,7 @@ func (m *Mock) PutEvents(ctx context.Context, events []driver.Event) (*driver.Pu
 		}
 
 		m.storeEvent(bd, &events[i])
+		m.dispatchEvent(ctx, bd, &events[i])
 
 		result.SuccessCount++
 		result.EventIDs = append(result.EventIDs, eventID)

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -135,6 +135,11 @@ func New(opts ...config.Option) *Provider {
 	p.FCM.SetMonitoring(p.CloudMonitoring)
 	p.ArtifactRegistry.SetMonitoring(p.CloudMonitoring)
 	p.Eventarc.SetMonitoring(p.CloudMonitoring)
+	// Eventarc -> destinations: a matching published event fires the trigger's
+	// Cloud Function (in-process Invoke) or Cloud Run service (HTTP delivery at
+	// the service URL), mirroring the Pub/Sub -> Cloud Functions wiring.
+	p.Eventarc.SetFunctionInvoker(p.CloudFunctions)
+	p.Eventarc.SetCloudRunInvoker(p.CloudRun)
 	p.CloudSQL.SetMonitoring(p.CloudMonitoring)
 	p.AlloyDB.SetMonitoring(p.CloudMonitoring)
 	p.GKE.SetMonitoring(p.CloudMonitoring)


### PR DESCRIPTION
## Summary

An Eventarc trigger's destination was never invoked: `PutEvents` only stored the event, so a trigger with a Cloud Run / Cloud Functions `destination` round-tripped through CRUD but was inert (silent no-op). This wires `PutEvents` to dispatch each published CloudEvent to every matching trigger's destination, mirroring the Pub/Sub -> Cloud Functions invocation (#803) and the Azure EventGrid -> Function delivery (#800).

## What changed

- `providers/gcp/eventarc/dispatch.go` (new): on `PutEvents`, match each stored event against every ENABLED trigger's `eventFilters` (AND over attributes; `type`/`source`/`subject` resolved from the event, other attributes from its data) and dispatch a structured CloudEvents 1.0 envelope (`specversion`, `id`, `source`, `type`, `subject`, `time`, `data`) to the trigger's destination:
  - **Cloud Function**: reuse the in-process `cloudfunctions.Mock.Invoke` seam (the same choke point #803 used) with `InvokeType: Event`.
  - **Cloud Run**: Cloud Run models CRUD only (no invoke seam), so resolve the service's serving URL via `GetService` and POST the CloudEvent over HTTP (best-effort, bounded 10s timeout).
- `providers/gcp/eventarc/eventarc.go`: peer fields + `SetFunctionInvoker` / `SetCloudRunInvoker` injectors; `PutEvents` calls `dispatchEvent`. Nil peers skip gracefully.
- `providers/gcp/gcp.go`: wire `p.Eventarc.SetFunctionInvoker(p.CloudFunctions)` and `p.Eventarc.SetCloudRunInvoker(p.CloudRun)`.

## Tests

`providers/gcp/eventarc/dispatch_test.go`: Cloud Function destination invoked with the CloudEvent; non-matching filter not dispatched; disabled trigger not invoked; Cloud Run destination delivered over HTTP (httptest); nil peers / no-destination trigger cause no panic and still store the event.

## Gates

build, vet, gofmt, golangci-lint (0 new) all green; targeted eventarc/cloudfunctions/cloudrun tests, `TestWiringParity`, `TestRealWorld`, and full `./providers/gcp/...` pass. `go generate ./...` produced no diff.