### PR TITLE
fix(gcp-bigtable): honor pageSize/pageToken on lists + strict updateMask on patches

### DIFF
--- a/providers/gcp/bigtable/bigtable.go
+++ b/providers/gcp/bigtable/bigtable.go
@@ -186,16 +186,52 @@ func (m *Mock) updateInstanceLocked(name string, cfg btdriver.UpdateInstanceConf
 		return btdriver.Instance{}, cerrors.Newf(cerrors.NotFound, "instance %q not found", name)
 	}
 
-	inst.DisplayName = orKeep(cfg.DisplayName, inst.DisplayName)
-	inst.Type = orKeep(cfg.Type, inst.Type)
-
-	if cfg.Labels != nil {
-		inst.Labels = copyLabels(cfg.Labels)
-	}
-
+	applyInstanceUpdate(&inst, cfg)
 	m.instances.Set(name, inst)
 
 	return inst, nil
+}
+
+// applyInstanceUpdate mutates inst per cfg. With no field mask it uses presence
+// heuristics (a non-empty value replaces, an empty one is kept), preserving the
+// pre-mask semantics. With a mask it writes only the masked fields — even to an
+// empty value, which clears them — and preserves every unmasked field.
+func applyInstanceUpdate(inst *btdriver.Instance, cfg btdriver.UpdateInstanceConfig) {
+	if cfg.UpdateMask == nil {
+		inst.DisplayName = orKeep(cfg.DisplayName, inst.DisplayName)
+		inst.Type = orKeep(cfg.Type, inst.Type)
+
+		if cfg.Labels != nil {
+			inst.Labels = copyLabels(cfg.Labels)
+		}
+
+		return
+	}
+
+	if maskHas(cfg.UpdateMask, "displayname") {
+		inst.DisplayName = cfg.DisplayName
+	}
+
+	if maskHas(cfg.UpdateMask, "type") {
+		inst.Type = cfg.Type
+	}
+
+	if maskHas(cfg.UpdateMask, "labels") {
+		inst.Labels = copyLabels(cfg.Labels)
+	}
+}
+
+// maskHas reports whether the normalized field-mask tokens name field. Tokens
+// are pre-normalized by the caller (lowercased, underscores stripped), so this
+// is a plain membership check.
+func maskHas(mask []string, field string) bool {
+	for _, p := range mask {
+		if p == field {
+			return true
+		}
+	}
+
+	return false
 }
 
 // UpdateInstance replaces an instance's mutable fields (synchronous Update RPC).

--- a/server/gcp/bigtable/app_profiles.go
+++ b/server/gcp/bigtable/app_profiles.go
@@ -68,9 +68,14 @@ func (h *Handler) listAppProfiles(w http.ResponseWriter, r *http.Request, rt *ro
 		return
 	}
 
