### PR TITLE
feat(azure-sql): Transparent Data Encryption (TDE)

### DIFF
--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -9192,6 +9192,21 @@
         ]
       },
       {
+        "name": "TransparentDataEncryptions",
+        "doc": "TransparentDataEncryptions is an OPTIONAL Azure SQL capability, discovered by",
+        "operations": [
+          {
+            "name": "GetTransparentDataEncryption"
+          },
+          {
+            "name": "ListTransparentDataEncryption"
+          },
+          {
+            "name": "SetTransparentDataEncryption"
+          }
+        ]
+      },
+      {
         "name": "Users",
         "doc": "Users is an OPTIONAL capability for managing database user accounts,",
         "operations": [

--- a/providers/azure/sql/databases.go
+++ b/providers/azure/sql/databases.go
@@ -65,6 +65,15 @@ func (m *Mock) CreateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 	}
 	m.databases.Set(key, db)
 
+	// Azure SQL databases are encrypted at rest by default: a create
+	// materializes the transparentDataEncryption/current sub-resource as
+	// Enabled so a Get on it round-trips without a separate PUT.
+	m.tde.Set(key, rdsdriver.TransparentDataEncryption{
+		Server:   cfg.Server,
+		Database: cfg.Name,
+		State:    rdsdriver.TDEStateEnabled,
+	})
+
 	out := db
 
 	return &out, nil
@@ -113,6 +122,8 @@ func (m *Mock) DeleteDatabase(_ context.Context, server, name string) error {
 	if !m.databases.Delete(dbKey(server, name)) {
 		return cerrors.Newf(cerrors.NotFound, "database %q not found on server %q", name, server)
 	}
+
+	m.tde.Delete(dbKey(server, name))
 
 	return nil
 }

--- a/providers/azure/sql/snapshot.go
+++ b/providers/azure/sql/snapshot.go
@@ -27,6 +27,7 @@ type sqlSnapshot struct {
 	ManagedInstances json.RawMessage `json:"managedInstances,omitempty"`
 	ManagedDatabases json.RawMessage `json:"managedDatabases,omitempty"`
 	Databases        json.RawMessage `json:"databases,omitempty"`
+	TDE              json.RawMessage `json:"tde,omitempty"`
 }
 
 // Snapshot captures the mock's entire state as JSON. includeAssets is unused —
@@ -56,6 +57,7 @@ func (m *Mock) snapshotStores(snap *sqlSnapshot) error {
 		{&snap.ManagedInstances, m.managedInstances.Snapshot},
 		{&snap.ManagedDatabases, m.managedDatabases.Snapshot},
 		{&snap.Databases, m.databases.Snapshot},
+		{&snap.TDE, m.tde.Snapshot},
 	}
 
 	for _, d := range dumps {
@@ -93,6 +95,7 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 		{snap.ManagedInstances, m.managedInstances.LoadSnapshot},
 		{snap.ManagedDatabases, m.managedDatabases.LoadSnapshot},
 		{snap.Databases, m.databases.LoadSnapshot},
+		{snap.TDE, m.tde.LoadSnapshot},
 	}
 
 	for _, l := range loads {

--- a/providers/azure/sql/snapshot_test.go
+++ b/providers/azure/sql/snapshot_test.go
@@ -25,6 +25,11 @@ func TestSnapshotRoundTripSQL(t *testing.T) {
 		t.Fatalf("create firewall rule: %v", err)
 	}
 
+	// A database auto-materializes a TDE record; both must survive the round-trip.
+	if _, err := src.CreateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "srv1", Name: "appdb"}); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
 	data, err := src.Snapshot(ctx, true)
 	requireNoError(t, err)
 
@@ -43,4 +48,8 @@ func TestSnapshotRoundTripSQL(t *testing.T) {
 	rules, err := dst.ListFirewallRules(ctx, "srv1")
 	requireNoError(t, err)
 	assertEqual(t, 1, len(rules))
+
+	tde, err := dst.GetTransparentDataEncryption(ctx, "srv1", "appdb")
+	requireNoError(t, err)
+	assertEqual(t, rdsdriver.TDEStateEnabled, tde.State)
 }

