### PR TITLE
feat(azure-compute): create managed image from a disk

### DIFF
--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -1819,6 +1819,8 @@ func containsPermission[T comparable](set []T, want T) bool {
 }
 
 // CreateImage creates a machine image from an instance.
+//
+//nolint:gocritic // hugeParam: cfg mirrors the driver-interface signature.
 func (m *Mock) CreateImage(_ context.Context, cfg driver.ImageConfig) (*driver.ImageInfo, error) {
 	if _, ok := m.instances.Get(cfg.InstanceID); !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "instance %q not found", cfg.InstanceID)

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -1250,9 +1250,18 @@ func (m *Mock) DescribeSnapshots(_ context.Context, ids []string) ([]driver.Snap
 	return describeResources(m.snapshots, ids), nil
 }
 
+//nolint:gocritic // hugeParam: cfg mirrors the driver-interface signature.
 func (m *Mock) CreateImage(_ context.Context, cfg driver.ImageConfig) (*driver.ImageInfo, error) {
-	if _, ok := m.instances.Get(cfg.InstanceID); !ok {
-		return nil, cerrors.Newf(cerrors.NotFound, "VM %q not found", cfg.InstanceID)
+	switch {
+	case cfg.InstanceID != "":
+		if _, ok := m.instances.Get(cfg.InstanceID); !ok {
+			return nil, cerrors.Newf(cerrors.NotFound, "VM %q not found", cfg.InstanceID)
+		}
+	case cfg.OSDiskID != "":
+		// Disk-sourced image: OSDiskID is the source disk's ARM ID, not a driver
+		// volume key, so the wire handler owns disk-existence validation.
+	default:
+		return nil, cerrors.New(cerrors.InvalidArgument, "image requires a source VM or OS disk")
 	}
 
 	id := fmt.Sprintf("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/images/img-%d",
@@ -1260,8 +1269,12 @@ func (m *Mock) CreateImage(_ context.Context, cfg driver.ImageConfig) (*driver.I
 
 	img := &driver.ImageInfo{
 		ID: id, Name: cfg.Name, State: stateAvailable, Description: cfg.Description,
-		CreatedAt: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
-		Tags:      copyTags(cfg.Tags),
+		CreatedAt:  m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		Tags:       copyTags(cfg.Tags),
+		OSDiskID:   cfg.OSDiskID,
+		OSType:     cfg.OSType,
+		OSState:    cfg.OSState,
+		DiskSizeGB: cfg.DiskSizeGB,
 	}
 	m.images.Set(id, img)
 

--- a/providers/azure/virtualmachines/vm_test.go
+++ b/providers/azure/virtualmachines/vm_test.go
@@ -1614,6 +1614,65 @@ func TestCreateImage(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})
+
+	t.Run("from disk", func(t *testing.T) {
+		m := newTestMock()
+
+		img, err := m.CreateImage(ctx, driver.ImageConfig{
+			Name:       "disk-image",
+			OSDiskID:   "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Compute/disks/os-disk",
+			OSType:     "Linux",
+			OSState:    "Generalized",
+			DiskSizeGB: 64,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, "disk-image", img.Name)
+		assert.Equal(t, "Linux", img.OSType)
+		assert.Equal(t, "Generalized", img.OSState)
+		assert.Equal(t, 64, img.DiskSizeGB)
+		assert.Contains(t, img.OSDiskID, "os-disk")
+	})
+
+	t.Run("no source", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateImage(ctx, driver.ImageConfig{Name: "no-source"})
+		require.Error(t, err)
+	})
+}
+
+// TestSnapshotRestoreDiskImageFields verifies the disk-sourced image fields
+// (OSDiskID/OSType/OSState/DiskSizeGB) survive a snapshot/restore round trip —
+// the images store is already in the mock's dumps list, so the new exported
+// ImageInfo fields must persist without an extra store entry.
+func TestSnapshotRestoreDiskImageFields(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	_, err := src.CreateImage(ctx, driver.ImageConfig{
+		Name:       "disk-image",
+		OSDiskID:   "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Compute/disks/os-disk",
+		OSType:     "Windows",
+		OSState:    "Specialized",
+		DiskSizeGB: 128,
+	})
+	require.NoError(t, err)
+
+	blob, err := src.Snapshot(ctx, false)
+	require.NoError(t, err)
+
+	dst := newTestMock()
+	require.NoError(t, dst.Restore(ctx, blob))
+
+	imgs, err := dst.DescribeImages(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, imgs, 1)
+
+	assert.Equal(t, "disk-image", imgs[0].Name)
+	assert.Contains(t, imgs[0].OSDiskID, "os-disk")
+	assert.Equal(t, "Windows", imgs[0].OSType)
+	assert.Equal(t, "Specialized", imgs[0].OSState)
+	assert.Equal(t, 128, imgs[0].DiskSizeGB)
 }
 
 func TestDeregisterImage(t *testing.T) {

--- a/providers/gcp/compute/gce.go
+++ b/providers/gcp/compute/gce.go
@@ -754,6 +754,7 @@ func (m *Mock) DescribeSnapshots(_ context.Context, ids []string) ([]driver.Snap
 	return describeResources(m.snapshots, ids), nil
 }
 
+//nolint:gocritic // hugeParam: cfg mirrors the driver-interface signature.
 func (m *Mock) CreateImage(_ context.Context, cfg driver.ImageConfig) (*driver.ImageInfo, error) {
 	// GCP images are created from a disk, snapshot, or import — not from a
 	// source instance. An empty InstanceID is one of those source-based paths,

--- a/server/azure/images/handler.go
+++ b/server/azure/images/handler.go
@@ -24,6 +24,11 @@ const (
 	// we can resolve a VM ARM ID to its driver-internal instance ID.
 	vmARMNameTag = "cloudemu:azureName"
 
+	// diskARMNameTag mirrors the constant in server/azure/disks so we can
+	// resolve a source-disk ARM ID to its stored volume when creating a
+	// managed image directly from a disk.
+	diskARMNameTag = "cloudemu:azureDiskName"
+
 	// defaultOSDiskSizeGB is the OS-disk size we report for a captured image
 	// when the source disk size is unknown (Azure's marketplace default).
 	defaultOSDiskSizeGB = 30
@@ -117,21 +122,10 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 		return
 	}
 
-	submittedVM := sourceVMID(req.Properties.SourceVirtualMachine)
-
-	driverInstanceID, err := h.resolveSourceVMID(r.Context(), submittedVM)
+	cfg, err := h.buildImageConfig(r.Context(), rp, &req)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
-	}
-
-	cfg := computedriver.ImageConfig{
-		InstanceID: driverInstanceID,
-		Name:       rp.ResourceName,
-		Tags: mergeTags(
-			req.Tags, rp.ResourceName, rp.ResourceGroup,
-			submittedVM, h.sourceOSType(r.Context(), driverInstanceID),
-		),
 	}
 
 	// ARM CreateOrUpdate is idempotent: replace an existing image in place
@@ -238,12 +232,150 @@ func (h *Handler) resolveSourceVMID(ctx context.Context, src string) (string, er
 	return "", cerrors.Newf(cerrors.NotFound, "source VM %s not found", name)
 }
 
+// buildImageConfig maps an ARM image request to a driver ImageConfig, choosing
+// the VM-capture path when sourceVirtualMachine is set and the disk-source path
+// when only storageProfile.osDisk.managedDisk.id is present.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) buildImageConfig(ctx context.Context, rp azurearm.ResourcePath, req *imageRequest) (computedriver.ImageConfig, error) {
+	submittedVM := sourceVMID(req.Properties.SourceVirtualMachine)
+	if submittedVM != "" {
+		driverInstanceID, err := h.resolveSourceVMID(ctx, submittedVM)
+		if err != nil {
+			return computedriver.ImageConfig{}, err
+		}
+
+		return computedriver.ImageConfig{
+			InstanceID: driverInstanceID,
+			Name:       rp.ResourceName,
+			Tags: mergeTags(
+				req.Tags, rp.ResourceName, rp.ResourceGroup,
+				submittedVM, h.sourceOSType(ctx, driverInstanceID),
+			),
+		}, nil
+	}
+
+	return h.diskImageConfig(ctx, rp, req)
+}
+
+// diskImageConfig builds the config for a managed image created directly from a
+// source OS disk (no VM capture). It validates the disk exists and captures its
+// size onto the image.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) diskImageConfig(ctx context.Context, rp azurearm.ResourcePath, req *imageRequest) (computedriver.ImageConfig, error) {
+	osDisk := osDiskOf(req.Properties.StorageProfile)
+
+	diskID := managedDiskID(osDisk)
+	if diskID == "" {
+		return computedriver.ImageConfig{}, cerrors.New(cerrors.InvalidArgument,
+			"sourceVirtualMachine.id or storageProfile.osDisk.managedDisk.id is required")
+	}
+
+	vol, err := h.resolveSourceDisk(ctx, diskID, rp.ResourceGroup)
+	if err != nil {
+		return computedriver.ImageConfig{}, err
+	}
+
+	return computedriver.ImageConfig{
+		Name:       rp.ResourceName,
+		OSDiskID:   diskID,
+		OSType:     osTypeOr(osDisk.OSType),
+		OSState:    osStateOr(osDisk.OSState),
+		DiskSizeGB: diskSizeOr(vol.Size, osDisk.DiskSizeGB),
+		Tags:       mergeTags(req.Tags, rp.ResourceName, rp.ResourceGroup, "", ""),
+	}, nil
+}
+
+// resolveSourceDisk finds the stored volume backing a source-disk ARM ID by its
+// ARM-tagged name, mirroring how disks/handler.go resolves a disk by name.
+func (h *Handler) resolveSourceDisk(ctx context.Context, diskID, resourceGroup string) (*computedriver.VolumeInfo, error) {
+	name := armSegment(diskID, "/disks/")
+	if name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "storageProfile.osDisk.managedDisk.id is malformed")
+	}
+
+	vols, err := h.compute.DescribeVolumes(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range vols {
+		if tagOr(vols[i].Tags, diskARMNameTag, "") != name {
+			continue
+		}
+
+		if resourceGroup != "" && tagOr(vols[i].Tags, rgTag, "") != resourceGroup {
+			continue
+		}
+
+		return &vols[i], nil
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "source disk %s not found", name)
+}
+
 func sourceVMID(r *resourceRef) string {
 	if r == nil {
 		return ""
 	}
 
 	return r.ID
+}
+
+func osDiskOf(sp *imageRequestStorageProfile) *imageRequestOSDisk {
+	if sp == nil {
+		return nil
+	}
+
+	return sp.OSDisk
+}
+
+func managedDiskID(d *imageRequestOSDisk) string {
+	if d == nil || d.ManagedDisk == nil {
+		return ""
+	}
+
+	return d.ManagedDisk.ID
+}
+
+// armSegment extracts the resource name that follows segment in an ARM ID
+// (e.g. the disk name after "/disks/").
+func armSegment(id, segment string) string {
+	idx := strings.LastIndex(id, segment)
+	if idx < 0 {
+		return ""
+	}
+
+	name := id[idx+len(segment):]
+	if i := strings.Index(name, "/"); i >= 0 {
+		name = name[:i]
+	}
+
+	return name
+}
+
+// osStateOr defaults an unspecified image OS state to Generalized, matching the
+// VM-capture default.
+func osStateOr(osState string) string {
+	if osState == "" {
+		return "Generalized"
+	}
+
+	return osState
+}
+
+// diskSizeOr prefers the actual source-disk size, falling back to a
+// client-supplied size and finally the marketplace default.
+func diskSizeOr(actual, requested int) int {
+	switch {
+	case actual > 0:
+		return actual
+	case requested > 0:
+		return requested
+	default:
+		return defaultOSDiskSizeGB
+	}
 }
 
 // sourceOSType returns the guest OS family of the source VM (driver instance
