### PR TITLE
refactor(server): extract shared server/serverkit assembly from cmd/cloudemu serve

### DIFF
--- a/cmd/cloudemu/serve.go
+++ b/cmd/cloudemu/serve.go
@@ -2,45 +2,21 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
-	"net"
-	"net/http"
 	"os"
 	"os/signal"
-	"path/filepath"
-	"sort"
-	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
-	"github.com/stackshy/cloudemu/v2"
 	"github.com/stackshy/cloudemu/v2/config"
-	"github.com/stackshy/cloudemu/v2/features/topology"
-	"github.com/stackshy/cloudemu/v2/persist"
-	eksprov "github.com/stackshy/cloudemu/v2/providers/aws/eks"
-	"github.com/stackshy/cloudemu/v2/seed"
-	"github.com/stackshy/cloudemu/v2/server/admin"
-	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
-	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
-	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
-	ociserver "github.com/stackshy/cloudemu/v2/server/oci"
-	"github.com/stackshy/cloudemu/v2/services/kubernetes"
-	"github.com/stackshy/cloudemu/v2/services/pricing"
-	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
+	"github.com/stackshy/cloudemu/v2/server/serverkit"
 )
 
 // errStateFileRequired is returned when --persist is set without --state-file.
 var errStateFileRequired = errors.New("--persist requires --state-file")
