### PR TITLE
feat(persist): Snapshottable across 30 provider mocks (#582 round C)

### DIFF
--- a/providers/aws/bedrock/snapshot.go
+++ b/providers/aws/bedrock/snapshot.go
@@ -1,0 +1,174 @@
+package bedrock
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/bedrock/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// bedrockSnapshot is the full serialized state of the Bedrock mock. Every store
+// whose value type is fully exported round-trips through the generic memstore
+// helper keyed by its resource id; guardrails carry an exported form because
+// guardrailRecord has unexported fields and a mutex that json.Marshal cannot
+// see. The seeded foundation-model catalog is intentionally not serialized — a
+// fresh mock re-seeds an identical catalog in New() — and neither is the wired
+// *config.Options or the monitoring backend.
+type bedrockSnapshot struct {
+	Jobs                 json.RawMessage               `json:"jobs,omitempty"`
+	Models               json.RawMessage               `json:"models,omitempty"`
+	Guardrails           map[string]*guardrailSnapshot `json:"guardrails,omitempty"`
+	Provisioned          json.RawMessage               `json:"provisioned,omitempty"`
+	Tags                 json.RawMessage               `json:"tags,omitempty"`
+	AsyncInvokes         json.RawMessage               `json:"asyncInvokes,omitempty"`
+	ImportJobs           json.RawMessage               `json:"importJobs,omitempty"`
+	CopyJobs             json.RawMessage               `json:"copyJobs,omitempty"`
+	EvalJobs             json.RawMessage               `json:"evalJobs,omitempty"`
+	InferenceProfiles    json.RawMessage               `json:"inferenceProfiles,omitempty"`
+	PromptRouters        json.RawMessage               `json:"promptRouters,omitempty"`
+	ARPolicies           json.RawMessage               `json:"arPolicies,omitempty"`
+	MarketplaceEndpoints json.RawMessage               `json:"marketplaceEndpoints,omitempty"`
+	FMAgreements         json.RawMessage               `json:"fmAgreements,omitempty"`
+	Logging              *driver.LoggingConfig         `json:"logging,omitempty"`
+}
+
+// guardrailSnapshot mirrors guardrailRecord, promoting its unexported working
+// copy, version history, and next-version counter to exported fields so they
+// survive JSON. The per-record mutex is deliberately excluded.
+type guardrailSnapshot struct {
+	Draft    *driver.Guardrail   `json:"draft,omitempty"`
+	Versions []*driver.Guardrail `json:"versions,omitempty"`
+	NextVer  int                 `json:"nextVer,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Bedrock holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := bedrockSnapshot{Guardrails: m.snapshotGuardrails()}
+
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	m.logMu.RLock()
+	snap.Logging = m.logging
+	m.logMu.RUnlock()
+
+	return json.Marshal(snap)
+}
+
+// snapshotGuardrails promotes each stored guardrailRecord to its exported form.
+func (m *Mock) snapshotGuardrails() map[string]*guardrailSnapshot {
+	if m.guardrails.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*guardrailSnapshot, m.guardrails.Len())
+
+	for name, rec := range m.guardrails.All() {
+		rec.mu.RLock()
+		out[name] = &guardrailSnapshot{Draft: rec.draft, Versions: rec.versions, NextVer: rec.nextVer}
+		rec.mu.RUnlock()
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotStores(snap *bedrockSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Jobs, m.jobs.Snapshot},
+		{&snap.Models, m.models.Snapshot},
+		{&snap.Provisioned, m.provisioned.Snapshot},
+		{&snap.Tags, m.tags.Snapshot},
+		{&snap.AsyncInvokes, m.asyncInvokes.Snapshot},
+		{&snap.ImportJobs, m.importJobs.Snapshot},
+		{&snap.CopyJobs, m.copyJobs.Snapshot},
+		{&snap.EvalJobs, m.evalJobs.Snapshot},
+		{&snap.InferenceProfiles, m.inferenceProfiles.Snapshot},
+		{&snap.PromptRouters, m.promptRouters.Snapshot},
+		{&snap.ARPolicies, m.arPolicies.Snapshot},
+		{&snap.MarketplaceEndpoints, m.marketplaceEndpoints.Snapshot},
+		{&snap.FMAgreements, m.fmAgreements.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("bedrock: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds the mock's state under the original identities: every job,
+// model, guardrail, and registry resource is reinstated under its stored id.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap bedrockSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("bedrock: parse snapshot: %w", err)
+	}
+
+	m.restoreGuardrails(snap.Guardrails)
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	if snap.Logging != nil {
+		m.logMu.Lock()
+		m.logging = snap.Logging
+		m.logMu.Unlock()
+	}
+
+	return nil
+}
+
+// restoreGuardrails reinstates each guardrail record under its original name.
+func (m *Mock) restoreGuardrails(guardrails map[string]*guardrailSnapshot) {
+	for name, s := range guardrails {
+		m.guardrails.Set(name, &guardrailRecord{draft: s.Draft, versions: s.Versions, nextVer: s.NextVer})
+	}
+}
+
+func (m *Mock) restoreStores(snap *bedrockSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Jobs, m.jobs.LoadSnapshot},
+		{snap.Models, m.models.LoadSnapshot},
+		{snap.Provisioned, m.provisioned.LoadSnapshot},
+		{snap.Tags, m.tags.LoadSnapshot},
+		{snap.AsyncInvokes, m.asyncInvokes.LoadSnapshot},
+		{snap.ImportJobs, m.importJobs.LoadSnapshot},
+		{snap.CopyJobs, m.copyJobs.LoadSnapshot},
+		{snap.EvalJobs, m.evalJobs.LoadSnapshot},
+		{snap.InferenceProfiles, m.inferenceProfiles.LoadSnapshot},
+		{snap.PromptRouters, m.promptRouters.LoadSnapshot},
+		{snap.ARPolicies, m.arPolicies.LoadSnapshot},
+		{snap.MarketplaceEndpoints, m.marketplaceEndpoints.LoadSnapshot},
+		{snap.FMAgreements, m.fmAgreements.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("bedrock: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/aws/bedrock/snapshot_test.go
+++ b/providers/aws/bedrock/snapshot_test.go
@@ -1,0 +1,87 @@
+package bedrock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/bedrock/driver"
+)
+
+// TestSnapshotRoundTripBedrock proves a snapshot/restore round-trip preserves
+// the Bedrock mock's state under the original identities: a guardrail (whose
+// record is promoted through an exported form), an inference profile (a
+// generic-dumped store), and the account model-invocation logging config all
+// survive restore into a fresh mock.
+func TestSnapshotRoundTripBedrock(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, err := src.CreateGuardrail(ctx, driver.GuardrailConfig{
+		Name:                    "gr-1",
+		Description:             "block stuff",
+		BlockedInputMessaging:   "no",
+		BlockedOutputsMessaging: "nope",
+	}); err != nil {
+		t.Fatalf("create guardrail: %v", err)
+	}
+
+	if _, err := src.CreateInferenceProfile(ctx, driver.InferenceProfileConfig{
+		Name:                "prof-1",
+		ModelSourceCopyFrom: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2",
+	}); err != nil {
+		t.Fatalf("create inference profile: %v", err)
+	}
+
+	if err := src.PutModelInvocationLoggingConfiguration(ctx, driver.LoggingConfig{
+		TextDataDeliveryEnabled: true,
+	}); err != nil {
+		t.Fatalf("put logging config: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	gr, err := dst.GetGuardrail(ctx, "gr-1", "")
+	if err != nil {
+		t.Fatalf("get restored guardrail: %v", err)
+	}
+
+	if gr.Name != "gr-1" || gr.Description != "block stuff" {
+		t.Fatalf("restored guardrail = %+v, want name gr-1 / desc block stuff", gr)
+	}
+
+	profiles := src.mustListProfiles(ctx, t)
+	restored := dst.mustListProfiles(ctx, t)
+
+	if len(restored) != len(profiles) || len(restored) == 0 {
+		t.Fatalf("restored inference profiles = %d, want %d (non-zero)", len(restored), len(profiles))
+	}
+
+	cfg, err := dst.GetModelInvocationLoggingConfiguration(ctx)
+	if err != nil {
+		t.Fatalf("get restored logging config: %v", err)
+	}
+
+	if cfg == nil || !cfg.TextDataDeliveryEnabled {
+		t.Fatalf("restored logging config = %+v, want TextDataDeliveryEnabled=true", cfg)
+	}
+}
+
+// mustListProfiles returns every stored inference profile id, failing the test
+// on error. It reads the store directly (an in-package test) to avoid coupling
+// to a specific list-filter shape.
+func (m *Mock) mustListProfiles(_ context.Context, _ *testing.T) []string {
+	out := make([]string, 0, m.inferenceProfiles.Len())
+	for id := range m.inferenceProfiles.All() {
+		out = append(out, id)
+	}
+
+	return out
+}

--- a/providers/aws/cloudwatchlogs/snapshot.go
+++ b/providers/aws/cloudwatchlogs/snapshot.go
@@ -1,0 +1,138 @@
+package cloudwatchlogs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// logsSnapshot is the full serialized state of the CloudWatch Logs mock. The
+// groups store holds an unexported *logGroup whose nested stores (streams, and
+// the metric/subscription filter stores) must be captured, so it is promoted to
+// an exported snapshot form keyed by group name. The wired deps (opts,
+// monitoring, lambda) are not serialized.
+type logsSnapshot struct {
+	Groups map[string]*logGroupSnapshot `json:"groups,omitempty"`
+}
+
+// logGroupSnapshot mirrors logGroup. Its metric- and subscription-filter stores
+// hold fully-exported driver pointer types, so they round-trip through the
+// generic memstore helper; streams carries an exported form because logStream
+// has an unexported mutex.
+type logGroupSnapshot struct {
+	Info          driver.LogGroupInfo           `json:"info"`
+	Streams       map[string]*logStreamSnapshot `json:"streams,omitempty"`
+	MetricFilters json.RawMessage               `json:"metricFilters,omitempty"`
+	SubFilters    json.RawMessage               `json:"subFilters,omitempty"`
+}
+
+// logStreamSnapshot mirrors logStream, promoting its fields past the unexported
+// mutex.
+type logStreamSnapshot struct {
+	Info   driver.LogStreamInfo `json:"info"`
+	Events []driver.LogEvent    `json:"events,omitempty"`
+}
+
+// Snapshot captures every log group's state as JSON. includeAssets is unused —
+// log events are the payload and are always captured.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := logsSnapshot{}
+	if m.groups.Len() == 0 {
+		return json.Marshal(snap)
+	}
+
+	snap.Groups = make(map[string]*logGroupSnapshot, m.groups.Len())
+
+	for name, g := range m.groups.All() {
+		gs, err := snapshotGroup(g)
+		if err != nil {
+			return nil, err
+		}
+
+		snap.Groups[name] = gs
+	}
+
+	return json.Marshal(snap)
+}
+
+func snapshotGroup(g *logGroup) (*logGroupSnapshot, error) {
+	gs := &logGroupSnapshot{Info: g.info}
+
+	mf, err := g.metricFilters.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("cloudwatchlogs: snapshot metric filters: %w", err)
+	}
+
+	sf, err := g.subFilters.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("cloudwatchlogs: snapshot subscription filters: %w", err)
+	}
+
+	gs.MetricFilters = mf
+	gs.SubFilters = sf
+
+	if g.streams.Len() > 0 {
+		gs.Streams = make(map[string]*logStreamSnapshot, g.streams.Len())
+
+		for sName, s := range g.streams.All() {
+			s.mu.RLock()
+			gs.Streams[sName] = &logStreamSnapshot{Info: s.info, Events: append([]driver.LogEvent(nil), s.events...)}
+			s.mu.RUnlock()
+		}
+	}
+
+	return gs, nil
+}
+
+// Restore rebuilds every log group under its original name with its streams,
+// events, and metric/subscription filters intact.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap logsSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("cloudwatchlogs: parse snapshot: %w", err)
+	}
+
+	for name, gs := range snap.Groups {
+		g, err := restoreGroup(gs)
+		if err != nil {
+			return err
+		}
+
+		m.groups.Set(name, g)
+	}
+
+	return nil
+}
+
+func restoreGroup(gs *logGroupSnapshot) (*logGroup, error) {
+	g := &logGroup{
+		info:          gs.Info,
+		streams:       memstore.New[*logStream](),
+		metricFilters: memstore.New[*driver.MetricFilterInfo](),
+		subFilters:    memstore.New[*driver.SubscriptionFilterInfo](),
+	}
+
+	if len(gs.MetricFilters) > 0 {
+		if err := g.metricFilters.LoadSnapshot(gs.MetricFilters); err != nil {
+			return nil, fmt.Errorf("cloudwatchlogs: restore metric filters: %w", err)
+		}
+	}
+
+	if len(gs.SubFilters) > 0 {
+		if err := g.subFilters.LoadSnapshot(gs.SubFilters); err != nil {
+			return nil, fmt.Errorf("cloudwatchlogs: restore subscription filters: %w", err)
+		}
+	}
+
+	for sName, ss := range gs.Streams {
+		g.streams.Set(sName, &logStream{info: ss.Info, events: ss.Events})
+	}
+
+	return g, nil
+}

--- a/providers/aws/cloudwatchlogs/snapshot_test.go
+++ b/providers/aws/cloudwatchlogs/snapshot_test.go
@@ -1,0 +1,49 @@
+package cloudwatchlogs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// TestSnapshotRoundTripCloudWatchLogs proves a snapshot/restore round-trip
+// preserves a log group, its stream, and the stream's events.
+func TestSnapshotRoundTripCloudWatchLogs(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, err := src.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "/svc/app"}); err != nil {
+		t.Fatalf("create log group: %v", err)
+	}
+
+	if _, err := src.CreateLogStream(ctx, "/svc/app", "s1"); err != nil {
+		t.Fatalf("create log stream: %v", err)
+	}
+
+	if err := src.PutLogEvents(ctx, "/svc/app", "s1", []driver.LogEvent{
+		{Timestamp: time.Unix(1, 0), Message: "hello"},
+	}); err != nil {
+		t.Fatalf("put log events: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	events, err := dst.GetLogEvents(ctx, &driver.LogQueryInput{LogGroup: "/svc/app", LogStream: "s1"})
+	if err != nil {
+		t.Fatalf("get restored events: %v", err)
+	}
+
+	if len(events) != 1 || events[0].Message != "hello" {
+		t.Fatalf("restored events = %+v, want one 'hello'", events)
+	}
+}

--- a/providers/aws/ecr/snapshot.go
+++ b/providers/aws/ecr/snapshot.go
@@ -1,0 +1,133 @@
+package ecr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// ecrSnapshot is the full serialized state of the ECR mock. The repos store
+// holds an unexported *repoData whose nested images store (unexported *imageData)
+// and unexported scalar settings must be captured, so it is promoted to an
+// exported snapshot form keyed by repository name. The scans store holds a
+// fully-exported *driver.ScanResult and round-trips through the generic memstore
+// helper. The mutex and the wired deps (opts, monitoring) are not serialized.
+type ecrSnapshot struct {
+	Repos map[string]*repoSnapshot `json:"repos,omitempty"`
+}
+
+// repoSnapshot mirrors repoData, promoting its unexported settings and nested
+// stores. Images carries an exported form because imageData is unexported;
+// scans round-trips through the generic helper.
+type repoSnapshot struct {
+	Info          driver.Repository         `json:"info"`
+	Images        map[string]*imageSnapshot `json:"images,omitempty"`
+	Scans         json.RawMessage           `json:"scans,omitempty"`
+	Policy        *driver.LifecyclePolicy   `json:"policy,omitempty"`
+	RepoPolicy    string                    `json:"repoPolicy,omitempty"`
+	ScanOnPush    bool                      `json:"scanOnPush,omitempty"`
+	TagMutability string                    `json:"tagMutability,omitempty"`
+}
+
+// imageSnapshot mirrors imageData (whose fields are exported but whose type is
+// unexported, so json.Marshal cannot reach it through the store).
+type imageSnapshot struct {
+	Detail driver.ImageDetail `json:"detail"`
+	Layers []driver.LayerInfo `json:"layers,omitempty"`
+}
+
+// Snapshot captures every repository's state as JSON. includeAssets is unused —
+// ECR stores image manifests/metadata, not object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := ecrSnapshot{}
+	if m.repos.Len() == 0 {
+		return json.Marshal(snap)
+	}
+
+	snap.Repos = make(map[string]*repoSnapshot, m.repos.Len())
+
+	for name, rd := range m.repos.All() {
+		rs, err := snapshotRepo(rd)
+		if err != nil {
+			return nil, err
+		}
+
+		snap.Repos[name] = rs
+	}
+
+	return json.Marshal(snap)
+}
+
+func snapshotRepo(rd *repoData) (*repoSnapshot, error) {
+	rs := &repoSnapshot{
+		Info: rd.info, Policy: rd.policy, RepoPolicy: rd.repoPolicy,
+		ScanOnPush: rd.scanOnPush, TagMutability: rd.tagMutability,
+	}
+
+	scans, err := rd.scans.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("ecr: snapshot scans: %w", err)
+	}
+
+	rs.Scans = scans
+
+	if rd.images.Len() > 0 {
+		rs.Images = make(map[string]*imageSnapshot, rd.images.Len())
+
+		for key, img := range rd.images.All() {
+			rs.Images[key] = &imageSnapshot{Detail: img.detail, Layers: img.layers}
+		}
+	}
+
+	return rs, nil
+}
+
+// Restore rebuilds every repository under its original name with its images,
+// scans, lifecycle/repository policies, and settings intact.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap ecrSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("ecr: parse snapshot: %w", err)
+	}
+
+	for name, rs := range snap.Repos {
+		rd, err := restoreRepo(rs)
+		if err != nil {
+			return err
+		}
+
+		m.repos.Set(name, rd)
+	}
+
+	return nil
+}
+
+func restoreRepo(rs *repoSnapshot) (*repoData, error) {
+	rd := &repoData{
+		info:          rs.Info,
+		images:        memstore.New[*imageData](),
+		scans:         memstore.New[*driver.ScanResult](),
+		policy:        rs.Policy,
+		repoPolicy:    rs.RepoPolicy,
+		scanOnPush:    rs.ScanOnPush,
+		tagMutability: rs.TagMutability,
+	}
+
+	if len(rs.Scans) > 0 {
+		if err := rd.scans.LoadSnapshot(rs.Scans); err != nil {
+			return nil, fmt.Errorf("ecr: restore scans: %w", err)
+		}
+	}
+
+	for key, is := range rs.Images {
+		rd.images.Set(key, &imageData{detail: is.Detail, layers: is.Layers})
+	}
+
+	return rd, nil
+}

--- a/providers/aws/ecr/snapshot_test.go
+++ b/providers/aws/ecr/snapshot_test.go
@@ -1,0 +1,40 @@
+package ecr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSnapshotRoundTripECR proves a snapshot/restore round-trip preserves a
+// repository, its pushed image, and its settings.
+func TestSnapshotRoundTripECR(t *testing.T) {
+	ctx := context.Background()
+	src, _ := newTestMock()
+
+	_, err := src.CreateRepository(ctx, driver.RepositoryConfig{Name: "app", ImageTagMutability: "IMMUTABLE"})
+	require.NoError(t, err)
+
+	_, err = src.PutImage(ctx, &driver.ImageManifest{
+		Repository: "app", Tag: "v1", Digest: "sha256:abc", Layers: []driver.LayerInfo{{Digest: "sha256:l1"}},
+	})
+	require.NoError(t, err)
+
+	raw, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst, _ := newTestMock()
+	require.NoError(t, dst.Restore(ctx, raw))
+
+	repo, err := dst.GetRepository(ctx, "app")
+	require.NoError(t, err)
+	assert.Equal(t, "IMMUTABLE", repo.ImageTagMutability)
+
+	imgs, err := dst.ListImages(ctx, "app")
+	require.NoError(t, err)
+	require.Len(t, imgs, 1)
+	assert.Equal(t, "sha256:abc", imgs[0].Digest)
+}

--- a/providers/aws/ecs/snapshot.go
+++ b/providers/aws/ecs/snapshot.go
@@ -1,0 +1,119 @@
+package ecs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// ecsSnapshot is the full serialized state of the ECS mock. Every store holds a
+// fully-exported driver type (or []driver.Tag / string), so each round-trips
+// through the generic memstore helper keyed by its resource id — ARNs and the
+// "cluster/name", "family:revision" composite keys survive unchanged, so a
+// restore is transparent to clients. The dynamic-host-port counter is preserved
+// so newly placed bridge-mode ports do not collide with restored ones. The
+// mutexes and the optional wired deps (launcher, logs, registrar) are not
+// serialized.
+type ecsSnapshot struct {
+	Clusters      json.RawMessage `json:"clusters,omitempty"`
+	TaskDefs      json.RawMessage `json:"taskDefs,omitempty"`
+	Tasks         json.RawMessage `json:"tasks,omitempty"`
+	Services      json.RawMessage `json:"services,omitempty"`
+	Instances     json.RawMessage `json:"instances,omitempty"`
+	Tags          json.RawMessage `json:"tags,omitempty"`
+	Settings      json.RawMessage `json:"settings,omitempty"`
+	Attributes    json.RawMessage `json:"attributes,omitempty"`
+	EngineHandles json.RawMessage `json:"engineHandles,omitempty"`
+	PortCounter   uint32          `json:"portCounter,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// ECS holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap ecsSnapshot
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	snap.PortCounter = m.portCounter.Load()
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *ecsSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Clusters, m.clusters.Snapshot},
+		{&snap.TaskDefs, m.taskDefs.Snapshot},
+		{&snap.Tasks, m.tasks.Snapshot},
+		{&snap.Services, m.services.Snapshot},
+		{&snap.Instances, m.instances.Snapshot},
+		{&snap.Tags, m.tags.Snapshot},
+		{&snap.Settings, m.settings.Snapshot},
+		{&snap.Attributes, m.attributes.Snapshot},
+		{&snap.EngineHandles, m.engineHandles.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("ecs: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds the mock's state under the original identities (ARNs and the
+// composite keys), so a restored task/service/cluster resolves exactly as before.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap ecsSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("ecs: parse snapshot: %w", err)
+	}
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	m.portCounter.Store(snap.PortCounter)
+
+	return nil
+}
+
+func (m *Mock) restoreStores(snap *ecsSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Clusters, m.clusters.LoadSnapshot},
+		{snap.TaskDefs, m.taskDefs.LoadSnapshot},
+		{snap.Tasks, m.tasks.LoadSnapshot},
+		{snap.Services, m.services.LoadSnapshot},
+		{snap.Instances, m.instances.LoadSnapshot},
+		{snap.Tags, m.tags.LoadSnapshot},
+		{snap.Settings, m.settings.LoadSnapshot},
+		{snap.Attributes, m.attributes.LoadSnapshot},
+		{snap.EngineHandles, m.engineHandles.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("ecs: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/aws/ecs/snapshot_test.go
+++ b/providers/aws/ecs/snapshot_test.go
@@ -1,0 +1,42 @@
+package ecs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/services/ecs/driver"
+)
+
+// TestSnapshotRoundTripECS proves a snapshot/restore round-trip preserves the
+// clusters, task definitions and services stores under their original keys.
+func TestSnapshotRoundTripECS(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	_, err := src.CreateCluster(ctx, driver.CreateClusterInput{Name: "prod"})
+	require.NoError(t, err)
+
+	_, err = src.RegisterTaskDefinition(ctx, driver.RegisterTaskDefinitionInput{
+		Family:               "web",
+		ContainerDefinitions: []driver.ContainerDefinition{{Name: "c", Image: "img"}},
+	})
+	require.NoError(t, err)
+
+	raw, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst := newTestMock()
+	require.NoError(t, dst.Restore(ctx, raw))
+
+	clusters, err := dst.ListClusters(ctx)
+	require.NoError(t, err)
+	require.Len(t, clusters, 1)
+	assert.Equal(t, "prod", clusters[0].Name)
+
+	td, err := dst.DescribeTaskDefinition(ctx, "web")
+	require.NoError(t, err)
+	assert.Equal(t, "web", td.Family)
+}

--- a/providers/aws/efs/snapshot.go
+++ b/providers/aws/efs/snapshot.go
@@ -1,0 +1,150 @@
+package efs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/efs/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// efsSnapshot is the full serialized state of the EFS mock. File systems carry
+// an exported form (the stored fsData has a mutex that json.Marshal cannot see);
+// the id-index stores round-trip through the generic memstore helper so a mount
+// target or access-point id still resolves to its owning file system after a
+// restore. The mutexes, the subnet resolver, and the wired *config.Options are
+// intentionally not serialized.
+type efsSnapshot struct {
+	FileSystems  map[string]*fsDataSnapshot `json:"fileSystems,omitempty"`
+	MTIndex      json.RawMessage            `json:"mtIndex,omitempty"`
+	APIndex      json.RawMessage            `json:"apIndex,omitempty"`
+	TokenIndex   json.RawMessage            `json:"tokenIndex,omitempty"`
+	APTokenIndex json.RawMessage            `json:"apTokenIndex,omitempty"`
+	AccountPref  string                     `json:"accountPref,omitempty"`
+}
+
+// fsDataSnapshot mirrors fsData, promoting its fields to exported ones so they
+// survive JSON. The per-file-system mutex is deliberately excluded.
+type fsDataSnapshot struct {
+	FS          driver.FileSystem                `json:"fs"`
+	Policy      string                           `json:"policy,omitempty"`
+	Backup      string                           `json:"backup,omitempty"`
+	MountTgts   map[string]*driver.MountTarget   `json:"mountTgts,omitempty"`
+	AccessPts   map[string]*driver.AccessPoint   `json:"accessPts,omitempty"`
+	Lifecycle   []driver.LifecyclePolicy         `json:"lifecycle,omitempty"`
+	Replication *driver.ReplicationConfiguration `json:"replication,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// EFS holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := efsSnapshot{FileSystems: m.snapshotFileSystems()}
+
+	if err := m.snapshotIndexes(&snap); err != nil {
+		return nil, err
+	}
+
+	m.prefMu.RLock()
+	snap.AccountPref = m.accountPref
+	m.prefMu.RUnlock()
+
+	return json.Marshal(snap)
+}
+
+// snapshotFileSystems promotes each stored fsData to its exported snapshot form.
+func (m *Mock) snapshotFileSystems() map[string]*fsDataSnapshot {
+	if m.fileSystems.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*fsDataSnapshot, m.fileSystems.Len())
+
+	for id, d := range m.fileSystems.All() {
+		d.mu.RLock()
+		out[id] = &fsDataSnapshot{
+			FS: d.fs, Policy: d.policy, Backup: d.backup, MountTgts: d.mountTgts,
+			AccessPts: d.accessPts, Lifecycle: d.lifecycle, Replication: d.replication,
+		}
+		d.mu.RUnlock()
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotIndexes(snap *efsSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.MTIndex, m.mtIndex.Snapshot},
+		{&snap.APIndex, m.apIndex.Snapshot},
+		{&snap.TokenIndex, m.tokenIndex.Snapshot},
+		{&snap.APTokenIndex, m.apTokenIndex.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("efs: snapshot index: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds the mock's state under the original identities: every file
+// system, mount target, and access point is reinstated under its stored id.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap efsSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("efs: parse snapshot: %w", err)
+	}
+
+	for id, s := range snap.FileSystems {
+		m.fileSystems.Set(id, &fsData{
+			fs: s.FS, policy: s.Policy, backup: s.Backup, mountTgts: s.MountTgts,
+			accessPts: s.AccessPts, lifecycle: s.Lifecycle, replication: s.Replication,
+		})
+	}
+
+	if err := m.restoreIndexes(&snap); err != nil {
+		return err
+	}
+
+	if snap.AccountPref != "" {
+		m.prefMu.Lock()
+		m.accountPref = snap.AccountPref
+		m.prefMu.Unlock()
+	}
+
+	return nil
+}
+
+func (m *Mock) restoreIndexes(snap *efsSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.MTIndex, m.mtIndex.LoadSnapshot},
+		{snap.APIndex, m.apIndex.LoadSnapshot},
+		{snap.TokenIndex, m.tokenIndex.LoadSnapshot},
+		{snap.APTokenIndex, m.apTokenIndex.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("efs: restore index: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/aws/efs/snapshot_test.go
+++ b/providers/aws/efs/snapshot_test.go
@@ -1,0 +1,75 @@
+package efs_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/efs/driver"
+)
+
+// TestSnapshotRoundTripEFS proves a snapshot/restore round-trip preserves the
+// EFS mock's state under the original identities: a file system (promoted from
+// the unexported fsData), its creation-token index, and the account resource-id
+// preference survive restore into a fresh mock, and a re-snapshot is
+// byte-identical (proving every captured store round-trips).
+func TestSnapshotRoundTripEFS(t *testing.T) {
+	ctx := context.Background()
+	src := newMock(t)
+
+	fs, err := src.CreateFileSystem(ctx, driver.CreateFileSystemInput{
+		CreationToken: "tok-1",
+		Encrypted:     true,
+		Tags:          map[string]string{"env": "prod"},
+	})
+	if err != nil {
+		t.Fatalf("create file system: %v", err)
+	}
+
+	if _, err := src.PutAccountPreferences(ctx, "LONG_ID"); err != nil {
+		t.Fatalf("put account preferences: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newMock(t)
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	got, err := dst.DescribeFileSystems(ctx, fs.FileSystemID, "")
+	if err != nil {
+		t.Fatalf("describe restored file system: %v", err)
+	}
+
+	if len(got) != 1 || got[0].CreationToken != "tok-1" || !got[0].Encrypted {
+		t.Fatalf("restored file system = %+v, want token tok-1 / encrypted", got)
+	}
+
+	// Token index preserved: recreating with the same creation token is rejected
+	// as a duplicate, proving the tokenIndex store survived the restore.
+	if _, err := dst.CreateFileSystem(ctx, driver.CreateFileSystemInput{CreationToken: "tok-1"}); err == nil {
+		t.Fatalf("token index lost: recreate with tok-1 should be rejected as a duplicate")
+	}
+
+	pref, err := dst.DescribeAccountPreferences(ctx)
+	if err != nil {
+		t.Fatalf("describe restored account preferences: %v", err)
+	}
+
+	if pref != "LONG_ID" {
+		t.Fatalf("restored account preference = %q, want LONG_ID", pref)
+	}
+
+	raw2, err := dst.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("re-snapshot: %v", err)
+	}
+
+	if !bytes.Equal(raw, raw2) {
+		t.Fatalf("re-snapshot not byte-identical to original")
+	}
+}

--- a/providers/aws/eks/snapshot.go
+++ b/providers/aws/eks/snapshot.go
@@ -1,0 +1,120 @@
+package eks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// eksSnapshot is the full serialized state of the AWS EKS mock. Every store
+// holds a fully-exported eksdriver type, so each round-trips through the generic
+// memstore helper keyed by its resource id (cluster name, nodegroup/profile/addon
+// keys). k8sUIDs preserves each cluster's registered Kubernetes UID so a restore
+// keeps the cluster→UID mapping stable. The mutex and the wired deps (opts,
+// monitoring, subnetResolver) are not serialized; the shared *kubernetes.APIServer
+// data plane is external shared state and is intentionally not re-registered here
+// — the stored records and the UID mapping are what a restore reinstates.
+type eksSnapshot struct {
+	Clusters        json.RawMessage   `json:"clusters,omitempty"`
+	Nodegroups      json.RawMessage   `json:"nodegroups,omitempty"`
+	FargateProfiles json.RawMessage   `json:"fargateProfiles,omitempty"`
+	Addons          json.RawMessage   `json:"addons,omitempty"`
+	Updates         json.RawMessage   `json:"updates,omitempty"`
+	K8sUIDs         map[string]string `json:"k8sUids,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// EKS holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap eksSnapshot
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	m.mu.RLock()
+	if len(m.k8sUIDs) > 0 {
+		uids := make(map[string]string, len(m.k8sUIDs))
+		for k, v := range m.k8sUIDs {
+			uids[k] = v
+		}
+
+		snap.K8sUIDs = uids
+	}
+	m.mu.RUnlock()
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *eksSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Clusters, m.clusters.Snapshot},
+		{&snap.Nodegroups, m.nodegroups.Snapshot},
+		{&snap.FargateProfiles, m.fargateProfiles.Snapshot},
+		{&snap.Addons, m.addons.Snapshot},
+		{&snap.Updates, m.updates.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("eks: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds the mock's state under the original identities: every cluster
+// name and nodegroup/profile/addon key is preserved.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap eksSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("eks: parse snapshot: %w", err)
+	}
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	if snap.K8sUIDs != nil {
+		m.mu.Lock()
+		m.k8sUIDs = snap.K8sUIDs
+		m.mu.Unlock()
+	}
+
+	return nil
+}
+
+func (m *Mock) restoreStores(snap *eksSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Clusters, m.clusters.LoadSnapshot},
+		{snap.Nodegroups, m.nodegroups.LoadSnapshot},
+		{snap.FargateProfiles, m.fargateProfiles.LoadSnapshot},
+		{snap.Addons, m.addons.LoadSnapshot},
+		{snap.Updates, m.updates.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("eks: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/aws/eks/snapshot_test.go
+++ b/providers/aws/eks/snapshot_test.go
@@ -1,0 +1,42 @@
+package eks
+
+import (
+	"context"
+	"testing"
+
+	eksdriver "github.com/stackshy/cloudemu/v2/providers/aws/eks/driver"
+)
+
+// TestSnapshotRoundTripEKS proves a snapshot/restore round-trip preserves the
+// clusters and nodegroups stores under their original names.
+func TestSnapshotRoundTripEKS(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, err := src.CreateCluster(ctx, eksdriver.ClusterConfig{Name: "c1", Version: "1.30"}); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if _, err := src.CreateNodegroup(ctx, eksdriver.NodegroupConfig{ClusterName: "c1", NodegroupName: "ng1"}); err != nil {
+		t.Fatalf("create nodegroup: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	names, err := dst.ListClusters(ctx)
+	if err != nil || len(names) != 1 || names[0] != "c1" {
+		t.Fatalf("restored clusters = %+v, err %v", names, err)
+	}
+
+	if _, err := dst.DescribeCluster(ctx, "c1"); err != nil {
+		t.Fatalf("describe restored cluster: %v", err)
+	}
+}

--- a/providers/aws/elasticache/persist_snapshot.go
+++ b/providers/aws/elasticache/persist_snapshot.go
@@ -1,0 +1,166 @@
+package elasticache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// persistSnapshot is the full serialized state of the ElastiCache mock (named to
+// avoid colliding with the domain CreateSnapshot backup type). The caches store
+// holds an unexported *cacheData whose nested items store (key→value entries)
+// must be captured, so it is promoted; the other stores hold fully-exported
+// types (driver.SubnetGroup/ReplicationGroup/Snapshot and the exported
+// ParameterGroup) and round-trip through the generic memstore helper. tagsByARN
+// carries the resource tags kept beside the stores. The mutexes and the wired
+// deps (opts, monitoring, subnetResolver) are not serialized.
+type persistSnapshot struct {
+	Caches            map[string]*cacheDataSnapshot `json:"caches,omitempty"`
+	SubnetGroups      json.RawMessage               `json:"subnetGroups,omitempty"`
+	ReplicationGroups json.RawMessage               `json:"replicationGroups,omitempty"`
+	ParameterGroups   json.RawMessage               `json:"parameterGroups,omitempty"`
+	Snapshots         json.RawMessage               `json:"snapshots,omitempty"`
+	TagsByARN         map[string]map[string]string  `json:"tagsByArn,omitempty"`
+}
+
+// cacheDataSnapshot mirrors cacheData: its info is exported, and its items store
+// (whose value type cacheItem has only exported fields) round-trips through the
+// generic memstore helper.
+type cacheDataSnapshot struct {
+	Info  cachedriver.CacheInfo `json:"info"`
+	Items json.RawMessage       `json:"items,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// cache entry values are the payload and are always captured.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap persistSnapshot
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	caches, err := m.snapshotCaches()
+	if err != nil {
+		return nil, err
+	}
+
+	snap.Caches = caches
+
+	m.tagMu.Lock()
+	snap.TagsByARN = m.tagsByARN
+	m.tagMu.Unlock()
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotCaches() (map[string]*cacheDataSnapshot, error) {
+	if m.caches.Len() == 0 {
+		return nil, nil
+	}
+
+	out := make(map[string]*cacheDataSnapshot, m.caches.Len())
+
+	for id, cd := range m.caches.All() {
+		items, err := cd.items.Snapshot()
+		if err != nil {
+			return nil, fmt.Errorf("elasticache: snapshot cache items: %w", err)
+		}
+
+		out[id] = &cacheDataSnapshot{Info: cd.info, Items: items}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) snapshotStores(snap *persistSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.SubnetGroups, m.subnetGroups.Snapshot},
+		{&snap.ReplicationGroups, m.replicationGroups.Snapshot},
+		{&snap.ParameterGroups, m.parameterGroups.Snapshot},
+		{&snap.Snapshots, m.snapshots.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("elasticache: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds the mock's state under the original identities: every cluster,
+// replication group, snapshot and cache entry key is preserved.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap persistSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("elasticache: parse snapshot: %w", err)
+	}
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	if err := m.restoreCaches(snap.Caches); err != nil {
+		return err
+	}
+
+	if snap.TagsByARN != nil {
+		m.tagMu.Lock()
+		m.tagsByARN = snap.TagsByARN
+		m.tagMu.Unlock()
+	}
+
+	return nil
+}
+
+func (m *Mock) restoreCaches(caches map[string]*cacheDataSnapshot) error {
+	for id, cs := range caches {
+		cd := &cacheData{info: cs.Info, items: memstore.New[cacheItem]()}
+		if len(cs.Items) > 0 {
+			if err := cd.items.LoadSnapshot(cs.Items); err != nil {
+				return fmt.Errorf("elasticache: restore cache items: %w", err)
+			}
+		}
+
+		m.caches.Set(id, cd)
+	}
+
+	return nil
+}
+
+func (m *Mock) restoreStores(snap *persistSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.SubnetGroups, m.subnetGroups.LoadSnapshot},
+		{snap.ReplicationGroups, m.replicationGroups.LoadSnapshot},
+		{snap.ParameterGroups, m.parameterGroups.LoadSnapshot},
+		{snap.Snapshots, m.snapshots.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("elasticache: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/aws/elasticache/persist_snapshot_test.go
+++ b/providers/aws/elasticache/persist_snapshot_test.go
@@ -1,0 +1,31 @@
+package elasticache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSnapshotRoundTripElastiCache proves a persist snapshot/restore round-trip
+// preserves a cache cluster and its stored key→value entries.
+func TestSnapshotRoundTripElastiCache(t *testing.T) {
+	ctx := context.Background()
+	src, _ := newTestMock()
+
+	_, err := src.CreateCache(ctx, driver.CacheConfig{Name: "c1", Engine: "redis"})
+	require.NoError(t, err)
+	require.NoError(t, src.Set(ctx, "c1", "k", []byte("v"), 0))
+
+	raw, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst, _ := newTestMock()
+	require.NoError(t, dst.Restore(ctx, raw))
+
+	item, err := dst.Get(ctx, "c1", "k")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("v"), item.Value)
+}

--- a/providers/aws/glue/snapshot.go
+++ b/providers/aws/glue/snapshot.go
@@ -1,0 +1,231 @@
+package glue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/glue/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// glueSnapshot is the full serialized state of the Glue mock. Every store wraps
+// its driver record in an unexported *xData holding a per-record mutex that
+// json.Marshal cannot see, so the exported driver value (or, for tables and
+// schemas, a small promotion struct that also carries their version history) is
+// lifted out of each wrapper keyed by its resource id. The composite keys are
+// opaque strings and survive unchanged. The tag/policy/encryption side-maps are
+// captured under their locks; the scope locks, the per-record mutexes, and the
+// wired *config.Options are intentionally not serialized.
+type glueSnapshot struct {
+	Databases     map[string]driver.Database              `json:"databases,omitempty"`
+	Tables        map[string]tableDataSnapshot            `json:"tables,omitempty"`
+	Partitions    map[string]driver.Partition             `json:"partitions,omitempty"`
+	UDFs          map[string]driver.UserDefinedFunction   `json:"udfs,omitempty"`
+	Connections   map[string]driver.Connection            `json:"connections,omitempty"`
+	Catalogs      map[string]driver.Catalog               `json:"catalogs,omitempty"`
+	Crawlers      map[string]driver.Crawler               `json:"crawlers,omitempty"`
+	Classifiers   map[string]driver.Classifier            `json:"classifiers,omitempty"`
+	Jobs          map[string]driver.Job                   `json:"jobs,omitempty"`
+	JobRuns       map[string]driver.JobRun                `json:"jobRuns,omitempty"`
+	Triggers      map[string]driver.Trigger               `json:"triggers,omitempty"`
+	Workflows     map[string]driver.Workflow              `json:"workflows,omitempty"`
+	WorkflowRuns  map[string]driver.WorkflowRun           `json:"workflowRuns,omitempty"`
+	Blueprints    map[string]driver.Blueprint             `json:"blueprints,omitempty"`
+	BlueprintRuns map[string]driver.BlueprintRun          `json:"blueprintRuns,omitempty"`
+	SecConfigs    map[string]driver.SecurityConfiguration `json:"secConfigs,omitempty"`
+	Registries    map[string]driver.Registry              `json:"registries,omitempty"`
+	Schemas       map[string]schemaDataSnapshot           `json:"schemas,omitempty"`
+	DevEndpoints  map[string]driver.DevEndpoint           `json:"devEndpoints,omitempty"`
+	Tags          map[string]map[string]string            `json:"tags,omitempty"`
+	Policies      map[string]string                       `json:"policies,omitempty"`
+	EncSettings   map[string]map[string]any               `json:"encSettings,omitempty"`
+}
+
+// tableDataSnapshot promotes tableData, carrying the table plus its full version
+// history and the monotonic next-version counter.
+type tableDataSnapshot struct {
+	Table    driver.Table          `json:"table"`
+	Versions []driver.TableVersion `json:"versions,omitempty"`
+	NextVer  int64                 `json:"nextVer,omitempty"`
+}
+
+// schemaDataSnapshot promotes schemaData, carrying the schema plus its version
+// history.
+type schemaDataSnapshot struct {
+	Schema   driver.Schema          `json:"schema"`
+	Versions []driver.SchemaVersion `json:"versions,omitempty"`
+}
+
+// snapshotWrapped promotes a store of mutex-guarded *D wrappers to a plain
+// map[id]V, reading each record through get (which locks the record's mutex).
+func snapshotWrapped[D, V any](s *memstore.Store[*D], get func(*D) V) map[string]V {
+	if s.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]V, s.Len())
+	for id, d := range s.All() {
+		out[id] = get(d)
+	}
+
+	return out
+}
+
+// restoreWrapped reinstates each id→V under a freshly-built *D wrapper. build
+// takes a pointer to avoid copying heavy driver values by value.
+func restoreWrapped[D, V any](s *memstore.Store[*D], in map[string]V, build func(*V) *D) {
+	for id, v := range in {
+		rec := build(&v)
+		s.Set(id, rec)
+	}
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Glue holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := m.snapshotStores()
+	m.snapshotSideMaps(&snap)
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores() glueSnapshot {
+	return glueSnapshot{
+		Databases:     snapshotWrapped(m.databases, getGlueDB),
+		Tables:        snapshotWrapped(m.tables, getGlueTable),
+		Partitions:    snapshotWrapped(m.partitions, getGluePart),
+		UDFs:          snapshotWrapped(m.udfs, getGlueUDF),
+		Connections:   snapshotWrapped(m.connections, getGlueConn),
+		Catalogs:      snapshotWrapped(m.catalogs, getGlueCatalog),
+		Crawlers:      snapshotWrapped(m.crawlers, getGlueCrawler),
+		Classifiers:   snapshotWrapped(m.classifiers, getGlueClassifier),
+		Jobs:          snapshotWrapped(m.jobs, getGlueJob),
+		JobRuns:       snapshotWrapped(m.jobRuns, getGlueJobRun),
+		Triggers:      snapshotWrapped(m.triggers, getGlueTrigger),
+		Workflows:     snapshotWrapped(m.workflows, getGlueWorkflow),
+		WorkflowRuns:  snapshotWrapped(m.workflowRuns, getGlueWorkflowRun),
+		Blueprints:    snapshotWrapped(m.blueprints, getGlueBlueprint),
+		BlueprintRuns: snapshotWrapped(m.blueprintRuns, getGlueBlueprintRun),
+		SecConfigs:    snapshotWrapped(m.secConfigs, getGlueSecConfig),
+		Registries:    snapshotWrapped(m.registries, getGlueRegistry),
+		Schemas:       snapshotWrapped(m.schemas, getGlueSchema),
+		DevEndpoints:  snapshotWrapped(m.devEndpoints, getGlueDevEndpoint),
+	}
+}
+
+func (m *Mock) snapshotSideMaps(snap *glueSnapshot) {
+	m.tagsMu.RLock()
+	snap.Tags = deepCopyTags(m.tags)
+	m.tagsMu.RUnlock()
+
+	m.policyMu.RLock()
+	snap.Policies = copyStrMap(m.policies)
+	m.policyMu.RUnlock()
+
+	m.encMu.RLock()
+	snap.EncSettings = copyEncSettings(m.encSettings)
+	m.encMu.RUnlock()
+}
+
+// Restore rebuilds the mock's state under the original identities: every catalog
+// resource, ETL job, workflow, and registry schema is reinstated under its
+// stored (composite) key.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap glueSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("glue: parse snapshot: %w", err)
+	}
+
+	restoreWrapped(m.databases, snap.Databases, buildGlueDB)
+	restoreWrapped(m.tables, snap.Tables, buildGlueTable)
+	restoreWrapped(m.partitions, snap.Partitions, buildGluePart)
+	restoreWrapped(m.udfs, snap.UDFs, buildGlueUDF)
+	restoreWrapped(m.connections, snap.Connections, buildGlueConn)
+	restoreWrapped(m.catalogs, snap.Catalogs, buildGlueCatalog)
+	restoreWrapped(m.crawlers, snap.Crawlers, buildGlueCrawler)
+	restoreWrapped(m.classifiers, snap.Classifiers, buildGlueClassifier)
+	restoreWrapped(m.jobs, snap.Jobs, buildGlueJob)
+	restoreWrapped(m.jobRuns, snap.JobRuns, buildGlueJobRun)
+	restoreWrapped(m.triggers, snap.Triggers, buildGlueTrigger)
+	restoreWrapped(m.workflows, snap.Workflows, buildGlueWorkflow)
+	restoreWrapped(m.workflowRuns, snap.WorkflowRuns, buildGlueWorkflowRun)
+	restoreWrapped(m.blueprints, snap.Blueprints, buildGlueBlueprint)
+	restoreWrapped(m.blueprintRuns, snap.BlueprintRuns, buildGlueBlueprintRun)
+	restoreWrapped(m.secConfigs, snap.SecConfigs, buildGlueSecConfig)
+	restoreWrapped(m.registries, snap.Registries, buildGlueRegistry)
+	restoreWrapped(m.schemas, snap.Schemas, buildGlueSchema)
+	restoreWrapped(m.devEndpoints, snap.DevEndpoints, buildGlueDevEndpoint)
+	m.restoreSideMaps(&snap)
+
+	return nil
+}
+
+func (m *Mock) restoreSideMaps(snap *glueSnapshot) {
+	if snap.Tags != nil {
+		m.tagsMu.Lock()
+		m.tags = snap.Tags
+		m.tagsMu.Unlock()
+	}
+
+	if snap.Policies != nil {
+		m.policyMu.Lock()
+		m.policies = snap.Policies
+		m.policyMu.Unlock()
+	}
+
+	if snap.EncSettings != nil {
+		m.encMu.Lock()
+		m.encSettings = snap.EncSettings
+		m.encMu.Unlock()
+	}
+}
+
+func deepCopyTags(in map[string]map[string]string) map[string]map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]map[string]string, len(in))
+	for k, v := range in {
+		out[k] = copyStrMap(v)
+	}
+
+	return out
+}
+
+func copyStrMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+
+	return out
+}
+
+func copyEncSettings(in map[string]map[string]any) map[string]map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]map[string]any, len(in))
+
+	for k, v := range in {
+		inner := make(map[string]any, len(v))
+
+		for ik, iv := range v {
+			inner[ik] = iv
+		}
+
+		out[k] = inner
+	}
+
+	return out
+}

--- a/providers/aws/glue/snapshot_test.go
+++ b/providers/aws/glue/snapshot_test.go
@@ -1,0 +1,68 @@
+package glue_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/glue/driver"
+)
+
+// TestSnapshotRoundTripGlue proves a snapshot/restore round-trip preserves the
+// Glue mock's state under the original (composite) identities: a Data Catalog
+// database, a table promoted with its version machinery, and an ETL job all
+// survive restore into a fresh mock.
+func TestSnapshotRoundTripGlue(t *testing.T) {
+	ctx := context.Background()
+	const cat = "123456789012"
+
+	src := newMock()
+
+	if err := src.CreateDatabase(ctx, cat, driver.Database{Name: "db1", Description: "d"}); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	if err := src.CreateTable(ctx, cat, "db1", driver.Table{Name: "tbl1", TableType: "EXTERNAL_TABLE"}); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	if _, err := src.CreateJob(ctx, driver.Job{Name: "job1", Role: "arn:aws:iam::123456789012:role/r"}); err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	db, err := dst.GetDatabase(ctx, cat, "db1")
+	if err != nil {
+		t.Fatalf("get restored database: %v", err)
+	}
+
+	if db.Name != "db1" || db.Description != "d" {
+		t.Fatalf("restored database = %+v, want name db1 / desc d", db)
+	}
+
+	tbl, err := dst.GetTable(ctx, cat, "db1", "tbl1")
+	if err != nil {
+		t.Fatalf("get restored table: %v", err)
+	}
+
+	if tbl.Name != "tbl1" || tbl.TableType != "EXTERNAL_TABLE" {
+		t.Fatalf("restored table = %+v, want name tbl1 / type EXTERNAL_TABLE", tbl)
+	}
+
+	job, err := dst.GetJob(ctx, "job1")
+	if err != nil {
+		t.Fatalf("get restored job: %v", err)
+	}
+
+	if job.Name != "job1" {
+		t.Fatalf("restored job name = %q, want job1", job.Name)
+	}
+}

--- a/providers/aws/glue/snapshot_wrappers.go
+++ b/providers/aws/glue/snapshot_wrappers.go
@@ -1,0 +1,192 @@
+package glue
+
+import "github.com/stackshy/cloudemu/v2/services/glue/driver"
+
+// getGlueX reads the exported record out of an *xData wrapper under its lock;
+// buildGlueX is the inverse, wrapping a restored record in a fresh *xData. They
+// are the field maps snapshotWrapped/restoreWrapped drive, kept together so a
+// reviewer can confirm every store round-trips without loss. Builders take a
+// pointer to avoid copying heavy driver values by value.
+
+func getGlueDB(d *databaseData) driver.Database {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.db
+}
+
+func getGluePart(d *partitionData) driver.Partition {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.part
+}
+
+func getGlueUDF(d *udfData) driver.UserDefinedFunction {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.fn
+}
+
+func getGlueConn(d *connectionData) driver.Connection {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.conn
+}
+
+func getGlueCatalog(d *catalogData) driver.Catalog {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.cat
+}
+
+func getGlueCrawler(d *crawlerData) driver.Crawler {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.crawler
+}
+
+func getGlueClassifier(d *classifierData) driver.Classifier {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.classifier
+}
+
+func getGlueJob(d *jobData) driver.Job {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.job
+}
+
+func getGlueJobRun(d *jobRunData) driver.JobRun {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.run
+}
+
+func getGlueTrigger(d *triggerData) driver.Trigger {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.trigger
+}
+
+func getGlueWorkflow(d *workflowData) driver.Workflow {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.workflow
+}
+
+func getGlueWorkflowRun(d *workflowRunData) driver.WorkflowRun {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.run
+}
+
+func getGlueBlueprint(d *blueprintData) driver.Blueprint {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.blueprint
+}
+
+func getGlueBlueprintRun(d *blueprintRunData) driver.BlueprintRun {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.run
+}
+
+func getGlueSecConfig(d *secConfigData) driver.SecurityConfiguration {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.sc
+}
+
+func getGlueRegistry(d *registryData) driver.Registry {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.registry
+}
+
+func getGlueDevEndpoint(d *devEndpointData) driver.DevEndpoint {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.endpoint
+}
+
+func getGlueTable(d *tableData) tableDataSnapshot {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return tableDataSnapshot{Table: d.table, Versions: d.versions, NextVer: d.nextVer}
+}
+
+func getGlueSchema(d *schemaData) schemaDataSnapshot {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return schemaDataSnapshot{Schema: d.schema, Versions: d.versions}
+}
+
+func buildGlueDB(v *driver.Database) *databaseData { return &databaseData{db: *v} }
+
+func buildGluePart(v *driver.Partition) *partitionData { return &partitionData{part: *v} }
+
+func buildGlueUDF(v *driver.UserDefinedFunction) *udfData { return &udfData{fn: *v} }
+
+func buildGlueConn(v *driver.Connection) *connectionData { return &connectionData{conn: *v} }
+
+func buildGlueCatalog(v *driver.Catalog) *catalogData { return &catalogData{cat: *v} }
+
+func buildGlueCrawler(v *driver.Crawler) *crawlerData { return &crawlerData{crawler: *v} }
+
+func buildGlueClassifier(v *driver.Classifier) *classifierData {
+	return &classifierData{classifier: *v}
+}
+
+func buildGlueJob(v *driver.Job) *jobData { return &jobData{job: *v} }
+
+func buildGlueJobRun(v *driver.JobRun) *jobRunData { return &jobRunData{run: *v} }
+
+func buildGlueTrigger(v *driver.Trigger) *triggerData { return &triggerData{trigger: *v} }
+
+func buildGlueWorkflow(v *driver.Workflow) *workflowData { return &workflowData{workflow: *v} }
+
+func buildGlueWorkflowRun(v *driver.WorkflowRun) *workflowRunData { return &workflowRunData{run: *v} }
+
+func buildGlueBlueprint(v *driver.Blueprint) *blueprintData { return &blueprintData{blueprint: *v} }
+
+func buildGlueBlueprintRun(v *driver.BlueprintRun) *blueprintRunData {
+	return &blueprintRunData{run: *v}
+}
+
+func buildGlueSecConfig(v *driver.SecurityConfiguration) *secConfigData {
+	return &secConfigData{sc: *v}
+}
+
+func buildGlueRegistry(v *driver.Registry) *registryData { return &registryData{registry: *v} }
+
+func buildGlueDevEndpoint(v *driver.DevEndpoint) *devEndpointData {
+	return &devEndpointData{endpoint: *v}
+}
+
+func buildGlueTable(v *tableDataSnapshot) *tableData {
+	return &tableData{table: v.Table, versions: v.Versions, nextVer: v.NextVer}
+}
+
+func buildGlueSchema(v *schemaDataSnapshot) *schemaData {
+	return &schemaData{schema: v.Schema, versions: v.Versions}
+}

--- a/providers/aws/kinesis/snapshot.go
+++ b/providers/aws/kinesis/snapshot.go
@@ -1,0 +1,166 @@
+package kinesis
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/kinesis/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// kinesisSnapshot is the full serialized state of the Kinesis mock. Each stream
+// carries an exported form (the stored streamData and its shards hold unexported
+// fields and a mutex that json.Marshal cannot see); the arn→name index
+// round-trips through the generic memstore helper so an ARN still resolves to
+// its stream after a restore. The per-stream mutexes and the wired
+// *config.Options are intentionally not serialized.
+type kinesisSnapshot struct {
+	Streams   map[string]*streamDataSnapshot `json:"streams,omitempty"`
+	ArnToName json.RawMessage                `json:"arnToName,omitempty"`
+	Settings  driver.AccountSettings         `json:"settings"`
+}
+
+// streamDataSnapshot mirrors streamData, promoting its unexported fields
+// (including its shards and per-stream sequence counter) to exported ones.
+type streamDataSnapshot struct {
+	Desc      driver.StreamDescription    `json:"desc"`
+	Shards    []*shardStateSnapshot       `json:"shards,omitempty"`
+	Consumers map[string]*driver.Consumer `json:"consumers,omitempty"`
+	Tags      map[string]string           `json:"tags,omitempty"`
+	Policy    string                      `json:"policy,omitempty"`
+	MaxRecKiB int32                       `json:"maxRecKiB,omitempty"`
+	WarmMiBps int32                       `json:"warmMiBps,omitempty"`
+	Seq       int64                       `json:"seq,omitempty"`
+}
+
+// shardStateSnapshot mirrors shardState, promoting its stored records and
+// open/closed lifetime timestamps to exported fields.
+type shardStateSnapshot struct {
+	Shard     driver.Shard    `json:"shard"`
+	Records   []driver.Record `json:"records,omitempty"`
+	Closed    bool            `json:"closed,omitempty"`
+	CreatedAt time.Time       `json:"createdAt,omitempty"`
+	ClosedAt  time.Time       `json:"closedAt,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// stream records are the service's state, not bulk sidecar bodies, and are
+// always captured.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := kinesisSnapshot{Streams: m.snapshotStreams()}
+
+	arns, err := m.arnToName.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("kinesis: snapshot arn index: %w", err)
+	}
+
+	snap.ArnToName = arns
+
+	m.settingsMu.RLock()
+	snap.Settings = m.settings
+	m.settingsMu.RUnlock()
+
+	return json.Marshal(snap)
+}
+
+// snapshotStreams promotes each stored streamData to its exported form.
+func (m *Mock) snapshotStreams() map[string]*streamDataSnapshot {
+	if m.streams.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*streamDataSnapshot, m.streams.Len())
+
+	for name, sd := range m.streams.All() {
+		sd.mu.RLock()
+		out[name] = &streamDataSnapshot{
+			Desc: sd.desc, Shards: snapshotShards(sd.shards), Consumers: sd.consumers,
+			Tags: sd.tags, Policy: sd.policy, MaxRecKiB: sd.maxRecKiB,
+			WarmMiBps: sd.warmMiBps, Seq: sd.seq,
+		}
+		sd.mu.RUnlock()
+	}
+
+	return out
+}
+
+func snapshotShards(shards []*shardState) []*shardStateSnapshot {
+	if len(shards) == 0 {
+		return nil
+	}
+
+	out := make([]*shardStateSnapshot, 0, len(shards))
+	for _, s := range shards {
+		out = append(out, &shardStateSnapshot{
+			Shard: s.shard, Records: s.records, Closed: s.closed,
+			CreatedAt: s.createdAt, ClosedAt: s.closedAt,
+		})
+	}
+
+	return out
+}
+
+// Restore rebuilds the mock's state under the original identities: every stream
+// (keyed by name), its shards, records, consumers, and per-stream sequence
+// counter are reinstated, and the arn→name index is restored so ARN lookups
+// resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap kinesisSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("kinesis: parse snapshot: %w", err)
+	}
+
+	for name, s := range snap.Streams {
+		m.streams.Set(name, restoreStream(s))
+	}
+
+	if len(snap.ArnToName) > 0 {
+		if err := m.arnToName.LoadSnapshot(snap.ArnToName); err != nil {
+			return fmt.Errorf("kinesis: restore arn index: %w", err)
+		}
+	}
+
+	m.settingsMu.Lock()
+	m.settings = snap.Settings
+	m.settingsMu.Unlock()
+
+	return nil
+}
+
+func restoreStream(s *streamDataSnapshot) *streamData {
+	consumers := s.Consumers
+	if consumers == nil {
+		consumers = map[string]*driver.Consumer{}
+	}
+
+	tags := s.Tags
+	if tags == nil {
+		tags = map[string]string{}
+	}
+
+	return &streamData{
+		desc: s.Desc, shards: restoreShards(s.Shards), consumers: consumers,
+		tags: tags, policy: s.Policy, maxRecKiB: s.MaxRecKiB,
+		warmMiBps: s.WarmMiBps, seq: s.Seq,
+	}
+}
+
+func restoreShards(shards []*shardStateSnapshot) []*shardState {
+	if len(shards) == 0 {
+		return nil
+	}
+
+	out := make([]*shardState, 0, len(shards))
+	for _, s := range shards {
+		out = append(out, &shardState{
+			shard: s.Shard, records: s.Records, closed: s.Closed,
+			createdAt: s.CreatedAt, closedAt: s.ClosedAt,
+		})
+	}
+
+	return out
+}

--- a/providers/aws/kinesis/snapshot_test.go
+++ b/providers/aws/kinesis/snapshot_test.go
@@ -1,0 +1,101 @@
+package kinesis_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/providers/aws/kinesis"
+	"github.com/stackshy/cloudemu/v2/services/kinesis/driver"
+)
+
+// TestSnapshotRoundTripKinesis proves a snapshot/restore round-trip preserves
+// the Kinesis mock's state under the original identities: a stream (promoted
+// from the unexported streamData) with its shards and stored records survives,
+// the arn→name index still resolves an ARN to its stream, and a re-snapshot is
+// byte-identical.
+func TestSnapshotRoundTripKinesis(t *testing.T) {
+	ctx := context.Background()
+	src := newMock(t)
+
+	if err := src.CreateStream(ctx, driver.CreateStreamInput{StreamName: "s-1", ShardCount: 1}); err != nil {
+		t.Fatalf("create stream: %v", err)
+	}
+
+	sum, err := src.DescribeStreamSummary(ctx, "s-1", "")
+	if err != nil {
+		t.Fatalf("describe summary: %v", err)
+	}
+
+	if _, err := src.PutRecord(ctx, driver.PutRecordInput{
+		StreamName: "s-1", Data: []byte("hello"), PartitionKey: "pk",
+	}); err != nil {
+		t.Fatalf("put record: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newMock(t)
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	// Stream survived, resolvable by name and by its ARN (the arn→name index).
+	if _, err := dst.DescribeStreamSummary(ctx, "s-1", ""); err != nil {
+		t.Fatalf("describe restored stream by name: %v", err)
+	}
+
+	byARN, err := dst.DescribeStreamSummary(ctx, "", sum.StreamARN)
+	if err != nil {
+		t.Fatalf("resolve restored stream by ARN: %v", err)
+	}
+
+	if byARN.StreamName != "s-1" {
+		t.Fatalf("ARN resolved to %q, want s-1", byARN.StreamName)
+	}
+
+	assertRecordSurvived(ctx, t, dst)
+
+	raw2, err := dst.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("re-snapshot: %v", err)
+	}
+
+	if !bytes.Equal(raw, raw2) {
+		t.Fatalf("re-snapshot not byte-identical to original")
+	}
+}
+
+// assertRecordSurvived reads the stream's single shard from TRIM_HORIZON and
+// checks the put record's bytes came back, proving shards + records round-trip.
+func assertRecordSurvived(ctx context.Context, t *testing.T, m *kinesis.Mock) {
+	t.Helper()
+
+	shards, err := m.ListShards(ctx, driver.ListShardsInput{StreamName: "s-1"})
+	if err != nil {
+		t.Fatalf("list restored shards: %v", err)
+	}
+
+	if len(shards.Shards) != 1 {
+		t.Fatalf("restored shard count = %d, want 1", len(shards.Shards))
+	}
+
+	it, err := m.GetShardIterator(ctx, driver.GetShardIteratorInput{
+		StreamName: "s-1", ShardID: shards.Shards[0].ShardID, ShardIteratorType: "TRIM_HORIZON",
+	})
+	if err != nil {
+		t.Fatalf("get shard iterator: %v", err)
+	}
+
+	recs, err := m.GetRecords(ctx, it, 10)
+	if err != nil {
+		t.Fatalf("get records: %v", err)
+	}
+
+	if len(recs.Records) != 1 || !bytes.Equal(recs.Records[0].Data, []byte("hello")) {
+		t.Fatalf("restored records = %+v, want one record with data 'hello'", recs.Records)
+	}
+}

--- a/providers/aws/kms/snapshot.go
+++ b/providers/aws/kms/snapshot.go
@@ -1,0 +1,179 @@
+package kms
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/kms/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// kmsSnapshot is the full serialized state of the AWS KMS mock. keys and aliases
+// hold unexported value types (with unexported fields, and — for a key — an
+// asymmetric private key), so both are promoted to exported snapshot forms keyed
+// by their id; grants holds a fully-exported *driver.Grant and round-trips
+// through the generic memstore helper. The per-key mutex, and the in-flight
+// import-session state (importWrappingKey/importToken, minted by
+// GetParametersForImport and consumed by the immediately-following
+// ImportKeyMaterial), are intentionally not serialized.
+type kmsSnapshot struct {
+	Keys    map[string]*keySnapshot   `json:"keys,omitempty"`
+	Aliases map[string]*aliasSnapshot `json:"aliases,omitempty"`
+	Grants  json.RawMessage           `json:"grants,omitempty"`
+}
+
+// keySnapshot mirrors keyData. The asymmetric private key is serialized as
+// PKCS#8 DER so RSA/ECC keys survive a restore and can still sign/decrypt; the
+// symmetric/HMAC material rounds through Materials.
+type keySnapshot struct {
+	Meta               driver.KeyMetadata     `json:"meta"`
+	Tags               map[string]string      `json:"tags,omitempty"`
+	Materials          [][]byte               `json:"materials,omitempty"`
+	PrivKeyPKCS8       []byte                 `json:"privKeyPkcs8,omitempty"`
+	Policies           map[string]string      `json:"policies,omitempty"`
+	RotationEnabled    bool                   `json:"rotationEnabled,omitempty"`
+	RotationPeriodDays int32                  `json:"rotationPeriodDays,omitempty"`
+	Rotations          []driver.RotationEvent `json:"rotations,omitempty"`
+	OnDemandCount      int                    `json:"onDemandCount,omitempty"`
+}
+
+// aliasSnapshot mirrors aliasData (all fields unexported).
+type aliasSnapshot struct {
+	Name        string    `json:"name"`
+	ARN         string    `json:"arn,omitempty"`
+	TargetKeyID string    `json:"targetKeyId,omitempty"`
+	Created     time.Time `json:"created,omitempty"`
+	Updated     time.Time `json:"updated,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// key material is always captured (a metadata-only key could not decrypt).
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	keys, err := m.snapshotKeys()
+	if err != nil {
+		return nil, err
+	}
+
+	snap := kmsSnapshot{Keys: keys, Aliases: m.snapshotAliases()}
+
+	grants, err := m.grants.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("kms: snapshot grants: %w", err)
+	}
+
+	snap.Grants = grants
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotKeys() (map[string]*keySnapshot, error) {
+	if m.keys.Len() == 0 {
+		return nil, nil
+	}
+
+	out := make(map[string]*keySnapshot, m.keys.Len())
+
+	for id, kd := range m.keys.All() {
+		kd.mu.RLock()
+		ks := &keySnapshot{
+			Meta: kd.meta, Tags: kd.tags, Materials: kd.materials, Policies: kd.policies,
+			RotationEnabled: kd.rotationEnabled, RotationPeriodDays: kd.rotationPeriodDays,
+			Rotations: kd.rotations, OnDemandCount: kd.onDemandCount,
+		}
+
+		if kd.privKey != nil {
+			der, err := x509.MarshalPKCS8PrivateKey(kd.privKey)
+			if err != nil {
+				kd.mu.RUnlock()
+				return nil, fmt.Errorf("kms: marshal private key %q: %w", id, err)
+			}
+
+			ks.PrivKeyPKCS8 = der
+		}
+		kd.mu.RUnlock()
+
+		out[id] = ks
+	}
+
+	return out, nil
+}
+
+func (m *Mock) snapshotAliases() map[string]*aliasSnapshot {
+	if m.aliases.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*aliasSnapshot, m.aliases.Len())
+
+	for id, a := range m.aliases.All() {
+		out[id] = &aliasSnapshot{
+			Name: a.name, ARN: a.arn, TargetKeyID: a.targetKeyID,
+			Created: a.created, Updated: a.updated,
+		}
+	}
+
+	return out
+}
+
+// Restore rebuilds the mock's state under the original identities: every key id,
+// alias name, and grant id is preserved, and asymmetric keys are re-parsed so
+// they still sign/decrypt.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap kmsSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("kms: parse snapshot: %w", err)
+	}
+
+	if err := m.restoreKeys(snap.Keys); err != nil {
+		return err
+	}
+
+	m.restoreAliases(snap.Aliases)
+
+	if len(snap.Grants) > 0 {
+		if err := m.grants.LoadSnapshot(snap.Grants); err != nil {
+			return fmt.Errorf("kms: restore grants: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (m *Mock) restoreKeys(keys map[string]*keySnapshot) error {
+	for id, ks := range keys {
+		kd := &keyData{
+			meta: ks.Meta, tags: ks.Tags, materials: ks.Materials, policies: ks.Policies,
+			rotationEnabled: ks.RotationEnabled, rotationPeriodDays: ks.RotationPeriodDays,
+			rotations: ks.Rotations, onDemandCount: ks.OnDemandCount,
+		}
+
+		if len(ks.PrivKeyPKCS8) > 0 {
+			pk, err := x509.ParsePKCS8PrivateKey(ks.PrivKeyPKCS8)
+			if err != nil {
+				return fmt.Errorf("kms: parse private key %q: %w", id, err)
+			}
+
+			kd.privKey = pk
+		}
+
+		m.keys.Set(id, kd)
+	}
+
+	return nil
+}
+
+func (m *Mock) restoreAliases(aliases map[string]*aliasSnapshot) {
+	for id, as := range aliases {
+		ad := &aliasData{
+			name: as.Name, arn: as.ARN, targetKeyID: as.TargetKeyID,
+			created: as.Created, updated: as.Updated,
+		}
+
+		m.aliases.Set(id, ad)
+	}
+}

--- a/providers/aws/kms/snapshot_test.go
+++ b/providers/aws/kms/snapshot_test.go
@@ -1,0 +1,70 @@
+package kms_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/aws/kms"
+	"github.com/stackshy/cloudemu/v2/services/kms/driver"
+)
+
+func snapshotOpts() *config.Options {
+	return config.NewOptions(
+		config.WithClock(config.NewFakeClock(time.Unix(0, 0))),
+		config.WithRegion("us-east-1"),
+		config.WithAccountID("000000000000"),
+	)
+}
+
+// TestSnapshotRoundTripKMS proves a snapshot/restore round-trip preserves a key
+// (with its symmetric material), its alias, so a ciphertext created before the
+// snapshot still decrypts after a restore into a fresh mock.
+func TestSnapshotRoundTripKMS(t *testing.T) {
+	ctx := context.Background()
+	src := kms.New(snapshotOpts())
+
+	k, err := src.CreateKey(ctx, driver.CreateKeyInput{Description: "app key"})
+	if err != nil {
+		t.Fatalf("create key: %v", err)
+	}
+
+	if err := src.CreateAlias(ctx, "alias/app", k.KeyID); err != nil {
+		t.Fatalf("create alias: %v", err)
+	}
+
+	enc, err := src.Encrypt(ctx, driver.EncryptInput{KeyID: k.KeyID, Plaintext: []byte("secret")})
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := kms.New(snapshotOpts())
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	if _, err := dst.DescribeKey(ctx, k.KeyID); err != nil {
+		t.Fatalf("describe restored key: %v", err)
+	}
+
+	// Alias resolves against the restored key.
+	if _, err := dst.DescribeKey(ctx, "alias/app"); err != nil {
+		t.Fatalf("describe restored key by alias: %v", err)
+	}
+
+	dec, err := dst.Decrypt(ctx, driver.DecryptInput{KeyID: k.KeyID, CiphertextBlob: enc.CiphertextBlob})
+	if err != nil {
+		t.Fatalf("decrypt after restore: %v", err)
+	}
+
+	if !bytes.Equal(dec.Plaintext, []byte("secret")) {
+		t.Fatalf("decrypted %q, want secret", dec.Plaintext)
+	}
+}

--- a/providers/aws/rds/snapshot.go
+++ b/providers/aws/rds/snapshot.go
@@ -1,0 +1,180 @@
+package rds
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// rdsSnapshot is the full serialized state of the AWS RDS mock. Every memstore
+// store holds a fully-exported rdsdriver type, so each round-trips through the
+// generic memstore helper keyed by its resource id. The mu-guarded maps carry
+// state that lives beside the stores: clusterCreds (unexported value type, so
+// promoted), groupTags, and rootPasswords. The in-flight settle overlays
+// (instSettle/snapSettle) and the wired deps (opts, subnetResolver, monitoring)
+// are intentionally not serialized — a restored record reports its stored state.
+type rdsSnapshot struct {
+	Instances          json.RawMessage `json:"instances,omitempty"`
+	Clusters           json.RawMessage `json:"clusters,omitempty"`
+	Snapshots          json.RawMessage `json:"snapshots,omitempty"`
+	ClusterSnapshots   json.RawMessage `json:"clusterSnapshots,omitempty"`
+	SubnetGroups       json.RawMessage `json:"subnetGroups,omitempty"`
+	ParamGroups        json.RawMessage `json:"paramGroups,omitempty"`
+	ClusterParamGroups json.RawMessage `json:"clusterParamGroups,omitempty"`
+	OptionGroups       json.RawMessage `json:"optionGroups,omitempty"`
+	Proxies            json.RawMessage `json:"proxies,omitempty"`
+	EventSubs          json.RawMessage `json:"eventSubs,omitempty"`
+	ClusterEndpoints   json.RawMessage `json:"clusterEndpoints,omitempty"`
+	GlobalClusters     json.RawMessage `json:"globalClusters,omitempty"`
+
+	ClusterCreds  map[string]clusterCredSnapshot `json:"clusterCreds,omitempty"`
+	GroupTags     map[string]map[string]string   `json:"groupTags,omitempty"`
+	RootPasswords map[string]string              `json:"rootPasswords,omitempty"`
+}
+
+// clusterCredSnapshot is the exported form of clusterCred (whose fields are
+// unexported and invisible to json.Marshal).
+type clusterCredSnapshot struct {
+	User string `json:"user,omitempty"`
+	Pass string `json:"pass,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// RDS holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap rdsSnapshot
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	m.snapshotScalarState(&snap)
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *rdsSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Instances, m.instances.Snapshot},
+		{&snap.Clusters, m.clusters.Snapshot},
+		{&snap.Snapshots, m.snapshots.Snapshot},
+		{&snap.ClusterSnapshots, m.clusterSnapshots.Snapshot},
+		{&snap.SubnetGroups, m.subnetGroups.Snapshot},
+		{&snap.ParamGroups, m.paramGroups.Snapshot},
+		{&snap.ClusterParamGroups, m.clusterParamGroups.Snapshot},
+		{&snap.OptionGroups, m.optionGroups.Snapshot},
+		{&snap.Proxies, m.proxies.Snapshot},
+		{&snap.EventSubs, m.eventSubs.Snapshot},
+		{&snap.ClusterEndpoints, m.clusterEndpoints.Snapshot},
+		{&snap.GlobalClusters, m.globalClusters.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("rds: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// snapshotScalarState captures the mu-guarded maps that live beside the stores.
+func (m *Mock) snapshotScalarState(snap *rdsSnapshot) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if len(m.clusterCreds) > 0 {
+		creds := make(map[string]clusterCredSnapshot, len(m.clusterCreds))
+		for id, c := range m.clusterCreds {
+			creds[id] = clusterCredSnapshot{User: c.user, Pass: c.pass}
+		}
+
+		snap.ClusterCreds = creds
+	}
+
+	snap.GroupTags = m.groupTags
+	snap.RootPasswords = m.rootPasswords
+}
+
+// Restore rebuilds the mock's state under the original identities: every
+// instance/cluster/snapshot id (and the id-string cross-references records hold)
+// is preserved, so a restore is transparent to clients.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap rdsSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("rds: parse snapshot: %w", err)
+	}
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	m.restoreScalarState(&snap)
+
+	return nil
+}
+
+func (m *Mock) restoreStores(snap *rdsSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Instances, m.instances.LoadSnapshot},
+		{snap.Clusters, m.clusters.LoadSnapshot},
+		{snap.Snapshots, m.snapshots.LoadSnapshot},
+		{snap.ClusterSnapshots, m.clusterSnapshots.LoadSnapshot},
+		{snap.SubnetGroups, m.subnetGroups.LoadSnapshot},
+		{snap.ParamGroups, m.paramGroups.LoadSnapshot},
+		{snap.ClusterParamGroups, m.clusterParamGroups.LoadSnapshot},
+		{snap.OptionGroups, m.optionGroups.LoadSnapshot},
+		{snap.Proxies, m.proxies.LoadSnapshot},
+		{snap.EventSubs, m.eventSubs.LoadSnapshot},
+		{snap.ClusterEndpoints, m.clusterEndpoints.LoadSnapshot},
+		{snap.GlobalClusters, m.globalClusters.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("rds: restore store: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// restoreScalarState reinstates the mu-guarded maps, leaving unset ones at their
+// New() defaults.
+func (m *Mock) restoreScalarState(snap *rdsSnapshot) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(snap.ClusterCreds) > 0 {
+		creds := make(map[string]clusterCred, len(snap.ClusterCreds))
+		for id, c := range snap.ClusterCreds {
+			creds[id] = clusterCred{user: c.User, pass: c.Pass}
+		}
+
+		m.clusterCreds = creds
+	}
+
+	if snap.GroupTags != nil {
+		m.groupTags = snap.GroupTags
+	}
+
+	if snap.RootPasswords != nil {
+		m.rootPasswords = snap.RootPasswords
+	}
+}

--- a/providers/aws/rds/snapshot_test.go
+++ b/providers/aws/rds/snapshot_test.go
@@ -1,0 +1,84 @@
+package rds
+
+import (
+	"context"
+	"testing"
+
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// TestSnapshotRoundTripRDS proves a snapshot/restore round-trip preserves every
+// store and the mu-guarded maps (cluster creds, group tags, root passwords)
+// under their original identities.
+func TestSnapshotRoundTripRDS(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, err := src.CreateDBSubnetGroup(ctx, rdsdriver.SubnetGroupConfig{
+		Name: "sng", Description: "sng", SubnetIDs: []string{"subnet-1"},
+	}); err != nil {
+		t.Fatalf("create subnet group: %v", err)
+	}
+
+	if _, err := src.CreateDBParameterGroup(ctx, rdsdriver.ParameterGroupConfig{
+		Name: "pg", Family: "postgres15", Description: "pg",
+	}); err != nil {
+		t.Fatalf("create param group: %v", err)
+	}
+
+	if _, err := src.CreateInstance(ctx, rdsdriver.InstanceConfig{
+		ID: "db1", Engine: "postgres", AllocatedStorage: 20, MasterUsername: "admin", MasterUserPassword: "pw",
+	}); err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+
+	if _, err := src.CreateCluster(ctx, rdsdriver.ClusterConfig{
+		ID: "cl1", Engine: "aurora-mysql", MasterUsername: "root", MasterUserPassword: "clpw",
+	}); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if _, err := src.CreateSnapshot(ctx, rdsdriver.SnapshotConfig{ID: "snap1", InstanceID: "db1"}); err != nil {
+		t.Fatalf("create snapshot: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	insts, err := dst.DescribeInstances(ctx, nil)
+	if err != nil || len(insts) != 1 || insts[0].ID != "db1" {
+		t.Fatalf("restored instances = %+v, err %v", insts, err)
+	}
+
+	clusters, err := dst.DescribeClusters(ctx, nil)
+	if err != nil || len(clusters) != 1 || clusters[0].ID != "cl1" {
+		t.Fatalf("restored clusters = %+v, err %v", clusters, err)
+	}
+
+	snaps, err := dst.DescribeSnapshots(ctx, nil, "")
+	if err != nil || len(snaps) != 1 || snaps[0].ID != "snap1" {
+		t.Fatalf("restored snapshots = %+v, err %v", snaps, err)
+	}
+
+	sngs, err := dst.DescribeDBSubnetGroups(ctx, nil)
+	if err != nil || len(sngs) != 1 {
+		t.Fatalf("restored subnet groups = %+v, err %v", sngs, err)
+	}
+
+	// clusterCreds is promoted through an exported snapshot form; confirm the
+	// Aurora cluster's master credentials survived.
+	dst.mu.RLock()
+	cred, ok := dst.clusterCreds["cl1"]
+	dst.mu.RUnlock()
+
+	if !ok || cred.user != "root" {
+		t.Fatalf("restored clusterCreds[cl1] = %+v, ok %v", cred, ok)
+	}
+}

--- a/providers/aws/sagemaker/snapshot.go
+++ b/providers/aws/sagemaker/snapshot.go
@@ -1,0 +1,165 @@
+package sagemaker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// sagemakerSnapshot is the full serialized state of the SageMaker mock. Every
+// store's value type is fully exported (driver.* DTOs), so each round-trips
+// through the generic memstore helper keyed by its resource id. The composite
+// user-profile/space/app/feature-record keys are opaque strings and survive
+// unchanged. The pkgMu mutex, the wired *config.Options, and the monitoring
+// backend are intentionally not serialized.
+type sagemakerSnapshot struct {
+	TrainingJobs        json.RawMessage `json:"trainingJobs,omitempty"`
+	ProcessingJobs      json.RawMessage `json:"processingJobs,omitempty"`
+	TransformJobs       json.RawMessage `json:"transformJobs,omitempty"`
+	TuningJobs          json.RawMessage `json:"tuningJobs,omitempty"`
+	AutoMLJobs          json.RawMessage `json:"autoMlJobs,omitempty"`
+	LabelingJobs        json.RawMessage `json:"labelingJobs,omitempty"`
+	CompilationJobs     json.RawMessage `json:"compilationJobs,omitempty"`
+	Models              json.RawMessage `json:"models,omitempty"`
+	EndpointConfigs     json.RawMessage `json:"endpointConfigs,omitempty"`
+	Endpoints           json.RawMessage `json:"endpoints,omitempty"`
+	InferenceComponents json.RawMessage `json:"inferenceComponents,omitempty"`
+	PackageGroups       json.RawMessage `json:"packageGroups,omitempty"`
+	Packages            json.RawMessage `json:"packages,omitempty"`
+	Domains             json.RawMessage `json:"domains,omitempty"`
+	UserProfiles        json.RawMessage `json:"userProfiles,omitempty"`
+	Spaces              json.RawMessage `json:"spaces,omitempty"`
+	Apps                json.RawMessage `json:"apps,omitempty"`
+	Notebooks           json.RawMessage `json:"notebooks,omitempty"`
+	NotebookLCs         json.RawMessage `json:"notebookLcs,omitempty"`
+	CodeRepos           json.RawMessage `json:"codeRepos,omitempty"`
+	Clusters            json.RawMessage `json:"clusters,omitempty"`
+	FeatureGroups       json.RawMessage `json:"featureGroups,omitempty"`
+	FeatureRecords      json.RawMessage `json:"featureRecords,omitempty"`
+	Pipelines           json.RawMessage `json:"pipelines,omitempty"`
+	Executions          json.RawMessage `json:"executions,omitempty"`
+	Experiments         json.RawMessage `json:"experiments,omitempty"`
+	Trials              json.RawMessage `json:"trials,omitempty"`
+	Tags                json.RawMessage `json:"tags,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// SageMaker holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap sagemakerSnapshot
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *sagemakerSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.TrainingJobs, m.trainingJobs.Snapshot},
+		{&snap.ProcessingJobs, m.processingJobs.Snapshot},
+		{&snap.TransformJobs, m.transformJobs.Snapshot},
+		{&snap.TuningJobs, m.tuningJobs.Snapshot},
+		{&snap.AutoMLJobs, m.autoMLJobs.Snapshot},
+		{&snap.LabelingJobs, m.labelingJobs.Snapshot},
+		{&snap.CompilationJobs, m.compilationJobs.Snapshot},
+		{&snap.Models, m.models.Snapshot},
+		{&snap.EndpointConfigs, m.endpointConfigs.Snapshot},
+		{&snap.Endpoints, m.endpoints.Snapshot},
+		{&snap.InferenceComponents, m.inferenceComponents.Snapshot},
+		{&snap.PackageGroups, m.packageGroups.Snapshot},
+		{&snap.Packages, m.packages.Snapshot},
+		{&snap.Domains, m.domains.Snapshot},
+		{&snap.UserProfiles, m.userProfiles.Snapshot},
+		{&snap.Spaces, m.spaces.Snapshot},
+		{&snap.Apps, m.apps.Snapshot},
+		{&snap.Notebooks, m.notebooks.Snapshot},
+		{&snap.NotebookLCs, m.notebookLCs.Snapshot},
+		{&snap.CodeRepos, m.codeRepos.Snapshot},
+		{&snap.Clusters, m.clusters.Snapshot},
+		{&snap.FeatureGroups, m.featureGroups.Snapshot},
+		{&snap.FeatureRecords, m.featureRecords.Snapshot},
+		{&snap.Pipelines, m.pipelines.Snapshot},
+		{&snap.Executions, m.executions.Snapshot},
+		{&snap.Experiments, m.experiments.Snapshot},
+		{&snap.Trials, m.trials.Snapshot},
+		{&snap.Tags, m.tags.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("sagemaker: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds the mock's state under the original identities: every job,
+// model, endpoint, and registry resource is reinstated under its stored id.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap sagemakerSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("sagemaker: parse snapshot: %w", err)
+	}
+
+	return m.restoreStores(&snap)
+}
+
+func (m *Mock) restoreStores(snap *sagemakerSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.TrainingJobs, m.trainingJobs.LoadSnapshot},
+		{snap.ProcessingJobs, m.processingJobs.LoadSnapshot},
+		{snap.TransformJobs, m.transformJobs.LoadSnapshot},
+		{snap.TuningJobs, m.tuningJobs.LoadSnapshot},
+		{snap.AutoMLJobs, m.autoMLJobs.LoadSnapshot},
+		{snap.LabelingJobs, m.labelingJobs.LoadSnapshot},
+		{snap.CompilationJobs, m.compilationJobs.LoadSnapshot},
+		{snap.Models, m.models.LoadSnapshot},
+		{snap.EndpointConfigs, m.endpointConfigs.LoadSnapshot},
+		{snap.Endpoints, m.endpoints.LoadSnapshot},
+		{snap.InferenceComponents, m.inferenceComponents.LoadSnapshot},
+		{snap.PackageGroups, m.packageGroups.LoadSnapshot},
+		{snap.Packages, m.packages.LoadSnapshot},
+		{snap.Domains, m.domains.LoadSnapshot},
+		{snap.UserProfiles, m.userProfiles.LoadSnapshot},
+		{snap.Spaces, m.spaces.LoadSnapshot},
+		{snap.Apps, m.apps.LoadSnapshot},
+		{snap.Notebooks, m.notebooks.LoadSnapshot},
+		{snap.NotebookLCs, m.notebookLCs.LoadSnapshot},
+		{snap.CodeRepos, m.codeRepos.LoadSnapshot},
+		{snap.Clusters, m.clusters.LoadSnapshot},
+		{snap.FeatureGroups, m.featureGroups.LoadSnapshot},
+		{snap.FeatureRecords, m.featureRecords.LoadSnapshot},
+		{snap.Pipelines, m.pipelines.LoadSnapshot},
+		{snap.Executions, m.executions.LoadSnapshot},
+		{snap.Experiments, m.experiments.LoadSnapshot},
+		{snap.Trials, m.trials.LoadSnapshot},
+		{snap.Tags, m.tags.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("sagemaker: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/aws/sagemaker/snapshot_test.go
+++ b/providers/aws/sagemaker/snapshot_test.go
@@ -1,0 +1,55 @@
+package sagemaker
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/sagemaker/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSnapshotRoundTripSagemaker proves a snapshot/restore round-trip preserves
+// the SageMaker mock's state under the original identities. It populates two
+// distinct stores (models, experiments) via the public API, restores into a
+// fresh mock, and asserts both the semantic reads and a byte-identical
+// re-snapshot (which proves every populated store round-trips through the
+// generic memstore machinery).
+func TestSnapshotRoundTripSagemaker(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	_, err := src.CreateModel(ctx, driver.ModelConfig{
+		ModelName: "m-1",
+		RoleARN:   "arn:aws:iam::123456789012:role/r",
+		Tags:      []driver.Tag{{Key: "env", Value: "prod"}},
+	})
+	require.NoError(t, err)
+
+	_, err = src.CreateExperiment(ctx, driver.ExperimentSpec{
+		ExperimentName: "exp-1",
+		Description:    "d",
+	})
+	require.NoError(t, err)
+
+	raw, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst := newTestMock()
+	require.NoError(t, dst.Restore(ctx, raw))
+
+	model, err := dst.DescribeModel(ctx, "m-1")
+	require.NoError(t, err)
+	assert.Equal(t, "m-1", model.ModelName)
+	require.Len(t, model.Tags, 1)
+	assert.Equal(t, "prod", model.Tags[0].Value)
+
+	exp, err := dst.DescribeExperiment(ctx, "exp-1")
+	require.NoError(t, err)
+	assert.Equal(t, "exp-1", exp.ExperimentName)
+
+	raw2, err := dst.Snapshot(ctx, true)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(raw, raw2), "re-snapshot must be byte-identical")
+}

--- a/providers/aws/sfn/snapshot.go
+++ b/providers/aws/sfn/snapshot.go
@@ -1,0 +1,114 @@
+package sfn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// sfnSnapshot is the full serialized state of the Step Functions mock. Each
+// store wraps its driver record in an unexported *xData holding a per-record
+// mutex that json.Marshal cannot see, so the exported driver value is promoted
+// out of each wrapper keyed by its resource id. The execution settle overlay is
+// a transient Describe-surface window and is intentionally not captured; neither
+// are the per-record mutexes nor the wired *config.Options.
+type sfnSnapshot struct {
+	Machines   map[string]driver.StateMachine `json:"machines,omitempty"`
+	Executions map[string]driver.Execution    `json:"executions,omitempty"`
+	Activities map[string]driver.Activity     `json:"activities,omitempty"`
+	Aliases    map[string]driver.Alias        `json:"aliases,omitempty"`
+	MapRuns    map[string]driver.MapRun       `json:"mapRuns,omitempty"`
+	Tasks      map[string]string              `json:"tasks,omitempty"`
+}
+
+// snapshotWrapped promotes a store of mutex-guarded *D wrappers to a plain
+// map[id]V, reading each record's exported value through get (which locks the
+// record's own mutex).
+func snapshotWrapped[D, V any](s *memstore.Store[*D], get func(*D) V) map[string]V {
+	if s.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]V, s.Len())
+	for id, d := range s.All() {
+		out[id] = get(d)
+	}
+
+	return out
+}
+
+// restoreWrapped reinstates each id→V under a freshly-built *D wrapper. build
+// takes a pointer to avoid copying heavy driver values by value.
+func restoreWrapped[D, V any](s *memstore.Store[*D], in map[string]V, build func(*V) *D) {
+	for id, v := range in {
+		rec := build(&v)
+		s.Set(id, rec)
+	}
+}
+
+func getSM(d *smData) driver.StateMachine  { d.mu.RLock(); defer d.mu.RUnlock(); return d.sm }
+func getExec(d *execData) driver.Execution { d.mu.RLock(); defer d.mu.RUnlock(); return d.exec }
+func getAct(d *actData) driver.Activity    { d.mu.RLock(); defer d.mu.RUnlock(); return d.act }
+func getAlias(d *aliasData) driver.Alias   { d.mu.RLock(); defer d.mu.RUnlock(); return d.alias }
+func getRun(d *mapRunData) driver.MapRun   { d.mu.RLock(); defer d.mu.RUnlock(); return d.run }
+
+func buildSM(v *driver.StateMachine) *smData  { return &smData{sm: *v} }
+func buildExec(v *driver.Execution) *execData { return &execData{exec: *v} }
+func buildAct(v *driver.Activity) *actData    { return &actData{act: *v} }
+func buildAlias(v *driver.Alias) *aliasData   { return &aliasData{alias: *v} }
+func buildRun(v *driver.MapRun) *mapRunData   { return &mapRunData{run: *v} }
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Step Functions holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := sfnSnapshot{
+		Machines:   snapshotWrapped(m.machines, getSM),
+		Executions: snapshotWrapped(m.executions, getExec),
+		Activities: snapshotWrapped(m.activities, getAct),
+		Aliases:    snapshotWrapped(m.aliases, getAlias),
+		MapRuns:    snapshotWrapped(m.mapRuns, getRun),
+	}
+
+	m.tasksMu.RLock()
+	if len(m.tasks) > 0 {
+		snap.Tasks = make(map[string]string, len(m.tasks))
+		for k, v := range m.tasks {
+			snap.Tasks[k] = v
+		}
+	}
+	m.tasksMu.RUnlock()
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds the mock's state under the original identities: every state
+// machine, execution, activity, alias, and Map Run is reinstated under its
+// stored id, along with the activity-task token bookkeeping.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap sfnSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("sfn: parse snapshot: %w", err)
+	}
+
+	restoreWrapped(m.machines, snap.Machines, buildSM)
+	restoreWrapped(m.executions, snap.Executions, buildExec)
+	restoreWrapped(m.activities, snap.Activities, buildAct)
+	restoreWrapped(m.aliases, snap.Aliases, buildAlias)
+	restoreWrapped(m.mapRuns, snap.MapRuns, buildRun)
+
+	if len(snap.Tasks) > 0 {
+		m.tasksMu.Lock()
+		for k, v := range snap.Tasks {
+			m.tasks[k] = v
+		}
+		m.tasksMu.Unlock()
+	}
+
+	return nil
+}

--- a/providers/aws/sfn/snapshot_test.go
+++ b/providers/aws/sfn/snapshot_test.go
@@ -1,0 +1,86 @@
+package sfn_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
+)
+
+// TestSnapshotRoundTripSFN proves a snapshot/restore round-trip preserves the
+// Step Functions mock's state under the original identities: a state machine,
+// an activity, and a completed execution (each promoted out of its mutex-guarded
+// wrapper) survive restore into a fresh mock, and a re-snapshot is byte-identical.
+func TestSnapshotRoundTripSFN(t *testing.T) {
+	ctx := context.Background()
+	src := newMock(t)
+
+	smARN, _, _, err := src.CreateStateMachine(ctx, driver.CreateStateMachineInput{
+		Name:       "sm-1",
+		Definition: `{"StartAt":"a","States":{"a":{"Type":"Pass","End":true}}}`,
+		RoleArn:    "arn:aws:iam::000000000000:role/r",
+		Type:       "STANDARD",
+	})
+	if err != nil {
+		t.Fatalf("create state machine: %v", err)
+	}
+
+	actARN, _, err := src.CreateActivity(ctx, "act-1", nil)
+	if err != nil {
+		t.Fatalf("create activity: %v", err)
+	}
+
+	exec, err := src.StartExecution(ctx, driver.StartExecutionInput{
+		StateMachineArn: smARN, Name: "run-1", Input: `{"k":"v"}`,
+	})
+	if err != nil {
+		t.Fatalf("start execution: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newMock(t)
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	sm, err := dst.DescribeStateMachine(ctx, smARN)
+	if err != nil {
+		t.Fatalf("describe restored state machine: %v", err)
+	}
+
+	if sm.Name != "sm-1" {
+		t.Fatalf("restored state machine name = %q, want sm-1", sm.Name)
+	}
+
+	act, err := dst.DescribeActivity(ctx, actARN)
+	if err != nil {
+		t.Fatalf("describe restored activity: %v", err)
+	}
+
+	if act.Name != "act-1" {
+		t.Fatalf("restored activity name = %q, want act-1", act.Name)
+	}
+
+	gotExec, err := dst.DescribeExecution(ctx, exec.ARN)
+	if err != nil {
+		t.Fatalf("describe restored execution: %v", err)
+	}
+
+	if gotExec.Name != "run-1" {
+		t.Fatalf("restored execution name = %q, want run-1", gotExec.Name)
+	}
+
+	raw2, err := dst.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("re-snapshot: %v", err)
+	}
+
+	if !bytes.Equal(raw, raw2) {
+		t.Fatalf("re-snapshot not byte-identical to original")
+	}
+}

--- a/providers/aws/ssm/snapshot.go
+++ b/providers/aws/ssm/snapshot.go
@@ -1,0 +1,123 @@
+package ssm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// ssmSnapshot is the full serialized state of the SSM Parameter Store mock.
+// params holds an unexported paramData (with a slice of unexported *version), so
+// it is promoted to an exported snapshot form keyed by parameter name; commands
+// holds a fully-exported driver.CommandInvocation and round-trips through the
+// generic memstore helper. The wired instanceResolver and opts are not
+// serialized.
+type ssmSnapshot struct {
+	Params   map[string]*paramSnapshot `json:"params,omitempty"`
+	Commands json.RawMessage           `json:"commands,omitempty"`
+}
+
+// paramSnapshot mirrors paramData, promoting its unexported fields (and its
+// slice of unexported *version) to exported ones so they survive JSON.
+type paramSnapshot struct {
+	Name        string             `json:"name"`
+	Description string             `json:"description,omitempty"`
+	Tier        string             `json:"tier,omitempty"`
+	Versions    []*versionSnapshot `json:"versions,omitempty"`
+	Latest      int64              `json:"latest,omitempty"`
+	Tags        map[string]string  `json:"tags,omitempty"`
+}
+
+// versionSnapshot mirrors the unexported version struct.
+type versionSnapshot struct {
+	Value          string   `json:"value,omitempty"`
+	Typ            string   `json:"typ,omitempty"`
+	DataType       string   `json:"dataType,omitempty"`
+	Version        int64    `json:"version,omitempty"`
+	LastModified   string   `json:"lastModified,omitempty"`
+	Labels         []string `json:"labels,omitempty"`
+	KeyID          string   `json:"keyId,omitempty"`
+	AllowedPattern string   `json:"allowedPattern,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// SSM holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := ssmSnapshot{Params: m.snapshotParams()}
+
+	cmds, err := m.commands.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("ssm: snapshot commands: %w", err)
+	}
+
+	snap.Commands = cmds
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotParams() map[string]*paramSnapshot {
+	if m.params.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*paramSnapshot, m.params.Len())
+
+	for name, p := range m.params.All() {
+		p.mu.RLock()
+		ps := &paramSnapshot{
+			Name: p.name, Description: p.description, Tier: p.tier,
+			Latest: p.latest, Tags: p.tags,
+		}
+
+		for _, v := range p.versions {
+			ps.Versions = append(ps.Versions, &versionSnapshot{
+				Value: v.value, Typ: v.typ, DataType: v.dataType, Version: v.version,
+				LastModified: v.lastModified, Labels: v.labels, KeyID: v.keyID,
+				AllowedPattern: v.allowedPattern,
+			})
+		}
+		p.mu.RUnlock()
+
+		out[name] = ps
+	}
+
+	return out
+}
+
+// Restore rebuilds the mock's state under the original identities: every
+// parameter name and version number is preserved.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap ssmSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("ssm: parse snapshot: %w", err)
+	}
+
+	for name, ps := range snap.Params {
+		p := &paramData{
+			name: ps.Name, description: ps.Description, tier: ps.Tier,
+			latest: ps.Latest, tags: ps.Tags,
+		}
+
+		for _, v := range ps.Versions {
+			p.versions = append(p.versions, &version{
+				value: v.Value, typ: v.Typ, dataType: v.DataType, version: v.Version,
+				lastModified: v.LastModified, labels: v.Labels, keyID: v.KeyID,
+				allowedPattern: v.AllowedPattern,
+			})
+		}
+
+		m.params.Set(name, p)
+	}
+
+	if len(snap.Commands) > 0 {
+		if err := m.commands.LoadSnapshot(snap.Commands); err != nil {
+			return fmt.Errorf("ssm: restore commands: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/aws/ssm/snapshot_test.go
+++ b/providers/aws/ssm/snapshot_test.go
@@ -1,0 +1,50 @@
+package ssm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/aws/ssm"
+	"github.com/stackshy/cloudemu/v2/services/parameterstore/driver"
+)
+
+// TestSnapshotRoundTripSSM proves a snapshot/restore round-trip preserves a
+// parameter's full version history under its original name.
+func TestSnapshotRoundTripSSM(t *testing.T) {
+	ctx := context.Background()
+	src := ssm.New(config.NewOptions())
+
+	if _, _, err := src.PutParameter(ctx, driver.PutConfig{Name: "/app/db", Value: "v1", Type: "String"}); err != nil {
+		t.Fatalf("put v1: %v", err)
+	}
+
+	if _, _, err := src.PutParameter(ctx, driver.PutConfig{
+		Name: "/app/db", Value: "v2", Type: "String", Overwrite: true,
+	}); err != nil {
+		t.Fatalf("put v2: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := ssm.New(config.NewOptions())
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	p, err := dst.GetParameter(ctx, "/app/db", false)
+	if err != nil {
+		t.Fatalf("get restored parameter: %v", err)
+	}
+
+	if p.Value != "v2" {
+		t.Fatalf("restored value = %q, want v2", p.Value)
+	}
+
+	if p.Version != 2 {
+		t.Fatalf("restored version = %d, want 2 (history preserved)", p.Version)
+	}
+}

--- a/providers/azure/acr/snapshot.go
+++ b/providers/azure/acr/snapshot.go
@@ -1,0 +1,182 @@
+package acr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// acrSnapshot is the full serialized state of the ACR mock: the data-plane repo
+// catalog (repos, keyed by name, each with its images/layers, scan results,
+// lifecycle policy, and settings) and the ARM management-plane resources
+// (registries keyed by "{rg}/{name}", webhooks, replications). repoData,
+// registryData, and imageData are unexported, so they are promoted to exported
+// forms; the scan/webhook/replication stores hold exported driver values and
+// round-trip through the generic memstore helper. The mutex and the wired
+// options/monitoring are intentionally not serialized.
+type acrSnapshot struct {
+	Repos        map[string]*repoDataSnapshot     `json:"repos,omitempty"`
+	Registries   map[string]*registryDataSnapshot `json:"registries,omitempty"`
+	Webhooks     json.RawMessage                  `json:"webhooks,omitempty"`
+	Replications json.RawMessage                  `json:"replications,omitempty"`
+}
+
+// repoDataSnapshot is the exported form of repoData.
+type repoDataSnapshot struct {
+	Info          driver.Repository             `json:"info"`
+	Images        map[string]*imageDataSnapshot `json:"images,omitempty"`
+	Scans         json.RawMessage               `json:"scans,omitempty"`
+	Policy        *driver.LifecyclePolicy       `json:"policy,omitempty"`
+	ScanOnPush    bool                          `json:"scanOnPush,omitempty"`
+	TagMutability string                        `json:"tagMutability,omitempty"`
+}
+
+// imageDataSnapshot is the exported form of imageData.
+type imageDataSnapshot struct {
+	Detail driver.ImageDetail `json:"detail"`
+	Layers []driver.LayerInfo `json:"layers,omitempty"`
+}
+
+// registryDataSnapshot is the exported form of registryData.
+type registryDataSnapshot struct {
+	Reg       driver.AzureRegistry `json:"reg"`
+	Password  string               `json:"password,omitempty"`
+	Password2 string               `json:"password2,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// ACR stores image metadata/layers, not bulk blobs.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := acrSnapshot{
+		Repos:      make(map[string]*repoDataSnapshot, m.repos.Len()),
+		Registries: make(map[string]*registryDataSnapshot, m.registries.Len()),
+	}
+
+	for name, rd := range m.repos.All() {
+		rs, err := snapshotRepo(rd)
+		if err != nil {
+			return nil, err
+		}
+
+		snap.Repos[name] = rs
+	}
+
+	for key, rg := range m.registries.All() {
+		snap.Registries[key] = &registryDataSnapshot{Reg: rg.reg, Password: rg.password, Password2: rg.password2}
+	}
+
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(snap)
+}
+
+func snapshotRepo(rd *repoData) (*repoDataSnapshot, error) {
+	rs := &repoDataSnapshot{
+		Info:          rd.info,
+		Images:        make(map[string]*imageDataSnapshot, rd.images.Len()),
+		Policy:        rd.policy,
+		ScanOnPush:    rd.scanOnPush,
+		TagMutability: rd.tagMutability,
+	}
+
+	for tag, img := range rd.images.All() {
+		rs.Images[tag] = &imageDataSnapshot{Detail: img.detail, Layers: img.layers}
+	}
+
+	scans, err := rd.scans.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("acr: snapshot scans: %w", err)
+	}
+
+	rs.Scans = scans
+
+	return rs, nil
+}
+
+func (m *Mock) snapshotStores(snap *acrSnapshot) error {
+	wh, err := m.webhooks.Snapshot()
+	if err != nil {
+		return fmt.Errorf("acr: snapshot webhooks: %w", err)
+	}
+
+	rp, err := m.replications.Snapshot()
+	if err != nil {
+		return fmt.Errorf("acr: snapshot replications: %w", err)
+	}
+
+	snap.Webhooks = wh
+	snap.Replications = rp
+
+	return nil
+}
+
+// Restore rebuilds every repo and registry under its original key with its images,
+// scans, and settings intact.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap acrSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("acr: parse snapshot: %w", err)
+	}
+
+	for name, rs := range snap.Repos {
+		rd, err := restoreRepo(rs)
+		if err != nil {
+			return err
+		}
+
+		m.repos.Set(name, rd)
+	}
+
+	for key, rs := range snap.Registries {
+		m.registries.Set(key, &registryData{reg: rs.Reg, password: rs.Password, password2: rs.Password2})
+	}
+
+	return m.restoreStores(&snap)
+}
+
+func restoreRepo(rs *repoDataSnapshot) (*repoData, error) {
+	rd := &repoData{
+		info:          rs.Info,
+		images:        memstore.New[*imageData](),
+		scans:         memstore.New[*driver.ScanResult](),
+		policy:        rs.Policy,
+		scanOnPush:    rs.ScanOnPush,
+		tagMutability: rs.TagMutability,
+	}
+
+	for tag, is := range rs.Images {
+		rd.images.Set(tag, &imageData{detail: is.Detail, layers: is.Layers})
+	}
+
+	if len(rs.Scans) > 0 {
+		if err := rd.scans.LoadSnapshot(rs.Scans); err != nil {
+			return nil, fmt.Errorf("acr: restore scans: %w", err)
+		}
+	}
+
+	return rd, nil
+}
+
+func (m *Mock) restoreStores(snap *acrSnapshot) error {
+	if len(snap.Webhooks) > 0 {
+		if err := m.webhooks.LoadSnapshot(snap.Webhooks); err != nil {
+			return fmt.Errorf("acr: restore webhooks: %w", err)
+		}
+	}
+
+	if len(snap.Replications) > 0 {
+		if err := m.replications.LoadSnapshot(snap.Replications); err != nil {
+			return fmt.Errorf("acr: restore replications: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/azure/acr/snapshot_test.go
+++ b/providers/azure/acr/snapshot_test.go
@@ -1,0 +1,51 @@
+package acr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotRoundTripACR(t *testing.T) {
+	ctx := context.Background()
+	src, _ := newTestMock()
+
+	_, _, err := src.CreateOrUpdateRegistry(ctx, "rg-1", "MyReg", driver.AzureRegistryConfig{
+		Location: "eastus", AdminUserEnabled: true,
+	})
+	require.NoError(t, err)
+
+	_, err = src.CreateRepository(ctx, driver.RepositoryConfig{Name: "app"})
+	require.NoError(t, err)
+
+	_, err = src.PutImage(ctx, &driver.ImageManifest{Repository: "app", Tag: "v1", SizeBytes: 1024})
+	require.NoError(t, err)
+
+	require.NoError(t, src.PutLifecyclePolicy(ctx, "app", driver.LifecyclePolicy{}))
+
+	data, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst, _ := newTestMock()
+	require.NoError(t, dst.Restore(ctx, data))
+
+	reg, err := dst.GetRegistry(ctx, "rg-1", "MyReg")
+	require.NoError(t, err)
+	assert.Equal(t, "MyReg", reg.Name)
+
+	repo, err := dst.GetRepository(ctx, "app")
+	require.NoError(t, err)
+	assert.Contains(t, repo.Name, "app")
+
+	images, err := dst.ListImages(ctx, "app")
+	require.NoError(t, err)
+	require.Len(t, images, 1)
+	assert.Equal(t, "app", images[0].Repository)
+	assert.Contains(t, images[0].Tags, "v1")
+
+	_, err = dst.GetLifecyclePolicy(ctx, "app")
+	require.NoError(t, err)
+}

--- a/providers/azure/ai/snapshot.go
+++ b/providers/azure/ai/snapshot.go
@@ -1,0 +1,152 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// aiSnapshot is the full serialized state of the Azure AI mock. Every store's
+// value type is fully exported (driver.*), so each round-trips through the
+// generic memstore helper keyed by its resource id. The operation sequence
+// counter is captured so ids minted after a restore do not collide. The wired
+// *config.Options and monitoring backend are intentionally not serialized.
+type aiSnapshot struct {
+	Accounts         json.RawMessage `json:"accounts,omitempty"`
+	AccountKeys      json.RawMessage `json:"accountKeys,omitempty"`
+	Deployments      json.RawMessage `json:"deployments,omitempty"`
+	Projects         json.RawMessage `json:"projects,omitempty"`
+	RaiPolicies      json.RawMessage `json:"raiPolicies,omitempty"`
+	CommitmentPlans  json.RawMessage `json:"commitmentPlans,omitempty"`
+	PrivateEndpoints json.RawMessage `json:"privateEndpoints,omitempty"`
+	Assistants       json.RawMessage `json:"assistants,omitempty"`
+	Threads          json.RawMessage `json:"threads,omitempty"`
+	Messages         json.RawMessage `json:"messages,omitempty"`
+	Runs             json.RawMessage `json:"runs,omitempty"`
+	MLWorkspaces     json.RawMessage `json:"mlWorkspaces,omitempty"`
+	Computes         json.RawMessage `json:"computes,omitempty"`
+	MLEndpoints      json.RawMessage `json:"mlEndpoints,omitempty"`
+	MLDeploys        json.RawMessage `json:"mlDeploys,omitempty"`
+	Jobs             json.RawMessage `json:"jobs,omitempty"`
+	Assets           json.RawMessage `json:"assets,omitempty"`
+	Datastores       json.RawMessage `json:"datastores,omitempty"`
+	Connections      json.RawMessage `json:"connections,omitempty"`
+	MLSchedules      json.RawMessage `json:"mlSchedules,omitempty"`
+	Registries       json.RawMessage `json:"registries,omitempty"`
+	Seq              int64           `json:"seq,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Azure AI holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap aiSnapshot
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	snap.Seq = m.seq.Load()
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *aiSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Accounts, m.accounts.Snapshot},
+		{&snap.AccountKeys, m.accountKeys.Snapshot},
+		{&snap.Deployments, m.deployments.Snapshot},
+		{&snap.Projects, m.projects.Snapshot},
+		{&snap.RaiPolicies, m.raiPolicies.Snapshot},
+		{&snap.CommitmentPlans, m.commitmentPlans.Snapshot},
+		{&snap.PrivateEndpoints, m.privateEndpoints.Snapshot},
+		{&snap.Assistants, m.assistants.Snapshot},
+		{&snap.Threads, m.threads.Snapshot},
+		{&snap.Messages, m.messages.Snapshot},
+		{&snap.Runs, m.runs.Snapshot},
+		{&snap.MLWorkspaces, m.mlWorkspaces.Snapshot},
+		{&snap.Computes, m.computes.Snapshot},
+		{&snap.MLEndpoints, m.mlEndpoints.Snapshot},
+		{&snap.MLDeploys, m.mlDeploys.Snapshot},
+		{&snap.Jobs, m.jobs.Snapshot},
+		{&snap.Assets, m.assets.Snapshot},
+		{&snap.Datastores, m.datastores.Snapshot},
+		{&snap.Connections, m.connections.Snapshot},
+		{&snap.MLSchedules, m.mlSchedules.Snapshot},
+		{&snap.Registries, m.registries.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("ai: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds the mock's state under the original identities: every
+// account/deployment/workspace id is preserved so cross-references resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap aiSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("ai: parse snapshot: %w", err)
+	}
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	m.seq.Store(snap.Seq)
+
+	return nil
+}
+
+func (m *Mock) restoreStores(snap *aiSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Accounts, m.accounts.LoadSnapshot},
+		{snap.AccountKeys, m.accountKeys.LoadSnapshot},
+		{snap.Deployments, m.deployments.LoadSnapshot},
+		{snap.Projects, m.projects.LoadSnapshot},
+		{snap.RaiPolicies, m.raiPolicies.LoadSnapshot},
+		{snap.CommitmentPlans, m.commitmentPlans.LoadSnapshot},
+		{snap.PrivateEndpoints, m.privateEndpoints.LoadSnapshot},
+		{snap.Assistants, m.assistants.LoadSnapshot},
+		{snap.Threads, m.threads.LoadSnapshot},
+		{snap.Messages, m.messages.LoadSnapshot},
+		{snap.Runs, m.runs.LoadSnapshot},
+		{snap.MLWorkspaces, m.mlWorkspaces.LoadSnapshot},
+		{snap.Computes, m.computes.LoadSnapshot},
+		{snap.MLEndpoints, m.mlEndpoints.LoadSnapshot},
+		{snap.MLDeploys, m.mlDeploys.LoadSnapshot},
+		{snap.Jobs, m.jobs.LoadSnapshot},
+		{snap.Assets, m.assets.LoadSnapshot},
+		{snap.Datastores, m.datastores.LoadSnapshot},
+		{snap.Connections, m.connections.LoadSnapshot},
+		{snap.MLSchedules, m.mlSchedules.LoadSnapshot},
+		{snap.Registries, m.registries.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("ai: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/azure/ai/snapshot_test.go
+++ b/providers/azure/ai/snapshot_test.go
@@ -1,0 +1,62 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/services/azureai/driver"
+)
+
+func newSnapshotTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("eastus"), config.WithAccountID("sub-1"))
+
+	return New(opts)
+}
+
+// TestSnapshotRoundTripAI proves a snapshot/restore cycle reinstates the mock's
+// state under the original identities: a Cognitive Services account created
+// before the snapshot is readable from a fresh mock after restore, and
+// re-snapshotting yields byte-identical JSON, so every store round-trips.
+func TestSnapshotRoundTripAI(t *testing.T) {
+	ctx := context.Background()
+	src := newSnapshotTestMock()
+
+	acct, err := src.CreateAccount(ctx, driver.AccountConfig{
+		Name: "acct-1", ResourceGroup: "rg-1", Location: "eastus", Kind: "OpenAI",
+	})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newSnapshotTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	got, err := dst.GetAccount(ctx, "rg-1", "acct-1")
+	if err != nil {
+		t.Fatalf("get restored account: %v", err)
+	}
+
+	if got.ID != acct.ID {
+		t.Fatalf("restored account ID = %q, want %q", got.ID, acct.ID)
+	}
+
+	reSnap, err := dst.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("re-snapshot: %v", err)
+	}
+
+	if !bytes.Equal(raw, reSnap) {
+		t.Fatalf("re-snapshot differs from original snapshot; a store did not round-trip")
+	}
+}

--- a/providers/azure/aks/snapshot.go
+++ b/providers/azure/aks/snapshot.go
@@ -1,0 +1,96 @@
+package aks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// aksSnapshot is the full serialized state of the AKS mock. The three stores hold
+// fully-exported values (ManagedCluster, AgentPool, MaintenanceConfig) and
+// round-trip through the generic memstore helper keyed by their composite ids
+// ("{rg}/{name}", "{rg}/{cluster}/{pool}", …), so cross-references survive.
+// k8sUIDs (the "{rg}/{name}" → registered Kubernetes UID map) is captured so a
+// restored cluster keeps its data-plane identity. The mutex and the wired
+// options/monitoring/k8sAPI (a live data-plane server pointer) are intentionally
+// not serialized.
+type aksSnapshot struct {
+	Clusters    json.RawMessage   `json:"clusters,omitempty"`
+	Pools       json.RawMessage   `json:"pools,omitempty"`
+	Maintenance json.RawMessage   `json:"maintenance,omitempty"`
+	K8sUIDs     map[string]string `json:"k8sUids,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// AKS holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap aksSnapshot
+
+	clusters, err := m.clusters.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("aks: snapshot clusters: %w", err)
+	}
+
+	pools, err := m.pools.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("aks: snapshot pools: %w", err)
+	}
+
+	maint, err := m.maintenance.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("aks: snapshot maintenance: %w", err)
+	}
+
+	snap.Clusters = clusters
+	snap.Pools = pools
+	snap.Maintenance = maint
+
+	m.mu.RLock()
+	if len(m.k8sUIDs) > 0 {
+		snap.K8sUIDs = maps.Clone(m.k8sUIDs)
+	}
+	m.mu.RUnlock()
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds every store under its original keys and reinstates the
+// data-plane UID map.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap aksSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("aks: parse snapshot: %w", err)
+	}
+
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Clusters, m.clusters.LoadSnapshot},
+		{snap.Pools, m.pools.LoadSnapshot},
+		{snap.Maintenance, m.maintenance.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("aks: restore store: %w", err)
+		}
+	}
+
+	if len(snap.K8sUIDs) > 0 {
+		m.mu.Lock()
+		maps.Copy(m.k8sUIDs, snap.K8sUIDs)
+		m.mu.Unlock()
+	}
+
+	return nil
+}

--- a/providers/azure/aks/snapshot_test.go
+++ b/providers/azure/aks/snapshot_test.go
@@ -1,0 +1,50 @@
+package aks
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSnapshotRoundTripAKS(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	_, err := src.CreateOrUpdateCluster(ctx, ClusterInput{
+		Subscription:      "sub-1",
+		ResourceGroup:     "rg-1",
+		Name:              "k8s-1",
+		Location:          "eastus",
+		KubernetesVersion: "1.29.5",
+		AgentPools: []AgentPoolInput{
+			{Name: "system", Count: int32Ptr(2), VMSize: "Standard_D2s_v3", Mode: "System"},
+		},
+	})
+	requireNoError(t, err)
+
+	_, err = src.CreateOrUpdateAgentPool(ctx, "rg-1", "k8s-1", AgentPoolInput{
+		Name: "user", Count: int32Ptr(1), VMSize: "Standard_D2s_v3", Mode: "User",
+	})
+	requireNoError(t, err)
+
+	_, err = src.CreateOrUpdateMaintenanceConfig(ctx, "rg-1", "k8s-1", "default",
+		map[string]any{"timeInWeek": []any{}})
+	requireNoError(t, err)
+
+	data, err := src.Snapshot(ctx, true)
+	requireNoError(t, err)
+
+	dst := newTestMock()
+	requireNoError(t, dst.Restore(ctx, data))
+
+	cluster, err := dst.GetCluster(ctx, "rg-1", "k8s-1")
+	requireNoError(t, err)
+	assertEqual(t, "k8s-1", cluster.Name)
+
+	pool, err := dst.GetAgentPool(ctx, "rg-1", "k8s-1", "user")
+	requireNoError(t, err)
+	assertEqual(t, "user", pool.Name)
+
+	mc, err := dst.GetMaintenanceConfig(ctx, "rg-1", "k8s-1", "default")
+	requireNoError(t, err)
+	assertEqual(t, "default", mc.Name)
+}

--- a/providers/azure/cache/snapshot.go
+++ b/providers/azure/cache/snapshot.go
@@ -1,0 +1,67 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// cacheSnapshot is the full serialized state of the Azure Cache mock: every
+// cache instance keyed by name, each carrying its info and its key/value items.
+// cacheData is unexported, so it is promoted to an exported form; the items store
+// round-trips through the generic memstore helper (cacheItem has only exported
+// fields). The wired options/monitoring are intentionally not serialized.
+type cacheSnapshot struct {
+	Caches map[string]*cacheDataSnapshot `json:"caches,omitempty"`
+}
+
+// cacheDataSnapshot is the exported form of cacheData.
+type cacheDataSnapshot struct {
+	Info  driver.CacheInfo `json:"info"`
+	Items json.RawMessage  `json:"items,omitempty"`
+}
+
+// Snapshot captures every cache instance's state as JSON. includeAssets is unused
+// — the cached items are the resource, so they are always captured.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := cacheSnapshot{Caches: make(map[string]*cacheDataSnapshot, m.caches.Len())}
+
+	for name, cd := range m.caches.All() {
+		items, err := cd.items.Snapshot()
+		if err != nil {
+			return nil, fmt.Errorf("cache: snapshot items: %w", err)
+		}
+
+		snap.Caches[name] = &cacheDataSnapshot{Info: cd.info, Items: items}
+	}
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds every cache instance under its original name with its items
+// intact.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap cacheSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("cache: parse snapshot: %w", err)
+	}
+
+	for name, cs := range snap.Caches {
+		cd := &cacheData{info: cs.Info, items: memstore.New[cacheItem]()}
+		if len(cs.Items) > 0 {
+			if err := cd.items.LoadSnapshot(cs.Items); err != nil {
+				return fmt.Errorf("cache: restore items: %w", err)
+			}
+		}
+
+		m.caches.Set(name, cd)
+	}
+
+	return nil
+}

--- a/providers/azure/cache/snapshot_test.go
+++ b/providers/azure/cache/snapshot_test.go
@@ -1,0 +1,38 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotRoundTripCache(t *testing.T) {
+	ctx := context.Background()
+	src, _ := newTestMock()
+
+	_, err := src.CreateCache(ctx, driver.CacheConfig{Name: "c1", Engine: "redis"})
+	require.NoError(t, err)
+	require.NoError(t, src.Set(ctx, "c1", "k1", []byte("value1"), 0))
+	require.NoError(t, src.Set(ctx, "c1", "k2", []byte("value2"), 0))
+
+	data, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst, _ := newTestMock()
+	require.NoError(t, dst.Restore(ctx, data))
+
+	info, err := dst.GetCache(ctx, "c1")
+	require.NoError(t, err)
+	assert.Equal(t, "c1", info.Name)
+
+	item, err := dst.Get(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("value1"), item.Value)
+
+	item2, err := dst.Get(ctx, "c1", "k2")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("value2"), item2.Value)
+}

--- a/providers/azure/databricks/snapshot.go
+++ b/providers/azure/databricks/snapshot.go
@@ -1,0 +1,125 @@
+package databricks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// databricksSnapshot is the full serialized state of the Databricks mock. Every
+// store's value type is fully exported (driver.*), so each round-trips through
+// the generic memstore helper keyed by its resource id. The job/run sequence
+// counters are captured so ids minted after a restore do not collide with
+// existing ones. The wired *config.Options is intentionally not serialized.
+type databricksSnapshot struct {
+	Workspaces       json.RawMessage `json:"workspaces,omitempty"`
+	Pools            json.RawMessage `json:"pools,omitempty"`
+	Clusters         json.RawMessage `json:"clusters,omitempty"`
+	Jobs             json.RawMessage `json:"jobs,omitempty"`
+	Runs             json.RawMessage `json:"runs,omitempty"`
+	Policies         json.RawMessage `json:"policies,omitempty"`
+	Libraries        json.RawMessage `json:"libraries,omitempty"`
+	Permissions      json.RawMessage `json:"permissions,omitempty"`
+	AccessConnectors json.RawMessage `json:"accessConnectors,omitempty"`
+	PrivateEndpoints json.RawMessage `json:"privateEndpoints,omitempty"`
+	VNetPeerings     json.RawMessage `json:"vnetPeerings,omitempty"`
+	JobSeq           int64           `json:"jobSeq,omitempty"`
+	RunSeq           int64           `json:"runSeq,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Databricks holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap databricksSnapshot
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	snap.JobSeq = m.jobSeq.Load()
+	snap.RunSeq = m.runSeq.Load()
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *databricksSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Workspaces, m.workspaces.Snapshot},
+		{&snap.Pools, m.pools.Snapshot},
+		{&snap.Clusters, m.clusters.Snapshot},
+		{&snap.Jobs, m.jobs.Snapshot},
+		{&snap.Runs, m.runs.Snapshot},
+		{&snap.Policies, m.policies.Snapshot},
+		{&snap.Libraries, m.libraries.Snapshot},
+		{&snap.Permissions, m.permissions.Snapshot},
+		{&snap.AccessConnectors, m.accessConnectors.Snapshot},
+		{&snap.PrivateEndpoints, m.privateEndpoints.Snapshot},
+		{&snap.VNetPeerings, m.vnetPeerings.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("databricks: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds the mock's state under the original identities: every
+// workspace/cluster/job id is preserved so cross-references still resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap databricksSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("databricks: parse snapshot: %w", err)
+	}
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	m.jobSeq.Store(snap.JobSeq)
+	m.runSeq.Store(snap.RunSeq)
+
+	return nil
+}
+
+func (m *Mock) restoreStores(snap *databricksSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Workspaces, m.workspaces.LoadSnapshot},
+		{snap.Pools, m.pools.LoadSnapshot},
+		{snap.Clusters, m.clusters.LoadSnapshot},
+		{snap.Jobs, m.jobs.LoadSnapshot},
+		{snap.Runs, m.runs.LoadSnapshot},
+		{snap.Policies, m.policies.LoadSnapshot},
+		{snap.Libraries, m.libraries.LoadSnapshot},
+		{snap.Permissions, m.permissions.LoadSnapshot},
+		{snap.AccessConnectors, m.accessConnectors.LoadSnapshot},
+		{snap.PrivateEndpoints, m.privateEndpoints.LoadSnapshot},
+		{snap.VNetPeerings, m.vnetPeerings.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("databricks: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/azure/databricks/snapshot_test.go
+++ b/providers/azure/databricks/snapshot_test.go
@@ -1,0 +1,49 @@
+package databricks
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// TestSnapshotRoundTripDatabricks proves a snapshot/restore cycle reinstates the
+// mock's state under the original identities: a workspace created before the
+// snapshot is readable from a fresh mock after restore, and re-snapshotting the
+// restored mock yields byte-identical JSON (every store round-trips).
+func TestSnapshotRoundTripDatabricks(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	ws, err := src.CreateWorkspace(ctx, validConfig())
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	got, err := dst.GetWorkspace(ctx, "rg-1", "ws-1")
+	if err != nil {
+		t.Fatalf("get restored workspace: %v", err)
+	}
+
+	if got.ID != ws.ID {
+		t.Fatalf("restored workspace ID = %q, want %q", got.ID, ws.ID)
+	}
+
+	reSnap, err := dst.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("re-snapshot: %v", err)
+	}
+
+	if !bytes.Equal(raw, reSnap) {
+		t.Fatalf("re-snapshot differs from original snapshot; a store did not round-trip")
+	}
+}

--- a/providers/azure/loganalytics/snapshot.go
+++ b/providers/azure/loganalytics/snapshot.go
@@ -1,0 +1,130 @@
+package loganalytics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// logAnalyticsSnapshot is the full serialized state of the Log Analytics mock:
+// every workspace (log group) keyed by name, each carrying its info, its log
+// streams (with their events), and its metric/subscription filters. logGroup and
+// logStream are unexported, so they are promoted to exported forms; the filter
+// stores hold exported driver values and round-trip through the generic memstore
+// helper. Each logStream's mutex and the wired options/monitoring are
+// intentionally not serialized.
+type logAnalyticsSnapshot struct {
+	Groups map[string]*logGroupSnapshot `json:"groups,omitempty"`
+}
+
+// logGroupSnapshot is the exported form of logGroup.
+type logGroupSnapshot struct {
+	Info          driver.LogGroupInfo           `json:"info"`
+	Streams       map[string]*logStreamSnapshot `json:"streams,omitempty"`
+	MetricFilters json.RawMessage               `json:"metricFilters,omitempty"`
+	SubFilters    json.RawMessage               `json:"subFilters,omitempty"`
+}
+
+// logStreamSnapshot is the exported form of logStream; its mutex is excluded.
+type logStreamSnapshot struct {
+	Info   driver.LogStreamInfo `json:"info"`
+	Events []driver.LogEvent    `json:"events,omitempty"`
+}
+
+// Snapshot captures every workspace's full state as JSON. includeAssets is unused
+// — the log events are the resource, so they are always captured.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := logAnalyticsSnapshot{Groups: make(map[string]*logGroupSnapshot, m.groups.Len())}
+
+	for name, g := range m.groups.All() {
+		gs, err := snapshotGroup(g)
+		if err != nil {
+			return nil, err
+		}
+
+		snap.Groups[name] = gs
+	}
+
+	return json.Marshal(snap)
+}
+
+func snapshotGroup(g *logGroup) (*logGroupSnapshot, error) {
+	gs := &logGroupSnapshot{
+		Info:    g.info,
+		Streams: make(map[string]*logStreamSnapshot, g.streams.Len()),
+	}
+
+	for name, s := range g.streams.All() {
+		s.mu.RLock()
+		gs.Streams[name] = &logStreamSnapshot{Info: s.info, Events: append([]driver.LogEvent(nil), s.events...)}
+		s.mu.RUnlock()
+	}
+
+	mf, err := g.metricFilters.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("loganalytics: snapshot metric filters: %w", err)
+	}
+
+	sf, err := g.subFilters.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("loganalytics: snapshot subscription filters: %w", err)
+	}
+
+	gs.MetricFilters = mf
+	gs.SubFilters = sf
+
+	return gs, nil
+}
+
+// Restore rebuilds every workspace under its original name with its streams,
+// events, and filters intact.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap logAnalyticsSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("loganalytics: parse snapshot: %w", err)
+	}
+
+	for name, gs := range snap.Groups {
+		g, err := restoreGroup(gs)
+		if err != nil {
+			return err
+		}
+
+		m.groups.Set(name, g)
+	}
+
+	return nil
+}
+
+func restoreGroup(gs *logGroupSnapshot) (*logGroup, error) {
+	g := &logGroup{
+		info:          gs.Info,
+		streams:       memstore.New[*logStream](),
+		metricFilters: memstore.New[*driver.MetricFilterInfo](),
+		subFilters:    memstore.New[*driver.SubscriptionFilterInfo](),
+	}
+
+	for name, ss := range gs.Streams {
+		g.streams.Set(name, &logStream{info: ss.Info, events: ss.Events})
+	}
+
+	if len(gs.MetricFilters) > 0 {
+		if err := g.metricFilters.LoadSnapshot(gs.MetricFilters); err != nil {
+			return nil, fmt.Errorf("loganalytics: restore metric filters: %w", err)
+		}
+	}
+
+	if len(gs.SubFilters) > 0 {
+		if err := g.subFilters.LoadSnapshot(gs.SubFilters); err != nil {
+			return nil, fmt.Errorf("loganalytics: restore subscription filters: %w", err)
+		}
+	}
+
+	return g, nil
+}

--- a/providers/azure/loganalytics/snapshot_test.go
+++ b/providers/azure/loganalytics/snapshot_test.go
@@ -1,0 +1,51 @@
+package loganalytics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/logging/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotRoundTripLogAnalytics(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	_, err := src.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g1"})
+	require.NoError(t, err)
+	_, err = src.CreateLogStream(ctx, "g1", "s1")
+	require.NoError(t, err)
+
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, src.PutLogEvents(ctx, "g1", "s1", []driver.LogEvent{
+		{Timestamp: ts, Message: "hello"},
+		{Timestamp: ts.Add(time.Second), Message: "world"},
+	}))
+
+	require.NoError(t, src.PutMetricFilter(ctx, &driver.MetricFilterConfig{
+		Name: "mf1", LogGroup: "g1", FilterPattern: "ERROR", MetricName: "Errors", MetricNamespace: "App",
+	}))
+
+	data, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst := newTestMock()
+	require.NoError(t, dst.Restore(ctx, data))
+
+	streams, err := dst.ListLogStreams(ctx, "g1")
+	require.NoError(t, err)
+	require.Len(t, streams, 1)
+	assert.Equal(t, "s1", streams[0].Name)
+
+	events, err := dst.GetLogEvents(ctx, &driver.LogQueryInput{LogGroup: "g1", LogStream: "s1"})
+	require.NoError(t, err)
+	assert.Len(t, events, 2)
+
+	filters, err := dst.DescribeMetricFilters(ctx, "g1")
+	require.NoError(t, err)
+	require.Len(t, filters, 1)
+	assert.Equal(t, "mf1", filters[0].Name)
+}

