### PR TITLE
fix(azure-databricks): model workspace parameters/encryption/network properties (round-trip for VNet-injection + CMK)

### DIFF
--- a/providers/azure/databricks/databricks.go
+++ b/providers/azure/databricks/databricks.go
@@ -120,6 +120,9 @@ func (m *Mock) CreateWorkspace(_ context.Context, cfg driver.WorkspaceConfig) (*
 		updated.Tags = copyMap(cfg.Tags)
 		updated.SKUName = skuOrDefault(cfg.SKUName)
 		updated.SKUTier = cfg.SKUTier
+		// ARM PUT replaces the resource: apply the incoming VNet/CMK/network
+		// properties so a re-PUT reflects the new desired state.
+		updated.WorkspaceExtendedProperties = cfg.WorkspaceExtendedProperties
 		m.workspaces.Set(k, &updated)
 
 		return cloneWorkspace(&updated), nil
@@ -141,6 +144,8 @@ func (m *Mock) CreateWorkspace(_ context.Context, cfg driver.WorkspaceConfig) (*
 		ProvisioningState:      driver.StateSucceeded,
 		Tags:                   copyMap(cfg.Tags),
 		CreatedAt:              m.opts.Clock.Now().UTC().Format(time.RFC3339),
+
+		WorkspaceExtendedProperties: cfg.WorkspaceExtendedProperties,
 	}
 
 	m.workspaces.Set(k, ws)

--- a/server/azure/databricks/operations.go
+++ b/server/azure/databricks/operations.go
@@ -29,6 +29,16 @@ func (h *Handler) createOrUpdateWorkspace(w http.ResponseWriter, r *http.Request
 
 	if body.Properties != nil {
 		cfg.ManagedResourceGroupID = body.Properties.ManagedResourceGroupID
+		cfg.WorkspaceExtendedProperties = dbxdriver.WorkspaceExtendedProperties{
+			Parameters:             body.Properties.Parameters,
+			PublicNetworkAccess:    body.Properties.PublicNetworkAccess,
+			RequiredNsgRules:       body.Properties.RequiredNsgRules,
+			Authorizations:         body.Properties.Authorizations,
+			UIDefinitionURI:        body.Properties.UIDefinitionURI,
+			ManagedDiskIdentity:    body.Properties.ManagedDiskIdentity,
+			StorageAccountIdentity: body.Properties.StorageAccountIdentity,
+			DiskEncryptionSetID:    body.Properties.DiskEncryptionSetID,
+		}
 	}
 
 	ws, err := h.dbx.CreateWorkspace(r.Context(), cfg)

--- a/server/azure/databricks/types.go
+++ b/server/azure/databricks/types.go
@@ -27,6 +27,19 @@ type workspaceProps struct {
 	WorkspaceURL           string `json:"workspaceUrl,omitempty"`
 	WorkspaceID            string `json:"workspaceId,omitempty"`
 	CreatedDateTime        string `json:"createdDateTime,omitempty"`
+
+	// VNet-injection, CMK, and managed-network properties. These carry the
+	// well-known armdatabricks.WorkspaceProperties fields the client PUTs and
+	// expects reflected byte-identically on GET. Reused directly from the driver
+	// so a single set of JSON-tagged types guarantees round-trip fidelity.
+	Parameters             *dbxdriver.WorkspaceCustomParameters       `json:"parameters,omitempty"`
+	PublicNetworkAccess    string                                     `json:"publicNetworkAccess,omitempty"`
+	RequiredNsgRules       string                                     `json:"requiredNsgRules,omitempty"`
+	Authorizations         []dbxdriver.WorkspaceProviderAuthorization `json:"authorizations,omitempty"`
+	UIDefinitionURI        string                                     `json:"uiDefinitionUri,omitempty"`
+	ManagedDiskIdentity    *dbxdriver.ManagedIdentityConfiguration    `json:"managedDiskIdentity,omitempty"`
+	StorageAccountIdentity *dbxdriver.ManagedIdentityConfiguration    `json:"storageAccountIdentity,omitempty"`
+	DiskEncryptionSetID    string                                     `json:"diskEncryptionSetId,omitempty"`
 }
 
 // workspaceUpdate is the PATCH body shape (tags-only update).
@@ -54,6 +67,15 @@ func toARMWorkspace(ws *dbxdriver.Workspace) armWorkspace {
 			WorkspaceURL:           ws.WorkspaceURL,
 			WorkspaceID:            ws.WorkspaceID,
 			CreatedDateTime:        ws.CreatedAt,
+
+			Parameters:             ws.Parameters,
+			PublicNetworkAccess:    ws.PublicNetworkAccess,
+			RequiredNsgRules:       ws.RequiredNsgRules,
+			Authorizations:         ws.Authorizations,
+			UIDefinitionURI:        ws.UIDefinitionURI,
+			ManagedDiskIdentity:    ws.ManagedDiskIdentity,
+			StorageAccountIdentity: ws.StorageAccountIdentity,
+			DiskEncryptionSetID:    ws.DiskEncryptionSetID,
 		},
 	}
 	if ws.SKUName != "" {

--- a/server/azure/databricks/workspace_parameters_roundtrip_test.go
+++ b/server/azure/databricks/workspace_parameters_roundtrip_test.go
@@ -1,0 +1,278 @@
+package databricks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks"
+)
+
+// createWorkspaceWithProps PUTs a workspace carrying the given properties and
+// returns the created resource via the real armdatabricks SDK.
+func createWorkspaceWithProps(
+	t *testing.T, client *armdatabricks.WorkspacesClient, props *armdatabricks.WorkspaceProperties,
+) armdatabricks.Workspace {
+	t.Helper()
+
+	props.ManagedResourceGroupID = to.Ptr(managed)
+
+	poller, err := client.BeginCreateOrUpdate(context.Background(), testRG, testWS, armdatabricks.Workspace{
+		Location:   to.Ptr("eastus"),
+		SKU:        &armdatabricks.SKU{Name: to.Ptr("premium")},
+		Tags:       map[string]*string{"env": to.Ptr("test")},
+		Properties: props,
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	res, err := poller.PollUntilDone(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	if res.Properties == nil || *res.Properties.ProvisioningState != armdatabricks.ProvisioningStateSucceeded {
+		t.Fatalf("expected Succeeded provisioning state, got %+v", res.Properties)
+	}
+
+	return res.Workspace
+}
+
+// TestSDKWorkspaceVNetInjectionRoundTrip proves a VNet-injected workspace's
+// custom network parameters survive the create->GET round-trip under
+// properties.parameters with the {value:...} wrapper.
+func TestSDKWorkspaceVNetInjectionRoundTrip(t *testing.T) {
+	client := newWorkspacesClient(t)
+	ctx := context.Background()
+
+	const (
+		vnetID  = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/virtualNetworks/my-vnet"
+		privSub = "private-subnet"
+		pubSub  = "public-subnet"
+	)
+
+	createWorkspaceWithProps(t, client, &armdatabricks.WorkspaceProperties{
+		Parameters: &armdatabricks.WorkspaceCustomParameters{
+			CustomVirtualNetworkID:  &armdatabricks.WorkspaceCustomStringParameter{Value: to.Ptr(vnetID)},
+			CustomPrivateSubnetName: &armdatabricks.WorkspaceCustomStringParameter{Value: to.Ptr(privSub)},
+			CustomPublicSubnetName:  &armdatabricks.WorkspaceCustomStringParameter{Value: to.Ptr(pubSub)},
+			EnableNoPublicIP:        &armdatabricks.WorkspaceCustomBooleanParameter{Value: to.Ptr(true)},
+		},
+	})
+
+	got, err := client.Get(ctx, testRG, testWS, nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	p := got.Properties.Parameters
+	if p == nil {
+		t.Fatal("expected properties.parameters to be reflected on GET")
+	}
+
+	requireStringParam(t, "customVirtualNetworkId", p.CustomVirtualNetworkID, vnetID)
+	requireStringParam(t, "customPrivateSubnetName", p.CustomPrivateSubnetName, privSub)
+	requireStringParam(t, "customPublicSubnetName", p.CustomPublicSubnetName, pubSub)
+
+	if p.EnableNoPublicIP == nil || p.EnableNoPublicIP.Value == nil || !*p.EnableNoPublicIP.Value {
+		t.Fatalf("expected enableNoPublicIp value=true, got %+v", p.EnableNoPublicIP)
+	}
+}
+
+// TestSDKWorkspaceCMKEncryptionRoundTrip proves CMK encryption parameters
+// survive the create->GET round-trip.
+func TestSDKWorkspaceCMKEncryptionRoundTrip(t *testing.T) {
+	client := newWorkspacesClient(t)
+	ctx := context.Background()
+
+	const (
+		keyName  = "my-cmk-key"
+		vaultURI = "https://my-vault.vault.azure.net/"
+		keyVer   = "abc123def456"
+	)
+
+	createWorkspaceWithProps(t, client, &armdatabricks.WorkspaceProperties{
+		Parameters: &armdatabricks.WorkspaceCustomParameters{
+			PrepareEncryption:               &armdatabricks.WorkspaceCustomBooleanParameter{Value: to.Ptr(true)},
+			RequireInfrastructureEncryption: &armdatabricks.WorkspaceCustomBooleanParameter{Value: to.Ptr(true)},
+			Encryption: &armdatabricks.WorkspaceEncryptionParameter{
+				Value: &armdatabricks.Encryption{
+					KeySource:   to.Ptr(armdatabricks.KeySourceMicrosoftKeyvault),
+					KeyName:     to.Ptr(keyName),
+					KeyVaultURI: to.Ptr(vaultURI),
+					KeyVersion:  to.Ptr(keyVer),
+				},
+			},
+		},
+	})
+
+	got, err := client.Get(ctx, testRG, testWS, nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	p := got.Properties.Parameters
+	if p == nil {
+		t.Fatal("expected properties.parameters to be reflected on GET")
+	}
+
+	if p.PrepareEncryption == nil || p.PrepareEncryption.Value == nil || !*p.PrepareEncryption.Value {
+		t.Fatalf("expected prepareEncryption value=true, got %+v", p.PrepareEncryption)
+	}
+
+	if p.RequireInfrastructureEncryption == nil || p.RequireInfrastructureEncryption.Value == nil ||
+		!*p.RequireInfrastructureEncryption.Value {
+		t.Fatalf("expected requireInfrastructureEncryption value=true, got %+v", p.RequireInfrastructureEncryption)
+	}
+
+	if p.Encryption == nil || p.Encryption.Value == nil {
+		t.Fatal("expected encryption parameter to be reflected on GET")
+	}
+
+	enc := p.Encryption.Value
+	if enc.KeySource == nil || *enc.KeySource != armdatabricks.KeySourceMicrosoftKeyvault {
+		t.Fatalf("keySource: got %v, want Microsoft.Keyvault", enc.KeySource)
+	}
+
+	if enc.KeyName == nil || *enc.KeyName != keyName {
+		t.Fatalf("keyName: got %v, want %q", enc.KeyName, keyName)
+	}
+
+	if enc.KeyVaultURI == nil || *enc.KeyVaultURI != vaultURI {
+		t.Fatalf("keyVaultUri: got %v, want %q", enc.KeyVaultURI, vaultURI)
+	}
+
+	if enc.KeyVersion == nil || *enc.KeyVersion != keyVer {
+		t.Fatalf("keyVersion: got %v, want %q", enc.KeyVersion, keyVer)
+	}
+}
+
+// TestSDKWorkspaceNetworkAccessRoundTrip proves publicNetworkAccess and
+// requiredNsgRules survive the create->GET round-trip.
+func TestSDKWorkspaceNetworkAccessRoundTrip(t *testing.T) {
+	client := newWorkspacesClient(t)
+	ctx := context.Background()
+
+	createWorkspaceWithProps(t, client, &armdatabricks.WorkspaceProperties{
+		PublicNetworkAccess: to.Ptr(armdatabricks.PublicNetworkAccessDisabled),
+		RequiredNsgRules:    to.Ptr(armdatabricks.RequiredNsgRulesNoAzureDatabricksRules),
+	})
+
+	got, err := client.Get(ctx, testRG, testWS, nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Properties.PublicNetworkAccess == nil ||
+		*got.Properties.PublicNetworkAccess != armdatabricks.PublicNetworkAccessDisabled {
+		t.Fatalf("publicNetworkAccess: got %v, want Disabled", got.Properties.PublicNetworkAccess)
+	}
+
+	if got.Properties.RequiredNsgRules == nil ||
+		*got.Properties.RequiredNsgRules != armdatabricks.RequiredNsgRulesNoAzureDatabricksRules {
+		t.Fatalf("requiredNsgRules: got %v, want NoAzureDatabricksRules", got.Properties.RequiredNsgRules)
+	}
+}
+
+// TestSDKWorkspaceParametersPreservedOnPatch proves a tags-only PATCH does not
+// wipe the previously-set parameters/encryption/network properties.
+func TestSDKWorkspaceParametersPreservedOnPatch(t *testing.T) {
+	client := newWorkspacesClient(t)
+	ctx := context.Background()
+
+	const vnetID = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/virtualNetworks/my-vnet"
+
+	createWorkspaceWithProps(t, client, &armdatabricks.WorkspaceProperties{
+		PublicNetworkAccess: to.Ptr(armdatabricks.PublicNetworkAccessDisabled),
+		Parameters: &armdatabricks.WorkspaceCustomParameters{
+			CustomVirtualNetworkID: &armdatabricks.WorkspaceCustomStringParameter{Value: to.Ptr(vnetID)},
+			EnableNoPublicIP:       &armdatabricks.WorkspaceCustomBooleanParameter{Value: to.Ptr(true)},
+			Encryption: &armdatabricks.WorkspaceEncryptionParameter{
+				Value: &armdatabricks.Encryption{
+					KeySource: to.Ptr(armdatabricks.KeySourceMicrosoftKeyvault),
+					KeyName:   to.Ptr("cmk"),
+				},
+			},
+		},
+	})
+
+	patchPoller, err := client.BeginUpdate(ctx, testRG, testWS, armdatabricks.WorkspaceUpdate{
+		Tags: map[string]*string{"env": to.Ptr("prod")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate: %v", err)
+	}
+
+	if _, err = patchPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("update PollUntilDone: %v", err)
+	}
+
+	got, err := client.Get(ctx, testRG, testWS, nil)
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" {
+		t.Fatalf("PATCH did not apply env=prod: %v", got.Tags)
+	}
+
+	if got.Properties.PublicNetworkAccess == nil ||
+		*got.Properties.PublicNetworkAccess != armdatabricks.PublicNetworkAccessDisabled {
+		t.Fatalf("PATCH wiped publicNetworkAccess: got %v", got.Properties.PublicNetworkAccess)
+	}
+
+	p := got.Properties.Parameters
+	if p == nil {
+		t.Fatal("PATCH wiped properties.parameters entirely")
+	}
+
+	requireStringParam(t, "customVirtualNetworkId", p.CustomVirtualNetworkID, vnetID)
+
+	if p.EnableNoPublicIP == nil || p.EnableNoPublicIP.Value == nil || !*p.EnableNoPublicIP.Value {
+		t.Fatalf("PATCH wiped enableNoPublicIp: %+v", p.EnableNoPublicIP)
+	}
+
+	if p.Encryption == nil || p.Encryption.Value == nil || p.Encryption.Value.KeyName == nil ||
+		*p.Encryption.Value.KeyName != "cmk" {
+		t.Fatalf("PATCH wiped encryption parameter: %+v", p.Encryption)
+	}
+}
+
+// TestSDKWorkspaceIdentitySynthesisIntact proves modeling the extended
+// properties does not regress the synthesized managedResourceGroupId /
+// workspaceUrl / workspaceId set on a plain workspace with no extra properties.
+func TestSDKWorkspaceIdentitySynthesisIntact(t *testing.T) {
+	client := newWorkspacesClient(t)
+
+	ws := createWorkspaceWithProps(t, client, &armdatabricks.WorkspaceProperties{})
+
+	if ws.Properties.ManagedResourceGroupID == nil || *ws.Properties.ManagedResourceGroupID != managed {
+		t.Fatalf("managedResourceGroupId: got %v, want %q", ws.Properties.ManagedResourceGroupID, managed)
+	}
+
+	if ws.Properties.WorkspaceURL == nil || *ws.Properties.WorkspaceURL == "" {
+		t.Fatal("expected a synthesized workspaceUrl")
+	}
+
+	if ws.Properties.WorkspaceID == nil || *ws.Properties.WorkspaceID == "" {
+		t.Fatal("expected a synthesized workspaceId")
+	}
+
+	// A plain workspace must not carry any spurious parameters block.
+	if ws.Properties.Parameters != nil {
+		t.Fatalf("expected no parameters for a plain workspace, got %+v", ws.Properties.Parameters)
+	}
+}
+
+func requireStringParam(t *testing.T, name string, got *armdatabricks.WorkspaceCustomStringParameter, want string) {
+	t.Helper()
+
+	if got == nil || got.Value == nil {
+		t.Fatalf("%s: expected value %q, got nil", name, want)
+	}
+
+	if *got.Value != want {
+		t.Fatalf("%s: got %q, want %q", name, *got.Value, want)
+	}
+}

--- a/services/databricks/driver/driver.go
+++ b/services/databricks/driver/driver.go
@@ -12,6 +12,85 @@ const (
 	StateFailed    = "Failed"
 )
 
+// WorkspaceCustomStringParameter wraps a string workspace custom parameter in
+// the ARM {value:...} envelope (armdatabricks.WorkspaceCustomStringParameter).
+type WorkspaceCustomStringParameter struct {
+	Value string `json:"value"`
+	Type  string `json:"type,omitempty"`
+}
+
+// WorkspaceCustomBoolParameter wraps a boolean workspace custom parameter in the
+// ARM {value:...} envelope (armdatabricks.WorkspaceCustomBooleanParameter).
+type WorkspaceCustomBoolParameter struct {
+	Value bool   `json:"value"`
+	Type  string `json:"type,omitempty"`
+}
+
+// WorkspaceEncryptionParameter wraps the CMK encryption details in the ARM
+// {value:...} envelope (armdatabricks.WorkspaceEncryptionParameter).
+type WorkspaceEncryptionParameter struct {
+	Value *WorkspaceEncryption `json:"value,omitempty"`
+	Type  string               `json:"type,omitempty"`
+}
+
+// WorkspaceEncryption holds Customer-Managed Key (CMK) encryption details
+// (armdatabricks.Encryption). Field JSON names match the real ARM wire exactly.
+type WorkspaceEncryption struct {
+	KeyName     string `json:"KeyName,omitempty"`
+	KeySource   string `json:"keySource,omitempty"`
+	KeyVaultURI string `json:"keyvaulturi,omitempty"`
+	KeyVersion  string `json:"keyversion,omitempty"`
+}
+
+// WorkspaceCustomParameters mirrors armdatabricks.WorkspaceCustomParameters: the
+// VNet-injection, CMK, and managed-network parameters a workspace is created
+// with. Each field is a {value:...} wrapper so it round-trips byte-identically.
+type WorkspaceCustomParameters struct {
+	CustomVirtualNetworkID          *WorkspaceCustomStringParameter `json:"customVirtualNetworkId,omitempty"`
+	CustomPrivateSubnetName         *WorkspaceCustomStringParameter `json:"customPrivateSubnetName,omitempty"`
+	CustomPublicSubnetName          *WorkspaceCustomStringParameter `json:"customPublicSubnetName,omitempty"`
+	EnableNoPublicIP                *WorkspaceCustomBoolParameter   `json:"enableNoPublicIp,omitempty"`
+	PrepareEncryption               *WorkspaceCustomBoolParameter   `json:"prepareEncryption,omitempty"`
+	Encryption                      *WorkspaceEncryptionParameter   `json:"encryption,omitempty"`
+	RequireInfrastructureEncryption *WorkspaceCustomBoolParameter   `json:"requireInfrastructureEncryption,omitempty"`
+	StorageAccountName              *WorkspaceCustomStringParameter `json:"storageAccountName,omitempty"`
+	StorageAccountSKUName           *WorkspaceCustomStringParameter `json:"storageAccountSkuName,omitempty"`
+	VnetAddressPrefix               *WorkspaceCustomStringParameter `json:"vnetAddressPrefix,omitempty"`
+	NatGatewayName                  *WorkspaceCustomStringParameter `json:"natGatewayName,omitempty"`
+	PublicIPName                    *WorkspaceCustomStringParameter `json:"publicIpName,omitempty"`
+	LoadBalancerID                  *WorkspaceCustomStringParameter `json:"loadBalancerId,omitempty"`
+	LoadBalancerBackendPoolName     *WorkspaceCustomStringParameter `json:"loadBalancerBackendPoolName,omitempty"`
+}
+
+// WorkspaceProviderAuthorization mirrors armdatabricks.WorkspaceProviderAuthorization.
+type WorkspaceProviderAuthorization struct {
+	PrincipalID      string `json:"principalId,omitempty"`
+	RoleDefinitionID string `json:"roleDefinitionId,omitempty"`
+}
+
+// ManagedIdentityConfiguration mirrors armdatabricks.ManagedIdentityConfiguration
+// (the managed-identity details for a workspace's managed disk / storage account).
+type ManagedIdentityConfiguration struct {
+	PrincipalID string `json:"principalId,omitempty"`
+	TenantID    string `json:"tenantId,omitempty"`
+	Type        string `json:"type,omitempty"`
+}
+
+// WorkspaceExtendedProperties carries the VNet-injection, CMK, and network
+// workspace properties beyond the basic managedResourceGroupId/URL/ID set. They
+// are set on create (PUT) and must round-trip on GET, and be preserved across a
+// tags-only PATCH. Shared between WorkspaceConfig (create input) and Workspace.
+type WorkspaceExtendedProperties struct {
+	Parameters             *WorkspaceCustomParameters       `json:"parameters,omitempty"`
+	PublicNetworkAccess    string                           `json:"publicNetworkAccess,omitempty"`
+	RequiredNsgRules       string                           `json:"requiredNsgRules,omitempty"`
+	Authorizations         []WorkspaceProviderAuthorization `json:"authorizations,omitempty"`
+	UIDefinitionURI        string                           `json:"uiDefinitionUri,omitempty"`
+	ManagedDiskIdentity    *ManagedIdentityConfiguration    `json:"managedDiskIdentity,omitempty"`
+	StorageAccountIdentity *ManagedIdentityConfiguration    `json:"storageAccountIdentity,omitempty"`
+	DiskEncryptionSetID    string                           `json:"diskEncryptionSetId,omitempty"`
+}
+
 // WorkspaceConfig describes a workspace to create.
 type WorkspaceConfig struct {
 	Name                   string
@@ -22,6 +101,8 @@ type WorkspaceConfig struct {
 	SKUTier                string
 	ManagedResourceGroupID string
 	Tags                   map[string]string
+
+	WorkspaceExtendedProperties
 }
 
 // Workspace describes a managed analytics workspace.
@@ -39,6 +120,8 @@ type Workspace struct {
 	ProvisioningState      string
 	Tags                   map[string]string
 	CreatedAt              string
+
+	WorkspaceExtendedProperties
 }
 
 // Databricks is the interface that workspace service implementations must


### PR DESCRIPTION
## Summary

Azure Databricks workspaces created via Terraform (or the ARM SDK) with VNet-injection or Customer-Managed Key (CMK) encryption suffered perpetual `terraform apply` drift: everything in `armdatabricks.WorkspaceProperties` beyond `managedResourceGroupId`/`provisioningState`/`workspaceUrl`/`workspaceId`/`createdDateTime` was dropped on the create round-trip and absent from GET, so `custom_virtual_network_id` / subnets / `no_public_ip` / CMK / `public_network_access_enabled` / `network_security_group_rules_required` always read back empty.

This models those properties end-to-end (driver -> provider -> wire) so whatever the client PUTs comes back byte-identically on GET and survives a tags-only PATCH.

## What changed

- **driver** (`services/databricks/driver/driver.go`): new JSON-tagged types mirroring `armdatabricks` (`WorkspaceCustomParameters` with the `{value:...}` wrappers, `WorkspaceEncryption`, `ManagedIdentityConfiguration`, `WorkspaceProviderAuthorization`), bundled in `WorkspaceExtendedProperties` embedded in both `WorkspaceConfig` and `Workspace`.
- **provider** (`providers/azure/databricks/databricks.go`): carry the extended properties on create and apply them on re-PUT (create-or-update); tags-only PATCH already copies the whole struct so parameters are preserved.
- **wire** (`server/azure/databricks/types.go`, `operations.go`): capture `properties.parameters`/`encryption`/`publicNetworkAccess`/`requiredNsgRules`/`authorizations`/`uiDefinitionUri`/identities/`diskEncryptionSetId` on PUT and reflect them on GET, reusing the driver types directly for single-source round-trip fidelity.

## Properties now round-tripping

- `parameters`: customVirtualNetworkId, customPrivateSubnetName, customPublicSubnetName, enableNoPublicIp, prepareEncryption, encryption (keySource/keyName/keyVaultUri/keyVersion), requireInfrastructureEncryption, storageAccountName, storageAccountSkuName, vnetAddressPrefix, natGatewayName, publicIpName, loadBalancerId, loadBalancerBackendPoolName
- top-level: publicNetworkAccess, requiredNsgRules, authorizations, uiDefinitionUri, managedDiskIdentity, storageAccountIdentity, diskEncryptionSetId

## Tests (real armdatabricks SDK over httptest)

- VNet-injection (custom vnet + private/public subnet + enableNoPublicIp) reflected under `properties.parameters` with the `{value:...}` wrapper
- CMK encryption (keySource=Microsoft.Keyvault + key details) + prepareEncryption + requireInfrastructureEncryption reflected
- publicNetworkAccess=Disabled + requiredNsgRules=NoAzureDatabricksRules reflected
- tags-only PATCH preserves parameters/encryption/network props (no wipe)
- no regression: synthesized managedResourceGroupId/workspaceUrl/workspaceId still present, LRO create -> Succeeded, plain workspace carries no spurious parameters block

Coverage docs regenerated (no diff); compatgen green (no diff).