### PR TITLE
feat(auth): opt-in AWS IAM authorization gate — action-level CheckPermission (PR2 of #493)

### DIFF
--- a/cmd/cloudemu/serve.go
+++ b/cmd/cloudemu/serve.go
@@ -115,8 +115,10 @@ func runServe(args []string) error {
 	fs.BoolVar(&c.persistMetaOnly, "persist-metadata-only", false, "persist resource structure but omit object bodies (smaller snapshot)")
 	fs.StringVar(&c.initDir, "init-dir", "", "apply every *.json seed fixture in this directory on startup")
 	fs.BoolVar(&c.enforceAuth, "enforce-auth", false,
-		"verify the AWS SigV4 signature on each request against a registered IAM access key (403 on failure); off by default. "+
-			"Long-term (AKIA) keys are verified; STS temporary (ASIA) credentials are accepted unverified for now (a follow-up)")
+		"verify the AWS SigV4 signature on each request against a registered IAM access key (403 on failure) and enforce IAM "+
+			"authorization; off by default. Long-term (AKIA) keys are verified; STS temporary (ASIA) credentials are accepted "+
+			"unverified for now. Authorization is enforced for JSON-RPC services only (query/REST are authenticated only) and "+
+			"applies only to principals that have IAM policies (a policy-less user and the admin/root identity are unrestricted)")
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "Usage: cloudemu serve [flags]\n\nStart the standalone emulator. Flags:\n")
 		fs.PrintDefaults()

