### PR TITLE
feat(azure): VMSS instance orchestration (list/get/delete/power ops) (#611)

### DIFF
--- a/providers/azure/virtualmachines/scaleset.go
+++ b/providers/azure/virtualmachines/scaleset.go
@@ -3,8 +3,20 @@ package virtualmachines
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strconv"
+	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// Per-instance power states a materialized scale-set VM reports. They mirror
+// the ARM PowerState codes the wire layer echoes, so the server can render them
+// directly without a translation table.
+const (
+	scaleSetVMRunning     = "running"
+	scaleSetVMStopped     = "stopped"
+	scaleSetVMDeallocated = "deallocated"
 )
 
 // ScaleSet is an Azure Virtual Machine Scale Set (VMSS). Only the fields a
@@ -30,6 +42,20 @@ type ScaleSet struct {
 	// ResourceGroup is the ARM resource group the scale set belongs to, so a
 	// resource-group cascade delete can find and tear down its scale sets.
 	ResourceGroup string
+	// Instances are the per-instance VMs materialized from Capacity. Each holds
+	// its ordinal instanceId and mutable power/provisioning state so a VMSS VM
+	// can be enumerated, addressed, powered off, and deleted individually
+	// (Microsoft.Compute/virtualMachineScaleSets/{vmss}/virtualMachines).
+	Instances []ScaleSetVM
+}
+
+// ScaleSetVM is one materialized virtual machine of a scale set. instanceId is
+// the string ordinal ("0", "1", …) Azure addresses the VM by; the name Azure
+// renders is "{vmss}_{instanceId}", built by the wire layer.
+type ScaleSetVM struct {
+	InstanceID        string
+	ProvisioningState string
+	PowerState        string // running / stopped / deallocated
 }
 
 // CreateScaleSet stores a VMSS, defaulting the fields real Azure fills in.
@@ -40,6 +66,31 @@ func (m *Mock) CreateScaleSet(_ context.Context, s ScaleSet) (*ScaleSet, error) 
 		return nil, cerrors.New(cerrors.InvalidArgument, "scale set name is required")
 	}
 
+	m.applyScaleSetDefaults(&s)
+
+	// CreateOrUpdate is idempotent: on a re-PUT of an existing scale set, carry
+	// its already-materialized instances forward so their power state survives,
+	// then reconcile only the count to the requested capacity.
+	if existing, ok := m.scaleSets.Get(s.Name); ok {
+		s.Instances = existing.Instances
+	}
+
+	s.Instances = reconcileScaleSetVMs(s.Instances, s.Capacity)
+
+	stored := s
+
+	m.scaleSets.Set(s.Name, &stored)
+
+	out := stored
+
+	return &out, nil
+}
+
+// applyScaleSetDefaults fills the fields real Azure defaults on create, in
+// place. A zero capacity is defaulted to 1 only when it wasn't explicitly
+// requested; an explicit "capacity":0 (scale-in-to-zero) is honored — a VMSS at
+// capacity 0 is a valid, running-with-no-instances state.
+func (m *Mock) applyScaleSetDefaults(s *ScaleSet) {
 	if s.ID == "" {
 		s.ID = fmt.Sprintf(
 			"/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/%s", s.Name)
@@ -57,9 +108,6 @@ func (m *Mock) CreateScaleSet(_ context.Context, s ScaleSet) (*ScaleSet, error) 
 		s.SKUTier = "Standard"
 	}
 
-	// A zero capacity is only defaulted to 1 when it wasn't explicitly
-	// requested; an explicit "capacity":0 (scale-in-to-zero) is honored —
-	// a VMSS at capacity 0 is a valid, running-with-no-instances state.
 	if s.Capacity == 0 && !s.CapacityZero {
 		s.Capacity = 1
 	}
@@ -71,14 +119,215 @@ func (m *Mock) CreateScaleSet(_ context.Context, s ScaleSet) (*ScaleSet, error) 
 	if s.OSType == "" {
 		s.OSType = "Linux"
 	}
+}
 