--- a/providers/azure/sql/sql.go
+++ b/providers/azure/sql/sql.go
@@ -73,6 +73,8 @@ type Mock struct {
 
 	// logical databases on a SQL server, key = "server/name"
 	databases *memstore.Store[rdsdriver.Database]
+	// transparent-data-encryption records, key = "server/database"
+	tde *memstore.Store[rdsdriver.TransparentDataEncryption]
 
 	opts       *config.Options
 	monitoring mondriver.Monitoring
@@ -90,6 +92,7 @@ func New(opts *config.Options) *Mock {
 		failoverGroups:   memstore.New[rdsdriver.FailoverGroup](),
 		aadAdmins:        memstore.New[rdsdriver.AADAdmin](),
 		databases:        memstore.New[rdsdriver.Database](),
+		tde:              memstore.New[rdsdriver.TransparentDataEncryption](),
 		managedInstances: memstore.New[rdsdriver.ManagedInstance](),
 		managedDatabases: memstore.New[rdsdriver.ManagedDatabase](),
 		opts:             opts,
@@ -580,6 +583,7 @@ func (m *Mock) deleteChildren(server string) {
 	prefix := server + "/"
 
 	deleteByPrefix(m.databases, prefix)
+	deleteByPrefix(m.tde, prefix)
 	deleteByPrefix(m.firewallRules, prefix)
 	deleteByPrefix(m.vnetRules, prefix)
 	deleteByPrefix(m.elasticPools, prefix)

--- a/providers/azure/sql/tde.go
+++ b/providers/azure/sql/tde.go
@@ -1,0 +1,71 @@
+package sql
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// SetTransparentDataEncryption sets the TDE state of a logical database,
+// implementing the relationaldb TransparentDataEncryptions optional capability.
+// It is the create-or-update for the transparentDataEncryption/current
+// sub-resource: the database must exist (real Azure answers 404 otherwise), and
+// an unset state defaults to Enabled to match Azure's encrypted-at-rest default.
+func (m *Mock) SetTransparentDataEncryption(
+	_ context.Context, cfg rdsdriver.TransparentDataEncryptionConfig,
+) (*rdsdriver.TransparentDataEncryption, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := dbKey(cfg.Server, cfg.Database)
+	if _, ok := m.databases.Get(key); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "database %q not found on server %q", cfg.Database, cfg.Server)
+	}
+
+	state := cfg.State
+	if state == "" {
+		state = rdsdriver.TDEStateEnabled
+	}
+
+	rec := rdsdriver.TransparentDataEncryption{Server: cfg.Server, Database: cfg.Database, State: state}
+	m.tde.Set(key, rec)
+
+	out := rec
+
+	return &out, nil
+}
+
+// GetTransparentDataEncryption returns a database's TDE state, or NotFound.
+func (m *Mock) GetTransparentDataEncryption(
+	_ context.Context, server, database string,
+) (*rdsdriver.TransparentDataEncryption, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	rec, ok := m.tde.Get(dbKey(server, database))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "database %q not found on server %q", database, server)
+	}
+
+	out := rec
+
+	return &out, nil
+}
+
+// ListTransparentDataEncryption returns a database's TDE records. Azure models
+// TDE as the single "current" sub-resource, so the list holds one entry (or is
+// empty when the database does not exist).
+func (m *Mock) ListTransparentDataEncryption(
+	_ context.Context, server, database string,
+) ([]rdsdriver.TransparentDataEncryption, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	out := []rdsdriver.TransparentDataEncryption{}
+	if rec, ok := m.tde.Get(dbKey(server, database)); ok {
+		out = append(out, rec)
+	}
+
+	return out, nil
+}

