### PR TITLE
test(persist): property-based discovery assertion so waves don't touch a frozen golden list (#582)

### DIFF
--- a/persist/snapshot_services_test.go
+++ b/persist/snapshot_services_test.go
@@ -1,52 +1,139 @@
 package persist_test
 
 import (
+	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
 
 	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
 	"github.com/stackshy/cloudemu/v2/persist"
 )
 
-// TestSnapshotServicesDiscovery pins that each provider factory's
-// SnapshotServices() enumerates exactly the services that implement
-// snapshot.Snapshottable today, keyed by a stable lowercased field-name key.
-// This is the auto-discovery contract persist relies on: adding a Snapshottable
-// service later grows this map with no persist change, and the keys must stay
-// stable so a snapshot restores into the right service across runs.
+// TestSnapshotServicesDiscovery checks the auto-discovery contract without a
+// frozen golden list: for each provider factory, SnapshotServices() (which calls
+// snapshot.Discover) must return exactly the set of keys an INDEPENDENT
+// reflection over the concrete Provider computes.
+//
+// The expected set is computed by reflectSnapshotKeys, a separate reimplementation
+// of the contract (exported, non-nil fields whose type implements Snapshottable,
+// keyed by the lowercased field name). It deliberately does NOT call Discover, so
+// the two only agree when Discover is correct. This still fails if Discover:
+//   - skips a field that implements Snapshottable (missed service),
+//   - returns a key for a field that does not implement it,
+//   - derives the key with the wrong casing, or
+//   - silently collapses two fields onto one key (collision).
+//
+// Because both sides recompute from the live struct, a NEW Snapshottable service
+// grows both sets together and needs no edit here — that is the point: parallel
+// persist waves never touch this file.
 func TestSnapshotServicesDiscovery(t *testing.T) {
 	tests := []struct {
 		provider string
-		services map[string]struct{}
-		want     []string
+		p        snapshotProvider
 	}{
-		{"aws", asSet(keysOf(cloudemu.NewAWS().SnapshotServices())), []string{"dynamodb", "ec2", "iam", "route53", "s3", "secretsmanager", "vpc"}},
-		{"azure", asSet(keysOf(cloudemu.NewAzure().SnapshotServices())), []string{"blobstorage", "cosmosdb", "dns", "iam", "keyvault", "virtualmachines", "vnet"}},
-		{"gcp", asSet(keysOf(cloudemu.NewGCP().SnapshotServices())), []string{"clouddns", "firestore", "gce", "gcs", "iam", "secretmanager", "vpc"}},
+		{"aws", cloudemu.NewAWS()},
+		{"azure", cloudemu.NewAzure()},
+		{"gcp", cloudemu.NewGCP()},
+		{"oci", cloudemu.NewOCI()},
 	}
 
 	for _, tc := range tests {
-		got := sortedSet(tc.services)
-		if strings.Join(got, ",") != strings.Join(tc.want, ",") {
-			t.Errorf("%s SnapshotServices keys = %v, want %v", tc.provider, got, tc.want)
+		discovered := tc.p.SnapshotServices()
+		got := asSet(keysOf(discovered))
+
+		want, collisions := reflectSnapshotKeys(tc.p)
+		if len(collisions) != 0 {
+			t.Errorf("%s: independent reflection found colliding snapshot keys %v — two Provider fields lowercase to the same key",
+				tc.provider, collisions)
 		}
 
-		for _, k := range got {
+		if g, w := sortedSet(got), sortedSet(want); strings.Join(g, ",") != strings.Join(w, ",") {
+			t.Errorf("%s SnapshotServices keys = %v, want (independently computed) %v", tc.provider, g, w)
+		}
+
+		for k := range got {
 			if k != strings.ToLower(k) {
 				t.Errorf("%s key %q is not lowercased (keys must be stable, case-normalized)", tc.provider, k)
 			}
 		}
+
+		// A discovered value must never be nil — Snapshot would panic on it.
+		for name, s := range discovered {
+			if s == nil {
+				t.Errorf("%s service %q discovered as nil", tc.provider, name)
+			}
+		}
+	}
+}
+
+// snapshotProvider is the slice of a provider factory the discovery test needs:
+// the auto-discovery entry point. Each of NewAWS/NewAzure/NewGCP/NewOCI satisfies
+// it. reflectSnapshotKeys still reflects over the concrete value behind it.
+type snapshotProvider interface {
+	SnapshotServices() persist.Services
+}
+
+// TestSnapshotDiscoveryCatchesRegressions is the negative path: it proves the
+// property assertion above would actually fire on a broken discovery, using
+// hand-built fake providers whose expected behavior is known.
+func TestSnapshotDiscoveryCatchesRegressions(t *testing.T) {
+	// A missed service: reflectSnapshotKeys includes a Snapshottable field; a
+	// hypothetical Discover that dropped it would produce a smaller set, and the
+	// set comparison (via setsEqual) would report inequality.
+	type provider struct {
+		Alpha   fakeSnapshottable // implements -> "alpha"
+		Beta    fakeSnapshottable // implements -> "beta"
+		NotASvc int               // not Snapshottable -> ignored
 	}
 
-	// Values must be non-nil (a nil Snapshottable would panic on Snapshot) — the
-	// discovery skips nil pointer fields.
-	for name, s := range cloudemu.NewAWS().SnapshotServices() {
-		if s == nil {
-			t.Errorf("aws service %q discovered as nil", name)
-		}
+	keys, collisions := reflectSnapshotKeys(&provider{})
+	if len(collisions) != 0 {
+		t.Fatalf("unexpected collisions on clean fake provider: %v", collisions)
+	}
+
+	if want := map[string]struct{}{"alpha": {}, "beta": {}}; !setsEqual(keys, want) {
+		t.Fatalf("reflectSnapshotKeys = %v, want %v", sortedSet(keys), sortedSet(want))
+	}
+
+	// (a) Missed service: a discovery that dropped "beta" must be caught.
+	if setsEqual(keys, map[string]struct{}{"alpha": {}}) {
+		t.Fatalf("setsEqual failed to detect a missing key — a dropped service would go unnoticed")
+	}
+
+	// (b) Extra / wrong key: a discovery that returned a key for NotASvc, or the
+	// wrong casing, must be caught.
+	if setsEqual(keys, map[string]struct{}{"alpha": {}, "beta": {}, "notasvc": {}}) {
+		t.Fatalf("setsEqual failed to detect an extra key")
+	}
+
+	if setsEqual(keys, map[string]struct{}{"Alpha": {}, "Beta": {}}) {
+		t.Fatalf("setsEqual treated a casing difference as equal")
+	}
+
+	// (c) Collision: two fields whose names lowercase to the same key. Discover
+	// silently collapses them into one map entry; reflectSnapshotKeys flags the
+	// collision so the main test's collision assertion fires.
+	type colliding struct {
+		Route53 fakeSnapshottable
+		ROUTE53 fakeSnapshottable
+	}
+
+	_, cc := reflectSnapshotKeys(&colliding{})
+	if len(cc) == 0 {
+		t.Fatalf("reflectSnapshotKeys did not report the route53/ROUTE53 collision")
+	}
+
+	// Two fields implement Snapshottable, but Discover keys by lowercased name and
+	// so collapses them into one entry — the silent data loss the collision report
+	// exists to surface.
+	if got := snapshot.Discover(&colliding{}); len(got) != 1 {
+		t.Fatalf("Discover(&colliding{}) has %d keys, want 1 (collision collapsed)", len(got))
 	}
 }
 
@@ -100,6 +187,75 @@ func TestReadFileRejectsIncompatibleSchema(t *testing.T) {
 	}
 }
 
+// reflectSnapshotKeys independently reproduces the auto-discovery contract that
+// snapshot.Discover implements, so the discovery test can assert against a set it
+// did not obtain from Discover. It reflects over the exported, non-nil struct
+// fields of p and, for each whose type implements snapshot.Snapshottable, records
+// the lowercased field name. It uses reflect.Type.Implements (not a value type
+// assertion, as Discover does) so the two are not the same code path. Any key
+// produced by more than one field is reported in collisions rather than silently
+// overwritten — the divergence a plain map would hide.
+func reflectSnapshotKeys(p any) (keys map[string]struct{}, collisions []string) {
+	keys = map[string]struct{}{}
+	seen := map[string]int{}
+
+	v := reflect.ValueOf(p)
+	for v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return keys, collisions
+		}
+
+		v = v.Elem()
+	}
+
+	if v.Kind() != reflect.Struct {
+		return keys, collisions
+	}
+
+	snapType := reflect.TypeOf((*snapshot.Snapshottable)(nil)).Elem()
+	t := v.Type()
+
+	for i := range t.NumField() {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+
+		fv := v.Field(i)
+		if fv.Kind() == reflect.Pointer && fv.IsNil() {
+			continue
+		}
+
+		if !fv.Type().Implements(snapType) {
+			continue
+		}
+
+		key := strings.ToLower(f.Name)
+		seen[key]++
+		keys[key] = struct{}{}
+	}
+
+	for k, n := range seen {
+		if n > 1 {
+			collisions = append(collisions, k)
+		}
+	}
+
+	sort.Strings(collisions)
+
+	return keys, collisions
+}
+
+// fakeSnapshottable is a minimal Snapshottable used only by the negative-path
+// test to build fake provider structs with known field layouts.
+type fakeSnapshottable struct{}
+
+func (fakeSnapshottable) Snapshot(context.Context, bool) (json.RawMessage, error) {
+	return json.RawMessage(`{}`), nil
+}
+
+func (fakeSnapshottable) Restore(context.Context, json.RawMessage) error { return nil }
+
 func keysOf(m persist.Services) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {
@@ -127,4 +283,18 @@ func sortedSet(set map[string]struct{}) []string {
 	sort.Strings(out)
 
 	return out
+}
+
+func setsEqual(a, b map[string]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
#582 — de-conflict: makes the discovery test property-based so future Snapshottable waves need no golden-list edit.

## What
`TestSnapshotServicesDiscovery` no longer pins each provider's snapshot keys against a hardcoded `want` slice. Instead it computes the expected key set **independently** of `snapshot.Discover` (via `reflectSnapshotKeys`, a separate reflection pass using `reflect.Type.Implements` rather than Discover's value type-assertion) and asserts `SnapshotServices() == that set`. Both sides recompute from the live `*Provider` struct, so a new Snapshottable service grows both sides together — no edit to this file per wave, so parallel persist waves stop conflicting on it.

## Why it is not tautological
The expected set is built by a distinct code path that never calls `Discover`. They only agree when Discover is correct. The test still fails if Discover: skips a Snapshottable field (missed service), emits a key for a non-implementing field, uses the wrong casing, or silently collapses two fields onto one key (collision).

## Regression coverage kept / proven
- **Missed service**: verified by temporarily making Discover skip `ec2` — the test failed (independent set still contained `ec2`).
- **Collision**: `reflectSnapshotKeys` reports any key produced by >1 field; the main test asserts zero collisions. `TestSnapshotDiscoveryCatchesRegressions` builds a fake provider with `Route53`/`ROUTE53` and proves the collision is reported and that Discover collapses it to one entry.
- **Extra/wrong-case key & dropped key**: `TestSnapshotDiscoveryCatchesRegressions` exercises the set comparison against known-wrong sets.
- Stable-lowercased-keys, OCI-empty, and schema-compat guards are unchanged.

Note on renames: a plain 1:1 field rename changes the key on both sides identically, so it is intentionally no longer pinned (that is the de-conflict tradeoff); a rename that introduces a collision is still caught.

Test-only change.