--- a/compat/aws/auth_authz_compat_test.go
+++ b/compat/aws/auth_authz_compat_test.go
@@ -1,0 +1,241 @@
+package aws
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/internal/compat"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// staticConfig builds an aws-sdk-go-v2 config that signs with the given static
+// credentials, so a real SDK client authenticates as a specific IAM user.
+func staticConfig(t *testing.T, accessKeyID, secret string) aws.Config {
+	t.Helper()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(accessKeyID, secret, ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("load aws config: %v", err)
+	}
+
+	return cfg
+}
+
+// attachInlinePolicy grants a user an inline policy document directly on the
+// driver, used to set up an authenticated caller's permissions for the test.
+func attachInlinePolicy(t *testing.T, m iamdriver.IAM, userName, name, doc string) {
+	t.Helper()
+
+	putter, ok := m.(interface {
+		PutUserPolicy(ctx context.Context, userName, policyName, policyDocument string) error
+	})
+	if !ok {
+		t.Fatal("IAM driver does not support PutUserPolicy")
+	}
+
+	if err := putter.PutUserPolicy(context.Background(), userName, name, doc); err != nil {
+		t.Fatalf("PutUserPolicy: %v", err)
+	}
+}
+
+// TestCompatAWSIAMAuthorizationQuery covers the query protocol (EC2): an IAM
+// user allowed only ec2:DescribeInstances can describe but not run instances.
+func TestCompatAWSIAMAuthorizationQuery(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	akid, secret := registerUserWithKey(t, cloud.IAM, "ec2user")
+	attachInlinePolicy(t, cloud.IAM, "ec2user", "ec2-describe-only", `{
+		"Version": "2012-10-17",
+		"Statement": [{"Effect": "Allow", "Action": "ec2:DescribeInstances", "Resource": "*"}]
+	}`)
+
+	sess := compat.BootAWS(t, awsserver.Drivers{
+		IAM:         cloud.IAM,
+		EC2:         cloud.EC2,
+		EnforceAuth: true,
+	})
+	client := ec2.NewFromConfig(staticConfig(t, akid, secret), func(o *ec2.Options) {
+		o.BaseEndpoint = aws.String(sess.Endpoint())
+	})
+	ctx := context.Background()
+
+	if _, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{}); err != nil {
+		t.Fatalf("DescribeInstances should be authorized, got: %v", err)
+	}
+
+	_, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:  aws.String("ami-12345678"),
+		MinCount: aws.Int32(1),
+		MaxCount: aws.Int32(1),
+	})
+	if code := apiErrorCode(t, err); code != "UnauthorizedOperation" {
+		t.Fatalf("RunInstances: want UnauthorizedOperation, got %q", code)
+	}
+}
+
+// TestCompatAWSIAMAuthorizationJSONRPC covers the JSON-RPC protocol (DynamoDB):
+// a user allowed GetItem/CreateTable but not PutItem is denied PutItem with
+// AccessDeniedException.
+func TestCompatAWSIAMAuthorizationJSONRPC(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	akid, secret := registerUserWithKey(t, cloud.IAM, "ddbuser")
+	attachInlinePolicy(t, cloud.IAM, "ddbuser", "ddb-read-create", `{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["dynamodb:CreateTable", "dynamodb:DescribeTable", "dynamodb:GetItem"],
+			"Resource": "*"
+		}]
+	}`)
+
+	sess := compat.BootAWS(t, awsserver.Drivers{
+		IAM:         cloud.IAM,
+		DynamoDB:    cloud.DynamoDB,
+		EnforceAuth: true,
+	})
+	client := dynamodb.NewFromConfig(staticConfig(t, akid, secret), func(o *dynamodb.Options) {
+		o.BaseEndpoint = aws.String(sess.Endpoint())
+	})
+	ctx := context.Background()
+
+	const table = "authz-items"
+	if _, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:   aws.String(table),
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash},
+		},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+	}); err != nil {
+		t.Fatalf("CreateTable should be authorized, got: %v", err)
+	}
+
+	if _, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(table),
+		Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "a"}},
+	}); err != nil {
+		t.Fatalf("GetItem should be authorized, got: %v", err)
+	}
+
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(table),
+		Item:      map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "a"}},
+	})
+	if code := apiErrorCode(t, err); code != "AccessDeniedException" {
+		t.Fatalf("PutItem: want AccessDeniedException, got %q", code)
+	}
+}
+
+// TestCompatAWSIAMAuthorizationGroup proves group-inherited permissions are
+// honored end-to-end: a user with no attached policy but membership in a group
+// that allows the action can perform it.
+func TestCompatAWSIAMAuthorizationGroup(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	ctx := context.Background()
+
+	akid, secret := registerUserWithKey(t, cloud.IAM, "groupuser")
+	if _, err := cloud.IAM.CreateGroup(ctx, iamdriver.GroupConfig{Name: "ec2-readers"}); err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+
+	pol, err := cloud.IAM.CreatePolicy(ctx, iamdriver.PolicyConfig{
+		Name: "ec2-describe",
+		PolicyDocument: `{"Version":"2012-10-17","Statement":[` +
+			`{"Effect":"Allow","Action":"ec2:DescribeInstances","Resource":"*"}]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+	if err := cloud.IAM.AttachGroupPolicy(ctx, "ec2-readers", pol.ARN); err != nil {
+		t.Fatalf("AttachGroupPolicy: %v", err)
+	}
+	if err := cloud.IAM.AddUserToGroup(ctx, "groupuser", "ec2-readers"); err != nil {
+		t.Fatalf("AddUserToGroup: %v", err)
+	}
+
+	sess := compat.BootAWS(t, awsserver.Drivers{IAM: cloud.IAM, EC2: cloud.EC2, EnforceAuth: true})
+	client := ec2.NewFromConfig(staticConfig(t, akid, secret), func(o *ec2.Options) {
+		o.BaseEndpoint = aws.String(sess.Endpoint())
+	})
+
+	if _, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{}); err != nil {
+		t.Fatalf("DescribeInstances via group policy should be authorized, got: %v", err)
+	}
+}
+
+// TestCompatAWSIAMAuthorizationBoundary proves a permissions boundary caps an
+// otherwise-admin user: an attached allow-all policy still cannot run an action
+// the boundary does not permit.
+func TestCompatAWSIAMAuthorizationBoundary(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	ctx := context.Background()
+
+	akid, secret := registerUserWithKey(t, cloud.IAM, "boundeduser")
+	attachInlinePolicy(t, cloud.IAM, "boundeduser", "admin-all",
+		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}`)
+
+	boundary, err := cloud.IAM.CreatePolicy(ctx, iamdriver.PolicyConfig{
+		Name: "s3-only-boundary",
+		PolicyDocument: `{"Version":"2012-10-17","Statement":[` +
+			`{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	if err := cloud.IAM.PutUserPermissionsBoundary(ctx, "boundeduser", boundary.ARN); err != nil {
+		t.Fatalf("PutUserPermissionsBoundary: %v", err)
+	}
+
+	sess := compat.BootAWS(t, awsserver.Drivers{IAM: cloud.IAM, EC2: cloud.EC2, EnforceAuth: true})
+	client := ec2.NewFromConfig(staticConfig(t, akid, secret), func(o *ec2.Options) {
+		o.BaseEndpoint = aws.String(sess.Endpoint())
+	})
+
+	_, err = client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:  aws.String("ami-12345678"),
+		MinCount: aws.Int32(1),
+		MaxCount: aws.Int32(1),
+	})
+	if code := apiErrorCode(t, err); code != "UnauthorizedOperation" {
+		t.Fatalf("RunInstances outside boundary: want UnauthorizedOperation, got %q", code)
+	}
+}
+
+// TestCompatAWSAuthorizationDisabled confirms that with EnforceAuth off (the
+// default) neither authentication nor authorization applies: the harness's dummy
+// creds run any action, so bootstrap flows are unaffected.
+func TestCompatAWSAuthorizationDisabled(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	sess := compat.BootAWS(t, awsserver.Drivers{IAM: cloud.IAM, EC2: cloud.EC2, DynamoDB: cloud.DynamoDB})
+	ctx := context.Background()
+
+	ec2c := ec2.NewFromConfig(sess.Config(), func(o *ec2.Options) {
+		o.BaseEndpoint = aws.String(sess.Endpoint())
+	})
+	if _, err := ec2c.DescribeInstances(ctx, &ec2.DescribeInstancesInput{}); err != nil {
+		t.Fatalf("DescribeInstances with auth disabled should succeed, got: %v", err)
+	}
+
+	ddbc := dynamodb.NewFromConfig(sess.Config(), func(o *dynamodb.Options) {
+		o.BaseEndpoint = aws.String(sess.Endpoint())
+	})
+	if _, err := ddbc.ListTables(ctx, &dynamodb.ListTablesInput{}); err != nil {
+		t.Fatalf("ListTables with auth disabled should succeed, got: %v", err)
+	}
+}

--- a/compat/aws/auth_authz_compat_test.go
+++ b/compat/aws/auth_authz_compat_test.go
@@ -1,12 +1,20 @@
 package aws
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -52,38 +60,26 @@ func attachInlinePolicy(t *testing.T, m iamdriver.IAM, userName, name, doc strin
 	}
 }
 
-// TestCompatAWSIAMAuthorizationQuery covers the query protocol (EC2): an IAM
-// user allowed only ec2:DescribeInstances can describe but not run instances.
-func TestCompatAWSIAMAuthorizationQuery(t *testing.T) {
-	cloud := cloudemu.NewAWS()
-	akid, secret := registerUserWithKey(t, cloud.IAM, "ec2user")
-	attachInlinePolicy(t, cloud.IAM, "ec2user", "ec2-describe-only", `{
-		"Version": "2012-10-17",
-		"Statement": [{"Effect": "Allow", "Action": "ec2:DescribeInstances", "Resource": "*"}]
-	}`)
+// createTable creates a simple hash-keyed table via a real DynamoDB client.
+func createTable(t *testing.T, client *dynamodb.Client, table string) {
+	t.Helper()
 
-	sess := compat.BootAWS(t, awsserver.Drivers{
-		IAM:         cloud.IAM,
-		EC2:         cloud.EC2,
-		EnforceAuth: true,
-	})
-	client := ec2.NewFromConfig(staticConfig(t, akid, secret), func(o *ec2.Options) {
-		o.BaseEndpoint = aws.String(sess.Endpoint())
-	})
-	ctx := context.Background()
-
-	if _, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{}); err != nil {
-		t.Fatalf("DescribeInstances should be authorized, got: %v", err)
+	if _, err := client.CreateTable(context.Background(), &dynamodb.CreateTableInput{
+		TableName:   aws.String(table),
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash},
+		},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+	}); err != nil {
+		t.Fatalf("CreateTable should be authorized, got: %v", err)
 	}
+}
 
-	_, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
-		ImageId:  aws.String("ami-12345678"),
-		MinCount: aws.Int32(1),
-		MaxCount: aws.Int32(1),
-	})
-	if code := apiErrorCode(t, err); code != "UnauthorizedOperation" {
-		t.Fatalf("RunInstances: want UnauthorizedOperation, got %q", code)
-	}
+func ddbKey(id string) map[string]ddbtypes.AttributeValue {
+	return map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: id}}
 }
 
 // TestCompatAWSIAMAuthorizationJSONRPC covers the JSON-RPC protocol (DynamoDB):
@@ -112,29 +108,18 @@ func TestCompatAWSIAMAuthorizationJSONRPC(t *testing.T) {
 	ctx := context.Background()
 
 	const table = "authz-items"
-	if _, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
-		TableName:   aws.String(table),
-		BillingMode: ddbtypes.BillingModePayPerRequest,
-		KeySchema: []ddbtypes.KeySchemaElement{
-			{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash},
-		},
-		AttributeDefinitions: []ddbtypes.AttributeDefinition{
-			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
-		},
-	}); err != nil {
-		t.Fatalf("CreateTable should be authorized, got: %v", err)
-	}
+	createTable(t, client, table)
 
 	if _, err := client.GetItem(ctx, &dynamodb.GetItemInput{
 		TableName: aws.String(table),
-		Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "a"}},
+		Key:       ddbKey("a"),
 	}); err != nil {
 		t.Fatalf("GetItem should be authorized, got: %v", err)
 	}
 
 	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
 		TableName: aws.String(table),
-		Item:      map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "a"}},
+		Item:      ddbKey("a"),
 	})
 	if code := apiErrorCode(t, err); code != "AccessDeniedException" {
 		t.Fatalf("PutItem: want AccessDeniedException, got %q", code)
@@ -143,44 +128,47 @@ func TestCompatAWSIAMAuthorizationJSONRPC(t *testing.T) {
 
 // TestCompatAWSIAMAuthorizationGroup proves group-inherited permissions are
 // honored end-to-end: a user with no attached policy but membership in a group
-// that allows the action can perform it.
+// that allows the action can perform it (JSON-RPC / DynamoDB).
 func TestCompatAWSIAMAuthorizationGroup(t *testing.T) {
 	cloud := cloudemu.NewAWS()
 	ctx := context.Background()
 
 	akid, secret := registerUserWithKey(t, cloud.IAM, "groupuser")
-	if _, err := cloud.IAM.CreateGroup(ctx, iamdriver.GroupConfig{Name: "ec2-readers"}); err != nil {
+	if _, err := cloud.IAM.CreateGroup(ctx, iamdriver.GroupConfig{Name: "ddb-readers"}); err != nil {
 		t.Fatalf("CreateGroup: %v", err)
 	}
 
 	pol, err := cloud.IAM.CreatePolicy(ctx, iamdriver.PolicyConfig{
-		Name: "ec2-describe",
-		PolicyDocument: `{"Version":"2012-10-17","Statement":[` +
-			`{"Effect":"Allow","Action":"ec2:DescribeInstances","Resource":"*"}]}`,
+		Name: "ddb-read-create",
+		PolicyDocument: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+			`"Action":["dynamodb:CreateTable","dynamodb:DescribeTable","dynamodb:GetItem"],"Resource":"*"}]}`,
 	})
 	if err != nil {
 		t.Fatalf("CreatePolicy: %v", err)
 	}
-	if err := cloud.IAM.AttachGroupPolicy(ctx, "ec2-readers", pol.ARN); err != nil {
+	if err := cloud.IAM.AttachGroupPolicy(ctx, "ddb-readers", pol.ARN); err != nil {
 		t.Fatalf("AttachGroupPolicy: %v", err)
 	}
-	if err := cloud.IAM.AddUserToGroup(ctx, "groupuser", "ec2-readers"); err != nil {
+	if err := cloud.IAM.AddUserToGroup(ctx, "groupuser", "ddb-readers"); err != nil {
 		t.Fatalf("AddUserToGroup: %v", err)
 	}
 
-	sess := compat.BootAWS(t, awsserver.Drivers{IAM: cloud.IAM, EC2: cloud.EC2, EnforceAuth: true})
-	client := ec2.NewFromConfig(staticConfig(t, akid, secret), func(o *ec2.Options) {
+	sess := compat.BootAWS(t, awsserver.Drivers{IAM: cloud.IAM, DynamoDB: cloud.DynamoDB, EnforceAuth: true})
+	client := dynamodb.NewFromConfig(staticConfig(t, akid, secret), func(o *dynamodb.Options) {
 		o.BaseEndpoint = aws.String(sess.Endpoint())
 	})
 
-	if _, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{}); err != nil {
-		t.Fatalf("DescribeInstances via group policy should be authorized, got: %v", err)
+	const table = "group-items"
+	createTable(t, client, table)
+
+	if _, err := client.GetItem(ctx, &dynamodb.GetItemInput{TableName: aws.String(table), Key: ddbKey("a")}); err != nil {
+		t.Fatalf("GetItem via group policy should be authorized, got: %v", err)
 	}
 }
 
 // TestCompatAWSIAMAuthorizationBoundary proves a permissions boundary caps an
 // otherwise-admin user: an attached allow-all policy still cannot run an action
-// the boundary does not permit.
+// the boundary does not permit (JSON-RPC / DynamoDB).
 func TestCompatAWSIAMAuthorizationBoundary(t *testing.T) {
 	cloud := cloudemu.NewAWS()
 	ctx := context.Background()
@@ -190,30 +178,113 @@ func TestCompatAWSIAMAuthorizationBoundary(t *testing.T) {
 		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}`)
 
 	boundary, err := cloud.IAM.CreatePolicy(ctx, iamdriver.PolicyConfig{
-		Name: "s3-only-boundary",
-		PolicyDocument: `{"Version":"2012-10-17","Statement":[` +
-			`{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}`,
+		Name: "ddb-read-boundary",
+		PolicyDocument: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+			`"Action":["dynamodb:CreateTable","dynamodb:DescribeTable","dynamodb:GetItem"],"Resource":"*"}]}`,
 	})
 	if err != nil {
 		t.Fatalf("CreatePolicy: %v", err)
 	}