--- a/server/azure/sql/handler.go
+++ b/server/azure/sql/handler.go
@@ -39,6 +39,11 @@ const (
 	subFailoverGroups = "failoverGroups"
 	subAdministrators = "administrators"
 
+	// subTDE is the transparentDataEncryption sub-resource of a database; the
+	// trailing "/current" name segment is dropped by the 4-segment ParsePath, so
+	// it surfaces as rp.SubResourceAction under a database path.
+	subTDE = "transparentDataEncryption"
+
 	subMIStart    = "start"
 	subMIStop     = "stop"
 	subMIFailover = "failover"
@@ -165,6 +170,13 @@ func (h *Handler) serveDatabaseRoute(w http.ResponseWriter, r *http.Request, rp 
 
 		h.listDatabases(w, r, rp, db)
 
+		return
+	}
+
+	// .../databases/{d}/transparentDataEncryption[/current]: a database
+	// sub-resource, not a database verb.
+	if rp.SubResourceAction == subTDE {
+		h.serveTDE(w, r, rp)
 		return
 	}
 

--- a/server/azure/sql/tde.go
+++ b/server/azure/sql/tde.go
@@ -1,0 +1,125 @@
+package sql
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// tdeName is the only transparentDataEncryption sub-resource name Azure defines
+// ("current"), echoed on read responses.
+const tdeName = "current"
+
+func (h *Handler) transparentDataEncryption() (rdsdriver.TransparentDataEncryptions, bool) {
+	c, ok := h.db.(rdsdriver.TransparentDataEncryptions)
+	return c, ok
+}
+
+type armTDE struct {
+	ID         string     `json:"id,omitempty"`
+	Name       string     `json:"name,omitempty"`
+	Type       string     `json:"type,omitempty"`
+	Properties *armTDECfg `json:"properties,omitempty"`
+}
+
+type armTDECfg struct {
+	State string `json:"state,omitempty"`
+}
+
+// serveTDE handles the database transparentDataEncryption/current sub-resource.
+// Real Azure SQL TDE PUT is synchronous, so every verb returns 200 inline with
+// no LRO. There is no Delete — TDE cannot be removed, only toggled.
+func (h *Handler) serveTDE(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	tde, ok := h.transparentDataEncryption()
+	if !ok {
+		writeUnsupported(w, "transparentDataEncryption")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.putTDE(w, r, rp, tde)
+	case http.MethodGet:
+		// A path ending at .../transparentDataEncryption (no "/current" name) is
+		// the list; one with the name is a single Get. The name segment is
+		// dropped by ParsePath, so distinguish on the raw path.
+		if tdeIsCollection(r.URL.Path) {
+			h.listTDE(w, r, rp, tde)
+			return
+		}
+
+		h.getTDE(w, r, rp, tde)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+// tdeIsCollection reports whether urlPath addresses the transparentDataEncryption
+// collection (ListByDatabase) rather than the single "current" sub-resource.
+func tdeIsCollection(urlPath string) bool {
+	return strings.HasSuffix(strings.Trim(urlPath, "/"), "/"+subTDE)
+}
+
+func (*Handler) putTDE(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, tde rdsdriver.TransparentDataEncryptions,
+) {
+	var body armTDE
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	cfg := rdsdriver.TransparentDataEncryptionConfig{Server: rp.ResourceName, Database: rp.SubResourceName}
+	if body.Properties != nil {
+		cfg.State = body.Properties.State
+	}
+
+	out, err := tde.SetTransparentDataEncryption(r.Context(), cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMTDE(out, rp))
+}
+
+func (*Handler) getTDE(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, tde rdsdriver.TransparentDataEncryptions,
+) {
+	out, err := tde.GetTransparentDataEncryption(r.Context(), rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMTDE(out, rp))
+}
+
+func (*Handler) listTDE(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, tde rdsdriver.TransparentDataEncryptions,
+) {
+	items, err := tde.ListTransparentDataEncryption(r.Context(), rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]armTDE, 0, len(items))
+	for i := range items {
+		out = append(out, toARMTDE(&items[i], rp))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armList[armTDE]{Value: out})
+}
+
+func toARMTDE(t *rdsdriver.TransparentDataEncryption, rp *azurearm.ResourcePath) armTDE {
+	dbID := armDatabaseID(rp.Subscription, rp.ResourceGroup, t.Server, t.Database)
+
+	return armTDE{
+		ID:         dbID + "/" + subTDE + "/" + tdeName,
+		Name:       tdeName,
+		Type:       providerName + "/" + resourceServers + "/" + subResourceDatabases + "/" + subTDE,
+		Properties: &armTDECfg{State: t.State},
+	}
+}

--- a/server/azure/sql/tde_sdk_test.go
+++ b/server/azure/sql/tde_sdk_test.go
@@ -1,0 +1,108 @@
+package sql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
+)
+
+// seedTDEDatabase creates a server and database so the TDE sub-resource has a
+// parent, returning the factory's clients.
+func seedTDEDatabase(t *testing.T) *armsql.ClientFactory {
+	t.Helper()
+
+	cf := newFactory(t)
+	ctx := context.Background()
+
+	srvPoller, err := cf.NewServersClient().BeginCreateOrUpdate(ctx, "rg-1", "srv1", armsql.Server{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("Server BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := srvPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Server PollUntilDone: %v", err)
+	}
+
+	dbPoller, err := cf.NewDatabasesClient().BeginCreateOrUpdate(ctx, "rg-1", "srv1", "appdb", armsql.Database{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("DB BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := dbPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("DB PollUntilDone: %v", err)
+	}
+
+	return cf
+}
+
+func TestSDKAzureSQLTransparentDataEncryption(t *testing.T) {
+	cf := seedTDEDatabase(t)
+	tde := cf.NewTransparentDataEncryptionsClient()
+	ctx := context.Background()
+
+	// A freshly created database reports TDE Enabled without any explicit PUT.
+	got, err := tde.Get(ctx, "rg-1", "srv1", "appdb", armsql.TransparentDataEncryptionNameCurrent, nil)
+	if err != nil {
+		t.Fatalf("Get (auto-materialized): %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.State == nil {
+		t.Fatal("expected TDE state set")
+	}
+
+	if *got.Properties.State != armsql.TransparentDataEncryptionStateEnabled {
+		t.Fatalf("got state %q, want Enabled", *got.Properties.State)
+	}
+
+	if got.Name == nil || *got.Name != "current" {
+		t.Fatalf("got name %v, want current", got.Name)
+	}
+
+	// CreateOrUpdate is synchronous (no LRO): a single response, not a poller.
+	up, err := tde.CreateOrUpdate(ctx, "rg-1", "srv1", "appdb",
+		armsql.TransparentDataEncryptionNameCurrent,
+		armsql.LogicalDatabaseTransparentDataEncryption{
+			Properties: &armsql.TransparentDataEncryptionProperties{
+				State: to.Ptr(armsql.TransparentDataEncryptionStateEnabled),
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate: %v", err)
+	}
+
+	if up.Properties == nil || *up.Properties.State != armsql.TransparentDataEncryptionStateEnabled {
+		t.Fatal("expected Enabled on CreateOrUpdate response")
+	}
+
+	// The set state round-trips through a Get.
+	got, err = tde.Get(ctx, "rg-1", "srv1", "appdb", armsql.TransparentDataEncryptionNameCurrent, nil)
+	if err != nil {
+		t.Fatalf("Get after set: %v", err)
+	}
+
+	if *got.Properties.State != armsql.TransparentDataEncryptionStateEnabled {
+		t.Fatalf("got state %q after set, want Enabled", *got.Properties.State)
+	}
+
+	// ListByDatabase returns the single "current" record.
+	pager := tde.NewListByDatabasePager("rg-1", "srv1", "appdb", nil)
+
+	page, err := pager.NextPage(ctx)
+	if err != nil {
+		t.Fatalf("ListByDatabase: %v", err)
+	}
+
+	if len(page.Value) != 1 {
+		t.Fatalf("got %d TDE records, want 1", len(page.Value))
+	}
+
+	if page.Value[0].Name == nil || *page.Value[0].Name != "current" {
+		t.Fatalf("got list name %v, want current", page.Value[0].Name)
+	}
+}

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -592,6 +592,43 @@ type DatabaseUpdater interface {
 	UpdateDatabase(ctx context.Context, cfg DatabaseConfig) (*Database, error)
 }
 
+// Transparent-data-encryption states, matching Microsoft.Sql's
+// TransparentDataEncryptionState. Azure SQL databases are encrypted at rest by
+// default, so a freshly created database reports TDEStateEnabled.
+const (
+	TDEStateEnabled  = "Enabled"
+	TDEStateDisabled = "Disabled"
+)
+
+// TransparentDataEncryptionConfig sets a logical database's TDE state.
+type TransparentDataEncryptionConfig struct {
+	Server   string
+	Database string
+	State    string
+}
+
+// TransparentDataEncryption is a logical database's transparent-data-encryption
+// configuration. Azure models it as a single "current" sub-resource of the
+// database, so it is keyed by (server, database) and carries just the state.
+type TransparentDataEncryption struct {
+	Server   string
+	Database string
+	State    string
+}
+
+// TransparentDataEncryptions is an OPTIONAL Azure SQL capability, discovered by
+// type assertion. It exposes the database transparentDataEncryption/current
+// sub-resource (set/get/list). A TDE record is materialized as Enabled when a
+// database is created, so a database always has one. Drivers that do not
+// implement it answer InvalidAction.
+type TransparentDataEncryptions interface {
+	SetTransparentDataEncryption(
+		ctx context.Context, cfg TransparentDataEncryptionConfig,
+	) (*TransparentDataEncryption, error)
+	GetTransparentDataEncryption(ctx context.Context, server, database string) (*TransparentDataEncryption, error)
+	ListTransparentDataEncryption(ctx context.Context, server, database string) ([]TransparentDataEncryption, error)
+}
+
 // FirewallRuleConfig describes a server firewall rule to create or replace.
 type FirewallRuleConfig struct {
 	Server         string


### PR DESCRIPTION
## What

Adds Azure SQL **Transparent Data Encryption** (the `Microsoft.Sql/servers/databases/transparentDataEncryption/current` sub-resource) so real `armsql.TransparentDataEncryptionsClient` code works against the emulator.

- New optional `TransparentDataEncryptions` capability on the relationaldb driver (`Set`/`Get`/`List`), discovered by type assertion — the cross-cloud driver is **not** widened.
- A TDE record is **auto-materialized as `Enabled`** when a database is created, matching Azure's encrypted-at-rest default, so a `Get`/`List` round-trips with no explicit PUT.
- Wire handler branches on `rp.SubResourceAction == "transparentDataEncryption"` inside `serveDatabaseRoute`; the trailing `/current` name segment is safely dropped by the 4-segment `ParsePath`, and Get vs. ListByDatabase is disambiguated on the raw path suffix.

## Architecture-fit

- Follows the existing sql sub-resource pattern (firewallRules / elasticPools): a self-contained `server/azure/sql/tde.go` handler + a `providers/azure/sql/tde.go` backend on a new `memstore.Store` keyed `"server/database"`.
- **Sync-200, no LRO, no Delete** — real Azure SQL TDE PUT is synchronous (the SDK method is `CreateOrUpdate`, not `Begin…`; it accepts 200/201/202 and does not poll). A 202 would be wrong; TDE also cannot be deleted, only toggled.
- No new ARG triple: TDE is a settings sub-resource of an existing database, not a discoverable ARM resource type, so it needs no Resource Graph row.

## Persistence

The TDE store bolts onto the already-`Snapshottable` sql `Mock`, which the completeness guard does **not** deep-check — so it was added manually to the snapshot `dumps`/`loads` lists and the `sqlSnapshot` struct, and the round-trip is asserted in `snapshot_test.go`. Cascade cleanup is wired: `DeleteDatabase` drops the record, and the server-delete prefix cascade (`deleteChildren`) covers it, so an RG purge leaves no orphans.

## Test

- Real-SDK e2e (`server/azure/sql/tde_sdk_test.go`): a freshly-created DB reports `Enabled` with no PUT; `CreateOrUpdate(state=Enabled)` → `Get` round-trips; `ListByDatabase` returns the single `current` record.
- Provider snapshot round-trip covers the auto-materialized TDE record.

Refs #611.
