### PR TITLE
feat(persist): OCI mocks Snapshottable + guard walks interface-exposed mocks (#582)

### DIFF
--- a/persist/completeness_test.go
+++ b/persist/completeness_test.go
@@ -33,14 +33,13 @@ var guardExclude = map[string]struct{}{}
 // Discover) so a NEW stateful service that forgets to add persistence fails
 // here, naming the field, until it is implemented or justified in guardExclude.
 //
-// OCI is intentionally covered-by-criterion-but-empty: the OCI Provider exposes
-// its services as DRIVER INTERFACES (netdriver.Networking, iamdriver.IAM, ...),
-// not concrete *Mock structs, so holdsStore — which walks static struct/pointer
-// types — never reaches the memstore.Store the concrete OCI mocks hold behind
-// those interfaces. OCI persistence is therefore out of scope by this guard's
-// criterion (the concrete OCI mocks do use memstore.Store; persisting them is a
-// separate follow-up). The AWS/Azure/GCP providers expose concrete *Mock fields,
-// so they are fully covered.
+// OCI is covered too, even though its Provider exposes services as DRIVER
+// INTERFACES (netdriver.Networking, iamdriver.IAM, ...) rather than concrete
+// *Mock structs: for a non-nil interface-typed field the guard resolves the
+// runtime concrete type behind it (e.g. *identity.Mock) and runs the same
+// holdsStore + Snapshottable check on that concrete type. So a stateful mock
+// hidden behind an interface is caught, not blind-spotted. The AWS/Azure/GCP
+// providers expose concrete *Mock fields, which take the static-type path.
 func TestSnapshotCompleteness(t *testing.T) {
 	snapType := reflect.TypeOf((*snapshot.Snapshottable)(nil)).Elem()
 
@@ -75,11 +74,25 @@ func TestSnapshotCompleteness(t *testing.T) {
 					continue
 				}
 
-				if !holdsStore(f.Type, 0) {
+				// Resolve an interface-typed field (every OCI service field) to
+				// the concrete type of the value it holds, so a stateful mock
+				// behind the interface is inspected like a concrete *Mock field.
+				// A nil interface holds no state and is skipped.
+				ft := f.Type
+				if ft.Kind() == reflect.Interface {
+					fv := v.Field(i)
+					if fv.IsNil() {
+						continue
+					}
+
+					ft = fv.Elem().Type()
+				}
+
+				if !holdsStore(ft, 0) {
 					continue
 				}
 
-				if f.Type.Implements(snapType) {
+				if ft.Implements(snapType) {
 					continue
 				}
 
@@ -91,7 +104,7 @@ func TestSnapshotCompleteness(t *testing.T) {
 				missing++
 
 				t.Errorf("%s: field %s (%s) holds a memstore.Store but is not Snapshottable — "+
-					"add persistence (see #582) or justify in guardExclude", prov.name, f.Name, f.Type)
+					"add persistence (see #582) or justify in guardExclude", prov.name, f.Name, ft)
 			}
 		})
 	}
@@ -102,10 +115,11 @@ func TestSnapshotCompleteness(t *testing.T) {
 }
 
 // holdsStore reports whether a *memstore.Store is reachable from type t within
