### PR TITLE
fix(gcp-gcs): persist notification configs, version history, and generation counters in snapshots

### DIFF
--- a/providers/gcp/gcs/snapshot.go
+++ b/providers/gcp/gcs/snapshot.go
@@ -13,28 +13,34 @@ import (
 var _ snapshot.Snapshottable = (*Mock)(nil)
 
 // gcsSnapshot is the full serialized state of the GCS mock: every bucket keyed
-// by name with its metadata, configuration sub-resources, and current objects.
-// In-progress multipart uploads are transient and intentionally not captured.
+// by name with its metadata, configuration sub-resources, and current objects,
+// plus the mock-level object-generation and notification-id counters so a
+// restore keeps minting past the restored maxima. In-progress multipart uploads
+// are transient and intentionally not captured.
 type gcsSnapshot struct {
-	Buckets map[string]*bucketSnapshot `json:"buckets,omitempty"`
+	Buckets  map[string]*bucketSnapshot `json:"buckets,omitempty"`
+	Gen      int64                      `json:"gen,omitempty"`
+	NotifGen int64                      `json:"notifGen,omitempty"`
 }
 
 type bucketSnapshot struct {
-	Name           string                     `json:"name"`
-	Region         string                     `json:"region,omitempty"`
-	CreatedAt      string                     `json:"createdAt,omitempty"`
-	Versioning     bool                       `json:"versioning,omitempty"`
-	Lifecycle      *driver.LifecycleConfig    `json:"lifecycle,omitempty"`
-	Policy         *driver.BucketPolicy       `json:"policy,omitempty"`
-	CORS           *driver.CORSConfig         `json:"cors,omitempty"`
-	Encryption     *driver.EncryptionConfig   `json:"encryption,omitempty"`
-	Tags           map[string]string          `json:"tags,omitempty"`
-	Location       string                     `json:"location,omitempty"`
-	StorageClass   string                     `json:"storageClass,omitempty"`
-	Metageneration int64                      `json:"metageneration,omitempty"`
-	Updated        string                     `json:"updated,omitempty"`
-	IAMPolicy      []byte                     `json:"iamPolicy,omitempty"`
-	Objects        map[string]*objectSnapshot `json:"objects,omitempty"`
+	Name           string                                  `json:"name"`
+	Region         string                                  `json:"region,omitempty"`
+	CreatedAt      string                                  `json:"createdAt,omitempty"`
+	Versioning     bool                                    `json:"versioning,omitempty"`
+	Lifecycle      *driver.LifecycleConfig                 `json:"lifecycle,omitempty"`
+	Policy         *driver.BucketPolicy                    `json:"policy,omitempty"`
+	CORS           *driver.CORSConfig                      `json:"cors,omitempty"`
+	Encryption     *driver.EncryptionConfig                `json:"encryption,omitempty"`
+	Tags           map[string]string                       `json:"tags,omitempty"`
+	Location       string                                  `json:"location,omitempty"`
+	StorageClass   string                                  `json:"storageClass,omitempty"`
+	Metageneration int64                                   `json:"metageneration,omitempty"`
+	Updated        string                                  `json:"updated,omitempty"`
+	IAMPolicy      []byte                                  `json:"iamPolicy,omitempty"`
+	Objects        map[string]*objectSnapshot              `json:"objects,omitempty"`
+	Versions       map[string][]*objectSnapshot            `json:"versions,omitempty"`
+	Notifications  map[string]driver.GCSNotificationConfig `json:"notifications,omitempty"`
 }
 
 // objectSnapshot mirrors gcsObject (all exported already), but Data is dropped
@@ -47,6 +53,7 @@ type objectSnapshot struct {
 	ContentType        string            `json:"contentType,omitempty"`
 	ETag               string            `json:"etag,omitempty"`
 	LastModified       string            `json:"lastModified,omitempty"`
+	Created            string            `json:"created,omitempty"`
 	Metadata           map[string]string `json:"metadata,omitempty"`
 	Tags               map[string]string `json:"tags,omitempty"`
 	Generation         int64             `json:"generation,omitempty"`
@@ -63,7 +70,11 @@ type objectSnapshot struct {
 // Snapshot captures every bucket's state as JSON. When includeAssets is false
 // the object bytes are omitted (metadata-only).
 func (m *Mock) Snapshot(_ context.Context, includeAssets bool) (json.RawMessage, error) {
-	snap := gcsSnapshot{Buckets: make(map[string]*bucketSnapshot, m.buckets.Len())}
+	snap := gcsSnapshot{
+		Buckets:  make(map[string]*bucketSnapshot, m.buckets.Len()),
+		Gen:      m.gen.Load(),
+		NotifGen: m.notifGen.Load(),
+	}
 
 	for name, bkt := range m.buckets.All() {
 		snap.Buckets[name] = snapshotBucket(bkt, includeAssets)
@@ -83,18 +94,55 @@ func snapshotBucket(bkt *bucketMeta, includeAssets bool) *bucketSnapshot {
 	}
 
 	for key, obj := range bkt.objects.All() {
-		bs.Objects[key] = &objectSnapshot{
-			Key: obj.Key, Data: assetBytes(obj.Data, includeAssets), Size: obj.Size,
-			ContentType: obj.ContentType, ETag: obj.ETag, LastModified: obj.LastModified,
-			Metadata: obj.Metadata, Tags: obj.Tags,
-			Generation: obj.Generation, Metageneration: obj.Metageneration,
-			MD5: obj.MD5, CRC32C: obj.CRC32C, CacheControl: obj.CacheControl,
-			ContentEncoding: obj.ContentEncoding, ContentDisposition: obj.ContentDisposition,
-			ContentLanguage: obj.ContentLanguage, StorageClass: obj.StorageClass,
+		bs.Objects[key] = objectToSnapshot(obj, includeAssets)
+	}
+
+	snapshotBucketVersionsAndNotifications(bkt, bs, includeAssets)
+
+	return bs
+}
+
+// snapshotBucketVersionsAndNotifications captures the archived (noncurrent)
+// object generations and the bucket's Pub/Sub notification configs, both guarded
+// by bkt.mu.
+func snapshotBucketVersionsAndNotifications(bkt *bucketMeta, bs *bucketSnapshot, includeAssets bool) {
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	if len(bkt.versions) > 0 {
+		bs.Versions = make(map[string][]*objectSnapshot, len(bkt.versions))
+
+		for key, chain := range bkt.versions {
+			out := make([]*objectSnapshot, 0, len(chain))
+			for _, v := range chain {
+				out = append(out, objectToSnapshot(v, includeAssets))
+			}
+
+			bs.Versions[key] = out
 		}
 	}
 
-	return bs
+	if len(bkt.notifications) > 0 {
+		bs.Notifications = make(map[string]driver.GCSNotificationConfig, len(bkt.notifications))
+		for id, cfg := range bkt.notifications {
+			bs.Notifications[id] = cfg
+		}
+	}
+}
+
+// objectToSnapshot projects a stored gcsObject into its serializable form,
+// dropping the bytes for a metadata-only snapshot. Shared by the current-object
+// and archived-version paths so both carry identical fields.
+func objectToSnapshot(obj *gcsObject, includeAssets bool) *objectSnapshot {
+	return &objectSnapshot{
+		Key: obj.Key, Data: assetBytes(obj.Data, includeAssets), Size: obj.Size,
+		ContentType: obj.ContentType, ETag: obj.ETag, LastModified: obj.LastModified,
+		Created: obj.Created, Metadata: obj.Metadata, Tags: obj.Tags,
+		Generation: obj.Generation, Metageneration: obj.Metageneration,
+		MD5: obj.MD5, CRC32C: obj.CRC32C, CacheControl: obj.CacheControl,
+		ContentEncoding: obj.ContentEncoding, ContentDisposition: obj.ContentDisposition,
+		ContentLanguage: obj.ContentLanguage, StorageClass: obj.StorageClass,
+	}
 }
 
 // assetBytes returns data only when assets are included, so metadata-only
@@ -114,6 +162,9 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 	if err := json.Unmarshal(data, &snap); err != nil {
 		return fmt.Errorf("gcs: parse snapshot: %w", err)
 	}
+
+	m.gen.Store(snap.Gen)
+	m.notifGen.Store(snap.NotifGen)
 
 	for name, bs := range snap.Buckets {
 		m.buckets.Set(name, restoreBucket(bs))
@@ -137,19 +188,44 @@ func restoreBucket(bs *bucketSnapshot) *bucketMeta {
 		encryption: bs.Encryption, tags: bs.Tags,
 		location: bs.Location, storageClass: bs.StorageClass,
 		metageneration: metagen, updated: bs.Updated, iamPolicy: bs.IAMPolicy,
-		versions: make(map[string][]*gcsObject),
+		versions:      restoreVersions(bs.Versions),
+		notifications: bs.Notifications,
 	}
 
 	for key, os := range bs.Objects {
-		bkt.objects.Set(key, &gcsObject{
-			Key: os.Key, Data: os.Data, Size: os.Size, ContentType: os.ContentType,
-			ETag: os.ETag, LastModified: os.LastModified, Metadata: os.Metadata, Tags: os.Tags,
-			Generation: os.Generation, Metageneration: os.Metageneration,
-			MD5: os.MD5, CRC32C: os.CRC32C, CacheControl: os.CacheControl,
-			ContentEncoding: os.ContentEncoding, ContentDisposition: os.ContentDisposition,
-			ContentLanguage: os.ContentLanguage, StorageClass: os.StorageClass,
-		})
+		bkt.objects.Set(key, snapshotToObject(os))
 	}
 
 	return bkt
+}
+
+// restoreVersions rebuilds the archived (noncurrent) generation chains,
+// preserving order. An empty history yields a fresh, non-nil map so the write
+// path can append without a nil check.
+func restoreVersions(snap map[string][]*objectSnapshot) map[string][]*gcsObject {
+	versions := make(map[string][]*gcsObject, len(snap))
+
+	for key, chain := range snap {
+		out := make([]*gcsObject, 0, len(chain))
+		for _, os := range chain {
+			out = append(out, snapshotToObject(os))
+		}
+
+		versions[key] = out
+	}
+
+	return versions
+}
+
+// snapshotToObject reconstructs a stored gcsObject from its serialized form.
+func snapshotToObject(os *objectSnapshot) *gcsObject {
+	return &gcsObject{
+		Key: os.Key, Data: os.Data, Size: os.Size, ContentType: os.ContentType,
+		ETag: os.ETag, LastModified: os.LastModified, Created: os.Created,
+		Metadata: os.Metadata, Tags: os.Tags,
+		Generation: os.Generation, Metageneration: os.Metageneration,
+		MD5: os.MD5, CRC32C: os.CRC32C, CacheControl: os.CacheControl,
+		ContentEncoding: os.ContentEncoding, ContentDisposition: os.ContentDisposition,
+		ContentLanguage: os.ContentLanguage, StorageClass: os.StorageClass,
+	}
 }

--- a/providers/gcp/gcs/snapshot_test.go
+++ b/providers/gcp/gcs/snapshot_test.go
@@ -1,0 +1,115 @@
+package gcs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSnapshotRestoreNotificationsVersionsAndCounters is the regression guard for
+// the data-loss bug: notification configs, noncurrent version history, and the
+// generation/notification counters must all survive a Snapshot -> new Mock ->
+// Restore round-trip, and the counters must keep minting past the restored max.
+func TestSnapshotRestoreNotificationsVersionsAndCounters(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	const bucket = "b1"
+	require.NoError(t, src.CreateBucket(ctx, bucket))
+	require.NoError(t, src.SetBucketVersioning(ctx, bucket, true))
+
+	// Overwrite an object so the first generation is archived as noncurrent.
+	require.NoError(t, src.PutObject(ctx, bucket, "obj", []byte("v1"), "text/plain", nil))
+	require.NoError(t, src.PutObject(ctx, bucket, "obj", []byte("v2"), "text/plain", nil))
+
+	notif, err := src.CreateNotificationConfig(ctx, bucket, &driver.GCSNotificationConfig{
+		Topic:         "projects/p/topics/t",
+		PayloadFormat: "JSON_API_V1",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, notif.ID)
+
+	// Capture the live generation so we can assert the counter advances past it.
+	live, err := src.HeadObject(ctx, bucket, "obj")
+	require.NoError(t, err)
+	maxGen := live.Generation
+
+	data, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst := newTestMock()
+	require.NoError(t, dst.Restore(ctx, data))
+
+	// 1. Notification config present after restore.
+	notifs, err := dst.ListNotificationConfigs(ctx, bucket)
+	require.NoError(t, err)
+	require.Len(t, notifs, 1)
+	assert.Equal(t, notif.ID, notifs[0].ID)
+	assert.Equal(t, "projects/p/topics/t", notifs[0].Topic)
+
+	got, err := dst.GetNotificationConfig(ctx, bucket, notif.ID)
+	require.NoError(t, err)
+	assert.Equal(t, notif.Topic, got.Topic)
+
+	// 2. Noncurrent version present after restore (v1 archived + v2 live = 2).
+	versioned, err := dst.ListObjectGenerations(ctx, bucket, driver.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, versioned.Objects, 2)
+
+	archived, err := dst.GetObjectGCS(ctx, bucket, "obj", ptrInt64(maxGen-1))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("v1"), archived.Data)
+
+	// 3. Generation counter continues monotonically: the next write mints a
+	// generation strictly greater than every restored generation.
+	require.NoError(t, dst.PutObject(ctx, bucket, "obj", []byte("v3"), "text/plain", nil))
+	after, err := dst.HeadObject(ctx, bucket, "obj")
+	require.NoError(t, err)
+	assert.Greater(t, after.Generation, maxGen, "next generation must exceed the restored max")
+
+	// 4. Notification id counter continues: the next config gets a fresh,
+	// non-colliding id.
+	notif2, err := dst.CreateNotificationConfig(ctx, bucket, &driver.GCSNotificationConfig{
+		Topic:         "projects/p/topics/t2",
+		PayloadFormat: "JSON_API_V1",
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, notif.ID, notif2.ID, "next notification id must not collide with the restored one")
+
+	list2, err := dst.ListNotificationConfigs(ctx, bucket)
+	require.NoError(t, err)
+	assert.Len(t, list2, 2)
+}
+
+// TestSnapshotRestoreEmptyBucketNilSafe confirms a bucket with no versions and no
+// notifications round-trips cleanly (nil maps must not panic).
+func TestSnapshotRestoreEmptyBucketNilSafe(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	require.NoError(t, src.CreateBucket(ctx, "plain"))
+	require.NoError(t, src.PutObject(ctx, "plain", "k", []byte("data"), "text/plain", nil))
+
+	data, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst := newTestMock()
+	require.NoError(t, dst.Restore(ctx, data))
+
+	obj, err := dst.GetObject(ctx, "plain", "k")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data"), obj.Data)
+
+	notifs, err := dst.ListNotificationConfigs(ctx, "plain")
+	require.NoError(t, err)
+	assert.Empty(t, notifs)
+
+	versioned, err := dst.ListObjectGenerations(ctx, "plain", driver.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, versioned.Objects, 1)
+}
+
+func ptrInt64(v int64) *int64 { return &v }


### PR DESCRIPTION
## Summary

Fixes a HIGH-severity persistence data-loss bug in the GCS mock's snapshot/restore. Three pieces of live state were silently dropped on a `Snapshot -> Restore` round-trip. AWS S3 (`providers/aws/s3/snapshot.go`) captures all the analogous fields; GCS was the outlier, so this mirrors S3.

### Dropped on restore before this fix
1. **Notification configs** (`bucketMeta.notifications`) — Pub/Sub notification configs added by `CreateNotificationConfig` were never captured, so a restored bucket returned `nil` and silently stopped emitting object events.
2. **Object version history** (`bucketMeta.versions`) — archived noncurrent generations were re-initialized empty on restore, losing all version history.
3. **Generation counters** (`Mock.gen`, `Mock.notifGen`) — not part of the snapshot; both reset to 0 on restore, so the next `PutObject` / `CreateNotificationConfig` minted id 1, colliding with restored resources.

### Fix
- Added `Versions` and `Notifications` to `bucketSnapshot`; populate in `snapshotBucket` (under `bkt.mu`) and restore in `restoreBucket` instead of re-initializing empty.
- Added `Gen` and `NotifGen` to the top-level `gcsSnapshot`; capture via `.Load()` and restore via `.Store()` so the next mint continues monotonically past the restored maxima — matching how S3 restores its `eventSeq` counter.
- Factored shared `objectToSnapshot` / `snapshotToObject` helpers so archived versions serialize with the exact same fields as current objects (a restored noncurrent version is byte-identical).

### Tests
- Round-trip: versioning + overwrite (noncurrent version) + notification config -> Snapshot -> new Mock -> Restore, asserting the notification config, the noncurrent version, and monotonic continuation of both counters.
- Empty bucket (no versions/notifications) round-trips nil-safe.
- Confirmed the round-trip test **fails without the fix** (notifications drop to 0).

Gates: build, vet, `go test ./providers/gcp/gcs/... ./server/gcp/gcs/... ./persist/...`, gofmt, compatgen (exit 0, zero diff), `go generate` (zero diff), golangci-lint `--new-from-rev` 0 new issues.
