### PR TITLE
feat(cli): add 'cloudemu doctor' preflight check (ports, version, docker) (#454)

### DIFF
--- a/cmd/cloudemu/doctor.go
+++ b/cmd/cloudemu/doctor.go
@@ -25,10 +25,8 @@ const (
 	markFail = "[fail]"
 )
 
-// enginesImagePointer is the one-line pointer at the :engines image, kept
-// identical to the message serve prints (errEnginesNotInLeanBinary) so the CLI
-// speaks with one voice about where the real engines live.
-const enginesImagePointer = "docker run -p 4566:4566 ghcr.io/stackshy/cloudemu:engines --all-real"
+// The doctor echoes serve's canonical enginesImagePointer (defined in serve.go)
+// so the two commands can't drift on where the real engines live.
 
 // portCheck is one default endpoint the emulator would bind. required marks a
 // port the default provider set (aws,azure,gcp) plus the k8s data-plane bind on

--- a/cmd/cloudemu/doctor.go
+++ b/cmd/cloudemu/doctor.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+
+	"github.com/stackshy/cloudemu/v2/server/serveflags"
+)
+
+// errPreflightBlocker is returned when a required port is in use, so runDoctor
+// exits non-zero after printing the report.
+var errPreflightBlocker = errors.New("preflight found a blocker (see above)")
+
+// Status markers for the doctor report. ASCII-only so they render the same on
+// every platform (this command is deliberately not Unix-tagged).
+const (
+	markPass = "[ ok ]"
+	markWarn = "[warn]"
+	markFail = "[fail]"
+)
+
+// enginesImagePointer is the one-line pointer at the :engines image, kept
+// identical to the message serve prints (errEnginesNotInLeanBinary) so the CLI
+// speaks with one voice about where the real engines live.
+const enginesImagePointer = "docker run -p 4566:4566 ghcr.io/stackshy/cloudemu:engines --all-real"
+
+// portCheck is one default endpoint the emulator would bind. required marks a
+// port the default provider set (aws,azure,gcp) plus the k8s data-plane bind on
+// startup — an in-use required port is a genuine blocker. OCI is opt-in, so a
+// busy OCI port is only a warning.
+type portCheck struct {
+	label    string
+	port     string
+	required bool
+}
+
+// defaultPortChecks returns the ports `cloudemu serve` binds by default, read
+// from serveflags so the doctor can never drift from the real defaults.
+func defaultPortChecks() []portCheck {
+	var c serveflags.CommonConfig
+
+	fs := flag.NewFlagSet("doctor-defaults", flag.ContinueOnError)
+	serveflags.RegisterCommon(fs, &c, func(string) string { return "" })
+	_ = fs.Parse(nil)
+
+	return []portCheck{
+		{"AWS", c.AWSPort, true},
+		{"Azure", c.AzurePort, true},
+		{"GCP", c.GCPPort, true},
+		{"Kubernetes", c.K8sPort, true},
+		{"OCI (opt-in)", c.OCIPort, false},
+	}
+}
+
+// checkPortFree reports whether a TCP listener can be bound at hostPort right
+// now. This is a point-in-time probe: a "free" port can still be taken before
+// `cloudemu serve` binds it (TOCTOU), which the report wording makes explicit.
+func checkPortFree(hostPort string) bool {
+	var lc net.ListenConfig
+
+	ln, err := lc.Listen(context.Background(), "tcp", hostPort)
+	if err != nil {
+		return false
+	}
+
+	_ = ln.Close()
+
+	return true
+}
+
+// dockerLine reports whether a `docker` binary is on PATH. Docker is needed only
+// to run the :engines image, so its absence is a warning, never a failure.
+// lookPath is injected (default exec.LookPath) so tests need no real docker.
+func dockerLine(lookPath func(string) (string, error)) string {
+	if path, err := lookPath("docker"); err == nil {
+		return fmt.Sprintf("%s docker found at %s (only needed for the :engines image)", markPass, path)
+	}
+
+	return fmt.Sprintf("%s docker not found on PATH — only needed if you run the :engines image", markWarn)
+}
+
+// writeDoctorReport writes the preflight report to w and returns the number of
+// genuine blockers (required ports in use). portFree and lookPath are injected so
+// the report is deterministic under test.
+func writeDoctorReport(
+	w io.Writer,
+	host string,
+	ports []portCheck,
+	portFree func(string) bool,
+	lookPath func(string) (string, error),
+) int {
+	fmt.Fprintln(w, "cloudemu doctor — preflight check")
+	fmt.Fprintln(w)
+
+	fmt.Fprintf(w, "%s version %s (commit %s, built %s by %s)\n", markPass, version, commit, date, builtBy)
+	fmt.Fprintln(w)
+
+	fmt.Fprintf(w, "Ports on %s (free = free at check time; a port can still be taken before serve binds it):\n", host)
+
+	blockers := 0
+
+	for _, p := range ports {
+		hostPort := net.JoinHostPort(host, p.port)
+
+		if portFree(hostPort) {
+			fmt.Fprintf(w, "  %s %-14s %s  free (at check time)\n", markPass, p.label, hostPort)
+
+			continue
+		}
+
+		if p.required {
+			blockers++
+
+			fmt.Fprintf(w, "  %s %-14s %s  in use — free it or pass a different --%s-port to serve\n",
+				markFail, p.label, hostPort, portFlagHint(p.label))
+
+			continue
+		}
+
+		fmt.Fprintf(w, "  %s %-14s %s  in use (opt-in; only bound when you start OCI)\n", markWarn, p.label, hostPort)
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, dockerLine(lookPath))
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, "Real engines (postgres/redis/subprocess/docker/localfs) are NOT compiled into this lean")
+	fmt.Fprintln(w, "binary. To run them, use the :engines image:")
+	fmt.Fprintf(w, "  %s\n", enginesImagePointer)
+	fmt.Fprintln(w)
+
+	if blockers == 0 {
+		fmt.Fprintf(w, "%s all preflight checks passed — ready to `cloudemu serve`.\n", markPass)
+	} else {
+		fmt.Fprintf(w, "%s %d required port(s) in use — free them before `cloudemu serve`.\n", markFail, blockers)
+	}
+
+	return blockers
+}
+
+// portFlagHint maps a port label to the serve flag that overrides it, for the
+// fix hint on an in-use required port.
+func portFlagHint(label string) string {
+	switch label {
+	case "AWS":
+		return "aws"
+	case "Azure":
+		return "azure"
+	case "GCP":
+		return "gcp"
+	case "Kubernetes":
+		return "k8s"
+	default:
+		return "oci"
+	}
+}
+
+// runDoctor runs the preflight check: build version, default ports free, docker
+// availability, and where the real engines live. It prints a pass/warn/fail
+// summary and returns a non-nil error only when a required port is in use.
+func runDoctor(args []string) error {
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+
+	host := fs.String("host", "127.0.0.1", "host/interface the emulator would bind (mirrors serve --host)")
+
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage: cloudemu doctor [flags]\n\n"+
+			"Preflight check: build version, default ports free, docker availability.\n\nFlags:\n")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	blockers := writeDoctorReport(os.Stdout, *host, defaultPortChecks(), checkPortFree, exec.LookPath)
+	if blockers > 0 {
+		return errPreflightBlocker
+	}
+
+	return nil
+}

