### PR TITLE
feat(serve): point users to the :engines image when engine flags are passed to the lean binary (#445)

### DIFF
--- a/cmd/cloudemu/serve.go
+++ b/cmd/cloudemu/serve.go
@@ -18,6 +18,39 @@ import (
 // errStateFileRequired is returned when --persist is set without --state-file.
 var errStateFileRequired = errors.New("--persist requires --state-file")
 
+// errEnginesNotInLeanBinary is returned when engine flags/env are passed to the
+// lean cloudemu binary, which deliberately does not compile the real engines
+// (postgres/redis/subprocess/docker/localfs) — those heavy deps live only in the
+// :engines image (contrib/server). Rather than silently ignore the intent, serve
+// points the user at the batteries image.
+var errEnginesNotInLeanBinary = errors.New(
+	"real engines (postgres/redis/subprocess/docker/localfs) aren't compiled into the lean cloudemu binary.\n" +
+		"run the batteries image:  docker run -p 4566:4566 ghcr.io/stackshy/cloudemu:engines --all-real\n" +
+		"(or build ./contrib/server from a repo checkout). see https://cloudemu.info/docs/standalone-server")
+
+// engineFlag names a real-engine selector understood by the :engines image
+// (contrib/server) but only stubbed in the lean binary. Env is its environment
+// form ("" when it has none). This single iterable list is the source of truth
+// PR-2 will promote into server/serveflags; both the stub registration and the
+// detector range over it, so a new engine capability is one line here.
+type engineFlag struct{ Name, Env string }
+
+// engineAllRealFlag is the one boolean engine flag; every other engine flag
+// takes a string value.
+const engineAllRealFlag = "all-real"
+
+//nolint:gochecknoglobals // single source of truth for engine flag names/envs; promoted to server/serveflags in PR-2
+var engineFlags = []engineFlag{
+	{"db", "CLOUDEMU_DB"},
+	{"cache", "CLOUDEMU_CACHE"},
+	{"functions", "CLOUDEMU_FUNCTIONS"},
+	{"compute", "CLOUDEMU_COMPUTE"},
+	{"containers", "CLOUDEMU_CONTAINERS"},
+	{"storage", "CLOUDEMU_STORAGE"},
+	{"storage-dir", ""},
+	{engineAllRealFlag, ""},
+}
+
 // serveConfig holds the resolved serve flags.
 type serveConfig struct {
 	providers         string
@@ -69,6 +102,12 @@ func runServe(args []string) error {
 		return err
 	}
 
+	// The lean binary can't run real engines; point the user at the :engines
+	// image before binding listeners or building providers.
+	if enginesRequested(fs, os.Getenv) {
+		return errEnginesNotInLeanBinary
+	}
+
 	if (c.tlsCert == "") != (c.tlsKey == "") {
 		return errors.New("--tls-cert and --tls-key must be given together")
 	}
@@ -102,6 +141,86 @@ func runServe(args []string) error {
 // (the cross-entrypoint parity guard) without executing a server.
 func newServeFlagSet(c *serveConfig) *flag.FlagSet {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	registerRealServeFlags(fs, c)
+	// Register the engine flags as inert stubs so the REAL parser handles every
+	// syntax (--db=x, --db x, -db) and an engine name that appears as another
+	// flag's value stays a value. runServe detects intent via fs.Visit.
+	registerEngineStubs(fs)
+
+	fs.Usage = func() {
+		out := fs.Output()
+		fmt.Fprintf(out, "Usage: cloudemu serve [flags]\n\nStart the standalone emulator. Flags:\n")
+		// Hide the engine stubs from --help: render from a real-only clone so the
+		// output matches stdlib's exact formatting without the engine flags, then
+		// point at the :engines image in a footer.
+		realOnly := flag.NewFlagSet("serve", flag.ContinueOnError)
+		realOnly.SetOutput(out)
+		registerRealServeFlags(realOnly, &serveConfig{})
+		realOnly.PrintDefaults()
+		fmt.Fprintf(out, "\nReal engines (postgres/redis/subprocess/docker/localfs) live in the "+
+			"cloudemu:engines image, not this lean binary:\n"+
+			"  docker run -p 4566:4566 ghcr.io/stackshy/cloudemu:engines --all-real\n")
+	}
+
+	return fs
+}
+
+// registerEngineStubs registers each engine flag as an inert stub whose target is
+// discarded. Their only purpose is to let the flag tokenizer accept the flag in
+// any form; detection is done afterwards via fs.Visit, never these values.
+func registerEngineStubs(fs *flag.FlagSet) {
+	for _, f := range engineFlags {
+		if f.Name == engineAllRealFlag {
+			_ = fs.Bool(f.Name, false, "")
+
+			continue
+		}
+
+		_ = fs.String(f.Name, "", "")
+	}
+}
+
+// isEngineFlag reports whether name is one of the real-engine selector flags.
+func isEngineFlag(name string) bool {
+	for _, f := range engineFlags {
+		if f.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// enginesRequested reports whether the user asked for a real engine — either by
+// setting an engine flag on the command line (detected via fs.Visit after a real
+// parse, so an engine name that is another flag's value does not count) or via a
+// non-empty engine env var.
+func enginesRequested(fs *flag.FlagSet, getenv func(string) string) bool {
+	set := false
+
+	fs.Visit(func(f *flag.Flag) {
+		if isEngineFlag(f.Name) {
+			set = true
+		}
+	})
+
+	if set {
+		return true
+	}
+
+	for _, f := range engineFlags {
+		if f.Env != "" && getenv(f.Env) != "" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// registerRealServeFlags registers every real serve flag against c. It is called
+// both for the live flag set and (with a throwaway config) to render --help
+// without the engine stubs.
+func registerRealServeFlags(fs *flag.FlagSet, c *serveConfig) {
 	// OCI is not started by default: it stays opt-in until its services land, so
 	// the default set never binds a port that serves nothing.
 	fs.StringVar(&c.providers, "providers", "aws,azure,gcp", "comma-separated providers to start: aws,azure,gcp,oci")
@@ -150,13 +269,6 @@ func newServeFlagSet(c *serveConfig) *flag.FlagSet {
 			"principals that have IAM policies. Azure: validate each request's Bearer token claims (accepted audience, expiry, a "+
 			"principal claim) and reject missing/malformed/expired/wrong-audience tokens with 401 — the token SIGNATURE is NOT "+
 			"verified (no Azure AD signing key), so this is claims-based authentication only; RBAC authorization is a follow-up")
-
-	fs.Usage = func() {
-		fmt.Fprintf(fs.Output(), "Usage: cloudemu serve [flags]\n\nStart the standalone emulator. Flags:\n")
-		fs.PrintDefaults()
-	}
-
-	return fs
 }
 
 // toServerkitConfig maps the resolved serve flags onto a serverkit.Config for

--- a/cmd/cloudemu/serve_engines_test.go
+++ b/cmd/cloudemu/serve_engines_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestServeEngineFlagsPointToEnginesImage verifies that engine flags/env passed
+// to the lean binary return the :engines pointer error before any server starts,
+// instead of being silently ignored.
+func TestServeEngineFlagsPointToEnginesImage(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		env  map[string]string
+	}{
+		{"db-flag", []string{"--db=postgres"}, nil},
+		{"all-real", []string{"--all-real"}, nil},
+		{"storage-dir", []string{"--storage-dir=/x"}, nil},
+		{"env-only", nil, map[string]string{"CLOUDEMU_DB": "postgres"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+
+			err := runServe(tc.args)
+			if !errors.Is(err, errEnginesNotInLeanBinary) {
+				t.Fatalf("runServe(%v) err = %v, want the :engines pointer", tc.args, err)
+			}
+
+			if !strings.Contains(err.Error(), "cloudemu:engines") {
+				t.Fatalf("pointer message %q does not mention the :engines image", err)
+			}
+		})
+	}
+}
+
+// TestServeAccountIDValueIsNotAnEngineFlag is the false-positive guard: with
+// `serve --account-id --db`, `--db` is the VALUE of --account-id (a string flag),
+// not a set flag. fs.Visit reports account-id set and db not set, so the engines
+// pointer must NOT trigger. This proves the stub-flags+fs.Visit approach (a raw
+// os.Args pre-scan would wrongly fire here).
+func TestServeAccountIDValueIsNotAnEngineFlag(t *testing.T) {
+	var c serveConfig
+
+	fs := newServeFlagSet(&c)
+	if err := fs.Parse([]string{"--account-id", "--db"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if c.accountID != "--db" {
+		t.Fatalf("account-id = %q, want %q (--db consumed as its value)", c.accountID, "--db")
+	}
+
+	if enginesRequested(fs, func(string) string { return "" }) {
+		t.Fatal("engines falsely detected: --db was account-id's value, not a set engine flag")
+	}
+}
+
+// TestServeNoEngineFlagsNotTriggered confirms a plain serve invocation with no
+// engine flag/env is not misread as an engine request.
+func TestServeNoEngineFlagsNotTriggered(t *testing.T) {
+	var c serveConfig
+
+	fs := newServeFlagSet(&c)
+	if err := fs.Parse([]string{"--quiet", "--region", "eu-west-1"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if enginesRequested(fs, func(string) string { return "" }) {
+		t.Fatal("engines detected for a plain serve invocation with no engine flag/env")
+	}
+}
+
+// TestServeEngineFlagSyntaxes confirms detection works for every flag syntax the
+// real parser accepts (--flag=v, --flag v, -flag) and for a non-empty env var.
+func TestServeEngineFlagSyntaxes(t *testing.T) {
+	syntaxes := [][]string{
+		{"--db=postgres"},
+		{"--db", "postgres"},
+		{"-db", "postgres"},
+		{"--all-real"},
+	}
+
+	for _, args := range syntaxes {
+		var c serveConfig
+
+		fs := newServeFlagSet(&c)
+		if err := fs.Parse(args); err != nil {
+			t.Fatalf("parse(%v): %v", args, err)
+		}
+
+		if !enginesRequested(fs, func(string) string { return "" }) {
+			t.Fatalf("engines NOT detected for %v", args)
+		}
+	}
+
+	// Env form, no flag set.
+	var c serveConfig
+
+	fs := newServeFlagSet(&c)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("parse(nil): %v", err)
+	}
+
+	getenv := func(k string) string {
+		if k == "CLOUDEMU_CACHE" {
+			return "redis"
+		}
+
+		return ""
+	}
+
+	if !enginesRequested(fs, getenv) {
+		t.Fatal("engines NOT detected for CLOUDEMU_CACHE env")
+	}
+}


### PR DESCRIPTION
## Summary

The lean `cloudemu` binary (CGO-off, zero-dep static build) deliberately does **not** compile the real engines (postgres/redis/subprocess/docker/localfs) — those heavy deps (embedded-postgres, miniredis, go-redis, Docker SDK) live only in the `:engines` image (`contrib/server`). This is the intended lean-core / module split.

Today, passing an engine flag to the lean binary is **silently ignored** — `cloudemu serve --db=postgres` starts an all-in-memory server with no hint that the flag did nothing. This PR closes #445's user-visible gap: instead of ignoring engine intent, lean `serve` now **detects** it and points the user at the batteries image.

## What changed (only `cmd/cloudemu/serve.go` + a new test)

- **Single iterable engine-flag list** (`engineFlags []engineFlag{Name, Env}`) covering `db/cache/functions/compute/containers/storage/storage-dir/all-real` and their `CLOUDEMU_*` envs. This is the single source of truth PR-2 will promote into `server/serveflags`; adding a future capability is one line.
- **Detection via registered stub flags + `fs.Visit` (not an `os.Args` pre-scan).** The engine flags are registered on the serve `FlagSet` as inert stubs, so the real parser handles every syntax (`--db=x`, `--db x`, `-db`). After `fs.Parse`, `fs.Visit` reports which engine flags were actually *set*, plus a check of each `CLOUDEMU_*` env. If any is set → return a pointer error **before** binding listeners / building providers.
  - No false positives: `cloudemu serve --account-id --db` sets `account-id="--db"` (consumed as the value) and does **not** trigger the pointer — `fs.Visit` correctly reports `db` was not set. A raw arg scan would wrongly fire here; a test pins this.
- **Pointer message** (stderr, exit 1) points at the actionable path — the `:engines` Docker image or a `contrib/server` source build — never a phantom `cloudemu-server` binary or `go install`:
  ```
  real engines (postgres/redis/subprocess/docker/localfs) aren't compiled into the lean cloudemu binary.
  run the batteries image:  docker run -p 4566:4566 ghcr.io/stackshy/cloudemu:engines --all-real
  (or build ./contrib/server from a repo checkout). see https://cloudemu.info/docs/standalone-server
  ```
- **`--help`** hides the engine stubs (rendered from a real-only clone so formatting is byte-identical to before) and adds a one-line footer pointing at the `:engines` image.
- Plain `cloudemu serve` with no engine flags/env behaves **exactly** as before.

## Tests (new `serve_engines_test.go`)

- `--db=postgres`, `--all-real`, `--storage-dir=/x`, and `CLOUDEMU_DB=postgres` (env, no flag) each → pointer error, no server started.
- False-positive guard: `serve --account-id --db` → `account-id == "--db"`, engines **not** detected.
- Plain `serve` and every flag syntax (`--db=v`, `--db v`, `-db`, `--all-real`, env) covered.

## Scope

PR-1 only: touches just `cmd/cloudemu/serve.go` + its test — no new package, no cross-module change, no `contrib` change. PR-2 (the `server/serveflags` shared-flag package that structurally kills serve-flag drift and promotes this engine-flag list) follows separately.

## Gates

`go build ./...`, `go vet ./...`, `go test ./cmd/cloudemu/... .`, `go generate ./...` (no diff) all clean; `golangci-lint` at baseline (zero new issues).