### PR TITLE
feat(telemetry): Azure/GCP audit logs + function execution logs (#847)

### DIFF
--- a/docs/coverage/aws/cloudwatch.md
+++ b/docs/coverage/aws/cloudwatch.md
@@ -20,6 +20,19 @@ AWS's `monitoring` service · portable interface `driver.Monitoring` · [AWS ind
 | `PutMetricData` |  |
 | `SetAlarmState` |  |
 
+## Optional capabilities
+
+Discovered by type assertion; only some providers implement these.
+
+### ActivityLogRecorder
+
+ActivityLogRecorder is an OPTIONAL capability, discovered by type assertion
+
+| Operation | Description |
+| --- | --- |
+| `ListActivityLogEvents` |  |
+| `RecordActivityLogEvent` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/azure/monitor.md
+++ b/docs/coverage/azure/monitor.md
@@ -20,6 +20,19 @@ Azure's `monitoring` service · portable interface `driver.Monitoring` · [Azure
 | `PutMetricData` |  |
 | `SetAlarmState` |  |
 
+## Optional capabilities
+
+Discovered by type assertion; only some providers implement these.
+
+### ActivityLogRecorder
+
+ActivityLogRecorder is an OPTIONAL capability, discovered by type assertion
+
+| Operation | Description |
+| --- | --- |
+| `ListActivityLogEvents` |  |
+| `RecordActivityLogEvent` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -6698,6 +6698,20 @@
         "name": "SetAlarmState"
       }
     ],
+    "optionalCapabilities": [
+      {
+        "name": "ActivityLogRecorder",
+        "doc": "ActivityLogRecorder is an OPTIONAL capability, discovered by type assertion",
+        "operations": [
+          {
+            "name": "ListActivityLogEvents"
+          },
+          {
+            "name": "RecordActivityLogEvent"
+          }
+        ]
+      }
+    ],
     "providers": {
       "aws": "CloudWatch",
       "azure": "Monitor",

--- a/docs/coverage/gcp/cloudmonitoring.md
+++ b/docs/coverage/gcp/cloudmonitoring.md
@@ -20,6 +20,19 @@ GCP's `monitoring` service · portable interface `driver.Monitoring` · [GCP ind
 | `PutMetricData` |  |
 | `SetAlarmState` |  |
 
+## Optional capabilities
+
+Discovered by type assertion; only some providers implement these.
+
+### ActivityLogRecorder
+
+ActivityLogRecorder is an OPTIONAL capability, discovered by type assertion
+
+| Operation | Description |
+| --- | --- |
+| `ListActivityLogEvents` |  |
+| `RecordActivityLogEvent` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/oci/monitoring.md
+++ b/docs/coverage/oci/monitoring.md
@@ -20,6 +20,19 @@ OCI's `monitoring` service · portable interface `driver.Monitoring` · [OCI ind
 | `PutMetricData` |  |
 | `SetAlarmState` |  |
 
+## Optional capabilities
+
+Discovered by type assertion; only some providers implement these.
+
+### ActivityLogRecorder
+
+ActivityLogRecorder is an OPTIONAL capability, discovered by type assertion
+
+| Operation | Description |
+| --- | --- |
+| `ListActivityLogEvents` |  |
+| `RecordActivityLogEvent` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -282,6 +282,9 @@ func New(opts ...config.Option) *Provider {
 	p.ECS.SetManagedInstanceLauncher(p.EC2)
 	// Engine-backed ECS tasks push their awslogs container output to CloudWatch Logs.
 	p.ECS.SetLogSink(p.CloudWatchLogs)
+	// Lambda invocations write START/END/REPORT lines (and captured stdout/stderr
+	// on the real-engine path) to CloudWatch Logs under /aws/lambda/<name>.
+	p.Lambda.SetLogSink(p.CloudWatchLogs)
 	// A service's loadBalancers[] register/deregister RUNNING tasks with their
 	// ELBv2 target group as the scheduler converges/drains the service.
 	p.ECS.SetTargetRegistrar(p.ELB)

--- a/providers/aws/lambda/execlogs.go
+++ b/providers/aws/lambda/execlogs.go
@@ -1,0 +1,70 @@
+package lambda
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// logGroupPrefix is the conventional CloudWatch Logs group real Lambda writes a
+// function's invocation logs under: /aws/lambda/<function-name>.
+const logGroupPrefix = "/aws/lambda/"
+
+// surfaceInvokeLogs writes one invocation's log lines into CloudWatch Logs,
+// mirroring the START/END/REPORT bookend real Lambda emits, plus any captured
+// stdout/stderr (from the real-engine path). It is best-effort: with no log
+// sink wired it is a no-op, so library users are unaffected.
+func (m *Mock) surfaceInvokeLogs(ctx context.Context, functionName, executedVersion, captured, funcError string) {
+	if m.logs == nil {
+		return
+	}
+
+	requestID := idgen.UUID()
+	now := m.opts.Clock.Now()
+	group := logGroupPrefix + functionName
+	stream := invokeLogStream(now, executedVersion, requestID)
+
+	lines := invokeLogLines(executedVersion, requestID, captured, funcError)
+
+	_, _ = m.logs.CreateLogGroup(ctx, logdriver.LogGroupConfig{Name: group})
+	_, _ = m.logs.CreateLogStream(ctx, group, stream)
+
+	events := make([]logdriver.LogEvent, 0, len(lines))
+	for _, line := range lines {
+		events = append(events, logdriver.LogEvent{Timestamp: now, Message: line})
+	}
+
+	_ = m.logs.PutLogEvents(ctx, group, stream, events)
+}
+
+// invokeLogStream builds the CloudWatch Logs stream name real Lambda uses for an
+// invocation: "YYYY/MM/DD/[<version>]<requestId>".
+func invokeLogStream(now time.Time, executedVersion, requestID string) string {
+	return fmt.Sprintf("%s/[%s]%s", now.UTC().Format("2006/01/02"), executedVersion, requestID)
+}
+
+// invokeLogLines renders the log lines for one invocation: the START bookend,
+// each captured stdout/stderr line, and the END/REPORT bookend, matching the
+// shape real Lambda writes to CloudWatch Logs.
+func invokeLogLines(executedVersion, requestID, captured, funcError string) []string {
+	lines := []string{fmt.Sprintf("START RequestId: %s Version: %s", requestID, executedVersion)}
+
+	if captured != "" {
+		lines = append(lines, strings.Split(strings.TrimRight(captured, "\n"), "\n")...)
+	}
+
+	if funcError != "" {
+		lines = append(lines, fmt.Sprintf("[ERROR] %s", funcError))
+	}
+
+	lines = append(lines,
+		fmt.Sprintf("END RequestId: %s", requestID),
+		fmt.Sprintf("REPORT RequestId: %s\tDuration: 1.00 ms\tBilled Duration: 1 ms", requestID),
+	)
+
+	return lines
+}

--- a/providers/aws/lambda/execlogs_test.go
+++ b/providers/aws/lambda/execlogs_test.go
@@ -1,0 +1,88 @@
+package lambda
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/aws/cloudwatchlogs"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// TestInvokeSurfacesLogsToCloudWatch verifies a Lambda invoke writes
+// START/END/REPORT lines into the conventional /aws/lambda/<name> log group,
+// retrievable via CloudWatch Logs GetLogEvents.
+func TestInvokeSurfacesLogsToCloudWatch(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	cwl := cloudwatchlogs.New(config.NewOptions(config.WithRegion("us-east-1")))
+	m.SetLogSink(cwl)
+
+	_, err := m.CreateFunction(ctx, defaultFuncConfig())
+	requireNoError(t, err)
+
+	_, err = m.Invoke(ctx, driver.InvokeInput{FunctionName: "my-func", Payload: []byte(`{}`)})
+	requireNoError(t, err)
+
+	events, err := cwl.GetLogEvents(ctx, &logdriver.LogQueryInput{LogGroup: "/aws/lambda/my-func"})
+	requireNoError(t, err)
+
+	joined := joinMessages(events)
+	for _, want := range []string{"START RequestId:", "END RequestId:", "REPORT RequestId:"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("missing %q in surfaced logs: %q", want, joined)
+		}
+	}
+}
+
+// TestInvokeSurfacesHandlerErrorLog verifies a handler error is surfaced as an
+// [ERROR] line alongside the START/END bookend.
+func TestInvokeSurfacesHandlerErrorLog(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	cwl := cloudwatchlogs.New(config.NewOptions(config.WithRegion("us-east-1")))
+	m.SetLogSink(cwl)
+
+	_, err := m.CreateFunction(ctx, defaultFuncConfig())
+	requireNoError(t, err)
+
+	m.RegisterHandler("my-func", func(context.Context, []byte) ([]byte, error) {
+		return nil, context.Canceled
+	})
+
+	_, err = m.Invoke(ctx, driver.InvokeInput{FunctionName: "my-func", Payload: []byte(`{}`)})
+	requireNoError(t, err)
+
+	events, err := cwl.GetLogEvents(ctx, &logdriver.LogQueryInput{LogGroup: "/aws/lambda/my-func"})
+	requireNoError(t, err)
+
+	if !strings.Contains(joinMessages(events), "[ERROR]") {
+		t.Fatalf("expected an [ERROR] line, got: %q", joinMessages(events))
+	}
+}
+
+// TestInvokeNoLogSinkDefault verifies the default path (no sink wired) is a
+// no-op — no panic, and the invoke still succeeds.
+func TestInvokeNoLogSinkDefault(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, defaultFuncConfig())
+	requireNoError(t, err)
+
+	out, err := m.Invoke(ctx, driver.InvokeInput{FunctionName: "my-func", Payload: []byte(`{}`)})
+	requireNoError(t, err)
+	assertEqual(t, 200, out.StatusCode)
+}
+
+func joinMessages(events []logdriver.LogEvent) string {
+	var b strings.Builder
+	for i := range events {
+		b.WriteString(events[i].Message)
+		b.WriteByte('\n')
+	}
+
+	return b.String()
+}

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
 	"github.com/stackshy/cloudemu/v2/internal/regionctx"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
 	"github.com/stackshy/cloudemu/v2/services/serverless/funcengine"
