### PR TITLE
fix(kubernetes): enforce spec.nodeName immutability on Pod replace (#895)

### DIFF
--- a/services/kubernetes/pod.go
+++ b/services/kubernetes/pod.go
@@ -326,6 +326,10 @@ func (s *ClusterState) updatePod(w http.ResponseWriter, r *http.Request, namespa
 		return
 	}
 
+	if enforcePodNodeNameImmutable(w, cur, &in) {
+		return
+	}
+
 	in.Namespace = namespace
 	in.UID = cur.UID
 	in.CreationTimestamp = cur.CreationTimestamp
@@ -367,6 +371,33 @@ func (s *ClusterState) updatePod(w http.ResponseWriter, r *http.Request, namespa
 	s.resyncEndpointsForNamespaceLocked(namespace)
 	s.wPods.publish(EventModified, namespace, *pod.DeepCopy())
 	writeJSON(w, http.StatusOK, &pod)
+}
+
+// enforcePodNodeNameImmutable applies kubernetes spec.nodeName immutability on a
+// Pod replace. An empty incoming nodeName carries the stored binding forward (a
+// spec-only PUT must not unschedule an already-bound Pod); a non-empty change to
+// a bound Pod is rejected with 422 Invalid, matching the real apiserver. Returns
+// true when it wrote a rejection and the caller must stop.
+func enforcePodNodeNameImmutable(w http.ResponseWriter, cur, in *corev1.Pod) bool {
+	if cur.Spec.NodeName == "" || in.Spec.NodeName == cur.Spec.NodeName {
+		return false
+	}
+
+	if in.Spec.NodeName == "" {
+		in.Spec.NodeName = cur.Spec.NodeName
+
+		return false
+	}
+
+	writeInvalid(w, kindPod, in.Name,
+		fmt.Sprintf("Pod %q is invalid: spec.nodeName: Forbidden: field is immutable", in.Name),
+		[]metav1.StatusCause{{
+			Type:    causeTypeFieldValueForbidden,
+			Message: "field is immutable",
+			Field:   "spec.nodeName",
+		}})
+
+	return true
 }
 
 // Patch flow is identical across namespaced resources; sharing would force a

--- a/services/kubernetes/pod_nodename_immutability_test.go
+++ b/services/kubernetes/pod_nodename_immutability_test.go
@@ -1,0 +1,126 @@
+// Tests for spec.nodeName immutability on a Pod PUT/replace (#895): once a Pod
+// is bound to a node, a replace that changes nodeName is rejected 422 Invalid,
+// and a replace that omits it carries the stored binding forward rather than
+// unscheduling (or, on the multi-node scheduler, re-flipping) a Running Pod.
+
+package kubernetes_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// createScheduledPod POSTs a minimal Pod pre-bound to node (a caller-set
+// spec.nodeName is honored by the scheduler) and returns the nodeName it ended
+// up on, asserting the binding is non-empty.
+func createScheduledPod(t *testing.T, base, name, node string) string {
+	t.Helper()
+
+	body := mustJSON(t, map[string]any{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": map[string]any{"name": name},
+		"spec": map[string]any{
+			"nodeName":   node,
+			"containers": []any{map[string]any{"name": "c", "image": "nginx"}},
+		},
+	})
+
+	resp := do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods", body)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create pod: status %d, want 201", resp.StatusCode)
+	}
+
+	created := decodeMap(t, resp.Body)
+	spec, _ := created["spec"].(map[string]any)
+	got, _ := spec["nodeName"].(string)
+
+	if got == "" {
+		t.Fatalf("created pod has no nodeName; expected it to be scheduled")
+	}
+
+	return got
+}
+
+func TestPodNodeNameImmutable_RejectsChange(t *testing.T) {
+	base, done := newMultiNodeFixture(t, 3)
+	defer done()
+
+	bound := createScheduledPod(t, base, "web", "cloudemu-node-1")
+
+	// A replace that points the bound Pod at a different node must be rejected.
+	body := mustJSON(t, map[string]any{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": map[string]any{"name": "web"},
+		"spec": map[string]any{
+			"nodeName":   "cloudemu-node-2",
+			"containers": []any{map[string]any{"name": "c", "image": "nginx"}},
+		},
+	})
+
+	resp := do(t, http.MethodPut, base+"/api/v1/namespaces/default/pods/web", body)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("replace with changed nodeName: status %d, want 422", resp.StatusCode)
+	}
+
+	status := decodeMap(t, resp.Body)
+	if reason, _ := status["reason"].(string); reason != "Invalid" {
+		t.Fatalf("reason: got %q, want Invalid", reason)
+	}
+
+	details, _ := status["details"].(map[string]any)
+	causes, _ := details["causes"].([]any)
+	if len(causes) != 1 {
+		t.Fatalf("expected 1 cause, got %d", len(causes))
+	}
+
+	cause, _ := causes[0].(map[string]any)
+	if field, _ := cause["field"].(string); field != "spec.nodeName" {
+		t.Fatalf("cause field: got %q, want spec.nodeName", field)
+	}
+
+	// The stored binding must be untouched by a rejected replace.
+	if got := podPlacements(t, base, "default")["web"]; got.node != bound || got.phase != "Running" {
+		t.Fatalf("after rejected replace: got node=%q phase=%q, want node=%q Running", got.node, got.phase, bound)
+	}
+}
+
+func TestPodNodeNameImmutable_CarriesForwardOnOmit(t *testing.T) {
+	base, done := newMultiNodeFixture(t, 3)
+	defer done()
+
+	// Bind to node-2, which is NOT the first-fit worker (node-1). Without the
+	// carry-forward, an omitted nodeName re-runs the scheduler and flips the Pod
+	// onto node-1, so this binding is what proves the fix holds.
+	bound := createScheduledPod(t, base, "web", "cloudemu-node-2")
+
+	// A spec-only replace that omits nodeName must keep the existing binding, not
+	// re-run the scheduler (which could flip the Pod onto another node or Pending).
+	body := mustJSON(t, map[string]any{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": map[string]any{"name": "web", "labels": map[string]any{"app": "web"}},
+		"spec": map[string]any{
+			"containers": []any{map[string]any{"name": "c", "image": "nginx"}},
+		},
+	})
+
+	resp := do(t, http.MethodPut, base+"/api/v1/namespaces/default/pods/web", body)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("replace omitting nodeName: status %d, want 200", resp.StatusCode)
+	}
+
+	updated := decodeMap(t, resp.Body)
+	spec, _ := updated["spec"].(map[string]any)
+	if node, _ := spec["nodeName"].(string); node != bound {
+		t.Fatalf("nodeName after omit: got %q, want carried-forward %q", node, bound)
+	}
+
+	if got := podPlacements(t, base, "default")["web"]; got.node != bound || got.phase != "Running" {
+		t.Fatalf("after carry-forward replace: got node=%q phase=%q, want node=%q Running", got.node, got.phase, bound)
+	}
+}

