### PR TITLE
feat(azure-servicebus): session support (Tier 1 enforcement + Tier 2 REST session surface)

### DIFF
--- a/providers/azure/servicebus/queue_storage.go
+++ b/providers/azure/servicebus/queue_storage.go
@@ -52,7 +52,7 @@ func (m *Mock) DequeueMessages(
 	}
 
 	now := m.opts.Clock.Now()
-	results, toRemove := m.collectVisibleMessages(qd, maxMsgs, visTimeout, now)
+	results, toRemove := m.collectVisibleMessages(qd, maxMsgs, visTimeout, now, nil)
 
 	removeByIndices(qd, toRemove)
 

--- a/providers/azure/servicebus/servicebus.go
+++ b/providers/azure/servicebus/servicebus.go
@@ -37,7 +37,11 @@ type sbMessage struct {
 	Attributes      map[string]string
 	// SystemProps carries Azure Service Bus brokered-message system properties
 	// (MessageId, CorrelationId, Label, SessionId, ...) preserved from the send.
-	SystemProps   map[string]string
+	SystemProps map[string]string
+	// SessionID is the message's Service Bus SessionId, promoted from
+	// SystemProps["SessionId"] at enqueue so session receive can filter on it in
+	// FIFO order. Empty on a non-session entity.
+	SessionID     string
 	ReceiptHandle string
 	VisibleAt     time.Time
 	SentAt        time.Time
@@ -73,6 +77,21 @@ type queueData struct {
 	// instead of dropping it (Service Bus deadLetteringOnMessageExpiration).
 	deadLetterOnExpiration bool
 	metadata               map[string]string
+	// requiresSession enables Service Bus sessions on the entity: every message
+	// must carry a SessionId, and messages are consumed per session. sessions
+	// tracks each session's lock and state, keyed by SessionId; it is allocated
+	// only for a session entity.
+	requiresSession bool
+	sessions        map[string]*sessionState
+}
+
+// sessionState tracks a single Service Bus session's lock ownership and its
+// opaque state blob. Fields are exported so it snapshots directly like
+// sbMessage. A zero LockOwner means the session is unlocked.
+type sessionState struct {
+	LockOwner   string    // opaque receiver/lock id holding the session; "" = unlocked
+	LockedUntil time.Time // session-lock expiry
+	State       string    // opaque session-state blob (get/set session state)
 }
 
 // FunctionTrigger is a function that gets called when a message is sent to a queue.
@@ -230,6 +249,11 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 		dlqConfig:              cfg.DeadLetterQueue,
 		deadLetterOnExpiration: cfg.DeadLetterOnExpiration,
 		metadata:               metadata,
+		requiresSession:        cfg.RequiresSession,
+	}
+
+	if cfg.RequiresSession {
+		qd.sessions = make(map[string]*sessionState)
 	}
 
 	m.queues.Set(url, qd)
@@ -306,6 +330,13 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		return nil, err
 	}
 
+	// A session-enabled entity requires every message to carry a SessionId (real
+	// Azure rejects a session-less send with InvalidOperation → 400).
+	sessionID := input.SystemProperties["SessionId"]
+	if qd.requiresSession && sessionID == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "SessionId is required for a session-enabled entity")
+	}
+
 	now := m.opts.Clock.Now()
 
 	// FIFO deduplication: check if same DeduplicationID was sent within 5-min window.
@@ -358,6 +389,7 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		DeduplicationID: input.DeduplicationID,
 		Attributes:      attrs,
 		SystemProps:     sysProps,
+		SessionID:       sessionID,
 		ReceiptHandle:   receiptHandle,
 		VisibleAt:       visibleAt,
 		SentAt:          now,
@@ -500,13 +532,9 @@ func (m *Mock) ReceiveMessages(_ context.Context, input driver.ReceiveMessageInp
 	}
 
 	now := m.opts.Clock.Now()
-	results, toRemove := m.collectVisibleMessages(qd, maxMsgs, visibilityTimeout, now)
+	results, toRemove := m.collectVisibleMessages(qd, maxMsgs, visibilityTimeout, now, plainReceiveAccept(qd))
 
-	// Remove DLQ-moved and expired messages in reverse order.
-	for i := len(toRemove) - 1; i >= 0; i-- {
-		idx := toRemove[i]
-		qd.messages = append(qd.messages[:idx], qd.messages[idx+1:]...)
-	}
+	removeByIndices(qd, toRemove)
 
 	if results == nil {
 		results = []driver.Message{}
@@ -518,6 +546,19 @@ func (m *Mock) ReceiveMessages(_ context.Context, input driver.ReceiveMessageInp
 	})
 
 	return results, nil
