### PR TITLE
feat(contrib-server): admin plane + persistence + init-dir via serverkit flags

### DIFF
--- a/contrib/server/README.md
+++ b/contrib/server/README.md
@@ -85,6 +85,34 @@ not on `PATH`.
 | `--project-id`        | `cloudemu-local`                         | GCP project id                             |
 | `--shutdown-timeout`  | `10s`                                    | grace period for in-flight requests        |
 
+## Admin, persistence & seeding
+
+At parity with `cloudemu serve`, these flags are threaded through to the shared
+`server/serverkit` assembly:
+
+| Flag                     | Default | Meaning                                                            |
+|--------------------------|---------|--------------------------------------------------------------------|
+| `--admin`                | `true`  | mount the `/_cloudemu` control plane (`reset`, `health`, `seed`, `snapshot`) for test isolation |
+| `--persist`              | `false` | restore state from `--state-file` on startup and save it on shutdown (includes object bodies) |
+| `--state-file`           | *(none)*| path to the JSON state snapshot (**required** with `--persist`)     |
+| `--persist-metadata-only`| `false` | persist resource structure but omit object bodies (smaller snapshot)|
+| `--init-dir`             | *(none)*| apply every `*.json` seed fixture in this directory on startup      |
+
+```bash
+# Isolated test runs: POST /_cloudemu/reset between suites to wipe state.
+go run . --admin
+
+# Persist state across restarts:
+go run . --persist --state-file ./state.json
+
+# Seed fixtures on boot:
+go run . --init-dir ./fixtures
+```
+
+`--admin` is on by default; on a non-loopback `--host` it prints a warning, since
+`POST /_cloudemu/reset` wipes all state and `GET /_cloudemu/snapshot` dumps it
+(secrets included) to any caller. Pass `--admin=false` to disable it.
+
 The Azure endpoint serves HTTPS with an in-memory self-signed certificate
 (covering `localhost` and the loopback IPs); clients must trust it or skip
 verification.

