### PR TITLE
fix(azure-cosmos): round-trip Cosmos account consistencyPolicy

### DIFF
--- a/server/azure/cosmosaccount/handler.go
+++ b/server/azure/cosmosaccount/handler.go
@@ -212,6 +212,14 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azu
 		attrs.Capabilities = capabilityNames(body.Properties.Capabilities)
 		attrs.Locations = toAccountLocations(body.Properties.Locations)
 		attrs.EnableMultipleWriteLocations = body.Properties.EnableMultipleWriteLocations
+
+		if cp := body.Properties.ConsistencyPolicy; cp != nil {
+			attrs.ConsistencyPolicy = dbdriver.ConsistencyPolicy{
+				DefaultConsistencyLevel: cp.DefaultConsistencyLevel,
+				MaxIntervalInSeconds:    cp.MaxIntervalInSeconds,
+				MaxStalenessPrefix:      cp.MaxStalenessPrefix,
+			}
+		}
 	}
 
 	if h.attrs != nil {
@@ -345,8 +353,28 @@ func renderAccount(subscription, base, name string, attrs dbdriver.AccountAttrib
 			ReadLocations:            all,
 			WriteLocations:           writeLocs,
 			FailoverPolicies:         toFailoverPolicies(name, locations),
+			ConsistencyPolicy:        renderConsistencyPolicy(attrs.ConsistencyPolicy),
 		},
 	}
+}
+
+// renderConsistencyPolicy echoes the stored consistency policy, defaulting to
+// Cosmos's Session level when none was submitted (matching real Azure, which
+// always returns a consistencyPolicy). The staleness bounds are surfaced only
+// for BoundedStaleness, where they are meaningful.
+func renderConsistencyPolicy(cp dbdriver.ConsistencyPolicy) *armConsistencyPolicy {
+	level := cp.DefaultConsistencyLevel
+	if level == "" {
+		level = "Session"
+	}
+
+	out := &armConsistencyPolicy{DefaultConsistencyLevel: level}
+	if strings.EqualFold(level, "BoundedStaleness") {
+		out.MaxIntervalInSeconds = cp.MaxIntervalInSeconds
+		out.MaxStalenessPrefix = cp.MaxStalenessPrefix
+	}
+
+	return out
 }
 
 // toAccountLocations converts the ARM create-request locations into the

--- a/server/azure/cosmosaccount/sdk_test.go
+++ b/server/azure/cosmosaccount/sdk_test.go
@@ -287,3 +287,59 @@ func TestSDKDatabaseAccountList(t *testing.T) {
 	assert.True(t, rgNames["acct-a1"] && rgNames["acct-a2"], "rg-a list missing accounts: %v", rgNames)
 	assert.False(t, rgNames["acct-b1"], "rg-a list must not include rg-b's account")
 }
