### PR TITLE
fix(kubernetes): stamp job-name/controller-uid labels on Job pods (#874)

### DIFF
--- a/services/kubernetes/phase1_fidelity_test.go
+++ b/services/kubernetes/phase1_fidelity_test.go
@@ -267,6 +267,73 @@ func TestPodExec_TypedNotImplemented(t *testing.T) {
 	}
 }
 
+func TestJobPodLabels(t *testing.T) {
+	base, done := newFixture(t)
+	defer done()
+
+	body := mustJSON(t, map[string]any{
+		"apiVersion": "batch/v1", "kind": "Job",
+		"metadata": map[string]any{"name": "labeljob"},
+		"spec": map[string]any{
+			"completions": 1,
+			"template": map[string]any{"spec": map[string]any{
+				"containers": []any{map[string]any{"name": "c", "image": "img"}},
+			}},
+		},
+	})
+
+	resp := do(t, http.MethodPost, base+"/apis/batch/v1/namespaces/default/jobs", body)
+	created := decodeMap(t, resp.Body)
+	resp.Body.Close()
+
+	createdMeta, _ := created["metadata"].(map[string]any)
+	jobUID, _ := createdMeta["uid"].(string)
+	if jobUID == "" {
+		t.Fatalf("created Job has empty metadata.uid")
+	}
+
+	pods := do(t, http.MethodGet, base+"/api/v1/namespaces/default/pods", nil)
+	defer pods.Body.Close()
+
+	list := decodeMap(t, pods.Body)
+	items, _ := list["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("job pod count: got %d, want 1", len(items))
+	}
+
+	pod, _ := items[0].(map[string]any)
+	podMeta, _ := pod["metadata"].(map[string]any)
+	rawLabels, _ := podMeta["labels"].(map[string]any)
+
+	labels := map[string]string{}
+	for k, v := range rawLabels {
+		s, _ := v.(string)
+		labels[k] = s
+	}
+
+	want := map[string]string{
+		"batch.kubernetes.io/job-name":       "labeljob",
+		"job-name":                           "labeljob",
+		"batch.kubernetes.io/controller-uid": jobUID,
+		"controller-uid":                     jobUID,
+	}
+	for k, v := range want {
+		if labels[k] != v {
+			t.Fatalf("pod label %q: got %q, want %q", k, labels[k], v)
+		}
+	}
+
+	if labels["batch.kubernetes.io/job-name"] != labels["job-name"] {
+		t.Fatalf("job-name aliases disagree: %q vs %q",
+			labels["batch.kubernetes.io/job-name"], labels["job-name"])
+	}
+
+	if labels["batch.kubernetes.io/controller-uid"] != labels["controller-uid"] {
+		t.Fatalf("controller-uid aliases disagree: %q vs %q",
+			labels["batch.kubernetes.io/controller-uid"], labels["controller-uid"])
+	}
+}
+
 func TestJobReconcile_ShrinkCorrectsSucceeded(t *testing.T) {
 	base, done := newFixture(t)
 	defer done()

--- a/services/kubernetes/reconcile.go
+++ b/services/kubernetes/reconcile.go
@@ -589,6 +589,18 @@ func reconcileIngress(_ *ClusterState, obj *unstructured.Unstructured) {
 		[]any{map[string]any{"ip": ingressLBIP}}, "status", "loadBalancer", "ingress")
 }
 
+// Job-controller Pod labels stamped by reconcileJob. These mirror the real
+// upstream Job controller: the batch.kubernetes.io/* keys are GA (job-name
+// since 1.27), and the bare job-name/controller-uid keys are the legacy
+// aliases kept for compatibility. They are stamped only on Job Pods (not in
+// the shared buildControllerPod, which also serves RS/STS/DS).
+const (
+	jobNameLabel                = "batch.kubernetes.io/job-name"
+	jobNameLegacyLabel          = "job-name"
+	jobControllerUIDLabel       = "batch.kubernetes.io/controller-uid"
+	jobControllerUIDLegacyLabel = "controller-uid"
+)
+
 // reconcileJob runs a Job to completion: it reconciles the Job's owned Pods to
 // exactly `completions` (default 1) Succeeded Pods and marks the Job Complete.
 // Reconciling to the exact count — rather than only topping up — means a lowered
@@ -622,6 +634,14 @@ func reconcileJob(s *ClusterState, obj *unstructured.Unstructured) {
 	// Top up the rest with Pods driven straight to Succeeded.
 	for len(owned) < completions {
 		pod := s.buildControllerPod(ns, obj.GetName()+"-"+shortID(), tmpl, owner)
+		// Stamp the real Job-controller Pod labels (GA + legacy aliases). Done
+		// here, not in buildControllerPod, so RS/STS/DS Pods are left untouched.
+		jobName := obj.GetName()
+		jobUID := string(owner.UID)
+		pod.Labels[jobNameLabel] = jobName
+		pod.Labels[jobNameLegacyLabel] = jobName
+		pod.Labels[jobControllerUIDLabel] = jobUID
+		pod.Labels[jobControllerUIDLegacyLabel] = jobUID
 		s.markPodSucceededLocked(pod)
 		s.pods[podKey(ns, pod.Name)] = pod
 		s.wPods.publish(EventAdded, ns, *pod.DeepCopy())


### PR DESCRIPTION
## Summary

Job Pods created by the in-memory Kubernetes reconciler were missing the standard Job-controller identity labels that real clusters stamp on every Job Pod. This is the residual item from #874 (the `creationTimestamp`/`resourceVersion` nits were already handled in `buildControllerPod`).

Each Job Pod now carries the four real upstream labels:

- `batch.kubernetes.io/job-name` = Job `metadata.name` (GA since k8s 1.27)
- `job-name` = Job name (legacy alias)
- `batch.kubernetes.io/controller-uid` = Job `metadata.uid`
- `controller-uid` = Job UID (legacy alias)

## Placement

The labels are stamped in `reconcileJob`'s top-up loop, immediately after `buildControllerPod`, **not** inside `buildControllerPod` itself. `buildControllerPod` is shared by ReplicaSet/StatefulSet/DaemonSet reconciliation — stamping Job labels there would wrongly label their Pods. Values come straight from the Job object at the call site: `obj.GetName()` and `owner.UID` (= `obj.GetUID()`, already populated on create and relied on by `podsOwnedByLocked`). Label keys are small named constants.

## Blast radius: none (additive)

- Job Pod ownership is by `ownerReferences` UID (`podsOwnedByLocked`), not label selector — added labels cannot affect which Pods a Job reconciles.
- Endpoints only match `PodRunning`; Job Pods are driven to `PodSucceeded`, so they never enter Endpoints regardless of labels.
- `labelsMatch` is selector⊆labels, so extra labels can only add matches, never remove one.

## Tests

Adds `TestJobPodLabels`: creates a `batch/v1` Job, reconciles, fetches the owned Pod, and asserts all four keys are present, the two `job-name` aliases agree and equal the Job name, and the two `controller-uid` aliases agree and equal the Job UID. Purely additive — no existing test asserted these labels.

Gates (GOMAXPROCS=3): `go build ./...`, `go vet`, `go test`, `go test -race`, and `golangci-lint` for `services/kubernetes/...` all clean (only the pre-existing `admission.go` gosec baseline remains). `go generate ./...` produces no diff.