### PR TITLE
feat(persist): full-surface identity-preserving snapshots (#582 wave 1)

### DIFF
--- a/cmd/cloudemu/persist_serve_test.go
+++ b/cmd/cloudemu/persist_serve_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stackshy/cloudemu/v2/seed"
+	"github.com/stackshy/cloudemu/v2/persist"
 )
 
 // TestRestoreStateIgnoresUnreadableFile covers M1's fail-open half: a corrupt or
@@ -20,12 +20,12 @@ func TestRestoreStateIgnoresUnreadableFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := restoreState(context.Background(), corrupt, map[string]seed.Target{}); err != nil {
+	if err := restoreState(context.Background(), corrupt, map[string]persist.Services{}); err != nil {
 		t.Fatalf("restoreState(corrupt) = %v, want nil (start empty)", err)
 	}
 
 	missing := filepath.Join(dir, "does-not-exist.json")
-	if err := restoreState(context.Background(), missing, map[string]seed.Target{}); err != nil {
+	if err := restoreState(context.Background(), missing, map[string]persist.Services{}); err != nil {
 		t.Fatalf("restoreState(missing) = %v, want nil", err)
 	}
 }

--- a/cmd/cloudemu/serve.go
+++ b/cmd/cloudemu/serve.go
@@ -169,10 +169,11 @@ func runServe(args []string) error {
 	}
 
 	var (
-		rebuildMu sync.Mutex
-		targets   map[string]seed.Target               // provider → current drivers, for seeding
-		netEngine *topology.Engine                     // AWS network-reachability engine (nil if aws not selected)
-		discovery map[string]*resourcediscovery.Engine // provider → inventory engine, for cost estimation
+		rebuildMu   sync.Mutex
+		targets     map[string]seed.Target               // provider → current drivers, for seeding + fixtures
+		snapTargets map[string]persist.Services          // provider → snapshottable services, for persist
+		netEngine   *topology.Engine                     // AWS network-reachability engine (nil if aws not selected)
+		discovery   map[string]*resourcediscovery.Engine // provider → inventory engine, for cost estimation
 	)
 	rebuild := func() {
 		// Serialise resets so two concurrent /_cloudemu/reset calls can't
@@ -205,6 +206,7 @@ func runServe(args []string) error {
 		}
 		fresh := make(map[string]http.Handler, len(sel))
 		freshTargets := make(map[string]seed.Target, len(sel))
+		freshSnapTargets := make(map[string]persist.Services, len(sel))
 		freshDiscovery := make(map[string]*resourcediscovery.Engine, len(sel))
 
 		var freshEngine *topology.Engine
@@ -222,6 +224,7 @@ func runServe(args []string) error {
 				cloud.EKS.SetK8sAPI(k8s)
 				fresh["aws"] = wrap(awsserver.New(d), "aws", c.logReqs)
 				freshTargets["aws"] = seed.Target{Storage: cloud.S3, Database: cloud.DynamoDB, Secrets: cloud.SecretsManager, Compute: cloud.EC2}
+				freshSnapTargets["aws"] = cloud.SnapshotServices()
 				freshEngine = topology.New(cloud.EC2, cloud.VPC, cloud.Route53)
 				freshDiscovery["aws"] = cloud.ResourceDiscovery
 			case "gcp":
@@ -231,6 +234,7 @@ func runServe(args []string) error {
 				cloud.GKE.SetK8sAPI(k8s)
 				fresh["gcp"] = wrap(gcpserver.New(d), "gcp", c.logReqs)
 				freshTargets["gcp"] = seed.Target{Storage: cloud.GCS, Database: cloud.Firestore, Secrets: cloud.SecretManager, Compute: cloud.GCE}
+				freshSnapTargets["gcp"] = cloud.SnapshotServices()
 				freshDiscovery["gcp"] = cloud.ResourceDiscovery
 			case "azure":
 				// Azure subscriptions are GUIDs, unlike the 12-digit AWS
@@ -247,6 +251,7 @@ func runServe(args []string) error {
 				cloud.AKS.SetK8sAPI(k8s)
 				fresh["azure"] = wrap(azureserver.New(d), "azure", c.logReqs)
 				freshTargets["azure"] = seed.Target{Storage: cloud.BlobStorage, Database: cloud.CosmosDB, Secrets: cloud.KeyVault, Compute: cloud.VirtualMachines}
+				freshSnapTargets["azure"] = cloud.SnapshotServices()
 				freshDiscovery["azure"] = cloud.ResourceDiscovery
 			case "oci":
 				cloud := cloudemu.NewOCI(opts...)
@@ -257,6 +262,7 @@ func runServe(args []string) error {
 					Storage: cloud.ObjectStorage, Database: cloud.NoSQL,
 					Secrets: cloud.Vault, Compute: cloud.Compute,
 				}
+				freshSnapTargets["oci"] = cloud.SnapshotServices()
 			}
 		}
 		if k8sBackend != nil {
@@ -266,6 +272,7 @@ func runServe(args []string) error {
 			backends[p].Swap(h)
 		}
 		targets = freshTargets
+		snapTargets = freshSnapTargets
 		netEngine = freshEngine
 		discovery = freshDiscovery
 	}
@@ -274,7 +281,7 @@ func runServe(args []string) error {
 	// Restore persisted state into the freshly-built providers before serving,
 	// so the first request already sees the resources from the last run.
 	if c.persist {
-		if err := restoreState(context.Background(), c.stateFile, targets); err != nil {
+		if err := restoreState(context.Background(), c.stateFile, snapTargets); err != nil {
 			return fmt.Errorf("restore persisted state: %w", err)
 		}
 	}
@@ -326,7 +333,7 @@ func runServe(args []string) error {
 	// rebuilds to empty then loads the posted state.
 	snapshotFn := func() ([]byte, error) {
 		rebuildMu.Lock()
-		cur := targets
+		cur := snapTargets
 		rebuildMu.Unlock()
 
 		snap, err := persist.ExportAll(context.Background(), cur, persist.Options{IncludeAssets: true})
@@ -353,7 +360,7 @@ func runServe(args []string) error {
 		rebuild() // wipe to empty before loading
 
 		rebuildMu.Lock()
-		cur := targets
+		cur := snapTargets
 		rebuildMu.Unlock()
 
 		return persist.RestoreAll(context.Background(), &snap, cur)
@@ -517,7 +524,7 @@ func runServe(args []string) error {
 
 	// Snapshot after Shutdown so no in-flight request can mutate state mid-read.
 	if c.persist {
-		if err := snapshotState(context.Background(), c.stateFile, !c.persistMetaOnly, targets); err != nil {
+		if err := snapshotState(context.Background(), c.stateFile, !c.persistMetaOnly, snapTargets); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to save state to %s: %v\n", c.stateFile, err)
 		} else if !c.quiet {
 			fmt.Fprintf(os.Stdout, "state saved to %s\n", c.stateFile)
@@ -531,7 +538,7 @@ func runServe(args []string) error {
 // providers. A missing file is not an error — the server just starts empty,
 // exactly as it does without --persist. Providers present in the snapshot but
 // not running now are skipped.
-func restoreState(ctx context.Context, path string, targets map[string]seed.Target) error {
+func restoreState(ctx context.Context, path string, targets map[string]persist.Services) error {
 	snap, err := persist.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -752,7 +759,7 @@ func applyInitFile(ctx context.Context, path, name string, targets map[string]se
 
 // snapshotState exports every running provider's state and writes the snapshot
 // file. Called after Shutdown, so the providers are quiescent.
-func snapshotState(ctx context.Context, path string, includeAssets bool, targets map[string]seed.Target) error {
+func snapshotState(ctx context.Context, path string, includeAssets bool, targets map[string]persist.Services) error {
 	snap, err := persist.ExportAll(ctx, targets, persist.Options{IncludeAssets: includeAssets})
 	if err != nil {
 		return err

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -11,6 +11,8 @@ package snapshot
 import (
 	"context"
 	"encoding/json"
+	"reflect"
+	"strings"
 )
 
 // Snapshottable is implemented by a service mock that can serialize its entire
@@ -24,4 +26,53 @@ import (
 type Snapshottable interface {
 	Snapshot(ctx context.Context, includeAssets bool) (json.RawMessage, error)
 	Restore(ctx context.Context, data json.RawMessage) error
+}
+
+// Discover reflects over the exported struct fields of p (a provider factory,
+// passed as a pointer to its struct) and returns the ones whose value
+// implements Snapshottable, keyed by a stable service name. The key is the
+// field name lowercased ("S3"->"s3", "SecretsManager"->"secretsmanager",
+// "EC2"->"ec2", "VPC"->"vpc"): a deterministic, build-independent identifier so
+// a snapshot restores into the same service across runs. persist iterates this
+// map, so the persisted surface automatically tracks whichever services
+// implement Snapshottable — no hand-kept registry that can drift.
+//
+// This is a one-shot enumeration run at snapshot/restore time (not a hot path).
+// A nil pointer field, an unexported field, or a field that does not implement
+// Snapshottable contributes nothing.
+func Discover(p any) map[string]Snapshottable {
+	out := map[string]Snapshottable{}
+
+	v := reflect.ValueOf(p)
+	for v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return out
+		}
+
+		v = v.Elem()
+	}
+
+	if v.Kind() != reflect.Struct {
+		return out
+	}
+
+	t := v.Type()
+
+	for i := range t.NumField() {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+
+		fv := v.Field(i)
+		if fv.Kind() == reflect.Pointer && fv.IsNil() {
+			continue
+		}
+
+		if s, ok := fv.Interface().(Snapshottable); ok {
+			out[strings.ToLower(f.Name)] = s
+		}
+	}
+
+	return out
 }

--- a/persist/identity_azure_test.go
+++ b/persist/identity_azure_test.go
@@ -7,7 +7,6 @@ import (
 
 	cloudemu "github.com/stackshy/cloudemu/v2"
 	"github.com/stackshy/cloudemu/v2/persist"
-	"github.com/stackshy/cloudemu/v2/seed"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
@@ -60,9 +59,7 @@ func TestIdentityPreservedAcrossRestoreAzure(t *testing.T) {
 
 	wantInstanceID := launched[0].ID
 
-	tSrc := seed.Target{Storage: src.BlobStorage, Database: src.CosmosDB, Secrets: src.KeyVault, Compute: src.VirtualMachines}
-
-	snap, err := persist.ExportAll(ctx, map[string]seed.Target{"azure": tSrc}, persist.Options{IncludeAssets: true})
+	snap, err := persist.ExportAll(ctx, map[string]persist.Services{"azure": src.SnapshotServices()}, persist.Options{IncludeAssets: true})
 	if err != nil {
 		t.Fatalf("ExportAll: %v", err)
 	}
@@ -79,8 +76,7 @@ func TestIdentityPreservedAcrossRestoreAzure(t *testing.T) {
 
 	// Restore into a completely fresh provider.
 	dst := cloudemu.NewAzure()
-	tDst := seed.Target{Storage: dst.BlobStorage, Database: dst.CosmosDB, Secrets: dst.KeyVault, Compute: dst.VirtualMachines}
-	if err := persist.RestoreAll(ctx, &got, map[string]seed.Target{"azure": tDst}); err != nil {
+	if err := persist.RestoreAll(ctx, &got, map[string]persist.Services{"azure": dst.SnapshotServices()}); err != nil {
 		t.Fatalf("RestoreAll: %v", err)
 	}
 

--- a/persist/identity_gcp_test.go
+++ b/persist/identity_gcp_test.go
@@ -7,7 +7,6 @@ import (
 
 	cloudemu "github.com/stackshy/cloudemu/v2"
 	"github.com/stackshy/cloudemu/v2/persist"
-	"github.com/stackshy/cloudemu/v2/seed"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
@@ -59,9 +58,7 @@ func TestIdentityPreservedAcrossRestoreGCP(t *testing.T) {
 
 	wantInstanceID := launched[0].ID
 
-	tSrc := seed.Target{Storage: src.GCS, Database: src.Firestore, Secrets: src.SecretManager, Compute: src.GCE}
-
-	snap, err := persist.ExportAll(ctx, map[string]seed.Target{"gcp": tSrc}, persist.Options{IncludeAssets: true})
+	snap, err := persist.ExportAll(ctx, map[string]persist.Services{"gcp": src.SnapshotServices()}, persist.Options{IncludeAssets: true})
 	if err != nil {
 		t.Fatalf("ExportAll: %v", err)
 	}
@@ -78,8 +75,7 @@ func TestIdentityPreservedAcrossRestoreGCP(t *testing.T) {
 
 	// Restore into a completely fresh provider.
 	dst := cloudemu.NewGCP()
-	tDst := seed.Target{Storage: dst.GCS, Database: dst.Firestore, Secrets: dst.SecretManager, Compute: dst.GCE}
-	if err := persist.RestoreAll(ctx, &got, map[string]seed.Target{"gcp": tDst}); err != nil {
+	if err := persist.RestoreAll(ctx, &got, map[string]persist.Services{"gcp": dst.SnapshotServices()}); err != nil {
 		t.Fatalf("RestoreAll: %v", err)
 	}
 

--- a/persist/identity_test.go
+++ b/persist/identity_test.go
@@ -7,7 +7,6 @@ import (
 
 	cloudemu "github.com/stackshy/cloudemu/v2"
 	"github.com/stackshy/cloudemu/v2/persist"
-	"github.com/stackshy/cloudemu/v2/seed"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
@@ -60,9 +59,7 @@ func TestIdentityPreservedAcrossRestore(t *testing.T) {
 	wantInstanceID := launched[0].ID
 
 	// Export the whole emulator to JSON bytes, exactly as the on-disk snapshot.
-	tSrc := seed.Target{Storage: src.S3, Database: src.DynamoDB, Secrets: src.SecretsManager, Compute: src.EC2}
-
-	snap, err := persist.ExportAll(ctx, map[string]seed.Target{"aws": tSrc}, persist.Options{IncludeAssets: true})
+	snap, err := persist.ExportAll(ctx, map[string]persist.Services{"aws": src.SnapshotServices()}, persist.Options{IncludeAssets: true})
 	if err != nil {
 		t.Fatalf("ExportAll: %v", err)
 	}
@@ -79,8 +76,7 @@ func TestIdentityPreservedAcrossRestore(t *testing.T) {
 
 	// Restore into a completely fresh provider.
 	dst := cloudemu.NewAWS()
-	tDst := seed.Target{Storage: dst.S3, Database: dst.DynamoDB, Secrets: dst.SecretsManager, Compute: dst.EC2}
-	if err := persist.RestoreAll(ctx, &got, map[string]seed.Target{"aws": tDst}); err != nil {
+	if err := persist.RestoreAll(ctx, &got, map[string]persist.Services{"aws": dst.SnapshotServices()}); err != nil {
 		t.Fatalf("RestoreAll: %v", err)
 	}
 

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -1,14 +1,15 @@
 // Package persist snapshots cloudemu provider state to disk and restores it, so
 // emulated resources survive a stop/start of the standalone server.
 //
-// A mock that implements internal/snapshot.Snapshottable serializes its own
-// full state (identity-preserving: resource ids and id-string cross-references
-// survive), captured under ProviderState.Services keyed by service name. For a
-// mock that does not implement it yet, Export/Restore fall back to the bespoke
-// path that reads and writes through the same provider-agnostic driver
-// interfaces the seed package uses — so one snapshot format still spans AWS,
-// Azure, and GCP as more services migrate. Either way the on-disk file is
-// human-readable, diffable JSON rather than an opaque binary blob.
+// Persistence is fully generic and full-surface: it iterates the per-provider
+// map of services that implement internal/snapshot.Snapshottable (produced by
+// each provider factory's SnapshotServices()), captures each service's
+// identity-preserving self-snapshot under ProviderState.Services keyed by
+// service name, and restores each one through the same interface. Because
+// resource ids and id-string cross-references are serialized as-is, a
+// snapshot/restore round-trip is transparent to clients. The on-disk file is
+// human-readable, diffable JSON rather than an opaque binary blob, and one
+// snapshot format spans AWS, Azure, GCP, and OCI.
 package persist
 
 import (
@@ -18,41 +19,28 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/stackshy/cloudemu/v2/internal/snapshot"
-	"github.com/stackshy/cloudemu/v2/seed"
-	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
-	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
-	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
-	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
-	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
 )
 
-// SchemaVersion is the on-disk snapshot format version. Bumped to 2 for the
-// per-driver identity-preserving layout (a migrated service's mock serializes
-// its own state under ProviderState.Services); a v1 snapshot is rejected on
-// load. Snapshots are a dev-only convenience, so a clean break is acceptable.
-const SchemaVersion = 2
+// SchemaVersion is the on-disk snapshot format version. Bumped to 3 for the
+// full-surface generic layout: every service captures itself under
+// ProviderState.Services and the bespoke per-kind arrays of the v2 layout are
+// gone, so a v2 (or older) snapshot can no longer be read. Snapshots are a
+// dev-only convenience, so a clean break with a clear error is acceptable.
+const SchemaVersion = 3
 
-const (
-	defaultContentType = "application/octet-stream"
+const dirPerm = 0o755
 
-	dirPerm = 0o755
+// errSchema is returned when a snapshot's schema version is not the one this
+// build reads. Static so callers (and err113) get a wrappable failure.
+var errSchema = errors.New("unsupported snapshot schema version")
 
-	// Service names keying ProviderState.Services for the generic (per-driver
-	// Snapshottable) path.
-	svcStorage  = "storage"
-	svcDatabase = "database"
-	svcSecrets  = "secrets"
-	svcCompute  = "compute"
-)
-
-// Sentinel errors so callers (and err113) get static, wrappable failures.
-var (
-	errNoDriver        = errors.New("snapshot names a resource kind with no driver in the target")
-	errSchema          = errors.New("unsupported snapshot schema version")
-	errNotSnapshotable = errors.New("snapshot carries per-driver state for a service whose target driver is not snapshottable")
-)
+// Services maps a stable service name to the mock that snapshots itself. It is
+// what a provider factory's SnapshotServices() returns and what Export/Restore
+// iterate.
+type Services = map[string]snapshot.Snapshottable
 
 // Snapshot is a multi-cloud, point-in-time capture of provider state, written
 // as one JSON document.
@@ -72,77 +60,29 @@ type Meta struct {
 	Providers       []string `json:"providers,omitempty"`
 }
 
-// ProviderState is a single provider's persisted resources. Services holds the
-// per-driver identity-preserving snapshots (keyed by service name) for mocks
-// that implement snapshot.Snapshottable; the remaining fields hold the bespoke
-// fallback capture for mocks not yet migrated. For any given service exactly one
-// representation is populated.
+// ProviderState is a single provider's persisted resources: the per-service
+// identity-preserving snapshots keyed by service name.
 type ProviderState struct {
-	Services  map[string]json.RawMessage `json:"services,omitempty"`
-	Buckets   []Bucket                   `json:"buckets,omitempty"`
-	Tables    []Table                    `json:"tables,omitempty"`
-	Secrets   []Secret                   `json:"secrets,omitempty"`
-	Instances []Instance                 `json:"instances,omitempty"`
-}
-
-// Bucket is an object-storage bucket and its objects.
-type Bucket struct {
-	Name    string   `json:"name"`
-	Objects []Object `json:"objects,omitempty"`
-}
-
-// Object is a stored object. Body is nil in a metadata-only snapshot; JSON
-// encodes it as base64.
-type Object struct {
-	Key         string `json:"key"`
-	ContentType string `json:"contentType,omitempty"`
-	Body        []byte `json:"body,omitempty"`
-}
-
-// Table is a NoSQL table, its secondary indexes, and its items.
-type Table struct {
-	Name         string               `json:"name"`
-	PartitionKey string               `json:"partitionKey"`
-	SortKey      string               `json:"sortKey,omitempty"`
-	GSIs         []dbdriver.GSIConfig `json:"gsis,omitempty"`
-	Items        []map[string]any     `json:"items,omitempty"`
-}
-
-// Secret is a secret and its current value. The value is always captured (a
-// secret without its value can't be restored usefully); metadata-only affects
-// only bulk object bodies.
-type Secret struct {
-	Name        string            `json:"name"`
-	Description string            `json:"description,omitempty"`
-	Tags        map[string]string `json:"tags,omitempty"`
-	Value       []byte            `json:"value,omitempty"`
-}
-
-// Instance is a compute instance's launch shape. Restore recreates it via
-// RunInstances, so the emulator assigns a fresh instance ID/IP — image, type,
-// and tags are preserved, identifiers are not.
-type Instance struct {
-	ImageID      string            `json:"imageId"`
-	InstanceType string            `json:"instanceType"`
-	Tags         map[string]string `json:"tags,omitempty"`
+	Services map[string]json.RawMessage `json:"services,omitempty"`
 }
 
 // Options controls what Export captures.
 type Options struct {
-	// IncludeAssets includes object bodies. When false (the default) the
-	// snapshot is metadata-only — bucket/object/table structure without the
-	// object bytes — which keeps the file small.
+	// IncludeAssets includes large object bodies (e.g. S3 object bytes). When
+	// false (the default) the snapshot is metadata-only, which keeps the file
+	// small. The flag is threaded to each service's Snapshot, so a service that
+	// distinguishes metadata from bulk bytes honors it.
 	IncludeAssets bool
 }
 
 // ExportAll captures the state of every provider in targets into one Snapshot.
 // It is the whole-emulator core shared by the persist-on-stop path and the
-// snapshot admin endpoint.
-func ExportAll(ctx context.Context, targets map[string]seed.Target, opts Options) (Snapshot, error) {
+// snapshot admin endpoint. Each provider's value is its SnapshotServices() map.
+func ExportAll(ctx context.Context, targets map[string]Services, opts Options) (Snapshot, error) {
 	snap := Snapshot{SchemaVersion: SchemaVersion, Providers: make(map[string]ProviderState, len(targets))}
 
-	for name, t := range targets {
-		ps, err := Export(ctx, t, opts)
+	for name := range targets {
+		ps, err := Export(ctx, targets[name], opts)
 		if err != nil {
 			return Snapshot{}, fmt.Errorf("export %s: %w", name, err)
 		}
@@ -156,15 +96,15 @@ func ExportAll(ctx context.Context, targets map[string]seed.Target, opts Options
 // RestoreAll restores each provider present in snap into the matching target.
 // Providers in the snapshot with no matching running target are skipped, and
 // targets should be freshly rebuilt (empty) before calling.
-func RestoreAll(ctx context.Context, snap *Snapshot, targets map[string]seed.Target) error {
+func RestoreAll(ctx context.Context, snap *Snapshot, targets map[string]Services) error {
 	for name := range snap.Providers {
-		t, ok := targets[name]
+		svcs, ok := targets[name]
 		if !ok {
 			continue
 		}
 
 		ps := snap.Providers[name]
-		if err := Restore(ctx, t, &ps); err != nil {
+		if err := Restore(ctx, svcs, &ps); err != nil {
 			return fmt.Errorf("restore %s: %w", name, err)
 		}
 	}
@@ -172,43 +112,24 @@ func RestoreAll(ctx context.Context, snap *Snapshot, targets map[string]seed.Tar
 	return nil
 }
 
-// Export captures a provider's current state. For each service whose mock
-// implements snapshot.Snapshottable, its identity-preserving self-snapshot is
-// stored under ProviderState.Services; every other service falls back to the
-// bespoke driver-replay capture. A nil driver for a kind contributes nothing.
-func Export(ctx context.Context, t seed.Target, opts Options) (ProviderState, error) {
+// Export captures a provider's current state by calling each service's
+// identity-preserving self-snapshot, keyed by service name under
+// ProviderState.Services. Keys are visited in sorted order for stable output.
+func Export(ctx context.Context, services Services, opts Options) (ProviderState, error) {
 	ps := ProviderState{Services: map[string]json.RawMessage{}}
 
-	if err := exportKind(ctx, &ps, svcStorage, t.Storage, opts.IncludeAssets, func() error {
-		buckets, err := exportBuckets(ctx, t.Storage, opts.IncludeAssets)
-		ps.Buckets = buckets
-		return err
-	}); err != nil {
-		return ProviderState{}, err
-	}
+	for _, name := range sortedKeys(services) {
+		s := services[name]
+		if s == nil {
+			continue
+		}
 
-	if err := exportKind(ctx, &ps, svcDatabase, t.Database, opts.IncludeAssets, func() error {
-		tables, err := exportTables(ctx, t.Database)
-		ps.Tables = tables
-		return err
-	}); err != nil {
-		return ProviderState{}, err
-	}
+		raw, err := s.Snapshot(ctx, opts.IncludeAssets)
+		if err != nil {
+			return ProviderState{}, fmt.Errorf("snapshot %s: %w", name, err)
+		}
 
-	if err := exportKind(ctx, &ps, svcSecrets, t.Secrets, opts.IncludeAssets, func() error {
-		secrets, err := exportSecrets(ctx, t.Secrets)
-		ps.Secrets = secrets
-		return err
-	}); err != nil {
-		return ProviderState{}, err
-	}
-
-	if err := exportKind(ctx, &ps, svcCompute, t.Compute, opts.IncludeAssets, func() error {
-		instances, err := exportInstances(ctx, t.Compute)
-		ps.Instances = instances
-		return err
-	}); err != nil {
-		return ProviderState{}, err
+		ps.Services[name] = raw
 	}
 
 	if len(ps.Services) == 0 {
@@ -218,335 +139,42 @@ func Export(ctx context.Context, t seed.Target, opts Options) (ProviderState, er
 	return ps, nil
 }
 
-// exportKind stores d's self-snapshot under name when d implements
-// Snapshottable; otherwise it runs the bespoke fallback capture.
-func exportKind[D any](ctx context.Context, ps *ProviderState, name string, d D, includeAssets bool, bespoke func() error) error {
-	if s, ok := any(d).(snapshot.Snapshottable); ok {
-		raw, err := s.Snapshot(ctx, includeAssets)
-		if err != nil {
-			return fmt.Errorf("snapshot %s: %w", name, err)
-		}
-
-		ps.Services[name] = raw
-
-		return nil
-	}
-
-	return bespoke()
-}
-
 // Restore writes a provider state back into what should be a freshly-built
-// (empty) provider. A service captured under Services is restored through its
-// mock's Snapshottable.Restore; otherwise the bespoke driver-replay path runs.
-func Restore(ctx context.Context, t seed.Target, ps *ProviderState) error {
-	if err := restoreKind(ctx, ps, svcStorage, t.Storage, func() error {
-		return restoreBuckets(ctx, t.Storage, ps.Buckets)
-	}); err != nil {
-		return err
+// (empty) provider, restoring each captured service through its mock's
+// Snapshottable.Restore. A service captured in the snapshot but not present in
+// services (e.g. a snapshot from a build with a wider surface) is skipped.
+// Sorted iteration keeps restore order deterministic.
+func Restore(ctx context.Context, services Services, ps *ProviderState) error {
+	names := make([]string, 0, len(ps.Services))
+	for name := range ps.Services {
+		names = append(names, name)
 	}
 
-	if err := restoreKind(ctx, ps, svcDatabase, t.Database, func() error {
-		return restoreTables(ctx, t.Database, ps.Tables)
-	}); err != nil {
-		return err
-	}
-
-	if err := restoreKind(ctx, ps, svcSecrets, t.Secrets, func() error {
-		return restoreSecrets(ctx, t.Secrets, ps.Secrets)
-	}); err != nil {
-		return err
-	}
-
-	return restoreKind(ctx, ps, svcCompute, t.Compute, func() error {
-		return restoreInstances(ctx, t.Compute, ps.Instances)
-	})
-}
-
-// restoreKind restores name's per-driver snapshot through d's Snapshottable when
-// the snapshot carries one; otherwise it runs the bespoke fallback restore.
-func restoreKind[D any](ctx context.Context, ps *ProviderState, name string, d D, bespoke func() error) error {
-	raw, ok := ps.Services[name]
-	if !ok {
-		return bespoke()
-	}
-
-	s, ok := any(d).(snapshot.Snapshottable)
-	if !ok {
-		return fmt.Errorf("%w: %s", errNotSnapshotable, name)
-	}
-
-	if err := s.Restore(ctx, raw); err != nil {
-		return fmt.Errorf("restore %s: %w", name, err)
-	}
-
-	return nil
-}
-
-func exportBuckets(ctx context.Context, d storagedriver.Bucket, includeAssets bool) ([]Bucket, error) {
-	if d == nil {
-		return nil, nil
-	}
-
-	infos, err := d.ListBuckets(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("list buckets: %w", err)
-	}
-
-	out := make([]Bucket, 0, len(infos))
-
-	for _, bi := range infos {
-		objs, err := exportObjects(ctx, d, bi.Name, includeAssets)
-		if err != nil {
-			return nil, err
-		}
-
-		out = append(out, Bucket{Name: bi.Name, Objects: objs})
-	}
-
-	return out, nil
-}
-
-func exportObjects(ctx context.Context, d storagedriver.Bucket, bucket string, includeAssets bool) ([]Object, error) {
-	var (
-		out   []Object
-		token string
-	)
-
-	for {
-		res, err := d.ListObjects(ctx, bucket, storagedriver.ListOptions{PageToken: token})
-		if err != nil {
-			return nil, fmt.Errorf("list objects in %q: %w", bucket, err)
-		}
-
-		for _, oi := range res.Objects {
-			obj := Object{Key: oi.Key, ContentType: oi.ContentType}
-
-			if includeAssets {
-				full, gErr := d.GetObject(ctx, bucket, oi.Key)
-				if gErr != nil {
-					return nil, fmt.Errorf("get object %s/%s: %w", bucket, oi.Key, gErr)
-				}
-
-				obj.Body = full.Data
-			}
-
-			out = append(out, obj)
-		}
-
-		if !res.IsTruncated || res.NextPageToken == "" {
-			break
-		}
-
-		token = res.NextPageToken
-	}
-
-	return out, nil
-}
-
-func exportTables(ctx context.Context, d dbdriver.Database) ([]Table, error) {
-	if d == nil {
-		return nil, nil
-	}
-
-	names, err := d.ListTables(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("list tables: %w", err)
-	}
-
-	out := make([]Table, 0, len(names))
+	sort.Strings(names)
 
 	for _, name := range names {
-		cfg, err := d.DescribeTable(ctx, name)
-		if err != nil {
-			return nil, fmt.Errorf("describe table %q: %w", name, err)
-		}
-
-		items, err := scanAll(ctx, d, name)
-		if err != nil {
-			return nil, err
-		}
-
-		out = append(out, Table{
-			Name:         name,
-			PartitionKey: cfg.PartitionKey,
-			SortKey:      cfg.SortKey,
-			GSIs:         cfg.GSIs,
-			Items:        items,
-		})
-	}
-
-	return out, nil
-}
-
-func scanAll(ctx context.Context, d dbdriver.Database, table string) ([]map[string]any, error) {
-	var (
-		items []map[string]any
-		token string
-	)
-
-	for {
-		res, err := d.Scan(ctx, dbdriver.ScanInput{Table: table, PageToken: token})
-		if err != nil {
-			return nil, fmt.Errorf("scan table %q: %w", table, err)
-		}
-
-		items = append(items, res.Items...)
-
-		if res.NextPageToken == "" {
-			break
-		}
-
-		token = res.NextPageToken
-	}
-
-	return items, nil
-}
-
-func exportSecrets(ctx context.Context, d secretsdriver.Secrets) ([]Secret, error) {
-	if d == nil {
-		return nil, nil
-	}
-
-	infos, err := d.ListSecrets(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("list secrets: %w", err)
-	}
-
-	out := make([]Secret, 0, len(infos))
-
-	for _, si := range infos {
-		ver, err := d.GetSecretValue(ctx, si.Name, "")
-		if err != nil {
-			return nil, fmt.Errorf("get secret value %q: %w", si.Name, err)
-		}
-
-		s := Secret{Name: si.Name, Description: si.Description, Tags: si.Tags}
-		if ver != nil {
-			s.Value = ver.Value
-		}
-
-		out = append(out, s)
-	}
-
-	return out, nil
-}
-
-func exportInstances(ctx context.Context, d computedriver.Compute) ([]Instance, error) {
-	if d == nil {
-		return nil, nil
-	}
-
-	insts, err := d.DescribeInstances(ctx, nil, nil)
-	if err != nil {
-		return nil, fmt.Errorf("describe instances: %w", err)
-	}
-
-	out := make([]Instance, 0, len(insts))
-
-	for i := range insts {
-		in := &insts[i]
-		// Terminated instances are tombstones; recreating them would resurrect
-		// deleted resources on restore.
-		if in.State == "terminated" {
+		s, ok := services[name]
+		if !ok || s == nil {
 			continue
 		}
 
-		out = append(out, Instance{ImageID: in.ImageID, InstanceType: in.InstanceType, Tags: in.Tags})
-	}
-
-	return out, nil
-}
-
-func restoreBuckets(ctx context.Context, d storagedriver.Bucket, buckets []Bucket) error {
-	if len(buckets) == 0 {
-		return nil
-	}
-
-	if d == nil {
-		return fmt.Errorf("%w: buckets", errNoDriver)
-	}
-
-	for _, b := range buckets {
-		if err := d.CreateBucket(ctx, b.Name); err != nil {
-			return fmt.Errorf("restore bucket %q: %w", b.Name, err)
-		}
-
-		for _, o := range b.Objects {
-			ct := o.ContentType
-			if ct == "" {
-				ct = defaultContentType
-			}
-
-			if err := d.PutObject(ctx, b.Name, o.Key, o.Body, ct, nil); err != nil {
-				return fmt.Errorf("restore object %s/%s: %w", b.Name, o.Key, err)
-			}
+		if err := s.Restore(ctx, ps.Services[name]); err != nil {
+			return fmt.Errorf("restore %s: %w", name, err)
 		}
 	}
 
 	return nil
 }
 
-func restoreTables(ctx context.Context, d dbdriver.Database, tables []Table) error {
-	if len(tables) == 0 {
-		return nil
+func sortedKeys(services Services) []string {
+	names := make([]string, 0, len(services))
+	for name := range services {
+		names = append(names, name)
 	}
 
-	if d == nil {
-		return fmt.Errorf("%w: tables", errNoDriver)
-	}
+	sort.Strings(names)
 
-	for _, tb := range tables {
-		cfg := dbdriver.TableConfig{Name: tb.Name, PartitionKey: tb.PartitionKey, SortKey: tb.SortKey, GSIs: tb.GSIs}
-		if err := d.CreateTable(ctx, cfg); err != nil {
-			return fmt.Errorf("restore table %q: %w", tb.Name, err)
-		}
-
-		for i, item := range tb.Items {
-			if err := d.PutItem(ctx, tb.Name, expr.RetypeItem(item)); err != nil {
-				return fmt.Errorf("restore table %q item %d: %w", tb.Name, i, err)
-			}
-		}
-	}
-
-	return nil
-}
-
-func restoreSecrets(ctx context.Context, d secretsdriver.Secrets, secrets []Secret) error {
-	if len(secrets) == 0 {
-		return nil
-	}
-
-	if d == nil {
-		return fmt.Errorf("%w: secrets", errNoDriver)
-	}
-
-	for _, s := range secrets {
-		cfg := secretsdriver.SecretConfig{Name: s.Name, Description: s.Description, Tags: s.Tags}
-		if _, err := d.CreateSecret(ctx, cfg, s.Value); err != nil {
-			return fmt.Errorf("restore secret %q: %w", s.Name, err)
-		}
-	}
-
-	return nil
-}
-
-func restoreInstances(ctx context.Context, d computedriver.Compute, instances []Instance) error {
-	if len(instances) == 0 {
-		return nil
-	}
-
-	if d == nil {
-		return fmt.Errorf("%w: instances", errNoDriver)
-	}
-
-	for _, in := range instances {
-		cfg := computedriver.InstanceConfig{ImageID: in.ImageID, InstanceType: in.InstanceType, Tags: in.Tags}
-		if _, err := d.RunInstances(ctx, cfg, 1); err != nil {
-			return fmt.Errorf("restore instance (%s): %w", in.ImageID, err)
-		}
-	}
-
-	return nil
+	return names
 }
 
 // WriteFile writes the snapshot as indented JSON, creating parent directories.
@@ -594,7 +222,8 @@ func (s Snapshot) WriteFile(path string) error {
 	return nil
 }
 
-// ReadFile loads a snapshot from disk, rejecting an unknown schema version.
+// ReadFile loads a snapshot from disk, rejecting an incompatible schema version
+// with a clear error rather than silently mis-restoring a stale layout.
 func ReadFile(path string) (Snapshot, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
@@ -607,7 +236,9 @@ func ReadFile(path string) (Snapshot, error) {
 	}
 
 	if s.SchemaVersion != SchemaVersion {
-		return Snapshot{}, fmt.Errorf("%w: got %d, want %d", errSchema, s.SchemaVersion, SchemaVersion)
+		return Snapshot{}, fmt.Errorf(
+			"%w: snapshot schema v%d is not compatible with this build (expected v%d); re-create the snapshot",
+			errSchema, s.SchemaVersion, SchemaVersion)
 	}
 
 	return s, nil

--- a/persist/persist_test.go
+++ b/persist/persist_test.go
@@ -41,7 +41,7 @@ func TestExportRestoreRoundTrip(t *testing.T) {
 		t.Fatalf("seed source: %v", err)
 	}
 
-	ps, err := persist.Export(ctx, tSrc, persist.Options{IncludeAssets: true})
+	ps, err := persist.Export(ctx, src.SnapshotServices(), persist.Options{IncludeAssets: true})
 	if err != nil {
 		t.Fatalf("export: %v", err)
 	}
@@ -58,8 +58,7 @@ func TestExportRestoreRoundTrip(t *testing.T) {
 	}
 
 	dst := cloudemu.NewAWS()
-	tDst := seed.Target{Storage: dst.S3, Database: dst.DynamoDB, Secrets: dst.SecretsManager, Compute: dst.EC2}
-	if err := persist.Restore(ctx, tDst, &restored); err != nil {
+	if err := persist.Restore(ctx, dst.SnapshotServices(), &restored); err != nil {
 		t.Fatalf("restore: %v", err)
 	}
 
@@ -121,7 +120,10 @@ func TestExportAllRestoreAllMultiProvider(t *testing.T) {
 		t.Fatalf("seed gcp: %v", err)
 	}
 
-	snap, err := persist.ExportAll(ctx, src, persist.Options{IncludeAssets: true})
+	snap, err := persist.ExportAll(ctx, map[string]persist.Services{
+		"aws": aws.SnapshotServices(),
+		"gcp": gcp.SnapshotServices(),
+	}, persist.Options{IncludeAssets: true})
 	if err != nil {
 		t.Fatalf("ExportAll: %v", err)
 	}
@@ -136,9 +138,9 @@ func TestExportAllRestoreAllMultiProvider(t *testing.T) {
 	}
 
 	aws2, gcp2 := cloudemu.NewAWS(), cloudemu.NewGCP()
-	dst := map[string]seed.Target{
-		"aws": {Storage: aws2.S3, Database: aws2.DynamoDB},
-		"gcp": {Storage: gcp2.GCS, Database: gcp2.Firestore},
+	dst := map[string]persist.Services{
+		"aws": aws2.SnapshotServices(),
+		"gcp": gcp2.SnapshotServices(),
 	}
 	if err := persist.RestoreAll(ctx, &got, dst); err != nil {
 		t.Fatalf("RestoreAll: %v", err)
@@ -180,13 +182,13 @@ func TestExportMetadataOnlyOmitsBodies(t *testing.T) {
 	}
 
 	// Metadata-only: the object is restored (still listed) but its bytes are gone.
-	meta, err := persist.Export(ctx, tSrc, persist.Options{IncludeAssets: false})
+	meta, err := persist.Export(ctx, src.SnapshotServices(), persist.Options{IncludeAssets: false})
 	if err != nil {
 		t.Fatalf("export metadata-only: %v", err)
 	}
 
 	metaDst := cloudemu.NewAWS()
-	if err := persist.Restore(ctx, seed.Target{Storage: metaDst.S3}, &meta); err != nil {
+	if err := persist.Restore(ctx, metaDst.SnapshotServices(), &meta); err != nil {
 		t.Fatalf("restore metadata-only: %v", err)
 	}
 
@@ -207,13 +209,13 @@ func TestExportMetadataOnlyOmitsBodies(t *testing.T) {
 	}
 
 	// IncludeAssets: the bytes survive.
-	full, err := persist.Export(ctx, tSrc, persist.Options{IncludeAssets: true})
+	full, err := persist.Export(ctx, src.SnapshotServices(), persist.Options{IncludeAssets: true})
 	if err != nil {
 		t.Fatalf("export with assets: %v", err)
 	}
 
 	fullDst := cloudemu.NewAWS()
-	if err := persist.Restore(ctx, seed.Target{Storage: fullDst.S3}, &full); err != nil {
+	if err := persist.Restore(ctx, fullDst.SnapshotServices(), &full); err != nil {
 		t.Fatalf("restore with assets: %v", err)
 	}
 
@@ -231,8 +233,7 @@ func TestExportMetadataOnlyOmitsBodies(t *testing.T) {
 func TestRestoreEmptyIsNoError(t *testing.T) {
 	ctx := context.Background()
 	dst := cloudemu.NewAWS()
-	tDst := seed.Target{Storage: dst.S3, Database: dst.DynamoDB}
-	if err := persist.Restore(ctx, tDst, &persist.ProviderState{}); err != nil {
+	if err := persist.Restore(ctx, dst.SnapshotServices(), &persist.ProviderState{}); err != nil {
 		t.Fatalf("restore empty: %v", err)
 	}
 }
@@ -251,13 +252,13 @@ func TestExportRestorePreservesGSIs(t *testing.T) {
 		t.Fatalf("create table with GSI: %v", err)
 	}
 
-	ps, err := persist.Export(ctx, seed.Target{Database: src.DynamoDB}, persist.Options{})
+	ps, err := persist.Export(ctx, src.SnapshotServices(), persist.Options{})
 	if err != nil {
 		t.Fatalf("export: %v", err)
 	}
 
 	dst := cloudemu.NewAWS()
-	if err := persist.Restore(ctx, seed.Target{Database: dst.DynamoDB}, &ps); err != nil {
+	if err := persist.Restore(ctx, dst.SnapshotServices(), &ps); err != nil {
 		t.Fatalf("restore: %v", err)
 	}
 
@@ -279,7 +280,7 @@ func TestSnapshotFileRoundTrip(t *testing.T) {
 	snap := persist.Snapshot{
 		SchemaVersion: persist.SchemaVersion,
 		Providers: map[string]persist.ProviderState{
-			"aws": {Secrets: []persist.Secret{{Name: "k", Value: []byte("v")}}},
+			"aws": {Services: map[string]json.RawMessage{"secretsmanager": json.RawMessage(`{"k":"v"}`)}},
 		},
 	}
 	if err := snap.WriteFile(path); err != nil {
@@ -290,7 +291,7 @@ func TestSnapshotFileRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
-	if got.SchemaVersion != persist.SchemaVersion || len(got.Providers["aws"].Secrets) != 1 {
+	if got.SchemaVersion != persist.SchemaVersion || len(got.Providers["aws"].Services) != 1 {
 		t.Fatalf("round-trip mismatch: %+v", got)
 	}
 

--- a/persist/snapshot_services_test.go
+++ b/persist/snapshot_services_test.go
@@ -1,0 +1,130 @@
+package persist_test
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/persist"
+)
+
+// TestSnapshotServicesDiscovery pins that each provider factory's
+// SnapshotServices() enumerates exactly the services that implement
+// snapshot.Snapshottable today, keyed by a stable lowercased field-name key.
+// This is the auto-discovery contract persist relies on: adding a Snapshottable
+// service later grows this map with no persist change, and the keys must stay
+// stable so a snapshot restores into the right service across runs.
+func TestSnapshotServicesDiscovery(t *testing.T) {
+	tests := []struct {
+		provider string
+		services map[string]struct{}
+		want     []string
+	}{
+		{"aws", asSet(keysOf(cloudemu.NewAWS().SnapshotServices())), []string{"dynamodb", "ec2", "s3", "secretsmanager"}},
+		{"azure", asSet(keysOf(cloudemu.NewAzure().SnapshotServices())), []string{"blobstorage", "cosmosdb", "keyvault", "virtualmachines"}},
+		{"gcp", asSet(keysOf(cloudemu.NewGCP().SnapshotServices())), []string{"firestore", "gce", "gcs", "secretmanager"}},
+	}
+
+	for _, tc := range tests {
+		got := sortedSet(tc.services)
+		if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+			t.Errorf("%s SnapshotServices keys = %v, want %v", tc.provider, got, tc.want)
+		}
+
+		for _, k := range got {
+			if k != strings.ToLower(k) {
+				t.Errorf("%s key %q is not lowercased (keys must be stable, case-normalized)", tc.provider, k)
+			}
+		}
+	}
+
+	// Values must be non-nil (a nil Snapshottable would panic on Snapshot) — the
+	// discovery skips nil pointer fields.
+	for name, s := range cloudemu.NewAWS().SnapshotServices() {
+		if s == nil {
+			t.Errorf("aws service %q discovered as nil", name)
+		}
+	}
+}
+
+// TestSnapshotServicesStableKeys guards the stability half: repeated calls on
+// fresh providers yield the identical key set, so a snapshot written by one run
+// restores into the same services on the next.
+func TestSnapshotServicesStableKeys(t *testing.T) {
+	a := keysOf(cloudemu.NewAWS().SnapshotServices())
+	b := keysOf(cloudemu.NewAWS().SnapshotServices())
+	sort.Strings(a)
+	sort.Strings(b)
+
+	if strings.Join(a, ",") != strings.Join(b, ",") {
+		t.Fatalf("SnapshotServices keys not stable across calls: %v vs %v", a, b)
+	}
+}
+
+// TestSnapshotServicesOCIEmpty documents that a provider with no Snapshottable
+// service yet (OCI today) discovers an empty map rather than erroring — the
+// mechanism auto-includes services as they implement the interface.
+func TestSnapshotServicesOCIEmpty(t *testing.T) {
+	if got := cloudemu.NewOCI().SnapshotServices(); len(got) != 0 {
+		t.Fatalf("oci SnapshotServices = %v, want empty", got)
+	}
+}
+
+// TestReadFileRejectsIncompatibleSchema is the load-compat guard: a v2 (or any
+// non-current) snapshot — whose bespoke per-kind layout this build no longer
+// reads — is rejected with a clear error, not silently mis-restored.
+func TestReadFileRejectsIncompatibleSchema(t *testing.T) {
+	dir := t.TempDir()
+
+	for _, body := range []string{
+		`{"schemaVersion":2,"providers":{"aws":{"buckets":[{"name":"b"}]}}}`,
+		`{"schemaVersion":1}`,
+		`{"schemaVersion":999}`,
+	} {
+		path := filepath.Join(dir, "snap.json")
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := persist.ReadFile(path)
+		if err == nil {
+			t.Fatalf("ReadFile(%s) = nil error, want compat rejection", body)
+		}
+
+		if !strings.Contains(err.Error(), "not compatible with this build") {
+			t.Fatalf("ReadFile error = %q, want a clear compatibility message", err)
+		}
+	}
+}
+
+func keysOf(m persist.Services) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+
+	return out
+}
+
+func asSet(keys []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		out[k] = struct{}{}
+	}
+
+	return out
+}
+
+func sortedSet(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+
+	sort.Strings(out)
+
+	return out
+}

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
 	"github.com/stackshy/cloudemu/v2/providers/aws/acm"
 	"github.com/stackshy/cloudemu/v2/providers/aws/bedrock"
 	"github.com/stackshy/cloudemu/v2/providers/aws/bedrockagent"
@@ -363,4 +364,13 @@ func (p *Provider) Close() error {
 	}
 
 	return errors.Join(errs...)
+}
+
+// SnapshotServices returns the provider's services that support identity-
+// preserving snapshotting, keyed by a stable lowercased field-name service key
+// (e.g. "s3", "dynamodb", "ec2"). persist iterates this map, so the persisted
+// surface automatically tracks whichever services implement
+// snapshot.Snapshottable — no hand-kept registry to drift.
+func (p *Provider) SnapshotServices() map[string]snapshot.Snapshottable {
+	return snapshot.Discover(p)
 }

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
 	"github.com/stackshy/cloudemu/v2/providers/azure/acr"
 	"github.com/stackshy/cloudemu/v2/providers/azure/ai"
 	"github.com/stackshy/cloudemu/v2/providers/azure/aks"
@@ -269,6 +270,15 @@ func (p *Provider) Close() error {
 	}
 
 	return errors.Join(errs...)
+}
+
+// SnapshotServices returns the provider's services that support identity-
+// preserving snapshotting, keyed by a stable lowercased field-name service key
+// (e.g. "blobstorage", "cosmosdb", "virtualmachines"). persist iterates this
+// map, so the persisted surface automatically tracks whichever services
+// implement snapshot.Snapshottable — no hand-kept registry to drift.
+func (p *Provider) SnapshotServices() map[string]snapshot.Snapshottable {
+	return snapshot.Discover(p)
 }
 
 // sqlDiscovery adapts the Azure relational mocks (SQL logical servers plus

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
 	"github.com/stackshy/cloudemu/v2/providers/gcp/alloydb"
 	"github.com/stackshy/cloudemu/v2/providers/gcp/artifactregistry"
 	"github.com/stackshy/cloudemu/v2/providers/gcp/bigtable"
@@ -190,6 +191,15 @@ func (p *Provider) Close() error {
 	}
 
 	return errors.Join(errs...)
+}
+
+// SnapshotServices returns the provider's services that support identity-
+// preserving snapshotting, keyed by a stable lowercased field-name service key
+// (e.g. "gcs", "firestore", "compute"). persist iterates this map, so the
+// persisted surface automatically tracks whichever services implement
+// snapshot.Snapshottable — no hand-kept registry to drift.
+func (p *Provider) SnapshotServices() map[string]snapshot.Snapshottable {
+	return snapshot.Discover(p)
 }
 
 // gcpRelationalDiscovery fans GCP's relational mocks (Cloud SQL instances and

--- a/providers/oci/oci.go
+++ b/providers/oci/oci.go
@@ -3,6 +3,7 @@ package oci
 
 import (
 	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
 	"github.com/stackshy/cloudemu/v2/providers/oci/identity"
 	"github.com/stackshy/cloudemu/v2/providers/oci/monitoring"
 	vcnprovider "github.com/stackshy/cloudemu/v2/providers/oci/vcn"
@@ -113,4 +114,13 @@ func (p *Provider) wireDiscovery() {
 			Serverless: p.Functions,
 		},
 	)
+}
+
+// SnapshotServices returns the provider's services that support identity-
+// preserving snapshotting, keyed by a stable lowercased field-name service key.
+// persist iterates this map, so the persisted surface automatically tracks
+// whichever services implement snapshot.Snapshottable — no hand-kept registry to
+// drift. (No OCI service implements it yet, so this is empty today.)
+func (p *Provider) SnapshotServices() map[string]snapshot.Snapshottable {
+	return snapshot.Discover(p)
 }


### PR DESCRIPTION
Wave 1 of #582.

Makes `persist/` full-surface and generic: it now snapshots **every** provider service that implements `internal/snapshot.Snapshottable` (identity-preserving), instead of only the 4 hard-coded resource kinds (buckets/tables/secrets/instances). The bespoke per-kind path is retired.

## What changed

**Auto-discovery (`internal/snapshot.Discover` + `Provider.SnapshotServices()`)**
- Added `snapshot.Discover(p any)`: reflects over a provider factory's exported struct fields and returns those whose value implements `Snapshottable`, keyed by the lowercased field name (`S3`->`s3`, `SecretsManager`->`secretsmanager`, `EC2`->`ec2`). The key is stable and build-independent, so a snapshot restores into the same service across runs. One-shot enumeration at snapshot/restore time, not a hot path.
- Added `func (p *Provider) SnapshotServices() map[string]snapshot.Snapshottable` to the AWS, Azure, GCP, and OCI factories (each delegates to `snapshot.Discover(p)`). This is drift-proof: any service that implements `Snapshottable` in a later wave is picked up automatically — no hand-kept registry.

**Generic persist (`persist/persist.go`)**
- `Export`/`Restore`/`ExportAll`/`RestoreAll` now iterate a `map[string]snapshot.Snapshottable` (exposed as `persist.Services`) with deterministic sorted iteration for stable output. `IncludeAssets` is threaded to each service's `Snapshot`.
- Retired the bespoke path: removed `ProviderState.{Buckets,Tables,Secrets,Instances}`, the `Bucket/Object/Table/Secret/Instance` structs, and every `export*`/`restore*`/`exportKind`/`restoreKind`/`scanAll` helper. `ProviderState` is now just `{Services map[string]json.RawMessage}`.

**Schema + compat guard**
- `SchemaVersion` bumped 2 -> 3 (the v2 bespoke-array layout is no longer read).
- `ReadFile` rejects any non-v3 snapshot with a clear error (`snapshot schema vN is not compatible with this build (expected v3); re-create the snapshot`). A best-effort v2 reader is intentionally not provided — a clean rejection is acceptable for pre-1.0 emulator state.

**serve.go wiring**
- The persist path (`restoreState`/`snapshotState`/`snapshotFn`/`restoreFn`) now uses `cloud.SnapshotServices()` per provider. `seed.Target` is kept for the fixture/seed path (unchanged), so seeding is unaffected.

## Coverage note
12 services implement `Snapshottable` today (AWS: s3/dynamodb/ec2/secretsmanager; Azure: blobstorage/cosmosdb/keyvault/virtualmachines; GCP: gcs/gce/firestore/secretmanager). Implementing it on more services is deferred to later waves — this PR only makes the mechanism include them automatically.

## Tests
- Identity round-trips (AWS/Azure/GCP) now run through the generic path and still preserve IDs/cross-references.
- `TestSnapshotServicesDiscovery` pins the exact discovered key set + lowercase/stable-key contract per provider; OCI discovers empty.
- `TestReadFileRejectsIncompatibleSchema` covers v2/v1/bogus-version rejection with the clear compat error.
- Full ExportAll->RestoreAll multi-provider round-trip; metadata-only vs IncludeAssets; GSI survival; empty-restore no-op.

## Gates
`go build ./...`, full `go vet ./...`, `go test ./persist/... ./providers/... ./cmd/... .`, `TestWiringParity|TestRealWorld`, gofmt, and `golangci-lint --new-from-rev=origin/development` (0 new issues) all green. `go generate ./...` produced no doc drift.