-
 	if err := cloud.IAM.PutUserPermissionsBoundary(ctx, "boundeduser", boundary.ARN); err != nil {
 		t.Fatalf("PutUserPermissionsBoundary: %v", err)
 	}
+
+	sess := compat.BootAWS(t, awsserver.Drivers{IAM: cloud.IAM, DynamoDB: cloud.DynamoDB, EnforceAuth: true})
+	client := dynamodb.NewFromConfig(staticConfig(t, akid, secret), func(o *dynamodb.Options) {
+		o.BaseEndpoint = aws.String(sess.Endpoint())
+	})
+
+	const table = "bounded-items"
+	createTable(t, client, table)
+
+	// Within the boundary: GetItem is allowed by both the admin policy and the boundary.
+	if _, err := client.GetItem(ctx, &dynamodb.GetItemInput{TableName: aws.String(table), Key: ddbKey("a")}); err != nil {
+		t.Fatalf("GetItem within boundary should be authorized, got: %v", err)
+	}
+
+	// Outside the boundary: PutItem is allowed by the admin policy but not the boundary.
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{TableName: aws.String(table), Item: ddbKey("a")})
+	if code := apiErrorCode(t, err); code != "AccessDeniedException" {
+		t.Fatalf("PutItem outside boundary: want AccessDeniedException, got %q", code)
+	}
+}
+
+// TestCompatAWSAuthorizationCrossServiceBypassClosed is the regression guard for
+// the credential-scope authorization bypass. It signs a request with a SigV4
+// credential scope of "s3" (which the caller's policy fully allows) but sends a
+// DynamoDB X-Amz-Target. Because the gate derives the IAM service from the
+// dispatch key (X-Amz-Target -> dynamodb), not the client-controlled scope, the
+// action authorized is dynamodb:PutItem — which the caller is NOT granted — so
+// the request is denied even though the signed scope is s3.
+func TestCompatAWSAuthorizationCrossServiceBypassClosed(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	akid, secret := registerUserWithKey(t, cloud.IAM, "bypasser")
+	// Full S3 access, nothing else. If the service came from the scope this would
+	// resolve to s3:PutItem (allowed) while the DynamoDB PutItem handler runs.
+	attachInlinePolicy(t, cloud.IAM, "bypasser", "s3-full",
+		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}`)
+
+	sess := compat.BootAWS(t, awsserver.Drivers{IAM: cloud.IAM, DynamoDB: cloud.DynamoDB, EnforceAuth: true})
+
+	body := []byte(`{"TableName":"anything","Item":{"id":{"S":"a"}}}`)
+	req, err := http.NewRequest(http.MethodPost, sess.Endpoint()+"/", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.PutItem")
+
+	// Sign with service "s3" so authentication (which reads the scope service)
+	// succeeds, while the X-Amz-Target still names DynamoDB.
+	sum := sha256.Sum256(body)
+	creds := aws.Credentials{AccessKeyID: akid, SecretAccessKey: secret}
+	if err := v4.NewSigner().SignHTTP(
+		context.Background(), creds, req, hex.EncodeToString(sum[:]), "s3", "us-east-1", time.Now().UTC(),
+	); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("cross-service bypass not closed: want 403, got %d (%s)", resp.StatusCode, raw)
+	}
+
+	var errBody struct {
+		Type string `json:"__type"`
+	}
+	if err := json.Unmarshal(raw, &errBody); err != nil {
+		t.Fatalf("decode error body %q: %v", raw, err)
+	}
+	if errBody.Type != "AccessDeniedException" {
+		t.Fatalf("want __type AccessDeniedException, got %q (%s)", errBody.Type, raw)
+	}
+}
+
+// TestCompatAWSAuthorizationQueryAuthenticatedOnly pins the documented limitation
+// that the query protocol is authenticated but NOT authorization-enforced in this
+// revision: a user whose policy grants only dynamodb:GetItem (no EC2 permission)
+// can still make an authenticated EC2 query call, because query authorization —
+// which cannot be soundly bound to the executed operation before dispatch — is a
+// follow-up.
+func TestCompatAWSAuthorizationQueryAuthenticatedOnly(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	akid, secret := registerUserWithKey(t, cloud.IAM, "queryuser")
+	attachInlinePolicy(t, cloud.IAM, "queryuser", "ddb-get-only",
+		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"dynamodb:GetItem","Resource":"*"}]}`)
 
 	sess := compat.BootAWS(t, awsserver.Drivers{IAM: cloud.IAM, EC2: cloud.EC2, EnforceAuth: true})
 	client := ec2.NewFromConfig(staticConfig(t, akid, secret), func(o *ec2.Options) {
 		o.BaseEndpoint = aws.String(sess.Endpoint())
 	})
 
