### PR TITLE
feat(kubernetes): seed kube-system (coredns, kube-proxy) + drive CronJobs on the opt-in ticker with history limits (#876)

### DIFF
--- a/services/kubernetes/apiserver.go
+++ b/services/kubernetes/apiserver.go
@@ -120,6 +120,11 @@ func (s *APIServer) TickAll() bool {
 	changed := false
 
 	for _, st := range states {
+		// CronJob firing is opt-in time-driven behavior like the staged Pod
+		// lifecycle — both are gated on progression (Tick and TickCronJobs
+		// self-gate), so the real-time serve ticker drives them together.
+		st.TickCronJobs()
+
 		if st.Tick() {
 			changed = true
 		}

--- a/services/kubernetes/cronjob.go
+++ b/services/kubernetes/cronjob.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"sort"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +35,13 @@ const (
 func (s *ClusterState) TickCronJobs() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// Defense-in-depth self-gate (mirrors Tick's at lifecycle.go): CronJob firing
+	// is opt-in time-driven behavior, so it stays a no-op unless progression is on
+	// — even if a caller other than the gated serve ticker reaches this.
+	if !s.lifecycleProgression {
+		return
+	}
 
 	cronStore := s.reg.getStore(apiGroupBatch, "v1", "cronjobs")
 	jobStore := s.reg.getStore(apiGroupBatch, "v1", "jobs")
@@ -178,22 +186,7 @@ func activeJobsFor(cj *unstructured.Unstructured, jobStore *registryStore) []*un
 
 // jobTerminal reports whether a Job has finished (Complete or Failed True).
 func jobTerminal(job *unstructured.Unstructured) bool {
-	conds, _, _ := unstructured.NestedSlice(job.Object, "status", "conditions")
-	for _, raw := range conds {
-		cond, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		ctype, _, _ := unstructured.NestedString(cond, "type")
-		cstatus, _, _ := unstructured.NestedString(cond, "status")
-
-		if cstatus == "True" && (ctype == "Complete" || ctype == "Failed") {
-			return true
-		}
-	}
-
-	return false
+	return jobHasCondition(job, "Complete") || jobHasCondition(job, "Failed")
 }
 
 // deleteJobLocked removes a Job and cascade-collects its Pods (Replace policy).
@@ -234,4 +227,101 @@ func (s *ClusterState) fireCronJobLocked(cj *unstructured.Unstructured, jobStore
 		"Created job "+jobName)
 
 	setLastScheduleTime(cj, fireTime)
+
+	// Trim finished Jobs beyond the history limits so `kubectl get jobs` self-
+	// trims and a long-lived `serve` doesn't accumulate Jobs unbounded.
+	s.pruneJobHistoryLocked(cj, jobStore)
+}
+
+// Default CronJob history limits (batch/v1 CronJobSpec), applied when the field
+// is unset — how many finished Jobs the controller keeps per CronJob.
+const (
+	defaultSuccessfulJobsHistoryLimit = 3
+	defaultFailedJobsHistoryLimit     = 1
+)
+
+// pruneJobHistoryLocked deletes the CronJob's finished Jobs beyond its
+// successfulJobsHistoryLimit / failedJobsHistoryLimit (defaults 3 / 1), keeping
+// the most recent of each. Active Jobs are never touched. Callers hold s.mu.
+func (s *ClusterState) pruneJobHistoryLocked(cj *unstructured.Unstructured, jobStore *registryStore) {
+	uid := cj.GetUID()
+
+	var succeeded, failed []*unstructured.Unstructured
+
+	for _, job := range jobStore.items {
+		if !ownedBy(job.GetOwnerReferences(), uid) {
+			continue
+		}
+
+		switch {
+		case jobHasCondition(job, "Complete"):
+			succeeded = append(succeeded, job)
+		case jobHasCondition(job, "Failed"):
+			failed = append(failed, job)
+		}
+	}
+
+	s.trimFinishedJobsLocked(succeeded, jobHistoryLimit(cj, "successfulJobsHistoryLimit",
+		defaultSuccessfulJobsHistoryLimit), jobStore)
+	s.trimFinishedJobsLocked(failed, jobHistoryLimit(cj, "failedJobsHistoryLimit",
+		defaultFailedJobsHistoryLimit), jobStore)
+}
+
+// trimFinishedJobsLocked deletes all but the `limit` most-recent Jobs from a set
+// of finished Jobs, sorting oldest-first (creationTimestamp, then name) for a
+// deterministic choice of which to drop. Callers hold s.mu.
+func (s *ClusterState) trimFinishedJobsLocked(jobs []*unstructured.Unstructured, limit int, jobStore *registryStore) {
+	if len(jobs) <= limit {
+		return
+	}
+
+	sort.Slice(jobs, func(i, j int) bool {
+		ti := jobs[i].GetCreationTimestamp().Time
+		tj := jobs[j].GetCreationTimestamp().Time
+
+		if !ti.Equal(tj) {
+			return ti.Before(tj)
+		}
+
+		return jobs[i].GetName() < jobs[j].GetName()
+	})
+
+	for _, job := range jobs[:len(jobs)-limit] {
+		s.deleteJobLocked(job, jobStore)
+	}
+}
+
+// jobHistoryLimit reads a CronJob history-limit field, falling back to def when
+// unset (a negative value clamps to 0 — keep none).
+func jobHistoryLimit(cj *unstructured.Unstructured, field string, def int) int {
+	n, found, _ := unstructured.NestedInt64(cj.Object, "spec", field)
+	if !found {
+		return def
+	}
+
+	if n < 0 {
+		return 0
+	}
+
+	return int(n)
+}
+
+// jobHasCondition reports whether a Job carries the named condition set True.
+func jobHasCondition(job *unstructured.Unstructured, condType string) bool {
+	conds, _, _ := unstructured.NestedSlice(job.Object, "status", "conditions")
+	for _, raw := range conds {
+		cond, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		ctype, _, _ := unstructured.NestedString(cond, "type")
+		cstatus, _, _ := unstructured.NestedString(cond, "status")
+
+		if ctype == condType && cstatus == "True" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/services/kubernetes/cronjob_internal_test.go
+++ b/services/kubernetes/cronjob_internal_test.go
@@ -21,6 +21,8 @@ func TestTickCronJobs_MaterializesJob(t *testing.T) {
 	// 5-minute boundary where "*/5 * * * *" is actually due.
 	clock := config.NewFakeClock(time.Date(2026, time.January, 1, 0, 0, 30, 0, time.UTC))
 	api.SetClock(clock)
+	// TickCronJobs self-gates on progression (opt-in time-driven firing).
+	api.SetLifecycleProgression(true)
 	uid, state := api.RegisterCluster()
 	ts := httptest.NewServer(api)
 

--- a/services/kubernetes/cronjob_test.go
+++ b/services/kubernetes/cronjob_test.go
@@ -25,6 +25,9 @@ func newCronFixture(t *testing.T) (*ClusterState, *config.FakeClock) {
 	api := NewAPIServer()
 	clock := config.NewFakeClock(cronBase())
 	api.SetClock(clock)
+	// CronJob firing is opt-in time-driven behavior (TickCronJobs self-gates on
+	// progression), so enable it before registering the cluster under test.
+	api.SetLifecycleProgression(true)
 
 	_, state := api.RegisterCluster()
 
@@ -211,6 +214,107 @@ func jobExists(state *ClusterState, name string) bool {
 	_, ok := st.items[objKey("default", name)]
 
 	return ok
+}
+
+// TestTickCronJobs_NoOpWithoutProgression asserts the self-gate: with the opt-in
+// progression flag off, a due CronJob never fires (defense-in-depth mirroring
+// Tick, so a caller other than the gated serve ticker still can't fire it).
+func TestTickCronJobs_NoOpWithoutProgression(t *testing.T) {
+	api := NewAPIServer()
+	clock := config.NewFakeClock(cronBase())
+	api.SetClock(clock)
+	// Progression deliberately NOT enabled.
+	_, state := api.RegisterCluster()
+
+	putCronJob(t, state, "backup", "*/5 * * * *", "", 0)
+
+	clock.Advance(10 * time.Minute) // well past a due boundary
+	state.TickCronJobs()
+
+	if got := countJobs(state); got != 0 {
+		t.Fatalf("without progression: %d jobs, want 0 (self-gate)", got)
+	}
+}
+
+// TestCronJob_SuccessfulHistoryPruned fires a CronJob repeatedly and asserts the
+// finished (successful) Jobs self-trim to successfulJobsHistoryLimit (default 3).
+func TestCronJob_SuccessfulHistoryPruned(t *testing.T) {
+	state, clock := newCronFixture(t)
+	putCronJob(t, state, "backup", "*/1 * * * *", "", 0)
+
+	// Fire five successive one-minute slots; each fired Job runs to Complete.
+	for range 5 {
+		clock.Advance(time.Minute)
+		state.TickCronJobs()
+	}
+
+	if got := countJobsByCondition(state, "Complete"); got != 3 {
+		t.Fatalf("successful history: got %d Complete jobs, want 3 (pruned)", got)
+	}
+
+	if got := countJobs(state); got != 3 {
+		t.Fatalf("total jobs after prune: got %d, want 3", got)
+	}
+}
+
+// TestCronJob_FailedHistoryPruned injects several failed Jobs, then fires the
+// CronJob once so the post-fire sweep trims them to failedJobsHistoryLimit
+// (default 1).
+func TestCronJob_FailedHistoryPruned(t *testing.T) {
+	state, clock := newCronFixture(t)
+	cj := putCronJob(t, state, "report", "*/5 * * * *", "", 0)
+
+	for _, name := range []string{"report-f1", "report-f2", "report-f3"} {
+		putFinishedJob(t, state, cj, name, "Failed")
+	}
+
+	clock.Advance(4*time.Minute + 30*time.Second) // reach 00:05:00 and fire
+	state.TickCronJobs()
+
+	if got := countJobsByCondition(state, "Failed"); got != 1 {
+		t.Fatalf("failed history: got %d Failed jobs, want 1 (pruned)", got)
+	}
+}
+
+// putFinishedJob injects a terminal (Complete/Failed) Job owned by cj.
+func putFinishedJob(t *testing.T, s *ClusterState, cj *unstructured.Unstructured, name, condType string) {
+	t.Helper()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	store := s.reg.getStore(apiGroupBatch, "v1", "jobs")
+
+	job := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "batch/v1",
+		"kind":       "Job",
+		"metadata":   map[string]any{"name": name, "namespace": "default"},
+		"status": map[string]any{
+			"conditions": []any{map[string]any{"type": condType, "status": "True"}},
+		},
+	}}
+	job.SetUID(types.UID(newUID()))
+	job.SetCreationTimestamp(s.now())
+	job.SetOwnerReferences([]metav1.OwnerReference{ownerRefOf(cj)})
+	s.stampRegistryRVLocked(job)
+	store.items[objKey("default", name)] = job
+}
+
+func countJobsByCondition(state *ClusterState, condType string) int {
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+
+	st := state.reg.getStore(apiGroupBatch, "v1", "jobs")
+
+	n := 0
+
+	for _, job := range st.items {
+		if jobHasCondition(job, condType) {
+			n++
+		}
+	}
+
+	return n
 }
 
 // --- cron parser unit tests -------------------------------------------------

--- a/services/kubernetes/deployment_test.go
+++ b/services/kubernetes/deployment_test.go
@@ -151,7 +151,8 @@ func TestDeployment_AllNamespacesListAndDefaultReplicas(t *testing.T) {
 	var list appsv1.DeploymentList
 	mustDecode(t, resp.Body, &list)
 
-	if len(list.Items) != 2 {
+	// 2 created Deployments + the seeded coredns Deployment = 3.
+	if len(list.Items) != 3 {
 		t.Fatalf("all-ns list: got %d items", len(list.Items))
 	}
 }

--- a/services/kubernetes/endpoints_test.go
+++ b/services/kubernetes/endpoints_test.go
@@ -195,7 +195,8 @@ func TestEndpoints_AllNamespacesList(t *testing.T) {
 	var list corev1.EndpointsList
 	mustDecode(t, resp.Body, &list)
 
-	if len(list.Items) != 2 {
-		t.Fatalf("got %d, want 2 endpoints across namespaces", len(list.Items))
+	// 2 created Services' endpoints + the seeded kube-dns Service's endpoints = 3.
+	if len(list.Items) != 3 {
+		t.Fatalf("got %d, want 3 endpoints across namespaces", len(list.Items))
 	}
 }

--- a/services/kubernetes/kube_system.go
+++ b/services/kubernetes/kube_system.go
@@ -1,0 +1,173 @@
+package kubernetes
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// A fresh real cluster never boots empty: kube-system already runs coredns
+// (cluster DNS), the kube-dns Service that fronts it, and a kube-proxy DaemonSet.
+// Seeding these as plain objects that ride the existing generic reconcile makes
+// `kubectl -n kube-system get pods/deploy/ds/svc` look like a managed cluster
+// (EKS/AKS/GKE) instead of a bare object store — without any bespoke controller.
+// They are cosmetic: coredns does not actually resolve DNS (there is no real
+// resolver), it just makes the cluster look real to tooling.
+//
+// Control-plane static pods (apiserver/scheduler/controller-manager/etcd) are
+// intentionally omitted — managed clusters hide them, which is the look we want.
+
+const (
+	// kubeDNSName is the shared name of the coredns Deployment's fronting Service
+	// and the workload's k8s-app label value.
+	kubeDNSName      = "kube-dns"
+	kubeDNSLabelKey  = "k8s-app"
+	corednsName      = "coredns"
+	kubeProxyName    = "kube-proxy"
+	namespaceKubeSys = "kube-system"
+
+	// corednsReplicas mirrors the default two-replica coredns Deployment a
+	// kubeadm/EKS/GKE cluster ships with.
+	corednsReplicas = 2
+
+	// kubeDNSClusterIPOffset is the well-known ClusterIP offset the kube-dns
+	// Service is pinned to (10.96.0.10), the value kubelet hands pods as their
+	// DNS server. The ClusterIP allocator's monotonic counter is bumped past it
+	// so a client Service never collides with (or re-hands out) .10.
+	kubeDNSClusterIPOffset uint32 = 10
+	kubeDNSClusterIP              = "10.96.0.10"
+
+	// coredns / kube-proxy container images. Cosmetic — nothing pulls them.
+	corednsImage   = "registry.k8s.io/coredns/coredns:v1.11.1"
+	kubeProxyImage = "registry.k8s.io/kube-proxy:" + nodeKubeletVersion
+
+	// kube-dns Service port numbers (DNS over UDP+TCP, plus the coredns metrics
+	// port), matching a real cluster's kube-dns Service.
+	dnsPort     = 53
+	metricsPort = 9153
+)
+
+// seedKubeSystemLocked populates kube-system with the standard cluster add-ons
+// (coredns Deployment + kube-dns Service + kube-proxy DaemonSet) as ordinary
+// objects driven through the existing reconcile paths. Default-on, deterministic.
+// Callers hold s.mu (invoked only from newClusterState, single-threaded).
+func (s *ClusterState) seedKubeSystemLocked() {
+	// coredns first: its reconcile materializes the Running pods the kube-dns
+	// Service's endpoints then populate from.
+	s.seedCoreDNSDeploymentLocked()
+	s.seedKubeDNSServiceLocked()
+	s.seedKubeProxyDaemonSetLocked()
+}
+
+// seedCoreDNSDeploymentLocked stores the coredns Deployment and reconciles it so
+// two Running coredns pods come up under the k8s-app=kube-dns label.
+func (s *ClusterState) seedCoreDNSDeploymentLocked() {
+	labels := map[string]string{kubeDNSLabelKey: kubeDNSName}
+	replicas := int32(corednsReplicas)
+
+	dep := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: apiVersionAppsV1},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              corednsName,
+			Namespace:         namespaceKubeSys,
+			UID:               types.UID(newUID()),
+			CreationTimestamp: s.now(),
+			ResourceVersion:   s.nextClusterRVLocked(),
+			Generation:        1,
+			Labels:            labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: corednsName, Image: corednsImage}},
+				},
+			},
+		},
+	}
+
+	s.deployments[deploymentKey(namespaceKubeSys, corednsName)] = dep
+	s.reconcileDeploymentLocked(dep)
+}
+
+// seedKubeDNSServiceLocked stores the kube-dns Service with its ClusterIP pinned
+// to 10.96.0.10, bumps the allocator past that offset so no client Service can
+// collide with it, and populates its endpoints from the coredns pods.
+func (s *ClusterState) seedKubeDNSServiceLocked() {
+	labels := map[string]string{kubeDNSLabelKey: kubeDNSName}
+
+	svc := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: apiVersionV1},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              kubeDNSName,
+			Namespace:         namespaceKubeSys,
+			UID:               types.UID(newUID()),
+			CreationTimestamp: s.now(),
+			ResourceVersion:   s.nextClusterRVLocked(),
+			Labels:            labels,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:       corev1.ServiceTypeClusterIP,
+			ClusterIP:  kubeDNSClusterIP,
+			ClusterIPs: []string{kubeDNSClusterIP},
+			Selector:   labels,
+			Ports: []corev1.ServicePort{
+				{Name: "dns", Port: dnsPort, Protocol: corev1.ProtocolUDP, TargetPort: intstr.FromInt(dnsPort)},
+				{Name: "dns-tcp", Port: dnsPort, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(dnsPort)},
+				{Name: "metrics", Port: metricsPort, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(metricsPort)},
+			},
+		},
+	}
+
+	// Pin: never re-hand .10, and keep client allocations contiguous above it.
+	if s.nextClusterIP <= kubeDNSClusterIPOffset {
+		s.nextClusterIP = kubeDNSClusterIPOffset + 1
+	}
+
+	s.services[serviceKey(namespaceKubeSys, kubeDNSName)] = svc
+	s.endpoints[endpointsKey(namespaceKubeSys, kubeDNSName)] = s.newEndpointsObject(namespaceKubeSys, kubeDNSName)
+	s.reconcileServiceEndpointsLocked(svc)
+}
+
+// seedKubeProxyDaemonSetLocked stores kube-proxy as a real DaemonSet object (not
+// a hand-written static pod) so the generic DaemonSet reconcile yields one pod
+// per node — one today, and N automatically once multi-node scheduling lands.
+func (s *ClusterState) seedKubeProxyDaemonSetLocked() {
+	store := s.reg.getStore(apiGroupApps, "v1", "daemonsets")
+	if store == nil {
+		return
+	}
+
+	labels := map[string]any{kubeDNSLabelKey: kubeProxyName}
+
+	ds := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": apiVersionAppsV1,
+		"kind":       "DaemonSet",
+		"metadata": map[string]any{
+			"name":      kubeProxyName,
+			"namespace": namespaceKubeSys,
+			"labels":    map[string]any{kubeDNSLabelKey: kubeProxyName},
+		},
+		"spec": map[string]any{
+			"selector": map[string]any{"matchLabels": labels},
+			"template": map[string]any{
+				"metadata": map[string]any{"labels": labels},
+				"spec": map[string]any{
+					"containers": []any{map[string]any{"name": kubeProxyName, "image": kubeProxyImage}},
+				},
+			},
+		},
+	}}
+	ds.SetUID(types.UID(newUID()))
+	ds.SetCreationTimestamp(s.now())
+	ds.SetGeneration(1)
+	s.stampRegistryRVLocked(ds)
+
+	store.items[objKey(namespaceKubeSys, kubeProxyName)] = ds
+	reconcileDaemonSet(s, ds)
+}

