### PR TITLE
feat(azure): emulate Microsoft.SqlVirtualMachine discovery overlay (#913)

### DIFF
--- a/server/azure/resourcegraph/handler.go
+++ b/server/azure/resourcegraph/handler.go
@@ -435,6 +435,7 @@ var portableToAzureTypeMap = map[string]string{ //nolint:gochecknoglobals // sta
 	"compute/Volume":                      "microsoft.compute/disks",
 	"compute/Snapshot":                    "microsoft.compute/snapshots",
 	"compute/ScaleSet":                    "microsoft.compute/virtualmachinescalesets",
+	"compute/SqlVirtualMachine":           "microsoft.sqlvirtualmachine/sqlvirtualmachines",
 	"networking/VPC":                      "microsoft.network/virtualnetworks",
 	"networking/Subnet":                   "microsoft.network/subnets",
 	"networking/SecurityGroup":            "microsoft.network/networksecuritygroups",

--- a/server/azure/resourcegraph/kql.go
+++ b/server/azure/resourcegraph/kql.go
@@ -75,6 +75,7 @@ const (
 	azureTypePubIPPfx  = "microsoft.network/publicipprefixes"
 	azureTypeRouteTbl  = "microsoft.network/routetables"
 	azureTypeVNetPeer  = "microsoft.network/virtualnetworks/virtualnetworkpeerings"
+	azureTypeSQLVM     = "microsoft.sqlvirtualmachine/sqlvirtualmachines"
 	azureTypeMLWorkspc = "microsoft.machinelearningservices/workspaces"
 	azureTypeMLEndpt   = "microsoft.machinelearningservices/workspaces/onlineendpoints"
 	azureTypeCognitive = "microsoft.cognitiveservices/accounts"
@@ -378,6 +379,7 @@ var azureToPortableType = map[string]portableResourceType{ //nolint:gochecknoglo
 	azureTypePubIPPfx:  {portableNetworking, "PublicIPPrefix"},
 	azureTypeRouteTbl:  {portableNetworking, "RouteTable"},
 	azureTypeVNetPeer:  {portableNetworking, "PeeringConnection"},
+	azureTypeSQLVM:     {portableCompute, "SqlVirtualMachine"},
 	azureTypeMLWorkspc: {portableAzureML, "Workspace"},
 	azureTypeMLEndpt:   {portableAzureML, "Endpoint"},
 	azureTypeCognitive: {portableCognitive, "Account"},

--- a/server/azure/resourcegraph/sql_virtual_machine_discovery_test.go
+++ b/server/azure/resourcegraph/sql_virtual_machine_discovery_test.go
@@ -1,0 +1,108 @@
+// Real-SDK round-trip test for issue #913: a compute VM opted in via the
+// cloudemu:sqlvm=true tag surfaces a paired Microsoft.SqlVirtualMachine overlay
+// row in Resource Graph, while a plain VM does not.
+
+package resourcegraph_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+// TestSDKResourceGraph_SQLVirtualMachineDiscovery pins issue #913: the SQL VM
+// overlay is a management view on a compute VM. A VM tagged cloudemu:sqlvm=true
+// gets one microsoft.sqlvirtualmachine/sqlvirtualmachines row that shares the
+// VM's name, resource group, location and (user-visible) tags — differing only
+// in the provider segment of its id — and an untagged VM gets none.
+func TestSDKResourceGraph_SQLVirtualMachineDiscovery(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	sqlVM, err := cloudP.VirtualMachines.RunInstances(ctx, computedriver.InstanceConfig{
+		InstanceType:  "Standard_D2s_v3",
+		Region:        "eastus",
+		ResourceGroup: "sql-rg",
+		Tags:          map[string]string{"cloudemu:sqlvm": "true", "env": "prod"},
+	}, 1)
+	require.NoError(t, err)
+	require.Len(t, sqlVM, 1)
+
+	plainVM, err := cloudP.VirtualMachines.RunInstances(ctx, computedriver.InstanceConfig{
+		InstanceType:  "Standard_D2s_v3",
+		Region:        "eastus",
+		ResourceGroup: "plain-rg",
+		Tags:          map[string]string{"env": "dev"},
+	}, 1)
+	require.NoError(t, err)
+	require.Len(t, plainVM, 1)
+
+	srv := azureserver.New(azureserver.Drivers{
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		SubscriptionID:    "123456789012",
+	})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newResourceGraphClient(t, ts)
+
+	t.Run("exactly one SQL VM overlay row, paired to the tagged VM", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type =~ 'microsoft.sqlvirtualmachine/sqlvirtualmachines'"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		require.Len(t, data, 1, "only the tagged VM produces an overlay row")
+
+		row := data[0].(map[string]any)
+		assert.Equal(t, "microsoft.sqlvirtualmachine/sqlvirtualmachines", row["type"])
+		assert.Equal(t, sqlVM[0].ID, row["name"], "overlay shares the paired VM's name")
+		assert.Equal(t, "sql-rg", row["resourceGroup"], "overlay shares the VM's resource group")
+		assert.Equal(t, "eastus", row["location"], "overlay shares the VM's location")
+
+		// Only the provider segment differs from the compute VM's id; the internal
+		// cloudemu: opt-in tag is stripped on the wire, leaving the real user tags.
+		id := row["id"].(string)
+		assert.Contains(t, id, "/subscriptions/123456789012/")
+		assert.Contains(t, id, "resourceGroups/sql-rg/")
+		assert.Contains(t, id, "/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/"+sqlVM[0].ID)
+
+		tags := row["tags"].(map[string]any)
+		assert.Equal(t, "prod", tags["env"])
+		assert.NotContains(t, tags, "cloudemu:sqlvm", "internal opt-in marker must not leak")
+	})
+
+	t.Run("the paired compute VM row still appears with the same name", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type =~ 'microsoft.compute/virtualmachines'"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		require.Len(t, data, 2, "both VMs remain plain compute rows")
+		assert.True(t, rowsHaveType(data, "microsoft.compute/virtualmachines"))
+	})
+
+	t.Run("a plain untagged VM yields no SQL VM overlay row", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type =~ 'microsoft.sqlvirtualmachine/sqlvirtualmachines'"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		for _, d := range data {
+			row := d.(map[string]any)
+			assert.NotEqual(t, plainVM[0].ID, row["name"], "the plain VM must not surface an overlay")
+		}
+	})
+}

