### PR TITLE
feat(persist): Snapshottable for IAM across AWS/Azure/GCP (#582 wave 3)

### DIFF
--- a/persist/snapshot_services_test.go
+++ b/persist/snapshot_services_test.go
@@ -23,9 +23,9 @@ func TestSnapshotServicesDiscovery(t *testing.T) {
 		services map[string]struct{}
 		want     []string
 	}{
-		{"aws", asSet(keysOf(cloudemu.NewAWS().SnapshotServices())), []string{"dynamodb", "ec2", "s3", "secretsmanager"}},
-		{"azure", asSet(keysOf(cloudemu.NewAzure().SnapshotServices())), []string{"blobstorage", "cosmosdb", "keyvault", "virtualmachines"}},
-		{"gcp", asSet(keysOf(cloudemu.NewGCP().SnapshotServices())), []string{"firestore", "gce", "gcs", "secretmanager"}},
+		{"aws", asSet(keysOf(cloudemu.NewAWS().SnapshotServices())), []string{"dynamodb", "ec2", "iam", "s3", "secretsmanager"}},
+		{"azure", asSet(keysOf(cloudemu.NewAzure().SnapshotServices())), []string{"blobstorage", "cosmosdb", "iam", "keyvault", "virtualmachines"}},
+		{"gcp", asSet(keysOf(cloudemu.NewGCP().SnapshotServices())), []string{"firestore", "gce", "gcs", "iam", "secretmanager"}},
 	}
 
 	for _, tc := range tests {

--- a/providers/aws/iam/snapshot.go
+++ b/providers/aws/iam/snapshot.go
@@ -1,0 +1,276 @@
+package iam
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// iamSnapshot is the full serialized state of the AWS IAM mock. Stores whose
+// value type has unexported fields (users, roles, policies) are promoted to an
+// exported snapshot form; the fully-exported stores round-trip through the
+// generic memstore helper. Every attachment/membership map and the account
+// password policy are captured too, so a snapshot/restore round-trip preserves
+// all identities (user/role/policy ARNs, group memberships, access-key ids) and
+// the EC2->instance-profile cross-reference (keyed by profile name) survives.
+type iamSnapshot struct {
+	Users    map[string]*userSnapshot   `json:"users,omitempty"`
+	Roles    map[string]*roleSnapshot   `json:"roles,omitempty"`
+	Policies map[string]*policySnapshot `json:"policies,omitempty"`
+
+	Groups           json.RawMessage `json:"groups,omitempty"`
+	AccessKeys       json.RawMessage `json:"accessKeys,omitempty"`
+	InstanceProfiles json.RawMessage `json:"instanceProfiles,omitempty"`
+	MFADevices       json.RawMessage `json:"mfaDevices,omitempty"`
+
+	UserPolicies  map[string]map[string]bool `json:"userPolicies,omitempty"`
+	RolePolicies  map[string]map[string]bool `json:"rolePolicies,omitempty"`
+	GroupPolicies map[string]map[string]bool `json:"groupPolicies,omitempty"`
+	GroupUsers    map[string]map[string]bool `json:"groupUsers,omitempty"`
+
+	UserInlinePolicies  map[string]map[string]string `json:"userInlinePolicies,omitempty"`
+	GroupInlinePolicies map[string]map[string]string `json:"groupInlinePolicies,omitempty"`
+
+	PasswordPolicy *driver.PasswordPolicy `json:"passwordPolicy,omitempty"`
+}
+
+// userSnapshot mirrors userData, promoting its unexported permissionsBoundary so
+// it survives JSON.
+type userSnapshot struct {
+	Name                string            `json:"name"`
+	ID                  string            `json:"id,omitempty"`
+	ARN                 string            `json:"arn,omitempty"`
+	Path                string            `json:"path,omitempty"`
+	Tags                map[string]string `json:"tags,omitempty"`
+	CreatedAt           string            `json:"createdAt,omitempty"`
+	PermissionsBoundary string            `json:"permissionsBoundary,omitempty"`
+}
+
+// roleSnapshot mirrors roleData, promoting its unexported inline policies and
+// permissions boundary.
+type roleSnapshot struct {
+	Name                string            `json:"name"`
+	ID                  string            `json:"id,omitempty"`
+	ARN                 string            `json:"arn,omitempty"`
+	Path                string            `json:"path,omitempty"`
+	Description         string            `json:"description,omitempty"`
+	AssumeRolePolicyDoc string            `json:"assumeRolePolicyDoc,omitempty"`
+	MaxSessionDuration  int               `json:"maxSessionDuration,omitempty"`
+	CreatedAt           string            `json:"createdAt,omitempty"`
+	Tags                map[string]string `json:"tags,omitempty"`
+	InlinePolicies      map[string]string `json:"inlinePolicies,omitempty"`
+	PermissionsBoundary string            `json:"permissionsBoundary,omitempty"`
+}
+
+// policySnapshot mirrors policyData, promoting its unexported version list and
+// counter so the version history (and default-version pointer) round-trips.
+type policySnapshot struct {
+	Name           string               `json:"name"`
+	ID             string               `json:"id,omitempty"`
+	ARN            string               `json:"arn,omitempty"`
+	Path           string               `json:"path,omitempty"`
+	PolicyDocument string               `json:"policyDocument,omitempty"`
+	Description    string               `json:"description,omitempty"`
+	Versions       []*policyVersionData `json:"versions,omitempty"`
+	VersionCounter int                  `json:"versionCounter,omitempty"`
+}
+
+// Snapshot captures the entire IAM state as JSON. includeAssets is unused — IAM
+// holds no bulk object bodies, so everything is always captured.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	snap := iamSnapshot{
+		Users:               m.snapshotUsers(),
+		Roles:               m.snapshotRoles(),
+		Policies:            m.snapshotPolicies(),
+		UserPolicies:        m.userPolicies,
+		RolePolicies:        m.rolePolicies,
+		GroupPolicies:       m.groupPolicies,
+		GroupUsers:          m.groupUsers,
+		UserInlinePolicies:  m.userInlinePolicies,
+		GroupInlinePolicies: m.groupInlinePolicies,
+		PasswordPolicy:      m.passwordPolicy,
+	}
+
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	//nolint:gosec // G117: persist intentionally serializes IAM access-key material so a snapshot/restore round-trip is transparent.
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotUsers() map[string]*userSnapshot {
+	out := make(map[string]*userSnapshot, m.users.Len())
+
+	for name, u := range m.users.All() {
+		out[name] = &userSnapshot{
+			Name: u.Name, ID: u.ID, ARN: u.ARN, Path: u.Path, Tags: u.Tags,
+			CreatedAt: u.CreatedAt, PermissionsBoundary: u.permissionsBoundary,
+		}
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotRoles() map[string]*roleSnapshot {
+	out := make(map[string]*roleSnapshot, m.roles.Len())
+
+	for name, r := range m.roles.All() {
+		out[name] = &roleSnapshot{
+			Name: r.Name, ID: r.ID, ARN: r.ARN, Path: r.Path, Description: r.Description,
+			AssumeRolePolicyDoc: r.AssumeRolePolicyDoc, MaxSessionDuration: r.MaxSessionDuration,
+			CreatedAt: r.CreatedAt, Tags: r.Tags, InlinePolicies: r.inlinePolicies,
+			PermissionsBoundary: r.permissionsBoundary,
+		}
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotPolicies() map[string]*policySnapshot {
+	out := make(map[string]*policySnapshot, m.policies.Len())
+
+	for arn, p := range m.policies.All() {
+		out[arn] = &policySnapshot{
+			Name: p.Name, ID: p.ID, ARN: p.ARN, Path: p.Path, PolicyDocument: p.PolicyDocument,
+			Description: p.Description, Versions: p.versions, VersionCounter: p.versionCounter,
+		}
+	}
+
+	return out
+}
+
+// snapshotStores dumps the fully-exported stores through the generic memstore
+// helper, preserving their keys (group name, access-key id, profile name, MFA
+// serial).
+func (m *Mock) snapshotStores(snap *iamSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Groups, m.groups.Snapshot},
+		{&snap.AccessKeys, m.accessKeys.Snapshot},
+		{&snap.InstanceProfiles, m.instanceProfiles.Snapshot},
+		{&snap.MFADevices, m.mfaDevices.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("iam: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds every store and attachment map under the original
+// identities. It is called on a freshly built (empty) mock.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap iamSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("iam: parse snapshot: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.restoreUsers(snap.Users)
+	m.restoreRoles(snap.Roles)
+	m.restorePolicies(snap.Policies)
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	if snap.UserPolicies != nil {
+		m.userPolicies = snap.UserPolicies
+	}
+
+	if snap.RolePolicies != nil {
+		m.rolePolicies = snap.RolePolicies
+	}
+
+	if snap.GroupPolicies != nil {
+		m.groupPolicies = snap.GroupPolicies
+	}
+
+	if snap.GroupUsers != nil {
+		m.groupUsers = snap.GroupUsers
+	}
+
+	if snap.UserInlinePolicies != nil {
+		m.userInlinePolicies = snap.UserInlinePolicies
+	}
+
+	if snap.GroupInlinePolicies != nil {
+		m.groupInlinePolicies = snap.GroupInlinePolicies
+	}
+
+	m.passwordPolicy = snap.PasswordPolicy
+
+	return nil
+}
+
+func (m *Mock) restoreUsers(users map[string]*userSnapshot) {
+	for name, u := range users {
+		m.users.Set(name, &userData{
+			Name: u.Name, ID: u.ID, ARN: u.ARN, Path: u.Path, Tags: u.Tags,
+			CreatedAt: u.CreatedAt, permissionsBoundary: u.PermissionsBoundary,
+		})
+	}
+}
+
+func (m *Mock) restoreRoles(roles map[string]*roleSnapshot) {
+	for name, r := range roles {
+		m.roles.Set(name, &roleData{
+			Name: r.Name, ID: r.ID, ARN: r.ARN, Path: r.Path, Description: r.Description,
+			AssumeRolePolicyDoc: r.AssumeRolePolicyDoc, MaxSessionDuration: r.MaxSessionDuration,
+			CreatedAt: r.CreatedAt, Tags: r.Tags, inlinePolicies: r.InlinePolicies,
+			permissionsBoundary: r.PermissionsBoundary,
+		})
+	}
+}
+
+func (m *Mock) restorePolicies(policies map[string]*policySnapshot) {
+	for arn, p := range policies {
+		m.policies.Set(arn, &policyData{
+			Name: p.Name, ID: p.ID, ARN: p.ARN, Path: p.Path, PolicyDocument: p.PolicyDocument,
+			Description: p.Description, versions: p.Versions, versionCounter: p.VersionCounter,
+		})
+	}
+}
+
+func (m *Mock) restoreStores(snap *iamSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Groups, m.groups.LoadSnapshot},
+		{snap.AccessKeys, m.accessKeys.LoadSnapshot},
+		{snap.InstanceProfiles, m.instanceProfiles.LoadSnapshot},
+		{snap.MFADevices, m.mfaDevices.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("iam: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/aws/iam/snapshot_test.go
+++ b/providers/aws/iam/snapshot_test.go
@@ -1,0 +1,148 @@
+package iam
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// TestSnapshotRestoreRoundTripAllStores populates every IAM store and every
+// attachment/membership map, snapshots, restores into a fresh mock, and asserts
+// each piece of state round-trips under its original identity — a missed store
+// would be silent data loss. The EC2->instance-profile cross-reference (profile
+// keyed by name, carrying its role name) is included.
+func TestSnapshotRestoreRoundTripAllStores(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	doc := makePolicyDoc([]map[string]any{{"Effect": "Allow", "Action": "s3:*", "Resource": "*"}})
+
+	requireNoError(t, mustCreateUser(src, "alice"))
+	requireNoError(t, mustCreateRole(src, "r1", doc))
+
+	pol, err := src.CreatePolicy(ctx, driver.PolicyConfig{Name: "p1", PolicyDocument: doc})
+	requireNoError(t, err)
+	// Add a second version so the version history + counter must round-trip.
+	_, err = src.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{
+		PolicyARN: pol.ARN, PolicyDocument: doc, SetAsDefault: true,
+	})
+	requireNoError(t, err)
+
+	_, err = src.CreateGroup(ctx, driver.GroupConfig{Name: "g1"})
+	requireNoError(t, err)
+
+	ak, err := src.CreateAccessKey(ctx, driver.AccessKeyConfig{UserName: "alice"})
+	requireNoError(t, err)
+
+	_, err = src.CreateInstanceProfile(ctx, driver.InstanceProfileConfig{Name: "prof1"})
+	requireNoError(t, err)
+	requireNoError(t, src.AddRoleToInstanceProfile(ctx, "prof1", "r1"))
+
+	mfa, err := src.CreateVirtualMFADevice(ctx, "dev1", "/")
+	requireNoError(t, err)
+
+	// Attachment / membership maps.
+	requireNoError(t, src.AttachUserPolicy(ctx, "alice", pol.ARN))
+	requireNoError(t, src.AttachRolePolicy(ctx, "r1", pol.ARN))
+	requireNoError(t, src.AttachGroupPolicy(ctx, "g1", pol.ARN))
+	requireNoError(t, src.AddUserToGroup(ctx, "alice", "g1"))
+
+	// Inline policies (user + group), role inline policy, permissions boundaries.
+	requireNoError(t, src.PutUserPolicy(ctx, "alice", "inlineU", doc))
+	requireNoError(t, src.PutGroupPolicy(ctx, "g1", "inlineG", doc))
+	requireNoError(t, src.PutRolePolicy(ctx, "r1", "inlineR", doc))
+	requireNoError(t, src.PutUserPermissionsBoundary(ctx, "alice", pol.ARN))
+	requireNoError(t, src.PutRolePermissionsBoundary(ctx, "r1", pol.ARN))
+
+	// Account password policy.
+	requireNoError(t, src.UpdateAccountPasswordPolicy(ctx, driver.PasswordPolicy{
+		MinimumPasswordLength: 14, RequireSymbols: true,
+	}))
+
+	data, err := src.Snapshot(ctx, false)
+	requireNoError(t, err)
+
+	dst := newTestMock()
+	requireNoError(t, dst.Restore(ctx, data))
+
+	// Stores.
+	u, ok := dst.users.Get("alice")
+	assertTrue(t, ok, "user alice restored")
+	assertEqual(t, pol.ARN, u.permissionsBoundary)
+
+	r, ok := dst.roles.Get("r1")
+	assertTrue(t, ok, "role r1 restored")
+	assertEqual(t, pol.ARN, r.permissionsBoundary)
+	assertEqual(t, doc, r.inlinePolicies["inlineR"])
+
+	p, ok := dst.policies.Get(pol.ARN)
+	assertTrue(t, ok, "policy restored under its ARN")
+	assertEqual(t, 2, len(p.versions))
+	assertEqual(t, 2, p.versionCounter)
+
+	assertTrue(t, dst.groups.Has("g1"), "group g1 restored")
+
+	restoredKey, ok := dst.accessKeys.Get(ak.AccessKeyID)
+	assertTrue(t, ok, "access key restored under its id")
+	assertEqual(t, "alice", restoredKey.UserName)
+
+	prof, ok := dst.instanceProfiles.Get("prof1")
+	assertTrue(t, ok, "instance profile restored")
+	assertEqual(t, "r1", prof.RoleName) // EC2 cross-ref preserved
+
+	assertTrue(t, dst.mfaDevices.Has(mfa.SerialNumber), "mfa device restored under its serial")
+
+	// Maps.
+	assertTrue(t, dst.userPolicies["alice"][pol.ARN], "user policy attachment restored")
+	assertTrue(t, dst.rolePolicies["r1"][pol.ARN], "role policy attachment restored")
+	assertTrue(t, dst.groupPolicies["g1"][pol.ARN], "group policy attachment restored")
+	assertTrue(t, dst.groupUsers["g1"]["alice"], "group membership restored")
+	assertEqual(t, doc, dst.userInlinePolicies["alice"]["inlineU"])
+	assertEqual(t, doc, dst.groupInlinePolicies["g1"]["inlineG"])
+
+	if dst.passwordPolicy == nil {
+		t.Fatal("password policy not restored")
+	}
+	assertEqual(t, 14, dst.passwordPolicy.MinimumPasswordLength)
+	assertTrue(t, dst.passwordPolicy.RequireSymbols, "password policy fields restored")
+}
+
+// TestSnapshotRestoreEmptyNilSafe confirms an empty mock round-trips without
+// panicking (nil maps must not blow up) and leaves the attachment maps usable.
+func TestSnapshotRestoreEmptyNilSafe(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	data, err := src.Snapshot(ctx, false)
+	requireNoError(t, err)
+
+	dst := newTestMock()
+	requireNoError(t, dst.Restore(ctx, data))
+
+	// The maps stay non-nil so subsequent attaches don't panic.
+	requireNoError(t, mustCreateUser(dst, "bob"))
+	pol, err := dst.CreatePolicy(ctx, driver.PolicyConfig{
+		Name:           "pp",
+		PolicyDocument: makePolicyDoc([]map[string]any{{"Effect": "Allow", "Action": "*", "Resource": "*"}}),
+	})
+	requireNoError(t, err)
+	requireNoError(t, dst.AttachUserPolicy(ctx, "bob", pol.ARN))
+}
+
+func mustCreateUser(m *Mock, name string) error {
+	_, err := m.CreateUser(context.Background(), driver.UserConfig{Name: name})
+	return err
+}
+
+func mustCreateRole(m *Mock, name, doc string) error {
+	_, err := m.CreateRole(context.Background(), driver.RoleConfig{Name: name, AssumeRolePolicyDoc: doc})
+	return err
+}
+
+func assertTrue(t *testing.T, cond bool, msg string) {
+	t.Helper()
+	if !cond {
+		t.Errorf("expected true: %s", msg)
+	}
+}

--- a/providers/azure/iam/snapshot.go
+++ b/providers/azure/iam/snapshot.go
@@ -1,0 +1,168 @@
+package iam
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// iamSnapshot is the full serialized state of the Azure IAM mock. The policies
+// store is promoted to an exported snapshot form (policyData carries an
+// unexported version list); the fully-exported stores round-trip through the
+// generic memstore helper. The attachment/membership maps are captured too, so
+// a snapshot/restore round-trip preserves all identities (user/role/policy
+// ARNs, group memberships, access-key ids, instance-profile names).
+type iamSnapshot struct {
+	Policies map[string]*policySnapshot `json:"policies,omitempty"`
+
+	Users            json.RawMessage `json:"users,omitempty"`
+	Roles            json.RawMessage `json:"roles,omitempty"`
+	Groups           json.RawMessage `json:"groups,omitempty"`
+	AccessKeys       json.RawMessage `json:"accessKeys,omitempty"`
+	InstanceProfiles json.RawMessage `json:"instanceProfiles,omitempty"`
+
+	UserPolicies map[string]map[string]bool `json:"userPolicies,omitempty"`
+	RolePolicies map[string]map[string]bool `json:"rolePolicies,omitempty"`
+	GroupUsers   map[string]map[string]bool `json:"groupUsers,omitempty"`
+}
+
+// policySnapshot mirrors policyData, promoting its unexported version list and
+// counter so the version history (and default-version pointer) round-trips.
+type policySnapshot struct {
+	Name           string               `json:"name"`
+	ID             string               `json:"id,omitempty"`
+	ARN            string               `json:"arn,omitempty"`
+	Path           string               `json:"path,omitempty"`
+	PolicyDocument string               `json:"policyDocument,omitempty"`
+	Description    string               `json:"description,omitempty"`
+	Versions       []*policyVersionData `json:"versions,omitempty"`
+	VersionCounter int                  `json:"versionCounter,omitempty"`
+}
+
+// Snapshot captures the entire IAM state as JSON. includeAssets is unused — IAM
+// holds no bulk object bodies, so everything is always captured.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	snap := iamSnapshot{
+		Policies:     m.snapshotPolicies(),
+		UserPolicies: m.userPolicies,
+		RolePolicies: m.rolePolicies,
+		GroupUsers:   m.groupUsers,
+	}
+
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	//nolint:gosec // G117: persist intentionally serializes IAM access-key material so a snapshot/restore round-trip is transparent.
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotPolicies() map[string]*policySnapshot {
+	out := make(map[string]*policySnapshot, m.policies.Len())
+
+	for arn, p := range m.policies.All() {
+		out[arn] = &policySnapshot{
+			Name: p.Name, ID: p.ID, ARN: p.ARN, Path: p.Path, PolicyDocument: p.PolicyDocument,
+			Description: p.Description, Versions: p.versions, VersionCounter: p.versionCounter,
+		}
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotStores(snap *iamSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Users, m.users.Snapshot},
+		{&snap.Roles, m.roles.Snapshot},
+		{&snap.Groups, m.groups.Snapshot},
+		{&snap.AccessKeys, m.accessKeys.Snapshot},
+		{&snap.InstanceProfiles, m.instanceProfiles.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("iam: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds every store and attachment map under the original
+// identities. It is called on a freshly built (empty) mock.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap iamSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("iam: parse snapshot: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.restorePolicies(snap.Policies)
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	if snap.UserPolicies != nil {
+		m.userPolicies = snap.UserPolicies
+	}
+
+	if snap.RolePolicies != nil {
+		m.rolePolicies = snap.RolePolicies
+	}
+
+	if snap.GroupUsers != nil {
+		m.groupUsers = snap.GroupUsers
+	}
+
+	return nil
+}
+
+func (m *Mock) restorePolicies(policies map[string]*policySnapshot) {
+	for arn, p := range policies {
+		m.policies.Set(arn, &policyData{
+			Name: p.Name, ID: p.ID, ARN: p.ARN, Path: p.Path, PolicyDocument: p.PolicyDocument,
+			Description: p.Description, versions: p.Versions, versionCounter: p.VersionCounter,
+		})
+	}
+}
+
+func (m *Mock) restoreStores(snap *iamSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Users, m.users.LoadSnapshot},
+		{snap.Roles, m.roles.LoadSnapshot},
+		{snap.Groups, m.groups.LoadSnapshot},
+		{snap.AccessKeys, m.accessKeys.LoadSnapshot},
+		{snap.InstanceProfiles, m.instanceProfiles.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("iam: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/azure/iam/snapshot_test.go
+++ b/providers/azure/iam/snapshot_test.go
@@ -1,0 +1,96 @@
+package iam
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSnapshotRestoreRoundTripAllStores populates every IAM store and every
+// attachment/membership map, snapshots, restores into a fresh mock, and asserts
+// each piece of state round-trips under its original identity — a missed store
+// would be silent data loss.
+func TestSnapshotRestoreRoundTripAllStores(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	const doc = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}`
+
+	_, err := src.CreateUser(ctx, driver.UserConfig{Name: "alice"})
+	require.NoError(t, err)
+	_, err = src.CreateRole(ctx, driver.RoleConfig{Name: "r1", AssumeRolePolicyDoc: doc})
+	require.NoError(t, err)
+
+	pol, err := src.CreatePolicy(ctx, driver.PolicyConfig{Name: "p1", PolicyDocument: doc})
+	require.NoError(t, err)
+	_, err = src.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{
+		PolicyARN: pol.ARN, PolicyDocument: doc, SetAsDefault: true,
+	})
+	require.NoError(t, err)
+
+	_, err = src.CreateGroup(ctx, driver.GroupConfig{Name: "g1"})
+	require.NoError(t, err)
+
+	ak, err := src.CreateAccessKey(ctx, driver.AccessKeyConfig{UserName: "alice"})
+	require.NoError(t, err)
+
+	_, err = src.CreateInstanceProfile(ctx, driver.InstanceProfileConfig{Name: "prof1"})
+	require.NoError(t, err)
+	require.NoError(t, src.AddRoleToInstanceProfile(ctx, "prof1", "r1"))
+
+	require.NoError(t, src.AttachUserPolicy(ctx, "alice", pol.ARN))
+	require.NoError(t, src.AttachRolePolicy(ctx, "r1", pol.ARN))
+	require.NoError(t, src.AddUserToGroup(ctx, "alice", "g1"))
+
+	data, err := src.Snapshot(ctx, false)
+	require.NoError(t, err)
+
+	dst := newTestMock()
+	require.NoError(t, dst.Restore(ctx, data))
+
+	// Stores.
+	assert.True(t, dst.users.Has("alice"), "user restored")
+	assert.True(t, dst.roles.Has("r1"), "role restored")
+
+	p, ok := dst.policies.Get(pol.ARN)
+	require.True(t, ok, "policy restored under its ARN")
+	assert.Len(t, p.versions, 2)
+	assert.Equal(t, 2, p.versionCounter)
+
+	assert.True(t, dst.groups.Has("g1"), "group restored")
+
+	restoredKey, ok := dst.accessKeys.Get(ak.AccessKeyID)
+	require.True(t, ok, "access key restored under its id")
+	assert.Equal(t, "alice", restoredKey.UserName)
+
+	prof, ok := dst.instanceProfiles.Get("prof1")
+	require.True(t, ok, "instance profile restored")
+	assert.Equal(t, "r1", prof.RoleName)
+
+	// Maps.
+	assert.True(t, dst.userPolicies["alice"][pol.ARN], "user attachment restored")
+	assert.True(t, dst.rolePolicies["r1"][pol.ARN], "role attachment restored")
+	assert.True(t, dst.groupUsers["g1"]["alice"], "group membership restored")
+}
+
+// TestSnapshotRestoreEmptyNilSafe confirms an empty mock round-trips without
+// panicking and leaves the attachment maps usable.
+func TestSnapshotRestoreEmptyNilSafe(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	data, err := src.Snapshot(ctx, false)
+	require.NoError(t, err)
+
+	dst := newTestMock()
+	require.NoError(t, dst.Restore(ctx, data))
+
+	_, err = dst.CreateUser(ctx, driver.UserConfig{Name: "bob"})
+	require.NoError(t, err)
+	pol, err := dst.CreatePolicy(ctx, driver.PolicyConfig{Name: "pp", PolicyDocument: "{}"})
+	require.NoError(t, err)
+	require.NoError(t, dst.AttachUserPolicy(ctx, "bob", pol.ARN))
+}

--- a/providers/gcp/iam/snapshot.go
+++ b/providers/gcp/iam/snapshot.go
@@ -1,0 +1,168 @@
+package iam
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// iamSnapshot is the full serialized state of the GCP IAM mock. The policies
+// store is promoted to an exported snapshot form (policyData carries an
+// unexported version list); the fully-exported stores round-trip through the
+// generic memstore helper. The attachment/membership maps are captured too, so
+// a snapshot/restore round-trip preserves all identities (user/role/policy
+// ARNs, group memberships, access-key ids, instance-profile names).
+type iamSnapshot struct {
+	Policies map[string]*policySnapshot `json:"policies,omitempty"`
+
+	Users            json.RawMessage `json:"users,omitempty"`
+	Roles            json.RawMessage `json:"roles,omitempty"`
+	Groups           json.RawMessage `json:"groups,omitempty"`
+	AccessKeys       json.RawMessage `json:"accessKeys,omitempty"`
+	InstanceProfiles json.RawMessage `json:"instanceProfiles,omitempty"`
+
+	UserPolicies map[string]map[string]bool `json:"userPolicies,omitempty"`
+	RolePolicies map[string]map[string]bool `json:"rolePolicies,omitempty"`
+	GroupUsers   map[string]map[string]bool `json:"groupUsers,omitempty"`
+}
+
+// policySnapshot mirrors policyData, promoting its unexported version list and
+// counter so the version history (and default-version pointer) round-trips.
+type policySnapshot struct {
+	Name           string               `json:"name"`
+	ID             string               `json:"id,omitempty"`
+	ARN            string               `json:"arn,omitempty"`
+	Path           string               `json:"path,omitempty"`
+	PolicyDocument string               `json:"policyDocument,omitempty"`
+	Description    string               `json:"description,omitempty"`
+	Versions       []*policyVersionData `json:"versions,omitempty"`
+	VersionCounter int                  `json:"versionCounter,omitempty"`
+}
+
+// Snapshot captures the entire IAM state as JSON. includeAssets is unused — IAM
+// holds no bulk object bodies, so everything is always captured.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	snap := iamSnapshot{
+		Policies:     m.snapshotPolicies(),
+		UserPolicies: m.userPolicies,
+		RolePolicies: m.rolePolicies,
+		GroupUsers:   m.groupUsers,
+	}
+
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	//nolint:gosec // G117: persist intentionally serializes IAM access-key material so a snapshot/restore round-trip is transparent.
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotPolicies() map[string]*policySnapshot {
+	out := make(map[string]*policySnapshot, m.policies.Len())
+
+	for arn, p := range m.policies.All() {
+		out[arn] = &policySnapshot{
+			Name: p.Name, ID: p.ID, ARN: p.ARN, Path: p.Path, PolicyDocument: p.PolicyDocument,
+			Description: p.Description, Versions: p.versions, VersionCounter: p.versionCounter,
+		}
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotStores(snap *iamSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Users, m.users.Snapshot},
+		{&snap.Roles, m.roles.Snapshot},
+		{&snap.Groups, m.groups.Snapshot},
+		{&snap.AccessKeys, m.accessKeys.Snapshot},
+		{&snap.InstanceProfiles, m.instanceProfiles.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("iam: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds every store and attachment map under the original
+// identities. It is called on a freshly built (empty) mock.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap iamSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("iam: parse snapshot: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.restorePolicies(snap.Policies)
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	if snap.UserPolicies != nil {
+		m.userPolicies = snap.UserPolicies
+	}
+
+	if snap.RolePolicies != nil {
+		m.rolePolicies = snap.RolePolicies
+	}
+
+	if snap.GroupUsers != nil {
+		m.groupUsers = snap.GroupUsers
+	}
+
+	return nil
+}
+
+func (m *Mock) restorePolicies(policies map[string]*policySnapshot) {
+	for arn, p := range policies {
+		m.policies.Set(arn, &policyData{
+			Name: p.Name, ID: p.ID, ARN: p.ARN, Path: p.Path, PolicyDocument: p.PolicyDocument,
+			Description: p.Description, versions: p.Versions, versionCounter: p.VersionCounter,
+		})
+	}
+}
+
+func (m *Mock) restoreStores(snap *iamSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Users, m.users.LoadSnapshot},
+		{snap.Roles, m.roles.LoadSnapshot},
+		{snap.Groups, m.groups.LoadSnapshot},
+		{snap.AccessKeys, m.accessKeys.LoadSnapshot},
+		{snap.InstanceProfiles, m.instanceProfiles.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("iam: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/gcp/iam/snapshot_test.go
+++ b/providers/gcp/iam/snapshot_test.go
@@ -1,0 +1,96 @@
+package iam
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSnapshotRestoreRoundTripAllStores populates every IAM store and every
+// attachment/membership map, snapshots, restores into a fresh mock, and asserts
+// each piece of state round-trips under its original identity — a missed store
+// would be silent data loss.
+func TestSnapshotRestoreRoundTripAllStores(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	const doc = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}`
+
+	_, err := src.CreateUser(ctx, driver.UserConfig{Name: "alice"})
+	require.NoError(t, err)
+	_, err = src.CreateRole(ctx, driver.RoleConfig{Name: "r1", AssumeRolePolicyDoc: doc})
+	require.NoError(t, err)
+
+	pol, err := src.CreatePolicy(ctx, driver.PolicyConfig{Name: "p1", PolicyDocument: doc})
+	require.NoError(t, err)
+	_, err = src.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{
+		PolicyARN: pol.ARN, PolicyDocument: doc, SetAsDefault: true,
+	})
+	require.NoError(t, err)
+
+	_, err = src.CreateGroup(ctx, driver.GroupConfig{Name: "g1"})
+	require.NoError(t, err)
+
+	ak, err := src.CreateAccessKey(ctx, driver.AccessKeyConfig{UserName: "alice"})
+	require.NoError(t, err)
+
+	_, err = src.CreateInstanceProfile(ctx, driver.InstanceProfileConfig{Name: "prof1"})
+	require.NoError(t, err)
+	require.NoError(t, src.AddRoleToInstanceProfile(ctx, "prof1", "r1"))
+
+	require.NoError(t, src.AttachUserPolicy(ctx, "alice", pol.ARN))
+	require.NoError(t, src.AttachRolePolicy(ctx, "r1", pol.ARN))
+	require.NoError(t, src.AddUserToGroup(ctx, "alice", "g1"))
+
+	data, err := src.Snapshot(ctx, false)
+	require.NoError(t, err)
+
+	dst := newTestMock()
+	require.NoError(t, dst.Restore(ctx, data))
+
+	// Stores.
+	assert.True(t, dst.users.Has("alice"), "user restored")
+	assert.True(t, dst.roles.Has("r1"), "role restored")
+
+	p, ok := dst.policies.Get(pol.ARN)
+	require.True(t, ok, "policy restored under its ARN")
+	assert.Len(t, p.versions, 2)
+	assert.Equal(t, 2, p.versionCounter)
+
+	assert.True(t, dst.groups.Has("g1"), "group restored")
+
+	restoredKey, ok := dst.accessKeys.Get(ak.AccessKeyID)
+	require.True(t, ok, "access key restored under its id")
+	assert.Equal(t, "alice", restoredKey.UserName)
+
+	prof, ok := dst.instanceProfiles.Get("prof1")
+	require.True(t, ok, "instance profile restored")
+	assert.Equal(t, "r1", prof.RoleName)
+
+	// Maps.
+	assert.True(t, dst.userPolicies["alice"][pol.ARN], "user attachment restored")
+	assert.True(t, dst.rolePolicies["r1"][pol.ARN], "role attachment restored")
+	assert.True(t, dst.groupUsers["g1"]["alice"], "group membership restored")
+}
+
+// TestSnapshotRestoreEmptyNilSafe confirms an empty mock round-trips without
+// panicking and leaves the attachment maps usable.
+func TestSnapshotRestoreEmptyNilSafe(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	data, err := src.Snapshot(ctx, false)
+	require.NoError(t, err)
+
+	dst := newTestMock()
+	require.NoError(t, dst.Restore(ctx, data))
+
+	_, err = dst.CreateUser(ctx, driver.UserConfig{Name: "bob"})
+	require.NoError(t, err)
+	pol, err := dst.CreatePolicy(ctx, driver.PolicyConfig{Name: "pp", PolicyDocument: "{}"})
+	require.NoError(t, err)
+	require.NoError(t, dst.AttachUserPolicy(ctx, "bob", pol.ARN))
+}


### PR DESCRIPTION
Wave 3 of #582.

Implements internal/snapshot.Snapshottable on the IAM provider mocks (providers/{aws,azure,gcp}/iam), so SnapshotServices() auto-discovery now includes the "iam" key for all three providers and persist captures/restores IAM state identity-preservingly.

Stores/maps captured per provider:
- AWS: users, roles, policies, groups, accessKeys, instanceProfiles, mfaDevices + userPolicies/rolePolicies/groupPolicies/groupUsers, userInlinePolicies/groupInlinePolicies, and the account passwordPolicy. Users/roles/policies use exported snapshot structs (unexported permissionsBoundary / inlinePolicies / version history); the rest round-trip via the generic memstore helper.
- Azure & GCP: users, roles, policies, groups, accessKeys, instanceProfiles + userPolicies/rolePolicies/groupUsers.

Identities (user/role/policy ARNs, group memberships, access-key ids, instance-profile names) and the EC2->instance-profile cross-ref survive restore.

Tests: per-provider snapshot -> restore-into-fresh round-trip asserting every store/map; the SnapshotServices discovery test now pins the "iam" key for each provider.