### PR TITLE
refactor(serve): extract shared serve flags into server/serveflags so the lean and :engines binaries can't drift (#445)

### DIFF
--- a/cmd/cloudemu/lean_deps_test.go
+++ b/cmd/cloudemu/lean_deps_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// engineModulePaths are the heavy real-engine dependencies that must never reach
+// the lean cloudemu binary. They live only in the :engines image (contrib/server);
+// the shared server/serveflags package the lean binary now builds from is
+// deliberately dep-light so pulling it in cannot drag these along. This is the
+// structural guard against the "compile engines into the lean binary" trap.
+//
+//nolint:gochecknoglobals // test fixture: the forbidden engine module paths
+var engineModulePaths = []string{
+	"github.com/fergusstrange/embedded-postgres",
+	"github.com/alicebob/miniredis",
+	"github.com/redis/go-redis",
+	"github.com/docker/docker",
+}
+
+// TestLeanBinaryHasNoEngineDeps shells `go list -deps .` for the lean binary and
+// fails if any forbidden engine module appears in its transitive dependency
+// graph. It proves both the lean binary and server/serveflags stay engine-free.
+func TestLeanBinaryHasNoEngineDeps(t *testing.T) {
+	out, err := exec.Command("go", "list", "-deps", ".").CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list -deps .: %v\n%s", err, out)
+	}
+
+	deps := string(out)
+
+	for _, mod := range engineModulePaths {
+		if strings.Contains(deps, mod) {
+			t.Errorf("lean binary transitively depends on engine module %q — it must stay engine-free", mod)
+		}
+	}
+}

--- a/cmd/cloudemu/persist_flags_test.go
+++ b/cmd/cloudemu/persist_flags_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/stackshy/cloudemu/v2/server/serveflags"
 	"github.com/stackshy/cloudemu/v2/server/serverkit"
 )
 
