### PR TITLE
docs: accuracy sweep — persistence, provider-native coverage, positioning, staleness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for AI agents working in the cloudemu repository. (Human contributors: 
 
 ## What cloudemu is
 
-Zero-cost, in-memory emulation of AWS, Azure, and GCP cloud **APIs**. It runs three ways: as a standalone server (the `cloudemu serve` binary or the `ghcr.io/stackshy/cloudemu` Docker image) that any app in any language points at, and in-process from Go via either the SDK-compat HTTP server or the typed mock API. It emulates control surfaces, not a real cloud — it does not run workloads/containers, serve real traffic, authenticate requests, enforce quotas, or persist state across restarts. See the [README](README.md) for the full framing and scope.
+Zero-cost, in-memory emulation of AWS, Azure, and GCP cloud **APIs**. It runs three ways: as a standalone server (the `cloudemu serve` binary or the `ghcr.io/stackshy/cloudemu` Docker image) that any app in any language points at, and in-process from Go via either the SDK-compat HTTP server or the typed mock API. It emulates control surfaces, not a real cloud — it does not run workloads/containers, serve real traffic, authenticate requests, or enforce quotas. State is in-memory and resettable, so it is ephemeral by default (lost on process exit unless saved); persistence is opt-in — the whole emulator's state can be snapshotted to one JSON file and restored identity-preservingly across all four providers (`--persist`, `snapshot save`/`load`, the `/_cloudemu/snapshot` endpoint, the `persist` package). See the [README](README.md) for the full framing and scope.
 
 ## Where the capabilities are
 

--- a/README.md
+++ b/README.md
@@ -95,11 +95,16 @@ By default everything is in memory — no real database, cache, or code runs. Wh
 
 The in-memory default is unchanged; `Provider.Close()` tears down whatever you wired.
 
+## Persistence (opt-in)
+
+State is in memory and resettable, so it's ephemeral by default. When you want it to survive a restart, snapshot the **whole emulator** — every stateful service across all four providers, identity-preserving — to a single JSON file and restore it into a fresh instance. Run the background server with `--persist`, capture named states with `cloudemu snapshot save`/`load`, hit `GET`/`POST /_cloudemu/snapshot`, or drive it from Go with the `persist` package. → [docs/persistence.md](docs/persistence.md)
+
 ## Docs
 
 - [Getting Started](docs/getting-started.md) — a working test in 5 minutes
 - [Standalone Server](docs/standalone-server.md) — the local dev cloud (Docker, flags, ports)
 - [Terraform / OpenTofu](docs/terraform.md) — run real IaC against cloudemu
+- [Persistence](docs/persistence.md) — snapshot & restore the whole emulator's state
 - [Architecture](docs/architecture.md) · [Features](docs/features.md) · [Chaos](docs/chaos.md) · [Topology](docs/topology.md)
 - [Capability coverage](docs/coverage/README.md) — every service and operation, generated
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ CloudEmu is a zero-cost, in-memory emulation of the AWS, Azure, GCP, OCI, and Ku
 - [Terraform / OpenTofu](terraform.md) -- Run real Terraform/OpenTofu against CloudEmu (the `cloudemu-tf` wrapper + manual provider config)
 - [Topology](topology.md) -- Network topology simulation engine
 - [Chaos](chaos.md) -- Fault, latency, and throttling injection across the service layer
+- [Persistence](persistence.md) -- Snapshot and restore the whole emulator's state (opt-in, identity-preserving)
 - [Getting Started](getting-started.md) -- Installation, provider creation, basic examples, configuration
 - [OCI Conventions](oci-conventions.md) -- The contract every OCI service implementation follows
 
@@ -30,5 +31,6 @@ CloudEmu is a zero-cost, in-memory emulation of the AWS, Azure, GCP, OCI, and Ku
 | Error injection and rate limiting | [Features](features.md#8-portable-api-cross-cutting-concerns) |
 | Cost tracking | [Features](features.md#7-cost-tracking) |
 | Real data-plane engines | [Features](features.md#11-real-data-plane-engines-opt-in) |
+| Snapshot & restore state | [Persistence](persistence.md) |
 | Configuration options | [Getting Started](getting-started.md#configuration-options) |
 | Package structure | [Architecture](architecture.md#package-structure-overview) |

--- a/docs/features.md
+++ b/docs/features.md
@@ -504,3 +504,50 @@ For the standalone server, the batteries-included `cloudemu-server` binary
 (`contrib/server`) turns engines on with flags (`--db`, `--cache`, `--functions`,
 `--compute`, `--containers`, `--all-real`) — see
 [standalone-server.md — Real engines](standalone-server.md#real-engines).
+
+## 12. Persistence (snapshot & restore, opt-in)
+
+State lives in `memstore`, so CloudEmu is **ephemeral by default** — everything is
+lost on process exit, and `/_cloudemu/reset` wipes it to empty. When you want state
+to survive a restart, the `persist` package captures the **whole emulator** as one
+JSON document and restores it into a fresh instance. It is strictly opt-in;
+CloudEmu never touches disk unless asked.
+
+Two properties distinguish it from a naive dump:
+
+- **Full-surface.** Every stateful service (one holding an in-memory
+  `memstore.Store`) across **AWS, Azure, GCP, and OCI** is captured — not a
+  hand-picked subset. A completeness guard (`persist/completeness_test.go`) fails
+  the build if a new stateful service is added without persistence, so coverage
+  can't silently drift.
+- **Identity-preserving.** Resource IDs and the ID-string cross-references between
+  resources are serialized as-is, so a snapshot → restore round-trip is transparent
+  to clients: a restored EC2 instance keeps its original `i-…` ID.
+
+Services are auto-discovered by reflection (`internal/snapshot.Discover`, exposed
+per provider as `SnapshotServices()`), and each mock serializes/restores itself via
+the `internal/snapshot.Snapshottable` interface. The on-disk file is one
+human-readable, `git`-diffable JSON document spanning every provider (schema
+version 3).
+
+```go
+import (
+    cloudemu "github.com/stackshy/cloudemu/v2"
+    "github.com/stackshy/cloudemu/v2/persist"
+)
+
+aws := cloudemu.NewAWS()
+targets := map[string]persist.Services{"aws": aws.SnapshotServices()}
+
+snap, _ := persist.ExportAll(ctx, targets, persist.Options{IncludeAssets: true})
+_ = snap.WriteFile("state.json")
+
+fresh := cloudemu.NewAWS()
+loaded, _ := persist.ReadFile("state.json")
+_ = persist.RestoreAll(ctx, &loaded, map[string]persist.Services{"aws": fresh.SnapshotServices()})
+```
+
+`Options{IncludeAssets: false}` (the default) yields a metadata-only snapshot
+(no large object bodies). On the standalone server the same capability is exposed
+as `cloudemu serve --persist`, the `cloudemu snapshot save`/`load` commands, and the
+`GET`/`POST /_cloudemu/snapshot` endpoint. Full guide: [persistence.md](persistence.md).

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,138 @@
+# Persistence (snapshot & restore)
+
+CloudEmu keeps all state in memory, so by default it is **ephemeral**: everything
+you create is lost when the process exits, and `/_cloudemu/reset` wipes it back to
+empty. Persistence is **opt-in** — CloudEmu never writes to disk unless you ask it
+to. When you do, it captures the **whole emulator** as a single JSON document and
+restores it into a fresh instance.
+
+Two properties make this more than a naive dump:
+
+- **Full-surface.** Every stateful service — one that holds in-memory state —
+  across **AWS, Azure, GCP, and OCI** is captured, not a hand-picked subset. A
+  completeness guard (`persist/completeness_test.go`) fails the build if a new
+  stateful service is added without persistence, so coverage can't silently drift.
+- **Identity-preserving.** Resource IDs and the ID-string cross-references between
+  resources (e.g. an instance's subnet/VPC, a secret's KMS key) are serialized
+  as-is, so a snapshot → restore round-trip is transparent to clients — a restored
+  EC2 instance keeps its `i-…` ID, not a freshly minted one.
+
+The snapshot is one human-readable, `git`-diffable JSON file that spans every
+provider (schema version 3).
+
+## Which surface should I use?
+
+| You want to… | Use |
+|--------------|-----|
+| Keep resources across a background-server `stop`→`start` | `cloudemu start --persist` |
+| Capture/name/switch between multiple states on a running server | `cloudemu snapshot save`/`load`/`list`/`delete` |
+| Export or replace the whole state over HTTP | `GET`/`POST /_cloudemu/snapshot` |
+| Save/restore state from Go code | the [`persist`](https://pkg.go.dev/github.com/stackshy/cloudemu/v2/persist) package |
+
+## `--persist` (auto save on stop, restore on start)
+
+Pass `--persist` to the background server and your resources survive a
+`stop`→`start` cycle:
+
+```sh
+cloudemu start --persist          # save on stop, restore on start
+# create buckets / tables / instances / secrets …
+cloudemu stop                     # writes <run-dir>/snapshot.json
+cloudemu start --persist          # your resources are back, same IDs
+cloudemu delete                   # also removes the snapshot
+```
+
+`start` manages the snapshot path for you. For the foreground server the path is
+explicit and required:
+
+```sh
+cloudemu serve --persist --state-file ./state.json
+cloudemu serve --persist --state-file ./state.json --persist-metadata-only  # skip object bodies
+```
+
+By default the snapshot **includes object bodies** (an S3 object comes back with
+its contents). `--persist-metadata-only` keeps only the resource structure for a
+smaller file; restored objects then come back as zero-byte keys until re-uploaded.
+
+## Named snapshots (`snapshot save` / `load` / `list` / `delete`)
+
+Where `--persist` auto-saves one state on stop, **named snapshots** capture, name,
+and switch between *multiple* states on a running server — a local, free
+equivalent of LocalStack's Cloud Pods:
+
+```sh
+cloudemu snapshot save baseline     # capture current state as "baseline"
+# … run a destructive test …
+cloudemu snapshot load baseline     # restore it instantly — no restart
+cloudemu snapshot list              # NAME  CREATED  PROVIDERS  SIZE
+cloudemu snapshot delete baseline
+```
+
+Each is a JSON file under `~/.cloudemu/snapshots/<name>.json` (override the dir
+with `--home`) — inspectable, `git`-diffable, and shareable: copy the file to a
+teammate and they `snapshot load` the identical state. Names match
+`[A-Za-z0-9._-]` (1–64 chars).
+
+`save`/`load` talk to the running server's control plane, so they need the
+`--admin` plane (on by default) and the `aws` or `gcp` provider running; `list`
+and `delete` are file operations that work without a running server. `load` is
+destructive — it wipes the running state (reset semantics) and repopulates from
+the snapshot, so anything created since the snapshot is discarded.
+
+## Admin endpoint (`/_cloudemu/snapshot`)
+
+The control plane exposes the same capability over HTTP, acting on every provider
+at once (like `reset`), so a call to any provider port covers the whole emulator:
+
+```sh
+# export the whole-emulator state as JSON
+curl http://127.0.0.1:4566/_cloudemu/snapshot > state.json
+
+# replace the whole-emulator state from a JSON document
+curl -X POST http://127.0.0.1:4566/_cloudemu/snapshot --data @state.json
+```
+
+Both are disabled (`501`) when the server is started with `--admin=false`. A
+POST larger than 512 MiB is rejected. See the control-plane section of
+[standalone-server.md](standalone-server.md#resetting-state-between-tests-_cloudemu)
+for the neighbouring `reset`/`seed` endpoints.
+
+## Go API (`persist` package)
+
+In-process code drives the same machinery directly. Each provider factory exposes
+`SnapshotServices()`, which auto-discovers the services that can snapshot
+themselves; `ExportAll`/`RestoreAll` operate over a `provider → services` map:
+
+```go
+import (
+    cloudemu "github.com/stackshy/cloudemu/v2"
+    "github.com/stackshy/cloudemu/v2/persist"
+)
+
+aws := cloudemu.NewAWS()
+targets := map[string]persist.Services{"aws": aws.SnapshotServices()}
+
+// Capture and write to disk.
+snap, _ := persist.ExportAll(ctx, targets, persist.Options{IncludeAssets: true})
+_ = snap.WriteFile("state.json")
+
+// Later, into a freshly built provider set:
+fresh := cloudemu.NewAWS()
+loaded, _ := persist.ReadFile("state.json")
+_ = persist.RestoreAll(ctx, &loaded, map[string]persist.Services{"aws": fresh.SnapshotServices()})
+```
+
+`persist.Options{IncludeAssets: false}` (the default) yields a metadata-only
+snapshot. `ReadFile` rejects an incompatible schema version with a clear error
+rather than mis-restoring a stale layout. Restore targets should be freshly built
+(empty) before you restore into them.
+
+## Notes
+
+- Persistence is a **dev-only convenience**. The on-disk schema can change between
+  CloudEmu versions; an incompatible snapshot is rejected with a clear error, so
+  re-create snapshots after upgrading rather than porting old ones.
+- Seed fixtures ([`/_cloudemu/seed`](standalone-server.md#resetting-state-between-tests-_cloudemu)
+  and the [`seed`](https://pkg.go.dev/github.com/stackshy/cloudemu/v2/seed)
+  package) are the complementary tool for standing up a **known baseline** from a
+  declarative file, rather than replaying a captured live state.

--- a/docs/standalone-server.md
+++ b/docs/standalone-server.md
@@ -115,19 +115,22 @@ cloudemu start --persist                       # full: structure + object bodies
 cloudemu start --persist --persist-metadata-only   # smaller: structure only
 ```
 
-Coverage is currently the data-bearing services that share a cross-provider
-driver interface — object storage (S3/Blob/GCS), NoSQL tables
-(DynamoDB/Firestore/Cosmos), secrets (Secrets Manager/Key Vault/Secret Manager),
-and compute instances (EC2/VMs/GCE); other services still start empty. The
-snapshot is a single human-readable JSON file spanning all three providers, so
-you can inspect or `git diff` it.
+Coverage is **full-surface**: every stateful service across all four providers
+(AWS, Azure, GCP, OCI) is captured, not a hand-picked subset — object storage,
+NoSQL tables, secrets, compute, networking, queues, DNS, and the rest — and a
+build-time completeness guard (`persist/completeness_test.go`) fails if a new
+stateful service is added without persistence, so coverage can't silently drift.
+The snapshot is a single human-readable JSON file spanning every provider, so you
+can inspect or `git diff` it. See [persistence.md](persistence.md) for the full
+picture (endpoint, Go API, guarantees).
 
-Fidelity notes: object bodies, secret values, and table items are all saved by
-default, along with any secondary indexes present in a table's configuration.
-Pass `--persist-metadata-only` to drop object *bodies* for a smaller snapshot —
-restored objects then come back as zero-byte keys until you re-upload them.
-Compute instances are recreated via `RunInstances`, so image/type/tags are
-preserved but the emulator assigns fresh instance IDs and IPs on restore.
+Fidelity notes: the snapshot is **identity-preserving** — resource IDs and the
+cross-references between resources are serialized as-is, so a restored EC2
+instance keeps its original `i-…` ID and IP, not a freshly minted one. Object
+bodies, secret values, and table items (with any secondary indexes) are all saved
+by default. Pass `--persist-metadata-only` to drop object *bodies* for a smaller
+snapshot — restored objects then come back as zero-byte keys until you re-upload
+them.
 
 ### Named snapshots (`snapshot save` / `load` / `list` / `delete`)
 
@@ -141,7 +144,7 @@ cloudemu start
 cloudemu snapshot save baseline     # capture current state as "baseline"
 # … run a destructive test …
 cloudemu snapshot load baseline     # restore it instantly — no restart
-cloudemu snapshot list              # NAME  CREATED  SIZE
+cloudemu snapshot list              # NAME  CREATED  PROVIDERS  SIZE
 cloudemu snapshot delete baseline
 ```
 
@@ -152,8 +155,8 @@ copy the file to a teammate and they `snapshot load` the identical state.
 `save` and `load` talk to the running server's control plane, so they need the
 `--admin` plane (on by default) and the `aws` or `gcp` provider running; `list`
 and `delete` are file operations that work without a running server. Snapshots
-cover the same services as persistence (object storage, NoSQL tables, secrets,
-compute instances). Names must match `[A-Za-z0-9._-]` (1–64 chars).
+cover the same full surface as persistence (every stateful service across all
+running providers). Names must match `[A-Za-z0-9._-]` (1–64 chars).
 
 `load` is destructive: it wipes the running state (reset semantics) and then
 repopulates from the snapshot, so anything created since the snapshot is
@@ -458,9 +461,3 @@ cloudemu-server --all-real
 `--db`/`--cache`/`--functions` need no Docker (`contrib/realengine`);
 `--compute`/`--containers` require a Docker daemon (`contrib/dockerengine`). The
 server calls `Provider.Close()` on shutdown, tearing every engine down.
-
-## Not yet included
-
-**Persistence** covers object storage and NoSQL tables today (see "Persistence
-across restarts" above); the remaining services and full **snapshot/restore**
-fidelity are tracked in #107.

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # cloudemu
 
-> Zero-cost, in-memory emulation of AWS, Azure, and GCP cloud **APIs**. Run it as a standalone server (binary or the `ghcr.io/stackshy/cloudemu` Docker image) and point any app in any language at a local endpoint, or use it in-process from Go (SDK-compat HTTP server, or typed mocks driven directly) — no accounts, no network, no bill. It emulates control surfaces, not a real cloud: it does not run workloads, serve traffic, authenticate requests, enforce quotas, or persist across restarts.
+> Zero-cost, in-memory emulation of AWS, Azure, and GCP cloud **APIs**. Run it as a standalone server (binary or the `ghcr.io/stackshy/cloudemu` Docker image) and point any app in any language at a local endpoint, or use it in-process from Go (SDK-compat HTTP server, or typed mocks driven directly) — no accounts, no network, no bill. It emulates control surfaces, not a real cloud: it does not run workloads, serve traffic, authenticate requests, or enforce quotas. State lives in memory and is resettable — ephemeral by default, so it is lost on process exit unless you save it — but the whole emulator's state can be snapshotted to a single JSON file and restored into a fresh instance (opt-in, identity-preserving across all providers), so resources survive a restart when you ask them to.
 
 ## Capabilities (start here)
 
@@ -22,3 +22,4 @@
 - [Features](docs/features.md): auto-metrics, alarm evaluation, IAM policy evaluation, FIFO dedup, error injection, fake clock.
 - [Chaos](docs/chaos.md): deliberately fail or slow services to test retry/timeout paths.
 - [Topology](docs/topology.md): network connectivity simulation across VPC, peering, security groups, ACLs.
+- [Persistence](docs/persistence.md): snapshot the whole emulator's state to JSON and restore it (opt-in `--persist`, named `snapshot save`/`load`, the `/_cloudemu/snapshot` endpoint, and the `persist` Go API).


### PR DESCRIPTION
Pre-release documentation-accuracy sweep. Every claim was re-verified against the current code before editing; generated `docs/coverage/` is untouched.

## Headline: full-surface persistence (#582) is now documented correctly

Persistence changed from a hand-picked subset to **full-surface, identity-preserving** snapshot/restore across all four providers (AWS/Azure/GCP/OCI), auto-discovered via `internal/snapshot.Snapshottable` + `SnapshotServices()`, guarded by `persist/completeness_test.go`. The docs still described the old, narrow behavior and in two places implied cloudemu "can't persist."

## Files changed

- **llms.txt** — scope sentence previously ended "…or persist across restarts," which reads as "no persistence." Reworded: state is in-memory/ephemeral by default, **but** the whole emulator can be snapshotted to JSON and restored (opt-in, identity-preserving). Added a Persistence link under Behavior & features.
- **AGENTS.md** — same "…or persist state across restarts" fix; reworded to opt-in full-surface snapshot/restore and named the surface (`--persist`, `snapshot save`/`load`, `/_cloudemu/snapshot`, `persist` package).
- **docs/persistence.md** (new) — dedicated guide covering the verified surface: `--persist`/`--state-file`/`--persist-metadata-only`, `snapshot save`/`load`/`list`/`delete`, `GET`/`POST /_cloudemu/snapshot`, and the `persist` Go API (`ExportAll`/`RestoreAll`/`WriteFile`/`ReadFile`, `SnapshotServices`). Full-surface + identity-preserving guarantees, schema-version note.
- **README.md** — added a short "Persistence (opt-in)" section (README previously never mentioned it) + a Docs link.
- **docs/features.md** — added section 12 (Persistence) with the full-surface/identity-preserving properties and a Go example.
- **docs/README.md** — linked the new persistence guide from the TOC and Quick Links.
- **docs/standalone-server.md** — corrected stale persistence claims: coverage is no longer "object storage + NoSQL tables + secrets + compute only" but full-surface across all four providers; restore is identity-preserving (dropped the wrong "emulator assigns fresh instance IDs and IPs on restore"); fixed the `snapshot list` column header (`NAME CREATED PROVIDERS SIZE`); removed the stale "Not yet included / tracked in #107" note.

## Verified accurate, no change
Ports (AWS 4566 / Azure 4568 TLS / GCP 4569 / K8s 4570 TLS / OCI 4571 opt-in), `docs/services.md` service list (Kubernetes/managed-k8s and provider-native services already present and consistent with `coverage.json`), `docs/terraform.md`, `docs/architecture.md`, `docs/getting-started.md`, chaos/topology docs. README already leads with the standalone "point any app in any language" framing.