### PR TITLE
fix(iam): NotAction/NotResource/Condition evaluation + resource-scoped authz (#841)

### DIFF
--- a/docs/coverage/aws/iam.md
+++ b/docs/coverage/aws/iam.md
@@ -60,6 +60,14 @@ AccessKeyResolver is an optional capability: an IAM implementation that can
 | --- | --- |
 | `AccessKeyByID` |  |
 
+### ContextualAuthorizer
+
+ContextualAuthorizer is an optional capability: an IAM implementation that can
+
+| Operation | Description |
+| --- | --- |
+| `CheckPermissionWithContext` |  |
+
 ### PolicyInspector
 
 PolicyInspector is an optional capability: an IAM implementation that can

--- a/docs/coverage/azure/iam.md
+++ b/docs/coverage/azure/iam.md
@@ -60,6 +60,14 @@ AccessKeyResolver is an optional capability: an IAM implementation that can
 | --- | --- |
 | `AccessKeyByID` |  |
 
+### ContextualAuthorizer
+
+ContextualAuthorizer is an optional capability: an IAM implementation that can
+
+| Operation | Description |
+| --- | --- |
+| `CheckPermissionWithContext` |  |
+
 ### PolicyInspector
 
 PolicyInspector is an optional capability: an IAM implementation that can

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -5325,6 +5325,15 @@
         ]
       },
       {
+        "name": "ContextualAuthorizer",
+        "doc": "ContextualAuthorizer is an optional capability: an IAM implementation that can",
+        "operations": [
+          {
+            "name": "CheckPermissionWithContext"
+          }
+        ]
+      },
+      {
         "name": "PolicyInspector",
         "doc": "PolicyInspector is an optional capability: an IAM implementation that can",
         "operations": [

--- a/docs/coverage/gcp/iam.md
+++ b/docs/coverage/gcp/iam.md
@@ -60,6 +60,14 @@ AccessKeyResolver is an optional capability: an IAM implementation that can
 | --- | --- |
 | `AccessKeyByID` |  |
 
+### ContextualAuthorizer
+
+ContextualAuthorizer is an optional capability: an IAM implementation that can
+
+| Operation | Description |
+| --- | --- |
+| `CheckPermissionWithContext` |  |
+
 ### PolicyInspector
 
 PolicyInspector is an optional capability: an IAM implementation that can

--- a/docs/coverage/oci/identity.md
+++ b/docs/coverage/oci/identity.md
@@ -60,6 +60,14 @@ AccessKeyResolver is an optional capability: an IAM implementation that can
 | --- | --- |
 | `AccessKeyByID` |  |
 
+### ContextualAuthorizer
+
+ContextualAuthorizer is an optional capability: an IAM implementation that can
+
+| Operation | Description |
+| --- | --- |
+| `CheckPermissionWithContext` |  |
+
 ### PolicyInspector
 
 PolicyInspector is an optional capability: an IAM implementation that can

--- a/providers/aws/iam/condition.go
+++ b/providers/aws/iam/condition.go
@@ -1,0 +1,332 @@
+package iam
+
+import (
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ConditionContext carries the request condition keys available for policy
+// evaluation (e.g. "aws:SourceIp", "aws:CurrentTime", "aws:SecureTransport",
+// "aws:PrincipalArn", "aws:RequestedRegion"). AWS condition keys are matched
+// case-insensitively, so lookups normalize the key. A nil or empty context means
+// no keys are available: a plain condition referencing a key then fails to
+// match, while its ...IfExists variant passes (real IAM rules).
+type ConditionContext map[string]string
+
+// get resolves a condition key case-insensitively, reporting whether it was
+// present in the request context.
+func (c ConditionContext) get(key string) (string, bool) {
+	if c == nil {
+		return "", false
+	}
+
+	if v, ok := c[key]; ok {
+		return v, true
+	}
+
+	for k, v := range c {
+		if strings.EqualFold(k, key) {
+			return v, true
+		}
+	}
+
+	return "", false
+}
+
+// evaluateConditions reports whether every operator/key in a statement's
+// Condition block is satisfied against the request context. AWS combines them
+// with AND across operators and AND across keys within an operator; within a
+// single key the listed values combine with OR (a negative operator requires
+// that none match). An empty condition block is vacuously true.
+func evaluateConditions(conds map[string]map[string]any, cctx ConditionContext) bool {
+	for rawOp, keyVals := range conds {
+		for key, raw := range keyVals {
+			if !evaluateConditionKey(rawOp, key, toStringSlice(raw), cctx) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// evaluateConditionKey evaluates one operator against one condition key and its
+// policy-supplied values. It resolves the request value from the context,
+// applies the ...IfExists rule for an absent key, and dispatches to the operator
+// family. The Null operator is handled first because it is defined in terms of
+// key presence, not the key's value.
+func evaluateConditionKey(rawOp, key string, values []string, cctx ConditionContext) bool {
+	base, ifExists := splitIfExists(rawOp)
+
+	ctxVal, present := cctx.get(key)
+
+	if strings.EqualFold(base, "Null") {
+		return evalNull(present, values)
+	}
+
+	if !present {
+		// A missing key never matches a plain condition; the ...IfExists variant
+		// passes so the statement is gated only when the key is actually supplied.
+		return ifExists
+	}
+
+	return evalPresentOperator(base, ctxVal, values)
+}
+
+// evalPresentOperator evaluates an operator whose key is present. String-shaped
+// operators (String*, Arn*, Ip*, Bool) share the value-comparator path; the
+// numeric and date families parse their operands. An unrecognized operator
+// conservatively fails to match.
+func evalPresentOperator(op, ctxVal string, values []string) bool {
+	if cmp, negate, ok := comparatorFor(op); ok {
+		return matchAny(values, negate, func(policyVal string) bool { return cmp(ctxVal, policyVal) })
+	}
+
+	if result, ok := evalNumeric(op, ctxVal, values); ok {
+		return result
+	}
+
+	if result, ok := evalDate(op, ctxVal, values); ok {
+		return result
+	}
+
+	return false
+}
+
+// splitIfExists strips a trailing "IfExists" suffix from an operator name,
+// reporting whether it was present.
+func splitIfExists(op string) (base string, ifExists bool) {
+	const suffix = "IfExists"
+	if strings.HasSuffix(op, suffix) && len(op) > len(suffix) {
+		return op[:len(op)-len(suffix)], true
+	}
+
+	return op, false
+}
+
+// matchAny applies pred to each policy value. For a positive operator it reports
+// whether any value matches; for a negative operator (negate) it reports whether
+// none match.
+func matchAny(values []string, negate bool, pred func(policyVal string) bool) bool {
+	for _, v := range values {
+		if pred(v) {
+			return !negate
+		}
+	}
+
+	return negate
+}
+
+// comparatorFor returns the string-value comparator for op (comparing the
+// request value to a policy value), whether the operator is negative, and
+// whether op belongs to a string-shaped family.
+func comparatorFor(op string) (cmp func(ctxVal, policyVal string) bool, negate, ok bool) {
+	if cmp, negate, ok := stringOp(op); ok {
+		return cmp, negate, ok
+	}
+
+	if cmp, negate, ok := arnOp(op); ok {
+		return cmp, negate, ok
+	}
+
+	if cmp, negate, ok := ipOp(op); ok {
+		return cmp, negate, ok
+	}
+
+	if op == "Bool" {
+		return boolMatch, false, true
+	}
+
+	return nil, false, false
+}
+
+func stringOp(op string) (cmp func(ctxVal, policyVal string) bool, negate, ok bool) {
+	switch op {
+	case "StringEquals":
+		return strEqual, false, true
+	case "StringNotEquals":
+		return strEqual, true, true
+	case "StringEqualsIgnoreCase":
+		return strings.EqualFold, false, true
+	case "StringNotEqualsIgnoreCase":
+		return strings.EqualFold, true, true
+	case "StringLike":
+		return strLike, false, true
+	case "StringNotLike":
+		return strLike, true, true
+	default:
+		return nil, false, false
+	}
+}
+
+// arnOp handles ARN operators. ArnEquals and ArnLike both allow the * wildcard
+// (AWS treats them equivalently apart from documented case handling).
+func arnOp(op string) (cmp func(ctxVal, policyVal string) bool, negate, ok bool) {
+	switch op {
+	case "ArnEquals", "ArnLike":
+		return strLike, false, true
+	case "ArnNotEquals", "ArnNotLike":
+		return strLike, true, true
+	default:
+		return nil, false, false
+	}
+}
+
+func ipOp(op string) (cmp func(ctxVal, policyVal string) bool, negate, ok bool) {
+	switch op {
+	case "IpAddress":
+		return ipMatch, false, true
+	case "NotIpAddress":
+		return ipMatch, true, true
+	default:
+		return nil, false, false
+	}
+}
+
+func strEqual(ctxVal, policyVal string) bool { return ctxVal == policyVal }
+
+// strLike matches ctxVal against a policy pattern that may contain * wildcards.
+func strLike(ctxVal, policyVal string) bool { return wildcardMatch(policyVal, ctxVal) }
+
+// boolMatch compares the request and policy values as booleans.
+func boolMatch(ctxVal, policyVal string) bool {
+	return strings.EqualFold(ctxVal, "true") == strings.EqualFold(policyVal, "true")
+}
+
+// ipMatch reports whether the request IP falls within the policy CIDR block (or
+// equals the policy bare address).
+func ipMatch(ctxVal, policyVal string) bool {
+	ip := net.ParseIP(strings.TrimSpace(ctxVal))
+	if ip == nil {
+		return false
+	}
+
+	return ipInCIDR(ip, strings.TrimSpace(policyVal))
+}
+
+// ipInCIDR reports whether ip falls within the CIDR block cidr. A bare address
+// (no "/") is treated as a single-host match.
+func ipInCIDR(ip net.IP, cidr string) bool {
+	if !strings.Contains(cidr, "/") {
+		other := net.ParseIP(cidr)
+		return other != nil && ip.Equal(other)
+	}
+
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false
+	}
+
+	return network.Contains(ip)
+}
+
+// evalNumeric evaluates a numeric operator. It reports handled=false when op is
+// not a numeric operator, so the dispatcher can try the next family.
+func evalNumeric(op, ctxVal string, values []string) (result, handled bool) {
+	rel, negate, ok := numericRelation(op)
+	if !ok {
+		return false, false
+	}
+
+	cf, err := strconv.ParseFloat(strings.TrimSpace(ctxVal), 64)
+	if err != nil {
+		return false, true
+	}
+
+	return matchAny(values, negate, func(policyVal string) bool {
+		vf, perr := strconv.ParseFloat(strings.TrimSpace(policyVal), 64)
+		return perr == nil && rel(cf, vf)
+	}), true
+}
+
+// numericRelation maps a numeric operator to its comparison (equality is used
+// for both NumericEquals and NumericNotEquals; the latter negates the match).
+func numericRelation(op string) (rel func(c, v float64) bool, negate, ok bool) {
+	switch op {
+	case "NumericEquals":
+		return func(c, v float64) bool { return c == v }, false, true
+	case "NumericNotEquals":
+		return func(c, v float64) bool { return c == v }, true, true
+	case "NumericLessThan":
+		return func(c, v float64) bool { return c < v }, false, true
+	case "NumericLessThanEquals":
+		return func(c, v float64) bool { return c <= v }, false, true
+	case "NumericGreaterThan":
+		return func(c, v float64) bool { return c > v }, false, true
+	case "NumericGreaterThanEquals":
+		return func(c, v float64) bool { return c >= v }, false, true
+	default:
+		return nil, false, false
+	}
+}
+
+// evalDate evaluates a date operator. It reports handled=false when op is not a
+// date operator.
+func evalDate(op, ctxVal string, values []string) (result, handled bool) {
+	rel, negate, ok := dateRelation(op)
+	if !ok {
+		return false, false
+	}
+
+	ct, err := parseDate(ctxVal)
+	if err != nil {
+		return false, true
+	}
+
+	return matchAny(values, negate, func(policyVal string) bool {
+		vt, perr := parseDate(policyVal)
+		return perr == nil && rel(ct, vt)
+	}), true
+}
+
+// dateRelation maps a date operator to its comparison (equality is used for both
+// DateEquals and DateNotEquals; the latter negates the match).
+func dateRelation(op string) (rel func(c, v time.Time) bool, negate, ok bool) {
+	switch op {
+	case "DateEquals":
+		return func(c, v time.Time) bool { return c.Equal(v) }, false, true
+	case "DateNotEquals":
+		return func(c, v time.Time) bool { return c.Equal(v) }, true, true
+	case "DateLessThan":
+		return func(c, v time.Time) bool { return c.Before(v) }, false, true
+	case "DateLessThanEquals":
+		return func(c, v time.Time) bool { return !c.After(v) }, false, true
+	case "DateGreaterThan":
+		return func(c, v time.Time) bool { return c.After(v) }, false, true
+	case "DateGreaterThanEquals":
+		return func(c, v time.Time) bool { return !c.Before(v) }, false, true
+	default:
+		return nil, false, false
+	}
+}
+
+// parseDate accepts an ISO 8601 / RFC 3339 timestamp or an epoch-seconds value,
+// matching the forms AWS accepts for date condition keys and values.
+func parseDate(s string) (time.Time, error) {
+	s = strings.TrimSpace(s)
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+
+	if secs, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return time.Unix(secs, 0).UTC(), nil
+	}
+
+	return time.Parse("2006-01-02T15:04:05Z", s)
+}
+
+// evalNull implements the Null operator: a value of "true" requires the key to
+// be absent from the request, "false" requires it to be present. Multiple values
+// combine with OR.
+func evalNull(present bool, values []string) bool {
+	for _, v := range values {
+		wantAbsent := strings.EqualFold(strings.TrimSpace(v), "true")
+		if wantAbsent == !present {
+			return true
+		}
+	}
+
+	return false
+}

--- a/providers/aws/iam/condition_test.go
+++ b/providers/aws/iam/condition_test.go
@@ -1,0 +1,348 @@
+package iam
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// decideDoc evaluates a single policy document for one action/resource with the
+// given request context, returning the simulation decision.
+func decideDoc(doc, action, resource string, cctx ConditionContext) string {
+	return decide([]string{doc}, action, resource, cctx)
+}
+
+// TestNotActionDeny proves a Deny with NotAction blocks every action EXCEPT the
+// listed one (fail-closed), while the listed action is still allowed.
+func TestNotActionDeny(t *testing.T) {
+	doc := makePolicyDoc([]map[string]any{
+		{"Effect": "Allow", "Action": "s3:*", "Resource": "*"},
+		{"Effect": "Deny", "NotAction": "s3:GetObject", "Resource": "*"},
+	})
+
+	// The listed action is exempt from the Deny, so it stays allowed.
+	assertEqual(t, decisionAllowed, decideDoc(doc, "s3:GetObject", "*", nil))
+
+	// Every other action falls into the NotAction complement and is denied.
+	assertEqual(t, decisionExplicitDeny, decideDoc(doc, "s3:PutObject", "*", nil))
+	assertEqual(t, decisionExplicitDeny, decideDoc(doc, "s3:DeleteObject", "*", nil))
+}
+
+// TestNotActionAllow proves an Allow with NotAction grants every action except
+// the listed ones.
+func TestNotActionAllow(t *testing.T) {
+	doc := makePolicyDoc([]map[string]any{
+		{"Effect": "Allow", "NotAction": []any{"iam:*", "sts:*"}, "Resource": "*"},
+	})
+
+	assertEqual(t, decisionAllowed, decideDoc(doc, "s3:GetObject", "*", nil))
+	assertEqual(t, decisionImplicitDeny, decideDoc(doc, "iam:CreateUser", "*", nil))
+}
+
+// TestNotResource proves NotResource matches every resource except the listed
+// ones, for both Deny and Allow.
+func TestNotResource(t *testing.T) {
+	deny := makePolicyDoc([]map[string]any{
+		{"Effect": "Allow", "Action": "s3:*", "Resource": "*"},
+		{"Effect": "Deny", "Action": "s3:*", "NotResource": "arn:aws:s3:::safe/*"},
+	})
+
+	// A resource inside the exempted set is not denied.
+	assertEqual(t, decisionAllowed, decideDoc(deny, "s3:GetObject", "arn:aws:s3:::safe/report.txt", nil))
+	// A resource outside it falls into the complement and is denied.
+	assertEqual(t, decisionExplicitDeny, decideDoc(deny, "s3:GetObject", "arn:aws:s3:::other/x", nil))
+}
+
+// TestConditionOperators exercises each supported condition operator against a
+// supplied request context.
+func TestConditionOperators(t *testing.T) {
+	tests := []struct {
+		name    string
+		cond    map[string]any
+		cctx    ConditionContext
+		allowed bool
+	}{
+		{
+			name:    "StringEquals match",
+			cond:    map[string]any{"StringEquals": map[string]any{"aws:username": "bob"}},
+			cctx:    ConditionContext{"aws:username": "bob"},
+			allowed: true,
+		},
+		{
+			name:    "StringEquals mismatch",
+			cond:    map[string]any{"StringEquals": map[string]any{"aws:username": "bob"}},
+			cctx:    ConditionContext{"aws:username": "alice"},
+			allowed: false,
+		},
+		{
+			name:    "StringNotEquals blocks listed",
+			cond:    map[string]any{"StringNotEquals": map[string]any{"aws:username": "bob"}},
+			cctx:    ConditionContext{"aws:username": "bob"},
+			allowed: false,
+		},
+		{
+			name:    "StringLike wildcard",
+			cond:    map[string]any{"StringLike": map[string]any{"aws:PrincipalArn": "arn:aws:iam::*:user/dev-*"}},
+			cctx:    ConditionContext{"aws:PrincipalArn": "arn:aws:iam::123:user/dev-bob"},
+			allowed: true,
+		},
+		{
+			name:    "StringEqualsIgnoreCase",
+			cond:    map[string]any{"StringEqualsIgnoreCase": map[string]any{"aws:username": "BOB"}},
+			cctx:    ConditionContext{"aws:username": "bob"},
+			allowed: true,
+		},
+		{
+			name:    "Bool secure transport true",
+			cond:    map[string]any{"Bool": map[string]any{"aws:SecureTransport": "true"}},
+			cctx:    ConditionContext{"aws:SecureTransport": "true"},
+			allowed: true,
+		},
+		{
+			name:    "Bool secure transport denied",
+			cond:    map[string]any{"Bool": map[string]any{"aws:SecureTransport": "true"}},
+			cctx:    ConditionContext{"aws:SecureTransport": "false"},
+			allowed: false,
+		},
+		{
+			name:    "NumericLessThan allows below",
+			cond:    map[string]any{"NumericLessThan": map[string]any{"s3:max-keys": "100"}},
+			cctx:    ConditionContext{"s3:max-keys": "50"},
+			allowed: true,
+		},
+		{
+			name:    "NumericLessThan denies at/above",
+			cond:    map[string]any{"NumericLessThan": map[string]any{"s3:max-keys": "100"}},
+			cctx:    ConditionContext{"s3:max-keys": "150"},
+			allowed: false,
+		},
+		{
+			name:    "IpAddress inside CIDR",
+			cond:    map[string]any{"IpAddress": map[string]any{"aws:SourceIp": "10.0.0.0/8"}},
+			cctx:    ConditionContext{"aws:SourceIp": "10.1.2.3"},
+			allowed: true,
+		},
+		{
+			name:    "IpAddress outside CIDR",
+			cond:    map[string]any{"IpAddress": map[string]any{"aws:SourceIp": "10.0.0.0/8"}},
+			cctx:    ConditionContext{"aws:SourceIp": "192.168.1.1"},
+			allowed: false,
+		},
+		{
+			name:    "NotIpAddress blocks inside CIDR",
+			cond:    map[string]any{"NotIpAddress": map[string]any{"aws:SourceIp": "10.0.0.0/8"}},
+			cctx:    ConditionContext{"aws:SourceIp": "10.1.2.3"},
+			allowed: false,
+		},
+		{
+			name:    "ArnLike match",
+			cond:    map[string]any{"ArnLike": map[string]any{"aws:PrincipalArn": "arn:aws:iam::*:role/app-*"}},
+			cctx:    ConditionContext{"aws:PrincipalArn": "arn:aws:iam::123:role/app-web"},
+			allowed: true,
+		},
+		{
+			name:    "DateGreaterThan after",
+			cond:    map[string]any{"DateGreaterThan": map[string]any{"aws:CurrentTime": "2020-01-01T00:00:00Z"}},
+			cctx:    ConditionContext{"aws:CurrentTime": "2025-06-01T00:00:00Z"},
+			allowed: true,
+		},
+		{
+			name:    "DateGreaterThan before denies",
+			cond:    map[string]any{"DateGreaterThan": map[string]any{"aws:CurrentTime": "2020-01-01T00:00:00Z"}},
+			cctx:    ConditionContext{"aws:CurrentTime": "2019-01-01T00:00:00Z"},
+			allowed: false,
+		},
+		{
+			name:    "IfExists passes when key absent",
+			cond:    map[string]any{"StringEqualsIfExists": map[string]any{"aws:username": "bob"}},
+			cctx:    ConditionContext{},
+			allowed: true,
+		},
+		{
+			name:    "IfExists still enforces when key present",
+			cond:    map[string]any{"StringEqualsIfExists": map[string]any{"aws:username": "bob"}},
+			cctx:    ConditionContext{"aws:username": "alice"},
+			allowed: false,
+		},
+		{
+			name:    "plain condition fails when key absent",
+			cond:    map[string]any{"StringEquals": map[string]any{"aws:username": "bob"}},
+			cctx:    ConditionContext{},
+			allowed: false,
+		},
+		{
+			name:    "Null false requires key present",
+			cond:    map[string]any{"Null": map[string]any{"aws:username": "false"}},
+			cctx:    ConditionContext{"aws:username": "bob"},
+			allowed: true,
+		},
+		{
+			name:    "Null false denies when key absent",
+			cond:    map[string]any{"Null": map[string]any{"aws:username": "false"}},
+			cctx:    ConditionContext{},
+			allowed: false,
+		},
+		{
+			name:    "Null true requires key absent",
+			cond:    map[string]any{"Null": map[string]any{"aws:MultiFactorAuthPresent": "true"}},
+			cctx:    ConditionContext{},
+			allowed: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := makePolicyDoc([]map[string]any{
+				{"Effect": "Allow", "Action": "ec2:RunInstances", "Resource": "*", "Condition": tc.cond},
+			})
+
+			got := decideDoc(doc, "ec2:RunInstances", "*", tc.cctx)
+
+			want := decisionImplicitDeny
+			if tc.allowed {
+				want = decisionAllowed
+			}
+
+			assertEqual(t, want, got)
+		})
+	}
+}
+
+// TestConditionMultipleKeysAnd proves that multiple keys under one operator must
+// all be satisfied (AWS AND semantics).
+func TestConditionMultipleKeysAnd(t *testing.T) {
+	doc := makePolicyDoc([]map[string]any{
+		{
+			"Effect": "Allow", "Action": "ec2:RunInstances", "Resource": "*",
+			"Condition": map[string]any{"StringEquals": map[string]any{
+				"aws:username":        "bob",
+				"aws:RequestedRegion": "us-east-1",
+			}},
+		},
+	})
+
+	both := ConditionContext{"aws:username": "bob", "aws:RequestedRegion": "us-east-1"}
+	assertEqual(t, decisionAllowed, decideDoc(doc, "ec2:RunInstances", "*", both))
+
+	wrongRegion := ConditionContext{"aws:username": "bob", "aws:RequestedRegion": "eu-west-1"}
+	assertEqual(t, decisionImplicitDeny, decideDoc(doc, "ec2:RunInstances", "*", wrongRegion))
+}
+
+// TestConditionValueListOr proves multiple values for one key combine with OR.
+func TestConditionValueListOr(t *testing.T) {
+	doc := makePolicyDoc([]map[string]any{
+		{
+			"Effect": "Allow", "Action": "ec2:RunInstances", "Resource": "*",
+			"Condition": map[string]any{"StringEquals": map[string]any{
+				"aws:RequestedRegion": []any{"us-east-1", "us-west-2"},
+			}},
+		},
+	})
+
+	assertEqual(t, decisionAllowed, decideDoc(doc, "ec2:RunInstances", "*",
+		ConditionContext{"aws:RequestedRegion": "us-west-2"}))
+	assertEqual(t, decisionImplicitDeny, decideDoc(doc, "ec2:RunInstances", "*",
+		ConditionContext{"aws:RequestedRegion": "eu-west-1"}))
+}
+
+// TestCheckPermissionWithContext proves the integration path evaluates a
+// Condition-guarded policy against the supplied request context.
+func TestCheckPermissionWithContext(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateUser(ctx, driver.UserConfig{Name: "bob"})
+	requireNoError(t, err)
+
+	doc := makePolicyDoc([]map[string]any{
+		{
+			"Effect": "Allow", "Action": "ec2:RunInstances", "Resource": "*",
+			"Condition": map[string]any{"IpAddress": map[string]any{"aws:SourceIp": "10.0.0.0/8"}},
+		},
+	})
+
+	pol, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "p", PolicyDocument: doc})
+	requireNoError(t, err)
+	requireNoError(t, m.AttachUserPolicy(ctx, "bob", pol.ARN))
+
+	allowed, err := m.CheckPermissionWithContext(ctx, "bob", "ec2:RunInstances", "*",
+		map[string]string{"aws:SourceIp": "10.9.9.9"})
+	requireNoError(t, err)
+	assertEqual(t, true, allowed)
+
+	denied, err := m.CheckPermissionWithContext(ctx, "bob", "ec2:RunInstances", "*",
+		map[string]string{"aws:SourceIp": "8.8.8.8"})
+	requireNoError(t, err)
+	assertEqual(t, false, denied)
+
+	// CheckPermission (no context) sees the guarded statement as unmatched.
+	plain, err := m.CheckPermission(ctx, "bob", "ec2:RunInstances", "*")
+	requireNoError(t, err)
+	assertEqual(t, false, plain)
+}
+
+// TestCheckPermissionResourceScoped proves a resource-scoped policy allows the
+// matching resource and denies a non-matching one.
+func TestCheckPermissionResourceScoped(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateUser(ctx, driver.UserConfig{Name: "carol"})
+	requireNoError(t, err)
+
+	doc := makeAllowDoc("s3:GetObject", "arn:aws:s3:::allowed/*")
+	pol, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "rs", PolicyDocument: doc})
+	requireNoError(t, err)
+	requireNoError(t, m.AttachUserPolicy(ctx, "carol", pol.ARN))
+
+	allowed, err := m.CheckPermission(ctx, "carol", "s3:GetObject", "arn:aws:s3:::allowed/report.txt")
+	requireNoError(t, err)
+	assertEqual(t, true, allowed)
+
+	denied, err := m.CheckPermission(ctx, "carol", "s3:GetObject", "arn:aws:s3:::other/report.txt")
+	requireNoError(t, err)
+	assertEqual(t, false, denied)
+}
+
+// TestSimulateReflectsCondition proves SimulatePrincipalPolicy honors the
+// request context passed through ContextEntries, including NotAction Deny.
+func TestSimulateReflectsCondition(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateUser(ctx, driver.UserConfig{Name: "dave"})
+	requireNoError(t, err)
+
+	doc := makePolicyDoc([]map[string]any{
+		{
+			"Effect": "Allow", "Action": "ec2:RunInstances", "Resource": "*",
+			"Condition": map[string]any{"StringEquals": map[string]any{"aws:username": "dave"}},
+		},
+		{"Effect": "Deny", "NotAction": "ec2:RunInstances", "Resource": "*"},
+	})
+
+	pol, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "sp", PolicyDocument: doc})
+	requireNoError(t, err)
+	requireNoError(t, m.AttachUserPolicy(ctx, "dave", pol.ARN))
+
+	src := "arn:aws:iam::123456789012:user/dave"
+
+	// With the matching context, the conditioned Allow applies.
+	res, err := m.SimulatePrincipalPolicy(ctx, src, []string{"ec2:RunInstances"}, nil, nil,
+		map[string]string{"aws:username": "dave"})
+	requireNoError(t, err)
+	assertEqual(t, decisionAllowed, decisionOf(res, "ec2:RunInstances"))
+
+	// A different context fails the condition, so the Allow no longer applies.
+	res, err = m.SimulatePrincipalPolicy(ctx, src, []string{"ec2:RunInstances"}, nil, nil,
+		map[string]string{"aws:username": "eve"})
+	requireNoError(t, err)
+	assertEqual(t, decisionImplicitDeny, decisionOf(res, "ec2:RunInstances"))
+
+	// The NotAction Deny blocks any other action (fail-closed).
+	res, err = m.SimulatePrincipalPolicy(ctx, src, []string{"ec2:TerminateInstances"}, nil, nil,
+		map[string]string{"aws:username": "dave"})
+	requireNoError(t, err)
+	assertEqual(t, decisionExplicitDeny, decisionOf(res, "ec2:TerminateInstances"))
+}