-	out := &bt.ListAppProfilesResponse{}
-	for i := range profiles {
-		out.AppProfiles = append(out.AppProfiles, toWireAppProfile(&profiles[i]))
+	page, next, ok := paginate(w, r, profiles)
+	if !ok {
+		return
+	}
+
+	out := &bt.ListAppProfilesResponse{NextPageToken: next}
+	for i := range page {
+		out.AppProfiles = append(out.AppProfiles, toWireAppProfile(&page[i]))
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, out)
@@ -82,7 +87,22 @@ func (h *Handler) updateAppProfile(w http.ResponseWriter, r *http.Request, rt *r
 		return
 	}
 
-	cfg := fromWireAppProfile(rt.parent, lastSegment(rt.name), &in)
+	id := lastSegment(rt.name)
+
+	// Without a mask, replace the profile from the body (legacy behavior). With
+	// a mask, overlay only the masked fields onto the current profile so an
+	// unmasked routing policy or description is preserved rather than wiped.
+	cfg := fromWireAppProfile(rt.parent, id, &in)
+
+	if mask := parseFieldMask(r.URL.Query().Get("updateMask")); mask != nil {
+		cur, err := h.db.GetAppProfile(r.Context(), rt.name)
+		if err != nil {
+			gcprest.WriteCErr(w, err)
+			return
+		}
+
+		cfg = mergeAppProfileConfig(rt.parent, id, cur, &in, mask)
+	}
 
 	a, op, err := h.db.UpdateAppProfile(r.Context(), rt.name, cfg)
 	if err != nil {

--- a/server/gcp/bigtable/backups.go
+++ b/server/gcp/bigtable/backups.go
@@ -105,9 +105,14 @@ func (h *Handler) listBackups(w http.ResponseWriter, r *http.Request, rt *route)
 		return
 	}
 
-	out := &bt.ListBackupsResponse{}
-	for i := range backups {
-		out.Backups = append(out.Backups, toWireBackup(&backups[i]))
+	page, next, ok := paginate(w, r, backups)
+	if !ok {
+		return
+	}
+
+	out := &bt.ListBackupsResponse{NextPageToken: next}
+	for i := range page {
+		out.Backups = append(out.Backups, toWireBackup(&page[i]))
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, out)

--- a/server/gcp/bigtable/clusters.go
+++ b/server/gcp/bigtable/clusters.go
@@ -87,9 +87,14 @@ func (h *Handler) listClusters(w http.ResponseWriter, r *http.Request, rt *route
 		return
 	}
 
-	out := &bt.ListClustersResponse{}
-	for i := range clusters {
-		out.Clusters = append(out.Clusters, toWireCluster(&clusters[i]))
+	page, next, ok := paginate(w, r, clusters)
+	if !ok {
+		return
+	}
+
+	out := &bt.ListClustersResponse{NextPageToken: next}
+	for i := range page {
+		out.Clusters = append(out.Clusters, toWireCluster(&page[i]))
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, out)
@@ -101,7 +106,23 @@ func (h *Handler) updateCluster(w http.ResponseWriter, r *http.Request, rt *rout
 		return
 	}
 
-	c, op, err := h.db.UpdateCluster(r.Context(), rt.name, int(in.ServeNodes), fromWireAutoscaling(&in))
+	serveNodes := int(in.ServeNodes)
+	autoscaling := fromWireAutoscaling(&in)
+
+	// With a field mask, apply only the masked scaling fields: an unmasked
+	// serveNodes/autoscaling is dropped so the driver preserves it instead of
+	// switching the cluster's scaling mode as a side effect.
+	if mask := parseFieldMask(r.URL.Query().Get("updateMask")); mask != nil {
+		if !mask.has("serveNodes") {
+			serveNodes = 0
+		}
+
+		if !mask.contains("autoscaling") {
+			autoscaling = nil
+		}
+	}
+
+	c, op, err := h.db.UpdateCluster(r.Context(), rt.name, serveNodes, autoscaling)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return

--- a/server/gcp/bigtable/convert.go
+++ b/server/gcp/bigtable/convert.go
@@ -189,6 +189,43 @@ func fromWireAppProfile(parent, id string, a *bt.AppProfile) btdriver.CreateAppP
 	return cfg
 }
 
+// mergeAppProfileConfig overlays the fields named by mask (from body) onto the
+// current app profile, returning an update config in which every unmasked field
+// keeps its current value. Routing is treated as one unit: any routing path in
+// the mask replaces the whole routing policy from the body.
+func mergeAppProfileConfig(
+	parent, id string, cur *btdriver.AppProfile, body *bt.AppProfile, mask *fieldMask,
+) btdriver.CreateAppProfileConfig {
+	cfg := btdriver.CreateAppProfileConfig{
+		Parent:                   parent,
+		AppProfileID:             id,
+		Description:              cur.Description,
+		MultiClusterRoutingAny:   cur.MultiClusterRoutingAny,
+		MultiClusterClusterIDs:   cur.MultiClusterClusterIDs,
+		SingleClusterID:          cur.SingleClusterID,
+		AllowTransactionalWrites: cur.AllowTransactionalWrites,
+		Priority:                 cur.Priority,
+	}
+
+	if mask.has("description") {
+		cfg.Description = body.Description
+	}
+
+	if mask.contains("routing") {
+		b := fromWireAppProfile(parent, id, body)
+		cfg.MultiClusterRoutingAny = b.MultiClusterRoutingAny
+		cfg.MultiClusterClusterIDs = b.MultiClusterClusterIDs
+		cfg.SingleClusterID = b.SingleClusterID
+		cfg.AllowTransactionalWrites = b.AllowTransactionalWrites
+	}
+
+	if mask.contains("priority") || mask.contains("isolation") {
+		cfg.Priority = body.Priority
+	}
+
+	return cfg
+}
+
 func toWireBackup(b *btdriver.Backup) *bt.Backup {
 	out := &bt.Backup{
 		Name: b.Name, SourceTable: b.SourceTable, SourceBackup: b.SourceBackup,

--- a/server/gcp/bigtable/instances.go
+++ b/server/gcp/bigtable/instances.go
@@ -91,9 +91,14 @@ func (h *Handler) listInstances(w http.ResponseWriter, r *http.Request, rt *rout
 		return
 	}
 
-	out := &bt.ListInstancesResponse{}
-	for i := range insts {
-		out.Instances = append(out.Instances, toWireInstance(&insts[i]))
+	page, next, ok := paginate(w, r, insts)
+	if !ok {
+		return
+	}
+
+	out := &bt.ListInstancesResponse{NextPageToken: next}
+	for i := range page {
+		out.Instances = append(out.Instances, toWireInstance(&page[i]))
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, out)
@@ -122,9 +127,12 @@ func (h *Handler) partialUpdateInstance(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	inst, op, err := h.db.PartialUpdateInstance(r.Context(), rt.name, btdriver.UpdateInstanceConfig{
-		DisplayName: in.DisplayName, Type: in.Type, Labels: in.Labels,
-	})
+	cfg := btdriver.UpdateInstanceConfig{DisplayName: in.DisplayName, Type: in.Type, Labels: in.Labels}
+	if mask := parseFieldMask(r.URL.Query().Get("updateMask")); mask != nil {
+		cfg.UpdateMask = mask.paths
+	}
+
+	inst, op, err := h.db.PartialUpdateInstance(r.Context(), rt.name, cfg)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return

--- a/server/gcp/bigtable/mask.go
+++ b/server/gcp/bigtable/mask.go
@@ -1,0 +1,69 @@
+package bigtable
+
+import "strings"
+
+// fieldMask is a parsed google.protobuf.FieldMask taken from the ?updateMask
+// query param. A nil *fieldMask means the client sent no mask, so the patch
+// handlers fall back to their presence-heuristic behavior for back-compat.
+type fieldMask struct {
+	// paths are normalized tokens: lowercased with underscores stripped, so
+	// snake_case and camelCase spellings of the same path compare equal
+	// ("deletion_protection" and "deletionProtection" both -> "deletionprotection").
+	paths []string
+}
+
+// parseFieldMask reads a comma-separated FieldMask. It returns nil when the
+// param is absent or empty so callers keep their legacy update behavior.
+func parseFieldMask(raw string) *fieldMask {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+
+	m := &fieldMask{}
+
+	for _, p := range strings.Split(raw, ",") {
+		if p = normalizeMaskPath(p); p != "" {
+			m.paths = append(m.paths, p)
+		}
+	}
+
+	if len(m.paths) == 0 {
+		return nil
+	}
+
+	return m
+}
+
+func normalizeMaskPath(s string) string {
+	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(s), "_", ""))
+}
+
+// has reports whether the mask names field, either exactly or as the leading
+// segment of a dotted sub-path (e.g. "singleClusterRouting.clusterId" is a
+// change to "singleClusterRouting"). field is normalized by this method.
+func (m *fieldMask) has(field string) bool {
+	field = normalizeMaskPath(field)
+
+	for _, p := range m.paths {
+		if p == field || strings.HasPrefix(p, field+".") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// contains reports whether any masked path contains sub as a substring, used
+// for the dotted autoscaling/routing paths whose exact spelling varies across
+// clients. sub is normalized by this method.
+func (m *fieldMask) contains(sub string) bool {
+	sub = normalizeMaskPath(sub)
+
+	for _, p := range m.paths {
+		if strings.Contains(p, sub) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/gcp/bigtable/pagination_updatemask_sdk_test.go
+++ b/server/gcp/bigtable/pagination_updatemask_sdk_test.go
@@ -1,0 +1,329 @@
+package bigtable_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strings"
+	"testing"
+
+	bt "google.golang.org/api/bigtableadmin/v2"
+)
+
+// mkInstance creates an instance (with a single cluster) via the real SDK.
+func mkInstance(t *testing.T, svc *bt.Service, id string, labels map[string]string) {
+	t.Helper()
+
+	op, err := svc.Projects.Instances.Create(instanceParent(), &bt.CreateInstanceRequest{
+		InstanceId: id,
+		Instance:   &bt.Instance{DisplayName: id, Type: "PRODUCTION", Labels: labels},
+		Clusters: map[string]bt.Cluster{
+			"c1": {Location: "projects/" + project + "/locations/us-central1-a", ServeNodes: 3, DefaultStorageType: "SSD"},
+		},
+	}).Do()
+	if err != nil {
+		t.Fatalf("create instance %s: %v", id, err)
+	}
+
+	if !op.Done {
+		t.Fatalf("create instance %s: op not done", id)
+	}
+}
+
+// assertPagedNames checks that names gathered across pages are the expected
+// count, in stable ascending order (no gap), with no duplicates.
+func assertPagedNames(t *testing.T, got []string, want int) {
+	t.Helper()
+
+	if len(got) != want {
+		t.Fatalf("paged names: got %d %v, want %d", len(got), got, want)
+	}
+
+	if !sort.StringsAreSorted(got) {
+		t.Fatalf("paged names not in stable ascending order: %v", got)
+	}
+
+	seen := make(map[string]bool, len(got))
+	for _, n := range got {
+		if seen[n] {
+			t.Fatalf("duplicate name across pages: %q in %v", n, got)
+		}
+
+		seen[n] = true
+	}
+}
+
+// getInstances lists instances over the raw wire. The bigtableadmin SDK exposes
+// no PageSize on the instances list call (the real API does not page it), so the
+// server's pagination is exercised directly with the real response type.
+func getInstances(t *testing.T, base, query string) *bt.ListInstancesResponse {
+	t.Helper()
+
+	resp, err := http.Get(base + "/v2/" + instanceParent() + "/instances?" + query) //nolint:noctx // test helper
+	if err != nil {
+		t.Fatalf("GET instances: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // test helper
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET instances: status %d", resp.StatusCode)
+	}
+
+	var out bt.ListInstancesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode instances: %v", err)
+	}
+
+	return &out
+}
+
+func TestSDKListInstancesPaging(t *testing.T) {
+	svc, ts := newSDKClientServer(t)
+	ids := []string{"i-a", "i-b", "i-c"}
+
+	for _, id := range ids {
+		mkInstance(t, svc, id, nil)
+	}
+
+	p1 := getInstances(t, ts.URL, "pageSize=2")
+	if len(p1.Instances) != 2 || p1.NextPageToken == "" {
+		t.Fatalf("page 1: got %d instances, token %q; want 2 + token", len(p1.Instances), p1.NextPageToken)
+	}
+
+	p2 := getInstances(t, ts.URL, "pageSize=2&pageToken="+p1.NextPageToken)
+	if len(p2.Instances) != 1 || p2.NextPageToken != "" {
+		t.Fatalf("page 2: got %d instances, token %q; want 1 + empty", len(p2.Instances), p2.NextPageToken)
+	}
+
+	got := make([]string, 0, len(ids))
+	for _, in := range append(append([]*bt.Instance{}, p1.Instances...), p2.Instances...) {
+		got = append(got, in.Name)
+	}
+
+	assertPagedNames(t, got, len(ids))
+}
+
+func TestSDKListTablesPaging(t *testing.T) {
+	svc := newSDKClient(t)
+	inst := createAppInstance(t, svc)
+
+	for _, id := range []string{"t-a", "t-b", "t-c"} {
+		if _, err := svc.Projects.Instances.Tables.Create(inst, &bt.CreateTableRequest{TableId: id}).Do(); err != nil {
+			t.Fatalf("create table %s: %v", id, err)
+		}
+	}
+
+	p1, err := svc.Projects.Instances.Tables.List(inst).PageSize(2).Do()
+	if err != nil || len(p1.Tables) != 2 || p1.NextPageToken == "" {
+		t.Fatalf("tables page 1: %v len=%d token=%q", err, len(p1.Tables), p1.NextPageToken)
+	}
+
+	p2, err := svc.Projects.Instances.Tables.List(inst).PageSize(2).PageToken(p1.NextPageToken).Do()
+	if err != nil || len(p2.Tables) != 1 || p2.NextPageToken != "" {
+		t.Fatalf("tables page 2: %v len=%d token=%q", err, len(p2.Tables), p2.NextPageToken)
+	}
+
+	got := make([]string, 0, 3)
+	for _, x := range p1.Tables {
+		got = append(got, x.Name)
+	}
+
+	for _, x := range p2.Tables {
+		got = append(got, x.Name)
+	}
+
+	assertPagedNames(t, got, 3)
+}
+
+func TestSDKListAppProfilesPaging(t *testing.T) {
+	svc := newSDKClient(t)
+	inst := createAppInstance(t, svc)
+
+	for _, id := range []string{"ap-a", "ap-b", "ap-c"} {
+		if _, err := svc.Projects.Instances.AppProfiles.Create(inst, &bt.AppProfile{
+			SingleClusterRouting: &bt.SingleClusterRouting{ClusterId: "c1"},
+		}).AppProfileId(id).Do(); err != nil {
+			t.Fatalf("create app profile %s: %v", id, err)
+		}
+	}
+
+	p1, err := svc.Projects.Instances.AppProfiles.List(inst).PageSize(2).Do()
+	if err != nil || len(p1.AppProfiles) != 2 || p1.NextPageToken == "" {
+		t.Fatalf("appProfiles page 1: %v len=%d token=%q", err, len(p1.AppProfiles), p1.NextPageToken)
+	}
+
+	p2, err := svc.Projects.Instances.AppProfiles.List(inst).PageSize(2).PageToken(p1.NextPageToken).Do()
+	if err != nil || len(p2.AppProfiles) != 1 || p2.NextPageToken != "" {
+		t.Fatalf("appProfiles page 2: %v len=%d token=%q", err, len(p2.AppProfiles), p2.NextPageToken)
+	}
+
+	got := make([]string, 0, 3)
+	for _, x := range p1.AppProfiles {
+		got = append(got, x.Name)
+	}
+
+	for _, x := range p2.AppProfiles {
+		got = append(got, x.Name)
+	}
+
+	assertPagedNames(t, got, 3)
+}
+
+func TestSDKListBackupsPaging(t *testing.T) {
+	svc := newSDKClient(t)
+	inst := createAppInstance(t, svc)
+	cluster := inst + "/clusters/c1"
+
+	if _, err := svc.Projects.Instances.Tables.Create(inst, &bt.CreateTableRequest{TableId: "src"}).Do(); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	for _, id := range []string{"b-a", "b-b", "b-c"} {
+		if _, err := svc.Projects.Instances.Clusters.Backups.Create(cluster, &bt.Backup{
+			SourceTable: inst + "/tables/src", ExpireTime: "2030-01-01T00:00:00Z",
+		}).BackupId(id).Do(); err != nil {
+			t.Fatalf("create backup %s: %v", id, err)
+		}
+	}
+
+	p1, err := svc.Projects.Instances.Clusters.Backups.List(cluster).PageSize(2).Do()
+	if err != nil || len(p1.Backups) != 2 || p1.NextPageToken == "" {
+		t.Fatalf("backups page 1: %v len=%d token=%q", err, len(p1.Backups), p1.NextPageToken)
+	}
+
+	p2, err := svc.Projects.Instances.Clusters.Backups.List(cluster).PageSize(2).PageToken(p1.NextPageToken).Do()
+	if err != nil || len(p2.Backups) != 1 || p2.NextPageToken != "" {
+		t.Fatalf("backups page 2: %v len=%d token=%q", err, len(p2.Backups), p2.NextPageToken)
+	}
+
+	got := make([]string, 0, 3)
+	for _, x := range p1.Backups {
+		got = append(got, x.Name)
+	}
+
+	for _, x := range p2.Backups {
+		got = append(got, x.Name)
+	}
+
+	assertPagedNames(t, got, 3)
+}
+
+func TestSDKUpdateMaskInstancePreservesAndClears(t *testing.T) {
+	svc := newSDKClient(t)
+	mkInstance(t, svc, "im", map[string]string{"env": "prod", "team": "data"})
+	inst := "projects/" + project + "/instances/im"
+
+	// A displayName-only mask must leave labels and type untouched.
+	if _, err := svc.Projects.Instances.PartialUpdateInstance(inst,
+		&bt.Instance{DisplayName: "Renamed"}).UpdateMask("displayName").Do(); err != nil {
+		t.Fatalf("partial update displayName: %v", err)
+	}
+
+	got, err := svc.Projects.Instances.Get(inst).Do()
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.DisplayName != "Renamed" {
+		t.Fatalf("displayName not applied: %q", got.DisplayName)
+	}
+
+	if len(got.Labels) != 2 || got.Labels["env"] != "prod" || got.Labels["team"] != "data" {
+		t.Fatalf("labels not preserved under displayName mask: %+v", got.Labels)
+	}
+
+	// A labels mask with an empty body clears labels (masked field written even
+	// when empty) while leaving the unmasked displayName intact.
+	if _, err := svc.Projects.Instances.PartialUpdateInstance(inst,
+		&bt.Instance{}).UpdateMask("labels").Do(); err != nil {
+		t.Fatalf("partial update clear labels: %v", err)
+	}
+
+	got, _ = svc.Projects.Instances.Get(inst).Do()
+	if len(got.Labels) != 0 {
+		t.Fatalf("labels not cleared by mask: %+v", got.Labels)
+	}
+
+	if got.DisplayName != "Renamed" {
+		t.Fatalf("displayName changed by an unrelated labels mask: %q", got.DisplayName)
+	}
+}
+
+func TestSDKUpdateMaskTablePreservesDeletionProtection(t *testing.T) {
+	svc := newSDKClient(t)
+	inst := createAppInstance(t, svc)
+	name := inst + "/tables/dp"
+
+	if _, err := svc.Projects.Instances.Tables.Create(inst, &bt.CreateTableRequest{
+		TableId: "dp", Table: &bt.Table{DeletionProtection: true},
+	}).Do(); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	// Patching an unrelated masked field must NOT reset deletionProtection.
+	if _, err := svc.Projects.Instances.Tables.Patch(name,
+		&bt.Table{}).UpdateMask("changeStreamConfig").Do(); err != nil {
+		t.Fatalf("patch table (unrelated field): %v", err)
+	}
+
+	got, err := svc.Projects.Instances.Tables.Get(name).Do()
+	if err != nil {
+		t.Fatalf("get table: %v", err)
+	}
+
+	if !got.DeletionProtection {
+		t.Fatal("deletionProtection was reset by an unrelated masked patch")
+	}
+
+	// Masking deletionProtection itself does change it.
+	if _, err := svc.Projects.Instances.Tables.Patch(name,
+		&bt.Table{DeletionProtection: false}).UpdateMask("deletionProtection").Do(); err != nil {
+		t.Fatalf("patch table (deletionProtection): %v", err)
+	}
+
+	got, _ = svc.Projects.Instances.Tables.Get(name).Do()
+	if got.DeletionProtection {
+		t.Fatal("deletionProtection not cleared when masked")
+	}
+}
+
+func TestSDKUpdateMaskAbsentKeepsHeuristic(t *testing.T) {
+	svc := newSDKClient(t)
+	mkInstance(t, svc, "ih", map[string]string{"k": "v"})
+	inst := "projects/" + project + "/instances/ih"
+
+	// No updateMask: legacy presence heuristic — a non-empty displayName is
+	// applied while empty type/labels are kept.
+	if _, err := svc.Projects.Instances.PartialUpdateInstance(inst, &bt.Instance{DisplayName: "H2"}).Do(); err != nil {
+		t.Fatalf("partial update (no mask): %v", err)
+	}
+
+	got, _ := svc.Projects.Instances.Get(inst).Do()
+	if got.DisplayName != "H2" {
+		t.Fatalf("displayName: %q", got.DisplayName)
+	}
+
+	if got.Type != "PRODUCTION" {
+		t.Fatalf("type not preserved by heuristic: %q", got.Type)
+	}
+
+	if got.Labels["k"] != "v" {
+		t.Fatalf("labels not preserved by heuristic: %+v", got.Labels)
+	}
+}
+
+func TestSDKCreateDuplicateInstanceConflict(t *testing.T) {
+	svc := newSDKClient(t)
+	mkInstance(t, svc, "dup", nil)
+
+	_, err := svc.Projects.Instances.Create(instanceParent(), &bt.CreateInstanceRequest{
+		InstanceId: "dup",
+		Instance:   &bt.Instance{DisplayName: "dup", Type: "PRODUCTION"},
+		Clusters: map[string]bt.Cluster{
+			"c1": {Location: "projects/" + project + "/locations/us-central1-a", ServeNodes: 3},
+		},
+	}).Do()
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("duplicate create: got %v, want alreadyExists", err)
+	}
+}

--- a/server/gcp/bigtable/paging.go
+++ b/server/gcp/bigtable/paging.go
@@ -1,0 +1,48 @@
+package bigtable
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+)
+
+const (
+	defaultPageSize = 100
+	maxPageSize     = 1000
+)
+
+// pageParams reads the ?pageSize / ?pageToken list query params. An absent,
+// non-numeric, or non-positive pageSize falls back to the default; larger
+// values are capped. token is the opaque offset cursor (empty for the first
+// page).
+func pageParams(r *http.Request) (size int, token string) {
+	size = defaultPageSize
+
+	if n, err := strconv.Atoi(r.URL.Query().Get("pageSize")); err == nil && n > 0 {
+		size = n
+	}
+
+	if size > maxPageSize {
+		size = maxPageSize
+	}
+
+	return size, r.URL.Query().Get("pageToken")
+}
+
+// paginate slices one page out of items (which the driver already returns in a
+// stable name order) using the request's pageSize/pageToken. It returns the
+// page items and the nextPageToken (empty on the last page). On a malformed
+// token it writes a 400 and returns ok=false.
+func paginate[T any](w http.ResponseWriter, r *http.Request, items []T) (page []T, nextPageToken string, ok bool) {
+	size, token := pageParams(r)
+
+	p, err := pagination.Paginate(items, token, size)
+	if err != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid pageToken")
+		return nil, "", false
+	}
+
+	return p.Items, p.NextPageToken, true
+}

--- a/server/gcp/bigtable/sdk_roundtrip_test.go
+++ b/server/gcp/bigtable/sdk_roundtrip_test.go
@@ -18,6 +18,17 @@ const project = "p1"
 func newSDKClient(t *testing.T) *bt.Service {
 	t.Helper()
 
+	svc, _ := newSDKClientServer(t)
+
+	return svc
+}
+
+// newSDKClientServer returns a real bigtableadmin client and the httptest
+// server it targets, so tests that need the raw endpoint URL (e.g. list
+// paging over a call the SDK exposes no PageSize for) can reach it directly.
+func newSDKClientServer(t *testing.T) (*bt.Service, *httptest.Server) {
+	t.Helper()
+
 	cloud := cloudemu.NewGCP()
 	srv := gcpserver.New(gcpserver.Drivers{Bigtable: cloud.Bigtable})
 
@@ -29,7 +40,7 @@ func newSDKClient(t *testing.T) *bt.Service {
 		t.Fatalf("bigtableadmin.NewService: %v", err)
 	}
 
-	return svc
+	return svc, ts
 }
 
 func instanceParent() string { return "projects/" + project }

--- a/server/gcp/bigtable/tables.go
+++ b/server/gcp/bigtable/tables.go
@@ -100,9 +100,14 @@ func (h *Handler) listTables(w http.ResponseWriter, r *http.Request, rt *route) 
 		return
 	}
 
-	out := &bt.ListTablesResponse{}
-	for i := range tables {
-		out.Tables = append(out.Tables, toWireTable(&tables[i]))
+	page, next, ok := paginate(w, r, tables)
+	if !ok {
+		return
+	}
+
+	out := &bt.ListTablesResponse{NextPageToken: next}
+	for i := range page {
+		out.Tables = append(out.Tables, toWireTable(&page[i]))
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, out)
@@ -114,9 +119,18 @@ func (h *Handler) patchTable(w http.ResponseWriter, r *http.Request, rt *route) 
 		return
 	}
 
+	// Without a mask, always write deletionProtection from the body (legacy
+	// behavior). With a mask, write it only when masked — so a patch of some
+	// other field (e.g. changeStreamConfig) leaves deletionProtection intact
+	// instead of silently resetting it to false.
 	dp := in.DeletionProtection
+	dpPtr := &dp
 
-	t, op, err := h.db.UpdateTable(r.Context(), rt.name, &dp)
+	if mask := parseFieldMask(r.URL.Query().Get("updateMask")); mask != nil && !mask.has("deletionProtection") {
+		dpPtr = nil
+	}
+
+	t, op, err := h.db.UpdateTable(r.Context(), rt.name, dpPtr)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return

--- a/services/bigtable/driver/driver.go
+++ b/services/bigtable/driver/driver.go
@@ -143,10 +143,17 @@ type CreateClusterConfig struct {
 }
 
 // UpdateInstanceConfig carries the mutable instance fields.
+//
+// UpdateMask holds the normalized field-mask tokens (lowercased, underscores
+// stripped) naming the fields the caller intends to change. When it is nil the
+// update falls back to presence heuristics (a non-empty value replaces, an
+// empty one is kept) for back-compat; when it is non-nil only the named fields
+// are written — even to an empty/zero value — and every other field is kept.
 type UpdateInstanceConfig struct {
 	DisplayName string
 	Type        string
 	Labels      map[string]string
+	UpdateMask  []string
 }
 
 // CreateTableConfig is the input to CreateTable.


### PR DESCRIPTION
## Summary

Adds list pagination and strict field-mask honoring to the GCP Bigtable Admin wire handler (`server/gcp/bigtable`). The surface was otherwise solid; this fills two real-client gaps found in audit without changing round-trip / LRO / error-mapping behavior.

### 1. List pagination (5 lists)
`ListInstances`, `ListClusters`, `ListTables`, `ListAppProfiles`, `ListBackups` now honor `pageSize` (default 100, capped at 1000) and `pageToken`, and emit `nextPageToken` when more results remain. Reuses the shared `internal/pagination` offset-token codec (same pattern as Secret Manager / Cloud DNS). The driver already returns results in stable name order, so paging is deterministic with no dup/gap.

### 2. Strict updateMask (4 patches)
`PartialUpdateInstance`, `patchTable`, `updateCluster`, `updateAppProfile` now parse the `updateMask` query param (comma-separated field paths, snake_case/camelCase tolerant) and apply **only** the masked fields — a masked field is written even to an empty/zero value (clear), an unmasked field is preserved.

Fixes the case where a table PATCH masking an unrelated field (e.g. `changeStreamConfig`) incidentally reset `deletionProtection` to `false`. When `updateMask` is **absent**, the previous presence-heuristic behavior is kept unchanged for back-compat.

- Instance mask is threaded into the driver (`UpdateInstanceConfig.UpdateMask`) so masked-but-empty fields can be cleared.
- Table (deletionProtection pointer) and cluster (serveNodes/autoscaling) mask gating is done at the handler layer.
- App-profile patch overlays masked fields onto the current profile so an unmasked routing policy / description is preserved.

No driver interface method signatures changed; `go generate` (docs) and compatgen produce zero diff.

## Tests
Real `google.golang.org/api/bigtableadmin/v2` client over `httptest`:
- Paging: instances (over the raw wire — the SDK exposes no `PageSize` for the instances list), plus tables, app profiles, and backups via the typed `PageSize`/`PageToken` calls — first page + `nextPageToken`, remainder page, stable order, no dup/gap.
- updateMask: displayName-only mask preserves labels/type; table `changeStreamConfig` mask preserves `deletionProtection` (the bug); a masked field can be cleared; absent mask keeps the old heuristic.
- Regression: duplicate-create 409 plus the existing round-trip / get / delete / LRO / 404 suite still pass.

Gates: `go build ./...`, `go vet ./...`, `go test ./server/gcp/bigtable/... ./providers/gcp/bigtable/...`, gofmt, and `golangci-lint --new-from-rev=origin/development` (0 new issues) all green.