### PR TITLE
fix(gcp-lb): serve external L7 HTTP(S) LB front-end chain (#826)

### DIFF
--- a/server/gcp/loadbalancer/handler.go
+++ b/server/gcp/loadbalancer/handler.go
@@ -34,6 +34,7 @@ package loadbalancer
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	lbdriver "github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
@@ -73,12 +74,14 @@ func New(lb lbdriver.LoadBalancer) *Handler {
 // the compute handler's /operations poll route.
 func (h *Handler) SetOperationRegistry(reg *gcprest.OperationRegistry) { h.ops = reg }
 
-// Matches returns true for /compute/v1/.../backendServices|forwardingRules
-// URLs. Disjoint from the compute (instances/operations/disks/…) and networks
-// (networks/subnetworks/firewalls) handlers, so registration order is
-// unconstrained.
+// Matches returns true for the load-balancing resource types — backendServices,
+// forwardingRules, healthChecks, targetPools, urlMaps, the L7 front-end chain
+// (targetHttpProxies, targetHttpsProxies, sslCertificates) and instanceGroups /
+// regionInstanceGroups. Disjoint from the compute (instances/operations/disks/…)
+// and networks (networks/subnetworks/firewalls) handlers, so registration order
+// is unconstrained.
 func (*Handler) Matches(r *http.Request) bool {
-	rp, ok := gcprest.ParsePath(r.URL.Path)
+	rp, ok := parseLBPath(r.URL.Path)
 	if !ok {
 		return false
 	}
@@ -92,7 +95,9 @@ func (*Handler) Matches(r *http.Request) bool {
 
 	switch rp.ResourceType {
 	case resourceBackendServices, resourceForwardingRules,
-		resourceHealthChecks, resourceTargetPools, resourceURLMaps:
+		resourceHealthChecks, resourceTargetPools, resourceURLMaps,
+		resourceTargetHTTPProxies, resourceTargetHTTPSProxies, resourceSslCertificates,
+		resourceInstanceGroups, resourceRegionInstanceGroups:
 		return true
 	}
 
@@ -101,7 +106,7 @@ func (*Handler) Matches(r *http.Request) bool {
 
 // ServeHTTP routes the request based on resource type and method.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	rp, ok := gcprest.ParsePath(r.URL.Path)
+	rp, ok := parseLBPath(r.URL.Path)
 	if !ok {
 		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "malformed path")
 		return
@@ -114,6 +119,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.routeForwardingRules(w, r, rp)
 	case resourceHealthChecks, resourceTargetPools, resourceURLMaps:
 		h.routeGCPResource(w, r, rp)
+	case resourceTargetHTTPProxies, resourceTargetHTTPSProxies, resourceSslCertificates,
+		resourceInstanceGroups, resourceRegionInstanceGroups:
+		h.routeL7Resource(w, r, rp)
 	default:
 		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unknown resource type")
 	}
@@ -177,3 +185,45 @@ func (h *Handler) routeForwardingRules(w http.ResponseWriter, r *http.Request, r
 		gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
 	}
 }
+
+// parseLBPath parses a load-balancing request path, adding one form the generic
+// gcprest.ParsePath deliberately rejects: the scopeless-global action URL the
+// compute SDK uses for a few global target-proxy actions, e.g.
+// /compute/v1/projects/{p}/targetHttpProxies/{name}/setUrlMap (no /global/
+// segment). Only the two global target-proxy types opt into that form; every
+// other path still goes through the strict parser unchanged.
+func parseLBPath(path string) (gcprest.ResourcePath, bool) {
+	if rp, ok := gcprest.ParsePath(path); ok {
+		return rp, true
+	}
+
+	const projects = gcprest.BasePrefix + "projects/"
+	if !strings.HasPrefix(path, projects) {
+		return gcprest.ResourcePath{}, false
+	}
+
+	parts := strings.Split(strings.TrimPrefix(path, projects), "/")
+	if len(parts) < scopelessMinParts {
+		return gcprest.ResourcePath{}, false
+	}
+
+	if parts[1] != resourceTargetHTTPProxies && parts[1] != resourceTargetHTTPSProxies {
+		return gcprest.ResourcePath{}, false
+	}
+
+	rp := gcprest.ResourcePath{
+		Project:      parts[0],
+		Scope:        gcprest.ScopeGlobal,
+		ResourceType: parts[1],
+		ResourceName: parts[2],
+	}
+	if len(parts) > scopelessMinParts {
+		rp.Action = parts[3]
+	}
+
+	return rp, true
+}
+
+// scopelessMinParts is the segment count of a scopeless-global named-resource
+// path (project / type / name).
+const scopelessMinParts = 3

--- a/server/gcp/loadbalancer/l7frontend.go
+++ b/server/gcp/loadbalancer/l7frontend.go
@@ -342,7 +342,7 @@ func (h *Handler) gcpResourceInUse(ctx context.Context, rp gcprest.ResourcePath)
 	case resourceTargetHTTPProxies, resourceTargetHTTPSProxies:
 		return h.forwardingRuleRefTarget(ctx, rp.ResourceName)
 	case resourceInstanceGroups, resourceRegionInstanceGroups:
-		return h.backendServiceRefGroup(ctx, rp.ResourceName)
+		return h.backendServiceRefGroup(ctx, rp)
 	default:
 		return ""
 	}
@@ -417,8 +417,10 @@ func (h *Handler) forwardingRuleRefTarget(ctx context.Context, proxyName string)
 }
 
 // backendServiceRefGroup returns the name of a backend service whose backends[]
-// reference the instance group groupName, or "" when none does.
-func (h *Handler) backendServiceRefGroup(ctx context.Context, groupName string) string {
+// reference the instance group identified by rp (scope + name), or "" when none does.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) backendServiceRefGroup(ctx context.Context, rp gcprest.ResourcePath) string {
 	tgs, err := h.lb.DescribeTargetGroups(ctx, nil)
 	if err != nil {
 		return ""
@@ -430,7 +432,15 @@ func (h *Handler) backendServiceRefGroup(ctx context.Context, groupName string) 
 		decodeJSONTag(tgs[i].Tags, bsBackendsTag, &backends)
 
 		for j := range backends {
-			if backends[j].Group != "" && lastPathSegment(backends[j].Group) == groupName {
+			if backends[j].Group == "" {
+				continue
+			}
+
+			// Match the group's scope AND name, not just the trailing name: a
+			// same-named instance group in a different zone/region must not be
+			// falsely reported as in use.
+			_, scope, name := parseGroupRef(backends[j].Group)
+			if name == rp.ResourceName && scope == rp.ScopeName {
 				return displayName(tgs[i].Tags, bsNameTag, tgs[i].Name)
 			}
 		}

--- a/server/gcp/loadbalancer/l7frontend.go
+++ b/server/gcp/loadbalancer/l7frontend.go
@@ -1,0 +1,449 @@
+package loadbalancer
+
+// External L7 HTTP(S) load-balancer front-end chain:
+//
+//	forwardingRule → targetHttp(s)Proxy → urlMap → backendService → instanceGroup
+//
+// The three front-end resource types (targetHttpProxies, targetHttpsProxies,
+// sslCertificates) and the instance-group backends (instanceGroups,
+// regionInstanceGroups) have no cross-provider driver model, so they reuse the
+// same opaque GCPComputeResourceStore path as healthChecks/urlMaps/targetPools:
+// the decoded insert body round-trips verbatim, with server identity layered on
+// read. On top of plain CRUD they add the L7 action verbs a real user calls to
+// wire the chain — setUrlMap / setSslCertificates on a proxy, and
+// addInstances / removeInstances / listInstances on an instance group.
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+	lbdriver "github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
+)
+
+// L7 front-end and instance-group collections served through the opaque store.
+const (
+	resourceTargetHTTPProxies    = "targetHttpProxies"
+	resourceTargetHTTPSProxies   = "targetHttpsProxies"
+	resourceSslCertificates      = "sslCertificates"
+	resourceInstanceGroups       = "instanceGroups"
+	resourceRegionInstanceGroups = "regionInstanceGroups"
+)
+
+// POST action verbs on a named L7 resource.
+const (
+	actionSetURLMap          = "setUrlMap"
+	actionSetSslCertificates = "setSslCertificates"
+	actionAddInstances       = "addInstances"
+	actionRemoveInstances    = "removeInstances"
+	actionListInstances      = "listInstances"
+)
+
+// Reserved body members and the field keys the opaque L7 resources use.
+const (
+	// reservedBodyPrefix marks stored body members that must never be emitted on
+	// the wire (they are not real GCP fields). gcpResourceJSON strips them.
+	reservedBodyPrefix = "cloudemu:"
+	// igMembersKey holds an instance group's membership (a list of instance URLs)
+	// inside the opaque body. Stripped from every response by gcpResourceJSON.
+	igMembersKey = "cloudemu:igMembers"
+	// fieldURLMap / fieldSslCertificates are the proxy body members the setUrlMap
+	// and setSslCertificates actions mutate.
+	fieldURLMap          = "urlMap"
+	fieldSslCertificates = "sslCertificates"
+)
+
+// routeL7Resource dispatches the L7 front-end resources: the POST action verbs
+// (setUrlMap, setSslCertificates, addInstances, removeInstances, listInstances)
+// on a named resource, and otherwise the shared opaque-resource CRUD.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) routeL7Resource(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.ResourceName != "" && rp.Action != "" && r.Method == http.MethodPost {
+		switch rp.Action {
+		case actionSetURLMap:
+			h.setProxyField(w, r, rp, fieldURLMap, false)
+		case actionSetSslCertificates:
+			h.setProxyField(w, r, rp, fieldSslCertificates, true)
+		case actionAddInstances:
+			h.mutateInstanceGroupMembers(w, r, rp, true)
+		case actionRemoveInstances:
+			h.mutateInstanceGroupMembers(w, r, rp, false)
+		case actionListInstances:
+			h.listInstanceGroupInstances(w, r, rp)
+		default:
+			gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+		}
+
+		return
+	}
+
+	h.routeGCPResource(w, r, rp)
+}
+
+// setProxyRequest is the union of the two proxy set-* action bodies: a single
+// urlMap reference (setUrlMap) or a list of certificate URLs (setSslCertificates).
+type setProxyRequest struct {
+	URLMap          string   `json:"urlMap,omitempty"`
+	SslCertificates []string `json:"sslCertificates,omitempty"`
+}
+
+// setProxyField applies compute.targetHttp(s)Proxies.setUrlMap /
+// setSslCertificates: it stores the reference onto the proxy's body so a
+// subsequent Get reflects it and the chain resolves. list selects between the
+// scalar urlMap and the sslCertificates list.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) setProxyField(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath, field string, list bool) {
+	store, ok := h.gcpStore()
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotImplemented, "notImplemented", "load balancer driver has no GCP resource store")
+		return
+	}
+
+	var req setProxyRequest
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	err := store.UpdateGCPResource(r.Context(), rp.ResourceType, scopeKeyOf(rp), rp.ResourceName,
+		func(res *lbdriver.GCPResource) {
+			if res.Body == nil {
+				res.Body = map[string]any{}
+			}
+
+			if list {
+				res.Body[field] = toAnySlice(req.SslCertificates)
+			} else {
+				res.Body[field] = req.URLMap
+			}
+		})
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := h.ops.RecordDone(hostOf(r), rp.Project, rp.Scope, rp.ScopeName, rp.ResourceType, rp.ResourceName, rp.Action)
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// instanceRef is one entry of an addInstances/removeInstances body's instances[].
+type instanceRef struct {
+	Instance string `json:"instance,omitempty"`
+}
+
+// instancesRequest is the addInstances/removeInstances request body.
+type instancesRequest struct {
+	Instances []instanceRef `json:"instances,omitempty"`
+}
+
+// mutateInstanceGroupMembers applies compute.instanceGroups.addInstances /
+// removeInstances by editing the instance group's membership stored in its
+// opaque body. Membership drives backendServices.getHealth and the group's
+// reported size.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) mutateInstanceGroupMembers(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath, add bool) {
+	store, ok := h.gcpStore()
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotImplemented, "notImplemented", "load balancer driver has no GCP resource store")
+		return
+	}
+
+	var req instancesRequest
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	changed := make([]string, 0, len(req.Instances))
+
+	for i := range req.Instances {
+		if req.Instances[i].Instance != "" {
+			changed = append(changed, req.Instances[i].Instance)
+		}
+	}
+
+	err := store.UpdateGCPResource(r.Context(), rp.ResourceType, scopeKeyOf(rp), rp.ResourceName,
+		func(res *lbdriver.GCPResource) {
+			if res.Body == nil {
+				res.Body = map[string]any{}
+			}
+
+			res.Body[igMembersKey] = toAnySlice(applyMembership(membersOf(res.Body), changed, add))
+		})
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	verb := actionAddInstances
+	if !add {
+		verb = actionRemoveInstances
+	}
+
+	op := h.ops.RecordDone(hostOf(r), rp.Project, rp.Scope, rp.ScopeName, rp.ResourceType, rp.ResourceName, verb)
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// listInstanceGroupInstances serves compute.instanceGroups.listInstances,
+// returning the group's members as a compute#instanceGroupsListInstances
+// envelope (each member's instance URL), the shape the SDK iterator reads.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listInstanceGroupInstances(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	store, ok := h.gcpStore()
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotImplemented, "notImplemented", "load balancer driver has no GCP resource store")
+		return
+	}
+
+	res, err := store.GetGCPResource(r.Context(), rp.ResourceType, scopeKeyOf(rp), rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	members := membersOf(res.Body)
+
+	items := make([]map[string]any, 0, len(members))
+	for _, m := range members {
+		items = append(items, map[string]any{"instance": m, "status": "RUNNING"})
+	}
+
+	envelope := map[string]any{
+		"kind":     "compute#instanceGroupsListInstances",
+		"id":       "projects/" + rp.Project + "/" + listScopeSegment(rp) + "/instanceGroups/" + rp.ResourceName,
+		"items":    items,
+		"selfLink": gcprest.SelfLink(hostOf(r), rp.Project, rp.Scope, rp.ScopeName, rp.ResourceType, rp.ResourceName),
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, envelope)
+}
+
+// applyMembership adds or removes changed from current, preserving order and
+// deduplicating on add.
+func applyMembership(current, changed []string, add bool) []string {
+	if add {
+		return dedupeAppend(current, changed)
+	}
+
+	drop := make(map[string]struct{}, len(changed))
+	for _, c := range changed {
+		drop[c] = struct{}{}
+	}
+
+	out := make([]string, 0, len(current))
+
+	for _, c := range current {
+		if _, ok := drop[c]; !ok {
+			out = append(out, c)
+		}
+	}
+
+	return out
+}
+
+// dedupeAppend appends each of add to base, skipping values already present.
+func dedupeAppend(base, add []string) []string {
+	seen := make(map[string]struct{}, len(base))
+	for _, b := range base {
+		seen[b] = struct{}{}
+	}
+
+	out := base
+
+	for _, a := range add {
+		if _, ok := seen[a]; ok {
+			continue
+		}
+
+		seen[a] = struct{}{}
+
+		out = append(out, a)
+	}
+
+	return out
+}
+
+// membersOf reads an instance group's stored membership, tolerating both the
+// []string set in-process and the []any produced by a JSON round-trip (persist).
+func membersOf(body map[string]any) []string {
+	raw, ok := body[igMembersKey]
+	if !ok {
+		return nil
+	}
+
+	switch v := raw.(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+
+		for _, e := range v {
+			if s, ok := e.(string); ok {
+				out = append(out, s)
+			}
+		}
+
+		return out
+	default:
+		return nil
+	}
+}
+
+// toAnySlice widens a []string to []any so it survives snapshot JSON encoding
+// the same way a client-supplied list would.
+func toAnySlice(in []string) []any {
+	out := make([]any, len(in))
+	for i, s := range in {
+		out[i] = s
+	}
+
+	return out
+}
+
+// singularOf renders the GCP error-message resource noun for a collection (e.g.
+// "targetHttpProxies" → "target_http_proxy"), matching real GCP's
+// resourceInUseByAnotherResource phrasing.
+func singularOf(collection string) string {
+	switch collection {
+	case resourceHealthChecks:
+		return "health_check"
+	case resourceURLMaps:
+		return "url_map"
+	case resourceSslCertificates:
+		return "ssl_certificate"
+	case resourceTargetHTTPProxies:
+		return "target_http_proxy"
+	case resourceTargetHTTPSProxies:
+		return "target_https_proxy"
+	case resourceInstanceGroups, resourceRegionInstanceGroups:
+		return "instance_group"
+	default:
+		return strings.TrimSuffix(collection, "s")
+	}
+}
+
+// gcpResourceInUse returns the name of a resource still referencing the opaque
+// resource being deleted, or "" when the delete is safe. It centralizes the
+// per-collection reference-integrity guards so no delete orphans a dependent.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) gcpResourceInUse(ctx context.Context, rp gcprest.ResourcePath) string {
+	switch rp.ResourceType {
+	case resourceHealthChecks:
+		return h.healthCheckInUse(ctx, rp)
+	case resourceURLMaps:
+		return h.opaqueRefsField(ctx, rp, []string{resourceTargetHTTPProxies, resourceTargetHTTPSProxies}, fieldURLMap)
+	case resourceSslCertificates:
+		return h.opaqueRefsField(ctx, rp, []string{resourceTargetHTTPSProxies}, fieldSslCertificates)
+	case resourceTargetHTTPProxies, resourceTargetHTTPSProxies:
+		return h.forwardingRuleRefTarget(ctx, rp.ResourceName)
+	case resourceInstanceGroups, resourceRegionInstanceGroups:
+		return h.backendServiceRefGroup(ctx, rp.ResourceName)
+	default:
+		return ""
+	}
+}
+
+// opaqueRefsField returns the name of a same-scope opaque resource (in any of
+// collections) whose body member field references rp.ResourceName by trailing
+// name, or "" when none does. field may be a scalar string or a list of
+// references.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) opaqueRefsField(ctx context.Context, rp gcprest.ResourcePath, collections []string, field string) string {
+	store, ok := h.gcpStore()
+	if !ok {
+		return ""
+	}
+
+	for _, coll := range collections {
+		items, err := store.ListGCPResources(ctx, coll, scopeKeyOf(rp))
+		if err != nil {
+			continue
+		}
+
+		for i := range items {
+			if bodyFieldRefs(items[i].Body[field], rp.ResourceName) {
+				return items[i].Name
+			}
+		}
+	}
+
+	return ""
+}
+
+// bodyFieldRefs reports whether a body member (a scalar reference or a list of
+// them) resolves to name by trailing path segment.
+func bodyFieldRefs(v any, name string) bool {
+	switch t := v.(type) {
+	case string:
+		return lastPathSegment(t) == name
+	case []any:
+		for _, e := range t {
+			if s, ok := e.(string); ok && lastPathSegment(s) == name {
+				return true
+			}
+		}
+	case []string:
+		for _, s := range t {
+			if lastPathSegment(s) == name {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// forwardingRuleRefTarget returns the name of a forwarding rule whose target
+// resolves to proxyName, or "" when none does.
+func (h *Handler) forwardingRuleRefTarget(ctx context.Context, proxyName string) string {
+	lbs, err := h.lb.DescribeLoadBalancers(ctx, nil)
+	if err != nil {
+		return ""
+	}
+
+	for i := range lbs {
+		if lastPathSegment(lbs[i].Tags[frTargetTag]) == proxyName {
+			return displayName(lbs[i].Tags, frNameTag, lbs[i].Name)
+		}
+	}
+
+	return ""
+}
+
+// backendServiceRefGroup returns the name of a backend service whose backends[]
+// reference the instance group groupName, or "" when none does.
+func (h *Handler) backendServiceRefGroup(ctx context.Context, groupName string) string {
+	tgs, err := h.lb.DescribeTargetGroups(ctx, nil)
+	if err != nil {
+		return ""
+	}
+
+	for i := range tgs {
+		var backends []backend
+
+		decodeJSONTag(tgs[i].Tags, bsBackendsTag, &backends)
+
+		for j := range backends {
+			if backends[j].Group != "" && lastPathSegment(backends[j].Group) == groupName {
+				return displayName(tgs[i].Tags, bsNameTag, tgs[i].Name)
+			}
+		}
+	}
+
+	return ""
+}
+
+// sortedMembers returns a stable-ordered copy of an instance group's members
+// for deterministic health reporting.
+func sortedMembers(members []string) []string {
+	out := append([]string(nil), members...)
+	sort.Strings(out)
+
+	return out
+}

--- a/server/gcp/loadbalancer/l7frontend_sdk_test.go
+++ b/server/gcp/loadbalancer/l7frontend_sdk_test.go
@@ -463,3 +463,72 @@ func lastSeg(ref string) string {
 
 	return ref
 }
+
+// TestSDKGCPInstanceGroupDeleteScopedToZone guards the in-use delete check
+// against matching an instance group by trailing name only: a same-named group
+// in a different zone must remain deletable even while another zone's group of
+// the same name is referenced by a backend service.
+func TestSDKGCPInstanceGroupDeleteScopedToZone(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	const otherZone = "us-central1-b"
+
+	igClient, err := gcpcompute.NewInstanceGroupsRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewInstanceGroupsRESTClient: %v", err)
+	}
+	t.Cleanup(func() { _ = igClient.Close() })
+
+	bsClient, err := gcpcompute.NewBackendServicesRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewBackendServicesRESTClient: %v", err)
+	}
+	t.Cleanup(func() { _ = bsClient.Close() })
+
+	// Same-named instance group in two different zones.
+	for _, zone := range []string{testZone, otherZone} {
+		z := zone
+		waitOp(ctx, t, "instanceGroup Insert "+z, func() (*gcpcompute.Operation, error) {
+			return igClient.Insert(ctx, &computepb.InsertInstanceGroupRequest{
+				Project:               testProject,
+				Zone:                  z,
+				InstanceGroupResource: &computepb.InstanceGroup{Name: ptrStr("shared-ig")},
+			})
+		})
+	}
+
+	// A backend service references ONLY the testZone group.
+	ig, err := igClient.Get(ctx, &computepb.GetInstanceGroupRequest{
+		Project: testProject, Zone: testZone, InstanceGroup: "shared-ig",
+	})
+	if err != nil {
+		t.Fatalf("instanceGroup Get: %v", err)
+	}
+
+	waitOp(ctx, t, "backendService Insert", func() (*gcpcompute.Operation, error) {
+		return bsClient.Insert(ctx, &computepb.InsertBackendServiceRequest{
+			Project: testProject,
+			BackendServiceResource: &computepb.BackendService{
+				Name:                ptrStr("shared-bs"),
+				Protocol:            ptrStr("HTTP"),
+				LoadBalancingScheme: ptrStr("EXTERNAL_MANAGED"),
+				Backends:            []*computepb.Backend{{Group: ptrStr(ig.GetSelfLink())}},
+			},
+		})
+	})
+
+	// The unreferenced same-named group in the other zone must delete cleanly.
+	if _, err := igClient.Delete(ctx, &computepb.DeleteInstanceGroupRequest{
+		Project: testProject, Zone: otherZone, InstanceGroup: "shared-ig",
+	}); err != nil {
+		t.Fatalf("delete of unreferenced same-named group in %s should succeed, got: %v", otherZone, err)
+	}
+
+	// The referenced group must still be blocked.
+	if _, err := igClient.Delete(ctx, &computepb.DeleteInstanceGroupRequest{
+		Project: testProject, Zone: testZone, InstanceGroup: "shared-ig",
+	}); err == nil {
+		t.Fatalf("delete of the in-use group in %s should be blocked", testZone)
+	}
+}

--- a/server/gcp/loadbalancer/l7frontend_sdk_test.go
+++ b/server/gcp/loadbalancer/l7frontend_sdk_test.go
@@ -1,0 +1,465 @@
+package loadbalancer_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+const testZone = "us-central1-a"
+
+// clientOpts is the shared REST client option set pointing at the test server.
+func clientOpts(ts *httptest.Server) []option.ClientOption {
+	return []option.ClientOption{
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	}
+}
+
+// TestSDKGCPL7Chain provisions a full external L7 HTTP LB the way a real user
+// does and asserts the front-end chain resolves end-to-end:
+//
+//	forwardingRule → targetHttpProxy → urlMap → backendService → instanceGroup
+//
+// It then registers an instance in the group and asserts listInstances and
+// backendServices.getHealth reflect the membership, and that delete cleans up.
+//
+//nolint:gocyclo,cyclop,maintidx // one linear end-to-end scenario, kept in a single test for readability
+func TestSDKGCPL7Chain(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	igClient, err := gcpcompute.NewInstanceGroupsRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewInstanceGroupsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = igClient.Close() })
+
+	bsClient, err := gcpcompute.NewBackendServicesRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewBackendServicesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = bsClient.Close() })
+
+	umClient, err := gcpcompute.NewUrlMapsRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewUrlMapsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = umClient.Close() })
+
+	proxyClient, err := gcpcompute.NewTargetHttpProxiesRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewTargetHttpProxiesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = proxyClient.Close() })
+
+	frClient, err := gcpcompute.NewGlobalForwardingRulesRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewGlobalForwardingRulesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = frClient.Close() })
+
+	// 1. instance group (zonal, unmanaged).
+	waitOp(ctx, t, "instanceGroup Insert", func() (*gcpcompute.Operation, error) {
+		return igClient.Insert(ctx, &computepb.InsertInstanceGroupRequest{
+			Project:               testProject,
+			Zone:                  testZone,
+			InstanceGroupResource: &computepb.InstanceGroup{Name: ptrStr("web-ig")},
+		})
+	})
+
+	ig, err := igClient.Get(ctx, &computepb.GetInstanceGroupRequest{
+		Project: testProject, Zone: testZone, InstanceGroup: "web-ig",
+	})
+	if err != nil {
+		t.Fatalf("instanceGroup Get: %v", err)
+	}
+
+	igLink := ig.GetSelfLink()
+	if igLink == "" {
+		t.Fatal("instanceGroup selfLink empty")
+	}
+
+	// 2. backend service referencing the instance group.
+	waitOp(ctx, t, "backendService Insert", func() (*gcpcompute.Operation, error) {
+		return bsClient.Insert(ctx, &computepb.InsertBackendServiceRequest{
+			Project: testProject,
+			BackendServiceResource: &computepb.BackendService{
+				Name:                ptrStr("web-bs"),
+				Protocol:            ptrStr("HTTP"),
+				LoadBalancingScheme: ptrStr("EXTERNAL_MANAGED"),
+				Backends:            []*computepb.Backend{{Group: ptrStr(igLink)}},
+			},
+		})
+	})
+
+	bsLink := getBackendServiceLink(ctx, t, bsClient, "web-bs")
+
+	// 3. url map whose default service is the backend service.
+	waitOp(ctx, t, "urlMap Insert", func() (*gcpcompute.Operation, error) {
+		return umClient.Insert(ctx, &computepb.InsertUrlMapRequest{
+			Project:        testProject,
+			UrlMapResource: &computepb.UrlMap{Name: ptrStr("web-map"), DefaultService: ptrStr(bsLink)},
+		})
+	})
+
+	umLink := getURLMapLink(ctx, t, umClient, "web-map")
+
+	// 4. target HTTP proxy pointing at the url map (created empty, then setUrlMap).
+	waitOp(ctx, t, "targetHttpProxy Insert", func() (*gcpcompute.Operation, error) {
+		return proxyClient.Insert(ctx, &computepb.InsertTargetHttpProxyRequest{
+			Project:                testProject,
+			TargetHttpProxyResource: &computepb.TargetHttpProxy{Name: ptrStr("web-proxy")},
+		})
+	})
+
+	waitOp(ctx, t, "targetHttpProxy SetUrlMap", func() (*gcpcompute.Operation, error) {
+		return proxyClient.SetUrlMap(ctx, &computepb.SetUrlMapTargetHttpProxyRequest{
+			Project:                 testProject,
+			TargetHttpProxy:         "web-proxy",
+			UrlMapReferenceResource: &computepb.UrlMapReference{UrlMap: ptrStr(umLink)},
+		})
+	})
+
+	proxy, err := proxyClient.Get(ctx, &computepb.GetTargetHttpProxyRequest{Project: testProject, TargetHttpProxy: "web-proxy"})
+	if err != nil {
+		t.Fatalf("targetHttpProxy Get: %v", err)
+	}
+
+	if lastSeg(proxy.GetUrlMap()) != "web-map" {
+		t.Fatalf("proxy.urlMap = %q, want ...web-map (setUrlMap not applied)", proxy.GetUrlMap())
+	}
+
+	proxyLink := proxy.GetSelfLink()
+
+	// 5. global forwarding rule targeting the proxy.
+	waitOp(ctx, t, "forwardingRule Insert", func() (*gcpcompute.Operation, error) {
+		return frClient.Insert(ctx, &computepb.InsertGlobalForwardingRuleRequest{
+			Project: testProject,
+			ForwardingRuleResource: &computepb.ForwardingRule{
+				Name:      ptrStr("web-fr"),
+				Target:    ptrStr(proxyLink),
+				PortRange: ptrStr("80"),
+			},
+		})
+	})
+
+	// --- walk the chain fr → proxy → urlMap → backendService → instanceGroup ---
+	fr, err := frClient.Get(ctx, &computepb.GetGlobalForwardingRuleRequest{Project: testProject, ForwardingRule: "web-fr"})
+	if err != nil {
+		t.Fatalf("forwardingRule Get: %v", err)
+	}
+
+	if lastSeg(fr.GetTarget()) != "web-proxy" {
+		t.Fatalf("fr.target = %q, want ...web-proxy", fr.GetTarget())
+	}
+
+	um, err := umClient.Get(ctx, &computepb.GetUrlMapRequest{Project: testProject, UrlMap: "web-map"})
+	if err != nil {
+		t.Fatalf("urlMap Get: %v", err)
+	}
+
+	if lastSeg(um.GetDefaultService()) != "web-bs" {
+		t.Fatalf("urlMap.defaultService = %q, want ...web-bs", um.GetDefaultService())
+	}
+
+	bs, err := bsClient.Get(ctx, &computepb.GetBackendServiceRequest{Project: testProject, BackendService: "web-bs"})
+	if err != nil {
+		t.Fatalf("backendService Get: %v", err)
+	}
+
+	if len(bs.GetBackends()) != 1 || lastSeg(bs.GetBackends()[0].GetGroup()) != "web-ig" {
+		t.Fatalf("backendService.backends = %v, want one referencing web-ig", bs.GetBackends())
+	}
+
+	// --- register an instance and assert membership is reflected ---
+	instURL := "projects/" + testProject + "/zones/" + testZone + "/instances/vm-1"
+
+	waitOp(ctx, t, "instanceGroup AddInstances", func() (*gcpcompute.Operation, error) {
+		return igClient.AddInstances(ctx, &computepb.AddInstancesInstanceGroupRequest{
+			Project: testProject, Zone: testZone, InstanceGroup: "web-ig",
+			InstanceGroupsAddInstancesRequestResource: &computepb.InstanceGroupsAddInstancesRequest{
+				Instances: []*computepb.InstanceReference{{Instance: ptrStr(instURL)}},
+			},
+		})
+	})
+
+	assertListInstances(ctx, t, igClient, instURL)
+	assertGetHealth(ctx, t, bsClient, igLink, instURL)
+
+	// --- reference integrity: the group can't be deleted while the backend uses it ---
+	_, err = igClient.Delete(ctx, &computepb.DeleteInstanceGroupRequest{Project: testProject, Zone: testZone, InstanceGroup: "web-ig"})
+	if err == nil {
+		t.Fatal("instanceGroup Delete while referenced: want error, got nil")
+	}
+
+	// --- teardown in dependency order ---
+	waitOp(ctx, t, "forwardingRule Delete", func() (*gcpcompute.Operation, error) {
+		return frClient.Delete(ctx, &computepb.DeleteGlobalForwardingRuleRequest{Project: testProject, ForwardingRule: "web-fr"})
+	})
+	waitOp(ctx, t, "targetHttpProxy Delete", func() (*gcpcompute.Operation, error) {
+		return proxyClient.Delete(ctx, &computepb.DeleteTargetHttpProxyRequest{Project: testProject, TargetHttpProxy: "web-proxy"})
+	})
+	waitOp(ctx, t, "urlMap Delete", func() (*gcpcompute.Operation, error) {
+		return umClient.Delete(ctx, &computepb.DeleteUrlMapRequest{Project: testProject, UrlMap: "web-map"})
+	})
+	waitOp(ctx, t, "backendService Delete", func() (*gcpcompute.Operation, error) {
+		return bsClient.Delete(ctx, &computepb.DeleteBackendServiceRequest{Project: testProject, BackendService: "web-bs"})
+	})
+	waitOp(ctx, t, "instanceGroup Delete", func() (*gcpcompute.Operation, error) {
+		return igClient.Delete(ctx, &computepb.DeleteInstanceGroupRequest{Project: testProject, Zone: testZone, InstanceGroup: "web-ig"})
+	})
+
+	if _, err := igClient.Get(ctx, &computepb.GetInstanceGroupRequest{Project: testProject, Zone: testZone, InstanceGroup: "web-ig"}); err == nil {
+		t.Fatal("instanceGroup Get after delete: want error, got nil")
+	}
+}
+
+// TestSDKGCPTargetHTTPSProxyWithCertificate covers the HTTPS front-end: an SSL
+// certificate, and a target HTTPS proxy that binds it via setSslCertificates and
+// a url map via setUrlMap.
+func TestSDKGCPTargetHTTPSProxyWithCertificate(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	certClient, err := gcpcompute.NewSslCertificatesRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewSslCertificatesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = certClient.Close() })
+
+	proxyClient, err := gcpcompute.NewTargetHttpsProxiesRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewTargetHttpsProxiesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = proxyClient.Close() })
+
+	waitOp(ctx, t, "sslCertificate Insert", func() (*gcpcompute.Operation, error) {
+		return certClient.Insert(ctx, &computepb.InsertSslCertificateRequest{
+			Project: testProject,
+			SslCertificateResource: &computepb.SslCertificate{
+				Name:        ptrStr("web-cert"),
+				Certificate: ptrStr("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"),
+			},
+		})
+	})
+
+	cert, err := certClient.Get(ctx, &computepb.GetSslCertificateRequest{Project: testProject, SslCertificate: "web-cert"})
+	if err != nil {
+		t.Fatalf("sslCertificate Get: %v", err)
+	}
+
+	certLink := cert.GetSelfLink()
+	if certLink == "" {
+		t.Fatal("sslCertificate selfLink empty")
+	}
+
+	waitOp(ctx, t, "targetHttpsProxy Insert", func() (*gcpcompute.Operation, error) {
+		return proxyClient.Insert(ctx, &computepb.InsertTargetHttpsProxyRequest{
+			Project:                  testProject,
+			TargetHttpsProxyResource: &computepb.TargetHttpsProxy{Name: ptrStr("web-https-proxy")},
+		})
+	})
+
+	waitOp(ctx, t, "targetHttpsProxy SetSslCertificates", func() (*gcpcompute.Operation, error) {
+		return proxyClient.SetSslCertificates(ctx, &computepb.SetSslCertificatesTargetHttpsProxyRequest{
+			Project:         testProject,
+			TargetHttpsProxy: "web-https-proxy",
+			TargetHttpsProxiesSetSslCertificatesRequestResource: &computepb.TargetHttpsProxiesSetSslCertificatesRequest{
+				SslCertificates: []string{certLink},
+			},
+		})
+	})
+
+	proxy, err := proxyClient.Get(ctx, &computepb.GetTargetHttpsProxyRequest{Project: testProject, TargetHttpsProxy: "web-https-proxy"})
+	if err != nil {
+		t.Fatalf("targetHttpsProxy Get: %v", err)
+	}
+
+	if len(proxy.GetSslCertificates()) != 1 || lastSeg(proxy.GetSslCertificates()[0]) != "web-cert" {
+		t.Fatalf("proxy.sslCertificates = %v, want [...web-cert]", proxy.GetSslCertificates())
+	}
+
+	// The certificate is pinned by the proxy and must not be deletable.
+	if _, err := certClient.Delete(ctx, &computepb.DeleteSslCertificateRequest{Project: testProject, SslCertificate: "web-cert"}); err == nil {
+		t.Fatal("sslCertificate Delete while bound: want error, got nil")
+	}
+}
+
+// TestGCPRegionInstanceGroupCRUD exercises the regional instance-group
+// collection over raw HTTP (the compute SDK's RegionInstanceGroups client has no
+// Insert), proving insert/get/list/delete round-trip at region scope.
+func TestGCPRegionInstanceGroupCRUD(t *testing.T) {
+	ts := newGCPLBServer(t)
+
+	base := ts.URL + "/compute/v1/projects/" + testProject + "/regions/us-central1/regionInstanceGroups"
+
+	if code, body := doJSON(t, ts, http.MethodPost, base, `{"name":"reg-ig"}`); code != http.StatusOK {
+		t.Fatalf("insert: status %d, body %s", code, body)
+	}
+
+	code, body := doJSON(t, ts, http.MethodGet, base+"/reg-ig", "")
+	if code != http.StatusOK {
+		t.Fatalf("get: status %d, body %s", code, body)
+	}
+
+	if !strings.Contains(body, `"reg-ig"`) || !strings.Contains(body, `/regions/us-central1/`) {
+		t.Fatalf("get body missing name/region self-link: %s", body)
+	}
+
+	if code, body := doJSON(t, ts, http.MethodGet, base, ""); code != http.StatusOK || !strings.Contains(body, `"reg-ig"`) {
+		t.Fatalf("list: status %d, body %s", code, body)
+	}
+
+	if code, body := doJSON(t, ts, http.MethodDelete, base+"/reg-ig", ""); code != http.StatusOK {
+		t.Fatalf("delete: status %d, body %s", code, body)
+	}
+
+	if code, _ := doJSON(t, ts, http.MethodGet, base+"/reg-ig", ""); code != http.StatusNotFound {
+		t.Fatalf("get after delete: status %d, want 404", code)
+	}
+}
+
+// --- helpers ---
+
+// waitOp runs a mutating call returning an LRO and waits for it to complete.
+func waitOp(ctx context.Context, t *testing.T, label string, call func() (*gcpcompute.Operation, error)) {
+	t.Helper()
+
+	op, err := call()
+	if err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("%s wait: %v", label, err)
+	}
+}
+
+func getBackendServiceLink(ctx context.Context, t *testing.T, c *gcpcompute.BackendServicesClient, name string) string {
+	t.Helper()
+
+	bs, err := c.Get(ctx, &computepb.GetBackendServiceRequest{Project: testProject, BackendService: name})
+	if err != nil {
+		t.Fatalf("backendService Get %s: %v", name, err)
+	}
+
+	return bs.GetSelfLink()
+}
+
+func getURLMapLink(ctx context.Context, t *testing.T, c *gcpcompute.UrlMapsClient, name string) string {
+	t.Helper()
+
+	um, err := c.Get(ctx, &computepb.GetUrlMapRequest{Project: testProject, UrlMap: name})
+	if err != nil {
+		t.Fatalf("urlMap Get %s: %v", name, err)
+	}
+
+	return um.GetSelfLink()
+}
+
+func assertListInstances(ctx context.Context, t *testing.T, c *gcpcompute.InstanceGroupsClient, wantInstance string) {
+	t.Helper()
+
+	it := c.ListInstances(ctx, &computepb.ListInstancesInstanceGroupsRequest{
+		Project: testProject, Zone: testZone, InstanceGroup: "web-ig",
+		InstanceGroupsListInstancesRequestResource: &computepb.InstanceGroupsListInstancesRequest{},
+	})
+
+	var got []string
+
+	for {
+		m, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("listInstances: %v", err)
+		}
+
+		got = append(got, m.GetInstance())
+	}
+
+	if len(got) != 1 || lastSeg(got[0]) != lastSeg(wantInstance) {
+		t.Fatalf("listInstances = %v, want [%s]", got, wantInstance)
+	}
+}
+
+func assertGetHealth(ctx context.Context, t *testing.T, c *gcpcompute.BackendServicesClient, group, wantInstance string) {
+	t.Helper()
+
+	health, err := c.GetHealth(ctx, &computepb.GetHealthBackendServiceRequest{
+		Project:                        testProject,
+		BackendService:                 "web-bs",
+		ResourceGroupReferenceResource: &computepb.ResourceGroupReference{Group: ptrStr(group)},
+	})
+	if err != nil {
+		t.Fatalf("getHealth: %v", err)
+	}
+
+	statuses := health.GetHealthStatus()
+	if len(statuses) != 1 || lastSeg(statuses[0].GetInstance()) != lastSeg(wantInstance) {
+		t.Fatalf("getHealth statuses = %v, want one for %s", statuses, wantInstance)
+	}
+
+	if statuses[0].GetHealthState() != "HEALTHY" {
+		t.Errorf("healthState = %q, want HEALTHY", statuses[0].GetHealthState())
+	}
+}
+
+// doJSON performs a raw JSON request against the test server and returns the
+// status code and response body.
+func doJSON(t *testing.T, ts *httptest.Server, method, url, body string) (int, string) {
+	t.Helper()
+
+	var reader io.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, url, reader)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	b, _ := io.ReadAll(resp.Body)
+
+	return resp.StatusCode, string(b)
+}
+
+// lastSeg returns the trailing path segment of a GCP reference.
+func lastSeg(ref string) string {
+	if idx := strings.LastIndex(ref, "/"); idx >= 0 {
+		return ref[idx+1:]
+	}
+
+	return ref
+}