-
-// errUnsupportedSnapshot is returned when a posted snapshot has an unknown
-// schema version.
-var errUnsupportedSnapshot = errors.New("unsupported snapshot schema version")
 
 // serveConfig holds the resolved serve flags.
 type serveConfig struct {
@@ -84,8 +60,8 @@ func (s *stringList) Set(v string) error {
 func runServe(args []string) error {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	var c serveConfig
-	// OCI is not started by default: it stays opt-in until its services land,
-	// so the default set never binds a port that serves nothing.
+	// OCI is not started by default: it stays opt-in until its services land, so
+	// the default set never binds a port that serves nothing.
 	fs.StringVar(&c.providers, "providers", "aws,azure,gcp", "comma-separated providers to start: aws,azure,gcp,oci")
 	fs.StringVar(&c.host, "host", "127.0.0.1", "host/interface to bind (use 0.0.0.0 to expose on the network)")
 	fs.StringVar(&c.advertiseHost, "advertise-host", "",
@@ -131,726 +107,58 @@ func runServe(args []string) error {
 	if (c.tlsCert == "") != (c.tlsKey == "") {
 		return errors.New("--tls-cert and --tls-key must be given together")
 	}
-
 	if c.persist && c.stateFile == "" {
 		return errStateFileRequired
 	}
-
-	// Resolve the host the Kubernetes data plane advertises to clients. The bind
-	// host isn't always reachable: under Docker the container binds 0.0.0.0 (all
-	// interfaces), but 0.0.0.0 is not a connectable address — a kubeconfig
-	// advertising https://0.0.0.0:4570 with a 0.0.0.0-only cert SAN can't be
-	// dialed or TLS-verified from the host. Advertise a routable host instead.
-	advertiseHost := advertiseHostFor(c.advertiseHost, c.host)
 
 	sel, err := parseProviders(c.providers)
 	if err != nil {
 		return err
 	}
 
-	opts := []config.Option{
-		config.WithAccountID(c.accountID),
-		config.WithRegion(c.region),
-		config.WithProjectID(c.projectID),
-	}
-	if c.latency > 0 {
-		opts = append(opts, config.WithLatency(c.latency))
-	}
-	if c.enforceAuth {
-		opts = append(opts, config.WithEnforceAuth())
-	}
-
-	var (
-		servers []*namedServer
-		eps     = endpointSet{}
-	)
-
-	// Each provider (and the shared Kubernetes data-plane) sits behind a
-	// hot-swappable backend. rebuild reconstructs a fresh Kubernetes server and
-	// every selected provider from scratch and swaps them in atomically — this
-	// is what /_cloudemu/reset calls to hand a test suite a clean slate without
-	// restarting the process.
-	backends := make(map[string]*admin.Backend, len(sel))
-	for _, p := range sel {
-		backends[p] = admin.NewBackend(nil)
-	}
-	var k8sBackend *admin.Backend
-	if c.k8sPort != "" {
-		k8sBackend = admin.NewBackend(nil)
-	}
-
-	var (
-		rebuildMu   sync.Mutex
-		targets     map[string]seed.Target               // provider → current drivers, for seeding + fixtures
-		snapTargets map[string]persist.Services          // provider → snapshottable services, for persist
-		netEngine   *topology.Engine                     // AWS network-reachability engine (nil if aws not selected)
-		discovery   map[string]*resourcediscovery.Engine // provider → inventory engine, for cost estimation
-	)
-	rebuild := func() {
-		// Serialise resets so two concurrent /_cloudemu/reset calls can't
-		// interleave and leave providers wired to different Kubernetes
-		// instances.
-		rebuildMu.Lock()
-		defer rebuildMu.Unlock()
-
-		// Build every fresh handler first, then swap them in. Building first
-		// means a construction panic leaves the running set untouched, and all
-		// providers in one reset share the single new Kubernetes data-plane
-		// (so a kubeconfig from any control plane reaches the same backend).
-		var k8s *kubernetes.APIServer
-		if k8sBackend != nil {
-			k8s = kubernetes.NewAPIServer()
-			// Tell the data plane the address it is reachable on, so the
-			// managed-Kubernetes control planes can advertise an endpoint that
-			// actually answers. Without this BaseURL() is "", every
-			// withK8sEndpoint bails, and DescribeCluster / GetCluster hand back
-			// the Wave 1 sentinel — which a real client-go tool cannot resolve.
-			//
-			// The data-plane listener binds c.host:c.k8sPort below; this must
-			// stay in step with it.
-			// https, because the listener below is served with a certificate
-			// signed by the CA DescribeCluster advertises. A caller building a
-			// rest.Config from Endpoint plus CertificateAuthority can then
-			// validate what it dials; over plain HTTP that CA certifies
-			// nothing and the handshake fails.
-			k8s.SetBaseURL("https://" + net.JoinHostPort(advertiseHost, c.k8sPort))
-		}
-		fresh := make(map[string]http.Handler, len(sel))
-		freshTargets := make(map[string]seed.Target, len(sel))
-		freshSnapTargets := make(map[string]persist.Services, len(sel))
-		freshDiscovery := make(map[string]*resourcediscovery.Engine, len(sel))
-
-		var freshEngine *topology.Engine
-
-		for _, p := range sel {
-			switch p {
-			case "aws":
-				cloud := cloudemu.NewAWS(opts...)
-				d := awsserver.DriversFrom(cloud)
-				d.K8sAPI = k8s
-				// Drivers.K8sAPI is only the server's PATH ROUTING for
-				// /k8s/{uid}/...; the control-plane mock keeps its own
-				// reference and needs it separately, or EKS still advertises
-				// the sentinel.
-				cloud.EKS.SetK8sAPI(k8s)
-				fresh["aws"] = wrap(awsserver.New(d), "aws", c.logReqs)
-				freshTargets["aws"] = seed.Target{Storage: cloud.S3, Database: cloud.DynamoDB, Secrets: cloud.SecretsManager, Compute: cloud.EC2}
-				freshSnapTargets["aws"] = cloud.SnapshotServices()
-				freshEngine = topology.New(cloud.EC2, cloud.VPC, cloud.Route53)
-				freshDiscovery["aws"] = cloud.ResourceDiscovery
-			case "gcp":
-				cloud := cloudemu.NewGCP(opts...)
-				d := gcpserver.DriversFrom(cloud)
-				d.K8sAPI = k8s
-				cloud.GKE.SetK8sAPI(k8s)
-				fresh["gcp"] = wrap(gcpserver.New(d), "gcp", c.logReqs)
-				freshTargets["gcp"] = seed.Target{Storage: cloud.GCS, Database: cloud.Firestore, Secrets: cloud.SecretManager, Compute: cloud.GCE}
-				freshSnapTargets["gcp"] = cloud.SnapshotServices()
-				freshDiscovery["gcp"] = cloud.ResourceDiscovery
-			case "azure":
-				// Azure subscriptions are GUIDs, unlike the 12-digit AWS
-				// account id. Give the Azure provider its own subscription so
-				// resource ids and Resource Graph scoping use a real Azure GUID
-				// (WithAccountID is last-wins). Copy opts so the override never
-				// leaks into another provider's option list.
-				azureOpts := make([]config.Option, len(opts), len(opts)+1)
-				copy(azureOpts, opts)
-				azureOpts = append(azureOpts, config.WithAccountID(c.azureSubscription))
-				cloud := cloudemu.NewAzure(azureOpts...)
-				d := azureserver.DriversFrom(cloud)
-				d.K8sAPI = k8s
-				cloud.AKS.SetK8sAPI(k8s)
-				fresh["azure"] = wrap(azureserver.New(d), "azure", c.logReqs)
-				freshTargets["azure"] = seed.Target{Storage: cloud.BlobStorage, Database: cloud.CosmosDB, Secrets: cloud.KeyVault, Compute: cloud.VirtualMachines}
-				freshSnapTargets["azure"] = cloud.SnapshotServices()
-				freshDiscovery["azure"] = cloud.ResourceDiscovery
-			case "oci":
-				cloud := cloudemu.NewOCI(opts...)
-				d := ociserver.DriversFrom(cloud)
-				d.K8sAPI = k8s
-				fresh["oci"] = wrap(ociserver.New(d), "oci", c.logReqs)
-				freshTargets["oci"] = seed.Target{
-					Storage: cloud.ObjectStorage, Database: cloud.NoSQL,
-					Secrets: cloud.Vault, Compute: cloud.Compute,
-				}
-				freshSnapTargets["oci"] = cloud.SnapshotServices()
-			}
-		}
-		if k8sBackend != nil {
-			k8sBackend.Swap(wrap(k8s, "kubernetes", c.logReqs))
-		}
-		for p, h := range fresh {
-			backends[p].Swap(h)
-		}
-		targets = freshTargets
-		snapTargets = freshSnapTargets
-		netEngine = freshEngine
-		discovery = freshDiscovery
-	}
-	rebuild() // populate the backends before serving
-
-	// Restore persisted state into the freshly-built providers before serving,
-	// so the first request already sees the resources from the last run.
-	if c.persist {
-		if err := restoreState(context.Background(), c.stateFile, snapTargets); err != nil {
-			return fmt.Errorf("restore persisted state: %w", err)
-		}
+	cfg := serverkit.Config{
+		Providers: sel,
+		Host:      c.host,
+		Ports: map[string]string{
+			"aws":   c.awsPort,
+			"azure": c.azurePort,
+			"gcp":   c.gcpPort,
+			"oci":   c.ociPort,
+		},
+		K8sPort:             c.k8sPort,
+		AdvertiseHost:       c.advertiseHost,
+		AzureSubscription:   c.azureSubscription,
+		Admin:               c.admin,
+		Persist:             c.persist,
+		StateFile:           c.stateFile,
+		PersistMetadataOnly: c.persistMetaOnly,
+		InitDir:             c.initDir,
+		TLSCert:             c.tlsCert,
+		TLSKey:              c.tlsKey,
+		TLSHosts:            c.tlsHosts,
+		Latency:             c.latency,
+		LogRequests:         c.logReqs,
+		Quiet:               c.quiet,
+		EnforceAuth:         c.enforceAuth,
+		EndpointsFile:       c.endpoints,
+		ShutdownTimeout:     c.shutdownTO,
+		BaseOptions: []config.Option{
+			config.WithAccountID(c.accountID),
+			config.WithRegion(c.region),
+			config.WithProjectID(c.projectID),
+		},
+		Out: os.Stdout,
 	}
 
-	// Apply init fixtures on top of the built (and possibly restored) providers,
-	// before serving, so the first request already sees the boot state.
-	if c.initDir != "" {
-		if err := applyInitDir(context.Background(), c.initDir, targets); err != nil {
-			return fmt.Errorf("apply init dir: %w", err)
-		}
-	}
-
-	// seedFor applies a fixture body to a provider's current drivers. It shares
-	// rebuildMu with reset so a seed and a reset can't run against each other's
-	// half-built state.
-	seedFor := func(provider string) func([]byte) (int, error) {
-		return func(fixture []byte) (int, error) {
-			f, err := seed.Load(fixture)
-			if err != nil {
-				return 0, err
-			}
-			// Read the current Target under the lock, but run Apply outside it:
-			// a large fixture (especially with --latency) must not hold the
-			// shared reset mutex for its whole duration.
-			rebuildMu.Lock()
-			t := targets[provider]
-			rebuildMu.Unlock()
-			if err := seed.Apply(context.Background(), f, t); err != nil {
-				return 0, err
-			}
-			return f.ResourceCount(), nil
-		}
-	}
-
-	// reset wipes all state, so warn if it's reachable off the loopback — e.g.
-	// a shared instance bound with --host 0.0.0.0, where anyone on the network
-	// could POST /_cloudemu/reset.
-	if c.admin && !isLoopbackHost(c.host) {
-		fmt.Fprintf(os.Stderr,
-			"warning: --admin control plane is reachable on non-loopback host %q — "+
-				"POST /_cloudemu/reset wipes all state, and GET /_cloudemu/snapshot dumps "+
-				"all emulated state (including secret values) to any caller; "+
-				"pass --admin=false to disable it\n",
-			c.host)
-	}
-
-	// snapshotFn/restoreFn back /_cloudemu/snapshot; both act on the whole
-	// emulator like reset. snapshot captures current state as JSON; restore
-	// rebuilds to empty then loads the posted state.
-	snapshotFn := func() ([]byte, error) {
-		rebuildMu.Lock()
-		cur := snapTargets
-		rebuildMu.Unlock()
-
-		snap, err := persist.ExportAll(context.Background(), cur, persist.Options{IncludeAssets: true})
-		if err != nil {
-			return nil, err
-		}
-
-		return json.MarshalIndent(snap, "", "  ")
-	}
-	restoreFn := func(body []byte) error {
-		var snap persist.Snapshot
-		if err := json.Unmarshal(body, &snap); err != nil {
-			return fmt.Errorf("parse snapshot: %w", err)
-		}
-
-		if snap.SchemaVersion != persist.SchemaVersion {
-			return fmt.Errorf("%w: got %d, want %d", errUnsupportedSnapshot, snap.SchemaVersion, persist.SchemaVersion)
-		}
-
-		// Destructive load (reset semantics): wipe to empty, then repopulate. If
-		// RestoreAll fails partway the running state is already gone — acceptable
-		// for a local emulator, but a future hardening is to restore into a
-		// staging build and swap it in only on success.
-		rebuild() // wipe to empty before loading
-
-		rebuildMu.Lock()
-		cur := snapTargets
-		rebuildMu.Unlock()
-
-		return persist.RestoreAll(context.Background(), &snap, cur)
-	}
-
-	// extraHandler serves the control-plane endpoints that plug into admin:
-	// network reachability (/net/*, AWS-only, needs the topology engine) and
-	// cost estimation (/cost, all providers, needs the discovery engines).
-	extraHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch strings.TrimPrefix(r.URL.Path, admin.Prefix) {
-		case "net/can-connect", "net/trace":
-			rebuildMu.Lock()
-			eng := netEngine
-			rebuildMu.Unlock()
-
-			if eng == nil {
-				writeNetErr(w, http.StatusServiceUnavailable, "network topology requires the aws provider")
-
-				return
-			}
-
-			if strings.HasSuffix(r.URL.Path, "trace") {
-				serveTrace(w, r, eng)
-			} else {
-				serveCanConnect(w, r, eng)
-			}
-		case "cost":
-			rebuildMu.Lock()
-			ds := discovery
-			rebuildMu.Unlock()
-
-			serveCost(w, r, ds)
-		default:
-			writeNetErr(w, http.StatusNotFound, "unknown control endpoint")
-		}
-	})
-
-	// handlerFor fronts a backend with the /_cloudemu control plane. With the
-	// admin API off the backend serves directly, so control paths fall through
-	// to the wire handlers (whatever they return for an unrouted path). seedFn
-	// may be nil (e.g. the Kubernetes port), which disables the seed endpoint.
-	handlerFor := func(b *admin.Backend, seedFn func([]byte) (int, error)) http.Handler {
-		if c.admin {
-			return admin.NewControl(b, rebuild, seedFn, snapshotFn, restoreFn, extraHandler)
-		}
-		return b
-	}
-
-	for _, p := range sel {
-		var (
-			addr   string
-			tlsCfg *tls.Config
-			isTLS  bool
-		)
-		switch p {
-		case "aws":
-			addr = net.JoinHostPort(c.host, c.awsPort)
-			eps.AWS = fmt.Sprintf("http://%s", addr)
-		case "gcp":
-			addr = net.JoinHostPort(c.host, c.gcpPort)
-			eps.GCP = fmt.Sprintf("http://%s", addr)
-		case "oci":
-			addr = net.JoinHostPort(c.host, c.ociPort)
-			eps.OCI = fmt.Sprintf("http://%s", addr)
-		case "azure":
-			addr = net.JoinHostPort(c.host, c.azurePort)
-			var err error
-			if tlsCfg, err = tlsConfig(c, addr); err != nil {
-				return fmt.Errorf("azure TLS: %w", err)
-			}
-			isTLS = true
-			eps.Azure = fmt.Sprintf("https://%s", addr)
-		}
-		servers = append(servers, &namedServer{
-			name: p,
-			srv:  &http.Server{Addr: addr, Handler: handlerFor(backends[p], seedFor(p)), TLSConfig: tlsCfg},
-			tls:  isTLS,
-		})
-	}
-
-	if k8sBackend != nil {
-		addr := net.JoinHostPort(c.host, c.k8sPort)
-
-		// The cert must certify the advertised host (what clients dial), plus the
-		// loopback names, plus any extra --tls-host SANs.
-		k8sTLS, err := eksprov.ServingTLSConfig(k8sCertHosts(advertiseHost, c.tlsHosts))
-		if err != nil {
-			return fmt.Errorf("kubernetes data-plane TLS: %w", err)
-		}
-
-		servers = append(servers, &namedServer{
-			name: "kubernetes",
-			srv:  &http.Server{Addr: addr, Handler: handlerFor(k8sBackend, nil), TLSConfig: k8sTLS},
-			tls:  true,
-		})
-		// Show the reachable (advertised) endpoint, not the bind address — the
-		// listener binds `addr` (may be 0.0.0.0) but clients dial advertiseHost.
-		eps.Kubernetes = fmt.Sprintf("https://%s", net.JoinHostPort(advertiseHost, c.k8sPort))
-	}
-
-	// Bind every listener before serving so a port clash fails fast, before
-	// we print a banner promising endpoints that never came up.
-	listeners := make([]net.Listener, len(servers))
-	for i, s := range servers {
-		ln, err := net.Listen("tcp", s.srv.Addr)
-		if err != nil {
-			for _, l := range listeners[:i] {
-				l.Close()
-			}
-			return fmt.Errorf("bind %s (%s): %w", s.name, s.srv.Addr, err)
-		}
-		listeners[i] = ln
-	}
-
-	errCh := make(chan error, len(servers))
-	for i, s := range servers {
-		s := s
-		ln := listeners[i]
-		go func() {
-			var err error
-			if s.tls {
-				err = s.srv.ServeTLS(ln, "", "")
-			} else {
-				err = s.srv.Serve(ln)
-			}
-			if err != nil && !errors.Is(err, http.ErrServerClosed) {
-				errCh <- fmt.Errorf("%s: %w", s.name, err)
-			}
-		}()
-	}
-
-	if !c.quiet {
-		printBanner(os.Stdout, &eps, c.admin)
-	}
-	if c.endpoints != "" {
-		if err := eps.writeFile(c.endpoints); err != nil {
-			return fmt.Errorf("write endpoints file: %w", err)
-		}
-	}
-
-	// Block until a signal or a fatal serve error.
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	select {
-	case err := <-errCh:
-		return err
-	case <-sigCh:
-		if !c.quiet {
-			fmt.Fprintln(os.Stdout, "\nshutting down…")
-		}
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), c.shutdownTO)
-	defer cancel()
-	var shutErr error
-	for _, s := range servers {
-		if err := s.srv.Shutdown(ctx); err != nil && shutErr == nil {
-			shutErr = err
-		}
-	}
-
-	// Snapshot after Shutdown so no in-flight request can mutate state mid-read.
-	if c.persist {
-		if err := snapshotState(context.Background(), c.stateFile, !c.persistMetaOnly, snapTargets); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: failed to save state to %s: %v\n", c.stateFile, err)
-		} else if !c.quiet {
-			fmt.Fprintf(os.Stdout, "state saved to %s\n", c.stateFile)
-		}
-	}
-
-	return shutErr
-}
-
-// restoreState loads the snapshot at path (if any) into the freshly-built
-// providers. A missing file is not an error — the server just starts empty,
-// exactly as it does without --persist. Providers present in the snapshot but
-// not running now are skipped.
-func restoreState(ctx context.Context, path string, targets map[string]persist.Services) error {
-	snap, err := persist.ReadFile(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil // first run — nothing to restore
-		}
-
-		// A corrupt / truncated / unknown-schema snapshot must not wedge startup
-		// on the very stop→start path this feature serves: warn and start empty
-		// rather than aborting.
-		fmt.Fprintf(os.Stderr, "warning: ignoring unreadable state file %s: %v\n", path, err)
-
-		return nil
-	}
-
-	return persist.RestoreAll(ctx, &snap, targets)
-}
-
-// costLine is one always-on resource with its estimated monthly cost.
-type costLine struct {
-	Provider   string  `json:"provider"`
-	Service    string  `json:"service"`
-	Type       string  `json:"type"`
-	ID         string  `json:"id"`
-	MonthlyUSD float64 `json:"monthlyUsd"`
-}
-
-// serveCost answers GET /_cloudemu/cost with an estimated monthly cost of the
-// current inventory (always-on resources only; usage-based services excluded).
-func serveCost(w http.ResponseWriter, r *http.Request, engines map[string]*resourcediscovery.Engine) {
-	var (
-		lines     []costLine
-		total     float64
-		byService = map[string]float64{}
-	)
-
-	for prov, eng := range engines {
-		if eng == nil {
-			continue
-		}
-
-		res, err := eng.ListAll(r.Context())
-		if err != nil {
-			writeNetErr(w, http.StatusInternalServerError, err.Error())
-
-			return
-		}
-
-		for i := range res {
-			rr := &res[i]
-
-			est := pricing.Monthly(rr.Provider, rr.Service, rr.Type, rr.SKU, rr.Region, rr.Properties)
-			if est <= 0 {
-				continue
-			}
-
-			lines = append(lines, costLine{Provider: prov, Service: rr.Service, Type: rr.Type, ID: rr.ID, MonthlyUSD: est})
-			total += est
-			byService[prov+"/"+rr.Service] += est
-		}
-	}
-
-	writeNetJSON(w, map[string]any{
-		"estimatedMonthlyUsd": total,
-		"byService":           byService,
-		"resources":           lines,
-	})
-}
-
-// serveCanConnect answers GET /_cloudemu/net/can-connect?from&to&port&protocol
-// with the engine's ConnectivityResult as JSON.
-func serveCanConnect(w http.ResponseWriter, r *http.Request, eng *topology.Engine) {
-	q := r.URL.Query()
-
-	from, to := q.Get("from"), q.Get("to")
-	if from == "" || to == "" {
-		writeNetErr(w, http.StatusBadRequest, "from and to instance IDs are required")
-
-		return
-	}
-
-	port, err := netPort(q.Get("port"))
-	if err != nil {
-		writeNetErr(w, http.StatusBadRequest, err.Error())
-
-		return
-	}
-
-	proto := q.Get("protocol")
-	if proto == "" {
-		proto = "tcp"
-	}
-
-	res, err := eng.CanConnect(r.Context(), topology.ConnectivityQuery{
-		SrcInstanceID: from, DstInstanceID: to, Port: port, Protocol: proto,
-	})
-	if err != nil {
-		writeNetErr(w, http.StatusBadRequest, err.Error())
-
-		return
-	}
-
-	writeNetJSON(w, res)
-}
-
-// serveTrace answers GET /_cloudemu/net/trace?from&to (to is a destination IP)
-// with the route hops as JSON.
-func serveTrace(w http.ResponseWriter, r *http.Request, eng *topology.Engine) {
-	q := r.URL.Query()
-
-	from, dest := q.Get("from"), q.Get("to")
-	if from == "" || dest == "" {
-		writeNetErr(w, http.StatusBadRequest, "from instance ID and to IP are required")
-
-		return
-	}
-
-	hops, err := eng.TraceRoute(r.Context(), from, dest)
-	if err != nil {
-		writeNetErr(w, http.StatusBadRequest, err.Error())
-
-		return
-	}
-
-	writeNetJSON(w, map[string]any{"hops": hops})
-}
-
-// netPort parses an optional port query value (empty → 0 = any).
-func netPort(s string) (int, error) {
-	if s == "" {
-		return 0, nil
-	}
-
-	n, err := strconv.Atoi(s)
-	if err != nil {
-		return 0, fmt.Errorf("invalid port %q: %w", s, err)
-	}
-
-	return n, nil
-}
-
-func writeNetJSON(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/json")
-
-	b, err := json.Marshal(v)
-	if err != nil {
-		writeNetErr(w, http.StatusInternalServerError, err.Error())
-
-		return
-	}
-
-	_, _ = w.Write(b)
-}
-
-func writeNetErr(w http.ResponseWriter, status int, msg string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
-}
-
-// applyInitDir applies every *.json fixture in dir (lexical order) to every
-// running provider on boot, bringing the emulator up to a known state. A
-// missing dir is a no-op. A parse error fails startup (clear misconfiguration);
-// an apply error only warns and continues, so a fixture that collides with
-// already-restored state can't wedge the boot.
-func applyInitDir(ctx context.Context, dir string, targets map[string]seed.Target) error {
-	entries, err := os.ReadDir(dir)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-
+	app, err := serverkit.New(&cfg)
 	if err != nil {
 		return err
 	}
 
-	names := make([]string, 0, len(entries))
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") {
-			names = append(names, e.Name())
-		}
-	}
-
-	sort.Strings(names)
-
-	for _, name := range names {
-		if err := applyInitFile(ctx, filepath.Join(dir, name), name, targets); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// applyInitFile loads one fixture file and applies it to every provider. A load
-// (parse) error is returned; per-provider apply errors are warned and skipped.
-func applyInitFile(ctx context.Context, path, name string, targets map[string]seed.Target) error {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
-
-	f, err := seed.Load(data)
-	if err != nil {
-		return fmt.Errorf("init fixture %s: %w", name, err)
-	}
-
-	for prov, t := range targets {
-		// IgnoreExisting so a resource that already exists (from restored state or
-		// an earlier init file) is skipped rather than aborting the rest of the
-		// fixture; other errors still warn.
-		if err := seed.Apply(ctx, f, t, seed.IgnoreExisting()); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: init %s on %s: %v\n", name, prov, err)
-		}
-	}
-
-	return nil
-}
-
-// snapshotState exports every running provider's state and writes the snapshot
-// file. Called after Shutdown, so the providers are quiescent.
-func snapshotState(ctx context.Context, path string, includeAssets bool, targets map[string]persist.Services) error {
-	snap, err := persist.ExportAll(ctx, targets, persist.Options{IncludeAssets: includeAssets})
-	if err != nil {
-		return err
-	}
-
-	return snap.WriteFile(path)
-}
-
-type namedServer struct {
-	name string
-	srv  *http.Server
-	tls  bool
-}
-
-// isLoopbackHost reports whether binding to h keeps the server local-only.
-// loopbackIPv4 is advertised for the Kubernetes data plane when the server binds
-// all interfaces (a published -p 4570:4570 maps to it from the host).
-const loopbackIPv4 = "127.0.0.1"
-
-// advertiseHostFor resolves the host the Kubernetes data plane advertises to
-// clients: an explicit --advertise-host wins; otherwise the bind host, unless
-// that binds all interfaces (0.0.0.0 / :: / empty — e.g. Docker), in which case
-// loopback.
-func advertiseHostFor(advertiseHost, bindHost string) string {
-	if advertiseHost != "" {
-		return advertiseHost
-	}
-
-	if isAllInterfaces(bindHost) {
-		return loopbackIPv4
-	}
-
-	return bindHost
-}
-
-// isAllInterfaces reports whether h is a bind-all address (not connectable).
-func isAllInterfaces(h string) bool {
-	switch h {
-	case "", "0.0.0.0", "::", "[::]":
-		return true
-	}
-
-	if ip := net.ParseIP(h); ip != nil {
-		return ip.IsUnspecified()
-	}
-
-	return false
-}
-
-// k8sCertHosts is the SAN set for the Kubernetes serving cert: the advertised
-// host (what clients dial and verify), the loopback names, and any extra
-// --tls-host entries, de-duplicated.
-func k8sCertHosts(advertiseHost string, extra stringList) []string {
-	base := []string{advertiseHost, "localhost", loopbackIPv4}
-
-	seen := map[string]bool{}
-	out := make([]string, 0, len(base)+len(extra))
-
-	for _, h := range append(base, extra...) {
-		if h == "" || seen[h] {
-			continue
-		}
-
-		seen[h] = true
-
-		out = append(out, h)
-	}
-
-	return out
-}
-
-func isLoopbackHost(h string) bool {
-	switch h {
-	case "127.0.0.1", "::1", "localhost":
-		return true
-	}
-	if ip := net.ParseIP(h); ip != nil {
-		return ip.IsLoopback()
-	}
-	return false
+	return app.Serve(ctx)
 }
 
 func parseProviders(s string) ([]string, error) {

--- a/server/serverkit/advertise.go
+++ b/server/serverkit/advertise.go
@@ -1,0 +1,76 @@
+package serverkit
+
+import "net"
+
+// loopbackIPv4 is advertised for the Kubernetes data plane when the server binds
+// all interfaces (a published -p 4570:4570 maps to it from the host).
+const loopbackIPv4 = "127.0.0.1"
+
+// advertiseHostFor resolves the host the Kubernetes data plane advertises to
+// clients: an explicit advertise host wins; otherwise the bind host, unless that
+// binds all interfaces (0.0.0.0 / :: / empty — e.g. Docker), in which case
+// loopback. The bind host isn't always reachable: under Docker the container
+// binds 0.0.0.0, but 0.0.0.0 is not a connectable address — a kubeconfig
+// advertising https://0.0.0.0:4570 with a 0.0.0.0-only cert SAN can't be dialed
+// or TLS-verified from the host.
+func advertiseHostFor(advertiseHost, bindHost string) string {
+	if advertiseHost != "" {
+		return advertiseHost
+	}
+
+	if isAllInterfaces(bindHost) {
+		return loopbackIPv4
+	}
+
+	return bindHost
+}
+
+// isAllInterfaces reports whether h is a bind-all address (not connectable).
+func isAllInterfaces(h string) bool {
+	switch h {
+	case "", "0.0.0.0", "::", "[::]":
+		return true
+	}
+
+	if ip := net.ParseIP(h); ip != nil {
+		return ip.IsUnspecified()
+	}
+
+	return false
+}
+
+// isLoopbackHost reports whether binding to h keeps the server local-only.
+func isLoopbackHost(h string) bool {
+	switch h {
+	case "127.0.0.1", "::1", "localhost":
+		return true
+	}
+
+	if ip := net.ParseIP(h); ip != nil {
+		return ip.IsLoopback()
+	}
+
+	return false
+}
+
+// k8sCertHosts is the SAN set for the Kubernetes serving cert: the advertised
+// host (what clients dial and verify), the loopback names, and any extra
+// --tls-host entries, de-duplicated.
+func k8sCertHosts(advertiseHost string, extra []string) []string {
+	base := []string{advertiseHost, "localhost", loopbackIPv4}
+
+	seen := map[string]bool{}
+	out := make([]string, 0, len(base)+len(extra))
+
+	for _, h := range append(base, extra...) {
+		if h == "" || seen[h] {
+			continue
+		}
+
+		seen[h] = true
+
+		out = append(out, h)
+	}
+
+	return out
+}

--- a/server/serverkit/advertise_test.go
+++ b/server/serverkit/advertise_test.go
@@ -1,4 +1,4 @@
-package main
+package serverkit
 
 import (
 	"reflect"
@@ -40,7 +40,7 @@ func TestK8sCertHosts(t *testing.T) {
 		t.Fatalf("loopback advertise: got %v, want [127.0.0.1 localhost] (deduped)", got)
 	}
 
-	got := k8sCertHosts("k8s.local", stringList{"192.168.1.5", "k8s.local"})
+	got := k8sCertHosts("k8s.local", []string{"192.168.1.5", "k8s.local"})
 	want := []string{"k8s.local", "localhost", "127.0.0.1", "192.168.1.5"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("custom advertise + extras: got %v, want %v", got, want)

--- a/server/serverkit/cost.go
+++ b/server/serverkit/cost.go
@@ -1,0 +1,59 @@
+package serverkit
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/services/pricing"
+	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
+)
+
+// costLine is one always-on resource with its estimated monthly cost.
+type costLine struct {
+	Provider   string  `json:"provider"`
+	Service    string  `json:"service"`
+	Type       string  `json:"type"`
+	ID         string  `json:"id"`
+	MonthlyUSD float64 `json:"monthlyUsd"`
+}
+
+// serveCost answers GET /_cloudemu/cost with an estimated monthly cost of the
+// current inventory (always-on resources only; usage-based services excluded).
+func serveCost(w http.ResponseWriter, r *http.Request, engines map[string]*resourcediscovery.Engine) {
+	var (
+		lines     []costLine
+		total     float64
+		byService = map[string]float64{}
+	)
+
+	for prov, eng := range engines {
+		if eng == nil {
+			continue
+		}
+
+		res, err := eng.ListAll(r.Context())
+		if err != nil {
+			writeNetErr(w, http.StatusInternalServerError, err.Error())
+
+			return
+		}
+
+		for i := range res {
+			rr := &res[i]
+
+			est := pricing.Monthly(rr.Provider, rr.Service, rr.Type, rr.SKU, rr.Region, rr.Properties)
+			if est <= 0 {
+				continue
+			}
+
+			lines = append(lines, costLine{Provider: prov, Service: rr.Service, Type: rr.Type, ID: rr.ID, MonthlyUSD: est})
+			total += est
+			byService[prov+"/"+rr.Service] += est
+		}
+	}
+
+	writeNetJSON(w, map[string]any{
+		"estimatedMonthlyUsd": total,
+		"byService":           byService,
+		"resources":           lines,
+	})
+}

--- a/server/serverkit/cost_serve_test.go
+++ b/server/serverkit/cost_serve_test.go
@@ -1,4 +1,4 @@
-package main
+package serverkit
 
 import (
 	"context"

--- a/server/serverkit/endpoints.go
+++ b/server/serverkit/endpoints.go
@@ -1,4 +1,4 @@
-package main
+package serverkit
 
 import (
 	"encoding/json"
@@ -6,6 +6,10 @@ import (
 	"io"
 	"os"
 )
+
+// endpointsFileMode is the permission for the written endpoints file: a
+// non-secret local convenience, readable by other tooling run as the same user.
+const endpointsFileMode = 0o644
 
 // endpointSet is the machine-readable bundle of URLs a client points at. Empty
 // fields (a provider that wasn't started) are omitted from the JSON.
@@ -22,11 +26,12 @@ func (e *endpointSet) writeFile(path string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, append(b, '\n'), 0o644)
+
+	return os.WriteFile(path, append(b, '\n'), endpointsFileMode)
 }
 
-// banner lists the endpoints in display order, so adding a provider is one
-// row rather than another branch in printBanner.
+// banner lists the endpoints in display order, so adding a provider is one row
+// rather than another branch in printBanner.
 func (e *endpointSet) banner() []struct{ label, url, note string } {
 	return []struct{ label, url, note string }{
 		{"AWS", e.AWS, ""},

--- a/server/serverkit/init.go
+++ b/server/serverkit/init.go
@@ -1,0 +1,72 @@
+package serverkit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/seed"
+)
+
+// applyInitDir applies every *.json fixture in dir (lexical order) to every
+// running provider on boot, bringing the emulator up to a known state. A missing
+// dir is a no-op. A parse error fails startup (clear misconfiguration); an apply
+// error only warns and continues, so a fixture that collides with
+// already-restored state can't wedge the boot.
+func applyInitDir(ctx context.Context, dir string, targets map[string]seed.Target) error {
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	names := make([]string, 0, len(entries))
+
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") {
+			names = append(names, e.Name())
+		}
+	}
+
+	sort.Strings(names)
+
+	for _, name := range names {
+		if err := applyInitFile(ctx, filepath.Join(dir, name), name, targets); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// applyInitFile loads one fixture file and applies it to every provider. A load
+// (parse) error is returned; per-provider apply errors are warned and skipped.
+func applyInitFile(ctx context.Context, path, name string, targets map[string]seed.Target) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	f, err := seed.Load(data)
+	if err != nil {
+		return fmt.Errorf("init fixture %s: %w", name, err)
+	}
+
+	for prov, t := range targets {
+		// IgnoreExisting so a resource that already exists (from restored state or
+		// an earlier init file) is skipped rather than aborting the rest of the
+		// fixture; other errors still warn.
+		if err := seed.Apply(ctx, f, t, seed.IgnoreExisting()); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: init %s on %s: %v\n", name, prov, err)
+		}
+	}
+
+	return nil
+}

--- a/server/serverkit/init_test.go
+++ b/server/serverkit/init_test.go
@@ -1,4 +1,4 @@
-package main
+package serverkit
 
 import (
 	"context"

--- a/server/serverkit/middleware.go
+++ b/server/serverkit/middleware.go
@@ -1,4 +1,4 @@
-package main
+package serverkit
 
 import (
 	"log"
@@ -7,22 +7,26 @@ import (
 )
 
 // wrap optionally decorates a provider handler with request logging. When
-// logging is off it returns the handler unchanged, so there is zero overhead
-// on the hot path.
+// logging is off it returns the handler unchanged, so there is zero overhead on
+// the hot path.
 func wrap(h http.Handler, provider string, logReqs bool) http.Handler {
 	if !logReqs {
 		return h
 	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		sw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
 		h.ServeHTTP(sw, r)
+		// The request method/path are the intended content of a local dev access
+		// log, not an untrusted sink — this is opt-in via --log-requests.
+		//nolint:gosec // G706: local dev request log of the request line
 		log.Printf("[%s] %s %s → %d (%s)", provider, r.Method, r.URL.Path, sw.status, time.Since(start).Round(time.Microsecond))
 	})
 }
 
-// statusWriter captures the first response status for logging while remaining
-// a transparent http.ResponseWriter. Write is not overridden — it promotes from
+// statusWriter captures the first response status for logging while remaining a
+// transparent http.ResponseWriter. Write is not overridden — it promotes from
 // the embedded writer, so a handler that writes a body without an explicit
 // WriteHeader is logged as the default 200.
 type statusWriter struct {
@@ -36,5 +40,6 @@ func (w *statusWriter) WriteHeader(code int) {
 		w.status = code
 		w.wroteHeader = true
 	}
+
 	w.ResponseWriter.WriteHeader(code)
 }

--- a/server/serverkit/net.go
+++ b/server/serverkit/net.go
@@ -1,0 +1,101 @@
+package serverkit
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/features/topology"
+)
+
+// serveCanConnect answers GET /_cloudemu/net/can-connect?from&to&port&protocol
+// with the engine's ConnectivityResult as JSON.
+func serveCanConnect(w http.ResponseWriter, r *http.Request, eng *topology.Engine) {
+	q := r.URL.Query()
+
+	from, to := q.Get("from"), q.Get("to")
+	if from == "" || to == "" {
+		writeNetErr(w, http.StatusBadRequest, "from and to instance IDs are required")
+
+		return
+	}
+
+	port, err := netPort(q.Get("port"))
+	if err != nil {
+		writeNetErr(w, http.StatusBadRequest, err.Error())
+
+		return
+	}
+
+	proto := q.Get("protocol")
+	if proto == "" {
+		proto = "tcp"
+	}
+
+	res, err := eng.CanConnect(r.Context(), topology.ConnectivityQuery{
+		SrcInstanceID: from, DstInstanceID: to, Port: port, Protocol: proto,
+	})
+	if err != nil {
+		writeNetErr(w, http.StatusBadRequest, err.Error())
+
+		return
+	}
+
+	writeNetJSON(w, res)
+}
+
+// serveTrace answers GET /_cloudemu/net/trace?from&to (to is a destination IP)
+// with the route hops as JSON.
+func serveTrace(w http.ResponseWriter, r *http.Request, eng *topology.Engine) {
+	q := r.URL.Query()
+
+	from, dest := q.Get("from"), q.Get("to")
+	if from == "" || dest == "" {
+		writeNetErr(w, http.StatusBadRequest, "from instance ID and to IP are required")
+
+		return
+	}
+
+	hops, err := eng.TraceRoute(r.Context(), from, dest)
+	if err != nil {
+		writeNetErr(w, http.StatusBadRequest, err.Error())
+
+		return
+	}
+
+	writeNetJSON(w, map[string]any{"hops": hops})
+}
+
+// netPort parses an optional port query value (empty → 0 = any).
+func netPort(s string) (int, error) {
+	if s == "" {
+		return 0, nil
+	}
+
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid port %q: %w", s, err)
+	}
+
+	return n, nil
+}
+
+func writeNetJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		writeNetErr(w, http.StatusInternalServerError, err.Error())
+
+		return
+	}
+
+	_, _ = w.Write(b)
+}
+
+func writeNetErr(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/server/serverkit/net_serve_test.go
+++ b/server/serverkit/net_serve_test.go
@@ -1,4 +1,4 @@
-package main
+package serverkit
 
 import (
 	"net/http"

--- a/server/serverkit/persist.go
+++ b/server/serverkit/persist.go
@@ -1,0 +1,43 @@
+package serverkit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/stackshy/cloudemu/v2/persist"
+)
+
+// restoreState loads the snapshot at path (if any) into the freshly-built
+// providers. A missing file is not an error — the server just starts empty,
+// exactly as it does without --persist. Providers present in the snapshot but
+// not running now are skipped.
+func restoreState(ctx context.Context, path string, targets map[string]persist.Services) error {
+	snap, err := persist.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil // first run — nothing to restore
+		}
+
+		// A corrupt / truncated / unknown-schema snapshot must not wedge startup
+		// on the very stop→start path this feature serves: warn and start empty
+		// rather than aborting.
+		fmt.Fprintf(os.Stderr, "warning: ignoring unreadable state file %s: %v\n", path, err)
+
+		return nil
+	}
+
+	return persist.RestoreAll(ctx, &snap, targets)
+}
+
+// snapshotState exports every running provider's state and writes the snapshot
+// file. Called after Shutdown, so the providers are quiescent.
+func snapshotState(ctx context.Context, path string, includeAssets bool, targets map[string]persist.Services) error {
+	snap, err := persist.ExportAll(ctx, targets, persist.Options{IncludeAssets: includeAssets})
+	if err != nil {
+		return err
+	}
+
+	return snap.WriteFile(path)
+}

