### PR TITLE
fix(gcp-gce): round-trip serviceAccounts + allocate networkIP from the subnet CIDR

### DIFF
--- a/features/chaos/wrappers_test.go
+++ b/features/chaos/wrappers_test.go
@@ -433,6 +433,7 @@ type computeConfigCompat = struct {
 	IamInstanceProfileName string
 	Identity               *computedriver.ManagedIdentity
 	NetworkInterfaces      []computedriver.AzureNICRef
+	PrivateIP              string
 }
 
 // computeInstanceConfig reproduces the helper used elsewhere in the package

--- a/providers/gcp/compute/gce.go
+++ b/providers/gcp/compute/gce.go
@@ -264,9 +264,18 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 		sg := make([]string, len(cfg.SecurityGroups))
 		copy(sg, cfg.SecurityGroups)
 
+		// Honor an explicit private IP (the wire layer resolves the client's
+		// networkIP or an address from the referenced subnet's CIDR) for the
+		// first instance; the rest of a multi-count batch fall back to the
+		// synthetic allocator so they never collide on the same address.
+		privateIP := m.nextIP()
+		if cfg.PrivateIP != "" && i == 0 {
+			privateIP = cfg.PrivateIP
+		}
+
 		inst := &instanceData{
 			ID: id, ImageID: cfg.ImageID, InstanceType: cfg.InstanceType,
-			State: compute.StatePending, PrivateIP: m.nextIP(), SubnetID: cfg.SubnetID,
+			State: compute.StatePending, PrivateIP: privateIP, SubnetID: cfg.SubnetID,
 			SecurityGroups: sg, Tags: tags,
 			LaunchTime: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
 		}

--- a/server/gcp/compute/handler.go
+++ b/server/gcp/compute/handler.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
 // Resource type names used in URL routing.
@@ -39,11 +40,18 @@ const (
 // operations.
 type Handler struct {
 	compute computedriver.Compute
+	// net resolves the subnetwork an instance references to its CIDR so a
+	// launched instance gets a networkIP inside that range. May be nil (no
+	// networking driver wired), in which case IP allocation falls back to the
+	// compute provider's synthetic allocator.
+	net netdriver.Networking
 }
 
-// New returns a Compute handler backed by c.
-func New(c computedriver.Compute) *Handler {
-	return &Handler{compute: c}
+// New returns a Compute handler backed by c. net (may be nil) lets insert
+// allocate an instance's private networkIP from the referenced subnetwork's
+// CIDR.
+func New(c computedriver.Compute, net netdriver.Networking) *Handler {
+	return &Handler{compute: c, net: net}
 }
 
 // Matches returns true for /compute/v1/projects/... URLs targeting instances

--- a/server/gcp/compute/instance_response.go
+++ b/server/gcp/compute/instance_response.go
@@ -42,7 +42,7 @@ func toInstanceResponse(inst *computedriver.Instance, project, host string) inst
 		},
 		Metadata:               metadataResponse(metaItems),
 		Scheduling:             defaultScheduling(),
-		ServiceAccounts:        defaultServiceAccounts(),
+		ServiceAccounts:        serviceAccountsFor(inst.Tags),
 		ShieldedInstanceConfig: defaultShieldedConfig(),
 	}
 
@@ -213,6 +213,17 @@ func defaultScheduling() *scheduling {
 		Preemptible:       false,
 		ProvisioningModel: "STANDARD",
 	}