@@ -110,12 +111,21 @@ type Mock struct {
 	handlersMu sync.RWMutex
 	handlers   map[string]driver.HandlerFunc
 	monitoring mondriver.Monitoring
-	mu         sync.Mutex // guards PublishVersion read-modify-write on funcData
+	logs       logdriver.Logging // optional: CloudWatch Logs sink for invocation logs
+	mu         sync.Mutex        // guards PublishVersion read-modify-write on funcData
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
 func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
 	m.monitoring = mon
+}
+
+// SetLogSink wires the CloudWatch Logs target that Invoke writes each
+// invocation's START/END/REPORT lines (and any captured stdout/stderr) into,
+// under the conventional /aws/lambda/<name> log group. Safe to leave unset —
+// invocation-log surfacing is then skipped, so library users are unaffected.
+func (m *Mock) SetLogSink(l logdriver.Logging) {
+	m.logs = l
 }
 
 //nolint:unparam // value is always 1 today but kept for future metrics like batch invocation counts.
@@ -337,6 +347,7 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 		// RegisterHandler to run real logic.
 		m.emitMetric(ctx, "Invocations", 1, dims)
 		m.emitMetric(ctx, "Duration", 1.0, dims)
+		m.surfaceInvokeLogs(ctx, input.FunctionName, executedVersion, "", "")
 
 		payload := input.Payload
 		if len(payload) == 0 {
@@ -350,6 +361,7 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 	if err != nil {
 		m.emitMetric(ctx, "Invocations", 1, dims)
 		m.emitMetric(ctx, "Errors", 1, dims)
+		m.surfaceInvokeLogs(ctx, input.FunctionName, executedVersion, "", err.Error())
 
 		return &driver.InvokeOutput{StatusCode: 500, Error: err.Error(), ExecutedVersion: executedVersion}, nil
 	}
@@ -357,6 +369,7 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 	m.emitMetric(ctx, "Invocations", 1, dims)
 	m.emitMetric(ctx, "Duration", 1.0, dims)
 	m.emitMetric(ctx, "ConcurrentExecutions", 1, dims)
+	m.surfaceInvokeLogs(ctx, input.FunctionName, executedVersion, "", "")
 
 	return &driver.InvokeOutput{StatusCode: 200, Payload: payload, ExecutedVersion: executedVersion}, nil
 }
