### PR TITLE
ci(contrib-server): publish cloudemu:engines batteries image + contrib CI test/smoke build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,11 +156,39 @@ jobs:
         run: |
           go build ./...
           go vet ./...
+      # embedded-postgres downloads its Postgres binary on first run; cache it so
+      # the CI-safe test tier (no docker socket needed — the E2E uses embedded
+      # Postgres, the degrade tests run WITHOUT docker) doesn't refetch each run.
+      - uses: actions/cache@v4
+        with:
+          path: ~/.embedded-postgres-go
+          key: embedded-postgres-${{ runner.os }}
+      # Advisory (report-only), matching the contrib-* convention: these tests
+      # need no docker socket but the embedded-Postgres binary download can flake;
+      # promote to blocking once proven stable.
+      - name: go test (report-only)
+        working-directory: contrib/server
+        run: "go test -count=1 ./... || echo '::warning::contrib/server go test reported findings (advisory)'"
       - name: install golangci-lint v2
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin"
       - name: golangci-lint run (report-only)
         working-directory: contrib/server
         run: "$(go env GOPATH)/bin/golangci-lint run --timeout=9m ./... || echo '::warning::golangci-lint reported findings (advisory)'"
+      # Only run the heavy multi-stage engines image build when the trees it is
+      # built from change, so it doesn't fire on every repo PR.
+      - name: filter engines-image paths
+        id: engines_paths
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            engines:
+              - 'contrib/server/**'
+              - 'contrib/realengine/**'
+              - 'contrib/dockerengine/**'
+              - 'server/serverkit/**'
+      - name: docker smoke build (engines image)
+        if: steps.engines_paths.outputs.engines == 'true'
+        run: docker build -f contrib/server/Dockerfile -t cloudemu-engines-test .
 
   contrib-terraform:
     name: Contrib (terraform)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,3 +47,52 @@ jobs:
           build-args: VERSION=${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # Batteries-included variant: the same wire server with the real data-plane
+  # engines compiled in (contrib/server/Dockerfile). Separate job because GHA
+  # permissions are per-job. Publishes the :engines moving tag alongside
+  # versioned :vX.Y.Z-engines / :X.Y-engines. It does NOT emit a plain :latest
+  # (that belongs to the root in-memory image above).
+  publish-engines:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          # An explicit tags block, NOT a global flavor.suffix: a suffix flavor
+          # would append `-engines` to every tag (yielding `latest-engines`) and
+          # never produce a bare `engines` tag. v2.2.0 -> :engines, :2.2.0-engines,
+          # :2.2-engines.
+          tags: |
+            type=raw,value=engines
+            type=semver,pattern={{version}},suffix=-engines
+            type=semver,pattern={{major}}.{{minor}},suffix=-engines
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: contrib/server/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: VERSION=${{ github.ref_name }}
+          cache-from: type=gha,scope=engines
+          cache-to: type=gha,mode=max,scope=engines

--- a/contrib/server/Dockerfile
+++ b/contrib/server/Dockerfile
@@ -28,9 +28,13 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # Debian (glibc) so embedded-postgres' binaries run; the docker CLI is copied in
 # so the Docker-backed engines (--db=mysql|both, --compute=docker,
 # --containers=docker) can shell out. Mount the host's docker socket to use them.
+# python3 + nodejs are the interpreters the subprocess functions engine execs
+# (contrib/realengine/functions/functions_runtime.go) — without them
+# --functions=subprocess would be shipped but unusable.
 FROM debian:12-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates python3 nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=docker:27-cli /usr/local/bin/docker /usr/local/bin/docker
@@ -42,10 +46,11 @@ ENV CLOUDEMU_DB=off \
     CLOUDEMU_CACHE=off \
     CLOUDEMU_FUNCTIONS=off \
     CLOUDEMU_COMPUTE=off \
-    CLOUDEMU_CONTAINERS=off
+    CLOUDEMU_CONTAINERS=off \
+    CLOUDEMU_STORAGE=off
 
-# AWS (LocalStack-compatible), Azure (HTTPS), GCP.
-EXPOSE 4566 4568 4569
+# AWS (LocalStack-compatible), Azure (HTTPS), GCP, Kubernetes (4570), OCI (4571).
+EXPOSE 4566 4568 4569 4570 4571
 
 # Bind all interfaces so the container is reachable from the host.
 ENTRYPOINT ["cloudemu-server"]

--- a/contrib/server/Dockerfile.dockerignore
+++ b/contrib/server/Dockerfile.dockerignore
@@ -1,0 +1,11 @@
+# Build context for the batteries-included engines image (contrib/server/Dockerfile).
+# BuildKit uses this in place of the repo-root .dockerignore when building with
+# `-f contrib/server/Dockerfile`. Unlike the root ignore, it KEEPS contrib/ —
+# the engines build needs contrib/server, contrib/realengine and
+# contrib/dockerengine (the module's relative `replace` targets).
+.git
+.github
+.claude
+docs
+*.md
+docker-compose.yml

--- a/contrib/server/README.md
+++ b/contrib/server/README.md
@@ -41,23 +41,39 @@ eval "$(cloudemu env)"
 
 ### Docker
 
-Build from the **repository root** (the module `replace`s the core and engine
-modules by relative path):
+The batteries-included image is published to GHCR as
+**`ghcr.io/stackshy/cloudemu:engines`** (the `:engines` variant of the root
+`ghcr.io/stackshy/cloudemu` in-memory image; versioned tags are
+`:vX.Y.Z-engines` / `:X.Y-engines`). It bundles `python3` and `nodejs` so the
+subprocess functions engine (`--functions=subprocess`) works out of the box, and
+exposes AWS (4566), Azure (4568), GCP (4569), Kubernetes (4570) and OCI (4571).
 
 ```bash
-docker build -f contrib/server/Dockerfile -t cloudemu-server .
+docker pull ghcr.io/stackshy/cloudemu:engines
 
-# In-memory:
-docker run --rm -p 4566:4566 -p 4568:4568 -p 4569:4569 cloudemu-server
-
-# Real Postgres + Redis via env:
+# No-arg run is pure in-memory (identical to `cloudemu serve`); every engine
+# defaults to off until you opt in:
 docker run --rm -p 4566:4566 -p 4568:4568 -p 4569:4569 \
-  -e CLOUDEMU_DB=postgres -e CLOUDEMU_CACHE=redis cloudemu-server
+  ghcr.io/stackshy/cloudemu:engines
+
+# Real Postgres + Redis via env (no Docker socket needed):
+docker run --rm -p 4566:4566 -p 4568:4568 -p 4569:4569 \
+  -e CLOUDEMU_DB=postgres -e CLOUDEMU_CACHE=redis \
+  ghcr.io/stackshy/cloudemu:engines
 
 # Docker-backed engines need the host docker socket:
 docker run --rm -p 4566:4566 -p 4568:4568 -p 4569:4569 \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -e CLOUDEMU_DB=mysql -e CLOUDEMU_CONTAINERS=docker cloudemu-server
+  -e CLOUDEMU_DB=mysql -e CLOUDEMU_CONTAINERS=docker \
+  ghcr.io/stackshy/cloudemu:engines
+```
+
+Or build it yourself from the **repository root** (the module `replace`s the core
+and engine modules by relative path, so the build context must be the repo root,
+not `contrib/server`):
+
+```bash
+docker build -f contrib/server/Dockerfile -t cloudemu-server .
 ```
 
 Without the socket mount, Docker-backed engines **degrade to in-memory** (see the


### PR DESCRIPTION
Final step of the Docker/library parity work — publishes the batteries-included contrib/server as `ghcr.io/stackshy/cloudemu:engines`.

## Changes (all additive — existing :latest publish + CI jobs untouched)
- **contrib/server/Dockerfile** — bundles `python3`+`nodejs` (for the subprocess functions engine), EXPOSEs 4570 (k8s) + 4571 (oci), adds `CLOUDEMU_STORAGE=off`. Engines default off, so a no-arg run is pure in-memory. Build context stays repo root (relative-replace + serverkit import).
- **.github/workflows/docker.yml** — new job publishing the engines image on `v*` tags, with its own `permissions: {contents: read, packages: write}`, explicit `type=raw,value=engines` tag (+ `:vX.Y.Z-engines`/`:X.Y-engines` via semver suffix), separate cache scope. No plain `latest` from this job.
- **.github/workflows/ci.yml** — adds an advisory `go test` (with embedded-postgres cache) + a paths-gated Docker smoke build to the existing contrib-server job.

Now `docker run -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/stackshy/cloudemu:engines` gives real Postgres/Redis/functions/containers.