### PR TITLE
test(azure-storage): guard the LRO 200-on-create contract

### DIFF
--- a/server/azure/storageaccount/handler.go
+++ b/server/azure/storageaccount/handler.go
@@ -289,6 +289,11 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azu
 		h.encryption.SetAccountEncryption(name, encryption)
 	}
 
+	// Storage account create-or-update is a long-running operation in the ARM
+	// SDK: armstorage AccountsClient.BeginCreate accepts only 200 (synchronous
+	// terminal) or 202 (async) as the initial status and rejects 201. So this
+	// path answers 200 with the terminal resource on both create and update —
+	// do not "fix" it to 201, which would break the real SDK poller.
 	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), rp))
 }
 

--- a/server/azure/storageaccount/sdk_test.go
+++ b/server/azure/storageaccount/sdk_test.go
@@ -7,7 +7,9 @@ package storageaccount_test
 
 import (
 	"context"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -182,4 +184,32 @@ func TestSDKStorageAccountList(t *testing.T) {
 		return out, nil
 	})
 	assert.ElementsMatch(t, []string{"acctA", "acctB"}, rgNames, "resource-group-scoped list must return both accounts")
+}
+
+// Storage account create-or-update is a long-running operation in the ARM SDK:
+// armstorage AccountsClient.BeginCreate's generated create accepts only 200
+// (synchronous terminal) or 202 (async) and rejects 201. So the handler must
+// answer 200 on both create and re-apply — this guards against a well-meaning
+// "return 201 on create" change that would break the real SDK poller.
+func TestSDKStorageAccountCreateReturns200LROContract(t *testing.T) {
+	srv := azureserver.New(azureserver.Drivers{BlobStorage: cloudemu.NewAzure().BlobStorage})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	url := ts.URL + "/subscriptions/sub-1/resourceGroups/rg-1/providers/" +
+		"Microsoft.Storage/storageAccounts/acct-status?api-version=2023-01-01"
+	body := `{"location":"westus2","kind":"StorageV2","sku":{"name":"Standard_LRS"}}`
+
+	put := func() int {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, url, strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := ts.Client().Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	assert.Equal(t, http.StatusOK, put(), "create must be 200 (LRO sync-terminal), never 201")
+	assert.Equal(t, http.StatusOK, put(), "re-apply stays 200")
 }


### PR DESCRIPTION
## Summary

The Azure audit flagged storage-account create as returning `200` where it "should" return `201`. Verifying against the real SDK shows this is a **false-positive**: `armstorage.AccountsClient.BeginCreate` is a long-running operation whose generated `create` accepts only **200 (synchronous terminal)** or **202 (async)** and **rejects 201** — returning 201 breaks the real SDK poller.

This PR locks the correct behavior instead of changing it:
- A regression-guard SDK test asserting create and re-apply both answer `200`.
- A comment on the handler explaining the LRO contract so nobody "fixes" it to 201 later.

No behavior change. Closes the audit's N8 line as not-a-bug.

## Test
`go test ./server/azure/storageaccount/...` — green; `golangci-lint` 0 issues.