--- a/server/gcp/loadbalancer/operations.go
+++ b/server/gcp/loadbalancer/operations.go
@@ -129,10 +129,11 @@ func (h *Handler) getBackendService(w http.ResponseWriter, r *http.Request, rp g
 
 // getBackendServiceHealth serves compute.backendServices.getHealth: POST
 // .../backendServices/{bs}/getHealth with a ResourceGroupReference body. The
-// backend service must exist (404 otherwise). The emulator does not model
-// instance-group membership or health probes, so it reports the referenced
-// group as HEALTHY when a group was named and an empty health set otherwise —
-// a valid BackendServiceGroupHealth shape the SDK/Terraform can read back.
+// backend service must exist (404 otherwise). It reports HEALTHY for each
+// instance actually registered in the referenced instance group (via
+// addInstances), so a real user sees the members they added; when the group has
+// no resolvable members it falls back to reporting the group itself as HEALTHY,
+// preserving a valid BackendServiceGroupHealth shape.
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) getBackendServiceHealth(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
@@ -148,13 +149,68 @@ func (h *Handler) getBackendServiceHealth(w http.ResponseWriter, r *http.Request
 
 	resp := backendServiceGroupHealth{Kind: "compute#backendServiceGroupHealth"}
 	if req.Group != "" {
-		resp.HealthStatus = []healthStatus{{
-			HealthState: "HEALTHY",
-			Instance:    req.Group,
-		}}
+		resp.HealthStatus = h.groupHealthStatus(r.Context(), req.Group)
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, resp)
+}
+
+// groupHealthStatus resolves an instance group reference to a HEALTHY entry per
+// registered member; when the group is unknown or empty it reports the group
+// reference itself as HEALTHY so the response is never empty for a named group.
+func (h *Handler) groupHealthStatus(ctx context.Context, group string) []healthStatus {
+	members := h.instanceGroupMembers(ctx, group)
+	if len(members) == 0 {
+		return []healthStatus{{HealthState: "HEALTHY", Instance: group}}
+	}
+
+	out := make([]healthStatus, 0, len(members))
+	for _, m := range members {
+		out = append(out, healthStatus{HealthState: "HEALTHY", Instance: m})
+	}
+
+	return out
+}
+
+// instanceGroupMembers resolves an instance-group reference (a zonal or regional
+// self-link / relative path) to its registered instance URLs, or nil when the
+// group is not an instance group this handler stores.
+func (h *Handler) instanceGroupMembers(ctx context.Context, group string) []string {
+	store, ok := h.gcpStore()
+	if !ok {
+		return nil
+	}
+
+	collection, scope, name := parseGroupRef(group)
+	if collection == "" {
+		return nil
+	}
+
+	res, err := store.GetGCPResource(ctx, collection, scope, name)
+	if err != nil {
+		return nil
+	}
+
+	return sortedMembers(membersOf(res.Body))
+}
+
+// parseGroupRef splits an instance-group reference into (collection, scope,
+// name). A ".../zones/{z}/instanceGroups/{n}" reference maps to the zonal
+// instanceGroups collection scoped by zone; ".../regions/{r}/instanceGroups/{n}"
+// to regionInstanceGroups scoped by region. Any other shape returns "".
+func parseGroupRef(ref string) (collection, scope, name string) {
+	parts := strings.Split(ref, "/")
+
+	for i := 0; i+1 < len(parts); i++ {
+		switch parts[i] {
+		case gcprest.ScopeZones:
+			return resourceInstanceGroups, parts[i+1], lastPathSegment(ref)
+		case gcprest.ScopeRegions:
+			return resourceRegionInstanceGroups, parts[i+1], lastPathSegment(ref)
+		}
+	}
+
+	return "", "", ""
 }
 
 //nolint:gocritic // rp is a request-scoped value

--- a/server/gcp/loadbalancer/resources.go
+++ b/server/gcp/loadbalancer/resources.go
@@ -372,5 +372,7 @@ func listScopeSegment(rp gcprest.ResourcePath) string {
 		return gcprest.ScopeGlobal
 	}
 
-	return gcprest.ScopeRegions + "/" + rp.ScopeName
+	// rp.Scope is already the collection segment ("zones" or "regions"); use it
+	// verbatim so a zonal list envelope's id isn't mislabeled as "regions/...".
+	return rp.Scope + "/" + rp.ScopeName
 }

