### PR TITLE
feat(azure-network): VPN gateways, local gateways, connections (#611)

### DIFF
--- a/docs/coverage/azure/vnet.md
+++ b/docs/coverage/azure/vnet.md
@@ -80,6 +80,25 @@ AzureApplicationSecurityGroups is the Azure-only application-security-group
 | `ListAzureApplicationSecurityGroups` | ListAzureApplicationSecurityGroups returns the ASGs in a resource group, or |
 | `PutAzureApplicationSecurityGroup` | PutAzureApplicationSecurityGroup creates or replaces an ASG in place (a |
 
+### AzureNetworkGateways
+
+AzureNetworkGateways is the Azure-only site-to-site VPN surface. Each resource
+
+| Operation | Description |
+| --- | --- |
+| `DeleteAzureLocalNetworkGateway` | DeleteAzureLocalNetworkGateway removes the local gateway, reporting whether it existed. |
+| `DeleteAzureVirtualNetworkGateway` | DeleteAzureVirtualNetworkGateway removes the gateway, reporting whether it existed. |
+| `DeleteAzureVirtualNetworkGatewayConnection` | DeleteAzureVirtualNetworkGatewayConnection removes the connection, reporting whether it existed. |
+| `GetAzureLocalNetworkGateway` | GetAzureLocalNetworkGateway returns the local gateway identified by (resourceGroup, name). |
+| `GetAzureVirtualNetworkGateway` | GetAzureVirtualNetworkGateway returns the gateway identified by (resourceGroup, name). |
+| `GetAzureVirtualNetworkGatewayConnection` | GetAzureVirtualNetworkGatewayConnection returns the connection identified by (resourceGroup, name). |
+| `ListAzureLocalNetworkGateways` | ListAzureLocalNetworkGateways returns the local gateways in a resource group, |
+| `ListAzureVirtualNetworkGatewayConnections` | ListAzureVirtualNetworkGatewayConnections returns the connections in a resource |
+| `ListAzureVirtualNetworkGateways` | ListAzureVirtualNetworkGateways returns the gateways in a resource group, or |
+| `PutAzureLocalNetworkGateway` | PutAzureLocalNetworkGateway creates or replaces a local network gateway in place. |
+| `PutAzureVirtualNetworkGateway` | PutAzureVirtualNetworkGateway creates or replaces a virtual network gateway |
+| `PutAzureVirtualNetworkGatewayConnection` | PutAzureVirtualNetworkGatewayConnection creates or replaces a connection in place. |
+
 ### AzureNetworkInterfaces
 
 AzureNetworkInterfaces is the Azure-specific network-interface surface,

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -7547,6 +7547,60 @@
         ]
       },
       {
+        "name": "AzureNetworkGateways",
+        "doc": "AzureNetworkGateways is the Azure-only site-to-site VPN surface. Each resource",
+        "operations": [
+          {
+            "name": "DeleteAzureLocalNetworkGateway",
+            "doc": "DeleteAzureLocalNetworkGateway removes the local gateway, reporting whether it existed."
+          },
+          {
+            "name": "DeleteAzureVirtualNetworkGateway",
+            "doc": "DeleteAzureVirtualNetworkGateway removes the gateway, reporting whether it existed."
+          },
+          {
+            "name": "DeleteAzureVirtualNetworkGatewayConnection",
+            "doc": "DeleteAzureVirtualNetworkGatewayConnection removes the connection, reporting whether it existed."
+          },
+          {
+            "name": "GetAzureLocalNetworkGateway",
+            "doc": "GetAzureLocalNetworkGateway returns the local gateway identified by (resourceGroup, name)."
+          },
+          {
+            "name": "GetAzureVirtualNetworkGateway",
+            "doc": "GetAzureVirtualNetworkGateway returns the gateway identified by (resourceGroup, name)."
+          },
+          {
+            "name": "GetAzureVirtualNetworkGatewayConnection",
+            "doc": "GetAzureVirtualNetworkGatewayConnection returns the connection identified by (resourceGroup, name)."
+          },
+          {
+            "name": "ListAzureLocalNetworkGateways",
+            "doc": "ListAzureLocalNetworkGateways returns the local gateways in a resource group,"
+          },
+          {
+            "name": "ListAzureVirtualNetworkGatewayConnections",
+            "doc": "ListAzureVirtualNetworkGatewayConnections returns the connections in a resource"
+          },
+          {
+            "name": "ListAzureVirtualNetworkGateways",
+            "doc": "ListAzureVirtualNetworkGateways returns the gateways in a resource group, or"
+          },
+          {
+            "name": "PutAzureLocalNetworkGateway",
+            "doc": "PutAzureLocalNetworkGateway creates or replaces a local network gateway in place."
+          },
+          {
+            "name": "PutAzureVirtualNetworkGateway",
+            "doc": "PutAzureVirtualNetworkGateway creates or replaces a virtual network gateway"
+          },
+          {
+            "name": "PutAzureVirtualNetworkGatewayConnection",
+            "doc": "PutAzureVirtualNetworkGatewayConnection creates or replaces a connection in place."
+          }
+        ]
+      },
+      {
         "name": "AzureNetworkInterfaces",
         "doc": "AzureNetworkInterfaces is the Azure-specific network-interface surface,",
         "operations": [

--- a/providers/azure/vnet/network_gateway.go
+++ b/providers/azure/vnet/network_gateway.go
@@ -1,0 +1,229 @@
+package vnet
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// Compile-time check that Mock serves the Azure network-gateway surface.
+var _ driver.AzureNetworkGateways = (*Mock)(nil)
+
+// gatewayKey composes the store key from the ARM addressing pair. Resource-group
+// names are case-insensitive in Azure, so it is lower-cased; the resource name is
+// preserved as-is, mirroring asgKey.
+func gatewayKey(resourceGroup, name string) string {
+	return strings.ToLower(resourceGroup) + "/" + name
+}
+
+// Virtual network gateways.
+
+// PutAzureVirtualNetworkGateway creates or replaces a virtual network gateway in
+// place, keyed by (resourceGroup, name), so a repeat createOrUpdate PUT updates
+// rather than duplicating.
+//
+//nolint:gocritic // hugeParam: gw mirrors the AzureNetworkGateways driver signature.
+func (m *Mock) PutAzureVirtualNetworkGateway(
+	_ context.Context, gw driver.AzureVirtualNetworkGateway,
+) driver.AzureVirtualNetworkGateway {
+	stored := cloneVNG(gw)
+	m.azureVNGateways.Set(gatewayKey(gw.ResourceGroup, gw.Name), stored)
+
+	return cloneVNG(stored)
+}
+
+// GetAzureVirtualNetworkGateway returns the gateway identified by (resourceGroup, name).
+func (m *Mock) GetAzureVirtualNetworkGateway(
+	_ context.Context, resourceGroup, name string,
+) (driver.AzureVirtualNetworkGateway, bool) {
+	gw, ok := m.azureVNGateways.Get(gatewayKey(resourceGroup, name))
+	if !ok {
+		return driver.AzureVirtualNetworkGateway{}, false
+	}
+
+	return cloneVNG(gw), true
+}
+
+// DeleteAzureVirtualNetworkGateway removes the gateway, reporting whether it existed.
+func (m *Mock) DeleteAzureVirtualNetworkGateway(_ context.Context, resourceGroup, name string) bool {
+	return m.azureVNGateways.Delete(gatewayKey(resourceGroup, name))
+}
+
+// ListAzureVirtualNetworkGateways returns the gateways in a resource group, or all
+// when resourceGroup is empty (subscription-wide list), ordered by key.
+func (m *Mock) ListAzureVirtualNetworkGateways(
+	_ context.Context, resourceGroup string,
+) []driver.AzureVirtualNetworkGateway {
+	out := make([]driver.AzureVirtualNetworkGateway, 0)
+
+	values := m.azureVNGateways.SortedValues()
+	for i := range values {
+		if resourceGroup != "" && !strings.EqualFold(values[i].ResourceGroup, resourceGroup) {
+			continue
+		}
+
+		out = append(out, cloneVNG(values[i]))
+	}
+
+	return out
+}
+
+// Local network gateways.
+
+// PutAzureLocalNetworkGateway creates or replaces a local network gateway in place.
+//
+//nolint:gocritic // hugeParam: gw mirrors the AzureNetworkGateways driver signature.
+func (m *Mock) PutAzureLocalNetworkGateway(
+	_ context.Context, gw driver.AzureLocalNetworkGateway,
+) driver.AzureLocalNetworkGateway {
+	stored := cloneLNG(gw)
+	m.azureLNGateways.Set(gatewayKey(gw.ResourceGroup, gw.Name), stored)
+
+	return cloneLNG(stored)
+}
+
+// GetAzureLocalNetworkGateway returns the local gateway identified by (resourceGroup, name).
+func (m *Mock) GetAzureLocalNetworkGateway(
+	_ context.Context, resourceGroup, name string,
+) (driver.AzureLocalNetworkGateway, bool) {
+	gw, ok := m.azureLNGateways.Get(gatewayKey(resourceGroup, name))
+	if !ok {
+		return driver.AzureLocalNetworkGateway{}, false
+	}
+
+	return cloneLNG(gw), true
+}
+
+// DeleteAzureLocalNetworkGateway removes the local gateway, reporting whether it existed.
+func (m *Mock) DeleteAzureLocalNetworkGateway(_ context.Context, resourceGroup, name string) bool {
+	return m.azureLNGateways.Delete(gatewayKey(resourceGroup, name))
+}
+
+// ListAzureLocalNetworkGateways returns the local gateways in a resource group, or
+// all when resourceGroup is empty (subscription-wide list), ordered by key.
+func (m *Mock) ListAzureLocalNetworkGateways(
+	_ context.Context, resourceGroup string,
+) []driver.AzureLocalNetworkGateway {
+	out := make([]driver.AzureLocalNetworkGateway, 0)
+
+	values := m.azureLNGateways.SortedValues()
+	for i := range values {
+		if resourceGroup != "" && !strings.EqualFold(values[i].ResourceGroup, resourceGroup) {
+			continue
+		}
+
+		out = append(out, cloneLNG(values[i]))
+	}
+
+	return out
+}
+
+// Gateway connections.
+
+// PutAzureVirtualNetworkGatewayConnection creates or replaces a connection in place.
+//
+//nolint:gocritic // hugeParam: conn mirrors the AzureNetworkGateways driver signature.
+func (m *Mock) PutAzureVirtualNetworkGatewayConnection(
+	_ context.Context, conn driver.AzureVirtualNetworkGatewayConnection,
+) driver.AzureVirtualNetworkGatewayConnection {
+	stored := cloneConn(conn)
+	m.azureGWConnections.Set(gatewayKey(conn.ResourceGroup, conn.Name), stored)
+
+	return cloneConn(stored)
+}
+
+// GetAzureVirtualNetworkGatewayConnection returns the connection identified by (resourceGroup, name).
+func (m *Mock) GetAzureVirtualNetworkGatewayConnection(
+	_ context.Context, resourceGroup, name string,
+) (driver.AzureVirtualNetworkGatewayConnection, bool) {
+	conn, ok := m.azureGWConnections.Get(gatewayKey(resourceGroup, name))
+	if !ok {
+		return driver.AzureVirtualNetworkGatewayConnection{}, false
+	}
+
+	return cloneConn(conn), true
+}
+
+// DeleteAzureVirtualNetworkGatewayConnection removes the connection, reporting whether it existed.
+func (m *Mock) DeleteAzureVirtualNetworkGatewayConnection(_ context.Context, resourceGroup, name string) bool {
+	return m.azureGWConnections.Delete(gatewayKey(resourceGroup, name))
+}
+
+// ListAzureVirtualNetworkGatewayConnections returns the connections in a resource
+// group, or all when resourceGroup is empty (subscription-wide list), ordered by key.
+func (m *Mock) ListAzureVirtualNetworkGatewayConnections(
+	_ context.Context, resourceGroup string,
+) []driver.AzureVirtualNetworkGatewayConnection {
+	out := make([]driver.AzureVirtualNetworkGatewayConnection, 0)
+
+	values := m.azureGWConnections.SortedValues()
+	for i := range values {
+		if resourceGroup != "" && !strings.EqualFold(values[i].ResourceGroup, resourceGroup) {
+			continue
+		}
+
+		out = append(out, cloneConn(values[i]))
+	}
+
+	return out
+}
+
+// Clone helpers deep-copy the tag map and any slices so stored and returned
+// values never alias a caller's containers.
+
+//nolint:gocritic // hugeParam: gw mirrors the AzureNetworkGateways driver signature.
+func cloneVNG(gw driver.AzureVirtualNetworkGateway) driver.AzureVirtualNetworkGateway {
+	out := gw
+	out.Tags = maybeCopyTags(gw.Tags)
+
+	if len(gw.IPConfigurations) > 0 {
+		out.IPConfigurations = append([]driver.AzureGatewayIPConfiguration(nil), gw.IPConfigurations...)
+	}
+
+	out.BgpSettings = cloneBgp(gw.BgpSettings)
+
+	return out
+}
+
+//nolint:gocritic // hugeParam: gw mirrors the AzureNetworkGateways driver signature.
+func cloneLNG(gw driver.AzureLocalNetworkGateway) driver.AzureLocalNetworkGateway {
+	out := gw
+	out.Tags = maybeCopyTags(gw.Tags)
+
+	if len(gw.AddressPrefixes) > 0 {
+		out.AddressPrefixes = append([]string(nil), gw.AddressPrefixes...)
+	}
+
+	out.BgpSettings = cloneBgp(gw.BgpSettings)
+
+	return out
+}
+
+//nolint:gocritic // hugeParam: conn mirrors the AzureNetworkGateways driver signature.
+func cloneConn(conn driver.AzureVirtualNetworkGatewayConnection) driver.AzureVirtualNetworkGatewayConnection {
+	out := conn
+	out.Tags = maybeCopyTags(conn.Tags)
+
+	return out
+}
+
+func cloneBgp(in *driver.AzureGatewayBgpSettings) *driver.AzureGatewayBgpSettings {
+	if in == nil {
+		return nil
+	}
+
+	cp := *in
+
+	return &cp
+}
+
+// maybeCopyTags copies a non-empty tag map and leaves an empty one nil, so a
+// clone never aliases the caller's map yet an absent map stays absent.
+func maybeCopyTags(tags map[string]string) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return copyTags(tags)
+}

--- a/providers/azure/vnet/snapshot.go
+++ b/providers/azure/vnet/snapshot.go
@@ -38,6 +38,9 @@ type vnetSnapshot struct {
 	AzureVNetPeerings   json.RawMessage `json:"azureVnetPeerings,omitempty"`
 	AzureASGs           json.RawMessage `json:"azureAsgs,omitempty"`
 	AzurePrefixes       json.RawMessage `json:"azurePublicIpPrefixes,omitempty"`
+	AzureVNGateways     json.RawMessage `json:"azureVirtualNetworkGateways,omitempty"`
+	AzureLNGateways     json.RawMessage `json:"azureLocalNetworkGateways,omitempty"`
+	AzureGWConnections  json.RawMessage `json:"azureGatewayConnections,omitempty"`
 }
 
 // Snapshot captures the mock's entire state as JSON. includeAssets is unused —
@@ -76,6 +79,9 @@ func (m *Mock) snapshotStores(snap *vnetSnapshot) error {
 		{&snap.AzureVNetPeerings, m.azureVNetPeerings.Snapshot},
 		{&snap.AzureASGs, m.azureASGs.Snapshot},
 		{&snap.AzurePrefixes, m.azurePrefixes.Snapshot},
+		{&snap.AzureVNGateways, m.azureVNGateways.Snapshot},
+		{&snap.AzureLNGateways, m.azureLNGateways.Snapshot},
+		{&snap.AzureGWConnections, m.azureGWConnections.Snapshot},
 	}
 
 	for _, d := range dumps {
@@ -126,6 +132,9 @@ func (m *Mock) restoreStores(snap *vnetSnapshot) error {
 		{snap.AzureVNetPeerings, m.azureVNetPeerings.LoadSnapshot},
 		{snap.AzureASGs, m.azureASGs.LoadSnapshot},
 		{snap.AzurePrefixes, m.azurePrefixes.LoadSnapshot},
+		{snap.AzureVNGateways, m.azureVNGateways.LoadSnapshot},
+		{snap.AzureLNGateways, m.azureLNGateways.LoadSnapshot},
+		{snap.AzureGWConnections, m.azureGWConnections.LoadSnapshot},
 	}
 
 	for _, l := range loads {

--- a/providers/azure/vnet/snapshot_test.go
+++ b/providers/azure/vnet/snapshot_test.go
@@ -43,6 +43,29 @@ func TestSnapshotRestoreRoundTrip(t *testing.T) {
 		SKUName: "Standard", SKUTier: "Regional", Tags: map[string]string{"team": "net"},
 	})
 
+	// Seed the full site-to-site VPN surface so the round-trip proves each of the
+	// three gateway stores is included in the snapshot dump/restore lists — the
+	// test would pass even with a store dropped if nothing referenced it.
+	src.PutAzureVirtualNetworkGateway(ctx, driver.AzureVirtualNetworkGateway{
+		Name: "vng1", ResourceGroup: "rg1", Location: "eastus",
+		GatewayType: "Vpn", VPNType: "RouteBased", SKUName: "VpnGw1", SKUTier: "VpnGw1",
+		BgpSettings: &driver.AzureGatewayBgpSettings{ASN: 65000, BgpPeeringAddress: "10.0.255.254"},
+		Tags:        map[string]string{"role": "hub"},
+	})
+
+	src.PutAzureLocalNetworkGateway(ctx, driver.AzureLocalNetworkGateway{
+		Name: "lng1", ResourceGroup: "rg1", Location: "eastus",
+		GatewayIPAddress: "203.0.113.10", AddressPrefixes: []string{"192.168.0.0/16"},
+	})
+
+	src.PutAzureVirtualNetworkGatewayConnection(ctx, driver.AzureVirtualNetworkGatewayConnection{
+		Name: "conn1", ResourceGroup: "rg1", Location: "eastus",
+		ConnectionType:           "IPsec",
+		VirtualNetworkGateway1ID: "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworkGateways/vng1",
+		LocalNetworkGateway2ID:   "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Network/localNetworkGateways/lng1",
+		SharedKey:                "psk-secret", RoutingWeight: 10,
+	})
+
 	data, err := src.Snapshot(ctx, true)
 	require.NoError(t, err)
 
@@ -83,6 +106,29 @@ func TestSnapshotRestoreRoundTrip(t *testing.T) {
 	assert.Equal(t, int32(28), pfx.PrefixLength)
 	assert.Equal(t, "Standard", pfx.SKUName)
 	assert.Equal(t, "net", pfx.Tags["team"])
+
+	// The virtual network gateway survives with its type, sku and BGP settings.
+	vng, ok := dst.GetAzureVirtualNetworkGateway(ctx, "rg1", "vng1")
+	require.True(t, ok, "virtual network gateway must survive snapshot/restore")
+	assert.Equal(t, "Vpn", vng.GatewayType)
+	assert.Equal(t, "VpnGw1", vng.SKUName)
+	assert.Equal(t, "hub", vng.Tags["role"])
+	require.NotNil(t, vng.BgpSettings, "BGP settings must round-trip")
+	assert.Equal(t, int64(65000), vng.BgpSettings.ASN)
+
+	// The local network gateway survives with its on-prem IP and address space.
+	lng, ok := dst.GetAzureLocalNetworkGateway(ctx, "rg1", "lng1")
+	require.True(t, ok, "local network gateway must survive snapshot/restore")
+	assert.Equal(t, "203.0.113.10", lng.GatewayIPAddress)
+	assert.Equal(t, []string{"192.168.0.0/16"}, lng.AddressPrefixes)
+
+	// The connection survives with its gateway references and shared key.
+	conn, ok := dst.GetAzureVirtualNetworkGatewayConnection(ctx, "rg1", "conn1")
+	require.True(t, ok, "gateway connection must survive snapshot/restore")
+	assert.Equal(t, "IPsec", conn.ConnectionType)
+	assert.Equal(t, "psk-secret", conn.SharedKey)
+	assert.Contains(t, conn.VirtualNetworkGateway1ID, "virtualNetworkGateways/vng1")
+	assert.Contains(t, conn.LocalNetworkGateway2ID, "localNetworkGateways/lng1")
 }
 
 // TestSnapshotEmpty confirms a fresh mock snapshots and restores without error.

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -85,6 +85,13 @@ type Mock struct {
 	// azurePrefixes holds the Azure-only public IP prefixes (a reserved CIDR range
 	// with no cross-cloud equivalent), keyed by (resourceGroup, name).
 	azurePrefixes *memstore.Store[driver.AzurePublicIPPrefix]
+	// azureVNGateways / azureLNGateways / azureGWConnections hold the Azure-only
+	// site-to-site VPN surface (virtual network gateways, local network gateways
+	// and connections), each keyed by (resourceGroup, name). None has a
+	// cross-cloud equivalent.
+	azureVNGateways    *memstore.Store[driver.AzureVirtualNetworkGateway]
+	azureLNGateways    *memstore.Store[driver.AzureLocalNetworkGateway]
+	azureGWConnections *memstore.Store[driver.AzureVirtualNetworkGatewayConnection]
 	// nicMu serializes network-interface create/update, whose private-IP
 	// allocation is a read-modify-write across the nics store (memstore is
 	// per-op safe but can't make that sequence atomic).
@@ -123,6 +130,9 @@ func New(opts *config.Options) *Mock {
 		azureVNetPeerings:   memstore.New[[]driver.AzureVNetPeering](),
 		azureASGs:           memstore.New[driver.AzureApplicationSecurityGroup](),
 		azurePrefixes:       memstore.New[driver.AzurePublicIPPrefix](),
+		azureVNGateways:     memstore.New[driver.AzureVirtualNetworkGateway](),
+		azureLNGateways:     memstore.New[driver.AzureLocalNetworkGateway](),
+		azureGWConnections:  memstore.New[driver.AzureVirtualNetworkGatewayConnection](),
 		opts:                opts,
 	}
 }

--- a/server/azure/vnet/application_security_group.go
+++ b/server/azure/vnet/application_security_group.go
@@ -135,7 +135,7 @@ func (*Handler) deleteASG(w http.ResponseWriter, r *http.Request, rp azurearm.Re
 	w.WriteHeader(http.StatusOK)
 }
 
-//nolint:gocritic // rp is a request-scoped value
+//nolint:gocritic,dupl // rp is request-scoped; mirrors the network-gateway list handlers over a distinct resource type
 func (*Handler) listASGs(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
 	svc netdriver.AzureApplicationSecurityGroups,
 ) {

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -107,7 +107,8 @@ func (*Handler) Matches(r *http.Request) bool {
 	}
 
 	switch rp.ResourceType {
-	case typeVNet, typeNSG, typeRouteTable, typePublicIP, typePublicIPPrefix, typeNIC, typeNATGateway, typeASG, typeLocations:
+	case typeVNet, typeNSG, typeRouteTable, typePublicIP, typePublicIPPrefix, typeNIC, typeNATGateway, typeASG,
+		typeVNGateway, typeLNGateway, typeConnection, typeLocations:
 		return true
 	}
 
@@ -153,9 +154,34 @@ func (h *Handler) routeByResourceType(w http.ResponseWriter, r *http.Request, rp
 	case typeASG:
 		h.routeASG(w, r, rp)
 	default:
+		if h.routeGatewayResourceType(w, r, rp) {
+			return
+		}
+
 		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
 			"unsupported resource type: "+rp.ResourceType)
 	}
+}
+
+// routeGatewayResourceType dispatches the site-to-site VPN resource types
+// (virtualNetworkGateways, localNetworkGateways, connections). Split out of
+// routeByResourceType so its dispatch switch stays under the cyclomatic-complexity
+// gate. It returns true when it handled the request.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) routeGatewayResourceType(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) bool {
+	switch rp.ResourceType {
+	case typeVNGateway:
+		h.routeVNGateway(w, r, rp)
+	case typeLNGateway:
+		h.routeLNGateway(w, r, rp)
+	case typeConnection:
+		h.routeConnection(w, r, rp)
+	default:
+		return false
+	}
+
+	return true
 }
 
 // serveLocationsOperationStatus answers the locations/operationStatuses poll
