### PR TITLE
fix(kubernetes): honor persistentVolumeClaimRetentionPolicy + cascade registry stores on namespace delete (#408)

### DIFF
--- a/services/kubernetes/namespace.go
+++ b/services/kubernetes/namespace.go
@@ -314,6 +314,41 @@ func (s *ClusterState) deleteNamespaceLocked(ns *corev1.Namespace) {
 	cascadeDeleteWithEvents(s, s.services, prefix, name, s.wServices)
 	cascadeDeleteWithEvents(s, s.deployments, prefix, name, s.wDeployments)
 	cascadeDeleteWithEvents(s, s.endpoints, prefix, name, s.wEndpoints)
+
+	// The typed maps above hold only 7 built-in kinds. Registry-backed namespaced
+	// objects (PVCs, StatefulSets, Ingresses, custom resources, …) live in
+	// s.reg.stores and were previously leaked on namespace delete. Sweep them too
+	// so a namespace delete removes everything inside it, matching real k8s.
+	s.cascadeRegistryStoresLocked(name)
+}
+
+// cascadeRegistryStoresLocked deletes every registry-backed namespaced object in
+// the named namespace, mirroring the typed cascade above (finalizer-gated:
+// finalizer-bearing objects go Terminating, the rest are removed with a DELETED
+// event). Cluster-scoped registry objects (PVs, Nodes, CRDs) carry an empty
+// namespace and never match. Callers hold s.mu — the set of stores only changes
+// under s.mu, so ranging s.reg.stores directly is safe (see garbageCollectLocked).
+func (s *ClusterState) cascadeRegistryStoresLocked(namespace string) {
+	prefix := namespace + "/"
+
+	for _, st := range s.reg.stores {
+		for key, obj := range st.items {
+			if !strings.HasPrefix(key, prefix) || obj.GetNamespace() != namespace {
+				continue
+			}
+
+			if s.markForDeletionUnstructured(obj) {
+				s.stampRegistryRVLocked(obj)
+				st.watch.publish(EventModified, namespace, *obj.DeepCopy())
+
+				continue
+			}
+
+			s.stampRegistryRVLocked(obj)
+			delete(st.items, key)
+			st.watch.publish(EventDeleted, namespace, *obj.DeepCopy())
+		}
+	}
 }
 
 // deepCopier constrains the element type of a per-resource map: it must be

--- a/services/kubernetes/reconcile.go
+++ b/services/kubernetes/reconcile.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -679,8 +680,23 @@ func (s *ClusterState) markPodSucceededLocked(pod *corev1.Pod) {
 	}
 }
 
+// PVC retention-policy values (spec.persistentVolumeClaimRetentionPolicy).
+const (
+	pvcRetentionRetain = "Retain"
+	pvcRetentionDelete = "Delete"
+)
+
 // syncStatefulSetPVCsLocked creates a Bound PVC per (volumeClaimTemplate,
