### PR TITLE
fix(persist): fsync snapshot file + parent dir before/after rename so a crash can't leave a truncated state file

### DIFF
--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -54,6 +54,14 @@ By default the snapshot **includes object bodies** (an S3 object comes back with
 its contents). `--persist-metadata-only` keeps only the resource structure for a
 smaller file; restored objects then come back as zero-byte keys until re-uploaded.
 
+Snapshot writes are **crash-safe**: the file is written to a temp file, `fsync`ed,
+`rename`d atomically onto the target, and the parent directory is then `fsync`ed —
+so an interrupted or power-lost write leaves the previous snapshot (or none) but
+never a truncated/empty state file. On **macOS** this is best-effort: Go's
+`File.Sync` issues `fsync(2)`, which does not flush the drive's own write cache
+(a true device flush needs `fcntl(F_FULLFSYNC)`, not issued here), so darwin gives
+no hard power-loss guarantee.
+
 ## Named snapshots (`snapshot save` / `load` / `list` / `delete`)
 
 Where `--persist` auto-saves one state on stop, **named snapshots** capture, name,

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -20,7 +20,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
+	"syscall"
 
 	"github.com/stackshy/cloudemu/v2/internal/snapshot"
 )
@@ -200,10 +202,16 @@ func (s Snapshot) WriteFile(path string) error {
 		return err
 	}
 
-	// Write to a temp file in the same dir, then rename onto the target. Rename
-	// is atomic on the same filesystem, so an interrupted write (disk-full, OOM,
-	// SIGKILL) leaves the previous snapshot — or none — but never a truncated
-	// file that would fail the next start.
+	// Write to a temp file in the same dir, fsync it, then rename onto the
+	// target. The full ordering — temp-write → fsync file → rename → best-effort
+	// fsync parent dir — is what makes the write crash-safe: fsync forces the
+	// data blocks to disk before the rename publishes the name, so power loss can
+	// leave the previous snapshot (or none) but never a truncated/empty file, and
+	// rename is atomic on the same filesystem. The parent-dir fsync then makes the
+	// rename entry itself durable. Darwin caveat: Go's File.Sync issues fsync(2),
+	// which on macOS flushes to the drive but does NOT flush the drive's own write
+	// cache (a true device flush needs fcntl(F_FULLFSYNC), which is not issued
+	// here), so on darwin this is best-effort, not a hard power-loss guarantee.
 	tmp, err := os.CreateTemp(dir, ".snapshot-*.tmp")
 	if err != nil {
 		return err
@@ -212,6 +220,16 @@ func (s Snapshot) WriteFile(path string) error {
 	tmpName := tmp.Name()
 
 	if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+
+		return err
+	}
+
+	// fsync the data to disk before the rename. This is the critical fix: without
+	// it the rename can be committed to the directory before the file's blocks
+	// reach disk, leaving an empty/truncated state file after a crash.
+	if err := tmp.Sync(); err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmpName)
 
@@ -230,7 +248,45 @@ func (s Snapshot) WriteFile(path string) error {
 		return err
 	}
 
+	// Make the rename entry itself durable. Best-effort by design (see fsyncDir).
+	if err := fsyncDir(dir); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// fsyncDir fsyncs a directory so a rename into it is durable across a crash. It
+// is best-effort: opening a directory handle for fsync fails on Windows, and
+// some filesystems reject a directory fsync with EINVAL/ENOTSUP. Those are
+// swallowed (there is nothing the caller can do and the file data is already
+// synced); genuinely unexpected errors are returned.
+func fsyncDir(dir string) error {
+	if runtime.GOOS == "windows" {
+		// Windows has no fsync-the-directory concept; the rename is durable once
+		// the file was synced above.
+		return nil
+	}
+
+	d, err := os.Open(dir)
+	if err != nil {
+		// Cannot open the directory as a handle on this platform/FS; treat as
+		// unsupported rather than failing the whole write.
+		return nil
+	}
+
+	syncErr := d.Sync()
+
+	if closeErr := d.Close(); closeErr != nil && syncErr == nil {
+		syncErr = closeErr
+	}
+
+	if syncErr == nil || errors.Is(syncErr, syscall.EINVAL) || errors.Is(syncErr, syscall.ENOTSUP) {
+		// EINVAL/ENOTSUP: this filesystem does not support fsync on a directory.
+		return nil
+	}
+
+	return syncErr
 }
 
 // ReadFile loads a snapshot from disk, rejecting an incompatible schema version