@@ -13,7 +14,7 @@ func TestServePersistFlagDefaults(t *testing.T) {
 	t.Setenv("CLOUDEMU_PERSIST_STRATEGY", "")
 	t.Setenv("CLOUDEMU_PERSIST_INTERVAL", "")
 
-	var c serveConfig
+	var c serveflags.CommonConfig
 	fs := newServeFlagSet(&c)
 
 	strat := fs.Lookup("persist-strategy")
@@ -39,11 +40,11 @@ func TestServePersistFlagDefaults(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if c.persistStrategy != "on-request" {
-		t.Fatalf("parsed strategy = %q, want on-request", c.persistStrategy)
+	if c.PersistStrategy != "on-request" {
+		t.Fatalf("parsed strategy = %q, want on-request", c.PersistStrategy)
 	}
 
-	if c.persistInterval.String() != "3s" {
-		t.Fatalf("parsed interval = %q, want 3s", c.persistInterval)
+	if c.PersistInterval.String() != "3s" {
+		t.Fatalf("parsed interval = %q, want 3s", c.PersistInterval)
 	}
 }

--- a/cmd/cloudemu/serve.go
+++ b/cmd/cloudemu/serve.go
@@ -7,16 +7,11 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
-	"time"
 
-	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/server/serveflags"
 	"github.com/stackshy/cloudemu/v2/server/serverkit"
 )
-
-// errStateFileRequired is returned when --persist is set without --state-file.
-var errStateFileRequired = errors.New("--persist requires --state-file")
 
 // errEnginesNotInLeanBinary is returned when engine flags/env are passed to the
 // lean cloudemu binary, which deliberately does not compile the real engines
@@ -28,74 +23,8 @@ var errEnginesNotInLeanBinary = errors.New(
 		"run the batteries image:  docker run -p 4566:4566 ghcr.io/stackshy/cloudemu:engines --all-real\n" +
 		"(or build ./contrib/server from a repo checkout). see https://cloudemu.info/docs/standalone-server")
 
-// engineFlag names a real-engine selector understood by the :engines image
-// (contrib/server) but only stubbed in the lean binary. Env is its environment
-// form ("" when it has none). This single iterable list is the source of truth
-// PR-2 will promote into server/serveflags; both the stub registration and the
-// detector range over it, so a new engine capability is one line here.
-type engineFlag struct{ Name, Env string }
-
-// engineAllRealFlag is the one boolean engine flag; every other engine flag
-// takes a string value.
-const engineAllRealFlag = "all-real"
-
-//nolint:gochecknoglobals // single source of truth for engine flag names/envs; promoted to server/serveflags in PR-2
-var engineFlags = []engineFlag{
-	{"db", "CLOUDEMU_DB"},
-	{"cache", "CLOUDEMU_CACHE"},
-	{"functions", "CLOUDEMU_FUNCTIONS"},
-	{"compute", "CLOUDEMU_COMPUTE"},
-	{"containers", "CLOUDEMU_CONTAINERS"},
-	{"storage", "CLOUDEMU_STORAGE"},
-	{"storage-dir", ""},
-	{engineAllRealFlag, ""},
-}
-
-// serveConfig holds the resolved serve flags.
-type serveConfig struct {
-	providers         string
-	host              string
-	advertiseHost     string
-	awsPort           string
-	azurePort         string
-	gcpPort           string
-	ociPort           string
-	k8sPort           string
-	accountID         string
-	azureSubscription string
-	region            string
-	projectID         string
-	latency           time.Duration
-	tlsCert           string
-	tlsKey            string
-	tlsHosts          stringList
-	endpoints         string
-	admin             bool
-	logReqs           bool
-	quiet             bool
-	shutdownTO        time.Duration
-	persist           bool
-	stateFile         string
-	persistMetaOnly   bool
-	persistStrategy   string
-	persistInterval   time.Duration
-	initDir           string
-	enforceAuth       bool
-	k8sProgression    bool
-	k8sProgInterval   time.Duration
-}
-
-// stringList is a repeatable string flag (e.g. --tls-host a --tls-host b).
-type stringList []string
-
-func (s *stringList) String() string { return strings.Join(*s, ",") }
-func (s *stringList) Set(v string) error {
-	*s = append(*s, v)
-	return nil
-}
-
 func runServe(args []string) error {
-	var c serveConfig
+	var c serveflags.CommonConfig
 
 	fs := newServeFlagSet(&c)
 	if err := fs.Parse(args); err != nil {
@@ -108,22 +37,18 @@ func runServe(args []string) error {
 		return errEnginesNotInLeanBinary
 	}
 
-	if (c.tlsCert == "") != (c.tlsKey == "") {
-		return errors.New("--tls-cert and --tls-key must be given together")
-	}
-
-	if c.persist && c.stateFile == "" {
-		return errStateFileRequired
+	if err := c.Validate(); err != nil {
+		return err
 	}
 
 	warnPersistFlagsWithoutPersist(fs, &c)
 
-	sel, err := parseProviders(c.providers)
+	sel, err := serveflags.ParseProviders(c.Providers)
 	if err != nil {
 		return err
 	}
 
-	cfg := c.toServerkitConfig(sel)
+	cfg := c.ToServerkitConfig(sel)
 
 	app, err := serverkit.New(&cfg)
 	if err != nil {
@@ -137,11 +62,14 @@ func runServe(args []string) error {
 }
 
 // newServeFlagSet registers every serve flag against c and returns the flag set.
-// Splitting registration out of runServe lets tests inspect flag names/defaults
-// (the cross-entrypoint parity guard) without executing a server.
-func newServeFlagSet(c *serveConfig) *flag.FlagSet {
+// The common flags come from the shared server/serveflags package (so this lean
+// binary and the :engines image can't drift); the engine selectors are registered
+// as inert stubs so the real parser handles every syntax and runServe can detect
+// engine intent via fs.Visit. Splitting registration out of runServe lets tests
+// inspect flag names/defaults without executing a server.
+func newServeFlagSet(c *serveflags.CommonConfig) *flag.FlagSet {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
-	registerRealServeFlags(fs, c)
+	serveflags.RegisterCommon(fs, c, os.Getenv)
 	// Register the engine flags as inert stubs so the REAL parser handles every
 	// syntax (--db=x, --db x, -db) and an engine name that appears as another
 	// flag's value stays a value. runServe detects intent via fs.Visit.
@@ -155,7 +83,7 @@ func newServeFlagSet(c *serveConfig) *flag.FlagSet {
 		// point at the :engines image in a footer.
 		realOnly := flag.NewFlagSet("serve", flag.ContinueOnError)
 		realOnly.SetOutput(out)
-		registerRealServeFlags(realOnly, &serveConfig{})
+		serveflags.RegisterCommon(realOnly, &serveflags.CommonConfig{}, os.Getenv)
 		realOnly.PrintDefaults()
 		fmt.Fprintf(out, "\nReal engines (postgres/redis/subprocess/docker/localfs) live in the "+
 			"cloudemu:engines image, not this lean binary:\n"+
@@ -169,8 +97,8 @@ func newServeFlagSet(c *serveConfig) *flag.FlagSet {
 // discarded. Their only purpose is to let the flag tokenizer accept the flag in
 // any form; detection is done afterwards via fs.Visit, never these values.
 func registerEngineStubs(fs *flag.FlagSet) {
-	for _, f := range engineFlags {
-		if f.Name == engineAllRealFlag {
+	for _, f := range serveflags.EngineFlags {
+		if f.Name == serveflags.EngineAllReal {
 			_ = fs.Bool(f.Name, false, "")
 
 			continue
@@ -178,17 +106,6 @@ func registerEngineStubs(fs *flag.FlagSet) {
 
 		_ = fs.String(f.Name, "", "")
 	}
-}
-
-// isEngineFlag reports whether name is one of the real-engine selector flags.
-func isEngineFlag(name string) bool {
-	for _, f := range engineFlags {
-		if f.Name == name {
-			return true
-		}
-	}
-
-	return false
 }
 
 // enginesRequested reports whether the user asked for a real engine — either by
@@ -199,7 +116,7 @@ func enginesRequested(fs *flag.FlagSet, getenv func(string) string) bool {
 	set := false
 
 	fs.Visit(func(f *flag.Flag) {
-		if isEngineFlag(f.Name) {
+		if serveflags.IsEngineFlag(f.Name) {
 			set = true
 		}
 	})
@@ -208,7 +125,7 @@ func enginesRequested(fs *flag.FlagSet, getenv func(string) string) bool {
 		return true
 	}
 
-	for _, f := range engineFlags {
+	for _, f := range serveflags.EngineFlags {
 		if f.Env != "" && getenv(f.Env) != "" {
 			return true
 		}
@@ -217,106 +134,10 @@ func enginesRequested(fs *flag.FlagSet, getenv func(string) string) bool {
 	return false
 }
 
-// registerRealServeFlags registers every real serve flag against c. It is called
-// both for the live flag set and (with a throwaway config) to render --help
-// without the engine stubs.
-func registerRealServeFlags(fs *flag.FlagSet, c *serveConfig) {
-	// OCI is not started by default: it stays opt-in until its services land, so
-	// the default set never binds a port that serves nothing.
-	fs.StringVar(&c.providers, "providers", "aws,azure,gcp", "comma-separated providers to start: aws,azure,gcp,oci")
-	fs.StringVar(&c.host, "host", "127.0.0.1", "host/interface to bind (use 0.0.0.0 to expose on the network)")
-	fs.StringVar(&c.advertiseHost, "advertise-host", "",
-		"host/IP the Kubernetes data-plane endpoint is advertised at in kubeconfigs and its TLS cert "+
-			"(default: --host, or 127.0.0.1 when binding all interfaces such as 0.0.0.0 under Docker)")
-	fs.StringVar(&c.awsPort, "aws-port", "4566", "port for the AWS endpoint (HTTP)")
-	fs.StringVar(&c.azurePort, "azure-port", "4568", "port for the Azure endpoint (HTTPS)")
-	fs.StringVar(&c.gcpPort, "gcp-port", "4569", "port for the GCP endpoint (HTTP)")
-	fs.StringVar(&c.ociPort, "oci-port", "4571", "port for the OCI endpoint (HTTP)")
-	fs.StringVar(&c.k8sPort, "k8s-port", "4570", "port for the shared Kubernetes data-plane (HTTPS); empty to disable")
-	fs.StringVar(&c.accountID, "account-id", "000000000000", "AWS account ID (also GCP/OCI) reported by the emulator")
-	fs.StringVar(&c.azureSubscription, "azure-subscription", "00000000-0000-0000-0000-000000000000",
-		"Azure subscription id reported by the emulator (a GUID; real Azure SDKs/CLIs require one)")
-	fs.StringVar(&c.region, "region", "us-east-1", "default region reported by the emulator")
-	fs.StringVar(&c.projectID, "project-id", "cloudemu-local", "GCP project ID reported by the emulator")
-	fs.DurationVar(&c.latency, "latency", 0, "artificial latency added to every emulated call (e.g. 20ms)")
-	fs.StringVar(&c.tlsCert, "tls-cert", "", "PEM cert file for the Azure HTTPS endpoint (default: a self-signed cert generated in memory)")
-	fs.StringVar(&c.tlsKey, "tls-key", "", "PEM key file matching --tls-cert")
-	fs.Var(&c.tlsHosts, "tls-host", "extra SAN host/IP for the generated self-signed cert (repeatable)")
-	fs.StringVar(&c.endpoints, "endpoints-file", "", "write the resolved endpoints as JSON to this path")
-	fs.BoolVar(&c.admin, "admin", true, "mount the /_cloudemu control plane (reset, health) for test isolation")
-	fs.BoolVar(&c.logReqs, "log-requests", false, "log every HTTP request (method, path, status, duration)")
-	fs.BoolVar(&c.quiet, "quiet", false, "suppress the startup banner")
-	fs.DurationVar(&c.shutdownTO, "shutdown-timeout", 10*time.Second, "grace period for in-flight requests on shutdown")
-	fs.BoolVar(&c.persist, "persist", false, "save state to --state-file on shutdown and restore it on startup (includes object bodies)")
-	fs.StringVar(&c.stateFile, "state-file", "", "path to the JSON state snapshot (required with --persist)")
-	fs.BoolVar(&c.persistMetaOnly, "persist-metadata-only", false, "persist resource structure but omit object bodies (smaller snapshot)")
-	fs.StringVar(&c.persistStrategy, "persist-strategy", envOr("CLOUDEMU_PERSIST_STRATEGY", serverkit.DefaultPersistStrategy),
-		"when to save with --persist: scheduled|on-request|on-shutdown|manual (env CLOUDEMU_PERSIST_STRATEGY)")
-	fs.DurationVar(&c.persistInterval, "persist-interval",
-		envDurationOr("CLOUDEMU_PERSIST_INTERVAL", serverkit.DefaultPersistInterval),
-		"save cadence for --persist-strategy=scheduled (env CLOUDEMU_PERSIST_INTERVAL)")
-	fs.StringVar(&c.initDir, "init-dir", "", "apply every *.json seed fixture in this directory on startup")
-	fs.BoolVar(&c.k8sProgression, "k8s-progression", envBoolOr("CLOUDEMU_K8S_PROGRESSION", false),
-		"Kubernetes: client-created Pods start Pending and visibly progress to Running on a ticker "+
-			"(default off = instant Running; env CLOUDEMU_K8S_PROGRESSION)")
-	fs.DurationVar(&c.k8sProgInterval, "k8s-progression-interval",
-		envDurationOr("CLOUDEMU_K8S_PROGRESSION_INTERVAL", time.Second),
-		"cadence of the --k8s-progression Pod-lifecycle ticker (env CLOUDEMU_K8S_PROGRESSION_INTERVAL)")
-	fs.BoolVar(&c.enforceAuth, "enforce-auth", false,
-		"require authentication on each request; off by default. AWS: verify the SigV4 signature against a registered IAM access "+
-			"key (403 on failure) and enforce IAM authorization — long-term (AKIA) keys are verified, STS temporary (ASIA) "+
-			"credentials are accepted unverified for now, authorization is enforced for JSON-RPC services only, and applies only to "+
-			"principals that have IAM policies. Azure: validate each request's Bearer token claims (accepted audience, expiry, a "+
-			"principal claim) and reject missing/malformed/expired/wrong-audience tokens with 401 — the token SIGNATURE is NOT "+
-			"verified (no Azure AD signing key), so this is claims-based authentication only; RBAC authorization is a follow-up")
-}
-
-// toServerkitConfig maps the resolved serve flags onto a serverkit.Config for
-// the given provider selection.
-func (c *serveConfig) toServerkitConfig(sel []string) serverkit.Config {
-	return serverkit.Config{
-		Providers: sel,
-		Host:      c.host,
-		Ports: map[string]string{
-			"aws":   c.awsPort,
-			"azure": c.azurePort,
-			"gcp":   c.gcpPort,
-			"oci":   c.ociPort,
-		},
-		K8sPort:                c.k8sPort,
-		AdvertiseHost:          c.advertiseHost,
-		K8sProgression:         c.k8sProgression,
-		K8sProgressionInterval: c.k8sProgInterval,
-		AzureSubscription:      c.azureSubscription,
-		Admin:                  c.admin,
-		Persist:                c.persist,
-		StateFile:              c.stateFile,
-		PersistMetadataOnly:    c.persistMetaOnly,
-		PersistStrategy:        c.persistStrategy,
-		PersistInterval:        c.persistInterval,
-		InitDir:                c.initDir,
-		TLSCert:                c.tlsCert,
-		TLSKey:                 c.tlsKey,
-		TLSHosts:               c.tlsHosts,
-		Latency:                c.latency,
-		LogRequests:            c.logReqs,
-		Quiet:                  c.quiet,
-		EnforceAuth:            c.enforceAuth,
-		EndpointsFile:          c.endpoints,
-		ShutdownTimeout:        c.shutdownTO,
-		BaseOptions: []config.Option{
-			config.WithAccountID(c.accountID),
-			config.WithRegion(c.region),
-			config.WithProjectID(c.projectID),
-		},
-		Out: os.Stdout,
-	}
-}
-
 // warnPersistFlagsWithoutPersist prints a one-line warning when a persist-tuning
 // flag was set explicitly but --persist is off, so the ignored knob is visible.
-func warnPersistFlagsWithoutPersist(fs *flag.FlagSet, c *serveConfig) {
-	if c.persist {
+func warnPersistFlagsWithoutPersist(fs *flag.FlagSet, c *serveflags.CommonConfig) {
+	if c.Persist {
 		return
 	}
 
@@ -329,71 +150,4 @@ func warnPersistFlagsWithoutPersist(fs *flag.FlagSet, c *serveConfig) {
 			fmt.Fprintf(os.Stderr, "warning: --%s has no effect without --persist\n", name)
 		}
 	}
-}
-
-// envOr returns the environment value for key, or def when it is unset/empty.
-func envOr(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-
-	return def
-}
-
-// envDurationOr parses the environment value for key as a duration, or returns
-// def when it is unset/empty/unparseable.
-func envDurationOr(key string, def time.Duration) time.Duration {
-	v := os.Getenv(key)
-	if v == "" {
-		return def
-	}
-
-	d, err := time.ParseDuration(v)
-	if err != nil {
-		return def
-	}
-
-	return d
-}
-
-// envBoolOr reads the environment value for key as a boolean (1/true/yes/on,
-// case-insensitive), or returns def when it is unset/empty/unrecognized.
-func envBoolOr(key string, def bool) bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
-	case "1", "true", "yes", "on":
-		return true
-	case "0", "false", "no", "off":
-		return false
-	default:
-		return def
-	}
-}
-
-func parseProviders(s string) ([]string, error) {
-	seen := map[string]bool{}
-
-	var out []string
-
-	for _, raw := range strings.Split(s, ",") {
-		p := strings.TrimSpace(strings.ToLower(raw))
-		if p == "" {
-			continue
-		}
-
-		if p != "aws" && p != "azure" && p != "gcp" && p != "oci" {
-			return nil, fmt.Errorf("unknown provider %q (want aws, azure, gcp, or oci)", p)
-		}
-
-		if !seen[p] {
-			seen[p] = true
-
-			out = append(out, p)
-		}
-	}
-
-	if len(out) == 0 {
-		return nil, errors.New("no providers selected")
-	}
-
-	return out, nil
 }

--- a/cmd/cloudemu/serve_common_flags_test.go
+++ b/cmd/cloudemu/serve_common_flags_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/server/serveflags"
+)
+
+// commonFlagNames returns the set of flag names a bare serveflags.RegisterCommon
+// produces — the shared source of truth both serve entrypoints build from.
+func commonFlagNames(t *testing.T) map[string]string {
+	t.Helper()
+
+	ref := flag.NewFlagSet("ref", flag.ContinueOnError)
+	serveflags.RegisterCommon(ref, &serveflags.CommonConfig{}, func(string) string { return "" })
+
+	names := map[string]string{}
+	ref.VisitAll(func(f *flag.Flag) { names[f.Name] = f.DefValue })
+
+	return names
+}
+
+// TestServeRegistersEveryCommonFlag proves the lean serve FlagSet is built from
+// serveflags.RegisterCommon: every shared common flag (name + default) is present.
+// Together with contrib's mirror of this test, neither main can carry a divergent
+// copy of a common flag — the drift the shared package removes.
+func TestServeRegistersEveryCommonFlag(t *testing.T) {
+	t.Setenv("CLOUDEMU_PERSIST_STRATEGY", "")
+	t.Setenv("CLOUDEMU_PERSIST_INTERVAL", "")
+	t.Setenv("CLOUDEMU_K8S_PROGRESSION", "")
+	t.Setenv("CLOUDEMU_K8S_PROGRESSION_INTERVAL", "")
+
+	var c serveflags.CommonConfig
+
+	fs := newServeFlagSet(&c)
+
+	for name, def := range commonFlagNames(t) {
+		f := fs.Lookup(name)
+		if f == nil {
+			t.Errorf("lean serve is missing shared common flag --%s", name)
+
+			continue
+		}
+
+		if f.DefValue != def {
+			t.Errorf("--%s default = %q in lean serve, want %q (shared)", name, f.DefValue, def)
+		}
+	}
+}

--- a/cmd/cloudemu/serve_engines_test.go
+++ b/cmd/cloudemu/serve_engines_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/stackshy/cloudemu/v2/server/serveflags"
 )
 
 // TestServeEngineFlagsPointToEnginesImage verifies that engine flags/env passed
@@ -45,15 +47,15 @@ func TestServeEngineFlagsPointToEnginesImage(t *testing.T) {
 // pointer must NOT trigger. This proves the stub-flags+fs.Visit approach (a raw
 // os.Args pre-scan would wrongly fire here).
 func TestServeAccountIDValueIsNotAnEngineFlag(t *testing.T) {
-	var c serveConfig
+	var c serveflags.CommonConfig
 
 	fs := newServeFlagSet(&c)
 	if err := fs.Parse([]string{"--account-id", "--db"}); err != nil {
 		t.Fatalf("parse: %v", err)
 	}
 
-	if c.accountID != "--db" {
-		t.Fatalf("account-id = %q, want %q (--db consumed as its value)", c.accountID, "--db")
+	if c.AccountID != "--db" {
+		t.Fatalf("account-id = %q, want %q (--db consumed as its value)", c.AccountID, "--db")
 	}
 
 	if enginesRequested(fs, func(string) string { return "" }) {
@@ -64,7 +66,7 @@ func TestServeAccountIDValueIsNotAnEngineFlag(t *testing.T) {
 // TestServeNoEngineFlagsNotTriggered confirms a plain serve invocation with no
 // engine flag/env is not misread as an engine request.
 func TestServeNoEngineFlagsNotTriggered(t *testing.T) {
-	var c serveConfig
+	var c serveflags.CommonConfig
 
 	fs := newServeFlagSet(&c)
 	if err := fs.Parse([]string{"--quiet", "--region", "eu-west-1"}); err != nil {
@@ -87,7 +89,7 @@ func TestServeEngineFlagSyntaxes(t *testing.T) {
 	}
 
 	for _, args := range syntaxes {
-		var c serveConfig
+		var c serveflags.CommonConfig
 
 		fs := newServeFlagSet(&c)
 		if err := fs.Parse(args); err != nil {
@@ -100,7 +102,7 @@ func TestServeEngineFlagSyntaxes(t *testing.T) {
 	}
 
 	// Env form, no flag set.
-	var c serveConfig
+	var c serveflags.CommonConfig
 
 	fs := newServeFlagSet(&c)
 	if err := fs.Parse(nil); err != nil {

--- a/contrib/server/admin_persist_test.go
+++ b/contrib/server/admin_persist_test.go
@@ -17,7 +17,7 @@ import (
 // --admin flag threads through to serverkit's control plane.
 func TestAdminReset(t *testing.T) {
 	cfg := testConfig(t, allEnginesOff())
-	cfg.admin = true
+	cfg.Admin = true
 
 	awsURL, stop := startAWS(t, cfg, mustOptions(t, &cfg))
 	defer stop()
@@ -45,9 +45,9 @@ func TestPersistRoundTrip(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "state.json")
 
 	cfg := testConfig(t, allEnginesOff())
-	cfg.admin = true
-	cfg.persist = true
-	cfg.stateFile = stateFile
+	cfg.Admin = true
+	cfg.Persist = true
+	cfg.StateFile = stateFile
 
 	awsURL, stop := startAWS(t, cfg, mustOptions(t, &cfg))
 	seedBucket(t, awsURL, "persist-me")
@@ -59,9 +59,9 @@ func TestPersistRoundTrip(t *testing.T) {
 
 	// A fresh app on the same state file (new ports) must restore the bucket.
 	cfg2 := testConfig(t, allEnginesOff())
-	cfg2.admin = true
-	cfg2.persist = true
-	cfg2.stateFile = stateFile
+	cfg2.Admin = true
+	cfg2.Persist = true
+	cfg2.StateFile = stateFile
 
 	awsURL2, stop2 := startAWS(t, cfg2, mustOptions(t, &cfg2))
 	defer stop2()
@@ -82,8 +82,8 @@ func TestInitDir(t *testing.T) {
 	}
 
 	cfg := testConfig(t, allEnginesOff())
-	cfg.admin = true
-	cfg.initDir = dir
+	cfg.Admin = true
+	cfg.InitDir = dir
 
 	awsURL, stop := startAWS(t, cfg, mustOptions(t, &cfg))
 	defer stop()
@@ -93,7 +93,8 @@ func TestInitDir(t *testing.T) {
 	}
 }
 
-// mustOptions builds the identity+engine options for a config or fails the test.
+// mustOptions builds the engine options for a config or fails the test. The
+// identity options are added by ToServerkitConfig inside newAppFromOptions.
 func mustOptions(t *testing.T, cfg *appConfig) []config.Option {
 	t.Helper()
 

--- a/contrib/server/app.go
+++ b/contrib/server/app.go
@@ -7,16 +7,6 @@ import (
 	"github.com/stackshy/cloudemu/v2/server/serverkit"
 )
 
-// Provider names accepted by --providers and mapped onto serverkit. OCI is
-// opt-in (not in the default set); Kubernetes is a shared data-plane toggled by
-// --k8s-port rather than a provider.
-const (
-	providerAWS   = "aws"
-	providerAzure = "azure"
-	providerGCP   = "gcp"
-	providerOCI   = "oci"
-)
-
 // app is the batteries-included emulator: a serverkit.App wired with the selected
 // real data-plane engines. serverkit owns provider construction, listener
 // binding, the shutdown/snapshot lifecycle, and engine teardown on Close, so this
@@ -26,58 +16,23 @@ type app struct {
 	kit *serverkit.App
 }
 
-// newAppFromOptions builds the serverkit App from an already-assembled option set
-// (identity plus engines). Keeping it separate from option-building lets tests
-// supply a pre-built set so an engine can bind a known port.
-func newAppFromOptions(cfg *appConfig, opts []config.Option) (*app, error) {
-	kit, err := serverkit.New(serverkitConfig(cfg, opts))
+// newAppFromOptions builds the serverkit App from an already-assembled engine
+// option set. The shared serveflags.ToServerkitConfig maps the common flags onto
+// serverkit.Config and seeds BaseOptions with the identity options
+// (account/region/project); this appends the real-engine options to BaseOptions
+// afterwards and points Out at this run's sink. Keeping option-building separate
+// lets tests supply a pre-built engine set so an engine can bind a known port.
+func newAppFromOptions(cfg *appConfig, engineOpts []config.Option) (*app, error) {
+	skc := cfg.ToServerkitConfig(cfg.providers)
+	skc.Out = cfg.out
+	skc.BaseOptions = append(skc.BaseOptions, engineOpts...)
+
+	kit, err := serverkit.New(&skc)
 	if err != nil {
 		return nil, err
 	}
 
 	return &app{cfg: *cfg, kit: kit}, nil
-}
-
-// serverkitConfig maps the resolved flag configuration onto a serverkit.Config.
-// serverkit builds every selected provider (aws/azure/gcp/oci) via
-// <provider>server.DriversFrom, wires the shared Kubernetes data-plane, admin
-// control plane, persistence, seeding, TLS, latency, request logging, and auth
-// enforcement, and owns the serve/shutdown/snapshot lifecycle plus engine
-// teardown — this module only supplies the real-engine BaseOptions.
-func serverkitConfig(cfg *appConfig, opts []config.Option) *serverkit.Config {
-	return &serverkit.Config{
-		Providers:     cfg.providers,
-		Host:          cfg.host,
-		AdvertiseHost: cfg.advertiseHost,
-		Ports: map[string]string{
-			providerAWS:   cfg.awsPort,
-			providerAzure: cfg.azurePort,
-			providerGCP:   cfg.gcpPort,
-			providerOCI:   cfg.ociPort,
-		},
-		K8sPort:                cfg.k8sPort,
-		K8sProgression:         cfg.k8sProgression,
-		K8sProgressionInterval: cfg.k8sProgInterval,
-		AzureSubscription:      cfg.azureSubscription,
-		Admin:               cfg.admin,
-		Persist:             cfg.persist,
-		StateFile:           cfg.stateFile,
-		PersistMetadataOnly: cfg.persistMetaOnly,
-		PersistStrategy:     cfg.persistStrategy,
-		PersistInterval:     cfg.persistInterval,
-		InitDir:             cfg.initDir,
-		TLSCert:             cfg.tlsCert,
-		TLSKey:              cfg.tlsKey,
-		TLSHosts:            cfg.tlsHosts,
-		Latency:             cfg.latency,
-		LogRequests:         cfg.logRequests,
-		Quiet:               cfg.quiet,
-		EnforceAuth:         cfg.enforceAuth,
-		EndpointsFile:       cfg.endpointsFile,
-		BaseOptions:         opts,
-		ShutdownTimeout:     cfg.shutdownTimeout,
-		Out:                 cfg.out,
-	}
 }
 
 // Serve runs the emulator until ctx is canceled, then gracefully shuts down and
@@ -86,24 +41,12 @@ func (a *app) Serve(ctx context.Context) error {
 	return a.kit.Serve(ctx)
 }
 
-// buildOptions assembles the identity options plus the selected engine options,
-// and returns the per-capability MODE table for the startup banner. dockerProbe
-// reports whether the docker CLI is available; a Docker-backed engine degrades to
-// in-memory (a MODE row) when it is not.
+// buildOptions assembles the selected engine options and returns the
+// per-capability MODE table for the startup banner. The identity options are
+// added by ToServerkitConfig, so this returns the engine options only, which
+// newAppFromOptions appends to BaseOptions. dockerProbe reports whether the docker
+// CLI is available; a Docker-backed engine degrades to in-memory (a MODE row)
+// when it is not.
 func buildOptions(cfg *appConfig, dockerProbe func() bool) ([]config.Option, []engineMode, error) {
-	engineOpts, modes, err := cfg.engines.buildEngineOptions(dockerProbe)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	const identityOpts = 3
-
-	opts := make([]config.Option, 0, identityOpts+len(engineOpts))
-	opts = append(opts,
-		config.WithAccountID(cfg.accountID),
-		config.WithRegion(cfg.region),
-		config.WithProjectID(cfg.projectID),
-	)
-
-	return append(opts, engineOpts...), modes, nil
+	return cfg.engines.buildEngineOptions(dockerProbe)
 }

--- a/contrib/server/common_flags_test.go
+++ b/contrib/server/common_flags_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"flag"
+	"sort"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/server/serveflags"
+)
+
+// noEnv reports every variable as unset, so defaults are the built-in ones.
+func noEnv(string) string { return "" }
+
+// buildParseFlagSet registers the batteries entrypoint's flags exactly as
+// parseFlags composes them: the engine selectors plus the shared common set.
+func buildParseFlagSet() *flag.FlagSet {
+	fs := flag.NewFlagSet("cloudemu-server", flag.ContinueOnError)
+
+	var (
+		engines engineSelection
+		allReal bool
+	)
+
+	registerEngineFlags(fs, &engines, &allReal, noEnv)
+	serveflags.RegisterCommon(fs, &serveflags.CommonConfig{}, noEnv)
+
+	return fs
+}
+
+// TestBatteriesRegistersEveryCommonFlag mirrors cmd/cloudemu's guard: the
+// batteries entrypoint registers every shared common flag (name + default) via
+// serveflags.RegisterCommon, so it can't drift from `cloudemu serve`.
+func TestBatteriesRegistersEveryCommonFlag(t *testing.T) {
+	ref := flag.NewFlagSet("ref", flag.ContinueOnError)
+	serveflags.RegisterCommon(ref, &serveflags.CommonConfig{}, noEnv)
+
+	fs := buildParseFlagSet()
+
+	ref.VisitAll(func(rf *flag.Flag) {
+		f := fs.Lookup(rf.Name)
+		if f == nil {
+			t.Errorf("batteries server is missing shared common flag --%s", rf.Name)
+
+			return
+		}
+
+		if f.DefValue != rf.DefValue {
+			t.Errorf("--%s default = %q in batteries server, want %q (shared)", rf.Name, f.DefValue, rf.DefValue)
+		}
+	})
+}
+
+// TestBatteriesEngineFlagNamesMatchSharedList proves the engine selectors this
+// module registers are exactly serveflags.EngineFlags — the single list the lean
+// binary's stub detector also ranges over. A rename in one place fails here.
+func TestBatteriesEngineFlagNamesMatchSharedList(t *testing.T) {
+	fs := buildParseFlagSet()
+
+	var got []string
+
+	fs.VisitAll(func(f *flag.Flag) {
+		if serveflags.IsEngineFlag(f.Name) {
+			got = append(got, f.Name)
+		}
+	})
+
+	want := make([]string, 0, len(serveflags.EngineFlags))
+	for _, f := range serveflags.EngineFlags {
+		want = append(want, f.Name)
+	}
+
+	sort.Strings(got)
+	sort.Strings(want)
+
+	if len(got) != len(want) {
+		t.Fatalf("engine flags registered = %v, want %v", got, want)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("engine flags registered = %v, want %v", got, want)
+		}
+	}
+}

--- a/contrib/server/enforce_auth_test.go
+++ b/contrib/server/enforce_auth_test.go
@@ -16,7 +16,7 @@ import (
 func TestEnforceAuthRejectsInvalidSignature(t *testing.T) {
 	t.Run("enforced rejects", func(t *testing.T) {
 		cfg := testConfig(t, allEnginesOff())
-		cfg.enforceAuth = true
+		cfg.EnforceAuth = true
 
 		awsURL, stop := startAWS(t, cfg, mustOptions(t, &cfg))
 		defer stop()
@@ -35,7 +35,7 @@ func TestEnforceAuthRejectsInvalidSignature(t *testing.T) {
 
 	t.Run("not enforced passes", func(t *testing.T) {
 		cfg := testConfig(t, allEnginesOff())
-		cfg.enforceAuth = false
+		cfg.EnforceAuth = false
 
 		awsURL, stop := startAWS(t, cfg, mustOptions(t, &cfg))
 		defer stop()

--- a/contrib/server/main.go
+++ b/contrib/server/main.go
@@ -6,89 +6,34 @@
 // Assembly (provider construction, listener binding, the shutdown/snapshot
 // lifecycle, engine teardown) is delegated to the shared server/serverkit
 // package, so this binary and `cloudemu serve` don't drift; this module only adds
-// the real-engine selection and its startup MODE banner. Flag names and defaults
-// mirror `cloudemu serve` for parity.
+// the real-engine selection and its startup MODE banner. The common flags are
+// registered from the shared server/serveflags package (the same source
+// `cloudemu serve` builds from), so the ~30 shared flags can't drift either.
 package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
-	"time"
 
-	"github.com/stackshy/cloudemu/v2/server/serverkit"
+	"github.com/stackshy/cloudemu/v2/server/serveflags"
 )
 
-// defaultShutdownTimeout is the grace period for in-flight requests.
-const defaultShutdownTimeout = 10 * time.Second
-
-var (
-	// errStateFileRequired is returned when --persist is set without --state-file.
-	errStateFileRequired = errors.New("--persist requires --state-file")
-	// errTLSPairRequired is returned when only one of --tls-cert/--tls-key is set.
-	errTLSPairRequired = errors.New("--tls-cert and --tls-key must be given together")
-	// errNoProviders is returned when --providers resolves to an empty set.
-	errNoProviders = errors.New("no providers selected")
-	// errUnknownProvider is returned for a --providers value outside aws/azure/gcp/oci.
-	errUnknownProvider = errors.New("unknown provider (want aws, azure, gcp, or oci)")
-)
-
-// stringList is a repeatable string flag (e.g. --tls-host a --tls-host b).
-type stringList []string
-
-func (s *stringList) String() string { return strings.Join(*s, ",") }
-
-func (s *stringList) Set(v string) error {
-	*s = append(*s, v)
-
-	return nil
-}
-
-// appConfig is the resolved flag/env configuration for one server run.
+// appConfig is the resolved flag/env configuration for one server run. The
+// common flags live in the embedded serveflags.CommonConfig (shared with
+// `cloudemu serve`); this module only adds the engine selection and the parsed
+// provider list.
 type appConfig struct {
+	serveflags.CommonConfig
+
 	engines engineSelection
 
-	providers     []string // parsed provider set: aws,azure,gcp,oci
-	host          string
-	advertiseHost string
-	awsPort       string
-	azurePort     string
-	gcpPort       string
-	ociPort       string
-	k8sPort       string
-
-	accountID         string
-	azureSubscription string
-	region            string
-	projectID         string
-
-	latency  time.Duration
-	tlsCert  string
-	tlsKey   string
-	tlsHosts stringList
-
-	admin           bool
-	logRequests     bool
-	quiet           bool
-	enforceAuth     bool
-	k8sProgression  bool
-	k8sProgInterval time.Duration
-	persist         bool
-	stateFile       string
-	persistMetaOnly bool
-	persistStrategy string
-	persistInterval time.Duration
-	initDir         string
-	endpointsFile   string
-
-	shutdownTimeout time.Duration
-	out             io.Writer // banner/diagnostics sink handed to serverkit
+	providers []string  // parsed provider set from CommonConfig.Providers
+	out       io.Writer // banner/diagnostics sink handed to serverkit
 }
 
 func main() {
@@ -128,7 +73,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 	// suppressed under --quiet.
 	warnDegraded(stderr, modes)
 
-	if !cfg.quiet {
+	if !cfg.Quiet {
 		printEngineModes(stdout, modes)
 	}
 
@@ -138,67 +83,21 @@ func run(args []string, stdout, stderr io.Writer) error {
 	return a.Serve(ctx)
 }
 
-// parseFlags resolves the configuration from args, with environment-variable
-// fallbacks for the engine selectors. Flag names/defaults mirror `cloudemu serve`.
+// parseFlags resolves the configuration from args. The engine selectors are this
+// module's own flags (with environment fallbacks); the ~30 common flags come from
+// serveflags.RegisterCommon, and the cross-field checks from CommonConfig.Validate
+// — so this entrypoint and `cloudemu serve` build the same serverkit.Config.
 func parseFlags(args []string, getenv func(string) string, out io.Writer) (appConfig, error) {
 	fs := flag.NewFlagSet("cloudemu-server", flag.ContinueOnError)
 	fs.SetOutput(out)
 
 	var (
-		cfg       appConfig
-		allReal   bool
-		providers string
+		cfg     appConfig
+		allReal bool
 	)
 
-	fs.StringVar(&cfg.engines.db, "db", engineEnvOr(getenv, "CLOUDEMU_DB"), "database engine: off|postgres|mysql|both")
-	fs.StringVar(&cfg.engines.cache, "cache", engineEnvOr(getenv, "CLOUDEMU_CACHE"), "cache engine: off|redis")
-	fs.StringVar(&cfg.engines.functions, "functions", engineEnvOr(getenv, "CLOUDEMU_FUNCTIONS"), "function engine: off|subprocess")
-	fs.StringVar(&cfg.engines.compute, "compute", engineEnvOr(getenv, "CLOUDEMU_COMPUTE"), "compute engine: off|docker")
-	fs.StringVar(&cfg.engines.containers, "containers", engineEnvOr(getenv, "CLOUDEMU_CONTAINERS"), "container engine: off|docker")
-	fs.StringVar(&cfg.engines.storage, "storage", engineEnvOr(getenv, "CLOUDEMU_STORAGE"), "storage engine: off|localfs")
-	fs.StringVar(&cfg.engines.storageDir, "storage-dir", "",
-		"root directory for --storage=localfs (default: a temporary directory)")
-	fs.BoolVar(&allReal, "all-real", false,
-		"shorthand: postgres + redis + subprocess + docker compute + docker containers + localfs storage")
-
-	fs.StringVar(&providers, "providers", "aws,azure,gcp", "comma-separated providers to start: aws,azure,gcp,oci")
-	fs.StringVar(&cfg.host, "host", "127.0.0.1", "host/interface to bind (0.0.0.0 exposes on the network)")
-	fs.StringVar(&cfg.advertiseHost, "advertise-host", "",
-		"host/IP the Kubernetes data-plane endpoint is advertised at in kubeconfigs and its TLS cert "+
-			"(default: --host, or 127.0.0.1 when binding all interfaces such as 0.0.0.0 under Docker)")
-	fs.StringVar(&cfg.awsPort, "aws-port", "4566", "port for the AWS endpoint (HTTP)")
-	fs.StringVar(&cfg.azurePort, "azure-port", "4568", "port for the Azure endpoint (HTTPS)")
-	fs.StringVar(&cfg.gcpPort, "gcp-port", "4569", "port for the GCP endpoint (HTTP)")
-	fs.StringVar(&cfg.ociPort, "oci-port", "4571", "port for the OCI endpoint (HTTP)")
-	fs.StringVar(&cfg.k8sPort, "k8s-port", "4570", "port for the shared Kubernetes data-plane (HTTPS); empty to disable")
-	fs.StringVar(&cfg.accountID, "account-id", "000000000000", "AWS account ID (also GCP/OCI) reported by the emulator")
-	fs.StringVar(&cfg.azureSubscription, "azure-subscription", "00000000-0000-0000-0000-000000000000",
-		"Azure subscription id reported by the emulator (a GUID)")
-	fs.StringVar(&cfg.region, "region", "us-east-1", "default region reported by the emulator")
-	fs.StringVar(&cfg.projectID, "project-id", "cloudemu-local", "GCP project ID reported by the emulator")
-
-	fs.DurationVar(&cfg.latency, "latency", 0, "artificial latency added to every emulated call (e.g. 20ms)")
-	fs.StringVar(&cfg.tlsCert, "tls-cert", "",
-		"PEM cert file for the Azure HTTPS endpoint (default: a self-signed cert generated in memory)")
-	fs.StringVar(&cfg.tlsKey, "tls-key", "", "PEM key file matching --tls-cert")
-	fs.Var(&cfg.tlsHosts, "tls-host", "extra SAN host/IP for the generated self-signed cert (repeatable)")
-
-	fs.BoolVar(&cfg.admin, "admin", true, "mount the /_cloudemu control plane (reset, health) for test isolation")
-	fs.BoolVar(&cfg.logRequests, "log-requests", false, "log every HTTP request (method, path, status, duration)")
-	fs.BoolVar(&cfg.quiet, "quiet", false, "suppress the startup banner")
-	fs.BoolVar(&cfg.enforceAuth, "enforce-auth", false, "require authentication on each request; off by default")
-	fs.BoolVar(&cfg.k8sProgression, "k8s-progression", envBoolOr(getenv, "CLOUDEMU_K8S_PROGRESSION", false),
-		"Kubernetes: client-created Pods start Pending and visibly progress to Running on a ticker "+
-			"(default off = instant Running; env CLOUDEMU_K8S_PROGRESSION)")
-	fs.DurationVar(&cfg.k8sProgInterval, "k8s-progression-interval",
-		envDurationOr(getenv, "CLOUDEMU_K8S_PROGRESSION_INTERVAL", time.Second),
-		"cadence of the --k8s-progression Pod-lifecycle ticker (env CLOUDEMU_K8S_PROGRESSION_INTERVAL)")
-	registerPersistFlags(fs, &cfg, getenv)
-	fs.StringVar(&cfg.initDir, "init-dir", "", "apply every *.json seed fixture in this directory on startup")
-	fs.StringVar(&cfg.endpointsFile, "endpoints-file", "", "write the resolved endpoints as JSON to this path")
-
-	fs.DurationVar(&cfg.shutdownTimeout, "shutdown-timeout", defaultShutdownTimeout,
-		"grace period for in-flight requests on shutdown")
+	registerEngineFlags(fs, &cfg.engines, &allReal, getenv)
+	serveflags.RegisterCommon(fs, &cfg.CommonConfig, getenv)
 
 	if err := fs.Parse(args); err != nil {
 		return appConfig{}, err
@@ -208,19 +107,15 @@ func parseFlags(args []string, getenv func(string) string, out io.Writer) (appCo
 		cfg.engines.applyAllReal()
 	}
 
-	sel, err := parseProviders(providers)
+	sel, err := serveflags.ParseProviders(cfg.Providers)
 	if err != nil {
 		return appConfig{}, err
 	}
 
 	cfg.providers = sel
 
-	if (cfg.tlsCert == "") != (cfg.tlsKey == "") {
-		return appConfig{}, errTLSPairRequired
-	}
-
-	if cfg.persist && cfg.stateFile == "" {
-		return appConfig{}, errStateFileRequired
+	if err := cfg.Validate(); err != nil {
+		return appConfig{}, err
 	}
 
 	warnPersistFlagsWithoutPersist(fs, &cfg, out)
@@ -228,36 +123,21 @@ func parseFlags(args []string, getenv func(string) string, out io.Writer) (appCo
 	return cfg, nil
 }
 
-// parseProviders converts the --providers flag into a de-duplicated, validated
-// provider list. It mirrors `cloudemu serve`'s parse so both entrypoints accept
-// the same values (aws, azure, gcp, oci).
-func parseProviders(s string) ([]string, error) {
-	seen := map[string]bool{}
-
-	var out []string
-
-	for _, raw := range strings.Split(s, ",") {
-		p := strings.TrimSpace(strings.ToLower(raw))
-		if p == "" {
-			continue
-		}
-
-		if p != providerAWS && p != providerAzure && p != providerGCP && p != providerOCI {
-			return nil, fmt.Errorf("%w: %q", errUnknownProvider, p)
-		}
-
-		if !seen[p] {
-			seen[p] = true
-
-			out = append(out, p)
-		}
-	}
-
-	if len(out) == 0 {
-		return nil, errNoProviders
-	}
-
-	return out, nil
+// registerEngineFlags registers the real-engine selectors — this module's only
+// flags beyond the shared common set. Their names are the single shared list
+// serveflags.EngineFlags (asserted by the engine-flag drift test), so the lean
+// binary's stub detector and this registration stay in lockstep.
+func registerEngineFlags(fs *flag.FlagSet, engines *engineSelection, allReal *bool, getenv func(string) string) {
+	fs.StringVar(&engines.db, "db", engineEnvOr(getenv, "CLOUDEMU_DB"), "database engine: off|postgres|mysql|both")
+	fs.StringVar(&engines.cache, "cache", engineEnvOr(getenv, "CLOUDEMU_CACHE"), "cache engine: off|redis")
+	fs.StringVar(&engines.functions, "functions", engineEnvOr(getenv, "CLOUDEMU_FUNCTIONS"), "function engine: off|subprocess")
+	fs.StringVar(&engines.compute, "compute", engineEnvOr(getenv, "CLOUDEMU_COMPUTE"), "compute engine: off|docker")
+	fs.StringVar(&engines.containers, "containers", engineEnvOr(getenv, "CLOUDEMU_CONTAINERS"), "container engine: off|docker")
+	fs.StringVar(&engines.storage, "storage", engineEnvOr(getenv, "CLOUDEMU_STORAGE"), "storage engine: off|localfs")
+	fs.StringVar(&engines.storageDir, "storage-dir", "",
+		"root directory for --storage=localfs (default: a temporary directory)")
+	fs.BoolVar(allReal, serveflags.EngineAllReal, false,
+		"shorthand: postgres + redis + subprocess + docker compute + docker containers + localfs storage")
 }
 
 // engineEnvOr returns the engine value from the environment for key, defaulting
@@ -270,65 +150,10 @@ func engineEnvOr(getenv func(string) string, key string) string {
 	return engineOff
 }
 
-// registerPersistFlags registers the persistence flag group against cfg, keeping
-// parseFlags under the statement limit and grouping the knobs that only matter
-// with --persist.
-func registerPersistFlags(fs *flag.FlagSet, cfg *appConfig, getenv func(string) string) {
-	fs.BoolVar(&cfg.persist, "persist", false,
-		"save state to --state-file on shutdown and restore it on startup (includes object bodies)")
-	fs.StringVar(&cfg.stateFile, "state-file", "", "path to the JSON state snapshot (required with --persist)")
-	fs.BoolVar(&cfg.persistMetaOnly, "persist-metadata-only", false,
-		"persist resource structure but omit object bodies (smaller snapshot)")
-	fs.StringVar(&cfg.persistStrategy, "persist-strategy",
-		envStrOr(getenv, "CLOUDEMU_PERSIST_STRATEGY", serverkit.DefaultPersistStrategy),
-		"when to save with --persist: scheduled|on-request|on-shutdown|manual (env CLOUDEMU_PERSIST_STRATEGY)")
-	fs.DurationVar(&cfg.persistInterval, "persist-interval",
-		envDurationOr(getenv, "CLOUDEMU_PERSIST_INTERVAL", serverkit.DefaultPersistInterval),
-		"save cadence for --persist-strategy=scheduled (env CLOUDEMU_PERSIST_INTERVAL)")
-}
-
-// envStrOr returns the environment value for key, or def when it is unset/empty.
-func envStrOr(getenv func(string) string, key, def string) string {
-	if v := getenv(key); v != "" {
-		return v
-	}
-
-	return def
-}
-
-// envBoolOr reads the environment value for key as a boolean (1/true/yes/on,
-// case-insensitive), or returns def when it is unset/empty/unrecognized.
-func envBoolOr(getenv func(string) string, key string, def bool) bool {
-	switch strings.ToLower(strings.TrimSpace(getenv(key))) {
-	case "1", "true", "yes", "on":
-		return true
-	case "0", "false", "no", "off":
-		return false
-	default:
-		return def
-	}
-}
-
-// envDurationOr parses the environment value for key as a duration, or returns
-// def when it is unset/empty/unparseable.
-func envDurationOr(getenv func(string) string, key string, def time.Duration) time.Duration {
-	v := getenv(key)
-	if v == "" {
-		return def
-	}
-
-	d, err := time.ParseDuration(v)
-	if err != nil {
-		return def
-	}
-
-	return d
-}
-
 // warnPersistFlagsWithoutPersist prints a warning for each persist-tuning flag
 // set explicitly while --persist is off, so the ignored knob is visible.
 func warnPersistFlagsWithoutPersist(fs *flag.FlagSet, cfg *appConfig, stderr io.Writer) {
-	if cfg.persist {
+	if cfg.Persist {
 		return
 	}
 

--- a/contrib/server/main_test.go
+++ b/contrib/server/main_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	realpostgres "github.com/stackshy/cloudemu/v2/contrib/realengine/postgres"
 	realredis "github.com/stackshy/cloudemu/v2/contrib/realengine/redis"
+	"github.com/stackshy/cloudemu/v2/server/serveflags"
 )
 
 // TestBatteriesServerE2E starts the batteries-included server in-process — now
@@ -42,9 +43,9 @@ func TestBatteriesServerE2E(t *testing.T) {
 	// Build the engines directly so the Postgres server binds a known free port,
 	// making the post-shutdown release assertion deterministic.
 	opts := []config.Option{
-		config.WithAccountID(cfg.accountID),
-		config.WithRegion(cfg.region),
-		config.WithProjectID(cfg.projectID),
+		config.WithAccountID(cfg.AccountID),
+		config.WithRegion(cfg.Region),
+		config.WithProjectID(cfg.ProjectID),
 		config.WithDatabaseEngine(realpostgres.New(pgPort)),
 		config.WithCacheEngine(realredis.New()),
 	}
@@ -86,8 +87,8 @@ func TestBatteriesServerIdentityPreserved(t *testing.T) {
 	)
 
 	cfg := testConfig(t, allEnginesOff())
-	cfg.accountID = wantAccount
-	cfg.region = wantRegion
+	cfg.AccountID = wantAccount
+	cfg.Region = wantRegion
 
 	opts, _, err := buildOptions(&cfg, dockerAvailable)
 	if err != nil {
@@ -162,8 +163,8 @@ func startAWS(t *testing.T, cfg appConfig, opts []config.Option) (string, func()
 
 	go func() { done <- a.Serve(ctx) }()
 
-	awsURL := "http://" + net.JoinHostPort(cfg.host, cfg.awsPort)
-	waitListening(t, cfg.host, cfg.awsPort)
+	awsURL := "http://" + net.JoinHostPort(cfg.Host, cfg.AWSPort)
+	waitListening(t, cfg.Host, cfg.AWSPort)
 
 	var stopped bool
 
@@ -195,18 +196,20 @@ func testConfig(t *testing.T, engines engineSelection) appConfig {
 	t.Helper()
 
 	return appConfig{
-		engines:           engines,
-		providers:         []string{providerAWS, providerAzure, providerGCP},
-		host:              "127.0.0.1",
-		awsPort:           freePortStr(t),
-		azurePort:         freePortStr(t),
-		gcpPort:           freePortStr(t),
-		accountID:         "000000000000",
-		azureSubscription: "00000000-0000-0000-0000-000000000000",
-		region:            "us-east-1",
-		projectID:         "cloudemu-local",
-		shutdownTimeout:   10 * time.Second,
-		out:               io.Discard,
+		CommonConfig: serveflags.CommonConfig{
+			Host:              "127.0.0.1",
+			AWSPort:           freePortStr(t),
+			AzurePort:         freePortStr(t),
+			GCPPort:           freePortStr(t),
+			AccountID:         "000000000000",
+			AzureSubscription: "00000000-0000-0000-0000-000000000000",
+			Region:            "us-east-1",
+			ProjectID:         "cloudemu-local",
+			ShutdownTimeout:   10 * time.Second,
+		},
+		engines:   engines,
+		providers: []string{"aws", "azure", "gcp"},
+		out:       io.Discard,
 	}
 }
 

--- a/contrib/server/parity_endpoints_test.go
+++ b/contrib/server/parity_endpoints_test.go
@@ -15,17 +15,17 @@ import (
 // dependency): any HTTP status proves the listener is up and the handler runs.
 func TestOCIEndpointBinds(t *testing.T) {
 	cfg := testConfig(t, allEnginesOff())
-	cfg.providers = []string{providerAWS, providerOCI}
-	cfg.ociPort = freePortStr(t)
+	cfg.providers = []string{"aws", "oci"}
+	cfg.OCIPort = freePortStr(t)
 
 	_, stop := startAWS(t, cfg, mustOptions(t, &cfg))
 	defer stop()
 
 	// The AWS listener answering (startAWS waited on it) does not prove OCI bound;
 	// wait for the OCI port explicitly, then hit it.
-	waitListening(t, cfg.host, cfg.ociPort)
+	waitListening(t, cfg.Host, cfg.OCIPort)
 
-	url := "http://" + net.JoinHostPort(cfg.host, cfg.ociPort) + "/"
+	url := "http://" + net.JoinHostPort(cfg.Host, cfg.OCIPort) + "/"
 
 	resp, err := http.Get(url) //nolint:noctx // short-lived in-process test call
 	if err != nil {
@@ -48,13 +48,13 @@ func TestOCIEndpointBinds(t *testing.T) {
 // verification; any HTTP status proves the TLS listener is up.
 func TestKubernetesEndpointReachable(t *testing.T) {
 	cfg := testConfig(t, allEnginesOff())
-	cfg.providers = []string{providerAWS}
-	cfg.k8sPort = freePortStr(t)
+	cfg.providers = []string{"aws"}
+	cfg.K8sPort = freePortStr(t)
 
 	_, stop := startAWS(t, cfg, mustOptions(t, &cfg))
 	defer stop()
 
-	waitListening(t, cfg.host, cfg.k8sPort)
+	waitListening(t, cfg.Host, cfg.K8sPort)
 
 	client := &http.Client{
 		Timeout: 5 * time.Second,
@@ -63,7 +63,7 @@ func TestKubernetesEndpointReachable(t *testing.T) {
 		},
 	}
 
-	url := "https://" + net.JoinHostPort(cfg.host, cfg.k8sPort) + "/"
+	url := "https://" + net.JoinHostPort(cfg.Host, cfg.K8sPort) + "/"
 
 	resp, err := client.Get(url) //nolint:noctx // short-lived in-process test call
 	if err != nil {

--- a/contrib/server/persist_flags_test.go
+++ b/contrib/server/persist_flags_test.go
@@ -18,12 +18,12 @@ func TestPersistFlagDefaults(t *testing.T) {
 		t.Fatalf("parseFlags: %v", err)
 	}
 
-	if cfg.persistStrategy != serverkit.DefaultPersistStrategy {
-		t.Fatalf("default strategy = %q, want %q", cfg.persistStrategy, serverkit.DefaultPersistStrategy)
+	if cfg.PersistStrategy != serverkit.DefaultPersistStrategy {
+		t.Fatalf("default strategy = %q, want %q", cfg.PersistStrategy, serverkit.DefaultPersistStrategy)
 	}
 
-	if cfg.persistInterval != serverkit.DefaultPersistInterval {
-		t.Fatalf("default interval = %v, want %v", cfg.persistInterval, serverkit.DefaultPersistInterval)
+	if cfg.PersistInterval != serverkit.DefaultPersistInterval {
+		t.Fatalf("default interval = %v, want %v", cfg.PersistInterval, serverkit.DefaultPersistInterval)
 	}
 
 	// Overrides flow through.
@@ -32,12 +32,12 @@ func TestPersistFlagDefaults(t *testing.T) {
 		t.Fatalf("parseFlags(override): %v", err)
 	}
 
-	if over.persistStrategy != "manual" {
-		t.Fatalf("override strategy = %q, want manual", over.persistStrategy)
+	if over.PersistStrategy != "manual" {
+		t.Fatalf("override strategy = %q, want manual", over.PersistStrategy)
 	}
 
-	if over.persistInterval.String() != "7s" {
-		t.Fatalf("override interval = %v, want 7s", over.persistInterval)
+	if over.PersistInterval.String() != "7s" {
+		t.Fatalf("override interval = %v, want 7s", over.PersistInterval)
 	}
 
 	// Env fallback is honored when the flag is absent.
@@ -57,11 +57,11 @@ func TestPersistFlagDefaults(t *testing.T) {
 		t.Fatalf("parseFlags(env): %v", err)
 	}
 
-	if fromEnv.persistStrategy != "on-request" {
-		t.Fatalf("env strategy = %q, want on-request", fromEnv.persistStrategy)
+	if fromEnv.PersistStrategy != "on-request" {
+		t.Fatalf("env strategy = %q, want on-request", fromEnv.PersistStrategy)
 	}
 
-	if fromEnv.persistInterval.String() != "2s" {
-		t.Fatalf("env interval = %v, want 2s", fromEnv.persistInterval)
+	if fromEnv.PersistInterval.String() != "2s" {
+		t.Fatalf("env interval = %v, want 2s", fromEnv.PersistInterval)
 	}
 }

--- a/server/serveflags/engineflags.go
+++ b/server/serveflags/engineflags.go
@@ -1,0 +1,38 @@
+package serveflags
+
+// EngineAllReal is the one boolean engine flag (a shorthand for the full real
+// engine set); every other engine flag takes a string value.
+const EngineAllReal = "all-real"
+
+// EngineFlag names a real-engine selector understood by the :engines image
+// (contrib/server) but only stubbed in the lean cloudemu binary. Env is its
+// environment-variable form ("" when it has none).
+type EngineFlag struct{ Name, Env string }
+
+// EngineFlags is the single source of truth for the real-engine selector flags.
+// Both entrypoints range over it: contrib/server registers each as a real flag,
+// the lean binary registers them as inert stubs and detects intent. Adding a new
+// engine capability is one line here, picked up everywhere.
+//
+//nolint:gochecknoglobals // single source of truth for engine flag names/envs, shared by both serve entrypoints
+var EngineFlags = []EngineFlag{
+	{"db", "CLOUDEMU_DB"},
+	{"cache", "CLOUDEMU_CACHE"},
+	{"functions", "CLOUDEMU_FUNCTIONS"},
+	{"compute", "CLOUDEMU_COMPUTE"},
+	{"containers", "CLOUDEMU_CONTAINERS"},
+	{"storage", "CLOUDEMU_STORAGE"},
+	{"storage-dir", ""},
+	{EngineAllReal, ""},
+}
+
+// IsEngineFlag reports whether name is one of the real-engine selector flags.
+func IsEngineFlag(name string) bool {
+	for _, f := range EngineFlags {
+		if f.Name == name {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/serveflags/serveflags.go
+++ b/server/serveflags/serveflags.go
@@ -1,0 +1,296 @@
+// Package serveflags is the shared, dependency-light source of truth for the
+// standalone emulator's command-line flags.
+//
+// Both serve entrypoints — the lean cmd/cloudemu binary and the
+// batteries-included contrib/server (the :engines image) — register their common
+// flags from here and build the same serverkit.Config, so the ~30 flags cannot
+// drift between the two mains. The engine selectors are a single shared list
+// (EngineFlags) both sides range over.
+//
+// The package imports only flag, os, strings, time, the core config package, and
+// serverkit; it NEVER imports an engine constructor or a contrib package (guarded
+// by a dep test), so the lean binary stays free of the heavy engine dependencies.
+package serveflags
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/server/serverkit"
+)
+
+// defaultShutdownTimeout is the grace period for in-flight requests on shutdown.
+const defaultShutdownTimeout = 10 * time.Second
+
+// defaultK8sProgressionInterval is the Pod-lifecycle ticker cadence when
+// --k8s-progression is on and no interval is given.
+const defaultK8sProgressionInterval = time.Second
+
+var (
+	// ErrTLSPairRequired is returned when only one of --tls-cert/--tls-key is set.
+	ErrTLSPairRequired = errors.New("--tls-cert and --tls-key must be given together")
+	// ErrStateFileRequired is returned when --persist is set without --state-file.
+	ErrStateFileRequired = errors.New("--persist requires --state-file")
+	// ErrNoProviders is returned when --providers resolves to an empty set.
+	ErrNoProviders = errors.New("no providers selected")
+	// ErrUnknownProvider is returned for a --providers value outside aws/azure/gcp/oci.
+	ErrUnknownProvider = errors.New("unknown provider (want aws, azure, gcp, or oci)")
+)
+
+// StringList is a repeatable string flag (e.g. --tls-host a --tls-host b).
+type StringList []string
+
+func (s *StringList) String() string { return strings.Join(*s, ",") }
+
+func (s *StringList) Set(v string) error {
+	*s = append(*s, v)
+
+	return nil
+}
+
+// CommonConfig is the full set of serve flags shared by both entrypoints. Only
+// the engine selectors (EngineFlags) live outside it — those are registered by
+// contrib/server and stubbed by the lean binary.
+type CommonConfig struct {
+	Providers     string
+	Host          string
+	AdvertiseHost string
+	AWSPort       string
+	AzurePort     string
+	GCPPort       string
+	OCIPort       string
+	K8sPort       string
+
+	AccountID         string
+	AzureSubscription string
+	Region            string
+	ProjectID         string
+
+	Latency  time.Duration
+	TLSCert  string
+	TLSKey   string
+	TLSHosts StringList
+
+	EndpointsFile string
+	Admin         bool
+	LogRequests   bool
+	Quiet         bool
+	EnforceAuth   bool
+
+	ShutdownTimeout time.Duration
+
+	Persist             bool
+	StateFile           string
+	PersistMetadataOnly bool
+	PersistStrategy     string
+	PersistInterval     time.Duration
+
+	InitDir string
+
+	K8sProgression         bool
+	K8sProgressionInterval time.Duration
+}
+
+// RegisterCommon registers every common serve flag against c. getenv is injected
+// (cmd passes os.Getenv; tests pass a stub) so the environment fallbacks stay
+// testable. The engine selectors are registered separately by each entrypoint.
+func RegisterCommon(fs *flag.FlagSet, c *CommonConfig, getenv func(string) string) {
+	// OCI is not started by default: it stays opt-in until its services land, so
+	// the default set never binds a port that serves nothing.
+	fs.StringVar(&c.Providers, "providers", "aws,azure,gcp", "comma-separated providers to start: aws,azure,gcp,oci")
+	fs.StringVar(&c.Host, "host", "127.0.0.1", "host/interface to bind (use 0.0.0.0 to expose on the network)")
+	fs.StringVar(&c.AdvertiseHost, "advertise-host", "",
+		"host/IP the Kubernetes data-plane endpoint is advertised at in kubeconfigs and its TLS cert "+
+			"(default: --host, or 127.0.0.1 when binding all interfaces such as 0.0.0.0 under Docker)")
+	fs.StringVar(&c.AWSPort, "aws-port", "4566", "port for the AWS endpoint (HTTP)")
+	fs.StringVar(&c.AzurePort, "azure-port", "4568", "port for the Azure endpoint (HTTPS)")
+	fs.StringVar(&c.GCPPort, "gcp-port", "4569", "port for the GCP endpoint (HTTP)")
+	fs.StringVar(&c.OCIPort, "oci-port", "4571", "port for the OCI endpoint (HTTP)")
+	fs.StringVar(&c.K8sPort, "k8s-port", "4570", "port for the shared Kubernetes data-plane (HTTPS); empty to disable")
+	fs.StringVar(&c.AccountID, "account-id", "000000000000", "AWS account ID (also GCP/OCI) reported by the emulator")
+	fs.StringVar(&c.AzureSubscription, "azure-subscription", "00000000-0000-0000-0000-000000000000",
+		"Azure subscription id reported by the emulator (a GUID; real Azure SDKs/CLIs require one)")
+	fs.StringVar(&c.Region, "region", "us-east-1", "default region reported by the emulator")
+	fs.StringVar(&c.ProjectID, "project-id", "cloudemu-local", "GCP project ID reported by the emulator")
+	fs.DurationVar(&c.Latency, "latency", 0, "artificial latency added to every emulated call (e.g. 20ms)")
+	fs.StringVar(&c.TLSCert, "tls-cert", "", "PEM cert file for the Azure HTTPS endpoint (default: a self-signed cert generated in memory)")
+	fs.StringVar(&c.TLSKey, "tls-key", "", "PEM key file matching --tls-cert")
+	fs.Var(&c.TLSHosts, "tls-host", "extra SAN host/IP for the generated self-signed cert (repeatable)")
+	fs.StringVar(&c.EndpointsFile, "endpoints-file", "", "write the resolved endpoints as JSON to this path")
+	fs.BoolVar(&c.Admin, "admin", true, "mount the /_cloudemu control plane (reset, health) for test isolation")
+	fs.BoolVar(&c.LogRequests, "log-requests", false, "log every HTTP request (method, path, status, duration)")
+	fs.BoolVar(&c.Quiet, "quiet", false, "suppress the startup banner")
+	fs.DurationVar(&c.ShutdownTimeout, "shutdown-timeout", defaultShutdownTimeout, "grace period for in-flight requests on shutdown")
+	fs.StringVar(&c.InitDir, "init-dir", "", "apply every *.json seed fixture in this directory on startup")
+
+	registerPersistFlags(fs, c, getenv)
+	registerK8sProgressionFlags(fs, c, getenv)
+	registerEnforceAuthFlag(fs, c)
+}
+
+// registerPersistFlags registers the persistence flag group, whose knobs only
+// matter with --persist.
+func registerPersistFlags(fs *flag.FlagSet, c *CommonConfig, getenv func(string) string) {
+	fs.BoolVar(&c.Persist, "persist", false, "save state to --state-file on shutdown and restore it on startup (includes object bodies)")
+	fs.StringVar(&c.StateFile, "state-file", "", "path to the JSON state snapshot (required with --persist)")
+	fs.BoolVar(&c.PersistMetadataOnly, "persist-metadata-only", false, "persist resource structure but omit object bodies (smaller snapshot)")
+	fs.StringVar(&c.PersistStrategy, "persist-strategy", envStrOr(getenv, "CLOUDEMU_PERSIST_STRATEGY", serverkit.DefaultPersistStrategy),
+		"when to save with --persist: scheduled|on-request|on-shutdown|manual (env CLOUDEMU_PERSIST_STRATEGY)")
+	fs.DurationVar(&c.PersistInterval, "persist-interval",
+		envDurationOr(getenv, "CLOUDEMU_PERSIST_INTERVAL", serverkit.DefaultPersistInterval),
+		"save cadence for --persist-strategy=scheduled (env CLOUDEMU_PERSIST_INTERVAL)")
+}
+
+// registerK8sProgressionFlags registers the KWOK-style staged Pod lifecycle knobs.
+func registerK8sProgressionFlags(fs *flag.FlagSet, c *CommonConfig, getenv func(string) string) {
+	fs.BoolVar(&c.K8sProgression, "k8s-progression", envBoolOr(getenv, "CLOUDEMU_K8S_PROGRESSION", false),
+		"Kubernetes: client-created Pods start Pending and visibly progress to Running on a ticker "+
+			"(default off = instant Running; env CLOUDEMU_K8S_PROGRESSION)")
+	fs.DurationVar(&c.K8sProgressionInterval, "k8s-progression-interval",
+		envDurationOr(getenv, "CLOUDEMU_K8S_PROGRESSION_INTERVAL", defaultK8sProgressionInterval),
+		"cadence of the --k8s-progression Pod-lifecycle ticker (env CLOUDEMU_K8S_PROGRESSION_INTERVAL)")
+}
+
+// registerEnforceAuthFlag registers --enforce-auth with the full SigV4/Bearer
+// usage. This is the single shared usage string for both entrypoints.
+func registerEnforceAuthFlag(fs *flag.FlagSet, c *CommonConfig) {
+	fs.BoolVar(&c.EnforceAuth, "enforce-auth", false,
+		"require authentication on each request; off by default. AWS: verify the SigV4 signature against a registered IAM access "+
+			"key (403 on failure) and enforce IAM authorization — long-term (AKIA) keys are verified, STS temporary (ASIA) "+
+			"credentials are accepted unverified for now, authorization is enforced for JSON-RPC services only, and applies only to "+
+			"principals that have IAM policies. Azure: validate each request's Bearer token claims (accepted audience, expiry, a "+
+			"principal claim) and reject missing/malformed/expired/wrong-audience tokens with 401 — the token SIGNATURE is NOT "+
+			"verified (no Azure AD signing key), so this is claims-based authentication only; RBAC authorization is a follow-up")
+}
+
+// Validate checks the cross-field constraints both entrypoints share: --tls-cert
+// and --tls-key must be given together, and --persist requires --state-file.
+func (c *CommonConfig) Validate() error {
+	if (c.TLSCert == "") != (c.TLSKey == "") {
+		return ErrTLSPairRequired
+	}
+
+	if c.Persist && c.StateFile == "" {
+		return ErrStateFileRequired
+	}
+
+	return nil
+}
+
+// ToServerkitConfig maps the resolved common flags onto a serverkit.Config for
+// the given (already parsed) provider selection. The three identity options
+// (account/region/project) go into BaseOptions here; contrib appends its engine
+// options to BaseOptions afterwards.
+func (c *CommonConfig) ToServerkitConfig(providers []string) serverkit.Config {
+	return serverkit.Config{
+		Providers: providers,
+		Host:      c.Host,
+		Ports: map[string]string{
+			"aws":   c.AWSPort,
+			"azure": c.AzurePort,
+			"gcp":   c.GCPPort,
+			"oci":   c.OCIPort,
+		},
+		K8sPort:                c.K8sPort,
+		AdvertiseHost:          c.AdvertiseHost,
+		K8sProgression:         c.K8sProgression,
+		K8sProgressionInterval: c.K8sProgressionInterval,
+		AzureSubscription:      c.AzureSubscription,
+		Admin:                  c.Admin,
+		Persist:                c.Persist,
+		StateFile:              c.StateFile,
+		PersistMetadataOnly:    c.PersistMetadataOnly,
+		PersistStrategy:        c.PersistStrategy,
+		PersistInterval:        c.PersistInterval,
+		InitDir:                c.InitDir,
+		TLSCert:                c.TLSCert,
+		TLSKey:                 c.TLSKey,
+		TLSHosts:               c.TLSHosts,
+		Latency:                c.Latency,
+		LogRequests:            c.LogRequests,
+		Quiet:                  c.Quiet,
+		EnforceAuth:            c.EnforceAuth,
+		EndpointsFile:          c.EndpointsFile,
+		ShutdownTimeout:        c.ShutdownTimeout,
+		BaseOptions: []config.Option{
+			config.WithAccountID(c.AccountID),
+			config.WithRegion(c.Region),
+			config.WithProjectID(c.ProjectID),
+		},
+		Out: os.Stdout,
+	}
+}
+
+// ParseProviders converts the --providers flag into a de-duplicated, validated
+// provider list. Both entrypoints use it so they accept the same values.
+func ParseProviders(s string) ([]string, error) {
+	seen := map[string]bool{}
+
+	var out []string
+
+	for _, raw := range strings.Split(s, ",") {
+		p := strings.TrimSpace(strings.ToLower(raw))
+		if p == "" {
+			continue
+		}
+
+		if p != "aws" && p != "azure" && p != "gcp" && p != "oci" {
+			return nil, fmt.Errorf("%w: %q", ErrUnknownProvider, p)
+		}
+
+		if !seen[p] {
+			seen[p] = true
+
+			out = append(out, p)
+		}
+	}
+
+	if len(out) == 0 {
+		return nil, ErrNoProviders
+	}
+
+	return out, nil
+}
+
+// envStrOr returns the environment value for key, or def when it is unset/empty.
+func envStrOr(getenv func(string) string, key, def string) string {
+	if v := getenv(key); v != "" {
+		return v
+	}
+
+	return def
+}
+
+// envDurationOr parses the environment value for key as a duration, or returns
+// def when it is unset/empty/unparseable.
+func envDurationOr(getenv func(string) string, key string, def time.Duration) time.Duration {
+	v := getenv(key)
+	if v == "" {
+		return def
+	}
+
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return def
+	}
+
+	return d
+}
+
+// envBoolOr reads the environment value for key as a boolean (1/true/yes/on,
+// case-insensitive), or returns def when it is unset/empty/unrecognized.
+func envBoolOr(getenv func(string) string, key string, def bool) bool {
+	switch strings.ToLower(strings.TrimSpace(getenv(key))) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return def
+	}
+}

--- a/server/serveflags/serveflags_test.go
+++ b/server/serveflags/serveflags_test.go
@@ -1,0 +1,249 @@
+package serveflags
+
+import (
+	"flag"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/server/serverkit"
+)
+
+// noEnv is a getenv stub that reports every variable as unset, so flag defaults
+// are the built-in ones (not the host environment).
+func noEnv(string) string { return "" }
+
+// commonFlagNames is the pinned set of flag names RegisterCommon must register —
+// the single source of truth both serve entrypoints build from. A common flag
+// added, renamed, or dropped in only one place changes this set and fails the
+// test, so the two mains cannot drift. Update it deliberately when the shared
+// flag set genuinely changes.
+//
+//nolint:gochecknoglobals // test fixture: the pinned common-flag name set
+var commonFlagNames = []string{
+	"account-id", "admin", "advertise-host", "aws-port", "azure-port", "azure-subscription",
+	"endpoints-file", "enforce-auth", "gcp-port", "host", "init-dir", "k8s-port",
+	"k8s-progression", "k8s-progression-interval", "latency", "log-requests", "oci-port",
+	"persist", "persist-interval", "persist-metadata-only", "persist-strategy", "project-id",
+	"providers", "quiet", "region", "shutdown-timeout", "state-file", "tls-cert", "tls-host",
+	"tls-key",
+}
+
+// registeredNames returns the sorted flag names a fresh RegisterCommon produces.
+func registeredNames() []string {
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	RegisterCommon(fs, &CommonConfig{}, noEnv)
+
+	var names []string
+
+	fs.VisitAll(func(f *flag.Flag) { names = append(names, f.Name) })
+	sort.Strings(names)
+
+	return names
+}
+
+// TestRegisterCommonNameSet is the drift guard: the flags RegisterCommon registers
+// must be exactly commonFlagNames. Both mains register their common flags here, so
+// pinning the set here pins it for both.
+func TestRegisterCommonNameSet(t *testing.T) {
+	got := registeredNames()
+
+	want := append([]string(nil), commonFlagNames...)
+	sort.Strings(want)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RegisterCommon flag set drifted:\n got=%v\nwant=%v", got, want)
+	}
+}
+
+// TestRegisterCommonDefaults pins the defaults that flow from shared constants, so
+// a change to the persist/k8s defaults can't silently diverge from serverkit.
+func TestRegisterCommonDefaults(t *testing.T) {
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	RegisterCommon(fs, &CommonConfig{}, noEnv)
+
+	cases := map[string]string{
+		"persist-strategy":         serverkit.DefaultPersistStrategy,
+		"persist-interval":         serverkit.DefaultPersistInterval.String(),
+		"k8s-progression":          "false",
+		"k8s-progression-interval": time.Second.String(),
+		"providers":                "aws,azure,gcp",
+		"aws-port":                 "4566",
+		"shutdown-timeout":         defaultShutdownTimeout.String(),
+	}
+
+	for name, want := range cases {
+		f := fs.Lookup(name)
+		if f == nil {
+			t.Fatalf("--%s not registered", name)
+		}
+
+		if f.DefValue != want {
+			t.Fatalf("--%s default = %q, want %q", name, f.DefValue, want)
+		}
+	}
+}
+
+// TestRegisterCommonEnvFallback proves the injected getenv drives the env-backed
+// defaults (contrib relies on an injectable getenv for its tests).
+func TestRegisterCommonEnvFallback(t *testing.T) {
+	env := map[string]string{
+		"CLOUDEMU_PERSIST_STRATEGY":       "on-request",
+		"CLOUDEMU_PERSIST_INTERVAL":       "2s",
+		"CLOUDEMU_K8S_PROGRESSION":        "true",
+		"CLOUDEMU_K8S_PROGRESSION_INTERVAL": "5s",
+	}
+	getenv := func(k string) string { return env[k] }
+
+	var c CommonConfig
+
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	RegisterCommon(fs, &c, getenv)
+
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if c.PersistStrategy != "on-request" {
+		t.Fatalf("persist-strategy = %q, want on-request (env)", c.PersistStrategy)
+	}
+
+	if c.PersistInterval != 2*time.Second {
+		t.Fatalf("persist-interval = %v, want 2s (env)", c.PersistInterval)
+	}
+
+	if !c.K8sProgression {
+		t.Fatal("k8s-progression = false, want true (env)")
+	}
+
+	if c.K8sProgressionInterval != 5*time.Second {
+		t.Fatalf("k8s-progression-interval = %v, want 5s (env)", c.K8sProgressionInterval)
+	}
+}
+
+// TestToServerkitConfigRoundTrip parses a representative arg set and asserts the
+// resulting serverkit.Config carries every value through — ports, persistence,
+// TLS, k8s progression, and the identity BaseOptions.
+func TestToServerkitConfigRoundTrip(t *testing.T) {
+	var c CommonConfig
+
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	RegisterCommon(fs, &c, noEnv)
+
+	args := []string{
+		"--host", "0.0.0.0",
+		"--aws-port", "5001", "--azure-port", "5002", "--gcp-port", "5003", "--oci-port", "5004",
+		"--k8s-port", "5005", "--advertise-host", "10.0.0.1",
+		"--account-id", "210987654321", "--region", "eu-west-2", "--project-id", "proj-x",
+		"--azure-subscription", "11111111-1111-1111-1111-111111111111",
+		"--latency", "20ms",
+		"--tls-cert", "/c.pem", "--tls-key", "/k.pem", "--tls-host", "a", "--tls-host", "b",
+		"--endpoints-file", "/eps.json",
+		"--admin=false", "--log-requests", "--quiet", "--enforce-auth",
+		"--shutdown-timeout", "3s",
+		"--persist", "--state-file", "/s.json", "--persist-metadata-only",
+		"--persist-strategy", "manual", "--persist-interval", "7s",
+		"--init-dir", "/seeds",
+		"--k8s-progression", "--k8s-progression-interval", "4s",
+	}
+	if err := fs.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if err := c.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	sel, err := ParseProviders(c.Providers)
+	if err != nil {
+		t.Fatalf("parse providers: %v", err)
+	}
+
+	sk := c.ToServerkitConfig(sel)
+
+	assertEqual(t, "host", sk.Host, "0.0.0.0")
+	assertEqual(t, "aws-port", sk.Ports["aws"], "5001")
+	assertEqual(t, "azure-port", sk.Ports["azure"], "5002")
+	assertEqual(t, "gcp-port", sk.Ports["gcp"], "5003")
+	assertEqual(t, "oci-port", sk.Ports["oci"], "5004")
+	assertEqual(t, "k8s-port", sk.K8sPort, "5005")
+	assertEqual(t, "advertise-host", sk.AdvertiseHost, "10.0.0.1")
+	assertEqual(t, "azure-subscription", sk.AzureSubscription, "11111111-1111-1111-1111-111111111111")
+	assertEqual(t, "latency", sk.Latency, 20*time.Millisecond)
+	assertEqual(t, "tls-cert", sk.TLSCert, "/c.pem")
+	assertEqual(t, "tls-key", sk.TLSKey, "/k.pem")
+	assertEqual(t, "endpoints-file", sk.EndpointsFile, "/eps.json")
+	assertEqual(t, "admin", sk.Admin, false)
+	assertEqual(t, "log-requests", sk.LogRequests, true)
+	assertEqual(t, "quiet", sk.Quiet, true)
+	assertEqual(t, "enforce-auth", sk.EnforceAuth, true)
+	assertEqual(t, "shutdown-timeout", sk.ShutdownTimeout, 3*time.Second)
+	assertEqual(t, "persist", sk.Persist, true)
+	assertEqual(t, "state-file", sk.StateFile, "/s.json")
+	assertEqual(t, "persist-metadata-only", sk.PersistMetadataOnly, true)
+	assertEqual(t, "persist-strategy", sk.PersistStrategy, "manual")
+	assertEqual(t, "persist-interval", sk.PersistInterval, 7*time.Second)
+	assertEqual(t, "init-dir", sk.InitDir, "/seeds")
+	assertEqual(t, "k8s-progression", sk.K8sProgression, true)
+	assertEqual(t, "k8s-progression-interval", sk.K8sProgressionInterval, 4*time.Second)
+
+	if !reflect.DeepEqual([]string(sk.TLSHosts), []string{"a", "b"}) {
+		t.Fatalf("tls-hosts = %v, want [a b]", sk.TLSHosts)
+	}
+
+	// The identity options are seeded into BaseOptions.
+	opts := config.NewOptions(sk.BaseOptions...)
+	assertEqual(t, "account-id option", opts.AccountID, "210987654321")
+	assertEqual(t, "region option", opts.Region, "eu-west-2")
+	assertEqual(t, "project-id option", opts.ProjectID, "proj-x")
+}
+
+// TestValidate covers the two cross-field rules both mains share.
+func TestValidate(t *testing.T) {
+	if err := (&CommonConfig{TLSCert: "/c.pem"}).Validate(); err != ErrTLSPairRequired {
+		t.Fatalf("tls-cert without tls-key: err = %v, want %v", err, ErrTLSPairRequired)
+	}
+
+	if err := (&CommonConfig{TLSKey: "/k.pem"}).Validate(); err != ErrTLSPairRequired {
+		t.Fatalf("tls-key without tls-cert: err = %v, want %v", err, ErrTLSPairRequired)
+	}
+
+	if err := (&CommonConfig{Persist: true}).Validate(); err != ErrStateFileRequired {
+		t.Fatalf("persist without state-file: err = %v, want %v", err, ErrStateFileRequired)
+	}
+
+	ok := &CommonConfig{TLSCert: "/c.pem", TLSKey: "/k.pem", Persist: true, StateFile: "/s.json"}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("valid config rejected: %v", err)
+	}
+}
+
+// TestParseProviders covers de-duplication, validation, and the empty case.
+func TestParseProviders(t *testing.T) {
+	got, err := ParseProviders("aws, AWS ,gcp,, oci")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, []string{"aws", "gcp", "oci"}) {
+		t.Fatalf("parsed = %v, want [aws gcp oci]", got)
+	}
+
+	if _, err := ParseProviders("aws,bogus"); err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+
+	if _, err := ParseProviders(" , "); err == nil {
+		t.Fatal("expected error for empty provider set")
+	}
+}
+
+func assertEqual[T comparable](t *testing.T, name string, got, want T) {
+	t.Helper()
+
+	if got != want {
+		t.Fatalf("%s = %v, want %v", name, got, want)
+	}
+}


### PR DESCRIPTION
## What & why

The two standalone-server entrypoints — the lean `cmd/cloudemu serve` (CGO-off, zero-dep static binary) and the batteries-included `contrib/server` (the `:engines` image) — hand-duplicated ~30 command-line flags. They were kept in lockstep only by a comment and a persist-only mirror test, so any new or renamed flag could silently drift between the two mains.

This PR (part of #445) extracts the shared flags into a new dependency-light core package, `server/serveflags`, that both mains build from. The refactor is behavior-preserving: for identical args the resulting `serverkit.Config` is unchanged.

## New package: `server/serveflags`

Imports only `flag`, `fmt`, `os`, `strings`, `time`, `config`, and `serverkit` — never an engine constructor or a contrib package, so the lean binary stays free of the heavy engine deps (embedded-postgres, miniredis, go-redis, Docker SDK).

- `CommonConfig` — the full shared flag set (providers, host/advertise-host, ports, identity, latency, TLS, persistence, init-dir, enforce-auth, k8s-progression, …).
- `RegisterCommon(fs, *CommonConfig, getenv)` — registers all common flags; `getenv` is injectable so the env-backed defaults stay testable (cmd passes `os.Getenv`).
- `(*CommonConfig).Validate()` — owns the cross-field rules both mains shared: `--tls-cert`/`--tls-key` must be paired, `--persist` requires `--state-file`.
- `(*CommonConfig).ToServerkitConfig(providers)` — maps the flags onto `serverkit.Config`, seeding `BaseOptions` with the three identity options.
- `ParseProviders(string)` — the folded provider parser.
- `StringList` — the repeatable `--tls-host` flag value.
- `EngineFlags` / `IsEngineFlag` — the single shared list of real-engine selectors (db/cache/functions/compute/containers/storage/storage-dir/all-real) that both sides range over.

## Both mains slimmed onto it

- `cmd/cloudemu/serve.go` registers its common flags via `RegisterCommon`, validates via `Validate`, and builds the config via `ToServerkitConfig`. The PR-1 engine-discoverability detector now reads `serveflags.EngineFlags` / `IsEngineFlag` (local duplicate removed). Behavior identical.
- `contrib/server/main.go` registers only the engine selectors plus `RegisterCommon`.
- `contrib/server/app.go` control-flow change: identity options now build inside `ToServerkitConfig`, so the engine options are appended to `cfg.BaseOptions` **after** calling it (rather than merging identity+engine before). The engine wiring — `buildEngineOptions`, the MODE table, and the Docker degrade path — is untouched.

## Guards

- **Drift guard** — `serveflags` pins the registered common-flag name set + shared-constant defaults; each main has a mirror test asserting it builds its FlagSet from `RegisterCommon` (names + defaults), and contrib asserts its engine-flag names equal `EngineFlags`. A common flag added/renamed in only one place fails a test.
- **Dep guard** — a test shells `go list -deps .` for the lean binary and fails if any of `embedded-postgres`, `miniredis`, `go-redis`, or `docker/docker` appears, proving the lean binary and `serveflags` stay engine-dep-free.

Zero change to the option/engine/teardown machinery (`config/engine.go`, `EngineClosers`, `Provider.Close`, `serverkit.closeProviders`, the `exportMu` guard).

Note: the only intended user-visible change is `contrib/server`'s `--enforce-auth --help` text, now unified to the fuller SigV4/Bearer usage string (both mains share one usage string).
