### PR TITLE
fix(azure): echo overlay recurses into arrays so inline-element unmodeled fields round-trip

### DIFF
--- a/server/azure/echo_array_test.go
+++ b/server/azure/echo_array_test.go
@@ -1,0 +1,209 @@
+package azure
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestMissingArrayElementsRecursesPerElement is the core capture-side guarantee:
+// an unmodeled sub-field on an array element (whose sibling fields the handler
+// models) is captured, aligned to the element's index, while a fully-modeled
+// element contributes nothing.
+func TestMissingArrayElementsRecursesPerElement(t *testing.T) {
+	req := []any{
+		map[string]any{"lun": float64(0), "caching": "ReadOnly", "writeAcceleratorEnabled": true},
+		map[string]any{"lun": float64(1), "caching": "None"},
+	}
+	resp := []any{
+		map[string]any{"lun": float64(0), "caching": "ReadOnly"},
+		map[string]any{"lun": float64(1), "caching": "None"},
+	}
+
+	got := missingArrayElements(req, resp)
+
+	want := []any{
+		map[string]any{"writeAcceleratorEnabled": true},
+		nil,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("missingArrayElements = %#v, want %#v", got, want)
+	}
+}
+
+// TestMissingArrayElementsNoUnmodeled returns nil when every element is fully
+// modeled, so the overlay records nothing for the array (no regression: a
+// modeled array is left untouched).
+func TestMissingArrayElementsNoUnmodeled(t *testing.T) {
+	req := []any{map[string]any{"lun": float64(0), "caching": "ReadOnly"}}
+	resp := []any{map[string]any{"lun": float64(0), "caching": "ReadOnly"}}
+
+	if got := missingArrayElements(req, resp); got != nil {
+		t.Fatalf("missingArrayElements = %#v, want nil", got)
+	}
+}
+
+// TestMissingArrayElementsLengthMismatch confirms neither a longer nor a shorter
+// request panics or describes more elements than the response holds. The
+// response count is authoritative: a request longer than the response yields no
+// phantom elements, and a request shorter simply leaves the response tail
+// unmatched.
+func TestMissingArrayElementsLengthMismatch(t *testing.T) {
+	// Request LONGER than response: only the response-length prefix is diffed.
+	reqLong := []any{
+		map[string]any{"lun": float64(0), "extra": "keep0"},
+		map[string]any{"lun": float64(1), "extra": "keep1"},
+		map[string]any{"lun": float64(2), "extra": "phantom"},
+	}
+	respShort := []any{
+		map[string]any{"lun": float64(0)},
+	}
+
+	got := missingArrayElements(reqLong, respShort)
+	if len(got) != 1 {
+		t.Fatalf("request longer than response: got len %d, want 1 (no phantom elements)", len(got))
+	}
+
+	if !reflect.DeepEqual(got[0], map[string]any{"extra": "keep0"}) {
+		t.Fatalf("request longer than response: got[0] = %#v, want {extra:keep0}", got[0])
+	}
+
+	// Request SHORTER than response: only the request-length prefix is diffed;
+	// the response tail is left unmatched (nil-safe, no index out of range).
+	reqShort := []any{map[string]any{"lun": float64(0), "extra": "keep0"}}
+	respLong := []any{
+		map[string]any{"lun": float64(0)},
+		map[string]any{"lun": float64(1)},
+	}
+
+	got = missingArrayElements(reqShort, respLong)
+	if len(got) != 1 || !reflect.DeepEqual(got[0], map[string]any{"extra": "keep0"}) {
+		t.Fatalf("request shorter than response: got = %#v, want [{extra:keep0}]", got)
+	}
+}
+
+// TestMissingArrayElementsScalarsAndNil confirms scalar elements and nil/empty
+// slices are no-ops at this level: a scalar element present in both is left to
+// the handler (the wholly-unmodeled scalar array is captured verbatim by the
+// caller's !present branch, not here), and empty inputs yield nil.
+func TestMissingArrayElementsScalarsAndNil(t *testing.T) {
+	if got := missingArrayElements([]any{"a", "b"}, []any{"a", "b"}); got != nil {
+		t.Fatalf("scalar arrays: got %#v, want nil", got)
+	}
+
+	if got := missingArrayElements(nil, nil); got != nil {
+		t.Fatalf("nil arrays: got %#v, want nil", got)
+	}
+
+	if got := missingArrayElements([]any{}, []any{map[string]any{"x": 1}}); got != nil {
+		t.Fatalf("empty request: got %#v, want nil", got)
+	}
+}
+
+// TestMergeArrayElementsPreservesResponseShape is the apply-side guarantee: the
+// response array's length, order and modeled fields are preserved exactly, only
+// the per-element unmodeled sub-fields are added back, and a modeled field is
+// never overwritten.
+func TestMergeArrayElementsPreservesResponseShape(t *testing.T) {
+	resp := []any{
+		map[string]any{"lun": float64(0), "diskSizeGB": float64(32)},
+		map[string]any{"lun": float64(1), "diskSizeGB": float64(64)},
+	}
+	unmodeled := []any{
+		// carries writeAcceleratorEnabled AND a modeled key (lun) that must NOT win.
+		map[string]any{"writeAcceleratorEnabled": true, "lun": float64(99)},
+		nil,
+	}
+
+	got := mergeArrayElements(resp, unmodeled)
+
+	if len(got) != 2 {
+		t.Fatalf("merge changed element count: got %d, want 2", len(got))
+	}
+
+	el0, _ := got[0].(map[string]any)
+	if el0["lun"] != float64(0) {
+		t.Errorf("merge overwrote modeled lun: got %v, want 0", el0["lun"])
+	}
+
+	if el0["diskSizeGB"] != float64(32) {
+		t.Errorf("merge lost modeled diskSizeGB: got %v", el0["diskSizeGB"])
+	}
+
+	if el0["writeAcceleratorEnabled"] != true {
+		t.Errorf("merge dropped unmodeled writeAcceleratorEnabled: got %v", el0["writeAcceleratorEnabled"])
+	}
+
+	if !reflect.DeepEqual(got[1], resp[1]) {
+		t.Errorf("merge disturbed an element with no overlay: got %#v, want %#v", got[1], resp[1])
+	}
+}
+
+// TestMergeArrayElementsNeverInjectsPhantom confirms an unmodeled slice longer
+// than the response never appends elements the response does not have (the
+// handler owns element count) and never indexes past either slice.
+func TestMergeArrayElementsNeverInjectsPhantom(t *testing.T) {
+	resp := []any{map[string]any{"lun": float64(0)}}
+	unmodeled := []any{
+		map[string]any{"extra": "keep0"},
+		map[string]any{"extra": "phantom"},
+	}
+
+	got := mergeArrayElements(resp, unmodeled)
+	if len(got) != 1 {
+		t.Fatalf("merge injected phantom elements: got len %d, want 1", len(got))
+	}
+
+	el0, _ := got[0].(map[string]any)
+	if el0["extra"] != "keep0" {
+		t.Errorf("merge dropped the first element's unmodeled field: got %v", el0["extra"])
+	}
+
+	// A response longer than the overlay leaves the tail untouched.
+	resp2 := []any{map[string]any{"lun": float64(0)}, map[string]any{"lun": float64(1)}}
+	got2 := mergeArrayElements(resp2, []any{nil})
+
+	if !reflect.DeepEqual(got2, resp2) {
+		t.Errorf("overlay shorter than response disturbed the tail: got %#v, want %#v", got2, resp2)
+	}
+}
+
+// TestMissingPropertiesArrayEndToEnd exercises the whole capture+merge cycle
+// through the public helpers exactly as the middleware chains them: an unmodeled
+// element sub-field nested under a modeled array (storageProfile.dataDisks)
+// survives, while the modeled fields stay authoritative and no element is added.
+func TestMissingPropertiesArrayEndToEnd(t *testing.T) {
+	req := map[string]any{
+		"storageProfile": map[string]any{
+			"dataDisks": []any{
+				map[string]any{"lun": float64(0), "diskSizeGB": float64(32), "writeAcceleratorEnabled": true},
+			},
+		},
+	}
+	resp := map[string]any{
+		"storageProfile": map[string]any{
+			"dataDisks": []any{
+				map[string]any{"lun": float64(0), "diskSizeGB": float64(32), "caching": "ReadOnly"},
+			},
+		},
+	}
+
+	unmodeled := missingProperties(req, resp)
+
+	merged := mergeProperties(resp, unmodeled)
+
+	sp, _ := merged["storageProfile"].(map[string]any)
+	disks, _ := sp["dataDisks"].([]any)
+
+	if len(disks) != 1 {
+		t.Fatalf("end-to-end changed disk count: got %d, want 1", len(disks))
+	}
+
+	d0, _ := disks[0].(map[string]any)
+	if d0["writeAcceleratorEnabled"] != true {
+		t.Errorf("end-to-end dropped unmodeled writeAcceleratorEnabled: got %v", d0["writeAcceleratorEnabled"])
+	}
+
+	if d0["lun"] != float64(0) || d0["diskSizeGB"] != float64(32) || d0["caching"] != "ReadOnly" {
+		t.Errorf("end-to-end disturbed modeled dataDisk fields: %#v", d0)
+	}
+}