-// maxStoreScanDepth nested struct/pointer hops. It walks STATIC types, so a field
-// typed as an interface (as every OCI service field is) is opaque and returns
-// false — the concrete mock behind it is never inspected. This is the same
-// criterion used to compute the set of services persistence must cover.
+// maxStoreScanDepth nested struct/pointer hops. It walks STATIC types, so an
+// interface type is opaque to it; the caller resolves an interface-typed
+// provider field to its runtime concrete type before calling this, so the mock
+// behind it is inspected. This is the same criterion used to compute the set of
+// services persistence must cover.
 func holdsStore(t reflect.Type, depth int) bool {
 	if depth > maxStoreScanDepth || t == nil {
 		return false

--- a/persist/oci_test.go
+++ b/persist/oci_test.go
@@ -1,0 +1,109 @@
+package persist_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/persist"
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// TestOCIProviderRoundTripPreservesCrossRefs is the whole-provider proof for the
+// OCI half of #582: a VCN + subnet, a user, a policy and a metric seeded across
+// the Identity / VCN / Monitoring mocks all survive a full ExportAll -> JSON ->
+// RestoreAll into a FRESH provider, and — crucially — the subnet still resolves
+// to its VCN under the same OCIDs. The OCI provider exposes services as driver
+// interfaces, so this also exercises the interface-aware discovery path.
+func TestOCIProviderRoundTripPreservesCrossRefs(t *testing.T) {
+	ctx := t.Context()
+	src := cloudemu.NewOCI()
+
+	vpc, err := src.VCN.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	if err != nil {
+		t.Fatalf("create vcn: %v", err)
+	}
+
+	subnet, err := src.VCN.CreateSubnet(ctx, netdriver.SubnetConfig{VPCID: vpc.ID, CIDRBlock: "10.0.1.0/24"})
+	if err != nil {
+		t.Fatalf("create subnet: %v", err)
+	}
+
+	if _, err = src.Identity.CreateUser(ctx, iamdriver.UserConfig{Name: "alice"}); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	pol, err := src.Identity.CreatePolicy(ctx, iamdriver.PolicyConfig{
+		Name:           "p1",
+		PolicyDocument: "Allow group Admins to manage all-resources in tenancy",
+	})
+	if err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+
+	if err = src.Monitoring.PutMetricData(ctx, []mondriver.MetricDatum{
+		{Namespace: "myapp", MetricName: "requests", Value: 7},
+	}); err != nil {
+		t.Fatalf("put metric: %v", err)
+	}
+
+	// Export the whole OCI provider and restore into a completely fresh one.
+	snap, err := persist.ExportAll(ctx,
+		map[string]persist.Services{"oci": src.SnapshotServices()}, persist.Options{})
+	if err != nil {
+		t.Fatalf("ExportAll: %v", err)
+	}
+
+	raw, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+
+	var got persist.Snapshot
+	if err = json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal snapshot: %v", err)
+	}
+
+	dst := cloudemu.NewOCI()
+	if err = persist.RestoreAll(ctx, &got, map[string]persist.Services{"oci": dst.SnapshotServices()}); err != nil {
+		t.Fatalf("RestoreAll: %v", err)
+	}
+
+	// The subnet keeps its OCID and its VCNID cross-reference resolves to the
+	// restored VCN — a snapshot that dropped the VCN would leave it dangling.
+	subnets, err := dst.VCN.DescribeSubnets(ctx, []string{subnet.ID})
+	if err != nil {
+		t.Fatalf("describe restored subnet: %v", err)
+	}
+	if len(subnets) != 1 || subnets[0].VPCID != vpc.ID {
+		t.Fatalf("subnet %q does not resolve to restored VCN %q: %v", subnet.ID, vpc.ID, subnets)
+	}
+
+	vpcs, err := dst.VCN.DescribeVPCs(ctx, []string{vpc.ID})
+	if err != nil {
+		t.Fatalf("describe restored vcn: %v", err)
+	}
+	if len(vpcs) != 1 || vpcs[0].ID != vpc.ID {
+		t.Fatalf("VCN %q not restored: %v", vpc.ID, vpcs)
+	}
+
+	// The user and policy survived under their identities.
+	if _, err = dst.Identity.GetUser(ctx, "alice"); err != nil {
+		t.Fatalf("restored user alice: %v", err)
+	}
+
+	if _, err = dst.Identity.GetPolicy(ctx, pol.ID); err != nil {
+		t.Fatalf("restored policy %q: %v", pol.ID, err)
+	}
+
+	// The metric survived.
+	names, err := dst.Monitoring.ListMetrics(ctx, "myapp")
+	if err != nil {
+		t.Fatalf("list restored metrics: %v", err)
+	}
+	if len(names) != 1 || names[0] != "requests" {
+		t.Fatalf("restored metric names = %v, want [requests]", names)
+	}
+}

--- a/persist/snapshot_services_test.go
+++ b/persist/snapshot_services_test.go
@@ -151,12 +151,24 @@ func TestSnapshotServicesStableKeys(t *testing.T) {
 	}
 }
 
-// TestSnapshotServicesOCIEmpty documents that a provider with no Snapshottable
-// service yet (OCI today) discovers an empty map rather than erroring — the
-// mechanism auto-includes services as they implement the interface.
-func TestSnapshotServicesOCIEmpty(t *testing.T) {
-	if got := cloudemu.NewOCI().SnapshotServices(); len(got) != 0 {
-		t.Fatalf("oci SnapshotServices = %v, want empty", got)
+// TestSnapshotServicesOCIDiscovered documents that the OCI provider discovers its
+// Snapshottable services even though it exposes them as driver interfaces:
+// snapshot.Discover asserts on the runtime value behind each field, so the
+// concrete mocks that implement the interface (Identity, VCN, Monitoring) are
+// picked up. Nil service fields (not yet wired) contribute nothing.
+func TestSnapshotServicesOCIDiscovered(t *testing.T) {
+	got := cloudemu.NewOCI().SnapshotServices()
+
+	for _, want := range []string{"identity", "vcn", "monitoring"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("oci SnapshotServices missing %q; got keys %v", want, keysOf(got))
+		}
+	}
+
+	for name, s := range got {
+		if s == nil {
+			t.Errorf("oci service %q discovered as nil", name)
+		}
 	}
 }
 
@@ -222,11 +234,19 @@ func reflectSnapshotKeys(p any) (keys map[string]struct{}, collisions []string) 
 		}
 
 		fv := v.Field(i)