@@ -516,12 +529,14 @@ func (m *Mock) invokeEngine(
 
 	if out.Error != "" {
 		m.emitMetric(ctx, "Errors", 1, dims)
+		m.surfaceInvokeLogs(ctx, input.FunctionName, executedVersion, out.Logs, out.Error)
 
 		return out, nil
 	}
 
 	m.emitMetric(ctx, "Duration", 1.0, dims)
 	m.emitMetric(ctx, "ConcurrentExecutions", 1, dims)
+	m.surfaceInvokeLogs(ctx, input.FunctionName, executedVersion, out.Logs, "")
 
 	return out, nil
 }

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -214,6 +214,9 @@ func New(opts ...config.Option) *Provider {
 	p.BlobStorage.SetMonitoring(p.Monitor)
 	p.CosmosDB.SetMonitoring(p.Monitor)
 	p.Functions.SetMonitoring(p.Monitor)
+	// Azure Functions invocations write execution logs (and captured stdout/
+	// stderr on the real-engine path) to Log Analytics.
+	p.Functions.SetLogSink(p.LogAnalytics)
 	p.ServiceBus.SetMonitoring(p.Monitor)
 	p.Cache.SetMonitoring(p.Monitor)
 	p.LogAnalytics.SetMonitoring(p.Monitor)

--- a/providers/azure/functions/execlogs.go
+++ b/providers/azure/functions/execlogs.go
@@ -1,0 +1,48 @@
+package functions
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// execLogGroup is the conventional Log Analytics table real Azure Functions
+// writes host/execution logs under.
+const execLogGroup = "FunctionAppLogs"
+
+// surfaceInvokeLogs writes one invocation's execution log lines into Log
+// Analytics under the function's stream, including any captured stdout/stderr
+// from the real-engine path. Best-effort: with no log sink wired it is a no-op.
+func (m *Mock) surfaceInvokeLogs(ctx context.Context, functionName, captured, funcError string) {
+	if m.logs == nil {
+		return
+	}
+
+	invocationID := idgen.UUID()
+	now := m.opts.Clock.Now()
+
+	lines := []string{fmt.Sprintf("Executing function=%s invocationId=%s", functionName, invocationID)}
+
+	if captured != "" {
+		lines = append(lines, strings.Split(strings.TrimRight(captured, "\n"), "\n")...)
+	}
+
+	if funcError != "" {
+		lines = append(lines, fmt.Sprintf("Executed function=%s Failed: %s", functionName, funcError))
+	} else {
+		lines = append(lines, fmt.Sprintf("Executed function=%s Succeeded, invocationId=%s", functionName, invocationID))
+	}
+
+	_, _ = m.logs.CreateLogGroup(ctx, logdriver.LogGroupConfig{Name: execLogGroup})
+	_, _ = m.logs.CreateLogStream(ctx, execLogGroup, functionName)
+
+	events := make([]logdriver.LogEvent, 0, len(lines))
+	for _, line := range lines {
+		events = append(events, logdriver.LogEvent{Timestamp: now, Message: line})
+	}
+
+	_ = m.logs.PutLogEvents(ctx, execLogGroup, functionName, events)
+}

--- a/providers/azure/functions/execlogs_test.go
+++ b/providers/azure/functions/execlogs_test.go
@@ -1,0 +1,68 @@
+package functions
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/azure/loganalytics"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInvokeSurfacesLogsToLogAnalytics verifies an Azure Functions invoke writes
+// execution log lines into Log Analytics under the FunctionAppLogs table,
+// retrievable via GetLogEvents.
+func TestInvokeSurfacesLogsToLogAnalytics(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	la := loganalytics.New(config.NewOptions(
+		config.WithClock(config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))),
+		config.WithAccountID("test-sub"),
+	))
+	m.SetLogSink(la)
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "myFunc", Runtime: "dotnet6"})
+	require.NoError(t, err)
+
+	_, err = m.Invoke(ctx, driver.InvokeInput{FunctionName: "myFunc", Payload: []byte(`{}`)})
+	require.NoError(t, err)
+
+	events, err := la.GetLogEvents(ctx, &logdriver.LogQueryInput{
+		LogGroup:  execLogGroup,
+		LogStream: "myFunc",
+	})
+	require.NoError(t, err)
+
+	joined := joinMessages(events)
+	assert.Contains(t, joined, "Executing function=myFunc")
+	assert.Contains(t, joined, "Succeeded")
+}
+
+// TestInvokeNoLogSinkDefault verifies the default path (no sink wired) is a
+// no-op — no panic, and the invoke still succeeds.
+func TestInvokeNoLogSinkDefault(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "myFunc", Runtime: "dotnet6"})
+	require.NoError(t, err)
+
+	out, err := m.Invoke(ctx, driver.InvokeInput{FunctionName: "myFunc", Payload: []byte(`{}`)})
+	require.NoError(t, err)
+	assert.Equal(t, 200, out.StatusCode)
+}
+
+func joinMessages(events []logdriver.LogEvent) string {
+	var b strings.Builder
+	for i := range events {
+		b.WriteString(events[i].Message)
+		b.WriteByte('\n')
+	}
+
+	return b.String()
+}

--- a/providers/azure/functions/functions.go
+++ b/providers/azure/functions/functions.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
 	"github.com/stackshy/cloudemu/v2/services/serverless/funcengine"
@@ -69,13 +70,21 @@ type Mock struct {
 	handlersMu sync.RWMutex
 	handlers   map[string]driver.HandlerFunc
 	monitoring mondriver.Monitoring
-	mu         sync.Mutex   // guards PublishVersion read-modify-write on funcData
-	sitesMu    sync.RWMutex // guards SiteMeta read-modify-write
+	logs       logdriver.Logging // optional: Log Analytics sink for invocation logs
+	mu         sync.Mutex        // guards PublishVersion read-modify-write on funcData
+	sitesMu    sync.RWMutex      // guards SiteMeta read-modify-write
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
 func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
 	m.monitoring = mon
+}
+
+// SetLogSink wires the Log Analytics target that Invoke writes each
+// invocation's execution log lines (and any captured stdout/stderr) into.
+// Safe to leave unset — invocation-log surfacing is then skipped.
+func (m *Mock) SetLogSink(l logdriver.Logging) {
+	m.logs = l
 }
 
 func (m *Mock) emitMetric(functionName string, metrics map[string]float64) {
@@ -255,6 +264,7 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 		m.emitMetric(input.FunctionName, map[string]float64{
 			"FunctionExecutionCount": 1, "FunctionExecutionUnits": 1,
 		})
+		m.surfaceInvokeLogs(ctx, input.FunctionName, "", "")
 
 		payload := input.Payload
 		if len(payload) == 0 {
@@ -269,6 +279,7 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 		m.emitMetric(input.FunctionName, map[string]float64{
 			"FunctionExecutionCount": 1, "FunctionExecutionUnits": 1, "FunctionErrors": 1,
 		})
+		m.surfaceInvokeLogs(ctx, input.FunctionName, "", err.Error())
 
 		return &driver.InvokeOutput{StatusCode: 500, Error: err.Error()}, nil
 	}
@@ -276,6 +287,7 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 	m.emitMetric(input.FunctionName, map[string]float64{
 		"FunctionExecutionCount": 1, "FunctionExecutionUnits": 1,
 	})
+	m.surfaceInvokeLogs(ctx, input.FunctionName, "", "")
 
 	return &driver.InvokeOutput{StatusCode: 200, Payload: payload}, nil
 }
@@ -326,6 +338,7 @@ func (m *Mock) invokeEngine(ctx context.Context, input driver.InvokeInput) (*dri
 		m.emitMetric(input.FunctionName, map[string]float64{
 			"FunctionExecutionCount": 1, "FunctionExecutionUnits": 1, "FunctionErrors": 1,
 		})
+		m.surfaceInvokeLogs(ctx, input.FunctionName, out.Logs, out.Error)
 
 		return out, nil
 	}
@@ -333,6 +346,7 @@ func (m *Mock) invokeEngine(ctx context.Context, input driver.InvokeInput) (*dri
 	m.emitMetric(input.FunctionName, map[string]float64{
 		"FunctionExecutionCount": 1, "FunctionExecutionUnits": 1,
 	})
+	m.surfaceInvokeLogs(ctx, input.FunctionName, out.Logs, "")
 
 	return out, nil
 }