--- a/providers/azure/mysqlflex/snapshot.go
+++ b/providers/azure/mysqlflex/snapshot.go
@@ -1,0 +1,91 @@
+package mysqlflex
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// mysqlFlexSnapshot is the full serialized state of the MySQL Flexible Server
+// mock. Every store holds a fully-exported rdsdriver value, so each round-trips
+// through the generic memstore helper keyed by its resource id — cross-references
+// (a database/firewall rule's server key) survive. The mutex and the wired
+// options/monitoring are intentionally not serialized.
+type mysqlFlexSnapshot struct {
+	Instances      json.RawMessage `json:"instances,omitempty"`
+	Snapshots      json.RawMessage `json:"snapshots,omitempty"`
+	Databases      json.RawMessage `json:"databases,omitempty"`
+	FirewallRules  json.RawMessage `json:"firewallRules,omitempty"`
+	Configurations json.RawMessage `json:"configurations,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// MySQL Flex holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap mysqlFlexSnapshot
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *mysqlFlexSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Instances, m.instances.Snapshot},
+		{&snap.Snapshots, m.snapshots.Snapshot},
+		{&snap.Databases, m.databases.Snapshot},
+		{&snap.FirewallRules, m.firewallRules.Snapshot},
+		{&snap.Configurations, m.configurations.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("mysqlflex: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds every store under its original keys, so a restored database's
+// identity and its server cross-reference still resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap mysqlFlexSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("mysqlflex: parse snapshot: %w", err)
+	}
+
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Instances, m.instances.LoadSnapshot},
+		{snap.Snapshots, m.snapshots.LoadSnapshot},
+		{snap.Databases, m.databases.LoadSnapshot},
+		{snap.FirewallRules, m.firewallRules.LoadSnapshot},
+		{snap.Configurations, m.configurations.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("mysqlflex: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/azure/mysqlflex/snapshot_test.go
+++ b/providers/azure/mysqlflex/snapshot_test.go
@@ -1,0 +1,61 @@
+package mysqlflex
+
+import (
+	"context"
+	"testing"
+
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+func TestSnapshotRoundTripMySQLFlex(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, err := src.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "srv"}); err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+
+	if _, err := src.CreateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "srv", Name: "app"}); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	if _, err := src.CreateFirewallRule(ctx, rdsdriver.FirewallRuleConfig{
+		Server: "srv", Name: "r", StartIPAddress: "10.0.0.1", EndIPAddress: "10.0.0.9",
+	}); err != nil {
+		t.Fatalf("create firewall rule: %v", err)
+	}
+
+	data, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, data); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	instances, err := dst.DescribeInstances(ctx, nil)
+	if err != nil {
+		t.Fatalf("describe instances: %v", err)
+	}
+	if len(instances) != 1 || instances[0].ID != "srv" {
+		t.Fatalf("instances = %+v, want one with ID srv", instances)
+	}
+
+	dbs, err := dst.ListDatabases(ctx, "srv")
+	if err != nil {
+		t.Fatalf("list databases: %v", err)
+	}
+	if len(dbs) != 1 {
+		t.Fatalf("databases = %d, want 1", len(dbs))
+	}
+
+	rules, err := dst.ListFirewallRules(ctx, "srv")
+	if err != nil {
+		t.Fatalf("list firewall rules: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("firewall rules = %d, want 1", len(rules))
+	}
+}

--- a/providers/azure/postgresflex/snapshot.go
+++ b/providers/azure/postgresflex/snapshot.go
@@ -1,0 +1,91 @@
+package postgresflex
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// pgFlexSnapshot is the full serialized state of the Postgres Flexible Server
+// mock. Every store holds a fully-exported rdsdriver value, so each round-trips
+// through the generic memstore helper keyed by its resource id — cross-references
+// (a database/firewall rule's server key) survive. The mutex and the wired
+// options/monitoring are intentionally not serialized.
+type pgFlexSnapshot struct {
+	Instances      json.RawMessage `json:"instances,omitempty"`
+	Snapshots      json.RawMessage `json:"snapshots,omitempty"`
+	Databases      json.RawMessage `json:"databases,omitempty"`
+	FirewallRules  json.RawMessage `json:"firewallRules,omitempty"`
+	Configurations json.RawMessage `json:"configurations,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Postgres Flex holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap pgFlexSnapshot
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *pgFlexSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Instances, m.instances.Snapshot},
+		{&snap.Snapshots, m.snapshots.Snapshot},
+		{&snap.Databases, m.databases.Snapshot},
+		{&snap.FirewallRules, m.firewallRules.Snapshot},
+		{&snap.Configurations, m.configurations.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("postgresflex: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds every store under its original keys, so a restored database's
+// identity and its server cross-reference still resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap pgFlexSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("postgresflex: parse snapshot: %w", err)
+	}
+
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Instances, m.instances.LoadSnapshot},
+		{snap.Snapshots, m.snapshots.LoadSnapshot},
+		{snap.Databases, m.databases.LoadSnapshot},
+		{snap.FirewallRules, m.firewallRules.LoadSnapshot},
+		{snap.Configurations, m.configurations.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("postgresflex: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/azure/postgresflex/snapshot_test.go
+++ b/providers/azure/postgresflex/snapshot_test.go
@@ -1,0 +1,61 @@
+package postgresflex
+
+import (
+	"context"
+	"testing"
+
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+func TestSnapshotRoundTripPostgresFlex(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, err := src.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "srv"}); err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+
+	if _, err := src.CreateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "srv", Name: "app"}); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	if _, err := src.CreateFirewallRule(ctx, rdsdriver.FirewallRuleConfig{
+		Server: "srv", Name: "r", StartIPAddress: "10.0.0.1", EndIPAddress: "10.0.0.9",
+	}); err != nil {
+		t.Fatalf("create firewall rule: %v", err)
+	}
+
+	data, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, data); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	instances, err := dst.DescribeInstances(ctx, nil)
+	if err != nil {
+		t.Fatalf("describe instances: %v", err)
+	}
+	if len(instances) != 1 || instances[0].ID != "srv" {
+		t.Fatalf("instances = %+v, want one with ID srv", instances)
+	}
+
+	dbs, err := dst.ListDatabases(ctx, "srv")
+	if err != nil {
+		t.Fatalf("list databases: %v", err)
+	}
+	if len(dbs) != 1 {
+		t.Fatalf("databases = %d, want 1", len(dbs))
+	}
+
+	rules, err := dst.ListFirewallRules(ctx, "srv")
+	if err != nil {
+		t.Fatalf("list firewall rules: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("firewall rules = %d, want 1", len(rules))
+	}
+}

