### PR TITLE
feat(azure-network): Private Link — privateEndpoints + privateLinkServices (#611)

### DIFF
--- a/docs/coverage/azure/vnet.md
+++ b/docs/coverage/azure/vnet.md
@@ -135,6 +135,21 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | `UpsertAzureNSGRule` | UpsertAzureNSGRule creates or replaces a single custom security rule by |
 | `UpsertAzureVNetPeering` | UpsertAzureVNetPeering creates or replaces a single virtualNetworkPeerings |
 
+### AzurePrivateLink
+
+AzurePrivateLink is the Azure-only Private Link surface. Each resource type is
+
+| Operation | Description |
+| --- | --- |
+| `DeleteAzurePrivateEndpoint` | DeleteAzurePrivateEndpoint removes the endpoint, reporting whether it existed. |
+| `DeleteAzurePrivateLinkService` | DeleteAzurePrivateLinkService removes the service, reporting whether it existed. |
+| `GetAzurePrivateEndpoint` | GetAzurePrivateEndpoint returns the endpoint identified by (resourceGroup, name). |
+| `GetAzurePrivateLinkService` | GetAzurePrivateLinkService returns the service identified by (resourceGroup, name). |
+| `ListAzurePrivateEndpoints` | ListAzurePrivateEndpoints returns the endpoints in a resource group, or all |
+| `ListAzurePrivateLinkServices` | ListAzurePrivateLinkServices returns the services in a resource group, or all |
+| `PutAzurePrivateEndpoint` | PutAzurePrivateEndpoint creates or replaces a private endpoint in place (a |
+| `PutAzurePrivateLinkService` | PutAzurePrivateLinkService creates or replaces a private link service in place. |
+
 ### AzurePublicIPPrefixes
 
 AzurePublicIPPrefixes is the Azure-only public-IP-prefix surface. Keyed by

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -7691,6 +7691,44 @@
         ]
       },
       {
+        "name": "AzurePrivateLink",
+        "doc": "AzurePrivateLink is the Azure-only Private Link surface. Each resource type is",
+        "operations": [
+          {
+            "name": "DeleteAzurePrivateEndpoint",
+            "doc": "DeleteAzurePrivateEndpoint removes the endpoint, reporting whether it existed."
+          },
+          {
+            "name": "DeleteAzurePrivateLinkService",
+            "doc": "DeleteAzurePrivateLinkService removes the service, reporting whether it existed."
+          },
+          {
+            "name": "GetAzurePrivateEndpoint",
+            "doc": "GetAzurePrivateEndpoint returns the endpoint identified by (resourceGroup, name)."
+          },
+          {
+            "name": "GetAzurePrivateLinkService",
+            "doc": "GetAzurePrivateLinkService returns the service identified by (resourceGroup, name)."
+          },
+          {
+            "name": "ListAzurePrivateEndpoints",
+            "doc": "ListAzurePrivateEndpoints returns the endpoints in a resource group, or all"
+          },
+          {
+            "name": "ListAzurePrivateLinkServices",
+            "doc": "ListAzurePrivateLinkServices returns the services in a resource group, or all"
+          },
+          {
+            "name": "PutAzurePrivateEndpoint",
+            "doc": "PutAzurePrivateEndpoint creates or replaces a private endpoint in place (a"
+          },
+          {
+            "name": "PutAzurePrivateLinkService",
+            "doc": "PutAzurePrivateLinkService creates or replaces a private link service in place."
+          }
+        ]
+      },
+      {
         "name": "AzurePublicIPPrefixes",
         "doc": "AzurePublicIPPrefixes is the Azure-only public-IP-prefix surface. Keyed by",
         "operations": [

--- a/providers/azure/vnet/private_link.go
+++ b/providers/azure/vnet/private_link.go
@@ -1,0 +1,170 @@
+package vnet
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// Compile-time check that Mock serves the Azure Private Link surface.
+var _ driver.AzurePrivateLink = (*Mock)(nil)
+
+// privateLinkKey composes the store key from the ARM addressing pair, matching
+// gatewayKey: resource-group names are case-insensitive in Azure, so the group
+// is lower-cased while the resource name is preserved as-is.
+func privateLinkKey(resourceGroup, name string) string {
+	return strings.ToLower(resourceGroup) + "/" + name
+}
+
+// Private endpoints.
+
+// PutAzurePrivateEndpoint creates or replaces a private endpoint in place, keyed
+// by (resourceGroup, name), so a repeat createOrUpdate PUT updates rather than
+// duplicating.
+//
+//nolint:gocritic // hugeParam: pe mirrors the AzurePrivateLink driver signature.
+func (m *Mock) PutAzurePrivateEndpoint(_ context.Context, pe driver.AzurePrivateEndpoint) driver.AzurePrivateEndpoint {
+	stored := clonePrivateEndpoint(pe)
+	m.azurePrivateEndpoints.Set(privateLinkKey(pe.ResourceGroup, pe.Name), stored)
+
+	return clonePrivateEndpoint(stored)
+}
+
+// GetAzurePrivateEndpoint returns the endpoint identified by (resourceGroup, name).
+func (m *Mock) GetAzurePrivateEndpoint(
+	_ context.Context, resourceGroup, name string,
+) (driver.AzurePrivateEndpoint, bool) {
+	pe, ok := m.azurePrivateEndpoints.Get(privateLinkKey(resourceGroup, name))
+	if !ok {
+		return driver.AzurePrivateEndpoint{}, false
+	}
+
+	return clonePrivateEndpoint(pe), true
+}
+
+// DeleteAzurePrivateEndpoint removes the endpoint, reporting whether it existed.
+func (m *Mock) DeleteAzurePrivateEndpoint(_ context.Context, resourceGroup, name string) bool {
+	return m.azurePrivateEndpoints.Delete(privateLinkKey(resourceGroup, name))
+}
+
+// ListAzurePrivateEndpoints returns the endpoints in a resource group, or all
+// when resourceGroup is empty (subscription-wide list), ordered by key.
+func (m *Mock) ListAzurePrivateEndpoints(_ context.Context, resourceGroup string) []driver.AzurePrivateEndpoint {
+	out := make([]driver.AzurePrivateEndpoint, 0)
+
+	values := m.azurePrivateEndpoints.SortedValues()
+	for i := range values {
+		if resourceGroup != "" && !strings.EqualFold(values[i].ResourceGroup, resourceGroup) {
+			continue
+		}
+
+		out = append(out, clonePrivateEndpoint(values[i]))
+	}
+
+	return out
+}
+
+// Private link services.
+
+// PutAzurePrivateLinkService creates or replaces a private link service in place.
+//
+//nolint:gocritic // hugeParam: pls mirrors the AzurePrivateLink driver signature.
+func (m *Mock) PutAzurePrivateLinkService(_ context.Context, pls driver.AzurePrivateLinkService) driver.AzurePrivateLinkService {
+	stored := clonePrivateLinkService(pls)
+	m.azurePrivateLinkServices.Set(privateLinkKey(pls.ResourceGroup, pls.Name), stored)
+
+	return clonePrivateLinkService(stored)
+}
+
+// GetAzurePrivateLinkService returns the service identified by (resourceGroup, name).
+func (m *Mock) GetAzurePrivateLinkService(
+	_ context.Context, resourceGroup, name string,
+) (driver.AzurePrivateLinkService, bool) {
+	pls, ok := m.azurePrivateLinkServices.Get(privateLinkKey(resourceGroup, name))
+	if !ok {
+		return driver.AzurePrivateLinkService{}, false
+	}
+
+	return clonePrivateLinkService(pls), true
+}
+
+// DeleteAzurePrivateLinkService removes the service, reporting whether it existed.
+func (m *Mock) DeleteAzurePrivateLinkService(_ context.Context, resourceGroup, name string) bool {
+	return m.azurePrivateLinkServices.Delete(privateLinkKey(resourceGroup, name))
+}
+
+// ListAzurePrivateLinkServices returns the services in a resource group, or all
+// when resourceGroup is empty (subscription-wide list), ordered by key.
+func (m *Mock) ListAzurePrivateLinkServices(_ context.Context, resourceGroup string) []driver.AzurePrivateLinkService {
+	out := make([]driver.AzurePrivateLinkService, 0)
+
+	values := m.azurePrivateLinkServices.SortedValues()
+	for i := range values {
+		if resourceGroup != "" && !strings.EqualFold(values[i].ResourceGroup, resourceGroup) {
+			continue
+		}
+
+		out = append(out, clonePrivateLinkService(values[i]))
+	}
+
+	return out
+}
+
+// Clone helpers deep-copy the tag map and any slices so stored and returned
+// values never alias a caller's containers.
+
+//nolint:gocritic // hugeParam: pe mirrors the AzurePrivateLink driver signature.
+func clonePrivateEndpoint(pe driver.AzurePrivateEndpoint) driver.AzurePrivateEndpoint {
+	out := pe
+	out.Tags = maybeCopyTags(pe.Tags)
+	out.PrivateLinkServiceConnections = cloneConnections(pe.PrivateLinkServiceConnections)
+	out.ManualConnections = cloneConnections(pe.ManualConnections)
+
+	return out
+}
+
+func cloneConnections(in []driver.AzurePrivateLinkServiceConnection) []driver.AzurePrivateLinkServiceConnection {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]driver.AzurePrivateLinkServiceConnection, len(in))
+	for i := range in {
+		out[i] = in[i]
+
+		if len(in[i].GroupIDs) > 0 {
+			out[i].GroupIDs = append([]string(nil), in[i].GroupIDs...)
+		}
+	}
+
+	return out
+}
+
+//nolint:gocritic // hugeParam: pls mirrors the AzurePrivateLink driver signature.
+func clonePrivateLinkService(pls driver.AzurePrivateLinkService) driver.AzurePrivateLinkService {
+	out := pls
+	out.Tags = maybeCopyTags(pls.Tags)
+
+	if len(pls.LoadBalancerFrontendIDs) > 0 {
+		out.LoadBalancerFrontendIDs = append([]string(nil), pls.LoadBalancerFrontendIDs...)
+	}
+
+	if len(pls.VisibilitySubscriptions) > 0 {
+		out.VisibilitySubscriptions = append([]string(nil), pls.VisibilitySubscriptions...)
+	}
+
+	if len(pls.AutoApprovalSubs) > 0 {
+		out.AutoApprovalSubs = append([]string(nil), pls.AutoApprovalSubs...)
+	}
+
+	if len(pls.Fqdns) > 0 {
+		out.Fqdns = append([]string(nil), pls.Fqdns...)
+	}
+
+	if len(pls.IPConfigurations) > 0 {
+		out.IPConfigurations = append([]driver.AzurePrivateLinkServiceIPConfiguration(nil), pls.IPConfigurations...)
+	}
+
+	return out
+}

