### PR TITLE
docs(coverage): regenerate for Service Bus session surface

### DIFF
--- a/docs/coverage/azure/queuestorage.md
+++ b/docs/coverage/azure/queuestorage.md
@@ -38,6 +38,17 @@ AzureQueueStorage is the Azure-specific Queue Storage data-plane surface,
 | `SetQueueMetadata` | SetQueueMetadata replaces the queue's user metadata. |
 | `UpdateMessage` | UpdateMessage updates a message's content (when body is non-nil) and its |
 
+### AzureSessionQueue
+
+AzureSessionQueue is the optional Azure Service Bus session surface, discovered
+
+| Operation | Description |
+| --- | --- |
+| `GetSessionState` | GetSessionState and SetSessionState read and write a session's opaque state. |
+| `ReceiveSession` | ReceiveSession returns up to maxMessages currently-visible messages for a |
+| `RenewSessionLock` | RenewSessionLock extends the session lock held by lockOwner. |
+| `SetSessionState` |  |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -6845,6 +6845,27 @@
             "doc": "UpdateMessage updates a message's content (when body is non-nil) and its"
           }
         ]
+      },
+      {
+        "name": "AzureSessionQueue",
+        "doc": "AzureSessionQueue is the optional Azure Service Bus session surface, discovered",
+        "operations": [
+          {
+            "name": "GetSessionState",
+            "doc": "GetSessionState and SetSessionState read and write a session's opaque state."
+          },
+          {
+            "name": "ReceiveSession",
+            "doc": "ReceiveSession returns up to maxMessages currently-visible messages for a"
+          },
+          {
+            "name": "RenewSessionLock",
+            "doc": "RenewSessionLock extends the session lock held by lockOwner."
+          },
+          {
+            "name": "SetSessionState"
+          }
+        ]
       }
     ],
     "providers": {


### PR DESCRIPTION
Mechanical `go run ./internal/coveragegen` regeneration. #904 added the `AzureSessionQueue` optional capability but did not regenerate `docs/coverage`, leaving it drifted on development. This syncs the generated coverage (`azure/queuestorage.md` + `coverage.json`) to the merged code. Generated output only — no hand edits.