### PR TITLE
fix(kubernetes): emit initial-events-end bookmark for WatchList so kubectl rollout status / get -w don't hang (#878)

### DIFF
--- a/services/kubernetes/events_table_test.go
+++ b/services/kubernetes/events_table_test.go
@@ -1,0 +1,77 @@
+// Server-side Table projection for core/v1 Events. `kubectl get events` renders
+// LAST SEEN / TYPE / REASON / OBJECT / MESSAGE (plus -o wide extras) rather than
+// the generic NAME / AGE fallback.
+
+package kubernetes_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestEvents_TableColumns(t *testing.T) {
+	base, closeFn := newFixture(t)
+	defer closeFn()
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	eventBody := []byte(`{
+		"apiVersion":"v1","kind":"Event",
+		"metadata":{"name":"web.evt1","namespace":"default"},
+		"involvedObject":{"apiVersion":"v1","kind":"Pod","name":"web-xyz","namespace":"default"},
+		"reason":"Scheduled","message":"Successfully assigned default/web-xyz",
+		"type":"Normal","source":{"component":"default-scheduler"},
+		"count":1,"firstTimestamp":"` + now + `","lastTimestamp":"` + now + `"}`)
+
+	resp := do(t, http.MethodPost, base+"/api/v1/namespaces/default/events", eventBody)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create event: status %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	table := getTable(t, base+"/api/v1/namespaces/default/events")
+
+	// Default (priority-0) columns kubectl prints, in order.
+	wantCols := []string{"Last Seen", "Type", "Reason", "Object", "Message"}
+	for _, name := range wantCols {
+		_ = columnIndex(t, table, name) // fatals if missing
+	}
+
+	// -o wide extras must also be declared.
+	for _, name := range []string{"Subobject", "Source", "First Seen", "Count", "Name"} {
+		_ = columnIndex(t, table, name)
+	}
+
+	if len(table.Rows) != 1 {
+		t.Fatalf("event table rows: got %d, want 1", len(table.Rows))
+	}
+
+	cells := table.Rows[0].Cells
+
+	cell := func(col string) any { return cells[columnIndex(t, table, col)] }
+
+	if got := cell("Type"); got != "Normal" {
+		t.Fatalf("Type cell: got %v, want Normal", got)
+	}
+
+	if got := cell("Reason"); got != "Scheduled" {
+		t.Fatalf("Reason cell: got %v, want Scheduled", got)
+	}
+
+	if got := cell("Object"); got != "pod/web-xyz" {
+		t.Fatalf("Object cell: got %v, want pod/web-xyz", got)
+	}
+
+	if got := cell("Message"); got != "Successfully assigned default/web-xyz" {
+		t.Fatalf("Message cell: got %v", got)
+	}
+
+	if got := cell("Source"); got != "default-scheduler" {
+		t.Fatalf("Source cell: got %v, want default-scheduler", got)
+	}
+
+	if got, ok := cell("Last Seen").(string); !ok || got == "" || got == "<unknown>" {
+		t.Fatalf("Last Seen cell: got %v, want a non-empty age", cells[columnIndex(t, table, "Last Seen")])
+	}
+}

--- a/services/kubernetes/registry.go
+++ b/services/kubernetes/registry.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -231,15 +232,17 @@ func (s *ClusterState) registryList(w http.ResponseWriter, r *http.Request, st *
 			return sel.Matches(labels.Set(u.GetLabels())) && matchesFields(&u, fields)
 		}
 
+		initial := watchSendInitialEvents(r)
+
 		s.mu.RLock()
 		sub := st.watch.subscribe(namespace)
 		items := st.snapshotLocked(namespace, r)
 		rv := s.clusterRVLocked()
 		s.mu.RUnlock()
 		streamWatch(r.Context(), w, sub, items, keep, watchOpts{
-			resume:      watchResume(r),
-			bookmarks:   watchBookmarksEnabled(r),
-			bookmarkObj: registryBookmark(st, rv),
+			resume:      watchResume(r) && !initial,
+			bookmarks:   watchBookmarksEnabled(r) || initial,
+			bookmarkObj: registryBookmark(st, rv, initial),
 		})
 
 		return
