### PR TITLE
feat(contrib/server): full flag-parity with cloudemu serve (OCI, k8s, storage engine, socket-degrade, TLS/latency/logging/auth)

### DIFF
--- a/contrib/server/README.md
+++ b/contrib/server/README.md
@@ -23,6 +23,12 @@ go run .
 # Real Postgres + real Redis (no Docker needed — embedded Postgres + miniredis):
 go run . --db=postgres --cache=redis
 
+# Persist object-storage bytes to a real local filesystem (no Docker):
+go run . --storage=localfs --storage-dir ./objects
+
+# Add the OCI endpoint and the shared Kubernetes data-plane:
+go run . --providers aws,azure,gcp,oci --k8s-port 4570
+
 # Everything real (Docker required for compute/containers):
 go run . --all-real
 ```
@@ -54,6 +60,17 @@ docker run --rm -p 4566:4566 -p 4568:4568 -p 4569:4569 \
   -e CLOUDEMU_DB=mysql -e CLOUDEMU_CONTAINERS=docker cloudemu-server
 ```
 
+Without the socket mount, Docker-backed engines **degrade to in-memory** (see the
+MODE banner section) rather than failing — so the same `docker run` works with or
+without the mount.
+
+> **Security note:** mounting `/var/run/docker.sock` grants the container
+> root-equivalent control of the host Docker daemon. Do it only for local dev on
+> a machine you trust; never mount the raw socket in shared or multi-tenant CI —
+> use a socket-proxy that restricts the API surface instead. If you cannot mount
+> a socket, just leave the Docker-backed engines off (or let them degrade) and use
+> the no-Docker engines (`postgres`, `redis`, `subprocess`, `localfs`).
+
 ## Engine flags / env
 
 Each capability is independently selectable; all default to `off` (in-memory).
@@ -66,24 +83,68 @@ Flags override the environment variable.
 | `--functions`  | `CLOUDEMU_FUNCTIONS`   | `off\|subprocess`          | subprocess function runner (no Docker)                                  |
 | `--compute`    | `CLOUDEMU_COMPUTE`     | `off\|docker`              | Docker-backed VM boot (Docker required)                                 |
 | `--containers` | `CLOUDEMU_CONTAINERS`  | `off\|docker`              | Docker-backed container workloads (Docker required)                     |
-| `--all-real`   | —                      | —                          | postgres + redis + subprocess + docker compute + docker containers      |
+| `--storage`    | `CLOUDEMU_STORAGE`     | `off\|localfs`             | persist object-storage bytes (S3/Blob/GCS) to a real local filesystem (no Docker) |
+| `--all-real`   | —                      | —                          | postgres + redis + subprocess + docker compute + docker containers + localfs storage |
 
-Docker-backed selections fail fast with a clear error when the `docker` CLI is
-not on `PATH`.
+`--storage-dir` sets the root directory for `--storage=localfs` (default: a
+temporary directory).
+
+### Startup MODE banner & docker-socket degrade
+
+At startup the server prints a per-capability **MODE banner** showing what each
+engine resolved to:
+
+```
+engines:
+  db          real (embedded postgres)
+  cache       real (miniredis)
+  functions   off
+  compute     fell-back-to-memory (no docker socket)
+  containers  off
+  storage     real (localfs)
+```
+
+A Docker-backed selection (`--db=mysql`, `--db=both`, `--compute=docker`,
+`--containers=docker`) **degrades to in-memory** — rather than failing — when the
+`docker` CLI/socket is absent: that capability drops its real engine, the banner
+row reads `fell-back-to-memory (no docker socket)`, and one warning line is
+written to stderr. This keeps a socket-less `docker run` booting instead of
+crashing. The MODE table is suppressed under `--quiet`; the degrade warnings are
+not. Non-Docker engines (`postgres`, `redis`, `subprocess`, `localfs`) never
+degrade.
 
 ## Other flags
 
+Flag names and defaults mirror `cloudemu serve`.
+
 | Flag                  | Default                                  | Meaning                                    |
 |-----------------------|------------------------------------------|--------------------------------------------|
+| `--providers`         | `aws,azure,gcp`                          | providers to start (`aws,azure,gcp,oci`; OCI opt-in) |
 | `--host`              | `127.0.0.1`                              | bind host (`0.0.0.0` exposes on network)   |
+| `--advertise-host`    | *(derives from `--host`)*                | host the Kubernetes endpoint is advertised at (its kubeconfig/TLS cert) |
 | `--aws-port`          | `4566`                                   | AWS endpoint (HTTP)                        |
 | `--azure-port`        | `4568`                                   | Azure endpoint (HTTPS, self-signed)        |
 | `--gcp-port`          | `4569`                                   | GCP endpoint (HTTP)                        |
-| `--account-id`        | `000000000000`                           | AWS/GCP account id                         |
+| `--oci-port`          | `4571`                                   | OCI endpoint (HTTP; only bound when `oci` is in `--providers`) |
+| `--k8s-port`          | `4570`                                   | shared Kubernetes data-plane (HTTPS); empty disables it |
+| `--account-id`        | `000000000000`                           | AWS/GCP/OCI account id                      |
 | `--azure-subscription`| `00000000-0000-0000-0000-000000000000`   | Azure subscription id (GUID)               |
 | `--region`            | `us-east-1`                              | default region                             |
 | `--project-id`        | `cloudemu-local`                         | GCP project id                             |
+| `--latency`           | `0`                                      | artificial latency added to every emulated call (e.g. `20ms`) |
+| `--tls-cert`          | *(self-signed)*                          | PEM cert file for the Azure HTTPS endpoint |
+| `--tls-key`           | *(self-signed)*                          | PEM key file matching `--tls-cert`         |
+| `--tls-host`          | —                                        | extra SAN host/IP for the self-signed cert (repeatable) |
+| `--log-requests`      | `false`                                  | log every HTTP request (method, path, status, duration) |
+| `--quiet`             | `false`                                  | suppress the startup banner                |
+| `--enforce-auth`      | `false`                                  | require authentication on each request (AWS SigV4 → 403 on an unregistered key; Azure Bearer-claims) |
+| `--endpoints-file`    | *(none)*                                 | write the resolved endpoints as JSON to this path |
 | `--shutdown-timeout`  | `10s`                                    | grace period for in-flight requests        |
+
+The OCI endpoint (`--providers` includes `oci`) and the shared Kubernetes
+data-plane (`--k8s-port`) are wired through the same `server/serverkit` assembly
+as `cloudemu serve`. The Kubernetes port serves HTTPS with its own self-signed
+serving certificate (`--tls-cert`/`--tls-key` apply only to the Azure endpoint).
 
 ## Admin, persistence & seeding
 