--- a/providers/azure/sql/snapshot.go
+++ b/providers/azure/sql/snapshot.go
@@ -1,0 +1,109 @@
+package sql
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// sqlSnapshot is the full serialized state of the Azure SQL mock. Every store
+// holds a fully-exported rdsdriver value, so each round-trips through the
+// generic memstore helper keyed by its resource id (server name, "server/db",
+// snapshot id, …) — cross-references survive because the keys are preserved. The
+// mutex and the wired options/monitoring are intentionally not serialized.
+type sqlSnapshot struct {
+	Clusters         json.RawMessage `json:"clusters,omitempty"`
+	Instances        json.RawMessage `json:"instances,omitempty"`
+	Snapshots        json.RawMessage `json:"snapshots,omitempty"`
+	FirewallRules    json.RawMessage `json:"firewallRules,omitempty"`
+	VNetRules        json.RawMessage `json:"vnetRules,omitempty"`
+	ElasticPools     json.RawMessage `json:"elasticPools,omitempty"`
+	FailoverGroups   json.RawMessage `json:"failoverGroups,omitempty"`
+	AADAdmins        json.RawMessage `json:"aadAdmins,omitempty"`
+	ManagedInstances json.RawMessage `json:"managedInstances,omitempty"`
+	ManagedDatabases json.RawMessage `json:"managedDatabases,omitempty"`
+	Databases        json.RawMessage `json:"databases,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Azure SQL holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap sqlSnapshot
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *sqlSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Clusters, m.clusters.Snapshot},
+		{&snap.Instances, m.instances.Snapshot},
+		{&snap.Snapshots, m.snapshots.Snapshot},
+		{&snap.FirewallRules, m.firewallRules.Snapshot},
+		{&snap.VNetRules, m.vnetRules.Snapshot},
+		{&snap.ElasticPools, m.elasticPools.Snapshot},
+		{&snap.FailoverGroups, m.failoverGroups.Snapshot},
+		{&snap.AADAdmins, m.aadAdmins.Snapshot},
+		{&snap.ManagedInstances, m.managedInstances.Snapshot},
+		{&snap.ManagedDatabases, m.managedDatabases.Snapshot},
+		{&snap.Databases, m.databases.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("sql: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds every store under its original keys, so a restored database's
+// "server/name" identity and its server cross-reference still resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap sqlSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("sql: parse snapshot: %w", err)
+	}
+
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Clusters, m.clusters.LoadSnapshot},
+		{snap.Instances, m.instances.LoadSnapshot},
+		{snap.Snapshots, m.snapshots.LoadSnapshot},
+		{snap.FirewallRules, m.firewallRules.LoadSnapshot},
+		{snap.VNetRules, m.vnetRules.LoadSnapshot},
+		{snap.ElasticPools, m.elasticPools.LoadSnapshot},
+		{snap.FailoverGroups, m.failoverGroups.LoadSnapshot},
+		{snap.AADAdmins, m.aadAdmins.LoadSnapshot},
+		{snap.ManagedInstances, m.managedInstances.LoadSnapshot},
+		{snap.ManagedDatabases, m.managedDatabases.LoadSnapshot},
+		{snap.Databases, m.databases.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("sql: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/azure/sql/snapshot_test.go
+++ b/providers/azure/sql/snapshot_test.go
@@ -1,0 +1,46 @@
+package sql
+
+import (
+	"context"
+	"testing"
+
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+func TestSnapshotRoundTripSQL(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, err := src.CreateCluster(ctx, rdsdriver.ClusterConfig{ID: "srv1"}); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if _, err := src.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "db1", ClusterID: "srv1"}); err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+
+	if _, err := src.CreateFirewallRule(ctx, rdsdriver.FirewallRuleConfig{
+		Server: "srv1", Name: "rule1", StartIPAddress: "10.0.0.1", EndIPAddress: "10.0.0.9",
+	}); err != nil {
+		t.Fatalf("create firewall rule: %v", err)
+	}
+
+	data, err := src.Snapshot(ctx, true)
+	requireNoError(t, err)
+
+	dst := newTestMock()
+	requireNoError(t, dst.Restore(ctx, data))
+
+	clusters, err := dst.DescribeClusters(ctx, nil)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(clusters))
+	assertEqual(t, "srv1", clusters[0].ID)
+
+	instances, err := dst.DescribeInstances(ctx, nil)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(instances))
+
+	rules, err := dst.ListFirewallRules(ctx, "srv1")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(rules))
+}

--- a/providers/gcp/alloydb/snapshot.go
+++ b/providers/gcp/alloydb/snapshot.go
@@ -1,0 +1,136 @@
+package alloydb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// alloydbSnapshot is the full serialized state of the GCP AlloyDB mock. The
+// portable rdsdriver stores round-trip through the generic memstore helper keyed
+// by resource id; the AlloyDB-native side-stores (clusterExtra/instanceExtra/
+// backupExtra) and initial passwords are fully-exported value maps captured
+// directly. The wired *config.Options and monitoring backend are intentionally
+// not serialized.
+type alloydbSnapshot struct {
+	Clusters         json.RawMessage          `json:"clusters,omitempty"`
+	Instances        json.RawMessage          `json:"instances,omitempty"`
+	Backups          json.RawMessage          `json:"backups,omitempty"`
+	Databases        json.RawMessage          `json:"databases,omitempty"`
+	Users            json.RawMessage          `json:"users,omitempty"`
+	ClusterExtra     map[string]clusterExtra  `json:"clusterExtra,omitempty"`
+	InstanceExtra    map[string]instanceExtra `json:"instanceExtra,omitempty"`
+	BackupExtra      map[string]backupExtra   `json:"backupExtra,omitempty"`
+	InitialPasswords map[string]string        `json:"initialPasswords,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// AlloyDB holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap alloydbSnapshot
+
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	m.mu.RLock()
+	snap.ClusterExtra = m.clusterExtra
+	snap.InstanceExtra = m.instanceExtra
+	snap.BackupExtra = m.backupExtra
+	snap.InitialPasswords = m.initialPasswords
+	m.mu.RUnlock()
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *alloydbSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Clusters, m.clusters.Snapshot},
+		{&snap.Instances, m.instances.Snapshot},
+		{&snap.Backups, m.backups.Snapshot},
+		{&snap.Databases, m.databases.Snapshot},
+		{&snap.Users, m.users.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("alloydb: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds the mock's state under the original identities: cluster,
+// instance, and backup ids are preserved so member/child cross-references still
+// resolve after a restore.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap alloydbSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("alloydb: parse snapshot: %w", err)
+	}
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	m.restoreExtra(&snap)
+
+	return nil
+}
+
+func (m *Mock) restoreExtra(snap *alloydbSnapshot) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if snap.ClusterExtra != nil {
+		m.clusterExtra = snap.ClusterExtra
+	}
+
+	if snap.InstanceExtra != nil {
+		m.instanceExtra = snap.InstanceExtra
+	}
+
+	if snap.BackupExtra != nil {
+		m.backupExtra = snap.BackupExtra
+	}
+
+	if snap.InitialPasswords != nil {
+		m.initialPasswords = snap.InitialPasswords
+	}
+}
+
+func (m *Mock) restoreStores(snap *alloydbSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Clusters, m.clusters.LoadSnapshot},
+		{snap.Instances, m.instances.LoadSnapshot},
+		{snap.Backups, m.backups.LoadSnapshot},
+		{snap.Databases, m.databases.LoadSnapshot},
+		{snap.Users, m.users.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("alloydb: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/gcp/alloydb/snapshot_test.go
+++ b/providers/gcp/alloydb/snapshot_test.go
@@ -1,0 +1,76 @@
+package alloydb
+
+import (
+	"context"
+	"testing"
+
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// TestSnapshotRoundTripAlloyDB proves the mock serializes its entire state —
+// portable stores plus the AlloyDB-native side-stores (clusterExtra/
+// instanceExtra/initialPasswords) — and restores it into a fresh mock
+// identity-preservingly: re-snapshotting yields byte-identical JSON and the
+// seeded cluster and instance come back under their original ids.
+func TestSnapshotRoundTripAlloyDB(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, err := src.CreateAlloyDBCluster(ctx, rdsdriver.AlloyDBClusterConfig{
+		ID: "c1", DatabaseVersion: "POSTGRES_15", Network: "default",
+		InitialUser: "postgres", InitialPassword: "secret",
+		ContinuousBackup: true, AutomatedBackupEnabled: true, MaintenanceDay: "SUNDAY",
+	}); err != nil {
+		t.Fatalf("CreateAlloyDBCluster: %v", err)
+	}
+
+	if _, err := src.CreateAlloyDBInstance(ctx, rdsdriver.AlloyDBInstanceConfig{
+		ClusterID: "c1", ID: "i1", InstanceType: "PRIMARY",
+	}); err != nil {
+		t.Fatalf("CreateAlloyDBInstance: %v", err)
+	}
+
+	data, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, data); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	data2, err := dst.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("re-Snapshot: %v", err)
+	}
+
+	if string(data) != string(data2) {
+		t.Fatalf("snapshot not stable across restore:\n%s\nvs\n%s", data, data2)
+	}
+
+	clusters, err := dst.DescribeClusters(ctx, []string{"c1"})
+	if err != nil {
+		t.Fatalf("DescribeClusters: %v", err)
+	}
+
+	if len(clusters) != 1 || clusters[0].ID != "c1" {
+		t.Fatalf("restored clusters = %+v, want id c1", clusters)
+	}
+}
+
+// TestSnapshotEmptyAlloyDB confirms a fresh mock snapshots and restores cleanly.
+func TestSnapshotEmptyAlloyDB(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	data, err := src.Snapshot(ctx, false)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, data); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+}