--- a/cmd/cloudemu/doctor_test.go
+++ b/cmd/cloudemu/doctor_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+)
+
+// TestCheckPortFree probes a port the test itself binds (expect in use) and an
+// unused port (expect free), exercising the real listen-then-close helper.
+func TestCheckPortFree(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("open listener: %v", err)
+	}
+	defer ln.Close()
+
+	busy := ln.Addr().String()
+	if checkPortFree(busy) {
+		t.Fatalf("checkPortFree(%q) = true, want false (a listener is bound there)", busy)
+	}
+
+	// Bind then close to obtain an address that is momentarily free.
+	free, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("open second listener: %v", err)
+	}
+
+	freeAddr := free.Addr().String()
+	_ = free.Close()
+
+	if !checkPortFree(freeAddr) {
+		t.Fatalf("checkPortFree(%q) = false, want true (nothing is bound there)", freeAddr)
+	}
+}
+
+// TestDockerLine confirms the injected lookPath drives the found/not-found line
+// and its pass/warn marker, so the check is testable without a real docker.
+func TestDockerLine(t *testing.T) {
+	found := func(string) (string, error) { return "/usr/bin/docker", nil }
+	line := dockerLine(found)
+
+	if !strings.Contains(line, markPass) || !strings.Contains(line, "/usr/bin/docker") {
+		t.Fatalf("found docker line = %q, want pass marker + path", line)
+	}
+
+	missing := func(string) (string, error) { return "", errors.New("not found") }
+	line = dockerLine(missing)
+
+	if !strings.Contains(line, markWarn) || strings.Contains(line, markFail) {
+		t.Fatalf("missing docker line = %q, want warn marker (not fail)", line)
+	}
+}
+
+// TestWriteDoctorReportBlockingPort verifies a required port in use is a blocker
+// (fail marker, non-zero return) while an opt-in OCI port in use is only a warn.
+func TestWriteDoctorReportBlockingPort(t *testing.T) {
+	ports := []portCheck{
+		{"AWS", "4566", true},
+		{"OCI (opt-in)", "4571", false},
+	}
+
+	// AWS busy (required → blocker), OCI busy (opt-in → warn only).
+	portFree := func(hostPort string) bool { return false }
+	found := func(string) (string, error) { return "/usr/bin/docker", nil }
+
+	var sb strings.Builder
+
+	blockers := writeDoctorReport(&sb, "127.0.0.1", ports, portFree, found)
+	out := sb.String()
+
+	if blockers != 1 {
+		t.Fatalf("blockers = %d, want 1 (only the required AWS port)", blockers)
+	}
+
+	if !strings.Contains(out, markFail) {
+		t.Fatalf("report missing fail marker for the in-use required port:\n%s", out)
+	}
+
+	if !strings.Contains(out, markWarn) {
+		t.Fatalf("report missing warn marker for the in-use opt-in OCI port:\n%s", out)
+	}
+
+	if !strings.Contains(out, "required port(s) in use") {
+		t.Fatalf("report missing the blocker summary line:\n%s", out)
+	}
+}
+
+// TestWriteDoctorReportAllClear verifies the all-pass path: zero blockers, a pass
+// summary, and the exact :engines pointer string.
+func TestWriteDoctorReportAllClear(t *testing.T) {
+	ports := []portCheck{
+		{"AWS", "4566", true},
+		{"Kubernetes", "4570", true},
+	}
+
+	portFree := func(string) bool { return true }
+	missing := func(string) (string, error) { return "", errors.New("not found") }
+
+	var sb strings.Builder
+
+	blockers := writeDoctorReport(&sb, "127.0.0.1", ports, portFree, missing)
+	out := sb.String()
+
+	if blockers != 0 {
+		t.Fatalf("blockers = %d, want 0 (all ports free)", blockers)
+	}
+
+	if !strings.Contains(out, "all preflight checks passed") {
+		t.Fatalf("report missing the all-clear summary:\n%s", out)
+	}
+
+	if !strings.Contains(out, markPass) {
+		t.Fatalf("report missing any pass marker:\n%s", out)
+	}
+
+	if !strings.Contains(out, enginesImagePointer) {
+		t.Fatalf("report missing the exact :engines pointer %q:\n%s", enginesImagePointer, out)
+	}
+
+	if !strings.Contains(out, "free (at check time)") {
+		t.Fatalf("report should phrase free ports as a point-in-time check:\n%s", out)
+	}
+}
+
+// TestDefaultPortChecks confirms the doctor reads the real serve defaults, so it
+// can never drift from what `cloudemu serve` binds.
+func TestDefaultPortChecks(t *testing.T) {
+	want := map[string]struct {
+		port     string
+		required bool
+	}{
+		"AWS":          {"4566", true},
+		"Azure":        {"4568", true},
+		"GCP":          {"4569", true},
+		"Kubernetes":   {"4570", true},
+		"OCI (opt-in)": {"4571", false},
+	}
+
+	got := defaultPortChecks()
+	if len(got) != len(want) {
+		t.Fatalf("defaultPortChecks() returned %d entries, want %d", len(got), len(want))
+	}
+
+	for _, p := range got {
+		exp, ok := want[p.label]
+		if !ok {
+			t.Fatalf("unexpected port label %q", p.label)
+		}
+
+		if p.port != exp.port || p.required != exp.required {
+			t.Fatalf("port %q = {%s, required=%v}, want {%s, required=%v}",
+				p.label, p.port, p.required, exp.port, exp.required)
+		}
+	}
+}