-// ordinal) named "<template>-<sts>-<ordinal>", owned by the StatefulSet.
+// ordinal) named "<template>-<sts>-<ordinal>". Ownership and scale-down deletion
+// honor spec.persistentVolumeClaimRetentionPolicy (default Retain/Retain):
+//   - whenDeleted=Delete stamps the StatefulSet as the PVC owner so
+//     garbageCollectLocked reaps the PVCs when the StatefulSet is deleted. The
+//     default (Retain) leaves NO owner ref, so the volumes survive a delete /
+//     helm uninstall — matching real k8s, where data is not lost on uninstall.
+//   - whenScaled=Delete removes the PVCs whose ordinal falls outside the new
+//     replica count. This is an EXPLICIT reap: StatefulSet scale-down deletes
+//     Pods with a bare delete that never invokes garbageCollectLocked, so a Pod
+//     owner ref would be inert here.
 func (s *ClusterState) syncStatefulSetPVCsLocked(sts *unstructured.Unstructured, replicas int) {
 	templates, found, _ := unstructured.NestedSlice(sts.Object, "spec", "volumeClaimTemplates")
 	if !found {
@@ -692,6 +708,8 @@ func (s *ClusterState) syncStatefulSetPVCsLocked(sts *unstructured.Unstructured,
 		return
 	}
 
+	whenDeleted, whenScaled := statefulSetPVCRetentionPolicy(sts)
+
 	for _, raw := range templates {
 		tmpl, ok := raw.(map[string]any)
 		if !ok {
@@ -699,6 +717,10 @@ func (s *ClusterState) syncStatefulSetPVCsLocked(sts *unstructured.Unstructured,
 		}
 
 		tmplName, _, _ := unstructured.NestedString(tmpl, "metadata", "name")
+
+		if whenScaled == pvcRetentionDelete {
+			s.reapScaledStatefulSetPVCsLocked(store, sts.GetNamespace(), tmplName, sts.GetName(), replicas)
+		}
 
 		for i := range replicas {
 			name := fmt.Sprintf("%s-%s-%d", tmplName, sts.GetName(), i)
@@ -724,11 +746,65 @@ func (s *ClusterState) syncStatefulSetPVCsLocked(sts *unstructured.Unstructured,
 			}}
 			pvc.SetUID(types.UID(newUID()))
 			pvc.SetCreationTimestamp(s.now())
-			pvc.SetOwnerReferences([]metav1.OwnerReference{ownerRefOf(sts)})
+
+			// Only whenDeleted=Delete stamps the owner ref — the one case where the
+			// STS-delete cascade should reap the PVC. Under the Retain default the
+			// PVC is deliberately ownerless so it outlives the StatefulSet.
+			if whenDeleted == pvcRetentionDelete {
+				pvc.SetOwnerReferences([]metav1.OwnerReference{ownerRefOf(sts)})
+			}
+
 			s.stampRegistryRVLocked(pvc)
 			store.items[key] = pvc
 			store.watch.publish(EventAdded, sts.GetNamespace(), *pvc.DeepCopy())
 		}
+	}
+}
+
+// statefulSetPVCRetentionPolicy reads spec.persistentVolumeClaimRetentionPolicy,
+// defaulting either field to Retain when unset — the apiserver default.
+func statefulSetPVCRetentionPolicy(sts *unstructured.Unstructured) (whenDeleted, whenScaled string) {
+	whenDeleted, whenScaled = pvcRetentionRetain, pvcRetentionRetain
+
+	if v, ok, _ := unstructured.NestedString(
+		sts.Object, "spec", "persistentVolumeClaimRetentionPolicy", "whenDeleted"); ok && v != "" {
+		whenDeleted = v
+	}
+
+	if v, ok, _ := unstructured.NestedString(
+		sts.Object, "spec", "persistentVolumeClaimRetentionPolicy", "whenScaled"); ok && v != "" {
+		whenScaled = v
+	}
+
+	return whenDeleted, whenScaled
+}
+
+// reapScaledStatefulSetPVCsLocked deletes the volumeClaimTemplate PVCs whose
+// ordinal is >= replicas — the whenScaled=Delete behavior. It scans the PVC
+// store for "<template>-<sts>-<ordinal>" names in the namespace and reaps the
+// out-of-range ones explicitly, because StatefulSet scale-down never runs the
+// ownerReference garbage collector.
+func (s *ClusterState) reapScaledStatefulSetPVCsLocked(
+	store *registryStore, namespace, tmplName, stsName string, replicas int,
+) {
+	prefix := fmt.Sprintf("%s-%s-", tmplName, stsName)
+
+	for key, pvc := range store.items {
+		if pvc.GetNamespace() != namespace {
+			continue
+		}
+
+		name := pvc.GetName()
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+
+		ordinal, err := strconv.Atoi(name[len(prefix):])
+		if err != nil || ordinal < replicas {
+			continue
+		}
+
+		s.reapRegistryObjectLocked(store, key, pvc)
 	}
 }
 

--- a/services/kubernetes/registry_ops.go
+++ b/services/kubernetes/registry_ops.go
@@ -91,6 +91,25 @@ func (s *ClusterState) garbageCollectLocked(owner types.UID) {
 	}
 }
 
