### PR TITLE
feat(persist): Snapshottable for remaining 24 stateful mocks + completeness guard (#582)

### DIFF
--- a/persist/completeness_test.go
+++ b/persist/completeness_test.go
@@ -1,0 +1,140 @@
+package persist_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+// maxStoreScanDepth bounds the transitive struct walk holdsStore performs. It
+// matches the depth used when the persistence scope was computed by reflection,
+// so this guard's criterion is the same one that enumerated the services to
+// implement: a provider field is "stateful" iff a *memstore.Store is reachable
+// from its type within this many nested struct/pointer hops.
+const maxStoreScanDepth = 4
+
+// guardExclude lists provider fields (keyed "provider/Field") that transitively
+// hold a *memstore.Store but are deliberately NOT persisted. It MUST stay empty
+// unless a field genuinely holds only transient/derived state that must not
+// survive a restart — and then only WITH a comment here justifying why. It is
+// not an escape hatch for unfinished persistence work: a real stateful field
+// belongs behind snapshot.Snapshottable, not in this list.
+//
+//nolint:gochecknoglobals // test fixture: an intentional, reviewed exclusion set.
+var guardExclude = map[string]struct{}{}
+
+// TestSnapshotCompleteness is the permanent completeness guard for #582: every
+// provider field that transitively holds a *memstore.Store must implement
+// snapshot.Snapshottable, or a stop/start of the server silently drops that
+// service's state. It reflects over the concrete provider structs (NOT over
+// Discover) so a NEW stateful service that forgets to add persistence fails
+// here, naming the field, until it is implemented or justified in guardExclude.
+//
+// OCI is intentionally covered-by-criterion-but-empty: the OCI Provider exposes
+// its services as DRIVER INTERFACES (netdriver.Networking, iamdriver.IAM, ...),
+// not concrete *Mock structs, so holdsStore — which walks static struct/pointer
+// types — never reaches the memstore.Store the concrete OCI mocks hold behind
+// those interfaces. OCI persistence is therefore out of scope by this guard's
+// criterion (the concrete OCI mocks do use memstore.Store; persisting them is a
+// separate follow-up). The AWS/Azure/GCP providers expose concrete *Mock fields,
+// so they are fully covered.
+func TestSnapshotCompleteness(t *testing.T) {
+	snapType := reflect.TypeOf((*snapshot.Snapshottable)(nil)).Elem()
+
+	providers := []struct {
+		name string
+		p    any
+	}{
+		{"aws", cloudemu.NewAWS()},
+		{"azure", cloudemu.NewAzure()},
+		{"gcp", cloudemu.NewGCP()},
+		{"oci", cloudemu.NewOCI()},
+	}
+
+	missing := 0
+
+	for _, prov := range providers {
+		t.Run(prov.name, func(t *testing.T) {
+			v := reflect.ValueOf(prov.p)
+			for v.Kind() == reflect.Pointer {
+				v = v.Elem()
+			}
+
+			if v.Kind() != reflect.Struct {
+				t.Fatalf("%s: provider is not a struct", prov.name)
+			}
+
+			pt := v.Type()
+
+			for i := range pt.NumField() {
+				f := pt.Field(i)
+				if !f.IsExported() {
+					continue
+				}
+
+				if !holdsStore(f.Type, 0) {
+					continue
+				}
+
+				if f.Type.Implements(snapType) {
+					continue
+				}
+
+				key := prov.name + "/" + f.Name
+				if _, ok := guardExclude[key]; ok {
+					continue
+				}
+
+				missing++
+
+				t.Errorf("%s: field %s (%s) holds a memstore.Store but is not Snapshottable — "+
+					"add persistence (see #582) or justify in guardExclude", prov.name, f.Name, f.Type)
+			}
+		})
+	}
+
+	if missing == 0 && len(guardExclude) != 0 {
+		t.Errorf("guardExclude has %d entr(ies) but nothing is missing — prune stale exclusions", len(guardExclude))
+	}
+}
+
+// holdsStore reports whether a *memstore.Store is reachable from type t within
+// maxStoreScanDepth nested struct/pointer hops. It walks STATIC types, so a field
+// typed as an interface (as every OCI service field is) is opaque and returns
+// false — the concrete mock behind it is never inspected. This is the same
+// criterion used to compute the set of services persistence must cover.
+func holdsStore(t reflect.Type, depth int) bool {
+	if depth > maxStoreScanDepth || t == nil {
+		return false
+	}
+
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	if strings.Contains(t.String(), "memstore.Store") {
+		return true
+	}
+
+	if t.Kind() != reflect.Struct {
+		return false
+	}
+
+	for i := range t.NumField() {
+		ft := t.Field(i).Type
+		if strings.Contains(ft.String(), "memstore.Store") {
+			return true
+		}
+
+		if k := ft.Kind(); k == reflect.Pointer || k == reflect.Struct {
+			if holdsStore(ft, depth+1) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -154,7 +155,17 @@ func Restore(ctx context.Context, services Services, ps *ProviderState) error {
 
 	for _, name := range names {
 		s, ok := services[name]
-		if !ok || s == nil {
+		if !ok {
+			// The snapshot carries a service this build no longer exposes (a
+			// wider-surface or newer snapshot restored into a narrower build).
+			// Skipping is intentional, but a silent skip hides state loss, so
+			// warn — this is what #817 asked for.
+			log.Printf("persist: restore: snapshot service %q has no matching target service; skipping", name)
+
+			continue
+		}
+
+		if s == nil {
 			continue
 		}
 

--- a/persist/restore_warn_test.go
+++ b/persist/restore_warn_test.go
@@ -1,0 +1,89 @@
+package persist_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log"
+	"strings"
+	"testing"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/persist"
+)
+
+// TestRestoreWarnsOnUnmatchedService covers #817: a snapshot that carries a
+// service the running build no longer exposes must not be silently dropped — the
+// skip is intentional, but it is logged as a warning so a state-loss on restore
+// is visible in the server logs rather than swallowed.
+func TestRestoreWarnsOnUnmatchedService(t *testing.T) {
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+
+	prev := log.Writer()
+	prevFlags := log.Flags()
+
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+
+	t.Cleanup(func() {
+		log.SetOutput(prev)
+		log.SetFlags(prevFlags)
+	})
+
+	// A provider state naming a service ("ghostservice") that the target does not
+	// expose. Restore must skip it AND warn.
+	ps := persist.ProviderState{Services: map[string]json.RawMessage{
+		"ghostservice": json.RawMessage(`{"anything":true}`),
+	}}
+
+	dst := cloudemu.NewAWS()
+	if err := persist.Restore(ctx, dst.SnapshotServices(), &ps); err != nil {
+		t.Fatalf("restore with unmatched service: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "ghostservice") || !strings.Contains(out, "no matching target service") {
+		t.Fatalf("expected a warning naming the unmatched service, got log: %q", out)
+	}
+}
+
+// TestRestoreNoWarnWhenAllServicesMatch is the negative control: restoring a
+// snapshot whose services all exist in the target emits no unmatched-service
+// warning, so the warn path only fires on genuine surface mismatch.
+func TestRestoreNoWarnWhenAllServicesMatch(t *testing.T) {
+	ctx := context.Background()
+
+	src := cloudemu.NewAWS()
+	if err := src.S3.CreateBucket(ctx, "warn-control"); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	ps, err := persist.Export(ctx, src.SnapshotServices(), persist.Options{})
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	var buf bytes.Buffer
+
+	prev := log.Writer()
+	prevFlags := log.Flags()
+
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+
+	t.Cleanup(func() {
+		log.SetOutput(prev)
+		log.SetFlags(prevFlags)
+	})
+
+	dst := cloudemu.NewAWS()
+	if err := persist.Restore(ctx, dst.SnapshotServices(), &ps); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	if strings.Contains(buf.String(), "no matching target service") {
+		t.Fatalf("unexpected unmatched-service warning on a fully-matching restore: %q", buf.String())
+	}
+}

--- a/providers/aws/acm/snapshot.go
+++ b/providers/aws/acm/snapshot.go
@@ -1,0 +1,71 @@
+package acm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/acm/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// acmSnapshot is the full serialized state of the AWS ACM mock. The certs store
+// holds an unexported *certData whose stored certificate lives in an unexported
+// field (invisible to json.Marshal), so it is promoted to an exported form keyed
+// by certificate ARN. The account-level configuration (cfgMu-guarded) is
+// captured beside it. The per-cert settle window (a read-time PENDING_VALIDATION
+// overlay) and the wired opts are intentionally not serialized — a restored
+// certificate reports its stored (final) state.
+type acmSnapshot struct {
+	Certs     map[string]*certSnapshot    `json:"certs,omitempty"`
+	AccountFg driver.AccountConfiguration `json:"accountFg"`
+}
+
+// certSnapshot is the exported form of certData; only the stored certificate is
+// durable state, the settle overlay and mutex are not.
+type certSnapshot struct {
+	Cert driver.Certificate `json:"cert"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// ACM holds certificate material, not bulk object bodies, and it is always kept.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := acmSnapshot{}
+
+	if m.certs.Len() > 0 {
+		snap.Certs = make(map[string]*certSnapshot, m.certs.Len())
+
+		for arn, cd := range m.certs.All() {
+			cd.mu.RLock()
+			snap.Certs[arn] = &certSnapshot{Cert: cd.cert}
+			cd.mu.RUnlock()
+		}
+	}
+
+	m.cfgMu.RLock()
+	snap.AccountFg = m.accountFg
+	m.cfgMu.RUnlock()
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds the mock's state under the original identities: every
+// certificate ARN is preserved, so an ARN a client holds still resolves.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap acmSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("acm: parse snapshot: %w", err)
+	}
+
+	for arn, cs := range snap.Certs {
+		m.certs.Set(arn, &certData{cert: cs.Cert})
+	}
+
+	m.cfgMu.Lock()
+	m.accountFg = snap.AccountFg
+	m.cfgMu.Unlock()
+
+	return nil
+}

--- a/providers/aws/acm/snapshot_test.go
+++ b/providers/aws/acm/snapshot_test.go
@@ -1,0 +1,63 @@
+package acm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/acm/driver"
+)
+
+// TestSnapshotRoundTripACM proves a snapshot/restore round-trip preserves each
+// certificate under its original ARN — including the issued PEM material — and
+// the account-level configuration.
+func TestSnapshotRoundTripACM(t *testing.T) {
+	ctx := context.Background()
+	src := newMock(t)
+
+	arn, err := src.RequestCertificate(ctx, driver.RequestCertificateInput{DomainName: "example.com"})
+	if err != nil {
+		t.Fatalf("RequestCertificate: %v", err)
+	}
+
+	if err := src.PutAccountConfiguration(ctx, driver.AccountConfiguration{DaysBeforeExpiry: 17}); err != nil {
+		t.Fatalf("PutAccountConfiguration: %v", err)
+	}
+
+	wantCert, wantChain, err := src.GetCertificate(ctx, arn)
+	if err != nil {
+		t.Fatalf("GetCertificate: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newMock(t)
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	d, err := dst.DescribeCertificate(ctx, arn)
+	if err != nil {
+		t.Fatalf("DescribeCertificate: %v", err)
+	}
+
+	if d.DomainName != "example.com" || d.Status != driver.StatusIssued {
+		t.Fatalf("restored cert = %+v", d)
+	}
+
+	gotCert, gotChain, err := dst.GetCertificate(ctx, arn)
+	if err != nil {
+		t.Fatalf("GetCertificate after restore: %v", err)
+	}
+
+	if gotCert != wantCert || gotChain != wantChain {
+		t.Fatalf("restored PEM material differs from original")
+	}
+
+	cfg, err := dst.GetAccountConfiguration(ctx)
+	if err != nil || cfg.DaysBeforeExpiry != 17 {
+		t.Fatalf("restored account config = %+v, err %v", cfg, err)
+	}
+}

--- a/providers/aws/bedrockagent/snapshot.go
+++ b/providers/aws/bedrockagent/snapshot.go
@@ -1,0 +1,90 @@
+package bedrockagent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// bedrockAgentSnapshot is the full serialized state of the AWS Bedrock Agent
+// mock. Every store holds a fully-exported *driver type, so each round-trips
+// through the generic memstore helper keyed by its resource id. The wired opts
+// are intentionally not serialized.
+type bedrockAgentSnapshot struct {
+	Agents      json.RawMessage `json:"agents,omitempty"`
+	Aliases     json.RawMessage `json:"aliases,omitempty"`
+	Knowledge   json.RawMessage `json:"knowledge,omitempty"`
+	DataSources json.RawMessage `json:"dataSources,omitempty"`
+	Jobs        json.RawMessage `json:"jobs,omitempty"`
+	Flows       json.RawMessage `json:"flows,omitempty"`
+	Prompts     json.RawMessage `json:"prompts,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Bedrock Agent holds resource metadata, not bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap bedrockAgentSnapshot
+
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Agents, m.agents.Snapshot},
+		{&snap.Aliases, m.aliases.Snapshot},
+		{&snap.Knowledge, m.knowledge.Snapshot},
+		{&snap.DataSources, m.dataSource.Snapshot},
+		{&snap.Jobs, m.jobs.Snapshot},
+		{&snap.Flows, m.flows.Snapshot},
+		{&snap.Prompts, m.prompts.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return nil, fmt.Errorf("bedrockagent: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds the mock's state under the original identities: every agent,
+// alias, knowledge base, data source, ingestion job, flow, and prompt id is
+// preserved so cross-references (e.g. a data source's knowledge-base id) resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap bedrockAgentSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("bedrockagent: parse snapshot: %w", err)
+	}
+
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Agents, m.agents.LoadSnapshot},
+		{snap.Aliases, m.aliases.LoadSnapshot},
+		{snap.Knowledge, m.knowledge.LoadSnapshot},
+		{snap.DataSources, m.dataSource.LoadSnapshot},
+		{snap.Jobs, m.jobs.LoadSnapshot},
+		{snap.Flows, m.flows.LoadSnapshot},
+		{snap.Prompts, m.prompts.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("bedrockagent: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/aws/bedrockagent/snapshot_test.go
+++ b/providers/aws/bedrockagent/snapshot_test.go
@@ -1,0 +1,51 @@
+package bedrockagent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/services/bedrockagent/driver"
+)
+
+// TestSnapshotRoundTripBedrockAgent proves a snapshot/restore round-trip
+// preserves agents, knowledge bases, and prompts under their original ids.
+func TestSnapshotRoundTripBedrockAgent(t *testing.T) {
+	ctx := context.Background()
+	src := newMock()
+
+	agent, err := src.CreateAgent(ctx, driver.AgentConfig{Name: "a1", FoundationModel: "fm"})
+	require.NoError(t, err)
+
+	kb, err := src.CreateKnowledgeBase(ctx, driver.KnowledgeBaseConfig{
+		Name:                       "kb1",
+		RoleArn:                    "arn:aws:iam::000000000000:role/kb",
+		KnowledgeBaseConfiguration: []byte(`{"type":"VECTOR"}`),
+	})
+	require.NoError(t, err)
+
+	prompt, err := src.CreatePrompt(ctx, driver.PromptConfig{Name: "p1"})
+	require.NoError(t, err)
+
+	raw, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst := newMock()
+	require.NoError(t, dst.Restore(ctx, raw))
+
+	gotAgent, err := dst.GetAgent(ctx, agent.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "a1", gotAgent.Name)
+	assert.Equal(t, "fm", gotAgent.FoundationModel)
+	assert.Equal(t, agent.ARN, gotAgent.ARN)
+
+	gotKB, err := dst.GetKnowledgeBase(ctx, kb.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "kb1", gotKB.Name)
+
+	gotPrompt, err := dst.GetPrompt(ctx, prompt.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "p1", gotPrompt.Name)
+}

--- a/providers/aws/cloudtrail/snapshot.go
+++ b/providers/aws/cloudtrail/snapshot.go
@@ -1,0 +1,312 @@
+package cloudtrail
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/cloudtrail/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// cloudtrailSnapshot is the full serialized state of the AWS CloudTrail mock.
+// The trails/eds/channels/dashboards/imports/queries stores each hold an
+// unexported *xData whose payload lives in unexported fields, so all six are
+// promoted to exported forms keyed by their store key (trail name, EDS/channel
+// ARN, dashboard name, import/query id). The name/ARN index stores hold plain
+// strings and round-trip through the generic memstore helper. The mu-guarded
+// maps (policies, tags, delegated) and the recorded management-event log are
+// captured beside them. The per-record mutexes and the wired opts are not
+// serialized.
+type cloudtrailSnapshot struct {
+	Trails      map[string]*trailSnapshot     `json:"trails,omitempty"`
+	TrailARNIdx json.RawMessage               `json:"trailArnIdx,omitempty"`
+	EDS         map[string]*edsSnapshot       `json:"eds,omitempty"`
+	EDSNameIdx  json.RawMessage               `json:"edsNameIdx,omitempty"`
+	ChanNameIdx json.RawMessage               `json:"chanNameIdx,omitempty"`
+	Channels    map[string]*channelSnapshot   `json:"channels,omitempty"`
+	Dashboards  map[string]*dashboardSnapshot `json:"dashboards,omitempty"`
+	Imports     map[string]driver.Import      `json:"imports,omitempty"`
+	Queries     map[string]driver.Query       `json:"queries,omitempty"`
+
+	Policies  map[string]string            `json:"policies,omitempty"`
+	Tags      map[string]map[string]string `json:"tags,omitempty"`
+	Delegated []string                     `json:"delegated,omitempty"`
+	Events    []driver.Event               `json:"events,omitempty"`
+}
+
+// trailSnapshot mirrors trailData (all fields unexported).
+type trailSnapshot struct {
+	Trail    driver.Trail                   `json:"trail"`
+	Status   driver.TrailStatus             `json:"status"`
+	Selors   []driver.EventSelector         `json:"selors,omitempty"`
+	AdvSel   []driver.AdvancedEventSelector `json:"advSel,omitempty"`
+	Insights []driver.InsightSelector       `json:"insights,omitempty"`
+}
+
+// edsSnapshot mirrors edsData (all fields unexported).
+type edsSnapshot struct {
+	EDS               driver.EventDataStore    `json:"eds"`
+	Insights          []driver.InsightSelector `json:"insights,omitempty"`
+	FederationRoleARN string                   `json:"federationRoleArn,omitempty"`
+	FederationStatus  string                   `json:"federationStatus,omitempty"`
+	MaxEventSize      string                   `json:"maxEventSize,omitempty"`
+}
+
+// channelSnapshot mirrors channelData.
+type channelSnapshot struct {
+	Channel      driver.Channel `json:"channel"`
+	MaxEventSize string         `json:"maxEventSize,omitempty"`
+}
+
+// dashboardSnapshot mirrors dashboardData.
+type dashboardSnapshot struct {
+	Dashboard driver.Dashboard `json:"dashboard"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// CloudTrail holds resource metadata and a bounded event log, not object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := cloudtrailSnapshot{}
+
+	m.snapshotStores(&snap)
+
+	if err := m.snapshotIndexes(&snap); err != nil {
+		return nil, err
+	}
+
+	m.snapshotScalarState(&snap)
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *cloudtrailSnapshot) {
+	m.snapshotStoresA(snap)
+	m.snapshotStoresB(snap)
+}
+
+func (m *Mock) snapshotStoresA(snap *cloudtrailSnapshot) {
+	if m.trails.Len() > 0 {
+		snap.Trails = make(map[string]*trailSnapshot, m.trails.Len())
+
+		for name, td := range m.trails.All() {
+			td.mu.RLock()
+			snap.Trails[name] = &trailSnapshot{
+				Trail: td.trail, Status: td.status, Selors: td.selors,
+				AdvSel: td.advSel, Insights: td.insights,
+			}
+			td.mu.RUnlock()
+		}
+	}
+
+	if m.eds.Len() > 0 {
+		snap.EDS = make(map[string]*edsSnapshot, m.eds.Len())
+
+		for arn, ed := range m.eds.All() {
+			ed.mu.RLock()
+			snap.EDS[arn] = &edsSnapshot{
+				EDS: ed.eds, Insights: ed.insights, FederationRoleARN: ed.federationRoleARN,
+				FederationStatus: ed.federationStatus, MaxEventSize: ed.maxEventSize,
+			}
+			ed.mu.RUnlock()
+		}
+	}
+
+	if m.channels.Len() > 0 {
+		snap.Channels = make(map[string]*channelSnapshot, m.channels.Len())
+
+		for arn, cd := range m.channels.All() {
+			cd.mu.RLock()
+			snap.Channels[arn] = &channelSnapshot{Channel: cd.channel, MaxEventSize: cd.maxEventSize}
+			cd.mu.RUnlock()
+		}
+	}
+}
+
+func (m *Mock) snapshotStoresB(snap *cloudtrailSnapshot) {
+	if m.dashboards.Len() > 0 {
+		snap.Dashboards = make(map[string]*dashboardSnapshot, m.dashboards.Len())
+
+		for name, dd := range m.dashboards.All() {
+			dd.mu.RLock()
+			snap.Dashboards[name] = &dashboardSnapshot{Dashboard: dd.dashboard}
+			dd.mu.RUnlock()
+		}
+	}
+
+	if m.imports.Len() > 0 {
+		snap.Imports = make(map[string]driver.Import, m.imports.Len())
+
+		for id, imp := range m.imports.All() {
+			imp.mu.RLock()
+			snap.Imports[id] = imp.imp
+			imp.mu.RUnlock()
+		}
+	}
+
+	if m.queries.Len() > 0 {
+		snap.Queries = make(map[string]driver.Query, m.queries.Len())
+
+		for id, q := range m.queries.All() {
+			q.mu.RLock()
+			snap.Queries[id] = q.q
+			q.mu.RUnlock()
+		}
+	}
+}
+
+func (m *Mock) snapshotIndexes(snap *cloudtrailSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.TrailARNIdx, m.trailARNIdx.Snapshot},
+		{&snap.EDSNameIdx, m.edsNameIdx.Snapshot},
+		{&snap.ChanNameIdx, m.chanNameIdx.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("cloudtrail: snapshot index: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+func (m *Mock) snapshotScalarState(snap *cloudtrailSnapshot) {
+	m.policyMu.RLock()
+	if len(m.policies) > 0 {
+		snap.Policies = m.policies
+	}
+	m.policyMu.RUnlock()
+
+	m.tagsMu.RLock()
+	if len(m.tags) > 0 {
+		snap.Tags = m.tags
+	}
+	m.tagsMu.RUnlock()
+
+	m.orgMu.Lock()
+	if len(m.delegated) > 0 {
+		snap.Delegated = make([]string, 0, len(m.delegated))
+		for acct := range m.delegated {
+			snap.Delegated = append(snap.Delegated, acct)
+		}
+	}
+	m.orgMu.Unlock()
+
+	m.eventsMu.RLock()
+	if len(m.events) > 0 {
+		snap.Events = append([]driver.Event(nil), m.events...)
+	}
+	m.eventsMu.RUnlock()
+}
+
+// Restore rebuilds the mock's state under the original identities: every trail
+// name, EDS/channel ARN, dashboard name, import/query id, and the name/ARN
+// indexes are preserved so a client's identifiers still resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap cloudtrailSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("cloudtrail: parse snapshot: %w", err)
+	}
+
+	m.restoreStores(&snap)
+
+	if err := m.restoreIndexes(&snap); err != nil {
+		return err
+	}
+
+	m.restoreScalarState(&snap)
+
+	return nil
+}
+
+func (m *Mock) restoreStores(snap *cloudtrailSnapshot) {
+	for name, ts := range snap.Trails {
+		m.trails.Set(name, &trailData{
+			trail: ts.Trail, status: ts.Status, selors: ts.Selors,
+			advSel: ts.AdvSel, insights: ts.Insights,
+		})
+	}
+
+	for arn, es := range snap.EDS {
+		m.eds.Set(arn, &edsData{
+			eds: es.EDS, insights: es.Insights, federationRoleARN: es.FederationRoleARN,
+			federationStatus: es.FederationStatus, maxEventSize: es.MaxEventSize,
+		})
+	}
+
+	for arn, cs := range snap.Channels {
+		m.channels.Set(arn, &channelData{channel: cs.Channel, maxEventSize: cs.MaxEventSize})
+	}
+
+	for name, ds := range snap.Dashboards {
+		m.dashboards.Set(name, &dashboardData{dashboard: ds.Dashboard})
+	}
+
+	for id := range snap.Imports {
+		m.imports.Set(id, &importData{imp: snap.Imports[id]})
+	}
+
+	for id, q := range snap.Queries {
+		m.queries.Set(id, &queryData{q: q})
+	}
+}
+
+func (m *Mock) restoreIndexes(snap *cloudtrailSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.TrailARNIdx, m.trailARNIdx.LoadSnapshot},
+		{snap.EDSNameIdx, m.edsNameIdx.LoadSnapshot},
+		{snap.ChanNameIdx, m.chanNameIdx.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("cloudtrail: restore index: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (m *Mock) restoreScalarState(snap *cloudtrailSnapshot) {
+	if snap.Policies != nil {
+		m.policyMu.Lock()
+		m.policies = snap.Policies
+		m.policyMu.Unlock()
+	}
+
+	if snap.Tags != nil {
+		m.tagsMu.Lock()
+		m.tags = snap.Tags
+		m.tagsMu.Unlock()
+	}
+
+	if len(snap.Delegated) > 0 {
+		m.orgMu.Lock()
+		for _, acct := range snap.Delegated {
+			m.delegated[acct] = struct{}{}
+		}
+		m.orgMu.Unlock()
+	}
+
+	if len(snap.Events) > 0 {
+		m.eventsMu.Lock()
+		m.events = snap.Events
+		m.eventsMu.Unlock()
+	}
+}

--- a/providers/aws/cloudtrail/snapshot_test.go
+++ b/providers/aws/cloudtrail/snapshot_test.go
@@ -1,0 +1,61 @@
+package cloudtrail
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/services/cloudtrail/driver"
+)
+
+// TestSnapshotRoundTripCloudTrail proves a snapshot/restore round-trip preserves
+// trails (with their ARN index), event data stores, tags, and the recorded
+// management-event log under their original identities.
+func TestSnapshotRoundTripCloudTrail(t *testing.T) {
+	ctx := context.Background()
+	src := newMock()
+
+	tr, err := src.CreateTrail(ctx, driver.CreateTrailInput{Name: "my-trail", S3BucketName: "bkt"})
+	require.NoError(t, err)
+
+	eds, err := src.CreateEventDataStore(ctx, driver.CreateEventDataStoreInput{Name: "eds1"})
+	require.NoError(t, err)
+
+	require.NoError(t, src.AddTags(ctx, tr.TrailARN, map[string]string{"env": "prod"}))
+
+	src.RecordEvent(&driver.Event{
+		EventID: "e1", EventName: "RunInstances", EventSource: "ec2.amazonaws.com",
+		EventTime: time.Unix(100, 0).UTC(), Username: "alice",
+	})
+
+	raw, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst := newMock()
+	require.NoError(t, dst.Restore(ctx, raw))
+
+	// Trail resolves by both name and its ARN (the ARN index survived).
+	got, err := dst.GetTrail(ctx, "my-trail")
+	require.NoError(t, err)
+	assert.Equal(t, "my-trail", got.Name)
+
+	byARN, err := dst.GetTrail(ctx, tr.TrailARN)
+	require.NoError(t, err)
+	assert.Equal(t, "my-trail", byARN.Name)
+
+	gotEDS, err := dst.GetEventDataStore(ctx, eds.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, "eds1", gotEDS.Name)
+
+	tags, err := dst.ListTags(ctx, []string{tr.TrailARN})
+	require.NoError(t, err)
+	assert.Equal(t, "prod", tags[tr.TrailARN]["env"])
+
+	events, _, err := dst.LookupEvents(ctx, driver.LookupInput{})
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "RunInstances", events[0].EventName)
+}

--- a/providers/aws/configservice/snapshot.go
+++ b/providers/aws/configservice/snapshot.go
@@ -1,0 +1,281 @@
+package configservice
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/configservice/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// configSnapshot is the full serialized state of the AWS Config mock. The
+// recorders/channels/rules/packs/aggregators/connectors stores hold unexported
+// *xData whose payload lives in unexported fields, so all six are promoted to
+// exported forms keyed by their store key. The remaining stores hold
+// fully-exported *driver types and round-trip through the generic memstore
+// helper. The authMu-guarded aggregation authorizations and remediation
+// exceptions, plus the token registry, are captured beside them. The per-record
+// mutexes and the wired opts are not serialized.
+type configSnapshot struct {
+	Recorders   map[string]*recorderSnapshot              `json:"recorders,omitempty"`
+	Channels    map[string]*channelSnapshot               `json:"channels,omitempty"`
+	Rules       map[string]*ruleSnapshot                  `json:"rules,omitempty"`
+	Packs       map[string]driver.ConformancePack         `json:"packs,omitempty"`
+	Aggregators map[string]driver.ConfigurationAggregator `json:"aggregators,omitempty"`
+	Connectors  map[string]*connectorSnapshot             `json:"connectors,omitempty"`
+
+	OrgRules    json.RawMessage `json:"orgRules,omitempty"`
+	OrgPacks    json.RawMessage `json:"orgPacks,omitempty"`
+	Remediation json.RawMessage `json:"remediation,omitempty"`
+	StoredQuery json.RawMessage `json:"storedQuery,omitempty"`
+	Retention   json.RawMessage `json:"retention,omitempty"`
+	Resources   json.RawMessage `json:"resources,omitempty"`
+
+	Authorizations []driver.AggregationAuthorization        `json:"authorizations,omitempty"`
+	RemExceptions  map[string][]driver.RemediationException `json:"remExceptions,omitempty"`
+	EvalTokens     map[string]string                        `json:"evalTokens,omitempty"`
+}
+
+// recorderSnapshot mirrors recorderData.
+type recorderSnapshot struct {
+	Rec driver.ConfigurationRecorder `json:"rec"`
+}
+
+// channelSnapshot mirrors channelData.
+type channelSnapshot struct {
+	Ch driver.DeliveryChannel `json:"ch"`
+}
+
+// ruleSnapshot mirrors ruleData, including the synthesized evaluations and the
+// opaque result token so PutEvaluations still validates after a restore.
+type ruleSnapshot struct {
+	Rule        driver.ConfigRule   `json:"rule"`
+	Evals       []driver.Evaluation `json:"evals,omitempty"`
+	ResultToken string              `json:"resultToken,omitempty"`
+}
+
+// connectorSnapshot mirrors connectorData (all fields unexported).
+type connectorSnapshot struct {
+	Name              string `json:"name"`
+	ARN               string `json:"arn,omitempty"`
+	ConnectorAgentArn string `json:"connectorAgentArn,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Config holds resource metadata, not bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := configSnapshot{}
+
+	m.snapshotPromoted(&snap)
+
+	if err := m.snapshotGeneric(&snap); err != nil {
+		return nil, err
+	}
+
+	m.snapshotScalarState(&snap)
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotPromoted(snap *configSnapshot) {
+	m.snapshotPromotedA(snap)
+	m.snapshotPromotedB(snap)
+}
+
+func (m *Mock) snapshotPromotedA(snap *configSnapshot) {
+	if m.recorders.Len() > 0 {
+		snap.Recorders = make(map[string]*recorderSnapshot, m.recorders.Len())
+
+		for k, rd := range m.recorders.All() {
+			rd.mu.RLock()
+			snap.Recorders[k] = &recorderSnapshot{Rec: rd.rec}
+			rd.mu.RUnlock()
+		}
+	}
+
+	if m.channels.Len() > 0 {
+		snap.Channels = make(map[string]*channelSnapshot, m.channels.Len())
+
+		for k, cd := range m.channels.All() {
+			cd.mu.RLock()
+			snap.Channels[k] = &channelSnapshot{Ch: cd.ch}
+			cd.mu.RUnlock()
+		}
+	}
+
+	if m.rules.Len() > 0 {
+		snap.Rules = make(map[string]*ruleSnapshot, m.rules.Len())
+
+		for k, rd := range m.rules.All() {
+			rd.mu.RLock()
+			snap.Rules[k] = &ruleSnapshot{Rule: rd.rule, Evals: rd.evals, ResultToken: rd.resultToken}
+			rd.mu.RUnlock()
+		}
+	}
+}
+
+func (m *Mock) snapshotPromotedB(snap *configSnapshot) {
+	if m.packs.Len() > 0 {
+		snap.Packs = make(map[string]driver.ConformancePack, m.packs.Len())
+
+		for k, pd := range m.packs.All() {
+			pd.mu.RLock()
+			snap.Packs[k] = pd.pack
+			pd.mu.RUnlock()
+		}
+	}
+
+	if m.aggregators.Len() > 0 {
+		snap.Aggregators = make(map[string]driver.ConfigurationAggregator, m.aggregators.Len())
+
+		for k, ad := range m.aggregators.All() {
+			ad.mu.RLock()
+			snap.Aggregators[k] = ad.agg
+			ad.mu.RUnlock()
+		}
+	}
+
+	if m.connectors.Len() > 0 {
+		snap.Connectors = make(map[string]*connectorSnapshot, m.connectors.Len())
+
+		for k, cd := range m.connectors.All() {
+			snap.Connectors[k] = &connectorSnapshot{Name: cd.name, ARN: cd.arn, ConnectorAgentArn: cd.connectorAgentArn}
+		}
+	}
+}
+
+func (m *Mock) snapshotGeneric(snap *configSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.OrgRules, m.orgRules.Snapshot},
+		{&snap.OrgPacks, m.orgPacks.Snapshot},
+		{&snap.Remediation, m.remediation.Snapshot},
+		{&snap.StoredQuery, m.storedQuery.Snapshot},
+		{&snap.Retention, m.retention.Snapshot},
+		{&snap.Resources, m.resources.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("configservice: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+func (m *Mock) snapshotScalarState(snap *configSnapshot) {
+	m.authMu.RLock()
+	if len(m.authorizations) > 0 {
+		snap.Authorizations = append([]driver.AggregationAuthorization(nil), m.authorizations...)
+	}
+
+	if len(m.remExceptions) > 0 {
+		snap.RemExceptions = m.remExceptions
+	}
+	m.authMu.RUnlock()
+
+	m.tokenMu.RLock()
+	if len(m.evalTokens) > 0 {
+		snap.EvalTokens = m.evalTokens
+	}
+	m.tokenMu.RUnlock()
+}
+
+// Restore rebuilds the mock's state under the original identities: every
+// recorder/channel/rule/pack/aggregator/connector key and every generic-store
+// resource id is preserved so a client's identifiers still resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap configSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("configservice: parse snapshot: %w", err)
+	}
+
+	m.restorePromoted(&snap)
+
+	if err := m.restoreGeneric(&snap); err != nil {
+		return err
+	}
+
+	m.restoreScalarState(&snap)
+
+	return nil
+}
+
+func (m *Mock) restorePromoted(snap *configSnapshot) {
+	for k, rs := range snap.Recorders {
+		m.recorders.Set(k, &recorderData{rec: rs.Rec})
+	}
+
+	for k, cs := range snap.Channels {
+		m.channels.Set(k, &channelData{ch: cs.Ch})
+	}
+
+	for k, rs := range snap.Rules {
+		m.rules.Set(k, &ruleData{rule: rs.Rule, evals: rs.Evals, resultToken: rs.ResultToken})
+	}
+
+	for k := range snap.Packs {
+		m.packs.Set(k, &packData{pack: snap.Packs[k]})
+	}
+
+	for k := range snap.Aggregators {
+		m.aggregators.Set(k, &aggData{agg: snap.Aggregators[k]})
+	}
+
+	for k, cs := range snap.Connectors {
+		m.connectors.Set(k, &connectorData{name: cs.Name, arn: cs.ARN, connectorAgentArn: cs.ConnectorAgentArn})
+	}
+}
+
+func (m *Mock) restoreGeneric(snap *configSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.OrgRules, m.orgRules.LoadSnapshot},
+		{snap.OrgPacks, m.orgPacks.LoadSnapshot},
+		{snap.Remediation, m.remediation.LoadSnapshot},
+		{snap.StoredQuery, m.storedQuery.LoadSnapshot},
+		{snap.Retention, m.retention.LoadSnapshot},
+		{snap.Resources, m.resources.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("configservice: restore store: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (m *Mock) restoreScalarState(snap *configSnapshot) {
+	m.authMu.Lock()
+	if len(snap.Authorizations) > 0 {
+		m.authorizations = snap.Authorizations
+	}
+
+	if snap.RemExceptions != nil {
+		m.remExceptions = snap.RemExceptions
+	}
+	m.authMu.Unlock()
+
+	if snap.EvalTokens != nil {
+		m.tokenMu.Lock()
+		m.evalTokens = snap.EvalTokens
+		m.tokenMu.Unlock()
+	}
+}

--- a/providers/aws/configservice/snapshot_test.go
+++ b/providers/aws/configservice/snapshot_test.go
@@ -1,0 +1,61 @@
+package configservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/configservice/driver"
+)
+
+// TestSnapshotRoundTripConfigService proves a snapshot/restore round-trip
+// preserves the configuration recorder, a config rule (a promoted store whose
+// value carries unexported evaluations/result-token state), and a conformance
+// pack under their original identities.
+func TestSnapshotRoundTripConfigService(t *testing.T) {
+	ctx := context.Background()
+	src := newMock(t)
+
+	putRecorder(t, src, "default")
+
+	if err := src.PutConfigRule(ctx, driver.ConfigRule{
+		ConfigRuleName: "rule1",
+		Source:         &driver.RuleSource{Owner: "AWS", SourceIdentifier: "S3_BUCKET_PUBLIC_READ_PROHIBITED"},
+	}); err != nil {
+		t.Fatalf("PutConfigRule: %v", err)
+	}
+
+	if _, err := src.PutConformancePack(ctx, driver.ConformancePack{
+		ConformancePackName: "pack1", DeliveryS3Bucket: "bkt", TemplateBody: "Resources: {}",
+	}); err != nil {
+		t.Fatalf("PutConformancePack: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newMock(t)
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	recs, err := dst.DescribeConfigurationRecorders(ctx, nil)
+	if err != nil || len(recs) != 1 || recs[0].Name != "default" {
+		t.Fatalf("restored recorders = %+v, err %v", recs, err)
+	}
+
+	rules, _, err := dst.DescribeConfigRules(ctx, nil, driver.Page{})
+	if err != nil || len(rules) != 1 || rules[0].ConfigRuleName != "rule1" {
+		t.Fatalf("restored rules = %+v, err %v", rules, err)
+	}
+
+	if rules[0].Source == nil || rules[0].Source.SourceIdentifier != "S3_BUCKET_PUBLIC_READ_PROHIBITED" {
+		t.Fatalf("restored rule source = %+v", rules[0].Source)
+	}
+
+	packs, _, err := dst.DescribeConformancePacks(ctx, nil, driver.Page{})
+	if err != nil || len(packs) != 1 || packs[0].ConformancePackName != "pack1" {
+		t.Fatalf("restored packs = %+v, err %v", packs, err)
+	}
+}

--- a/providers/aws/guardduty/snapshot.go
+++ b/providers/aws/guardduty/snapshot.go
@@ -1,0 +1,386 @@
+package guardduty
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/guardduty/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// guarddutySnapshot is the full serialized state of the Amazon GuardDuty mock.
+// The detectors store holds an unexported *detectorData whose entire payload
+// (the detector plus its nested member/invitation/publishing/finding maps and
+// its admin, org-config and malware settings) lives in unexported fields, so it
+// is promoted to an exported form keyed by detector id. The malwarePlans and
+// malwareScans stores hold unexported value types, promoted likewise; orgAdmins
+// holds plain bools and round-trips through the generic memstore helper. The
+// per-detector mutex, createMu, and the wired opts are not serialized.
+type guarddutySnapshot struct {
+	Detectors    map[string]*detectorSnapshot   `json:"detectors,omitempty"`
+	OrgAdmins    json.RawMessage                `json:"orgAdmins,omitempty"`
+	MalwarePlans map[string]malwarePlanSnapshot `json:"malwarePlans,omitempty"`
+	MalwareScans map[string]malwareScanSnapshot `json:"malwareScans,omitempty"`
+}
+
+// detectorSnapshot mirrors detectorData. The maps of exported driver types are
+// captured directly; the maps of unexported types and the admin/org/malware
+// sub-state are promoted.
+type detectorSnapshot struct {
+	Detector        driver.Detector                    `json:"detector"`
+	IPSets          map[string]driver.IPSet            `json:"ipSets,omitempty"`
+	ThreatIS        map[string]driver.ThreatIntelSet   `json:"threatIS,omitempty"`
+	ThreatES        map[string]driver.ThreatEntitySet  `json:"threatES,omitempty"`
+	TrustES         map[string]driver.TrustedEntitySet `json:"trustES,omitempty"`
+	Filters         map[string]driver.Filter           `json:"filters,omitempty"`
+	Members         map[string]memberSnapshot          `json:"members,omitempty"`
+	Invites         map[string]invitationSnapshot      `json:"invites,omitempty"`
+	Admin           *adminSnapshot                     `json:"admin,omitempty"`
+	OrgConfig       orgConfigSnapshot                  `json:"orgConfig"`
+	PublishDests    map[string]destSnapshot            `json:"publishDests,omitempty"`
+	Findings        map[string]findingSnapshot         `json:"findings,omitempty"`
+	MalwareSettings malwareSettingsSnapshot            `json:"malwareSettings"`
+}
+
+type memberSnapshot struct {
+	AccountID          string    `json:"accountId"`
+	Email              string    `json:"email,omitempty"`
+	RelationshipStatus string    `json:"relationshipStatus,omitempty"`
+	InvitedAt          time.Time `json:"invitedAt,omitempty"`
+	UpdatedAt          time.Time `json:"updatedAt,omitempty"`
+}
+
+type invitationSnapshot struct {
+	InviterAccountID string    `json:"inviterAccountId"`
+	InvitationID     string    `json:"invitationId,omitempty"`
+	InvitedAt        time.Time `json:"invitedAt,omitempty"`
+	Status           string    `json:"status,omitempty"`
+}
+
+type adminSnapshot struct {
+	AccountID    string    `json:"accountId"`
+	InvitationID string    `json:"invitationId,omitempty"`
+	InvitedAt    time.Time `json:"invitedAt,omitempty"`
+	Status       string    `json:"status,omitempty"`
+}
+
+type orgConfigSnapshot struct {
+	AutoEnable        *bool             `json:"autoEnable,omitempty"`
+	AutoEnableMembers string            `json:"autoEnableMembers,omitempty"`
+	Features          []json.RawMessage `json:"features,omitempty"`
+	DataSources       json.RawMessage   `json:"dataSources,omitempty"`
+}
+
+type destSnapshot struct {
+	DestinationID   string            `json:"destinationId"`
+	DestinationType string            `json:"destinationType,omitempty"`
+	DestinationARN  string            `json:"destinationArn,omitempty"`
+	KmsKeyARN       string            `json:"kmsKeyArn,omitempty"`
+	Status          string            `json:"status,omitempty"`
+	Tags            map[string]string `json:"tags,omitempty"`
+	CreatedAt       time.Time         `json:"createdAt,omitempty"`
+	UpdatedAt       time.Time         `json:"updatedAt,omitempty"`
+}
+
+type findingSnapshot struct {
+	ID             string    `json:"id"`
+	FindingType    string    `json:"findingType,omitempty"`
+	Severity       float64   `json:"severity,omitempty"`
+	Confidence     float64   `json:"confidence,omitempty"`
+	Title          string    `json:"title,omitempty"`
+	Description    string    `json:"description,omitempty"`
+	AccountID      string    `json:"accountId,omitempty"`
+	Region         string    `json:"region,omitempty"`
+	ARN            string    `json:"arn,omitempty"`
+	Archived       bool      `json:"archived,omitempty"`
+	Count          int32     `json:"count,omitempty"`
+	ResourceRole   string    `json:"resourceRole,omitempty"`
+	ResourceType   string    `json:"resourceType,omitempty"`
+	Feedback       string    `json:"feedback,omitempty"`
+	Comment        string    `json:"comment,omitempty"`
+	CreatedAt      time.Time `json:"createdAt,omitempty"`
+	UpdatedAt      time.Time `json:"updatedAt,omitempty"`
+	EventFirstSeen time.Time `json:"eventFirstSeen,omitempty"`
+	EventLastSeen  time.Time `json:"eventLastSeen,omitempty"`
+}
+
+type malwareSettingsSnapshot struct {
+	EbsSnapshotPreservation string          `json:"ebsSnapshotPreservation,omitempty"`
+	ScanResourceCriteria    json.RawMessage `json:"scanResourceCriteria,omitempty"`
+}
+
+type malwarePlanSnapshot struct {
+	ID                string            `json:"id"`
+	ARN               string            `json:"arn,omitempty"`
+	Role              string            `json:"role,omitempty"`
+	ProtectedResource json.RawMessage   `json:"protectedResource,omitempty"`
+	Actions           json.RawMessage   `json:"actions,omitempty"`
+	Status            string            `json:"status,omitempty"`
+	Tags              map[string]string `json:"tags,omitempty"`
+	CreatedAt         time.Time         `json:"createdAt,omitempty"`
+}
+
+type malwareScanSnapshot struct {
+	ScanID       string    `json:"scanId"`
+	ResourceARN  string    `json:"resourceArn,omitempty"`
+	ResourceType string    `json:"resourceType,omitempty"`
+	Status       string    `json:"status,omitempty"`
+	Result       string    `json:"result,omitempty"`
+	ScanType     string    `json:"scanType,omitempty"`
+	StartedAt    time.Time `json:"startedAt,omitempty"`
+	CompletedAt  time.Time `json:"completedAt,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// GuardDuty holds resource metadata, not bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := guarddutySnapshot{}
+
+	if m.detectors.Len() > 0 {
+		snap.Detectors = make(map[string]*detectorSnapshot, m.detectors.Len())
+
+		for id, dd := range m.detectors.All() {
+			dd.mu.RLock()
+			snap.Detectors[id] = snapshotDetector(dd)
+			dd.mu.RUnlock()
+		}
+	}
+
+	admins, err := m.orgAdmins.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("guardduty: snapshot orgAdmins: %w", err)
+	}
+
+	snap.OrgAdmins = admins
+
+	snap.MalwarePlans = snapshotMalwarePlans(m.malwarePlans.All())
+	snap.MalwareScans = snapshotMalwareScans(m.malwareScans.All())
+
+	return json.Marshal(snap)
+}
+
+func snapshotDetector(dd *detectorData) *detectorSnapshot {
+	ds := &detectorSnapshot{
+		Detector: dd.detector, IPSets: dd.ipSets, ThreatIS: dd.threatIS,
+		ThreatES: dd.threatES, TrustES: dd.trustES, Filters: dd.filters,
+		OrgConfig: orgConfigSnapshot{
+			AutoEnable: dd.orgConfig.autoEnable, AutoEnableMembers: dd.orgConfig.autoEnableMembers,
+			Features: dd.orgConfig.features, DataSources: dd.orgConfig.dataSources,
+		},
+		MalwareSettings: malwareSettingsSnapshot{
+			EbsSnapshotPreservation: dd.malwareSettings.ebsSnapshotPreservation,
+			ScanResourceCriteria:    dd.malwareSettings.scanResourceCriteria,
+		},
+	}
+
+	if len(dd.members) > 0 {
+		ds.Members = make(map[string]memberSnapshot, len(dd.members))
+
+		for k, v := range dd.members {
+			ds.Members[k] = memberSnapshot{
+				AccountID: v.accountID, Email: v.email, RelationshipStatus: v.relationshipStatus,
+				InvitedAt: v.invitedAt, UpdatedAt: v.updatedAt,
+			}
+		}
+	}
+
+	if len(dd.invites) > 0 {
+		ds.Invites = make(map[string]invitationSnapshot, len(dd.invites))
+
+		for k, v := range dd.invites {
+			ds.Invites[k] = invitationSnapshot{
+				InviterAccountID: v.inviterAccountID, InvitationID: v.invitationID,
+				InvitedAt: v.invitedAt, Status: v.status,
+			}
+		}
+	}
+
+	if dd.admin != nil {
+		ds.Admin = &adminSnapshot{
+			AccountID: dd.admin.accountID, InvitationID: dd.admin.invitationID,
+			InvitedAt: dd.admin.invitedAt, Status: dd.admin.status,
+		}
+	}
+
+	if len(dd.publishDests) > 0 {
+		ds.PublishDests = make(map[string]destSnapshot, len(dd.publishDests))
+
+		for k := range dd.publishDests {
+			v := dd.publishDests[k]
+			ds.PublishDests[k] = destSnapshot{
+				DestinationID: v.destinationID, DestinationType: v.destinationType,
+				DestinationARN: v.destinationARN, KmsKeyARN: v.kmsKeyARN, Status: v.status,
+				Tags: v.tags, CreatedAt: v.createdAt, UpdatedAt: v.updatedAt,
+			}
+		}
+	}
+
+	if len(dd.findings) > 0 {
+		ds.Findings = make(map[string]findingSnapshot, len(dd.findings))
+
+		for k := range dd.findings {
+			f := dd.findings[k]
+			ds.Findings[k] = findingToSnapshot(&f)
+		}
+	}
+
+	return ds
+}
+
+//nolint:dupl // inverse field map of findingFromSnapshot; mirrored lists are inherent.
+func findingToSnapshot(v *findingData) findingSnapshot {
+	return findingSnapshot{
+		ID: v.id, FindingType: v.findingType, Severity: v.severity, Confidence: v.confidence,
+		Title: v.title, Description: v.description, AccountID: v.accountID, Region: v.region,
+		ARN: v.arn, Archived: v.archived, Count: v.count, ResourceRole: v.resourceRole,
+		ResourceType: v.resourceType, Feedback: v.feedback, Comment: v.comment,
+		CreatedAt: v.createdAt, UpdatedAt: v.updatedAt,
+		EventFirstSeen: v.eventFirstSeen, EventLastSeen: v.eventLastSeen,
+	}
+}
+
+func snapshotMalwarePlans(all map[string]malwarePlanData) map[string]malwarePlanSnapshot {
+	if len(all) == 0 {
+		return nil
+	}
+
+	out := make(map[string]malwarePlanSnapshot, len(all))
+
+	for id := range all {
+		p := all[id]
+		out[id] = malwarePlanSnapshot{
+			ID: p.id, ARN: p.arn, Role: p.role, ProtectedResource: p.protectedResource,
+			Actions: p.actions, Status: p.status, Tags: p.tags, CreatedAt: p.createdAt,
+		}
+	}
+
+	return out
+}
+
+func snapshotMalwareScans(all map[string]malwareScanData) map[string]malwareScanSnapshot {
+	if len(all) == 0 {
+		return nil
+	}
+
+	out := make(map[string]malwareScanSnapshot, len(all))
+
+	for id := range all {
+		s := all[id]
+		out[id] = malwareScanSnapshot{
+			ScanID: s.scanID, ResourceARN: s.resourceARN, ResourceType: s.resourceType,
+			Status: s.status, Result: s.result, ScanType: s.scanType,
+			StartedAt: s.startedAt, CompletedAt: s.completedAt,
+		}
+	}
+
+	return out
+}
+
+// Restore rebuilds the mock's state under the original identities: every
+// detector id, member/invitation/finding/publishing-destination key, and
+// malware plan/scan id is preserved so a client's identifiers still resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap guarddutySnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("guardduty: parse snapshot: %w", err)
+	}
+
+	for id, ds := range snap.Detectors {
+		m.detectors.Set(id, restoreDetector(ds))
+	}
+
+	if len(snap.OrgAdmins) > 0 {
+		if err := m.orgAdmins.LoadSnapshot(snap.OrgAdmins); err != nil {
+			return fmt.Errorf("guardduty: restore orgAdmins: %w", err)
+		}
+	}
+
+	for id := range snap.MalwarePlans {
+		p := snap.MalwarePlans[id]
+		m.malwarePlans.Set(id, malwarePlanData{
+			id: p.ID, arn: p.ARN, role: p.Role, protectedResource: p.ProtectedResource,
+			actions: p.Actions, status: p.Status, tags: p.Tags, createdAt: p.CreatedAt,
+		})
+	}
+
+	for id := range snap.MalwareScans {
+		s := snap.MalwareScans[id]
+		m.malwareScans.Set(id, malwareScanData{
+			scanID: s.ScanID, resourceARN: s.ResourceARN, resourceType: s.ResourceType,
+			status: s.Status, result: s.Result, scanType: s.ScanType,
+			startedAt: s.StartedAt, completedAt: s.CompletedAt,
+		})
+	}
+
+	return nil
+}
+
+func restoreDetector(ds *detectorSnapshot) *detectorData {
+	dd := &detectorData{
+		detector: ds.Detector, ipSets: ds.IPSets, threatIS: ds.ThreatIS,
+		threatES: ds.ThreatES, trustES: ds.TrustES, filters: ds.Filters,
+		members: map[string]memberData{}, invites: map[string]invitationData{},
+		publishDests: map[string]destData{}, findings: map[string]findingData{},
+		orgConfig: orgConfigData{
+			autoEnable: ds.OrgConfig.AutoEnable, autoEnableMembers: ds.OrgConfig.AutoEnableMembers,
+			features: ds.OrgConfig.Features, dataSources: ds.OrgConfig.DataSources,
+		},
+		malwareSettings: malwareScanSettings{
+			ebsSnapshotPreservation: ds.MalwareSettings.EbsSnapshotPreservation,
+			scanResourceCriteria:    ds.MalwareSettings.ScanResourceCriteria,
+		},
+	}
+
+	for k, v := range ds.Members {
+		dd.members[k] = memberData{
+			accountID: v.AccountID, email: v.Email, relationshipStatus: v.RelationshipStatus,
+			invitedAt: v.InvitedAt, updatedAt: v.UpdatedAt,
+		}
+	}
+
+	for k, v := range ds.Invites {
+		dd.invites[k] = invitationData{
+			inviterAccountID: v.InviterAccountID, invitationID: v.InvitationID,
+			invitedAt: v.InvitedAt, status: v.Status,
+		}
+	}
+
+	if ds.Admin != nil {
+		dd.admin = &adminLink{
+			accountID: ds.Admin.AccountID, invitationID: ds.Admin.InvitationID,
+			invitedAt: ds.Admin.InvitedAt, status: ds.Admin.Status,
+		}
+	}
+
+	for k := range ds.PublishDests {
+		v := ds.PublishDests[k]
+		dd.publishDests[k] = destData{
+			destinationID: v.DestinationID, destinationType: v.DestinationType,
+			destinationARN: v.DestinationARN, kmsKeyARN: v.KmsKeyARN, status: v.Status,
+			tags: v.Tags, createdAt: v.CreatedAt, updatedAt: v.UpdatedAt,
+		}
+	}
+
+	for k := range ds.Findings {
+		f := ds.Findings[k]
+		dd.findings[k] = findingFromSnapshot(&f)
+	}
+
+	return dd
+}
+
+//nolint:dupl // inverse field map of findingToSnapshot; mirrored lists are inherent.
+func findingFromSnapshot(v *findingSnapshot) findingData {
+	return findingData{
+		id: v.ID, findingType: v.FindingType, severity: v.Severity, confidence: v.Confidence,
+		title: v.Title, description: v.Description, accountID: v.AccountID, region: v.Region,
+		arn: v.ARN, archived: v.Archived, count: v.Count, resourceRole: v.ResourceRole,
+		resourceType: v.ResourceType, feedback: v.Feedback, comment: v.Comment,
+		createdAt: v.CreatedAt, updatedAt: v.UpdatedAt,
+		eventFirstSeen: v.EventFirstSeen, eventLastSeen: v.EventLastSeen,
+	}
+}

--- a/providers/aws/guardduty/snapshot_test.go
+++ b/providers/aws/guardduty/snapshot_test.go
@@ -1,0 +1,62 @@
+package guardduty_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/guardduty/driver"
+)
+
+// TestSnapshotRoundTripGuardDuty proves a snapshot/restore round-trip preserves
+// a detector together with its nested child state (a filter lives in the
+// detector's unexported filters map) under their original identities.
+func TestSnapshotRoundTripGuardDuty(t *testing.T) {
+	ctx := context.Background()
+	src := newMock()
+
+	det, err := src.CreateDetector(ctx, driver.CreateDetectorInput{
+		Enable: true,
+		Tags:   map[string]string{"env": "prod"},
+	})
+	if err != nil {
+		t.Fatalf("CreateDetector: %v", err)
+	}
+
+	if _, err := src.CreateFilter(ctx, driver.CreateFilterInput{
+		DetectorID:      det.ID,
+		Name:            "f1",
+		FindingCriteria: []byte(`{"criterion":{}}`),
+	}); err != nil {
+		t.Fatalf("CreateFilter: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	gotDet, err := dst.GetDetector(ctx, det.ID)
+	if err != nil {
+		t.Fatalf("GetDetector: %v", err)
+	}
+
+	if gotDet.Tags["env"] != "prod" {
+		t.Fatalf("restored detector tags = %+v", gotDet.Tags)
+	}
+
+	// The filter is nested inside the detector's unexported filters map; confirm
+	// the promotion carried it across.
+	f, err := dst.GetFilter(ctx, det.ID, "f1")
+	if err != nil {
+		t.Fatalf("GetFilter: %v", err)
+	}
+
+	if f.Name != "f1" {
+		t.Fatalf("restored filter = %+v", f)
+	}
+}

--- a/providers/aws/kafka/snapshot.go
+++ b/providers/aws/kafka/snapshot.go
@@ -1,0 +1,148 @@
+package kafka
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/kafka/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// kafkaSnapshot is the full serialized state of the Amazon MSK mock. The
+// clusters/configs/vpcConns/replicators stores hold unexported *xData whose
+// payload lives in unexported fields, so each is promoted to an exported form
+// keyed by its ARN. clusterNames holds plain strings and round-trips through the
+// generic memstore helper. The operations store is NOT serialized: it is an
+// index of *clusterData pointers shared with the clusters store, rebuilt on
+// restore from each cluster's operations slice so the shared identity (a
+// DescribeClusterOperation resolves to the same cluster object) is preserved.
+// The per-record mutexes, createMu, and the wired opts are not serialized.
+type kafkaSnapshot struct {
+	Clusters     map[string]*clusterSnapshot     `json:"clusters,omitempty"`
+	ClusterNames json.RawMessage                 `json:"clusterNames,omitempty"`
+	Configs      map[string]driver.Configuration `json:"configs,omitempty"`
+	VPCConns     map[string]driver.VpcConnection `json:"vpcConns,omitempty"`
+	Replicators  map[string]*replicatorSnapshot  `json:"replicators,omitempty"`
+}
+
+// clusterSnapshot mirrors clusterData (all fields unexported).
+type clusterSnapshot struct {
+	Cluster       driver.Cluster            `json:"cluster"`
+	Operations    []driver.ClusterOperation `json:"operations,omitempty"`
+	Topics        map[string]driver.Topic   `json:"topics,omitempty"`
+	ScramSecrets  []string                  `json:"scramSecrets,omitempty"`
+	Policy        string                    `json:"policy,omitempty"`
+	PolicyVersion string                    `json:"policyVersion,omitempty"`
+}
+
+// replicatorSnapshot mirrors replicatorData.
+type replicatorSnapshot struct {
+	Replicator driver.Replicator `json:"replicator"`
+	Version    string            `json:"version,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// MSK holds resource metadata, not bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := kafkaSnapshot{}
+
+	if m.clusters.Len() > 0 {
+		snap.Clusters = make(map[string]*clusterSnapshot, m.clusters.Len())
+
+		for arn, cd := range m.clusters.All() {
+			cd.mu.RLock()
+			snap.Clusters[arn] = &clusterSnapshot{
+				Cluster: cd.cluster, Operations: cd.operations, Topics: cd.topics,
+				ScramSecrets: cd.scramSecrets, Policy: cd.policy, PolicyVersion: cd.policyVersion,
+			}
+			cd.mu.RUnlock()
+		}
+	}
+
+	names, err := m.clusterNames.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("kafka: snapshot clusterNames: %w", err)
+	}
+
+	snap.ClusterNames = names
+
+	if m.configs.Len() > 0 {
+		snap.Configs = make(map[string]driver.Configuration, m.configs.Len())
+
+		for arn, cd := range m.configs.All() {
+			cd.mu.RLock()
+			snap.Configs[arn] = cd.config
+			cd.mu.RUnlock()
+		}
+	}
+
+	if m.vpcConns.Len() > 0 {
+		snap.VPCConns = make(map[string]driver.VpcConnection, m.vpcConns.Len())
+
+		for arn, vd := range m.vpcConns.All() {
+			vd.mu.RLock()
+			snap.VPCConns[arn] = vd.vpc
+			vd.mu.RUnlock()
+		}
+	}
+
+	if m.replicators.Len() > 0 {
+		snap.Replicators = make(map[string]*replicatorSnapshot, m.replicators.Len())
+
+		for arn, rd := range m.replicators.All() {
+			rd.mu.RLock()
+			snap.Replicators[arn] = &replicatorSnapshot{Replicator: rd.replicator, Version: rd.version}
+			rd.mu.RUnlock()
+		}
+	}
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds the mock's state under the original identities: every cluster,
+// configuration, VPC-connection, and replicator ARN is preserved, and the
+// operations index is reconstructed to share each restored cluster's pointer.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap kafkaSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("kafka: parse snapshot: %w", err)
+	}
+
+	for arn, cs := range snap.Clusters {
+		cd := &clusterData{
+			cluster: cs.Cluster, operations: cs.Operations, topics: cs.Topics,
+			scramSecrets: cs.ScramSecrets, policy: cs.Policy, policyVersion: cs.PolicyVersion,
+		}
+
+		m.clusters.Set(arn, cd)
+
+		// Rebuild the operation index against the same clusterData pointer so a
+		// DescribeClusterOperation resolves to this exact cluster.
+		for _, op := range cd.operations {
+			m.operations.Set(op.OperationARN, cd)
+		}
+	}
+
+	if len(snap.ClusterNames) > 0 {
+		if err := m.clusterNames.LoadSnapshot(snap.ClusterNames); err != nil {
+			return fmt.Errorf("kafka: restore clusterNames: %w", err)
+		}
+	}
+
+	for arn := range snap.Configs {
+		m.configs.Set(arn, &configData{config: snap.Configs[arn]})
+	}
+
+	for arn, vpc := range snap.VPCConns {
+		m.vpcConns.Set(arn, &vpcConnData{vpc: vpc})
+	}
+
+	for arn, rs := range snap.Replicators {
+		m.replicators.Set(arn, &replicatorData{replicator: rs.Replicator, version: rs.Version})
+	}
+
+	return nil
+}

--- a/providers/aws/kafka/snapshot_test.go
+++ b/providers/aws/kafka/snapshot_test.go
@@ -1,0 +1,65 @@
+package kafka_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/kafka/driver"
+)
+
+// TestSnapshotRoundTripKafka proves a snapshot/restore round-trip preserves a
+// cluster and — critically — rebuilds the operations index so a
+// DescribeClusterOperation still resolves to the restored cluster's operation.
+func TestSnapshotRoundTripKafka(t *testing.T) {
+	ctx := context.Background()
+	src := newMock(t)
+
+	out, err := src.CreateCluster(ctx, driver.CreateClusterInput{
+		ClusterName:         "my-cluster",
+		KafkaVersion:        "3.6.0",
+		NumberOfBrokerNodes: 2,
+		BrokerNodeGroupInfo: &driver.BrokerNodeGroupInfo{
+			ClientSubnets: []string{"subnet-1", "subnet-2"},
+			InstanceType:  "kafka.m5.large",
+		},
+		Tags: map[string]string{"env": "prod"},
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	op, err := src.UpdateBrokerCount(ctx, out.ClusterARN, out.CurrentVersion, 4)
+	if err != nil {
+		t.Fatalf("UpdateBrokerCount: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newMock(t)
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	got, err := dst.DescribeCluster(ctx, out.ClusterARN)
+	if err != nil {
+		t.Fatalf("DescribeCluster: %v", err)
+	}
+
+	if got.ClusterName != "my-cluster" || got.Tags["env"] != "prod" {
+		t.Fatalf("restored cluster = %+v", got)
+	}
+
+	// The operations index shares pointers with the clusters store; confirm it
+	// was rebuilt so the operation ARN still resolves.
+	gotOp, err := dst.DescribeClusterOperation(ctx, op.OperationARN)
+	if err != nil {
+		t.Fatalf("DescribeClusterOperation: %v", err)
+	}
+
+	if gotOp.OperationARN != op.OperationARN || gotOp.ClusterARN != out.ClusterARN {
+		t.Fatalf("restored operation = %+v", gotOp)
+	}
+}

--- a/providers/aws/keyspaces/snapshot.go
+++ b/providers/aws/keyspaces/snapshot.go
@@ -1,0 +1,94 @@
+package keyspaces
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// keyspacesSnapshot is the full serialized state of the Amazon Keyspaces mock.
+// The keyspaces/tables/udts stores hold fully-exported ksdriver value types, so
+// each round-trips through the generic memstore helper keyed by its store key
+// (keyspace name; "keyspace/table"; "keyspace/typename"). The mu-guarded tags
+// map (keyed by resource ARN) is captured beside them. The wired opts are not
+// serialized. A fresh mock is seeded with the system keyspaces, and the snapshot
+// carries them too, so LoadSnapshot's merge is idempotent.
+type keyspacesSnapshot struct {
+	Keyspaces json.RawMessage              `json:"keyspaces,omitempty"`
+	Tables    json.RawMessage              `json:"tables,omitempty"`
+	UDTs      json.RawMessage              `json:"udts,omitempty"`
+	Tags      map[string]map[string]string `json:"tags,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Keyspaces holds schema metadata, not bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap keyspacesSnapshot
+
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Keyspaces, m.keyspaces.Snapshot},
+		{&snap.Tables, m.tables.Snapshot},
+		{&snap.UDTs, m.udts.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return nil, fmt.Errorf("keyspaces: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	m.mu.RLock()
+	if len(m.tags) > 0 {
+		snap.Tags = m.tags
+	}
+	m.mu.RUnlock()
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds the mock's state under the original identities: every
+// keyspace name, "keyspace/table" and "keyspace/typename" key, and tag ARN is
+// preserved so a client's identifiers still resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap keyspacesSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("keyspaces: parse snapshot: %w", err)
+	}
+
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Keyspaces, m.keyspaces.LoadSnapshot},
+		{snap.Tables, m.tables.LoadSnapshot},
+		{snap.UDTs, m.udts.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("keyspaces: restore store: %w", err)
+		}
+	}
+
+	if snap.Tags != nil {
+		m.mu.Lock()
+		m.tags = snap.Tags
+		m.mu.Unlock()
+	}
+
+	return nil
+}

--- a/providers/aws/keyspaces/snapshot_test.go
+++ b/providers/aws/keyspaces/snapshot_test.go
@@ -1,0 +1,64 @@
+package keyspaces
+
+import (
+	"context"
+	"testing"
+
+	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
+)
+
+// TestSnapshotRoundTripKeyspaces proves a snapshot/restore round-trip preserves
+// keyspaces, tables (keyed by "keyspace/table"), and the mu-guarded tag map
+// under their original identities.
+func TestSnapshotRoundTripKeyspaces(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, err := src.CreateKeyspace(ctx, ksdriver.CreateKeyspaceConfig{Name: "ks1"}); err != nil {
+		t.Fatalf("CreateKeyspace: %v", err)
+	}
+
+	if _, err := src.CreateTable(ctx, ksdriver.CreateTableConfig{
+		KeyspaceName: "ks1",
+		Name:         "tbl1",
+		SchemaDefinition: ksdriver.SchemaDefinition{
+			AllColumns:    []ksdriver.ColumnDefinition{{Name: "id", Type: "text"}},
+			PartitionKeys: []ksdriver.PartitionKey{{Name: "id"}},
+		},
+	}); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	if err := src.TagResource(ctx, src.keyspaceARN("ks1"), map[string]string{"env": "prod"}); err != nil {
+		t.Fatalf("TagResource: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	ks, err := dst.GetKeyspace(ctx, "ks1")
+	if err != nil || ks.Name != "ks1" {
+		t.Fatalf("restored keyspace = %+v, err %v", ks, err)
+	}
+
+	tbl, err := dst.GetTable(ctx, "ks1", "tbl1")
+	if err != nil || tbl.Name != "tbl1" {
+		t.Fatalf("restored table = %+v, err %v", tbl, err)
+	}
+
+	tags, err := dst.ListTagsForResource(ctx, src.keyspaceARN("ks1"))
+	if err != nil {
+		t.Fatalf("ListTagsForResource: %v", err)
+	}
+
+	if len(tags) != 1 || tags[0].Key != "env" || tags[0].Value != "prod" {
+		t.Fatalf("restored tags = %+v", tags)
+	}
+}

--- a/providers/aws/lambda/snapshot.go
+++ b/providers/aws/lambda/snapshot.go
@@ -1,0 +1,190 @@
+package lambda
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// lambdaSnapshot is the full serialized state of the AWS Lambda mock. The funcs
+// store holds an unexported funcData whose payload (function info, published
+// versions carrying their deployment-package config, aliases, resource policies,
+// concurrency, URL and AWS-only config) lives in unexported fields, so it is
+// promoted to an exported form keyed by function name. The layers store holds an
+// unexported *layerData with a nested version store, also promoted; mappings
+// holds a fully-exported *driver type and round-trips through the generic
+// memstore helper. The live in-process handler funcs (funcData.handler and the
+// handlers registry) and the wired opts/monitoring are NOT serialized — they are
+// re-registered by the host process, not persistable state. On restore a
+// function's handler is re-linked from the handlers registry if one is present.
+type lambdaSnapshot struct {
+	Funcs    map[string]*funcSnapshot  `json:"funcs,omitempty"`
+	Layers   map[string]*layerSnapshot `json:"layers,omitempty"`
+	Mappings json.RawMessage           `json:"mappings,omitempty"`
+}
+
+// funcSnapshot mirrors funcData. Versions carry each published version's config
+// and code identity (CodeSHA256) — not the raw deployment-package bytes, which
+// the mock does not retain — so republished code is still identified after a
+// restore; aliases are captured by name.
+type funcSnapshot struct {
+	Info         driver.FunctionInfo                              `json:"info"`
+	EngineBacked bool                                             `json:"engineBacked,omitempty"`
+	Versions     []*versionSnapshot                               `json:"versions,omitempty"`
+	NextVersion  int                                              `json:"nextVersion,omitempty"`
+	Aliases      map[string]driver.Alias                          `json:"aliases,omitempty"`
+	Concurrency  *driver.ConcurrencyConfig                        `json:"concurrency,omitempty"`
+	Policies     map[string]map[string]driver.PermissionStatement `json:"policies,omitempty"`
+	URLConfig    *driver.FunctionURLConfig                        `json:"urlConfig,omitempty"`
+	AWSConfig    driver.AWSFunctionConfig                         `json:"awsConfig"`
+}
+
+// versionSnapshot mirrors versionData (all fields unexported). Config carries the
+// published version's configuration and its code identity (CodeSHA256), not the
+// raw deployment-package bytes.
+type versionSnapshot struct {
+	Config     driver.FunctionConfig `json:"config"`
+	Version    string                `json:"version"`
+	CodeSHA    string                `json:"codeSha,omitempty"`
+	RevisionID string                `json:"revisionId,omitempty"`
+	CreatedAt  string                `json:"createdAt,omitempty"`
+}
+
+// layerSnapshot mirrors layerData; its version store holds a fully-exported
+// *driver.LayerVersion and round-trips through the generic helper.
+type layerSnapshot struct {
+	Versions json.RawMessage `json:"versions,omitempty"`
+	NextVer  int             `json:"nextVer,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// published versions retain only their code identity (CodeSHA256) and config,
+// not raw deployment-package bytes, so there are no bulk object bodies to gate.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := lambdaSnapshot{}
+
+	if m.funcs.Len() > 0 {
+		snap.Funcs = make(map[string]*funcSnapshot, m.funcs.Len())
+
+		for _, name := range m.funcs.Keys() {
+			fd, ok := m.funcs.Get(name)
+			if !ok {
+				continue
+			}
+
+			snap.Funcs[name] = snapshotFunc(&fd)
+		}
+	}
+
+	if m.layers.Len() > 0 {
+		snap.Layers = make(map[string]*layerSnapshot, m.layers.Len())
+
+		for name, ld := range m.layers.All() {
+			vers, err := ld.versions.Snapshot()
+			if err != nil {
+				return nil, fmt.Errorf("lambda: snapshot layer versions: %w", err)
+			}
+
+			snap.Layers[name] = &layerSnapshot{Versions: vers, NextVer: ld.nextVer}
+		}
+	}
+
+	mappings, err := m.mappings.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("lambda: snapshot mappings: %w", err)
+	}
+
+	snap.Mappings = mappings
+
+	return json.Marshal(snap)
+}
+
+func snapshotFunc(fd *funcData) *funcSnapshot {
+	fs := &funcSnapshot{
+		Info: fd.info, EngineBacked: fd.engineBacked, NextVersion: fd.nextVersion,
+		Concurrency: fd.concurrency, Policies: fd.policies, URLConfig: fd.urlConfig,
+		AWSConfig: fd.awsConfig,
+	}
+
+	for _, v := range fd.versions {
+		fs.Versions = append(fs.Versions, &versionSnapshot{
+			Config: v.config, Version: v.version, CodeSHA: v.codeSHA,
+			RevisionID: v.revisionID, CreatedAt: v.createdAt,
+		})
+	}
+
+	if fd.aliases != nil && fd.aliases.Len() > 0 {
+		fs.Aliases = make(map[string]driver.Alias, fd.aliases.Len())
+		for k, ad := range fd.aliases.All() {
+			fs.Aliases[k] = ad.alias
+		}
+	}
+
+	return fs
+}
+
+// Restore rebuilds the mock's state under the original identities: every
+// function name (and the ARNs/versions/aliases it carries), layer name, and
+// event-source-mapping UUID is preserved so a client's identifiers still resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap lambdaSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("lambda: parse snapshot: %w", err)
+	}
+
+	for name, fs := range snap.Funcs {
+		m.funcs.Set(name, m.restoreFunc(name, fs))
+	}
+
+	for name, ls := range snap.Layers {
+		ld := &layerData{versions: memstore.New[*driver.LayerVersion](), nextVer: ls.NextVer}
+		if len(ls.Versions) > 0 {
+			if err := ld.versions.LoadSnapshot(ls.Versions); err != nil {
+				return fmt.Errorf("lambda: restore layer versions: %w", err)
+			}
+		}
+
+		m.layers.Set(name, ld)
+	}
+
+	if len(snap.Mappings) > 0 {
+		if err := m.mappings.LoadSnapshot(snap.Mappings); err != nil {
+			return fmt.Errorf("lambda: restore mappings: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (m *Mock) restoreFunc(name string, fs *funcSnapshot) funcData {
+	fd := funcData{
+		info: fs.Info, engineBacked: fs.EngineBacked, nextVersion: fs.NextVersion,
+		aliases: memstore.New[*aliasData](), concurrency: fs.Concurrency,
+		policies: fs.Policies, urlConfig: fs.URLConfig, awsConfig: fs.AWSConfig,
+	}
+
+	// Re-link the live handler if the host process has registered one for this
+	// function; a freshly built mock has none, matching a cold process start.
+	m.handlersMu.RLock()
+	fd.handler = m.handlers[name]
+	m.handlersMu.RUnlock()
+
+	for _, v := range fs.Versions {
+		fd.versions = append(fd.versions, &versionData{
+			config: v.Config, version: v.Version, codeSHA: v.CodeSHA,
+			revisionID: v.RevisionID, createdAt: v.CreatedAt,
+		})
+	}
+
+	for k, a := range fs.Aliases {
+		fd.aliases.Set(k, &aliasData{alias: a})
+	}
+
+	return fd
+}

--- a/providers/aws/lambda/snapshot_test.go
+++ b/providers/aws/lambda/snapshot_test.go
@@ -1,0 +1,93 @@
+package lambda
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// TestSnapshotRoundTripLambda proves a snapshot/restore round-trip preserves a
+// function together with its published version (and that version's captured
+// config), an alias pointing at that version, and an event-source mapping — all
+// under their original identities.
+func TestSnapshotRoundTripLambda(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	cfg := defaultFuncConfig()
+	cfg.Code = []byte("zip-bytes-here")
+
+	if _, err := src.CreateFunction(ctx, cfg); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	ver, err := src.PublishVersion(ctx, cfg.Name, "v1")
+	if err != nil {
+		t.Fatalf("PublishVersion: %v", err)
+	}
+
+	if _, err := src.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: cfg.Name, Name: "live", FunctionVersion: ver.Version,
+	}); err != nil {
+		t.Fatalf("CreateAlias: %v", err)
+	}
+
+	esm, err := src.CreateEventSourceMapping(ctx, driver.EventSourceMappingConfig{
+		FunctionName:   cfg.Name,
+		EventSourceArn: "arn:aws:sqs:us-east-1:123456789012:q",
+		BatchSize:      10,
+		Enabled:        true,
+	})
+	if err != nil {
+		t.Fatalf("CreateEventSourceMapping: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	fn, err := dst.GetFunction(ctx, cfg.Name)
+	if err != nil || fn.Tags["env"] != "test" || fn.CodeSHA256 == "" {
+		t.Fatalf("restored function = %+v, err %v", fn, err)
+	}
+
+	vers, err := dst.ListVersions(ctx, cfg.Name)
+	if err != nil {
+		t.Fatalf("ListVersions: %v", err)
+	}
+
+	var found bool
+	for _, v := range vers {
+		if v.Version == ver.Version {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatalf("published version %s missing from restored versions %+v", ver.Version, vers)
+	}
+
+	// The published version's captured config carries the code identity the mock
+	// retains (CodeSHA256); confirm the promotion preserved it verbatim.
+	fd, ok := dst.funcs.Get(cfg.Name)
+	if !ok || len(fd.versions) != 1 || fd.versions[0].config.Name != cfg.Name {
+		t.Fatalf("restored funcData versions = %+v, ok %v", fd.versions, ok)
+	}
+
+	alias, err := dst.GetAlias(ctx, cfg.Name, "live")
+	if err != nil || alias.FunctionVersion != ver.Version {
+		t.Fatalf("restored alias = %+v, err %v", alias, err)
+	}
+
+	gotESM, err := dst.GetEventSourceMapping(ctx, esm.UUID)
+	if err != nil || gotESM.FunctionArn == "" {
+		t.Fatalf("restored esm = %+v, err %v", gotESM, err)
+	}
+}

--- a/providers/aws/memorydb/snapshot.go
+++ b/providers/aws/memorydb/snapshot.go
@@ -1,0 +1,154 @@
+package memorydb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// memorydbSnapshot is the full serialized state of the AWS MemoryDB mock. Every
+// memstore store holds a fully-exported mdbdriver type (Cluster, ACL, User,
+// ParameterGroup, SubnetGroup, Snapshot, MultiRegionCluster, ReservedNode), so
+// each round-trips through the generic memstore helper keyed by its resource
+// name. The mu-guarded state that lives beside the stores — the parameter-group
+// overrides, the ARN-keyed tag maps, and the append-only event log — is captured
+// alongside. The wired deps (opts, monitoring) are intentionally not serialized:
+// a restore reinstates records, not the CloudWatch backend they emit into.
+type memorydbSnapshot struct {
+	Clusters        json.RawMessage `json:"clusters,omitempty"`
+	ACLs            json.RawMessage `json:"acls,omitempty"`
+	Users           json.RawMessage `json:"users,omitempty"`
+	ParameterGroups json.RawMessage `json:"parameterGroups,omitempty"`
+	SubnetGroups    json.RawMessage `json:"subnetGroups,omitempty"`
+	Snapshots       json.RawMessage `json:"snapshots,omitempty"`
+	MultiRegion     json.RawMessage `json:"multiRegion,omitempty"`
+	ReservedNodes   json.RawMessage `json:"reservedNodes,omitempty"`
+
+	ParamOverrides map[string]map[string]string `json:"paramOverrides,omitempty"`
+	Tags           map[string]map[string]string `json:"tags,omitempty"`
+	Events         []mdbdriver.Event            `json:"events,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// MemoryDB is control-plane only and holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap memorydbSnapshot
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	m.snapshotScalarState(&snap)
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *memorydbSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Clusters, m.clusters.Snapshot},
+		{&snap.ACLs, m.acls.Snapshot},
+		{&snap.Users, m.users.Snapshot},
+		{&snap.ParameterGroups, m.parameterGroups.Snapshot},
+		{&snap.SubnetGroups, m.subnetGroups.Snapshot},
+		{&snap.Snapshots, m.snapshots.Snapshot},
+		{&snap.MultiRegion, m.multiRegion.Snapshot},
+		{&snap.ReservedNodes, m.reservedNodes.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("memorydb: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// snapshotScalarState captures the mu-guarded maps and event log beside the
+// stores.
+func (m *Mock) snapshotScalarState(snap *memorydbSnapshot) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	snap.ParamOverrides = m.paramOverrides
+	snap.Tags = m.tags
+
+	if len(m.events) > 0 {
+		snap.Events = append([]mdbdriver.Event(nil), m.events...)
+	}
+}
+
+// Restore rebuilds the mock's state under the original identities: every cluster,
+// ACL, user, and group name (and the name-string cross-references records hold)
+// is preserved, so a restore is transparent to clients.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap memorydbSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("memorydb: parse snapshot: %w", err)
+	}
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	m.restoreScalarState(&snap)
+
+	return nil
+}
+
+func (m *Mock) restoreStores(snap *memorydbSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Clusters, m.clusters.LoadSnapshot},
+		{snap.ACLs, m.acls.LoadSnapshot},
+		{snap.Users, m.users.LoadSnapshot},
+		{snap.ParameterGroups, m.parameterGroups.LoadSnapshot},
+		{snap.SubnetGroups, m.subnetGroups.LoadSnapshot},
+		{snap.Snapshots, m.snapshots.LoadSnapshot},
+		{snap.MultiRegion, m.multiRegion.LoadSnapshot},
+		{snap.ReservedNodes, m.reservedNodes.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("memorydb: restore store: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// restoreScalarState reinstates the mu-guarded maps and event log, leaving unset
+// ones at their New() defaults.
+func (m *Mock) restoreScalarState(snap *memorydbSnapshot) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if snap.ParamOverrides != nil {
+		m.paramOverrides = snap.ParamOverrides
+	}
+
+	if snap.Tags != nil {
+		m.tags = snap.Tags
+	}
+
+	if snap.Events != nil {
+		m.events = snap.Events
+	}
+}

--- a/providers/aws/memorydb/snapshot_test.go
+++ b/providers/aws/memorydb/snapshot_test.go
@@ -1,0 +1,63 @@
+package memorydb
+
+import (
+	"context"
+	"testing"
+
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+// TestSnapshotRoundTripMemoryDB proves a snapshot/restore round-trip preserves
+// every store and the mu-guarded state (tags, events) under their original
+// identities.
+func TestSnapshotRoundTripMemoryDB(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, err := src.CreateSubnetGroup(ctx, mdbdriver.CreateSubnetGroupConfig{
+		Name: "sng", Description: "sng desc", SubnetIDs: []string{"subnet-1", "subnet-2"},
+	}); err != nil {
+		t.Fatalf("create subnet group: %v", err)
+	}
+
+	c, err := src.CreateCluster(ctx, mdbdriver.CreateClusterConfig{
+		Name: "c1", NumShards: 2, NumReplicasPerShard: i32p(1), SubnetGroupName: "sng",
+	})
+	if err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if _, err := src.TagResource(ctx, c.ARN, map[string]string{"env": "prod"}); err != nil {
+		t.Fatalf("tag cluster: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	clusters, err := dst.DescribeClusters(ctx, []string{"c1"})
+	if err != nil || len(clusters) != 1 || clusters[0].Name != "c1" {
+		t.Fatalf("restored clusters = %+v, err %v", clusters, err)
+	}
+
+	if clusters[0].SubnetGroupName != "sng" || len(clusters[0].Shards) != 2 {
+		t.Fatalf("cluster config not preserved: %+v", clusters[0])
+	}
+
+	sngs, err := dst.DescribeSubnetGroups(ctx, []string{"sng"})
+	if err != nil || len(sngs) != 1 || sngs[0].Description != "sng desc" {
+		t.Fatalf("restored subnet groups = %+v, err %v", sngs, err)
+	}
+
+	// Tags (mu-guarded, ARN-keyed) survived the round-trip.
+	tags, err := dst.ListTags(ctx, c.ARN)
+	if err != nil || len(tags) != 1 || tags[0].Key != "env" || tags[0].Value != "prod" {
+		t.Fatalf("restored tags = %+v, err %v", tags, err)
+	}
+}

--- a/providers/aws/networkfirewall/snapshot.go
+++ b/providers/aws/networkfirewall/snapshot.go
@@ -1,0 +1,117 @@
+package networkfirewall
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// networkfirewallSnapshot is the full serialized state of the AWS Network
+// Firewall mock. Every memstore store holds a fully-exported *nfdriver pointer
+// type (Firewall, FirewallPolicy, RuleGroup), so each round-trips through the
+// generic memstore helper under its exact key — firewalls/policies by name, rule
+// groups by the "TYPE/name" composite key, so DescribeRuleGroup's type-qualified
+// lookup keeps working after a restore. The mu-guarded logging map (firewall
+// name -> log types) is captured beside the stores. The wired opts is
+// intentionally not serialized.
+type networkfirewallSnapshot struct {
+	Firewalls  json.RawMessage     `json:"firewalls,omitempty"`
+	Policies   json.RawMessage     `json:"policies,omitempty"`
+	RuleGroups json.RawMessage     `json:"ruleGroups,omitempty"`
+	Logging    map[string][]string `json:"logging,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Network Firewall is control-plane only and holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap networkfirewallSnapshot
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	m.mu.RLock()
+	logging := make(map[string][]string, len(m.logging))
+
+	for name, types := range m.logging {
+		logging[name] = append([]string(nil), types...)
+	}
+
+	m.mu.RUnlock()
+
+	if len(logging) > 0 {
+		snap.Logging = logging
+	}
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *networkfirewallSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Firewalls, m.firewalls.Snapshot},
+		{&snap.Policies, m.policies.Snapshot},
+		{&snap.RuleGroups, m.ruleGroups.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("networkfirewall: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds the mock's state under the original identities: every
+// firewall/policy/rule-group name and ARN (and the ARN cross-references records
+// hold) is preserved, so a restore is transparent to clients.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap networkfirewallSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("networkfirewall: parse snapshot: %w", err)
+	}
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	if snap.Logging != nil {
+		m.logging = snap.Logging
+	}
+	m.mu.Unlock()
+
+	return nil
+}
+
+func (m *Mock) restoreStores(snap *networkfirewallSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Firewalls, m.firewalls.LoadSnapshot},
+		{snap.Policies, m.policies.LoadSnapshot},
+		{snap.RuleGroups, m.ruleGroups.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("networkfirewall: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/aws/networkfirewall/snapshot_test.go
+++ b/providers/aws/networkfirewall/snapshot_test.go
@@ -1,0 +1,72 @@
+package networkfirewall
+
+import (
+	"context"
+	"testing"
+
+	nfdriver "github.com/stackshy/cloudemu/v2/services/networkfirewall/driver"
+)
+
+// TestSnapshotRoundTripNetworkFirewall proves a snapshot/restore round-trip
+// preserves the firewall/policy/rule-group stores and the mu-guarded logging map
+// under their original identities.
+func TestSnapshotRoundTripNetworkFirewall(t *testing.T) {
+	ctx := context.Background()
+	src := newMock()
+
+	pol, err := src.CreateFirewallPolicy(ctx, nfdriver.CreateFirewallPolicyConfig{
+		Name: "pol-1", Description: "policy one",
+	})
+	if err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+
+	fw, err := src.CreateFirewall(ctx, nfdriver.CreateFirewallConfig{
+		Name: "fw-1", VPCID: "vpc-1", SubnetIDs: []string{"subnet-1"}, PolicyARN: pol.ARN,
+	})
+	if err != nil {
+		t.Fatalf("create firewall: %v", err)
+	}
+
+	if _, err := src.CreateRuleGroup(ctx, nfdriver.CreateRuleGroupConfig{
+		Name: "rg-1", Type: "STATEFUL", Capacity: 100,
+	}); err != nil {
+		t.Fatalf("create rule group: %v", err)
+	}
+
+	if err := src.UpdateLoggingConfiguration(ctx, "fw-1", []string{"FLOW", "ALERT"}); err != nil {
+		t.Fatalf("update logging: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	gotFw, err := dst.DescribeFirewall(ctx, "fw-1", "")
+	if err != nil || gotFw.ARN != fw.ARN || gotFw.PolicyARN != pol.ARN {
+		t.Fatalf("restored firewall = %+v, err %v", gotFw, err)
+	}
+
+	gotPol, err := dst.DescribeFirewallPolicy(ctx, "pol-1", "")
+	if err != nil || gotPol.Description != "policy one" {
+		t.Fatalf("restored policy = %+v, err %v", gotPol, err)
+	}
+
+	// Rule group keyed by "TYPE/name" resolves through the type-qualified lookup.
+	gotRg, err := dst.DescribeRuleGroup(ctx, "rg-1", "", "STATEFUL")
+	if err != nil || gotRg.Capacity != 100 {
+		t.Fatalf("restored rule group = %+v, err %v", gotRg, err)
+	}
+
+	// Logging (mu-guarded) survived.
+	logs, err := dst.DescribeLoggingConfiguration(ctx, "fw-1")
+	if err != nil || len(logs) != 2 || logs[0] != "FLOW" || logs[1] != "ALERT" {
+		t.Fatalf("restored logging = %+v, err %v", logs, err)
+	}
+}

--- a/providers/aws/opensearch/snapshot.go
+++ b/providers/aws/opensearch/snapshot.go
@@ -1,0 +1,175 @@
+package opensearch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/opensearch/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// opensearchSnapshot is the full serialized state of the AWS OpenSearch mock. The
+// domains store holds an unexported *domainData (whose fields — status, config,
+// tags, dataSrcs — are all unexported and invisible to json.Marshal), so it is
+// promoted to an exported domainSnapshot keyed by domain name. Every other store
+// holds a fully-exported *driver pointer type (or a plain string for the
+// name-claim stores pkgNames/appNames), so each round-trips through the generic
+// memstore helper under its exact key — preserving the composite keys used by
+// pkgAssoc ("packageID|domainName") so cross-references survive. The mu-guarded
+// defaultAppSet (application id -> raw default config) is captured beside the
+// stores. The per-domain mutex and the wired opts are intentionally not
+// serialized.
+type opensearchSnapshot struct {
+	Domains  map[string]*domainSnapshot `json:"domains,omitempty"`
+	Packages json.RawMessage            `json:"packages,omitempty"`
+	VpcEnds  json.RawMessage            `json:"vpcEnds,omitempty"`
+	Inbound  json.RawMessage            `json:"inbound,omitempty"`
+	Outbound json.RawMessage            `json:"outbound,omitempty"`
+	Apps     json.RawMessage            `json:"apps,omitempty"`
+	DQData   json.RawMessage            `json:"dqDataSrcs,omitempty"`
+	Reserved json.RawMessage            `json:"reserved,omitempty"`
+	PkgAssoc json.RawMessage            `json:"pkgAssoc,omitempty"`
+	PkgNames json.RawMessage            `json:"pkgNames,omitempty"`
+	AppNames json.RawMessage            `json:"appNames,omitempty"`
+
+	DefaultAppSet map[string]json.RawMessage `json:"defaultAppSet,omitempty"`
+}
+
+// domainSnapshot is the exported form of domainData (all fields unexported). The
+// per-domain mutex is transient and not carried.
+type domainSnapshot struct {
+	Status   driver.DomainStatus          `json:"status"`
+	Config   driver.DomainConfig          `json:"config"`
+	Tags     map[string]string            `json:"tags,omitempty"`
+	DataSrcs map[string]driver.DataSource `json:"dataSrcs,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// OpenSearch is control-plane only and holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := opensearchSnapshot{Domains: m.snapshotDomains()}
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	m.defaultAppMu.RLock()
+	snap.DefaultAppSet = m.defaultAppSet
+	m.defaultAppMu.RUnlock()
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotDomains() map[string]*domainSnapshot {
+	if m.domains.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*domainSnapshot, m.domains.Len())
+
+	for name, dd := range m.domains.All() {
+		dd.mu.RLock()
+		out[name] = &domainSnapshot{
+			Status: dd.status, Config: dd.config, Tags: dd.tags, DataSrcs: dd.dataSrcs,
+		}
+		dd.mu.RUnlock()
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotStores(snap *opensearchSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Packages, m.packages.Snapshot},
+		{&snap.VpcEnds, m.vpcEnds.Snapshot},
+		{&snap.Inbound, m.inbound.Snapshot},
+		{&snap.Outbound, m.outbound.Snapshot},
+		{&snap.Apps, m.apps.Snapshot},
+		{&snap.DQData, m.dqDataSrcs.Snapshot},
+		{&snap.Reserved, m.reserved.Snapshot},
+		{&snap.PkgAssoc, m.pkgAssoc.Snapshot},
+		{&snap.PkgNames, m.pkgNames.Snapshot},
+		{&snap.AppNames, m.appNames.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("opensearch: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds the mock's state under the original identities: every domain
+// name, package/application id, and connection id (and the id cross-references
+// records hold) is preserved, so a restore is transparent to clients.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap opensearchSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("opensearch: parse snapshot: %w", err)
+	}
+
+	m.restoreDomains(snap.Domains)
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	m.defaultAppMu.Lock()
+	if snap.DefaultAppSet != nil {
+		m.defaultAppSet = snap.DefaultAppSet
+	}
+	m.defaultAppMu.Unlock()
+
+	return nil
+}
+
+func (m *Mock) restoreDomains(domains map[string]*domainSnapshot) {
+	for name, ds := range domains {
+		dd := &domainData{status: ds.Status, config: ds.Config, tags: ds.Tags, dataSrcs: ds.DataSrcs}
+		if dd.dataSrcs == nil {
+			dd.dataSrcs = map[string]driver.DataSource{}
+		}
+
+		m.domains.Set(name, dd)
+	}
+}
+
+func (m *Mock) restoreStores(snap *opensearchSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Packages, m.packages.LoadSnapshot},
+		{snap.VpcEnds, m.vpcEnds.LoadSnapshot},
+		{snap.Inbound, m.inbound.LoadSnapshot},
+		{snap.Outbound, m.outbound.LoadSnapshot},
+		{snap.Apps, m.apps.LoadSnapshot},
+		{snap.DQData, m.dqDataSrcs.LoadSnapshot},
+		{snap.Reserved, m.reserved.LoadSnapshot},
+		{snap.PkgAssoc, m.pkgAssoc.LoadSnapshot},
+		{snap.PkgNames, m.pkgNames.LoadSnapshot},
+		{snap.AppNames, m.appNames.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("opensearch: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/aws/opensearch/snapshot_test.go
+++ b/providers/aws/opensearch/snapshot_test.go
@@ -1,0 +1,55 @@
+package opensearch_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/opensearch/driver"
+)
+
+// TestSnapshotRoundTripOpenSearch proves a snapshot/restore round-trip preserves
+// the promoted domain store (whose *domainData carries unexported status/config/
+// tags) and the fully-exported package store under their original identities.
+func TestSnapshotRoundTripOpenSearch(t *testing.T) {
+	ctx := context.Background()
+	src := newMock(t)
+
+	if _, err := src.CreateDomain(ctx, driver.CreateDomainInput{
+		DomainName:    "my-domain",
+		EngineVersion: "OpenSearch_2.11",
+		ClusterConfig: driver.ClusterConfig{InstanceType: "t3.small.search", InstanceCount: 3},
+		Tags:          map[string]string{"env": "prod"},
+	}); err != nil {
+		t.Fatalf("create domain: %v", err)
+	}
+
+	if _, err := src.CreatePackage(ctx, driver.CreatePackageInput{
+		PackageName: "pkg-1", PackageType: "TXT-DICTIONARY", S3BucketName: "b", S3Key: "k",
+	}); err != nil {
+		t.Fatalf("create package: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newMock(t)
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	desc, err := dst.DescribeDomain(ctx, "my-domain")
+	if err != nil {
+		t.Fatalf("describe domain: %v", err)
+	}
+
+	if desc.EngineVersion != "OpenSearch_2.11" || desc.ClusterConfig.InstanceCount != 3 {
+		t.Fatalf("domain config not preserved after restore: %+v", desc)
+	}
+
+	pkgs, _, err := dst.DescribePackages(ctx, driver.Page{})
+	if err != nil || len(pkgs) != 1 || pkgs[0].PackageName != "pkg-1" {
+		t.Fatalf("restored packages = %+v, err %v", pkgs, err)
+	}
+}

--- a/providers/aws/redshift/snapshot.go
+++ b/providers/aws/redshift/snapshot.go
@@ -1,0 +1,114 @@
+package redshift
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// redshiftSnapshot is the full serialized state of the AWS Redshift mock. Every
+// memstore store holds a fully-exported value type — rdbdriver.Cluster /
+// rdbdriver.ClusterSnapshot for the shared resources, and the redshift-package
+// ParameterGroup / SubnetGroup (all fields exported) for the redshift-specific
+// ones — so each round-trips through the generic memstore helper keyed by its
+// resource id/name. The mu-guarded tagsByARN map (ARN -> tag map) lives beside
+// the stores and is captured with them. The wired deps (opts, monitoring,
+// subnetResolver) and the real DatabaseEngine backing are intentionally not
+// serialized: a restored cluster reports its stored endpoint, not a re-provisioned
+// engine host.
+type redshiftSnapshot struct {
+	Clusters         json.RawMessage `json:"clusters,omitempty"`
+	ClusterSnapshots json.RawMessage `json:"clusterSnapshots,omitempty"`
+	ParameterGroups  json.RawMessage `json:"parameterGroups,omitempty"`
+	SubnetGroups     json.RawMessage `json:"subnetGroups,omitempty"`
+
+	TagsByARN map[string]map[string]string `json:"tagsByArn,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Redshift is control-plane only and holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap redshiftSnapshot
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	m.mu.RLock()
+	snap.TagsByARN = m.tagsByARN
+	m.mu.RUnlock()
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotStores(snap *redshiftSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Clusters, m.clusters.Snapshot},
+		{&snap.ClusterSnapshots, m.clusterSnapshots.Snapshot},
+		{&snap.ParameterGroups, m.parameterGroups.Snapshot},
+		{&snap.SubnetGroups, m.subnetGroups.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("redshift: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// Restore rebuilds the mock's state under the original identities: every cluster
+// id, snapshot id, and group name (and the id/name cross-references records hold)
+// is preserved, so a restore is transparent to clients.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap redshiftSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("redshift: parse snapshot: %w", err)
+	}
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	if snap.TagsByARN != nil {
+		m.tagsByARN = snap.TagsByARN
+	}
+	m.mu.Unlock()
+
+	return nil
+}
+
+func (m *Mock) restoreStores(snap *redshiftSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Clusters, m.clusters.LoadSnapshot},
+		{snap.ClusterSnapshots, m.clusterSnapshots.LoadSnapshot},
+		{snap.ParameterGroups, m.parameterGroups.LoadSnapshot},
+		{snap.SubnetGroups, m.subnetGroups.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("redshift: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/aws/redshift/snapshot_test.go
+++ b/providers/aws/redshift/snapshot_test.go
@@ -1,0 +1,78 @@
+package redshift
+
+import (
+	"context"
+	"testing"
+
+	rdbdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// TestSnapshotRoundTripRedshift proves a snapshot/restore round-trip preserves
+// every store and the mu-guarded ARN-keyed tag map under their original
+// identities.
+func TestSnapshotRoundTripRedshift(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, err := src.CreateClusterSubnetGroup(ctx, "sng", "sng desc", []string{"subnet-1"}); err != nil {
+		t.Fatalf("create subnet group: %v", err)
+	}
+
+	if _, err := src.CreateClusterParameterGroup(ctx, "pg", "redshift-1.0", "pg desc"); err != nil {
+		t.Fatalf("create param group: %v", err)
+	}
+
+	cl, err := src.CreateCluster(ctx, rdbdriver.ClusterConfig{
+		ID: "cl1", Engine: "redshift", NodeType: "dc2.large", NumberOfNodes: 2,
+		MasterUsername: "admin", SubnetGroupName: "sng",
+	})
+	if err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if _, err := src.CreateClusterSnapshot(ctx, rdbdriver.ClusterSnapshotConfig{
+		ID: "snap1", ClusterID: "cl1",
+	}); err != nil {
+		t.Fatalf("create cluster snapshot: %v", err)
+	}
+
+	if err := src.CreateTags(ctx, cl.ARN, map[string]string{"env": "prod"}); err != nil {
+		t.Fatalf("create tags: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	clusters, err := dst.DescribeClusters(ctx, []string{"cl1"})
+	if err != nil || len(clusters) != 1 || clusters[0].NodeType != "dc2.large" || clusters[0].NumberOfNodes != 2 {
+		t.Fatalf("restored clusters = %+v, err %v", clusters, err)
+	}
+
+	snaps, err := dst.DescribeClusterSnapshots(ctx, []string{"snap1"}, "")
+	if err != nil || len(snaps) != 1 || snaps[0].ClusterID != "cl1" {
+		t.Fatalf("restored cluster snapshots = %+v, err %v", snaps, err)
+	}
+
+	pgs, err := dst.DescribeClusterParameterGroups(ctx, []string{"pg"})
+	if err != nil || len(pgs) != 1 || pgs[0].Family != "redshift-1.0" {
+		t.Fatalf("restored param groups = %+v, err %v", pgs, err)
+	}
+
+	sngs, err := dst.DescribeClusterSubnetGroups(ctx, []string{"sng"})
+	if err != nil || len(sngs) != 1 || sngs[0].Description != "sng desc" {
+		t.Fatalf("restored subnet groups = %+v, err %v", sngs, err)
+	}
+
+	// Tags (mu-guarded, ARN-keyed) survived the round-trip.
+	tags, err := dst.DescribeTags(ctx, cl.ARN)
+	if err != nil || tags["env"] != "prod" {
+		t.Fatalf("restored tags = %+v, err %v", tags, err)
+	}
+}

--- a/providers/aws/route53resolver/snapshot.go
+++ b/providers/aws/route53resolver/snapshot.go
@@ -1,0 +1,122 @@
+package route53resolver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// route53resolverSnapshot is the full serialized state of the AWS Route 53
+// Resolver mock. Every memstore store holds a fully-exported value type — a
+// *driver pointer type for each resource, or a plain string / []string /
+// []driver.Tag for the policy, firewall-domain, tag, and idempotency stores — so
+// each round-trips through the generic memstore helper under its exact key. The
+// composite keys matter and are preserved: fwRules is keyed by
+// "group|domainList|qtype", tags by resource ARN, and idem by
+// "kind|creatorRequestID", so a replayed idempotent create still resolves after a
+// restore. The wired opts and the serializing mutex are intentionally not
+// serialized.
+type route53resolverSnapshot struct {
+	Endpoints    json.RawMessage `json:"endpoints,omitempty"`
+	Rules        json.RawMessage `json:"rules,omitempty"`
+	RuleAssocs   json.RawMessage `json:"ruleAssocs,omitempty"`
+	RulePolicies json.RawMessage `json:"rulePolicies,omitempty"`
+	QLCs         json.RawMessage `json:"qlcs,omitempty"`
+	QLCAssocs    json.RawMessage `json:"qlcAssocs,omitempty"`
+	QLCPolicies  json.RawMessage `json:"qlcPolicies,omitempty"`
+	RslvrConfigs json.RawMessage `json:"rslvrConfigs,omitempty"`
+	DnssecCfgs   json.RawMessage `json:"dnssecCfgs,omitempty"`
+	FwDomLists   json.RawMessage `json:"fwDomLists,omitempty"`
+	FwDomains    json.RawMessage `json:"fwDomains,omitempty"`
+	FwRuleGroups json.RawMessage `json:"fwRuleGroups,omitempty"`
+	FwRules      json.RawMessage `json:"fwRules,omitempty"`
+	FwAssocs     json.RawMessage `json:"fwAssocs,omitempty"`
+	FwConfigs    json.RawMessage `json:"fwConfigs,omitempty"`
+	FwPolicies   json.RawMessage `json:"fwPolicies,omitempty"`
+	Outposts     json.RawMessage `json:"outposts,omitempty"`
+	Tags         json.RawMessage `json:"tags,omitempty"`
+	Idem         json.RawMessage `json:"idem,omitempty"`
+}
+
+// storeRefs pairs each snapshot field with its store's Snapshot/LoadSnapshot
+// entry points, so dump and load walk the identical, symmetric list.
+func (m *Mock) storeRefs(snap *route53resolverSnapshot) []struct {
+	dst  *json.RawMessage
+	dump func() ([]byte, error)
+	load func([]byte) error
+} {
+	return []struct {
+		dst  *json.RawMessage
+		dump func() ([]byte, error)
+		load func([]byte) error
+	}{
+		{&snap.Endpoints, m.endpoints.Snapshot, m.endpoints.LoadSnapshot},
+		{&snap.Rules, m.rules.Snapshot, m.rules.LoadSnapshot},
+		{&snap.RuleAssocs, m.ruleAssocs.Snapshot, m.ruleAssocs.LoadSnapshot},
+		{&snap.RulePolicies, m.rulePolicies.Snapshot, m.rulePolicies.LoadSnapshot},
+		{&snap.QLCs, m.qlcs.Snapshot, m.qlcs.LoadSnapshot},
+		{&snap.QLCAssocs, m.qlcAssocs.Snapshot, m.qlcAssocs.LoadSnapshot},
+		{&snap.QLCPolicies, m.qlcPolicies.Snapshot, m.qlcPolicies.LoadSnapshot},
+		{&snap.RslvrConfigs, m.rslvrConfigs.Snapshot, m.rslvrConfigs.LoadSnapshot},
+		{&snap.DnssecCfgs, m.dnssecCfgs.Snapshot, m.dnssecCfgs.LoadSnapshot},
+		{&snap.FwDomLists, m.fwDomLists.Snapshot, m.fwDomLists.LoadSnapshot},
+		{&snap.FwDomains, m.fwDomains.Snapshot, m.fwDomains.LoadSnapshot},
+		{&snap.FwRuleGroups, m.fwRuleGroups.Snapshot, m.fwRuleGroups.LoadSnapshot},
+		{&snap.FwRules, m.fwRules.Snapshot, m.fwRules.LoadSnapshot},
+		{&snap.FwAssocs, m.fwAssocs.Snapshot, m.fwAssocs.LoadSnapshot},
+		{&snap.FwConfigs, m.fwConfigs.Snapshot, m.fwConfigs.LoadSnapshot},
+		{&snap.FwPolicies, m.fwPolicies.Snapshot, m.fwPolicies.LoadSnapshot},
+		{&snap.Outposts, m.outposts.Snapshot, m.outposts.LoadSnapshot},
+		{&snap.Tags, m.tags.Snapshot, m.tags.LoadSnapshot},
+		{&snap.Idem, m.idem.Snapshot, m.idem.LoadSnapshot},
+	}
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Route 53 Resolver is control-plane only and holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var snap route53resolverSnapshot
+
+	for _, r := range m.storeRefs(&snap) {
+		b, err := r.dump()
+		if err != nil {
+			return nil, fmt.Errorf("route53resolver: snapshot store: %w", err)
+		}
+
+		*r.dst = b
+	}
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds the mock's state under the original identities: every
+// endpoint/rule/config id, ARN, and composite key (and the id cross-references
+// records hold) is preserved, so a restore is transparent to clients.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap route53resolverSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("route53resolver: parse snapshot: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, r := range m.storeRefs(&snap) {
+		if len(*r.dst) == 0 {
+			continue
+		}
+
+		if err := r.load(*r.dst); err != nil {
+			return fmt.Errorf("route53resolver: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/aws/route53resolver/snapshot_test.go
+++ b/providers/aws/route53resolver/snapshot_test.go
@@ -1,0 +1,58 @@
+package route53resolver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/services/route53resolver/driver"
+)
+
+// TestSnapshotRoundTripRoute53Resolver proves a snapshot/restore round-trip
+// preserves the resource stores, the ARN-keyed tag store, and the idempotency
+// store under their original identities.
+func TestSnapshotRoundTripRoute53Resolver(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	ep, err := src.CreateResolverEndpoint(ctx, &driver.CreateResolverEndpointInput{
+		Name:             "in-1",
+		Direction:        directionInbound,
+		SecurityGroupIDs: []string{"sg-1"},
+		IPAddresses:      []driver.IPAddress{{SubnetID: "subnet-a"}, {SubnetID: "subnet-b"}},
+		Tags:             []driver.Tag{{Key: "env", Value: "test"}},
+	})
+	require.NoError(t, err)
+
+	rule, err := src.CreateResolverRule(ctx, &driver.CreateResolverRuleInput{
+		Name: "rule-1", DomainName: "example.com.", RuleType: "FORWARD",
+		ResolverEndpointID: ep.ID,
+		TargetIPs:          []driver.TargetAddress{{IP: "10.0.0.2", Port: int32(53)}},
+	})
+	require.NoError(t, err)
+
+	raw, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst := newTestMock()
+	require.NoError(t, dst.Restore(ctx, raw))
+
+	gotEP, err := dst.GetResolverEndpoint(ctx, ep.ID)
+	require.NoError(t, err)
+	assert.Equal(t, ep.ARN, gotEP.ARN)
+	assert.Equal(t, directionInbound, gotEP.Direction)
+	assert.Equal(t, int32(2), gotEP.IPAddressCount)
+
+	gotRule, err := dst.GetResolverRule(ctx, rule.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "example.com.", gotRule.DomainName)
+	require.Len(t, gotRule.TargetIPs, 1)
+	assert.Equal(t, "10.0.0.2", gotRule.TargetIPs[0].IP)
+
+	// Tags (stored in the ARN-keyed tag store) survived the round-trip.
+	tags, err := dst.ListTagsForResource(ctx, ep.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, []driver.Tag{{Key: "env", Value: "test"}}, tags)
+}

--- a/providers/aws/sesv2/snapshot.go
+++ b/providers/aws/sesv2/snapshot.go
@@ -1,0 +1,344 @@
+package sesv2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/sesv2/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// sesv2Snapshot is the full serialized state of the AWS SES v2 mock. Five stores
+// hold unexported value types whose only stateful field is a driver value behind
+// a per-record mutex — identityData, configSetData, and templateData wrap a
+// single driver struct, while contactListData and tenantData additionally own a
+// nested memstore of fully-exported entries — so all five are promoted to
+// exported snapshot forms keyed by resource name (the nested stores round-trip
+// through the generic memstore helper). Every other store holds a fully-exported
+// *driver pointer type (or driver.SuppressedDestination) and round-trips through
+// the generic helper. The mutex-guarded account state, the sent-message log, and
+// the dashboard/VDM/auto-warmup flags are captured beside the stores. The wired
+// opts and every per-record mutex are intentionally not serialized.
+type sesv2Snapshot struct {
+	Identities   map[string]*identitySnapshot    `json:"identities,omitempty"`
+	ConfigSets   map[string]*configSetSnapshot   `json:"configSets,omitempty"`
+	Templates    map[string]*templateSnapshot    `json:"templates,omitempty"`
+	ContactLists map[string]*contactListSnapshot `json:"contactLists,omitempty"`
+	Tenants      map[string]*tenantSnapshot      `json:"tenants,omitempty"`
+
+	Suppressed   json.RawMessage `json:"suppressed,omitempty"`
+	CVTemplates  json.RawMessage `json:"cvTemplates,omitempty"`
+	IPPools      json.RawMessage `json:"ipPools,omitempty"`
+	DedicatedIps json.RawMessage `json:"dedicatedIps,omitempty"`
+	TestReports  json.RawMessage `json:"testReports,omitempty"`
+	ImportJobs   json.RawMessage `json:"importJobs,omitempty"`
+	ExportJobs   json.RawMessage `json:"exportJobs,omitempty"`
+	RepEntities  json.RawMessage `json:"repEntities,omitempty"`
+	Endpoints    json.RawMessage `json:"endpoints,omitempty"`
+
+	Sent              []driver.SentMessage `json:"sent,omitempty"`
+	Account           driver.Account       `json:"account"`
+	DashboardEnabled  bool                 `json:"dashboardEnabled,omitempty"`
+	VDMEnabled        bool                 `json:"vdmEnabled,omitempty"`
+	AutoWarmupEnabled bool                 `json:"autoWarmupEnabled,omitempty"`
+}
+
+// identitySnapshot mirrors identityData (its driver.Identity is behind an
+// unexported field). configSetSnapshot and templateSnapshot follow the same shape.
+type identitySnapshot struct {
+	Identity driver.Identity `json:"identity"`
+}
+
+type configSetSnapshot struct {
+	ConfigurationSet driver.ConfigurationSet `json:"configurationSet"`
+}
+
+type templateSnapshot struct {
+	Template driver.Template `json:"template"`
+}
+
+// contactListSnapshot mirrors contactListData, promoting its ContactList and its
+// nested contacts store (fully-exported *driver.Contact, so it round-trips).
+type contactListSnapshot struct {
+	ContactList driver.ContactList `json:"contactList"`
+	Contacts    json.RawMessage    `json:"contacts,omitempty"`
+}
+
+// tenantSnapshot mirrors tenantData, promoting its Tenant and its nested
+// resources store (fully-exported driver.TenantResource).
+type tenantSnapshot struct {
+	Tenant    driver.Tenant   `json:"tenant"`
+	Resources json.RawMessage `json:"resources,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// SES v2 retains message metadata, not object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := sesv2Snapshot{
+		Identities: m.snapshotIdentities(),
+		ConfigSets: m.snapshotConfigSets(),
+		Templates:  m.snapshotTemplates(),
+	}
+
+	if err := m.snapshotNested(&snap); err != nil {
+		return nil, err
+	}
+
+	if err := m.snapshotStores(&snap); err != nil {
+		return nil, err
+	}
+
+	m.snapshotScalarState(&snap)
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotIdentities() map[string]*identitySnapshot {
+	if m.identities.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*identitySnapshot, m.identities.Len())
+
+	for name, d := range m.identities.All() {
+		d.mu.RLock()
+		out[name] = &identitySnapshot{Identity: d.id}
+		d.mu.RUnlock()
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotConfigSets() map[string]*configSetSnapshot {
+	if m.configSets.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*configSetSnapshot, m.configSets.Len())
+
+	for name, d := range m.configSets.All() {
+		d.mu.RLock()
+		out[name] = &configSetSnapshot{ConfigurationSet: d.cs}
+		d.mu.RUnlock()
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotTemplates() map[string]*templateSnapshot {
+	if m.templates.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*templateSnapshot, m.templates.Len())
+
+	for name, d := range m.templates.All() {
+		d.mu.RLock()
+		out[name] = &templateSnapshot{Template: d.tpl}
+		d.mu.RUnlock()
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotNested(snap *sesv2Snapshot) error {
+	if m.contactLists.Len() > 0 {
+		snap.ContactLists = make(map[string]*contactListSnapshot, m.contactLists.Len())
+
+		for name, d := range m.contactLists.All() {
+			d.mu.RLock()
+			contacts, err := d.contacts.Snapshot()
+			cl := d.cl
+			d.mu.RUnlock()
+
+			if err != nil {
+				return fmt.Errorf("sesv2: snapshot contacts: %w", err)
+			}
+
+			snap.ContactLists[name] = &contactListSnapshot{ContactList: cl, Contacts: contacts}
+		}
+	}
+
+	if m.tenants.Len() > 0 {
+		snap.Tenants = make(map[string]*tenantSnapshot, m.tenants.Len())
+
+		for name, d := range m.tenants.All() {
+			d.mu.RLock()
+			resources, err := d.resources.Snapshot()
+			tn := d.t
+			d.mu.RUnlock()
+
+			if err != nil {
+				return fmt.Errorf("sesv2: snapshot tenant resources: %w", err)
+			}
+
+			snap.Tenants[name] = &tenantSnapshot{Tenant: tn, Resources: resources}
+		}
+	}
+
+	return nil
+}
+
+func (m *Mock) snapshotStores(snap *sesv2Snapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Suppressed, m.suppressed.Snapshot},
+		{&snap.CVTemplates, m.cvTemplates.Snapshot},
+		{&snap.IPPools, m.ipPools.Snapshot},
+		{&snap.DedicatedIps, m.dedicatedIps.Snapshot},
+		{&snap.TestReports, m.testReports.Snapshot},
+		{&snap.ImportJobs, m.importJobs.Snapshot},
+		{&snap.ExportJobs, m.exportJobs.Snapshot},
+		{&snap.RepEntities, m.repEntities.Snapshot},
+		{&snap.Endpoints, m.endpoints.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("sesv2: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+// snapshotScalarState captures the mutex-guarded account, sent log, and dashboard
+// flags.
+func (m *Mock) snapshotScalarState(snap *sesv2Snapshot) {
+	m.sentMu.RLock()
+	if len(m.sent) > 0 {
+		snap.Sent = append([]driver.SentMessage(nil), m.sent...)
+	}
+	m.sentMu.RUnlock()
+
+	m.acctMu.RLock()
+	snap.Account = m.account
+	m.acctMu.RUnlock()
+
+	m.dashMu.RLock()
+	snap.DashboardEnabled = m.dashboardEnabled
+	snap.VDMEnabled = m.vdmEnabled
+	snap.AutoWarmupEnabled = m.autoWarmupEnabled
+	m.dashMu.RUnlock()
+}
+
+// Restore rebuilds the mock's state under the original identities: every identity
+// name, config-set name, template name, contact-list/tenant name (and the nested
+// contacts/resources under them) is preserved, so a restore is transparent to
+// clients.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap sesv2Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("sesv2: parse snapshot: %w", err)
+	}
+
+	m.restorePromoted(&snap)
+
+	if err := m.restoreNested(&snap); err != nil {
+		return err
+	}
+
+	if err := m.restoreStores(&snap); err != nil {
+		return err
+	}
+
+	m.restoreScalarState(&snap)
+
+	return nil
+}
+
+func (m *Mock) restorePromoted(snap *sesv2Snapshot) {
+	for name, s := range snap.Identities {
+		m.identities.Set(name, &identityData{id: s.Identity})
+	}
+
+	for name, s := range snap.ConfigSets {
+		m.configSets.Set(name, &configSetData{cs: s.ConfigurationSet})
+	}
+
+	for name, s := range snap.Templates {
+		m.templates.Set(name, &templateData{tpl: s.Template})
+	}
+}
+
+func (m *Mock) restoreNested(snap *sesv2Snapshot) error {
+	for name, s := range snap.ContactLists {
+		cld := &contactListData{cl: s.ContactList, contacts: memstore.New[*driver.Contact]()}
+		if len(s.Contacts) > 0 {
+			if err := cld.contacts.LoadSnapshot(s.Contacts); err != nil {
+				return fmt.Errorf("sesv2: restore contacts: %w", err)
+			}
+		}
+
+		m.contactLists.Set(name, cld)
+	}
+
+	for name, s := range snap.Tenants {
+		td := &tenantData{t: s.Tenant, resources: memstore.New[driver.TenantResource]()}
+		if len(s.Resources) > 0 {
+			if err := td.resources.LoadSnapshot(s.Resources); err != nil {
+				return fmt.Errorf("sesv2: restore tenant resources: %w", err)
+			}
+		}
+
+		m.tenants.Set(name, td)
+	}
+
+	return nil
+}
+
+func (m *Mock) restoreStores(snap *sesv2Snapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Suppressed, m.suppressed.LoadSnapshot},
+		{snap.CVTemplates, m.cvTemplates.LoadSnapshot},
+		{snap.IPPools, m.ipPools.LoadSnapshot},
+		{snap.DedicatedIps, m.dedicatedIps.LoadSnapshot},
+		{snap.TestReports, m.testReports.LoadSnapshot},
+		{snap.ImportJobs, m.importJobs.LoadSnapshot},
+		{snap.ExportJobs, m.exportJobs.LoadSnapshot},
+		{snap.RepEntities, m.repEntities.LoadSnapshot},
+		{snap.Endpoints, m.endpoints.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("sesv2: restore store: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (m *Mock) restoreScalarState(snap *sesv2Snapshot) {
+	m.sentMu.Lock()
+	if snap.Sent != nil {
+		m.sent = snap.Sent
+	}
+	m.sentMu.Unlock()
+
+	m.acctMu.Lock()
+	m.account = snap.Account
+	m.acctMu.Unlock()
+
+	m.dashMu.Lock()
+	m.dashboardEnabled = snap.DashboardEnabled
+	m.vdmEnabled = snap.VDMEnabled
+	m.autoWarmupEnabled = snap.AutoWarmupEnabled
+	m.dashMu.Unlock()
+}

--- a/providers/aws/sesv2/snapshot_test.go
+++ b/providers/aws/sesv2/snapshot_test.go
@@ -1,0 +1,71 @@
+package sesv2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/sesv2/driver"
+)
+
+// TestSnapshotRoundTripSESV2 proves a snapshot/restore round-trip preserves the
+// promoted identity/config-set stores, a contact list with its nested contacts
+// store, and the mutex-guarded account state under their original identities.
+func TestSnapshotRoundTripSESV2(t *testing.T) {
+	ctx := context.Background()
+	src := newMock(t)
+
+	if _, err := src.CreateEmailIdentity(ctx, driver.CreateIdentityInput{EmailIdentity: "sender@example.com"}); err != nil {
+		t.Fatalf("create identity: %v", err)
+	}
+
+	if err := src.CreateConfigurationSet(ctx, driver.CreateConfigurationSetInput{Name: "cs-1"}); err != nil {
+		t.Fatalf("create config set: %v", err)
+	}
+
+	if err := src.CreateContactList(ctx, driver.ContactListInput{Name: "list-1", Description: "my list"}); err != nil {
+		t.Fatalf("create contact list: %v", err)
+	}
+
+	if err := src.CreateContact(ctx, driver.ContactInput{
+		ContactListName: "list-1", EmailAddress: "c@example.com",
+	}); err != nil {
+		t.Fatalf("create contact: %v", err)
+	}
+
+	// Mutate account state so its restore is observable.
+	if err := src.PutAccountDetails(ctx, "", "", true); err != nil {
+		t.Fatalf("put account details: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newMock(t)
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	id, err := dst.GetEmailIdentity(ctx, "sender@example.com")
+	if err != nil || id == nil {
+		t.Fatalf("restored identity = %+v, err %v", id, err)
+	}
+
+	cs, err := dst.GetConfigurationSet(ctx, "cs-1")
+	if err != nil || cs.Name != "cs-1" {
+		t.Fatalf("restored config set = %+v, err %v", cs, err)
+	}
+
+	// Nested contacts store survived under the promoted contact list.
+	c, err := dst.GetContact(ctx, "list-1", "c@example.com")
+	if err != nil || c.EmailAddress != "c@example.com" {
+		t.Fatalf("restored contact = %+v, err %v", c, err)
+	}
+
+	// Mutex-guarded account state survived.
+	acct, err := dst.GetAccount(ctx)
+	if err != nil || !acct.ProductionAccessEnabled {
+		t.Fatalf("restored account = %+v, err %v", acct, err)
+	}
+}

--- a/providers/aws/vpclattice/snapshot.go
+++ b/providers/aws/vpclattice/snapshot.go
@@ -1,0 +1,115 @@
+package vpclattice
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// vpclatticeSnapshot is the full serialized state of the AWS VPC Lattice mock.
+// Every memstore store holds a fully-exported value type — a *driver pointer type
+// for each resource, or a plain []driver.RegisteredTarget / string /
+// map[string]string for the targets, resource-policy, and tag stores — so each
+// round-trips through the generic memstore helper under its exact key. The keys
+// are the resource ids and ARNs (targets keyed by target-group id, resource
+// policies and tags by resource ARN), so the id/ARN cross-references records hold
+// survive a restore. The wired opts and the serializing mutex are intentionally
+// not serialized.
+type vpclatticeSnapshot struct {
+	ServiceNetworks json.RawMessage `json:"serviceNetworks,omitempty"`
+	Services        json.RawMessage `json:"services,omitempty"`
+	Listeners       json.RawMessage `json:"listeners,omitempty"`
+	Rules           json.RawMessage `json:"rules,omitempty"`
+	TargetGroups    json.RawMessage `json:"targetGroups,omitempty"`
+	Targets         json.RawMessage `json:"targets,omitempty"`
+	SNVpcAssocs     json.RawMessage `json:"snVpcAssocs,omitempty"`
+	SNSvcAssocs     json.RawMessage `json:"snSvcAssocs,omitempty"`
+	SNResAssocs     json.RawMessage `json:"snResAssocs,omitempty"`
+	ResourceConfigs json.RawMessage `json:"resourceConfigs,omitempty"`
+	ResourceGws     json.RawMessage `json:"resourceGws,omitempty"`
+	AccessLogSubs   json.RawMessage `json:"accessLogSubs,omitempty"`
+	AuthPolicies    json.RawMessage `json:"authPolicies,omitempty"`
+	ResourcePolics  json.RawMessage `json:"resourcePolics,omitempty"`
+	DomainVerifs    json.RawMessage `json:"domainVerifs,omitempty"`
+	Tags            json.RawMessage `json:"tags,omitempty"`
+}
+
+// storeRefs pairs each snapshot field with its store's Snapshot/LoadSnapshot
+// entry points, so dump and load walk the identical, symmetric list.
+func (m *Mock) storeRefs(snap *vpclatticeSnapshot) []struct {
+	dst  *json.RawMessage
+	dump func() ([]byte, error)
+	load func([]byte) error
+} {
+	return []struct {
+		dst  *json.RawMessage
+		dump func() ([]byte, error)
+		load func([]byte) error
+	}{
+		{&snap.ServiceNetworks, m.serviceNetworks.Snapshot, m.serviceNetworks.LoadSnapshot},
+		{&snap.Services, m.services.Snapshot, m.services.LoadSnapshot},
+		{&snap.Listeners, m.listeners.Snapshot, m.listeners.LoadSnapshot},
+		{&snap.Rules, m.rules.Snapshot, m.rules.LoadSnapshot},
+		{&snap.TargetGroups, m.targetGroups.Snapshot, m.targetGroups.LoadSnapshot},
+		{&snap.Targets, m.targets.Snapshot, m.targets.LoadSnapshot},
+		{&snap.SNVpcAssocs, m.snVpcAssocs.Snapshot, m.snVpcAssocs.LoadSnapshot},
+		{&snap.SNSvcAssocs, m.snSvcAssocs.Snapshot, m.snSvcAssocs.LoadSnapshot},
+		{&snap.SNResAssocs, m.snResAssocs.Snapshot, m.snResAssocs.LoadSnapshot},
+		{&snap.ResourceConfigs, m.resourceConfigs.Snapshot, m.resourceConfigs.LoadSnapshot},
+		{&snap.ResourceGws, m.resourceGws.Snapshot, m.resourceGws.LoadSnapshot},
+		{&snap.AccessLogSubs, m.accessLogSubs.Snapshot, m.accessLogSubs.LoadSnapshot},
+		{&snap.AuthPolicies, m.authPolicies.Snapshot, m.authPolicies.LoadSnapshot},
+		{&snap.ResourcePolics, m.resourcePolics.Snapshot, m.resourcePolics.LoadSnapshot},
+		{&snap.DomainVerifs, m.domainVerifs.Snapshot, m.domainVerifs.LoadSnapshot},
+		{&snap.Tags, m.tags.Snapshot, m.tags.LoadSnapshot},
+	}
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// VPC Lattice is control-plane only and holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var snap vpclatticeSnapshot
+
+	for _, r := range m.storeRefs(&snap) {
+		b, err := r.dump()
+		if err != nil {
+			return nil, fmt.Errorf("vpclattice: snapshot store: %w", err)
+		}
+
+		*r.dst = b
+	}
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds the mock's state under the original identities: every resource
+// id, ARN, and association id (and the id/ARN cross-references records hold) is
+// preserved, so a restore is transparent to clients.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap vpclatticeSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("vpclattice: parse snapshot: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, r := range m.storeRefs(&snap) {
+		if len(*r.dst) == 0 {
+			continue
+		}
+
+		if err := r.load(*r.dst); err != nil {
+			return fmt.Errorf("vpclattice: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/aws/vpclattice/snapshot_test.go
+++ b/providers/aws/vpclattice/snapshot_test.go
@@ -1,0 +1,64 @@
+package vpclattice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/services/vpclattice/driver"
+)
+
+// TestSnapshotRoundTripVPCLattice proves a snapshot/restore round-trip preserves
+// the resource stores, the target-group-keyed targets store, and the ARN-keyed
+// tag store under their original identities.
+func TestSnapshotRoundTripVPCLattice(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	sn, err := src.CreateServiceNetwork(ctx, &driver.CreateServiceNetworkInput{Name: "sn"})
+	require.NoError(t, err)
+
+	svc, err := src.CreateService(ctx, &driver.CreateServiceInput{
+		Name: "svc", Tags: map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	tg, err := src.CreateTargetGroup(ctx, &driver.CreateTargetGroupInput{Name: "tg", Type: "IP"})
+	require.NoError(t, err)
+
+	_, _, err = src.RegisterTargets(ctx, tg.ID, []driver.RegisteredTarget{{ID: "10.0.0.1", Port: 443}})
+	require.NoError(t, err)
+
+	raw, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst := newTestMock()
+	require.NoError(t, dst.Restore(ctx, raw))
+
+	gotSN, err := dst.GetServiceNetwork(ctx, sn.ID)
+	require.NoError(t, err)
+	assert.Equal(t, sn.ARN, gotSN.ARN)
+	assert.Equal(t, "sn", gotSN.Name)
+
+	gotSvc, err := dst.GetService(ctx, svc.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "svc", gotSvc.Name)
+
+	gotTG, err := dst.GetTargetGroup(ctx, tg.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "tg", gotTG.Name)
+	assert.Equal(t, "IP", gotTG.Type)
+
+	// The target-group-keyed targets store survived the round-trip.
+	gotTargets, err := dst.ListTargets(ctx, tg.ID)
+	require.NoError(t, err)
+	require.Len(t, gotTargets, 1)
+	assert.Equal(t, "10.0.0.1", gotTargets[0].ID)
+
+	// Tags (ARN-keyed tag store) survived the round-trip.
+	tags, err := dst.ListTagsForResource(ctx, svc.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, "prod", tags["env"])
+}

--- a/providers/aws/wafv2/snapshot.go
+++ b/providers/aws/wafv2/snapshot.go
@@ -1,0 +1,225 @@
+package wafv2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/wafv2/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// wafv2Snapshot is the full serialized state of the AWS WAFv2 mock. Every
+// memstore store holds an unexported *xxxData whose only stateful field is a
+// driver value (webACLData/ipSetData/ruleGroupData/regexSetData) or a
+// scope+raw-JSON pair (loggingConfigData), all behind a per-record mutex and
+// invisible to json.Marshal, so each store is promoted to an exported snapshot
+// form keyed by its composite "scope/id" (or, for logging, the ResourceArn) — the
+// keys that keep the REGIONAL and CLOUDFRONT namespaces from colliding after a
+// restore. The three mutex-guarded side maps — assoc (protected-resource ARN ->
+// web-ACL ARN), policies (rule-group ARN -> permission policy), and apiKeys
+// (composite key -> summary) — are captured beside the stores. The per-record and
+// create mutexes and the wired opts are intentionally not serialized.
+type wafv2Snapshot struct {
+	WebACLs  map[string]*webACLSnapshot    `json:"webACLs,omitempty"`
+	IPSets   map[string]*ipSetSnapshot     `json:"ipSets,omitempty"`
+	RuleGrps map[string]*ruleGroupSnapshot `json:"ruleGrps,omitempty"`
+	Regexes  map[string]*regexSetSnapshot  `json:"regexes,omitempty"`
+	LogCfgs  map[string]*loggingSnapshot   `json:"logCfgs,omitempty"`
+
+	Assoc    map[string]string               `json:"assoc,omitempty"`
+	Policies map[string]string               `json:"policies,omitempty"`
+	APIKeys  map[string]driver.APIKeySummary `json:"apiKeys,omitempty"`
+}
+
+// webACLSnapshot mirrors webACLData (its driver.WebACL is behind an unexported
+// field). The other three resource snapshots follow the same one-field shape.
+type webACLSnapshot struct {
+	ACL driver.WebACL `json:"acl"`
+}
+
+type ipSetSnapshot struct {
+	Set driver.IPSet `json:"set"`
+}
+
+type ruleGroupSnapshot struct {
+	Grp driver.RuleGroup `json:"grp"`
+}
+
+type regexSetSnapshot struct {
+	Set driver.RegexPatternSet `json:"set"`
+}
+
+// loggingSnapshot mirrors loggingConfigData (its scope and raw config are both
+// unexported).
+type loggingSnapshot struct {
+	Scope string          `json:"scope"`
+	Cfg   json.RawMessage `json:"cfg,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// WAFv2 is control-plane only and holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := wafv2Snapshot{
+		WebACLs:  m.snapshotWebACLs(),
+		IPSets:   m.snapshotIPSets(),
+		RuleGrps: m.snapshotRuleGroups(),
+		Regexes:  m.snapshotRegexes(),
+		LogCfgs:  m.snapshotLogCfgs(),
+	}
+
+	m.snapshotSideMaps(&snap)
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotWebACLs() map[string]*webACLSnapshot {
+	if m.webACLs.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*webACLSnapshot, m.webACLs.Len())
+
+	for k, d := range m.webACLs.All() {
+		d.mu.RLock()
+		out[k] = &webACLSnapshot{ACL: d.acl}
+		d.mu.RUnlock()
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotIPSets() map[string]*ipSetSnapshot {
+	if m.ipSets.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*ipSetSnapshot, m.ipSets.Len())
+
+	for k, d := range m.ipSets.All() {
+		d.mu.RLock()
+		out[k] = &ipSetSnapshot{Set: d.set}
+		d.mu.RUnlock()
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotRuleGroups() map[string]*ruleGroupSnapshot {
+	if m.ruleGrps.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*ruleGroupSnapshot, m.ruleGrps.Len())
+
+	for k, d := range m.ruleGrps.All() {
+		d.mu.RLock()
+		out[k] = &ruleGroupSnapshot{Grp: d.grp}
+		d.mu.RUnlock()
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotRegexes() map[string]*regexSetSnapshot {
+	if m.regexes.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*regexSetSnapshot, m.regexes.Len())
+
+	for k, d := range m.regexes.All() {
+		d.mu.RLock()
+		out[k] = &regexSetSnapshot{Set: d.set}
+		d.mu.RUnlock()
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotLogCfgs() map[string]*loggingSnapshot {
+	if m.logCfgs.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*loggingSnapshot, m.logCfgs.Len())
+
+	for k, d := range m.logCfgs.All() {
+		out[k] = &loggingSnapshot{Scope: d.scope, Cfg: d.cfg}
+	}
+
+	return out
+}
+
+func (m *Mock) snapshotSideMaps(snap *wafv2Snapshot) {
+	m.assocMu.RLock()
+	snap.Assoc = m.assoc
+	m.assocMu.RUnlock()
+
+	m.policyMu.RLock()
+	snap.Policies = m.policies
+	m.policyMu.RUnlock()
+
+	m.apiKeyMu.RLock()
+	snap.APIKeys = m.apiKeys
+	m.apiKeyMu.RUnlock()
+}
+
+// Restore rebuilds the mock's state under the original identities: every resource
+// keeps its (scope,id) composite key, ARN, and lock token, so a restore is
+// transparent to clients.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap wafv2Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("wafv2: parse snapshot: %w", err)
+	}
+
+	m.restoreStores(&snap)
+	m.restoreSideMaps(&snap)
+
+	return nil
+}
+
+func (m *Mock) restoreStores(snap *wafv2Snapshot) {
+	for k, s := range snap.WebACLs {
+		m.webACLs.Set(k, &webACLData{acl: s.ACL})
+	}
+
+	for k, s := range snap.IPSets {
+		m.ipSets.Set(k, &ipSetData{set: s.Set})
+	}
+
+	for k, s := range snap.RuleGrps {
+		m.ruleGrps.Set(k, &ruleGroupData{grp: s.Grp})
+	}
+
+	for k, s := range snap.Regexes {
+		m.regexes.Set(k, &regexSetData{set: s.Set})
+	}
+
+	for k, s := range snap.LogCfgs {
+		m.logCfgs.Set(k, &loggingConfigData{scope: s.Scope, cfg: s.Cfg})
+	}
+}
+
+func (m *Mock) restoreSideMaps(snap *wafv2Snapshot) {
+	m.assocMu.Lock()
+	if snap.Assoc != nil {
+		m.assoc = snap.Assoc
+	}
+	m.assocMu.Unlock()
+
+	m.policyMu.Lock()
+	if snap.Policies != nil {
+		m.policies = snap.Policies
+	}
+	m.policyMu.Unlock()
+
+	m.apiKeyMu.Lock()
+	if snap.APIKeys != nil {
+		m.apiKeys = snap.APIKeys
+	}
+	m.apiKeyMu.Unlock()
+}

--- a/providers/aws/wafv2/snapshot_test.go
+++ b/providers/aws/wafv2/snapshot_test.go
@@ -1,0 +1,73 @@
+package wafv2
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/wafv2/driver"
+)
+
+// TestSnapshotRoundTripWAFV2 proves a snapshot/restore round-trip preserves the
+// promoted resource stores (whose *xxxData carry unexported driver values) and
+// the mutex-guarded association side map under their original identities.
+func TestSnapshotRoundTripWAFV2(t *testing.T) {
+	ctx := context.Background()
+	src := newMock()
+
+	acl, err := src.CreateWebACL(ctx, driver.CreateWebACLInput{
+		Name:  "acl1",
+		Scope: driver.ScopeRegional,
+		Rules: json.RawMessage(`[{"Name":"r1"}]`),
+	})
+	if err != nil {
+		t.Fatalf("create web acl: %v", err)
+	}
+
+	ipset, err := src.CreateIPSet(ctx, driver.CreateIPSetInput{
+		Name: "ips1", Scope: driver.ScopeRegional, IPAddressVersion: "IPV4",
+		Addresses: []string{"10.0.0.0/24"},
+	})
+	if err != nil {
+		t.Fatalf("create ip set: %v", err)
+	}
+
+	const protectedARN = "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/x/y"
+	if err := src.AssociateWebACL(ctx, acl.ARN, protectedARN); err != nil {
+		t.Fatalf("associate: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	gotACL, err := dst.GetWebACL(ctx, driver.Ref{Scope: driver.ScopeRegional, ID: acl.ID})
+	if err != nil {
+		t.Fatalf("get web acl: %v", err)
+	}
+
+	if gotACL.ARN != acl.ARN || string(gotACL.Rules) != `[{"Name":"r1"}]` {
+		t.Fatalf("web acl not preserved: %+v", gotACL)
+	}
+
+	gotIPSet, err := dst.GetIPSet(ctx, driver.Ref{Scope: driver.ScopeRegional, ID: ipset.ID})
+	if err != nil {
+		t.Fatalf("get ip set: %v", err)
+	}
+
+	if len(gotIPSet.Addresses) != 1 || gotIPSet.Addresses[0] != "10.0.0.0/24" {
+		t.Fatalf("ip set addresses not preserved: %+v", gotIPSet)
+	}
+
+	// The mutex-guarded association side map survived the round-trip.
+	protecting, err := dst.GetWebACLForResource(ctx, protectedARN)
+	if err != nil || protecting == nil || protecting.ARN != acl.ARN {
+		t.Fatalf("restored association = %+v, err %v", protecting, err)
+	}
+}

--- a/providers/azure/containerinstances/snapshot.go
+++ b/providers/azure/containerinstances/snapshot.go
@@ -1,0 +1,62 @@
+package containerinstances
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/containerinstances/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// ciSnapshot is the full serialized state of the Azure Container Instances mock.
+// The groups store holds an unexported *groupData whose fields (the container
+// group plus its engine handle/engine-backed flag) are unexported, so it is
+// promoted to an exported form keyed by the composite ARM key
+// (subscription/resourceGroup/name). The wired opts and the live container-engine
+// workload are not serialized — a restored group reports its stored state.
+type ciSnapshot struct {
+	Groups map[string]*groupSnapshot `json:"groups,omitempty"`
+}
+
+// groupSnapshot mirrors groupData (all fields unexported).
+type groupSnapshot struct {
+	Group        driver.ContainerGroup `json:"group"`
+	Handle       string                `json:"handle,omitempty"`
+	EngineBacked bool                  `json:"engineBacked,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// ACI holds container-group metadata, not bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := ciSnapshot{}
+
+	if m.groups.Len() > 0 {
+		snap.Groups = make(map[string]*groupSnapshot, m.groups.Len())
+		for key, gd := range m.groups.All() {
+			snap.Groups[key] = &groupSnapshot{
+				Group: gd.group, Handle: gd.handle, EngineBacked: gd.engineBacked,
+			}
+		}
+	}
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds the mock's state under the original identities: every
+// container group's composite ARM key is preserved so a client's identifiers
+// still resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap ciSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("containerinstances: parse snapshot: %w", err)
+	}
+
+	for key, gs := range snap.Groups {
+		m.groups.Set(key, &groupData{group: gs.Group, handle: gs.Handle, engineBacked: gs.EngineBacked})
+	}
+
+	return nil
+}

--- a/providers/azure/containerinstances/snapshot_test.go
+++ b/providers/azure/containerinstances/snapshot_test.go
@@ -1,0 +1,50 @@
+package containerinstances
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/services/containerinstances/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+)
+
+// TestSnapshotRoundTripContainerInstances proves a snapshot/restore round-trip
+// preserves a container group under its composite ARM identity.
+func TestSnapshotRoundTripContainerInstances(t *testing.T) {
+	ctx := context.Background()
+	src := New(config.NewOptions())
+
+	sc := scope.Scope{Subscription: "sub1", ResourceGroup: "rg1"}
+	if _, err := src.CreateContainerGroup(ctx, driver.ContainerGroupConfig{
+		Name:     "cg1",
+		Location: "eastus",
+		OSType:   "Linux",
+		Containers: []driver.ContainerConfig{
+			{Name: "c1", Image: "nginx:latest"},
+		},
+		Tags:  map[string]string{"env": "prod"},
+		Scope: sc,
+	}); err != nil {
+		t.Fatalf("CreateContainerGroup: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := New(config.NewOptions())
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	got, err := dst.GetContainerGroup(ctx, "sub1", "rg1", "cg1")
+	if err != nil {
+		t.Fatalf("GetContainerGroup: %v", err)
+	}
+
+	if got.Name != "cg1" || got.Tags["env"] != "prod" || len(got.Containers) != 1 {
+		t.Fatalf("restored group = %+v", got)
+	}
+}

--- a/providers/azure/cosmospostgresql/snapshot.go
+++ b/providers/azure/cosmospostgresql/snapshot.go
@@ -1,0 +1,99 @@
+package cosmospostgresql
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// cpgSnapshot is the full serialized state of the Cosmos DB for PostgreSQL mock.
+// Every store holds a fully-exported cpgdriver value type, so each round-trips
+// through the generic memstore helper keyed by its composite ARM key. The
+// mu-guarded coordinatorHosts map (clusterKey -> reachable coordinator host when
+// a real DatabaseEngine backs the cluster) is captured beside them. The wired
+// opts are not serialized.
+type cpgSnapshot struct {
+	Clusters      json.RawMessage   `json:"clusters,omitempty"`
+	FirewallRules json.RawMessage   `json:"firewallRules,omitempty"`
+	Roles         json.RawMessage   `json:"roles,omitempty"`
+	PrivateEPs    json.RawMessage   `json:"privateEps,omitempty"`
+	ServerConfigs json.RawMessage   `json:"serverConfigs,omitempty"`
+	Coordinators  map[string]string `json:"coordinators,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Cosmos PostgreSQL holds resource metadata, not bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap cpgSnapshot
+
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Clusters, m.clusters.Snapshot},
+		{&snap.FirewallRules, m.firewallRules.Snapshot},
+		{&snap.Roles, m.roles.Snapshot},
+		{&snap.PrivateEPs, m.privateEPs.Snapshot},
+		{&snap.ServerConfigs, m.serverConfigs.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return nil, fmt.Errorf("cosmospostgresql: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	m.mu.RLock()
+	if len(m.coordinatorHosts) > 0 {
+		snap.Coordinators = m.coordinatorHosts
+	}
+	m.mu.RUnlock()
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds the mock's state under the original identities: every cluster,
+// firewall rule, role, private-endpoint, and server-configuration composite key
+// is preserved so a client's identifiers still resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap cpgSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("cosmospostgresql: parse snapshot: %w", err)
+	}
+
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Clusters, m.clusters.LoadSnapshot},
+		{snap.FirewallRules, m.firewallRules.LoadSnapshot},
+		{snap.Roles, m.roles.LoadSnapshot},
+		{snap.PrivateEPs, m.privateEPs.LoadSnapshot},
+		{snap.ServerConfigs, m.serverConfigs.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("cosmospostgresql: restore store: %w", err)
+		}
+	}
+
+	if snap.Coordinators != nil {
+		m.mu.Lock()
+		m.coordinatorHosts = snap.Coordinators
+		m.mu.Unlock()
+	}
+
+	return nil
+}

--- a/providers/azure/cosmospostgresql/snapshot_test.go
+++ b/providers/azure/cosmospostgresql/snapshot_test.go
@@ -1,0 +1,49 @@
+package cosmospostgresql
+
+import (
+	"context"
+	"testing"
+
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
+)
+
+// TestSnapshotRoundTripCosmosPostgreSQL proves a snapshot/restore round-trip
+// preserves a cluster and a child firewall rule under their composite ARM keys.
+func TestSnapshotRoundTripCosmosPostgreSQL(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, _, err := src.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+		Name: "pg1", ResourceGroup: "rg1", Location: "eastus", NodeCount: 2,
+		Tags: map[string]string{"env": "prod"},
+	}); err != nil {
+		t.Fatalf("CreateOrUpdateCluster: %v", err)
+	}
+
+	if _, err := src.CreateOrUpdateFirewallRule(ctx, cpgdriver.CreateFirewallRuleConfig{
+		ResourceGroup: "rg1", ClusterName: "pg1", Name: "allow-all",
+		StartIPAddress: "0.0.0.0", EndIPAddress: "255.255.255.255",
+	}); err != nil {
+		t.Fatalf("CreateOrUpdateFirewallRule: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	c, err := dst.GetCluster(ctx, "rg1", "pg1")
+	if err != nil || c.Name != "pg1" || c.Tags["env"] != "prod" || c.NodeCount != 2 {
+		t.Fatalf("restored cluster = %+v, err %v", c, err)
+	}
+
+	fr, err := dst.GetFirewallRule(ctx, "rg1", "pg1", "allow-all")
+	if err != nil || fr.StartIPAddress != "0.0.0.0" {
+		t.Fatalf("restored firewall rule = %+v, err %v", fr, err)
+	}
+}

--- a/providers/azure/functions/snapshot.go
+++ b/providers/azure/functions/snapshot.go
@@ -1,0 +1,220 @@
+package functions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// functionsSnapshot is the full serialized state of the Azure Functions mock.
+// The funcs store holds an unexported funcData whose payload (function info,
+// published versions carrying their deployment-package config, and aliases)
+// lives in unexported fields, so it is promoted to an exported form keyed by
+// function name; layers is promoted likewise for its nested version store. The
+// mappings/plans/sites stores hold fully-exported types and round-trip through
+// the generic memstore helper. The live in-process handler funcs (funcData.handler
+// and the handlers registry) and the wired opts/monitoring are NOT serialized —
+// they are re-registered by the host process. On restore a function's handler is
+// re-linked from the handlers registry if one is present.
+type functionsSnapshot struct {
+	Funcs    map[string]*funcSnapshot  `json:"funcs,omitempty"`
+	Layers   map[string]*layerSnapshot `json:"layers,omitempty"`
+	Mappings json.RawMessage           `json:"mappings,omitempty"`
+	Plans    json.RawMessage           `json:"plans,omitempty"`
+	Sites    json.RawMessage           `json:"sites,omitempty"`
+}
+
+// funcSnapshot mirrors funcData. The mock does not retain raw deployment-package
+// bytes (they are deployed to the external FunctionEngine and discarded); what
+// survives is the code IDENTITY — CodeSHA256 on info and each version's config —
+// plus the aliases, captured by name.
+type funcSnapshot struct {
+	Info         driver.FunctionInfo       `json:"info"`
+	EngineBacked bool                      `json:"engineBacked,omitempty"`
+	Versions     []*versionSnapshot        `json:"versions,omitempty"`
+	NextVersion  int                       `json:"nextVersion,omitempty"`
+	Aliases      map[string]driver.Alias   `json:"aliases,omitempty"`
+	Concurrency  *driver.ConcurrencyConfig `json:"concurrency,omitempty"`
+}
+
+// versionSnapshot mirrors versionData (all fields unexported).
+type versionSnapshot struct {
+	Config    driver.FunctionConfig `json:"config"`
+	Version   string                `json:"version"`
+	CodeSHA   string                `json:"codeSha,omitempty"`
+	CreatedAt string                `json:"createdAt,omitempty"`
+}
+
+// layerSnapshot mirrors layerData; its version store holds a fully-exported
+// *driver.LayerVersion and round-trips through the generic helper.
+type layerSnapshot struct {
+	Versions json.RawMessage `json:"versions,omitempty"`
+	NextVer  int             `json:"nextVer,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// each published version's config (the code identity) is always captured so
+// republished functions survive a restore.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	snap := functionsSnapshot{}
+
+	if m.funcs.Len() > 0 {
+		snap.Funcs = make(map[string]*funcSnapshot, m.funcs.Len())
+
+		for _, name := range m.funcs.Keys() {
+			fd, ok := m.funcs.Get(name)
+			if !ok {
+				continue
+			}
+
+			snap.Funcs[name] = snapshotFunc(&fd)
+		}
+	}
+
+	if m.layers.Len() > 0 {
+		snap.Layers = make(map[string]*layerSnapshot, m.layers.Len())
+
+		for _, name := range m.layers.Keys() {
+			ld, ok := m.layers.Get(name)
+			if !ok {
+				continue
+			}
+
+			vers, err := ld.versions.Snapshot()
+			if err != nil {
+				return nil, fmt.Errorf("functions: snapshot layer versions: %w", err)
+			}
+
+			snap.Layers[name] = &layerSnapshot{Versions: vers, NextVer: ld.nextVer}
+		}
+	}
+
+	if err := m.snapshotGenericStores(&snap); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(snap)
+}
+
+func (m *Mock) snapshotGenericStores(snap *functionsSnapshot) error {
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Mappings, m.mappings.Snapshot},
+		{&snap.Plans, m.plans.Snapshot},
+		{&snap.Sites, m.sites.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return fmt.Errorf("functions: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return nil
+}
+
+func snapshotFunc(fd *funcData) *funcSnapshot {
+	fs := &funcSnapshot{
+		Info: fd.info, EngineBacked: fd.engineBacked,
+		NextVersion: fd.nextVersion, Concurrency: fd.concurrency,
+	}
+
+	for _, v := range fd.versions {
+		fs.Versions = append(fs.Versions, &versionSnapshot{
+			Config: v.config, Version: v.version, CodeSHA: v.codeSHA, CreatedAt: v.createdAt,
+		})
+	}
+
+	if fd.aliases != nil && fd.aliases.Len() > 0 {
+		fs.Aliases = make(map[string]driver.Alias, fd.aliases.Len())
+		for k, ad := range fd.aliases.All() {
+			fs.Aliases[k] = ad.alias
+		}
+	}
+
+	return fs
+}
+
+// Restore rebuilds the mock's state under the original identities: every function
+// name, layer name, event-source-mapping UUID, App Service plan and site key is
+// preserved so a client's identifiers still resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap functionsSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("functions: parse snapshot: %w", err)
+	}
+
+	for name, fs := range snap.Funcs {
+		m.funcs.Set(name, m.restoreFunc(name, fs))
+	}
+
+	for name, ls := range snap.Layers {
+		ld := &layerData{versions: memstore.New[*driver.LayerVersion](), nextVer: ls.NextVer}
+		if len(ls.Versions) > 0 {
+			if err := ld.versions.LoadSnapshot(ls.Versions); err != nil {
+				return fmt.Errorf("functions: restore layer versions: %w", err)
+			}
+		}
+
+		m.layers.Set(name, ld)
+	}
+
+	return m.restoreGenericStores(&snap)
+}
+
+func (m *Mock) restoreGenericStores(snap *functionsSnapshot) error {
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Mappings, m.mappings.LoadSnapshot},
+		{snap.Plans, m.plans.LoadSnapshot},
+		{snap.Sites, m.sites.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("functions: restore store: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (m *Mock) restoreFunc(name string, fs *funcSnapshot) funcData {
+	fd := funcData{
+		info: fs.Info, engineBacked: fs.EngineBacked, nextVersion: fs.NextVersion,
+		aliases: memstore.New[*aliasData](), concurrency: fs.Concurrency,
+	}
+
+	m.handlersMu.RLock()
+	fd.handler = m.handlers[name]
+	m.handlersMu.RUnlock()
+
+	for _, v := range fs.Versions {
+		fd.versions = append(fd.versions, &versionData{
+			config: v.Config, version: v.Version, codeSHA: v.CodeSHA, createdAt: v.CreatedAt,
+		})
+	}
+
+	for k, a := range fs.Aliases {
+		fd.aliases.Set(k, &aliasData{alias: a})
+	}
+
+	return fd
+}

--- a/providers/azure/functions/snapshot_test.go
+++ b/providers/azure/functions/snapshot_test.go
@@ -1,0 +1,67 @@
+package functions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// TestSnapshotRoundTripFunctions proves a snapshot/restore round-trip preserves
+// a function together with its published version (and captured config) under
+// their original identities.
+func TestSnapshotRoundTripFunctions(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	cfg := driver.FunctionConfig{
+		Name: "myFunc", Runtime: "dotnet6", Handler: "MyApp::Handler",
+		Memory: 256, Timeout: 30, Tags: map[string]string{"team": "backend"},
+		Code: []byte("zip-bytes"),
+	}
+	if _, err := src.CreateFunction(ctx, cfg); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	ver, err := src.PublishVersion(ctx, cfg.Name, "v1")
+	if err != nil {
+		t.Fatalf("PublishVersion: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	fn, err := dst.GetFunction(ctx, cfg.Name)
+	if err != nil || fn.Tags["team"] != "backend" || fn.Runtime != "dotnet6" {
+		t.Fatalf("restored function = %+v, err %v", fn, err)
+	}
+
+	vers, err := dst.ListVersions(ctx, cfg.Name)
+	if err != nil {
+		t.Fatalf("ListVersions: %v", err)
+	}
+
+	var found bool
+	for _, v := range vers {
+		if v.Version == ver.Version {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatalf("published version %s missing from %+v", ver.Version, vers)
+	}
+
+	// The published version's captured config survived the promotion.
+	fd, ok := dst.funcs.Get(cfg.Name)
+	if !ok || len(fd.versions) != 1 || fd.versions[0].config.Name != cfg.Name {
+		t.Fatalf("restored funcData versions = %+v, ok %v", fd.versions, ok)
+	}
+}

--- a/providers/azure/managedcassandra/snapshot.go
+++ b/providers/azure/managedcassandra/snapshot.go
@@ -1,0 +1,66 @@
+package managedcassandra
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// mcSnapshot is the full serialized state of the Azure Managed Cassandra mock.
+// Both stores hold fully-exported mcdriver value types, so each round-trips
+// through the generic memstore helper keyed by its composite ARM key ("rg/name"
+// for clusters, "rg/cluster/name" for data centers). The wired opts are not
+// serialized.
+type mcSnapshot struct {
+	Clusters    json.RawMessage `json:"clusters,omitempty"`
+	DataCenters json.RawMessage `json:"dataCenters,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Managed Cassandra holds resource metadata, not bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap mcSnapshot
+
+	clusters, err := m.clusters.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("managedcassandra: snapshot clusters: %w", err)
+	}
+
+	dcs, err := m.dataCenters.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("managedcassandra: snapshot dataCenters: %w", err)
+	}
+
+	snap.Clusters = clusters
+	snap.DataCenters = dcs
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds the mock's state under the original identities: every cluster
+// and data-center composite key is preserved so a client's identifiers still
+// resolve.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap mcSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("managedcassandra: parse snapshot: %w", err)
+	}
+
+	if len(snap.Clusters) > 0 {
+		if err := m.clusters.LoadSnapshot(snap.Clusters); err != nil {
+			return fmt.Errorf("managedcassandra: restore clusters: %w", err)
+		}
+	}
+
+	if len(snap.DataCenters) > 0 {
+		if err := m.dataCenters.LoadSnapshot(snap.DataCenters); err != nil {
+			return fmt.Errorf("managedcassandra: restore dataCenters: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/azure/managedcassandra/snapshot_test.go
+++ b/providers/azure/managedcassandra/snapshot_test.go
@@ -1,0 +1,49 @@
+package managedcassandra
+
+import (
+	"context"
+	"testing"
+
+	mcdriver "github.com/stackshy/cloudemu/v2/services/managedcassandra/driver"
+)
+
+// TestSnapshotRoundTripManagedCassandra proves a snapshot/restore round-trip
+// preserves a cluster and a child data center under their composite ARM keys.
+func TestSnapshotRoundTripManagedCassandra(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, err := src.CreateOrUpdateCluster(ctx, mcdriver.CreateClusterConfig{
+		Name: "cass", ResourceGroup: "rg1", Location: "eastus",
+		DelegatedManagementSubnetID: "/subnets/sn", Tags: map[string]string{"env": "prod"},
+	}); err != nil {
+		t.Fatalf("CreateOrUpdateCluster: %v", err)
+	}
+
+	if _, err := src.CreateOrUpdateDataCenter(ctx, mcdriver.CreateDataCenterConfig{
+		ClusterName: "cass", ResourceGroup: "rg1", Name: "dc1",
+		DataCenterLocation: "eastus", NodeCount: 3, DelegatedSubnetID: "/subnets/sn",
+	}); err != nil {
+		t.Fatalf("CreateOrUpdateDataCenter: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	c, err := dst.GetCluster(ctx, "rg1", "cass")
+	if err != nil || c.Name != "cass" || c.Tags["env"] != "prod" {
+		t.Fatalf("restored cluster = %+v, err %v", c, err)
+	}
+
+	dc, err := dst.GetDataCenter(ctx, "rg1", "cass", "dc1")
+	if err != nil || dc.NodeCount != 3 {
+		t.Fatalf("restored data center = %+v, err %v", dc, err)
+	}
+}

--- a/providers/azure/search/snapshot.go
+++ b/providers/azure/search/snapshot.go
@@ -1,0 +1,106 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// searchSnapshot is the full serialized state of the Azure AI Search mock. Every
+// store holds a fully-exported driver value type (or the documents store's
+// map[string]any) keyed by service[/index]/name, so each round-trips through the
+// generic memstore helper — no promotion is needed. Seq is the monotonic etag
+// counter, captured so restored resources keep issuing fresh (non-colliding)
+// etags. The wired deps (m.opts, m.monitoring) are intentionally not serialized.
+type searchSnapshot struct {
+	Services     json.RawMessage `json:"services,omitempty"`
+	AdminKeys    json.RawMessage `json:"adminKeys,omitempty"`
+	QueryKeys    json.RawMessage `json:"queryKeys,omitempty"`
+	SharedLinks  json.RawMessage `json:"sharedLinks,omitempty"`
+	PrivateConns json.RawMessage `json:"privateConns,omitempty"`
+	Indexes      json.RawMessage `json:"indexes,omitempty"`
+	Documents    json.RawMessage `json:"documents,omitempty"`
+	Indexers     json.RawMessage `json:"indexers,omitempty"`
+	IndexerRuns  json.RawMessage `json:"indexerRuns,omitempty"`
+	DataSources  json.RawMessage `json:"dataSources,omitempty"`
+	Skillsets    json.RawMessage `json:"skillsets,omitempty"`
+	SynonymMaps  json.RawMessage `json:"synonymMaps,omitempty"`
+	Aliases      json.RawMessage `json:"aliases,omitempty"`
+	Seq          int64           `json:"seq,omitempty"`
+}
+
+// storeDumps pairs each snapshot field with its store's Snapshot/LoadSnapshot so
+// the dump and restore loops stay symmetric over the same store set.
+func (m *Mock) storeDumps(snap *searchSnapshot) []struct {
+	raw  *json.RawMessage
+	dump func() ([]byte, error)
+	load func([]byte) error
+} {
+	return []struct {
+		raw  *json.RawMessage
+		dump func() ([]byte, error)
+		load func([]byte) error
+	}{
+		{&snap.Services, m.services.Snapshot, m.services.LoadSnapshot},
+		{&snap.AdminKeys, m.adminKeys.Snapshot, m.adminKeys.LoadSnapshot},
+		{&snap.QueryKeys, m.queryKeys.Snapshot, m.queryKeys.LoadSnapshot},
+		{&snap.SharedLinks, m.sharedLinks.Snapshot, m.sharedLinks.LoadSnapshot},
+		{&snap.PrivateConns, m.privateConns.Snapshot, m.privateConns.LoadSnapshot},
+		{&snap.Indexes, m.indexes.Snapshot, m.indexes.LoadSnapshot},
+		{&snap.Documents, m.documents.Snapshot, m.documents.LoadSnapshot},
+		{&snap.Indexers, m.indexers.Snapshot, m.indexers.LoadSnapshot},
+		{&snap.IndexerRuns, m.indexerRuns.Snapshot, m.indexerRuns.LoadSnapshot},
+		{&snap.DataSources, m.dataSources.Snapshot, m.dataSources.LoadSnapshot},
+		{&snap.Skillsets, m.skillsets.Snapshot, m.skillsets.LoadSnapshot},
+		{&snap.SynonymMaps, m.synonymMaps.Snapshot, m.synonymMaps.LoadSnapshot},
+		{&snap.Aliases, m.aliases.Snapshot, m.aliases.LoadSnapshot},
+	}
+}
+
+// Snapshot captures every service and its data-plane resources as JSON.
+// includeAssets is unused — documents are always captured (they are the data
+// plane's payload, not a separable bulk asset).
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	var snap searchSnapshot
+
+	for _, d := range m.storeDumps(&snap) {
+		b, err := d.dump()
+		if err != nil {
+			return nil, fmt.Errorf("search: snapshot store: %w", err)
+		}
+
+		*d.raw = b
+	}
+
+	snap.Seq = m.seq.Load()
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds every service and data-plane resource under its original
+// service[/index]/name key, so cross-references (documents to their index,
+// aliases to their index) survive unchanged.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap searchSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("search: parse snapshot: %w", err)
+	}
+
+	for _, d := range m.storeDumps(&snap) {
+		if len(*d.raw) == 0 {
+			continue
+		}
+
+		if err := d.load(*d.raw); err != nil {
+			return fmt.Errorf("search: restore store: %w", err)
+		}
+	}
+
+	m.seq.Store(snap.Seq)
+
+	return nil
+}

--- a/providers/azure/search/snapshot_test.go
+++ b/providers/azure/search/snapshot_test.go
@@ -1,0 +1,66 @@
+package search
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/services/azuresearch/driver"
+)
+
+func newSnapshotTestMock() *Mock {
+	opts := config.NewOptions(config.WithRegion("eastus"), config.WithAccountID("sub-1"))
+
+	return New(opts)
+}
+
+// TestSnapshotRoundTripSearch proves a snapshot/restore round-trip preserves a
+// search service, one of its indexes, and an indexed document under their
+// original identities, with key fields intact.
+func TestSnapshotRoundTripSearch(t *testing.T) {
+	ctx := context.Background()
+	src := newSnapshotTestMock()
+
+	if _, err := src.CreateService(ctx, driver.ServiceConfig{
+		Name: "svc1", ResourceGroup: "rg1", Location: "eastus", SKUName: "standard",
+	}); err != nil {
+		t.Fatalf("create service: %v", err)
+	}
+
+	if _, err := src.CreateOrUpdateIndex(ctx, "svc1", driver.Index{
+		Name:   "idx1",
+		Fields: []driver.Field{{Name: "id", Type: "Edm.String", Key: true}, {Name: "title", Type: "Edm.String"}},
+	}); err != nil {
+		t.Fatalf("create index: %v", err)
+	}
+
+	if _, err := src.IndexDocuments(ctx, "svc1", "idx1", []driver.IndexAction{
+		{Action: "upload", Document: map[string]any{"id": "d1", "title": "hello"}},
+	}); err != nil {
+		t.Fatalf("index documents: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newSnapshotTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	if svc, err := dst.GetService(ctx, "rg1", "svc1"); err != nil || svc.SKUName != "standard" {
+		t.Fatalf("restored service = %+v, err %v", svc, err)
+	}
+
+	idx, err := dst.GetIndex(ctx, "svc1", "idx1")
+	if err != nil || len(idx.Fields) != 2 {
+		t.Fatalf("restored index = %+v, err %v", idx, err)
+	}
+
+	doc, err := dst.GetDocument(ctx, "svc1", "idx1", "d1")
+	if err != nil || doc["title"] != "hello" {
+		t.Fatalf("restored document = %+v, err %v", doc, err)
+	}
+}

--- a/providers/gcp/bigtable/snapshot.go
+++ b/providers/gcp/bigtable/snapshot.go
@@ -1,0 +1,114 @@
+package bigtable
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	btdriver "github.com/stackshy/cloudemu/v2/services/bigtable/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// btSnapshot is the full serialized state of the Bigtable Admin mock. Every store
+// holds a fully-exported btdriver value type keyed by its full GCP resource name
+// (projects/{p}/instances/{i}/...), so each round-trips through the generic
+// memstore helper — no promotion is needed. policies is a plain mu-guarded map of
+// resource -> IAM Policy (a fully-exported type), and opSeq is the operation-name
+// counter, both captured beside the stores so restored operation ids do not
+// collide with fresh ones. The wired deps (m.opts) and the RWMutex are
+// intentionally not serialized.
+type btSnapshot struct {
+	Instances   json.RawMessage            `json:"instances,omitempty"`
+	Clusters    json.RawMessage            `json:"clusters,omitempty"`
+	Tables      json.RawMessage            `json:"tables,omitempty"`
+	AppProfiles json.RawMessage            `json:"appProfiles,omitempty"`
+	Backups     json.RawMessage            `json:"backups,omitempty"`
+	Operations  json.RawMessage            `json:"operations,omitempty"`
+	Policies    map[string]btdriver.Policy `json:"policies,omitempty"`
+	OpSeq       uint64                     `json:"opSeq,omitempty"`
+}
+
+// Snapshot captures every instance and its children as JSON. includeAssets is
+// unused — Bigtable Admin is control-plane only and holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var snap btSnapshot
+
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Instances, m.instances.Snapshot},
+		{&snap.Clusters, m.clusters.Snapshot},
+		{&snap.Tables, m.tables.Snapshot},
+		{&snap.AppProfiles, m.appProfiles.Snapshot},
+		{&snap.Backups, m.backups.Snapshot},
+		{&snap.Operations, m.operations.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return nil, fmt.Errorf("bigtable: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	if len(m.policies) > 0 {
+		snap.Policies = make(map[string]btdriver.Policy, len(m.policies))
+		for k, v := range m.policies {
+			snap.Policies[k] = clonePolicy(&v)
+		}
+	}
+
+	snap.OpSeq = m.opSeq.Load()
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds every instance and child under its original resource name, so
+// cross-references (cluster->instance, table->instance) and IAM policies survive.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap btSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("bigtable: parse snapshot: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Instances, m.instances.LoadSnapshot},
+		{snap.Clusters, m.clusters.LoadSnapshot},
+		{snap.Tables, m.tables.LoadSnapshot},
+		{snap.AppProfiles, m.appProfiles.LoadSnapshot},
+		{snap.Backups, m.backups.LoadSnapshot},
+		{snap.Operations, m.operations.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("bigtable: restore store: %w", err)
+		}
+	}
+
+	for k, v := range snap.Policies {
+		m.policies[k] = clonePolicy(&v)
+	}
+
+	m.opSeq.Store(snap.OpSeq)
+
+	return nil
+}

--- a/providers/gcp/bigtable/snapshot_test.go
+++ b/providers/gcp/bigtable/snapshot_test.go
@@ -1,0 +1,64 @@
+package bigtable
+
+import (
+	"context"
+	"testing"
+
+	btdriver "github.com/stackshy/cloudemu/v2/services/bigtable/driver"
+)
+
+// TestSnapshotRoundTripBigtable proves a snapshot/restore round-trip preserves an
+// instance, its initial cluster, a table, and a resource IAM policy under their
+// original resource names.
+func TestSnapshotRoundTripBigtable(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	inst := mustInstance(t, src, "app")
+
+	if _, err := src.CreateTable(ctx, btdriver.CreateTableConfig{
+		Parent: inst, TableID: "t1",
+		ColumnFamilies: map[string]btdriver.ColumnFamily{"cf1": {}},
+	}); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	if _, err := src.SetIamPolicy(ctx, inst, btdriver.Policy{
+		Bindings: []btdriver.Binding{{Role: "roles/bigtable.user", Members: []string{"user:a@b.com"}}},
+	}); err != nil {
+		t.Fatalf("set iam policy: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	if got, err := dst.GetInstance(ctx, inst); err != nil || got.DisplayName != "app" {
+		t.Fatalf("restored instance = %+v, err %v", got, err)
+	}
+
+	clusters, err := dst.ListClusters(ctx, inst)
+	if err != nil || len(clusters) != 1 || clusters[0].ServeNodes != 3 {
+		t.Fatalf("restored clusters = %+v, err %v", clusters, err)
+	}
+
+	tbl, err := dst.GetTable(ctx, inst+"/tables/t1")
+	if err != nil {
+		t.Fatalf("get restored table: %v", err)
+	}
+
+	if _, ok := tbl.ColumnFamilies["cf1"]; !ok {
+		t.Fatalf("restored table missing column family cf1: %+v", tbl.ColumnFamilies)
+	}
+
+	pol, err := dst.GetIamPolicy(ctx, inst)
+	if err != nil || len(pol.Bindings) != 1 || pol.Bindings[0].Role != "roles/bigtable.user" {
+		t.Fatalf("restored policy = %+v, err %v", pol, err)
+	}
+}

--- a/providers/gcp/cloudfunctions/snapshot.go
+++ b/providers/gcp/cloudfunctions/snapshot.go
@@ -1,0 +1,203 @@
+package cloudfunctions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// funcsSnapshot is the full serialized state of the Cloud Functions mock. The
+// funcs and layers stores hold unexported value types (funcData/layerData) whose
+// fields — the function info, its published versions, its aliases (a nested store
+// of unexported aliasData), and its layer versions — are all unexported and
+// invisible to json.Marshal, so both are promoted to exported forms keyed by
+// their resource name. The mappings store holds a fully-exported
+// *EventSourceMappingInfo and round-trips through the generic memstore helper.
+// The registered Go handlers (funcData.handler and m.handlers), the wired
+// monitoring/opts deps, and the mutex are intentionally not serialized: a
+// restored function reports its stored config and versions, and a Go handler is
+// re-registered by the host process. Uploaded deployment-package bytes are not
+// stored in this mock at all (they are pushed to the configured FunctionEngine on
+// deploy), so what survives is the function configuration and per-version
+// CodeSHA, not raw code bytes.
+type funcsSnapshot struct {
+	Funcs    map[string]*funcSnapshot  `json:"funcs,omitempty"`
+	Layers   map[string]*layerSnapshot `json:"layers,omitempty"`
+	Mappings json.RawMessage           `json:"mappings,omitempty"`
+}
+
+// funcSnapshot mirrors funcData, promoting its unexported info/versions/aliases
+// and concurrency. The live handler func is intentionally omitted.
+type funcSnapshot struct {
+	Info         driver.FunctionInfo       `json:"info"`
+	EngineBacked bool                      `json:"engineBacked,omitempty"`
+	Versions     []*versionSnapshot        `json:"versions,omitempty"`
+	NextVersion  int                       `json:"nextVersion,omitempty"`
+	Aliases      map[string]*aliasSnapshot `json:"aliases,omitempty"`
+	Concurrency  *driver.ConcurrencyConfig `json:"concurrency,omitempty"`
+}
+
+// versionSnapshot mirrors versionData (all fields unexported).
+type versionSnapshot struct {
+	Config    driver.FunctionConfig `json:"config"`
+	Version   string                `json:"version"`
+	CodeSHA   string                `json:"codeSHA,omitempty"`
+	CreatedAt string                `json:"createdAt,omitempty"`
+}
+
+// aliasSnapshot mirrors aliasData (whose single field is unexported).
+type aliasSnapshot struct {
+	Alias driver.Alias `json:"alias"`
+}
+
+// layerSnapshot mirrors layerData: NextVer plus the nested versions store, which
+// holds a fully-exported *driver.LayerVersion and round-trips through the generic
+// helper.
+type layerSnapshot struct {
+	Versions json.RawMessage `json:"versions,omitempty"`
+	NextVer  int             `json:"nextVer,omitempty"`
+}
+
+// Snapshot captures every function, layer, and mapping as JSON. includeAssets is
+// unused — see the funcsSnapshot note on deployment bytes.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	snap := funcsSnapshot{Funcs: m.snapshotFuncs(), Layers: m.snapshotLayers()}
+
+	mappings, err := m.mappings.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("cloudfunctions: snapshot mappings: %w", err)
+	}
+
+	snap.Mappings = mappings
+
+	return json.Marshal(snap)
+}
+
+// snapshotFuncs promotes every funcData into its exported form. The caller holds
+// m.mu.
+func (m *Mock) snapshotFuncs() map[string]*funcSnapshot {
+	if m.funcs.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*funcSnapshot, m.funcs.Len())
+
+	for _, name := range m.funcs.Keys() {
+		fd, ok := m.funcs.Get(name)
+		if !ok {
+			continue
+		}
+
+		fs := &funcSnapshot{
+			Info: fd.info, EngineBacked: fd.engineBacked,
+			NextVersion: fd.nextVersion, Concurrency: fd.concurrency,
+		}
+
+		for _, v := range fd.versions {
+			fs.Versions = append(fs.Versions, &versionSnapshot{
+				Config: v.config, Version: v.version, CodeSHA: v.codeSHA, CreatedAt: v.createdAt,
+			})
+		}
+
+		if fd.aliases != nil && fd.aliases.Len() > 0 {
+			fs.Aliases = make(map[string]*aliasSnapshot, fd.aliases.Len())
+			for an, ad := range fd.aliases.All() {
+				fs.Aliases[an] = &aliasSnapshot{Alias: ad.alias}
+			}
+		}
+
+		out[name] = fs
+	}
+
+	return out
+}
+
+// snapshotLayers promotes every layerData, dumping its nested versions store
+// through the generic helper. The caller holds m.mu.
+func (m *Mock) snapshotLayers() map[string]*layerSnapshot {
+	if m.layers.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*layerSnapshot, m.layers.Len())
+
+	for name, ld := range m.layers.All() {
+		ls := &layerSnapshot{NextVer: ld.nextVer}
+		if b, err := ld.versions.Snapshot(); err == nil {
+			ls.Versions = b
+		}
+
+		out[name] = ls
+	}
+
+	return out
+}
+
+// Restore rebuilds every function, layer, and mapping under its original name, so
+// aliases and versions survive unchanged.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap funcsSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("cloudfunctions: parse snapshot: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.restoreFuncs(snap.Funcs)
+	m.restoreLayers(snap.Layers)
+
+	if len(snap.Mappings) > 0 {
+		if err := m.mappings.LoadSnapshot(snap.Mappings); err != nil {
+			return fmt.Errorf("cloudfunctions: restore mappings: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// restoreFuncs reinstates each promoted funcData. The handler stays nil until the
+// host re-registers it. The caller holds m.mu.
+func (m *Mock) restoreFuncs(funcs map[string]*funcSnapshot) {
+	for name, fs := range funcs {
+		fd := funcData{
+			info: fs.Info, engineBacked: fs.EngineBacked,
+			nextVersion: fs.NextVersion, concurrency: fs.Concurrency,
+			aliases: memstore.New[*aliasData](),
+		}
+
+		for _, v := range fs.Versions {
+			fd.versions = append(fd.versions, &versionData{
+				config: v.Config, version: v.Version, codeSHA: v.CodeSHA, createdAt: v.CreatedAt,
+			})
+		}
+
+		for an, as := range fs.Aliases {
+			fd.aliases.Set(an, &aliasData{alias: as.Alias})
+		}
+
+		m.funcs.Set(name, fd)
+	}
+}
+
+// restoreLayers reinstates each promoted layerData and its nested versions store.
+// The caller holds m.mu.
+func (m *Mock) restoreLayers(layers map[string]*layerSnapshot) {
+	for name, ls := range layers {
+		ld := &layerData{versions: memstore.New[*driver.LayerVersion](), nextVer: ls.NextVer}
+		if len(ls.Versions) > 0 {
+			_ = ld.versions.LoadSnapshot(ls.Versions)
+		}
+
+		m.layers.Set(name, ld)
+	}
+}

--- a/providers/gcp/cloudfunctions/snapshot_test.go
+++ b/providers/gcp/cloudfunctions/snapshot_test.go
@@ -1,0 +1,80 @@
+package cloudfunctions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// TestSnapshotRoundTripCloudFunctions proves a snapshot/restore round-trip
+// preserves a function, its published version (with CodeSHA), an alias, and a
+// layer version under their original identities.
+func TestSnapshotRoundTripCloudFunctions(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, err := src.CreateFunction(ctx, driver.FunctionConfig{
+		Name: "fn1", Runtime: "go121", Handler: "Handle", Memory: 256, Timeout: 60,
+		Code: []byte("deployment-package-bytes"), Framework: "http",
+	}); err != nil {
+		t.Fatalf("create function: %v", err)
+	}
+
+	ver, err := src.PublishVersion(ctx, "fn1", "v1")
+	if err != nil {
+		t.Fatalf("publish version: %v", err)
+	}
+
+	if _, err := src.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "fn1", Name: "prod", FunctionVersion: ver.Version,
+	}); err != nil {
+		t.Fatalf("create alias: %v", err)
+	}
+
+	if _, err := src.PublishLayerVersion(ctx, driver.LayerConfig{
+		Name: "shared", Content: []byte("layer-bytes"), CompatibleRuntimes: []string{"go121"},
+	}); err != nil {
+		t.Fatalf("publish layer: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	fn, err := dst.GetFunction(ctx, "fn1")
+	if err != nil || fn.Runtime != "go121" || fn.Handler != "Handle" {
+		t.Fatalf("restored function = %+v, err %v", fn, err)
+	}
+
+	vers, err := dst.ListVersions(ctx, "fn1")
+	if err != nil {
+		t.Fatalf("list versions: %v", err)
+	}
+
+	var found bool
+
+	for _, v := range vers {
+		if v.Version == "1" && v.CodeSHA256 == ver.CodeSHA256 {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatalf("published version 1 with sha %q not found in %+v", ver.CodeSHA256, vers)
+	}
+
+	if a, err := dst.GetAlias(ctx, "fn1", "prod"); err != nil || a.FunctionVersion != "1" {
+		t.Fatalf("restored alias = %+v, err %v", a, err)
+	}
+
+	if lv, err := dst.GetLayerVersion(ctx, "shared", 1); err != nil || lv.ContentSize != int64(len("layer-bytes")) {
+		t.Fatalf("restored layer version = %+v, err %v", lv, err)
+	}
+}

--- a/providers/gcp/cloudrun/snapshot.go
+++ b/providers/gcp/cloudrun/snapshot.go
@@ -1,0 +1,96 @@
+package cloudrun
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// crSnapshot is the full serialized state of the Cloud Run mock. Every store
+// holds a fully-exported driver value type (Job, Execution, Service, Revision) —
+// or, for engineHandles, a plain []string — keyed by resource id, so each
+// round-trips through the generic memstore helper; no promotion is needed. The
+// container template a job/service/revision carries (its image reference and
+// command, the deployable "code") lives in those exported fields and survives
+// unchanged. The wired ContainerEngine (m.opts) and the mutex are intentionally
+// not serialized; a restored engineHandles entry records that a job's executions
+// were engine-backed, but the real containers behind those handles do not survive
+// a process restart.
+type crSnapshot struct {
+	Jobs          json.RawMessage `json:"jobs,omitempty"`
+	Executions    json.RawMessage `json:"executions,omitempty"`
+	Services      json.RawMessage `json:"services,omitempty"`
+	Revisions     json.RawMessage `json:"revisions,omitempty"`
+	EngineHandles json.RawMessage `json:"engineHandles,omitempty"`
+}
+
+// Snapshot captures every job, execution, service, and revision as JSON.
+// includeAssets is unused — Cloud Run holds container references, not object
+// bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var snap crSnapshot
+
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Jobs, m.jobs.Snapshot},
+		{&snap.Executions, m.executions.Snapshot},
+		{&snap.Services, m.services.Snapshot},
+		{&snap.Revisions, m.revisions.Snapshot},
+		{&snap.EngineHandles, m.engineHandles.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return nil, fmt.Errorf("cloudrun: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds every job, execution, service, and revision under its original
+// id, so parent references (execution->job, revision->service) survive unchanged.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap crSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("cloudrun: parse snapshot: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Jobs, m.jobs.LoadSnapshot},
+		{snap.Executions, m.executions.LoadSnapshot},
+		{snap.Services, m.services.LoadSnapshot},
+		{snap.Revisions, m.revisions.LoadSnapshot},
+		{snap.EngineHandles, m.engineHandles.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("cloudrun: restore store: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/providers/gcp/cloudrun/snapshot_test.go
+++ b/providers/gcp/cloudrun/snapshot_test.go
@@ -1,0 +1,53 @@
+package cloudrun
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/cloudrun/driver"
+)
+
+// TestSnapshotRoundTripCloudRun proves a snapshot/restore round-trip preserves a
+// job and a service (with its materialized revision) under their original ids,
+// with the container image reference — the deployable "code" — intact.
+func TestSnapshotRoundTripCloudRun(t *testing.T) {
+	ctx := context.Background()
+	src := newMock(t, nil)
+
+	if _, err := src.CreateJob(ctx, jobCfg()); err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+
+	if _, err := src.CreateService(ctx, driver.ServiceConfig{
+		Name: "web", Location: "us-central1",
+		Containers: []driver.Container{{Name: "app", Image: "gcr.io/proj/app:v1"}},
+	}); err != nil {
+		t.Fatalf("create service: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newMock(t, nil)
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	job, err := dst.GetJob(ctx, "batch")
+	if err != nil || len(job.Containers) != 1 || job.Containers[0].Image != "busybox" {
+		t.Fatalf("restored job = %+v, err %v", job, err)
+	}
+
+	svc, err := dst.GetService(ctx, "web")
+	if err != nil || len(svc.Containers) != 1 || svc.Containers[0].Image != "gcr.io/proj/app:v1" {
+		t.Fatalf("restored service = %+v, err %v", svc, err)
+	}
+
+	// The service's first revision was materialized on create and must survive.
+	revs, err := dst.ListRevisions(ctx, "web")
+	if err != nil || len(revs) != 1 || revs[0].Containers[0].Image != "gcr.io/proj/app:v1" {
+		t.Fatalf("restored revisions = %+v, err %v", revs, err)
+	}
+}


### PR DESCRIPTION
Final batch for #582 — completes identity-preserving persistence across all memstore-backed provider mocks.

## Services (24)
- **AWS (16):** acm, bedrockagent, cloudtrail, configservice, guardduty, kafka, keyspaces, lambda, memorydb, networkfirewall, opensearch, redshift, route53resolver, sesv2, vpclattice, wafv2
- **Azure (5):** containerinstances, cosmospostgresql, functions, managedcassandra, search
- **GCP (3):** bigtable, cloudfunctions, cloudrun

Each implements internal/snapshot.Snapshottable (identity-preserving keys, unexported-field promotions where needed). Serverless mocks (lambda/functions/cloudfunctions/cloudrun) persist function code + config. Auto-discovered by the property-based discovery test (no golden-list edit).

## Completeness guard
persist/completeness_test.go reflects over every provider and FAILS if a mock holds a memstore.Store but is not Snapshottable — with an empty exclude list. This machine-verifies #582's 'all stateful services' claim and prevents future regressions.

## Folds
- #817: persist.Restore now warns (instead of silently skipping) when a snapshot carries a service key with no matching target (persist/restore_warn_test.go).

Refs #582. Completes AWS/Azure/GCP; OCI persistence (concrete OCI mocks hold real memstore.Store state but the Provider exposes them as driver interfaces, so the static-type guard cannot see them) is tracked as remaining work before #582 is fully closed.