### PR TITLE
fix(azure): well-formed list-by-subscription IDs, no phantom VNet, disk location, ACI PATCH, 201 on create

### DIFF
--- a/compat/azure/prerelease_findings_compat_test.go
+++ b/compat/azure/prerelease_findings_compat_test.go
@@ -1,0 +1,409 @@
+package azure
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/internal/compat"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// These tests reproduce and lock down the pre-release Azure acceptance findings.
+// They drive the same raw ARM JSON wire a real azure-sdk-for-go / az / Terraform
+// azurerm client emits, through CloudEmu's in-process Azure wire server.
+
+const (
+	preRelSub = "sub-prerel"
+	preRelRG  = "rg-prerel"
+	apiVer    = "?api-version=2023-09-01"
+)
+
+// bootPreRel boots the Azure wire server with every driver the finding tests
+// touch, sharing one server across subtests.
+func bootPreRel(t *testing.T) *compat.AzureSession {
+	t.Helper()
+
+	p := cloudemu.NewAzure()
+
+	return compat.BootAzure(t, azureserver.Drivers{
+		VirtualMachines:    p.VirtualMachines,
+		Disks:              p.VirtualMachines,
+		Network:            p.VNet,
+		DNS:                p.DNS,
+		ServiceBus:         p.ServiceBus,
+		AKS:                p.AKS,
+		ContainerInstances: p.ContainerInstances,
+		EventGrid:          p.EventGrid,
+		SQL:                p.SQL,
+		PostgresFlex:       p.PostgresFlex,
+		MySQLFlex:          p.MySQLFlex,
+		Monitor:            p.Monitor,
+	})
+}
+
+// armReq issues one raw ARM request and returns the status code and parsed body.
+func armReq(t *testing.T, sess *compat.AzureSession, method, path, body string) (int, map[string]any) {
+	t.Helper()
+
+	var rdr io.Reader
+	if body != "" {
+		rdr = bytes.NewReader([]byte(body))
+	}
+
+	req, err := http.NewRequest(method, sess.Endpoint()+path+apiVer, rdr)
+	if err != nil {
+		t.Fatalf("new request %s %s: %v", method, path, err)
+	}
+
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := sess.Transport().Do(req)
+	if err != nil {
+		t.Fatalf("do %s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+
+	var parsed map[string]any
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &parsed)
+	}
+
+	return resp.StatusCode, parsed
+}
+
+// rgScoped / subScoped build ARM collection/resource paths.
+func rgScoped(provider, resType, name string) string {
+	p := "/subscriptions/" + preRelSub + "/resourceGroups/" + preRelRG +
+		"/providers/" + provider + "/" + resType
+	if name != "" {
+		p += "/" + name
+	}
+
+	return p
+}
+
+func subScoped(provider, resType string) string {
+	return "/subscriptions/" + preRelSub + "/providers/" + provider + "/" + resType
+}
+
+// assertWellFormedID fails when an ARM id is missing its resource group segment
+// (the `resourceGroups//` malformation the finding is about).
+func assertWellFormedID(t *testing.T, id string) {
+	t.Helper()
+
+	if id == "" {
+		t.Fatal("resource id is empty")
+	}
+
+	if strings.Contains(id, "resourceGroups//") {
+		t.Errorf("malformed id (empty resource-group segment): %s", id)
+	}
+
+	if !strings.Contains(id, "/resourceGroups/"+preRelRG+"/") {
+		t.Errorf("id does not carry its resource group %q: %s", preRelRG, id)
+	}
+}
+
+// listIDs pulls the "id" of each item in an ARM {"value":[...]} response.
+func listIDs(t *testing.T, body map[string]any) []string {
+	t.Helper()
+
+	// An empty ARM collection serializes as {"value":null}; treat that as zero
+	// ids rather than an error.
+	val, _ := body["value"].([]any)
+
+	ids := make([]string, 0, len(val))
+
+	for _, it := range val {
+		m, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if id, ok := m["id"].(string); ok {
+			ids = append(ids, id)
+		}
+	}
+
+	return ids
+}
+
+// TestPreReleaseListBySubscriptionIDs covers the systemic HIGH finding: every
+// subscription-scoped list must render each resource's id with its true
+// resourceGroups/{rg} segment (not the empty `resourceGroups//`).
+func TestPreReleaseListBySubscriptionIDs(t *testing.T) {
+	sess := bootPreRel(t)
+
+	cases := []struct {
+		name     string
+		provider string
+		resType  string
+		resName  string
+		body     string
+	}{
+		{
+			name: "virtualMachines", provider: "Microsoft.Compute", resType: "virtualMachines", resName: "vm1",
+			body: `{"location":"eastus","properties":{"hardwareProfile":{"vmSize":"Standard_D2s_v3"}}}`,
+		},
+		{
+			name: "disks", provider: "Microsoft.Compute", resType: "disks", resName: "disk1",
+			body: `{"location":"westus2","sku":{"name":"Premium_LRS"},"properties":{"diskSizeGB":32,"creationData":{"createOption":"Empty"}}}`,
+		},
+		{
+			name: "sqlServers", provider: "Microsoft.Sql", resType: "servers", resName: "sqlsrv1",
+			body: `{"location":"eastus","properties":{"administratorLogin":"adm","administratorLoginPassword":"P@ssw0rd!23"}}`,
+		},
+		{
+			name: "mysqlFlex", provider: "Microsoft.DBforMySQL", resType: "flexibleServers", resName: "mysql1",
+			body: `{"location":"eastus","sku":{"name":"Standard_B1ms","tier":"Burstable"},` +
+				`"properties":{"administratorLogin":"adm","administratorLoginPassword":"P@ssw0rd!23","version":"8.0.21"}}`,
+		},
+		{
+			name: "postgresFlex", provider: "Microsoft.DBforPostgreSQL", resType: "flexibleServers", resName: "pg1",
+			body: `{"location":"eastus","sku":{"name":"Standard_B1ms","tier":"Burstable"},` +
+				`"properties":{"administratorLogin":"adm","administratorLoginPassword":"P@ssw0rd!23","version":"14"}}`,
+		},
+		{
+			name: "eventGridTopics", provider: "Microsoft.EventGrid", resType: "topics", resName: "topic1",
+			body: `{"location":"eastus"}`,
+		},
+		{
+			name: "dnsZones", provider: "Microsoft.Network", resType: "dnsZones", resName: "example-prerel.com",
+			body: `{"location":"global"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, _ := armReq(t, sess, http.MethodPut, rgScoped(tc.provider, tc.resType, tc.resName), tc.body)
+			if status >= 300 && status != http.StatusAccepted {
+				t.Fatalf("create %s: status %d", tc.name, status)
+			}
+
+			_, listBody := armReq(t, sess, http.MethodGet, subScoped(tc.provider, tc.resType), "")
+
+			ids := listIDs(t, listBody)
+			if len(ids) == 0 {
+				t.Fatalf("subscription-scoped list of %s returned no items", tc.name)
+			}
+
+			for _, id := range ids {
+				assertWellFormedID(t, id)
+			}
+		})
+	}
+
+	// EventGrid additionally derives properties.metricResourceId from the id, so
+	// it must be well-formed too.
+	t.Run("eventGridMetricResourceID", func(t *testing.T) {
+		_, listBody := armReq(t, sess, http.MethodGet, subScoped("Microsoft.EventGrid", "topics"), "")
+
+		val, _ := listBody["value"].([]any)
+		if len(val) == 0 {
+			t.Fatal("no eventgrid topics listed")
+		}
+
+		for _, it := range val {
+			m, _ := it.(map[string]any)
+			props, _ := m["properties"].(map[string]any)
+			metricID, _ := props["metricResourceId"].(string)
+			assertWellFormedID(t, metricID)
+		}
+	})
+}
+
+// TestPreReleaseNoPhantomVNet covers the HIGH finding: creating a standalone NSG
+// (or route table) must not leak a fabricated virtualNetworks resource.
+func TestPreReleaseNoPhantomVNet(t *testing.T) {
+	sess := bootPreRel(t)
+
+	t.Run("networkSecurityGroups", func(t *testing.T) {
+		status, _ := armReq(t, sess, http.MethodPut,
+			rgScoped("Microsoft.Network", "networkSecurityGroups", "nsg1"), `{"location":"eastus"}`)
+		if status >= 300 && status != http.StatusAccepted {
+			t.Fatalf("create NSG: status %d", status)
+		}
+
+		assertNoVNets(t, sess)
+	})
+
+	t.Run("routeTables", func(t *testing.T) {
+		status, _ := armReq(t, sess, http.MethodPut,
+			rgScoped("Microsoft.Network", "routeTables", "rt1"), `{"location":"eastus"}`)
+		if status >= 300 && status != http.StatusAccepted {
+			t.Fatalf("create route table: status %d", status)
+		}
+
+		assertNoVNets(t, sess)
+	})
+
+	// A real user-created VNet must still list correctly.
+	t.Run("realVNetStillLists", func(t *testing.T) {
+		status, _ := armReq(t, sess, http.MethodPut,
+			rgScoped("Microsoft.Network", "virtualNetworks", "vnet-real"),
+			`{"location":"eastus","properties":{"addressSpace":{"addressPrefixes":["10.1.0.0/16"]}}}`)
+		if status >= 300 && status != http.StatusAccepted {
+			t.Fatalf("create VNet: status %d", status)
+		}
+
+		_, listBody := armReq(t, sess, http.MethodGet, subScoped("Microsoft.Network", "virtualNetworks"), "")
+
+		ids := listIDs(t, listBody)
+		if len(ids) != 1 {
+			t.Fatalf("expected exactly the one real vnet, got %d: %v", len(ids), ids)
+		}
+
+		if !strings.Contains(ids[0], "/virtualNetworks/vnet-real") {
+			t.Errorf("listed vnet is not the user's: %s", ids[0])
+		}
+
+		assertWellFormedID(t, ids[0])
+	})
+}
+
+func assertNoVNets(t *testing.T, sess *compat.AzureSession) {
+	t.Helper()
+
+	_, subBody := armReq(t, sess, http.MethodGet, subScoped("Microsoft.Network", "virtualNetworks"), "")
+	if ids := listIDs(t, subBody); len(ids) != 0 {
+		t.Errorf("subscription vnet list leaked a phantom network: %v", ids)
+	}
+
+	_, rgBody := armReq(t, sess, http.MethodGet, rgScoped("Microsoft.Network", "virtualNetworks", ""), "")
+	if ids := listIDs(t, rgBody); len(ids) != 0 {
+		t.Errorf("resource-group vnet list leaked a phantom network: %v", ids)
+	}
+}
+
+// TestPreReleaseDiskLocationRoundTrips covers the MEDIUM finding: a disk created
+// in westus2 must read back its region, not the eastus default.
+func TestPreReleaseDiskLocationRoundTrips(t *testing.T) {
+	sess := bootPreRel(t)
+
+	status, _ := armReq(t, sess, http.MethodPut,
+		rgScoped("Microsoft.Compute", "disks", "disk-loc"),
+		`{"location":"westus2","sku":{"name":"Premium_LRS"},"properties":{"diskSizeGB":16,"creationData":{"createOption":"Empty"}}}`)
+	if status >= 300 && status != http.StatusAccepted {
+		t.Fatalf("create disk: status %d", status)
+	}
+
+	_, getBody := armReq(t, sess, http.MethodGet, rgScoped("Microsoft.Compute", "disks", "disk-loc"), "")
+	if loc, _ := getBody["location"].(string); loc != "westus2" {
+		t.Errorf("GET disk location = %q, want westus2", loc)
+	}
+
+	_, listBody := armReq(t, sess, http.MethodGet, subScoped("Microsoft.Compute", "disks"), "")
+
+	val, _ := listBody["value"].([]any)
+	found := false
+
+	for _, it := range val {
+		m, _ := it.(map[string]any)
+		if name, _ := m["name"].(string); name != "disk-loc" {
+			continue
+		}
+
+		found = true
+
+		if loc, _ := m["location"].(string); loc != "westus2" {
+			t.Errorf("LIST disk location = %q, want westus2", loc)
+		}
+	}
+
+	if !found {
+		t.Error("disk-loc not present in subscription list")
+	}
+}
+
+// TestPreReleaseACIPatch covers the MEDIUM finding: PATCH on a container group
+// (ARM "Container Groups - Update") must merge tags and return 200, not 405.
+func TestPreReleaseACIPatch(t *testing.T) {
+	sess := bootPreRel(t)
+
+	create := `{"location":"eastus","tags":{"team":"a"},"properties":{"osType":"Linux",` +
+		`"containers":[{"name":"c1","properties":{"image":"nginx",` +
+		`"resources":{"requests":{"cpu":1,"memoryInGB":1}}}}]}}`
+
+	status, _ := armReq(t, sess, http.MethodPut,
+		rgScoped("Microsoft.ContainerInstance", "containerGroups", "cg1"), create)
+	if status != http.StatusCreated {
+		t.Fatalf("create container group: status %d, want 201", status)
+	}
+
+	status, patchBody := armReq(t, sess, http.MethodPatch,
+		rgScoped("Microsoft.ContainerInstance", "containerGroups", "cg1"), `{"tags":{"env":"prod"}}`)
+	if status != http.StatusOK {
+		t.Fatalf("PATCH container group: status %d, want 200", status)
+	}
+
+	tags, _ := patchBody["tags"].(map[string]any)
+	if tags["env"] != "prod" {
+		t.Errorf("PATCH did not apply tag env=prod: %v", tags)
+	}
+
+	if tags["team"] != "a" {
+		t.Errorf("PATCH did not preserve existing tag team=a: %v", tags)
+	}
+}
+
+// TestPreReleaseCreateReturns201 covers the LOW finding: an ARM PUT that creates
+// a new resource returns 201, and an in-place update returns 200.
+func TestPreReleaseCreateReturns201(t *testing.T) {
+	sess := bootPreRel(t)
+
+	cases := []struct {
+		name     string
+		provider string
+		resType  string
+		resName  string
+		body     string
+	}{
+		{
+			name: "mysqlFlex", provider: "Microsoft.DBforMySQL", resType: "flexibleServers", resName: "mysql201",
+			body: `{"location":"eastus","sku":{"name":"Standard_B1ms","tier":"Burstable"},` +
+				`"properties":{"administratorLogin":"adm","administratorLoginPassword":"P@ssw0rd!23","version":"8.0.21"}}`,
+		},
+		{
+			name: "postgresFlex", provider: "Microsoft.DBforPostgreSQL", resType: "flexibleServers", resName: "pg201",
+			body: `{"location":"eastus","sku":{"name":"Standard_B1ms","tier":"Burstable"},` +
+				`"properties":{"administratorLogin":"adm","administratorLoginPassword":"P@ssw0rd!23","version":"14"}}`,
+		},
+		{
+			name: "sqlServers", provider: "Microsoft.Sql", resType: "servers", resName: "sql201",
+			body: `{"location":"eastus","properties":{"administratorLogin":"adm","administratorLoginPassword":"P@ssw0rd!23"}}`,
+		},
+		{
+			name: "serviceBus", provider: "Microsoft.ServiceBus", resType: "namespaces", resName: "sb201",
+			body: `{"location":"eastus","sku":{"name":"Standard"}}`,
+		},
+		{
+			name: "aks", provider: "Microsoft.ContainerService", resType: "managedClusters", resName: "aks201",
+			body: `{"location":"eastus","properties":{"dnsPrefix":"aks201"}}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := rgScoped(tc.provider, tc.resType, tc.resName)
+
+			status, _ := armReq(t, sess, http.MethodPut, path, tc.body)
+			if status != http.StatusCreated {
+				t.Errorf("first create: status %d, want 201", status)
+			}
+
+			status, _ = armReq(t, sess, http.MethodPut, path, tc.body)
+			if status != http.StatusOK {
+				t.Errorf("re-PUT update: status %d, want 200", status)
+			}
+		})
+	}
+}