+}
+
+// serviceAccountsFor reflects the serviceAccounts[] the client attached at
+// insert time (email + scopes, round-tripped exactly). When the client omitted
+// them, it falls back to the default compute service account real GCP attaches.
+func serviceAccountsFor(tags map[string]string) []serviceAccount {
+	if sas := decodeServiceAccounts(tags); len(sas) > 0 {
+		return sas
+	}
+
+	return defaultServiceAccounts()
 }
 
 func defaultServiceAccounts() []serviceAccount {

--- a/server/gcp/compute/instance_state.go
+++ b/server/gcp/compute/instance_state.go
@@ -23,6 +23,7 @@ const (
 	keyNetwork       = "cloudemu:gcp:network"
 	keyZone          = "cloudemu:gcp:zone"
 	keyAccessConfigs = "cloudemu:gcp:accessconfigs"
+	keyServiceAccts  = "cloudemu:gcp:serviceaccounts"
 )
 
 // internalTagPrefix marks tag keys that carry CloudEmu-internal GCP state
@@ -34,7 +35,7 @@ const kvStride = 2
 
 // internalTagCap is the number of internal keys insertTags may add, used only
 // as a map preallocation hint.
-const internalTagCap = 7
+const internalTagCap = 8
 
 func isInternalTag(key string) bool {
 	return strings.HasPrefix(key, internalTagPrefix)
@@ -75,6 +76,20 @@ func decodeAccessConfigs(tags map[string]string) []accessConfig {
 	}
 
 	return acs
+}
+
+func decodeServiceAccounts(tags map[string]string) []serviceAccount {
+	raw := tags[keyServiceAccts]
+	if raw == "" {
+		return nil
+	}
+
+	var sas []serviceAccount
+	if err := json.Unmarshal([]byte(raw), &sas); err != nil {
+		return nil
+	}
+
+	return sas
 }
 
 // ephemeralIPPrefix is the leading octet of GCP's public 34.0.0.0/8 range,

--- a/server/gcp/compute/instances.go
+++ b/server/gcp/compute/instances.go
@@ -56,12 +56,15 @@ func (h *Handler) insertInstance(w http.ResponseWriter, r *http.Request, rp gcpr
 		return
 	}
 
+	subnet := firstSubnet(req.NetworkInterfaces)
+
 	cfg := computedriver.InstanceConfig{
 		ImageID:      bootImage(req.Disks),
 		InstanceType: machineTypeShort(req.MachineType),
-		SubnetID:     firstSubnet(req.NetworkInterfaces),
+		SubnetID:     subnet,
 		Tags:         insertTags(&req, rp.ScopeName),
 		UserData:     startupScript(req.Metadata),
+		PrivateIP:    h.privateIPFor(r.Context(), &req, subnet, rp.ScopeName),
 	}
 
 	instances, err := h.compute.RunInstances(r.Context(), cfg, 1)
@@ -337,6 +340,10 @@ func insertTags(req *instanceRequest, zone string) map[string]string {
 
 	if acs := accessConfigsFor(req.NetworkInterfaces, req.Name); len(acs) > 0 {
 		out[keyAccessConfigs] = encodeJSON(acs)
+	}
+
+	if len(req.ServiceAccounts) > 0 {
+		out[keyServiceAccts] = encodeJSON(req.ServiceAccounts)
 	}
 
 	return out

--- a/server/gcp/compute/networkip.go
+++ b/server/gcp/compute/networkip.go
@@ -1,0 +1,141 @@
+package compute
+
+import (
+	"context"
+	"encoding/binary"
+	"net"
+)
+
+// subnetNameTag mirrors the tag the GCP VPC wire handler stamps the
+// subnetwork's user-facing name into (server/gcp/vpc). Kept as a local copy so
+// the compute handler can resolve a subnetwork reference to its stored subnet
+// without importing the vpc handler package.
+const subnetNameTag = "cloudemu:gcpSubnetName"
+
+// ipReservedLowAddrs is the count of low addresses GCP reserves in every
+// subnet (network, gateway, and two more). The broadcast (highest) address is
+// reserved separately.
+const ipReservedLowAddrs = 4
+
+// privateIPFor decides the private networkIP for a launching instance. An
+// explicit networkIP on the request is honored verbatim. Otherwise, when a
+// subnetwork is referenced and resolvable to a CIDR, an address is allocated
+// from that range (past the reserved low addresses, deduped against instances
+// already in the subnet). It returns "" to defer to the provider's synthetic
+// allocator when no subnetwork is referenced or the subnet can't be resolved.
+func (h *Handler) privateIPFor(ctx context.Context, req *instanceRequest, subnet, zone string) string {
+	if ip := firstNetworkIP(req.NetworkInterfaces); ip != "" {
+		return ip
+	}
+
+	if h.net == nil || subnet == "" {
+		return ""
+	}
+
+	cidr, ok := h.subnetCIDR(ctx, subnet, zone)
+	if !ok || cidr == "" {
+		return ""
+	}
+
+	return allocateFromCIDR(cidr, h.usedIPsInSubnet(ctx, subnet))
+}
+
+// firstNetworkIP returns the first explicit networkIP the caller set on a NIC.
+func firstNetworkIP(nics []networkInterface) string {
+	for i := range nics {
+		if nics[i].NetworkIP != "" {
+			return nics[i].NetworkIP
+		}
+	}
+
+	return ""
+}
+
+// subnetCIDR resolves a subnetwork reference (self-link or bare name) to the
+// stored subnet's CIDR, matching by the VPC handler's name tag and, when the
+// reference carries a region, the subnet's region.
+func (h *Handler) subnetCIDR(ctx context.Context, subnetRef, zone string) (string, bool) {
+	subnets, err := h.net.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return "", false
+	}
+
+	region, name := parseSubnetRef(subnetRef, zone)
+
+	for i := range subnets {
+		s := &subnets[i]
+		if tagOr(s.Tags, subnetNameTag, lastSegment(s.ID)) != name {
+			continue
+		}
+
+		if s.AvailabilityZone != "" && region != "" && s.AvailabilityZone != region {
+			continue
+		}
+
+		return s.CIDRBlock, true
+	}
+
+	return "", false
+}
+
+// usedIPsInSubnet collects the private IPs already assigned to instances in the
+// referenced subnet, so a fresh allocation avoids colliding with them.
+func (h *Handler) usedIPsInSubnet(ctx context.Context, subnetRef string) map[string]bool {
+	used := make(map[string]bool)
+
+	instances, err := h.compute.DescribeInstances(ctx, nil, nil)
+	if err != nil {
+		return used
+	}
+
+	name := lastSegment(subnetRef)
+
+	for i := range instances {
+		if instances[i].PrivateIP != "" && lastSegment(instances[i].SubnetID) == name {
+			used[instances[i].PrivateIP] = true
+		}
+	}
+
+	return used
+}
+
+// allocateFromCIDR returns the lowest free IPv4 host address in cidr, skipping
+// the reserved low addresses and the broadcast address and any address already
+// in use. It returns "" for a non-IPv4 CIDR, a range too small to host a VM, or
+// an exhausted range — leaving the caller to fall back to the provider.
+func allocateFromCIDR(cidr string, used map[string]bool) string {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return ""
+	}
+
+	base := ipnet.IP.To4()
+	if base == nil || len(ipnet.Mask) != net.IPv4len {
+		return ""
+	}
+
+	netInt := binary.BigEndian.Uint32(base)
+	broadcast := netInt | ^binary.BigEndian.Uint32(ipnet.Mask)
+
+	// The range must hold the reserved low addresses plus at least one host
+	// below the broadcast address.
+	if broadcast-netInt <= ipReservedLowAddrs {
+		return ""
+	}
+
+	first := netInt + ipReservedLowAddrs
+	last := broadcast - 1 // exclude the broadcast (highest) address
+
+	for v := first; v <= last; v++ {
+		var buf [net.IPv4len]byte
+
+		binary.BigEndian.PutUint32(buf[:], v)
+
+		ip := net.IP(buf[:]).String()
+		if !used[ip] {
+			return ip
+		}
+	}
+
+	return ""
+}