--- a/providers/aws/iam/iam.go
+++ b/providers/aws/iam/iam.go
@@ -756,9 +756,40 @@ type policyDoc struct {
 }
 
 type policyStatement struct {
-	Effect   string `json:"Effect"`
-	Action   any    `json:"Action"`
-	Resource any    `json:"Resource"`
+	Effect      string                    `json:"Effect"`
+	Action      any                       `json:"Action"`
+	NotAction   any                       `json:"NotAction"`
+	Resource    any                       `json:"Resource"`
+	NotResource any                       `json:"NotResource"`
+	Condition   map[string]map[string]any `json:"Condition"`
+}
+
+// actionMatches reports whether the statement applies to action. Action and
+// NotAction are mutually exclusive: NotAction matches every action EXCEPT those
+// listed. A statement carrying neither cannot match (AWS requires one).
+func (s *policyStatement) actionMatches(action string) bool {
+	switch {
+	case s.Action != nil:
+		return matchesAction(toStringSlice(s.Action), action)
+	case s.NotAction != nil:
+		return !matchesAction(toStringSlice(s.NotAction), action)
+	default:
+		return false
+	}
+}
+
+// resourceMatches reports whether the statement applies to resource. Resource
+// and NotResource are mutually exclusive: NotResource matches every resource
+// EXCEPT those listed. A statement carrying neither cannot match.
+func (s *policyStatement) resourceMatches(resource string) bool {
+	switch {
+	case s.Resource != nil:
+		return matchesResource(toStringSlice(s.Resource), resource)
+	case s.NotResource != nil:
+		return !matchesResource(toStringSlice(s.NotResource), resource)
+	default:
+		return false
+	}
 }
 
 func wildcardMatch(pattern, value string) bool {
@@ -829,21 +860,22 @@ func matchesResource(resources []string, resource string) bool {
 	return false
 }
 
-func evaluatePolicy(doc, action, resource string) (allow, deny bool) {
+func evaluatePolicy(doc, action, resource string, cctx ConditionContext) (allow, deny bool) {
 	var pd policyDoc
 	if err := json.Unmarshal([]byte(doc), &pd); err != nil {
 		return false, false
 	}
 
 	for _, stmt := range pd.Statement {
-		actions := toStringSlice(stmt.Action)
-		resources := toStringSlice(stmt.Resource)
-
-		if !matchesAction(actions, action) {
+		if !stmt.actionMatches(action) {
 			continue
 		}
 
-		if !matchesResource(resources, resource) {
+		if !stmt.resourceMatches(resource) {
+			continue
+		}
+
+		if !evaluateConditions(stmt.Condition, cctx) {
 			continue
 		}
 
@@ -864,15 +896,28 @@ func evaluatePolicy(doc, action, resource string) (allow, deny bool) {
 // when a permissions boundary is attached, intersects that set with the
 // boundary: the action must be allowed by BOTH the identity policies and the
 // boundary. An explicit Deny anywhere wins; the default is an implicit deny.
-func (m *Mock) CheckPermission(_ context.Context, principal, action, resource string) (bool, error) {
-	entityType := m.principalEntityType(principal)
+func (m *Mock) CheckPermission(ctx context.Context, principal, action, resource string) (bool, error) {
+	return m.CheckPermissionWithContext(ctx, principal, action, resource, nil)
+}
 
-	if decide(m.gatherPrincipalDocs(entityType, principal), action, resource) != decisionAllowed {
+// CheckPermissionWithContext is CheckPermission with an explicit request
+// condition context (aws:SourceIp, aws:CurrentTime, aws:PrincipalArn, …) so
+// statements guarded by a Condition are evaluated against the real request. It
+// is the AWS-only ContextualAuthorizer capability the authorization gate reaches
+// via a type assertion; CheckPermission delegates here with an empty context, so
+// callers that supply no keys see today's behavior.
+func (m *Mock) CheckPermissionWithContext(
+	_ context.Context, principal, action, resource string, cctx map[string]string,
+) (bool, error) {
+	entityType := m.principalEntityType(principal)
+	ctxKeys := ConditionContext(cctx)
+
+	if decide(m.gatherPrincipalDocs(entityType, principal), action, resource, ctxKeys) != decisionAllowed {
 		return false, nil
 	}
 
 	if boundary, ok := m.permissionsBoundaryDoc(entityType, principal); ok &&
-		decide([]string{boundary}, action, resource) != decisionAllowed {
+		decide([]string{boundary}, action, resource, ctxKeys) != decisionAllowed {
 		return false, nil
 	}
 

--- a/providers/aws/iam/simulate.go
+++ b/providers/aws/iam/simulate.go
@@ -23,26 +23,27 @@ const (
 // named by policySourceARN (plus any extra policy documents) against each
 // action/resource pair (IAM SimulatePrincipalPolicy).
 func (m *Mock) SimulatePrincipalPolicy(
-	_ context.Context, policySourceARN string, actions, resourceARNs, extraPolicies []string,
+	_ context.Context, policySourceARN string, actions, resourceARNs, extraPolicies []string, condCtx map[string]string,
 ) ([]driver.SimulationResult, error) {
 	entityType, name := parsePrincipalARN(policySourceARN)
 	docs := m.gatherPrincipalDocs(entityType, name)
 	docs = append(docs, extraPolicies...)
 
-	return simulate(docs, actions, resourceARNs), nil
+	return simulate(docs, actions, resourceARNs, ConditionContext(condCtx)), nil
 }
 
 // SimulateCustomPolicy evaluates a set of standalone policy documents against
 // each action/resource pair (IAM SimulateCustomPolicy).
 func (*Mock) SimulateCustomPolicy(
-	_ context.Context, policyDocs, actions, resourceARNs []string,
+	_ context.Context, policyDocs, actions, resourceARNs []string, condCtx map[string]string,
 ) ([]driver.SimulationResult, error) {
-	return simulate(policyDocs, actions, resourceARNs), nil
+	return simulate(policyDocs, actions, resourceARNs, ConditionContext(condCtx)), nil
 }
 
 // simulate evaluates every action against every resource (defaulting to "*"
-// when no resources are given) and reports the resulting decision.
-func simulate(docs, actions, resourceARNs []string) []driver.SimulationResult {
+// when no resources are given) and reports the resulting decision, applying the
+// supplied request condition context to each statement's Condition block.
+func simulate(docs, actions, resourceARNs []string, cctx ConditionContext) []driver.SimulationResult {
 	resources := resourceARNs
 	if len(resources) == 0 {
 		resources = []string{"*"}
@@ -55,7 +56,7 @@ func simulate(docs, actions, resourceARNs []string) []driver.SimulationResult {
 			results = append(results, driver.SimulationResult{
 				ActionName:   action,
 				ResourceName: resource,
-				Decision:     decide(docs, action, resource),
+				Decision:     decide(docs, action, resource, cctx),
 			})
 		}
 	}
@@ -66,11 +67,11 @@ func simulate(docs, actions, resourceARNs []string) []driver.SimulationResult {
 // decide reduces a set of policy documents to a single simulation decision for
 // one action/resource: an explicit Deny wins, then any Allow, else the default
 // implicit deny.
-func decide(docs []string, action, resource string) string {
+func decide(docs []string, action, resource string, cctx ConditionContext) string {
 	allow, deny := false, false
 
 	for _, doc := range docs {
-		a, d := evaluatePolicy(doc, action, resource)
+		a, d := evaluatePolicy(doc, action, resource, cctx)
 		if d {
 			deny = true
 		}

--- a/providers/aws/iam/simulate_test.go
+++ b/providers/aws/iam/simulate_test.go
@@ -28,7 +28,7 @@ func TestSimulatePrincipalPolicy(t *testing.T) {
 	requireNoError(t, m.AttachRolePolicy(ctx, "r", pol.ARN))
 
 	results, err := m.SimulatePrincipalPolicy(ctx, "arn:aws:iam::123456789012:role/r",
-		[]string{"s3:ListBucket", "s3:DeleteObject"}, []string{"arn:aws:s3:::b"}, nil)
+		[]string{"s3:ListBucket", "s3:DeleteObject"}, []string{"arn:aws:s3:::b"}, nil, nil)
 	requireNoError(t, err)
 
 	assertEqual(t, 2, len(results))
@@ -55,7 +55,7 @@ func TestSimulatePrincipalPolicyWithGroups(t *testing.T) {
 
 	// The user inherits the group's policy in the simulation.
 	results, err := m.SimulatePrincipalPolicy(ctx, "arn:aws:iam::123456789012:user/u",
-		[]string{"ec2:DescribeInstances"}, nil, nil)
+		[]string{"ec2:DescribeInstances"}, nil, nil, nil)
 	requireNoError(t, err)
 	assertEqual(t, "allowed", decisionOf(results, "ec2:DescribeInstances"))
 }
@@ -70,7 +70,7 @@ func TestSimulateCustomPolicyExplicitDeny(t *testing.T) {
 	})
 
 	results, err := m.SimulateCustomPolicy(ctx, []string{deny},
-		[]string{"s3:GetObject", "s3:DeleteObject"}, nil)
+		[]string{"s3:GetObject", "s3:DeleteObject"}, nil, nil)
 	requireNoError(t, err)
 
 	// No resources supplied -> defaults to "*".

--- a/server/aws/authgate.go
+++ b/server/aws/authgate.go
@@ -67,7 +67,7 @@ func newAuthGate(iamDriver iamdriver.IAM, accountID string) func(http.ResponseWr
 			return r, false
 		}
 
-		if !authorize(w, r, principal, iamDriver) {
+		if !authorize(w, r, principal, iamDriver, body, accountID) {
 			return r, false
 		}
 

--- a/server/aws/authzgate.go
+++ b/server/aws/authzgate.go
@@ -1,11 +1,16 @@
 package aws
 
 import (
+	"encoding/json"
+	"net"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/stackshy/cloudemu/v2/server/authctx"
 	"github.com/stackshy/cloudemu/v2/server/wire"
+	"github.com/stackshy/cloudemu/v2/server/wire/sigv4"
 	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
 )
 
@@ -79,7 +84,7 @@ var jsonRPCServiceByTarget = map[string]string{
 // caller scoped to service A run an operation that executes under service B, so
 // action+resource authorization bound to the routed operation is a follow-up.
 func authorize(
-	w http.ResponseWriter, r *http.Request, p authctx.Principal, iamDriver iamdriver.IAM,
+	w http.ResponseWriter, r *http.Request, p authctx.Principal, iamDriver iamdriver.IAM, body []byte, accountID string,
 ) bool {
 	service, action, decision := deriveAction(r)
 
@@ -101,14 +106,112 @@ func authorize(
 		return true // no policies defined: unrestricted (dev-friendly bootstrap).
 	}
 
-	allowed, err := iamDriver.CheckPermission(r.Context(), p.UserName, action, "*")
-	if err == nil && allowed {
+	resource := deriveResource(service, body, sigv4.Region(r), accountID)
+
+	if checkPermission(r, p, iamDriver, action, resource) {
 		return true
 	}
 
 	writeAuthzDenied(w, p, action)
 
 	return false
+}
+
+// checkPermission evaluates the action against the derived resource for the
+// caller. When the IAM driver supports the ContextualAuthorizer capability, the
+// request condition context (source IP, region, principal, secure transport,
+// current time) is threaded so Condition-guarded statements are honored;
+// otherwise it falls back to the resource-only CheckPermission.
+func checkPermission(
+	r *http.Request, p authctx.Principal, iamDriver iamdriver.IAM, action, resource string,
+) bool {
+	if ca, ok := iamDriver.(iamdriver.ContextualAuthorizer); ok {
+		allowed, err := ca.CheckPermissionWithContext(r.Context(), p.UserName, action, resource, requestConditionContext(r, p))
+		return err == nil && allowed
+	}
+
+	allowed, err := iamDriver.CheckPermission(r.Context(), p.UserName, action, resource)
+
+	return err == nil && allowed
+}
+
+// requestConditionContext gathers the AWS global condition keys the gate can
+// derive from the request and the verified principal. Keys that cannot be
+// determined are omitted, so a policy that references an absent key evaluates
+// per IAM's absent-key rules (plain → no match, ...IfExists → match).
+func requestConditionContext(r *http.Request, p authctx.Principal) map[string]string {
+	ctx := map[string]string{
+		"aws:CurrentTime":     time.Now().UTC().Format(time.RFC3339),
+		"aws:SecureTransport": strconv.FormatBool(r.TLS != nil),
+	}
+
+	if ip := clientIP(r); ip != "" {
+		ctx["aws:SourceIp"] = ip
+	}
+
+	if p.ARN != "" {
+		ctx["aws:PrincipalArn"] = p.ARN
+	}
+
+	if p.UserName != "" {
+		ctx["aws:username"] = p.UserName
+	}
+
+	if region := sigv4.Region(r); region != "" {
+		ctx["aws:RequestedRegion"] = region
+	}
+
+	return ctx
+}
+
+// clientIP extracts the caller's source IP, preferring the first X-Forwarded-For
+// hop and falling back to the connection's RemoteAddr (port stripped).
+func clientIP(r *http.Request) string {
+	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
+		if i := strings.IndexByte(fwd, ','); i >= 0 {
+			return strings.TrimSpace(fwd[:i])
+		}
+
+		return strings.TrimSpace(fwd)
+	}
+
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+
+	return r.RemoteAddr
+}
+
+// deriveResource derives the target resource ARN for an authorized action from
+// the request, so resource-scoped Allow/Deny policies apply. It covers the
+// services whose JSON-RPC body names a single primary resource; where the
+// resource cannot be derived it falls back to "*", which matches any
+// resource-scoped statement's "*" and leaves resource-scoped statements for
+// other resources non-binding (the pre-existing behavior).
+func deriveResource(service string, body []byte, region, accountID string) string {
+	if service == "dynamodb" {
+		if name := jsonField(body, "TableName"); name != "" {
+			return "arn:aws:dynamodb:" + region + ":" + accountID + ":table/" + name
+		}
+	}
+
+	return "*"
+}
+
+// jsonField extracts a single top-level string field from a JSON-RPC request
+// body without fully modeling the operation. It returns "" when the body is not
+// an object or the field is absent or non-string.
+func jsonField(body []byte, field string) string {
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		return ""
+	}
+
+	if v, ok := m[field].(string); ok {
+		return v
+	}
+
+	return ""
 }
 
 // deriveAction maps an incoming request to its IAM action (e.g. dynamodb:PutItem)

--- a/server/aws/authzgate.go
+++ b/server/aws/authzgate.go
@@ -164,17 +164,12 @@ func requestConditionContext(r *http.Request, p authctx.Principal) map[string]st
 	return ctx
 }
 
-// clientIP extracts the caller's source IP, preferring the first X-Forwarded-For
-// hop and falling back to the connection's RemoteAddr (port stripped).
+// clientIP extracts the caller's source IP for the aws:SourceIp condition key.
+// It uses ONLY the connection's RemoteAddr (port stripped) — never the
+// caller-controlled X-Forwarded-For header. The wire server has no trusted
+// reverse proxy in front of it, so honoring X-Forwarded-For would let any
+// client spoof its source IP and defeat the IpAddress/NotIpAddress conditions.
 func clientIP(r *http.Request) string {
-	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
-		if i := strings.IndexByte(fwd, ','); i >= 0 {
-			return strings.TrimSpace(fwd[:i])
-		}
-
-		return strings.TrimSpace(fwd)
-	}
-
 	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
 		return host
 	}

--- a/server/aws/authzgate_test.go
+++ b/server/aws/authzgate_test.go
@@ -1,0 +1,115 @@
+package aws
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// dynamoProbe answers any DynamoDB JSON-RPC request with 200, so a test can
+// observe whether the authorization gate let the request through to dispatch.
+type dynamoProbe struct{}
+
+func (dynamoProbe) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.Header.Get("X-Amz-Target"), "DynamoDB_20120810.")
+}
+
+func (dynamoProbe) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	_, _ = io.WriteString(w, "ok")
+}
+
+// signedDynamoRequest builds and SigV4-signs a DynamoDB PutItem request whose
+// body targets the given table.
+func signedDynamoRequest(t *testing.T, url, table string, creds aws.Credentials) *http.Request {
+	t.Helper()
+
+	body := `{"TableName":"` + table + `","Item":{}}`
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.PutItem")
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+
+	sum := sha256.Sum256([]byte(body))
+	if err := v4.NewSigner().SignHTTP(
+		context.Background(), creds, req, hex.EncodeToString(sum[:]), "dynamodb", "us-east-1", time.Now(),
+	); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	return req
+}
+
+// TestAuthzGateResourceScoped proves the authorization gate derives the target
+// resource ARN from the request body so a resource-scoped policy allows the
+// matching table and denies a non-matching one.
+func TestAuthzGateResourceScoped(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	ctx := context.Background()
+
+	if _, err := cloud.IAM.CreateUser(ctx, iamdriver.UserConfig{Name: "dyn"}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	doc := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"dynamodb:*",` +
+		`"Resource":"arn:aws:dynamodb:us-east-1:123456789012:table/allowed"}]}`
+
+	pol, err := cloud.IAM.CreatePolicy(ctx, iamdriver.PolicyConfig{Name: "dynpol", PolicyDocument: doc})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	if err := cloud.IAM.AttachUserPolicy(ctx, "dyn", pol.ARN); err != nil {
+		t.Fatalf("AttachUserPolicy: %v", err)
+	}
+
+	ak, err := cloud.IAM.CreateAccessKey(ctx, iamdriver.AccessKeyConfig{UserName: "dyn"})
+	if err != nil {
+		t.Fatalf("CreateAccessKey: %v", err)
+	}
+
+	srv := New(Drivers{IAM: cloud.IAM, AccountID: "123456789012", Region: "us-east-1", EnforceAuth: true})
+	srv.Register(dynamoProbe{})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	creds := aws.Credentials{AccessKeyID: ak.AccessKeyID, SecretAccessKey: ak.SecretAccessKey}
+
+	// Matching table: the resource-scoped Allow applies, so the request proceeds.
+	resp, err := http.DefaultClient.Do(signedDynamoRequest(t, ts.URL+"/", "allowed", creds))
+	if err != nil {
+		t.Fatalf("do allowed: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("matching table: want 200, got %d", resp.StatusCode)
+	}
+
+	// Non-matching table: the Allow no longer applies, so the gate denies (403).
+	resp, err = http.DefaultClient.Do(signedDynamoRequest(t, ts.URL+"/", "denied", creds))
+	if err != nil {
+		t.Fatalf("do denied: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("non-matching table: want 403, got %d", resp.StatusCode)
+	}
+}

--- a/server/aws/iam/simulate.go
+++ b/server/aws/iam/simulate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/xml"
 	"net/http"
+	"strconv"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
@@ -13,10 +14,10 @@ import (
 // of the portable IAM driver, so the handler type-asserts for it.
 type policySimulator interface {
 	SimulatePrincipalPolicy(
-		ctx context.Context, policySourceARN string, actions, resourceARNs, extraPolicies []string,
+		ctx context.Context, policySourceARN string, actions, resourceARNs, extraPolicies []string, condCtx map[string]string,
 	) ([]iamdriver.SimulationResult, error)
 	SimulateCustomPolicy(
-		ctx context.Context, policyDocs, actions, resourceARNs []string,
+		ctx context.Context, policyDocs, actions, resourceARNs []string, condCtx map[string]string,
 	) ([]iamdriver.SimulationResult, error)
 }
 
@@ -78,8 +79,9 @@ func (h *Handler) simulatePrincipalPolicy(w http.ResponseWriter, r *http.Request
 
 	resources := awsquery.ListStrings(r.Form, "ResourceArns.member")
 	extra := awsquery.ListStrings(r.Form, "PolicyInputList.member")
+	condCtx := parseContextEntries(r)
 
-	results, err := sim.SimulatePrincipalPolicy(r.Context(), r.Form.Get("PolicySourceArn"), actions, resources, extra)
+	results, err := sim.SimulatePrincipalPolicy(r.Context(), r.Form.Get("PolicySourceArn"), actions, resources, extra, condCtx)
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -90,6 +92,35 @@ func (h *Handler) simulatePrincipalPolicy(w http.ResponseWriter, r *http.Request
 		Result:   simulateResult{EvaluationResults: toEvaluationResults(results)},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
+}
+
+// parseContextEntries reads the SimulatePolicy ContextEntries.member.N groups
+// (ContextKeyName + ContextKeyValues.member.M) into a flat key→value condition
+// context, taking the first value of each key. It stops at the first absent
+// index, matching the contiguous 1..N form SDKs emit.
+func parseContextEntries(r *http.Request) map[string]string {
+	const maxEntries = 64
+
+	out := map[string]string{}
+
+	for i := 1; i <= maxEntries; i++ {
+		base := "ContextEntries.member." + strconv.Itoa(i)
+
+		name := r.Form.Get(base + ".ContextKeyName")
+		if name == "" {
+			break
+		}
+
+		if vals := awsquery.ListStrings(r.Form, base+".ContextKeyValues.member"); len(vals) > 0 {
+			out[name] = vals[0]
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
 }
 
 func (h *Handler) simulateCustomPolicy(w http.ResponseWriter, r *http.Request) {
@@ -108,8 +139,9 @@ func (h *Handler) simulateCustomPolicy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resources := awsquery.ListStrings(r.Form, "ResourceArns.member")
+	condCtx := parseContextEntries(r)
 
-	results, err := sim.SimulateCustomPolicy(r.Context(), docs, actions, resources)
+	results, err := sim.SimulateCustomPolicy(r.Context(), docs, actions, resources, condCtx)
 	if err != nil {
 		writeErr(w, err)
 		return

--- a/server/wire/sigv4/sigv4.go
+++ b/server/wire/sigv4/sigv4.go
@@ -67,6 +67,19 @@ func AccessKeyID(r *http.Request) string {
 	return in.accessKeyID
 }
 
+// Region returns the AWS region from the request's SigV4 credential scope, or ""
+// when the request carries no parseable SigV4 material. The authorization gate
+// uses it to populate the aws:RequestedRegion condition key and to derive
+// region-qualified resource ARNs.
+func Region(r *http.Request) string {
+	in, err := parseInputs(r)
+	if err != nil {
+		return ""
+	}
+
+	return in.region
+}
+
 // Verify checks the request's SigV4 signature against the secret resolved for
 // its access key id. On success it returns the resolved principal; on failure a
 // typed AuthError (HTTP 403). body is the buffered request body (the gate reads

--- a/services/iam/driver/driver.go
+++ b/services/iam/driver/driver.go
@@ -215,6 +215,20 @@ type PolicyInspector interface {
 	PrincipalHasPolicies(ctx context.Context, name string) bool
 }
 
+// ContextualAuthorizer is an optional capability: an IAM implementation that can
+// evaluate a permission with an explicit request condition context (aws:SourceIp,
+// aws:CurrentTime, aws:SecureTransport, aws:PrincipalArn, aws:RequestedRegion, …)
+// so statements guarded by a Condition are evaluated against the real request.
+// The AWS authorization gate type-asserts for it to authorize the routed
+// action against the derived target resource with the caller's context. Like
+// PolicyInspector it is AWS-only and therefore not part of the shared IAM
+// interface. A nil context makes it equivalent to CheckPermission.
+type ContextualAuthorizer interface {
+	CheckPermissionWithContext(
+		ctx context.Context, principal, action, resource string, condCtx map[string]string,
+	) (bool, error)
+}
+
 // IAM is the interface that IAM provider implementations must satisfy.
 type IAM interface {
 	CreateUser(ctx context.Context, config UserConfig) (*UserInfo, error)


### PR DESCRIPTION
## Summary

Fixes #841. IAM policy evaluation only read `Action`/`Resource`, silently dropping `NotAction`, `NotResource` and `Condition`, and the authorization gate hardcoded `resource="*"`. Now that `CheckPermission` gates the wire (#493), those made allow/deny decisions wrong (a `NotAction` Deny under-enforced, conditional statements applied unconditionally, resource-scoped policies never bit). This makes the evaluator match real IAM semantics end-to-end.

## What changed

**Statement model** — added `NotAction`, `NotResource` and `Condition` to the policy statement. `Action`/`NotAction` (and `Resource`/`NotResource`) are mutually exclusive: `NotAction` matches every action except those listed, so a `Deny` with `NotAction` fails closed. Explicit-Deny-wins and wildcard matching are preserved.

**Reusable condition evaluator** (`providers/aws/iam/condition.go`) — a focused, per-operator evaluator decomposed by family (no `nolint`), evaluated against a request condition context with real AWS absent-key rules (plain condition → no match, `...IfExists` → match).

Operators: `StringEquals` / `StringNotEquals` / `StringEqualsIgnoreCase` / `StringNotEqualsIgnoreCase` / `StringLike` / `StringNotLike`, `Bool`, `NumericEquals` / `NotEquals` / `LessThan(Equals)` / `GreaterThan(Equals)`, `DateEquals` / `NotEquals` / `LessThan(Equals)` / `GreaterThan(Equals)`, `ArnEquals` / `ArnLike` / `ArnNotEquals` / `ArnNotLike`, `IpAddress` / `NotIpAddress` (CIDR), `Null`, and the `...IfExists` variants of all.

**Context keys threaded from the request**: `aws:SourceIp`, `aws:CurrentTime`, `aws:SecureTransport`, `aws:PrincipalArn`, `aws:username`, `aws:RequestedRegion`.

**Resource-scoped authz** (`server/aws/authzgate.go`) — derives the target resource ARN from the request (DynamoDB table from the JSON body today; `*` fallback for actions whose resource can't be derived) and threads the condition context via the new `ContextualAuthorizer` capability. Public API stays backward-compatible: `CheckPermission` delegates to `CheckPermissionWithContext` with an empty context (today's behavior); `SimulatePrincipalPolicy` / `SimulateCustomPolicy` honor `ContextEntries`.

## Tests

- Provider (`providers/aws/iam`): `NotAction` Deny blocks the complement / allows the listed (fail-closed), `NotResource` likewise, each condition operator allow/deny against a supplied context, IfExists present-vs-absent, `Null`, multi-key AND / multi-value OR, `CheckPermissionWithContext`, resource-scoped allow/deny, and `SimulatePrincipalPolicy` reflecting conditions.
- Server (`server/aws`): real SigV4-signed DynamoDB request through the authz gate — a resource-scoped policy allows the matching table and 403s a non-matching one.

## Deferred

Resource derivation currently covers the DynamoDB table ARN (the JSON-RPC service with resource-level policies and the enforced protocol); other actions fall back to `*`. Additional per-service derivations can follow incrementally.