--- a/docs/coverage/README.md
+++ b/docs/coverage/README.md
@@ -25,7 +25,7 @@ code does not implement. Machine-readable: [`coverage.json`](./coverage.json).
 | `cloudtrail` | [CloudTrail](./aws/cloudtrail.md) | — | — | — | 60 |
 | `compute` | [EC2](./aws/ec2.md) | [VirtualMachines](./azure/virtualmachines.md) | [GCE](./gcp/gce.md) | — | 37 |
 | `configservice` | [Config](./aws/config.md) | — | — | — | 102 |
-| `containerinstances` | — | [ContainerInstances](./azure/containerinstances.md) | — | — | 9 |
+| `containerinstances` | — | [ContainerInstances](./azure/containerinstances.md) | — | — | 10 |
 | `containerregistry` | [ECR](./aws/ecr.md) | [ACR](./azure/acr.md) | [ArtifactRegistry](./gcp/artifactregistry.md) | — | 15 |
 | `cosmosaccount` | — | [Cosmosaccount](./azure/cosmosaccount.md) | — | — | 0 |
 | `cosmospostgresql` | — | [CosmosPostgreSQL](./azure/cosmospostgresql.md) | — | — | 34 |

--- a/docs/coverage/azure/README.md
+++ b/docs/coverage/azure/README.md
@@ -10,7 +10,7 @@ Services cloudemu emulates for Azure, by native name. Back to the [cross-provide
 | [AKS](./aks.md) | — (provider-native) | 16 |
 | [BlobStorage](./blobstorage.md) | `storage` | 35 |
 | [Cache](./cache.md) | `cache` | 17 |
-| [ContainerInstances](./containerinstances.md) | `containerinstances` | 9 |
+| [ContainerInstances](./containerinstances.md) | `containerinstances` | 10 |
 | [CosmosDB](./cosmosdb.md) | `database` | 24 |
 | [CosmosPostgreSQL](./cosmospostgresql.md) | `cosmospostgresql` | 34 |
 | [Cosmosaccount](./cosmosaccount.md) | — (provider-native) | 0 |

--- a/docs/coverage/azure/containerinstances.md
+++ b/docs/coverage/azure/containerinstances.md
@@ -3,7 +3,7 @@
 
 Azure's `containerinstances` service · portable interface `driver.ContainerInstances` · [Azure index](./README.md)
 
-## Operations (9)
+## Operations (10)
 
 | Operation | Description |
 | --- | --- |
@@ -16,6 +16,7 @@ Azure's `containerinstances` service · portable interface `driver.ContainerInst
 | `RestartContainerGroup` | RestartContainerGroup restarts all containers in the group. Returns NotFound |
 | `StartContainerGroup` | StartContainerGroup starts all containers in a stopped group, allocating |
 | `StopContainerGroup` | StopContainerGroup stops all containers in the group and deallocates |
+| `UpdateContainerGroupTags` | UpdateContainerGroupTags merges tags into an existing group and returns it, |
 
 ## Not in scope
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -2746,6 +2746,10 @@
       {
         "name": "StopContainerGroup",
         "doc": "StopContainerGroup stops all containers in the group and deallocates"
+      },
+      {
+        "name": "UpdateContainerGroupTags",
+        "doc": "UpdateContainerGroupTags merges tags into an existing group and returns it,"
       }
     ],
     "providers": {

--- a/providers/azure/containerinstances/containerinstances.go
+++ b/providers/azure/containerinstances/containerinstances.go
@@ -188,6 +188,39 @@ func (m *Mock) restartOnFailure(
 	return handle, statuses, nil
 }
 
+// UpdateContainerGroupTags merges tags into an existing group and returns it,
+// leaving the running workload untouched (ARM "Container Groups - Update" is a
+// PATCH that updates a group's tags).
+func (m *Mock) UpdateContainerGroupTags(
+	_ context.Context, subscription, resourceGroup, name string, tags map[string]string,
+) (*driver.ContainerGroup, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := groupKey(subscription, resourceGroup, name)
+
+	data, ok := m.groups.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container group %q not found", name)
+	}
+
+	merged := make(map[string]string, len(data.group.Tags)+len(tags))
+	for k, v := range data.group.Tags {
+		merged[k] = v
+	}
+
+	for k, v := range tags {
+		merged[k] = v
+	}
+
+	data.group.Tags = merged
+	m.groups.Set(key, data)
+
+	out := data.group
+
+	return &out, nil
+}
+
 // GetContainerGroup returns the recorded group scoped to subscription and
 // resourceGroup.
 func (m *Mock) GetContainerGroup(_ context.Context, subscription, resourceGroup, name string) (*driver.ContainerGroup, error) {

--- a/providers/azure/sql/sql.go
+++ b/providers/azure/sql/sql.go
@@ -468,6 +468,7 @@ func (m *Mock) CreateCluster(_ context.Context, cfg rdsdriver.ClusterConfig) (*r
 		Location:       orDefault(cfg.Location, m.opts.Region),
 		CreatedAt:      m.opts.Clock.Now().UTC(),
 		Tags:           copyTags(cfg.Tags),
+		Scope:          cfg.Scope,
 	}
 
 	m.clusters.Set(cfg.ID, cluster)

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -1055,6 +1055,7 @@ func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver
 		IOPS:             cfg.IOPS,
 		Throughput:       cfg.Throughput,
 		Tier:             cfg.Tier,
+		Location:         cfg.Location,
 	}
 	m.volumes.Set(id, vol)
 