--- a/providers/azure/vnet/snapshot.go
+++ b/providers/azure/vnet/snapshot.go
@@ -41,6 +41,9 @@ type vnetSnapshot struct {
 	AzureVNGateways     json.RawMessage `json:"azureVirtualNetworkGateways,omitempty"`
 	AzureLNGateways     json.RawMessage `json:"azureLocalNetworkGateways,omitempty"`
 	AzureGWConnections  json.RawMessage `json:"azureGatewayConnections,omitempty"`
+
+	AzurePrivateEndpoints    json.RawMessage `json:"azurePrivateEndpoints,omitempty"`
+	AzurePrivateLinkServices json.RawMessage `json:"azurePrivateLinkServices,omitempty"`
 }
 
 // Snapshot captures the mock's entire state as JSON. includeAssets is unused —
@@ -82,6 +85,8 @@ func (m *Mock) snapshotStores(snap *vnetSnapshot) error {
 		{&snap.AzureVNGateways, m.azureVNGateways.Snapshot},
 		{&snap.AzureLNGateways, m.azureLNGateways.Snapshot},
 		{&snap.AzureGWConnections, m.azureGWConnections.Snapshot},
+		{&snap.AzurePrivateEndpoints, m.azurePrivateEndpoints.Snapshot},
+		{&snap.AzurePrivateLinkServices, m.azurePrivateLinkServices.Snapshot},
 	}
 
 	for _, d := range dumps {
@@ -135,6 +140,8 @@ func (m *Mock) restoreStores(snap *vnetSnapshot) error {
 		{snap.AzureVNGateways, m.azureVNGateways.LoadSnapshot},
 		{snap.AzureLNGateways, m.azureLNGateways.LoadSnapshot},
 		{snap.AzureGWConnections, m.azureGWConnections.LoadSnapshot},
+		{snap.AzurePrivateEndpoints, m.azurePrivateEndpoints.LoadSnapshot},
+		{snap.AzurePrivateLinkServices, m.azurePrivateLinkServices.LoadSnapshot},
 	}
 
 	for _, l := range loads {

--- a/providers/azure/vnet/snapshot_test.go
+++ b/providers/azure/vnet/snapshot_test.go
@@ -66,6 +66,29 @@ func TestSnapshotRestoreRoundTrip(t *testing.T) {
 		SharedKey:                "psk-secret", RoutingWeight: 10,
 	})
 
+	// Seed the Private Link surface so the round-trip proves the private endpoint
+	// and private link service stores are included in the snapshot dump/restore
+	// lists — the test would pass even with a store dropped if nothing referenced it.
+	plsID := "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Network/privateLinkServices/pls1"
+
+	src.PutAzurePrivateEndpoint(ctx, driver.AzurePrivateEndpoint{
+		Name: "pe1", ResourceGroup: "rg1", Location: "eastus",
+		SubnetID: subnet.ID,
+		PrivateLinkServiceConnections: []driver.AzurePrivateLinkServiceConnection{
+			{Name: "conn", PrivateLinkServiceID: plsID, GroupIDs: []string{"blob"}, Status: "Approved"},
+		},
+		Tags: map[string]string{"env": "prod"},
+	})
+
+	src.PutAzurePrivateLinkService(ctx, driver.AzurePrivateLinkService{
+		Name: "pls1", ResourceGroup: "rg1", Location: "eastus",
+		LoadBalancerFrontendIDs: []string{"/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/frontendIPConfigurations/fe"},
+		IPConfigurations: []driver.AzurePrivateLinkServiceIPConfiguration{
+			{Name: "ipcfg", SubnetID: subnet.ID, PrivateIPAllocationMethod: "Dynamic", Primary: true},
+		},
+		VisibilitySubscriptions: []string{"sub-1"}, EnableProxyProtocol: true,
+	})
+
 	data, err := src.Snapshot(ctx, true)
 	require.NoError(t, err)
 
@@ -129,6 +152,24 @@ func TestSnapshotRestoreRoundTrip(t *testing.T) {
 	assert.Equal(t, "psk-secret", conn.SharedKey)
 	assert.Contains(t, conn.VirtualNetworkGateway1ID, "virtualNetworkGateways/vng1")
 	assert.Contains(t, conn.LocalNetworkGateway2ID, "localNetworkGateways/lng1")
+
+	// The private endpoint survives with its subnet ref and connection.
+	pe, ok := dst.GetAzurePrivateEndpoint(ctx, "rg1", "pe1")
+	require.True(t, ok, "private endpoint must survive snapshot/restore")
+	assert.Equal(t, subnet.ID, pe.SubnetID, "private endpoint keeps its subnet cross-reference")
+	assert.Equal(t, "prod", pe.Tags["env"])
+	require.Len(t, pe.PrivateLinkServiceConnections, 1)
+	assert.Equal(t, plsID, pe.PrivateLinkServiceConnections[0].PrivateLinkServiceID)
+	assert.Equal(t, []string{"blob"}, pe.PrivateLinkServiceConnections[0].GroupIDs)
+
+	// The private link service survives with its ip config and visibility.
+	pls, ok := dst.GetAzurePrivateLinkService(ctx, "rg1", "pls1")
+	require.True(t, ok, "private link service must survive snapshot/restore")
+	assert.True(t, pls.EnableProxyProtocol)
+	assert.Equal(t, []string{"sub-1"}, pls.VisibilitySubscriptions)
+	require.Len(t, pls.IPConfigurations, 1)
+	assert.Equal(t, subnet.ID, pls.IPConfigurations[0].SubnetID)
+	assert.True(t, pls.IPConfigurations[0].Primary)
 }
 
 // TestSnapshotEmpty confirms a fresh mock snapshots and restores without error.

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -92,6 +92,12 @@ type Mock struct {
 	azureVNGateways    *memstore.Store[driver.AzureVirtualNetworkGateway]
 	azureLNGateways    *memstore.Store[driver.AzureLocalNetworkGateway]
 	azureGWConnections *memstore.Store[driver.AzureVirtualNetworkGatewayConnection]
+	// azurePrivateEndpoints / azurePrivateLinkServices hold the Azure-only
+	// Private Link surface (Microsoft.Network/privateEndpoints and
+	// privateLinkServices), each keyed by (resourceGroup, name). Neither has a
+	// cross-cloud equivalent.
+	azurePrivateEndpoints    *memstore.Store[driver.AzurePrivateEndpoint]
+	azurePrivateLinkServices *memstore.Store[driver.AzurePrivateLinkService]
 	// nicMu serializes network-interface create/update, whose private-IP
 	// allocation is a read-modify-write across the nics store (memstore is
 	// per-op safe but can't make that sequence atomic).
@@ -133,7 +139,11 @@ func New(opts *config.Options) *Mock {
 		azureVNGateways:     memstore.New[driver.AzureVirtualNetworkGateway](),
 		azureLNGateways:     memstore.New[driver.AzureLocalNetworkGateway](),
 		azureGWConnections:  memstore.New[driver.AzureVirtualNetworkGatewayConnection](),
-		opts:                opts,
+
+		azurePrivateEndpoints:    memstore.New[driver.AzurePrivateEndpoint](),
+		azurePrivateLinkServices: memstore.New[driver.AzurePrivateLinkService](),
+
+		opts: opts,
 	}
 }
 

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -108,7 +108,7 @@ func (*Handler) Matches(r *http.Request) bool {
 
 	switch rp.ResourceType {
 	case typeVNet, typeNSG, typeRouteTable, typePublicIP, typePublicIPPrefix, typeNIC, typeNATGateway, typeASG,
-		typeVNGateway, typeLNGateway, typeConnection, typeLocations:
+		typeVNGateway, typeLNGateway, typeConnection, typePrivateEndpoint, typePrivateLinkService, typeLocations:
 		return true
 	}
 
@@ -154,13 +154,24 @@ func (h *Handler) routeByResourceType(w http.ResponseWriter, r *http.Request, rp
 	case typeASG:
 		h.routeASG(w, r, rp)
 	default:
-		if h.routeGatewayResourceType(w, r, rp) {
+		if h.routeOptionalResourceType(w, r, rp) {
 			return
 		}
 
 		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
 			"unsupported resource type: "+rp.ResourceType)
 	}
+}
+
+// routeOptionalResourceType dispatches the Azure-only resource types served
+// through type-asserted networking-driver capabilities (site-to-site VPN
+// gateways, Private Link). Split out of routeByResourceType so that switch stays
+// under the cyclomatic-complexity gate as capabilities are added. It returns
+// true when it handled the request.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) routeOptionalResourceType(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) bool {
+	return h.routeGatewayResourceType(w, r, rp) || h.routePrivateLinkResourceType(w, r, rp)
 }
 
 // routeGatewayResourceType dispatches the site-to-site VPN resource types