-	stored := s
+// reconcileScaleSetVMs returns the instance set a scale set at capacity should
+// hold, given the instances it currently holds. It always returns a fresh
+// slice (never aliasing existing) so the caller can store it without sharing a
+// backing array with a prior version. Scaling out appends new instances with
+// the next monotonic ordinals (so a gap left by a deleted instance is not
+// reused); scaling in drops the highest-ordinal instances, matching Azure's
+// default scale-in ordering.
+func reconcileScaleSetVMs(existing []ScaleSetVM, capacity int) []ScaleSetVM {
+	if capacity < 0 {
+		capacity = 0
+	}
 
-	m.scaleSets.Set(s.Name, &stored)
+	out := make([]ScaleSetVM, len(existing))
+	copy(out, existing)
+	sortScaleSetVMs(out)
 
-	out := stored
+	if len(out) > capacity {
+		return out[:capacity]
+	}
 
-	return &out, nil
+	for next := nextOrdinal(out); len(out) < capacity; next++ {
+		out = append(out, ScaleSetVM{
+			InstanceID:        strconv.Itoa(next),
+			ProvisioningState: "Succeeded",
+			PowerState:        scaleSetVMRunning,
+		})
+	}
+
+	return out
+}
+
+// sortScaleSetVMs orders instances by numeric ordinal ascending; a non-numeric
+// id (never produced by us) sorts after the numeric ones by string.
+func sortScaleSetVMs(vms []ScaleSetVM) {
+	sort.SliceStable(vms, func(i, j int) bool {
+		a, aok := ordinalOf(vms[i].InstanceID)
+		b, bok := ordinalOf(vms[j].InstanceID)
+
+		if aok && bok {
+			return a < b
+		}
+
+		if aok != bok {
+			return aok
+		}
+
+		return vms[i].InstanceID < vms[j].InstanceID
+	})
+}
+
+// nextOrdinal returns the smallest ordinal not already in use — one past the
+// highest numeric instanceId, or 0 when there are none.
+func nextOrdinal(vms []ScaleSetVM) int {
+	next := 0
+
+	for i := range vms {
+		if n, ok := ordinalOf(vms[i].InstanceID); ok && n >= next {
+			next = n + 1
+		}
+	}
+
+	return next
+}
+
+func ordinalOf(id string) (int, bool) {
+	n, err := strconv.Atoi(id)
+	if err != nil {
+		return 0, false
+	}
+
+	return n, true
+}
+
+// findScaleSetKey resolves a scale-set name to the exact store key, matching
+// case-insensitively (ARM resource names are case-insensitive).
+func (m *Mock) findScaleSetKey(name string) (string, bool) {
+	if m.scaleSets.Has(name) {
+		return name, true
+	}
+
+	for _, s := range m.scaleSets.SortedValues() {
+		if strings.EqualFold(s.Name, name) {
+			return s.Name, true
+		}
+	}
+
+	return "", false
+}
+
+// ListScaleSetVMs returns the materialized VMs of a scale set (ARM VMSS VMs
+// List). Returns NotFound when no scale set with that name exists.
+func (m *Mock) ListScaleSetVMs(_ context.Context, vmssName string) ([]ScaleSetVM, error) {
+	key, ok := m.findScaleSetKey(vmssName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "virtualMachineScaleSet %q not found", vmssName)
+	}
+
+	set, _ := m.scaleSets.Get(key)
+
+	out := make([]ScaleSetVM, len(set.Instances))
+	copy(out, set.Instances)
+
+	return out, nil
+}
+
+// GetScaleSetVM returns a single materialized VM of a scale set by instanceId.
+func (m *Mock) GetScaleSetVM(_ context.Context, vmssName, instanceID string) (*ScaleSetVM, error) {
+	key, ok := m.findScaleSetKey(vmssName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "virtualMachineScaleSet %q not found", vmssName)
+	}
+
+	set, _ := m.scaleSets.Get(key)
+
+	for i := range set.Instances {
+		if set.Instances[i].InstanceID == instanceID {
+			vm := set.Instances[i]
+			return &vm, nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "virtualMachineScaleSet %q has no instance %q", vmssName, instanceID)
+}
+
+// DeleteScaleSetVM removes one instance from a scale set and decrements its
+// effective capacity, so a follow-up list reports one fewer VM.
+func (m *Mock) DeleteScaleSetVM(_ context.Context, vmssName, instanceID string) error {
+	key, ok := m.findScaleSetKey(vmssName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "virtualMachineScaleSet %q not found", vmssName)
+	}
+
+	found := false
+
+	m.scaleSets.Update(key, func(s *ScaleSet) *ScaleSet {
+		for i := range s.Instances {
+			if s.Instances[i].InstanceID != instanceID {
+				continue
+			}
+
+			s.Instances = append(s.Instances[:i], s.Instances[i+1:]...)
+			s.Capacity = len(s.Instances)
+			found = true
+
+			break
+		}
+
+		return s
+	})
+
+	if !found {
+		return cerrors.Newf(cerrors.NotFound, "virtualMachineScaleSet %q has no instance %q", vmssName, instanceID)
+	}
+
+	return nil
+}
+
+// PowerScaleSetVM applies a per-instance power action (start / poweroff /
+// deallocate / restart / reimage) to one VM of a scale set, updating its power
+// state. Unknown actions are rejected with InvalidArgument.
+func (m *Mock) PowerScaleSetVM(_ context.Context, vmssName, instanceID, action string) error {
+	key, ok := m.findScaleSetKey(vmssName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "virtualMachineScaleSet %q not found", vmssName)
+	}
+
+	power, perr := powerStateForAction(action)
+	if perr != nil {
+		return perr
+	}
+
+	found := false
+
+	m.scaleSets.Update(key, func(s *ScaleSet) *ScaleSet {
+		for i := range s.Instances {
+			if s.Instances[i].InstanceID == instanceID {
+				s.Instances[i].PowerState = power
+				found = true
+
+				break
+			}
+		}
+
+		return s
+	})
+
+	if !found {
+		return cerrors.Newf(cerrors.NotFound, "virtualMachineScaleSet %q has no instance %q", vmssName, instanceID)
+	}
+
+	return nil
+}
+
+// powerStateForAction maps a per-instance power action verb to the power state
+// the instance settles in. start/restart/reimage leave the VM running;
+// poweroff stops it (allocated); deallocate releases the compute.
+func powerStateForAction(action string) (string, error) {
+	switch strings.ToLower(action) {
+	case "start", "restart", "reimage":
+		return scaleSetVMRunning, nil
+	case "poweroff":
+		return scaleSetVMStopped, nil
+	case "deallocate":
+		return scaleSetVMDeallocated, nil
+	default:
+		return "", cerrors.Newf(cerrors.InvalidArgument, "unsupported scale-set VM power action %q", action)
+	}
 }
 
 // DeleteScaleSet removes a stored VMSS by name (ARM VMSS Delete). Returns

