### PR TITLE
fix(azure-servicebus): resolvable list pagination (nextLink)

### DIFF
--- a/server/azure/servicebus/handler.go
+++ b/server/azure/servicebus/handler.go
@@ -220,7 +220,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case kind == kindCheckName:
 		h.checkNameAvailability(w, r)
 	case sp.namespace == "":
-		h.listNamespaces(w, sp)
+		h.listNamespaces(w, r, sp)
 	case len(sp.segs) == 0:
 		h.serveNamespace(w, r, sp)
 	default:
@@ -266,7 +266,7 @@ func (h *Handler) listChildren(w http.ResponseWriter, r *http.Request, sp sbPath
 	resources := collect(ns)
 	h.mu.RUnlock()
 
-	azurearm.WriteJSON(w, http.StatusOK, paginate(resources))
+	azurearm.WriteJSON(w, http.StatusOK, paginate(r, resources))
 }
 
 // nsKey normalizes a namespace name to its store key. Service Bus namespace

--- a/server/azure/servicebus/namespace.go
+++ b/server/azure/servicebus/namespace.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -167,7 +168,7 @@ func (h *Handler) deleteNamespace(w http.ResponseWriter, sp sbPath) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func (h *Handler) listNamespaces(w http.ResponseWriter, sp sbPath) {
+func (h *Handler) listNamespaces(w http.ResponseWriter, r *http.Request, sp sbPath) {
 	h.mu.RLock()
 
 	resources := make([]any, 0)
@@ -186,7 +187,7 @@ func (h *Handler) listNamespaces(w http.ResponseWriter, sp sbPath) {
 
 	h.mu.RUnlock()
 
-	azurearm.WriteJSON(w, http.StatusOK, paginate(resources))
+	azurearm.WriteJSON(w, http.StatusOK, paginate(r, resources))
 }
 
 func (h *Handler) checkNameAvailability(w http.ResponseWriter, r *http.Request) {
@@ -273,12 +274,52 @@ func writeNSNotFound(w http.ResponseWriter, name string) {
 		"namespace not found: "+name)
 }
 
-// paginate splits resources into a first page plus a nextLink placeholder when
-// the collection exceeds listPageSize.
-func paginate(resources []any) listResponse {
-	if len(resources) <= listPageSize {
-		return listResponse{Value: resources}
+// paginate returns the listPageSize-sized window of resources that starts at the
+// request's $skip offset. When more items remain it emits a nextLink — an
+// absolute URL that repeats the request with $skip advanced — that armservicebus
+// pagers follow until the collection is exhausted. A collection that fits a
+// single page (skip 0, len <= listPageSize) returns no nextLink.
+func paginate(r *http.Request, resources []any) listResponse {
+	skip := paginationSkip(r)
+	if skip >= len(resources) {
+		return listResponse{Value: []any{}}
 	}
 
-	return listResponse{Value: resources[:listPageSize], NextLink: "cloudemu-nextpage"}
+	end := skip + listPageSize
+	if end >= len(resources) {
+		return listResponse{Value: resources[skip:]}
+	}
+
+	return listResponse{Value: resources[skip:end], NextLink: nextPageLink(r, end)}
+}
+
+// paginationSkip reads the $skip offset a follow-up page request carries. A
+// missing or malformed value pages from the start.
+func paginationSkip(r *http.Request) int {
+	n, err := strconv.Atoi(r.URL.Query().Get(skipParam))
+	if err != nil || n < 0 {
+		return 0
+	}
+
+	return n
+}
+
+// nextPageLink builds the absolute URL that continues a listing at offset skip,
+// preserving the request path and query (api-version included) and overriding
+// $skip. armservicebus pagers GET this URL verbatim, so it must carry scheme and
+// host — a server request URL has neither.
+func nextPageLink(r *http.Request, skip int) string {
+	next := *r.URL
+	next.Host = r.Host
+
+	next.Scheme = "http"
+	if r.TLS != nil {
+		next.Scheme = "https"
+	}
+
+	q := next.Query()
+	q.Set(skipParam, strconv.Itoa(skip))
+	next.RawQuery = q.Encode()
+
+	return next.String()
 }

--- a/server/azure/servicebus/pagination_sdk_test.go
+++ b/server/azure/servicebus/pagination_sdk_test.go
@@ -1,0 +1,69 @@
+package servicebus_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2"
+)
+
+// TestSDKListQueuesPaginated is the regression for the unresolvable nextLink
+// placeholder: a namespace with more than one page of queues (>100) must be
+// fully enumerable by the armservicebus pager, which follows each nextLink as an
+// absolute URL. Every created queue must come back exactly once across the
+// pages, and the listing must actually span more than a single page.
+func TestSDKListQueuesPaginated(t *testing.T) {
+	ts := pubsubServer(t)
+	cf := newClientFactory(t, ts)
+	ctx := context.Background()
+
+	createNS(t, cf.NewNamespacesClient(), rgName, nsName, nil)
+
+	queues := cf.NewQueuesClient()
+
+	const total = 150
+	for i := range total {
+		name := fmt.Sprintf("q-%03d", i)
+		if _, err := queues.CreateOrUpdate(ctx, rgName, nsName, name,
+			armservicebus.SBQueue{}, nil); err != nil {
+			t.Fatalf("create queue %s: %v", name, err)
+		}
+	}
+
+	seen := map[string]int{}
+	pages := 0
+
+	pager := queues.NewListByNamespacePager(rgName, nsName, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("list page %d: %v", pages, err)
+		}
+
+		pages++
+
+		for _, q := range page.Value {
+			if q.Name == nil {
+				t.Fatal("queue in page has nil name")
+			}
+
+			seen[*q.Name]++
+		}
+	}
+
+	if pages < 2 {
+		t.Fatalf("listed %d queues in %d page(s); want the collection to span multiple pages", len(seen), pages)
+	}
+
+	if len(seen) != total {
+		t.Fatalf("saw %d distinct queues across %d pages, want %d", len(seen), pages, total)
+	}
+
+	for i := range total {
+		name := fmt.Sprintf("q-%03d", i)
+		if seen[name] != 1 {
+			t.Fatalf("queue %s appeared %d times across pages, want exactly 1", name, seen[name])
+		}
+	}
+}

--- a/server/azure/servicebus/rule.go
+++ b/server/azure/servicebus/rule.go
@@ -29,7 +29,7 @@ func (h *Handler) serveRuleCollection(w http.ResponseWriter, r *http.Request, sp
 
 	h.mu.RUnlock()
 
-	azurearm.WriteJSON(w, http.StatusOK, paginate(resources))
+	azurearm.WriteJSON(w, http.StatusOK, paginate(r, resources))
 }
 
 func (h *Handler) serveRule(w http.ResponseWriter, r *http.Request, sp sbPath, topic, sub, name string) {

--- a/server/azure/servicebus/state.go
+++ b/server/azure/servicebus/state.go
@@ -26,6 +26,9 @@ const (
 	defaultRootRuleName = "RootManageSharedAccessKey"
 	// listPageSize is how many entities a list returns before emitting a nextLink.
 	listPageSize = 100
+	// skipParam is the query parameter a paged list request carries to resume at
+	// an offset, mirroring the $skip nextLink real Azure returns.
+	skipParam = "$skip"
 )
 
 const (

--- a/server/azure/servicebus/subscription.go
+++ b/server/azure/servicebus/subscription.go
@@ -35,7 +35,7 @@ func (h *Handler) serveSubCollection(w http.ResponseWriter, r *http.Request, sp 
 
 	h.mu.RUnlock()
 
-	azurearm.WriteJSON(w, http.StatusOK, paginate(resources))
+	azurearm.WriteJSON(w, http.StatusOK, paginate(r, resources))
 }
 
 func (h *Handler) serveSubscription(w http.ResponseWriter, r *http.Request, sp sbPath, topic, name string) {


### PR DESCRIPTION
## Problem

Service Bus list responses emitted a literal `nextLink` placeholder that no route resolves. `paginate` in `server/azure/servicebus/namespace.go` set `NextLink: "cloudemu-nextpage"`, and `listPageSize` is 100. Once a list surface holds more than 100 entities, the pager returns a nextLink the SDK cannot GET, so the remaining items are unreachable. Real Azure returns a resolvable `$skip` continuation URL.

## Fix

`paginate` now reads a `$skip` offset from the request, returns that page window, and — when more items remain — emits an **absolute** nextLink (same path + query with `$skip` advanced, api-version preserved) that `armservicebus` pagers GET verbatim until the collection is exhausted. Scheme/host are filled from the request since a server request URL carries neither.

Applies to every list surface `paginate` serves: namespaces, queues, topics, subscriptions, rules, and authorization rules. Single-page responses (`<=100`, `skip 0`) are byte-compatible with before and carry no nextLink.

## Test

Adds a real armservicebus SDK e2e test (`pagination_sdk_test.go`) that creates 150 queues and drives `NewListByNamespacePager`, asserting the listing spans more than one page and returns every queue exactly once.

## Gates

- `go build ./...` — clean
- `go test ./server/azure/servicebus/...` — pass
- `golangci-lint run ./server/azure/servicebus/...` — zero new issues (the 3 pre-existing `canonicalheader` findings live in the untouched `dataplane.go`)