--- a/server/gcp/loadbalancer/resources.go
+++ b/server/gcp/loadbalancer/resources.go
@@ -28,9 +28,14 @@ const (
 //
 //nolint:gochecknoglobals // immutable lookup table, not mutable state
 var resourceKind = map[string]string{
-	resourceHealthChecks: "compute#healthCheck",
-	resourceTargetPools:  "compute#targetPool",
-	resourceURLMaps:      "compute#urlMap",
+	resourceHealthChecks:         "compute#healthCheck",
+	resourceTargetPools:          "compute#targetPool",
+	resourceURLMaps:              "compute#urlMap",
+	resourceTargetHTTPProxies:    "compute#targetHttpProxy",
+	resourceTargetHTTPSProxies:   "compute#targetHttpsProxy",
+	resourceSslCertificates:      "compute#sslCertificate",
+	resourceInstanceGroups:       "compute#instanceGroup",
+	resourceRegionInstanceGroups: "compute#instanceGroup",
 }
 
 // gcpStore returns the store capability, or false when the backing driver does
@@ -249,18 +254,17 @@ func (h *Handler) deleteGCPResource(w http.ResponseWriter, r *http.Request, rp g
 		return
 	}
 
-	// A health check referenced by a backend service's healthChecks[] cannot be
-	// deleted in real GCP (400 resourceInUseByAnotherResource); deleting it here
-	// would leave the backend service pointing at a health check that no longer
-	// exists. (url-maps are pinned only by target-proxies, which are
-	// unimplemented, so no url-map delete guard is reachable yet.)
-	if rp.ResourceType == resourceHealthChecks {
-		if bs := h.healthCheckInUse(r.Context(), rp); bs != "" {
-			gcprest.WriteError(w, http.StatusBadRequest, reasonResourceInUse,
-				"The health_check resource '"+rp.ResourceName+"' is already being used by '"+bs+"'")
+	// Real GCP refuses to delete a resource still referenced by another (400
+	// resourceInUseByAnotherResource); deleting it here would orphan the
+	// dependent — a backend service pointing at a missing health check, a target
+	// proxy at a missing url-map, an https proxy at a missing certificate, a
+	// backend service at a missing instance group, or a forwarding rule at a
+	// missing proxy.
+	if ref := h.gcpResourceInUse(r.Context(), rp); ref != "" {
+		gcprest.WriteError(w, http.StatusBadRequest, reasonResourceInUse,
+			"The "+singularOf(rp.ResourceType)+" resource '"+rp.ResourceName+"' is already being used by '"+ref+"'")
 
-			return
-		}
+		return
 	}
 
 	if err := store.DeleteGCPResource(r.Context(), rp.ResourceType, scopeKeyOf(rp), rp.ResourceName); err != nil {
@@ -278,7 +282,14 @@ func (h *Handler) deleteGCPResource(w http.ResponseWriter, r *http.Request, rp g
 //nolint:gocritic // rp is a request-scoped value
 func gcpResourceJSON(res *lbdriver.GCPResource, rp gcprest.ResourcePath, host string) map[string]any {
 	out := make(map[string]any, len(res.Body)+internalFieldCount)
+
 	for k, v := range res.Body {
+		// Reserved internal members (e.g. instance-group membership) are stored in
+		// the body but must never leak onto the wire — they are not real GCP fields.
+		if strings.HasPrefix(k, reservedBodyPrefix) {
+			continue
+		}
+
 		out[k] = v
 	}
 
@@ -288,8 +299,17 @@ func gcpResourceJSON(res *lbdriver.GCPResource, rp gcprest.ResourcePath, host st
 	out["creationTimestamp"] = res.CreationTimestamp
 	out["selfLink"] = gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, res.Collection, res.Name)
 
-	if rp.Scope == gcprest.ScopeRegions {
+	switch rp.Scope {
+	case gcprest.ScopeRegions:
 		out["region"] = host + "/compute/v1/projects/" + rp.Project + "/regions/" + rp.ScopeName
+	case gcprest.ScopeZones:
+		out["zone"] = host + "/compute/v1/projects/" + rp.Project + "/zones/" + rp.ScopeName
+	}
+
+	// An instance group reports its member count as size, mirroring real GCP so a
+	// client can see membership changes without listing instances.
+	if res.Collection == resourceInstanceGroups || res.Collection == resourceRegionInstanceGroups {
+		out["size"] = len(membersOf(res.Body))
 	}
 
 	return out
@@ -297,8 +317,8 @@ func gcpResourceJSON(res *lbdriver.GCPResource, rp gcprest.ResourcePath, host st
 
 // internalFieldCount is the number of server-injected members gcpResourceJSON
 // adds on top of the stored body (kind, id, name, creationTimestamp, selfLink,
-// region).
-const internalFieldCount = 6
+// region/zone, size).
+const internalFieldCount = 7
 
 // healthCheckInUse returns the name of a same-scope backend service whose
 // healthChecks[] references the health check being deleted, or "" when none


### PR DESCRIPTION
## Summary

Completes the GCP external L7 HTTP(S) Load Balancer front-end (#826). Before this change `server/gcp/loadbalancer` only routed `backendServices` and `forwardingRules`; the target-proxy, certificate and instance-group resource types were unserved, so the `forwardingRule → targetHttpProxy → urlMap → backendService → instanceGroup` chain was severed (501/405 for a real user).

## What changed

New resource types, served through the existing opaque `GCPComputeResourceStore` (no new driver surface, so `docs/coverage` is unchanged):

- **targetHttpProxies / targetHttpsProxies** — insert/get/list/delete, plus the `setUrlMap` (both) and `setSslCertificates` (https) action verbs.
- **sslCertificates** — insert/get/list/delete (self-managed cert model).
- **instanceGroups** (zonal, unmanaged) and **regionInstanceGroups** — insert/get/list/delete, plus `addInstances` / `removeInstances` / `listInstances`. Membership is stored in the resource and drives the group's reported `size`.

Wiring:

- The chain now resolves end-to-end: a forwarding rule's `target` → proxy, the proxy's `urlMap` → url map, the url map's `defaultService` → backend service, the backend service's `backends[].group` → instance group. Every reference round-trips verbatim so a client can walk the whole chain.
- `backendServices.getHealth` reflects the referenced instance group's registered members (HEALTHY per instance), falling back to the group reference itself when empty.
- Delete is guarded by reference integrity across the chain (url-map pinned by a proxy, certificate pinned by an https proxy, instance group pinned by a backend service, proxy pinned by a forwarding rule) — real GCP's `resourceInUseByAnotherResource`.
- The compute API addresses `setUrlMap` / `setSslCertificates` with a scopeless-global URL that the shared strict parser rejects; a local `parseLBPath` fallback handles just that form for the two global target-proxy types, leaving the shared parser untouched.

Managed instance groups (`instanceGroupManagers`) are intentionally out of scope — a documented follow-up; what `backendServices` reference (unmanaged instance groups) is fully wired.

## Tests

- `TestSDKGCPL7Chain` — provisions the full chain via the real compute SDK, walks it end-to-end, registers an instance and asserts `listInstances` + `getHealth` reflect membership, checks the in-use delete guard, then tears down in order.
- `TestSDKGCPTargetHTTPSProxyWithCertificate` — HTTPS proxy bound to an SSL certificate via `setSslCertificates`, with the certificate delete-guard.
- `TestGCPRegionInstanceGroupCRUD` — regional instance-group CRUD over raw HTTP (the SDK's RegionInstanceGroups client has no Insert).
