### PR TITLE
feat(kubernetes): advanced scheduling — node/pod affinity, topology spread, scoring (#893)

### DIFF
--- a/services/kubernetes/node.go
+++ b/services/kubernetes/node.go
@@ -24,8 +24,10 @@ import (
 // node in name-sorted order), and deleting one contracts it (nodeOnDelete
 // deletes the node-pinned DaemonSet Pods and reschedules every other bound Pod
 // onto a remaining fitting node, falling back to Pending). Node/inter-pod
-// affinity, topology spread, scoring/bin-packing, and tolerationSeconds/live
-// eviction are deferred follow-ups.
+// affinity, topology spread, and preferred-affinity scoring extend the filter/
+// score path in scheduling.go; tolerationSeconds and live NoExecute taint-based
+// eviction (evicting a running Pod after its toleration expires) still need a
+// background controller loop and remain a deferred follow-up.
 
 const (
 	// nodeKubeletVersion is the Kubernetes version the synthetic nodes report;
@@ -298,11 +300,13 @@ func (s *ClusterState) nodeInternalIPLocked(name string) string {
 // succeeded. An explicit spec.nodeName bypasses the scheduler (kubelet-style
 // direct assignment). With a single node, the pod is placed unconditionally
 // (the historical back-compat path — no nodeSelector/taint/request gating). With
-// multiple nodes it runs deterministic first-fit over the name-sorted candidates,
-// filtering by nodeSelector, taints/tolerations, and request feasibility; the
-// first feasible node wins. When nothing fits it emits FailedScheduling and
-// returns false, leaving the caller to mark the pod Unschedulable. Callers hold
-// s.mu.
+// multiple nodes it runs the two-phase scheduler: feasibleNodesLocked filters
+// the name-sorted candidates by nodeSelector, taints/tolerations, request
+// feasibility, required nodeAffinity, required inter-pod (anti)affinity, and
+// DoNotSchedule topology spread; bestScoredNodeLocked then scores the survivors
+// by preferred affinity and spread skew, breaking ties by lowest name. When
+// nothing is feasible it emits FailedScheduling and returns false, leaving the
+// caller to mark the pod Unschedulable. Callers hold s.mu.
 func (s *ClusterState) scheduleNodeLocked(pod *corev1.Pod) bool {
 	if pod.Spec.NodeName != "" {
 		return true
@@ -325,29 +329,18 @@ func (s *ClusterState) scheduleNodeLocked(pod *corev1.Pod) bool {
 		return true
 	}
 
-	for i := range nodes {
-		n := &nodes[i]
-		if !labelsMatch(pod.Spec.NodeSelector, n.labels) {
-			continue
-		}
+	feasible := s.feasibleNodesLocked(pod, nodes)
+	if len(feasible) == 0 {
+		s.recordFailedSchedulingLocked(pod)
 
-		if !podToleratesTaints(pod.Spec.Tolerations, n.taints) {
-			continue
-		}
-
-		if !s.podFitsNodeLocked(pod, n) {
-			continue
-		}
-
-		pod.Spec.NodeName = n.name
-		s.recordScheduledLocked(pod, n.name)
-
-		return true
+		return false
 	}
 
-	s.recordFailedSchedulingLocked(pod)
+	best := s.bestScoredNodeLocked(pod, feasible, nodes)
+	pod.Spec.NodeName = best
+	s.recordScheduledLocked(pod, best)
 
-	return false
+	return true
 }
 
 // recordScheduledLocked emits the scheduler's Scheduled event for a placed pod.
@@ -361,7 +354,7 @@ func (s *ClusterState) recordScheduledLocked(pod *corev1.Pod, node string) {
 func (s *ClusterState) recordFailedSchedulingLocked(pod *corev1.Pod) {
 	s.recordEventLocked(objectReferenceForPod(pod), "FailedScheduling",
 		"0/"+fmt.Sprint(len(s.nodesLocked()))+" nodes are available: no node matches the pod's "+
-			"nodeSelector, tolerations, or resource requests.")
+			"nodeSelector, tolerations, resource requests, affinity, or topology spread constraints.")
 }
 
 // podToleratesTaints reports whether the pod's tolerations cover every

--- a/services/kubernetes/scheduling.go
+++ b/services/kubernetes/scheduling.go
@@ -1,0 +1,476 @@
+package kubernetes
+
+// scheduling.go extends the multi-node scheduler (scheduleNodeLocked in node.go)
+// with the kube-scheduler predicate/priority split beyond the v1 first-fit set
+// (nodeSelector/taints/requests):
+//
+//   - Filtering (hard/required): required nodeAffinity, required inter-pod
+//     affinity/anti-affinity keyed by topologyKey, and topologySpreadConstraints
+//     with whenUnsatisfiable=DoNotSchedule. A Pod no node satisfies stays
+//     Pending/Unschedulable, matching real Kubernetes.
+//   - Scoring (soft/preferred): among the nodes that pass filtering, preferred
+//     nodeAffinity/pod-(anti)affinity weights and topology-spread skew
+//     minimization pick the best node deterministically (stable tie-break by
+//     node name), replacing naive first-fit with score-then-lowest-name.
+//
+// tolerationSeconds and live NoExecute taint-based eviction (evicting an
+// already-running Pod after its toleration expires) need a background eviction
+// controller loop and remain a deferred follow-up; only schedule-time taint
+// admission (podToleratesTaints, in node.go) is modeled here.
+
+import (
+	"math"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// feasibleNodesLocked returns the subset of nodes (name-sorted order preserved)
+// that pass every hard scheduling predicate for pod. Callers hold s.mu.
+func (s *ClusterState) feasibleNodesLocked(pod *corev1.Pod, nodes []schedNode) []schedNode {
+	out := make([]schedNode, 0, len(nodes))
+
+	for i := range nodes {
+		if s.nodeFitsPodLocked(pod, &nodes[i], nodes) {
+			out = append(out, nodes[i])
+		}
+	}
+
+	return out
+}
+
+// nodeFitsPodLocked reports whether n satisfies every required predicate for
+// pod: nodeSelector, taint tolerations, request feasibility, required
+// nodeAffinity, required inter-pod (anti)affinity, and DoNotSchedule topology
+// spread. Callers hold s.mu.
+func (s *ClusterState) nodeFitsPodLocked(pod *corev1.Pod, n *schedNode, nodes []schedNode) bool {
+	if !labelsMatch(pod.Spec.NodeSelector, n.labels) {
+		return false
+	}
+
+	if !podToleratesTaints(pod.Spec.Tolerations, n.taints) {
+		return false
+	}
+
+	if !s.podFitsNodeLocked(pod, n) {
+		return false
+	}
+
+	if !nodeMatchesRequiredAffinity(pod, n) {
+		return false
+	}
+
+	if !s.nodeSatisfiesPodAffinityLocked(pod, n, nodes) {
+		return false
+	}
+
+	return s.nodeSatisfiesTopologySpreadLocked(pod, n, nodes)
+}
+
+// bestScoredNodeLocked picks the highest-scoring node among feasible: preferred
+// affinity weight (higher wins), then lowest resulting topology-spread skew,
+// then lowest name (feasible is already name-sorted, so an unbroken tie keeps
+// the earliest). Callers hold s.mu.
+func (s *ClusterState) bestScoredNodeLocked(pod *corev1.Pod, feasible, nodes []schedNode) string {
+	best := 0
+	bestAff := s.preferredScoreLocked(pod, &feasible[0], nodes)
+	bestSkew := s.spreadScoreLocked(pod, &feasible[0], nodes)
+
+	for i := 1; i < len(feasible); i++ {
+		aff := s.preferredScoreLocked(pod, &feasible[i], nodes)
+		skew := s.spreadScoreLocked(pod, &feasible[i], nodes)
+
+		if aff > bestAff || (aff == bestAff && skew < bestSkew) {
+			best, bestAff, bestSkew = i, aff, skew
+		}
+	}
+
+	return feasible[best].name
+}
+
+// nodeMatchesRequiredAffinity reports whether n satisfies the pod's required
+// nodeAffinity. Terms are OR-ed (any matching term suffices); an absent
+// requirement is unconstrained.
+func nodeMatchesRequiredAffinity(pod *corev1.Pod, n *schedNode) bool {
+	aff := pod.Spec.Affinity
+	if aff == nil || aff.NodeAffinity == nil {
+		return true
+	}
+
+	req := aff.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	if req == nil || len(req.NodeSelectorTerms) == 0 {
+		return true
+	}
+
+	for i := range req.NodeSelectorTerms {
+		if nodeSelectorTermMatches(&req.NodeSelectorTerms[i], n) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// nodeSelectorTermMatches reports whether n satisfies a single nodeSelectorTerm:
+// every matchExpression (over labels) AND every matchField (metadata.name only)
+// must hold.
+func nodeSelectorTermMatches(term *corev1.NodeSelectorTerm, n *schedNode) bool {
+	for i := range term.MatchExpressions {
+		if !nodeSelectorReqMatches(&term.MatchExpressions[i], n.labels) {
+			return false
+		}
+	}
+
+	for i := range term.MatchFields {
+		f := &term.MatchFields[i]
+		if f.Key != "metadata.name" || !nodeSelectorReqMatches(f, map[string]string{"metadata.name": n.name}) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// nodeSelectorReqMatches evaluates one NodeSelectorRequirement against a label
+// set, honoring In/NotIn/Exists/DoesNotExist/Gt/Lt.
+func nodeSelectorReqMatches(req *corev1.NodeSelectorRequirement, lbls map[string]string) bool {
+	val, has := lbls[req.Key]
+
+	switch req.Operator {
+	case corev1.NodeSelectorOpIn:
+		return has && containsStr(req.Values, val)
+	case corev1.NodeSelectorOpNotIn:
+		return !has || !containsStr(req.Values, val)
+	case corev1.NodeSelectorOpExists:
+		return has
+	case corev1.NodeSelectorOpDoesNotExist:
+		return !has
+	case corev1.NodeSelectorOpGt:
+		return numericCompare(val, has, req.Values, true)
+	case corev1.NodeSelectorOpLt:
+		return numericCompare(val, has, req.Values, false)
+	default:
+		return false
+	}
+}
+
+// numericCompare implements the Gt/Lt operators: both the label value and the
+// single requirement value must parse as integers. gt selects greater-than.
+func numericCompare(val string, has bool, values []string, gt bool) bool {
+	if !has || len(values) != 1 {
+		return false
+	}
+
+	lv, err1 := strconv.ParseInt(val, 10, 64)
+	rv, err2 := strconv.ParseInt(values[0], 10, 64)
+
+	if err1 != nil || err2 != nil {
+		return false
+	}
+
+	if gt {
+		return lv > rv
+	}
+
+	return lv < rv
+}
+
+// nodeSatisfiesPodAffinityLocked reports whether n satisfies every required
+// inter-pod affinity term (a matching pod shares n's topology domain) and
+// anti-affinity term (no matching pod shares it). Callers hold s.mu.
+func (s *ClusterState) nodeSatisfiesPodAffinityLocked(pod *corev1.Pod, n *schedNode, nodes []schedNode) bool {
+	aff := pod.Spec.Affinity
+	if aff == nil {
+		return true
+	}
+
+	if aff.PodAffinity != nil {
+		for i := range aff.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
+			if !s.podAffinityTermSatisfiedLocked(pod, n, &aff.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution[i], true, nodes) {
+				return false
+			}
+		}
+	}
+
+	if aff.PodAntiAffinity != nil {
+		for i := range aff.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
+			t := &aff.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[i]
+			if !s.podAffinityTermSatisfiedLocked(pod, n, t, false, nodes) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// podAffinityTermSatisfiedLocked reports whether placing pod on n satisfies one
+// (anti)affinity term. want=true (affinity) needs a matching pod in n's topology
+// domain; want=false (anti-affinity) needs none. A node lacking the term's
+// topologyKey can never satisfy affinity and always satisfies anti-affinity.
+// Callers hold s.mu.
+func (s *ClusterState) podAffinityTermSatisfiedLocked(
+	pod *corev1.Pod, n *schedNode, term *corev1.PodAffinityTerm, want bool, nodes []schedNode,
+) bool {
+	domain, ok := n.labels[term.TopologyKey]
+	if !ok {
+		return !want
+	}
+
+	return s.matchingPodInDomainLocked(pod.Namespace, term, domain, nodes) == want
+}
+
+// matchingPodInDomainLocked reports whether any already-scheduled, non-terminal
+// pod matching the term's labelSelector (in the term's namespaces, defaulting to
+// podNS) runs on a node whose topologyKey value equals domain. Callers hold s.mu.
+func (s *ClusterState) matchingPodInDomainLocked(
+	podNS string, term *corev1.PodAffinityTerm, domain string, nodes []schedNode,
+) bool {
+	sel, err := metav1.LabelSelectorAsSelector(term.LabelSelector)
+	if err != nil {
+		return false
+	}
+
+	namespaces := affinityTermNamespaces(podNS, term)
+	nodeDomain := nodeDomainIndex(nodes, term.TopologyKey)
+
+	for _, p := range s.pods {
+		if p.Spec.NodeName == "" || podTerminal(p) || !namespaces[p.Namespace] {
+			continue
+		}
+
+		if nodeDomain[p.Spec.NodeName] == domain && sel.Matches(labels.Set(p.Labels)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// affinityTermNamespaces returns the namespace set an inter-pod affinity term
+// scopes to: its explicit Namespaces list, else the scheduling pod's own
+// namespace. NamespaceSelector is not modeled.
+func affinityTermNamespaces(podNS string, term *corev1.PodAffinityTerm) map[string]bool {
+	if len(term.Namespaces) == 0 {
+		return map[string]bool{podNS: true}
+	}
+
+	out := make(map[string]bool, len(term.Namespaces))
+	for _, ns := range term.Namespaces {
+		out[ns] = true
+	}
+
+	return out
+}
+
+// nodeSatisfiesTopologySpreadLocked reports whether placing pod on n keeps every
+// DoNotSchedule spread constraint within maxSkew. Callers hold s.mu.
+func (s *ClusterState) nodeSatisfiesTopologySpreadLocked(pod *corev1.Pod, n *schedNode, nodes []schedNode) bool {
+	for i := range pod.Spec.TopologySpreadConstraints {
+		c := &pod.Spec.TopologySpreadConstraints[i]
+		if c.WhenUnsatisfiable != corev1.DoNotSchedule {
+			continue
+		}
+
+		if !s.spreadConstraintOKLocked(pod, n, c, nodes) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// spreadConstraintOKLocked reports whether hypothetically placing pod on n keeps
+// constraint c's skew (max-min matching-pod count across topology domains)
+// within maxSkew. A node without the constraint's topologyKey is unconstrained.
+// Callers hold s.mu.
+func (s *ClusterState) spreadConstraintOKLocked(
+	pod *corev1.Pod, n *schedNode, c *corev1.TopologySpreadConstraint, nodes []schedNode,
+) bool {
+	domain, ok := n.labels[c.TopologyKey]
+	if !ok {
+		return true
+	}
+
+	counts := s.domainMatchCountsLocked(pod.Namespace, c, nodes)
+	counts[domain]++
+
+	maxSkew := int(c.MaxSkew)
+	if maxSkew < 1 {
+		maxSkew = 1
+	}
+
+	return maxSkewOf(counts) <= maxSkew
+}
+
+// domainMatchCountsLocked counts, per topology domain, the already-scheduled
+// pods in podNS matching c's labelSelector. Every domain that exists among the
+// nodes carrying c's topologyKey is seeded to 0 so empty domains lower the min.
+// Callers hold s.mu.
+func (s *ClusterState) domainMatchCountsLocked(
+	podNS string, c *corev1.TopologySpreadConstraint, nodes []schedNode,
+) map[string]int {
+	counts := seededDomains(nodes, c.TopologyKey)
+
+	sel, err := metav1.LabelSelectorAsSelector(c.LabelSelector)
+	if err != nil {
+		return counts
+	}
+
+	nodeDomain := nodeDomainIndex(nodes, c.TopologyKey)
+
+	for _, p := range s.pods {
+		if p.Spec.NodeName == "" || podTerminal(p) || p.Namespace != podNS {
+			continue
+		}
+
+		if d, ok := nodeDomain[p.Spec.NodeName]; ok && sel.Matches(labels.Set(p.Labels)) {
+			counts[d]++
+		}
+	}
+
+	return counts
+}
+
+// preferredScoreLocked sums the pod's satisfied soft-preference weights on n:
+// preferred nodeAffinity plus preferred pod affinity/anti-affinity. Callers hold
+// s.mu.
+func (s *ClusterState) preferredScoreLocked(pod *corev1.Pod, n *schedNode, nodes []schedNode) int64 {
+	aff := pod.Spec.Affinity
+	if aff == nil {
+		return 0
+	}
+
+	var score int64
+
+	if aff.NodeAffinity != nil {
+		score += preferredNodeAffinityScore(aff.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution, n)
+	}
+
+	if aff.PodAffinity != nil {
+		score += s.weightedPodTermScoreLocked(pod, aff.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution, n, true, nodes)
+	}
+
+	if aff.PodAntiAffinity != nil {
+		score += s.weightedPodTermScoreLocked(pod, aff.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution, n, false, nodes)
+	}
+
+	return score
+}
+
+// preferredNodeAffinityScore sums the weights of the preferred nodeAffinity
+// terms whose preference matches n.
+func preferredNodeAffinityScore(terms []corev1.PreferredSchedulingTerm, n *schedNode) int64 {
+	var score int64
+
+	for i := range terms {
+		if nodeSelectorTermMatches(&terms[i].Preference, n) {
+			score += int64(terms[i].Weight)
+		}
+	}
+
+	return score
+}
+
+// weightedPodTermScoreLocked sums the weights of the weighted (anti)affinity
+// terms satisfied by placing pod on n. Callers hold s.mu.
+func (s *ClusterState) weightedPodTermScoreLocked(
+	pod *corev1.Pod, terms []corev1.WeightedPodAffinityTerm, n *schedNode, want bool, nodes []schedNode,
+) int64 {
+	var score int64
+
+	for i := range terms {
+		if s.podAffinityTermSatisfiedLocked(pod, n, &terms[i].PodAffinityTerm, want, nodes) {
+			score += int64(terms[i].Weight)
+		}
+	}
+
+	return score
+}
+
+// spreadScoreLocked returns the total resulting skew across all of the pod's
+// topology spread constraints if it were placed on n (lower is more balanced).
+// Callers hold s.mu.
+func (s *ClusterState) spreadScoreLocked(pod *corev1.Pod, n *schedNode, nodes []schedNode) int {
+	total := 0
+
+	for i := range pod.Spec.TopologySpreadConstraints {
+		c := &pod.Spec.TopologySpreadConstraints[i]
+
+		domain, ok := n.labels[c.TopologyKey]
+		if !ok {
+			continue
+		}
+
+		counts := s.domainMatchCountsLocked(pod.Namespace, c, nodes)
+		counts[domain]++
+		total += maxSkewOf(counts)
+	}
+
+	return total
+}
+
+// seededDomains returns a counts map with a zero entry for every distinct
+// topology domain present among nodes carrying topologyKey, so empty domains
+// count toward the skew's minimum.
+func seededDomains(nodes []schedNode, topologyKey string) map[string]int {
+	counts := map[string]int{}
+
+	for i := range nodes {
+		if d, ok := nodes[i].labels[topologyKey]; ok {
+			if _, seen := counts[d]; !seen {
+				counts[d] = 0
+			}
+		}
+	}
+
+	return counts
+}
+
+// nodeDomainIndex maps node name -> topology domain value for every node that
+// carries topologyKey.
+func nodeDomainIndex(nodes []schedNode, topologyKey string) map[string]string {
+	out := make(map[string]string, len(nodes))
+
+	for i := range nodes {
+		if v, ok := nodes[i].labels[topologyKey]; ok {
+			out[nodes[i].name] = v
+		}
+	}
+
+	return out
+}
+
+// maxSkewOf returns max-min over the domain counts (0 when empty).
+func maxSkewOf(counts map[string]int) int {
+	if len(counts) == 0 {
+		return 0
+	}
+
+	minV, maxV := math.MaxInt, math.MinInt
+
+	for _, v := range counts {
+		if v < minV {
+			minV = v
+		}
+
+		if v > maxV {
+			maxV = v
+		}
+	}
+
+	return maxV - minV
+}
+
+// containsStr reports whether vals contains target.
+func containsStr(vals []string, target string) bool {
+	for _, v := range vals {
+		if v == target {
+			return true
+		}
+	}
+
+	return false
+}

--- a/services/kubernetes/scheduling_test.go
+++ b/services/kubernetes/scheduling_test.go
@@ -1,0 +1,284 @@
+// Tests for the advanced scheduler (#893): required nodeAffinity placement and
+// rejection, required inter-pod anti-affinity spreading across topology domains,
+// topologySpreadConstraints balancing with maxSkew, preferred-affinity scoring
+// biasing placement over first-fit, and an unsatisfiable required constraint
+// leaving a Pod Pending. A plain Pod (no affinity/spread) must still schedule
+// first-fit exactly as before (regression guard). tolerationSeconds / live
+// NoExecute eviction are a deferred follow-up and not covered here.
+
+package kubernetes_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// labeledNodeJSON registers a schedulable, untainted worker Node with an
+// explicit label set and 4 CPU allocatable — a client seeding a labeled node
+// pool (zones, disk types) for affinity/spread scheduling.
+func labeledNodeJSON(t *testing.T, name string, labels map[string]any) []byte {
+	t.Helper()
+
+	l := map[string]any{"kubernetes.io/hostname": name}
+	for k, v := range labels {
+		l[k] = v
+	}
+
+	return mustJSON(t, map[string]any{
+		"apiVersion": "v1", "kind": "Node",
+		"metadata": map[string]any{"name": name, "labels": l},
+		"status": map[string]any{
+			"allocatable": map[string]any{"cpu": "4"},
+			"addresses":   []any{map[string]any{"type": "InternalIP", "address": "10.0.0.50"}},
+		},
+	})
+}
+
+// registerNode POSTs a Node and asserts it was created.
+func registerNode(t *testing.T, base string, body []byte) {
+	t.Helper()
+
+	resp := do(t, http.MethodPost, base+"/api/v1/nodes", body)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("node create status: got %d, want 201", resp.StatusCode)
+	}
+}
+
+// zonedPoolFixture returns a fixture whose only labeled worker pool is the nodes
+// the caller registers. It starts from a single (untainted) seed node with no
+// "pool" label, so a pod pinned via nodeSelector pool=app only ever considers
+// the registered zone nodes — isolating affinity/spread behavior from the seed.
+func zonedPoolFixture(t *testing.T, nodes ...[]byte) (string, func()) {
+	t.Helper()
+
+	base, done := newMultiNodeFixture(t, 1)
+	for _, n := range nodes {
+		registerNode(t, base, n)
+	}
+
+	return base, done
+}
+
+const zoneKey = "topology.kubernetes.io/zone"
+
+func TestScheduling_RequiredNodeAffinityPlacesAndRejects(t *testing.T) {
+	base, done := zonedPoolFixture(t,
+		labeledNodeJSON(t, "worker-ssd", map[string]any{"pool": "app", "disktype": "ssd"}),
+		labeledNodeJSON(t, "worker-hdd", map[string]any{"pool": "app", "disktype": "hdd"}),
+	)
+	defer done()
+
+	// required nodeAffinity disktype In [ssd] must place onto the ssd node only.
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods",
+		affinityPodJSON(t, "wants-ssd", "ssd")).Body.Close()
+
+	if got := podPlacements(t, base, "default")["wants-ssd"]; got.node != "worker-ssd" || got.phase != "Running" {
+		t.Fatalf("wants-ssd: node=%q phase=%q, want worker-ssd/Running", got.node, got.phase)
+	}
+
+	// required nodeAffinity disktype In [nvme] matches no node -> Pending.
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods",
+		affinityPodJSON(t, "wants-nvme", "nvme")).Body.Close()
+
+	if got := podPlacements(t, base, "default")["wants-nvme"]; got.phase != "Pending" || got.node != "" {
+		t.Fatalf("wants-nvme: phase=%q node=%q, want Pending/unscheduled", got.phase, got.node)
+	}
+}
+
+// affinityPodJSON builds a Pod pinned to the app pool that requires
+// disktype==disk via required nodeAffinity.
+func affinityPodJSON(t *testing.T, name, disk string) []byte {
+	t.Helper()
+
+	return mustJSON(t, map[string]any{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": map[string]any{"name": name},
+		"spec": map[string]any{
+			"nodeSelector": map[string]any{"pool": "app"},
+			"affinity": map[string]any{"nodeAffinity": map[string]any{
+				"requiredDuringSchedulingIgnoredDuringExecution": map[string]any{
+					"nodeSelectorTerms": []any{map[string]any{
+						"matchExpressions": []any{map[string]any{
+							"key": "disktype", "operator": "In", "values": []any{disk},
+						}},
+					}},
+				},
+			}},
+			"containers": []any{map[string]any{"name": "c", "image": "nginx"}},
+		},
+	})
+}
+
+func TestScheduling_PodAntiAffinitySeparatesZones(t *testing.T) {
+	base, done := zonedPoolFixture(t,
+		labeledNodeJSON(t, "worker-a", map[string]any{"pool": "app", zoneKey: "zone-a"}),
+		labeledNodeJSON(t, "worker-b", map[string]any{"pool": "app", zoneKey: "zone-b"}),
+	)
+	defer done()
+
+	// Two web Pods that repel each other by zone must land in different zones.
+	for _, name := range []string{"web-1", "web-2"} {
+		do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods",
+			antiAffinityPodJSON(t, name)).Body.Close()
+	}
+
+	pods := podPlacements(t, base, "default")
+	if pods["web-1"].phase != "Running" || pods["web-2"].phase != "Running" {
+		t.Fatalf("both anti-affinity pods must be Running, got %+v", pods)
+	}
+
+	if pods["web-1"].node == pods["web-2"].node {
+		t.Fatalf("anti-affinity failed: both pods on %q, want different zones", pods["web-1"].node)
+	}
+}
+
+// antiAffinityPodJSON builds an app=web Pod that repels other app=web Pods
+// across the zone topology key.
+func antiAffinityPodJSON(t *testing.T, name string) []byte {
+	t.Helper()
+
+	return mustJSON(t, map[string]any{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": map[string]any{"name": name, "labels": map[string]any{"app": "web"}},
+		"spec": map[string]any{
+			"nodeSelector": map[string]any{"pool": "app"},
+			"affinity": map[string]any{"podAntiAffinity": map[string]any{
+				"requiredDuringSchedulingIgnoredDuringExecution": []any{map[string]any{
+					"topologyKey":   zoneKey,
+					"labelSelector": map[string]any{"matchLabels": map[string]any{"app": "web"}},
+				}},
+			}},
+			"containers": []any{map[string]any{"name": "c", "image": "nginx"}},
+		},
+	})
+}
+
+func TestScheduling_TopologySpreadBalancesZones(t *testing.T) {
+	base, done := zonedPoolFixture(t,
+		labeledNodeJSON(t, "worker-a", map[string]any{"pool": "app", zoneKey: "zone-a"}),
+		labeledNodeJSON(t, "worker-b", map[string]any{"pool": "app", zoneKey: "zone-b"}),
+	)
+	defer done()
+
+	// 4 replicas with maxSkew=1 across two zones must split 2/2.
+	dep := mustJSON(t, map[string]any{
+		"apiVersion": "apps/v1", "kind": "Deployment",
+		"metadata": map[string]any{"name": "spread"},
+		"spec": map[string]any{
+			"replicas": int64(4),
+			"selector": map[string]any{"matchLabels": map[string]any{"app": "web"}},
+			"template": map[string]any{
+				"metadata": map[string]any{"labels": map[string]any{"app": "web"}},
+				"spec": map[string]any{
+					"nodeSelector": map[string]any{"pool": "app"},
+					"topologySpreadConstraints": []any{map[string]any{
+						"maxSkew":           int64(1),
+						"topologyKey":       zoneKey,
+						"whenUnsatisfiable": "DoNotSchedule",
+						"labelSelector":     map[string]any{"matchLabels": map[string]any{"app": "web"}},
+					}},
+					"containers": []any{map[string]any{"name": "c", "image": "nginx"}},
+				},
+			},
+		},
+	})
+	do(t, http.MethodPost, base+"/apis/apps/v1/namespaces/default/deployments", dep).Body.Close()
+
+	perNode := map[string]int{}
+
+	for name, p := range podPlacements(t, base, "default") {
+		if p.phase != "Running" {
+			t.Fatalf("pod %s not Running: phase=%q", name, p.phase)
+		}
+
+		perNode[p.node]++
+	}
+
+	if perNode["worker-a"] != 2 || perNode["worker-b"] != 2 {
+		t.Fatalf("topology spread imbalance: worker-a=%d worker-b=%d, want 2/2", perNode["worker-a"], perNode["worker-b"])
+	}
+}
+
+func TestScheduling_PreferredNodeAffinityBiasesPlacement(t *testing.T) {
+	base, done := zonedPoolFixture(t,
+		labeledNodeJSON(t, "worker-a", map[string]any{"pool": "app", zoneKey: "zone-a"}),
+		labeledNodeJSON(t, "worker-b", map[string]any{"pool": "app", zoneKey: "zone-b"}),
+	)
+	defer done()
+
+	// worker-a sorts first (first-fit would pick it), but a preferred nodeAffinity
+	// weight for zone-b must bias placement onto worker-b.
+	pod := mustJSON(t, map[string]any{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": map[string]any{"name": "prefers-b"},
+		"spec": map[string]any{
+			"nodeSelector": map[string]any{"pool": "app"},
+			"affinity": map[string]any{"nodeAffinity": map[string]any{
+				"preferredDuringSchedulingIgnoredDuringExecution": []any{map[string]any{
+					"weight": int64(100),
+					"preference": map[string]any{"matchExpressions": []any{map[string]any{
+						"key": zoneKey, "operator": "In", "values": []any{"zone-b"},
+					}}},
+				}},
+			}},
+			"containers": []any{map[string]any{"name": "c", "image": "nginx"}},
+		},
+	})
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods", pod).Body.Close()
+
+	if got := podPlacements(t, base, "default")["prefers-b"]; got.node != "worker-b" || got.phase != "Running" {
+		t.Fatalf("prefers-b: node=%q phase=%q, want worker-b/Running (preferred affinity over first-fit)", got.node, got.phase)
+	}
+}
+
+func TestScheduling_UnsatisfiableRequiredConstraintStaysPending(t *testing.T) {
+	base, done := zonedPoolFixture(t,
+		labeledNodeJSON(t, "worker-a", map[string]any{"pool": "app"}),
+	)
+	defer done()
+
+	// required nodeAffinity gpu Exists matches no node -> Pending + FailedScheduling.
+	pod := mustJSON(t, map[string]any{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": map[string]any{"name": "needs-gpu"},
+		"spec": map[string]any{
+			"nodeSelector": map[string]any{"pool": "app"},
+			"affinity": map[string]any{"nodeAffinity": map[string]any{
+				"requiredDuringSchedulingIgnoredDuringExecution": map[string]any{
+					"nodeSelectorTerms": []any{map[string]any{
+						"matchExpressions": []any{map[string]any{"key": "gpu", "operator": "Exists"}},
+					}},
+				},
+			}},
+			"containers": []any{map[string]any{"name": "c", "image": "nginx"}},
+		},
+	})
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods", pod).Body.Close()
+
+	if got := podPlacements(t, base, "default")["needs-gpu"]; got.phase != "Pending" || got.node != "" {
+		t.Fatalf("needs-gpu: phase=%q node=%q, want Pending/unscheduled", got.phase, got.node)
+	}
+
+	if !eventReasons(t, base+"/api/v1/namespaces/default/events")["FailedScheduling"] {
+		t.Fatalf("expected a FailedScheduling event for the unschedulable pod")
+	}
+}
+
+func TestScheduling_PlainPodStillSchedulesFirstFit(t *testing.T) {
+	base, done := newMultiNodeFixture(t, 3)
+	defer done()
+
+	// No affinity/spread: first-fit onto the lowest-named worker, as before #893.
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods",
+		mustJSON(t, map[string]any{
+			"apiVersion": "v1", "kind": "Pod",
+			"metadata": map[string]any{"name": "plain"},
+			"spec":     map[string]any{"containers": []any{map[string]any{"name": "c", "image": "nginx"}}},
+		})).Body.Close()
+
+	if got := podPlacements(t, base, "default")["plain"]; got.node != "cloudemu-node-1" || got.phase != "Running" {
+		t.Fatalf("plain pod: node=%q phase=%q, want cloudemu-node-1/Running (unchanged first-fit)", got.node, got.phase)
+	}
+}


### PR DESCRIPTION
## What

Extends the multi-node Kubernetes scheduler (`scheduleNodeLocked`, deferred from #875's first-fit v1) with the real kube-scheduler predicate/priority split. Single-node clusters keep their unconditional back-compat placement; the two-phase path activates only at N>1.

### Filtering (hard / required)
- **Required `nodeAffinity`** (`requiredDuringSchedulingIgnoredDuringExecution`) — OR across `nodeSelectorTerms`, AND across `matchExpressions` (In/NotIn/Exists/DoesNotExist/Gt/Lt) and `matchFields` (`metadata.name`).
- **Required inter-pod affinity / anti-affinity** — keyed by `topologyKey` + label selector over already-scheduled pods; affinity needs a matching pod in the node's topology domain, anti-affinity needs none.
- **Topology spread `whenUnsatisfiable: DoNotSchedule`** — hypothetical placement must keep `maxSkew` across domains.

A pod no node satisfies stays Pending/Unschedulable with a `FailedScheduling` event, matching real Kubernetes.

### Scoring (soft / preferred)
Among nodes that pass filtering: preferred `nodeAffinity` weights, preferred pod (anti)affinity weights, and topology-spread skew minimization pick the best node. Deterministic, FakeClock-safe, stable tie-break by lowest node name (score-then-first-fit).

`nodeSelector`, taints/tolerations, and request feasibility (v1) continue to gate as before. Plain pods with no affinity/spread still schedule first-fit unchanged (regression-guarded).

## Why
Closes the advanced-scheduling gap tracked in #893 so IaC/manifests relying on affinity, anti-affinity, and topology spread place realistically against the emulator.

## Explicitly deferred (follow-up, NOT in this PR)
- **`tolerationSeconds` + live NoExecute taint-based eviction** — evicting an already-running pod after its toleration expires requires a background eviction-controller loop (a cross-cutting concern separate from schedule-time placement). Only schedule-time taint admission is modeled. Left as a documented follow-up rather than half-building an eviction loop.
- **`NamespaceSelector`** on inter-pod affinity terms (explicit `namespaces` list and the pod's own namespace are honored).

## Tests
New `scheduling_test.go` (black-box, HTTP): required nodeAffinity places/rejects, anti-affinity separates zones, topology spread balances 2/2 with maxSkew=1, preferred affinity biases over first-fit, unsatisfiable required constraint stays Pending, and a regression guard that a plain pod still schedules first-fit. The five new-behavior tests were confirmed to fail before the change.

Gates: `go build ./...`, `go test ./services/kubernetes/...`, `go test -race`, `golangci-lint` (0 new; the one remaining gosec finding is pre-existing in admission.go), and coveragegen (no diff — no driver-interface change).