-		if fv.Kind() == reflect.Pointer && fv.IsNil() {
+		if (fv.Kind() == reflect.Pointer || fv.Kind() == reflect.Interface) && fv.IsNil() {
 			continue
 		}
 
-		if !fv.Type().Implements(snapType) {
+		// Resolve an interface-typed field to the concrete value it holds, so a
+		// mock exposed as a driver interface (every OCI service field) is
+		// discovered by the same criterion as a concrete field.
+		ft := fv.Type()
+		if fv.Kind() == reflect.Interface {
+			ft = fv.Elem().Type()
+		}
+
+		if !ft.Implements(snapType) {
 			continue
 		}
 

--- a/providers/oci/identity/snapshot.go
+++ b/providers/oci/identity/snapshot.go
@@ -1,0 +1,169 @@
+package identity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// identitySnapshot is the full serialized state of the OCI Identity mock. Every
+// store is keyed by resource OCID so cross-references (a membership's UserID /
+// GroupID, a policy's compartment scope, a compartment's parent) still resolve
+// after a restore. The fully-exported value types round-trip through the generic
+// memstore helper; policies carry an exported form because policy has unexported
+// fields (parsed / versions / versionCounter). The mutex and *config.Options are
+// intentionally not serialized.
+type identitySnapshot struct {
+	Users         json.RawMessage            `json:"users,omitempty"`
+	Groups        json.RawMessage            `json:"groups,omitempty"`
+	Memberships   json.RawMessage            `json:"memberships,omitempty"`
+	Compartments  json.RawMessage            `json:"compartments,omitempty"`
+	DynamicGroups json.RawMessage            `json:"dynamicGroups,omitempty"`
+	AuthTokens    json.RawMessage            `json:"authTokens,omitempty"`
+	Policies      map[string]*policySnapshot `json:"policies,omitempty"`
+}
+
+// policySnapshot mirrors policy, promoting its unexported fields (versions and
+// versionCounter) to exported ones so they survive JSON. parsed is derived from
+// Statements and rebuilt on restore rather than serialized. policyRevision is
+// fully exported, so the version history embeds directly.
+type policySnapshot struct {
+	ID             string            `json:"id"`
+	Name           string            `json:"name,omitempty"`
+	Description    string            `json:"description,omitempty"`
+	Statements     []string          `json:"statements,omitempty"`
+	TimeCreated    string            `json:"timeCreated,omitempty"`
+	VersionDate    string            `json:"versionDate,omitempty"`
+	Scope          scope.Scope       `json:"scope,omitempty"`
+	FreeformTags   map[string]string `json:"freeformTags,omitempty"`
+	Versions       []*policyRevision `json:"versions,omitempty"`
+	VersionCounter int               `json:"versionCounter,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Identity holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	snap := identitySnapshot{Policies: m.snapshotPolicies()}
+
+	dumps := []struct {
+		dst *json.RawMessage
+		fn  func() ([]byte, error)
+	}{
+		{&snap.Users, m.users.Snapshot},
+		{&snap.Groups, m.groups.Snapshot},
+		{&snap.Memberships, m.memberships.Snapshot},
+		{&snap.Compartments, m.compartments.Snapshot},
+		{&snap.DynamicGroups, m.dynamicGroups.Snapshot},
+		{&snap.AuthTokens, m.authTokens.Snapshot},
+	}
+
+	for _, d := range dumps {
+		b, err := d.fn()
+		if err != nil {
+			return nil, fmt.Errorf("identity: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	// G117 false positive: the authTokens key names a store of auth-token
+	// metadata that is intentionally persisted, not a leaked credential.
+	//nolint:gosec // authTokens is a resource store, not a hardcoded secret.
+	return json.Marshal(snap)
+}
+
+// snapshotPolicies promotes each stored policy to its exported snapshot form.
+// Callers hold m.mu.
+func (m *Mock) snapshotPolicies() map[string]*policySnapshot {
+	if m.policies.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*policySnapshot, m.policies.Len())
+
+	for id, p := range m.policies.All() {
+		out[id] = &policySnapshot{
+			ID:             p.ID,
+			Name:           p.Name,
+			Description:    p.Description,
+			Statements:     copyStrings(p.Statements),
+			TimeCreated:    p.TimeCreated,
+			VersionDate:    p.VersionDate,
+			Scope:          p.Scope,
+			FreeformTags:   copyTags(p.FreeformTags),
+			Versions:       p.versions,
+			VersionCounter: p.versionCounter,
+		}
+	}
+
+	return out
+}
+
+// Restore rebuilds the mock's state under the original identities, so restored
+// users, groups, memberships, policies and compartments keep their OCIDs and
+// every id-string cross-reference between them still resolves.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap identitySnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("identity: parse snapshot: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.restorePolicies(snap.Policies)
+
+	loads := []struct {
+		src json.RawMessage
+		fn  func([]byte) error
+	}{
+		{snap.Users, m.users.LoadSnapshot},
+		{snap.Groups, m.groups.LoadSnapshot},
+		{snap.Memberships, m.memberships.LoadSnapshot},
+		{snap.Compartments, m.compartments.LoadSnapshot},
+		{snap.DynamicGroups, m.dynamicGroups.LoadSnapshot},
+		{snap.AuthTokens, m.authTokens.LoadSnapshot},
+	}
+
+	for _, l := range loads {
+		if len(l.src) == 0 {
+			continue
+		}
+
+		if err := l.fn(l.src); err != nil {
+			return fmt.Errorf("identity: restore store: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// restorePolicies reinstates each policy under its original OCID, re-deriving the
+// parsed statements from the stored text so Evaluate works after a restore.
+// Callers hold m.mu.
+func (m *Mock) restorePolicies(policies map[string]*policySnapshot) {
+	for id, s := range policies {
+		parsed, _ := parseStatements(s.Statements)
+		m.policies.Set(id, &policy{
+			ID:             s.ID,
+			Name:           s.Name,
+			Description:    s.Description,
+			Statements:     copyStrings(s.Statements),
+			TimeCreated:    s.TimeCreated,
+			VersionDate:    s.VersionDate,
+			Scope:          s.Scope,
+			FreeformTags:   copyTags(s.FreeformTags),
+			parsed:         parsed,
+			versions:       s.Versions,
+			versionCounter: s.VersionCounter,
+		})
+	}
+}

--- a/providers/oci/identity/snapshot_test.go
+++ b/providers/oci/identity/snapshot_test.go
@@ -1,0 +1,113 @@
+package identity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// TestSnapshotRestoreRoundTripAllStores seeds every identity store, snapshots,
+// restores into a fresh mock and asserts each piece of state comes back under
+// its original OCID — a missed store would be silent data loss. The
+// user->group membership cross-reference and the policy version history (an
+// unexported field that needs promotion) are both exercised.
+func TestSnapshotRestoreRoundTripAllStores(t *testing.T) {
+	ctx := t.Context()
+	src := newMock(t)
+
+	comp := newCompartment(t, src, tenancy, "team")
+
+	user, err := src.CreateOCIUser(ctx, PrincipalSpec{CompartmentID: comp, Name: "alice"})
+	require.NoError(t, err)
+
+	group, err := src.CreateOCIGroup(ctx, PrincipalSpec{CompartmentID: comp, Name: adminName})
+	require.NoError(t, err)
+
+	mem, err := src.CreateOCIGroupMembership(ctx, user.ID, group.ID)
+	require.NoError(t, err)
+
+	pol, err := src.CreateStatementPolicy(ctx, &PolicySpec{
+		CompartmentID: comp,
+		Name:          "p1",
+		Statements:    []string{"Allow group Admins to manage all-resources in tenancy"},
+	})
+	require.NoError(t, err)
+
+	// A second revision so the version history + counter must round-trip.
+	_, err = src.UpdateStatementPolicy(ctx, pol.ID, PolicyUpdate{
+		Statements: []string{"Allow group Admins to read all-resources in tenancy"},
+	})
+	require.NoError(t, err)
+
+	dg, err := src.CreateRole(ctx, driver.RoleConfig{
+		Name: "builders", AssumeRolePolicyDoc: "instance.compartment.id = 'x'",
+	})
+	require.NoError(t, err)
+
+	key, err := src.CreateAccessKey(ctx, driver.AccessKeyConfig{UserName: "alice"})
+	require.NoError(t, err)
+
+	data, err := src.Snapshot(ctx, false)
+	require.NoError(t, err)
+
+	dst := newMock(t)
+	require.NoError(t, dst.Restore(ctx, data))
+
+	// Compartment restored under its OCID.
+	gotComp, err := dst.GetCompartment(ctx, comp)
+	require.NoError(t, err)
+	assert.Equal(t, "team", gotComp.Name)
+
+	// User + group restored, and the membership still binds the same OCIDs.
+	gotUser, err := dst.GetOCIUser(ctx, user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, comp, gotUser.CompartmentID)
+
+	gotMem, err := dst.GetOCIGroupMembership(ctx, mem.ID)
+	require.NoError(t, err)
+	assert.Equal(t, user.ID, gotMem.UserID)
+	assert.Equal(t, group.ID, gotMem.GroupID)
+
+	// Policy restored with its version history and parsed statements (Evaluate
+	// only works when parsed is rebuilt on restore).
+	rp, ok := dst.policies.Get(pol.ID)
+	require.True(t, ok, "policy restored under its OCID")
+	assert.Len(t, rp.versions, 2)
+	assert.Equal(t, 2, rp.versionCounter)
+	assert.NotEmpty(t, rp.parsed, "parsed statements rebuilt on restore")
+
+	granted, err := dst.Evaluate(ctx, &AccessRequest{
+		Groups: []string{adminName}, Verb: "read", ResourceType: "all-resources", CompartmentID: comp,
+	})
+	require.NoError(t, err)
+	assert.True(t, granted, "restored policy still grants access")
+
+	// Dynamic group + auth token restored.
+	gotDG, err := dst.GetRole(ctx, dg.Name)
+	require.NoError(t, err)
+	assert.Equal(t, dg.ID, gotDG.ID)
+
+	keys, err := dst.ListAccessKeys(ctx, "alice")
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, key.AccessKeyID, keys[0].AccessKeyID)
+}
+
+// TestSnapshotRestoreEmptyNilSafe confirms an empty mock round-trips without
+// panicking and stays usable afterwards.
+func TestSnapshotRestoreEmptyNilSafe(t *testing.T) {
+	ctx := t.Context()
+	src := newMock(t)
+
+	data, err := src.Snapshot(ctx, false)
+	require.NoError(t, err)
+
+	dst := newMock(t)
+	require.NoError(t, dst.Restore(ctx, data))
+
+	_, err = dst.CreateOCIUser(ctx, PrincipalSpec{CompartmentID: tenancy, Name: "bob"})
+	require.NoError(t, err)
+}

--- a/providers/oci/monitoring/snapshot.go
+++ b/providers/oci/monitoring/snapshot.go
@@ -1,0 +1,195 @@
+package monitoring
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// monitoringSnapshot is the full serialized state of the OCI Monitoring mock.
+// Series and alarms carry exported forms because metricSeries and alarmRecord
+// have entirely unexported fields; notification channels are a fully-exported
+// driver type and round-trip through the generic memstore helper. Each map is
+// keyed by its store's key (series key / alarm OCID / channel OCID) so a restore
+// reinstates every entry under the same identity. The mutex and *config.Options
+// are intentionally not serialized.
+type monitoringSnapshot struct {
+	Series   map[string]*seriesSnapshot `json:"series,omitempty"`
+	Alarms   map[string]*alarmSnapshot  `json:"alarms,omitempty"`
+	Channels json.RawMessage            `json:"channels,omitempty"`
+}
+
+// seriesSnapshot mirrors metricSeries, promoting its unexported fields (and the
+// unexported metricPoint samples) to exported ones so they survive JSON.
+type seriesSnapshot struct {
+	Place         scope.Scope       `json:"place,omitempty"`
+	Namespace     string            `json:"namespace,omitempty"`
+	ResourceGroup string            `json:"resourceGroup,omitempty"`
+	Name          string            `json:"name,omitempty"`
+	Dimensions    map[string]string `json:"dimensions,omitempty"`
+	Points        []pointSnapshot   `json:"points,omitempty"`
+}
+
+// pointSnapshot is the exported form of metricPoint.
+type pointSnapshot struct {
+	Timestamp time.Time `json:"timestamp"`
+	Value     float64   `json:"value"`
+}
+
+// alarmSnapshot mirrors alarmRecord, promoting its unexported fields to exported
+// ones. OCIAlarmSpec and driver.AlarmHistoryEntry are fully exported, so the
+// spec and the state-change history embed directly.
+type alarmSnapshot struct {
+	ID             string                     `json:"id"`
+	Place          scope.Scope                `json:"place,omitempty"`
+	Spec           OCIAlarmSpec               `json:"spec"`
+	Status         string                     `json:"status,omitempty"`
+	LifecycleState string                     `json:"lifecycleState,omitempty"`
+	TimeCreated    time.Time                  `json:"timeCreated,omitempty"`
+	TimeUpdated    time.Time                  `json:"timeUpdated,omitempty"`
+	TimeTriggered  time.Time                  `json:"timeTriggered,omitempty"`
+	BreachSince    time.Time                  `json:"breachSince,omitempty"`
+	History        []driver.AlarmHistoryEntry `json:"history,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// Monitoring holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	channels, err := m.channels.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("monitoring: snapshot channels: %w", err)
+	}
+
+	return json.Marshal(monitoringSnapshot{
+		Series:   m.snapshotSeries(),
+		Alarms:   m.snapshotAlarms(),
+		Channels: channels,
+	})
+}
+
+// snapshotSeries promotes each stored metric series to its exported form.
+// Callers hold m.mu.
+func (m *Mock) snapshotSeries() map[string]*seriesSnapshot {
+	if m.series.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*seriesSnapshot, m.series.Len())
+
+	for key, s := range m.series.All() {
+		points := make([]pointSnapshot, 0, len(s.points))
+		for _, p := range s.points {
+			points = append(points, pointSnapshot{Timestamp: p.timestamp, Value: p.value})
+		}
+
+		out[key] = &seriesSnapshot{
+			Place:         s.place,
+			Namespace:     s.namespace,
+			ResourceGroup: s.resourceGroup,
+			Name:          s.name,
+			Dimensions:    copyTags(s.dimensions),
+			Points:        points,
+		}
+	}
+
+	return out
+}
+
+// snapshotAlarms promotes each stored alarm to its exported form. Callers hold
+// m.mu.
+func (m *Mock) snapshotAlarms() map[string]*alarmSnapshot {
+	if m.alarms.Len() == 0 {
+		return nil
+	}
+
+	out := make(map[string]*alarmSnapshot, m.alarms.Len())
+
+	for id, a := range m.alarms.All() {
+		out[id] = &alarmSnapshot{
+			ID:             a.id,
+			Place:          a.place,
+			Spec:           a.spec,
+			Status:         a.status,
+			LifecycleState: a.lifecycleState,
+			TimeCreated:    a.timeCreated,
+			TimeUpdated:    a.timeUpdated,
+			TimeTriggered:  a.timeTriggered,
+			BreachSince:    a.breachSince,
+			History:        append([]driver.AlarmHistoryEntry(nil), a.history...),
+		}
+	}
+
+	return out
+}
+
+// Restore rebuilds the mock's state under the original identities: each series
+// key, alarm OCID and channel OCID is preserved, so a restored alarm's history
+// and a restored series' samples come back intact.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap monitoringSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("monitoring: parse snapshot: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.restoreSeries(snap.Series)
+	m.restoreAlarms(snap.Alarms)
+
+	if len(snap.Channels) != 0 {
+		if err := m.channels.LoadSnapshot(snap.Channels); err != nil {
+			return fmt.Errorf("monitoring: restore channels: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// restoreSeries reinstates each metric series under its original key. Callers
+// hold m.mu.
+func (m *Mock) restoreSeries(series map[string]*seriesSnapshot) {
+	for key, s := range series {
+		points := make([]metricPoint, 0, len(s.Points))
+		for _, p := range s.Points {
+			points = append(points, metricPoint{timestamp: p.Timestamp, value: p.Value})
+		}
+
+		m.series.Set(key, &metricSeries{
+			place:         s.Place,
+			namespace:     s.Namespace,
+			resourceGroup: s.ResourceGroup,
+			name:          s.Name,
+			dimensions:    copyTags(s.Dimensions),
+			points:        points,
+		})
+	}
+}
+
+// restoreAlarms reinstates each alarm under its original OCID. Callers hold m.mu.
+func (m *Mock) restoreAlarms(alarms map[string]*alarmSnapshot) {
+	for id, a := range alarms {
+		m.alarms.Set(id, &alarmRecord{
+			id:             a.ID,
+			place:          a.Place,
+			spec:           a.Spec,
+			status:         a.Status,
+			lifecycleState: a.LifecycleState,
+			timeCreated:    a.TimeCreated,
+			timeUpdated:    a.TimeUpdated,
+			timeTriggered:  a.TimeTriggered,
+			breachSince:    a.BreachSince,
+			history:        append([]driver.AlarmHistoryEntry(nil), a.History...),
+		})
+	}
+}

--- a/providers/oci/monitoring/snapshot_test.go
+++ b/providers/oci/monitoring/snapshot_test.go
@@ -1,0 +1,81 @@
+package monitoring
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// TestSnapshotRestoreRoundTrip seeds metric series, a fired alarm (with state
+// history) and a notification channel, snapshots, restores into a fresh mock and
+// asserts each store's state comes back — including the alarm's history and the
+// series' samples, both promoted from unexported fields.
+func TestSnapshotRestoreRoundTrip(t *testing.T) {
+	src, now := newMock(t)
+	ctx := t.Context()
+
+	alarm, err := src.CreateOCIAlarm(ctx, alarmSpec(compartmentA, "high-cpu", "CpuUtilization[1m].mean() > 80"))
+	require.NoError(t, err)
+
+	// A breaching sample fires the alarm, writing a state-change history entry.
+	post(t, src, compartmentA, "CpuUtilization", now.Add(-10*time.Second), 95)
+
+	ch, err := src.CreateNotificationChannel(ctx, driver.NotificationChannelConfig{
+		Name: "ops", Type: "EMAIL", Endpoint: "ops@example.com",
+	})
+	require.NoError(t, err)
+
+	data, err := src.Snapshot(ctx, false)
+	require.NoError(t, err)
+
+	dst, _ := newMock(t)
+	require.NoError(t, dst.Restore(ctx, data))
+
+	// The alarm is back under its OCID, still FIRING, with its history intact.
+	fired, err := dst.GetOCIAlarm(ctx, alarm.ID)
+	require.NoError(t, err)
+	assert.Equal(t, StatusFiring, fired.Status)
+	assert.False(t, fired.TimeTriggered.IsZero())
+
+	history, err := dst.OCIAlarmHistory(ctx, alarm.ID, 0)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, StatusOK, history[0].OldState)
+	assert.Equal(t, StatusFiring, history[0].NewState)
+
+	// The metric series survived with its sample: a summarize query aggregates it.
+	metrics, err := dst.SummarizeOCIMetrics(ctx, compartmentA, OCIMetricQuery{
+		Namespace: namespace,
+		Query:     "CpuUtilization[1m].mean()",
+		StartTime: now.Add(-time.Hour),
+		EndTime:   now,
+	})
+	require.NoError(t, err)
+	require.Len(t, metrics, 1)
+	require.NotEmpty(t, metrics[0].Values)
+	assert.InDelta(t, 95.0, metrics[0].Values[0], 0.001)
+
+	// The notification channel is back under its OCID.
+	gotCh, err := dst.GetNotificationChannel(ctx, ch.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "ops", gotCh.Name)
+}
+
+// TestSnapshotRestoreEmptyNilSafe confirms an empty mock round-trips cleanly.
+func TestSnapshotRestoreEmptyNilSafe(t *testing.T) {
+	src, _ := newMock(t)
+	ctx := t.Context()
+
+	data, err := src.Snapshot(ctx, false)
+	require.NoError(t, err)
+
+	dst, _ := newMock(t)
+	require.NoError(t, dst.Restore(ctx, data))
+
+	_, err = dst.CreateOCIAlarm(ctx, alarmSpec(compartmentA, "fresh", "CpuUtilization[1m].mean() > 80"))
+	require.NoError(t, err)
+}

--- a/providers/oci/oci.go
+++ b/providers/oci/oci.go
@@ -120,7 +120,9 @@ func (p *Provider) wireDiscovery() {
 // preserving snapshotting, keyed by a stable lowercased field-name service key.
 // persist iterates this map, so the persisted surface automatically tracks
 // whichever services implement snapshot.Snapshottable — no hand-kept registry to
-// drift. (No OCI service implements it yet, so this is empty today.)
+// drift. Discover asserts on the runtime value behind each interface field, so
+// the concrete mocks that implement it (Identity, VCN, Monitoring) are picked up
+// even though the provider exposes them as driver interfaces.
 func (p *Provider) SnapshotServices() map[string]snapshot.Snapshottable {
 	return snapshot.Discover(p)
 }

--- a/providers/oci/vcn/snapshot.go
+++ b/providers/oci/vcn/snapshot.go
@@ -1,0 +1,115 @@
+package vcn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/internal/snapshot"
+)
+
+var _ snapshot.Snapshottable = (*Mock)(nil)
+
+// vcnSnapshot is the full serialized state of the OCI VCN mock. Every memstore
+// store is dumped keyed by its resource OCID so cross-references (a subnet's
+// VCNID, a route-table association's SubnetID, a peering's requester/accepter
+// VCNs) still resolve after a restore. The scopes and created side-stores are
+// captured too, so a restored resource keeps its compartment and creation time.
+// Every VCN value type is fully exported, so all stores round-trip through the
+// generic memstore helper; the mutex and *config.Options are not serialized.
+type vcnSnapshot struct {
+	VCNs          json.RawMessage `json:"vcns,omitempty"`
+	Subnets       json.RawMessage `json:"subnets,omitempty"`
+	NSGs          json.RawMessage `json:"nsgs,omitempty"`
+	SecurityLists json.RawMessage `json:"securityLists,omitempty"`
+	RouteTables   json.RawMessage `json:"routeTables,omitempty"`
+	RTAssocs      json.RawMessage `json:"rtAssocs,omitempty"`
+	IGWs          json.RawMessage `json:"igws,omitempty"`
+	NATGateways   json.RawMessage `json:"natGateways,omitempty"`
+	ServiceGWs    json.RawMessage `json:"serviceGateways,omitempty"`
+	PublicIPs     json.RawMessage `json:"publicIps,omitempty"`
+	VNICs         json.RawMessage `json:"vnics,omitempty"`
+	PrivateIPs    json.RawMessage `json:"privateIps,omitempty"`
+	DHCPOptions   json.RawMessage `json:"dhcpOptions,omitempty"`
+	Peerings      json.RawMessage `json:"peerings,omitempty"`
+	LPGs          json.RawMessage `json:"lpgs,omitempty"`
+	FlowLogs      json.RawMessage `json:"flowLogs,omitempty"`
+	Scopes        json.RawMessage `json:"scopes,omitempty"`
+	Created       json.RawMessage `json:"created,omitempty"`
+}
+
+// Snapshot captures the mock's entire state as JSON. includeAssets is unused —
+// VCN holds no bulk object bodies.
+func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var snap vcnSnapshot
+
+	for _, d := range m.snapshotDumps(&snap) {
+		b, err := d.fn()
+		if err != nil {
+			return nil, fmt.Errorf("vcn: snapshot store: %w", err)
+		}
+
+		*d.dst = b
+	}
+
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds the mock's state under the original identities: every OCID
+// and the id-string cross-references between resources are preserved.
+func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
+	var snap vcnSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("vcn: parse snapshot: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, d := range m.snapshotDumps(&snap) {
+		if len(*d.dst) == 0 {
+			continue
+		}
+
+		if err := d.load(*d.dst); err != nil {
+			return fmt.Errorf("vcn: restore store: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// storeDump pairs a snapshot field with its store's dump and load functions, so
+// Snapshot and Restore share one table and cannot drift apart.
+type storeDump struct {
+	dst  *json.RawMessage
+	fn   func() ([]byte, error)
+	load func([]byte) error
+}
+
+// snapshotDumps lists every store alongside the snapshot field it maps to.
+func (m *Mock) snapshotDumps(snap *vcnSnapshot) []storeDump {
+	return []storeDump{
+		{&snap.VCNs, m.vcns.Snapshot, m.vcns.LoadSnapshot},
+		{&snap.Subnets, m.subnets.Snapshot, m.subnets.LoadSnapshot},
+		{&snap.NSGs, m.nsgs.Snapshot, m.nsgs.LoadSnapshot},
+		{&snap.SecurityLists, m.securityLists.Snapshot, m.securityLists.LoadSnapshot},
+		{&snap.RouteTables, m.routeTables.Snapshot, m.routeTables.LoadSnapshot},
+		{&snap.RTAssocs, m.rtAssocs.Snapshot, m.rtAssocs.LoadSnapshot},
+		{&snap.IGWs, m.igws.Snapshot, m.igws.LoadSnapshot},
+		{&snap.NATGateways, m.natGateways.Snapshot, m.natGateways.LoadSnapshot},
+		{&snap.ServiceGWs, m.serviceGWs.Snapshot, m.serviceGWs.LoadSnapshot},
+		{&snap.PublicIPs, m.publicIPs.Snapshot, m.publicIPs.LoadSnapshot},
+		{&snap.VNICs, m.vnics.Snapshot, m.vnics.LoadSnapshot},
+		{&snap.PrivateIPs, m.privateIPs.Snapshot, m.privateIPs.LoadSnapshot},
+		{&snap.DHCPOptions, m.dhcpOptions.Snapshot, m.dhcpOptions.LoadSnapshot},
+		{&snap.Peerings, m.peerings.Snapshot, m.peerings.LoadSnapshot},
+		{&snap.LPGs, m.lpgs.Snapshot, m.lpgs.LoadSnapshot},
+		{&snap.FlowLogs, m.flowLogs.Snapshot, m.flowLogs.LoadSnapshot},
+		{&snap.Scopes, m.scopes.Snapshot, m.scopes.LoadSnapshot},
+		{&snap.Created, m.created.Snapshot, m.created.LoadSnapshot},
+	}
+}

--- a/providers/oci/vcn/snapshot_test.go
+++ b/providers/oci/vcn/snapshot_test.go
@@ -1,0 +1,90 @@
+package vcn_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+)
+
+// TestSnapshotRestoreRoundTrip seeds a VCN, subnet, NSG, gateway and public IP,
+// snapshots, restores into a fresh mock and asserts each resource comes back
+// under its original OCID with cross-references intact — the subnet still points
+// at its VCN, and the recorded scope/creation time survive.
+func TestSnapshotRestoreRoundTrip(t *testing.T) {
+	ctx := t.Context()
+	src := newMock(t)
+
+	v := newVCN(t, src, vcnCIDR)
+
+	subnet, err := src.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: subnetCIDR})
+	require.NoError(t, err)
+
+	sg, err := src.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{
+		Name: "app", Description: "app tier", VPCID: v.ID,
+	})
+	require.NoError(t, err)
+
+	igw, err := src.CreateInternetGateway(ctx, driver.InternetGatewayConfig{})
+	require.NoError(t, err)
+
+	eip, err := src.AllocateAddress(ctx, driver.ElasticIPConfig{})
+	require.NoError(t, err)
+
+	// Move the subnet into a non-default compartment so the scopes store is
+	// exercised, not just the create-time default.
+	src.SetScope(subnet.ID, scope.Scope{Compartment: otherCompartment})
+
+	data, err := src.Snapshot(ctx, false)
+	require.NoError(t, err)
+
+	dst := newMock(t)
+	require.NoError(t, dst.Restore(ctx, data))
+
+	// VCN restored under its OCID with its default resources.
+	vcns, err := dst.DescribeVPCs(ctx, []string{v.ID})
+	require.NoError(t, err)
+	require.Len(t, vcns, 1)
+	assert.Equal(t, vcnCIDR, vcns[0].CIDRBlock)
+
+	// Subnet restored and its VCNID cross-reference still resolves.
+	subnets, err := dst.DescribeSubnets(ctx, []string{subnet.ID})
+	require.NoError(t, err)
+	require.Len(t, subnets, 1)
+	assert.Equal(t, v.ID, subnets[0].VPCID)
+
+	// Security group and gateway and public IP restored under their OCIDs.
+	sgs, err := dst.DescribeSecurityGroups(ctx, []string{sg.ID})
+	require.NoError(t, err)
+	require.Len(t, sgs, 1)
+
+	igws, err := dst.DescribeInternetGateways(ctx, []string{igw.ID})
+	require.NoError(t, err)
+	require.Len(t, igws, 1)
+
+	eips, err := dst.DescribeAddresses(ctx, []string{eip.AllocationID})
+	require.NoError(t, err)
+	require.Len(t, eips, 1)
+
+	// The side-stores (scope, creation time) survived.
+	assert.Equal(t, otherCompartment, dst.Scope(subnet.ID).Compartment)
+	assert.NotEmpty(t, dst.Created(v.ID), "creation time restored")
+}
+
+// TestSnapshotRestoreEmptyNilSafe confirms an empty mock round-trips cleanly.
+func TestSnapshotRestoreEmptyNilSafe(t *testing.T) {
+	ctx := t.Context()
+	src := newMock(t)
+
+	data, err := src.Snapshot(ctx, false)
+	require.NoError(t, err)
+
+	dst := newMock(t)
+	require.NoError(t, dst.Restore(ctx, data))
+
+	_, err = dst.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: vcnCIDR})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

