### PR TITLE
chore(fidelity): cleanup batch — SFN/CloudTrail docs, SigV4 fail-closed, SSM history decryption, audit clock, ASL/API-GW/Lambda validation

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -2627,25 +2627,50 @@ returned unchanged by `DescribeStateMachine`.
 | Definition tooling | TestState, ValidateStateMachineDefinition |
 | Tags | TagResource, UntagResource, ListTagsForResource |
 
-**No ASL interpreter — a deliberate simplification.** The emulator does not
-execute the Amazon States Language. `StartExecution` (and `StartSyncExecution`)
-complete the execution immediately: it transitions `RUNNING → SUCCEEDED` with
-output echoing the input, and `GetExecutionHistory` synthesises a minimal but
-valid event list (`ExecutionStarted → PassStateEntered → PassStateExited →
-ExecutionSucceeded`). Because nothing schedules real work, `GetActivityTask`
-returns an empty task token (the same long-poll-empty result real clients see),
-and `SendTaskSuccess/Failure/Heartbeat` reject any token as `InvalidToken`. This
-keeps behaviour deterministic and dependency-free while preserving the SDK wire
-shapes for build-and-orchestrate testing.
+**A real ASL interpreter runs executions.** `StartExecution` and
+`StartSyncExecution` actually interpret the Amazon States Language definition
+against the input rather than echoing it. The interpreter executes **Pass,
+Choice, Wait, Task, Parallel, Map, Succeed, and Fail** states, following
+`Next`/`End` transitions to a terminal state and producing the real
+`GetExecutionHistory` event sequence for the path taken (state Entered/Exited,
+Task Scheduled/Started/Succeeded/Failed, Parallel/Map iteration events, and the
+terminal `ExecutionSucceeded`/`ExecutionFailed`). Supported semantics:
 
-Consistent with the no-interpreter model: `RedriveExecution` records a fresh
-redrive date on an existing execution rather than re-running it; `TestState`
-succeeds for any non-empty definition and echoes the input as output;
-`ValidateStateMachineDefinition` returns `OK` for a non-empty, valid-JSON
-definition and `FAIL` with a diagnostic otherwise (no semantic ASL validation).
-Distributed-map Map Runs are never produced by execution, so `ListMapRuns`
-returns empty for ordinary executions; `DescribeMapRun`/`UpdateMapRun` operate on
-Map Run records seeded through the provider's `SeedMapRun` helper.
+- **I/O processing** — `InputPath`, `Parameters`, `ResultSelector`,
+  `ResultPath`, and `OutputPath` with JSONPath evaluation, including the `.$`
+  reference form and merge-onto-input `ResultPath` semantics.
+- **Choice rules** — string/numeric/boolean/timestamp comparators and the
+  `And`/`Or`/`Not` combinators (including the `...Path` variants), with `Default`.
+- **Error handling** — `Retry` (with `IntervalSeconds`/`MaxAttempts`/`BackoffRate`
+  and `ErrorEquals` matching) and `Catch` (routing to a fallback state with the
+  error carried on `ResultPath`).
+- **Intrinsic functions** — `States.Format`, `States.Array`,
+  `States.ArrayGetItem`, `States.StringToJson`, `States.JsonToString`, and
+  `States.UUID`.
+- **The context object** — `$$` resolves the execution/state context
+  (`Execution.Name`, `StateMachine`, `State.EnteredTime`, …).
+- **Task → Lambda** — a `Task` whose `Resource` is `arn:aws:states:::lambda:invoke`
+  (payload from `Parameters.Payload`) or a direct Lambda function ARN really
+  invokes the wired Lambda backend; a `FunctionError` feeds `Retry`/`Catch`.
+
+Definitions are **validated at create time**: `CreateStateMachine` (and
+`ValidateStateMachineDefinition`) parse the ASL and reject structural errors —
+unknown `Type`, missing `Next`/`End`, a `Next`/`Default` that names no state,
+result-shaping fields on states that don't support them, malformed Choice rules,
+and out-of-range `Retry` fields. `TestState` runs a single state through the
+interpreter and returns its real output (or error). Bounded guards protect the
+host: executions cap total state transitions (`CloudEmu.StateTransitionLimitExceeded`)
+and Parallel/Map nesting depth (`CloudEmu.ExecutionNestingLimitExceeded`).
+
+**Deferred (not yet interpreted):** the **JSONata** query language is rejected at
+create time (JSONPath only); the **`.sync`** and **`.waitForTaskToken`**
+service-integration patterns; and **service integrations other than Lambda** —
+including **Activity** tasks, so `GetActivityTask` still returns an empty token
+and `SendTaskSuccess/Failure/Heartbeat` reject any token as `InvalidToken`.
+`RedriveExecution` records a fresh redrive date rather than re-running.
+Distributed-map Map Runs are not produced by ordinary executions, so
+`ListMapRuns` returns empty and `DescribeMapRun`/`UpdateMapRun` operate on Map Run
+records seeded through the provider's `SeedMapRun` helper.
 
 **Total: 36 operations.**
 