+// reapRegistryObjectLocked deletes one registry object with the same
+// finalizer-gating and teardown a direct DELETE performs (registryDelete): a
+// finalizer-bearing object goes Terminating (MODIFIED event), otherwise it is
+// torn down (owned-child cascade + quota release) and a DELETED event is
+// published. Used by the StatefulSet whenScaled=Delete PVC reap, where the
+// namespace lives on so quota must stay accurate. Callers hold s.mu.
+func (s *ClusterState) reapRegistryObjectLocked(store *registryStore, key string, obj *unstructured.Unstructured) {
+	if s.markForDeletionUnstructured(obj) {
+		s.stampRegistryRVLocked(obj)
+		store.watch.publish(EventModified, obj.GetNamespace(), *obj.DeepCopy())
+
+		return
+	}
+
+	s.stampRegistryRVLocked(obj)
+	s.teardownRegistryObjectLocked(store, key, obj)
+	store.watch.publish(EventDeleted, obj.GetNamespace(), *obj.DeepCopy())
+}
+
 func ownedBy(refs []metav1.OwnerReference, owner types.UID) bool {
 	for _, ref := range refs {
 		if ref.UID == owner {

--- a/services/kubernetes/statefulset_pvc_retention_test.go
+++ b/services/kubernetes/statefulset_pvc_retention_test.go
@@ -1,0 +1,274 @@
+// Tests for StatefulSet persistentVolumeClaimRetentionPolicy handling and the
+// paired namespace-delete registry-store cascade. The default policy is
+// Retain/Retain, so volumeClaimTemplate PVCs must OUTLIVE a StatefulSet delete
+// (the "helm uninstall does not lose data" property); whenDeleted=Delete opts
+// the PVCs into the STS-delete cascade; whenScaled=Delete reaps the PVCs of
+// ordinals dropped by a scale-down.
+
+package kubernetes_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// makeStatefulSet builds a StatefulSet manifest with a single "data"
+// volumeClaimTemplate. extraSpec is merged into spec (e.g. a
+// persistentVolumeClaimRetentionPolicy).
+func makeStatefulSet(name string, replicas int, extraSpec map[string]any) map[string]any {
+	spec := map[string]any{
+		"replicas":    int64(replicas),
+		"serviceName": name,
+		"selector":    map[string]any{"matchLabels": map[string]any{"app": name}},
+		"template": map[string]any{
+			"metadata": map[string]any{"labels": map[string]any{"app": name}},
+			"spec": map[string]any{
+				"containers": []any{map[string]any{"name": "c", "image": "nginx"}},
+			},
+		},
+		"volumeClaimTemplates": []any{
+			map[string]any{
+				"metadata": map[string]any{"name": "data"},
+				"spec": map[string]any{
+					"accessModes": []any{"ReadWriteOnce"},
+					"resources":   map[string]any{"requests": map[string]any{"storage": "1Gi"}},
+				},
+			},
+		},
+	}
+
+	for k, v := range extraSpec {
+		spec[k] = v
+	}
+
+	return map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "StatefulSet",
+		"metadata":   map[string]any{"name": name},
+		"spec":       spec,
+	}
+}
+
+// pvcExists reports whether the named PVC is present in the default namespace.
+func pvcExists(t *testing.T, base, name string) bool {
+	t.Helper()
+
+	resp := do(t, http.MethodGet, base+"/api/v1/namespaces/default/persistentvolumeclaims/"+name, nil)
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true
+	case http.StatusNotFound:
+		return false
+	default:
+		t.Fatalf("get pvc %s: unexpected status %d", name, resp.StatusCode)
+
+		return false
+	}
+}
+
+func createStatefulSet(t *testing.T, base string, sts map[string]any) {
+	t.Helper()
+
+	resp := do(t, http.MethodPost, base+"/apis/apps/v1/namespaces/default/statefulsets", mustJSON(t, sts))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create statefulset: got %d, want 201", resp.StatusCode)
+	}
+}
+
+// TestStatefulSetPVC_SurvivesDelete_DefaultRetain is the ticket fix: with the
+// default Retain/Retain policy the volumeClaimTemplate PVC has no owner ref, so
+// deleting the StatefulSet (a helm uninstall) leaves the data behind.
+func TestStatefulSetPVC_SurvivesDelete_DefaultRetain(t *testing.T) {
+	base, done := newFixture(t)
+	defer done()
+
+	createStatefulSet(t, base, makeStatefulSet("web", 1, nil))
+
+	// The PVC exists and is Bound.
+	resp := do(t, http.MethodGet, base+"/api/v1/namespaces/default/persistentvolumeclaims/data-web-0", nil)
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		t.Fatalf("get data-web-0: got %d, want 200", resp.StatusCode)
+	}
+
+	pvc := decodeMap(t, resp.Body)
+	status, _ := pvc["status"].(map[string]any)
+	if phase, _ := status["phase"].(string); phase != "Bound" {
+		t.Fatalf("data-web-0 phase = %q, want Bound", phase)
+	}
+
+	// A Retain PVC must carry NO owner ref, or the STS-delete cascade would reap it.
+	meta, _ := pvc["metadata"].(map[string]any)
+	if owners, _ := meta["ownerReferences"].([]any); len(owners) != 0 {
+		t.Fatalf("data-web-0 has owner refs under Retain: %v", owners)
+	}
+
+	// Uninstall: delete the StatefulSet.
+	del := do(t, http.MethodDelete, base+"/apis/apps/v1/namespaces/default/statefulsets/web", nil)
+	if del.StatusCode != http.StatusOK {
+		del.Body.Close()
+		t.Fatalf("delete statefulset: got %d, want 200", del.StatusCode)
+	}
+	del.Body.Close()
+
+	// The PVC must SURVIVE — data is not lost on uninstall.
+	if !pvcExists(t, base, "data-web-0") {
+		t.Fatalf("data-web-0 was deleted on STS delete under default Retain (data loss)")
+	}
+}
+
+// TestStatefulSetPVC_WhenDeletedDelete_RemovedOnDelete verifies that opting into
+// whenDeleted=Delete stamps the STS owner ref so the STS-delete cascade reaps
+// the PVC.
+func TestStatefulSetPVC_WhenDeletedDelete_RemovedOnDelete(t *testing.T) {
+	base, done := newFixture(t)
+	defer done()
+
+	createStatefulSet(t, base, makeStatefulSet("web", 1, map[string]any{
+		"persistentVolumeClaimRetentionPolicy": map[string]any{
+			"whenDeleted": "Delete",
+			"whenScaled":  "Retain",
+		},
+	}))
+
+	if !pvcExists(t, base, "data-web-0") {
+		t.Fatalf("data-web-0 not created")
+	}
+
+	del := do(t, http.MethodDelete, base+"/apis/apps/v1/namespaces/default/statefulsets/web", nil)
+	if del.StatusCode != http.StatusOK {
+		del.Body.Close()
+		t.Fatalf("delete statefulset: got %d, want 200", del.StatusCode)
+	}
+	del.Body.Close()
+
+	if pvcExists(t, base, "data-web-0") {
+		t.Fatalf("data-web-0 survived STS delete under whenDeleted=Delete (owner-ref cascade did not fire)")
+	}
+}
+
+// TestStatefulSetPVC_WhenScaledDelete_ReapsOrdinals verifies the explicit
+// out-of-range-ordinal reap: with whenScaled=Delete, scaling 3 -> 1 removes the
+// PVCs for ordinals 1 and 2 while keeping ordinal 0.
+func TestStatefulSetPVC_WhenScaledDelete_ReapsOrdinals(t *testing.T) {
+	base, done := newFixture(t)
+	defer done()
+
+	policy := map[string]any{
+		"persistentVolumeClaimRetentionPolicy": map[string]any{
+			"whenDeleted": "Retain",
+			"whenScaled":  "Delete",
+		},
+	}
+
+	createStatefulSet(t, base, makeStatefulSet("web", 3, policy))
+
+	for _, n := range []string{"data-web-0", "data-web-1", "data-web-2"} {
+		if !pvcExists(t, base, n) {
+			t.Fatalf("%s not created at replicas=3", n)
+		}
+	}
+
+	// Scale down to 1.
+	put := do(t, http.MethodPut, base+"/apis/apps/v1/namespaces/default/statefulsets/web",
+		mustJSON(t, makeStatefulSet("web", 1, policy)))
+	if put.StatusCode != http.StatusOK {
+		put.Body.Close()
+		t.Fatalf("scale statefulset: got %d, want 200", put.StatusCode)
+	}
+	put.Body.Close()
+
+	// Ordinal 0 kept; ordinals 1 and 2 reaped.
+	if !pvcExists(t, base, "data-web-0") {
+		t.Fatalf("data-web-0 removed on scale-down (ordinal 0 must survive)")
+	}
+
+	for _, n := range []string{"data-web-1", "data-web-2"} {
+		if pvcExists(t, base, n) {
+			t.Fatalf("%s survived whenScaled=Delete scale-down (explicit reap did not fire)", n)
+		}
+	}
+}
+
+// TestNamespaceDelete_CascadesRegistryStores verifies the paired fix: deleting a
+// namespace removes registry-backed namespaced objects (PVCs, StatefulSets, and
+// custom resources), which the typed-map-only cascade previously leaked.
+func TestNamespaceDelete_CascadesRegistryStores(t *testing.T) {
+	base, done := newFixture(t)
+	defer done()
+
+	// A CRD so we can put a namespaced custom resource in the doomed namespace.
+	createWidgetCRD(t, base)
+
+	nsBody := mustJSON(t, map[string]any{
+		"apiVersion": "v1", "kind": "Namespace",
+		"metadata": map[string]any{"name": "doomed"},
+	})
+
+	nsResp := do(t, http.MethodPost, base+"/api/v1/namespaces", nsBody)
+	if nsResp.StatusCode != http.StatusCreated {
+		nsResp.Body.Close()
+		t.Fatalf("create namespace: got %d, want 201", nsResp.StatusCode)
+	}
+	nsResp.Body.Close()
+
+	// A StatefulSet (registry-backed) with a volumeClaimTemplate → also a PVC.
+	sts := do(t, http.MethodPost, base+"/apis/apps/v1/namespaces/doomed/statefulsets",
+		mustJSON(t, makeStatefulSet("web", 1, nil)))
+	if sts.StatusCode != http.StatusCreated {
+		sts.Body.Close()
+		t.Fatalf("create statefulset in doomed: got %d, want 201", sts.StatusCode)
+	}
+	sts.Body.Close()
+
+	// A custom resource.
+	cr := do(t, http.MethodPost, base+"/apis/example.com/v1/namespaces/doomed/widgets",
+		mustJSON(t, map[string]any{
+			"apiVersion": "example.com/v1", "kind": "Widget",
+			"metadata": map[string]any{"name": "w1"},
+			"spec":     map[string]any{"size": int64(3)},
+		}))
+	if cr.StatusCode != http.StatusCreated {
+		cr.Body.Close()
+		t.Fatalf("create widget in doomed: got %d, want 201", cr.StatusCode)
+	}
+	cr.Body.Close()
+
+	// Sanity: everything is present before the namespace delete.
+	present := map[string]string{
+		"statefulset": "/apis/apps/v1/namespaces/doomed/statefulsets/web",
+		"pvc":         "/api/v1/namespaces/doomed/persistentvolumeclaims/data-web-0",
+		"widget":      "/apis/example.com/v1/namespaces/doomed/widgets/w1",
+	}
+
+	for kind, path := range present {
+		resp := do(t, http.MethodGet, base+path, nil)
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			t.Fatalf("%s before delete: got %d, want 200", kind, resp.StatusCode)
+		}
+		resp.Body.Close()
+	}
+
+	// Delete the namespace.
+	del := do(t, http.MethodDelete, base+"/api/v1/namespaces/doomed", nil)
+	if del.StatusCode != http.StatusOK {
+		del.Body.Close()
+		t.Fatalf("delete namespace: got %d, want 200", del.StatusCode)
+	}
+	del.Body.Close()
+
+	// Every registry-backed object in the namespace is gone.
+	for kind, path := range present {
+		resp := do(t, http.MethodGet, base+path, nil)
+		if resp.StatusCode != http.StatusNotFound {
+			resp.Body.Close()
+			t.Fatalf("%s after namespace delete: got %d, want 404 (leaked)", kind, resp.StatusCode)
+		}
+		resp.Body.Close()
+	}
+}


