### PR TITLE
feat(sfn): ASL interpreter PR3 — Parallel/Map + catchable state errors (#581)

### DIFF
--- a/providers/aws/sfn/asl/asl_test.go
+++ b/providers/aws/sfn/asl/asl_test.go
@@ -132,17 +132,36 @@ func TestPayloadTemplateWithContext(t *testing.T) {
 }
 
 func TestParseAcceptsAndRejects(t *testing.T) {
-	good := `{"StartAt":"A","States":{"A":{"Type":"Pass","End":true}}}`
-	if _, err := Parse(good); err != nil {
-		t.Fatalf("Parse(valid) = %v", err)
+	goods := []string{
+		`{"StartAt":"A","States":{"A":{"Type":"Pass","End":true}}}`,
+		`{"StartAt":"P","States":{"P":{"Type":"Parallel","End":true,"Branches":[` +
+			`{"StartAt":"A","States":{"A":{"Type":"Pass","End":true}}}]}}}`,
+		`{"StartAt":"M","States":{"M":{"Type":"Map","ItemsPath":"$.n","End":true,"MaxConcurrency":2,` +
+			`"ItemProcessor":{"StartAt":"I","States":{"I":{"Type":"Pass","End":true}}}}}}`,
+	}
+	for _, good := range goods {
+		if _, err := Parse(good); err != nil {
+			t.Fatalf("Parse(valid) = %v (%s)", err, good)
+		}
 	}
 
 	bad := []string{
 		`{"StartAt":"A","States":{"A":{"Type":"Wait","Seconds":1,"Result":{},"End":true}}}`,
 		`{"StartAt":"Missing","States":{"A":{"Type":"Pass","End":true}}}`,
 		`{"QueryLanguage":"JSONata","StartAt":"A","States":{"A":{"Type":"Pass","End":true}}}`,
-		// Pass does not support ResultSelector (Task/Parallel/Map only).
+		// Pass does not support ResultSelector/Retry/Catch (Task/Parallel/Map only).
 		`{"StartAt":"A","States":{"A":{"Type":"Pass","ResultSelector":{"x.$":"$.y"},"End":true}}}`,
+		`{"StartAt":"A","States":{"A":{"Type":"Pass","Retry":[{"ErrorEquals":["States.ALL"]}],"End":true}}}`,
+		`{"StartAt":"A","States":{"A":{"Type":"Pass","Catch":[{"ErrorEquals":["States.ALL"],"Next":"A"}],"End":true}}}`,
+		// Out-of-range Retrier fields are rejected at create time.
+		`{"StartAt":"T","States":{"T":{"Type":"Task","Resource":"arn:aws:states:::lambda:invoke",` +
+			`"Retry":[{"ErrorEquals":["States.ALL"],"BackoffRate":0.5}],"End":true}}}`,
+		// Parallel with no branches, and a Parallel branch that is itself invalid.
+		`{"StartAt":"P","States":{"P":{"Type":"Parallel","Branches":[],"End":true}}}`,
+		`{"StartAt":"P","States":{"P":{"Type":"Parallel","End":true,"Branches":[` +
+			`{"StartAt":"X","States":{"Y":{"Type":"Pass","End":true}}}]}}}`,
+		// Map with no ItemProcessor/Iterator.
+		`{"StartAt":"M","States":{"M":{"Type":"Map","ItemsPath":"$.n","End":true}}}`,
 	}
 
 	for _, def := range bad {

--- a/providers/aws/sfn/asl/history.go
+++ b/providers/aws/sfn/asl/history.go
@@ -7,14 +7,17 @@ import "github.com/stackshy/cloudemu/v2/services/sfn/driver"
 // The event set for this build is:
 //
 //	ExecutionStarted
-//	<Type>StateEntered / <Type>StateExited   (Pass, Choice, Wait, Succeed, Task)
+//	<Type>StateEntered / <Type>StateExited   (Pass, Choice, Wait, Succeed, Task,
+//	                                           Parallel, Map)
 //	FailStateEntered                          (Fail — terminal, no exit)
 //	LambdaFunctionScheduled / LambdaFunctionStarted /
 //	LambdaFunctionSucceeded / LambdaFunctionFailed   (Task->Lambda sub-events)
 //	ExecutionSucceeded / ExecutionFailed / ExecutionAborted
 //
-// Richer AWS sub-events (MapIteration*, evaluation events) are out of scope
-// until the Parallel/Map handlers land.
+// A Parallel/Map's nested branch/iteration states emit their own
+// <Type>StateEntered/Exited events inline between the Parallel/Map enter and
+// exit. Richer AWS sub-events (MapIterationStarted/Succeeded, per-branch
+// evaluation events) are out of scope.
 
 // historyFail builds the FailStateEntered event for a Fail state.
 func historyFail(st *State) *driver.HistoryEvent {

--- a/providers/aws/sfn/asl/interpret.go
+++ b/providers/aws/sfn/asl/interpret.go
@@ -15,6 +15,11 @@ import (
 // make, so a Choice/Next cycle fails loudly instead of spinning forever.
 const defaultMaxSteps = 10000
 
+// defaultMaxNesting bounds how deeply Parallel/Map sub-state-machines may nest,
+// so a pathological Parallel-in-Parallel definition fails loudly instead of
+// exhausting the Go stack.
+const defaultMaxNesting = 32
+
 // handler evaluates one state. It returns the state's effective output, the name
 // of the next state (empty when terminal), whether the execution terminates
 // here (SUCCEEDED), or an error (mapped to ExecutionFailed). Each handler emits
@@ -77,16 +82,18 @@ type RunResult struct {
 }
 
 type interp struct {
-	def       *StateMachineDef
-	baseTime  time.Time
-	offset    time.Duration
-	waitTotal time.Duration
-	steps     int
-	maxSteps  int
-	hist      []driver.HistoryEvent
-	lastID    int64
-	ctxObj    map[string]any
-	handlers  map[string]handler
+	def        *StateMachineDef
+	baseTime   time.Time
+	offset     time.Duration
+	waitTotal  time.Duration
+	steps      int
+	maxSteps   int
+	depth      int
+	maxNesting int
+	hist       []driver.HistoryEvent
+	lastID     int64
+	ctxObj     map[string]any
+	handlers   map[string]handler
 
 	// invokeLambda is the Task->Lambda seam; nil means echo-input fallback.
 	invokeLambda LambdaInvoker
@@ -109,6 +116,7 @@ func Run(ctx context.Context, def *StateMachineDef, in *RunInput) *RunResult {
 		def:          def,
 		baseTime:     in.StartTime,
 		maxSteps:     maxSteps,
+		maxNesting:   defaultMaxNesting,
 		handlers:     buildHandlers(),
 		invokeLambda: in.InvokeLambda,
 	}
@@ -137,48 +145,74 @@ func buildHandlers() map[string]handler {
 		TypeSucceed:  succeedHandler,
 		TypeFail:     failHandler,
 		TypeTask:     taskHandler,
-		TypeParallel: unsupportedHandler,
-		TypeMap:      unsupportedHandler,
+		TypeParallel: parallelHandler,
+		TypeMap:      mapHandler,
 	}
 }
 
-// walk runs the state graph from StartAt following Next/End until a terminal
-// state, an unrecovered error, or the step guard trips.
+// walk runs the top-level state graph and maps its outcome to a RunResult with
+// the terminal ExecutionSucceeded/ExecutionFailed event.
 func (it *interp) walk(ctx context.Context, input any) *RunResult {
-	cur := it.def.StartAt
+	out, se := it.runGraph(ctx, it.def.StartAt, it.def.States, input)
+	if se != nil {
+		return it.fail(se.Code, se.Cause)
+	}
+
+	return it.succeed(out)
+}
+
+// runGraph walks a state graph from startAt following Next/End until a terminal
+// state, an unrecovered error, or a guard trips. It is shared by the top-level
+// execution and by nested Parallel branches / Map iterations, so the step budget
+// and history accumulator are common across the whole run and ctx (carrying the
+// recursion-guard depth) threads into every handler.
+func (it *interp) runGraph(ctx context.Context, startAt string, states map[string]*State, input any) (any, *stateError) {
+	cur := startAt
 	raw := input
 
 	for {
 		// Honor cancellation of the calling request (the ctx is also what the
-		// PR2 Task->Lambda recursion guard rides on).
+		// Task->Lambda recursion guard rides on).
 		if err := ctx.Err(); err != nil {
-			return it.fail("CloudEmu.ExecutionCanceled", err.Error())
+			return nil, &stateError{Code: "CloudEmu.ExecutionCanceled", Cause: err.Error()}
 		}
 
 		it.steps++
 		if it.steps > it.maxSteps {
-			return it.fail("CloudEmu.StateTransitionLimitExceeded",
-				fmt.Sprintf("execution exceeded the %d state-transition limit", it.maxSteps))
+			return nil, &stateError{Code: "CloudEmu.StateTransitionLimitExceeded",
+				Cause: fmt.Sprintf("execution exceeded the %d state-transition limit", it.maxSteps)}
 		}
 
-		st := it.def.States[cur]
+		st := states[cur]
 		it.enterStateContext(st)
 
 		out, next, terminal, err := it.handlers[st.Type](ctx, it, st, raw)
 		if err != nil {
-			se := asStateError(err)
-
-			return it.fail(se.Code, se.Cause)
+			return nil, asStateError(err)
 		}
 
 		if terminal {
-			return it.succeed(out)
+			return out, nil
 		}
 
 		raw = out
 		cur = next
 	}
 }
+
+// enterNesting bounds Parallel/Map nesting depth, failing loudly before the Go
+// stack can be exhausted by a pathological definition.
+func (it *interp) enterNesting() *stateError {
+	it.depth++
+	if it.depth > it.maxNesting {
+		return &stateError{Code: "CloudEmu.ExecutionNestingLimitExceeded",
+			Cause: fmt.Sprintf("execution exceeded the %d Parallel/Map nesting limit", it.maxNesting)}
+	}
+
+	return nil
+}
+
+func (it *interp) leaveNesting() { it.depth-- }
 
 func (it *interp) succeed(out any) *RunResult {
 	s := toJSON(out)

--- a/providers/aws/sfn/asl/io.go
+++ b/providers/aws/sfn/asl/io.go
@@ -109,6 +109,58 @@ func (it *interp) applyOutputPath(st *State, doc any) (any, error) {
 	return v, nil
 }
 
+// stateInput runs the input side of the pipeline (InputPath -> Parameters),
+// producing the value the state's work receives. Errors are returned as
+// *stateError so a Task/Parallel/Map I/O failure feeds Retry/Catch.
+func (it *interp) stateInput(st *State, raw any) (any, *stateError) {
+	filtered, err := it.applyInputPath(st, raw)
+	if err != nil {
+		return nil, asStateError(err)
+	}
+
+	params, err := it.applyParameters(st, filtered)
+	if err != nil {
+		return nil, asStateError(err)
+	}
+
+	return params, nil
+}
+
+// resultPipeline runs the result side of the pipeline (ResultSelector ->
+// ResultPath onto the RAW input -> OutputPath) on a state's work result. Errors
+// are returned as *stateError so they are catchable, consistent with Task.
+func (it *interp) resultPipeline(st *State, raw, result any) (any, *stateError) {
+	selected, err := it.applyResultSelector(st, result)
+	if err != nil {
+		return nil, asStateError(err)
+	}
+
+	merged, err := it.applyResultPath(st, raw, selected)
+	if err != nil {
+		return nil, asStateError(err)
+	}
+
+	out, err := it.applyOutputPath(st, merged)
+	if err != nil {
+		return nil, asStateError(err)
+	}
+
+	return out, nil
+}
+
+// catchOrFail routes a state failure to a matching Catcher (transitioning to its
+// Next with the {Error,Cause} error output merged at its ResultPath), or
+// propagates it to ExecutionFailed when no Catcher matches. It is shared by
+// Task/Parallel/Map, so their own I/O-pipeline errors are catchable exactly like
+// their work failures.
+func catchOrFail(st *State, raw any, se *stateError) (out any, next string, terminal bool, err error) {
+	if caughtOut, catchNext, ok := tryCatch(st, raw, se); ok {
+		return caughtOut, catchNext, false, nil
+	}
+
+	return nil, "", false, se
+}
+
 // passThroughOutput is the output pipeline for states with no result to merge
 // (Choice, Wait, Succeed): the effective output is OutputPath applied to the
 // InputPath-filtered input.

--- a/providers/aws/sfn/asl/map.go
+++ b/providers/aws/sfn/asl/map.go
@@ -1,0 +1,146 @@
+package asl
+
+import (
+	"context"
+	"fmt"
+)
+
+// mapHandler runs a Map state: it resolves the items array (ItemsPath, or the
+// whole effective input when absent) and runs the ItemProcessor/Iterator
+// sub-state-machine once per item, sequentially, applying ItemSelector to shape
+// each iteration's input. The state's result is the array of per-iteration
+// outputs in order. Any iteration failure fails the Map, which — with the state's
+// own I/O-pipeline errors — flows through the state's Retry (re-running all
+// iterations) and Catch. MaxConcurrency is parsed but not honored (execution is
+// sequential). ctx threads into every iteration so a Map -> Task -> Lambda cycle
+// stays bounded by the recursion guard.
+func mapHandler(ctx context.Context, it *interp, st *State, raw any) (out any, next string, terminal bool, err error) {
+	it.enterState(st, raw)
+
+	out, se := it.runWithRetry(st, func() (any, *stateError) {
+		return it.runMap(ctx, st, raw)
+	})
+	if se != nil {
+		return catchOrFail(st, raw, se)
+	}
+
+	it.exitState(st, out)
+
+	return out, st.Next, st.End, nil
+}
+
+// runMap is one Map attempt: it resolves the items, runs the processor per item,
+// and threads the ordered iteration outputs through the result pipeline
+// (ResultSelector -> ResultPath onto the RAW input -> OutputPath).
+func (it *interp) runMap(ctx context.Context, st *State, raw any) (any, *stateError) {
+	if se := it.enterNesting(); se != nil {
+		return nil, se
+	}
+	defer it.leaveNesting()
+
+	input, se := it.stateInput(st, raw)
+	if se != nil {
+		return nil, se
+	}
+
+	items, se := it.resolveItems(st, input)
+	if se != nil {
+		return nil, se
+	}
+
+	proc := st.processor()
+
+	results := make([]any, 0, len(items))
+
+	for idx, item := range items {
+		iterIn, ise := it.applyItemSelector(st, input, item, idx)
+		if ise != nil {
+			return nil, ise
+		}
+
+		iterOut, rse := it.runGraph(ctx, proc.StartAt, proc.States, iterIn)
+		if rse != nil {
+			return nil, rse
+		}
+
+		results = append(results, iterOut)
+	}
+
+	return it.resultPipeline(st, raw, results)
+}
+
+// resolveItems yields the array a Map iterates over: ItemsPath resolved against
+// the effective input, else a literal Items array, else the effective input
+// itself. A non-array or a missing ItemsPath fails loudly (feeding Retry/Catch).
+func (it *interp) resolveItems(st *State, input any) ([]any, *stateError) {
+	src, se := it.mapItemsSource(st, input)
+	if se != nil {
+		return nil, se
+	}
+
+	arr, ok := src.([]any)
+	if !ok {
+		return nil, &stateError{Code: "States.Runtime",
+			Cause: fmt.Sprintf("Map state %q items did not resolve to an array", st.name)}
+	}
+
+	return arr, nil
+}
+
+func (it *interp) mapItemsSource(st *State, input any) (any, *stateError) {
+	switch {
+	case st.ItemsPath != "":
+		v, present, err := it.resolvePath(st.ItemsPath, input)
+		if err != nil {
+			return nil, asStateError(err)
+		}
+
+		if !present {
+			return nil, &stateError{Code: "States.Runtime",
+				Cause: fmt.Sprintf("ItemsPath %q could not be found in the input", st.ItemsPath)}
+		}
+
+		return v, nil
+	case st.Items != nil:
+		v, err := rawToValue(st.Items)
+		if err != nil {
+			return nil, asStateError(err)
+		}
+
+		return v, nil
+	default:
+		return input, nil
+	}
+}
+
+// applyItemSelector shapes one iteration's input. Absent ItemSelector passes the
+// item through unchanged; otherwise the ItemSelector payload template resolves
+// against the Map's effective input with $$.Map.Item.{Index,Value} bound to the
+// current iteration.
+func (it *interp) applyItemSelector(st *State, input, item any, idx int) (any, *stateError) {
+	if st.ItemSelector == nil {
+		return item, nil
+	}
+
+	it.setMapContext(idx, item)
+	defer it.clearMapContext()
+
+	v, err := it.applyPayloadTemplate(st.ItemSelector, input)
+	if err != nil {
+		return nil, asStateError(err)
+	}
+
+	return v, nil
+}
+
+// setMapContext binds $$.Map.Item.{Index,Value} for an ItemSelector evaluation.
+func (it *interp) setMapContext(idx int, item any) {
+	it.ctxObj["Map"] = map[string]any{
+		"Item": map[string]any{"Index": float64(idx), "Value": item},
+	}
+}
+
+// clearMapContext removes the $$.Map binding once the iteration input is built.
+func (it *interp) clearMapContext() {
+	delete(it.ctxObj, "Map")
+}

--- a/providers/aws/sfn/asl/parallel.go
+++ b/providers/aws/sfn/asl/parallel.go
@@ -1,0 +1,53 @@
+package asl
+
+import "context"
+
+// parallelHandler runs a Parallel state: each branch is its own sub-state-machine
+// run, sequentially, on the SAME effective input (InputPath -> Parameters). The
+// state's result is the JSON array of branch outputs in branch order. Any branch
+// failure fails the Parallel state with that branch's error, which — together
+// with the state's own I/O-pipeline errors — flows through the state's Retry
+// (re-running all branches) and Catch. ctx threads into every branch run, so a
+// Parallel -> Task -> Lambda cycle stays bounded by the recursion guard.
+func parallelHandler(ctx context.Context, it *interp, st *State, raw any) (out any, next string, terminal bool, err error) {
+	it.enterState(st, raw)
+
+	out, se := it.runWithRetry(st, func() (any, *stateError) {
+		return it.runParallel(ctx, st, raw)
+	})
+	if se != nil {
+		return catchOrFail(st, raw, se)
+	}
+
+	it.exitState(st, out)
+
+	return out, st.Next, st.End, nil
+}
+
+// runParallel is one Parallel attempt: it runs every branch to completion on the
+// shared effective input and threads the ordered branch outputs through the
+// result pipeline (ResultSelector -> ResultPath onto the RAW input -> OutputPath).
+func (it *interp) runParallel(ctx context.Context, st *State, raw any) (any, *stateError) {
+	if se := it.enterNesting(); se != nil {
+		return nil, se
+	}
+	defer it.leaveNesting()
+
+	input, se := it.stateInput(st, raw)
+	if se != nil {
+		return nil, se
+	}
+
+	results := make([]any, 0, len(st.Branches))
+
+	for _, br := range st.Branches {
+		branchOut, bse := it.runGraph(ctx, br.StartAt, br.States, input)
+		if bse != nil {
+			return nil, bse
+		}
+
+		results = append(results, branchOut)
+	}
+
+	return it.resultPipeline(st, raw, results)
+}

--- a/providers/aws/sfn/asl/parse.go
+++ b/providers/aws/sfn/asl/parse.go
@@ -5,15 +5,15 @@
 // per-state event history. It is driven by config.Clock so Wait timing is
 // deterministic under a FakeClock.
 //
-// Supported in this build: Pass, Choice, Wait, Succeed, Fail, and Task (the
+// Supported in this build: Pass, Choice, Wait, Succeed, Fail, Task (the
 // arn:aws:states:::lambda:invoke and bare Lambda-function-ARN forms, with Retry
-// and Catch); the full InputPath -> Parameters -> Result -> ResultSelector ->
-// ResultPath -> OutputPath I/O pipeline; a reference/selection JSONPath subset;
-// the $$ context object; and a first-wave intrinsic set. Parallel and Map parse
-// (so a definition containing them is accepted at create time) but fail loudly
-// at run time until their handlers land. JSONata query language, and JSONPath
-// filters/wildcards/recursive-descent, are rejected rather than silently
-// mis-run.
+// and Catch), Parallel (branches run sequentially to completion), and Map
+// (iterations run sequentially over the resolved items; MaxConcurrency is parsed
+// but not honored); the full InputPath -> Parameters -> Result -> ResultSelector
+// -> ResultPath -> OutputPath I/O pipeline; a reference/selection JSONPath
+// subset; the $$ context object; and a first-wave intrinsic set. JSONata query
+// language, and JSONPath filters/wildcards/recursive-descent, are rejected
+// rather than silently mis-run.
 package asl
 
 import (
@@ -89,6 +89,28 @@ type State struct {
 	Resource string     `json:"Resource"`
 	Retry    []*Retrier `json:"Retry"`
 	Catch    []*Catcher `json:"Catch"`
+
+	// Parallel: each branch is its own sub-state-machine run on the same input.
+	Branches []*StateMachineDef `json:"Branches"`
+
+	// Map: the ItemProcessor (or legacy Iterator) sub-state-machine runs once per
+	// resolved item. MaxConcurrency is parsed but sequential execution is used.
+	ItemProcessor  *StateMachineDef `json:"ItemProcessor"`
+	Iterator       *StateMachineDef `json:"Iterator"`
+	ItemsPath      string           `json:"ItemsPath"`
+	Items          json.RawMessage  `json:"Items"`
+	ItemSelector   json.RawMessage  `json:"ItemSelector"`
+	MaxConcurrency *int             `json:"MaxConcurrency"` // parsed; execution is sequential
+}
+
+// processor returns the Map state's sub-state-machine, preferring the modern
+// ItemProcessor over the legacy Iterator.
+func (s *State) processor() *StateMachineDef {
+	if s.ItemProcessor != nil {
+		return s.ItemProcessor
+	}
+
+	return s.Iterator
 }
 
 // StateMachineDef is a parsed ASL definition.
@@ -130,16 +152,34 @@ func Parse(definition string) (*StateMachineDef, error) {
 		return nil, aslErrf("definition is missing the required top-level 'States' object")
 	}
 
+	if err := validateStates(&def); err != nil {
+		return nil, err
+	}
+
+	return &def, nil
+}
+
+// validateStates populates each state's name and structurally validates it,
+// recursing into Parallel branches and Map processors.
+func validateStates(def *StateMachineDef) error {
+	if def.StartAt == "" {
+		return aslErrf("sub-state-machine is missing the required 'StartAt' field")
+	}
+
+	if len(def.States) == 0 {
+		return aslErrf("sub-state-machine is missing the required 'States' object")
+	}
+
 	if _, ok := def.States[def.StartAt]; !ok {
-		return nil, aslErrf("StartAt %q does not name a state in 'States'", def.StartAt)
+		return aslErrf("StartAt %q does not name a state in 'States'", def.StartAt)
 	}
 
 	for name, st := range def.States {
 		st.name = name
 		if err := validateState(def.States, st); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return &def, nil
+	return nil
 }

--- a/providers/aws/sfn/asl/pass.go
+++ b/providers/aws/sfn/asl/pass.go
@@ -43,12 +43,3 @@ func passHandler(_ context.Context, it *interp, st *State, raw any) (out any, ne
 
 	return out, st.Next, st.End, nil
 }
-
-// unsupportedHandler fails an execution loudly when it reaches a state type
-// whose interpreter has not landed yet (Task, Parallel, Map).
-func unsupportedHandler(_ context.Context, _ *interp, st *State, _ any) (out any, next string, terminal bool, err error) {
-	return nil, "", false, &stateError{
-		Code:  "States.Runtime",
-		Cause: fmt.Sprintf("state type %q is not yet supported by the interpreter", st.Type),
-	}
-}

--- a/providers/aws/sfn/asl/retry.go
+++ b/providers/aws/sfn/asl/retry.go
@@ -1,7 +1,6 @@
 package asl
 
 import (
-	"context"
 	"math"
 	"time"
 )
@@ -11,6 +10,7 @@ const (
 	defaultRetryInterval = 1.0
 	defaultRetryMax      = 3
 	defaultBackoffRate   = 2.0
+	minBackoffRate       = 1.0
 	errAll               = "States.ALL"
 )
 
@@ -35,17 +35,16 @@ type Catcher struct {
 	ResultPath  pathField `json:"ResultPath"`
 }
 
-// invokeTaskWithRetry runs the Lambda invocation, retrying on a matching Retrier
-// until it succeeds or the matched Retrier's MaxAttempts is exhausted. Backoff
-// advances the virtual clock (config.Clock), so timing is FakeClock-deterministic
-// and folds into the settle window under AsyncSettle.
-func (it *interp) invokeTaskWithRetry(
-	ctx context.Context, st *State, funcRef string, payload []byte,
-) (any, *stateError) {
+// runWithRetry runs attempt, retrying on a matching Retrier until it succeeds or
+// the matched Retrier's MaxAttempts is exhausted. Backoff advances the virtual
+// clock (config.Clock), so timing is FakeClock-deterministic and folds into the
+// settle window under AsyncSettle. It is shared by Task (re-invoking the Lambda),
+// Parallel (re-running all branches), and Map (re-running all iterations).
+func (it *interp) runWithRetry(st *State, attempt func() (any, *stateError)) (any, *stateError) {
 	attempts := make([]int, len(st.Retry))
 
 	for {
-		result, se := it.invokeLambdaTask(ctx, st, funcRef, payload)
+		result, se := attempt()
 		if se == nil {
 			return result, nil
 		}

--- a/providers/aws/sfn/asl/task.go
+++ b/providers/aws/sfn/asl/task.go
@@ -17,60 +17,23 @@ const lambdaInvokeResource = "arn:aws:states:::lambda:invoke"
 // reports.
 const lambdaOKStatus = 200
 
-// taskHandler runs a Task state. It resolves the Lambda call from the Resource
-// ARN and the InputPath->Parameters-shaped payload, invokes the function through
-// the recursion-guarded seam under Retry, and on success runs the result through
-// ResultSelector->ResultPath->OutputPath. A failure that no Catcher handles
-// propagates to ExecutionFailed; a caught failure transitions to the Catcher's
-// Next with the {Error,Cause} error output merged at its ResultPath.
+// taskHandler runs a Task state. The whole state — its InputPath/Parameters
+// input pipeline, the recursion-guarded Lambda invoke, and its
+// ResultSelector/ResultPath/OutputPath result pipeline — runs under Retry, so a
+// matching Retrier re-runs the state (re-invoking the function) exactly as real
+// AWS does. Any failure the Retriers do not recover, INCLUDING a state-internal
+// I/O-pipeline error (States.ParameterPathFailure / States.ResultPathMatchFailure
+// / an unsupported Resource), is routed through the state's Catch: a matching
+// Catcher transitions to its Next with the {Error,Cause} error output merged at
+// its ResultPath; otherwise it propagates to ExecutionFailed.
 func taskHandler(ctx context.Context, it *interp, st *State, raw any) (out any, next string, terminal bool, err error) {
 	it.enterState(st, raw)
 
-	funcRef, payload, perr := it.prepareTask(st, raw)
-	if perr != nil {
-		return nil, "", false, perr
-	}
-
-	result, se := it.invokeTaskWithRetry(ctx, st, funcRef, payload)
+	out, se := it.runWithRetry(st, func() (any, *stateError) {
+		return it.runTaskOnce(ctx, st, raw)
+	})
 	if se != nil {
-		return handleTaskError(st, raw, se)
-	}
-
-	return it.finishTask(st, raw, result)
-}
-
-// prepareTask runs the input pipeline (InputPath->Parameters) and resolves the
-// target function reference and the payload delivered to it.
-func (it *interp) prepareTask(st *State, raw any) (funcRef string, payload []byte, err error) {
-	filtered, ferr := it.applyInputPath(st, raw)
-	if ferr != nil {
-		return "", nil, ferr
-	}
-
-	params, perr := it.applyParameters(st, filtered)
-	if perr != nil {
-		return "", nil, perr
-	}
-
-	return resolveLambdaCall(st, params)
-}
-
-// finishTask runs the result pipeline on a successful task result and emits the
-// TaskStateExited event.
-func (it *interp) finishTask(st *State, raw, result any) (out any, next string, terminal bool, err error) {
-	selected, err := it.applyResultSelector(st, result)
-	if err != nil {
-		return nil, "", false, err
-	}
-
-	merged, err := it.applyResultPath(st, raw, selected)
-	if err != nil {
-		return nil, "", false, err
-	}
-
-	out, err = it.applyOutputPath(st, merged)
-	if err != nil {
-		return nil, "", false, err
+		return catchOrFail(st, raw, se)
 	}
 
 	it.exitState(st, out)
@@ -78,14 +41,26 @@ func (it *interp) finishTask(st *State, raw, result any) (out any, next string, 
 	return out, st.Next, st.End, nil
 }
 
-// handleTaskError routes a task failure to a matching Catcher (transitioning to
-// its Next), or propagates it to ExecutionFailed when no Catcher matches.
-func handleTaskError(st *State, raw any, se *stateError) (out any, next string, terminal bool, err error) {
-	if caughtOut, catchNext, ok := tryCatch(st, raw, se); ok {
-		return caughtOut, catchNext, false, nil
+// runTaskOnce is one Task attempt: it runs the input pipeline, resolves and
+// invokes the Lambda through the recursion-guarded seam, then runs the result
+// pipeline. Every failure (I/O or invoke) is a *stateError so Retry/Catch see it.
+func (it *interp) runTaskOnce(ctx context.Context, st *State, raw any) (any, *stateError) {
+	input, se := it.stateInput(st, raw)
+	if se != nil {
+		return nil, se
 	}
 
-	return nil, "", false, se
+	funcRef, payload, err := resolveLambdaCall(st, input)
+	if err != nil {
+		return nil, asStateError(err)
+	}
+
+	result, se := it.invokeLambdaTask(ctx, st, funcRef, payload)
+	if se != nil {
+		return nil, se
+	}
+
+	return it.resultPipeline(st, raw, result)
 }
 
 // invokeLambdaTask performs one Lambda invocation attempt, emitting the

--- a/providers/aws/sfn/asl/validate.go
+++ b/providers/aws/sfn/asl/validate.go
@@ -19,29 +19,99 @@ func validateState(states map[string]*State, st *State) error {
 		return err
 	}
 
+	if err := validateRetriers(st); err != nil {
+		return err
+	}
+
 	if st.Type == TypeChoice {
 		return validateChoice(states, st)
 	}
 
+	if err := validateSubMachines(st); err != nil {
+		return err
+	}
+
 	return validateTransitions(states, st)
+}
+
+// validateSubMachines validates the nested state machines a Parallel (Branches)
+// or Map (ItemProcessor/Iterator) state carries, mirroring the create-time
+// structural checks AWS applies to the top-level definition.
+func validateSubMachines(st *State) error {
+	switch st.Type {
+	case TypeParallel:
+		if len(st.Branches) == 0 {
+			return aslErrf("Parallel state %q must have a non-empty 'Branches' array", st.name)
+		}
+
+		for i, br := range st.Branches {
+			if err := validateStates(br); err != nil {
+				return aslErrf("Parallel state %q branch %d: %s", st.name, i, err.Error())
+			}
+		}
+	case TypeMap:
+		proc := st.processor()
+		if proc == nil {
+			return aslErrf("Map state %q must have an 'ItemProcessor' (or 'Iterator')", st.name)
+		}
+
+		if err := validateStates(proc); err != nil {
+			return aslErrf("Map state %q processor: %s", st.name, err.Error())
+		}
+	}
+
+	return nil
+}
+
+// validateRetriers rejects out-of-range Retrier fields at create time:
+// IntervalSeconds and MaxAttempts must be >= 0, and BackoffRate must be >= 1.0.
+func validateRetriers(st *State) error {
+	for i, r := range st.Retry {
+		switch {
+		case r.IntervalSeconds != nil && *r.IntervalSeconds < 0:
+			return aslErrf("state %q Retry[%d] 'IntervalSeconds' must be >= 0", st.name, i)
+		case r.MaxAttempts != nil && *r.MaxAttempts < 0:
+			return aslErrf("state %q Retry[%d] 'MaxAttempts' must be >= 0", st.name, i)
+		case r.BackoffRate != nil && *r.BackoffRate < minBackoffRate:
+			return aslErrf("state %q Retry[%d] 'BackoffRate' must be >= 1.0", st.name, i)
+		}
+	}
+
+	return nil
 }
 
 // validateFieldApplicability rejects result-shaping fields on the state types
 // that do not support them (Wait, Choice, Succeed, Fail), matching AWS's
 // create-time rejection.
 func validateFieldApplicability(st *State) error {
-	// Pass supports Parameters/Result/ResultPath but not ResultSelector, which
-	// is valid only on Task/Parallel/Map (matching AWS's create-time rejection).
-	if st.Type == TypePass && st.ResultSelector != nil {
-		return aslErrf("state %q (%s) does not support the 'ResultSelector' field", st.name, st.Type)
-	}
-
 	switch st.Type {
+	case TypePass:
+		return validatePassFields(st)
 	case TypeWait, TypeChoice, TypeSucceed, TypeFail:
+		return validateNonResultFields(st)
 	default:
 		return nil
 	}
+}
 
+// validatePassFields rejects the result-shaping fields a Pass state does not
+// support: ResultSelector, Retry, and Catch (Task/Parallel/Map only).
+func validatePassFields(st *State) error {
+	switch {
+	case st.ResultSelector != nil:
+		return aslErrf("state %q (%s) does not support the 'ResultSelector' field", st.name, st.Type)
+	case len(st.Retry) > 0:
+		return aslErrf("state %q (%s) does not support the 'Retry' field", st.name, st.Type)
+	case len(st.Catch) > 0:
+		return aslErrf("state %q (%s) does not support the 'Catch' field", st.name, st.Type)
+	}
+
+	return nil
+}
+
+// validateNonResultFields rejects every result-shaping field on the state types
+// (Wait, Choice, Succeed, Fail) that support none of them.
+func validateNonResultFields(st *State) error {
 	switch {
 	case st.Parameters != nil:
 		return aslErrf("state %q (%s) does not support the 'Parameters' field", st.name, st.Type)

--- a/providers/aws/sfn/parallel_map_test.go
+++ b/providers/aws/sfn/parallel_map_test.go
@@ -1,0 +1,298 @@
+package sfn_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
+)
+
+// TestParallelBranchesArrayOutput runs a Parallel with two branches and asserts
+// the state output is the JSON array of branch outputs in branch order.
+func TestParallelBranchesArrayOutput(t *testing.T) {
+	def := `{"StartAt":"P","States":{
+		"P":{"Type":"Parallel","End":true,"Branches":[
+			{"StartAt":"A","States":{"A":{"Type":"Pass","Result":{"branch":1},"End":true}}},
+			{"StartAt":"B","States":{"B":{"Type":"Pass","Result":{"branch":2},"End":true}}}
+		]}}}`
+
+	exec := runSync(t, newMock(t), "par", def, `{}`)
+
+	if exec.Status != driver.ExecStatusSucceeded {
+		t.Fatalf("status = %q (err=%q cause=%q), want SUCCEEDED", exec.Status, exec.Error, exec.Cause)
+	}
+
+	if !jsonEqual(t, exec.Output, `[{"branch":1},{"branch":2}]`) {
+		t.Fatalf("output = %q, want the ordered branch-output array", exec.Output)
+	}
+}
+
+// TestParallelBranchFailureCaught asserts a branch failure fails the Parallel
+// state and is routed to the Parallel's Catch (not straight to ExecutionFailed).
+func TestParallelBranchFailureCaught(t *testing.T) {
+	def := `{"StartAt":"P","States":{
+		"P":{"Type":"Parallel","End":true,
+			"Branches":[
+				{"StartAt":"A","States":{"A":{"Type":"Pass","End":true}}},
+				{"StartAt":"F","States":{"F":{"Type":"Fail","Error":"BranchBoom","Cause":"branch blew up"}}}
+			],
+			"Catch":[{"ErrorEquals":["BranchBoom"],"Next":"Rescue","ResultPath":"$.error"}]},
+		"Rescue":{"Type":"Pass","End":true}}}`
+
+	exec := runSync(t, newMock(t), "par-catch", def, `{"seed":7}`)
+
+	if exec.Status != driver.ExecStatusSucceeded {
+		t.Fatalf("status = %q (err=%q cause=%q), want SUCCEEDED via Catch", exec.Status, exec.Error, exec.Cause)
+	}
+
+	if !jsonEqual(t, exec.Output, `{"seed":7,"error":{"Error":"BranchBoom","Cause":"branch blew up"}}`) {
+		t.Fatalf("output = %q, want the raw input with the caught error merged at $.error", exec.Output)
+	}
+}
+
+// TestParallelResultPathMergesOntoRawInput asserts ResultSelector/ResultPath on a
+// Parallel splice the branch-output array onto the RAW input, preserving siblings.
+func TestParallelResultPathMergesOntoRawInput(t *testing.T) {
+	def := `{"StartAt":"P","States":{
+		"P":{"Type":"Parallel","End":true,"ResultPath":"$.results",
+			"Branches":[
+				{"StartAt":"A","States":{"A":{"Type":"Pass","Result":1,"End":true}}},
+				{"StartAt":"B","States":{"B":{"Type":"Pass","Result":2,"End":true}}}
+			]}}}`
+
+	exec := runSync(t, newMock(t), "par-rp", def, `{"orig":true}`)
+
+	if exec.Status != driver.ExecStatusSucceeded {
+		t.Fatalf("status = %q (err=%q), want SUCCEEDED", exec.Status, exec.Error)
+	}
+
+	if !jsonEqual(t, exec.Output, `{"orig":true,"results":[1,2]}`) {
+		t.Fatalf("output = %q, want the array merged at $.results with siblings preserved", exec.Output)
+	}
+}
+
+// TestMapPerItemOutputWithItemSelector runs a Map over an array and asserts the
+// output is the per-iteration array with ItemSelector ($$.Map.Item.*) applied.
+func TestMapPerItemOutputWithItemSelector(t *testing.T) {
+	def := `{"StartAt":"M","States":{
+		"M":{"Type":"Map","End":true,"ItemsPath":"$.nums","MaxConcurrency":3,
+			"ItemSelector":{"value.$":"$$.Map.Item.Value","index.$":"$$.Map.Item.Index"},
+			"ItemProcessor":{"StartAt":"I","States":{"I":{"Type":"Pass","End":true}}}}}}`
+
+	exec := runSync(t, newMock(t), "map", def, `{"nums":[10,20,30]}`)
+
+	if exec.Status != driver.ExecStatusSucceeded {
+		t.Fatalf("status = %q (err=%q cause=%q), want SUCCEEDED", exec.Status, exec.Error, exec.Cause)
+	}
+
+	want := `[{"value":10,"index":0},{"value":20,"index":1},{"value":30,"index":2}]`
+	if !jsonEqual(t, exec.Output, want) {
+		t.Fatalf("output = %q, want %q", exec.Output, want)
+	}
+}
+
+// TestMapIterationFailureFailsMap asserts one iteration failing fails the Map
+// with that iteration's error when no Catcher handles it.
+func TestMapIterationFailureFailsMap(t *testing.T) {
+	def := `{"StartAt":"M","States":{
+		"M":{"Type":"Map","End":true,"ItemsPath":"$.items",
+			"ItemProcessor":{"StartAt":"C","States":{
+				"C":{"Type":"Choice","Choices":[{"Variable":"$","NumericLessThan":3,"Next":"OK"}],"Default":"Boom"},
+				"OK":{"Type":"Pass","End":true},
+				"Boom":{"Type":"Fail","Error":"TooBig","Cause":"item exceeded the limit"}}}}}}`
+
+	exec := runSync(t, newMock(t), "map-fail", def, `{"items":[1,2,5]}`)
+
+	if exec.Status != driver.ExecStatusFailed {
+		t.Fatalf("status = %q, want FAILED (iteration failure propagates)", exec.Status)
+	}
+
+	if exec.Error != "TooBig" {
+		t.Fatalf("error = %q, want TooBig from the failing iteration", exec.Error)
+	}
+}
+
+// TestMapResultSelectorAndResultPath asserts ResultSelector reshapes the Map
+// result array and ResultPath splices it onto the raw input.
+func TestMapResultSelectorAndResultPath(t *testing.T) {
+	def := `{"StartAt":"M","States":{
+		"M":{"Type":"Map","End":true,"ItemsPath":"$.n",
+			"ResultSelector":{"items.$":"$"},
+			"ResultPath":"$.mapped",
+			"ItemProcessor":{"StartAt":"I","States":{"I":{"Type":"Pass","End":true}}}}}}`
+
+	exec := runSync(t, newMock(t), "map-rs", def, `{"n":[1,2],"keep":9}`)
+
+	if exec.Status != driver.ExecStatusSucceeded {
+		t.Fatalf("status = %q (err=%q), want SUCCEEDED", exec.Status, exec.Error)
+	}
+
+	if !jsonEqual(t, exec.Output, `{"n":[1,2],"keep":9,"mapped":{"items":[1,2]}}`) {
+		t.Fatalf("output = %q, want the reshaped result merged at $.mapped", exec.Output)
+	}
+}
+
+// TestTaskResultPathFailureIsCaught is the Medium PR2-review fix: a Task whose
+// ResultPath uses unsupported syntax fails with States.ResultPathMatchFailure —
+// a state-internal I/O error that must now be CAUGHT by a matching Catcher rather
+// than bypassing Catch and going straight to ExecutionFailed.
+func TestTaskResultPathFailureIsCaught(t *testing.T) {
+	inv := fakeLambda{fn: func(_ context.Context, _ string, _ []byte) ([]byte, string, error) {
+		return []byte(`{"ok":1}`), "", nil
+	}}
+
+	def := `{"StartAt":"T","States":{
+		"T":{"Type":"Task","Resource":"` + lambdaFuncARN + `","ResultPath":"$.a.b[0]","End":true,
+			"Catch":[{"ErrorEquals":["States.ResultPathMatchFailure"],"Next":"Rescue","ResultPath":"$.caught"}]},
+		"Rescue":{"Type":"Pass","End":true}}}`
+
+	exec := runSync(t, taskMock(t, inv), "task-rp-catch", def, `{"in":1}`)
+
+	if exec.Status != driver.ExecStatusSucceeded {
+		t.Fatalf("status = %q (err=%q cause=%q), want SUCCEEDED via Catch — the ResultPath error must be catchable",
+			exec.Status, exec.Error, exec.Cause)
+	}
+
+	if !jsonEqual(t, exec.Output,
+		`{"in":1,"caught":{"Error":"States.ResultPathMatchFailure","Cause":"ResultPath \"$.a.b[0]\" uses unsupported syntax"}}`) {
+		t.Fatalf("output = %q, want the raw input with the caught ResultPath error at $.caught", exec.Output)
+	}
+}
+
+// TestParallelTaskLambdaRecursionBounded proves ctx (carrying recursion-guard
+// depth) threads through a Parallel branch: a Parallel -> Task -> Lambda cycle
+// that re-enters StartExecution terminates at recursionguard.MaxDepth with a
+// bounded States.TaskFailed instead of overflowing the stack.
+func TestParallelTaskLambdaRecursionBounded(t *testing.T) {
+	m := newMock(t)
+
+	def := `{"StartAt":"P","States":{"P":{"Type":"Parallel","End":true,
+		"Branches":[{"StartAt":"T","States":{"T":{"Type":"Task","Resource":"` + lambdaFuncARN + `","End":true}}}]}}}`
+	arn := createDef(t, m, "par-recurse", def)
+
+	maxDepth := 0
+	m.SetLambdaSyncInvoker(fakeLambda{fn: func(ctx context.Context, _ string, payload []byte) ([]byte, string, error) {
+		d := recursionguard.Depth(ctx)
+		if d > maxDepth {
+			maxDepth = d
+		}
+
+		if d >= recursionguard.MaxDepth {
+			return nil, "recursion limit reached", nil
+		}
+
+		sub, err := m.StartSyncExecution(recursionguard.WithDepth(ctx, d+1),
+			driver.StartExecutionInput{StateMachineArn: arn, Name: fmt.Sprintf("r%d", d), Input: string(payload)})
+		if err != nil {
+			return nil, "", err
+		}
+
+		if sub.Status == driver.ExecStatusFailed {
+			return nil, sub.Error, nil
+		}
+
+		return []byte(sub.Output), "", nil
+	}})
+
+	top, err := m.StartExecution(context.Background(),
+		driver.StartExecutionInput{StateMachineArn: arn, Name: "top", Input: `{}`})
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	if top.Status != driver.ExecStatusFailed || top.Error != "States.TaskFailed" {
+		t.Fatalf("top terminal = %q/%q, want FAILED/States.TaskFailed (bounded recursion through Parallel branch)",
+			top.Status, top.Error)
+	}
+
+	if maxDepth != recursionguard.MaxDepth {
+		t.Fatalf("max ctx depth = %d, want %d (guard reached across the Parallel branch)",
+			maxDepth, recursionguard.MaxDepth)
+	}
+}
+
+// TestCreateRejectsPassRetryCatch is the Low PR2-review fix: Pass supports
+// neither Retry nor Catch, so a definition using them is rejected at create time.
+func TestCreateRejectsPassRetryCatch(t *testing.T) {
+	cases := map[string]string{
+		"retry on pass": `{"StartAt":"A","States":{"A":{"Type":"Pass",` +
+			`"Retry":[{"ErrorEquals":["States.ALL"]}],"End":true}}}`,
+		"catch on pass": `{"StartAt":"A","States":{"A":{"Type":"Pass",` +
+			`"Catch":[{"ErrorEquals":["States.ALL"],"Next":"A"}],"End":true}}}`,
+	}
+
+	for name, def := range cases {
+		err := createErr(t, def)
+		if !errors.IsInvalidArgument(err) {
+			t.Fatalf("%s: want InvalidArgument, got %v", name, err)
+		}
+
+		if exceptionOf(err) != driver.ExInvalidDefinition {
+			t.Fatalf("%s: want InvalidDefinition, got %q (%v)", name, exceptionOf(err), err)
+		}
+	}
+}
+
+// TestCreateRejectsOutOfRangeRetrier is the Low PR2-review fix: Retrier fields are
+// bounds-checked at create time (IntervalSeconds >= 0, MaxAttempts >= 0,
+// BackoffRate >= 1.0).
+func TestCreateRejectsOutOfRangeRetrier(t *testing.T) {
+	arn := lambdaFuncARN
+	cases := map[string]string{
+		"backoff below 1": `{"StartAt":"T","States":{"T":{"Type":"Task","Resource":"` + arn + `",` +
+			`"Retry":[{"ErrorEquals":["States.ALL"],"BackoffRate":0.5}],"End":true}}}`,
+		"negative interval": `{"StartAt":"T","States":{"T":{"Type":"Task","Resource":"` + arn + `",` +
+			`"Retry":[{"ErrorEquals":["States.ALL"],"IntervalSeconds":-1}],"End":true}}}`,
+		"negative maxattempts": `{"StartAt":"T","States":{"T":{"Type":"Task","Resource":"` + arn + `",` +
+			`"Retry":[{"ErrorEquals":["States.ALL"],"MaxAttempts":-2}],"End":true}}}`,
+	}
+
+	for name, def := range cases {
+		err := createErr(t, def)
+		if !errors.IsInvalidArgument(err) {
+			t.Fatalf("%s: want InvalidArgument, got %v", name, err)
+		}
+
+		if exceptionOf(err) != driver.ExInvalidDefinition {
+			t.Fatalf("%s: want InvalidDefinition, got %q (%v)", name, exceptionOf(err), err)
+		}
+	}
+}
+
+// TestParallelMapHistoryEvents asserts the nested branch/iteration state events
+// appear inline between the Parallel/Map enter and exit, with a valid chain.
+func TestParallelMapHistoryEvents(t *testing.T) {
+	def := `{"StartAt":"P","States":{
+		"P":{"Type":"Parallel","End":true,"Branches":[
+			{"StartAt":"A","States":{"A":{"Type":"Pass","End":true}}}
+		]}}}`
+
+	m := newMock(t)
+	exec := runSync(t, m, "par-hist", def, `{}`)
+
+	events, err := m.GetExecutionHistory(context.Background(), exec.ARN, false)
+	if err != nil {
+		t.Fatalf("GetExecutionHistory: %v", err)
+	}
+
+	want := []string{
+		"ExecutionStarted",
+		"ParallelStateEntered",
+		"PassStateEntered", "PassStateExited",
+		"ParallelStateExited",
+		"ExecutionSucceeded",
+	}
+
+	if len(events) != len(want) {
+		t.Fatalf("history has %d events, want %d: %+v", len(events), len(want), events)
+	}
+
+	for i, w := range want {
+		if events[i].Type != w {
+			t.Fatalf("event %d type = %q, want %q", i, events[i].Type, w)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Final PR of the Step Functions ASL interpreter (#581). Adds the **Parallel** and **Map** state handlers — completing the interpreter's first-wave state set — and folds in three fidelity fixes flagged in the PR2 review.

### Parallel (`parallel.go`)
- Each branch is its own sub-state-machine, run **sequentially to completion** on the same effective input (InputPath → Parameters).
- Result is the **JSON array of branch outputs in branch order**.
- Any branch failure fails the Parallel state with that branch's error, feeding the state's Retry (re-running all branches) and Catch.
- `ctx` threads into every branch run, so a `Parallel → Task → Lambda` cycle stays bounded by the recursion guard.
- Emits `ParallelStateEntered/Exited` with the nested branch state events inline.

### Map (`map.go`)
- Resolves the items array (ItemsPath, a literal Items array, or the whole effective input), runs the `ItemProcessor`/`Iterator` sub-state-machine **once per item sequentially**, applying `ItemSelector` per item with `$$.Map.Item.{Index,Value}` bound.
- Result is the array of per-iteration outputs in order.
- `MaxConcurrency` is parsed but execution is sequential (documented).
- Any iteration failure fails the Map, feeding Retry/Catch.
- Emits `MapStateEntered/Exited` with nested iteration state events inline.

The full I/O pipeline (ResultSelector / ResultPath onto the **RAW** input / OutputPath) is applied to Parallel/Map results, consistent with Task. Recursive sub-machine validation and a Parallel/Map nesting guard (`CloudEmu.ExecutionNestingLimitExceeded`) were added.

## Three PR2-review fixes folded in

1. **[Medium] Catchable state-internal errors.** A Task's own I/O-pipeline failures (`States.ParameterPathFailure` / `States.ResultPathMatchFailure` / unsupported Resource) previously went straight to `ExecutionFailed`, bypassing that Task's `Catch`. They are now routed through the same Retry/Catch matching as invoke failures — the whole state (input pipeline → recursion-guarded invoke → result pipeline) runs under Retry, so a matching Retrier re-runs it exactly as real AWS does, and any unrecovered error flows through Catch. The same shared `catchOrFail` path applies to Parallel/Map I/O errors.
2. **[Low] Reject Retry/Catch on Pass** at validation (Pass supports neither).
3. **[Low] Bounds-check Retrier fields at create time** — `IntervalSeconds >= 0`, `MaxAttempts >= 0`, `BackoffRate >= 1.0` — rejected with InvalidDefinition.

After this PR the `unsupportedHandler` for Parallel/Map is removed (both are implemented).

## Tests (hand-rolled)

`providers/aws/sfn/parallel_map_test.go` + extended `asl/asl_test.go`:
- Parallel with 2 branches → ordered array output
- branch failure fails Parallel and is caught by its Catch
- Map over N items → per-item output array with ItemSelector applied
- iteration failure fails the Map
- ResultPath/ResultSelector on Parallel and Map (merge onto raw input, siblings preserved)
- recursion guard still bounds a `Parallel → Task → Lambda` cycle
- **a Task whose ResultPath fails is now CAUGHT by a matching Catcher** (asserts it routes to the catcher, not ExecutionFailed)
- Retry/Catch rejected on Pass; out-of-range Retrier (e.g. BackoffRate 0.5) rejected at create
- Parallel history event sequence

## Gates (GOMAXPROCS=2)

- `go build ./...` + `go vet ./providers/aws/sfn/...` — clean
- `go test ./providers/aws/sfn/... ./server/aws/... ./compat/aws/` — pass
- `go test -race ./providers/aws/sfn/...` — pass
- `go test ./providers/` (wiring parity) — pass
- `go generate ./...` — no driver-interface change, nothing to regen
- `golangci-lint run ./providers/aws/sfn/...` — 0 issues
