### PR TITLE
fix(gcp-monitoring): re-sync notificationChannels to the alarm on alertPolicies.patch (preserving state)

### DIFF
--- a/providers/gcp/monitoring/incidentdelivery_test.go
+++ b/providers/gcp/monitoring/incidentdelivery_test.go
@@ -163,6 +163,70 @@ func TestBreachEmailChannelRecordOnly(t *testing.T) {
 	assert.Empty(t, pub.topics, "email channel must not publish to pubsub")
 }
 
+// TestSetAlarmActionsResyncsChannelsPreservingState covers the patch re-sync
+// gap: after a breach delivered to channel A, replacing the alarm's actions with
+// channel B (as alertPolicies.patch does) must (1) preserve the alarm's current
+// ALARM state and its history — no CreateAlarm reset — and (2) route subsequent
+// incident deliveries to B, never again to A.
+func TestSetAlarmActionsResyncsChannelsPreservingState(t *testing.T) {
+	m, clk := newTestMock()
+
+	pub := &fakePublisher{}
+	m.SetPubSubPublisher(pub)
+
+	ctx := context.Background()
+	const topicA = "projects/test-project/topics/a"
+	const topicB = "projects/test-project/topics/b"
+	idA := createChannel(t, m, channelTypePubSub, topicA)
+	idB := createChannel(t, m, channelTypePubSub, topicB)
+
+	// Create the alarm targeting A and breach it: delivers open to A, state ALARM.
+	require.NoError(t, m.CreateAlarm(ctx, driver.AlarmConfig{
+		Name: "cpu-hot", Namespace: "gcp", MetricName: "metric",
+		ComparisonOperator: "GreaterThanThreshold", Threshold: 0,
+		Period: 60, EvaluationPeriods: 1, Stat: "Average",
+		AlarmActions: []string{idA},
+	}))
+	require.NoError(t, m.PutMetricData(ctx, []driver.MetricDatum{{
+		Namespace: "gcp", MetricName: "metric", Value: 1, Timestamp: clk.Now(),
+	}}))
+
+	alarms, err := m.DescribeAlarms(ctx, []string{"cpu-hot"})
+	require.NoError(t, err)
+	require.Equal(t, "ALARM", alarms[0].State)
+
+	histBefore, err := m.GetAlarmHistory(ctx, "cpu-hot", 0)
+	require.NoError(t, err)
+	require.Len(t, histBefore, 1)
+
+	// Re-sync channels to B in place. State and history must be preserved.
+	require.NoError(t, m.SetAlarmActions(ctx, "cpu-hot", []string{idB}))
+
+	alarms, err = m.DescribeAlarms(ctx, []string{"cpu-hot"})
+	require.NoError(t, err)
+	assert.Equal(t, "ALARM", alarms[0].State, "re-syncing channels must not reset alarm state")
+	assert.Equal(t, []string{idB}, alarms[0].AlarmActions, "alarm actions must reflect the new channel set")
+
+	histAfter, err := m.GetAlarmHistory(ctx, "cpu-hot", 0)
+	require.NoError(t, err)
+	assert.Len(t, histAfter, 1, "re-syncing channels must not add or reset history")
+
+	// Recover then breach again: both new deliveries must target B, never A.
+	clk.Advance(60e9)
+	require.NoError(t, m.PutMetricData(ctx, []driver.MetricDatum{{
+		Namespace: "gcp", MetricName: "metric", Value: 0, Timestamp: clk.Now(),
+	}}))
+	clk.Advance(60e9)
+	require.NoError(t, m.PutMetricData(ctx, []driver.MetricDatum{{
+		Namespace: "gcp", MetricName: "metric", Value: 1, Timestamp: clk.Now(),
+	}}))
+
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	require.Equal(t, []string{topicA, topicB, topicB}, pub.topics,
+		"first delivery went to A; every delivery after the re-sync goes to B")
+}
+
 // TestRecoveryDeliversClosedIncident covers open+close delivery: a breach then a
 // recovery each deliver, the second carrying a closed incident — and the state /
 // history transitions are unchanged (no regression).

--- a/providers/gcp/monitoring/monitoring.go
+++ b/providers/gcp/monitoring/monitoring.go
@@ -458,6 +458,23 @@ func (m *Mock) SetAlarmState(_ context.Context, name, state, reason string) erro
 	return nil
 }
 
