### PR TITLE
refactor(aws-lambda): move BuildLambdaStreamEvent out of the cross-cloud driver (#577)

### DIFF
--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -1414,7 +1414,7 @@ func (m *Mock) flushStreamDeliveries(callerCtx context.Context) {
 			batch = append(batch, pending[k].rec)
 		}
 
-		payload := driver.BuildLambdaStreamEvent(pending[i].streamARN, pending[i].region, pending[i].viewType, batch)
+		payload := buildLambdaStreamEvent(pending[i].streamARN, pending[i].region, pending[i].viewType, batch)
 		_, _ = m.streamInvoker.DeliverEventSourceBatch(ctx, pending[i].streamARN, payload)
 
 		i = j

--- a/providers/aws/dynamodb/stream_event.go
+++ b/providers/aws/dynamodb/stream_event.go
@@ -1,0 +1,81 @@
+package dynamodb
+
+import (
+	"encoding/json"
+
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+// DynamoDB Streams event envelope constants for the shape Lambda delivers to a
+// stream event-source-mapping target.
+const (
+	streamEventSource  = "aws:dynamodb"
+	streamEventVersion = "1.1"
+)
+
+// buildLambdaStreamEvent renders a batch of change records into the exact JSON
+// event Lambda delivers to a DynamoDB stream event-source-mapping target:
+// {"Records":[{eventID,eventName,eventVersion,eventSource,awsRegion,
+// eventSourceARN,dynamodb:{ApproximateCreationDateTime,Keys,NewImage,OldImage,
+// SequenceNumber,SizeBytes,StreamViewType}}]}. Keys/NewImage/OldImage are
+// AttributeValue-encoded (driver.MarshalItem), matching the shape aws-sdk
+// events.DynamoDBEvent binds.
+func buildLambdaStreamEvent(streamARN, region, viewType string, recs []driver.StreamRecord) []byte {
+	records := make([]map[string]any, 0, len(recs))
+	for i := range recs {
+		records = append(records, lambdaStreamRecord(&recs[i], streamARN, region, viewType))
+	}
+
+	b, err := json.Marshal(map[string]any{"Records": records})
+	if err != nil {
+		return []byte(`{"Records":[]}`)
+	}
+
+	return b
+}
+
+func lambdaStreamRecord(rec *driver.StreamRecord, streamARN, region, viewType string) map[string]any {
+	dyn := map[string]any{
+		"ApproximateCreationDateTime": float64(rec.Timestamp.Unix()),
+		"Keys":                        driver.MarshalItem(rec.Keys),
+		"SequenceNumber":              rec.SequenceNumber,
+		"SizeBytes":                   streamRecordSize(rec),
+		"StreamViewType":              viewType,
+	}
+
+	if rec.NewImage != nil {
+		dyn["NewImage"] = driver.MarshalItem(rec.NewImage)
+	}
+
+	if rec.OldImage != nil {
+		dyn["OldImage"] = driver.MarshalItem(rec.OldImage)
+	}
+
+	return map[string]any{
+		"eventID":        rec.EventID,
+		"eventName":      rec.EventType,
+		"eventVersion":   streamEventVersion,
+		"eventSource":    streamEventSource,
+		"awsRegion":      region,
+		"eventSourceARN": streamARN,
+		"dynamodb":       dyn,
+	}
+}
+
+// streamRecordSize estimates a record's on-the-wire size, as DynamoDB reports it
+// on each stream record: a JSON byte count of the captured keys/images.
+func streamRecordSize(rec *driver.StreamRecord) int {
+	size := 0
+
+	for _, m := range []map[string]any{rec.Keys, rec.NewImage, rec.OldImage} {
+		if m == nil {
+			continue
+		}
+
+		if b, err := json.Marshal(m); err == nil {
+			size += len(b)
+		}
+	}
+
+	return size
+}

--- a/providers/aws/lambda/esm_delivery_test.go
+++ b/providers/aws/lambda/esm_delivery_test.go
@@ -2,6 +2,7 @@ package lambda
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
@@ -73,5 +74,61 @@ func TestDeliverEventSourceBatch(t *testing.T) {
 
 	if delivered {
 		t.Fatal("delivered = true for an ARN with no matching mapping")
+	}
+}
+
+// TestDeliverEventSourceBatchDoesNotAbortSiblings verifies that when two enabled
+// mappings target the same source, one whose function raises does not starve the
+// other: both mappings run and the failure is surfaced after all have run (real
+// AWS pollers are independent, so a sibling's error must not skip a mapping).
+func TestDeliverEventSourceBatchDoesNotAbortSiblings(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	failCfg := defaultFuncConfig()
+	failCfg.Name = "fail-func"
+
+	okCfg := defaultFuncConfig()
+	okCfg.Name = "ok-func"
+
+	if _, err := m.CreateFunction(ctx, failCfg); err != nil {
+		t.Fatalf("CreateFunction(fail): %v", err)
+	}
+
+	if _, err := m.CreateFunction(ctx, okCfg); err != nil {
+		t.Fatalf("CreateFunction(ok): %v", err)
+	}
+
+	m.RegisterHandler("fail-func", func(_ context.Context, _ []byte) ([]byte, error) {
+		return nil, errors.New("boom")
+	})
+
+	var okRan bool
+	m.RegisterHandler("ok-func", func(_ context.Context, _ []byte) ([]byte, error) {
+		okRan = true
+		return nil, nil
+	})
+
+	const streamARN = "arn:aws:dynamodb:us-east-1:000000000000:table/orders/stream/2025-01-01T00:00:00.000"
+
+	for _, fn := range []string{"fail-func", "ok-func"} {
+		if _, err := m.CreateEventSourceMapping(ctx, driver.EventSourceMappingConfig{
+			EventSourceArn: streamARN, FunctionName: fn, Enabled: true,
+		}); err != nil {
+			t.Fatalf("CreateEventSourceMapping(%s): %v", fn, err)
+		}
+	}
+
+	delivered, err := m.DeliverEventSourceBatch(ctx, streamARN, []byte(`{"Records":[]}`))
+	if !delivered {
+		t.Fatal("delivered = false, want true (mappings matched)")
+	}
+
+	if err == nil {
+		t.Fatal("err = nil, want the failing mapping's error surfaced")
+	}
+
+	if !okRan {
+		t.Fatal("ok-func did not run: a sibling mapping's failure aborted delivery")
 	}
 }

--- a/services/database/driver/attributevalue.go
+++ b/services/database/driver/attributevalue.go
@@ -2,24 +2,16 @@ package driver
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"strconv"
 
 	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
 )
 
-// DynamoDB Streams event envelope constants shared by the Streams data-plane
-// wire handler and Lambda event-source-mapping delivery.
-const (
-	streamEventSource  = "aws:dynamodb"
-	streamEventVersion = "1.1"
-)
-
 // MarshalAttributeValue wraps a plain Go value (as the in-memory providers store
 // items) into a single DynamoDB AttributeValue wire map, e.g. "x" -> {"S":"x"}.
 // It is the canonical native->AV encoder, shared by the DynamoDB wire codec and
-// by Lambda stream event delivery so both render identical AttributeValue JSON.
+// by DynamoDB stream event delivery so both render identical AttributeValue JSON.
 func MarshalAttributeValue(v any) map[string]any {
 	if av, ok := marshalBinaryOrSet(v); ok {
 		return av
@@ -109,70 +101,4 @@ func MarshalItem(item map[string]any) map[string]any {
 	}
 
 	return out
-}
-
-// BuildLambdaStreamEvent renders a batch of change records into the exact JSON
-// event Lambda delivers to a DynamoDB stream event-source-mapping target:
-// {"Records":[{eventID,eventName,eventVersion,eventSource,awsRegion,
-// eventSourceARN,dynamodb:{ApproximateCreationDateTime,Keys,NewImage,OldImage,
-// SequenceNumber,SizeBytes,StreamViewType}}]}. Keys/NewImage/OldImage are
-// AttributeValue-encoded, matching the shape aws-sdk events.DynamoDBEvent binds.
-func BuildLambdaStreamEvent(streamARN, region, viewType string, recs []StreamRecord) []byte {
-	records := make([]map[string]any, 0, len(recs))
-	for i := range recs {
-		records = append(records, lambdaStreamRecord(&recs[i], streamARN, region, viewType))
-	}
-
-	b, err := json.Marshal(map[string]any{"Records": records})
-	if err != nil {
-		return []byte(`{"Records":[]}`)
-	}
-
-	return b
-}
-
-func lambdaStreamRecord(rec *StreamRecord, streamARN, region, viewType string) map[string]any {
-	dyn := map[string]any{
-		"ApproximateCreationDateTime": float64(rec.Timestamp.Unix()),
-		"Keys":                        MarshalItem(rec.Keys),
-		"SequenceNumber":              rec.SequenceNumber,
-		"SizeBytes":                   streamRecordSize(rec),
-		"StreamViewType":              viewType,
-	}
-
-	if rec.NewImage != nil {
-		dyn["NewImage"] = MarshalItem(rec.NewImage)
-	}
-
-	if rec.OldImage != nil {
-		dyn["OldImage"] = MarshalItem(rec.OldImage)
-	}
-
-	return map[string]any{
-		"eventID":        rec.EventID,
-		"eventName":      rec.EventType,
-		"eventVersion":   streamEventVersion,
-		"eventSource":    streamEventSource,
-		"awsRegion":      region,
-		"eventSourceARN": streamARN,
-		"dynamodb":       dyn,
-	}
-}
-
-// streamRecordSize estimates a record's on-the-wire size, as DynamoDB reports it
-// on each stream record: a JSON byte count of the captured keys/images.
-func streamRecordSize(rec *StreamRecord) int {
-	size := 0
-
-	for _, m := range []map[string]any{rec.Keys, rec.NewImage, rec.OldImage} {
-		if m == nil {
-			continue
-		}
-
-		if b, err := json.Marshal(m); err == nil {
-			size += len(b)
-		}
-	}
-
-	return size
 }


### PR DESCRIPTION
## What

Closes the last open items of #577.

**(a) Relocate `BuildLambdaStreamEvent` (wrong home -> correct home).**
The DynamoDB-stream Lambda event-shape builder lived in the provider-agnostic, cross-cloud `services/database/driver` package - an AWS-Lambda-specific symbol in a shared driver interface package. It is moved to its only consumer, `providers/aws/dynamodb`, as unexported `buildLambdaStreamEvent`.

- The DynamoDB provider is the correct owner: it holds the `StreamRecord` data and hands an opaque `[]byte` payload to the Lambda side across the `StreamEventInvoker` interface. Placing the builder in `providers/aws/lambda` would have forced `dynamodb -> lambda` to import the very coupling that interface exists to avoid; keeping it in `dynamodb` preserves the decoupling.
- The shared driver file kept only the provider-agnostic AttributeValue marshalers (`MarshalItem`/`MarshalAttributeValue`, still used by the DynamoDB wire codec in `server/aws/dynamodb`), so it is renamed `stream_event.go -> attributevalue.go`. The Lambda-only helpers (`lambdaStreamRecord`, `streamRecordSize`) and the `aws:dynamodb`/`1.1` envelope constants moved with the builder. No dead re-export/shim remains in the old location.

**(b) Verify sibling-abort + DryRun-qualifier - both already correct.**
- Sibling-abort: `DeliverEventSourceBatch` already invokes every matching enabled mapping regardless of an earlier one's outcome and surfaces the error only after all have run. Added `TestDeliverEventSourceBatchDoesNotAbortSiblings` to lock it in (two mappings on one ARN, one raises, the sibling still runs and the failure is returned).
- DryRun-qualifier: `Invoke` already resolves the qualifier before the DryRun 204 path, so an unknown alias/version returns `ResourceNotFoundException`; the wire handler routes DryRun through `Invoke`, propagating it. Already covered by `TestInvokeDryRunValidatesQualifier`.

## Why
An AWS-Lambda-specific event-shape helper does not belong in the provider-agnostic database driver interface package; production code in the shared driver should carry only provider-agnostic symbols.

Pure relocation refactor - no behavior change, no wire-op change (coverage docs unchanged).