--- a/server/serverkit/persist_serve_test.go
+++ b/server/serverkit/persist_serve_test.go
@@ -1,4 +1,4 @@
-package main
+package serverkit
 
 import (
 	"context"
@@ -9,9 +9,9 @@ import (
 	"github.com/stackshy/cloudemu/v2/persist"
 )
 
-// TestRestoreStateIgnoresUnreadableFile covers M1's fail-open half: a corrupt or
+// TestRestoreStateIgnoresUnreadableFile covers the fail-open half: a corrupt or
 // missing snapshot must not wedge startup — restoreState warns and starts empty
-// rather than returning an error that aborts runServe.
+// rather than returning an error that aborts New.
 func TestRestoreStateIgnoresUnreadableFile(t *testing.T) {
 	dir := t.TempDir()
 

--- a/server/serverkit/serverkit.go
+++ b/server/serverkit/serverkit.go
@@ -3,9 +3,9 @@
 // It builds every selected provider, fronts each with the /_cloudemu admin
 // control plane, wires the shared Kubernetes data-plane, persistence, seeding,
 // and TLS, binds the listeners, and owns the serve/shutdown/snapshot lifecycle.
-// It is the single source of truth consumed by both cmd/cloudemu/serve.go and
-// the batteries-included contrib/server — extracting it keeps their behavior
-// from drifting.
+// It is the source of truth for cmd/cloudemu/serve.go, and the seam the
+// batteries-included contrib/server adopts in a follow-up so the two
+// entrypoints don't drift.
 //
 // Beyond moving serve's proven assembly, serverkit adds one capability the old
 // inline code lacked: it tracks the current live *Provider set and Close()es the

--- a/server/serverkit/serverkit.go
+++ b/server/serverkit/serverkit.go
@@ -1,0 +1,729 @@
+// Package serverkit is the shared assembly layer for the standalone emulator.
+//
+// It builds every selected provider, fronts each with the /_cloudemu admin
+// control plane, wires the shared Kubernetes data-plane, persistence, seeding,
+// and TLS, binds the listeners, and owns the serve/shutdown/snapshot lifecycle.
+// It is the single source of truth consumed by both cmd/cloudemu/serve.go and
+// the batteries-included contrib/server — extracting it keeps their behavior
+// from drifting.
+//
+// Beyond moving serve's proven assembly, serverkit adds one capability the old
+// inline code lacked: it tracks the current live *Provider set and Close()es the
+// outgoing providers after every rebuild swap (reset/restore) and on final
+// shutdown after the snapshot, so real data-plane engines (embedded Postgres,
+// miniredis, Docker containers) are torn down rather than leaked. For the
+// engineless in-process providers cmd/cloudemu builds, Close is a no-op.
+package serverkit
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/features/topology"
+	"github.com/stackshy/cloudemu/v2/persist"
+	eksprov "github.com/stackshy/cloudemu/v2/providers/aws/eks"
+	"github.com/stackshy/cloudemu/v2/seed"
+	"github.com/stackshy/cloudemu/v2/server/admin"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+	ociserver "github.com/stackshy/cloudemu/v2/server/oci"
+	"github.com/stackshy/cloudemu/v2/services/kubernetes"
+	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
+)
+
+// errUnsupportedSnapshot is returned when a posted snapshot has an unknown
+// schema version.
+var errUnsupportedSnapshot = errors.New("unsupported snapshot schema version")
+
+// defaultShutdownTimeout is the grace period applied when Config leaves
+// ShutdownTimeout unset.
+const defaultShutdownTimeout = 10 * time.Second
+
+// serverReadHeaderTimeout bounds how long a client may take to send request
+// headers, closing the Slowloris hole a zero timeout leaves open.
+const serverReadHeaderTimeout = 10 * time.Second
+
+// Provider names, shared by the build and bind switches.
+const (
+	providerAWS   = "aws"
+	providerAzure = "azure"
+	providerGCP   = "gcp"
+	providerOCI   = "oci"
+)
+
+// closer is the Close() surface of a *Provider, cascaded across rebuild swaps
+// and on shutdown to free the real engines (embedded Postgres, miniredis, Docker
+// containers) it wired. Close is idempotent and a no-op for engineless
+// providers, so tracking it is safe for cmd/cloudemu and correct for contrib.
+type closer interface{ Close() error }
+
+// Config is the flat data seam serverkit assembles a server from. Both
+// entrypoints fill it: cmd/cloudemu from its serve flags, contrib/server from
+// its engine flags. It carries no behavior.
+type Config struct {
+	Providers []string // selected providers, already parsed: aws,azure,gcp,oci
+
+	Host          string            // host/interface to bind
+	Ports         map[string]string // per-provider bind ports, keys aws/azure/gcp/oci (and optionally k8s)
+	K8sPort       string            // shared Kubernetes data-plane port; empty disables it
+	AdvertiseHost string            // host the Kubernetes endpoint is advertised at (default: derived from Host)
+
+	AzureSubscription string // Azure subscription GUID reported by the emulator (last-wins WithAccountID)
+
+	Admin bool // mount the /_cloudemu control plane
+
+	Persist             bool   // save/restore state around the process lifetime
+	StateFile           string // path to the JSON state snapshot
+	PersistMetadataOnly bool   // omit object bodies from the snapshot
+	InitDir             string // apply every *.json fixture in this dir on boot
+
+	TLSCert  string   // PEM cert for the Azure HTTPS endpoint (empty: self-signed)
+	TLSKey   string   // PEM key matching TLSCert
+	TLSHosts []string // extra SAN hosts for the generated self-signed cert
+
+	Latency     time.Duration // artificial latency added to every emulated call
+	LogRequests bool          // log every HTTP request
+	Quiet       bool          // suppress the startup banner
+	EnforceAuth bool          // require authentication on each request
+
+	EndpointsFile   string        // write resolved endpoints as JSON here
+	ShutdownTimeout time.Duration // grace period for in-flight requests on shutdown
+
+	BaseOptions []config.Option // identity + (for contrib) engine options every provider is built with
+	Out         io.Writer       // banner/diagnostics sink (default: os.Stdout)
+}
+
+// App is a fully-wired, not-yet-serving emulator. New builds and populates the
+// backends; Serve binds the listeners and runs until the context is canceled.
+type App struct {
+	cfg Config
+	out io.Writer
+
+	sel           []string
+	baseOpts      []config.Option
+	advertiseHost string
+	k8sPort       string
+
+	backends   map[string]*admin.Backend
+	k8sBackend *admin.Backend
+
+	// rebuildMu serializes resets so two concurrent /_cloudemu/reset calls can't
+	// interleave and leave providers wired to different Kubernetes instances. It
+	// also guards the current-state fields below and the live provider set.
+	rebuildMu   sync.Mutex
+	targets     map[string]seed.Target
+	snapTargets map[string]persist.Services
+	netEngine   *topology.Engine
+	discovery   map[string]*resourcediscovery.Engine
+	providers   []closer // current live providers, Close()d when swapped out
+}
+
+// New builds every selected provider behind its admin backend, restores any
+// persisted state, and applies init-dir fixtures — everything up to binding the
+// listeners. The returned App is ready to Serve.
+func New(cfg *Config) (*App, error) {
+	out := cfg.Out
+	if out == nil {
+		out = os.Stdout
+	}
+
+	k8sPort := cfg.K8sPort
+	if k8sPort == "" {
+		k8sPort = cfg.Ports["k8s"]
+	}
+
+	a := &App{
+		cfg:           *cfg,
+		out:           out,
+		sel:           cfg.Providers,
+		baseOpts:      baseOptsFor(cfg),
+		advertiseHost: advertiseHostFor(cfg.AdvertiseHost, cfg.Host),
+		k8sPort:       k8sPort,
+		backends:      make(map[string]*admin.Backend, len(cfg.Providers)),
+	}
+	for _, p := range cfg.Providers {
+		a.backends[p] = admin.NewBackend(nil)
+	}
+
+	if k8sPort != "" {
+		a.k8sBackend = admin.NewBackend(nil)
+	}
+
+	a.Rebuild() // populate the backends before serving
+
+	if err := a.applyBootState(); err != nil {
+		return nil, err
+	}
+
+	// reset wipes all state, so warn if it's reachable off the loopback — e.g. a
+	// shared instance bound with --host 0.0.0.0, where anyone on the network
+	// could POST /_cloudemu/reset.
+	if w := dangerWarning(cfg); w != "" {
+		fmt.Fprintln(os.Stderr, w)
+	}
+
+	return a, nil
+}
+
+// baseOptsFor clones Config.BaseOptions and appends the latency/auth options, so
+// the caller's slice is never mutated and buildProvider's Azure copy starts from
+// a stable base.
+func baseOptsFor(cfg *Config) []config.Option {
+	baseOpts := append([]config.Option(nil), cfg.BaseOptions...)
+
+	if cfg.Latency > 0 {
+		baseOpts = append(baseOpts, config.WithLatency(cfg.Latency))
+	}
+
+	if cfg.EnforceAuth {
+		baseOpts = append(baseOpts, config.WithEnforceAuth())
+	}
+
+	return baseOpts
+}
+
+// applyBootState restores persisted state and applies init-dir fixtures onto the
+// freshly-built providers before serving, so the first request already sees the
+// boot state. Restore runs first; init fixtures apply on top.
+func (a *App) applyBootState() error {
+	if a.cfg.Persist {
+		if err := restoreState(context.Background(), a.cfg.StateFile, a.snapTargets); err != nil {
+			return fmt.Errorf("restore persisted state: %w", err)
+		}
+	}
+
+	if a.cfg.InitDir != "" {
+		if err := applyInitDir(context.Background(), a.cfg.InitDir, a.targets); err != nil {
+			return fmt.Errorf("apply init dir: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Rebuild reconstructs a fresh Kubernetes server and every selected provider
+// from scratch and swaps them in atomically — this is what /_cloudemu/reset
+// calls to hand a test suite a clean slate without restarting the process. After
+// the swap it Close()es the providers it replaced (a no-op when no engine is
+// wired) so their real engines are freed rather than leaked.
+func (a *App) Rebuild() {
+	outgoing := a.swapFresh()
+	// Swap-then-close: the fresh handlers already serve new requests before the
+	// outgoing providers are torn down, so no request is ever routed to a
+	// half-closed engine. A request already in flight against the outgoing
+	// handler at the instant of the swap may still be mid-query when its
+	// provider's Close runs immediately after — an accepted best-effort tradeoff
+	// for a local dev/test tool, consistent with the destructive-reset
+	// philosophy, not an oversight. A short drain window is a possible future
+	// refinement.
+	a.closeProviders(outgoing)
+}
+
+// swapFresh builds every fresh handler, swaps them into the backends under the
+// rebuild lock, and returns the providers it displaced (for the caller to close
+// outside the lock). Building first means a construction panic leaves the
+// running set untouched, and all providers in one reset share the single new
+// Kubernetes data-plane.
+func (a *App) swapFresh() []closer {
+	a.rebuildMu.Lock()
+	defer a.rebuildMu.Unlock()
+
+	var k8s *kubernetes.APIServer
+	if a.k8sBackend != nil {
+		k8s = kubernetes.NewAPIServer()
+		// Tell the data plane the address it is reachable on, so the
+		// managed-Kubernetes control planes can advertise an endpoint that
+		// actually answers. https, because the listener is served with a cert
+		// signed by the CA DescribeCluster advertises.
+		k8s.SetBaseURL("https://" + net.JoinHostPort(a.advertiseHost, a.k8sPort))
+	}
+
+	fresh := make(map[string]http.Handler, len(a.sel))
+	freshTargets := make(map[string]seed.Target, len(a.sel))
+	freshSnapTargets := make(map[string]persist.Services, len(a.sel))
+	freshDiscovery := make(map[string]*resourcediscovery.Engine, len(a.sel))
+
+	var (
+		freshEngine    *topology.Engine
+		freshProviders []closer
+	)
+
+	for _, p := range a.sel {
+		b := a.buildProvider(p, k8s)
+		fresh[p] = b.handler
+		freshTargets[p] = b.target
+		freshSnapTargets[p] = b.snap
+
+		if b.discovery != nil {
+			freshDiscovery[p] = b.discovery
+		}
+
+		if b.engine != nil {
+			freshEngine = b.engine
+		}
+
+		if b.provider != nil {
+			freshProviders = append(freshProviders, b.provider)
+		}
+	}
+
+	if a.k8sBackend != nil {
+		a.k8sBackend.Swap(wrap(k8s, "kubernetes", a.cfg.LogRequests))
+	}
+
+	for p, h := range fresh {
+		a.backends[p].Swap(h)
+	}
+
+	a.targets = freshTargets
+	a.snapTargets = freshSnapTargets
+	a.netEngine = freshEngine
+	a.discovery = freshDiscovery
+
+	outgoing := a.providers
+	a.providers = freshProviders
+
+	return outgoing
+}
+
+// builtProvider is one freshly-constructed provider: its wire handler plus the
+// cross-cutting hooks (seed target, snapshot services, discovery/topology
+// engines, and the closer for engine teardown).
+type builtProvider struct {
+	handler   http.Handler
+	target    seed.Target
+	snap      persist.Services
+	discovery *resourcediscovery.Engine // nil for oci
+	engine    *topology.Engine          // non-nil only for aws (network topology)
+	provider  closer                    // nil for oci (no Close/engine teardown)
+}
+
+// buildProvider constructs one provider and its hooks. It shares the single new
+// Kubernetes data-plane k8s across every provider in a rebuild.
+func (a *App) buildProvider(p string, k8s *kubernetes.APIServer) builtProvider {
+	switch p {
+	case providerAWS:
+		cloud := cloudemu.NewAWS(a.baseOpts...)
+		d := awsserver.DriversFrom(cloud)
+		d.K8sAPI = k8s
+		// Drivers.K8sAPI is only the server's PATH ROUTING for /k8s/{uid}/...;
+		// the control-plane mock keeps its own reference and needs it
+		// separately, or EKS still advertises the sentinel.
+		cloud.EKS.SetK8sAPI(k8s)
+
+		return builtProvider{
+			handler:   wrap(awsserver.New(d), providerAWS, a.cfg.LogRequests),
+			target:    seed.Target{Storage: cloud.S3, Database: cloud.DynamoDB, Secrets: cloud.SecretsManager, Compute: cloud.EC2},
+			snap:      cloud.SnapshotServices(),
+			discovery: cloud.ResourceDiscovery,
+			engine:    topology.New(cloud.EC2, cloud.VPC, cloud.Route53),
+			provider:  cloud,
+		}
+	case providerGCP:
+		cloud := cloudemu.NewGCP(a.baseOpts...)
+		d := gcpserver.DriversFrom(cloud)
+		d.K8sAPI = k8s
+		cloud.GKE.SetK8sAPI(k8s)
+
+		return builtProvider{
+			handler:   wrap(gcpserver.New(d), providerGCP, a.cfg.LogRequests),
+			target:    seed.Target{Storage: cloud.GCS, Database: cloud.Firestore, Secrets: cloud.SecretManager, Compute: cloud.GCE},
+			snap:      cloud.SnapshotServices(),
+			discovery: cloud.ResourceDiscovery,
+			provider:  cloud,
+		}
+	case providerAzure:
+		// Azure subscriptions are GUIDs, unlike the 12-digit AWS account id.
+		// Give the Azure provider its own subscription so resource ids and
+		// Resource Graph scoping use a real Azure GUID (WithAccountID is
+		// last-wins). Copy opts so the override never leaks into another
+		// provider's option list.
+		azureOpts := make([]config.Option, len(a.baseOpts), len(a.baseOpts)+1)
+		copy(azureOpts, a.baseOpts)
+		azureOpts = append(azureOpts, config.WithAccountID(a.cfg.AzureSubscription))
+		cloud := cloudemu.NewAzure(azureOpts...)
+		d := azureserver.DriversFrom(cloud)
+		d.K8sAPI = k8s
+		cloud.AKS.SetK8sAPI(k8s)
+
+		return builtProvider{
+			handler:   wrap(azureserver.New(d), providerAzure, a.cfg.LogRequests),
+			target:    seed.Target{Storage: cloud.BlobStorage, Database: cloud.CosmosDB, Secrets: cloud.KeyVault, Compute: cloud.VirtualMachines},
+			snap:      cloud.SnapshotServices(),
+			discovery: cloud.ResourceDiscovery,
+			provider:  cloud,
+		}
+	case providerOCI:
+		cloud := cloudemu.NewOCI(a.baseOpts...)
+		d := ociserver.DriversFrom(cloud)
+		d.K8sAPI = k8s
+		// OCI has no managed-Kubernetes service, so no SetK8sAPI here, and its
+		// *Provider carries no engines to close.
+		return builtProvider{
+			handler: wrap(ociserver.New(d), providerOCI, a.cfg.LogRequests),
+			target: seed.Target{
+				Storage: cloud.ObjectStorage, Database: cloud.NoSQL,
+				Secrets: cloud.Vault, Compute: cloud.Compute,
+			},
+			snap: cloud.SnapshotServices(),
+		}
+	}
+
+	return builtProvider{}
+}
+
+// closeProviders closes each provider best-effort, cascading engine teardown. It
+// runs after the swap (or after the shutdown snapshot), never before, and never
+// aborts on an error — a failed teardown is logged, not fatal.
+func (a *App) closeProviders(providers []closer) {
+	for _, p := range providers {
+		if err := p.Close(); err != nil {
+			fmt.Fprintf(a.out, "warning: closing provider engines: %v\n", err)
+		}
+	}
+}
+
+// seedFor applies a fixture body to a provider's current drivers. It shares
+// rebuildMu with reset so a seed and a reset can't run against each other's
+// half-built state.
+func (a *App) seedFor(provider string) func([]byte) (int, error) {
+	return func(fixture []byte) (int, error) {
+		f, err := seed.Load(fixture)
+		if err != nil {
+			return 0, err
+		}
+		// Read the current Target under the lock, but run Apply outside it: a
+		// large fixture (especially with --latency) must not hold the shared
+		// reset mutex for its whole duration.
+		a.rebuildMu.Lock()
+		t := a.targets[provider]
+		a.rebuildMu.Unlock()
+
+		if err := seed.Apply(context.Background(), f, t); err != nil {
+			return 0, err
+		}
+
+		return f.ResourceCount(), nil
+	}
+}
+
+// snapshot captures current state as JSON. It acts on the whole emulator, like
+// reset, so a call to any provider port covers every provider.
+func (a *App) snapshot() ([]byte, error) {
+	a.rebuildMu.Lock()
+	cur := a.snapTargets
+	a.rebuildMu.Unlock()
+
+	snap, err := persist.ExportAll(context.Background(), cur, persist.Options{IncludeAssets: true})
+	if err != nil {
+		return nil, err
+	}
+
+	return json.MarshalIndent(snap, "", "  ")
+}
+
+// restore rebuilds to empty then loads the posted state. The load is destructive
+// (reset semantics): rebuild wipes to empty first, so a RestoreAll that fails
+// partway leaves an empty store, not a half-old/half-new mix — acceptable for a
+// local emulator. The rebuild also Close()es the about-to-be-wiped providers,
+// reaping their engines.
+func (a *App) restore(body []byte) error {
+	var snap persist.Snapshot
+	if err := json.Unmarshal(body, &snap); err != nil {
+		return fmt.Errorf("parse snapshot: %w", err)
+	}
+
+	if snap.SchemaVersion != persist.SchemaVersion {
+		return fmt.Errorf("%w: got %d, want %d", errUnsupportedSnapshot, snap.SchemaVersion, persist.SchemaVersion)
+	}
+
+	a.Rebuild() // wipe to empty before loading
+
+	a.rebuildMu.Lock()
+	cur := a.snapTargets
+	a.rebuildMu.Unlock()
+
+	return persist.RestoreAll(context.Background(), &snap, cur)
+}
+
+// extraHandler serves the control-plane endpoints that plug into admin: network
+// reachability (/net/*, AWS-only, needs the topology engine) and cost estimation
+// (/cost, all providers, needs the discovery engines).
+func (a *App) extraHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch strings.TrimPrefix(r.URL.Path, admin.Prefix) {
+		case "net/can-connect", "net/trace":
+			a.rebuildMu.Lock()
+			eng := a.netEngine
+			a.rebuildMu.Unlock()
+
+			if eng == nil {
+				writeNetErr(w, http.StatusServiceUnavailable, "network topology requires the aws provider")
+
+				return
+			}
+
+			if strings.HasSuffix(r.URL.Path, "trace") {
+				serveTrace(w, r, eng)
+			} else {
+				serveCanConnect(w, r, eng)
+			}
+		case "cost":
+			a.rebuildMu.Lock()
+			ds := a.discovery
+			a.rebuildMu.Unlock()
+
+			serveCost(w, r, ds)
+		default:
+			writeNetErr(w, http.StatusNotFound, "unknown control endpoint")
+		}
+	})
+}
+
+// handlerFor fronts a backend with the /_cloudemu control plane. With the admin
+// API off the backend serves directly. seedFn may be nil (e.g. the Kubernetes
+// port), which disables the seed endpoint.
+func (a *App) handlerFor(b *admin.Backend, seedFn func([]byte) (int, error)) http.Handler {
+	if a.cfg.Admin {
+		return admin.NewControl(b, a.Rebuild, seedFn, a.snapshot, a.restore, a.extraHandler())
+	}
+
+	return b
+}
+
+// Serve binds every listener, starts serving, and blocks until ctx is canceled
+// or a listener fails fatally. On cancellation it gracefully shuts the servers
+// down, writes the persistence snapshot (if enabled), then closes the live
+// providers.
+func (a *App) Serve(ctx context.Context) error {
+	servers, eps, err := a.buildServers()
+	if err != nil {
+		return err
+	}
+
+	listeners, err := bindListeners(servers)
+	if err != nil {
+		return err
+	}
+
+	errCh := serveAll(servers, listeners)
+
+	if !a.cfg.Quiet {
+		printBanner(a.out, &eps, a.cfg.Admin)
+	}
+
+	if a.cfg.EndpointsFile != "" {
+		if err := eps.writeFile(a.cfg.EndpointsFile); err != nil {
+			return fmt.Errorf("write endpoints file: %w", err)
+		}
+	}
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		if !a.cfg.Quiet {
+			fmt.Fprintln(a.out, "\nshutting down…")
+		}
+	}
+
+	return a.shutdown(servers)
+}
+
+// buildServers assembles the per-provider (and Kubernetes) HTTP servers and the
+// endpoint set advertised to clients.
+func (a *App) buildServers() ([]*namedServer, endpointSet, error) {
+	var servers []*namedServer
+
+	eps := endpointSet{}
+
+	for _, p := range a.sel {
+		var (
+			addr   string
+			tlsCfg *tls.Config
+			isTLS  bool
+		)
+
+		switch p {
+		case providerAWS:
+			addr = net.JoinHostPort(a.cfg.Host, a.cfg.Ports[providerAWS])
+			eps.AWS = fmt.Sprintf("http://%s", addr)
+		case providerGCP:
+			addr = net.JoinHostPort(a.cfg.Host, a.cfg.Ports[providerGCP])
+			eps.GCP = fmt.Sprintf("http://%s", addr)
+		case providerOCI:
+			addr = net.JoinHostPort(a.cfg.Host, a.cfg.Ports[providerOCI])
+			eps.OCI = fmt.Sprintf("http://%s", addr)
+		case providerAzure:
+			addr = net.JoinHostPort(a.cfg.Host, a.cfg.Ports[providerAzure])
+
+			var err error
+
+			if tlsCfg, err = tlsConfig(&a.cfg, addr); err != nil {
+				return nil, eps, fmt.Errorf("azure TLS: %w", err)
+			}
+
+			isTLS = true
+			eps.Azure = fmt.Sprintf("https://%s", addr)
+		}
+
+		servers = append(servers, &namedServer{
+			name: p,
+			srv: &http.Server{
+				Addr:              addr,
+				Handler:           a.handlerFor(a.backends[p], a.seedFor(p)),
+				TLSConfig:         tlsCfg,
+				ReadHeaderTimeout: serverReadHeaderTimeout,
+			},
+			tls: isTLS,
+		})
+	}
+
+	if a.k8sBackend != nil {
+		addr := net.JoinHostPort(a.cfg.Host, a.k8sPort)
+
+		// The cert must certify the advertised host (what clients dial), plus the
+		// loopback names, plus any extra --tls-host SANs. k8s uses its own eksprov
+		// cert — the --tls-cert override applies only to the Azure listener.
+		k8sTLS, err := eksprov.ServingTLSConfig(k8sCertHosts(a.advertiseHost, a.cfg.TLSHosts))
+		if err != nil {
+			return nil, eps, fmt.Errorf("kubernetes data-plane TLS: %w", err)
+		}
+
+		servers = append(servers, &namedServer{
+			name: "kubernetes",
+			srv: &http.Server{
+				Addr:              addr,
+				Handler:           a.handlerFor(a.k8sBackend, nil),
+				TLSConfig:         k8sTLS,
+				ReadHeaderTimeout: serverReadHeaderTimeout,
+			},
+			tls: true,
+		})
+		// Show the reachable (advertised) endpoint, not the bind address.
+		eps.Kubernetes = fmt.Sprintf("https://%s", net.JoinHostPort(a.advertiseHost, a.k8sPort))
+	}
+
+	return servers, eps, nil
+}
+
+// shutdown gracefully stops the servers, writes the persistence snapshot after
+// they are quiescent (so no in-flight request can mutate state mid-read), and
+// only then closes the live providers — engines must stay readable through the
+// snapshot.
+func (a *App) shutdown(servers []*namedServer) error {
+	to := a.cfg.ShutdownTimeout
+	if to <= 0 {
+		to = defaultShutdownTimeout
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), to)
+	defer cancel()
+
+	var shutErr error
+	for _, s := range servers {
+		if err := s.srv.Shutdown(ctx); err != nil && shutErr == nil {
+			shutErr = err
+		}
+	}
+
+	if a.cfg.Persist {
+		if err := snapshotState(context.Background(), a.cfg.StateFile, !a.cfg.PersistMetadataOnly, a.snapTargets); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to save state to %s: %v\n", a.cfg.StateFile, err)
+		} else if !a.cfg.Quiet {
+			fmt.Fprintf(a.out, "state saved to %s\n", a.cfg.StateFile)
+		}
+	}
+
+	a.rebuildMu.Lock()
+	cur := a.providers
+	a.rebuildMu.Unlock()
+	a.closeProviders(cur)
+
+	return shutErr
+}
+
+// namedServer is one endpoint's HTTP server plus how it is served.
+type namedServer struct {
+	name string
+	srv  *http.Server
+	tls  bool
+}
+
+// bindListeners binds every listener up front so a port clash fails fast, before
+// a banner promises endpoints that never came up. A partial failure closes the
+// listeners already opened.
+func bindListeners(servers []*namedServer) ([]net.Listener, error) {
+	listeners := make([]net.Listener, len(servers))
+
+	var lc net.ListenConfig
+
+	for i, s := range servers {
+		ln, err := lc.Listen(context.Background(), "tcp", s.srv.Addr)
+		if err != nil {
+			for _, l := range listeners[:i] {
+				l.Close()
+			}
+
+			return nil, fmt.Errorf("bind %s (%s): %w", s.name, s.srv.Addr, err)
+		}
+
+		listeners[i] = ln
+	}
+
+	return listeners, nil
+}
+
+// serveAll starts every bound listener in its own goroutine and returns a
+// channel reporting the first fatal serve error.
+func serveAll(servers []*namedServer, listeners []net.Listener) <-chan error {
+	errCh := make(chan error, len(servers))
+
+	for i, s := range servers {
+		ln := listeners[i]
+
+		go func() {
+			var err error
+			if s.tls {
+				err = s.srv.ServeTLS(ln, "", "")
+			} else {
+				err = s.srv.Serve(ln)
+			}
+
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				errCh <- fmt.Errorf("%s: %w", s.name, err)
+			}
+		}()
+	}
+
+	return errCh
+}
+
+// dangerWarning returns the non-loopback admin warning, or "" when it doesn't
+// apply. reset wipes all state and snapshot dumps it (secrets included), so an
+// admin control plane reachable off the loopback is called out.
+func dangerWarning(cfg *Config) string {
+	if !cfg.Admin || isLoopbackHost(cfg.Host) {
+		return ""
+	}
+
+	return fmt.Sprintf(
+		"warning: --admin control plane is reachable on non-loopback host %q — "+
+			"POST /_cloudemu/reset wipes all state, and GET /_cloudemu/snapshot dumps "+
+			"all emulated state (including secret values) to any caller; "+
+			"pass --admin=false to disable it",
+		cfg.Host)
+}

