### PR TITLE
fix(gcp): firestore scoping, LB getHealth, monitoring labels/patch/delete, artifactregistry deletes, gen2 download, compute operations 404

### DIFF
--- a/compat/gcp/compute_compat_test.go
+++ b/compat/gcp/compute_compat_test.go
@@ -318,3 +318,77 @@ func (e notFoundError) Error() string { return string(e) }
 func errNotFound(msg string) error {
 	return notFoundError(strings.TrimSpace(msg))
 }
+
+// TestComputeOperationsGetUnknown404 proves a GET for an operation name that was
+// never issued returns 404 NOT_FOUND, rather than a fabricated DONE. A genuine
+// operation (minted by an instance delete) still resolves, so op.Wait succeeds.
+func TestComputeOperationsGetUnknown404(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	sess := compat.BootGCP(t, gcpserver.Drivers{Compute: cloudP.GCE})
+	ctx := context.Background()
+
+	opts := []option.ClientOption{
+		option.WithEndpoint(sess.Endpoint()),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(sess.Transport()),
+	}
+
+	zoneOps, err := gcpcompute.NewZoneOperationsRESTClient(ctx, opts...)
+	if err != nil {
+		t.Fatalf("NewZoneOperationsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = zoneOps.Close() })
+
+	globalOps, err := gcpcompute.NewGlobalOperationsRESTClient(ctx, opts...)
+	if err != nil {
+		t.Fatalf("NewGlobalOperationsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = globalOps.Close() })
+
+	if _, err := zoneOps.Get(ctx, &computepb.GetZoneOperationRequest{
+		Project: compat.GCPProject, Zone: testZone, Operation: "operation-does-not-exist",
+	}); err == nil {
+		t.Fatal("zoneOperations.get of a bogus operation returned success, want 404")
+	}
+
+	if _, err := globalOps.Get(ctx, &computepb.GetGlobalOperationRequest{
+		Project: compat.GCPProject, Operation: "operation-bogus-global",
+	}); err == nil {
+		t.Fatal("globalOperations.get of a bogus operation returned success, want 404")
+	}
+
+	// A genuine operation (from an instance insert) must still resolve: op.Wait
+	// polls zoneOperations.get and succeeds.
+	instances, err := gcpcompute.NewInstancesRESTClient(ctx, opts...)
+	if err != nil {
+		t.Fatalf("NewInstancesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = instances.Close() })
+
+	op, err := instances.Insert(ctx, &computepb.InsertInstanceRequest{
+		Project: compat.GCPProject,
+		Zone:    testZone,
+		InstanceResource: &computepb.Instance{
+			Name:        strPtr("op-vm"),
+			MachineType: strPtr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+			Disks: []*computepb.AttachedDisk{{
+				Boot:       boolPtr(true),
+				AutoDelete: boolPtr(true),
+				InitializeParams: &computepb.AttachedDiskInitializeParams{
+					SourceImage: strPtr("projects/debian-cloud/global/images/family/debian-12"),
+				},
+			}},
+			NetworkInterfaces: []*computepb.NetworkInterface{{Network: strPtr("global/networks/default")}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("insert instance: %v", err)
+	}
+
+	if werr := op.Wait(ctx); werr != nil {
+		t.Fatalf("wait on genuine operation: %v", werr)
+	}
+}

--- a/compat/gcp/containerregistry_compat_test.go
+++ b/compat/gcp/containerregistry_compat_test.go
@@ -122,3 +122,83 @@ func TestGCPContainerRegistryCompat(t *testing.T) {
 		return err
 	})
 }
+
+// TestArtifactRegistryPackageVersionDelete proves packages.delete and
+// packages.versions.delete remove the backing image and return a done LRO,
+// rather than 404 (the sub-collections were previously read-only GET). Each
+// image is modeled as one package (id = digest) with one version (the digest).
+func TestArtifactRegistryPackageVersionDelete(t *testing.T) {
+	const (
+		repoID   = "del-images"
+		location = "us"
+		imageSz  = 2048
+	)
+
+	provider := cloudemu.NewGCP()
+	sess := compat.BootGCP(t, gcpserver.Drivers{ArtifactRegistry: provider.ArtifactRegistry})
+	ctx := context.Background()
+
+	svcClient, err := ar.NewService(ctx,
+		option.WithEndpoint(sess.Endpoint()),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(sess.Transport()),
+	)
+	if err != nil {
+		t.Fatalf("artifactregistry service: %v", err)
+	}
+
+	parent := "projects/" + compat.GCPProject + "/locations/" + location
+	name := parent + "/repositories/" + repoID
+
+	createOp, err := svcClient.Projects.Locations.Repositories.Create(parent, &ar.Repository{
+		Format: "DOCKER",
+	}).RepositoryId(repoID).Context(ctx).Do()
+	if err != nil || !createOp.Done {
+		t.Fatalf("create repo: %v (done=%v)", err, createOp != nil && createOp.Done)
+	}
+
+	// Seed two images (distinct digests) — one exercised via packages.delete, the
+	// other via versions.delete.
+	seed := func(tag string) string {
+		img, perr := provider.ArtifactRegistry.PutImage(ctx, &crdriver.ImageManifest{
+			Repository: repoID,
+			Tag:        tag,
+			MediaType:  "application/vnd.docker.distribution.manifest.v2+json",
+			SizeBytes:  imageSz,
+		})
+		if perr != nil {
+			t.Fatalf("seed PutImage %s: %v", tag, perr)
+		}
+
+		return img.Digest
+	}
+
+	pkgDigest := seed("pkg")
+	verDigest := seed("ver")
+
+	pkgName := name + "/packages/" + pkgDigest
+
+	delPkgOp, err := svcClient.Projects.Locations.Repositories.Packages.Delete(pkgName).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("packages.delete: %v", err)
+	}
+
+	if !delPkgOp.Done {
+		t.Fatalf("packages.delete operation not done: %+v", delPkgOp)
+	}
+
+	if _, err := svcClient.Projects.Locations.Repositories.Packages.Get(pkgName).Context(ctx).Do(); err == nil {
+		t.Fatalf("package still readable after delete")
+	}
+
+	verName := name + "/packages/" + verDigest + "/versions/" + verDigest
+
+	delVerOp, err := svcClient.Projects.Locations.Repositories.Packages.Versions.Delete(verName).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("versions.delete: %v", err)
+	}
+
+	if !delVerOp.Done {
+		t.Fatalf("versions.delete operation not done: %+v", delVerOp)
+	}
+}

--- a/compat/gcp/database_compat_test.go
+++ b/compat/gcp/database_compat_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"testing"
 
 	gcpfirestore "cloud.google.com/go/firestore"
@@ -126,3 +127,91 @@ const (
 	docID      = "u1"
 	wantAge    = 30
 )
+
+// TestFirestoreListCollectionIDsScoped proves listCollectionIds is scoped to the
+// requested parent: a root call returns only the immediate top-level collection
+// ids and a per-document call returns only that document's direct subcollection
+// ids — each a single id segment, never a full nested path, and never another
+// document's subcollections. Pre-fix, both returned every driver table name
+// verbatim (root yielded "cities/SF/landmarks"; a document call leaked unrelated
+// collections).
+func TestFirestoreListCollectionIDsScoped(t *testing.T) {
+	provider := cloudemu.NewGCP()
+	sess := compat.BootGCP(t, gcpserver.Drivers{Firestore: provider.Firestore})
+	ctx := context.Background()
+
+	client, err := gcpfirestore.NewRESTClient(ctx, compat.GCPProject,
+		option.WithEndpoint(sess.Endpoint()),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(sess.Transport()),
+	)
+	if err != nil {
+		t.Fatalf("firestore REST client: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	// Two top-level collections (cities, users) and a subcollection (landmarks)
+	// under the cities/SF document.
+	writes := []struct {
+		ref  *gcpfirestore.DocumentRef
+		data map[string]any
+	}{
+		{client.Collection("cities").Doc("SF"), map[string]any{"name": "San Francisco"}},
+		{client.Collection("cities").Doc("SF").Collection("landmarks").Doc("GG"), map[string]any{"name": "Golden Gate"}},
+		{client.Collection("users").Doc("alice"), map[string]any{"name": "Alice"}},
+	}
+	for _, wr := range writes {
+		if _, serr := wr.ref.Set(ctx, wr.data); serr != nil {
+			t.Fatalf("seed %s: %v", wr.ref.Path, serr)
+		}
+	}
+
+	rootIDs := collectCollectionIDs(t, client.Collections(ctx))
+	if !equalStrings(rootIDs, []string{"cities", "users"}) {
+		t.Fatalf("root listCollectionIds = %v, want [cities users]", rootIDs)
+	}
+
+	docIDs := collectCollectionIDs(t, client.Collection("cities").Doc("SF").Collections(ctx))
+	if !equalStrings(docIDs, []string{"landmarks"}) {
+		t.Fatalf("cities/SF listCollectionIds = %v, want [landmarks]", docIDs)
+	}
+}
+
+// collectCollectionIDs drains a CollectionIterator into a sorted slice of ids.
+func collectCollectionIDs(t *testing.T, it *gcpfirestore.CollectionIterator) []string {
+	t.Helper()
+
+	var ids []string
+
+	for {
+		ref, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("collection iterator: %v", err)
+		}
+
+		ids = append(ids, ref.ID)
+	}
+
+	sort.Strings(ids)
+
+	return ids
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/compat/gcp/loadbalancer_compat_test.go
+++ b/compat/gcp/loadbalancer_compat_test.go
@@ -132,3 +132,58 @@ func TestLoadBalancerCompat(t *testing.T) {
 		return op.Wait(ctx)
 	})
 }
+
+// TestBackendServiceGetHealth proves compute.backendServices.getHealth returns a
+// valid BackendServiceGroupHealth (kind + healthStatus) rather than 405. Pre-fix
+// the named-resource POST fell through to method-not-allowed.
+func TestBackendServiceGetHealth(t *testing.T) {
+	const backendName = "compat-health-backend"
+
+	cloud := cloudemu.NewGCP()
+	sess := compat.BootGCP(t, gcpserver.Drivers{LB: cloud.LB, Compute: cloud.GCE})
+	ctx := context.Background()
+
+	bsClient, err := gcpcompute.NewBackendServicesRESTClient(ctx,
+		option.WithEndpoint(sess.Endpoint()),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(sess.Transport()),
+	)
+	if err != nil {
+		t.Fatalf("NewBackendServicesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = bsClient.Close() })
+
+	project := compat.GCPProject
+	strp := func(s string) *string { return &s }
+
+	op, err := bsClient.Insert(ctx, &computepb.InsertBackendServiceRequest{
+		Project: project,
+		BackendServiceResource: &computepb.BackendService{
+			Name:     strp(backendName),
+			Protocol: strp("HTTP"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("insert backend service: %v", err)
+	}
+
+	if werr := op.Wait(ctx); werr != nil {
+		t.Fatalf("wait insert: %v", werr)
+	}
+
+	health, err := bsClient.GetHealth(ctx, &computepb.GetHealthBackendServiceRequest{
+		Project:        project,
+		BackendService: backendName,
+		ResourceGroupReferenceResource: &computepb.ResourceGroupReference{
+			Group: strp("projects/" + project + "/zones/us-central1-a/instanceGroups/ig-1"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("getHealth: %v", err)
+	}
+
+	if health.GetKind() != "compute#backendServiceGroupHealth" {
+		t.Fatalf("getHealth kind = %q, want compute#backendServiceGroupHealth", health.GetKind())
+	}
+}

--- a/compat/gcp/monitoring_compat_test.go
+++ b/compat/gcp/monitoring_compat_test.go
@@ -3,7 +3,10 @@ package gcp
 import (
 	"context"
 	"testing"
+	"time"
 
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
 	monitoring "google.golang.org/api/monitoring/v3"
 	"google.golang.org/api/option"
 
@@ -68,4 +71,174 @@ func TestCloudMonitoringCompat(t *testing.T) {
 
 		return derr
 	})
+}
+
+// TestGCEInstanceMonitoredResourceLabels proves a GCE auto-metric's timeSeries
+// carries a gce_instance monitored resource whose labels include zone and
+// project_id, so a resource.labels.zone filter matches. Pre-fix the resource
+// carried only instance_id (a full path), and the zone/project_id filters
+// returned zero series.
+func TestGCEInstanceMonitoredResourceLabels(t *testing.T) {
+	const zone = "us-central1-a"
+
+	cloud := cloudemu.NewGCP()
+	sess := compat.BootGCP(t, gcpserver.Drivers{Compute: cloud.GCE, Monitoring: cloud.CloudMonitoring})
+	ctx := context.Background()
+
+	opts := []option.ClientOption{
+		option.WithEndpoint(sess.Endpoint()),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(sess.Transport()),
+	}
+
+	instances, err := gcpcompute.NewInstancesRESTClient(ctx, opts...)
+	if err != nil {
+		t.Fatalf("NewInstancesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = instances.Close() })
+
+	strp := func(s string) *string { return &s }
+	boolp := func(b bool) *bool { return &b }
+
+	op, err := instances.Insert(ctx, &computepb.InsertInstanceRequest{
+		Project: compat.GCPProject,
+		Zone:    zone,
+		InstanceResource: &computepb.Instance{
+			Name:        strp("metric-vm"),
+			MachineType: strp("zones/" + zone + "/machineTypes/n1-standard-1"),
+			Disks: []*computepb.AttachedDisk{{
+				Boot:       boolp(true),
+				AutoDelete: boolp(true),
+				InitializeParams: &computepb.AttachedDiskInitializeParams{
+					SourceImage: strp("projects/debian-cloud/global/images/family/debian-12"),
+				},
+			}},
+			NetworkInterfaces: []*computepb.NetworkInterface{{Network: strp("global/networks/default")}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("insert instance: %v", err)
+	}
+
+	if werr := op.Wait(ctx); werr != nil {
+		t.Fatalf("wait instance: %v", werr)
+	}
+
+	mon, err := monitoring.NewService(ctx, opts...)
+	if err != nil {
+		t.Fatalf("monitoring.NewService: %v", err)
+	}
+
+	now := time.Now().UTC()
+	resp, err := mon.Projects.TimeSeries.List("projects/"+compat.GCPProject).
+		Filter(`metric.type = "compute.googleapis.com/instance/cpu/utilization" AND resource.labels.zone = "`+zone+`"`).
+		IntervalStartTime(now.Add(-1 * time.Hour).Format(time.RFC3339)).
+		IntervalEndTime(now.Add(1 * time.Minute).Format(time.RFC3339)).
+		Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("timeSeries.list: %v", err)
+	}
+
+	if len(resp.TimeSeries) == 0 {
+		t.Fatalf("zone-filtered timeSeries.list returned no series")
+	}
+
+	res := resp.TimeSeries[0].Resource
+	if res == nil || res.Type != "gce_instance" {
+		t.Fatalf("resource = %+v, want gce_instance", res)
+	}
+
+	if res.Labels["zone"] != zone {
+		t.Fatalf("resource.labels.zone = %q, want %q", res.Labels["zone"], zone)
+	}
+
+	if res.Labels["project_id"] == "" {
+		t.Fatalf("resource.labels.project_id is empty, want the instance's project")
+	}
+}
+
+// TestNotificationChannelPatch proves notificationChannels.patch updates a
+// channel's displayName/labels in place (keeping its name), rather than 405.
+func TestNotificationChannelPatch(t *testing.T) {
+	cloud := cloudemu.NewGCP()
+	sess := compat.BootGCP(t, gcpserver.Drivers{Monitoring: cloud.CloudMonitoring})
+	ctx := context.Background()
+
+	svc, err := monitoring.NewService(ctx,
+		option.WithEndpoint(sess.Endpoint()),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(sess.Transport()),
+	)
+	if err != nil {
+		t.Fatalf("monitoring.NewService: %v", err)
+	}
+
+	parent := "projects/" + compat.GCPProject
+
+	created, err := svc.Projects.NotificationChannels.Create(parent, &monitoring.NotificationChannel{
+		Type:        "email",
+		DisplayName: "on-call",
+		Labels:      map[string]string{"email_address": "a@example.com"},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("create channel: %v", err)
+	}
+
+	patched, err := svc.Projects.NotificationChannels.Patch(created.Name, &monitoring.NotificationChannel{
+		DisplayName: "on-call-updated",
+		Labels:      map[string]string{"email_address": "b@example.com"},
+	}).UpdateMask("display_name,labels").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("patch channel: %v", err)
+	}
+
+	if patched.Name != created.Name {
+		t.Fatalf("patch changed channel name %q -> %q", created.Name, patched.Name)
+	}
+
+	if patched.DisplayName != "on-call-updated" {
+		t.Fatalf("patched displayName = %q, want on-call-updated", patched.DisplayName)
+	}
+
+	if patched.Labels["email_address"] != "b@example.com" {
+		t.Fatalf("patched label email_address = %q, want b@example.com", patched.Labels["email_address"])
+	}
+}
+
+// TestMetricDescriptorDelete proves metricDescriptors.delete removes a custom
+// descriptor (create then delete then get -> 404), rather than 405.
+func TestMetricDescriptorDelete(t *testing.T) {
+	const mtype = "custom.googleapis.com/compat/widgets"
+
+	cloud := cloudemu.NewGCP()
+	sess := compat.BootGCP(t, gcpserver.Drivers{Monitoring: cloud.CloudMonitoring})
+	ctx := context.Background()
+
+	svc, err := monitoring.NewService(ctx,
+		option.WithEndpoint(sess.Endpoint()),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(sess.Transport()),
+	)
+	if err != nil {
+		t.Fatalf("monitoring.NewService: %v", err)
+	}
+
+	parent := "projects/" + compat.GCPProject
+
+	if _, err := svc.Projects.MetricDescriptors.Create(parent, &monitoring.MetricDescriptor{
+		Type:       mtype,
+		MetricKind: "GAUGE",
+		ValueType:  "DOUBLE",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create descriptor: %v", err)
+	}
+
+	if _, err := svc.Projects.MetricDescriptors.Delete(parent + "/metricDescriptors/" + mtype).Context(ctx).Do(); err != nil {
+		t.Fatalf("delete descriptor: %v", err)
+	}
+
+	if _, err := svc.Projects.MetricDescriptors.Get(parent + "/metricDescriptors/" + mtype).Context(ctx).Do(); err == nil {
+		t.Fatalf("descriptor still readable after delete")
+	}
 }

--- a/compat/gcp/networking_compat_test.go
+++ b/compat/gcp/networking_compat_test.go
@@ -197,3 +197,93 @@ func skipIteratorDone(err error) error {
 
 	return err
 }
+
+// TestRouteNetworkSelfLink proves compute.routes.get normalizes the Route's
+// network reference to a fully-qualified self-link URL on read, rather than
+// echoing the caller's relative "global/networks/{name}" verbatim (a perpetual
+// Terraform google_compute_route.network diff pre-fix). The global next-hop
+// gateway reference is normalized the same way.
+func TestRouteNetworkSelfLink(t *testing.T) {
+	const (
+		routeNet  = "compat-route-net"
+		routeName = "compat-route"
+	)
+
+	ctx := context.Background()
+	cloudP := cloudemu.NewGCP()
+	sess := compat.BootGCP(t, gcpserver.Drivers{Networking: cloudP.VPC, Compute: cloudP.GCE})
+
+	opts := []option.ClientOption{
+		option.WithEndpoint(sess.Endpoint()),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(sess.Transport()),
+	}
+
+	nets, err := gcpcompute.NewNetworksRESTClient(ctx, opts...)
+	if err != nil {
+		t.Fatalf("NewNetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = nets.Close() })
+
+	routes, err := gcpcompute.NewRoutesRESTClient(ctx, opts...)
+	if err != nil {
+		t.Fatalf("NewRoutesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = routes.Close() })
+
+	strp := func(s string) *string { return &s }
+	boolp := func(b bool) *bool { return &b }
+	project := compat.GCPProject
+
+	netOp, err := nets.Insert(ctx, &computepb.InsertNetworkRequest{
+		Project: project,
+		NetworkResource: &computepb.Network{
+			Name:                  strp(routeNet),
+			AutoCreateSubnetworks: boolp(false),
+		},
+	})
+	if err != nil {
+		t.Fatalf("insert network: %v", err)
+	}
+
+	if werr := netOp.Wait(ctx); werr != nil {
+		t.Fatalf("wait network: %v", werr)
+	}
+
+	// Insert a route referencing the network by a relative path — the shape
+	// Terraform sends.
+	rtOp, err := routes.Insert(ctx, &computepb.InsertRouteRequest{
+		Project: project,
+		RouteResource: &computepb.Route{
+			Name:           strp(routeName),
+			Network:        strp("global/networks/" + routeNet),
+			DestRange:      strp("10.20.0.0/16"),
+			NextHopGateway: strp("global/gateways/default-internet-gateway"),
+			Priority:       func() *uint32 { p := uint32(1000); return &p }(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+
+	if werr := rtOp.Wait(ctx); werr != nil {
+		t.Fatalf("wait route: %v", werr)
+	}
+
+	got, err := routes.Get(ctx, &computepb.GetRouteRequest{Project: project, Route: routeName})
+	if err != nil {
+		t.Fatalf("get route: %v", err)
+	}
+
+	wantNet := sess.Endpoint() + "/compute/v1/projects/" + project + "/global/networks/" + routeNet
+	if got.GetNetwork() != wantNet {
+		t.Fatalf("route network = %q, want self-link %q", got.GetNetwork(), wantNet)
+	}
+
+	wantGw := sess.Endpoint() + "/compute/v1/projects/" + project + "/global/gateways/default-internet-gateway"
+	if got.GetNextHopGateway() != wantGw {
+		t.Fatalf("route nextHopGateway = %q, want self-link %q", got.GetNextHopGateway(), wantGw)
+	}
+}

--- a/compat/gcp/serverless_compat_test.go
+++ b/compat/gcp/serverless_compat_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	cf "google.golang.org/api/cloudfunctions/v1"
+	cfv2 "google.golang.org/api/cloudfunctions/v2"
 	"google.golang.org/api/option"
 
 	cloudemu "github.com/stackshy/cloudemu/v2"
@@ -141,4 +142,53 @@ func TestCloudFunctionsCompat(t *testing.T) {
 
 		return nil
 	})
+}
+
+// TestGen2GenerateDownloadURL proves the gen2 (v2) functions.generateDownloadUrl
+// method returns a downloadUrl for an existing function, rather than 404
+// ("unknown method"). generateUploadUrl already worked; download was the gap.
+func TestGen2GenerateDownloadURL(t *testing.T) {
+	provider := cloudemu.NewGCP()
+	sess := compat.BootGCP(t, gcpserver.Drivers{CloudFunctions: provider.CloudFunctions})
+	ctx := context.Background()
+
+	svc, err := cfv2.NewService(ctx,
+		option.WithEndpoint(sess.Endpoint()),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(sess.Transport()),
+	)
+	if err != nil {
+		t.Fatalf("cloudfunctions v2 service: %v", err)
+	}
+
+	parent := "projects/" + compat.GCPProject + "/locations/us-central1"
+	name := parent + "/functions/g2dl"
+
+	createOp, err := svc.Projects.Locations.Functions.Create(parent, &cfv2.Function{
+		Environment: "GEN_2",
+		BuildConfig: &cfv2.BuildConfig{
+			Runtime:    "go121",
+			EntryPoint: "Hello",
+			Source: &cfv2.Source{
+				StorageSource: &cfv2.StorageSource{Bucket: "b", Object: "o.zip"},
+			},
+		},
+	}).FunctionId("g2dl").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("create gen2 function: %v", err)
+	}
+
+	if !createOp.Done {
+		t.Fatal("create operation not done")
+	}
+
+	resp, err := svc.Projects.Locations.Functions.
+		GenerateDownloadUrl(name, &cfv2.GenerateDownloadUrlRequest{}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("generateDownloadUrl: %v", err)
+	}
+
+	if resp.DownloadUrl == "" {
+		t.Fatalf("generateDownloadUrl returned empty downloadUrl")
+	}
 }

--- a/providers/gcp/compute/gce.go
+++ b/providers/gcp/compute/gce.go
@@ -134,7 +134,32 @@ func gcpMetricNames() []string {
 	}
 }
 
-func (m *Mock) emitInstanceMetrics(ctx context.Context, instanceID, launchTime string) {
+// gcpZoneTagKey mirrors the wire layer's zone tag (server/gcp/compute
+// instance_state.go keyZone): a GCE instance's launch zone is round-tripped
+// through its tags because the driver Instance model has no zone field. The
+// metric emitters read it so the gce_instance monitored resource carries a zone
+// label (see metricDimensions).
+const gcpZoneTagKey = "cloudemu:gcp:zone"
+
+// metricDimensions builds the gce_instance monitored-resource labels stamped on
+// every emitted metric datum: project_id and instance_id are always present,
+// zone when the launch zone is known. Cloud Monitoring resource filters
+// (resource.labels.zone=…, resource.labels.project_id=…) match on these, so all
+// three must be emitted for a filtered timeSeries.list to return the series.
+func (m *Mock) metricDimensions(instanceID, zone string) map[string]string {
+	dims := map[string]string{
+		"instance_id": instanceID,
+		"project_id":  m.opts.ProjectID,
+	}
+
+	if zone != "" {
+		dims["zone"] = zone
+	}
+
+	return dims
+}
+
+func (m *Mock) emitInstanceMetrics(ctx context.Context, instanceID, launchTime, zone string) {
 	if m.monitoring == nil {
 		return
 	}
@@ -146,6 +171,7 @@ func (m *Mock) emitInstanceMetrics(ctx context.Context, instanceID, launchTime s
 
 	metrics := gcpMetricNames()
 	values := []float64{0.25, 1024.0, 512.0, 100.0, 50.0}
+	dims := m.metricDimensions(instanceID, zone)
 
 	var data []mondriver.MetricDatum
 
@@ -160,7 +186,7 @@ func (m *Mock) emitInstanceMetrics(ctx context.Context, instanceID, launchTime s
 				MetricName: metricName,
 				Value:      values[i],
 				Unit:       "None",
-				Dimensions: map[string]string{"instance_id": instanceID},
+				Dimensions: dims,
 				Timestamp:  ts,
 			})
 		}
@@ -169,13 +195,14 @@ func (m *Mock) emitInstanceMetrics(ctx context.Context, instanceID, launchTime s
 	_ = m.monitoring.PutMetricData(ctx, data)
 }
 
-func (m *Mock) emitLifecycleMetrics(ctx context.Context, instanceID string, values []float64) {
+func (m *Mock) emitLifecycleMetrics(ctx context.Context, instanceID, zone string, values []float64) {
 	if m.monitoring == nil {
 		return
 	}
 
 	metrics := gcpMetricNames()
 	now := m.opts.Clock.Now()
+	dims := m.metricDimensions(instanceID, zone)
 	data := make([]mondriver.MetricDatum, len(metrics))
 
 	for i, metricName := range metrics {
@@ -184,7 +211,7 @@ func (m *Mock) emitLifecycleMetrics(ctx context.Context, instanceID string, valu
 			MetricName: metricName,
 			Value:      values[i],
 			Unit:       "None",
-			Dimensions: map[string]string{"instance_id": instanceID},
+			Dimensions: dims,
 			Timestamp:  now,
 		}
 	}
@@ -302,7 +329,7 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 		inst.State = compute.StateRunning
 		results = append(results, toInstance(inst))
 		created = append(created, inst)
-		m.emitInstanceMetrics(ctx, id, inst.LaunchTime)
+		m.emitInstanceMetrics(ctx, id, inst.LaunchTime, tags[gcpZoneTagKey])
 	}
 
 	return results, nil
@@ -348,7 +375,7 @@ func (m *Mock) transitionInstances(ctx context.Context, instanceIDs []string, t 
 		_ = m.sm.Transition(id, t.finalState)
 		inst.State = t.finalState
 
-		m.emitLifecycleMetrics(ctx, id, t.metricValues)
+		m.emitLifecycleMetrics(ctx, id, inst.Tags[gcpZoneTagKey], t.metricValues)
 	}
 
 	return nil

--- a/providers/gcp/monitoring/monitoring.go
+++ b/providers/gcp/monitoring/monitoring.go
@@ -501,6 +501,35 @@ func (m *Mock) CreateNotificationChannel(
 	return ch, nil
 }
 
+// UpdateNotificationChannel applies apply to a copy of the stored channel and
+// persists it, keeping the channel's stable ID (and thus its resource name).
+// It backs the wire layer's notificationChannels.patch. Mutating a copy rather
+// than the stored pointer avoids racing a concurrent Get/List that shares it.
+func (m *Mock) UpdateNotificationChannel(
+	_ context.Context, id string, apply func(*driver.NotificationChannelInfo),
+) (*driver.NotificationChannelInfo, error) {
+	existing, ok := m.channels.Get(id)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "notification channel %q not found", id)
+	}
+
+	updated := *existing
+
+	if existing.Tags != nil {
+		tags := make(map[string]string, len(existing.Tags))
+		for k, v := range existing.Tags {
+			tags[k] = v
+		}
+
+		updated.Tags = tags
+	}
+
+	apply(&updated)
+	m.channels.Set(id, &updated)
+
+	return &updated, nil
+}
+
 // DeleteNotificationChannel deletes the notification channel with the given ID.
 func (m *Mock) DeleteNotificationChannel(_ context.Context, id string) error {
 	if !m.channels.Delete(id) {

--- a/server/gcp/artifactregistry/handler.go
+++ b/server/gcp/artifactregistry/handler.go
@@ -243,8 +243,16 @@ func (h *Handler) serveResource(w http.ResponseWriter, r *http.Request, rt *rout
 }
 
 // serveSub dispatches the repository sub-collections (docker images, packages,
-// versions, tags, files). All are read-only GETs.
+// versions, tags, files). Reads are GETs; packages and versions also accept
+// DELETE (packages.delete / versions.delete), routed through servePackages.
 func (h *Handler) serveSub(w http.ResponseWriter, r *http.Request, rt *route) {
+	// The packages sub-tree owns both GET (list/get) and DELETE (package/version
+	// removal); it dispatches on method itself.
+	if rt.sub == packagesSeg {
+		h.servePackages(w, r, rt)
+		return
+	}
+
 	if r.Method != http.MethodGet {
 		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported "+rt.sub+" operation")
 		return
@@ -253,8 +261,6 @@ func (h *Handler) serveSub(w http.ResponseWriter, r *http.Request, rt *route) {
 	switch rt.sub {
 	case dockerImagesSeg:
 		h.listDockerImages(w, r, rt)
-	case packagesSeg:
-		h.servePackages(w, r, rt)
 	case filesSeg:
 		h.listFiles(w, r, rt)
 	default:

--- a/server/gcp/artifactregistry/subcollections.go
+++ b/server/gcp/artifactregistry/subcollections.go
@@ -16,22 +16,28 @@ import (
 // the Repository body.
 
 // servePackages dispatches the packages sub-tree: the packages collection, a
-// single package, and its versions / tags sub-collections.
+// single package, and its versions / tags sub-collections. A single package and
+// a single version also accept DELETE (packages.delete / versions.delete); the
+// collections, tags, and the packages collection itself remain read-only.
 func (h *Handler) servePackages(w http.ResponseWriter, r *http.Request, rt *route) {
 	if rt.pkg == "" {
+		if !requireGet(w, r, "packages") {
+			return
+		}
+
 		h.listPackages(w, r, rt)
+
 		return
 	}
 
 	switch rt.pkgSub {
 	case versionsSeg:
-		if rt.pkgSubID != "" {
-			h.getVersion(w, r, rt)
+		h.serveVersions(w, r, rt)
+	case tagsSeg:
+		if !requireGet(w, r, "tags") {
 			return
 		}
 
-		h.listVersions(w, r, rt)
-	case tagsSeg:
 		if rt.pkgSubID != "" {
 			h.getTag(w, r, rt)
 			return
@@ -39,10 +45,96 @@ func (h *Handler) servePackages(w http.ResponseWriter, r *http.Request, rt *rout
 
 		h.listTags(w, r, rt)
 	case "":
-		h.getPackage(w, r, rt)
+		h.servePackage(w, r, rt)
 	default:
 		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported package sub-collection "+rt.pkgSub)
 	}
+}
+
+// servePackage serves a single package: GET returns it, DELETE removes it (and
+// its underlying image), returning a done long-running operation.
+func (h *Handler) servePackage(w http.ResponseWriter, r *http.Request, rt *route) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getPackage(w, r, rt)
+	case http.MethodDelete:
+		h.deletePackage(w, r, rt)
+	default:
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported package operation")
+	}
+}
+
+// serveVersions serves the versions sub-collection: GET lists or gets a version,
+// DELETE removes a single version (packages.versions.delete).
+func (h *Handler) serveVersions(w http.ResponseWriter, r *http.Request, rt *route) {
+	if rt.pkgSubID == "" {
+		if !requireGet(w, r, "versions") {
+			return
+		}
+
+		h.listVersions(w, r, rt)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getVersion(w, r, rt)
+	case http.MethodDelete:
+		h.deleteVersion(w, r, rt)
+	default:
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported version operation")
+	}
+}
+
+// deletePackage removes a package (packages.delete) — the driver models one
+// image per package keyed by digest, so this deletes that image — and returns a
+// done LRO the SDK/gcloud polls.
+func (h *Handler) deletePackage(w http.ResponseWriter, r *http.Request, rt *route) {
+	if _, ok := h.findImage(w, r, rt); !ok {
+		return
+	}
+
+	if err := h.registry.DeleteImage(r.Context(), rt.repository, rt.pkg); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, h.doneOperation(rt, rt.pkg, nil))
+}
+
+// deleteVersion removes a single version (packages.versions.delete). The version
+// id must equal the package's digest (one version per image); it deletes the
+// backing image and returns a done LRO.
+func (h *Handler) deleteVersion(w http.ResponseWriter, r *http.Request, rt *route) {
+	img, ok := h.findImage(w, r, rt)
+	if !ok {
+		return
+	}
+
+	if rt.pkgSubID != img.Digest {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "version "+rt.pkgSubID+" not found")
+		return
+	}
+
+	if err := h.registry.DeleteImage(r.Context(), rt.repository, img.Digest); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, h.doneOperation(rt, rt.pkgSubID, nil))
+}
+
+// requireGet writes a 404 (matching the sub-collection's read-only error shape)
+// and returns false when the method is not GET.
+func requireGet(w http.ResponseWriter, r *http.Request, what string) bool {
+	if r.Method == http.MethodGet {
+		return true
+	}
+
+	gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported "+what+" operation")
+
+	return false
 }
 
 // getVersion returns a single version (.../packages/{pkg}/versions/{version}).

--- a/server/gcp/cloudfunctions/gen2.go
+++ b/server/gcp/cloudfunctions/gen2.go
@@ -91,6 +91,11 @@ type gen2UploadURLResponse struct {
 	StorageSource *gen2StorageSource `json:"storageSource,omitempty"`
 }
 
+// gen2DownloadURLResponse is the body of v2 functions:generateDownloadUrl.
+type gen2DownloadURLResponse struct {
+	DownloadURL string `json:"downloadUrl"`
+}
+
 // v2Path holds the parsed components of a /v2/projects/... Cloud Functions URL.
 // For an operation poll, name carries the operation id.
 type v2Path struct {
@@ -210,6 +215,8 @@ func (h *Handler) serveV2Action(w http.ResponseWriter, r *http.Request, p v2Path
 	switch p.action {
 	case actionGenerateUploadURL:
 		h.generateUploadURLV2(w, r, p)
+	case actionGenerateDownloadURL:
+		h.generateDownloadURLV2(w, r, p)
 	case actionGetIamPolicy, actionSetIamPolicy:
 		h.serveV2IamPolicy(w, r, p)
 	case actionTestIamPermissions:
@@ -438,6 +445,32 @@ func (h *Handler) generateUploadURLV2(w http.ResponseWriter, r *http.Request, p 
 			Object: token + ".zip",
 		},
 	})
+}
+
+// generateDownloadURLV2 serves v2 functions:generateDownloadUrl on a named
+// function: it returns a URL from which the function's deployed source can be
+// downloaded. The function must exist (404 otherwise). gen2 source is only
+// staged (not executed) in the emulator, so the URL is synthetic — enough for
+// the SDK/gcloud call to succeed and read back a downloadUrl.
+func (h *Handler) generateDownloadURLV2(w http.ResponseWriter, r *http.Request, p v2Path) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+
+	h.mu.RLock()
+	_, ok := h.gen2[p.fullName()]
+	h.mu.RUnlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "function "+p.name+" not found")
+		return
+	}
+
+	downloadURL := requestScheme(r) + "://" + r.Host + pathPrefix + p.project + "/" + locationsSeg + "/" + p.location +
+		"/" + functionsSeg + "/" + p.name + "/source.zip"
+
+	writeJSON(w, http.StatusOK, gen2DownloadURLResponse{DownloadURL: downloadURL})
 }
 
 // mergeGen2 applies a patch body onto the stored function under the update mask.

--- a/server/gcp/cloudfunctions/handler.go
+++ b/server/gcp/cloudfunctions/handler.go
@@ -57,6 +57,9 @@ const (
 	actionCall = "call"
 	// actionGenerateUploadURL mints an upload URL for a source deploy.
 	actionGenerateUploadURL = "generateUploadUrl"
+	// actionGenerateDownloadURL mints a URL to download a function's source
+	// (gen2 functions.generateDownloadUrl).
+	actionGenerateDownloadURL = "generateDownloadUrl"
 	// actionGetIamPolicy / actionSetIamPolicy are the IAM invoker-policy verbs.
 	actionGetIamPolicy = "getIamPolicy"
 	actionSetIamPolicy = "setIamPolicy"

--- a/server/gcp/compute/disks.go
+++ b/server/gcp/compute/disks.go
@@ -88,7 +88,7 @@ func (h *Handler) insertDisk(w http.ResponseWriter, r *http.Request, rp gcprest.
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
+	op := h.ops.RecordDone(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
 		"disks", req.Name, "insert")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -166,7 +166,7 @@ func (h *Handler) deleteDisk(w http.ResponseWriter, r *http.Request, rp gcprest.
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
+	op := h.ops.RecordDone(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
 		"disks", rp.ResourceName, "delete")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -218,7 +218,7 @@ func (h *Handler) resizeDisk(w http.ResponseWriter, r *http.Request, rp gcprest.
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
+	op := h.ops.RecordDone(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
 		"disks", rp.ResourceName, "resize")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)

--- a/server/gcp/compute/handler.go
+++ b/server/gcp/compute/handler.go
@@ -45,6 +45,12 @@ type Handler struct {
 	// networking driver wired), in which case IP allocation falls back to the
 	// compute provider's synthetic allocator.
 	net netdriver.Networking
+	// ops records the compute#operation names this handler mints so a poll of an
+	// operation that was never issued returns 404 instead of a fabricated DONE.
+	// Shared with the networks and load-balancing handlers (which mint compute
+	// operations this handler's /operations route serves). Nil in a package-level
+	// server, where every operation poll is answered DONE (legacy behavior).
+	ops *gcprest.OperationRegistry
 }
 
 // New returns a Compute handler backed by c. net (may be nil) lets insert
@@ -53,6 +59,11 @@ type Handler struct {
 func New(c computedriver.Compute, net netdriver.Networking) *Handler {
 	return &Handler{compute: c, net: net}
 }
+
+// SetOperationRegistry wires the shared compute-operation registry so this
+// handler records the operations it mints and 404s a poll for an operation name
+// that was never issued.
+func (h *Handler) SetOperationRegistry(reg *gcprest.OperationRegistry) { h.ops = reg }
 
 // Matches returns true for /compute/v1/projects/... URLs targeting instances
 // or operations resources. Other resource types fall through so future
@@ -124,7 +135,7 @@ func (h *Handler) serveAggregated(w http.ResponseWriter, r *http.Request, rp gcp
 func (h *Handler) routeResource(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) bool {
 	switch rp.ResourceType {
 	case resourceOperations:
-		serveOperations(w, r, rp)
+		h.serveOperations(w, r, rp)
 	case resourceDisks:
 		h.serveDisksRoute(w, r, rp)
 	case resourceSnapshots:
@@ -296,11 +307,14 @@ func (h *Handler) dispatchInstanceVerb(w http.ResponseWriter, r *http.Request, r
 	}
 }
 
-// serveOperations handles GET on operations/{name}. Since our mock executes
-// synchronously, every operation lookup returns DONE.
+// serveOperations handles GET on operations/{name}. Since the mock executes
+// synchronously, a known operation always reads back DONE. An operation name
+// that was never minted (a bogus poll, `gcloud compute operations describe
+// <bogus>`) is 404, matching real GCP, rather than a fabricated DONE — provided
+// a shared registry is wired (a nil registry keeps the legacy allow-all).
 //
 //nolint:gocritic // rp is a request-scoped value
-func serveOperations(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+func (h *Handler) serveOperations(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
 	if r.Method != http.MethodGet {
 		writeNotImplemented(w, r.Method+" "+r.URL.Path)
 		return
@@ -316,6 +330,13 @@ func serveOperations(w http.ResponseWriter, r *http.Request, rp gcprest.Resource
 			"items":    []any{},
 			"selfLink": gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, "operations", ""),
 		})
+
+		return
+	}
+
+	if !h.ops.Has(rp.Scope, rp.ScopeName, rp.ResourceName) {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound",
+			"The resource 'operations/"+rp.ResourceName+"' was not found")
 
 		return
 	}

--- a/server/gcp/compute/images.go
+++ b/server/gcp/compute/images.go
@@ -91,7 +91,7 @@ func (h *Handler) insertImage(w http.ResponseWriter, r *http.Request, rp gcprest
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, gcprest.ScopeGlobal, "",
+	op := h.ops.RecordDone(hostFromRequest(r), rp.Project, gcprest.ScopeGlobal, "",
 		"images", req.Name, "insert")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -146,7 +146,7 @@ func (h *Handler) deleteImage(w http.ResponseWriter, r *http.Request, rp gcprest
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, gcprest.ScopeGlobal, "",
+	op := h.ops.RecordDone(hostFromRequest(r), rp.Project, gcprest.ScopeGlobal, "",
 		"images", rp.ResourceName, "delete")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)

--- a/server/gcp/compute/instance_actions.go
+++ b/server/gcp/compute/instance_actions.go
@@ -187,7 +187,7 @@ func (h *Handler) applyMutation(
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
+	op := h.ops.RecordDone(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
 		"instances", rp.ResourceName, opType)
 
 	gcprest.WriteJSON(w, http.StatusOK, op)

--- a/server/gcp/compute/instances.go
+++ b/server/gcp/compute/instances.go
@@ -78,7 +78,7 @@ func (h *Handler) insertInstance(w http.ResponseWriter, r *http.Request, rp gcpr
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
+	op := h.ops.RecordDone(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
 		"instances", req.Name, "insert")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -200,7 +200,7 @@ func (h *Handler) deleteInstance(w http.ResponseWriter, r *http.Request, rp gcpr
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
+	op := h.ops.RecordDone(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
 		"instances", rp.ResourceName, "delete")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -245,7 +245,7 @@ func (h *Handler) action(
 		return
 	}
 
-	doneOp := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
+	doneOp := h.ops.RecordDone(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
 		"instances", rp.ResourceName, opType)
 
 	gcprest.WriteJSON(w, http.StatusOK, doneOp)

--- a/server/gcp/compute/snapshots.go
+++ b/server/gcp/compute/snapshots.go
@@ -85,7 +85,7 @@ func (h *Handler) insertSnapshot(w http.ResponseWriter, r *http.Request, rp gcpr
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, gcprest.ScopeGlobal, "",
+	op := h.ops.RecordDone(hostFromRequest(r), rp.Project, gcprest.ScopeGlobal, "",
 		"snapshots", req.Name, "insert")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -140,7 +140,7 @@ func (h *Handler) deleteSnapshot(w http.ResponseWriter, r *http.Request, rp gcpr
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, gcprest.ScopeGlobal, "",
+	op := h.ops.RecordDone(hostFromRequest(r), rp.Project, gcprest.ScopeGlobal, "",
 		"snapshots", rp.ResourceName, "delete")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)

--- a/server/gcp/firestore/handler.go
+++ b/server/gcp/firestore/handler.go
@@ -177,7 +177,7 @@ func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, base, acti
 	case "rollback":
 		h.rollback(w, r)
 	case "listCollectionIds":
-		h.listCollectionIDs(w, r)
+		h.listCollectionIDs(w, r, base)
 	default:
 		writeError(w, http.StatusNotImplemented, "UNIMPLEMENTED", "action not implemented: "+action)
 	}

--- a/server/gcp/firestore/transaction.go
+++ b/server/gcp/firestore/transaction.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/internal/pagination"
@@ -57,14 +58,25 @@ type listCollectionIDsResponse struct {
 	NextPageToken string   `json:"nextPageToken,omitempty"`
 }
 
-// listCollectionIDs handles POST .../documents:listCollectionIds (and the
-// per-document variant). Collections are created lazily on first write and
-// modeled as driver tables, so the collection ids are the table names. The body
-// (pageSize/pageToken) is optional; an absent body lists all ids.
-func (h *Handler) listCollectionIDs(w http.ResponseWriter, r *http.Request) {
+// listCollectionIDs handles POST .../documents:listCollectionIds (root) and the
+// per-document variant .../documents/{coll}/{doc}:listCollectionIds. Collections
+// are created lazily on first write and modeled as driver tables keyed by their
+// full parent path, so the ids returned must be scoped to the request's parent:
+// the root call returns only immediate top-level collections and a per-document
+// call returns only that document's direct subcollections — each a single id
+// segment, never a full nested path. base is the resource path before the
+// ":listCollectionIds" action. The body (pageSize/pageToken) is optional; an
+// absent body lists all matching ids.
+func (h *Handler) listCollectionIDs(w http.ResponseWriter, r *http.Request, base string) {
 	var req listCollectionIDsRequest
 
 	if r.ContentLength != 0 && !decodeJSON(w, r, &req) {
+		return
+	}
+
+	parent, perr := parseFirestorePath(base)
+	if perr != nil {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", perr.Error())
 		return
 	}
 
@@ -74,10 +86,11 @@ func (h *Handler) listCollectionIDs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sort.Strings(names)
+	ids := immediateCollectionIDs(names, parent.parentPath())
+	sort.Strings(ids)
 
-	page, perr := pagination.Paginate(names, req.PageToken, req.PageSize)
-	if perr != nil {
+	page, pgerr := pagination.Paginate(ids, req.PageToken, req.PageSize)
+	if pgerr != nil {
 		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "invalid pageToken")
 		return
 	}
@@ -86,4 +99,44 @@ func (h *Handler) listCollectionIDs(w http.ResponseWriter, r *http.Request) {
 		CollectionIDs: page.Items,
 		NextPageToken: page.NextPageToken,
 	})
+}
+
+// immediateCollectionIDs filters the driver table names (each a full parent
+// path like "cities" or "cities/SF/landmarks") to the collection ids that are
+// immediate children of parent, returning only each match's final path segment.
+// A parent of "" selects the top-level collections. This scopes the result to
+// the requested document so an unrelated document's subcollections never leak.
+func immediateCollectionIDs(tables []string, parent string) []string {
+	seen := make(map[string]struct{}, len(tables))
+
+	ids := make([]string, 0, len(tables))
+
+	for _, t := range tables {
+		rest := t
+
+		if parent != "" {
+			prefix := parent + "/"
+			if !strings.HasPrefix(t, prefix) {
+				continue
+			}
+
+			rest = t[len(prefix):]
+		}
+
+		// An immediate child collection is a single segment under the parent;
+		// skip a deeper subcollection path (it has another "/") or an empty rest.
+		if rest == "" || strings.Contains(rest, "/") {
+			continue
+		}
+
+		if _, ok := seen[rest]; ok {
+			continue
+		}
+
+		seen[rest] = struct{}{}
+
+		ids = append(ids, rest)
+	}
+
+	return ids
 }

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/server/gcp/servicenetworking"
 	vertexaisrv "github.com/stackshy/cloudemu/v2/server/gcp/vertexai"
 	"github.com/stackshy/cloudemu/v2/server/gcp/vpc"
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	btdriver "github.com/stackshy/cloudemu/v2/services/bigtable/driver"
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
 	cloudrundriver "github.com/stackshy/cloudemu/v2/services/cloudrun/driver"
@@ -159,16 +160,28 @@ func New(d Drivers) *server.Server {
 	opsReg := lro.NewRegistry()
 	srv.Register(lro.New(opsReg))
 
+	// Shared compute-operation registry. The compute handler's /operations route
+	// serves every compute#operation poll (its own, plus the networks and load-
+	// balancing handlers', which mint compute operations but have no operations
+	// route of their own). Sharing one registry lets an Insert/Delete poll resolve
+	// a real operation and 404 a name that was never issued, uniformly across the
+	// three handlers.
+	computeOps := gcprest.NewOperationRegistry()
+
 	if d.Compute != nil {
 		// d.Networking (may be nil) lets insert allocate the instance's private
 		// networkIP from the referenced subnetwork's CIDR.
-		srv.Register(compute.New(d.Compute, d.Networking))
+		computeH := compute.New(d.Compute, d.Networking)
+		computeH.SetOperationRegistry(computeOps)
+		srv.Register(computeH)
 	}
 
 	if d.Networking != nil {
 		// d.Compute (may be nil) lets the subnetwork delete guard reject removing a
 		// subnet that still has instances.
-		srv.Register(vpc.New(d.Networking, d.Compute))
+		netH := vpc.New(d.Networking, d.Compute)
+		netH.SetOperationRegistry(computeOps)
+		srv.Register(netH)
 	}
 
 	// Service Networking has no driver: a private-services connection is a
@@ -185,7 +198,9 @@ func New(d Drivers) *server.Server {
 	// return operation envelopes the SDK polls via the compute handler's
 	// /global/operations route.
 	if d.LB != nil {
-		srv.Register(lbsrv.New(d.LB))
+		lbH := lbsrv.New(d.LB)
+		lbH.SetOperationRegistry(computeOps)
+		srv.Register(lbH)
 	}
 
 	// Compute-space catch-all. Registered AFTER the compute, networks and load-

--- a/server/gcp/loadbalancer/handler.go
+++ b/server/gcp/loadbalancer/handler.go
@@ -44,6 +44,10 @@ const (
 	resourceForwardingRules = "forwardingRules"
 )
 
+// actionGetHealth is the POST action on a named backend service that returns the
+// health of its backends (compute.backendServices.getHealth).
+const actionGetHealth = "getHealth"
+
 // reasonResourceInUse is the GCP error reason returned when a delete is rejected
 // because another resource still references the target. Real GCP answers such a
 // delete with HTTP 400 and this reason, so dependents are never orphaned.
@@ -52,12 +56,22 @@ const reasonResourceInUse = "resourceInUseByAnotherResource"
 // Handler serves the GCP load-balancing REST surface.
 type Handler struct {
 	lb lbdriver.LoadBalancer
+	// ops records the compute#operation names this handler mints so the compute
+	// handler's shared /operations route (which serves LB operation polls)
+	// resolves a real operation and 404s a bogus one. Nil in a package-level
+	// server (every operation poll answered DONE, legacy behavior).
+	ops *gcprest.OperationRegistry
 }
 
 // New returns a GCP load balancer handler backed by lb.
 func New(lb lbdriver.LoadBalancer) *Handler {
 	return &Handler{lb: lb}
 }
+
+// SetOperationRegistry wires the shared compute-operation registry so the
+// operations this handler mints are resolvable (and unknown names 404) through
+// the compute handler's /operations poll route.
+func (h *Handler) SetOperationRegistry(reg *gcprest.OperationRegistry) { h.ops = reg }
 
 // Matches returns true for /compute/v1/.../backendServices|forwardingRules
 // URLs. Disjoint from the compute (instances/operations/disks/…) and networks
@@ -117,6 +131,13 @@ func (h *Handler) routeBackendServices(w http.ResponseWriter, r *http.Request, r
 			gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
 		}
 
+		return
+	}
+
+	// getHealth is a POST action on a named backend service, distinct from the
+	// resource-level verbs below.
+	if r.Method == http.MethodPost && rp.Action == actionGetHealth {
+		h.getBackendServiceHealth(w, r, rp)
 		return
 	}
 

--- a/server/gcp/loadbalancer/operations.go
+++ b/server/gcp/loadbalancer/operations.go
@@ -61,7 +61,7 @@ func (h *Handler) insertBackendService(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, rp.Scope, rp.ScopeName,
+	op := h.ops.RecordDone(hostOf(r), rp.Project, rp.Scope, rp.ScopeName,
 		resourceBackendServices, req.Name, "insert")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -110,7 +110,7 @@ func (h *Handler) patchBackendService(w http.ResponseWriter, r *http.Request, rp
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, rp.Scope, rp.ScopeName,
+	op := h.ops.RecordDone(hostOf(r), rp.Project, rp.Scope, rp.ScopeName,
 		resourceBackendServices, rp.ResourceName, "patch")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -125,6 +125,36 @@ func (h *Handler) getBackendService(w http.ResponseWriter, r *http.Request, rp g
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, toBackendServiceResponse(tg, rp, hostOf(r)))
+}
+
+// getBackendServiceHealth serves compute.backendServices.getHealth: POST
+// .../backendServices/{bs}/getHealth with a ResourceGroupReference body. The
+// backend service must exist (404 otherwise). The emulator does not model
+// instance-group membership or health probes, so it reports the referenced
+// group as HEALTHY when a group was named and an empty health set otherwise —
+// a valid BackendServiceGroupHealth shape the SDK/Terraform can read back.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getBackendServiceHealth(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if _, err := h.findTGByName(r.Context(), rp, rp.ResourceName); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	var req resourceGroupReference
+	if r.ContentLength != 0 && !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	resp := backendServiceGroupHealth{Kind: "compute#backendServiceGroupHealth"}
+	if req.Group != "" {
+		resp.HealthStatus = []healthStatus{{
+			HealthState: "HEALTHY",
+			Instance:    req.Group,
+		}}
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, resp)
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -197,7 +227,7 @@ func (h *Handler) deleteBackendService(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, rp.Scope, rp.ScopeName,
+	op := h.ops.RecordDone(hostOf(r), rp.Project, rp.Scope, rp.ScopeName,
 		resourceBackendServices, rp.ResourceName, "delete")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -263,7 +293,7 @@ func (h *Handler) insertForwardingRule(w http.ResponseWriter, r *http.Request, r
 		}
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, rp.Scope, rp.ScopeName,
+	op := h.ops.RecordDone(hostOf(r), rp.Project, rp.Scope, rp.ScopeName,
 		resourceForwardingRules, req.Name, "insert")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -337,7 +367,7 @@ func (h *Handler) deleteForwardingRule(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, rp.Scope, rp.ScopeName,
+	op := h.ops.RecordDone(hostOf(r), rp.Project, rp.Scope, rp.ScopeName,
 		resourceForwardingRules, rp.ResourceName, "delete")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)

--- a/server/gcp/loadbalancer/resources.go
+++ b/server/gcp/loadbalancer/resources.go
@@ -113,7 +113,7 @@ func (h *Handler) mutateGCPResource(w http.ResponseWriter, r *http.Request, rp g
 		verb = "patch"
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, rp.Scope, rp.ScopeName, rp.ResourceType, rp.ResourceName, verb)
+	op := h.ops.RecordDone(hostOf(r), rp.Project, rp.Scope, rp.ScopeName, rp.ResourceType, rp.ResourceName, verb)
 	gcprest.WriteJSON(w, http.StatusOK, op)
 }
 
@@ -165,7 +165,7 @@ func (h *Handler) insertGCPResource(w http.ResponseWriter, r *http.Request, rp g
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, rp.Scope, rp.ScopeName, rp.ResourceType, name, "insert")
+	op := h.ops.RecordDone(hostOf(r), rp.Project, rp.Scope, rp.ScopeName, rp.ResourceType, name, "insert")
 	gcprest.WriteJSON(w, http.StatusOK, op)
 }
 
@@ -268,7 +268,7 @@ func (h *Handler) deleteGCPResource(w http.ResponseWriter, r *http.Request, rp g
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, rp.Scope, rp.ScopeName, rp.ResourceType, rp.ResourceName, "delete")
+	op := h.ops.RecordDone(hostOf(r), rp.Project, rp.Scope, rp.ScopeName, rp.ResourceType, rp.ResourceName, "delete")
 	gcprest.WriteJSON(w, http.StatusOK, op)
 }
 

--- a/server/gcp/loadbalancer/types.go
+++ b/server/gcp/loadbalancer/types.go
@@ -67,6 +67,27 @@ type backendServiceResponse struct {
 	SelfLink            string              `json:"selfLink"`
 }
 
+// resourceGroupReference is the getHealth request body: the instance-group (or
+// NEG) URL whose backends' health is being queried.
+type resourceGroupReference struct {
+	Group string `json:"group,omitempty"`
+}
+
+// healthStatus is one backend instance's health entry in a
+// backendServiceGroupHealth response.
+type healthStatus struct {
+	HealthState string `json:"healthState,omitempty"`
+	Instance    string `json:"instance,omitempty"`
+	IPAddress   string `json:"ipAddress,omitempty"`
+	Port        int    `json:"port,omitempty"`
+}
+
+// backendServiceGroupHealth is the compute.backendServices.getHealth response.
+type backendServiceGroupHealth struct {
+	Kind         string         `json:"kind"`
+	HealthStatus []healthStatus `json:"healthStatus,omitempty"`
+}
+
 type backendServiceListResponse struct {
 	Kind          string                   `json:"kind"`
 	ID            string                   `json:"id"`

--- a/server/gcp/monitoring/metricdescriptors.go
+++ b/server/gcp/monitoring/metricdescriptors.go
@@ -23,12 +23,38 @@ func (h *Handler) serveMetricDescriptors(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	if r.Method != http.MethodGet {
+	mtype := strings.Join(rest, "/")
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getDescriptor(w, project, mtype)
+	case http.MethodDelete:
+		h.deleteDescriptor(w, project, mtype)
+	default:
 		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+	}
+}
+
+// deleteDescriptor removes a custom metric descriptor created via
+// metricDescriptors.create. Only custom descriptors are deletable — a descriptor
+// synthesized from live series (or one that never existed) is 404, matching real
+// GCP, which rejects deleting a built-in/absent descriptor.
+func (h *Handler) deleteDescriptor(w http.ResponseWriter, _, mtype string) {
+	h.mu.Lock()
+
+	_, ok := h.descriptors[mtype]
+	if ok {
+		delete(h.descriptors, mtype)
+	}
+
+	h.mu.Unlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "metricDescriptor "+mtype+" not found")
 		return
 	}
 
-	h.getDescriptor(w, project, strings.Join(rest, "/"))
+	writeJSON(w, http.StatusOK, map[string]any{})
 }
 
 func (h *Handler) listDescriptors(w http.ResponseWriter, project string) {

--- a/server/gcp/monitoring/notificationchannels.go
+++ b/server/gcp/monitoring/notificationchannels.go
@@ -1,6 +1,7 @@
 package monitoring
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -27,11 +28,62 @@ func (h *Handler) serveNotificationChannels(w http.ResponseWriter, r *http.Reque
 	switch r.Method {
 	case http.MethodGet:
 		h.getChannel(w, r, project, id)
+	case http.MethodPatch:
+		h.patchChannel(w, r, project, id)
 	case http.MethodDelete:
 		h.deleteChannel(w, r, id)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
 	}
+}
+
+// channelUpdater is the optional monitoring-driver extension that persists a
+// notification-channel patch. Only the GCP mock implements it; a driver without
+// it gets a 501 on PATCH rather than a shared-interface method it can't satisfy.
+type channelUpdater interface {
+	UpdateNotificationChannel(
+		ctx context.Context, id string, apply func(*mondriver.NotificationChannelInfo),
+	) (*mondriver.NotificationChannelInfo, error)
+}
+
+// patchChannel serves notificationChannels.patch: it merges the request body's
+// present fields (displayName, type, labels) onto the stored channel, keeping
+// its stable name, and returns the updated channel.
+func (h *Handler) patchChannel(w http.ResponseWriter, r *http.Request, project, id string) {
+	updater, ok := h.mon.(channelUpdater)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "UNIMPLEMENTED", "notification channel patch unsupported")
+		return
+	}
+
+	var body notificationChannel
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		return
+	}
+
+	info, err := updater.UpdateNotificationChannel(r.Context(), id, func(ch *mondriver.NotificationChannelInfo) {
+		if body.DisplayName != "" {
+			ch.Name = body.DisplayName
+		}
+
+		if body.Type != "" {
+			ch.Type = body.Type
+		}
+
+		if body.Labels != nil {
+			ch.Tags = body.Labels
+			ch.Endpoint = channelEndpoint(body.Labels)
+		}
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toChannelJSON(project, info))
 }
 
 func (h *Handler) createChannel(w http.ResponseWriter, r *http.Request, project string) {

--- a/server/gcp/monitoring/timeseries.go
+++ b/server/gcp/monitoring/timeseries.go
@@ -163,12 +163,27 @@ func oneSeries(fullType string, data []mondriver.MetricDatum) timeSeries {
 	}
 }
 
+// resourceFor derives a datum's monitored resource from its label set. A datum
+// carrying an instance_id is a gce_instance whose resource labels are
+// project_id, instance_id and zone (whichever were emitted) — the same labels
+// Cloud Monitoring filters like resource.labels.zone=… match against, so a
+// filtered timeSeries.list returns the series. Anything else is the global
+// resource.
 func resourceFor(labels map[string]string) monitoredRes {
-	if id, ok := labels["instance_id"]; ok {
-		return monitoredRes{Type: "gce_instance", Labels: map[string]string{"instance_id": id}}
+	id, ok := labels["instance_id"]
+	if !ok {
+		return monitoredRes{Type: "global"}
 	}
 
-	return monitoredRes{Type: "global"}
+	resLabels := map[string]string{"instance_id": id}
+
+	for _, key := range []string{"project_id", "zone"} {
+		if v, ok := labels[key]; ok {
+			resLabels[key] = v
+		}
+	}
+
+	return monitoredRes{Type: "gce_instance", Labels: resLabels}
 }
 
 func inWindow(ts, start, end time.Time) bool {

--- a/server/gcp/vpc/addresses.go
+++ b/server/gcp/vpc/addresses.go
@@ -202,7 +202,7 @@ func (h *Handler) insertAddress(w http.ResponseWriter, r *http.Request, rp gcpre
 	h.addresses.put(rp.Project, scopeOf(rp), named.Name,
 		h.enrichAddress(raw, rp, hostOf(r), named.Name))
 
-	gcprest.WriteJSON(w, http.StatusOK, gcprest.NewDoneOperation(hostOf(r), rp.Project,
+	gcprest.WriteJSON(w, http.StatusOK, h.ops.RecordDone(hostOf(r), rp.Project,
 		rp.Scope, rp.ScopeName, resourceAddresses, named.Name, "insert"))
 }
 
@@ -377,7 +377,7 @@ func (h *Handler) deleteAddress(w http.ResponseWriter, r *http.Request, rp gcpre
 		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, gcprest.NewDoneOperation(host, rp.Project,
+	gcprest.WriteJSON(w, http.StatusOK, h.ops.RecordDone(host, rp.Project,
 		rp.Scope, rp.ScopeName, resourceAddresses, rp.ResourceName, "delete"))
 }
 

--- a/server/gcp/vpc/handler.go
+++ b/server/gcp/vpc/handler.go
@@ -106,6 +106,10 @@ type Handler struct {
 	routers   *routerStore
 	addresses *addressStore
 	routes    *routeStore
+	// ops records the compute#operation names this handler mints so the compute
+	// handler's shared /operations route (which serves these polls) resolves a
+	// real operation and 404s a bogus one. Nil in a package-level server.
+	ops *gcprest.OperationRegistry
 }
 
 // New returns a networks handler. compute is optional (may be nil): when
@@ -119,6 +123,11 @@ func New(n netdriver.Networking, compute instanceLister) *Handler {
 		routes:    newRouteStore(),
 	}
 }
+
+// SetOperationRegistry wires the shared compute-operation registry so the
+// operations this handler mints are resolvable (and unknown names 404) through
+// the compute handler's /operations poll route.
+func (h *Handler) SetOperationRegistry(reg *gcprest.OperationRegistry) { h.ops = reg }
 
 // Matches returns true for /compute/v1/.../networks|subnetworks|firewalls URLs.
 func (*Handler) Matches(r *http.Request) bool {
@@ -310,7 +319,7 @@ func (h *Handler) insertNetwork(w http.ResponseWriter, r *http.Request, rp gcpre
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+	op := h.ops.RecordDone(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
 		"networks", req.Name, "insert")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -428,7 +437,7 @@ func (h *Handler) deleteNetwork(w http.ResponseWriter, r *http.Request, rp gcpre
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+	op := h.ops.RecordDone(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
 		"networks", rp.ResourceName, "delete")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -473,7 +482,7 @@ func (h *Handler) patchNetwork(w http.ResponseWriter, r *http.Request, rp gcpres
 		}
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+	op := h.ops.RecordDone(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
 		"networks", rp.ResourceName, "patch")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -528,7 +537,7 @@ func (h *Handler) insertSubnetwork(w http.ResponseWriter, r *http.Request, rp gc
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
+	op := h.ops.RecordDone(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
 		"subnetworks", req.Name, "insert")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -656,7 +665,7 @@ func (h *Handler) deleteSubnetwork(w http.ResponseWriter, r *http.Request, rp gc
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
+	op := h.ops.RecordDone(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
 		"subnetworks", rp.ResourceName, "delete")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -705,7 +714,7 @@ func (h *Handler) patchSubnetwork(w http.ResponseWriter, r *http.Request, rp gcp
 		}
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
+	op := h.ops.RecordDone(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
 		"subnetworks", rp.ResourceName, "patch")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -785,7 +794,7 @@ func (h *Handler) expandSubnetIPCIDR(w http.ResponseWriter, r *http.Request, rp 
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
+	op := h.ops.RecordDone(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
 		"subnetworks", rp.ResourceName, expandAction)
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -950,7 +959,7 @@ func (h *Handler) insertFirewall(w http.ResponseWriter, r *http.Request, rp gcpr
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+	op := h.ops.RecordDone(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
 		"firewalls", req.Name, "insert")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -1020,7 +1029,7 @@ func (h *Handler) deleteFirewall(w http.ResponseWriter, r *http.Request, rp gcpr
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+	op := h.ops.RecordDone(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
 		"firewalls", rp.ResourceName, "delete")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -1059,7 +1068,7 @@ func (h *Handler) patchFirewall(w http.ResponseWriter, r *http.Request, rp gcpre
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+	op := h.ops.RecordDone(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
 		"firewalls", rp.ResourceName, "patch")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)

--- a/server/gcp/vpc/routers.go
+++ b/server/gcp/vpc/routers.go
@@ -133,7 +133,7 @@ func (h *Handler) insertRouter(w http.ResponseWriter, r *http.Request, rp gcpres
 
 	h.routers.put(rp.Project, rp.ScopeName, req.Name, body)
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
+	op := h.ops.RecordDone(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
 		resourceRouters, req.Name, "insert")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -182,7 +182,7 @@ func (h *Handler) patchRouter(w http.ResponseWriter, r *http.Request, rp gcprest
 
 	h.routers.put(rp.Project, rp.ScopeName, rp.ResourceName, body)
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
+	op := h.ops.RecordDone(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
 		resourceRouters, rp.ResourceName, "patch")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
@@ -197,7 +197,7 @@ func (h *Handler) deleteRouter(w http.ResponseWriter, r *http.Request, rp gcpres
 		return
 	}
 
-	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
+	op := h.ops.RecordDone(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
 		resourceRouters, rp.ResourceName, "delete")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)

--- a/server/gcp/vpc/routes.go
+++ b/server/gcp/vpc/routes.go
@@ -124,7 +124,7 @@ func (h *Handler) insertRoute(w http.ResponseWriter, r *http.Request, rp gcprest
 
 	h.routes.put(rp.Project, name, enrichRoute(raw, rp, hostOf(r), name))
 
-	gcprest.WriteJSON(w, http.StatusOK, gcprest.NewDoneOperation(hostOf(r), rp.Project,
+	gcprest.WriteJSON(w, http.StatusOK, h.ops.RecordDone(hostOf(r), rp.Project,
 		gcprest.ScopeGlobal, "", resourceRoutes, name, "insert"))
 }
 
@@ -181,14 +181,18 @@ func (h *Handler) deleteRoute(w http.ResponseWriter, r *http.Request, rp gcprest
 		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, gcprest.NewDoneOperation(hostOf(r), rp.Project,
+	gcprest.WriteJSON(w, http.StatusOK, h.ops.RecordDone(hostOf(r), rp.Project,
 		gcprest.ScopeGlobal, "", resourceRoutes, rp.ResourceName, "delete"))
 }
 
 // enrichRoute stamps the server-assigned fields (kind, id, selfLink,
 // creationTimestamp) onto a route while preserving the caller's routing spec
-// (network, destRange, next-hop, priority). Without them a Get reads back an
-// incomplete resource.
+// (destRange, priority). It also normalizes the reference fields — network and
+// the global next-hop references — to fully-qualified self-link URLs, matching
+// real GCP's read shape so a caller (Terraform google_compute_route) that sends
+// a relative "global/networks/default" doesn't read back a value that never
+// stops diffing against the API's absolute self-link. Without this a Get returns
+// the caller's raw relative reference verbatim.
 //
 //nolint:gocritic // rp is a request-scoped value
 func enrichRoute(raw json.RawMessage, rp gcprest.ResourcePath, host, name string) json.RawMessage {
@@ -202,10 +206,28 @@ func enrichRoute(raw json.RawMessage, rp gcprest.ResourcePath, host, name string
 	body["selfLink"] = gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", resourceRoutes, name)
 	body["creationTimestamp"] = nowRFC3339()
 
+	qualifyGlobalRef(body, "network", host, rp.Project, "networks")
+	qualifyGlobalRef(body, "nextHopNetwork", host, rp.Project, "networks")
+	qualifyGlobalRef(body, "nextHopGateway", host, rp.Project, "gateways")
+
 	enriched, err := json.Marshal(body)
 	if err != nil {
 		return raw
 	}
 
 	return enriched
+}
+
+// qualifyGlobalRef rewrites body[field], when present and non-empty, to a
+// fully-qualified global self-link under collection (e.g. networks, gateways),
+// preserving only the trailing name segment of whatever reference the caller
+// supplied (bare name, relative path, or absolute URL). A field that is absent
+// or not a string is left untouched.
+func qualifyGlobalRef(body map[string]any, field, host, project, collection string) {
+	raw, ok := body[field].(string)
+	if !ok || raw == "" {
+		return
+	}
+
+	body[field] = gcprest.SelfLink(host, project, gcprest.ScopeGlobal, "", collection, lastSegment(raw))
 }

--- a/server/wire/gcprest/gcprest.go
+++ b/server/wire/gcprest/gcprest.go
@@ -18,10 +18,74 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 )
+
+// OperationRegistry records the compute#operation names the compute-family
+// handlers (compute, networks/vpc, load balancing) mint, so a subsequent
+// zone/region/global Operations.get resolves a real operation and 404s a name
+// that was never issued — matching real GCP, instead of fabricating DONE for any
+// name. A nil *OperationRegistry records nothing and reports every name as
+// present, preserving the legacy allow-all behavior for a handler constructed
+// without a shared registry (e.g. a package-level test).
+type OperationRegistry struct {
+	mu   sync.RWMutex
+	seen map[string]struct{}
+}
+
+// NewOperationRegistry returns an empty operation registry.
+func NewOperationRegistry() *OperationRegistry {
+	return &OperationRegistry{seen: map[string]struct{}{}}
+}
+
+// opKey scopes an operation name by the URL scope it is polled under, so a
+// zonal, regional, and global operation of the same name stay distinct.
+func opKey(scope, scopeName, name string) string {
+	return scope + "\x00" + scopeName + "\x00" + name
+}
+
+// Record notes that operation name exists at scope/scopeName. Nil-safe: a nil
+// registry is a no-op.
+func (reg *OperationRegistry) Record(scope, scopeName, name string) {
+	if reg == nil {
+		return
+	}
+
+	reg.mu.Lock()
+	reg.seen[opKey(scope, scopeName, name)] = struct{}{}
+	reg.mu.Unlock()
+}
+
+// Has reports whether operation name was recorded at scope/scopeName. A nil
+// registry reports true (not enforcing), so a handler without a shared registry
+// keeps answering every operation poll as it did before.
+func (reg *OperationRegistry) Has(scope, scopeName, name string) bool {
+	if reg == nil {
+		return true
+	}
+
+	reg.mu.RLock()
+	_, ok := reg.seen[opKey(scope, scopeName, name)]
+	reg.mu.RUnlock()
+
+	return ok
+}
+
+// RecordDone builds a DONE operation for a mutation (via NewDoneOperation) and
+// records its name so a later poll resolves it. It replaces a bare
+// NewDoneOperation call at a handler's mint sites; a nil registry still returns
+// the operation but records nothing.
+func (reg *OperationRegistry) RecordDone(
+	host, project, scope, scopeName, resourceType, name, opType string,
+) Operation {
+	op := NewDoneOperation(host, project, scope, scopeName, resourceType, name, opType)
+	reg.Record(scope, scopeName, op.Name)
+
+	return op
+}
 
 // ContentType is the JSON content type used by all REST responses.
 const ContentType = "application/json"


### PR DESCRIPTION
Pre-release acceptance findings (GCP). Fixes: firestore listCollectionIds now scoped to the requested parent (was leaking all collections cross-document); backendServices.getHealth; compute routes network self-link; cloudmonitoring gce_instance zone/project labels; notificationChannels.patch; artifactregistry package/version delete; metricDescriptors.delete; cloudfunctions gen2 generateDownloadUrl; compute operations.get 404 for unknown ops. Excludes the external L7 LB build-out (tracked in #826). Real-SDK repro tests added.