@@ -1088,6 +1089,10 @@ func (m *Mock) UpdateVolume(_ context.Context, id string, cfg driver.VolumeConfi
 
 	if cfg.Tier != "" {
 		vol.Tier = cfg.Tier
+	}
+
+	if cfg.Location != "" {
+		vol.Location = cfg.Location
 	}
 
 	vol.IOPS = cfg.IOPS

--- a/server/azure/aks/operations.go
+++ b/server/azure/aks/operations.go
@@ -16,6 +16,9 @@ func (h *Handler) createOrUpdateCluster(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
+	_, getErr := h.be.GetCluster(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	existed := getErr == nil
+
 	cluster, err := h.be.CreateOrUpdateCluster(r.Context(), buildClusterInput(&body, rp))
 	if err != nil {
 		azurearm.WriteCErr(w, err)
@@ -24,7 +27,14 @@ func (h *Handler) createOrUpdateCluster(w http.ResponseWriter, r *http.Request, 
 
 	pools, _ := h.be.ListAgentPools(r.Context(), rp.ResourceGroup, rp.ResourceName)
 
-	azurearm.WriteJSON(w, http.StatusOK, toARMCluster(cluster, pools, rp.Subscription))
+	// ARM PUT of a new resource returns 201 Created; an in-place update of an
+	// existing one returns 200.
+	status := http.StatusCreated
+	if existed {
+		status = http.StatusOK
+	}
+
+	azurearm.WriteJSON(w, status, toARMCluster(cluster, pools, rp.Subscription))
 }
 
 func buildClusterInput(body *armManagedCluster, rp *azurearm.ResourcePath) aks.ClusterInput {

--- a/server/azure/containerinstances/handler.go
+++ b/server/azure/containerinstances/handler.go
@@ -98,13 +98,20 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.serveNamedGroup(w, r, &rp)
+}
+
+// serveNamedGroup dispatches the method verbs on a single named container group.
+func (h *Handler) serveNamedGroup(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	switch r.Method {
 	case http.MethodPut:
-		h.createOrUpdateGroup(w, r, &rp)
+		h.createOrUpdateGroup(w, r, rp)
+	case http.MethodPatch:
+		h.updateGroup(w, r, rp)
 	case http.MethodGet:
-		h.getGroup(w, r, &rp)
+		h.getGroup(w, r, rp)
 	case http.MethodDelete:
-		h.deleteGroup(w, r, &rp)
+		h.deleteGroup(w, r, rp)
 	default:
 		writeMethodNotAllowed(w)
 	}

--- a/server/azure/containerinstances/operations.go
+++ b/server/azure/containerinstances/operations.go
@@ -37,6 +37,26 @@ func (h *Handler) createOrUpdateGroup(w http.ResponseWriter, r *http.Request, rp
 	azurearm.WriteJSON(w, status, toGroupJSON(rp, group))
 }
 
+// updateGroup handles PATCH — ContainerGroups.Update. Real Azure's Update is a
+// PATCH that merges the request tags into an existing group and returns it
+// (200). A missing group answers 404.
+func (h *Handler) updateGroup(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body containerGroupJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	group, err := h.aci.UpdateContainerGroupTags(
+		r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName, body.Tags)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toGroupJSON(rp, group))
+}
+
 // lifecycleGroup handles the POST start/stop/restart verbs. All three complete
 // inline and answer 204 No Content, terminating the SDK's begin-poller.
 func (h *Handler) lifecycleGroup(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {

--- a/server/azure/disks/handler.go
+++ b/server/azure/disks/handler.go
@@ -222,6 +222,10 @@ func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rp azu
 
 		name := tagOr(vols[i].Tags, armNameTag, vols[i].ID)
 		scope := rp
+		// On a subscription-scoped list rp.ResourceGroup is empty; use the disk's
+		// own recorded group so the rendered id carries its true
+		// resourceGroups/{rg} segment.
+		scope.ResourceGroup = tagOr(vols[i].Tags, rgTag, rp.ResourceGroup)
 		scope.ResourceName = name
 		out = append(out, h.toDiskResponse(r.Context(), &vols[i], scope, ""))
 	}
@@ -255,6 +259,7 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 		IOPS:       req.Properties.DiskIOPSReadWrite,
 		Throughput: req.Properties.DiskMBpsReadWrite,
 		Tier:       diskTier(req.Properties.Tier, skuTier(req.SKU)),
+		Location:   req.Location,
 		Tags:       mergeDiskTags(req.Tags, rp.ResourceName, rp.ResourceGroup, createOption, sourceID),
 	}
 
@@ -468,6 +473,12 @@ func writeDiskAsync(w http.ResponseWriter, r *http.Request, sub, opID string, bo
 func (h *Handler) toDiskResponse(
 	ctx context.Context, vol *computedriver.VolumeInfo, rp azurearm.ResourcePath, location string,
 ) diskResponse {
+	// On Get/List the caller passes no location; report the region the disk was
+	// created in (persisted on the volume) rather than always defaulting.
+	if location == "" {
+		location = vol.Location
+	}
+
 	if location == "" {
 		location = defaultLocation
 	}

--- a/server/azure/dns/types.go
+++ b/server/azure/dns/types.go
@@ -219,7 +219,15 @@ func privateFromZoneType(zt string) bool {
 // toZoneJSON converts a driver zone into its ARM element for the given path
 // scope. Azure DNS zones are always "global" location.
 func toZoneJSON(rp *azurearm.ResourcePath, info *dnsdriver.ZoneInfo) zoneJSON {
-	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeZones, info.Name)
+	// Build the id from the zone's own group, not the request path's — which is
+	// empty on a subscription-scoped list — so the id carries its true
+	// resourceGroups/{rg} segment.
+	rg := info.Scope.ResourceGroup
+	if rg == "" {
+		rg = rp.ResourceGroup
+	}
+
+	id := azurearm.BuildResourceID(rp.Subscription, rg, providerName, typeZones, info.Name)
 
 	return zoneJSON{
 		ID:       id,

--- a/server/azure/eventgrid/types.go
+++ b/server/azure/eventgrid/types.go
@@ -72,7 +72,15 @@ func topicEndpoint(name, location string) string {
 // toTopicJSON converts a driver event bus into its ARM Topic element for the
 // given path scope.
 func toTopicJSON(rp *azurearm.ResourcePath, info *ebdriver.EventBusInfo) topicJSON {
-	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeTopics, info.Name)
+	// Build the id (and the derived metricResourceId) from the topic's own
+	// group, not the request path's — which is empty on a subscription-scoped
+	// list — so the id carries its true resourceGroups/{rg} segment.
+	rg := info.Scope.ResourceGroup
+	if rg == "" {
+		rg = rp.ResourceGroup
+	}
+
+	id := azurearm.BuildResourceID(rp.Subscription, rg, providerName, typeTopics, info.Name)
 	loc := topicLocation(info)
 
 	inputSchema := info.InputSchema

--- a/server/azure/mysqlflex/operations.go
+++ b/server/azure/mysqlflex/operations.go
@@ -100,6 +100,10 @@ func (h *Handler) createServer(w http.ResponseWriter, r *http.Request, rp *azure
 		}
 	}
 
+	// ARM PUT of a new resource returns 201 Created; an in-place update of an
+	// existing one returns 200.
+	status := http.StatusCreated
+
 	inst, err := h.db.CreateInstance(r.Context(), cfg)
 	if err != nil {
 		if !cerrors.IsAlreadyExists(err) {
@@ -111,9 +115,11 @@ func (h *Handler) createServer(w http.ResponseWriter, r *http.Request, rp *azure
 		if inst, ok = h.upsertOnNameCollision(w, r, rp, &body); !ok {
 			return
 		}
+
+		status = http.StatusOK
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toARMServer(inst, rp.Subscription, rp.ResourceGroup))
+	azurearm.WriteJSON(w, status, toARMServer(inst, rp.Subscription, rp.ResourceGroup))
 }
 
 // upsertOnNameCollision resolves a PUT whose server name is already taken.
@@ -250,7 +256,15 @@ func (h *Handler) listServers(w http.ResponseWriter, r *http.Request, rp *azurea
 			continue
 		}
 
-		out = append(out, toARMServer(&insts[i], rp.Subscription, rp.ResourceGroup))
+		// Render the id from the server's own group, not the request path's
+		// (empty on a subscription-scoped list) — so the id carries its true
+		// resourceGroups/{rg} segment.
+		rg := insts[i].Scope.ResourceGroup
+		if rg == "" {
+			rg = rp.ResourceGroup
+		}
+
+		out = append(out, toARMServer(&insts[i], rp.Subscription, rg))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, armList[armServer]{Value: out})

--- a/server/azure/postgresflex/operations.go
+++ b/server/azure/postgresflex/operations.go
@@ -111,6 +111,10 @@ func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, r
 	cfg := instanceFromBody(&body, rp)
 	cfg.ID = rp.ResourceName
 
+	// ARM PUT of a new resource returns 201 Created; an in-place update of an
+	// existing one returns 200.
+	status := http.StatusCreated
+
 	inst, err := h.db.CreateInstance(r.Context(), cfg)
 	if err != nil {
 		if !cerrors.IsAlreadyExists(err) {
@@ -122,9 +126,11 @@ func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, r
 		if inst, ok = h.upsertOnNameCollision(w, r, rp, &body); !ok {
 			return
 		}
+
+		status = http.StatusOK
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toARMServer(inst, rp.Subscription, rp.ResourceGroup))
+	azurearm.WriteJSON(w, status, toARMServer(inst, rp.Subscription, rp.ResourceGroup))
 }
 
 // upsertOnNameCollision resolves a PUT whose server name is already taken.
@@ -281,7 +287,15 @@ func (h *Handler) listServers(w http.ResponseWriter, r *http.Request, rp *azurea
 			continue
 		}
 
-		out = append(out, toARMServer(&insts[i], rp.Subscription, rp.ResourceGroup))
+		// Render the id from the server's own group, not the request path's
+		// (empty on a subscription-scoped list) — so the id carries its true
+		// resourceGroups/{rg} segment.
+		rg := insts[i].Scope.ResourceGroup
+		if rg == "" {
+			rg = rp.ResourceGroup
+		}
+
+		out = append(out, toARMServer(&insts[i], rp.Subscription, rg))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, armList[armServer]{Value: out})

--- a/server/azure/queue_servicebus_routing_test.go
+++ b/server/azure/queue_servicebus_routing_test.go
@@ -105,7 +105,7 @@ func nsScope() string {
 func seedSBNamespace(t *testing.T, ts *httptest.Server) {
 	t.Helper()
 
-	sbDo(t, ts, http.MethodPut, nsScope()+sbAPIVer, `{"location":"eastus"}`, http.StatusOK)
+	sbDo(t, ts, http.MethodPut, nsScope()+sbAPIVer, `{"location":"eastus"}`, http.StatusCreated)
 }
 
 // newStorageQueueClient returns an azqueue client for a named Storage queue on

--- a/server/azure/servicebus/dataplane_topic_test.go
+++ b/server/azure/servicebus/dataplane_topic_test.go
@@ -182,7 +182,7 @@ func TestDataPlaneSubscriptionDeleteDrainsStore(t *testing.T) {
 func TestNamespaceCaseInsensitive(t *testing.T) {
 	srv, _ := newTestServer(t)
 
-	if r := doRequest(t, srv, http.MethodPut, nsURLNamed("Case-NS")+apiVer, `{"location":"eastus"}`); r.StatusCode != http.StatusOK {
+	if r := doRequest(t, srv, http.MethodPut, nsURLNamed("Case-NS")+apiVer, `{"location":"eastus"}`); r.StatusCode != http.StatusCreated {
 		t.Fatalf("create namespace = %d", r.StatusCode)
 	}
 

--- a/server/azure/servicebus/namespace.go
+++ b/server/azure/servicebus/namespace.go
@@ -67,7 +67,14 @@ func (h *Handler) createNamespace(w http.ResponseWriter, r *http.Request, sp sbP
 	resource := toNamespaceResource(ns)
 	h.mu.Unlock()
 
-	azurearm.WriteJSON(w, http.StatusOK, resource)
+	// ARM PUT of a new resource returns 201 Created; an in-place update of an
+	// existing one returns 200.
+	status := http.StatusCreated
+	if existed {
+		status = http.StatusOK
+	}
+
+	azurearm.WriteJSON(w, status, resource)
 }
 
 func (h *Handler) updateNamespace(w http.ResponseWriter, r *http.Request, sp sbPath) {

--- a/server/azure/servicebus/servicebus_test.go
+++ b/server/azure/servicebus/servicebus_test.go
@@ -45,7 +45,7 @@ func seedNamespace(t *testing.T, srv *httptest.Server) {
 	t.Helper()
 
 	resp := doRequest(t, srv, http.MethodPut, nsURL()+apiVer, `{"location":"eastus"}`)
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusCreated {
 		t.Fatalf("seed namespace = %d", resp.StatusCode)
 	}
 
@@ -60,7 +60,7 @@ func TestNamespaceLifecycle(t *testing.T) {
 	srv, _ := newTestServer(t)
 
 	put := doRequest(t, srv, http.MethodPut, nsURL()+apiVer, `{"location":"eastus"}`)
-	if put.StatusCode != http.StatusOK {
+	if put.StatusCode != http.StatusCreated {
 		t.Fatalf("PUT namespace = %d", put.StatusCode)
 	}
 

--- a/server/azure/sql/operations.go
+++ b/server/azure/sql/operations.go
@@ -7,6 +7,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // ---- Server (logical) ops ----
@@ -29,12 +30,17 @@ func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, r
 		}),
 		EngineVersion: reqVersion,
 		Tags:          body.Tags,
+		Scope:         scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
 	}
 
 	// Azure SQL synthesizes version "12.0" when a server create omits it.
 	if cfg.EngineVersion == "" {
 		cfg.EngineVersion = defaultServerVersion
 	}
+
+	// ARM PUT of a new resource returns 201 Created; an in-place update of an
+	// existing one returns 200.
+	status := http.StatusCreated
 
 	cluster, err := h.db.CreateCluster(r.Context(), cfg)
 	if err != nil {
@@ -55,9 +61,11 @@ func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, r
 			azurearm.WriteCErr(w, err)
 			return
 		}
+
+		status = http.StatusOK
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toARMServer(cluster, rp.Subscription, rp.ResourceGroup))
+	azurearm.WriteJSON(w, status, toARMServer(cluster, rp.Subscription, rp.ResourceGroup))
 }
 
 func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
@@ -113,9 +121,24 @@ func (h *Handler) listServers(w http.ResponseWriter, r *http.Request, rp *azurea
 		return
 	}
 
+	filter := scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}
+
 	out := make([]armServer, 0, len(clusters))
+
 	for i := range clusters {
-		out = append(out, toARMServer(&clusters[i], rp.Subscription, rp.ResourceGroup))
+		if !clusters[i].Scope.Matches(filter) {
+			continue
+		}
+
+		// Render the id from the server's own group, not the request path's
+		// (empty on a subscription-scoped list) — so the id carries its true
+		// resourceGroups/{rg} segment.
+		rg := clusters[i].Scope.ResourceGroup
+		if rg == "" {
+			rg = rp.ResourceGroup
+		}
+
+		out = append(out, toARMServer(&clusters[i], rp.Subscription, rg))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, armList[armServer]{Value: out})

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -576,6 +576,10 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, rp azurearm.Resou
 
 		name := tagOr(instances[i].Tags, armNameTag, instances[i].ID)
 		scope := rp
+		// On a subscription-scoped list rp.ResourceGroup is empty; use the
+		// instance's own recorded group so the rendered id carries its true
+		// resourceGroups/{rg} segment (arm.ParseResourceID / Terraform state).
+		scope.ResourceGroup = instances[i].ResourceGroup
 		scope.ResourceName = name
 		out = append(out, h.buildVMResponse(r.Context(), &instances[i], scope, vmRequest{}, provisioningSucceeded))
 	}

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -52,6 +52,12 @@ const (
 	// are already scoped.
 	armVNetRGTag = "cloudemu:azureVNetResourceGroup"
 	armNSGRGTag  = "cloudemu:azureNSGResourceGroup"
+	// armSyntheticAnchorTag marks a VPC that was fabricated purely to satisfy the
+	// networking driver's mandatory VPCID when creating a standalone NSG or route
+	// table (which are top-level, VNet-independent resources in Azure). Such an
+	// anchor is internal plumbing, not a user resource, so it is excluded from the
+	// virtualNetworks list/get responses.
+	armSyntheticAnchorTag = "cloudemu:azureSyntheticVNetAnchor"
 	// armSubnetNATTag stores the full ARM resource id of the NAT gateway a
 	// subnet is associated with (set via the subnet's own natGateway
 	// property), so both the subnet response and the NAT gateway's
@@ -515,6 +521,12 @@ func (h *Handler) listVNets(w http.ResponseWriter, r *http.Request, rp azurearm.
 	out := vnetListResponse{}
 
 	for i := range infos {
+		// Skip anchors fabricated only to satisfy the driver's mandatory VPCID
+		// when creating a standalone NSG/route table — they are not user vnets.
+		if tagOr(infos[i].Tags, armSyntheticAnchorTag, "") == "true" {
+			continue
+		}
+
 		itemRG := tagOr(infos[i].Tags, armVNetRGTag, "")
 		// An RG-scoped list (rp.ResourceGroup set) returns only that group's
 		// networks; a subscription-scoped list (empty) returns all, each stamped
@@ -1213,7 +1225,10 @@ func (h *Handler) upsertNSG(ctx context.Context, rg, name string,
 	if len(vpcs) > 0 {
 		anchor = vpcs[0].ID
 	} else {
-		v, vErr := h.net.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		v, vErr := h.net.CreateVPC(ctx, netdriver.VPCConfig{
+			CIDRBlock: "10.0.0.0/16",
+			Tags:      map[string]string{armSyntheticAnchorTag: "true"},
+		})
 		if vErr != nil {
 			return nil, vErr
 		}

--- a/server/azure/vnet/route_table.go
+++ b/server/azure/vnet/route_table.go
@@ -85,7 +85,10 @@ func (h *Handler) upsertRouteTable(ctx context.Context, rg, name string) (*netdr
 	if len(vpcs) > 0 {
 		anchor = vpcs[0].ID
 	} else {
-		v, vErr := h.net.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		v, vErr := h.net.CreateVPC(ctx, netdriver.VPCConfig{
+			CIDRBlock: "10.0.0.0/16",
+			Tags:      map[string]string{armSyntheticAnchorTag: "true"},
+		})
 		if vErr != nil {
 			return nil, vErr
 		}

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -397,6 +397,10 @@ type VolumeConfig struct {
 	SnapshotID string
 	// KmsKeyID is the KMS key protecting the volume's encryption key, when set.
 	KmsKeyID string
+	// Location is the Azure region the managed disk is created in (ARM disk
+	// top-level "location"), persisted so Get/List report where it lives.
+	// Empty for AWS/GCP, which locate volumes by AvailabilityZone.
+	Location string
 }
 
 // VolumeInfo describes a block storage volume.
@@ -422,6 +426,9 @@ type VolumeInfo struct {
 	SnapshotID string
 	// KmsKeyID is the KMS key protecting the volume's encryption key, when set.
 	KmsKeyID string
+	// Location is the Azure region the managed disk was created in (ARM disk
+	// top-level "location"). Empty for AWS/GCP.
+	Location string
 }
 
 // SnapshotConfig describes a snapshot to create.

--- a/services/containerinstances/driver/driver.go
+++ b/services/containerinstances/driver/driver.go
@@ -126,6 +126,14 @@ type ContainerInstances interface {
 	// NotFound when the group does not exist.
 	DeleteContainerGroup(ctx context.Context, subscription, resourceGroup, name string) error
 
+	// UpdateContainerGroupTags merges tags into an existing group and returns it,
+	// leaving the running workload untouched. This backs ARM "Container Groups -
+	// Update", a PATCH that updates a group's tags. Returns NotFound when the
+	// group does not exist.
+	UpdateContainerGroupTags(
+		ctx context.Context, subscription, resourceGroup, name string, tags map[string]string,
+	) (*ContainerGroup, error)
+
 	// ListContainerGroups returns the groups visible under filter.
 	ListContainerGroups(ctx context.Context, filter scope.Scope) ([]ContainerGroup, error)
 

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -319,6 +319,9 @@ type ClusterConfig struct {
 	// top-level "location"). Empty for AWS/GCP.
 	Location string
 	Tags     map[string]string
+	// Scope records where an Azure SQL logical server lives (subscription/
+	// resource group). Zero for AWS/GCP and unscoped portable callers.
+	Scope scope.Scope
 }
 
 // Cluster describes an Aurora-style database cluster.
@@ -366,6 +369,9 @@ type Cluster struct {
 	Location  string
 	CreatedAt time.Time
 	Tags      map[string]string
+	// Scope records where an Azure SQL logical server lives (subscription/
+	// resource group). Zero for AWS/GCP and unscoped portable callers.
+	Scope scope.Scope
 }
 
 // SnapshotConfig configures an instance snapshot.


### PR DESCRIPTION
Pre-release acceptance findings (Azure). Fixes: (HIGH) malformed resourceGroups// IDs on list-by-subscription across VM/disks/SQL/mysqlFlex/postgresFlex/EventGrid/DNS; (HIGH) standalone NSG/route-table no longer fabricates a listable phantom VNet; (MED) managed disk location persisted; (MED) ACI containerGroups PATCH; (LOW) 201 on create for mysqlFlex/postgresFlex/SQL/ServiceBus/AKS. Adds a shared compute VolumeInfo.Location field (AWS/GCP unaffected, full vet + cross-provider compat green). Real-SDK repro tests added; coverage regenerated.