--- a/server/azure/resourcegraph/sql_virtual_machine_type_test.go
+++ b/server/azure/resourcegraph/sql_virtual_machine_type_test.go
@@ -1,0 +1,20 @@
+package resourcegraph
+
+import "testing"
+
+// TestSQLVirtualMachineTypeMapping locks the #913 ARG-triple: the SQL VM overlay
+// maps both ways between the portable compute/SqlVirtualMachine pair and the real
+// ARM type microsoft.sqlvirtualmachine/sqlvirtualmachines.
+func TestSQLVirtualMachineTypeMapping(t *testing.T) {
+	const armSQLVM = "microsoft.sqlvirtualmachine/sqlvirtualmachines"
+
+	// Forward: KQL `where type == '<armSQLVM>'` resolves to the overlay pair.
+	if svc, typ := mapAzureType(armSQLVM); svc != "compute" || typ != "SqlVirtualMachine" {
+		t.Errorf("mapAzureType(%q) = (%q,%q), want (compute,SqlVirtualMachine)", armSQLVM, svc, typ)
+	}
+
+	// Reverse: a discovered overlay row stamps the real ARM type.
+	if got := portableToAzureType("compute", "SqlVirtualMachine"); got != armSQLVM {
+		t.Errorf("portableToAzureType(compute,SqlVirtualMachine) = %q, want %q", got, armSQLVM)
+	}
+}

--- a/services/resourcediscovery/arn.go
+++ b/services/resourcediscovery/arn.go
@@ -84,6 +84,15 @@ func (e *Engine) computeInstanceARN(id, resourceGroup string) string {
 	}
 }
 
+// computeSQLVirtualMachineARN builds the ARM id for the Microsoft.SqlVirtualMachine
+// overlay paired with a compute VM. It shares the VM's name and resource group,
+// differing from computeInstanceARN only in the provider/type segment. Azure-only
+// — the overlay walker never calls it for AWS/GCP — so no per-provider switch.
+func (e *Engine) computeSQLVirtualMachineARN(name, resourceGroup string) string {
+	return idgen.AzureID(e.accountID, azureResourceGroupOrDefault(resourceGroup),
+		"Microsoft.SqlVirtualMachine", "sqlVirtualMachines", name)
+}
+
 // computeVolumeARN canonicalizes a block-volume id. When the driver already
 // hands back a fully-qualified id (an Azure managed-disk ARM path, a GCP
 // self-link, or an AWS ARN) it is used verbatim; otherwise a per-provider id