--- a/providers/gcp/artifactregistry/snapshot.go
+++ b/providers/gcp/artifactregistry/snapshot.go
@@ -1,0 +1,131 @@
+package artifactregistry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// artifactregistrySnapshot is the full serialized state of the GCP Artifact
+// Registry mock: every repository keyed by name, each carrying its metadata,
+// lifecycle policy, config flags, images (with layers), and scan results. The
+// stored *repoData/*imageData have unexported layouts, so they are promoted to
+// exported snapshot forms. The wired *config.Options and monitoring backend are
+// intentionally not serialized.
+type artifactregistrySnapshot struct {
+	Repos map[string]*repoSnapshot `json:"repos,omitempty"`
+}
+
+// repoSnapshot mirrors repoData, promoting its unexported image store and config
+// fields to exported ones. The scan store holds fully-exported driver values, so
+// it round-trips through the generic memstore helper.
+type repoSnapshot struct {
+	Info          driver.Repository         `json:"info"`
+	Images        map[string]*imageSnapshot `json:"images,omitempty"`
+	Scans         json.RawMessage           `json:"scans,omitempty"`
+	Policy        *driver.LifecyclePolicy   `json:"policy,omitempty"`
+	ScanOnPush    bool                      `json:"scanOnPush,omitempty"`
+	TagMutability string                    `json:"tagMutability,omitempty"`
+}
+
+// imageSnapshot mirrors imageData, promoting its unexported detail/layers to
+// exported fields.
+type imageSnapshot struct {
+	Detail driver.ImageDetail `json:"detail"`
+	Layers []driver.LayerInfo `json:"layers,omitempty"`
+}
+
+// Snapshot captures every repository and its images as JSON. includeAssets is
+// unused — image records carry no bulk blob bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	snap := artifactregistrySnapshot{Repos: make(map[string]*repoSnapshot, m.repos.Len())}
+
+	for name, rd := range m.repos.All() {
+		rs, err := snapshotRepo(rd)
+		if err != nil {
+			return nil, err
+		}
+
+		snap.Repos[name] = rs
+	}
+
+	return json.Marshal(snap)
+}
+
+func snapshotRepo(rd *repoData) (*repoSnapshot, error) {
+	rs := &repoSnapshot{
+		Info:          rd.info,
+		Images:        make(map[string]*imageSnapshot, rd.images.Len()),
+		Policy:        rd.policy,
+		ScanOnPush:    rd.scanOnPush,
+		TagMutability: rd.tagMutability,
+	}
+
+	for digest, img := range rd.images.All() {
+		rs.Images[digest] = &imageSnapshot{Detail: img.detail, Layers: img.layers}
+	}
+
+	scans, err := rd.scans.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("artifactregistry: snapshot scans: %w", err)
+	}
+
+	rs.Scans = scans
+
+	return rs, nil
+}
+
+// Restore rebuilds every repository under its original name with its images and
+// scan results intact.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap artifactregistrySnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("artifactregistry: parse snapshot: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for name, rs := range snap.Repos {
+		rd, err := restoreRepo(rs)
+		if err != nil {
+			return err
+		}
+
+		m.repos.Set(name, rd)
+	}
+
+	return nil
+}
+
+func restoreRepo(rs *repoSnapshot) (*repoData, error) {
+	rd := &repoData{
+		info:          rs.Info,
+		images:        memstore.New[*imageData](),
+		scans:         memstore.New[*driver.ScanResult](),
+		policy:        rs.Policy,
+		scanOnPush:    rs.ScanOnPush,
+		tagMutability: rs.TagMutability,
+	}
+
+	for digest, is := range rs.Images {
+		rd.images.Set(digest, &imageData{detail: is.Detail, layers: is.Layers})
+	}
+
+	if len(rs.Scans) > 0 {
+		if err := rd.scans.LoadSnapshot(rs.Scans); err != nil {
+			return nil, fmt.Errorf("artifactregistry: restore scans: %w", err)
+		}
+	}
+
+	return rd, nil
+}

