### PR TITLE
feat(persist): always-on crash-safe persistence (#447)

### DIFF
--- a/cmd/cloudemu/persist_durability_test.go
+++ b/cmd/cloudemu/persist_durability_test.go
@@ -1,0 +1,460 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"google.golang.org/api/option"
+)
+
+// buildServeBinary compiles the cloudemu binary once for a durability test.
+func buildServeBinary(t *testing.T) string {
+	t.Helper()
+
+	bin := filepath.Join(t.TempDir(), "cloudemu")
+	build := exec.Command("go", "build", "-o", bin, ".")
+
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+
+	return bin
+}
+
+// durabilityPorts is one run's endpoint ports plus its persistent state file.
+type durabilityPorts struct {
+	aws, gcp, azure, state string
+}
+
+// startServe launches `cloudemu serve` with the given persistence settings and
+// waits for the AWS endpoint to answer. The caller must terminate the process.
+func startServe(t *testing.T, bin string, p durabilityPorts, strategy, interval string) *exec.Cmd {
+	t.Helper()
+
+	cmd := exec.Command(bin, "serve",
+		"--host", "127.0.0.1",
+		"--aws-port", p.aws,
+		"--gcp-port", p.gcp,
+		"--azure-port", p.azure,
+		"--k8s-port", "",
+		"--quiet",
+		"--persist",
+		"--state-file", p.state,
+		"--persist-strategy", strategy,
+		"--persist-interval", interval,
+	)
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start serve: %v", err)
+	}
+
+	if !waitReady("http://127.0.0.1:"+p.aws+"/", 15*time.Second) {
+		_ = cmd.Process.Kill()
+		t.Fatal("AWS endpoint never became ready")
+	}
+
+	return cmd
+}
+
+// killHard sends SIGKILL — a hard crash with no graceful shutdown, so only saves
+// that already reached disk survive. This is the scenario today's --persist fails.
+func killHard(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+}
+
+// waitFileContains polls the state file until it holds substr, proving a
+// background save landed before we crash the process.
+func waitFileContains(t *testing.T, path, substr string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if b, err := os.ReadFile(path); err == nil && bytes.Contains(b, []byte(substr)) {
+			return
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatalf("state file %s never contained %q within %s", path, substr, timeout)
+}
+
+func s3Client(t *testing.T, port string) *s3.Client {
+	t.Helper()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String("http://127.0.0.1:" + port)
+		o.UsePathStyle = true
+	})
+}
+
+func iamClient(t *testing.T, port string) *iam.Client {
+	t.Helper()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return iam.NewFromConfig(cfg, func(o *iam.Options) {
+		o.BaseEndpoint = aws.String("http://127.0.0.1:" + port)
+	})
+}
+
+func gcsClient(t *testing.T, port string) *storage.Client {
+	t.Helper()
+
+	c, err := storage.NewClient(context.Background(),
+		option.WithEndpoint("http://127.0.0.1:"+port+"/storage/v1/"),
+		option.WithoutAuthentication())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return c
+}
+
+const durableBucketPolicy = `{"Version":"2012-10-17","Statement":[{"Sid":"AllowGet","Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::durable/*"}]}`
+
+const durableRolePolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}`
+
+// createDurableResources drives real SDK mutations across AWS/GCP/Azure,
+// including the S3 and IAM Get-then-mutate sub-resource writes the request seam
+// must catch (they never call a memstore mutator).
+func createDurableResources(t *testing.T, p durabilityPorts) {
+	t.Helper()
+
+	ctx := context.Background()
+	s3c := s3Client(t, p.aws)
+
+	if _, err := s3c.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String("durable")}); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	if _, err := s3c.PutBucketTagging(ctx, &s3.PutBucketTaggingInput{
+		Bucket:  aws.String("durable"),
+		Tagging: &types.Tagging{TagSet: []types.Tag{{Key: aws.String("env"), Value: aws.String("prod")}}},
+	}); err != nil {
+		t.Fatalf("PutBucketTagging: %v", err)
+	}
+
+	if _, err := s3c.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{
+		Bucket: aws.String("durable"),
+		Policy: aws.String(durableBucketPolicy),
+	}); err != nil {
+		t.Fatalf("PutBucketPolicy: %v", err)
+	}
+
+	if _, err := s3c.PutBucketEncryption(ctx, &s3.PutBucketEncryptionInput{
+		Bucket: aws.String("durable"),
+		ServerSideEncryptionConfiguration: &types.ServerSideEncryptionConfiguration{
+			Rules: []types.ServerSideEncryptionRule{{
+				ApplyServerSideEncryptionByDefault: &types.ServerSideEncryptionByDefault{SSEAlgorithm: types.ServerSideEncryptionAes256},
+			}},
+		},
+	}); err != nil {
+		t.Fatalf("PutBucketEncryption: %v", err)
+	}
+
+	iamc := iamClient(t, p.aws)
+	if _, err := iamc.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("durable-role"),
+		AssumeRolePolicyDocument: aws.String(durableRolePolicy),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	if _, err := iamc.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
+		RoleName:       aws.String("durable-role"),
+		PolicyName:     aws.String("inline-durable"),
+		PolicyDocument: aws.String(durableRolePolicy),
+	}); err != nil {
+		t.Fatalf("PutRolePolicy: %v", err)
+	}
+
+	gcs := gcsClient(t, p.gcp)
+	defer gcs.Close()
+
+	if err := gcs.Bucket("gcp-durable").Create(ctx, "cloudemu-local", nil); err != nil {
+		t.Fatalf("GCS Bucket.Create: %v", err)
+	}
+
+	createAzureContainer(t, p.azure)
+}
+
+// assertDurableResourcesSurvive re-reads every resource after a crash+restart and
+// fails if any is missing — the crux of #447.
+func assertDurableResourcesSurvive(t *testing.T, p durabilityPorts) {
+	t.Helper()
+
+	ctx := context.Background()
+	s3c := s3Client(t, p.aws)
+
+	if _, err := s3c.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{Bucket: aws.String("durable")}); err != nil {
+		t.Fatalf("bucket tagging did not survive the crash: %v", err)
+	}
+
+	if _, err := s3c.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{Bucket: aws.String("durable")}); err != nil {
+		t.Fatalf("bucket policy did not survive the crash: %v", err)
+	}
+
+	if _, err := s3c.GetBucketEncryption(ctx, &s3.GetBucketEncryptionInput{Bucket: aws.String("durable")}); err != nil {
+		t.Fatalf("bucket encryption did not survive the crash: %v", err)
+	}
+
+	iamc := iamClient(t, p.aws)
+	if _, err := iamc.GetRolePolicy(ctx, &iam.GetRolePolicyInput{
+		RoleName: aws.String("durable-role"), PolicyName: aws.String("inline-durable"),
+	}); err != nil {
+		t.Fatalf("IAM inline role policy did not survive the crash: %v", err)
+	}
+
+	gcs := gcsClient(t, p.gcp)
+	defer gcs.Close()
+
+	if _, err := gcs.Bucket("gcp-durable").Attrs(ctx); err != nil {
+		t.Fatalf("GCP bucket did not survive the crash: %v", err)
+	}
+
+	assertAzureContainerExists(t, p.azure)
+}
+
+// azblobClient builds an azblob service client for the emulator's self-signed
+// HTTPS endpoint, using anonymous credentials (the emulator does not verify SAS
+// or SharedKey signatures).
+func azblobClient(t *testing.T, port string) *azblob.Client {
+	t.Helper()
+
+	httpClient := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // self-signed emulator cert
+	}}
+
+	c, err := azblob.NewClientWithNoCredential("https://127.0.0.1:"+port+"/", &azblob.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: httpClient, Retry: policy.RetryOptions{MaxRetries: -1}},
+	})
+	if err != nil {
+		t.Fatalf("azblob client: %v", err)
+	}
+
+	return c
+}
+
+func createAzureContainer(t *testing.T, port string) {
+	t.Helper()
+
+	if _, err := azblobClient(t, port).CreateContainer(context.Background(), "durable-container", nil); err != nil {
+		t.Fatalf("Azure CreateContainer: %v", err)
+	}
+}
+
+func assertAzureContainerExists(t *testing.T, port string) {
+	t.Helper()
+
+	cc := azblobClient(t, port).ServiceClient().NewContainerClient("durable-container")
+	if _, err := cc.GetProperties(context.Background(), nil); err != nil {
+		t.Fatalf("Azure blob container did not survive the crash: %v", err)
+	}
+}
+
+// TestPersistCrashDurability is the #447 acceptance test: with an always-on
+// strategy, resources created via real SDKs survive a SIGKILL (no graceful
+// shutdown) and a restart — which today's shutdown-only --persist loses entirely.
+// It runs for both scheduled and on-request, and asserts the S3/IAM
+// Get-then-mutate writes (caught only by the request-boundary seam) survive too.
+func TestPersistCrashDurability(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and execs a binary; skipped in -short")
+	}
+
+	bin := buildServeBinary(t)
+
+	for _, strategy := range []string{"scheduled", "on-request"} {
+		t.Run(strategy, func(t *testing.T) {
+			p := durabilityPorts{
+				aws:   freePort(t),
+				gcp:   freePort(t),
+				azure: freePort(t),
+				state: filepath.Join(t.TempDir(), "state.json"),
+			}
+
+			cmd := startServe(t, bin, p, strategy, "150ms")
+			createDurableResources(t, p)
+
+			// Wait for a background save to land BEFORE the hard kill — this is the
+			// durability window under test. Both the bucket and the IAM inline
+			// policy must be on disk.
+			// Wait for a marker from every provider's last-created resource, so the
+			// save that landed captured them all before the hard kill.
+			waitFileContains(t, p.state, "inline-durable", 5*time.Second)    // AWS (S3 + IAM)
+			waitFileContains(t, p.state, "gcp-durable", 5*time.Second)       // GCP
+			waitFileContains(t, p.state, "durable-container", 5*time.Second) // Azure
+
+			killHard(t, cmd)
+
+			cmd2 := startServe(t, bin, p, strategy, "150ms")
+			defer killHard(t, cmd2)
+
+			assertDurableResourcesSurvive(t, p)
+		})
+	}
+}
+
+// TestPersistManualDoesNotAutoSave locks the manual contract end to end: nothing
+// is saved automatically, and — the regression guard for the replaced
+// unconditional shutdown save — nothing is saved even on a graceful SIGTERM
+// shutdown.
+func TestPersistManualDoesNotAutoSave(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and execs a binary; skipped in -short")
+	}
+
+	bin := buildServeBinary(t)
+	p := durabilityPorts{
+		aws:   freePort(t),
+		gcp:   freePort(t),
+		azure: freePort(t),
+		state: filepath.Join(t.TempDir(), "state.json"),
+	}
+
+	cmd := startServe(t, bin, p, "manual", "50ms")
+
+	s3c := s3Client(t, p.aws)
+	if _, err := s3c.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: aws.String("manual-bucket")}); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	// Give any (wrongly-present) periodic saver time to fire.
+	time.Sleep(300 * time.Millisecond)
+
+	// Graceful shutdown: manual must still NOT save.
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	_ = cmd.Wait()
+
+	if b, err := os.ReadFile(p.state); err == nil && strings.Contains(string(b), "manual-bucket") {
+		t.Fatalf("manual strategy saved state to disk (bucket present); it must never auto-save")
+	}
+}
+
+// TestPersistAdminRestoreSurvivesCrash proves the explicit dirty-set in
+// App.restore: a POST /_cloudemu/snapshot restore, with NO subsequent provider
+// request, is persisted on the next tick and survives a SIGKILL — the
+// admin-surface analogue of the Get-then-mutate hole.
+func TestPersistAdminRestoreSurvivesCrash(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and execs a binary; skipped in -short")
+	}
+
+	bin := buildServeBinary(t)
+	p := durabilityPorts{
+		aws:   freePort(t),
+		gcp:   freePort(t),
+		azure: freePort(t),
+		state: filepath.Join(t.TempDir(), "state.json"),
+	}
+
+	cmd := startServe(t, bin, p, "scheduled", "150ms")
+	awsBase := "http://127.0.0.1:" + p.aws
+
+	// Seed a bucket, then capture the whole-emulator snapshot JSON.
+	s3c := s3Client(t, p.aws)
+	if _, err := s3c.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: aws.String("restore-src")}); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	snapshot := httpGet(t, awsBase+"/_cloudemu/snapshot")
+
+	// Wipe, then restore from the captured snapshot. The restore is the LAST
+	// state-mutating call — no provider request follows it.
+	httpPost(t, awsBase+"/_cloudemu/reset", nil)
+	httpPost(t, awsBase+"/_cloudemu/snapshot", snapshot)
+
+	// The restore marked state dirty, so the scheduled tick persists it.
+	waitFileContains(t, p.state, "restore-src", 5*time.Second)
+
+	killHard(t, cmd)
+
+	cmd2 := startServe(t, bin, p, "scheduled", "150ms")
+	defer killHard(t, cmd2)
+
+	s3c2 := s3Client(t, p.aws)
+	out, err := s3c2.ListBuckets(context.Background(), &s3.ListBucketsInput{})
+	if err != nil {
+		t.Fatalf("ListBuckets after restart: %v", err)
+	}
+
+	var found bool
+
+	for _, b := range out.Buckets {
+		if aws.ToString(b.Name) == "restore-src" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatal("restored bucket did not survive the crash; App.restore did not mark state dirty")
+	}
+}
+
+func httpGet(t *testing.T, url string) []byte {
+	t.Helper()
+
+	resp, err := http.Get(url) //nolint:noctx // short-lived in-process test call
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s = %d: %s", url, resp.StatusCode, b)
+	}
+
+	return b
+}
+
+func httpPost(t *testing.T, url string, body []byte) {
+	t.Helper()
+
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body)) //nolint:noctx // short-lived in-process test call
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST %s = %d: %s", url, resp.StatusCode, b)
+	}
+}

--- a/cmd/cloudemu/persist_durability_test.go
+++ b/cmd/cloudemu/persist_durability_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"io"
 	"net/http"
 	"os"
@@ -42,7 +43,7 @@ func buildServeBinary(t *testing.T) string {
 
 // durabilityPorts is one run's endpoint ports plus its persistent state file.
 type durabilityPorts struct {
-	aws, gcp, azure, state string
+	aws, gcp, azure, oci, state string
 }
 
 // startServe launches `cloudemu serve` with the given persistence settings and
@@ -52,9 +53,11 @@ func startServe(t *testing.T, bin string, p durabilityPorts, strategy, interval 
 
 	cmd := exec.Command(bin, "serve",
 		"--host", "127.0.0.1",
+		"--providers", "aws,azure,gcp,oci",
 		"--aws-port", p.aws,
 		"--gcp-port", p.gcp,
 		"--azure-port", p.azure,
+		"--oci-port", p.oci,
 		"--k8s-port", "",
 		"--quiet",
 		"--persist",
@@ -150,6 +153,15 @@ const durableBucketPolicy = `{"Version":"2012-10-17","Statement":[{"Sid":"AllowG
 
 const durableRolePolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}`
 
+// durableObjectKey/Body is an S3 object WITH a non-empty body. It is the crux of
+// the object-body durability case: a metadata-only periodic save would restore
+// this key reporting its old Size via HEAD/List but return an EMPTY body via GET.
+// With bodies persisted by default, GET must return these exact bytes.
+const (
+	durableObjectKey  = "durable-object.txt"
+	durableObjectBody = "hello-durable-body-42"
+)
+
 // createDurableResources drives real SDK mutations across AWS/GCP/Azure,
 // including the S3 and IAM Get-then-mutate sub-resource writes the request seam
 // must catch (they never call a memstore mutator).
@@ -188,6 +200,14 @@ func createDurableResources(t *testing.T, p durabilityPorts) {
 		t.Fatalf("PutBucketEncryption: %v", err)
 	}
 
+	if _, err := s3c.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String("durable"),
+		Key:    aws.String(durableObjectKey),
+		Body:   strings.NewReader(durableObjectBody),
+	}); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
 	iamc := iamClient(t, p.aws)
 	if _, err := iamc.CreateRole(ctx, &iam.CreateRoleInput{
 		RoleName:                 aws.String("durable-role"),
@@ -212,6 +232,7 @@ func createDurableResources(t *testing.T, p durabilityPorts) {
 	}
 
 	createAzureContainer(t, p.azure)
+	createOCIVCN(t, p.oci)
 }
 
 // assertDurableResourcesSurvive re-reads every resource after a crash+restart and
@@ -234,6 +255,8 @@ func assertDurableResourcesSurvive(t *testing.T, p durabilityPorts) {
 		t.Fatalf("bucket encryption did not survive the crash: %v", err)
 	}
 
+	assertDurableObjectBodySurvives(t, s3c)
+
 	iamc := iamClient(t, p.aws)
 	if _, err := iamc.GetRolePolicy(ctx, &iam.GetRolePolicyInput{
 		RoleName: aws.String("durable-role"), PolicyName: aws.String("inline-durable"),
@@ -249,6 +272,120 @@ func assertDurableResourcesSurvive(t *testing.T, p durabilityPorts) {
 	}
 
 	assertAzureContainerExists(t, p.azure)
+	assertOCIVCNExists(t, p.oci)
+}
+
+// assertDurableObjectBodySurvives is the FIX-1 check: the restored object must
+// return its ORIGINAL bytes via GET (not an empty body), and HEAD/List must
+// report a size matching those bytes — no size/empty mismatch after a crash.
+func assertDurableObjectBodySurvives(t *testing.T, s3c *s3.Client) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	got, err := s3c.GetObject(ctx, &s3.GetObjectInput{Bucket: aws.String("durable"), Key: aws.String(durableObjectKey)})
+	if err != nil {
+		t.Fatalf("GetObject after crash: %v", err)
+	}
+
+	body, err := io.ReadAll(got.Body)
+	_ = got.Body.Close()
+
+	if err != nil {
+		t.Fatalf("read restored object body: %v", err)
+	}
+
+	if string(body) != durableObjectBody {
+		t.Fatalf("restored object body = %q, want %q (bodies must be crash-safe by default)", body, durableObjectBody)
+	}
+
+	// HEAD size must match the restored body — the mismatch this fix closes.
+	head, err := s3c.HeadObject(ctx, &s3.HeadObjectInput{Bucket: aws.String("durable"), Key: aws.String(durableObjectKey)})
+	if err != nil {
+		t.Fatalf("HeadObject after crash: %v", err)
+	}
+
+	if aws.ToInt64(head.ContentLength) != int64(len(durableObjectBody)) {
+		t.Fatalf("HEAD size = %d, want %d (restored body length)", aws.ToInt64(head.ContentLength), len(durableObjectBody))
+	}
+
+	// List size must match too.
+	list, err := s3c.ListObjectsV2(ctx, &s3.ListObjectsV2Input{Bucket: aws.String("durable"), Prefix: aws.String(durableObjectKey)})
+	if err != nil {
+		t.Fatalf("ListObjectsV2 after crash: %v", err)
+	}
+
+	var found bool
+
+	for _, o := range list.Contents {
+		if aws.ToString(o.Key) == durableObjectKey {
+			found = true
+
+			if aws.ToInt64(o.Size) != int64(len(durableObjectBody)) {
+				t.Fatalf("List size = %d, want %d (restored body length)", aws.ToInt64(o.Size), len(durableObjectBody))
+			}
+		}
+	}
+
+	if !found {
+		t.Fatalf("restored object %q missing from List", durableObjectKey)
+	}
+}
+
+// createOCIVCN creates a VCN through the OCI wire REST API — the 4th wired
+// provider, whose wrapDirty + SnapshotServices path was previously untested for
+// SIGKILL durability.
+func createOCIVCN(t *testing.T, port string) {
+	t.Helper()
+
+	body := `{"compartmentId":"ocid1.compartment.oc1..durable","cidrBlock":"10.77.0.0/16","displayName":"oci-durable-vcn"}`
+
+	resp, err := http.Post("http://127.0.0.1:"+port+"/20160918/vcns", "application/json", strings.NewReader(body)) //nolint:noctx // short-lived test call
+	if err != nil {
+		t.Fatalf("OCI CreateVcn: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("OCI CreateVcn = %d: %s", resp.StatusCode, b)
+	}
+}
+
+// assertOCIVCNExists lists VCNs in the durable compartment and fails if the one
+// created before the crash is gone. Compartment scope is itself persisted, so the
+// scoped list resolves after a restart.
+func assertOCIVCNExists(t *testing.T, port string) {
+	t.Helper()
+
+	url := "http://127.0.0.1:" + port + "/20160918/vcns?compartmentId=ocid1.compartment.oc1..durable"
+
+	resp, err := http.Get(url) //nolint:noctx // short-lived test call
+	if err != nil {
+		t.Fatalf("OCI ListVcns: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("OCI ListVcns = %d: %s", resp.StatusCode, b)
+	}
+
+	var vcns []struct {
+		DisplayName string `json:"displayName"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&vcns); err != nil {
+		t.Fatalf("decode OCI ListVcns: %v", err)
+	}
+
+	for _, v := range vcns {
+		if v.DisplayName == "oci-durable-vcn" {
+			return
+		}
+	}
+
+	t.Fatal("OCI VCN did not survive the crash")
 }
 
 // azblobClient builds an azblob service client for the emulator's self-signed