+// SetAlarmActions replaces an alert policy's notification targets (AlarmActions)
+// in place, preserving the alarm's current State/StateReason/history and its
+// evaluation config. alertPolicies.patch uses this to re-sync a changed
+// notificationChannels list onto the backing alarm without the state reset a
+// CreateAlarm would cause; a subsequent breach then delivers to the new channel
+// set. actions is copied defensively.
+func (m *Mock) SetAlarmActions(_ context.Context, name string, actions []string) error {
+	a, ok := m.alarms.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "alert policy %q not found", name)
+	}
+
+	a.AlarmActions = append([]string{}, actions...)
+
+	return nil
+}
+
 // CreateNotificationChannel creates a new notification channel and returns its info.
 func (m *Mock) CreateNotificationChannel(
 	_ context.Context, cfg driver.NotificationChannelConfig,

--- a/server/gcp/monitoring/alertpolicies.go
+++ b/server/gcp/monitoring/alertpolicies.go
@@ -1,6 +1,7 @@
 package monitoring
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -8,6 +9,15 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
+
+// alarmActionSetter is the optional driver capability used to re-sync a policy's
+// notificationChannels onto the backing alarm's AlarmActions in place, without
+// the state reset a CreateAlarm would cause. The GCP monitoring mock provides
+// it; keeping it optional avoids forcing every driver.Monitoring impl to carry a
+// method only the alertPolicies.patch path needs.
+type alarmActionSetter interface {
+	SetAlarmActions(ctx context.Context, name string, actions []string) error
+}
 
 // serveAlertPolicies routes /v3/projects/{p}/alertPolicies[/{id}].
 func (h *Handler) serveAlertPolicies(w http.ResponseWriter, r *http.Request, project string, rest []string) {
@@ -175,7 +185,13 @@ func (h *Handler) patchPolicy(w http.ResponseWriter, r *http.Request, project, n
 		cur.UserLabels = body.UserLabels
 	}
 
-	if body.NotificationChannels != nil {
+	// A provided notificationChannels list replaces the policy's channels and is
+	// re-synced onto the backing alarm below. Presence (non-nil) mirrors GCP
+	// patch semantics and the rest of this handler's field-scoped updates: an
+	// unrelated patch that omits the field leaves channels — and delivery —
+	// untouched.
+	channelsProvided := body.NotificationChannels != nil
+	if channelsProvided {
 		cur.NotificationChannels = body.NotificationChannels
 	}
 
@@ -186,6 +202,18 @@ func (h *Handler) patchPolicy(w http.ResponseWriter, r *http.Request, project, n
 	cur.MutationRecord = &mutationRecord{MutateTime: nowRFC3339(), MutatedBy: "cloudemu"}
 	h.policies[name] = cur
 	h.mu.Unlock()
+
+	// Re-sync the changed channels onto the driver alarm's AlarmActions so a
+	// later breach delivers to the new set. Done in place (SetAlarmActions), not
+	// via CreateAlarm, so the alarm's current state/history is preserved.
+	if channelsProvided {
+		if setter, ok := h.mon.(alarmActionSetter); ok {
+			if err := setter.SetAlarmActions(r.Context(), name, cur.NotificationChannels); err != nil && !cerrors.IsNotFound(err) {
+				writeErr(w, err)
+				return
+			}
+		}
+	}
 
 	cur.Name = policyResourceName(project, name)
 

--- a/server/gcp/monitoring/client_test.go
+++ b/server/gcp/monitoring/client_test.go
@@ -3,6 +3,7 @@ package monitoring_test
 import (
 	"context"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"google.golang.org/api/option"
 
 	"github.com/stackshy/cloudemu/v2"
+	gcpmonitoring "github.com/stackshy/cloudemu/v2/providers/gcp/monitoring"
 	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 )
@@ -302,4 +304,114 @@ func TestAlertPolicyPatch(t *testing.T) {
 	if !patched.Enabled {
 		t.Error("patch omitting enabled silently disabled the policy")
 	}
+}
+
+// TestAlertPolicyPatchResyncsChannels guards the patch channel gap: editing a
+// policy's notificationChannels via PATCH must re-sync them onto the backing
+// alarm's AlarmActions (so a later breach delivers to the new set) while
+// preserving the alarm's current state/history; an unrelated patch (displayName)
+// must leave the channels untouched.
+func TestAlertPolicyPatchResyncsChannels(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Monitoring: cloudP.CloudMonitoring})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc := newClient(t, ts)
+	ctx := context.Background()
+
+	const chanA = "projects/p1/notificationChannels/chanA"
+	const chanB = "projects/p1/notificationChannels/chanB"
+
+	created, err := svc.Projects.AlertPolicies.Create("projects/p1", &monitoring.AlertPolicy{
+		DisplayName:          "editable",
+		NotificationChannels: []string{chanA},
+	}).Do()
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	id := created.Name[strings.LastIndex(created.Name, "/")+1:]
+
+	// #806 create path: notificationChannels wired onto the alarm's AlarmActions.
+	if got := alarmActions(t, cloudP.CloudMonitoring, id); !equalStrings(got, []string{chanA}) {
+		t.Fatalf("after create AlarmActions=%v want [%s]", got, chanA)
+	}
+
+	// Simulate a prior breach so the patch's state/history preservation is provable.
+	if err := cloudP.CloudMonitoring.SetAlarmState(ctx, id, "ALARM", "breach"); err != nil {
+		t.Fatalf("set alarm state: %v", err)
+	}
+
+	histBefore, err := cloudP.CloudMonitoring.GetAlarmHistory(ctx, id, 0)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+
+	// Unrelated patch (displayName only): channels must be untouched.
+	if _, err := svc.Projects.AlertPolicies.Patch(created.Name, &monitoring.AlertPolicy{
+		DisplayName: "renamed",
+	}).UpdateMask("displayName").Do(); err != nil {
+		t.Fatalf("patch displayName: %v", err)
+	}
+
+	if got := alarmActions(t, cloudP.CloudMonitoring, id); !equalStrings(got, []string{chanA}) {
+		t.Fatalf("displayName patch changed AlarmActions to %v want [%s]", got, chanA)
+	}
+
+	// Patch notificationChannels to B: re-synced onto the alarm.
+	if _, err := svc.Projects.AlertPolicies.Patch(created.Name, &monitoring.AlertPolicy{
+		NotificationChannels: []string{chanB},
+	}).UpdateMask("notificationChannels").Do(); err != nil {
+		t.Fatalf("patch channels: %v", err)
+	}
+
+	if got := alarmActions(t, cloudP.CloudMonitoring, id); !equalStrings(got, []string{chanB}) {
+		t.Fatalf("after channel patch AlarmActions=%v want [%s]", got, chanB)
+	}
+
+	// State and history preserved across the channel patch (no CreateAlarm reset).
+	alarms, err := cloudP.CloudMonitoring.DescribeAlarms(ctx, []string{id})
+	if err != nil || len(alarms) != 1 {
+		t.Fatalf("describe: err=%v n=%d", err, len(alarms))
+	}
+
+	if alarms[0].State != "ALARM" {
+		t.Errorf("channel patch reset alarm state to %q want ALARM", alarms[0].State)
+	}
+
+	histAfter, err := cloudP.CloudMonitoring.GetAlarmHistory(ctx, id, 0)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+
+	if len(histAfter) != len(histBefore) {
+		t.Errorf("channel patch changed history len %d -> %d", len(histBefore), len(histAfter))
+	}
+}
+
+// alarmActions returns the backing alarm's AlarmActions for the given policy id.
+func alarmActions(t *testing.T, mon *gcpmonitoring.Mock, id string) []string {
+	t.Helper()
+
+	alarms, err := mon.DescribeAlarms(context.Background(), []string{id})
+	if err != nil || len(alarms) != 1 {
+		t.Fatalf("describe alarm %s: err=%v n=%d", id, err, len(alarms))
+	}
+
+	return alarms[0].AlarmActions
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
## Summary

GCP Cloud Monitoring's `alertPolicies.patch` updated a policy's `notificationChannels` in the handler registry but never re-synced them onto the backing driver alarm's `AlarmActions`. Since incident delivery (#806) reads `AlarmActions`, editing a policy's channels via PATCH had no effect on where incidents were delivered.

## Change

- `alertPolicies.patch`: when the request provides `notificationChannels`, re-sync them onto the backing alarm's `AlarmActions` so a subsequent breach delivers to the new channel set. The re-sync happens in place — an unrelated patch (e.g. `displayName` only) that omits the field leaves channels and delivery untouched.
- Added `SetAlarmActions(ctx, name, actions)` on the GCP monitoring mock to replace the alarm's actions **in place**, preserving the alarm's current `State`/`StateReason`/history and evaluation config. Routing through `CreateAlarm` would have reset alarm state — a regression — so it is deliberately avoided. The handler reaches the method via a small optional interface, so no other `driver.Monitoring` implementation is forced to carry a method only this path needs.

## Tests

- Provider-level: after a breach delivered to channel A, re-syncing actions to channel B preserves ALARM state and history, and every subsequent delivery targets B (never A again).
- Server-level (real `monitoring/v3` client): create wires channels onto the alarm (#806); an unrelated `displayName` patch leaves channels unchanged; a `notificationChannels` patch re-syncs them while preserving alarm state/history.