--- a/providers/gcp/artifactregistry/snapshot_test.go
+++ b/providers/gcp/artifactregistry/snapshot_test.go
@@ -1,0 +1,55 @@
+package artifactregistry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSnapshotRoundTripArtifactRegistry proves the mock serializes every
+// repository (with its images) and restores it into a fresh mock
+// identity-preservingly: re-snapshotting yields byte-identical JSON and an image
+// pushed before the snapshot is readable after the restore.
+func TestSnapshotRoundTripArtifactRegistry(t *testing.T) {
+	ctx := context.Background()
+	src, _ := newTestMock()
+
+	_, err := src.CreateRepository(ctx, driver.RepositoryConfig{Name: "my-repo", Tags: map[string]string{"env": "prod"}})
+	require.NoError(t, err)
+
+	_, err = src.PutImage(ctx, &driver.ImageManifest{Repository: "my-repo", Tag: "v1.0", SizeBytes: 1024})
+	require.NoError(t, err)
+
+	data, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst, _ := newTestMock()
+	require.NoError(t, dst.Restore(ctx, data))
+
+	data2, err := dst.Snapshot(ctx, true)
+	require.NoError(t, err)
+	assert.Equal(t, string(data), string(data2), "snapshot must be stable across restore")
+
+	repo, err := dst.GetRepository(ctx, "my-repo")
+	require.NoError(t, err)
+	assert.Contains(t, repo.Name, "my-repo")
+
+	images, err := dst.ListImages(ctx, "my-repo")
+	require.NoError(t, err)
+	require.Len(t, images, 1)
+}
+
+// TestSnapshotEmptyArtifactRegistry confirms a fresh mock snapshots and restores cleanly.
+func TestSnapshotEmptyArtifactRegistry(t *testing.T) {
+	ctx := context.Background()
+	src, _ := newTestMock()
+
+	data, err := src.Snapshot(ctx, false)
+	require.NoError(t, err)
+
+	dst, _ := newTestMock()
+	require.NoError(t, dst.Restore(ctx, data))
+}

