### PR TITLE
fix(gcp-gce): model instance external-IP accessConfigs/natIP + reserved-address IN_USE lifecycle

### DIFF
--- a/server/gcp/compute/external_ip_sdk_test.go
+++ b/server/gcp/compute/external_ip_sdk_test.go
@@ -1,0 +1,314 @@
+package compute_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// testRegion is the region enclosing testZone; reserved addresses are regional.
+const testRegion = "us-central1"
+
+// newGCPServerWithNet builds an in-process GCP server backed by a fresh GCP
+// cloud with both compute and networking wired, so instances and reserved
+// addresses share one backend — the setup the external-IP linkage needs.
+func newGCPServerWithNet(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Compute: cloudP.GCE, Networking: cloudP.VPC})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+func newAddressesSDKClient(t *testing.T, ts *httptest.Server) *gcpcompute.AddressesClient {
+	t.Helper()
+
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewAddressesRESTClient(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewAddressesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+// reserveAddress reserves a regional address and returns its allocated IP.
+func reserveAddress(t *testing.T, c *gcpcompute.AddressesClient, name string) string {
+	t.Helper()
+
+	ctx := context.Background()
+
+	op, err := c.Insert(ctx, &computepb.InsertAddressRequest{
+		Project: testProject, Region: testRegion,
+		AddressResource: &computepb.Address{Name: ptrStr(name)},
+	})
+	if err != nil {
+		t.Fatalf("address Insert: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("address Insert wait: %v", err)
+	}
+
+	got, err := c.Get(ctx, &computepb.GetAddressRequest{
+		Project: testProject, Region: testRegion, Address: name,
+	})
+	if err != nil {
+		t.Fatalf("address Get: %v", err)
+	}
+
+	if got.GetAddress() == "" {
+		t.Fatalf("reserved address %s has no allocated IP", name)
+	}
+
+	return got.GetAddress()
+}
+
+// insertInstanceWithAccessConfig creates an instance whose nic0 carries a single
+// accessConfig. natIP is set only when non-empty (a reserved address); an empty
+// natIP exercises the ephemeral-IP synthesis path.
+func insertInstanceWithAccessConfig(t *testing.T, c *gcpcompute.InstancesClient, name, natIP string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	ac := &computepb.AccessConfig{}
+	if natIP != "" {
+		ac.NatIP = ptrStr(natIP)
+	}
+
+	op, err := c.Insert(ctx, &computepb.InsertInstanceRequest{
+		Project: testProject, Zone: testZone,
+		InstanceResource: &computepb.Instance{
+			Name:        ptrStr(name),
+			MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+			NetworkInterfaces: []*computepb.NetworkInterface{{
+				Network:       ptrStr("global/networks/default"),
+				AccessConfigs: []*computepb.AccessConfig{ac},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("instance Insert: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("instance Insert wait: %v", err)
+	}
+}
+
+func firstAccessConfig(t *testing.T, inst *computepb.Instance) *computepb.AccessConfig {
+	t.Helper()
+
+	if len(inst.GetNetworkInterfaces()) == 0 {
+		t.Fatalf("instance %s has no networkInterfaces", inst.GetName())
+	}
+
+	acs := inst.GetNetworkInterfaces()[0].GetAccessConfigs()
+	if len(acs) == 0 {
+		t.Fatalf("instance %s nic0 has no accessConfigs", inst.GetName())
+	}
+
+	return acs[0]
+}
+
+// TestSDKReservedAddressReflectedAndInUse proves an accessConfig natIP pointing
+// at a reserved address round-trips on the instance and flips that address to
+// IN_USE with users[] naming the instance (test a).
+func TestSDKReservedAddressReflectedAndInUse(t *testing.T) {
+	ts := newGCPServerWithNet(t)
+	instances := newSDKInstancesClient(t, ts)
+	addresses := newAddressesSDKClient(t, ts)
+	ctx := context.Background()
+
+	ip := reserveAddress(t, addresses, "web-ip")
+	insertInstanceWithAccessConfig(t, instances, "web-vm", ip)
+
+	inst, err := instances.Get(ctx, &computepb.GetInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "web-vm",
+	})
+	if err != nil {
+		t.Fatalf("instance Get: %v", err)
+	}
+
+	ac := firstAccessConfig(t, inst)
+	if ac.GetNatIP() != ip {
+		t.Errorf("accessConfig natIP=%q want %q", ac.GetNatIP(), ip)
+	}
+
+	if ac.GetType() != "ONE_TO_ONE_NAT" {
+		t.Errorf("accessConfig type=%q want ONE_TO_ONE_NAT", ac.GetType())
+	}
+
+	if ac.GetName() != "External NAT" {
+		t.Errorf("accessConfig name=%q want External NAT", ac.GetName())
+	}
+
+	addr, err := addresses.Get(ctx, &computepb.GetAddressRequest{
+		Project: testProject, Region: testRegion, Address: "web-ip",
+	})
+	if err != nil {
+		t.Fatalf("address Get: %v", err)
+	}
+
+	if addr.GetStatus() != "IN_USE" {
+		t.Errorf("address status=%q want IN_USE", addr.GetStatus())
+	}
+
+	users := addr.GetUsers()
+	if len(users) == 0 || !strings.HasSuffix(users[0], "/instances/web-vm") {
+		t.Errorf("address users=%v want one ending /instances/web-vm", users)
+	}
+}
+
+// TestSDKEphemeralExternalIPSynthesized proves an accessConfig with no natIP
+// gets an ephemeral external IP synthesized and reflected on the instance,
+// without touching any reserved address (test b).
+func TestSDKEphemeralExternalIPSynthesized(t *testing.T) {
+	ts := newGCPServerWithNet(t)
+	instances := newSDKInstancesClient(t, ts)
+	ctx := context.Background()
+
+	insertInstanceWithAccessConfig(t, instances, "ephemeral-vm", "")
+
+	inst, err := instances.Get(ctx, &computepb.GetInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "ephemeral-vm",
+	})
+	if err != nil {
+		t.Fatalf("instance Get: %v", err)
+	}
+
+	ac := firstAccessConfig(t, inst)
+	if ac.GetNatIP() == "" {
+		t.Error("ephemeral accessConfig has no synthesized natIP")
+	}
+
+	if ac.GetType() != "ONE_TO_ONE_NAT" {
+		t.Errorf("accessConfig type=%q want ONE_TO_ONE_NAT", ac.GetType())
+	}
+}
+
+// TestSDKDeleteInUseAddressRejected proves a reserved address held by an
+// instance cannot be deleted (400 resourceInUseByAnotherResource), and that it
+// reverts to RESERVED and deletes cleanly once the instance is gone (test c).
+func TestSDKDeleteInUseAddressRejected(t *testing.T) {
+	ts := newGCPServerWithNet(t)
+	instances := newSDKInstancesClient(t, ts)
+	addresses := newAddressesSDKClient(t, ts)
+	ctx := context.Background()
+
+	ip := reserveAddress(t, addresses, "pinned-ip")
+	insertInstanceWithAccessConfig(t, instances, "holder-vm", ip)
+
+	// Delete while IN_USE must fail.
+	_, err := addresses.Delete(ctx, &computepb.DeleteAddressRequest{
+		Project: testProject, Region: testRegion, Address: "pinned-ip",
+	})
+	if err == nil {
+		t.Fatal("Delete of in-use address succeeded, want resourceInUseByAnotherResource")
+	}
+
+	if !strings.Contains(err.Error(), "resourceInUseByAnotherResource") && !strings.Contains(err.Error(), "400") {
+		t.Errorf("Delete error = %v, want resourceInUseByAnotherResource/400", err)
+	}
+
+	// Delete the instance releasing the address.
+	delOp, err := instances.Delete(ctx, &computepb.DeleteInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "holder-vm",
+	})
+	if err != nil {
+		t.Fatalf("instance Delete: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Fatalf("instance Delete wait: %v", err)
+	}
+
+	// Address is back to RESERVED.
+	addr, err := addresses.Get(ctx, &computepb.GetAddressRequest{
+		Project: testProject, Region: testRegion, Address: "pinned-ip",
+	})
+	if err != nil {
+		t.Fatalf("address Get after instance delete: %v", err)
+	}
+
+	if addr.GetStatus() != "RESERVED" {
+		t.Errorf("address status=%q want RESERVED after release", addr.GetStatus())
+	}
+
+	if len(addr.GetUsers()) != 0 {
+		t.Errorf("address users=%v want empty after release", addr.GetUsers())
+	}
+
+	// And now it deletes cleanly.
+	addrDelOp, err := addresses.Delete(ctx, &computepb.DeleteAddressRequest{
+		Project: testProject, Region: testRegion, Address: "pinned-ip",
+	})
+	if err != nil {
+		t.Fatalf("address Delete after release: %v", err)
+	}
+
+	if err := addrDelOp.Wait(ctx); err != nil {
+		t.Fatalf("address Delete wait: %v", err)
+	}
+}
+
+// TestSDKInstanceWithoutAccessConfigHasNoExternalIP proves the no-regression
+// case: an instance created without an accessConfig has no external IP and its
+// nic0 carries no accessConfigs (test d).
+func TestSDKInstanceWithoutAccessConfigHasNoExternalIP(t *testing.T) {
+	ts := newGCPServerWithNet(t)
+	instances := newSDKInstancesClient(t, ts)
+	ctx := context.Background()
+
+	op, err := instances.Insert(ctx, &computepb.InsertInstanceRequest{
+		Project: testProject, Zone: testZone,
+		InstanceResource: &computepb.Instance{
+			Name:        ptrStr("private-vm"),
+			MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+			NetworkInterfaces: []*computepb.NetworkInterface{{
+				Network: ptrStr("global/networks/default"),
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("instance Insert: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("instance Insert wait: %v", err)
+	}
+
+	inst, err := instances.Get(ctx, &computepb.GetInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "private-vm",
+	})
+	if err != nil {
+		t.Fatalf("instance Get: %v", err)
+	}
+
+	if len(inst.GetNetworkInterfaces()) == 0 {
+		t.Fatal("private-vm has no networkInterfaces")
+	}
+
+	if acs := inst.GetNetworkInterfaces()[0].GetAccessConfigs(); len(acs) != 0 {
+		t.Errorf("private-vm nic0 has %d accessConfigs, want 0", len(acs))
+	}
+}

--- a/server/gcp/compute/instance_response.go
+++ b/server/gcp/compute/instance_response.go
@@ -123,17 +123,23 @@ func diskSizeFor(d *attachedDisk) string {
 func instanceNICs(inst *computedriver.Instance, host, project, zone string) []networkInterface {
 	network := qualifyNetwork(host, project, tagOr(inst.Tags, keyNetwork, ""))
 	subnet := qualifySubnetwork(host, project, zone, inst.SubnetID)
+	accessConfigs := decodeAccessConfigs(inst.Tags)
 
-	if network == "" && subnet == "" && inst.PrivateIP == "" {
+	if network == "" && subnet == "" && inst.PrivateIP == "" && len(accessConfigs) == 0 {
 		return nil
 	}
 
+	for i := range accessConfigs {
+		accessConfigs[i].Kind = "compute#accessConfig"
+	}
+
 	return []networkInterface{{
-		Name:       "nic0",
-		Network:    network,
-		Subnetwork: subnet,
-		NetworkIP:  inst.PrivateIP,
-		StackType:  "IPV4_ONLY",
+		Name:          "nic0",
+		Network:       network,
+		Subnetwork:    subnet,
+		NetworkIP:     inst.PrivateIP,
+		StackType:     "IPV4_ONLY",
+		AccessConfigs: accessConfigs,
 	}}
 }
 

--- a/server/gcp/compute/instance_state.go
+++ b/server/gcp/compute/instance_state.go
@@ -5,7 +5,9 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"hash/fnv"
+	"net"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -15,11 +17,12 @@ import (
 // entries of the instance's tag map, keyed with the "cloudemu:gcp" prefix.
 // These keys are stripped from the emitted labels.
 const (
-	keyDisks    = "cloudemu:gcp:disks"
-	keyNetTags  = "cloudemu:gcp:nettags"
-	keyMetadata = "cloudemu:gcp:metadata"
-	keyNetwork  = "cloudemu:gcp:network"
-	keyZone     = "cloudemu:gcp:zone"
+	keyDisks         = "cloudemu:gcp:disks"
+	keyNetTags       = "cloudemu:gcp:nettags"
+	keyMetadata      = "cloudemu:gcp:metadata"
+	keyNetwork       = "cloudemu:gcp:network"
+	keyZone          = "cloudemu:gcp:zone"
+	keyAccessConfigs = "cloudemu:gcp:accessconfigs"
 )
 
 // internalTagPrefix marks tag keys that carry CloudEmu-internal GCP state
@@ -31,7 +34,7 @@ const kvStride = 2
 
 // internalTagCap is the number of internal keys insertTags may add, used only
 // as a map preallocation hint.
-const internalTagCap = 6
+const internalTagCap = 7
 
 func isInternalTag(key string) bool {
 	return strings.HasPrefix(key, internalTagPrefix)
@@ -58,6 +61,41 @@ func decodeDisks(tags map[string]string) []attachedDisk {
 	}
 
 	return disks
+}
+
+func decodeAccessConfigs(tags map[string]string) []accessConfig {
+	raw := tags[keyAccessConfigs]
+	if raw == "" {
+		return nil
+	}
+
+	var acs []accessConfig
+	if err := json.Unmarshal([]byte(raw), &acs); err != nil {
+		return nil
+	}
+
+	return acs
+}
+
+// ephemeralIPPrefix is the leading octet of GCP's public 34.0.0.0/8 range,
+// which CloudEmu maps synthesized ephemeral external IPs into.
+const ephemeralIPPrefix = 34
+
+// ephemeralExternalIP synthesizes a deterministic external IP in GCP's public
+// 34.x range for an accessConfig the caller left without a natIP (real GCP
+// auto-assigns an ephemeral one). Deterministic in the instance name + index so
+// repeated GETs report a stable address.
+func ephemeralExternalIP(seed string, index int) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(seed))
+	_, _ = h.Write([]byte(strconv.Itoa(index)))
+
+	var buf [net.IPv4len]byte
+
+	binary.BigEndian.PutUint32(buf[:], h.Sum32())
+	buf[0] = ephemeralIPPrefix
+
+	return net.IP(buf[:]).String()
 }
 
 func decodeNetTags(tags map[string]string) []string {

--- a/server/gcp/compute/instances.go
+++ b/server/gcp/compute/instances.go
@@ -335,7 +335,60 @@ func insertTags(req *instanceRequest, zone string) map[string]string {
 		out[keyNetwork] = net
 	}
 
+	if acs := accessConfigsFor(req.NetworkInterfaces, req.Name); len(acs) > 0 {
+		out[keyAccessConfigs] = encodeJSON(acs)
+	}
+
 	return out
+}
+
+// accessConfig field defaults GCP stamps on an external-IP mapping.
+const (
+	accessConfigOneToOneNAT = "ONE_TO_ONE_NAT"
+	accessConfigDefaultName = "External NAT"
+	accessConfigNetworkTier = "PREMIUM"
+)
+
+// accessConfigsFor extracts the external-IP accessConfigs off the instance's
+// network interfaces (CloudEmu models a single nic0, so the first NIC that
+// carries them), filling GCP's server-side defaults. An accessConfig with no
+// natIP is given a synthesized ephemeral external IP (mirroring GCP assigning
+// one); an explicit natIP — a reserved google_compute_address — is preserved so
+// that address reads back IN_USE while this instance holds it.
+func accessConfigsFor(nics []networkInterface, instanceName string) []accessConfig {
+	for i := range nics {
+		if len(nics[i].AccessConfigs) == 0 {
+			continue
+		}
+
+		out := make([]accessConfig, 0, len(nics[i].AccessConfigs))
+
+		for j := range nics[i].AccessConfigs {
+			ac := nics[i].AccessConfigs[j]
+
+			if ac.Type == "" {
+				ac.Type = accessConfigOneToOneNAT
+			}
+
+			if ac.Name == "" {
+				ac.Name = accessConfigDefaultName
+			}
+
+			if ac.NetworkTier == "" {
+				ac.NetworkTier = accessConfigNetworkTier
+			}
+
+			if ac.NatIP == "" {
+				ac.NatIP = ephemeralExternalIP(instanceName, j)
+			}
+
+			out = append(out, ac)
+		}
+
+		return out
+	}
+
+	return nil
 }
 
 // findInZone looks up an instance by GCP name, scoped to zone. An instance with

--- a/server/gcp/compute/types.go
+++ b/server/gcp/compute/types.go
@@ -54,11 +54,25 @@ type diskInitializeParams struct {
 }
 
 type networkInterface struct {
-	Name       string `json:"name,omitempty"`
-	Network    string `json:"network,omitempty"`
-	Subnetwork string `json:"subnetwork,omitempty"`
-	NetworkIP  string `json:"networkIP,omitempty"`
-	StackType  string `json:"stackType,omitempty"`
+	Name          string         `json:"name,omitempty"`
+	Network       string         `json:"network,omitempty"`
+	Subnetwork    string         `json:"subnetwork,omitempty"`
+	NetworkIP     string         `json:"networkIP,omitempty"`
+	StackType     string         `json:"stackType,omitempty"`
+	AccessConfigs []accessConfig `json:"accessConfigs,omitempty"`
+}
+
+// accessConfig models compute#accessConfig — the external-IP mapping on a
+// network interface. A ONE_TO_ONE_NAT config carries the instance's public IP:
+// when natIP names a reserved compute#address that address flips RESERVED->IN_USE
+// while the instance holds it; when natIP is omitted GCP assigns an ephemeral
+// external IP, which CloudEmu synthesizes at insert time so a GET reflects one.
+type accessConfig struct {
+	Kind        string `json:"kind,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Name        string `json:"name,omitempty"`
+	NatIP       string `json:"natIP,omitempty"`
+	NetworkTier string `json:"networkTier,omitempty"`
 }
 
 type tagsBlock struct {

--- a/server/gcp/vpc/addresses.go
+++ b/server/gcp/vpc/addresses.go
@@ -1,6 +1,7 @@
 package vpc
 
 import (
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"net"
@@ -249,6 +250,8 @@ func (h *Handler) getAddress(w http.ResponseWriter, r *http.Request, rp gcprest.
 		return
 	}
 
+	body = reflectAddressUsage(body, h.addressUsersByIP(r.Context(), hostOf(r), rp.Project))
+
 	gcprest.WriteJSON(w, http.StatusOK, body)
 }
 
@@ -256,12 +259,13 @@ func (h *Handler) getAddress(w http.ResponseWriter, r *http.Request, rp gcprest.
 func (h *Handler) listAddresses(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
 	all := h.addresses.list(rp.Project, scopeOf(rp))
 	filter := r.URL.Query().Get("filter")
+	usersByIP := h.addressUsersByIP(r.Context(), hostOf(r), rp.Project)
 
 	items := make([]json.RawMessage, 0, len(all))
 
 	for _, body := range all {
 		if nameMatches(filter, rawName(body)) {
-			items = append(items, body)
+			items = append(items, reflectAddressUsage(body, usersByIP))
 		}
 	}
 
@@ -291,6 +295,7 @@ func (h *Handler) aggregatedListAddresses(w http.ResponseWriter, r *http.Request
 	byScope := h.addresses.allByScope(rp.Project)
 	filter := r.URL.Query().Get("filter")
 	host := hostOf(r)
+	usersByIP := h.addressUsersByIP(r.Context(), host, rp.Project)
 	items := map[string]addressesScopedList{}
 
 	for scope, bodies := range byScope {
@@ -303,7 +308,7 @@ func (h *Handler) aggregatedListAddresses(w http.ResponseWriter, r *http.Request
 
 		for _, b := range bodies {
 			if nameMatches(filter, rawName(b)) {
-				list = append(list, b)
+				list = append(list, reflectAddressUsage(b, usersByIP))
 			}
 		}
 
@@ -341,6 +346,30 @@ func rawName(body json.RawMessage) string {
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) deleteAddress(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	host := hostOf(r)
+
+	// Real GCP refuses to delete a reserved address an instance still holds via
+	// an accessConfig natIP, returning 400 resourceInUseByAnotherResource (the
+	// same in-use guard the disk/subnetwork deletes carry). The address deletes
+	// cleanly once the instance releasing it is gone.
+	body, ok := h.addresses.get(rp.Project, scopeOf(rp), rp.ResourceName)
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound",
+			"address "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	if ip := addressIP(body); ip != "" {
+		if users := h.addressUsersByIP(r.Context(), host, rp.Project)[ip]; len(users) > 0 {
+			addrLink := gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, resourceAddresses, rp.ResourceName)
+			gcprest.WriteError(w, http.StatusBadRequest, "resourceInUseByAnotherResource",
+				"The address resource '"+addrLink+"' is already being used by '"+users[0]+"'")
+
+			return
+		}
+	}
+
 	if !h.addresses.delete(rp.Project, scopeOf(rp), rp.ResourceName) {
 		gcprest.WriteError(w, http.StatusNotFound, "notFound",
 			"address "+rp.ResourceName+" not found")
@@ -348,6 +377,112 @@ func (h *Handler) deleteAddress(w http.ResponseWriter, r *http.Request, rp gcpre
 		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, gcprest.NewDoneOperation(hostOf(r), rp.Project,
+	gcprest.WriteJSON(w, http.StatusOK, gcprest.NewDoneOperation(host, rp.Project,
 		rp.Scope, rp.ScopeName, resourceAddresses, rp.ResourceName, "delete"))
+}
+
+// instAccessConfigsTag mirrors the compute wire handler's internal tag key
+// (server/gcp/compute) that round-trips an instance's external-IP accessConfigs,
+// so this handler can tell whether an instance is holding a reserved address
+// without importing the compute server package.
+const instAccessConfigsTag = "cloudemu:gcp:accessconfigs"
+
+// addressUsersByIP scans instances and maps each external IP an instance holds
+// through its accessConfigs[].natIP to the self-links of the instances using it.
+// A reserved address whose IP appears here reads back IN_USE with users[]
+// pointing at that instance (mirrors the compute-side disk users[] scan). A nil
+// compute driver (compute not wired) reports no users.
+func (h *Handler) addressUsersByIP(ctx context.Context, host, project string) map[string][]string {
+	if h.compute == nil {
+		return nil
+	}
+
+	instances, err := h.compute.DescribeInstances(ctx, nil, nil)
+	if err != nil {
+		return nil
+	}
+
+	out := make(map[string][]string)
+
+	for i := range instances {
+		name := tagOr(instances[i].Tags, instNameTag, instances[i].ID)
+		zone := tagOr(instances[i].Tags, instZoneTag, "")
+		link := gcprest.SelfLink(host, project, gcprest.ScopeZones, zone, "instances", name)
+
+		for _, ip := range natIPsOf(instances[i].Tags) {
+			if ip != "" {
+				out[ip] = append(out[ip], link)
+			}
+		}
+	}
+
+	return out
+}
+
+// natIPsOf decodes the external IPs an instance's accessConfigs reference from
+// its round-trip tag entry.
+func natIPsOf(tags map[string]string) []string {
+	raw := tags[instAccessConfigsTag]
+	if raw == "" {
+		return nil
+	}
+
+	var acs []struct {
+		NatIP string `json:"natIP"`
+	}
+
+	if err := json.Unmarshal([]byte(raw), &acs); err != nil {
+		return nil
+	}
+
+	out := make([]string, 0, len(acs))
+	for _, ac := range acs {
+		out = append(out, ac.NatIP)
+	}
+
+	return out
+}
+
+// reflectAddressUsage overlays the live IN_USE status and users[] onto a stored
+// address body when an instance holds its IP. Real GCP flips a reserved address
+// RESERVED->IN_USE while an instance's accessConfig references it, then back to
+// RESERVED once the instance is gone; deriving it from the instance scan keeps
+// the two consistent without cross-handler mutation.
+func reflectAddressUsage(body json.RawMessage, usersByIP map[string][]string) json.RawMessage {
+	if len(usersByIP) == 0 {
+		return body
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil || m == nil {
+		return body
+	}
+
+	ip, _ := m["address"].(string)
+
+	users := usersByIP[ip]
+	if len(users) == 0 {
+		return body
+	}
+
+	m["status"] = "IN_USE"
+	m["users"] = users
+
+	out, err := json.Marshal(m)
+	if err != nil {
+		return body
+	}
+
+	return out
+}
+
+// addressIP extracts the allocated IP from a stored address body.
+func addressIP(body json.RawMessage) string {
+	var a struct {
+		Address string `json:"address"`
+	}
+
+	_ = json.Unmarshal(body, &a)
+
+	return a.Address
 }


### PR DESCRIPTION
## Summary

Models the GCE instance external-IP (`accessConfigs[].natIP`) chain, which was entirely unmodeled — causing perpetual Terraform drift on `google_compute_instance { network_interface { access_config { nat_ip = google_compute_address.x.address } } }` and leaving a reserved `google_compute_address` stuck at `RESERVED` forever with no in-use protection.

### What changed

1. **accessConfigs[] round-trip on the instance NIC.** Added an `accessConfig` type (Type/Name/NatIP/NetworkTier) to the wire `networkInterface`, captured on insert into an internal `cloudemu:gcp:accessconfigs` tag, and reflected on GET via `instanceNICs`. GCP's server-side defaults are filled (`ONE_TO_ONE_NAT` / `External NAT` / `PREMIUM`). An accessConfig with an explicit `natIP` (a reserved address) is preserved; one with no `natIP` gets a deterministic synthesized ephemeral IP in GCP's public `34.0.0.0/8` range, matching GCP auto-assigning one.

2. **Reserved-address IN_USE lifecycle.** A reserved address whose IP an instance holds via `accessConfigs[].natIP` now reads back `status: IN_USE` with `users[]` naming the instance. This is **derived from the instance scan** at read time (mirrors the disk `users[]` reflection and the subnetwork in-use guard) rather than mutated cross-handler, so it reverts to `RESERVED` automatically once the instance is deleted — no stale state.

3. **deleteAddress in-use guard.** Deleting an address an instance still holds is rejected with `400 resourceInUseByAnotherResource` (mirrors the disk/subnet guards from #801); it deletes cleanly once released.

### Linkage keying

The `natIP` ↔ address link is keyed by the **IP-address string** (`natIP == google_compute_address.address`) — exactly how Terraform wires it. A `natIP` referencing a non-existent address is accepted and reflected (consistent with how subnetwork refs are handled — stored, not existence-validated).

### Tests

New `external_ip_sdk_test.go` drives the real `cloud.google.com/go` compute client over httptest:
- reserved address → instance with that `natIP` → instance reflects `accessConfigs[].natIP`; address is `IN_USE` with `users[]` → instance
- accessConfig with no `natIP` → ephemeral external IP synthesized + reflected
- delete address while IN_USE → `resourceInUseByAnotherResource`; delete instance → address back to `RESERVED` → address deletes cleanly
- no-regression: instance without an accessConfig has no external IP / no accessConfigs

### Gates

`go build ./...`, `go vet`, scoped `go test` (server/gcp/compute, providers/gcp/compute, server/gcp/vpc, providers/gcp/vpc, features/topology), `TestWiringParity`/`TestRealWorld`, `gofmt`, `golangci-lint --new-from-rev` (0 new), `go generate` + compatgen (no diff) — all green.