--- a/cmd/cloudemu/main.go
+++ b/cmd/cloudemu/main.go
@@ -24,6 +24,7 @@ Usage:
   cloudemu net ...           Check network reachability (can-connect, trace)
   cloudemu cost              Estimate the monthly cost of the current resources
   cloudemu env               Print shell exports to point SDKs/CLIs at a running server
+  cloudemu doctor            Preflight check: version, default ports free, docker
   cloudemu serve [flags]     Run the server in the foreground (see: cloudemu serve -h)
   cloudemu version           Print the version
   cloudemu help              Show this message
@@ -44,6 +45,7 @@ const (
 	cmdNet      = "net"
 	cmdCost     = "cost"
 	cmdEnv      = "env"
+	cmdDoctor   = "doctor"
 )
 
 // Build metadata, overridden at release time by GoReleaser ldflags
@@ -89,6 +91,11 @@ func main() {
 		}
 	case cmdEnv:
 		if err := runEnv(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "cloudemu:", err)
+			os.Exit(1)
+		}
+	case cmdDoctor:
+		if err := runDoctor(os.Args[2:]); err != nil {
 			fmt.Fprintln(os.Stderr, "cloudemu:", err)
 			os.Exit(1)
 		}

--- a/cmd/cloudemu/serve.go
+++ b/cmd/cloudemu/serve.go
@@ -13,6 +13,12 @@ import (
 	"github.com/stackshy/cloudemu/v2/server/serverkit"
 )
 