### PR DESCRIPTION
## Summary

StatefulSet `volumeClaimTemplate` PVCs were **unconditionally** stamped with the StatefulSet as owner in `syncStatefulSetPVCsLocked`. Because `garbageCollectLocked` cascades on an owner's delete, deleting a StatefulSet (a `helm uninstall`) reaped every PVC — a **data-loss bug**. Real Kubernetes defaults `persistentVolumeClaimRetentionPolicy` to `Retain/Retain`, where the PVCs are ownerless and survive both delete and scale-down.

This PR makes cloudemu honor `spec.persistentVolumeClaimRetentionPolicy` and, paired with it, fixes a pre-existing namespace-cascade leak.

## Changes

### 1. PVC retention policy (`reconcile.go`)
- **Retain/Retain (default)** → **no owner ref**. PVCs outlive the StatefulSet, so a helm uninstall no longer loses data.
- **`whenDeleted=Delete`** → set the StatefulSet owner ref, so the STS-delete GC cascade reaps the PVC (the one case where the owner-ref mechanism actually works).
- **`whenScaled=Delete`** → **explicit out-of-range-ordinal reap** in the PVC-sync path. StatefulSet scale-down deletes Pods with a bare `delete(s.pods,…)` that never invokes `garbageCollectLocked`, so a Pod owner ref would be inert. Instead, after computing the new replica count, any `volumeClaimTemplate` PVC whose ordinal `>= replicas` is deleted directly (finalizer-gated, quota-accurate — same teardown as a direct DELETE).

