### PR TITLE
fix(aws-lambda): enforce reserved concurrency on Invoke (#431)

### DIFF
--- a/providers/aws/lambda/concurrency.go
+++ b/providers/aws/lambda/concurrency.go
@@ -51,3 +51,58 @@ func (m *Mock) DeleteFunctionConcurrency(_ context.Context, functionName string)
 
 	return nil
 }
+
+// reserveInvocationSlot enforces reserved concurrency for an invoke. A function
+// with no reserved limit is unbounded, so it returns a no-op release. When the
+// reserved limit is exhausted it returns a Throttled error the wire layer maps
+// to a 429 TooManyRequestsException. Otherwise it reserves a slot and returns
+// the release the caller defers to return it on completion.
+func (m *Mock) reserveInvocationSlot(fd *funcData, functionName string) (func(), error) {
+	if fd.concurrency == nil {
+		return func() {}, nil
+	}
+
+	release, ok := m.acquireConcurrency(functionName, fd.concurrency.ReservedConcurrentExecutions)
+	if !ok {
+		return nil, errReservedConcurrencyExceeded(functionName)
+	}
+
+	return release, nil
+}
+
+// acquireConcurrency reserves an execution slot for a function that has reserved
+// concurrency configured. It returns false when granting the slot would push the
+// in-flight count past reserved (the caller must throttle the invoke); otherwise
+// it increments the count and returns a release func the caller defers to return
+// the slot when the invocation completes. A reserved value of 0 always fails,
+// throttling every invoke. The map read-modify-write is guarded by inflightMu so
+// concurrent invokes account correctly.
+func (m *Mock) acquireConcurrency(functionName string, reserved int) (func(), bool) {
+	m.inflightMu.Lock()
+	defer m.inflightMu.Unlock()
+
+	if m.inflight[functionName] >= reserved {
+		return nil, false
+	}
+
+	m.inflight[functionName]++
+
+	return func() {
+		m.inflightMu.Lock()
+		defer m.inflightMu.Unlock()
+
+		m.inflight[functionName]--
+		if m.inflight[functionName] <= 0 {
+			delete(m.inflight, functionName)
+		}
+	}, true
+}
+
+// errReservedConcurrencyExceeded is the throttling error Invoke returns when a
+// function's reserved-concurrency limit is exhausted. The wire layer maps a
+// Throttled Lambda error to a 429 TooManyRequestsException whose Reason is
+// ReservedFunctionConcurrentInvocationLimitExceeded, matching real Lambda.
+func errReservedConcurrencyExceeded(functionName string) error {
+	return cerrors.Newf(cerrors.Throttled,
+		"rate exceeded for function %s: reserved concurrency limit reached", functionName)
+}

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -114,6 +114,10 @@ type Mock struct {
 	monitoring mondriver.Monitoring
 	logs       logdriver.Logging // optional: CloudWatch Logs sink for invocation logs
 	mu         sync.Mutex        // guards PublishVersion read-modify-write on funcData
+	// inflightMu guards inflight, the number of invocations currently executing
+	// per function name. It backs reserved-concurrency enforcement on Invoke.
+	inflightMu sync.Mutex
+	inflight   map[string]int
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -149,6 +153,7 @@ func New(opts *config.Options) *Mock {
 		mappings: memstore.New[*driver.EventSourceMappingInfo](),
 		opts:     opts,
 		handlers: make(map[string]driver.HandlerFunc),
+		inflight: make(map[string]int),
 	}
 }
 
@@ -326,14 +331,19 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 		return &driver.InvokeOutput{StatusCode: dryRunStatusCode, ExecutedVersion: executedVersion}, nil
 	}
 
+	// Enforce reserved concurrency: an invoke that would push the in-flight count
+	// past the function's reserved limit is throttled instead of executed.
+	// release returns the slot once this invocation completes.
+	release, err := m.reserveInvocationSlot(&fd, input.FunctionName)
+	if err != nil {
+		return nil, err
+	}
+
+	defer release()
+
 	dims := map[string]string{"FunctionName": input.FunctionName}
 