--- a/server/gcp/compute/networkip_sdk_test.go
+++ b/server/gcp/compute/networkip_sdk_test.go
@@ -1,0 +1,267 @@
+package compute_test
+
+import (
+	"context"
+	"net"
+	"net/http/httptest"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/option"
+)
+
+// TestSDKInstanceServiceAccountsRoundTrip proves an instance created with an
+// explicit service_account (email + scopes) reflects that exact block on GET,
+// while an instance created without one falls back to the default compute
+// service account real GCP attaches.
+func TestSDKInstanceServiceAccountsRoundTrip(t *testing.T) {
+	ts := newGCPServerWithNet(t)
+	client := newSDKInstancesClient(t, ts)
+
+	email := "sa@p-1.iam.gserviceaccount.com"
+	scopes := []string{
+		"https://www.googleapis.com/auth/devstorage.read_only",
+		"https://www.googleapis.com/auth/logging.write",
+	}
+
+	insertBasicInstance(t, client, "sa-vm", &computepb.NetworkInterface{
+		Network: ptrStr("global/networks/default"),
+	}, []*computepb.ServiceAccount{{Email: ptrStr(email), Scopes: scopes}})
+
+	got := getSDKInstance(t, client, "sa-vm")
+
+	sas := got.GetServiceAccounts()
+	if len(sas) != 1 {
+		t.Fatalf("sa-vm has %d serviceAccounts, want 1", len(sas))
+	}
+
+	if sas[0].GetEmail() != email {
+		t.Errorf("serviceAccount email=%q want %q", sas[0].GetEmail(), email)
+	}
+
+	if len(sas[0].GetScopes()) != 2 || sas[0].GetScopes()[0] != scopes[0] || sas[0].GetScopes()[1] != scopes[1] {
+		t.Errorf("serviceAccount scopes=%v want %v", sas[0].GetScopes(), scopes)
+	}
+
+	// An instance without a service_account gets the default compute SA.
+	insertBasicInstance(t, client, "default-sa-vm", &computepb.NetworkInterface{
+		Network: ptrStr("global/networks/default"),
+	}, nil)
+
+	def := getSDKInstance(t, client, "default-sa-vm")
+
+	dsas := def.GetServiceAccounts()
+	if len(dsas) != 1 || dsas[0].GetEmail() != "default" {
+		t.Fatalf("default-sa-vm serviceAccounts=%v want single email=default", dsas)
+	}
+
+	if len(dsas[0].GetScopes()) != 1 || dsas[0].GetScopes()[0] != "https://www.googleapis.com/auth/cloud-platform" {
+		t.Errorf("default SA scopes=%v want [cloud-platform]", dsas[0].GetScopes())
+	}
+}
+
+// TestSDKInstanceNetworkIPFromSubnetCIDR proves an instance launched into a
+// subnetwork gets a private networkIP inside that subnet's ipCidrRange (past
+// the reserved low addresses), a second instance gets a distinct in-range IP,
+// an explicit networkIP is honored verbatim, and an instance in no subnet
+// falls back cleanly to the synthetic allocator.
+func TestSDKInstanceNetworkIPFromSubnetCIDR(t *testing.T) {
+	ts := newGCPServerWithNet(t)
+	client := newSDKInstancesClient(t, ts)
+
+	const cidr = "10.20.0.0/24"
+
+	createSubnet(t, ts, "vpc-ip", "sub-ip", cidr)
+
+	subRef := "projects/" + testProject + "/regions/" + testRegion + "/subnetworks/sub-ip"
+
+	insertBasicInstance(t, client, "sub-vm-1", &computepb.NetworkInterface{
+		Subnetwork: ptrStr(subRef),
+	}, nil)
+	insertBasicInstance(t, client, "sub-vm-2", &computepb.NetworkInterface{
+		Subnetwork: ptrStr(subRef),
+	}, nil)
+
+	ip1 := getSDKInstanceNetworkIP(t, client, "sub-vm-1")
+	ip2 := getSDKInstanceNetworkIP(t, client, "sub-vm-2")
+
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("ParseCIDR: %v", err)
+	}
+
+	assertInRangePastReserved(t, ipnet, ip1)
+	assertInRangePastReserved(t, ipnet, ip2)
+
+	if ip1 == ip2 {
+		t.Errorf("sub-vm-1 and sub-vm-2 share networkIP %s, want distinct", ip1)
+	}
+
+	// An explicit networkIP is honored as-is.
+	const explicit = "10.20.0.99"
+
+	insertBasicInstance(t, client, "sub-vm-explicit", &computepb.NetworkInterface{
+		Subnetwork: ptrStr(subRef),
+		NetworkIP:  ptrStr(explicit),
+	}, nil)
+
+	if got := getSDKInstanceNetworkIP(t, client, "sub-vm-explicit"); got != explicit {
+		t.Errorf("explicit networkIP=%s want %s", got, explicit)
+	}
+
+	// An instance in no subnetwork falls back to the synthetic allocator: it
+	// still gets an IP and does not land in the subnet's range.
+	insertBasicInstance(t, client, "no-sub-vm", &computepb.NetworkInterface{
+		Network: ptrStr("global/networks/default"),
+	}, nil)
+
+	fallback := getSDKInstanceNetworkIP(t, client, "no-sub-vm")
+	if fallback == "" {
+		t.Fatal("no-sub-vm has no networkIP, want synthetic fallback")
+	}
+
+	if ipnet.Contains(net.ParseIP(fallback)) {
+		t.Errorf("no-sub-vm networkIP=%s unexpectedly inside %s", fallback, cidr)
+	}
+}
+
+// insertBasicInstance creates an instance with a single NIC and the given
+// service accounts, waiting for the operation to complete.
+func insertBasicInstance(
+	t *testing.T, c *gcpcompute.InstancesClient, name string,
+	nic *computepb.NetworkInterface, sas []*computepb.ServiceAccount,
+) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	op, err := c.Insert(ctx, &computepb.InsertInstanceRequest{
+		Project: testProject, Zone: testZone,
+		InstanceResource: &computepb.Instance{
+			Name:              ptrStr(name),
+			MachineType:       ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+			NetworkInterfaces: []*computepb.NetworkInterface{nic},
+			ServiceAccounts:   sas,
+		},
+	})
+	if err != nil {
+		t.Fatalf("instance %s Insert: %v", name, err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("instance %s Insert wait: %v", name, err)
+	}
+}
+
+func getSDKInstance(t *testing.T, c *gcpcompute.InstancesClient, name string) *computepb.Instance {
+	t.Helper()
+
+	inst, err := c.Get(context.Background(), &computepb.GetInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: name,
+	})
+	if err != nil {
+		t.Fatalf("instance %s Get: %v", name, err)
+	}
+
+	return inst
+}
+
+func getSDKInstanceNetworkIP(t *testing.T, c *gcpcompute.InstancesClient, name string) string {
+	t.Helper()
+
+	inst := getSDKInstance(t, c, name)
+
+	nics := inst.GetNetworkInterfaces()
+	if len(nics) == 0 {
+		t.Fatalf("instance %s has no networkInterfaces", name)
+	}
+
+	return nics[0].GetNetworkIP()
+}
+
+// createSubnet creates a custom-mode network and a subnetwork with the given
+// CIDR in testRegion, so an instance can reference it by name.
+func createSubnet(t *testing.T, ts *httptest.Server, netName, subName, cidr string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	netClient, err := gcpcompute.NewNetworksRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewNetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = netClient.Close() })
+
+	auto := false
+
+	netOp, err := netClient.Insert(ctx, &computepb.InsertNetworkRequest{
+		Project: testProject,
+		NetworkResource: &computepb.Network{
+			Name:                  ptrStr(netName),
+			AutoCreateSubnetworks: &auto,
+		},
+	})
+	if err != nil {
+		t.Fatalf("network Insert: %v", err)
+	}
+
+	if err := netOp.Wait(ctx); err != nil {
+		t.Fatalf("network Insert wait: %v", err)
+	}
+
+	subClient, err := gcpcompute.NewSubnetworksRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewSubnetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = subClient.Close() })
+
+	subOp, err := subClient.Insert(ctx, &computepb.InsertSubnetworkRequest{
+		Project: testProject, Region: testRegion,
+		SubnetworkResource: &computepb.Subnetwork{
+			Name:        ptrStr(subName),
+			Network:     ptrStr("projects/" + testProject + "/global/networks/" + netName),
+			IpCidrRange: ptrStr(cidr),
+		},
+	})
+	if err != nil {
+		t.Fatalf("subnetwork Insert: %v", err)
+	}
+
+	if err := subOp.Wait(ctx); err != nil {
+		t.Fatalf("subnetwork Insert wait: %v", err)
+	}
+}
+
+// assertInRangePastReserved fails unless ip is inside ipnet and past the four
+// reserved low addresses (network, gateway, and two more).
+func assertInRangePastReserved(t *testing.T, ipnet *net.IPNet, ip string) {
+	t.Helper()
+
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		t.Fatalf("networkIP %q is not a valid IP", ip)
+	}
+
+	if !ipnet.Contains(parsed) {
+		t.Fatalf("networkIP %s is not inside %s", ip, ipnet.String())
+	}
+
+	v4 := parsed.To4()
+	base := ipnet.IP.To4()
+
+	if v4 == nil || base == nil {
+		t.Fatalf("networkIP %s / range %s are not IPv4", ip, ipnet.String())
+	}
+
+	// The host offset within the range must skip the four reserved low addresses.
+	offset := (uint32(v4[0])<<24 | uint32(v4[1])<<16 | uint32(v4[2])<<8 | uint32(v4[3])) -
+		(uint32(base[0])<<24 | uint32(base[1])<<16 | uint32(base[2])<<8 | uint32(base[3]))
+	if offset < 4 {
+		t.Errorf("networkIP %s offset %d falls in the reserved low addresses (want >= 4)", ip, offset)
+	}
+}

