### PR TITLE
fix(lambda): guard alias in-place mutation; enforce -race CI gate (#587)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
       - run: go test -race ./providers/aws/bedrock/... ./server/aws/bedrock/... ./providers/aws/bedrockagent/... ./server/aws/bedrockagent/... ./server/aws/bedrockagentruntime/...
 
   race:
-    name: Race (advisory)
+    name: Race
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -268,15 +268,13 @@ jobs:
           key: go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             go-${{ runner.os }}-
-      # Advisory whole-tree race detector. -race is 2-10x slower and much of the
-      # codebase is not race-clean yet (mutable entities held as *T behind
-      # memstore.Store have their fields mutated without per-entity sync), so this
-      # is non-blocking for now: it surfaces data races as warnings while the
-      # per-entity-mutex idiom (see SQS queueData.mu; use memstore.Update, never
-      # Get+Set) is rolled out provider-by-provider. Flip to blocking once green.
-      # Tracking: github issue "Architecture Theme 1".
-      - name: go test -race ./... (advisory)
-        run: go test -race -timeout 20m ./... || echo '::warning::go test -race reported findings (advisory; concurrency hardening in progress)'
+      # Blocking whole-tree race detector. The per-entity-mutex idiom (see SQS
+      # queueData.mu / EC2 instanceData.mu; use memstore.Update, never Get+Set) is
+      # rolled out across the mutable-store entities, so the tree is race-clean and
+      # any newly introduced data race must fail CI. -race is 2-10x slower, hence
+      # the generous timeout.
+      - name: go test -race ./...
+        run: go test -race -timeout 20m ./...
 
   tidy:
     name: Tidy

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,7 +124,7 @@ So the rule for any entity that is stored as a pointer and mutated after it is f
 
 Never do `v, _ := store.Get(k); mutate(v); store.Set(k, v)` as a way to "update" shared state. Beyond the field-level race, `Get`-then-`Set` is a **lost-update** race: two callers read the same value, each mutates its copy, and the second `Set` silently clobbers the first. This is a logical check-then-act race that the `-race` detector does **not** catch (no conflicting memory access on the same address), so it will not show up in CI — use `Update` or a per-entity lock instead.
 
-An advisory `go test -race ./...` job runs in CI while the per-entity locking is rolled out mock by mock (see #587).
+A blocking `go test -race ./...` job runs in CI (the `Race` gate): the tree is race-clean, so any newly introduced data race fails the build (#587).
 
 ## Fourth provider: OCI (in progress)
 

--- a/providers/aws/dynamodb/concurrency_test.go
+++ b/providers/aws/dynamodb/concurrency_test.go
@@ -1,0 +1,59 @@
+package dynamodb
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+// TestConcurrentItemRaceFree hammers a single table and item with concurrent
+// PutItem/UpdateItem/GetItem/Scan calls. The item paths use copy-on-write (Set a
+// fresh map) and clone-on-read, so a shared item map is never mutated in place;
+// this test guards that invariant under `go test -race`.
+func TestConcurrentItemRaceFree(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	createTestTable(m, "hot-table")
+
+	key := map[string]any{"pk": "p", "sk": "s"}
+
+	const (
+		workers    = 8
+		iterations = 40
+	)
+
+	var wg sync.WaitGroup
+
+	run := func(fn func()) {
+		defer wg.Done()
+
+		for i := 0; i < iterations; i++ {
+			fn()
+		}
+	}
+
+	wg.Add(4 * workers)
+
+	for w := 0; w < workers; w++ {
+		go run(func() {
+			_ = m.PutItem(ctx, "hot-table", map[string]any{"pk": "p", "sk": "s", "n": 1})
+		})
+		go run(func() {
+			_, _ = m.UpdateItem(ctx, driver.UpdateItemInput{
+				Table:   "hot-table",
+				Key:     key,
+				Actions: []driver.UpdateAction{{Action: "SET", Field: "n", Value: 2}},
+			})
+		})
+		go run(func() { _, _ = m.GetItem(ctx, "hot-table", key) })
+		go run(func() { _, _ = m.Scan(ctx, driver.ScanInput{Table: "hot-table"}) })
+	}
+
+	wg.Wait()
+
+	if _, err := m.DescribeTable(ctx, "hot-table"); err != nil {
+		t.Fatalf("DescribeTable after storm: %v", err)
+	}
+}

--- a/providers/aws/lambda/aliases.go
+++ b/providers/aws/lambda/aliases.go
@@ -63,6 +63,11 @@ func (m *Mock) UpdateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 		return nil, cerrors.Newf(cerrors.NotFound, "alias %s not found", cfg.Name)
 	}
 
+	// ad is a shared pointer held in the store; guard the read-validate-mutate of
+	// its alias fields so a concurrent Update/Get/List cannot race it.
+	ad.mu.Lock()
+	defer ad.mu.Unlock()
+
 	// Compute the prospective effective FunctionVersion without touching the
 	// live alias yet. UpdateAlias is atomic in real AWS: if any validation
 	// fails the alias must be left completely unchanged.
@@ -97,8 +102,8 @@ func (m *Mock) UpdateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 
 	ad.alias.RevisionID = newRevisionID()
 
-	fd.aliases.Set(cfg.Name, ad)
-
+	// ad is the shared pointer already held in the store, so the in-place
+	// mutations above are already visible — no re-Set needed.
 	result := ad.alias
 
 	return &result, nil
@@ -132,7 +137,9 @@ func (m *Mock) GetAlias(_ context.Context, functionName, aliasName string) (*dri
 		return nil, cerrors.Newf(cerrors.NotFound, "alias %s not found", aliasName)
 	}
 
+	ad.mu.Lock()
 	result := ad.alias
+	ad.mu.Unlock()
 
 	return &result, nil
 }
@@ -148,7 +155,9 @@ func (m *Mock) ListAliases(_ context.Context, functionName string) ([]driver.Ali
 	aliases := make([]driver.Alias, 0, len(all))
 
 	for _, ad := range all {
+		ad.mu.Lock()
 		aliases = append(aliases, ad.alias)
+		ad.mu.Unlock()
 	}
 
 	return aliases, nil

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -76,6 +76,7 @@ type versionData struct {
 }
 
 type aliasData struct {
+	mu    sync.Mutex // guards alias, mutated in place after the entity is stored
 	alias driver.Alias
 }
 

--- a/providers/aws/lambda/lambda_test.go
+++ b/providers/aws/lambda/lambda_test.go
@@ -947,6 +947,67 @@ func TestAliasRoutingConfigDeepCopy(t *testing.T) {
 	assertEqual(t, 0.5, alias.RoutingConfig.AdditionalVersionWeights["2"])
 }
 
+// TestConcurrentAliasRaceFree hammers a single alias with concurrent
+// UpdateAlias/GetAlias/ListAliases calls. Every one of these paths reads or
+// mutates fields on the shared *aliasData, so without per-entity
+// synchronization the -race detector flags a data race on alias.FunctionVersion
+// / Description / RoutingConfig. It must run clean under `go test -race`.
+func TestConcurrentAliasRaceFree(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
+	_, _ = m.PublishVersion(ctx, "my-func", "v1")
+	_, _ = m.PublishVersion(ctx, "my-func", "v2")
+
+	_, err := m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName:    "my-func",
+		Name:            "prod",
+		FunctionVersion: "1",
+	})
+	requireNoError(t, err)
+
+	const (
+		workers    = 8
+		iterations = 40
+	)
+
+	var wg sync.WaitGroup
+
+	run := func(fn func()) {
+		defer wg.Done()
+
+		for i := 0; i < iterations; i++ {
+			fn()
+		}
+	}
+
+	wg.Add(4 * workers)
+
+	for w := 0; w < workers; w++ {
+		go run(func() {
+			_, _ = m.UpdateAlias(ctx, driver.AliasConfig{
+				FunctionName: "my-func", Name: "prod", FunctionVersion: "1", Description: "a",
+			})
+		})
+		go run(func() {
+			_, _ = m.UpdateAlias(ctx, driver.AliasConfig{
+				FunctionName: "my-func", Name: "prod", FunctionVersion: "2", Description: "b",
+			})
+		})
+		go run(func() { _, _ = m.GetAlias(ctx, "my-func", "prod") })
+		go run(func() { _, _ = m.ListAliases(ctx, "my-func") })
+	}
+
+	wg.Wait()
+
+	alias, err := m.GetAlias(ctx, "my-func", "prod")
+	requireNoError(t, err)
+
+	if alias.FunctionVersion != "1" && alias.FunctionVersion != "2" {
+		t.Fatalf("alias left in inconsistent version %q", alias.FunctionVersion)
+	}
+}
+
 func requireNoError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/providers/aws/sqs/concurrency_test.go