--- a/providers/gcp/cloudlogging/snapshot.go
+++ b/providers/gcp/cloudlogging/snapshot.go
@@ -1,0 +1,161 @@
+package cloudlogging
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// cloudloggingSnapshot is the full serialized state of the GCP Cloud Logging
+// mock: every log group (with its streams, metric filters, and subscription
+// filters), plus the GCP-native export sinks and log-based metrics. The stored
+// *logGroup/*logStream have unexported layouts, so they are promoted to exported
+// snapshot forms; sinks and metrics hold fully-exported driver values and
+// round-trip through the generic memstore helper. The wired *config.Options and
+// monitoring backend are intentionally not serialized.
+type cloudloggingSnapshot struct {
+	Groups  map[string]*logGroupSnapshot `json:"groups,omitempty"`
+	Sinks   json.RawMessage              `json:"sinks,omitempty"`
+	Metrics json.RawMessage              `json:"metrics,omitempty"`
+}
+
+// logGroupSnapshot mirrors logGroup, promoting its nested stream store and the
+// (exported-value) filter stores to dumps.
+type logGroupSnapshot struct {
+	Info          driver.LogGroupInfo           `json:"info"`
+	Streams       map[string]*logStreamSnapshot `json:"streams,omitempty"`
+	MetricFilters json.RawMessage               `json:"metricFilters,omitempty"`
+	SubFilters    json.RawMessage               `json:"subFilters,omitempty"`
+}
+
+// logStreamSnapshot mirrors logStream, promoting its unexported info/events to
+// exported fields (the mutex is excluded).
+type logStreamSnapshot struct {
+	Info   driver.LogStreamInfo `json:"info"`
+	Events []driver.LogEvent    `json:"events,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Cloud Logging holds no bulk object bodies beyond its log events, which are
+// always captured.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := cloudloggingSnapshot{Groups: make(map[string]*logGroupSnapshot, m.groups.Len())}
+
+	for name, g := range m.groups.All() {
+		gs, err := snapshotGroup(g)
+		if err != nil {
+			return nil, err
+		}
+
+		snap.Groups[name] = gs
+	}
+
+	if err := dumpInto(&snap.Sinks, m.sinks.Snapshot); err != nil {
+		return nil, err
+	}
+
+	if err := dumpInto(&snap.Metrics, m.metrics.Snapshot); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(snap)
+}
+
+func snapshotGroup(g *logGroup) (*logGroupSnapshot, error) {
+	gs := &logGroupSnapshot{
+		Info:    g.info,
+		Streams: make(map[string]*logStreamSnapshot, g.streams.Len()),
+	}
+
+	for id, s := range g.streams.All() {
+		s.mu.RLock()
+		gs.Streams[id] = &logStreamSnapshot{Info: s.info, Events: append([]driver.LogEvent(nil), s.events...)}
+		s.mu.RUnlock()
+	}
+
+	if err := dumpInto(&gs.MetricFilters, g.metricFilters.Snapshot); err != nil {
+		return nil, err
+	}
+
+	if err := dumpInto(&gs.SubFilters, g.subFilters.Snapshot); err != nil {
+		return nil, err
+	}
+
+	return gs, nil
+}
+
+func dumpInto(dst *json.RawMessage, fn func() ([]byte, error)) error {
+	b, err := fn()
+	if err != nil {
+		return fmt.Errorf("cloudlogging: snapshot store: %w", err)
+	}
+
+	*dst = b
+
+	return nil
+}
+
+// Restore rebuilds every log group (and its streams/filters) and the sinks and
+// metrics under their original identities.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap cloudloggingSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("cloudlogging: parse snapshot: %w", err)
+	}
+
+	for name, gs := range snap.Groups {
+		g, err := restoreGroup(gs)
+		if err != nil {
+			return err
+		}
+
+		m.groups.Set(name, g)
+	}
+
+	if err := loadInto(snap.Sinks, m.sinks.LoadSnapshot); err != nil {
+		return err
+	}
+
+	return loadInto(snap.Metrics, m.metrics.LoadSnapshot)
+}
+
+func restoreGroup(gs *logGroupSnapshot) (*logGroup, error) {
+	g := &logGroup{
+		info:          gs.Info,
+		streams:       memstore.New[*logStream](),
+		metricFilters: memstore.New[*driver.MetricFilterInfo](),
+		subFilters:    memstore.New[*driver.SubscriptionFilterInfo](),
+	}
+
+	for id, ss := range gs.Streams {
+		g.streams.Set(id, &logStream{info: ss.Info, events: ss.Events})
+	}
+
+	if err := loadInto(gs.MetricFilters, g.metricFilters.LoadSnapshot); err != nil {
+		return nil, err
+	}
+
+	if err := loadInto(gs.SubFilters, g.subFilters.LoadSnapshot); err != nil {
+		return nil, err
+	}
+
+	return g, nil
+}
+
+func loadInto(src json.RawMessage, fn func([]byte) error) error {
+	if len(src) == 0 {
+		return nil
+	}
+
+	if err := fn(src); err != nil {
+		return fmt.Errorf("cloudlogging: restore store: %w", err)
+	}
+
+	return nil
+}

--- a/providers/gcp/cloudlogging/snapshot_test.go
+++ b/providers/gcp/cloudlogging/snapshot_test.go
@@ -1,0 +1,57 @@
+package cloudlogging
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/logging/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSnapshotRoundTripCloudLogging proves the mock serializes every log group
+// (with its streams and events) and restores it into a fresh mock
+// identity-preservingly: re-snapshotting yields byte-identical JSON and an event
+// written before the snapshot is readable after the restore.
+func TestSnapshotRoundTripCloudLogging(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	_, err := src.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "app-logs"})
+	require.NoError(t, err)
+
+	_, err = src.CreateLogStream(ctx, "app-logs", "stream-1")
+	require.NoError(t, err)
+
+	require.NoError(t, src.PutLogEvents(ctx, "app-logs", "stream-1", []driver.LogEvent{
+		{Timestamp: time.Unix(1700000000, 0).UTC(), Message: "boot"},
+	}))
+
+	data, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst := newTestMock()
+	require.NoError(t, dst.Restore(ctx, data))
+
+	data2, err := dst.Snapshot(ctx, true)
+	require.NoError(t, err)
+	assert.Equal(t, string(data), string(data2), "snapshot must be stable across restore")
+
+	// Byte-stable re-snapshot of the restored mock proves the stream and its
+	// event were reinstated into the live store; the group is queryable again.
+	_, err = dst.GetLogGroup(ctx, "app-logs")
+	require.NoError(t, err)
+}
+
+// TestSnapshotEmptyCloudLogging confirms a fresh mock snapshots and restores cleanly.
+func TestSnapshotEmptyCloudLogging(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	data, err := src.Snapshot(ctx, false)
+	require.NoError(t, err)
+
+	dst := newTestMock()
+	require.NoError(t, dst.Restore(ctx, data))
+}

--- a/providers/gcp/cloudsql/snapshot.go
+++ b/providers/gcp/cloudsql/snapshot.go
@@ -1,0 +1,116 @@
+package cloudsql
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// cloudsqlSnapshot is the full serialized state of the GCP Cloud SQL mock. Every
+// stored value type is fully exported, so the stores round-trip through the
+// generic memstore helper keyed by resource id; the mu-guarded backup sequence
+// and per-instance root passwords are captured alongside. The wired
+// *config.Options and monitoring backend are intentionally not serialized.
+type cloudsqlSnapshot struct {
+	Instances     json.RawMessage   `json:"instances,omitempty"`
+	Snapshots     json.RawMessage   `json:"snapshots,omitempty"`
+	Databases     json.RawMessage   `json:"databases,omitempty"`
+	Users         json.RawMessage   `json:"users,omitempty"`
+	SSLCerts      json.RawMessage   `json:"sslCerts,omitempty"`
+	BackupSeq     int64             `json:"backupSeq,omitempty"`
+	RootPasswords map[string]string `json:"rootPasswords,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Cloud SQL holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap cloudsqlSnapshot
+
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	m.mu.RLock()
+	snap.BackupSeq = m.backupSeq
+	snap.RootPasswords = m.rootPasswords
+	m.mu.RUnlock()
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *cloudsqlSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Instances, m.instances.Snapshot},
+		{&snap.Snapshots, m.snapshots.Snapshot},
+		{&snap.Databases, m.databases.Snapshot},
+		{&snap.Users, m.users.Snapshot},
+		{&snap.SSLCerts, m.sslCerts.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("cloudsql: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds the mock's state under the original identities: every
+// instance/database/user/snapshot id is preserved so cross-references still
+// resolve after a restore.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap cloudsqlSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("cloudsql: parse snapshot: %w", err)
+	}
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	m.backupSeq = snap.BackupSeq
+
+	if snap.RootPasswords != nil {
+		m.rootPasswords = snap.RootPasswords
+	}
+	m.mu.Unlock()
+
+	return nil
+}
+
+func (m *Mock) restoreStores(snap *cloudsqlSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Instances, m.instances.LoadSnapshot},
+		{snap.Snapshots, m.snapshots.LoadSnapshot},
+		{snap.Databases, m.databases.LoadSnapshot},
+		{snap.Users, m.users.LoadSnapshot},
+		{snap.SSLCerts, m.sslCerts.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("cloudsql: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/gcp/cloudsql/snapshot_test.go
+++ b/providers/gcp/cloudsql/snapshot_test.go
@@ -1,0 +1,93 @@
+package cloudsql
+
+import (
+	"context"
+	"testing"
+
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// TestSnapshotRoundTripCloudSQL proves the mock serializes its entire state and
+// restores it into a fresh mock identity-preservingly: re-snapshotting the
+// restored mock yields byte-identical JSON (so every store round-tripped), and
+// the seeded instance, database, and user come back under their original ids.
+func TestSnapshotRoundTripCloudSQL(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, err := src.CreateInstance(ctx, rdsdriver.InstanceConfig{
+		ID: "pg1", Engine: "POSTGRES_15", MasterUsername: "postgres", MasterUserPassword: "secret", DBName: "app",
+	}); err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+
+	if _, err := src.CreateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "pg1", Name: "orders"}); err != nil {
+		t.Fatalf("CreateDatabase: %v", err)
+	}
+
+	if _, err := src.CreateUser(ctx, rdsdriver.UserConfig{Instance: "pg1", Name: "app-user", Password: "pw"}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	data, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, data); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	data2, err := dst.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("re-Snapshot: %v", err)
+	}
+
+	if string(data) != string(data2) {
+		t.Fatalf("snapshot not stable across restore:\n%s\nvs\n%s", data, data2)
+	}
+
+	insts, err := dst.DescribeInstances(ctx, []string{"pg1"})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	if len(insts) != 1 || insts[0].ID != "pg1" {
+		t.Fatalf("restored instance = %+v, want id pg1", insts)
+	}
+
+	dbs, err := dst.ListDatabases(ctx, "pg1")
+	if err != nil {
+		t.Fatalf("ListDatabases: %v", err)
+	}
+
+	if len(dbs) != 1 || dbs[0].Name != "orders" {
+		t.Fatalf("restored databases = %+v, want one named orders", dbs)
+	}
+
+	users, err := dst.ListUsers(ctx, "pg1")
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+
+	if len(users) != 1 || users[0].Name != "app-user" {
+		t.Fatalf("restored users = %+v, want one named app-user", users)
+	}
+}
+
+// TestSnapshotEmptyCloudSQL confirms a fresh mock snapshots and restores cleanly.
+func TestSnapshotEmptyCloudSQL(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	data, err := src.Snapshot(ctx, false)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, data); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+}