-	_, err = client.RunInstances(ctx, &ec2.RunInstancesInput{
-		ImageId:  aws.String("ami-12345678"),
-		MinCount: aws.Int32(1),
-		MaxCount: aws.Int32(1),
-	})
-	if code := apiErrorCode(t, err); code != "UnauthorizedOperation" {
-		t.Fatalf("RunInstances outside boundary: want UnauthorizedOperation, got %q", code)
+	if _, err := client.DescribeInstances(context.Background(), &ec2.DescribeInstancesInput{}); err != nil {
+		t.Fatalf("query call is authenticated-only and should succeed, got: %v", err)
 	}
 }
 

--- a/config/options.go
+++ b/config/options.go
@@ -72,8 +72,10 @@ type Options struct {
 
 	// EnforceAuth, when true, makes the AWS wire server verify the SigV4
 	// signature on each incoming request against a registered IAM access key and
-	// reject bad/missing signatures with 403. Default false, which accepts any
-	// credentials exactly as before (the historical behavior).
+	// reject bad/missing signatures with 403. It also gates JSON-RPC operations
+	// through IAM authorization (see WithEnforceAuth for the exact scope and
+	// limitations). Default false, which accepts any credentials exactly as
+	// before (the historical behavior).
 	EnforceAuth bool
 }
 
@@ -190,15 +192,28 @@ func WithAsyncSettle() Option {
 	}
 }
 
-// WithEnforceAuth turns on AWS SigV4 request authentication: the wire server
-// verifies each request's signature against a registered IAM access key and
-// rejects bad/missing signatures with 403. Off by default, which accepts any
-// credentials (the historical behavior).
+// WithEnforceAuth turns on AWS SigV4 request authentication and IAM
+// authorization: the wire server verifies each request's signature against a
+// registered IAM access key (rejecting bad/missing signatures with 403) and then
+// checks the caller's IAM policies before dispatch. Off by default, which accepts
+// any credentials (the historical behavior).
 //
-// Scope of this revision: long-term (AKIA) access-key signatures are verified;
-// STS temporary (ASIA) credentials are accepted without signature verification
-// (a follow-up), and request timestamps are not checked for expiry. It is
-// authentication only — IAM policy is not yet enforced on the wire.
+// Authentication scope: long-term (AKIA) access-key signatures are verified; STS
+// temporary (ASIA) credentials are accepted without signature verification (a
+// follow-up), and request timestamps are not checked for expiry.
+//
+// Authorization scope: enforced for JSON-RPC services (DynamoDB, KMS, SQS, …),
+// where the operation is bound to the X-Amz-Target header the dispatcher routes
+// on. Query and REST services are authenticated only — their executed operation's
+// IAM service cannot be soundly determined before dispatch (query routing is by
+// action name and the SigV4 credential scope is client-controlled), so
+// action+resource authorization for them is a follow-up. Authorization is
+// action-level (resource "*").
+//
+// Foundation limitation: authorization applies only to principals that have IAM
+// policies defined. A valid IAM user or role with NO policies is left
+// unrestricted here (real AWS implicit-denies a policy-less principal), and the
+// account-admin/root and ASIA bootstrap identities are always allowed.
 func WithEnforceAuth() Option {
 	return func(o *Options) {
 		o.EnforceAuth = true

--- a/docs/coverage/aws/iam.md
+++ b/docs/coverage/aws/iam.md
@@ -60,6 +60,14 @@ AccessKeyResolver is an optional capability: an IAM implementation that can
 | --- | --- |
 | `AccessKeyByID` |  |
 
+### PolicyInspector
+
+PolicyInspector is an optional capability: an IAM implementation that can
+
+| Operation | Description |
+| --- | --- |
+| `PrincipalHasPolicies` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/azure/iam.md
+++ b/docs/coverage/azure/iam.md
@@ -60,6 +60,14 @@ AccessKeyResolver is an optional capability: an IAM implementation that can
 | --- | --- |
 | `AccessKeyByID` |  |
 
+### PolicyInspector
+
+PolicyInspector is an optional capability: an IAM implementation that can
+
+| Operation | Description |
+| --- | --- |
+| `PrincipalHasPolicies` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -5323,6 +5323,15 @@
             "name": "AccessKeyByID"
           }
         ]
