### PR TITLE
fix(azure-network): reject public IP double-attach across NIC and NAT gateway

### DIFF
--- a/server/azure/vnet/nat_gateway.go
+++ b/server/azure/vnet/nat_gateway.go
@@ -105,7 +105,7 @@ func (h *Handler) createNATGateway(w http.ResponseWriter, r *http.Request, rp az
 		ConnectivityType: "public",
 	}
 
-	allocationID, err := h.resolveNATGatewayAllocation(r.Context(), req.Properties.PublicIPAddresses)
+	allocationID, err := h.resolveNATGatewayAllocation(r.Context(), rp, req.Properties.PublicIPAddresses)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -149,8 +149,14 @@ func (h *Handler) createNATGateway(w http.ResponseWriter, r *http.Request, rp az
 // body's properties.publicIpAddresses to the driver Elastic IP allocation id
 // CreateNATGateway expects. Real Azure supports multiple public IPs per NAT
 // gateway; this mock binds only the first, matching the cross-cloud driver
-// model's single AllocationID.
-func (h *Handler) resolveNATGatewayAllocation(ctx context.Context, publicIPAddresses []armIDRef) (string, error) {
+// model's single AllocationID. It rejects a public IP already claimed by a NIC
+// or another NAT gateway (a static public IP binds to one owner), excluding this
+// NAT gateway on an idempotent re-PUT.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) resolveNATGatewayAllocation(
+	ctx context.Context, rp azurearm.ResourcePath, publicIPAddresses []armIDRef,
+) (string, error) {
 	if len(publicIPAddresses) == 0 {
 		return "", nil
 	}
@@ -165,6 +171,13 @@ func (h *Handler) resolveNATGatewayAllocation(ctx context.Context, publicIPAddre
 	pip, err := findPublicIPByName(ctx, h.net, pipRP.ResourceGroup, pipRP.ResourceName)
 	if err != nil {
 		return "", err
+	}
+
+	if kind, owner, claimed := h.publicIPClaimant(
+		ctx, pipID, pip.AllocationID, claimKindNAT, rp.ResourceGroup, rp.ResourceName,
+	); claimed {
+		return "", cerrors.Newf(cerrors.FailedPrecondition,
+			"public IP %q is already associated with %s %q", pipID, kind, owner)
 	}
 
 	return pip.AllocationID, nil

--- a/server/azure/vnet/nat_gateway_test.go
+++ b/server/azure/vnet/nat_gateway_test.go
@@ -215,6 +215,107 @@ func TestSDKNATGatewayPublicIPAlreadyBound(t *testing.T) {
 	}
 }
 
+// TestSDKPublicIPCrossOwnerConflict guards the shared public-IP claim check
+// across NIC and NAT gateway. A static public IP binds to exactly one owner in
+// real Azure, so once a NIC holds it a NAT gateway cannot take it, and vice
+// versa — the two subsystems (NIC by ARM id, NAT by Elastic-IP allocation) did
+// not consult each other before this guard.
+func TestSDKPublicIPCrossOwnerConflict(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	pips, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nicClient, err := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	natClient, err := armnetwork.NewNatGatewaysClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mkPIP := func(name string) string {
+		pp, cErr := pips.BeginCreateOrUpdate(ctx, "rg-1", name, armnetwork.PublicIPAddress{
+			Location: to.Ptr("eastus"),
+			SKU:      &armnetwork.PublicIPAddressSKU{Name: to.Ptr(armnetwork.PublicIPAddressSKUNameStandard)},
+			Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+				PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+			},
+		}, nil)
+		if cErr != nil {
+			t.Fatalf("create pip %s: %v", name, cErr)
+		}
+
+		pollDone(t, pp)
+
+		return "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/publicIPAddresses/" + name
+	}
+
+	bindNIC := func(name, pipID string) error {
+		np, cErr := nicClient.BeginCreateOrUpdate(ctx, "rg-1", name, armnetwork.Interface{
+			Location: to.Ptr("eastus"),
+			Properties: &armnetwork.InterfacePropertiesFormat{
+				IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+					Name: to.Ptr("ipconfig1"),
+					Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+						PublicIPAddress: &armnetwork.PublicIPAddress{ID: to.Ptr(pipID)},
+					},
+				}},
+			},
+		}, nil)
+		if cErr != nil {
+			return cErr
+		}
+
+		_, pErr := np.PollUntilDone(ctx, nil)
+
+		return pErr
+	}
+
+	bindNAT := func(name, pipID string) error {
+		np, cErr := natClient.BeginCreateOrUpdate(ctx, "rg-1", name, armnetwork.NatGateway{
+			Location: to.Ptr("eastus"),
+			Properties: &armnetwork.NatGatewayPropertiesFormat{
+				PublicIPAddresses: []*armnetwork.SubResource{{ID: to.Ptr(pipID)}},
+			},
+		}, nil)
+		if cErr != nil {
+			return cErr
+		}
+
+		_, pErr := np.PollUntilDone(ctx, nil)
+
+		return pErr
+	}
+
+	// NIC-then-NAT: a public IP held by a NIC cannot be bound to a NAT gateway.
+	pipA := mkPIP("pip-nic-then-nat")
+	if bErr := bindNIC("nic-a", pipA); bErr != nil {
+		t.Fatalf("nic bind pip-a: %v", bErr)
+	}
+
+	if bErr := bindNAT("nat-a", pipA); bErr == nil {
+		t.Fatal("NAT gateway bound a public IP already held by a NIC; want an ARM error")
+	}
+
+	// NAT-then-NIC: a public IP held by a NAT gateway cannot be attached to a NIC.
+	pipB := mkPIP("pip-nat-then-nic")
+	if bErr := bindNAT("nat-b", pipB); bErr != nil {
+		t.Fatalf("nat bind pip-b: %v", bErr)
+	}
+
+	var respErr *azcore.ResponseError
+	if bErr := bindNIC("nic-b", pipB); !errors.As(bErr, &respErr) {
+		t.Fatalf("NIC attached a public IP already held by a NAT gateway; got %v, want an ARM error", bErr)
+	}
+}
+
 // TestSDKNATGatewayResourceGroupIsolation guards the same RG-isolation fix
 // applied to NAT gateways: two resource groups may each have a NAT gateway
 // named identically, and a resource-group-scoped List must only see its own.