@@ -668,6 +679,7 @@ func (h *Handler) PurgeResourceGroup(ctx context.Context, _, resourceGroup strin
 	h.purgeASGs(ctx, resourceGroup)
 	h.purgePublicIPPrefixes(ctx, resourceGroup)
 	h.purgeNetworkGateways(ctx, resourceGroup)
+	h.purgePrivateLink(ctx, resourceGroup)
 
 	return firstErr
 }

--- a/server/azure/vnet/private_link.go
+++ b/server/azure/vnet/private_link.go
@@ -1,0 +1,621 @@
+package vnet
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// Microsoft.Network Private Link resource types.
+const (
+	typePrivateEndpoint    = "privateEndpoints"
+	typePrivateLinkService = "privateLinkServices"
+
+	// connectionStatusApproved is the default state the emulator stamps on a new
+	// private endpoint connection: Private Link auto-approves here rather than
+	// leaving it Pending for an out-of-band approval workflow.
+	connectionStatusApproved = "Approved"
+
+	// plsAliasHashLen is how many hash characters the synthesized private link
+	// service alias carries (real Azure aliases embed a short opaque token).
+	plsAliasHashLen = 12
+)
+
+// ARM JSON shapes — privateEndpoints.
+
+type peConnectionState struct {
+	Status          string `json:"status,omitempty"`
+	Description     string `json:"description,omitempty"`
+	ActionsRequired string `json:"actionsRequired,omitempty"`
+}
+
+type peConnectionProps struct {
+	PrivateLinkServiceID              string             `json:"privateLinkServiceId,omitempty"`
+	GroupIDs                          []string           `json:"groupIds,omitempty"`
+	RequestMessage                    string             `json:"requestMessage,omitempty"`
+	PrivateLinkServiceConnectionState *peConnectionState `json:"privateLinkServiceConnectionState,omitempty"`
+}
+
+type peConnection struct {
+	Name       string            `json:"name,omitempty"`
+	Properties peConnectionProps `json:"properties"`
+}
+
+type privateEndpointRequest struct {
+	Location   string                      `json:"location"`
+	Tags       map[string]string           `json:"tags,omitempty"`
+	Properties privateEndpointRequestProps `json:"properties"`
+}
+
+type privateEndpointRequestProps struct {
+	Subnet                        *armIDRef      `json:"subnet,omitempty"`
+	CustomNetworkInterfaceName    string         `json:"customNetworkInterfaceName,omitempty"`
+	PrivateLinkServiceConnections []peConnection `json:"privateLinkServiceConnections,omitempty"`
+	ManualPrivateLinkServiceConns []peConnection `json:"manualPrivateLinkServiceConnections,omitempty"`
+}
+
+type privateEndpointResponse struct {
+	ID         string                       `json:"id"`
+	Name       string                       `json:"name"`
+	Type       string                       `json:"type"`
+	Location   string                       `json:"location"`
+	Tags       map[string]string            `json:"tags,omitempty"`
+	Etag       string                       `json:"etag,omitempty"`
+	Properties privateEndpointResponseProps `json:"properties"`
+}
+
+type privateEndpointResponseProps struct {
+	ProvisioningState             string         `json:"provisioningState"`
+	Subnet                        *armIDRef      `json:"subnet,omitempty"`
+	CustomNetworkInterfaceName    string         `json:"customNetworkInterfaceName,omitempty"`
+	PrivateLinkServiceConnections []peConnection `json:"privateLinkServiceConnections,omitempty"`
+	ManualPrivateLinkServiceConns []peConnection `json:"manualPrivateLinkServiceConnections,omitempty"`
+	NetworkInterfaces             []armIDRef     `json:"networkInterfaces,omitempty"`
+}
+
+type privateEndpointListResponse struct {
+	Value []privateEndpointResponse `json:"value"`
+}
+
+// ARM JSON shapes — privateLinkServices.
+
+type plsIPConfigProps struct {
+	PrivateIPAllocationMethod string    `json:"privateIPAllocationMethod,omitempty"`
+	Primary                   bool      `json:"primary,omitempty"`
+	Subnet                    *armIDRef `json:"subnet,omitempty"`
+}
+
+type plsIPConfig struct {
+	Name       string           `json:"name,omitempty"`
+	Properties plsIPConfigProps `json:"properties"`
+}
+
+type plsSubscriptions struct {
+	Subscriptions []string `json:"subscriptions,omitempty"`
+}
+
+type privateLinkServiceRequest struct {
+	Location   string                         `json:"location"`
+	Tags       map[string]string              `json:"tags,omitempty"`
+	Properties privateLinkServiceRequestProps `json:"properties"`
+}
+
+type privateLinkServiceRequestProps struct {
+	LoadBalancerFrontendIPConfigurations []armIDRef        `json:"loadBalancerFrontendIpConfigurations,omitempty"`
+	IPConfigurations                     []plsIPConfig     `json:"ipConfigurations,omitempty"`
+	Visibility                           *plsSubscriptions `json:"visibility,omitempty"`
+	AutoApproval                         *plsSubscriptions `json:"autoApproval,omitempty"`
+	EnableProxyProtocol                  *bool             `json:"enableProxyProtocol,omitempty"`
+	Fqdns                                []string          `json:"fqdns,omitempty"`
+}
+
+type privateLinkServiceResponse struct {
+	ID         string                          `json:"id"`
+	Name       string                          `json:"name"`
+	Type       string                          `json:"type"`
+	Location   string                          `json:"location"`
+	Tags       map[string]string               `json:"tags,omitempty"`
+	Etag       string                          `json:"etag,omitempty"`
+	Properties privateLinkServiceResponseProps `json:"properties"`
+}
+
+type privateLinkServiceResponseProps struct {
+	ProvisioningState                    string            `json:"provisioningState"`
+	Alias                                string            `json:"alias,omitempty"`
+	LoadBalancerFrontendIPConfigurations []armIDRef        `json:"loadBalancerFrontendIpConfigurations,omitempty"`
+	IPConfigurations                     []plsIPConfig     `json:"ipConfigurations,omitempty"`
+	Visibility                           *plsSubscriptions `json:"visibility,omitempty"`
+	AutoApproval                         *plsSubscriptions `json:"autoApproval,omitempty"`
+	EnableProxyProtocol                  bool              `json:"enableProxyProtocol"`
+	Fqdns                                []string          `json:"fqdns,omitempty"`
+	NetworkInterfaces                    []armIDRef        `json:"networkInterfaces,omitempty"`
+	PrivateEndpointConnections           []any             `json:"privateEndpointConnections,omitempty"`
+}
+
+type privateLinkServiceListResponse struct {
+	Value []privateLinkServiceResponse `json:"value"`
+}
+
+// privateLinkCap returns the Private Link surface if the networking driver
+// implements it (the Azure provider does; AWS/GCP do not).
+func (h *Handler) privateLinkCap() (netdriver.AzurePrivateLink, bool) {
+	svc, ok := h.net.(netdriver.AzurePrivateLink)
+
+	return svc, ok
+}
+
+// routePrivateLinkResourceType dispatches the Private Link resource types
+// (privateEndpoints, privateLinkServices). Split out of routeByResourceType so
+// its dispatch switch stays under the cyclomatic-complexity gate. It returns
+// true when it handled the request.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) routePrivateLinkResourceType(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) bool {
+	switch rp.ResourceType {
+	case typePrivateEndpoint:
+		h.routePrivateEndpoint(w, r, rp)
+	case typePrivateLinkService:
+		h.routePrivateLinkService(w, r, rp)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// routePrivateEndpoint dispatches Microsoft.Network/privateEndpoints requests.
+//
+//nolint:gocritic,dupl // rp is request-scoped; capability-gated dispatch mirrored by routePrivateLinkService over a distinct type
+func (h *Handler) routePrivateEndpoint(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	svc, ok := h.privateLinkCap()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"private link is not supported by this networking driver")
+
+		return
+	}
+
+	if rp.ResourceName == "" {
+		h.listPrivateEndpoints(w, r, rp, svc)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createPrivateEndpoint(w, r, rp, svc)
+	case http.MethodGet:
+		h.getPrivateEndpoint(w, r, rp, svc)
+	case http.MethodDelete:
+		h.deletePrivateEndpoint(w, r, rp, svc)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) createPrivateEndpoint(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzurePrivateLink,
+) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	var req privateEndpointRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	loc := req.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	rec := netdriver.AzurePrivateEndpoint{
+		Name:                          rp.ResourceName,
+		ResourceGroup:                 rp.ResourceGroup,
+		Location:                      loc,
+		Tags:                          req.Tags,
+		CustomNetworkInterfaceName:    req.Properties.CustomNetworkInterfaceName,
+		PrivateLinkServiceConnections: toRecordConnections(req.Properties.PrivateLinkServiceConnections),
+		ManualConnections:             toRecordConnections(req.Properties.ManualPrivateLinkServiceConns),
+	}
+
+	if req.Properties.Subnet != nil {
+		rec.SubnetID = req.Properties.Subnet.ID
+	}
+
+	stored := svc.PutAzurePrivateEndpoint(r.Context(), rec)
+
+	// Create is a long LRO in real Azure; a sync 200 with a terminal
+	// provisioningState completes the armnetwork poller immediately (the same
+	// convention the vnet/gateway creates use), so the SDK never hangs.
+	writeAcceptedAsync(w, r, rp.Subscription, "pe-create-"+rp.ResourceName, privateEndpointResponseFrom(stored, rp))
+}
+
+// toRecordConnections maps decoded privateLinkServiceConnections to driver
+// records, defaulting an unspecified connection state to Approved (the emulator
+// auto-approves).
+func toRecordConnections(in []peConnection) []netdriver.AzurePrivateLinkServiceConnection {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]netdriver.AzurePrivateLinkServiceConnection, 0, len(in))
+
+	for i := range in {
+		conn := netdriver.AzurePrivateLinkServiceConnection{
+			Name:                 in[i].Name,
+			PrivateLinkServiceID: in[i].Properties.PrivateLinkServiceID,
+			GroupIDs:             in[i].Properties.GroupIDs,
+			RequestMessage:       in[i].Properties.RequestMessage,
+			Status:               connectionStatusApproved,
+		}
+
+		if st := in[i].Properties.PrivateLinkServiceConnectionState; st != nil {
+			if st.Status != "" {
+				conn.Status = st.Status
+			}
+
+			conn.Description = st.Description
+		}
+
+		out = append(out, conn)
+	}
+
+	return out
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) getPrivateEndpoint(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzurePrivateLink,
+) {
+	pe, ok := svc.GetAzurePrivateEndpoint(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"private endpoint "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, privateEndpointResponseFrom(pe, rp))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) deletePrivateEndpoint(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzurePrivateLink,
+) {
+	svc.DeleteAzurePrivateEndpoint(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	writeAcceptedAsync(w, r, rp.Subscription, "pe-delete-"+rp.ResourceName, nil)
+}
+
+//nolint:gocritic,dupl // rp is request-scoped; mirrors listPrivateLinkServices over a distinct resource type
+func (*Handler) listPrivateEndpoints(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzurePrivateLink,
+) {
+	pes := svc.ListAzurePrivateEndpoints(r.Context(), rp.ResourceGroup)
+
+	out := privateEndpointListResponse{Value: make([]privateEndpointResponse, 0, len(pes))}
+
+	for i := range pes {
+		scope := rp
+		scope.ResourceGroup = pes[i].ResourceGroup
+		scope.ResourceName = pes[i].Name
+		out.Value = append(out.Value, privateEndpointResponseFrom(pes[i], scope))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func privateEndpointResponseFrom(pe netdriver.AzurePrivateEndpoint, rp azurearm.ResourcePath) privateEndpointResponse {
+	loc := pe.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typePrivateEndpoint, rp.ResourceName)
+
+	props := privateEndpointResponseProps{
+		ProvisioningState:             provisioningSucceeded,
+		CustomNetworkInterfaceName:    pe.CustomNetworkInterfaceName,
+		PrivateLinkServiceConnections: fromRecordConnections(pe.PrivateLinkServiceConnections),
+		ManualPrivateLinkServiceConns: fromRecordConnections(pe.ManualConnections),
+		// A real private endpoint materializes a NIC; expose the synthesized
+		// read-only reference so a caller inspecting networkInterfaces sees one.
+		NetworkInterfaces: []armIDRef{{ID: azurearm.BuildResourceID(
+			rp.Subscription, rp.ResourceGroup, providerName, typeNIC, rp.ResourceName+".nic")}},
+	}
+
+	if pe.SubnetID != "" {
+		props.Subnet = &armIDRef{ID: pe.SubnetID}
+	}
+
+	return privateEndpointResponse{
+		ID:         id,
+		Name:       rp.ResourceName,
+		Type:       providerName + "/" + typePrivateEndpoint,
+		Location:   loc,
+		Tags:       pe.Tags,
+		Etag:       etagOf(id),
+		Properties: props,
+	}
+}
+
+func fromRecordConnections(in []netdriver.AzurePrivateLinkServiceConnection) []peConnection {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]peConnection, 0, len(in))
+
+	for i := range in {
+		out = append(out, peConnection{
+			Name: in[i].Name,
+			Properties: peConnectionProps{
+				PrivateLinkServiceID: in[i].PrivateLinkServiceID,
+				GroupIDs:             in[i].GroupIDs,
+				RequestMessage:       in[i].RequestMessage,
+				PrivateLinkServiceConnectionState: &peConnectionState{
+					Status:      in[i].Status,
+					Description: in[i].Description,
+				},
+			},
+		})
+	}
+
+	return out
+}
+
+// routePrivateLinkService dispatches Microsoft.Network/privateLinkServices requests.
+//
+//nolint:gocritic,dupl // rp is request-scoped; capability-gated dispatch mirrored by routePrivateEndpoint over a distinct type
+func (h *Handler) routePrivateLinkService(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	svc, ok := h.privateLinkCap()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"private link is not supported by this networking driver")
+
+		return
+	}
+
+	if rp.ResourceName == "" {
+		h.listPrivateLinkServices(w, r, rp, svc)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createPrivateLinkService(w, r, rp, svc)
+	case http.MethodGet:
+		h.getPrivateLinkService(w, r, rp, svc)
+	case http.MethodDelete:
+		h.deletePrivateLinkService(w, r, rp, svc)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) createPrivateLinkService(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzurePrivateLink,
+) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	var req privateLinkServiceRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	loc := req.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	stored := svc.PutAzurePrivateLinkService(r.Context(), plsRecord(rp, loc, &req))
+
+	writeAcceptedAsync(w, r, rp.Subscription, "pls-create-"+rp.ResourceName, privateLinkServiceResponseFrom(stored, rp))
+}
+
+// plsRecord maps a decoded PUT body to the driver record.
+//
+//nolint:gocritic // rp is a request-scoped value
+func plsRecord(rp azurearm.ResourcePath, loc string, req *privateLinkServiceRequest) netdriver.AzurePrivateLinkService {
+	rec := netdriver.AzurePrivateLinkService{
+		Name:                    rp.ResourceName,
+		ResourceGroup:           rp.ResourceGroup,
+		Location:                loc,
+		Tags:                    req.Tags,
+		LoadBalancerFrontendIDs: refIDs(req.Properties.LoadBalancerFrontendIPConfigurations),
+		IPConfigurations:        toRecordPLSIPConfigs(req.Properties.IPConfigurations),
+		EnableProxyProtocol:     derefBool(req.Properties.EnableProxyProtocol),
+		Fqdns:                   req.Properties.Fqdns,
+	}
+
+	if req.Properties.Visibility != nil {
+		rec.VisibilitySubscriptions = req.Properties.Visibility.Subscriptions
+	}
+
+	if req.Properties.AutoApproval != nil {
+		rec.AutoApprovalSubs = req.Properties.AutoApproval.Subscriptions
+	}
+
+	return rec
+}
+
+func toRecordPLSIPConfigs(in []plsIPConfig) []netdriver.AzurePrivateLinkServiceIPConfiguration {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]netdriver.AzurePrivateLinkServiceIPConfiguration, 0, len(in))
+
+	for i := range in {
+		cfg := netdriver.AzurePrivateLinkServiceIPConfiguration{
+			Name:                      in[i].Name,
+			PrivateIPAllocationMethod: in[i].Properties.PrivateIPAllocationMethod,
+			Primary:                   in[i].Properties.Primary,
+		}
+
+		if in[i].Properties.Subnet != nil {
+			cfg.SubnetID = in[i].Properties.Subnet.ID
+		}
+
+		out = append(out, cfg)
+	}
+
+	return out
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) getPrivateLinkService(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzurePrivateLink,
+) {
+	pls, ok := svc.GetAzurePrivateLinkService(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"private link service "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, privateLinkServiceResponseFrom(pls, rp))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) deletePrivateLinkService(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzurePrivateLink,
+) {
+	svc.DeleteAzurePrivateLinkService(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	writeAcceptedAsync(w, r, rp.Subscription, "pls-delete-"+rp.ResourceName, nil)
+}
+
+//nolint:gocritic,dupl // rp is request-scoped; mirrors listPrivateEndpoints over a distinct resource type
+func (*Handler) listPrivateLinkServices(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzurePrivateLink,
+) {
+	svcs := svc.ListAzurePrivateLinkServices(r.Context(), rp.ResourceGroup)
+
+	out := privateLinkServiceListResponse{Value: make([]privateLinkServiceResponse, 0, len(svcs))}
+
+	for i := range svcs {
+		scope := rp
+		scope.ResourceGroup = svcs[i].ResourceGroup
+		scope.ResourceName = svcs[i].Name
+		out.Value = append(out.Value, privateLinkServiceResponseFrom(svcs[i], scope))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func privateLinkServiceResponseFrom(pls netdriver.AzurePrivateLinkService, rp azurearm.ResourcePath) privateLinkServiceResponse {
+	loc := pls.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typePrivateLinkService, rp.ResourceName)
+
+	props := privateLinkServiceResponseProps{
+		ProvisioningState:                    provisioningSucceeded,
+		Alias:                                rp.ResourceName + "." + shortEtag(id) + "." + loc + ".azure.privatelinkservice",
+		LoadBalancerFrontendIPConfigurations: refsOf(pls.LoadBalancerFrontendIDs),
+		IPConfigurations:                     fromRecordPLSIPConfigs(pls.IPConfigurations),
+		EnableProxyProtocol:                  pls.EnableProxyProtocol,
+		Fqdns:                                pls.Fqdns,
+	}
+
+	if len(pls.VisibilitySubscriptions) > 0 {
+		props.Visibility = &plsSubscriptions{Subscriptions: pls.VisibilitySubscriptions}
+	}
+
+	if len(pls.AutoApprovalSubs) > 0 {
+		props.AutoApproval = &plsSubscriptions{Subscriptions: pls.AutoApprovalSubs}
+	}
+
+	return privateLinkServiceResponse{
+		ID:         id,
+		Name:       rp.ResourceName,
+		Type:       providerName + "/" + typePrivateLinkService,
+		Location:   loc,
+		Tags:       pls.Tags,
+		Etag:       etagOf(id),
+		Properties: props,
+	}
+}
+
+func fromRecordPLSIPConfigs(in []netdriver.AzurePrivateLinkServiceIPConfiguration) []plsIPConfig {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]plsIPConfig, 0, len(in))
+
+	for i := range in {
+		props := plsIPConfigProps{
+			PrivateIPAllocationMethod: in[i].PrivateIPAllocationMethod,
+			Primary:                   in[i].Primary,
+		}
+
+		if in[i].SubnetID != "" {
+			props.Subnet = &armIDRef{ID: in[i].SubnetID}
+		}
+
+		out = append(out, plsIPConfig{Name: in[i].Name, Properties: props})
+	}
+
+	return out
+}
+
+// shortEtag reuses etagOf's hash to synthesize the stable alias segment real
+// Azure assigns a private link service.
+func shortEtag(id string) string {
+	e := etagOf(id)
+	if len(e) > plsAliasHashLen {
+		return e[:plsAliasHashLen]
+	}
+
+	return e
+}
+
+// refsOf wraps a slice of ids back into armIDRefs.
+func refsOf(ids []string) []armIDRef {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	out := make([]armIDRef, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, armIDRef{ID: id})
+	}
+
+	return out
+}
+
+// purgePrivateLink deletes every private endpoint and private link service in
+// the resource group, part of the PurgeResourceGroup cascade. Private endpoints
+// are removed first as they reference the services.
+func (h *Handler) purgePrivateLink(ctx context.Context, resourceGroup string) {
+	svc, ok := h.privateLinkCap()
+	if !ok {
+		return
+	}
+
+	pes := svc.ListAzurePrivateEndpoints(ctx, resourceGroup)
+	for i := range pes {
+		svc.DeleteAzurePrivateEndpoint(ctx, pes[i].ResourceGroup, pes[i].Name)
+	}
+
+	svcs := svc.ListAzurePrivateLinkServices(ctx, resourceGroup)
+	for i := range svcs {
+		svc.DeleteAzurePrivateLinkService(ctx, svcs[i].ResourceGroup, svcs[i].Name)
+	}
+}

