### PR TITLE
feat(install): Homebrew tap + one-line install.sh + README install methods (#444)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,8 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pushes the Homebrew formula to github.com/stackshy/homebrew-tap.
+          # MAINTAINER PREREQUISITE (one-time): add a repo secret named
+          # HOMEBREW_TAP_TOKEN — a PAT with write access to the tap repo.
+          # Without it the release still publishes; only the brew push is skipped.
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,3 +67,38 @@ changelog:
 release:
   draft: false
   prerelease: auto # a pre-release tag (v1.2.0-rc1) is marked pre-release
+
+# Publish a Homebrew cask to the tap repo on each stable `v*` tag, so users can
+# `brew install stackshy/tap/cloudemu`. GoReleaser v2 deprecated `brews`
+# (formulae) in favour of `homebrew_casks` for distributing prebuilt binaries —
+# `goreleaser check` is clean only with casks. A cask installs the downloaded
+# `cloudemu` binary directly (no source build); `binary "cloudemu"` is the cask
+# equivalent of a formula's `bin.install "cloudemu"`.
+#
+# Prerequisites the maintainer must set up ONCE (see .github/workflows/release.yml):
+#   1. The public tap repo github.com/stackshy/homebrew-tap must exist.
+#   2. A repo secret HOMEBREW_TAP_TOKEN (a PAT with write access to the tap)
+#      must be added to this repo — GoReleaser uses it to push the cask.
+homebrew_casks:
+  - name: cloudemu
+    binaries:
+      - cloudemu
+    ids:
+      - cloudemu
+    repository:
+      owner: stackshy
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: "https://cloudemu.info/"
+    description: "In-memory emulator for AWS, Azure & GCP cloud APIs — run a local cloud, $0."
+    license: "MIT"
+    # Don't push a cask for pre-releases (rc/beta tags).
+    skip_upload: auto
+    # The binary is unsigned; strip Gatekeeper's quarantine flag on install so
+    # macOS doesn't block the first run.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/cloudemu"]
+          end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,27 @@ Fix all issues. If a `//nolint` directive is needed, always include an explanati
 - Include steps to reproduce for bug reports
 - Tag issues with appropriate labels (aws, azure, gcp, enhancement, bug)
 
+## Releases (maintainers)
+
+Pushing a `v*` tag triggers `.github/workflows/release.yml`, which runs
+GoReleaser to build cross-platform binaries, publish a GitHub Release with
+`checksums.txt`, and push a Homebrew cask to `github.com/stackshy/homebrew-tap`
+(so users can `brew install stackshy/tap/cloudemu`).
+
+One-time prerequisites for the Homebrew push:
+
+1. The public tap repo `github.com/stackshy/homebrew-tap` must exist.
+2. Add a repository secret named `HOMEBREW_TAP_TOKEN` — a Personal Access Token
+   with **write** access to the tap repo. GoReleaser uses it to commit the cask.
+   Without it, the release still publishes; only the Homebrew push is skipped.
+
+Validate config changes locally before tagging:
+
+```sh
+go run github.com/goreleaser/goreleaser/v2@latest check
+go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean --skip=publish
+```
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,27 @@ It emulates the API **control surface** your code actually calls, not real infra
 2. **In-process SDK server** (Go) — a `httptest.NewServer` your tests point the real SDKs at. No container.
 3. **Typed Go API** — call the in-memory mocks directly: `cloud.EC2.RunInstances(ctx, …)`.
 
+## Install
+
+Get the `cloudemu` CLI — pick whichever fits your setup:
+
+```sh
+# Homebrew (macOS / Linux)
+brew install stackshy/tap/cloudemu
+
+# One-line install script (macOS / Linux) — downloads the release binary and verifies its checksum
+curl -fsSL https://raw.githubusercontent.com/stackshy/cloudemu/HEAD/install.sh | sh
+
+# Go toolchain
+go install github.com/stackshy/cloudemu/v2/cmd/cloudemu@latest
+
+# Docker — no install, just run the server
+docker run --rm -p 4566:4566 -p 4568:4568 -p 4569:4569 -p 4570:4570 \
+  ghcr.io/stackshy/cloudemu:latest
+```
+
+Prebuilt binaries for every OS/arch are on the [releases page](https://github.com/stackshy/cloudemu/releases). The install script honours a version arg and an `INSTALL_DIR` override, e.g. `... | sh -s -- v2.5.0` or `INSTALL_DIR="$HOME/bin" ... | sh`. To use cloudemu as a Go library instead, see [Quickstart](#quickstart) below.
+
 ## Quickstart
 
 **To integrate cloudemu with an existing application, run it in server mode and set your SDK's endpoint** (`AWS_ENDPOINT_URL` / `BaseEndpoint`, `option.WithEndpoint`, or the Azure ARM endpoint override), then point your already-running app or services at it. Do **not** write a `_test.go` file to spin it up in-process for integration — that's library mode, for unit tests inside cloudemu-aware Go code (shown last).

--- a/docs/standalone-server.md
+++ b/docs/standalone-server.md
@@ -11,10 +11,26 @@ right tool for unit tests.
 
 ## Install & run
 
+Install the `cloudemu` CLI with whichever fits your setup, then `cloudemu serve`:
+
 ```sh
+# Homebrew (macOS / Linux)
+brew install stackshy/tap/cloudemu
+
+# One-line install script (downloads the release binary + verifies its checksum)
+curl -fsSL https://raw.githubusercontent.com/stackshy/cloudemu/HEAD/install.sh | sh
+
+# Go toolchain
 go install github.com/stackshy/cloudemu/v2/cmd/cloudemu@latest
+```
+
+```sh
 cloudemu serve
 ```
+
+The install script takes an optional version arg and an `INSTALL_DIR` override
+(`... | sh -s -- v2.5.0`, `INSTALL_DIR="$HOME/bin" ... | sh`). Prebuilt binaries
+for every OS/arch are on the [releases page](https://github.com/stackshy/cloudemu/releases).
 
 Or from a checkout:
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,137 @@
+#!/bin/sh
+# install.sh — one-line installer for the cloudemu CLI.
+#
+# Detects your OS/arch, downloads the matching release archive from GitHub,
+# verifies its SHA-256 against the release's checksums.txt, and installs the
+# `cloudemu` binary into a bin directory on your PATH.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/stackshy/cloudemu/HEAD/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/stackshy/cloudemu/HEAD/install.sh | sh -s -- v2.5.0
+#   INSTALL_DIR="$HOME/bin" curl -fsSL https://raw.githubusercontent.com/stackshy/cloudemu/HEAD/install.sh | sh
+#
+# Env overrides:
+#   INSTALL_DIR   target bin directory (default: /usr/local/bin, else $HOME/.local/bin)
+#   VERSION       release tag to install (default: latest); a positional arg wins over this
+set -eu
+
+REPO="stackshy/cloudemu"
+BINARY="cloudemu"
+
+info() { printf '%s\n' "cloudemu: $*"; }
+err() { printf '%s\n' "cloudemu: error: $*" >&2; exit 1; }
+
+# --- pick an HTTP downloader ------------------------------------------------
+if command -v curl >/dev/null 2>&1; then
+  http_get() { curl -fsSL "$1"; }
+  http_download() { curl -fsSL -o "$2" "$1"; }
+elif command -v wget >/dev/null 2>&1; then
+  http_get() { wget -qO- "$1"; }
+  http_download() { wget -qO "$2" "$1"; }
+else
+  err "need curl or wget installed"
+fi
+
+# --- detect OS --------------------------------------------------------------
+os="$(uname -s)"
+case "$os" in
+  Linux) os="linux" ;;
+  Darwin) os="darwin" ;;
+  *) err "unsupported OS: $os (only linux and darwin are supported)" ;;
+esac
+
+# --- detect arch (map uname -> goreleaser/goarch naming) --------------------
+arch="$(uname -m)"
+case "$arch" in
+  x86_64 | amd64) arch="amd64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+  *) err "unsupported architecture: $arch (only amd64 and arm64 are supported)" ;;
+esac
+
+# --- resolve version tag ----------------------------------------------------
+tag="${1:-${VERSION:-}}"
+if [ -z "$tag" ]; then
+  info "resolving latest release..."
+  tag="$(http_get "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' \
+    | head -n1 \
+    | sed 's/.*"tag_name"[^"]*"\([^"]*\)".*/\1/')"
+  [ -n "$tag" ] || err "could not resolve the latest release tag from the GitHub API"
+fi
+
+# goreleaser archives use the version WITHOUT the leading "v"
+version="${tag#v}"
+archive="${BINARY}_${version}_${os}_${arch}.tar.gz"
+base_url="https://github.com/${REPO}/releases/download/${tag}"
+
+info "installing ${BINARY} ${tag} (${os}/${arch})"
+
+# --- download into a temp dir -----------------------------------------------
+tmp="$(mktemp -d 2>/dev/null || mktemp -d -t cloudemu)"
+cleanup() { rm -rf "$tmp"; }
+trap cleanup EXIT INT TERM
+
+info "downloading ${archive}..."
+http_download "${base_url}/${archive}" "${tmp}/${archive}" \
+  || err "download failed: ${base_url}/${archive}"
+
+info "downloading checksums.txt..."
+http_download "${base_url}/checksums.txt" "${tmp}/checksums.txt" \
+  || err "could not download checksums.txt from ${base_url}"
+
+# --- verify sha256 ----------------------------------------------------------
+expected="$(grep " ${archive}\$" "${tmp}/checksums.txt" | awk '{print $1}' | head -n1)"
+[ -n "$expected" ] || err "no checksum entry for ${archive} in checksums.txt"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "${tmp}/${archive}" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual="$(shasum -a 256 "${tmp}/${archive}" | awk '{print $1}')"
+else
+  err "need sha256sum or shasum to verify the download"
+fi
+
+if [ "$expected" != "$actual" ]; then
+  err "checksum mismatch for ${archive} (expected ${expected}, got ${actual})"
+fi
+info "checksum verified"
+
+# --- extract ----------------------------------------------------------------
+tar -xzf "${tmp}/${archive}" -C "${tmp}" "${BINARY}" \
+  || err "failed to extract ${BINARY} from ${archive}"
+[ -f "${tmp}/${BINARY}" ] || err "${BINARY} not found in ${archive}"
+chmod +x "${tmp}/${BINARY}"
+
+# --- choose install dir + install -------------------------------------------
+install_to() {
+  dir="$1"
+  if [ -d "$dir" ] && [ -w "$dir" ]; then
+    mv "${tmp}/${BINARY}" "${dir}/${BINARY}"
+    return 0
+  fi
+  return 1
+}
+
+path_note=""
+if [ -n "${INSTALL_DIR:-}" ]; then
+  mkdir -p "$INSTALL_DIR" || err "cannot create INSTALL_DIR: $INSTALL_DIR"
+  install_to "$INSTALL_DIR" || err "cannot write to INSTALL_DIR: $INSTALL_DIR"
+  dest="$INSTALL_DIR"
+elif install_to "/usr/local/bin"; then
+  dest="/usr/local/bin"
+elif command -v sudo >/dev/null 2>&1 && [ -d "/usr/local/bin" ] \
+    && sudo mv "${tmp}/${BINARY}" "/usr/local/bin/${BINARY}"; then
+  dest="/usr/local/bin"
+else
+  dest="${HOME}/.local/bin"
+  mkdir -p "$dest" || err "cannot create ${dest}"
+  install_to "$dest" || err "cannot write to ${dest}"
+  case ":${PATH}:" in
+    *":${dest}:"*) ;;
+    *) path_note="  Add it to your PATH:  export PATH=\"${dest}:\$PATH\"" ;;
+  esac
+fi
+
+info "installed ${BINARY} to ${dest}/${BINARY}"
+[ -z "$path_note" ] || printf '%s\n' "$path_note"
+info "run '${BINARY} version' to verify"


### PR DESCRIPTION
## Summary

Finishes the install DX for #444 (PR-A prebuilt binaries via GoReleaser already merged). Adds the remaining three install paths in one PR:

- **Homebrew (PR-B)** — GoReleaser now publishes a Homebrew **cask** to `github.com/stackshy/homebrew-tap` on each stable `v*` tag. Users install with `brew install stackshy/tap/cloudemu`. The generated cask carries both macOS and Linux download blocks.
- **install.sh (PR-C)** — a POSIX `sh` one-line installer at repo root. Detects OS/arch, resolves the latest release via the GitHub API (or a pinned version arg), downloads the matching archive, **verifies its SHA-256 against `checksums.txt`**, extracts `cloudemu`, and installs it (`/usr/local/bin` with a sudo fallback, else `$HOME/.local/bin` with a PATH note). Supports a version arg and `INSTALL_DIR` override.
- **README + docs** — new `## Install` section listing brew, install.sh, `go install`, and Docker; the standalone-server doc's install block expanded to match.
- **Maintainer docs** — the one-time `HOMEBREW_TAP_TOKEN` secret prerequisite documented in `release.yml`, `.goreleaser.yaml`, and a new CONTRIBUTING "Releases" section.

## Why a cask, not a formula

GoReleaser v2.18 **deprecated `brews`** (formulae) in favour of `homebrew_casks` for distributing prebuilt binaries — `goreleaser check` is only deprecation-clean with casks. The cask installs the downloaded binary directly (no source build) and a postflight strips the macOS Gatekeeper quarantine flag on the unsigned binary.

## Validation

- `goreleaser check` — config valid, **0 deprecation warnings**
- `goreleaser release --snapshot --clean --skip=publish` — builds all 6 targets and generates `dist/homebrew/Casks/cloudemu.rb`
- `shellcheck install.sh` + `sh -n install.sh` — clean
- `actionlint .github/workflows/release.yml` — clean
- `go build ./...`, `go vet ./...`, `go generate ./...` (no diff) — clean

## Maintainer step still required

Add a repo secret **`HOMEBREW_TAP_TOKEN`** (a PAT with write access to the tap repo) so GoReleaser can push the cask. Without it the release still publishes; only the Homebrew push is skipped.