-	h := fd.handler
-	if h == nil {
-		m.handlersMu.RLock()
-		h = m.handlers[input.FunctionName]
-		m.handlersMu.RUnlock()
-	}
+	h := m.resolveHandler(&fd, input.FunctionName)
 
 	if h == nil && fd.engineBacked {
 		return m.invokeEngine(ctx, input, dims, executedVersion)
@@ -373,6 +383,20 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 	m.surfaceInvokeLogs(ctx, input.FunctionName, executedVersion, "", "")
 
 	return &driver.InvokeOutput{StatusCode: 200, Payload: payload, ExecutedVersion: executedVersion}, nil
+}
+
+// resolveHandler returns the Go handler to run for an invoke: the one attached
+// to the function record, else one registered out-of-band via RegisterHandler,
+// or nil when the function has no Go handler (a stub or engine-backed invoke).
+func (m *Mock) resolveHandler(fd *funcData, name string) driver.HandlerFunc {
+	if fd.handler != nil {
+		return fd.handler
+	}
+
+	m.handlersMu.RLock()
+	defer m.handlersMu.RUnlock()
+
+	return m.handlers[name]
 }
 
 // resolveQualifier resolves an Invoke Qualifier (empty, "$LATEST", a numeric

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -1468,7 +1468,30 @@ func writeErr(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusConflict, "ResourceConflictException", msg)
 	case cerrors.IsInvalidArgument(err):
 		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", msg)
+	case cerrors.IsThrottled(err):
+		writeThrottle(w, msg)
 	default:
 		writeError(w, http.StatusInternalServerError, "ServiceException", msg)
 	}
+}
+
+// reservedConcurrencyReason is the Reason a reserved-concurrency throttle
+// carries in the TooManyRequestsException body — the value real Lambda returns
+// when a function's ReservedConcurrentExecutions limit is exhausted.
+const reservedConcurrencyReason = "ReservedFunctionConcurrentInvocationLimitExceeded"
+
+// writeThrottle emits the 429 TooManyRequestsException a throttled Invoke
+// returns. The body carries the Reason field the SDK deserializes into
+// TooManyRequestsException.Reason so callers can distinguish a reserved-
+// concurrency throttle from other limits.
+func writeThrottle(w http.ResponseWriter, msg string) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.Header().Set("X-Amzn-Errortype", "TooManyRequestsException")
+	w.WriteHeader(http.StatusTooManyRequests)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"Type":    "TooManyRequestsException",
+		"Message": msg,
+		"message": msg,
+		"Reason":  reservedConcurrencyReason,
+	})
 }

