### PR TITLE
fix(aws): ESM + Lambda routing fidelity follow-ups (#577)

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -268,6 +268,9 @@ func New(opts ...config.Option) *Provider {
 	// An IamInstanceProfile passed to RunInstances resolves through IAM so the
 	// role->profile->instance chain reads back on DescribeInstances.
 	p.EC2.SetInstanceProfileResolver(p.IAM)
+	// A KmsKeyId passed to CreateSecret is validated against KMS, so a secret
+	// can't reference a key that doesn't exist.
+	p.SecretsManager.SetKMSKeyResolver(p.KMS)
 	p.SSM.SetInstanceResolver(p.EC2)
 	// ECS-registered container instances surface as managed EC2 instances, so
 	// #159 (ECS) composes with #300 (EC2 managed-resource visibility).
@@ -314,6 +317,10 @@ func New(opts ...config.Option) *Provider {
 	// event-source-mapping target(s), deleting the message on success or
 	// leaving it for DLQ redrive on failure (mirrors the DynamoDB Streams wiring).
 	p.SQS.SetEventSourceInvoker(p.Lambda)
+	// Kinesis -> Lambda: records written to a stream (PutRecord/PutRecords)
+	// deliver a Kinesis-shaped event batch to the stream's event-source-mapping
+	// target(s) (mirrors the DynamoDB Streams -> Lambda wiring).
+	p.Kinesis.SetLambdaInvoker(p.Lambda)
 	// CloudWatch Logs subscription filters -> Lambda: log events matching a
 	// subscription filter's pattern are delivered (gzipped awslogs payload) to
 	// the filter's Lambda destination on PutLogEvents.

--- a/providers/aws/kinesis/event_source_mapping_test.go
+++ b/providers/aws/kinesis/event_source_mapping_test.go
@@ -1,0 +1,161 @@
+package kinesis_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/aws/kinesis"
+	"github.com/stackshy/cloudemu/v2/services/kinesis/driver"
+)
+
+// recordingKinesisInvoker captures Kinesis -> Lambda event-source-mapping
+// deliveries, mirroring providers/aws/dynamodb's recordingStreamInvoker. It
+// always reports a mapping as present (delivered=true).
+type recordingKinesisInvoker struct {
+	arns     []string
+	payloads [][]byte
+}
+
+func (r *recordingKinesisInvoker) DeliverEventSourceBatch(_ context.Context, arn string, payload []byte) (bool, error) {
+	r.arns = append(r.arns, arn)
+	r.payloads = append(r.payloads, payload)
+
+	return true, nil
+}
+
+// TestPutRecordDeliversToLambda verifies that, once a Lambda invoker is wired,
+// PutRecord delivers a real Kinesis Lambda event (see
+// https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html) tagged with
+// the stream's ARN, with the record data base64-encoded.
+func TestPutRecordDeliversToLambda(t *testing.T) {
+	ctx := context.Background()
+	m := kinesis.New(config.NewOptions(config.WithRegion("us-east-1"), config.WithAccountID("123456789012")))
+
+	inv := &recordingKinesisInvoker{}
+	m.SetLambdaInvoker(inv)
+
+	if err := m.CreateStream(ctx, driver.CreateStreamInput{StreamName: "events", ShardCount: 1}); err != nil {
+		t.Fatalf("CreateStream: %v", err)
+	}
+
+	res, err := m.PutRecord(ctx, driver.PutRecordInput{
+		StreamName: "events", PartitionKey: "pk-1", Data: []byte("hello-kinesis"),
+	})
+	if err != nil {
+		t.Fatalf("PutRecord: %v", err)
+	}
+
+	wantARN := "arn:aws:kinesis:us-east-1:123456789012:stream/events"
+	if len(inv.arns) != 1 || inv.arns[0] != wantARN {
+		t.Fatalf("deliveries = %v, want exactly one to %s", inv.arns, wantARN)
+	}
+
+	var event struct {
+		Records []struct {
+			Kinesis struct {
+				PartitionKey   string `json:"partitionKey"`
+				SequenceNumber string `json:"sequenceNumber"`
+				Data           string `json:"data"`
+			} `json:"kinesis"`
+			EventSource    string `json:"eventSource"`
+			EventName      string `json:"eventName"`
+			EventID        string `json:"eventID"`
+			EventSourceARN string `json:"eventSourceARN"`
+			AWSRegion      string `json:"awsRegion"`
+		} `json:"Records"`
+	}
+
+	if err := json.Unmarshal(inv.payloads[0], &event); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+
+	if len(event.Records) != 1 {
+		t.Fatalf("Records = %d, want 1", len(event.Records))
+	}
+
+	rec := event.Records[0]
+
+	if rec.EventSource != "aws:kinesis" || rec.EventName != "aws:kinesis:record" {
+		t.Fatalf("eventSource=%q eventName=%q", rec.EventSource, rec.EventName)
+	}
+
+	if rec.EventSourceARN != wantARN || rec.AWSRegion != "us-east-1" {
+		t.Fatalf("eventSourceARN=%q awsRegion=%q", rec.EventSourceARN, rec.AWSRegion)
+	}
+
+	if rec.Kinesis.PartitionKey != "pk-1" || rec.Kinesis.SequenceNumber != res.SequenceNumber {
+		t.Fatalf("partitionKey=%q sequenceNumber=%q, want pk-1 / %s",
+			rec.Kinesis.PartitionKey, rec.Kinesis.SequenceNumber, res.SequenceNumber)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(rec.Kinesis.Data)
+	if err != nil {
+		t.Fatalf("data is not base64: %v", err)
+	}
+
+	if string(decoded) != "hello-kinesis" {
+		t.Fatalf("data = %q, want hello-kinesis", decoded)
+	}
+
+	if rec.EventID != res.ShardID+":"+res.SequenceNumber {
+		t.Fatalf("eventID = %q, want %s:%s", rec.EventID, res.ShardID, res.SequenceNumber)
+	}
+}
+
+// TestPutRecordsDeliversBatchToLambda verifies PutRecords delivers a single
+// event batch carrying every appended record to the mapped Lambda.
+func TestPutRecordsDeliversBatchToLambda(t *testing.T) {
+	ctx := context.Background()
+	m := kinesis.New(config.NewOptions(config.WithRegion("us-east-1"), config.WithAccountID("123456789012")))
+
+	inv := &recordingKinesisInvoker{}
+	m.SetLambdaInvoker(inv)
+
+	if err := m.CreateStream(ctx, driver.CreateStreamInput{StreamName: "batch", ShardCount: 1}); err != nil {
+		t.Fatalf("CreateStream: %v", err)
+	}
+
+	_, _, err := m.PutRecords(ctx, "batch", "", []driver.PutRecordsRequestEntry{
+		{PartitionKey: "a", Data: []byte("1")},
+		{PartitionKey: "b", Data: []byte("2")},
+		{PartitionKey: "c", Data: []byte("3")},
+	})
+	if err != nil {
+		t.Fatalf("PutRecords: %v", err)
+	}
+
+	if len(inv.payloads) != 1 {
+		t.Fatalf("deliveries = %d, want 1 batch", len(inv.payloads))
+	}
+
+	var event struct {
+		Records []json.RawMessage `json:"Records"`
+	}
+
+	if err := json.Unmarshal(inv.payloads[0], &event); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+
+	if len(event.Records) != 3 {
+		t.Fatalf("Records = %d, want 3", len(event.Records))
+	}
+}
+
+// TestPutRecordNoInvokerNoDelivery verifies PutRecord never delivers when no
+// Lambda invoker is wired (the default).
+func TestPutRecordNoInvokerNoDelivery(t *testing.T) {
+	ctx := context.Background()
+	m := kinesis.New(config.NewOptions())
+
+	if err := m.CreateStream(ctx, driver.CreateStreamInput{StreamName: "s", ShardCount: 1}); err != nil {
+		t.Fatalf("CreateStream: %v", err)
+	}
+
+	// No panic / no delivery path when the invoker is nil.
+	if _, err := m.PutRecord(ctx, driver.PutRecordInput{StreamName: "s", PartitionKey: "k", Data: []byte("d")}); err != nil {
+		t.Fatalf("PutRecord: %v", err)
+	}
+}

--- a/providers/aws/kinesis/kinesis.go
+++ b/providers/aws/kinesis/kinesis.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
 	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/services/kinesis/driver"
 )
@@ -67,6 +68,14 @@ type streamData struct {
 	mu        sync.RWMutex
 }
 
+// EventSourceInvoker delivers a Kinesis event batch to whatever Lambda
+// event-source-mappings target the stream identified by eventSourceARN. The
+// Lambda mock satisfies it, enabling real Kinesis -> Lambda invocation
+// (mirroring the DynamoDB Streams / SQS event-source-mapping wiring).
+type EventSourceInvoker interface {
+	DeliverEventSourceBatch(ctx context.Context, eventSourceARN string, payload []byte) (delivered bool, err error)
+}
+
 // Mock is an in-memory implementation of AWS Kinesis Data Streams.
 type Mock struct {
 	// streams is keyed by stream name; arnToName resolves an ARN to its name.
@@ -75,6 +84,10 @@ type Mock struct {
 
 	settingsMu sync.RWMutex
 	settings   driver.AccountSettings
+
+	// esmInvoker, when wired via SetLambdaInvoker, receives a Kinesis-shaped
+	// event batch on every PutRecord(s) so a mapped Lambda actually runs.
+	esmInvoker EventSourceInvoker
 
 	opts *config.Options
 }
@@ -87,6 +100,31 @@ func New(opts *config.Options) *Mock {
 		settings:  driver.AccountSettings{CommitmentStatus: "DISABLED"},
 		opts:      opts,
 	}
+}
+
+// SetLambdaInvoker wires the Lambda backend so records written to a stream
+// invoke the stream's event-source-mapping targets.
+func (m *Mock) SetLambdaInvoker(i EventSourceInvoker) {
+	m.esmInvoker = i
+}
+
+// deliverToLambda delivers a batch of just-appended records to the Lambda
+// event-source-mappings targeting the stream, as a real Kinesis ESM poller
+// would. It runs after the stream lock is released so a mapped Lambda may
+// safely call back into Kinesis, and always on a fresh background context that
+// carries forward only the re-entrant delivery depth (internal/recursionguard):
+// InvokeExternal's guard, the single choke point every delivery funnels
+// through, bounds a handler that writes back into its own source stream. A
+// no-op when no invoker is wired or the batch is empty.
+func (m *Mock) deliverToLambda(callerCtx context.Context, streamARN string, recs []driver.LambdaEventRecord) {
+	if m.esmInvoker == nil || len(recs) == 0 {
+		return
+	}
+
+	ctx := recursionguard.WithDepth(context.Background(), recursionguard.Depth(callerCtx))
+	region := regionctx.RegionOr(callerCtx, m.opts.Region)
+	payload := driver.BuildLambdaKinesisEvent(streamARN, region, recs)
+	_, _ = m.esmInvoker.DeliverEventSourceBatch(ctx, streamARN, payload)
 }
 
 func (m *Mock) streamARN(ctx context.Context, name string) string {

--- a/providers/aws/kinesis/records.go
+++ b/providers/aws/kinesis/records.go
@@ -111,7 +111,7 @@ func shardForHashKey(shards []*shardState, key *big.Int) *shardState {
 // it, returning the assigned shard id and sequence number.
 //
 //nolint:gocritic // in is the public PutRecord input, taken by value to match the driver API
-func (m *Mock) PutRecord(_ context.Context, in driver.PutRecordInput) (*driver.PutRecordResult, error) {
+func (m *Mock) PutRecord(ctx context.Context, in driver.PutRecordInput) (*driver.PutRecordResult, error) {
 	if in.PartitionKey == "" {
 		return nil, invalidArg("PartitionKey is required")
 	}
@@ -122,28 +122,39 @@ func (m *Mock) PutRecord(_ context.Context, in driver.PutRecordInput) (*driver.P
 	}
 
 	sd.mu.Lock()
-	defer sd.mu.Unlock()
 
 	if limit := recordSizeLimit(sd); len(in.Data) > limit {
+		sd.mu.Unlock()
 		return nil, validationErr("record data of %d bytes exceeds the %d-byte limit", len(in.Data), limit)
 	}
 
 	shard, seq, err := m.appendRecord(sd, in.PartitionKey, in.ExplicitHashKey, in.Data)
 	if err != nil {
+		sd.mu.Unlock()
 		return nil, err
 	}
 
-	return &driver.PutRecordResult{
+	res := &driver.PutRecordResult{
 		ShardID:        shard,
 		SequenceNumber: seq,
 		EncryptionType: sd.desc.EncryptionType,
-	}, nil
+	}
+	esm := driver.LambdaEventRecord{
+		ShardID: shard, SequenceNumber: seq, PartitionKey: in.PartitionKey,
+		Data: in.Data, ArrivalTime: m.now(),
+	}
+	streamARN := m.streamARN(ctx, sd.desc.StreamName)
+	sd.mu.Unlock()
+
+	m.deliverToLambda(ctx, streamARN, []driver.LambdaEventRecord{esm})
+
+	return res, nil
 }
 
 // PutRecords appends a batch of records, returning a per-entry result (records
 // never fail individually in the emulator) and the failed count.
 func (m *Mock) PutRecords(
-	_ context.Context, name, arn string, entries []driver.PutRecordsRequestEntry,
+	ctx context.Context, name, arn string, entries []driver.PutRecordsRequestEntry,
 ) ([]driver.PutRecordsResultEntry, int32, error) {
 	if len(entries) == 0 {
 		return nil, 0, invalidArg("Records must contain at least one entry")
@@ -160,13 +171,14 @@ func (m *Mock) PutRecords(
 	}
 
 	sd.mu.Lock()
-	defer sd.mu.Unlock()
 
 	if err := validateBatchSize(sd, entries); err != nil {
+		sd.mu.Unlock()
 		return nil, 0, err
 	}
 
 	out := make([]driver.PutRecordsResultEntry, 0, len(entries))
+	esm := make([]driver.LambdaEventRecord, 0, len(entries))
 
 	for i := range entries {
 		if entries[i].PartitionKey == "" {
@@ -187,6 +199,10 @@ func (m *Mock) PutRecords(
 		}
 
 		out = append(out, driver.PutRecordsResultEntry{ShardID: shard, SequenceNumber: seq})
+		esm = append(esm, driver.LambdaEventRecord{
+			ShardID: shard, SequenceNumber: seq, PartitionKey: entries[i].PartitionKey,
+			Data: entries[i].Data, ArrivalTime: m.now(),
+		})
 	}
 
 	var failed int32
@@ -196,6 +212,11 @@ func (m *Mock) PutRecords(
 			failed++
 		}
 	}
+
+	streamARN := m.streamARN(ctx, sd.desc.StreamName)
+	sd.mu.Unlock()
+
+	m.deliverToLambda(ctx, streamARN, esm)
 
 	return out, failed, nil
 }

--- a/providers/aws/lambda/aliases.go
+++ b/providers/aws/lambda/aliases.go
@@ -159,31 +159,45 @@ func copyRoutingConfig(rc *driver.AliasRoutingConfig) *driver.AliasRoutingConfig
 		return nil
 	}
 
-	cp := *rc
+	if len(rc.AdditionalVersionWeights) == 0 {
+		return &driver.AliasRoutingConfig{}
+	}
 
-	return &cp
+	weights := make(map[string]float64, len(rc.AdditionalVersionWeights))
+	for v, w := range rc.AdditionalVersionWeights {
+		weights[v] = w
+	}
+
+	return &driver.AliasRoutingConfig{AdditionalVersionWeights: weights}
 }
 
 // validateRoutingConfig enforces the RoutingConfig.AdditionalVersionWeights
-// rules real Lambda applies: neither the alias's own version nor the additional
-// version can be $LATEST (InvalidParameterValueException), and the additional
+// rules real Lambda applies: neither the alias's own version nor any additional
+// version can be $LATEST (InvalidParameterValueException), and every additional
 // version must exist (ResourceNotFoundException). effectiveVersion is the alias's
-// own FunctionVersion after the operation. An absent additional version is a no-op.
+// own FunctionVersion after the operation. An empty weights map is a no-op.
 func (m *Mock) validateRoutingConfig(fd *funcData, effectiveVersion string, rc *driver.AliasRoutingConfig) error {
-	if rc == nil || rc.AdditionalVersion == "" {
+	if rc == nil || len(rc.AdditionalVersionWeights) == 0 {
 		return nil
 	}
 
 	// A weighted alias cannot point to $LATEST — this restriction applies to the
-	// alias's own FunctionVersion (the primary target) as well as the additional
-	// version. Both must be published.
-	if effectiveVersion == latestVersion || rc.AdditionalVersion == latestVersion {
+	// alias's own FunctionVersion (the primary target) as well as every
+	// additional version. All must be published.
+	if effectiveVersion == latestVersion {
 		return cerrors.New(cerrors.InvalidArgument,
 			"Alias with weights can not be created with function version $LATEST")
 	}
 
-	if !m.versionExists(fd, rc.AdditionalVersion) {
-		return cerrors.Newf(cerrors.NotFound, "version %s not found", rc.AdditionalVersion)
+	for version := range rc.AdditionalVersionWeights {
+		if version == latestVersion {
+			return cerrors.New(cerrors.InvalidArgument,
+				"Alias with weights can not be created with function version $LATEST")
+		}
+
+		if !m.versionExists(fd, version) {
+			return cerrors.Newf(cerrors.NotFound, "version %s not found", version)
+		}
 	}
 
 	return nil

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -5,9 +5,11 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"maps"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -35,6 +37,12 @@ const (
 	timeFormat       = "2006-01-02T15:04:05Z"
 	// tracingModePassThrough is the AWS Lambda default X-Ray tracing mode.
 	tracingModePassThrough = "PassThrough"
+	// invokeTypeDryRun is the X-Amz-Invocation-Type value that validates
+	// parameters and permissions (including the Qualifier) without running the
+	// function.
+	invokeTypeDryRun = "DryRun"
+	// dryRunStatusCode is the HTTP 204 No Content a successful DryRun reports.
+	dryRunStatusCode = 204
 )
 
 // AWS Lambda create-time defaults applied when the client omits the field:
@@ -294,9 +302,17 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", input.FunctionName)
 	}
 
-	executedVersion, err := m.resolveQualifier(&fd, input.Qualifier)
+	executedVersion, err := m.resolveQualifier(&fd, input.Qualifier, input.Payload)
 	if err != nil {
 		return nil, err
+	}
+
+	// A DryRun validates the function, qualifier, and permissions but runs
+	// nothing and emits no metrics: resolveQualifier above has already rejected
+	// an unknown alias/version with ResourceNotFoundException, so a DryRun that
+	// reaches here is valid and reports 204 No Content.
+	if input.InvokeType == invokeTypeDryRun {
+		return &driver.InvokeOutput{StatusCode: dryRunStatusCode, ExecutedVersion: executedVersion}, nil
 	}
 
 	dims := map[string]string{"FunctionName": input.FunctionName}
@@ -348,17 +364,20 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 // resolveQualifier resolves an Invoke Qualifier (empty, "$LATEST", a numeric
 // published version, or an alias name) to the concrete version that should be
 // reported as ExecutedVersion, matching real Lambda's alias-resolution
-// semantics: an alias resolves one hop to its target FunctionVersion (aliases
-// can't point to other aliases); a version qualifier must name a version that
-// was actually published. An unknown qualifier is a ResourceNotFoundException,
+// semantics: an alias resolves one hop to a FunctionVersion (aliases can't
+// point to other aliases); a version qualifier must name a version that was
+// actually published. A weighted alias splits between its primary
+// FunctionVersion and the versions in RoutingConfig.AdditionalVersionWeights;
+// routingKey (the invoke payload) selects one deterministically (see
+// selectAliasVersion). An unknown qualifier is a ResourceNotFoundException,
 // the same error AWS returns for an alias or version that doesn't exist.
-func (m *Mock) resolveQualifier(fd *funcData, qualifier string) (string, error) {
+func (m *Mock) resolveQualifier(fd *funcData, qualifier string, routingKey []byte) (string, error) {
 	if qualifier == "" || qualifier == latestVersion {
 		return latestVersion, nil
 	}
 
 	if ad, ok := fd.aliases.Get(qualifier); ok {
-		return ad.alias.FunctionVersion, nil
+		return selectAliasVersion(&ad.alias, routingKey), nil
 	}
 
 	if m.versionExists(fd, qualifier) {
@@ -366,6 +385,50 @@ func (m *Mock) resolveQualifier(fd *funcData, qualifier string) (string, error) 
 	}
 
 	return "", cerrors.Newf(cerrors.NotFound, "function version/alias not found for %s", qualifier)
+}
+
+// selectAliasVersion picks the concrete version a weighted alias routes an
+// invocation to: the additional versions in RoutingConfig.AdditionalVersionWeights
+// receive their configured fractions of traffic, the alias's primary
+// FunctionVersion the remainder. The choice is deterministic in routingKey
+// (the invoke payload) — a given event always routes to the same version, and
+// across many distinct events the split approaches the configured weights — so
+// tests can assert the distribution without flakiness. An alias with no weights
+// always resolves to its primary FunctionVersion.
+func selectAliasVersion(a *driver.Alias, routingKey []byte) string {
+	rc := a.RoutingConfig
+	if rc == nil || len(rc.AdditionalVersionWeights) == 0 {
+		return a.FunctionVersion
+	}
+
+	// Iterate additional versions in a stable (sorted) order so the cumulative
+	// bands are reproducible; the primary version owns [sum,1).
+	versions := make([]string, 0, len(rc.AdditionalVersionWeights))
+	for v := range rc.AdditionalVersionWeights {
+		versions = append(versions, v)
+	}
+
+	sort.Strings(versions)
+
+	point := hashToUnitFloat(routingKey)
+	cumulative := 0.0
+
+	for _, v := range versions {
+		cumulative += rc.AdditionalVersionWeights[v]
+		if point < cumulative {
+			return v
+		}
+	}
+
+	return a.FunctionVersion
+}
+
+// hashToUnitFloat maps arbitrary bytes to a point in [0.0,1.0) via a SHA-256
+// digest, giving a stable, uniformly spread value for weighted-alias routing.
+func hashToUnitFloat(key []byte) float64 {
+	sum := sha256.Sum256(key)
+	// Divide a 64-bit prefix by 2^64 to land in [0,1).
+	return float64(binary.BigEndian.Uint64(sum[:8])) / (1 << 64)
 }
 
 // InvokeExternal asynchronously invokes the function identified by its ARN with

--- a/providers/aws/lambda/lambda_test.go
+++ b/providers/aws/lambda/lambda_test.go
@@ -409,8 +409,7 @@ func TestUpdateAlias(t *testing.T) {
 			Name:            "atomic",
 			FunctionVersion: "2",
 			RoutingConfig: &driver.AliasRoutingConfig{
-				AdditionalVersion: "$LATEST",
-				Weight:            0.1,
+				AdditionalVersionWeights: map[string]float64{"$LATEST": 0.1},
 			},
 		})
 		assertError(t, err, true)
@@ -464,26 +463,23 @@ func TestAliasWeightedRouting(t *testing.T) {
 		Name:            "canary",
 		FunctionVersion: "1",
 		RoutingConfig: &driver.AliasRoutingConfig{
-			AdditionalVersion: "2",
-			Weight:            0.1,
+			AdditionalVersionWeights: map[string]float64{"2": 0.1},
 		},
 	})
 	requireNoError(t, err)
 	assertEqual(t, "1", alias.FunctionVersion)
-	assertEqual(t, "2", alias.RoutingConfig.AdditionalVersion)
-	assertEqual(t, 0.1, alias.RoutingConfig.Weight)
+	assertEqual(t, 0.1, alias.RoutingConfig.AdditionalVersionWeights["2"])
 
 	// Update routing config
 	updated, err := m.UpdateAlias(ctx, driver.AliasConfig{
 		FunctionName: "my-func",
 		Name:         "canary",
 		RoutingConfig: &driver.AliasRoutingConfig{
-			AdditionalVersion: "2",
-			Weight:            0.5,
+			AdditionalVersionWeights: map[string]float64{"2": 0.5},
 		},
 	})
 	requireNoError(t, err)
-	assertEqual(t, 0.5, updated.RoutingConfig.Weight)
+	assertEqual(t, 0.5, updated.RoutingConfig.AdditionalVersionWeights["2"])
 }
 
 func TestAliasWeightedRoutingRejectsLatest(t *testing.T) {
@@ -498,8 +494,7 @@ func TestAliasWeightedRoutingRejectsLatest(t *testing.T) {
 		Name:            "bad",
 		FunctionVersion: "$LATEST",
 		RoutingConfig: &driver.AliasRoutingConfig{
-			AdditionalVersion: "1",
-			Weight:            0.1,
+			AdditionalVersionWeights: map[string]float64{"1": 0.1},
 		},
 	})
 	assertError(t, err, true)
@@ -517,11 +512,120 @@ func TestAliasWeightedRoutingRejectsLatest(t *testing.T) {
 		FunctionName: "my-func",
 		Name:         "plain",
 		RoutingConfig: &driver.AliasRoutingConfig{
-			AdditionalVersion: "1",
-			Weight:            0.1,
+			AdditionalVersionWeights: map[string]float64{"1": 0.1},
 		},
 	})
 	assertError(t, err, true)
+}
+
+func TestAliasWeightedRoutingSplitsInvocations(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
+	_, _ = m.PublishVersion(ctx, "my-func", "v1") // version "1"
+	_, _ = m.PublishVersion(ctx, "my-func", "v2") // version "2"
+
+	_, err := m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName:    "my-func",
+		Name:            "canary",
+		FunctionVersion: "1",
+		RoutingConfig: &driver.AliasRoutingConfig{
+			AdditionalVersionWeights: map[string]float64{"2": 0.3},
+		},
+	})
+	requireNoError(t, err)
+
+	const n = 2000
+
+	counts := map[string]int{}
+
+	for i := 0; i < n; i++ {
+		out, invokeErr := m.Invoke(ctx, driver.InvokeInput{
+			FunctionName: "my-func",
+			Qualifier:    "canary",
+			Payload:      []byte(fmt.Sprintf("event-%d", i)),
+		})
+		requireNoError(t, invokeErr)
+		counts[out.ExecutedVersion]++
+	}
+
+	// Weighted routing is deterministic in the payload, so this split is stable
+	// across runs: both versions receive traffic and version 2 lands near its
+	// configured 30% weight.
+	if counts["1"] == 0 || counts["2"] == 0 {
+		t.Fatalf("expected both versions to receive traffic, got %+v", counts)
+	}
+
+	frac := float64(counts["2"]) / float64(n)
+	if frac < 0.25 || frac > 0.35 {
+		t.Fatalf("version 2 share = %.3f, want ~0.30 (counts %+v)", frac, counts)
+	}
+}
+
+func TestAliasWeightedRoutingIsDeterministicPerPayload(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
+	_, _ = m.PublishVersion(ctx, "my-func", "v1")
+	_, _ = m.PublishVersion(ctx, "my-func", "v2")
+
+	_, err := m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName:    "my-func",
+		Name:            "canary",
+		FunctionVersion: "1",
+		RoutingConfig: &driver.AliasRoutingConfig{
+			AdditionalVersionWeights: map[string]float64{"2": 0.5},
+		},
+	})
+	requireNoError(t, err)
+
+	first, err := m.Invoke(ctx, driver.InvokeInput{
+		FunctionName: "my-func", Qualifier: "canary", Payload: []byte("stable-key"),
+	})
+	requireNoError(t, err)
+
+	for i := 0; i < 20; i++ {
+		out, invokeErr := m.Invoke(ctx, driver.InvokeInput{
+			FunctionName: "my-func", Qualifier: "canary", Payload: []byte("stable-key"),
+		})
+		requireNoError(t, invokeErr)
+
+		if out.ExecutedVersion != first.ExecutedVersion {
+			t.Fatalf("same payload routed to %q then %q; must be deterministic",
+				first.ExecutedVersion, out.ExecutedVersion)
+		}
+	}
+}
+
+func TestInvokeDryRunValidatesQualifier(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
+	_, _ = m.PublishVersion(ctx, "my-func", "v1")
+	_, _ = m.CreateAlias(ctx, driver.AliasConfig{FunctionName: "my-func", Name: "prod", FunctionVersion: "1"})
+
+	t.Run("valid alias returns 204 without running", func(t *testing.T) {
+		out, err := m.Invoke(ctx, driver.InvokeInput{
+			FunctionName: "my-func", InvokeType: "DryRun", Qualifier: "prod",
+		})
+		requireNoError(t, err)
+		assertEqual(t, 204, out.StatusCode)
+		assertEqual(t, "1", out.ExecutedVersion)
+	})
+
+	t.Run("unknown alias is ResourceNotFound", func(t *testing.T) {
+		_, err := m.Invoke(ctx, driver.InvokeInput{
+			FunctionName: "my-func", InvokeType: "DryRun", Qualifier: "missing",
+		})
+		assertError(t, err, true)
+	})
+
+	t.Run("unknown version is ResourceNotFound", func(t *testing.T) {
+		_, err := m.Invoke(ctx, driver.InvokeInput{
+			FunctionName: "my-func", InvokeType: "DryRun", Qualifier: "99",
+		})
+		assertError(t, err, true)
+	})
 }
 
 func TestPublishLayerVersion(t *testing.T) {
@@ -771,8 +875,7 @@ func TestAliasRoutingConfigDeepCopy(t *testing.T) {
 	_, _ = m.PublishVersion(ctx, "my-func", "v2")
 
 	rc := &driver.AliasRoutingConfig{
-		AdditionalVersion: "2",
-		Weight:            0.5,
+		AdditionalVersionWeights: map[string]float64{"2": 0.5},
 	}
 
 	_, err := m.CreateAlias(ctx, driver.AliasConfig{
@@ -783,12 +886,12 @@ func TestAliasRoutingConfigDeepCopy(t *testing.T) {
 	})
 	requireNoError(t, err)
 
-	// Mutate the original config
-	rc.Weight = 0.9
+	// Mutate the original config's map: the stored alias must be unaffected.
+	rc.AdditionalVersionWeights["2"] = 0.9
 
 	alias, err := m.GetAlias(ctx, "my-func", "deep-copy")
 	requireNoError(t, err)
-	assertEqual(t, 0.5, alias.RoutingConfig.Weight)
+	assertEqual(t, 0.5, alias.RoutingConfig.AdditionalVersionWeights["2"])
 }
 
 func requireNoError(t *testing.T, err error) {

--- a/providers/aws/lambda/policy.go
+++ b/providers/aws/lambda/policy.go
@@ -44,8 +44,9 @@ func (m *Mock) AddPermission(_ context.Context, functionName, qualifier string, 
 	}
 
 	// A qualifier must name a version/alias that exists; a grant on a missing one
-	// is a ResourceNotFoundException, matching real Lambda.
-	if _, err := m.resolveQualifier(&fd, qualifier); err != nil {
+	// is a ResourceNotFoundException, matching real Lambda. Routing key is nil:
+	// this only validates existence, not which weighted version traffic hits.
+	if _, err := m.resolveQualifier(&fd, qualifier, nil); err != nil {
 		return err
 	}
 

--- a/providers/aws/secretsmanager/secretsmanager.go
+++ b/providers/aws/secretsmanager/secretsmanager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	kmsdriver "github.com/stackshy/cloudemu/v2/services/kms/driver"
 	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
 )
 
@@ -43,10 +44,21 @@ const (
 	defaultRecoveryWindowDays = 30
 )
 
+// KMSKeyResolver validates that a customer-managed KMS key referenced by a
+// secret actually exists. The KMS mock satisfies it via DescribeKey (which
+// resolves a key id, ARN, or alias), so CreateSecret can reject a KmsKeyId that
+// names no key — mirroring how EC2 resolves an IAM instance profile through IAM.
+type KMSKeyResolver interface {
+	DescribeKey(ctx context.Context, keyID string) (*kmsdriver.KeyMetadata, error)
+}
+
 // Mock is an in-memory mock implementation of the AWS Secrets Manager service.
 type Mock struct {
 	secrets *memstore.Store[*secretData]
-	opts    *config.Options
+	// kmsResolver, when wired via SetKMSKeyResolver, validates a caller-supplied
+	// KmsKeyId against KMS on CreateSecret. Nil leaves the reference unchecked.
+	kmsResolver KMSKeyResolver
+	opts        *config.Options
 }
 
 // New creates a new Secrets Manager mock with the given configuration options.
@@ -57,10 +69,29 @@ func New(opts *config.Options) *Mock {
 	}
 }
 
+// SetKMSKeyResolver wires the KMS backend so a KmsKeyId passed to CreateSecret
+// is validated to exist, matching real Secrets Manager.
+func (m *Mock) SetKMSKeyResolver(r KMSKeyResolver) {
+	m.kmsResolver = r
+}
+
 // CreateSecret creates a new secret with an initial value.
-func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []byte) (*driver.SecretInfo, error) {
+//
+//nolint:gocritic // hugeParam: cfg matches the driver.Secrets interface signature.
+func (m *Mock) CreateSecret(ctx context.Context, cfg driver.SecretConfig, value []byte) (*driver.SecretInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "secret name is required")
+	}
+
+	// A customer-supplied KmsKeyId must reference a key that exists; real Secrets
+	// Manager rejects an unknown key with InvalidParameterException rather than
+	// storing a dangling reference. The default aws/secretsmanager key (used when
+	// KmsKeyId is empty) always exists, so only an explicit reference is checked.
+	if cfg.KMSKeyID != "" && m.kmsResolver != nil {
+		if _, err := m.kmsResolver.DescribeKey(ctx, cfg.KMSKeyID); err != nil {
+			return nil, errors.Newf(errors.InvalidArgument,
+				"KMS key %q does not exist or is not accessible", cfg.KMSKeyID)
+		}
 	}
 
 	if existing, ok := m.secrets.Get(cfg.Name); ok {

--- a/providers/aws/secretsmanager/secretsmanager_test.go
+++ b/providers/aws/secretsmanager/secretsmanager_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/aws/kms"
+	kmsdriver "github.com/stackshy/cloudemu/v2/services/kms/driver"
 	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,6 +72,31 @@ func TestCreateSecret(t *testing.T) {
 			assert.NotEmpty(t, info.UpdatedAt)
 		})
 	}