+++ b/providers/aws/sqs/concurrency_test.go
@@ -1,0 +1,54 @@
+package sqs
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+)
+
+// TestConcurrentQueueRaceFree hammers a single queue with concurrent
+// SendMessage/ReceiveMessages/SetQueueAttributes/GetQueueAttributes calls. Each
+// path reads or mutates fields on the shared *queueData (messages, attributes,
+// lastModifiedAt), so without queueData.mu the -race detector flags a data race.
+// It must run clean under `go test -race`.
+func TestConcurrentQueueRaceFree(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	q := createStdQueue(m, "hot-queue")
+	url := q.URL
+
+	const (
+		workers    = 8
+		iterations = 40
+	)
+
+	var wg sync.WaitGroup
+
+	run := func(fn func()) {
+		defer wg.Done()
+
+		for i := 0; i < iterations; i++ {
+			fn()
+		}
+	}
+
+	wg.Add(4 * workers)
+
+	for w := 0; w < workers; w++ {
+		go run(func() { _, _ = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "x"}) })
+		go run(func() {
+			_, _ = m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: url, MaxMessages: 5})
+		})
+		go run(func() { _ = m.SetQueueAttributes(ctx, url, map[string]int{"VisibilityTimeout": 45}) })
+		go run(func() { _, _ = m.GetQueueAttributes(ctx, url) })
+	}
+
+	wg.Wait()
+
+	if _, err := m.GetQueueAttributes(ctx, url); err != nil {
+		t.Fatalf("GetQueueAttributes after storm: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the one real data race in the mutable-store concurrency class (#587) and, now that the tree is race-clean, promotes the advisory `-race` CI job to a blocking gate.

### The race
`UpdateAlias` fetched the shared `*aliasData` from the store via `fd.aliases.Get()` and mutated its `alias` fields (`FunctionVersion`, `Description`, `RoutingConfig`, `RevisionID`) with no lock — a classic get-then-mutate race against concurrent `UpdateAlias`/`GetAlias`/`ListAliases`. The new stress test flags 33 `DATA RACE` reports without the fix.

### Fix (follows the documented `queueData.mu` / `instanceData.mu` idiom)
- `aliasData` gains its own `sync.Mutex` guarding `alias`; held around every read/write in `UpdateAlias`, `GetAlias`, `ListAliases`. `CreateAlias` builds the entity fully before `Set`.
- Dropped the redundant `fd.aliases.Set(name, ad)` in `UpdateAlias` (ad is the shared pointer already in the store).

### Stress tests (surface latent races under `-race`)
- `providers/aws/lambda`: `TestConcurrentAliasRaceFree` — N goroutines hammering Update/Get/List on one alias.
- `providers/aws/sqs`: `TestConcurrentQueueRaceFree` — Send/Receive/Set/Get on one queue.
- `providers/aws/dynamodb`: `TestConcurrentItemRaceFree` — Put/Update/Get/Scan on one item (guards the copy-on-write invariant).

### CI gate
`go test -race ./...` is now blocking (`Race` job). Verified locally: full tree `go test -race ./...` = **306 ok, 0 DATA RACE, 0 FAIL**. `docs/architecture.md` updated to say the gate is enforced.

No other real races were found by the detector across the whole tree.
