### PR TITLE
fix(aws): strip internal error-code prefix from wire error messages + CloudWatch CBOR message key

### DIFF
--- a/compat/aws/error_message_shape_compat_test.go
+++ b/compat/aws/error_message_shape_compat_test.go
@@ -1,0 +1,272 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/acm"
+	"github.com/aws/aws-sdk-go-v2/service/cloudtrail"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	"github.com/aws/aws-sdk-go-v2/service/efs"
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	"github.com/aws/aws-sdk-go-v2/service/glue"
+	"github.com/aws/aws-sdk-go-v2/service/guardduty"
+	"github.com/aws/aws-sdk-go-v2/service/kafka"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/networkfirewall"
+	"github.com/aws/aws-sdk-go-v2/service/opensearch"
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/sfn"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
+	"github.com/aws/aws-sdk-go-v2/service/wafv2"
+	waftypes "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
+	smithy "github.com/aws/smithy-go"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/internal/compat"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// codePrefixes are the internal cloudemu error-taxonomy tokens that
+// cerrors.(*Error).Error() prepends as "<Code>: <Message>". A real AWS error
+// MESSAGE never begins with one of these; only the machine-readable Code member
+// carries the taxonomy. Every wire handler must render the human message via
+// cerrors.Message(err), not err.Error().
+var codePrefixes = []string{
+	"NotFound: ",
+	"AlreadyExists: ",
+	"InvalidArgument: ",
+	"FailedPrecondition: ",
+	"PermissionDenied: ",
+	"Throttled: ",
+	"Internal: ",
+	"Unimplemented: ",
+	"ResourceExhausted: ",
+}
+
+// assertNoCodePrefix fails when the SDK-visible error message begins with an
+// internal cloudemu code prefix. It requires a non-empty message so a dropped
+// message (the CloudWatch CBOR bug) is caught too.
+func assertNoCodePrefix(t *testing.T, service string, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("%s: expected an error, got nil", service)
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("%s: error is not a smithy.APIError: %v", service, err)
+	}
+
+	msg := apiErr.ErrorMessage()
+	if msg == "" {
+		t.Fatalf("%s: error message is empty (code=%s)", service, apiErr.ErrorCode())
+	}
+
+	for _, p := range codePrefixes {
+		if strings.HasPrefix(msg, p) {
+			t.Fatalf("%s: error message leaks internal code prefix %q: %q (code=%s)",
+				service, p, msg, apiErr.ErrorCode())
+		}
+	}
+}
+
+// TestAWSErrorMessageShapeCompat drives a not-found/duplicate error through the
+// real aws-sdk-go-v2 client for every service that previously rendered the wire
+// error message with err.Error() (leaking the internal "<Code>: " prefix). Each
+// sub-test asserts the SDK-visible ErrorMessage() carries the clean human
+// message only.
+func TestAWSErrorMessageShapeCompat(t *testing.T) {
+	sess := compat.BootAWS(t, awsserver.DriversFrom(cloudemu.NewAWS()))
+	cfg := sess.Config()
+	ep := sess.Endpoint()
+	ctx := context.Background()
+
+	t.Run("EFS", func(t *testing.T) {
+		c := efs.NewFromConfig(cfg, func(o *efs.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.DescribeMountTargets(ctx, &efs.DescribeMountTargetsInput{
+			FileSystemId: aws.String("fs-00000000"),
+		})
+		assertNoCodePrefix(t, "EFS.DescribeMountTargets", err)
+	})
+
+	t.Run("SFN", func(t *testing.T) {
+		c := sfn.NewFromConfig(cfg, func(o *sfn.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.DescribeExecution(ctx, &sfn.DescribeExecutionInput{
+			ExecutionArn: aws.String("arn:aws:states:us-east-1:000000000000:execution:m:missing"),
+		})
+		assertNoCodePrefix(t, "SFN.DescribeExecution", err)
+	})
+
+	t.Run("SSM", func(t *testing.T) {
+		c := ssm.NewFromConfig(cfg, func(o *ssm.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.GetParameter(ctx, &ssm.GetParameterInput{Name: aws.String("/missing")})
+		assertNoCodePrefix(t, "SSM.GetParameter", err)
+	})
+
+	t.Run("Glue", func(t *testing.T) {
+		c := glue.NewFromConfig(cfg, func(o *glue.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.GetDatabase(ctx, &glue.GetDatabaseInput{Name: aws.String("nope")})
+		assertNoCodePrefix(t, "Glue.GetDatabase", err)
+	})
+
+	t.Run("KMS", func(t *testing.T) {
+		c := kms.NewFromConfig(cfg, func(o *kms.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.DescribeKey(ctx, &kms.DescribeKeyInput{KeyId: aws.String("nope")})
+		assertNoCodePrefix(t, "KMS.DescribeKey", err)
+	})
+
+	t.Run("Kinesis", func(t *testing.T) {
+		c := kinesis.NewFromConfig(cfg, func(o *kinesis.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.DescribeStream(ctx, &kinesis.DescribeStreamInput{StreamName: aws.String("nope")})
+		assertNoCodePrefix(t, "Kinesis.DescribeStream", err)
+	})
+
+	t.Run("ECR", func(t *testing.T) {
+		c := ecr.NewFromConfig(cfg, func(o *ecr.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.DescribeImages(ctx, &ecr.DescribeImagesInput{RepositoryName: aws.String("nope")})
+		assertNoCodePrefix(t, "ECR.DescribeImages", err)
+	})
+
+	t.Run("SecretsManager", func(t *testing.T) {
+		c := secretsmanager.NewFromConfig(cfg, func(o *secretsmanager.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{SecretId: aws.String("nope")})
+		assertNoCodePrefix(t, "SecretsManager.DescribeSecret", err)
+	})
+
+	t.Run("ElastiCache", func(t *testing.T) {
+		c := elasticache.NewFromConfig(cfg, func(o *elasticache.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.DescribeCacheClusters(ctx, &elasticache.DescribeCacheClustersInput{
+			CacheClusterId: aws.String("nope"),
+		})
+		assertNoCodePrefix(t, "ElastiCache.DescribeCacheClusters", err)
+	})
+
+	t.Run("Redshift", func(t *testing.T) {
+		c := redshift.NewFromConfig(cfg, func(o *redshift.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.DescribeClusters(ctx, &redshift.DescribeClustersInput{
+			ClusterIdentifier: aws.String("nope"),
+		})
+		assertNoCodePrefix(t, "Redshift.DescribeClusters", err)
+	})
+
+	t.Run("ACM", func(t *testing.T) {
+		c := acm.NewFromConfig(cfg, func(o *acm.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.DescribeCertificate(ctx, &acm.DescribeCertificateInput{
+			CertificateArn: aws.String("arn:aws:acm:us-east-1:000000000000:certificate/nope"),
+		})
+		assertNoCodePrefix(t, "ACM.DescribeCertificate", err)
+	})
+
+	t.Run("OpenSearch", func(t *testing.T) {
+		c := opensearch.NewFromConfig(cfg, func(o *opensearch.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.DescribeDomain(ctx, &opensearch.DescribeDomainInput{DomainName: aws.String("nope")})
+		assertNoCodePrefix(t, "OpenSearch.DescribeDomain", err)
+	})
+
+	t.Run("WAFv2", func(t *testing.T) {
+		c := wafv2.NewFromConfig(cfg, func(o *wafv2.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.GetIPSet(ctx, &wafv2.GetIPSetInput{
+			Name:  aws.String("nope"),
+			Scope: waftypes.ScopeRegional,
+			Id:    aws.String("00000000-0000-0000-0000-000000000000"),
+		})
+		assertNoCodePrefix(t, "WAFv2.GetIPSet", err)
+	})
+
+	t.Run("CloudWatchLogs", func(t *testing.T) {
+		c := cloudwatchlogs.NewFromConfig(cfg, func(o *cloudwatchlogs.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.GetLogEvents(ctx, &cloudwatchlogs.GetLogEventsInput{
+			LogGroupName:  aws.String("nope"),
+			LogStreamName: aws.String("stream"),
+		})
+		assertNoCodePrefix(t, "CloudWatchLogs.GetLogEvents", err)
+	})
+
+	t.Run("Kafka", func(t *testing.T) {
+		c := kafka.NewFromConfig(cfg, func(o *kafka.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.DescribeClusterV2(ctx, &kafka.DescribeClusterV2Input{
+			ClusterArn: aws.String("arn:aws:kafka:us-east-1:000000000000:cluster/nope/00000000"),
+		})
+		assertNoCodePrefix(t, "Kafka.DescribeClusterV2", err)
+	})
+
+	t.Run("NetworkFirewall", func(t *testing.T) {
+		c := networkfirewall.NewFromConfig(cfg, func(o *networkfirewall.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.DescribeFirewall(ctx, &networkfirewall.DescribeFirewallInput{
+			FirewallName: aws.String("nope"),
+		})
+		assertNoCodePrefix(t, "NetworkFirewall.DescribeFirewall", err)
+	})
+
+	t.Run("CloudTrail", func(t *testing.T) {
+		c := cloudtrail.NewFromConfig(cfg, func(o *cloudtrail.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.GetTrail(ctx, &cloudtrail.GetTrailInput{Name: aws.String("nope")})
+		assertNoCodePrefix(t, "CloudTrail.GetTrail", err)
+	})
+
+	t.Run("GuardDuty", func(t *testing.T) {
+		c := guardduty.NewFromConfig(cfg, func(o *guardduty.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.GetDetector(ctx, &guardduty.GetDetectorInput{DetectorId: aws.String("nope")})
+		assertNoCodePrefix(t, "GuardDuty.GetDetector", err)
+	})
+
+	t.Run("VPCLattice", func(t *testing.T) {
+		c := vpclattice.NewFromConfig(cfg, func(o *vpclattice.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.GetService(ctx, &vpclattice.GetServiceInput{ServiceIdentifier: aws.String("svc-nope")})
+		assertNoCodePrefix(t, "VPCLattice.GetService", err)
+	})
+
+	t.Run("SNS", func(t *testing.T) {
+		c := sns.NewFromConfig(cfg, func(o *sns.Options) { o.BaseEndpoint = aws.String(ep) })
+		_, err := c.GetTopicAttributes(ctx, &sns.GetTopicAttributesInput{
+			TopicArn: aws.String("arn:aws:sns:us-east-1:000000000000:nope"),
+		})
+		assertNoCodePrefix(t, "SNS.GetTopicAttributes", err)
+	})
+}
+
+// TestAWSCloudWatchCBORErrorMessageCompat asserts that CloudWatch (the only
+// rpc-v2-cbor service) surfaces the modeled error message to aws-sdk-go-v2.
+// Before the fix, writeCBORError serialized the message under the CBOR key
+// "Message" (capital) while the SDK reads "message" (lowercase), so every
+// CloudWatch error arrived with an empty (or smithy-fallback "UnknownError")
+// message.
+func TestAWSCloudWatchCBORErrorMessageCompat(t *testing.T) {
+	sess := compat.BootAWS(t, awsserver.DriversFrom(cloudemu.NewAWS()))
+	c := cloudwatch.NewFromConfig(sess.Config(), func(o *cloudwatch.Options) {
+		o.BaseEndpoint = aws.String(sess.Endpoint())
+	})
+	ctx := context.Background()
+
+	_, err := c.SetAlarmState(ctx, &cloudwatch.SetAlarmStateInput{
+		AlarmName:   aws.String("ghost"),
+		StateValue:  cwtypes.StateValueOk,
+		StateReason: aws.String("test"),
+	})
+	if err == nil {
+		t.Fatal("SetAlarmState on a missing alarm: expected an error, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("SetAlarmState: error is not a smithy.APIError: %v", err)
+	}
+
+	msg := apiErr.ErrorMessage()
+	if msg == "" || msg == "UnknownError" {
+		t.Fatalf("SetAlarmState: CloudWatch CBOR error message was dropped (code=%s, message=%q)",
+			apiErr.ErrorCode(), msg)
+	}
+}

--- a/server/aws/acm/handler.go
+++ b/server/aws/acm/handler.go
@@ -98,21 +98,23 @@ func dispatch[Req any](
 // distinct exceptions like InvalidArnException / InvalidParameterException /
 // InvalidStateException surface as themselves rather than a generic code map.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	var apiErr *acmdriver.APIError
 	if errors.As(err, &apiErr) {
-		wire.WriteJSONError(w, http.StatusBadRequest, apiErr.Exception, err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, apiErr.Exception, msg)
 
 		return
 	}
 
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", msg)
 	case cerrors.IsInvalidArgument(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", msg)
 	case cerrors.IsFailedPrecondition(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceInUseException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceInUseException", msg)
 	default:
-		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalException", err.Error())
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalException", msg)
 	}
 }

--- a/server/aws/cloudtrail/handler.go
+++ b/server/aws/cloudtrail/handler.go
@@ -152,23 +152,25 @@ func dispatch[Req any](
 // tagged with a specific CloudTrail exception (via driver.APIError) take
 // precedence so distinct exceptions surface as themselves.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	var apiErr *ctdriver.APIError
 	if errors.As(err, &apiErr) {
-		wire.WriteJSONError(w, http.StatusBadRequest, apiErr.Exception, err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, apiErr.Exception, msg)
 
 		return
 	}
 
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", msg)
 	case cerrors.IsAlreadyExists(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceAlreadyExistsException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceAlreadyExistsException", msg)
 	case cerrors.IsInvalidArgument(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterException", msg)
 	case cerrors.IsFailedPrecondition(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ConflictException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ConflictException", msg)
 	default:
-		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalFailureException", err.Error())
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalFailureException", msg)
 	}
 }

--- a/server/aws/cloudwatch/handler.go
+++ b/server/aws/cloudwatch/handler.go
@@ -172,7 +172,7 @@ func extractOperation(path string) string {
 func writeCBORError(w http.ResponseWriter, status int, errType, msg string) {
 	payload := map[string]any{
 		"__type":  errType,
-		"Message": msg,
+		"message": msg,
 	}
 
 	body, _ := cbor.Marshal(payload)

--- a/server/aws/cloudwatchlogs/handler.go
+++ b/server/aws/cloudwatchlogs/handler.go
@@ -163,18 +163,20 @@ var validRetentionInDays = map[int]bool{
 // responses. Like the other AWS JSON 1.1 services, errors are HTTP 400 with a
 // "__type" body the SDK maps to a typed exception.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", msg)
 	case cerrors.IsAlreadyExists(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceAlreadyExistsException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceAlreadyExistsException", msg)
 	case cerrors.IsInvalidArgument(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterException", msg)
 	case cerrors.IsFailedPrecondition(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidOperationException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidOperationException", msg)
 	case cerrors.GetCode(err) == cerrors.ResourceExhausted:
-		wire.WriteJSONError(w, http.StatusBadRequest, "LimitExceededException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "LimitExceededException", msg)
 	default:
-		wire.WriteJSONError(w, http.StatusInternalServerError, "ServiceUnavailableException", err.Error())
+		wire.WriteJSONError(w, http.StatusInternalServerError, "ServiceUnavailableException", msg)
 	}
 }

--- a/server/aws/ecr/handler.go
+++ b/server/aws/ecr/handler.go
@@ -132,7 +132,7 @@ func (h *Handler) getAuthorizationToken(w http.ResponseWriter, r *http.Request) 
 // returns ImageTagAlreadyExistsException (not RepositoryNotEmptyException).
 func writePutImageErr(w http.ResponseWriter, err error) {
 	if cerrors.IsFailedPrecondition(err) {
-		wire.WriteJSONError(w, http.StatusBadRequest, "ImageTagAlreadyExistsException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ImageTagAlreadyExistsException", cerrors.Message(err))
 		return
 	}
 
@@ -147,24 +147,26 @@ func writeErr(w http.ResponseWriter, err error) {
 	// ImageNotFoundException vs ScanNotFoundException vs
 	// RepositoryPolicyNotFoundException), which the generic code-based mapping
 	// below would otherwise collapse to RepositoryNotFoundException.
+	msg := cerrors.Message(err)
+
 	var ex interface{ ECRException() string }
 	if stderrors.As(err, &ex) {
-		wire.WriteJSONError(w, http.StatusBadRequest, ex.ECRException(), err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, ex.ECRException(), msg)
 		return
 	}
 
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "RepositoryNotFoundException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "RepositoryNotFoundException", msg)
 	case cerrors.IsAlreadyExists(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "RepositoryAlreadyExistsException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "RepositoryAlreadyExistsException", msg)
 	case cerrors.IsInvalidArgument(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterException", msg)
 	case cerrors.IsFailedPrecondition(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "RepositoryNotEmptyException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "RepositoryNotEmptyException", msg)
 	case cerrors.GetCode(err) == cerrors.ResourceExhausted:
-		wire.WriteJSONError(w, http.StatusBadRequest, "LimitExceededException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "LimitExceededException", msg)
 	default:
-		wire.WriteJSONError(w, http.StatusInternalServerError, "ServerException", err.Error())
+		wire.WriteJSONError(w, http.StatusInternalServerError, "ServerException", msg)
 	}
 }

--- a/server/aws/efs/errors.go
+++ b/server/aws/efs/errors.go
@@ -100,7 +100,7 @@ func writeErr(w http.ResponseWriter, err error) {
 
 	status, errType := exceptionFor(kind, err)
 
-	body := errorBody{Type: errType, ErrorCode: errType, Message: err.Error()}
+	body := errorBody{Type: errType, ErrorCode: errType, Message: cerrors.Message(err)}
 	if kind == driver.KindFileSystem {
 		body.FileSystemID = resourceID
 	}

--- a/server/aws/elasticache/handler.go
+++ b/server/aws/elasticache/handler.go
@@ -206,17 +206,19 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // writeErr maps cloudemu errors to ElastiCache XML error responses.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		awsquery.WriteXMLError(w, http.StatusNotFound, notFoundCode(err), err.Error())
+		awsquery.WriteXMLError(w, http.StatusNotFound, notFoundCode(err), msg)
 	case cerrors.IsAlreadyExists(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, alreadyExistsCode(err), err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, alreadyExistsCode(err), msg)
 	case cerrors.IsInvalidArgument(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", msg)
 	case cerrors.IsFailedPrecondition(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, failedPreconditionCode(err), err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, failedPreconditionCode(err), msg)
 	default:
-		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", err.Error())
+		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", msg)
 	}
 }
 

--- a/server/aws/glue/handler.go
+++ b/server/aws/glue/handler.go
@@ -86,25 +86,27 @@ func dispatch[Req any](
 // distinct exceptions like EntityNotFoundException / AlreadyExistsException /
 // InvalidInputException surface as themselves rather than a generic code map.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	var apiErr *gluedriver.APIError
 	if errors.As(err, &apiErr) {
-		wire.WriteJSONError(w, http.StatusBadRequest, apiErr.Exception, err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, apiErr.Exception, msg)
 
 		return
 	}
 
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, gluedriver.ExEntityNotFound, err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, gluedriver.ExEntityNotFound, msg)
 	case cerrors.IsAlreadyExists(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, gluedriver.ExAlreadyExists, err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, gluedriver.ExAlreadyExists, msg)
 	case cerrors.IsInvalidArgument(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, gluedriver.ExInvalidInput, err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, gluedriver.ExInvalidInput, msg)
 	case cerrors.GetCode(err) == cerrors.ResourceExhausted:
-		wire.WriteJSONError(w, http.StatusBadRequest, gluedriver.ExResourceNumberLimit, err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, gluedriver.ExResourceNumberLimit, msg)
 	case cerrors.IsFailedPrecondition(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, gluedriver.ExConcurrentModification, err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, gluedriver.ExConcurrentModification, msg)
 	default:
-		wire.WriteJSONError(w, http.StatusInternalServerError, gluedriver.ExInternalService, err.Error())
+		wire.WriteJSONError(w, http.StatusInternalServerError, gluedriver.ExInternalService, msg)
 	}
 }

--- a/server/aws/guardduty/errors.go
+++ b/server/aws/guardduty/errors.go
@@ -65,15 +65,17 @@ func exceptionForCode(err error) (status int, errType string) {
 // driver.APIError values are honored first so the exact exception name is
 // preserved; untagged errors fall back to the canonical-code mapping.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	var apiErr *driver.APIError
 	if errors.As(err, &apiErr) {
-		writeError(w, statusForException(apiErr.Exception), apiErr.Exception, err.Error())
+		writeError(w, statusForException(apiErr.Exception), apiErr.Exception, msg)
 
 		return
 	}
 
 	status, errType := exceptionForCode(err)
-	writeError(w, status, errType, err.Error())
+	writeError(w, status, errType, msg)
 }
 
 func notFoundPath(w http.ResponseWriter, path string) {

--- a/server/aws/kafka/errors.go
+++ b/server/aws/kafka/errors.go
@@ -70,15 +70,17 @@ func exceptionForCode(err error) (status int, errType string) {
 // driver.APIError values are honored first so the exact exception name is
 // preserved; untagged errors fall back to the canonical-code mapping.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	var apiErr *driver.APIError
 	if errors.As(err, &apiErr) {
-		writeError(w, statusForException(apiErr.Exception), apiErr.Exception, err.Error())
+		writeError(w, statusForException(apiErr.Exception), apiErr.Exception, msg)
 
 		return
 	}
 
 	status, errType := exceptionForCode(err)
-	writeError(w, status, errType, err.Error())
+	writeError(w, status, errType, msg)
 }
 
 func notFoundPath(w http.ResponseWriter, path string) {

--- a/server/aws/kinesis/handler.go
+++ b/server/aws/kinesis/handler.go
@@ -118,21 +118,23 @@ func dispatch[Req any](
 // writeErr maps a driver error to the closest Kinesis JSON error type, honoring
 // a tagged driver.APIError exception when present.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	var apiErr *kinesisdriver.APIError
 	if errors.As(err, &apiErr) {
-		wire.WriteJSONError(w, http.StatusBadRequest, apiErr.Exception, err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, apiErr.Exception, msg)
 
 		return
 	}
 
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", msg)
 	case cerrors.IsAlreadyExists(err), cerrors.IsFailedPrecondition(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceInUseException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceInUseException", msg)
 	case cerrors.IsInvalidArgument(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidArgumentException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidArgumentException", msg)
 	default:
-		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalFailure", err.Error())
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalFailure", msg)
 	}
 }

--- a/server/aws/kms/handler.go
+++ b/server/aws/kms/handler.go
@@ -156,22 +156,24 @@ func sentinelException(err error) string {
 // errors take precedence so distinct crypto/state failures reach the client as
 // their real typed exceptions rather than a generic ValidationException.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	if exc := sentinelException(err); exc != "" {
-		wire.WriteJSONError(w, http.StatusBadRequest, exc, err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, exc, msg)
 
 		return
 	}
 
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "NotFoundException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "NotFoundException", msg)
 	case cerrors.IsAlreadyExists(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "AlreadyExistsException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "AlreadyExistsException", msg)
 	case cerrors.IsInvalidArgument(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", msg)
 	case cerrors.IsFailedPrecondition(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "KMSInvalidStateException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "KMSInvalidStateException", msg)
 	default:
-		wire.WriteJSONError(w, http.StatusInternalServerError, "KMSInternalException", err.Error())
+		wire.WriteJSONError(w, http.StatusInternalServerError, "KMSInternalException", msg)
 	}
 }

--- a/server/aws/networkfirewall/handler.go
+++ b/server/aws/networkfirewall/handler.go
@@ -91,7 +91,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 const updateToken = "00000000-0000-0000-0000-000000000000"
 
 func writeErr(w http.ResponseWriter, err error) {
-	msg := err.Error()
+	msg := cerrors.Message(err)
 
 	switch {
 	case cerrors.IsNotFound(err):

--- a/server/aws/opensearch/errors.go
+++ b/server/aws/opensearch/errors.go
@@ -65,15 +65,17 @@ func exceptionForCode(err error) (status int, errType string) {
 // driver.APIError values are honored first so the exact exception name is
 // preserved; untagged errors fall back to the canonical-code mapping.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	var apiErr *driver.APIError
 	if errors.As(err, &apiErr) {
-		writeError(w, statusForException(apiErr.Exception), apiErr.Exception, err.Error())
+		writeError(w, statusForException(apiErr.Exception), apiErr.Exception, msg)
 
 		return
 	}
 
 	status, errType := exceptionForCode(err)
-	writeError(w, status, errType, err.Error())
+	writeError(w, status, errType, msg)
 }
 
 func notFoundPath(w http.ResponseWriter, path string) {

--- a/server/aws/redshift/handler.go
+++ b/server/aws/redshift/handler.go
@@ -209,17 +209,19 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // writeErr maps cloudemu errors to Redshift XML error responses.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		awsquery.WriteXMLError(w, http.StatusNotFound, notFoundCode(err), err.Error())
+		awsquery.WriteXMLError(w, http.StatusNotFound, notFoundCode(err), msg)
 	case cerrors.IsAlreadyExists(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, alreadyExistsCode(err), err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, alreadyExistsCode(err), msg)
 	case cerrors.IsInvalidArgument(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", msg)
 	case cerrors.IsFailedPrecondition(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidClusterState", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidClusterState", msg)
 	default:
-		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", err.Error())
+		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", msg)
 	}
 }
 

--- a/server/aws/secretsmanager/batch.go
+++ b/server/aws/secretsmanager/batch.go
@@ -88,12 +88,12 @@ func (h *Handler) batchLookup(r *http.Request, secretID string) (*secretValueEnt
 
 	info, err := h.secrets.GetSecret(r.Context(), name)
 	if err != nil {
-		return nil, &batchErrorEntry{SecretID: secretID, ErrorCode: batchErrorCode(err), Message: err.Error()}
+		return nil, &batchErrorEntry{SecretID: secretID, ErrorCode: batchErrorCode(err), Message: cerrors.Message(err)}
 	}
 
 	ver, err := h.getVersion(r, name, "", "")
 	if err != nil {
-		return nil, &batchErrorEntry{SecretID: secretID, ErrorCode: batchErrorCode(err), Message: err.Error()}
+		return nil, &batchErrorEntry{SecretID: secretID, ErrorCode: batchErrorCode(err), Message: cerrors.Message(err)}
 	}
 
 	entry := secretValueEntry{

--- a/server/aws/secretsmanager/handler.go
+++ b/server/aws/secretsmanager/handler.go
@@ -122,18 +122,20 @@ var errNotSupported = cerrors.New(cerrors.Unimplemented, "operation not supporte
 // responses. Secrets Manager returns errors as HTTP 400 with a "__type" body
 // the SDK maps to a typed exception.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", msg)
 	case cerrors.IsAlreadyExists(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceExistsException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceExistsException", msg)
 	case cerrors.IsInvalidArgument(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterException", msg)
 	case cerrors.IsFailedPrecondition(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidRequestException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidRequestException", msg)
 	case cerrors.GetCode(err) == cerrors.ResourceExhausted:
-		wire.WriteJSONError(w, http.StatusBadRequest, "LimitExceededException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "LimitExceededException", msg)
 	default:
-		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServiceError", err.Error())
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServiceError", msg)
 	}
 }

--- a/server/aws/sfn/handler.go
+++ b/server/aws/sfn/handler.go
@@ -119,23 +119,25 @@ func dispatch[Req any](
 // precedence so distinct exceptions like StateMachineDoesNotExist /
 // ExecutionAlreadyExists / InvalidArn surface as themselves.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	var apiErr *sfndriver.APIError
 	if errors.As(err, &apiErr) {
-		wire.WriteJSONError(w, http.StatusBadRequest, apiErr.Exception, err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, apiErr.Exception, msg)
 
 		return
 	}
 
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFound", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFound", msg)
 	case cerrors.IsAlreadyExists(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ConflictException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ConflictException", msg)
 	case cerrors.IsInvalidArgument(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", msg)
 	case cerrors.IsFailedPrecondition(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ConflictException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ConflictException", msg)
 	default:
-		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalError", err.Error())
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalError", msg)
 	}
 }

--- a/server/aws/sns/handler.go
+++ b/server/aws/sns/handler.go
@@ -211,15 +211,17 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // set of error codes; the SDK maps NotFound → NotFoundException and
 // InvalidParameter → InvalidParameterException.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		awsquery.WriteXMLError(w, http.StatusNotFound, "NotFound", err.Error())
+		awsquery.WriteXMLError(w, http.StatusNotFound, "NotFound", msg)
 	case cerrors.IsInvalidArgument(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameter", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameter", msg)
 	case cerrors.IsAlreadyExists(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameter", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameter", msg)
 	default:
-		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalError", err.Error())
+		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalError", msg)
 	}
 }
 

--- a/server/aws/sns/subscription_attributes.go
+++ b/server/aws/sns/subscription_attributes.go
@@ -227,7 +227,7 @@ func (h *Handler) publishBatch(w http.ResponseWriter, r *http.Request) {
 		})
 		if err != nil {
 			failures = append(failures, batchErrorEntry{
-				ID: entryID, Code: batchErrorCode(err), Message: err.Error(), SenderFault: true,
+				ID: entryID, Code: batchErrorCode(err), Message: cerrors.Message(err), SenderFault: true,
 			})
 
 			continue

--- a/server/aws/ssm/handler.go
+++ b/server/aws/ssm/handler.go
@@ -80,16 +80,18 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // returns errors as HTTP 400 with a "__type" body the SDK maps to a typed
 // exception.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ParameterNotFound", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ParameterNotFound", msg)
 	case cerrors.IsAlreadyExists(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ParameterAlreadyExists", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ParameterAlreadyExists", msg)
 	case cerrors.IsInvalidArgument(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", msg)
 	case cerrors.GetCode(err) == cerrors.ResourceExhausted:
-		wire.WriteJSONError(w, http.StatusBadRequest, "ParameterLimitExceeded", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ParameterLimitExceeded", msg)
 	default:
-		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServerError", msg)
 	}
 }

--- a/server/aws/ssm/operations.go
+++ b/server/aws/ssm/operations.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	ssmdriver "github.com/stackshy/cloudemu/v2/services/parameterstore/driver"
 )
@@ -39,14 +40,14 @@ func (h *Handler) putParameter(w http.ResponseWriter, r *http.Request) {
 		// real Parameter Store with HierarchyTypeMismatchException, not the
 		// generic ValidationException.
 		if errors.Is(err, ssmdriver.ErrTypeMismatch) {
-			wire.WriteJSONError(w, http.StatusBadRequest, "HierarchyTypeMismatchException", err.Error())
+			wire.WriteJSONError(w, http.StatusBadRequest, "HierarchyTypeMismatchException", cerrors.Message(err))
 			return
 		}
 
 		// An unrecognized Type is UnsupportedParameterType, not the generic
 		// ValidationException that InvalidArgument maps to.
 		if errors.Is(err, ssmdriver.ErrUnsupportedType) {
-			wire.WriteJSONError(w, http.StatusBadRequest, "UnsupportedParameterType", err.Error())
+			wire.WriteJSONError(w, http.StatusBadRequest, "UnsupportedParameterType", cerrors.Message(err))
 			return
 		}
 
@@ -68,7 +69,7 @@ func (h *Handler) getParameter(w http.ResponseWriter, r *http.Request) {
 		// The parameter existed but the requested version/label didn't — AWS
 		// returns the distinct ParameterVersionNotFound, not ParameterNotFound.
 		if errors.Is(err, ssmdriver.ErrVersionNotFound) {
-			wire.WriteJSONError(w, http.StatusBadRequest, "ParameterVersionNotFound", err.Error())
+			wire.WriteJSONError(w, http.StatusBadRequest, "ParameterVersionNotFound", cerrors.Message(err))
 			return
 		}
 		writeErr(w, err)
@@ -114,12 +115,12 @@ func (h *Handler) getParametersByPath(w http.ResponseWriter, r *http.Request) {
 		// GetParametersByPath rejects an unsupported filter key/option with the
 		// distinct InvalidFilterKey/InvalidFilterOption, not ValidationException.
 		if errors.Is(err, ssmdriver.ErrInvalidFilterKey) {
-			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidFilterKey", err.Error())
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidFilterKey", cerrors.Message(err))
 			return
 		}
 
 		if errors.Is(err, ssmdriver.ErrInvalidFilterOption) {
-			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidFilterOption", err.Error())
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidFilterOption", cerrors.Message(err))
 			return
 		}
 

--- a/server/aws/ssm/run_command.go
+++ b/server/aws/ssm/run_command.go
@@ -84,7 +84,7 @@ func (h *Handler) sendCommand(w http.ResponseWriter, r *http.Request) {
 		// code — it is the ordinary Run Command bring-up failure — and
 		// ParameterNotFound would send them looking at the wrong subsystem.
 		if cerrors.IsNotFound(err) {
-			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidInstanceId", err.Error())
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidInstanceId", cerrors.Message(err))
 			return
 		}
 
@@ -139,7 +139,7 @@ func (h *Handler) getCommandInvocation(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// AWS names this one specifically, and callers branch on it while
 		// polling a command that has not registered yet.
-		wire.WriteJSONError(w, http.StatusBadRequest, "InvocationDoesNotExist", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvocationDoesNotExist", cerrors.Message(err))
 
 		return
 	}

--- a/server/aws/vpclattice/errors.go
+++ b/server/aws/vpclattice/errors.go
@@ -29,21 +29,23 @@ func writeError(w http.ResponseWriter, status int, errType, msg string) {
 
 // writeErr maps a canonical cloudemu error to the closest VPC Lattice exception.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", msg)
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "ConflictException", err.Error())
+		writeError(w, http.StatusConflict, "ConflictException", msg)
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "ValidationException", err.Error())
+		writeError(w, http.StatusBadRequest, "ValidationException", msg)
 	case cerrors.IsPermissionDenied(err):
-		writeError(w, http.StatusForbidden, "AccessDeniedException", err.Error())
+		writeError(w, http.StatusForbidden, "AccessDeniedException", msg)
 	case cerrors.IsFailedPrecondition(err):
-		writeError(w, http.StatusConflict, "ConflictException", err.Error())
+		writeError(w, http.StatusConflict, "ConflictException", msg)
 	case cerrors.IsThrottled(err):
-		writeError(w, http.StatusTooManyRequests, "ThrottlingException", err.Error())
+		writeError(w, http.StatusTooManyRequests, "ThrottlingException", msg)
 	default:
-		writeError(w, http.StatusInternalServerError, "InternalServerException", err.Error())
+		writeError(w, http.StatusInternalServerError, "InternalServerException", msg)
 	}
 }
 

--- a/server/aws/wafv2/handler.go
+++ b/server/aws/wafv2/handler.go
@@ -154,23 +154,25 @@ func dispatch[Req any](
 // tagged with a specific WAFv2 exception (via driver.APIError) take precedence
 // so distinct exceptions surface as themselves rather than a generic code map.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	var apiErr *wafdriver.APIError
 	if errors.As(err, &apiErr) {
-		wire.WriteJSONError(w, http.StatusBadRequest, apiErr.Exception, err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, apiErr.Exception, msg)
 
 		return
 	}
 
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "WAFNonexistentItemException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "WAFNonexistentItemException", msg)
 	case cerrors.IsAlreadyExists(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "WAFDuplicateItemException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "WAFDuplicateItemException", msg)
 	case cerrors.IsInvalidArgument(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "WAFInvalidParameterException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "WAFInvalidParameterException", msg)
 	case cerrors.IsFailedPrecondition(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "WAFOptimisticLockException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "WAFOptimisticLockException", msg)
 	default:
-		wire.WriteJSONError(w, http.StatusInternalServerError, "WAFInternalErrorException", err.Error())
+		wire.WriteJSONError(w, http.StatusInternalServerError, "WAFInternalErrorException", msg)
 	}
 }


### PR DESCRIPTION
## Summary

Two related pre-release audit findings on AWS wire error responses, fixed so the SDK-visible error MESSAGE matches real AWS (the machine-readable Code is unchanged).

### 1. Internal cerrors code-prefix leaked into the user-facing error message (~19 services)

Handlers passed `err.Error()` as the wire message. `cerrors.(*Error).Error()` formats `"<Code>: <Message>"`, so `smithy.APIError.ErrorMessage()` began with `NotFound: ` / `AlreadyExists: ` / `InvalidArgument: ` / `FailedPrecondition: `. Real AWS never puts an internal taxonomy token in the message body.

Fix: render the wire message via `cerrors.Message(err)` (already the pattern in EC2/DynamoDB/RDS/MemoryDB) instead of `err.Error()`. Error codes and HTTP statuses are untouched.

Services corrected: EFS, SFN, SSM, Glue, KMS, Kinesis, ECR, SecretsManager, ElastiCache, Redshift, ACM, OpenSearch, WAFv2, CloudWatchLogs, Kafka, NetworkFirewall, CloudTrail, GuardDuty, VPCLattice, SNS (also the SecretsManager/SNS batch per-entry error messages).

### 2. CloudWatch (rpc-v2-cbor) dropped the error message entirely

`writeCBORError` serialized the message under CBOR key `"Message"` (capital), but aws-sdk-go-v2's CloudWatch CBOR deserializer reads `"message"` (lowercase), so every CloudWatch error arrived with an empty / smithy-fallback `UnknownError` message. Fixed the key casing to `"message"`.

## Tests

New `compat/aws/error_message_shape_compat_test.go` drives real aws-sdk-go-v2 clients against the in-process wire server:
- `TestAWSErrorMessageShapeCompat` — one sub-test per affected service asserting `ErrorMessage()` is non-empty and carries no internal code prefix.
- `TestAWSCloudWatchCBORErrorMessageCompat` — asserts CloudWatch surfaces the real modeled message.

Both were confirmed to fail before the fix and pass after.

## Gates

`go build`, `go vet ./...`, `go test ./compat/aws/... ./server/aws/...`, `go generate ./...` (no diff), and golangci-lint (`--new-from-rev`: 0 new issues) all green.