--- a/contrib/server/admin_persist_test.go
+++ b/contrib/server/admin_persist_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+)
+
+// TestAdminReset boots the batteries server with the admin control plane on,
+// seeds a bucket through /_cloudemu/seed, confirms it shows up in the snapshot,
+// then POSTs /_cloudemu/reset and confirms the state is wiped — proving the
+// --admin flag threads through to serverkit's control plane.
+func TestAdminReset(t *testing.T) {
+	cfg := testConfig(t, allEnginesOff())
+	cfg.admin = true
+
+	awsURL, stop := startAWS(t, cfg, mustOptions(t, &cfg))
+	defer stop()
+
+	seedBucket(t, awsURL, "reset-me")
+
+	if snap := getSnapshot(t, awsURL); !strings.Contains(snap, "reset-me") {
+		t.Fatalf("seeded bucket missing from snapshot before reset")
+	}
+
+	if code := post(t, awsURL+"/_cloudemu/reset", nil); code != http.StatusOK {
+		t.Fatalf("reset status = %d, want 200", code)
+	}
+
+	if snap := getSnapshot(t, awsURL); strings.Contains(snap, "reset-me") {
+		t.Fatalf("bucket still present after reset — state not cleared")
+	}
+}
+
+// TestPersistRoundTrip creates a resource, shuts the server down so serverkit
+// writes the persistence snapshot, then boots a fresh app pointed at the same
+// state file and confirms the resource is restored on boot — proving --persist
+// and --state-file thread through.
+func TestPersistRoundTrip(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "state.json")
+
+	cfg := testConfig(t, allEnginesOff())
+	cfg.admin = true
+	cfg.persist = true
+	cfg.stateFile = stateFile
+
+	awsURL, stop := startAWS(t, cfg, mustOptions(t, &cfg))
+	seedBucket(t, awsURL, "persist-me")
+	stop() // shutdown writes the snapshot to stateFile
+
+	if _, err := os.Stat(stateFile); err != nil {
+		t.Fatalf("state file not written on shutdown: %v", err)
+	}
+
+	// A fresh app on the same state file (new ports) must restore the bucket.
+	cfg2 := testConfig(t, allEnginesOff())
+	cfg2.admin = true
+	cfg2.persist = true
+	cfg2.stateFile = stateFile
+
+	awsURL2, stop2 := startAWS(t, cfg2, mustOptions(t, &cfg2))
+	defer stop2()
+
+	if snap := getSnapshot(t, awsURL2); !strings.Contains(snap, "persist-me") {
+		t.Fatalf("bucket not restored on boot from %s", stateFile)
+	}
+}
+
+// TestInitDir writes a fixture into an init dir and confirms it is seeded on
+// boot — proving --init-dir threads through to serverkit.
+func TestInitDir(t *testing.T) {
+	dir := t.TempDir()
+	fixture := `{"buckets":[{"name":"seeded-bucket"}]}`
+
+	if err := os.WriteFile(filepath.Join(dir, "fixture.json"), []byte(fixture), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	cfg := testConfig(t, allEnginesOff())
+	cfg.admin = true
+	cfg.initDir = dir
+
+	awsURL, stop := startAWS(t, cfg, mustOptions(t, &cfg))
+	defer stop()
+
+	if snap := getSnapshot(t, awsURL); !strings.Contains(snap, "seeded-bucket") {
+		t.Fatalf("init-dir fixture not seeded on boot")
+	}
+}
+
+// mustOptions builds the identity+engine options for a config or fails the test.
+func mustOptions(t *testing.T, cfg *appConfig) []config.Option {
+	t.Helper()
+
+	opts, err := buildOptions(cfg)
+	if err != nil {
+		t.Fatalf("buildOptions: %v", err)
+	}
+
+	return opts
+}
+
+// seedBucket seeds one empty bucket through the admin /_cloudemu/seed endpoint.
+func seedBucket(t *testing.T, baseURL, name string) {
+	t.Helper()
+
+	body := strings.NewReader(`{"buckets":[{"name":"` + name + `"}]}`)
+	if code := post(t, baseURL+"/_cloudemu/seed", body); code != http.StatusOK {
+		t.Fatalf("seed status = %d, want 200", code)
+	}
+}
+
+// getSnapshot returns the admin /_cloudemu/snapshot body as a string.
+func getSnapshot(t *testing.T, baseURL string) string {
+	t.Helper()
+
+	resp, err := http.Get(baseURL + "/_cloudemu/snapshot") //nolint:noctx // short-lived in-process test call
+	if err != nil {
+		t.Fatalf("GET snapshot: %v", err)
+	}
+	defer resp.Body.Close()
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read snapshot body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("snapshot status = %d, want 200", resp.StatusCode)
+	}
+
+	return string(b)
+}
+
+// post issues a POST to url and returns the status code, failing on transport
+// error.
+func post(t *testing.T, url string, body io.Reader) int {
+	t.Helper()
+
+	resp, err := http.Post(url, "application/json", body) //nolint:noctx // short-lived in-process test call
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	return resp.StatusCode
+}

--- a/contrib/server/app.go
+++ b/contrib/server/app.go
@@ -47,11 +47,12 @@ func newAppFromOptions(cfg *appConfig, opts []config.Option) (*app, error) {
 }
 
 // serverkitConfig maps the resolved flag configuration onto a serverkit.Config.
-// This build runs aws/azure/gcp with the real-engine BaseOptions and no
-// admin/persist/k8s surface — that parity arrives in later PRs. The swap from
-// awsserver.NewFromProvider to serverkit (which builds via <provider>server.
-// DriversFrom) is identity-preserving: DriversFrom copies AccountID/Region/
-// EnforceAuth verbatim, and with k8s disabled K8sAPI is nil on both paths.
+// This build runs aws/azure/gcp with the real-engine BaseOptions plus the admin
+// control plane, persistence, and init-dir seeding — k8s/oci/tls parity arrives
+// in later PRs. The swap from awsserver.NewFromProvider to serverkit (which
+// builds via <provider>server.DriversFrom) is identity-preserving: DriversFrom
+// copies AccountID/Region/EnforceAuth verbatim, and with k8s disabled K8sAPI is
+// nil on both paths.
 func serverkitConfig(cfg *appConfig, opts []config.Option) *serverkit.Config {
 	return &serverkit.Config{
 		Providers: []string{providerAWS, providerAzure, providerGCP},
@@ -61,10 +62,15 @@ func serverkitConfig(cfg *appConfig, opts []config.Option) *serverkit.Config {
 			providerAzure: cfg.azurePort,
 			providerGCP:   cfg.gcpPort,
 		},
-		AzureSubscription: cfg.azureSubscription,
-		BaseOptions:       opts,
-		ShutdownTimeout:   cfg.shutdownTimeout,
-		Out:               cfg.out,
+		AzureSubscription:   cfg.azureSubscription,
+		Admin:               cfg.admin,
+		Persist:             cfg.persist,
+		StateFile:           cfg.stateFile,
+		PersistMetadataOnly: cfg.persistMetaOnly,
+		InitDir:             cfg.initDir,
+		BaseOptions:         opts,
+		ShutdownTimeout:     cfg.shutdownTimeout,
+		Out:                 cfg.out,
 	}
 }
 

