### PR TITLE
feat(kubernetes): dynamic node add/remove with reschedule (#894)

### DIFF
--- a/services/kubernetes/node.go
+++ b/services/kubernetes/node.go
@@ -14,13 +14,18 @@ import (
 // The emulator runs one or more synthetic Nodes (KWOK-style: node objects with a
 // Ready status and no kubelet). By default it runs a single node
 // (cloudemu-node-0) and every Pod schedules onto it — the behavior every
-// single-node test relies on. With --k8s-nodes N (fixed at cluster creation,
-// immutable) it seeds one control-plane node plus N-1 workers and routes Pod
-// placement through a deterministic first-fit scheduler
-// (scheduleNodeLocked) that honors nodeSelector, taints/tolerations, and
-// resource-request feasibility. Node/inter-pod affinity, topology spread,
-// scoring/bin-packing, tolerationSeconds/live eviction, and dynamic node
-// add/remove are deferred follow-ups.
+// single-node test relies on. With --k8s-nodes N it seeds one control-plane node
+// plus N-1 workers and routes Pod placement through a deterministic first-fit
+// scheduler (scheduleNodeLocked) that honors nodeSelector, taints/tolerations,
+// and resource-request feasibility.
+//
+// Node membership is also dynamic: registering a Node through the API expands
+// the schedulable set (reconcileNode retries every Pending Pod against the new
+// node in name-sorted order), and deleting one contracts it (nodeOnDelete
+// deletes the node-pinned DaemonSet Pods and reschedules every other bound Pod
+// onto a remaining fitting node, falling back to Pending). Node/inter-pod
+// affinity, topology spread, scoring/bin-packing, and tolerationSeconds/live
+// eviction are deferred follow-ups.
 
 const (
 	// nodeKubeletVersion is the Kubernetes version the synthetic nodes report;
@@ -44,6 +49,9 @@ const (
 	nodeAllocatableMemory = "8041864Ki"
 	// nodeAddressTypeInternalIP is the Node address type carrying the routable IP.
 	nodeAddressTypeInternalIP = "InternalIP"
+	// kindDaemonSet is the DaemonSet Kind, matched on a Pod's ownerReference to
+	// decide a removed node's Pod is deleted (node-pinned) rather than rescheduled.
+	kindDaemonSet = "DaemonSet"
 )
 
 // nodeNameForIndex returns the deterministic name of the i-th synthetic node.
@@ -445,6 +453,131 @@ func podRequests(pod *corev1.Pod) (cpu, mem resource.Quantity) {
 	return cpu, mem
 }
 
+// reconcileNode runs after a Node is created or updated through the API. A node
+// added (or re-labeled/un-tainted) at runtime expands the schedulable set, so
+// every Pod still Pending — nothing fit it when it was created — is retried
+// against the current nodes and placed if one now accepts it. Seeded nodes are
+// inserted directly and never reach this hook, so the fixed-at-seed multi-node
+// path is unchanged.
+func reconcileNode(s *ClusterState, _ *unstructured.Unstructured) {
+	s.reschedulePendingPodsLocked()
+}
+
+// nodeOnDelete runs after a Node is removed through the API. Its bound Pods can
+// no longer run there: DaemonSet Pods are node-pinned one-per-node, so the Pod
+// for the gone node is deleted (a later DaemonSet write will not recreate it —
+// the node is gone), while every other bound Pod is rescheduled onto a remaining
+// fitting node. The node's kube-node-lease Lease is removed too. Callers hold
+// s.mu.
+func nodeOnDelete(s *ClusterState, obj *unstructured.Unstructured) {
+	s.evacuateNodeLocked(obj.GetName())
+	s.deleteNodeLeaseLocked(obj.GetName())
+}
+
+// reschedulePendingPodsLocked retries every unscheduled, non-terminal Pod
+// against the current node set in deterministic (name-sorted) order, placing
+// those that now fit and refreshing Endpoints for the namespaces that changed.
+// Callers hold s.mu.
+func (s *ClusterState) reschedulePendingPodsLocked() {
+	touched := map[string]bool{}
+
+	for _, key := range s.sortedPodKeysLocked() {
+		pod := s.pods[key]
+		if pod.Spec.NodeName != "" || podTerminal(pod) {
+			continue
+		}
+
+		s.markPodRunningLocked(pod)
+
+		if pod.Spec.NodeName != "" {
+			touched[pod.Namespace] = true
+			pod.ResourceVersion = s.nextClusterRVLocked()
+			s.wPods.publish(EventModified, pod.Namespace, *pod.DeepCopy())
+		}
+	}
+
+	for ns := range touched {
+		s.resyncEndpointsForNamespaceLocked(ns)
+	}
+}
+
+// evacuateNodeLocked handles the Pods bound to a just-removed node in
+// deterministic (name-sorted) order: DaemonSet Pods are deleted (node-pinned,
+// one per node), and every other Pod is unbound and rescheduled onto a remaining
+// fitting node (Pending when none fits). Endpoints are refreshed for the
+// namespaces that changed. Callers hold s.mu.
+func (s *ClusterState) evacuateNodeLocked(node string) {
+	touched := map[string]bool{}
+
+	for _, key := range s.sortedPodKeysLocked() {
+		pod := s.pods[key]
+		if pod.Spec.NodeName != node || podTerminal(pod) {
+			continue
+		}
+
+		if podOwnedByDaemonSet(pod) {
+			delete(s.pods, key)
+			s.wPods.publish(EventDeleted, pod.Namespace, *pod.DeepCopy())
+		} else {
+			s.rebindPodLocked(pod)
+		}
+
+		touched[pod.Namespace] = true
+	}
+
+	for ns := range touched {
+		s.resyncEndpointsForNamespaceLocked(ns)
+	}
+}
+
+// rebindPodLocked unbinds a Pod from its (removed) node and re-runs the scheduler
+// so it lands on a remaining fitting node, or falls back to Pending/
+// Unschedulable. The Pod keeps its identity (UID/name); its runtime status is
+// cleared first so a re-placed Pod gets a fresh IP and a Pending one carries no
+// stale address. Callers hold s.mu.
+func (s *ClusterState) rebindPodLocked(pod *corev1.Pod) {
+	pod.Spec.NodeName = ""
+	pod.Status.PodIP = ""
+	pod.Status.PodIPs = nil
+	pod.Status.HostIP = ""
+	pod.Status.ContainerStatuses = nil
+
+	s.markPodRunningLocked(pod)
+
+	pod.ResourceVersion = s.nextClusterRVLocked()
+	s.wPods.publish(EventModified, pod.Namespace, *pod.DeepCopy())
+}
+
+// sortedPodKeysLocked returns s.pods keys in name-sorted order so a scheduling
+// sweep visits Pods deterministically. Callers hold s.mu.
+func (s *ClusterState) sortedPodKeysLocked() []string {
+	keys := make([]string, 0, len(s.pods))
+	for k := range s.pods {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+// podTerminal reports whether a Pod has reached a terminal phase and so is not a
+// (re)scheduling candidate.
+func podTerminal(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed
+}
+
+// podOwnedByDaemonSet reports whether a Pod is controlled by a DaemonSet.
+func podOwnedByDaemonSet(pod *corev1.Pod) bool {
+	for i := range pod.OwnerReferences {
+		if pod.OwnerReferences[i].Kind == kindDaemonSet {
+			return true
+		}
+	}
+
+	return false
+}
+
 // seedNodeLeaseLocked creates a node's kube-node-lease Lease (kubelet heartbeat
 // object), so `kubectl -n kube-node-lease get leases` shows every node's lease
 // like a real cluster. Callers hold s.mu.
@@ -474,4 +607,25 @@ func (s *ClusterState) seedNodeLeaseLocked(name string) {
 	s.stampRegistryRVLocked(lease)
 
 	store.items[objKey("kube-node-lease", name)] = lease
+}
+
+// deleteNodeLeaseLocked removes a node's kube-node-lease Lease — the counterpart
+// to seedNodeLeaseLocked — when the node is deleted, so no orphan lease outlives
+// its node. Callers hold s.mu.
+func (s *ClusterState) deleteNodeLeaseLocked(name string) {
+	store := s.reg.getStore(apiGroupCoordination, "v1", "leases")
+	if store == nil {
+		return
+	}
+
+	key := objKey("kube-node-lease", name)
+
+	lease, ok := store.items[key]
+	if !ok {
+		return
+	}
+
+	s.stampRegistryRVLocked(lease)
+	delete(store.items, key)
+	store.watch.publish(EventDeleted, "kube-node-lease", *lease.DeepCopy())
 }

--- a/services/kubernetes/node.go
+++ b/services/kubernetes/node.go
@@ -455,12 +455,41 @@ func podRequests(pod *corev1.Pod) (cpu, mem resource.Quantity) {
 
 // reconcileNode runs after a Node is created or updated through the API. A node
 // added (or re-labeled/un-tainted) at runtime expands the schedulable set, so
-// every Pod still Pending — nothing fit it when it was created — is retried
-// against the current nodes and placed if one now accepts it. Seeded nodes are
-// inserted directly and never reach this hook, so the fixed-at-seed multi-node
-// path is unchanged.
+// real k8s's controllers react on Node membership: every existing DaemonSet
+// re-fans onto the new node (refanDaemonSetsLocked), and every Pod still Pending
+// — nothing fit it when it was created — is retried against the current nodes
+// and placed if one now accepts it. DaemonSets are re-fanned first so their
+// node-pinned Pods claim capacity before the Pending resweep fills the rest.
+// Seeded nodes are inserted directly and never reach this hook, so the
+// fixed-at-seed multi-node path is unchanged.
 func reconcileNode(s *ClusterState, _ *unstructured.Unstructured) {
+	s.refanDaemonSetsLocked()
 	s.reschedulePendingPodsLocked()
+}
+
+// refanDaemonSetsLocked re-runs every DaemonSet's placement against the current
+// node set so a newly-added node immediately gets the DaemonSet Pods it matches
+// (real k8s's DaemonSet controller watches Node creation). It reuses the normal
+// DaemonSet reconcile in deterministic name-sorted order: placement is
+// idempotent (a node that already has the Pod is skipped) and writes Pods
+// straight to the typed store, so it never routes back through registryCreate/
+// Update and cannot re-trigger Node reconcile. Callers hold s.mu.
+func (s *ClusterState) refanDaemonSetsLocked() {
+	store := s.reg.getStore(apiGroupApps, "v1", "daemonsets")
+	if store == nil {
+		return
+	}
+
+	keys := make([]string, 0, len(store.items))
+	for k := range store.items {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		reconcileDaemonSet(s, store.items[k])
+	}
 }
 
 // nodeOnDelete runs after a Node is removed through the API. Its bound Pods can

--- a/services/kubernetes/node_dynamic_test.go
+++ b/services/kubernetes/node_dynamic_test.go
@@ -70,6 +70,37 @@ func TestDynamicNode_AddSchedulesPendingPod(t *testing.T) {
 	}
 }
 
+func TestDynamicNode_AddRefansDaemonSet(t *testing.T) {
+	base, done := newMultiNodeFixture(t, 3) // node-0 (tainted), node-1 + node-2 (workers)
+	defer done()
+
+	// A DaemonSet fans one Pod onto each worker (agent-cloudemu-node-1/-2).
+	ds := mustJSON(t, map[string]any{
+		"apiVersion": "apps/v1", "kind": "DaemonSet",
+		"metadata": map[string]any{"name": "agent"},
+		"spec": map[string]any{
+			"selector": map[string]any{"matchLabels": map[string]any{"app": "agent"}},
+			"template": map[string]any{
+				"metadata": map[string]any{"labels": map[string]any{"app": "agent"}},
+				"spec":     map[string]any{"containers": []any{map[string]any{"name": "c", "image": "agent"}}},
+			},
+		},
+	})
+	do(t, http.MethodPost, base+"/apis/apps/v1/namespaces/default/daemonsets", ds).Body.Close()
+
+	if _, ok := podPlacements(t, base, "default")["agent-cloudemu-node-9"]; ok {
+		t.Fatalf("agent-cloudemu-node-9 must not exist before the node is added")
+	}
+
+	// Registering a new schedulable node must immediately re-fan the DaemonSet
+	// onto it, as the real DaemonSet controller does on Node creation.
+	do(t, http.MethodPost, base+"/api/v1/nodes", workerNodeJSON(t, "cloudemu-node-9", "4")).Body.Close()
+
+	if got := podPlacements(t, base, "default")["agent-cloudemu-node-9"]; got.node != "cloudemu-node-9" || got.phase != "Running" {
+		t.Fatalf("agent-cloudemu-node-9 after add: node=%q phase=%q, want cloudemu-node-9/Running", got.node, got.phase)
+	}
+}
+
 func TestDynamicNode_DeleteReschedulesBoundPod(t *testing.T) {
 	base, done := newMultiNodeFixture(t, 3) // node-0 (tainted), node-1 + node-2 (workers, 4 CPU)
 	defer done()

--- a/services/kubernetes/node_dynamic_test.go
+++ b/services/kubernetes/node_dynamic_test.go
@@ -1,0 +1,153 @@
+// Tests for dynamic Node add/remove (#894): registering a Node at runtime
+// schedules Pods left Pending because nothing fit them, and deleting a Node
+// reschedules its bound Pods onto a remaining fitting node (and deletes the
+// node-pinned DaemonSet Pods). Node membership was fixed-at-seed before this.
+
+package kubernetes_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// workerNodeJSON builds a schedulable worker Node (untainted, cpu allocatable)
+// as a client would POST it to register a node at runtime.
+func workerNodeJSON(t *testing.T, name, cpu string) []byte {
+	t.Helper()
+
+	return mustJSON(t, map[string]any{
+		"apiVersion": "v1", "kind": "Node",
+		"metadata": map[string]any{
+			"name":   name,
+			"labels": map[string]any{"kubernetes.io/hostname": name},
+		},
+		"status": map[string]any{
+			"allocatable": map[string]any{"cpu": cpu},
+			"addresses":   []any{map[string]any{"type": "InternalIP", "address": "10.0.0.99"}},
+		},
+	})
+}
+
+// cpuPodJSON builds a Pod requesting `cpu` CPU with no control-plane toleration.
+func cpuPodJSON(t *testing.T, name, cpu string) []byte {
+	t.Helper()
+
+	return mustJSON(t, map[string]any{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": map[string]any{"name": name},
+		"spec": map[string]any{
+			"containers": []any{map[string]any{
+				"name": "c", "image": "nginx",
+				"resources": map[string]any{"requests": map[string]any{"cpu": cpu}},
+			}},
+		},
+	})
+}
+
+func TestDynamicNode_AddSchedulesPendingPod(t *testing.T) {
+	base, done := newMultiNodeFixture(t, 2) // node-0 (control-plane, tainted), node-1 (worker, 4 CPU)
+	defer done()
+
+	// Fill the only worker, then add a Pod that no longer fits: node-1 is full and
+	// the control-plane node is tainted -> the second Pod is stuck Pending.
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods", cpuPodJSON(t, "filler", "4")).Body.Close()
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods", cpuPodJSON(t, "waiter", "4")).Body.Close()
+
+	if got := podPlacements(t, base, "default")["waiter"]; got.phase != "Pending" || got.node != "" {
+		t.Fatalf("waiter before add: phase=%q node=%q, want Pending/unscheduled", got.phase, got.node)
+	}
+
+	// Register a new worker at runtime -> the Pending Pod must schedule onto it.
+	resp := do(t, http.MethodPost, base+"/api/v1/nodes", workerNodeJSON(t, "cloudemu-node-9", "4"))
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("node create status: got %d, want 201", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	if got := podPlacements(t, base, "default")["waiter"]; got.phase != "Running" || got.node != "cloudemu-node-9" {
+		t.Fatalf("waiter after add: phase=%q node=%q, want Running/cloudemu-node-9", got.phase, got.node)
+	}
+}
+
+func TestDynamicNode_DeleteReschedulesBoundPod(t *testing.T) {
+	base, done := newMultiNodeFixture(t, 3) // node-0 (tainted), node-1 + node-2 (workers, 4 CPU)
+	defer done()
+
+	// First-fit places the Pod on node-1 (node-0 tainted, node-1 fits 2<=4 first).
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods", cpuPodJSON(t, "mover", "2")).Body.Close()
+
+	if got := podPlacements(t, base, "default")["mover"]; got.node != "cloudemu-node-1" || got.phase != "Running" {
+		t.Fatalf("mover before delete: node=%q phase=%q, want cloudemu-node-1/Running", got.node, got.phase)
+	}
+
+	// Delete the node it runs on -> it must reschedule onto the remaining worker.
+	resp := do(t, http.MethodDelete, base+"/api/v1/nodes/cloudemu-node-1", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("node delete status: got %d, want 200", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	if got := podPlacements(t, base, "default")["mover"]; got.node != "cloudemu-node-2" || got.phase != "Running" {
+		t.Fatalf("mover after delete: node=%q phase=%q, want cloudemu-node-2/Running", got.node, got.phase)
+	}
+}
+
+func TestDynamicNode_DeleteWithNoRemainingFitGoesPending(t *testing.T) {
+	base, done := newMultiNodeFixture(t, 3) // node-0 (tainted), node-1 + node-2 (workers, 4 CPU)
+	defer done()
+
+	// Fill node-1 (first-fit), then place "solo" on node-2. Both workers are now
+	// full; the control-plane node stays tainted.
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods", cpuPodJSON(t, "block", "4")).Body.Close()
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods", cpuPodJSON(t, "solo", "4")).Body.Close()
+
+	if got := podPlacements(t, base, "default")["solo"]; got.node != "cloudemu-node-2" {
+		t.Fatalf("solo before delete: node=%q, want cloudemu-node-2", got.node)
+	}
+
+	// Delete solo's node. Two nodes remain (still multi-node): the control-plane
+	// node is tainted and node-1 is full, so solo falls back to Pending.
+	do(t, http.MethodDelete, base+"/api/v1/nodes/cloudemu-node-2", nil).Body.Close()
+
+	if got := podPlacements(t, base, "default")["solo"]; got.phase != "Pending" || got.node != "" {
+		t.Fatalf("solo after delete: phase=%q node=%q, want Pending/unscheduled", got.phase, got.node)
+	}
+}
+
+func TestDynamicNode_DeleteRemovesNodePinnedDaemonSetPod(t *testing.T) {
+	base, done := newMultiNodeFixture(t, 3) // node-0 (tainted), node-1 + node-2 (workers)
+	defer done()
+
+	// A DaemonSet fans one Pod onto each worker (agent-cloudemu-node-1/-2).
+	ds := mustJSON(t, map[string]any{
+		"apiVersion": "apps/v1", "kind": "DaemonSet",
+		"metadata": map[string]any{"name": "agent"},
+		"spec": map[string]any{
+			"selector": map[string]any{"matchLabels": map[string]any{"app": "agent"}},
+			"template": map[string]any{
+				"metadata": map[string]any{"labels": map[string]any{"app": "agent"}},
+				"spec":     map[string]any{"containers": []any{map[string]any{"name": "c", "image": "agent"}}},
+			},
+		},
+	})
+	do(t, http.MethodPost, base+"/apis/apps/v1/namespaces/default/daemonsets", ds).Body.Close()
+
+	if _, ok := podPlacements(t, base, "default")["agent-cloudemu-node-1"]; !ok {
+		t.Fatalf("DaemonSet Pod agent-cloudemu-node-1 should exist before the node is deleted")
+	}
+
+	// Deleting the node removes its node-pinned DaemonSet Pod (not rescheduled:
+	// DaemonSet Pods are one-per-node, and the node is gone).
+	do(t, http.MethodDelete, base+"/api/v1/nodes/cloudemu-node-1", nil).Body.Close()
+
+	pods := podPlacements(t, base, "default")
+	if _, ok := pods["agent-cloudemu-node-1"]; ok {
+		t.Fatalf("DaemonSet Pod agent-cloudemu-node-1 must be deleted with its node")
+	}
+
+	if _, ok := pods["agent-cloudemu-node-2"]; !ok {
+		t.Fatalf("DaemonSet Pod on the surviving worker must remain")
+	}
+}

--- a/services/kubernetes/registry_defs.go
+++ b/services/kubernetes/registry_defs.go
@@ -166,6 +166,7 @@ func coreRegistryDefs() []*resourceDef {
 		{
 			group: "", version: "v1", kind: "Node", listKind: "NodeList",
 			plural: "nodes", namespaced: false, hasStatus: true,
+			reconcile: reconcileNode, onDelete: nodeOnDelete,
 			tableColumns: nodeTableProjector(),
 		},
 		{


### PR DESCRIPTION
## What

Makes Kubernetes Node membership dynamic. A Node is now a first-class, mutable
placement target: registering one at runtime expands the schedulable set, and
deleting one contracts it.

Closes #894 (multi-node was fixed-at-seed; deleting/adding a Node object was a
documented no-op because the registry had no cross-kind reconcile on write/delete).

## Semantics

- **Node CREATE / UPDATE** — wired a `reconcile` hook (`reconcileNode`) on the
  Node registry def. When a node is added (or re-labeled / un-tainted), every Pod
  still Pending — nothing fit it at creation — is retried against the current node
  set and placed if one now accepts it.
- **Node DELETE** — wired an `onDelete` hook (`nodeOnDelete`). For each non-terminal
  Pod bound to the removed node:
  - **DaemonSet Pods** are deleted — they are node-pinned one-per-node, so the Pod
    for a gone node is removed, not moved (a later DaemonSet write won't recreate it).
  - **every other Pod** is unbound and rescheduled onto a remaining fitting node,
    falling back to Pending/Unschedulable when none fits.
  The node's `kube-node-lease` Lease is removed too (counterpart to seeding).

## Determinism

Both sweeps iterate Pods in name-sorted order and reuse the existing first-fit
scheduler (`scheduleNodeLocked`), so placement is reproducible. Seeded nodes are
inserted directly and never reach the reconcile hook, so the fixed-at-seed
multi-node path and every single-node test are unchanged. Reducing a cluster to a
single remaining node intentionally re-enters the documented single-node
back-compat path (unconditional placement).

## Tests

`node_dynamic_test.go`: pending Pod schedules after a node is added; a bound Pod
reschedules onto the surviving worker after its node is deleted; no-remaining-fit
falls back to Pending; a node-pinned DaemonSet Pod is deleted with its node. All
four fail before the change.

Blast radius is confined to the `kubernetes` package; EKS/GKE/AKS/serverkit
consumers pass. No driver-interface change, so no coverage-doc diff.