@@ -2887,9 +2912,10 @@ AWS-only. Real `aws-sdk-go-v2/service/cloudtrail` clients (and the
 (`awsserver.Drivers{CloudTrail: cloud.CloudTrail}`). Broad operation coverage
 across trails, event data stores, channels, dashboards, imports, event/insight
 selectors, ad-hoc CloudTrail Lake queries, resource policies, and tags. The
-control-plane CRUD/state paths are faithfully emulated; the analytics and
-event-stream surfaces are synthesized/limited (see below), since there is no real
-audit event stream behind the emulator.
+control-plane CRUD/state paths are faithfully emulated, and **management events
+are recorded from served API activity** so `LookupEvents` reflects real calls
+(see below); only the Lake analytics / Insights surfaces remain
+synthesized/limited.
 
 | Family | Operations |
 |--------|-----------|
@@ -2903,7 +2929,8 @@ audit event stream behind the emulator.
 | Resource policy / config | PutResourcePolicy, GetResourcePolicy, DeleteResourcePolicy, PutEventConfiguration, GetEventConfiguration |
 | Organization | RegisterOrganizationDelegatedAdmin, DeregisterOrganizationDelegatedAdmin |
 | Tags | AddTags, RemoveTags, ListTags |
-| Read-only (synthesized) | LookupEvents, ListPublicKeys, ListInsightsData, ListInsightsMetricData, SearchSampleQueries |
+| Read-only (recorded) | LookupEvents |
+| Read-only (synthesized) | ListPublicKeys, ListInsightsData, ListInsightsMetricData, SearchSampleQueries |
 
 `CreateTrail` validates the trail name (3–128 chars, allowed charset, no
 adjacent separators, not an IP) → `InvalidTrailNameException`, claims the name
@@ -2915,14 +2942,19 @@ created `ENABLED` with an ARN; a malformed EDS ARN is
 `EventDataStoreNotFoundException`; `DeleteEventDataStore` is a soft delete
 (→ `PENDING_DELETION`) unless termination protection is on.
 
-**No real event stream — a deliberate simplification.** The emulator records no
-audit events, so the read-only analytics surfaces return synthesized/empty
-results: `LookupEvents`, `ListInsightsData`, `ListInsightsMetricData` and
-`ListPublicKeys` return empty pages; ad-hoc `StartQuery` is accepted, stored and
-immediately marked `FINISHED` with an empty result set; `SearchSampleQueries`
-returns a small fixed catalog of CloudTrail Lake sample queries. Emulated
-imports complete instantly with no failures. This preserves the SDK wire shapes
-for build-and-orchestrate testing without a dependency on real event data.
+**Management events are recorded; Lake analytics are synthesized.** A
+post-dispatch observer derives a CloudTrail management event from each served
+request (the operation name from `X-Amz-Target`/`Action`, the source service and
+access-key id from the SigV4 credential scope, and a read-only classification by
+verb prefix), so `LookupEvents` returns the real API activity — newest first,
+paginated, and filtered by the request's attribute/time selectors — rather than
+an empty page. CloudTrail's own read-only polling is not recorded, so a client
+tailing `LookupEvents` never crowds out the activity it is observing, and the log
+is bounded. The remaining analytics surfaces stay synthesized: `ListInsightsData`,
+`ListInsightsMetricData` and `ListPublicKeys` return empty pages; ad-hoc
+`StartQuery` is accepted, stored and immediately marked `FINISHED` with an empty
+result set; `SearchSampleQueries` returns a small fixed catalog of CloudTrail
+Lake sample queries; and emulated imports complete instantly with no failures.
 
 **Total: 60 operations.**
 

--- a/providers/aws/apigateway/apigateway_test.go
+++ b/providers/aws/apigateway/apigateway_test.go
@@ -340,3 +340,30 @@ func TestInvokeRouteMalformedLambdaResponse(t *testing.T) {
 		t.Fatalf("malformed lambda response should be 502, got %d", resp.StatusCode)
 	}
 }
+
+// TestCreateResourceRejectsSecondVariableSibling proves a parent may have at
+// most one variable (path-parameter) child: creating {name} after {id} under the
+// same parent is a ConflictException (AlreadyExists), since two variable siblings
+// would make route matching depend on map iteration order.
+func TestCreateResourceRejectsSecondVariableSibling(t *testing.T) {
+	m := newMock(t)
+
+	api, err := m.CreateRestAPI(ctx(), &driver.CreateRestAPIInput{Name: "petstore"})
+	if err != nil {
+		t.Fatalf("CreateRestAPI: %v", err)
+	}
+
+	if _, err = m.CreateResource(ctx(), api.ID, api.RootResourceID, "{id}"); err != nil {
+		t.Fatalf("CreateResource({id}): %v", err)
+	}
+
+	// A second variable sibling with a different name is rejected.
+	if _, err = m.CreateResource(ctx(), api.ID, api.RootResourceID, "{name}"); !errors.IsAlreadyExists(err) {
+		t.Fatalf("CreateResource({name}) error = %v, want AlreadyExists (ConflictException)", err)
+	}
+
+	// A literal sibling alongside the variable child is still allowed.
+	if _, err = m.CreateResource(ctx(), api.ID, api.RootResourceID, "pets"); err != nil {
+		t.Fatalf("CreateResource(pets) alongside {id}: %v", err)
+	}
+}

--- a/providers/aws/apigateway/resources.go
+++ b/providers/aws/apigateway/resources.go
@@ -34,6 +34,17 @@ func (m *Mock) CreateResource(_ context.Context, restAPIID, parentID, pathPart s
 			"Another resource with the same parent already has this name: %s", pathPart)
 	}
 