--- a/server/gcp/compute/types.go
+++ b/server/gcp/compute/types.go
@@ -14,6 +14,7 @@ type instanceRequest struct {
 	Tags              tagsBlock          `json:"tags,omitempty"`
 	Labels            map[string]string  `json:"labels,omitempty"`
 	Metadata          metadataBlock      `json:"metadata,omitempty"`
+	ServiceAccounts   []serviceAccount   `json:"serviceAccounts,omitempty"`
 }
 
 // metadataBlock is GCP's instance metadata. The boot script is carried as a

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -160,7 +160,9 @@ func New(d Drivers) *server.Server {
 	srv.Register(lro.New(opsReg))
 
 	if d.Compute != nil {
-		srv.Register(compute.New(d.Compute))
+		// d.Networking (may be nil) lets insert allocate the instance's private
+		// networkIP from the referenced subnetwork's CIDR.
+		srv.Register(compute.New(d.Compute, d.Networking))
 	}
 
 	if d.Networking != nil {

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -55,6 +55,12 @@ type InstanceConfig struct {
 	// setting the NIC's properties.virtualMachine back-reference. Ignored by
 	// AWS/GCP.
 	NetworkInterfaces []AzureNICRef
+	// PrivateIP is an explicit private IPv4 address to assign to the launched
+	// instance's primary NIC. Empty leaves allocation to the provider. Used by
+	// GCP, where the wire layer either honors the client's networkIP or picks an
+	// address from the referenced subnetwork's CIDR before launch. Ignored by
+	// AWS/Azure.
+	PrivateIP string
 }
 
 // AzureNICRef identifies a Network Interface (Microsoft.Network/networkInterfaces)


### PR DESCRIPTION
## Summary

Fixes two GCE instance field-modeling gaps that caused Terraform drift on `google_compute_instance`.

### GAP A — serviceAccounts hardcoded
`defaultServiceAccounts()` always returned `{email:"default", scopes:[cloud-platform]}`, so an instance created with a `service_account { email, scopes }` block dropped the client's value and GET never reflected it.

- Capture `serviceAccounts[]` at insert into a new internal tag (`cloudemu:gcp:serviceaccounts`), mirroring the accessConfigs (#810) tag pattern; `internalTagCap` bumped 7 → 8.
- Reflect the exact email + scopes on GET. When the client omits `serviceAccounts`, keep the default compute SA (real GCP attaches it).

### GAP B — networkIP not from the subnet CIDR
`nextIP()` handed out generic `10.128.x.x` regardless of the referenced subnetwork, so `networkIP` never fell inside the subnet's `ipCidrRange`.

- The compute wire handler now takes the networking driver (mirrors `vpc.New(net, compute)`); wired in `server/gcp/gcp.go` via `compute.New(d.Compute, d.Networking)`.
- On insert it resolves the referenced subnetwork to its CIDR and allocates the lowest free host address past the reserved low addresses (`.0`/`.1`/`.2`/`.3`) and the broadcast, deduped against instances already in that subnet. Carried to the provider via a new additive `InstanceConfig.PrivateIP`.
- An explicit `networkIP` in the request is honored verbatim. No subnetwork / unresolvable subnet falls back cleanly to the synthetic allocator (no regression).

## Tests

Real `cloud.google.com/go/compute` clients over httptest:
- `TestSDKInstanceServiceAccountsRoundTrip` — explicit email+scopes reflected on GET; omitted → default compute SA.
- `TestSDKInstanceNetworkIPFromSubnetCIDR` — instance in a `10.20.0.0/24` subnet gets an in-range IP past reserved addresses; a 2nd instance gets a distinct in-range IP; explicit networkIP honored; instance in no subnet falls back cleanly.

Gates: build, vet, `go generate`/compatgen (no diff), gofmt, golangci-lint `--new-from-rev` (0 new), and the full targeted test set all green.