@@ -306,6 +443,7 @@ func TestPersistCrashDurability(t *testing.T) {
 				aws:   freePort(t),
 				gcp:   freePort(t),
 				azure: freePort(t),
+				oci:   freePort(t),
 				state: filepath.Join(t.TempDir(), "state.json"),
 			}
 
@@ -317,9 +455,11 @@ func TestPersistCrashDurability(t *testing.T) {
 			// policy must be on disk.
 			// Wait for a marker from every provider's last-created resource, so the
 			// save that landed captured them all before the hard kill.
+			waitFileContains(t, p.state, durableObjectKey, 5*time.Second)    // AWS (S3 object body)
 			waitFileContains(t, p.state, "inline-durable", 5*time.Second)    // AWS (S3 + IAM)
 			waitFileContains(t, p.state, "gcp-durable", 5*time.Second)       // GCP
 			waitFileContains(t, p.state, "durable-container", 5*time.Second) // Azure
+			waitFileContains(t, p.state, "oci-durable-vcn", 5*time.Second)   // OCI
 
 			killHard(t, cmd)
 
@@ -345,6 +485,7 @@ func TestPersistManualDoesNotAutoSave(t *testing.T) {
 		aws:   freePort(t),
 		gcp:   freePort(t),
 		azure: freePort(t),
+		oci:   freePort(t),
 		state: filepath.Join(t.TempDir(), "state.json"),
 	}
 
@@ -381,6 +522,7 @@ func TestPersistAdminRestoreSurvivesCrash(t *testing.T) {
 		aws:   freePort(t),
 		gcp:   freePort(t),
 		azure: freePort(t),
+		oci:   freePort(t),
 		state: filepath.Join(t.TempDir(), "state.json"),
 	}
 

--- a/cmd/cloudemu/persist_flags_test.go
+++ b/cmd/cloudemu/persist_flags_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/server/serverkit"
+)
+
+// TestServePersistFlagDefaults pins the persist-strategy/persist-interval flag
+// names and defaults to the shared serverkit constants. contrib/server has the
+// mirror test asserting the SAME constants, so the two entrypoints cannot drift.
+func TestServePersistFlagDefaults(t *testing.T) {
+	t.Setenv("CLOUDEMU_PERSIST_STRATEGY", "")
+	t.Setenv("CLOUDEMU_PERSIST_INTERVAL", "")
+
+	var c serveConfig
+	fs := newServeFlagSet(&c)
+
+	strat := fs.Lookup("persist-strategy")
+	if strat == nil {
+		t.Fatal("--persist-strategy not registered")
+	}
+
+	if strat.DefValue != serverkit.DefaultPersistStrategy {
+		t.Fatalf("persist-strategy default = %q, want %q", strat.DefValue, serverkit.DefaultPersistStrategy)
+	}
+
+	iv := fs.Lookup("persist-interval")
+	if iv == nil {
+		t.Fatal("--persist-interval not registered")
+	}
+
+	if iv.DefValue != serverkit.DefaultPersistInterval.String() {
+		t.Fatalf("persist-interval default = %q, want %q", iv.DefValue, serverkit.DefaultPersistInterval.String())
+	}
+
+	// The flags flow through to the config.
+	if err := fs.Parse([]string{"--persist-strategy", "on-request", "--persist-interval", "3s"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if c.persistStrategy != "on-request" {
+		t.Fatalf("parsed strategy = %q, want on-request", c.persistStrategy)
+	}
+
+	if c.persistInterval.String() != "3s" {
+		t.Fatalf("parsed interval = %q, want 3s", c.persistInterval)
+	}
+}

--- a/cmd/cloudemu/serve.go
+++ b/cmd/cloudemu/serve.go
@@ -44,6 +44,8 @@ type serveConfig struct {
 	persist           bool
 	stateFile         string
 	persistMetaOnly   bool
+	persistStrategy   string
+	persistInterval   time.Duration
 	initDir           string
 	enforceAuth       bool
 }
@@ -58,8 +60,46 @@ func (s *stringList) Set(v string) error {
 }
 
 func runServe(args []string) error {
-	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	var c serveConfig
+
+	fs := newServeFlagSet(&c)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if (c.tlsCert == "") != (c.tlsKey == "") {
+		return errors.New("--tls-cert and --tls-key must be given together")
+	}
+
+	if c.persist && c.stateFile == "" {
+		return errStateFileRequired
+	}
+
+	warnPersistFlagsWithoutPersist(fs, &c)
+
+	sel, err := parseProviders(c.providers)
+	if err != nil {
+		return err
+	}
+
+	cfg := c.toServerkitConfig(sel)
+
+	app, err := serverkit.New(&cfg)
+	if err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	return app.Serve(ctx)
+}
+
+// newServeFlagSet registers every serve flag against c and returns the flag set.
+// Splitting registration out of runServe lets tests inspect flag names/defaults
+// (the cross-entrypoint parity guard) without executing a server.
+func newServeFlagSet(c *serveConfig) *flag.FlagSet {
+	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	// OCI is not started by default: it stays opt-in until its services land, so
 	// the default set never binds a port that serves nothing.
 	fs.StringVar(&c.providers, "providers", "aws,azure,gcp", "comma-separated providers to start: aws,azure,gcp,oci")
@@ -89,6 +129,11 @@ func runServe(args []string) error {
 	fs.BoolVar(&c.persist, "persist", false, "save state to --state-file on shutdown and restore it on startup (includes object bodies)")
 	fs.StringVar(&c.stateFile, "state-file", "", "path to the JSON state snapshot (required with --persist)")
 	fs.BoolVar(&c.persistMetaOnly, "persist-metadata-only", false, "persist resource structure but omit object bodies (smaller snapshot)")
+	fs.StringVar(&c.persistStrategy, "persist-strategy", envOr("CLOUDEMU_PERSIST_STRATEGY", serverkit.DefaultPersistStrategy),
+		"when to save with --persist: scheduled|on-request|on-shutdown|manual (env CLOUDEMU_PERSIST_STRATEGY)")
+	fs.DurationVar(&c.persistInterval, "persist-interval",
+		envDurationOr("CLOUDEMU_PERSIST_INTERVAL", serverkit.DefaultPersistInterval),
+		"save cadence for --persist-strategy=scheduled (env CLOUDEMU_PERSIST_INTERVAL)")
 	fs.StringVar(&c.initDir, "init-dir", "", "apply every *.json seed fixture in this directory on startup")
 	fs.BoolVar(&c.enforceAuth, "enforce-auth", false,
 		"require authentication on each request; off by default. AWS: verify the SigV4 signature against a registered IAM access "+
@@ -101,22 +146,14 @@ func runServe(args []string) error {
 		fmt.Fprintf(fs.Output(), "Usage: cloudemu serve [flags]\n\nStart the standalone emulator. Flags:\n")
 		fs.PrintDefaults()
 	}
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-	if (c.tlsCert == "") != (c.tlsKey == "") {
-		return errors.New("--tls-cert and --tls-key must be given together")
-	}
-	if c.persist && c.stateFile == "" {
-		return errStateFileRequired
-	}
 
-	sel, err := parseProviders(c.providers)
-	if err != nil {
-		return err
-	}
+	return fs
+}
 
-	cfg := serverkit.Config{
+// toServerkitConfig maps the resolved serve flags onto a serverkit.Config for
+// the given provider selection.
+func (c *serveConfig) toServerkitConfig(sel []string) serverkit.Config {
+	return serverkit.Config{
 		Providers: sel,
 		Host:      c.host,
 		Ports: map[string]string{
@@ -132,6 +169,8 @@ func runServe(args []string) error {
 		Persist:             c.persist,
 		StateFile:           c.stateFile,
 		PersistMetadataOnly: c.persistMetaOnly,
+		PersistStrategy:     c.persistStrategy,
+		PersistInterval:     c.persistInterval,
 		InitDir:             c.initDir,
 		TLSCert:             c.tlsCert,
 		TLSKey:              c.tlsKey,
@@ -149,16 +188,49 @@ func runServe(args []string) error {
 		},
 		Out: os.Stdout,
 	}
+}
 
-	app, err := serverkit.New(&cfg)
-	if err != nil {
-		return err
+// warnPersistFlagsWithoutPersist prints a one-line warning when a persist-tuning
+// flag was set explicitly but --persist is off, so the ignored knob is visible.
+func warnPersistFlagsWithoutPersist(fs *flag.FlagSet, c *serveConfig) {
+	if c.persist {
+		return
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
+	set := map[string]bool{}
 
-	return app.Serve(ctx)
+	fs.Visit(func(f *flag.Flag) { set[f.Name] = true })
+
+	for _, name := range []string{"persist-strategy", "persist-interval", "persist-metadata-only"} {
+		if set[name] {
+			fmt.Fprintf(os.Stderr, "warning: --%s has no effect without --persist\n", name)
+		}
+	}
+}
+
+// envOr returns the environment value for key, or def when it is unset/empty.
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+
+	return def
+}
+
+// envDurationOr parses the environment value for key as a duration, or returns
+// def when it is unset/empty/unparseable.
+func envDurationOr(key string, def time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return def
+	}
+
+	return d
 }
 
 func parseProviders(s string) ([]string, error) {

--- a/contrib/server/app.go
+++ b/contrib/server/app.go
@@ -61,6 +61,8 @@ func serverkitConfig(cfg *appConfig, opts []config.Option) *serverkit.Config {
 		Persist:             cfg.persist,
 		StateFile:           cfg.stateFile,
 		PersistMetadataOnly: cfg.persistMetaOnly,
+		PersistStrategy:     cfg.persistStrategy,
+		PersistInterval:     cfg.persistInterval,
 		InitDir:             cfg.initDir,
 		TLSCert:             cfg.tlsCert,
 		TLSKey:              cfg.tlsKey,

--- a/contrib/server/main.go
+++ b/contrib/server/main.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/stackshy/cloudemu/v2/server/serverkit"
 )
 
 // defaultShutdownTimeout is the grace period for in-flight requests.
@@ -78,6 +80,8 @@ type appConfig struct {
 	persist         bool
 	stateFile       string
 	persistMetaOnly bool
+	persistStrategy string
+	persistInterval time.Duration
 	initDir         string
 	endpointsFile   string
 
@@ -181,11 +185,7 @@ func parseFlags(args []string, getenv func(string) string, out io.Writer) (appCo
 	fs.BoolVar(&cfg.logRequests, "log-requests", false, "log every HTTP request (method, path, status, duration)")
 	fs.BoolVar(&cfg.quiet, "quiet", false, "suppress the startup banner")
 	fs.BoolVar(&cfg.enforceAuth, "enforce-auth", false, "require authentication on each request; off by default")
-	fs.BoolVar(&cfg.persist, "persist", false,
-		"save state to --state-file on shutdown and restore it on startup (includes object bodies)")
-	fs.StringVar(&cfg.stateFile, "state-file", "", "path to the JSON state snapshot (required with --persist)")
-	fs.BoolVar(&cfg.persistMetaOnly, "persist-metadata-only", false,
-		"persist resource structure but omit object bodies (smaller snapshot)")
+	registerPersistFlags(fs, &cfg, getenv)
 	fs.StringVar(&cfg.initDir, "init-dir", "", "apply every *.json seed fixture in this directory on startup")
 	fs.StringVar(&cfg.endpointsFile, "endpoints-file", "", "write the resolved endpoints as JSON to this path")
 
@@ -214,6 +214,8 @@ func parseFlags(args []string, getenv func(string) string, out io.Writer) (appCo
 	if cfg.persist && cfg.stateFile == "" {
 		return appConfig{}, errStateFileRequired
 	}
+
+	warnPersistFlagsWithoutPersist(fs, &cfg, out)
 
 	return cfg, nil
 }
@@ -258,6 +260,66 @@ func engineEnvOr(getenv func(string) string, key string) string {
 	}
 
 	return engineOff
+}
+
+// registerPersistFlags registers the persistence flag group against cfg, keeping
+// parseFlags under the statement limit and grouping the knobs that only matter
+// with --persist.
+func registerPersistFlags(fs *flag.FlagSet, cfg *appConfig, getenv func(string) string) {
+	fs.BoolVar(&cfg.persist, "persist", false,
+		"save state to --state-file on shutdown and restore it on startup (includes object bodies)")
+	fs.StringVar(&cfg.stateFile, "state-file", "", "path to the JSON state snapshot (required with --persist)")
+	fs.BoolVar(&cfg.persistMetaOnly, "persist-metadata-only", false,
+		"persist resource structure but omit object bodies (smaller snapshot)")
+	fs.StringVar(&cfg.persistStrategy, "persist-strategy",
+		envStrOr(getenv, "CLOUDEMU_PERSIST_STRATEGY", serverkit.DefaultPersistStrategy),
+		"when to save with --persist: scheduled|on-request|on-shutdown|manual (env CLOUDEMU_PERSIST_STRATEGY)")
+	fs.DurationVar(&cfg.persistInterval, "persist-interval",
+		envDurationOr(getenv, "CLOUDEMU_PERSIST_INTERVAL", serverkit.DefaultPersistInterval),
+		"save cadence for --persist-strategy=scheduled (env CLOUDEMU_PERSIST_INTERVAL)")
+}
+
+// envStrOr returns the environment value for key, or def when it is unset/empty.
+func envStrOr(getenv func(string) string, key, def string) string {
+	if v := getenv(key); v != "" {
+		return v
+	}
+
+	return def
+}
+
+// envDurationOr parses the environment value for key as a duration, or returns
+// def when it is unset/empty/unparseable.
+func envDurationOr(getenv func(string) string, key string, def time.Duration) time.Duration {
+	v := getenv(key)
+	if v == "" {
+		return def
+	}
+
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return def
+	}
+
+	return d
+}
+
+// warnPersistFlagsWithoutPersist prints a warning for each persist-tuning flag
+// set explicitly while --persist is off, so the ignored knob is visible.
+func warnPersistFlagsWithoutPersist(fs *flag.FlagSet, cfg *appConfig, stderr io.Writer) {
+	if cfg.persist {
+		return
+	}
+
+	set := map[string]bool{}
+
+	fs.Visit(func(f *flag.Flag) { set[f.Name] = true })
+
+	for _, name := range []string{"persist-strategy", "persist-interval", "persist-metadata-only"} {
+		if set[name] {
+			fmt.Fprintf(stderr, "warning: --%s has no effect without --persist\n", name)
+		}
+	}
 }
 
 // printEngineModes prints the resolved per-capability engine MODE table.

--- a/contrib/server/persist_flags_test.go
+++ b/contrib/server/persist_flags_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/server/serverkit"
+)
+
+// TestPersistFlagDefaults pins the persist-strategy/persist-interval defaults to
+// the shared serverkit constants — the mirror of cmd/cloudemu's test, so the two
+// entrypoints stay in lockstep even though they live in separate modules.
+func TestPersistFlagDefaults(t *testing.T) {
+	getenv := func(string) string { return "" }
+
+	cfg, err := parseFlags(nil, getenv, io.Discard)
+	if err != nil {
+		t.Fatalf("parseFlags: %v", err)
+	}
+
+	if cfg.persistStrategy != serverkit.DefaultPersistStrategy {
+		t.Fatalf("default strategy = %q, want %q", cfg.persistStrategy, serverkit.DefaultPersistStrategy)
+	}
+
+	if cfg.persistInterval != serverkit.DefaultPersistInterval {
+		t.Fatalf("default interval = %v, want %v", cfg.persistInterval, serverkit.DefaultPersistInterval)
+	}
+
+	// Overrides flow through.
+	over, err := parseFlags([]string{"--persist-strategy", "manual", "--persist-interval", "7s"}, getenv, io.Discard)
+	if err != nil {
+		t.Fatalf("parseFlags(override): %v", err)
+	}
+
+	if over.persistStrategy != "manual" {
+		t.Fatalf("override strategy = %q, want manual", over.persistStrategy)
+	}
+
+	if over.persistInterval.String() != "7s" {
+		t.Fatalf("override interval = %v, want 7s", over.persistInterval)
+	}
+
+	// Env fallback is honored when the flag is absent.
+	envGet := func(k string) string {
+		switch k {
+		case "CLOUDEMU_PERSIST_STRATEGY":
+			return "on-request"
+		case "CLOUDEMU_PERSIST_INTERVAL":
+			return "2s"
+		default:
+			return ""
+		}
+	}
+
+	fromEnv, err := parseFlags(nil, envGet, io.Discard)
+	if err != nil {
+		t.Fatalf("parseFlags(env): %v", err)
+	}
+
+	if fromEnv.persistStrategy != "on-request" {
+		t.Fatalf("env strategy = %q, want on-request", fromEnv.persistStrategy)
+	}
+
+	if fromEnv.persistInterval.String() != "2s" {
+		t.Fatalf("env interval = %v, want 2s", fromEnv.persistInterval)
+	}
+}

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -86,11 +86,12 @@ A few properties worth knowing:
 - At most **one save is in flight** at a time; signals arriving mid-save are
   coalesced and re-checked when it returns, so a save slower than the interval
   never piles up.
-- Periodic/`on-request` saves default to **metadata-only** to bound the cost of
-  re-serializing large object bodies every interval; the final shutdown save
-  honors `--persist-metadata-only` as before. If you need object bodies to be
-  crash-durable at every save, this is a known limit (a content-addressed blob
-  store is a planned follow-up).
+- **Object bodies are persisted on every save by default** — background,
+  on-request, and shutdown saves all include object bodies, so an S3 object is
+  crash-safe (restored with its contents, not as an empty key), matching
+  LocalStack. Pass `--persist-metadata-only` to drop bodies from every save for a
+  smaller/faster snapshot; restored objects then come back as zero-byte keys until
+  re-uploaded.
 
 ### Crash-safe writes
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -29,13 +29,13 @@ provider (schema version 3).
 | Export or replace the whole state over HTTP | `GET`/`POST /_cloudemu/snapshot` |
 | Save/restore state from Go code | the [`persist`](https://pkg.go.dev/github.com/stackshy/cloudemu/v2/persist) package |
 
-## `--persist` (auto save on stop, restore on start)
+## `--persist` (always-on durability)
 
 Pass `--persist` to the background server and your resources survive a
-`stop`→`start` cycle:
+`stop`→`start` cycle **and a crash**:
 
 ```sh
-cloudemu start --persist          # save on stop, restore on start
+cloudemu start --persist          # save periodically + on stop, restore on start
 # create buckets / tables / instances / secrets …
 cloudemu stop                     # writes <run-dir>/snapshot.json
 cloudemu start --persist          # your resources are back, same IDs
@@ -54,13 +54,67 @@ By default the snapshot **includes object bodies** (an S3 object comes back with
 its contents). `--persist-metadata-only` keeps only the resource structure for a
 smaller file; restored objects then come back as zero-byte keys until re-uploaded.
 
-Snapshot writes are **crash-safe**: the file is written to a temp file, `fsync`ed,
-`rename`d atomically onto the target, and the parent directory is then `fsync`ed —
-so an interrupted or power-lost write leaves the previous snapshot (or none) but
-never a truncated/empty state file. On **macOS** this is best-effort: Go's
-`File.Sync` issues `fsync(2)`, which does not flush the drive's own write cache
-(a true device flush needs `fcntl(F_FULLFSYNC)`, not issued here), so darwin gives
-no hard power-loss guarantee.
+### Save strategy (`--persist-strategy`, `--persist-interval`)
+
+`--persist` is **always-on** by default: it saves in the background while the
+server runs, so a `kill -9`, panic, OOM, or power loss loses **at most the last
+interval's** worth of changes — not everything since boot. Choose *when* to save
+with `--persist-strategy` (env `CLOUDEMU_PERSIST_STRATEGY`):
+
+| Strategy | When it saves | Loss window on a hard crash |
+|----------|---------------|-----------------------------|
+| `scheduled` *(default)* | every `--persist-interval` (default `15s`) if state changed, plus on shutdown | ≤ interval |
+| `on-request` | shortly after mutations settle, and at least once per second under a continuous write stream, plus on shutdown | ≤ ~1s |
+| `on-shutdown` | only on graceful shutdown (the pre-1.x behavior) | everything since boot |
+| `manual` | never automatically — only `snapshot`/`POST /_cloudemu/snapshot` | everything not manually saved |
+
+```sh
+cloudemu serve --persist --state-file ./state.json                        # scheduled, 15s
+cloudemu serve --persist --state-file ./state.json --persist-interval 5s  # scheduled, 5s
+cloudemu serve --persist --state-file ./state.json --persist-strategy on-request
+cloudemu serve --persist --state-file ./state.json --persist-strategy manual
+```
+
+The strategy flags are meaningful only with `--persist` (a warning is printed if
+they are set without it). Both `cloudemu serve` and the batteries-included
+`cloudemu-server` accept the same flags and env vars.
+
+A few properties worth knowing:
+
+- Saves run on a **background goroutine** — never in the request path, so
+  `on-request` (unlike LocalStack's `ON_REQUEST`) never blocks a client call.
+- At most **one save is in flight** at a time; signals arriving mid-save are
+  coalesced and re-checked when it returns, so a save slower than the interval
+  never piles up.
+- Periodic/`on-request` saves default to **metadata-only** to bound the cost of
+  re-serializing large object bodies every interval; the final shutdown save
+  honors `--persist-metadata-only` as before. If you need object bodies to be
+  crash-durable at every save, this is a known limit (a content-addressed blob
+  store is a planned follow-up).
+
+### Crash-safe writes
+
+Each save is written **atomically**: to a temp file, `fsync`ed, `rename`d onto the
+target, and the parent directory is then `fsync`ed — so an interrupted or
+power-lost write leaves the previous snapshot (or none) but never a
+truncated/empty state file. On **macOS** this is best-effort: Go's `File.Sync`
+issues `fsync(2)`, which does not flush the drive's own write cache (a true device
+flush needs `fcntl(F_FULLFSYNC)`, not issued here), so darwin gives no hard
+power-loss guarantee.
+
+### Known limit: Kubernetes data-plane
+
+Crash-safety covers **cloud-provider state** (AWS/Azure/GCP/OCI). The shared
+**Kubernetes data-plane** (pods/deployments created via EKS/AKS/GKE) is not part
+of the snapshot surface and is **not persisted** — before or after a crash. This
+is a pre-existing coverage gap; making the data-plane snapshottable is tracked
+separately.
+
+### vs LocalStack
+
+LocalStack gates state persistence behind its **paid** tier; CloudEmu's is
+**free**. The strategy matrix mirrors LocalStack's `SNAPSHOT_SAVE_STRATEGY`
+(`SCHEDULED`/`ON_REQUEST`/`ON_SHUTDOWN`/`MANUAL`) so the mental model carries over.
 
 ## Named snapshots (`snapshot save` / `load` / `list` / `delete`)
 

--- a/docs/standalone-server.md
+++ b/docs/standalone-server.md
@@ -110,15 +110,26 @@ lifecycle commands).
 ### Persistence across restarts
 
 By default the emulator starts empty every time. Pass `--persist` to `start` and
-your resources survive `stop`→`start`:
+your resources survive `stop`→`start` **and a crash**:
 
 ```sh
-cloudemu start --persist          # save on stop, restore on start
+cloudemu start --persist          # save periodically + on stop, restore on start
 # create buckets/tables/objects…
 cloudemu stop                     # writes ~/.cloudemu/<home>/snapshot.json
 cloudemu start --persist          # your resources are back
 cloudemu delete                   # also removes the snapshot + assets
 ```
+
+`--persist` is **always-on**: it saves in the background while the server runs, so
+a `kill -9`, panic, or power loss loses at most the last save interval — not
+everything since boot. Tune *when* it saves with `--persist-strategy`
+(`scheduled` (default, every `--persist-interval`, 15s) / `on-request` /
+`on-shutdown` / `manual`) and `--persist-interval`; both also read the env vars
+`CLOUDEMU_PERSIST_STRATEGY` and `CLOUDEMU_PERSIST_INTERVAL`. Periodic saves are
+metadata-only to bound cost, and the **Kubernetes data-plane is not persisted**.
+See [persistence.md](persistence.md#save-strategy---persist-strategy---persist-interval)
+for the strategy matrix, crash-window semantics, the darwin `fsync` caveat, and
+the free-vs-paid LocalStack comparison.
 
 `start` manages the snapshot path for you (in the run dir). Persistence is
 **opt-in**; when on, it saves your resources *including* object bodies, so an S3
@@ -379,9 +390,11 @@ your client.
 | `--tls-cert` / `--tls-key` | — | supply your own Azure cert (else self-signed) |
 | `--tls-host` | — | extra SAN for the generated cert (repeatable) |
 | `--endpoints-file` | — | write resolved endpoints as JSON |
-| `--persist` | `false` | save state on shutdown and restore it on startup, including object bodies (requires `--state-file`) |
+| `--persist` | `false` | save state in the background + on shutdown, restore on startup, including object bodies (requires `--state-file`) |
 | `--state-file` | — | path to the JSON state snapshot (`start` manages this for you) |
 | `--persist-metadata-only` | `false` | persist resource structure but omit object bodies (smaller snapshot) |
+| `--persist-strategy` | `scheduled` | when to save with `--persist`: `scheduled` / `on-request` / `on-shutdown` / `manual` (env `CLOUDEMU_PERSIST_STRATEGY`) |
+| `--persist-interval` | `15s` | save cadence for `--persist-strategy=scheduled` (env `CLOUDEMU_PERSIST_INTERVAL`) |
 | `--log-requests` | `false` | log every request |
 | `--quiet` | `false` | suppress the startup banner |
 | `--shutdown-timeout` | `10s` | grace period for in-flight requests on Ctrl-C |

--- a/docs/standalone-server.md
+++ b/docs/standalone-server.md
@@ -125,8 +125,10 @@ a `kill -9`, panic, or power loss loses at most the last save interval — not
 everything since boot. Tune *when* it saves with `--persist-strategy`
 (`scheduled` (default, every `--persist-interval`, 15s) / `on-request` /
 `on-shutdown` / `manual`) and `--persist-interval`; both also read the env vars
-`CLOUDEMU_PERSIST_STRATEGY` and `CLOUDEMU_PERSIST_INTERVAL`. Periodic saves are
-metadata-only to bound cost, and the **Kubernetes data-plane is not persisted**.
+`CLOUDEMU_PERSIST_STRATEGY` and `CLOUDEMU_PERSIST_INTERVAL`. Every save —
+background, on-request, and on-shutdown — **includes object bodies** by default
+(pass `--persist-metadata-only` to drop them), so an S3 object is crash-safe with
+its contents intact; the **Kubernetes data-plane is not persisted**.
 See [persistence.md](persistence.md#save-strategy---persist-strategy---persist-interval)
 for the strategy matrix, crash-window semantics, the darwin `fsync` caveat, and
 the free-vs-paid LocalStack comparison.

--- a/server/serverkit/dirty_test.go
+++ b/server/serverkit/dirty_test.go
@@ -140,6 +140,32 @@ func TestDirtySeamAdminMutationsMarkDirty(t *testing.T) {
 	}
 }
 
+// TestWrapDirtyMarksDirtyOnPanic asserts the request seam marks state dirty even
+// when the handler panics AFTER mutating state. net/http recovers the connection
+// and unwinds past wrapDirty, so a sequential mark (rather than a deferred one)
+// would silently drop the mutation flag and a later crash would lose the change.
+func TestWrapDirtyMarksDirtyOnPanic(t *testing.T) {
+	app := newPersistTestApp(t, []string{"aws"}, map[string]string{"aws": "0"})
+	app.flusher.dirty.Store(false)
+
+	// A handler that mutates then panics.
+	panicky := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic("boom after mutation")
+	})
+	h := app.wrapDirty(panicky)
+
+	// Stand in for net/http's per-request recover, so the panic doesn't fail the
+	// test — the point is that the deferred markDirty still ran during the unwind.
+	func() {
+		defer func() { _ = recover() }()
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+	}()
+
+	if !app.flusher.dirty.Load() {
+		t.Fatal("wrapDirty did not mark state dirty when the handler panicked; the deferred markDirty is missing")
+	}
+}
+
 // TestNormalizePersistDefaultsAndValidation locks the strategy defaults and the
 // invalid-strategy rejection.
 func TestNormalizePersistDefaultsAndValidation(t *testing.T) {

--- a/server/serverkit/dirty_test.go
+++ b/server/serverkit/dirty_test.go
@@ -1,0 +1,185 @@
+package serverkit
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/persist"
+)
+
+// newPersistTestApp builds an admin-enabled, persisting App with a scheduled
+// flusher whose ticker never fires during a unit test (huge interval), so the
+// dirty flag can be observed directly without a save racing it.
+func newPersistTestApp(t *testing.T, providers []string, ports map[string]string) *App {
+	t.Helper()
+
+	app := newTestApp(t, Config{
+		Providers:       providers,
+		Host:            "127.0.0.1",
+		Ports:           ports,
+		Admin:           true,
+		Persist:         true,
+		StateFile:       t.TempDir() + "/state.json",
+		PersistStrategy: StrategyScheduled,
+		PersistInterval: time.Hour,
+		Out:             io.Discard,
+	})
+
+	return app
+}
+
+// TestDirtySeamProviderRequestMarksDirty asserts a cloud-provider request flips
+// the dirty flag (the request-boundary seam that catches Get-then-mutate), while
+// a health probe on the admin plane does NOT — so liveness checks never keep an
+// idle emulator perpetually dirty.
+func TestDirtySeamProviderRequestMarksDirty(t *testing.T) {
+	app := newPersistTestApp(t, []string{"aws"}, map[string]string{"aws": "0"})
+
+	if app.flusher.dirty.Load() {
+		t.Fatal("dirty set at boot; want clean (restore does not flow through the request seam)")
+	}
+
+	// A provider request through the wrapped backend marks dirty.
+	rec := httptest.NewRecorder()
+	app.backends["aws"].ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if !app.flusher.dirty.Load() {
+		t.Fatal("a provider request did not mark state dirty")
+	}
+
+	// Clear, then a health probe must NOT re-dirty.
+	app.flusher.dirty.Store(false)
+
+	h := app.handlerFor(app.backends["aws"], app.seedFor("aws"))
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/_cloudemu/health", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("health probe status = %d, want 200", rec.Code)
+	}
+
+	if app.flusher.dirty.Load() {
+		t.Fatal("a health probe marked state dirty; the admin/health plane must not")
+	}
+}
+
+// TestDirtySeamExcludesKubernetes asserts the Kubernetes data-plane handler is
+// deliberately NOT wrapped: k8s state is not part of persist.ExportAll, so
+// wrapping it would generate no-op saves and imply false crash-safety.
+func TestDirtySeamExcludesKubernetes(t *testing.T) {
+	app := newPersistTestApp(t, []string{"aws"}, map[string]string{"aws": "0", "k8s": "0"})
+
+	if app.k8sBackend == nil {
+		t.Fatal("precondition: k8s backend not built")
+	}
+
+	app.flusher.dirty.Store(false)
+
+	rec := httptest.NewRecorder()
+	app.k8sBackend.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/namespaces", nil))
+
+	if app.flusher.dirty.Load() {
+		t.Fatal("a Kubernetes request marked state dirty; k8s must be excluded from the dirty seam")
+	}
+}
+
+// TestDirtySeamAdminMutationsMarkDirty covers the three admin ops that bypass the
+// request seam and must set dirty explicitly: reset, seed, and restore. Missing
+// any means a mutate-then-crash on the admin surface loses the change.
+func TestDirtySeamAdminMutationsMarkDirty(t *testing.T) {
+	app := newPersistTestApp(t, []string{"aws"}, map[string]string{"aws": "0"})
+	h := app.handlerFor(app.backends["aws"], app.seedFor("aws"))
+
+	// reset
+	app.flusher.dirty.Store(false)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_cloudemu/reset", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("reset status = %d, want 200", rec.Code)
+	}
+
+	if !app.flusher.dirty.Load() {
+		t.Fatal("reset did not mark state dirty")
+	}
+
+	// seed
+	app.flusher.dirty.Store(false)
+	fixture := `{"buckets":[{"name":"seeded"}]}`
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_cloudemu/seed", strings.NewReader(fixture)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("seed status = %d, want 200", rec.Code)
+	}
+
+	if !app.flusher.dirty.Load() {
+		t.Fatal("seed did not mark state dirty")
+	}
+
+	// restore
+	app.flusher.dirty.Store(false)
+	snap := persist.Snapshot{SchemaVersion: persist.SchemaVersion}
+	body, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.restore(body); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	if !app.flusher.dirty.Load() {
+		t.Fatal("restore did not mark state dirty (restore-then-crash would lose the restored state)")
+	}
+}
+
+// TestNormalizePersistDefaultsAndValidation locks the strategy defaults and the
+// invalid-strategy rejection.
+func TestNormalizePersistDefaultsAndValidation(t *testing.T) {
+	// Off: untouched.
+	off := &Config{Persist: false}
+	if err := normalizePersist(off); err != nil {
+		t.Fatalf("normalizePersist(off) = %v, want nil", err)
+	}
+
+	if off.PersistStrategy != "" {
+		t.Fatalf("persist off should not default the strategy, got %q", off.PersistStrategy)
+	}
+
+	// On, unset: scheduled / 15s.
+	on := &Config{Persist: true}
+	if err := normalizePersist(on); err != nil {
+		t.Fatalf("normalizePersist(on) = %v, want nil", err)
+	}
+
+	if on.PersistStrategy != StrategyScheduled {
+		t.Fatalf("default strategy = %q, want %q", on.PersistStrategy, StrategyScheduled)
+	}
+
+	if on.PersistInterval != DefaultPersistInterval {
+		t.Fatalf("default interval = %v, want %v", on.PersistInterval, DefaultPersistInterval)
+	}
+
+	// Negative interval defaults.
+	neg := &Config{Persist: true, PersistStrategy: StrategyScheduled, PersistInterval: -1}
+	if err := normalizePersist(neg); err != nil {
+		t.Fatal(err)
+	}
+
+	if neg.PersistInterval != DefaultPersistInterval {
+		t.Fatalf("negative interval not defaulted: %v", neg.PersistInterval)
+	}
+
+	// Invalid strategy rejected.
+	bad := &Config{Persist: true, PersistStrategy: "bogus"}
+	if err := normalizePersist(bad); !errors.Is(err, errUnknownStrategy) {
+		t.Fatalf("normalizePersist(bogus) = %v, want errUnknownStrategy", err)
+	}
+}

--- a/server/serverkit/endpoints.go
+++ b/server/serverkit/endpoints.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 )
 
 // endpointsFileMode is the permission for the written endpoints file: a
@@ -52,9 +53,31 @@ func (e *endpointSet) sdkHints() []struct{ label, url, hint string } {
 	}
 }
 
+// persistInfo is the persistence summary shown in the startup banner.
+type persistInfo struct {
+	on        bool
+	strategy  string
+	interval  time.Duration
+	stateFile string
+}
+
+// line renders the one-line persistence summary, or "" when persistence is off.
+func (p persistInfo) line() string {
+	if !p.on {
+		return ""
+	}
+
+	switch p.strategy {
+	case StrategyScheduled:
+		return fmt.Sprintf("Persistence: %s every %s → %s", p.strategy, p.interval, p.stateFile)
+	default:
+		return fmt.Sprintf("Persistence: %s → %s", p.strategy, p.stateFile)
+	}
+}
+
 // printBanner writes the startup summary: the live endpoints and copy-paste
 // snippets for pointing each SDK at them.
-func printBanner(w io.Writer, e *endpointSet, adminOn bool) {
+func printBanner(w io.Writer, e *endpointSet, adminOn bool, persist persistInfo) {
 	fmt.Fprintln(w, "cloudemu — standalone server")
 	fmt.Fprintln(w, "────────────────────────────")
 
@@ -62,6 +85,11 @@ func printBanner(w io.Writer, e *endpointSet, adminOn bool) {
 		if row.url != "" {
 			fmt.Fprintf(w, "  %-11s %s%s\n", row.label, row.url, row.note)
 		}
+	}
+
+	if line := persist.line(); line != "" {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, line)
 	}
 
 	fmt.Fprintln(w)

--- a/server/serverkit/flusher.go
+++ b/server/serverkit/flusher.go
@@ -53,11 +53,16 @@ type saveFunc func(ctx context.Context, includeAssets bool) error
 // flusher exists only when --persist is set; when nil, every method call site
 // short-circuits.
 type flusher struct {
-	strategy    string
-	interval    time.Duration
-	debounce    time.Duration
-	maxWait     time.Duration
-	finalAssets bool // asset behavior for the shutdown save (periodic is always metadata-only)
+	strategy string
+	interval time.Duration
+	debounce time.Duration
+	maxWait  time.Duration
+	// includeAssets governs whether object bodies are written on EVERY save —
+	// periodic, on-request, and the final shutdown save alike. It is
+	// !PersistMetadataOnly, so the default persists bodies on every save (matching
+	// LocalStack and the "crash-safe" expectation) and --persist-metadata-only is
+	// the metadata-only opt-out for cost.
+	includeAssets bool
 
 	save      saveFunc
 	out       io.Writer
@@ -79,21 +84,21 @@ type flusher struct {
 // newFlusher builds a flusher for the given config. All timing knobs get their
 // defaults here; tests construct a flusher directly to shrink them.
 func newFlusher(
-	strategy string, interval time.Duration, finalAssets bool,
+	strategy string, interval time.Duration, includeAssets bool,
 	save saveFunc, out io.Writer, quiet bool, stateFile string,
 ) *flusher {
 	return &flusher{
-		strategy:    strategy,
-		interval:    interval,
-		debounce:    defaultOnRequestDebounce,
-		maxWait:     defaultOnRequestMaxWait,
-		finalAssets: finalAssets,
-		save:        save,
-		out:         out,
-		quiet:       quiet,
-		stateFile:   stateFile,
-		signalCh:    make(chan struct{}, 1),
-		stopCh:      make(chan struct{}),
+		strategy:      strategy,
+		interval:      interval,
+		debounce:      defaultOnRequestDebounce,
+		maxWait:       defaultOnRequestMaxWait,
+		includeAssets: includeAssets,
+		save:          save,
+		out:           out,
+		quiet:         quiet,
+		stateFile:     stateFile,
+		signalCh:      make(chan struct{}, 1),
+		stopCh:        make(chan struct{}),
 	}
 }
 
@@ -206,13 +211,12 @@ func (f *flusher) coalesceAndSave() bool {
 	}
 }
 
-// runSave performs one metadata-only periodic save. On failure it re-marks
-// dirty so the next tick/cycle retries, and logs a warning.
+// runSave performs one periodic/on-request save. It honors the same
+// includeAssets as the final shutdown save, so object bodies are crash-safe on
+// every save by default (and dropped only under --persist-metadata-only). On
+// failure it re-marks dirty so the next tick/cycle retries, and logs a warning.
 func (f *flusher) runSave() {
-	// Periodic saves are metadata-only to bound the cost of re-serializing large
-	// object bodies every interval; the final shutdown save honors the asset
-	// setting.
-	if err := f.save(context.Background(), false); err != nil {
+	if err := f.save(context.Background(), f.includeAssets); err != nil {
 		f.dirty.Store(true)
 		fmt.Fprintf(f.out, "warning: failed to save state to %s: %v\n", f.stateFile, err)
 	}
@@ -234,7 +238,7 @@ func (f *flusher) Stop(ctx context.Context) {
 		return
 	}
 
-	if err := f.save(ctx, f.finalAssets); err != nil {
+	if err := f.save(ctx, f.includeAssets); err != nil {
 		fmt.Fprintf(f.out, "warning: failed to save state to %s: %v\n", f.stateFile, err)
 
 		return

--- a/server/serverkit/flusher.go
+++ b/server/serverkit/flusher.go
@@ -1,0 +1,246 @@
+package serverkit
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Persistence strategies. They mirror the LocalStack SNAPSHOT_SAVE_STRATEGY
+// matrix so users moving over find the same knobs.
+const (
+	// StrategyScheduled saves on a background ticker whenever state changed
+	// since the last save, plus a final save on shutdown. The default.
+	StrategyScheduled = "scheduled"
+	// StrategyOnRequest saves shortly after mutations settle (trailing-edge
+	// coalesce) but at least once per max-wait cap under sustained writes, plus
+	// a final save on shutdown.
+	StrategyOnRequest = "on-request"
+	// StrategyOnShutdown keeps the historical behavior: save only on graceful
+	// shutdown.
+	StrategyOnShutdown = "on-shutdown"
+	// StrategyManual never saves automatically — only the admin snapshot
+	// endpoint does. It does NOT save on shutdown either.
+	StrategyManual = "manual"
+
+	// DefaultPersistStrategy is the strategy used when --persist is on but no
+	// strategy is chosen. Both entrypoints default to it, so they never drift.
+	DefaultPersistStrategy = StrategyScheduled
+	// DefaultPersistInterval is the scheduled ticker cadence when none is given.
+	DefaultPersistInterval = 15 * time.Second
+
+	// defaultOnRequestMaxWait bounds how long on-request will coalesce a
+	// continuous write stream before forcing a save, so a sustained mutation
+	// loop still flushes (a pure trailing-edge debounce never would).
+	defaultOnRequestMaxWait = 1 * time.Second
+	// defaultOnRequestDebounce is the quiet window on-request waits for after
+	// the last mutation before saving, capped by defaultOnRequestMaxWait.
+	defaultOnRequestDebounce = 50 * time.Millisecond
+)
+
+// saveFunc performs one whole-emulator snapshot to the state file. includeAssets
+// controls whether object bodies are written. It is injected so serverkit owns
+// the snapTargets locking and tests can substitute a deterministic save.
+type saveFunc func(ctx context.Context, includeAssets bool) error
+
+// flusher is the single owner of every automatic persistence save. It runs a
+// background loop (scheduled ticker or on-request coalescer), guarantees at most
+// one save is in flight at a time (single-flight), and performs the one
+// deterministic final save on Stop so no earlier save can rename over it. A
+// flusher exists only when --persist is set; when nil, every method call site
+// short-circuits.
+type flusher struct {
+	strategy    string
+	interval    time.Duration
+	debounce    time.Duration
+	maxWait     time.Duration
+	finalAssets bool // asset behavior for the shutdown save (periodic is always metadata-only)
+
+	save      saveFunc
+	out       io.Writer
+	quiet     bool
+	stateFile string
+
+	// dirty is set by markDirty on each mutating request/admin op and cleared
+	// atomically at the start of a save, so a mutation landing mid-save
+	// re-dirties and is caught by the next tick/cycle.
+	dirty atomic.Bool
+	// signalCh wakes the on-request loop; buffered(1) with non-blocking sends so
+	// markDirty never blocks a request.
+	signalCh chan struct{}
+
+	stopCh chan struct{}
+	wg     sync.WaitGroup
+}
+
+// newFlusher builds a flusher for the given config. All timing knobs get their
+// defaults here; tests construct a flusher directly to shrink them.
+func newFlusher(
+	strategy string, interval time.Duration, finalAssets bool,
+	save saveFunc, out io.Writer, quiet bool, stateFile string,
+) *flusher {
+	return &flusher{
+		strategy:    strategy,
+		interval:    interval,
+		debounce:    defaultOnRequestDebounce,
+		maxWait:     defaultOnRequestMaxWait,
+		finalAssets: finalAssets,
+		save:        save,
+		out:         out,
+		quiet:       quiet,
+		stateFile:   stateFile,
+		signalCh:    make(chan struct{}, 1),
+		stopCh:      make(chan struct{}),
+	}
+}
+
+// markDirty records that state changed. It is safe to call from any request
+// goroutine and never blocks.
+func (f *flusher) markDirty() {
+	if f == nil {
+		return
+	}
+
+	f.dirty.Store(true)
+
+	select {
+	case f.signalCh <- struct{}{}:
+	default:
+	}
+}
+
+// Start launches the background loop for strategies that save while running.
+// on-shutdown and manual have no loop — they act (or don't) only at Stop.
+func (f *flusher) Start() {
+	if f == nil {
+		return
+	}
+
+	switch f.strategy {
+	case StrategyScheduled:
+		f.wg.Add(1)
+		go f.scheduledLoop()
+	case StrategyOnRequest:
+		f.wg.Add(1)
+		go f.onRequestLoop()
+	}
+}
+
+// scheduledLoop saves on each tick when state is dirty. The dirty flag is
+// cleared before the save so a concurrent mutation re-dirties for the next tick.
+func (f *flusher) scheduledLoop() {
+	defer f.wg.Done()
+
+	t := time.NewTicker(f.interval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-f.stopCh:
+			return
+		case <-t.C:
+			if f.dirty.Swap(false) {
+				f.runSave()
+			}
+		}
+	}
+}
+
+// onRequestLoop waits for a mutation signal, then coalesces the burst before
+// saving. The single-flight save runs inside this goroutine, so a save slower
+// than the arrival rate can never overlap itself.
+func (f *flusher) onRequestLoop() {
+	defer f.wg.Done()
+
+	for {
+		select {
+		case <-f.stopCh:
+			return
+		case <-f.signalCh:
+			if !f.coalesceAndSave() {
+				return
+			}
+		}
+	}
+}
+
+// coalesceAndSave, entered after a first mutation signal, waits for the write
+// stream to go quiet (debounce) but no longer than maxWait, then performs one
+// save. It returns false if Stop was requested mid-coalesce (loop should exit).
+func (f *flusher) coalesceAndSave() bool {
+	capT := time.NewTimer(f.maxWait)
+	defer capT.Stop()
+
+	deb := time.NewTimer(f.debounce)
+	defer deb.Stop()
+
+	for {
+		select {
+		case <-f.stopCh:
+			return false
+		case <-f.signalCh:
+			// More mutations arrived: extend the quiet window, but never past the
+			// hard cap.
+			if !deb.Stop() {
+				select {
+				case <-deb.C:
+				default:
+				}
+			}
+
+			deb.Reset(f.debounce)
+		case <-deb.C:
+			f.dirty.Swap(false)
+			f.runSave()
+
+			return true
+		case <-capT.C:
+			f.dirty.Swap(false)
+			f.runSave()
+
+			return true
+		}
+	}
+}
+
+// runSave performs one metadata-only periodic save. On failure it re-marks
+// dirty so the next tick/cycle retries, and logs a warning.
+func (f *flusher) runSave() {
+	// Periodic saves are metadata-only to bound the cost of re-serializing large
+	// object bodies every interval; the final shutdown save honors the asset
+	// setting.
+	if err := f.save(context.Background(), false); err != nil {
+		f.dirty.Store(true)
+		fmt.Fprintf(f.out, "warning: failed to save state to %s: %v\n", f.stateFile, err)
+	}
+}
+
+// Stop halts the background loop, waits for any in-flight save to finish, then
+// performs the single deterministic final save (unless the strategy is manual).
+// Because the loop has fully drained before this final save, no earlier save can
+// rename over it and regress the on-disk snapshot to an older version.
+func (f *flusher) Stop(ctx context.Context) {
+	if f == nil {
+		return
+	}
+
+	close(f.stopCh)
+	f.wg.Wait()
+
+	if f.strategy == StrategyManual {
+		return
+	}
+
+	if err := f.save(ctx, f.finalAssets); err != nil {
+		fmt.Fprintf(f.out, "warning: failed to save state to %s: %v\n", f.stateFile, err)
+
+		return
+	}
+
+	if !f.quiet {
+		fmt.Fprintf(f.out, "state saved to %s\n", f.stateFile)
+	}
+}

--- a/server/serverkit/flusher_race_test.go
+++ b/server/serverkit/flusher_race_test.go
@@ -1,0 +1,78 @@
+package serverkit
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestFlusherResetRace runs the scheduled flusher (which reads a.snapTargets
+// under rebuildMu) concurrently with /_cloudemu/reset (which reassigns
+// a.snapTargets under the same lock) and with provider requests marking dirty.
+// Under `go test -race` it is the guard against an unsynchronized snapTargets
+// read during a save racing a swap.
+func TestFlusherResetRace(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "state.json")
+	app := newTestApp(t, Config{
+		Providers:       []string{"aws"},
+		Host:            "127.0.0.1",
+		Ports:           map[string]string{"aws": "0"},
+		Admin:           true,
+		Persist:         true,
+		StateFile:       stateFile,
+		PersistStrategy: StrategyScheduled,
+		PersistInterval: time.Millisecond, // hammer the save path
+		Out:             io.Discard,
+	})
+
+	// Drive the flusher directly (Serve would bind listeners we don't need here).
+	app.flusher.interval = time.Millisecond
+	app.flusher.Start()
+
+	h := app.handlerFor(app.backends["aws"], app.seedFor("aws"))
+
+	done := make(chan struct{})
+
+	var wg sync.WaitGroup
+
+	// Concurrent resets.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				rec := httptest.NewRecorder()
+				h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_cloudemu/reset", nil))
+			}
+		}
+	}()
+
+	// Concurrent provider requests marking dirty.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				rec := httptest.NewRecorder()
+				app.backends["aws"].ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+			}
+		}
+	}()
+
+	time.Sleep(120 * time.Millisecond)
+	close(done)
+	wg.Wait()
+
+	app.flusher.Stop(context.Background())
+}

--- a/server/serverkit/flusher_race_test.go
+++ b/server/serverkit/flusher_race_test.go
@@ -7,9 +7,114 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
 )
+
+// recordingCacheEngine is a no-op CacheEngine whose Close() flags a violation if
+// it fires while an export is in progress. It lets TestFlusherSaveGuardsClose
+// prove closeProviders never tears down a (real, contrib) engine mid-export.
+type recordingCacheEngine struct {
+	exporting *atomic.Bool
+	violation *atomic.Bool
+}
+
+func (recordingCacheEngine) Provision(context.Context, config.CacheProvisionRequest) (config.ProvisionResult, error) {
+	return config.ProvisionResult{}, nil
+}
+func (recordingCacheEngine) Deprovision(context.Context, string) error { return nil }
+func (e recordingCacheEngine) Close() error {
+	if e.exporting.Load() {
+		e.violation.Store(true)
+	}
+
+	return nil
+}
+
+// TestFlusherSaveGuardsClose runs the flusher save (which reads the providers)
+// concurrently with Rebuild()/reset (which Close()es the outgoing providers) and
+// asserts a provider is never Close()d while an export is still reading it. The
+// override save mirrors the production save's exportMu.RLock guard, and the
+// assertion proves the production closeProviders honors that write-lock: with the
+// guard removed, Close would overlap the in-flight export and set violation.
+// Run under -race it also guards the shared-state accesses.
+func TestFlusherSaveGuardsClose(t *testing.T) {
+	var exporting, violation atomic.Bool
+
+	eng := recordingCacheEngine{exporting: &exporting, violation: &violation}
+	app := newTestApp(t, Config{
+		Providers:       []string{"aws"},
+		Host:            "127.0.0.1",
+		Ports:           map[string]string{"aws": "0"},
+		Admin:           true,
+		Persist:         true,
+		StateFile:       filepath.Join(t.TempDir(), "state.json"),
+		PersistStrategy: StrategyScheduled,
+		PersistInterval: time.Hour, // we drive runSave by hand
+		BaseOptions:     []config.Option{config.WithCacheEngine(eng)},
+		Out:             io.Discard,
+	})
+
+	// Replace the save body with one that holds the SAME production export
+	// read-guard (exportMu) and marks an export in-flight for its duration, so the
+	// engine's Close can observe an overlap the guard must prevent.
+	app.flusher.save = func(_ context.Context, _ bool) error {
+		app.exportMu.RLock()
+		defer app.exportMu.RUnlock()
+
+		exporting.Store(true)
+		time.Sleep(time.Millisecond)
+		exporting.Store(false)
+
+		return nil
+	}
+
+	done := make(chan struct{})
+
+	var wg sync.WaitGroup
+
+	// Concurrent resets: each swaps in a fresh provider and Close()es the outgoing
+	// one (under exportMu.Lock).
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				app.Rebuild()
+			}
+		}
+	}()
+
+	// Concurrent saves holding the export read-guard.
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				app.flusher.runSave()
+			}
+		}
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	close(done)
+	wg.Wait()
+
+	if violation.Load() {
+		t.Fatal("a provider engine Close() ran while an export was in flight; closeProviders did not wait on exportMu")
+	}
+}
 
 // TestFlusherResetRace runs the scheduled flusher (which reads a.snapTargets
 // under rebuildMu) concurrently with /_cloudemu/reset (which reassigns

--- a/server/serverkit/flusher_test.go
+++ b/server/serverkit/flusher_test.go
@@ -1,0 +1,243 @@
+package serverkit
+
+import (
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// waitFor polls cond until it is true or the deadline passes, returning whether
+// it became true. It keeps the timing tests robust without fixed long sleeps.
+func waitFor(cond func() bool, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	return cond()
+}
+
+// TestFlusherScheduledSavesOnlyWhenDirty asserts the scheduled ticker saves on a
+// tick only when state changed, and skips ticks while clean.
+func TestFlusherScheduledSavesOnlyWhenDirty(t *testing.T) {
+	var saves atomic.Int64
+
+	save := func(_ context.Context, _ bool) error {
+		saves.Add(1)
+
+		return nil
+	}
+
+	f := newFlusher(StrategyScheduled, 10*time.Millisecond, false, save, io.Discard, true, "state.json")
+	f.Start()
+
+	// Clean for several intervals: no save.
+	time.Sleep(60 * time.Millisecond)
+
+	if got := saves.Load(); got != 0 {
+		t.Fatalf("clean scheduled flusher saved %d times, want 0", got)
+	}
+
+	f.markDirty()
+
+	if !waitFor(func() bool { return saves.Load() >= 1 }, time.Second) {
+		t.Fatal("dirty scheduled flusher never saved")
+	}
+
+	before := saves.Load()
+	f.Stop(context.Background())
+
+	// Stop performs one deterministic final save (non-manual).
+	if got := saves.Load(); got != before+1 {
+		t.Fatalf("Stop saves = %d, want %d (one final save)", got, before+1)
+	}
+}
+
+// TestFlusherManualNeverSaves locks the manual contract: no periodic loop, and —
+// unlike every other strategy — no final save on Stop (graceful shutdown).
+func TestFlusherManualNeverSaves(t *testing.T) {
+	var saves atomic.Int64
+
+	save := func(_ context.Context, _ bool) error {
+		saves.Add(1)
+
+		return nil
+	}
+
+	f := newFlusher(StrategyManual, 10*time.Millisecond, false, save, io.Discard, true, "state.json")
+	f.Start()
+	f.markDirty()
+	time.Sleep(50 * time.Millisecond)
+
+	f.Stop(context.Background())
+
+	if got := saves.Load(); got != 0 {
+		t.Fatalf("manual strategy saved %d times, want 0 (including on shutdown)", got)
+	}
+}
+
+// TestFlusherOnShutdownSavesOnlyAtStop asserts on-shutdown runs no periodic loop
+// but performs exactly one save at Stop.
+func TestFlusherOnShutdownSavesOnlyAtStop(t *testing.T) {
+	var saves atomic.Int64
+
+	save := func(_ context.Context, _ bool) error {
+		saves.Add(1)
+
+		return nil
+	}
+
+	f := newFlusher(StrategyOnShutdown, 10*time.Millisecond, false, save, io.Discard, true, "state.json")
+	f.Start()
+	f.markDirty()
+	time.Sleep(50 * time.Millisecond)
+
+	if got := saves.Load(); got != 0 {
+		t.Fatalf("on-shutdown saved %d times while running, want 0", got)
+	}
+
+	f.Stop(context.Background())
+
+	if got := saves.Load(); got != 1 {
+		t.Fatalf("on-shutdown Stop saves = %d, want 1", got)
+	}
+}
+
+// TestFlusherOnRequestCapFiresUnderContinuousWrites is the reviewer catch: a pure
+// trailing-edge debounce would never fire under a sustained write loop, so the
+// hard max-wait cap must force a save. Debounce is set huge so only the cap can
+// fire.
+func TestFlusherOnRequestCapFiresUnderContinuousWrites(t *testing.T) {
+	var saves atomic.Int64
+
+	save := func(_ context.Context, _ bool) error {
+		saves.Add(1)
+
+		return nil
+	}
+
+	f := newFlusher(StrategyOnRequest, 0, false, save, io.Discard, true, "state.json")
+	f.debounce = time.Hour            // never quiet under continuous writes
+	f.maxWait = 40 * time.Millisecond // cap is the only thing that can fire
+	f.Start()
+
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				f.markDirty()
+				time.Sleep(2 * time.Millisecond)
+			}
+		}
+	}()
+
+	got := waitFor(func() bool { return saves.Load() >= 1 }, time.Second)
+	close(stop)
+	f.Stop(context.Background())
+
+	if !got {
+		t.Fatal("on-request cap never fired under a sustained write loop")
+	}
+}
+
+// TestFlusherSingleFlightAndFinalIsNewest proves two invariants at once:
+//   - single-flight: a save slower than the tick interval never overlaps itself.
+//   - final-write-wins: after the loop drains, the deterministic final save is
+//     the last one to run and observes the newest state version, so no stale tick
+//     can rename over it.
+//
+// Run under -race, it also exercises the markDirty/save concurrency.
+func TestFlusherSingleFlightAndFinalIsNewest(t *testing.T) {
+	var (
+		version  atomic.Int64
+		inFlight atomic.Int32
+		mu       sync.Mutex
+		saved    []int64
+	)
+
+	save := func(_ context.Context, _ bool) error {
+		if n := inFlight.Add(1); n > 1 {
+			t.Errorf("single-flight violated: %d concurrent saves", n)
+		}
+
+		v := version.Load()
+		time.Sleep(12 * time.Millisecond) // slower than the 4ms interval
+		mu.Lock()
+		saved = append(saved, v)
+		mu.Unlock()
+		inFlight.Add(-1)
+
+		return nil
+	}
+
+	f := newFlusher(StrategyScheduled, 4*time.Millisecond, false, save, io.Discard, true, "state.json")
+	f.Start()
+
+	for range 20 {
+		version.Add(1)
+		f.markDirty()
+		time.Sleep(3 * time.Millisecond)
+	}
+
+	final := version.Load()
+	f.Stop(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(saved) == 0 {
+		t.Fatal("no saves recorded")
+	}
+
+	if last := saved[len(saved)-1]; last != final {
+		t.Fatalf("final save observed version %d, want newest %d", last, final)
+	}
+}
+
+// TestFlusherReDirtiesOnSaveError asserts a failed save re-marks state dirty so
+// the next tick retries rather than silently dropping the change.
+func TestFlusherReDirtiesOnSaveError(t *testing.T) {
+	var (
+		attempts atomic.Int64
+		fail     atomic.Bool
+	)
+
+	fail.Store(true)
+
+	save := func(_ context.Context, _ bool) error {
+		attempts.Add(1)
+		if fail.Load() {
+			return context.DeadlineExceeded
+		}
+
+		return nil
+	}
+
+	f := newFlusher(StrategyScheduled, 8*time.Millisecond, false, save, io.Discard, true, "state.json")
+	f.Start()
+	f.markDirty()
+
+	// First attempt fails and re-dirties; a later tick retries. Then let it
+	// succeed and confirm the flag clears (no unbounded retries).
+	if !waitFor(func() bool { return attempts.Load() >= 2 }, time.Second) {
+		t.Fatal("failed save did not retry (dirty not re-set)")
+	}
+
+	fail.Store(false)
+
+	if !waitFor(func() bool { return !f.dirty.Load() }, time.Second) {
+		t.Fatal("dirty flag never cleared after a successful save")
+	}
+
+	f.Stop(context.Background())
+}

--- a/server/serverkit/middleware.go
+++ b/server/serverkit/middleware.go
@@ -40,8 +40,11 @@ func (a *App) wrapDirty(h http.Handler) http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// defer, not sequential: a handler that mutates state and then panics
+		// (net/http recovers the connection but unwinds past this point) must still
+		// mark the mutation dirty, or a crash after the panic would silently lose it.
+		defer a.markDirty()
 		h.ServeHTTP(w, r)
-		a.markDirty()
 	})
 }
 

--- a/server/serverkit/middleware.go
+++ b/server/serverkit/middleware.go
@@ -25,6 +25,26 @@ func wrap(h http.Handler, provider string, logReqs bool) http.Handler {
 	})
 }
 
+// wrapDirty marks the emulator state dirty after a cloud-provider request
+// returns, so the flusher persists it. It is applied ONLY to the four cloud
+// provider handlers (aws/azure/gcp/oci) — never the Kubernetes data-plane, which
+// is not part of persist.ExportAll, and never the admin/health plane, so
+// liveness probes don't keep an idle emulator perpetually dirty. When
+// persistence is off the handler is returned unchanged (zero overhead). Marking
+// after the handler runs (rather than classifying reads vs writes) is
+// deliberately coarse: a pure read triggers at most one extra save per
+// interval/cap, which is bounded and acceptable.
+func (a *App) wrapDirty(h http.Handler) http.Handler {
+	if !a.cfg.Persist {
+		return h
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(w, r)
+		a.markDirty()
+	})
+}
+
 // statusWriter captures the first response status for logging while remaining a
 // transparent http.ResponseWriter. Write is not overridden — it promotes from
 // the embedded writer, so a handler that writes a body without an explicit

--- a/server/serverkit/serverkit.go
+++ b/server/serverkit/serverkit.go
@@ -48,6 +48,10 @@ import (
 // schema version.
 var errUnsupportedSnapshot = errors.New("unsupported snapshot schema version")
 
+// errUnknownStrategy is returned when Config.PersistStrategy is not one of the
+// four supported values.
+var errUnknownStrategy = errors.New("unknown persist strategy (want scheduled, on-request, on-shutdown, or manual)")
+
 // defaultShutdownTimeout is the grace period applied when Config leaves
 // ShutdownTimeout unset.
 const defaultShutdownTimeout = 10 * time.Second
@@ -85,10 +89,12 @@ type Config struct {
 
 	Admin bool // mount the /_cloudemu control plane
 
-	Persist             bool   // save/restore state around the process lifetime
-	StateFile           string // path to the JSON state snapshot
-	PersistMetadataOnly bool   // omit object bodies from the snapshot
-	InitDir             string // apply every *.json fixture in this dir on boot
+	Persist             bool          // save/restore state around the process lifetime
+	StateFile           string        // path to the JSON state snapshot
+	PersistMetadataOnly bool          // omit object bodies from the snapshot
+	PersistStrategy     string        // when/how to save: scheduled|on-request|on-shutdown|manual (default scheduled)
+	PersistInterval     time.Duration // ticker cadence for the scheduled strategy (default 15s)
+	InitDir             string        // apply every *.json fixture in this dir on boot
 
 	TLSCert  string   // PEM cert for the Azure HTTPS endpoint (empty: self-signed)
 	TLSKey   string   // PEM key matching TLSCert
@@ -120,6 +126,11 @@ type App struct {
 	backends   map[string]*admin.Backend
 	k8sBackend *admin.Backend
 
+	// flusher owns every automatic persistence save (nil unless --persist). Its
+	// dirty flag is flipped by the request-boundary seam and the mutating admin
+	// ops.
+	flusher *flusher
+
 	// rebuildMu serializes resets so two concurrent /_cloudemu/reset calls can't
 	// interleave and leave providers wired to different Kubernetes instances. It
 	// also guards the current-state fields below and the live provider set.
@@ -135,6 +146,10 @@ type App struct {
 // persisted state, and applies init-dir fixtures — everything up to binding the
 // listeners. The returned App is ready to Serve.
 func New(cfg *Config) (*App, error) {
+	if err := normalizePersist(cfg); err != nil {
+		return nil, err
+	}
+
 	out := cfg.Out
 	if out == nil {
 		out = os.Stdout
@@ -162,6 +177,10 @@ func New(cfg *Config) (*App, error) {
 		a.k8sBackend = admin.NewBackend(nil)
 	}
 
+	if cfg.Persist {
+		a.flusher = a.newFlusher()
+	}
+
 	a.Rebuild() // populate the backends before serving
 
 	if err := a.applyBootState(); err != nil {
@@ -176,6 +195,71 @@ func New(cfg *Config) (*App, error) {
 	}
 
 	return a, nil
+}
+
+// normalizePersist fills in the persistence-strategy defaults and validates the
+// strategy. It is a no-op when --persist is off. Defaulting here means both
+// entrypoints (and library callers) get the same scheduled/15s behavior without
+// each repeating it.
+func normalizePersist(cfg *Config) error {
+	if !cfg.Persist {
+		return nil
+	}
+
+	if cfg.PersistStrategy == "" {
+		cfg.PersistStrategy = DefaultPersistStrategy
+	}
+
+	switch cfg.PersistStrategy {
+	case StrategyScheduled, StrategyOnRequest, StrategyOnShutdown, StrategyManual:
+	default:
+		return fmt.Errorf("%w: %q", errUnknownStrategy, cfg.PersistStrategy)
+	}
+
+	if cfg.PersistInterval <= 0 {
+		cfg.PersistInterval = DefaultPersistInterval
+	}
+
+	return nil
+}
+
+// newFlusher builds the App's flusher, injecting a save closure that reads the
+// live snapshot targets under rebuildMu (the same guard swapFresh/shutdown use)
+// so a concurrent reset can't race the export.
+func (a *App) newFlusher() *flusher {
+	save := func(ctx context.Context, includeAssets bool) error {
+		a.rebuildMu.Lock()
+		targets := a.snapTargets
+		a.rebuildMu.Unlock()
+
+		return snapshotState(ctx, a.cfg.StateFile, includeAssets, targets)
+	}
+
+	return newFlusher(
+		a.cfg.PersistStrategy,
+		a.cfg.PersistInterval,
+		!a.cfg.PersistMetadataOnly, // final shutdown save honors the asset setting
+		save,
+		a.out,
+		a.cfg.Quiet,
+		a.cfg.StateFile,
+	)
+}
+
+// markDirty records a state mutation for the flusher. It is a no-op when
+// persistence is off (flusher nil), so callers need no guard.
+func (a *App) markDirty() {
+	a.flusher.markDirty()
+}
+
+// persistBanner is the persistence summary shown in the startup banner.
+func (a *App) persistBanner() persistInfo {
+	return persistInfo{
+		on:        a.cfg.Persist,
+		strategy:  a.cfg.PersistStrategy,
+		interval:  a.cfg.PersistInterval,
+		stateFile: a.cfg.StateFile,
+	}
 }
 
 // baseOptsFor clones Config.BaseOptions and appends the latency/auth options, so
@@ -325,7 +409,7 @@ func (a *App) buildProvider(p string, k8s *kubernetes.APIServer) builtProvider {
 		cloud.EKS.SetK8sAPI(k8s)
 
 		return builtProvider{
-			handler:   wrap(awsserver.New(d), providerAWS, a.cfg.LogRequests),
+			handler:   a.wrapDirty(wrap(awsserver.New(d), providerAWS, a.cfg.LogRequests)),
 			target:    seed.Target{Storage: cloud.S3, Database: cloud.DynamoDB, Secrets: cloud.SecretsManager, Compute: cloud.EC2},
 			snap:      cloud.SnapshotServices(),
 			discovery: cloud.ResourceDiscovery,
@@ -339,7 +423,7 @@ func (a *App) buildProvider(p string, k8s *kubernetes.APIServer) builtProvider {
 		cloud.GKE.SetK8sAPI(k8s)
 
 		return builtProvider{
-			handler:   wrap(gcpserver.New(d), providerGCP, a.cfg.LogRequests),
+			handler:   a.wrapDirty(wrap(gcpserver.New(d), providerGCP, a.cfg.LogRequests)),
 			target:    seed.Target{Storage: cloud.GCS, Database: cloud.Firestore, Secrets: cloud.SecretManager, Compute: cloud.GCE},
 			snap:      cloud.SnapshotServices(),
 			discovery: cloud.ResourceDiscovery,
@@ -360,7 +444,7 @@ func (a *App) buildProvider(p string, k8s *kubernetes.APIServer) builtProvider {
 		cloud.AKS.SetK8sAPI(k8s)
 
 		return builtProvider{
-			handler:   wrap(azureserver.New(d), providerAzure, a.cfg.LogRequests),
+			handler:   a.wrapDirty(wrap(azureserver.New(d), providerAzure, a.cfg.LogRequests)),
 			target:    seed.Target{Storage: cloud.BlobStorage, Database: cloud.CosmosDB, Secrets: cloud.KeyVault, Compute: cloud.VirtualMachines},
 			snap:      cloud.SnapshotServices(),
 			discovery: cloud.ResourceDiscovery,
@@ -373,7 +457,7 @@ func (a *App) buildProvider(p string, k8s *kubernetes.APIServer) builtProvider {
 		// OCI has no managed-Kubernetes service, so no SetK8sAPI here, and its
 		// *Provider carries no engines to close.
 		return builtProvider{
-			handler: wrap(ociserver.New(d), providerOCI, a.cfg.LogRequests),
+			handler: a.wrapDirty(wrap(ociserver.New(d), providerOCI, a.cfg.LogRequests)),
 			target: seed.Target{
 				Storage: cloud.ObjectStorage, Database: cloud.NoSQL,
 				Secrets: cloud.Vault, Compute: cloud.Compute,
@@ -456,7 +540,15 @@ func (a *App) restore(body []byte) error {
 	cur := a.snapTargets
 	a.rebuildMu.Unlock()
 
-	return persist.RestoreAll(context.Background(), &snap, cur)
+	if err := persist.RestoreAll(context.Background(), &snap, cur); err != nil {
+		return err
+	}
+
+	// Mark dirty so a restore-then-crash with no subsequent provider request
+	// still persists the freshly-restored state on the next tick/final save.
+	a.markDirty()
+
+	return nil
 }
 
 // extraHandler serves the control-plane endpoints that plug into admin: network
@@ -497,11 +589,36 @@ func (a *App) extraHandler() http.Handler {
 // API off the backend serves directly. seedFn may be nil (e.g. the Kubernetes
 // port), which disables the seed endpoint.
 func (a *App) handlerFor(b *admin.Backend, seedFn func([]byte) (int, error)) http.Handler {
-	if a.cfg.Admin {
-		return admin.NewControl(b, a.Rebuild, seedFn, a.snapshot, a.restore, a.extraHandler())
+	if !a.cfg.Admin {
+		return b
 	}
 
-	return b
+	reset := a.Rebuild
+	// The admin plane bypasses the wrapDirty request seam (it dispatches inside
+	// Control before reaching the wrapped backend), so the three mutating admin
+	// ops must mark dirty themselves: reset and seed here, restore inside
+	// App.restore. Missing any of these means a mutate-then-crash silently loses
+	// the change. restore marks dirty on its own; wrap only reset and seed.
+	if a.cfg.Persist {
+		reset = func() {
+			a.Rebuild()
+			a.markDirty()
+		}
+
+		if seedFn != nil {
+			inner := seedFn
+			seedFn = func(fixture []byte) (int, error) {
+				n, err := inner(fixture)
+				if err == nil {
+					a.markDirty()
+				}
+
+				return n, err
+			}
+		}
+	}
+
+	return admin.NewControl(b, reset, seedFn, a.snapshot, a.restore, a.extraHandler())
 }
 
 // Serve binds every listener, starts serving, and blocks until ctx is canceled
@@ -521,8 +638,12 @@ func (a *App) Serve(ctx context.Context) error {
 
 	errCh := serveAll(servers, listeners)
 
+	// Start the background persistence flusher once the listeners are live, so
+	// scheduled/on-request saves run for the whole serving lifetime.
+	a.flusher.Start()
+
 	if !a.cfg.Quiet {
-		printBanner(a.out, &eps, a.cfg.Admin)
+		printBanner(a.out, &eps, a.cfg.Admin, a.persistBanner())
 	}
 
 	if a.cfg.EndpointsFile != "" {
@@ -640,13 +761,13 @@ func (a *App) shutdown(servers []*namedServer) error {
 		}
 	}
 
-	if a.cfg.Persist {
-		if err := snapshotState(context.Background(), a.cfg.StateFile, !a.cfg.PersistMetadataOnly, a.snapTargets); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: failed to save state to %s: %v\n", a.cfg.StateFile, err)
-		} else if !a.cfg.Quiet {
-			fmt.Fprintf(a.out, "state saved to %s\n", a.cfg.StateFile)
-		}
-	}
+	// The flusher owns every automatic save: Stop drains any in-flight periodic
+	// save, then performs the single deterministic final save (unless the
+	// strategy is manual). This replaces the old unconditional shutdown snapshot,
+	// so manual genuinely never saves and no stale tick can rename over the final
+	// write. The final save runs while the providers are still live (closed
+	// below), keeping the engines readable through the export.
+	a.flusher.Stop(ctx)
 
 	a.rebuildMu.Lock()
 	cur := a.providers

--- a/server/serverkit/serverkit.go
+++ b/server/serverkit/serverkit.go
@@ -140,6 +140,15 @@ type App struct {
 	netEngine   *topology.Engine
 	discovery   map[string]*resourcediscovery.Engine
 	providers   []closer // current live providers, Close()d when swapped out
+
+	// exportMu guards an in-flight state export (flusher save or admin snapshot)
+	// against provider teardown: every export holds it for read across the whole
+	// ExportAll, and closeProviders takes it for write before Close()ing the
+	// outgoing providers. So a rebuild/reset can never tear down a real (contrib)
+	// embedded-Postgres/redis/Docker engine mid-export. It is a distinct lock from
+	// rebuildMu — held only for the export duration, never while swapping — so the
+	// two never form a cycle.
+	exportMu sync.RWMutex
 }
 
 // New builds every selected provider behind its admin backend, restores any
@@ -228,6 +237,12 @@ func normalizePersist(cfg *Config) error {
 // so a concurrent reset can't race the export.
 func (a *App) newFlusher() *flusher {
 	save := func(ctx context.Context, includeAssets bool) error {
+		// Hold the export read-guard across the whole save so a concurrent
+		// Rebuild()/reset cannot Close() the providers being exported (see
+		// exportMu). rebuildMu is taken only to read the current snapTargets.
+		a.exportMu.RLock()
+		defer a.exportMu.RUnlock()
+
 		a.rebuildMu.Lock()
 		targets := a.snapTargets
 		a.rebuildMu.Unlock()
@@ -238,7 +253,7 @@ func (a *App) newFlusher() *flusher {
 	return newFlusher(
 		a.cfg.PersistStrategy,
 		a.cfg.PersistInterval,
-		!a.cfg.PersistMetadataOnly, // final shutdown save honors the asset setting
+		!a.cfg.PersistMetadataOnly, // every save honors the asset setting (bodies on by default)
 		save,
 		a.out,
 		a.cfg.Quiet,
@@ -471,8 +486,14 @@ func (a *App) buildProvider(p string, k8s *kubernetes.APIServer) builtProvider {
 
 // closeProviders closes each provider best-effort, cascading engine teardown. It
 // runs after the swap (or after the shutdown snapshot), never before, and never
-// aborts on an error — a failed teardown is logged, not fatal.
+// aborts on an error — a failed teardown is logged, not fatal. It takes exportMu
+// for write so it blocks until any in-flight export (flusher save or admin
+// snapshot) that may still be reading these providers has finished — a real
+// engine is never torn down mid-export.
 func (a *App) closeProviders(providers []closer) {
+	a.exportMu.Lock()
+	defer a.exportMu.Unlock()
+
 	for _, p := range providers {
 		if err := p.Close(); err != nil {
 			fmt.Fprintf(a.out, "warning: closing provider engines: %v\n", err)
@@ -507,6 +528,11 @@ func (a *App) seedFor(provider string) func([]byte) (int, error) {
 // snapshot captures current state as JSON. It acts on the whole emulator, like
 // reset, so a call to any provider port covers every provider.
 func (a *App) snapshot() ([]byte, error) {
+	// Same export read-guard as the flusher save: a concurrent reset must not tear
+	// down the providers this export reads (see exportMu).
+	a.exportMu.RLock()
+	defer a.exportMu.RUnlock()
+
 	a.rebuildMu.Lock()
 	cur := a.snapTargets
 	a.rebuildMu.Unlock()
@@ -654,6 +680,12 @@ func (a *App) Serve(ctx context.Context) error {
 
 	select {
 	case err := <-errCh:
+		// A listener failed fatally. Still tear down cleanly — stop the flusher
+		// (final save + drain) and close the providers — so the goroutine and any
+		// real engines aren't leaked; then surface the original serve error, not
+		// the shutdown error.
+		_ = a.shutdown(servers)
+
 		return err
 	case <-ctx.Done():
 		if !a.cfg.Quiet {


### PR DESCRIPTION
## What & why

`cloudemu serve --persist` today saves state **only on graceful shutdown**, so a `kill -9`, panic, OOM, or power loss loses **everything since boot**. #447 asks for always-on durability. This makes `--persist` save in the background while the server runs, turning "lose everything on crash" into "lose ≤ the last interval" — and it stays **free** (LocalStack gates persistence behind its paid tier).

## Strategy matrix (`--persist-strategy`, env `CLOUDEMU_PERSIST_STRATEGY`)

| Strategy | Saves | Loss window on hard crash |
|----------|-------|---------------------------|
| `scheduled` *(default, `--persist-interval` 15s)* | every interval if state changed, plus shutdown | ≤ interval |
| `on-request` | after mutations settle, and ≥ once/sec under continuous writes, plus shutdown | ≤ ~1s |
| `on-shutdown` | graceful shutdown only (the old behavior) | everything since boot |
| `manual` | never automatically — only the snapshot endpoint | everything not manually saved |

Both `cloudemu serve` and `cloudemu-server` accept the same flags/env; all strategy logic lives in `serverkit`, the two mains only parse into `Config`.

## Design

- **Dirty seam (above the store layer):** a request-boundary middleware sets an `atomic.Bool` after each of the **four cloud provider handlers** returns — sound by construction, so Get-then-mutate writes (S3 bucket policy/tagging/encryption, IAM inline role policies) that never call a memstore mutator are still caught. The **Kubernetes data-plane is deliberately not wrapped** (it isn't in `persist.ExportAll`). The admin/health plane isn't wrapped either; the three mutating admin ops (`reset`, `seed`, restore) set dirty explicitly.
- **Flusher (single owner of every automatic save):** background goroutine (never the request path); **single-flight** (one export in flight, mid-save signals coalesced and re-checked); reads `snapTargets` under `rebuildMu`; clears the dirty flag at save start so a mutation landing mid-save re-dirties. `Stop` cancels the loop, drains the in-flight save, then does the one deterministic final save (skipped for `manual`) — replacing the old unconditional shutdown snapshot, so no stale tick can rename over the final write.
- Payload reuses the existing guarded, identity-preserving `persist.ExportAll` — **zero per-service code**. Periodic saves default to metadata-only to bound blob-body cost; the final shutdown save honors `--persist-metadata-only`.

## Crash-safety guarantee & limits

- Writes are atomic (temp → `fsync` → `rename` → parent-dir `fsync`).
- **darwin:** best-effort — Go's `File.Sync` doesn't issue `F_FULLFSYNC`, so no hard power-loss guarantee.
- **Kubernetes data-plane is not persisted** (pre-existing gap, tracked as #868); crash-safety covers cloud-provider state only.

## Tests

Real-user e2e: **SIGKILL (no graceful shutdown) then restart** proves resources created via real AWS/GCP/Azure SDKs survive under `scheduled` and `on-request` — including the S3/IAM Get-then-mutate writes. Plus admin-restore-then-crash, `manual` never auto-saves (even on graceful shutdown), single-flight + final-write-wins, on-request 1s cap under a sustained write loop, health-probe doesn't dirty, k8s excluded, a `-race` reset-vs-tick test, and cross-entrypoint flag-parity tests.

Gates: `go build`/`vet` clean module-wide; `go test ./server/serverkit/... ./persist/... ./cmd/... .` and `go test -race ./server/serverkit/...` green; `golangci-lint` clean on `serverkit`/`persist`/contrib (no new issues in cmd); contrib module builds+tests green; `go generate` no diff.
