### PR TITLE
feat(azure-monitor): seed VM Available Memory Percentage/Bytes metrics (#912)

### DIFF
--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -71,8 +71,19 @@ type lifecycleTransition struct {
 }
 
 var (
-	runningMetricValues = []float64{25.0, 1024.0, 512.0, 100.0, 50.0} //nolint:gochecknoglobals // package-level test fixtures
-	zeroMetricValues    = []float64{0.0, 0.0, 0.0, 0.0, 0.0}          //nolint:gochecknoglobals // package-level test fixtures
+	// vmMetricNames are the Azure Monitor metric names auto-seeded for every VM,
+	// order-aligned with runningMetricValues/zeroMetricValues so both seed paths
+	// (emitInstanceMetrics, emitLifecycleMetrics) share one list and cannot drift.
+	// The trailing two match the memory metrics real Azure publishes under
+	// Microsoft.Compute/virtualMachines.
+	vmMetricNames = []string{ //nolint:gochecknoglobals // package-level config
+		"Percentage CPU", "Network In Total", "Network Out Total",
+		"Disk Read Operations/Sec", "Disk Write Operations/Sec",
+		"Available Memory Percentage", "Available Memory Bytes",
+	}
+	// The trailing two values are the memory metrics: ~60% available and 4 GiB.
+	runningMetricValues = []float64{25.0, 1024.0, 512.0, 100.0, 50.0, 60.0, 4294967296.0} //nolint:gochecknoglobals // fixtures
+	zeroMetricValues    = []float64{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}                    //nolint:gochecknoglobals // fixtures
 
 	startTransition = lifecycleTransition{ //nolint:gochecknoglobals // package-level config
 		intermediateState:     compute.StatePending,
@@ -236,22 +247,21 @@ func (m *Mock) emitInstanceMetrics(ctx context.Context, inst *instanceData) {
 		lt = m.opts.Clock.Now()
 	}
 
-	metrics := []string{"Percentage CPU", "Network In Total", "Network Out Total", "Disk Read Operations/Sec", "Disk Write Operations/Sec"}
-	values := []float64{25.0, 1024.0, 512.0, 100.0, 50.0}
 	resourceID := m.armResourceID(inst)
 
 	var data []mondriver.MetricDatum
 
-	// Backfill the 5 datapoints going backward from launch time so they land in
-	// the recent past. Forward-dating would place them in the future, where a
-	// metrics query ending at "now" filters them out.
-	for i, metricName := range metrics {
+	// Backfill 5 datapoints per metric going backward from launch time so they
+	// land in the recent past. Forward-dating would place them in the future,
+	// where a metrics query ending at "now" filters them out. A freshly-run VM
+	// is running, so it seeds the running values.
+	for i, metricName := range vmMetricNames {
 		for j := 0; j < 5; j++ {
 			ts := lt.Add(-time.Duration(j) * time.Minute)
 			data = append(data, mondriver.MetricDatum{
 				Namespace:  "Microsoft.Compute/virtualMachines",
 				MetricName: metricName,
-				Value:      values[i],
+				Value:      runningMetricValues[i],
 				Unit:       "None",
 				Dimensions: map[string]string{"resourceId": resourceID},
 				Timestamp:  ts,
@@ -267,12 +277,11 @@ func (m *Mock) emitLifecycleMetrics(ctx context.Context, inst *instanceData, val
 		return
 	}
 
-	metrics := []string{"Percentage CPU", "Network In Total", "Network Out Total", "Disk Read Operations/Sec", "Disk Write Operations/Sec"}
 	now := m.opts.Clock.Now()
 	resourceID := m.armResourceID(inst)
-	data := make([]mondriver.MetricDatum, len(metrics))
+	data := make([]mondriver.MetricDatum, len(vmMetricNames))
 
-	for i, metricName := range metrics {
+	for i, metricName := range vmMetricNames {
 		data[i] = mondriver.MetricDatum{
 			Namespace:  "Microsoft.Compute/virtualMachines",
 			MetricName: metricName,

--- a/providers/azure/virtualmachines/vm_test.go
+++ b/providers/azure/virtualmachines/vm_test.go
@@ -1176,13 +1176,15 @@ func TestRunInstancesWithMonitoring(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, instances, 1)
 
-	// Should have emitted 5 metrics x 5 backfill datapoints = 25 data points
-	assert.Len(t, mon.data, 25)
+	// Should have emitted 7 metrics x 5 backfill datapoints = 35 data points
+	assert.Len(t, mon.data, 35)
 	assert.True(t, mon.hasMetric("Microsoft.Compute/virtualMachines", "Percentage CPU"))
 	assert.True(t, mon.hasMetric("Microsoft.Compute/virtualMachines", "Network In Total"))
 	assert.True(t, mon.hasMetric("Microsoft.Compute/virtualMachines", "Network Out Total"))
 	assert.True(t, mon.hasMetric("Microsoft.Compute/virtualMachines", "Disk Read Operations/Sec"))
 	assert.True(t, mon.hasMetric("Microsoft.Compute/virtualMachines", "Disk Write Operations/Sec"))
+	assert.True(t, mon.hasMetric("Microsoft.Compute/virtualMachines", "Available Memory Percentage"))
+	assert.True(t, mon.hasMetric("Microsoft.Compute/virtualMachines", "Available Memory Bytes"))
 }
 
 func TestLifecycleMetricsEmission(t *testing.T) {
@@ -1197,8 +1199,8 @@ func TestLifecycleMetricsEmission(t *testing.T) {
 		mon.reset()
 		err := m.StopInstances(ctx, []string{id})
 		require.NoError(t, err)
-		// 5 metrics, 1 datapoint each
-		assert.Len(t, mon.data, 5)
+		// 7 metrics, 1 datapoint each
+		assert.Len(t, mon.data, 7)
 
 		for _, d := range mon.data {
 			assert.Equal(t, 0.0, d.Value)
@@ -1209,7 +1211,7 @@ func TestLifecycleMetricsEmission(t *testing.T) {
 		mon.reset()
 		err := m.StartInstances(ctx, []string{id})
 		require.NoError(t, err)
-		assert.Len(t, mon.data, 5)
+		assert.Len(t, mon.data, 7)
 
 		assert.True(t, mon.hasMetric("Microsoft.Compute/virtualMachines", "Percentage CPU"))
 	})
@@ -1218,19 +1220,69 @@ func TestLifecycleMetricsEmission(t *testing.T) {
 		mon.reset()
 		err := m.RebootInstances(ctx, []string{id})
 		require.NoError(t, err)
-		assert.Len(t, mon.data, 5)
+		assert.Len(t, mon.data, 7)
 	})
 
 	t.Run("terminate emits zero metrics", func(t *testing.T) {
 		mon.reset()
 		err := m.TerminateInstances(ctx, []string{id})
 		require.NoError(t, err)
-		assert.Len(t, mon.data, 5)
+		assert.Len(t, mon.data, 7)
 
 		for _, d := range mon.data {
 			assert.Equal(t, 0.0, d.Value)
 		}
 	})
+}
+
+// TestVMMemoryMetricsSeeded proves an SDK client reading VM memory utilization
+// sees a real backfilled series for both Azure memory metrics: RunInstances
+// seeds Available Memory Percentage / Available Memory Bytes under
+// Microsoft.Compute/virtualMachines, scoped to the VM's resourceId dimension,
+// with the running values; a Stop then re-seeds them at zero.
+func TestVMMemoryMetricsSeeded(t *testing.T) {
+	ctx := context.Background()
+	m, mon := newTestMockWithMonitoring()
+
+	instances, err := m.RunInstances(ctx, driver.InstanceConfig{
+		ImageID: "img-1", InstanceType: "Standard_B1s", ResourceGroup: "rg",
+	}, 1)
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+
+	resourceID := m.armResourceID(&instanceData{ID: instances[0].ID, ResourceGroup: "rg"})
+
+	pct := mon.series(resourceID, "Available Memory Percentage")
+	require.NotEmpty(t, pct, "expected a backfilled Available Memory Percentage series")
+
+	for _, v := range pct {
+		assert.Equal(t, 60.0, v)
+	}
+
+	bytesSeries := mon.series(resourceID, "Available Memory Bytes")
+	require.NotEmpty(t, bytesSeries, "expected a backfilled Available Memory Bytes series")
+
+	for _, v := range bytesSeries {
+		assert.Equal(t, 4294967296.0, v)
+	}
+
+	// A Stop re-seeds both memory metrics at zero, like the other lifecycle metrics.
+	mon.reset()
+	require.NoError(t, m.StopInstances(ctx, []string{instances[0].ID}))
+
+	stoppedPct := mon.series(resourceID, "Available Memory Percentage")
+	require.NotEmpty(t, stoppedPct)
+
+	for _, v := range stoppedPct {
+		assert.Equal(t, 0.0, v)
+	}
+
+	stoppedBytes := mon.series(resourceID, "Available Memory Bytes")
+	require.NotEmpty(t, stoppedBytes)
+
+	for _, v := range stoppedBytes {
+		assert.Equal(t, 0.0, v)
+	}
 }
 
 func TestValidateASGBoundsNegativeMin(t *testing.T) {
@@ -1811,6 +1863,20 @@ func (c *vmMetricsCollector) hasMetric(namespace, metricName string) bool {
 	}
 
 	return false
+}
+
+// series returns the values of every datum for metricName scoped to the given
+// resourceId dimension, mirroring what a resource-scoped armmonitor query reads.
+func (c *vmMetricsCollector) series(resourceID, metricName string) []float64 {
+	var values []float64
+
+	for _, d := range c.data {
+		if d.MetricName == metricName && d.Dimensions["resourceId"] == resourceID {
+			values = append(values, d.Value)
+		}
+	}
+
+	return values
 }
 
 func TestSetInstanceVPC(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #912. Azure VM metric auto-seeding only published 5 metrics (CPU/Network/Disk) and omitted the two **memory** metrics real Azure exposes under `Microsoft.Compute/virtualMachines`: `Available Memory Percentage` and `Available Memory Bytes`. A resource-scoped `armmonitor` query for either returned an empty timeseries, so SDK clients doing memory-driven rightsize/idle logic had nothing to read.

## What changed

- Seed both memory metrics alongside the existing five in both seed paths (`emitInstanceMetrics` on RunInstances, `emitLifecycleMetrics` on Start/Stop/PowerOff/Deallocate/Reboot/Terminate), dimensioned per-resource like the others. Running values: `Available Memory Percentage` = 60, `Available Memory Bytes` = 4 GiB; both 0 when stopped (matches the existing stopped=zeros convention).
- **DRY refactor to prevent the drift this bug came from:** the metric-name list was duplicated as a string literal in both functions (and `emitInstanceMetrics` had its own values literal). Extracted a single package-level `vmMetricNames` slice, order-aligned with `runningMetricValues`/`zeroMetricValues`, and used it in both paths. Adding a metric is now a one-line change in one place.

## VMSS

Checked as the issue asked: VM Scale Sets (`scaleset.go`) do **not** seed metrics — only these two VM functions call `PutMetricData` in the package — so there is nothing to change for VMSS.

## Tests

- New `TestVMMemoryMetricsSeeded`: creates a VM and asserts a non-empty backfilled series for both memory metrics scoped to the VM's `resourceId`, with the running values, then asserts a Stop re-seeds both at zero. Fails before this change (the names were never seeded).
- Updated existing datapoint-count assertions (5→7 metrics; 25→35 backfill points).

## Gates

`go build ./...`, `go test ./providers/azure/virtualmachines/... ./providers/azure/monitor/... ./server/azure/monitor/...`, and `golangci-lint` on the package all pass. `coveragegen` produces no docs diff (no driver-interface change).