--- a/providers/azure/monitor/activitylog.go
+++ b/providers/azure/monitor/activitylog.go
@@ -1,0 +1,122 @@
+package monitor
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+const (
+	// maxActivityLogEvents bounds the in-memory Activity Log. Real Azure keeps 90
+	// days of events; the emulator keeps the most recent maxActivityLogEvents and
+	// drops the oldest, so a long-lived process stays bounded.
+	maxActivityLogEvents = 2000
+	// defaultActivityLogRecords caps a query with no explicit MaxRecords.
+	defaultActivityLogRecords = 1000
+)
+
+// Compile-time check that Mock implements the optional recorder capability.
+var _ driver.ActivityLogRecorder = (*Mock)(nil)
+
+// RecordActivityLogEvent appends a management event to the bounded Activity Log
+// the Activity Log API reads. The wire server calls it as ARM activity flows
+// through it, so the emulator's activity log reflects real API calls. It is
+// part of the Azure-only ActivityLogRecorder capability (see the driver pkg).
+func (m *Mock) RecordActivityLogEvent(e *driver.ActivityLogEvent) {
+	if e == nil {
+		return
+	}
+
+	// The recorder owns the timestamp and ids so the clock (FakeClock in tests)
+	// stays in the provider.
+	e.EventTimestamp = m.opts.Clock.Now()
+	if e.EventID == "" {
+		e.EventID = idgen.UUID()
+	}
+
+	if e.CorrelationID == "" {
+		e.CorrelationID = idgen.UUID()
+	}
+
+	if e.Status == "" {
+		e.Status = "Succeeded"
+	}
+
+	if e.Level == "" {
+		e.Level = "Informational"
+	}
+
+	m.activityMu.Lock()
+	defer m.activityMu.Unlock()
+
+	m.activityLog = append(m.activityLog, *e)
+	// Amortized trim: re-slice only once the log reaches the 2x high-water mark,
+	// then drop back to cap, keeping the common append O(1).
+	if len(m.activityLog) > 2*maxActivityLogEvents {
+		m.activityLog = append([]driver.ActivityLogEvent(nil), m.activityLog[len(m.activityLog)-maxActivityLogEvents:]...)
+	}
+}
+
+// ListActivityLogEvents returns recorded events matching the query's time and
+// resource filters, newest first. A zero query returns every event.
+//
+//nolint:gocritic // q is a small filter struct; by-value matches the driver capability signature.
+func (m *Mock) ListActivityLogEvents(q driver.ActivityLogQuery) []driver.ActivityLogEvent {
+	m.activityMu.Lock()
+	all := append([]driver.ActivityLogEvent(nil), m.activityLog...)
+	m.activityMu.Unlock()
+
+	// Reverse into newest-inserted-first order, then stable-sort by timestamp
+	// descending. A stable sort keeps insertion order for equal timestamps, so
+	// events recorded in the same instant (e.g. under a FakeClock) still return
+	// deterministically newest-first.
+	for i, j := 0, len(all)-1; i < j; i, j = i+1, j-1 {
+		all[i], all[j] = all[j], all[i]
+	}
+
+	sort.SliceStable(all, func(i, j int) bool {
+		return all[i].EventTimestamp.After(all[j].EventTimestamp)
+	})
+
+	limit := q.MaxRecords
+	if limit <= 0 {
+		limit = defaultActivityLogRecords
+	}
+
+	matched := make([]driver.ActivityLogEvent, 0, len(all))
+
+	for i := range all {
+		if activityMatches(&all[i], &q) {
+			matched = append(matched, all[i])
+			if len(matched) >= limit {
+				break
+			}
+		}
+	}
+
+	return matched
+}
+
+// activityMatches reports whether an event satisfies the query's time window
+// and resource filters (Azure matches on the filters supplied).
+func activityMatches(e *driver.ActivityLogEvent, q *driver.ActivityLogQuery) bool {
+	if !q.StartTime.IsZero() && e.EventTimestamp.Before(q.StartTime) {
+		return false
+	}
+
+	if !q.EndTime.IsZero() && e.EventTimestamp.After(q.EndTime) {
+		return false
+	}
+
+	if q.ResourceGroup != "" && !strings.EqualFold(e.ResourceGroup, q.ResourceGroup) {
+		return false
+	}
+
+	if q.ResourceID != "" && !strings.EqualFold(e.ResourceID, q.ResourceID) {
+		return false
+	}
+
+	return true
+}

--- a/providers/azure/monitor/activitylog_test.go
+++ b/providers/azure/monitor/activitylog_test.go
@@ -1,0 +1,44 @@
+package monitor
+
+import (
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRecordAndListActivityLog verifies events are recorded newest-first and
+// filtered by resource group.
+func TestRecordAndListActivityLog(t *testing.T) {
+	m, _ := newTestMock()
+
+	m.RecordActivityLogEvent(&driver.ActivityLogEvent{
+		OperationName: "Microsoft.Network/virtualNetworks/write", ResourceGroup: "rg-a",
+	})
+	m.RecordActivityLogEvent(&driver.ActivityLogEvent{
+		OperationName: "Microsoft.Compute/virtualMachines/write", ResourceGroup: "rg-b",
+	})
+
+	all := m.ListActivityLogEvents(driver.ActivityLogQuery{})
+	require.Len(t, all, 2)
+
+	// Newest first: the compute event was recorded last.
+	assert.Equal(t, "Microsoft.Compute/virtualMachines/write", all[0].OperationName)
+	// Recorder stamps id, correlation id, timestamp, and defaults.
+	assert.NotEmpty(t, all[0].EventID)
+	assert.NotEmpty(t, all[0].CorrelationID)
+	assert.Equal(t, "Succeeded", all[0].Status)
+	assert.False(t, all[0].EventTimestamp.IsZero())
+
+	filtered := m.ListActivityLogEvents(driver.ActivityLogQuery{ResourceGroup: "rg-a"})
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "rg-a", filtered[0].ResourceGroup)
+}
+
+// TestActivityLogNilEventIgnored verifies a nil event is a safe no-op.
+func TestActivityLogNilEventIgnored(t *testing.T) {
+	m, _ := newTestMock()
+	m.RecordActivityLogEvent(nil)
+	assert.Empty(t, m.ListActivityLogEvents(driver.ActivityLogQuery{}))
+}

--- a/providers/azure/monitor/monitor.go
+++ b/providers/azure/monitor/monitor.go
@@ -63,6 +63,8 @@ type Mock struct {
 	deliveries       []ActionGroupDelivery
 	webhookDeliverer WebhookDeliverer
 	history          []driver.AlarmHistoryEntry
+	activityMu       sync.Mutex
+	activityLog      []driver.ActivityLogEvent
 	opts             *config.Options
 }
 

--- a/providers/gcp/cloudfunctions/execlogs.go
+++ b/providers/gcp/cloudfunctions/execlogs.go
@@ -1,0 +1,48 @@
+package cloudfunctions
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// execLogGroup is the conventional Cloud Logging log name real Cloud Functions
+// writes execution logs under.
+const execLogGroup = "cloudfunctions.googleapis.com/cloud-functions"
+
+// surfaceInvokeLogs writes one invocation's execution log lines into Cloud
+// Logging under the function's stream, including any captured stdout/stderr
+// from the real-engine path. Best-effort: with no log sink wired it is a no-op.
+func (m *Mock) surfaceInvokeLogs(ctx context.Context, functionName, captured, funcError string) {
+	if m.logs == nil {
+		return
+	}
+
+	executionID := idgen.UUID()
+	now := m.opts.Clock.Now()
+
+	lines := []string{fmt.Sprintf("Function execution started (execution_id: %s)", executionID)}
+
+	if captured != "" {
+		lines = append(lines, strings.Split(strings.TrimRight(captured, "\n"), "\n")...)
+	}
+
+	if funcError != "" {
+		lines = append(lines, fmt.Sprintf("Error: %s", funcError))
+	}
+
+	lines = append(lines, fmt.Sprintf("Function execution took 1 ms, finished (execution_id: %s)", executionID))
+
+	_, _ = m.logs.CreateLogGroup(ctx, logdriver.LogGroupConfig{Name: execLogGroup})
+	_, _ = m.logs.CreateLogStream(ctx, execLogGroup, functionName)
+
+	events := make([]logdriver.LogEvent, 0, len(lines))
+	for _, line := range lines {
+		events = append(events, logdriver.LogEvent{Timestamp: now, Message: line})
+	}
+
+	_ = m.logs.PutLogEvents(ctx, execLogGroup, functionName, events)
+}

