### PR TITLE
fix(aws): Terraform-blocking gaps — EC2 instance attributes, Lambda code-signing route, DynamoDB PPR GSI throughput

### DIFF
--- a/compat/aws/terraform_iac_compat_test.go
+++ b/compat/aws/terraform_iac_compat_test.go
@@ -1,0 +1,266 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsdynamodb "github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/internal/compat"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// These tests reproduce the read-back / routing / error-shape gaps that made
+// `terraform apply/plan/destroy` against the hashicorp/aws provider fail. They
+// drive the real aws-sdk-go-v2 clients (the SDK Terraform uses) against the
+// in-process wire server. They intentionally do NOT record compat-matrix cells
+// (no sess.Op) — they assert the exact shapes the provider depends on.
+
+// TestTerraformEC2InstanceAttributes covers the aws_instance apply blocker: the
+// provider reads DescribeInstanceAttribute for instanceInitiatedShutdownBehavior,
+// disableApiStop and disableApiTermination, which previously errored with
+// InvalidParameterValue and aborted the apply.
+func TestTerraformEC2InstanceAttributes(t *testing.T) {
+	provider := cloudemu.NewAWS()
+	sess := compat.BootAWS(t, awsserver.Drivers{EC2: provider.EC2})
+
+	client := awsec2.NewFromConfig(sess.Config(), func(o *awsec2.Options) {
+		o.BaseEndpoint = aws.String(sess.Endpoint())
+	})
+	ctx := context.Background()
+
+	run, err := client.RunInstances(ctx, &awsec2.RunInstancesInput{
+		ImageId:      aws.String("ami-12345678"),
+		InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	id := aws.ToString(run.Instances[0].InstanceId)
+
+	// instanceInitiatedShutdownBehavior defaults to "stop".
+	shutdown, err := client.DescribeInstanceAttribute(ctx, &awsec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String(id),
+		Attribute:  ec2types.InstanceAttributeNameInstanceInitiatedShutdownBehavior,
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstanceAttribute(instanceInitiatedShutdownBehavior): %v", err)
+	}
+
+	if shutdown.InstanceInitiatedShutdownBehavior == nil ||
+		aws.ToString(shutdown.InstanceInitiatedShutdownBehavior.Value) != "stop" {
+		t.Fatalf("instanceInitiatedShutdownBehavior = %+v, want stop", shutdown.InstanceInitiatedShutdownBehavior)
+	}
+
+	// disableApiStop defaults to false.
+	stop, err := client.DescribeInstanceAttribute(ctx, &awsec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String(id),
+		Attribute:  ec2types.InstanceAttributeNameDisableApiStop,
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstanceAttribute(disableApiStop): %v", err)
+	}
+
+	if stop.DisableApiStop == nil || aws.ToBool(stop.DisableApiStop.Value) {
+		t.Fatalf("disableApiStop = %+v, want false", stop.DisableApiStop)
+	}
+
+	// disableApiTermination defaults to false.
+	term, err := client.DescribeInstanceAttribute(ctx, &awsec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String(id),
+		Attribute:  ec2types.InstanceAttributeNameDisableApiTermination,
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstanceAttribute(disableApiTermination): %v", err)
+	}
+
+	if term.DisableApiTermination == nil || aws.ToBool(term.DisableApiTermination.Value) {
+		t.Fatalf("disableApiTermination = %+v, want false", term.DisableApiTermination)
+	}
+
+	// A ModifyInstanceAttribute round-trips through DescribeInstanceAttribute.
+	if _, err := client.ModifyInstanceAttribute(ctx, &awsec2.ModifyInstanceAttributeInput{
+		InstanceId:                        aws.String(id),
+		InstanceInitiatedShutdownBehavior: &ec2types.AttributeValue{Value: aws.String("terminate")},
+	}); err != nil {
+		t.Fatalf("ModifyInstanceAttribute(instanceInitiatedShutdownBehavior): %v", err)
+	}
+
+	got, err := client.DescribeInstanceAttribute(ctx, &awsec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String(id),
+		Attribute:  ec2types.InstanceAttributeNameInstanceInitiatedShutdownBehavior,
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstanceAttribute after modify: %v", err)
+	}
+
+	if aws.ToString(got.InstanceInitiatedShutdownBehavior.Value) != "terminate" {
+		t.Fatalf("instanceInitiatedShutdownBehavior after modify = %q, want terminate",
+			aws.ToString(got.InstanceInitiatedShutdownBehavior.Value))
+	}
+}
+
+// TestTerraformLambdaCodeSigningConfig covers the aws_lambda_function apply
+// blocker: the provider reads GetFunctionCodeSigningConfig on every function
+// refresh. The request previously fell through to the S3 catch-all and returned
+// XML the REST-JSON client could not parse.
+func TestTerraformLambdaCodeSigningConfig(t *testing.T) {
+	provider := cloudemu.NewAWS()
+	sess := compat.BootAWS(t, awsserver.Drivers{Lambda: provider.Lambda})
+
+	client := awslambda.NewFromConfig(sess.Config(), func(o *awslambda.Options) {
+		o.BaseEndpoint = aws.String(sess.Endpoint())
+	})
+	ctx := context.Background()
+
+	const fnName = "tf-fn"
+
+	if _, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String(fnName),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("fake-zip")},
+	}); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	out, err := client.GetFunctionCodeSigningConfig(ctx, &awslambda.GetFunctionCodeSigningConfigInput{
+		FunctionName: aws.String(fnName),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionCodeSigningConfig: %v", err)
+	}
+
+	if aws.ToString(out.FunctionName) != fnName {
+		t.Fatalf("FunctionName = %q, want %q", aws.ToString(out.FunctionName), fnName)
+	}
+
+	if aws.ToString(out.CodeSigningConfigArn) != "" {
+		t.Fatalf("CodeSigningConfigArn = %q, want empty (no config)", aws.ToString(out.CodeSigningConfigArn))
+	}
+
+	// A missing function still 404s (typed ResourceNotFoundException).
+	_, err = client.GetFunctionCodeSigningConfig(ctx, &awslambda.GetFunctionCodeSigningConfigInput{
+		FunctionName: aws.String("nope"),
+	})
+
+	var rnf *lambdatypes.ResourceNotFoundException
+	if !errors.As(err, &rnf) {
+		t.Fatalf("GetFunctionCodeSigningConfig(missing) error = %v, want ResourceNotFoundException", err)
+	}
+}
+
+// TestTerraformDynamoDBPPRGSIThroughput covers the PAY_PER_REQUEST + GSI
+// perpetual-drift blocker: each GSI must read back with its IndexName and a
+// ProvisionedThroughput block of zeros, or the provider blanks the index and
+// re-plans it forever.
+func TestTerraformDynamoDBPPRGSIThroughput(t *testing.T) {
+	provider := cloudemu.NewAWS()
+	sess := compat.BootAWS(t, awsserver.Drivers{DynamoDB: provider.DynamoDB})
+
+	client := awsdynamodb.NewFromConfig(sess.Config(), func(o *awsdynamodb.Options) {
+		o.BaseEndpoint = aws.String(sess.Endpoint())
+	})
+	ctx := context.Background()
+
+	const (
+		tableName = "tf-ppr"
+		indexName = "gsi1"
+	)
+
+	if _, err := client.CreateTable(ctx, &awsdynamodb.CreateTableInput{
+		TableName:   aws.String(tableName),
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("sort"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash},
+		},
+		GlobalSecondaryIndexes: []ddbtypes.GlobalSecondaryIndex{{
+			IndexName: aws.String(indexName),
+			KeySchema: []ddbtypes.KeySchemaElement{
+				{AttributeName: aws.String("sort"), KeyType: ddbtypes.KeyTypeHash},
+			},
+			Projection: &ddbtypes.Projection{ProjectionType: ddbtypes.ProjectionTypeAll},
+		}},
+	}); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	desc, err := client.DescribeTable(ctx, &awsdynamodb.DescribeTableInput{TableName: aws.String(tableName)})
+	if err != nil {
+		t.Fatalf("DescribeTable: %v", err)
+	}
+
+	gsis := desc.Table.GlobalSecondaryIndexes
+	if len(gsis) != 1 {
+		t.Fatalf("GlobalSecondaryIndexes = %d, want 1", len(gsis))
+	}
+
+	if aws.ToString(gsis[0].IndexName) != indexName {
+		t.Fatalf("GSI IndexName = %q, want %q", aws.ToString(gsis[0].IndexName), indexName)
+	}
+
+	pt := gsis[0].ProvisionedThroughput
+	if pt == nil {
+		t.Fatal("GSI ProvisionedThroughput is nil; TF blanks the index and re-plans forever")
+	}
+
+	if aws.ToInt64(pt.ReadCapacityUnits) != 0 || aws.ToInt64(pt.WriteCapacityUnits) != 0 {
+		t.Fatalf("GSI ProvisionedThroughput = r%d/w%d, want 0/0 for PAY_PER_REQUEST",
+			aws.ToInt64(pt.ReadCapacityUnits), aws.ToInt64(pt.WriteCapacityUnits))
+	}
+}
+
+// TestTerraformSQSNonExistentQueue covers the destroy blocker: the provider's
+// delete waiter polls GetQueueAttributes on the deleted queue and must see the
+// typed QueueDoesNotExist error to treat the queue as gone. That typed error only
+// deserializes when the JSON __type is the modeled shape name "QueueDoesNotExist"
+// (not the legacy query code), so this locks that shape in.
+func TestTerraformSQSNonExistentQueue(t *testing.T) {
+	provider := cloudemu.NewAWS()
+	sess := compat.BootAWS(t, awsserver.Drivers{SQS: provider.SQS})
+
+	client := awssqs.NewFromConfig(sess.Config(), func(o *awssqs.Options) {
+		o.BaseEndpoint = aws.String(sess.Endpoint())
+	})
+	ctx := context.Background()
+
+	created, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("tf-doomed")})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	if _, err := client.DeleteQueue(ctx, &awssqs.DeleteQueueInput{QueueUrl: created.QueueUrl}); err != nil {
+		t.Fatalf("DeleteQueue: %v", err)
+	}
+
+	_, err = client.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       created.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameAll},
+	})
+	if err == nil {
+		t.Fatal("GetQueueAttributes on deleted queue returned nil error, want QueueDoesNotExist")
+	}
+
+	var qdne *sqstypes.QueueDoesNotExist
+	if !errors.As(err, &qdne) {
+		t.Fatalf("GetQueueAttributes error = %v, want typed *QueueDoesNotExist", err)
+	}
+}

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -183,6 +183,14 @@ type instanceData struct {
 	// ebsOptimized is the EBS-optimized flag toggled via
 	// ModifyInstanceAttribute(EbsOptimized).
 	ebsOptimized bool
+	// disableAPIStop is the stop-protection flag set via
+	// ModifyInstanceAttribute(DisableApiStop), read back by
+	// DescribeInstanceAttribute(disableApiStop). Defaults false.
+	disableAPIStop bool
+	// shutdownBehavior is the instance-initiated shutdown behavior
+	// ("stop"/"terminate") set via ModifyInstanceAttribute; empty means the
+	// default "stop".
+	shutdownBehavior string
 	// reservationID groups all instances launched by one RunInstances call under
 	// a shared AWS reservation (r-xxxx).
 	reservationID string
@@ -1259,6 +1267,13 @@ const (
 	attrUserData              = "userData"
 	attrEbsOptimized          = "ebsOptimized"
 	attrMonitoring            = "monitoring"
+
+	attrInstanceInitiatedShutdownBehavior = "instanceInitiatedShutdownBehavior"
+	attrDisableAPIStop                    = "disableApiStop"
+
+	// shutdownBehaviorStop is the default instanceInitiatedShutdownBehavior
+	// value, matching real EC2 (the alternative is "terminate").
+	shutdownBehaviorStop = "stop"
 )
 
 // SetInstanceAttribute updates a single instance attribute in place. It backs
@@ -1282,6 +1297,10 @@ func (m *Mock) SetInstanceAttribute(_ context.Context, instanceID, name, value s
 		inst.sourceDestCheck = parseBool(value)
 	case attrEbsOptimized:
 		inst.ebsOptimized = parseBool(value)
+	case attrDisableAPIStop:
+		inst.disableAPIStop = parseBool(value)
+	case attrInstanceInitiatedShutdownBehavior:
+		inst.shutdownBehavior = value
 	case attrUserData:
 		inst.userData = value
 	case attrMonitoring:
@@ -1331,21 +1350,53 @@ func (m *Mock) GetInstanceAttribute(_ context.Context, instanceID, name string) 
 	inst.mu.Lock()
 	defer inst.mu.Unlock()
 
+	if v, ok := inst.boolAttribute(name); ok {
+		return strconv.FormatBool(v), nil
+	}
+
+	if v, ok := inst.stringAttribute(name); ok {
+		return v, nil
+	}
+
+	return "", cerrors.Newf(cerrors.InvalidArgument, "unsupported instance attribute %q", name)
+}
+
+// boolAttribute returns the boolean instance attribute named by name and whether
+// name is a boolean attribute. Caller holds inst.mu.
+func (d *instanceData) boolAttribute(name string) (value, ok bool) {
 	switch name {
 	case attrDisableAPITermination:
-		return strconv.FormatBool(inst.disableAPITermination), nil
+		return d.disableAPITermination, true
 	case attrSourceDestCheck:
-		return strconv.FormatBool(inst.sourceDestCheck), nil
+		return d.sourceDestCheck, true
 	case attrEbsOptimized:
-		return strconv.FormatBool(inst.ebsOptimized), nil
-	case attrInstanceType:
-		return inst.InstanceType, nil
-	case attrUserData:
-		return inst.userData, nil
-	case attrMonitoring:
-		return inst.monitoring, nil
+		return d.ebsOptimized, true
+	case attrDisableAPIStop:
+		return d.disableAPIStop, true
 	default:
-		return "", cerrors.Newf(cerrors.InvalidArgument, "unsupported instance attribute %q", name)
+		return false, false
+	}
+}
+
+// stringAttribute returns the string instance attribute named by name and whether
+// name is a string attribute. instanceInitiatedShutdownBehavior defaults to
+// "stop" when unset. Caller holds inst.mu.
+func (d *instanceData) stringAttribute(name string) (value string, ok bool) {
+	switch name {
+	case attrInstanceInitiatedShutdownBehavior:
+		if d.shutdownBehavior == "" {
+			return shutdownBehaviorStop, true
+		}
+
+		return d.shutdownBehavior, true
+	case attrInstanceType:
+		return d.InstanceType, true
+	case attrUserData:
+		return d.userData, true
+	case attrMonitoring:
+		return d.monitoring, true
+	default:
+		return "", false
 	}
 }
 

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -576,10 +576,20 @@ func gsiDescriptions(cfg *dbdriver.TableConfig, billing string) []map[string]any
 			"IndexSizeBytes": 0,
 		}
 
