### PR TITLE
feat(sfn): ASL interpreter PR2 — Task/Lambda with Retry/Catch (#581)

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -318,6 +318,24 @@ func New(opts ...config.Option) *Provider {
 	p.EventBridge.SetLambdaInvoker(p.Lambda)
 	p.EventBridge.SetSNSPublisher(p.SNS)
 	p.EventBridge.SetStepFunctionsStarter(p.SFN)
+	// Step Functions -> Lambda: a Task state (arn:aws:states:::lambda:invoke or a
+	// bare Lambda function ARN) invokes the function synchronously through the
+	// recursion-guarded InvokeSync seam, so a Task->Lambda->StartExecution->Task
+	// cycle terminates at recursionguard.MaxDepth instead of overflowing.
+	p.SFN.SetLambdaSyncInvoker(p.Lambda)
+	wireLambdaEventSources(p)
+
+	p.ResourceDiscovery = resourcediscovery.New(
+		resourcediscovery.ProviderAWS, o.AccountID, o.Region, awsDrivers(p),
+	)
+
+	return p
+}
+
+// wireLambdaEventSources wires the services that deliver events to Lambda
+// through the shared InvokeExternal choke point. It is split out of New so the
+// factory stays within the function-length budget.
+func wireLambdaEventSources(p *Provider) {
 	// S3 event notifications deliver to their configured targets: SQS queues,
 	// SNS topics, and Lambda functions.
 	p.S3.SetSQSDeliverer(p.SQS)
@@ -338,12 +356,6 @@ func New(opts ...config.Option) *Provider {
 	// subscription filter's pattern are delivered (gzipped awslogs payload) to
 	// the filter's Lambda destination on PutLogEvents.
 	p.CloudWatchLogs.SetLambdaInvoker(p.Lambda)
-
-	p.ResourceDiscovery = resourcediscovery.New(
-		resourcediscovery.ProviderAWS, o.AccountID, o.Region, awsDrivers(p),
-	)
-
-	return p
 }
 
 // awsDrivers assembles the resource-discovery driver set from the provider's

--- a/providers/aws/lambda/invoke_sync.go
+++ b/providers/aws/lambda/invoke_sync.go
@@ -1,0 +1,53 @@
+package lambda
+
+import (
+	"context"
+	"fmt"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// InvokeSync synchronously invokes the function identified by its ARN (or bare
+// name) and returns the output payload plus a functionError set when the handler
+// ran but raised (StatusCode 500 / a non-empty out.Error — the same X-Amz-
+// Function-Error semantics Invoke reports). It backs the Step Functions
+// Task->Lambda seam (sfn.LambdaSyncInvoker).
+//
+// Like InvokeExternal, it is a synchronous Lambda-delivery entry point that
+// bypasses the Invoke wire path's choke points, so it MUST carry the same
+// recursive-loop guard: a Task whose Lambda starts an execution that Tasks back
+// into Lambda re-enters here on the same goroutine (invoke -> handler ->
+// StartExecution -> Task -> InvokeSync -> ...). ctx carries the re-entrant
+// delivery depth (see internal/recursionguard); once it reaches
+// recursionguard.MaxDepth — matching AWS Lambda's own recursive-loop detection
+// (~16 invocations within one chain of requests) — the invocation is dropped
+// and reported as a bounded functionError (which the Task maps to
+// States.TaskFailed) instead of recursing the process into an unrecoverable
+// stack overflow.
+func (m *Mock) InvokeSync(
+	ctx context.Context, functionARN string, payload []byte,
+) (output []byte, functionError string, err error) {
+	name := functionNameFromARN(functionARN)
+	if _, ok := m.funcs.Get(name); !ok {
+		return nil, "", cerrors.Newf(cerrors.NotFound, "function %s not found", name)
+	}
+
+	depth := recursionguard.Depth(ctx)
+	if depth >= recursionguard.MaxDepth {
+		return nil, fmt.Sprintf(
+			"Lambda recursive invocation limit (%d) reached for function %s", recursionguard.MaxDepth, name), nil
+	}
+
+	ctx = recursionguard.WithDepth(ctx, depth+1)
+
+	out, invErr := m.Invoke(ctx, driver.InvokeInput{
+		FunctionName: name, Payload: payload, InvokeType: "RequestResponse",
+	})
+	if invErr != nil {
+		return nil, "", invErr
+	}
+
+	return out.Payload, out.Error, nil
+}

--- a/providers/aws/lambda/invoke_sync_test.go
+++ b/providers/aws/lambda/invoke_sync_test.go
@@ -1,0 +1,118 @@
+package lambda
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+)
+
+// TestInvokeSyncReturnsOutput verifies InvokeSync runs the handler and returns
+// its output payload with no functionError.
+func TestInvokeSyncReturnsOutput(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	m.RegisterHandler("my-func", func(_ context.Context, payload []byte) ([]byte, error) {
+		return append([]byte("echo:"), payload...), nil
+	})
+
+	out, funcErr, err := m.InvokeSync(ctx, "arn:aws:lambda:us-east-1:000000000000:function:my-func", []byte("hi"))
+	if err != nil || funcErr != "" {
+		t.Fatalf("InvokeSync err=%v funcErr=%q", err, funcErr)
+	}
+
+	if string(out) != "echo:hi" {
+		t.Fatalf("InvokeSync output = %q, want echo:hi", out)
+	}
+}
+
+// TestInvokeSyncFunctionError surfaces a raising handler as a non-empty
+// functionError (which the Step Functions Task maps to States.TaskFailed).
+func TestInvokeSyncFunctionError(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	m.RegisterHandler("my-func", func(_ context.Context, _ []byte) ([]byte, error) {
+		return nil, context.Canceled
+	})
+
+	_, funcErr, err := m.InvokeSync(ctx, "my-func", []byte("{}"))
+	if err != nil {
+		t.Fatalf("InvokeSync err = %v, want nil (handler failure is a functionError)", err)
+	}
+
+	if funcErr == "" {
+		t.Fatal("InvokeSync functionError is empty, want the handler error surfaced")
+	}
+}
+
+// TestInvokeSyncRecursionGuardBoundary asserts InvokeSync at MaxDepth drops the
+// invocation and reports a bounded functionError instead of invoking.
+func TestInvokeSyncRecursionGuardBoundary(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	ran := false
+	m.RegisterHandler("my-func", func(_ context.Context, _ []byte) ([]byte, error) {
+		ran = true
+		return []byte("{}"), nil
+	})
+
+	atMax := recursionguard.WithDepth(ctx, recursionguard.MaxDepth)
+
+	_, funcErr, err := m.InvokeSync(atMax, "my-func", []byte("{}"))
+	if err != nil {
+		t.Fatalf("InvokeSync at MaxDepth err = %v", err)
+	}
+
+	if funcErr == "" {
+		t.Fatal("InvokeSync at MaxDepth returned no functionError, want the recursion-limit error")
+	}
+
+	if ran {
+		t.Fatal("handler ran at MaxDepth, want the invocation dropped")
+	}
+}
+
+// TestInvokeSyncSelfRecursionTerminates proves a handler that re-invokes itself
+// through InvokeSync terminates at recursionguard.MaxDepth (never a stack
+// overflow), because InvokeSync increments the ctx depth on each hop.
+func TestInvokeSyncSelfRecursionTerminates(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	maxSeen := 0
+	m.RegisterHandler("my-func", func(hctx context.Context, _ []byte) ([]byte, error) {
+		if d := recursionguard.Depth(hctx); d > maxSeen {
+			maxSeen = d
+		}
+		// Re-enter through the same sync seam; the guard bounds the chain.
+		_, _, err := m.InvokeSync(hctx, "my-func", []byte("{}"))
+		return []byte("{}"), err
+	})
+
+	if _, _, err := m.InvokeSync(ctx, "my-func", []byte("{}")); err != nil {
+		t.Fatalf("InvokeSync self-recursion err = %v", err)
+	}
+
+	if maxSeen < recursionguard.MaxDepth {
+		t.Fatalf("max handler depth = %d, want to reach MaxDepth %d", maxSeen, recursionguard.MaxDepth)
+	}
+}

--- a/providers/aws/sfn/asl/history.go
+++ b/providers/aws/sfn/asl/history.go
@@ -7,12 +7,14 @@ import "github.com/stackshy/cloudemu/v2/services/sfn/driver"
 // The event set for this build is:
 //
 //	ExecutionStarted
-//	<Type>StateEntered / <Type>StateExited   (Pass, Choice, Wait, Succeed)
+//	<Type>StateEntered / <Type>StateExited   (Pass, Choice, Wait, Succeed, Task)
 //	FailStateEntered                          (Fail — terminal, no exit)
-//	ExecutionSucceeded / ExecutionFailed
+//	LambdaFunctionScheduled / LambdaFunctionStarted /
+//	LambdaFunctionSucceeded / LambdaFunctionFailed   (Task->Lambda sub-events)
+//	ExecutionSucceeded / ExecutionFailed / ExecutionAborted
 //
-// Richer AWS sub-events (LambdaFunction*, MapIteration*, evaluation events) are
-// out of scope until the Task/Parallel/Map handlers land.
+// Richer AWS sub-events (MapIteration*, evaluation events) are out of scope
+// until the Parallel/Map handlers land.
 
 // historyFail builds the FailStateEntered event for a Fail state.
 func historyFail(st *State) *driver.HistoryEvent {
@@ -22,4 +24,22 @@ func historyFail(st *State) *driver.HistoryEvent {
 		Error:     st.Error,
 		Cause:     st.Cause,
 	}
+}
+
+// historyLambdaScheduled builds the LambdaFunctionScheduled event carrying the
+// Task Resource and the payload delivered to the function.
+func historyLambdaScheduled(st *State, payload []byte) *driver.HistoryEvent {
+	return &driver.HistoryEvent{Type: "LambdaFunctionScheduled", Resource: st.Resource, Input: string(payload)}
+}
+
+// historyLambdaSucceeded builds the LambdaFunctionSucceeded event carrying the
+// task result.
+func historyLambdaSucceeded(result any) *driver.HistoryEvent {
+	return &driver.HistoryEvent{Type: "LambdaFunctionSucceeded", Output: toJSON(result)}
+}
+
+// historyLambdaFailed builds the LambdaFunctionFailed event carrying the error
+// code and cause that surface to Retry/Catch.
+func historyLambdaFailed(se *stateError) *driver.HistoryEvent {
+	return &driver.HistoryEvent{Type: "LambdaFunctionFailed", Error: se.Code, Cause: se.Cause}
 }

--- a/providers/aws/sfn/asl/interpret.go
+++ b/providers/aws/sfn/asl/interpret.go
@@ -42,6 +42,14 @@ func asStateError(err error) *stateError {
 	return &stateError{Code: "States.Runtime", Cause: err.Error()}
 }
 
+// LambdaInvoker invokes a Lambda function synchronously for a Task state. It
+// returns the function's output payload; a non-empty functionError when the
+// function ran but raised (mapped upstream to States.TaskFailed, feeding
+// Retry/Catch); or a transport err. The sfn Mock wires a recursion-guarded
+// adapter here so a Task->Lambda->StartExecution->Task cycle terminates at
+// recursionguard.MaxDepth instead of overflowing the stack.
+type LambdaInvoker func(ctx context.Context, functionARN string, payload []byte) (output []byte, functionError string, err error)
+
 // RunInput carries the per-execution context the interpreter needs.
 type RunInput struct {
 	Input      string
@@ -53,6 +61,9 @@ type RunInput struct {
 	StartTime  time.Time
 	SettleBase time.Duration
 	MaxSteps   int
+	// InvokeLambda is the Task->Lambda seam. When nil (library-only
+	// construction), a Task echoes its input so existing behavior is preserved.
+	InvokeLambda LambdaInvoker
 }
 
 // RunResult is the outcome of interpreting a definition against an input.
@@ -76,6 +87,9 @@ type interp struct {
 	lastID    int64
 	ctxObj    map[string]any
 	handlers  map[string]handler
+
+	// invokeLambda is the Task->Lambda seam; nil means echo-input fallback.
+	invokeLambda LambdaInvoker
 }
 
 // Run interprets def against the execution input, returning the terminal status,
@@ -92,10 +106,11 @@ func Run(ctx context.Context, def *StateMachineDef, in *RunInput) *RunResult {
 	}
 
 	it := &interp{
-		def:      def,
-		baseTime: in.StartTime,
-		maxSteps: maxSteps,
-		handlers: buildHandlers(),
+		def:          def,
+		baseTime:     in.StartTime,
+		maxSteps:     maxSteps,
+		handlers:     buildHandlers(),
+		invokeLambda: in.InvokeLambda,
 	}
 
 	input := parseInput(in.Input)
@@ -121,7 +136,7 @@ func buildHandlers() map[string]handler {
 		TypeWait:     waitHandler,
 		TypeSucceed:  succeedHandler,
 		TypeFail:     failHandler,
-		TypeTask:     unsupportedHandler,
+		TypeTask:     taskHandler,
 		TypeParallel: unsupportedHandler,
 		TypeMap:      unsupportedHandler,
 	}

--- a/providers/aws/sfn/asl/io.go
+++ b/providers/aws/sfn/asl/io.go
@@ -48,19 +48,36 @@ func (it *interp) applyParameters(st *State, input any) (any, error) {
 	return it.applyPayloadTemplate(st.Parameters, input)
 }
 
-// applyResultPath merges the result onto the RAW input. Absent ResultPath
-// defaults to "$" (the result replaces the document); an explicit null discards
-// the result and passes the raw input through; a path splices the result in.
-func (*interp) applyResultPath(st *State, raw, result any) (any, error) {
-	if !st.ResultPath.set || st.ResultPath.path == "$" {
+// applyResultSelector reshapes a Task/Parallel/Map result via a payload template
+// before ResultPath merges it. Absent ResultSelector passes the result through.
+func (it *interp) applyResultSelector(st *State, result any) (any, error) {
+	if st.ResultSelector == nil {
 		return result, nil
 	}
 
-	if st.ResultPath.null {
+	return it.applyPayloadTemplate(st.ResultSelector, result)
+}
+
+// applyResultPath merges the result onto the RAW input using the state's
+// ResultPath. Absent ResultPath defaults to "$" (the result replaces the
+// document); an explicit null discards the result and passes the raw input
+// through; a path splices the result in.
+func (*interp) applyResultPath(st *State, raw, result any) (any, error) {
+	return mergeResultPath(st.ResultPath, raw, result)
+}
+
+// mergeResultPath splices result into raw at the given ResultPath (the shared
+// semantic used by both a state's ResultPath and a Catcher's ResultPath).
+func mergeResultPath(rp pathField, raw, result any) (any, error) {
+	if !rp.set || rp.path == "$" {
+		return result, nil
+	}
+
+	if rp.null {
 		return raw, nil
 	}
 
-	fields, err := objectFieldPath(st.ResultPath.path)
+	fields, err := objectFieldPath(rp.path)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/aws/sfn/asl/parse.go
+++ b/providers/aws/sfn/asl/parse.go
@@ -5,13 +5,15 @@
 // per-state event history. It is driven by config.Clock so Wait timing is
 // deterministic under a FakeClock.
 //
-// Supported in this build: Pass, Choice, Wait, Succeed, Fail; the full
-// InputPath -> Parameters -> Result -> ResultSelector -> ResultPath -> OutputPath
-// I/O pipeline; a reference/selection JSONPath subset; the $$ context object; and
-// a first-wave intrinsic set. Task, Parallel and Map parse (so a definition
-// containing them is accepted at create time) but fail loudly at run time until
-// their handlers land. JSONata query language, and JSONPath filters/wildcards/
-// recursive-descent, are rejected rather than silently mis-run.
+// Supported in this build: Pass, Choice, Wait, Succeed, Fail, and Task (the
+// arn:aws:states:::lambda:invoke and bare Lambda-function-ARN forms, with Retry
+// and Catch); the full InputPath -> Parameters -> Result -> ResultSelector ->
+// ResultPath -> OutputPath I/O pipeline; a reference/selection JSONPath subset;
+// the $$ context object; and a first-wave intrinsic set. Parallel and Map parse
+// (so a definition containing them is accepted at create time) but fail loudly
+// at run time until their handlers land. JSONata query language, and JSONPath
+// filters/wildcards/recursive-descent, are rejected rather than silently
+// mis-run.
 package asl
 
 import (
@@ -83,8 +85,10 @@ type State struct {
 	Error string `json:"Error"`
 	Cause string `json:"Cause"`
 
-	// Task (parsed; handled in a later PR).
-	Resource string `json:"Resource"`
+	// Task.
+	Resource string     `json:"Resource"`
+	Retry    []*Retrier `json:"Retry"`
+	Catch    []*Catcher `json:"Catch"`
 }
 
 // StateMachineDef is a parsed ASL definition.

--- a/providers/aws/sfn/asl/retry.go
+++ b/providers/aws/sfn/asl/retry.go
@@ -1,0 +1,142 @@
+package asl
+
+import (
+	"context"
+	"math"
+	"time"
+)
+
+// ASL Retrier defaults applied when a field is omitted.
+const (
+	defaultRetryInterval = 1.0
+	defaultRetryMax      = 3
+	defaultBackoffRate   = 2.0
+	errAll               = "States.ALL"
+)
+
+// Retrier is one entry in a state's Retry array. MaxDelaySeconds and
+// JitterStrategy are parsed but deliberately NOT honored yet (a documented
+// deferred no-op) so a definition using them is accepted without silently
+// changing backoff timing.
+type Retrier struct {
+	ErrorEquals     []string `json:"ErrorEquals"`
+	IntervalSeconds *float64 `json:"IntervalSeconds"`
+	MaxAttempts     *int     `json:"MaxAttempts"`
+	BackoffRate     *float64 `json:"BackoffRate"`
+	MaxDelaySeconds *int     `json:"MaxDelaySeconds"` // deferred no-op
+	JitterStrategy  string   `json:"JitterStrategy"`  // deferred no-op
+}
+
+// Catcher is one entry in a state's Catch array: a matching error transitions to
+// Next with the {Error,Cause} error output merged at ResultPath.
+type Catcher struct {
+	ErrorEquals []string  `json:"ErrorEquals"`
+	Next        string    `json:"Next"`
+	ResultPath  pathField `json:"ResultPath"`
+}
+
+// invokeTaskWithRetry runs the Lambda invocation, retrying on a matching Retrier
+// until it succeeds or the matched Retrier's MaxAttempts is exhausted. Backoff
+// advances the virtual clock (config.Clock), so timing is FakeClock-deterministic
+// and folds into the settle window under AsyncSettle.
+func (it *interp) invokeTaskWithRetry(
+	ctx context.Context, st *State, funcRef string, payload []byte,
+) (any, *stateError) {
+	attempts := make([]int, len(st.Retry))
+
+	for {
+		result, se := it.invokeLambdaTask(ctx, st, funcRef, payload)
+		if se == nil {
+			return result, nil
+		}
+
+		idx := matchRetrier(st.Retry, se.Code)
+		if idx < 0 || attempts[idx] >= retrierMaxAttempts(st.Retry[idx]) {
+			return nil, se
+		}
+
+		it.backoff(retrierDelay(st.Retry[idx], attempts[idx]))
+
+		attempts[idx]++
+	}
+}
+
+// tryCatch finds the first Catcher matching se and, on a match, returns the
+// error output merged at the Catcher's ResultPath and the Catcher's Next.
+func tryCatch(st *State, raw any, se *stateError) (out any, next string, ok bool) {
+	for _, c := range st.Catch {
+		if !errorMatches(c.ErrorEquals, se.Code) {
+			continue
+		}
+
+		errOut := map[string]any{"Error": se.Code, "Cause": se.Cause}
+
+		merged, err := mergeResultPath(c.ResultPath, raw, errOut)
+		if err != nil {
+			merged = errOut
+		}
+
+		return merged, c.Next, true
+	}
+
+	return nil, "", false
+}
+
+// matchRetrier returns the index of the first Retrier whose ErrorEquals matches
+// code, or -1. Per the ASL spec the first match wins; a later Retrier is not
+// consulted even if the matched one's attempts are exhausted.
+func matchRetrier(retriers []*Retrier, code string) int {
+	for i, r := range retriers {
+		if errorMatches(r.ErrorEquals, code) {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// errorMatches reports whether an error code satisfies an ErrorEquals set;
+// States.ALL matches any error.
+func errorMatches(errorEquals []string, code string) bool {
+	for _, e := range errorEquals {
+		if e == errAll || e == code {
+			return true
+		}
+	}
+
+	return false
+}
+
+// retrierMaxAttempts is the Retrier's MaxAttempts, defaulting to 3. A value of 0
+// means the error is never retried.
+func retrierMaxAttempts(r *Retrier) int {
+	if r.MaxAttempts == nil {
+		return defaultRetryMax
+	}
+
+	return *r.MaxAttempts
+}
+
+// retrierDelay is IntervalSeconds * BackoffRate^attempt (attempt counts prior
+// retries of this Retrier), with the ASL defaults applied when fields are unset.
+func retrierDelay(r *Retrier, attempt int) time.Duration {
+	interval := defaultRetryInterval
+	if r.IntervalSeconds != nil {
+		interval = *r.IntervalSeconds
+	}
+
+	rate := defaultBackoffRate
+	if r.BackoffRate != nil {
+		rate = *r.BackoffRate
+	}
+
+	secs := interval * math.Pow(rate, float64(attempt))
+
+	return time.Duration(secs * float64(time.Second))
+}
+
+// backoff advances the interpreter's virtual clock offset and Wait/Retry total.
+func (it *interp) backoff(d time.Duration) {
+	it.offset += d
+	it.waitTotal += d
+}

--- a/providers/aws/sfn/asl/task.go
+++ b/providers/aws/sfn/asl/task.go
@@ -1,0 +1,211 @@
+package asl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
+)
+
+// lambdaInvokeResource is the optimized Task integration ARN for a synchronous
+// Lambda invoke; its Parameters carry FunctionName + Payload.
+const lambdaInvokeResource = "arn:aws:states:::lambda:invoke"
+
+// lambdaOKStatus is the StatusCode a successful lambda:invoke response envelope
+// reports.
+const lambdaOKStatus = 200
+
+// taskHandler runs a Task state. It resolves the Lambda call from the Resource
+// ARN and the InputPath->Parameters-shaped payload, invokes the function through
+// the recursion-guarded seam under Retry, and on success runs the result through
+// ResultSelector->ResultPath->OutputPath. A failure that no Catcher handles
+// propagates to ExecutionFailed; a caught failure transitions to the Catcher's
+// Next with the {Error,Cause} error output merged at its ResultPath.
+func taskHandler(ctx context.Context, it *interp, st *State, raw any) (out any, next string, terminal bool, err error) {
+	it.enterState(st, raw)
+
+	funcRef, payload, perr := it.prepareTask(st, raw)
+	if perr != nil {
+		return nil, "", false, perr
+	}
+
+	result, se := it.invokeTaskWithRetry(ctx, st, funcRef, payload)
+	if se != nil {
+		return handleTaskError(st, raw, se)
+	}
+
+	return it.finishTask(st, raw, result)
+}
+
+// prepareTask runs the input pipeline (InputPath->Parameters) and resolves the
+// target function reference and the payload delivered to it.
+func (it *interp) prepareTask(st *State, raw any) (funcRef string, payload []byte, err error) {
+	filtered, ferr := it.applyInputPath(st, raw)
+	if ferr != nil {
+		return "", nil, ferr
+	}
+
+	params, perr := it.applyParameters(st, filtered)
+	if perr != nil {
+		return "", nil, perr
+	}
+
+	return resolveLambdaCall(st, params)
+}
+
+// finishTask runs the result pipeline on a successful task result and emits the
+// TaskStateExited event.
+func (it *interp) finishTask(st *State, raw, result any) (out any, next string, terminal bool, err error) {
+	selected, err := it.applyResultSelector(st, result)
+	if err != nil {
+		return nil, "", false, err
+	}
+
+	merged, err := it.applyResultPath(st, raw, selected)
+	if err != nil {
+		return nil, "", false, err
+	}
+
+	out, err = it.applyOutputPath(st, merged)
+	if err != nil {
+		return nil, "", false, err
+	}
+
+	it.exitState(st, out)
+
+	return out, st.Next, st.End, nil
+}
+
+// handleTaskError routes a task failure to a matching Catcher (transitioning to
+// its Next), or propagates it to ExecutionFailed when no Catcher matches.
+func handleTaskError(st *State, raw any, se *stateError) (out any, next string, terminal bool, err error) {
+	if caughtOut, catchNext, ok := tryCatch(st, raw, se); ok {
+		return caughtOut, catchNext, false, nil
+	}
+
+	return nil, "", false, se
+}
+
+// invokeLambdaTask performs one Lambda invocation attempt, emitting the
+// LambdaFunctionScheduled/Started and Succeeded/Failed sub-events. With no seam
+// wired (library-only construction) it echoes the payload as the result.
+func (it *interp) invokeLambdaTask(ctx context.Context, st *State, funcRef string, payload []byte) (any, *stateError) {
+	it.emit(historyLambdaScheduled(st, payload))
+	it.emit(&driver.HistoryEvent{Type: "LambdaFunctionStarted"})
+
+	if it.invokeLambda == nil {
+		result := wrapTaskResult(st, payload)
+		it.emit(historyLambdaSucceeded(result))
+
+		return result, nil
+	}
+
+	outBytes, funcErr, err := it.invokeLambda(ctx, funcRef, payload)
+	if se := taskFailure(err, funcErr); se != nil {
+		it.emit(historyLambdaFailed(se))
+
+		return nil, se
+	}
+
+	result := wrapTaskResult(st, outBytes)
+	it.emit(historyLambdaSucceeded(result))
+
+	return result, nil
+}
+
+// taskFailure maps a transport error or a Lambda functionError to States.TaskFailed
+// (feeding Retry/Catch), or returns nil when the invocation succeeded.
+func taskFailure(err error, funcErr string) *stateError {
+	switch {
+	case err != nil:
+		return &stateError{Code: "States.TaskFailed", Cause: err.Error()}
+	case funcErr != "":
+		return &stateError{Code: "States.TaskFailed", Cause: funcErr}
+	default:
+		return nil
+	}
+}
+
+// resolveLambdaCall parses the Task Resource, returning the target function
+// reference and the payload to deliver. It supports the optimized
+// arn:aws:states:::lambda:invoke integration (payload from Parameters.Payload)
+// and the bare Lambda-function-ARN form (payload is the effective input). Any
+// other Resource fails loudly, feeding Retry/Catch rather than panicking.
+func resolveLambdaCall(st *State, params any) (funcRef string, payload []byte, err error) {
+	switch {
+	case st.Resource == lambdaInvokeResource:
+		return optimizedLambdaCall(params)
+	case isLambdaFunctionARN(st.Resource):
+		return st.Resource, valueToBytes(params), nil
+	default:
+		return "", nil, &stateError{Code: "States.Runtime",
+			Cause: fmt.Sprintf("unsupported Task Resource %q (only Lambda is supported)", st.Resource)}
+	}
+}
+
+// optimizedLambdaCall extracts FunctionName and Payload from the Parameters of
+// an arn:aws:states:::lambda:invoke Task.
+func optimizedLambdaCall(params any) (funcRef string, payload []byte, err error) {
+	m, ok := params.(map[string]any)
+	if !ok {
+		return "", nil, &stateError{Code: "States.Runtime",
+			Cause: "lambda:invoke Task requires Parameters with FunctionName"}
+	}
+
+	fn, _ := m["FunctionName"].(string)
+	if fn == "" {
+		return "", nil, &stateError{Code: "States.Runtime",
+			Cause: "lambda:invoke Task Parameters is missing FunctionName"}
+	}
+
+	return fn, valueToBytes(m["Payload"]), nil
+}
+
+// wrapTaskResult shapes the raw Lambda output into the state's result: the
+// optimized lambda:invoke integration wraps it in the Lambda invoke response
+// envelope, while the bare-ARN form yields the function output directly.
+func wrapTaskResult(st *State, outBytes []byte) any {
+	out := bytesToValue(outBytes)
+	if st.Resource == lambdaInvokeResource {
+		return map[string]any{"ExecutedVersion": "$LATEST", "Payload": out, "StatusCode": float64(lambdaOKStatus)}
+	}
+
+	return out
+}
+
+// isLambdaFunctionARN reports whether res is a bare Lambda function ARN.
+func isLambdaFunctionARN(res string) bool {
+	return strings.HasPrefix(res, "arn:aws:lambda:") && strings.Contains(res, ":function:")
+}
+
+// valueToBytes marshals a payload value to JSON, defaulting a nil/failed value
+// to an empty object.
+func valueToBytes(v any) []byte {
+	if v == nil {
+		return []byte(emptyObject)
+	}
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		return []byte(emptyObject)
+	}
+
+	return b
+}
+
+// bytesToValue parses a JSON payload into a Go value, defaulting empty/invalid
+// bytes to an empty object.
+func bytesToValue(b []byte) any {
+	if len(b) == 0 {
+		return map[string]any{}
+	}
+
+	var v any
+	if err := json.Unmarshal(b, &v); err != nil {
+		return map[string]any{}
+	}
+
+	return v
+}

--- a/providers/aws/sfn/asl/teststate.go
+++ b/providers/aws/sfn/asl/teststate.go
@@ -25,7 +25,11 @@ const testStateName = "__TestState__"
 // the Next it would transition to (the selected branch for a Choice; empty for a
 // terminal state), and SUCCEEDED/FAILED. A structurally-invalid state is a
 // parse error the caller maps to its own validation surface.
-func TestOne(definition string, in *RunInput) (*StateResult, error) {
+func TestOne(ctx context.Context, definition string, in *RunInput) (*StateResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	var st State
 	if err := json.Unmarshal([]byte(definition), &st); err != nil {
 		return nil, fmt.Errorf("state definition is not valid JSON: %w", err)
@@ -37,12 +41,15 @@ func TestOne(definition string, in *RunInput) (*StateResult, error) {
 
 	st.name = testStateName
 
-	it := &interp{baseTime: in.StartTime, offset: in.SettleBase, maxSteps: 1, handlers: buildHandlers()}
+	it := &interp{
+		baseTime: in.StartTime, offset: in.SettleBase, maxSteps: 1,
+		handlers: buildHandlers(), invokeLambda: in.InvokeLambda,
+	}
 	input := parseInput(in.Input)
 	it.buildContext(in, input)
 	it.enterStateContext(&st)
 
-	out, next, terminal, err := it.handlers[st.Type](context.Background(), it, &st, input)
+	out, next, terminal, err := it.handlers[st.Type](ctx, it, &st, input)
 	if err != nil {
 		se := asStateError(err)
 

--- a/providers/aws/sfn/asl/validate.go
+++ b/providers/aws/sfn/asl/validate.go
@@ -51,6 +51,10 @@ func validateFieldApplicability(st *State) error {
 		return aslErrf("state %q (%s) does not support the 'ResultSelector' field", st.name, st.Type)
 	case st.ResultPath.set:
 		return aslErrf("state %q (%s) does not support the 'ResultPath' field", st.name, st.Type)
+	case len(st.Retry) > 0:
+		return aslErrf("state %q (%s) does not support the 'Retry' field", st.name, st.Type)
+	case len(st.Catch) > 0:
+		return aslErrf("state %q (%s) does not support the 'Catch' field", st.name, st.Type)
 	}
 
 	return nil

--- a/providers/aws/sfn/executions.go
+++ b/providers/aws/sfn/executions.go
@@ -58,6 +58,7 @@ func (m *Mock) runExecution(ctx context.Context, in driver.StartExecutionInput, 
 	res := interpret(ctx, definition, &asl.RunInput{
 		Input: in.Input, ExecArn: arn, ExecName: name, SMArn: in.StateMachineArn,
 		SMName: smName, RoleArn: roleArn, StartTime: now, SettleBase: settle.DefaultExecutionSettle,
+		InvokeLambda: m.lambdaInvoker(),
 	})
 
 	exec := execFromResult(arn, name, in, now, res)
@@ -78,6 +79,17 @@ func (m *Mock) runExecution(ctx context.Context, in driver.StartExecutionInput, 
 	out := observedExec(&exec, window, now)
 
 	return &out, nil
+}
+
+// lambdaInvoker returns the Task->Lambda seam as the interpreter's callback, or
+// nil when no Lambda backend is wired (library-only construction), in which case
+// a Task echoes its input.
+func (m *Mock) lambdaInvoker() asl.LambdaInvoker {
+	if m.lambdaSync == nil {
+		return nil
+	}
+
+	return m.lambdaSync.InvokeSync
 }
 
 // interpret parses and runs a definition. A definition accepted at create time

--- a/providers/aws/sfn/sfn.go
+++ b/providers/aws/sfn/sfn.go
@@ -5,12 +5,14 @@
 // walks from StartAt following Next/End, computes the terminal status/output,
 // and records the per-state event list GetExecutionHistory returns. Execution is
 // synchronous; the settle overlay keeps RUNNING observable under AsyncSettle.
-// ctx is threaded end-to-end so a later Task->Lambda seam carries recursionguard
-// depth. Pass, Choice, Wait, Succeed and Fail are supported; Task, Parallel and
-// Map parse but fail loudly at run time until their handlers land.
+// ctx is threaded end-to-end so the Task->Lambda seam carries recursionguard
+// depth. Pass, Choice, Wait, Succeed, Fail and Task (Lambda, with Retry/Catch)
+// are supported; Parallel and Map parse but fail loudly at run time until their
+// handlers land.
 package sfn
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"time"
@@ -24,6 +26,17 @@ import (
 
 // Compile-time check that Mock implements driver.SFN.
 var _ driver.SFN = (*Mock)(nil)
+
+// LambdaSyncInvoker is the Task->Lambda seam a Task state uses to invoke a
+// function synchronously. It is deliberately named apart from the
+// InvokeExternal-shaped LambdaInvoker used by eventbridge/s3/sns: those are
+// fire-and-forget, whereas this returns the function output and a functionError
+// (mapped to States.TaskFailed). The lambda backend's adapter carries the
+// recursionguard depth so a Task->Lambda->StartExecution->Task cycle terminates
+// at recursionguard.MaxDepth instead of overflowing the stack.
+type LambdaSyncInvoker interface {
+	InvokeSync(ctx context.Context, functionARN string, payload []byte) (output []byte, functionError string, err error)
+}
 
 const (
 	// maxTags is the SFN cap on tags per resource.
@@ -51,7 +64,18 @@ type Mock struct {
 	tasksMu sync.RWMutex
 	tasks   map[string]string // taskToken -> executionArn (activity task bookkeeping)
 
+	// lambdaSync is the Task->Lambda seam; nil until SetLambdaSyncInvoker wires
+	// the Lambda backend (library-only construction leaves Task echoing input).
+	lambdaSync LambdaSyncInvoker
+
 	opts *config.Options
+}
+
+// SetLambdaSyncInvoker wires the Lambda backend so a Task state
+// (arn:aws:states:::lambda:invoke or a bare Lambda function ARN) invokes the
+// function synchronously through the recursion-guarded seam.
+func (m *Mock) SetLambdaSyncInvoker(i LambdaSyncInvoker) {
+	m.lambdaSync = i
 }
 
 // smData is a state machine plus its own lock.

--- a/providers/aws/sfn/task_test.go
+++ b/providers/aws/sfn/task_test.go
@@ -1,0 +1,326 @@
+package sfn_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	"github.com/stackshy/cloudemu/v2/providers/aws/sfn"
+	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
+)
+
+const lambdaFuncARN = "arn:aws:lambda:us-east-1:000000000000:function:f"
+
+// fakeLambda is a test LambdaSyncInvoker: its InvokeSync delegates to fn.
+type fakeLambda struct {
+	fn func(ctx context.Context, arn string, payload []byte) ([]byte, string, error)
+}
+
+func (f fakeLambda) InvokeSync(
+	ctx context.Context, arn string, payload []byte,
+) (output []byte, functionError string, err error) {
+	return f.fn(ctx, arn, payload)
+}
+
+// taskMock builds a Step Functions mock with the given Task->Lambda seam wired.
+func taskMock(t *testing.T, inv sfn.LambdaSyncInvoker) *sfn.Mock {
+	t.Helper()
+
+	m := newMock(t)
+	m.SetLambdaSyncInvoker(inv)
+
+	return m
+}
+
+// TestTaskInvokesLambdaReturnsOutput runs a bare-function-ARN Task and asserts
+// the execution output is the Lambda's output threaded through the pipeline.
+func TestTaskInvokesLambdaReturnsOutput(t *testing.T) {
+	inv := fakeLambda{fn: func(_ context.Context, arn string, _ []byte) ([]byte, string, error) {
+		if arn != lambdaFuncARN {
+			t.Errorf("Task delivered to %q, want %q", arn, lambdaFuncARN)
+		}
+
+		return []byte(`{"result":42}`), "", nil
+	}}
+
+	def := `{"StartAt":"T","States":{"T":{"Type":"Task","Resource":"` + lambdaFuncARN + `","End":true}}}`
+
+	exec := runSync(t, taskMock(t, inv), "task-out", def, `{"in":1}`)
+
+	if exec.Status != driver.ExecStatusSucceeded {
+		t.Fatalf("status = %q err=%q cause=%q", exec.Status, exec.Error, exec.Cause)
+	}
+
+	if !jsonEqual(t, exec.Output, `{"result":42}`) {
+		t.Fatalf("output = %q, want the Lambda output", exec.Output)
+	}
+}
+
+// TestTaskLambdaInvokeResultSelector uses the optimized lambda:invoke integration
+// and a ResultSelector to reshape the response envelope, pinning both the
+// Payload-wrapping and the ResultSelector stage.
+func TestTaskLambdaInvokeResultSelector(t *testing.T) {
+	inv := fakeLambda{fn: func(_ context.Context, _ string, payload []byte) ([]byte, string, error) {
+		// The Payload template forwarded the whole input.
+		if string(payload) != `{"v":7}` {
+			t.Errorf("lambda payload = %q, want {\"v\":7}", payload)
+		}
+
+		return []byte(`{"doubled":14}`), "", nil
+	}}
+
+	def := `{"StartAt":"T","States":{"T":{"Type":"Task",
+		"Resource":"arn:aws:states:::lambda:invoke",
+		"Parameters":{"FunctionName":"f","Payload.$":"$"},
+		"ResultSelector":{"body.$":"$.Payload"},"End":true}}}`
+
+	exec := runSync(t, taskMock(t, inv), "task-rs", def, `{"v":7}`)
+
+	if exec.Status != driver.ExecStatusSucceeded {
+		t.Fatalf("status = %q err=%q", exec.Status, exec.Error)
+	}
+
+	if !jsonEqual(t, exec.Output, `{"body":{"doubled":14}}`) {
+		t.Fatalf("output = %q, want ResultSelector-reshaped {\"body\":{\"doubled\":14}}", exec.Output)
+	}
+}
+
+// TestTaskCatchRoutesError asserts a Lambda functionError becomes States.TaskFailed
+// and a matching Catcher merges the {Error,Cause} output at its ResultPath and
+// transitions to its Next.
+func TestTaskCatchRoutesError(t *testing.T) {
+	inv := fakeLambda{fn: func(_ context.Context, _ string, _ []byte) ([]byte, string, error) {
+		return nil, "boom", nil
+	}}
+
+	def := `{"StartAt":"T","States":{
+		"T":{"Type":"Task","Resource":"` + lambdaFuncARN + `",
+			"Catch":[{"ErrorEquals":["States.TaskFailed"],"Next":"H","ResultPath":"$.error"}],"End":true},
+		"H":{"Type":"Pass","End":true}}}`
+
+	exec := runSync(t, taskMock(t, inv), "task-catch", def, `{"keep":1}`)
+
+	if exec.Status != driver.ExecStatusSucceeded {
+		t.Fatalf("status = %q err=%q, want SUCCEEDED via Catch", exec.Status, exec.Error)
+	}
+
+	want := `{"keep":1,"error":{"Error":"States.TaskFailed","Cause":"boom"}}`
+	if !jsonEqual(t, exec.Output, want) {
+		t.Fatalf("output = %q, want the error merged at $.error over the raw input", exec.Output)
+	}
+}
+
+// TestTaskRetryThenSucceed asserts a Task retries a failing Lambda and succeeds
+// once the function stops failing, deterministically under the FakeClock.
+func TestTaskRetryThenSucceed(t *testing.T) {
+	attempts := 0
+	inv := fakeLambda{fn: func(_ context.Context, _ string, _ []byte) ([]byte, string, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, "transient", nil
+		}
+
+		return []byte(`{"ok":true}`), "", nil
+	}}
+
+	def := `{"StartAt":"T","States":{"T":{"Type":"Task","Resource":"` + lambdaFuncARN + `",
+		"Retry":[{"ErrorEquals":["States.TaskFailed"],"IntervalSeconds":1,"MaxAttempts":3,"BackoffRate":2}],
+		"End":true}}}`
+
+	exec := runSync(t, taskMock(t, inv), "task-retry-ok", def, `{}`)
+
+	if exec.Status != driver.ExecStatusSucceeded {
+		t.Fatalf("status = %q err=%q, want SUCCEEDED after retries", exec.Status, exec.Error)
+	}
+
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3 (initial + 2 retries)", attempts)
+	}
+
+	if !jsonEqual(t, exec.Output, `{"ok":true}`) {
+		t.Fatalf("output = %q, want the eventual success", exec.Output)
+	}
+}
+
+// TestTaskRetryExhaustedFails asserts a Task that keeps failing propagates
+// States.TaskFailed once the matched Retrier's MaxAttempts is exhausted.
+func TestTaskRetryExhaustedFails(t *testing.T) {
+	attempts := 0
+	inv := fakeLambda{fn: func(_ context.Context, _ string, _ []byte) ([]byte, string, error) {
+		attempts++
+		return nil, "always", nil
+	}}
+
+	def := `{"StartAt":"T","States":{"T":{"Type":"Task","Resource":"` + lambdaFuncARN + `",
+		"Retry":[{"ErrorEquals":["States.ALL"],"IntervalSeconds":1,"MaxAttempts":2}],"End":true}}}`
+
+	exec := runSync(t, taskMock(t, inv), "task-retry-fail", def, `{}`)
+
+	if exec.Status != driver.ExecStatusFailed || exec.Error != "States.TaskFailed" {
+		t.Fatalf("terminal = %q/%q, want FAILED/States.TaskFailed", exec.Status, exec.Error)
+	}
+
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3 (initial + 2 retries)", attempts)
+	}
+}
+
+// TestTaskRetryBackoffDeterministicUnderAsyncSettle proves Retry backoff folds
+// into the settle window: the execution holds RUNNING until the FakeClock is
+// advanced past the base settle plus the backoff, then reports SUCCEEDED.
+func TestTaskRetryBackoffDeterministicUnderAsyncSettle(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	m := asyncMock(t, fc)
+	calls := 0
+	m.SetLambdaSyncInvoker(fakeLambda{fn: func(_ context.Context, _ string, _ []byte) ([]byte, string, error) {
+		calls++
+		if calls == 1 {
+			return nil, "transient", nil // first attempt fails, forcing one backoff
+		}
+
+		return []byte(`{"ok":true}`), "", nil
+	}})
+	ctx := context.Background()
+
+	def := `{"StartAt":"T","States":{"T":{"Type":"Task","Resource":"` + lambdaFuncARN + `",
+		"Retry":[{"ErrorEquals":["States.TaskFailed"],"IntervalSeconds":4,"MaxAttempts":1}],"End":true}}}`
+	arn := createDef(t, m, "task-async-retry", def)
+
+	start, err := m.StartExecution(ctx, driver.StartExecutionInput{StateMachineArn: arn, Name: "r1", Input: `{}`})
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	if start.Status != driver.ExecStatusRunning {
+		t.Fatalf("initial status = %q, want RUNNING while backing off", start.Status)
+	}
+
+	// Base settle (1s) + Retry backoff (4s) = 5s window.
+	fc.Advance(5 * time.Second)
+
+	got, _ := m.DescribeExecution(ctx, start.ARN)
+	if got.Status != driver.ExecStatusSucceeded {
+		t.Fatalf("status after advance = %q, want SUCCEEDED", got.Status)
+	}
+
+	if calls != 2 {
+		t.Fatalf("lambda calls = %d, want 2 (one failure + one success)", calls)
+	}
+}
+
+// TestTaskNoInvokerEchoesInput asserts a Task with no Lambda seam wired falls
+// back to echoing its input, preserving the pre-interpreter behavior.
+func TestTaskNoInvokerEchoesInput(t *testing.T) {
+	def := `{"StartAt":"T","States":{"T":{"Type":"Task","Resource":"` + lambdaFuncARN + `","End":true}}}`
+
+	// newMock wires no LambdaSyncInvoker.
+	exec := runSync(t, newMock(t), "task-echo", def, `{"echo":"me"}`)
+
+	if exec.Status != driver.ExecStatusSucceeded {
+		t.Fatalf("status = %q err=%q, want SUCCEEDED (echo fallback)", exec.Status, exec.Error)
+	}
+
+	if !jsonEqual(t, exec.Output, `{"echo":"me"}`) {
+		t.Fatalf("output = %q, want the input echoed", exec.Output)
+	}
+}
+
+// TestTaskLambdaHistoryEvents asserts the LambdaFunction* sub-events appear in
+// GetExecutionHistory in order, bracketed by TaskStateEntered/Exited.
+func TestTaskLambdaHistoryEvents(t *testing.T) {
+	inv := fakeLambda{fn: func(_ context.Context, _ string, _ []byte) ([]byte, string, error) {
+		return []byte(`{"r":1}`), "", nil
+	}}
+
+	def := `{"StartAt":"T","States":{"T":{"Type":"Task","Resource":"` + lambdaFuncARN + `","End":true}}}`
+
+	m := taskMock(t, inv)
+	exec := runSync(t, m, "task-hist", def, `{}`)
+	ctx := context.Background()
+
+	events, err := m.GetExecutionHistory(ctx, exec.ARN, false)
+	if err != nil {
+		t.Fatalf("GetExecutionHistory: %v", err)
+	}
+
+	wantTypes := []string{
+		"ExecutionStarted",
+		"TaskStateEntered",
+		"LambdaFunctionScheduled", "LambdaFunctionStarted", "LambdaFunctionSucceeded",
+		"TaskStateExited",
+		"ExecutionSucceeded",
+	}
+
+	if len(events) != len(wantTypes) {
+		t.Fatalf("history has %d events, want %d: %+v", len(events), len(wantTypes), events)
+	}
+
+	for i, want := range wantTypes {
+		if events[i].Type != want {
+			t.Fatalf("event %d type = %q, want %q", i, events[i].Type, want)
+		}
+	}
+
+	assertChain(t, events)
+
+	if events[2].Resource != lambdaFuncARN {
+		t.Fatalf("LambdaFunctionScheduled Resource = %q, want %q", events[2].Resource, lambdaFuncARN)
+	}
+}
+
+// TestTaskRecursionGuardTerminates is the load-bearing recursion test: a Lambda
+// seam that re-enters the FULL cycle — StartExecution on a state machine whose
+// Task invokes Lambda again — terminates at recursionguard.MaxDepth with a
+// bounded States.TaskFailed, never a stack overflow. It calls the REAL
+// StartExecution entry point so ctx-threading on the production path is proven,
+// and asserts the ctx depth increments across the StartExecution boundary.
+func TestTaskRecursionGuardTerminates(t *testing.T) {
+	m := newMock(t)
+
+	def := `{"StartAt":"T","States":{"T":{"Type":"Task","Resource":"` + lambdaFuncARN + `","End":true}}}`
+	arn := createDef(t, m, "recurse", def)
+
+	maxDepth := 0
+	m.SetLambdaSyncInvoker(fakeLambda{fn: func(ctx context.Context, _ string, payload []byte) ([]byte, string, error) {
+		// Replicate the lambda adapter's guard, then re-enter the whole cycle
+		// through the real StartExecution entry point.
+		d := recursionguard.Depth(ctx)
+		if d > maxDepth {
+			maxDepth = d
+		}
+
+		if d >= recursionguard.MaxDepth {
+			return nil, "recursion limit reached", nil
+		}
+
+		sub, err := m.StartSyncExecution(recursionguard.WithDepth(ctx, d+1),
+			driver.StartExecutionInput{StateMachineArn: arn, Name: fmt.Sprintf("r%d", d), Input: string(payload)})
+		if err != nil {
+			return nil, "", err
+		}
+
+		if sub.Status == driver.ExecStatusFailed {
+			return nil, sub.Error, nil // propagate the bounded failure up the chain
+		}
+
+		return []byte(sub.Output), "", nil
+	}})
+
+	top, err := m.StartExecution(context.Background(),
+		driver.StartExecutionInput{StateMachineArn: arn, Name: "top", Input: `{}`})
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	if top.Status != driver.ExecStatusFailed || top.Error != "States.TaskFailed" {
+		t.Fatalf("top terminal = %q/%q, want FAILED/States.TaskFailed (bounded recursion)", top.Status, top.Error)
+	}
+
+	if maxDepth != recursionguard.MaxDepth {
+		t.Fatalf("max ctx depth = %d, want %d (guard reached across the StartExecution boundary)",
+			maxDepth, recursionguard.MaxDepth)
+	}
+}

--- a/providers/aws/sfn/teststate.go
+++ b/providers/aws/sfn/teststate.go
@@ -11,14 +11,17 @@ import (
 // TestState evaluates a single state definition through the interpreter: it runs
 // the state's I/O pipeline and handler once (following a Choice to its selected
 // branch without executing it) and returns the resulting Output/Status/NextState,
-// or Error/Cause on failure. ctx is accepted for parity with the Task->Lambda
-// seam a later PR threads through the same handlers.
-func (m *Mock) TestState(_ context.Context, in driver.TestStateInput) (*driver.TestStateResult, error) {
+// or Error/Cause on failure. ctx is threaded into the same Task->Lambda seam
+// StartExecution uses, so a single Task state under test carries recursionguard
+// depth consistently.
+func (m *Mock) TestState(ctx context.Context, in driver.TestStateInput) (*driver.TestStateResult, error) {
 	if strings.TrimSpace(in.Definition) == "" {
 		return nil, invalidName("definition is required")
 	}
 
-	res, err := asl.TestOne(in.Definition, &asl.RunInput{Input: in.Input, StartTime: m.now()})
+	res, err := asl.TestOne(ctx, in.Definition, &asl.RunInput{
+		Input: in.Input, StartTime: m.now(), InvokeLambda: m.lambdaInvoker(),
+	})
 	if err != nil {
 		return nil, invalidDefinition(err.Error())
 	}

--- a/providers/wiring_parity_test.go
+++ b/providers/wiring_parity_test.go
@@ -180,12 +180,16 @@ func parseWiredSetters(t *testing.T, path string) map[fieldMethod]bool {
 		t.Fatalf("parse %s: %v", path, err)
 	}
 
+	funcs := map[string]*ast.FuncDecl{}
+
 	var newFn *ast.FuncDecl
 
 	for _, decl := range file.Decls {
-		if fd, ok := decl.(*ast.FuncDecl); ok && fd.Recv == nil && fd.Name.Name == "New" {
-			newFn = fd
-			break
+		if fd, ok := decl.(*ast.FuncDecl); ok && fd.Recv == nil {
+			funcs[fd.Name.Name] = fd
+			if fd.Name.Name == "New" {
+				newFn = fd
+			}
 		}
 	}
 
@@ -200,7 +204,49 @@ func parseWiredSetters(t *testing.T, path string) map[fieldMethod]bool {
 
 	wired := map[fieldMethod]bool{}
 
+	// Scan New()'s body plus the bodies of the same-file helper functions New()
+	// calls (e.g. a wireXxx(p) helper extracted for length): wiring factored out
+	// of New() still counts. The acceptable base variable is New()'s provider var
+	// for New() itself, and the helper's parameter names for each helper.
+	scanBody(newFn.Body, map[string]bool{recv: true}, wired)
+
 	ast.Inspect(newFn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		id, ok := call.Fun.(*ast.Ident)
+		if !ok {
+			return true
+		}
+
+		helper, ok := funcs[id.Name]
+		if !ok || helper == newFn || helper.Body == nil {
+			return true
+		}
+
+		bases := map[string]bool{}
+		if helper.Type.Params != nil {
+			for _, p := range helper.Type.Params.List {
+				for _, nm := range p.Names {
+					bases[nm.Name] = true
+				}
+			}
+		}
+
+		scanBody(helper.Body, bases, wired)
+
+		return true
+	})
+
+	return wired
+}
+
+// scanBody records every `<base>.<Field>.Set<Method>()` wiring call in body
+// whose base identifier is one of the accepted provider variable names.
+func scanBody(body *ast.BlockStmt, bases map[string]bool, wired map[fieldMethod]bool) {
+	ast.Inspect(body, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
@@ -217,7 +263,7 @@ func parseWiredSetters(t *testing.T, path string) map[fieldMethod]bool {
 		}
 
 		base, ok := inner.X.(*ast.Ident)
-		if !ok || base.Name != recv {
+		if !ok || !bases[base.Name] {
 			return true
 		}
 
@@ -225,8 +271,6 @@ func parseWiredSetters(t *testing.T, path string) map[fieldMethod]bool {
 
 		return true
 	})
-
-	return wired
 }
 
 // providerReceiverName finds the local variable New() assigns `&Provider{}`

--- a/server/aws/sfn/lambda_task_test.go
+++ b/server/aws/sfn/lambda_task_test.go
@@ -1,0 +1,98 @@
+package sfn_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awssfn "github.com/aws/aws-sdk-go-v2/service/sfn"
+	sfntypes "github.com/aws/aws-sdk-go-v2/service/sfn/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+	serverless "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// TestSDKTaskLambdaHistoryDetails runs a Task->Lambda state machine end to end
+// through the wire server and asserts GetExecutionHistory surfaces the
+// LambdaFunction* sub-events with populated detail structs.
+func TestSDKTaskLambdaHistoryDetails(t *testing.T) {
+	ctx := context.Background()
+
+	cloud := cloudemu.NewAWS()
+
+	if _, err := cloud.Lambda.CreateFunction(ctx, serverless.FunctionConfig{
+		Name: "taskfn", Runtime: "go1.x", Handler: "main", Memory: 128, Timeout: 30,
+	}); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	cloud.Lambda.RegisterHandler("taskfn", func(_ context.Context, _ []byte) ([]byte, error) {
+		return []byte(`{"handled":true}`), nil
+	})
+
+	srv := awsserver.New(awsserver.Drivers{SFN: cloud.SFN})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	c := awssfn.NewFromConfig(cfg, func(o *awssfn.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+
+	def := `{"StartAt":"T","States":{"T":{"Type":"Task",` +
+		`"Resource":"arn:aws:lambda:us-east-1:000000000000:function:taskfn","End":true}}}`
+
+	sm, err := c.CreateStateMachine(ctx, &awssfn.CreateStateMachineInput{
+		Name: aws.String("task-sm"), Definition: aws.String(def),
+		RoleArn: aws.String("arn:aws:iam::123456789012:role/svc"),
+	})
+	if err != nil {
+		t.Fatalf("CreateStateMachine: %v", err)
+	}
+
+	start, err := c.StartExecution(ctx, &awssfn.StartExecutionInput{
+		StateMachineArn: sm.StateMachineArn, Name: aws.String("run"), Input: aws.String(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	hist, err := c.GetExecutionHistory(ctx, &awssfn.GetExecutionHistoryInput{ExecutionArn: start.ExecutionArn})
+	if err != nil {
+		t.Fatalf("GetExecutionHistory: %v", err)
+	}
+
+	var sawScheduled, sawSucceeded bool
+
+	for _, e := range hist.Events {
+		if e.Type == sfntypes.HistoryEventTypeLambdaFunctionScheduled {
+			if e.LambdaFunctionScheduledEventDetails == nil ||
+				aws.ToString(e.LambdaFunctionScheduledEventDetails.Resource) == "" {
+				t.Fatalf("LambdaFunctionScheduled has nil/empty details: %+v", e)
+			}
+
+			sawScheduled = true
+		}
+
+		if e.Type == sfntypes.HistoryEventTypeLambdaFunctionSucceeded {
+			if e.LambdaFunctionSucceededEventDetails == nil {
+				t.Fatalf("LambdaFunctionSucceeded has nil details: %+v", e)
+			}
+
+			sawSucceeded = true
+		}
+	}
+
+	if !sawScheduled || !sawSucceeded {
+		t.Fatalf("missing Lambda sub-events (scheduled=%v succeeded=%v)", sawScheduled, sawSucceeded)
+	}
+}

--- a/server/aws/sfn/operations.go
+++ b/server/aws/sfn/operations.go
@@ -191,34 +191,55 @@ func eventsToWire(events []sfndriver.HistoryEvent) []historyEvent {
 			ID: e.ID, PreviousEventID: e.PreviousEventID, Type: e.Type, Timestamp: epoch(e.Timestamp),
 		}
 
-		if e.Type == "ExecutionStarted" {
-			he.ExecutionStartedDetails = &executionStartedDetails{Input: e.Input}
-		}
-
-		if e.Type == "ExecutionSucceeded" {
-			he.ExecutionSucceededDetails = &executionSucceededDetails{Output: e.Output}
-		}
-
-		if e.Type == "ExecutionFailed" {
-			he.ExecutionFailedDetails = &executionFailedDetails{Error: e.Error, Cause: e.Cause}
-		}
-
-		if e.Type == "ExecutionAborted" {
-			he.ExecutionAbortedDetails = &executionAbortedDetails{Error: e.Error, Cause: e.Cause}
-		}
-
-		if strings.HasSuffix(e.Type, "StateEntered") {
-			he.StateEnteredDetails = &stateEnteredDetails{Name: e.StateName, Input: e.Input}
-		}
-
-		if strings.HasSuffix(e.Type, "StateExited") {
-			he.StateExitedDetails = &stateExitedDetails{Name: e.StateName, Output: e.Output}
-		}
+		populateEventDetails(&he, e)
 
 		out = append(out, he)
 	}
 
 	return out
+}
+
+// populateEventDetails fills the type-specific detail struct on a wire history
+// event. The *StateEntered/*StateExited suffixes generalize across state types
+// (Pass/Choice/Wait/Succeed/Task), while the execution- and Lambda-specific
+// events map by exact Type.
+func populateEventDetails(he *historyEvent, e *sfndriver.HistoryEvent) {
+	populateExecutionDetails(he, e)
+	populateLambdaDetails(he, e)
+
+	if strings.HasSuffix(e.Type, "StateEntered") {
+		he.StateEnteredDetails = &stateEnteredDetails{Name: e.StateName, Input: e.Input}
+	}
+
+	if strings.HasSuffix(e.Type, "StateExited") {
+		he.StateExitedDetails = &stateExitedDetails{Name: e.StateName, Output: e.Output}
+	}
+}
+
+func populateExecutionDetails(he *historyEvent, e *sfndriver.HistoryEvent) {
+	switch e.Type {
+	case "ExecutionStarted":
+		he.ExecutionStartedDetails = &executionStartedDetails{Input: e.Input}
+	case "ExecutionSucceeded":
+		he.ExecutionSucceededDetails = &executionSucceededDetails{Output: e.Output}
+	case "ExecutionFailed":
+		he.ExecutionFailedDetails = &executionFailedDetails{Error: e.Error, Cause: e.Cause}
+	case "ExecutionAborted":
+		he.ExecutionAbortedDetails = &executionAbortedDetails{Error: e.Error, Cause: e.Cause}
+	}
+}
+
+func populateLambdaDetails(he *historyEvent, e *sfndriver.HistoryEvent) {
+	switch e.Type {
+	case "LambdaFunctionScheduled":
+		he.LambdaFunctionScheduledDetails = &lambdaFunctionScheduledDetails{Resource: e.Resource, Parameters: e.Input}
+	case "LambdaFunctionStarted":
+		he.LambdaFunctionStartedDetails = &lambdaFunctionStartedDetails{}
+	case "LambdaFunctionSucceeded":
+		he.LambdaFunctionSucceededDetails = &lambdaFunctionSucceededDetails{Output: e.Output}
+	case "LambdaFunctionFailed":
+		he.LambdaFunctionFailedDetails = &lambdaFunctionFailedDetails{Error: e.Error, Cause: e.Cause}
+	}
 }
 
 func (h *Handler) describeStateMachineForExecution(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/sfn/types.go
+++ b/server/aws/sfn/types.go
@@ -393,17 +393,38 @@ type executionAbortedDetails struct {
 	Cause string `json:"cause,omitempty"`
 }
 
+type lambdaFunctionScheduledDetails struct {
+	Resource   string `json:"resource"`
+	Region     string `json:"region,omitempty"`
+	Parameters string `json:"parameters,omitempty"`
+}
+
+type lambdaFunctionStartedDetails struct{}
+
+type lambdaFunctionSucceededDetails struct {
+	Output string `json:"output,omitempty"`
+}
+
+type lambdaFunctionFailedDetails struct {
+	Error string `json:"error,omitempty"`
+	Cause string `json:"cause,omitempty"`
+}
+
 type historyEvent struct {
-	ID                        int64                      `json:"id"`
-	PreviousEventID           int64                      `json:"previousEventId"`
-	Type                      string                     `json:"type"`
-	Timestamp                 *float64                   `json:"timestamp"`
-	ExecutionStartedDetails   *executionStartedDetails   `json:"executionStartedEventDetails,omitempty"`
-	ExecutionSucceededDetails *executionSucceededDetails `json:"executionSucceededEventDetails,omitempty"`
-	ExecutionFailedDetails    *executionFailedDetails    `json:"executionFailedEventDetails,omitempty"`
-	ExecutionAbortedDetails   *executionAbortedDetails   `json:"executionAbortedEventDetails,omitempty"`
-	StateEnteredDetails       *stateEnteredDetails       `json:"stateEnteredEventDetails,omitempty"`
-	StateExitedDetails        *stateExitedDetails        `json:"stateExitedEventDetails,omitempty"`
+	ID                             int64                           `json:"id"`
+	PreviousEventID                int64                           `json:"previousEventId"`
+	Type                           string                          `json:"type"`
+	Timestamp                      *float64                        `json:"timestamp"`
+	ExecutionStartedDetails        *executionStartedDetails        `json:"executionStartedEventDetails,omitempty"`
+	ExecutionSucceededDetails      *executionSucceededDetails      `json:"executionSucceededEventDetails,omitempty"`
+	ExecutionFailedDetails         *executionFailedDetails         `json:"executionFailedEventDetails,omitempty"`
+	ExecutionAbortedDetails        *executionAbortedDetails        `json:"executionAbortedEventDetails,omitempty"`
+	StateEnteredDetails            *stateEnteredDetails            `json:"stateEnteredEventDetails,omitempty"`
+	StateExitedDetails             *stateExitedDetails             `json:"stateExitedEventDetails,omitempty"`
+	LambdaFunctionScheduledDetails *lambdaFunctionScheduledDetails `json:"lambdaFunctionScheduledEventDetails,omitempty"`
+	LambdaFunctionStartedDetails   *lambdaFunctionStartedDetails   `json:"lambdaFunctionStartedEventDetails,omitempty"`
+	LambdaFunctionSucceededDetails *lambdaFunctionSucceededDetails `json:"lambdaFunctionSucceededEventDetails,omitempty"`
+	LambdaFunctionFailedDetails    *lambdaFunctionFailedDetails    `json:"lambdaFunctionFailedEventDetails,omitempty"`
 }
 
 type getExecutionHistoryResponse struct {

--- a/services/sfn/driver/driver.go
+++ b/services/sfn/driver/driver.go
@@ -142,6 +142,9 @@ type HistoryEvent struct {
 	// FailStateEntered, ExecutionAborted, LambdaFunctionFailed).
 	Error string
 	Cause string
+	// Resource names the integration a task sub-event targets (e.g. the Task
+	// Resource ARN on a LambdaFunctionScheduled event).
+	Resource string
 }
 
 // Activity is a task worker registration.


### PR DESCRIPTION
## Summary

PR2 of 3 for the Step Functions ASL interpreter (#581). Adds the **Task state** (`arn:aws:states:::lambda:invoke` and the bare Lambda function ARN form) on top of the PR1 walker, with a **recursion-guarded synchronous Lambda invoke seam**, **Retry/Catch** error handling, the **ResultSelector** pipeline stage, and the **LambdaFunction\*** history sub-events.

Parallel/Map remain unsupported and keep failing loudly at run time — those land in PR3.

## What changed

**Task handler (`providers/aws/sfn/asl/task.go`)**
- Parses the Task `Resource`: the optimized `arn:aws:states:::lambda:invoke` integration (payload from `Parameters.Payload`, wrapped in the Lambda response envelope) and the bare `arn:aws:lambda:…:function:…` form (payload is the effective input, result is the function output directly). Any other Resource fails loudly, feeding Retry/Catch — never a panic.
- Full I/O pipeline including the new **ResultSelector** stage (`InputPath → Parameters → invoke → ResultSelector → ResultPath → OutputPath`).
- Emits `TaskStateEntered/Exited` plus the Lambda sub-events `LambdaFunctionScheduled/Started/Succeeded/Failed`.
- With no seam wired (library-only construction) a Task echoes its input, preserving prior behavior.

**Recursion-guarded seam**
- `sfn.LambdaSyncInvoker` interface (`InvokeSync(ctx, functionARN, payload) (output, functionError, err)`), named apart from the fire-and-forget `LambdaInvoker` used elsewhere, wired via `SetLambdaSyncInvoker` in `providers/aws/aws.go`.
- `lambda.InvokeSync` replicates `InvokeExternal`'s recursionguard discipline inline: at `recursionguard.MaxDepth` (16) it drops the invocation and returns a **bounded functionError** mapped upstream to `States.TaskFailed` — never a stack overflow — otherwise `WithDepth(ctx, depth+1)` before delegating to a `RequestResponse` Invoke.
- `ctx` now threads `StartExecution → runExecution → run() → Task → InvokeSync`, so a `Lambda → StartExecution → Task → Lambda` cycle (and the EventBridge → SFN → Task → Lambda path) terminates at `MaxDepth`.

**Retry/Catch (`providers/aws/sfn/asl/retry.go`)**
- Retry: `ErrorEquals` (incl. `States.ALL`), `IntervalSeconds`/`MaxAttempts`/`BackoffRate` with ASL defaults (1/3/2.0); first-matching-retrier-wins; backoff advances the virtual clock so it is FakeClock-deterministic and folds into the settle window under AsyncSettle. `MaxDelaySeconds`/`JitterStrategy` are parsed as documented deferred no-ops.
- Catch: `ErrorEquals` match → `{Error,Cause}` output merged at the Catcher's `ResultPath` → transition to `Next`. Retry evaluated before Catch; exhausted Retry propagates to Catch, else `ExecutionFailed`.

**Wire + driver**
- `driver.HistoryEvent` gains a `Resource` field (for `LambdaFunctionScheduled`); new `lambdaFunction*EventDetails` wire structs and `eventsToWire` mapping.

## Tests

Hand-rolled (no testify), all green:
- Task returns the Lambda output (bare ARN); `lambda:invoke` + ResultSelector reshapes the response envelope.
- Lambda error → `States.TaskFailed` → Catch routes with the error merged at ResultPath.
- Retry retries then succeeds; Retry exhausted → FAILED (attempt counts asserted); deterministic Retry backoff under AsyncSettle + FakeClock (RUNNING → SUCCEEDED after advancing the clock).
- No-invoker fallback echoes input.
- `LambdaFunction*` history events appear in order via `GetExecutionHistory`, forward + chained; wire-layer e2e asserts the SDK surfaces the detail structs.
- **Recursion guard**: a Lambda seam that re-enters the full cycle through the real `StartExecution` entry point terminates at `recursionguard.MaxDepth` with `States.TaskFailed` (not a stack overflow), and the ctx depth increments across the `StartExecution` boundary; plus lambda-side `InvokeSync` boundary + self-recursion tests.

## Gates (GOMAXPROCS=2)

- `go build ./...`, `go vet` — clean
- `go test ./providers/aws/sfn/... ./providers/aws/lambda/... ./server/aws/... ./compat/aws/` — pass (incl. `-race` on the recursion path)
- `go generate ./...` — no doc/coverage diff
- `golangci-lint` on `providers/aws/sfn/... providers/aws/lambda/...` — 0 issues (one pre-existing, unrelated `rds_discovery` gocyclo remains, untouched by this PR)