--- a/services/resourcediscovery/walkers.go
+++ b/services/resourcediscovery/walkers.go
@@ -109,6 +109,22 @@ const (
 // own block so its longer name does not reflow the alignment above.
 const TypeUserAssignedIdentity = "UserAssignedIdentity"
 
+// TypeSQLVirtualMachine is the portable type for an Azure SQL virtual machine
+// (Microsoft.SqlVirtualMachine/sqlVirtualMachines) — a management overlay on a
+// paired compute VM of the same name/resource group. It sits under
+// ServiceCompute and is synthesized in the compute walker from a VM opted in via
+// the cloudemu:sqlvm tag, so it needs no stored state and no driver capability.
+const TypeSQLVirtualMachine = "SqlVirtualMachine"
+
+// sqlVMOptInTagKey and sqlVMOptInTagValue mark a compute VM as opting in to a
+// paired Microsoft.SqlVirtualMachine overlay row in discovery. Only Azure VMs
+// carrying the tag get the overlay, so plain VMs — and every AWS/GCP VM — are
+// unaffected.
+const (
+	sqlVMOptInTagKey   = "cloudemu:sqlvm"
+	sqlVMOptInTagValue = "true"
+)
+
 // Azure/GCP managed-SQL server types. These portable types map to per-cloud
 // native type strings in Resource Graph (Azure) and Cloud Asset (GCP). AWS RDS
 // uses TypeDBInstance/DBCluster/DBSnapshot above.
@@ -190,7 +206,49 @@ func (e *Engine) walkCompute(ctx context.Context) ([]Resource, error) {
 		return nil, err
 	}
 
-	return append(out, snaps...), nil
+	out = append(out, snaps...)
+
+	out = append(out, e.walkSQLVirtualMachines(instances)...)
+
+	return out, nil
+}
+
+// walkSQLVirtualMachines synthesizes a Microsoft.SqlVirtualMachine overlay row
+// for each Azure compute VM opted in via the cloudemu:sqlvm=true tag. The
+// overlay is a pure derived view of the paired VM — it shares the VM's name,
+// resource group, region and tags, differing only in the provider segment of
+// its id — so it needs no stored state and no driver capability. AWS/GCP VMs
+// never reach this (provider-gated), so their discovery output is unchanged.
+func (e *Engine) walkSQLVirtualMachines(instances []computedriver.Instance) []Resource {
+	if e.provider != ProviderAzure {
+		return nil
+	}
+
+	out := make([]Resource, 0, len(instances))
+
+	for i := range instances {
+		inst := &instances[i]
+		if inst.Tags[sqlVMOptInTagKey] != sqlVMOptInTagValue {
+			continue
+		}
+
+		region := inst.Region
+		if region == "" {
+			region = e.region
+		}
+
+		out = append(out, Resource{
+			Provider: e.provider,
+			Service:  ServiceCompute,
+			Type:     TypeSQLVirtualMachine,
+			ID:       inst.ID,
+			ARN:      e.computeSQLVirtualMachineARN(inst.ID, inst.ResourceGroup),
+			Region:   region,
+			Tags:     copyTags(inst.Tags),
+		})
+	}
+
+	return out
 }
 
 // walkSnapshots surfaces block-storage snapshots (EBS / GCE / Azure disk


### PR DESCRIPTION
## What

Emulates the `Microsoft.SqlVirtualMachine/sqlVirtualMachines` resource type in Azure discovery. In real Azure a SQL VM is a management overlay on a paired `Microsoft.Compute/virtualMachines` resource of the same name + resource group; it appears in Resource Graph as its own row while its metrics live on the paired compute VM. cloudemu emitted the compute VM but never the overlay, so a discovery client (`resources | where type =~ 'microsoft.sqlvirtualmachine/sqlvirtualmachines'`) found nothing. Closes #913.

## Why / how

- **Opt-in tag.** A compute VM carrying `cloudemu:sqlvm=true` gets a paired overlay row. Plain VMs are untouched, so the change is invisible unless explicitly requested.
- **Walker-synthesized, no new state.** The overlay is a pure derived view of the tagged VM, synthesized in the compute walker (`walkSQLVirtualMachines`) by reading the already-fetched instances. It shares the VM's name, resource group, region and (user-visible) tags; only the provider segment of the id differs (`.../providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/<name>`). No new stored resource, no new service package, and no widening of the cross-cloud driver interface.
- **ARG triple.** Adds the portable `compute/SqlVirtualMachine` type plus the forward (KQL type → portable pair) and reverse (portable pair → ARM type string) Resource Graph map entries, so both `where type =~ 'microsoft.sqlvirtualmachine/sqlvirtualmachines'` and the generic `/resources` listing return the row with the correct type.

## Blast radius

**AWS/GCP discovery is byte-unchanged.** `walkSQLVirtualMachines` returns `nil` for any provider other than Azure (appending nothing), the new ARN builder is only reached from that Azure-gated path, and the Resource Graph map changes are purely additive keys in Azure-only lookup tables. No existing code path is altered.

## Tests

- Real-SDK e2e (`armresourcegraph` client over an httptest TLS server): a VM tagged `cloudemu:sqlvm=true` yields exactly one overlay row with the expected type, name, resource group, location, tags and ARM-shaped id; the paired compute VM row still appears; a plain untagged VM yields no overlay row.
- Mapping unit test locking the forward/reverse ARG triple.

Gates green: `go build ./...`, targeted `go test`, `golangci-lint` (0 new issues vs base). Coverage docs regenerated with no diff (no driver interface changed).