+	// A parent may have at most one variable (path-parameter) child. Real API
+	// Gateway rejects a second variable sibling with a different name as a
+	// ConflictException; allowing both ({id} then {name}) would make matchRoute
+	// nondeterministic (it depends on Go map iteration order).
+	if isPathParam(pathPart) {
+		if sib := findVariableSibling(ad.resources, parentID); sib != nil && sib.PathPart != pathPart {
+			return nil, cerrors.Newf(cerrors.AlreadyExists,
+				"A sibling (%s) of this resource already has a variable path part -- only one is allowed", sib.PathPart)
+		}
+	}
+
 	res := &driver.Resource{
 		ID: genID(), RestAPIID: restAPIID, ParentID: parentID,
 		PathPart: pathPart, Path: fullPath, Methods: map[string]*driver.Method{},
@@ -97,6 +108,24 @@ func joinPath(parentPath, pathPart string) string {
 func findByPath(resources map[string]*driver.Resource, path string) *driver.Resource {
 	for _, r := range resources {
 		if r.Path == path {
+			return r
+		}
+	}
+
+	return nil
+}
+
+// isPathParam reports whether a pathPart is a variable segment — a "{param}"
+// placeholder or a "{proxy+}" greedy segment — rather than a literal.
+func isPathParam(pathPart string) bool {
+	return strings.HasPrefix(pathPart, "{") && strings.HasSuffix(pathPart, "}")
+}
+
+// findVariableSibling returns an existing child of parentID whose pathPart is a
+// variable segment, or nil. A parent may have at most one such child.
+func findVariableSibling(resources map[string]*driver.Resource, parentID string) *driver.Resource {
+	for _, r := range resources {
+		if r.ParentID == parentID && isPathParam(r.PathPart) {
 			return r
 		}
 	}

--- a/providers/aws/lambda/aliases.go
+++ b/providers/aws/lambda/aliases.go
@@ -173,9 +173,11 @@ func copyRoutingConfig(rc *driver.AliasRoutingConfig) *driver.AliasRoutingConfig
 
 // validateRoutingConfig enforces the RoutingConfig.AdditionalVersionWeights
 // rules real Lambda applies: neither the alias's own version nor any additional
-// version can be $LATEST (InvalidParameterValueException), and every additional
-// version must exist (ResourceNotFoundException). effectiveVersion is the alias's
-// own FunctionVersion after the operation. An empty weights map is a no-op.
+// version can be $LATEST (InvalidParameterValueException), every additional
+// version must exist (ResourceNotFoundException), each weight must be within
+// [0.0, 1.0], and the additional weights must sum to at most 1.0
+// (InvalidParameterValueException). effectiveVersion is the alias's own
+// FunctionVersion after the operation. An empty weights map is a no-op.
 func (m *Mock) validateRoutingConfig(fd *funcData, effectiveVersion string, rc *driver.AliasRoutingConfig) error {
 	if rc == nil || len(rc.AdditionalVersionWeights) == 0 {
 		return nil
@@ -189,7 +191,9 @@ func (m *Mock) validateRoutingConfig(fd *funcData, effectiveVersion string, rc *
 			"Alias with weights can not be created with function version $LATEST")
 	}
 
-	for version := range rc.AdditionalVersionWeights {
+	var weightSum float64
+
+	for version, weight := range rc.AdditionalVersionWeights {
 		if version == latestVersion {
 			return cerrors.New(cerrors.InvalidArgument,
 				"Alias with weights can not be created with function version $LATEST")
@@ -198,6 +202,20 @@ func (m *Mock) validateRoutingConfig(fd *funcData, effectiveVersion string, rc *
 		if !m.versionExists(fd, version) {
 			return cerrors.Newf(cerrors.NotFound, "version %s not found", version)
 		}
+
+		if weight < driver.MinVersionWeight || weight > driver.MaxVersionWeight {
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"Weight for version %s must be between 0.0 and 1.0", version)
+		}
+
+		weightSum += weight
+	}
+
+	// The additional weights share traffic with the primary version, so their
+	// sum cannot exceed 1.0 (the primary keeps the remainder).
+	if weightSum > driver.MaxVersionWeight {
+		return cerrors.New(cerrors.InvalidArgument,
+			"Sum of the additional version weights must not exceed 1.0")
 	}
 
 	return nil

--- a/providers/aws/lambda/lambda_test.go
+++ b/providers/aws/lambda/lambda_test.go
@@ -518,6 +518,59 @@ func TestAliasWeightedRoutingRejectsLatest(t *testing.T) {
 	assertError(t, err, true)
 }
 
+// TestAliasWeightedRoutingRejectsOutOfBoundsWeights proves each additional
+// version weight must lie in [0.0, 1.0] and the additional weights must sum to
+// at most 1.0 — real Lambda rejects violations as InvalidParameterValueException.
+func TestAliasWeightedRoutingRejectsOutOfBoundsWeights(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
+	_, _ = m.PublishVersion(ctx, "my-func", "v1")
+	_, _ = m.PublishVersion(ctx, "my-func", "v2")
+
+	// A weight above 1.0 is rejected.
+	_, err := m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "my-func", Name: "over", FunctionVersion: "1",
+		RoutingConfig: &driver.AliasRoutingConfig{
+			AdditionalVersionWeights: map[string]float64{"2": 1.5},
+		},
+	})
+	assertError(t, err, true)
+
+	// A negative weight is rejected.
+	_, err = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "my-func", Name: "neg", FunctionVersion: "1",
+		RoutingConfig: &driver.AliasRoutingConfig{
+			AdditionalVersionWeights: map[string]float64{"2": -0.1},
+		},
+	})
+	assertError(t, err, true)
+
+	// Additional weights that sum above 1.0 are rejected on UpdateAlias too.
+	_, err = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "my-func", Name: "canary", FunctionVersion: "1",
+	})
+	requireNoError(t, err)
+
+	_, err = m.UpdateAlias(ctx, driver.AliasConfig{
+		FunctionName: "my-func", Name: "canary",
+		RoutingConfig: &driver.AliasRoutingConfig{
+			AdditionalVersionWeights: map[string]float64{"2": 0.7, "1": 0.6},
+		},
+	})
+	assertError(t, err, true)
+
+	// A valid in-bounds weight is still accepted.
+	alias, err := m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "my-func", Name: "ok", FunctionVersion: "1",
+		RoutingConfig: &driver.AliasRoutingConfig{
+			AdditionalVersionWeights: map[string]float64{"2": 0.25},
+		},
+	})
+	requireNoError(t, err)
+	assertEqual(t, 0.25, alias.RoutingConfig.AdditionalVersionWeights["2"])
+}
+
 func TestAliasWeightedRoutingSplitsInvocations(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/providers/aws/sfn/asl/asl_test.go
+++ b/providers/aws/sfn/asl/asl_test.go
@@ -213,3 +213,45 @@ func TestRunHonorsContextCancellation(t *testing.T) {
 		t.Fatalf("cancelled run: status=%q error=%q, want FAILED/CloudEmu.ExecutionCanceled", res.Status, res.Error)
 	}
 }
+
+// TestRetrierIntervalSecondsMustBePositive proves the create-time validator
+// rejects a zero IntervalSeconds (the ASL spec requires a positive interval;
+// only MaxAttempts may be zero).
+func TestRetrierIntervalSecondsMustBePositive(t *testing.T) {
+	zero := `{"StartAt":"T","States":{"T":{"Type":"Task","Resource":"arn:aws:states:::lambda:invoke",` +
+		`"Retry":[{"ErrorEquals":["States.ALL"],"IntervalSeconds":0}],"End":true}}}`
+	if _, err := Parse(zero); err == nil {
+		t.Fatal("Parse should reject Retry.IntervalSeconds = 0 (must be > 0)")
+	}
+
+	// A positive interval (and a zero MaxAttempts) is accepted.
+	ok := `{"StartAt":"T","States":{"T":{"Type":"Task","Resource":"arn:aws:states:::lambda:invoke",` +
+		`"Retry":[{"ErrorEquals":["States.ALL"],"IntervalSeconds":1,"MaxAttempts":0}],"End":true}}}`
+	if _, err := Parse(ok); err != nil {
+		t.Fatalf("Parse(valid retrier) = %v", err)
+	}
+}
+
+// TestExecutionNestingLimitExceeded trips the Parallel/Map nesting guard: a
+// definition nesting Parallel-in-Parallel past the depth limit fails the
+// execution with CloudEmu.ExecutionNestingLimitExceeded rather than exhausting
+// the Go stack.
+func TestExecutionNestingLimitExceeded(t *testing.T) {
+	// Wrap a Pass in more nested Parallel states than the interpreter's nesting
+	// limit (defaultMaxNesting = 32), so entering the innermost trips the guard.
+	def := `{"StartAt":"P","States":{"P":{"Type":"Pass","End":true}}}`
+	for i := 0; i < 40; i++ {
+		def = `{"StartAt":"P","States":{"P":{"Type":"Parallel","End":true,"Branches":[` + def + `]}}}`
+	}
+
+	parsed, err := Parse(def)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	res := Run(context.Background(), parsed, &RunInput{Input: `{}`, StartTime: time.Unix(0, 0)})
+	if res.Status != "FAILED" || res.Error != "CloudEmu.ExecutionNestingLimitExceeded" {
+		t.Fatalf("deeply nested run: status=%q error=%q, want FAILED/CloudEmu.ExecutionNestingLimitExceeded",
+			res.Status, res.Error)
+	}
+}