Closes the last gap in #582 (OCI). The OCI provider's concrete mocks held real `memstore.Store` state but were not `snapshot.Snapshottable`, and the completeness guard could not see them because the OCI `Provider` exposes every service as a driver **interface** (not a concrete `*Mock`), while the guard walked static field types.

### OCI services persisted
Identity-preserving `Snapshot`/`Restore` on every stateful OCI mock:

- **Identity** (`providers/oci/identity`) — users, groups, memberships, compartments, dynamic groups, auth tokens (generic), plus **policies** with an exported promotion form (unexported `versions`/`versionCounter`; `parsed` re-derived from statements on restore).
- **VCN** (`providers/oci/vcn`) — all 16 resource stores (VCN, subnet, NSG, security list, route table + associations, gateways, public IPs, VNICs, private IPs, DHCP options, peerings, LPGs, flow logs) plus the `scopes`/`created` side-stores. All value types are fully exported, so all round-trip through the generic memstore helper.
- **Monitoring** (`providers/oci/monitoring`) — notification channels (generic), plus **metric series** and **alarms** with exported promotion forms (both value types are entirely unexported; alarm state-change history and series samples are preserved).

### Guard extension
`persist/completeness_test.go` now resolves an **interface-typed** provider field (holding a non-nil value) to its runtime concrete type and runs the same `holdsStore` + `Snapshottable` check on it. So a stateful mock hidden behind a driver interface (every OCI service field) is caught, not blind-spotted. `reflectSnapshotKeys` in the discovery test does the same resolution, so `TestSnapshotServicesDiscovery` still holds. The guard passes over all 4 providers with an **empty** `guardExclude`.

### Tests
- Per-mock snapshot/restore round-trips (seed via driver methods, restore into a fresh mock, assert state + cross-refs).
- Full-OCI-provider `ExportAll` → JSON → `RestoreAll` into a fresh `NewOCI()`, asserting a seeded VCN/subnet/user/policy/metric survive with the subnet→VCN cross-reference intact.
- Repurposed `TestSnapshotServicesOCIEmpty` → `TestSnapshotServicesOCIDiscovered`.

refs #582