--- a/server/azure/echo_properties.go
+++ b/server/azure/echo_properties.go
@@ -468,10 +468,12 @@ func sanitizeUnmodeled(v any) any {
 }
 
 // missingProperties returns the entries of req that resp does not already carry,
-// descending into nested objects so an unmodeled leaf under a modeled parent is
-// still captured. A key present in both as scalars is considered modeled (the
-// handler owns it) and is omitted. Write-only secret keys (writeOnlyProperty)
-// are skipped at every level so they are never captured, persisted, or echoed.
+// descending into nested objects — and, element-by-element, into arrays of
+// objects — so an unmodeled leaf under a modeled parent (or under a modeled
+// array element, e.g. a vnet inline subnet or a VM data disk) is still captured.
+// A key present in both as scalars is considered modeled (the handler owns it)
+// and is omitted. Write-only secret keys (writeOnlyProperty) are skipped at
+// every level so they are never captured, persisted, or echoed.
 func missingProperties(req, resp map[string]any) map[string]any {
 	if len(req) == 0 {
 		return nil
@@ -495,12 +497,21 @@ func missingProperties(req, resp map[string]any) map[string]any {
 			continue
 		}
 
-		reqChild, reqIsMap := reqVal.(map[string]any)
-		respChild, respIsMap := respVal.(map[string]any)
+		if reqChild, ok := reqVal.(map[string]any); ok {
+			if respChild, ok := respVal.(map[string]any); ok {
+				if nested := missingProperties(reqChild, respChild); len(nested) > 0 {
+					out[k] = nested
+				}
+			}
 
-		if reqIsMap && respIsMap {
-			if nested := missingProperties(reqChild, respChild); len(nested) > 0 {
-				out[k] = nested
+			continue
+		}
+
+		if reqArr, ok := reqVal.([]any); ok {
+			if respArr, ok := respVal.([]any); ok {
+				if nested := missingArrayElements(reqArr, respArr); nested != nil {
+					out[k] = nested
+				}
 			}
 		}
 	}
@@ -512,9 +523,55 @@ func missingProperties(req, resp map[string]any) map[string]any {
 	return out
 }
 
+// missingArrayElements diffs a request array against the response array that a
+// handler returned for the same key, element by element and aligned by index,
+// so unmodeled sub-fields on an array element (e.g. an inline subnet's or a data
+// disk's un-modeled property) survive round-trip the same way nested-object
+// sub-fields already do. It returns an []any positionally aligned to the request
+// prefix, each entry being that element's own missingProperties diff (or nil
+// when the element carries nothing unmodeled), or nil overall when no element
+// has anything to carry.
+//
+// It never describes more elements than BOTH sides have (n = min): the handler
+// alone decides how many elements the response holds, so a request longer than
+// the response contributes nothing for the surplus (no phantom elements), and a
+// request shorter than the response simply leaves the response tail unenriched.
+// Only object elements paired with object elements are diffed; a scalar element
+// present in both is left to the handler (a wholly-unmodeled scalar array is
+// captured verbatim by the caller's !present branch instead).
+func missingArrayElements(req, resp []any) []any {
+	n := len(resp)
+	if len(req) < n {
+		n = len(req)
+	}
+
+	out := make([]any, n)
+
+	found := false
+
+	for i := 0; i < n; i++ {
+		reqEl, reqOK := req[i].(map[string]any)
+		respEl, respOK := resp[i].(map[string]any)
+
+		if reqOK && respOK {
+			if nested := missingProperties(reqEl, respEl); len(nested) > 0 {
+				out[i] = nested
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		return nil
+	}
+
+	return out
+}
+
 // mergeProperties overlays the unmodeled properties onto resp without
 // overwriting any key resp already carries (the handler/driver is authoritative
-// for the properties it models). Nested objects are merged recursively.
+// for the properties it models). Nested objects — and, element by element,
+// arrays of objects — are merged recursively.
 func mergeProperties(resp, unmodeled map[string]any) map[string]any {
 	// Size the map to resp and let it grow for the unmodeled keys — summing the
 	// two lengths as a capacity hint is a pointless overflow risk for no gain.
@@ -530,12 +587,53 @@ func mergeProperties(resp, unmodeled map[string]any) map[string]any {
 			continue
 		}
 
-		existingChild, existingIsMap := existing.(map[string]any)
-		addChild, addIsMap := addVal.(map[string]any)
+		if existingChild, ok := existing.(map[string]any); ok {
+			if addChild, ok := addVal.(map[string]any); ok {
+				out[k] = mergeProperties(existingChild, addChild)
+			}
 
-		if existingIsMap && addIsMap {
-			out[k] = mergeProperties(existingChild, addChild)
+			continue
 		}
+
+		if existingArr, ok := existing.([]any); ok {
+			if addArr, ok := addVal.([]any); ok {
+				out[k] = mergeArrayElements(existingArr, addArr)
+			}
+		}
+	}
+
+	return out
+}
+
+// mergeArrayElements enriches each response array element with the unmodeled
+// sub-fields captured for it, aligned by index — the apply-side mirror of
+// missingArrayElements. It preserves the response array exactly: same length,
+// same order, same elements, only adding back per-element unmodeled sub-fields
+// (via mergeProperties, which never overwrites a modeled field). It never
+// appends elements the response does not have (the handler owns element count)
+// and never indexes past either slice; elements the overlay has nothing for, and
+// any element that is not an object on both sides, pass through unchanged.
+func mergeArrayElements(resp, unmodeled []any) []any {
+	out := make([]any, len(resp))
+	copy(out, resp)
+
+	n := len(unmodeled)
+	if len(resp) < n {
+		n = len(resp)
+	}
+
+	for i := 0; i < n; i++ {
+		add, addOK := unmodeled[i].(map[string]any)
+		if !addOK || len(add) == 0 {
+			continue
+		}
+
+		base, baseOK := out[i].(map[string]any)
+		if !baseOK {
+			continue
+		}
+
+		out[i] = mergeProperties(base, add)
 	}
 
 	return out

--- a/server/azure/virtualmachines/overlay_datadisk_test.go
+++ b/server/azure/virtualmachines/overlay_datadisk_test.go
@@ -1,0 +1,125 @@
+package virtualmachines_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+)
+
+// TestSDKDataDiskUnmodeledFieldRoundTrips is the load-bearing test for the echo
+// overlay's array recursion on VMs: a data disk attached with a sub-field the
+// handler does not model (writeAcceleratorEnabled) must reflect that sub-field
+// on the VM's storageProfile.dataDisks entry at GET — before the fix it was
+// dropped because the overlay only recursed into maps, never array elements —
+// while the modeled fields the handler rebuilds from real attachment state
+// (lun, diskSizeGB, managedDisk.id) stay authoritative and no phantom disk is
+// injected.
+func TestSDKDataDiskUnmodeledFieldRoundTrips(t *testing.T) {
+	vmClient, diskClient := newDataDiskTestServer(t)
+	ctx := context.Background()
+
+	vmPoller, err := vmClient.BeginCreateOrUpdate(ctx, "rg-1", "vm-wa",
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				OSProfile: &armcompute.OSProfile{ComputerName: to.Ptr("vm-wa"), AdminUsername: to.Ptr("azureuser")},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate VM: %v", err)
+	}
+
+	if _, err := pollUntilDone(ctx, vmPoller); err != nil {
+		t.Fatalf("CreateOrUpdate VM poll: %v", err)
+	}
+
+	disk, err := createDataDisk(ctx, t, diskClient, "disk-wa")
+	if err != nil {
+		t.Fatalf("create disk-wa: %v", err)
+	}
+
+	// Attach the disk at lun 0, carrying an unmodeled sub-field
+	// (writeAcceleratorEnabled) alongside the modeled managedDisk reference.
+	attachPoller, err := vmClient.BeginCreateOrUpdate(ctx, "rg-1", "vm-wa",
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				StorageProfile: &armcompute.StorageProfile{
+					DataDisks: []*armcompute.DataDisk{{
+						Lun:                     to.Ptr[int32](0),
+						CreateOption:            to.Ptr(armcompute.DiskCreateOptionTypesAttach),
+						ManagedDisk:             &armcompute.ManagedDiskParameters{ID: disk.ID},
+						WriteAcceleratorEnabled: to.Ptr(true),
+					}},
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate attach: %v", err)
+	}
+
+	attached, err := pollUntilDone(ctx, attachPoller)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate attach poll: %v", err)
+	}
+
+	// The unmodeled sub-field must survive on the create response too.
+	assertDataDiskWriteAccel(t, attached.Properties.StorageProfile, disk.ID)
+
+	// And, the real point of the fix, on a later GET.
+	got, err := vmClient.Get(ctx, "rg-1", "vm-wa", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	assertDataDiskWriteAccel(t, got.Properties.StorageProfile, disk.ID)
+}
+
+// assertDataDiskWriteAccel asserts the VM has exactly one data disk at lun 0
+// whose modeled fields (diskSizeGB, managedDisk.id) are authoritative AND whose
+// unmodeled writeAcceleratorEnabled round-tripped true.
+func assertDataDiskWriteAccel(t *testing.T, sp *armcompute.StorageProfile, wantDiskID *string) {
+	t.Helper()
+
+	if sp == nil {
+		t.Fatalf("storageProfile is nil, want one data disk")
+	}
+
+	if len(sp.DataDisks) != 1 {
+		t.Fatalf("dataDisks=%d entries, want exactly 1 (no phantom elements)", len(sp.DataDisks))
+	}
+
+	d := sp.DataDisks[0]
+
+	if d.Lun == nil || *d.Lun != 0 {
+		t.Errorf("dataDisk lun=%v, want 0", d.Lun)
+	}
+
+	if d.DiskSizeGB == nil || *d.DiskSizeGB != 32 {
+		t.Errorf("dataDisk diskSizeGB=%v, want 32 (modeled)", d.DiskSizeGB)
+	}
+
+	if d.ManagedDisk == nil || d.ManagedDisk.ID == nil || wantDiskID == nil || *d.ManagedDisk.ID != *wantDiskID {
+		t.Errorf("dataDisk managedDisk.id=%v, want %v (modeled)", managedDiskID(d), derefStr(wantDiskID))
+	}
+
+	if d.WriteAcceleratorEnabled == nil || !*d.WriteAcceleratorEnabled {
+		t.Errorf("dataDisk dropped unmodeled writeAcceleratorEnabled: got %v", d.WriteAcceleratorEnabled)
+	}
+}
+
+func managedDiskID(d *armcompute.DataDisk) string {
+	if d == nil || d.ManagedDisk == nil {
+		return "<nil>"
+	}
+
+	return derefStr(d.ManagedDisk.ID)
+}

--- a/server/azure/vnet/overlay_inline_subnet_test.go
+++ b/server/azure/vnet/overlay_inline_subnet_test.go
@@ -1,0 +1,150 @@
+package vnet_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKInlineSubnetUnmodeledFieldRoundTrips is the load-bearing test for the
+// echo overlay's array recursion: a vnet created with an INLINE subnet carrying
+// a sub-field the handler does not model (privateEndpointNetworkPolicies) must
+// reflect that sub-field on the inline subnet at GET — before the fix it was
+// dropped because the overlay only recursed into maps, never array elements —
+// while the modeled sub-field (addressPrefix) stays authoritative and no phantom
+// subnet is injected. It also confirms a STANDALONE subnet PUT still echoes the
+// same unmodeled field (the existing map/scalar path, unchanged).
+func TestSDKInlineSubnetUnmodeledFieldRoundTrips(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Network: cloudP.VNet})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnetClient, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	poller, err := vnetClient.BeginCreateOrUpdate(ctx, "rg-1", "vnet-inline",
+		armnetwork.VirtualNetwork{
+			Location: to.Ptr("eastus"),
+			Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+				AddressSpace: &armnetwork.AddressSpace{
+					AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")},
+				},
+				Subnets: []*armnetwork.Subnet{{
+					Name: to.Ptr("sub-a"),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						AddressPrefix: to.Ptr("10.0.1.0/24"),
+						// Not modeled by the vnet handler's subnetResponseProps:
+						// this is exactly the sub-field that used to be dropped on
+						// the inline subnet while a standalone subnet PUT kept it.
+						PrivateEndpointNetworkPolicies: to.Ptr(armnetwork.VirtualNetworkPrivateEndpointNetworkPoliciesEnabled),
+					},
+				}},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("vnet BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("vnet create poll: %v", err)
+	}
+
+	got, err := vnetClient.Get(ctx, "rg-1", "vnet-inline", nil)
+	if err != nil {
+		t.Fatalf("vnet Get: %v", err)
+	}
+
+	subs := got.Properties.Subnets
+	if len(subs) != 1 {
+		t.Fatalf("GET returned %d subnets, want exactly 1 (no phantom elements)", len(subs))
+	}
+
+	sub := subs[0]
+	if sub.Properties == nil {
+		t.Fatalf("inline subnet has no properties: %#v", sub)
+	}
+
+	// Modeled field: authoritative and correct (not duplicated/clobbered).
+	if sub.Properties.AddressPrefix == nil || *sub.Properties.AddressPrefix != "10.0.1.0/24" {
+		t.Errorf("inline subnet addressPrefix=%v, want 10.0.1.0/24", deref(sub.Properties.AddressPrefix))
+	}
+
+	// Unmodeled field: must now round-trip on the inline subnet (was dropped).
+	if sub.Properties.PrivateEndpointNetworkPolicies == nil ||
+		*sub.Properties.PrivateEndpointNetworkPolicies != armnetwork.VirtualNetworkPrivateEndpointNetworkPoliciesEnabled {
+		t.Errorf("inline subnet dropped unmodeled privateEndpointNetworkPolicies: got %v",
+			policyOf(sub.Properties.PrivateEndpointNetworkPolicies))
+	}
+
+	// A STANDALONE subnet PUT must still echo the same unmodeled field — the
+	// pre-existing map/scalar overlay path, which this change must not regress.
+	subnetClient, err := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subPoller, err := subnetClient.BeginCreateOrUpdate(ctx, "rg-1", "vnet-inline", "sub-standalone",
+		armnetwork.Subnet{
+			Properties: &armnetwork.SubnetPropertiesFormat{
+				AddressPrefix:                  to.Ptr("10.0.2.0/24"),
+				PrivateEndpointNetworkPolicies: to.Ptr(armnetwork.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled),
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("subnet BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := subPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("subnet create poll: %v", err)
+	}
+
+	gotSub, err := subnetClient.Get(ctx, "rg-1", "vnet-inline", "sub-standalone", nil)
+	if err != nil {
+		t.Fatalf("subnet Get: %v", err)
+	}
+
+	if gotSub.Properties == nil || gotSub.Properties.PrivateEndpointNetworkPolicies == nil ||
+		*gotSub.Properties.PrivateEndpointNetworkPolicies != armnetwork.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled {
+		t.Errorf("standalone subnet no longer echoes unmodeled privateEndpointNetworkPolicies: got %v",
+			policyOf(subPolicy(gotSub.Properties)))
+	}
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return "<nil>"
+	}
+
+	return *s
+}
+
+func policyOf(p *armnetwork.VirtualNetworkPrivateEndpointNetworkPolicies) string {
+	if p == nil {
+		return "<nil>"
+	}
+
+	return string(*p)
+}
+
+func subPolicy(p *armnetwork.SubnetPropertiesFormat) *armnetwork.VirtualNetworkPrivateEndpointNetworkPolicies {
+	if p == nil {
+		return nil
+	}
+
+	return p.PrivateEndpointNetworkPolicies
+}


### PR DESCRIPTION
## Summary

The Azure unmodeled-property echo overlay (`server/azure/echo_properties.go`) preserved request properties an ARM handler dropped, but its missing-property computation only recursed into **maps**, never **arrays**. So when a request carried an array of objects and some per-element sub-fields were not modeled by the typed response, those sub-fields were silently dropped on GET. A standalone subnet PUT echoed such a field; the same subnet declared inline under its vnet did not — an inconsistency real Azure does not have.

This extends the overlay to recurse into arrays element-by-element, aligned by index, exactly as it already does for map values.

## What changed

- `missingProperties` now pairs a request array with the response array for the same key and diffs each element via new helper `missingArrayElements`, carrying forward unmodeled per-element sub-fields.
- `mergeProperties` now merges arrays element-by-element via new helper `mergeArrayElements`, enriching each response element with its captured unmodeled sub-fields.
- Existing map and scalar semantics are unchanged; the change is purely additive (only previously-dropped element sub-fields are now carried).

### Guardrails preserved
- Only **adds back** unmodeled fields — never overrides a modeled field, never reorders.
- Never injects elements the response does not have: the response array's length/order/elements are preserved exactly (the handler owns element count).
- Length mismatch is safe (min of the two lengths; no index-out-of-range, no phantom elements); nil/absent/scalar arrays are no-ops.
- Write-only-secret stripping (`sanitizeUnmodeled`/`writeOnlyProperty`) is unaffected — array recursion only descends where both sides are objects.

## Tests
- `server/azure/vnet`: real `armnetwork` client creates a vnet with an inline subnet carrying `privateEndpointNetworkPolicies` (unmodeled) -> GET reflects it on the inline subnet; modeled `addressPrefix` stays authoritative; a standalone subnet PUT still echoes the field (unchanged).
- `server/azure/virtualmachines`: real `armcompute` client attaches a data disk with `writeAcceleratorEnabled` (unmodeled) -> create response and GET both reflect it; modeled `lun`/`diskSizeGB`/`managedDisk.id` stay correct; exactly one disk (no phantom).
- `server/azure` internal unit tests for `missingArrayElements`/`mergeArrayElements`: length mismatch (longer/shorter), scalars, nil/empty, no-phantom, no-override.

Both SDK tests were confirmed to fail without the array-recursion change and pass with it. Full `go test ./server/azure/... ./providers/azure/...` is green.