### 2. Namespace cascade fix (`namespace.go`)
`deleteNamespaceLocked` swept only the 7 typed maps and never `s.reg.stores`, so a namespace delete **leaked** all registry-backed namespaced objects (PVCs, StatefulSets, Ingresses, custom resources). Added a namespace-scoped sweep of `s.reg.stores` (finalizer-gated, mirroring the typed cascade; cluster-scoped objects never match) so a namespace delete removes everything inside it, matching real k8s.

## Tests (`statefulset_pvc_retention_test.go`, HTTP-fixture style)
- STS + volumeClaimTemplate → PVC created + Bound, **no owner ref**; delete STS → PVC **survives** (default Retain).
- `whenDeleted=Delete` → delete STS → PVC removed.
- `whenScaled=Delete`, replicas 3 → 3 PVCs; scale to 1 → ordinals 1,2 removed, ordinal 0 kept.
- Namespace delete with a PVC + StatefulSet + CRD/CR → all removed.

## Validation (GOMAXPROCS=3)
- `go build ./...` clean
- `go vet ./services/kubernetes/...` clean
- `go test -count=1 ./services/kubernetes/...` pass
- `go test -race -count=1 ./services/kubernetes/...` pass
- `golangci-lint run ./services/kubernetes/...` — only the pre-existing `admission.go:351` gosec (baseline), exit 0
- `go generate ./...` — no diff
