### PR TITLE
feat(azure-network): Public IP Prefixes

### DIFF
--- a/docs/coverage/azure/vnet.md
+++ b/docs/coverage/azure/vnet.md
@@ -116,6 +116,17 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | `UpsertAzureNSGRule` | UpsertAzureNSGRule creates or replaces a single custom security rule by |
 | `UpsertAzureVNetPeering` | UpsertAzureVNetPeering creates or replaces a single virtualNetworkPeerings |
 
+### AzurePublicIPPrefixes
+
+AzurePublicIPPrefixes is the Azure-only public-IP-prefix surface. Keyed by
+
+| Operation | Description |
+| --- | --- |
+| `DeleteAzurePublicIPPrefix` | DeleteAzurePublicIPPrefix removes the prefix, reporting whether it existed. |
+| `GetAzurePublicIPPrefix` | GetAzurePublicIPPrefix returns the prefix identified by (resourceGroup, name). |
+| `ListAzurePublicIPPrefixes` | ListAzurePublicIPPrefixes returns the prefixes in a resource group, or all |
+| `PutAzurePublicIPPrefix` | PutAzurePublicIPPrefix creates or replaces a prefix in place (a repeat |
+
 ### NetworkInterfaceAttacher
 
 NetworkInterfaceAttacher is the AWS-specific ENI attach surface

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -7349,6 +7349,28 @@
         ]
       },
       {
+        "name": "AzurePublicIPPrefixes",
+        "doc": "AzurePublicIPPrefixes is the Azure-only public-IP-prefix surface. Keyed by",
+        "operations": [
+          {
+            "name": "DeleteAzurePublicIPPrefix",
+            "doc": "DeleteAzurePublicIPPrefix removes the prefix, reporting whether it existed."
+          },
+          {
+            "name": "GetAzurePublicIPPrefix",
+            "doc": "GetAzurePublicIPPrefix returns the prefix identified by (resourceGroup, name)."
+          },
+          {
+            "name": "ListAzurePublicIPPrefixes",
+            "doc": "ListAzurePublicIPPrefixes returns the prefixes in a resource group, or all"
+          },
+          {
+            "name": "PutAzurePublicIPPrefix",
+            "doc": "PutAzurePublicIPPrefix creates or replaces a prefix in place (a repeat"
+          }
+        ]
+      },
+      {
         "name": "ClientVPN",
         "doc": "ClientVPN is an OPTIONAL AWS capability (type-asserted).",
         "operations": [

--- a/providers/azure/vnet/public_ip_prefix.go
+++ b/providers/azure/vnet/public_ip_prefix.go
@@ -1,0 +1,136 @@
+package vnet
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// Compile-time check that Mock serves the Azure public-IP-prefix surface.
+var _ driver.AzurePublicIPPrefixes = (*Mock)(nil)
+
+const (
+	// defaultPrefixLength is applied when a createOrUpdate omits prefixLength, so a
+	// prefix always resolves to a concrete CIDR.
+	defaultPrefixLength = 28
+	// octetMask masks a byte out of the block counter when composing the CIDR.
+	octetMask = 0xFF
+)
+
+// prefixKey composes the store key from the ARM addressing pair. Resource-group
+// names are case-insensitive in Azure, so it is lower-cased; the prefix name is
+// preserved as-is, mirroring asgKey.
+func prefixKey(resourceGroup, name string) string {
+	return strings.ToLower(resourceGroup) + "/" + name
+}
+
+// PutAzurePublicIPPrefix creates or replaces a prefix in place, keyed by
+// (resourceGroup, name). On create it allocates a deterministic CIDR of the
+// requested size; on an idempotent re-PUT it preserves the existing IPPrefix and
+// PrefixLength (both immutable in real Azure) and only refreshes the mutable
+// fields.
+//
+//nolint:gocritic // hugeParam: prefix mirrors the AzurePublicIPPrefixes driver signature.
+func (m *Mock) PutAzurePublicIPPrefix(
+	_ context.Context, prefix driver.AzurePublicIPPrefix,
+) driver.AzurePublicIPPrefix {
+	m.prefixMu.Lock()
+	defer m.prefixMu.Unlock()
+
+	key := prefixKey(prefix.ResourceGroup, prefix.Name)
+
+	stored := clonePrefix(prefix)
+
+	if existing, ok := m.azurePrefixes.Get(key); ok {
+		// Re-PUT: the synthesized CIDR and its length are immutable, so carry them
+		// forward rather than re-allocating a second block.
+		stored.IPPrefix = existing.IPPrefix
+		stored.PrefixLength = existing.PrefixLength
+	} else {
+		if stored.PrefixLength <= 0 {
+			stored.PrefixLength = defaultPrefixLength
+		}
+
+		stored.IPPrefix = m.allocatePrefixCIDR(stored.PrefixLength)
+	}
+
+	m.azurePrefixes.Set(key, stored)
+
+	return clonePrefix(stored)
+}
+
+// allocatePrefixCIDR hands out the next unused /24 from the 10.0.0.0/8 pool and
+// masks it to prefixLength, giving each prefix a distinct, aligned CIDR. The
+// counter is monotonic (deterministic, no randomness) and, since Azure IPv4
+// public-IP prefixes are /24–/31, the host bits always fit inside the last octet
+// so the .0 base is aligned. Caller holds prefixMu.
+func (m *Mock) allocatePrefixCIDR(prefixLength int32) string {
+	block := m.nextPrefixBlock
+	m.nextPrefixBlock++
+
+	return fmt.Sprintf("10.%d.%d.0/%d", (block>>8)&octetMask, block&octetMask, prefixLength)
+}
+
+// GetAzurePublicIPPrefix returns the prefix identified by (resourceGroup, name).
+func (m *Mock) GetAzurePublicIPPrefix(
+	_ context.Context, resourceGroup, name string,
+) (driver.AzurePublicIPPrefix, bool) {
+	prefix, ok := m.azurePrefixes.Get(prefixKey(resourceGroup, name))
+	if !ok {
+		return driver.AzurePublicIPPrefix{}, false
+	}
+
+	return clonePrefix(prefix), true
+}
+
+// DeleteAzurePublicIPPrefix removes the prefix, reporting whether it existed.
+func (m *Mock) DeleteAzurePublicIPPrefix(_ context.Context, resourceGroup, name string) bool {
+	return m.azurePrefixes.Delete(prefixKey(resourceGroup, name))
+}
+
+// ListAzurePublicIPPrefixes returns the prefixes in a resource group, or all when
+// resourceGroup is empty (subscription-wide list), ordered by key.
+func (m *Mock) ListAzurePublicIPPrefixes(
+	_ context.Context, resourceGroup string,
+) []driver.AzurePublicIPPrefix {
+	out := make([]driver.AzurePublicIPPrefix, 0)
+
+	values := m.azurePrefixes.SortedValues()
+	for i := range values {
+		if resourceGroup != "" && !strings.EqualFold(values[i].ResourceGroup, resourceGroup) {
+			continue
+		}
+
+		out = append(out, clonePrefix(values[i]))
+	}
+
+	return out
+}
+
+// clonePrefix deep-copies the tag map and zones slice so stored and returned
+// values never alias a caller's containers.
+//
+//nolint:gocritic // hugeParam: prefix mirrors the AzurePublicIPPrefixes driver signature.
+func clonePrefix(prefix driver.AzurePublicIPPrefix) driver.AzurePublicIPPrefix {
+	out := driver.AzurePublicIPPrefix{
+		Name:          prefix.Name,
+		ResourceGroup: prefix.ResourceGroup,
+		Location:      prefix.Location,
+		PrefixLength:  prefix.PrefixLength,
+		IPPrefix:      prefix.IPPrefix,
+		SKUName:       prefix.SKUName,
+		SKUTier:       prefix.SKUTier,
+	}
+
+	if len(prefix.Tags) > 0 {
+		out.Tags = copyTags(prefix.Tags)
+	}
+
+	if len(prefix.Zones) > 0 {
+		out.Zones = append([]string(nil), prefix.Zones...)
+	}
+
+	return out
+}

--- a/providers/azure/vnet/snapshot.go
+++ b/providers/azure/vnet/snapshot.go
@@ -37,6 +37,7 @@ type vnetSnapshot struct {
 	AzureRouteTableMeta json.RawMessage `json:"azureRouteTableMeta,omitempty"`
 	AzureVNetPeerings   json.RawMessage `json:"azureVnetPeerings,omitempty"`
 	AzureASGs           json.RawMessage `json:"azureAsgs,omitempty"`
+	AzurePrefixes       json.RawMessage `json:"azurePublicIpPrefixes,omitempty"`
 }
 
 // Snapshot captures the mock's entire state as JSON. includeAssets is unused —
@@ -74,6 +75,7 @@ func (m *Mock) snapshotStores(snap *vnetSnapshot) error {
 		{&snap.AzureRouteTableMeta, m.azureRouteTableMeta.Snapshot},
 		{&snap.AzureVNetPeerings, m.azureVNetPeerings.Snapshot},
 		{&snap.AzureASGs, m.azureASGs.Snapshot},
+		{&snap.AzurePrefixes, m.azurePrefixes.Snapshot},
 	}
 
 	for _, d := range dumps {
@@ -123,6 +125,7 @@ func (m *Mock) restoreStores(snap *vnetSnapshot) error {
 		{snap.AzureRouteTableMeta, m.azureRouteTableMeta.LoadSnapshot},
 		{snap.AzureVNetPeerings, m.azureVNetPeerings.LoadSnapshot},
 		{snap.AzureASGs, m.azureASGs.LoadSnapshot},
+		{snap.AzurePrefixes, m.azurePrefixes.LoadSnapshot},
 	}
 
 	for _, l := range loads {

--- a/providers/azure/vnet/snapshot_test.go
+++ b/providers/azure/vnet/snapshot_test.go
@@ -38,6 +38,11 @@ func TestSnapshotRestoreRoundTrip(t *testing.T) {
 		Name: "asg1", ResourceGroup: "rg1", Location: "eastus", Tags: map[string]string{"env": "prod"},
 	})
 
+	storedPrefix := src.PutAzurePublicIPPrefix(ctx, driver.AzurePublicIPPrefix{
+		Name: "pfx1", ResourceGroup: "rg1", Location: "eastus", PrefixLength: 28,
+		SKUName: "Standard", SKUTier: "Regional", Tags: map[string]string{"team": "net"},
+	})
+
 	data, err := src.Snapshot(ctx, true)
 	require.NoError(t, err)
 
@@ -70,6 +75,14 @@ func TestSnapshotRestoreRoundTrip(t *testing.T) {
 	asg, ok := dst.GetAzureApplicationSecurityGroup(ctx, "rg1", "asg1")
 	require.True(t, ok, "ASG must survive snapshot/restore")
 	assert.Equal(t, "prod", asg.Tags["env"])
+
+	// The public IP prefix survives with its synthesized CIDR and sku intact.
+	pfx, ok := dst.GetAzurePublicIPPrefix(ctx, "rg1", "pfx1")
+	require.True(t, ok, "public IP prefix must survive snapshot/restore")
+	assert.Equal(t, storedPrefix.IPPrefix, pfx.IPPrefix, "synthesized ipPrefix must round-trip")
+	assert.Equal(t, int32(28), pfx.PrefixLength)
+	assert.Equal(t, "Standard", pfx.SKUName)
+	assert.Equal(t, "net", pfx.Tags["team"])
 }
 
 // TestSnapshotEmpty confirms a fresh mock snapshots and restores without error.

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -82,11 +82,23 @@ type Mock struct {
 	// azureASGs holds the Azure-only application security groups (tag-like
 	// groupings with no cross-cloud equivalent), keyed by (resourceGroup, name).
 	azureASGs *memstore.Store[driver.AzureApplicationSecurityGroup]
+	// azurePrefixes holds the Azure-only public IP prefixes (a reserved CIDR range
+	// with no cross-cloud equivalent), keyed by (resourceGroup, name).
+	azurePrefixes *memstore.Store[driver.AzurePublicIPPrefix]
 	// nicMu serializes network-interface create/update, whose private-IP
 	// allocation is a read-modify-write across the nics store (memstore is
 	// per-op safe but can't make that sequence atomic).
 	nicMu sync.RWMutex
-	opts  *config.Options
+	// prefixMu serializes public-IP-prefix create/update: the CIDR allocation is a
+	// read-modify-write across nextPrefixBlock and the azurePrefixes store that
+	// memstore cannot make atomic on its own.
+	prefixMu sync.Mutex
+	// nextPrefixBlock is the monotonic /24 block index the CIDR allocator hands out.
+	// It is intentionally not serialized: each prefix persists its own synthesized
+	// IPPrefix, so a restore preserves every allocation, and the counter only needs
+	// to be unique within a running process.
+	nextPrefixBlock uint32
+	opts            *config.Options
 }
 
 // New creates a new Azure Virtual Network mock.
@@ -110,6 +122,7 @@ func New(opts *config.Options) *Mock {
 		azureRouteTableMeta: memstore.New[driver.AzureRouteTableMetadata](),
 		azureVNetPeerings:   memstore.New[[]driver.AzureVNetPeering](),
 		azureASGs:           memstore.New[driver.AzureApplicationSecurityGroup](),
+		azurePrefixes:       memstore.New[driver.AzurePublicIPPrefix](),
 		opts:                opts,
 	}
 }

--- a/server/azure/resourcegraph/handler.go
+++ b/server/azure/resourcegraph/handler.go
@@ -466,6 +466,7 @@ var portableToAzureTypeMap = map[string]string{ //nolint:gochecknoglobals // sta
 	"iam/Role":                            "microsoft.authorization/roledefinitions",
 	"networking/NatGateway":               "microsoft.network/natgateways",
 	"networking/ApplicationSecurityGroup": "microsoft.network/applicationsecuritygroups",
+	"networking/PublicIPPrefix":           "microsoft.network/publicipprefixes",
 	"networking/RouteTable":               "microsoft.network/routetables",
 	"networking/PeeringConnection":        "microsoft.network/virtualnetworks/virtualnetworkpeerings",
 	"machinelearningservices/Workspace":   "microsoft.machinelearningservices/workspaces",

--- a/server/azure/resourcegraph/kql.go
+++ b/server/azure/resourcegraph/kql.go
@@ -72,6 +72,7 @@ const (
 	azureTypeRoleDef   = "microsoft.authorization/roledefinitions"
 	azureTypeNATGw     = "microsoft.network/natgateways"
 	azureTypeASG       = "microsoft.network/applicationsecuritygroups"
+	azureTypePubIPPfx  = "microsoft.network/publicipprefixes"
 	azureTypeRouteTbl  = "microsoft.network/routetables"
 	azureTypeVNetPeer  = "microsoft.network/virtualnetworks/virtualnetworkpeerings"
 	azureTypeMLWorkspc = "microsoft.machinelearningservices/workspaces"
@@ -374,6 +375,7 @@ var azureToPortableType = map[string]portableResourceType{ //nolint:gochecknoglo
 	azureTypeRoleDef:   {portableIAM, "Role"},
 	azureTypeNATGw:     {portableNetworking, "NatGateway"},
 	azureTypeASG:       {portableNetworking, "ApplicationSecurityGroup"},
+	azureTypePubIPPfx:  {portableNetworking, "PublicIPPrefix"},
 	azureTypeRouteTbl:  {portableNetworking, "RouteTable"},
 	azureTypeVNetPeer:  {portableNetworking, "PeeringConnection"},
 	azureTypeMLWorkspc: {portableAzureML, "Workspace"},

--- a/server/azure/vnet/application_security_group.go
+++ b/server/azure/vnet/application_security_group.go
@@ -51,7 +51,7 @@ func (h *Handler) asgCap() (netdriver.AzureApplicationSecurityGroups, bool) {
 // ApplicationSecurityGroupsClient pollers complete on a synchronous terminal
 // 200, so create/get/delete all answer sync-200 (no 202 async plumbing).
 //
-//nolint:gocritic // rp is a request-scoped value
+//nolint:gocritic,dupl // rp is request-scoped; capability-gated dispatch mirrored by routePublicIPPrefix over a distinct type
 func (h *Handler) routeASG(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	svc, ok := h.asgCap()
 	if !ok {

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -107,7 +107,7 @@ func (*Handler) Matches(r *http.Request) bool {
 	}
 
 	switch rp.ResourceType {
-	case typeVNet, typeNSG, typeRouteTable, typePublicIP, typeNIC, typeNATGateway, typeASG, typeLocations:
+	case typeVNet, typeNSG, typeRouteTable, typePublicIP, typePublicIPPrefix, typeNIC, typeNATGateway, typeASG, typeLocations:
 		return true
 	}
 
@@ -126,6 +126,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.routeByResourceType(w, r, rp)
+}
+
+// routeByResourceType dispatches to the per-type router. Split out of ServeHTTP
+// so the dispatch stays under the cyclomatic-complexity gate as resource types
+// are added (the same reason serveLocationsOperationStatus is separate).
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) routeByResourceType(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	switch rp.ResourceType {
 	case typeVNet:
 		h.routeVNet(w, r, rp)
@@ -135,6 +144,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.routeRouteTable(w, r, rp)
 	case typePublicIP:
 		h.routePublicIP(w, r, rp)
+	case typePublicIPPrefix:
+		h.routePublicIPPrefix(w, r, rp)
 	case typeNIC:
 		h.routeNIC(w, r, rp)
 	case typeNATGateway:
@@ -629,6 +640,7 @@ func (h *Handler) PurgeResourceGroup(ctx context.Context, _, resourceGroup strin
 	recordErr(h.purgeNSGs(ctx, resourceGroup))
 	recordErr(h.purgeRouteTables(ctx, resourceGroup))
 	h.purgeASGs(ctx, resourceGroup)
+	h.purgePublicIPPrefixes(ctx, resourceGroup)
 
 	return firstErr
 }
@@ -1364,6 +1376,13 @@ func (h *Handler) createPublicIP(w http.ResponseWriter, r *http.Request, rp azur
 	tags := mergeTags(req.Tags, armPublicIPTag, rp.ResourceName)
 	tags = mergeTags(tags, armPublicIPRGTag, rp.ResourceGroup)
 
+	// A public IP may be drawn from a public IP prefix. The mock only records the
+	// reference (deferred child-IP allocation); the prefix rebuilds its read-only
+	// publicIPAddresses[] back-reference by scanning for this internal tag.
+	if req.Properties.PublicIPPrefix != nil && req.Properties.PublicIPPrefix.ID != "" {
+		tags = mergeTags(tags, armPublicIPPrefixTag, req.Properties.PublicIPPrefix.ID)
+	}
+
 	cfg := netdriver.ElasticIPConfig{
 		SKU:                sku,
 		AllocationMethod:   req.Properties.PublicIPAllocationMethod,
@@ -1868,6 +1887,10 @@ func (h *Handler) toPublicIPResponse(
 	}
 
 	out.Properties.IPConfiguration = h.publicIPConfigurationRef(ctx, rp.Subscription, id)
+
+	if prefixID := tagOr(info.Tags, armPublicIPPrefixTag, ""); prefixID != "" {
+		out.Properties.PublicIPPrefix = &armIDRef{ID: prefixID}
+	}
 
 	return out
 }

--- a/server/azure/vnet/public_ip_prefix.go
+++ b/server/azure/vnet/public_ip_prefix.go
@@ -1,0 +1,280 @@
+package vnet
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+const (
+	// typePublicIPPrefix is the Microsoft.Network resource type for public IP prefixes.
+	typePublicIPPrefix = "publicIPPrefixes"
+	// armPublicIPPrefixTag records, on a public IP, the ARM id of the prefix it was
+	// carved from. It is internal (cloudemu: prefix) so stripInternal keeps it out
+	// of the public IP's own tags; the prefix's read-only publicIPAddresses[]
+	// back-reference is rebuilt by scanning public IPs for it.
+	armPublicIPPrefixTag = "cloudemu:azurePublicIPPrefixId"
+)
+
+// ARM JSON shapes for Microsoft.Network/publicIPPrefixes. The sku is TOP-LEVEL
+// (not nested under properties), matching the armnetwork PublicIPPrefix model.
+
+type publicIPPrefixRequest struct {
+	Location   string                 `json:"location"`
+	Tags       map[string]string      `json:"tags,omitempty"`
+	SKU        *publicIPPrefixSKU     `json:"sku,omitempty"`
+	Zones      []string               `json:"zones,omitempty"`
+	Properties publicIPPrefixReqProps `json:"properties"`
+}
+
+type publicIPPrefixSKU struct {
+	Name string `json:"name,omitempty"`
+	Tier string `json:"tier,omitempty"`
+}
+
+type publicIPPrefixReqProps struct {
+	PrefixLength int32 `json:"prefixLength,omitempty"`
+}
+
+type publicIPPrefixResponse struct {
+	ID         string                  `json:"id"`
+	Name       string                  `json:"name"`
+	Type       string                  `json:"type"`
+	Location   string                  `json:"location"`
+	Tags       map[string]string       `json:"tags,omitempty"`
+	SKU        *publicIPPrefixSKU      `json:"sku,omitempty"`
+	Zones      []string                `json:"zones,omitempty"`
+	Etag       string                  `json:"etag,omitempty"`
+	Properties publicIPPrefixRespProps `json:"properties"`
+}
+
+type publicIPPrefixRespProps struct {
+	ProvisioningState string `json:"provisioningState"`
+	PrefixLength      int32  `json:"prefixLength,omitempty"`
+	IPPrefix          string `json:"ipPrefix,omitempty"`
+	// PublicIPAddresses is read-only: a public IP joins a prefix by setting its own
+	// publicIPPrefix property, so this list is rebuilt by scanning public IPs that
+	// reference this prefix, never written directly.
+	PublicIPAddresses []armIDRef `json:"publicIPAddresses,omitempty"`
+}
+
+type publicIPPrefixListResponse struct {
+	Value []publicIPPrefixResponse `json:"value"`
+}
+
+// prefixCap returns the public-IP-prefix surface if the networking driver
+// implements it (the Azure provider does; AWS/GCP do not).
+func (h *Handler) prefixCap() (netdriver.AzurePublicIPPrefixes, bool) {
+	svc, ok := h.net.(netdriver.AzurePublicIPPrefixes)
+
+	return svc, ok
+}
+
+// routePublicIPPrefix dispatches Microsoft.Network/publicIPPrefixes requests.
+// armnetwork's PublicIPPrefixesClient uses BeginCreateOrUpdate / BeginDelete
+// pollers, so PUT and DELETE ride the shared async plumbing (writeAcceptedAsync +
+// the locations/operationStatuses responder) exactly like NAT gateways.
+//
+//nolint:gocritic,dupl // rp is request-scoped; mirrors routeASG's capability-gated dispatch over a distinct resource type
+func (h *Handler) routePublicIPPrefix(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	svc, ok := h.prefixCap()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"public IP prefixes are not supported by this networking driver")
+
+		return
+	}
+
+	if rp.ResourceName == "" {
+		h.listPublicIPPrefixes(w, r, rp, svc)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createPublicIPPrefix(w, r, rp, svc)
+	case http.MethodGet:
+		h.getPublicIPPrefix(w, r, rp, svc)
+	case http.MethodDelete:
+		h.deletePublicIPPrefix(w, r, rp, svc)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) createPublicIPPrefix(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzurePublicIPPrefixes,
+) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	var req publicIPPrefixRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	loc := req.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	prefix := netdriver.AzurePublicIPPrefix{
+		Name:          rp.ResourceName,
+		ResourceGroup: rp.ResourceGroup,
+		Location:      loc,
+		Tags:          req.Tags,
+		Zones:         req.Zones,
+		PrefixLength:  req.Properties.PrefixLength,
+	}
+
+	if req.SKU != nil {
+		prefix.SKUName = req.SKU.Name
+		prefix.SKUTier = req.SKU.Tier
+	}
+
+	stored := svc.PutAzurePublicIPPrefix(r.Context(), prefix)
+
+	writeAcceptedAsync(w, r, rp.Subscription, "pipprefix-create-"+rp.ResourceName,
+		h.publicIPPrefixResponse(r.Context(), stored, rp))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getPublicIPPrefix(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzurePublicIPPrefixes,
+) {
+	prefix, ok := svc.GetAzurePublicIPPrefix(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"public IP prefix "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, h.publicIPPrefixResponse(r.Context(), prefix, rp))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) deletePublicIPPrefix(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzurePublicIPPrefixes,
+) {
+	// A missing prefix deletes idempotently; either way the poller completes on
+	// the async operationStatuses Succeeded, matching armnetwork's BeginDelete.
+	svc.DeleteAzurePublicIPPrefix(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	writeAcceptedAsync(w, r, rp.Subscription, "pipprefix-delete-"+rp.ResourceName, nil)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listPublicIPPrefixes(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzurePublicIPPrefixes,
+) {
+	// An empty ResourceGroup in the path means a subscription-wide list.
+	prefixes := svc.ListAzurePublicIPPrefixes(r.Context(), rp.ResourceGroup)
+
+	out := publicIPPrefixListResponse{Value: make([]publicIPPrefixResponse, 0, len(prefixes))}
+
+	for i := range prefixes {
+		scope := rp
+		scope.ResourceGroup = prefixes[i].ResourceGroup
+		scope.ResourceName = prefixes[i].Name
+		out.Value = append(out.Value, h.publicIPPrefixResponse(r.Context(), prefixes[i], scope))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) publicIPPrefixResponse(
+	ctx context.Context, prefix netdriver.AzurePublicIPPrefix, rp azurearm.ResourcePath,
+) publicIPPrefixResponse {
+	loc := prefix.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typePublicIPPrefix, rp.ResourceName)
+
+	out := publicIPPrefixResponse{
+		ID:       id,
+		Name:     rp.ResourceName,
+		Type:     providerName + "/" + typePublicIPPrefix,
+		Location: loc,
+		Tags:     prefix.Tags,
+		Zones:    prefix.Zones,
+		Etag:     etagOf(id),
+		Properties: publicIPPrefixRespProps{
+			ProvisioningState: provisioningSucceeded,
+			PrefixLength:      prefix.PrefixLength,
+			IPPrefix:          prefix.IPPrefix,
+			PublicIPAddresses: h.prefixPublicIPRefs(ctx, id),
+		},
+	}
+
+	if prefix.SKUName != "" || prefix.SKUTier != "" {
+		out.SKU = &publicIPPrefixSKU{Name: prefix.SKUName, Tier: prefix.SKUTier}
+	}
+
+	return out
+}
+
+// prefixPublicIPRefs scans public IPs for the ones carved from this prefix (their
+// armPublicIPPrefixTag matches the prefix ARM id), building each public IP's own
+// ARM resource id. This is the read-only publicIPAddresses[] back-reference; a
+// public IP created with a publicIPPrefix ref only stores the ref (child-IP
+// allocation from the prefix range is deferred).
+func (h *Handler) prefixPublicIPRefs(ctx context.Context, prefixARMID string) []armIDRef {
+	eips, err := h.net.DescribeAddresses(ctx, nil)
+	if err != nil {
+		return nil
+	}
+
+	var out []armIDRef
+
+	for i := range eips {
+		if tagOr(eips[i].Tags, armPublicIPPrefixTag, "") != prefixARMID {
+			continue
+		}
+
+		pipName := tagOr(eips[i].Tags, armPublicIPTag, "")
+		if pipName == "" {
+			continue
+		}
+
+		pipRG := tagOr(eips[i].Tags, armPublicIPRGTag, "")
+		id := azurearm.BuildResourceID(prefixSubscription(prefixARMID), pipRG, providerName, typePublicIP, pipName)
+		out = append(out, armIDRef{ID: id})
+	}
+
+	return out
+}
+
+// prefixSubscription extracts the subscription id from a prefix ARM id so the
+// public IP back-references share the same subscription. The id shape is
+// /subscriptions/{sub}/resourceGroups/... — a malformed id yields "".
+func prefixSubscription(armID string) string {
+	rp, ok := azurearm.ParsePath(armID)
+	if !ok {
+		return ""
+	}
+
+	return rp.Subscription
+}
+
+// purgePublicIPPrefixes deletes every public IP prefix in the resource group,
+// part of the PurgeResourceGroup cascade so prefixes don't orphan on RG delete.
+func (h *Handler) purgePublicIPPrefixes(ctx context.Context, resourceGroup string) {
+	svc, ok := h.prefixCap()
+	if !ok {
+		return
+	}
+
+	prefixes := svc.ListAzurePublicIPPrefixes(ctx, resourceGroup)
+	for i := range prefixes {
+		svc.DeleteAzurePublicIPPrefix(ctx, prefixes[i].ResourceGroup, prefixes[i].Name)
+	}
+}

--- a/server/azure/vnet/public_ip_prefix_test.go
+++ b/server/azure/vnet/public_ip_prefix_test.go
@@ -1,0 +1,203 @@
+package vnet_test
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// TestSDKPublicIPPrefixRoundTrip drives the real armnetwork PublicIPPrefixesClient
+// through its Begin* pollers: create synthesizes an ipPrefix CIDR of the requested
+// size, get/list round-trip it with the top-level sku, and delete makes a
+// subsequent get 404. Every op used to fall through to the vnet 501 default.
+func TestSDKPublicIPPrefixRoundTrip(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	client, err := armnetwork.NewPublicIPPrefixesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const prefixLength = int32(28)
+
+	cp, err := client.BeginCreateOrUpdate(ctx, "rg-1", "pfx-1", armnetwork.PublicIPPrefix{
+		Location: to.Ptr("eastus"),
+		SKU: &armnetwork.PublicIPPrefixSKU{
+			Name: to.Ptr(armnetwork.PublicIPPrefixSKUNameStandard),
+			Tier: to.Ptr(armnetwork.PublicIPPrefixSKUTierRegional),
+		},
+		Properties: &armnetwork.PublicIPPrefixPropertiesFormat{
+			PrefixLength: to.Ptr(prefixLength),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	created := pollDone(t, cp)
+
+	if created.Name == nil || *created.Name != "pfx-1" {
+		t.Fatalf("name=%v want pfx-1", created.Name)
+	}
+
+	if created.Properties == nil || created.Properties.IPPrefix == nil {
+		t.Fatalf("missing synthesized ipPrefix: %+v", created.Properties)
+	}
+
+	assertPrefixSize(t, *created.Properties.IPPrefix, prefixLength)
+
+	if created.Properties.PrefixLength == nil || *created.Properties.PrefixLength != prefixLength {
+		t.Errorf("prefixLength=%v want %d", created.Properties.PrefixLength, prefixLength)
+	}
+
+	if created.SKU == nil || created.SKU.Name == nil || *created.SKU.Name != armnetwork.PublicIPPrefixSKUNameStandard {
+		t.Errorf("sku name=%v want Standard", created.SKU)
+	}
+
+	if created.SKU == nil || created.SKU.Tier == nil || *created.SKU.Tier != armnetwork.PublicIPPrefixSKUTierRegional {
+		t.Errorf("sku tier=%v want Regional", created.SKU)
+	}
+
+	// GET round-trips the synthesized CIDR unchanged.
+	got, err := client.Get(ctx, "rg-1", "pfx-1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.IPPrefix == nil ||
+		*got.Properties.IPPrefix != *created.Properties.IPPrefix {
+		t.Errorf("get ipPrefix=%v want %v", got.Properties, *created.Properties.IPPrefix)
+	}
+
+	// LIST includes the prefix.
+	pager := client.NewListPager("rg-1", nil)
+
+	var names []string
+
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("list: %v", perr)
+		}
+
+		for _, p := range page.Value {
+			if p.Name != nil {
+				names = append(names, *p.Name)
+			}
+		}
+	}
+
+	if len(names) != 1 || names[0] != "pfx-1" {
+		t.Errorf("list=%v want [pfx-1]", names)
+	}
+
+	// DELETE, then GET should 404.
+	dp, err := client.BeginDelete(ctx, "rg-1", "pfx-1", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete: %v", err)
+	}
+
+	pollDone(t, dp)
+
+	_, err = client.Get(ctx, "rg-1", "pfx-1", nil)
+	if err == nil {
+		t.Fatal("Get after delete: want error, got nil")
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Errorf("Get after delete: want 404, got %v", err)
+	}
+}
+
+// TestSDKPublicIPPrefixPublicIPBackReference verifies the read-only
+// publicIPAddresses[] back-reference: a public IP created with a publicIPPrefix
+// ref shows up on the prefix's GET, and the public IP echoes the prefix.
+func TestSDKPublicIPPrefixPublicIPBackReference(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	prefixes, err := armnetwork.NewPublicIPPrefixesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp, err := prefixes.BeginCreateOrUpdate(ctx, "rg-1", "pfx-ref", armnetwork.PublicIPPrefix{
+		Location:   to.Ptr("eastus"),
+		SKU:        &armnetwork.PublicIPPrefixSKU{Name: to.Ptr(armnetwork.PublicIPPrefixSKUNameStandard)},
+		Properties: &armnetwork.PublicIPPrefixPropertiesFormat{PrefixLength: to.Ptr(int32(30))},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create prefix: %v", err)
+	}
+
+	pollDone(t, cp)
+
+	prefixID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/publicIPPrefixes/pfx-ref"
+
+	pips, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pp, err := pips.BeginCreateOrUpdate(ctx, "rg-1", "pip-from-pfx", armnetwork.PublicIPAddress{
+		Location: to.Ptr("eastus"),
+		SKU:      &armnetwork.PublicIPAddressSKU{Name: to.Ptr(armnetwork.PublicIPAddressSKUNameStandard)},
+		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+			PublicIPPrefix:           &armnetwork.SubResource{ID: to.Ptr(prefixID)},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create pip: %v", err)
+	}
+
+	createdPIP := pollDone(t, pp)
+
+	// The public IP echoes the prefix it was drawn from.
+	if createdPIP.Properties == nil || createdPIP.Properties.PublicIPPrefix == nil ||
+		createdPIP.Properties.PublicIPPrefix.ID == nil || *createdPIP.Properties.PublicIPPrefix.ID != prefixID {
+		t.Errorf("pip publicIPPrefix=%v want %s", createdPIP.Properties, prefixID)
+	}
+
+	// The prefix's read-only publicIPAddresses[] lists the public IP.
+	got, err := prefixes.Get(ctx, "rg-1", "pfx-ref", nil)
+	if err != nil {
+		t.Fatalf("get prefix: %v", err)
+	}
+
+	pipID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/publicIPAddresses/pip-from-pfx"
+
+	if got.Properties == nil || len(got.Properties.PublicIPAddresses) != 1 ||
+		got.Properties.PublicIPAddresses[0].ID == nil || *got.Properties.PublicIPAddresses[0].ID != pipID {
+		t.Errorf("prefix publicIPAddresses=%+v want [%s]", got.Properties, pipID)
+	}
+}
+
+// assertPrefixSize checks the CIDR mask equals prefixLength and the address is a
+// well-formed dotted quad.
+func assertPrefixSize(t *testing.T, cidr string, prefixLength int32) {
+	t.Helper()
+
+	addr, mask, ok := strings.Cut(cidr, "/")
+	if !ok {
+		t.Fatalf("ipPrefix %q is not a CIDR", cidr)
+	}
+
+	if mask != strconv.Itoa(int(prefixLength)) {
+		t.Errorf("ipPrefix %q mask=%s want /%d", cidr, mask, prefixLength)
+	}
+
+	if strings.Count(addr, ".") != 3 {
+		t.Errorf("ipPrefix %q address is not a dotted quad", cidr)
+	}
+}

--- a/server/azure/vnet/types.go
+++ b/server/azure/vnet/types.go
@@ -176,6 +176,10 @@ type publicIPReqProps struct {
 	PublicIPAllocationMethod string                  `json:"publicIPAllocationMethod,omitempty"`
 	IdleTimeoutInMinutes     int                     `json:"idleTimeoutInMinutes,omitempty"`
 	DNSSettings              *publicIPDNSSettingsReq `json:"dnsSettings,omitempty"`
+	// PublicIPPrefix is the optional prefix a public IP is drawn from. The mock
+	// only stores the reference (child-IP allocation from the prefix range is
+	// deferred); the prefix's publicIPAddresses[] back-reference is rebuilt from it.
+	PublicIPPrefix *armIDRef `json:"publicIPPrefix,omitempty"`
 }
 
 type publicIPDNSSettingsReq struct {
@@ -202,6 +206,9 @@ type publicIPRespProps struct {
 	// IPConfiguration is the back-reference to the NIC ipConfiguration a real
 	// publicIPAddresses GET reports once a NIC attaches the address.
 	IPConfiguration *armIDRef `json:"ipConfiguration,omitempty"`
+	// PublicIPPrefix echoes the prefix this public IP was created from, when one
+	// was supplied on the create.
+	PublicIPPrefix *armIDRef `json:"publicIPPrefix,omitempty"`
 }
 
 type publicIPDNSSettings struct {

--- a/services/networking/driver/azure_public_ip_prefix.go
+++ b/services/networking/driver/azure_public_ip_prefix.go
@@ -1,0 +1,52 @@
+package driver
+
+import "context"
+
+// Microsoft.Network/publicIPPrefixes reserves a contiguous CIDR range from which
+// standard public IP addresses can be drawn. The cross-cloud Networking model has
+// no equivalent, so — like AzureNetworkMetadata and AzureApplicationSecurityGroups
+// — the Azure provider stores it through this OPTIONAL, type-asserted capability.
+// AWS and GCP do not implement it.
+
+// AzurePublicIPPrefix is one Microsoft.Network/publicIPPrefixes resource,
+// addressed by (resourceGroup, name) to match ARM. IPPrefix is the CIDR the
+// provider synthesizes at create time (of size PrefixLength) and is immutable for
+// the life of the prefix, so a later createOrUpdate PUT preserves it.
+type AzurePublicIPPrefix struct {
+	Name          string
+	ResourceGroup string
+	Location      string
+	Tags          map[string]string
+	Zones         []string
+	// PrefixLength is the CIDR mask length requested at create (e.g. 28). It is
+	// immutable after create, matching real Azure.
+	PrefixLength int32
+	// IPPrefix is the synthesized CIDR (e.g. "10.0.0.0/28"), allocated by the
+	// provider from a deterministic private pool. Empty on the value handed to
+	// Put; the provider fills it in.
+	IPPrefix string
+	// SKUName / SKUTier echo the top-level sku the caller submitted (Standard or
+	// StandardV2, tier Regional). They are not part of the cross-cloud model, so
+	// they live here on the Azure-only record.
+	SKUName string
+	SKUTier string
+}
+
+// AzurePublicIPPrefixes is the Azure-only public-IP-prefix surface. Keyed by
+// (resourceGroup, name) for idempotent createOrUpdate; an empty resourceGroup on
+// List means subscription-wide.
+type AzurePublicIPPrefixes interface {
+	// PutAzurePublicIPPrefix creates or replaces a prefix in place (a repeat
+	// createOrUpdate PUT updates rather than duplicating). On create it synthesizes
+	// and stores the IPPrefix CIDR; on an idempotent re-PUT it preserves the
+	// existing IPPrefix and PrefixLength (both immutable in real Azure). It returns
+	// the stored value with IPPrefix populated.
+	PutAzurePublicIPPrefix(ctx context.Context, prefix AzurePublicIPPrefix) AzurePublicIPPrefix
+	// GetAzurePublicIPPrefix returns the prefix identified by (resourceGroup, name).
+	GetAzurePublicIPPrefix(ctx context.Context, resourceGroup, name string) (AzurePublicIPPrefix, bool)
+	// DeleteAzurePublicIPPrefix removes the prefix, reporting whether it existed.
+	DeleteAzurePublicIPPrefix(ctx context.Context, resourceGroup, name string) bool
+	// ListAzurePublicIPPrefixes returns the prefixes in a resource group, or all
+	// when resourceGroup is empty (subscription-wide list), ordered by key.
+	ListAzurePublicIPPrefixes(ctx context.Context, resourceGroup string) []AzurePublicIPPrefix
+}

--- a/services/resourcediscovery/arn.go
+++ b/services/resourcediscovery/arn.go
@@ -63,6 +63,7 @@ const (
 	netKindPeering       = "vpc-peering-connection"
 	netKindRouteTable    = "route-table"
 	netKindAppSecGroup   = "application-security-group"
+	netKindPubIPPrefix   = "public-ip-prefix"
 )
 
 // computeInstanceARN builds the canonical identifier for a compute instance.
@@ -173,6 +174,7 @@ var azureNetworkTypeByKind = map[string]string{ //nolint:gochecknoglobals // sta
 	netKindPeering:       "virtualNetworkPeerings",
 	netKindRouteTable:    "routeTables",
 	netKindAppSecGroup:   "applicationSecurityGroups",
+	netKindPubIPPrefix:   "publicIPPrefixes",
 }
 
 func azureNetworkType(kind string) string {

--- a/services/resourcediscovery/walkers.go
+++ b/services/resourcediscovery/walkers.go
@@ -95,6 +95,7 @@ const (
 	TypePeeringConnection = "PeeringConnection"
 	TypeRouteTable        = "RouteTable"
 	TypeAppSecurityGroup  = "ApplicationSecurityGroup"
+	TypePublicIPPrefix    = "PublicIPPrefix"
 	TypeModel             = "Model"
 	TypeEndpoint          = "Endpoint"
 	TypeNotebookInstance  = "NotebookInstance"
@@ -438,12 +439,48 @@ func (e *Engine) walkNetworking(ctx context.Context) ([]Resource, error) {
 
 	out = append(out, ifaces...)
 
-	return append(out, e.walkApplicationSecurityGroups(ctx)...), nil
+	out = append(out, e.walkApplicationSecurityGroups(ctx)...)
+
+	return append(out, e.walkPublicIPPrefixes(ctx)...), nil
+}
+
+// walkPublicIPPrefixes adds Azure public IP prefixes when the driver models them
+// (an optional, type-asserted capability only the Azure provider implements).
+// AWS/GCP fail the assertion and contribute nothing.
+//
+//nolint:dupl // mirrors walkApplicationSecurityGroups over a distinct type-asserted Azure capability
+func (e *Engine) walkPublicIPPrefixes(ctx context.Context) []Resource {
+	svc, ok := e.drivers.Networking.(netdriver.AzurePublicIPPrefixes)
+	if !ok {
+		return nil
+	}
+
+	prefixes := svc.ListAzurePublicIPPrefixes(ctx, "")
+
+	out := make([]Resource, 0, len(prefixes))
+
+	for i := range prefixes {
+		region := prefixes[i].Location
+		if region == "" {
+			region = e.region
+		}
+
+		out = append(out, Resource{
+			Provider: e.provider, Service: ServiceNetworking, Type: TypePublicIPPrefix,
+			ID:     prefixes[i].Name,
+			ARN:    e.networkARN(netKindPubIPPrefix, prefixes[i].Name, prefixes[i].ResourceGroup),
+			Region: region, Tags: copyTags(prefixes[i].Tags),
+		})
+	}
+
+	return out
 }
 
 // walkApplicationSecurityGroups adds Azure application security groups when the
 // driver models them (an optional, type-asserted capability only the Azure
 // provider implements). AWS/GCP fail the assertion and contribute nothing.
+//
+//nolint:dupl // mirrors walkPublicIPPrefixes over a distinct type-asserted Azure capability
 func (e *Engine) walkApplicationSecurityGroups(ctx context.Context) []Resource {
 	svc, ok := e.drivers.Networking.(netdriver.AzureApplicationSecurityGroups)
 	if !ok {


### PR DESCRIPTION
## What

Adds `Microsoft.Network/publicIPPrefixes` (CRUD + list) to the Azure vnet wire handler, driven end-to-end by the real `armnetwork.PublicIPPrefixesClient`.

- On **create** the provider synthesizes `properties.ipPrefix` — a CIDR of the requested `prefixLength` carved from a deterministic `10.0.0.0/8` allocator (monotonic /24 block counter, no randomness). `prefixLength` defaults to 28 when omitted and is immutable on re-PUT.
- **sku is top-level** (`Standard`/`StandardV2`, tier `Regional`), echoed back on GET.
- Read-only **`publicIPAddresses[]` back-reference**: rebuilt by scanning public IPs whose `publicIPPrefix` ref matches this prefix. A public IP created with a `publicIPPrefix` ref only stores the ref (child-IP allocation from the prefix range is deferred); the public IP echoes the prefix on its own GET.

## Architecture fit

- **LRO:** PUT + DELETE ride the vnet handler's existing async plumbing (`writeAcceptedAsync` + the `locations/operationStatuses` responder) — the same pattern as NAT gateways, so `BeginCreateOrUpdate`/`BeginDelete` pollers terminate cleanly.
- **Snapshot:** new store bolts onto the already-`Snapshottable` vnet `Mock`; since the completeness guard only checks the field type, the store was **manually** added to the provider's snapshot dumps/loads list and a round-trip assertion added to `snapshot_test.go`.
- **Purge:** added to the `PurgeResourceGroup` cascade so prefixes don't orphan on RG delete.
- **ARG triple (#334):** type-asserted walker in `resourcediscovery`, portable `TypePublicIPPrefix` const, and resourcegraph forward/reverse map entries. All additions are Azure-gated — **AWS/GCP ARNs and Resource Graph rows are byte-unchanged** (the walker fails the type assertion on AWS/GCP; the arn.go entry only extends the Azure type map).
- Azure-only surface modeled as an optional, type-asserted `AzurePublicIPPrefixes` capability on the networking driver (mirrors `AzureApplicationSecurityGroups`); the cross-cloud driver is not widened.
- `docs/coverage/` regenerated.

## Test

Real-SDK e2e through the pollers (`server/azure/vnet/public_ip_prefix_test.go`):
- `BeginCreateOrUpdate` (prefixLength=28) → `PollUntilDone` → `Get` round-trips a synthesized `ipPrefix` of the right size + top-level sku; list; `BeginDelete` → subsequent `Get` returns 404.
- Back-reference test: a public IP created with a `publicIPPrefix` ref appears in the prefix's read-only `publicIPAddresses[]` and echoes the prefix.
- Provider snapshot/restore round-trip asserts the synthesized CIDR + sku survive.

Refs #611.