### PR TITLE
fix(azure-arg): real resourceGroup/location on non-compute rows + strip internal tags

### DIFF
--- a/server/azure/resourcegraph/azure_row_correctness_test.go
+++ b/server/azure/resourcegraph/azure_row_correctness_test.go
@@ -1,0 +1,160 @@
+// Real-SDK regression for A1: Azure Resource Graph rows for non-compute
+// resources must report the resource's real resourceGroup and Azure region
+// (not the literal "default" / an AWS-style "us-east-1"), and must never leak
+// the internal "cloudemu:"-prefixed ARM bookkeeping tags. Resources are created
+// through the live ARM wire (armnetwork / armcompute) so the resource-group tag
+// and region metadata the walker reads are actually populated, then discovered
+// through the live armresourcegraph client.
+
+package resourcegraph_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+func armClientOpts(t *testing.T, ts *httptest.Server) *arm.ClientOptions {
+	t.Helper()
+
+	return &arm.ClientOptions{ClientOptions: azcore.ClientOptions{
+		Cloud: cloud.Configuration{Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		}},
+		Transport: ts.Client(),
+		Retry:     policy.RetryOptions{MaxRetries: -1},
+	}}
+}
+
+// rowByType returns the first ARG row whose `type` equals typ, failing the test
+// when none is present.
+func rowByType(t *testing.T, data []any, typ string) map[string]any {
+	t.Helper()
+
+	for _, d := range data {
+		row, ok := d.(map[string]any)
+		if ok && row["type"] == typ {
+			return row
+		}
+	}
+
+	t.Fatalf("no ARG row of type %q in %d rows", typ, len(data))
+
+	return nil
+}
+
+// TestSDKResourceGraph_RealResourceGroupAndLocation pins A1: an Azure VNet
+// created under a specific resource group and region reports both faithfully in
+// its Resource Graph row, and a VM row carries no internal cloudemu:* tag.
+func TestSDKResourceGraph_RealResourceGroupAndLocation(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	const (
+		rg     = "rg-prod"
+		region = "westus2"
+	)
+
+	srv := azureserver.New(azureserver.Drivers{
+		Network:           cloudP.VNet,
+		VirtualMachines:   cloudP.VirtualMachines,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		SubscriptionID:    "123456789012",
+	})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	opts := armClientOpts(t, ts)
+
+	// Create a VNet through the ARM wire so the resource-group tag and region
+	// metadata the discovery walker reads are actually populated.
+	vnets, err := armnetwork.NewVirtualNetworksClient("123456789012", fakeCred{}, opts)
+	require.NoError(t, err)
+
+	vnetPoller, err := vnets.BeginCreateOrUpdate(ctx, rg, "vnet-app", armnetwork.VirtualNetwork{
+		Location: to.Ptr(region),
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = vnetPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	require.NoError(t, err)
+
+	// Create a VM through the ARM wire so it carries the internal cloudemu:azureName
+	// tag the wire handler stamps — the tag that must not leak into an ARG row.
+	vms, err := armcompute.NewVirtualMachinesClient("123456789012", fakeCred{}, opts)
+	require.NoError(t, err)
+
+	vmPoller, err := vms.BeginCreateOrUpdate(ctx, rg, "vm-app", armcompute.VirtualMachine{
+		Location: to.Ptr(region),
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armcompute.VirtualMachineProperties{
+			HardwareProfile: &armcompute.HardwareProfile{VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3)},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = vmPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	require.NoError(t, err)
+
+	client := newResourceGraphClient(t, ts)
+
+	out, err := client.Resources(ctx, armresourcegraph.QueryRequest{Query: to.Ptr("Resources")}, nil)
+	require.NoError(t, err)
+
+	data, ok := out.Data.([]any)
+	require.True(t, ok, "expected []any data, got %T", out.Data)
+
+	t.Run("vnet reports its real resourceGroup and Azure region", func(t *testing.T) {
+		row := rowByType(t, data, "microsoft.network/virtualnetworks")
+
+		assert.Equal(t, rg, row["resourceGroup"],
+			"VNet row must carry its real resource group, not the literal \"default\"")
+		assert.Equal(t, region, row["location"],
+			"VNet row must carry its real Azure region, not the AWS-style engine default")
+		assert.Contains(t, row["id"].(string), "/resourceGroups/"+rg+"/",
+			"the VNet resource id must embed its real resource group")
+
+		// Real user tags survive; internal ones do not.
+		tags := row["tags"].(map[string]any)
+		assert.Equal(t, "prod", tags["env"])
+		assertNoInternalTags(t, tags)
+	})
+
+	t.Run("vm row carries no internal cloudemu:* tag", func(t *testing.T) {
+		row := rowByType(t, data, "microsoft.compute/virtualmachines")
+
+		tags := row["tags"].(map[string]any)
+		assert.Equal(t, "prod", tags["env"], "the real user tag survives")
+		assertNoInternalTags(t, tags)
+	})
+}
+
+func assertNoInternalTags(t *testing.T, tags map[string]any) {
+	t.Helper()
+
+	for k := range tags {
+		assert.Falsef(t, strings.HasPrefix(k, "cloudemu:"),
+			"internal tag %q leaked into the ARG row", k)
+	}
+}

--- a/server/azure/resourcegraph/handler.go
+++ b/server/azure/resourcegraph/handler.go
@@ -19,6 +19,12 @@ const (
 	pathOperations       = "/providers/Microsoft.ResourceGraph/operations"
 )
 
+// internalTagPrefix is the marker the Azure wire handlers use for internal ARM
+// bookkeeping tags (resource name, resource group, disk name, …). These are an
+// implementation detail of how the cross-cloud driver models are mapped to ARM
+// and must never appear on a resource row a client reads.
+const internalTagPrefix = "cloudemu:"
+
 // Handler serves Azure Resource Graph ARM-JSON requests.
 type Handler struct {
 	engine         *resourcediscovery.Engine
@@ -351,12 +357,39 @@ func resourceGroupOrDefault(id string) string {
 	return rest
 }
 
+// tagsOrEmpty renders a resource's tags for the ARG row, dropping the internal
+// "cloudemu:"-prefixed tags the Azure wire handlers stamp on resources (e.g. the
+// ARM name and resource-group markers) so they never leak to a client, while
+// preserving every real user tag. A nil/all-internal map renders as {}.
 func tagsOrEmpty(tags map[string]string) map[string]string {
-	if tags == nil {
-		return map[string]string{}
+	if out := StripInternalTags(tags); out != nil {
+		return out
 	}
 
-	return tags
+	return map[string]string{}
+}
+
+// StripInternalTags returns tags with the internal "cloudemu:"-prefixed markers
+// removed, preserving every real user tag; it returns nil when nothing remains.
+// Exported so other Azure handlers that render resourcediscovery.Resource tags
+// (e.g. the resource-group exportTemplate) drop the same internal bookkeeping
+// tags Resource Graph does, rather than leaking them.
+func StripInternalTags(tags map[string]string) map[string]string {
+	var out map[string]string
+
+	for k, v := range tags {
+		if strings.HasPrefix(k, internalTagPrefix) {
+			continue
+		}
+
+		if out == nil {
+			out = make(map[string]string, len(tags))
+		}
+
+		out[k] = v
+	}
+
+	return out
 }
 
 // extractSubscription pulls /subscriptions/<id>/... out of an Azure resource

--- a/server/azure/resourcegroups/handler.go
+++ b/server/azure/resourcegroups/handler.go
@@ -464,8 +464,10 @@ func exportResourceEntry(r *resourcediscovery.Resource) map[string]any {
 		entry["properties"] = r.Properties
 	}
 
-	if len(r.Tags) > 0 {
-		entry["tags"] = r.Tags
+	// Drop the internal "cloudemu:" ARM-bookkeeping tags so the exported template
+	// carries only real user tags, matching what Resource Graph renders.
+	if tags := resourcegraph.StripInternalTags(r.Tags); len(tags) > 0 {
+		entry["tags"] = tags
 	}
 
 	return entry

--- a/services/resourcediscovery/arn.go
+++ b/services/resourcediscovery/arn.go
@@ -14,6 +14,43 @@ import (
 
 const azureDefaultResourceGroup = "default"
 
+// Azure ARM resource-group tag keys. The Azure wire handlers stamp the owning
+// resource group onto each resource's tags under these keys, because the
+// cross-cloud driver models carry no resource-group field. They are duplicated
+// here rather than imported because the services layer must not depend on the
+// server layer; they are stable wire-contract strings. A resource carries at
+// most one of them.
+const (
+	azureVNetRGTag       = "cloudemu:azureVNetResourceGroup"
+	azureNSGRGTag        = "cloudemu:azureNSGResourceGroup"
+	azurePublicIPRGTag   = "cloudemu:azurePublicIPResourceGroup"
+	azureNATGatewayRGTag = "cloudemu:azureNatGatewayResourceGroup"
+	azureRouteTableRGTag = "cloudemu:azureRouteTableResourceGroup"
+	azureDiskRGTag       = "cloudemu:azureRG"
+)
+
+// azureRGFromTags returns the Azure resource group recorded on a resource's ARM
+// tags, or "" when none is present (a portable-API creation that recorded no
+// group, or a non-Azure provider whose tags never carry these keys). A resource
+// carries at most one of the keys, so the first match wins. Callers gate this on
+// the Azure provider so AWS/GCP ARNs stay byte-unchanged.
+func (e *Engine) azureRGFromTags(tags map[string]string) string {
+	if e.provider != ProviderAzure {
+		return ""
+	}
+
+	for _, k := range []string{
+		azureVNetRGTag, azureNSGRGTag, azurePublicIPRGTag,
+		azureNATGatewayRGTag, azureRouteTableRGTag, azureDiskRGTag,
+	} {
+		if v := tags[k]; v != "" {
+			return v
+		}
+	}
+
+	return ""
+}
+
 // Network resource kind constants used by per-provider ARN routing.
 const (
 	netKindVPC           = "vpc"
@@ -48,8 +85,9 @@ func (e *Engine) computeInstanceARN(id, resourceGroup string) string {
 // computeVolumeARN canonicalizes a block-volume id. When the driver already
 // hands back a fully-qualified id (an Azure managed-disk ARM path, a GCP
 // self-link, or an AWS ARN) it is used verbatim; otherwise a per-provider id
-// is built from the short id.
-func (e *Engine) computeVolumeARN(id string) string {
+// is built from the short id. resourceGroup is the Azure managed-disk group
+// (empty falls back to the default); AWS/GCP ignore it.
+func (e *Engine) computeVolumeARN(id, resourceGroup string) string {
 	if isQualifiedID(id) {
 		return id
 	}
@@ -58,7 +96,7 @@ func (e *Engine) computeVolumeARN(id string) string {
 	case ProviderAWS:
 		return idgen.AWSARN("ec2", e.region, e.accountID, "volume/"+id)
 	case ProviderAzure:
-		return idgen.AzureID(e.accountID, azureDefaultResourceGroup, "Microsoft.Compute", "disks", id)
+		return idgen.AzureID(e.accountID, azureResourceGroupOrDefault(resourceGroup), "Microsoft.Compute", "disks", id)
 	case ProviderGCP:
 		return idgen.GCPID(e.accountID, "zones/"+e.region+"/disks", id)
 	default:
@@ -68,7 +106,9 @@ func (e *Engine) computeVolumeARN(id string) string {
 
 // computeSnapshotARN canonicalizes a block-storage snapshot id, using an
 // already-qualified id verbatim and otherwise building a per-provider one.
-func (e *Engine) computeSnapshotARN(id string) string {
+// resourceGroup is the Azure snapshot group (empty falls back to the default);
+// AWS/GCP ignore it.
+func (e *Engine) computeSnapshotARN(id, resourceGroup string) string {
 	if isQualifiedID(id) {
 		return id
 	}
@@ -77,7 +117,7 @@ func (e *Engine) computeSnapshotARN(id string) string {
 	case ProviderAWS:
 		return idgen.AWSARN("ec2", e.region, e.accountID, "snapshot/"+id)
 	case ProviderAzure:
-		return idgen.AzureID(e.accountID, azureDefaultResourceGroup, "Microsoft.Compute", "snapshots", id)
+		return idgen.AzureID(e.accountID, azureResourceGroupOrDefault(resourceGroup), "Microsoft.Compute", "snapshots", id)
 	case ProviderGCP:
 		return idgen.GCPID(e.accountID, "global/snapshots", id)
 	default:
@@ -100,13 +140,17 @@ func isQualifiedID(id string) bool {
 	}
 }
 
-func (e *Engine) networkARN(kind, id string) string {
+// networkARN builds the canonical identifier for a network resource.
+// resourceGroup is the Azure resource group the resource belongs to (empty
+// falls back to the default group); AWS/GCP ignore it, so their ARNs are
+// byte-unchanged.
+func (e *Engine) networkARN(kind, id, resourceGroup string) string {
 	switch e.provider {
 	case ProviderAWS:
 		return idgen.AWSARN("ec2", e.region, e.accountID, kind+"/"+id)
 	case ProviderAzure:
 		azureType := azureNetworkType(kind)
-		return idgen.AzureID(e.accountID, azureDefaultResourceGroup, "Microsoft.Network", azureType, id)
+		return idgen.AzureID(e.accountID, azureResourceGroupOrDefault(resourceGroup), "Microsoft.Network", azureType, id)
 	case ProviderGCP:
 		return idgen.GCPID(e.accountID, gcpNetworkCollection(kind), id)
 	default:
@@ -164,12 +208,15 @@ func gcpNetworkCollection(kind string) string {
 	}
 }
 
-func (e *Engine) storageBucketARN(name string) string {
+// storageBucketARN builds the canonical identifier for a storage bucket/account.
+// resourceGroup is the Azure storage-account group (empty falls back to the
+// default); AWS/GCP ignore it.
+func (e *Engine) storageBucketARN(name, resourceGroup string) string {
 	switch e.provider {
 	case ProviderAWS:
 		return fmt.Sprintf("arn:aws:s3:::%s", name)
 	case ProviderAzure:
-		return idgen.AzureID(e.accountID, azureDefaultResourceGroup, "Microsoft.Storage",
+		return idgen.AzureID(e.accountID, azureResourceGroupOrDefault(resourceGroup), "Microsoft.Storage",
 			"storageAccounts/default/blobServices/default/containers", name)
 	case ProviderGCP:
 		return idgen.GCPID(e.accountID, "buckets", name)
@@ -178,12 +225,15 @@ func (e *Engine) storageBucketARN(name string) string {
 	}
 }
 
-func (e *Engine) databaseTableARN(name string) string {
+// databaseTableARN builds the canonical identifier for a database table/account.
+// resourceGroup is the Azure Cosmos DB account group (empty falls back to the
+// default); AWS/GCP ignore it.
+func (e *Engine) databaseTableARN(name, resourceGroup string) string {
 	switch e.provider {
 	case ProviderAWS:
 		return idgen.AWSARN("dynamodb", e.region, e.accountID, "table/"+name)
 	case ProviderAzure:
-		return idgen.AzureID(e.accountID, azureDefaultResourceGroup, "Microsoft.DocumentDB",
+		return idgen.AzureID(e.accountID, azureResourceGroupOrDefault(resourceGroup), "Microsoft.DocumentDB",
 			"databaseAccounts/default/sqlDatabases/default/containers", name)
 	case ProviderGCP:
 		return idgen.GCPID(e.accountID, "databases/(default)/collections", name)

--- a/services/resourcediscovery/walkers.go
+++ b/services/resourcediscovery/walkers.go
@@ -195,7 +195,7 @@ func (e *Engine) walkSnapshots(ctx context.Context) ([]Resource, error) {
 
 	return e.emitSimple(ServiceCompute, TypeSnapshot, len(snaps),
 		func(i int) (string, string, map[string]string) {
-			return shortName(snaps[i].ID), e.computeSnapshotARN(snaps[i].ID), snaps[i].Tags
+			return shortName(snaps[i].ID), e.computeSnapshotARN(snaps[i].ID, e.azureRGFromTags(snaps[i].Tags)), snaps[i].Tags
 		}), nil
 }
 
@@ -225,12 +225,14 @@ func (e *Engine) walkVolumes(ctx context.Context, rgByInstance map[string]string
 		}
 
 		out = append(out, Resource{
-			Provider:   e.provider,
-			Service:    ServiceCompute,
-			Type:       TypeVolume,
-			ID:         shortName(v.ID),
-			ARN:        e.computeVolumeARN(v.ID),
-			Region:     e.region,
+			Provider: e.provider,
+			Service:  ServiceCompute,
+			Type:     TypeVolume,
+			ID:       shortName(v.ID),
+			ARN:      e.computeVolumeARN(v.ID, e.azureRGFromTags(v.Tags)),
+			// Azure managed disks record their region on VolumeInfo.Location; it is
+			// empty for AWS/GCP, so those fall back to e.region unchanged.
+			Region:     firstNonEmpty(v.Location, e.region),
 			Tags:       copyTags(v.Tags),
 			SKU:        v.VolumeType,
 			SKUTier:    v.Tier,
@@ -243,8 +245,53 @@ func (e *Engine) walkVolumes(ctx context.Context, rgByInstance map[string]string
 	return out, nil
 }
 
+// azureNetLocation returns the Azure region recorded in the optional
+// AzureNetworkMetadata capability for a virtual network, network security group
+// or route table. It falls back to the engine region when the provider is not
+// Azure, the capability is absent, or no metadata was stored (a portable-API
+// creation) — which is also what every non-Azure provider gets, so their rows
+// are unchanged. This is where the real per-resource region lives: the
+// cross-cloud VPCInfo/SecurityGroupInfo/RouteTable models carry none.
+func (e *Engine) azureNetLocation(ctx context.Context, azMeta netdriver.AzureNetworkMetadata, kind, id string) string {
+	if azMeta == nil {
+		return e.region
+	}
+
+	if loc := azureMetaLocation(ctx, azMeta, kind, id); loc != "" {
+		return loc
+	}
+
+	return e.region
+}
+
+// azureMetaLocation returns the stored region for one Azure network resource, or
+// "" when the kind carries no metadata region or none was recorded. A not-found
+// lookup yields a zero-value metadata whose Location is "", which the caller
+// treats the same as "no region".
+func azureMetaLocation(ctx context.Context, azMeta netdriver.AzureNetworkMetadata, kind, id string) string {
+	switch kind {
+	case netKindVPC:
+		md, _ := azMeta.GetAzureVNetMetadata(ctx, id)
+		return md.Location
+	case netKindSecurityGroup:
+		md, _ := azMeta.GetAzureNSGMetadata(ctx, id)
+		return md.Location
+	case netKindRouteTable:
+		md, _ := azMeta.GetAzureRouteTableMetadata(ctx, id)
+		return md.Location
+	default:
+		return ""
+	}
+}
+
 func (e *Engine) walkNetworking(ctx context.Context) ([]Resource, error) {
 	out := []Resource{}
+
+	// AzureNetworkMetadata is an optional, type-asserted capability (only the
+	// Azure provider implements it) that records the per-resource region the
+	// cross-cloud models cannot. AWS/GCP fail the assertion, so azMeta is nil and
+	// every row keeps e.region.
+	azMeta, _ := e.drivers.Networking.(netdriver.AzureNetworkMetadata)
 
 	vpcs, err := e.drivers.Networking.DescribeVPCs(ctx, nil)
 	if err != nil {
@@ -260,8 +307,8 @@ func (e *Engine) walkNetworking(ctx context.Context) ([]Resource, error) {
 		out = append(out, Resource{
 			Provider: e.provider, Service: ServiceNetworking, Type: TypeVPC,
 			ID:     v.ID,
-			ARN:    e.networkARN(netKindVPC, v.ID),
-			Region: e.region, Tags: copyTags(v.Tags),
+			ARN:    e.networkARN(netKindVPC, v.ID, e.azureRGFromTags(v.Tags)),
+			Region: e.azureNetLocation(ctx, azMeta, netKindVPC, v.ID), Tags: copyTags(v.Tags),
 			Properties: props,
 		})
 	}
@@ -280,7 +327,7 @@ func (e *Engine) walkNetworking(ctx context.Context) ([]Resource, error) {
 		out = append(out, Resource{
 			Provider: e.provider, Service: ServiceNetworking, Type: TypeSubnet,
 			ID:     s.ID,
-			ARN:    e.networkARN(netKindSubnet, s.ID),
+			ARN:    e.networkARN(netKindSubnet, s.ID, e.azureRGFromTags(s.Tags)),
 			Region: e.region, Tags: copyTags(s.Tags),
 			Properties: props,
 		})
@@ -295,8 +342,8 @@ func (e *Engine) walkNetworking(ctx context.Context) ([]Resource, error) {
 		out = append(out, Resource{
 			Provider: e.provider, Service: ServiceNetworking, Type: TypeSecurityGroup,
 			ID:     sg.ID,
-			ARN:    e.networkARN(netKindSecurityGroup, sg.ID),
-			Region: e.region, Tags: copyTags(sg.Tags),
+			ARN:    e.networkARN(netKindSecurityGroup, sg.ID, e.azureRGFromTags(sg.Tags)),
+			Region: e.azureNetLocation(ctx, azMeta, netKindSecurityGroup, sg.ID), Tags: copyTags(sg.Tags),
 		})
 	}
 
@@ -314,7 +361,7 @@ func (e *Engine) walkNetworking(ctx context.Context) ([]Resource, error) {
 		out = append(out, Resource{
 			Provider: e.provider, Service: ServiceNetworking, Type: TypeElasticIP,
 			ID:     eip.AllocationID,
-			ARN:    e.networkARN(netKindElasticIP, eip.AllocationID),
+			ARN:    e.networkARN(netKindElasticIP, eip.AllocationID, e.azureRGFromTags(eip.Tags)),
 			Region: e.region, Tags: copyTags(eip.Tags),
 			SKU:        eip.SKU,
 			Properties: props,
@@ -330,7 +377,7 @@ func (e *Engine) walkNetworking(ctx context.Context) ([]Resource, error) {
 		out = append(out, Resource{
 			Provider: e.provider, Service: ServiceNetworking, Type: TypeNATGateway,
 			ID:     ng.ID,
-			ARN:    e.networkARN(netKindNATGateway, ng.ID),
+			ARN:    e.networkARN(netKindNATGateway, ng.ID, e.azureRGFromTags(ng.Tags)),
 			Region: e.region, Tags: copyTags(ng.Tags),
 		})
 	}
@@ -344,7 +391,7 @@ func (e *Engine) walkNetworking(ctx context.Context) ([]Resource, error) {
 		out = append(out, Resource{
 			Provider: e.provider, Service: ServiceNetworking, Type: TypeInternetGateway,
 			ID:     igw.ID,
-			ARN:    e.networkARN(netKindInternetGW, igw.ID),
+			ARN:    e.networkARN(netKindInternetGW, igw.ID, e.azureRGFromTags(igw.Tags)),
 			Region: e.region, Tags: copyTags(igw.Tags),
 		})
 	}
@@ -358,7 +405,7 @@ func (e *Engine) walkNetworking(ctx context.Context) ([]Resource, error) {
 		out = append(out, Resource{
 			Provider: e.provider, Service: ServiceNetworking, Type: TypePeeringConnection,
 			ID:     pc.ID,
-			ARN:    e.networkARN(netKindPeering, pc.ID),
+			ARN:    e.networkARN(netKindPeering, pc.ID, e.azureRGFromTags(pc.Tags)),
 			Region: e.region, Tags: copyTags(pc.Tags),
 		})
 	}
@@ -372,8 +419,8 @@ func (e *Engine) walkNetworking(ctx context.Context) ([]Resource, error) {
 		out = append(out, Resource{
 			Provider: e.provider, Service: ServiceNetworking, Type: TypeRouteTable,
 			ID:     rt.ID,
-			ARN:    e.networkARN(netKindRouteTable, rt.ID),
-			Region: e.region, Tags: copyTags(rt.Tags),
+			ARN:    e.networkARN(netKindRouteTable, rt.ID, e.azureRGFromTags(rt.Tags)),
+			Region: e.azureNetLocation(ctx, azMeta, netKindRouteTable, rt.ID), Tags: copyTags(rt.Tags),
 		})
 	}
 
@@ -410,7 +457,7 @@ func (e *Engine) walkNetworkInterfaces(ctx context.Context) ([]Resource, error) 
 		out = append(out, Resource{
 			Provider: e.provider, Service: ServiceNetworking, Type: TypeNetworkIface,
 			ID:     eni.ID,
-			ARN:    e.networkARN(netKindNetworkIface, eni.ID),
+			ARN:    e.networkARN(netKindNetworkIface, eni.ID, e.azureRGFromTags(eni.Tags)),
 			Region: e.region, Tags: copyTags(eni.Tags),
 		})
 	}
@@ -447,33 +494,53 @@ func (e *Engine) walkStorage(ctx context.Context) ([]Resource, error) {
 		res := Resource{
 			Provider: e.provider, Service: ServiceStorage, Type: TypeBucket,
 			ID:     b.Name,
-			ARN:    e.storageBucketARN(b.Name),
+			ARN:    e.storageBucketARN(b.Name, ""),
 			Region: region, Tags: tags,
 		}
 
-		// Optional capability: providers whose buckets carry storage-account
-		// attributes (Azure) project SKU/kind/access-tier for cost discovery.
-		// A non-nil error here is load-bearing: silently dropping it would leave
-		// the cost fields absent — the exact failure this projection closes — so
-		// propagate it rather than swallow.
-		if attrer, ok := e.drivers.Storage.(storagedriver.BucketAttributes); ok {
-			a, aErr := attrer.BucketAttributes(ctx, b.Name)
-			if aErr != nil {
-				return nil, fmt.Errorf("walkStorage attributes %q: %w", b.Name, aErr)
-			}
-
-			res.SKU = a.SKU
-			res.Kind = a.Kind
-
-			if a.AccessTier != "" {
-				res.Properties = map[string]any{"accessTier": a.AccessTier}
-			}
+		if err := e.applyStorageAttrs(ctx, &res, b.Name); err != nil {
+			return nil, err
 		}
 
 		out = append(out, res)
 	}
 
 	return out, nil
+}
+
+// applyStorageAttrs folds a bucket's optional storage-account attributes onto
+// res: SKU/kind/access-tier for cost discovery, plus (for Azure) the account's
+// real resource group and region — the cross-cloud bucket carries neither, so
+// these keep ARG / exportTemplate from reporting "default"/us-east-1. A non-nil
+// error is load-bearing (a silent drop would lose the cost fields), so it
+// propagates. Providers without the capability leave res unchanged.
+func (e *Engine) applyStorageAttrs(ctx context.Context, res *Resource, name string) error {
+	attrer, ok := e.drivers.Storage.(storagedriver.BucketAttributes)
+	if !ok {
+		return nil
+	}
+
+	a, err := attrer.BucketAttributes(ctx, name)
+	if err != nil {
+		return fmt.Errorf("walkStorage attributes %q: %w", name, err)
+	}
+
+	res.SKU = a.SKU
+	res.Kind = a.Kind
+
+	if a.ResourceGroup != "" {
+		res.ARN = e.storageBucketARN(name, a.ResourceGroup)
+	}
+
+	if a.Location != "" {
+		res.Region = a.Location
+	}
+
+	if a.AccessTier != "" {
+		res.Properties = map[string]any{"accessTier": a.AccessTier}
+	}
+
+	return nil
 }
 
 func (e *Engine) walkDatabase(ctx context.Context) ([]Resource, error) {
@@ -500,46 +567,67 @@ func (e *Engine) walkDatabase(ctx context.Context) ([]Resource, error) {
 		res := Resource{
 			Provider: e.provider, Service: ServiceDatabase, Type: TypeTable,
 			ID:     name,
-			ARN:    e.databaseTableARN(name),
+			ARN:    e.databaseTableARN(name, ""),
 			Region: e.region, Tags: tags,
 		}
 
-		// Optional capability: providers whose tables map to a richer account
-		// resource (Azure Cosmos DB) project the account's cost attributes.
-		// A non-nil error here is load-bearing: silently dropping it would leave
-		// the cost attributes absent — the exact failure this projection closes —
-		// so propagate it rather than swallow.
-		if attrer, ok := e.drivers.Database.(dbdriver.TableAttributes); ok {
-			a, aErr := attrer.TableAttributes(ctx, name)
-			if aErr != nil {
-				return nil, fmt.Errorf("walkDatabase attributes %q: %w", name, aErr)
-			}
-
-			res.Kind = a.Kind
-
-			props := map[string]any{}
-			putStr(props, "databaseAccountOfferType", a.OfferType)
-
-			if len(a.Capabilities) > 0 {
-				caps := make([]any, 0, len(a.Capabilities))
-				for _, c := range a.Capabilities {
-					caps = append(caps, map[string]any{"name": c})
-				}
-
-				props["capabilities"] = caps
-			}
-
-			if a.EnableFreeTier {
-				props["enableFreeTier"] = true
-			}
-
-			res.Properties = orNilProps(props)
+		if err := e.applyDatabaseAttrs(ctx, &res, name); err != nil {
+			return nil, err
 		}
 
 		out = append(out, res)
 	}
 
 	return out, nil
+}
+
+// applyDatabaseAttrs folds a table's optional account attributes onto res: kind,
+// offer type, capabilities and free-tier for cost discovery, plus (for Azure
+// Cosmos DB) the account's real resource group and region — the cross-cloud
+// table carries neither, so these keep ARG / exportTemplate from reporting
+// "default"/us-east-1. A non-nil error is load-bearing (a silent drop would lose
+// the cost attributes), so it propagates. Providers without the capability leave
+// res unchanged.
+func (e *Engine) applyDatabaseAttrs(ctx context.Context, res *Resource, name string) error {
+	attrer, ok := e.drivers.Database.(dbdriver.TableAttributes)
+	if !ok {
+		return nil
+	}
+
+	a, err := attrer.TableAttributes(ctx, name)
+	if err != nil {
+		return fmt.Errorf("walkDatabase attributes %q: %w", name, err)
+	}
+
+	res.Kind = a.Kind
+
+	if a.ResourceGroup != "" {
+		res.ARN = e.databaseTableARN(name, a.ResourceGroup)
+	}
+
+	if a.Location != "" {
+		res.Region = a.Location
+	}
+
+	props := map[string]any{}
+	putStr(props, "databaseAccountOfferType", a.OfferType)
+
+	if len(a.Capabilities) > 0 {
+		caps := make([]any, 0, len(a.Capabilities))
+		for _, c := range a.Capabilities {
+			caps = append(caps, map[string]any{"name": c})
+		}
+
+		props["capabilities"] = caps
+	}
+
+	if a.EnableFreeTier {
+		props["enableFreeTier"] = true
+	}
+
+	res.Properties = orNilProps(props)
+
+	return nil
 }
 
 func (e *Engine) walkServerless(ctx context.Context) ([]Resource, error) {


### PR DESCRIPTION
## Problem (A1)

Azure Resource Graph (`Microsoft.ResourceGraph/resources`), the generic resource-list, and `exportTemplate` reported the **wrong** `resourceGroup` and `location` for **non-compute** Azure resources:

- `services/resourcediscovery/arn.go` built every non-compute Azure ARN with the literal `azureDefaultResourceGroup = "default"`, so rows rendered `resourceGroup: "default"` regardless of where the resource actually lived.
- The walkers in `services/resourcediscovery/walkers.go` hardcoded `Region: e.region` (the engine default, `us-east-1`) for those same resources, so Azure rows rendered an **AWS-style** `location: "us-east-1"`.
- The internal ARM tag `cloudemu:azureName` (and the other `cloudemu:*` bookkeeping tags) leaked onto Azure rows — they were never stripped by the wire renderers.

Compute VMs (`inst.ResourceGroup`/`inst.Region`) and storage buckets (`b.Region`) already threaded real values; the other types did not.

## Fix

Thread the **real** per-resource resource group and region into the Azure rows, mirroring compute VMs, reading from where each type actually stores them:

- **Networking** — resource group from the ARM tags the wire handlers stamp (`cloudemu:azure*ResourceGroup`); region from the `AzureNetworkMetadata` type-asserted capability (`GetAzureVNetMetadata`/`GetAzureNSGMetadata`/`GetAzureRouteTableMetadata`) for VNet / NSG / route table.
- **Storage** & **Database (Cosmos)** — resource group and region from the existing `BucketAttributes` / `TableAttributes` projections (`AccountAttributes.ResourceGroup`/`.Location`).
- **Volumes (managed disks)** — resource group from the disk ARM tag; region from `VolumeInfo.Location`. Snapshots get the resource group from their ARM tag.
- The `*ARN` builders now take a `resourceGroup` argument; the Azure branch folds it into the id, the AWS/GCP branches ignore it.
- **Internal-tag stripping** — added `StripInternalTags` in `server/azure/resourcegraph` and applied it in `resourceToWire` (ARG + generic resource-list) and the resource-group `exportTemplate` path, so `cloudemu:*` tags never leak while real user tags are preserved.

### Left as-is (region not persisted by the emulator, noted for follow-up)
Public IP, NAT gateway, subnet, network interface, snapshot, serverless function and monitoring-alarm rows keep the engine region for `location` — those types do not store a per-resource region anywhere the walker can reach (the Azure wire handlers themselves fall back to `defaultLoc` for public IP). Their **resource group** is still fixed where an ARM tag exists (public IP / NAT gateway / snapshot). Faking a region was explicitly avoided.

## Blast radius — AWS/GCP unaffected

Every change is Azure-scoped or provider-gated: `azureRGFromTags` returns `""` for non-Azure providers, `azureNetLocation` returns `e.region` when the `AzureNetworkMetadata` capability is absent (AWS/GCP fail the type assertion), the AWS/GCP `*ARN` branches ignore the new `resourceGroup` argument, and `StripInternalTags` only removes the `cloudemu:` prefix that no AWS/GCP tag carries.

Verified green (byte-unchanged behavior):
- `server/aws/resourceexplorer2`, `server/aws/resourcegroupstaggingapi`, `server/aws/configservice`
- `server/gcp/cloudasset`
- full `./server/aws/...` and `./server/gcp/...` suites

## Test

Added `server/azure/resourcegraph/azure_row_correctness_test.go`: a real-SDK test that creates a VNet (via the live `armnetwork` client) under `rg-prod`/`westus2` and a VM (via `armcompute`), then queries through the live `armresourcegraph` client and asserts the VNet row reports `resourceGroup: "rg-prod"` and `location: "westus2"` (not `default`/`us-east-1`), its id embeds the real group, and neither the VNet nor the VM row carries any `cloudemu:*` tag while the real `env=prod` user tag survives.

## Gates
- `go build ./...` — clean
- `go test ./services/resourcediscovery/... ./server/azure/resourcegraph/... ./server/azure/resourcegroups/...` and all three providers' discovery paths — green
- `golangci-lint run ./services/resourcediscovery/... ./server/azure/resourcegraph/...` — zero new issues (baseline pre-existing issues unchanged)