@@ -641,6 +667,7 @@ func (h *Handler) PurgeResourceGroup(ctx context.Context, _, resourceGroup strin
 	recordErr(h.purgeRouteTables(ctx, resourceGroup))
 	h.purgeASGs(ctx, resourceGroup)
 	h.purgePublicIPPrefixes(ctx, resourceGroup)
+	h.purgeNetworkGateways(ctx, resourceGroup)
 
 	return firstErr
 }

--- a/server/azure/vnet/network_gateway.go
+++ b/server/azure/vnet/network_gateway.go
@@ -1,0 +1,741 @@
+package vnet
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// Microsoft.Network site-to-site VPN resource types.
+const (
+	typeVNGateway  = "virtualNetworkGateways"
+	typeLNGateway  = "localNetworkGateways"
+	typeConnection = "connections"
+
+	connectionStatusConnected = "Connected"
+)
+
+// ARM JSON shapes.
+
+type gatewaySKU struct {
+	Name string `json:"name,omitempty"`
+	Tier string `json:"tier,omitempty"`
+}
+
+type bgpSettings struct {
+	ASN               int64  `json:"asn,omitempty"`
+	BgpPeeringAddress string `json:"bgpPeeringAddress,omitempty"`
+	PeerWeight        int32  `json:"peerWeight,omitempty"`
+}
+
+// virtualNetworkGateways.
+
+type vngIPConfig struct {
+	Name       string           `json:"name,omitempty"`
+	Properties vngIPConfigProps `json:"properties"`
+}
+
+type vngIPConfigProps struct {
+	PrivateIPAllocationMethod string    `json:"privateIPAllocationMethod,omitempty"`
+	PublicIPAddress           *armIDRef `json:"publicIPAddress,omitempty"`
+	Subnet                    *armIDRef `json:"subnet,omitempty"`
+}
+
+type vngRequest struct {
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Properties vngRequestProps   `json:"properties"`
+}
+
+type vngRequestProps struct {
+	GatewayType          string        `json:"gatewayType,omitempty"`
+	VPNType              string        `json:"vpnType,omitempty"`
+	VPNGatewayGeneration string        `json:"vpnGatewayGeneration,omitempty"`
+	SKU                  *gatewaySKU   `json:"sku,omitempty"`
+	EnableBGP            *bool         `json:"enableBgp,omitempty"`
+	ActiveActive         *bool         `json:"activeActive,omitempty"`
+	IPConfigurations     []vngIPConfig `json:"ipConfigurations,omitempty"`
+	BgpSettings          *bgpSettings  `json:"bgpSettings,omitempty"`
+}
+
+type vngResponse struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Etag       string            `json:"etag,omitempty"`
+	Properties vngResponseProps  `json:"properties"`
+}
+
+type vngResponseProps struct {
+	ProvisioningState string        `json:"provisioningState"`
+	GatewayType       string        `json:"gatewayType,omitempty"`
+	VPNType           string        `json:"vpnType,omitempty"`
+	VPNGeneration     string        `json:"vpnGatewayGeneration,omitempty"`
+	SKU               *gatewaySKU   `json:"sku,omitempty"`
+	EnableBGP         bool          `json:"enableBgp"`
+	ActiveActive      bool          `json:"activeActive"`
+	IPConfigurations  []vngIPConfig `json:"ipConfigurations,omitempty"`
+	BgpSettings       *bgpSettings  `json:"bgpSettings,omitempty"`
+}
+
+type vngListResponse struct {
+	Value []vngResponse `json:"value"`
+}
+
+// localNetworkGateways.
+
+type lngRequest struct {
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Properties lngRequestProps   `json:"properties"`
+}
+
+type lngRequestProps struct {
+	GatewayIPAddress         string        `json:"gatewayIpAddress,omitempty"`
+	Fqdn                     string        `json:"fqdn,omitempty"`
+	LocalNetworkAddressSpace *addressSpace `json:"localNetworkAddressSpace,omitempty"`
+	BgpSettings              *bgpSettings  `json:"bgpSettings,omitempty"`
+}
+
+type lngResponse struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Etag       string            `json:"etag,omitempty"`
+	Properties lngResponseProps  `json:"properties"`
+}
+
+type lngResponseProps struct {
+	ProvisioningState        string        `json:"provisioningState"`
+	GatewayIPAddress         string        `json:"gatewayIpAddress,omitempty"`
+	Fqdn                     string        `json:"fqdn,omitempty"`
+	LocalNetworkAddressSpace *addressSpace `json:"localNetworkAddressSpace,omitempty"`
+	BgpSettings              *bgpSettings  `json:"bgpSettings,omitempty"`
+}
+
+type lngListResponse struct {
+	Value []lngResponse `json:"value"`
+}
+
+// connections (Microsoft.Network/connections).
+
+type connRequest struct {
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Properties connRequestProps  `json:"properties"`
+}
+
+type connRequestProps struct {
+	ConnectionType         string    `json:"connectionType,omitempty"`
+	ConnectionProtocol     string    `json:"connectionProtocol,omitempty"`
+	VirtualNetworkGateway1 *armIDRef `json:"virtualNetworkGateway1,omitempty"`
+	VirtualNetworkGateway2 *armIDRef `json:"virtualNetworkGateway2,omitempty"`
+	LocalNetworkGateway2   *armIDRef `json:"localNetworkGateway2,omitempty"`
+	SharedKey              string    `json:"sharedKey,omitempty"`
+	RoutingWeight          int32     `json:"routingWeight,omitempty"`
+	EnableBGP              *bool     `json:"enableBgp,omitempty"`
+}
+
+type connResponse struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Etag       string            `json:"etag,omitempty"`
+	Properties connResponseProps `json:"properties"`
+}
+
+type connResponseProps struct {
+	ProvisioningState      string    `json:"provisioningState"`
+	ConnectionStatus       string    `json:"connectionStatus,omitempty"`
+	ConnectionType         string    `json:"connectionType,omitempty"`
+	ConnectionProtocol     string    `json:"connectionProtocol,omitempty"`
+	VirtualNetworkGateway1 *armIDRef `json:"virtualNetworkGateway1,omitempty"`
+	VirtualNetworkGateway2 *armIDRef `json:"virtualNetworkGateway2,omitempty"`
+	LocalNetworkGateway2   *armIDRef `json:"localNetworkGateway2,omitempty"`
+	SharedKey              string    `json:"sharedKey,omitempty"`
+	RoutingWeight          int32     `json:"routingWeight,omitempty"`
+	EnableBGP              bool      `json:"enableBgp"`
+}
+
+type connListResponse struct {
+	Value []connResponse `json:"value"`
+}
+
+// gatewayCap returns the site-to-site VPN surface if the networking driver
+// implements it (the Azure provider does; AWS/GCP do not).
+func (h *Handler) gatewayCap() (netdriver.AzureNetworkGateways, bool) {
+	svc, ok := h.net.(netdriver.AzureNetworkGateways)
+
+	return svc, ok
+}
+
+// routeVNGateway dispatches Microsoft.Network/virtualNetworkGateways requests.
+//
+//nolint:gocritic,dupl // rp is request-scoped; capability-gated dispatch mirrored by routeLNGateway over a distinct type
+func (h *Handler) routeVNGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	svc, ok := h.gatewayCap()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"network gateways are not supported by this networking driver")
+
+		return
+	}
+
+	if rp.ResourceName == "" {
+		h.listVNGateways(w, r, rp, svc)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createVNGateway(w, r, rp, svc)
+	case http.MethodGet:
+		h.getVNGateway(w, r, rp, svc)
+	case http.MethodDelete:
+		h.deleteVNGateway(w, r, rp, svc)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) createVNGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkGateways,
+) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	var req vngRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	loc := req.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	stored := svc.PutAzureVirtualNetworkGateway(r.Context(), vngRecord(rp, loc, &req))
+
+	// Create is a long LRO in real Azure; a sync 200 with a terminal
+	// provisioningState completes the armnetwork poller immediately (the same
+	// convention the vnet/NAT-gateway creates use), so the SDK never hangs.
+	writeAcceptedAsync(w, r, rp.Subscription, "vng-create-"+rp.ResourceName, vngResponseFrom(stored, rp))
+}
+
+// vngRecord maps a decoded PUT body to the driver record.
+//
+//nolint:gocritic // rp is a request-scoped value
+func vngRecord(rp azurearm.ResourcePath, loc string, req *vngRequest) netdriver.AzureVirtualNetworkGateway {
+	rec := netdriver.AzureVirtualNetworkGateway{
+		Name:             rp.ResourceName,
+		ResourceGroup:    rp.ResourceGroup,
+		Location:         loc,
+		Tags:             req.Tags,
+		GatewayType:      req.Properties.GatewayType,
+		VPNType:          req.Properties.VPNType,
+		VPNGeneration:    req.Properties.VPNGatewayGeneration,
+		EnableBGP:        derefBool(req.Properties.EnableBGP),
+		ActiveActive:     derefBool(req.Properties.ActiveActive),
+		IPConfigurations: toRecordIPConfigs(req.Properties.IPConfigurations),
+		BgpSettings:      toRecordBgp(req.Properties.BgpSettings),
+	}
+
+	if req.Properties.SKU != nil {
+		rec.SKUName = req.Properties.SKU.Name
+		rec.SKUTier = req.Properties.SKU.Tier
+	}
+
+	return rec
+}
+
+func toRecordIPConfigs(in []vngIPConfig) []netdriver.AzureGatewayIPConfiguration {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]netdriver.AzureGatewayIPConfiguration, 0, len(in))
+
+	for i := range in {
+		cfg := netdriver.AzureGatewayIPConfiguration{
+			Name:                      in[i].Name,
+			PrivateIPAllocationMethod: in[i].Properties.PrivateIPAllocationMethod,
+		}
+
+		if in[i].Properties.Subnet != nil {
+			cfg.SubnetID = in[i].Properties.Subnet.ID
+		}
+
+		if in[i].Properties.PublicIPAddress != nil {
+			cfg.PublicIPAddressID = in[i].Properties.PublicIPAddress.ID
+		}
+
+		out = append(out, cfg)
+	}
+
+	return out
+}
+
+func toRecordBgp(in *bgpSettings) *netdriver.AzureGatewayBgpSettings {
+	if in == nil {
+		return nil
+	}
+
+	return &netdriver.AzureGatewayBgpSettings{
+		ASN:               in.ASN,
+		BgpPeeringAddress: in.BgpPeeringAddress,
+		PeerWeight:        in.PeerWeight,
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) getVNGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkGateways,
+) {
+	gw, ok := svc.GetAzureVirtualNetworkGateway(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"virtual network gateway "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, vngResponseFrom(gw, rp))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) deleteVNGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkGateways,
+) {
+	svc.DeleteAzureVirtualNetworkGateway(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	writeAcceptedAsync(w, r, rp.Subscription, "vng-delete-"+rp.ResourceName, nil)
+}
+
+//nolint:gocritic,dupl // rp is request-scoped; mirrors listLNGateways/listConnections over a distinct resource type
+func (*Handler) listVNGateways(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkGateways,
+) {
+	gws := svc.ListAzureVirtualNetworkGateways(r.Context(), rp.ResourceGroup)
+
+	out := vngListResponse{Value: make([]vngResponse, 0, len(gws))}
+
+	for i := range gws {
+		scope := rp
+		scope.ResourceGroup = gws[i].ResourceGroup
+		scope.ResourceName = gws[i].Name
+		out.Value = append(out.Value, vngResponseFrom(gws[i], scope))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func vngResponseFrom(gw netdriver.AzureVirtualNetworkGateway, rp azurearm.ResourcePath) vngResponse {
+	loc := gw.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeVNGateway, rp.ResourceName)
+
+	props := vngResponseProps{
+		ProvisioningState: provisioningSucceeded,
+		GatewayType:       gw.GatewayType,
+		VPNType:           gw.VPNType,
+		VPNGeneration:     gw.VPNGeneration,
+		EnableBGP:         gw.EnableBGP,
+		ActiveActive:      gw.ActiveActive,
+		IPConfigurations:  fromRecordIPConfigs(gw.IPConfigurations),
+		BgpSettings:       fromRecordBgp(gw.BgpSettings),
+	}
+
+	if gw.SKUName != "" || gw.SKUTier != "" {
+		props.SKU = &gatewaySKU{Name: gw.SKUName, Tier: gw.SKUTier}
+	}
+
+	return vngResponse{
+		ID:         id,
+		Name:       rp.ResourceName,
+		Type:       providerName + "/" + typeVNGateway,
+		Location:   loc,
+		Tags:       gw.Tags,
+		Etag:       etagOf(id),
+		Properties: props,
+	}
+}
+
+func fromRecordIPConfigs(in []netdriver.AzureGatewayIPConfiguration) []vngIPConfig {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]vngIPConfig, 0, len(in))
+
+	for i := range in {
+		props := vngIPConfigProps{PrivateIPAllocationMethod: in[i].PrivateIPAllocationMethod}
+
+		if in[i].SubnetID != "" {
+			props.Subnet = &armIDRef{ID: in[i].SubnetID}
+		}
+
+		if in[i].PublicIPAddressID != "" {
+			props.PublicIPAddress = &armIDRef{ID: in[i].PublicIPAddressID}
+		}
+
+		out = append(out, vngIPConfig{Name: in[i].Name, Properties: props})
+	}
+
+	return out
+}
+
+func fromRecordBgp(in *netdriver.AzureGatewayBgpSettings) *bgpSettings {
+	if in == nil {
+		return nil
+	}
+
+	return &bgpSettings{
+		ASN:               in.ASN,
+		BgpPeeringAddress: in.BgpPeeringAddress,
+		PeerWeight:        in.PeerWeight,
+	}
+}
+
+// routeLNGateway dispatches Microsoft.Network/localNetworkGateways requests.
+//
+//nolint:gocritic,dupl // rp is request-scoped; capability-gated dispatch mirrored by routeVNGateway over a distinct type
+func (h *Handler) routeLNGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	svc, ok := h.gatewayCap()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"network gateways are not supported by this networking driver")
+
+		return
+	}
+
+	if rp.ResourceName == "" {
+		h.listLNGateways(w, r, rp, svc)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createLNGateway(w, r, rp, svc)
+	case http.MethodGet:
+		h.getLNGateway(w, r, rp, svc)
+	case http.MethodDelete:
+		h.deleteLNGateway(w, r, rp, svc)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) createLNGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkGateways,
+) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	var req lngRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	loc := req.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	rec := netdriver.AzureLocalNetworkGateway{
+		Name:             rp.ResourceName,
+		ResourceGroup:    rp.ResourceGroup,
+		Location:         loc,
+		Tags:             req.Tags,
+		GatewayIPAddress: req.Properties.GatewayIPAddress,
+		FQDN:             req.Properties.Fqdn,
+		BgpSettings:      toRecordBgp(req.Properties.BgpSettings),
+	}
+
+	if req.Properties.LocalNetworkAddressSpace != nil {
+		rec.AddressPrefixes = req.Properties.LocalNetworkAddressSpace.AddressPrefixes
+	}
+
+	stored := svc.PutAzureLocalNetworkGateway(r.Context(), rec)
+
+	writeAcceptedAsync(w, r, rp.Subscription, "lng-create-"+rp.ResourceName, lngResponseFrom(stored, rp))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) getLNGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkGateways,
+) {
+	gw, ok := svc.GetAzureLocalNetworkGateway(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"local network gateway "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, lngResponseFrom(gw, rp))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) deleteLNGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkGateways,
+) {
+	svc.DeleteAzureLocalNetworkGateway(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	writeAcceptedAsync(w, r, rp.Subscription, "lng-delete-"+rp.ResourceName, nil)
+}
+
+//nolint:gocritic,dupl // rp is request-scoped; mirrors listVNGateways/listConnections over a distinct resource type
+func (*Handler) listLNGateways(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkGateways,
+) {
+	gws := svc.ListAzureLocalNetworkGateways(r.Context(), rp.ResourceGroup)
+
+	out := lngListResponse{Value: make([]lngResponse, 0, len(gws))}
+
+	for i := range gws {
+		scope := rp
+		scope.ResourceGroup = gws[i].ResourceGroup
+		scope.ResourceName = gws[i].Name
+		out.Value = append(out.Value, lngResponseFrom(gws[i], scope))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func lngResponseFrom(gw netdriver.AzureLocalNetworkGateway, rp azurearm.ResourcePath) lngResponse {
+	loc := gw.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeLNGateway, rp.ResourceName)
+
+	props := lngResponseProps{
+		ProvisioningState: provisioningSucceeded,
+		GatewayIPAddress:  gw.GatewayIPAddress,
+		Fqdn:              gw.FQDN,
+		BgpSettings:       fromRecordBgp(gw.BgpSettings),
+	}
+
+	if len(gw.AddressPrefixes) > 0 {
+		props.LocalNetworkAddressSpace = &addressSpace{AddressPrefixes: gw.AddressPrefixes}
+	}
+
+	return lngResponse{
+		ID:         id,
+		Name:       rp.ResourceName,
+		Type:       providerName + "/" + typeLNGateway,
+		Location:   loc,
+		Tags:       gw.Tags,
+		Etag:       etagOf(id),
+		Properties: props,
+	}
+}
+
+// routeConnection dispatches Microsoft.Network/connections requests.
+//
+//nolint:gocritic,dupl // rp is request-scoped; capability-gated dispatch mirrored by routeVNGateway over a distinct type
+func (h *Handler) routeConnection(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	svc, ok := h.gatewayCap()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"network gateways are not supported by this networking driver")
+
+		return
+	}
+
+	if rp.ResourceName == "" {
+		h.listConnections(w, r, rp, svc)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createConnection(w, r, rp, svc)
+	case http.MethodGet:
+		h.getConnection(w, r, rp, svc)
+	case http.MethodDelete:
+		h.deleteConnection(w, r, rp, svc)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) createConnection(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkGateways,
+) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	var req connRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	loc := req.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	rec := netdriver.AzureVirtualNetworkGatewayConnection{
+		Name:                     rp.ResourceName,
+		ResourceGroup:            rp.ResourceGroup,
+		Location:                 loc,
+		Tags:                     req.Tags,
+		ConnectionType:           req.Properties.ConnectionType,
+		ConnectionProtocol:       req.Properties.ConnectionProtocol,
+		VirtualNetworkGateway1ID: refID(req.Properties.VirtualNetworkGateway1),
+		VirtualNetworkGateway2ID: refID(req.Properties.VirtualNetworkGateway2),
+		LocalNetworkGateway2ID:   refID(req.Properties.LocalNetworkGateway2),
+		SharedKey:                req.Properties.SharedKey,
+		RoutingWeight:            req.Properties.RoutingWeight,
+		EnableBGP:                derefBool(req.Properties.EnableBGP),
+	}
+
+	stored := svc.PutAzureVirtualNetworkGatewayConnection(r.Context(), rec)
+
+	writeAcceptedAsync(w, r, rp.Subscription, "conn-create-"+rp.ResourceName, connResponseFrom(stored, rp))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) getConnection(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkGateways,
+) {
+	conn, ok := svc.GetAzureVirtualNetworkGatewayConnection(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"connection "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, connResponseFrom(conn, rp))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) deleteConnection(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkGateways,
+) {
+	svc.DeleteAzureVirtualNetworkGatewayConnection(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	writeAcceptedAsync(w, r, rp.Subscription, "conn-delete-"+rp.ResourceName, nil)
+}
+
+//nolint:gocritic,dupl // rp is request-scoped; mirrors listVNGateways/listLNGateways over a distinct resource type
+func (*Handler) listConnections(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkGateways,
+) {
+	conns := svc.ListAzureVirtualNetworkGatewayConnections(r.Context(), rp.ResourceGroup)
+
+	out := connListResponse{Value: make([]connResponse, 0, len(conns))}
+
+	for i := range conns {
+		scope := rp
+		scope.ResourceGroup = conns[i].ResourceGroup
+		scope.ResourceName = conns[i].Name
+		out.Value = append(out.Value, connResponseFrom(conns[i], scope))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func connResponseFrom(conn netdriver.AzureVirtualNetworkGatewayConnection, rp azurearm.ResourcePath) connResponse {
+	loc := conn.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeConnection, rp.ResourceName)
+
+	return connResponse{
+		ID:       id,
+		Name:     rp.ResourceName,
+		Type:     providerName + "/" + typeConnection,
+		Location: loc,
+		Tags:     conn.Tags,
+		Etag:     etagOf(id),
+		Properties: connResponseProps{
+			ProvisioningState:      provisioningSucceeded,
+			ConnectionStatus:       connectionStatusConnected,
+			ConnectionType:         conn.ConnectionType,
+			ConnectionProtocol:     conn.ConnectionProtocol,
+			VirtualNetworkGateway1: refOf(conn.VirtualNetworkGateway1ID),
+			VirtualNetworkGateway2: refOf(conn.VirtualNetworkGateway2ID),
+			LocalNetworkGateway2:   refOf(conn.LocalNetworkGateway2ID),
+			SharedKey:              conn.SharedKey,
+			RoutingWeight:          conn.RoutingWeight,
+			EnableBGP:              conn.EnableBGP,
+		},
+	}
+}
+
+// refID returns an armIDRef's id, or "" when the reference is nil.
+func refID(ref *armIDRef) string {
+	if ref == nil {
+		return ""
+	}
+
+	return ref.ID
+}
+
+// refOf wraps a non-empty id back into an armIDRef, or nil when the id is empty.
+func refOf(id string) *armIDRef {
+	if id == "" {
+		return nil
+	}
+
+	return &armIDRef{ID: id}
+}
+
+// derefBool returns the pointed-to bool, or false when the pointer is nil.
+func derefBool(b *bool) bool {
+	return b != nil && *b
+}
+
+// purgeNetworkGateways deletes every connection, then every virtual and local
+// network gateway in the resource group, part of the PurgeResourceGroup cascade.
+// Connections are removed first as they reference the gateways.
+func (h *Handler) purgeNetworkGateways(ctx context.Context, resourceGroup string) {
+	svc, ok := h.gatewayCap()
+	if !ok {
+		return
+	}
+
+	conns := svc.ListAzureVirtualNetworkGatewayConnections(ctx, resourceGroup)
+	for i := range conns {
+		svc.DeleteAzureVirtualNetworkGatewayConnection(ctx, conns[i].ResourceGroup, conns[i].Name)
+	}
+
+	vngs := svc.ListAzureVirtualNetworkGateways(ctx, resourceGroup)
+	for i := range vngs {
+		svc.DeleteAzureVirtualNetworkGateway(ctx, vngs[i].ResourceGroup, vngs[i].Name)
+	}
+
+	lngs := svc.ListAzureLocalNetworkGateways(ctx, resourceGroup)
+	for i := range lngs {
+		svc.DeleteAzureLocalNetworkGateway(ctx, lngs[i].ResourceGroup, lngs[i].Name)
+	}
+}

--- a/server/azure/vnet/network_gateway_test.go
+++ b/server/azure/vnet/network_gateway_test.go
@@ -1,0 +1,375 @@
+package vnet_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// TestSDKNetworkGatewaysRoundTrip drives the real armnetwork gateway clients
+// through their Begin* pollers end-to-end: it stands up the prerequisites (a
+// public IP + a GatewaySubnet), then creates a virtual network gateway, a local
+// network gateway and an IPsec connection referencing both, and asserts get/list
+// round-trip them and delete makes a subsequent get 404. Every op used to fall
+// through to the vnet 501 default. The key regression it guards is the create
+// LRO: the pollers must complete rather than hang.
+func TestSDKNetworkGatewaysRoundTrip(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	const rg = "rg-gw"
+
+	subnetID := seedGatewayPrerequisites(t, ctx, opts, rg)
+
+	vngClient, err := armnetwork.NewVirtualNetworkGatewaysClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pipID := "/subscriptions/sub-1/resourceGroups/" + rg + "/providers/Microsoft.Network/publicIPAddresses/gw-pip"
+
+	vngCreate, err := vngClient.BeginCreateOrUpdate(ctx, rg, "vng-1", armnetwork.VirtualNetworkGateway{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkGatewayPropertiesFormat{
+			GatewayType: to.Ptr(armnetwork.VirtualNetworkGatewayTypeVPN),
+			VPNType:     to.Ptr(armnetwork.VPNTypeRouteBased),
+			SKU: &armnetwork.VirtualNetworkGatewaySKU{
+				Name: to.Ptr(armnetwork.VirtualNetworkGatewaySKUNameVPNGw1),
+				Tier: to.Ptr(armnetwork.VirtualNetworkGatewaySKUTierVPNGw1),
+			},
+			EnableBgp: to.Ptr(false),
+			IPConfigurations: []*armnetwork.VirtualNetworkGatewayIPConfiguration{
+				{
+					Name: to.Ptr("gwipconfig"),
+					Properties: &armnetwork.VirtualNetworkGatewayIPConfigurationPropertiesFormat{
+						PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+						Subnet:                    &armnetwork.SubResource{ID: to.Ptr(subnetID)},
+						PublicIPAddress:           &armnetwork.SubResource{ID: to.Ptr(pipID)},
+					},
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("vng BeginCreateOrUpdate: %v", err)
+	}
+
+	vng := pollDone(t, vngCreate)
+
+	if vng.Name == nil || *vng.Name != "vng-1" {
+		t.Fatalf("vng name=%v want vng-1", vng.Name)
+	}
+
+	if vng.Properties == nil || vng.Properties.GatewayType == nil ||
+		*vng.Properties.GatewayType != armnetwork.VirtualNetworkGatewayTypeVPN {
+		t.Errorf("vng gatewayType=%v want Vpn", vng.Properties)
+	}
+
+	if vng.Properties.ProvisioningState == nil ||
+		*vng.Properties.ProvisioningState != armnetwork.ProvisioningStateSucceeded {
+		t.Errorf("vng provisioningState=%v want Succeeded", vng.Properties.ProvisioningState)
+	}
+
+	if len(vng.Properties.IPConfigurations) != 1 ||
+		vng.Properties.IPConfigurations[0].Properties.Subnet == nil ||
+		*vng.Properties.IPConfigurations[0].Properties.Subnet.ID != subnetID {
+		t.Errorf("vng ipConfigurations=%+v want subnet %s", vng.Properties.IPConfigurations, subnetID)
+	}
+
+	vngID := *vng.ID
+
+	// Local network gateway (the on-prem side).
+	lngClient, err := armnetwork.NewLocalNetworkGatewaysClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lngCreate, err := lngClient.BeginCreateOrUpdate(ctx, rg, "lng-1", armnetwork.LocalNetworkGateway{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.LocalNetworkGatewayPropertiesFormat{
+			GatewayIPAddress:         to.Ptr("203.0.113.10"),
+			LocalNetworkAddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("192.168.0.0/16")}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("lng BeginCreateOrUpdate: %v", err)
+	}
+
+	lng := pollDone(t, lngCreate)
+
+	if lng.Properties == nil || lng.Properties.GatewayIPAddress == nil ||
+		*lng.Properties.GatewayIPAddress != "203.0.113.10" {
+		t.Errorf("lng gatewayIpAddress=%v want 203.0.113.10", lng.Properties)
+	}
+
+	if len(lng.Properties.LocalNetworkAddressSpace.AddressPrefixes) != 1 ||
+		*lng.Properties.LocalNetworkAddressSpace.AddressPrefixes[0] != "192.168.0.0/16" {
+		t.Errorf("lng addressPrefixes=%+v want [192.168.0.0/16]", lng.Properties.LocalNetworkAddressSpace)
+	}
+
+	lngID := *lng.ID
+
+	// Connection joining the two gateways.
+	connClient, err := armnetwork.NewVirtualNetworkGatewayConnectionsClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	connCreate, err := connClient.BeginCreateOrUpdate(ctx, rg, "conn-1", armnetwork.VirtualNetworkGatewayConnection{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkGatewayConnectionPropertiesFormat{
+			ConnectionType:         to.Ptr(armnetwork.VirtualNetworkGatewayConnectionTypeIPsec),
+			VirtualNetworkGateway1: &armnetwork.VirtualNetworkGateway{ID: to.Ptr(vngID)},
+			LocalNetworkGateway2:   &armnetwork.LocalNetworkGateway{ID: to.Ptr(lngID)},
+			SharedKey:              to.Ptr("s3cr3t-psk"),
+			RoutingWeight:          to.Ptr(int32(10)),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("conn BeginCreateOrUpdate: %v", err)
+	}
+
+	conn := pollDone(t, connCreate)
+
+	if conn.Properties == nil || conn.Properties.ConnectionType == nil ||
+		*conn.Properties.ConnectionType != armnetwork.VirtualNetworkGatewayConnectionTypeIPsec {
+		t.Errorf("conn connectionType=%v want IPsec", conn.Properties)
+	}
+
+	if conn.Properties.VirtualNetworkGateway1 == nil || conn.Properties.VirtualNetworkGateway1.ID == nil ||
+		*conn.Properties.VirtualNetworkGateway1.ID != vngID {
+		t.Errorf("conn virtualNetworkGateway1=%v want %s", conn.Properties.VirtualNetworkGateway1, vngID)
+	}
+
+	if conn.Properties.LocalNetworkGateway2 == nil || conn.Properties.LocalNetworkGateway2.ID == nil ||
+		*conn.Properties.LocalNetworkGateway2.ID != lngID {
+		t.Errorf("conn localNetworkGateway2=%v want %s", conn.Properties.LocalNetworkGateway2, lngID)
+	}
+
+	assertGatewayGetList(t, ctx, vngClient, lngClient, connClient, rg)
+	assertGatewayDelete(t, ctx, vngClient, lngClient, connClient, rg)
+}
+
+// seedGatewayPrerequisites creates the public IP and the GatewaySubnet a virtual
+// network gateway's ipConfiguration references, returning the subnet id.
+func seedGatewayPrerequisites(t *testing.T, ctx context.Context, opts *arm.ClientOptions, rg string) string {
+	t.Helper()
+
+	pips, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pipCreate, err := pips.BeginCreateOrUpdate(ctx, rg, "gw-pip", armnetwork.PublicIPAddress{
+		Location: to.Ptr("eastus"),
+		SKU:      &armnetwork.PublicIPAddressSKU{Name: to.Ptr(armnetwork.PublicIPAddressSKUNameStandard)},
+		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create public IP: %v", err)
+	}
+
+	pollDone(t, pipCreate)
+
+	vnets, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vnetCreate, err := vnets.BeginCreateOrUpdate(ctx, rg, "vnet-gw", armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.10.0.0/16")}},
+			Subnets: []*armnetwork.Subnet{
+				{
+					Name:       to.Ptr("GatewaySubnet"),
+					Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.10.255.0/27")},
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create vnet: %v", err)
+	}
+
+	pollDone(t, vnetCreate)
+
+	return "/subscriptions/sub-1/resourceGroups/" + rg +
+		"/providers/Microsoft.Network/virtualNetworks/vnet-gw/subnets/GatewaySubnet"
+}
+
+// assertGatewayGetList checks Get and the list pagers return each resource.
+func assertGatewayGetList(
+	t *testing.T, ctx context.Context,
+	vng *armnetwork.VirtualNetworkGatewaysClient,
+	lng *armnetwork.LocalNetworkGatewaysClient,
+	conn *armnetwork.VirtualNetworkGatewayConnectionsClient,
+	rg string,
+) {
+	t.Helper()
+
+	if _, err := vng.Get(ctx, rg, "vng-1", nil); err != nil {
+		t.Errorf("vng Get: %v", err)
+	}
+
+	if _, err := lng.Get(ctx, rg, "lng-1", nil); err != nil {
+		t.Errorf("lng Get: %v", err)
+	}
+
+	if _, err := conn.Get(ctx, rg, "conn-1", nil); err != nil {
+		t.Errorf("conn Get: %v", err)
+	}
+
+	if got := listVNGNames(t, ctx, vng, rg); len(got) != 1 || got[0] != "vng-1" {
+		t.Errorf("vng list=%v want [vng-1]", got)
+	}
+
+	lngPager := lng.NewListPager(rg, nil)
+	if got := drainNames(t, ctx, lngPager.More, func() ([]*string, error) {
+		p, err := lngPager.NextPage(ctx)
+		return lngNames(p.Value), err
+	}); len(got) != 1 || *got[0] != "lng-1" {
+		t.Errorf("lng list=%v want [lng-1]", derefAll(got))
+	}
+
+	connPager := conn.NewListPager(rg, nil)
+	if got := drainNames(t, ctx, connPager.More, func() ([]*string, error) {
+		p, err := connPager.NextPage(ctx)
+		return connNames(p.Value), err
+	}); len(got) != 1 || *got[0] != "conn-1" {
+		t.Errorf("conn list=%v want [conn-1]", derefAll(got))
+	}
+}
+
+// assertGatewayDelete deletes all three resources and confirms a follow-up Get 404s.
+func assertGatewayDelete(
+	t *testing.T, ctx context.Context,
+	vng *armnetwork.VirtualNetworkGatewaysClient,
+	lng *armnetwork.LocalNetworkGatewaysClient,
+	conn *armnetwork.VirtualNetworkGatewayConnectionsClient,
+	rg string,
+) {
+	t.Helper()
+
+	connDelete, err := conn.BeginDelete(ctx, rg, "conn-1", nil)
+	if err != nil {
+		t.Fatalf("conn BeginDelete: %v", err)
+	}
+
+	pollDone(t, connDelete)
+
+	vngDelete, err := vng.BeginDelete(ctx, rg, "vng-1", nil)
+	if err != nil {
+		t.Fatalf("vng BeginDelete: %v", err)
+	}
+
+	pollDone(t, vngDelete)
+
+	lngDelete, err := lng.BeginDelete(ctx, rg, "lng-1", nil)
+	if err != nil {
+		t.Fatalf("lng BeginDelete: %v", err)
+	}
+
+	pollDone(t, lngDelete)
+
+	_, err = vng.Get(ctx, rg, "vng-1", nil)
+	assertNotFound(t, err, "vng Get after delete")
+
+	_, err = lng.Get(ctx, rg, "lng-1", nil)
+	assertNotFound(t, err, "lng Get after delete")
+
+	_, err = conn.Get(ctx, rg, "conn-1", nil)
+	assertNotFound(t, err, "conn Get after delete")
+}
+
+func listVNGNames(
+	t *testing.T, ctx context.Context, client *armnetwork.VirtualNetworkGatewaysClient, rg string,
+) []string {
+	t.Helper()
+
+	pager := client.NewListPager(rg, nil)
+
+	var names []string
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("vng list: %v", err)
+		}
+
+		for _, g := range page.Value {
+			if g.Name != nil {
+				names = append(names, *g.Name)
+			}
+		}
+	}
+
+	return names
+}
+
+func drainNames(t *testing.T, _ context.Context, more func() bool, next func() ([]*string, error)) []*string {
+	t.Helper()
+
+	var out []*string
+
+	for more() {
+		names, err := next()
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+
+		out = append(out, names...)
+	}
+
+	return out
+}
+
+func lngNames(in []*armnetwork.LocalNetworkGateway) []*string {
+	out := make([]*string, 0, len(in))
+	for _, g := range in {
+		out = append(out, g.Name)
+	}
+
+	return out
+}
+
+func connNames(in []*armnetwork.VirtualNetworkGatewayConnection) []*string {
+	out := make([]*string, 0, len(in))
+	for _, c := range in {
+		out = append(out, c.Name)
+	}
+
+	return out
+}
+
+func derefAll(in []*string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s != nil {
+			out = append(out, *s)
+		}
+	}
+
+	return out
+}
+
+func assertNotFound(t *testing.T, err error, what string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("%s: want error, got nil", what)
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Errorf("%s: want 404, got %v", what, err)
+	}
+}

--- a/services/networking/driver/azure_network_gateway.go
+++ b/services/networking/driver/azure_network_gateway.go
@@ -1,0 +1,117 @@
+package driver
+
+import "context"
+
+// Microsoft.Network's site-to-site VPN surface — virtualNetworkGateways,
+// localNetworkGateways and connections — has no equivalent in the cross-cloud
+// Networking model, so — like AzureApplicationSecurityGroups and
+// AzurePublicIPPrefixes — the Azure provider stores it through this OPTIONAL,
+// type-asserted capability. AWS and GCP do not implement it. All three resource
+// types are addressed by (resourceGroup, name) to match ARM; an empty
+// resourceGroup on a List means subscription-wide.
+
+// AzureGatewayBgpSettings is the BGP speaker configuration shared by virtual and
+// local network gateways.
+type AzureGatewayBgpSettings struct {
+	ASN               int64
+	BgpPeeringAddress string
+	PeerWeight        int32
+}
+
+// AzureGatewayIPConfiguration is one ipConfiguration of a virtual network
+// gateway, referencing a GatewaySubnet and (usually) a public IP.
+type AzureGatewayIPConfiguration struct {
+	Name                      string
+	SubnetID                  string
+	PublicIPAddressID         string
+	PrivateIPAllocationMethod string
+}
+
+// AzureVirtualNetworkGateway is one Microsoft.Network/virtualNetworkGateways
+// resource.
+type AzureVirtualNetworkGateway struct {
+	Name             string
+	ResourceGroup    string
+	Location         string
+	Tags             map[string]string
+	GatewayType      string
+	VPNType          string
+	VPNGeneration    string
+	SKUName          string
+	SKUTier          string
+	EnableBGP        bool
+	ActiveActive     bool
+	IPConfigurations []AzureGatewayIPConfiguration
+	BgpSettings      *AzureGatewayBgpSettings
+}
+
+// AzureLocalNetworkGateway is one Microsoft.Network/localNetworkGateways
+// resource — the on-premises end of a site-to-site tunnel.
+type AzureLocalNetworkGateway struct {
+	Name             string
+	ResourceGroup    string
+	Location         string
+	Tags             map[string]string
+	GatewayIPAddress string
+	FQDN             string
+	AddressPrefixes  []string
+	BgpSettings      *AzureGatewayBgpSettings
+}
+
+// AzureVirtualNetworkGatewayConnection is one Microsoft.Network/connections
+// resource, joining a virtual network gateway to either a local network gateway
+// (IPsec) or a second virtual network gateway (Vnet2Vnet).
+type AzureVirtualNetworkGatewayConnection struct {
+	Name                     string
+	ResourceGroup            string
+	Location                 string
+	Tags                     map[string]string
+	ConnectionType           string
+	ConnectionProtocol       string
+	VirtualNetworkGateway1ID string
+	VirtualNetworkGateway2ID string
+	LocalNetworkGateway2ID   string
+	SharedKey                string
+	RoutingWeight            int32
+	EnableBGP                bool
+}
+
+// AzureNetworkGateways is the Azure-only site-to-site VPN surface. Each resource
+// type is keyed by (resourceGroup, name) for idempotent createOrUpdate.
+type AzureNetworkGateways interface {
+	// PutAzureVirtualNetworkGateway creates or replaces a virtual network gateway
+	// in place (a repeat createOrUpdate PUT updates rather than duplicating),
+	// returning the stored value.
+	PutAzureVirtualNetworkGateway(ctx context.Context, gw AzureVirtualNetworkGateway) AzureVirtualNetworkGateway
+	// GetAzureVirtualNetworkGateway returns the gateway identified by (resourceGroup, name).
+	GetAzureVirtualNetworkGateway(ctx context.Context, resourceGroup, name string) (AzureVirtualNetworkGateway, bool)
+	// DeleteAzureVirtualNetworkGateway removes the gateway, reporting whether it existed.
+	DeleteAzureVirtualNetworkGateway(ctx context.Context, resourceGroup, name string) bool
+	// ListAzureVirtualNetworkGateways returns the gateways in a resource group, or
+	// all when resourceGroup is empty, ordered by key.
+	ListAzureVirtualNetworkGateways(ctx context.Context, resourceGroup string) []AzureVirtualNetworkGateway
+
+	// PutAzureLocalNetworkGateway creates or replaces a local network gateway in place.
+	PutAzureLocalNetworkGateway(ctx context.Context, gw AzureLocalNetworkGateway) AzureLocalNetworkGateway
+	// GetAzureLocalNetworkGateway returns the local gateway identified by (resourceGroup, name).
+	GetAzureLocalNetworkGateway(ctx context.Context, resourceGroup, name string) (AzureLocalNetworkGateway, bool)
+	// DeleteAzureLocalNetworkGateway removes the local gateway, reporting whether it existed.
+	DeleteAzureLocalNetworkGateway(ctx context.Context, resourceGroup, name string) bool
+	// ListAzureLocalNetworkGateways returns the local gateways in a resource group,
+	// or all when resourceGroup is empty, ordered by key.
+	ListAzureLocalNetworkGateways(ctx context.Context, resourceGroup string) []AzureLocalNetworkGateway
+
+	// PutAzureVirtualNetworkGatewayConnection creates or replaces a connection in place.
+	PutAzureVirtualNetworkGatewayConnection(
+		ctx context.Context, conn AzureVirtualNetworkGatewayConnection,
+	) AzureVirtualNetworkGatewayConnection
+	// GetAzureVirtualNetworkGatewayConnection returns the connection identified by (resourceGroup, name).
+	GetAzureVirtualNetworkGatewayConnection(
+		ctx context.Context, resourceGroup, name string,
+	) (AzureVirtualNetworkGatewayConnection, bool)
+	// DeleteAzureVirtualNetworkGatewayConnection removes the connection, reporting whether it existed.
+	DeleteAzureVirtualNetworkGatewayConnection(ctx context.Context, resourceGroup, name string) bool
+	// ListAzureVirtualNetworkGatewayConnections returns the connections in a resource
+	// group, or all when resourceGroup is empty, ordered by key.
+	ListAzureVirtualNetworkGatewayConnections(ctx context.Context, resourceGroup string) []AzureVirtualNetworkGatewayConnection
+}


### PR DESCRIPTION
## What

Implements the Azure **network gateways** sub-feature of #611 end-to-end on the `Microsoft.Network` wire surface — three previously-unimplemented ARM resource types that all fell through to the vnet handler's 501 default:

- **`virtualNetworkGateways`** — gatewayType (Vpn/ExpressRoute), vpnType, sku (name+tier), ipConfigurations (GatewaySubnet + public IP refs), bgpSettings, enableBgp/activeActive.
- **`localNetworkGateways`** — gatewayIpAddress, fqdn, localNetworkAddressSpace, bgpSettings.
- **`connections`** (`Microsoft.Network/connections`) — connectionType (IPsec/Vnet2Vnet), virtualNetworkGateway1, localNetworkGateway2 / virtualNetworkGateway2, sharedKey, routingWeight, connectionStatus.

Each type gets full CRUD + list-by-RG (and subscription-wide list), correct ARM resource ids, `provisioningState: Succeeded`, connection `connectionStatus: Connected`, and idempotent createOrUpdate PUT.

## Why

The Azure real-user deep-sweep (#611) flagged the site-to-site VPN surface as entirely missing; real `armnetwork` clients (`VirtualNetworkGatewaysClient`, `LocalNetworkGatewaysClient`, `VirtualNetworkGatewayConnectionsClient`) got a 501 and their Begin* pollers hung.

## Approach — extended the existing vnet package

Gateways slot into the existing `server/azure/vnet` handler, which already owns the `Microsoft.Network` namespace and is registered — no `server/azure/azure.go` change needed. The three types are registered in `Matches` and dispatched via a `routeGatewayResourceType` pre-dispatch helper (keeps `routeByResourceType` under the cyclomatic gate), and are cascaded on RG delete via `purgeNetworkGateways` (connections first, then gateways).

They have no cross-cloud model, so — like Application Security Groups and Public IP Prefixes — state lives behind an OPTIONAL, type-asserted `AzureNetworkGateways` driver capability implemented only by the Azure provider (three new identity-preserving memstores, wired into Snapshot/Restore).

## LRO handling / poller-hang avoidance

Gateway create is a long LRO in real Azure. Following the established vnet/NAT-gateway convention, create answers a synchronous 200 whose body carries a terminal `provisioningState: Succeeded`, which completes the armnetwork poller immediately; delete answers 202 + `Azure-AsyncOperation` pointing at the `locations/operationStatuses` path the vnet handler already serves as `Succeeded`. No hang.

## Tests

New real-SDK e2e (`network_gateway_test.go`) drives the actual `armnetwork` clients against an in-process cloudemu server: seeds a public IP + GatewaySubnet, creates a virtual network gateway (poller completes), a local network gateway, and an IPsec connection referencing both, then get/list/delete with a 404-after-delete assertion.

Regenerated `docs/coverage` (new `AzureNetworkGateways` interface).