### PR TITLE
feat(auth): opt-in Azure claims-based bearer authentication (#493)

### DIFF
--- a/cmd/cloudemu/serve.go
+++ b/cmd/cloudemu/serve.go
@@ -115,10 +115,12 @@ func runServe(args []string) error {
 	fs.BoolVar(&c.persistMetaOnly, "persist-metadata-only", false, "persist resource structure but omit object bodies (smaller snapshot)")
 	fs.StringVar(&c.initDir, "init-dir", "", "apply every *.json seed fixture in this directory on startup")
 	fs.BoolVar(&c.enforceAuth, "enforce-auth", false,
-		"verify the AWS SigV4 signature on each request against a registered IAM access key (403 on failure) and enforce IAM "+
-			"authorization; off by default. Long-term (AKIA) keys are verified; STS temporary (ASIA) credentials are accepted "+
-			"unverified for now. Authorization is enforced for JSON-RPC services only (query/REST are authenticated only) and "+
-			"applies only to principals that have IAM policies (a policy-less user and the admin/root identity are unrestricted)")
+		"require authentication on each request; off by default. AWS: verify the SigV4 signature against a registered IAM access "+
+			"key (403 on failure) and enforce IAM authorization — long-term (AKIA) keys are verified, STS temporary (ASIA) "+
+			"credentials are accepted unverified for now, authorization is enforced for JSON-RPC services only, and applies only to "+
+			"principals that have IAM policies. Azure: validate each request's Bearer token claims (accepted audience, expiry, a "+
+			"principal claim) and reject missing/malformed/expired/wrong-audience tokens with 401 — the token SIGNATURE is NOT "+
+			"verified (no Azure AD signing key), so this is claims-based authentication only; RBAC authorization is a follow-up")
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "Usage: cloudemu serve [flags]\n\nStart the standalone emulator. Flags:\n")
 		fs.PrintDefaults()