--- a/contrib/server/main.go
+++ b/contrib/server/main.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -23,6 +24,9 @@ import (
 // defaultShutdownTimeout is the grace period for in-flight requests.
 const defaultShutdownTimeout = 10 * time.Second
 
+// errStateFileRequired is returned when --persist is set without --state-file.
+var errStateFileRequired = errors.New("--persist requires --state-file")
+
 // appConfig is the resolved flag/env configuration for one server run.
 type appConfig struct {
 	engines           engineSelection
@@ -34,6 +38,11 @@ type appConfig struct {
 	azureSubscription string
 	region            string
 	projectID         string
+	admin             bool
+	persist           bool
+	stateFile         string
+	persistMetaOnly   bool
+	initDir           string
 	shutdownTimeout   time.Duration
 	out               io.Writer // banner/diagnostics sink handed to serverkit
 }
@@ -98,6 +107,15 @@ func parseFlags(args []string, getenv func(string) string, out io.Writer) (appCo
 		"Azure subscription id reported by the emulator (a GUID)")
 	fs.StringVar(&cfg.region, "region", "us-east-1", "default region reported by the emulator")
 	fs.StringVar(&cfg.projectID, "project-id", "cloudemu-local", "GCP project ID reported by the emulator")
+
+	fs.BoolVar(&cfg.admin, "admin", true, "mount the /_cloudemu control plane (reset, health) for test isolation")
+	fs.BoolVar(&cfg.persist, "persist", false,
+		"save state to --state-file on shutdown and restore it on startup (includes object bodies)")
+	fs.StringVar(&cfg.stateFile, "state-file", "", "path to the JSON state snapshot (required with --persist)")
+	fs.BoolVar(&cfg.persistMetaOnly, "persist-metadata-only", false,
+		"persist resource structure but omit object bodies (smaller snapshot)")
+	fs.StringVar(&cfg.initDir, "init-dir", "", "apply every *.json seed fixture in this directory on startup")
+
 	fs.DurationVar(&cfg.shutdownTimeout, "shutdown-timeout", defaultShutdownTimeout, "grace period for in-flight requests on shutdown")
 
 	if err := fs.Parse(args); err != nil {
@@ -106,6 +124,10 @@ func parseFlags(args []string, getenv func(string) string, out io.Writer) (appCo
 
 	if allReal {
 		cfg.engines.applyAllReal()
+	}
+
+	if cfg.persist && cfg.stateFile == "" {
+		return appConfig{}, errStateFileRequired
 	}
 
 	return cfg, nil


### PR DESCRIPTION
## Summary

Brings the batteries-included `contrib/server` to parity with `cloudemu serve` for the admin control plane, persistence, and boot-time fixtures. serverkit already implements all of this — this PR only exposes the flags and threads them into `serverkit.Config`.

## Flags added (matching `cloudemu serve` names/defaults)

- `--admin` (default `true`) — mount the `/_cloudemu` control plane (reset/health/seed/snapshot)
- `--persist` (default `false`) + `--state-file` — restore state on startup, snapshot on shutdown (`--persist` requires `--state-file`)
- `--persist-metadata-only` (default `false`) — omit object bodies from the snapshot
- `--init-dir` — apply every `*.json` seed fixture in a directory on boot

Each is mapped onto the corresponding `serverkit.Config` field (`Admin`/`Persist`/`StateFile`/`PersistMetadataOnly`/`InitDir`); serverkit owns the control-plane mount, restore-on-boot, snapshot-on-shutdown, and init-dir application. No behavior is re-implemented in contrib.

## Tests

New `contrib/server/admin_persist_test.go` (hand-rolled helpers, no testify):
- `TestAdminReset` — with `--admin`, POST `/_cloudemu/reset` returns OK and clears seeded state
- `TestPersistRoundTrip` — create a resource -> shutdown (snapshot) -> fresh app restores it from the state file
- `TestInitDir` — a fixture JSON in `--init-dir` is seeded on boot

Engines are off for these, so they are fast and need no Docker/downloads. Existing engine e2e tests still pass.

## Docs

`contrib/server/README.md` gains an "Admin, persistence & seeding" section documenting the new flags.