--- a/providers/azure/virtualmachines/scaleset_test.go
+++ b/providers/azure/virtualmachines/scaleset_test.go
@@ -2,6 +2,7 @@ package virtualmachines
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/stackshy/cloudemu/v2/services/compute/driver"
@@ -84,6 +85,89 @@ func TestCreateScaleSetExplicitRoundTrip(t *testing.T) {
 	assert.Equal(t, "Windows_Server", got.LicenseType)
 	assert.Equal(t, "Windows", got.OSType)
 	assert.Equal(t, "prod", got.Tags["env"])
+}
+
+func TestScaleSetMaterializesInstances(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateScaleSet(ctx, ScaleSet{Name: "vmss-mat", Capacity: 3})
+	require.NoError(t, err)
+
+	vms, err := m.ListScaleSetVMs(ctx, "vmss-mat")
+	require.NoError(t, err)
+	require.Len(t, vms, 3)
+
+	// Fresh create assigns ordinals 0..N-1, all running.
+	for i, vm := range vms {
+		assert.Equal(t, strconv.Itoa(i), vm.InstanceID)
+		assert.Equal(t, scaleSetVMRunning, vm.PowerState)
+		assert.Equal(t, "Succeeded", vm.ProvisioningState)
+	}
+}
+
+func TestScaleSetPowerAndDeleteInstance(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateScaleSet(ctx, ScaleSet{Name: "vmss-ops", Capacity: 3})
+	require.NoError(t, err)
+
+	require.NoError(t, m.PowerScaleSetVM(ctx, "vmss-ops", "0", "poweroff"))
+	require.NoError(t, m.PowerScaleSetVM(ctx, "vmss-ops", "1", "deallocate"))
+
+	vm0, err := m.GetScaleSetVM(ctx, "vmss-ops", "0")
+	require.NoError(t, err)
+	assert.Equal(t, scaleSetVMStopped, vm0.PowerState)
+
+	vm1, err := m.GetScaleSetVM(ctx, "vmss-ops", "1")
+	require.NoError(t, err)
+	assert.Equal(t, scaleSetVMDeallocated, vm1.PowerState)
+
+	// Deleting an instance drops it and decrements the effective count.
+	require.NoError(t, m.DeleteScaleSetVM(ctx, "vmss-ops", "1"))
+
+	vms, err := m.ListScaleSetVMs(ctx, "vmss-ops")
+	require.NoError(t, err)
+	require.Len(t, vms, 2)
+
+	_, err = m.GetScaleSetVM(ctx, "vmss-ops", "1")
+	require.Error(t, err)
+
+	// An unsupported power verb is rejected.
+	require.Error(t, m.PowerScaleSetVM(ctx, "vmss-ops", "0", "bogus"))
+}
+
+func TestScaleSetReconcilePreservesStateAcrossCapacityChange(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateScaleSet(ctx, ScaleSet{Name: "vmss-rc", Capacity: 2})
+	require.NoError(t, err)
+	require.NoError(t, m.PowerScaleSetVM(ctx, "vmss-rc", "0", "poweroff"))
+
+	// Scale out to 4: existing instances keep their power state; new instances
+	// get the next monotonic ordinals.
+	_, err = m.CreateScaleSet(ctx, ScaleSet{Name: "vmss-rc", Capacity: 4})
+	require.NoError(t, err)
+
+	vm0, err := m.GetScaleSetVM(ctx, "vmss-rc", "0")
+	require.NoError(t, err)
+	assert.Equal(t, scaleSetVMStopped, vm0.PowerState, "existing instance power state must survive scale-out")
+
+	vms, err := m.ListScaleSetVMs(ctx, "vmss-rc")
+	require.NoError(t, err)
+	require.Len(t, vms, 4)
+	assert.Equal(t, "3", vms[3].InstanceID)
+
+	// Scale in to 1: the highest-ordinal instances are dropped.
+	_, err = m.CreateScaleSet(ctx, ScaleSet{Name: "vmss-rc", Capacity: 1})
+	require.NoError(t, err)
+
+	vms, err = m.ListScaleSetVMs(ctx, "vmss-rc")
+	require.NoError(t, err)
+	require.Len(t, vms, 1)
+	assert.Equal(t, "0", vms[0].InstanceID)
 }
 
 func TestRunInstancesCarriesCostFields(t *testing.T) {

--- a/server/azure/virtualmachines/scaleset_instances.go
+++ b/server/azure/virtualmachines/scaleset_instances.go
@@ -1,0 +1,242 @@
+package virtualmachines
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	providervm "github.com/stackshy/cloudemu/v2/providers/azure/virtualmachines"
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+// defaultVMSSLocation is the location reported for a scale set (and its VMs)
+// whose stored location is unknown.
+const defaultVMSSLocation = "eastus"
+
+// serveScaleSetSubResource dispatches the sub-resource paths of a scale set:
+// the per-instance VM surface (.../virtualMachines[/{instanceId}[/{action}]])
+// and the scale-set-level instanceView.
+//
+//nolint:gocritic // rp is a request-scoped value passed once per request
+func serveScaleSetSubResource(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store scaleSetStore) {
+	switch strings.ToLower(rp.SubResource) {
+	case "virtualmachines":
+		serveScaleSetVM(w, r, rp, store)
+	case "instanceview":
+		if r.Method != http.MethodGet {
+			writeNotImplemented(w, r.Method+" "+r.URL.Path)
+			return
+		}
+
+		scaleSetInstanceView(w, r, rp, store)
+	default:
+		writeNotImplemented(w, r.Method+" "+r.URL.Path)
+	}
+}
+
+// serveScaleSetVM routes the VMSS VM surface: LIST (collection), GET/DELETE (a
+// single instance), and the POST power actions (start/powerOff/deallocate/
+// restart/reimage). rp.SubResourceName is the instanceId; rp.SubResourceAction
+// is the power verb when present.
+//
+//nolint:gocritic // rp is a request-scoped value passed once per request
+func serveScaleSetVM(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store scaleSetStore) {
+	if rp.SubResourceName == "" {
+		if r.Method == http.MethodGet {
+			listScaleSetVMs(w, r, rp, store)
+			return
+		}
+
+		writeNotImplemented(w, r.Method+" "+r.URL.Path)
+
+		return
+	}
+
+	if rp.SubResourceAction != "" {
+		// instanceView is a GET sub-path on a single instance; the power verbs
+		// (start/powerOff/deallocate/restart/reimage) are POST actions.
+		if strings.EqualFold(rp.SubResourceAction, "instanceView") {
+			if r.Method != http.MethodGet {
+				writeNotImplemented(w, r.Method+" "+r.URL.Path)
+				return
+			}
+
+			scaleSetVMInstanceView(w, r, rp, store)
+
+			return
+		}
+
+		if r.Method != http.MethodPost {
+			writeNotImplemented(w, r.Method+" "+r.URL.Path)
+			return
+		}
+
+		scaleSetVMPowerAction(w, r, rp, store)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		getScaleSetVM(w, r, rp, store)
+	case http.MethodDelete:
+		deleteScaleSetVM(w, r, rp, store)
+	default:
+		writeNotImplemented(w, r.Method+" "+r.URL.Path)
+	}
+}
+
+// listScaleSetVMs handles GET .../virtualMachineScaleSets/{vmss}/virtualMachines.
+//
+//nolint:gocritic // rp is a request-scoped value
+func listScaleSetVMs(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store scaleSetStore) {
+	vms, err := store.ListScaleSetVMs(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	loc := scaleSetLocation(r.Context(), store, rp.ResourceName)
+	out := make([]vmssVMResponse, 0, len(vms))
+
+	for i := range vms {
+		out = append(out, toVMSSVMResponse(rp, vms[i], loc))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, vmssVMListResponse{Value: out})
+}
+
+// getScaleSetVM handles GET .../virtualMachines/{instanceId}.
+//
+//nolint:gocritic // rp is a request-scoped value
+func getScaleSetVM(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store scaleSetStore) {
+	vm, err := store.GetScaleSetVM(r.Context(), rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	loc := scaleSetLocation(r.Context(), store, rp.ResourceName)
+
+	azurearm.WriteJSON(w, http.StatusOK, toVMSSVMResponse(rp, *vm, loc))
+}
+
+// deleteScaleSetVM handles DELETE .../virtualMachines/{instanceId}. Returns 202
+// + the async-operation polling headers so the SDK poller settles cleanly, and
+// a follow-up list reports one fewer instance.
+//
+//nolint:gocritic // rp is a request-scoped value
+func deleteScaleSetVM(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store scaleSetStore) {
+	if err := store.DeleteScaleSetVM(r.Context(), rp.ResourceName, rp.SubResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "vmss-vm-delete-"+rp.ResourceName+"-"+rp.SubResourceName)
+}
+
+// scaleSetVMPowerAction handles the POST power actions on a single instance
+// (start/powerOff/deallocate/restart/reimage). Returns 202 + async polling
+// headers.
+//
+//nolint:gocritic // rp is a request-scoped value
+func scaleSetVMPowerAction(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store scaleSetStore) {
+	if err := store.PowerScaleSetVM(r.Context(), rp.ResourceName, rp.SubResourceName, rp.SubResourceAction); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "vmss-vm-"+rp.SubResourceAction+"-"+rp.ResourceName+"-"+rp.SubResourceName)
+}
+
+// scaleSetVMInstanceView handles GET .../virtualMachines/{instanceId}/instanceView,
+// returning the single instance's VirtualMachineScaleSetVMInstanceView statuses.
+//
+//nolint:gocritic // rp is a request-scoped value
+func scaleSetVMInstanceView(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store scaleSetStore) {
+	vm, err := store.GetScaleSetVM(r.Context(), rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	power := defaultIfEmpty(vm.PowerState, "running")
+
+	azurearm.WriteJSON(w, http.StatusOK, instanceView{
+		Statuses: []instanceViewStatus{
+			{Code: "ProvisioningState/succeeded", Level: "Info", DisplayStatus: "Provisioning succeeded"},
+			{Code: "PowerState/" + power, Level: "Info", DisplayStatus: "VM " + power},
+		},
+	})
+}
+
+// scaleSetInstanceView handles GET .../virtualMachineScaleSets/{name}/instanceView.
+//
+//nolint:gocritic // rp is a request-scoped value
+func scaleSetInstanceView(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store scaleSetStore) {
+	vms, err := store.ListScaleSetVMs(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	counts := map[string]int{}
+	for i := range vms {
+		counts["ProvisioningState/"+strings.ToLower(defaultIfEmpty(vms[i].ProvisioningState, "succeeded"))]++
+	}
+
+	summary := make([]vmssStatusSummary, 0, len(counts))
+	for code, n := range counts {
+		summary = append(summary, vmssStatusSummary{Code: code, Count: n})
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, vmssInstanceViewResponse{
+		VirtualMachine: &vmssVMStatusesSummary{StatusesSummary: summary},
+		Statuses: []instanceViewStatus{
+			{Code: "ProvisioningState/succeeded", Level: "Info", DisplayStatus: "Provisioning succeeded"},
+		},
+	})
+}
+
+// scaleSetLocation resolves a scale set's location for rendering its VMs'
+// required location field, falling back to eastus when unknown.
+func scaleSetLocation(ctx context.Context, store scaleSetStore, name string) string {
+	sets, err := store.ListScaleSets(ctx)
+	if err != nil {
+		return defaultVMSSLocation
+	}
+
+	for i := range sets {
+		if strings.EqualFold(sets[i].Name, name) {
+			return defaultIfEmpty(sets[i].Location, defaultVMSSLocation)
+		}
+	}
+
+	return defaultVMSSLocation
+}
+
+// toVMSSVMResponse maps a stored ScaleSetVM onto the ARM wire shape. The id is
+// the nested VMSS-VM resource id; the name is Azure's "{vmss}_{instanceId}".
+//
+//nolint:gocritic // rp is a value type passed once per response build
+func toVMSSVMResponse(rp azurearm.ResourcePath, vm providervm.ScaleSetVM, location string) vmssVMResponse {
+	base := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceTypeScaleSets, rp.ResourceName)
+	power := defaultIfEmpty(vm.PowerState, "running")
+
+	return vmssVMResponse{
+		ID:         base + "/virtualMachines/" + vm.InstanceID,
+		Name:       rp.ResourceName + "_" + vm.InstanceID,
+		Type:       providerName + "/" + resourceTypeScaleSets + "/virtualMachines",
+		Location:   location,
+		InstanceID: vm.InstanceID,
+		Properties: vmssVMResponseProps{
+			ProvisioningState: defaultIfEmpty(vm.ProvisioningState, "Succeeded"),
+			InstanceView: &instanceView{
+				Statuses: []instanceViewStatus{
+					{Code: "ProvisioningState/succeeded", Level: "Info", DisplayStatus: "Provisioning succeeded"},
+					{Code: "PowerState/" + power, Level: "Info", DisplayStatus: "VM " + power},
+				},
+			},
+		},
+	}
+}

--- a/server/azure/virtualmachines/scaleset_instances_test.go
+++ b/server/azure/virtualmachines/scaleset_instances_test.go
@@ -1,0 +1,183 @@
+package virtualmachines_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKVMSSInstanceOrchestration drives the real armcompute
+// VirtualMachineScaleSetVMsClient against an in-process cloudemu server: a
+// scale set created at capacity N materializes N addressable instances that can
+// be listed, fetched, powered off, and deleted — a delete dropping one so the
+// list returns N-1.
+func TestSDKVMSSInstanceOrchestration(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ssClient, err := armcompute.NewVirtualMachineScaleSetsClient("sub-1", fakeCred{}, sdkClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vmClient, err := armcompute.NewVirtualMachineScaleSetVMsClient("sub-1", fakeCred{}, sdkClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	const (
+		rg       = "rg-1"
+		name     = "orch-vmss"
+		capacity = 3
+	)
+
+	createVMSSWithCapacity(ctx, t, ssClient, rg, name, capacity)
+
+	// LIST returns the materialized instances, one per capacity unit.
+	ids := listVMSSVMInstanceIDs(ctx, t, vmClient, rg, name)
+	if len(ids) != capacity {
+		t.Fatalf("List: got %d instances, want %d", len(ids), capacity)
+	}
+
+	// GET a single instance resolves it and echoes its ordinal + composite name.
+	got, err := vmClient.Get(ctx, rg, name, ids[0], nil)
+	if err != nil {
+		t.Fatalf("Get instance %q: %v", ids[0], err)
+	}
+
+	if got.InstanceID == nil || *got.InstanceID != ids[0] {
+		t.Fatalf("Get instanceId = %v, want %q", got.InstanceID, ids[0])
+	}
+
+	if got.Name == nil || *got.Name != name+"_"+ids[0] {
+		t.Fatalf("Get name = %v, want %q", got.Name, name+"_"+ids[0])
+	}
+
+	// POWER OFF one instance; its instanceView must reflect PowerState/stopped.
+	powerOffVMSSVM(ctx, t, vmClient, rg, name, ids[0])
+
+	if state := instanceViewPowerState(ctx, t, vmClient, rg, name, ids[0]); state != "PowerState/stopped" {
+		t.Fatalf("after powerOff, power state = %q, want PowerState/stopped", state)
+	}
+
+	// DELETE one instance; the list must then return one fewer.
+	deleteVMSSVM(ctx, t, vmClient, rg, name, ids[1])
+
+	after := listVMSSVMInstanceIDs(ctx, t, vmClient, rg, name)
+	if len(after) != capacity-1 {
+		t.Fatalf("List after delete: got %d instances, want %d", len(after), capacity-1)
+	}
+
+	for _, id := range after {
+		if id == ids[1] {
+			t.Fatalf("deleted instance %q still present after delete", ids[1])
+		}
+	}
+}
+
+func createVMSSWithCapacity(
+	ctx context.Context, t *testing.T, client *armcompute.VirtualMachineScaleSetsClient, rg, name string, capacity int64,
+) {
+	t.Helper()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rg, name, armcompute.VirtualMachineScaleSet{
+		Location: to.Ptr("westus2"),
+		SKU: &armcompute.SKU{
+			Name:     to.Ptr("Standard_D2s_v3"),
+			Tier:     to.Ptr("Standard"),
+			Capacity: to.Ptr(capacity),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("VMSS BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("VMSS create poll: %v", err)
+	}
+}
+
+func listVMSSVMInstanceIDs(
+	ctx context.Context, t *testing.T, client *armcompute.VirtualMachineScaleSetVMsClient, rg, name string,
+) []string {
+	t.Helper()
+
+	var ids []string
+
+	pager := client.NewListPager(rg, name, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("VMSS VM list: %v", err)
+		}
+
+		for _, vm := range page.Value {
+			if vm.InstanceID != nil {
+				ids = append(ids, *vm.InstanceID)
+			}
+		}
+	}
+
+	return ids
+}
+
+func powerOffVMSSVM(
+	ctx context.Context, t *testing.T, client *armcompute.VirtualMachineScaleSetVMsClient, rg, name, instanceID string,
+) {
+	t.Helper()
+
+	poller, err := client.BeginPowerOff(ctx, rg, name, instanceID, nil)
+	if err != nil {
+		t.Fatalf("BeginPowerOff %q: %v", instanceID, err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("PowerOff poll: %v", err)
+	}
+}
+
+func deleteVMSSVM(
+	ctx context.Context, t *testing.T, client *armcompute.VirtualMachineScaleSetVMsClient, rg, name, instanceID string,
+) {
+	t.Helper()
+
+	poller, err := client.BeginDelete(ctx, rg, name, instanceID, nil)
+	if err != nil {
+		t.Fatalf("BeginDelete %q: %v", instanceID, err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("Delete poll: %v", err)
+	}
+}
+
+func instanceViewPowerState(
+	ctx context.Context, t *testing.T, client *armcompute.VirtualMachineScaleSetVMsClient, rg, name, instanceID string,
+) string {
+	t.Helper()
+
+	view, err := client.GetInstanceView(ctx, rg, name, instanceID, nil)
+	if err != nil {
+		t.Fatalf("GetInstanceView %q: %v", instanceID, err)
+	}
+
+	for _, s := range view.Statuses {
+		if s.Code != nil && strings.HasPrefix(*s.Code, "PowerState/") {
+			return *s.Code
+		}
+	}
+
+	return ""
+}

--- a/server/azure/virtualmachines/scalesets.go
+++ b/server/azure/virtualmachines/scalesets.go
@@ -17,6 +17,10 @@ type scaleSetStore interface {
 	CreateScaleSet(ctx context.Context, s providervm.ScaleSet) (*providervm.ScaleSet, error)
 	ListScaleSets(ctx context.Context) ([]providervm.ScaleSet, error)
 	DeleteScaleSet(ctx context.Context, name string) error
+	ListScaleSetVMs(ctx context.Context, vmssName string) ([]providervm.ScaleSetVM, error)
+	GetScaleSetVM(ctx context.Context, vmssName, instanceID string) (*providervm.ScaleSetVM, error)
+	DeleteScaleSetVM(ctx context.Context, vmssName, instanceID string) error
+	PowerScaleSetVM(ctx context.Context, vmssName, instanceID, action string) error
 }
 
 // serveScaleSet dispatches PUT/GET on Microsoft.Compute/virtualMachineScaleSets.
@@ -30,7 +34,7 @@ func (h *Handler) serveScaleSet(w http.ResponseWriter, r *http.Request, rp azure
 	}
 
 	if rp.SubResource != "" {
-		writeNotImplemented(w, r.Method+" "+r.URL.Path)
+		serveScaleSetSubResource(w, r, rp, store)
 		return
 	}
 

--- a/server/azure/virtualmachines/scalesets_types.go
+++ b/server/azure/virtualmachines/scalesets_types.go
@@ -54,3 +54,41 @@ type vmssResponseProps struct {
 type vmssListResponse struct {
 	Value []vmssResponse `json:"value"`
 }
+
+// vmssVMResponse is the outbound shape for a single materialized scale-set VM
+// (Microsoft.Compute/virtualMachineScaleSets/{vmss}/virtualMachines/{instanceId}).
+type vmssVMResponse struct {
+	ID         string              `json:"id"`
+	Name       string              `json:"name"`
+	Type       string              `json:"type"`
+	Location   string              `json:"location"`
+	InstanceID string              `json:"instanceId"`
+	Properties vmssVMResponseProps `json:"properties"`
+}
+
+type vmssVMResponseProps struct {
+	ProvisioningState string        `json:"provisioningState"`
+	InstanceView      *instanceView `json:"instanceView,omitempty"`
+}
+
+// vmssVMListResponse is the outbound shape for a scale-set VM list.
+type vmssVMListResponse struct {
+	Value []vmssVMResponse `json:"value"`
+}
+
+// vmssInstanceViewResponse is the outbound VirtualMachineScaleSetInstanceView
+// for GET virtualMachineScaleSets/{name}/instanceView: per-provisioning-state
+// instance counts plus the scale set's own status line.
+type vmssInstanceViewResponse struct {
+	VirtualMachine *vmssVMStatusesSummary `json:"virtualMachine,omitempty"`
+	Statuses       []instanceViewStatus   `json:"statuses,omitempty"`
+}
+
+type vmssVMStatusesSummary struct {
+	StatusesSummary []vmssStatusSummary `json:"statusesSummary,omitempty"`
+}
+
+type vmssStatusSummary struct {
+	Code  string `json:"code"`
+	Count int    `json:"count"`
+}


### PR DESCRIPTION
## What

Implements **VMSS instance orchestration** — a sub-feature of #611 — end-to-end. A scale set now materializes enumerable, addressable, controllable VM instances driven by its SKU capacity, and the wire server serves the `Microsoft.Compute/virtualMachineScaleSets/{vmss}/virtualMachines` surface that previously hit `writeNotImplemented`.

Supported operations (real `armcompute` `VirtualMachineScaleSetVMsClient`):

- `GET .../virtualMachines` — list the per-instance VMs
- `GET .../virtualMachines/{instanceId}` — get a single instance
- `DELETE .../virtualMachines/{instanceId}` — remove an instance
- `POST .../virtualMachines/{instanceId}/{start|powerOff|deallocate|restart|reimage}` — per-instance power ops
- `GET .../virtualMachines/{instanceId}/instanceView` — per-instance instance view
- `GET .../virtualMachineScaleSets/{name}/instanceView` — scale-set-level instance view (per-state counts)

## Why

The Azure real-user deep-sweep (#611) flagged VMSS instances as entirely unimplemented: any `/virtualMachines` sub-resource path on the scale-set handler returned `501 NotImplemented`, so a scale set was a bare CRUD record with no addressable VMs.

## Instance materialization model

- Instance ids are string ordinals (`"0"`, `"1"`, …). The Azure resource name is rendered `{vmss}_{instanceId}`.
- Creating a scale set (or re-PUTting one) reconciles its instances to the SKU capacity:
  - **scale out** appends new instances with the next *monotonic* ordinals (a gap left by a deleted instance is not reused);
  - **scale in** drops the highest-ordinal instances, matching Azure's default scale-in ordering;
  - surviving instances keep their power state across a capacity change (idempotent CreateOrUpdate).
- Deleting an instance drops it and decrements the effective capacity, so a follow-up list returns one fewer VM.
- Per-instance power ops update the instance's power state (`running` / `stopped` / `deallocated`), echoed in the ARM `PowerState/*` instanceView status.

## LRO handling

Delete and the power actions return `202 Accepted` with the `Azure-AsyncOperation` / `Location` headers pointing at the existing `operationStatuses` endpoint (which reports `Succeeded`), so SDK `Begin*` pollers settle cleanly — the same pattern the scale-set delete and single-VM lifecycle already use. GET/LIST/instanceView are synchronous 200s.

## Blast radius

`server/azure/virtualmachines` + `providers/azure/virtualmachines` only. Existing scale-set CRUD is unchanged (the `writeNotImplemented` was only on the sub-resource path). `go run ./internal/coveragegen` produces no diff: the VMSS scale-set surface is server-local (type-asserted against the provider `ScaleSet` type, not exposed via a `services/compute/driver` interface), so it is not surfaced by coveragegen — consistent with the pre-existing scale-set CRUD methods.

## Tests

- Real-SDK e2e (`VirtualMachineScaleSetVMsClient`): create at capacity N → list returns N → get one (ordinal + composite name) → power off one (instanceView reflects `PowerState/stopped`) → delete one → list returns N-1.
- Provider unit tests: materialization, power/delete, and capacity-change reconciliation (state preservation on scale-out, highest-ordinal drop on scale-in).

Gates: `go build ./...`, `go test ./server/azure/virtualmachines/... ./providers/azure/virtualmachines/... ./internal/coveragegen/...`, and `golangci-lint` on the touched packages all green.