--- a/services/kubernetes/wire.go
+++ b/services/kubernetes/wire.go
@@ -13,6 +13,12 @@ import (
 // both requests and responses.
 const contentTypeJSON = "application/json"
 
+// causeTypeFieldValueForbidden mirrors the field.ErrorTypeForbidden cause the
+// apiserver emits for an immutable-field violation. apimachinery's metav1 does
+// not export a constant for this value (only the internal field package does),
+// so it is spelled here to match the wire.
+const causeTypeFieldValueForbidden metav1.CauseType = "FieldValueForbidden"
+
 // writeJSON marshals v and writes it as a JSON response with the given
 // status code. The Kubernetes Content-Type is always application/json.
 func writeJSON(w http.ResponseWriter, status int, v any) {
@@ -48,6 +54,25 @@ func writeAlreadyExists(w http.ResponseWriter, message string) {
 // writeBadRequest emits a 400 Status response.
 func writeBadRequest(w http.ResponseWriter, message string) {
 	writeStatus(w, http.StatusBadRequest, metav1.StatusReasonBadRequest, message)
+}
+
+// writeInvalid emits a 422 Status response with field-level causes, matching
+// what a real apiserver returns when a request fails validation (e.g. changing
+// an immutable field). client-go decodes it as a typed error (kerrors.IsInvalid)
+// and exposes the causes.
+func writeInvalid(w http.ResponseWriter, kind, name, message string, causes []metav1.StatusCause) {
+	writeJSON(w, http.StatusUnprocessableEntity, &metav1.Status{
+		TypeMeta: metav1.TypeMeta{Kind: "Status", APIVersion: "v1"},
+		Status:   metav1.StatusFailure,
+		Code:     http.StatusUnprocessableEntity,
+		Reason:   metav1.StatusReasonInvalid,
+		Message:  message,
+		Details: &metav1.StatusDetails{
+			Kind:   kind,
+			Name:   name,
+			Causes: causes,
+		},
+	})
 }
 
 // writeMethodNotAllowed emits a 405 Status response.


### PR DESCRIPTION
## Summary
Enforces Kubernetes `spec.nodeName` immutability on a Pod PUT/replace, matching real apiserver behavior. Surfaced during #875 review: with the multi-node scheduler, a replace that omits `nodeName` re-ran the scheduler and could flip a Running Pod onto a different node (or back to Pending), and a replace that changed `nodeName` was silently accepted.

## What changed
`updatePod` now reconciles the incoming `spec.nodeName` against the stored binding before persisting:
- **Change to an already-bound Pod** → rejected with `422 Unprocessable Entity`, a `Status` object with `reason: Invalid` and a `details.causes` entry (`type: FieldValueForbidden`, `field: spec.nodeName`, `message: field is immutable`). client-go decodes this as `kerrors.IsInvalid`.
- **Omitted (empty) `nodeName`** → the stored binding is carried forward, so a spec-only replace no longer unschedules or reschedules a bound Pod.
- Same `nodeName` or an unbound Pod → unchanged behavior.

Scope is the Pod replace path only (create/patch untouched). Adds a small `writeInvalid` wire helper for the 422/Invalid shape.

## Tests
`services/kubernetes/pod_nodename_immutability_test.go`: (a) a replace changing `nodeName` is rejected with the Invalid/`spec.nodeName` error and the binding is untouched; (b) a replace omitting `nodeName` preserves the binding (bound to a non-first-fit node so a regression would flip it). Both fail without the fix.

Closes #895
