### PR TITLE
feat: state snapshot fork + rewind (time travel) (#107)

### DIFF
--- a/features/timetravel/timetravel.go
+++ b/features/timetravel/timetravel.go
@@ -1,0 +1,246 @@
+// Package timetravel adds named in-memory state snapshots to a running
+// emulator, layered on the existing whole-emulator snapshot primitive.
+//
+// It holds a registry of name -> serialized state, where each serialized state
+// is the marshaled persist.Snapshot produced by persist.ExportAll. On top of
+// that it offers three operations beyond a plain save/restore:
+//
+//   - Rewind: restore live emulator state to a named snapshot (undo).
+//   - Fork:   copy a stored snapshot under a new name, so a "what-if" branch
+//     can be explored (rewind to it, mutate, re-save it) without disturbing the
+//     branch it was forked from or any other branch.
+//   - Save/List/Delete: manage the named snapshots by label.
+//
+// The registry is provider-agnostic: it drives the same capture/restore surface
+// persist already uses, wired in as two funcs, and never touches individual
+// provider mocks. Stored snapshots are independent byte copies, so forks are
+// isolated by construction — mutating one branch cannot reach another. It is
+// deterministic and fully in-memory; snapshot timestamps come from a
+// config.Clock so tests observe fixed times.
+package timetravel
+
+import (
+	"encoding/json"
+	"regexp"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/persist"
+)
+
+// maxNameLen bounds a snapshot label.
+const maxNameLen = 64
+
+// nameRE matches an acceptable snapshot label: 1-64 chars of [A-Za-z0-9._-].
+// The bare "." and ".." are rejected separately so a label can never be a
+// path-traversal token if a caller ever persists it to disk.
+var nameRE = regexp.MustCompile(`^[A-Za-z0-9._-]{1,` + strconv.Itoa(maxNameLen) + `}$`)
+
+// CaptureFunc returns the whole-emulator live state as a marshaled
+// persist.Snapshot. Registry stores exactly these bytes under a label.
+type CaptureFunc func() ([]byte, error)
+
+// RestoreFunc replaces the whole-emulator live state from a marshaled
+// persist.Snapshot. Registry passes back the bytes it stored.
+type RestoreFunc func(state []byte) error
+
+// entry is one stored named snapshot. data is an independent copy of the
+// captured bytes, so forks never alias each other.
+type entry struct {
+	data       []byte
+	createdAt  time.Time
+	forkedFrom string
+	providers  []string
+}
+
+// Info describes a stored snapshot without exposing its bytes.
+type Info struct {
+	Name       string    `json:"name"`
+	CreatedAt  time.Time `json:"createdAt"`
+	ForkedFrom string    `json:"forkedFrom,omitempty"`
+	Providers  []string  `json:"providers,omitempty"`
+	Size       int       `json:"size"`
+}
+
+// Registry is a thread-safe store of named emulator snapshots supporting
+// save/list/delete plus rewind and fork.
+type Registry struct {
+	clock   config.Clock
+	capture CaptureFunc
+	restore RestoreFunc
+
+	mu      sync.RWMutex
+	entries map[string]*entry
+}
+
+// New builds a registry that captures and restores live state through the given
+// funcs. A nil clock defaults to the real system clock.
+func New(clock config.Clock, capture CaptureFunc, restore RestoreFunc) *Registry {
+	if clock == nil {
+		clock = config.RealClock{}
+	}
+
+	return &Registry{
+		clock:   clock,
+		capture: capture,
+		restore: restore,
+		entries: map[string]*entry{},
+	}
+}
+
+// Save captures current live state and stores it under name, overwriting any
+// existing snapshot with that name (so a branch can be re-saved after a rewind
+// and mutation).
+func (r *Registry) Save(name string) error {
+	if !validName(name) {
+		return errInvalidName(name)
+	}
+
+	data, err := r.capture()
+	if err != nil {
+		return cerrors.Newf(cerrors.Internal, "capture state: %v", err)
+	}
+
+	providers, err := providersOf(data)
+	if err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.entries[name] = &entry{
+		data:       cloneBytes(data),
+		createdAt:  r.clock.Now(),
+		providers:  providers,
+		forkedFrom: "",
+	}
+
+	return nil
+}
+
+// Rewind restores live state to the snapshot stored under name.
+func (r *Registry) Rewind(name string) error {
+	r.mu.RLock()
+	e, ok := r.entries[name]
+	r.mu.RUnlock()
+
+	if !ok {
+		return errNotFound(name)
+	}
+
+	if err := r.restore(cloneBytes(e.data)); err != nil {
+		return cerrors.Newf(cerrors.Internal, "restore state: %v", err)
+	}
+
+	return nil
+}
+
+// Fork copies the snapshot stored under from into a new, independent snapshot
+// named to. The copy is a distinct byte slice, so rewinding to and re-saving
+// either branch never affects the other. It fails if to already exists, so an
+// existing branch is never silently clobbered.
+func (r *Registry) Fork(from, to string) error {
+	if !validName(to) {
+		return errInvalidName(to)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	src, ok := r.entries[from]
+	if !ok {
+		return errNotFound(from)
+	}
+
+	if _, exists := r.entries[to]; exists {
+		return cerrors.Newf(cerrors.AlreadyExists, "snapshot %q already exists", to)
+	}
+
+	r.entries[to] = &entry{
+		data:       cloneBytes(src.data),
+		createdAt:  r.clock.Now(),
+		providers:  append([]string(nil), src.providers...),
+		forkedFrom: from,
+	}
+
+	return nil
+}
+
+// Delete removes the snapshot stored under name.
+func (r *Registry) Delete(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.entries[name]; !ok {
+		return errNotFound(name)
+	}
+
+	delete(r.entries, name)
+
+	return nil
+}
+
+// List returns the stored snapshots ordered by name.
+func (r *Registry) List() []Info {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make([]Info, 0, len(r.entries))
+	for name, e := range r.entries {
+		out = append(out, Info{
+			Name:       name,
+			CreatedAt:  e.createdAt,
+			ForkedFrom: e.forkedFrom,
+			Providers:  append([]string(nil), e.providers...),
+			Size:       len(e.data),
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+
+	return out
+}
+
+// providersOf parses a captured snapshot to list the providers it holds, which
+// doubles as a validation that the bytes are a well-formed snapshot of the
+// version this build understands.
+func providersOf(data []byte) ([]string, error) {
+	var snap persist.Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return nil, cerrors.Newf(cerrors.Internal, "parse captured snapshot: %v", err)
+	}
+
+	names := make([]string, 0, len(snap.Providers))
+	for p := range snap.Providers {
+		names = append(names, p)
+	}
+
+	sort.Strings(names)
+
+	return names, nil
+}
+
+func validName(name string) bool {
+	return name != "." && name != ".." && nameRE.MatchString(name)
+}
+
+func cloneBytes(b []byte) []byte {
+	c := make([]byte, len(b))
+	copy(c, b)
+
+	return c
+}
+
+func errNotFound(name string) error {
+	return cerrors.Newf(cerrors.NotFound, "snapshot %q not found", name)
+}
+
+func errInvalidName(name string) error {
+	return cerrors.Newf(cerrors.InvalidArgument,
+		"invalid snapshot name %q: 1-%d chars of [A-Za-z0-9._-], excluding . and ..", name, maxNameLen)
+}

--- a/features/timetravel/timetravel_test.go
+++ b/features/timetravel/timetravel_test.go
@@ -1,0 +1,204 @@
+package timetravel_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/features/timetravel"
+	"github.com/stackshy/cloudemu/v2/persist"
+	"github.com/stackshy/cloudemu/v2/providers/aws"
+)
+
+// awsWorld is a minimal live-state harness: it captures the current provider's
+// whole-emulator state via persist.ExportAll and restores it into a FRESH,
+// empty provider via persist.RestoreAll — exactly the reset-then-restore the
+// standalone server does on a rewind. Reassigning p on restore means later
+// captures observe the restored state.
+type awsWorld struct {
+	ctx context.Context
+	p   *aws.Provider
+}
+
+func (w *awsWorld) services() map[string]persist.Services {
+	return map[string]persist.Services{"aws": w.p.SnapshotServices()}
+}
+
+func (w *awsWorld) capture() ([]byte, error) {
+	snap, err := persist.ExportAll(w.ctx, w.services(), persist.Options{IncludeAssets: true})
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(snap)
+}
+
+func (w *awsWorld) restore(state []byte) error {
+	var snap persist.Snapshot
+	if err := json.Unmarshal(state, &snap); err != nil {
+		return err
+	}
+
+	w.p = cloudemu.NewAWS() // wipe to empty before loading, like the server
+
+	return persist.RestoreAll(w.ctx, &snap, w.services())
+}
+
+func (w *awsWorld) createBucket(t *testing.T, name string) {
+	t.Helper()
+
+	if err := w.p.S3.CreateBucket(w.ctx, name); err != nil {
+		t.Fatalf("create bucket %q: %v", name, err)
+	}
+}
+
+func (w *awsWorld) buckets(t *testing.T) map[string]bool {
+	t.Helper()
+
+	infos, err := w.p.S3.ListBuckets(w.ctx)
+	if err != nil {
+		t.Fatalf("list buckets: %v", err)
+	}
+
+	set := map[string]bool{}
+	for _, b := range infos {
+		set[b.Name] = true
+	}
+
+	return set
+}
+
+// TestRewindAndForkIsolation is the real-user time-travel flow: save a named
+// point, mutate past it, rewind back to it, then fork the point into a branch
+// and mutate the branch — asserting the original point is untouched.
+func TestRewindAndForkIsolation(t *testing.T) {
+	w := &awsWorld{ctx: context.Background(), p: cloudemu.NewAWS()}
+	clock := config.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	reg := timetravel.New(clock, w.capture, w.restore)
+
+	// v1 point: one bucket.
+	w.createBucket(t, "b-v1")
+	if err := reg.Save("v1"); err != nil {
+		t.Fatalf("save v1: %v", err)
+	}
+
+	// Mutate past v1, then rewind — the later bucket must be gone, v1 present.
+	w.createBucket(t, "b-later")
+	if err := reg.Rewind("v1"); err != nil {
+		t.Fatalf("rewind v1: %v", err)
+	}
+
+	got := w.buckets(t)
+	if !got["b-v1"] || got["b-later"] {
+		t.Fatalf("after rewind to v1, buckets = %v; want b-v1 present, b-later gone", got)
+	}
+
+	// Fork v1 into an independent branch, rewind onto it, and mutate it.
+	if err := reg.Fork("v1", "branch"); err != nil {
+		t.Fatalf("fork v1->branch: %v", err)
+	}
+
+	if err := reg.Rewind("branch"); err != nil {
+		t.Fatalf("rewind branch: %v", err)
+	}
+
+	w.createBucket(t, "b-branch")
+	if err := reg.Save("branch"); err != nil { // re-save the branch with its new state
+		t.Fatalf("save branch: %v", err)
+	}
+
+	// Rewinding to v1 must NOT see the branch's mutation: fork isolation.
+	if err := reg.Rewind("v1"); err != nil {
+		t.Fatalf("rewind v1 after branch mutation: %v", err)
+	}
+
+	got = w.buckets(t)
+	if !got["b-v1"] || got["b-branch"] {
+		t.Fatalf("v1 leaked branch state: buckets = %v; want only b-v1", got)
+	}
+}
+
+// TestListReportsMetadata checks the registry surfaces names, fork lineage, and
+// the deterministic clock's timestamp.
+func TestListReportsMetadata(t *testing.T) {
+	w := &awsWorld{ctx: context.Background(), p: cloudemu.NewAWS()}
+	created := time.Date(2026, 2, 3, 4, 5, 6, 0, time.UTC)
+	reg := timetravel.New(config.NewFakeClock(created), w.capture, w.restore)
+
+	if err := reg.Save("base"); err != nil {
+		t.Fatalf("save base: %v", err)
+	}
+
+	if err := reg.Fork("base", "feature"); err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+
+	list := reg.List()
+	if len(list) != 2 {
+		t.Fatalf("list len = %d, want 2", len(list))
+	}
+
+	// List is name-sorted: base, feature.
+	if list[0].Name != "base" || list[1].Name != "feature" {
+		t.Fatalf("list order = %q,%q; want base,feature", list[0].Name, list[1].Name)
+	}
+
+	if list[1].ForkedFrom != "base" {
+		t.Fatalf("feature.ForkedFrom = %q, want base", list[1].ForkedFrom)
+	}
+
+	if !list[0].CreatedAt.Equal(created) {
+		t.Fatalf("base.CreatedAt = %v, want %v", list[0].CreatedAt, created)
+	}
+
+	if len(list[0].Providers) == 0 || list[0].Providers[0] != "aws" {
+		t.Fatalf("base.Providers = %v, want [aws]", list[0].Providers)
+	}
+}
+
+// TestErrorsAndDelete checks the not-found, duplicate-fork, invalid-name, and
+// delete paths carry the right canonical error codes.
+func TestErrorsAndDelete(t *testing.T) {
+	w := &awsWorld{ctx: context.Background(), p: cloudemu.NewAWS()}
+	reg := timetravel.New(nil, w.capture, w.restore) // nil clock -> real clock default
+
+	if err := reg.Rewind("missing"); !cerrors.IsNotFound(err) {
+		t.Fatalf("rewind missing: got %v, want NotFound", err)
+	}
+
+	if err := reg.Delete("missing"); !cerrors.IsNotFound(err) {
+		t.Fatalf("delete missing: got %v, want NotFound", err)
+	}
+
+	if err := reg.Save("bad name"); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("save invalid name: got %v, want InvalidArgument", err)
+	}
+
+	if err := reg.Save(".."); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("save '..': got %v, want InvalidArgument", err)
+	}
+
+	if err := reg.Save("keep"); err != nil {
+		t.Fatalf("save keep: %v", err)
+	}
+
+	if err := reg.Fork("keep", "keep"); !cerrors.IsAlreadyExists(err) {
+		t.Fatalf("fork onto existing name: got %v, want AlreadyExists", err)
+	}
+
+	if err := reg.Fork("missing", "new"); !cerrors.IsNotFound(err) {
+		t.Fatalf("fork from missing: got %v, want NotFound", err)
+	}
+
+	if err := reg.Delete("keep"); err != nil {
+		t.Fatalf("delete keep: %v", err)
+	}
+
+	if len(reg.List()) != 0 {
+		t.Fatalf("list after delete = %v, want empty", reg.List())
+	}
+}

--- a/server/serverkit/serverkit.go
+++ b/server/serverkit/serverkit.go
@@ -31,6 +31,7 @@ import (
 
 	cloudemu "github.com/stackshy/cloudemu/v2"
 	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/features/timetravel"
 	"github.com/stackshy/cloudemu/v2/features/topology"
 	"github.com/stackshy/cloudemu/v2/persist"
 	eksprov "github.com/stackshy/cloudemu/v2/providers/aws/eks"
@@ -155,6 +156,12 @@ type App struct {
 	// ops.
 	flusher *flusher
 
+	// timetravel holds named in-memory state snapshots for rewind/fork, layered
+	// on the same whole-emulator capture/restore the snapshot endpoint uses. It
+	// survives resets (the registry is not part of provider state), so a rewind
+	// can undo a reset.
+	timetravel *timetravel.Registry
+
 	// rebuildMu serializes resets so two concurrent /_cloudemu/reset calls can't
 	// interleave and leave providers wired to different Kubernetes instances. It
 	// also guards the current-state fields below and the live provider set.
@@ -215,6 +222,10 @@ func New(cfg *Config) (*App, error) {
 	}
 
 	a.Rebuild() // populate the backends before serving
+
+	// The registry captures/restores whole-emulator state through the same funcs
+	// the snapshot endpoint uses, so rewind/fork reuse persist.ExportAll/RestoreAll.
+	a.timetravel = timetravel.New(config.RealClock{}, a.snapshot, a.restore)
 
 	if err := a.applyBootState(); err != nil {
 		return nil, err
@@ -673,6 +684,12 @@ func (a *App) extraHandler() http.Handler {
 
 			serveCost(w, r, ds)
 		default:
+			if strings.HasPrefix(strings.TrimPrefix(r.URL.Path, admin.Prefix), timeTravelPrefix) {
+				a.serveTimeTravel(w, r)
+
+				return
+			}
+
 			writeNetErr(w, http.StatusNotFound, "unknown control endpoint")
 		}
 	})

--- a/server/serverkit/timetravel.go
+++ b/server/serverkit/timetravel.go
@@ -1,0 +1,110 @@
+package serverkit
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/admin"
+)
+
+// timeTravelPrefix is the control-plane sub-space for the named-snapshot
+// registry. It sits under the existing snapshot surface but never collides with
+// the plain "snapshot" endpoint (export/restore), which is matched exactly.
+const timeTravelPrefix = "snapshot/"
+
+// serveTimeTravel routes the named-snapshot registry endpoints:
+//
+//	GET    /_cloudemu/snapshot/                       list
+//	POST   /_cloudemu/snapshot/{name}                 save (capture live state)
+//	DELETE /_cloudemu/snapshot/{name}                 delete
+//	POST   /_cloudemu/snapshot/{name}/rewind          rewind live state to {name}
+//	POST   /_cloudemu/snapshot/{from}/fork/{to}       fork {from} into {to}
+func (a *App) serveTimeTravel(w http.ResponseWriter, r *http.Request) {
+	sub := strings.TrimPrefix(strings.TrimPrefix(r.URL.Path, admin.Prefix), timeTravelPrefix)
+
+	if sub == "" {
+		a.serveTimeTravelList(w, r)
+
+		return
+	}
+
+	seg := strings.Split(sub, "/")
+
+	switch {
+	case len(seg) == 1:
+		a.serveTimeTravelByName(w, r, seg[0])
+	case len(seg) == 2 && seg[1] == "rewind":
+		serveTimeTravelAction(w, r, http.MethodPost, "rewind", func() error { return a.timetravel.Rewind(seg[0]) })
+	case len(seg) == 3 && seg[1] == "fork":
+		serveTimeTravelAction(w, r, http.MethodPost, "forked", func() error { return a.timetravel.Fork(seg[0], seg[2]) })
+	default:
+		writeNetErr(w, http.StatusNotFound, "unknown snapshot endpoint")
+	}
+}
+
+func (a *App) serveTimeTravelList(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeNetErr(w, http.StatusMethodNotAllowed, "listing snapshots requires GET")
+
+		return
+	}
+
+	writeNetJSON(w, map[string]any{"snapshots": a.timetravel.List()})
+}
+
+// serveTimeTravelByName handles POST (save) and DELETE for /snapshot/{name}.
+func (a *App) serveTimeTravelByName(w http.ResponseWriter, r *http.Request, name string) {
+	switch r.Method {
+	case http.MethodPost:
+		if err := a.timetravel.Save(name); err != nil {
+			writeNetErr(w, statusForError(err), err.Error())
+
+			return
+		}
+
+		writeNetJSON(w, map[string]string{"status": "saved", "name": name})
+	case http.MethodDelete:
+		if err := a.timetravel.Delete(name); err != nil {
+			writeNetErr(w, statusForError(err), err.Error())
+
+			return
+		}
+
+		writeNetJSON(w, map[string]string{"status": "deleted", "name": name})
+	default:
+		writeNetErr(w, http.StatusMethodNotAllowed, "snapshot save requires POST, delete requires DELETE")
+	}
+}
+
+// serveTimeTravelAction runs a single mutating registry op (rewind/fork) guarded
+// by the required method, reporting status on success.
+func serveTimeTravelAction(w http.ResponseWriter, r *http.Request, method, status string, do func() error) {
+	if r.Method != method {
+		writeNetErr(w, http.StatusMethodNotAllowed, "this snapshot action requires "+method)
+
+		return
+	}
+
+	if err := do(); err != nil {
+		writeNetErr(w, statusForError(err), err.Error())
+
+		return
+	}
+
+	writeNetJSON(w, map[string]string{"status": status})
+}
+
+// statusForError maps a registry error's canonical code to an HTTP status.
+func statusForError(err error) int {
+	switch {
+	case errors.IsNotFound(err):
+		return http.StatusNotFound
+	case errors.IsAlreadyExists(err):
+		return http.StatusConflict
+	case errors.IsInvalidArgument(err):
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
+}

--- a/server/serverkit/timetravel_serve_test.go
+++ b/server/serverkit/timetravel_serve_test.go
@@ -1,0 +1,113 @@
+package serverkit
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// timeTravelApp builds an admin-enabled single-provider App and returns its
+// control-plane handler.
+func timeTravelApp(t *testing.T) (*App, http.Handler) {
+	t.Helper()
+
+	app := newTestApp(t, Config{
+		Providers: []string{"aws"},
+		Host:      "127.0.0.1",
+		Ports:     map[string]string{"aws": "0"},
+		Admin:     true,
+		Out:       io.Discard,
+	})
+
+	return app, app.handlerFor(app.backends["aws"], app.seedFor("aws"))
+}
+
+func ttDo(t *testing.T, h http.Handler, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	var r io.Reader
+	if body != "" {
+		r = strings.NewReader(body)
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(method, path, r))
+
+	return rec
+}
+
+// TestTimeTravelServeRewind drives the named-snapshot registry over the real
+// admin HTTP surface: seed a bucket, save a named point, reset (wipe), then
+// rewind — the bucket comes back.
+func TestTimeTravelServeRewind(t *testing.T) {
+	_, h := timeTravelApp(t)
+
+	if rec := ttDo(t, h, http.MethodPost, "/_cloudemu/seed", `{"buckets":[{"name":"b-seed"}]}`); rec.Code != http.StatusOK {
+		t.Fatalf("seed = %d %q", rec.Code, rec.Body.String())
+	}
+
+	if rec := ttDo(t, h, http.MethodPost, "/_cloudemu/snapshot/v1", ""); rec.Code != http.StatusOK {
+		t.Fatalf("save v1 = %d %q", rec.Code, rec.Body.String())
+	}
+
+	if rec := ttDo(t, h, http.MethodPost, "/_cloudemu/reset", ""); rec.Code != http.StatusOK {
+		t.Fatalf("reset = %d", rec.Code)
+	}
+
+	// After reset the export must not carry the bucket.
+	if rec := ttDo(t, h, http.MethodGet, "/_cloudemu/snapshot", ""); strings.Contains(rec.Body.String(), "b-seed") {
+		t.Fatalf("bucket still present after reset: %s", rec.Body.String())
+	}
+
+	if rec := ttDo(t, h, http.MethodPost, "/_cloudemu/snapshot/v1/rewind", ""); rec.Code != http.StatusOK {
+		t.Fatalf("rewind = %d %q", rec.Code, rec.Body.String())
+	}
+
+	if rec := ttDo(t, h, http.MethodGet, "/_cloudemu/snapshot", ""); !strings.Contains(rec.Body.String(), "b-seed") {
+		t.Fatalf("bucket not restored by rewind: %s", rec.Body.String())
+	}
+}
+
+// TestTimeTravelServeListForkErrors exercises list, fork, and the error paths.
+func TestTimeTravelServeListForkErrors(t *testing.T) {
+	_, h := timeTravelApp(t)
+
+	if rec := ttDo(t, h, http.MethodPost, "/_cloudemu/snapshot/base", ""); rec.Code != http.StatusOK {
+		t.Fatalf("save base = %d %q", rec.Code, rec.Body.String())
+	}
+
+	if rec := ttDo(t, h, http.MethodPost, "/_cloudemu/snapshot/base/fork/branch", ""); rec.Code != http.StatusOK {
+		t.Fatalf("fork = %d %q", rec.Code, rec.Body.String())
+	}
+
+	rec := ttDo(t, h, http.MethodGet, "/_cloudemu/snapshot/", "")
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "base") || !strings.Contains(rec.Body.String(), "branch") {
+		t.Fatalf("list = %d %q, want base+branch", rec.Code, rec.Body.String())
+	}
+
+	// Rewind a missing snapshot -> 404.
+	if rec := ttDo(t, h, http.MethodPost, "/_cloudemu/snapshot/missing/rewind", ""); rec.Code != http.StatusNotFound {
+		t.Fatalf("rewind missing = %d, want 404", rec.Code)
+	}
+
+	// Fork onto an existing name -> 409.
+	if rec := ttDo(t, h, http.MethodPost, "/_cloudemu/snapshot/base/fork/branch", ""); rec.Code != http.StatusConflict {
+		t.Fatalf("fork onto existing = %d, want 409", rec.Code)
+	}
+
+	// Wrong method on save path -> 405.
+	if rec := ttDo(t, h, http.MethodPut, "/_cloudemu/snapshot/base", ""); rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("PUT save = %d, want 405", rec.Code)
+	}
+
+	// Delete then confirm it's gone from the list.
+	if rec := ttDo(t, h, http.MethodDelete, "/_cloudemu/snapshot/branch", ""); rec.Code != http.StatusOK {
+		t.Fatalf("delete branch = %d %q", rec.Code, rec.Body.String())
+	}
+
+	if rec := ttDo(t, h, http.MethodGet, "/_cloudemu/snapshot/", ""); strings.Contains(rec.Body.String(), "branch") {
+		t.Fatalf("branch still listed after delete: %s", rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

Implements the state-management core of #107 — named in-memory snapshots with **rewind** and **fork** — layered on the existing whole-emulator snapshot primitive rather than reinventing serialization.

A new `features/timetravel` package holds a provider-agnostic **snapshot registry** (name -> serialized state). It drives the exact capture/restore surface `persist.ExportAll`/`persist.RestoreAll` already power (wired in as two funcs), so it never touches individual provider mocks. Stored snapshots are independent byte copies, making forks isolated by construction. Timestamps come from a `config.Clock` for deterministic tests.

## Operations

- `Save(name)` — capture current live state under a label (overwrites, so a branch can be re-saved).
- `List()` — labels with created-at, providers, fork lineage, size.
- `Delete(name)` — drop a label.
- `Rewind(name)` — restore live state to a named snapshot (undo, incl. undoing a reset).
- `Fork(from, newName)` — copy a stored snapshot into an independent branch to explore a what-if without disturbing the source or other branches.

## Admin surface

Extends the control plane under the existing snapshot space (no collision with the plain `GET/POST /_cloudemu/snapshot` export/restore, which are matched exactly):

- `POST /_cloudemu/snapshot/{name}` — save
- `GET /_cloudemu/snapshot/` — list
- `POST /_cloudemu/snapshot/{name}/rewind` — rewind
- `POST /_cloudemu/snapshot/{name}/fork/{newName}` — fork
- `DELETE /_cloudemu/snapshot/{name}` — delete

Canonical error codes map to HTTP status (NotFound→404, AlreadyExists→409, InvalidArgument→400). The registry is wired into the serverkit `App` and survives resets.

CLI: kept to the admin HTTP surface. The existing `cloudemu snapshot save/load/list/delete` operate on client-side disk files with different semantics; overloading them with the in-memory registry would be confusing, so the two are left separate.

## Tests

- `features/timetravel`: real-user flow with a live AWS provider through `persist.ExportAll`/`RestoreAll` — save v1, mutate past it, rewind, then fork + mutate branch and assert v1 is untouched (fork isolation); plus metadata/list and error-code coverage.
- `server/serverkit`: end-to-end over the admin HTTP handler — seed a bucket, save, reset, rewind (bucket returns); list/fork/delete and 404/409/405 paths.

## Gates

`go build ./...`, targeted `go test` (persist, admin, serverkit, features, root), `go vet`, and `golangci-lint` on touched packages all green; `coveragegen` produces no docs diff.