### PR TITLE
fix(auth): harden SigV4 enforce-auth path — verify ASIA temp creds, enforce expiry/skew, bind content-sha256 (#839)

### DIFF
--- a/compat/aws/auth_sigv4_compat_test.go
+++ b/compat/aws/auth_sigv4_compat_test.go
@@ -132,10 +132,15 @@ func TestCompatAWSSigV4AuthEnabled(t *testing.T) {
 		}
 	})
 
-	t.Run("TempCredentialAccepted", func(t *testing.T) {
+	t.Run("ForgedTempCredentialRejected", func(t *testing.T) {
+		// ASIA temporary credentials are now verified against STS-issued
+		// sessions, so a forged one that STS never minted is rejected rather
+		// than trusted (a real assumed-role credential is covered by the STS
+		// session-store tests).
 		client := iamClientAt(t, sess.Endpoint(), "ASIATEMPCREDENTIAL00", "any-synthetic-secret", "session-token")
-		if _, err := client.ListUsers(ctx, &iam.ListUsersInput{}); err != nil {
-			t.Fatalf("STS-style temporary (ASIA) credential should pass through, got: %v", err)
+		_, err := client.ListUsers(ctx, &iam.ListUsersInput{})
+		if code := apiErrorCode(t, err); code != "InvalidClientTokenId" {
+			t.Fatalf("forged temp credential: want InvalidClientTokenId, got %q", code)
 		}
 	})
 

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -183,6 +183,10 @@ type Provider struct {
 	// EnforceAuth mirrors config.Options.EnforceAuth: when true the AWS wire
 	// server verifies each request's SigV4 signature. Off by default.
 	EnforceAuth bool
+	// Clock mirrors config.Options.Clock: it drives SigV4 timestamp-expiry and
+	// STS temporary-credential expiry when EnforceAuth is on. Threaded to the
+	// wire server so a FakeClock stays deterministic there too.
+	Clock config.Clock
 
 	// engineClosers holds any wired real engines that implement io.Closer, so
 	// Close can cascade teardown to them. Empty for the in-memory default.
@@ -239,6 +243,7 @@ func New(opts ...config.Option) *Provider {
 		AccountID:           o.AccountID,
 		Region:              o.Region,
 		EnforceAuth:         o.EnforceAuth,
+		Clock:               o.Clock,
 		engineClosers:       o.EngineClosers(),
 	}
 	p.EC2.SetMonitoring(p.CloudWatch)

--- a/server/aws/authgate.go
+++ b/server/aws/authgate.go
@@ -8,31 +8,34 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/server/authctx"
+	stssrv "github.com/stackshy/cloudemu/v2/server/aws/sts"
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	"github.com/stackshy/cloudemu/v2/server/wire/sigv4"
 	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
 )
 
-// tempCredentialPrefix marks STS-issued temporary access keys. Their secret is
-// synthetic (derived by STS, not stored as an IAM access key), so their SigV4
-// signature cannot be verified here; such requests are treated as authenticated
-// pass-throughs in this revision, and verifying temporary-credential signatures
-// is a follow-up. Note the limitation this leaves: unsigned or malformed
-// requests are still rejected, but ANY credential whose scope carries an
-// ASIA-prefixed key id is trusted without a signature check — so this is not yet
-// a hard boundary against a forged ASIA credential. That is acceptable for a
-// local dev emulator (rejecting all ASIA would break legitimate STS/IRSA/
-// instance-profile flows) and is closed when temp-credential verification lands.
+// tempCredentialPrefix marks STS-issued temporary access keys (ASIA). Their
+// secret is minted by STS, which — when EnforceAuth is on — records it in the
+// session store so the signature made with it can be SigV4-verified here exactly
+// like a long-term AKIA key, and a forged ASIA credential (unknown/wrong secret)
+// is rejected.
 const tempCredentialPrefix = "ASIA"
 
 // newAuthGate builds the SigV4 authentication pre-dispatch hook. It buffers and
 // restores the request body (downstream Matches/ParseForm read it), resolves
-// the caller's secret via the IAM access-key resolver, verifies the signature,
+// the caller's secret via the IAM access-key resolver (long-term AKIA keys) or
+// the STS session store (temporary ASIA credentials), verifies the signature,
 // and either attaches the resolved principal to the request context (proceed)
-// or writes a 403 AWS error (stop).
-func newAuthGate(iamDriver iamdriver.IAM, accountID string) func(http.ResponseWriter, *http.Request) (*http.Request, bool) {
+// or writes a 403 AWS error (stop). clock drives timestamp-expiry evaluation.
+func newAuthGate(
+	iamDriver iamdriver.IAM, accountID string, sessions *stssrv.SessionStore, clock config.Clock,
+) func(http.ResponseWriter, *http.Request) (*http.Request, bool) {
 	resolver, _ := iamDriver.(iamdriver.AccessKeyResolver)
+
+	if clock == nil {
+		clock = config.RealClock{}
+	}
 
 	return func(w http.ResponseWriter, r *http.Request) (*http.Request, bool) {
 		body := drainBody(r)
@@ -50,15 +53,23 @@ func newAuthGate(iamDriver iamdriver.IAM, accountID string) func(http.ResponseWr
 			return r, false
 		}
 
-		// Temporary STS credentials cannot be SigV4-verified (synthetic secret);
-		// pass them through as authenticated for now (documented follow-up).
+		// Temporary STS credentials are verified against the secret STS recorded
+		// when it minted them (resolved from the session store), so a forged ASIA
+		// credential and an expired session are both rejected.
 		if strings.HasPrefix(akid, tempCredentialPrefix) {
+			principal, aerr := verifyTempCredential(r, body, akid, accountID, sessions, clock)
+
 			restore()
 
-			return withPrincipal(r, authctx.Principal{AccessKeyID: akid, AccountID: accountID}), true
+			if aerr != nil {
+				writeAuthError(w, r, aerr)
+				return r, false
+			}
+
+			return withPrincipal(r, principal), true
 		}
 
-		principal, aerr := sigv4.Verify(r, body, resolverLookup(r, resolver), config.RealClock{})
+		principal, aerr := sigv4.Verify(r, body, resolverLookup(r, resolver), clock)
 
 		restore()
 
@@ -73,6 +84,44 @@ func newAuthGate(iamDriver iamdriver.IAM, accountID string) func(http.ResponseWr
 
 		return withPrincipal(r, principal), true
 	}
+}
+
+// verifyTempCredential authenticates an STS temporary (ASIA) credential. It
+// resolves the secret STS recorded for the presented access key id, rejects an
+// unknown key (InvalidClientTokenId) or an expired session (ExpiredToken), then
+// SigV4-verifies the signature against that secret. When no session store is
+// wired the credential is unverifiable, so it fails closed.
+func verifyTempCredential(
+	r *http.Request, body []byte, akid, accountID string, sessions *stssrv.SessionStore, clock config.Clock,
+) (authctx.Principal, *sigv4.AuthError) {
+	invalid := &sigv4.AuthError{
+		Code:       "InvalidClientTokenId",
+		Message:    "The security token included in the request is invalid.",
+		HTTPStatus: http.StatusForbidden,
+	}
+
+	if sessions == nil {
+		return authctx.Principal{}, invalid
+	}
+
+	sess, ok := sessions.Lookup(akid)
+	if !ok {
+		return authctx.Principal{}, invalid
+	}
+
+	if clock.Now().UTC().After(sess.Expiration) {
+		return authctx.Principal{}, &sigv4.AuthError{
+			Code:       "ExpiredToken",
+			Message:    "The security token included in the request is expired.",
+			HTTPStatus: http.StatusForbidden,
+		}
+	}
+
+	lookup := func(id string) (string, authctx.Principal, bool) {
+		return sess.SecretAccessKey, authctx.Principal{AccessKeyID: id, AccountID: accountID}, true
+	}
+
+	return sigv4.Verify(r, body, lookup, clock)
 }
 
 // resolverLookup adapts the IAM access-key resolver to sigv4.LookupFunc,

--- a/server/aws/authgate_temp_test.go
+++ b/server/aws/authgate_temp_test.go
@@ -1,0 +1,252 @@
+package aws
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awssts "github.com/aws/aws-sdk-go-v2/service/sts"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	stssrv "github.com/stackshy/cloudemu/v2/server/aws/sts"
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+const tempTestAccount = "123456789012"
+
+// signTemp signs r with the given temporary credentials at signingTime using the
+// real v4 signer, so the request carries the ASIA credential's SigV4 material and
+// X-Amz-Security-Token exactly as an SDK would produce.
+func signTemp(t *testing.T, r *http.Request, akid, secret, token string, signingTime time.Time) {
+	t.Helper()
+
+	creds := aws.Credentials{AccessKeyID: akid, SecretAccessKey: secret, SessionToken: token}
+	if err := v4.NewSigner().SignHTTP(
+		r.Context(), creds, r, hex.EncodeToString(func() []byte { s := sha256.Sum256(nil); return s[:] }()),
+		"iam", "us-east-1", signingTime,
+	); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+}
+
+// TestVerifyTempCredential exercises the STS temporary-credential branch of the
+// gate directly: a signature made with the STS-issued secret verifies, a forged
+// secret is rejected, an unknown key is rejected, and an expired session is
+// rejected — all deterministically on a FakeClock.
+func TestVerifyTempCredential(t *testing.T) {
+	now := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	clock := config.NewFakeClock(now)
+	store := stssrv.NewSessionStore(clock)
+
+	issued := store.Mint(time.Hour) // Expiration = now + 1h
+
+	newReq := func() *http.Request {
+		r, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+			"http://example.local/", strings.NewReader(""))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return r
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		r := newReq()
+		signTemp(t, r, issued.AccessKeyID, issued.SecretAccessKey, issued.SessionToken, now)
+
+		p, aerr := verifyTempCredential(r, nil, issued.AccessKeyID, tempTestAccount, store, clock)
+		if aerr != nil {
+			t.Fatalf("valid temp credential rejected: %v", aerr)
+		}
+		if p.AccessKeyID != issued.AccessKeyID {
+			t.Fatalf("principal AccessKeyID = %q, want %q", p.AccessKeyID, issued.AccessKeyID)
+		}
+	})
+
+	t.Run("forged-secret", func(t *testing.T) {
+		r := newReq()
+		signTemp(t, r, issued.AccessKeyID, "forged-secret-000000000000000000000000", issued.SessionToken, now)
+
+		_, aerr := verifyTempCredential(r, nil, issued.AccessKeyID, tempTestAccount, store, clock)
+		if aerr == nil || aerr.Code != "SignatureDoesNotMatch" {
+			t.Fatalf("want SignatureDoesNotMatch, got %v", aerr)
+		}
+	})
+
+	t.Run("unknown-key", func(t *testing.T) {
+		r := newReq()
+		signTemp(t, r, "ASIAUNKNOWN0000000000", issued.SecretAccessKey, issued.SessionToken, now)
+
+		_, aerr := verifyTempCredential(r, nil, "ASIAUNKNOWN0000000000", tempTestAccount, store, clock)
+		if aerr == nil || aerr.Code != "InvalidClientTokenId" {
+			t.Fatalf("want InvalidClientTokenId, got %v", aerr)
+		}
+	})
+
+	t.Run("no-store-fails-closed", func(t *testing.T) {
+		r := newReq()
+		signTemp(t, r, issued.AccessKeyID, issued.SecretAccessKey, issued.SessionToken, now)
+
+		_, aerr := verifyTempCredential(r, nil, issued.AccessKeyID, tempTestAccount, nil, clock)
+		if aerr == nil || aerr.Code != "InvalidClientTokenId" {
+			t.Fatalf("want InvalidClientTokenId (fail closed), got %v", aerr)
+		}
+	})
+
+	t.Run("expired-session", func(t *testing.T) {
+		shortClock := config.NewFakeClock(now)
+		shortStore := stssrv.NewSessionStore(shortClock)
+		short := shortStore.Mint(15 * time.Minute) // Expiration = now + 15m
+
+		r := newReq()
+		signTemp(t, r, short.AccessKeyID, short.SecretAccessKey, short.SessionToken, now)
+
+		shortClock.Advance(time.Hour) // now past expiration
+		_, aerr := verifyTempCredential(r, nil, short.AccessKeyID, tempTestAccount, shortStore, shortClock)
+		if aerr == nil || aerr.Code != "ExpiredToken" {
+			t.Fatalf("want ExpiredToken, got %v", aerr)
+		}
+	})
+}
+
+// TestAuthGateVerifiesAssumedRoleCredential is the real-user end-to-end flow: a
+// registered AKIA key assumes a role over the SDK, then the returned ASIA
+// credential is used to make an authenticated request against the same server —
+// proving STS and the gate share the session store. A tampered secret is
+// rejected. Uses the real clock so the SDK's own signing time is fresh.
+func TestAuthGateVerifiesAssumedRoleCredential(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	ctx := context.Background()
+
+	if _, err := cloud.IAM.CreateUser(ctx, iamdriver.UserConfig{Name: "dave"}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	ak, err := cloud.IAM.CreateAccessKey(ctx, iamdriver.AccessKeyConfig{UserName: "dave"})
+	if err != nil {
+		t.Fatalf("CreateAccessKey: %v", err)
+	}
+
+	// The wired IAM enforces the target role's trust policy, so create AppRole
+	// trusting the account root (the caller principal STS evaluates against).
+	if _, err := cloud.IAM.CreateRole(ctx, iamdriver.RoleConfig{
+		Name: "AppRole",
+		AssumeRolePolicyDoc: `{"Statement":[{"Effect":"Allow",` +
+			`"Principal":{"AWS":"arn:aws:iam::` + tempTestAccount + `:root"},"Action":"sts:AssumeRole"}]}`,
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	srv := New(Drivers{IAM: cloud.IAM, STS: true, AccountID: tempTestAccount, EnforceAuth: true})
+	srv.Register(principalProbe{})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Assume a role with the long-term key; the SDK signs the AssumeRole call.
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(ak.AccessKeyID, ak.SecretAccessKey, ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	stsc := awssts.NewFromConfig(cfg, func(o *awssts.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+
+	out, err := stsc.AssumeRole(ctx, &awssts.AssumeRoleInput{
+		RoleArn:         aws.String("arn:aws:iam::123456789012:role/AppRole"),
+		RoleSessionName: aws.String("e2e"),
+	})
+	if err != nil {
+		t.Fatalf("AssumeRole: %v", err)
+	}
+
+	tempAKID := aws.ToString(out.Credentials.AccessKeyId)
+	tempSecret := aws.ToString(out.Credentials.SecretAccessKey)
+	tempToken := aws.ToString(out.Credentials.SessionToken)
+
+	if !strings.HasPrefix(tempAKID, "ASIA") {
+		t.Fatalf("temp AccessKeyId = %q, want ASIA prefix", tempAKID)
+	}
+
+	// Use the assumed-role credentials to make an authenticated request.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/_whoami", strings.NewReader(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	signTemp(t, req, tempAKID, tempSecret, tempToken, time.Now())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("assumed-role request: want 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	// A tampered secret on the same ASIA key id must be rejected.
+	forged, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/_whoami", strings.NewReader(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	signTemp(t, forged, tempAKID, tempSecret+"tampered", tempToken, time.Now())
+
+	fresp, err := http.DefaultClient.Do(forged)
+	if err != nil {
+		t.Fatalf("do forged: %v", err)
+	}
+	_ = fresp.Body.Close()
+
+	if fresp.StatusCode != http.StatusForbidden {
+		t.Fatalf("forged assumed-role request: want 403, got %d", fresp.StatusCode)
+	}
+}
+
+// TestSTSCredentialsGatedByEnforceAuth proves the session store — and thus the
+// unique/verifiable credentials — appear only under EnforceAuth. With it off,
+// AssumeRole returns the fixed synthetic credential the emulator always has, so
+// the default behavior is unchanged.
+func TestSTSCredentialsGatedByEnforceAuth(t *testing.T) {
+	srv := New(Drivers{STS: true, AccountID: tempTestAccount})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	stsc := awssts.NewFromConfig(cfg, func(o *awssts.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+
+	out, err := stsc.AssumeRole(context.Background(), &awssts.AssumeRoleInput{
+		RoleArn:         aws.String("arn:aws:iam::123456789012:role/AppRole"),
+		RoleSessionName: aws.String("off"),
+	})
+	if err != nil {
+		t.Fatalf("AssumeRole: %v", err)
+	}
+
+	if got := aws.ToString(out.Credentials.AccessKeyId); got != "ASIACLOUDEMU000000000" {
+		t.Fatalf("EnforceAuth off: AccessKeyId = %q, want fixed synthetic value", got)
+	}
+}

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -9,6 +9,7 @@ package aws
 import (
 	"net/http"
 
+	"github.com/stackshy/cloudemu/v2/config"
 	awsprovider "github.com/stackshy/cloudemu/v2/providers/aws"
 	eksdriver "github.com/stackshy/cloudemu/v2/providers/aws/eks/driver"
 	"github.com/stackshy/cloudemu/v2/server"
@@ -243,6 +244,10 @@ type Drivers struct {
 	// to principals that have IAM policies defined — a policy-less user/role and
 	// the account-admin/root and ASIA identities are left unrestricted.
 	EnforceAuth bool
+	// Clock drives SigV4 timestamp-expiry evaluation and STS temporary-credential
+	// expiry when EnforceAuth is on. Nil uses the real clock; tests inject a
+	// FakeClock for determinism. Ignored when EnforceAuth is off.
+	Clock config.Clock
 }
 
 // DriversFrom builds a Drivers bundle wiring every service handler to the
@@ -301,6 +306,7 @@ func DriversFrom(p *awsprovider.Provider) Drivers {
 		AccountID:           p.AccountID,
 		Region:              p.Region,
 		EnforceAuth:         p.EnforceAuth,
+		Clock:               p.Clock,
 	}
 }
 
@@ -562,11 +568,30 @@ func New(d Drivers) *server.Server {
 	// AssumeRole, GetSessionToken) is disjoint from RDS, Redshift, IAM, ELBv2,
 	// ElastiCache, SNS, and EC2, so no shadowing occurs. It has no driver, so
 	// it's gated on the STS bool. Registered before the EC2 catch-all.
+	// When EnforceAuth is on, STS records the temporary credentials it mints in a
+	// session store so the auth gate can verify signatures made with them (and
+	// reject expired sessions). Off, the store stays nil and STS returns its
+	// fixed synthetic credentials unchanged.
+	authClock := d.Clock
+	if authClock == nil {
+		authClock = config.RealClock{}
+	}
+
+	var stsSessions *stssrv.SessionStore
+	if d.EnforceAuth {
+		stsSessions = stssrv.NewSessionStore(authClock)
+	}
+
 	if d.STS {
 		// Pass the IAM driver so AssumeRole can enforce the target role's trust
 		// policy and existence. d.IAM may be nil (standalone STS-only), in which
 		// case AssumeRole stays permissive.
-		srv.Register(stssrv.New(d.AccountID, d.Region, d.IAM))
+		stsHandler := stssrv.New(d.AccountID, d.Region, d.IAM)
+		if stsSessions != nil {
+			stsHandler.SetSessions(stsSessions)
+		}
+
+		srv.Register(stsHandler)
 	}
 
 	if d.EC2 != nil || d.VPC != nil {
@@ -677,7 +702,7 @@ func New(d Drivers) *server.Server {
 	// on, and adds no request-path change beyond a context value.
 	var authGate func(http.ResponseWriter, *http.Request) (*http.Request, bool)
 	if d.EnforceAuth {
-		authGate = newAuthGate(d.IAM, d.AccountID)
+		authGate = newAuthGate(d.IAM, d.AccountID, stsSessions, authClock)
 	}
 
 	srv.SetPreDispatch(composePreDispatch(newRegionStamp(), authGate))

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -234,8 +234,9 @@ type Drivers struct {
 	// implement the optional access-key resolver; without it every signed request
 	// fails to resolve its key (InvalidClientTokenId).
 	//
-	// Long-term (AKIA) keys are verified; STS temporary (ASIA) credentials are
-	// accepted without signature verification (a follow-up).
+	// Long-term (AKIA) keys and STS temporary (ASIA) credentials are both
+	// verified — ASIA against the secret STS minted for that session (rejected
+	// if forged or expired).
 	//
 	// It also enforces IAM authorization for JSON-RPC services (the operation is
 	// bound to the X-Amz-Target header the dispatcher routes on); query and REST

--- a/server/aws/sts/handler.go
+++ b/server/aws/sts/handler.go
@@ -64,7 +64,17 @@ type Handler struct {
 	accountID string
 	region    string
 	trust     roleTrustEvaluator
+	// sessions, when set, records the temporary credentials this handler mints
+	// so the SigV4 authentication gate can verify signatures made with them. It
+	// is wired only when EnforceAuth is on; left nil the handler returns the
+	// fixed synthetic credentials it always has (auth-off byte-for-byte).
+	sessions *SessionStore
 }
+
+// SetSessions wires the temporary-credential store. When set, AssumeRole /
+// GetSessionToken / GetFederationToken (and the other credential-minting
+// operations) issue unique, verifiable credentials recorded in the store.
+func (h *Handler) SetSessions(s *SessionStore) { h.sessions = s }
 
 // New returns an STS handler that reports the given accountID and region. Empty
 // values fall back to sensible defaults so a well-formed identity is always

--- a/server/aws/sts/operations.go
+++ b/server/aws/sts/operations.go
@@ -215,12 +215,25 @@ func (h *Handler) getSessionToken(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// synthCredentials builds a deterministic set of temporary credentials with an
-// expiration in the future. cloudemu does not validate signatures, so any
-// non-empty values satisfy SDK clients.
+// synthCredentials builds a set of temporary credentials with an expiration in
+// the future. When a session store is wired (EnforceAuth on) it mints unique,
+// verifiable credentials and records their secret so the auth gate can verify a
+// signature made with them; otherwise it returns the fixed synthetic values it
+// always has (default, auth-off behavior is byte-for-byte unchanged).
 func (h *Handler) synthCredentials(dur time.Duration) credentials {
 	if dur <= 0 {
 		dur = sessionDuration
+	}
+
+	if h.sessions != nil {
+		sess := h.sessions.Mint(dur)
+
+		return credentials{
+			AccessKeyID:     sess.AccessKeyID,
+			SecretAccessKey: sess.SecretAccessKey,
+			SessionToken:    sess.SessionToken,
+			Expiration:      sess.Expiration.Format(time.RFC3339),
+		}
 	}
 
 	return credentials{

--- a/server/aws/sts/sessions.go
+++ b/server/aws/sts/sessions.go
@@ -1,0 +1,116 @@
+package sts
+
+import (
+	"crypto/rand"
+	"sync"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+)
+
+// Session is one set of temporary credentials STS minted, retained so the SigV4
+// authentication gate can resolve the secret it issued and verify a signature
+// made with it (and reject the credential once expired). The session token is
+// kept so the gate can bind the request's X-Amz-Security-Token to this session.
+type Session struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+	Expiration      time.Time
+}
+
+// SessionStore records the temporary credentials STS issues so their signatures
+// can be verified later. It is created only when EnforceAuth is on; with it
+// absent STS returns the fixed synthetic credentials it always has (so the
+// default, auth-off behavior is byte-for-byte unchanged). Safe for concurrent
+// use.
+type SessionStore struct {
+	mu       sync.RWMutex
+	clock    config.Clock
+	sessions map[string]Session
+}
+
+// NewSessionStore returns an empty store using clock for expiration stamping and
+// evaluation. A nil clock falls back to the real clock.
+func NewSessionStore(clock config.Clock) *SessionStore {
+	if clock == nil {
+		clock = config.RealClock{}
+	}
+
+	return &SessionStore{clock: clock, sessions: make(map[string]Session)}
+}
+
+// tempKeyRandomLen is the number of random uppercase-alphanumeric characters
+// after the ASIA prefix (real STS access key ids are 20 chars: 4 + 16).
+const tempKeyRandomLen = 16
+
+// secretLen is the length of a generated temporary secret (real STS secrets are
+// 40-character base64-ish strings; any high-entropy value works here).
+const secretLen = 40
+
+// sessionTokenRandomLen is the random suffix length of a generated session token.
+const sessionTokenRandomLen = 32
+
+// Mint generates a unique temporary credential set valid for dur, records it,
+// and returns it. Each call yields a distinct access key id and a fresh
+// high-entropy secret, so a caller that does not hold the issued secret cannot
+// forge a valid signature.
+func (s *SessionStore) Mint(dur time.Duration) Session {
+	if dur <= 0 {
+		dur = sessionDuration
+	}
+
+	sess := Session{
+		AccessKeyID:     tempCredentialPrefix + randUpperAlnum(tempKeyRandomLen),
+		SecretAccessKey: randUpperAlnum(secretLen),
+		SessionToken:    "cloudemu-session-" + randUpperAlnum(sessionTokenRandomLen),
+		Expiration:      s.clock.Now().UTC().Add(dur),
+	}
+
+	s.mu.Lock()
+	s.sessions[sess.AccessKeyID] = sess
+	s.mu.Unlock()
+
+	return sess
+}
+
+// Lookup returns the recorded session for id, if any. Expiry is not filtered
+// here: the gate compares the returned Expiration against its own clock so it
+// can return the expired-token error shape distinctly from an unknown key.
+func (s *SessionStore) Lookup(id string) (Session, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	sess, ok := s.sessions[id]
+
+	return sess, ok
+}
+
+// tempCredentialPrefix marks STS-issued temporary access key ids (real STS uses
+// the same "ASIA" prefix).
+const tempCredentialPrefix = "ASIA"
+
+// alnumUpper is the alphabet for generated key ids/secrets (AWS access key ids
+// are uppercase alphanumeric).
+const alnumUpper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// randUpperAlnum returns n cryptographically-random uppercase-alphanumeric
+// characters. It draws from crypto/rand; on the practically-impossible read
+// error it falls back to the first alphabet character so the result is still
+// well-formed (an unverifiable-but-present credential, never a panic).
+func randUpperAlnum(n int) string {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		for i := range buf {
+			buf[i] = alnumUpper[0]
+		}
+
+		return string(buf)
+	}
+
+	for i := range buf {
+		buf[i] = alnumUpper[int(buf[i])%len(alnumUpper)]
+	}
+
+	return string(buf)
+}

--- a/server/wire/sigv4/hardening_test.go
+++ b/server/wire/sigv4/hardening_test.go
@@ -1,0 +1,195 @@
+package sigv4
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+
+	"github.com/stackshy/cloudemu/v2/config"
+)
+
+// signAt signs r with the real v4 signer at signingTime, using the given payload
+// hash verbatim (so a caller can sign UNSIGNED-PAYLOAD or a real body hash).
+func signAt(t *testing.T, r *http.Request, payloadHash, service string, signingTime time.Time) {
+	t.Helper()
+
+	creds := aws.Credentials{AccessKeyID: testAKID, SecretAccessKey: testSecret}
+	if err := v4.NewSigner().SignHTTP(
+		r.Context(), creds, r, payloadHash, service, "us-east-1", signingTime,
+	); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+}
+
+// TestVerifyClockSkew proves a header-signed request outside the 5-minute skew
+// window is rejected while a fresh one (evaluated at signing time) passes.
+func TestVerifyClockSkew(t *testing.T) {
+	signingTime := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	body := []byte("Action=ListUsers&Version=2010-05-08")
+
+	newSigned := func() *http.Request {
+		r, err := http.NewRequest(http.MethodPost, "http://example.local/", strings.NewReader(string(body)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		sum := sha256.Sum256(body)
+		signAt(t, r, hex.EncodeToString(sum[:]), "iam", signingTime)
+
+		return r
+	}
+
+	// Fresh: clock at signing time -> passes.
+	if _, aerr := Verify(newSigned(), body, lookupOK(testSecret), config.NewFakeClock(signingTime)); aerr != nil {
+		t.Fatalf("fresh request rejected: %v", aerr)
+	}
+
+	// Skew exceeded (10 minutes later) -> RequestTimeTooSkewed.
+	late := config.NewFakeClock(signingTime.Add(10 * time.Minute))
+	if _, aerr := Verify(newSigned(), body, lookupOK(testSecret), late); aerr == nil ||
+		aerr.Code != "RequestTimeTooSkewed" {
+		t.Fatalf("want RequestTimeTooSkewed, got %v", aerr)
+	}
+
+	// Skew exceeded in the past direction too.
+	early := config.NewFakeClock(signingTime.Add(-10 * time.Minute))
+	if _, aerr := Verify(newSigned(), body, lookupOK(testSecret), early); aerr == nil ||
+		aerr.Code != "RequestTimeTooSkewed" {
+		t.Fatalf("want RequestTimeTooSkewed (past), got %v", aerr)
+	}
+}
+
+// TestVerifyPresignedExpiry proves a presigned URL is accepted inside its
+// X-Amz-Expires window and rejected once it has elapsed.
+func TestVerifyPresignedExpiry(t *testing.T) {
+	signingTime := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	const expires = 900 * time.Second
+
+	presign := func() *http.Request {
+		base, err := http.NewRequest(http.MethodGet, "http://example.local/bucket/key", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		q := base.URL.Query()
+		q.Set("X-Amz-Expires", strconv.Itoa(int(expires.Seconds())))
+		base.URL.RawQuery = q.Encode()
+
+		creds := aws.Credentials{AccessKeyID: testAKID, SecretAccessKey: testSecret}
+		uri, _, err := v4.NewSigner().PresignHTTP(
+			base.Context(), creds, base, "UNSIGNED-PAYLOAD", "s3", "us-east-1", signingTime,
+		)
+		if err != nil {
+			t.Fatalf("presign: %v", err)
+		}
+
+		r, err := http.NewRequest(http.MethodGet, uri, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return r
+	}
+
+	// Inside the window -> passes.
+	fresh := config.NewFakeClock(signingTime.Add(5 * time.Minute))
+	if _, aerr := Verify(presign(), nil, lookupOK(testSecret), fresh); aerr != nil {
+		t.Fatalf("presigned URL inside window rejected: %v", aerr)
+	}
+
+	// Past the window -> expired.
+	expired := config.NewFakeClock(signingTime.Add(expires + time.Minute))
+	if _, aerr := Verify(presign(), nil, lookupOK(testSecret), expired); aerr == nil ||
+		aerr.Code != "AccessDenied" {
+		t.Fatalf("want AccessDenied (expired), got %v", aerr)
+	}
+}
+
+// TestVerifyContentSHA256BodySwap proves a request whose body is swapped after
+// signing but whose signed x-amz-content-sha256 header is kept is rejected, and
+// that a genuine body still verifies.
+func TestVerifyContentSHA256BodySwap(t *testing.T) {
+	signingTime := time.Now()
+	original := []byte(`{"amount":1}`)
+
+	newSigned := func() *http.Request {
+		r, err := http.NewRequest(http.MethodPost, "http://example.local/bucket/key",
+			strings.NewReader(string(original)))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// A real S3 client sends x-amz-content-sha256 as a signed header, so the
+		// canonical request binds to the header value, not the live body — the
+		// exact condition a body swap exploits.
+		sum := sha256.Sum256(original)
+		r.Header.Set("X-Amz-Content-Sha256", hex.EncodeToString(sum[:]))
+		signAt(t, r, hex.EncodeToString(sum[:]), "s3", signingTime)
+
+		return r
+	}
+
+	// Genuine body: header matches -> passes.
+	if _, aerr := Verify(newSigned(), original, lookupOK(testSecret), config.RealClock{}); aerr != nil {
+		t.Fatalf("genuine body rejected: %v", aerr)
+	}
+
+	// Swapped body, header (and signature) preserved -> mismatch.
+	swapped := []byte(`{"amount":9999}`)
+	if _, aerr := Verify(newSigned(), swapped, lookupOK(testSecret), config.RealClock{}); aerr == nil ||
+		aerr.Code != "XAmzContentSHA256Mismatch" {
+		t.Fatalf("want XAmzContentSHA256Mismatch, got %v", aerr)
+	}
+}
+
+// TestVerifyUnsignedPayloadSkipsBodyBinding proves that with the UNSIGNED-PAYLOAD
+// sentinel the body is not re-hashed, so a request still verifies regardless of
+// the body bytes presented (the SDK's legitimate unsigned-payload mode).
+func TestVerifyUnsignedPayloadSkipsBodyBinding(t *testing.T) {
+	r, err := http.NewRequest(http.MethodPut, "http://example.local/bucket/key",
+		strings.NewReader("streamed-body"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r.Header.Set("X-Amz-Content-Sha256", "UNSIGNED-PAYLOAD")
+	signAt(t, r, "UNSIGNED-PAYLOAD", "s3", time.Now())
+
+	// Present a different body than was streamed: UNSIGNED-PAYLOAD means the body
+	// is not bound, so verification still passes.
+	if _, aerr := Verify(r, []byte("anything-else"), lookupOK(testSecret), config.RealClock{}); aerr != nil {
+		t.Fatalf("UNSIGNED-PAYLOAD request rejected: %v", aerr)
+	}
+}
+
+// TestIsHexSHA256 covers the sentinel/real-hash discriminator.
+func TestIsHexSHA256(t *testing.T) {
+	real := hex.EncodeToString(func() []byte { s := sha256.Sum256([]byte("x")); return s[:] }())
+
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{real, true},
+		{strings.ToUpper(real), true},
+		{"UNSIGNED-PAYLOAD", false},
+		{"STREAMING-AWS4-HMAC-SHA256-PAYLOAD", false},
+		{"", false},
+		{real[:63], false},
+		{real[:63] + "g", false},
+	}
+
+	for _, c := range cases {
+		if got := isHexSHA256(c.in); got != c.want {
+			t.Errorf("isHexSHA256(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/server/wire/sigv4/sigv4.go
+++ b/server/wire/sigv4/sigv4.go
@@ -15,7 +15,9 @@ import (
 	"encoding/hex"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/server/authctx"
@@ -27,6 +29,15 @@ const (
 	unsignedStatus = http.StatusForbidden
 	// credScopeParts is AKID/DATE/REGION/SERVICE/aws4_request.
 	credScopeParts = 5
+	// maxClockSkew is the tolerance between a signed request's X-Amz-Date and the
+	// server clock for the Authorization-header form (real AWS allows 5 minutes).
+	maxClockSkew = 5 * time.Minute
+	// amzDateFormat is the ISO-8601 basic timestamp the SDK puts in X-Amz-Date.
+	amzDateFormat = "20060102T150405Z"
+	// sha256HexLen is the length of a hex-encoded SHA-256 digest; an
+	// x-amz-content-sha256 of exactly this many hex chars is a real body hash
+	// (not one of the UNSIGNED-PAYLOAD / STREAMING-* sentinels).
+	sha256HexLen = 64
 )
 
 // AuthError is a typed authentication failure carrying the AWS error code and
@@ -51,7 +62,8 @@ type signInputs struct {
 	service       string
 	signedHeaders []string
 	signature     string
-	amzDate       string // full timestamp used in the string-to-sign
+	amzDate       string        // full timestamp used in the string-to-sign
+	expires       time.Duration // presigned validity window (X-Amz-Expires); 0 if absent
 	presigned     bool
 }
 
@@ -69,11 +81,19 @@ func AccessKeyID(r *http.Request) string {
 
 // Verify checks the request's SigV4 signature against the secret resolved for
 // its access key id. On success it returns the resolved principal; on failure a
-// typed AuthError (HTTP 403). body is the buffered request body (the gate reads
-// and restores it). clock is accepted for skew evaluation; expiry is not
-// strictly enforced in this revision (the emulator commonly runs on a FakeClock
-// and tests may sign with fixed dates).
-func Verify(r *http.Request, body []byte, lookup LookupFunc, _ config.Clock) (authctx.Principal, *AuthError) {
+// typed AuthError. body is the buffered request body (the gate reads and
+// restores it). clock drives timestamp-expiry evaluation, so a FakeClock makes
+// it deterministic in tests.
+//
+// Beyond the signature it enforces two body/time bindings a captured-but-valid
+// signature would otherwise slip past:
+//   - x-amz-content-sha256 body binding: when the header is a real body hash
+//     (not a sentinel), the actual body is re-hashed and a mismatch is rejected,
+//     so a body swap that keeps the signed header fails.
+//   - timestamp expiry / clock skew: an X-Amz-Date outside the allowed window
+//     (5-minute skew for header-signed requests, X-Amz-Expires for presigned
+//     URLs) is rejected, so a captured signature cannot be replayed later.
+func Verify(r *http.Request, body []byte, lookup LookupFunc, clock config.Clock) (authctx.Principal, *AuthError) {
 	in, err := parseInputs(r)
 	if err != nil {
 		return authctx.Principal{}, err
@@ -88,6 +108,10 @@ func Verify(r *http.Request, body []byte, lookup LookupFunc, _ config.Clock) (au
 		}
 	}
 
+	if aerr := checkContentSHA256(r, body); aerr != nil {
+		return authctx.Principal{}, aerr
+	}
+
 	canonReq := canonicalRequest(r, body, &in)
 	sts := stringToSign(&in, canonReq)
 	expected := hex.EncodeToString(sign(signingKey(secret, &in), []byte(sts)))
@@ -100,7 +124,119 @@ func Verify(r *http.Request, body []byte, lookup LookupFunc, _ config.Clock) (au
 		}
 	}
 
+	if aerr := checkExpiry(&in, clock); aerr != nil {
+		return authctx.Principal{}, aerr
+	}
+
 	return principal, nil
+}
+
+// checkContentSHA256 re-binds the S3 x-amz-content-sha256 header to the actual
+// body. The header value is part of the signed canonical request, so a captured
+// request whose body is swapped but whose header is left intact still produces a
+// matching signature; re-hashing the body and comparing closes that gap. The
+// UNSIGNED-PAYLOAD and STREAMING-* sentinels carry no body hash, so they are
+// skipped (recognized by not being a 64-char hex digest). Absent header: skip.
+func checkContentSHA256(r *http.Request, body []byte) *AuthError {
+	v := r.Header.Get("X-Amz-Content-Sha256")
+	if !isHexSHA256(v) {
+		return nil
+	}
+
+	sum := sha256.Sum256(body)
+	if !strings.EqualFold(v, hex.EncodeToString(sum[:])) {
+		return &AuthError{
+			Code:       "XAmzContentSHA256Mismatch",
+			Message:    "The provided 'x-amz-content-sha256' header does not match what was computed.",
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+
+	return nil
+}
+
+// isHexSHA256 reports whether v is exactly a hex-encoded SHA-256 digest (and so
+// a real body hash rather than a sentinel such as UNSIGNED-PAYLOAD).
+func isHexSHA256(v string) bool {
+	if len(v) != sha256HexLen {
+		return false
+	}
+
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// checkExpiry rejects a request whose signing timestamp is outside the allowed
+// window. Header-signed requests must be within maxClockSkew of now in either
+// direction; presigned URLs must be within their X-Amz-Expires window (and not
+// dated in the future beyond the skew). An unparseable date is not evaluated
+// (the signature already matched), which never happens for real SDK requests.
+func checkExpiry(in *signInputs, clock config.Clock) *AuthError {
+	signed, ok := parseAmzDate(in.amzDate)
+	if !ok {
+		return nil
+	}
+
+	now := clock.Now().UTC()
+
+	if in.presigned {
+		if in.expires > 0 && now.After(signed.Add(in.expires)) {
+			return expiredErr()
+		}
+
+		if now.Before(signed.Add(-maxClockSkew)) {
+			return skewErr()
+		}
+
+		return nil
+	}
+
+	diff := now.Sub(signed)
+	if diff < 0 {
+		diff = -diff
+	}
+
+	if diff > maxClockSkew {
+		return skewErr()
+	}
+
+	return nil
+}
+
+// parseAmzDate parses the X-Amz-Date value, accepting the ISO-8601 basic form
+// the SDK uses and the RFC1123 form a Date-header fallback may carry.
+func parseAmzDate(s string) (time.Time, bool) {
+	if t, err := time.Parse(amzDateFormat, s); err == nil {
+		return t.UTC(), true
+	}
+
+	if t, err := time.Parse(time.RFC1123, s); err == nil {
+		return t.UTC(), true
+	}
+
+	return time.Time{}, false
+}
+
+func expiredErr() *AuthError {
+	return &AuthError{
+		Code:       "AccessDenied",
+		Message:    "Request has expired",
+		HTTPStatus: unsignedStatus,
+	}
+}
+
+func skewErr() *AuthError {
+	return &AuthError{
+		Code:       "RequestTimeTooSkewed",
+		Message:    "The difference between the request time and the current time is too large.",
+		HTTPStatus: unsignedStatus,
+	}
 }
 
 // parseInputs extracts the signing material from either the Authorization
@@ -152,13 +288,24 @@ func parseHeader(r *http.Request, auth string) (signInputs, *AuthError) {
 func parsePresigned(r *http.Request) (signInputs, *AuthError) {
 	q := r.URL.Query()
 
-	return buildInputs(
+	in, aerr := buildInputs(
 		q.Get("X-Amz-Credential"),
 		q.Get("X-Amz-SignedHeaders"),
 		q.Get("X-Amz-Signature"),
 		q.Get("X-Amz-Date"),
 		true,
 	)
+	if aerr != nil {
+		return in, aerr
+	}
+
+	if v := q.Get("X-Amz-Expires"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			in.expires = time.Duration(secs) * time.Second
+		}
+	}
+
+	return in, nil
 }
 
 // buildInputs assembles and validates signInputs from raw fields.


### PR DESCRIPTION
Closes #839. Auth hardening follow-ups after the SigV4 authN foundation (#838). Every change is gated on `--enforce-auth`; with it off (the default) behavior is byte-for-byte unchanged.

## 1. ASIA temporary credentials are now verified (was: trusted unverified)
STS previously returned a single constant synthetic ASIA credential and the gate trusted any ASIA-prefixed key with no signature check. STS now records the temporary credentials it mints in a per-server session store (`server/aws/sts/sessions.go`), created only when enforce-auth is on. Each `AssumeRole` / `GetSessionToken` / `GetFederationToken` / web-identity / SAML call mints a unique ASIA key id with a fresh high-entropy secret and stores `id -> {secret, expiration}`. The auth gate resolves the ASIA key's secret from that store and SigV4-verifies the signature exactly like a long-term AKIA key.

- Valid signature made with the STS-issued secret: accepted.
- Forged/wrong secret: `SignatureDoesNotMatch`.
- Unknown ASIA key: `InvalidClientTokenId`.
- Expired session: `ExpiredToken`.
- No store wired (shouldn't happen when enforce-auth is on): fails closed.

## 2. Timestamp expiry / clock skew enforced
`sigv4.Verify` now uses the injected `config.Clock` (was ignored). Header-signed requests must be within 5 minutes of server time in either direction (`RequestTimeTooSkewed`); presigned URLs must be inside their `X-Amz-Expires` window and not future-dated beyond the skew (`AccessDenied` / "Request has expired"). This stops a captured signature from replaying. `FakeClock` makes it deterministic in tests.

## 3. x-amz-content-sha256 bound to the body
When the header is a real hex SHA-256 (not a sentinel), the body is re-hashed and a mismatch is rejected with `XAmzContentSHA256Mismatch` — so a body swap that keeps the signed header fails. `UNSIGNED-PAYLOAD` and the `STREAMING-*` sentinels carry no body hash and are skipped (recognized as not being a 64-char hex digest). Genuine signed requests where the header matches the body are unaffected.

## Tests
`server/wire/sigv4/hardening_test.go` (skew, presigned expiry, body-swap rejection, UNSIGNED-PAYLOAD passthrough, sentinel discriminator) and `server/aws/authgate_temp_test.go` (temp-credential valid/forged/unknown/expired via FakeClock; real-SDK end-to-end AssumeRole -> signed request proving STS and the gate share the store; enforce-auth-off returns the fixed synthetic credential). All use hand-rolled helpers; the real aws-sdk-go-v2 v4 signer produces the signatures.

Gates: `go build`, `go vet`, `go test` (server + sigv4 + iam), `go generate` (no doc diff), and `golangci-lint` on the touched packages all pass with no new issues.