--- a/contrib/server/admin_persist_test.go
+++ b/contrib/server/admin_persist_test.go
@@ -97,7 +97,7 @@ func TestInitDir(t *testing.T) {
 func mustOptions(t *testing.T, cfg *appConfig) []config.Option {
 	t.Helper()
 
-	opts, err := buildOptions(cfg)
+	opts, _, err := buildOptions(cfg, dockerAvailable)
 	if err != nil {
 		t.Fatalf("buildOptions: %v", err)
 	}

--- a/contrib/server/app.go
+++ b/contrib/server/app.go
@@ -7,12 +7,14 @@ import (
 	"github.com/stackshy/cloudemu/v2/server/serverkit"
 )
 
-// Providers wired by the batteries-included server. Kubernetes and OCI are
-// intentionally omitted in this build; they arrive in a later PR.
+// Provider names accepted by --providers and mapped onto serverkit. OCI is
+// opt-in (not in the default set); Kubernetes is a shared data-plane toggled by
+// --k8s-port rather than a provider.
 const (
 	providerAWS   = "aws"
 	providerAzure = "azure"
 	providerGCP   = "gcp"
+	providerOCI   = "oci"
 )
 
 // app is the batteries-included emulator: a serverkit.App wired with the selected
@@ -24,19 +26,9 @@ type app struct {
 	kit *serverkit.App
 }
 
-// newApp assembles the engine options and builds the serverkit App.
-func newApp(cfg *appConfig) (*app, error) {
-	opts, err := buildOptions(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return newAppFromOptions(cfg, opts)
-}
-
-// newAppFromOptions is newApp's core: it builds the serverkit App from an
-// already-assembled option set (identity plus engines). Keeping it separate lets
-// tests supply a pre-built set so an engine can bind a known port.
+// newAppFromOptions builds the serverkit App from an already-assembled option set
+// (identity plus engines). Keeping it separate from option-building lets tests
+// supply a pre-built set so an engine can bind a known port.
 func newAppFromOptions(cfg *appConfig, opts []config.Option) (*app, error) {
 	kit, err := serverkit.New(serverkitConfig(cfg, opts))
 	if err != nil {
@@ -47,27 +39,37 @@ func newAppFromOptions(cfg *appConfig, opts []config.Option) (*app, error) {
 }
 
 // serverkitConfig maps the resolved flag configuration onto a serverkit.Config.
-// This build runs aws/azure/gcp with the real-engine BaseOptions plus the admin
-// control plane, persistence, and init-dir seeding — k8s/oci/tls parity arrives
-// in later PRs. The swap from awsserver.NewFromProvider to serverkit (which
-// builds via <provider>server.DriversFrom) is identity-preserving: DriversFrom
-// copies AccountID/Region/EnforceAuth verbatim, and with k8s disabled K8sAPI is
-// nil on both paths.
+// serverkit builds every selected provider (aws/azure/gcp/oci) via
+// <provider>server.DriversFrom, wires the shared Kubernetes data-plane, admin
+// control plane, persistence, seeding, TLS, latency, request logging, and auth
+// enforcement, and owns the serve/shutdown/snapshot lifecycle plus engine
+// teardown — this module only supplies the real-engine BaseOptions.
 func serverkitConfig(cfg *appConfig, opts []config.Option) *serverkit.Config {
 	return &serverkit.Config{
-		Providers: []string{providerAWS, providerAzure, providerGCP},
-		Host:      cfg.host,
+		Providers:     cfg.providers,
+		Host:          cfg.host,
+		AdvertiseHost: cfg.advertiseHost,
 		Ports: map[string]string{
 			providerAWS:   cfg.awsPort,
 			providerAzure: cfg.azurePort,
 			providerGCP:   cfg.gcpPort,
+			providerOCI:   cfg.ociPort,
 		},
+		K8sPort:             cfg.k8sPort,
 		AzureSubscription:   cfg.azureSubscription,
 		Admin:               cfg.admin,
 		Persist:             cfg.persist,
 		StateFile:           cfg.stateFile,
 		PersistMetadataOnly: cfg.persistMetaOnly,
 		InitDir:             cfg.initDir,
+		TLSCert:             cfg.tlsCert,
+		TLSKey:              cfg.tlsKey,
+		TLSHosts:            cfg.tlsHosts,
+		Latency:             cfg.latency,
+		LogRequests:         cfg.logRequests,
+		Quiet:               cfg.quiet,
+		EnforceAuth:         cfg.enforceAuth,
+		EndpointsFile:       cfg.endpointsFile,
 		BaseOptions:         opts,
 		ShutdownTimeout:     cfg.shutdownTimeout,
 		Out:                 cfg.out,
@@ -80,11 +82,14 @@ func (a *app) Serve(ctx context.Context) error {
 	return a.kit.Serve(ctx)
 }
 
-// buildOptions assembles the identity options plus the selected engine options.
-func buildOptions(cfg *appConfig) ([]config.Option, error) {
-	engineOpts, err := cfg.engines.buildEngineOptions()
+// buildOptions assembles the identity options plus the selected engine options,
+// and returns the per-capability MODE table for the startup banner. dockerProbe
+// reports whether the docker CLI is available; a Docker-backed engine degrades to
+// in-memory (a MODE row) when it is not.
+func buildOptions(cfg *appConfig, dockerProbe func() bool) ([]config.Option, []engineMode, error) {
+	engineOpts, modes, err := cfg.engines.buildEngineOptions(dockerProbe)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	const identityOpts = 3
@@ -96,5 +101,5 @@ func buildOptions(cfg *appConfig) ([]config.Option, error) {
 		config.WithProjectID(cfg.projectID),
 	)
 
-	return append(opts, engineOpts...), nil
+	return append(opts, engineOpts...), modes, nil
 }

--- a/contrib/server/enforce_auth_test.go
+++ b/contrib/server/enforce_auth_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+)
+
+// TestEnforceAuthRejectsInvalidSignature proves --enforce-auth threads through to
+// serverkit's WithEnforceAuth: with it on, an AWS request signed with dummy
+// credentials (an unregistered access key) is rejected with a 403, and with it
+// off the same dummy credentials pass. The SDK signs with the static creds set in
+// awsSDKConfig ("test"/"test"), which are not a registered IAM access key.
+func TestEnforceAuthRejectsInvalidSignature(t *testing.T) {
+	t.Run("enforced rejects", func(t *testing.T) {
+		cfg := testConfig(t, allEnginesOff())
+		cfg.enforceAuth = true
+
+		awsURL, stop := startAWS(t, cfg, mustOptions(t, &cfg))
+		defer stop()
+
+		client := rdsClient(t, awsURL)
+
+		_, err := client.DescribeDBInstances(context.Background(), &rds.DescribeDBInstancesInput{})
+		if err == nil {
+			t.Fatalf("DescribeDBInstances with unregistered creds succeeded, want 403 under --enforce-auth")
+		}
+
+		if !strings.Contains(err.Error(), "403") && !strings.Contains(err.Error(), "InvalidClientTokenId") {
+			t.Fatalf("error does not look like an auth rejection: %v", err)
+		}
+	})
+
+	t.Run("not enforced passes", func(t *testing.T) {
+		cfg := testConfig(t, allEnginesOff())
+		cfg.enforceAuth = false
+
+		awsURL, stop := startAWS(t, cfg, mustOptions(t, &cfg))
+		defer stop()
+
+		client := rdsClient(t, awsURL)
+
+		if _, err := client.DescribeDBInstances(context.Background(), &rds.DescribeDBInstancesInput{}); err != nil {
+			t.Fatalf("DescribeDBInstances with dummy creds failed while --enforce-auth off: %v", err)
+		}
+	})
+}

--- a/contrib/server/engine_degrade_test.go
+++ b/contrib/server/engine_degrade_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+
+	"github.com/stackshy/cloudemu/v2/config"
+)
+
+// noDocker is a socket probe that reports Docker as unavailable, so a
+// Docker-backed selection is forced down its degrade path regardless of the test
+// host — deterministic without requiring (or forbidding) a real docker socket.
+func noDocker() bool { return false }
+
+// withDocker is the opposite probe, so a test can exercise the real-selection
+// path without a live socket.
+func withDocker() bool { return true }
+
+// modeFor returns the MODE row for a capability, failing if it is missing.
+func modeFor(t *testing.T, modes []engineMode, capability string) engineMode {
+	t.Helper()
+
+	for _, m := range modes {
+		if m.capability == capability {
+			return m
+		}
+	}
+
+	t.Fatalf("no MODE row for capability %q", capability)
+
+	return engineMode{}
+}
+
+// TestDockerBackedEngineDegradesWithoutSocket asserts that every Docker-backed
+// selection degrades to in-memory (a MODE row, not an error) when the socket is
+// absent, and that the degraded capability wires no real engine option.
+func TestDockerBackedEngineDegradesWithoutSocket(t *testing.T) {
+	cases := []struct {
+		name string
+		sel  engineSelection
+		cap  string
+	}{
+		{"db=mysql", engineSelection{db: dbMySQL}, capDB},
+		{"db=both", engineSelection{db: dbBoth}, capDB},
+		{"compute=docker", engineSelection{compute: backingDocker}, capCompute},
+		{"containers=docker", engineSelection{containers: backingDocker}, capContainers},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, modes, err := tc.sel.buildEngineOptions(noDocker)
+			if err != nil {
+				t.Fatalf("buildEngineOptions returned error instead of degrading: %v", err)
+			}
+
+			m := modeFor(t, modes, tc.cap)
+			if m.status != modeMemory {
+				t.Fatalf("%s status = %q, want %q", tc.cap, m.status, modeMemory)
+			}
+
+			if m.detail != reasonNoDocker {
+				t.Fatalf("%s detail = %q, want %q", tc.cap, m.detail, reasonNoDocker)
+			}
+
+			// The degraded capability must wire no real engine.
+			o := config.NewOptions(opts...)
+
+			switch tc.cap {
+			case capDB:
+				if o.DatabaseEngine != nil {
+					t.Fatalf("db degraded but DatabaseEngine is wired")
+				}
+			case capCompute:
+				if o.ComputeEngine != nil {
+					t.Fatalf("compute degraded but ComputeEngine is wired")
+				}
+			case capContainers:
+				if o.ContainerEngine != nil {
+					t.Fatalf("containers degraded but ContainerEngine is wired")
+				}
+			}
+		})
+	}
+}
+
+// TestDegradedEngineStillBoots proves a Docker-backed selection with the socket
+// absent still boots the full server and the degraded capability works in-memory:
+// the db degrades to memory, yet an RDS instance can be created and describes with
+// a (synthetic) endpoint. The probe is forced false, so the test never requires
+// Docker.
+func TestDegradedEngineStillBoots(t *testing.T) {
+	cfg := testConfig(t, engineSelection{db: dbMySQL})
+
+	opts, modes, err := buildOptions(&cfg, noDocker)
+	if err != nil {
+		t.Fatalf("buildOptions: %v", err)
+	}
+
+	if m := modeFor(t, modes, capDB); m.status != modeMemory {
+		t.Fatalf("db status = %q, want %q", m.status, modeMemory)
+	}
+
+	awsURL, stop := startAWS(t, cfg, opts)
+	defer stop()
+
+	client := rdsClient(t, awsURL)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBInstance(ctx, &rds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("degraded-db"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		AllocatedStorage:     aws.Int32(20),
+		MasterUsername:       aws.String("u"),
+		MasterUserPassword:   aws.String("password-123"),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance on degraded (in-memory) db: %v", err)
+	}
+
+	desc, err := client.DescribeDBInstances(ctx, &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String("degraded-db"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBInstances: %v", err)
+	}
+
+	if len(desc.DBInstances) != 1 || desc.DBInstances[0].Endpoint == nil {
+		t.Fatalf("degraded db reported no endpoint: %+v", desc.DBInstances)
+	}
+}
+
+// TestStorageEngineWiresOption proves --storage=localfs wires a config.StorageEngine
+// into the built options and records a real MODE row — a unit-level check that
+// needs no S3 SDK.
+func TestStorageEngineWiresOption(t *testing.T) {
+	sel := engineSelection{storage: storageLocalFS, storageDir: t.TempDir()}
+
+	opts, modes, err := sel.buildEngineOptions(withDocker)
+	if err != nil {
+		t.Fatalf("buildEngineOptions: %v", err)
+	}
+
+	if o := config.NewOptions(opts...); o.StorageEngine == nil {
+		t.Fatalf("storage=localfs did not wire a StorageEngine into the options")
+	}
+
+	if m := modeFor(t, modes, capStorage); m.status != modeReal {
+		t.Fatalf("storage status = %q, want %q", m.status, modeReal)
+	}
+}
+
+// TestStorageEngineOffByDefault proves the default selection wires no storage
+// engine, keeping object bytes in-memory.
+func TestStorageEngineOffByDefault(t *testing.T) {
+	sel := allEnginesOff()
+
+	opts, modes, err := sel.buildEngineOptions(withDocker)
+	if err != nil {
+		t.Fatalf("buildEngineOptions: %v", err)
+	}
+
+	if o := config.NewOptions(opts...); o.StorageEngine != nil {
+		t.Fatalf("storage engine wired with no --storage flag")
+	}
+
+	if m := modeFor(t, modes, capStorage); m.status != modeOff {
+		t.Fatalf("storage status = %q, want %q", m.status, modeOff)
+	}
+}

--- a/contrib/server/engines.go
+++ b/contrib/server/engines.go
@@ -10,6 +10,7 @@ import (
 	dockercompute "github.com/stackshy/cloudemu/v2/contrib/dockerengine/compute"
 	dockercontainer "github.com/stackshy/cloudemu/v2/contrib/dockerengine/container"
 	dockermysql "github.com/stackshy/cloudemu/v2/contrib/dockerengine/mysql"
+	"github.com/stackshy/cloudemu/v2/contrib/realengine/blobstore"
 	realfunctions "github.com/stackshy/cloudemu/v2/contrib/realengine/functions"
 	realpostgres "github.com/stackshy/cloudemu/v2/contrib/realengine/postgres"
 	realredis "github.com/stackshy/cloudemu/v2/contrib/realengine/redis"
@@ -30,20 +31,42 @@ const (
 	functionsSubprocess = "subprocess"
 
 	backingDocker = "docker"
+
+	storageLocalFS = "localfs"
 )
+
+// Capability names, used as the left column of the startup MODE banner.
+const (
+	capDB         = "db"
+	capCache      = "cache"
+	capFunctions  = "functions"
+	capCompute    = "compute"
+	capContainers = "containers"
+	capStorage    = "storage"
+)
+
+// MODE statuses reported per capability in the startup banner.
+const (
+	modeOff    = "off"                 // no real engine selected — in-memory
+	modeReal   = "real"                // the selected real engine is wired
+	modeMemory = "fell-back-to-memory" // selected but unavailable, degraded
+)
+
+// reasonNoDocker is the degrade reason when a Docker-backed engine is selected
+// but the docker socket/CLI is absent.
+const reasonNoDocker = "no docker socket"
 
 // defaultEnginePort lets a Docker/embedded engine pick its standard port.
 const defaultEnginePort = 0
 
 // Engine-selection errors. Static so err113 stays satisfied; the offending
-// value is wrapped in at the call site.
+// value is wrapped in at the call site. Docker absence is NOT an error — a
+// Docker-backed selection degrades to in-memory instead (see buildEngineOptions).
 var (
-	// errDockerUnavailable reports a Docker-backed engine was requested but the
-	// docker CLI is not on PATH.
-	errDockerUnavailable = errors.New("docker CLI not found on PATH — required for the selected engine")
 	errInvalidDB         = errors.New("invalid --db value (want off|postgres|mysql|both)")
 	errInvalidCompute    = errors.New("invalid --compute value (want off|docker)")
 	errInvalidContainers = errors.New("invalid --containers value (want off|docker)")
+	errInvalidStorage    = errors.New("invalid --storage value (want off|localfs)")
 )
 
 // engineSelection is the resolved engine choice for each capability.
@@ -53,11 +76,22 @@ type engineSelection struct {
 	functions  string
 	compute    string
 	containers string
+	storage    string
+	storageDir string // root dir for --storage=localfs; empty picks a temp dir
+}
+
+// engineMode is one capability's resolved backing for the startup MODE banner:
+// what it ended up as (real / fell-back-to-memory / off) and a short detail
+// (the engine description, or the fallback reason).
+type engineMode struct {
+	capability string
+	status     string
+	detail     string
 }
 
 // applyAllReal turns on the batteries-included real-engine set (Postgres, Redis,
-// subprocess functions, Docker compute + containers) for any capability still
-// left off.
+// subprocess functions, Docker compute + containers, localfs storage) for any
+// capability still left off.
 func (s *engineSelection) applyAllReal() {
 	if s.db == engineOff {
 		s.db = dbPostgres
@@ -78,59 +112,87 @@ func (s *engineSelection) applyAllReal() {
 	if s.containers == engineOff {
 		s.containers = backingDocker
 	}
+
+	if s.storage == engineOff {
+		s.storage = storageLocalFS
+	}
 }
 
 // buildEngineOptions turns the selection into config.Options that wire the
-// chosen real engines into every cloud. An empty selection returns no options,
-// leaving the emulator fully in-memory.
-func (s *engineSelection) buildEngineOptions() ([]config.Option, error) {
-	var opts []config.Option
+// chosen real engines into every cloud, plus a per-capability MODE table for the
+// startup banner. An empty selection returns no options, leaving the emulator
+// fully in-memory. A Docker-backed engine selected while dockerAvailable reports
+// false degrades to in-memory (a MODE row, not an error) so a socket-less run
+// still boots. Genuinely invalid flag values return an error.
+func (s *engineSelection) buildEngineOptions(dockerAvailable func() bool) ([]config.Option, []engineMode, error) {
+	var (
+		opts  []config.Option
+		modes []engineMode
+	)
 
-	if opt, err := databaseOption(s.db); err != nil {
-		return nil, err
-	} else if opt != nil {
-		opts = append(opts, opt)
-	}
-
-	if s.cache == cacheRedis {
-		opts = append(opts, config.WithCacheEngine(realredis.New()))
-	}
-
-	if s.functions == functionsSubprocess {
-		opts = append(opts, config.WithFunctionEngine(realfunctions.New()))
-	}
-
-	if opt, err := computeOption(s.compute); err != nil {
-		return nil, err
-	} else if opt != nil {
-		opts = append(opts, opt)
-	}
-
-	if opt, err := containerOption(s.containers); err != nil {
-		return nil, err
-	} else if opt != nil {
-		opts = append(opts, opt)
-	}
-
-	return opts, nil
-}
-
-// databaseOption builds the database-engine option for the selection.
-func databaseOption(v string) (config.Option, error) {
-	switch v {
-	case engineOff:
-		return nil, nil
-	case dbPostgres:
-		return config.WithDatabaseEngine(realpostgres.New(defaultEnginePort)), nil
-	case dbMySQL:
-		if !dockerAvailable() {
-			return nil, fmt.Errorf("--db=mysql: %w", errDockerUnavailable)
+	// add records one capability that cannot fail (cache/functions/off).
+	add := func(opt config.Option, m engineMode) {
+		if opt != nil {
+			opts = append(opts, opt)
 		}
 
-		return config.WithDatabaseEngine(dockermysql.New(defaultEnginePort)), nil
+		modes = append(modes, m)
+	}
+
+	// addErr records one capability whose flag value may be invalid.
+	addErr := func(opt config.Option, m engineMode, err error) error {
+		if err != nil {
+			return err
+		}
+
+		add(opt, m)
+
+		return nil
+	}
+
+	// A zero-value selection field means "off" (in-memory): the flag path always
+	// resolves to "off", but a directly-constructed selection may leave it empty.
+	if err := addErr(databaseOption(orOff(s.db), dockerAvailable)); err != nil {
+		return nil, nil, err
+	}
+
+	add(cacheOption(orOff(s.cache)))
+	add(functionsOption(orOff(s.functions)))
+
+	if err := addErr(computeOption(orOff(s.compute), dockerAvailable)); err != nil {
+		return nil, nil, err
+	}
+
+	if err := addErr(containerOption(orOff(s.containers), dockerAvailable)); err != nil {
+		return nil, nil, err
+	}
+
+	if err := addErr(storageOption(orOff(s.storage), s.storageDir)); err != nil {
+		return nil, nil, err
+	}
+
+	return opts, modes, nil
+}
+
+// databaseOption builds the database-engine option for the selection. mysql/both
+// need Docker; without it they degrade to in-memory.
+func databaseOption(v string, dockerAvailable func() bool) (config.Option, engineMode, error) {
+	switch v {
+	case engineOff:
+		return nil, engineMode{capDB, modeOff, ""}, nil
+	case dbPostgres:
+		return config.WithDatabaseEngine(realpostgres.New(defaultEnginePort)),
+			engineMode{capDB, modeReal, "embedded postgres"}, nil
+	case dbMySQL:
+		if !dockerAvailable() {
+			return nil, engineMode{capDB, modeMemory, reasonNoDocker}, nil
+		}
+
+		return config.WithDatabaseEngine(dockermysql.New(defaultEnginePort)),
+			engineMode{capDB, modeReal, "docker mysql"}, nil
 	case dbBoth:
 		if !dockerAvailable() {
-			return nil, fmt.Errorf("--db=both: %w", errDockerUnavailable)
+			return nil, engineMode{capDB, modeMemory, reasonNoDocker}, nil
 		}
 
 		pg, my := realpostgres.New(defaultEnginePort), dockermysql.New(defaultEnginePort)
@@ -142,42 +204,94 @@ func databaseOption(v string) (config.Option, error) {
 			backings: []io.Closer{pg, my},
 		}
 
-		return config.WithDatabaseEngine(eng), nil
+		return config.WithDatabaseEngine(eng), engineMode{capDB, modeReal, "embedded postgres + docker mysql"}, nil
 	default:
-		return nil, fmt.Errorf("%w: %q", errInvalidDB, v)
+		return nil, engineMode{}, fmt.Errorf("%w: %q", errInvalidDB, v)
 	}
 }
 
-// computeOption builds the compute-engine option for the selection.
-func computeOption(v string) (config.Option, error) {
+// cacheOption builds the cache-engine option. Only redis is backed (miniredis,
+// no Docker); any other non-off value leaves the cache in-memory.
+func cacheOption(v string) (config.Option, engineMode) {
+	if v == cacheRedis {
+		return config.WithCacheEngine(realredis.New()), engineMode{capCache, modeReal, "miniredis"}
+	}
+
+	return nil, engineMode{capCache, modeOff, ""}
+}
+
+// functionsOption builds the function-engine option. Only subprocess is backed
+// (runs real python3/node, no Docker); any other non-off value leaves functions
+// stubbed.
+func functionsOption(v string) (config.Option, engineMode) {
+	if v == functionsSubprocess {
+		return config.WithFunctionEngine(realfunctions.New()), engineMode{capFunctions, modeReal, "subprocess (python3/node)"}
+	}
+
+	return nil, engineMode{capFunctions, modeOff, ""}
+}
+
+// computeOption builds the compute-engine option for the selection. docker
+// degrades to in-memory when the socket is absent.
+func computeOption(v string, dockerAvailable func() bool) (config.Option, engineMode, error) {
 	switch v {
 	case engineOff:
-		return nil, nil
+		return nil, engineMode{capCompute, modeOff, ""}, nil
 	case backingDocker:
 		if !dockerAvailable() {
-			return nil, fmt.Errorf("--compute=docker: %w", errDockerUnavailable)
+			return nil, engineMode{capCompute, modeMemory, reasonNoDocker}, nil
 		}
 
-		return config.WithComputeEngine(dockercompute.New()), nil
+		return config.WithComputeEngine(dockercompute.New()), engineMode{capCompute, modeReal, "docker"}, nil
 	default:
-		return nil, fmt.Errorf("%w: %q", errInvalidCompute, v)
+		return nil, engineMode{}, fmt.Errorf("%w: %q", errInvalidCompute, v)
 	}
 }
 
-// containerOption builds the container-engine option for the selection.
-func containerOption(v string) (config.Option, error) {
+// containerOption builds the container-engine option for the selection. docker
+// degrades to in-memory when the socket is absent.
+func containerOption(v string, dockerAvailable func() bool) (config.Option, engineMode, error) {
 	switch v {
 	case engineOff:
-		return nil, nil
+		return nil, engineMode{capContainers, modeOff, ""}, nil
 	case backingDocker:
 		if !dockerAvailable() {
-			return nil, fmt.Errorf("--containers=docker: %w", errDockerUnavailable)
+			return nil, engineMode{capContainers, modeMemory, reasonNoDocker}, nil
 		}
 
-		return config.WithContainerEngine(dockercontainer.New()), nil
+		return config.WithContainerEngine(dockercontainer.New()), engineMode{capContainers, modeReal, "docker"}, nil
 	default:
-		return nil, fmt.Errorf("%w: %q", errInvalidContainers, v)
+		return nil, engineMode{}, fmt.Errorf("%w: %q", errInvalidContainers, v)
 	}
+}
+
+// storageOption builds the storage-engine option for the selection. localfs
+// persists object bytes to a real local filesystem (no Docker); an empty dir
+// picks a temp directory.
+func storageOption(v, dir string) (config.Option, engineMode, error) {
+	switch v {
+	case engineOff:
+		return nil, engineMode{capStorage, modeOff, ""}, nil
+	case storageLocalFS:
+		detail := "localfs"
+		if dir != "" {
+			detail = "localfs " + dir
+		}
+
+		return config.WithStorageEngine(blobstore.New(dir)), engineMode{capStorage, modeReal, detail}, nil
+	default:
+		return nil, engineMode{}, fmt.Errorf("%w: %q", errInvalidStorage, v)
+	}
+}
+
+// orOff maps an empty selection value to "off", so a zero-value engineSelection
+// field is treated as in-memory rather than an invalid value.
+func orOff(v string) string {
+	if v == "" {
+		return engineOff
+	}
+
+	return v
 }
 
 // dockerAvailable reports whether the docker CLI is on PATH. The dockerengine

--- a/contrib/server/main.go
+++ b/contrib/server/main.go
@@ -6,7 +6,8 @@
 // Assembly (provider construction, listener binding, the shutdown/snapshot
 // lifecycle, engine teardown) is delegated to the shared server/serverkit
 // package, so this binary and `cloudemu serve` don't drift; this module only adds
-// the real-engine selection.
+// the real-engine selection and its startup MODE banner. Flag names and defaults
+// mirror `cloudemu serve` for parity.
 package main
 
 import (
@@ -17,6 +18,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -24,27 +26,63 @@ import (
 // defaultShutdownTimeout is the grace period for in-flight requests.
 const defaultShutdownTimeout = 10 * time.Second
 
-// errStateFileRequired is returned when --persist is set without --state-file.
-var errStateFileRequired = errors.New("--persist requires --state-file")
+var (
+	// errStateFileRequired is returned when --persist is set without --state-file.
+	errStateFileRequired = errors.New("--persist requires --state-file")
+	// errTLSPairRequired is returned when only one of --tls-cert/--tls-key is set.
+	errTLSPairRequired = errors.New("--tls-cert and --tls-key must be given together")
+	// errNoProviders is returned when --providers resolves to an empty set.
+	errNoProviders = errors.New("no providers selected")
+	// errUnknownProvider is returned for a --providers value outside aws/azure/gcp/oci.
+	errUnknownProvider = errors.New("unknown provider (want aws, azure, gcp, or oci)")
+)
+
+// stringList is a repeatable string flag (e.g. --tls-host a --tls-host b).
+type stringList []string
+
+func (s *stringList) String() string { return strings.Join(*s, ",") }
+
+func (s *stringList) Set(v string) error {
+	*s = append(*s, v)
+
+	return nil
+}
 
 // appConfig is the resolved flag/env configuration for one server run.
 type appConfig struct {
-	engines           engineSelection
-	host              string
-	awsPort           string
-	azurePort         string
-	gcpPort           string
+	engines engineSelection
+
+	providers     []string // parsed provider set: aws,azure,gcp,oci
+	host          string
+	advertiseHost string
+	awsPort       string
+	azurePort     string
+	gcpPort       string
+	ociPort       string
+	k8sPort       string
+
 	accountID         string
 	azureSubscription string
 	region            string
 	projectID         string
-	admin             bool
-	persist           bool
-	stateFile         string
-	persistMetaOnly   bool
-	initDir           string
-	shutdownTimeout   time.Duration
-	out               io.Writer // banner/diagnostics sink handed to serverkit
+
+	latency  time.Duration
+	tlsCert  string
+	tlsKey   string
+	tlsHosts stringList
+
+	admin           bool
+	logRequests     bool
+	quiet           bool
+	enforceAuth     bool
+	persist         bool
+	stateFile       string
+	persistMetaOnly bool
+	initDir         string
+	endpointsFile   string
+
+	shutdownTimeout time.Duration
+	out             io.Writer // banner/diagnostics sink handed to serverkit
 }
 
 func main() {
@@ -54,9 +92,9 @@ func main() {
 	}
 }
 
-// run parses configuration, builds the server, and blocks until a termination
-// signal (or a fatal serve error) arrives. serverkit owns the serve/shutdown
-// lifecycle, so run only wires the signal context and the engine banner.
+// run parses configuration, builds the server, prints the engine MODE banner,
+// and blocks until a termination signal (or a fatal serve error) arrives.
+// serverkit owns the serve/shutdown lifecycle and the endpoint banner.
 func run(args []string, stdout, stderr io.Writer) error {
 	cfg, err := parseFlags(args, os.Getenv, stderr)
 	if err != nil {
@@ -65,7 +103,12 @@ func run(args []string, stdout, stderr io.Writer) error {
 
 	cfg.out = stdout
 
-	a, err := newApp(&cfg)
+	opts, modes, err := buildOptions(&cfg, dockerAvailable)
+	if err != nil {
+		return err
+	}
+
+	a, err := newAppFromOptions(&cfg, opts)
 	if err != nil {
 		return err
 	}
@@ -73,7 +116,15 @@ func run(args []string, stdout, stderr io.Writer) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	printEngines(&cfg, stdout)
+	// The MODE banner prints before serverkit's endpoint banner: serverkit prints
+	// its banner from inside Serve (which then blocks), so this is the last chance
+	// to emit synchronously. Degrade warnings always go to stderr; the table is
+	// suppressed under --quiet.
+	warnDegraded(stderr, modes)
+
+	if !cfg.quiet {
+		printEngineModes(stdout, modes)
+	}
 
 	// serverkit binds the listeners, prints the endpoint banner, and owns the
 	// graceful-shutdown → persistence-snapshot → engine-teardown ordering. Serve
@@ -82,41 +133,64 @@ func run(args []string, stdout, stderr io.Writer) error {
 }
 
 // parseFlags resolves the configuration from args, with environment-variable
-// fallbacks for the engine selectors.
+// fallbacks for the engine selectors. Flag names/defaults mirror `cloudemu serve`.
 func parseFlags(args []string, getenv func(string) string, out io.Writer) (appConfig, error) {
 	fs := flag.NewFlagSet("cloudemu-server", flag.ContinueOnError)
 	fs.SetOutput(out)
 
-	var cfg appConfig
-
-	var allReal bool
+	var (
+		cfg       appConfig
+		allReal   bool
+		providers string
+	)
 
 	fs.StringVar(&cfg.engines.db, "db", engineEnvOr(getenv, "CLOUDEMU_DB"), "database engine: off|postgres|mysql|both")
 	fs.StringVar(&cfg.engines.cache, "cache", engineEnvOr(getenv, "CLOUDEMU_CACHE"), "cache engine: off|redis")
 	fs.StringVar(&cfg.engines.functions, "functions", engineEnvOr(getenv, "CLOUDEMU_FUNCTIONS"), "function engine: off|subprocess")
 	fs.StringVar(&cfg.engines.compute, "compute", engineEnvOr(getenv, "CLOUDEMU_COMPUTE"), "compute engine: off|docker")
 	fs.StringVar(&cfg.engines.containers, "containers", engineEnvOr(getenv, "CLOUDEMU_CONTAINERS"), "container engine: off|docker")
-	fs.BoolVar(&allReal, "all-real", false, "shorthand: postgres + redis + subprocess + docker compute + docker containers")
+	fs.StringVar(&cfg.engines.storage, "storage", engineEnvOr(getenv, "CLOUDEMU_STORAGE"), "storage engine: off|localfs")
+	fs.StringVar(&cfg.engines.storageDir, "storage-dir", "",
+		"root directory for --storage=localfs (default: a temporary directory)")
+	fs.BoolVar(&allReal, "all-real", false,
+		"shorthand: postgres + redis + subprocess + docker compute + docker containers + localfs storage")
 
+	fs.StringVar(&providers, "providers", "aws,azure,gcp", "comma-separated providers to start: aws,azure,gcp,oci")
 	fs.StringVar(&cfg.host, "host", "127.0.0.1", "host/interface to bind (0.0.0.0 exposes on the network)")
+	fs.StringVar(&cfg.advertiseHost, "advertise-host", "",
+		"host/IP the Kubernetes data-plane endpoint is advertised at in kubeconfigs and its TLS cert "+
+			"(default: --host, or 127.0.0.1 when binding all interfaces such as 0.0.0.0 under Docker)")
 	fs.StringVar(&cfg.awsPort, "aws-port", "4566", "port for the AWS endpoint (HTTP)")
 	fs.StringVar(&cfg.azurePort, "azure-port", "4568", "port for the Azure endpoint (HTTPS)")
 	fs.StringVar(&cfg.gcpPort, "gcp-port", "4569", "port for the GCP endpoint (HTTP)")
-	fs.StringVar(&cfg.accountID, "account-id", "000000000000", "AWS account ID (also GCP) reported by the emulator")
+	fs.StringVar(&cfg.ociPort, "oci-port", "4571", "port for the OCI endpoint (HTTP)")
+	fs.StringVar(&cfg.k8sPort, "k8s-port", "4570", "port for the shared Kubernetes data-plane (HTTPS); empty to disable")
+	fs.StringVar(&cfg.accountID, "account-id", "000000000000", "AWS account ID (also GCP/OCI) reported by the emulator")
 	fs.StringVar(&cfg.azureSubscription, "azure-subscription", "00000000-0000-0000-0000-000000000000",
 		"Azure subscription id reported by the emulator (a GUID)")
 	fs.StringVar(&cfg.region, "region", "us-east-1", "default region reported by the emulator")
 	fs.StringVar(&cfg.projectID, "project-id", "cloudemu-local", "GCP project ID reported by the emulator")
 
+	fs.DurationVar(&cfg.latency, "latency", 0, "artificial latency added to every emulated call (e.g. 20ms)")
+	fs.StringVar(&cfg.tlsCert, "tls-cert", "",
+		"PEM cert file for the Azure HTTPS endpoint (default: a self-signed cert generated in memory)")
+	fs.StringVar(&cfg.tlsKey, "tls-key", "", "PEM key file matching --tls-cert")
+	fs.Var(&cfg.tlsHosts, "tls-host", "extra SAN host/IP for the generated self-signed cert (repeatable)")
+
 	fs.BoolVar(&cfg.admin, "admin", true, "mount the /_cloudemu control plane (reset, health) for test isolation")
+	fs.BoolVar(&cfg.logRequests, "log-requests", false, "log every HTTP request (method, path, status, duration)")
+	fs.BoolVar(&cfg.quiet, "quiet", false, "suppress the startup banner")
+	fs.BoolVar(&cfg.enforceAuth, "enforce-auth", false, "require authentication on each request; off by default")
 	fs.BoolVar(&cfg.persist, "persist", false,
 		"save state to --state-file on shutdown and restore it on startup (includes object bodies)")
 	fs.StringVar(&cfg.stateFile, "state-file", "", "path to the JSON state snapshot (required with --persist)")
 	fs.BoolVar(&cfg.persistMetaOnly, "persist-metadata-only", false,
 		"persist resource structure but omit object bodies (smaller snapshot)")
 	fs.StringVar(&cfg.initDir, "init-dir", "", "apply every *.json seed fixture in this directory on startup")
+	fs.StringVar(&cfg.endpointsFile, "endpoints-file", "", "write the resolved endpoints as JSON to this path")
 
-	fs.DurationVar(&cfg.shutdownTimeout, "shutdown-timeout", defaultShutdownTimeout, "grace period for in-flight requests on shutdown")
+	fs.DurationVar(&cfg.shutdownTimeout, "shutdown-timeout", defaultShutdownTimeout,
+		"grace period for in-flight requests on shutdown")
 
 	if err := fs.Parse(args); err != nil {
 		return appConfig{}, err
@@ -126,11 +200,54 @@ func parseFlags(args []string, getenv func(string) string, out io.Writer) (appCo
 		cfg.engines.applyAllReal()
 	}
 
+	sel, err := parseProviders(providers)
+	if err != nil {
+		return appConfig{}, err
+	}
+
+	cfg.providers = sel
+
+	if (cfg.tlsCert == "") != (cfg.tlsKey == "") {
+		return appConfig{}, errTLSPairRequired
+	}
+
 	if cfg.persist && cfg.stateFile == "" {
 		return appConfig{}, errStateFileRequired
 	}
 
 	return cfg, nil
+}
+
+// parseProviders converts the --providers flag into a de-duplicated, validated
+// provider list. It mirrors `cloudemu serve`'s parse so both entrypoints accept
+// the same values (aws, azure, gcp, oci).
+func parseProviders(s string) ([]string, error) {
+	seen := map[string]bool{}
+
+	var out []string
+
+	for _, raw := range strings.Split(s, ",") {
+		p := strings.TrimSpace(strings.ToLower(raw))
+		if p == "" {
+			continue
+		}
+
+		if p != providerAWS && p != providerAzure && p != providerGCP && p != providerOCI {
+			return nil, fmt.Errorf("%w: %q", errUnknownProvider, p)
+		}
+
+		if !seen[p] {
+			seen[p] = true
+
+			out = append(out, p)
+		}
+	}
+
+	if len(out) == 0 {
+		return nil, errNoProviders
+	}
+
+	return out, nil
 }
 
 // engineEnvOr returns the engine value from the environment for key, defaulting
@@ -143,9 +260,28 @@ func engineEnvOr(getenv func(string) string, key string) string {
 	return engineOff
 }
 
-// printEngines prints the resolved real-engine selection. serverkit prints the
-// endpoint banner and SDK hints itself once the listeners are bound.
-func printEngines(cfg *appConfig, w io.Writer) {
-	fmt.Fprintf(w, "engines: db=%s cache=%s functions=%s compute=%s containers=%s\n",
-		cfg.engines.db, cfg.engines.cache, cfg.engines.functions, cfg.engines.compute, cfg.engines.containers)
+// printEngineModes prints the resolved per-capability engine MODE table.
+// serverkit prints the endpoint banner and SDK hints itself once the listeners
+// are bound.
+func printEngineModes(w io.Writer, modes []engineMode) {
+	fmt.Fprintln(w, "engines:")
+
+	for _, m := range modes {
+		line := fmt.Sprintf("  %-11s %s", m.capability, m.status)
+		if m.detail != "" {
+			line += fmt.Sprintf(" (%s)", m.detail)
+		}
+
+		fmt.Fprintln(w, line)
+	}
+}
+
+// warnDegraded emits one stderr line per capability that fell back to in-memory,
+// so the degrade is visible even under --quiet (which suppresses the table).
+func warnDegraded(stderr io.Writer, modes []engineMode) {
+	for _, m := range modes {
+		if m.status == modeMemory {
+			fmt.Fprintf(stderr, "warning: %s engine fell back to in-memory (%s)\n", m.capability, m.detail)
+		}
+	}
 }

--- a/contrib/server/main_test.go
+++ b/contrib/server/main_test.go
@@ -89,7 +89,7 @@ func TestBatteriesServerIdentityPreserved(t *testing.T) {
 	cfg.accountID = wantAccount
 	cfg.region = wantRegion
 
-	opts, err := buildOptions(&cfg)
+	opts, _, err := buildOptions(&cfg, dockerAvailable)
 	if err != nil {
 		t.Fatalf("buildOptions: %v", err)
 	}
@@ -196,6 +196,7 @@ func testConfig(t *testing.T, engines engineSelection) appConfig {
 
 	return appConfig{
 		engines:           engines,
+		providers:         []string{providerAWS, providerAzure, providerGCP},
 		host:              "127.0.0.1",
 		awsPort:           freePortStr(t),
 		azurePort:         freePortStr(t),
@@ -446,6 +447,7 @@ func allEnginesOff() engineSelection {
 		functions:  engineOff,
 		compute:    engineOff,
 		containers: engineOff,
+		storage:    engineOff,
 	}
 }
 

--- a/contrib/server/parity_endpoints_test.go
+++ b/contrib/server/parity_endpoints_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestOCIEndpointBinds boots the batteries server with --providers aws,oci and
+// asserts the OCI endpoint binds and answers HTTP — proving --oci-port and the
+// oci provider thread through serverkit. It uses a raw HTTP request (no OCI SDK
+// dependency): any HTTP status proves the listener is up and the handler runs.
+func TestOCIEndpointBinds(t *testing.T) {
+	cfg := testConfig(t, allEnginesOff())
+	cfg.providers = []string{providerAWS, providerOCI}
+	cfg.ociPort = freePortStr(t)
+
+	_, stop := startAWS(t, cfg, mustOptions(t, &cfg))
+	defer stop()
+
+	// The AWS listener answering (startAWS waited on it) does not prove OCI bound;
+	// wait for the OCI port explicitly, then hit it.
+	waitListening(t, cfg.host, cfg.ociPort)
+
+	url := "http://" + net.JoinHostPort(cfg.host, cfg.ociPort) + "/"
+
+	resp, err := http.Get(url) //nolint:noctx // short-lived in-process test call
+	if err != nil {
+		t.Fatalf("GET OCI endpoint %s: %v", url, err)
+	}
+
+	defer resp.Body.Close()
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode == 0 {
+		t.Fatalf("OCI endpoint returned no HTTP status")
+	}
+}
+
+// TestKubernetesEndpointReachable boots with the shared Kubernetes data-plane
+// enabled (--k8s-port set) and asserts its HTTPS endpoint answers — proving
+// --k8s-port threads through and serverkit binds the k8s listener with its
+// self-signed serving cert. The cert is self-signed, so the client skips
+// verification; any HTTP status proves the TLS listener is up.
+func TestKubernetesEndpointReachable(t *testing.T) {
+	cfg := testConfig(t, allEnginesOff())
+	cfg.providers = []string{providerAWS}
+	cfg.k8sPort = freePortStr(t)
+
+	_, stop := startAWS(t, cfg, mustOptions(t, &cfg))
+	defer stop()
+
+	waitListening(t, cfg.host, cfg.k8sPort)
+
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // self-signed emulator cert
+		},
+	}
+
+	url := "https://" + net.JoinHostPort(cfg.host, cfg.k8sPort) + "/"
+
+	resp, err := client.Get(url) //nolint:noctx // short-lived in-process test call
+	if err != nil {
+		t.Fatalf("GET Kubernetes endpoint %s: %v", url, err)
+	}
+
+	defer resp.Body.Close()
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode == 0 {
+		t.Fatalf("Kubernetes endpoint returned no HTTP status")
+	}
+}


### PR DESCRIPTION
Brings the batteries-included `contrib/server` to full flag-parity with `cmd/cloudemu serve`. serverkit already wires OCI, the shared Kubernetes data-plane, TLS, latency, request logging, and auth enforcement — this PR only exposes the flags and threads them into `serverkit.Config`. Flag names and defaults mirror `serve.go` exactly.

Batches plan steps **D + E + F** (kept separate for reviewability in the plan; done as one PR since they are the same low-risk pattern). Does **not** touch the Dockerfile / docker.yml / ci.yml — that is the separate final PR G.

## D — OCI + Kubernetes
- `--oci-port` (default 4571), `--k8s-port` (default 4570, empty disables).
- `--providers` accepts `oci` (opt-in), parsed with a mirror of serve.go's `parseProviders`.
- Ports threaded into `serverkit.Config` (`Ports["oci"]`, `K8sPort`). serverkit already mirrors serve.go's OCI (no `SetK8sAPI`) and k8s wiring.

## E — Storage engine + socket-degrade + MODE banner
- `--storage=off|localfs` + `--storage-dir` → `config.WithStorageEngine(blobstore.New(root))` (6th engine); `--all-real` enables it.
- Docker-socket **degrade-to-memory**: when a docker-backed engine (`mysql`/`both`/`compute`/`containers`) is selected but the socket is absent, that capability drops its real option and records a `fell-back-to-memory (no docker socket)` MODE row + one stderr warning, instead of hard-failing. Flag-overrides-env precedence preserved.
- `engines.go` now returns the per-provider `[]config.Option` **and** a per-capability MODE table; `main.go` prints the MODE banner at startup (suppressed under `--quiet`; degrade warnings always shown).

## F — TLS / latency / logging / auth / advertise
- `--tls-cert` / `--tls-key` / `--tls-host` (repeatable), `--latency`, `--log-requests`, `--quiet`, `--enforce-auth`, `--advertise-host`, `--endpoints-file` → matching `serverkit.Config` fields (`Latency`/`EnforceAuth` via the Config fields serverkit maps to `WithLatency`/`WithEnforceAuth`).

## Tests (hand-rolled helpers, no new SDK deps)
- OCI endpoint binds and answers (`--providers aws,oci`).
- Kubernetes HTTPS endpoint reachable when `--k8s-port` set.
- Socket-degrade: forced probe seam asserts db=mysql/both, compute=docker, containers=docker degrade (MODE row + no real engine wired), the server still boots, and the degraded capability works in-memory — deterministic regardless of whether docker is present.
- enforce-auth: with `--enforce-auth` an unregistered-key request is rejected (403); without it dummy creds pass.
- StorageEngine: unit assertion that `--storage=localfs` wires `WithStorageEngine` into the built options (no S3 SDK dep).

README updated: new flags, MODE banner, socket-degrade behavior, and socket-mount security note.