--- a/persist/persist_test.go
+++ b/persist/persist_test.go
@@ -304,3 +304,48 @@ func TestSnapshotFileRoundTrip(t *testing.T) {
 		t.Fatal("ReadFile(unknown schema) = nil error, want rejection")
 	}
 }
+
+// TestWriteFileFreshNestedDirAndOverwrite exercises the durable-write path: a
+// write into a fresh multi-level directory (MkdirAll + file fsync + parent-dir
+// fsync) succeeds and round-trips, and a second write atomically replaces the
+// existing target rather than failing on the rename.
+func TestWriteFileFreshNestedDirAndOverwrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "a", "b", "c", "snapshot.json")
+
+	snap := persist.Snapshot{
+		SchemaVersion: persist.SchemaVersion,
+		Providers: map[string]persist.ProviderState{
+			"aws": {Services: map[string]json.RawMessage{"s3": json.RawMessage(`{"one":1}`)}},
+		},
+	}
+	if err := snap.WriteFile(path); err != nil {
+		t.Fatalf("WriteFile (fresh nested dir): %v", err)
+	}
+
+	got, err := persist.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if len(got.Providers["aws"].Services) != 1 {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+
+	// Overwrite the existing target: the rename must replace it atomically.
+	snap2 := persist.Snapshot{
+		SchemaVersion: persist.SchemaVersion,
+		Providers: map[string]persist.ProviderState{
+			"aws": {Services: map[string]json.RawMessage{"s3": json.RawMessage(`{"one":1}`), "ec2": json.RawMessage(`{"two":2}`)}},
+		},
+	}
+	if err := snap2.WriteFile(path); err != nil {
+		t.Fatalf("WriteFile (overwrite existing): %v", err)
+	}
+
+	got2, err := persist.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile after overwrite: %v", err)
+	}
+	if len(got2.Providers["aws"].Services) != 2 {
+		t.Fatalf("overwrite not reflected: %+v", got2)
+	}
+}


### PR DESCRIPTION
## Bug

`persist.Snapshot.WriteFile` wrote a temp file, closed it, and `os.Rename`d it onto the target — but never `fsync`ed. On power loss the rename can be committed to the directory before the file's data blocks reach disk, leaving an **empty/truncated `snapshot.json`** that fails the next start. The old comment overclaimed crash-safety (it only reasoned about atomicity of `rename`, not durability). This affects the shipped `--persist` / `/_cloudemu/snapshot` feature.

## Fix

Make durable writes always-on (a snapshot write is infrequent, so no flag):

1. `tmp.Sync()` after the write and **before** `Close()`, failing the write on error — data hits disk before the rename. This is the critical fix.
2. After `os.Rename`, `fsync` the parent directory (new `fsyncDir` helper) so the rename entry itself is durable.
3. Rewrote the comment to state the real guarantee: temp-write → fsync file → rename → best-effort fsync dir.

`fsyncDir` is cross-platform-safe (repo ships linux/darwin/windows via GoReleaser):
- `runtime.GOOS == "windows"` returns early (no directory-fsync concept; opening a dir handle fails there).
- If the directory can't be opened as a handle, treated as unsupported (no failure).
- A directory-fsync that returns `EINVAL`/`ENOTSUP` (filesystem doesn't support it) is swallowed via `errors.Is`; genuinely unexpected errors are returned.

## Darwin caveat

Go's `File.Sync` issues `fsync(2)`, which on macOS does **not** flush the drive's own write cache (a true device flush needs `fcntl(F_FULLFSYNC)`, not issued here). So on darwin this is best-effort, not a hard power-loss guarantee. Documented in code, the `WriteFile` comment, and `docs/persistence.md`.

## Tests / gates

Added `TestWriteFileFreshNestedDirAndOverwrite` (fresh nested dir MkdirAll+fsync path, plus atomic overwrite of an existing target). Build (linux/darwin/windows), vet, `go test ./persist/... ./server/serverkit/...`, `go test -race ./persist/...`, and golangci-lint all clean.