+		// Real AWS attaches ProvisionedThroughput to every GSI, including on a
+		// PAY_PER_REQUEST table where the capacities read back as zero. Omitting it
+		// there makes the Terraform provider blank the whole index element (name
+		// included), producing a perpetual add/remove diff — so emit zeros.
 		if billing == billingProvisioned {
 			desc["ProvisionedThroughput"] = map[string]any{
 				"ReadCapacityUnits":      cfg.ReadCapacityUnits,
 				"WriteCapacityUnits":     cfg.WriteCapacityUnits,
+				"NumberOfDecreasesToday": 0,
+			}
+		} else {
+			desc["ProvisionedThroughput"] = map[string]any{
+				"ReadCapacityUnits":      0,
+				"WriteCapacityUnits":     0,
 				"NumberOfDecreasesToday": 0,
 			}
 		}

--- a/server/aws/ec2/operations.go
+++ b/server/aws/ec2/operations.go
@@ -36,6 +36,9 @@ const (
 	attrEbsOptimized          = "ebsOptimized"
 	attrGroupSet              = "groupSet"
 	attrMonitoring            = "monitoring"
+
+	attrInstanceInitiatedShutdownBehavior = "instanceInitiatedShutdownBehavior"
+	attrDisableAPIStop                    = "disableApiStop"
 )
 
 // reservationPrefix is the AWS reservation ID prefix (r-xxxx).