+
+// A submitted consistencyPolicy must round-trip on create and GET, including the
+// BoundedStaleness bounds. Real Azure always returns a consistencyPolicy, so an
+// account created without one must default to Session.
+func TestSDKDatabaseAccountConsistencyPolicy(t *testing.T) {
+	ctx := context.Background()
+	client := newDatabaseAccountsClient(t)
+
+	poller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "cosmos-bs", armcosmos.DatabaseAccountCreateUpdateParameters{
+		Location: to.Ptr("westus2"),
+		Properties: &armcosmos.DatabaseAccountCreateUpdateProperties{
+			DatabaseAccountOfferType: to.Ptr("Standard"),
+			Locations: []*armcosmos.Location{
+				{LocationName: to.Ptr("westus2"), FailoverPriority: to.Ptr[int32](0)},
+			},
+			ConsistencyPolicy: &armcosmos.ConsistencyPolicy{
+				DefaultConsistencyLevel: to.Ptr(armcosmos.DefaultConsistencyLevelBoundedStaleness),
+				MaxIntervalInSeconds:    to.Ptr[int32](300),
+				MaxStalenessPrefix:      to.Ptr[int64](100000),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+	assertBoundedStaleness(t, created.Properties)
+
+	// ... and survives an independent GET.
+	got, err := client.Get(ctx, "rg-1", "cosmos-bs", nil)
+	require.NoError(t, err)
+	assertBoundedStaleness(t, got.Properties)
+
+	// An account created with no policy defaults to Session (real Azure always
+	// returns a consistencyPolicy).
+	createAccount(t, client, "rg-1", "cosmos-def", "westus2")
+	def, err := client.Get(ctx, "rg-1", "cosmos-def", nil)
+	require.NoError(t, err)
+	require.NotNil(t, def.Properties)
+	require.NotNil(t, def.Properties.ConsistencyPolicy)
+	require.NotNil(t, def.Properties.ConsistencyPolicy.DefaultConsistencyLevel)
+	assert.Equal(t, armcosmos.DefaultConsistencyLevelSession, *def.Properties.ConsistencyPolicy.DefaultConsistencyLevel)
+}
+
+func assertBoundedStaleness(t *testing.T, props *armcosmos.DatabaseAccountGetProperties) {
+	t.Helper()
+
+	require.NotNil(t, props)
+	require.NotNil(t, props.ConsistencyPolicy)
+	require.NotNil(t, props.ConsistencyPolicy.DefaultConsistencyLevel)
+	assert.Equal(t, armcosmos.DefaultConsistencyLevelBoundedStaleness, *props.ConsistencyPolicy.DefaultConsistencyLevel)
+	require.NotNil(t, props.ConsistencyPolicy.MaxIntervalInSeconds)
+	assert.Equal(t, int32(300), *props.ConsistencyPolicy.MaxIntervalInSeconds)
+	require.NotNil(t, props.ConsistencyPolicy.MaxStalenessPrefix)
+	assert.Equal(t, int64(100000), *props.ConsistencyPolicy.MaxStalenessPrefix)
+}

--- a/server/azure/cosmosaccount/types.go
+++ b/server/azure/cosmosaccount/types.go
@@ -11,11 +11,20 @@ type armAccountCreate struct {
 }
 
 type armAccountCreateProps struct {
-	DatabaseAccountOfferType     string          `json:"databaseAccountOfferType,omitempty"`
-	EnableFreeTier               bool            `json:"enableFreeTier,omitempty"`
-	Capabilities                 []armCapability `json:"capabilities,omitempty"`
-	Locations                    []armLocation   `json:"locations,omitempty"`
-	EnableMultipleWriteLocations bool            `json:"enableMultipleWriteLocations,omitempty"`
+	DatabaseAccountOfferType     string                `json:"databaseAccountOfferType,omitempty"`
+	EnableFreeTier               bool                  `json:"enableFreeTier,omitempty"`
+	Capabilities                 []armCapability       `json:"capabilities,omitempty"`
+	Locations                    []armLocation         `json:"locations,omitempty"`
+	EnableMultipleWriteLocations bool                  `json:"enableMultipleWriteLocations,omitempty"`
+	ConsistencyPolicy            *armConsistencyPolicy `json:"consistencyPolicy,omitempty"`
+}
+
+// armConsistencyPolicy is the ARM Cosmos consistencyPolicy shape. The staleness
+// bounds are meaningful only for the BoundedStaleness level.
+type armConsistencyPolicy struct {
+	DefaultConsistencyLevel string `json:"defaultConsistencyLevel,omitempty"`
+	MaxIntervalInSeconds    int32  `json:"maxIntervalInSeconds,omitempty"`
+	MaxStalenessPrefix      int64  `json:"maxStalenessPrefix,omitempty"`
 }
 
 // armCapability is the ARM capability shape ([{name}]).
@@ -35,15 +44,16 @@ type armAccount struct {
 }
 
 type armAccountProps struct {
-	DatabaseAccountOfferType string          `json:"databaseAccountOfferType,omitempty"`
-	EnableFreeTier           bool            `json:"enableFreeTier,omitempty"`
-	Capabilities             []armCapability `json:"capabilities,omitempty"`
-	ProvisioningState        string          `json:"provisioningState,omitempty"`
-	DocumentEndpoint         string          `json:"documentEndpoint,omitempty"`
-	Locations                []armLocation   `json:"locations,omitempty"`
-	ReadLocations            []armLocation   `json:"readLocations,omitempty"`
-	WriteLocations           []armLocation   `json:"writeLocations,omitempty"`
-	FailoverPolicies         []armFailover   `json:"failoverPolicies,omitempty"`
+	DatabaseAccountOfferType string                `json:"databaseAccountOfferType,omitempty"`
+	EnableFreeTier           bool                  `json:"enableFreeTier,omitempty"`
+	Capabilities             []armCapability       `json:"capabilities,omitempty"`
+	ProvisioningState        string                `json:"provisioningState,omitempty"`
+	DocumentEndpoint         string                `json:"documentEndpoint,omitempty"`
+	Locations                []armLocation         `json:"locations,omitempty"`
+	ReadLocations            []armLocation         `json:"readLocations,omitempty"`
+	WriteLocations           []armLocation         `json:"writeLocations,omitempty"`
+	FailoverPolicies         []armFailover         `json:"failoverPolicies,omitempty"`
+	ConsistencyPolicy        *armConsistencyPolicy `json:"consistencyPolicy,omitempty"`
 }
 
 // armLocation is a region entry in a database account's location arrays.

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -316,6 +316,19 @@ type AccountAttributes struct {
 	// EnableMultipleWriteLocations mirrors the ARM property of the same name:
 	// when true every declared location accepts writes, not just priority 0.
 	EnableMultipleWriteLocations bool
+	// ConsistencyPolicy is the account's default consistency level (and, for
+	// BoundedStaleness, its staleness bounds). Empty DefaultConsistencyLevel
+	// means the account uses Cosmos's Session default.
+	ConsistencyPolicy ConsistencyPolicy
+}
+
+// ConsistencyPolicy mirrors the ARM Cosmos `consistencyPolicy` shape: the
+// account's default consistency level, plus the staleness bounds that apply
+// only when the level is BoundedStaleness.
+type ConsistencyPolicy struct {
+	DefaultConsistencyLevel string // Session (default) / Strong / BoundedStaleness / Eventual / ConsistentPrefix
+	MaxIntervalInSeconds    int32  // BoundedStaleness only
+	MaxStalenessPrefix      int64  // BoundedStaleness only
 }
 
 // TableAttributes is an OPTIONAL capability, discovered by type assertion (like


### PR DESCRIPTION
## Problem
Azure Cosmos `databaseAccounts` create accepted `properties.consistencyPolicy` but silently dropped it — GET never returned a consistency level. Real Azure always returns a `consistencyPolicy`, and clients (Terraform `azurerm_cosmosdb_account`, the SDK) read it back to detect drift.

## Fix
- Model `ConsistencyPolicy` (defaultConsistencyLevel + BoundedStaleness bounds) on the driver `AccountAttributes`.
- Read `properties.consistencyPolicy` on create-or-update; echo it on create/get/list.
- Default to Cosmos's **Session** level when none is submitted (matches real Azure). `maxIntervalInSeconds`/`maxStalenessPrefix` surface only for BoundedStaleness.

## Test
Real-SDK e2e (`armcosmos`): create with BoundedStaleness (interval 300, prefix 100000) round-trips on create + independent GET; an account created with no policy reports Session. `go test ./server/azure/cosmosaccount/... ./services/database/...` green; cosmosaccount lint clean.