--- a/server/azure/vnet/private_link_test.go
+++ b/server/azure/vnet/private_link_test.go
@@ -1,0 +1,217 @@
+package vnet_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// TestSDKPrivateLinkRoundTrip drives the real armnetwork PrivateEndpointsClient
+// and PrivateLinkServicesClient through their Begin* pollers end-to-end: it
+// creates a private link service (the provider side) and a private endpoint (the
+// consumer side) referencing it, then asserts get/list round-trip them and
+// delete makes a subsequent get 404. The key regression it guards is the create
+// LRO: the pollers must complete rather than hang (every op used to fall through
+// to the vnet 501 default).
+func TestSDKPrivateLinkRoundTrip(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	const rg = "rg-pl"
+
+	plsClient, err := armnetwork.NewPrivateLinkServicesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subnetID := "/subscriptions/sub-1/resourceGroups/" + rg +
+		"/providers/Microsoft.Network/virtualNetworks/vnet-pl/subnets/svc"
+	frontendID := "/subscriptions/sub-1/resourceGroups/" + rg +
+		"/providers/Microsoft.Network/loadBalancers/lb-pl/frontendIPConfigurations/fe"
+
+	plsCreate, err := plsClient.BeginCreateOrUpdate(ctx, rg, "pls-1", armnetwork.PrivateLinkService{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.PrivateLinkServiceProperties{
+			EnableProxyProtocol: to.Ptr(true),
+			LoadBalancerFrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+				{ID: to.Ptr(frontendID)},
+			},
+			IPConfigurations: []*armnetwork.PrivateLinkServiceIPConfiguration{
+				{
+					Name: to.Ptr("ipcfg"),
+					Properties: &armnetwork.PrivateLinkServiceIPConfigurationProperties{
+						Primary:                   to.Ptr(true),
+						PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+						Subnet:                    &armnetwork.Subnet{ID: to.Ptr(subnetID)},
+					},
+				},
+			},
+			Visibility:   &armnetwork.PrivateLinkServicePropertiesVisibility{Subscriptions: []*string{to.Ptr("sub-1")}},
+			AutoApproval: &armnetwork.PrivateLinkServicePropertiesAutoApproval{Subscriptions: []*string{to.Ptr("sub-1")}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("pls BeginCreateOrUpdate: %v", err)
+	}
+
+	pls := pollDone(t, plsCreate)
+
+	if pls.Name == nil || *pls.Name != "pls-1" {
+		t.Fatalf("pls name=%v want pls-1", pls.Name)
+	}
+
+	if pls.Properties == nil || pls.Properties.ProvisioningState == nil ||
+		*pls.Properties.ProvisioningState != armnetwork.ProvisioningStateSucceeded {
+		t.Errorf("pls provisioningState=%v want Succeeded", pls.Properties)
+	}
+
+	if pls.Properties.EnableProxyProtocol == nil || !*pls.Properties.EnableProxyProtocol {
+		t.Errorf("pls enableProxyProtocol=%v want true", pls.Properties.EnableProxyProtocol)
+	}
+
+	if len(pls.Properties.IPConfigurations) != 1 ||
+		pls.Properties.IPConfigurations[0].Properties.Subnet == nil ||
+		*pls.Properties.IPConfigurations[0].Properties.Subnet.ID != subnetID {
+		t.Errorf("pls ipConfigurations=%+v want subnet %s", pls.Properties.IPConfigurations, subnetID)
+	}
+
+	plsID := *pls.ID
+
+	// Private endpoint (the consumer side) referencing the service above.
+	peClient, err := armnetwork.NewPrivateEndpointsClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	peCreate, err := peClient.BeginCreateOrUpdate(ctx, rg, "pe-1", armnetwork.PrivateEndpoint{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.PrivateEndpointProperties{
+			Subnet: &armnetwork.Subnet{ID: to.Ptr(subnetID)},
+			PrivateLinkServiceConnections: []*armnetwork.PrivateLinkServiceConnection{
+				{
+					Name: to.Ptr("conn"),
+					Properties: &armnetwork.PrivateLinkServiceConnectionProperties{
+						PrivateLinkServiceID: to.Ptr(plsID),
+						GroupIDs:             []*string{to.Ptr("blob")},
+						RequestMessage:       to.Ptr("please approve"),
+					},
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("pe BeginCreateOrUpdate: %v", err)
+	}
+
+	pe := pollDone(t, peCreate)
+
+	if pe.Properties == nil || pe.Properties.Subnet == nil || pe.Properties.Subnet.ID == nil ||
+		*pe.Properties.Subnet.ID != subnetID {
+		t.Errorf("pe subnet=%v want %s", pe.Properties, subnetID)
+	}
+
+	if len(pe.Properties.PrivateLinkServiceConnections) != 1 {
+		t.Fatalf("pe connections=%+v want 1", pe.Properties.PrivateLinkServiceConnections)
+	}
+
+	conn := pe.Properties.PrivateLinkServiceConnections[0]
+	if conn.Properties == nil || conn.Properties.PrivateLinkServiceID == nil ||
+		*conn.Properties.PrivateLinkServiceID != plsID {
+		t.Errorf("pe connection privateLinkServiceId=%v want %s", conn.Properties, plsID)
+	}
+
+	// The emulator auto-approves a new connection.
+	if conn.Properties.PrivateLinkServiceConnectionState == nil ||
+		conn.Properties.PrivateLinkServiceConnectionState.Status == nil ||
+		*conn.Properties.PrivateLinkServiceConnectionState.Status != "Approved" {
+		t.Errorf("pe connection state=%v want Approved", conn.Properties.PrivateLinkServiceConnectionState)
+	}
+
+	assertPrivateLinkGetList(t, ctx, peClient, plsClient, rg)
+	assertPrivateLinkDelete(t, ctx, peClient, plsClient, rg)
+}
+
+// assertPrivateLinkGetList checks Get and the list pagers return each resource.
+func assertPrivateLinkGetList(
+	t *testing.T, ctx context.Context,
+	pe *armnetwork.PrivateEndpointsClient,
+	pls *armnetwork.PrivateLinkServicesClient,
+	rg string,
+) {
+	t.Helper()
+
+	if _, err := pe.Get(ctx, rg, "pe-1", nil); err != nil {
+		t.Errorf("pe Get: %v", err)
+	}
+
+	if _, err := pls.Get(ctx, rg, "pls-1", nil); err != nil {
+		t.Errorf("pls Get: %v", err)
+	}
+
+	pePager := pe.NewListPager(rg, nil)
+	if got := drainNames(t, ctx, pePager.More, func() ([]*string, error) {
+		p, err := pePager.NextPage(ctx)
+		return peNames(p.Value), err
+	}); len(got) != 1 || *got[0] != "pe-1" {
+		t.Errorf("pe list=%v want [pe-1]", derefAll(got))
+	}
+
+	plsPager := pls.NewListPager(rg, nil)
+	if got := drainNames(t, ctx, plsPager.More, func() ([]*string, error) {
+		p, err := plsPager.NextPage(ctx)
+		return plsNames(p.Value), err
+	}); len(got) != 1 || *got[0] != "pls-1" {
+		t.Errorf("pls list=%v want [pls-1]", derefAll(got))
+	}
+}
+
+// assertPrivateLinkDelete deletes both resources and confirms a follow-up Get 404s.
+func assertPrivateLinkDelete(
+	t *testing.T, ctx context.Context,
+	pe *armnetwork.PrivateEndpointsClient,
+	pls *armnetwork.PrivateLinkServicesClient,
+	rg string,
+) {
+	t.Helper()
+
+	peDelete, err := pe.BeginDelete(ctx, rg, "pe-1", nil)
+	if err != nil {
+		t.Fatalf("pe BeginDelete: %v", err)
+	}
+
+	pollDone(t, peDelete)
+
+	plsDelete, err := pls.BeginDelete(ctx, rg, "pls-1", nil)
+	if err != nil {
+		t.Fatalf("pls BeginDelete: %v", err)
+	}
+
+	pollDone(t, plsDelete)
+
+	_, err = pe.Get(ctx, rg, "pe-1", nil)
+	assertNotFound(t, err, "pe Get after delete")
+
+	_, err = pls.Get(ctx, rg, "pls-1", nil)
+	assertNotFound(t, err, "pls Get after delete")
+}
+
+func peNames(in []*armnetwork.PrivateEndpoint) []*string {
+	out := make([]*string, 0, len(in))
+	for _, p := range in {
+		out = append(out, p.Name)
+	}
+
+	return out
+}
+
+func plsNames(in []*armnetwork.PrivateLinkService) []*string {
+	out := make([]*string, 0, len(in))
+	for _, p := range in {
+		out = append(out, p.Name)
+	}
+
+	return out
+}

--- a/services/networking/driver/azure_private_link.go
+++ b/services/networking/driver/azure_private_link.go
@@ -1,0 +1,91 @@
+package driver
+
+import "context"
+
+// Microsoft.Network's Private Link surface — privateEndpoints and
+// privateLinkServices — has no equivalent in the cross-cloud Networking model,
+// so — like AzureNetworkGateways and AzurePublicIPPrefixes — the Azure provider
+// stores it through this OPTIONAL, type-asserted capability. AWS and GCP do not
+// implement it. Both resource types are addressed by (resourceGroup, name) to
+// match ARM; an empty resourceGroup on a List means subscription-wide.
+//
+// These are the standalone Microsoft.Network/privateEndpoints and
+// privateLinkServices resources, distinct from the per-service
+// privateEndpointConnections sub-resource surfaces (e.g. the cosmos-postgres or
+// databricks workspace connections), which each service models on its own.
+
+// AzurePrivateLinkServiceConnection is one privateLinkServiceConnections entry
+// on a private endpoint: the consumer's connection to a provider resource.
+type AzurePrivateLinkServiceConnection struct {
+	Name                 string
+	PrivateLinkServiceID string
+	GroupIDs             []string
+	RequestMessage       string
+	// Status is the connection-state enum (Pending/Approved/Rejected). The
+	// emulator auto-approves a new connection, so it defaults to Approved unless
+	// the request supplies one.
+	Status      string
+	Description string
+}
+
+// AzurePrivateEndpoint is one Microsoft.Network/privateEndpoints resource.
+type AzurePrivateEndpoint struct {
+	Name                          string
+	ResourceGroup                 string
+	Location                      string
+	Tags                          map[string]string
+	SubnetID                      string
+	CustomNetworkInterfaceName    string
+	PrivateLinkServiceConnections []AzurePrivateLinkServiceConnection
+	ManualConnections             []AzurePrivateLinkServiceConnection
+}
+
+// AzurePrivateLinkServiceIPConfiguration is one ipConfigurations entry of a
+// private link service, allocating an address from the service's subnet.
+type AzurePrivateLinkServiceIPConfiguration struct {
+	Name                      string
+	SubnetID                  string
+	PrivateIPAllocationMethod string
+	Primary                   bool
+}
+
+// AzurePrivateLinkService is one Microsoft.Network/privateLinkServices resource
+// — the provider side of a Private Link, fronted by a load balancer.
+type AzurePrivateLinkService struct {
+	Name                    string
+	ResourceGroup           string
+	Location                string
+	Tags                    map[string]string
+	LoadBalancerFrontendIDs []string
+	IPConfigurations        []AzurePrivateLinkServiceIPConfiguration
+	VisibilitySubscriptions []string
+	AutoApprovalSubs        []string
+	EnableProxyProtocol     bool
+	Fqdns                   []string
+}
+
+// AzurePrivateLink is the Azure-only Private Link surface. Each resource type is
+// keyed by (resourceGroup, name) for idempotent createOrUpdate.
+type AzurePrivateLink interface {
+	// PutAzurePrivateEndpoint creates or replaces a private endpoint in place (a
+	// repeat createOrUpdate PUT updates rather than duplicating), returning the
+	// stored value.
+	PutAzurePrivateEndpoint(ctx context.Context, pe AzurePrivateEndpoint) AzurePrivateEndpoint
+	// GetAzurePrivateEndpoint returns the endpoint identified by (resourceGroup, name).
+	GetAzurePrivateEndpoint(ctx context.Context, resourceGroup, name string) (AzurePrivateEndpoint, bool)
+	// DeleteAzurePrivateEndpoint removes the endpoint, reporting whether it existed.
+	DeleteAzurePrivateEndpoint(ctx context.Context, resourceGroup, name string) bool
+	// ListAzurePrivateEndpoints returns the endpoints in a resource group, or all
+	// when resourceGroup is empty, ordered by key.
+	ListAzurePrivateEndpoints(ctx context.Context, resourceGroup string) []AzurePrivateEndpoint
+
+	// PutAzurePrivateLinkService creates or replaces a private link service in place.
+	PutAzurePrivateLinkService(ctx context.Context, pls AzurePrivateLinkService) AzurePrivateLinkService
+	// GetAzurePrivateLinkService returns the service identified by (resourceGroup, name).
+	GetAzurePrivateLinkService(ctx context.Context, resourceGroup, name string) (AzurePrivateLinkService, bool)
+	// DeleteAzurePrivateLinkService removes the service, reporting whether it existed.
+	DeleteAzurePrivateLinkService(ctx context.Context, resourceGroup, name string) bool
+	// ListAzurePrivateLinkServices returns the services in a resource group, or all
+	// when resourceGroup is empty, ordered by key.
+	ListAzurePrivateLinkServices(ctx context.Context, resourceGroup string) []AzurePrivateLinkService
+}


### PR DESCRIPTION
## What

Implements the standalone Azure **Private Link** surface (part of umbrella #611):

- **`Microsoft.Network/privateEndpoints`** — PUT/GET/DELETE + list-by-RG and list-by-subscription. Properties: `subnet`, `privateLinkServiceConnections`/`manualPrivateLinkServiceConnections` (`{name, privateLinkServiceId, groupIds, requestMessage, privateLinkServiceConnectionState{status,description}}`), `customNetworkInterfaceName`, and read-only `networkInterfaces` + `provisioningState`. A new connection is auto-approved (`status: Approved`) unless the request supplies a state.
- **`Microsoft.Network/privateLinkServices`** — PUT/GET/DELETE + list. Properties: `loadBalancerFrontendIpConfigurations`, `ipConfigurations`, `visibility`, `autoApproval`, `enableProxyProtocol`, `fqdns`, and read-only `alias` + `provisioningState`.

## Why

The Azure real-user deep-sweep (#611) flagged Private Link as entirely unimplemented; both resource types previously fell through to the vnet handler's 501 default. These are distinct from the per-service `privateEndpointConnections` sub-resources (e.g. cosmos-postgres, databricks), which each service models on its own.

## Design

- **Extends the existing vnet handler** (which owns `Microsoft.Network` and is already registered) — no `server/azure/azure.go` change — exactly mirroring the just-merged network-gateways PR (#933).
- Backed by a new **optional, type-asserted `AzurePrivateLink` driver capability** (Azure-only, like `AzureNetworkGateways`); AWS/GCP do not implement it, so the handler answers 501 when the driver lacks it.
- **LRO handling:** create returns a synchronous 200 with a terminal `provisioningState: Succeeded`, completing the armnetwork `Begin*` poller immediately; delete returns 202 + `Azure-AsyncOperation` pointing at the `locations/.../operationStatuses` path the vnet handler already serves. No poller hang.
- **Persistence:** two new identity-preserving memstores wired into `providers/azure/vnet/snapshot.go`'s `snapshotStores`/`restoreStores` lists. RG-delete cascade extended with a `purgePrivateLink` (endpoints purged before services).

## Tests

- **Real-SDK e2e** (`server/azure/vnet/private_link_test.go`): drives the real `armnetwork` `PrivateEndpointsClient` + `PrivateLinkServicesClient` through their `BeginCreateOrUpdate`/`Get`/`NewListPager`/`BeginDelete` pollers against an in-process cloudemu server — asserts create (pollers complete, no hang) → get/list → delete-then-404 for both, plus connection auto-approval. Reuses the existing armnetwork v1.1.0 (no dep bump).
- **Snapshot round-trip** (`providers/azure/vnet/snapshot_test.go`): seeds a private endpoint + private link service and asserts they survive snapshot/restore with their cross-references — fails if either store is dropped from the dump/restore lists.

## Scope

AWS and GCP are unchanged. `docs/coverage/` regenerated. No dependency bump; contrib submodules unaffected.
