### PR TITLE
fix(kms): encrypt Secrets Manager & SSM SecureString through real KMS (#581)

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/providers/aws/keyspaces"
 	"github.com/stackshy/cloudemu/v2/providers/aws/kinesis"
 	"github.com/stackshy/cloudemu/v2/providers/aws/kms"
+	"github.com/stackshy/cloudemu/v2/providers/aws/kmscrypto"
 	"github.com/stackshy/cloudemu/v2/providers/aws/lambda"
 	"github.com/stackshy/cloudemu/v2/providers/aws/memorydb"
 	"github.com/stackshy/cloudemu/v2/providers/aws/networkfirewall"
@@ -273,9 +274,13 @@ func New(opts ...config.Option) *Provider {
 	// An IamInstanceProfile passed to RunInstances resolves through IAM so the
 	// role->profile->instance chain reads back on DescribeInstances.
 	p.EC2.SetInstanceProfileResolver(p.IAM)
-	// A KmsKeyId passed to CreateSecret is validated against KMS, so a secret
-	// can't reference a key that doesn't exist.
-	p.SecretsManager.SetKMSKeyResolver(p.KMS)
+	// Secrets Manager and SSM SecureString values are encrypted through real KMS
+	// (envelope encryption): a KmsKeyId is validated to exist, the value is stored
+	// as genuine ciphertext, and a later disabled/deleted key makes reads fail as
+	// in AWS. Both services share one Envelope over the KMS backend.
+	kmsCrypto := kmscrypto.New(p.KMS)
+	p.SecretsManager.SetKMSCrypto(kmsCrypto)
+	p.SSM.SetKMSCrypto(kmsCrypto)
 	p.SSM.SetInstanceResolver(p.EC2)
 	// ECS-registered container instances surface as managed EC2 instances, so
 	// #159 (ECS) composes with #300 (EC2 managed-resource visibility).

--- a/providers/aws/kmscrypto/kmscrypto.go
+++ b/providers/aws/kmscrypto/kmscrypto.go
@@ -1,0 +1,193 @@
+// Package kmscrypto routes Secrets Manager and SSM SecureString values through
+// real KMS envelope encryption so their at-rest form is genuine ciphertext and
+// their KMS-failure paths are real: a disabled or deleted key makes a read fail
+// exactly as it does in AWS.
+//
+// Encrypt asks KMS for a data key (wrapped under the addressed KMS key), seals
+// the value locally with AES-256-GCM under that data key, and returns a
+// self-describing blob carrying the wrapped key. Decrypt unwraps the data key
+// back through KMS — the step that surfaces a disabled/deleted key — then opens
+// the AES-GCM ciphertext. KMS's own crypto (providers/aws/kms) is used as-is and
+// never modified.
+package kmscrypto
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/binary"
+	"sync"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	kmsdriver "github.com/stackshy/cloudemu/v2/services/kms/driver"
+)
+
+// Envelope blob layout: magic(1) | wrappedKeyLen(uint32 BE) | wrappedKey |
+// nonce(12) | AES-256-GCM ciphertext. The wrapped key is a KMS ciphertext blob
+// that names its own key, so Decrypt needs no key id from the caller.
+const (
+	blobMagic  = 0x01
+	nonceSize  = 12
+	headerSize = 5 // magic(1) + wrappedKeyLen(4)
+)
+
+// KMS is the slice of the KMS backend this package needs. The KMS mock
+// (*kms.Mock) satisfies it; a data key is minted per value and unwrapped on
+// read, and an unresolvable managed-key reference is created on demand.
+type KMS interface {
+	DescribeKey(ctx context.Context, keyID string) (*kmsdriver.KeyMetadata, error)
+	CreateKey(ctx context.Context, in kmsdriver.CreateKeyInput) (*kmsdriver.KeyMetadata, error)
+	GenerateDataKey(ctx context.Context, in kmsdriver.GenerateDataKeyInput) (*kmsdriver.GenerateDataKeyOutput, error)
+	Decrypt(ctx context.Context, in kmsdriver.DecryptInput) (*kmsdriver.DecryptOutput, error)
+}
+
+// Envelope encrypts and decrypts secret values through a KMS backend.
+type Envelope struct {
+	kms KMS
+
+	mu sync.Mutex
+	// managed caches a key reference (typically the reserved
+	// alias/aws/secretsmanager or alias/aws/ssm managed-key aliases, which KMS
+	// won't let callers create) to the customer-managed key created on demand for
+	// it, so every value under one reference shares a single key.
+	managed map[string]string
+}
+
+// New wraps a KMS backend as an Envelope encryptor.
+func New(k KMS) *Envelope {
+	return &Envelope{kms: k, managed: make(map[string]string)}
+}
+
+// DescribeKey passes through to KMS so a caller can validate that an explicit
+// KmsKeyId names a real key before adopting it.
+func (e *Envelope) DescribeKey(ctx context.Context, keyID string) (*kmsdriver.KeyMetadata, error) {
+	return e.kms.DescribeKey(ctx, keyID)
+}
+
+// resolveKeyID turns a key reference (key id, ARN, or alias) into a usable key
+// id. A reference KMS already resolves is used directly; one it does not (the
+// reserved AWS-managed aliases, or an SSM key id that was never validated) gets
+// a customer-managed key created and cached on demand.
+func (e *Envelope) resolveKeyID(ctx context.Context, keyRef string) (string, error) {
+	if md, err := e.kms.DescribeKey(ctx, keyRef); err == nil {
+		return md.KeyID, nil
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if id, ok := e.managed[keyRef]; ok {
+		if _, err := e.kms.DescribeKey(ctx, id); err == nil {
+			return id, nil
+		}
+	}
+
+	md, err := e.kms.CreateKey(ctx, kmsdriver.CreateKeyInput{Description: "cloudemu managed key for " + keyRef})
+	if err != nil {
+		return "", err
+	}
+
+	e.managed[keyRef] = md.KeyID
+
+	return md.KeyID, nil
+}
+
+// Encrypt seals plaintext under the key named by keyRef and returns the envelope
+// blob. keyRef must be non-empty (callers pass an explicit KmsKeyId or their
+// service's default managed alias).
+func (e *Envelope) Encrypt(ctx context.Context, keyRef string, plaintext []byte) ([]byte, error) {
+	keyID, err := e.resolveKeyID(ctx, keyRef)
+	if err != nil {
+		return nil, err
+	}
+
+	dk, err := e.kms.GenerateDataKey(ctx, kmsdriver.GenerateDataKeyInput{KeyID: keyID, KeySpec: kmsdriver.DataKeyAES256})
+	if err != nil {
+		return nil, err
+	}
+
+	defer wipe(dk.Plaintext)
+
+	aead, err := gcm(dk.Plaintext)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, nonceSize)
+	if _, rerr := rand.Read(nonce); rerr != nil {
+		return nil, errors.Newf(errors.Internal, "nonce: %v", rerr)
+	}
+
+	sealed := aead.Seal(nil, nonce, plaintext, nil)
+
+	out := make([]byte, 0, headerSize+len(dk.CiphertextBlob)+len(nonce)+len(sealed))
+	out = append(out, blobMagic)
+	//nolint:gosec // a KMS ciphertext blob is a few hundred bytes, never near uint32 max
+	out = binary.BigEndian.AppendUint32(out, uint32(len(dk.CiphertextBlob)))
+	out = append(out, dk.CiphertextBlob...)
+	out = append(out, nonce...)
+	out = append(out, sealed...)
+
+	return out, nil
+}
+
+// Decrypt opens an envelope blob produced by Encrypt. Unwrapping the data key
+// goes back through KMS, so a disabled or deleted key surfaces the KMS error
+// here — matching a real Secrets Manager / SSM read against a broken key.
+func (e *Envelope) Decrypt(ctx context.Context, blob []byte) ([]byte, error) {
+	if len(blob) < headerSize || blob[0] != blobMagic {
+		return nil, errInvalidBlob()
+	}
+
+	wrappedLen := int(binary.BigEndian.Uint32(blob[1:headerSize]))
+
+	rest := blob[headerSize:]
+	if len(rest) < wrappedLen+nonceSize {
+		return nil, errInvalidBlob()
+	}
+
+	wrapped := rest[:wrappedLen]
+	rest = rest[wrappedLen:]
+	nonce, sealed := rest[:nonceSize], rest[nonceSize:]
+
+	dec, err := e.kms.Decrypt(ctx, kmsdriver.DecryptInput{CiphertextBlob: wrapped})
+	if err != nil {
+		return nil, err
+	}
+
+	defer wipe(dec.Plaintext)
+
+	aead, err := gcm(dec.Plaintext)
+	if err != nil {
+		return nil, err
+	}
+
+	pt, err := aead.Open(nil, nonce, sealed, nil)
+	if err != nil {
+		return nil, errInvalidBlob()
+	}
+
+	return pt, nil
+}
+
+// errInvalidBlob is the error for a malformed, truncated, or tampered blob.
+func errInvalidBlob() error {
+	return errors.New(errors.InvalidArgument, "invalid encrypted value")
+}
+
+func gcm(key []byte) (cipher.AEAD, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, errors.Newf(errors.Internal, "aes cipher: %v", err)
+	}
+
+	return cipher.NewGCM(block)
+}
+
+// wipe zeroes plaintext key material after use.
+func wipe(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/providers/aws/kmscrypto/kmscrypto_test.go
+++ b/providers/aws/kmscrypto/kmscrypto_test.go
@@ -1,0 +1,102 @@
+package kmscrypto_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/aws/kms"
+	"github.com/stackshy/cloudemu/v2/providers/aws/kmscrypto"
+	kmsdriver "github.com/stackshy/cloudemu/v2/services/kms/driver"
+)
+
+func newEnvelope() (*kmscrypto.Envelope, *kms.Mock) {
+	k := kms.New(config.NewOptions(config.WithRegion("us-east-1")))
+	return kmscrypto.New(k), k
+}
+
+func TestEnvelopeRoundTripWithExplicitKey(t *testing.T) {
+	e, k := newEnvelope()
+	ctx := context.Background()
+
+	key, err := k.CreateKey(ctx, kmsdriver.CreateKeyInput{})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	plaintext := []byte("secret payload")
+
+	blob, err := e.Encrypt(ctx, key.KeyID, plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	if bytes.Equal(blob, plaintext) {
+		t.Fatal("Encrypt returned the plaintext")
+	}
+
+	got, err := e.Decrypt(ctx, blob)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("Decrypt = %q, want %q", got, plaintext)
+	}
+}
+
+// TestEnvelopeCreatesManagedKeyOnDemand covers the reserved managed-key alias
+// path: a reference KMS cannot resolve gets a key created for it, and the same
+// reference reuses that key.
+func TestEnvelopeCreatesManagedKeyOnDemand(t *testing.T) {
+	e, _ := newEnvelope()
+	ctx := context.Background()
+
+	first, err := e.Encrypt(ctx, "alias/aws/secretsmanager", []byte("a"))
+	if err != nil {
+		t.Fatalf("Encrypt 1: %v", err)
+	}
+
+	second, err := e.Encrypt(ctx, "alias/aws/secretsmanager", []byte("b"))
+	if err != nil {
+		t.Fatalf("Encrypt 2: %v", err)
+	}
+
+	for _, blob := range [][]byte{first, second} {
+		if _, err := e.Decrypt(ctx, blob); err != nil {
+			t.Fatalf("Decrypt managed-key blob: %v", err)
+		}
+	}
+}
+
+func TestEnvelopeDecryptFailsAfterKeyDisabled(t *testing.T) {
+	e, k := newEnvelope()
+	ctx := context.Background()
+
+	key, err := k.CreateKey(ctx, kmsdriver.CreateKeyInput{})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	blob, err := e.Encrypt(ctx, key.KeyID, []byte("v"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	if err := k.DisableKey(ctx, key.KeyID); err != nil {
+		t.Fatalf("DisableKey: %v", err)
+	}
+
+	if _, err := e.Decrypt(ctx, blob); err == nil {
+		t.Fatal("Decrypt after DisableKey: want error, got nil")
+	}
+}
+
+func TestEnvelopeDecryptRejectsGarbage(t *testing.T) {
+	e, _ := newEnvelope()
+
+	if _, err := e.Decrypt(context.Background(), []byte("not a blob")); err == nil {
+		t.Fatal("Decrypt(garbage): want error, got nil")
+	}
+}

--- a/providers/aws/secretsmanager/encryption_test.go
+++ b/providers/aws/secretsmanager/encryption_test.go
@@ -1,0 +1,96 @@
+package secretsmanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/aws/kms"
+	"github.com/stackshy/cloudemu/v2/providers/aws/kmscrypto"
+	kmsdriver "github.com/stackshy/cloudemu/v2/services/kms/driver"
+	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newEncryptedMock() (*Mock, *kms.Mock) {
+	k := kms.New(config.NewOptions(config.WithRegion("us-east-1")))
+	m := newTestMock()
+	m.SetKMSCrypto(kmscrypto.New(k))
+
+	return m, k
+}
+
+// storedValue reaches into the backing store to read a version's at-rest bytes,
+// so a test can assert the value is stored as ciphertext rather than plaintext.
+func storedValue(t *testing.T, m *Mock, name string) []byte {
+	t.Helper()
+
+	sd, ok := m.secrets.Get(name)
+	require.True(t, ok, "secret %q not found", name)
+
+	require.NotEmpty(t, sd.versions)
+
+	return sd.versions[len(sd.versions)-1].Value
+}
+
+func TestSecretEncryptedAtRestAndRoundTrips(t *testing.T) {
+	m, _ := newEncryptedMock()
+	ctx := context.Background()
+
+	const value = "hunter2"
+
+	_, err := m.CreateSecret(ctx, driver.SecretConfig{Name: "db/creds"}, []byte(value))
+	require.NoError(t, err)
+
+	// At rest, the value is genuine ciphertext, not the plaintext.
+	assert.NotEqual(t, []byte(value), storedValue(t, m, "db/creds"))
+
+	// GetSecretValue decrypts back to the original plaintext.
+	got, err := m.GetSecretValue(ctx, "db/creds", "")
+	require.NoError(t, err)
+	assert.Equal(t, value, string(got.Value))
+
+	// A new version through PutSecretValue also round-trips.
+	_, err = m.PutSecretValue(ctx, "db/creds", []byte("rotated"))
+	require.NoError(t, err)
+
+	got, err = m.GetSecretValue(ctx, "db/creds", "")
+	require.NoError(t, err)
+	assert.Equal(t, "rotated", string(got.Value))
+}
+
+func TestGetSecretValueFailsAfterKeyDisabled(t *testing.T) {
+	m, k := newEncryptedMock()
+	ctx := context.Background()
+
+	key, err := k.CreateKey(ctx, kmsdriver.CreateKeyInput{})
+	require.NoError(t, err)
+
+	_, err = m.CreateSecret(ctx, driver.SecretConfig{Name: "db/creds", KMSKeyID: key.KeyID}, []byte("v"))
+	require.NoError(t, err)
+
+	// Readable while the key is enabled.
+	_, err = m.GetSecretValue(ctx, "db/creds", "")
+	require.NoError(t, err)
+
+	require.NoError(t, k.DisableKey(ctx, key.KeyID))
+
+	// A disabled key makes the read fail, as in real Secrets Manager.
+	_, err = m.GetSecretValue(ctx, "db/creds", "")
+	require.Error(t, err)
+}
+
+func TestSecretNoKMSFallbackStoresPlaintext(t *testing.T) {
+	m := newTestMock() // no KMS wired
+	ctx := context.Background()
+
+	_, err := m.CreateSecret(ctx, driver.SecretConfig{Name: "db/creds"}, []byte("plain"))
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte("plain"), storedValue(t, m, "db/creds"))
+
+	got, err := m.GetSecretValue(ctx, "db/creds", "")
+	require.NoError(t, err)
+	assert.Equal(t, "plain", string(got.Value))
+}

--- a/providers/aws/secretsmanager/secretsmanager.go
+++ b/providers/aws/secretsmanager/secretsmanager.go
@@ -44,21 +44,29 @@ const (
 	defaultRecoveryWindowDays = 30
 )
 
-// KMSKeyResolver validates that a customer-managed KMS key referenced by a
-// secret actually exists. The KMS mock satisfies it via DescribeKey (which
-// resolves a key id, ARN, or alias), so CreateSecret can reject a KmsKeyId that
-// names no key — mirroring how EC2 resolves an IAM instance profile through IAM.
-type KMSKeyResolver interface {
+// defaultKMSKey is the AWS-managed key Secrets Manager uses to encrypt a secret
+// whose CreateSecret request omitted KmsKeyId.
+const defaultKMSKey = "alias/aws/secretsmanager"
+
+// KMSCrypto is the KMS seam Secrets Manager uses. DescribeKey validates that an
+// explicit KmsKeyId names a real key (rejecting a dangling reference, as real
+// Secrets Manager does); Encrypt/Decrypt route the secret value through real KMS
+// so its at-rest form is genuine ciphertext and a disabled/deleted key makes the
+// read fail. The kmscrypto.Envelope adapter satisfies it.
+type KMSCrypto interface {
 	DescribeKey(ctx context.Context, keyID string) (*kmsdriver.KeyMetadata, error)
+	Encrypt(ctx context.Context, keyID string, plaintext []byte) ([]byte, error)
+	Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error)
 }
 
 // Mock is an in-memory mock implementation of the AWS Secrets Manager service.
 type Mock struct {
 	secrets *memstore.Store[*secretData]
-	// kmsResolver, when wired via SetKMSKeyResolver, validates a caller-supplied
-	// KmsKeyId against KMS on CreateSecret. Nil leaves the reference unchecked.
-	kmsResolver KMSKeyResolver
-	opts        *config.Options
+	// kmsCrypto, when wired via SetKMSCrypto, validates a caller-supplied KmsKeyId
+	// against KMS and encrypts stored secret values through it. Nil leaves the
+	// reference unchecked and stores values in the clear (library fallback).
+	kmsCrypto KMSCrypto
+	opts      *config.Options
 }
 
 // New creates a new Secrets Manager mock with the given configuration options.
@@ -69,10 +77,52 @@ func New(opts *config.Options) *Mock {
 	}
 }
 