--- a/providers/gcp/cloudfunctions/execlogs_test.go
+++ b/providers/gcp/cloudfunctions/execlogs_test.go
@@ -1,0 +1,68 @@
+package cloudfunctions
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/gcp/cloudlogging"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInvokeSurfacesLogsToCloudLogging verifies a Cloud Functions invoke writes
+// execution log lines into Cloud Logging under the conventional log name,
+// retrievable via GetLogEvents.
+func TestInvokeSurfacesLogsToCloudLogging(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	cl := cloudlogging.New(config.NewOptions(
+		config.WithClock(config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))),
+		config.WithProjectID("test-project"),
+	))
+	m.SetLogSink(cl)
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "my-func", Runtime: "go121"})
+	require.NoError(t, err)
+
+	_, err = m.Invoke(ctx, driver.InvokeInput{FunctionName: "my-func", Payload: []byte(`{}`)})
+	require.NoError(t, err)
+
+	events, err := cl.GetLogEvents(ctx, &logdriver.LogQueryInput{
+		LogGroup:  execLogGroup,
+		LogStream: "my-func",
+	})
+	require.NoError(t, err)
+
+	joined := joinMessages(events)
+	assert.Contains(t, joined, "Function execution started")
+	assert.Contains(t, joined, "finished")
+}
+
+// TestInvokeNoLogSinkDefault verifies the default path (no sink wired) is a
+// no-op — no panic, and the invoke still succeeds.
+func TestInvokeNoLogSinkDefault(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "my-func", Runtime: "go121"})
+	require.NoError(t, err)
+
+	out, err := m.Invoke(ctx, driver.InvokeInput{FunctionName: "my-func", Payload: []byte(`{}`)})
+	require.NoError(t, err)
+	assert.Equal(t, 200, out.StatusCode)
+}
+
+func joinMessages(events []logdriver.LogEvent) string {
+	var b strings.Builder
+	for i := range events {
+		b.WriteString(events[i].Message)
+		b.WriteByte('\n')
+	}
+
+	return b.String()
+}

--- a/providers/gcp/cloudfunctions/functions.go
+++ b/providers/gcp/cloudfunctions/functions.go
@@ -13,6 +13,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
 	"github.com/stackshy/cloudemu/v2/services/serverless/funcengine"
@@ -66,12 +67,20 @@ type Mock struct {
 	handlersMu sync.RWMutex
 	handlers   map[string]driver.HandlerFunc
 	monitoring mondriver.Monitoring
-	mu         sync.Mutex // guards PublishVersion read-modify-write on funcData
+	logs       logdriver.Logging // optional: Cloud Logging sink for invocation logs
+	mu         sync.Mutex        // guards PublishVersion read-modify-write on funcData
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
 func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
 	m.monitoring = mon
+}
+
+// SetLogSink wires the Cloud Logging target that Invoke writes each
+// invocation's execution log lines (and any captured stdout/stderr) into.
+// Safe to leave unset — invocation-log surfacing is then skipped.
+func (m *Mock) SetLogSink(l logdriver.Logging) {
+	m.logs = l
 }
 
 //nolint:unparam // value kept as parameter for API consistency with other service emitMetric helpers.
@@ -247,6 +256,7 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 		noHandlerDims := map[string]string{"function_name": input.FunctionName}
 		m.emitMetric(ctx, "function/execution_count", 1, noHandlerDims)
 		m.emitMetric(ctx, "function/execution_times", 1, noHandlerDims)
+		m.surfaceInvokeLogs(ctx, input.FunctionName, "", "")
 
 		payload := input.Payload
 		if len(payload) == 0 {
@@ -263,12 +273,14 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 		m.emitMetric(ctx, "function/execution_count", 1, dims)
 		m.emitMetric(ctx, "function/execution_times", 1, dims)
 		m.emitMetric(ctx, "function/error_count", 1, dims)
+		m.surfaceInvokeLogs(ctx, input.FunctionName, "", err.Error())
 
 		return &driver.InvokeOutput{StatusCode: 500, Error: err.Error()}, nil
 	}
 
 	m.emitMetric(ctx, "function/execution_count", 1, dims)
 	m.emitMetric(ctx, "function/execution_times", 1, dims)
+	m.surfaceInvokeLogs(ctx, input.FunctionName, "", "")
 
 	return &driver.InvokeOutput{StatusCode: 200, Payload: payload}, nil
 }