--- a/providers/aws/sfn/asl/validate.go
+++ b/providers/aws/sfn/asl/validate.go
@@ -64,12 +64,14 @@ func validateSubMachines(st *State) error {
 }
 
 // validateRetriers rejects out-of-range Retrier fields at create time:
-// IntervalSeconds and MaxAttempts must be >= 0, and BackoffRate must be >= 1.0.
+// IntervalSeconds must be > 0 (positive) and MaxAttempts must be >= 0
+// (non-negative), and BackoffRate must be >= 1.0 — matching the ASL spec, which
+// allows a zero MaxAttempts (retry disabled) but requires a positive interval.
 func validateRetriers(st *State) error {
 	for i, r := range st.Retry {
 		switch {
-		case r.IntervalSeconds != nil && *r.IntervalSeconds < 0:
-			return aslErrf("state %q Retry[%d] 'IntervalSeconds' must be >= 0", st.name, i)
+		case r.IntervalSeconds != nil && *r.IntervalSeconds <= 0:
+			return aslErrf("state %q Retry[%d] 'IntervalSeconds' must be > 0", st.name, i)
 		case r.MaxAttempts != nil && *r.MaxAttempts < 0:
 			return aslErrf("state %q Retry[%d] 'MaxAttempts' must be >= 0", st.name, i)
 		case r.BackoffRate != nil && *r.BackoffRate < minBackoffRate:

--- a/providers/aws/ssm/encryption_test.go
+++ b/providers/aws/ssm/encryption_test.go
@@ -60,6 +60,47 @@ func TestSecureStringEncryptedAtRest(t *testing.T) {
 	}
 }
 
+// TestGetParameterHistoryDecryption verifies GetParameterHistory honors
+// WithDecryption like GetParameter: true returns the decrypted plaintext for
+// each version, false returns the opaque ciphertext blob.
+func TestGetParameterHistoryDecryption(t *testing.T) {
+	m, _ := newEncryptedMock(t)
+	ctx := context.Background()
+
+	const (
+		v1 = "secret-one"
+		v2 = "secret-two"
+	)
+
+	for _, val := range []string{v1, v2} {
+		if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+			Name: "/db/password", Value: val, Type: driver.TypeSecureString, Overwrite: true,
+		}); err != nil {
+			t.Fatalf("PutParameter(%q): %v", val, err)
+		}
+	}
+
+	dec, err := m.GetParameterHistory(ctx, "/db/password", true)
+	if err != nil {
+		t.Fatalf("GetParameterHistory(WithDecryption=true): %v", err)
+	}
+
+	if len(dec) != 2 || dec[0].Value != v1 || dec[1].Value != v2 {
+		t.Fatalf("decrypted history = %+v, want [%q %q]", dec, v1, v2)
+	}
+
+	opaque, err := m.GetParameterHistory(ctx, "/db/password", false)
+	if err != nil {
+		t.Fatalf("GetParameterHistory(WithDecryption=false): %v", err)
+	}
+
+	for i, p := range opaque {
+		if p.Value == v1 || p.Value == v2 || p.Value == "" {
+			t.Fatalf("history[%d] value %q is plaintext/empty; want opaque ciphertext", i, p.Value)
+		}
+	}
+}
+
 // TestStringParameterNotEncrypted verifies String parameters are untouched by
 // KMS: their value is returned in the clear regardless of WithDecryption.
 func TestStringParameterNotEncrypted(t *testing.T) {

--- a/providers/aws/ssm/ssm.go
+++ b/providers/aws/ssm/ssm.go
@@ -659,7 +659,9 @@ func (m *Mock) DescribeParameters(_ context.Context) ([]driver.ParameterMetadata
 }
 
 // GetParameterHistory returns every version of a parameter, oldest first.
-func (m *Mock) GetParameterHistory(_ context.Context, name string) ([]driver.Parameter, error) {
+// withDecryption controls SecureString decryption, mirroring GetParameter: when
+// false each version's value is the opaque ciphertext blob.
+func (m *Mock) GetParameterHistory(ctx context.Context, name string, withDecryption bool) ([]driver.Parameter, error) {
 	pd, ok := m.params.Get(name)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "parameter %q not found", name)
@@ -672,11 +674,16 @@ func (m *Mock) GetParameterHistory(_ context.Context, name string) ([]driver.Par
 
 	out := make([]driver.Parameter, 0, len(pd.versions))
 	for _, v := range pd.versions {
+		value, err := m.revealValue(ctx, v, withDecryption)
+		if err != nil {
+			return nil, err
+		}
+
 		labels := append([]string(nil), v.labels...)
 		out = append(out, driver.Parameter{
 			Name:             pd.name,
 			Type:             v.typ,
-			Value:            v.value,
+			Value:            value,
 			Version:          v.version,
 			ARN:              m.arn(pd.name),
 			DataType:         v.dataType,

--- a/providers/aws/ssm/ssm_test.go
+++ b/providers/aws/ssm/ssm_test.go
@@ -43,7 +43,7 @@ func TestPutOverwriteAndHistory(t *testing.T) {
 		t.Fatalf("overwrite version = %d, want 2", v2)
 	}
 
-	hist, err := m.GetParameterHistory(ctx, "/a")
+	hist, err := m.GetParameterHistory(ctx, "/a", false)
 	if err != nil {
 		t.Fatalf("GetParameterHistory: %v", err)
 	}

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -91,6 +91,10 @@ type Provider struct {
 	// the options.
 	ProjectID string
 	Region    string
+	// Clock is the time source this provider was created with, exposed so a
+	// standalone server can drive time-stamped observers (e.g. the Cloud Audit
+	// Log recorder) off the same clock — deterministic under a FakeClock.
+	Clock config.Clock
 
 	// engineClosers holds any wired real engines that implement io.Closer, so
 	// Close can cascade teardown to them. Empty for the in-memory default.
@@ -125,6 +129,7 @@ func New(opts ...config.Option) *Provider {
 		VertexAI:         vertexai.New(o),
 		ProjectID:        o.ProjectID,
 		Region:           o.Region,
+		Clock:            o.Clock,
 	}
 	p.GCE.SetMonitoring(p.CloudMonitoring)
 	p.GCS.SetMonitoring(p.CloudMonitoring)

--- a/server/aws/authgate_temp_test.go
+++ b/server/aws/authgate_temp_test.go
@@ -49,7 +49,10 @@ func TestVerifyTempCredential(t *testing.T) {
 	clock := config.NewFakeClock(now)
 	store := stssrv.NewSessionStore(clock)
 
-	issued := store.Mint(time.Hour) // Expiration = now + 1h
+	issued, err := store.Mint(time.Hour) // Expiration = now + 1h
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
 
 	newReq := func() *http.Request {
 		r, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
@@ -107,7 +110,10 @@ func TestVerifyTempCredential(t *testing.T) {
 	t.Run("expired-session", func(t *testing.T) {
 		shortClock := config.NewFakeClock(now)
 		shortStore := stssrv.NewSessionStore(shortClock)
-		short := shortStore.Mint(15 * time.Minute) // Expiration = now + 15m
+		short, err := shortStore.Mint(15 * time.Minute) // Expiration = now + 15m
+		if err != nil {
+			t.Fatalf("Mint: %v", err)
+		}
 
 		r := newReq()
 		signTemp(t, r, short.AccessKeyID, short.SecretAccessKey, short.SessionToken, now)

--- a/server/aws/dispatch_ordering_test.go
+++ b/server/aws/dispatch_ordering_test.go
@@ -133,6 +133,7 @@ func TestRESTHandlersWinBeforeS3(t *testing.T) {
 		{"route53_before_s3", "/2013-04-01/hostedzone", "ListHostedZonesResponse"},
 		{"efs_before_s3", "/2015-02-01/file-systems", "FileSystems"},
 		{"eks_before_s3", "/clusters", "clusters"},
+		{"apigateway_before_s3", "/restapis", "item"},
 	}
 
 	for _, tc := range cases {

--- a/server/aws/ssm/operations.go
+++ b/server/aws/ssm/operations.go
@@ -232,7 +232,7 @@ func (h *Handler) getParameterHistory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	history, err := h.store.GetParameterHistory(r.Context(), req.Name)
+	history, err := h.store.GetParameterHistory(r.Context(), req.Name, req.WithDecryption)
 	if err != nil {
 		writeErr(w, err)
 		return

--- a/server/aws/sts/operations.go
+++ b/server/aws/sts/operations.go
@@ -63,10 +63,15 @@ func (h *Handler) assumeRole(w http.ResponseWriter, r *http.Request) {
 
 	assumedArn := "arn:aws:sts::" + h.accountID + ":assumed-role/" + roleName + "/" + sessionName
 
+	creds, ok := h.mintCredentials(w, durationFromForm(r))
+	if !ok {
+		return
+	}
+
 	awsquery.WriteXMLResponse(w, assumeRoleResponse{
 		Xmlns: Namespace,
 		Result: assumeRoleResult{
-			Credentials: h.synthCredentials(durationFromForm(r)),
+			Credentials: creds,
 			AssumedRoleUser: assumedRoleUser{
 				AssumedRoleID: "AROACLOUDEMU0000000000:" + sessionName,
 				Arn:           assumedArn,
@@ -109,10 +114,15 @@ func (h *Handler) assumeRoleWithWebIdentity(w http.ResponseWriter, r *http.Reque
 		provider = "cloudemu.local"
 	}
 
+	creds, ok := h.mintCredentials(w, durationFromForm(r))
+	if !ok {
+		return
+	}
+
 	awsquery.WriteXMLResponse(w, assumeRoleWithWebIdentityResponse{
 		Xmlns: Namespace,
 		Result: assumeRoleWithWebIdentityResult{
-			Credentials: h.synthCredentials(durationFromForm(r)),
+			Credentials: creds,
 			AssumedRoleUser: assumedRoleUser{
 				AssumedRoleID: "AROACLOUDEMU0000000000:" + sessionName,
 				Arn:           assumedArn,
@@ -132,10 +142,15 @@ func (h *Handler) assumeRoleWithSAML(w http.ResponseWriter, r *http.Request) {
 	sessionName := "cloudemu-saml-session"
 	assumedArn := "arn:aws:sts::" + h.accountID + ":assumed-role/" + roleName + "/" + sessionName
 
+	creds, ok := h.mintCredentials(w, durationFromForm(r))
+	if !ok {
+		return
+	}
+
 	awsquery.WriteXMLResponse(w, assumeRoleWithSAMLResponse{
 		Xmlns: Namespace,
 		Result: assumeRoleWithSAMLResult{
-			Credentials: h.synthCredentials(durationFromForm(r)),
+			Credentials: creds,
 			AssumedRoleUser: assumedRoleUser{
 				AssumedRoleID: "AROACLOUDEMU0000000000:" + sessionName,
 				Arn:           assumedArn,
@@ -158,10 +173,15 @@ func (h *Handler) getFederationToken(w http.ResponseWriter, r *http.Request) {
 		name = "cloudemu-federated"
 	}
 
+	creds, ok := h.mintCredentials(w, durationFromForm(r))
+	if !ok {
+		return
+	}
+
 	awsquery.WriteXMLResponse(w, getFederationTokenResponse{
 		Xmlns: Namespace,
 		Result: getFederationTokenResult{
-			Credentials: h.synthCredentials(durationFromForm(r)),
+			Credentials: creds,
 			FederatedUser: federatedUser{
 				FederatedUserID: h.accountID + ":" + name,
 				Arn:             "arn:aws:sts::" + h.accountID + ":federated-user/" + name,
@@ -208,9 +228,14 @@ func durationFromForm(r *http.Request) time.Duration {
 
 // getSessionToken returns synthetic temporary credentials.
 func (h *Handler) getSessionToken(w http.ResponseWriter, r *http.Request) {
+	creds, ok := h.mintCredentials(w, durationFromForm(r))
+	if !ok {
+		return
+	}
+
 	awsquery.WriteXMLResponse(w, getSessionTokenResponse{
 		Xmlns:    Namespace,
-		Result:   getSessionTokenResult{Credentials: h.synthCredentials(durationFromForm(r))},
+		Result:   getSessionTokenResult{Credentials: creds},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -220,20 +245,23 @@ func (h *Handler) getSessionToken(w http.ResponseWriter, r *http.Request) {
 // verifiable credentials and records their secret so the auth gate can verify a
 // signature made with them; otherwise it returns the fixed synthetic values it
 // always has (default, auth-off behavior is byte-for-byte unchanged).
-func (h *Handler) synthCredentials(dur time.Duration) credentials {
+func (h *Handler) synthCredentials(dur time.Duration) (credentials, error) {
 	if dur <= 0 {
 		dur = sessionDuration
 	}
 
 	if h.sessions != nil {
-		sess := h.sessions.Mint(dur)
+		sess, err := h.sessions.Mint(dur)
+		if err != nil {
+			return credentials{}, err
+		}
 
 		return credentials{
 			AccessKeyID:     sess.AccessKeyID,
 			SecretAccessKey: sess.SecretAccessKey,
 			SessionToken:    sess.SessionToken,
 			Expiration:      sess.Expiration.Format(time.RFC3339),
-		}
+		}, nil
 	}
 
 	return credentials{
@@ -241,7 +269,22 @@ func (h *Handler) synthCredentials(dur time.Duration) credentials {
 		SecretAccessKey: "cloudemuSecretAccessKey0000000000000000",
 		SessionToken:    "cloudemu-session-token",
 		Expiration:      time.Now().UTC().Add(dur).Format(time.RFC3339),
+	}, nil
+}
+
+// mintCredentials builds temporary credentials for a handler, writing a
+// InternalFailure error response and reporting ok=false when credential
+// generation fails closed (a crypto/rand read error).
+func (h *Handler) mintCredentials(w http.ResponseWriter, dur time.Duration) (credentials, bool) {
+	creds, err := h.synthCredentials(dur)
+	if err != nil {
+		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure",
+			"could not generate temporary credentials")
+
+		return credentials{}, false
 	}
+
+	return creds, true
 }
 
 // roleNameFromArn extracts the role name (last path segment) from a role ARN

--- a/server/aws/sts/sessions.go
+++ b/server/aws/sts/sessions.go
@@ -54,16 +54,32 @@ const sessionTokenRandomLen = 32
 // Mint generates a unique temporary credential set valid for dur, records it,
 // and returns it. Each call yields a distinct access key id and a fresh
 // high-entropy secret, so a caller that does not hold the issued secret cannot
-// forge a valid signature.
-func (s *SessionStore) Mint(dur time.Duration) Session {
+// forge a valid signature. It fails closed on a crypto/rand read error rather
+// than issuing a predictable, forgeable credential.
+func (s *SessionStore) Mint(dur time.Duration) (Session, error) {
 	if dur <= 0 {
 		dur = sessionDuration
 	}
 
+	akid, err := randUpperAlnum(tempKeyRandomLen)
+	if err != nil {
+		return Session{}, err
+	}
+
+	secret, err := randUpperAlnum(secretLen)
+	if err != nil {
+		return Session{}, err
+	}
+
+	token, err := randUpperAlnum(sessionTokenRandomLen)
+	if err != nil {
+		return Session{}, err
+	}
+
 	sess := Session{
-		AccessKeyID:     tempCredentialPrefix + randUpperAlnum(tempKeyRandomLen),
-		SecretAccessKey: randUpperAlnum(secretLen),
-		SessionToken:    "cloudemu-session-" + randUpperAlnum(sessionTokenRandomLen),
+		AccessKeyID:     tempCredentialPrefix + akid,
+		SecretAccessKey: secret,
+		SessionToken:    "cloudemu-session-" + token,
 		Expiration:      s.clock.Now().UTC().Add(dur),
 	}
 
@@ -71,7 +87,7 @@ func (s *SessionStore) Mint(dur time.Duration) Session {
 	s.sessions[sess.AccessKeyID] = sess
 	s.mu.Unlock()
 
-	return sess
+	return sess, nil
 }
 
 // Lookup returns the recorded session for id, if any. Expiry is not filtered
@@ -95,22 +111,18 @@ const tempCredentialPrefix = "ASIA"
 const alnumUpper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 // randUpperAlnum returns n cryptographically-random uppercase-alphanumeric
-// characters. It draws from crypto/rand; on the practically-impossible read
-// error it falls back to the first alphabet character so the result is still
-// well-formed (an unverifiable-but-present credential, never a panic).
-func randUpperAlnum(n int) string {
+// characters drawn from crypto/rand. On the practically-impossible read error it
+// returns the error rather than a predictable fallback, so a caller never issues
+// a forgeable credential built from low-entropy bytes.
+func randUpperAlnum(n int) (string, error) {
 	buf := make([]byte, n)
 	if _, err := rand.Read(buf); err != nil {
-		for i := range buf {
-			buf[i] = alnumUpper[0]
-		}
-
-		return string(buf)
+		return "", err
 	}
 
 	for i := range buf {
 		buf[i] = alnumUpper[int(buf[i])%len(alnumUpper)]
 	}
 
-	return string(buf)
+	return string(buf), nil
 }

--- a/server/aws/sts/sessions_test.go
+++ b/server/aws/sts/sessions_test.go
@@ -1,0 +1,51 @@
+package sts_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/server/aws/sts"
+)
+
+// TestMintYieldsDistinctHighEntropyCredentials proves Mint returns unique,
+// well-formed temporary credentials on the crypto/rand success path — the guard
+// against the removed predictable fallback, which would have produced identical,
+// forgeable credentials on every call.
+func TestMintYieldsDistinctHighEntropyCredentials(t *testing.T) {
+	store := sts.NewSessionStore(config.NewFakeClock(time.Unix(0, 0)))
+
+	a, err := store.Mint(time.Hour)
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+
+	b, err := store.Mint(time.Hour)
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+
+	if !strings.HasPrefix(a.AccessKeyID, "ASIA") {
+		t.Fatalf("access key id %q missing ASIA prefix", a.AccessKeyID)
+	}
+
+	if a.AccessKeyID == b.AccessKeyID || a.SecretAccessKey == b.SecretAccessKey || a.SessionToken == b.SessionToken {
+		t.Fatal("two Mint calls returned identical credentials; entropy source is broken")
+	}
+
+	// A predictable fallback would repeat a single alphabet character; a genuine
+	// draw has more than one distinct character.
+	if distinctChars(a.SecretAccessKey) < 2 {
+		t.Fatalf("secret %q has too little entropy (predictable fallback?)", a.SecretAccessKey)
+	}
+}
+
+func distinctChars(s string) int {
+	seen := map[rune]struct{}{}
+	for _, r := range s {
+		seen[r] = struct{}{}
+	}
+
+	return len(seen)
+}

--- a/server/gcp/auditlog_recording.go
+++ b/server/gcp/auditlog_recording.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
-	"time"
 
+	"github.com/stackshy/cloudemu/v2/config"
 	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
 )
 
@@ -30,7 +30,7 @@ const (
 // observer. Read-only requests (GET) and Cloud Logging's own operations are
 // skipped — Admin Activity logs record writes/deletes/actions, and recording
 // logging reads/writes would flood the log with its own traffic.
-func recordAuditLogEvent(logs logdriver.Logging, r *http.Request) {
+func recordAuditLogEvent(logs logdriver.Logging, r *http.Request, clock config.Clock) {
 	if r.Method == http.MethodGet || r.Method == http.MethodHead {
 		return
 	}
@@ -56,7 +56,7 @@ func recordAuditLogEvent(logs logdriver.Logging, r *http.Request) {
 	}
 
 	ctx := context.Background()
-	now := time.Now()
+	now := clock.Now().UTC()
 
 	_, _ = logs.CreateLogGroup(ctx, logdriver.LogGroupConfig{Name: auditLogGroup})
 	_, _ = logs.CreateLogStream(ctx, auditLogGroup, service)

--- a/server/gcp/auditlog_test.go
+++ b/server/gcp/auditlog_test.go
@@ -6,8 +6,10 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
 	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
 	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
 )
@@ -48,6 +50,39 @@ func TestAuditLogRecordsMutatingOp(t *testing.T) {
 
 	if !strings.Contains(joined, "AuditLog") || !strings.Contains(joined, "topics/audit-topic") {
 		t.Fatalf("audit entry missing expected fields: %s", joined)
+	}
+}
+
+// TestAuditLogUsesInjectedClock verifies the audit entry timestamp comes from
+// the provider's clock (a FakeClock here) rather than time.Now(), so the log is
+// deterministic.
+func TestAuditLogUsesInjectedClock(t *testing.T) {
+	fixed := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	p := cloudemu.NewGCP(config.WithClock(config.NewFakeClock(fixed)))
+	srv := gcpserver.New(gcpserver.DriversFrom(p))
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	code, _ := do(t, ts, http.MethodPut, "/v1/projects/demo/topics/clock-topic", `{}`)
+	if code < 200 || code >= 300 {
+		t.Fatalf("create topic: status %d", code)
+	}
+
+	events, err := p.CloudLogging.GetLogEvents(context.Background(), &logdriver.LogQueryInput{
+		LogGroup: auditLogName,
+	})
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+
+	if len(events) == 0 {
+		t.Fatal("expected an audit log entry, got none")
+	}
+
+	if !events[len(events)-1].Timestamp.Equal(fixed) {
+		t.Fatalf("audit entry timestamp = %v, want the injected clock time %v",
+			events[len(events)-1].Timestamp, fixed)
 	}
 }
 

--- a/server/gcp/from_provider.go
+++ b/server/gcp/from_provider.go
@@ -39,6 +39,7 @@ func DriversFrom(p *gcpprovider.Provider) Drivers {
 		AlloyDB:           nil,
 		ResourceDiscovery: p.ResourceDiscovery,
 		ProjectID:         p.ProjectID,
+		Clock:             p.Clock,
 	}
 }
 

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -9,6 +9,7 @@ package gcp
 import (
 	"net/http"
 
+	"github.com/stackshy/cloudemu/v2/config"
 	gkeprov "github.com/stackshy/cloudemu/v2/providers/gcp/gke"
 	gcpmon "github.com/stackshy/cloudemu/v2/providers/gcp/monitoring"
 	"github.com/stackshy/cloudemu/v2/server"
@@ -119,6 +120,10 @@ type Drivers struct {
 	// is used as the fallback.
 	ResourceDiscovery *resourcediscovery.Engine
 	ProjectID         string
+	// Clock drives time-stamped request observers (the Cloud Audit Log
+	// recorder). Leave nil to use the real clock; set it to the provider's clock
+	// so a FakeClock makes audit timestamps deterministic in tests.
+	Clock config.Clock
 }
 
 // New returns a server that speaks GCP's REST JSON wire protocol for every
@@ -406,17 +411,22 @@ func New(d Drivers) *server.Server {
 	// Cloud Audit Log Admin Activity entry for mutating operations, so the audit
 	// trail reflects real API activity. This is the GCP analog of the AWS
 	// CloudTrail observer.
-	installAuditObserver(srv, d.CloudLogging)
+	installAuditObserver(srv, d.CloudLogging, d.Clock)
 
 	return srv
 }
 
 // installAuditObserver wires the Cloud Audit Log observer when Cloud Logging is
-// present. A nil sink leaves the server's request path unchanged.
-func installAuditObserver(srv *server.Server, logs logdriver.Logging) {
+// present. A nil sink leaves the server's request path unchanged; a nil clock
+// falls back to the real clock.
+func installAuditObserver(srv *server.Server, logs logdriver.Logging, clock config.Clock) {
 	if logs == nil {
 		return
 	}
 
-	srv.SetObserver(func(r *http.Request) { recordAuditLogEvent(logs, r) })
+	if clock == nil {
+		clock = config.RealClock{}
+	}
+
+	srv.SetObserver(func(r *http.Request) { recordAuditLogEvent(logs, r, clock) })
 }

--- a/server/wire/sigv4/hardening_test.go
+++ b/server/wire/sigv4/hardening_test.go
@@ -170,6 +170,22 @@ func TestVerifyUnsignedPayloadSkipsBodyBinding(t *testing.T) {
 	}
 }
 
+// TestCheckExpiryFailsClosedOnUnparseableDate proves the skew/expiry check fails
+// closed under EnforceAuth: an X-Amz-Date the server cannot parse is rejected
+// rather than silently skipped (which would let a captured signature replay).
+func TestCheckExpiryFailsClosedOnUnparseableDate(t *testing.T) {
+	if aerr := checkExpiry(&signInputs{amzDate: "not-a-real-date"}, config.RealClock{}); aerr == nil {
+		t.Fatal("unparseable X-Amz-Date should fail closed (rejected), got nil")
+	}
+
+	// A well-formed date within skew still passes.
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	good := &signInputs{amzDate: now.Format(amzDateFormat)}
+	if aerr := checkExpiry(good, config.NewFakeClock(now)); aerr != nil {
+		t.Fatalf("well-formed date rejected: %v", aerr)
+	}
+}
+
 // TestIsHexSHA256 covers the sentinel/real-hash discriminator.
 func TestIsHexSHA256(t *testing.T) {
 	real := hex.EncodeToString(func() []byte { s := sha256.Sum256([]byte("x")); return s[:] }())

--- a/server/wire/sigv4/sigv4.go
+++ b/server/wire/sigv4/sigv4.go
@@ -188,12 +188,17 @@ func isHexSHA256(v string) bool {
 // checkExpiry rejects a request whose signing timestamp is outside the allowed
 // window. Header-signed requests must be within maxClockSkew of now in either
 // direction; presigned URLs must be within their X-Amz-Expires window (and not
-// dated in the future beyond the skew). An unparseable date is not evaluated
-// (the signature already matched), which never happens for real SDK requests.
+// dated in the future beyond the skew). Verify runs only under EnforceAuth, so
+// an unparseable date fails closed (rejected) rather than silently skipping the
+// skew/expiry check — a real SDK request always carries a parseable timestamp.
 func checkExpiry(in *signInputs, clock config.Clock) *AuthError {
 	signed, ok := parseAmzDate(in.amzDate)
 	if !ok {
-		return nil
+		return &AuthError{
+			Code:       "AccessDenied",
+			Message:    "Request timestamp is missing or could not be parsed",
+			HTTPStatus: unsignedStatus,
+		}
 	}
 
 	now := clock.Now().UTC()

--- a/services/parameterstore/driver/driver.go
+++ b/services/parameterstore/driver/driver.go
@@ -196,7 +196,9 @@ type ParameterStore interface {
 	DescribeParameters(ctx context.Context) ([]ParameterMetadata, error)
 
 	// GetParameterHistory returns every version of a parameter, oldest first.
-	GetParameterHistory(ctx context.Context, name string) ([]Parameter, error)
+	// withDecryption controls whether SecureString values are decrypted, mirroring
+	// GetParameter (false returns the opaque ciphertext blob).
+	GetParameterHistory(ctx context.Context, name string, withDecryption bool) ([]Parameter, error)
 	// LabelParameterVersion attaches labels to a specific version (0 = latest).
 	LabelParameterVersion(ctx context.Context, name string, version int64, labels []string) (appliedVersion int64, invalid []string, err error)
 }

--- a/services/parameterstore/parameterstore.go
+++ b/services/parameterstore/parameterstore.go
@@ -206,9 +206,9 @@ func (p *ParameterStore) DescribeParameters(ctx context.Context) ([]driver.Param
 }
 
 // GetParameterHistory returns every version of a parameter, oldest first.
-func (p *ParameterStore) GetParameterHistory(ctx context.Context, name string) ([]driver.Parameter, error) {
+func (p *ParameterStore) GetParameterHistory(ctx context.Context, name string, withDecryption bool) ([]driver.Parameter, error) {
 	out, err := p.do(ctx, "GetParameterHistory", name, func() (any, error) {
-		return p.driver.GetParameterHistory(ctx, name)
+		return p.driver.GetParameterHistory(ctx, name, withDecryption)
 	})
 	if err != nil {
 		return nil, err

--- a/services/serverless/driver/driver.go
+++ b/services/serverless/driver/driver.go
@@ -66,6 +66,15 @@ type AliasConfig struct {
 	RoutingConfig   *AliasRoutingConfig // for weighted aliases
 }
 
+// Version-weight bounds real Lambda enforces on an alias's
+// AdditionalVersionWeights: each weight is a traffic fraction in [0.0, 1.0], and
+// the additional weights sum to at most 1.0 (the remainder is the primary
+// version's share).
+const (
+	MinVersionWeight = 0.0
+	MaxVersionWeight = 1.0
+)
+
 // AliasRoutingConfig defines weighted routing between versions. It mirrors the
 // AWS Lambda AliasRoutingConfiguration shape: AdditionalVersionWeights maps a
 // published version to the fraction of traffic (0.0-1.0) it receives; the


### PR DESCRIPTION
## Summary

A batch of small, independent fidelity/correctness follow-ups surfaced by prior reviews. Each touches disjoint files; each carries a focused test (or doc verification).

### 1. docs — stale "not implemented" claims (SFN + CloudTrail)
- **Step Functions**: rewrote the section that still claimed *"No ASL interpreter — the emulator does not execute the Amazon States Language"*. The interpreter shipped (#859/#860/#861) and really runs Pass/Choice/Wait/Task(→Lambda)/Parallel/Map with Retry/Catch, JSONPath I/O processing, intrinsics, the `$$` context object, real execution history, and create-time validation. Honestly notes the deferrals (JSONata, `.sync`/`.waitForTaskToken`, non-Lambda service integrations including Activity tasks, distributed-map runs) and the nesting/step guards.
- **CloudTrail**: fixed the now-false *"records no audit events / `LookupEvents` returns empty pages"* claim — management events are recorded from served requests (#502) and `LookupEvents` reflects them; only the Lake analytics/Insights surfaces remain synthesized.

### 2. SigV4 hardening follow-ups (#839)
- `checkExpiry` now **fails closed** on an unparseable `X-Amz-Date` (reject, not silently skip the skew/expiry check). `Verify` runs only under EnforceAuth, so the auth-off path is unchanged.
- STS session `Mint` **returns an error on crypto/rand failure** instead of a predictable, forgeable fallback credential; the five STS handlers surface it as `InternalFailure`.

### 3. SSM `GetParameterHistory` decryption (#857)
Forwards `WithDecryption` to the value read (was returning the opaque ciphertext even when `WithDecryption=true`), mirroring `GetParameter`. Driver signature updated across the portable wrapper and server.

### 4. GCP audit-log clock (#858)
`auditlog_recording.go` uses the injected clock (threaded from the provider) instead of `time.Now()`, so FakeClock tests are deterministic.

### 5. ASL Retrier bound + nesting test (#861)
`Retrier.IntervalSeconds` must be `> 0` (positive) per the ASL spec (only `MaxAttempts` is non-negative). Adds a test that trips the `CloudEmu.ExecutionNestingLimitExceeded` guard via deeply nested Parallel-in-Parallel.

### 6. API Gateway sibling validation + dispatch guard (#862)
`CreateResource` rejects a second variable sibling with a **different** path-parameter name (`{id}` then `{name}`) as a ConflictException — real API Gateway behavior; two variable siblings made `matchRoute` depend on Go map order. Also adds an `apigateway_before_s3` case to the dispatch-ordering table (execute-api handler stays ahead of the S3 catch-all, the #590 pattern).

### 7. Lambda alias weight bounds (#856)
Validates `AdditionalVersionWeights`: each weight in `[0.0, 1.0]` and the additional weights sum to at most `1.0`, rejected at PutAlias/UpdateAlias. (The concurrent-alias data race remains deferred to #587.)

## Testing
- `go build ./... && go vet ./...` — clean
- `go test ./server/... ./providers/... ./services/...` — pass
- `go generate ./...` — no regen (interface signature change did not alter the coverage listing)
- `golangci-lint run` on every touched package — 0 new issues vs `development`

New tests: SFN retrier/nesting, SigV4 fail-closed, STS Mint entropy, SSM history decryption, GCP audit clock determinism, API Gateway sibling rejection, Lambda weight bounds.