--- a/server/serverkit/serverkit_test.go
+++ b/server/serverkit/serverkit_test.go
@@ -1,0 +1,228 @@
+package serverkit
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/persist"
+)
+
+// fakeCacheEngine is a no-op CacheEngine that also implements io.Closer, so a
+// provider built with it registers it as an engine-closer. Its Close increments
+// a shared counter, letting a test observe that serverkit closes the outgoing
+// providers across a rebuild — the leak guard for the contrib real-engine case.
+type fakeCacheEngine struct{ closed *atomic.Int64 }
+
+func (fakeCacheEngine) Provision(context.Context, config.CacheProvisionRequest) (config.ProvisionResult, error) {
+	return config.ProvisionResult{}, nil
+}
+func (fakeCacheEngine) Deprovision(context.Context, string) error { return nil }
+func (f fakeCacheEngine) Close() error {
+	f.closed.Add(1)
+	return nil
+}
+
+func newTestApp(t *testing.T, cfg Config) *App {
+	t.Helper()
+	if cfg.Out == nil {
+		cfg.Out = io.Discard
+	}
+	app, err := New(&cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return app
+}
+
+// TestProviderClosedOnResetAndRestore is the leak guard: the outgoing provider's
+// engines must be Close()d after a rebuild swap on BOTH /_cloudemu/reset and the
+// snapshot restore path — not only on final shutdown. Without this, contrib's
+// real embedded-postgres/Docker engines would leak on every reset.
+func TestProviderClosedOnResetAndRestore(t *testing.T) {
+	var closed atomic.Int64
+	app := newTestApp(t, Config{
+		Providers:   []string{"aws"},
+		Host:        "127.0.0.1",
+		Ports:       map[string]string{"aws": "0"},
+		Admin:       true,
+		BaseOptions: []config.Option{config.WithCacheEngine(fakeCacheEngine{closed: &closed})},
+		Out:         io.Discard,
+	})
+
+	// New's initial build has no predecessor to close.
+	if got := closed.Load(); got != 0 {
+		t.Fatalf("after New: closed = %d, want 0 (no outgoing provider yet)", got)
+	}
+
+	// A reset swaps in a fresh provider and must close the one it replaced.
+	app.Rebuild()
+	if got := closed.Load(); got != 1 {
+		t.Fatalf("after reset: closed = %d, want 1 (outgoing provider closed)", got)
+	}
+
+	// A snapshot restore also rebuilds-to-empty, so it too must close the
+	// outgoing provider.
+	snap := persist.Snapshot{SchemaVersion: persist.SchemaVersion}
+	body, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := app.restore(body); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if got := closed.Load(); got != 2 {
+		t.Fatalf("after restore: closed = %d, want 2 (reset + restore both closed)", got)
+	}
+}
+
+// TestRestoreIsDestructive locks the documented semantic: restore wipes to empty
+// before loading (no staging swap), so state present before the restore and
+// absent from the posted snapshot is gone afterwards.
+func TestRestoreIsDestructive(t *testing.T) {
+	ctx := context.Background()
+	app := newTestApp(t, Config{
+		Providers: []string{"aws"},
+		Host:      "127.0.0.1",
+		Ports:     map[string]string{"aws": "0"},
+		Admin:     true,
+		Out:       io.Discard,
+	})
+
+	// Seed a bucket into the running provider.
+	if err := app.targets["aws"].Storage.CreateBucket(ctx, "pre-existing"); err != nil {
+		t.Fatalf("seed bucket: %v", err)
+	}
+	if b, _ := app.targets["aws"].Storage.ListBuckets(ctx); len(b) != 1 {
+		t.Fatalf("precondition: want 1 bucket, got %d", len(b))
+	}
+
+	// Restore an empty (but schema-valid) snapshot: the wipe must remove the
+	// pre-existing bucket.
+	snap := persist.Snapshot{SchemaVersion: persist.SchemaVersion}
+	body, _ := json.Marshal(snap)
+	if err := app.restore(body); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	// After the destructive restore the store is empty, and targets point at the
+	// freshly-rebuilt provider.
+	buckets, err := app.targets["aws"].Storage.ListBuckets(ctx)
+	if err != nil {
+		t.Fatalf("list after restore: %v", err)
+	}
+	if len(buckets) != 0 {
+		t.Fatalf("after destructive restore: %d buckets, want 0 (wiped)", len(buckets))
+	}
+}
+
+// TestSnapshotOnShutdownBeforeClose asserts the shutdown ordering: the
+// persistence snapshot is written while the providers are still live, and the
+// providers are closed only afterwards. A snapshot that captured the seeded
+// bucket AND a provider Close that fired both being true proves the snapshot ran
+// before teardown (engines readable at snapshot time).
+func TestSnapshotOnShutdownBeforeClose(t *testing.T) {
+	ctx := context.Background()
+	stateFile := filepath.Join(t.TempDir(), "state.json")
+
+	var closed atomic.Int64
+	app := newTestApp(t, Config{
+		Providers:   []string{"aws"},
+		Host:        "127.0.0.1",
+		Ports:       map[string]string{"aws": "0"},
+		Admin:       true,
+		Persist:     true,
+		StateFile:   stateFile,
+		BaseOptions: []config.Option{config.WithCacheEngine(fakeCacheEngine{closed: &closed})},
+		Out:         io.Discard,
+	})
+
+	if err := app.targets["aws"].Storage.CreateBucket(ctx, "keep-me"); err != nil {
+		t.Fatalf("seed bucket: %v", err)
+	}
+
+	// Serve until the context is cancelled, then it shuts down (snapshot, then
+	// close).
+	sctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := app.Serve(sctx); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+
+	// The snapshot was written and holds the seeded bucket — so it ran while the
+	// provider was still live.
+	data, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("read state file: %v", err)
+	}
+	if !strings.Contains(string(data), "keep-me") {
+		t.Fatalf("snapshot missing seeded bucket; state=%s", data)
+	}
+	// And the provider was closed on shutdown.
+	if got := closed.Load(); got != 1 {
+		t.Fatalf("provider closed %d times on shutdown, want 1", got)
+	}
+}
+
+// TestDangerWarning covers the non-loopback admin warning gate.
+func TestDangerWarning(t *testing.T) {
+	if w := dangerWarning(&Config{Admin: true, Host: "0.0.0.0"}); w == "" {
+		t.Fatal("non-loopback admin host: want a warning, got none")
+	}
+	if w := dangerWarning(&Config{Admin: true, Host: "127.0.0.1"}); w != "" {
+		t.Fatalf("loopback admin host: want no warning, got %q", w)
+	}
+	if w := dangerWarning(&Config{Admin: false, Host: "0.0.0.0"}); w != "" {
+		t.Fatalf("admin off: want no warning, got %q", w)
+	}
+}
+
+// TestSeedNilReturns501 checks the admin wiring: a backend fronted without a
+// seed function (as the Kubernetes listener is) answers /_cloudemu/seed with 501.
+func TestSeedNilReturns501(t *testing.T) {
+	app := newTestApp(t, Config{
+		Providers: []string{"aws"},
+		Host:      "127.0.0.1",
+		Ports:     map[string]string{"aws": "0"},
+		Admin:     true,
+		Out:       io.Discard,
+	})
+
+	h := app.handlerFor(app.backends["aws"], nil) // nil seedFn, like the k8s port
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_cloudemu/seed", strings.NewReader("{}")))
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("seed with nil seedFn = %d, want 501", rec.Code)
+	}
+}
+
+// TestSeedBodyCapReturns413 checks the 32 MiB fixture cap is enforced through the
+// assembled control plane.
+func TestSeedBodyCapReturns413(t *testing.T) {
+	app := newTestApp(t, Config{
+		Providers: []string{"aws"},
+		Host:      "127.0.0.1",
+		Ports:     map[string]string{"aws": "0"},
+		Admin:     true,
+		Out:       io.Discard,
+	})
+
+	const overCap = (32 << 20) + 1 // one byte past the 32 MiB cap
+	body := bytes.NewReader(make([]byte, overCap))
+
+	h := app.handlerFor(app.backends["aws"], app.seedFor("aws"))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_cloudemu/seed", body))
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized fixture = %d, want 413", rec.Code)
+	}
+}