+// enginesImagePointer is the single canonical `docker run` line that points users
+// at the :engines image. serve prints it (the error below and --help footer) and
+// doctor echoes it, all from this one const so the CLI can never drift on where
+// the real engines live.
+const enginesImagePointer = "docker run -p 4566:4566 ghcr.io/stackshy/cloudemu:engines --all-real"
+
 // errEnginesNotInLeanBinary is returned when engine flags/env are passed to the
 // lean cloudemu binary, which deliberately does not compile the real engines
 // (postgres/redis/subprocess/docker/localfs) — those heavy deps live only in the
@@ -20,7 +26,7 @@ import (
 // points the user at the batteries image.
 var errEnginesNotInLeanBinary = errors.New(
 	"real engines (postgres/redis/subprocess/docker/localfs) aren't compiled into the lean cloudemu binary.\n" +
-		"run the batteries image:  docker run -p 4566:4566 ghcr.io/stackshy/cloudemu:engines --all-real\n" +
+		"run the batteries image:  " + enginesImagePointer + "\n" +
 		"(or build ./contrib/server from a repo checkout). see https://cloudemu.info/docs/standalone-server")
 
 func runServe(args []string) error {
@@ -87,7 +93,7 @@ func newServeFlagSet(c *serveflags.CommonConfig) *flag.FlagSet {
 		realOnly.PrintDefaults()
 		fmt.Fprintf(out, "\nReal engines (postgres/redis/subprocess/docker/localfs) live in the "+
 			"cloudemu:engines image, not this lean binary:\n"+
-			"  docker run -p 4566:4566 ghcr.io/stackshy/cloudemu:engines --all-real\n")
+			"  "+enginesImagePointer+"\n")
 	}
 
 	return fs

--- a/cmd/cloudemu/serve_engines_test.go
+++ b/cmd/cloudemu/serve_engines_test.go
@@ -41,6 +41,47 @@ func TestServeEngineFlagsPointToEnginesImage(t *testing.T) {
 	}
 }
 
