### PR TITLE
feat(aws): region-aware resources — stamp the request's region on ARNs/resources

### DIFF
--- a/compat/aws/region_awareness_compat_test.go
+++ b/compat/aws/region_awareness_compat_test.go
@@ -11,6 +11,7 @@ import (
 	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	awsecr "github.com/aws/aws-sdk-go-v2/service/ecr"
 	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
@@ -332,6 +333,111 @@ func TestRegionAwarenessAWSCompat(t *testing.T) {
 		}
 		if strings.Contains(arn, regionTokyo) {
 			t.Fatalf("iam: global ARN %q was wrongly stamped with a region", arn)
+		}
+	})
+}
+
+// TestRegionAwarenessCrossRegionChild is the adversarial case the same-region
+// suite cannot catch: it creates a PARENT with a client in one region, then
+// issues the CHILD-creating call with a client signed for a DIFFERENT region,
+// and asserts the child's ARN carries the PARENT's region, not the request's.
+// A child must inherit its parent's region (from the parent's stored ARN), per
+// the PR's child-ARN-inheritance contract. These cases FAIL against code that
+// reconstructs the child region from the request.
+func TestRegionAwarenessCrossRegionChild(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	sess := compat.BootAWS(t, awsserver.Drivers{ECS: cloud.ECS, ElastiCache: cloud.ElastiCache})
+
+	ctx := context.Background()
+	cfg := sess.Config()
+	endpoint := sess.Endpoint()
+
+	// ECS: a task created in ap-northeast-1 against a cluster that lives in
+	// us-east-1 must carry the cluster's region on both its cluster and task ARN.
+	t.Run("ecs_runtask_inherits_cluster_region", func(t *testing.T) {
+		home := awsecs.NewFromConfig(cfg, func(o *awsecs.Options) {
+			o.Region = regionDefault
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		if _, err := home.CreateCluster(ctx, &awsecs.CreateClusterInput{
+			ClusterName: aws.String("xr-cluster"),
+		}); err != nil {
+			t.Fatalf("CreateCluster: %v", err)
+		}
+		if _, err := home.RegisterTaskDefinition(ctx, &awsecs.RegisterTaskDefinitionInput{
+			Family:                  aws.String("xr-td"),
+			NetworkMode:             ecstypes.NetworkModeAwsvpc,
+			RequiresCompatibilities: []ecstypes.Compatibility{ecstypes.CompatibilityFargate},
+			Cpu:                     aws.String("256"),
+			Memory:                  aws.String("512"),
+			ContainerDefinitions: []ecstypes.ContainerDefinition{{
+				Name: aws.String("app"), Image: aws.String("nginx:latest"), Essential: aws.Bool(true),
+			}},
+		}); err != nil {
+			t.Fatalf("RegisterTaskDefinition: %v", err)
+		}
+
+		// RunTask from a DIFFERENT region than the cluster was created in.
+		away := awsecs.NewFromConfig(cfg, func(o *awsecs.Options) {
+			o.Region = regionTokyo
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		run, err := away.RunTask(ctx, &awsecs.RunTaskInput{
+			Cluster:        aws.String("xr-cluster"),
+			TaskDefinition: aws.String("xr-td"),
+			LaunchType:     ecstypes.LaunchTypeFargate,
+			NetworkConfiguration: &ecstypes.NetworkConfiguration{
+				AwsvpcConfiguration: &ecstypes.AwsVpcConfiguration{Subnets: []string{"subnet-1"}},
+			},
+		})
+		if err != nil {
+			t.Fatalf("RunTask: %v", err)
+		}
+		if len(run.Tasks) != 1 {
+			t.Fatalf("RunTask returned %d tasks, want 1", len(run.Tasks))
+		}
+
+		clusterARN := aws.ToString(run.Tasks[0].ClusterArn)
+		taskARN := aws.ToString(run.Tasks[0].TaskArn)
+		assertRegion(t, "ecs task's clusterArn", clusterARN, regionDefault)
+		assertRegion(t, "ecs task ARN", taskARN, regionDefault)
+		if strings.Contains(clusterARN, regionTokyo) || strings.Contains(taskARN, regionTokyo) {
+			t.Fatalf("ecs: child ARNs leaked the request region: clusterArn=%q taskArn=%q", clusterARN, taskARN)
+		}
+	})
+
+	// ElastiCache: a snapshot taken in ap-northeast-1 of a cache cluster that
+	// lives in us-east-1 must carry the cluster's region.
+	t.Run("elasticache_snapshot_inherits_cluster_region", func(t *testing.T) {
+		home := awselasticache.NewFromConfig(cfg, func(o *awselasticache.Options) {
+			o.Region = regionDefault
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		if _, err := home.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+			CacheClusterId: aws.String("xr-cache"),
+			Engine:         aws.String("redis"),
+			CacheNodeType:  aws.String("cache.t3.micro"),
+			NumCacheNodes:  aws.Int32(1),
+		}); err != nil {
+			t.Fatalf("CreateCacheCluster: %v", err)
+		}
+
+		// CreateSnapshot from a DIFFERENT region than the cache cluster.
+		away := awselasticache.NewFromConfig(cfg, func(o *awselasticache.Options) {
+			o.Region = regionTokyo
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		out, err := away.CreateSnapshot(ctx, &awselasticache.CreateSnapshotInput{
+			CacheClusterId: aws.String("xr-cache"),
+			SnapshotName:   aws.String("xr-snap"),
+		})
+		if err != nil {
+			t.Fatalf("CreateSnapshot: %v", err)
+		}
+		arn := aws.ToString(out.Snapshot.ARN)
+		assertRegion(t, "elasticache snapshot", arn, regionDefault)
+		if strings.Contains(arn, regionTokyo) {
+			t.Fatalf("elasticache: snapshot ARN %q leaked the request region", arn)
 		}
 	})
 }

--- a/compat/aws/region_awareness_compat_test.go
+++ b/compat/aws/region_awareness_compat_test.go
@@ -1,0 +1,337 @@
+package aws
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awscwl "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	awsdynamodb "github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	awsecr "github.com/aws/aws-sdk-go-v2/service/ecr"
+	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
+	awskinesis "github.com/aws/aws-sdk-go-v2/service/kinesis"
+	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+	awssfn "github.com/aws/aws-sdk-go-v2/service/sfn"
+	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/internal/compat"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// The two regions exercised: one non-default region a client actually addresses,
+// and the emulator's default. A regional resource must carry whichever the
+// client used, not the fixed default.
+const (
+	regionTokyo   = "ap-northeast-1"
+	regionDefault = "us-east-1"
+)
+
+// assertRegion fails when arn does not carry want in its region field. It is the
+// single assertion every regional case shares.
+func assertRegion(t *testing.T, service, arn, want string) {
+	t.Helper()
+
+	if arn == "" {
+		t.Fatalf("%s: empty ARN", service)
+	}
+
+	if !strings.Contains(arn, ":"+want+":") {
+		t.Fatalf("%s: ARN %q does not carry region %q", service, arn, want)
+	}
+}
+
+// TestRegionAwarenessAWSCompat drives real aws-sdk-go-v2 clients configured for
+// ap-northeast-1 against CloudEmu's in-process wire server and asserts each
+// regional resource is stamped with the request's region (not the fixed
+// us-east-1 default). It also asserts a us-east-1 client still gets us-east-1,
+// and that a global service (IAM) stays region-less.
+func TestRegionAwarenessAWSCompat(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	sess := compat.BootAWS(t, awsserver.Drivers{
+		ECR: cloud.ECR, SQS: cloud.SQS, SNS: cloud.SNS, Lambda: cloud.Lambda,
+		DynamoDB: cloud.DynamoDB, KMS: cloud.KMS, CloudWatchLogs: cloud.CloudWatchLogs,
+		Kinesis: cloud.Kinesis, RDS: cloud.RDS, ElastiCache: cloud.ElastiCache,
+		SFN: cloud.SFN, ECS: cloud.ECS, EKS: cloud.EKS, IAM: cloud.IAM,
+	})
+
+	ctx := context.Background()
+	cfg := sess.Config()
+	endpoint := sess.Endpoint()
+
+	t.Run("ecr", func(t *testing.T) {
+		c := awsecr.NewFromConfig(cfg, func(o *awsecr.Options) {
+			o.Region = regionTokyo
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		out, err := c.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+			RepositoryName: aws.String("region-repo"),
+		})
+		if err != nil {
+			t.Fatalf("CreateRepository: %v", err)
+		}
+		assertRegion(t, "ecr", aws.ToString(out.Repository.RepositoryArn), regionTokyo)
+
+		// Read-back must reflect the stored request region, not the read's.
+		desc, err := c.DescribeRepositories(ctx, &awsecr.DescribeRepositoriesInput{
+			RepositoryNames: []string{"region-repo"},
+		})
+		if err != nil {
+			t.Fatalf("DescribeRepositories: %v", err)
+		}
+		assertRegion(t, "ecr read-back", aws.ToString(desc.Repositories[0].RepositoryArn), regionTokyo)
+	})
+
+	t.Run("sqs", func(t *testing.T) {
+		c := awssqs.NewFromConfig(cfg, func(o *awssqs.Options) {
+			o.Region = regionTokyo
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		out, err := c.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("region-queue")})
+		if err != nil {
+			t.Fatalf("CreateQueue: %v", err)
+		}
+		if url := aws.ToString(out.QueueUrl); !strings.Contains(url, regionTokyo) {
+			t.Fatalf("sqs: QueueUrl %q does not carry region %q", url, regionTokyo)
+		}
+
+		attrs, err := c.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+			QueueUrl:       out.QueueUrl,
+			AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameQueueArn},
+		})
+		if err != nil {
+			t.Fatalf("GetQueueAttributes: %v", err)
+		}
+		assertRegion(t, "sqs", attrs.Attributes["QueueArn"], regionTokyo)
+	})
+
+	t.Run("sns", func(t *testing.T) {
+		c := awssns.NewFromConfig(cfg, func(o *awssns.Options) {
+			o.Region = regionTokyo
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		out, err := c.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("region-topic")})
+		if err != nil {
+			t.Fatalf("CreateTopic: %v", err)
+		}
+		assertRegion(t, "sns", aws.ToString(out.TopicArn), regionTokyo)
+	})
+
+	t.Run("lambda", func(t *testing.T) {
+		c := awslambda.NewFromConfig(cfg, func(o *awslambda.Options) {
+			o.Region = regionTokyo
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		out, err := c.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+			FunctionName: aws.String("region-fn"),
+			Runtime:      lambdatypes.RuntimeGo1x,
+			Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+			Handler:      aws.String("main"),
+			Code:         &lambdatypes.FunctionCode{ZipFile: []byte("fake-zip")},
+		})
+		if err != nil {
+			t.Fatalf("CreateFunction: %v", err)
+		}
+		assertRegion(t, "lambda", aws.ToString(out.FunctionArn), regionTokyo)
+	})
+
+	t.Run("dynamodb", func(t *testing.T) {
+		c := awsdynamodb.NewFromConfig(cfg, func(o *awsdynamodb.Options) {
+			o.Region = regionTokyo
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		out, err := c.CreateTable(ctx, &awsdynamodb.CreateTableInput{
+			TableName:   aws.String("region-table"),
+			BillingMode: dynamodbtypes.BillingModePayPerRequest,
+			AttributeDefinitions: []dynamodbtypes.AttributeDefinition{
+				{AttributeName: aws.String("id"), AttributeType: dynamodbtypes.ScalarAttributeTypeS},
+			},
+			KeySchema: []dynamodbtypes.KeySchemaElement{
+				{AttributeName: aws.String("id"), KeyType: dynamodbtypes.KeyTypeHash},
+			},
+		})
+		if err != nil {
+			t.Fatalf("CreateTable: %v", err)
+		}
+		assertRegion(t, "dynamodb", aws.ToString(out.TableDescription.TableArn), regionTokyo)
+	})
+
+	t.Run("kms", func(t *testing.T) {
+		c := awskms.NewFromConfig(cfg, func(o *awskms.Options) {
+			o.Region = regionTokyo
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		out, err := c.CreateKey(ctx, &awskms.CreateKeyInput{})
+		if err != nil {
+			t.Fatalf("CreateKey: %v", err)
+		}
+		assertRegion(t, "kms", aws.ToString(out.KeyMetadata.Arn), regionTokyo)
+	})
+
+	t.Run("cloudwatchlogs", func(t *testing.T) {
+		c := awscwl.NewFromConfig(cfg, func(o *awscwl.Options) {
+			o.Region = regionTokyo
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		if _, err := c.CreateLogGroup(ctx, &awscwl.CreateLogGroupInput{
+			LogGroupName: aws.String("region-lg"),
+		}); err != nil {
+			t.Fatalf("CreateLogGroup: %v", err)
+		}
+		out, err := c.DescribeLogGroups(ctx, &awscwl.DescribeLogGroupsInput{
+			LogGroupNamePrefix: aws.String("region-lg"),
+		})
+		if err != nil {
+			t.Fatalf("DescribeLogGroups: %v", err)
+		}
+		assertRegion(t, "logs", aws.ToString(out.LogGroups[0].Arn), regionTokyo)
+	})
+
+	t.Run("kinesis", func(t *testing.T) {
+		c := awskinesis.NewFromConfig(cfg, func(o *awskinesis.Options) {
+			o.Region = regionTokyo
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		if _, err := c.CreateStream(ctx, &awskinesis.CreateStreamInput{
+			StreamName: aws.String("region-stream"), ShardCount: aws.Int32(1),
+		}); err != nil {
+			t.Fatalf("CreateStream: %v", err)
+		}
+		out, err := c.DescribeStreamSummary(ctx, &awskinesis.DescribeStreamSummaryInput{
+			StreamName: aws.String("region-stream"),
+		})
+		if err != nil {
+			t.Fatalf("DescribeStreamSummary: %v", err)
+		}
+		assertRegion(t, "kinesis", aws.ToString(out.StreamDescriptionSummary.StreamARN), regionTokyo)
+	})
+
+	t.Run("rds", func(t *testing.T) {
+		c := awsrds.NewFromConfig(cfg, func(o *awsrds.Options) {
+			o.Region = regionTokyo
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		out, err := c.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+			DBInstanceIdentifier: aws.String("region-db"),
+			Engine:               aws.String("mysql"),
+			DBInstanceClass:      aws.String("db.t3.micro"),
+			AllocatedStorage:     aws.Int32(20),
+			MasterUsername:       aws.String("admin"),
+			MasterUserPassword:   aws.String("password123"),
+		})
+		if err != nil {
+			t.Fatalf("CreateDBInstance: %v", err)
+		}
+		assertRegion(t, "rds", aws.ToString(out.DBInstance.DBInstanceArn), regionTokyo)
+	})
+
+	t.Run("elasticache", func(t *testing.T) {
+		c := awselasticache.NewFromConfig(cfg, func(o *awselasticache.Options) {
+			o.Region = regionTokyo
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		out, err := c.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+			CacheClusterId: aws.String("region-cache"),
+			Engine:         aws.String("redis"),
+			CacheNodeType:  aws.String("cache.t3.micro"),
+			NumCacheNodes:  aws.Int32(1),
+		})
+		if err != nil {
+			t.Fatalf("CreateCacheCluster: %v", err)
+		}
+		assertRegion(t, "elasticache", aws.ToString(out.CacheCluster.ARN), regionTokyo)
+	})
+
+	t.Run("sfn", func(t *testing.T) {
+		c := awssfn.NewFromConfig(cfg, func(o *awssfn.Options) {
+			o.Region = regionTokyo
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		out, err := c.CreateStateMachine(ctx, &awssfn.CreateStateMachineInput{
+			Name:       aws.String("region-sm"),
+			Definition: aws.String(`{"StartAt":"a","States":{"a":{"Type":"Pass","End":true}}}`),
+			RoleArn:    aws.String("arn:aws:iam::000000000000:role/test"),
+		})
+		if err != nil {
+			t.Fatalf("CreateStateMachine: %v", err)
+		}
+		assertRegion(t, "sfn", aws.ToString(out.StateMachineArn), regionTokyo)
+	})
+
+	t.Run("ecs", func(t *testing.T) {
+		c := awsecs.NewFromConfig(cfg, func(o *awsecs.Options) {
+			o.Region = regionTokyo
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		out, err := c.CreateCluster(ctx, &awsecs.CreateClusterInput{ClusterName: aws.String("region-cluster")})
+		if err != nil {
+			t.Fatalf("CreateCluster: %v", err)
+		}
+		assertRegion(t, "ecs", aws.ToString(out.Cluster.ClusterArn), regionTokyo)
+	})
+
+	t.Run("eks", func(t *testing.T) {
+		c := awseks.NewFromConfig(cfg, func(o *awseks.Options) {
+			o.Region = regionTokyo
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		out, err := c.CreateCluster(ctx, &awseks.CreateClusterInput{
+			Name:    aws.String("region-eks"),
+			RoleArn: aws.String("arn:aws:iam::000000000000:role/test"),
+			ResourcesVpcConfig: &ekstypes.VpcConfigRequest{
+				SubnetIds: []string{"subnet-1", "subnet-2"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("CreateCluster: %v", err)
+		}
+		assertRegion(t, "eks", aws.ToString(out.Cluster.Arn), regionTokyo)
+	})
+
+	// Default region unchanged: a us-east-1 client still gets us-east-1.
+	t.Run("default_region_unchanged", func(t *testing.T) {
+		c := awssns.NewFromConfig(cfg, func(o *awssns.Options) {
+			o.Region = regionDefault
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		out, err := c.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("default-topic")})
+		if err != nil {
+			t.Fatalf("CreateTopic: %v", err)
+		}
+		assertRegion(t, "sns default", aws.ToString(out.TopicArn), regionDefault)
+		if strings.Contains(aws.ToString(out.TopicArn), regionTokyo) {
+			t.Fatalf("sns default: ARN %q leaked non-default region", aws.ToString(out.TopicArn))
+		}
+	})
+
+	// Global service unchanged: IAM ARNs are region-less regardless of the
+	// client's region. Stamping a region here would be wrong.
+	t.Run("global_iam_region_less", func(t *testing.T) {
+		c := awsiam.NewFromConfig(cfg, func(o *awsiam.Options) {
+			o.Region = regionTokyo
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+		out, err := c.CreateUser(ctx, &awsiam.CreateUserInput{UserName: aws.String("region-user")})
+		if err != nil {
+			t.Fatalf("CreateUser: %v", err)
+		}
+		arn := aws.ToString(out.User.Arn)
+		if !strings.HasPrefix(arn, "arn:aws:iam::") {
+			t.Fatalf("iam: ARN %q is not a region-less IAM ARN", arn)
+		}
+		if strings.Contains(arn, regionTokyo) {
+			t.Fatalf("iam: global ARN %q was wrongly stamped with a region", arn)
+		}
+	})
+}

--- a/internal/regionctx/regionctx.go
+++ b/internal/regionctx/regionctx.go
@@ -1,0 +1,40 @@
+// Package regionctx carries the AWS region a caller actually addressed on a
+// request context, so in-memory backends stamp resources and ARNs with the
+// region the client used rather than the emulator's fixed default.
+//
+// The AWS query/REST wire protocols carry no region parameter; the only place a
+// caller states which region it believes it is talking to is the SigV4
+// credential scope (Credential=AKID/DATE/<REGION>/<SERVICE>/aws4_request). The
+// server derives that region once, in a pre-dispatch hook, and stamps it here;
+// every driver method then reads it back with RegionOr, falling back to the
+// configured default when the request carried no region (an unsigned request,
+// or the typed Go API with no HTTP request at all). That fallback keeps the
+// library path and all existing default-region behavior byte-for-byte
+// identical.
+package regionctx
+
+import "context"
+
+type regionKey struct{}
+
+// WithRegion returns a copy of ctx carrying region. An empty region is not
+// stored, so RegionOr falls back to the caller's default rather than an empty
+// string.
+func WithRegion(ctx context.Context, region string) context.Context {
+	if region == "" {
+		return ctx
+	}
+
+	return context.WithValue(ctx, regionKey{}, region)
+}
+
+// RegionOr returns the request region stamped on ctx, or fallback when none is
+// present. Backends pass their configured default (opts.Region) as fallback so
+// callers with no request region keep the existing behavior.
+func RegionOr(ctx context.Context, fallback string) string {
+	if r, ok := ctx.Value(regionKey{}).(string); ok && r != "" {
+		return r
+	}
+
+	return fallback
+}

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/services/logging/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/scope"
@@ -83,7 +84,7 @@ func New(opts *config.Options) *Mock {
 }
 
 // CreateLogGroup creates a new CloudWatch log group.
-func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
+func (m *Mock) CreateLogGroup(ctx context.Context, cfg driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "log group name is required")
 	}
@@ -95,7 +96,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 	// A log group created without a retention policy never expires: AWS leaves
 	// retentionInDays unset (nil on the SDK) rather than defaulting to 30 days.
 	// The zero value flows through to DescribeLogGroups, which omits the field.
-	arn := idgen.AWSARN("logs", m.opts.Region, m.opts.AccountID, "log-group:"+cfg.Name)
+	arn := idgen.AWSARN("logs", regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID, "log-group:"+cfg.Name)
 
 	tags := make(map[string]string, len(cfg.Tags))
 	for k, v := range cfg.Tags {

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/services/database/driver"
 	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
@@ -322,7 +323,7 @@ func itemKey(cfg driver.TableConfig, item map[string]any) string {
 	return pk
 }
 
-func (m *Mock) CreateTable(_ context.Context, cfg driver.TableConfig) error {
+func (m *Mock) CreateTable(ctx context.Context, cfg driver.TableConfig) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -330,7 +331,7 @@ func (m *Mock) CreateTable(_ context.Context, cfg driver.TableConfig) error {
 		return cerrors.Newf(cerrors.AlreadyExists, "table %s already exists", cfg.Name)
 	}
 
-	cfg.TableArn = idgen.AWSARN("dynamodb", m.opts.Region, m.opts.AccountID, "table/"+cfg.Name)
+	cfg.TableArn = idgen.AWSARN("dynamodb", regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID, "table/"+cfg.Name)
 	cfg.CreatedAtUnix = float64(m.opts.Clock.Now().Unix())
 	cfg.TableID = uuidV4()
 
@@ -361,6 +362,22 @@ func (m *Mock) newStreamIdentity(tableArn string) (label, arn string) {
 	arn = tableArn + "/stream/" + label
 
 	return label, arn
+}
+
+// arnRegion returns the region field of a DynamoDB ARN
+// (arn:aws:dynamodb:<region>:<account>:table/<name>), or fallback when the ARN
+// is malformed. A table's stored ARN is the source of truth for its region, so
+// a stream-delivery event's region is derived from it rather than the configured
+// default.
+func arnRegion(arn, fallback string) string {
+	const regionField, minFields = 3, 6
+
+	parts := strings.Split(arn, ":")
+	if len(parts) < minFields || parts[regionField] == "" {
+		return fallback
+	}
+
+	return parts[regionField]
 }
 
 // uuidV4 returns a random RFC-4122 v4 UUID, the format a real DynamoDB TableId
@@ -1354,7 +1371,7 @@ func (m *Mock) queueStreamDelivery(td *tableData, rec *driver.StreamRecord) {
 
 	m.pendingStream = append(m.pendingStream, pendingStreamEvent{
 		streamARN: td.config.StreamArn,
-		region:    m.opts.Region,
+		region:    arnRegion(td.config.TableArn, m.opts.Region),
 		viewType:  td.streamConfig.ViewType,
 		rec:       *rec,
 	})

--- a/providers/aws/ecr/authtoken.go
+++ b/providers/aws/ecr/authtoken.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"time"
+
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 )
 
 // authTokenTTL is how long a GetAuthorizationToken response stays valid. Real
@@ -15,9 +17,9 @@ const authTokenTTL = 12 * time.Hour
 // registry proxy endpoint, and an expiry — everything `docker login` and
 // image push/pull need. The emulator does not validate the token on later
 // requests; it exists so auth flows succeed.
-func (m *Mock) GetAuthorizationToken(_ context.Context) (token, proxyEndpoint string, expiresAt time.Time, err error) {
+func (m *Mock) GetAuthorizationToken(ctx context.Context) (token, proxyEndpoint string, expiresAt time.Time, err error) {
 	token = base64.StdEncoding.EncodeToString([]byte("AWS:cloudemu"))
-	proxyEndpoint = fmt.Sprintf("https://%s.dkr.ecr.%s.amazonaws.com", m.opts.AccountID, m.opts.Region)
+	proxyEndpoint = fmt.Sprintf("https://%s.dkr.ecr.%s.amazonaws.com", m.opts.AccountID, regionctx.RegionOr(ctx, m.opts.Region))
 	expiresAt = m.opts.Clock.Now().Add(authTokenTTL).UTC()
 
 	return token, proxyEndpoint, expiresAt, nil

--- a/providers/aws/ecr/ecr.go
+++ b/providers/aws/ecr/ecr.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
@@ -75,7 +76,7 @@ func New(opts *config.Options) *Mock {
 }
 
 // CreateRepository creates a new ECR repository.
-func (m *Mock) CreateRepository(_ context.Context, cfg driver.RepositoryConfig) (*driver.Repository, error) {
+func (m *Mock) CreateRepository(ctx context.Context, cfg driver.RepositoryConfig) (*driver.Repository, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "repository name is required")
 	}
@@ -93,8 +94,9 @@ func (m *Mock) CreateRepository(_ context.Context, cfg driver.RepositoryConfig) 
 	}
 
 	tags := copyTags(cfg.Tags)
-	uri := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", m.opts.AccountID, m.opts.Region, cfg.Name)
-	arn := fmt.Sprintf("arn:aws:ecr:%s:%s:repository/%s", m.opts.Region, m.opts.AccountID, cfg.Name)
+	region := regionctx.RegionOr(ctx, m.opts.Region)
+	uri := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", m.opts.AccountID, region, cfg.Name)
+	arn := fmt.Sprintf("arn:aws:ecr:%s:%s:repository/%s", region, m.opts.AccountID, cfg.Name)
 
 	info := driver.Repository{
 		Name:               cfg.Name,

--- a/providers/aws/ecs/clusters.go
+++ b/providers/aws/ecs/clusters.go
@@ -4,18 +4,19 @@ import (
 	"context"
 
 	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/services/ecs/driver"
 )
 
 // CreateCluster creates a cluster, defaulting the name to "default".
-func (m *Mock) CreateCluster(_ context.Context, in driver.CreateClusterInput) (*driver.Cluster, error) {
+func (m *Mock) CreateCluster(ctx context.Context, in driver.CreateClusterInput) (*driver.Cluster, error) {
 	name := in.Name
 	if name == "" {
 		name = defaultCluster
 	}
 
 	c := &driver.Cluster{
-		ARN:      m.arn("cluster/" + name),
+		ARN:      m.arnIn(regionctx.RegionOr(ctx, m.opts.Region), "cluster/"+name),
 		Name:     name,
 		Status:   statusActive,
 		Tags:     copyTags(in.Tags),
@@ -57,7 +58,7 @@ func (m *Mock) ListClusters(_ context.Context) ([]driver.Cluster, error) {
 
 // DescribeClusters resolves each id to a cluster; unresolved ids become
 // failures. An empty id list returns every cluster.
-func (m *Mock) DescribeClusters(_ context.Context, ids []string) ([]driver.Cluster, []driver.Failure, error) {
+func (m *Mock) DescribeClusters(ctx context.Context, ids []string) ([]driver.Cluster, []driver.Failure, error) {
 	if len(ids) == 0 {
 		all := m.clusters.SortedValues()
 
@@ -79,7 +80,10 @@ func (m *Mock) DescribeClusters(_ context.Context, ids []string) ([]driver.Clust
 			continue
 		}
 
-		failures = append(failures, driver.Failure{ARN: m.arn("cluster/" + name), Reason: "MISSING"})
+		failures = append(failures, driver.Failure{
+			ARN:    m.arnIn(regionctx.RegionOr(ctx, m.opts.Region), "cluster/"+name),
+			Reason: "MISSING",
+		})
 	}
 
 	return found, failures, nil

--- a/providers/aws/ecs/ecs.go
+++ b/providers/aws/ecs/ecs.go
@@ -112,8 +112,33 @@ func (m *Mock) nextEphemeralPort() int {
 	return ephemeralPortBase + int(n%ephemeralPortSpan)
 }
 
+// arn builds an ECS ARN in the emulator's configured default region. It backs
+// the ctx-less internal paths (seed helpers, container-instance registration);
+// request-scoped create paths use arnIn with the caller's region instead.
 func (m *Mock) arn(resource string) string {
-	return idgen.AWSARN("ecs", m.opts.Region, m.opts.AccountID, resource)
+	return m.arnIn(m.opts.Region, resource)
+}
+
+// arnIn builds an ECS ARN stamped with region. Create paths pass the caller's
+// request region (regionctx.RegionOr(ctx, m.opts.Region)) so a resource's ARN
+// reflects the region the client used; a child ARN derives region from its
+// parent's stored ARN so the two always match.
+func (m *Mock) arnIn(region, resource string) string {
+	return idgen.AWSARN("ecs", region, m.opts.AccountID, resource)
+}
+
+// arnRegion returns the region field of an ECS ARN
+// (arn:aws:ecs:<region>:<account>:<resource>), or fallback when the ARN is
+// malformed.
+func arnRegion(arn, fallback string) string {
+	const regionField, minFields = 3, 6
+
+	parts := strings.Split(arn, ":")
+	if len(parts) < minFields || parts[regionField] == "" {
+		return fallback
+	}
+
+	return parts[regionField]
 }
 
 // rootPrincipalARN is the account-root IAM principal ECS records as a service's

--- a/providers/aws/ecs/exec.go
+++ b/providers/aws/ecs/exec.go
@@ -32,9 +32,10 @@ func (m *Mock) ExecuteCommand(ctx context.Context, in driver.ExecuteCommandInput
 		}
 	}
 
+	region := arnRegion(t.ClusterARN, m.opts.Region)
 	sessionID := "ecs-execute-command-" + m.hexID()
-	streamURL := "wss://ssmmessages." + m.opts.Region + ".amazonaws.com/v1/data-channel/" + sessionID + "?role=publish_subscribe"
-	containerARN := m.arn("container/" + clusterNameFromARN(t.ClusterARN) + "/" + trailingID(t.ARN) + "/" + idgen.GenerateID(""))
+	streamURL := "wss://ssmmessages." + region + ".amazonaws.com/v1/data-channel/" + sessionID + "?role=publish_subscribe"
+	containerARN := m.arnIn(region, "container/"+clusterNameFromARN(t.ClusterARN)+"/"+trailingID(t.ARN)+"/"+idgen.GenerateID(""))
 
 	return &driver.ExecuteCommandResult{
 		ClusterARN:    t.ClusterARN,

--- a/providers/aws/ecs/services.go
+++ b/providers/aws/ecs/services.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/services/ecs/driver"
 )
 
@@ -96,7 +97,9 @@ func (m *Mock) CreateService(ctx context.Context, in driver.CreateServiceInput) 
 			"desiredCount must not be specified for a DAEMON service")
 	}
 
-	svc := serviceFromInput(&in, m.arn, cluster, m.now(), m.rootPrincipalARN())
+	region := regionctx.RegionOr(ctx, m.opts.Region)
+	arnIn := func(resource string) string { return m.arnIn(region, resource) }
+	svc := serviceFromInput(&in, arnIn, cluster, m.now(), m.rootPrincipalARN())
 
 	if err := m.reserveServiceName(serviceKey(cluster, in.ServiceName), svc); err != nil {
 		return nil, err
@@ -493,7 +496,7 @@ func (m *Mock) ListServices(_ context.Context, cluster string) ([]driver.Service
 }
 
 // DescribeServices resolves services by name or ARN; unresolved ids become failures.
-func (m *Mock) DescribeServices(_ context.Context, cluster string, ids []string) ([]driver.Service, []driver.Failure, error) {
+func (m *Mock) DescribeServices(ctx context.Context, cluster string, ids []string) ([]driver.Service, []driver.Failure, error) {
 	want := resolveClusterName(cluster)
 	if !m.clusterExists(want) {
 		return nil, nil, apiErrf(errors.NotFound, excClusterNotFound, "cluster %q not found", want)
@@ -508,7 +511,10 @@ func (m *Mock) DescribeServices(_ context.Context, cluster string, ids []string)
 			continue
 		}
 
-		failures = append(failures, driver.Failure{ARN: m.arn("service/" + want + "/" + serviceNameOf(id)), Reason: "MISSING"})
+		failures = append(failures, driver.Failure{
+			ARN:    m.arnIn(regionctx.RegionOr(ctx, m.opts.Region), "service/"+want+"/"+serviceNameOf(id)),
+			Reason: "MISSING",
+		})
 	}
 
 	return found, failures, nil

--- a/providers/aws/ecs/taskdefs.go
+++ b/providers/aws/ecs/taskdefs.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/services/ecs/driver"
 )
 
@@ -18,7 +19,7 @@ const sortDesc = "DESC"
 // the revision number (starting at 1).
 //
 //nolint:gocritic // in is passed by value to satisfy the driver.ECS interface; the copy is cheap for a mock.
-func (m *Mock) RegisterTaskDefinition(_ context.Context, in driver.RegisterTaskDefinitionInput) (*driver.TaskDefinition, error) {
+func (m *Mock) RegisterTaskDefinition(ctx context.Context, in driver.RegisterTaskDefinitionInput) (*driver.TaskDefinition, error) {
 	if in.Family == "" {
 		return nil, errors.New(errors.InvalidArgument, "family is required")
 	}
@@ -31,8 +32,9 @@ func (m *Mock) RegisterTaskDefinition(_ context.Context, in driver.RegisterTaskD
 	defer m.regMu.Unlock()
 
 	revision := m.nextRevision(in.Family)
+	region := regionctx.RegionOr(ctx, m.opts.Region)
 	td := &driver.TaskDefinition{
-		ARN:                     m.arn(fmt.Sprintf("task-definition/%s:%d", in.Family, revision)),
+		ARN:                     m.arnIn(region, fmt.Sprintf("task-definition/%s:%d", in.Family, revision)),
 		Family:                  in.Family,
 		Revision:                revision,
 		Status:                  statusActive,

--- a/providers/aws/ecs/tasks.go
+++ b/providers/aws/ecs/tasks.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/services/container/containerengine"
 	"github.com/stackshy/cloudemu/v2/services/ecs/driver"
 )
@@ -26,7 +27,7 @@ const maxRunTaskCount = 10
 //nolint:gocritic // in is passed by value to satisfy the driver.ECS interface; the copy is cheap for a mock.
 func (m *Mock) RunTask(ctx context.Context, in driver.RunTaskInput) ([]driver.Task, []driver.Failure, error) {
 	cluster := resolveClusterName(in.Cluster)
-	clusterARN := m.arn("cluster/" + cluster)
+	clusterARN := m.arnIn(regionctx.RegionOr(ctx, m.opts.Region), "cluster/"+cluster)
 
 	if !m.clusterActive(cluster) {
 		return nil, nil, apiErrf(errors.NotFound, excClusterNotFound, "cluster %q not found", cluster)
@@ -198,7 +199,7 @@ type taskSpec struct {
 // stores the task PENDING so the service reports RunningCount<DesiredCount.
 func (m *Mock) launchTask(ctx context.Context, spec *taskSpec, pendingOnShortfall bool) (*driver.Task, *driver.Failure) {
 	task := &driver.Task{
-		ARN:               m.arn("task/" + spec.cluster + "/" + m.hexID()),
+		ARN:               m.arnIn(arnRegion(spec.clusterARN, m.opts.Region), "task/"+spec.cluster+"/"+m.hexID()),
 		ClusterARN:        spec.clusterARN,
 		TaskDefinitionARN: spec.td.ARN,
 		LaunchType:        spec.launchType,

--- a/providers/aws/ecs/tasks.go
+++ b/providers/aws/ecs/tasks.go
@@ -27,7 +27,18 @@ const maxRunTaskCount = 10
 //nolint:gocritic // in is passed by value to satisfy the driver.ECS interface; the copy is cheap for a mock.
 func (m *Mock) RunTask(ctx context.Context, in driver.RunTaskInput) ([]driver.Task, []driver.Failure, error) {
 	cluster := resolveClusterName(in.Cluster)
-	clusterARN := m.arnIn(regionctx.RegionOr(ctx, m.opts.Region), "cluster/"+cluster)
+
+	// A task is a child of its cluster, so its cluster/task ARNs must carry the
+	// cluster's region — the region the cluster was created in — not the region
+	// this RunTask request happens to be signed for. Derive it from the stored
+	// cluster's ARN; only the implicit (never-created) default cluster has no
+	// stored ARN, so it falls back to the request region.
+	region := regionctx.RegionOr(ctx, m.opts.Region)
+	if c, ok := m.clusters.Get(cluster); ok {
+		region = arnRegion(c.ARN, region)
+	}
+
+	clusterARN := m.arnIn(region, "cluster/"+cluster)
 
 	if !m.clusterActive(cluster) {
 		return nil, nil, apiErrf(errors.NotFound, excClusterNotFound, "cluster %q not found", cluster)

--- a/providers/aws/eks/eks.go
+++ b/providers/aws/eks/eks.go
@@ -24,6 +24,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	eksdriver "github.com/stackshy/cloudemu/v2/providers/aws/eks/driver"
 	"github.com/stackshy/cloudemu/v2/services/kubernetes"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
@@ -184,19 +185,35 @@ func (m *Mock) recordUpdate(u *eksdriver.ClusterUpdate) *eksdriver.ClusterUpdate
 	return &out
 }
 
-func (m *Mock) clusterARN(name string) string {
-	return idgen.AWSARN("eks", m.opts.Region, m.opts.AccountID, "cluster/"+name)
+func (m *Mock) clusterARN(region, name string) string {
+	return idgen.AWSARN("eks", region, m.opts.AccountID, "cluster/"+name)
+}
+
+// arnRegion returns the region field of an EKS ARN
+// (arn:aws:eks:<region>:<account>:<resource>), or fallback when the ARN is
+// malformed. A cluster's stored ARN is the source of truth for the region of
+// its child resources (nodegroups, Fargate profiles, addons), so a child always
+// shares its cluster's region.
+func arnRegion(arn, fallback string) string {
+	const regionField, minFields = 3, 6
+
+	parts := strings.Split(arn, ":")
+	if len(parts) < minFields || parts[regionField] == "" {
+		return fallback
+	}
+
+	return parts[regionField]
 }
 
 // oidcIssuer derives a stable OpenID Connect issuer URL for a cluster, matching
 // the real EKS shape https://oidc.eks.<region>.amazonaws.com/id/<32-hex>. The
 // id is a deterministic hash of account + cluster name so it does not change
 // between DescribeCluster calls.
-func (m *Mock) oidcIssuer(name string) string {
+func (m *Mock) oidcIssuer(region, name string) string {
 	sum := sha256.Sum256([]byte(m.opts.AccountID + "/" + name))
 	id := strings.ToUpper(hex.EncodeToString(sum[:16]))
 
-	return fmt.Sprintf("https://oidc.eks.%s.amazonaws.com/id/%s", m.opts.Region, id)
+	return fmt.Sprintf("https://oidc.eks.%s.amazonaws.com/id/%s", region, id)
 }
 
 // clusterSecurityGroupID synthesizes the deterministic cluster security group
@@ -209,18 +226,18 @@ func (m *Mock) clusterSecurityGroupID(name string) string {
 	return "sg-" + hex.EncodeToString(sum[:8])
 }
 
-func (m *Mock) nodegroupARN(clusterName, nodegroupName string) string {
-	return idgen.AWSARN("eks", m.opts.Region, m.opts.AccountID,
+func (m *Mock) nodegroupARN(region, clusterName, nodegroupName string) string {
+	return idgen.AWSARN("eks", region, m.opts.AccountID,
 		"nodegroup/"+clusterName+"/"+nodegroupName)
 }
 
-func (m *Mock) fargateARN(clusterName, profileName string) string {
-	return idgen.AWSARN("eks", m.opts.Region, m.opts.AccountID,
+func (m *Mock) fargateARN(region, clusterName, profileName string) string {
+	return idgen.AWSARN("eks", region, m.opts.AccountID,
 		"fargateprofile/"+clusterName+"/"+profileName)
 }
 
-func (m *Mock) addonARN(clusterName, addonName string) string {
-	return idgen.AWSARN("eks", m.opts.Region, m.opts.AccountID,
+func (m *Mock) addonARN(region, clusterName, addonName string) string {
+	return idgen.AWSARN("eks", region, m.opts.AccountID,
 		"addon/"+clusterName+"/"+addonName)
 }
 
@@ -472,16 +489,17 @@ func (m *Mock) CreateCluster(ctx context.Context, cfg eksdriver.ClusterConfig) (
 		version = defaultKubernetesVersion
 	}
 
+	region := regionctx.RegionOr(ctx, m.opts.Region)
 	cluster := eksdriver.Cluster{
 		Name:                 cfg.Name,
-		ARN:                  m.clusterARN(cfg.Name),
+		ARN:                  m.clusterARN(region, cfg.Name),
 		Version:              version,
 		PlatformVersion:      defaultPlatformVersion,
 		RoleArn:              cfg.RoleArn,
 		Endpoint:             wavePlaceholderEndpoint,
 		CertificateAuthority: stubCertificate(),
 		Status:               eksdriver.ClusterStatusActive,
-		OIDCIssuer:           m.oidcIssuer(cfg.Name),
+		OIDCIssuer:           m.oidcIssuer(region, cfg.Name),
 		VPCConfig: eksdriver.VPCConfig{
 			SubnetIDs:              copyStrings(cfg.VPCConfig.SubnetIDs),
 			SecurityGroupIDs:       copyStrings(cfg.VPCConfig.SecurityGroupIDs),
@@ -758,7 +776,8 @@ func (m *Mock) CreateNodegroup(_ context.Context, cfg eksdriver.NodegroupConfig)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.clusters.Get(cfg.ClusterName); !ok {
+	parent, ok := m.clusters.Get(cfg.ClusterName)
+	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cfg.ClusterName)
 	}
 
@@ -792,7 +811,7 @@ func (m *Mock) CreateNodegroup(_ context.Context, cfg eksdriver.NodegroupConfig)
 	ng := eksdriver.Nodegroup{
 		ClusterName:    cfg.ClusterName,
 		NodegroupName:  cfg.NodegroupName,
-		ARN:            m.nodegroupARN(cfg.ClusterName, cfg.NodegroupName),
+		ARN:            m.nodegroupARN(arnRegion(parent.ARN, m.opts.Region), cfg.ClusterName, cfg.NodegroupName),
 		NodeRole:       cfg.NodeRole,
 		Subnets:        copyStrings(cfg.Subnets),
 		InstanceTypes:  instanceTypes,
@@ -974,7 +993,8 @@ func (m *Mock) CreateFargateProfile(
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.clusters.Get(cfg.ClusterName); !ok {
+	parent, ok := m.clusters.Get(cfg.ClusterName)
+	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cfg.ClusterName)
 	}
 
@@ -987,7 +1007,7 @@ func (m *Mock) CreateFargateProfile(
 	fp := eksdriver.FargateProfile{
 		ClusterName:        cfg.ClusterName,
 		FargateProfileName: cfg.FargateProfileName,
-		ARN:                m.fargateARN(cfg.ClusterName, cfg.FargateProfileName),
+		ARN:                m.fargateARN(arnRegion(parent.ARN, m.opts.Region), cfg.ClusterName, cfg.FargateProfileName),
 		PodExecutionRole:   cfg.PodExecutionRole,
 		Subnets:            copyStrings(cfg.Subnets),
 		Selectors:          append([]eksdriver.FargateProfileSelector(nil), cfg.Selectors...),
@@ -1081,7 +1101,8 @@ func (m *Mock) CreateAddon(_ context.Context, cfg eksdriver.AddonConfig) (*eksdr
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.clusters.Get(cfg.ClusterName); !ok {
+	parent, ok := m.clusters.Get(cfg.ClusterName)
+	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cfg.ClusterName)
 	}
 
@@ -1097,7 +1118,7 @@ func (m *Mock) CreateAddon(_ context.Context, cfg eksdriver.AddonConfig) (*eksdr
 		ClusterName:           cfg.ClusterName,
 		AddonName:             cfg.AddonName,
 		AddonVersion:          cfg.AddonVersion,
-		ARN:                   m.addonARN(cfg.ClusterName, cfg.AddonName),
+		ARN:                   m.addonARN(arnRegion(parent.ARN, m.opts.Region), cfg.ClusterName, cfg.AddonName),
 		ServiceAccountRoleArn: cfg.ServiceAccountRoleArn,
 		ConfigurationValues:   cfg.ConfigurationValues,
 		Status:                eksdriver.AddonStatusActive,

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -7,12 +7,14 @@ import (
 	"maps"
 	"path"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	cacheengine "github.com/stackshy/cloudemu/v2/services/cache/cacheengine"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
@@ -129,9 +131,24 @@ func (m *Mock) requireSubnetGroup(name string) error {
 	return nil
 }
 
-// cacheARN builds an ElastiCache cluster ARN.
-func (m *Mock) cacheARN(name string) string {
-	return "arn:aws:elasticache:" + m.opts.Region + ":" + m.opts.AccountID + ":cluster:" + name
+// cacheARN builds an ElastiCache cluster ARN in the given region.
+func (m *Mock) cacheARN(region, name string) string {
+	return "arn:aws:elasticache:" + region + ":" + m.opts.AccountID + ":cluster:" + name
+}
+
+// arnRegion returns the region field of an ElastiCache ARN
+// (arn:aws:elasticache:<region>:<account>:<type>:<name>), or fallback when the
+// ARN is malformed. A replication group's stored ARN is the source of truth for
+// the region of a cache cluster retained from it.
+func arnRegion(arn, fallback string) string {
+	const regionField, minFields = 3, 6
+
+	parts := strings.Split(arn, ":")
+	if len(parts) < minFields || parts[regionField] == "" {
+		return fallback
+	}
+
+	return parts[regionField]
 }
 
 // defaultEngineVersion returns the ElastiCache default engine version for an
@@ -237,7 +254,8 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 		return nil, err
 	}
 
-	endpoint := clusterEndpoint(cfg.Name, m.opts.Region, engine, resolvePort(engine, cfg.Port))
+	region := regionctx.RegionOr(ctx, m.opts.Region)
+	endpoint := clusterEndpoint(cfg.Name, region, engine, resolvePort(engine, cfg.Port))
 
 	tags := make(map[string]string, len(cfg.Tags))
 	for k, v := range cfg.Tags {
@@ -252,7 +270,7 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 		EngineVersion:      engineVersion,
 		Status:             statusAvailable,
 		Endpoint:           endpoint,
-		ARN:                m.cacheARN(cfg.Name),
+		ARN:                m.cacheARN(region, cfg.Name),
 		CreatedAt:          m.opts.Clock.Now().UTC().Format(time.RFC3339),
 		Tags:               tags,
 		NumCacheNodes:      numNodes,

--- a/providers/aws/elasticache/replication_group.go
+++ b/providers/aws/elasticache/replication_group.go
@@ -9,6 +9,7 @@ import (
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	cacheengine "github.com/stackshy/cloudemu/v2/services/cache/cacheengine"
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
 )
@@ -50,6 +51,7 @@ func (m *Mock) CreateReplicationGroup(
 		engineVersion = defaultEngineVersion(engine)
 	}
 
+	region := regionctx.RegionOr(ctx, m.opts.Region)
 	rg := cachedriver.ReplicationGroup{
 		ID:            cfg.ID,
 		Description:   cfg.Description,
@@ -61,16 +63,16 @@ func (m *Mock) CreateReplicationGroup(
 		// Callers read the primary endpoint to build a connection string; a
 		// group without one is indistinguishable from a broken provision.
 		PrimaryAddress: fmt.Sprintf("%s.%s.cache.amazonaws.com",
-			cfg.ID, m.opts.Region),
+			cfg.ID, region),
 		PrimaryPort: defaultRedisPort,
 		// The reader endpoint lets clients scale reads across the replicas.
 		ReaderAddress: fmt.Sprintf("%s-ro.%s.cache.amazonaws.com",
-			cfg.ID, m.opts.Region),
+			cfg.ID, region),
 		ReaderPort:        defaultRedisPort,
 		MemberClusters:    memberClusters(cfg.ID, nodes),
 		AutomaticFailover: failoverStatus(cfg.AutomaticFailoverEnabled),
 		SubnetGroupName:   cfg.SubnetGroupName,
-		ARN: "arn:aws:elasticache:" + m.opts.Region + ":" + m.opts.AccountID +
+		ARN: "arn:aws:elasticache:" + region + ":" + m.opts.AccountID +
 			":replicationgroup:" + cfg.ID,
 	}
 
@@ -263,7 +265,7 @@ func (m *Mock) retainPrimaryCluster(rg *cachedriver.ReplicationGroup) {
 		EngineVersion:   rg.EngineVersion,
 		Status:          statusAvailable,
 		Endpoint:        net.JoinHostPort(rg.PrimaryAddress, strconv.Itoa(rg.PrimaryPort)),
-		ARN:             m.cacheARN(rg.ID),
+		ARN:             m.cacheARN(arnRegion(rg.ARN, m.opts.Region), rg.ID),
 		CreatedAt:       m.opts.Clock.Now().UTC().Format(time.RFC3339),
 		NumCacheNodes:   1,
 		SubnetGroupName: rg.SubnetGroupName,

--- a/providers/aws/elasticache/snapshot.go
+++ b/providers/aws/elasticache/snapshot.go
@@ -30,6 +30,10 @@ func (m *Mock) CreateSnapshot(ctx context.Context, cfg cachedriver.SnapshotConfi
 			"SnapshotAlreadyExistsFault: snapshot %q already exists", name)
 	}
 
+	// A snapshot is a child of the cluster or replication group it backs up, so
+	// it inherits that source's region. The request region is only a fallback for
+	// the (AWS-invalid) case where no source is given.
+	region := regionctx.RegionOr(ctx, m.opts.Region)
 	snap := cachedriver.Snapshot{
 		Name:          name,
 		Status:        statusAvailable,
@@ -37,10 +41,10 @@ func (m *Mock) CreateSnapshot(ctx context.Context, cfg cachedriver.SnapshotConfi
 		Port:          defaultRedisPort,
 		NumCacheNodes: 1,
 		CreatedAt:     m.opts.Clock.Now().UTC(),
-		ARN:           m.snapshotARN(regionctx.RegionOr(ctx, m.opts.Region), name),
+		ARN:           m.snapshotARN(region, name),
 	}
 
-	if err := m.fillSnapshotSource(cfg, &snap); err != nil {
+	if err := m.fillSnapshotSource(cfg, &snap, region); err != nil {
 		return nil, err
 	}
 
@@ -50,8 +54,11 @@ func (m *Mock) CreateSnapshot(ctx context.Context, cfg cachedriver.SnapshotConfi
 }
 
 // fillSnapshotSource resolves the snapshot's source cluster or replication group
-// and copies its identity onto snap.
-func (m *Mock) fillSnapshotSource(cfg cachedriver.SnapshotConfig, snap *cachedriver.Snapshot) error {
+// and copies its identity onto snap, including stamping the snapshot's ARN with
+// the source's region (from its stored ARN) so the child inherits the parent's
+// region rather than the request's. fallbackRegion is used only if the source's
+// stored ARN is malformed.
+func (m *Mock) fillSnapshotSource(cfg cachedriver.SnapshotConfig, snap *cachedriver.Snapshot, fallbackRegion string) error {
 	switch {
 	case cfg.CacheClusterID != "":
 		cd, ok := m.caches.Get(cfg.CacheClusterID)
@@ -69,6 +76,7 @@ func (m *Mock) fillSnapshotSource(cfg cachedriver.SnapshotConfig, snap *cachedri
 		snap.EngineVersion = cd.info.EngineVersion
 		snap.NodeType = cd.info.NodeType
 		snap.ParameterGroupName = paramGroupName(cd.info.Engine)
+		snap.ARN = m.snapshotARN(arnRegion(cd.info.ARN, fallbackRegion), snap.Name)
 
 		if cd.info.NumCacheNodes > 0 {
 			snap.NumCacheNodes = cd.info.NumCacheNodes
@@ -85,6 +93,7 @@ func (m *Mock) fillSnapshotSource(cfg cachedriver.SnapshotConfig, snap *cachedri
 		snap.EngineVersion = rg.EngineVersion
 		snap.NodeType = rg.NodeType
 		snap.ParameterGroupName = paramGroupName(rg.Engine)
+		snap.ARN = m.snapshotARN(arnRegion(rg.ARN, fallbackRegion), snap.Name)
 
 		if rg.PrimaryPort != 0 {
 			snap.Port = rg.PrimaryPort

--- a/providers/aws/elasticache/snapshot.go
+++ b/providers/aws/elasticache/snapshot.go
@@ -5,12 +5,13 @@ import (
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
 )
 
-// snapshotARN builds an ElastiCache snapshot ARN.
-func (m *Mock) snapshotARN(name string) string {
-	return "arn:aws:elasticache:" + m.opts.Region + ":" + m.opts.AccountID + ":snapshot:" + name
+// snapshotARN builds an ElastiCache snapshot ARN in the given region.
+func (m *Mock) snapshotARN(region, name string) string {
+	return "arn:aws:elasticache:" + region + ":" + m.opts.AccountID + ":snapshot:" + name
 }
 
 // CreateSnapshot takes a point-in-time backup of a cache cluster or replication
@@ -18,7 +19,7 @@ func (m *Mock) snapshotARN(name string) string {
 // with SnapshotAlreadyExistsFault; the identity of the source (engine, node
 // type, version, port, node count) is copied into the snapshot so a restore can
 // recreate a like-for-like cluster.
-func (m *Mock) CreateSnapshot(_ context.Context, cfg cachedriver.SnapshotConfig) (*cachedriver.Snapshot, error) {
+func (m *Mock) CreateSnapshot(ctx context.Context, cfg cachedriver.SnapshotConfig) (*cachedriver.Snapshot, error) {
 	name := strings.ToLower(cfg.SnapshotName)
 	if name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "SnapshotName is required")
@@ -36,7 +37,7 @@ func (m *Mock) CreateSnapshot(_ context.Context, cfg cachedriver.SnapshotConfig)
 		Port:          defaultRedisPort,
 		NumCacheNodes: 1,
 		CreatedAt:     m.opts.Clock.Now().UTC(),
-		ARN:           m.snapshotARN(name),
+		ARN:           m.snapshotARN(regionctx.RegionOr(ctx, m.opts.Region), name),
 	}
 
 	if err := m.fillSnapshotSource(cfg, &snap); err != nil {

--- a/providers/aws/elasticache/subnet_group.go
+++ b/providers/aws/elasticache/subnet_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
@@ -44,7 +45,7 @@ func (m *Mock) CreateCacheSubnetGroup(
 		SubnetIDs:   append([]string(nil), cfg.SubnetIDs...),
 		VPCID:       m.resolveVPCID(ctx, cfg.SubnetIDs),
 		Status:      "Complete",
-		ARN: "arn:aws:elasticache:" + m.opts.Region + ":" + m.opts.AccountID +
+		ARN: "arn:aws:elasticache:" + regionctx.RegionOr(ctx, m.opts.Region) + ":" + m.opts.AccountID +
 			":subnetgroup:" + cfg.Name,
 	}
 	m.subnetGroups.Set(cfg.Name, sg)

--- a/providers/aws/kinesis/consumers.go
+++ b/providers/aws/kinesis/consumers.go
@@ -8,7 +8,7 @@ import (
 )
 
 // RegisterStreamConsumer registers an enhanced fan-out consumer on a stream.
-func (m *Mock) RegisterStreamConsumer(_ context.Context, streamARN, consumerName string) (*driver.Consumer, error) {
+func (m *Mock) RegisterStreamConsumer(ctx context.Context, streamARN, consumerName string) (*driver.Consumer, error) {
 	if consumerName == "" {
 		return nil, invalidArg("ConsumerName is required")
 	}
@@ -27,7 +27,7 @@ func (m *Mock) RegisterStreamConsumer(_ context.Context, streamARN, consumerName
 
 	c := &driver.Consumer{
 		ConsumerName:              consumerName,
-		ConsumerARN:               m.consumerARN(sd.desc.StreamName, consumerName),
+		ConsumerARN:               m.consumerARN(ctx, sd.desc.StreamName, consumerName),
 		ConsumerStatus:            driver.ConsumerActive,
 		ConsumerCreationTimestamp: m.now(),
 		StreamARN:                 sd.desc.StreamARN,

--- a/providers/aws/kinesis/kinesis.go
+++ b/providers/aws/kinesis/kinesis.go
@@ -5,6 +5,7 @@
 package kinesis
 
 import (
+	"context"
 	"crypto/md5" //nolint:gosec // MD5 is the Kinesis partition-key hash, not used for security
 	"fmt"
 	"math/big"
@@ -15,6 +16,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/services/kinesis/driver"
 )
 
@@ -87,12 +89,12 @@ func New(opts *config.Options) *Mock {
 	}
 }
 
-func (m *Mock) streamARN(name string) string {
-	return idgen.AWSARN("kinesis", m.opts.Region, m.opts.AccountID, "stream/"+name)
+func (m *Mock) streamARN(ctx context.Context, name string) string {
+	return idgen.AWSARN("kinesis", regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID, "stream/"+name)
 }
 
-func (m *Mock) consumerARN(streamName, consumerName string) string {
-	return idgen.AWSARN("kinesis", m.opts.Region, m.opts.AccountID,
+func (m *Mock) consumerARN(ctx context.Context, streamName, consumerName string) string {
+	return idgen.AWSARN("kinesis", regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID,
 		"stream/"+streamName+"/consumer/"+consumerName)
 }
 

--- a/providers/aws/kinesis/streams.go
+++ b/providers/aws/kinesis/streams.go
@@ -43,7 +43,7 @@ func (*Mock) buildShards(count int32, startIndex int, startSeq string, createdAt
 
 // CreateStream creates a new stream with the requested shard count (or on-demand
 // default) and moves it straight to ACTIVE.
-func (m *Mock) CreateStream(_ context.Context, in driver.CreateStreamInput) error {
+func (m *Mock) CreateStream(ctx context.Context, in driver.CreateStreamInput) error {
 	if in.StreamName == "" {
 		return invalidArg("StreamName is required")
 	}
@@ -69,7 +69,7 @@ func (m *Mock) CreateStream(_ context.Context, in driver.CreateStreamInput) erro
 		return invalidArg("ShardCount must be at least 1 for provisioned streams")
 	}
 
-	arn := m.streamARN(in.StreamName)
+	arn := m.streamARN(ctx, in.StreamName)
 	now := m.now()
 
 	sd := &streamData{

--- a/providers/aws/kms/aliases.go
+++ b/providers/aws/kms/aliases.go
@@ -27,7 +27,7 @@ func validateAliasName(name string) error {
 }
 
 // CreateAlias points a new alias at a key.
-func (m *Mock) CreateAlias(_ context.Context, aliasName, targetKeyID string) error {
+func (m *Mock) CreateAlias(ctx context.Context, aliasName, targetKeyID string) error {
 	if err := validateAliasName(aliasName); err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func (m *Mock) CreateAlias(_ context.Context, aliasName, targetKeyID string) err
 	now := m.now()
 	m.aliases.Set(aliasName, &aliasData{
 		name:        aliasName,
-		arn:         m.aliasARN(aliasName),
+		arn:         m.aliasARN(ctx, aliasName),
 		targetKeyID: id,
 		created:     now,
 		updated:     now,

--- a/providers/aws/kms/keyimport.go
+++ b/providers/aws/kms/keyimport.go
@@ -190,7 +190,7 @@ func (m *Mock) ReplicateKey(_ context.Context, in driver.ReplicateKeyInput) (*dr
 
 	kd.meta.ReplicaRegions = appendUnique(kd.meta.ReplicaRegions, in.ReplicaRegion)
 	if kd.meta.PrimaryRegion == "" {
-		kd.meta.PrimaryRegion = m.opts.Region
+		kd.meta.PrimaryRegion = arnRegion(kd.meta.ARN, m.opts.Region)
 	}
 
 	desc := in.Description

--- a/providers/aws/kms/kms.go
+++ b/providers/aws/kms/kms.go
@@ -2,6 +2,7 @@
 package kms
 
 import (
+	"context"
 	"crypto"
 	"crypto/rsa"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/services/kms/driver"
 )
 
@@ -101,12 +103,26 @@ func newKeyID() string {
 	return fmt.Sprintf("%s-0000-4000-8000-%012s", n, n)
 }
 
-func (m *Mock) keyARN(keyID string) string {
-	return idgen.AWSARN("kms", m.opts.Region, m.opts.AccountID, "key/"+keyID)
+func (m *Mock) keyARN(ctx context.Context, keyID string) string {
+	return idgen.AWSARN("kms", regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID, "key/"+keyID)
 }
 
-func (m *Mock) aliasARN(name string) string {
-	return idgen.AWSARN("kms", m.opts.Region, m.opts.AccountID, name)
+func (m *Mock) aliasARN(ctx context.Context, name string) string {
+	return idgen.AWSARN("kms", regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID, name)
+}
+
+// arnRegion returns the region field of a KMS ARN
+// (arn:aws:kms:<region>:<account>:key/<id>), or fallback when the ARN is
+// malformed. A key's stored ARN is the source of truth for its region.
+func arnRegion(arn, fallback string) string {
+	const regionField, minFields = 3, 6
+
+	parts := strings.Split(arn, ":")
+	if len(parts) < minFields || parts[regionField] == "" {
+		return fallback
+	}
+
+	return parts[regionField]
 }
 
 func (m *Mock) now() time.Time {

--- a/providers/aws/kms/lifecycle.go
+++ b/providers/aws/kms/lifecycle.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/services/kms/driver"
 )
 
@@ -15,7 +16,7 @@ const symmetricKeyBytes = 32 // AES-256
 // CreateKey creates a customer master key, generating its material.
 //
 //nolint:gocritic // in is the public CreateKey input, taken by value to match the driver API
-func (m *Mock) CreateKey(_ context.Context, in driver.CreateKeyInput) (*driver.KeyMetadata, error) {
+func (m *Mock) CreateKey(ctx context.Context, in driver.CreateKeyInput) (*driver.KeyMetadata, error) {
 	usage := in.KeyUsage
 	if usage == "" {
 		usage = driver.UsageEncryptDecrypt
@@ -45,7 +46,7 @@ func (m *Mock) CreateKey(_ context.Context, in driver.CreateKeyInput) (*driver.K
 	kd := &keyData{
 		meta: driver.KeyMetadata{
 			KeyID:        id,
-			ARN:          m.keyARN(id),
+			ARN:          m.keyARN(ctx, id),
 			AWSAccountID: m.opts.AccountID,
 			Description:  in.Description,
 			Enabled:      true,
@@ -67,7 +68,7 @@ func (m *Mock) CreateKey(_ context.Context, in driver.CreateKeyInput) (*driver.K
 
 	if in.MultiRegion {
 		kd.meta.MultiRegionKeyType = "PRIMARY"
-		kd.meta.PrimaryRegion = m.opts.Region
+		kd.meta.PrimaryRegion = regionctx.RegionOr(ctx, m.opts.Region)
 	}
 
 	if err := populateKeyMaterial(kd, spec, origin); err != nil {

--- a/providers/aws/lambda/aliases.go
+++ b/providers/aws/lambda/aliases.go
@@ -29,7 +29,7 @@ func (m *Mock) CreateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 	}
 
 	aliasARN := idgen.AWSARN(
-		"lambda", m.opts.Region, m.opts.AccountID,
+		"lambda", arnRegion(fd.info.ARN, m.opts.Region), m.opts.AccountID,
 		"function:"+cfg.FunctionName+":"+cfg.Name,
 	)
 

--- a/providers/aws/lambda/esm.go
+++ b/providers/aws/lambda/esm.go
@@ -67,6 +67,22 @@ func (m *Mock) CreateEventSourceMapping(
 	return &result, nil
 }
 
+// arnRegion returns the region field of a Lambda ARN
+// (arn:aws:lambda:<region>:<account>:function:<name>), or fallback when the ARN
+// is malformed. A function's stored ARN is the source of truth for its region,
+// so an alias ARN and a function URL are derived from it rather than the
+// configured default.
+func arnRegion(arn, fallback string) string {
+	const regionField, minFields = 3, 6
+
+	parts := strings.Split(arn, ":")
+	if len(parts) < minFields || parts[regionField] == "" {
+		return fallback
+	}
+
+	return parts[regionField]
+}
+
 // functionARN resolves an event-source-mapping target to a full function ARN.
 // A value already shaped like an ARN is returned unchanged; a bare name is
 // looked up (falling back to a synthesized ARN if the function isn't tracked,

--- a/providers/aws/lambda/functionurl.go
+++ b/providers/aws/lambda/functionurl.go
@@ -48,7 +48,7 @@ func (m *Mock) CreateFunctionURLConfig(_ context.Context, cfg driver.FunctionURL
 	url := &driver.FunctionURLConfig{
 		FunctionName: cfg.FunctionName,
 		FunctionArn:  fd.info.ARN,
-		FunctionURL:  m.functionURL(),
+		FunctionURL:  functionURL(arnRegion(fd.info.ARN, m.opts.Region)),
 		AuthType:     authType,
 		InvokeMode:   invokeMode,
 		Cors:         cfg.Cors,
@@ -155,11 +155,11 @@ func (m *Mock) ListFunctionURLConfigs(_ context.Context, functionName string) ([
 
 // functionURL synthesizes a Lambda Function URL of the real shape
 // https://<url-id>.lambda-url.<region>.on.aws/.
-func (m *Mock) functionURL() string {
+func functionURL(region string) string {
 	var b [16]byte
 	if _, err := rand.Read(b[:]); err != nil {
-		return fmt.Sprintf("https://cloudemu.lambda-url.%s.on.aws/", m.opts.Region)
+		return fmt.Sprintf("https://cloudemu.lambda-url.%s.on.aws/", region)
 	}
 
-	return fmt.Sprintf("https://%s.lambda-url.%s.on.aws/", hex.EncodeToString(b[:8])+hex.EncodeToString(b[8:]), m.opts.Region)
+	return fmt.Sprintf("https://%s.lambda-url.%s.on.aws/", hex.EncodeToString(b[:8])+hex.EncodeToString(b[8:]), region)
 }

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
 	"github.com/stackshy/cloudemu/v2/services/serverless/funcengine"
@@ -153,7 +154,7 @@ func (m *Mock) CreateFunction(ctx context.Context, cfg driver.FunctionConfig) (*
 		return nil, err
 	}
 
-	arn := idgen.AWSARN("lambda", m.opts.Region, m.opts.AccountID, "function:"+cfg.Name)
+	arn := idgen.AWSARN("lambda", regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID, "function:"+cfg.Name)
 	info := driver.FunctionInfo{
 		Name: cfg.Name, ARN: arn, Runtime: cfg.Runtime, Handler: cfg.Handler,
 		Role: cfg.Role, Description: cfg.Description,

--- a/providers/aws/lambda/layers.go
+++ b/providers/aws/lambda/layers.go
@@ -11,13 +11,14 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
 )
 
 // PublishLayerVersion publishes a new version of a layer.
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
-func (m *Mock) PublishLayerVersion(_ context.Context, cfg driver.LayerConfig) (*driver.LayerVersion, error) {
+func (m *Mock) PublishLayerVersion(ctx context.Context, cfg driver.LayerConfig) (*driver.LayerVersion, error) {
 	ld, ok := m.layers.Get(cfg.Name)
 	if !ok {
 		ld = &layerData{
@@ -34,7 +35,7 @@ func (m *Mock) PublishLayerVersion(_ context.Context, cfg driver.LayerConfig) (*
 	shaStr := fmt.Sprintf("%x", hash)
 
 	arn := idgen.AWSARN(
-		"lambda", m.opts.Region, m.opts.AccountID,
+		"lambda", regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID,
 		"layer:"+cfg.Name+":"+strconv.Itoa(ver),
 	)
 

--- a/providers/aws/rds/advanced_restore.go
+++ b/providers/aws/rds/advanced_restore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/services/relationaldb/dbengine"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
@@ -32,7 +33,7 @@ func (m *Mock) CopyDBSnapshot(_ context.Context, source, target string, tags map
 
 	snap := src
 	snap.ID = target
-	snap.ARN = snapshotARN(m.opts.Region, m.opts.AccountID, target)
+	snap.ARN = snapshotARN(arnRegion(src.ARN, m.opts.Region), m.opts.AccountID, target)
 	snap.State = rdsdriver.SnapshotAvailable
 	snap.CreatedAt = m.opts.Clock.Now().UTC()
 
@@ -71,7 +72,7 @@ func (m *Mock) CopyDBClusterSnapshot(_ context.Context, source, target string, t
 
 	snap := src
 	snap.ID = target
-	snap.ARN = clusterSnapshotARN(m.opts.Region, m.opts.AccountID, target)
+	snap.ARN = clusterSnapshotARN(arnRegion(src.ARN, m.opts.Region), m.opts.AccountID, target)
 	snap.State = rdsdriver.SnapshotAvailable
 	snap.CreatedAt = m.opts.Clock.Now().UTC()
 
@@ -120,11 +121,12 @@ func (m *Mock) RestoreDBInstanceToPointInTime(
 		instanceClass = src.InstanceClass
 	}
 
+	region := regionctx.RegionOr(ctx, m.opts.Region)
 	inst := src
 	inst.ID = input.TargetInstanceID
-	inst.ARN = instanceARN(m.opts.Region, m.opts.AccountID, input.TargetInstanceID)
+	inst.ARN = instanceARN(region, m.opts.AccountID, input.TargetInstanceID)
 	inst.InstanceClass = instanceClass
-	inst.Endpoint = endpointFor(input.TargetInstanceID, m.opts.Region, "abcd1234")
+	inst.Endpoint = endpointFor(input.TargetInstanceID, region, "abcd1234")
 	inst.State = rdsdriver.StateAvailable
 	inst.CreatedAt = m.opts.Clock.Now().UTC()
 	inst.ReadReplicaSource = ""
@@ -184,11 +186,12 @@ func (m *Mock) RestoreDBClusterToPointInTime(
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "DB cluster %q already exists", input.TargetClusterID)
 	}
 
+	region := regionctx.RegionOr(ctx, m.opts.Region)
 	cluster := src
 	cluster.ID = input.TargetClusterID
-	cluster.ARN = clusterARN(m.opts.Region, m.opts.AccountID, input.TargetClusterID)
-	cluster.Endpoint = endpointFor(input.TargetClusterID, m.opts.Region, "cluster")
-	cluster.ReaderEndpoint = endpointFor(input.TargetClusterID, m.opts.Region, "cluster-ro")
+	cluster.ARN = clusterARN(region, m.opts.AccountID, input.TargetClusterID)
+	cluster.Endpoint = endpointFor(input.TargetClusterID, region, "cluster")
+	cluster.ReaderEndpoint = endpointFor(input.TargetClusterID, region, "cluster-ro")
 	cluster.State = rdsdriver.StateAvailable
 	cluster.Members = nil
 	cluster.CreatedAt = m.opts.Clock.Now().UTC()

--- a/providers/aws/rds/aurora.go
+++ b/providers/aws/rds/aurora.go
@@ -5,6 +5,7 @@ import (
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
 
@@ -26,7 +27,7 @@ func globalClusterARN(accountID, id string) string {
 // ---- custom cluster endpoints ----
 
 //nolint:gocritic // cfg matches the driver interface signature.
-func (m *Mock) CreateDBClusterEndpoint(_ context.Context, cfg rdsdriver.ClusterEndpointConfig) (*rdsdriver.ClusterEndpoint, error) {
+func (m *Mock) CreateDBClusterEndpoint(ctx context.Context, cfg rdsdriver.ClusterEndpointConfig) (*rdsdriver.ClusterEndpoint, error) {
 	if cfg.EndpointID == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "DBClusterEndpointIdentifier is required")
 	}
@@ -42,11 +43,12 @@ func (m *Mock) CreateDBClusterEndpoint(_ context.Context, cfg rdsdriver.ClusterE
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "DB cluster endpoint %q already exists", cfg.EndpointID)
 	}
 
+	region := regionctx.RegionOr(ctx, m.opts.Region)
 	ep := rdsdriver.ClusterEndpoint{
 		EndpointID:         cfg.EndpointID,
 		ClusterID:          cfg.ClusterID,
-		ARN:                clusterEndpointARN(m.opts.Region, m.opts.AccountID, cfg.EndpointID),
-		Endpoint:           endpointFor(cfg.EndpointID, m.opts.Region, "cluster-custom"),
+		ARN:                clusterEndpointARN(region, m.opts.AccountID, cfg.EndpointID),
+		Endpoint:           endpointFor(cfg.EndpointID, region, "cluster-custom"),
 		Status:             rdsdriver.StateAvailable,
 		EndpointType:       "CUSTOM",
 		CustomEndpointType: cfg.EndpointType,

--- a/providers/aws/rds/dbproxy.go
+++ b/providers/aws/rds/dbproxy.go
@@ -6,6 +6,7 @@ import (
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
 
@@ -26,7 +27,7 @@ func errProxyNotFound(name string) error {
 }
 
 //nolint:gocritic // cfg matches the driver interface signature.
-func (m *Mock) CreateDBProxy(_ context.Context, cfg rdsdriver.DBProxyConfig) (*rdsdriver.DBProxy, error) {
+func (m *Mock) CreateDBProxy(ctx context.Context, cfg rdsdriver.DBProxyConfig) (*rdsdriver.DBProxy, error) {
 	if cfg.Name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "DBProxyName is required")
 	}
@@ -42,13 +43,14 @@ func (m *Mock) CreateDBProxy(_ context.Context, cfg rdsdriver.DBProxyConfig) (*r
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "DB proxy %q already exists", cfg.Name)
 	}
 
+	region := regionctx.RegionOr(ctx, m.opts.Region)
 	proxy := rdsdriver.DBProxy{
 		Name:                cfg.Name,
-		ARN:                 proxyARN(m.opts.Region, m.opts.AccountID, cfg.Name),
+		ARN:                 proxyARN(region, m.opts.AccountID, cfg.Name),
 		Status:              "available",
 		EngineFamily:        cfg.EngineFamily,
 		RoleARN:             cfg.RoleARN,
-		Endpoint:            fmt.Sprintf("%s.proxy-abcd1234.%s.rds.amazonaws.com", cfg.Name, m.opts.Region),
+		Endpoint:            fmt.Sprintf("%s.proxy-abcd1234.%s.rds.amazonaws.com", cfg.Name, region),
 		VPCSubnetIDs:        append([]string(nil), cfg.VPCSubnetIDs...),
 		VPCSecurityGroupIDs: append([]string(nil), cfg.VPCSecurityGroupIDs...),
 		RequireTLS:          cfg.RequireTLS,
@@ -240,14 +242,15 @@ func (m *Mock) DescribeDBProxyTargetGroups(_ context.Context, name string) ([]rd
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if !m.proxies.Has(name) {
+	proxy, ok := m.proxies.Get(name)
+	if !ok {
 		return nil, errProxyNotFound(name)
 	}
 
 	return []rdsdriver.ProxyTargetGroup{{
 		Name:      defaultTargetGroup,
 		ProxyName: name,
-		ARN:       proxyTargetGroupARN(m.opts.Region, m.opts.AccountID, name),
+		ARN:       proxyTargetGroupARN(arnRegion(proxy.ARN, m.opts.Region), m.opts.AccountID, name),
 		IsDefault: true,
 	}}, nil
 }

--- a/providers/aws/rds/events.go
+++ b/providers/aws/rds/events.go
@@ -5,6 +5,7 @@ import (
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
 
@@ -36,7 +37,7 @@ var eventCategoryCatalog = map[string][]string{
 }
 
 //nolint:gocritic // cfg matches the driver interface signature.
-func (m *Mock) CreateEventSubscription(_ context.Context, cfg rdsdriver.EventSubscriptionConfig) (*rdsdriver.EventSubscription, error) {
+func (m *Mock) CreateEventSubscription(ctx context.Context, cfg rdsdriver.EventSubscriptionConfig) (*rdsdriver.EventSubscription, error) {
 	if cfg.Name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "SubscriptionName is required")
 	}
@@ -54,7 +55,7 @@ func (m *Mock) CreateEventSubscription(_ context.Context, cfg rdsdriver.EventSub
 
 	sub := rdsdriver.EventSubscription{
 		Name:            cfg.Name,
-		ARN:             eventSubscriptionARN(m.opts.Region, m.opts.AccountID, cfg.Name),
+		ARN:             eventSubscriptionARN(regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID, cfg.Name),
 		CustomerAWSID:   m.opts.AccountID,
 		SnsTopicARN:     cfg.SnsTopicARN,
 		SourceType:      cfg.SourceType,

--- a/providers/aws/rds/option_group.go
+++ b/providers/aws/rds/option_group.go
@@ -7,6 +7,7 @@ import (
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
 
@@ -59,7 +60,7 @@ var optionGroupOptionCatalog = map[string][]string{
 	"sqlserver-se": {"TDE", "SQLSERVER_AUDIT"},
 }
 
-func (m *Mock) CreateOptionGroup(_ context.Context, cfg rdsdriver.OptionGroupConfig) (*rdsdriver.OptionGroup, error) {
+func (m *Mock) CreateOptionGroup(ctx context.Context, cfg rdsdriver.OptionGroupConfig) (*rdsdriver.OptionGroup, error) {
 	if cfg.Name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "OptionGroupName is required")
 	}
@@ -84,7 +85,7 @@ func (m *Mock) CreateOptionGroup(_ context.Context, cfg rdsdriver.OptionGroupCon
 		EngineName:         cfg.EngineName,
 		MajorEngineVersion: cfg.MajorEngineVersion,
 		Description:        cfg.Description,
-		ARN:                optionGroupARN(m.opts.Region, m.opts.AccountID, cfg.Name),
+		ARN:                optionGroupARN(regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID, cfg.Name),
 	}
 	m.optionGroups.Set(cfg.Name, og)
 	m.setGroupTags(og.ARN, copyTags(cfg.Tags))
@@ -212,7 +213,7 @@ func (m *Mock) CopyOptionGroup(_ context.Context, source, target, description st
 		EngineName:         src.EngineName,
 		MajorEngineVersion: src.MajorEngineVersion,
 		Description:        description,
-		ARN:                optionGroupARN(m.opts.Region, m.opts.AccountID, target),
+		ARN:                optionGroupARN(arnRegion(src.ARN, m.opts.Region), m.opts.AccountID, target),
 		Options:            append([]rdsdriver.Option(nil), src.Options...),
 	}
 	m.optionGroups.Set(target, og)

--- a/providers/aws/rds/parameter_group.go
+++ b/providers/aws/rds/parameter_group.go
@@ -6,6 +6,7 @@ import (
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
 
@@ -84,7 +85,7 @@ func copyParams(src map[string]rdsdriver.Parameter) map[string]rdsdriver.Paramet
 
 // ---- DB parameter groups ----
 
-func (m *Mock) CreateDBParameterGroup(_ context.Context, cfg rdsdriver.ParameterGroupConfig) (*rdsdriver.ParameterGroup, error) {
+func (m *Mock) CreateDBParameterGroup(ctx context.Context, cfg rdsdriver.ParameterGroupConfig) (*rdsdriver.ParameterGroup, error) {
 	if cfg.Name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "DBParameterGroupName is required")
 	}
@@ -108,7 +109,7 @@ func (m *Mock) CreateDBParameterGroup(_ context.Context, cfg rdsdriver.Parameter
 		Name:        cfg.Name,
 		Family:      cfg.Family,
 		Description: cfg.Description,
-		ARN:         parameterGroupARN(m.opts.Region, m.opts.AccountID, cfg.Name),
+		ARN:         parameterGroupARN(regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID, cfg.Name),
 		Parameters:  map[string]rdsdriver.Parameter{},
 	}
 	m.paramGroups.Set(cfg.Name, pg)
@@ -265,7 +266,7 @@ func (m *Mock) CopyDBParameterGroup(_ context.Context, source, target, descripti
 		Name:        target,
 		Family:      src.Family,
 		Description: description,
-		ARN:         parameterGroupARN(m.opts.Region, m.opts.AccountID, target),
+		ARN:         parameterGroupARN(arnRegion(src.ARN, m.opts.Region), m.opts.AccountID, target),
 		Parameters:  copyParams(src.Parameters),
 	}
 	m.paramGroups.Set(target, pg)
@@ -278,7 +279,7 @@ func (m *Mock) CopyDBParameterGroup(_ context.Context, source, target, descripti
 // ---- DB cluster parameter groups ----
 
 func (m *Mock) CreateDBClusterParameterGroup(
-	_ context.Context, cfg rdsdriver.ParameterGroupConfig,
+	ctx context.Context, cfg rdsdriver.ParameterGroupConfig,
 ) (*rdsdriver.ClusterParameterGroup, error) {
 	if cfg.Name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "DBClusterParameterGroupName is required")
@@ -303,7 +304,7 @@ func (m *Mock) CreateDBClusterParameterGroup(
 		Name:        cfg.Name,
 		Family:      cfg.Family,
 		Description: cfg.Description,
-		ARN:         clusterParameterGroupARN(m.opts.Region, m.opts.AccountID, cfg.Name),
+		ARN:         clusterParameterGroupARN(regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID, cfg.Name),
 		Parameters:  map[string]rdsdriver.Parameter{},
 	}
 	m.clusterParamGroups.Set(cfg.Name, pg)
@@ -452,7 +453,7 @@ func (m *Mock) CopyDBClusterParameterGroup(
 		Name:        target,
 		Family:      src.Family,
 		Description: description,
-		ARN:         clusterParameterGroupARN(m.opts.Region, m.opts.AccountID, target),
+		ARN:         clusterParameterGroupARN(arnRegion(src.ARN, m.opts.Region), m.opts.AccountID, target),
 		Parameters:  copyParams(src.Parameters),
 	}
 	m.clusterParamGroups.Set(target, pg)

--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -19,6 +19,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/internal/settle"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	dbengine "github.com/stackshy/cloudemu/v2/services/relationaldb/dbengine"
@@ -245,6 +246,22 @@ func instanceARN(region, accountID, id string) string {
 	return idgen.AWSARN("rds", region, accountID, "db:"+id)
 }
 
+// arnRegion returns the region field of an RDS ARN
+// (arn:aws:rds:<region>:<account>:<type>:<id>), or fallback when the ARN is
+// malformed. A source resource's stored ARN is the source of truth for the
+// region of a resource derived from it (a snapshot, a renamed instance), so the
+// two always share a region.
+func arnRegion(arn, fallback string) string {
+	const regionField, minFields = 3, 6
+
+	parts := strings.Split(arn, ":")
+	if len(parts) < minFields || parts[regionField] == "" {
+		return fallback
+	}
+
+	return parts[regionField]
+}
+
 // resourceID derives a stable, region-unique RDS resource id (e.g.
 // "db-ABCDEF...", "cluster-ABCDEF...") from a prefix and the resource id. Real
 // AWS assigns an opaque immutable id; a deterministic hash keeps it stable
@@ -358,7 +375,7 @@ func (m *Mock) CreateInstance(ctx context.Context, cfg rdsdriver.InstanceConfig)
 		return nil, err
 	}
 
-	inst, plan, err := m.reserveInstance(cfg)
+	inst, plan, err := m.reserveInstance(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -384,7 +401,7 @@ func (m *Mock) CreateInstance(ctx context.Context, cfg rdsdriver.InstanceConfig)
 // the provisioning plan snapshotted while the lock is held.
 //
 //nolint:gocritic // cfg matches the driver interface signature.
-func (m *Mock) reserveInstance(cfg rdsdriver.InstanceConfig) (rdsdriver.Instance, createPlan, error) {
+func (m *Mock) reserveInstance(ctx context.Context, cfg rdsdriver.InstanceConfig) (rdsdriver.Instance, createPlan, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -398,7 +415,7 @@ func (m *Mock) reserveInstance(cfg rdsdriver.InstanceConfig) (rdsdriver.Instance
 		}
 	}
 
-	inst := m.newInstance(cfg)
+	inst := m.newInstance(ctx, cfg)
 	m.instances.Set(cfg.ID, inst)
 	m.instSettle[cfg.ID] = settle.Pending(rdsdriver.StateCreating, m.opts.Clock.Now(),
 		m.opts.SettleDuration(settle.DefaultDBInstanceSettle))
@@ -417,7 +434,7 @@ func (m *Mock) reserveInstance(cfg rdsdriver.InstanceConfig) (rdsdriver.Instance
 // endpoint. The caller holds the lock.
 //
 //nolint:gocritic // cfg matches the driver interface signature.
-func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
+func (m *Mock) newInstance(ctx context.Context, cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 	port := cfg.Port
 	if port == 0 {
 		port = defaultPortFor(cfg.Engine)
@@ -443,9 +460,11 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		engineVersion = defaultEngineVersion(cfg.Engine)
 	}
 
+	region := regionctx.RegionOr(ctx, m.opts.Region)
+
 	return rdsdriver.Instance{
 		ID:                         cfg.ID,
-		ARN:                        instanceARN(m.opts.Region, m.opts.AccountID, cfg.ID),
+		ARN:                        instanceARN(region, m.opts.AccountID, cfg.ID),
 		Engine:                     cfg.Engine,
 		EngineVersion:              engineVersion,
 		InstanceClass:              instanceClass,
@@ -453,7 +472,7 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		StorageType:                storageType,
 		MasterUsername:             cfg.MasterUsername,
 		DBName:                     cfg.DBName,
-		Endpoint:                   endpointFor(cfg.ID, m.opts.Region, "abcd1234"),
+		Endpoint:                   endpointFor(cfg.ID, region, "abcd1234"),
 		Port:                       port,
 		State:                      rdsdriver.StateAvailable,
 		MultiAZ:                    cfg.MultiAZ,
@@ -811,7 +830,7 @@ func (m *Mock) renameInstance(oldID, newID string, inst rdsdriver.Instance) (*rd
 	}
 
 	inst.ID = newID
-	inst.ARN = instanceARN(m.opts.Region, m.opts.AccountID, newID)
+	inst.ARN = instanceARN(arnRegion(inst.ARN, m.opts.Region), m.opts.AccountID, newID)
 
 	m.instances.Delete(oldID)
 	m.instances.Set(newID, inst)
@@ -985,7 +1004,7 @@ func (m *Mock) transitionInstance(id, from, to string, cpu, conns float64, verb 
 // CreateCluster creates an Aurora-style cluster.
 //
 //nolint:gocritic // cfg matches the driver interface signature.
-func (m *Mock) CreateCluster(_ context.Context, cfg rdsdriver.ClusterConfig) (*rdsdriver.Cluster, error) {
+func (m *Mock) CreateCluster(ctx context.Context, cfg rdsdriver.ClusterConfig) (*rdsdriver.Cluster, error) {
 	if cfg.ID == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "DBClusterIdentifier is required")
 	}
@@ -1016,15 +1035,16 @@ func (m *Mock) CreateCluster(_ context.Context, cfg rdsdriver.ClusterConfig) (*r
 		allocatedStorage = auroraAllocatedStorage
 	}
 
+	region := regionctx.RegionOr(ctx, m.opts.Region)
 	cluster := rdsdriver.Cluster{
 		ID:                          cfg.ID,
-		ARN:                         clusterARN(m.opts.Region, m.opts.AccountID, cfg.ID),
+		ARN:                         clusterARN(region, m.opts.AccountID, cfg.ID),
 		Engine:                      cfg.Engine,
 		EngineVersion:               cfg.EngineVersion,
 		MasterUsername:              cfg.MasterUsername,
 		DatabaseName:                cfg.DatabaseName,
-		Endpoint:                    endpointFor(cfg.ID, m.opts.Region, "cluster"),
-		ReaderEndpoint:              endpointFor(cfg.ID, m.opts.Region, "cluster-ro"),
+		Endpoint:                    endpointFor(cfg.ID, region, "cluster"),
+		ReaderEndpoint:              endpointFor(cfg.ID, region, "cluster-ro"),
 		Port:                        port,
 		State:                       rdsdriver.StateAvailable,
 		VPCSecurityGroups:           append([]string(nil), cfg.VPCSecurityGroups...),
@@ -1036,7 +1056,7 @@ func (m *Mock) CreateCluster(_ context.Context, cfg rdsdriver.ClusterConfig) (*r
 		StorageEncrypted:            cfg.StorageEncrypted,
 		KmsKeyID:                    resolveKMSKeyID(cfg.StorageEncrypted, cfg.KmsKeyID),
 		DeletionProtection:          cfg.DeletionProtection,
-		AvailabilityZones:           availabilityZones(m.opts.Region),
+		AvailabilityZones:           availabilityZones(region),
 		CreatedAt:                   m.opts.Clock.Now().UTC(),
 		Tags:                        copyTags(cfg.Tags),
 	}
@@ -1226,7 +1246,7 @@ func (m *Mock) CreateSnapshot(_ context.Context, cfg rdsdriver.SnapshotConfig) (
 
 	snap := rdsdriver.Snapshot{
 		ID:               cfg.ID,
-		ARN:              snapshotARN(m.opts.Region, m.opts.AccountID, cfg.ID),
+		ARN:              snapshotARN(arnRegion(inst.ARN, m.opts.Region), m.opts.AccountID, cfg.ID),
 		InstanceID:       cfg.InstanceID,
 		Engine:           inst.Engine,
 		EngineVersion:    inst.EngineVersion,
@@ -1333,9 +1353,10 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 
 	password := m.rootPasswords[snap.InstanceID]
 
+	region := regionctx.RegionOr(ctx, m.opts.Region)
 	inst := rdsdriver.Instance{
 		ID:               input.NewInstanceID,
-		ARN:              instanceARN(m.opts.Region, m.opts.AccountID, input.NewInstanceID),
+		ARN:              instanceARN(region, m.opts.AccountID, input.NewInstanceID),
 		Engine:           snap.Engine,
 		EngineVersion:    snap.EngineVersion,
 		InstanceClass:    instanceClass,
@@ -1343,7 +1364,7 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 		StorageType:      defaultStorageType,
 		MasterUsername:   username,
 		DBName:           dbName,
-		Endpoint:         endpointFor(input.NewInstanceID, m.opts.Region, "abcd1234"),
+		Endpoint:         endpointFor(input.NewInstanceID, region, "abcd1234"),
 		Port:             port,
 		State:            rdsdriver.StateAvailable,
 		CreatedAt:        m.opts.Clock.Now().UTC(),
@@ -1448,7 +1469,7 @@ func (m *Mock) CreateClusterSnapshot(
 
 	snap := rdsdriver.ClusterSnapshot{
 		ID:            cfg.ID,
-		ARN:           clusterSnapshotARN(m.opts.Region, m.opts.AccountID, cfg.ID),
+		ARN:           clusterSnapshotARN(arnRegion(cluster.ARN, m.opts.Region), m.opts.AccountID, cfg.ID),
 		ClusterID:     cfg.ClusterID,
 		Engine:        cluster.Engine,
 		EngineVersion: cluster.EngineVersion,
@@ -1533,14 +1554,15 @@ func (m *Mock) RestoreClusterFromSnapshot(
 	// database is reachable and future members provision consistently.
 	creds := m.clusterCreds[snap.ClusterID]
 
+	region := regionctx.RegionOr(ctx, m.opts.Region)
 	cluster := rdsdriver.Cluster{
 		ID:             input.NewClusterID,
-		ARN:            clusterARN(m.opts.Region, m.opts.AccountID, input.NewClusterID),
+		ARN:            clusterARN(region, m.opts.AccountID, input.NewClusterID),
 		Engine:         snap.Engine,
 		EngineVersion:  snap.EngineVersion,
 		MasterUsername: creds.user,
-		Endpoint:       endpointFor(input.NewClusterID, m.opts.Region, "cluster"),
-		ReaderEndpoint: endpointFor(input.NewClusterID, m.opts.Region, "cluster-ro"),
+		Endpoint:       endpointFor(input.NewClusterID, region, "cluster"),
+		ReaderEndpoint: endpointFor(input.NewClusterID, region, "cluster-ro"),
 		Port:           defaultPortFor(snap.Engine),
 		State:          rdsdriver.StateAvailable,
 		CreatedAt:      m.opts.Clock.Now().UTC(),

--- a/providers/aws/rds/read_replica.go
+++ b/providers/aws/rds/read_replica.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	dbengine "github.com/stackshy/cloudemu/v2/services/relationaldb/dbengine"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
@@ -23,7 +24,7 @@ func (m *Mock) sourceEngineBacked(engine string) bool {
 // DBName, and DBParameterGroup unless the caller overrides them.
 //
 //nolint:gocritic // cfg matches the driver interface signature.
-func (m *Mock) CreateDBInstanceReadReplica(_ context.Context, cfg rdsdriver.ReadReplicaConfig) (*rdsdriver.Instance, error) {
+func (m *Mock) CreateDBInstanceReadReplica(ctx context.Context, cfg rdsdriver.ReadReplicaConfig) (*rdsdriver.Instance, error) {
 	if cfg.ID == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "DBInstanceIdentifier is required")
 	}
@@ -67,7 +68,9 @@ func (m *Mock) CreateDBInstanceReadReplica(_ context.Context, cfg rdsdriver.Read
 	// client reading from the replica reaches the real database — provisioning a
 	// separate empty database would leave the replica seeing none of the source's
 	// data. A synthetic source keeps the synthetic replica endpoint.
-	endpoint := endpointFor(cfg.ID, m.opts.Region, "abcd1234")
+	region := regionctx.RegionOr(ctx, m.opts.Region)
+
+	endpoint := endpointFor(cfg.ID, region, "abcd1234")
 	if m.sourceEngineBacked(src.Engine) {
 		endpoint = src.Endpoint
 		port = src.Port
@@ -75,7 +78,7 @@ func (m *Mock) CreateDBInstanceReadReplica(_ context.Context, cfg rdsdriver.Read
 
 	replica := rdsdriver.Instance{
 		ID:                   cfg.ID,
-		ARN:                  instanceARN(m.opts.Region, m.opts.AccountID, cfg.ID),
+		ARN:                  instanceARN(region, m.opts.AccountID, cfg.ID),
 		Engine:               src.Engine,
 		EngineVersion:        src.EngineVersion,
 		InstanceClass:        instanceClass,

--- a/providers/aws/rds/subnet_group.go
+++ b/providers/aws/rds/subnet_group.go
@@ -5,6 +5,7 @@ import (
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
@@ -56,7 +57,7 @@ func (m *Mock) CreateDBSubnetGroup(
 		SubnetIDs:   append([]string(nil), cfg.SubnetIDs...),
 		VPCID:       m.resolveVPCID(ctx, cfg.SubnetIDs),
 		Status:      "Complete",
-		ARN:         idgen.AWSARN("rds", m.opts.Region, m.opts.AccountID, "subgrp:"+cfg.Name),
+		ARN:         idgen.AWSARN("rds", regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID, "subgrp:"+cfg.Name),
 	}
 	m.subnetGroups.Set(cfg.Name, sg)
 

--- a/providers/aws/sfn/activities.go
+++ b/providers/aws/sfn/activities.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
 )
 
@@ -21,13 +22,13 @@ func (m *Mock) getActivity(arn string) (*actData, error) {
 }
 
 func (m *Mock) CreateActivity(
-	_ context.Context, name string, tags map[string]string,
+	ctx context.Context, name string, tags map[string]string,
 ) (arn string, created time.Time, err error) {
 	if name == "" {
 		return "", time.Time{}, invalidName("activity name is required")
 	}
 
-	arn = m.activityARN(name)
+	arn = m.activityARN(regionctx.RegionOr(ctx, m.opts.Region), name)
 	now := m.now()
 
 	if !m.activities.SetIfAbsent(arn, &actData{act: driver.Activity{

--- a/providers/aws/sfn/executions.go
+++ b/providers/aws/sfn/executions.go
@@ -57,7 +57,7 @@ func (m *Mock) runExecution(in driver.StartExecutionInput, async bool) (*driver.
 		name = idgen.GenerateID("exec-")
 	}
 
-	arn := m.execARN(smName, name)
+	arn := m.execARN(arnRegion(in.StateMachineArn, m.opts.Region), smName, name)
 	now := m.now()
 
 	output := in.Input

--- a/providers/aws/sfn/maprun.go
+++ b/providers/aws/sfn/maprun.go
@@ -26,7 +26,7 @@ func (m *Mock) SeedMapRun(executionArn string, run driver.MapRun) (string, error
 	execName := ed.exec.Name
 	ed.mu.RUnlock()
 
-	arn := m.mapRunARN(smName, execName, idgen.GenerateID("mr-"))
+	arn := m.mapRunARN(arnRegion(smArn, m.opts.Region), smName, execName, idgen.GenerateID("mr-"))
 	now := m.now()
 
 	run.ARN = arn

--- a/providers/aws/sfn/sfn.go
+++ b/providers/aws/sfn/sfn.go
@@ -101,24 +101,40 @@ func (m *Mock) now() time.Time {
 	return m.opts.Clock.Now().UTC()
 }
 
-func (m *Mock) smARN(name string) string {
-	return idgen.AWSARN("states", m.opts.Region, m.opts.AccountID, "stateMachine:"+name)
+func (m *Mock) smARN(region, name string) string {
+	return idgen.AWSARN("states", region, m.opts.AccountID, "stateMachine:"+name)
 }
 
-func (m *Mock) execARN(smName, execName string) string {
-	return idgen.AWSARN("states", m.opts.Region, m.opts.AccountID, "execution:"+smName+":"+execName)
+func (m *Mock) execARN(region, smName, execName string) string {
+	return idgen.AWSARN("states", region, m.opts.AccountID, "execution:"+smName+":"+execName)
 }
 
-func (m *Mock) activityARN(name string) string {
-	return idgen.AWSARN("states", m.opts.Region, m.opts.AccountID, "activity:"+name)
+func (m *Mock) activityARN(region, name string) string {
+	return idgen.AWSARN("states", region, m.opts.AccountID, "activity:"+name)
 }
 
-func (m *Mock) aliasARN(smName, alias string) string {
-	return idgen.AWSARN("states", m.opts.Region, m.opts.AccountID, "stateMachine:"+smName+":"+alias)
+func (m *Mock) aliasARN(region, smName, alias string) string {
+	return idgen.AWSARN("states", region, m.opts.AccountID, "stateMachine:"+smName+":"+alias)
 }
 
-func (m *Mock) mapRunARN(smName, execName, id string) string {
-	return idgen.AWSARN("states", m.opts.Region, m.opts.AccountID, "mapRun:"+smName+"/"+execName+":"+id)
+func (m *Mock) mapRunARN(region, smName, execName, id string) string {
+	return idgen.AWSARN("states", region, m.opts.AccountID, "mapRun:"+smName+"/"+execName+":"+id)
+}
+
+// arnRegion returns the region field of a Step Functions ARN
+// (arn:aws:states:<region>:<account>:<resource>), or fallback when the ARN is
+// malformed. A parent resource's stored ARN is the source of truth for the
+// region of the child ARNs derived from it (executions, aliases, map runs), so
+// a child always shares its parent's region.
+func arnRegion(arn, fallback string) string {
+	const regionField, minFields = 3, 6
+
+	parts := strings.Split(arn, ":")
+	if len(parts) < minFields || parts[regionField] == "" {
+		return fallback
+	}
+
+	return parts[regionField]
 }
 
 // smNameFromARN extracts the state machine name from a state machine ARN.

--- a/providers/aws/sfn/statemachines.go
+++ b/providers/aws/sfn/statemachines.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
 )
 
@@ -53,7 +54,7 @@ func (m *Mock) getSM(arn string) (*smData, error) {
 //
 //nolint:gocritic // in is a value to satisfy the driver.SFN interface signature.
 func (m *Mock) CreateStateMachine(
-	_ context.Context, in driver.CreateStateMachineInput,
+	ctx context.Context, in driver.CreateStateMachineInput,
 ) (arn, versionArn string, created time.Time, err error) {
 	if in.Name == "" {
 		return "", "", time.Time{}, invalidName("state machine name is required")
@@ -78,7 +79,7 @@ func (m *Mock) CreateStateMachine(
 		smType = driver.TypeStandard
 	}
 
-	arn = m.smARN(in.Name)
+	arn = m.smARN(regionctx.RegionOr(ctx, m.opts.Region), in.Name)
 	now := m.now()
 	sm := driver.StateMachine{
 		ARN: arn, Name: in.Name, Definition: in.Definition, RoleArn: in.RoleArn,

--- a/providers/aws/sfn/versions.go
+++ b/providers/aws/sfn/versions.go
@@ -142,7 +142,7 @@ func (m *Mock) CreateStateMachineAlias(
 		return "", time.Time{}, err
 	}
 
-	arn = m.aliasARN(smName, name)
+	arn = m.aliasARN(arnRegion(routing[0].StateMachineVersionArn, m.opts.Region), smName, name)
 	now := m.now()
 	alias := driver.Alias{
 		ARN: arn, Name: name, Description: description,
@@ -178,7 +178,7 @@ func (m *Mock) validateRouting(smName string, routing []driver.RouteEntry) error
 			return validationErr("all routing versions must belong to the same state machine")
 		}
 
-		sd, err := m.getSM(m.smARN(smName))
+		sd, err := m.getSM(m.smARN(arnRegion(routing[i].StateMachineVersionArn, m.opts.Region), smName))
 		if err != nil {
 			return err
 		}

--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/notification/driver"
 	"github.com/stackshy/cloudemu/v2/services/scope"
@@ -153,7 +154,23 @@ func New(opts *config.Options) *Mock {
 }
 
 // CreateTopic creates a new SNS topic.
-func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.TopicInfo, error) {
+// arnRegion returns the region field of an SNS ARN
+// (arn:aws:sns:<region>:<account>:<name>), or fallback when the ARN is
+// malformed. A topic's stored ARN is the source of truth for its region, so a
+// subscription ARN and the notification-envelope URLs are derived from it rather
+// than the configured default.
+func arnRegion(arn, fallback string) string {
+	const regionField, minFields = 3, 6
+
+	parts := strings.Split(arn, ":")
+	if len(parts) < minFields || parts[regionField] == "" {
+		return fallback
+	}
+
+	return parts[regionField]
+}
+
+func (m *Mock) CreateTopic(ctx context.Context, cfg driver.TopicConfig) (*driver.TopicInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "topic name is required")
 	}
@@ -162,7 +179,7 @@ func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 		return nil, errors.Newf(errors.AlreadyExists, "topic %q already exists", cfg.Name)
 	}
 
-	arn := idgen.AWSARN("sns", m.opts.Region, m.opts.AccountID, cfg.Name)
+	arn := idgen.AWSARN("sns", regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID, cfg.Name)
 
 	tags := make(map[string]string, len(cfg.Tags))
 	for k, v := range cfg.Tags {
@@ -314,7 +331,7 @@ func (m *Mock) Subscribe(_ context.Context, cfg driver.SubscriptionConfig) (*dri
 	}
 
 	subID := idgen.GenerateID("sub-")
-	arn := idgen.AWSARN("sns", m.opts.Region, m.opts.AccountID, cfg.TopicID+":"+subID)
+	arn := idgen.AWSARN("sns", arnRegion(td.info.ResourceID, m.opts.Region), m.opts.AccountID, cfg.TopicID+":"+subID)
 
 	attrs := make(map[string]string, len(cfg.Attributes))
 	for k, v := range cfg.Attributes {
@@ -637,9 +654,9 @@ func (m *Mock) notificationEnvelopeMap(
 		"Timestamp":        m.opts.Clock.Now().UTC().Format(time.RFC3339),
 		"SignatureVersion": "1",
 		"Signature":        "Q2xvdWRFbXVFeGFtcGxlU2lnbmF0dXJl",
-		"SigningCertURL": "https://sns." + m.opts.Region +
+		"SigningCertURL": "https://sns." + arnRegion(td.info.ResourceID, m.opts.Region) +
 			".amazonaws.com/SimpleNotificationService-cloudemu.pem",
-		"UnsubscribeURL": "https://sns." + m.opts.Region +
+		"UnsubscribeURL": "https://sns." + arnRegion(td.info.ResourceID, m.opts.Region) +
 			".amazonaws.com/?Action=Unsubscribe&SubscriptionArn=" + subARN,
 	}
 

--- a/providers/aws/sqs/sqs.go
+++ b/providers/aws/sqs/sqs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
@@ -176,7 +177,7 @@ func (m *Mock) DeliverExternalFIFO(ctx context.Context, queueARN, body, groupID,
 // CreateQueue creates a new SQS queue.
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
-func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.QueueInfo, error) {
+func (m *Mock) CreateQueue(ctx context.Context, cfg driver.QueueConfig) (*driver.QueueInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "queue name is required")
 	}
@@ -185,8 +186,9 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 		return nil, errors.New(errors.InvalidArgument, "FIFO queue name must end with .fifo")
 	}
 
-	url := fmt.Sprintf("https://sqs.%s.amazonaws.com/%s/%s", m.opts.Region, m.opts.AccountID, cfg.Name)
-	arn := idgen.AWSARN("sqs", m.opts.Region, m.opts.AccountID, cfg.Name)
+	region := regionctx.RegionOr(ctx, m.opts.Region)
+	url := fmt.Sprintf("https://sqs.%s.amazonaws.com/%s/%s", region, m.opts.AccountID, cfg.Name)
+	arn := idgen.AWSARN("sqs", region, m.opts.AccountID, cfg.Name)
 
 	// CreateQueue is idempotent: re-creating an existing queue with the exact
 	// same attributes returns the existing URL. QueueNameExists is returned only
@@ -327,6 +329,21 @@ func (m *Mock) parseRedrivePolicy(raw string) *driver.DeadLetterConfig {
 	}
 
 	return &driver.DeadLetterConfig{TargetQueueURL: url, MaxReceiveCount: int(maxReceive)}
+}
+
+// arnRegion returns the region field of an SQS ARN
+// (arn:aws:sqs:<region>:<account>:<name>), or fallback when the ARN is
+// malformed. The stored queue ARN is the source of truth for a queue's region,
+// so the ESM event region is derived from it rather than the configured default.
+func arnRegion(arn, fallback string) string {
+	const regionField, minFields = 3, 6
+
+	parts := strings.Split(arn, ":")
+	if len(parts) < minFields || parts[regionField] == "" {
+		return fallback
+	}
+
+	return parts[regionField]
 }
 
 // urlForARN returns the queue URL whose ARN matches, or "" if none.
@@ -519,7 +536,7 @@ func (m *Mock) deliverToESM(callerCtx context.Context, qd *queueData, msg *sqsMe
 		trial.ReceiveCount = trialCount
 		received := buildReceivedMessage(&trial, qd.visibilityTimeout, m.opts.Clock.Now())
 		arn := qd.info.ARN
-		region := m.opts.Region
+		region := arnRegion(arn, m.opts.Region)
 		qd.mu.Unlock()
 
 		payload := driver.BuildLambdaSQSEvent(arn, region, []driver.Message{received})

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -669,11 +669,40 @@ func New(d Drivers) *server.Server {
 		srv.SetObserver(func(r *http.Request) { recordManagementEvent(rec, r) })
 	}
 
-	// Opt-in SigV4 request authentication. Installed only when enabled, so the
-	// default request path is byte-for-byte unchanged.
+	// Region awareness always runs; SigV4 authentication is opt-in. Both are
+	// pre-dispatch concerns, so they are composed into one hook: the region
+	// stamper first rewrites the request context with the caller's region (from
+	// the SigV4 credential scope), then the auth gate — when enabled — runs on
+	// that rewritten request. The region stamper does not depend on auth being
+	// on, and adds no request-path change beyond a context value.
+	var authGate func(http.ResponseWriter, *http.Request) (*http.Request, bool)
 	if d.EnforceAuth {
-		srv.SetPreDispatch(newAuthGate(d.IAM, d.AccountID))
+		authGate = newAuthGate(d.IAM, d.AccountID)
 	}
 
+	srv.SetPreDispatch(composePreDispatch(newRegionStamp(), authGate))
+
 	return srv
+}
+
+// composePreDispatch chains pre-dispatch hooks left to right: each may rewrite
+// the request (the next hook sees the rewrite) and any may stop dispatch. Nil
+// hooks are skipped, so an absent auth gate adds nothing.
+func composePreDispatch(
+	hooks ...func(http.ResponseWriter, *http.Request) (*http.Request, bool),
+) func(http.ResponseWriter, *http.Request) (*http.Request, bool) {
+	return func(w http.ResponseWriter, r *http.Request) (*http.Request, bool) {
+		for _, hook := range hooks {
+			if hook == nil {
+				continue
+			}
+
+			var proceed bool
+			if r, proceed = hook(w, r); !proceed {
+				return r, false
+			}
+		}
+
+		return r, true
+	}
 }

--- a/server/aws/region_stamp.go
+++ b/server/aws/region_stamp.go
@@ -1,0 +1,25 @@
+package aws
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+)
+
+// newRegionStamp builds a pre-dispatch hook that reads the caller's region from
+// the SigV4 credential scope and stamps it on the request context, so backends
+// stamp resources and ARNs with the region the client addressed rather than the
+// emulator's fixed default. It always proceeds and never writes a response; an
+// unsigned request carries no region, leaving the context untouched so backends
+// fall back to their configured default (identical to the pre-change path).
+func newRegionStamp() func(http.ResponseWriter, *http.Request) (*http.Request, bool) {
+	return func(_ http.ResponseWriter, r *http.Request) (*http.Request, bool) {
+		region := awsquery.CredentialScopeRegion(r.Header.Get("Authorization"))
+		if region == "" {
+			return r, true
+		}
+
+		return r.WithContext(regionctx.WithRegion(r.Context(), region)), true
+	}
+}

--- a/server/wire/awsquery/awsquery.go
+++ b/server/wire/awsquery/awsquery.go
@@ -259,3 +259,27 @@ func CredentialScopeService(auth string) string {
 
 	return parts[serviceField]
 }
+
+// CredentialScopeRegion extracts the region from a SigV4 Authorization header's
+// credential scope: "Credential=AKID/20260101/<region>/service/aws4_request".
+// It returns "" when the header is absent or malformed, so callers fall back to
+// their configured default region rather than a stray field. The wire protocols
+// carry no region parameter, so the signature scope is the only statement of
+// which region the caller addressed.
+func CredentialScopeRegion(auth string) string {
+	i := strings.Index(auth, "Credential=")
+	if i < 0 {
+		return ""
+	}
+
+	parts := strings.Split(auth[i+len("Credential="):], "/")
+
+	// A well-formed credential scope is AKID/DATE/REGION/SERVICE/aws4_request —
+	// require all five so a truncated scope yields "" rather than a stray field.
+	const regionField, scopeFields = 2, 5
+	if len(parts) < scopeFields || parts[regionField] == "" {
+		return ""
+	}
+
+	return parts[regionField]
+}

--- a/server/wire/awsquery/awsquery_test.go
+++ b/server/wire/awsquery/awsquery_test.go
@@ -256,3 +256,29 @@ func TestCredentialScopeService(t *testing.T) {
 		})
 	}
 }
+
+func TestCredentialScopeRegion(t *testing.T) {
+	const realHeader = "AWS4-HMAC-SHA256 Credential=AKID/20260101/ap-northeast-1/sns/aws4_request, " +
+		"SignedHeaders=host;x-amz-date, Signature=abc123"
+
+	tests := map[string]struct {
+		auth string
+		want string
+	}{
+		"real tokyo header":   {realHeader, "ap-northeast-1"},
+		"us-west-2 scope":     {"AWS4-HMAC-SHA256 Credential=AKID/20260101/us-west-2/rds/aws4_request, Signature=x", "us-west-2"},
+		"service independent": {"Credential=AKID/20260101/eu-central-1/monitoring/aws4_request", "eu-central-1"},
+		"missing credential":  {"AWS4-HMAC-SHA256 SignedHeaders=host, Signature=x", ""},
+		"empty":               {"", ""},
+		"truncated scope":     {"Credential=AKID/20260101/us-east-1/sns", ""},
+		"empty region field":  {"Credential=AKID/20260101//sns/aws4_request", ""},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := awsquery.CredentialScopeRegion(tc.auth); got != tc.want {
+				t.Errorf("CredentialScopeRegion(%q) = %q, want %q", tc.auth, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

AWS resources were stamped with the fixed configured region (`opts.Region`, default `us-east-1`) regardless of the region the client actually used, so a client configured for `ap-northeast-1` got resources and ARNs stamped `us-east-1`. This makes CloudEmu region-aware: a regional resource's region/ARN now reflects the request's region.

## Mechanism

- **Region derivation** — the AWS query/REST wire protocols carry no region parameter, so the region is read from the SigV4 credential scope (`Credential=AKID/DATE/<REGION>/<SERVICE>/aws4_request`). Added `awsquery.CredentialScopeRegion(auth)`, mirroring the existing `CredentialScopeService`.
- **Context plumbing** — new `internal/regionctx` package (`WithRegion` / `RegionOr`), importable by both `server/aws/*` and `providers/aws/*` with no import cycle.
- **Single stamp point** — an always-on region-stamper pre-dispatch hook (`server/aws/region_stamp.go`) rewrites each request's context with the caller's region. It is composed with the opt-in auth gate via `composePreDispatch`, so it runs independently of `EnforceAuth`. Wire handlers already thread `r.Context()` into the drivers, so backends read the region back via `regionctx.RegionOr(ctx, m.opts.Region)`.
- **Store-at-create is the source of truth** — the region is stamped on the resource at create time, so a resource created in `ap-northeast-1` reads back as `ap-northeast-1` regardless of the read request's region. Child ARNs (executions, aliases, snapshots, nodegroups, …) derive their region from the parent's stored ARN, so a child always matches its parent.

## Regional services converted

ec2 (already), ecr, sqs, sns, lambda, dynamodb, kms, kinesis, sfn, ecs, eks, rds, elasticache, cloudwatchlogs.

## Intentionally left region-less (global services)

IAM (`arn:aws:iam::<account>:...`), Route 53, S3 bucket ARNs, STS/CloudFront — these are global or region-less by design and must not be stamped.

## Default / library path unchanged

When a request carries no region (unsigned request, or the typed Go API / library path with no HTTP request), `RegionOr` falls back to `opts.Region` exactly as before. `NewAWS()`'s default region is unchanged. No behavior change for library/typed-API callers.

## Tests

- `compat/aws/region_awareness_compat_test.go` — real aws-sdk-go-v2 clients configured for `ap-northeast-1` create a resource per regional service and assert its ARN / read-back shows `ap-northeast-1`; a `us-east-1` client still gets `us-east-1`; and IAM (global) stays region-less.
- Unit test for `CredentialScopeRegion`.
- Full `go build` / `go vet` / `go test ./...` green; `go generate` no diff; golangci-lint on touched packages introduces 0 new issues.

## Follow-up (not in this PR)

Remaining regional services still on the fixed default (acm, bedrock*, configservice, cloudtrail, cloudwatch, efs, elbv2, eventbridge, glue, guardduty, kafka, keyspaces, memorydb, networkfirewall, opensearch, redshift, route53resolver, s3 object/notification, sagemaker, secretsmanager, sesv2, ssm, vpc*, vpclattice, wafv2) — same mechanism applies; deferred to keep this PR reviewable.