--- a/server/serverkit/tls.go
+++ b/server/serverkit/tls.go
@@ -1,4 +1,4 @@
-package main
+package serverkit
 
 import (
 	"crypto/ecdsa"
@@ -14,27 +14,33 @@ import (
 	"time"
 )
 
+// certSerialBits is the bit length of the self-signed certificate serial number.
+const certSerialBits = 128
+
 // tlsConfig returns the TLS config for the Azure HTTPS endpoint. If the user
 // supplied a cert/key pair we load it; otherwise we mint a self-signed cert in
 // memory covering localhost, the loopback IPs, the bind host, and any extra
 // --tls-host SANs.
-func tlsConfig(c serveConfig, addr string) (*tls.Config, error) {
-	if c.tlsCert != "" {
-		cert, err := tls.LoadX509KeyPair(c.tlsCert, c.tlsKey)
+func tlsConfig(cfg *Config, addr string) (*tls.Config, error) {
+	if cfg.TLSCert != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
 		if err != nil {
 			return nil, err
 		}
+
 		return &tls.Config{MinVersion: tls.VersionTLS12, Certificates: []tls.Certificate{cert}}, nil
 	}
 
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
-		host = c.host
+		host = cfg.Host
 	}
-	cert, err := selfSignedCert(append([]string{"localhost", host}, c.tlsHosts...))
+
+	cert, err := selfSignedCert(append([]string{"localhost", host}, cfg.TLSHosts...))
 	if err != nil {
 		return nil, err
 	}
+
 	return &tls.Config{MinVersion: tls.VersionTLS12, Certificates: []tls.Certificate{cert}}, nil
 }
 
@@ -47,7 +53,7 @@ func selfSignedCert(hosts []string) (tls.Certificate, error) {
 		return tls.Certificate{}, err
 	}
 
-	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), certSerialBits))
 	if err != nil {
 		return tls.Certificate{}, err
 	}
