### PR TITLE
fix(azure-storage): emit BlobCreated on PutBlockList and CopyBlob paths

### DIFF
--- a/providers/azure/blobstorage/blob_extensions.go
+++ b/providers/azure/blobstorage/blob_extensions.go
@@ -123,6 +123,7 @@ func (m *Mock) CommitBlockList(
 	ctr.staging.Delete(blob)
 
 	m.emitMetric(container, map[string]float64{"Transactions": 1, "Ingress": float64(len(data))})
+	m.emitBlobCreatedAPI(ctx, obj, container, blobEventAPIPutBlockList)
 
 	info := objectInfo(obj)
 

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -731,6 +731,7 @@ func (m *Mock) copyBlobInternal(
 	dstCtr.objects.Set(dstKey, dstObj)
 
 	m.emitMetric(dstBucket, map[string]float64{"Transactions": 1})
+	m.emitBlobCreatedAPI(ctx, dstObj, dstBucket, blobEventAPICopyBlob)
 
 	info := objectInfo(dstObj)
 

--- a/providers/azure/blobstorage/eventgrid_events.go
+++ b/providers/azure/blobstorage/eventgrid_events.go
@@ -17,6 +17,11 @@ const (
 	eventTypeBlobDeleted = "Microsoft.Storage.BlobDeleted"
 	blobEventAPICreate   = "PutBlob"
 	blobEventAPIDelete   = "DeleteBlob"
+	// blobEventAPIPutBlockList / blobEventAPICopyBlob are the api operation names
+	// real Azure stamps on the BlobCreated event when a blob is written via
+	// Commit Block List (large / SDK-chunked uploads) or a blob copy.
+	blobEventAPIPutBlockList = "PutBlockList"
+	blobEventAPICopyBlob     = "CopyBlob"
 	// blobEventDataVersion is the schema version real Azure Blob Storage stamps
 	// on its BlobCreated/BlobDeleted event data.
 	blobEventDataVersion = "2"
@@ -66,9 +71,17 @@ func (m *Mock) storageAccountID() string {
 	return idgen.AzureID(m.opts.AccountID, rg, storageProvider, storageResourceType, AccountName)
 }
 
-// emitBlobCreated fires a Microsoft.Storage.BlobCreated event for a written blob.
+// emitBlobCreated fires a Microsoft.Storage.BlobCreated event for a blob written
+// via the Put Blob path (api=PutBlob).
 func (m *Mock) emitBlobCreated(ctx context.Context, obj *blobObject, container string) {
-	m.emitBlobEvent(ctx, eventTypeBlobCreated, blobEventAPICreate, &blobEventFacts{
+	m.emitBlobCreatedAPI(ctx, obj, container, blobEventAPICreate)
+}
+
+// emitBlobCreatedAPI fires a Microsoft.Storage.BlobCreated event for a written
+// blob, stamping the given api operation name (PutBlob / PutBlockList / CopyBlob)
+// so consumers see which write path produced the blob, as real Azure does.
+func (m *Mock) emitBlobCreatedAPI(ctx context.Context, obj *blobObject, container, api string) {
+	m.emitBlobEvent(ctx, eventTypeBlobCreated, api, &blobEventFacts{
 		container: container, key: obj.Key, eTag: obj.ETag,
 		contentType: obj.ContentType, contentLength: obj.Size, blobType: obj.BlobType,
 	})

--- a/providers/azure/blobstorage/eventgrid_events_test.go
+++ b/providers/azure/blobstorage/eventgrid_events_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/providers/azure/eventgrid"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -145,6 +146,95 @@ func TestBlobCreatedEmitsToSubscriber(t *testing.T) {
 	// topic is the storage account's ARM id (the source resource), not the Event
 	// Grid topic the subscription hangs off.
 	assert.Contains(t, got[0].Topic, "/providers/Microsoft.Storage/storageAccounts/cloudemu")
+}
+
+// TestBlobCreatedEmitsOnCommitBlockList covers the block-list upload path (the
+// standard SDK path for large blobs): StageBlock + CommitBlockList delivers a
+// Microsoft.Storage.BlobCreated event stamped api=PutBlockList.
+func TestBlobCreatedEmitsOnCommitBlockList(t *testing.T) {
+	receiver := newBlobWebhookReceiver(t)
+	bm, eg := newWiredMocks(t)
+	ctx := context.Background()
+
+	subscribe(t, eg, "sub1", receiver.URL, map[string]any{
+		"includedEventTypes": []string{eventTypeBlobCreated},
+	})
+
+	require.NoError(t, bm.CreateBucket(ctx, "big"))
+	require.NoError(t, bm.StageBlock(ctx, "big", "large.bin", "b1", []byte("foo")))
+	require.NoError(t, bm.StageBlock(ctx, "big", "large.bin", "b2", []byte("bar")))
+	_, err := bm.CommitBlockList(ctx, "big", "large.bin",
+		[]driver.BlockListEntry{
+			{ID: "b1", List: driver.BlockListLatest},
+			{ID: "b2", List: driver.BlockListLatest},
+		}, "application/octet-stream", nil, nil)
+	require.NoError(t, err)
+
+	got := receiver.events()
+	require.Len(t, got, 1)
+	assert.Equal(t, eventTypeBlobCreated, got[0].EventType)
+	assert.Equal(t, "/blobServices/default/containers/big/blobs/large.bin", got[0].Subject)
+
+	var data map[string]any
+	require.NoError(t, json.Unmarshal(got[0].Data, &data))
+	assert.Equal(t, blobEventAPIPutBlockList, data["api"])
+	assert.EqualValues(t, 6, data["contentLength"])
+	assert.NotEmpty(t, data["eTag"])
+	assert.Equal(t, "https://cloudemu.blob.core.windows.net/big/large.bin", data["url"])
+}
+
+// TestBlobCreatedEmitsOnCopyBlob covers the copy path: CopyObject delivers a
+// Microsoft.Storage.BlobCreated event stamped api=CopyBlob on completion (the
+// destination blob exists), with the destination subject.
+func TestBlobCreatedEmitsOnCopyBlob(t *testing.T) {
+	receiver := newBlobWebhookReceiver(t)
+	bm, eg := newWiredMocks(t)
+	ctx := context.Background()
+
+	subscribe(t, eg, "sub1", receiver.URL, map[string]any{
+		"includedEventTypes": []string{eventTypeBlobCreated},
+	})
+
+	require.NoError(t, bm.CreateBucket(ctx, "src"))
+	require.NoError(t, bm.CreateBucket(ctx, "dst"))
+	require.NoError(t, bm.PutObject(ctx, "src", "orig.txt", []byte("hello"), "text/plain", nil))
+
+	require.NoError(t, bm.CopyObject(ctx, "dst", "copy.txt", driver.CopySource{Bucket: "src", Key: "orig.txt"}))
+
+	got := receiver.events()
+	// Two BlobCreated events: the source PutObject (PutBlob) and the copy (CopyBlob).
+	require.Len(t, got, 2)
+
+	var copyData map[string]any
+	require.NoError(t, json.Unmarshal(got[1].Data, &copyData))
+	assert.Equal(t, eventTypeBlobCreated, got[1].EventType)
+	assert.Equal(t, "/blobServices/default/containers/dst/blobs/copy.txt", got[1].Subject)
+	assert.Equal(t, blobEventAPICopyBlob, copyData["api"])
+	assert.EqualValues(t, 5, copyData["contentLength"])
+	assert.Equal(t, "https://cloudemu.blob.core.windows.net/dst/copy.txt", copyData["url"])
+}
+
+// TestBlockListAndCopySucceedWithoutPublisher covers the nil-publisher safety of
+// both new emit paths: with no Event Grid publisher wired, CommitBlockList and
+// CopyObject still succeed (no panic).
+func TestBlockListAndCopySucceedWithoutPublisher(t *testing.T) {
+	bm := newTestMock() // no SetEventGridPublisher
+	ctx := context.Background()
+
+	require.NoError(t, bm.CreateBucket(ctx, "src"))
+	require.NoError(t, bm.CreateBucket(ctx, "dst"))
+
+	require.NoError(t, bm.StageBlock(ctx, "src", "k", "b1", []byte("foo")))
+	_, err := bm.CommitBlockList(ctx, "src", "k",
+		[]driver.BlockListEntry{{ID: "b1", List: driver.BlockListLatest}},
+		"text/plain", nil, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, bm.CopyObject(ctx, "dst", "k", driver.CopySource{Bucket: "src", Key: "k"}))
+
+	obj, err := bm.GetObject(ctx, "dst", "k")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("foo"), obj.Data)
 }
 
 // TestBlobDeletedEmitsToSubscriber covers case (b): a DELETE delivers a


### PR DESCRIPTION
## Summary

Extends the Azure Blob -> Event Grid producer (#804) to fire `Microsoft.Storage.BlobCreated` on the two write paths that were previously silent: **Commit Block List** (the standard SDK upload path for large / chunked blobs) and **Copy Blob**. Before this, only the Put Blob path (`putBlockBlobInternal`) emitted, so a user uploading a large blob via block-list or copying a blob received no Event Grid event.

## Changes

- `CommitBlockList` success path now emits `BlobCreated` with `api=PutBlockList`.
- `copyBlobInternal` (backing `CopyObject`/`CopyObjectV2`) emits `BlobCreated` with `api=CopyBlob` on copy completion (destination blob exists), matching real Azure.
- Reuses the existing #804 event builder/schema via a new `emitBlobCreatedAPI(api)` helper; the subject/data shape is identical, only the `api` field differs. No schema duplication.
- Best-effort / nil-publisher-safe exactly like #804: with no Event Grid publisher wired, both writes still succeed.

## Tests

- Block-list upload (StageBlock + CommitBlockList) delivers a `BlobCreated` event with `api=PutBlockList`, correct subject/data.
- CopyBlob delivers `BlobCreated` with `api=CopyBlob` on completion (destination subject).
- Nil-publisher: both new paths succeed, no panic.
- No regression: Put Blob still emits `api=PutBlob`; block-list/copy CRUD unchanged.