--- a/compat/azure/auth_claims_compat_test.go
+++ b/compat/azure/auth_claims_compat_test.go
@@ -1,0 +1,246 @@
+package azure
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/internal/compat"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+const claimsAuthSubscriptionID = "11111111-1111-1111-1111-111111111111"
+
+// makeJWT hand-builds an unsigned (dummy-signature) three-part JWT from the
+// given claims. cloudemu validates a token's structure and claims, not its
+// signature, so a real signing key is unnecessary — this is exactly the shape a
+// real Azure token has on the wire.
+func makeJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+
+	enc := base64.RawURLEncoding.EncodeToString
+
+	header, err := json.Marshal(map[string]any{"alg": "RS256", "typ": "JWT", "kid": "test-key"})
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+
+	return enc(header) + "." + enc(payload) + "." + enc([]byte("dummy-signature"))
+}
+
+// validClaims returns a well-formed claim set: the ARM audience, an object id
+// principal, a tenant, and an expiry far in the future.
+func validClaims() map[string]any {
+	return map[string]any{
+		"aud": "https://management.azure.com",
+		"oid": "abcd1234-0000-0000-0000-00000000abcd",
+		"tid": claimsAuthSubscriptionID,
+		"exp": float64(time.Now().Add(time.Hour).Unix()),
+	}
+}
+
+// staticJWTCred is an azcore.TokenCredential that always returns the same
+// pre-built JWT, so a real Azure SDK client injects it as the bearer token.
+type staticJWTCred struct{ token string }
+
+func (c staticJWTCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: c.token, ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+// armClientOptions points an ARM client at the emulator's TLS endpoint with the
+// ARM audience configured. ARM is a bearer-token API, so it runs over TLS.
+func armClientOptions(sess *compat.AzureSession) *arm.ClientOptions {
+	return &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: cloud.Configuration{
+				ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+					cloud.ResourceManager: {
+						Endpoint: sess.Endpoint(),
+						Audience: "https://management.azure.com",
+					},
+				},
+			},
+			Transport: sess.Transport(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+}
+
+// listRoleDefinitions drives one real ARM read (role-definition list) through
+// the armauthorization SDK using cred, returning any error. A nil error means
+// the claims gate admitted the request and the handler served it.
+func listRoleDefinitions(ctx context.Context, sess *compat.AzureSession, cred azcore.TokenCredential) error {
+	cf, err := armauthorization.NewClientFactory(claimsAuthSubscriptionID, cred, armClientOptions(sess))
+	if err != nil {
+		return err
+	}
+
+	pager := cf.NewRoleDefinitionsClient().NewListPager("/subscriptions/"+claimsAuthSubscriptionID, nil)
+	for pager.More() {
+		if _, err := pager.NextPage(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// TestCompatAzureClaimsAuthDisabled confirms the default (auth off) path is
+// unchanged: a normal Azure SDK call still succeeds with the harness's fake
+// credential (whose token is not even a JWT).
+func TestCompatAzureClaimsAuthDisabled(t *testing.T) {
+	provider := cloudemu.NewAzure()
+	sess := compat.BootAzureTLS(t, azureserver.Drivers{IAM: provider.IAM})
+
+	if err := listRoleDefinitions(context.Background(), sess, compat.FakeAzureCred()); err != nil {
+		t.Fatalf("ARM call with auth disabled should succeed, got: %v", err)
+	}
+}
+
+// TestCompatAzureClaimsAuthEnabledValid exercises the enforced path with a real
+// SDK client injecting a valid bearer JWT (ARM audience, an oid principal): the
+// ARM call succeeds, proving the gate admitted it and dispatch proceeded.
+func TestCompatAzureClaimsAuthEnabledValid(t *testing.T) {
+	provider := cloudemu.NewAzure()
+	sess := compat.BootAzureTLS(t, azureserver.Drivers{IAM: provider.IAM, EnforceAuth: true})
+
+	cred := staticJWTCred{token: makeJWT(t, validClaims())}
+	if err := listRoleDefinitions(context.Background(), sess, cred); err != nil {
+		t.Fatalf("ARM call with a valid bearer token should succeed, got: %v", err)
+	}
+}
+
+// armGet issues a raw ARM GET carrying the given Authorization header value
+// (empty means no header) and returns the response, so the negative cases can
+// assert the exact 401 shape the SDK would surface. It targets a subscription
+// path (ARM-shaped) — the request never reaches a handler when the gate rejects
+// it.
+func armGet(t *testing.T, sess *compat.AzureSession, authHeader string) *http.Response {
+	t.Helper()
+
+	url := sess.Endpoint() + "/subscriptions/" + claimsAuthSubscriptionID + "?api-version=2022-12-01"
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+
+	resp, err := sess.Transport().Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+
+	return resp
+}
+
+// assertInvalidToken asserts the response is a 401 InvalidAuthenticationToken
+// with the bearer challenge header, the shape real Azure AD returns.
+func assertInvalidToken(t *testing.T, resp *http.Response) {
+	t.Helper()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+
+	if resp.Header.Get("WWW-Authenticate") == "" {
+		t.Error("missing WWW-Authenticate challenge header")
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	var envelope struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("decode error envelope %q: %v", string(body), err)
+	}
+
+	if envelope.Error.Code != "InvalidAuthenticationToken" {
+		t.Fatalf("error code = %q, want InvalidAuthenticationToken", envelope.Error.Code)
+	}
+}
+
+// TestCompatAzureClaimsAuthRejections covers every rejection path under
+// enforcement: a missing header, a malformed token, a foreign audience, a token
+// with no principal claim, and an expired token — each a 401
+// InvalidAuthenticationToken.
+func TestCompatAzureClaimsAuthRejections(t *testing.T) {
+	provider := cloudemu.NewAzure()
+	sess := compat.BootAzureTLS(t, azureserver.Drivers{IAM: provider.IAM, EnforceAuth: true})
+
+	t.Run("NoAuthorizationHeader", func(t *testing.T) {
+		assertInvalidToken(t, armGet(t, sess, ""))
+	})
+
+	t.Run("NotBearerScheme", func(t *testing.T) {
+		assertInvalidToken(t, armGet(t, sess, "Basic dXNlcjpwYXNz"))
+	})
+
+	t.Run("MalformedToken", func(t *testing.T) {
+		assertInvalidToken(t, armGet(t, sess, "Bearer not-a-jwt"))
+	})
+
+	t.Run("WrongAudience", func(t *testing.T) {
+		claims := validClaims()
+		claims["aud"] = "https://attacker.example.com"
+		assertInvalidToken(t, armGet(t, sess, "Bearer "+makeJWT(t, claims)))
+	})
+
+	t.Run("NoPrincipalClaim", func(t *testing.T) {
+		claims := validClaims()
+		delete(claims, "oid")
+		assertInvalidToken(t, armGet(t, sess, "Bearer "+makeJWT(t, claims)))
+	})
+
+	t.Run("ExpiredToken", func(t *testing.T) {
+		claims := validClaims()
+		claims["exp"] = float64(time.Now().Add(-time.Hour).Unix())
+		assertInvalidToken(t, armGet(t, sess, "Bearer "+makeJWT(t, claims)))
+	})
+}
+
+// TestCompatAzureClaimsAuthAbsentExpAccepted confirms the lenient expiry rule: a
+// token with no "exp" claim is admitted (the response is anything but a 401),
+// so tokens minted under a fixed clock without an expiry still authenticate.
+func TestCompatAzureClaimsAuthAbsentExpAccepted(t *testing.T) {
+	provider := cloudemu.NewAzure()
+	sess := compat.BootAzureTLS(t, azureserver.Drivers{IAM: provider.IAM, EnforceAuth: true})
+
+	claims := validClaims()
+	delete(claims, "exp")
+
+	resp := armGet(t, sess, "Bearer "+makeJWT(t, claims))
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		t.Fatalf("token without exp should be accepted, got 401")
+	}
+}

--- a/config/options.go
+++ b/config/options.go
@@ -70,12 +70,16 @@ type Options struct {
 	// behavior). See internal/settle.
 	AsyncSettle bool
 
-	// EnforceAuth, when true, makes the AWS wire server verify the SigV4
-	// signature on each incoming request against a registered IAM access key and
-	// reject bad/missing signatures with 403. It also gates JSON-RPC operations
-	// through IAM authorization (see WithEnforceAuth for the exact scope and
-	// limitations). Default false, which accepts any credentials exactly as
-	// before (the historical behavior).
+	// EnforceAuth, when true, turns on request authentication for every provider
+	// wire server. AWS verifies the SigV4 signature on each request against a
+	// registered IAM access key (rejecting bad/missing signatures with 403) and
+	// gates JSON-RPC operations through IAM authorization. Azure validates each
+	// request's Bearer token claims (audience, expiry, principal) and rejects
+	// missing/malformed/expired/wrong-audience tokens with 401 — the token
+	// signature is NOT verified, because cloudemu has no Azure AD signing key, so
+	// Azure enforcement is claims-based authentication only. See WithEnforceAuth
+	// for the exact scope and limitations. Default false, which accepts any
+	// credentials exactly as before (the historical behavior).
 	EnforceAuth bool
 }
 
@@ -192,28 +196,43 @@ func WithAsyncSettle() Option {
 	}
 }
 
-// WithEnforceAuth turns on AWS SigV4 request authentication and IAM
-// authorization: the wire server verifies each request's signature against a
-// registered IAM access key (rejecting bad/missing signatures with 403) and then
-// checks the caller's IAM policies before dispatch. Off by default, which accepts
-// any credentials (the historical behavior).
+// WithEnforceAuth turns on request authentication for every provider wire
+// server. Off by default, which accepts any credentials (the historical
+// behavior).
 //
-// Authentication scope: long-term (AKIA) access-key signatures are verified; STS
-// temporary (ASIA) credentials are accepted without signature verification (a
-// follow-up), and request timestamps are not checked for expiry.
+// AWS — SigV4 authentication and IAM authorization: the wire server verifies
+// each request's signature against a registered IAM access key (rejecting
+// bad/missing signatures with 403) and then checks the caller's IAM policies
+// before dispatch.
+//   - Authentication scope: long-term (AKIA) access-key signatures are verified;
+//     STS temporary (ASIA) credentials are accepted without signature
+//     verification (a follow-up), and request timestamps are not checked for
+//     expiry.
+//   - Authorization scope: enforced for JSON-RPC services (DynamoDB, KMS, SQS,
+//     …), where the operation is bound to the X-Amz-Target header the dispatcher
+//     routes on. Query and REST services are authenticated only — their executed
+//     operation's IAM service cannot be soundly determined before dispatch, so
+//     action+resource authorization for them is a follow-up. Authorization is
+//     action-level (resource "*").
+//   - Foundation limitation: authorization applies only to principals that have
+//     IAM policies defined. A valid IAM user or role with NO policies is left
+//     unrestricted here (real AWS implicit-denies a policy-less principal), and
+//     the account-admin/root and ASIA bootstrap identities are always allowed.
 //
-// Authorization scope: enforced for JSON-RPC services (DynamoDB, KMS, SQS, …),
-// where the operation is bound to the X-Amz-Target header the dispatcher routes
-// on. Query and REST services are authenticated only — their executed operation's
-// IAM service cannot be soundly determined before dispatch (query routing is by
-// action name and the SigV4 credential scope is client-controlled), so
-// action+resource authorization for them is a follow-up. Authorization is
-// action-level (resource "*").
-//
-// Foundation limitation: authorization applies only to principals that have IAM
-// policies defined. A valid IAM user or role with NO policies is left
-// unrestricted here (real AWS implicit-denies a policy-less principal), and the
-// account-admin/root and ASIA bootstrap identities are always allowed.
+// Azure — claims-based bearer authentication: the wire server requires an
+// "Authorization: Bearer <jwt>" on each request, validates the token's claims
+// (a well-formed three-part JWT, an accepted Azure audience, an un-expired
+// "exp", and a principal claim — oid, appid/azp or sub), resolves the principal
+// onto the request context, and rejects missing/malformed/expired/wrong-audience
+// tokens with 401 InvalidAuthenticationToken.
+//   - Documented limitation: the token SIGNATURE is NOT verified. Azure tokens
+//     are signed by Azure AD's private key, which the emulator does not hold, so
+//     (unlike AWS SigV4) it cannot cryptographically verify a real Azure token.
+//     Azure enforcement therefore validates token structure and claims only;
+//     signature verification / emulator-issued tokens are a possible later
+//     enhancement.
+//   - This is authentication only. Azure RBAC (role-assignment) authorization is
+//     a follow-up.
 func WithEnforceAuth() Option {
 	return func(o *Options) {
 		o.EnforceAuth = true

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -161,6 +161,13 @@ type Provider struct {
 	// Region is the Azure location this provider serves.
 	Region string
 
+	// EnforceAuth mirrors config.Options.EnforceAuth: when true the Azure wire
+	// server validates the claims of each request's Bearer token (audience,
+	// expiry, principal) and rejects bad/missing tokens with 401. The token
+	// signature is not verified (cloudemu has no Azure AD signing key). Off by
+	// default.
+	EnforceAuth bool
+
 	// engineClosers holds any wired real engines that implement io.Closer, so
 	// Close can cascade teardown to them. Empty for the in-memory default.
 	engineClosers []io.Closer
@@ -200,6 +207,7 @@ func New(opts ...config.Option) *Provider {
 		Search:             search.New(o),
 		SubscriptionID:     o.AccountID,
 		Region:             o.Region,
+		EnforceAuth:        o.EnforceAuth,
 	}
 	p.VirtualMachines.SetMonitoring(p.Monitor)
 	p.VirtualMachines.SetNICAttacher(p.VNet)

--- a/server/authctx/authctx.go
+++ b/server/authctx/authctx.go
@@ -1,8 +1,12 @@
-// Package authctx carries the authenticated caller (the resolved IAM principal)
-// on a request context. The AWS SigV4 authentication gate populates it after it
-// verifies a request signature; handlers that need to know who is calling read
-// it back with PrincipalFrom. When authentication is disabled (the default) no
-// principal is stored and PrincipalFrom reports ok=false.
+// Package authctx carries the authenticated caller on a request context.
+//
+// The AWS SigV4 authentication gate populates an AWS Principal after it verifies
+// a request signature; the Azure claims-auth gate populates an AzurePrincipal
+// after it validates a bearer token's claims. Handlers that need to know who is
+// calling read the value back with PrincipalFrom / AzurePrincipalFrom. When
+// authentication is disabled (the default) no principal is stored and the
+// accessors report ok=false. The two principal types use distinct context keys,
+// so the AWS and Azure gates never collide.
 package authctx
 
 import "context"
@@ -26,5 +30,36 @@ func WithPrincipal(ctx context.Context, p Principal) context.Context {
 // request was not authenticated.
 func PrincipalFrom(ctx context.Context) (Principal, bool) {
 	p, ok := ctx.Value(principalKey{}).(Principal)
+	return p, ok
+}
+
+// AzurePrincipal is the caller resolved from a validated Azure AD bearer token.
+//
+// cloudemu does not hold Azure AD's signing key, so it cannot cryptographically
+// verify a real Azure token. These fields therefore come from the token's
+// UNVERIFIED claims: the Azure gate validates the token's structure, audience,
+// expiry and the presence of a principal claim, but NOT its signature. Treat
+// the values as an authenticated caller's identity only under that documented
+// limitation.
+type AzurePrincipal struct {
+	// ObjectID is the caller's Azure AD object id (the "oid" claim), when present.
+	ObjectID string
+	// AppID is the calling application id (the "appid" or "azp" claim), when present.
+	AppID string
+	// TenantID is the Azure AD tenant (the "tid" claim), when present.
+	TenantID string
+}
+
+type azurePrincipalKey struct{}
+
+// WithAzurePrincipal returns a copy of ctx carrying p.
+func WithAzurePrincipal(ctx context.Context, p AzurePrincipal) context.Context {
+	return context.WithValue(ctx, azurePrincipalKey{}, p)
+}
+
+// AzurePrincipalFrom returns the Azure principal stored on ctx, or ok=false when
+// the request was not authenticated.
+func AzurePrincipalFrom(ctx context.Context) (AzurePrincipal, bool) {
+	p, ok := ctx.Value(azurePrincipalKey{}).(AzurePrincipal)
 	return p, ok
 }

--- a/server/azure/authgate.go
+++ b/server/azure/authgate.go
@@ -1,0 +1,243 @@
+package azure
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/server/authctx"
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+// invalidTokenCode is the error code Azure AD returns for a missing, malformed,
+// expired or wrong-audience bearer token.
+const invalidTokenCode = "InvalidAuthenticationToken"
+
+// bearerChallengeHeader is the WWW-Authenticate challenge sent with a 401 so an
+// Azure SDK knows to acquire a token and retry, mirroring real Azure AD.
+const bearerChallengeHeader = `Bearer authorization_uri="https://login.microsoftonline.com/common"`
+
+// newAuthGate builds the Azure claims-based authentication pre-dispatch hook.
+//
+// cloudemu cannot verify a real Azure token's signature (it does not hold Azure
+// AD's private key), so the gate validates the token's STRUCTURE and CLAIMS —
+// well-formed three-part JWT, an accepted Azure audience, an un-expired "exp"
+// and a principal claim — and NOT the signature. On success it attaches the
+// resolved principal to the request context; on failure it writes a 401 and
+// stops dispatch. It only reads the Authorization header, so the request body is
+// left untouched for the downstream handler.
+func newAuthGate(clock config.Clock) func(http.ResponseWriter, *http.Request) (*http.Request, bool) {
+	if clock == nil {
+		clock = config.RealClock{}
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) (*http.Request, bool) {
+		token, ok := bearerToken(r)
+		if !ok {
+			writeAuthError(w, "Request is missing a Bearer authentication token")
+			return r, false
+		}
+
+		claims, err := parseClaims(token)
+		if err != nil {
+			writeAuthError(w, "Bearer token is malformed: "+err.Error())
+			return r, false
+		}
+
+		if !acceptedAudience(claims.audiences()) {
+			writeAuthError(w, "Bearer token audience is not an accepted Azure audience")
+			return r, false
+		}
+
+		if claims.expired(clock.Now()) {
+			writeAuthError(w, "Bearer token has expired")
+			return r, false
+		}
+
+		principal, ok := claims.principal()
+		if !ok {
+			writeAuthError(w, "Bearer token carries no principal claim (oid, appid, azp or sub)")
+			return r, false
+		}
+
+		return r.WithContext(authctx.WithAzurePrincipal(r.Context(), principal)), true
+	}
+}
+
+// bearerToken returns the token from an "Authorization: Bearer <jwt>" header.
+// The scheme match is case-insensitive; ok is false when the header is absent or
+// carries a different scheme.
+func bearerToken(r *http.Request) (string, bool) {
+	const prefix = "bearer "
+
+	h := r.Header.Get("Authorization")
+	if len(h) < len(prefix) || !strings.EqualFold(h[:len(prefix)], prefix) {
+		return "", false
+	}
+
+	token := strings.TrimSpace(h[len(prefix):])
+	if token == "" {
+		return "", false
+	}
+
+	return token, true
+}
+
+// azureClaims is the subset of Azure AD JWT claims the gate validates. "aud" is
+// kept raw because Azure tokens carry it as either a single string (v1) or an
+// array of strings (v2/multi-resource).
+type azureClaims struct {
+	Aud   json.RawMessage `json:"aud"`
+	Exp   *float64        `json:"exp"`
+	Oid   string          `json:"oid"`
+	Appid string          `json:"appid"`
+	Azp   string          `json:"azp"`
+	Sub   string          `json:"sub"`
+	Tid   string          `json:"tid"`
+}
+
+// parseClaims decodes the claims payload (the second segment) of a three-part
+// JWT without verifying its signature. It errors when the token is not a
+// well-formed three-part JWT or the payload is not valid base64url JSON.
+func parseClaims(token string) (*azureClaims, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return nil, errNotThreeParts
+	}
+
+	payload, err := decodeSegment(parts[1])
+	if err != nil {
+		return nil, err
+	}
+
+	var c azureClaims
+	if err := json.Unmarshal(payload, &c); err != nil {
+		return nil, err
+	}
+
+	return &c, nil
+}
+
+// errValue is a lightweight sentinel error type so the gate can report parse
+// failures without pulling in a heavier error package.
+type errValue string
+
+func (e errValue) Error() string { return string(e) }
+
+// errNotThreeParts marks a token that is not a well-formed three-part JWT.
+const errNotThreeParts errValue = "not a three-part JWT"
+
+// decodeSegment base64url-decodes a JWT segment, tolerating the presence or
+// absence of "=" padding (JWTs are unpadded, but some issuers pad).
+func decodeSegment(seg string) ([]byte, error) {
+	if b, err := base64.RawURLEncoding.DecodeString(seg); err == nil {
+		return b, nil
+	}
+
+	return base64.URLEncoding.DecodeString(seg)
+}
+
+// audiences returns the token's audience values, decoding "aud" as either a
+// single string or an array of strings.
+func (c *azureClaims) audiences() []string {
+	if len(c.Aud) == 0 {
+		return nil
+	}
+
+	var single string
+	if json.Unmarshal(c.Aud, &single) == nil {
+		return []string{single}
+	}
+
+	var many []string
+	if json.Unmarshal(c.Aud, &many) == nil {
+		return many
+	}
+
+	return nil
+}
+
+// expired reports whether a clearly-set "exp" is in the past relative to now.
+// It is deliberately lenient: an absent or non-positive "exp" is accepted, so a
+// token minted under a fixed test clock without an expiry still passes.
+func (c *azureClaims) expired(now time.Time) bool {
+	if c.Exp == nil || *c.Exp <= 0 {
+		return false
+	}
+
+	return time.Unix(int64(*c.Exp), 0).Before(now)
+}
+
+// principal resolves the caller identity from the claims, preferring the object
+// id, then the application id, then the subject. ok is false when none is set.
+func (c *azureClaims) principal() (authctx.AzurePrincipal, bool) {
+	appID := c.Appid
+	if appID == "" {
+		appID = c.Azp
+	}
+
+	switch {
+	case c.Oid != "":
+		return authctx.AzurePrincipal{ObjectID: c.Oid, AppID: appID, TenantID: c.Tid}, true
+	case appID != "":
+		return authctx.AzurePrincipal{AppID: appID, TenantID: c.Tid}, true
+	case c.Sub != "":
+		return authctx.AzurePrincipal{ObjectID: c.Sub, AppID: appID, TenantID: c.Tid}, true
+	default:
+		return authctx.AzurePrincipal{}, false
+	}
+}
+
+// acceptedAudience reports whether any audience is an accepted Azure audience:
+// the ARM audience (with or without a trailing slash) or a data-plane resource
+// audience under a known Azure host suffix (vault/storage/cognitiveservices/…).
+// The set is intentionally permissive; a foreign audience (e.g. an attacker's
+// own resource) is still rejected.
+func acceptedAudience(auds []string) bool {
+	armAudiences := map[string]bool{
+		"https://management.azure.com":        true,
+		"https://management.core.windows.net": true,
+		"https://graph.microsoft.com":         true,
+		"https://graph.windows.net":           true,
+	}
+
+	azureHostSuffixes := []string{
+		".azure.com", ".azure.net", ".windows.net",
+		".microsoftonline.com", ".microsoft.com", ".azurewebsites.net",
+	}
+
+	for _, aud := range auds {
+		normalized := strings.ToLower(strings.TrimRight(strings.TrimSpace(aud), "/"))
+		if normalized == "" {
+			continue
+		}
+
+		if armAudiences[normalized] {
+			return true
+		}
+
+		u, err := url.Parse(normalized)
+		if err != nil || u.Host == "" {
+			continue
+		}
+
+		for _, suffix := range azureHostSuffixes {
+			if strings.HasSuffix(u.Host, suffix) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// writeAuthError renders a 401 in the ARM error envelope with the bearer
+// challenge header, matching Azure AD's InvalidAuthenticationToken response.
+func writeAuthError(w http.ResponseWriter, message string) {
+	w.Header().Set("WWW-Authenticate", bearerChallengeHeader)
+	azurearm.WriteError(w, http.StatusUnauthorized, invalidTokenCode, message)
+}

--- a/server/azure/authgate_test.go
+++ b/server/azure/authgate_test.go
@@ -1,0 +1,227 @@
+package azure
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/server/authctx"
+)
+
+// jwtWith builds an unsigned three-part JWT carrying the given claims, the shape
+// the gate parses (it validates claims, not the signature).
+func jwtWith(t *testing.T, claims map[string]any) string {
+	t.Helper()
+
+	enc := base64.RawURLEncoding.EncodeToString
+
+	header, err := json.Marshal(map[string]any{"alg": "RS256", "typ": "JWT"})
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+
+	return enc(header) + "." + enc(payload) + "." + enc([]byte("sig"))
+}
+
+// runGate feeds a request carrying authHeader through the gate under fixedNow and
+// returns whether dispatch proceeded plus the recorded response.
+func runGate(t *testing.T, authHeader string, fixedNow time.Time) (bool, *authctx.AzurePrincipal, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	gate := newAuthGate(config.NewFakeClock(fixedNow))
+
+	req := httptest.NewRequest(http.MethodGet, "/subscriptions/sub/resource", nil)
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+
+	rec := httptest.NewRecorder()
+	out, proceed := gate(rec, req)
+
+	var principal *authctx.AzurePrincipal
+	if p, ok := authctx.AzurePrincipalFrom(out.Context()); ok {
+		principal = &p
+	}
+
+	return proceed, principal, rec
+}
+
+func assertGate401(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+
+	if rec.Header().Get("WWW-Authenticate") == "" {
+		t.Error("missing WWW-Authenticate header")
+	}
+
+	var envelope struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode error body %q: %v", rec.Body.String(), err)
+	}
+
+	if envelope.Error.Code != invalidTokenCode {
+		t.Fatalf("error code = %q, want %q", envelope.Error.Code, invalidTokenCode)
+	}
+}
+
+func TestAuthGateRejections(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		authHeader string
+		claims     map[string]any // when set, wrapped as "Bearer <jwt>"
+	}{
+		{name: "MissingHeader"},
+		{name: "NotBearer", authHeader: "Basic abc"},
+		{name: "EmptyBearer", authHeader: "Bearer "},
+		{name: "Malformed", authHeader: "Bearer aaa.bbb"},
+		{name: "WrongAudience", claims: map[string]any{"aud": "https://evil.example.com", "oid": "o1"}},
+		{name: "EmptyAudience", claims: map[string]any{"aud": "", "oid": "o1"}},
+		{name: "NoPrincipal", claims: map[string]any{"aud": "https://management.azure.com"}},
+		{
+			name:   "Expired",
+			claims: map[string]any{"aud": "https://management.azure.com", "oid": "o1", "exp": float64(now.Add(-time.Minute).Unix())},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			header := tc.authHeader
+			if tc.claims != nil {
+				header = "Bearer " + jwtWith(t, tc.claims)
+			}
+
+			proceed, _, rec := runGate(t, header, now)
+			if proceed {
+				t.Fatal("gate proceeded, want rejection")
+			}
+
+			assertGate401(t, rec)
+		})
+	}
+}
+
+func TestAuthGateResolvesPrincipal(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		claims     map[string]any
+		wantObject string
+		wantApp    string
+		wantTenant string
+	}{
+		{
+			name:       "PrefersOid",
+			claims:     map[string]any{"aud": "https://management.azure.com", "oid": "obj-1", "appid": "app-1", "tid": "tenant-1"},
+			wantObject: "obj-1", wantApp: "app-1", wantTenant: "tenant-1",
+		},
+		{
+			name:    "AppIDWhenNoOid",
+			claims:  map[string]any{"aud": "https://vault.azure.net", "appid": "app-2"},
+			wantApp: "app-2",
+		},
+		{
+			name:    "AzpWhenNoAppid",
+			claims:  map[string]any{"aud": "https://storage.azure.com", "azp": "app-3"},
+			wantApp: "app-3",
+		},
+		{
+			name:       "SubWhenNoOidOrApp",
+			claims:     map[string]any{"aud": "https://management.core.windows.net/", "sub": "subj-1"},
+			wantObject: "subj-1",
+		},
+		{
+			name:       "AudienceArrayAccepted",
+			claims:     map[string]any{"aud": []string{"https://evil.example.com", "https://management.azure.com"}, "oid": "obj-4"},
+			wantObject: "obj-4",
+		},
+		{
+			name:       "AbsentExpAccepted",
+			claims:     map[string]any{"aud": "https://management.azure.com", "oid": "obj-5"},
+			wantObject: "obj-5",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			proceed, principal, _ := runGate(t, "Bearer "+jwtWith(t, tc.claims), now)
+			if !proceed {
+				t.Fatal("gate rejected a valid token, want proceed")
+			}
+
+			if principal == nil {
+				t.Fatal("no principal attached to context")
+			}
+
+			if principal.ObjectID != tc.wantObject || principal.AppID != tc.wantApp || principal.TenantID != tc.wantTenant {
+				t.Fatalf("principal = %+v, want object=%q app=%q tenant=%q",
+					*principal, tc.wantObject, tc.wantApp, tc.wantTenant)
+			}
+		})
+	}
+}
+
+// TestAuthGateDefaultOff confirms a server built without EnforceAuth installs no
+// gate: an unauthenticated request is not rejected at the pre-dispatch stage
+// (it reaches handler matching, here yielding the dispatcher's 501 rather than a
+// 401 auth error).
+func TestAuthGateDefaultOff(t *testing.T) {
+	srv := New(Drivers{})
+
+	req := httptest.NewRequest(http.MethodGet, "/subscriptions/sub/resource?api-version=2022-12-01", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusUnauthorized {
+		t.Fatal("default-off server rejected an unauthenticated request with 401")
+	}
+}
+
+// TestAuthGateEnabledRejectsUnauthenticated confirms a server built with
+// EnforceAuth installs the gate: an unauthenticated request is rejected with a
+// 401 before any handler runs.
+func TestAuthGateEnabledRejectsUnauthenticated(t *testing.T) {
+	srv := New(Drivers{EnforceAuth: true})
+
+	req := httptest.NewRequest(http.MethodGet, "/subscriptions/sub/resource?api-version=2022-12-01", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 under EnforceAuth", rec.Code)
+	}
+
+	body, _ := io.ReadAll(rec.Body)
+
+	var envelope struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("decode error body %q: %v", string(body), err)
+	}
+
+	if envelope.Error.Code != invalidTokenCode {
+		t.Fatalf("error code = %q, want %q", envelope.Error.Code, invalidTokenCode)
+	}
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -9,6 +9,7 @@ package azure
 import (
 	"net/http"
 
+	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/server"
 	"github.com/stackshy/cloudemu/v2/server/azure/acr"
 	azureaiserver "github.com/stackshy/cloudemu/v2/server/azure/ai"
@@ -175,6 +176,20 @@ type Drivers struct {
 	// TenantID is the Azure AD tenant reported by the subscriptions Get/List and
 	// the global tenants list. Empty falls back to defaultTenantID.
 	TenantID string
+	// EnforceAuth turns on Azure claims-based bearer authentication: each
+	// incoming request must carry an "Authorization: Bearer <jwt>" whose claims
+	// validate (accepted Azure audience, un-expired "exp", a principal claim),
+	// and the resolved principal is attached to the request context. Missing,
+	// malformed, expired or wrong-audience tokens are rejected with 401
+	// InvalidAuthenticationToken. Off by default, which accepts any credentials
+	// exactly as before.
+	//
+	// Because cloudemu does not hold Azure AD's signing key, the token SIGNATURE
+	// is NOT verified — only its structure and claims are. This is a documented
+	// limitation, distinct from AWS SigV4 where the shared secret lets the
+	// emulator verify signatures. This gate is authentication only; RBAC
+	// authorization is a follow-up.
+	EnforceAuth bool
 }
 
 // defaultTenantID is reported when Drivers.TenantID is unset, so a caller
@@ -545,6 +560,14 @@ func New(d Drivers) http.Handler {
 	// ARM-specific resource handlers.
 	if d.BlobStorage != nil {
 		srv.Register(blobstorage.New(d.BlobStorage))
+	}
+
+	// Opt-in claims-based bearer authentication. Installed only when enabled, so
+	// the default request path is byte-for-byte unchanged. Registered on the raw
+	// server so the pre-dispatch gate runs before handler matching (and before
+	// the unmodeled-property overlay below wraps the response).
+	if d.EnforceAuth {
+		srv.SetPreDispatch(newAuthGate(config.RealClock{}))
 	}
 
 	return echoUnmodeledProperties(srv, newPropertyOverlay())

--- a/server/azure/from_provider.go
+++ b/server/azure/from_provider.go
@@ -73,6 +73,7 @@ func DriversFrom(p *azureprovider.Provider) Drivers {
 
 		ResourceDiscovery: p.ResourceDiscovery,
 		SubscriptionID:    p.SubscriptionID,
+		EnforceAuth:       p.EnforceAuth,
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds opt-in **Azure claims-based bearer authentication** to the Azure wire server, the Azure half of #493. It reuses the same `config.EnforceAuth` flag (`--enforce-auth` / `config.WithEnforceAuth()`) the AWS auth work introduced, so a single switch turns on authentication for both providers. Default OFF — behavior is byte-for-byte unchanged when the flag is not set.

This PR is **authentication only**. Azure RBAC (role-assignment) authorization is a separate follow-up.

## Why claims-based, not signature verification

Azure bearer tokens are JWTs signed by Azure AD's private key. cloudemu does not hold that key and therefore **cannot cryptographically verify a real Azure token** (unlike AWS SigV4, where the emulator knows the shared secret). So Azure enforcement validates token **structure + claims**, not the signature. This is a deliberate, documented limitation, disclosed on every user-facing surface (`WithEnforceAuth` / `Options.EnforceAuth` godoc, the Azure server `Drivers.EnforceAuth` godoc, the provider field, and the `--enforce-auth` flag help). Signature verification / emulator-issued tokens are a possible later enhancement.

## What it does (when `EnforceAuth` is on)

A pre-dispatch gate (`server/azure/authgate.go`), installed via `server.Server.SetPreDispatch` only when enabled — mirroring the AWS gate — runs before handler matching and:

- Requires `Authorization: Bearer <jwt>`; missing/non-Bearer → **401 `InvalidAuthenticationToken`** (ARM error envelope `{"error":{"code":...,"message":...}}`, plus a `WWW-Authenticate: Bearer` challenge header).
- Parses the JWT (three base64url parts; decodes the **claims payload only**, does not verify the signature). Validates:
  - well-formed three-part JWT;
  - **audience** (`aud`, string or array) is an accepted Azure audience — the ARM audience and any data-plane resource under a known Azure host suffix (`*.azure.com`, `*.azure.net`, `*.windows.net`, …); a foreign audience is rejected;
  - **expiry** (`exp`) — lenient: rejects only a clearly-set, clearly-past `exp` (uses the clock); absent/zero `exp` is accepted;
  - a **principal claim** is present, precedence `oid` → `appid`/`azp` → `sub`; none → 401.
- On success attaches an `authctx.AzurePrincipal{ObjectID, AppID, TenantID}` to the request context (new, distinct context key from the AWS principal) and proceeds. Only the header is read; the request body is untouched.

Wiring mirrors AWS end-to-end: `Options.EnforceAuth` → `azureprovider.Provider.EnforceAuth` → `azureserver.Drivers.EnforceAuth` (via `DriversFrom`) → gate install in `azureserver.New`. `--enforce-auth` now enables enforcement for the Azure server as well as AWS.

## Tests

- `compat/azure/auth_claims_compat_test.go` — real `azure-sdk-for-go` (armauthorization over the TLS harness). Disabled default still works; enabled + valid injected JWT (custom `TokenCredential`) succeeds; missing/not-Bearer/malformed/wrong-audience/no-principal/expired each → 401 `InvalidAuthenticationToken`; absent `exp` accepted.
- `server/azure/authgate_test.go` — unit coverage of claim validation (audience set incl. array form, principal precedence, expiry under a `FakeClock`), the 401 shape, and default-off vs enabled server behavior.

Gates: `go build ./...`, full `go vet ./...`, full `go test ./...` (whole suite green, default-off unregressed), `go generate ./...` (no docs diff), golangci-lint on touched packages (0 new).