+      },
+      {
+        "name": "PolicyInspector",
+        "doc": "PolicyInspector is an optional capability: an IAM implementation that can",
+        "operations": [
+          {
+            "name": "PrincipalHasPolicies"
+          }
+        ]
       }
     ],
     "providers": {

--- a/docs/coverage/gcp/iam.md
+++ b/docs/coverage/gcp/iam.md
@@ -60,6 +60,14 @@ AccessKeyResolver is an optional capability: an IAM implementation that can
 | --- | --- |
 | `AccessKeyByID` |  |
 
+### PolicyInspector
+
+PolicyInspector is an optional capability: an IAM implementation that can
+
+| Operation | Description |
+| --- | --- |
+| `PrincipalHasPolicies` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/oci/identity.md
+++ b/docs/coverage/oci/identity.md
@@ -60,6 +60,14 @@ AccessKeyResolver is an optional capability: an IAM implementation that can
 | --- | --- |
 | `AccessKeyByID` |  |
 
+### PolicyInspector
+
+PolicyInspector is an optional capability: an IAM implementation that can
+
+| Operation | Description |
+| --- | --- |
+| `PrincipalHasPolicies` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/providers/aws/iam/check_permission_depth_test.go
+++ b/providers/aws/iam/check_permission_depth_test.go
@@ -1,0 +1,157 @@
+package iam
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// TestCheckPermissionViaGroup proves the deepened evaluation honors policies a
+// user inherits from a group it belongs to (not just directly attached ones).
+func TestCheckPermissionViaGroup(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	requireNoError(t, mustUser(t, m, "dana"))
+	requireNoError(t, mustGroup(t, m, "readers"))
+
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{
+		Name: "s3-read",
+		PolicyDocument: makePolicyDoc([]map[string]any{
+			{"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"},
+		}),
+	})
+	requireNoError(t, err)
+	requireNoError(t, m.AttachGroupPolicy(ctx, "readers", p.ARN))
+	requireNoError(t, m.AddUserToGroup(ctx, "dana", "readers"))
+
+	allowed, err := m.CheckPermission(ctx, "dana", "s3:GetObject", "*")
+	requireNoError(t, err)
+	assertEqual(t, true, allowed)
+
+	denied, err := m.CheckPermission(ctx, "dana", "s3:PutObject", "*")
+	requireNoError(t, err)
+	assertEqual(t, false, denied)
+}
+
+// TestCheckPermissionViaInlinePolicy proves inline user policies are evaluated.
+func TestCheckPermissionViaInlinePolicy(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	requireNoError(t, mustUser(t, m, "erin"))
+	requireNoError(t, m.PutUserPolicy(ctx, "erin", "inline-read", makePolicyDoc([]map[string]any{
+		{"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"},
+	})))
+
+	allowed, err := m.CheckPermission(ctx, "erin", "s3:GetObject", "*")
+	requireNoError(t, err)
+	assertEqual(t, true, allowed)
+}
+
+// TestCheckPermissionPermissionsBoundary proves a permissions boundary intersects
+// the identity policies: an action allowed by an attached policy is still denied
+// when the boundary does not permit it, and allowed when both do.
+func TestCheckPermissionPermissionsBoundary(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	requireNoError(t, mustUser(t, m, "frank"))
+
+	admin, err := m.CreatePolicy(ctx, driver.PolicyConfig{
+		Name: "admin-all",
+		PolicyDocument: makePolicyDoc([]map[string]any{
+			{"Effect": "Allow", "Action": "*", "Resource": "*"},
+		}),
+	})
+	requireNoError(t, err)
+	requireNoError(t, m.AttachUserPolicy(ctx, "frank", admin.ARN))
+
+	boundary, err := m.CreatePolicy(ctx, driver.PolicyConfig{
+		Name: "boundary-s3-only",
+		PolicyDocument: makePolicyDoc([]map[string]any{
+			{"Effect": "Allow", "Action": "s3:*", "Resource": "*"},
+		}),
+	})
+	requireNoError(t, err)
+	requireNoError(t, m.PutUserPermissionsBoundary(ctx, "frank", boundary.ARN))
+
+	t.Run("within boundary allowed", func(t *testing.T) {
+		allowed, err := m.CheckPermission(ctx, "frank", "s3:GetObject", "*")
+		requireNoError(t, err)
+		assertEqual(t, true, allowed)
+	})
+
+	t.Run("outside boundary denied despite admin allow", func(t *testing.T) {
+		allowed, err := m.CheckPermission(ctx, "frank", "ec2:RunInstances", "*")
+		requireNoError(t, err)
+		assertEqual(t, false, allowed)
+	})
+}
+
+// TestCheckPermissionExplicitDenyInGroupWins proves an explicit Deny inherited
+// from a group overrides an Allow on a directly attached policy.
+func TestCheckPermissionExplicitDenyInGroupWins(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	requireNoError(t, mustUser(t, m, "gwen"))
+	requireNoError(t, mustGroup(t, m, "locked"))
+
+	allow, err := m.CreatePolicy(ctx, driver.PolicyConfig{
+		Name: "allow-all",
+		PolicyDocument: makePolicyDoc([]map[string]any{
+			{"Effect": "Allow", "Action": "*", "Resource": "*"},
+		}),
+	})
+	requireNoError(t, err)
+	requireNoError(t, m.AttachUserPolicy(ctx, "gwen", allow.ARN))
+
+	deny, err := m.CreatePolicy(ctx, driver.PolicyConfig{
+		Name: "deny-terminate",
+		PolicyDocument: makePolicyDoc([]map[string]any{
+			{"Effect": "Deny", "Action": "ec2:TerminateInstances", "Resource": "*"},
+		}),
+	})
+	requireNoError(t, err)
+	requireNoError(t, m.AttachGroupPolicy(ctx, "locked", deny.ARN))
+	requireNoError(t, m.AddUserToGroup(ctx, "gwen", "locked"))
+
+	allowed, err := m.CheckPermission(ctx, "gwen", "ec2:TerminateInstances", "*")
+	requireNoError(t, err)
+	assertEqual(t, false, allowed)
+}
+
+// TestPrincipalHasPolicies confirms the inspector distinguishes a principal with
+// no policies from one that has an attached, inline, group, or boundary policy.
+func TestPrincipalHasPolicies(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	requireNoError(t, mustUser(t, m, "hank"))
+	if m.PrincipalHasPolicies(ctx, "hank") {
+		t.Fatal("fresh user should report no policies")
+	}
+
+	requireNoError(t, m.PutUserPolicy(ctx, "hank", "inline", makePolicyDoc([]map[string]any{
+		{"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"},
+	})))
+	if !m.PrincipalHasPolicies(ctx, "hank") {
+		t.Fatal("user with an inline policy should report having policies")
+	}
+}
+
+func mustUser(t *testing.T, m *Mock, name string) error {
+	t.Helper()
+	_, err := m.CreateUser(context.Background(), driver.UserConfig{Name: name})
+
+	return err
+}
+
+func mustGroup(t *testing.T, m *Mock, name string) error {
+	t.Helper()
+	_, err := m.CreateGroup(context.Background(), driver.GroupConfig{Name: name})
+
+	return err
+}

--- a/providers/aws/iam/iam.go
+++ b/providers/aws/iam/iam.go
@@ -28,6 +28,10 @@ var _ driver.IAM = (*Mock)(nil)
 // by the AWS SigV4 authentication gate.
 var _ driver.AccessKeyResolver = (*Mock)(nil)
 