--- a/server/azure/vnet/network_interface.go
+++ b/server/azure/vnet/network_interface.go
@@ -147,7 +147,7 @@ func (h *Handler) createNIC(w http.ResponseWriter, r *http.Request, rp azurearm.
 		return
 	}
 
-	ipConfigs, err := h.buildIPConfigs(r.Context(), rp.ResourceGroup, rp.ResourceName, req.Properties.IPConfigurations, svc)
+	ipConfigs, err := h.buildIPConfigs(r.Context(), rp.ResourceGroup, rp.ResourceName, req.Properties.IPConfigurations)
 	if err != nil {
 		if cerrors.IsFailedPrecondition(err) {
 			azurearm.WriteError(w, http.StatusBadRequest, "PublicIPAddressCannotBeAssignedToMultipleIpConfigs", err.Error())
@@ -254,8 +254,8 @@ func (*Handler) listNICs(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 // dynamic private IP from the right range. rg/nicName identify the NIC being
 // created or updated, so a re-PUT of the same NIC doesn't conflict with its
 // own existing public IP reference.
-func (h *Handler) buildIPConfigs(ctx context.Context, rg, nicName string, in []nicIPConfigRequest,
-	svc netdriver.AzureNetworkInterfaces,
+func (h *Handler) buildIPConfigs(
+	ctx context.Context, rg, nicName string, in []nicIPConfigRequest,
 ) ([]netdriver.AzureIPConfig, error) {
 	out := make([]netdriver.AzureIPConfig, 0, len(in))
 
@@ -287,13 +287,17 @@ func (h *Handler) buildIPConfigs(ctx context.Context, rg, nicName string, in []n
 				return nil, cerrors.Newf(cerrors.InvalidArgument, "malformed public IP id %q", p.PublicIPAddress.ID)
 			}
 
-			if _, err := findPublicIPByName(ctx, h.net, pipRP.ResourceGroup, pipRP.ResourceName); err != nil {
+			pip, err := findPublicIPByName(ctx, h.net, pipRP.ResourceGroup, pipRP.ResourceName)
+			if err != nil {
 				return nil, cerrors.Newf(cerrors.InvalidArgument,
 					"ipConfiguration references public IP %q which does not exist", pipRP.ResourceName)
 			}
 
-			if err := checkPublicIPNotAttached(ctx, svc, p.PublicIPAddress.ID, rg, nicName); err != nil {
-				return nil, err
+			if kind, owner, claimed := h.publicIPClaimant(
+				ctx, p.PublicIPAddress.ID, pip.AllocationID, claimKindNIC, rg, nicName,
+			); claimed {
+				return nil, cerrors.Newf(cerrors.FailedPrecondition,
+					"public IP %q is already associated with %s %q", p.PublicIPAddress.ID, kind, owner)
 			}
 
 			cfg.PublicIPID = p.PublicIPAddress.ID
@@ -329,31 +333,88 @@ func backendPoolIDs(refs []armIDRef) []string {
 	return out
 }
 
-// checkPublicIPNotAttached rejects attaching armID to (rg, nicName) when it is
-// already referenced by a DIFFERENT network interface's ipConfiguration — a
-// static public IP can only be bound to one NIC at a time in real Azure
-// (PublicIPAddressCannotBeAssignedToMultipleIpConfigs). A re-PUT of the same
-// NIC that keeps its own existing reference is not a conflict.
-func checkPublicIPNotAttached(ctx context.Context, svc netdriver.AzureNetworkInterfaces, armID, rg, nicName string) error {
+// Owner kinds a public IP can be claimed by, used to exclude the resource being
+// (re-)written from its own conflict check.
+const (
+	claimKindNIC = "nic"
+	claimKindNAT = "nat"
+)
+
+// publicIPClaimant returns the owner already bound to the public IP other than
+// the resource being written (selfKind + selfRG + selfName), so a NIC and a NAT
+// gateway both refuse to steal a static public IP that is already in use — real
+// Azure binds one to a single owner (PublicIPAddressCannotBeAssignedToMultiple…).
+// NICs reference the IP by its ARM id; NAT gateways reference it by the driver
+// Elastic-IP allocationID, so the caller passes both.
+func (h *Handler) publicIPClaimant(
+	ctx context.Context, pipArmID, allocationID, selfKind, selfRG, selfName string,
+) (kind, name string, claimed bool) {
+	if n, ok := h.nicPublicIPClaimant(ctx, pipArmID, selfKind, selfRG, selfName); ok {
+		return "network interface", n, true
+	}
+
+	if n, ok := h.natPublicIPClaimant(ctx, allocationID, selfKind, selfRG, selfName); ok {
+		return "NAT gateway", n, true
+	}
+
+	return "", "", false
+}
+
+// nicPublicIPClaimant reports the name of a network interface (other than self)
+// whose ipConfiguration already references pipArmID.
+func (h *Handler) nicPublicIPClaimant(ctx context.Context, pipArmID, selfKind, selfRG, selfName string) (string, bool) {
+	svc, ok := h.net.(netdriver.AzureNetworkInterfaces)
+	if !ok {
+		return "", false
+	}
+
 	nics, err := svc.ListNetworkInterfaces(ctx, "")
 	if err != nil {
-		return err
+		return "", false
 	}
 
 	for i := range nics {
-		if strings.EqualFold(nics[i].ResourceGroup, rg) && nics[i].Name == nicName {
+		if selfKind == claimKindNIC && strings.EqualFold(nics[i].ResourceGroup, selfRG) &&
+			strings.EqualFold(nics[i].Name, selfName) {
 			continue
 		}
 
 		for j := range nics[i].IPConfigs {
-			if strings.EqualFold(nics[i].IPConfigs[j].PublicIPID, armID) {
-				return cerrors.Newf(cerrors.FailedPrecondition,
-					"public IP %q is already associated with network interface %q", armID, nics[i].Name)
+			if strings.EqualFold(nics[i].IPConfigs[j].PublicIPID, pipArmID) {
+				return nics[i].Name, true
 			}
 		}
 	}
 
-	return nil
+	return "", false
+}
+
+// natPublicIPClaimant reports the name of a NAT gateway (other than self) already
+// bound to the Elastic-IP allocationID. An empty allocationID never matches.
+func (h *Handler) natPublicIPClaimant(ctx context.Context, allocationID, selfKind, selfRG, selfName string) (string, bool) {
+	if allocationID == "" {
+		return "", false
+	}
+
+	gws, err := h.net.DescribeNATGateways(ctx, nil)
+	if err != nil {
+		return "", false
+	}
+
+	for i := range gws {
+		name := tagOr(gws[i].Tags, armNATGatewayTag, "")
+		rg := tagOr(gws[i].Tags, armNATGatewayRGTag, "")
+
+		if selfKind == claimKindNAT && strings.EqualFold(rg, selfRG) && strings.EqualFold(name, selfName) {
+			continue
+		}
+
+		if strings.EqualFold(gws[i].AllocationID, allocationID) {
+			return name, true
+		}
+	}
+
+	return "", false
 }
 
 // subnetCIDR resolves the address prefix of the subnet named by an ARM subnet


### PR DESCRIPTION
## Problem
A static public IP binds to exactly one owner in real Azure, but the two guards didn't consult each other:
- The NIC ipConfiguration guard scanned only **other NICs** (by ARM id).
- The NAT gateway allocation path had **no guard at all**.

So the same public IP could be attached to a NIC **and** a NAT gateway simultaneously (or a NIC after a NAT gateway held it), producing an impossible topology. (Two NAT gateways sharing one IP was already blocked at the driver Elastic-IP-association level; the NIC↔NAT cross-case was the gap.)

## Fix
A single shared claim check (`publicIPClaimant`) scans **both** owners — NICs by ARM id and NAT gateways by the driver Elastic-IP allocation — and is consulted from both the NIC ipConfiguration path and the NAT gateway allocation path. It excludes the resource being written, so an idempotent re-PUT keeping its own IP is not a conflict. Self-exclusion now compares the NIC name case-insensitively (was case-sensitive — the #586 nit). Removed the now-dead `checkPublicIPNotAttached` and its unused `svc` parameter.

## Test
Real-SDK e2e (`armnetwork`): NIC-then-NAT and NAT-then-NIC both rejected with an ARM error; existing NIC↔NIC, NAT↔NAT, RG-isolation and re-PUT-swap tests still green. `go test ./server/azure/vnet/...` passes; no new lint issues.