@@ -441,7 +444,10 @@ func (h *Handler) applyInstanceAttributes(r *http.Request, id string) error {
 		return nil
 	}
 
-	for _, name := range []string{attrDisableAPITermination, attrSourceDestCheck, attrEbsOptimized, attrUserData} {
+	for _, name := range []string{
+		attrDisableAPITermination, attrSourceDestCheck, attrEbsOptimized, attrUserData,
+		attrDisableAPIStop, attrInstanceInitiatedShutdownBehavior,
+	} {
 		if v := r.Form.Get(attrForm(name) + ".Value"); v != "" {
 			if err := attributer.SetInstanceAttribute(r.Context(), id, name, v); err != nil {
 				return err
@@ -497,6 +503,15 @@ func (h *Handler) describeInstanceAttribute(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	setInstanceAttributeField(&resp, attr, val)
+
+	awsquery.WriteXMLResponse(w, resp)
+}
+
+// setInstanceAttributeField places the read attribute value into the matching
+// field of resp. Boolean attributes wrap val == "true"; string attributes carry
+// val verbatim. Each DescribeInstanceAttribute response holds exactly one.
+func setInstanceAttributeField(resp *describeInstanceAttributeResponse, attr, val string) {
 	switch attr {
 	case attrDisableAPITermination:
 		resp.DisableAPITermination = &attributeBooleanValueXML{Value: val == formTrue}
@@ -504,13 +519,15 @@ func (h *Handler) describeInstanceAttribute(w http.ResponseWriter, r *http.Reque
 		resp.SourceDestCheck = &attributeBooleanValueXML{Value: val == formTrue}
 	case attrEbsOptimized:
 		resp.EBSOptimized = &attributeBooleanValueXML{Value: val == formTrue}
+	case attrDisableAPIStop:
+		resp.DisableAPIStop = &attributeBooleanValueXML{Value: val == formTrue}
+	case attrInstanceInitiatedShutdownBehavior:
+		resp.ShutdownBehavior = &attributeValueXML{Value: val}
 	case attrInstanceType:
 		resp.InstanceType = &attributeValueXML{Value: val}
 	case attrUserData:
 		resp.UserData = &attributeValueXML{Value: val}
 	}
-
-	awsquery.WriteXMLResponse(w, resp)
 }
 
 // attachInstanceGroups populates resp.Groups from the instance's current
@@ -543,6 +560,10 @@ func attrForm(name string) string {
 		return "SourceDestCheck"
 	case attrEbsOptimized:
 		return "EbsOptimized"
+	case attrDisableAPIStop:
+		return "DisableApiStop"
+	case attrInstanceInitiatedShutdownBehavior:
+		return "InstanceInitiatedShutdownBehavior"
 	case attrUserData:
 		return "UserData"
 	default:

--- a/server/aws/ec2/xml.go
+++ b/server/aws/ec2/xml.go
@@ -268,8 +268,10 @@ type describeInstanceAttributeResponse struct {
 	DisableAPITermination *attributeBooleanValueXML `xml:"disableApiTermination,omitempty"`
 	SourceDestCheck       *attributeBooleanValueXML `xml:"sourceDestCheck,omitempty"`
 	EBSOptimized          *attributeBooleanValueXML `xml:"ebsOptimized,omitempty"`
+	DisableAPIStop        *attributeBooleanValueXML `xml:"disableApiStop,omitempty"`
 	InstanceType          *attributeValueXML        `xml:"instanceType,omitempty"`
 	UserData              *attributeValueXML        `xml:"userData,omitempty"`
+	ShutdownBehavior      *attributeValueXML        `xml:"instanceInitiatedShutdownBehavior,omitempty"`
 	Groups                []groupItem               `xml:"groupSet>item,omitempty"`
 }
 

--- a/server/aws/lambda/code_signing.go
+++ b/server/aws/lambda/code_signing.go
@@ -1,0 +1,65 @@
+package lambda
+
+import (
+	"net/http"
+	"strings"
+)
+
+// isCodeSigningPath reports whether path is a function code-signing-config
+// sub-resource (/2020-06-30/functions/{name}/code-signing-config).
+func isCodeSigningPath(path string) bool {
+	_, ok := codeSigningFunctionName(path)
+
+	return ok
+}
+
+// codeSigningFunctionName extracts the function name from a code-signing-config
+// path and whether the path is one. The name is a single segment between the
+// version prefix and the /code-signing-config suffix.
+func codeSigningFunctionName(path string) (string, bool) {
+	if !strings.HasPrefix(path, codeSigningPrefix) || !strings.HasSuffix(path, codeSigningSuffix) {
+		return "", false
+	}
+
+	rest := strings.TrimPrefix(strings.TrimPrefix(path, codeSigningPrefix), "/")
+	name := strings.TrimSuffix(rest, codeSigningSuffix)
+
+	if name == "" || strings.Contains(name, "/") {
+		return "", false
+	}
+
+	return name, true
+}
+
+// serveFunctionCodeSigningConfig handles the code-signing-config sub-resource.
+// cloudemu does not associate code-signing configs with functions, so a GET on
+// an existing function returns 200 with an empty CodeSigningConfigArn (matching
+// a function that has none). The function's existence is still validated so a
+// missing function 404s. Terraform's function read calls this on every refresh;
+// before this route existed the request fell through to the S3 catch-all and
+// returned XML the REST-JSON client could not parse.
+func (h *Handler) serveFunctionCodeSigningConfig(w http.ResponseWriter, r *http.Request) {
+	name, ok := codeSigningFunctionName(r.URL.Path)
+	if !ok {
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "unsupported Lambda path")
+		return
+	}
+
+	if _, err := h.fn.GetFunction(r.Context(), name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, map[string]any{
+			"FunctionName":         name,
+			"CodeSigningConfigArn": "",
+		})
+	case http.MethodDelete:
+		// No config is stored, so removal is a no-op that AWS answers 204.
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "unsupported method for code-signing-config")
+	}
+}

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -60,6 +60,16 @@ const layersPrefix = "/2018-10-31/layers"
 // 2021-10-31, so it needs its own Matches clause.
 const functionURLPrefix = "/2021-10-31/functions"
 
+// Function code-signing-config sub-resource (GetFunctionCodeSigningConfig et al).
+// Versioned under 2020-06-30 on the {name}/code-signing-config sub-resource, so
+// it needs its own Matches clause — otherwise the REST-JSON request falls through
+// to the S3 catch-all, which returns XML the Lambda client can't parse. Terraform
+// reads it on every function refresh.
+const (
+	codeSigningPrefix = "/2020-06-30/functions"
+	codeSigningSuffix = "/code-signing-config"
+)
+
 // subVersions is the "versions" path segment shared by the function-versions
 // route (/functions/{name}/versions) and the layer-versions routes.
 const subVersions = "versions"
@@ -194,7 +204,8 @@ func (*Handler) Matches(r *http.Request) bool {
 		strings.HasPrefix(r.URL.Path, concurrencyWritePrefix) ||
 		strings.HasPrefix(r.URL.Path, concurrencyReadPrefix) ||
 		strings.HasPrefix(r.URL.Path, layersPrefix) ||
-		strings.HasPrefix(r.URL.Path, functionURLPrefix)
+		strings.HasPrefix(r.URL.Path, functionURLPrefix) ||
+		isCodeSigningPath(r.URL.Path)
 }
 
 // ServeHTTP dispatches Lambda operations based on path shape and method.
@@ -259,6 +270,8 @@ func (h *Handler) routePrefixed(w http.ResponseWriter, r *http.Request) bool {
 		h.serveLayers(w, r)
 	case strings.HasPrefix(r.URL.Path, functionURLPrefix):
 		h.serveFunctionURL(w, r)
+	case isCodeSigningPath(r.URL.Path):
+		h.serveFunctionCodeSigningConfig(w, r)
 	default:
 		name, ok := concurrencyFunctionName(r.URL.Path)
 		if !ok {

--- a/server/aws/sqs/handler.go
+++ b/server/aws/sqs/handler.go
@@ -22,6 +22,16 @@ import (
 
 const targetPrefix = "AmazonSQS."
 
+// errNonExistentQueue is the __type value for a missing queue. Modern SQS speaks
+// AwsJson1_0, where the SDK resolves the error shape from __type: "QueueDoesNotExist"
+// is the modeled shape name, so it deserializes into the typed sqs types
+// QueueDoesNotExist that the aws-sdk-go-v2 / Terraform delete waiter matches on
+// (via errs.IsA and ErrorCode()=="QueueDoesNotExist"). Do NOT change this to the
+// legacy query-protocol code "AWS.SimpleQueueService.NonExistentQueue" — as a JSON
+// __type it matches no modeled shape, dropping the SDK back to a generic error the
+// waiter does not recognize, so destroy hangs.
+const errNonExistentQueue = "QueueDoesNotExist"
+
 // Handler serves SQS JSON-RPC requests against a messagequeue.MessageQueue
 // driver.
 type Handler struct {
@@ -161,7 +171,7 @@ func (h *Handler) getQueueURL(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wire.WriteJSONError(w, http.StatusBadRequest,
-		"QueueDoesNotExist", "queue not found: "+req.QueueName)
+		errNonExistentQueue, "queue not found: "+req.QueueName)
 }
 
 func (h *Handler) listQueues(w http.ResponseWriter, r *http.Request) {
@@ -1131,7 +1141,7 @@ func (h *Handler) purgeQueue(w http.ResponseWriter, r *http.Request) {
 func writeErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "QueueDoesNotExist", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, errNonExistentQueue, err.Error())
 	case cerrors.IsAlreadyExists(err):
 		wire.WriteJSONError(w, http.StatusBadRequest, "QueueNameExists", err.Error())
 	case cerrors.IsInvalidArgument(err):

--- a/server/aws/sqs/sdk_roundtrip_test.go
+++ b/server/aws/sqs/sdk_roundtrip_test.go
@@ -2,6 +2,7 @@ package sqs_test
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -152,10 +153,20 @@ func TestSDKSQSDeleteQueue(t *testing.T) {
 		t.Fatalf("DeleteQueue: %v", err)
 	}
 
-	if _, err := client.GetQueueUrl(ctx, &awssqs.GetQueueUrlInput{
+	_, err := client.GetQueueUrl(ctx, &awssqs.GetQueueUrlInput{
 		QueueName: aws.String("doomed"),
-	}); err == nil {
+	})
+	if err == nil {
 		t.Fatal("GetQueueUrl after delete returned nil error, want QueueDoesNotExist")
+	}
+
+	// The SDK only deserializes the typed QueueDoesNotExist error when the wire
+	// __type is the modeled shape name "QueueDoesNotExist" — the shape the
+	// Terraform / aws-sdk-go-v2 delete waiter matches (errs.IsA) to treat a queue
+	// as gone. The legacy query code would drop back to a generic error here.
+	var qdne *sqstypes.QueueDoesNotExist
+	if !errors.As(err, &qdne) {
+		t.Fatalf("GetQueueUrl error = %v, want typed *QueueDoesNotExist", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes real `terraform apply/plan/destroy` blockers found running `terraform` v1.14 (hashicorp/aws v5) against `cloudemu serve`. Each fix lands at the correct 3-layer location and is gated by a real aws-sdk-go-v2 repro in `compat/aws/terraform_iac_compat_test.go` (asserting the exact read-back shape Terraform depends on).

### EC2 instance attributes (CRITICAL — `aws_instance` apply hard-failed)
Terraform reads `DescribeInstanceAttribute` for `instanceInitiatedShutdownBehavior`, `disableApiStop` and `disableApiTermination`; the first two returned `InvalidParameterValue` and aborted the apply. Added support across the provider (`GetInstanceAttribute`/`SetInstanceAttribute`), the wire handler (`DescribeInstanceAttribute`/`ModifyInstanceAttribute`), and the XML response — `instanceInitiatedShutdownBehavior` defaults to `stop`, `disableApiStop`/`disableApiTermination` default to false.

### Lambda code-signing route (CRITICAL — `aws_lambda_function` apply hard-failed)
Terraform calls `GET /2020-06-30/functions/{name}/code-signing-config` on every refresh. It wasn't matched by the Lambda handler and fell through to the S3 path-style handler, returning `NoSuchBucket` XML the REST-JSON client can't parse. Lambda now matches and routes the code-signing-config sub-resource and returns a valid empty `GetFunctionCodeSigningConfig` JSON (404s a missing function).

### DynamoDB PAY_PER_REQUEST GSI throughput (HIGH — perpetual drift)
A GSI on a PPR table omitted its per-index `ProvisionedThroughput`, so the provider blanked the whole index (including `IndexName`) and re-planned it every apply. Now every GSI emits `ProvisionedThroughput` — table capacities for PROVISIONED, zeros for PAY_PER_REQUEST — matching real AWS. PROVISIONED behavior is unchanged.

### SQS missing-queue error shape (regression guard)
Investigated the reported destroy failure. The existing `__type` `QueueDoesNotExist` is already the modeled shape name the aws-sdk-go-v2 / Terraform delete waiter matches (deserializes to the typed `*QueueDoesNotExist`, `ErrorCode() == "QueueDoesNotExist"`). The audit's proposed change to the legacy query code `AWS.SimpleQueueService.NonExistentQueue` would have **broken** that typed-error match. Kept the correct value, centralized it behind a documented constant, and added a regression test so it can't be "fixed" the wrong way.

## Not done
- **Account-ID consistency (LOW):** EC2 uses `123456789012` while STS/IAM/SQS/etc. use the configured `000000000000`. Aligning it safely means threading the configured `AccountID` through `ec2.New` (which doesn't receive it today) and the provider Mock, plus replacing ~32 non-test usages of package-level constants and updating 7 test files — a wide, high-risk blast radius that doesn't belong with these apply/destroy blockers. Deferred.

## Tests / gates
- `compat/aws/terraform_iac_compat_test.go` — four real-SDK repros (EC2 attrs, Lambda code-signing, DynamoDB PPR GSI, SQS typed missing-queue).
- `go build ./...`, `go vet ./...`, and `go test ./compat/aws/... ./server/aws/... ./providers/aws/...` all green; `go generate ./...` produces no docs diff; golangci-lint clean on touched files (no new issues).
