### PR TITLE
feat(sfn): real ASL interpreter core (PR1/3) for Step Functions (#581)

### DIFF
--- a/docs/coverage/aws/sfn.md
+++ b/docs/coverage/aws/sfn.md
@@ -36,7 +36,7 @@ AWS's `sfn` service · portable interface `driver.SFN` · [AWS index](./README.m
 | `SendTaskSuccess` |  |
 | `StartExecution` | Executions. |
 | `StartSyncExecution` |  |
-| `StopExecution` |  |
+| `StopExecution` | StopExecution aborts a still-settling execution, persisting the caller's |
 | `TagResource` | Tags. |
 | `TestState` | Definition tooling. |
 | `UntagResource` |  |

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -11093,7 +11093,8 @@
         "name": "StartSyncExecution"
       },
       {
-        "name": "StopExecution"
+        "name": "StopExecution",
+        "doc": "StopExecution aborts a still-settling execution, persisting the caller's"
       },
       {
         "name": "TagResource",

--- a/providers/aws/sfn/asl/asl_test.go
+++ b/providers/aws/sfn/asl/asl_test.go
@@ -1,0 +1,175 @@
+package asl
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestGlobMatch(t *testing.T) {
+	cases := []struct {
+		pattern, s string
+		want       bool
+	}{
+		{"foo*bar", "foobar", true},
+		{"foo*bar", "fooXXbar", true},
+		{"foo*bar", "foobaz", false},
+		{"*", "anything", true},
+		{"a*b*c", "axxbyyc", true},
+		{"a*b*c", "axxc", false},
+		{"literal", "literal", true},
+		{"literal", "other", false},
+		{`foo\*bar`, "foo*bar", true},
+		{`foo\*bar`, "fooXbar", false},
+	}
+
+	for _, c := range cases {
+		if got := globMatch(c.pattern, c.s); got != c.want {
+			t.Errorf("globMatch(%q,%q) = %v, want %v", c.pattern, c.s, got, c.want)
+		}
+	}
+}
+
+func TestEvalPath(t *testing.T) {
+	root := map[string]any{
+		"a": map[string]any{"b": []any{float64(10), float64(20), float64(30)}},
+		"s": "hi",
+	}
+
+	cases := []struct {
+		path    string
+		want    any
+		present bool
+	}{
+		{"$", root, true},
+		{"$.s", "hi", true},
+		{"$.a.b[2]", float64(30), true},
+		{"$['s']", "hi", true},
+		{"$.missing", nil, false},
+		{"$.a.b[9]", nil, false},
+	}
+
+	for _, c := range cases {
+		got, present, err := evalPath(c.path, root)
+		if err != nil {
+			t.Fatalf("evalPath(%q) error: %v", c.path, err)
+		}
+
+		if present != c.present {
+			t.Errorf("evalPath(%q) present = %v, want %v", c.path, present, c.present)
+		}
+
+		if present && !reflect.DeepEqual(got, c.want) {
+			t.Errorf("evalPath(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+func TestEvalPathUnsupportedFailsLoudly(t *testing.T) {
+	for _, p := range []string{"$.a[*]", "$..b", "$.a[?(@.x)]"} {
+		if _, _, err := evalPath(p, map[string]any{}); err == nil {
+			t.Errorf("evalPath(%q) should reject unsupported syntax", p)
+		}
+	}
+}
+
+func TestIntrinsics(t *testing.T) {
+	it := &interp{}
+	it.buildContext(&RunInput{ExecName: "run"}, nil)
+
+	input := map[string]any{"name": "Ada", "n": float64(2)}
+
+	got, err := it.evalIntrinsic(`States.Format('Hi {}, item {}', $.name, $.n)`, input)
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+
+	if got != "Hi Ada, item 2" {
+		t.Errorf("Format = %q", got)
+	}
+
+	arr, err := it.evalIntrinsic(`States.Array($.name, 1, 'x')`, input)
+	if err != nil {
+		t.Fatalf("Array: %v", err)
+	}
+
+	if !reflect.DeepEqual(arr, []any{"Ada", float64(1), "x"}) {
+		t.Errorf("Array = %#v", arr)
+	}
+
+	item, err := it.evalIntrinsic(`States.ArrayGetItem(States.Array('a','b','c'), 1)`, input)
+	if err != nil {
+		t.Fatalf("ArrayGetItem: %v", err)
+	}
+
+	if item != "b" {
+		t.Errorf("ArrayGetItem = %v", item)
+	}
+
+	uuid, err := it.evalIntrinsic(`States.UUID()`, input)
+	if err != nil || len(uuid.(string)) != 36 {
+		t.Errorf("UUID = %v (err=%v)", uuid, err)
+	}
+}
+
+func TestPayloadTemplateWithContext(t *testing.T) {
+	it := &interp{}
+	it.buildContext(&RunInput{ExecName: "myrun"}, nil)
+
+	tmpl := json.RawMessage(`{"lit":"x","from.$":"$.v","name.$":"$$.Execution.Name"}`)
+
+	got, err := it.applyPayloadTemplate(tmpl, map[string]any{"v": float64(7)})
+	if err != nil {
+		t.Fatalf("applyPayloadTemplate: %v", err)
+	}
+
+	want := map[string]any{"lit": "x", "from": float64(7), "name": "myrun"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("payload = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseAcceptsAndRejects(t *testing.T) {
+	good := `{"StartAt":"A","States":{"A":{"Type":"Pass","End":true}}}`
+	if _, err := Parse(good); err != nil {
+		t.Fatalf("Parse(valid) = %v", err)
+	}
+
+	bad := []string{
+		`{"StartAt":"A","States":{"A":{"Type":"Wait","Seconds":1,"Result":{},"End":true}}}`,
+		`{"StartAt":"Missing","States":{"A":{"Type":"Pass","End":true}}}`,
+		`{"QueryLanguage":"JSONata","StartAt":"A","States":{"A":{"Type":"Pass","End":true}}}`,
+	}
+
+	for _, def := range bad {
+		if _, err := Parse(def); err == nil {
+			t.Errorf("Parse(%q) should have failed", def)
+		}
+	}
+}
+
+func TestResultPathMergesOntoRaw(t *testing.T) {
+	def, err := Parse(`{"StartAt":"T","States":{"T":{"Type":"Pass",
+		"InputPath":"$.detail","Result":{"ok":true},"ResultPath":"$.result","End":true}}}`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	res := Run(nil, def, &RunInput{
+		Input: `{"detail":{"id":1},"meta":"keep"}`, StartTime: time.Unix(0, 0),
+	})
+
+	if res.Status != "SUCCEEDED" {
+		t.Fatalf("status = %q (%s)", res.Status, res.Cause)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.Output), &out); err != nil {
+		t.Fatalf("output not JSON: %v", err)
+	}
+
+	if out["meta"] != "keep" {
+		t.Fatalf("sibling 'meta' lost: %v", out)
+	}
+}

--- a/providers/aws/sfn/asl/asl_test.go
+++ b/providers/aws/sfn/asl/asl_test.go
@@ -1,6 +1,7 @@
 package asl
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -140,6 +141,8 @@ func TestParseAcceptsAndRejects(t *testing.T) {
 		`{"StartAt":"A","States":{"A":{"Type":"Wait","Seconds":1,"Result":{},"End":true}}}`,
 		`{"StartAt":"Missing","States":{"A":{"Type":"Pass","End":true}}}`,
 		`{"QueryLanguage":"JSONata","StartAt":"A","States":{"A":{"Type":"Pass","End":true}}}`,
+		// Pass does not support ResultSelector (Task/Parallel/Map only).
+		`{"StartAt":"A","States":{"A":{"Type":"Pass","ResultSelector":{"x.$":"$.y"},"End":true}}}`,
 	}
 
 	for _, def := range bad {
@@ -171,5 +174,23 @@ func TestResultPathMergesOntoRaw(t *testing.T) {
 
 	if out["meta"] != "keep" {
 		t.Fatalf("sibling 'meta' lost: %v", out)
+	}
+}
+
+// TestRunHonorsContextCancellation proves the ctx actually reaches the walk loop
+// (if Run discarded it, a cancelled ctx would be unobserved and the run would
+// SUCCEED) — the plumbing the PR2 Task->Lambda recursion guard relies on.
+func TestRunHonorsContextCancellation(t *testing.T) {
+	def, err := Parse(`{"StartAt":"A","States":{"A":{"Type":"Pass","End":true}}}`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	res := Run(ctx, def, &RunInput{Input: `{}`, StartTime: time.Unix(0, 0)})
+	if res.Status != "FAILED" || res.Error != "CloudEmu.ExecutionCanceled" {
+		t.Fatalf("cancelled run: status=%q error=%q, want FAILED/CloudEmu.ExecutionCanceled", res.Status, res.Error)
 	}
 }

--- a/providers/aws/sfn/asl/choice.go
+++ b/providers/aws/sfn/asl/choice.go
@@ -1,0 +1,244 @@
+package asl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ChoiceRule is one rule in a Choice state: either a leaf comparator (Variable +
+// one operator in ops) or a logical combinator (And/Or/Not). A top-level rule
+// also carries Next.
+type ChoiceRule struct {
+	Variable string
+	Next     string
+	And      []*ChoiceRule
+	Or       []*ChoiceRule
+	Not      *ChoiceRule
+	ops      map[string]json.RawMessage
+}
+
+// reservedRuleKeys are the ChoiceRule fields that are not comparator operators.
+func reservedRuleKey(k string) bool {
+	return inList(k, "Variable", "Next", "And", "Or", "Not", "Comment")
+}
+
+// UnmarshalJSON separates the structural fields from the (single) comparator
+// operator, which is kept in ops for family dispatch.
+func (r *ChoiceRule) UnmarshalJSON(b []byte) error {
+	var known struct {
+		Variable string
+		Next     string
+		And      []*ChoiceRule
+		Or       []*ChoiceRule
+		Not      *ChoiceRule
+	}
+
+	if err := json.Unmarshal(b, &known); err != nil {
+		return err
+	}
+
+	r.Variable, r.Next, r.And, r.Or, r.Not = known.Variable, known.Next, known.And, known.Or, known.Not
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+
+	r.ops = make(map[string]json.RawMessage)
+
+	for k, v := range raw {
+		if !reservedRuleKey(k) {
+			r.ops[k] = v
+		}
+	}
+
+	return nil
+}
+
+// choiceHandler runs a Choice state: it evaluates each rule against the
+// InputPath-filtered input, transitioning to the first match's Next (or Default),
+// and fails with States.NoChoiceMatched when nothing matches and no Default is set.
+func choiceHandler(_ context.Context, it *interp, st *State, raw any) (out any, next string, terminal bool, err error) {
+	it.enterState(st, raw)
+
+	in, err := it.applyInputPath(st, raw)
+	if err != nil {
+		return nil, "", false, err
+	}
+
+	for _, rule := range st.Choices {
+		match, err := it.evalRule(rule, in)
+		if err != nil {
+			return nil, "", false, err
+		}
+
+		if match {
+			return it.choiceExit(st, in, rule.Next)
+		}
+	}
+
+	if st.Default != "" {
+		return it.choiceExit(st, in, st.Default)
+	}
+
+	return nil, "", false, &stateError{Code: "States.NoChoiceMatched",
+		Cause: fmt.Sprintf("no choice rule matched in state %q and no Default was specified", st.name)}
+}
+
+func (it *interp) choiceExit(st *State, in any, next string) (out any, nextState string, terminal bool, err error) {
+	out, err = it.applyOutputPath(st, in)
+	if err != nil {
+		return nil, "", false, err
+	}
+
+	it.exitState(st, out)
+
+	return out, next, false, nil
+}
+
+// evalRule evaluates a choice rule (leaf comparator or And/Or/Not combinator).
+func (it *interp) evalRule(rule *ChoiceRule, input any) (bool, error) {
+	switch {
+	case rule.Not != nil:
+		m, err := it.evalRule(rule.Not, input)
+
+		return !m, err
+	case len(rule.And) > 0:
+		return it.evalAll(rule.And, input)
+	case len(rule.Or) > 0:
+		return it.evalAny(rule.Or, input)
+	}
+
+	var op string
+
+	var operand json.RawMessage
+
+	for k, v := range rule.ops {
+		op, operand = k, v
+	}
+
+	return it.evalLeaf(rule.Variable, op, operand, input)
+}
+
+// evalLeaf resolves the variable and dispatches to the comparator family. An
+// absent variable is a non-match for value comparators; type-check comparators
+// handle absence themselves.
+func (it *interp) evalLeaf(varPath, op string, operand json.RawMessage, input any) (bool, error) {
+	val, present, err := it.resolvePath(varPath, input)
+	if err != nil {
+		return false, err
+	}
+
+	if comparatorFamily(op) == famTypeCheck {
+		return evalTypeCheck(op, operand, val, present)
+	}
+
+	if !present {
+		return false, nil
+	}
+
+	comparand, err := it.resolveComparand(op, operand, input)
+	if err != nil {
+		return false, err
+	}
+
+	return dispatchComparator(op, val, comparand)
+}
+
+func dispatchComparator(op string, val, comparand any) (bool, error) {
+	switch comparatorFamily(op) {
+	case famString:
+		return evalString(op, val, comparand), nil
+	case famNumeric:
+		return evalNumeric(op, val, comparand), nil
+	case famBoolean:
+		return evalBoolean(val, comparand), nil
+	case famTimestamp:
+		return evalTimestamp(op, val, comparand), nil
+	default:
+		return false, aslErrf("unknown comparator %q", op)
+	}
+}
+
+// resolveComparand yields the value a comparator compares against: a ...Path
+// operator resolves a JSONPath against the input; otherwise the operand is a
+// literal JSON value.
+func (it *interp) resolveComparand(op string, operand json.RawMessage, input any) (any, error) {
+	if strings.HasSuffix(op, "Path") {
+		var p string
+		if err := json.Unmarshal(operand, &p); err != nil {
+			return nil, err
+		}
+
+		v, present, err := it.resolvePath(p, input)
+		if err != nil {
+			return nil, err
+		}
+
+		if !present {
+			return nil, aslErrf("comparator path %q could not be found", p)
+		}
+
+		return v, nil
+	}
+
+	return rawToValue(operand)
+}
+
+// Comparator families.
+const (
+	famTypeCheck = "typecheck"
+	famString    = "string"
+	famNumeric   = "numeric"
+	famBoolean   = "boolean"
+	famTimestamp = "timestamp"
+)
+
+// comparatorFamily classifies an operator, or returns "" for an unknown one.
+func comparatorFamily(op string) string {
+	switch {
+	case isTypeCheckOp(op):
+		return famTypeCheck
+	case isStringOp(op):
+		return famString
+	case isNumericOp(op):
+		return famNumeric
+	case isBooleanOp(op):
+		return famBoolean
+	case isTimestampOp(op):
+		return famTimestamp
+	default:
+		return ""
+	}
+}
+
+func inList(s string, list ...string) bool {
+	for _, x := range list {
+		if x == s {
+			return true
+		}
+	}
+
+	return false
+}
+
+// orderMatch maps a -1/0/1 comparison result to the operator's ordering
+// semantics. More specific suffixes are checked before their prefixes.
+func orderMatch(cmp int, op string) bool {
+	switch {
+	case strings.Contains(op, "GreaterThanEquals"):
+		return cmp >= 0
+	case strings.Contains(op, "LessThanEquals"):
+		return cmp <= 0
+	case strings.Contains(op, "GreaterThan"):
+		return cmp > 0
+	case strings.Contains(op, "LessThan"):
+		return cmp < 0
+	case strings.Contains(op, "Equals"):
+		return cmp == 0
+	default:
+		return false
+	}
+}

--- a/providers/aws/sfn/asl/choice_bool.go
+++ b/providers/aws/sfn/asl/choice_bool.go
@@ -1,0 +1,21 @@
+package asl
+
+func isBooleanOp(op string) bool {
+	return op == "BooleanEquals" || op == "BooleanEqualsPath"
+}
+
+// evalBoolean evaluates BooleanEquals/BooleanEqualsPath. A non-boolean value or
+// comparand is a non-match.
+func evalBoolean(val, comparand any) bool {
+	a, ok := val.(bool)
+	if !ok {
+		return false
+	}
+
+	b, ok := comparand.(bool)
+	if !ok {
+		return false
+	}
+
+	return a == b
+}

--- a/providers/aws/sfn/asl/choice_logic.go
+++ b/providers/aws/sfn/asl/choice_logic.go
@@ -1,0 +1,33 @@
+package asl
+
+// evalAll reports whether every sub-rule matches (And).
+func (it *interp) evalAll(rules []*ChoiceRule, input any) (bool, error) {
+	for _, r := range rules {
+		m, err := it.evalRule(r, input)
+		if err != nil {
+			return false, err
+		}
+
+		if !m {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// evalAny reports whether any sub-rule matches (Or).
+func (it *interp) evalAny(rules []*ChoiceRule, input any) (bool, error) {
+	for _, r := range rules {
+		m, err := it.evalRule(r, input)
+		if err != nil {
+			return false, err
+		}
+
+		if m {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/providers/aws/sfn/asl/choice_numeric.go
+++ b/providers/aws/sfn/asl/choice_numeric.go
@@ -1,0 +1,51 @@
+package asl
+
+import "strings"
+
+func isNumericOp(op string) bool {
+	base := strings.TrimSuffix(op, "Path")
+
+	return inList(base, "NumericEquals", "NumericLessThan", "NumericGreaterThan",
+		"NumericLessThanEquals", "NumericGreaterThanEquals")
+}
+
+// evalNumeric evaluates the numeric comparator family. A non-numeric value or
+// comparand is a non-match.
+func evalNumeric(op string, val, comparand any) bool {
+	a, ok := toFloat(val)
+	if !ok {
+		return false
+	}
+
+	b, ok := toFloat(comparand)
+	if !ok {
+		return false
+	}
+
+	return orderMatch(cmpFloat(a, b), op)
+}
+
+// toFloat converts a JSON-decoded numeric value to float64.
+func toFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
+func cmpFloat(a, b float64) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/providers/aws/sfn/asl/choice_string.go
+++ b/providers/aws/sfn/asl/choice_string.go
@@ -1,0 +1,90 @@
+package asl
+
+import "strings"
+
+func isStringOp(op string) bool {
+	if op == opStringMatches {
+		return true
+	}
+
+	base := strings.TrimSuffix(op, "Path")
+
+	return inList(base, "StringEquals", "StringLessThan", "StringGreaterThan",
+		"StringLessThanEquals", "StringGreaterThanEquals")
+}
+
+// evalString evaluates the string comparator family. StringMatches applies a
+// glob-style pattern; the others are lexicographic comparisons. A type mismatch
+// is a non-match.
+func evalString(op string, val, comparand any) bool {
+	s, ok := val.(string)
+	if !ok {
+		return false
+	}
+
+	c, ok := comparand.(string)
+	if !ok {
+		return false
+	}
+
+	if op == opStringMatches {
+		return globMatch(c, s)
+	}
+
+	return orderMatch(strings.Compare(s, c), op)
+}
+
+// globMatch reports whether s matches an ASL StringMatches pattern, where '*'
+// matches any (possibly empty) sequence and '\' escapes the next character. It
+// works by splitting the pattern into the literal segments between stars and
+// matching them in order.
+func globMatch(pattern, s string) bool {
+	parts := splitOnStar(pattern)
+	if len(parts) == 1 {
+		return parts[0] == s
+	}
+
+	if !strings.HasPrefix(s, parts[0]) {
+		return false
+	}
+
+	rem := s[len(parts[0]):]
+	last := len(parts) - 1
+
+	for i := 1; i < last; i++ {
+		idx := strings.Index(rem, parts[i])
+		if idx < 0 {
+			return false
+		}
+
+		rem = rem[idx+len(parts[i]):]
+	}
+
+	return strings.HasSuffix(rem, parts[last])
+}
+
+// splitOnStar splits a pattern into the literal segments delimited by unescaped
+// '*' characters, honoring '\' escapes.
+func splitOnStar(pattern string) []string {
+	var (
+		parts []string
+		cur   strings.Builder
+	)
+
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+
+		switch {
+		case c == '\\' && i+1 < len(pattern):
+			i++
+			cur.WriteByte(pattern[i])
+		case c == '*':
+			parts = append(parts, cur.String())
+			cur.Reset()
+		default:
+			cur.WriteByte(c)
+		}
+	}
+
+	return append(parts, cur.String())
+}

--- a/providers/aws/sfn/asl/choice_timestamp.go
+++ b/providers/aws/sfn/asl/choice_timestamp.go
@@ -1,0 +1,60 @@
+package asl
+
+import (
+	"strings"
+	"time"
+)
+
+func isTimestampOp(op string) bool {
+	base := strings.TrimSuffix(op, "Path")
+
+	return inList(base, "TimestampEquals", "TimestampLessThan", "TimestampGreaterThan",
+		"TimestampLessThanEquals", "TimestampGreaterThanEquals")
+}
+
+// evalTimestamp evaluates the timestamp comparator family, parsing both operands
+// as RFC 3339. A value that is not a valid timestamp string is a non-match.
+func evalTimestamp(op string, val, comparand any) bool {
+	a, ok := toTime(val)
+	if !ok {
+		return false
+	}
+
+	b, ok := toTime(comparand)
+	if !ok {
+		return false
+	}
+
+	return orderMatch(cmpTime(a, b), op)
+}
+
+func toTime(v any) (time.Time, bool) {
+	s, ok := v.(string)
+	if !ok {
+		return time.Time{}, false
+	}
+
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	return t, true
+}
+
+func isTimestamp(s string) bool {
+	_, err := time.Parse(time.RFC3339, s)
+
+	return err == nil
+}
+
+func cmpTime(a, b time.Time) int {
+	switch {
+	case a.Before(b):
+		return -1
+	case a.After(b):
+		return 1
+	default:
+		return 0
+	}
+}

--- a/providers/aws/sfn/asl/choice_typecheck.go
+++ b/providers/aws/sfn/asl/choice_typecheck.go
@@ -1,0 +1,46 @@
+package asl
+
+import "encoding/json"
+
+func isTypeCheckOp(op string) bool {
+	return inList(op, "IsNull", "IsPresent", "IsNumeric", "IsString", "IsBoolean", "IsTimestamp")
+}
+
+// evalTypeCheck evaluates the Is* comparators, whose operand is a boolean: the
+// rule matches when the actual type-check result equals the requested boolean.
+// These comparators handle an absent variable themselves.
+func evalTypeCheck(op string, operand json.RawMessage, val any, present bool) (bool, error) {
+	var want bool
+	if err := json.Unmarshal(operand, &want); err != nil {
+		return false, err
+	}
+
+	return typeCheckResult(op, val, present) == want, nil
+}
+
+func typeCheckResult(op string, val any, present bool) bool {
+	switch op {
+	case "IsPresent":
+		return present
+	case "IsNull":
+		return present && val == nil
+	case "IsString":
+		_, ok := val.(string)
+
+		return ok
+	case "IsBoolean":
+		_, ok := val.(bool)
+
+		return ok
+	case "IsNumeric":
+		_, ok := toFloat(val)
+
+		return ok
+	case "IsTimestamp":
+		s, ok := val.(string)
+
+		return ok && isTimestamp(s)
+	default:
+		return false
+	}
+}

--- a/providers/aws/sfn/asl/context.go
+++ b/providers/aws/sfn/asl/context.go
@@ -1,0 +1,97 @@
+package asl
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// applyPayloadTemplate resolves a Parameters/ResultSelector payload template
+// against input: object keys ending in ".$" take a JSONPath ("$"/"$$") or an
+// intrinsic string and are rewritten to the stripped key with the resolved
+// value; all other values are passed through (recursing into objects/arrays).
+func (it *interp) applyPayloadTemplate(tmpl json.RawMessage, input any) (any, error) {
+	var node any
+	if err := json.Unmarshal(tmpl, &node); err != nil {
+		return nil, err
+	}
+
+	return it.resolveTemplateNode(node, input)
+}
+
+func (it *interp) resolveTemplateNode(node, input any) (any, error) {
+	switch n := node.(type) {
+	case map[string]any:
+		return it.resolveTemplateMap(n, input)
+	case []any:
+		out := make([]any, len(n))
+
+		for i, v := range n {
+			rv, err := it.resolveTemplateNode(v, input)
+			if err != nil {
+				return nil, err
+			}
+
+			out[i] = rv
+		}
+
+		return out, nil
+	default:
+		return node, nil
+	}
+}
+
+func (it *interp) resolveTemplateMap(n map[string]any, input any) (any, error) {
+	out := make(map[string]any, len(n))
+
+	for k, v := range n {
+		if !strings.HasSuffix(k, ".$") {
+			rv, err := it.resolveTemplateNode(v, input)
+			if err != nil {
+				return nil, err
+			}
+
+			out[k] = rv
+
+			continue
+		}
+
+		s, ok := v.(string)
+		if !ok {
+			return nil, aslErrf("payload template field %q must be a string", k)
+		}
+
+		rv, err := it.resolveTemplateString(s, input)
+		if err != nil {
+			return nil, err
+		}
+
+		out[strings.TrimSuffix(k, ".$")] = rv
+	}
+
+	return out, nil
+}
+
+// resolveTemplateString resolves a ".$" template value: an intrinsic invocation
+// (States.*), or a JSONPath against the input ($) or context object ($$).
+func (it *interp) resolveTemplateString(s string, input any) (any, error) {
+	if strings.HasPrefix(s, "States.") {
+		return it.evalIntrinsic(s, input)
+	}
+
+	if strings.HasPrefix(s, "$") {
+		v, present, err := it.resolvePath(s, input)
+		if err != nil {
+			return nil, err
+		}
+
+		if !present {
+			return nil, &stateError{Code: "States.ParameterPathFailure",
+				Cause: fmt.Sprintf("payload template path %q could not be found", s)}
+		}
+
+		return v, nil
+	}
+
+	return nil, aslErrf("payload template value %q must be a JSONPath or an intrinsic", s)
+}

--- a/providers/aws/sfn/asl/errors.go
+++ b/providers/aws/sfn/asl/errors.go
@@ -1,0 +1,17 @@
+package asl
+
+import cerrors "github.com/stackshy/cloudemu/v2/errors"
+
+// Query-language and payload literals shared across the parser and interpreter.
+const (
+	queryLangJSONata = "JSONata"
+	emptyObject      = "{}"
+	opStringMatches  = "StringMatches"
+)
+
+// aslErrf builds a definition/parse error carrying the canonical
+// InvalidArgument code. Callers at the sfn layer surface it as an
+// InvalidDefinition-shaped API error via err.Error().
+func aslErrf(format string, args ...any) error {
+	return cerrors.Newf(cerrors.InvalidArgument, format, args...)
+}

--- a/providers/aws/sfn/asl/fail.go
+++ b/providers/aws/sfn/asl/fail.go
@@ -1,0 +1,12 @@
+package asl
+
+import "context"
+
+// failHandler runs a Fail state: it emits a FailStateEntered event (terminal, so
+// no exit) and returns a stateError carrying the state's Error/Cause, which the
+// walker records as ExecutionFailed.
+func failHandler(_ context.Context, it *interp, st *State, _ any) (out any, next string, terminal bool, err error) {
+	it.emit(historyFail(st))
+
+	return nil, "", false, &stateError{Code: st.Error, Cause: st.Cause}
+}

--- a/providers/aws/sfn/asl/history.go
+++ b/providers/aws/sfn/asl/history.go
@@ -1,0 +1,25 @@
+package asl
+
+import "github.com/stackshy/cloudemu/v2/services/sfn/driver"
+
+// The event history is accumulated by interp.emit (interpret.go), which assigns
+// the monotonic ID, chains PreviousEventID, and stamps the virtual timestamp.
+// The event set for this build is:
+//
+//	ExecutionStarted
+//	<Type>StateEntered / <Type>StateExited   (Pass, Choice, Wait, Succeed)
+//	FailStateEntered                          (Fail — terminal, no exit)
+//	ExecutionSucceeded / ExecutionFailed
+//
+// Richer AWS sub-events (LambdaFunction*, MapIteration*, evaluation events) are
+// out of scope until the Task/Parallel/Map handlers land.
+
+// historyFail builds the FailStateEntered event for a Fail state.
+func historyFail(st *State) *driver.HistoryEvent {
+	return &driver.HistoryEvent{
+		Type:      "FailStateEntered",
+		StateName: st.name,
+		Error:     st.Error,
+		Cause:     st.Cause,
+	}
+}

--- a/providers/aws/sfn/asl/interpret.go
+++ b/providers/aws/sfn/asl/interpret.go
@@ -81,7 +81,11 @@ type interp struct {
 // Run interprets def against the execution input, returning the terminal status,
 // output (or error/cause), the full event history, and the accumulated Wait
 // duration (used to extend the settle window under AsyncSettle).
-func Run(_ context.Context, def *StateMachineDef, in *RunInput) *RunResult {
+func Run(ctx context.Context, def *StateMachineDef, in *RunInput) *RunResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	maxSteps := in.MaxSteps
 	if maxSteps <= 0 {
 		maxSteps = defaultMaxSteps
@@ -103,7 +107,7 @@ func Run(_ context.Context, def *StateMachineDef, in *RunInput) *RunResult {
 	it.emit(&driver.HistoryEvent{Type: "ExecutionStarted", Timestamp: in.StartTime, Input: emptyOr(in.Input)})
 	it.offset = in.SettleBase
 
-	res := it.walk(context.Background(), input)
+	res := it.walk(ctx, input)
 	res.History = it.hist
 	res.WaitTotal = it.waitTotal
 
@@ -130,6 +134,12 @@ func (it *interp) walk(ctx context.Context, input any) *RunResult {
 	raw := input
 
 	for {
+		// Honor cancellation of the calling request (the ctx is also what the
+		// PR2 Task->Lambda recursion guard rides on).
+		if err := ctx.Err(); err != nil {
+			return it.fail("CloudEmu.ExecutionCanceled", err.Error())
+		}
+
 		it.steps++
 		if it.steps > it.maxSteps {
 			return it.fail("CloudEmu.StateTransitionLimitExceeded",

--- a/providers/aws/sfn/asl/interpret.go
+++ b/providers/aws/sfn/asl/interpret.go
@@ -1,0 +1,255 @@
+package asl
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
+)
+
+// defaultMaxSteps bounds the number of state transitions a single execution may
+// make, so a Choice/Next cycle fails loudly instead of spinning forever.
+const defaultMaxSteps = 10000
+
+// handler evaluates one state. It returns the state's effective output, the name
+// of the next state (empty when terminal), whether the execution terminates
+// here (SUCCEEDED), or an error (mapped to ExecutionFailed). Each handler emits
+// its own <Type>StateEntered/<Type>StateExited events; the walker emits the
+// terminal ExecutionSucceeded/ExecutionFailed.
+type handler func(ctx context.Context, it *interp, st *State, raw any) (out any, next string, terminal bool, err error)
+
+// stateError is a run-time failure carrying the ASL error code and cause that
+// surface on the ExecutionFailed event and the execution's Error/Cause.
+type stateError struct {
+	Code  string
+	Cause string
+}
+
+func (e *stateError) Error() string { return e.Code + ": " + e.Cause }
+
+// asStateError extracts a *stateError from err, mapping any other error to a
+// generic States.Runtime failure.
+func asStateError(err error) *stateError {
+	var se *stateError
+	if stderrors.As(err, &se) {
+		return se
+	}
+
+	return &stateError{Code: "States.Runtime", Cause: err.Error()}
+}
+
+// RunInput carries the per-execution context the interpreter needs.
+type RunInput struct {
+	Input      string
+	ExecArn    string
+	ExecName   string
+	SMArn      string
+	SMName     string
+	RoleArn    string
+	StartTime  time.Time
+	SettleBase time.Duration
+	MaxSteps   int
+}
+
+// RunResult is the outcome of interpreting a definition against an input.
+type RunResult struct {
+	Status    string
+	Output    string
+	Error     string
+	Cause     string
+	History   []driver.HistoryEvent
+	WaitTotal time.Duration
+}
+
+type interp struct {
+	def       *StateMachineDef
+	baseTime  time.Time
+	offset    time.Duration
+	waitTotal time.Duration
+	steps     int
+	maxSteps  int
+	hist      []driver.HistoryEvent
+	lastID    int64
+	ctxObj    map[string]any
+	handlers  map[string]handler
+}
+
+// Run interprets def against the execution input, returning the terminal status,
+// output (or error/cause), the full event history, and the accumulated Wait
+// duration (used to extend the settle window under AsyncSettle).
+func Run(_ context.Context, def *StateMachineDef, in *RunInput) *RunResult {
+	maxSteps := in.MaxSteps
+	if maxSteps <= 0 {
+		maxSteps = defaultMaxSteps
+	}
+
+	it := &interp{
+		def:      def,
+		baseTime: in.StartTime,
+		maxSteps: maxSteps,
+		handlers: buildHandlers(),
+	}
+
+	input := parseInput(in.Input)
+	it.buildContext(in, input)
+
+	// ExecutionStarted sits at the start instant; subsequent events sit at
+	// baseTime+SettleBase (+Wait offsets), so the settle overlay hides them until
+	// the execution's window elapses.
+	it.emit(&driver.HistoryEvent{Type: "ExecutionStarted", Timestamp: in.StartTime, Input: emptyOr(in.Input)})
+	it.offset = in.SettleBase
+
+	res := it.walk(context.Background(), input)
+	res.History = it.hist
+	res.WaitTotal = it.waitTotal
+
+	return res
+}
+
+func buildHandlers() map[string]handler {
+	return map[string]handler{
+		TypePass:     passHandler,
+		TypeChoice:   choiceHandler,
+		TypeWait:     waitHandler,
+		TypeSucceed:  succeedHandler,
+		TypeFail:     failHandler,
+		TypeTask:     unsupportedHandler,
+		TypeParallel: unsupportedHandler,
+		TypeMap:      unsupportedHandler,
+	}
+}
+
+// walk runs the state graph from StartAt following Next/End until a terminal
+// state, an unrecovered error, or the step guard trips.
+func (it *interp) walk(ctx context.Context, input any) *RunResult {
+	cur := it.def.StartAt
+	raw := input
+
+	for {
+		it.steps++
+		if it.steps > it.maxSteps {
+			return it.fail("CloudEmu.StateTransitionLimitExceeded",
+				fmt.Sprintf("execution exceeded the %d state-transition limit", it.maxSteps))
+		}
+
+		st := it.def.States[cur]
+		it.enterStateContext(st)
+
+		out, next, terminal, err := it.handlers[st.Type](ctx, it, st, raw)
+		if err != nil {
+			se := asStateError(err)
+
+			return it.fail(se.Code, se.Cause)
+		}
+
+		if terminal {
+			return it.succeed(out)
+		}
+
+		raw = out
+		cur = next
+	}
+}
+
+func (it *interp) succeed(out any) *RunResult {
+	s := toJSON(out)
+	it.emit(&driver.HistoryEvent{Type: "ExecutionSucceeded", Output: s})
+
+	return &RunResult{Status: driver.ExecStatusSucceeded, Output: s}
+}
+
+func (it *interp) fail(code, cause string) *RunResult {
+	it.emit(&driver.HistoryEvent{Type: "ExecutionFailed", Error: code, Cause: cause})
+
+	return &RunResult{Status: driver.ExecStatusFailed, Error: code, Cause: cause}
+}
+
+// emit assigns the monotonic ID, chains PreviousEventID, and fills the virtual
+// timestamp (baseTime+offset) when the caller left it zero.
+func (it *interp) emit(ev *driver.HistoryEvent) {
+	it.lastID++
+	ev.ID = it.lastID
+
+	if it.lastID > 1 {
+		ev.PreviousEventID = it.lastID - 1
+	}
+
+	if ev.Timestamp.IsZero() {
+		ev.Timestamp = it.baseTime.Add(it.offset)
+	}
+
+	it.hist = append(it.hist, *ev)
+}
+
+func (it *interp) enterState(st *State, input any) {
+	it.emit(&driver.HistoryEvent{Type: st.Type + "StateEntered", StateName: st.name, Input: toJSON(input)})
+}
+
+func (it *interp) exitState(st *State, output any) {
+	it.emit(&driver.HistoryEvent{Type: st.Type + "StateExited", StateName: st.name, Output: toJSON(output)})
+}
+
+func (it *interp) buildContext(in *RunInput, input any) {
+	it.ctxObj = map[string]any{
+		"Execution": map[string]any{
+			"Id": in.ExecArn, "Input": input, "Name": in.ExecName,
+			"RoleArn": in.RoleArn, "StartTime": in.StartTime.UTC().Format(time.RFC3339),
+		},
+		"State":        map[string]any{"Name": "", "EnteredTime": ""},
+		"StateMachine": map[string]any{"Id": in.SMArn, "Name": in.SMName},
+	}
+}
+
+func (it *interp) enterStateContext(st *State) {
+	sc, _ := it.ctxObj["State"].(map[string]any)
+	if sc == nil {
+		return
+	}
+
+	sc["Name"] = st.name
+	sc["EnteredTime"] = it.baseTime.Add(it.offset).UTC().Format(time.RFC3339)
+}
+
+// resolvePath evaluates a JSONPath against the state input, or against the $$
+// context object when the path is $$-prefixed.
+func (it *interp) resolvePath(path string, input any) (value any, present bool, err error) {
+	if strings.HasPrefix(path, "$$") {
+		return evalPath("$"+path[2:], it.ctxObj)
+	}
+
+	return evalPath(path, input)
+}
+
+func parseInput(s string) any {
+	if strings.TrimSpace(s) == "" {
+		return map[string]any{}
+	}
+
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		return map[string]any{}
+	}
+
+	return v
+}
+
+func emptyOr(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return emptyObject
+	}
+
+	return s
+}
+
+func toJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return emptyObject
+	}
+
+	return string(b)
+}

--- a/providers/aws/sfn/asl/intrinsics.go
+++ b/providers/aws/sfn/asl/intrinsics.go
@@ -1,0 +1,228 @@
+package asl
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// evalIntrinsic evaluates a first-wave intrinsic invocation such as
+// States.Format('{}', $.x). Supported: Format, Array, ArrayGetItem, StringToJson,
+// JsonToString, UUID. Unsupported intrinsics fail loudly.
+func (it *interp) evalIntrinsic(expr string, input any) (any, error) {
+	name, argsStr, err := splitIntrinsic(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	args, err := it.evalArgs(argsStr, input)
+	if err != nil {
+		return nil, err
+	}
+
+	switch name {
+	case "States.Format":
+		return intrinsicFormat(args)
+	case "States.Array":
+		return args, nil
+	case "States.ArrayGetItem":
+		return intrinsicArrayGetItem(args)
+	case "States.StringToJson":
+		return intrinsicStringToJSON(args)
+	case "States.JsonToString":
+		return intrinsicJSONToString(args)
+	case "States.UUID":
+		return newUUID(), nil
+	default:
+		return nil, aslErrf("unsupported intrinsic function %q", name)
+	}
+}
+
+// splitIntrinsic separates "States.Func(args...)" into its name and argument
+// string.
+func splitIntrinsic(expr string) (name, args string, err error) {
+	open := strings.IndexByte(expr, '(')
+	if open < 0 || !strings.HasSuffix(expr, ")") {
+		return "", "", aslErrf("malformed intrinsic %q", expr)
+	}
+
+	return expr[:open], expr[open+1 : len(expr)-1], nil
+}
+
+// evalArgs splits the top-level, comma-separated arguments and evaluates each.
+func (it *interp) evalArgs(argsStr string, input any) ([]any, error) {
+	toks := splitArgs(argsStr)
+
+	args := make([]any, 0, len(toks))
+
+	for _, tok := range toks {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+
+		v, err := it.evalArg(tok, input)
+		if err != nil {
+			return nil, err
+		}
+
+		args = append(args, v)
+	}
+
+	return args, nil
+}
+
+func (it *interp) evalArg(tok string, input any) (any, error) {
+	switch {
+	case strings.HasPrefix(tok, "States."):
+		return it.evalIntrinsic(tok, input)
+	case strings.HasPrefix(tok, "$"):
+		v, present, err := it.resolvePath(tok, input)
+		if err != nil {
+			return nil, err
+		}
+
+		if !present {
+			return nil, aslErrf("intrinsic argument path %q not found", tok)
+		}
+
+		return v, nil
+	case strings.HasPrefix(tok, "'"):
+		return unquoteIntrinsic(tok), nil
+	default:
+		var v any
+		if err := json.Unmarshal([]byte(tok), &v); err != nil {
+			return nil, aslErrf("invalid intrinsic argument %q", tok)
+		}
+
+		return v, nil
+	}
+}
+
+// splitArgs splits an argument list on top-level commas, respecting single
+// quotes and nested parentheses.
+func splitArgs(s string) []string {
+	var (
+		out   []string
+		depth int
+		inStr bool
+		start int
+	)
+
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case c == '\\' && inStr:
+			i++
+		case c == '\'':
+			inStr = !inStr
+		case inStr:
+		case c == '(':
+			depth++
+		case c == ')':
+			depth--
+		case c == ',' && depth == 0:
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+
+	return append(out, s[start:])
+}
+
+func unquoteIntrinsic(tok string) string {
+	tok = strings.TrimPrefix(tok, "'")
+	tok = strings.TrimSuffix(tok, "'")
+	tok = strings.ReplaceAll(tok, "\\'", "'")
+
+	return strings.ReplaceAll(tok, "\\\\", "\\")
+}
+
+func intrinsicFormat(args []any) (any, error) {
+	if len(args) == 0 {
+		return nil, aslErrf("States.Format requires a template string")
+	}
+
+	tmpl, ok := args[0].(string)
+	if !ok {
+		return nil, aslErrf("States.Format template must be a string")
+	}
+
+	out := tmpl
+
+	for _, a := range args[1:] {
+		out = strings.Replace(out, emptyObject, stringify(a), 1)
+	}
+
+	return out, nil
+}
+
+// arrayGetItemArgc is the argument count States.ArrayGetItem(array, index) takes.
+const arrayGetItemArgc = 2
+
+func intrinsicArrayGetItem(args []any) (any, error) {
+	if len(args) != arrayGetItemArgc {
+		return nil, aslErrf("States.ArrayGetItem requires an array and an index")
+	}
+
+	arr, ok := args[0].([]any)
+	idx, okIdx := toFloat(args[1])
+
+	if !ok || !okIdx || int(idx) < 0 || int(idx) >= len(arr) {
+		return nil, aslErrf("States.ArrayGetItem index out of range")
+	}
+
+	return arr[int(idx)], nil
+}
+
+func intrinsicStringToJSON(args []any) (any, error) {
+	if len(args) != 1 {
+		return nil, aslErrf("States.StringToJson requires one string argument")
+	}
+
+	s, ok := args[0].(string)
+	if !ok {
+		return nil, aslErrf("States.StringToJson argument must be a string")
+	}
+
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		return nil, fmt.Errorf("States.StringToJson: %w", err)
+	}
+
+	return v, nil
+}
+
+func intrinsicJSONToString(args []any) (any, error) {
+	if len(args) != 1 {
+		return nil, aslErrf("States.JsonToString requires one argument")
+	}
+
+	b, err := json.Marshal(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("States.JsonToString: %w", err)
+	}
+
+	return string(b), nil
+}
+
+// stringify renders an intrinsic argument for States.Format substitution.
+func stringify(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	default:
+		return toJSON(v)
+	}
+}
+
+// newUUID returns a random RFC 4122 version-4 UUID. It is non-deterministic,
+// which is why interpreter output/history is persisted rather than recomputed.
+func newUUID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}

--- a/providers/aws/sfn/asl/io.go
+++ b/providers/aws/sfn/asl/io.go
@@ -1,0 +1,181 @@
+package asl
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// The I/O pipeline stages, applied per state only where ASL permits:
+//
+//	raw -> InputPath -> Parameters -> [work -> Result] -> ResultSelector -> ResultPath -> OutputPath
+//
+// ResultPath's merge base is the RAW input handed to the state (before
+// InputPath), so InputPath-narrow + ResultPath-reattach preserves the sibling
+// fields InputPath excluded.
+
+// applyInputPath selects the sub-document a state operates on. Absent InputPath
+// means the whole input ("$"); an explicit null yields an empty object.
+func (it *interp) applyInputPath(st *State, raw any) (any, error) {
+	if !st.InputPath.set {
+		return raw, nil
+	}
+
+	if st.InputPath.null {
+		return map[string]any{}, nil
+	}
+
+	v, present, err := it.resolvePath(st.InputPath.path, raw)
+	if err != nil {
+		return nil, err
+	}
+
+	if !present {
+		return nil, &stateError{Code: "States.ParameterPathFailure",
+			Cause: fmt.Sprintf("InputPath %q could not be found in the input", st.InputPath.path)}
+	}
+
+	return v, nil
+}
+
+// applyParameters resolves the Parameters payload template against the filtered
+// input, producing the payload the state work receives.
+func (it *interp) applyParameters(st *State, input any) (any, error) {
+	if st.Parameters == nil {
+		return input, nil
+	}
+
+	return it.applyPayloadTemplate(st.Parameters, input)
+}
+
+// applyResultPath merges the result onto the RAW input. Absent ResultPath
+// defaults to "$" (the result replaces the document); an explicit null discards
+// the result and passes the raw input through; a path splices the result in.
+func (*interp) applyResultPath(st *State, raw, result any) (any, error) {
+	if !st.ResultPath.set || st.ResultPath.path == "$" {
+		return result, nil
+	}
+
+	if st.ResultPath.null {
+		return raw, nil
+	}
+
+	fields, err := objectFieldPath(st.ResultPath.path)
+	if err != nil {
+		return nil, err
+	}
+
+	return spliceFields(deepCopy(raw), fields, result), nil
+}
+
+// applyOutputPath selects the effective output. Absent OutputPath means the
+// whole document ("$"); an explicit null yields an empty object.
+func (it *interp) applyOutputPath(st *State, doc any) (any, error) {
+	if !st.OutputPath.set {
+		return doc, nil
+	}
+
+	if st.OutputPath.null {
+		return map[string]any{}, nil
+	}
+
+	v, present, err := it.resolvePath(st.OutputPath.path, doc)
+	if err != nil {
+		return nil, err
+	}
+
+	if !present {
+		return nil, &stateError{Code: "States.OutputMatchFailure",
+			Cause: fmt.Sprintf("OutputPath %q could not be found in the output", st.OutputPath.path)}
+	}
+
+	return v, nil
+}
+
+// passThroughOutput is the output pipeline for states with no result to merge
+// (Choice, Wait, Succeed): the effective output is OutputPath applied to the
+// InputPath-filtered input.
+func (it *interp) passThroughOutput(st *State, raw any) (any, error) {
+	in, err := it.applyInputPath(st, raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return it.applyOutputPath(st, in)
+}
+
+// objectFieldPath parses a ResultPath into its object field names. Only the
+// reference subset "$.a.b" is supported; an index or unsupported syntax is a
+// loud States.ResultPathMatchFailure rather than a wrong silent merge.
+func objectFieldPath(path string) ([]string, error) {
+	if !strings.HasPrefix(path, "$") {
+		return nil, &stateError{Code: "States.ResultPathMatchFailure",
+			Cause: fmt.Sprintf("ResultPath %q is not a valid reference path", path)}
+	}
+
+	rest := strings.TrimPrefix(path, "$")
+	rest = strings.TrimPrefix(rest, ".")
+
+	if rest == "" {
+		return nil, nil
+	}
+
+	fields := strings.Split(rest, ".")
+	for _, f := range fields {
+		if f == "" || strings.ContainsAny(f, "[]*?@") {
+			return nil, &stateError{Code: "States.ResultPathMatchFailure",
+				Cause: fmt.Sprintf("ResultPath %q uses unsupported syntax", path)}
+		}
+	}
+
+	return fields, nil
+}
+
+// spliceFields returns doc with result set at the nested object path fields,
+// creating intermediate objects as needed.
+func spliceFields(doc any, fields []string, result any) any {
+	if len(fields) == 0 {
+		return result
+	}
+
+	m, ok := doc.(map[string]any)
+	if !ok {
+		m = map[string]any{}
+	}
+
+	m[fields[0]] = spliceFields(m[fields[0]], fields[1:], result)
+
+	return m
+}
+
+// deepCopy clones a JSON value so a ResultPath merge never mutates the raw input.
+func deepCopy(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			out[k] = deepCopy(val)
+		}
+
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, val := range t {
+			out[i] = deepCopy(val)
+		}
+
+		return out
+	default:
+		return v
+	}
+}
+
+// jsonNumberOrValue unmarshals a raw JSON value into a Go value.
+func rawToValue(raw json.RawMessage) (any, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}

--- a/providers/aws/sfn/asl/jsonpath.go
+++ b/providers/aws/sfn/asl/jsonpath.go
@@ -1,0 +1,140 @@
+package asl
+
+import (
+	"strconv"
+	"strings"
+)
+
+// evalPath evaluates a JSONPath reference against root, returning the selected
+// value and whether it was present. Only the reference/selection subset is
+// supported: "$", "$.a.b", "$[0]", "$.a.b[2]". Filters, wildcards and recursive
+// descent are rejected with an error so an unsupported path fails loudly rather
+// than returning a wrong silent result.
+func evalPath(path string, root any) (value any, present bool, err error) {
+	if path == "" || path[0] != '$' {
+		return nil, false, aslErrf("invalid JSONPath %q: must start with '$'", path)
+	}
+
+	if rerr := rejectUnsupportedPath(path); rerr != nil {
+		return nil, false, rerr
+	}
+
+	if path == "$" {
+		return root, true, nil
+	}
+
+	toks, terr := tokenizePath(path[1:])
+	if terr != nil {
+		return nil, false, terr
+	}
+
+	cur := root
+
+	for _, t := range toks {
+		next, ok := t.apply(cur)
+		if !ok {
+			return nil, false, nil
+		}
+
+		cur = next
+	}
+
+	return cur, true, nil
+}
+
+func rejectUnsupportedPath(path string) error {
+	if strings.ContainsAny(path, "*?@") || strings.Contains(path, "..") {
+		return aslErrf("JSONPath %q uses unsupported syntax (filters/wildcards/recursive descent)", path)
+	}
+
+	return nil
+}
+
+// pathToken is one selection step: a map field or a slice index.
+type pathToken struct {
+	field   string
+	index   int
+	isIndex bool
+}
+
+func (t pathToken) apply(cur any) (any, bool) {
+	if t.isIndex {
+		arr, ok := cur.([]any)
+		if !ok || t.index < 0 || t.index >= len(arr) {
+			return nil, false
+		}
+
+		return arr[t.index], true
+	}
+
+	m, ok := cur.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+
+	v, ok := m[t.field]
+
+	return v, ok
+}
+
+// tokenizePath splits the portion of a path after the leading '$' into tokens.
+func tokenizePath(s string) ([]pathToken, error) {
+	var toks []pathToken
+
+	for s != "" {
+		switch s[0] {
+		case '.':
+			field, rest := scanField(s[1:])
+			if field == "" {
+				return nil, aslErrf("empty field name in JSONPath")
+			}
+
+			toks = append(toks, pathToken{field: field})
+			s = rest
+		case '[':
+			tok, rest, err := scanBracket(s)
+			if err != nil {
+				return nil, err
+			}
+
+			toks = append(toks, tok)
+			s = rest
+		default:
+			return nil, aslErrf("unexpected character %q in JSONPath", s[0])
+		}
+	}
+
+	return toks, nil
+}
+
+// scanField reads a dotted field name up to the next '.' or '['.
+func scanField(s string) (field, rest string) {
+	i := strings.IndexAny(s, ".[")
+	if i < 0 {
+		return s, ""
+	}
+
+	return s[:i], s[i:]
+}
+
+// scanBracket reads a "[...]" selector: a numeric index, or a quoted field name.
+func scanBracket(s string) (pathToken, string, error) {
+	end := strings.IndexByte(s, ']')
+	if end < 0 {
+		return pathToken{}, "", aslErrf("unterminated '[' in JSONPath")
+	}
+
+	inner := s[1:end]
+	rest := s[end+1:]
+
+	if len(inner) >= 2 && (inner[0] == '\'' || inner[0] == '"') {
+		return pathToken{field: inner[1 : len(inner)-1]}, rest, nil
+	}
+
+	idx, err := strconv.Atoi(inner)
+	if err != nil {
+		return pathToken{}, "", aslErrf("invalid array index %q in JSONPath", inner)
+	}
+
+	return pathToken{index: idx, isIndex: true}, rest, nil
+}

--- a/providers/aws/sfn/asl/parse.go
+++ b/providers/aws/sfn/asl/parse.go
@@ -1,0 +1,141 @@
+// Package asl is a dependency-free interpreter for a practical subset of the
+// Amazon States Language (ASL). It parses a state-machine definition into typed
+// structs, validates it structurally up front, and walks the state graph from
+// StartAt following Next/End — computing the terminal status/output and a
+// per-state event history. It is driven by config.Clock so Wait timing is
+// deterministic under a FakeClock.
+//
+// Supported in this build: Pass, Choice, Wait, Succeed, Fail; the full
+// InputPath -> Parameters -> Result -> ResultSelector -> ResultPath -> OutputPath
+// I/O pipeline; a reference/selection JSONPath subset; the $$ context object; and
+// a first-wave intrinsic set. Task, Parallel and Map parse (so a definition
+// containing them is accepted at create time) but fail loudly at run time until
+// their handlers land. JSONata query language, and JSONPath filters/wildcards/
+// recursive-descent, are rejected rather than silently mis-run.
+package asl
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// State type names.
+const (
+	TypePass     = "Pass"
+	TypeChoice   = "Choice"
+	TypeWait     = "Wait"
+	TypeSucceed  = "Succeed"
+	TypeFail     = "Fail"
+	TypeTask     = "Task"
+	TypeParallel = "Parallel"
+	TypeMap      = "Map"
+)
+
+// pathField is a three-state ASL path field: absent, explicit JSON null, or a
+// string path. The distinction is load-bearing — e.g. ResultPath absent means
+// "$" (replace), ResultPath:null means "discard the result, pass raw input".
+type pathField struct {
+	set  bool
+	null bool
+	path string
+}
+
+// UnmarshalJSON records presence and distinguishes null from a string value.
+// It is only invoked when the key is present, so set stays false when absent.
+func (p *pathField) UnmarshalJSON(b []byte) error {
+	p.set = true
+	if string(b) == "null" {
+		p.null = true
+
+		return nil
+	}
+
+	return json.Unmarshal(b, &p.path)
+}
+
+// State is one ASL state. Fields not relevant to a given Type are simply unset.
+type State struct {
+	name string // populated from the States map key
+
+	Type           string          `json:"Type"`
+	Comment        string          `json:"Comment"`
+	Next           string          `json:"Next"`
+	End            bool            `json:"End"`
+	QueryLanguage  string          `json:"QueryLanguage"`
+	InputPath      pathField       `json:"InputPath"`
+	OutputPath     pathField       `json:"OutputPath"`
+	Parameters     json.RawMessage `json:"Parameters"`
+	Result         json.RawMessage `json:"Result"`
+	ResultSelector json.RawMessage `json:"ResultSelector"`
+	ResultPath     pathField       `json:"ResultPath"`
+
+	// Choice.
+	Choices []*ChoiceRule `json:"Choices"`
+	Default string        `json:"Default"`
+
+	// Wait.
+	Seconds       *int   `json:"Seconds"`
+	SecondsPath   string `json:"SecondsPath"`
+	Timestamp     string `json:"Timestamp"`
+	TimestampPath string `json:"TimestampPath"`
+
+	// Fail.
+	Error string `json:"Error"`
+	Cause string `json:"Cause"`
+
+	// Task (parsed; handled in a later PR).
+	Resource string `json:"Resource"`
+}
+
+// StateMachineDef is a parsed ASL definition.
+type StateMachineDef struct {
+	Comment       string            `json:"Comment"`
+	StartAt       string            `json:"StartAt"`
+	States        map[string]*State `json:"States"`
+	QueryLanguage string            `json:"QueryLanguage"`
+}
+
+// knownTypes is the set of ASL state types the parser accepts structurally.
+func knownType(t string) bool {
+	switch t {
+	case TypePass, TypeChoice, TypeWait, TypeSucceed, TypeFail, TypeTask, TypeParallel, TypeMap:
+		return true
+	default:
+		return false
+	}
+}
+
+// Parse unmarshals and structurally validates an ASL definition. A returned
+// error carries a human-readable message; callers map it to their own
+// InvalidDefinition-shaped API error.
+func Parse(definition string) (*StateMachineDef, error) {
+	var def StateMachineDef
+	if err := json.Unmarshal([]byte(definition), &def); err != nil {
+		return nil, fmt.Errorf("definition is not valid JSON: %w", err)
+	}
+
+	if def.QueryLanguage == queryLangJSONata {
+		return nil, aslErrf("QueryLanguage %q is not supported (JSONPath only)", def.QueryLanguage)
+	}
+
+	if def.StartAt == "" {
+		return nil, aslErrf("definition is missing the required top-level 'StartAt' field")
+	}
+
+	if len(def.States) == 0 {
+		return nil, aslErrf("definition is missing the required top-level 'States' object")
+	}
+
+	if _, ok := def.States[def.StartAt]; !ok {
+		return nil, aslErrf("StartAt %q does not name a state in 'States'", def.StartAt)
+	}
+
+	for name, st := range def.States {
+		st.name = name
+		if err := validateState(def.States, st); err != nil {
+			return nil, err
+		}
+	}
+
+	return &def, nil
+}

--- a/providers/aws/sfn/asl/pass.go
+++ b/providers/aws/sfn/asl/pass.go
@@ -1,0 +1,54 @@
+package asl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// passHandler runs a Pass state: InputPath -> Parameters produce the effective
+// input; the result is the explicit Result field when present, else that input;
+// then ResultPath (onto the raw input) -> OutputPath produce the output.
+func passHandler(_ context.Context, it *interp, st *State, raw any) (out any, next string, terminal bool, err error) {
+	it.enterState(st, raw)
+
+	filtered, err := it.applyInputPath(st, raw)
+	if err != nil {
+		return nil, "", false, err
+	}
+
+	filtered, err = it.applyParameters(st, filtered)
+	if err != nil {
+		return nil, "", false, err
+	}
+
+	result := filtered
+	if st.Result != nil {
+		if uerr := json.Unmarshal(st.Result, &result); uerr != nil {
+			return nil, "", false, fmt.Errorf("pass state %q Result is not valid JSON: %w", st.name, uerr)
+		}
+	}
+
+	merged, err := it.applyResultPath(st, raw, result)
+	if err != nil {
+		return nil, "", false, err
+	}
+
+	out, err = it.applyOutputPath(st, merged)
+	if err != nil {
+		return nil, "", false, err
+	}
+
+	it.exitState(st, out)
+
+	return out, st.Next, st.End, nil
+}
+
+// unsupportedHandler fails an execution loudly when it reaches a state type
+// whose interpreter has not landed yet (Task, Parallel, Map).
+func unsupportedHandler(_ context.Context, _ *interp, st *State, _ any) (out any, next string, terminal bool, err error) {
+	return nil, "", false, &stateError{
+		Code:  "States.Runtime",
+		Cause: fmt.Sprintf("state type %q is not yet supported by the interpreter", st.Type),
+	}
+}

--- a/providers/aws/sfn/asl/succeed.go
+++ b/providers/aws/sfn/asl/succeed.go
@@ -1,0 +1,18 @@
+package asl
+
+import "context"
+
+// succeedHandler runs a Succeed state: it terminates the execution SUCCEEDED,
+// passing the InputPath/OutputPath-filtered input through as the output.
+func succeedHandler(_ context.Context, it *interp, st *State, raw any) (out any, next string, terminal bool, err error) {
+	it.enterState(st, raw)
+
+	out, err = it.passThroughOutput(st, raw)
+	if err != nil {
+		return nil, "", false, err
+	}
+
+	it.exitState(st, out)
+
+	return out, "", true, nil
+}

--- a/providers/aws/sfn/asl/teststate.go
+++ b/providers/aws/sfn/asl/teststate.go
@@ -1,0 +1,76 @@
+package asl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
+)
+
+// StateResult is the outcome of evaluating a single state via TestOne.
+type StateResult struct {
+	Output    string
+	NextState string
+	Status    string
+	Error     string
+	Cause     string
+}
+
+// testStateName is the synthetic name a TestOne single state is run under.
+const testStateName = "__TestState__"
+
+// TestOne evaluates one bare ASL state definition against an input, running its
+// handler exactly once (it does not follow Next). It returns the state's output,
+// the Next it would transition to (the selected branch for a Choice; empty for a
+// terminal state), and SUCCEEDED/FAILED. A structurally-invalid state is a
+// parse error the caller maps to its own validation surface.
+func TestOne(definition string, in *RunInput) (*StateResult, error) {
+	var st State
+	if err := json.Unmarshal([]byte(definition), &st); err != nil {
+		return nil, fmt.Errorf("state definition is not valid JSON: %w", err)
+	}
+
+	if err := validateSingleState(&st); err != nil {
+		return nil, err
+	}
+
+	st.name = testStateName
+
+	it := &interp{baseTime: in.StartTime, offset: in.SettleBase, maxSteps: 1, handlers: buildHandlers()}
+	input := parseInput(in.Input)
+	it.buildContext(in, input)
+	it.enterStateContext(&st)
+
+	out, next, terminal, err := it.handlers[st.Type](context.Background(), it, &st, input)
+	if err != nil {
+		se := asStateError(err)
+
+		return &StateResult{Status: driver.TestStatusFailed, Error: se.Code, Cause: se.Cause}, nil
+	}
+
+	res := &StateResult{Status: driver.TestStatusSucceeded, Output: toJSON(out)}
+	if !terminal {
+		res.NextState = next
+	}
+
+	return res, nil
+}
+
+// validateSingleState applies the state-level checks that do not depend on the
+// surrounding States map (Next-target existence is not checkable for one state).
+func validateSingleState(st *State) error {
+	if st.Type == "" {
+		return aslErrf("state is missing the required 'Type' field")
+	}
+
+	if !knownType(st.Type) {
+		return aslErrf("unknown state Type %q", st.Type)
+	}
+
+	if st.QueryLanguage == queryLangJSONata {
+		return aslErrf("QueryLanguage %q is not supported (JSONPath only)", st.QueryLanguage)
+	}
+
+	return validateFieldApplicability(st)
+}

--- a/providers/aws/sfn/asl/validate.go
+++ b/providers/aws/sfn/asl/validate.go
@@ -1,0 +1,175 @@
+package asl
+
+// validateState performs the structural checks real Step Functions applies at
+// CreateStateMachine time for the given state.
+func validateState(states map[string]*State, st *State) error {
+	if st.Type == "" {
+		return aslErrf("state %q is missing the required 'Type' field", st.name)
+	}
+
+	if !knownType(st.Type) {
+		return aslErrf("state %q has unknown Type %q", st.name, st.Type)
+	}
+
+	if st.QueryLanguage == queryLangJSONata {
+		return aslErrf("state %q QueryLanguage %q is not supported (JSONPath only)", st.name, st.QueryLanguage)
+	}
+
+	if err := validateFieldApplicability(st); err != nil {
+		return err
+	}
+
+	if st.Type == TypeChoice {
+		return validateChoice(states, st)
+	}
+
+	return validateTransitions(states, st)
+}
+
+// validateFieldApplicability rejects result-shaping fields on the state types
+// that do not support them (Wait, Choice, Succeed, Fail), matching AWS's
+// create-time rejection.
+func validateFieldApplicability(st *State) error {
+	switch st.Type {
+	case TypeWait, TypeChoice, TypeSucceed, TypeFail:
+	default:
+		return nil
+	}
+
+	switch {
+	case st.Parameters != nil:
+		return aslErrf("state %q (%s) does not support the 'Parameters' field", st.name, st.Type)
+	case st.Result != nil:
+		return aslErrf("state %q (%s) does not support the 'Result' field", st.name, st.Type)
+	case st.ResultSelector != nil:
+		return aslErrf("state %q (%s) does not support the 'ResultSelector' field", st.name, st.Type)
+	case st.ResultPath.set:
+		return aslErrf("state %q (%s) does not support the 'ResultPath' field", st.name, st.Type)
+	}
+
+	return nil
+}
+
+// validateTransitions checks Next/End for a non-Choice state: terminal states
+// (Succeed, Fail) take neither; every other state needs exactly one of Next or
+// End, and a Next must name an existing state.
+func validateTransitions(states map[string]*State, st *State) error {
+	if st.Type == TypeSucceed || st.Type == TypeFail {
+		return nil
+	}
+
+	if st.Next == "" && !st.End {
+		return aslErrf("state %q must specify either 'Next' or 'End'", st.name)
+	}
+
+	if st.Next != "" && st.End {
+		return aslErrf("state %q specifies both 'Next' and 'End'", st.name)
+	}
+
+	if st.Next != "" {
+		if _, ok := states[st.Next]; !ok {
+			return aslErrf("state %q Next %q does not name a state", st.name, st.Next)
+		}
+	}
+
+	return nil
+}
+
+// validateChoice checks a Choice state has at least one rule, every rule names
+// an existing Next target, and any Default names an existing state.
+func validateChoice(states map[string]*State, st *State) error {
+	if len(st.Choices) == 0 {
+		return aslErrf("Choice state %q must have a non-empty 'Choices' array", st.name)
+	}
+
+	for i, rule := range st.Choices {
+		if err := validateRule(states, st.name, i, rule); err != nil {
+			return err
+		}
+	}
+
+	if st.Default != "" {
+		if _, ok := states[st.Default]; !ok {
+			return aslErrf("Choice state %q Default %q does not name a state", st.name, st.Default)
+		}
+	}
+
+	return nil
+}
+
+// validateRule checks a single choice rule: a top-level rule must carry Next to
+// an existing state, and must be either a leaf comparator or a logical (And/Or/
+// Not) combinator — never both, never neither.
+func validateRule(states map[string]*State, stateName string, idx int, rule *ChoiceRule) error {
+	if rule.Next == "" {
+		return aslErrf("Choice state %q rule %d is missing 'Next'", stateName, idx)
+	}
+
+	if _, ok := states[rule.Next]; !ok {
+		return aslErrf("Choice state %q rule %d Next %q does not name a state", stateName, idx, rule.Next)
+	}
+
+	return validateRuleShape(stateName, idx, rule)
+}
+
+// validateRuleShape checks the comparator/combinator well-formedness of a rule
+// (and its nested logical rules), independent of the top-level Next.
+func validateRuleShape(stateName string, idx int, rule *ChoiceRule) error {
+	logical := len(rule.And) > 0 || len(rule.Or) > 0 || rule.Not != nil
+	leaf := rule.Variable != "" || len(rule.ops) > 0
+
+	if logical && leaf {
+		return aslErrf("Choice state %q rule %d mixes a comparator with And/Or/Not", stateName, idx)
+	}
+
+	if !logical && !leaf {
+		return aslErrf("Choice state %q rule %d has no comparator or And/Or/Not", stateName, idx)
+	}
+
+	if leaf {
+		return validateLeaf(stateName, idx, rule)
+	}
+
+	return validateNestedRules(stateName, idx, rule)
+}
+
+// validateNestedRules validates the sub-rules of a logical (And/Or/Not) rule.
+func validateNestedRules(stateName string, idx int, rule *ChoiceRule) error {
+	for _, sub := range rule.And {
+		if err := validateRuleShape(stateName, idx, sub); err != nil {
+			return err
+		}
+	}
+
+	for _, sub := range rule.Or {
+		if err := validateRuleShape(stateName, idx, sub); err != nil {
+			return err
+		}
+	}
+
+	if rule.Not != nil {
+		return validateRuleShape(stateName, idx, rule.Not)
+	}
+
+	return nil
+}
+
+// validateLeaf checks a leaf comparator carries a Variable and exactly one known
+// operator, and that a ...Path operator is only used where a Path variant exists.
+func validateLeaf(stateName string, idx int, rule *ChoiceRule) error {
+	if rule.Variable == "" {
+		return aslErrf("Choice state %q rule %d comparator is missing 'Variable'", stateName, idx)
+	}
+
+	if len(rule.ops) != 1 {
+		return aslErrf("Choice state %q rule %d must have exactly one comparator operator", stateName, idx)
+	}
+
+	for op := range rule.ops {
+		if comparatorFamily(op) == "" {
+			return aslErrf("Choice state %q rule %d has unknown comparator %q", stateName, idx, op)
+		}
+	}
+
+	return nil
+}

--- a/providers/aws/sfn/asl/validate.go
+++ b/providers/aws/sfn/asl/validate.go
@@ -30,6 +30,12 @@ func validateState(states map[string]*State, st *State) error {
 // that do not support them (Wait, Choice, Succeed, Fail), matching AWS's
 // create-time rejection.
 func validateFieldApplicability(st *State) error {
+	// Pass supports Parameters/Result/ResultPath but not ResultSelector, which
+	// is valid only on Task/Parallel/Map (matching AWS's create-time rejection).
+	if st.Type == TypePass && st.ResultSelector != nil {
+		return aslErrf("state %q (%s) does not support the 'ResultSelector' field", st.name, st.Type)
+	}
+
 	switch st.Type {
 	case TypeWait, TypeChoice, TypeSucceed, TypeFail:
 	default:

--- a/providers/aws/sfn/asl/wait.go
+++ b/providers/aws/sfn/asl/wait.go
@@ -1,0 +1,93 @@
+package asl
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// waitHandler runs a Wait state: it advances the virtual clock offset by the
+// wait duration (so later history events sit past it, and the settle window
+// extends under AsyncSettle), then passes the input through.
+func waitHandler(_ context.Context, it *interp, st *State, raw any) (out any, next string, terminal bool, err error) {
+	it.enterState(st, raw)
+
+	dur, err := it.waitDuration(st, raw)
+	if err != nil {
+		return nil, "", false, err
+	}
+
+	it.offset += dur
+	it.waitTotal += dur
+
+	out, err = it.passThroughOutput(st, raw)
+	if err != nil {
+		return nil, "", false, err
+	}
+
+	it.exitState(st, out)
+
+	return out, st.Next, st.End, nil
+}
+
+// waitDuration resolves a Wait state's delay from Seconds/SecondsPath (relative)
+// or Timestamp/TimestampPath (absolute, clamped to the virtual now).
+func (it *interp) waitDuration(st *State, raw any) (time.Duration, error) {
+	switch {
+	case st.Seconds != nil:
+		return time.Duration(*st.Seconds) * time.Second, nil
+	case st.SecondsPath != "":
+		return it.secondsFromPath(st.SecondsPath, raw)
+	case st.Timestamp != "":
+		return it.untilTimestamp(st.Timestamp)
+	case st.TimestampPath != "":
+		return it.timestampFromPath(st.TimestampPath, raw)
+	default:
+		return 0, &stateError{Code: "States.Runtime",
+			Cause: fmt.Sprintf("Wait state %q has no Seconds/SecondsPath/Timestamp/TimestampPath", st.name)}
+	}
+}
+
+func (it *interp) secondsFromPath(path string, raw any) (time.Duration, error) {
+	v, present, err := it.resolvePath(path, raw)
+	if err != nil {
+		return 0, err
+	}
+
+	secs, ok := toFloat(v)
+	if !present || !ok {
+		return 0, &stateError{Code: "States.Runtime",
+			Cause: fmt.Sprintf("SecondsPath %q did not resolve to a number", path)}
+	}
+
+	return time.Duration(secs) * time.Second, nil
+}
+
+func (it *interp) timestampFromPath(path string, raw any) (time.Duration, error) {
+	v, present, err := it.resolvePath(path, raw)
+	if err != nil {
+		return 0, err
+	}
+
+	ts, ok := v.(string)
+	if !present || !ok {
+		return 0, &stateError{Code: "States.Runtime",
+			Cause: fmt.Sprintf("TimestampPath %q did not resolve to a timestamp", path)}
+	}
+
+	return it.untilTimestamp(ts)
+}
+
+func (it *interp) untilTimestamp(ts string) (time.Duration, error) {
+	target, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return 0, &stateError{Code: "States.Runtime", Cause: fmt.Sprintf("invalid Wait timestamp %q", ts)}
+	}
+
+	d := target.Sub(it.baseTime.Add(it.offset))
+	if d < 0 {
+		return 0, nil
+	}
+
+	return d, nil
+}

--- a/providers/aws/sfn/executions.go
+++ b/providers/aws/sfn/executions.go
@@ -7,17 +7,9 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/settle"
+	"github.com/stackshy/cloudemu/v2/providers/aws/sfn/asl"
 	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
 )
-
-// historyEventCount is the number of synthesized events per successful
-// execution (ExecutionStarted, PassStateEntered, PassStateExited,
-// ExecutionSucceeded).
-const historyEventCount = 4
-
-// passStateName is the synthetic Pass state name the emulator reports in
-// StateEntered/StateExited history events (no real ASL interpreter runs).
-const passStateName = "PassState"
 
 func (m *Mock) getExec(arn string) (*execData, error) {
 	if !validExecutionARN(arn) {
@@ -32,10 +24,14 @@ func (m *Mock) getExec(arn string) (*execData, error) {
 	return ed, nil
 }
 
-// runExecution builds and stores a synchronously-completed execution. The
-// emulator does not interpret the ASL definition: the execution starts RUNNING
-// and immediately transitions to SUCCEEDED with output echoing the input.
-func (m *Mock) runExecution(in driver.StartExecutionInput, async bool) (*driver.Execution, error) {
+// runExecution interprets the state machine's ASL definition, storing a
+// synchronously-completed execution: it walks the graph from StartAt computing
+// the terminal status/output (or Error/Cause on failure) and the full per-state
+// history. ctx is threaded into the interpreter so a Task->Lambda seam (a later
+// PR) carries recursionguard depth. The settle overlay keeps RUNNING observable
+// under AsyncSettle; its window is extended by any Wait durations the run
+// accumulated.
+func (m *Mock) runExecution(ctx context.Context, in driver.StartExecutionInput, async bool) (*driver.Execution, error) {
 	sd, err := m.getSM(in.StateMachineArn)
 	if err != nil {
 		return nil, err
@@ -48,8 +44,7 @@ func (m *Mock) runExecution(in driver.StartExecutionInput, async bool) (*driver.
 	}
 
 	sd.mu.RLock()
-	smName := sd.sm.Name
-	smType := sd.sm.Type
+	smName, smType, definition, roleArn := sd.sm.Name, sd.sm.Type, sd.sm.Definition, sd.sm.RoleArn
 	sd.mu.RUnlock()
 
 	name := in.Name
@@ -60,24 +55,20 @@ func (m *Mock) runExecution(in driver.StartExecutionInput, async bool) (*driver.
 	arn := m.execARN(arnRegion(in.StateMachineArn, m.opts.Region), smName, name)
 	now := m.now()
 
-	output := in.Input
-	if output == "" {
-		output = emptyJSON
-	}
+	res := interpret(ctx, definition, &asl.RunInput{
+		Input: in.Input, ExecArn: arn, ExecName: name, SMArn: in.StateMachineArn,
+		SMName: smName, RoleArn: roleArn, StartTime: now, SettleBase: settle.DefaultExecutionSettle,
+	})
 
-	exec := driver.Execution{
-		ARN: arn, Name: name, StateMachineArn: in.StateMachineArn,
-		Status: driver.ExecStatusSucceeded, Input: in.Input, Output: output,
-		StartDate: now, StopDate: now,
-	}
+	exec := execFromResult(arn, name, in, now, res)
 
 	// A synchronous execution (StartSyncExecution) returns its terminal result
 	// immediately, so it carries no settle window; only the asynchronous
-	// StartExecution settles RUNNING -> SUCCEEDED.
+	// StartExecution settles RUNNING -> terminal, over a window extended by Wait.
 	var window settle.Window
 	if async {
 		window = settle.Pending(driver.ExecStatusRunning, now,
-			m.opts.SettleDuration(settle.DefaultExecutionSettle))
+			m.opts.SettleDuration(settle.DefaultExecutionSettle+res.WaitTotal))
 	}
 
 	if !m.executions.SetIfAbsent(arn, &execData{exec: exec, settle: window}) {
@@ -87,6 +78,46 @@ func (m *Mock) runExecution(in driver.StartExecutionInput, async bool) (*driver.
 	out := observedExec(&exec, window, now)
 
 	return &out, nil
+}
+
+// interpret parses and runs a definition. A definition accepted at create time
+// always parses; a parse failure here (e.g. after an UpdateStateMachine that
+// bypassed validation) fails the execution loudly rather than panicking.
+func interpret(ctx context.Context, definition string, in *asl.RunInput) *asl.RunResult {
+	def, err := asl.Parse(definition)
+	if err != nil {
+		return &asl.RunResult{
+			Status: driver.ExecStatusFailed, Error: "States.Runtime", Cause: err.Error(),
+			History: []driver.HistoryEvent{
+				{ID: 1, Type: "ExecutionStarted", Timestamp: in.StartTime, Input: emptyOr(in.Input)},
+				{ID: 2, PreviousEventID: 1, Type: "ExecutionFailed", Timestamp: in.StartTime,
+					Error: "States.Runtime", Cause: err.Error()},
+			},
+		}
+	}
+
+	return asl.Run(ctx, def, in)
+}
+
+// execFromResult assembles the stored execution record from an interpreter run.
+func execFromResult(
+	arn, name string, in driver.StartExecutionInput, now time.Time, res *asl.RunResult,
+) driver.Execution {
+	return driver.Execution{
+		ARN: arn, Name: name, StateMachineArn: in.StateMachineArn,
+		Status: res.Status, Input: in.Input, Output: res.Output,
+		Error: res.Error, Cause: res.Cause,
+		StartDate: now, StopDate: now, History: res.History,
+	}
+}
+
+// emptyOr returns "{}" for a blank execution input, else the input verbatim.
+func emptyOr(input string) string {
+	if input == "" {
+		return emptyJSON
+	}
+
+	return input
 }
 
 // idempotentReuse resolves a StartExecution name collision. StartExecution is
@@ -127,8 +158,8 @@ func observedExec(exec *driver.Execution, w settle.Window, now time.Time) driver
 	return out
 }
 
-func (m *Mock) StartExecution(_ context.Context, in driver.StartExecutionInput) (*driver.Execution, error) {
-	return m.runExecution(in, true)
+func (m *Mock) StartExecution(ctx context.Context, in driver.StartExecutionInput) (*driver.Execution, error) {
+	return m.runExecution(ctx, in, true)
 }
 
 // StartExternal starts a state-machine execution on behalf of a cross-service
@@ -149,8 +180,8 @@ func (m *Mock) StartExternal(ctx context.Context, stateMachineARN, input string)
 	return err
 }
 
-func (m *Mock) StartSyncExecution(_ context.Context, in driver.StartExecutionInput) (*driver.Execution, error) {
-	return m.runExecution(in, false)
+func (m *Mock) StartSyncExecution(ctx context.Context, in driver.StartExecutionInput) (*driver.Execution, error) {
+	return m.runExecution(ctx, in, false)
 }
 
 func (m *Mock) DescribeExecution(_ context.Context, arn string) (*driver.Execution, error) {
@@ -167,7 +198,7 @@ func (m *Mock) DescribeExecution(_ context.Context, arn string) (*driver.Executi
 	return &out, nil
 }
 
-func (m *Mock) StopExecution(_ context.Context, arn, _, _ string) (time.Time, error) {
+func (m *Mock) StopExecution(_ context.Context, arn, errCode, cause string) (time.Time, error) {
 	ed, err := m.getExec(arn)
 	if err != nil {
 		return time.Time{}, err
@@ -179,17 +210,44 @@ func (m *Mock) StopExecution(_ context.Context, arn, _, _ string) (time.Time, er
 	now := m.now()
 
 	// While an execution is still settling (observably RUNNING under AsyncSettle),
-	// Stop aborts it: ABORTED with a stop date and no output, and the window is
-	// cleared so it stays aborted. An already-settled (terminal) execution is not
-	// re-stopped — StopExecution returns its recorded stop date.
+	// Stop aborts it: ABORTED with a stop date, no output, the caller's error/cause
+	// persisted, and the history trimmed to the events already visible plus a
+	// terminal ExecutionAborted. The window is cleared so it stays aborted. An
+	// already-settled (terminal) execution is not re-stopped.
 	if !ed.settle.Settled(now) {
 		ed.exec.Status = driver.ExecStatusAborted
 		ed.exec.StopDate = now
 		ed.exec.Output = ""
+		ed.exec.Error = errCode
+		ed.exec.Cause = cause
+		ed.exec.History = abortHistory(ed.exec.History, now, errCode, cause)
 		ed.settle = settle.Window{}
 	}
 
 	return ed.exec.StopDate, nil
+}
+
+// abortHistory trims an execution's history to the events already observable at
+// now (those whose Timestamp has elapsed) and appends a terminal ExecutionAborted
+// event, so an aborted run's history never shows its would-be terminal success.
+func abortHistory(events []driver.HistoryEvent, now time.Time, errCode, cause string) []driver.HistoryEvent {
+	visible := make([]driver.HistoryEvent, 0, len(events)+1)
+
+	for i := range events {
+		if !events[i].Timestamp.After(now) {
+			visible = append(visible, events[i])
+		}
+	}
+
+	var prev int64
+	if n := len(visible); n > 0 {
+		prev = visible[n-1].ID
+	}
+
+	return append(visible, driver.HistoryEvent{
+		ID: prev + 1, PreviousEventID: prev, Type: "ExecutionAborted",
+		Timestamp: now, Error: errCode, Cause: cause,
+	})
 }
 
 func (m *Mock) ListExecutions(_ context.Context, stateMachineArn, statusFilter string) ([]driver.Execution, error) {
@@ -221,37 +279,34 @@ func (m *Mock) ListExecutions(_ context.Context, stateMachineArn, statusFilter s
 	return out, nil
 }
 
-// GetExecutionHistory synthesizes a minimal but valid event list for a
-// completed execution: ExecutionStarted -> PassStateEntered -> PassStateExited
-// -> ExecutionSucceeded. No real ASL interpreter runs.
+// GetExecutionHistory returns the real per-state event list the interpreter
+// produced. While an execution is still observably RUNNING (settle window
+// unelapsed), the list is truncated to the events whose virtual Timestamp has
+// elapsed — generalizing the previous "only ExecutionStarted while RUNNING"
+// rule — so the terminal event is not yet visible. Reverse order is applied last.
 func (m *Mock) GetExecutionHistory(_ context.Context, arn string, reverse bool) ([]driver.HistoryEvent, error) {
 	ed, err := m.getExec(arn)
 	if err != nil {
 		return nil, err
 	}
 
+	now := m.now()
+
 	ed.mu.RLock()
-	exec := ed.exec
-	settled := ed.settle.Settled(m.now())
+	settled := ed.settle.Settled(now)
+	events := append([]driver.HistoryEvent(nil), ed.exec.History...)
 	ed.mu.RUnlock()
 
-	ts := exec.StartDate
-	// While an execution is still observably RUNNING, only the start event has
-	// happened; the terminal ExecutionSucceeded is not yet in the history,
-	// matching the RUNNING status the Describe surface reports.
 	if !settled {
-		events := []driver.HistoryEvent{
-			{ID: 1, PreviousEventID: 0, Type: "ExecutionStarted", Timestamp: ts, Input: exec.Input},
+		visible := events[:0]
+
+		for i := range events {
+			if !events[i].Timestamp.After(now) {
+				visible = append(visible, events[i])
+			}
 		}
 
-		return events, nil
-	}
-
-	events := []driver.HistoryEvent{
-		{ID: 1, PreviousEventID: 0, Type: "ExecutionStarted", Timestamp: ts, Input: exec.Input},
-		{ID: 2, PreviousEventID: 1, Type: "PassStateEntered", Timestamp: ts, StateName: passStateName, Input: exec.Input},
-		{ID: 3, PreviousEventID: 2, Type: "PassStateExited", Timestamp: ts, StateName: passStateName, Output: exec.Output},
-		{ID: historyEventCount, PreviousEventID: 3, Type: "ExecutionSucceeded", Timestamp: exec.StopDate, Output: exec.Output},
+		events = visible
 	}
 
 	if reverse {

--- a/providers/aws/sfn/interpreter_history_test.go
+++ b/providers/aws/sfn/interpreter_history_test.go
@@ -1,0 +1,261 @@
+package sfn_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/aws/sfn"
+	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
+)
+
+// asyncMock builds a Step Functions mock with AsyncSettle and a FakeClock so
+// Wait/Retry observably hold an execution RUNNING under a deterministic clock.
+func asyncMock(t *testing.T, fc *config.FakeClock) *sfn.Mock {
+	t.Helper()
+
+	return sfn.New(config.NewOptions(
+		config.WithClock(fc), config.WithRegion("us-east-1"),
+		config.WithAccountID("000000000000"), config.WithAsyncSettle(),
+	))
+}
+
+// assertChain verifies the ID/PreviousEventID chain: IDs are 1..n monotonic and
+// each event's PreviousEventID points at the prior event (0 for the first).
+func assertChain(t *testing.T, events []driver.HistoryEvent) {
+	t.Helper()
+
+	for i, e := range events {
+		wantID := int64(i + 1)
+		if e.ID != wantID {
+			t.Fatalf("event %d ID = %d, want %d", i, e.ID, wantID)
+		}
+
+		var wantPrev int64
+		if i > 0 {
+			wantPrev = events[i-1].ID
+		}
+
+		if e.PreviousEventID != wantPrev {
+			t.Fatalf("event %d PreviousEventID = %d, want %d", i, e.PreviousEventID, wantPrev)
+		}
+	}
+}
+
+// TestInterpreterHistorySequence asserts GetExecutionHistory returns the real
+// per-state event sequence with a valid PreviousEventID chain, forward and
+// reversed.
+func TestInterpreterHistorySequence(t *testing.T) {
+	def := `{"StartAt":"P","States":{
+		"P":{"Type":"Pass","Result":{"step":1},"ResultPath":"$.p","Next":"C"},
+		"C":{"Type":"Choice","Choices":[{"Variable":"$.p.step","NumericEquals":1,"Next":"S"}],"Default":"S"},
+		"S":{"Type":"Succeed"}}}`
+
+	m := newMock(t)
+	exec := runSync(t, m, "hist", def, `{}`)
+	ctx := context.Background()
+
+	events, err := m.GetExecutionHistory(ctx, exec.ARN, false)
+	if err != nil {
+		t.Fatalf("GetExecutionHistory: %v", err)
+	}
+
+	wantTypes := []string{
+		"ExecutionStarted",
+		"PassStateEntered", "PassStateExited",
+		"ChoiceStateEntered", "ChoiceStateExited",
+		"SucceedStateEntered", "SucceedStateExited",
+		"ExecutionSucceeded",
+	}
+
+	if len(events) != len(wantTypes) {
+		t.Fatalf("history has %d events, want %d: %+v", len(events), len(wantTypes), events)
+	}
+
+	for i, want := range wantTypes {
+		if events[i].Type != want {
+			t.Fatalf("event %d type = %q, want %q", i, events[i].Type, want)
+		}
+	}
+
+	assertChain(t, events)
+
+	rev, err := m.GetExecutionHistory(ctx, exec.ARN, true)
+	if err != nil {
+		t.Fatalf("GetExecutionHistory reverse: %v", err)
+	}
+
+	if rev[0].Type != "ExecutionSucceeded" || rev[len(rev)-1].Type != "ExecutionStarted" {
+		t.Fatalf("reversed history ends = %q..%q, want ExecutionSucceeded..ExecutionStarted",
+			rev[0].Type, rev[len(rev)-1].Type)
+	}
+}
+
+// TestInterpreterSnapshotRoundTripHistory proves the event history rides the
+// persisted execution through a snapshot/restore round trip.
+func TestInterpreterSnapshotRoundTripHistory(t *testing.T) {
+	def := `{"StartAt":"P","States":{"P":{"Type":"Pass","Result":{"a":1},"End":true}}}`
+
+	ctx := context.Background()
+	src := newMock(t)
+	exec := runSync(t, src, "snap", def, `{}`)
+
+	before, err := src.GetExecutionHistory(ctx, exec.ARN, false)
+	if err != nil {
+		t.Fatalf("history before snapshot: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newMock(t)
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	after, err := dst.GetExecutionHistory(ctx, exec.ARN, false)
+	if err != nil {
+		t.Fatalf("history after restore: %v", err)
+	}
+
+	if len(before) != len(after) {
+		t.Fatalf("history length changed across restore: %d -> %d", len(before), len(after))
+	}
+
+	for i := range before {
+		if before[i] != after[i] {
+			t.Fatalf("event %d differs after restore: %+v vs %+v", i, before[i], after[i])
+		}
+	}
+}
+
+// TestInterpreterWaitFakeClock pins deterministic Wait timing under AsyncSettle:
+// the execution is RUNNING with a truncated history before the FakeClock is
+// advanced past the settle window, then SUCCEEDED with the full history after.
+func TestInterpreterWaitFakeClock(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	m := asyncMock(t, fc)
+	ctx := context.Background()
+
+	def := `{"StartAt":"W","States":{"W":{"Type":"Wait","Seconds":2,"Next":"S"},"S":{"Type":"Succeed"}}}`
+	arn := createDef(t, m, "wait", def)
+
+	start, err := m.StartExecution(ctx, driver.StartExecutionInput{StateMachineArn: arn, Name: "w1", Input: `{}`})
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	if start.Status != driver.ExecStatusRunning {
+		t.Fatalf("initial status = %q, want RUNNING", start.Status)
+	}
+
+	hist, _ := m.GetExecutionHistory(ctx, start.ARN, false)
+	if historyHasType(hist, "ExecutionSucceeded") {
+		t.Fatalf("terminal event visible while RUNNING: %+v", hist)
+	}
+
+	// Base execution settle (1s) + Wait (2s) = 3s window.
+	fc.Advance(3 * time.Second)
+
+	got, _ := m.DescribeExecution(ctx, start.ARN)
+	if got.Status != driver.ExecStatusSucceeded {
+		t.Fatalf("status after advance = %q, want SUCCEEDED", got.Status)
+	}
+
+	hist, _ = m.GetExecutionHistory(ctx, start.ARN, false)
+	if !historyHasType(hist, "WaitStateExited") || !historyHasType(hist, "ExecutionSucceeded") {
+		t.Fatalf("settled history missing wait/terminal events: %+v", hist)
+	}
+}
+
+// TestInterpreterWaitInstantWithoutAsyncSettle asserts a Wait completes instantly
+// (SUCCEEDED, full history) when AsyncSettle is off — the default.
+func TestInterpreterWaitInstantWithoutAsyncSettle(t *testing.T) {
+	def := `{"StartAt":"W","States":{"W":{"Type":"Wait","Seconds":30,"Next":"S"},"S":{"Type":"Succeed"}}}`
+
+	exec := runSync(t, newMock(t), "wait-instant", def, `{}`)
+
+	if exec.Status != driver.ExecStatusSucceeded {
+		t.Fatalf("status = %q, want instant SUCCEEDED", exec.Status)
+	}
+}
+
+// TestInterpreterStopSurfacesErrorCause asserts StopExecution during the RUNNING
+// window aborts the execution and persists the caller's Error/Cause, and that the
+// history ends with ExecutionAborted.
+func TestInterpreterStopSurfacesErrorCause(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	m := asyncMock(t, fc)
+	ctx := context.Background()
+
+	def := `{"StartAt":"W","States":{"W":{"Type":"Wait","Seconds":10,"Next":"S"},"S":{"Type":"Succeed"}}}`
+	arn := createDef(t, m, "stop", def)
+
+	start, _ := m.StartExecution(ctx, driver.StartExecutionInput{StateMachineArn: arn, Name: "s1", Input: `{}`})
+
+	if _, err := m.StopExecution(ctx, start.ARN, "Halt", "operator stopped"); err != nil {
+		t.Fatalf("StopExecution: %v", err)
+	}
+
+	got, _ := m.DescribeExecution(ctx, start.ARN)
+	if got.Status != driver.ExecStatusAborted || got.Error != "Halt" || got.Cause != "operator stopped" {
+		t.Fatalf("aborted execution = %+v, want ABORTED/Halt/operator stopped", got)
+	}
+
+	hist, _ := m.GetExecutionHistory(ctx, start.ARN, false)
+	if len(hist) == 0 || hist[len(hist)-1].Type != "ExecutionAborted" {
+		t.Fatalf("history does not end with ExecutionAborted: %+v", hist)
+	}
+}
+
+// TestInterpreterMaxStepsGuard asserts a Choice/Next cycle fails loudly with the
+// non-States.* transition-limit code rather than spinning forever.
+func TestInterpreterMaxStepsGuard(t *testing.T) {
+	def := `{"StartAt":"A","States":{
+		"A":{"Type":"Choice","Choices":[{"Variable":"$.x","NumericEquals":1,"Next":"A"}],"Default":"A"}}}`
+
+	exec := runSync(t, newMock(t), "cycle", def, `{"x":1}`)
+
+	if exec.Status != driver.ExecStatusFailed {
+		t.Fatalf("status = %q, want FAILED", exec.Status)
+	}
+
+	if exec.Error != "CloudEmu.StateTransitionLimitExceeded" {
+		t.Fatalf("error = %q, want CloudEmu.StateTransitionLimitExceeded (a non-States.* code)", exec.Error)
+	}
+}
+
+// TestInterpreterStartExecutionForwardsContext exercises the ctx-threaded entry
+// point: StartExecution now forwards its context into runExecution/the
+// interpreter (the plumbing the PR2 recursion guard rides). A value-carrying
+// context runs to a real interpreted result.
+func TestInterpreterStartExecutionForwardsContext(t *testing.T) {
+	type ctxKey struct{}
+
+	def := `{"StartAt":"P","States":{"P":{"Type":"Pass","Result":{"ok":true},"End":true}}}`
+	m := newMock(t)
+	arn := createDef(t, m, "ctx", def)
+
+	ctx := context.WithValue(context.Background(), ctxKey{}, "v")
+	exec, err := m.StartExecution(ctx, driver.StartExecutionInput{StateMachineArn: arn, Name: "c1", Input: `{}`})
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	if exec.Status == "" {
+		t.Fatalf("expected an interpreted status, got empty: %+v", exec)
+	}
+}
+
+func historyHasType(events []driver.HistoryEvent, typ string) bool {
+	for _, e := range events {
+		if e.Type == typ {
+			return true
+		}
+	}
+
+	return false
+}

--- a/providers/aws/sfn/interpreter_test.go
+++ b/providers/aws/sfn/interpreter_test.go
@@ -1,0 +1,186 @@
+package sfn_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/providers/aws/sfn"
+	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
+)
+
+// createDef registers a state machine with the given verbatim ASL definition.
+func createDef(t *testing.T, m *sfn.Mock, name, def string) string {
+	t.Helper()
+
+	arn, _, _, err := m.CreateStateMachine(context.Background(), driver.CreateStateMachineInput{
+		Name: name, Definition: def, RoleArn: "arn:aws:iam::000000000000:role/r",
+	})
+	if err != nil {
+		t.Fatalf("CreateStateMachine(%s): %v", name, err)
+	}
+
+	return arn
+}
+
+// runSync creates a machine and runs one synchronous (instant) execution.
+func runSync(t *testing.T, m *sfn.Mock, name, def, input string) *driver.Execution {
+	t.Helper()
+
+	arn := createDef(t, m, name, def)
+
+	exec, err := m.StartSyncExecution(context.Background(), driver.StartExecutionInput{
+		StateMachineArn: arn, Name: "run", Input: input,
+	})
+	if err != nil {
+		t.Fatalf("StartSyncExecution(%s): %v", name, err)
+	}
+
+	return exec
+}
+
+// jsonEqual reports whether two JSON strings are semantically equal.
+func jsonEqual(t *testing.T, got, want string) bool {
+	t.Helper()
+
+	var g, w any
+	if err := json.Unmarshal([]byte(got), &g); err != nil {
+		t.Fatalf("got is not JSON: %q (%v)", got, err)
+	}
+
+	if err := json.Unmarshal([]byte(want), &w); err != nil {
+		t.Fatalf("want is not JSON: %q (%v)", want, err)
+	}
+
+	return reflect.DeepEqual(g, w)
+}
+
+// TestInterpreterPassWaitChoiceSucceed runs a Pass -> Wait -> Choice -> Succeed
+// machine end to end and asserts the terminal status and output document.
+func TestInterpreterPassWaitChoiceSucceed(t *testing.T) {
+	def := `{"StartAt":"P","States":{
+		"P":{"Type":"Pass","Result":{"step":1},"ResultPath":"$.p","Next":"W"},
+		"W":{"Type":"Wait","Seconds":0,"Next":"C"},
+		"C":{"Type":"Choice","Choices":[{"Variable":"$.p.step","NumericEquals":1,"Next":"S"}],"Default":"F"},
+		"S":{"Type":"Succeed"},
+		"F":{"Type":"Fail","Error":"Bad","Cause":"unexpected"}}}`
+
+	exec := runSync(t, newMock(t), "pwcs", def, `{"x":10}`)
+
+	if exec.Status != driver.ExecStatusSucceeded {
+		t.Fatalf("status = %q (err=%q cause=%q), want SUCCEEDED", exec.Status, exec.Error, exec.Cause)
+	}
+
+	if !jsonEqual(t, exec.Output, `{"x":10,"p":{"step":1}}`) {
+		t.Fatalf("output = %q, want the input with p.step reattached", exec.Output)
+	}
+}
+
+// TestInterpreterFailState asserts a Fail state terminates FAILED with Error/Cause.
+func TestInterpreterFailState(t *testing.T) {
+	def := `{"StartAt":"F","States":{"F":{"Type":"Fail","Error":"MyError","Cause":"my cause"}}}`
+
+	exec := runSync(t, newMock(t), "failmc", def, `{}`)
+
+	if exec.Status != driver.ExecStatusFailed || exec.Error != "MyError" || exec.Cause != "my cause" {
+		t.Fatalf("Fail terminal = %+v, want FAILED/MyError/my cause", exec)
+	}
+}
+
+// TestInterpreterChoiceComparatorFamilies drives one branch per comparator
+// family (string, numeric, boolean, timestamp, type-check, StringMatches glob)
+// plus the Default fall-through.
+func TestInterpreterChoiceComparatorFamilies(t *testing.T) {
+	def := `{"StartAt":"C","States":{
+		"C":{"Type":"Choice","Choices":[
+			{"Variable":"$.s","StringEquals":"hello","Next":"Str"},
+			{"Variable":"$.n","NumericGreaterThan":10,"Next":"Num"},
+			{"Variable":"$.b","BooleanEquals":true,"Next":"Bool"},
+			{"Variable":"$.t","TimestampLessThan":"2020-01-01T00:00:00Z","Next":"Ts"},
+			{"Variable":"$.p","IsPresent":true,"Next":"Present"},
+			{"Variable":"$.m","StringMatches":"foo*bar","Next":"Match"}
+		],"Default":"Def"},
+		"Str":{"Type":"Pass","Result":"str","End":true},
+		"Num":{"Type":"Pass","Result":"num","End":true},
+		"Bool":{"Type":"Pass","Result":"bool","End":true},
+		"Ts":{"Type":"Pass","Result":"ts","End":true},
+		"Present":{"Type":"Pass","Result":"present","End":true},
+		"Match":{"Type":"Pass","Result":"match","End":true},
+		"Def":{"Type":"Pass","Result":"def","End":true}}}`
+
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{`{"s":"hello"}`, `"str"`},
+		{`{"n":42}`, `"num"`},
+		{`{"b":true}`, `"bool"`},
+		{`{"t":"2019-06-01T00:00:00Z"}`, `"ts"`},
+		{`{"p":"x"}`, `"present"`},
+		{`{"m":"fooXXbar"}`, `"match"`},
+		{`{"other":1}`, `"def"`},
+	}
+
+	for i, tc := range cases {
+		m := newMock(t)
+		exec := runSync(t, m, fmt.Sprintf("choice-%d", i), def, tc.input)
+
+		if exec.Status != driver.ExecStatusSucceeded {
+			t.Fatalf("case %d status = %q err=%q", i, exec.Status, exec.Error)
+		}
+
+		if !jsonEqual(t, exec.Output, tc.want) {
+			t.Fatalf("case %d input %s output = %q, want %q", i, tc.input, exec.Output, tc.want)
+		}
+	}
+}
+
+// TestInterpreterResultPathMergesOntoRawInput is the corrected-semantic guard:
+// InputPath narrows the state's view, but ResultPath reattaches the result onto
+// the RAW input, so the sibling fields InputPath excluded survive in the output.
+func TestInterpreterResultPathMergesOntoRawInput(t *testing.T) {
+	def := `{"StartAt":"T","States":{"T":{"Type":"Pass",
+		"InputPath":"$.detail","Result":{"ok":true},"ResultPath":"$.result","End":true}}}`
+
+	exec := runSync(t, newMock(t), "rp-merge", def, `{"detail":{"id":1},"meta":"keep"}`)
+
+	// meta was excluded by InputPath but must survive, because ResultPath merges
+	// onto the RAW input, not the InputPath-filtered document.
+	want := `{"detail":{"id":1},"meta":"keep","result":{"ok":true}}`
+	if !jsonEqual(t, exec.Output, want) {
+		t.Fatalf("output = %q, want %q (sibling 'meta' preserved via raw-input merge)", exec.Output, want)
+	}
+}
+
+// TestInterpreterResultPathNullAndDefault pins the two other ResultPath modes:
+// null passes the RAW input through unchanged (discarding the result), and the
+// default '$' replaces the document with the result.
+func TestInterpreterResultPathNullAndDefault(t *testing.T) {
+	null := `{"StartAt":"T","States":{"T":{"Type":"Pass",
+		"InputPath":"$.detail","Result":{"ignored":true},"ResultPath":null,"End":true}}}`
+	exec := runSync(t, newMock(t), "rp-null", null, `{"detail":{"id":1},"meta":"keep"}`)
+
+	if !jsonEqual(t, exec.Output, `{"detail":{"id":1},"meta":"keep"}`) {
+		t.Fatalf("ResultPath:null output = %q, want the raw input passed through", exec.Output)
+	}
+
+	def := `{"StartAt":"T","States":{"T":{"Type":"Pass","Result":{"x":1},"End":true}}}`
+	exec = runSync(t, newMock(t), "rp-default", def, `{"meta":"gone"}`)
+
+	if !jsonEqual(t, exec.Output, `{"x":1}`) {
+		t.Fatalf("default ResultPath output = %q, want the result replacing the document", exec.Output)
+	}
+}
+
+// TestInterpreterOutputPathFilters asserts OutputPath narrows the effective output.
+func TestInterpreterOutputPathFilters(t *testing.T) {
+	def := `{"StartAt":"T","States":{"T":{"Type":"Pass","OutputPath":"$.detail","End":true}}}`
+
+	exec := runSync(t, newMock(t), "outpath", def, `{"detail":{"id":9},"meta":"x"}`)
+
+	if !jsonEqual(t, exec.Output, `{"id":9}`) {
+		t.Fatalf("OutputPath output = %q, want just the selected sub-document", exec.Output)
+	}
+}

--- a/providers/aws/sfn/interpreter_validation_test.go
+++ b/providers/aws/sfn/interpreter_validation_test.go
@@ -1,0 +1,135 @@
+package sfn_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
+)
+
+// createErr attempts to create a state machine and returns the error.
+func createErr(t *testing.T, def string) error {
+	t.Helper()
+
+	m := newMock(t)
+	_, _, _, err := m.CreateStateMachine(context.Background(), driver.CreateStateMachineInput{
+		Name: "sm", Definition: def, RoleArn: "arn:aws:iam::000000000000:role/r",
+	})
+
+	return err
+}
+
+// TestCreateRejectsInvalidDefinitions asserts the stricter parser rejects a
+// range of malformed ASL at CreateStateMachine time with InvalidDefinition.
+func TestCreateRejectsInvalidDefinitions(t *testing.T) {
+	cases := map[string]string{
+		"jsonata top-level":     `{"QueryLanguage":"JSONata","StartAt":"A","States":{"A":{"Type":"Pass","End":true}}}`,
+		"jsonata per-state":     `{"StartAt":"A","States":{"A":{"Type":"Pass","QueryLanguage":"JSONata","End":true}}}`,
+		"unknown state type":    `{"StartAt":"A","States":{"A":{"Type":"Frobnicate","End":true}}}`,
+		"dangling next":         `{"StartAt":"A","States":{"A":{"Type":"Pass","Next":"Nowhere"}}}`,
+		"missing next and end":  `{"StartAt":"A","States":{"A":{"Type":"Pass"}}}`,
+		"choice without rules":  `{"StartAt":"A","States":{"A":{"Type":"Choice","Choices":[]}}}`,
+		"params on wait":        `{"StartAt":"A","States":{"A":{"Type":"Wait","Seconds":1,"Parameters":{"x":1},"End":true}}}`,
+		"resultpath on succeed": `{"StartAt":"A","States":{"A":{"Type":"Succeed","ResultPath":"$.r"}}}`,
+		"missing startat":       `{"States":{"A":{"Type":"Pass","End":true}}}`,
+		"not json":              `{not json`,
+	}
+
+	for name, def := range cases {
+		err := createErr(t, def)
+		if !errors.IsInvalidArgument(err) {
+			t.Fatalf("%s: want InvalidArgument, got %v", name, err)
+		}
+
+		if exceptionOf(err) != driver.ExInvalidDefinition {
+			t.Fatalf("%s: want InvalidDefinition exception, got %q (%v)", name, exceptionOf(err), err)
+		}
+	}
+}
+
+// TestValidateStateMachineDefinitionRejects asserts the same structural checks
+// surface as FAIL diagnostics through ValidateStateMachineDefinition.
+func TestValidateStateMachineDefinitionRejects(t *testing.T) {
+	m := newMock(t)
+	ctx := context.Background()
+
+	bad := []string{
+		`{"QueryLanguage":"JSONata","StartAt":"A","States":{"A":{"Type":"Pass","End":true}}}`,
+		`{"StartAt":"A","States":{"A":{"Type":"Choice","Choices":[]}}}`,
+		`{"StartAt":"A","States":{"A":{"Type":"Pass","Next":"Missing"}}}`,
+	}
+
+	for _, def := range bad {
+		res, err := m.ValidateStateMachineDefinition(ctx, def, driver.TypeStandard)
+		if err != nil {
+			t.Fatalf("ValidateStateMachineDefinition returned error: %v", err)
+		}
+
+		if res.Result != driver.ValidationResultFail || len(res.Diagnostics) == 0 {
+			t.Fatalf("definition %q should FAIL with a diagnostic, got %+v", def, res)
+		}
+	}
+
+	good := `{"StartAt":"A","States":{"A":{"Type":"Pass","End":true}}}`
+	res, _ := m.ValidateStateMachineDefinition(ctx, good, driver.TypeStandard)
+	if res.Result != driver.ValidationResultOK {
+		t.Fatalf("valid definition should be OK, got %+v", res)
+	}
+}
+
+// TestUnsupportedJSONPathFailsLoudly asserts that a definition using JSONPath
+// syntax outside the supported subset (here a wildcard) fails the execution
+// loudly instead of silently returning a wrong result.
+func TestUnsupportedJSONPathFailsLoudly(t *testing.T) {
+	def := `{"StartAt":"C","States":{
+		"C":{"Type":"Choice","Choices":[{"Variable":"$.items.*","IsPresent":true,"Next":"S"}],"Default":"S"},
+		"S":{"Type":"Succeed"}}}`
+
+	exec := runSync(t, newMock(t), "badpath", def, `{"items":[1,2]}`)
+
+	if exec.Status != driver.ExecStatusFailed {
+		t.Fatalf("status = %q, want FAILED for unsupported JSONPath", exec.Status)
+	}
+}
+
+// TestUnsupportedStateTypeFailsLoudly asserts a Task/Parallel/Map state (valid
+// ASL, accepted at create time) fails loudly at run time until its handler lands.
+func TestUnsupportedStateTypeFailsLoudly(t *testing.T) {
+	def := `{"StartAt":"T","States":{"T":{"Type":"Task",
+		"Resource":"arn:aws:states:::lambda:invoke","End":true}}}`
+
+	// Accepted at create time (valid ASL).
+	if err := createErr(t, def); err != nil {
+		t.Fatalf("Task definition should be accepted at create time, got %v", err)
+	}
+
+	exec := runSync(t, newMock(t), "task", def, `{}`)
+	if exec.Status != driver.ExecStatusFailed {
+		t.Fatalf("Task run status = %q, want FAILED (unsupported until PR2)", exec.Status)
+	}
+}
+
+// TestIdempotentDuplicateCreate asserts two identical CreateStateMachine calls
+// (verbatim definition) return the same machine rather than AlreadyExists.
+func TestIdempotentDuplicateCreate(t *testing.T) {
+	m := newMock(t)
+	ctx := context.Background()
+	def := `{"StartAt":"A","States":{"A":{"Type":"Pass","End":true}}}`
+
+	in := driver.CreateStateMachineInput{Name: "dup", Definition: def, RoleArn: "arn:aws:iam::000000000000:role/r"}
+
+	arn1, _, _, err := m.CreateStateMachine(ctx, in)
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+
+	arn2, _, _, err := m.CreateStateMachine(ctx, in)
+	if err != nil {
+		t.Fatalf("idempotent duplicate create should succeed, got %v", err)
+	}
+
+	if arn1 != arn2 {
+		t.Fatalf("duplicate create returned a different ARN: %q vs %q", arn1, arn2)
+	}
+}

--- a/providers/aws/sfn/sfn.go
+++ b/providers/aws/sfn/sfn.go
@@ -1,9 +1,13 @@
 // Package sfn provides an in-memory mock implementation of AWS Step Functions.
 //
-// The mock stores each state machine's ASL definition verbatim but does not
-// interpret it: StartExecution completes the execution immediately (RUNNING
-// then SUCCEEDED) with output echoing the input, and GetExecutionHistory
-// synthesizes a minimal, valid event list (ExecutionStarted -> ExecutionSucceeded).
+// The mock stores each state machine's ASL definition verbatim and interprets
+// it with a real state-graph walker (see providers/aws/sfn/asl): StartExecution
+// walks from StartAt following Next/End, computes the terminal status/output,
+// and records the per-state event list GetExecutionHistory returns. Execution is
+// synchronous; the settle overlay keeps RUNNING observable under AsyncSettle.
+// ctx is threaded end-to-end so a later Task->Lambda seam carries recursionguard
+// depth. Pass, Choice, Wait, Succeed and Fail are supported; Task, Parallel and
+// Map parse but fail loudly at run time until their handlers land.
 package sfn
 
 import (

--- a/providers/aws/sfn/sfn_test.go
+++ b/providers/aws/sfn/sfn_test.go
@@ -482,7 +482,10 @@ func TestTestState(t *testing.T) {
 	m := newMock(t)
 	ctx := context.Background()
 
-	res, err := m.TestState(ctx, driver.TestStateInput{Definition: definition, Input: `{"a":1}`})
+	// TestState evaluates a single state definition (not a whole machine).
+	res, err := m.TestState(ctx, driver.TestStateInput{
+		Definition: `{"Type":"Pass","End":true}`, Input: `{"a":1}`,
+	})
 	if err != nil {
 		t.Fatalf("TestState: %v", err)
 	}

--- a/providers/aws/sfn/statemachines.go
+++ b/providers/aws/sfn/statemachines.go
@@ -2,35 +2,22 @@ package sfn
 
 import (
 	"context"
-	"encoding/json"
 	"strconv"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/regionctx"
+	"github.com/stackshy/cloudemu/v2/providers/aws/sfn/asl"
 	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
 )
 
-// validateASL performs a minimal Amazon States Language structural check: the
-// definition must be a JSON object carrying a top-level "StartAt" string and a
-// non-empty "States" object. Real Step Functions rejects anything else with
-// InvalidDefinition. No full semantic validation is performed.
+// validateASL runs the ASL parser's structural validation so CreateStateMachine
+// rejects semantically-invalid definitions (unknown state Type, dangling Next,
+// Choice without Choices, unsupported fields on Wait/Choice/Succeed/Fail,
+// QueryLanguage JSONata) with InvalidDefinition, matching real Step Functions.
 func validateASL(definition string) error {
-	var doc struct {
-		StartAt string                     `json:"StartAt"`
-		States  map[string]json.RawMessage `json:"States"`
-	}
-
-	if err := json.Unmarshal([]byte(definition), &doc); err != nil {
-		return invalidDefinition("definition is not valid JSON")
-	}
-
-	if doc.StartAt == "" {
-		return invalidDefinition("definition is missing the required top-level 'StartAt' field")
-	}
-
-	if len(doc.States) == 0 {
-		return invalidDefinition("definition is missing the required top-level 'States' object")
+	if _, err := asl.Parse(definition); err != nil {
+		return invalidDefinition(err.Error())
 	}
 
 	return nil
@@ -185,28 +172,18 @@ func (m *Mock) UpdateStateMachine(
 			"UpdateStateMachine requires at least one of definition or roleArn")
 	}
 
+	// A new definition must be structurally valid, matching real SFN's update-time
+	// validation (and keeping run-time interpretation safe).
+	if in.Definition != "" {
+		if verr := validateASL(in.Definition); verr != nil {
+			return nil, verr
+		}
+	}
+
 	sd.mu.Lock()
 	defer sd.mu.Unlock()
 
-	if in.Definition != "" {
-		sd.sm.Definition = in.Definition
-	}
-
-	if in.RoleArn != "" {
-		sd.sm.RoleArn = in.RoleArn
-	}
-
-	if in.LoggingConfigJSON != "" {
-		sd.sm.LoggingConfigJSON = in.LoggingConfigJSON
-	}
-
-	if in.TracingConfigJSON != "" {
-		sd.sm.TracingConfigJSON = in.TracingConfigJSON
-	}
-
-	if in.EncryptionCfgJSON != "" {
-		sd.sm.EncryptionCfgJSON = in.EncryptionCfgJSON
-	}
+	applyStateMachineUpdate(&sd.sm, in)
 
 	now := m.now()
 	sd.sm.RevisionID = idgen.GenerateID("")
@@ -217,6 +194,32 @@ func (m *Mock) UpdateStateMachine(
 	}
 
 	return res, nil
+}
+
+// applyStateMachineUpdate copies each supplied (non-empty) UpdateStateMachine
+// field onto the stored state machine. The caller holds sm's write lock.
+//
+//nolint:gocritic // in is a value to satisfy the driver.SFN interface signature.
+func applyStateMachineUpdate(sm *driver.StateMachine, in driver.UpdateStateMachineInput) {
+	if in.Definition != "" {
+		sm.Definition = in.Definition
+	}
+
+	if in.RoleArn != "" {
+		sm.RoleArn = in.RoleArn
+	}
+
+	if in.LoggingConfigJSON != "" {
+		sm.LoggingConfigJSON = in.LoggingConfigJSON
+	}
+
+	if in.TracingConfigJSON != "" {
+		sm.TracingConfigJSON = in.TracingConfigJSON
+	}
+
+	if in.EncryptionCfgJSON != "" {
+		sm.EncryptionCfgJSON = in.EncryptionCfgJSON
+	}
 }
 
 func (m *Mock) DeleteStateMachine(_ context.Context, arn string) error {

--- a/providers/aws/sfn/teststate.go
+++ b/providers/aws/sfn/teststate.go
@@ -2,54 +2,57 @@ package sfn
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 
+	"github.com/stackshy/cloudemu/v2/providers/aws/sfn/asl"
 	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
 )
 
-// TestState evaluates a single state definition. The emulator runs no Amazon
-// States Language interpreter: a non-empty definition succeeds and echoes the
-// input as output (an empty input echoes "{}"); an empty definition fails.
-func (*Mock) TestState(_ context.Context, in driver.TestStateInput) (*driver.TestStateResult, error) {
+// TestState evaluates a single state definition through the interpreter: it runs
+// the state's I/O pipeline and handler once (following a Choice to its selected
+// branch without executing it) and returns the resulting Output/Status/NextState,
+// or Error/Cause on failure. ctx is accepted for parity with the Task->Lambda
+// seam a later PR threads through the same handlers.
+func (m *Mock) TestState(_ context.Context, in driver.TestStateInput) (*driver.TestStateResult, error) {
 	if strings.TrimSpace(in.Definition) == "" {
 		return nil, invalidName("definition is required")
 	}
 
-	output := in.Input
-	if strings.TrimSpace(output) == "" {
-		output = emptyJSON
+	res, err := asl.TestOne(in.Definition, &asl.RunInput{Input: in.Input, StartTime: m.now()})
+	if err != nil {
+		return nil, invalidDefinition(err.Error())
 	}
 
-	return &driver.TestStateResult{Output: output, Status: driver.TestStatusSucceeded}, nil
+	return &driver.TestStateResult{
+		Output: res.Output, Status: res.Status, NextState: res.NextState,
+		Error: res.Error, Cause: res.Cause,
+	}, nil
 }
 
-// ValidateStateMachineDefinition checks that a definition is non-empty, valid
-// JSON. No semantic Amazon States Language validation is performed: valid JSON
-// yields result OK with no diagnostics; anything else yields FAIL with a single
-// error diagnostic.
+// ValidateStateMachineDefinition runs the ASL parser's structural validation:
+// valid definitions yield result OK; a structural violation (bad JSON, missing
+// StartAt, unknown state Type, dangling Next, Choice without Choices, unsupported
+// fields on Wait/Choice/Succeed/Fail, QueryLanguage JSONata) yields FAIL with a
+// single error diagnostic.
 func (*Mock) ValidateStateMachineDefinition(
 	_ context.Context, definition, _ string,
 ) (*driver.ValidationResult, error) {
 	if strings.TrimSpace(definition) == "" {
-		return &driver.ValidationResult{
-			Result: driver.ValidationResultFail,
-			Diagnostics: []driver.ValidationDiagnostic{{
-				Severity: driver.ValidationSeverityError, Code: "MISSING_DEFINITION",
-				Message: "state machine definition is required",
-			}},
-		}, nil
+		return validationFail("MISSING_DEFINITION", "state machine definition is required"), nil
 	}
 
-	if !json.Valid([]byte(definition)) {
-		return &driver.ValidationResult{
-			Result: driver.ValidationResultFail,
-			Diagnostics: []driver.ValidationDiagnostic{{
-				Severity: driver.ValidationSeverityError, Code: "SCHEMA_VALIDATION_FAILED",
-				Message: "definition is not valid JSON",
-			}},
-		}, nil
+	if _, err := asl.Parse(definition); err != nil {
+		return validationFail("SCHEMA_VALIDATION_FAILED", err.Error()), nil
 	}
 
 	return &driver.ValidationResult{Result: driver.ValidationResultOK}, nil
+}
+
+func validationFail(code, message string) *driver.ValidationResult {
+	return &driver.ValidationResult{
+		Result: driver.ValidationResultFail,
+		Diagnostics: []driver.ValidationDiagnostic{{
+			Severity: driver.ValidationSeverityError, Code: code, Message: message,
+		}},
+	}
 }

--- a/server/aws/sfn/operations.go
+++ b/server/aws/sfn/operations.go
@@ -199,6 +199,14 @@ func eventsToWire(events []sfndriver.HistoryEvent) []historyEvent {
 			he.ExecutionSucceededDetails = &executionSucceededDetails{Output: e.Output}
 		}
 
+		if e.Type == "ExecutionFailed" {
+			he.ExecutionFailedDetails = &executionFailedDetails{Error: e.Error, Cause: e.Cause}
+		}
+
+		if e.Type == "ExecutionAborted" {
+			he.ExecutionAbortedDetails = &executionAbortedDetails{Error: e.Error, Cause: e.Cause}
+		}
+
 		if strings.HasSuffix(e.Type, "StateEntered") {
 			he.StateEnteredDetails = &stateEnteredDetails{Name: e.StateName, Input: e.Input}
 		}

--- a/server/aws/sfn/types.go
+++ b/server/aws/sfn/types.go
@@ -383,6 +383,16 @@ type stateExitedDetails struct {
 	Output string `json:"output,omitempty"`
 }
 
+type executionFailedDetails struct {
+	Error string `json:"error,omitempty"`
+	Cause string `json:"cause,omitempty"`
+}
+
+type executionAbortedDetails struct {
+	Error string `json:"error,omitempty"`
+	Cause string `json:"cause,omitempty"`
+}
+
 type historyEvent struct {
 	ID                        int64                      `json:"id"`
 	PreviousEventID           int64                      `json:"previousEventId"`
@@ -390,6 +400,8 @@ type historyEvent struct {
 	Timestamp                 *float64                   `json:"timestamp"`
 	ExecutionStartedDetails   *executionStartedDetails   `json:"executionStartedEventDetails,omitempty"`
 	ExecutionSucceededDetails *executionSucceededDetails `json:"executionSucceededEventDetails,omitempty"`
+	ExecutionFailedDetails    *executionFailedDetails    `json:"executionFailedEventDetails,omitempty"`
+	ExecutionAbortedDetails   *executionAbortedDetails   `json:"executionAbortedEventDetails,omitempty"`
 	StateEnteredDetails       *stateEnteredDetails       `json:"stateEnteredEventDetails,omitempty"`
 	StateExitedDetails        *stateExitedDetails        `json:"stateExitedEventDetails,omitempty"`
 }

--- a/services/sfn/driver/driver.go
+++ b/services/sfn/driver/driver.go
@@ -3,11 +3,12 @@
 // verbatim), executions, execution history, activities, tags, and — where the
 // SDK exposes them — state-machine versions and aliases.
 //
-// The emulator does NOT interpret the Amazon States Language: StartExecution
-// completes an execution immediately (RUNNING then SUCCEEDED) with output
-// echoing the input, and GetExecutionHistory synthesizes a minimal but valid
-// event list. This keeps behavior deterministic and dependency-free while
-// preserving the SDK wire shapes.
+// The emulator interprets the Amazon States Language with a real state-graph
+// walker (see providers/aws/sfn/asl): StartExecution walks the definition from
+// StartAt following Next/End, computes the true terminal status and output, and
+// records a per-state event history. Execution completes synchronously; the
+// settle overlay keeps RUNNING->SUCCEEDED/FAILED observable under AsyncSettle.
+// The interpreter is dependency-free and deterministic (driven by config.Clock).
 package driver
 
 import (
@@ -120,6 +121,9 @@ type Execution struct {
 	Cause           string
 	StartDate       time.Time
 	StopDate        time.Time
+	// History is the full per-state event list the interpreter produced, stored
+	// on the execution so it round-trips through snapshot/persist for free.
+	History []HistoryEvent
 }
 
 // HistoryEvent is one entry in an execution's event history.
@@ -134,6 +138,10 @@ type HistoryEvent struct {
 	// ExecutionSucceeded and StateExited events.
 	Input  string
 	Output string
+	// Error and Cause are set on failure/abort events (ExecutionFailed,
+	// FailStateEntered, ExecutionAborted, LambdaFunctionFailed).
+	Error string
+	Cause string
 }
 
 // Activity is a task worker registration.
@@ -275,6 +283,8 @@ type SFN interface {
 	StartExecution(ctx context.Context, in StartExecutionInput) (*Execution, error)
 	StartSyncExecution(ctx context.Context, in StartExecutionInput) (*Execution, error)
 	DescribeExecution(ctx context.Context, arn string) (*Execution, error)
+	// StopExecution aborts a still-settling execution, persisting the caller's
+	// errCode/cause onto the execution's Error/Cause fields.
 	StopExecution(ctx context.Context, arn, errCode, cause string) (time.Time, error)
 	ListExecutions(ctx context.Context, stateMachineArn, statusFilter string) ([]Execution, error)
 	GetExecutionHistory(ctx context.Context, arn string, reverse bool) ([]HistoryEvent, error)


### PR DESCRIPTION
## Summary

PR1 of 3 replacing the Step Functions auto-succeed stub with a real Amazon States Language (ASL) interpreter (#581). This PR ships the **core walker + I/O pipeline + history plumbing**; Task→Lambda lands in PR2, Parallel/Map in PR3.

New internal package `providers/aws/sfn/asl` walks the state graph from `StartAt` following `Next`/`End`, computes the true terminal status/output, and records a real per-state event history.

### What's live
- **State types:** Pass, Choice, Wait, Succeed, Fail. Task/Parallel/Map parse (accepted at create time) but fail loudly at run time until their handlers land.
- **Choice comparators:** String (incl. glob `StringMatches`), Numeric, Boolean, Timestamp, type-checks (`IsNull`/`IsPresent`/`IsNumeric`/`IsString`/`IsBoolean`/`IsTimestamp`), And/Or/Not, and `...Path` variants.
- **I/O pipeline:** `InputPath → Parameters → [Result] → ResultPath → OutputPath`, applied per state only where ASL permits.
- **JSONPath:** reference/selection subset (`$`, `$.a.b`, `$[0]`, `$.a.b[2]`); filters/wildcards/recursive-descent are rejected, not silently mis-run.
- **`$$` context object** + first-wave intrinsics (`Format`, `Array`, `ArrayGetItem`, `StringToJson`, `JsonToString`, `UUID`).
- **History:** monotonic IDs with a chained `PreviousEventID`, persisted on `driver.Execution.History` so it snapshot/restores for free; `ExecutionFailed`/`ExecutionAborted` carry Error/Cause.

### Corrected semantics
- **ResultPath merges onto the RAW input** (the document handed to the state, *before* InputPath filtered it) — so InputPath-narrow + ResultPath-reattach preserves the sibling fields InputPath excluded. `ResultPath:null` passes the raw input through; default `$` replaces the document. Explicitly tested.
- **ctx is threaded end-to-end:** `runExecution` now takes `ctx`; `StartExecution`/`StartSyncExecution` forward it instead of discarding it (plumbing for the PR2 Task→Lambda recursion guard, even though no PR1 handler consumes it).

### Validation
Stricter `CreateStateMachine`/`UpdateStateMachine`/`ValidateStateMachineDefinition`/`TestState`: unknown state type, dangling `Next`, `Choice` without `Choices`, unsupported fields on Wait/Choice/Succeed/Fail, and `QueryLanguage: "JSONata"` are rejected with InvalidDefinition. Definitions are still stored verbatim (snapshot/persist untouched).

### Execution model
Synchronous whole-graph execution preserved; the `settle.Window` overlay still gates RUNNING→terminal observability under `AsyncSettle` (off by default → instant), extended by accumulated `Wait` durations. `GetExecutionHistory` time-truncates events while unsettled.

## Tests
- Pass/Wait/Choice/Succeed/Fail run to correct terminal output; a Choice branch per comparator family.
- **Dedicated ResultPath test** proving InputPath-narrow + ResultPath-reattach preserves the excluded sibling field, plus `ResultPath:null` and default `$`.
- OutputPath filtering; malformed ASL / JSONata / unsupported-JSONPath rejection at create/validate time.
- `GetExecutionHistory` real event sequence with a valid `PreviousEventID` chain (forward + reversed); snapshot/restore round-trips history byte-identically.
- Wait under `AsyncSettle` + FakeClock (RUNNING+truncated → SUCCEEDED+full) and instant without it; StopExecution surfaces Error/Cause on ABORTED; maxSteps Choice/Next cycle fails with `CloudEmu.StateTransitionLimitExceeded`; ctx-forwarding entry point.
- asl-package unit tests for glob, JSONPath, intrinsics, payload template, parser.

## Gates (GOMAXPROCS=2)
`go build ./...`, `go vet`, `go test ./...` (full suite), `go generate ./...` (coverage regen committed), and `golangci-lint run` on the sfn packages — all green, 0 lint issues, no `nolint` added.

## Follow-ups
- **PR2:** Task(Lambda) + recursion-guarded `LambdaSyncInvoker` seam + Retry/Catch + `LambdaFunction*` sub-events.
- **PR3:** Parallel (sequential branches) + Map (sequential iterations).
