### PR TITLE
fix(azure-keyvault): host/path-aware vault routing (B7 container-steal + B8 bare-host isolation)

### DIFF
--- a/compat/azure/secrets_compat_test.go
+++ b/compat/azure/secrets_compat_test.go
@@ -26,7 +26,9 @@ func TestAzureSecretsCompat(t *testing.T) {
 	provider := cloudemu.NewAzure()
 	sess := compat.BootAzureTLS(t, azureserver.Drivers{KeyVault: provider.KeyVault})
 
-	client, err := azsecrets.NewClient(sess.Endpoint(), compat.FakeAzureCred(), &azsecrets.ClientOptions{
+	// On a bare host the vault is named by a leading path segment (/{vault}); the
+	// emulator no longer collapses an unnamed host to a single "default" vault.
+	client, err := azsecrets.NewClient(sess.Endpoint()+"/default", compat.FakeAzureCred(), &azsecrets.ClientOptions{
 		ClientOptions: azcore.ClientOptions{
 			Transport: sess.Transport(),
 			Retry:     policy.RetryOptions{MaxRetries: -1},

--- a/server/azure/dispatch_ordering_test.go
+++ b/server/azure/dispatch_ordering_test.go
@@ -47,7 +47,10 @@ func TestSpecificHandlersWinBeforeBlobFallback(t *testing.T) {
 		path string
 	}{
 		{"cosmos_dbs_before_blob", "/dbs"},
-		{"keyvault_secrets_before_blob", "/secrets"},
+		// Key Vault claims the vault-scoped data-plane path /{vault}/secrets on a
+		// bare host; a bare /secrets is intentionally a blob container path (so a
+		// container literally named "secrets" can be created).
+		{"keyvault_secrets_before_blob", "/default/secrets"},
 		{"acr_catalog_before_blob", "/acr/v1/_catalog"},
 	}
 

--- a/server/azure/keyvault/certs_dataplane_test.go
+++ b/server/azure/keyvault/certs_dataplane_test.go
@@ -77,7 +77,7 @@ func TestCertificatesRoundTrip(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	client := ts.Client()
-	base := ts.URL
+	base := ts.URL + "/default"
 
 	// Create.
 	status, ct, raw := certRoundTrip(t, client, http.MethodPost, base+"/certificates/mycert/create", selfSignedPolicy)
@@ -169,7 +169,7 @@ func TestCertificateNotFoundIs404(t *testing.T) {
 	ts := httptest.NewTLSServer(srv)
 	t.Cleanup(ts.Close)
 
-	status, _, raw := certRoundTrip(t, ts.Client(), http.MethodGet, ts.URL+"/certificates/does-not-exist", "")
+	status, _, raw := certRoundTrip(t, ts.Client(), http.MethodGet, ts.URL+"/default/certificates/does-not-exist", "")
 	if status != http.StatusNotFound {
 		t.Fatalf("get missing certificate status = %d, want 404\nbody: %s", status, raw)
 	}
@@ -203,7 +203,7 @@ func TestCertificatesNotMisroutedToStorage(t *testing.T) {
 
 	// POST create must land in Key Vault (202 + cert operation), not the Table
 	// Storage handler's 400 odata.error.
-	status, ct, raw := certRoundTrip(t, client, http.MethodPost, ts.URL+"/certificates/mycert/create", selfSignedPolicy)
+	status, ct, raw := certRoundTrip(t, client, http.MethodPost, ts.URL+"/default/certificates/mycert/create", selfSignedPolicy)
 	if status != http.StatusAccepted {
 		t.Fatalf("full-server create status = %d (%s), want 202 — cert request mis-routed to storage?\nbody: %s", status, ct, raw)
 	}
@@ -218,7 +218,7 @@ func TestCertificatesNotMisroutedToStorage(t *testing.T) {
 
 	// GET /certificates must likewise reach Key Vault (200 list), not the
 	// Blob/Queue handler's XML 400.
-	status, ct, raw = certRoundTrip(t, client, http.MethodGet, ts.URL+"/certificates", "")
+	status, ct, raw = certRoundTrip(t, client, http.MethodGet, ts.URL+"/default/certificates", "")
 	if status != http.StatusOK {
 		t.Fatalf("full-server list status = %d (%s), want 200 — mis-routed to storage?\nbody: %s", status, ct, raw)
 	}

--- a/server/azure/keyvault/certs_handler.go
+++ b/server/azure/keyvault/certs_handler.go
@@ -56,16 +56,21 @@ func NewCerts(s secretsdriver.Secrets) *CertsHandler {
 // permissive storage fallbacks. Disjoint from ARM (/subscriptions/…) and from
 // the secrets (/secrets) and keys (/keys) surfaces.
 func (*CertsHandler) Matches(r *http.Request) bool {
-	p := r.URL.Path
+	_, p, ok := vaultScope(r)
+	if !ok {
+		return false
+	}
 
 	return p == certsPrefix || strings.HasPrefix(p, certsPrefix+"/") ||
 		p == deletedCertsPrefix || strings.HasPrefix(p, deletedCertsPrefix+"/")
 }
 
 // ServeHTTP answers the bearer challenge for unauthenticated requests, then
-// routes on the path and method.
+// routes on the vault-stripped path and method.
 func (h *CertsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	serveDataPlane(w, r, h.kv == nil, "Key Vault certificates backend unavailable", dataPlaneRoutes{
+	_, kvPath, _ := vaultScope(r)
+
+	serveDataPlane(w, r, kvPath, h.kv == nil, "Key Vault certificates backend unavailable", dataPlaneRoutes{
 		deletedPrefix: deletedCertsPrefix,
 		mainPrefix:    certsPrefix,
 		routeDeleted:  func(tail string) { h.routeDeleted(w, r, tail) },

--- a/server/azure/keyvault/handler.go
+++ b/server/azure/keyvault/handler.go
@@ -63,16 +63,21 @@ func New(s secretsdriver.Secrets) *Handler {
 // Matches claims /secrets and /deletedsecrets data-plane requests. Disjoint
 // from ARM (/subscriptions/…) and the Databricks secrets API (/api/{ver}/…).
 func (*Handler) Matches(r *http.Request) bool {
-	p := r.URL.Path
+	_, p, ok := vaultScope(r)
+	if !ok {
+		return false
+	}
 
 	return p == pathPrefix || strings.HasPrefix(p, pathPrefix+"/") ||
 		p == deletedPrefix || strings.HasPrefix(p, deletedPrefix+"/")
 }
 
 // ServeHTTP answers the bearer challenge for unauthenticated requests, then
-// routes on the path and method.
+// routes on the vault-stripped path and method.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	serveDataPlane(w, r, h.kv == nil, "Key Vault secrets backend unavailable", dataPlaneRoutes{
+	_, kvPath, _ := vaultScope(r)
+
+	serveDataPlane(w, r, kvPath, h.kv == nil, "Key Vault secrets backend unavailable", dataPlaneRoutes{
 		deletedPrefix: deletedPrefix,
 		mainPrefix:    pathPrefix,
 		routeDeleted:  func(tail string) { h.routeDeleted(w, r, tail) },
@@ -92,7 +97,11 @@ type dataPlaneRoutes struct {
 // serveDataPlane runs the shared Key Vault data-plane preamble — bearer
 // challenge, backend-availability check, then dispatch to the deleted or main
 // path space — used by both the secrets and keys handlers.
-func serveDataPlane(w http.ResponseWriter, r *http.Request, backendUnavailable bool, unavailableMsg string, routes dataPlaneRoutes) {
+// path is the vault-stripped Key Vault data-plane path (from vaultScope), so a
+// bare-host /{vault}/secrets/… routes identically to a vault-host /secrets/….
+func serveDataPlane(
+	w http.ResponseWriter, r *http.Request, path string, backendUnavailable bool, unavailableMsg string, routes dataPlaneRoutes,
+) {
 	if bearerChallenge(w, r) {
 		return
 	}
@@ -102,12 +111,12 @@ func serveDataPlane(w http.ResponseWriter, r *http.Request, backendUnavailable b
 		return
 	}
 
-	if r.URL.Path == routes.deletedPrefix || strings.HasPrefix(r.URL.Path, routes.deletedPrefix+"/") {
-		routes.routeDeleted(strings.Trim(strings.TrimPrefix(r.URL.Path, routes.deletedPrefix), "/"))
+	if path == routes.deletedPrefix || strings.HasPrefix(path, routes.deletedPrefix+"/") {
+		routes.routeDeleted(strings.Trim(strings.TrimPrefix(path, routes.deletedPrefix), "/"))
 		return
 	}
 
-	routes.routeMain(strings.Trim(strings.TrimPrefix(r.URL.Path, routes.mainPrefix), "/"))
+	routes.routeMain(strings.Trim(strings.TrimPrefix(path, routes.mainPrefix), "/"))
 }
 
 // routeSecrets dispatches /secrets[...] requests.
@@ -205,21 +214,74 @@ var vaultSuffixes = []string{
 	".managedhsm.usgovcloudapi.net",
 }
 
-// vaultFromRequest extracts the vault name that scopes secret/key isolation
-// for r, so that a secret or key created in one vault is never visible
-// through another. Real Key Vault clients address a vault via its unique
-// {vault-name}.vault.azure.net (or Managed HSM equivalent) subdomain; a
-// request whose Host carries none of those suffixes (a bare host, as in a
-// test pointed directly at this server without DisableChallengeResourceVerification-style
-// vault URLs) falls back to a single "default" vault, matching this server's
-// pre-multi-vault behavior.
-func vaultFromRequest(r *http.Request) string {
-	host, _, _ := strings.Cut(r.Host, ":")
+// kvDataPlaneKeywords are the leading path segments of the Key Vault data-plane
+// surface. A request is a Key Vault data-plane request only when its
+// vault-stripped path begins with one of these.
+//
+//nolint:gochecknoglobals // read-only lookup set, not mutable state
+var kvDataPlaneKeywords = map[string]bool{
+	"secrets": true, "deletedsecrets": true,
+	"keys": true, "deletedkeys": true,
+	"certificates": true, "deletedcertificates": true,
+}
 
+// vaultScope resolves the vault that scopes isolation for r and the Key Vault
+// data-plane path with any vault-selecting prefix stripped, reporting whether r
+// is a Key Vault data-plane request at all. Two addressing forms are supported:
+//
+//   - Vault host: r.Host carries a {vault}.vault.azure.net (or Managed HSM / Gov
+//     / China) suffix — the real-cloud form. The vault is the host's leading
+//     label and the path is unchanged. On this form Key Vault always wins, so it
+//     never shadows a blob container of the same name.
+//   - Bare host (a local `serve` on localhost:PORT): the vault is the leading
+//     path segment, i.e. /{vault}/secrets/…, so multiple vaults isolate. A bare
+//     /secrets (no vault segment) is NOT a Key Vault request and falls through to
+//     blob storage — which is what lets a blob container literally named
+//     "secrets"/"keys"/"certificates" be created.
+func vaultScope(r *http.Request) (vault, kvPath string, ok bool) {
+	path := r.URL.Path
+
+	host, _, _ := strings.Cut(r.Host, ":")
 	for _, suffix := range vaultSuffixes {
 		if i := strings.Index(host, suffix); i > 0 {
-			return host[:i]
+			if !kvDataPlaneKeywords[firstSegment(path)] {
+				return "", "", false
+			}
+
+			return host[:i], path, true
 		}
+	}
+
+	// Bare host: /{vault}/{keyword}/… — the vault is the leading segment. A bare
+	// /{keyword} (no vault) or a reserved leading segment is not a KV request.
+	seg, rest, hasRest := strings.Cut(strings.TrimPrefix(path, "/"), "/")
+	if !hasRest || seg == "" || seg == "subscriptions" || kvDataPlaneKeywords[seg] {
+		return "", "", false
+	}
+
+	if !kvDataPlaneKeywords[firstSegment("/"+rest)] {
+		return "", "", false
+	}
+
+	return seg, "/" + rest, true
+}
+
+// firstSegment returns the first '/'-separated segment of path.
+func firstSegment(path string) string {
+	seg, _, _ := strings.Cut(strings.TrimPrefix(path, "/"), "/")
+
+	return seg
+}
+
+// vaultFromRequest returns the vault name that scopes secret/key/certificate
+// isolation for r, so a secret created in one vault is never visible through
+// another. It delegates to vaultScope; operation handlers call it only after
+// Matches has confirmed the request is a Key Vault data-plane request, so the
+// scope always resolves. The "default" fallback is unreachable in that path and
+// kept only as a defensive value.
+func vaultFromRequest(r *http.Request) string {
+	if v, _, ok := vaultScope(r); ok {
+		return v
 	}
 
 	return "default"

--- a/server/azure/keyvault/keys_handler.go
+++ b/server/azure/keyvault/keys_handler.go
@@ -69,16 +69,21 @@ func NewKeys(s secretsdriver.Secrets) *KeysHandler {
 // Matches claims /keys and /deletedkeys data-plane requests. Disjoint from ARM
 // (/subscriptions/…) and from the secrets surface (/secrets, /deletedsecrets).
 func (*KeysHandler) Matches(r *http.Request) bool {
-	p := r.URL.Path
+	_, p, ok := vaultScope(r)
+	if !ok {
+		return false
+	}
 
 	return p == keysPrefix || strings.HasPrefix(p, keysPrefix+"/") ||
 		p == deletedKeysPrefix || strings.HasPrefix(p, deletedKeysPrefix+"/")
 }
 
 // ServeHTTP answers the bearer challenge for unauthenticated requests, then
-// routes on the path and method.
+// routes on the vault-stripped path and method.
 func (h *KeysHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	serveDataPlane(w, r, h.kv == nil, "Key Vault keys backend unavailable", dataPlaneRoutes{
+	_, kvPath, _ := vaultScope(r)
+
+	serveDataPlane(w, r, kvPath, h.kv == nil, "Key Vault keys backend unavailable", dataPlaneRoutes{
 		deletedPrefix: deletedKeysPrefix,
 		mainPrefix:    keysPrefix,
 		routeDeleted:  func(tail string) { h.routeDeleted(w, r, tail) },

--- a/server/azure/keyvault/sdk_keys_roundtrip_test.go
+++ b/server/azure/keyvault/sdk_keys_roundtrip_test.go
@@ -25,7 +25,7 @@ func newKeysClient(t *testing.T) *azkeys.Client {
 	ts := httptest.NewTLSServer(srv)
 	t.Cleanup(ts.Close)
 
-	client, err := azkeys.NewClient(ts.URL, fakeCred{}, &azkeys.ClientOptions{
+	client, err := azkeys.NewClient(ts.URL+"/default", fakeCred{}, &azkeys.ClientOptions{
 		ClientOptions: azcore.ClientOptions{
 			Transport: ts.Client(),
 			Retry:     policy.RetryOptions{MaxRetries: -1},

--- a/server/azure/keyvault/sdk_roundtrip_test.go
+++ b/server/azure/keyvault/sdk_roundtrip_test.go
@@ -31,7 +31,7 @@ func newSecretsClient(t *testing.T) *azsecrets.Client {
 	ts := httptest.NewTLSServer(srv)
 	t.Cleanup(ts.Close)
 
-	client, err := azsecrets.NewClient(ts.URL, fakeCred{}, &azsecrets.ClientOptions{
+	client, err := azsecrets.NewClient(ts.URL+"/default", fakeCred{}, &azsecrets.ClientOptions{
 		ClientOptions: azcore.ClientOptions{
 			Transport: ts.Client(),
 			Retry:     policy.RetryOptions{MaxRetries: -1},

--- a/server/azure/keyvault/sdk_validity_rotate_cert_test.go
+++ b/server/azure/keyvault/sdk_validity_rotate_cert_test.go
@@ -214,13 +214,13 @@ func TestKeyVaultCertificateMintsSecretAndKey(t *testing.T) {
 	httpClient := ts.Client()
 
 	// Create the certificate over raw REST (no cert SDK in this module).
-	status, _, raw := certRoundTrip(t, httpClient, http.MethodPost, ts.URL+"/certificates/tls-cert/create", selfSignedPolicy)
+	status, _, raw := certRoundTrip(t, httpClient, http.MethodPost, ts.URL+"/default/certificates/tls-cert/create", selfSignedPolicy)
 	if status != http.StatusAccepted {
 		t.Fatalf("create cert status = %d, want 202\nbody: %s", status, raw)
 	}
 
 	// The certificate bundle advertises SID/KID pointing at the backing objects.
-	status, _, raw = certRoundTrip(t, httpClient, http.MethodGet, ts.URL+"/certificates/tls-cert", "")
+	status, _, raw = certRoundTrip(t, httpClient, http.MethodGet, ts.URL+"/default/certificates/tls-cert", "")
 	if status != http.StatusOK {
 		t.Fatalf("get cert status = %d, want 200\nbody: %s", status, raw)
 	}
@@ -237,7 +237,7 @@ func TestKeyVaultCertificateMintsSecretAndKey(t *testing.T) {
 	ctx := context.Background()
 
 	// The addressable secret returns the certificate value and is managed.
-	secrets, err := azsecrets.NewClient(ts.URL, fakeCred{}, &azsecrets.ClientOptions{
+	secrets, err := azsecrets.NewClient(ts.URL+"/default", fakeCred{}, &azsecrets.ClientOptions{
 		ClientOptions:                        azcore.ClientOptions{Transport: httpClient, Retry: policy.RetryOptions{MaxRetries: -1}},
 		DisableChallengeResourceVerification: true,
 	})
@@ -259,7 +259,7 @@ func TestKeyVaultCertificateMintsSecretAndKey(t *testing.T) {
 	}
 
 	// The addressable key exposes the certificate's key and is managed.
-	keys, err := azkeys.NewClient(ts.URL, fakeCred{}, &azkeys.ClientOptions{
+	keys, err := azkeys.NewClient(ts.URL+"/default", fakeCred{}, &azkeys.ClientOptions{
 		ClientOptions:                        azcore.ClientOptions{Transport: httpClient, Retry: policy.RetryOptions{MaxRetries: -1}},
 		DisableChallengeResourceVerification: true,
 	})

--- a/server/azure/keyvault/vault_scope_test.go
+++ b/server/azure/keyvault/vault_scope_test.go
@@ -1,0 +1,115 @@
+package keyvault_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// secretsClientAt builds an azsecrets client addressing a named vault via the
+// bare-host path form (http://host/{vault}), the multi-vault addressing that
+// lets a local `serve` isolate vaults without a *.vault.azure.net host.
+func secretsClientAt(t *testing.T, ts *httptest.Server, vault string) *azsecrets.Client {
+	t.Helper()
+
+	client, err := azsecrets.NewClient(ts.URL+"/"+vault, fakeCred{}, &azsecrets.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+		DisableChallengeResourceVerification: true,
+	})
+	if err != nil {
+		t.Fatalf("azsecrets.NewClient(%s): %v", vault, err)
+	}
+
+	return client
+}
+
+// TestKeyVaultDoesNotStealBlobContainer is the B7 regression: on a bare host a
+// blob container named after a Key Vault keyword (secrets/keys/certificates)
+// must be created by the storage handler, not stolen (405) by Key Vault — while
+// a real Key Vault op via the /{vault}/secrets form still reaches Key Vault.
+func TestKeyVaultDoesNotStealBlobContainer(t *testing.T) {
+	cloud := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		KeyVault:    cloud.KeyVault,
+		BlobStorage: cloud.BlobStorage,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	for _, name := range []string{"secrets", "keys", "certificates"} {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut, ts.URL+"/"+name+"?restype=container", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		resp, err := ts.Client().Do(req)
+		if err != nil {
+			t.Fatalf("create container %q: %v", name, err)
+		}
+
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("PUT container %q = %d, want 201 (Key Vault must not steal a blob container)", name, resp.StatusCode)
+		}
+	}
+
+	client := secretsClientAt(t, ts, "kv1")
+	if _, err := client.SetSecret(ctx, "s1", azsecrets.SetSecretParameters{Value: to.Ptr("v1")}, nil); err != nil {
+		t.Fatalf("SetSecret via /kv1/secrets should reach Key Vault: %v", err)
+	}
+}
+
+// TestKeyVaultBareHostMultiVaultIsolation is the B8 regression: two vaults
+// addressed by a leading path segment on a bare host are independent namespaces,
+// so a secret in one is never visible through the other (previously every bare
+// host collapsed into a single "default" vault).
+func TestKeyVaultBareHostMultiVaultIsolation(t *testing.T) {
+	cloud := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{KeyVault: cloud.KeyVault})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	vaultA := secretsClientAt(t, ts, "vault-a")
+	vaultB := secretsClientAt(t, ts, "vault-b")
+
+	if _, err := vaultA.SetSecret(ctx, "shared", azsecrets.SetSecretParameters{Value: to.Ptr("from-a")}, nil); err != nil {
+		t.Fatalf("set in vault-a: %v", err)
+	}
+
+	// vault-b must NOT resolve vault-a's secret.
+	if _, err := vaultB.GetSecret(ctx, "shared", "", nil); err == nil {
+		t.Fatal("vault-b resolved vault-a's secret; bare-host vaults are not isolated")
+	}
+
+	// vault-b holds its own independent "shared", and it does not overwrite A's.
+	if _, err := vaultB.SetSecret(ctx, "shared", azsecrets.SetSecretParameters{Value: to.Ptr("from-b")}, nil); err != nil {
+		t.Fatalf("set in vault-b: %v", err)
+	}
+
+	got, err := vaultA.GetSecret(ctx, "shared", "", nil)
+	if err != nil {
+		t.Fatalf("get in vault-a: %v", err)
+	}
+
+	if got.Value == nil || *got.Value != "from-a" {
+		t.Fatalf("vault-a secret = %v, want from-a (cross-vault contamination)", got.Value)
+	}
+}


### PR DESCRIPTION
## Problems
- **B7 (routing collision):** the Key Vault data-plane matchers for `/secrets`, `/keys`, `/certificates` were pure path-prefix and register before the blob fallback, so a blob **container** literally named "secrets"/"keys"/"certificates" was stolen by Key Vault (405) instead of being created.
- **B8 (isolation collapse):** vault identity came only from a `{vault}.vault.azure.net` Host, so on a bare-host `serve` (localhost:4568) **every vault collapsed into one namespace**.

## Fix
A single `vaultScope(r) → (vault, kvPath, ok)` resolver drives all three `Matches` and `ServeHTTP`:
- **Vault host** (`{vault}.vault.azure.net` / Managed HSM / Gov / China): vault = host label, path unchanged. Key Vault always wins on this form and never shadows a blob container. (Existing vhost multi-vault tests pass verbatim.)
- **Bare host**: the vault is the **leading path segment** — `/{vault}/secrets/…` — so multiple vaults isolate. A bare `/secrets` (no vault) is **not** a Key Vault request and falls through to blob, which is what lets a container named "secrets" be created.

`vaultFromRequest` now delegates to `vaultScope`; `serveDataPlane` routes on the vault-stripped path so bare-host `/{vault}/secrets/…` routes identically to vhost `/secrets/…`. No ARM control-plane, provider, or snapshot changes.

## Addressing (bare-host multi-vault)
```go
azsecrets.NewClient("http://localhost:4568/vault-a", cred, …) // isolated from…
azsecrets.NewClient("http://localhost:4568/vault-b", cred, …)
```
vhost/DNS-override users keep `https://vault-a.vault.azure.net` unchanged.

## Behavior change
A bare-host client with **no** vault segment (`http://localhost:4568`) no longer resolves to a silent "default" vault for Key Vault — name a vault in the URL. Bare-host test helpers repointed to `/default`.

## Test
New `vault_scope_test.go`: B7 (a blob container named secrets/keys/certificates is created, not stolen, while `/kv1/secrets` still reaches Key Vault) and B8 (`/vault-a` vs `/vault-b` isolate). Existing secrets/keys/certs round-trip + vhost multi-vault tests green. `go test ./server/azure/keyvault/...` passes; lint clean.