--- a/server/aws/lambda/reserved_concurrency_test.go
+++ b/server/aws/lambda/reserved_concurrency_test.go
@@ -1,0 +1,181 @@
+package lambda_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+)
+
+// invokeSync issues a synchronous invoke and returns the error (nil on success).
+func invokeSync(t *testing.T, client *awslambda.Client, name string, optFns ...func(*awslambda.Options)) error {
+	t.Helper()
+
+	_, err := client.Invoke(context.Background(), &awslambda.InvokeInput{
+		FunctionName:   aws.String(name),
+		InvocationType: lambdatypes.InvocationTypeRequestResponse,
+		Payload:        []byte(`{}`),
+	}, optFns...)
+
+	return err
+}
+
+// noRetry disables the SDK's automatic retry of throttling responses so a
+// throttle assertion sees the single raw 429 immediately rather than after the
+// default exponential backoff.
+func noRetry(o *awslambda.Options) { o.Retryer = aws.NopRetryer{} }
+
+// assertThrottled asserts err is the reserved-concurrency TooManyRequestsException:
+// HTTP 429, error code TooManyRequestsException, and Reason
+// ReservedFunctionConcurrentInvocationLimitExceeded.
+func assertThrottled(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("Invoke over the reserved-concurrency limit: want error, got nil")
+	}
+
+	var tmr *lambdatypes.TooManyRequestsException
+	if !errors.As(err, &tmr) {
+		t.Fatalf("error = %T %v, want *TooManyRequestsException", err, err)
+	}
+
+	if tmr.Reason != lambdatypes.ThrottleReasonReservedFunctionConcurrentInvocationLimitExceeded {
+		t.Errorf("Reason = %q, want ReservedFunctionConcurrentInvocationLimitExceeded", tmr.Reason)
+	}
+
+	var re *awshttp.ResponseError
+	if !errors.As(err, &re) {
+		t.Fatalf("error = %T %v, want *awshttp.ResponseError for status", err, err)
+	}
+
+	if re.HTTPStatusCode() != 429 {
+		t.Errorf("HTTP status = %d, want 429", re.HTTPStatusCode())
+	}
+}
+
+// TestSDKReservedConcurrencyLifecycle covers the Put/Get/Delete round-trip and,
+// with reserved=0 (throttle everything), that Invoke is rejected with a 429
+// TooManyRequestsException and works again once the limit is cleared.
+func TestSDKReservedConcurrencyLifecycle(t *testing.T) {
+	client, cloud := newSDKClient(t)
+	ctx := context.Background()
+
+	createBasicFunction(t, client, "resv")
+	cloud.Lambda.RegisterHandler("resv", func(_ context.Context, p []byte) ([]byte, error) {
+		return p, nil
+	})
+
+	// A limit is not enforced until PutFunctionConcurrency runs.
+	if err := invokeSync(t, client, "resv"); err != nil {
+		t.Fatalf("Invoke before any reserved concurrency: %v", err)
+	}
+
+	putOut, err := client.PutFunctionConcurrency(ctx, &awslambda.PutFunctionConcurrencyInput{
+		FunctionName:                 aws.String("resv"),
+		ReservedConcurrentExecutions: aws.Int32(0),
+	})
+	if err != nil {
+		t.Fatalf("PutFunctionConcurrency: %v", err)
+	}
+	if putOut.ReservedConcurrentExecutions == nil || *putOut.ReservedConcurrentExecutions != 0 {
+		t.Fatalf("Put reserved = %v, want 0", putOut.ReservedConcurrentExecutions)
+	}
+
+	getOut, err := client.GetFunctionConcurrency(ctx, &awslambda.GetFunctionConcurrencyInput{
+		FunctionName: aws.String("resv"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConcurrency: %v", err)
+	}
+	if getOut.ReservedConcurrentExecutions == nil || *getOut.ReservedConcurrentExecutions != 0 {
+		t.Fatalf("Get reserved = %v, want 0", getOut.ReservedConcurrentExecutions)
+	}
+
+	// reserved=0 throttles every invoke.
+	assertThrottled(t, invokeSync(t, client, "resv", noRetry))
+
+	if _, err = client.DeleteFunctionConcurrency(ctx, &awslambda.DeleteFunctionConcurrencyInput{
+		FunctionName: aws.String("resv"),
+	}); err != nil {
+		t.Fatalf("DeleteFunctionConcurrency: %v", err)
+	}
+
+	// The limit is gone; invokes succeed again.
+	if err = invokeSync(t, client, "resv"); err != nil {
+		t.Fatalf("Invoke after DeleteFunctionConcurrency: %v", err)
+	}
+}
+
+// TestSDKReservedConcurrencyEnforcedUnderConcurrency drives real concurrent
+// invocations against a reserved limit: a blocking handler holds `limit` slots
+// in flight, invokes beyond the limit are throttled with 429, and once the held
+// invocations complete the accounting resets so a fresh invoke succeeds. Run
+// under -race to guard the counter.
+func TestSDKReservedConcurrencyEnforcedUnderConcurrency(t *testing.T) {
+	client, cloud := newSDKClient(t)
+	ctx := context.Background()
+
+	const limit = 2
+
+	createBasicFunction(t, client, "cc")
+
+	started := make(chan struct{}, limit)
+	release := make(chan struct{})
+	cloud.Lambda.RegisterHandler("cc", func(_ context.Context, p []byte) ([]byte, error) {
+		started <- struct{}{}
+		<-release
+
+		return p, nil
+	})
+
+	if _, err := client.PutFunctionConcurrency(ctx, &awslambda.PutFunctionConcurrencyInput{
+		FunctionName:                 aws.String("cc"),
+		ReservedConcurrentExecutions: aws.Int32(limit),
+	}); err != nil {
+		t.Fatalf("PutFunctionConcurrency: %v", err)
+	}
+
+	// Launch `limit` invokes that each acquire a slot and then block in the
+	// handler, so both slots are held simultaneously.
+	var wg sync.WaitGroup
+
+	wg.Add(limit)
+
+	for i := 0; i < limit; i++ {
+		go func() {
+			defer wg.Done()
+
+			if err := invokeSync(t, client, "cc"); err != nil {
+				t.Errorf("in-flight invoke %d: unexpected error %v", i, err)
+			}
+		}()
+	}
+
+	// Wait until both slots are held before probing the limit.
+	for i := 0; i < limit; i++ {
+		<-started
+	}
+
+	// With both slots held, further invokes are throttled immediately (the
+	// handler is never entered for them).
+	for i := 0; i < 3; i++ {
+		assertThrottled(t, invokeSync(t, client, "cc", noRetry))
+	}
+
+	// Let the held invocations finish and drain the accounting.
+	close(release)
+	wg.Wait()
+
+	// The counter is back to zero (release is closed, so the handler no longer
+	// blocks), so a fresh invoke acquires a slot and succeeds. The started
+	// channel has room (cap == limit) for its non-blocking send.
+	if err := invokeSync(t, client, "cc"); err != nil {
+		t.Fatalf("Invoke after held invocations drained: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Enforce Lambda **reserved concurrency** on `Invoke`. Previously `PutFunctionConcurrency` stored `ReservedConcurrentExecutions` but nothing gated invocations against it (item from #431: "Lambda reserved concurrency stored but doesn't gate invokes → enforce").

## Why

Real AWS Lambda rejects an invoke that would exceed a function's reserved concurrency with `TooManyRequestsException` (HTTP 429, `Reason: ReservedFunctionConcurrentInvocationLimitExceeded`). Apps and tests that rely on this throttling behavior saw every invoke succeed against the emulator.

## Enforcement + error shape

- The AWS Lambda provider (`providers/aws/lambda`) tracks in-flight executions per function. On `Invoke`, when the function has a reserved limit set, it reserves a slot before executing and releases it on completion (deferred). A reserved limit of `0` throttles every invoke.
- When granting a slot would exceed the reserved limit, `Invoke` returns a `Throttled` error instead of executing.
- The wire layer maps a throttled Lambda error to **HTTP 429 `TooManyRequestsException`** with the body `Reason: ReservedFunctionConcurrentInvocationLimitExceeded`, which the SDK deserializes into `TooManyRequestsException.Reason`.
- `Put/Get/DeleteFunctionConcurrency` read/set/clear the limit as before; deleting it restores unbounded invokes.

## Concurrency accounting

- In-flight counts live in a per-function map guarded by a dedicated mutex (`inflightMu`); reserve/release is a lock-guarded read-modify-write, so accounting is correct under concurrent goroutine invokes and the count drains back to zero.
- DryRun invocations do not consume a slot (they never execute), matching AWS.
- Verified race-free under `go test -race`.

## Tests

`server/aws/lambda/reserved_concurrency_test.go` (real `aws-sdk-go-v2/service/lambda` client):
- Put/Get round-trip; reserved=0 → `Invoke` returns 429 `TooManyRequestsException` with the reserved-concurrency `Reason`; `DeleteFunctionConcurrency` clears it and invokes succeed again.
- Concurrent-invoke test: a blocking handler holds `limit` slots in flight, over-limit invokes are throttled with 429, and once the held invocations drain a fresh invoke succeeds (run under `-race`).

## Gates

`go build ./...`, `go test` + `go test -race` on the lambda packages, `go run ./internal/coveragegen` (no diff — the ops were already listed), and `golangci-lint` on the touched packages all pass.