-// SetKMSKeyResolver wires the KMS backend so a KmsKeyId passed to CreateSecret
-// is validated to exist, matching real Secrets Manager.
-func (m *Mock) SetKMSKeyResolver(r KMSKeyResolver) {
-	m.kmsResolver = r
+// SetKMSCrypto wires the KMS backend so a KmsKeyId passed to CreateSecret is
+// validated to exist and stored secret values are encrypted through real KMS.
+func (m *Mock) SetKMSCrypto(c KMSCrypto) {
+	m.kmsCrypto = c
+}
+
+// encrypt seals a secret value under kmsKeyID (empty selects the default
+// aws/secretsmanager managed key). With no KMS wired it returns the value
+// unchanged — the library plaintext fallback.
+func (m *Mock) encrypt(ctx context.Context, kmsKeyID string, plaintext []byte) ([]byte, error) {
+	if m.kmsCrypto == nil {
+		stored := make([]byte, len(plaintext))
+		copy(stored, plaintext)
+
+		return stored, nil
+	}
+
+	keyRef := kmsKeyID
+	if keyRef == "" {
+		keyRef = defaultKMSKey
+	}
+
+	return m.kmsCrypto.Encrypt(ctx, keyRef, plaintext)
+}
+
+// decrypt reverses encrypt. With no KMS wired the stored bytes are already
+// plaintext.
+func (m *Mock) decrypt(ctx context.Context, stored []byte) ([]byte, error) {
+	if m.kmsCrypto == nil {
+		return stored, nil
+	}
+
+	return m.kmsCrypto.Decrypt(ctx, stored)
+}
+
+// decryptVersion decrypts a copied version's Value in place, so every read path
+// returns plaintext. A KMS failure (disabled/deleted key) surfaces here.
+func (m *Mock) decryptVersion(ctx context.Context, v *driver.SecretVersion) (*driver.SecretVersion, error) {
+	plaintext, err := m.decrypt(ctx, v.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	v.Value = plaintext
+
+	return v, nil
 }
 
 // CreateSecret creates a new secret with an initial value.
@@ -87,8 +137,8 @@ func (m *Mock) CreateSecret(ctx context.Context, cfg driver.SecretConfig, value 
 	// Manager rejects an unknown key with InvalidParameterException rather than
 	// storing a dangling reference. The default aws/secretsmanager key (used when
 	// KmsKeyId is empty) always exists, so only an explicit reference is checked.
-	if cfg.KMSKeyID != "" && m.kmsResolver != nil {
-		if _, err := m.kmsResolver.DescribeKey(ctx, cfg.KMSKeyID); err != nil {
+	if cfg.KMSKeyID != "" && m.kmsCrypto != nil {
+		if _, err := m.kmsCrypto.DescribeKey(ctx, cfg.KMSKeyID); err != nil {
 			return nil, errors.Newf(errors.InvalidArgument,
 				"KMS key %q does not exist or is not accessible", cfg.KMSKeyID)
 		}
@@ -130,8 +180,10 @@ func (m *Mock) CreateSecret(ctx context.Context, cfg driver.SecretConfig, value 
 		KMSKeyID:    cfg.KMSKeyID,
 	}
 
-	data := make([]byte, len(value))
-	copy(data, value)
+	stored, err := m.encrypt(ctx, cfg.KMSKeyID, value)
+	if err != nil {
+		return nil, err
+	}
 
 	// AWS uses the ClientRequestToken as the version id (a UUID); absent one, it
 	// generates a UUID itself.
@@ -142,7 +194,7 @@ func (m *Mock) CreateSecret(ctx context.Context, cfg driver.SecretConfig, value 
 
 	version := driver.SecretVersion{
 		VersionID: versionID,
-		Value:     data,
+		Value:     stored,
 		CreatedAt: now,
 		Current:   true,
 	}
@@ -280,7 +332,7 @@ func (m *Mock) PutSecretValue(_ context.Context, name string, value []byte) (*dr
 //     leaves the prior AWSCURRENT untouched. An empty versionStages promotes the
 //     new version to AWSCURRENT (demoting the prior current to AWSPREVIOUS).
 func (m *Mock) PutSecretValueStaged(
-	_ context.Context, name string, value []byte, clientRequestToken string, versionStages []string,
+	ctx context.Context, name string, value []byte, clientRequestToken string, versionStages []string,
 ) (*driver.SecretVersion, error) {
 	sd, ok := m.secrets.Get(name)
 	if !ok {
@@ -295,13 +347,15 @@ func (m *Mock) PutSecretValueStaged(
 			"secret is scheduled for deletion, so this operation is not allowed")
 	}
 
-	data := make([]byte, len(value))
-	copy(data, value)
-
 	if clientRequestToken != "" {
 		if existing, dup := sd.versionByID(clientRequestToken); dup {
-			return m.reusedTokenVersion(existing, data, clientRequestToken)
+			return m.reusedTokenVersion(ctx, existing, value, clientRequestToken)
 		}
+	}
+
+	stored, err := m.encrypt(ctx, sd.info.KMSKeyID, value)
+	if err != nil {
+		return nil, err
 	}
 
 	versionID := clientRequestToken
@@ -312,7 +366,7 @@ func (m *Mock) PutSecretValueStaged(
 	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
 	sd.versions = append(sd.versions, driver.SecretVersion{
 		VersionID: versionID,
-		Value:     data,
+		Value:     stored,
 		CreatedAt: now,
 	})
 	sd.applyStages(versionID, versionStages)
@@ -325,11 +379,17 @@ func (m *Mock) PutSecretValueStaged(
 
 // reusedTokenVersion enforces ClientRequestToken idempotency: same token + same
 // content returns the existing version unchanged; same token + different content
-// is ResourceExistsException.
-func (*Mock) reusedTokenVersion(
-	existing *driver.SecretVersion, data []byte, token string,
+// is ResourceExistsException. The comparison is on plaintext — the stored value
+// is ciphertext whose bytes differ per write even for identical content.
+func (m *Mock) reusedTokenVersion(
+	ctx context.Context, existing *driver.SecretVersion, value []byte, token string,
 ) (*driver.SecretVersion, error) {
-	if bytes.Equal(existing.Value, data) {
+	existingPlain, err := m.decrypt(ctx, existing.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	if bytes.Equal(existingPlain, value) {
 		return copyVersion(existing), nil
 	}
 
@@ -337,8 +397,10 @@ func (*Mock) reusedTokenVersion(
 		"a version with ClientRequestToken %q already exists with different content", token)
 }
 
-// GetSecretValue retrieves a secret value. Empty versionID returns the current version.
-func (m *Mock) GetSecretValue(_ context.Context, name, versionID string) (*driver.SecretVersion, error) {
+// GetSecretValue retrieves a secret value. Empty versionID returns the current
+// version. The stored value is decrypted through KMS; a secret whose KMS key was
+// later disabled or deleted fails here with the KMS error, as in real AWS.
+func (m *Mock) GetSecretValue(ctx context.Context, name, versionID string) (*driver.SecretVersion, error) {
 	sd, ok := m.secrets.Get(name)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
@@ -352,25 +414,10 @@ func (m *Mock) GetSecretValue(_ context.Context, name, versionID string) (*drive
 			"secret is scheduled for deletion, so this operation is not allowed")
 	}
 
-	for _, v := range sd.versions {
-		if versionID == "" && v.Current {
-			result := v
-
-			data := make([]byte, len(v.Value))
-			copy(data, v.Value)
-			result.Value = data
-
-			return &result, nil
-		}
-
-		if v.VersionID == versionID {
-			result := v
-
-			data := make([]byte, len(v.Value))
-			copy(data, v.Value)
-			result.Value = data
-
-			return &result, nil
+	for i := range sd.versions {
+		v := &sd.versions[i]
+		if (versionID == "" && v.Current) || v.VersionID == versionID {
+			return m.decryptVersion(ctx, copyVersion(v))
 		}
 	}
 

--- a/providers/aws/secretsmanager/secretsmanager_test.go
+++ b/providers/aws/secretsmanager/secretsmanager_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/providers/aws/kms"
+	"github.com/stackshy/cloudemu/v2/providers/aws/kmscrypto"
 	kmsdriver "github.com/stackshy/cloudemu/v2/services/kms/driver"
 	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
 	"github.com/stretchr/testify/assert"
@@ -78,7 +79,7 @@ func TestCreateSecretValidatesKMSKey(t *testing.T) {
 	ctx := context.Background()
 	m := newTestMock()
 	k := kms.New(config.NewOptions(config.WithRegion("us-east-1")))
-	m.SetKMSKeyResolver(k)
+	m.SetKMSCrypto(kmscrypto.New(k))
 
 	// An explicit KmsKeyId that names no key is rejected.
 	_, err := m.CreateSecret(ctx, driver.SecretConfig{

--- a/providers/aws/secretsmanager/staging.go
+++ b/providers/aws/secretsmanager/staging.go
@@ -138,7 +138,7 @@ func (m *Mock) MarkVersionBinary(_ context.Context, name, versionID string) erro
 // GetSecretValueStage returns a secret value addressed by version ID or by stage
 // label (AWSCURRENT/AWSPREVIOUS/custom). An empty versionID and stage returns the
 // current version.
-func (m *Mock) GetSecretValueStage(_ context.Context, name, versionID, stage string) (*driver.SecretVersion, error) {
+func (m *Mock) GetSecretValueStage(ctx context.Context, name, versionID, stage string) (*driver.SecretVersion, error) {
 	sd, ok := m.secrets.Get(name)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
@@ -154,7 +154,7 @@ func (m *Mock) GetSecretValueStage(_ context.Context, name, versionID, stage str
 
 	if versionID != "" {
 		if v, found := sd.versionByID(versionID); found {
-			return copyVersion(v), nil
+			return m.decryptVersion(ctx, copyVersion(v))
 		}
 
 		return nil, errors.Newf(errors.NotFound, "version %q not found for secret %q", versionID, name)
@@ -175,7 +175,7 @@ func (m *Mock) GetSecretValueStage(_ context.Context, name, versionID, stage str
 		return nil, errors.Newf(errors.NotFound, "stage %q not found for secret %q", label, name)
 	}
 
-	return copyVersion(v), nil
+	return m.decryptVersion(ctx, copyVersion(v))
 }
 
 // SecretVersionStages returns the stage labels for each version ID, so

--- a/providers/aws/secretsmanager/update.go
+++ b/providers/aws/secretsmanager/update.go
@@ -14,7 +14,7 @@ import (
 // SecretString/SecretBinary are optional). An empty description leaves the
 // existing one unchanged. It returns the created version's id (empty when no
 // value change created a version), which UpdateSecret echoes to the caller.
-func (m *Mock) UpdateSecret(_ context.Context, name, description string, value []byte) (*driver.SecretInfo, string, error) {
+func (m *Mock) UpdateSecret(ctx context.Context, name, description string, value []byte) (*driver.SecretInfo, string, error) {
 	sd, ok := m.secrets.Get(name)
 	if !ok {
 		return nil, "", errors.Newf(errors.NotFound, "secret %q not found", name)
@@ -37,13 +37,15 @@ func (m *Mock) UpdateSecret(_ context.Context, name, description string, value [
 	var versionID string
 
 	if value != nil {
-		data := make([]byte, len(value))
-		copy(data, value)
+		stored, err := m.encrypt(ctx, sd.info.KMSKeyID, value)
+		if err != nil {
+			return nil, "", err
+		}
 
 		versionID = idgen.UUID()
 		sd.versions = append(sd.versions, driver.SecretVersion{
 			VersionID: versionID,
-			Value:     data,
+			Value:     stored,
 			CreatedAt: now,
 		})
 		sd.promoteToCurrent(versionID)

--- a/providers/aws/ssm/encryption_test.go
+++ b/providers/aws/ssm/encryption_test.go
@@ -1,0 +1,134 @@
+package ssm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/aws/kms"
+	"github.com/stackshy/cloudemu/v2/providers/aws/kmscrypto"
+	"github.com/stackshy/cloudemu/v2/providers/aws/ssm"
+	kmsdriver "github.com/stackshy/cloudemu/v2/services/kms/driver"
+	"github.com/stackshy/cloudemu/v2/services/parameterstore/driver"
+)
+
+func newEncryptedMock(t *testing.T) (*ssm.Mock, *kms.Mock) {
+	t.Helper()
+
+	k := kms.New(config.NewOptions(config.WithRegion("us-east-1")))
+	m := ssm.New(config.NewOptions())
+	m.SetKMSCrypto(kmscrypto.New(k))
+
+	return m, k
+}
+
+// TestSecureStringEncryptedAtRest verifies a SecureString is genuine ciphertext
+// at rest: WithDecryption=true returns the value, WithDecryption=false returns
+// an opaque blob that is neither the plaintext nor empty.
+func TestSecureStringEncryptedAtRest(t *testing.T) {
+	m, _ := newEncryptedMock(t)
+	ctx := context.Background()
+
+	const secret = "topsecret-value"
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/db/password", Value: secret, Type: driver.TypeSecureString,
+	}); err != nil {
+		t.Fatalf("PutParameter: %v", err)
+	}
+
+	dec, err := m.GetParameter(ctx, "/db/password", true)
+	if err != nil {
+		t.Fatalf("GetParameter(WithDecryption=true): %v", err)
+	}
+
+	if dec.Value != secret {
+		t.Fatalf("decrypted value = %q, want %q", dec.Value, secret)
+	}
+
+	opaque, err := m.GetParameter(ctx, "/db/password", false)
+	if err != nil {
+		t.Fatalf("GetParameter(WithDecryption=false): %v", err)
+	}
+
+	if opaque.Value == secret {
+		t.Fatal("WithDecryption=false returned the plaintext; want opaque ciphertext")
+	}
+
+	if opaque.Value == "" {
+		t.Fatal("WithDecryption=false returned an empty value")
+	}
+}
+
+// TestStringParameterNotEncrypted verifies String parameters are untouched by
+// KMS: their value is returned in the clear regardless of WithDecryption.
+func TestStringParameterNotEncrypted(t *testing.T) {
+	m, _ := newEncryptedMock(t)
+	ctx := context.Background()
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/app/host", Value: "db.internal", Type: driver.TypeString,
+	}); err != nil {
+		t.Fatalf("PutParameter: %v", err)
+	}
+
+	for _, withDecryption := range []bool{false, true} {
+		got, err := m.GetParameter(ctx, "/app/host", withDecryption)
+		if err != nil {
+			t.Fatalf("GetParameter(%v): %v", withDecryption, err)
+		}
+
+		if got.Value != "db.internal" {
+			t.Fatalf("String value (WithDecryption=%v) = %q, want db.internal", withDecryption, got.Value)
+		}
+	}
+}
+
+// TestSecureStringFailsAfterKeyDisabled verifies a decrypting read fails once the
+// KMS key backing the parameter is disabled, matching real Parameter Store.
+func TestSecureStringFailsAfterKeyDisabled(t *testing.T) {
+	m, k := newEncryptedMock(t)
+	ctx := context.Background()
+
+	key, err := k.CreateKey(ctx, kmsdriver.CreateKeyInput{})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/db/password", Value: "s3cr3t", Type: driver.TypeSecureString, KeyID: key.KeyID,
+	}); err != nil {
+		t.Fatalf("PutParameter: %v", err)
+	}
+
+	if err := k.DisableKey(ctx, key.KeyID); err != nil {
+		t.Fatalf("DisableKey: %v", err)
+	}
+
+	if _, err := m.GetParameter(ctx, "/db/password", true); err == nil {
+		t.Fatal("GetParameter(WithDecryption=true) after DisableKey: want error, got nil")
+	}
+}
+
+// TestSecureStringNoKMSFallback verifies that without a KMS backend wired, a
+// SecureString is stored and returned verbatim (the library plaintext fallback)
+// and nothing panics.
+func TestSecureStringNoKMSFallback(t *testing.T) {
+	m := ssm.New(config.NewOptions())
+	ctx := context.Background()
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/db/password", Value: "plain-secret", Type: driver.TypeSecureString,
+	}); err != nil {
+		t.Fatalf("PutParameter: %v", err)
+	}
+
+	got, err := m.GetParameter(ctx, "/db/password", true)
+	if err != nil {
+		t.Fatalf("GetParameter: %v", err)
+	}
+
+	if got.Value != "plain-secret" {
+		t.Fatalf("fallback value = %q, want plain-secret", got.Value)
+	}
+}

--- a/providers/aws/ssm/ssm.go
+++ b/providers/aws/ssm/ssm.go
@@ -5,15 +5,19 @@
 // adds recording/metrics/rate-limiting/error-injection/latency lives in the
 // module-root parameterstore package (parameterstore/parameterstore.go).
 //
-// Values are stored verbatim regardless of Type; SecureString parameters are
-// NOT encrypted (there is no real KMS integration), so WithDecryption is a
-// no-op and the raw value is always returned. A SecureString's KeyId is still
-// recorded and round-tripped (defaulting to alias/aws/ssm) — the emulator
-// models the KeyId association without performing the encryption.
+// When a KMS backend is wired (SetKMSCrypto), a SecureString parameter's value
+// is encrypted through real KMS: PutParameter stores genuine ciphertext,
+// GetParameter/GetParameters with WithDecryption=true return the decrypted
+// value, and WithDecryption=false returns the opaque ciphertext blob (matching
+// AWS). Its KeyId is recorded and round-tripped (defaulting to alias/aws/ssm),
+// and a disabled/deleted key makes a decrypting read fail. String/StringList
+// values are never encrypted. Without KMS wired (library fallback) values are
+// stored verbatim and WithDecryption is a no-op.
 package ssm
 
 import (
 	"context"
+	"encoding/base64"
 	"regexp"
 	"sort"
 	"strconv"
@@ -54,12 +58,66 @@ type paramData struct {
 	mu          sync.RWMutex
 }
 
+// KMSCrypto is the KMS seam SSM uses to encrypt SecureString values. Encrypt
+// seals a value under a resolved key; Decrypt reverses it, surfacing a
+// disabled/deleted key as an error. The kmscrypto.Envelope adapter satisfies it.
+type KMSCrypto interface {
+	Encrypt(ctx context.Context, keyID string, plaintext []byte) ([]byte, error)
+	Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error)
+}
+
 // Mock is an in-memory mock implementation of SSM Parameter Store.
 type Mock struct {
 	params           *memstore.Store[*paramData]
 	commands         *memstore.Store[driver.CommandInvocation]
 	instanceResolver InstanceResolver
-	opts             *config.Options
+	// kmsCrypto, when wired via SetKMSCrypto, encrypts SecureString values through
+	// real KMS. Nil stores them verbatim (library plaintext fallback).
+	kmsCrypto KMSCrypto
+	opts      *config.Options
+}
+
+// SetKMSCrypto wires the KMS backend so SecureString values are encrypted at
+// rest and decrypted on read when WithDecryption is set.
+func (m *Mock) SetKMSCrypto(c KMSCrypto) {
+	m.kmsCrypto = c
+}
+
+// sealValue encrypts a SecureString value under keyID, returning a base64
+// ciphertext blob (the opaque form AWS returns when WithDecryption is false).
+// Non-secure types and the no-KMS fallback return the value unchanged.
+func (m *Mock) sealValue(ctx context.Context, effectiveType, keyID, plaintext string) (string, error) {
+	if effectiveType != driver.TypeSecureString || m.kmsCrypto == nil {
+		return plaintext, nil
+	}
+
+	blob, err := m.kmsCrypto.Encrypt(ctx, keyID, []byte(plaintext))
+	if err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(blob), nil
+}
+
+// revealValue is the read-side inverse of sealValue. A SecureString is decrypted
+// only when WithDecryption is set and KMS is wired; otherwise the stored form
+// (opaque ciphertext, or plaintext in the fallback) is returned as-is.
+func (m *Mock) revealValue(ctx context.Context, v *version, withDecryption bool) (string, error) {
+	if v.typ != driver.TypeSecureString || m.kmsCrypto == nil || !withDecryption {
+		return v.value, nil
+	}
+
+	blob, err := base64.StdEncoding.DecodeString(v.value)
+	if err != nil {
+		return "", errors.New(errors.InvalidArgument, "invalid encrypted parameter value")
+	}
+
+	plaintext, err := m.kmsCrypto.Decrypt(ctx, blob)
+	if err != nil {
+		return "", err
+	}
+
+	return string(plaintext), nil
 }
 
 // New creates a new SSM Parameter Store mock.
@@ -214,7 +272,7 @@ func (m *Mock) PutParameter(ctx context.Context, cfg driver.PutConfig) (int64, s
 	now := m.now()
 
 	if existing, ok := m.params.Get(cfg.Name); ok {
-		return overwriteParameter(existing, &cfg, tier, dataType, now)
+		return m.overwriteParameter(ctx, existing, &cfg, tier, dataType, now)
 	}
 
 	return m.createParameter(ctx, &cfg, tier, dataType, now)
@@ -223,8 +281,8 @@ func (m *Mock) PutParameter(ctx context.Context, cfg driver.PutConfig) (int64, s
 // overwriteParameter appends a new version to an existing parameter (the
 // Overwrite path). Overwrite without the flag is rejected, and changing the
 // type is rejected via resolveOverwriteType.
-func overwriteParameter(
-	existing *paramData, cfg *driver.PutConfig, tier, dataType, now string,
+func (m *Mock) overwriteParameter(
+	ctx context.Context, existing *paramData, cfg *driver.PutConfig, tier, dataType, now string,
 ) (ver int64, assignedTier string, err error) {
 	existing.mu.Lock()
 	defer existing.mu.Unlock()
@@ -244,9 +302,14 @@ func overwriteParameter(
 		return 0, "", err
 	}
 
+	storedValue, err := m.sealValue(ctx, newType, keyID, cfg.Value)
+	if err != nil {
+		return 0, "", err
+	}
+
 	next := existing.latest + 1
 	existing.versions = append(existing.versions, &version{
-		value:          cfg.Value,
+		value:          storedValue,
 		typ:            newType,
 		dataType:       dataType,
 		version:        next,
@@ -272,13 +335,18 @@ func (m *Mock) createParameter(
 		return 0, "", err
 	}
 
+	storedValue, err := m.sealValue(ctx, newType, keyID, cfg.Value)
+	if err != nil {
+		return 0, "", err
+	}
+
 	pd := &paramData{
 		name:        cfg.Name,
 		description: cfg.Description,
 		tier:        tier,
 		latest:      1,
 		versions: []*version{{
-			value:          cfg.Value,
+			value:          storedValue,
 			typ:            newType,
 			dataType:       dataType,
 			version:        1,
@@ -349,22 +417,29 @@ func (pd *paramData) versionByNumber(n int64) (*version, bool) {
 	return nil, false
 }
 
-func (m *Mock) toParameter(pd *paramData, v *version, selector string) driver.Parameter {
+func (m *Mock) toParameter(
+	ctx context.Context, pd *paramData, v *version, selector string, withDecryption bool,
+) (driver.Parameter, error) {
 	name := pd.name
 	if selector != "" {
 		name = pd.name + ":" + selector
 	}
 
+	value, err := m.revealValue(ctx, v, withDecryption)
+	if err != nil {
+		return driver.Parameter{}, err
+	}
+
 	return driver.Parameter{
 		Name:         pd.name,
 		Type:         v.typ,
-		Value:        v.value,
+		Value:        value,
 		Version:      v.version,
 		ARN:          m.arn(pd.name),
 		DataType:     v.dataType,
 		LastModified: v.lastModified,
 		Selector:     selectorFor(name, pd.name),
-	}
+	}, nil
 }
 
 func selectorFor(requested, base string) string {
@@ -376,9 +451,9 @@ func selectorFor(requested, base string) string {
 }
 
 // GetParameter retrieves a single parameter by name, honoring an optional
-// ":version" or ":label" selector suffix. withDecryption is accepted but has no
-// effect: SecureString values are stored and returned in the clear.
-func (m *Mock) GetParameter(_ context.Context, name string, _ bool) (*driver.Parameter, error) {
+// ":version" or ":label" selector suffix. For a SecureString, withDecryption=true
+// returns the decrypted value; false returns the opaque ciphertext blob.
+func (m *Mock) GetParameter(ctx context.Context, name string, withDecryption bool) (*driver.Parameter, error) {
 	base, selector := resolveSelector(name)
 
 	// AWS-published parameters are readable from every account without having
@@ -401,14 +476,19 @@ func (m *Mock) GetParameter(_ context.Context, name string, _ bool) (*driver.Par
 		return nil, driver.ErrVersionNotFound
 	}
 
-	p := m.toParameter(pd, v, selector)
+	p, err := m.toParameter(ctx, pd, v, selector, withDecryption)
+	if err != nil {
+		return nil, err
+	}
 
 	return &p, nil
 }
 
 // GetParameters retrieves multiple parameters, reporting names that were not
 // found (or whose selector did not resolve) as invalid rather than erroring.
-func (m *Mock) GetParameters(_ context.Context, names []string, _ bool) ([]driver.Parameter, []string, error) {
+func (m *Mock) GetParameters(
+	ctx context.Context, names []string, withDecryption bool,
+) ([]driver.Parameter, []string, error) {
 	found := make([]driver.Parameter, 0, len(names))
 
 	var invalid []string
@@ -434,8 +514,14 @@ func (m *Mock) GetParameters(_ context.Context, names []string, _ bool) ([]drive
 			continue
 		}
 
-		found = append(found, m.toParameter(pd, v, selector))
+		p, err := m.toParameter(ctx, pd, v, selector, withDecryption)
 		pd.mu.RUnlock()
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+		found = append(found, p)
 	}
 
 	return found, invalid, nil
@@ -444,7 +530,7 @@ func (m *Mock) GetParameters(_ context.Context, names []string, _ bool) ([]drive
 // GetParametersByPath returns the latest version of every parameter under a
 // hierarchical path. With Recursive false, only direct children are returned;
 // with Recursive true, the whole subtree is returned.
-func (m *Mock) GetParametersByPath(_ context.Context, in driver.GetByPathInput) ([]driver.Parameter, error) {
+func (m *Mock) GetParametersByPath(ctx context.Context, in driver.GetByPathInput) ([]driver.Parameter, error) {
 	path := in.Path
 	if path == "" {
 		path = "/"
@@ -466,27 +552,50 @@ func (m *Mock) GetParametersByPath(_ context.Context, in driver.GetByPathInput) 
 	var out []driver.Parameter
 
 	for _, pd := range m.params.All() {
-		name := pd.name
-		if !strings.HasPrefix(name, prefix) {
-			continue
+		p, matched, err := m.pathParameter(ctx, pd, prefix, &in)
+		if err != nil {
+			return nil, err
 		}
 
-		rest := strings.TrimPrefix(name, prefix)
-		// Non-recursive: only direct children (no further "/" in the remainder).
-		if !in.Recursive && strings.Contains(rest, "/") {
-			continue
+		if matched {
+			out = append(out, p)
 		}
-
-		pd.mu.RLock()
-		if v, ok := pd.versionByNumber(pd.latest); ok && matchesByPathFilters(v, in.ParameterFilters) {
-			out = append(out, m.toParameter(pd, v, ""))
-		}
-		pd.mu.RUnlock()
 	}
 
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 
 	return out, nil
+}
+
+// pathParameter renders pd's latest version for a GetParametersByPath result,
+// reporting matched=false when pd is out of the path's scope or filtered out.
+// SecureString values are decrypted only when in.WithDecryption is set.
+func (m *Mock) pathParameter(
+	ctx context.Context, pd *paramData, prefix string, in *driver.GetByPathInput,
+) (param driver.Parameter, matched bool, err error) {
+	if !strings.HasPrefix(pd.name, prefix) {
+		return driver.Parameter{}, false, nil
+	}
+
+	// Non-recursive: only direct children (no further "/" in the remainder).
+	if !in.Recursive && strings.Contains(strings.TrimPrefix(pd.name, prefix), "/") {
+		return driver.Parameter{}, false, nil
+	}
+
+	pd.mu.RLock()
+	defer pd.mu.RUnlock()
+
+	v, ok := pd.versionByNumber(pd.latest)
+	if !ok || !matchesByPathFilters(v, in.ParameterFilters) {
+		return driver.Parameter{}, false, nil
+	}
+
+	param, err = m.toParameter(ctx, pd, v, "", in.WithDecryption)
+	if err != nil {
+		return driver.Parameter{}, false, err
+	}
+
+	return param, true, nil
 }
 
 // DeleteParameter removes a parameter and all its versions. A ":version"/


### PR DESCRIPTION
## Summary

Part of #581 (the KMS↔Secrets/SSM cosmetic-crypto gap). Secrets Manager and SSM SecureString values are now encrypted through **real KMS** instead of being stored verbatim, so their at-rest form is genuine ciphertext and their KMS-failure paths are real.

KMS's own crypto (`providers/aws/kms`) is used unchanged.

## What changed

- **New crypto seam** `providers/aws/kmscrypto` (`Envelope`): `Encrypt(keyRef, plaintext)` mints a KMS data key (wrapped under the addressed key), seals the value locally with AES-256-GCM, and returns a self-describing blob; `Decrypt` unwraps the data key back through KMS — the step that surfaces a disabled/deleted key — then opens the ciphertext. An unresolvable managed-key reference (the reserved `alias/aws/secretsmanager` / `alias/aws/ssm`, which KMS refuses to let callers alias) is created and cached on demand.
- **Secrets Manager**: `CreateSecret` / `PutSecretValue` / `UpdateSecret` encrypt under the explicit `KmsKeyId` (validated to exist) or the default `aws/secretsmanager` key; every read path (`GetSecretValue`, `GetSecretValueStage`) decrypts. `KmsKeyId` reflection, versioning, and `VersionStages` are preserved. `ClientRequestToken` idempotency now compares plaintext.
- **SSM**: `PutParameter(Type=SecureString)` stores ciphertext (base64); `GetParameter`/`GetParameters`/`GetParametersByPath` with `WithDecryption=true` decrypt, `WithDecryption=false` returns the opaque blob (matching AWS). String/StringList params are untouched.
- **Wiring**: both services share one `Envelope` over the KMS backend in `providers/aws/aws.go`.
- **Fallback**: with no KMS wired (library users who didn't create KMS), both services keep today's plaintext behavior — nil-safe, nothing breaks.

## Tests

Round-trip create→get with a real key; `GetSecretValue` fails after the key is disabled; SecureString put→get(WithDecryption true returns value, false does not return plaintext); String params unaffected; the no-KMS plaintext fallback still works; plus unit tests for the `Envelope` adapter.

## Gates

`go build`/`go vet`, `go test ./providers/aws/... ./server/aws/... ./compat/aws/`, `go generate ./...` (no doc changes), and golangci-lint on the touched packages all green — 0 new gating issues.