+// Compile-time check that Mock implements the optional policy inspector used by
+// the AWS IAM authorization gate.
+var _ driver.PolicyInspector = (*Mock)(nil)
+
 // Mock is an in-memory mock implementation of the AWS IAM service.
 type Mock struct {
 	users            *memstore.Store[*userData]
@@ -853,51 +857,89 @@ func evaluatePolicy(doc, action, resource string) (allow, deny bool) {
 	return allow, deny
 }
 
-func (m *Mock) collectPolicyARNs(principal string) map[string]bool {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+// CheckPermission reports whether a principal (a user, role, or group friendly
+// name) is allowed to perform action on resource. It evaluates the principal's
+// full effective policy set — attached managed policies, inline policies, and
+// (for a user) the policies inherited from every group it belongs to — and,
+// when a permissions boundary is attached, intersects that set with the
+// boundary: the action must be allowed by BOTH the identity policies and the
+// boundary. An explicit Deny anywhere wins; the default is an implicit deny.
+func (m *Mock) CheckPermission(_ context.Context, principal, action, resource string) (bool, error) {
+	entityType := m.principalEntityType(principal)
 
-	policyARNs := make(map[string]bool)
-
-	for arn := range m.userPolicies[principal] {
-		policyARNs[arn] = true
+	if decide(m.gatherPrincipalDocs(entityType, principal), action, resource) != decisionAllowed {
+		return false, nil
 	}
 
-	for arn := range m.rolePolicies[principal] {
-		policyARNs[arn] = true
+	if boundary, ok := m.permissionsBoundaryDoc(entityType, principal); ok &&
+		decide([]string{boundary}, action, resource) != decisionAllowed {
+		return false, nil
 	}
 
-	return policyARNs
+	return true, nil
 }
 
-// CheckPermission evaluates attached policies to determine if a principal is allowed
-// to perform the given action on the given resource. Explicit Deny wins over Allow.
-func (m *Mock) CheckPermission(_ context.Context, principal, action, resource string) (bool, error) {
-	policyARNs := m.collectPolicyARNs(principal)
+// principalEntityType classifies an IAM principal named by its friendly name as
+// a user, role, or group (in that precedence), or "" when no such entity exists.
+func (m *Mock) principalEntityType(name string) string {
+	switch {
+	case m.users.Has(name):
+		return "user"
+	case m.roles.Has(name):
+		return "role"
+	case m.groups.Has(name):
+		return "group"
+	default:
+		return ""
+	}
+}
 
+// permissionsBoundaryDoc returns the policy document of the permissions boundary
+// attached to a user or role, and ok=false when none is set or it cannot be
+// resolved. Groups cannot carry a boundary.
+func (m *Mock) permissionsBoundaryDoc(entityType, name string) (string, bool) {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
 
-	hasAllow := false
+	arn := ""
 
-	for arn := range policyARNs {
-		p, ok := m.policies.Get(arn)
-		if !ok || p.PolicyDocument == "" {
-			continue
+	switch entityType {
+	case "user":
+		if u, ok := m.users.Get(name); ok {
+			arn = u.permissionsBoundary
 		}
-
-		allow, deny := evaluatePolicy(p.PolicyDocument, action, resource)
-
-		if deny {
-			return false, nil
-		}
-
-		if allow {
-			hasAllow = true
+	case "role":
+		if rd, ok := m.roles.Get(name); ok {
+			arn = rd.permissionsBoundary
 		}
 	}
 
-	return hasAllow, nil
+	m.mu.RUnlock()
+
+	if arn == "" {
+		return "", false
+	}
+
+	if p, ok := m.policies.Get(arn); ok && p.PolicyDocument != "" {
+		return p.PolicyDocument, true
+	}
+
+	return "", false
+}
+
+// PrincipalHasPolicies reports whether a user or role has any identity policies
+// (attached, inline, or group-inherited) or a permissions boundary in effect.
+// The authorization gate uses it to leave a principal with no policies defined
+// unrestricted, enforcing CheckPermission only once policies exist.
+func (m *Mock) PrincipalHasPolicies(_ context.Context, name string) bool {
+	entityType := m.principalEntityType(name)
+
+	if len(m.gatherPrincipalDocs(entityType, name)) > 0 {
+		return true
+	}
+
+	_, hasBoundary := m.permissionsBoundaryDoc(entityType, name)
+
+	return hasBoundary
 }
 
 // CreateGroup creates a new IAM group.

--- a/providers/aws/iam/simulate.go
+++ b/providers/aws/iam/simulate.go
@@ -11,6 +11,14 @@ import (
 // portable driver; the wire layer reaches them via a type assertion on the
 // Mock. The evaluation reuses the same wildcard matcher CheckPermission uses.
 
+// Policy-evaluation decisions. These are the AWS SimulatePolicy EvalDecision
+// values and are shared by CheckPermission so authorization matches simulation.
+const (
+	decisionAllowed      = "allowed"
+	decisionExplicitDeny = "explicitDeny"
+	decisionImplicitDeny = "implicitDeny"
+)
+
 // SimulatePrincipalPolicy evaluates the policies attached to the principal
 // named by policySourceARN (plus any extra policy documents) against each
 // action/resource pair (IAM SimulatePrincipalPolicy).
@@ -74,11 +82,11 @@ func decide(docs []string, action, resource string) string {
 
 	switch {
 	case deny:
-		return "explicitDeny"
+		return decisionExplicitDeny
 	case allow:
-		return "allowed"
+		return decisionAllowed
 	default:
-		return "implicitDeny"
+		return decisionImplicitDeny
 	}
 }
 

--- a/server/aws/authgate.go
+++ b/server/aws/authgate.go
@@ -67,7 +67,7 @@ func newAuthGate(iamDriver iamdriver.IAM, accountID string) func(http.ResponseWr
 			return r, false
 		}
 
-		if !authorize(w, r, body, principal, iamDriver) {
+		if !authorize(w, r, principal, iamDriver) {
 			return r, false
 		}
 

--- a/server/aws/authgate.go
+++ b/server/aws/authgate.go
@@ -67,6 +67,10 @@ func newAuthGate(iamDriver iamdriver.IAM, accountID string) func(http.ResponseWr
 			return r, false
 		}
 
+		if !authorize(w, r, body, principal, iamDriver) {
+			return r, false
+		}
+
 		return withPrincipal(r, principal), true
 	}
 }

--- a/server/aws/authzgate.go
+++ b/server/aws/authzgate.go
@@ -2,39 +2,95 @@ package aws
 
 import (
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/authctx"
 	"github.com/stackshy/cloudemu/v2/server/wire"
-	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
 )
 
-// ec2Service is the SigV4 credential-scope service name for the EC2 query
-// endpoint (also used for VPC/Auto Scaling, which share it). EC2 reports an
-// authorization failure as UnauthorizedOperation rather than AccessDenied.
-const ec2Service = "ec2"
+// authzDecision is the outcome of deriving an IAM action for a request.
+type authzDecision int
 
-// authorize is the authorization step layered on top of the SigV4
-// authentication gate. It runs only when EnforceAuth is on and after a request
-// has been authenticated, so p is a verified IAM principal (a user resolved from
-// a long-term access key). It derives the IAM action for the request, and for a
-// real IAM principal that has policies defined it gates the action through
-// CheckPermission. It returns proceed=false only when the action is denied, in
-// which case it has already written the 403.
+const (
+	// authzSkip: the request is authenticated only (REST and other protocols
+	// whose executed operation is not bound to a signal the gate can read before
+	// dispatch). No authorization decision is made.
+	authzSkip authzDecision = iota
+	// authzEnforce: the IAM action was derived from the dispatch key; gate it
+	// through CheckPermission.
+	authzEnforce
+	// authzDeny: the request is a JSON-RPC call whose target does not map to a
+	// known served service, so the executed operation cannot be bound to an IAM
+	// action. Fail closed rather than authorize on an unverifiable service.
+	authzDeny
+)
+
+// jsonRPCServiceByTarget maps a JSON-RPC X-Amz-Target prefix (the part before
+// the operation, e.g. "DynamoDB_20120810." or "TrentService.") to the IAM
+// service the operation belongs to. The X-Amz-Target header is the value the
+// dispatcher itself routes on, so a service derived from it is bound to the
+// handler that actually runs — unlike the SigV4 credential scope, which the
+// client controls independently of the operation. Every JSON-RPC service the
+// wire server serves must appear here; an unmapped target fails closed.
 //
-// Authorization is enforced only for the query and JSON-RPC protocols, where the
-// action is derivable from the request before dispatch (the SigV4 scope service
-// plus the Action parameter or the X-Amz-Target operation). REST services (S3,
-// Lambda, Route53, EFS, EKS, …) carry no pre-dispatch action here, so they are
-// authenticated only; resource-level and REST authorization are a follow-up.
+//nolint:gochecknoglobals // static protocol lookup table
+var jsonRPCServiceByTarget = map[string]string{
+	"DynamoDB_20120810.":                    "dynamodb",
+	"DynamoDBStreams_20120810.":             "dynamodb",
+	"AmazonSQS.":                            "sqs",
+	"AmazonSSM.":                            "ssm",
+	"TrentService.":                         "kms",
+	"CertificateManager.":                   "acm",
+	"AWSStepFunctions.":                     "states",
+	"Kinesis_20131202.":                     "kinesis",
+	"CloudTrail_20131101.":                  "cloudtrail",
+	"AWSGlue.":                              "glue",
+	"StarlingDoveService.":                  "config",
+	"AWSWAF_20190729.":                      "wafv2",
+	"AmazonEC2ContainerServiceV20141113.":   "ecs",
+	"AmazonEC2ContainerRegistry_V20150921.": "ecr",
+	"Route53Resolver.":                      "route53resolver",
+	"AWSEvents.":                            "events",
+	"Logs_20140328.":                        "logs",
+	"SageMaker.":                            "sagemaker",
+	"secretsmanager.":                       "secretsmanager",
+	"KeyspacesService.":                     "cassandra",
+	"AmazonMemoryDB.":                       "memorydb",
+	"NetworkFirewall_20201112.":             "network-firewall",
+	"ResourceGroupsTaggingAPI_20170126.":    "tag",
+}
+
+// authorize is the authorization step layered on top of the SigV4 authentication
+// gate. It runs only when EnforceAuth is on and after a request has been
+// authenticated, so p is a verified IAM principal. It derives the IAM action for
+// the request from the dispatch key and, for a real IAM principal that has
+// policies defined, gates the action through CheckPermission. It returns
+// proceed=false only when the action is denied, having already written the 403.
+//
+// Authorization is enforced for the JSON-RPC protocol, where the X-Amz-Target
+// header both routes the request and names the service, so the service the gate
+// authorizes is the one the handler runs. The query and REST protocols are
+// authenticated only: there the executed operation's IAM service is not bound to
+// any pre-dispatch signal the gate can trust — query dispatch routes on the
+// action name (a single handler, e.g. EC2, serves several IAM services such as
+// ec2/vpc/autoscaling), and the SigV4 credential scope is client-controlled and
+// decoupled from the operation. Authorizing query/REST on that scope would let a
+// caller scoped to service A run an operation that executes under service B, so
+// action+resource authorization bound to the routed operation is a follow-up.
 func authorize(
-	w http.ResponseWriter, r *http.Request, body []byte, p authctx.Principal, iamDriver iamdriver.IAM,
+	w http.ResponseWriter, r *http.Request, p authctx.Principal, iamDriver iamdriver.IAM,
 ) bool {
-	service, action, ok := deriveAction(r, body)
-	if !ok {
-		return true // REST / non-derivable action: authenticate only.
+	service, action, decision := deriveAction(r)
+
+	if decision == authzSkip {
+		return true
+	}
+
+	if decision == authzDeny {
+		// JSON-RPC target that maps to no known service: fail closed.
+		writeAuthzDenied(w, p, service+":"+jsonRPCTargetOperation(r))
+		return false
 	}
 
 	if isAdminPrincipal(p) {
@@ -50,52 +106,43 @@ func authorize(
 		return true
 	}
 
-	writeAuthzDenied(w, r, service, p, action)
+	writeAuthzDenied(w, p, action)
 
 	return false
 }
 
-// deriveAction maps an incoming request to its IAM action (e.g. ec2:RunInstances,
-// dynamodb:PutItem). It returns ok=false for requests whose action is not
-// derivable before dispatch — every REST service. The service name comes from
-// the SigV4 credential scope, which is authoritative and unambiguous (the JSON-RPC
-// X-Amz-Target prefix, e.g. "TrentService" for KMS, is not).
-func deriveAction(r *http.Request, body []byte) (service, action string, ok bool) {
-	service = awsquery.CredentialScopeService(r.Header.Get("Authorization"))
-	if service == "" {
-		return "", "", false
+// deriveAction maps an incoming request to its IAM action (e.g. dynamodb:PutItem)
+// using only signals bound to how the request is dispatched. For JSON-RPC it uses
+// the X-Amz-Target header: the prefix selects the service via jsonRPCServiceByTarget
+// (the same header the dispatcher routes on) and the suffix is the operation. A
+// JSON-RPC request whose target prefix is not mapped returns authzDeny (fail
+// closed). All other protocols (query, REST) return authzSkip: authenticate only.
+func deriveAction(r *http.Request) (service, action string, decision authzDecision) {
+	target := r.Header.Get("X-Amz-Target")
+	if target == "" {
+		return "", "", authzSkip
 	}
 
-	if target := r.Header.Get("X-Amz-Target"); target != "" {
-		op := target[strings.LastIndexByte(target, '.')+1:]
-		if op == "" {
-			return "", "", false
-		}
+	prefix := target[:strings.LastIndexByte(target, '.')+1]
+	op := jsonRPCTargetOperation(r)
 
-		return service, service + ":" + op, true
+	svc, ok := jsonRPCServiceByTarget[prefix]
+	if !ok || op == "" {
+		return svc, "", authzDeny
 	}
 
-	if op := queryActionParam(r, body); op != "" {
-		return service, service + ":" + op, true
-	}
-
-	return "", "", false
+	return svc, svc + ":" + op, authzEnforce
 }
 
-// queryActionParam reads the AWS query-protocol Action parameter without
-// consuming the request body the downstream handler will re-parse: it prefers
-// the query string (GET) and falls back to parsing the buffered form-encoded
-// body (POST).
-func queryActionParam(r *http.Request, body []byte) string {
-	if v := r.URL.Query().Get("Action"); v != "" {
-		return v
+// jsonRPCTargetOperation returns the operation suffix of the X-Amz-Target header
+// (the part after the last "."), or "" when absent.
+func jsonRPCTargetOperation(r *http.Request) string {
+	target := r.Header.Get("X-Amz-Target")
+	if target == "" {
+		return ""
 	}
 
-	if vals, err := url.ParseQuery(string(body)); err == nil {
-		return vals.Get("Action")
-	}
-
-	return ""
+	return target[strings.LastIndexByte(target, '.')+1:]
 }
 
 // isAdminPrincipal reports whether p is the account-root / bootstrap admin
@@ -121,23 +168,12 @@ func principalHasPolicies(r *http.Request, p authctx.Principal, iamDriver iamdri
 	return inspector.PrincipalHasPolicies(r.Context(), p.UserName)
 }
 
-// writeAuthzDenied renders a 403 authorization failure in the wire shape of the
-// target protocol: AccessDeniedException (JSON) for JSON-RPC, UnauthorizedOperation
-// (XML) for EC2, and AccessDenied (XML) for other query-protocol services.
-func writeAuthzDenied(w http.ResponseWriter, r *http.Request, service string, p authctx.Principal, action string) {
+// writeAuthzDenied renders a 403 authorization failure. Enforced authorization is
+// JSON-RPC only, so the response is always AccessDeniedException in the JSON-RPC
+// error shape.
+func writeAuthzDenied(w http.ResponseWriter, p authctx.Principal, action string) {
 	msg := "User: " + principalARN(p) + " is not authorized to perform: " + action
-
-	if r.Header.Get("X-Amz-Target") != "" {
-		wire.WriteJSONError(w, http.StatusForbidden, "AccessDeniedException", msg)
-		return
-	}
-
-	code := "AccessDenied"
-	if service == ec2Service {
-		code = "UnauthorizedOperation"
-	}
-
-	awsquery.WriteXMLError(w, http.StatusForbidden, code, msg)
+	wire.WriteJSONError(w, http.StatusForbidden, "AccessDeniedException", msg)
 }
 
 // principalARN returns a stable identifier for the caller in an error message,

--- a/server/aws/authzgate.go
+++ b/server/aws/authzgate.go
@@ -1,0 +1,151 @@
+package aws
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/authctx"
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// ec2Service is the SigV4 credential-scope service name for the EC2 query
+// endpoint (also used for VPC/Auto Scaling, which share it). EC2 reports an
+// authorization failure as UnauthorizedOperation rather than AccessDenied.
+const ec2Service = "ec2"
+
+// authorize is the authorization step layered on top of the SigV4
+// authentication gate. It runs only when EnforceAuth is on and after a request
+// has been authenticated, so p is a verified IAM principal (a user resolved from
+// a long-term access key). It derives the IAM action for the request, and for a
+// real IAM principal that has policies defined it gates the action through
+// CheckPermission. It returns proceed=false only when the action is denied, in
+// which case it has already written the 403.
+//
+// Authorization is enforced only for the query and JSON-RPC protocols, where the
+// action is derivable from the request before dispatch (the SigV4 scope service
+// plus the Action parameter or the X-Amz-Target operation). REST services (S3,
+// Lambda, Route53, EFS, EKS, …) carry no pre-dispatch action here, so they are
+// authenticated only; resource-level and REST authorization are a follow-up.
+func authorize(
+	w http.ResponseWriter, r *http.Request, body []byte, p authctx.Principal, iamDriver iamdriver.IAM,
+) bool {
+	service, action, ok := deriveAction(r, body)
+	if !ok {
+		return true // REST / non-derivable action: authenticate only.
+	}
+
+	if isAdminPrincipal(p) {
+		return true // account root / bootstrap admin identity: full access.
+	}
+
+	if !principalHasPolicies(r, p, iamDriver) {
+		return true // no policies defined: unrestricted (dev-friendly bootstrap).
+	}
+
+	allowed, err := iamDriver.CheckPermission(r.Context(), p.UserName, action, "*")
+	if err == nil && allowed {
+		return true
+	}
+
+	writeAuthzDenied(w, r, service, p, action)
+
+	return false
+}
+
+// deriveAction maps an incoming request to its IAM action (e.g. ec2:RunInstances,
+// dynamodb:PutItem). It returns ok=false for requests whose action is not
+// derivable before dispatch — every REST service. The service name comes from
+// the SigV4 credential scope, which is authoritative and unambiguous (the JSON-RPC
+// X-Amz-Target prefix, e.g. "TrentService" for KMS, is not).
+func deriveAction(r *http.Request, body []byte) (service, action string, ok bool) {
+	service = awsquery.CredentialScopeService(r.Header.Get("Authorization"))
+	if service == "" {
+		return "", "", false
+	}
+
+	if target := r.Header.Get("X-Amz-Target"); target != "" {
+		op := target[strings.LastIndexByte(target, '.')+1:]
+		if op == "" {
+			return "", "", false
+		}
+
+		return service, service + ":" + op, true
+	}
+
+	if op := queryActionParam(r, body); op != "" {
+		return service, service + ":" + op, true
+	}
+
+	return "", "", false
+}
+
+// queryActionParam reads the AWS query-protocol Action parameter without
+// consuming the request body the downstream handler will re-parse: it prefers
+// the query string (GET) and falls back to parsing the buffered form-encoded
+// body (POST).
+func queryActionParam(r *http.Request, body []byte) string {
+	if v := r.URL.Query().Get("Action"); v != "" {
+		return v
+	}
+
+	if vals, err := url.ParseQuery(string(body)); err == nil {
+		return vals.Get("Action")
+	}
+
+	return ""
+}
+
+// isAdminPrincipal reports whether p is the account-root / bootstrap admin
+// identity, which is always allowed (mirroring real IAM, where root has full
+// access). A verified long-term key always resolves to a named IAM user, so in
+// practice this guards only an explicit root identity and the defensive
+// empty-name case; STS temporary (ASIA) credentials are allowed earlier, in the
+// authentication gate, without reaching here.
+func isAdminPrincipal(p authctx.Principal) bool {
+	return p.UserName == "" || p.UserName == "root" || strings.HasSuffix(p.ARN, ":root")
+}
+
+// principalHasPolicies reports whether the IAM driver can see any policies in
+// effect for p. When the driver cannot be inspected, or the principal has no
+// policies at all, authorization is left unenforced so a freshly created
+// key-only user is not locked out before any policy is written.
+func principalHasPolicies(r *http.Request, p authctx.Principal, iamDriver iamdriver.IAM) bool {
+	inspector, ok := iamDriver.(iamdriver.PolicyInspector)
+	if !ok {
+		return false
+	}
+
+	return inspector.PrincipalHasPolicies(r.Context(), p.UserName)
+}
+
+// writeAuthzDenied renders a 403 authorization failure in the wire shape of the
+// target protocol: AccessDeniedException (JSON) for JSON-RPC, UnauthorizedOperation
+// (XML) for EC2, and AccessDenied (XML) for other query-protocol services.
+func writeAuthzDenied(w http.ResponseWriter, r *http.Request, service string, p authctx.Principal, action string) {
+	msg := "User: " + principalARN(p) + " is not authorized to perform: " + action
+
+	if r.Header.Get("X-Amz-Target") != "" {
+		wire.WriteJSONError(w, http.StatusForbidden, "AccessDeniedException", msg)
+		return
+	}
+
+	code := "AccessDenied"
+	if service == ec2Service {
+		code = "UnauthorizedOperation"
+	}
+
+	awsquery.WriteXMLError(w, http.StatusForbidden, code, msg)
+}
+
+// principalARN returns a stable identifier for the caller in an error message,
+// preferring the resolved ARN and falling back to the user name.
+func principalARN(p authctx.Principal) string {
+	if p.ARN != "" {
+		return p.ARN
+	}
+
+	return p.UserName
+}

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -234,8 +234,14 @@ type Drivers struct {
 	// fails to resolve its key (InvalidClientTokenId).
 	//
 	// Long-term (AKIA) keys are verified; STS temporary (ASIA) credentials are
-	// accepted without signature verification (a follow-up). Authentication only:
-	// IAM policy is not yet enforced on the wire.
+	// accepted without signature verification (a follow-up).
+	//
+	// It also enforces IAM authorization for JSON-RPC services (the operation is
+	// bound to the X-Amz-Target header the dispatcher routes on); query and REST
+	// services are authenticated only, because their executed operation cannot be
+	// soundly bound to an IAM service before dispatch. Authorization applies only
+	// to principals that have IAM policies defined — a policy-less user/role and
+	// the account-admin/root and ASIA identities are left unrestricted.
 	EnforceAuth bool
 }
 

--- a/services/iam/driver/driver.go
+++ b/services/iam/driver/driver.go
@@ -205,6 +205,16 @@ type AccessKeyResolver interface {
 	AccessKeyByID(ctx context.Context, id string) (AccessKeyAuth, bool)
 }
 
+// PolicyInspector is an optional capability: an IAM implementation that can
+// report whether a principal has any policies in effect. The AWS authorization
+// gate type-asserts for it so it can leave a principal with no policies defined
+// unrestricted (a dev-friendly bootstrap default), enforcing CheckPermission
+// only once policies exist. Like AccessKeyResolver it is AWS-only and therefore
+// not part of the shared IAM interface.
+type PolicyInspector interface {
+	PrincipalHasPolicies(ctx context.Context, name string) bool
+}
+
 // IAM is the interface that IAM provider implementations must satisfy.
 type IAM interface {
 	CreateUser(ctx context.Context, config UserConfig) (*UserInfo, error)


### PR DESCRIPTION
## Summary

PR 2 of #493. Building on PR 1's SigV4 authentication (#838), this adds **IAM authorization**: after a request's principal is resolved, the IAM action is derived and gated through `CheckPermission`. Opt-in via the same `EnforceAuth` flag — when off, behavior is unchanged.

## What changed

**Deepened `CheckPermission` (the PDP)** — evaluates the principal's full effective policy set: attached managed + inline + group-inherited policies (via `gatherPrincipalDocs`), intersected with the permissions boundary when set (allowed only if BOTH identity policies and boundary allow). Explicit `Deny` anywhere wins. The shallow attached-only `collectPolicyARNs` path is removed; signature/behavior for callers preserved.

**Authorization bound to the dispatch key (security-critical).** The IAM service is derived from the signal the dispatcher actually routes on, never from the client-controlled SigV4 credential scope:
- **JSON-RPC** (DynamoDB, KMS, SQS, SSM, Kinesis, Glue, Step Functions, ECR, ECS, …): service comes from an explicit `X-Amz-Target` prefix → IAM-service map. `action = <service>:<operation>`. A JSON-RPC target that maps to no served service **fails closed** (403). This is the enforced surface.
- **Query and REST**: authenticated only. Their executed operation's IAM service cannot be soundly determined before dispatch — query routing is by action name, a single handler (e.g. EC2) serves several IAM services (ec2/vpc/autoscaling), and the credential scope is client-controlled. Authorizing on that scope would let a caller scoped to service A run an operation that executes under service B (a cross-service privilege escalation), so action+resource authorization bound to the routed operation is a documented follow-up.

Denials use the JSON-RPC `AccessDeniedException` (403) shape. The account-root/bootstrap admin and STS temporary (ASIA) identities are always allowed; a principal with **no policies defined** is left unrestricted (real AWS implicit-denies a policy-less principal) — a disclosed foundation limitation now documented on `WithEnforceAuth`, `Drivers.EnforceAuth`, and the `--enforce-auth` flag help.

## Tests

Real aws-sdk-go-v2 compat tests (`compat/aws/auth_authz_compat_test.go`):
- DynamoDB JSON-RPC allow/deny (GetItem allowed, PutItem denied), group-inherited allow, permissions-boundary cap.
- **Cross-service bypass regression**: a principal with `s3:*` signs with credential scope `s3` but sends `X-Amz-Target: DynamoDB_20120810.PutItem` → 403 `AccessDeniedException`, because the service derives from the target (dynamodb), not the scope.
- Query is authenticated-only (an EC2 query call succeeds for a caller lacking EC2 permission).
- `EnforceAuth`-off regression.

IAM unit tests prove inline / group / boundary / explicit-deny depth in `CheckPermission`.

## Scope note

Enforced authorization is action-level (resource `"*"`) for JSON-RPC. Query/REST authorization and resource-level (ARN) authorization — bound to the routed operation — are follow-ups.