+// TestEnginesHintSharedBetweenServeAndDoctor asserts serve and doctor surface the
+// one canonical enginesImagePointer in their actual output, so a future edit to
+// the const changes every code path and none can silently hardcode a divergent
+// hint. It exercises all three call sites: serve's error, serve's --help footer,
+// and the doctor report.
+func TestEnginesHintSharedBetweenServeAndDoctor(t *testing.T) {
+	// serve's engines-pointer error.
+	if !strings.Contains(errEnginesNotInLeanBinary.Error(), enginesImagePointer) {
+		t.Fatalf("serve error %q does not contain the shared hint %q",
+			errEnginesNotInLeanBinary.Error(), enginesImagePointer)
+	}
+
+	// serve's --help footer.
+	var c serveflags.CommonConfig
+
+	fs := newServeFlagSet(&c)
+
+	var help strings.Builder
+
+	fs.SetOutput(&help)
+	fs.Usage()
+
+	if !strings.Contains(help.String(), enginesImagePointer) {
+		t.Fatalf("serve --help footer does not contain the shared hint %q:\n%s",
+			enginesImagePointer, help.String())
+	}
+
+	// doctor's report footer.
+	var report strings.Builder
+
+	writeDoctorReport(&report, "127.0.0.1",
+		[]portCheck{{"AWS", "4566", true}},
+		func(string) bool { return true },
+		func(string) (string, error) { return "", errors.New("not found") })
+
+	if !strings.Contains(report.String(), enginesImagePointer) {
+		t.Fatalf("doctor report does not contain the shared hint %q:\n%s",
+			enginesImagePointer, report.String())
+	}
+}
+
 // TestServeAccountIDValueIsNotAnEngineFlag is the false-positive guard: with
 // `serve --account-id --db`, `--db` is the VALUE of --account-id (a string flag),
 // not a set flag. fs.Visit reports account-id set and db not set, so the engines

--- a/docs/standalone-server.md
+++ b/docs/standalone-server.md
@@ -276,6 +276,40 @@ well as NoSQL throughput, data transfer, and per-request charges. It's meant to
 catch "why is this so expensive?" surprises early, not to reconcile invoices; a
 live pricing-API integration is a planned follow-up.
 
+## Preflight check (`cloudemu doctor`)
+
+A fast, no-server sanity check to run before `cloudemu serve` — it confirms the
+default ports are free, prints the build version, and flags whether `docker` is
+available (needed only for the `:engines` image):
+
+```sh
+cloudemu doctor                 # check 127.0.0.1
+cloudemu doctor --host 0.0.0.0  # check the interface you'll bind serve to
+```
+
+```text
+cloudemu doctor — preflight check
+
+[ ok ] version 2.x.y (commit abc1234, built 2026-08-30 by goreleaser)
+
+Ports on 127.0.0.1 (free = free at check time; a port can still be taken before serve binds it):
+  [ ok ] AWS            127.0.0.1:4566  free (at check time)
+  [ ok ] Azure          127.0.0.1:4568  free (at check time)
+  [ ok ] GCP            127.0.0.1:4569  free (at check time)
+  [ ok ] Kubernetes     127.0.0.1:4570  free (at check time)
+  [ ok ] OCI (opt-in)   127.0.0.1:4571  free (at check time)
+
+[ ok ] docker found at /usr/bin/docker (only needed for the :engines image)
+...
+[ ok ] all preflight checks passed — ready to `cloudemu serve`.
+```
+
+An in-use **required** port (AWS/Azure/GCP/Kubernetes) is a blocker: the line is
+marked `[fail]`, the summary tells you how many, and the command exits non-zero
+(so it drops straight into a CI gate). The opt-in **OCI** port and a missing
+`docker` are `[warn]` only — never a failure. The port defaults are read from
+serve itself, so they can't drift from what `cloudemu serve` actually binds.
+
 ## Ports
 
 | Provider   | Default | Protocol | Notes                                    |