+}
+
+// plainReceiveAccept is the predicate for a plain (non-session) receive. On a
+// session entity it accepts nothing — Service Bus sessions are consumed only via
+// the session receiver, so a plain REST receive against a session queue returns
+// empty, matching real Azure (where session receive is not available over REST).
+// On a non-session entity it returns nil, accepting every message unchanged.
+func plainReceiveAccept(qd *queueData) func(*sbMessage) bool {
+	if !qd.requiresSession {
+		return nil
+	}
+
+	return func(*sbMessage) bool { return false }
 }
 
 func clampMaxMessages(maxMessages int) int {
@@ -532,8 +573,13 @@ func clampMaxMessages(maxMessages int) int {
 	return maxMessages
 }
 
+// collectVisibleMessages gathers up to maxMessages visible messages that pass
+// the accept predicate (nil accepts every message), reaping expired ones and
+// dead-lettering exhausted ones. The predicate lets the plain and session
+// receive paths share one collector: the plain path skips session messages on a
+// session entity, the session path selects a single SessionId.
 func (m *Mock) collectVisibleMessages(
-	qd *queueData, maxMessages, visibilityTimeout int, now time.Time,
+	qd *queueData, maxMessages, visibilityTimeout int, now time.Time, accept func(*sbMessage) bool,
 ) (messages []driver.Message, dlqIndices []int) {
 	var results []driver.Message
 
@@ -542,6 +588,10 @@ func (m *Mock) collectVisibleMessages(
 	for i, msg := range qd.messages {
 		if len(results) >= maxMessages {
 			break
+		}
+
+		if accept != nil && !accept(msg) {
+			continue
 		}
 
 		if m.reapExpired(qd, msg, now) {
@@ -792,7 +842,7 @@ func (m *Mock) ReceiveMessagesWithOptions(
 	}
 
 	now := m.opts.Clock.Now()
-	results, toRemove := m.collectVisibleMessages(qd, maxMsgs, visTimeout, now)
+	results, toRemove := m.collectVisibleMessages(qd, maxMsgs, visTimeout, now, plainReceiveAccept(qd))
 
 	removeByIndices(qd, toRemove)
 

--- a/providers/azure/servicebus/servicebus.go
+++ b/providers/azure/servicebus/servicebus.go
@@ -339,19 +339,44 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 
 	now := m.opts.Clock.Now()
 
-	// FIFO deduplication: check if same DeduplicationID was sent within 5-min window.
-	if existingID, found := findDuplicate(qd, &input, now); found {
+	// A repeat DeduplicationID (FIFO) or MessageId (Service Bus dup-detection)
+	// inside the window is silently accepted but not re-enqueued.
+	if existingID, found := findSendDuplicate(qd, &input, now); found {
 		return &driver.SendMessageOutput{MessageID: existingID}, nil
 	}
 
-	// Service Bus duplicate detection: a repeat MessageId inside the configured
-	// window is silently accepted but not re-enqueued.
-	if existingID, found := findMessageIDDuplicate(qd, &input, now); found {
-		return &driver.SendMessageOutput{MessageID: existingID}, nil
+	msg := buildSendMessage(&input, sessionID, now, qd.delaySeconds)
+	qd.messages = append(qd.messages, msg)
+	recordSendDedup(qd, &input, now)
+
+	m.fireTrigger(input.QueueURL, msg)
+
+	m.emitMetric(qd.info.Name, map[string]float64{
+		"IncomingMessages": 1, "Size": float64(len(input.Body)),
+	})
+
+	return &driver.SendMessageOutput{
+		MessageID:  msg.ID,
+		ExpiresAt:  msg.ExpiresAt,
+		PopReceipt: msg.ReceiptHandle,
+	}, nil
+}
+
+// findSendDuplicate reports an already-accepted message id when input is a FIFO
+// (DeduplicationID) or Service Bus (MessageId) duplicate within the dedup window.
+func findSendDuplicate(qd *queueData, input *driver.SendMessageInput, now time.Time) (string, bool) {
+	if id, found := findDuplicate(qd, input, now); found {
+		return id, true
 	}
 
-	msgID := idgen.GenerateID("sb-msg-")
+	return findMessageIDDuplicate(qd, input, now)
+}
 
+// buildSendMessage constructs the stored message from a send, copying the caller
+// maps and resolving the effective visibility/expiry. TimeToLive is measured
+// from the message's active time (visibleAt), so a scheduled message with a TTL
+// shorter than its delay still survives until at least its scheduled enqueue.
+func buildSendMessage(input *driver.SendMessageInput, sessionID string, now time.Time, queueDelay int) *sbMessage {
 	attrs := make(map[string]string, len(input.Attributes))
 	for k, v := range input.Attributes {
 		attrs[k] = v
@@ -364,75 +389,58 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 
 	delaySeconds := input.DelaySeconds
 	if delaySeconds == 0 {
-		delaySeconds = qd.delaySeconds
+		delaySeconds = queueDelay
 	}
 
 	visibleAt := now.Add(time.Duration(delaySeconds) * time.Second)
-	// TimeToLive is measured from when the message becomes active (its enqueue
-	// time), not from submit. For a scheduled message (ScheduledEnqueueTimeUtc in
-	// the future, carried here as a delivery delay) the effective enqueue time is
-	// visibleAt, so a message scheduled for T+delay with a TTL shorter than the
-	// delay still survives until at least T+delay and then lives for its full TTL.
-	// For a non-scheduled send visibleAt == now, so this is unchanged.
-	expiresAt := computeExpiry(visibleAt, input.MessageTTLSeconds)
 
-	// Mint a pop receipt at enqueue time so the message can be deleted or updated
-	// with the Put Message-returned receipt before its first dequeue, as Azure
-	// Queue Storage allows. A subsequent dequeue issues a fresh receipt that
-	// supersedes this one.
-	receiptHandle := idgen.GenerateID("sb-lock-")
-
-	msg := &sbMessage{
-		ID:              msgID,
+	return &sbMessage{
+		ID:              idgen.GenerateID("sb-msg-"),
 		Body:            input.Body,
 		GroupID:         input.GroupID,
 		DeduplicationID: input.DeduplicationID,
 		Attributes:      attrs,
 		SystemProps:     sysProps,
 		SessionID:       sessionID,
-		ReceiptHandle:   receiptHandle,
-		VisibleAt:       visibleAt,
-		SentAt:          now,
-		ExpiresAt:       expiresAt,
+		// A pop receipt minted at enqueue lets the message be deleted/updated with
+		// the Put Message-returned receipt before its first dequeue.
+		ReceiptHandle: idgen.GenerateID("sb-lock-"),
+		VisibleAt:     visibleAt,
+		SentAt:        now,
+		ExpiresAt:     computeExpiry(visibleAt, input.MessageTTLSeconds),
 	}
+}
 
-	qd.messages = append(qd.messages, msg)
-
+// recordSendDedup updates the FIFO and Service Bus duplicate-detection indexes
+// for a just-enqueued message.
+func recordSendDedup(qd *queueData, input *driver.SendMessageInput, now time.Time) {
 	if qd.info.FIFO && input.DeduplicationID != "" {
 		qd.deduplicationIndex[input.DeduplicationID] = now
 	}
 
 	if qd.requiresDupDetection {
-		if mid := messageIDOf(&input); mid != "" {
+		if mid := messageIDOf(input); mid != "" {
 			qd.dedupByMessageID[mid] = now
 		}
 	}
+}
 
-	// Fire Function trigger if registered.
+// fireTrigger invokes any registered Function trigger for the queue.
+func (m *Mock) fireTrigger(queueURL string, msg *sbMessage) {
 	m.mu.RLock()
-	trigger := m.triggers[input.QueueURL]
+	trigger := m.triggers[queueURL]
 	m.mu.RUnlock()
 
-	if trigger != nil {
-		triggerMsg := driver.Message{
-			MessageID:  msgID,
-			Body:       input.Body,
-			Attributes: attrs,
-			GroupID:    input.GroupID,
-		}
-
-		trigger(input.QueueURL, triggerMsg)
+	if trigger == nil {
+		return
 	}
 
-	m.emitMetric(qd.info.Name, map[string]float64{
-		"IncomingMessages": 1, "Size": float64(len(input.Body)),
+	trigger(queueURL, driver.Message{
+		MessageID:  msg.ID,
+		Body:       msg.Body,
+		Attributes: msg.Attributes,
+		GroupID:    msg.GroupID,
 	})
-
-	return &driver.SendMessageOutput{
-		MessageID:  msgID,
-		ExpiresAt:  expiresAt,
-		PopReceipt: receiptHandle,
-	}, nil
 }
 
 func validateFIFORequirements(qd *queueData, input *driver.SendMessageInput) error {

--- a/providers/azure/servicebus/sessions.go
+++ b/providers/azure/servicebus/sessions.go
@@ -1,0 +1,211 @@
+package servicebus
+
+import (
+	"context"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+)
+
+// Compile-time check that Mock implements the optional session surface.
+var _ driver.AzureSessionQueue = (*Mock)(nil)
+
+// ReceiveSession returns up to maxMessages currently-visible messages for a
+// session in FIFO order and acquires or refreshes the session lock for
+// lockOwner. An empty sessionID accepts the next unlocked session that has a
+// visible message; the accepted session id is returned. peekLock=false completes
+// the returned messages immediately (receive-and-delete).
+//
+// Service Bus sessions have no real REST data plane (real SDKs drive them over
+// AMQP), so this receive side is a CloudEmu REST extension; the send-side
+// SessionId enforcement it pairs with is faithful to real Azure.
+func (m *Mock) ReceiveSession(
+	_ context.Context, queueURL, sessionID, lockOwner string, maxMessages, lockSecs int, peekLock bool,
+) (string, []driver.Message, error) {
+	qd, ok := m.queues.Get(queueURL)
+	if !ok {
+		return "", nil, cerrors.Newf(cerrors.NotFound, "queue %q not found", queueURL)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	if !qd.requiresSession {
+		return "", nil, cerrors.New(cerrors.InvalidArgument, "entity is not session-enabled")
+	}
+
+	qd.ensureSessions()
+
+	now := m.opts.Clock.Now()
+
+	if lockSecs <= 0 {
+		lockSecs = qd.visibilityTimeout
+	}
+
+	sid := sessionID
+	if sid == "" {
+		if sid = qd.nextAvailableSession(lockOwner, now); sid == "" {
+			return "", nil, nil // no session with a visible message is available
+		}
+	}
+
+	if !qd.acquireSessionLock(sid, lockOwner, now, lockSecs) {
+		return "", nil, cerrors.Newf(cerrors.FailedPrecondition, "session %q is locked by another receiver", sid)
+	}
+
+	results, toRemove := m.collectVisibleMessages(qd, clampMaxMessages(maxMessages), lockSecs, now,
+		func(msg *sbMessage) bool { return msg.SessionID == sid })
+	removeByIndices(qd, toRemove)
+
+	if !peekLock {
+		deleteMessagesByID(qd, results)
+	}
+
+	if results == nil {
+		results = []driver.Message{}
+	}
+
+	return sid, results, nil
+}
+
+// GetSessionState returns the opaque state blob for a session (empty when the
+// session has no stored state).
+func (m *Mock) GetSessionState(_ context.Context, queueURL, sessionID string) (string, error) {
+	qd, ok := m.queues.Get(queueURL)
+	if !ok {
+		return "", cerrors.Newf(cerrors.NotFound, "queue %q not found", queueURL)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	if s := qd.sessions[sessionID]; s != nil {
+		return s.State, nil
+	}
+
+	return "", nil
+}
+
+// SetSessionState writes a session's opaque state blob.
+func (m *Mock) SetSessionState(_ context.Context, queueURL, sessionID, state string) error {
+	qd, ok := m.queues.Get(queueURL)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "queue %q not found", queueURL)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	if !qd.requiresSession {
+		return cerrors.New(cerrors.InvalidArgument, "entity is not session-enabled")
+	}
+
+	qd.ensureSessions()
+
+	qd.session(sessionID).State = state
+
+	return nil
+}
+
+// RenewSessionLock extends the session lock held by lockOwner.
+func (m *Mock) RenewSessionLock(_ context.Context, queueURL, sessionID, lockOwner string, lockSecs int) error {
+	qd, ok := m.queues.Get(queueURL)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "queue %q not found", queueURL)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	now := m.opts.Clock.Now()
+
+	s := qd.sessions[sessionID]
+	if s == nil || s.LockOwner != lockOwner || !s.LockedUntil.After(now) {
+		return cerrors.Newf(cerrors.FailedPrecondition, "session %q is not locked by this receiver", sessionID)
+	}
+
+	if lockSecs <= 0 {
+		lockSecs = qd.visibilityTimeout
+	}
+
+	s.LockedUntil = now.Add(time.Duration(lockSecs) * time.Second)
+
+	return nil
+}
+
+// ensureSessions lazily allocates the session map (a restored session queue with
+// no sessions yet carries a nil map from the omitempty snapshot).
+func (qd *queueData) ensureSessions() {
+	if qd.sessions == nil {
+		qd.sessions = make(map[string]*sessionState)
+	}
+}
+
+// session returns the state for sid, creating an unlocked entry if absent.
+func (qd *queueData) session(sid string) *sessionState {
+	s := qd.sessions[sid]
+	if s == nil {
+		s = &sessionState{}
+		qd.sessions[sid] = s
+	}
+
+	return s
+}
+
+// nextAvailableSession returns the SessionId of the first message (in FIFO order)
+// that is currently visible and belongs to a session that is unlocked, has an
+// expired lock, or is already held by lockOwner. Empty when none is available.
+func (qd *queueData) nextAvailableSession(lockOwner string, now time.Time) string {
+	for _, msg := range qd.messages {
+		if msg.SessionID == "" || msg.VisibleAt.After(now) {
+			continue
+		}
+
+		if s := qd.sessions[msg.SessionID]; s != nil &&
+			s.LockOwner != "" && s.LockOwner != lockOwner && s.LockedUntil.After(now) {
+			continue // locked by another receiver
+		}
+
+		return msg.SessionID
+	}
+
+	return ""
+}
+
+// acquireSessionLock grants or refreshes the session lock for lockOwner,
+// reporting false when another receiver already holds an unexpired lock.
+func (qd *queueData) acquireSessionLock(sid, lockOwner string, now time.Time, lockSecs int) bool {
+	s := qd.session(sid)
+	if s.LockOwner != "" && s.LockOwner != lockOwner && s.LockedUntil.After(now) {
+		return false
+	}
+
+	s.LockOwner = lockOwner
+	s.LockedUntil = now.Add(time.Duration(lockSecs) * time.Second)
+
+	return true
+}
+
+// deleteMessagesByID drops the messages just returned by a receive-and-delete
+// (matched by id).
+func deleteMessagesByID(qd *queueData, msgs []driver.Message) {
+	if len(msgs) == 0 {
+		return
+	}
+
+	ids := make(map[string]bool, len(msgs))
+	for i := range msgs {
+		ids[msgs[i].MessageID] = true
+	}
+
+	kept := qd.messages[:0]
+
+	for _, msg := range qd.messages {
+		if !ids[msg.ID] {
+			kept = append(kept, msg)
+		}
+	}
+
+	qd.messages = kept
+}

--- a/providers/azure/servicebus/snapshot.go
+++ b/providers/azure/servicebus/snapshot.go
@@ -39,6 +39,8 @@ type queueSnapshot struct {
 	DLQConfig              *driver.DeadLetterConfig `json:"dlqConfig,omitempty"`
 	DeadLetterOnExpiration bool                     `json:"deadLetterOnExpiration,omitempty"`
 	Metadata               map[string]string        `json:"metadata,omitempty"`
+	RequiresSession        bool                     `json:"requiresSession,omitempty"`
+	Sessions               map[string]*sessionState `json:"sessions,omitempty"`
 }
 
 // Snapshot captures the mock's entire state as JSON. includeAssets is unused —
@@ -68,7 +70,7 @@ func snapshotQueue(qd *queueData) *queueSnapshot {
 		DeduplicationIndex: qd.deduplicationIndex, RequiresDupDetection: qd.requiresDupDetection,
 		DupDetectionWindow: qd.dupDetectionWindow, DedupByMessageID: qd.dedupByMessageID,
 		DLQConfig: qd.dlqConfig, DeadLetterOnExpiration: qd.deadLetterOnExpiration,
-		Metadata: qd.metadata,
+		Metadata: qd.metadata, RequiresSession: qd.requiresSession, Sessions: qd.sessions,
 	}
 
 	if len(qd.messages) > 0 {
@@ -102,7 +104,7 @@ func restoreQueue(qs *queueSnapshot) *queueData {
 		deduplicationIndex: qs.DeduplicationIndex, requiresDupDetection: qs.RequiresDupDetection,
 		dupDetectionWindow: qs.DupDetectionWindow, dedupByMessageID: qs.DedupByMessageID,
 		dlqConfig: qs.DLQConfig, deadLetterOnExpiration: qs.DeadLetterOnExpiration,
-		metadata: qs.Metadata,
+		metadata: qs.Metadata, requiresSession: qs.RequiresSession, sessions: qs.Sessions,
 	}
 
 	if qd.deduplicationIndex == nil {

--- a/server/azure/servicebus/handler.go
+++ b/server/azure/servicebus/handler.go
@@ -169,9 +169,45 @@ func (h *Handler) Matches(r *http.Request) bool {
 		return h.claimsDataPlane(r.URL.Path)
 	}
 
+	if isSessionPlanePath(r.URL.Path) {
+		return h.claimsSessionPlane(r.URL.Path)
+	}
+
 	_, _, ok := parseSBPath(r.URL.Path)
 
 	return ok
+}
+
+// claimsSessionPlane reports whether a /{entity}/sessions/… URL addresses a
+// Service Bus entity this handler holds, mirroring claimsDataPlane. The session
+// data plane has no Queue Storage counterpart, but the entity-resolution guard
+// keeps an unknown entity from being wrongly claimed.
+func (h *Handler) claimsSessionPlane(p string) bool {
+	tgt, ok := parseSessionPath(p)
+	if !ok || tgt.entity == "" {
+		return false
+	}
+
+	return h.holdsEntity(tgt.namespace, tgt.entity, tgt.sub)
+}
+
+// holdsEntity reports whether this handler holds the addressed Service Bus
+// entity: a subscription's parent topic when sub is set, else a flat queue or
+// topic of that name.
+func (h *Handler) holdsEntity(namespace, entity, sub string) bool {
+	if sub != "" {
+		_, ok := h.resolveTopicSubURLs(namespace, entity)
+
+		return ok
+	}
+
+	if _, ok := h.resolveQueue(namespace, entity); ok {
+		return true
+	}
+
+	_, isTopic := h.resolveTopicSubURLs(namespace, entity)
+
+	return isTopic
 }
 
 // claimsDataPlane reports whether a data-plane URL addresses a Service Bus
@@ -185,28 +221,23 @@ func (h *Handler) claimsDataPlane(p string) bool {
 		return false
 	}
 
-	if tgt.sub != "" {
-		// A "/{topic}/subscriptions/{sub}/messages" request is Service Bus's to
-		// serve whenever the parent topic exists (Queue Storage has no such
-		// shape). serveSubscriptionData then 404s a missing subscription.
-		_, ok := h.resolveTopicSubURLs(tgt.namespace, tgt.entity)
-
-		return ok
-	}
-
-	if _, ok := h.resolveQueue(tgt.namespace, tgt.entity); ok {
-		return true
-	}
-
-	_, isTopic := h.resolveTopicSubURLs(tgt.namespace, tgt.entity)
-
-	return isTopic
+	// A "/{topic}/subscriptions/{sub}/messages" request is Service Bus's to serve
+	// whenever the parent topic exists (Queue Storage has no such shape);
+	// serveSubscriptionData then 404s a missing subscription. A flat
+	// "/{entity}/messages" is claimed only when the entity resolves to a known
+	// queue/topic, so an unknown entity falls through to Queue Storage.
+	return h.holdsEntity(tgt.namespace, tgt.entity, tgt.sub)
 }
 
 // ServeHTTP routes by URL shape.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if isDataPlanePath(r.URL.Path) {
 		h.serveDataPlane(w, r)
+		return
+	}
+
+	if isSessionPlanePath(r.URL.Path) {
+		h.serveSessionPlane(w, r)
 		return
 	}
 

--- a/server/azure/servicebus/queue.go
+++ b/server/azure/servicebus/queue.go
@@ -78,6 +78,7 @@ func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request, sp sbPath,
 			DeadLetterOnExpiration:     req.Properties.DeadLetteringOnExpiration,
 			RequiresDuplicateDetection: req.Properties.RequiresDuplicateDetection,
 			DuplicateDetectionWindow:   dupDetectionWindow(req.Properties.DuplicateDetectionHistoryTimeWindow),
+			RequiresSession:            req.Properties.RequiresSession,
 		})
 		if err != nil && !cerrors.IsAlreadyExists(err) {
 			h.mu.Unlock()

--- a/server/azure/servicebus/session_dataplane.go
+++ b/server/azure/servicebus/session_dataplane.go
@@ -155,7 +155,10 @@ func serveSessionReceive(
 	owner := sessionOwner(r)
 	peekLock := r.Method == http.MethodPost
 
-	sid, msgs, err := sess.ReceiveSession(r.Context(), url, sessionID, owner, 1, lockSecs, peekLock)
+	// The accepted session id travels back in BrokerProperties (SessionId,
+	// preserved from the send), so an accept-next caller learns which session it
+	// holds without a separate field.
+	_, msgs, err := sess.ReceiveSession(r.Context(), url, sessionID, owner, 1, lockSecs, peekLock)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -177,8 +180,11 @@ func serveSessionReceive(
 		lockToken = msg.ReceiptHandle
 		status = http.StatusCreated
 
+		// Settle a peek-locked session message via the plain message-lock URL: the
+		// message lock is separate from the session lock, and a /sessions/{sid}
+		// infix would not route back to serveLockedMessage for completion.
 		w.Header().Set("Location",
-			"/"+sessionEntityBase(url)+"/"+segSessions+"/"+sid+"/"+segMessages+"/"+msg.MessageID+"/"+msg.ReceiptHandle)
+			"/"+sessionEntityBase(url)+"/"+segMessages+"/"+msg.MessageID+"/"+msg.ReceiptHandle)
 	}
 
 	w.Header().Set("BrokerProperties", brokerPropertiesHeader(&msg, lockToken))

--- a/server/azure/servicebus/session_dataplane.go
+++ b/server/azure/servicebus/session_dataplane.go
@@ -1,0 +1,259 @@
+package servicebus
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+)
+
+// Session data-plane surface. Azure Service Bus sessions have no real REST data
+// plane — the official SDKs drive sessions over AMQP, which cloudemu does not
+// speak — so this /{entity}/sessions/… route family is a cloudemu-proprietary
+// REST extension. No real SDK exercises it; it lets a REST client drive the
+// session model (accept-next-session, session-scoped receive, session lock,
+// session state) that the faithful send-side SessionId enforcement pairs with.
+const (
+	segSessions        = "sessions"
+	segState           = "state"
+	segHead            = "head"
+	sessionOwnerHeader = "X-Cloudemu-Session-Owner"
+)
+
+// sessionTarget is a parsed /{entity}/sessions/… data-plane URL.
+type sessionTarget struct {
+	namespace string
+	entity    string
+	sub       string // subscription name; "" for a queue
+	sessionID string // "" on /sessions/head means accept-next-session
+	head      bool   // .../sessions[/{sid}]/head — receive
+	state     bool   // .../sessions/{sid}/state — get/set session state
+}
+
+// isSessionPlanePath reports whether p is a session data-plane URL (contains a
+// /sessions segment) rather than an ARM control-plane path.
+func isSessionPlanePath(p string) bool {
+	if strings.HasPrefix(p, "/subscriptions/") {
+		return false
+	}
+
+	return strings.Contains(p, "/"+segSessions)
+}
+
+// parseSessionPath resolves the entity scope before the /sessions segment
+// (reusing the /messages scope parser) and the session id / sub-route after it.
+func parseSessionPath(p string) (sessionTarget, bool) {
+	segs := strings.Split(strings.Trim(p, "/"), "/")
+
+	si := -1
+
+	for i, s := range segs {
+		if s == segSessions {
+			si = i
+			break
+		}
+	}
+
+	if si < 1 {
+		return sessionTarget{}, false
+	}
+
+	scope := parseEntityScope(segs, si)
+
+	tgt := sessionTarget{namespace: scope.namespace, entity: scope.entity, sub: scope.sub}
+	if !parseSessionTail(segs[si+1:], &tgt) {
+		return sessionTarget{}, false
+	}
+
+	return tgt, true
+}
+
+// parseSessionTail fills the session id / head / state fields from the segments
+// after /sessions, reporting whether the shape is valid.
+func parseSessionTail(tail []string, tgt *sessionTarget) bool {
+	switch {
+	case len(tail) == 1 && tail[0] == segHead:
+		tgt.head = true // accept-next-session + receive
+	case len(tail) == 1:
+		tgt.sessionID = tail[0] // renew lock on a named session
+	case len(tail) == 2 && tail[1] == segHead:
+		tgt.sessionID, tgt.head = tail[0], true
+	case len(tail) == 2 && tail[1] == segState:
+		tgt.sessionID, tgt.state = tail[0], true
+	default:
+		return false
+	}
+
+	return true
+}
+
+// serveSessionPlane routes the session data-plane extension.
+func (h *Handler) serveSessionPlane(w http.ResponseWriter, r *http.Request) {
+	tgt, ok := parseSessionPath(r.URL.Path)
+	if !ok || tgt.entity == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed session data-plane path")
+		return
+	}
+
+	sess, ok := h.mq.(mqdriver.AzureSessionQueue)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented", "session data plane not supported")
+		return
+	}
+
+	url, lockSecs, ok := h.resolveSessionEntity(&tgt)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "entity not found: "+tgt.entity)
+		return
+	}
+
+	switch {
+	case tgt.state:
+		serveSessionState(w, r, sess, url, tgt.sessionID)
+	case tgt.head:
+		serveSessionReceive(w, r, sess, url, tgt.sessionID, lockSecs)
+	case tgt.sessionID != "" && r.Method == http.MethodPost:
+		renewSessionLock(w, r, sess, url, tgt.sessionID)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+// resolveSessionEntity resolves the backing store URL and lock duration for a
+// session-addressed queue or topic subscription.
+func (h *Handler) resolveSessionEntity(tgt *sessionTarget) (url string, lockSecs int, ok bool) {
+	if tgt.sub != "" {
+		cfg, found := h.resolveSubscription(tgt.namespace, tgt.entity, tgt.sub)
+		if !found {
+			return "", 0, false
+		}
+
+		return cfg.url, cfg.lockSecs, true
+	}
+
+	cfg, found := h.resolveQueue(tgt.namespace, tgt.entity)
+	if !found {
+		return "", 0, false
+	}
+
+	return cfg.url, cfg.lockSecs, true
+}
+
+// serveSessionReceive handles POST (peek-lock) / DELETE (receive-and-delete) on
+// .../sessions[/{sid}]/head. An empty session id accepts the next unlocked
+// session. The accepted session and its lock owner are returned in headers.
+func serveSessionReceive(
+	w http.ResponseWriter, r *http.Request, sess mqdriver.AzureSessionQueue, url, sessionID string, lockSecs int,
+) {
+	if r.Method != http.MethodPost && r.Method != http.MethodDelete {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	owner := sessionOwner(r)
+	peekLock := r.Method == http.MethodPost
+
+	sid, msgs, err := sess.ReceiveSession(r.Context(), url, sessionID, owner, 1, lockSecs, peekLock)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.Header().Set(sessionOwnerHeader, owner)
+
+	if len(msgs) == 0 {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	msg := msgs[0]
+
+	lockToken := ""
+	status := http.StatusOK
+
+	if peekLock {
+		lockToken = msg.ReceiptHandle
+		status = http.StatusCreated
+
+		w.Header().Set("Location",
+			"/"+sessionEntityBase(url)+"/"+segSessions+"/"+sid+"/"+segMessages+"/"+msg.MessageID+"/"+msg.ReceiptHandle)
+	}
+
+	w.Header().Set("BrokerProperties", brokerPropertiesHeader(&msg, lockToken))
+	writeMessage(w, &msg, status)
+}
+
+// serveSessionState handles GET/PUT on .../sessions/{sid}/state.
+func serveSessionState(
+	w http.ResponseWriter, r *http.Request, sess mqdriver.AzureSessionQueue, url, sessionID string,
+) {
+	if sessionID == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "session id required")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		state, err := sess.GetSessionState(r.Context(), url, sessionID)
+		if err != nil {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(state)) //nolint:gosec // session state is an opaque octet-stream blob, not HTML
+	case http.MethodPut:
+		body, ok := readSendBody(w, r)
+		if !ok {
+			return
+		}
+
+		if err := sess.SetSessionState(r.Context(), url, sessionID, body); err != nil {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+// renewSessionLock handles POST on .../sessions/{sid} to extend the session lock
+// held by the X-Cloudemu-Session-Owner the caller was granted at accept time.
+func renewSessionLock(
+	w http.ResponseWriter, r *http.Request, sess mqdriver.AzureSessionQueue, url, sessionID string,
+) {
+	owner := sessionOwner(r)
+	if err := sess.RenewSessionLock(r.Context(), url, sessionID, owner, 0); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.Header().Set(sessionOwnerHeader, owner)
+	w.WriteHeader(http.StatusOK)
+}
+
+// sessionOwner reads the caller's session-lock owner token, minting one when
+// absent so an accept-next receiver gets a token to renew and complete with.
+func sessionOwner(r *http.Request) string {
+	if o := r.Header.Get(sessionOwnerHeader); o != "" {
+		return o
+	}
+
+	return idgen.GenerateID("sb-session-")
+}
+
+// sessionEntityBase is the "{namespace}/{entity}" (or "/…/subscriptions/{sub}")
+// URL prefix of a backing store URL, used for the peek-lock Location header. The
+// backing URL is https://{acct}.servicebus.windows.net/{namespace}/{entity}[…].
+func sessionEntityBase(backingURL string) string {
+	if i := strings.Index(backingURL, ".windows.net/"); i >= 0 {
+		return strings.Trim(backingURL[i+len(".windows.net/"):], "/")
+	}
+
+	return backingURL
+}

--- a/server/azure/servicebus/sessions_dataplane_test.go
+++ b/server/azure/servicebus/sessions_dataplane_test.go
@@ -110,6 +110,72 @@ func TestSessionReceiveAcceptNextAndState(t *testing.T) {
 	}
 }
 
+// TestSessionPeekLockSettlement confirms a peek-locked session message can be
+// completed via its advertised Location header (the message-lock URL), after
+// which the session has no more messages.
+func TestSessionPeekLockSettlement(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+	createSessionQueue(t, srv, "sq")
+
+	sessionSend(t, srv, "sq", "s1", "a1")
+
+	acc := doRequest(t, srv, http.MethodPost, "/"+nsName+"/sq/sessions/head", "")
+	if acc.StatusCode != http.StatusCreated {
+		t.Fatalf("accept-next = %d, want 201", acc.StatusCode)
+	}
+
+	_ = readBody(t, acc)
+
+	owner := acc.Header.Get(sessOwnerHeader)
+
+	loc := acc.Header.Get("Location")
+	if loc == "" {
+		t.Fatal("peek-lock response missing Location header")
+	}
+
+	// The Location must route back to complete (delete) the locked message.
+	done := doRequest(t, srv, http.MethodDelete, loc, "")
+	if done.StatusCode != http.StatusOK {
+		t.Fatalf("complete via Location %q = %d, want 200 (unroutable settlement URL?)", loc, done.StatusCode)
+	}
+
+	// The same session holder now sees no more messages (the session lock is
+	// still held, so the accept must reuse the granted owner token).
+	empty := doRequest(t, srv, http.MethodPost, "/"+nsName+"/sq/sessions/s1/head", "",
+		map[string]string{sessOwnerHeader: owner})
+	if empty.StatusCode != http.StatusNoContent {
+		t.Fatalf("session receive after complete = %d, want 204", empty.StatusCode)
+	}
+}
+
+// TestSessionReceiveAndDelete confirms a DELETE on .../sessions/{sid}/head
+// receives and removes the message in one step.
+func TestSessionReceiveAndDelete(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+	createSessionQueue(t, srv, "sq")
+
+	sessionSend(t, srv, "sq", "s1", "a1")
+
+	owner := map[string]string{sessOwnerHeader: "o1"}
+
+	got := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/sq/sessions/s1/head", "", owner)
+	if got.StatusCode != http.StatusOK {
+		t.Fatalf("receive-and-delete = %d, want 200", got.StatusCode)
+	}
+
+	if body := readBody(t, got); body != "a1" {
+		t.Fatalf("receive-and-delete body = %q, want a1", body)
+	}
+
+	// Message is gone (same session holder, so the lock is not the blocker).
+	empty := doRequest(t, srv, http.MethodPost, "/"+nsName+"/sq/sessions/s1/head", "", owner)
+	if empty.StatusCode != http.StatusNoContent {
+		t.Fatalf("session receive after delete = %d, want 204", empty.StatusCode)
+	}
+}
+
 // TestSessionLockExclusivity confirms a session locked by one receiver cannot be
 // accepted by another until the lock is released or expires.
 func TestSessionLockExclusivity(t *testing.T) {

--- a/server/azure/servicebus/sessions_dataplane_test.go
+++ b/server/azure/servicebus/sessions_dataplane_test.go
@@ -1,0 +1,133 @@
+package servicebus_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const sessOwnerHeader = "X-Cloudemu-Session-Owner"
+
+func createSessionQueue(t *testing.T, srv *httptest.Server, name string) {
+	t.Helper()
+
+	if r := doRequest(t, srv, http.MethodPut, queueURL(name)+apiVer,
+		`{"properties":{"requiresSession":true}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create session queue = %d", r.StatusCode)
+	}
+}
+
+func sessionSend(t *testing.T, srv *httptest.Server, queue, sessionID, body string) {
+	t.Helper()
+
+	r := doRequest(t, srv, http.MethodPost, "/"+nsName+"/"+queue+"/messages", body,
+		map[string]string{"BrokerProperties": `{"SessionId":"` + sessionID + `"}`})
+	if r.StatusCode != http.StatusCreated {
+		t.Fatalf("session send (%s) = %d, want 201", sessionID, r.StatusCode)
+	}
+}
+
+// TestSessionSendEnforcement is the Tier-1 (real, faithful) behavior: a session
+// entity requires a SessionId on every send, and a plain (non-session) receive
+// against it returns nothing — real Azure Service Bus sessions are consumed only
+// via the session receiver, which has no REST equivalent.
+func TestSessionSendEnforcement(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+	createSessionQueue(t, srv, "sq")
+
+	noSid := doRequest(t, srv, http.MethodPost, "/"+nsName+"/sq/messages", "payload")
+	if noSid.StatusCode != http.StatusBadRequest {
+		t.Fatalf("session-less send to a session entity = %d, want 400", noSid.StatusCode)
+	}
+
+	sessionSend(t, srv, "sq", "s1", "payload")
+
+	plain := doRequest(t, srv, http.MethodPost, "/"+nsName+"/sq/messages/head", "")
+	if plain.StatusCode != http.StatusNoContent {
+		t.Fatalf("plain receive on a session entity = %d, want 204 (empty)", plain.StatusCode)
+	}
+}
+
+// TestSessionReceiveAcceptNextAndState drives the Tier-2 REST session extension:
+// accept-next-session, session-scoped receive, and session state round-trip.
+func TestSessionReceiveAcceptNextAndState(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+	createSessionQueue(t, srv, "sq")
+
+	sessionSend(t, srv, "sq", "s1", "a1")
+	sessionSend(t, srv, "sq", "s2", "b1")
+
+	// accept-next picks the FIFO-first session (s1) and returns its message.
+	acc := doRequest(t, srv, http.MethodPost, "/"+nsName+"/sq/sessions/head", "")
+	if acc.StatusCode != http.StatusCreated {
+		t.Fatalf("accept-next = %d, want 201", acc.StatusCode)
+	}
+
+	if body := readBody(t, acc); body != "a1" {
+		t.Fatalf("accept-next body = %q, want a1", body)
+	}
+
+	if sid := brokerHeader(t, acc)["SessionId"]; sid != "s1" {
+		t.Fatalf("accepted SessionId = %q, want s1", sid)
+	}
+
+	owner := acc.Header.Get(sessOwnerHeader)
+	if owner == "" {
+		t.Fatal("accept-next response missing session owner header")
+	}
+
+	// A named receive of s2 returns only s2's message.
+	rs2 := doRequest(t, srv, http.MethodPost, "/"+nsName+"/sq/sessions/s2/head", "")
+	if rs2.StatusCode != http.StatusCreated {
+		t.Fatalf("s2 receive = %d, want 201", rs2.StatusCode)
+	}
+
+	if body := readBody(t, rs2); body != "b1" {
+		t.Fatalf("s2 body = %q, want b1", body)
+	}
+
+	// Session state on s1 round-trips.
+	if r := doRequest(t, srv, http.MethodPut, "/"+nsName+"/sq/sessions/s1/state", "mystate"); r.StatusCode != http.StatusOK {
+		t.Fatalf("set session state = %d, want 200", r.StatusCode)
+	}
+
+	gs := doRequest(t, srv, http.MethodGet, "/"+nsName+"/sq/sessions/s1/state", "")
+	if gs.StatusCode != http.StatusOK {
+		t.Fatalf("get session state = %d, want 200", gs.StatusCode)
+	}
+
+	if body := readBody(t, gs); body != "mystate" {
+		t.Fatalf("session state = %q, want mystate", body)
+	}
+
+	// Renewing s1's lock with the granted owner token succeeds.
+	rn := doRequest(t, srv, http.MethodPost, "/"+nsName+"/sq/sessions/s1", "",
+		map[string]string{sessOwnerHeader: owner})
+	if rn.StatusCode != http.StatusOK {
+		t.Fatalf("renew session lock = %d, want 200", rn.StatusCode)
+	}
+}
+
+// TestSessionLockExclusivity confirms a session locked by one receiver cannot be
+// accepted by another until the lock is released or expires.
+func TestSessionLockExclusivity(t *testing.T) {
+	srv, _ := newTestServer(t)
+	seedNamespace(t, srv)
+	createSessionQueue(t, srv, "sq")
+
+	sessionSend(t, srv, "sq", "s1", "a1")
+
+	first := doRequest(t, srv, http.MethodPost, "/"+nsName+"/sq/sessions/s1/head", "")
+	if first.StatusCode != http.StatusCreated {
+		t.Fatalf("first accept of s1 = %d, want 201", first.StatusCode)
+	}
+
+	// A different owner is refused while the lock is held.
+	second := doRequest(t, srv, http.MethodPost, "/"+nsName+"/sq/sessions/s1/head", "",
+		map[string]string{sessOwnerHeader: "other-owner"})
+	if second.StatusCode != http.StatusConflict {
+		t.Fatalf("second owner accept of a locked session = %d, want 409", second.StatusCode)
+	}
+}

--- a/server/azure/servicebus/subscription.go
+++ b/server/azure/servicebus/subscription.go
@@ -192,6 +192,7 @@ func (h *Handler) createSubQueue(
 		DeadLetterOnExpiration:     props.DeadLetteringOnExpiration,
 		RequiresDuplicateDetection: dup.enabled,
 		DuplicateDetectionWindow:   dup.window,
+		RequiresSession:            props.RequiresSession,
 	})
 	if err != nil && !cerrors.IsAlreadyExists(err) {
 		return "", "", err

--- a/services/messagequeue/driver/driver.go
+++ b/services/messagequeue/driver/driver.go
@@ -35,6 +35,11 @@ type QueueConfig struct {
 	// Bus: 10 minutes).
 	DuplicateDetectionWindow time.Duration
 
+	// RequiresSession enables Azure Service Bus sessions on the entity: every
+	// message must carry a SessionId, and messages are consumed per session. It is
+	// immutable after create. Ignored by non-Azure providers.
+	RequiresSession bool
+
 	// AWS SQS extras (ignored by non-AWS providers).
 	ReceiveMessageWaitTimeSeconds int
 	ContentBasedDeduplication     bool
@@ -293,6 +298,29 @@ type AzureQueueStorage interface {
 	GetQueueMetadata(ctx context.Context, queueURL string) (AzureQueueMetadata, error)
 	// SetQueueMetadata replaces the queue's user metadata.
 	SetQueueMetadata(ctx context.Context, queueURL string, metadata map[string]string) error
+}
+
+// AzureSessionQueue is the optional Azure Service Bus session surface, discovered
+// by type assertion on a MessageQueue backend (only the Azure Mock implements
+// it). Service Bus sessions have no real REST data plane — real SDKs drive
+// sessions over AMQP — so the receive side here is a CloudEmu REST extension that
+// lets a REST client exercise the session model; the send-side enforcement it
+// pairs with is faithful to real Azure.
+type AzureSessionQueue interface {
+	// ReceiveSession returns up to maxMessages currently-visible messages for a
+	// session in FIFO order and acquires or refreshes the session lock for
+	// lockOwner (for lockSecs seconds). An empty sessionID means accept the next
+	// unlocked session that has a visible message; the accepted session id is
+	// returned. peekLock=false completes the messages immediately (receive-and-
+	// delete).
+	ReceiveSession(
+		ctx context.Context, queueURL, sessionID, lockOwner string, maxMessages, lockSecs int, peekLock bool,
+	) (acceptedSession string, messages []Message, err error)
+	// GetSessionState and SetSessionState read and write a session's opaque state.
+	GetSessionState(ctx context.Context, queueURL, sessionID string) (string, error)
+	SetSessionState(ctx context.Context, queueURL, sessionID, state string) error
+	// RenewSessionLock extends the session lock held by lockOwner.
+	RenewSessionLock(ctx context.Context, queueURL, sessionID, lockOwner string, lockSecs int) error
 }
 
 // MessageQueue is the interface that message queue provider implementations must satisfy.


### PR DESCRIPTION
## Background
Azure Service Bus `requiresSession` round-tripped through ARM but was never enforced. **Sessions have no real REST data plane** — the official SDKs drive them over AMQP, which CloudEmu doesn't speak — so this splits into two tiers.

## Tier 1 — real & faithful (any REST/SDK client exercises it)
- A **session-enabled entity rejects a send with no `SessionId`** (400).
- A **plain receive on a session entity returns nothing** (204) — sessions are consumed only via the session receiver, matching real Azure over REST.
- `RequiresSession` now propagates ARM → `QueueConfig` → backend (queue + subscription create); `SessionId` is promoted to a first-class message field; persisted in snapshots.

## Tier 2 — CloudEmu REST session extension (flagged non-standard)
A `/{entity}/sessions/…` route family (no Azure equivalent; a bespoke REST surface, since no real SDK can drive sessions over REST):
- `POST /{entity}/sessions/head` — accept-next-session + peek-lock; `POST|DELETE /{entity}/sessions/{sid}/head` — named session receive (FIFO, session-scoped).
- `POST /{entity}/sessions/{sid}` — renew session lock; `GET|PUT /{entity}/sessions/{sid}/state` — session state.
- Session lock exclusivity + owner token (`X-Cloudemu-Session-Owner`), separate from the message lock. Topic subscriptions reuse the same scope parser.

True SDK-level session parity needs an AMQP data plane (a separate, larger effort) — deferred.

## Architecture
Send validation + session receive share the existing message collector via an `accept` predicate (no duplication). New `AzureSessionQueue` optional driver interface, type-asserted like `AzureQueueStorage` — only the Azure Mock implements it. Non-session queues are byte-unchanged (predicate is nil). `SendMessage` refactored into helpers (build/dedup/trigger) to stay within complexity limits.

## Test
Tier 1 (send enforcement + plain-receive-empty) and Tier 2 (accept-next, named session receive, session state round-trip, lock exclusivity 409) all covered via the raw-HTTP data-plane harness. `go test ./server/azure/servicebus/... ./providers/azure/servicebus/... ./persist/` green; SB packages lint-clean.