+}
+
+func TestCreateSecretValidatesKMSKey(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	k := kms.New(config.NewOptions(config.WithRegion("us-east-1")))
+	m.SetKMSKeyResolver(k)
+
+	// An explicit KmsKeyId that names no key is rejected.
+	_, err := m.CreateSecret(ctx, driver.SecretConfig{
+		Name: "bad-key", KMSKeyID: "arn:aws:kms:us-east-1:123456789012:key/does-not-exist",
+	}, []byte("v"))
+	require.Error(t, err)
+
+	// A KmsKeyId that resolves to a real key is accepted and reflected back.
+	key, err := k.CreateKey(ctx, kmsdriver.CreateKeyInput{})
+	require.NoError(t, err)
+
+	info, err := m.CreateSecret(ctx, driver.SecretConfig{Name: "good-key", KMSKeyID: key.KeyID}, []byte("v"))
+	require.NoError(t, err)
+	assert.Equal(t, key.KeyID, info.KMSKeyID)
+
+	// No KmsKeyId means the default aws/secretsmanager key: never validated.
+	_, err = m.CreateSecret(ctx, driver.SecretConfig{Name: "default-key"}, []byte("v"))
+	require.NoError(t, err)
 }
 
 func TestCreateSecretDuplicate(t *testing.T) {

--- a/providers/aws/sqs/event_source_mapping_test.go
+++ b/providers/aws/sqs/event_source_mapping_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
@@ -120,6 +121,70 @@ func TestEventSourceInvokerDeliversOnSend(t *testing.T) {
 	info, err := m.GetQueueInfo(ctx, q.URL)
 	requireNoError(t, err)
 	assertEqual(t, 0, info.ApproxMessageCount)
+}
+
+// TestEventSourceInvokerHonorsDelaySeconds verifies that a message sent with
+// DelaySeconds is NOT delivered to the Lambda event-source-mapping while it is
+// still inside its delay window, and IS delivered once the delay elapses and a
+// later send re-sweeps the queue — mirroring how a real SQS->Lambda ESM poller
+// only sees a message after its delay makes it visible.
+func TestEventSourceInvokerHonorsDelaySeconds(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+
+	inv := &recordingESMInvoker{}
+	m.SetEventSourceInvoker(inv)
+
+	q, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "delay-queue"})
+	requireNoError(t, err)
+
+	// A delayed message is not yet visible, so the ESM must not receive it.
+	_, err = m.SendMessage(ctx, driver.SendMessageInput{
+		QueueURL: q.URL, Body: "delayed", DelaySeconds: 5,
+	})
+	requireNoError(t, err)
+
+	if len(inv.arns) != 0 {
+		t.Fatalf("deliveries before delay elapsed = %d, want 0", len(inv.arns))
+	}
+
+	// Advance past the delay and send a second message: the sweep now sees both.
+	fc.Advance(6 * time.Second)
+
+	_, err = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: q.URL, Body: "trigger"})
+	requireNoError(t, err)
+
+	if len(inv.payloads) != 2 {
+		t.Fatalf("deliveries after delay elapsed = %d, want 2", len(inv.payloads))
+	}
+
+	if !deliveredBody(t, inv.payloads, "delayed") {
+		t.Fatal("the delayed message was never delivered after its delay elapsed")
+	}
+}
+
+// deliveredBody reports whether any delivered SQS event batch carries a record
+// with the given body.
+func deliveredBody(t *testing.T, payloads [][]byte, body string) bool {
+	t.Helper()
+
+	for _, p := range payloads {
+		var event struct {
+			Records []struct {
+				Body string `json:"body"`
+			} `json:"Records"`
+		}
+
+		requireNoError(t, json.Unmarshal(p, &event))
+
+		for _, rec := range event.Records {
+			if rec.Body == body {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // TestEventSourceInvokerNoInvokerNoDelivery verifies SendMessage never delivers

--- a/providers/aws/sqs/sqs.go
+++ b/providers/aws/sqs/sqs.go
@@ -460,7 +460,7 @@ func (m *Mock) SendMessage(ctx context.Context, input driver.SendMessageInput) (
 	// outside qd.mu so a handler that calls back into SQS (SendMessage,
 	// ReceiveMessage, DeleteMessage against this or another queue) never
 	// deadlocks on it.
-	m.deliverToESM(ctx, qd, msg)
+	m.deliverToESM(ctx, qd)
 
 	return &driver.SendMessageOutput{
 		MessageID:      msgID,
@@ -468,16 +468,57 @@ func (m *Mock) SendMessage(ctx context.Context, input driver.SendMessageInput) (
 	}, nil
 }
 
-// deliverToESM synchronously delivers a newly sent message to the Lambda
-// event-source-mapping(s) targeting this queue, mirroring real SQS ESM
-// polling collapsed into the SendMessage call since the emulator has no
-// background poller. Each pass builds a trial "received" view of the message
-// (a fresh ReceiptHandle, ReceiveCount+1) without touching the stored message
-// yet, and only commits that receive once DeliverEventSourceBatch reports
-// delivered=true — i.e. a mapping actually exists for this queue's ARN. A
-// queue with no ESM configured at all must therefore leave the message
-// completely untouched, rather than have "nothing happened" misread as a
-// processed batch.
+// deliverToESM sweeps the queue for messages whose delay has elapsed and
+// delivers each to the Lambda event-source-mapping(s) targeting this queue,
+// mirroring real SQS ESM polling collapsed into the SendMessage call since the
+// emulator has no background poller. Only messages that are visible now
+// (VisibleAt <= now) are swept: a message still inside its DelaySeconds window
+// is not yet visible to a poller, so it is skipped and picked up by the next
+// SendMessage on this queue after its delay elapses — the same visibility gate
+// the ReceiveMessages poll path applies (see collectVisibleMessages). The
+// visible set is snapshotted once so the sweep is bounded regardless of a
+// per-message outcome. A no-op when no invoker is wired.
+//
+// callerCtx is SendMessage's own context, used only to read the re-entrant
+// delivery depth (internal/recursionguard): a mapped handler commonly
+// re-sends to the very queue that triggered it, re-entering here through the
+// same synchronous call chain (SendMessage -> deliver -> Invoke -> handler ->
+// SendMessage -> ...). Delivery itself always runs on a fresh background
+// context, decoupled from callerCtx's cancellation/deadline (delivery must
+// still complete once the SendMessage call has already returned), carrying
+// forward only the depth so the chain stays bounded.
+func (m *Mock) deliverToESM(callerCtx context.Context, qd *queueData) {
+	if m.esmInvoker == nil {
+		return
+	}
+
+	ctx := recursionguard.WithDepth(context.Background(), recursionguard.Depth(callerCtx))
+
+	qd.mu.Lock()
+	now := m.opts.Clock.Now()
+	pending := make([]*sqsMessage, 0, len(qd.messages))
+
+	for _, msg := range qd.messages {
+		if !msg.VisibleAt.After(now) {
+			pending = append(pending, msg)
+		}
+	}
+
+	qd.mu.Unlock()
+
+	for _, msg := range pending {
+		m.deliverMessageToESM(ctx, qd, msg)
+	}
+}
+
+// deliverMessageToESM delivers a single already-visible message to the Lambda
+// event-source-mapping(s) targeting this queue. Each pass builds a trial
+// "received" view of the message (a fresh ReceiptHandle, ReceiveCount+1)
+// without touching the stored message yet, and only commits that receive once
+// DeliverEventSourceBatch reports delivered=true — i.e. a mapping actually
+// exists for this queue's ARN. A queue with no ESM configured at all must
+// therefore leave the message completely untouched, rather than have "nothing
+// happened" misread as a processed batch.
 //
 // Once a mapping has genuinely consumed the message: on success it is
 // deleted, matching "When your function successfully processes a batch,
@@ -488,23 +529,8 @@ func (m *Mock) SendMessage(ctx context.Context, input driver.SendMessageInput) (
 // in a synchronous loop until it either succeeds or exceedsMaxReceive is
 // reached, at which point the same DLQ-redrive threshold ReceiveMessages
 // honors (see collectVisibleMessages) moves the message to the dead-letter
-// queue. A no-op when no invoker is wired.
-//
-// callerCtx is SendMessage's own context, used only to read the re-entrant
-// delivery depth (internal/recursionguard): a mapped handler commonly
-// re-sends to the very queue that triggered it, re-entering here through the
-// same synchronous call chain (SendMessage -> deliver -> Invoke -> handler ->
-// SendMessage -> ...). Delivery itself always runs on a fresh background
-// context, decoupled from callerCtx's cancellation/deadline (delivery must
-// still complete once the SendMessage call has already returned), carrying
-// forward only the depth so the chain stays bounded.
-func (m *Mock) deliverToESM(callerCtx context.Context, qd *queueData, msg *sqsMessage) {
-	if m.esmInvoker == nil {
-		return
-	}
-
-	ctx := recursionguard.WithDepth(context.Background(), recursionguard.Depth(callerCtx))
-
+// queue. ctx already carries the re-entrant delivery depth.
+func (m *Mock) deliverMessageToESM(ctx context.Context, qd *queueData, msg *sqsMessage) {
 	for {
 		qd.mu.Lock()
 

--- a/providers/azure/functions/aliases.go
+++ b/providers/azure/functions/aliases.go
@@ -136,9 +136,16 @@ func copyRoutingConfig(rc *driver.AliasRoutingConfig) *driver.AliasRoutingConfig
 		return nil
 	}
 
-	cp := *rc
+	if len(rc.AdditionalVersionWeights) == 0 {
+		return &driver.AliasRoutingConfig{}
+	}
 
-	return &cp
+	weights := make(map[string]float64, len(rc.AdditionalVersionWeights))
+	for v, w := range rc.AdditionalVersionWeights {
+		weights[v] = w
+	}
+
+	return &driver.AliasRoutingConfig{AdditionalVersionWeights: weights}
 }
 
 // versionExists checks whether a version string exists for the given function.

--- a/providers/azure/functions/functions_test.go
+++ b/providers/azure/functions/functions_test.go
@@ -776,8 +776,7 @@ func TestUpdateAliasWithRoutingConfig(t *testing.T) {
 
 	t.Run("update with routing config", func(t *testing.T) {
 		rc := &driver.AliasRoutingConfig{
-			AdditionalVersion: "2",
-			Weight:            0.1,
+			AdditionalVersionWeights: map[string]float64{"2": 0.1},
 		}
 		result, err := m.UpdateAlias(ctx, driver.AliasConfig{
 			FunctionName: "fn1", Name: "prod", FunctionVersion: "1",
@@ -785,8 +784,7 @@ func TestUpdateAliasWithRoutingConfig(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, result.RoutingConfig)
-		assert.Equal(t, "2", result.RoutingConfig.AdditionalVersion)
-		assert.InDelta(t, 0.1, result.RoutingConfig.Weight, 0.001)
+		assert.InDelta(t, 0.1, result.RoutingConfig.AdditionalVersionWeights["2"], 0.001)
 	})
 
 	t.Run("update description only", func(t *testing.T) {
@@ -988,8 +986,7 @@ func TestAliasRoutingConfigDeepCopy(t *testing.T) {
 	require.NoError(t, err)
 
 	rc := &driver.AliasRoutingConfig{
-		AdditionalVersion: "1",
-		Weight:            0.5,
+		AdditionalVersionWeights: map[string]float64{"1": 0.5},
 	}
 
 	_, err = m.CreateAlias(ctx, driver.AliasConfig{
@@ -1000,11 +997,11 @@ func TestAliasRoutingConfigDeepCopy(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Mutate the original config
-	rc.Weight = 0.9
+	// Mutate the original config's map: the stored alias must be unaffected.
+	rc.AdditionalVersionWeights["1"] = 0.9
 
 	alias, err := m.GetAlias(ctx, "fn-dc", "deep-copy")
 	require.NoError(t, err)
 	require.NotNil(t, alias.RoutingConfig)
-	assert.InDelta(t, 0.5, alias.RoutingConfig.Weight, 0.001)
+	assert.InDelta(t, 0.5, alias.RoutingConfig.AdditionalVersionWeights["1"], 0.001)
 }

--- a/providers/gcp/cloudfunctions/aliases.go
+++ b/providers/gcp/cloudfunctions/aliases.go
@@ -136,9 +136,16 @@ func copyRoutingConfig(rc *driver.AliasRoutingConfig) *driver.AliasRoutingConfig
 		return nil
 	}
 
-	cp := *rc
+	if len(rc.AdditionalVersionWeights) == 0 {
+		return &driver.AliasRoutingConfig{}
+	}
 
-	return &cp
+	weights := make(map[string]float64, len(rc.AdditionalVersionWeights))
+	for v, w := range rc.AdditionalVersionWeights {
+		weights[v] = w
+	}
+
+	return &driver.AliasRoutingConfig{AdditionalVersionWeights: weights}
 }
 
 // versionExists checks whether a version string exists for the given function.

--- a/providers/gcp/cloudfunctions/functions_test.go
+++ b/providers/gcp/cloudfunctions/functions_test.go
@@ -766,14 +766,12 @@ func TestUpdateAliasRoutingConfig(t *testing.T) {
 			FunctionName: "f-rc", Name: "prod",
 			FunctionVersion: "1",
 			RoutingConfig: &driver.AliasRoutingConfig{
-				AdditionalVersion: "2",
-				Weight:            0.1,
+				AdditionalVersionWeights: map[string]float64{"2": 0.1},
 			},
 		})
 		require.NoError(t, updateErr)
 		require.NotNil(t, alias.RoutingConfig)
-		assert.Equal(t, "2", alias.RoutingConfig.AdditionalVersion)
-		assert.InDelta(t, 0.1, alias.RoutingConfig.Weight, 0.001)
+		assert.InDelta(t, 0.1, alias.RoutingConfig.AdditionalVersionWeights["2"], 0.001)
 	})
 
 	t.Run("update version to non-existent fails", func(t *testing.T) {
@@ -964,8 +962,7 @@ func TestAliasRoutingConfigDeepCopy(t *testing.T) {
 	require.NoError(t, err)
 
 	rc := &driver.AliasRoutingConfig{
-		AdditionalVersion: "1",
-		Weight:            0.5,
+		AdditionalVersionWeights: map[string]float64{"1": 0.5},
 	}
 
 	_, err = m.CreateAlias(ctx, driver.AliasConfig{
@@ -976,11 +973,11 @@ func TestAliasRoutingConfigDeepCopy(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Mutate the original config
-	rc.Weight = 0.9
+	// Mutate the original config's map: the stored alias must be unaffected.
+	rc.AdditionalVersionWeights["1"] = 0.9
 
 	alias, err := m.GetAlias(ctx, "f-dc", "deep-copy")
 	require.NoError(t, err)
 	require.NotNil(t, alias.RoutingConfig)
-	assert.InDelta(t, 0.5, alias.RoutingConfig.Weight, 0.001)
+	assert.InDelta(t, 0.5, alias.RoutingConfig.AdditionalVersionWeights["1"], 0.001)
 }

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -757,18 +757,19 @@ func (h *Handler) serveAlias(w http.ResponseWriter, r *http.Request, name, alias
 }
 
 // toRoutingConfig maps the wire AliasRoutingConfiguration (a map of additional
-// version -> weight) to the single-additional-version driver shape. Only the
-// first entry is honored, which matches the driver's model.
+// version -> weight) to the driver shape, preserving the full weights map so
+// every additional version reaches the backend's weighted-routing selection.
 func toRoutingConfig(rc *aliasRoutingConfig) *sdrv.AliasRoutingConfig {
 	if rc == nil || len(rc.AdditionalVersionWeights) == 0 {
 		return nil
 	}
 
+	weights := make(map[string]float64, len(rc.AdditionalVersionWeights))
 	for version, weight := range rc.AdditionalVersionWeights {
-		return &sdrv.AliasRoutingConfig{AdditionalVersion: version, Weight: weight}
+		weights[version] = weight
 	}
 
-	return nil
+	return &sdrv.AliasRoutingConfig{AdditionalVersionWeights: weights}
 }
 
 func toAliasResponse(a *sdrv.Alias) aliasResponse {
@@ -780,12 +781,13 @@ func toAliasResponse(a *sdrv.Alias) aliasResponse {
 		RevisionID:      a.RevisionID,
 	}
 
-	if a.RoutingConfig != nil {
-		resp.RoutingConfig = &aliasRoutingConfig{
-			AdditionalVersionWeights: map[string]float64{
-				a.RoutingConfig.AdditionalVersion: a.RoutingConfig.Weight,
-			},
+	if a.RoutingConfig != nil && len(a.RoutingConfig.AdditionalVersionWeights) > 0 {
+		weights := make(map[string]float64, len(a.RoutingConfig.AdditionalVersionWeights))
+		for version, weight := range a.RoutingConfig.AdditionalVersionWeights {
+			weights[version] = weight
 		}
+
+		resp.RoutingConfig = &aliasRoutingConfig{AdditionalVersionWeights: weights}
 	}
 
 	return resp
@@ -1145,10 +1147,17 @@ func (h *Handler) invoke(w http.ResponseWriter, r *http.Request, name string) {
 	invokeType := r.Header.Get("X-Amz-Invocation-Type")
 
 	// A DryRun invocation validates the request without executing the function:
-	// confirm the function exists, then return 204 No Content (real Lambda runs
-	// nothing and returns no payload).
+	// confirm the function AND the qualifier (alias/version) exist, then return
+	// 204 No Content (real Lambda runs nothing and returns no payload). Routing
+	// through Invoke reuses the driver's qualifier resolution, so an unknown
+	// alias/version fails with ResourceNotFoundException rather than a spurious
+	// 204.
 	if invokeType == invocationTypeDryRun {
-		if _, err = h.fn.GetFunction(r.Context(), functionName); err != nil {
+		if _, err = h.fn.Invoke(r.Context(), sdrv.InvokeInput{
+			FunctionName: functionName,
+			InvokeType:   invocationTypeDryRun,
+			Qualifier:    qualifier,
+		}); err != nil {
 			writeErr(w, err)
 			return
 		}

--- a/server/aws/lambda/sdk_roundtrip_test.go
+++ b/server/aws/lambda/sdk_roundtrip_test.go
@@ -176,6 +176,53 @@ func TestSDKLambdaInvokeOnMissingFunction(t *testing.T) {
 	}
 }
 
+// TestSDKLambdaDryRunValidatesQualifier verifies a DryRun invoke validates the
+// Qualifier: a known alias returns 204 No Content while an unknown alias/version
+// is ResourceNotFoundException rather than a spurious 204.
+func TestSDKLambdaDryRunValidatesQualifier(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "dry")
+
+	if _, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
+		FunctionName: aws.String("dry"),
+	}); err != nil {
+		t.Fatalf("PublishVersion: %v", err)
+	}
+
+	if _, err := client.CreateAlias(ctx, &awslambda.CreateAliasInput{
+		FunctionName: aws.String("dry"), Name: aws.String("prod"), FunctionVersion: aws.String("1"),
+	}); err != nil {
+		t.Fatalf("CreateAlias: %v", err)
+	}
+
+	// A DryRun against a valid alias validates and returns 204 with no payload.
+	resp, err := client.Invoke(ctx, &awslambda.InvokeInput{
+		FunctionName:   aws.String("dry"),
+		InvocationType: lambdatypes.InvocationTypeDryRun,
+		Qualifier:      aws.String("prod"),
+	})
+	if err != nil {
+		t.Fatalf("DryRun(prod): %v", err)
+	}
+
+	if resp.StatusCode != 204 {
+		t.Fatalf("DryRun(prod) StatusCode = %d, want 204", resp.StatusCode)
+	}
+
+	// A DryRun against an unknown qualifier is ResourceNotFoundException, not 204.
+	_, err = client.Invoke(ctx, &awslambda.InvokeInput{
+		FunctionName:   aws.String("dry"),
+		InvocationType: lambdatypes.InvocationTypeDryRun,
+		Qualifier:      aws.String("missing"),
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ResourceNotFoundException" {
+		t.Fatalf("DryRun(missing) err = %v, want ResourceNotFoundException", err)
+	}
+}
+
 func TestSDKLambdaConcurrencyRoundtrip(t *testing.T) {
 	client, _ := newSDKClient(t)
 	ctx := context.Background()

--- a/server/aws/secretsmanager/kms_key_test.go
+++ b/server/aws/secretsmanager/kms_key_test.go
@@ -6,22 +6,29 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awssm "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+
+	kmsdriver "github.com/stackshy/cloudemu/v2/services/kms/driver"
 )
 
 // TestCreateSecretKmsKeyIdReflectedOnDescribe drives the real-user flow: create
-// a secret encrypted with a customer KMS key, then DescribeSecret and confirm
-// the KmsKeyId round-trips (the key->secret reference is visible, matching the
-// DescribeSecret KmsKeyId field a tool like Terraform reads back).
+// a customer KMS key, create a secret encrypted with it, then DescribeSecret and
+// confirm the KmsKeyId round-trips (the key->secret reference is visible,
+// matching the DescribeSecret KmsKeyId field a tool like Terraform reads back).
 func TestCreateSecretKmsKeyIdReflectedOnDescribe(t *testing.T) {
-	client := newSecretsClient(t)
+	client, cloud := newSecretsClientWithCloud(t)
 	ctx := context.Background()
 
-	const keyARN = "arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+	// The referenced key must exist: CreateSecret validates KmsKeyId against KMS,
+	// as real Secrets Manager does.
+	key, err := cloud.KMS.CreateKey(ctx, kmsdriver.CreateKeyInput{})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
 
 	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
 		Name:         aws.String("encrypted-secret"),
 		SecretString: aws.String("hunter2"),
-		KmsKeyId:     aws.String(keyARN),
+		KmsKeyId:     aws.String(key.ARN),
 	}); err != nil {
 		t.Fatalf("CreateSecret: %v", err)
 	}
@@ -33,8 +40,25 @@ func TestCreateSecretKmsKeyIdReflectedOnDescribe(t *testing.T) {
 		t.Fatalf("DescribeSecret: %v", err)
 	}
 
-	if got := aws.ToString(desc.KmsKeyId); got != keyARN {
-		t.Fatalf("DescribeSecret KmsKeyId = %q, want %q", got, keyARN)
+	if got := aws.ToString(desc.KmsKeyId); got != key.ARN {
+		t.Fatalf("DescribeSecret KmsKeyId = %q, want %q", got, key.ARN)
+	}
+}
+
+// TestCreateSecretRejectsUnknownKmsKey confirms CreateSecret validates the
+// referenced KMS key: a KmsKeyId that names no key is rejected, matching real
+// Secrets Manager rather than storing a dangling reference.
+func TestCreateSecretRejectsUnknownKmsKey(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	_, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name:         aws.String("bad-key-secret"),
+		SecretString: aws.String("hunter2"),
+		KmsKeyId:     aws.String("arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab"),
+	})
+	if err == nil {
+		t.Fatal("CreateSecret with unknown KmsKeyId returned nil error, want failure")
 	}
 }
 

--- a/server/aws/secretsmanager/sdk_roundtrip_test.go
+++ b/server/aws/secretsmanager/sdk_roundtrip_test.go
@@ -13,10 +13,22 @@ import (
 	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 
 	"github.com/stackshy/cloudemu/v2"
+	awsprovider "github.com/stackshy/cloudemu/v2/providers/aws"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
 )
 
 func newSecretsClient(t *testing.T) *awssm.Client {
+	t.Helper()
+
+	client, _ := newSecretsClientWithCloud(t)
+
+	return client
+}
+
+// newSecretsClientWithCloud returns a Secrets Manager SDK client bound to a live
+// wire server plus the backing provider, so a test can seed cross-service state
+// (e.g. create a KMS key that a secret then references) via the Go API.
+func newSecretsClientWithCloud(t *testing.T) (*awssm.Client, *awsprovider.Provider) {
 	t.Helper()
 
 	cloud := cloudemu.NewAWS()
@@ -35,7 +47,7 @@ func newSecretsClient(t *testing.T) *awssm.Client {
 
 	return awssm.NewFromConfig(cfg, func(o *awssm.Options) {
 		o.BaseEndpoint = aws.String(ts.URL)
-	})
+	}), cloud
 }
 
 func TestSDKSecretLifecycle(t *testing.T) {

--- a/services/kinesis/driver/lambda_event.go
+++ b/services/kinesis/driver/lambda_event.go
@@ -1,0 +1,73 @@
+package driver
+
+import (
+	"encoding/json"
+	"time"
+)
+
+const (
+	// kinesisEventSource is the eventSource value Lambda stamps on every record
+	// delivered from a Kinesis event-source-mapping.
+	kinesisEventSource = "aws:kinesis"
+	// kinesisEventName is the eventName Lambda reports for a Kinesis record.
+	kinesisEventName = "aws:kinesis:record"
+	// kinesisSchemaVersion / kinesisEventVersion are the fixed schema/event
+	// versions Lambda reports for a Kinesis record.
+	kinesisSchemaVersion = "1.0"
+	kinesisEventVersion  = "1.0"
+	// millisPerSecond converts a millisecond timestamp to the fractional-seconds
+	// approximateArrivalTimestamp Lambda reports for a Kinesis record.
+	millisPerSecond = 1000
+)
+
+// LambdaEventRecord is one Kinesis record together with the shard it landed in,
+// carrying exactly the fields BuildLambdaKinesisEvent renders into a Lambda
+// event record. Data is the raw record bytes; the builder base64-encodes them.
+type LambdaEventRecord struct {
+	ShardID        string
+	SequenceNumber string
+	PartitionKey   string
+	Data           []byte
+	ArrivalTime    time.Time
+}
+
+// BuildLambdaKinesisEvent renders a batch of Kinesis records into the exact JSON
+// event Lambda delivers to a Kinesis event-source-mapping target:
+// {"Records":[{kinesis:{kinesisSchemaVersion,partitionKey,sequenceNumber,data,
+// approximateArrivalTimestamp},eventSource:"aws:kinesis",eventVersion,eventID,
+// eventName:"aws:kinesis:record",awsRegion,eventSourceARN}]}. data is the
+// base64-encoded record payload, matching the shape aws-sdk events.KinesisEvent
+// binds. See https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html.
+func BuildLambdaKinesisEvent(eventSourceARN, region string, recs []LambdaEventRecord) []byte {
+	records := make([]map[string]any, 0, len(recs))
+	for i := range recs {
+		records = append(records, lambdaKinesisRecord(&recs[i], eventSourceARN, region))
+	}
+
+	b, err := json.Marshal(map[string]any{"Records": records})
+	if err != nil {
+		return []byte(`{"Records":[]}`)
+	}
+
+	return b
+}
+
+func lambdaKinesisRecord(rec *LambdaEventRecord, eventSourceARN, region string) map[string]any {
+	return map[string]any{
+		"kinesis": map[string]any{
+			"kinesisSchemaVersion": kinesisSchemaVersion,
+			"partitionKey":         rec.PartitionKey,
+			"sequenceNumber":       rec.SequenceNumber,
+			// json.Marshal base64-encodes a []byte, exactly as Lambda delivers the
+			// data field.
+			"data":                        rec.Data,
+			"approximateArrivalTimestamp": float64(rec.ArrivalTime.UnixMilli()) / millisPerSecond,
+		},
+		"eventSource":    kinesisEventSource,
+		"eventVersion":   kinesisEventVersion,
+		"eventID":        rec.ShardID + ":" + rec.SequenceNumber,
+		"eventName":      kinesisEventName,
+		"awsRegion":      region,
+		"eventSourceARN": eventSourceARN,
+	}
+}

--- a/services/serverless/driver/driver.go
+++ b/services/serverless/driver/driver.go
@@ -66,10 +66,12 @@ type AliasConfig struct {
 	RoutingConfig   *AliasRoutingConfig // for weighted aliases
 }
 
-// AliasRoutingConfig defines weighted routing between versions.
+// AliasRoutingConfig defines weighted routing between versions. It mirrors the
+// AWS Lambda AliasRoutingConfiguration shape: AdditionalVersionWeights maps a
+// published version to the fraction of traffic (0.0-1.0) it receives; the
+// remaining traffic goes to the alias's primary FunctionVersion.
 type AliasRoutingConfig struct {
-	AdditionalVersion string
-	Weight            float64 // 0.0-1.0, traffic percentage to additional version
+	AdditionalVersionWeights map[string]float64
 }
 
 // Alias represents a function alias.
@@ -222,7 +224,7 @@ type FunctionInfo struct {
 type InvokeInput struct {
 	FunctionName string
 	Payload      []byte
-	InvokeType   string // "RequestResponse" or "Event"
+	InvokeType   string // "RequestResponse", "Event", or "DryRun"
 	// Qualifier selects a published version (a numeric version string) or
 	// alias to invoke instead of the mutable $LATEST code. Empty invokes
 	// $LATEST, matching the AWS Lambda Invoke Qualifier parameter.


### PR DESCRIPTION
Closes the event-source-mapping and Lambda routing fidelity gaps from #577.

- Kinesis PutRecord/PutRecords invoke mapped Lambdas (aws:kinesis event batch via the existing DeliverEventSourceBatch choke point)
- SQS→Lambda ESM honors DelaySeconds (visibility-gated sweep, mirrors the poll path)
- Lambda weighted-alias routing: full AdditionalVersionWeights map preserved end-to-end + deterministic weighted selection
- Lambda DryRun validates Qualifier (unknown alias/version → ResourceNotFoundException)
- SecretsManager CreateSecret validates KmsKeyId against KMS

5/6 checklist items done (+ sibling-mapping resilience already in code). Deferred: SQS async-delivery revisit; relocating BuildLambdaStreamEvent out of the cross-cloud services/database/driver package.