@@ -287,7 +321,8 @@ live pricing-API integration is a planned follow-up.
 
 Override with `--aws-port`, `--azure-port`, `--gcp-port`, `--k8s-port`. Start a
 subset with `--providers=aws,gcp`. Bind an interface with `--host 0.0.0.0` (the
-default `127.0.0.1` keeps it local-only).
+default `127.0.0.1` keeps it local-only). Run [`cloudemu
+doctor`](#preflight-check-cloudemu-doctor) first to confirm these ports are free.
 
 ## Pointing SDKs at it
 


### PR DESCRIPTION
## What

Adds a `cloudemu doctor` subcommand — a fast, dependency-free preflight check you run before `cloudemu serve` (closes #454).

## Checks it runs

- **Build version** — prints the ldflag-stamped `version/commit/date/builtBy`.
- **Default ports free** — for each port `serve` binds by default (read from `server/serveflags` so it can't drift: AWS 4566, Azure 4568, GCP 4569, Kubernetes 4570, OCI 4571), tries to `Listen` then closes. Required ports (aws/azure/gcp/k8s) in use are blockers; OCI is opt-in so it only warns. Accepts `--host` (default `127.0.0.1`) mirroring `cloudemu env`. This is a point-in-time probe, so output says "free (at check time)" — not a guarantee (TOCTOU-honest).
- **Docker** — `exec.LookPath("docker")` (cross-platform stdlib). Framed as "only needed for the :engines image" — a warning when absent, never a hard failure.
- **Engines note** — states the real engines aren't compiled into the lean binary and points at the `:engines` image using the exact same string `serve` prints: `docker run -p 4566:4566 ghcr.io/stackshy/cloudemu:engines --all-real`.

Exit code is non-zero only when a required port is in use.

## Sample output

```
cloudemu doctor — preflight check

[ ok ] version dev (commit none, built unknown by unknown)

Ports on 127.0.0.1 (free = free at check time; a port can still be taken before serve binds it):
  [ ok ] AWS            127.0.0.1:4566  free (at check time)
  [ ok ] Azure          127.0.0.1:4568  free (at check time)
  [ ok ] GCP            127.0.0.1:4569  free (at check time)
  [ ok ] Kubernetes     127.0.0.1:4570  free (at check time)
  [ ok ] OCI (opt-in)   127.0.0.1:4571  free (at check time)

[ ok ] docker found at /usr/local/bin/docker (only needed for the :engines image)

Real engines (postgres/redis/subprocess/docker/localfs) are NOT compiled into this lean
binary. To run them, use the :engines image:
  docker run -p 4566:4566 ghcr.io/stackshy/cloudemu:engines --all-real

[ ok ] all preflight checks passed — ready to `cloudemu serve`.
```

## Notes

- New file `cmd/cloudemu/doctor.go` is **cross-platform** — no `//go:build` tag (verified with `GOOS=windows go build ./cmd/cloudemu`).
- The Docker check is behind an injected `lookPath` param and the port checker takes an explicit `host:port`, so both are unit-testable without a real docker/server (mirrors serve's injected-getenv pattern). Tests are hand-rolled asserts (no testify).

## Gates

`go build ./...`, `go vet ./cmd/cloudemu/...`, `go test ./cmd/cloudemu/...`, `golangci-lint` (zero new vs baseline), and `go generate ./...` (no diff) all pass; Windows cross-compile succeeds.