--- a/services/kubernetes/kube_system_test.go
+++ b/services/kubernetes/kube_system_test.go
@@ -1,0 +1,124 @@
+package kubernetes_test
+
+import (
+	"net/http"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// A fresh cluster's kube-system should look like a managed cluster: a 2-replica
+// coredns Deployment (2 Running pods), a kube-proxy DaemonSet (1 pod on the sole
+// node), and a kube-dns Service pinned to 10.96.0.10.
+
+func TestKubeSystem_CoreDNSDeploymentRunning(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	resp := do(t, http.MethodGet, base+"/apis/apps/v1/namespaces/kube-system/deployments/coredns", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get coredns: status %d", resp.StatusCode)
+	}
+
+	var dep appsv1.Deployment
+	mustDecode(t, resp.Body, &dep)
+
+	if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 2 {
+		t.Fatalf("coredns spec.replicas: got %v, want 2", dep.Spec.Replicas)
+	}
+
+	if dep.Status.ReadyReplicas != 2 {
+		t.Fatalf("coredns status.readyReplicas: got %d, want 2", dep.Status.ReadyReplicas)
+	}
+
+	pods := listKubeSystemPods(t, base, "k8s-app=kube-dns")
+	if len(pods.Items) != 2 {
+		t.Fatalf("coredns pods: got %d, want 2", len(pods.Items))
+	}
+
+	for _, p := range pods.Items {
+		if p.Status.Phase != corev1.PodRunning {
+			t.Fatalf("coredns pod %s: phase %q, want Running", p.Name, p.Status.Phase)
+		}
+	}
+}
+
+func TestKubeSystem_KubeProxyDaemonSetRunning(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	resp := do(t, http.MethodGet, base+"/apis/apps/v1/namespaces/kube-system/daemonsets/kube-proxy", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get kube-proxy: status %d", resp.StatusCode)
+	}
+
+	var ds appsv1.DaemonSet
+	mustDecode(t, resp.Body, &ds)
+
+	if ds.Status.DesiredNumberScheduled != 1 || ds.Status.NumberReady != 1 {
+		t.Fatalf("kube-proxy status: desired=%d ready=%d, want 1/1",
+			ds.Status.DesiredNumberScheduled, ds.Status.NumberReady)
+	}
+
+	pods := listKubeSystemPods(t, base, "k8s-app=kube-proxy")
+	if len(pods.Items) != 1 {
+		t.Fatalf("kube-proxy pods: got %d, want 1", len(pods.Items))
+	}
+
+	if pods.Items[0].Status.Phase != corev1.PodRunning {
+		t.Fatalf("kube-proxy pod phase: %q, want Running", pods.Items[0].Status.Phase)
+	}
+}
+
+func TestKubeSystem_KubeDNSServicePinnedClusterIP(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	resp := do(t, http.MethodGet, base+"/api/v1/namespaces/kube-system/services/kube-dns", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get kube-dns: status %d", resp.StatusCode)
+	}
+
+	var svc corev1.Service
+	mustDecode(t, resp.Body, &svc)
+
+	if svc.Spec.ClusterIP != "10.96.0.10" {
+		t.Fatalf("kube-dns ClusterIP: got %q, want 10.96.0.10", svc.Spec.ClusterIP)
+	}
+
+	wantPorts := map[string]corev1.Protocol{
+		"53/UDP": corev1.ProtocolUDP, "53/TCP": corev1.ProtocolTCP, "9153/TCP": corev1.ProtocolTCP,
+	}
+	if len(svc.Spec.Ports) != len(wantPorts) {
+		t.Fatalf("kube-dns ports: got %d, want %d", len(svc.Spec.Ports), len(wantPorts))
+	}
+
+	// Its endpoints should be populated from the coredns pods.
+	epResp := do(t, http.MethodGet, base+"/api/v1/namespaces/kube-system/endpoints/kube-dns", nil)
+	var ep corev1.Endpoints
+	mustDecode(t, epResp.Body, &ep)
+
+	addrs := 0
+	for _, s := range ep.Subsets {
+		addrs += len(s.Addresses)
+	}
+
+	if addrs != 2 {
+		t.Fatalf("kube-dns endpoints addresses: got %d, want 2 (coredns pods)", addrs)
+	}
+}
+
+func listKubeSystemPods(t *testing.T, base, selector string) corev1.PodList {
+	t.Helper()
+
+	resp := do(t, http.MethodGet, base+"/api/v1/namespaces/kube-system/pods?labelSelector="+selector, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list kube-system pods (%s): status %d", selector, resp.StatusCode)
+	}
+
+	var list corev1.PodList
+	mustDecode(t, resp.Body, &list)
+
+	return list
+}

--- a/services/kubernetes/pod_test.go
+++ b/services/kubernetes/pod_test.go
@@ -137,8 +137,9 @@ func TestPod_AllNamespacesListAndUpdate(t *testing.T) {
 	var list corev1.PodList
 	mustDecode(t, resp.Body, &list)
 
-	if len(list.Items) != 2 {
-		t.Fatalf("all-ns list: got %d items, want 2", len(list.Items))
+	// 2 user pods + the seeded kube-system add-ons: 2 coredns + 1 kube-proxy = 5.
+	if len(list.Items) != 5 {
+		t.Fatalf("all-ns list: got %d items, want 5", len(list.Items))
 	}
 
 	// Update via PUT — name must match URL.

--- a/services/kubernetes/service_test.go
+++ b/services/kubernetes/service_test.go
@@ -13,8 +13,9 @@ func TestService_ClusterIPAllocatedSequentially(t *testing.T) {
 	base, cleanup := newFixture(t)
 	t.Cleanup(cleanup)
 
-	// First three Services with empty ClusterIP — should get 10.96.0.1, .2, .3.
-	wantIPs := []string{"10.96.0.1", "10.96.0.2", "10.96.0.3"}
+	// The seeded kube-dns Service pins .10 and bumps the allocator past it, so the
+	// first three client Services get contiguous IPs starting at .11.
+	wantIPs := []string{"10.96.0.11", "10.96.0.12", "10.96.0.13"}
 
 	for i, want := range wantIPs {
 		body := mustJSON(t, &corev1.Service{
@@ -261,7 +262,8 @@ func TestService_LifecycleAndAllNamespacesList(t *testing.T) {
 	var list corev1.ServiceList
 	mustDecode(t, resp.Body, &list)
 
-	if len(list.Items) != 2 {
+	// 2 created Services + the seeded kube-dns Service = 3.
+	if len(list.Items) != 3 {
 		t.Fatalf("all-ns list: got %d items", len(list.Items))
 	}
 

--- a/services/kubernetes/state.go
+++ b/services/kubernetes/state.go
@@ -190,6 +190,10 @@ func newClusterState(
 		s.seedNodeLeaseLocked()
 	}
 
+	// Seed the standard kube-system add-ons (coredns, kube-dns Service,
+	// kube-proxy DaemonSet) so a fresh cluster looks managed, not empty.
+	s.seedKubeSystemLocked()
+
 	return s
 }
 


### PR DESCRIPTION
## Summary

Part of the Tier-2 Kubernetes real-cluster epic (#876). Makes a fresh cluster look like a managed cluster and gives CronJobs a real firing loop, without breaking CloudEmu's determinism pillar (static realism default-on; time-driven behavior opt-in behind `--k8s-progression`).

### 1. Static kube-system seeds (DEFAULT-ON, deterministic)
A fresh cluster now boots kube-system with the standard add-ons — `kubectl -n kube-system get pods/deploy/ds/svc` looks like EKS/AKS/GKE instead of an empty object store. All are plain objects that ride the existing generic reconcile (no bespoke controller):

- **coredns Deployment** (apps/v1, replicas 2, `k8s-app=kube-dns`) → the existing Deployment reconcile yields 2 Running coredns pods (via a real ReplicaSet).
- **kube-dns Service** (v1, ports 53/UDP + 53/TCP + 9153/TCP) with its **ClusterIP pinned to `10.96.0.10`**; the monotonic ClusterIP allocator is **bumped past .10** so a client Service never collides with (or re-hands out) it. Endpoints populate from the coredns pods via the existing resync.
- **kube-proxy DaemonSet** (apps/v1, `k8s-app=kube-proxy`) seeded as a **real DaemonSet object** (not a hand-written static pod), so the DaemonSet reconcile yields 1 pod on the single node today and auto-scales to N once multi-node scheduling lands — zero further code needed.

Control-plane static pods (apiserver/scheduler/etc.) are intentionally omitted for the managed-cluster look. coredns is cosmetic (no real DNS resolver) — it just makes the cluster look real to tooling. No new snapshot `validate()` requirements: the seeds live in the normal typed maps / registry stores and snapshot cleanly.

### 2. CronJob firing on the opt-in ticker
`TickCronJobs()` (previously called only from tests) is now wired into `APIServer.TickAll()`, which the existing real-time serve ticker drives — gated on `--k8s-progression`. A **defense-in-depth self-gate** (`if !s.lifecycleProgression { return }`, mirroring `Tick()`) was added inside `TickCronJobs()` so it stays a no-op unless progression is on, regardless of caller. Tests still drive it directly under a FakeClock.

### 3. Job history-limit pruning
After each fire, finished Jobs beyond `successfulJobsHistoryLimit` (default 3) / `failedJobsHistoryLimit` (default 1) are deleted (oldest-first, deterministic), so `kubectl get jobs` self-trims and a long-lived `serve` doesn't grow unbounded.

## Tests
- Fresh cluster kube-system: coredns Deployment (2 Running pods), kube-proxy DaemonSet (1 pod), kube-dns Service @ 10.96.0.10 with populated endpoints.
- CronJob under progression + FakeClock fires on schedule; successful history trims to ≤3, failed to ≤1.
- `TickCronJobs` with progression off is a no-op (the self-gate).
- Updated `service_test.go` first-client-IP expectations (now `.11/.12/.13` — kube-dns consumed .10 and bumped the counter) plus the all-namespace pod/service/deployment/endpoint count assertions that shift with the seeds.

All gates green: `go build ./...`, `go vet`, `go test` (full suite) + `-race`, `golangci-lint` (0 new — the one gosec G704 is pre-existing in the untouched admission.go), `go generate` no diff.