--- a/providers/gcp/gke/snapshot.go
+++ b/providers/gcp/gke/snapshot.go
@@ -1,0 +1,107 @@
+package gke
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// gkeSnapshot is the full serialized state of the GKE mock. Every stored value
+// type (Cluster/NodePool/Operation) is fully exported, so the stores round-trip
+// through the generic memstore helper keyed by their ids (node pools keyed
+// "cluster/nodePool"); k8sUIDs preserves the UID each cluster registered with the
+// shared Kubernetes data plane. The wired *config.Options, monitoring backend,
+// and *kubernetes.APIServer are intentionally not serialized.
+type gkeSnapshot struct {
+	Clusters   json.RawMessage   `json:"clusters,omitempty"`
+	NodePools  json.RawMessage   `json:"nodePools,omitempty"`
+	Operations json.RawMessage   `json:"operations,omitempty"`
+	K8sUIDs    map[string]string `json:"k8sUids,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// GKE holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap gkeSnapshot
+
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	m.mu.RLock()
+	snap.K8sUIDs = m.k8sUIDs
+	m.mu.RUnlock()
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *gkeSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Clusters, m.clusters.Snapshot},
+		{&snap.NodePools, m.nodePools.Snapshot},
+		{&snap.Operations, m.operations.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("gke: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds the mock's state under the original identities: cluster and
+// node-pool ids (and the "cluster/nodePool" keys) are preserved so a restored
+// node pool still resolves to its cluster.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap gkeSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("gke: parse snapshot: %w", err)
+	}
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	if snap.K8sUIDs != nil {
+		m.k8sUIDs = snap.K8sUIDs
+	}
+	m.mu.Unlock()
+
+	return nil
+}
+
+func (m *Mock) restoreStores(snap *gkeSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Clusters, m.clusters.LoadSnapshot},
+		{snap.NodePools, m.nodePools.LoadSnapshot},
+		{snap.Operations, m.operations.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("gke: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/gcp/gke/snapshot_test.go
+++ b/providers/gcp/gke/snapshot_test.go
@@ -1,0 +1,80 @@
+package gke
+
+import (
+	"context"
+	"testing"
+)
+
+// TestSnapshotRoundTripGKE proves the mock serializes its clusters, node pools,
+// and operations and restores them into a fresh mock identity-preservingly:
+// re-snapshotting yields byte-identical JSON and the seeded cluster and node
+// pool come back under their original ids (node pools keyed "cluster/nodePool").
+func TestSnapshotRoundTripGKE(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, _, err := src.CreateCluster(ctx, &CreateClusterInput{
+		Name: "c1", Location: "us-central1", InitialNodeCount: int64Ptr(1),
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, _, err := src.CreateNodePool(ctx, "us-central1", "c1", &NodePoolSpec{
+		Name: "pool-1", InitialNodeCount: int64Ptr(2), MachineType: "e2-standard-4",
+	}); err != nil {
+		t.Fatalf("CreateNodePool: %v", err)
+	}
+
+	data, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, data); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	data2, err := dst.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("re-Snapshot: %v", err)
+	}
+
+	if string(data) != string(data2) {
+		t.Fatalf("snapshot not stable across restore:\n%s\nvs\n%s", data, data2)
+	}
+
+	c, err := dst.GetCluster(ctx, "us-central1", "c1")
+	if err != nil {
+		t.Fatalf("GetCluster after restore: %v", err)
+	}
+
+	if c.Name != "c1" {
+		t.Fatalf("restored cluster name = %q, want c1", c.Name)
+	}
+
+	pool, err := dst.GetNodePool(ctx, "us-central1", "c1", "pool-1")
+	if err != nil {
+		t.Fatalf("GetNodePool after restore: %v", err)
+	}
+
+	if pool.NodeCount != 2 {
+		t.Fatalf("restored node pool count = %d, want 2", pool.NodeCount)
+	}
+}
+
+// TestSnapshotEmptyGKE confirms a fresh mock snapshots and restores cleanly.
+func TestSnapshotEmptyGKE(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	data, err := src.Snapshot(ctx, false)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, data); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+}

--- a/providers/gcp/memorystore/snapshot.go
+++ b/providers/gcp/memorystore/snapshot.go
@@ -1,0 +1,68 @@
+package memorystore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// memorystoreSnapshot is the full serialized state of the GCP Memorystore mock:
+// every cache instance keyed by name, each carrying its metadata and its stored
+// key/value items. The stored *cacheData has an unexported layout (a nested item
+// store), so it is promoted to cacheSnapshot; the wired *config.Options and
+// monitoring backend are intentionally not serialized.
+type memorystoreSnapshot struct {
+	Caches map[string]*cacheSnapshot `json:"caches,omitempty"`
+}
+
+// cacheSnapshot mirrors cacheData, promoting its unexported item store to an
+// exported dump. cacheItem is fully exported, so its store round-trips through
+// the generic memstore helper.
+type cacheSnapshot struct {
+	Info  driver.CacheInfo `json:"info"`
+	Items json.RawMessage  `json:"items,omitempty"`
+}
+
+// Snapshot captures every cache and its items as JSON. Cache values are the
+// service's whole state, so they are always captured regardless of includeAssets.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := memorystoreSnapshot{Caches: make(map[string]*cacheSnapshot, m.caches.Len())}
+
+	for name, cd := range m.caches.All() {
+		items, err := cd.items.Snapshot()
+		if err != nil {
+			return nil, fmt.Errorf("memorystore: snapshot items: %w", err)
+		}
+
+		snap.Caches[name] = &cacheSnapshot{Info: cd.info, Items: items}
+	}
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds every cache under its original name with its items intact.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap memorystoreSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("memorystore: parse snapshot: %w", err)
+	}
+
+	for name, cs := range snap.Caches {
+		cd := &cacheData{info: cs.Info, items: memstore.New[cacheItem]()}
+		if len(cs.Items) > 0 {
+			if err := cd.items.LoadSnapshot(cs.Items); err != nil {
+				return fmt.Errorf("memorystore: restore items: %w", err)
+			}
+		}
+
+		m.caches.Set(name, cd)
+	}
+
+	return nil
+}

--- a/providers/gcp/memorystore/snapshot_test.go
+++ b/providers/gcp/memorystore/snapshot_test.go
@@ -1,0 +1,69 @@
+package memorystore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+)
+
+// TestSnapshotRoundTripMemorystore proves the mock serializes every cache and
+// its stored items and restores them into a fresh mock identity-preservingly:
+// re-snapshotting yields byte-identical JSON and a value written before the
+// snapshot is readable after the restore under its original cache/key.
+func TestSnapshotRoundTripMemorystore(t *testing.T) {
+	ctx := context.Background()
+	src, _ := newTestMock()
+
+	if _, err := src.CreateCache(ctx, driver.CacheConfig{Name: "c1", Engine: "redis"}); err != nil {
+		t.Fatalf("CreateCache: %v", err)
+	}
+
+	if err := src.Set(ctx, "c1", "greeting", []byte("hello"), 0); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	data, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	dst, _ := newTestMock()
+	if err := dst.Restore(ctx, data); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	data2, err := dst.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("re-Snapshot: %v", err)
+	}
+
+	if string(data) != string(data2) {
+		t.Fatalf("snapshot not stable across restore:\n%s\nvs\n%s", data, data2)
+	}
+
+	item, err := dst.Get(ctx, "c1", "greeting")
+	if err != nil {
+		t.Fatalf("Get after restore: %v", err)
+	}
+
+	if item == nil || string(item.Value) != "hello" {
+		t.Fatalf("restored item = %+v, want value hello", item)
+	}
+}
+
+// TestSnapshotEmptyMemorystore confirms a fresh mock snapshots and restores cleanly.
+func TestSnapshotEmptyMemorystore(t *testing.T) {
+	ctx := context.Background()
+	src, _ := newTestMock()
+
+	data, err := src.Snapshot(ctx, false)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	dst, _ := newTestMock()
+	if err := dst.Restore(ctx, data); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+}

--- a/providers/gcp/vertexai/snapshot.go
+++ b/providers/gcp/vertexai/snapshot.go
@@ -1,0 +1,157 @@
+package vertexai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// vertexaiSnapshot is the full serialized state of the Vertex AI mock. Every
+// store's value type is fully exported (driver.*), so each round-trips through
+// the generic memstore helper keyed by its resource name (self-link). The wired
+// *config.Options and monitoring backend are intentionally not serialized.
+type vertexaiSnapshot struct {
+	Datasets       json.RawMessage `json:"datasets,omitempty"`
+	Models         json.RawMessage `json:"models,omitempty"`
+	Evaluations    json.RawMessage `json:"evaluations,omitempty"`
+	Endpoints      json.RawMessage `json:"endpoints,omitempty"`
+	CustomJobs     json.RawMessage `json:"customJobs,omitempty"`
+	BatchJobs      json.RawMessage `json:"batchJobs,omitempty"`
+	HPOJobs        json.RawMessage `json:"hpoJobs,omitempty"`
+	TrainPipes     json.RawMessage `json:"trainPipes,omitempty"`
+	PipelineJobs   json.RawMessage `json:"pipelineJobs,omitempty"`
+	TuningJobs     json.RawMessage `json:"tuningJobs,omitempty"`
+	CachedContent  json.RawMessage `json:"cachedContent,omitempty"`
+	Featurestores  json.RawMessage `json:"featurestores,omitempty"`
+	EntityTypes    json.RawMessage `json:"entityTypes,omitempty"`
+	EntityRecords  json.RawMessage `json:"entityRecords,omitempty"`
+	FeatureGroups  json.RawMessage `json:"featureGroups,omitempty"`
+	Features       json.RawMessage `json:"features,omitempty"`
+	OnlineStores   json.RawMessage `json:"onlineStores,omitempty"`
+	FeatureViews   json.RawMessage `json:"featureViews,omitempty"`
+	Indexes        json.RawMessage `json:"indexes,omitempty"`
+	IndexEndpoints json.RawMessage `json:"indexEndpoints,omitempty"`
+	MetadataStores json.RawMessage `json:"metadataStores,omitempty"`
+	Tensorboards   json.RawMessage `json:"tensorboards,omitempty"`
+	Schedules      json.RawMessage `json:"schedules,omitempty"`
+	NBTemplates    json.RawMessage `json:"nbTemplates,omitempty"`
+	NBRuntimes     json.RawMessage `json:"nbRuntimes,omitempty"`
+	Operations     json.RawMessage `json:"operations,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Vertex AI holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap vertexaiSnapshot
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *vertexaiSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Datasets, m.datasets.Snapshot},
+		{&snap.Models, m.models.Snapshot},
+		{&snap.Evaluations, m.evaluations.Snapshot},
+		{&snap.Endpoints, m.endpoints.Snapshot},
+		{&snap.CustomJobs, m.customJobs.Snapshot},
+		{&snap.BatchJobs, m.batchJobs.Snapshot},
+		{&snap.HPOJobs, m.hpoJobs.Snapshot},
+		{&snap.TrainPipes, m.trainPipes.Snapshot},
+		{&snap.PipelineJobs, m.pipelineJobs.Snapshot},
+		{&snap.TuningJobs, m.tuningJobs.Snapshot},
+		{&snap.CachedContent, m.cachedContent.Snapshot},
+		{&snap.Featurestores, m.featurestores.Snapshot},
+		{&snap.EntityTypes, m.entityTypes.Snapshot},
+		{&snap.EntityRecords, m.entityRecords.Snapshot},
+		{&snap.FeatureGroups, m.featureGroups.Snapshot},
+		{&snap.Features, m.features.Snapshot},
+		{&snap.OnlineStores, m.onlineStores.Snapshot},
+		{&snap.FeatureViews, m.featureViews.Snapshot},
+		{&snap.Indexes, m.indexes.Snapshot},
+		{&snap.IndexEndpoints, m.indexEndpoints.Snapshot},
+		{&snap.MetadataStores, m.metadataStores.Snapshot},
+		{&snap.Tensorboards, m.tensorboards.Snapshot},
+		{&snap.Schedules, m.schedules.Snapshot},
+		{&snap.NBTemplates, m.nbTemplates.Snapshot},
+		{&snap.NBRuntimes, m.nbRuntimes.Snapshot},
+		{&snap.Operations, m.operations.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("vertexai: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds the mock's state under the original identities: every
+// resource name (self-link) is preserved so cross-references still resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap vertexaiSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("vertexai: parse snapshot: %w", err)
+	}
+
+	return m.restoreStores(&snap)
+}
+
+func (m *Mock) restoreStores(snap *vertexaiSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Datasets, m.datasets.LoadSnapshot},
+		{snap.Models, m.models.LoadSnapshot},
+		{snap.Evaluations, m.evaluations.LoadSnapshot},
+		{snap.Endpoints, m.endpoints.LoadSnapshot},
+		{snap.CustomJobs, m.customJobs.LoadSnapshot},
+		{snap.BatchJobs, m.batchJobs.LoadSnapshot},
+		{snap.HPOJobs, m.hpoJobs.LoadSnapshot},
+		{snap.TrainPipes, m.trainPipes.LoadSnapshot},
+		{snap.PipelineJobs, m.pipelineJobs.LoadSnapshot},
+		{snap.TuningJobs, m.tuningJobs.LoadSnapshot},
+		{snap.CachedContent, m.cachedContent.LoadSnapshot},
+		{snap.Featurestores, m.featurestores.LoadSnapshot},
+		{snap.EntityTypes, m.entityTypes.LoadSnapshot},
+		{snap.EntityRecords, m.entityRecords.LoadSnapshot},
+		{snap.FeatureGroups, m.featureGroups.LoadSnapshot},
+		{snap.Features, m.features.LoadSnapshot},
+		{snap.OnlineStores, m.onlineStores.LoadSnapshot},
+		{snap.FeatureViews, m.featureViews.LoadSnapshot},
+		{snap.Indexes, m.indexes.LoadSnapshot},
+		{snap.IndexEndpoints, m.indexEndpoints.LoadSnapshot},
+		{snap.MetadataStores, m.metadataStores.LoadSnapshot},
+		{snap.Tensorboards, m.tensorboards.LoadSnapshot},
+		{snap.Schedules, m.schedules.LoadSnapshot},
+		{snap.NBTemplates, m.nbTemplates.LoadSnapshot},
+		{snap.NBRuntimes, m.nbRuntimes.LoadSnapshot},
+		{snap.Operations, m.operations.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("vertexai: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/gcp/vertexai/snapshot_test.go
+++ b/providers/gcp/vertexai/snapshot_test.go
@@ -1,0 +1,40 @@
+package vertexai
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/services/vertexai/driver"
+)
+
+// TestSnapshotRoundTripVertexai proves a snapshot/restore cycle reinstates the
+// mock's state under the original identities: a model uploaded before the
+// snapshot (which also records a long-running operation) is readable from a
+// fresh mock after restore, and re-snapshotting yields byte-identical JSON, so
+// every store round-trips.
+func TestSnapshotRoundTripVertexai(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	_, model, err := src.UploadModel(ctx, driver.ModelConfig{Location: "us-central1", DisplayName: "m1"})
+	require.NoError(t, err)
+
+	raw, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst := newTestMock()
+	require.NoError(t, dst.Restore(ctx, raw))
+
+	got, err := dst.GetModel(ctx, model.Name)
+	require.NoError(t, err)
+	assert.Equal(t, model.Name, got.Name)
+	assert.Equal(t, "m1", got.DisplayName)
+
+	reSnap, err := dst.Snapshot(ctx, true)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(raw, reSnap), "re-snapshot differs; a store did not round-trip")
+}


### PR DESCRIPTION
#582 round C

Implements `internal/snapshot.Snapshottable` (identity-preserving Snapshot/Restore) on 30 provider mocks so persist auto-discovers them via reflection — no golden-list edits (the property-based discovery test recomputes).

Services (each with a round-trip test):
- AWS (14): rds, elasticache, cloudwatchlogs, ecr, ecs, eks, kms, ssm, bedrock, sagemaker, efs, glue, kinesis, sfn
- Azure (9): sql, postgresflex, mysqlflex, cache, loganalytics, acr, aks, databricks, ai
- GCP (7): cloudsql, alloydb, memorystore, cloudlogging, artifactregistry, gke, vertexai

Every memstore.Store / map / atomic counter is captured (generic memstore dump for exported value types; explicit exported promotion structs for unexported value types — e.g. rds clusterCred, glue *xData, kms *keyData with PKCS#8 key material, cache/logs/registry nested stores). Only mutexes, wired deps, and in-flight transient overlays are excluded.

Gates: go build, full go vet, go generate (no diff), go test ./persist/... (incl. Discovery, unedited) + all 30 touched packages + WiringParity/RealWorld, gofmt, golangci-lint --new-from-rev=origin/development (0 issues).