@@ -291,6 +303,8 @@ func (m *Mock) invokeEngine(ctx context.Context, input driver.InvokeInput) (*dri
 	if out.Error != "" {
 		m.emitMetric(ctx, "function/error_count", 1, dims)
 	}
+
+	m.surfaceInvokeLogs(ctx, input.FunctionName, out.Logs, out.Error)
 
 	return out, nil
 }

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -130,6 +130,9 @@ func New(opts ...config.Option) *Provider {
 	p.GCS.SetMonitoring(p.CloudMonitoring)
 	p.Firestore.SetMonitoring(p.CloudMonitoring)
 	p.CloudFunctions.SetMonitoring(p.CloudMonitoring)
+	// Cloud Functions invocations write execution logs (and captured stdout/
+	// stderr on the real-engine path) to Cloud Logging.
+	p.CloudFunctions.SetLogSink(p.CloudLogging)
 	p.PubSub.SetMonitoring(p.CloudMonitoring)
 	p.Memorystore.SetMonitoring(p.CloudMonitoring)
 	p.CloudLogging.SetMonitoring(p.CloudMonitoring)

--- a/server/azure/activitylog_recording.go
+++ b/server/azure/activitylog_recording.go
@@ -1,0 +1,61 @@
+package azure
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// defaultActivityCaller is the caller recorded when a request carries no
+// identity the emulator can attribute (auth is accepted but not verified).
+const defaultActivityCaller = "cloudemu@localhost"
+
+// recordActivityLogEvent derives an Azure Activity Log management event from a
+// served ARM request and records it. It runs as the server's post-dispatch
+// observer, so the Activity Log API reflects real API activity. Read-only
+// requests (GET/HEAD) and non-ARM (data-plane) URLs are skipped — Activity
+// Log's Administrative category records writes/deletes/actions, not reads.
+func recordActivityLogEvent(rec mondriver.ActivityLogRecorder, r *http.Request) {
+	verb := writeVerb(r.Method)
+	if verb == "" {
+		return
+	}
+
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok || rp.Provider == "" || rp.ResourceType == "" {
+		return
+	}
+
+	// The Activity Log itself is a read API; don't record its own reads (they're
+	// GETs and already filtered out), and never record microsoft.insights
+	// activity-log queries even if a client POSTs to them.
+	if strings.EqualFold(rp.Provider, "Microsoft.Insights") {
+		return
+	}
+
+	rec.RecordActivityLogEvent(&mondriver.ActivityLogEvent{
+		OperationName:    rp.Provider + "/" + rp.ResourceType + "/" + verb,
+		ResourceID:       strings.TrimRight(r.URL.Path, "/"),
+		ResourceProvider: rp.Provider,
+		ResourceGroup:    rp.ResourceGroup,
+		SubscriptionID:   rp.Subscription,
+		Caller:           defaultActivityCaller,
+	})
+}
+
+// writeVerb maps an HTTP method to the ARM operation verb the Activity Log
+// records, or "" for read-only methods that aren't recorded.
+func writeVerb(method string) string {
+	switch method {
+	case http.MethodPut, http.MethodPatch:
+		return "write"
+	case http.MethodDelete:
+		return "delete"
+	case http.MethodPost:
+		return "action"
+	default:
+		return ""
+	}
+}

--- a/server/azure/activitylog_test.go
+++ b/server/azure/activitylog_test.go
@@ -1,0 +1,142 @@
+package azure_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// alCred is a static-token credential for the Activity Log test.
+type alCred struct{}
+
+func (alCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+// TestActivityLogRecordsMutatingARMOp verifies a mutating ARM operation is
+// auto-recorded and surfaced by the Activity Log read API — the Azure analogue
+// of AWS CloudTrail LookupEvents reflecting a mutating call.
+func TestActivityLogRecordsMutatingARMOp(t *testing.T) {
+	p := cloudemu.NewAzure()
+	srv := azureserver.NewFromProvider(p)
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: cloud.Configuration{
+				ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+					cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+				},
+			},
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	const sub = "sub-al"
+
+	vnetClient, err := armnetwork.NewVirtualNetworksClient(sub, alCred{}, opts)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+
+	poller, err := vnetClient.BeginCreateOrUpdate(ctx, "rg-al", "vnet-al", armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("begin create: %v", err)
+	}
+
+	if _, err = poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("create vnet: %v", err)
+	}
+
+	// Read the Activity Log via its management-events API (no auth needed — the
+	// default server accepts any credentials).
+	url := ts.URL + "/subscriptions/" + sub +
+		"/providers/Microsoft.Insights/eventtypes/management/values?api-version=2015-04-01"
+
+	resp, err := ts.Client().Get(url)
+	if err != nil {
+		t.Fatalf("get activity log: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		t.Fatalf("activity log status %d: %s", resp.StatusCode, body)
+	}
+
+	var got struct {
+		Value []struct {
+			OperationName struct {
+				Value string `json:"value"`
+			} `json:"operationName"`
+			ResourceGroupName string `json:"resourceGroupName"`
+		} `json:"value"`
+	}
+	if err = json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode: %v (%s)", err, body)
+	}
+
+	found := false
+	for _, e := range got.Value {
+		if e.OperationName.Value == "Microsoft.Network/virtualNetworks/write" && e.ResourceGroupName == "rg-al" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected recorded virtualNetworks/write event, got: %s", body)
+	}
+}
+
+// TestActivityLogEmptyWithoutMutation verifies the Activity Log stays empty when
+// no mutating operation has run — the default, no-noise path.
+func TestActivityLogEmptyWithoutMutation(t *testing.T) {
+	p := cloudemu.NewAzure()
+	srv := azureserver.NewFromProvider(p)
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	url := ts.URL + "/subscriptions/sub-x" +
+		"/providers/Microsoft.Insights/eventtypes/management/values?api-version=2015-04-01"
+
+	resp, err := ts.Client().Get(url)
+	if err != nil {
+		t.Fatalf("get activity log: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status %d: %s", resp.StatusCode, body)
+	}
+
+	if !strings.Contains(string(body), `"value":[]`) {
+		t.Fatalf("expected empty activity log, got: %s", body)
+	}
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -284,6 +284,12 @@ func New(d Drivers) http.Handler {
 	if d.Monitor != nil {
 		srv.Register(monitor.NewMetricsHandler(d.Monitor))
 		srv.Register(monitor.NewDiagnosticSettingsHandler())
+		// Activity Log read API — registered only when the monitoring backend
+		// supports the recorder capability, so its suffix match wins over any
+		// resource handler for .../eventtypes/management/values.
+		if alh := monitor.NewActivityLogHandler(d.Monitor); alh != nil {
+			srv.Register(alh)
+		}
 	}
 
 	// Register more-specific compute resource handlers first so their
@@ -576,6 +582,14 @@ func New(d Drivers) http.Handler {
 	// the unmodeled-property overlay below wraps the response).
 	if d.EnforceAuth {
 		srv.SetPreDispatch(newAuthGate(config.RealClock{}))
+	}
+
+	// When the monitoring backend can record Activity Log events, observe every
+	// served ARM request and log a management event so the Activity Log API
+	// reflects real API activity. This is the Azure analog of the AWS
+	// CloudTrail observer.
+	if rec, ok := d.Monitor.(mondriver.ActivityLogRecorder); ok {
+		srv.SetObserver(func(r *http.Request) { recordActivityLogEvent(rec, r) })
 	}
 
 	return echoUnmodeledProperties(srv, newPropertyOverlay())

--- a/server/azure/monitor/activitylog.go
+++ b/server/azure/monitor/activitylog.go
@@ -1,0 +1,130 @@
+package monitor
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// activityLogSuffix is the Activity Log "list management events" API path
+// (GET {scope}/providers/Microsoft.Insights/eventtypes/management/values).
+const activityLogSuffix = "/providers/microsoft.insights/eventtypes/management/values"
+
+// ActivityLogHandler serves the Azure Activity Log read API. It surfaces the
+// management events the wire server auto-records as ARM operations flow through
+// it (see the server observer), so a client that lists the Activity Log sees
+// real API activity. It is backed by the optional ActivityLogRecorder
+// capability; when the monitoring backend doesn't implement it, Matches is
+// false so the handler adds nothing.
+type ActivityLogHandler struct {
+	rec mondriver.ActivityLogRecorder
+}
+
+// NewActivityLogHandler returns an Activity Log handler when m implements the
+// recorder capability, else nil (so callers register it only when usable).
+func NewActivityLogHandler(m mondriver.Monitoring) *ActivityLogHandler {
+	rec, ok := m.(mondriver.ActivityLogRecorder)
+	if !ok {
+		return nil
+	}
+
+	return &ActivityLogHandler{rec: rec}
+}
+
+// Matches claims GETs on {scope}/providers/Microsoft.Insights/eventtypes/
+// management/values. The lowercased-suffix match wins over any resource handler.
+func (h *ActivityLogHandler) Matches(r *http.Request) bool {
+	if h == nil || h.rec == nil || r.Method != http.MethodGet {
+		return false
+	}
+
+	return strings.HasSuffix(strings.ToLower(r.URL.Path), activityLogSuffix)
+}
+
+func (h *ActivityLogHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	q := mondriver.ActivityLogQuery{
+		ResourceGroup: filterEq(r.URL.Query().Get("$filter"), "resourceGroupName"),
+		StartTime:     filterTime(r.URL.Query().Get("$filter"), "ge"),
+		EndTime:       filterTime(r.URL.Query().Get("$filter"), "le"),
+	}
+
+	events := h.rec.ListActivityLogEvents(q)
+
+	value := make([]map[string]any, 0, len(events))
+	for i := range events {
+		value = append(value, activityLogJSON(&events[i]))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, map[string]any{"value": value})
+}
+
+// activityLogJSON renders one event in the shape the Activity Log API returns.
+func activityLogJSON(e *mondriver.ActivityLogEvent) map[string]any {
+	return map[string]any{
+		"eventDataId":       e.EventID,
+		"correlationId":     e.CorrelationID,
+		"eventName":         map[string]any{"value": "EndRequest", "localizedValue": "End request"},
+		"operationName":     map[string]any{"value": e.OperationName, "localizedValue": e.OperationName},
+		"status":            map[string]any{"value": e.Status, "localizedValue": e.Status},
+		"level":             e.Level,
+		"resourceId":        e.ResourceID,
+		"resourceGroupName": e.ResourceGroup,
+		"resourceProviderName": map[string]any{
+			"value": e.ResourceProvider, "localizedValue": e.ResourceProvider,
+		},
+		"subscriptionId": e.SubscriptionID,
+		"caller":         e.Caller,
+		"eventTimestamp": e.EventTimestamp.UTC().Format(time.RFC3339Nano),
+		"category":       map[string]any{"value": "Administrative", "localizedValue": "Administrative"},
+	}
+}
+
+// filterEq pulls the value of "<field> eq '<value>'" from an OData $filter, if
+// present. Activity Log filters are simple conjunctions, so a substring scan is
+// enough for the fields the emulator supports.
+func filterEq(filter, field string) string {
+	lower := strings.ToLower(filter)
+	key := strings.ToLower(field) + " eq '"
+
+	i := strings.Index(lower, key)
+	if i < 0 {
+		return ""
+	}
+
+	rest := filter[i+len(key):]
+	if j := strings.IndexByte(rest, '\''); j >= 0 {
+		return rest[:j]
+	}
+
+	return ""
+}
+
+// filterTime pulls the timestamp of "eventTimestamp <op> '<rfc3339>'" from an
+// OData $filter, where op is "ge" (start) or "le" (end). A missing or
+// unparseable bound returns the zero time (no bound).
+func filterTime(filter, op string) time.Time {
+	lower := strings.ToLower(filter)
+	key := "eventtimestamp " + op + " '"
+
+	i := strings.Index(lower, key)
+	if i < 0 {
+		return time.Time{}
+	}
+
+	rest := filter[i+len(key):]
+
+	j := strings.IndexByte(rest, '\'')
+	if j < 0 {
+		return time.Time{}
+	}
+
+	t, err := time.Parse(time.RFC3339, rest[:j])
+	if err != nil {
+		return time.Time{}
+	}
+
+	return t
+}

--- a/server/gcp/auditlog_recording.go
+++ b/server/gcp/auditlog_recording.go
@@ -1,0 +1,90 @@
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+const (
+	// auditLogGroup is the conventional Cloud Logging log name real Cloud Audit
+	// Logs Admin Activity entries are written under. Reading the audit trail is a
+	// Cloud Logging entries:list filtered on this logName.
+	auditLogGroup = "cloudaudit.googleapis.com/activity"
+	// defaultAuditPrincipal is the caller recorded when a request carries no
+	// identity the emulator can attribute (auth is accepted but not verified).
+	defaultAuditPrincipal = "cloudemu@localhost"
+	// genericAuditService is the service name used for API paths rooted at a
+	// bare version segment (e.g. "/v1/projects/...") where no service prefix
+	// identifies the owning API.
+	genericAuditService = "googleapis.com"
+)
+
+// recordAuditLogEvent derives a Cloud Audit Log Admin Activity entry from a
+// served GCP REST request and writes it into Cloud Logging, so a client reading
+// the audit trail sees real API activity. It runs as the server's post-dispatch
+// observer. Read-only requests (GET) and Cloud Logging's own operations are
+// skipped — Admin Activity logs record writes/deletes/actions, and recording
+// logging reads/writes would flood the log with its own traffic.
+func recordAuditLogEvent(logs logdriver.Logging, r *http.Request) {
+	if r.Method == http.MethodGet || r.Method == http.MethodHead {
+		return
+	}
+
+	if isLoggingOperation(r.URL.Path) {
+		return
+	}
+
+	service := auditServiceName(r.URL.Path)
+	entry := map[string]any{
+		"@type":        "type.googleapis.com/google.cloud.audit.AuditLog",
+		"serviceName":  service,
+		"methodName":   r.Method + " " + r.URL.Path,
+		"resourceName": strings.TrimPrefix(r.URL.Path, "/"),
+		"authenticationInfo": map[string]any{
+			"principalEmail": defaultAuditPrincipal,
+		},
+	}
+
+	msg, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+
+	ctx := context.Background()
+	now := time.Now()
+
+	_, _ = logs.CreateLogGroup(ctx, logdriver.LogGroupConfig{Name: auditLogGroup})
+	_, _ = logs.CreateLogStream(ctx, auditLogGroup, service)
+	_ = logs.PutLogEvents(ctx, auditLogGroup, service, []logdriver.LogEvent{
+		{Timestamp: now, Message: string(msg)},
+	})
+}
+
+// isLoggingOperation reports whether a path targets Cloud Logging itself
+// (entries:write/list or the projects/{p}/logs family), which must not be
+// audit-recorded to avoid the log capturing its own traffic.
+func isLoggingOperation(path string) bool {
+	return strings.Contains(path, "/entries:") || strings.Contains(path, "/logs")
+}
+
+// auditServiceName derives the GCP service name from a REST path, e.g.
+// "/compute/v1/projects/..." -> "compute.googleapis.com". Paths rooted at a
+// bare version (e.g. "/v1/projects/...") fall back to a generic service.
+func auditServiceName(path string) string {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) == 0 || parts[0] == "" {
+		return genericAuditService
+	}
+
+	first := parts[0]
+	if first == "v1" || first == "v2" || first == "v3" || strings.HasPrefix(first, "v1") {
+		return genericAuditService
+	}
+
+	return first + ".googleapis.com"
+}

--- a/server/gcp/auditlog_test.go
+++ b/server/gcp/auditlog_test.go
@@ -1,0 +1,74 @@
+package gcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+const auditLogName = "cloudaudit.googleapis.com/activity"
+
+// TestAuditLogRecordsMutatingOp verifies a mutating GCP API operation is
+// auto-recorded as a Cloud Audit Log entry in Cloud Logging — the GCP analogue
+// of AWS CloudTrail LookupEvents reflecting a mutating call.
+func TestAuditLogRecordsMutatingOp(t *testing.T) {
+	p := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.DriversFrom(p))
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	// PUT a Pub/Sub topic — a mutating operation the server handles.
+	code, _ := do(t, ts, http.MethodPut, "/v1/projects/demo/topics/audit-topic", `{}`)
+	if code < 200 || code >= 300 {
+		t.Fatalf("create topic: status %d", code)
+	}
+
+	events, err := p.CloudLogging.GetLogEvents(context.Background(), &logdriver.LogQueryInput{
+		LogGroup: auditLogName,
+	})
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+
+	if len(events) == 0 {
+		t.Fatal("expected an audit log entry for the mutating op, got none")
+	}
+
+	joined := ""
+	for i := range events {
+		joined += events[i].Message
+	}
+
+	if !strings.Contains(joined, "AuditLog") || !strings.Contains(joined, "topics/audit-topic") {
+		t.Fatalf("audit entry missing expected fields: %s", joined)
+	}
+}
+
+// TestAuditLogSkipsReads verifies a read-only (GET) operation is NOT recorded —
+// Admin Activity audit logs record writes/deletes/actions, not reads.
+func TestAuditLogSkipsReads(t *testing.T) {
+	p := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.DriversFrom(p))
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	// A GET (list topics) must not produce an audit entry.
+	do(t, ts, http.MethodGet, "/v1/projects/demo/topics", "")
+
+	events, err := p.CloudLogging.GetLogEvents(context.Background(), &logdriver.LogQueryInput{
+		LogGroup: auditLogName,
+	})
+	// The audit log group may not exist yet (no writes) — a not-found is
+	// equivalent to "no audit entries".
+	if err == nil && len(events) != 0 {
+		t.Fatalf("expected no audit entries for a read, got %d", len(events))
+	}
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -7,6 +7,8 @@
 package gcp
 
 import (
+	"net/http"
+
 	gkeprov "github.com/stackshy/cloudemu/v2/providers/gcp/gke"
 	gcpmon "github.com/stackshy/cloudemu/v2/providers/gcp/monitoring"
 	"github.com/stackshy/cloudemu/v2/server"
@@ -128,7 +130,7 @@ type Drivers struct {
 // firestore, monitoring) ahead of GCS so first-match-wins keeps each on the
 // correct package.
 //
-//nolint:gocritic,gocyclo,funlen // Drivers is all interface fields; one if-per-driver is the simplest expression and grows with the bundle.
+//nolint:gocritic,gocyclo,gocognit,funlen // Drivers is all interface fields; one if-per-driver, grows with the bundle.
 func New(d Drivers) *server.Server {
 	// AlloyDB and GKE claim the same /v1/projects/{p}/locations/{l}/clusters
 	// paths, so enabling both would silently shadow one. Fail fast rather than
@@ -400,5 +402,21 @@ func New(d Drivers) *server.Server {
 		srv.Register(gcsHandler)
 	}
 
+	// When Cloud Logging is present, observe every served request and write a
+	// Cloud Audit Log Admin Activity entry for mutating operations, so the audit
+	// trail reflects real API activity. This is the GCP analog of the AWS
+	// CloudTrail observer.
+	installAuditObserver(srv, d.CloudLogging)
+
 	return srv
+}
+
+// installAuditObserver wires the Cloud Audit Log observer when Cloud Logging is
+// present. A nil sink leaves the server's request path unchanged.
+func installAuditObserver(srv *server.Server, logs logdriver.Logging) {
+	if logs == nil {
+		return
+	}
+
+	srv.SetObserver(func(r *http.Request) { recordAuditLogEvent(logs, r) })
 }

--- a/services/monitoring/driver/activitylog.go
+++ b/services/monitoring/driver/activitylog.go
@@ -1,0 +1,40 @@
+package driver
+
+import "time"
+
+// ActivityLogEvent is one Azure Activity Log entry — a management-plane
+// operation recorded automatically as ARM traffic flows through the wire
+// server. It mirrors the fields the Activity Log API surfaces per event.
+type ActivityLogEvent struct {
+	EventID          string
+	OperationName    string // e.g. Microsoft.Compute/virtualMachines/write
+	ResourceID       string // the target resource path
+	ResourceProvider string // e.g. Microsoft.Compute
+	ResourceGroup    string
+	Caller           string
+	Status           string // Succeeded / Failed
+	Level            string // Informational / Error
+	SubscriptionID   string
+	CorrelationID    string
+	EventTimestamp   time.Time
+}
+
+// ActivityLogQuery filters ListActivityLogEvents. A zero value returns every
+// recorded event, newest first.
+type ActivityLogQuery struct {
+	StartTime     time.Time
+	EndTime       time.Time
+	ResourceGroup string
+	ResourceID    string
+	MaxRecords    int
+}
+
+// ActivityLogRecorder is an OPTIONAL capability, discovered by type assertion
+// on a Monitoring backend. The Azure wire server calls RecordActivityLogEvent
+// as ARM operations flow through it, so the Activity Log API reflects real API
+// activity rather than staying empty. Recording is Azure-specific, so it is
+// kept off the mandatory Monitoring interface.
+type ActivityLogRecorder interface {
+	RecordActivityLogEvent(e *ActivityLogEvent)
+	ListActivityLogEvents(q ActivityLogQuery) []ActivityLogEvent
+}

--- a/services/serverless/driver/driver.go
+++ b/services/serverless/driver/driver.go
@@ -241,6 +241,11 @@ type InvokeOutput struct {
 	// names a version, or "$LATEST" for an unqualified invoke. Mirrors the
 	// AWS Lambda Invoke ExecutedVersion response field.
 	ExecutedVersion string
+	// Logs is the stdout/stderr the invocation produced on the real-engine
+	// path (empty for stub/handler invocations). It is surfaced to the log
+	// service (CloudWatch Logs / Cloud Logging / Log Analytics) rather than
+	// returned on the wire.
+	Logs string
 }
 
 // HandlerFunc is a function handler that processes invocations.

--- a/services/serverless/funcengine/funcengine.go
+++ b/services/serverless/funcengine/funcengine.go
@@ -51,7 +51,7 @@ func Invoke(ctx context.Context, engine config.FunctionEngine, name string, even
 		return nil, err
 	}
 
-	out := &driver.InvokeOutput{StatusCode: okStatusCode, Payload: res.Payload}
+	out := &driver.InvokeOutput{StatusCode: okStatusCode, Payload: res.Payload, Logs: res.Logs}
 	if res.FunctionError != "" {
 		out.Error = res.FunctionError
 	}


### PR DESCRIPTION
Closes the auto-telemetry parity gaps in #847.

**Audit logs (mirror AWS CloudTrail's observer):**
- Azure Activity Log — server/azure auto-records mutating ARM operations, queryable via the activity-log API
- GCP Cloud Audit Logs — server/gcp auto-records API operations, surfaced through Cloud Logging

**Function execution logs (mirror the ECS awslogs sink):**
- Lambda, Cloud Functions, Azure Functions invokes auto-write execution log lines (and real-engine stdout/stderr) to CloudWatch Logs / Cloud Logging / Log Analytics; conventional log group/stream auto-created.

No-observer / no-sink default paths are byte-unchanged. Metrics + alarms were already at parity across all 3 clouds.