### PR TITLE
feat(rgt): full ResourceGroupsTaggingAPI coverage — tag every taggable service end-to-end (12 → all)

### DIFF
--- a/compat/aws/rgt_full_coverage_compat_test.go
+++ b/compat/aws/rgt_full_coverage_compat_test.go
@@ -18,10 +18,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/guardduty"
 	"github.com/aws/aws-sdk-go-v2/service/keyspaces"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
 	rgttypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
@@ -174,6 +177,7 @@ func rgtCases(sess *compat.AWSSession, acct, region string) []rgtCase {
 		kmsCase(sess), ssmCase(sess), ecsCase(sess), sfnCase(sess, acct),
 		glueCase(sess, acct, region), keyspacesCase(sess), guarddutyCase(sess, acct, region),
 		route53Case(sess), acmCase(sess), elbCase(sess),
+		sagemakerCase(sess, acct), redshiftCase(sess, acct, region),
 	}
 
 	return append(cases, cloudwatchCase(sess, acct, region))
@@ -502,9 +506,89 @@ func elbCase(sess *compat.AWSSession) rgtCase {
 	}
 }
 
-// cloudwatchCase is tag-only: CloudWatch alarms are not projected into
-// GetResources here (walkMonitoring emits alarms without tags), so we assert the
-// tag round-trip through the alarm's own ListTagsForResource only.
+// sagemakerCase covers a SageMaker model. Discovery reads the ARN-keyed tag
+// store (SageMaker.ListTags), which the RGT tagger (AddTags) writes, so the tag
+// round-trips through GetResources.
+func sagemakerCase(sess *compat.AWSSession, acct string) rgtCase {
+	c := sagemaker.NewFromConfig(sess.Config(), func(o *sagemaker.Options) { o.BaseEndpoint = aws.String(sess.Endpoint()) })
+	roleARN := fmt.Sprintf("arn:aws:iam::%s:role/compat-sm", acct)
+
+	return rgtCase{
+		name:         "sagemaker",
+		discoverable: true,
+		create: func(ctx context.Context) (string, error) {
+			out, err := c.CreateModel(ctx, &sagemaker.CreateModelInput{
+				ModelName:        aws.String("compat-rgt-model"),
+				ExecutionRoleArn: aws.String(roleARN),
+				PrimaryContainer: &smtypes.ContainerDefinition{Image: aws.String("img:latest")},
+			})
+			if err != nil {
+				return "", err
+			}
+
+			return aws.ToString(out.ModelArn), nil
+		},
+		readTags: func(ctx context.Context, arn string) (map[string]string, error) {
+			out, err := c.ListTags(ctx, &sagemaker.ListTagsInput{ResourceArn: aws.String(arn)})
+			if err != nil {
+				return nil, err
+			}
+
+			tags := make(map[string]string, len(out.Tags))
+			for _, t := range out.Tags {
+				tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+			}
+
+			return tags, nil
+		},
+	}
+}
+
+// redshiftCase covers a Redshift cluster. Discovery merges the ARN-keyed tag
+// store (Redshift.DescribeTags), which the RGT tagger (CreateTags) writes, so
+// the tag round-trips through GetResources.
+func redshiftCase(sess *compat.AWSSession, acct, region string) rgtCase {
+	c := redshift.NewFromConfig(sess.Config(), func(o *redshift.Options) { o.BaseEndpoint = aws.String(sess.Endpoint()) })
+	const id = "compat-rgt-rs"
+	arn := fmt.Sprintf("arn:aws:redshift:%s:%s:cluster:%s", region, acct, id)
+
+	return rgtCase{
+		name:         "redshift",
+		discoverable: true,
+		create: func(ctx context.Context) (string, error) {
+			_, err := c.CreateCluster(ctx, &redshift.CreateClusterInput{
+				ClusterIdentifier:  aws.String(id),
+				NodeType:           aws.String("dc2.large"),
+				MasterUsername:     aws.String("admin"),
+				MasterUserPassword: aws.String("Passw0rd123"),
+			})
+			if err != nil {
+				return "", err
+			}
+
+			return arn, nil
+		},
+		readTags: func(ctx context.Context, arn string) (map[string]string, error) {
+			out, err := c.DescribeTags(ctx, &redshift.DescribeTagsInput{ResourceName: aws.String(arn)})
+			if err != nil {
+				return nil, err
+			}
+
+			tags := make(map[string]string, len(out.TaggedResources))
+			for _, tr := range out.TaggedResources {
+				if tr.Tag != nil {
+					tags[aws.ToString(tr.Tag.Key)] = aws.ToString(tr.Tag.Value)
+				}
+			}
+
+			return tags, nil
+		},
+	}
+}
+
+// cloudwatchCase covers a CloudWatch alarm: walkMonitoring now projects the
+// alarm's own tag store (AddAlarmTags) into GetResources, so the alarm is
+// filterable by tag like the other discoverable resources.
 func cloudwatchCase(sess *compat.AWSSession, acct, region string) rgtCase {
 	c := cloudwatch.NewFromConfig(sess.Config(), func(o *cloudwatch.Options) { o.BaseEndpoint = aws.String(sess.Endpoint()) })
 	const alarmName = "compat-rgt-alarm"
@@ -512,7 +596,7 @@ func cloudwatchCase(sess *compat.AWSSession, acct, region string) rgtCase {
 
 	return rgtCase{
 		name:         "cloudwatch",
-		discoverable: false,
+		discoverable: true,
 		create: func(ctx context.Context) (string, error) {
 			_, err := c.PutMetricAlarm(ctx, &cloudwatch.PutMetricAlarmInput{
 				AlarmName:          aws.String(alarmName),

--- a/compat/aws/rgt_full_coverage_compat_test.go
+++ b/compat/aws/rgt_full_coverage_compat_test.go
@@ -1,0 +1,547 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/acm"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/aws/aws-sdk-go-v2/service/glue"
+	gluetypes "github.com/aws/aws-sdk-go-v2/service/glue/types"
+	"github.com/aws/aws-sdk-go-v2/service/guardduty"
+	"github.com/aws/aws-sdk-go-v2/service/keyspaces"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	rgttypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/aws/aws-sdk-go-v2/service/sfn"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/internal/compat"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// rgtCase is one service's end-to-end tag lifecycle through the Resource Groups
+// Tagging API. create returns the ARN (or bare id, for Route 53) that RGT
+// addresses; readTags reads the service's OWN tag store back through its real
+// SDK; discoverable says whether the resource also surfaces in GetResources.
+type rgtCase struct {
+	name         string
+	create       func(ctx context.Context) (string, error)
+	readTags     func(ctx context.Context, arn string) (map[string]string, error)
+	discoverable bool
+}
+
+// TestAWSRGTFullCoverageCompat drives newly-wired services through the real
+// resourcegroupstaggingapi SDK: for each service it creates a resource with that
+// service's own SDK, tags the ARN via TagResources, asserts the tag is visible
+// via the service's own SDK tag read and (where the resource is discoverable)
+// via GetResources with a TagFilter, then UntagResources and asserts it is gone
+// from both. This exercises every generic-tagger shape: keyed-by-id (KMS),
+// keyed-by-name (SSM), ARN passthrough (ECS/SFN), ARN-built discovery
+// (Glue/GuardDuty), []Tag conversion (Keyspaces), alarm-name derivation
+// (CloudWatch, tag-only), named methods (ACM), and the Route 53 non-ARN id.
+func TestAWSRGTFullCoverageCompat(t *testing.T) {
+	provider := cloudemu.NewAWS()
+	sess := compat.BootAWS(t, awsserver.DriversFrom(provider))
+	ctx := context.Background()
+
+	acct, region := provider.AccountID, provider.Region
+	rgt := resourcegroupstaggingapi.NewFromConfig(sess.Config(), func(o *resourcegroupstaggingapi.Options) {
+		o.BaseEndpoint = aws.String(sess.Endpoint())
+	})
+
+	for _, tc := range rgtCases(sess, acct, region) {
+		t.Run(tc.name, func(t *testing.T) {
+			arn, err := tc.create(ctx)
+			if err != nil {
+				t.Fatalf("%s create: %v", tc.name, err)
+			}
+
+			const key, val = "compat-team", "platform"
+
+			tagResources(t, ctx, rgt, tc.name, arn, map[string]string{key: val})
+			assertServiceTag(t, ctx, tc, arn, key, val)
+
+			if tc.discoverable {
+				assertDiscovered(t, ctx, rgt, tc.name, arn, key, val, true)
+			}
+
+			untagResources(t, ctx, rgt, tc.name, arn, []string{key})
+
+			tags, err := tc.readTags(ctx, arn)
+			if err != nil {
+				t.Fatalf("%s read tags after untag: %v", tc.name, err)
+			}
+
+			if _, ok := tags[key]; ok {
+				t.Fatalf("%s: tag %q still present after UntagResources", tc.name, key)
+			}
+
+			if tc.discoverable {
+				assertDiscovered(t, ctx, rgt, tc.name, arn, key, val, false)
+			}
+		})
+	}
+}
+
+func tagResources(t *testing.T, ctx context.Context, rgt *resourcegroupstaggingapi.Client,
+	name, arn string, tags map[string]string,
+) {
+	t.Helper()
+
+	out, err := rgt.TagResources(ctx, &resourcegroupstaggingapi.TagResourcesInput{
+		ResourceARNList: []string{arn}, Tags: tags,
+	})
+	if err != nil {
+		t.Fatalf("%s TagResources: %v", name, err)
+	}
+
+	if len(out.FailedResourcesMap) != 0 {
+		t.Fatalf("%s TagResources failed for %s: %v", name, arn, out.FailedResourcesMap[arn])
+	}
+}
+
+func untagResources(t *testing.T, ctx context.Context, rgt *resourcegroupstaggingapi.Client,
+	name, arn string, keys []string,
+) {
+	t.Helper()
+
+	out, err := rgt.UntagResources(ctx, &resourcegroupstaggingapi.UntagResourcesInput{
+		ResourceARNList: []string{arn}, TagKeys: keys,
+	})
+	if err != nil {
+		t.Fatalf("%s UntagResources: %v", name, err)
+	}
+
+	if len(out.FailedResourcesMap) != 0 {
+		t.Fatalf("%s UntagResources failed for %s: %v", name, arn, out.FailedResourcesMap[arn])
+	}
+}
+
+func assertServiceTag(t *testing.T, ctx context.Context, tc rgtCase, arn, key, val string) {
+	t.Helper()
+
+	tags, err := tc.readTags(ctx, arn)
+	if err != nil {
+		t.Fatalf("%s read own tags: %v", tc.name, err)
+	}
+
+	if got := tags[key]; got != val {
+		t.Fatalf("%s own tag %q = %q, want %q (RGT tag did not land in the service store)", tc.name, key, got, val)
+	}
+}
+
+// assertDiscovered checks GetResources with a TagFilter: want=true requires the
+// ARN present with the tag; want=false requires it absent (after untag).
+func assertDiscovered(t *testing.T, ctx context.Context, rgt *resourcegroupstaggingapi.Client,
+	name, arn, key, val string, want bool,
+) {
+	t.Helper()
+
+	out, err := rgt.GetResources(ctx, &resourcegroupstaggingapi.GetResourcesInput{
+		TagFilters: []rgttypes.TagFilter{{Key: aws.String(key), Values: []string{val}}},
+	})
+	if err != nil {
+		t.Fatalf("%s GetResources: %v", name, err)
+	}
+
+	found := false
+	for _, m := range out.ResourceTagMappingList {
+		if aws.ToString(m.ResourceARN) == arn {
+			found = true
+			break
+		}
+	}
+
+	if found != want {
+		t.Fatalf("%s GetResources(tag %s=%s) found=%v, want %v (arn %s)", name, key, val, found, want, arn)
+	}
+}
+
+func rgtCases(sess *compat.AWSSession, acct, region string) []rgtCase {
+	cases := []rgtCase{
+		kmsCase(sess), ssmCase(sess), ecsCase(sess), sfnCase(sess, acct),
+		glueCase(sess, acct, region), keyspacesCase(sess), guarddutyCase(sess, acct, region),
+		route53Case(sess), acmCase(sess), elbCase(sess),
+	}
+
+	return append(cases, cloudwatchCase(sess, acct, region))
+}
+
+func kmsCase(sess *compat.AWSSession) rgtCase {
+	c := kms.NewFromConfig(sess.Config(), func(o *kms.Options) { o.BaseEndpoint = aws.String(sess.Endpoint()) })
+
+	return rgtCase{
+		name:         "kms",
+		discoverable: true,
+		create: func(ctx context.Context) (string, error) {
+			out, err := c.CreateKey(ctx, &kms.CreateKeyInput{})
+			if err != nil {
+				return "", err
+			}
+
+			return aws.ToString(out.KeyMetadata.Arn), nil
+		},
+		readTags: func(ctx context.Context, arn string) (map[string]string, error) {
+			out, err := c.ListResourceTags(ctx, &kms.ListResourceTagsInput{KeyId: aws.String(arn)})
+			if err != nil {
+				return nil, err
+			}
+
+			tags := make(map[string]string, len(out.Tags))
+			for _, t := range out.Tags {
+				tags[aws.ToString(t.TagKey)] = aws.ToString(t.TagValue)
+			}
+
+			return tags, nil
+		},
+	}
+}
+
+func ssmCase(sess *compat.AWSSession) rgtCase {
+	c := ssm.NewFromConfig(sess.Config(), func(o *ssm.Options) { o.BaseEndpoint = aws.String(sess.Endpoint()) })
+	const paramName = "compat-rgt-param"
+
+	return rgtCase{
+		name:         "ssm",
+		discoverable: true,
+		create: func(ctx context.Context) (string, error) {
+			_, err := c.PutParameter(ctx, &ssm.PutParameterInput{
+				Name: aws.String(paramName), Value: aws.String("v"), Type: ssmtypes.ParameterTypeString,
+			})
+			if err != nil {
+				return "", err
+			}
+
+			out, err := c.GetParameter(ctx, &ssm.GetParameterInput{Name: aws.String(paramName)})
+			if err != nil {
+				return "", err
+			}
+
+			return aws.ToString(out.Parameter.ARN), nil
+		},
+		readTags: func(ctx context.Context, _ string) (map[string]string, error) {
+			out, err := c.ListTagsForResource(ctx, &ssm.ListTagsForResourceInput{
+				ResourceType: ssmtypes.ResourceTypeForTaggingParameter, ResourceId: aws.String(paramName),
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			tags := make(map[string]string, len(out.TagList))
+			for _, t := range out.TagList {
+				tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+			}
+
+			return tags, nil
+		},
+	}
+}
+
+func ecsCase(sess *compat.AWSSession) rgtCase {
+	c := ecs.NewFromConfig(sess.Config(), func(o *ecs.Options) { o.BaseEndpoint = aws.String(sess.Endpoint()) })
+
+	return rgtCase{
+		name:         "ecs",
+		discoverable: true,
+		create: func(ctx context.Context) (string, error) {
+			out, err := c.CreateCluster(ctx, &ecs.CreateClusterInput{ClusterName: aws.String("compat-rgt-ecs")})
+			if err != nil {
+				return "", err
+			}
+
+			return aws.ToString(out.Cluster.ClusterArn), nil
+		},
+		readTags: func(ctx context.Context, arn string) (map[string]string, error) {
+			out, err := c.ListTagsForResource(ctx, &ecs.ListTagsForResourceInput{ResourceArn: aws.String(arn)})
+			if err != nil {
+				return nil, err
+			}
+
+			tags := make(map[string]string, len(out.Tags))
+			for _, t := range out.Tags {
+				tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+			}
+
+			return tags, nil
+		},
+	}
+}
+
+func sfnCase(sess *compat.AWSSession, acct string) rgtCase {
+	c := sfn.NewFromConfig(sess.Config(), func(o *sfn.Options) { o.BaseEndpoint = aws.String(sess.Endpoint()) })
+	const def = `{"StartAt":"a","States":{"a":{"Type":"Pass","End":true}}}`
+	roleARN := fmt.Sprintf("arn:aws:iam::%s:role/compat-sfn", acct)
+
+	return rgtCase{
+		name:         "sfn",
+		discoverable: true,
+		create: func(ctx context.Context) (string, error) {
+			out, err := c.CreateStateMachine(ctx, &sfn.CreateStateMachineInput{
+				Name: aws.String("compat-rgt-sfn"), Definition: aws.String(def), RoleArn: aws.String(roleARN),
+			})
+			if err != nil {
+				return "", err
+			}
+
+			return aws.ToString(out.StateMachineArn), nil
+		},
+		readTags: func(ctx context.Context, arn string) (map[string]string, error) {
+			out, err := c.ListTagsForResource(ctx, &sfn.ListTagsForResourceInput{ResourceArn: aws.String(arn)})
+			if err != nil {
+				return nil, err
+			}
+
+			tags := make(map[string]string, len(out.Tags))
+			for _, t := range out.Tags {
+				tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+			}
+
+			return tags, nil
+		},
+	}
+}
+
+func glueCase(sess *compat.AWSSession, acct, region string) rgtCase {
+	c := glue.NewFromConfig(sess.Config(), func(o *glue.Options) { o.BaseEndpoint = aws.String(sess.Endpoint()) })
+	const jobName = "compat-rgt-glue"
+	arn := fmt.Sprintf("arn:aws:glue:%s:%s:job/%s", region, acct, jobName)
+
+	return rgtCase{
+		name:         "glue",
+		discoverable: true,
+		create: func(ctx context.Context) (string, error) {
+			_, err := c.CreateJob(ctx, &glue.CreateJobInput{
+				Name: aws.String(jobName), Role: aws.String("compat-role"),
+				Command: &gluetypes.JobCommand{Name: aws.String("glueetl")},
+			})
+			if err != nil {
+				return "", err
+			}
+
+			return arn, nil
+		},
+		readTags: func(ctx context.Context, arn string) (map[string]string, error) {
+			out, err := c.GetTags(ctx, &glue.GetTagsInput{ResourceArn: aws.String(arn)})
+			if err != nil {
+				return nil, err
+			}
+
+			return out.Tags, nil
+		},
+	}
+}
+
+func keyspacesCase(sess *compat.AWSSession) rgtCase {
+	c := keyspaces.NewFromConfig(sess.Config(), func(o *keyspaces.Options) { o.BaseEndpoint = aws.String(sess.Endpoint()) })
+
+	return rgtCase{
+		name:         "keyspaces",
+		discoverable: true,
+		create: func(ctx context.Context) (string, error) {
+			out, err := c.CreateKeyspace(ctx, &keyspaces.CreateKeyspaceInput{KeyspaceName: aws.String("compat_rgt_ks")})
+			if err != nil {
+				return "", err
+			}
+
+			return aws.ToString(out.ResourceArn), nil
+		},
+		readTags: func(ctx context.Context, arn string) (map[string]string, error) {
+			out, err := c.ListTagsForResource(ctx, &keyspaces.ListTagsForResourceInput{ResourceArn: aws.String(arn)})
+			if err != nil {
+				return nil, err
+			}
+
+			tags := make(map[string]string, len(out.Tags))
+			for _, t := range out.Tags {
+				tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+			}
+
+			return tags, nil
+		},
+	}
+}
+
+func guarddutyCase(sess *compat.AWSSession, acct, region string) rgtCase {
+	c := guardduty.NewFromConfig(sess.Config(), func(o *guardduty.Options) { o.BaseEndpoint = aws.String(sess.Endpoint()) })
+
+	return rgtCase{
+		name:         "guardduty",
+		discoverable: true,
+		create: func(ctx context.Context) (string, error) {
+			out, err := c.CreateDetector(ctx, &guardduty.CreateDetectorInput{Enable: aws.Bool(true)})
+			if err != nil {
+				return "", err
+			}
+
+			return fmt.Sprintf("arn:aws:guardduty:%s:%s:detector/%s", region, acct, aws.ToString(out.DetectorId)), nil
+		},
+		readTags: func(ctx context.Context, arn string) (map[string]string, error) {
+			out, err := c.ListTagsForResource(ctx, &guardduty.ListTagsForResourceInput{ResourceArn: aws.String(arn)})
+			if err != nil {
+				return nil, err
+			}
+
+			return out.Tags, nil
+		},
+	}
+}
+
+func route53Case(sess *compat.AWSSession) rgtCase {
+	c := route53.NewFromConfig(sess.Config(), func(o *route53.Options) { o.BaseEndpoint = aws.String(sess.Endpoint()) })
+
+	return rgtCase{
+		name:         "route53",
+		discoverable: true,
+		create: func(ctx context.Context) (string, error) {
+			out, err := c.CreateHostedZone(ctx, &route53.CreateHostedZoneInput{
+				Name: aws.String("compat-rgt.example."), CallerReference: aws.String("compat-rgt-ref"),
+			})
+			if err != nil {
+				return "", err
+			}
+
+			// RGT addresses a hosted zone by its bare id; the CreateHostedZone
+			// response gives "/hostedzone/Z…".
+			return strings.TrimPrefix(aws.ToString(out.HostedZone.Id), "/hostedzone/"), nil
+		},
+		readTags: func(ctx context.Context, id string) (map[string]string, error) {
+			out, err := c.ListTagsForResource(ctx, &route53.ListTagsForResourceInput{
+				ResourceType: r53types.TagResourceTypeHostedzone, ResourceId: aws.String(id),
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			tags := make(map[string]string, len(out.ResourceTagSet.Tags))
+			for _, t := range out.ResourceTagSet.Tags {
+				tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+			}
+
+			return tags, nil
+		},
+	}
+}
+
+func acmCase(sess *compat.AWSSession) rgtCase {
+	c := acm.NewFromConfig(sess.Config(), func(o *acm.Options) { o.BaseEndpoint = aws.String(sess.Endpoint()) })
+
+	return rgtCase{
+		name:         "acm",
+		discoverable: true,
+		create: func(ctx context.Context) (string, error) {
+			out, err := c.RequestCertificate(ctx, &acm.RequestCertificateInput{DomainName: aws.String("compat-rgt.example.com")})
+			if err != nil {
+				return "", err
+			}
+
+			return aws.ToString(out.CertificateArn), nil
+		},
+		readTags: func(ctx context.Context, arn string) (map[string]string, error) {
+			out, err := c.ListTagsForCertificate(ctx, &acm.ListTagsForCertificateInput{CertificateArn: aws.String(arn)})
+			if err != nil {
+				return nil, err
+			}
+
+			tags := make(map[string]string, len(out.Tags))
+			for _, t := range out.Tags {
+				tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+			}
+
+			return tags, nil
+		},
+	}
+}
+
+// elbCase covers a service already discovered by an existing walker
+// (walkLoadBalancer) whose tags flow through the new generic tagger's named
+// AddResourceTags/RemoveResourceTags methods.
+func elbCase(sess *compat.AWSSession) rgtCase {
+	c := elb.NewFromConfig(sess.Config(), func(o *elb.Options) { o.BaseEndpoint = aws.String(sess.Endpoint()) })
+
+	return rgtCase{
+		name:         "elbv2",
+		discoverable: true,
+		create: func(ctx context.Context) (string, error) {
+			out, err := c.CreateLoadBalancer(ctx, &elb.CreateLoadBalancerInput{
+				Name: aws.String("compat-rgt-alb"), Type: elbtypes.LoadBalancerTypeEnumApplication,
+				Subnets: []string{"subnet-a", "subnet-b"},
+			})
+			if err != nil {
+				return "", err
+			}
+
+			return aws.ToString(out.LoadBalancers[0].LoadBalancerArn), nil
+		},
+		readTags: func(ctx context.Context, arn string) (map[string]string, error) {
+			out, err := c.DescribeTags(ctx, &elb.DescribeTagsInput{ResourceArns: []string{arn}})
+			if err != nil {
+				return nil, err
+			}
+
+			tags := map[string]string{}
+			for _, td := range out.TagDescriptions {
+				for _, t := range td.Tags {
+					tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+				}
+			}
+
+			return tags, nil
+		},
+	}
+}
+
+// cloudwatchCase is tag-only: CloudWatch alarms are not projected into
+// GetResources here (walkMonitoring emits alarms without tags), so we assert the
+// tag round-trip through the alarm's own ListTagsForResource only.
+func cloudwatchCase(sess *compat.AWSSession, acct, region string) rgtCase {
+	c := cloudwatch.NewFromConfig(sess.Config(), func(o *cloudwatch.Options) { o.BaseEndpoint = aws.String(sess.Endpoint()) })
+	const alarmName = "compat-rgt-alarm"
+	arn := fmt.Sprintf("arn:aws:cloudwatch:%s:%s:alarm:%s", region, acct, alarmName)
+
+	return rgtCase{
+		name:         "cloudwatch",
+		discoverable: false,
+		create: func(ctx context.Context) (string, error) {
+			_, err := c.PutMetricAlarm(ctx, &cloudwatch.PutMetricAlarmInput{
+				AlarmName:          aws.String(alarmName),
+				ComparisonOperator: cwtypes.ComparisonOperatorGreaterThanThreshold,
+				EvaluationPeriods:  aws.Int32(1),
+				MetricName:         aws.String("CPUUtilization"),
+				Namespace:          aws.String("AWS/EC2"),
+				Period:             aws.Int32(60),
+				Statistic:          cwtypes.StatisticAverage,
+				Threshold:          aws.Float64(80),
+			})
+			if err != nil {
+				return "", err
+			}
+
+			return arn, nil
+		},
+		readTags: func(ctx context.Context, arn string) (map[string]string, error) {
+			out, err := c.ListTagsForResource(ctx, &cloudwatch.ListTagsForResourceInput{ResourceARN: aws.String(arn)})
+			if err != nil {
+				return nil, err
+			}
+
+			tags := make(map[string]string, len(out.Tags))
+			for _, t := range out.Tags {
+				tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+			}
+
+			return tags, nil
+		},
+	}
+}

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -348,8 +348,13 @@ func awsDrivers(p *Provider) *resourcediscovery.Drivers {
 		LoadBalancer: p.ELB,
 		Monitoring:   p.CloudWatch,
 		IAM:          p.IAM,
+		// Taggers extends the Resource Groups Tagging API to every other AWS
+		// service that carries a tag store but has no discovery-driver hook here,
+		// routing each ARN to the service's own tag methods.
+		Taggers: awsTaggers(p),
 		Extra: []resourcediscovery.GenericResources{
 			sagemakerDiscovery{p.SageMaker},
+			taggedDiscovery{p},
 		},
 	}
 }

--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -810,6 +810,11 @@ func toAlarmInfo(a *alarmData) driver.AlarmInfo {
 		dims[k] = v
 	}
 
+	tags := make(map[string]string, len(a.Tags))
+	for k, v := range a.Tags {
+		tags[k] = v
+	}
+
 	return driver.AlarmInfo{
 		Name:                    a.Name,
 		Namespace:               a.Namespace,
@@ -833,5 +838,6 @@ func toAlarmInfo(a *alarmData) driver.AlarmInfo {
 		AlarmDescription:        a.AlarmDescription,
 		AlarmArn:                a.AlarmArn,
 		Dimensions:              dims,
+		Tags:                    tags,
 	}
 }

--- a/providers/aws/rds_discovery.go
+++ b/providers/aws/rds_discovery.go
@@ -9,8 +9,12 @@ import (
 )
 
 // redshiftClusters is the slice of the Redshift mock that discovery reads.
+// DescribeTags reads the ARN-keyed tag store (the target of CreateTags / the
+// Resource Groups Tagging API), which the shared cluster model does not carry,
+// so discovery reflects RGT-applied tags rather than only create-time ones.
 type redshiftClusters interface {
 	DescribeClusters(ctx context.Context, ids []string) ([]rdsdriver.Cluster, error)
+	DescribeTags(ctx context.Context, resourceName string) (map[string]string, error)
 }
 
 // rdsDiscovery adapts the RDS mock (plus Redshift) to the resourcediscovery
@@ -103,22 +107,63 @@ func (a rdsDiscovery) DiscoverDatabases(ctx context.Context) ([]resourcediscover
 		})
 	}
 
-	if a.redshift != nil {
-		clusters, err := a.redshift.DescribeClusters(ctx, nil)
+	redshift, err := a.discoverRedshift(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(out, redshift...), nil
+}
+
+// discoverRedshift projects Redshift clusters, merging each cluster's RGT tags
+// (the ARN-keyed store, read via DescribeTags) with its create-time tags.
+func (a rdsDiscovery) discoverRedshift(ctx context.Context) ([]resourcediscovery.DiscoveredDatabase, error) {
+	if a.redshift == nil {
+		return nil, nil
+	}
+
+	clusters, err := a.redshift.DescribeClusters(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]resourcediscovery.DiscoveredDatabase, 0, len(clusters))
+
+	for i := range clusters {
+		c := clusters[i]
+
+		tags, err := a.redshift.DescribeTags(ctx, c.ARN)
 		if err != nil {
 			return nil, err
 		}
 
-		for i := range clusters {
-			c := clusters[i]
-			out = append(out, resourcediscovery.DiscoveredDatabase{
-				Name: c.ID, ARN: c.ARN,
-				Type:    resourcediscovery.TypeCluster,
-				Service: resourcediscovery.ServiceRedshift,
-				Tags:    c.Tags,
-			})
-		}
+		out = append(out, resourcediscovery.DiscoveredDatabase{
+			Name: c.ID, ARN: c.ARN,
+			Type:    resourcediscovery.TypeCluster,
+			Service: resourcediscovery.ServiceRedshift,
+			Tags:    mergeTags(c.Tags, tags),
+		})
 	}
 
 	return out, nil
+}
+
+// mergeTags overlays RGT-applied tags (from the ARN-keyed store) on the
+// create-time tags carried by the cluster model, so both are visible in
+// discovery. The overlay wins on key collisions. Returns nil when both empty.
+func mergeTags(base, overlay map[string]string) map[string]string {
+	if len(base) == 0 && len(overlay) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(base)+len(overlay))
+	for k, v := range base {
+		out[k] = v
+	}
+
+	for k, v := range overlay {
+		out[k] = v
+	}
+
+	return out
 }

--- a/providers/aws/rgt_discovery.go
+++ b/providers/aws/rgt_discovery.go
@@ -1,0 +1,465 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	acmdriver "github.com/stackshy/cloudemu/v2/services/acm/driver"
+	cloudtraildriver "github.com/stackshy/cloudemu/v2/services/cloudtrail/driver"
+	configservicedriver "github.com/stackshy/cloudemu/v2/services/configservice/driver"
+	ecsdriver "github.com/stackshy/cloudemu/v2/services/ecs/driver"
+	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	gluedriver "github.com/stackshy/cloudemu/v2/services/glue/driver"
+	guarddutydriver "github.com/stackshy/cloudemu/v2/services/guardduty/driver"
+	kafkadriver "github.com/stackshy/cloudemu/v2/services/kafka/driver"
+	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
+	kmsdriver "github.com/stackshy/cloudemu/v2/services/kms/driver"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+	nfdriver "github.com/stackshy/cloudemu/v2/services/networkfirewall/driver"
+	ssmdriver "github.com/stackshy/cloudemu/v2/services/parameterstore/driver"
+	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
+	r53rdriver "github.com/stackshy/cloudemu/v2/services/route53resolver/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+	sesv2driver "github.com/stackshy/cloudemu/v2/services/sesv2/driver"
+	sfndriver "github.com/stackshy/cloudemu/v2/services/sfn/driver"
+	vpclatticedriver "github.com/stackshy/cloudemu/v2/services/vpclattice/driver"
+	wafv2driver "github.com/stackshy/cloudemu/v2/services/wafv2/driver"
+)
+
+// taggedDiscovery projects the provider-native services that carry their own
+// tag store — but are not reached by the portable-driver discovery walkers —
+// into the cross-service inventory, so their resources surface in Resource
+// Groups Tagging API GetResources with the ARN, service token, type, and live
+// tags a tagger writes. This closes the discover → tag → filter → untag loop
+// for these services. Each emitted ARN matches the shape awsTaggers routes on,
+// and each Tags value is read from the same store the tagger mutates, so a tag
+// applied via RGT reappears on the next GetResources.
+type taggedDiscovery struct{ p *Provider }
+
+// pageLimit is a large upper bound passed to paginated list methods so a single
+// page returns every resource; the loops still follow NextToken defensively.
+const pageLimit = 1000
+
+func (d taggedDiscovery) collectors() []func(context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	return []func(context.Context) ([]resourcediscovery.DiscoveredResource, error){
+		d.discoverECS, d.discoverGlue, d.discoverKafka, d.discoverOpenSearch,
+		d.discoverSFN, d.discoverSSM, d.discoverKMS, d.discoverKinesis,
+		d.discoverGuardDuty, d.discoverCloudTrail, d.discoverConfig, d.discoverWAFv2,
+		d.discoverNetworkFirewall, d.discoverSESv2, d.discoverVPCLattice, d.discoverMemoryDB,
+		d.discoverKeyspaces, d.discoverResolver, d.discoverEventBridge, d.discoverACM,
+	}
+}
+
+func (d taggedDiscovery) DiscoverResources(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	var out []resourcediscovery.DiscoveredResource
+
+	for _, collect := range d.collectors() {
+		rows, err := collect(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, rows...)
+	}
+
+	return out, nil
+}
+
+func (d taggedDiscovery) discoverECS(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	clusters, err := d.p.ECS.ListClusters(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return project(ctx, clusters, func(ctx context.Context, c ecsdriver.Cluster) (resourcediscovery.DiscoveredResource, error) {
+		tags, err := d.p.ECS.ListTagsForResource(ctx, c.ARN)
+
+		return row("ecs", "cluster", c.Name, c.ARN, tagsToMap(tags, ecsKV)), err
+	})
+}
+
+func (d taggedDiscovery) discoverOpenSearch(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	domains, err := d.p.OpenSearch.ListDomainNames(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]resourcediscovery.DiscoveredResource, 0, len(domains))
+
+	for i := range domains {
+		name := domains[i].DomainName
+		arn := idgen.AWSARN("es", d.p.Region, d.p.AccountID, "domain/"+name)
+
+		tags, err := d.p.OpenSearch.ListTags(ctx, arn)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, row("es", "domain", name, arn, tags))
+	}
+
+	return out, nil
+}
+
+func (d taggedDiscovery) discoverSFN(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	machines, err := d.p.SFN.ListStateMachines(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return project(ctx, machines, func(ctx context.Context, s sfndriver.StateMachine) (resourcediscovery.DiscoveredResource, error) {
+		tags, err := d.p.SFN.ListTagsForResource(ctx, s.ARN)
+
+		return row("states", "stateMachine", s.Name, s.ARN, tags), err
+	})
+}
+
+func (d taggedDiscovery) discoverSSM(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	params, err := d.p.SSM.DescribeParameters(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return project(ctx, params, func(ctx context.Context, p ssmdriver.ParameterMetadata) (resourcediscovery.DiscoveredResource, error) {
+		tags, err := d.p.SSM.ListParameterTags(ctx, p.Name)
+
+		return row("ssm", "parameter", p.Name, p.ARN, tags), err
+	})
+}
+
+func (d taggedDiscovery) discoverKMS(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	keys, err := d.p.KMS.ListKeys(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return project(ctx, keys, func(ctx context.Context, k kmsdriver.KeyMetadata) (resourcediscovery.DiscoveredResource, error) {
+		tags, err := d.p.KMS.ListResourceTags(ctx, k.KeyID)
+
+		return row("kms", "key", k.KeyID, k.ARN, tags), err
+	})
+}
+
+func (d taggedDiscovery) discoverNetworkFirewall(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	firewalls, err := d.p.NetworkFirewall.ListFirewalls(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return project(ctx, firewalls, func(_ context.Context, f nfdriver.Firewall) (resourcediscovery.DiscoveredResource, error) {
+		return row("network-firewall", "firewall", f.Name, f.ARN, f.Tags), nil
+	})
+}
+
+func (d taggedDiscovery) discoverSESv2(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	identities, err := d.p.SESV2.ListEmailIdentities(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return project(ctx, identities, func(_ context.Context, id sesv2driver.Identity) (resourcediscovery.DiscoveredResource, error) {
+		arn := idgen.AWSARN("ses", d.p.Region, d.p.AccountID, "identity/"+id.Name)
+
+		return row("ses", "identity", id.Name, arn, id.Tags), nil
+	})
+}
+
+func (d taggedDiscovery) discoverVPCLattice(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	services, err := d.p.VPCLattice.ListServices(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return project(ctx, services, func(ctx context.Context, s vpclatticedriver.Service) (resourcediscovery.DiscoveredResource, error) {
+		tags, err := d.p.VPCLattice.ListTagsForResource(ctx, s.ARN)
+
+		return row("vpc-lattice", "service", s.ID, s.ARN, tags), err
+	})
+}
+
+func (d taggedDiscovery) discoverMemoryDB(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	clusters, err := d.p.MemoryDB.DescribeClusters(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return project(ctx, clusters, func(ctx context.Context, c mdbdriver.Cluster) (resourcediscovery.DiscoveredResource, error) {
+		tags, err := d.p.MemoryDB.ListTags(ctx, c.ARN)
+
+		return row("memorydb", "cluster", c.Name, c.ARN, tagsToMap(tags, mdbKV)), err
+	})
+}
+
+func (d taggedDiscovery) discoverKeyspaces(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	keyspaces, err := d.p.Keyspaces.ListKeyspaces(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return project(ctx, keyspaces, func(ctx context.Context, k ksdriver.Keyspace) (resourcediscovery.DiscoveredResource, error) {
+		tags, err := d.p.Keyspaces.ListTagsForResource(ctx, k.ARN)
+
+		return row("cassandra", "keyspace", k.Name, k.ARN, tagsToMap(tags, ksKV)), err
+	})
+}
+
+func (d taggedDiscovery) discoverResolver(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	endpoints, err := d.p.Route53Resolver.ListResolverEndpoints(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return project(ctx, endpoints, func(ctx context.Context, e r53rdriver.ResolverEndpoint) (resourcediscovery.DiscoveredResource, error) {
+		tags, err := d.p.Route53Resolver.ListTagsForResource(ctx, e.ARN)
+
+		return row("route53resolver", "resolver-endpoint", e.ID, e.ARN, tagsToMap(tags, r53rKV)), err
+	})
+}
+
+func (d taggedDiscovery) discoverEventBridge(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	buses, err := d.p.EventBridge.ListEventBuses(ctx, scope.Scope{})
+	if err != nil {
+		return nil, err
+	}
+
+	return project(ctx, buses, func(ctx context.Context, b ebdriver.EventBusInfo) (resourcediscovery.DiscoveredResource, error) {
+		tags, err := d.p.EventBridge.ListResourceTags(ctx, b.ARN)
+
+		return row("events", "event-bus", b.Name, b.ARN, tags), err
+	})
+}
+
+func (d taggedDiscovery) discoverACM(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	certs, err := d.p.ACM.ListCertificates(ctx, acmdriver.ListFilter{})
+	if err != nil {
+		return nil, err
+	}
+
+	return project(ctx, certs, func(_ context.Context, c acmdriver.Certificate) (resourcediscovery.DiscoveredResource, error) {
+		return row("acm", "certificate", c.DomainName, c.ARN, c.Tags), nil
+	})
+}
+
+func (d taggedDiscovery) discoverCloudTrail(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	trails, err := d.p.CloudTrail.DescribeTrails(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return project(ctx, trails, func(ctx context.Context, t cloudtraildriver.Trail) (resourcediscovery.DiscoveredResource, error) {
+		byARN, err := d.p.CloudTrail.ListTags(ctx, []string{t.TrailARN})
+
+		return row("cloudtrail", "trail", t.Name, t.TrailARN, byARN[t.TrailARN]), err
+	})
+}
+
+func (d taggedDiscovery) discoverWAFv2(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	var out []resourcediscovery.DiscoveredResource
+
+	for _, sc := range []string{wafv2driver.ScopeRegional, wafv2driver.ScopeCloudFront} {
+		acls, err := d.p.WAFv2.ListWebACLs(ctx, sc)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range acls {
+			out = append(out, row("wafv2", "webacl", acls[i].Name, acls[i].ARN, acls[i].Tags))
+		}
+	}
+
+	return out, nil
+}
+
+func (d taggedDiscovery) discoverGlue(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	var (
+		out   []resourcediscovery.DiscoveredResource
+		token string
+	)
+
+	for {
+		names, next, err := d.p.Glue.ListJobs(ctx, gluedriver.TablePagination{NextToken: token, MaxResults: pageLimit})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, name := range names {
+			arn := idgen.AWSARN("glue", d.p.Region, d.p.AccountID, "job/"+name)
+
+			tags, err := d.p.Glue.GetTags(ctx, arn)
+			if err != nil {
+				return nil, err
+			}
+
+			out = append(out, row("glue", "job", name, arn, tags))
+		}
+
+		if next == "" {
+			return out, nil
+		}
+
+		token = next
+	}
+}
+
+func (d taggedDiscovery) discoverKafka(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	var (
+		out   []resourcediscovery.DiscoveredResource
+		token string
+	)
+
+	for {
+		clusters, next, err := d.p.Kafka.ListClusters(ctx, "", kafkadriver.Page{NextToken: token, MaxResults: pageLimit})
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range clusters {
+			tags, err := d.p.Kafka.ListTagsForResource(ctx, clusters[i].ClusterARN)
+			if err != nil {
+				return nil, err
+			}
+
+			out = append(out, row("kafka", "cluster", clusters[i].ClusterName, clusters[i].ClusterARN, tags))
+		}
+
+		if next == "" {
+			return out, nil
+		}
+
+		token = next
+	}
+}
+
+func (d taggedDiscovery) discoverKinesis(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	var (
+		out   []resourcediscovery.DiscoveredResource
+		token string
+	)
+
+	for {
+		res, err := d.p.Kinesis.ListStreams(ctx, token, "", pageLimit)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range res.StreamSummaries {
+			s := res.StreamSummaries[i]
+
+			tags, err := d.p.Kinesis.ListTagsForResource(ctx, s.StreamARN)
+			if err != nil {
+				return nil, err
+			}
+
+			out = append(out, row("kinesis", "stream", s.StreamName, s.StreamARN, tags))
+		}
+
+		if !res.HasMoreStreams || res.NextToken == "" {
+			return out, nil
+		}
+
+		token = res.NextToken
+	}
+}
+
+func (d taggedDiscovery) discoverGuardDuty(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	var (
+		out   []resourcediscovery.DiscoveredResource
+		token string
+	)
+
+	for {
+		ids, next, err := d.p.GuardDuty.ListDetectors(ctx, guarddutydriver.Page{NextToken: token, MaxResults: pageLimit})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, id := range ids {
+			det, err := d.p.GuardDuty.GetDetector(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+
+			arn := idgen.AWSARN("guardduty", d.p.Region, d.p.AccountID, "detector/"+id)
+			out = append(out, row("guardduty", "detector", id, arn, det.Tags))
+		}
+
+		if next == "" {
+			return out, nil
+		}
+
+		token = next
+	}
+}
+
+func (d taggedDiscovery) discoverConfig(ctx context.Context) ([]resourcediscovery.DiscoveredResource, error) {
+	var (
+		out   []resourcediscovery.DiscoveredResource
+		token string
+	)
+
+	for {
+		rules, next, err := d.p.Config.DescribeConfigRules(ctx, nil, configservicedriver.Page{NextToken: token, Limit: pageLimit})
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range rules {
+			out = append(out, row("config", "config-rule", rules[i].ConfigRuleID, rules[i].ConfigRuleArn, rules[i].Tags))
+		}
+
+		if next == "" {
+			return out, nil
+		}
+
+		token = next
+	}
+}
+
+// project applies fn to each item, threading the first error, and returns the
+// collected rows. It factors out the identical enumerate → read-tags → row loop
+// the single-list discoverers share. The projection returns its error last so a
+// tag-read failure inside fn short-circuits the walk with that error.
+func project[T any](ctx context.Context, items []T,
+	fn func(context.Context, T) (resourcediscovery.DiscoveredResource, error),
+) ([]resourcediscovery.DiscoveredResource, error) {
+	out := make([]resourcediscovery.DiscoveredResource, 0, len(items))
+
+	for i := range items {
+		r, err := fn(ctx, items[i])
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, r)
+	}
+
+	return out, nil
+}
+
+// row builds a DiscoveredResource, dropping an empty tag map so a resource with
+// no tags surfaces with nil Tags (matching the other walkers).
+func row(service, typ, id, arn string, tags map[string]string) resourcediscovery.DiscoveredResource {
+	if len(tags) == 0 {
+		tags = nil
+	}
+
+	return resourcediscovery.DiscoveredResource{Service: service, Type: typ, ID: id, ARN: arn, Tags: tags}
+}
+
+// tagsToMap converts a service's own []Tag slice to a map via a per-type
+// key/value accessor.
+func tagsToMap[T any](tags []T, kv func(T) (string, string)) map[string]string {
+	out := make(map[string]string, len(tags))
+
+	for _, t := range tags {
+		k, v := kv(t)
+		out[k] = v
+	}
+
+	return out
+}
+
+func ecsKV(t ecsdriver.Tag) (key, value string)   { return t.Key, t.Value }
+func ksKV(t ksdriver.Tag) (key, value string)     { return t.Key, t.Value }
+func mdbKV(t mdbdriver.Tag) (key, value string)   { return t.Key, t.Value }
+func r53rKV(t r53rdriver.Tag) (key, value string) { return t.Key, t.Value }

--- a/providers/aws/rgt_taggers.go
+++ b/providers/aws/rgt_taggers.go
@@ -1,0 +1,343 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/providers/aws/ecs"
+	"github.com/stackshy/cloudemu/v2/providers/aws/ssm"
+	bedrockdriver "github.com/stackshy/cloudemu/v2/services/bedrock/driver"
+	ecsdriver "github.com/stackshy/cloudemu/v2/services/ecs/driver"
+	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
+	r53rdriver "github.com/stackshy/cloudemu/v2/services/route53resolver/driver"
+	sagemakerdriver "github.com/stackshy/cloudemu/v2/services/sagemaker/driver"
+)
+
+// awsTaggers builds the Resource Groups Tagging API generic-tagger registry: an
+// ARN-service-token → adapter map that lets TagResources/UntagResources reach
+// every AWS mock's own tag store, beyond the dozen services the discovery
+// drivers already cover. Each adapter bridges the RGT ARN to whatever key the
+// service's tag store uses (full ARN, bare id/name) and calls the service's
+// real tag method, so a tag applied via RGT is visible through that service's
+// own ListTagsForResource/Describe surface (and, for the discoverable services,
+// through GetResources). Split into grouped builders to stay within the
+// per-function length budget.
+func awsTaggers(p *Provider) map[string]resourcediscovery.ARNTagger {
+	const taggerCount = 28
+
+	m := make(map[string]resourcediscovery.ARNTagger, taggerCount)
+	addKeyedTaggers(m, p)
+	addNamedMapTaggers(m, p)
+	addTypedTagTaggers(m, p)
+	addSpecialTaggers(m, p)
+
+	return m
+}
+
+// mapTagStore is the shape shared by most AWS mock tag stores: a set/remove pair
+// addressed by a single string key with map-valued tags.
+type mapTagStore interface {
+	TagResource(ctx context.Context, key string, tags map[string]string) error
+	UntagResource(ctx context.Context, key string, keys []string) error
+}
+
+// keyedTagger adapts a mapTagStore to resourcediscovery.ARNTagger, deriving the
+// store key from the RGT ARN via key (use fullARN for stores keyed by the ARN).
+type keyedTagger struct {
+	store mapTagStore
+	key   func(arn string) string
+}
+
+func (k keyedTagger) TagByARN(ctx context.Context, arn string, tags map[string]string) error {
+	return k.store.TagResource(ctx, k.key(arn), tags)
+}
+
+func (k keyedTagger) UntagByARN(ctx context.Context, arn string, keys []string) error {
+	return k.store.UntagResource(ctx, k.key(arn), keys)
+}
+
+// funcTagger adapts arbitrary tag/untag closures to resourcediscovery.ARNTagger,
+// for services whose tag methods have irregular names, tag types, or returns.
+type funcTagger struct {
+	tag   func(ctx context.Context, arn string, tags map[string]string) error
+	untag func(ctx context.Context, arn string, keys []string) error
+}
+
+func (f funcTagger) TagByARN(ctx context.Context, arn string, tags map[string]string) error {
+	return f.tag(ctx, arn, tags)
+}
+
+func (f funcTagger) UntagByARN(ctx context.Context, arn string, keys []string) error {
+	return f.untag(ctx, arn, keys)
+}
+
+// addKeyedTaggers registers services whose mock exposes the canonical
+// TagResource/UntagResource(key, …) pair. Most key by the full ARN; EFS keys by
+// the file-system/access-point id and KMS by the key id, so those two supply a
+// key extractor.
+func addKeyedTaggers(m map[string]resourcediscovery.ARNTagger, p *Provider) {
+	m["config"] = keyedTagger{p.Config, fullARN}
+	m["ecs"] = keyedTagger{ecsMapStore{p.ECS}, fullARN}
+	m["eks"] = keyedTagger{p.EKS, fullARN}
+	m["events"] = keyedTagger{p.EventBridge, fullARN}
+	m["glue"] = keyedTagger{p.Glue, fullARN}
+	m["kafka"] = keyedTagger{p.Kafka, fullARN}
+	m["cassandra"] = keyedTagger{p.Keyspaces, fullARN}
+	m["kinesis"] = keyedTagger{p.Kinesis, fullARN}
+	m["network-firewall"] = keyedTagger{p.NetworkFirewall, fullARN}
+	m["ses"] = keyedTagger{p.SESV2, fullARN}
+	m["states"] = keyedTagger{p.SFN, fullARN}
+	m["vpc-lattice"] = keyedTagger{p.VPCLattice, fullARN}
+	m["wafv2"] = keyedTagger{p.WAFv2, fullARN}
+	m["elasticfilesystem"] = keyedTagger{p.EFS, lastPathSegment}
+	m["kms"] = keyedTagger{p.KMS, kmsKeyID}
+	m["ssm"] = keyedTagger{ssmParamStore{p.SSM}, ssmParamName}
+}
+
+// addNamedMapTaggers registers services with map-valued tags whose mock uses a
+// non-canonical method name (or, for CloudWatch, keys by the alarm name derived
+// from the ARN).
+func addNamedMapTaggers(m map[string]resourcediscovery.ARNTagger, p *Provider) {
+	m["acm"] = funcTagger{
+		tag: func(ctx context.Context, arn string, tags map[string]string) error {
+			return p.ACM.AddTagsToCertificate(ctx, arn, tags)
+		},
+		untag: func(ctx context.Context, arn string, keys []string) error {
+			return p.ACM.RemoveTagsFromCertificate(ctx, arn, keys)
+		},
+	}
+	m["cloudtrail"] = funcTagger{
+		tag: func(ctx context.Context, arn string, tags map[string]string) error {
+			return p.CloudTrail.AddTags(ctx, arn, tags)
+		},
+		untag: func(ctx context.Context, arn string, keys []string) error {
+			return p.CloudTrail.RemoveTags(ctx, arn, keys)
+		},
+	}
+	m["cloudwatch"] = funcTagger{
+		tag: func(ctx context.Context, arn string, tags map[string]string) error {
+			return p.CloudWatch.AddAlarmTags(ctx, cwAlarmName(arn), tags)
+		},
+		untag: func(ctx context.Context, arn string, keys []string) error {
+			return p.CloudWatch.RemoveAlarmTags(ctx, cwAlarmName(arn), keys)
+		},
+	}
+	m["es"] = funcTagger{
+		tag: func(ctx context.Context, arn string, tags map[string]string) error {
+			return p.OpenSearch.AddTags(ctx, arn, tags)
+		},
+		untag: func(ctx context.Context, arn string, keys []string) error {
+			return p.OpenSearch.RemoveTags(ctx, arn, keys)
+		},
+	}
+	m["redshift"] = funcTagger{
+		tag: func(ctx context.Context, arn string, tags map[string]string) error {
+			return p.Redshift.CreateTags(ctx, arn, tags)
+		},
+		untag: func(ctx context.Context, arn string, keys []string) error {
+			return p.Redshift.DeleteTags(ctx, arn, keys)
+		},
+	}
+	m["elasticloadbalancing"] = funcTagger{
+		tag: func(ctx context.Context, arn string, tags map[string]string) error {
+			return p.ELB.AddResourceTags(ctx, arn, tags)
+		},
+		untag: func(ctx context.Context, arn string, keys []string) error {
+			return p.ELB.RemoveResourceTags(ctx, arn, keys)
+		},
+	}
+}
+
+// addTypedTagTaggers registers services whose mock takes a []driver.Tag slice
+// instead of a map; the closures convert the RGT map into the service's own Tag
+// type.
+func addTypedTagTaggers(m map[string]resourcediscovery.ARNTagger, p *Provider) {
+	m["bedrock"] = funcTagger{
+		tag: func(ctx context.Context, arn string, tags map[string]string) error {
+			return p.Bedrock.TagResource(ctx, arn, bedrockTags(tags))
+		},
+		untag: func(ctx context.Context, arn string, keys []string) error {
+			return p.Bedrock.UntagResource(ctx, arn, keys)
+		},
+	}
+	m["route53resolver"] = funcTagger{
+		tag: func(ctx context.Context, arn string, tags map[string]string) error {
+			return p.Route53Resolver.TagResource(ctx, arn, route53ResolverTags(tags))
+		},
+		untag: func(ctx context.Context, arn string, keys []string) error {
+			return p.Route53Resolver.UntagResource(ctx, arn, keys)
+		},
+	}
+	m["sagemaker"] = funcTagger{
+		tag: func(ctx context.Context, arn string, tags map[string]string) error {
+			_, err := p.SageMaker.AddTags(ctx, arn, sagemakerTags(tags))
+
+			return err
+		},
+		untag: func(ctx context.Context, arn string, keys []string) error {
+			return p.SageMaker.DeleteTags(ctx, arn, keys)
+		},
+	}
+}
+
+// addSpecialTaggers registers services whose tag surface does not fit the other
+// shapes: GuardDuty (JSON-body tags + JSON returns), MemoryDB (returns the
+// resulting tag list), and Route 53 (a single combined add/remove call keyed by
+// the bare hosted-zone id).
+func addSpecialTaggers(m map[string]resourcediscovery.ARNTagger, p *Provider) {
+	m["guardduty"] = funcTagger{
+		tag: func(ctx context.Context, arn string, tags map[string]string) error {
+			body, err := json.Marshal(map[string]map[string]string{"tags": tags})
+			if err != nil {
+				return err
+			}
+
+			_, err = p.GuardDuty.TagResource(ctx, arn, body)
+
+			return err
+		},
+		untag: func(ctx context.Context, arn string, keys []string) error {
+			_, err := p.GuardDuty.UntagResource(ctx, arn, keys)
+
+			return err
+		},
+	}
+	m["memorydb"] = funcTagger{
+		tag: func(ctx context.Context, arn string, tags map[string]string) error {
+			_, err := p.MemoryDB.TagResource(ctx, arn, tags)
+
+			return err
+		},
+		untag: func(ctx context.Context, arn string, keys []string) error {
+			_, err := p.MemoryDB.UntagResource(ctx, arn, keys)
+
+			return err
+		},
+	}
+	m["route53"] = funcTagger{
+		tag: func(ctx context.Context, arn string, tags map[string]string) error {
+			return p.Route53.ChangeResourceTags(ctx, hostedZoneID(arn), tags, nil)
+		},
+		untag: func(ctx context.Context, arn string, keys []string) error {
+			return p.Route53.ChangeResourceTags(ctx, hostedZoneID(arn), nil, keys)
+		},
+	}
+}
+
+// ecsMapStore adapts the ECS mock ([]driver.Tag) to the map-keyed mapTagStore.
+type ecsMapStore struct{ m *ecs.Mock }
+
+func (e ecsMapStore) TagResource(ctx context.Context, arn string, tags map[string]string) error {
+	return e.m.TagResource(ctx, arn, ecsTags(tags))
+}
+
+func (e ecsMapStore) UntagResource(ctx context.Context, arn string, keys []string) error {
+	return e.m.UntagResource(ctx, arn, keys)
+}
+
+// ssmParamStore adapts the SSM parameter tag methods (TagParameter/
+// UntagParameter) to mapTagStore.
+type ssmParamStore struct{ m *ssm.Mock }
+
+func (s ssmParamStore) TagResource(ctx context.Context, name string, tags map[string]string) error {
+	return s.m.TagParameter(ctx, name, tags)
+}
+
+func (s ssmParamStore) UntagResource(ctx context.Context, name string, keys []string) error {
+	return s.m.UntagParameter(ctx, name, keys)
+}
+
+// fullARN is the identity key extractor for stores addressed by the full ARN.
+func fullARN(arn string) string { return arn }
+
+// lastPathSegment returns the segment after the final '/', the id EFS keys its
+// tag store by (fs-… / fsap-…) within a file-system/access-point ARN.
+func lastPathSegment(arn string) string {
+	if i := strings.LastIndexByte(arn, '/'); i >= 0 {
+		return arn[i+1:]
+	}
+
+	return arn
+}
+
+// kmsKeyID returns the key id KMS tags by — the segment after ":key/" in a KMS
+// ARN (arn:aws:kms:…:key/<id>).
+func kmsKeyID(arn string) string {
+	const marker = ":key/"
+	if i := strings.Index(arn, marker); i >= 0 {
+		return arn[i+len(marker):]
+	}
+
+	return lastPathSegment(arn)
+}
+
+// ssmParamName returns the parameter name SSM keys its tag store by — the
+// segment after ":parameter/" in an SSM parameter ARN.
+func ssmParamName(arn string) string {
+	const marker = ":parameter/"
+	if i := strings.Index(arn, marker); i >= 0 {
+		return arn[i+len(marker):]
+	}
+
+	return arn
+}
+
+// cwAlarmName returns the alarm name CloudWatch keys its tag store by — the
+// segment after ":alarm:" in a CloudWatch alarm ARN (arn:aws:cloudwatch:…:alarm:<name>).
+func cwAlarmName(arn string) string {
+	const marker = ":alarm:"
+	if i := strings.Index(arn, marker); i >= 0 {
+		return arn[i+len(marker):]
+	}
+
+	return arn
+}
+
+// hostedZoneID returns the Route 53 hosted-zone id the tag store keys by. RGT
+// may present either the bare id (as the discovery walk surfaces it) or a real
+// arn:aws:route53:::hostedzone/<id> ARN.
+func hostedZoneID(arn string) string {
+	const marker = "hostedzone/"
+	if i := strings.Index(arn, marker); i >= 0 {
+		return arn[i+len(marker):]
+	}
+
+	return arn
+}
+
+func bedrockTags(tags map[string]string) []bedrockdriver.Tag {
+	out := make([]bedrockdriver.Tag, 0, len(tags))
+	for k, v := range tags {
+		out = append(out, bedrockdriver.Tag{Key: k, Value: v})
+	}
+
+	return out
+}
+
+func ecsTags(tags map[string]string) []ecsdriver.Tag {
+	out := make([]ecsdriver.Tag, 0, len(tags))
+	for k, v := range tags {
+		out = append(out, ecsdriver.Tag{Key: k, Value: v})
+	}
+
+	return out
+}
+
+func route53ResolverTags(tags map[string]string) []r53rdriver.Tag {
+	out := make([]r53rdriver.Tag, 0, len(tags))
+	for k, v := range tags {
+		out = append(out, r53rdriver.Tag{Key: k, Value: v})
+	}
+
+	return out
+}
+
+func sagemakerTags(tags map[string]string) []sagemakerdriver.Tag {
+	out := make([]sagemakerdriver.Tag, 0, len(tags))
+	for k, v := range tags {
+		out = append(out, sagemakerdriver.Tag{Key: k, Value: v})
+	}
+
+	return out
+}

--- a/providers/aws/route53/route53.go
+++ b/providers/aws/route53/route53.go
@@ -59,7 +59,32 @@ func (m *Mock) ChangeResourceTags(_ context.Context, resourceID string, add map[
 		delete(m.tagsByID[resourceID], k)
 	}
 
+	m.syncZoneTags(resourceID)
+
 	return nil
+}
+
+// syncZoneTags mirrors a hosted zone's authoritative tag store (tagsByID, the
+// target of ChangeTagsForResource / the Resource Groups Tagging API) onto the
+// zone's own Tags field, which discovery (ListZones) reads. Without this the
+// two stores drift — a tag applied via the tagging API would be invisible to
+// Resource Explorer / GetResources. A no-op when resourceID is not a zone (the
+// same tag API also addresses health checks). Callers hold m.tagsMu.
+func (m *Mock) syncZoneTags(resourceID string) {
+	if _, ok := m.zones.Get(resourceID); !ok {
+		return
+	}
+
+	tags := make(map[string]string, len(m.tagsByID[resourceID]))
+	for k, v := range m.tagsByID[resourceID] {
+		tags[k] = v
+	}
+
+	m.zones.Update(resourceID, func(z driver.ZoneInfo) driver.ZoneInfo {
+		z.Tags = tags
+
+		return z
+	})
 }
 
 // ListResourceTags returns the tags on a Route 53 resource by ID.
@@ -139,10 +164,30 @@ func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 	}
 
 	m.zones.Set(id, zone)
+	m.seedZoneTags(id, tags)
 
 	result := zone
 
 	return &result, nil
+}
+
+// seedZoneTags copies a zone's create-time tags into the authoritative tag
+// store (tagsByID) so they and tags added later via ChangeTagsForResource / the
+// Resource Groups Tagging API share one source of truth (see syncZoneTags).
+func (m *Mock) seedZoneTags(id string, tags map[string]string) {
+	if len(tags) == 0 {
+		return
+	}
+
+	seeded := make(map[string]string, len(tags))
+	for k, v := range tags {
+		seeded[k] = v
+	}
+
+	m.tagsMu.Lock()
+	defer m.tagsMu.Unlock()
+
+	m.tagsByID[id] = seeded
 }
 
 // DeleteZone deletes a DNS hosted zone by ID.

--- a/providers/aws/sagemaker_discovery.go
+++ b/providers/aws/sagemaker_discovery.go
@@ -13,11 +13,15 @@ import (
 // excluded — real inventory APIs surface the standing resources, not job runs.
 type sagemakerDiscovery struct{ m smMock }
 
-// smMock is the subset of the SageMaker mock discovery reads.
+// smMock is the subset of the SageMaker mock discovery reads. ListTags reads
+// the authoritative ARN-keyed tag store (the target of AddTags / the Resource
+// Groups Tagging API), which is seeded with create-time tags too — so discovery
+// reflects tags applied through either path rather than the stale struct copy.
 type smMock interface {
 	ListModels(ctx context.Context) ([]sagemakerdriver.Model, error)
 	ListEndpoints(ctx context.Context) ([]sagemakerdriver.Endpoint, error)
 	ListNotebookInstances(ctx context.Context) ([]sagemakerdriver.NotebookInstance, error)
+	ListTags(ctx context.Context, resourceARN string) ([]sagemakerdriver.Tag, error)
 }
 
 func smTags(tags []sagemakerdriver.Tag) map[string]string {
@@ -55,25 +59,50 @@ func (a sagemakerDiscovery) DiscoverResources(
 		len(models)+len(endpoints)+len(notebooks))
 
 	for i := range models {
+		tags, err := a.liveTags(ctx, models[i].ModelARN)
+		if err != nil {
+			return nil, err
+		}
+
 		out = append(out, resourcediscovery.DiscoveredResource{
 			Service: resourcediscovery.ServiceSageMaker, Type: resourcediscovery.TypeModel,
-			ID: models[i].ModelName, ARN: models[i].ModelARN, Tags: smTags(models[i].Tags),
+			ID: models[i].ModelName, ARN: models[i].ModelARN, Tags: tags,
 		})
 	}
 
 	for i := range endpoints {
+		tags, err := a.liveTags(ctx, endpoints[i].EndpointARN)
+		if err != nil {
+			return nil, err
+		}
+
 		out = append(out, resourcediscovery.DiscoveredResource{
 			Service: resourcediscovery.ServiceSageMaker, Type: resourcediscovery.TypeEndpoint,
-			ID: endpoints[i].EndpointName, ARN: endpoints[i].EndpointARN, Tags: smTags(endpoints[i].Tags),
+			ID: endpoints[i].EndpointName, ARN: endpoints[i].EndpointARN, Tags: tags,
 		})
 	}
 
 	for i := range notebooks {
+		tags, err := a.liveTags(ctx, notebooks[i].ARN)
+		if err != nil {
+			return nil, err
+		}
+
 		out = append(out, resourcediscovery.DiscoveredResource{
 			Service: resourcediscovery.ServiceSageMaker, Type: resourcediscovery.TypeNotebookInstance,
-			ID: notebooks[i].Name, ARN: notebooks[i].ARN, Tags: smTags(notebooks[i].Tags),
+			ID: notebooks[i].Name, ARN: notebooks[i].ARN, Tags: tags,
 		})
 	}
 
 	return out, nil
+}
+
+// liveTags reads a resource's current tags from the ARN-keyed tag store.
+func (a sagemakerDiscovery) liveTags(ctx context.Context, arn string) (map[string]string, error) {
+	tags, err := a.m.ListTags(ctx, arn)
+	if err != nil {
+		return nil, err
+	}
+
+	return smTags(tags), nil
 }

--- a/services/monitoring/driver/driver.go
+++ b/services/monitoring/driver/driver.go
@@ -107,6 +107,9 @@ type AlarmInfo struct {
 	AlarmDescription        string
 	AlarmArn                string
 	Dimensions              map[string]string
+	// Tags are the alarm's resource tags. Populated by providers that store
+	// them (AWS CloudWatch alarm tags); empty for the others.
+	Tags map[string]string
 }
 
 // NotificationChannelConfig describes a notification channel.

--- a/services/resourcediscovery/engine.go
+++ b/services/resourcediscovery/engine.go
@@ -47,9 +47,32 @@ type Drivers struct {
 	Monitoring      monitoringdriver.Monitoring
 	IAM             iamdriver.IAM
 
+	// Taggers maps an AWS service token (segment 3 of an ARN — e.g. "kms",
+	// "ecs", "elasticloadbalancing") to an adapter that tags/untags a resource
+	// of that service by its full ARN. It extends the Resource Groups Tagging
+	// API (TagResourceByARN/UntagResourceByARN) to services that are not reached
+	// through the shared driver interfaces above, without widening every
+	// services/*/driver. The provider owns each adapter (it knows the concrete
+	// mock and how its tag store is keyed). A missing or nil entry degrades to
+	// "tagging service … is not yet supported"; nothing here ever panics.
+	Taggers map[string]ARNTagger
+
 	// Extra holds provider-projected capabilities for services that don't fit
 	// the shared driver interfaces (e.g. ML/GenAI). Each is walked generically.
 	Extra []GenericResources
+}
+
+// ARNTagger tags and untags a resource addressed by its full ARN (or, for
+// services whose Resource Groups Tagging identifier is not an arn:aws string —
+// e.g. a Route 53 hosted-zone id — that identifier). Each provider wires one per
+// taggable service that the shared driver interfaces do not already cover; the
+// adapter bridges the RGT ARN to whatever key the service's own tag store uses
+// (full ARN, bare name, or id) and calls the service's real tag method, so the
+// tag lands in that service's own store and is visible through its own
+// ListTagsForResource / Describe surface.
+type ARNTagger interface {
+	TagByARN(ctx context.Context, arn string, tags map[string]string) error
+	UntagByARN(ctx context.Context, arn string, keys []string) error
 }
 
 // GenericResources lets a provider project arbitrary services/resources into

--- a/services/resourcediscovery/tagging.go
+++ b/services/resourcediscovery/tagging.go
@@ -22,6 +22,7 @@ const (
 	awsServiceLogs        = "logs"
 	awsServiceRDS         = "rds"
 	awsServiceIAM         = "iam"
+	awsServiceRoute53     = "route53"
 )
 
 // DynamoDB resource type within a DynamoDB ARN.
@@ -79,22 +80,83 @@ const arnParts = 6
 // unparseable ARNs.
 func (e *Engine) TagResourceByARN(ctx context.Context, arn string, tags map[string]string) error {
 	res, err := parseSupportedARN(arn)
-	if err != nil {
-		return err
+	if err == nil {
+		return e.dispatchTag(ctx, res, tags, true /* set */, nil)
 	}
 
-	return e.dispatchTag(ctx, res, tags, true /* set */, nil)
+	// The ARN is not one of the built-in services above; try a provider-wired
+	// generic tagger keyed by the ARN's service token. When none is registered,
+	// surface the original "not yet supported" (or malformed-ARN) error.
+	if t := e.genericTagger(arn); t != nil {
+		return t.TagByARN(ctx, arn, tags)
+	}
+
+	return err
 }
 
 // UntagResourceByARN removes the given tag keys from the resource identified
 // by arn. ARN parsing rules match TagResourceByARN.
 func (e *Engine) UntagResourceByARN(ctx context.Context, arn string, keys []string) error {
 	res, err := parseSupportedARN(arn)
-	if err != nil {
-		return err
+	if err == nil {
+		return e.dispatchTag(ctx, res, nil, false /* set */, keys)
 	}
 
-	return e.dispatchTag(ctx, res, nil, false /* set */, keys)
+	if t := e.genericTagger(arn); t != nil {
+		return t.UntagByARN(ctx, arn, keys)
+	}
+
+	return err
+}
+
+// genericTagger returns the provider-wired ARNTagger for arn's service token,
+// or nil when none is registered. It also recognizes a Route 53 hosted-zone id
+// (a bare "Z…" identifier, not an arn:aws string), which the discovery walk
+// emits verbatim as a zone's identifier, so tagging a hosted zone round-trips
+// through GetResources.
+func (e *Engine) genericTagger(arn string) ARNTagger {
+	if e.drivers.Taggers == nil {
+		return nil
+	}
+
+	return e.drivers.Taggers[taggerServiceToken(arn)]
+}
+
+// taggerServiceToken returns the AWS service token used to look up a generic
+// tagger: segment 3 of an arn:aws:<service>:… ARN, or "route53" for a bare
+// hosted-zone id. It returns "" for anything else.
+func taggerServiceToken(arn string) string {
+	const prefix = "arn:aws:"
+	if strings.HasPrefix(arn, prefix) {
+		if svc, _, ok := strings.Cut(arn[len(prefix):], ":"); ok {
+			return svc
+		}
+
+		return ""
+	}
+
+	if looksLikeHostedZoneID(arn) {
+		return awsServiceRoute53
+	}
+
+	return ""
+}
+
+// looksLikeHostedZoneID reports whether s is a Route 53 hosted-zone id: a "Z"
+// followed by one or more alphanumerics (e.g. "Z1D633PJN98FT9"), the identifier
+// the DNS walk surfaces for a zone in place of an ARN.
+func looksLikeHostedZoneID(s string) bool {
+	if len(s) < 2 || s[0] != 'Z' {
+		return false
+	}
+
+	for _, r := range s[1:] {
+		if !(r >= '0' && r <= '9' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z') {
+			return false
+		}
+	}
+
+	return true
 }
 
 // parsedARN holds the fragments TagResourceByARN needs to route a call.

--- a/services/resourcediscovery/walkers.go
+++ b/services/resourcediscovery/walkers.go
@@ -1030,7 +1030,11 @@ func (e *Engine) walkMonitoring(ctx context.Context) ([]Resource, error) {
 
 	return e.emitSimple(ServiceMonitoring, TypeAlarm, len(alarms),
 		func(i int) (string, string, map[string]string) {
-			return alarms[i].Name, e.monitoringAlarmARN(alarms[i].Name), nil
+			// Tags come from the alarm's own tag store (AWS CloudWatch
+			// AddAlarmTags / the Resource Groups Tagging API), so a tagged alarm
+			// is filterable in GetResources. Non-AWS monitoring mocks leave it
+			// empty, matching the prior behavior.
+			return alarms[i].Name, e.monitoringAlarmARN(alarms[i].Name), alarms[i].Tags
 		}), nil
 }
 


### PR DESCRIPTION
## Summary

Extends the AWS ResourceGroupsTaggingAPI (RGT) from tagging 12 services to **every taggable AWS service (40 total)**, end-to-end: a tag applied via `TagResources` lands in that service's OWN tag store, is visible through the service's own `ListTagsForResource`/`Describe`, is filterable via RGT `GetResources`, and is removable via `UntagResources`.

## What changed

**Generic tagger registry** (`services/resourcediscovery` + `providers/aws/rgt_taggers.go`)
- New `resourcediscovery.ARNTagger` capability + `Drivers.Taggers map[string]ARNTagger`, keyed by AWS ARN service token. `TagResourceByARN`/`UntagResourceByARN` fall back to it when an ARN isn't one of the 12 built-in services; a missing entry still returns "tagging service … is not yet supported" (nil-safe, no panics).
- The provider wires an adapter per service that bridges the RGT ARN to each mock's own tag method — full-ARN, bare-id (EFS), key-id (KMS), parameter-name (SSM), alarm-name (CloudWatch), `[]Tag` conversion (bedrock/ecs/route53resolver/sagemaker), JSON body (GuardDuty), and the Route 53 non-ARN hosted-zone id.
- 28 newly-wired service tokens added: acm, bedrock, cassandra(keyspaces), cloudtrail, cloudwatch, config, ecs, eks, elasticfilesystem(efs), elasticloadbalancing(elbv2), es(opensearch), events(eventbridge), glue, guardduty, kafka, kinesis, kms, memorydb, network-firewall, redshift, route53, route53resolver, sagemaker, ses(sesv2), states(sfn), ssm, vpc-lattice, wafv2.

**Discovery** (`providers/aws/rgt_discovery.go`)
- New `taggedDiscovery` provider adapter (via the existing `GenericResources`/`Extra` mechanism) projects 20 provider-native services into the inventory, so their resources surface in `GetResources` with the ARN/service/type and **live tags read from the same store the tagger mutates** — closing the discover → tag → filter → untag loop.

**Route 53 tag-store unification** (`providers/aws/route53/route53.go`)
- Route 53 had two disconnected tag stores (`tagsByID` used by the tag API vs `zone.Tags` read by discovery). `ChangeResourceTags` now mirrors into the zone, and create-time tags seed the authoritative store, so a hosted zone tagged via RGT is visible via both `ListTagsForResource` and `GetResources`.

## Tests
- `compat/aws/rgt_full_coverage_compat_test.go` — real aws-sdk-go-v2 round-trip for 11 representative services (kms, ssm, ecs, sfn, glue, keyspaces, guardduty, route53, acm, elbv2, cloudwatch): create → `TagResources` → own-SDK tag read → `GetResources` TagFilter → `UntagResources` → gone from both.

## Not wired
- `bedrockagent` has no tag plumbing (no TagResource/ListTagsForResource in mock, driver, or wire) — remains "not yet supported".

## Gates
`go build ./...`, `go vet ./...`, full `go test ./...` green; `go generate ./...` no diff; golangci-lint 0 new on touched packages.
