### PR TITLE
fix(aws): EC2 uses the configured account id for cross-service ARN/owner consistency

### DIFF
--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -60,9 +60,6 @@ const (
 	visibilityHidden  = "hidden"
 	visibilityVisible = "visible"
 
-	// awsAccountID is the fixed owner account for resources this mock creates,
-	// echoed as ownerId on volumes/snapshots/images.
-	awsAccountID = "123456789012"
 	// defaultEBSKeyID is the stub KMS key id used when an encrypted volume is
 	// created without an explicit KmsKeyId (real EC2 substitutes the account's
 	// default EBS key).
@@ -1472,7 +1469,7 @@ func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver
 
 	kmsKeyID := cfg.KmsKeyID
 	if cfg.Encrypted && kmsKeyID == "" {
-		kmsKeyID = idgen.AWSARN("kms", m.opts.Region, awsAccountID, "key/"+defaultEBSKeyID)
+		kmsKeyID = idgen.AWSARN("kms", m.opts.Region, m.opts.AccountID, "key/"+defaultEBSKeyID)
 	}
 
 	vol := &driver.VolumeInfo{
@@ -1685,7 +1682,7 @@ func (m *Mock) CreateSnapshot(_ context.Context, cfg driver.SnapshotConfig) (*dr
 		Size:        vol.Size,
 		CreatedAt:   m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
 		Tags:        copyTags(cfg.Tags),
-		OwnerID:     awsAccountID,
+		OwnerID:     m.opts.AccountID,
 		Progress:    "100%",
 		Encrypted:   vol.Encrypted,
 	}
@@ -1839,7 +1836,7 @@ func (m *Mock) CreateImage(_ context.Context, cfg driver.ImageConfig) (*driver.I
 		Description: "Created by CreateImage for " + id,
 		Size:        imageRootDeviceSize,
 		CreatedAt:   now,
-		OwnerID:     awsAccountID,
+		OwnerID:     m.opts.AccountID,
 		Progress:    "100%",
 	})
 
@@ -1850,7 +1847,7 @@ func (m *Mock) CreateImage(_ context.Context, cfg driver.ImageConfig) (*driver.I
 		Description:        cfg.Description,
 		CreatedAt:          now,
 		Tags:               copyTags(cfg.Tags),
-		OwnerID:            awsAccountID,
+		OwnerID:            m.opts.AccountID,
 		Architecture:       "x86_64",
 		RootDeviceType:     "ebs",
 		RootDeviceName:     "/dev/sda1",
@@ -1909,7 +1906,7 @@ func (m *Mock) CopyImage(_ context.Context, input driver.CopyImageInput) (*drive
 	copyImg := *src
 	copyImg.ID = id
 	copyImg.CreatedAt = m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z")
-	copyImg.OwnerID = awsAccountID
+	copyImg.OwnerID = m.opts.AccountID
 	copyImg.LaunchPermissions = nil
 	copyImg.Tags = copyTags(input.Tags)
 
@@ -2074,7 +2071,7 @@ func (m *Mock) CopySnapshot(_ context.Context, in driver.CopySnapshotInput) (*dr
 		Size:        src.Size,
 		CreatedAt:   m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
 		Tags:        copyTags(in.Tags),
-		OwnerID:     awsAccountID,
+		OwnerID:     m.opts.AccountID,
 		Progress:    "100%",
 		Encrypted:   src.Encrypted || in.Encrypted,
 	}
@@ -2115,7 +2112,7 @@ func (m *Mock) RegisterImage(_ context.Context, in driver.RegisterImageInput) (*
 		Description:         in.Description,
 		CreatedAt:           m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
 		Tags:                copyTags(in.Tags),
-		OwnerID:             awsAccountID,
+		OwnerID:             m.opts.AccountID,
 		Architecture:        nonEmpty(in.Architecture, "x86_64"),
 		RootDeviceType:      "ebs",
 		RootDeviceName:      nonEmpty(in.RootDeviceName, "/dev/sda1"),

--- a/providers/aws/ec2/template.go
+++ b/providers/aws/ec2/template.go
@@ -35,7 +35,7 @@ func (m *Mock) CreateLaunchTemplate(
 	}
 
 	now := m.opts.Clock.Now().UTC().Format(timeFormat)
-	createdBy := idgen.AWSARN("iam", "", awsAccountID, "root")
+	createdBy := idgen.AWSARN("iam", "", m.opts.AccountID, "root")
 
 	tmpl := &driver.LaunchTemplate{
 		ID:             idgen.GenerateID("lt-"),

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -552,7 +552,7 @@ func New(d Drivers) *server.Server {
 	}
 
 	if d.EC2 != nil || d.VPC != nil {
-		srv.Register(ec2.New(d.EC2, d.VPC))
+		srv.Register(ec2.New(d.EC2, d.VPC, d.AccountID))
 	}
 
 	if d.Lambda != nil {

--- a/server/aws/ec2/account_id_consistency_test.go
+++ b/server/aws/ec2/account_id_consistency_test.go
@@ -1,0 +1,72 @@
+package ec2_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// TestEC2AccountIDMatchesSTS pins that EC2 owner-ids use the SAME configured
+// account id as the rest of the AWS server. EC2 previously hardcoded
+// 123456789012 while STS/IAM/SQS/... reported the configured id, so anything
+// parsing owner-ids/ARNs across services (cross-service IaC, cost tooling) saw
+// two different accounts. A custom --account-id must now be reflected by EC2's
+// VPC ownerId AND by STS GetCallerIdentity, and the two must agree.
+func TestEC2AccountIDMatchesSTS(t *testing.T) {
+	const wantAccount = "999988887777"
+
+	ctx := context.Background()
+
+	cloud := cloudemu.NewAWS(config.WithAccountID(wantAccount))
+	ts := httptest.NewServer(awsserver.New(awsserver.DriversFrom(cloud)))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	cfg.BaseEndpoint = aws.String(ts.URL)
+
+	ec2Client := ec2.NewFromConfig(cfg)
+	stsClient := sts.NewFromConfig(cfg)
+
+	vpc, err := ec2Client.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	ec2Owner := aws.ToString(vpc.Vpc.OwnerId)
+	if ec2Owner != wantAccount {
+		t.Errorf("EC2 VPC ownerId = %q, want configured account %q", ec2Owner, wantAccount)
+	}
+
+	ident, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		t.Fatalf("GetCallerIdentity: %v", err)
+	}
+
+	stsAccount := aws.ToString(ident.Account)
+	if stsAccount != wantAccount {
+		t.Errorf("STS account = %q, want configured account %q", stsAccount, wantAccount)
+	}
+
+	// The whole point: EC2 and its sibling services agree on one account id.
+	if ec2Owner != stsAccount {
+		t.Errorf("cross-service account mismatch: EC2 ownerId %q != STS account %q", ec2Owner, stsAccount)
+	}
+}

--- a/server/aws/ec2/address.go
+++ b/server/aws/ec2/address.go
@@ -140,7 +140,7 @@ func (h *Handler) describeAddresses(w http.ResponseWriter, r *http.Request) {
 		// account that owns the interface, which in the emulator is the single
 		// default account.
 		if addr.NetworkInterfaceID != "" {
-			addr.NetworkInterfaceOwnerID = ownerID
+			addr.NetworkInterfaceOwnerID = h.accountID
 		}
 
 		out = append(out, addr)

--- a/server/aws/ec2/console_output_test.go
+++ b/server/aws/ec2/console_output_test.go
@@ -37,7 +37,7 @@ func (e *recordingEngine) Deprovision(_ context.Context, _ string) error { retur
 func newEngineHandler(eng config.ComputeEngine) *Handler {
 	opts := config.NewOptions(config.WithComputeEngine(eng))
 
-	return New(awsec2.New(opts), nil)
+	return New(awsec2.New(opts), nil, opts.AccountID)
 }
 
 func TestRunInstancesBase64DecodesUserData(t *testing.T) {

--- a/server/aws/ec2/dhcp_options.go
+++ b/server/aws/ec2/dhcp_options.go
@@ -54,7 +54,7 @@ func (h *Handler) routeDHCPOptions(w http.ResponseWriter, r *http.Request, actio
 	return true
 }
 
-func (*Handler) createDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
+func (h *Handler) createDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
 	out, err := d.CreateDHCPOptions(r.Context(), netdriver.DHCPOptionsConfig{
 		Configuration: parseDHCPConfigurations(r),
 		Tags:          mergeTagSpecs(awsquery.TagSpecs(r.Form), "dhcp-options"),
@@ -69,7 +69,7 @@ func (*Handler) createDHCPOptions(w http.ResponseWriter, r *http.Request, d netd
 		Xmlns   string         `xml:"xmlns,attr"`
 		Req     string         `xml:"requestId"`
 		Opts    dhcpOptionsXML `xml:"dhcpOptions"`
-	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Opts: toDHCPOptionsXML(out)})
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Opts: h.toDHCPOptionsXML(out)})
 }
 
 func (*Handler) deleteDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
@@ -81,7 +81,7 @@ func (*Handler) deleteDHCPOptions(w http.ResponseWriter, r *http.Request, d netd
 	writeReturnTrue(w, "DeleteDhcpOptionsResponse")
 }
 
-func (*Handler) describeDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
+func (h *Handler) describeDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
 	items, err := d.DescribeDHCPOptions(r.Context(), awsquery.ListStrings(r.Form, "DhcpOptionsId"))
 	if err != nil {
 		writeDHCPErr(w, err)
@@ -94,7 +94,7 @@ func (*Handler) describeDHCPOptions(w http.ResponseWriter, r *http.Request, d ne
 		return
 	}
 
-	out := filterXML(items, filters, dhcpMatchesFilters, toDHCPOptionsXML)
+	out := filterXML(items, filters, dhcpMatchesFilters, h.toDHCPOptionsXML)
 
 	page, next := pageNetworkingXML(out, r, func(d dhcpOptionsXML) string { return d.DhcpOptionsID })
 
@@ -136,7 +136,7 @@ func parseDHCPConfigurations(r *http.Request) map[string][]string {
 	return out
 }
 
-func toDHCPOptionsXML(d *netdriver.DHCPOptions) dhcpOptionsXML {
+func (h *Handler) toDHCPOptionsXML(d *netdriver.DHCPOptions) dhcpOptionsXML {
 	keys := make([]string, 0, len(d.Configuration))
 	for k := range d.Configuration {
 		keys = append(keys, k)
@@ -155,7 +155,7 @@ func toDHCPOptionsXML(d *netdriver.DHCPOptions) dhcpOptionsXML {
 		cfgs = append(cfgs, dhcpConfigXML{Key: k, Values: vals})
 	}
 
-	return dhcpOptionsXML{DhcpOptionsID: d.ID, OwnerID: ownerID, DhcpConfigurations: cfgs, Tags: toTagItems(d.Tags)}
+	return dhcpOptionsXML{DhcpOptionsID: d.ID, OwnerID: h.accountID, DhcpConfigurations: cfgs, Tags: toTagItems(d.Tags)}
 }
 
 func dhcpMatchesFilters(d *netdriver.DHCPOptions, filters []awsquery.Filter) bool {

--- a/server/aws/ec2/ec2_phase2_test.go
+++ b/server/aws/ec2/ec2_phase2_test.go
@@ -16,7 +16,7 @@ import (
 func newFullHandler() *Handler {
 	opts := config.NewOptions()
 
-	return New(awsec2.New(opts), awsvpc.New(opts))
+	return New(awsec2.New(opts), awsvpc.New(opts), opts.AccountID)
 }
 
 func TestRouteVPCDispatchesAllActions(t *testing.T) {
@@ -354,15 +354,16 @@ func TestResolveRouteTarget(t *testing.T) {
 }
 
 func TestToVpcXMLStateDefaults(t *testing.T) {
+	h := newFullHandler()
 	in := &netdriver.VPCInfo{ID: "vpc-x", CIDRBlock: "10.0.0.0/16"} // no State
 
-	got := toVpcXML(in)
+	got := h.toVpcXML(in)
 	if got.State != "available" {
 		t.Errorf("default state should be 'available', got %q", got.State)
 	}
 
 	in.State = "pending"
-	got = toVpcXML(in)
+	got = h.toVpcXML(in)
 
 	if got.State != "pending" {
 		t.Errorf("explicit state preserved: %q", got.State)
@@ -372,9 +373,10 @@ func TestToVpcXMLStateDefaults(t *testing.T) {
 func TestToSubnetXMLStateDefaults(t *testing.T) {
 	const usableIPs = 251
 
+	h := newFullHandler()
 	in := &netdriver.SubnetInfo{ID: "subnet-x", VPCID: "vpc-x", AvailableIPAddressCount: usableIPs}
 
-	got := toSubnetXML(in, "us-east-1")
+	got := h.toSubnetXML(in, "us-east-1")
 	if got.State != "available" {
 		t.Errorf("default state: %q", got.State)
 	}
@@ -387,13 +389,15 @@ func TestToSubnetXMLStateDefaults(t *testing.T) {
 }
 
 func TestToInternetGatewayXMLAttachment(t *testing.T) {
+	h := newFullHandler()
+
 	detached := &netdriver.InternetGateway{ID: "igw-1"}
-	if got := toInternetGatewayXML(detached); len(got.Attachments) != 0 {
+	if got := h.toInternetGatewayXML(detached); len(got.Attachments) != 0 {
 		t.Errorf("detached IGW should have 0 attachments, got %d", len(got.Attachments))
 	}
 
 	attached := &netdriver.InternetGateway{ID: "igw-2", VpcID: "vpc-1"}
-	got := toInternetGatewayXML(attached)
+	got := h.toInternetGatewayXML(attached)
 
 	if len(got.Attachments) != 1 {
 		t.Fatalf("attached IGW should have 1 attachment, got %d", len(got.Attachments))
@@ -416,7 +420,7 @@ func TestToRouteTableXMLTargetMapping(t *testing.T) {
 		},
 	}
 
-	got := toRouteTableXML(rt)
+	got := newFullHandler().toRouteTableXML(rt)
 	if len(got.Routes) != 3 {
 		t.Fatalf("len=%d want 3", len(got.Routes))
 	}
@@ -472,7 +476,7 @@ func TestToIPPermissionXMLsGroupsByTuple(t *testing.T) {
 		{Protocol: "tcp", FromPort: 443, ToPort: 443, CIDR: "0.0.0.0/0"},
 	}
 
-	got := toIPPermissionXMLs(rules)
+	got := newFullHandler().toIPPermissionXMLs(rules)
 	if len(got) != 2 {
 		t.Fatalf("len=%d want 2 tuples", len(got))
 	}
@@ -484,7 +488,7 @@ func TestToIPPermissionXMLsGroupsByTuple(t *testing.T) {
 }
 
 func TestToIPPermissionXMLsEmpty(t *testing.T) {
-	if got := toIPPermissionXMLs(nil); got != nil {
+	if got := newFullHandler().toIPPermissionXMLs(nil); got != nil {
 		t.Errorf("empty rules should give nil, got %v", got)
 	}
 }

--- a/server/aws/ec2/ec2_test.go
+++ b/server/aws/ec2/ec2_test.go
@@ -21,7 +21,8 @@ import (
 // unit tests only need the compute driver; Phase-2 tests in security_group_test.go
 // and siblings construct their own Handler with both drivers.
 func newHandler() *Handler {
-	return New(awsec2.New(config.NewOptions()), nil)
+	opts := config.NewOptions()
+	return New(awsec2.New(opts), nil, opts.AccountID)
 }
 
 // do runs a request through the handler and returns the recorded response.
@@ -290,7 +291,7 @@ func TestToInstanceXMLs(t *testing.T) {
 		Tags:           map[string]string{"k": "v"},
 	}}
 
-	got := New(nil, nil).toInstanceXMLs(context.Background(), in)
+	got := New(nil, nil, "").toInstanceXMLs(context.Background(), in)
 
 	if len(got) != 1 {
 		t.Fatalf("len=%d want 1", len(got))
@@ -307,7 +308,7 @@ func TestToInstanceXMLs(t *testing.T) {
 }
 
 func TestToInstanceXMLsEmpty(t *testing.T) {
-	got := New(nil, nil).toInstanceXMLs(context.Background(), nil)
+	got := New(nil, nil, "").toInstanceXMLs(context.Background(), nil)
 	if len(got) != 0 {
 		t.Errorf("empty input should give empty result, got %v", got)
 	}

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -27,18 +27,34 @@ const maxFormBodyBytes = 1 << 20
 // non-existent instance id.
 const codeInvalidInstanceID = "InvalidInstanceID.NotFound"
 
+// defaultAccountID is the owner account id echoed on EC2/VPC resources when the
+// server is constructed without an explicit account id. It matches the AWS
+// server's default so EC2 owner-ids and ARNs agree with STS/IAM/SQS/etc.
+const defaultAccountID = "000000000000"
+
 // Handler serves EC2 query-protocol requests. Real AWS EC2 serves both
 // compute and VPC/networking on one endpoint, so the handler holds both
 // drivers and dispatches based on the Action parameter.
 type Handler struct {
 	compute computedriver.Compute
 	vpc     netdriver.Networking
+	// accountID is the configured owner account echoed as the ownerId on
+	// resources and embedded in ARNs, so EC2/VPC agree with the account id the
+	// rest of the AWS server (STS/IAM/SQS/...) reports. Defaults to
+	// defaultAccountID when the caller passes an empty string.
+	accountID string
 }
 
 // New returns an EC2 handler backed by c and v. Either may be nil if only
 // one service is being emulated, though most workflows need both together.
-func New(c computedriver.Compute, v netdriver.Networking) *Handler {
-	return &Handler{compute: c, vpc: v}
+// accountID is the owner account echoed on resources; an empty string falls
+// back to defaultAccountID.
+func New(c computedriver.Compute, v netdriver.Networking, accountID string) *Handler {
+	if accountID == "" {
+		accountID = defaultAccountID
+	}
+
+	return &Handler{compute: c, vpc: v, accountID: accountID}
 }
 
 // Matches returns true for EC2-shaped requests. EC2 uses the AWS query

--- a/server/aws/ec2/internet_gateway.go
+++ b/server/aws/ec2/internet_gateway.go
@@ -78,7 +78,7 @@ func (h *Handler) createInternetGateway(w http.ResponseWriter, r *http.Request) 
 	awsquery.WriteXMLResponse(w, createInternetGatewayResponseXML{
 		Xmlns:           awsquery.Namespace,
 		RequestID:       awsquery.RequestID,
-		InternetGateway: toInternetGatewayXML(igw),
+		InternetGateway: h.toInternetGatewayXML(igw),
 	})
 }
 
@@ -140,7 +140,7 @@ func (h *Handler) describeInternetGateways(w http.ResponseWriter, r *http.Reques
 	}
 
 	page, next := pageNetworkingXML(
-		filterXML(igws, filters, igwMatchesFilters, toInternetGatewayXML), r,
+		filterXML(igws, filters, igwMatchesFilters, h.toInternetGatewayXML), r,
 		func(igw internetGatewayXML) string { return igw.InternetGatewayID })
 
 	awsquery.WriteXMLResponse(w, describeInternetGatewaysResponseXML{
@@ -203,10 +203,10 @@ func igwAttachmentState(igw *netdriver.InternetGateway) string {
 	return stateAvailable
 }
 
-func toInternetGatewayXML(igw *netdriver.InternetGateway) internetGatewayXML {
+func (h *Handler) toInternetGatewayXML(igw *netdriver.InternetGateway) internetGatewayXML {
 	xi := internetGatewayXML{
 		InternetGatewayID: igw.ID,
-		OwnerID:           ownerID,
+		OwnerID:           h.accountID,
 		Tags:              toTagItems(igw.Tags),
 	}
 

--- a/server/aws/ec2/network_acl.go
+++ b/server/aws/ec2/network_acl.go
@@ -101,7 +101,7 @@ func (h *Handler) createNetworkACL(w http.ResponseWriter, r *http.Request) {
 	awsquery.WriteXMLResponse(w, createNetworkACLResponseXML{
 		Xmlns:      awsquery.Namespace,
 		RequestID:  awsquery.RequestID,
-		NetworkACL: toNetworkACLXML(acl),
+		NetworkACL: h.toNetworkACLXML(acl),
 	})
 }
 
@@ -134,7 +134,7 @@ func (h *Handler) describeNetworkACLs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := filterXML(acls, filters, naclMatchesFilters, toNetworkACLXML)
+	out := filterXML(acls, filters, naclMatchesFilters, h.toNetworkACLXML)
 	page, next := pageNetworkingXML(out, r, func(a networkACLXML) string { return a.NetworkACLID })
 
 	awsquery.WriteXMLResponse(w, describeNetworkACLsResponseXML{
@@ -276,11 +276,11 @@ func writeNetworkACLAssocErr(w http.ResponseWriter, err error) {
 	}
 }
 
-func toNetworkACLXML(a *netdriver.NetworkACL) networkACLXML {
+func (h *Handler) toNetworkACLXML(a *netdriver.NetworkACL) networkACLXML {
 	x := networkACLXML{
 		NetworkACLID: a.ID,
 		VpcID:        a.VPCID,
-		OwnerID:      ownerID,
+		OwnerID:      h.accountID,
 		IsDefault:    a.IsDefault,
 		Tags:         toTagItems(a.Tags),
 	}

--- a/server/aws/ec2/operations.go
+++ b/server/aws/ec2/operations.go
@@ -101,7 +101,7 @@ func (h *Handler) runInstances(w http.ResponseWriter, r *http.Request) {
 		Xmlns:         awsquery.Namespace,
 		RequestID:     awsquery.RequestID,
 		ReservationID: reservationIDFor(&instances[0]),
-		OwnerID:       ownerID,
+		OwnerID:       h.accountID,
 		Instances:     h.toInstanceXMLs(r.Context(), instances),
 	})
 }
@@ -241,7 +241,7 @@ func (h *Handler) groupReservations(ctx context.Context, instances []computedriv
 		res, ok := byID[rid]
 		if !ok {
 			order = append(order, rid)
-			byID[rid] = &reservationXML{ReservationID: rid, OwnerID: ownerID}
+			byID[rid] = &reservationXML{ReservationID: rid, OwnerID: h.accountID}
 			res = byID[rid]
 		}
 

--- a/server/aws/ec2/peering.go
+++ b/server/aws/ec2/peering.go
@@ -212,7 +212,7 @@ func (h *Handler) enrichedPeeringXML(r *http.Request, p *netdriver.PeeringConnec
 		VpcPeeringConnectionID: p.ID,
 		RequesterVpcInfo:       h.peeringVpcInfo(r, p.RequesterVPC, region),
 		AccepterVpcInfo:        h.peeringVpcInfo(r, p.AccepterVPC, region),
-		Status:                 peeringStatusXML{Code: p.Status, Message: peeringStatusMessage(p.Status)},
+		Status:                 peeringStatusXML{Code: p.Status, Message: h.peeringStatusMessage(p.Status)},
 		CreationTime:           p.CreatedAt,
 		Tags:                   toTagItems(p.Tags),
 	}
@@ -222,7 +222,7 @@ func (h *Handler) enrichedPeeringXML(r *http.Request, p *netdriver.PeeringConnec
 // VPC's CIDR from the networking driver so IaC that reads accepter/requester
 // CIDRs (Terraform aws_vpc_peering_connection) sees real values.
 func (h *Handler) peeringVpcInfo(r *http.Request, vpcID, region string) peeringVpcInfo {
-	info := peeringVpcInfo{VpcID: vpcID, OwnerID: ownerID, Region: region}
+	info := peeringVpcInfo{VpcID: vpcID, OwnerID: h.accountID, Region: region}
 	if vpcID == "" {
 		return info
 	}
@@ -237,10 +237,10 @@ func (h *Handler) peeringVpcInfo(r *http.Request, vpcID, region string) peeringV
 
 // peeringStatusMessage mirrors the human-readable status message AWS attaches to
 // each peering status code.
-func peeringStatusMessage(code string) string {
+func (h *Handler) peeringStatusMessage(code string) string {
 	switch code {
 	case "pending-acceptance":
-		return "Pending Acceptance by " + ownerID
+		return "Pending Acceptance by " + h.accountID
 	case "active":
 		return "Active"
 	case "rejected":

--- a/server/aws/ec2/prefix_list.go
+++ b/server/aws/ec2/prefix_list.go
@@ -57,7 +57,7 @@ func (h *Handler) routePrefixLists(w http.ResponseWriter, r *http.Request, actio
 	return true
 }
 
-func (*Handler) createPrefixList(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
+func (h *Handler) createPrefixList(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
 	maxEntries, _ := strconv.Atoi(r.Form.Get("MaxEntries"))
 
 	out, err := p.CreateManagedPrefixList(r.Context(), netdriver.PrefixListConfig{
@@ -77,10 +77,10 @@ func (*Handler) createPrefixList(w http.ResponseWriter, r *http.Request, p netdr
 		Xmlns   string        `xml:"xmlns,attr"`
 		Req     string        `xml:"requestId"`
 		PL      prefixListXML `xml:"prefixList"`
-	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: toPrefixListXML(regionFromRequest(r), out)})
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: h.toPrefixListXML(regionFromRequest(r), out)})
 }
 
-func (*Handler) deletePrefixList(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
+func (h *Handler) deletePrefixList(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
 	out, err := p.DeleteManagedPrefixList(r.Context(), r.Form.Get("PrefixListId"))
 	if err != nil {
 		writePrefixListErr(w, err)
@@ -92,10 +92,10 @@ func (*Handler) deletePrefixList(w http.ResponseWriter, r *http.Request, p netdr
 		Xmlns   string        `xml:"xmlns,attr"`
 		Req     string        `xml:"requestId"`
 		PL      prefixListXML `xml:"prefixList"`
-	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: toPrefixListXML(regionFromRequest(r), out)})
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: h.toPrefixListXML(regionFromRequest(r), out)})
 }
 
-func (*Handler) describePrefixLists(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
+func (h *Handler) describePrefixLists(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
 	items, err := p.DescribeManagedPrefixLists(r.Context(), awsquery.ListStrings(r.Form, "PrefixListId"))
 	if err != nil {
 		writePrefixListErr(w, err)
@@ -106,7 +106,7 @@ func (*Handler) describePrefixLists(w http.ResponseWriter, r *http.Request, p ne
 
 	out := make([]prefixListXML, 0, len(items))
 	for i := range items {
-		out = append(out, toPrefixListXML(region, &items[i]))
+		out = append(out, h.toPrefixListXML(region, &items[i]))
 	}
 
 	awsquery.WriteXMLResponse(w, struct {
@@ -137,7 +137,7 @@ func (*Handler) getPrefixListEntries(w http.ResponseWriter, r *http.Request, p n
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
 }
 
-func (*Handler) modifyPrefixList(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
+func (h *Handler) modifyPrefixList(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
 	id := r.Form.Get("PrefixListId")
 
 	if err := checkPrefixListVersion(r, p, id); err != nil {
@@ -157,7 +157,7 @@ func (*Handler) modifyPrefixList(w http.ResponseWriter, r *http.Request, p netdr
 		Xmlns   string        `xml:"xmlns,attr"`
 		Req     string        `xml:"requestId"`
 		PL      prefixListXML `xml:"prefixList"`
-	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: toPrefixListXML(regionFromRequest(r), out)})
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: h.toPrefixListXML(regionFromRequest(r), out)})
 }
 
 // checkPrefixListVersion enforces the optimistic-concurrency guard AWS applies
@@ -264,23 +264,23 @@ func parsePrefixListEntries(r *http.Request) []netdriver.PrefixListEntry {
 	return nil
 }
 
-func toPrefixListXML(region string, p *netdriver.PrefixList) prefixListXML {
+func (h *Handler) toPrefixListXML(region string, p *netdriver.PrefixList) prefixListXML {
 	return prefixListXML{
-		PrefixListID: p.ID, PrefixListArn: prefixListARN(region, p.ID),
+		PrefixListID: p.ID, PrefixListArn: h.prefixListARN(region, p.ID),
 		PrefixListName: p.Name, AddressFamily: p.AddressFamily,
 		MaxEntries: p.MaxEntries, State: p.State, Version: p.Version,
-		OwnerID: ownerID, Tags: toTagItems(p.Tags),
+		OwnerID: h.accountID, Tags: toTagItems(p.Tags),
 	}
 }
 
 // prefixListARN builds the managed-prefix-list ARN AWS returns; the SDK and
 // Terraform read prefixListArn to reference the list in policies and rules.
-func prefixListARN(region, id string) string {
+func (h *Handler) prefixListARN(region, id string) string {
 	if id == "" {
 		return ""
 	}
 
-	return "arn:aws:ec2:" + region + ":" + ownerID + ":prefix-list/" + id
+	return "arn:aws:ec2:" + region + ":" + h.accountID + ":prefix-list/" + id
 }
 
 func writePrefixListErr(w http.ResponseWriter, err error) {

--- a/server/aws/ec2/route_table.go
+++ b/server/aws/ec2/route_table.go
@@ -132,7 +132,7 @@ func (h *Handler) createRouteTable(w http.ResponseWriter, r *http.Request) {
 	awsquery.WriteXMLResponse(w, createRouteTableResponseXML{
 		Xmlns:      awsquery.Namespace,
 		RequestID:  awsquery.RequestID,
-		RouteTable: toRouteTableXML(rt),
+		RouteTable: h.toRouteTableXML(rt),
 	})
 }
 
@@ -157,7 +157,7 @@ func (h *Handler) describeRouteTables(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		out = append(out, toRouteTableXML(&rts[i]))
+		out = append(out, h.toRouteTableXML(&rts[i]))
 	}
 
 	page, next := pageNetworkingXML(out, r, func(rt routeTableXML) string { return rt.RouteTableID })
@@ -405,11 +405,11 @@ func anyAssoc(rt *netdriver.RouteTable, pred func(netdriver.RouteTableAssociatio
 	return false
 }
 
-func toRouteTableXML(rt *netdriver.RouteTable) routeTableXML {
+func (h *Handler) toRouteTableXML(rt *netdriver.RouteTable) routeTableXML {
 	x := routeTableXML{
 		RouteTableID: rt.ID,
 		VpcID:        rt.VPCID,
-		OwnerID:      ownerID,
+		OwnerID:      h.accountID,
 		Tags:         toTagItems(rt.Tags),
 	}
 

--- a/server/aws/ec2/security_group.go
+++ b/server/aws/ec2/security_group.go
@@ -224,7 +224,7 @@ func (h *Handler) describeSecurityGroups(w http.ResponseWriter, r *http.Request)
 			continue
 		}
 
-		out = append(out, toSecurityGroupXML(&sgs[i]))
+		out = append(out, h.toSecurityGroupXML(&sgs[i]))
 	}
 
 	page, next := pageNetworkingXML(out, r, func(sg securityGroupXML) string { return sg.GroupID })
@@ -346,8 +346,8 @@ func (h *Handler) describeSecurityGroupRules(w http.ResponseWriter, r *http.Requ
 			continue
 		}
 
-		items = appendSGRuleXMLs(items, sg.ID, false, sg.IngressRules, wantRuleIDs, filters)
-		items = appendSGRuleXMLs(items, sg.ID, true, sg.EgressRules, wantRuleIDs, filters)
+		items = h.appendSGRuleXMLs(items, sg.ID, false, sg.IngressRules, wantRuleIDs, filters)
+		items = h.appendSGRuleXMLs(items, sg.ID, true, sg.EgressRules, wantRuleIDs, filters)
 	}
 
 	awsquery.WriteXMLResponse(w, describeSecurityGroupRulesResponseXML{
@@ -359,7 +359,7 @@ func (h *Handler) describeSecurityGroupRules(w http.ResponseWriter, r *http.Requ
 
 // appendSGRuleXMLs appends the rules to out as SecurityGroupRule items, keeping
 // only those whose id is in wantRuleIDs when that selector is non-empty.
-func appendSGRuleXMLs(
+func (h *Handler) appendSGRuleXMLs(
 	out []securityGroupRuleXML,
 	groupID string,
 	egress bool,
@@ -376,7 +376,7 @@ func appendSGRuleXMLs(
 			continue
 		}
 
-		out = append(out, toSecurityGroupRuleXML(groupID, egress, &rules[i]))
+		out = append(out, h.toSecurityGroupRuleXML(groupID, egress, &rules[i]))
 	}
 
 	return out
@@ -544,7 +544,7 @@ func (h *Handler) applyRules(w http.ResponseWriter, r *http.Request, spec ruleAp
 	// Authorize (existing != nil) echoes the created SecurityGroupRule set; the
 	// idempotent Revoke path carries no payload.
 	if spec.existing != nil {
-		writeAuthorizeSGResponse(w, spec.responseName, groupID, spec.egress, rules)
+		h.writeAuthorizeSGResponse(w, spec.responseName, groupID, spec.egress, rules)
 		return
 	}
 
@@ -567,10 +567,10 @@ func applyRuleTagSpecs(form url.Values, rules []netdriver.SecurityRule) {
 
 // writeAuthorizeSGResponse emits <return>true</return> plus the
 // securityGroupRuleSet AWS returns from Authorize{Ingress,Egress}.
-func writeAuthorizeSGResponse(w http.ResponseWriter, name, groupID string, egress bool, rules []netdriver.SecurityRule) {
+func (h *Handler) writeAuthorizeSGResponse(w http.ResponseWriter, name, groupID string, egress bool, rules []netdriver.SecurityRule) {
 	items := make([]securityGroupRuleXML, 0, len(rules))
 	for i := range rules {
-		items = append(items, toSecurityGroupRuleXML(groupID, egress, &rules[i]))
+		items = append(items, h.toSecurityGroupRuleXML(groupID, egress, &rules[i]))
 	}
 
 	awsquery.WriteXMLResponse(w, authorizeSecurityGroupResponseXML{
@@ -585,11 +585,11 @@ func writeAuthorizeSGResponse(w http.ResponseWriter, name, groupID string, egres
 // toSecurityGroupRuleXML maps one stored rule to the flat SecurityGroupRule
 // wire shape, emitting exactly the target element (cidrIpv4/cidrIpv6/
 // prefixListId/referencedGroupInfo) the rule carries.
-func toSecurityGroupRuleXML(groupID string, egress bool, rule *netdriver.SecurityRule) securityGroupRuleXML {
+func (h *Handler) toSecurityGroupRuleXML(groupID string, egress bool, rule *netdriver.SecurityRule) securityGroupRuleXML {
 	x := securityGroupRuleXML{
 		SecurityGroupRuleID: rule.RuleID,
 		GroupID:             groupID,
-		GroupOwnerID:        ownerID,
+		GroupOwnerID:        h.accountID,
 		IsEgress:            egress,
 		IPProtocol:          rule.Protocol,
 		FromPort:            rule.FromPort,
@@ -604,7 +604,7 @@ func toSecurityGroupRuleXML(groupID string, egress bool, rule *netdriver.Securit
 	if rule.ReferencedGroupID != "" {
 		userID := rule.ReferencedGroupOwnerID
 		if userID == "" {
-			userID = ownerID
+			userID = h.accountID
 		}
 
 		x.ReferencedGroupInfo = &referencedGroupInfoXML{GroupID: rule.ReferencedGroupID, UserID: userID}
@@ -772,15 +772,15 @@ func groupsFromNested(form url.Values, prefix string) []referencedGroup {
 	return out
 }
 
-func toSecurityGroupXML(s *netdriver.SecurityGroupInfo) securityGroupXML {
+func (h *Handler) toSecurityGroupXML(s *netdriver.SecurityGroupInfo) securityGroupXML {
 	return securityGroupXML{
-		OwnerID:             ownerID,
+		OwnerID:             h.accountID,
 		GroupID:             s.ID,
 		GroupName:           s.Name,
 		GroupDescription:    s.Description,
 		VpcID:               s.VPCID,
-		IPPermissions:       toIPPermissionXMLs(s.IngressRules),
-		IPPermissionsEgress: toIPPermissionXMLs(s.EgressRules),
+		IPPermissions:       h.toIPPermissionXMLs(s.IngressRules),
+		IPPermissionsEgress: h.toIPPermissionXMLs(s.EgressRules),
 		Tags:                toTagItems(s.Tags),
 	}
 }
@@ -788,7 +788,7 @@ func toSecurityGroupXML(s *netdriver.SecurityGroupInfo) securityGroupXML {
 // toIPPermissionXMLs groups rules by (protocol, fromPort, toPort) so each
 // entry in the response carries all its CIDR ranges in one <item>. That's
 // how real AWS shapes the DescribeSecurityGroups payload.
-func toIPPermissionXMLs(rules []netdriver.SecurityRule) []ipPermissionXML {
+func (h *Handler) toIPPermissionXMLs(rules []netdriver.SecurityRule) []ipPermissionXML {
 	if len(rules) == 0 {
 		return nil
 	}
@@ -818,7 +818,7 @@ func toIPPermissionXMLs(rules []netdriver.SecurityRule) []ipPermissionXML {
 			order = append(order, k)
 		}
 
-		addRuleTarget(perm, rule)
+		h.addRuleTarget(perm, rule)
 	}
 
 	out := make([]ipPermissionXML, 0, len(order))
@@ -831,7 +831,7 @@ func toIPPermissionXMLs(rules []netdriver.SecurityRule) []ipPermissionXML {
 
 // addRuleTarget appends the rule's single target (IPv4 / IPv6 / prefix list /
 // referenced group) to the matching sub-list of the IpPermission.
-func addRuleTarget(perm *ipPermissionXML, rule *netdriver.SecurityRule) {
+func (h *Handler) addRuleTarget(perm *ipPermissionXML, rule *netdriver.SecurityRule) {
 	switch {
 	case rule.CIDR != "":
 		perm.IPRanges = append(perm.IPRanges, ipRangeXML{CidrIP: rule.CIDR, Description: rule.Description})
@@ -843,7 +843,7 @@ func addRuleTarget(perm *ipPermissionXML, rule *netdriver.SecurityRule) {
 	case rule.ReferencedGroupID != "":
 		userID := rule.ReferencedGroupOwnerID
 		if userID == "" {
-			userID = ownerID
+			userID = h.accountID
 		}
 
 		perm.Groups = append(perm.Groups,

--- a/server/aws/ec2/subnet.go
+++ b/server/aws/ec2/subnet.go
@@ -72,7 +72,7 @@ func (h *Handler) createSubnet(w http.ResponseWriter, r *http.Request) {
 	awsquery.WriteXMLResponse(w, createSubnetResponseXML{
 		Xmlns:     awsquery.Namespace,
 		RequestID: awsquery.RequestID,
-		Subnet:    toSubnetXML(info, regionFromRequest(r)),
+		Subnet:    h.toSubnetXML(info, regionFromRequest(r)),
 	})
 }
 
@@ -105,7 +105,7 @@ func (h *Handler) describeSubnets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	region := regionFromRequest(r)
-	toXML := func(s *netdriver.SubnetInfo) subnetXML { return toSubnetXML(s, region) }
+	toXML := func(s *netdriver.SubnetInfo) subnetXML { return h.toSubnetXML(s, region) }
 
 	page, next := pageNetworkingXML(
 		filterXML(subnets, filters, subnetMatchesFilters, toXML), r,
@@ -147,7 +147,7 @@ func (h *Handler) modifySubnetAttribute(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
-func toSubnetXML(s *netdriver.SubnetInfo, region string) subnetXML {
+func (h *Handler) toSubnetXML(s *netdriver.SubnetInfo, region string) subnetXML {
 	state := s.State
 	if state == "" {
 		state = stateAvailable
@@ -162,12 +162,12 @@ func toSubnetXML(s *netdriver.SubnetInfo, region string) subnetXML {
 		AvailabilityZone:    s.AvailabilityZone,
 		AvailabilityZoneID:  zoneIDFor(s.AvailabilityZone),
 		MapPublicIPOnLaunch: s.MapPublicIPOnLaunch,
-		OwnerID:             ownerID,
+		OwnerID:             h.accountID,
 		Tags:                toTagItems(s.Tags),
 	}
 
 	if s.ID != "" {
-		x.SubnetArn = idgen.AWSARN("ec2", region, ownerID, "subnet/"+s.ID)
+		x.SubnetArn = idgen.AWSARN("ec2", region, h.accountID, "subnet/"+s.ID)
 	}
 
 	return x

--- a/server/aws/ec2/vpc.go
+++ b/server/aws/ec2/vpc.go
@@ -95,7 +95,7 @@ func (h *Handler) createVpc(w http.ResponseWriter, r *http.Request) {
 	awsquery.WriteXMLResponse(w, createVpcResponseXML{
 		Xmlns:     awsquery.Namespace,
 		RequestID: awsquery.RequestID,
-		Vpc:       toVpcXML(info),
+		Vpc:       h.toVpcXML(info),
 	})
 }
 
@@ -129,7 +129,7 @@ func (h *Handler) describeVpcs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	page, next := pageNetworkingXML(
-		filterXML(vpcs, filters, vpcMatchesFilters, toVpcXML), r,
+		filterXML(vpcs, filters, vpcMatchesFilters, h.toVpcXML), r,
 		func(v vpcXML) string { return v.VpcID })
 
 	awsquery.WriteXMLResponse(w, describeVpcsResponseXML{
@@ -140,7 +140,7 @@ func (h *Handler) describeVpcs(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func toVpcXML(v *netdriver.VPCInfo) vpcXML {
+func (h *Handler) toVpcXML(v *netdriver.VPCInfo) vpcXML {
 	state := v.State
 	if state == "" {
 		state = stateAvailable
@@ -153,7 +153,7 @@ func toVpcXML(v *netdriver.VPCInfo) vpcXML {
 		DhcpOptionsID:           nonEmpty(v.DhcpOptionsID, dhcpDefault),
 		InstanceTenancy:         nonEmpty(v.InstanceTenancy, tenancyDefaultXML),
 		IsDefault:               false,
-		OwnerID:                 ownerID,
+		OwnerID:                 h.accountID,
 		CidrBlockAssociationSet: vpcCidrAssociationSet(v),
 		Tags:                    toTagItems(v.Tags),
 	}

--- a/server/aws/ec2/xml.go
+++ b/server/aws/ec2/xml.go
@@ -12,10 +12,6 @@ const (
 	stateCodeStopping     = 64
 	stateCodeStopped      = 80
 
-	// Canonical "owner" returned in responses. SDK clients don't validate it;
-	// any 12-digit account id works.
-	ownerID = "123456789012"
-
 	// stateRunning is the driver's string name for a running instance.
 	stateRunning = "running"
 )


### PR DESCRIPTION
## Summary

EC2 hardcoded the AWS account id `123456789012` for every owner-id and ARN it emitted, while every other AWS service (STS, IAM, SQS, SNS, DynamoDB, ...) uses the server's configured account id (`Drivers.AccountID` / `config.WithAccountID`, default `000000000000` for the standalone binary). Anything parsing owner-ids or ARNs across services — cross-service IaC, cost tooling — saw EC2 belonging to a different account than the rest of the emulator.

## What changed

- **Provider mock** (`providers/aws/ec2`): removed the hardcoded `awsAccountID` const; volumes/snapshots/images/reservations and the default-EBS-key ARN now use `m.opts.AccountID` (the same source `o.AccountID` STS/IAM read), matching the existing `m.opts.Region` pattern.
- **Wire handler** (`server/aws/ec2`): removed the package-level `ownerID` const; the `Handler` now carries a configured `accountID` (defaults to `000000000000` when empty), threaded in from `d.AccountID` in `server/aws/aws.go` exactly like `iam.New(d.IAM, d.AccountID)`. Every VPC/subnet/route-table/IGW/NACL/DHCP/prefix-list/security-group owner-id and ARN now reflects it.

A custom `--account-id` (or `config.WithAccountID`) is now reflected by EC2 too — previously it was ignored for EC2 resources.

## Test

Added `TestEC2AccountIDMatchesSTS`: boots the AWS server with a custom account id and asserts an EC2 VPC's `ownerId` equals both the configured id and `STS GetCallerIdentity`'s account — proving cross-service consistency.

Full `go test ./...` is green; `go generate` produces no docs diff; no new lint issues.