@@ -268,12 +271,18 @@ func (s *ClusterState) registryList(w http.ResponseWriter, r *http.Request, st *
 
 // registryBookmark builds the minimal object a BOOKMARK watch event carries for
 // a registry-backed kind: just the kind's apiVersion/kind and the current
-// cluster resourceVersion.
-func registryBookmark(st *registryStore, rv string) *unstructured.Unstructured {
+// cluster resourceVersion. When initialEvents is set (a WatchList request) it
+// also carries the k8s.io/initial-events-end annotation marking the end of the
+// initial-state replay, without which modern kubectl/informers hang.
+func registryBookmark(st *registryStore, rv string, initialEvents bool) *unstructured.Unstructured {
 	bm := &unstructured.Unstructured{}
 	bm.SetAPIVersion(st.def.apiVersion())
 	bm.SetKind(st.def.kind)
 	bm.SetResourceVersion(rv)
+
+	if initialEvents {
+		bm.SetAnnotations(map[string]string{metav1.InitialEventsAnnotationKey: watchQueryValue})
+	}
 
 	return bm
 }

--- a/services/kubernetes/registry_defs.go
+++ b/services/kubernetes/registry_defs.go
@@ -171,6 +171,7 @@ func coreRegistryDefs() []*resourceDef {
 		{
 			group: "", version: "v1", kind: "Event", listKind: "EventList",
 			plural: "events", namespaced: true,
+			tableColumns: eventTableProjector(),
 		},
 		{
 			group: "", version: "v1", kind: "ResourceQuota", listKind: "ResourceQuotaList",

--- a/services/kubernetes/table.go
+++ b/services/kubernetes/table.go
@@ -29,6 +29,12 @@ type tableProjector struct {
 	// object's creationTimestamp-relative age, precomputed from the cluster clock
 	// so it is deterministic under a FakeClock.
 	cells func(u *unstructured.Unstructured, age string) []any
+	// cellsAt is an optional clock-aware variant used by kinds whose columns are
+	// relative to a timestamp other than creationTimestamp (Events render "Last
+	// Seen"/"First Seen" from lastTimestamp/firstTimestamp). When set it takes
+	// precedence over cells. nowUnixNano is the cluster clock, so output stays
+	// deterministic under a FakeClock.
+	cellsAt func(u *unstructured.Unstructured, nowUnixNano int64) []any
 }
 
 // resourceVersionSetter is satisfied by every typed *…List (via the embedded
@@ -181,7 +187,16 @@ func (s *ClusterState) writeObjectWithColumns(w http.ResponseWriter, r *http.Req
 // tableRow builds one Table row: the projected cells plus the embedded object
 // (full object, PartialObjectMetadata, or nothing) per the includeObject mode.
 func (s *ClusterState) tableRow(u *unstructured.Unstructured, proj *tableProjector, mode string) metav1.TableRow {
-	row := metav1.TableRow{Cells: proj.cells(u, ageOf(u, s.now().Time.UnixNano()))}
+	now := s.now().Time.UnixNano()
+
+	var cells []any
+	if proj.cellsAt != nil {
+		cells = proj.cellsAt(u, now)
+	} else {
+		cells = proj.cells(u, ageOf(u, now))
+	}
+
+	row := metav1.TableRow{Cells: cells}
 
 	switch mode {
 	case includeObjectNone:
@@ -272,10 +287,31 @@ func resolveProjector(kind string, override *tableProjector) *tableProjector {
 func ageOf(u *unstructured.Unstructured, nowUnixNano int64) string {
 	ct := u.GetCreationTimestamp()
 	if ct.IsZero() {
-		return "<unknown>"
+		return cellUnknown
 	}
 
 	d := nowUnixNano - ct.UnixNano()
+	if d < 0 {
+		d = 0
+	}
+
+	return duration.HumanDuration(time.Duration(d))
+}
+
+// ageSince renders the human-readable age between an RFC3339 timestamp string
+// and now. Used by the Event projector's Last Seen / First Seen columns, which
+// are relative to lastTimestamp / firstTimestamp rather than creationTimestamp.
+func ageSince(tsStr string, nowUnixNano int64) string {
+	if tsStr == "" {
+		return cellUnknown
+	}
+
+	t, err := time.Parse(time.RFC3339, tsStr)
+	if err != nil {
+		return cellUnknown
+	}
+
+	d := nowUnixNano - t.UnixNano()
 	if d < 0 {
 		d = 0
 	}

--- a/services/kubernetes/table_columns.go
+++ b/services/kubernetes/table_columns.go
@@ -21,6 +21,7 @@ import (
 // keep the projections consistent).
 const (
 	cellNone        = "<none>"
+	cellUnknown     = "<unknown>"
 	condTypeReady   = "Ready"
 	condStatusTrue  = "True"
 	jobCondComplete = "Complete"
@@ -359,6 +360,74 @@ func orNone(s string) string {
 	}
 
 	return s
+}
+
+// eventTableProjector renders core/v1 Events into kubectl's default LAST SEEN /
+// TYPE / REASON / OBJECT / MESSAGE columns (plus the `-o wide` extras Subobject,
+// Source, First Seen, Count, Name), mirroring real kubectl. Last Seen / First
+// Seen are relative to lastTimestamp / firstTimestamp, so it uses the
+// clock-aware cellsAt variant instead of the creationTimestamp-based age.
+func eventTableProjector() *tableProjector {
+	return &tableProjector{
+		columns: []metav1.TableColumnDefinition{
+			col("Last Seen", "string"),
+			col("Type", "string"),
+			col("Reason", "string"),
+			col("Object", "string"),
+			wideCol("Subobject"),
+			wideCol("Source"),
+			col("Message", "string"),
+			wideCol("First Seen"),
+			wideCol("Count"),
+			{Name: "Name", Type: "string", Format: "name", Priority: 1},
+		},
+		cellsAt: func(u *unstructured.Unstructured, now int64) []any {
+			return []any{
+				ageSince(ustr(u, "lastTimestamp"), now),
+				orNone(ustr(u, "type")),
+				orNone(ustr(u, "reason")),
+				eventObjectRef(u),
+				orNone(ustr(u, "involvedObject", "fieldPath")),
+				orNone(eventSourceString(u)),
+				strings.TrimSpace(ustr(u, "message")),
+				ageSince(ustr(u, "firstTimestamp"), now),
+				uint64at(u, "count"),
+				u.GetName(),
+			}
+		},
+	}
+}
+
+// eventObjectRef is the Event's OBJECT column: "<lowercase kind>/<name>", the
+// same shape real kubectl prints (e.g. "deployment/web", "pod/web-abc123").
+func eventObjectRef(u *unstructured.Unstructured) string {
+	kind := strings.ToLower(ustr(u, "involvedObject", "kind"))
+	name := ustr(u, "involvedObject", "name")
+
+	switch {
+	case name == "":
+		return orNone(kind)
+	case kind == "":
+		return name
+	default:
+		return kind + "/" + name
+	}
+}
+
+// eventSourceString is the Event's SOURCE column: the reporting component and,
+// when present, the host — matching kubectl's formatEventSource.
+func eventSourceString(u *unstructured.Unstructured) string {
+	comp := ustr(u, "source", "component")
+	host := ustr(u, "source", "host")
+
+	switch {
+	case host == "":
+		return comp
+	case comp == "":
+		return host
+	default:
+		return comp + ", " + host
+	}
 }
 
 func orClusterIP(s string) string {

--- a/services/kubernetes/watch.go
+++ b/services/kubernetes/watch.go
@@ -19,25 +19,36 @@ func serveWatch[T any](
 	s *ClusterState, w http.ResponseWriter, r *http.Request,
 	b *broadcaster, namespace, apiVersion, kind string, collect func() []T, keep func(T) bool,
 ) {
+	initial := watchSendInitialEvents(r)
+
 	s.mu.RLock()
 	sub := b.subscribe(namespace)
 	items := collect()
 	rv := s.clusterRVLocked()
 	s.mu.RUnlock()
 	streamWatch(r.Context(), w, sub, items, keep, watchOpts{
-		resume:      watchResume(r),
-		bookmarks:   watchBookmarksEnabled(r),
-		bookmarkObj: typedBookmark(apiVersion, kind, rv),
+		resume:      watchResume(r) && !initial,
+		bookmarks:   watchBookmarksEnabled(r) || initial,
+		bookmarkObj: typedBookmark(apiVersion, kind, rv, initial),
 	})
 }
 
 // typedBookmark builds the minimal object a BOOKMARK watch event carries for a
-// typed kind: its apiVersion/kind and the current cluster resourceVersion.
-func typedBookmark(apiVersion, kind, rv string) *metav1.PartialObjectMetadata {
-	return &metav1.PartialObjectMetadata{
+// typed kind: its apiVersion/kind and the current cluster resourceVersion. When
+// initialEvents is set (a WatchList streaming-list request), the object also
+// carries the k8s.io/initial-events-end annotation that tells a client-go
+// reflector the initial state has been fully replayed — without it modern
+// kubectl (rollout status / get -w / wait) blocks forever.
+func typedBookmark(apiVersion, kind, rv string, initialEvents bool) *metav1.PartialObjectMetadata {
+	bm := &metav1.PartialObjectMetadata{
 		TypeMeta:   metav1.TypeMeta{APIVersion: apiVersion, Kind: kind},
 		ObjectMeta: metav1.ObjectMeta{ResourceVersion: rv},
 	}
+	if initialEvents {
+		bm.Annotations = map[string]string{metav1.InitialEventsAnnotationKey: watchQueryValue}
+	}
+
+	return bm
 }
 
 // watchOpts carries the per-request watch behaviors parsed from the query.
@@ -53,8 +64,9 @@ type watchOpts struct {
 	bookmarks bool
 	// bookmarkObj, when non-nil and bookmarks is set, is emitted once after the
 	// initial sync as a BOOKMARK event carrying the current resourceVersion, so
-	// the client can resume from it without a relist. Only registry-backed kinds
-	// (which track a store resourceVersion) supply one.
+	// the client can resume from it without a relist. For a WatchList request
+	// (sendInitialEvents=true) it also carries the k8s.io/initial-events-end
+	// annotation marking the end of the initial-state replay.
 	bookmarkObj any
 }
 
@@ -69,6 +81,18 @@ func watchResume(r *http.Request) bool {
 // watchBookmarksEnabled reports whether the client opted into BOOKMARK events.
 func watchBookmarksEnabled(r *http.Request) bool {
 	return r.URL.Query().Get("allowWatchBookmarks") == watchQueryValue
+}
+
+// watchSendInitialEvents reports whether the request is a WatchList
+// streaming-list (`sendInitialEvents=true`): the current state is streamed as
+// ADDED events, then a terminal BOOKMARK carrying the initial-events-end
+// annotation is emitted. kubectl 1.30+ (rollout status / get -w / wait) and
+// modern client-go informers default to this protocol and block until they see
+// that annotated bookmark. resourceVersionMatch=NotOlderThan with an empty/"0"
+// resourceVersion means "current state then stream", so the initial replay is
+// always performed (resume is forced off by the caller).
+func watchSendInitialEvents(r *http.Request) bool {
+	return r.URL.Query().Get("sendInitialEvents") == watchQueryValue
 }
 
 // parseListSelectors extracts the labelSelector and fieldSelector from a list

--- a/services/kubernetes/watchlist_test.go
+++ b/services/kubernetes/watchlist_test.go
@@ -1,0 +1,202 @@
+// WatchList (streaming-list) protocol tests. kubectl 1.30+ and modern client-go
+// informers default to the WatchList protocol
+// (sendInitialEvents=true&resourceVersionMatch=NotOlderThan&allowWatchBookmarks=true&watch=true):
+// the server streams current state as ADDED events, then a terminal BOOKMARK
+// carrying metadata.annotations["k8s.io/initial-events-end"]="true". client-go
+// blocks until it sees that annotated bookmark, so its absence hangs
+// `kubectl rollout status`, `kubectl get -w`, and `kubectl wait` forever.
+
+package kubernetes_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+const initialEventsEndAnnotation = "k8s.io/initial-events-end"
+
+// wireEvent is the on-the-wire watch event shape: {"type":..,"object":{..}}.
+type wireEvent struct {
+	Type   string `json:"type"`
+	Object struct {
+		Kind     string `json:"kind"`
+		Metadata struct {
+			ResourceVersion string            `json:"resourceVersion"`
+			Annotations     map[string]string `json:"annotations"`
+		} `json:"metadata"`
+	} `json:"object"`
+}
+
+// readWatchUntilBookmark streams a watch response, returning the events seen up
+// to and including the first BOOKMARK (or all events if the stream/ctx ends).
+func readWatchUntilBookmark(t *testing.T, body io.Reader) []wireEvent {
+	t.Helper()
+
+	dec := json.NewDecoder(body)
+
+	var events []wireEvent
+
+	for {
+		var ev wireEvent
+		if err := dec.Decode(&ev); err != nil {
+			return events
+		}
+
+		events = append(events, ev)
+
+		if ev.Type == "BOOKMARK" {
+			return events
+		}
+	}
+}
+
+// watchListURL builds a WatchList request URL for a list path.
+func watchListURL(base, path string) string {
+	return base + path +
+		"?watch=true&sendInitialEvents=true&resourceVersionMatch=NotOlderThan&allowWatchBookmarks=true"
+}
+
+func TestWatchList_EmitsInitialEventsEndBookmark(t *testing.T) {
+	cases := []struct {
+		name       string
+		createPath string
+		listPath   string
+		body       func(name string) []byte
+		kind       string
+	}{
+		{
+			name:       "typed_configmaps",
+			createPath: "/api/v1/namespaces/default/configmaps",
+			listPath:   "/api/v1/namespaces/default/configmaps",
+			kind:       "ConfigMap",
+			body: func(name string) []byte {
+				return []byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"` +
+					name + `","namespace":"default"}}`)
+			},
+		},
+		{
+			name:       "registry_replicasets",
+			createPath: "/apis/apps/v1/namespaces/default/replicasets",
+			listPath:   "/apis/apps/v1/namespaces/default/replicasets",
+			kind:       "ReplicaSet",
+			body: func(name string) []byte {
+				return []byte(`{"apiVersion":"apps/v1","kind":"ReplicaSet","metadata":{"name":"` +
+					name + `","namespace":"default"}}`)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base, closeFn := newFixture(t)
+			defer closeFn()
+
+			for _, name := range []string{"a", "b"} {
+				do(t, http.MethodPost, base+tc.createPath, tc.body(name)).Body.Close()
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, watchListURL(base, tc.listPath), nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("watchlist request: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("watchlist status: got %d, want 200", resp.StatusCode)
+			}
+
+			events := readWatchUntilBookmark(t, resp.Body)
+
+			// Expect: 2 ADDED then a terminal BOOKMARK.
+			if len(events) < 3 {
+				t.Fatalf("got %d events, want >=3 (2 ADDED + BOOKMARK): %+v", len(events), events)
+			}
+
+			added := 0
+
+			for _, ev := range events[:len(events)-1] {
+				if ev.Type != "ADDED" {
+					t.Fatalf("pre-bookmark event type: got %q, want ADDED", ev.Type)
+				}
+
+				added++
+			}
+
+			if added != 2 {
+				t.Fatalf("ADDED events before bookmark: got %d, want 2", added)
+			}
+
+			last := events[len(events)-1]
+			if last.Type != "BOOKMARK" {
+				t.Fatalf("terminal event type: got %q, want BOOKMARK", last.Type)
+			}
+
+			if got := last.Object.Metadata.Annotations[initialEventsEndAnnotation]; got != "true" {
+				t.Fatalf("bookmark %s annotation: got %q, want \"true\" (annotations=%v)",
+					initialEventsEndAnnotation, got, last.Object.Metadata.Annotations)
+			}
+
+			if last.Object.Kind != tc.kind {
+				t.Fatalf("bookmark kind: got %q, want %q", last.Object.Kind, tc.kind)
+			}
+
+			rv, err := strconv.Atoi(last.Object.Metadata.ResourceVersion)
+			if err != nil || rv <= 0 {
+				t.Fatalf("bookmark resourceVersion %q invalid: %v", last.Object.Metadata.ResourceVersion, err)
+			}
+		})
+	}
+}
+
+// TestWatch_PlainBookmarkHasNoInitialEventsEndAnnotation is the regression guard:
+// a plain `?watch=true&allowWatchBookmarks=true` (no sendInitialEvents) still gets
+// a post-sync BOOKMARK, but WITHOUT the initial-events-end annotation — so we
+// don't turn every ordinary watch into a WatchList sync.
+func TestWatch_PlainBookmarkHasNoInitialEventsEndAnnotation(t *testing.T) {
+	base, closeFn := newFixture(t)
+	defer closeFn()
+
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/configmaps",
+		[]byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"a","namespace":"default"}}`)).Body.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	url := base + "/api/v1/namespaces/default/configmaps?watch=true&allowWatchBookmarks=true"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("watch request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	events := readWatchUntilBookmark(t, resp.Body)
+
+	last := events[len(events)-1]
+	if last.Type != "BOOKMARK" {
+		t.Fatalf("terminal event type: got %q, want BOOKMARK", last.Type)
+	}
+
+	if _, present := last.Object.Metadata.Annotations[initialEventsEndAnnotation]; present {
+		t.Fatalf("plain watch bookmark must NOT carry the %s annotation: %v",
+			initialEventsEndAnnotation, last.Object.Metadata.Annotations)
+	}
+}


### PR DESCRIPTION
## Problem

`kubectl rollout status`, `kubectl get -w`, and `kubectl wait` hang forever against the CloudEmu Kubernetes data plane on modern kubectl (1.30+). This breaks the "rollout" feature advertised in #878 and the README's "client-go informers work" claim.

kubectl 1.30+ ships the `WatchListClient` feature gate default-ON. `rollout status` / `get -w` / `wait` and modern client-go informers therefore use the **WatchList streaming-list protocol**: a LIST-as-watch issued with

```
?watch=true&sendInitialEvents=true&resourceVersionMatch=NotOlderThan&allowWatchBookmarks=true
```

The server must stream the current state as `ADDED` events, then emit a terminal `BOOKMARK` whose object carries `metadata.annotations["k8s.io/initial-events-end"] = "true"` plus the list-level `resourceVersion`. client-go's reflector blocks until it sees that annotated bookmark. CloudEmu emitted a post-sync bookmark but WITHOUT the annotation, so the client never considered the list synced.

Reproduced against `cloudemu serve` + real kubectl 1.35: the reflector logs `hasn't received required bookmark event marking the end of initial events stream` and the command times out.

## Fix

- Detect `sendInitialEvents=true` (new `watchSendInitialEvents` helper). For such requests the terminal `BOOKMARK` object now carries the `k8s.io/initial-events-end: "true"` annotation and the current cluster/list resourceVersion.
- Applied in BOTH watch entry points so every kind works: the typed handlers (`serveWatch`, used by Deployments/Pods/etc.) and the generic registry watch path (`registryList`). Both feed the shared `streamWatch`, so `typedBookmark`/`registryBookmark` grew an `initialEvents` flag.
- WatchList uses `resourceVersionMatch=NotOlderThan` with an empty/`0` resourceVersion meaning "send current state then stream" — so `resume` is forced off when `sendInitialEvents=true`, guaranteeing the initial `ADDED` replay is not skipped.
- Plain `?watch=true&allowWatchBookmarks=true` (no `sendInitialEvents`) is unchanged: it still gets a post-sync bookmark WITHOUT the annotation (regression-guarded by a test).

### Bonus: `kubectl get events` columns

Added a server-side Table projector for core/v1 Events so `kubectl get events` renders `LAST SEEN / TYPE / REASON / OBJECT / MESSAGE` (plus the `-o wide` extras) instead of the generic `NAME / AGE` fallback, mirroring real kubectl. Needed a clock-aware `cellsAt` projector variant because Last Seen / First Seen are relative to `lastTimestamp` / `firstTimestamp`, not `creationTimestamp`.

## Before / after (real kubectl 1.35 against `cloudemu serve` + EKS cluster)

Before:
```
$ kubectl rollout status deployment/web
reflector.go:1159] "Warning: event bookmark expired" err="... hasn't received required bookmark event marking the end of initial events stream ..."
error: timed out waiting for the condition        (hung 20s until timeout)
```

After:
```
$ kubectl rollout status deployment/web
deployment "web" successfully rolled out           (0.07s)

$ kubectl wait --for=condition=available deployment/web
deployment.apps/web condition met

$ kubectl get pods -w                               (streams, interruptible, no hang)

$ kubectl get events
LAST SEEN   TYPE     REASON             OBJECT                        MESSAGE
15s         Normal   Scheduled          pod/web-...                   Successfully assigned default/web-... to cloudemu-node-0
...
```

## Tests

- `TestWatchList_EmitsInitialEventsEndBookmark` — issues a real WatchList request against a populated store (typed ConfigMaps + registry ReplicaSets) and asserts the stream is `ADDED × N` then a terminal `BOOKMARK` carrying the `k8s.io/initial-events-end: "true"` annotation and a valid resourceVersion.
- `TestWatch_PlainBookmarkHasNoInitialEventsEndAnnotation` — regression guard that a plain watch's bookmark does NOT carry the annotation.
- `TestEvents_TableColumns` — asserts the Event Table columns and cell values.

Gates (GOMAXPROCS=3): `go build ./...`, `go vet ./...`, `go test ./services/kubernetes/... ./server/... .`, `go test -race ./services/kubernetes/...`, `golangci-lint ./services/kubernetes/...` (only the pre-existing admission.go:351 gosec baseline), `go generate ./...` (no diff) — all clean.