@@ -290,18 +422,15 @@ func toImageResponse(img *computedriver.ImageInfo, rp azurearm.ResourcePath, loc
 
 	props := imageResponseProps{
 		ProvisioningState: "Succeeded",
-		StorageProfile: &imageStorageProfile{
-			OSDisk: &imageOSDisk{
-				OSType:             osTypeOr(tagOr(img.Tags, osTypeTag, "")),
-				OSState:            "Generalized",
-				DiskSizeGB:         defaultOSDiskSizeGB,
-				StorageAccountType: "Standard_LRS",
-			},
-		},
+		StorageProfile:    &imageStorageProfile{OSDisk: osDiskResponse(img)},
 	}
 
-	if src := tagOr(img.Tags, sourceVMTag, ""); src != "" {
-		props.SourceVirtualMachine = &resourceRef{ID: src}
+	// A disk-sourced image has no sourceVirtualMachine; a VM-captured one echoes
+	// the captured VM reference exactly as before (byte-unchanged).
+	if img.OSDiskID == "" {
+		if src := tagOr(img.Tags, sourceVMTag, ""); src != "" {
+			props.SourceVirtualMachine = &resourceRef{ID: src}
+		}
 	}
 
 	return imageResponse{
@@ -311,6 +440,28 @@ func toImageResponse(img *computedriver.ImageInfo, rp azurearm.ResourcePath, loc
 		Location:   location,
 		Tags:       stripInternalTags(img.Tags),
 		Properties: props,
+	}
+}
+
+// osDiskResponse builds the image's osDisk echo. A disk-sourced image reports
+// its captured managedDisk and disk size; a VM-captured image keeps its prior
+// tag-derived shape byte-for-byte.
+func osDiskResponse(img *computedriver.ImageInfo) *imageOSDisk {
+	if img.OSDiskID != "" {
+		return &imageOSDisk{
+			OSType:             osTypeOr(img.OSType),
+			OSState:            osStateOr(img.OSState),
+			ManagedDisk:        &resourceRef{ID: img.OSDiskID},
+			DiskSizeGB:         img.DiskSizeGB,
+			StorageAccountType: "Standard_LRS",
+		}
+	}
+
+	return &imageOSDisk{
+		OSType:             osTypeOr(tagOr(img.Tags, osTypeTag, "")),
+		OSState:            "Generalized",
+		DiskSizeGB:         defaultOSDiskSizeGB,
+		StorageAccountType: "Standard_LRS",
 	}
 }
 

--- a/server/azure/images/image_from_disk_test.go
+++ b/server/azure/images/image_from_disk_test.go
@@ -1,0 +1,161 @@
+package images_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKImageFromDisk exercises creating a managed image directly from a source
+// OS disk (no sourceVirtualMachine) and verifies Get round-trips osType/osState/
+// diskSizeGB and the source managedDisk reference.
+func TestSDKImageFromDisk(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloudP.VirtualMachines,
+		Disks:           cloudP.VirtualMachines,
+		Images:          cloudP.VirtualMachines,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	// Create the source managed disk.
+	diskClient, err := armcompute.NewDisksClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diskPoller, err := diskClient.BeginCreateOrUpdate(ctx, "rg-1", "os-disk",
+		armcompute.Disk{
+			Location: to.Ptr("eastus"),
+			SKU:      &armcompute.DiskSKU{Name: to.Ptr(armcompute.DiskStorageAccountTypesPremiumLRS)},
+			Properties: &armcompute.DiskProperties{
+				CreationData: &armcompute.CreationData{CreateOption: to.Ptr(armcompute.DiskCreateOptionEmpty)},
+				DiskSizeGB:   to.Ptr[int32](64),
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("disk create: %v", err)
+	}
+
+	if _, err := diskPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("disk poll: %v", err)
+	}
+
+	diskID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/disks/os-disk"
+
+	// Create the image from that disk — no sourceVirtualMachine.
+	imgClient, err := armcompute.NewImagesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	imgPoller, err := imgClient.BeginCreateOrUpdate(ctx, "rg-1", "img-from-disk",
+		armcompute.Image{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.ImageProperties{
+				StorageProfile: &armcompute.ImageStorageProfile{
+					OSDisk: &armcompute.ImageOSDisk{
+						OSType:      to.Ptr(armcompute.OperatingSystemTypesLinux),
+						OSState:     to.Ptr(armcompute.OperatingSystemStateTypesGeneralized),
+						ManagedDisk: &armcompute.SubResource{ID: to.Ptr(diskID)},
+					},
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("img BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := imgPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("img poll: %v", err)
+	}
+
+	got, err := imgClient.Get(ctx, "rg-1", "img-from-disk", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	osDisk := got.Properties.StorageProfile.OSDisk
+	if osDisk == nil {
+		t.Fatal("storageProfile.osDisk missing on disk-sourced image")
+	}
+
+	if osDisk.OSType == nil || *osDisk.OSType != armcompute.OperatingSystemTypesLinux {
+		t.Errorf("osType=%v want Linux", osDisk.OSType)
+	}
+
+	if osDisk.OSState == nil || *osDisk.OSState != armcompute.OperatingSystemStateTypesGeneralized {
+		t.Errorf("osState=%v want Generalized", osDisk.OSState)
+	}
+
+	if osDisk.DiskSizeGB == nil || *osDisk.DiskSizeGB != 64 {
+		t.Errorf("diskSizeGB=%v want 64", osDisk.DiskSizeGB)
+	}
+
+	if osDisk.ManagedDisk == nil || osDisk.ManagedDisk.ID == nil || *osDisk.ManagedDisk.ID != diskID {
+		t.Errorf("managedDisk.id=%v want %s", osDisk.ManagedDisk, diskID)
+	}
+
+	// A disk-sourced image carries no VM capture reference.
+	if got.Properties.SourceVirtualMachine != nil {
+		t.Errorf("sourceVirtualMachine should be absent, got %v", got.Properties.SourceVirtualMachine)
+	}
+}
+
+// TestSDKImageFromDiskMissingDisk verifies creating an image from a disk that
+// does not exist fails rather than silently producing an empty image.
+func TestSDKImageFromDiskMissingDisk(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloudP.VirtualMachines,
+		Disks:           cloudP.VirtualMachines,
+		Images:          cloudP.VirtualMachines,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	imgClient, err := armcompute.NewImagesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	missing := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/disks/ghost"
+
+	poller, err := imgClient.BeginCreateOrUpdate(ctx, "rg-1", "img-ghost",
+		armcompute.Image{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.ImageProperties{
+				StorageProfile: &armcompute.ImageStorageProfile{
+					OSDisk: &armcompute.ImageOSDisk{
+						OSType:      to.Ptr(armcompute.OperatingSystemTypesLinux),
+						OSState:     to.Ptr(armcompute.OperatingSystemStateTypesGeneralized),
+						ManagedDisk: &armcompute.SubResource{ID: to.Ptr(missing)},
+					},
+				},
+			},
+		}, nil)
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	}
+
+	if err == nil {
+		t.Fatal("expected error creating image from a non-existent disk")
+	}
+}

--- a/server/azure/images/types.go
+++ b/server/azure/images/types.go
@@ -9,7 +9,21 @@ type imageRequest struct {
 }
 
 type imageRequestProps struct {
-	SourceVirtualMachine *resourceRef `json:"sourceVirtualMachine,omitempty"`
+	SourceVirtualMachine *resourceRef                `json:"sourceVirtualMachine,omitempty"`
+	StorageProfile       *imageRequestStorageProfile `json:"storageProfile,omitempty"`
+}
+
+// imageRequestStorageProfile carries the source OS disk for a managed image
+// created directly from a disk (no VM capture).
+type imageRequestStorageProfile struct {
+	OSDisk *imageRequestOSDisk `json:"osDisk,omitempty"`
+}
+
+type imageRequestOSDisk struct {
+	OSType      string       `json:"osType,omitempty"`
+	OSState     string       `json:"osState,omitempty"`
+	ManagedDisk *resourceRef `json:"managedDisk,omitempty"`
+	DiskSizeGB  int          `json:"diskSizeGB,omitempty"`
 }
 
 type resourceRef struct {
@@ -38,10 +52,11 @@ type imageStorageProfile struct {
 }
 
 type imageOSDisk struct {
-	OSType             string `json:"osType,omitempty"`
-	OSState            string `json:"osState,omitempty"`
-	DiskSizeGB         int    `json:"diskSizeGB,omitempty"`
-	StorageAccountType string `json:"storageAccountType,omitempty"`
+	OSType             string       `json:"osType,omitempty"`
+	OSState            string       `json:"osState,omitempty"`
+	ManagedDisk        *resourceRef `json:"managedDisk,omitempty"`
+	DiskSizeGB         int          `json:"diskSizeGB,omitempty"`
+	StorageAccountType string       `json:"storageAccountType,omitempty"`
 }
 
 type imageListResponse struct {

--- a/services/compute/compute.go
+++ b/services/compute/compute.go
@@ -435,6 +435,8 @@ func (c *Compute) DescribeSnapshots(ctx context.Context, ids []string) ([]driver
 }
 
 // CreateImage creates a machine image from an instance.
+//
+//nolint:gocritic // hugeParam: cfg mirrors the driver-interface signature.
 func (c *Compute) CreateImage(ctx context.Context, cfg driver.ImageConfig) (*driver.ImageInfo, error) {
 	out, err := c.do(ctx, "CreateImage", cfg, func() (any, error) { return c.driver.CreateImage(ctx, cfg) })
 	if err != nil {

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -481,6 +481,18 @@ type ImageConfig struct {
 	Name        string
 	Description string
 	Tags        map[string]string
+	// OSDiskID is the source OS managed-disk ID an image is created from
+	// directly (Azure managed-image-from-disk), an alternative to InstanceID /
+	// VM capture. Exactly one of InstanceID or OSDiskID is set.
+	OSDiskID string
+	// OSType is the guest OS family ("Linux"/"Windows") recorded on the image's
+	// OS disk when it is built from a disk (VM capture derives it from the VM).
+	OSType string
+	// OSState is the image OS state ("Generalized"/"Specialized") for a
+	// disk-sourced image.
+	OSState string
+	// DiskSizeGB is the source OS disk size captured onto a disk-sourced image.
+	DiskSizeGB int
 }
 
 // ImageInfo describes a machine image.
@@ -512,6 +524,17 @@ type ImageInfo struct {
 	// LaunchPermissions holds the launchPermission attribute set by
 	// ModifyImageAttribute (AMI sharing). Empty means private.
 	LaunchPermissions []ImageLaunchPermission
+	// OSDiskID is the source OS managed-disk ID an Azure image was created from
+	// directly (managed-image-from-disk). Empty for VM-captured images. The
+	// json tags on these Azure-only fields keep VM-captured images byte-stable
+	// in snapshots (zero values are omitted).
+	OSDiskID string `json:"osDiskId,omitempty"`
+	// OSType is the guest OS family recorded on a disk-sourced image's OS disk.
+	OSType string `json:"osType,omitempty"`
+	// OSState is the OS state ("Generalized"/"Specialized") of a disk-sourced image.
+	OSState string `json:"osState,omitempty"`
+	// DiskSizeGB is the OS disk size captured onto a disk-sourced image.
+	DiskSizeGB int `json:"diskSizeGB,omitempty"`
 }
 
 // ImageLaunchPermission is one launchPermission grant on an AMI: either a Group


### PR DESCRIPTION
## What

Adds a source-disk path for Azure managed images. Previously an image could only be created by capturing a VM (`sourceVirtualMachine`). This lets `armcompute` `ImagesClient` create a `Microsoft.Compute/images` directly from an existing managed disk via `storageProfile.osDisk.managedDisk.id`, with no VM involved.

- `driver.ImageConfig` / `ImageInfo` gain optional `OSDiskID` / `OSType` / `OSState` / `DiskSizeGB` — a disk-source alternative to `InstanceID`.
- The images handler branches: when `sourceVirtualMachine` is absent but `storageProfile.osDisk.managedDisk.id` is present, it resolves the disk by its ARM name (mirroring `disks/handler.go`), captures its size, and creates the image from the disk. The VM-capture branch is untouched.
- Response echoes the `storageProfile.osDisk` with `managedDisk`, `osType`, `osState`, `diskSizeGB`. Sync-200 (no LRO), matching the existing images poller contract.

## Architecture fit

- Additive-only: a VM-captured image is byte-unchanged when the new fields are absent — the new response fields (`managedDisk`, and the new `ImageInfo` json tags) are all `omitempty`, so old images serialize identically on the wire and in snapshots.
- ID-space discipline: `OSDiskID` holds the client-facing ARM disk ID (drift-safe echo); the wire handler owns disk-existence validation (the provider does not treat it as a driver key).
- The `hugeParam` gocritic nolint added to each `CreateImage` impl (AWS/GCP/Azure/portable) follows the existing interface-signature convention (`UpdateVolume` already carries it) — growing `ImageConfig` past 80 bytes trips it uniformly.

## Persistence note

The images store is already in the VM mock's snapshot dumps list, and the new `ImageInfo` fields are exported, so they persist automatically. Verified with a snapshot -> restore round-trip test asserting `OSDiskID`/`OSType`/`OSState`/`DiskSizeGB` survive.

## Test

- Real-SDK e2e (`armcompute` `DisksClient` + `ImagesClient`): create a disk, create an image from `managedDisk.id` (no `sourceVirtualMachine`) -> `Get` round-trips `osType`/`osState`/`diskSizeGB`/`managedDisk.id`, and `sourceVirtualMachine` is absent.
- Negative e2e: image-from-a-missing-disk fails rather than producing an empty image.
- Provider unit tests (from-disk, no-source error) + the snapshot round-trip test.
- Existing VM-capture SDK/wire tests still pass unchanged.

Ref #611.