@@ -62,13 +68,16 @@ func selfSignedCert(hosts []string) (tls.Certificate, error) {
 		BasicConstraintsValid: true,
 	}
 	// Always cover the loopback IPs so https://127.0.0.1 / [::1] verify.
-	tmpl.IPAddresses = append(tmpl.IPAddresses, net.IPv4(127, 0, 0, 1), net.IPv6loopback)
+	tmpl.IPAddresses = append(tmpl.IPAddresses, net.ParseIP(loopbackIPv4), net.IPv6loopback)
+
 	seen := map[string]bool{}
 	for _, h := range hosts {
 		if h == "" || seen[h] {
 			continue
 		}
+
 		seen[h] = true
+
 		if ip := net.ParseIP(h); ip != nil {
 			tmpl.IPAddresses = append(tmpl.IPAddresses, ip)
 		} else {
@@ -85,6 +94,7 @@ func selfSignedCert(hosts []string) (tls.Certificate, error) {
 	if err != nil {
 		return tls.Certificate{}, err
 	}
+
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
 
@@ -92,5 +102,6 @@ func selfSignedCert(hosts []string) (tls.Certificate, error) {
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("assemble keypair: %w", err)
 	}
+
 	return cert, nil
 }

--- a/server/serverkit/tls_test.go
+++ b/server/serverkit/tls_test.go
@@ -1,0 +1,93 @@
+package serverkit
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestTLSConfigSelfSigned checks the generated cert certifies localhost, the
+// loopback IPs, the bind host, and any extra --tls-host SANs.
+func TestTLSConfigSelfSigned(t *testing.T) {
+	cfg := Config{Host: "myhost", TLSHosts: []string{"1.2.3.4", "extra.local"}}
+
+	tc, err := tlsConfig(&cfg, "myhost:4568")
+	if err != nil {
+		t.Fatalf("tlsConfig: %v", err)
+	}
+	if len(tc.Certificates) != 1 {
+		t.Fatalf("got %d certificates, want 1", len(tc.Certificates))
+	}
+
+	leaf, err := x509.ParseCertificate(tc.Certificates[0].Certificate[0])
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+
+	wantDNS := map[string]bool{"localhost": false, "myhost": false, "extra.local": false}
+	for _, n := range leaf.DNSNames {
+		if _, ok := wantDNS[n]; ok {
+			wantDNS[n] = true
+		}
+	}
+	for name, seen := range wantDNS {
+		if !seen {
+			t.Fatalf("cert DNS names %v missing %q", leaf.DNSNames, name)
+		}
+	}
+
+	var haveLoopback, haveExtra bool
+	for _, ip := range leaf.IPAddresses {
+		if ip.String() == "127.0.0.1" {
+			haveLoopback = true
+		}
+		if ip.String() == "1.2.3.4" {
+			haveExtra = true
+		}
+	}
+	if !haveLoopback {
+		t.Fatalf("cert IPs %v missing loopback 127.0.0.1", leaf.IPAddresses)
+	}
+	if !haveExtra {
+		t.Fatalf("cert IPs %v missing extra SAN 1.2.3.4", leaf.IPAddresses)
+	}
+}
+
+// TestTLSConfigCustomCert checks a user-supplied --tls-cert/--tls-key pair is
+// loaded instead of minting a self-signed cert.
+func TestTLSConfigCustomCert(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+
+	cert, err := selfSignedCert([]string{"localhost"})
+	if err != nil {
+		t.Fatalf("mint cert for fixture: %v", err)
+	}
+	writePEM(t, certPath, "CERTIFICATE", cert.Certificate[0])
+	keyDER, err := x509.MarshalECPrivateKey(cert.PrivateKey.(*ecdsa.PrivateKey)) //nolint:forcetypeassert // selfSignedCert uses ECDSA
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	writePEM(t, keyPath, "EC PRIVATE KEY", keyDER)
+
+	cfg := Config{TLSCert: certPath, TLSKey: keyPath}
+	tc, err := tlsConfig(&cfg, "127.0.0.1:4568")
+	if err != nil {
+		t.Fatalf("tlsConfig with custom cert: %v", err)
+	}
+	if len(tc.Certificates) != 1 {
+		t.Fatalf("got %d certificates, want 1", len(tc.Certificates))
+	}
+}
+
+func writePEM(t *testing.T, path, blockType string, der []byte) {
+	t.Helper()
+	b := pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der})
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

Extracts the standalone-server assembly out of `cmd/cloudemu/serve.go` into a new **exported** package `server/serverkit`, so one assembly can back both the shipped `cloudemu serve` binary and (in a later PR) the batteries-included `contrib/server`. This is **PR 0/A** of the Phase 2 program — it is the core extraction only. It does **not** touch `contrib/server`, engines, or Docker.

## What moved

- New `serverkit.Config` (flat data seam) and `serverkit.App` (`New`, `Serve`, `Rebuild`) now own the whole assembly: per-provider build (`cloudemu.New{AWS,Azure,GCP,OCI}` → `<provider>server.DriversFrom` → K8s routing + EKS/GKE/AKS `SetK8sAPI`, OCI excluded), the `admin.Backend` hot-swap control plane, persistence restore/snapshot, init-dir seeding, the `/net/*` + `/cost` admin endpoints, advertise-host/TLS handling, the startup banner + endpoints-file, and the bind → serve → shutdown → snapshot lifecycle. The Azure `WithAccountID(subscription)` last-wins override stays internal, applied to a copy so it never leaks into aws/gcp/oci.
- `cmd/cloudemu/{middleware.go, tlscert.go, endpoints.go}` moved into serverkit (`middleware.go`, `tls.go`, `endpoints.go`) and were deleted from `cmd/cloudemu`.
- `cmd/cloudemu/serve.go` is now a thin flag-parse → `serverkit.Config` → `serverkit.New`/`Serve` wrapper (keeps `parseProviders`).
- The five white-box test files (`advertise`, `persist_serve`, `init`, `net_serve`, `cost_serve`) moved into serverkit as same-package tests; their cmd copies were deleted. The black-box binary tests (`serve`, `lifecycle`, `snapshot`) stay in `cmd/cloudemu` as the byte-identity oracle.

## New capability (not in the old inline code)

serverkit tracks the current live `*Provider` set and `Close()`es the **outgoing** providers after every rebuild swap (`/_cloudemu/reset` and snapshot restore) and on final shutdown **after** the snapshot. This reaps real data-plane engines (embedded Postgres, miniredis, Docker containers) instead of leaking them on every reset — a no-op for cmd/cloudemu's engineless providers. Swap-then-close ordering guarantees a fresh request never routes to a torn-down engine; the in-flight-request-vs-Close best-effort tradeoff is documented in-code as accepted, not an oversight.

## Behavior parity

Serve behavior is **byte-identical** for the `cloudemu serve` binary, guarded by the retained `cmd/cloudemu` black-box tests. New serverkit tests lock: the leak guard (Close fires on reset AND restore, not only shutdown), destructive restore (wipe-to-empty), snapshot-before-close shutdown ordering, the non-loopback admin warning, seed-nil → 501, the 32 MiB fixture body cap, and self-signed + custom-cert TLS.

## Gates

`go build ./...`, `go vet ./...`, `go test ./...`, and `go generate ./...` (no diff) all pass; `golangci-lint run ./server/serverkit/...` reports 0 issues.
