### PR TITLE
feat(aws-ec2): Reserved Instances purchase/reporting + commitment source (#942)

### DIFF
--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -683,7 +683,12 @@ func New(d Drivers) *server.Server {
 	}
 
 	if d.EC2 != nil || d.VPC != nil {
-		srv.Register(ec2.New(d.EC2, d.VPC, d.AccountID))
+		// Clock/Region drive the EC2 handler's wire-only Reserved Instance surface
+		// (deterministic queued/active/retired timeline; region-tagged commitments
+		// and offering catalog). Its purchased reservations also implement
+		// cost.Commitments — union them with the Savings Plans source via
+		// cost.Combine for the CE reservation coverage/utilization consumer.
+		srv.Register(ec2.New(d.EC2, d.VPC, d.AccountID, ec2.WithClock(d.Clock), ec2.WithRegion(d.Region)))
 	}
 
 	if d.Lambda != nil {

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -7,9 +7,11 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+	"github.com/stackshy/cloudemu/v2/services/cost"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
@@ -43,19 +45,74 @@ type Handler struct {
 	// rest of the AWS server (STS/IAM/SQS/...) reports. Defaults to
 	// defaultAccountID when the caller passes an empty string.
 	accountID string
+	// ri holds the wire-only Reserved Instance purchase/reporting surface (a
+	// billing instrument, so no compute-driver method backs it). It is always
+	// initialized, so the RI actions work even when the handler is built without
+	// a clock/region (falling back to the real clock and a default region).
+	ri *riStore
+}
+
+// Option configures optional Handler behavior. Options are additive and
+// backward-compatible: existing New(c, v, accountID) callers keep working
+// unchanged, and only the wire server passes clock/region for deterministic
+// Reserved Instance timelines.
+type Option func(*Handler)
+
+// WithClock sets the clock driving the Reserved Instance queued/active/retired
+// timeline (nil = real clock). Tests inject a config.FakeClock for determinism.
+func WithClock(clock config.Clock) Option {
+	return func(h *Handler) { h.ri.clock = clockOrReal(clock) }
+}
+
+// WithRegion sets the region tagging purchased reservations and the RI
+// commitment scope, and seeds the offering catalog's AZ names.
+func WithRegion(region string) Option {
+	return func(h *Handler) {
+		if region != "" {
+			h.ri.region = region
+			h.ri.offerings = seedRIOfferings(region)
+		}
+	}
 }
 
 // New returns an EC2 handler backed by c and v. Either may be nil if only
 // one service is being emulated, though most workflows need both together.
 // accountID is the owner account echoed on resources; an empty string falls
-// back to defaultAccountID.
-func New(c computedriver.Compute, v netdriver.Networking, accountID string) *Handler {
+// back to defaultAccountID. Options configure the optional Reserved Instance
+// surface (clock/region); with none the RI ops run on the real clock.
+func New(c computedriver.Compute, v netdriver.Networking, accountID string, opts ...Option) *Handler {
 	if accountID == "" {
 		accountID = defaultAccountID
 	}
 
-	return &Handler{compute: c, vpc: v, accountID: accountID}
+	h := &Handler{
+		compute:   c,
+		vpc:       v,
+		accountID: accountID,
+		ri:        newRIStore("", nil),
+	}
+
+	for _, opt := range opts {
+		opt(h)
+	}
+
+	return h
 }
+
+// clockOrReal returns clock, or a real clock when clock is nil.
+func clockOrReal(clock config.Clock) config.Clock {
+	if clock == nil {
+		return config.RealClock{}
+	}
+
+	return clock
+}
+
+// Commitments exposes the Reserved Instance store as a cost.Commitments source,
+// so a later Cost Explorer coverage/utilization handler (billing-parity step 3)
+// can amortize the reservations purchased here. Union it with the Savings Plans
+// source via cost.Combine to price RI and SP commitments together.
+func (h *Handler) Commitments() cost.Commitments { return h.ri }
 
 // Matches returns true for EC2-shaped requests. EC2 uses the AWS query
 // protocol: either a POST with form-encoded body (the SDK default) or a GET
@@ -130,6 +187,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.routeMetadata,
 		h.routeInstanceStatus,
 		h.routeIamInstanceProfileAssociations,
+		h.routeReservedInstances,
 	}
 	for _, route := range routes {
 		if route(w, r, action) {

--- a/server/aws/ec2/reserved_instances.go
+++ b/server/aws/ec2/reserved_instances.go
@@ -1,0 +1,556 @@
+package ec2
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/services/cost"
+)
+
+// Reserved Instance lifecycle states (a subset of the ReservedInstanceState
+// enum). State is never frozen at purchase time — it is derived from the clock
+// on every read (effectiveState): queued before start, active in [start, end),
+// retired at or after end. A source RI retired by a modification is terminally
+// retired and short-circuits the time rule.
+const (
+	riStateActive  = "active"
+	riStateQueued  = "queued"
+	riStateRetired = "retired"
+)
+
+// Reserved Instance scope (Scope enum): whether the reservation applies across a
+// Region or is pinned to a single Availability Zone.
+const (
+	scopeRegion = "Region"
+	scopeAZ     = "Availability Zone"
+)
+
+// Offering classes (OfferingClassType enum).
+const (
+	offeringClassStandard    = "standard"
+	offeringClassConvertible = "convertible"
+)
+
+// Offering types (OfferingTypeValues enum) — the modern payment-option-named
+// offering types.
+const (
+	offeringTypeAllUpfront     = "All Upfront"
+	offeringTypePartialUpfront = "Partial Upfront"
+	offeringTypeNoUpfront      = "No Upfront"
+)
+
+// Term durations in seconds: a one-year and a three-year commitment.
+const (
+	riTermOneYear   = int64(365 * 24 * 60 * 60)
+	riTermThreeYear = 3 * riTermOneYear
+)
+
+// riCurrencyUSD is the only currency the seeded catalog prices in (ISO 4217).
+const riCurrencyUSD = "USD"
+
+// recurringFrequencyHourly is the RecurringCharge frequency for a per-hour charge.
+const recurringFrequencyHourly = "Hourly"
+
+// Default RIProductDescription values the seeded catalog quotes.
+const (
+	productLinuxUNIX = "Linux/UNIX"
+	productWindows   = "Windows"
+)
+
+// defaultRIRegion tags reservations and Commitment scope when the handler is
+// constructed without an explicit region.
+const defaultRIRegion = "us-east-1"
+
+// reservedInstance is one purchased Reserved Instance. State lives only in the
+// wire server (no portable driver represents RIs — it is a billing instrument,
+// not a compute resource), so the EC2 handler owns this shape directly, exactly
+// as the Savings Plans handler owns its plan shape.
+type reservedInstance struct {
+	id                 string
+	offeringID         string
+	instanceType       string
+	availabilityZone   string
+	scope              string
+	duration           int64
+	start              time.Time
+	end                time.Time
+	fixedPrice         float64
+	usagePrice         float64
+	recurringHourly    float64
+	instanceCount      int32
+	productDescription string
+	instanceTenancy    string
+	offeringClass      string
+	offeringType       string
+	currencyCode       string
+	tags               map[string]string
+	// retired marks a source RI that a ModifyReservedInstances request replaced.
+	// It is terminal and sticky, short-circuiting the clock-derived state so a
+	// modified reservation never reports active again.
+	retired bool
+}
+
+// effectiveState resolves an RI's current state from now rather than a value
+// frozen at purchase: queued until start, active in [start, end), retired at or
+// after end. A reservation retired by a modification stays retired regardless of
+// the clock.
+func (ri *reservedInstance) effectiveState(now time.Time) string {
+	if ri.retired {
+		return riStateRetired
+	}
+
+	switch {
+	case now.Before(ri.start):
+		return riStateQueued
+	case now.Before(ri.end):
+		return riStateActive
+	default:
+		return riStateRetired
+	}
+}
+
+// riOffering is one entry in the seeded DescribeReservedInstancesOfferings
+// catalog. A PurchaseReservedInstancesOffering request names an offering by id;
+// the purchased reservation inherits the offering's terms.
+type riOffering struct {
+	id                 string
+	instanceType       string
+	availabilityZone   string
+	scope              string
+	duration           int64
+	fixedPrice         float64
+	usagePrice         float64
+	recurringHourly    float64
+	productDescription string
+	instanceTenancy    string
+	offeringClass      string
+	offeringType       string
+	marketplace        bool
+	// pricingTiers are the volume-discount PricingDetail rows (count, price).
+	pricingTiers []pricingTier
+}
+
+// pricingTier is one PricingDetail row: the number of reservations available at
+// the given per-instance price.
+type pricingTier struct {
+	count int32
+	price float64
+}
+
+// riModification is one recorded ModifyReservedInstances request. The emulator
+// settles instantly, so a recorded modification lands "fulfilled" immediately —
+// no request lingers in "processing".
+type riModification struct {
+	id            string
+	clientToken   string
+	status        string
+	createDate    time.Time
+	updateDate    time.Time
+	effectiveDate time.Time
+	sourceIDs     []string
+	results       []modificationResult
+}
+
+// modificationResult links a target configuration to the RI created to satisfy
+// it. reservedInstancesID is populated because the emulator fulfills instantly.
+type modificationResult struct {
+	reservedInstancesID string
+	availabilityZone    string
+	instanceCount       int32
+	instanceType        string
+	platform            string
+	scope               string
+}
+
+// riStore is the in-memory backing state for the EC2 handler's Reserved Instance
+// surface. The purchased set and modification log are memstore.Stores; the
+// offering catalog is static (seeded at construction). It is wire-server state
+// (like the Savings Plans store), not a provider mock, so it needs no persist
+// Snapshottable wiring.
+type riStore struct {
+	mu     sync.Mutex
+	clock  config.Clock
+	region string
+
+	instances     *memstore.Store[*reservedInstance]
+	modifications *memstore.Store[*riModification]
+	offerings     []riOffering
+	byModToken    map[string]string // clientToken -> modificationId, for idempotency
+}
+
+// newRIStore returns a Reserved Instance store with the offering catalog seeded.
+// A nil clock falls back to the real clock so deterministic tests inject a
+// FakeClock; an empty region falls back to defaultRIRegion.
+func newRIStore(region string, clock config.Clock) *riStore {
+	if clock == nil {
+		clock = config.RealClock{}
+	}
+
+	if region == "" {
+		region = defaultRIRegion
+	}
+
+	return &riStore{
+		clock:         clock,
+		region:        region,
+		instances:     memstore.New[*reservedInstance](),
+		modifications: memstore.New[*riModification](),
+		offerings:     seedRIOfferings(region),
+		byModToken:    map[string]string{},
+	}
+}
+
+// seedRIOfferings returns a representative Reserved Instance offering catalog
+// spanning the standard/convertible offering classes, both term lengths, all
+// three payment (offering) types, Region and AZ scopes, and the Linux/UNIX and
+// Windows product descriptions.
+func seedRIOfferings(region string) []riOffering {
+	az := region + "a"
+
+	return []riOffering{
+		{
+			id: "649fd0c8-1yr-std-noupfront", instanceType: "t3.medium", scope: scopeRegion,
+			duration: riTermOneYear, recurringHourly: 0.0308,
+			productDescription: productLinuxUNIX, instanceTenancy: tenancyDefault,
+			offeringClass: offeringClassStandard, offeringType: offeringTypeNoUpfront,
+			pricingTiers: []pricingTier{{count: 10, price: 0}},
+		},
+		{
+			id: "438012d3-3yr-std-allupfront", instanceType: "m5.large", scope: scopeRegion,
+			duration: riTermThreeYear, fixedPrice: 1200,
+			productDescription: productLinuxUNIX, instanceTenancy: tenancyDefault,
+			offeringClass: offeringClassStandard, offeringType: offeringTypeAllUpfront,
+			pricingTiers: []pricingTier{{count: 10, price: 1200}, {count: 40, price: 1150}},
+		},
+		{
+			id: "7c3e91a0-1yr-conv-partial", instanceType: "m5.large", availabilityZone: az, scope: scopeAZ,
+			duration: riTermOneYear, fixedPrice: 480, recurringHourly: 0.028,
+			productDescription: productLinuxUNIX, instanceTenancy: tenancyDefault,
+			offeringClass: offeringClassConvertible, offeringType: offeringTypePartialUpfront,
+			pricingTiers: []pricingTier{{count: 10, price: 480}},
+		},
+		{
+			id: "b19a44f5-1yr-std-noupfront-win", instanceType: "c5.xlarge", scope: scopeRegion,
+			duration: riTermOneYear, usagePrice: 0.10, recurringHourly: 0.121,
+			productDescription: productWindows, instanceTenancy: tenancyDefault,
+			offeringClass: offeringClassStandard, offeringType: offeringTypeNoUpfront,
+			pricingTiers: []pricingTier{{count: 10, price: 0}},
+		},
+	}
+}
+
+// findOffering returns the seeded offering with the given id.
+func (s *riStore) findOffering(id string) (*riOffering, bool) {
+	for i := range s.offerings {
+		if s.offerings[i].id == id {
+			return &s.offerings[i], true
+		}
+	}
+
+	return nil, false
+}
+
+// purchaseInput is the decoded PurchaseReservedInstancesOffering request.
+type purchaseInput struct {
+	offeringID    string
+	instanceCount int32
+	limitPrice    *float64
+	purchaseTime  time.Time
+}
+
+// purchase buys a Reserved Instance against a seeded offering. A future
+// purchaseTime queues the reservation (state queued, effective from that time);
+// otherwise it is immediately active. A LimitPrice below the offering's total
+// fixed price is rejected (marketplace price protection), matching the real API.
+func (s *riStore) purchase(in *purchaseInput) (string, error) {
+	off, ok := s.findOffering(in.offeringID)
+	if !ok {
+		return "", cerrors.Newf(cerrors.InvalidArgument, "reserved instances offering not found: %s", in.offeringID)
+	}
+
+	count := in.instanceCount
+	if count < 1 {
+		count = 1
+	}
+
+	if in.limitPrice != nil && off.fixedPrice*float64(count) > *in.limitPrice {
+		return "", cerrors.Newf(cerrors.InvalidArgument,
+			"total price exceeds LimitPrice %.2f", *in.limitPrice)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.clock.Now().UTC()
+	start := now
+
+	if in.purchaseTime.After(now) {
+		start = in.purchaseTime.UTC()
+	}
+
+	id := idgen.UUID()
+	s.instances.Set(id, &reservedInstance{
+		id:                 id,
+		offeringID:         off.id,
+		instanceType:       off.instanceType,
+		availabilityZone:   off.availabilityZone,
+		scope:              off.scope,
+		duration:           off.duration,
+		start:              start,
+		end:                start.Add(time.Duration(off.duration) * time.Second),
+		fixedPrice:         off.fixedPrice,
+		usagePrice:         off.usagePrice,
+		recurringHourly:    off.recurringHourly,
+		instanceCount:      count,
+		productDescription: off.productDescription,
+		instanceTenancy:    off.instanceTenancy,
+		offeringClass:      off.offeringClass,
+		offeringType:       off.offeringType,
+		currencyCode:       riCurrencyUSD,
+	})
+
+	return id, nil
+}
+
+// describe returns the reservations matching f, in ascending id order for
+// deterministic output. Each returned reservation is a copy carrying its
+// clock-derived effective state resolved at now, so a describe reflects
+// lifecycle transitions without mutating stored state.
+func (s *riStore) describe(f riFilter, now time.Time) []*reservedInstance {
+	all := s.instances.All()
+	out := make([]*reservedInstance, 0, len(all))
+
+	for _, ri := range all {
+		if !f.matches(ri, ri.effectiveState(now)) {
+			continue
+		}
+
+		view := *ri
+		out = append(out, &view)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].id < out[j].id })
+
+	return out
+}
+
+// modifyInput is the decoded ModifyReservedInstances request.
+type modifyInput struct {
+	clientToken   string
+	reservedIDs   []string
+	targetConfigs []targetConfig
+}
+
+// targetConfig is one requested ReservedInstancesConfiguration target.
+type targetConfig struct {
+	availabilityZone string
+	instanceCount    int32
+	instanceType     string
+	platform         string
+	scope            string
+}
+
+// modify records a ModifyReservedInstances request and settles it instantly:
+// each target configuration mints a new active reservation (inheriting the
+// source terms, with the AZ/count/type/platform/scope overrides applied) and the
+// source reservations are terminally retired. The net hourly commitment is
+// preserved — the new reservations replace the retired sources in the
+// Commitments feed. A repeated clientToken is idempotent.
+func (s *riStore) modify(in *modifyInput) (string, error) {
+	if len(in.reservedIDs) == 0 || len(in.targetConfigs) == 0 {
+		return "", cerrors.New(cerrors.InvalidArgument,
+			"ModifyReservedInstances requires reserved instance ids and target configurations")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if in.clientToken != "" {
+		if id, seen := s.byModToken[in.clientToken]; seen {
+			return id, nil
+		}
+	}
+
+	now := s.clock.Now().UTC()
+	sources := make([]*reservedInstance, 0, len(in.reservedIDs))
+
+	for _, id := range in.reservedIDs {
+		ri, ok := s.instances.Get(id)
+		if !ok {
+			return "", cerrors.Newf(cerrors.NotFound, "reserved instance not found: %s", id)
+		}
+
+		if state := ri.effectiveState(now); state != riStateActive {
+			return "", cerrors.Newf(cerrors.FailedPrecondition,
+				"reserved instance %s is %s, only active reservations can be modified", id, state)
+		}
+
+		sources = append(sources, ri)
+	}
+
+	return s.applyModification(in, sources, now), nil
+}
+
+// applyModification mints the target reservations, retires the sources and
+// records the (instantly fulfilled) modification. The caller holds s.mu.
+func (s *riStore) applyModification(in *modifyInput, sources []*reservedInstance, now time.Time) string {
+	tmpl := sources[0]
+	results := make([]modificationResult, 0, len(in.targetConfigs))
+
+	for _, tc := range in.targetConfigs {
+		newRI := reservationFromTarget(tmpl, tc, now)
+		s.instances.Set(newRI.id, newRI)
+
+		results = append(results, modificationResult{
+			reservedInstancesID: newRI.id,
+			availabilityZone:    newRI.availabilityZone,
+			instanceCount:       newRI.instanceCount,
+			instanceType:        newRI.instanceType,
+			platform:            newRI.productDescription,
+			scope:               newRI.scope,
+		})
+	}
+
+	sourceIDs := make([]string, len(sources))
+
+	for i, src := range sources {
+		src.retired = true
+		s.instances.Set(src.id, src)
+		sourceIDs[i] = src.id
+	}
+
+	modID := idgen.UUID()
+	s.modifications.Set(modID, &riModification{
+		id:            modID,
+		clientToken:   in.clientToken,
+		status:        "fulfilled",
+		createDate:    now,
+		updateDate:    now,
+		effectiveDate: now,
+		sourceIDs:     sourceIDs,
+		results:       results,
+	})
+
+	if in.clientToken != "" {
+		s.byModToken[in.clientToken] = modID
+	}
+
+	return modID
+}
+
+// reservationFromTarget mints a new active reservation from a source template
+// with a target configuration's overrides applied. The new reservation keeps the
+// source's remaining term (same end), so the modification neither extends nor
+// shortens the commitment.
+func reservationFromTarget(tmpl *reservedInstance, tc targetConfig, now time.Time) *reservedInstance {
+	newRI := *tmpl
+	newRI.id = idgen.UUID()
+	newRI.retired = false
+	newRI.start = now
+	newRI.tags = nil
+
+	if tc.availabilityZone != "" {
+		newRI.availabilityZone = tc.availabilityZone
+	}
+
+	if tc.instanceCount > 0 {
+		newRI.instanceCount = tc.instanceCount
+	}
+
+	if tc.instanceType != "" {
+		newRI.instanceType = tc.instanceType
+	}
+
+	if tc.platform != "" {
+		newRI.productDescription = tc.platform
+	}
+
+	if tc.scope != "" {
+		newRI.scope = tc.scope
+	}
+
+	return &newRI
+}
+
+// describeModifications returns the recorded modifications matching the id and
+// client-token filters, in ascending id order.
+func (s *riStore) describeModifications(ids, clientTokens []string) []*riModification {
+	idSet := toStringSet(ids)
+	tokenSet := toStringSet(clientTokens)
+
+	all := s.modifications.All()
+	out := make([]*riModification, 0, len(all))
+
+	for _, m := range all {
+		if len(idSet) > 0 {
+			if _, ok := idSet[m.id]; !ok {
+				continue
+			}
+		}
+
+		if len(tokenSet) > 0 {
+			if _, ok := tokenSet[m.clientToken]; !ok {
+				continue
+			}
+		}
+
+		out = append(out, m)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].id < out[j].id })
+
+	return out
+}
+
+// ListActive satisfies cost.Commitments: it returns every Reserved Instance
+// whose clock-derived effective state at instant at is active, normalized to the
+// provider-agnostic cost.Commitment shape the billing engine amortizes. The
+// hourly commitment is the reservation's recurring hourly charge times its
+// instance count — the effective dollar commitment per hour. State is resolved
+// from at (not purchase), so an RI bought with a future purchaseTime starts
+// feeding commitments once at reaches its start, and an expired reservation
+// drops out at its end. A later Cost Explorer coverage/utilization handler
+// (billing-parity step 3) reads real purchased commitments through this,
+// alongside the Savings Plans source (union them via cost.Combine).
+func (s *riStore) ListActive(_ context.Context, at time.Time) ([]cost.Commitment, error) {
+	var out []cost.Commitment
+
+	for _, ri := range s.instances.All() {
+		if ri.effectiveState(at) != riStateActive {
+			continue
+		}
+
+		out = append(out, cost.Commitment{
+			ID:                  ri.id,
+			Provider:            "aws",
+			Kind:                cost.KindReservedInstance,
+			Scope:               s.region,
+			HourlyCommitmentUSD: ri.recurringHourly * float64(ri.instanceCount),
+			Start:               ri.start,
+			End:                 ri.end,
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+
+	return out, nil
+}
+
+func toStringSet(items []string) map[string]struct{} {
+	if len(items) == 0 {
+		return nil
+	}
+
+	out := make(map[string]struct{}, len(items))
+	for _, i := range items {
+		out[i] = struct{}{}
+	}
+
+	return out
+}

--- a/server/aws/ec2/reserved_instances_test.go
+++ b/server/aws/ec2/reserved_instances_test.go
@@ -1,0 +1,371 @@
+package ec2_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	cloudconfig "github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/server"
+	ec2srv "github.com/stackshy/cloudemu/v2/server/aws/ec2"
+	"github.com/stackshy/cloudemu/v2/services/cost"
+)
+
+// newRIClient wires a standalone EC2 handler (no compute/VPC driver — the
+// Reserved Instance surface is wire-only) with a FakeClock the test controls,
+// and returns a real aws-sdk-go-v2 EC2 client plus the handler and clock. The
+// handler is returned so tests can read its cost.Commitments feed directly, the
+// seam the Cost Explorer reservation consumer (billing-parity step 3) uses.
+func newRIClient(t *testing.T) (*awsec2.Client, *ec2srv.Handler, *cloudconfig.FakeClock) {
+	t.Helper()
+
+	fc := cloudconfig.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	h := ec2srv.New(nil, nil, "000000000000", ec2srv.WithClock(fc), ec2srv.WithRegion("us-east-1"))
+
+	srv := server.New()
+	srv.Register(h)
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	cfg.BaseEndpoint = aws.String(ts.URL)
+
+	return awsec2.NewFromConfig(cfg), h, fc
+}
+
+// TestReservedInstancesOfferingsAndPurchase exercises the offering catalog, an
+// immediate purchase (active now) and the DescribeReservedInstances readback
+// through the real SDK wire path.
+func TestReservedInstancesOfferingsAndPurchase(t *testing.T) {
+	ctx := context.Background()
+	client, h, fc := newRIClient(t)
+
+	offs, err := client.DescribeReservedInstancesOfferings(ctx, &awsec2.DescribeReservedInstancesOfferingsInput{})
+	if err != nil {
+		t.Fatalf("DescribeReservedInstancesOfferings: %v", err)
+	}
+
+	if len(offs.ReservedInstancesOfferings) == 0 {
+		t.Fatal("offerings catalog is empty, want a seeded set")
+	}
+
+	// The seeded catalog must expose volume-tier pricing details and recurring
+	// charges — the fields a real client reads when comparing offerings.
+	var offeringID string
+
+	for i := range offs.ReservedInstancesOfferings {
+		o := offs.ReservedInstancesOfferings[i]
+		if aws.ToString(o.ReservedInstancesOfferingId) == "649fd0c8-1yr-std-noupfront" {
+			offeringID = aws.ToString(o.ReservedInstancesOfferingId)
+
+			if len(o.PricingDetails) == 0 {
+				t.Error("offering missing pricingDetailsSet")
+			}
+
+			if len(o.RecurringCharges) == 0 {
+				t.Error("no-upfront offering missing recurringCharges")
+			}
+		}
+	}
+
+	if offeringID == "" {
+		t.Fatal("seeded offering 649fd0c8-1yr-std-noupfront not found")
+	}
+
+	pur, err := client.PurchaseReservedInstancesOffering(ctx, &awsec2.PurchaseReservedInstancesOfferingInput{
+		ReservedInstancesOfferingId: aws.String(offeringID),
+		InstanceCount:               aws.Int32(3),
+	})
+	if err != nil {
+		t.Fatalf("PurchaseReservedInstancesOffering: %v", err)
+	}
+
+	riID := aws.ToString(pur.ReservedInstancesId)
+	if riID == "" {
+		t.Fatal("purchase returned no reservedInstancesId")
+	}
+
+	desc, err := client.DescribeReservedInstances(ctx, &awsec2.DescribeReservedInstancesInput{
+		ReservedInstancesIds: []string{riID},
+	})
+	if err != nil {
+		t.Fatalf("DescribeReservedInstances: %v", err)
+	}
+
+	if len(desc.ReservedInstances) != 1 {
+		t.Fatalf("describe returned %d reservations, want 1", len(desc.ReservedInstances))
+	}
+
+	ri := desc.ReservedInstances[0]
+	if ri.State != ec2types.ReservedInstanceStateActive {
+		t.Fatalf("purchased-now reservation state = %q, want active", ri.State)
+	}
+
+	if aws.ToInt32(ri.InstanceCount) != 3 {
+		t.Fatalf("instanceCount = %d, want 3", aws.ToInt32(ri.InstanceCount))
+	}
+
+	// The commitment feed reports the reservation as active immediately, with an
+	// hourly commitment of recurringHourly (0.0308) * instanceCount (3).
+	assertActiveCommitment(t, h, fc.Now(), riID, 0.0308*3)
+}
+
+// TestReservedInstancesLazyClockState pins the clock-derived lifecycle a future
+// purchase walks through — queued, then active once the clock reaches its start,
+// then retired once past its end — asserting both the wire DescribeReservedInstances
+// state AND the cost.Commitments feed at each instant (the #944 clock-advance gap).
+func TestReservedInstancesLazyClockState(t *testing.T) {
+	ctx := context.Background()
+	client, h, fc := newRIClient(t)
+
+	// A one-year offering purchased with a future purchaseTime (30 days out).
+	start := fc.Now().Add(30 * 24 * time.Hour)
+
+	pur, err := client.PurchaseReservedInstancesOffering(ctx, &awsec2.PurchaseReservedInstancesOfferingInput{
+		ReservedInstancesOfferingId: aws.String("649fd0c8-1yr-std-noupfront"),
+		InstanceCount:               aws.Int32(1),
+		PurchaseTime:                aws.Time(start),
+	})
+	if err != nil {
+		t.Fatalf("PurchaseReservedInstancesOffering: %v", err)
+	}
+
+	riID := aws.ToString(pur.ReservedInstancesId)
+
+	// Before start: queued on the wire, absent from the commitment feed.
+	if got := describeState(ctx, t, client, riID); got != ec2types.ReservedInstanceStateQueued {
+		t.Fatalf("state before start = %q, want queued", got)
+	}
+
+	assertNoCommitment(t, h, fc.Now(), riID)
+
+	// Advance past start: active on the wire, present in the feed.
+	fc.Advance(31 * 24 * time.Hour)
+
+	if got := describeState(ctx, t, client, riID); got != ec2types.ReservedInstanceStateActive {
+		t.Fatalf("state after start = %q, want active", got)
+	}
+
+	assertActiveCommitment(t, h, fc.Now(), riID, 0.0308)
+
+	// Advance past end (one year total): retired on the wire, excluded from the feed.
+	fc.Advance(365 * 24 * time.Hour)
+
+	if got := describeState(ctx, t, client, riID); got != ec2types.ReservedInstanceStateRetired {
+		t.Fatalf("state after end = %q, want retired", got)
+	}
+
+	assertNoCommitment(t, h, fc.Now(), riID)
+}
+
+// TestReservedInstancesCombineWithSavingsPlans proves the RI commitment source
+// unions cleanly with another source via cost.Combine — the seam the Cost
+// Explorer consumer uses to price RI and Savings Plans commitments together.
+func TestReservedInstancesCombineWithSavingsPlans(t *testing.T) {
+	ctx := context.Background()
+	client, h, fc := newRIClient(t)
+
+	if _, err := client.PurchaseReservedInstancesOffering(ctx, &awsec2.PurchaseReservedInstancesOfferingInput{
+		ReservedInstancesOfferingId: aws.String("649fd0c8-1yr-std-noupfront"),
+		InstanceCount:               aws.Int32(2),
+	}); err != nil {
+		t.Fatalf("purchase: %v", err)
+	}
+
+	other := staticCommitments{{ID: "sp-1", Kind: cost.KindSavingsPlan, HourlyCommitmentUSD: 1.0,
+		Start: fc.Now().Add(-time.Hour), End: fc.Now().Add(time.Hour)}}
+
+	combined := cost.Combine(h.Commitments(), other)
+
+	got, err := combined.ListActive(ctx, fc.Now())
+	if err != nil {
+		t.Fatalf("combined ListActive: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("combined feed returned %d commitments, want 2 (1 RI + 1 SP)", len(got))
+	}
+
+	var haveRI, haveSP bool
+
+	for _, c := range got {
+		switch c.Kind {
+		case cost.KindReservedInstance:
+			haveRI = true
+		case cost.KindSavingsPlan:
+			haveSP = true
+		}
+	}
+
+	if !haveRI || !haveSP {
+		t.Fatalf("combined feed missing a kind: RI=%v SP=%v", haveRI, haveSP)
+	}
+}
+
+// TestReservedInstancesModify settles a modification instantly: the source is
+// retired and a new active reservation with the target configuration replaces
+// it, preserving the net commitment.
+func TestReservedInstancesModify(t *testing.T) {
+	ctx := context.Background()
+	client, h, fc := newRIClient(t)
+
+	pur, err := client.PurchaseReservedInstancesOffering(ctx, &awsec2.PurchaseReservedInstancesOfferingInput{
+		ReservedInstancesOfferingId: aws.String("649fd0c8-1yr-std-noupfront"),
+		InstanceCount:               aws.Int32(4),
+	})
+	if err != nil {
+		t.Fatalf("purchase: %v", err)
+	}
+
+	sourceID := aws.ToString(pur.ReservedInstancesId)
+
+	mod, err := client.ModifyReservedInstances(ctx, &awsec2.ModifyReservedInstancesInput{
+		ReservedInstancesIds: []string{sourceID},
+		TargetConfigurations: []ec2types.ReservedInstancesConfiguration{
+			{AvailabilityZone: aws.String("us-east-1b"), InstanceCount: aws.Int32(4)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ModifyReservedInstances: %v", err)
+	}
+
+	if aws.ToString(mod.ReservedInstancesModificationId) == "" {
+		t.Fatal("modify returned no modification id")
+	}
+
+	mods, err := client.DescribeReservedInstancesModifications(ctx,
+		&awsec2.DescribeReservedInstancesModificationsInput{})
+	if err != nil {
+		t.Fatalf("DescribeReservedInstancesModifications: %v", err)
+	}
+
+	if len(mods.ReservedInstancesModifications) != 1 {
+		t.Fatalf("got %d modifications, want 1", len(mods.ReservedInstancesModifications))
+	}
+
+	rec := mods.ReservedInstancesModifications[0]
+	if got := aws.ToString(rec.Status); got != "fulfilled" {
+		t.Fatalf("modification status = %q, want fulfilled (instant settle)", got)
+	}
+
+	// The source id round-trips through the nested reservedInstancesSet list, and
+	// the modification result names a newly minted target reservation.
+	if len(rec.ReservedInstancesIds) != 1 || aws.ToString(rec.ReservedInstancesIds[0].ReservedInstancesId) != sourceID {
+		t.Fatalf("modification reservedInstancesIds = %+v, want [%s]", rec.ReservedInstancesIds, sourceID)
+	}
+
+	if len(rec.ModificationResults) != 1 || aws.ToString(rec.ModificationResults[0].ReservedInstancesId) == "" {
+		t.Fatalf("modification result missing target reservation id: %+v", rec.ModificationResults)
+	}
+
+	// The source is retired; exactly one active reservation (the target) remains,
+	// so the commitment feed still reports a single active RI.
+	if got := describeState(ctx, t, client, sourceID); got != ec2types.ReservedInstanceStateRetired {
+		t.Fatalf("source state after modify = %q, want retired", got)
+	}
+
+	active, err := h.Commitments().ListActive(ctx, fc.Now())
+	if err != nil {
+		t.Fatalf("ListActive: %v", err)
+	}
+
+	if len(active) != 1 {
+		t.Fatalf("active commitments after modify = %d, want 1 (target replaces source)", len(active))
+	}
+}
+
+// describeState reads one reservation's clock-derived state through the wire.
+func describeState(
+	ctx context.Context, t *testing.T, client *awsec2.Client, riID string,
+) ec2types.ReservedInstanceState {
+	t.Helper()
+
+	desc, err := client.DescribeReservedInstances(ctx, &awsec2.DescribeReservedInstancesInput{
+		ReservedInstancesIds: []string{riID},
+	})
+	if err != nil {
+		t.Fatalf("DescribeReservedInstances: %v", err)
+	}
+
+	if len(desc.ReservedInstances) != 1 {
+		t.Fatalf("describe returned %d reservations, want 1", len(desc.ReservedInstances))
+	}
+
+	return desc.ReservedInstances[0].State
+}
+
+// assertActiveCommitment asserts the feed reports riID active at instant at with
+// the expected hourly commitment.
+func assertActiveCommitment(t *testing.T, h *ec2srv.Handler, at time.Time, riID string, wantHourly float64) {
+	t.Helper()
+
+	got, err := h.Commitments().ListActive(context.Background(), at)
+	if err != nil {
+		t.Fatalf("ListActive: %v", err)
+	}
+
+	for _, c := range got {
+		if c.ID != riID {
+			continue
+		}
+
+		if c.Kind != cost.KindReservedInstance {
+			t.Errorf("commitment kind = %q, want ReservedInstance", c.Kind)
+		}
+
+		const eps = 1e-9
+		if diff := c.HourlyCommitmentUSD - wantHourly; diff > eps || diff < -eps {
+			t.Errorf("hourly commitment = %v, want %v", c.HourlyCommitmentUSD, wantHourly)
+		}
+
+		return
+	}
+
+	t.Fatalf("reservation %s not active in commitment feed at %v", riID, at)
+}
+
+// assertNoCommitment asserts riID is absent from the feed at instant at.
+func assertNoCommitment(t *testing.T, h *ec2srv.Handler, at time.Time, riID string) {
+	t.Helper()
+
+	got, err := h.Commitments().ListActive(context.Background(), at)
+	if err != nil {
+		t.Fatalf("ListActive: %v", err)
+	}
+
+	for _, c := range got {
+		if c.ID == riID {
+			t.Fatalf("reservation %s must not be in the commitment feed at %v (state not active)", riID, at)
+		}
+	}
+}
+
+// staticCommitments is a fixed cost.Commitments source for exercising cost.Combine.
+type staticCommitments []cost.Commitment
+
+func (s staticCommitments) ListActive(_ context.Context, at time.Time) ([]cost.Commitment, error) {
+	var out []cost.Commitment
+
+	for _, c := range s {
+		if !at.Before(c.Start) && at.Before(c.End) {
+			out = append(out, c)
+		}
+	}
+
+	return out, nil
+}

--- a/server/aws/ec2/reserved_instances_wire.go
+++ b/server/aws/ec2/reserved_instances_wire.go
@@ -1,0 +1,542 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+)
+
+// timeLayout is the RFC3339 layout EC2 uses for reservation timestamps.
+const timeLayout = time.RFC3339
+
+// Reserved Instance describe filter names. filterAvailabilityZone (volume.go)
+// and filterState (networking_common.go) are shared with the other EC2 handlers.
+const (
+	riFilterProductDescription = "product-description"
+	riFilterInstanceType       = "instance-type"
+	riFilterScope              = "scope"
+	riFilterInstanceTenancy    = "instance-tenancy"
+	riFilterDuration           = "duration"
+	riFilterOfferingClass      = "offering-class"
+	riFilterOfferingType       = "offering-type"
+	riFilterMarketplace        = "marketplace"
+	riFilterClientToken        = "client-token"
+)
+
+// routeReservedInstances dispatches the Reserved Instance billing actions. It is
+// additive: it claims only RI actions and returns false for everything else, so
+// the rest of the EC2 handler is unaffected. When the handler was constructed
+// without a clock/region (the RI store is always initialized, so this is never
+// nil), the ops run against the real clock.
+func (h *Handler) routeReservedInstances(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
+	case "DescribeReservedInstancesOfferings":
+		h.describeReservedInstancesOfferings(w, r)
+	case "PurchaseReservedInstancesOffering":
+		h.purchaseReservedInstancesOffering(w, r)
+	case "DescribeReservedInstances":
+		h.describeReservedInstances(w, r)
+	case "ModifyReservedInstances":
+		h.modifyReservedInstances(w, r)
+	case "DescribeReservedInstancesModifications":
+		h.describeReservedInstancesModifications(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// riFilter is the parsed DescribeReservedInstances predicate: an explicit id set
+// plus attribute filters. A reservation matches when it satisfies every
+// populated dimension (AND across dimensions, OR within a value list).
+type riFilter struct {
+	ids   map[string]struct{}
+	attrs []awsquery.Filter
+}
+
+// matches reports whether ri satisfies the filter. state is the reservation's
+// clock-derived effective state (passed in rather than read from a stored field)
+// so the state filter matches the live lifecycle.
+func (f riFilter) matches(ri *reservedInstance, state string) bool {
+	if len(f.ids) > 0 {
+		if _, ok := f.ids[ri.id]; !ok {
+			return false
+		}
+	}
+
+	for _, attr := range f.attrs {
+		if !riAttrMatches(ri, state, attr) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// riAttrMatches reports whether ri satisfies one attribute filter. An unknown
+// filter name is tolerated (matches), mirroring the permissive real API.
+func riAttrMatches(ri *reservedInstance, state string, attr awsquery.Filter) bool {
+	var got string
+
+	switch attr.Name {
+	case filterAvailabilityZone:
+		got = ri.availabilityZone
+	case riFilterDuration:
+		got = strconv.FormatInt(ri.duration, 10)
+	case riFilterProductDescription:
+		got = ri.productDescription
+	case filterState:
+		got = state
+	case riFilterInstanceType:
+		got = ri.instanceType
+	case riFilterScope:
+		got = ri.scope
+	case riFilterInstanceTenancy:
+		got = ri.instanceTenancy
+	case riFilterOfferingClass:
+		got = ri.offeringClass
+	case riFilterOfferingType:
+		got = ri.offeringType
+	default:
+		return true
+	}
+
+	return containsString(attr.Values, got)
+}
+
+// --- DescribeReservedInstancesOfferings -----------------------------------
+
+func (h *Handler) describeReservedInstancesOfferings(w http.ResponseWriter, r *http.Request) {
+	offeringIDs := toStringSet(awsquery.ListStrings(r.Form, "ReservedInstancesOfferingId"))
+	instanceType := r.Form.Get("InstanceType")
+	offeringClass := r.Form.Get("OfferingClass")
+	offeringType := r.Form.Get("OfferingType")
+	filters := awsquery.Filters(r.Form)
+
+	out := make([]riOfferingXML, 0, len(h.ri.offerings))
+
+	for i := range h.ri.offerings {
+		o := &h.ri.offerings[i]
+
+		if len(offeringIDs) > 0 {
+			if _, ok := offeringIDs[o.id]; !ok {
+				continue
+			}
+		}
+
+		if !offeringMatches(o, instanceType, offeringClass, offeringType, filters) {
+			continue
+		}
+
+		out = append(out, toRIOfferingXML(o))
+	}
+
+	awsquery.WriteXMLResponse(w, describeRIOfferingsResponse{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Offerings: out,
+	})
+}
+
+// offeringMatches applies the DescribeReservedInstancesOfferings scalar
+// parameters and Filter.N predicates to one offering.
+func offeringMatches(
+	o *riOffering, instanceType, offeringClass, offeringType string, filters []awsquery.Filter,
+) bool {
+	if instanceType != "" && o.instanceType != instanceType {
+		return false
+	}
+
+	if offeringClass != "" && o.offeringClass != offeringClass {
+		return false
+	}
+
+	if offeringType != "" && o.offeringType != offeringType {
+		return false
+	}
+
+	for _, filter := range filters {
+		if !offeringAttrMatches(o, filter) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func offeringAttrMatches(o *riOffering, filter awsquery.Filter) bool {
+	var got string
+
+	switch filter.Name {
+	case riFilterInstanceType:
+		got = o.instanceType
+	case riFilterProductDescription:
+		got = o.productDescription
+	case filterAvailabilityZone:
+		got = o.availabilityZone
+	case riFilterScope:
+		got = o.scope
+	case riFilterMarketplace:
+		got = strconv.FormatBool(o.marketplace)
+	default:
+		return true
+	}
+
+	return containsString(filter.Values, got)
+}
+
+// --- PurchaseReservedInstancesOffering ------------------------------------
+
+func (h *Handler) purchaseReservedInstancesOffering(w http.ResponseWriter, r *http.Request) {
+	in := &purchaseInput{
+		offeringID:    r.Form.Get("ReservedInstancesOfferingId"),
+		instanceCount: parseInt32(r.Form.Get("InstanceCount")),
+	}
+
+	if raw := r.Form.Get("LimitPrice.Amount"); raw != "" {
+		if amt, err := strconv.ParseFloat(raw, 64); err == nil {
+			in.limitPrice = &amt
+		}
+	}
+
+	if raw := r.Form.Get("PurchaseTime"); raw != "" {
+		if t, err := time.Parse(timeLayout, raw); err == nil {
+			in.purchaseTime = t
+		}
+	}
+
+	id, err := h.ri.purchase(in)
+	if err != nil {
+		writeRIErr(w, err)
+
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, purchaseRIResponse{
+		Xmlns:               awsquery.Namespace,
+		RequestID:           awsquery.RequestID,
+		ReservedInstancesID: id,
+	})
+}
+
+// --- DescribeReservedInstances --------------------------------------------
+
+func (h *Handler) describeReservedInstances(w http.ResponseWriter, r *http.Request) {
+	now := h.ri.clock.Now().UTC()
+	f := riFilter{
+		ids:   toStringSet(awsquery.ListStrings(r.Form, "ReservedInstancesId")),
+		attrs: withScalarFilters(awsquery.Filters(r.Form), r.Form.Get("OfferingClass"), r.Form.Get("OfferingType")),
+	}
+
+	reservations := h.ri.describe(f, now)
+
+	out := make([]reservedInstanceXML, 0, len(reservations))
+	for _, ri := range reservations {
+		out = append(out, toReservedInstanceXML(ri, ri.effectiveState(now)))
+	}
+
+	awsquery.WriteXMLResponse(w, describeRIResponse{
+		Xmlns:             awsquery.Namespace,
+		RequestID:         awsquery.RequestID,
+		ReservedInstances: out,
+	})
+}
+
+// withScalarFilters folds the OfferingClass/OfferingType scalar parameters into
+// the Filter.N set as offering-class/offering-type predicates when supplied, so
+// they filter through the one attribute-matching path.
+func withScalarFilters(filters []awsquery.Filter, offeringClass, offeringType string) []awsquery.Filter {
+	if offeringClass != "" {
+		filters = append(filters, awsquery.Filter{Name: riFilterOfferingClass, Values: []string{offeringClass}})
+	}
+
+	if offeringType != "" {
+		filters = append(filters, awsquery.Filter{Name: riFilterOfferingType, Values: []string{offeringType}})
+	}
+
+	return filters
+}
+
+// --- ModifyReservedInstances ----------------------------------------------
+
+func (h *Handler) modifyReservedInstances(w http.ResponseWriter, r *http.Request) {
+	in := &modifyInput{
+		clientToken: r.Form.Get("ClientToken"),
+		reservedIDs: awsquery.ListStrings(r.Form, "ReservedInstancesId"),
+	}
+
+	for _, idx := range awsquery.CollectIndices(r.Form, "ReservedInstancesConfigurationSetItemType") {
+		in.targetConfigs = append(in.targetConfigs, parseTargetConfig(r, idx))
+	}
+
+	id, err := h.ri.modify(in)
+	if err != nil {
+		writeRIErr(w, err)
+
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, modifyRIResponse{
+		Xmlns:                           awsquery.Namespace,
+		RequestID:                       awsquery.RequestID,
+		ReservedInstancesModificationID: id,
+	})
+}
+
+// parseTargetConfig reads one ReservedInstancesConfigurationSetItemType.N group.
+func parseTargetConfig(r *http.Request, idx int) targetConfig {
+	base := "ReservedInstancesConfigurationSetItemType." + strconv.Itoa(idx)
+
+	return targetConfig{
+		availabilityZone: r.Form.Get(base + ".AvailabilityZone"),
+		instanceType:     r.Form.Get(base + ".InstanceType"),
+		platform:         r.Form.Get(base + ".Platform"),
+		scope:            r.Form.Get(base + ".Scope"),
+		instanceCount:    parseInt32(r.Form.Get(base + ".InstanceCount")),
+	}
+}
+
+// parseInt32 parses a decimal string to int32, returning 0 on any parse error
+// or out-of-range value (the caller treats 0 as "unset").
+func parseInt32(s string) int32 {
+	n, err := strconv.ParseInt(s, 10, 32)
+	if err != nil {
+		return 0
+	}
+
+	return int32(n)
+}
+
+// --- DescribeReservedInstancesModifications --------------------------------
+
+func (h *Handler) describeReservedInstancesModifications(w http.ResponseWriter, r *http.Request) {
+	ids := awsquery.ListStrings(r.Form, "ReservedInstancesModificationId")
+	clientTokens := filterValues(awsquery.Filters(r.Form), riFilterClientToken)
+
+	mods := h.ri.describeModifications(ids, clientTokens)
+
+	out := make([]riModificationXML, 0, len(mods))
+	for _, m := range mods {
+		out = append(out, toRIModificationXML(m))
+	}
+
+	awsquery.WriteXMLResponse(w, describeRIModificationsResponse{
+		Xmlns:         awsquery.Namespace,
+		RequestID:     awsquery.RequestID,
+		Modifications: out,
+	})
+}
+
+// filterValues returns the values of the named filter across the filter set.
+func filterValues(filters []awsquery.Filter, name string) []string {
+	var out []string
+
+	for _, f := range filters {
+		if f.Name == name {
+			out = append(out, f.Values...)
+		}
+	}
+
+	return out
+}
+
+// writeRIErr maps a store/validation error to the closest EC2 RI error code.
+func writeRIErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidReservedInstancesId.NotFound", "IncorrectReservedInstancesState")
+}
+
+// --- XML shapes ------------------------------------------------------------
+
+type recurringChargeXML struct {
+	Amount    float64 `xml:"amount"`
+	Frequency string  `xml:"frequency"`
+}
+
+type pricingDetailXML struct {
+	Count int32   `xml:"count"`
+	Price float64 `xml:"price"`
+}
+
+type riOfferingXML struct {
+	ReservedInstancesOfferingID string               `xml:"reservedInstancesOfferingId"`
+	InstanceType                string               `xml:"instanceType"`
+	AvailabilityZone            string               `xml:"availabilityZone,omitempty"`
+	Duration                    int64                `xml:"duration"`
+	FixedPrice                  float64              `xml:"fixedPrice"`
+	UsagePrice                  float64              `xml:"usagePrice"`
+	ProductDescription          string               `xml:"productDescription"`
+	InstanceTenancy             string               `xml:"instanceTenancy"`
+	CurrencyCode                string               `xml:"currencyCode"`
+	OfferingType                string               `xml:"offeringType"`
+	OfferingClass               string               `xml:"offeringClass"`
+	Scope                       string               `xml:"scope"`
+	Marketplace                 bool                 `xml:"marketplace"`
+	RecurringCharges            []recurringChargeXML `xml:"recurringCharges>item,omitempty"`
+	PricingDetails              []pricingDetailXML   `xml:"pricingDetailsSet>item,omitempty"`
+}
+
+type describeRIOfferingsResponse struct {
+	XMLName   xml.Name        `xml:"DescribeReservedInstancesOfferingsResponse"`
+	Xmlns     string          `xml:"xmlns,attr"`
+	RequestID string          `xml:"requestId"`
+	Offerings []riOfferingXML `xml:"reservedInstancesOfferingsSet>item"`
+}
+
+type purchaseRIResponse struct {
+	XMLName             xml.Name `xml:"PurchaseReservedInstancesOfferingResponse"`
+	Xmlns               string   `xml:"xmlns,attr"`
+	RequestID           string   `xml:"requestId"`
+	ReservedInstancesID string   `xml:"reservedInstancesId"`
+}
+
+type reservedInstanceXML struct {
+	ReservedInstancesID string               `xml:"reservedInstancesId"`
+	InstanceType        string               `xml:"instanceType"`
+	AvailabilityZone    string               `xml:"availabilityZone,omitempty"`
+	Start               string               `xml:"start"`
+	End                 string               `xml:"end"`
+	Duration            int64                `xml:"duration"`
+	UsagePrice          float64              `xml:"usagePrice"`
+	FixedPrice          float64              `xml:"fixedPrice"`
+	InstanceCount       int32                `xml:"instanceCount"`
+	ProductDescription  string               `xml:"productDescription"`
+	State               string               `xml:"state"`
+	InstanceTenancy     string               `xml:"instanceTenancy"`
+	CurrencyCode        string               `xml:"currencyCode"`
+	OfferingType        string               `xml:"offeringType"`
+	OfferingClass       string               `xml:"offeringClass"`
+	Scope               string               `xml:"scope"`
+	RecurringCharges    []recurringChargeXML `xml:"recurringCharges>item,omitempty"`
+	Tags                []tagItem            `xml:"tagSet>item,omitempty"`
+}
+
+type describeRIResponse struct {
+	XMLName           xml.Name              `xml:"DescribeReservedInstancesResponse"`
+	Xmlns             string                `xml:"xmlns,attr"`
+	RequestID         string                `xml:"requestId"`
+	ReservedInstances []reservedInstanceXML `xml:"reservedInstancesSet>item"`
+}
+
+type modifyRIResponse struct {
+	XMLName                         xml.Name `xml:"ModifyReservedInstancesResponse"`
+	Xmlns                           string   `xml:"xmlns,attr"`
+	RequestID                       string   `xml:"requestId"`
+	ReservedInstancesModificationID string   `xml:"reservedInstancesModificationId"`
+}
+
+type modificationResultXML struct {
+	ReservedInstancesID string `xml:"reservedInstancesId,omitempty"`
+	AvailabilityZone    string `xml:"targetConfiguration>availabilityZone,omitempty"`
+	InstanceCount       int32  `xml:"targetConfiguration>instanceCount"`
+	InstanceType        string `xml:"targetConfiguration>instanceType,omitempty"`
+	Platform            string `xml:"targetConfiguration>platform,omitempty"`
+	Scope               string `xml:"targetConfiguration>scope,omitempty"`
+}
+
+type riModificationXML struct {
+	ReservedInstancesModificationID string                  `xml:"reservedInstancesModificationId"`
+	ClientToken                     string                  `xml:"clientToken,omitempty"`
+	Status                          string                  `xml:"status"`
+	CreateDate                      string                  `xml:"createDate"`
+	UpdateDate                      string                  `xml:"updateDate"`
+	EffectiveDate                   string                  `xml:"effectiveDate"`
+	ReservedInstancesIDs            []string                `xml:"reservedInstancesSet>item>reservedInstancesId"`
+	ModificationResults             []modificationResultXML `xml:"modificationResultSet>item"`
+}
+
+type describeRIModificationsResponse struct {
+	XMLName       xml.Name            `xml:"DescribeReservedInstancesModificationsResponse"`
+	Xmlns         string              `xml:"xmlns,attr"`
+	RequestID     string              `xml:"requestId"`
+	Modifications []riModificationXML `xml:"reservedInstancesModificationsSet>item"`
+}
+
+// --- converters ------------------------------------------------------------
+
+func toRIOfferingXML(o *riOffering) riOfferingXML {
+	out := riOfferingXML{
+		ReservedInstancesOfferingID: o.id,
+		InstanceType:                o.instanceType,
+		AvailabilityZone:            o.availabilityZone,
+		Duration:                    o.duration,
+		FixedPrice:                  o.fixedPrice,
+		UsagePrice:                  o.usagePrice,
+		ProductDescription:          o.productDescription,
+		InstanceTenancy:             o.instanceTenancy,
+		CurrencyCode:                riCurrencyUSD,
+		OfferingType:                o.offeringType,
+		OfferingClass:               o.offeringClass,
+		Scope:                       o.scope,
+		Marketplace:                 o.marketplace,
+	}
+
+	if o.recurringHourly > 0 {
+		out.RecurringCharges = []recurringChargeXML{{Amount: o.recurringHourly, Frequency: recurringFrequencyHourly}}
+	}
+
+	for _, t := range o.pricingTiers {
+		out.PricingDetails = append(out.PricingDetails, pricingDetailXML{Count: t.count, Price: t.price})
+	}
+
+	return out
+}
+
+func toReservedInstanceXML(ri *reservedInstance, state string) reservedInstanceXML {
+	out := reservedInstanceXML{
+		ReservedInstancesID: ri.id,
+		InstanceType:        ri.instanceType,
+		AvailabilityZone:    ri.availabilityZone,
+		Start:               ri.start.Format(timeLayout),
+		End:                 ri.end.Format(timeLayout),
+		Duration:            ri.duration,
+		UsagePrice:          ri.usagePrice,
+		FixedPrice:          ri.fixedPrice,
+		InstanceCount:       ri.instanceCount,
+		ProductDescription:  ri.productDescription,
+		State:               state,
+		InstanceTenancy:     ri.instanceTenancy,
+		CurrencyCode:        ri.currencyCode,
+		OfferingType:        ri.offeringType,
+		OfferingClass:       ri.offeringClass,
+		Scope:               ri.scope,
+	}
+
+	if ri.recurringHourly > 0 {
+		out.RecurringCharges = []recurringChargeXML{{Amount: ri.recurringHourly, Frequency: recurringFrequencyHourly}}
+	}
+
+	for k, v := range ri.tags {
+		out.Tags = append(out.Tags, tagItem{Key: k, Value: v})
+	}
+
+	return out
+}
+
+func toRIModificationXML(m *riModification) riModificationXML {
+	out := riModificationXML{
+		ReservedInstancesModificationID: m.id,
+		ClientToken:                     m.clientToken,
+		Status:                          m.status,
+		CreateDate:                      m.createDate.Format(timeLayout),
+		UpdateDate:                      m.updateDate.Format(timeLayout),
+		EffectiveDate:                   m.effectiveDate.Format(timeLayout),
+		ReservedInstancesIDs:            m.sourceIDs,
+	}
+
+	for _, res := range m.results {
+		out.ModificationResults = append(out.ModificationResults, modificationResultXML{
+			ReservedInstancesID: res.reservedInstancesID,
+			AvailabilityZone:    res.availabilityZone,
+			InstanceCount:       res.instanceCount,
+			InstanceType:        res.instanceType,
+			Platform:            res.platform,
+			Scope:               res.scope,
+		})
+	}
+
+	return out
+}

--- a/services/cost/combine.go
+++ b/services/cost/combine.go
@@ -1,0 +1,52 @@
+package cost
+
+import (
+	"context"
+	"sort"
+	"time"
+)
+
+// combined is the union of several Commitments sources. It lets the billing
+// engine amortize commitments that live in different backends together — AWS
+// Reserved Instances (served by the EC2 handler) and Savings Plans (served by
+// the Savings Plans handler) both implement Commitments, and the Cost Explorer
+// reservation coverage/utilization consumer reads them as one source.
+type combined struct {
+	sources []Commitments
+}
+
+// Combine unions several Commitments sources into one. ListActive concatenates
+// every source's active commitments at the query instant, in a deterministic
+// (ID-sorted) order. Nil sources are skipped, so Combine(nil, sp) == sp's view.
+// Combining zero sources yields a source that is always empty.
+func Combine(sources ...Commitments) Commitments {
+	kept := make([]Commitments, 0, len(sources))
+
+	for _, s := range sources {
+		if s != nil {
+			kept = append(kept, s)
+		}
+	}
+
+	return &combined{sources: kept}
+}
+
+// ListActive returns the union of every source's active commitments at at. The
+// first error from any source is returned (with no partial result), so a caller
+// never amortizes a half-read set.
+func (c *combined) ListActive(ctx context.Context, at time.Time) ([]Commitment, error) {
+	var out []Commitment
+
+	for _, s := range c.sources {
+		got, err := s.ListActive(ctx, at)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, got...)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+
+	return out, nil
+}

--- a/services/cost/combine_test.go
+++ b/services/cost/combine_test.go
@@ -1,0 +1,59 @@
+package cost
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixedSource is a Commitments source returning a fixed set regardless of at.
+type fixedSource []Commitment
+
+func (f fixedSource) ListActive(_ context.Context, _ time.Time) ([]Commitment, error) {
+	return f, nil
+}
+
+// errSource is a Commitments source that always errors.
+type errSource struct{}
+
+func (errSource) ListActive(_ context.Context, _ time.Time) ([]Commitment, error) {
+	return nil, errors.New("boom")
+}
+
+func TestCombineUnionsSourcesSorted(t *testing.T) {
+	ri := fixedSource{{ID: "ri-2", Kind: KindReservedInstance, HourlyCommitmentUSD: 2}}
+	sp := fixedSource{{ID: "sp-1", Kind: KindSavingsPlan, HourlyCommitmentUSD: 1}}
+
+	got, err := Combine(ri, sp).ListActive(context.Background(), time.Now())
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	// Union is ID-sorted for deterministic output regardless of source order.
+	assert.Equal(t, "ri-2", got[0].ID)
+	assert.Equal(t, "sp-1", got[1].ID)
+}
+
+func TestCombineSkipsNilSources(t *testing.T) {
+	sp := fixedSource{{ID: "sp-1", Kind: KindSavingsPlan}}
+
+	got, err := Combine(nil, sp, nil).ListActive(context.Background(), time.Now())
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "sp-1", got[0].ID)
+}
+
+func TestCombineEmptyIsEmpty(t *testing.T) {
+	got, err := Combine().ListActive(context.Background(), time.Now())
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestCombinePropagatesError(t *testing.T) {
+	got, err := Combine(fixedSource{{ID: "a"}}, errSource{}).ListActive(context.Background(), time.Now())
+	require.Error(t, err)
+	assert.Nil(t, got)
+}


### PR DESCRIPTION
## What & why

Billing-parity #942, build-order **step 5**: AWS **Reserved Instances** purchase/reporting on EC2, feeding the shared `services/cost.Commitments` interface alongside Savings Plans (#944). This gives a real `aws-sdk-go-v2/service/ec2` client (or `aws ec2` CLI / IaC) a working RI purchase + describe surface, and exposes the purchased reservations as commitments the Cost Explorer reservation coverage/utilization consumer (step 3) will amortize.

Additive to the existing EC2 query handler — no new codec, no new handler package, no driver change.

## Operations (classic AWS Query/XML, `Version=2016-11-15`)

Slotted into the existing `server/aws/ec2` query dispatch via a new `routeReservedInstances`:

- `DescribeReservedInstancesOfferings` — seeded catalog (standard/convertible, 1yr/3yr, All/Partial/No Upfront, Region + AZ scope, Linux/UNIX + Windows), with `pricingDetailsSet` volume tiers, `recurringCharges`, and marketplace filter.
- `PurchaseReservedInstancesOffering` — `{InstanceCount, LimitPrice, PurchaseTime (future ⇒ queued), ReservedInstancesOfferingId}` → `{reservedInstancesId}`. LimitPrice price-protection enforced.
- `DescribeReservedInstances` — filters (availability-zone/duration/product-description/state/instance-type/scope/tenancy), `OfferingClass`/`OfferingType` scalars.
- `ModifyReservedInstances` + `DescribeReservedInstancesModifications` — instant-settle (status `fulfilled`): each target configuration mints a new active reservation and terminally retires the source, preserving net commitment; `ClientToken` idempotent.

**Deferred:** `DescribeReservedInstancesListings` (Reserved Instance Marketplace resale listings) — out of scope for the purchase/reporting core.

## Lazy clock-derived state (the #944 lesson)

State is **never frozen at purchase**. `effectiveState(now)` derives it on every read from `config.Clock` vs start/end: `queued` when `now < start`, `active` in `[start, end)`, `retired` at/after `end`; a source retired by a modification is terminally retired. `DescribeReservedInstances` reports the effective state, and the Commitments feed returns an RI as active iff its effective state is active at the query instant.

## cost.Commitments wiring (RI + SP aggregation for step 3)

- The RI store implements `cost.Commitments.ListActive`, mapping each active RI → `cost.Commitment{Kind: ReservedInstance, HourlyCommitmentUSD: recurringHourly × instanceCount, Start, End}`, exposed via `(*ec2.Handler).Commitments()`.
- New `cost.Combine(sources ...Commitments)` aggregator returns the ID-sorted union of several sources (nil-skipping, first-error-propagating). Step 3's CE consumer unions RI + the #944 Savings Plans source with `cost.Combine(ec2Handler.Commitments(), savingsPlans.Commitments())`.
- `server/aws/aws.go` passes `ec2.WithClock`/`ec2.WithRegion` so the wire server's RI timeline is deterministic and commitments are region-scoped.

## Persist

RI state lives only in the wire server (a billing instrument, not a compute resource — no portable driver), exactly like the Savings Plans store, so it needs no persist #582 Snapshottable wiring.

## Blast radius

EC2 is heavily used — this is strictly additive: a new route appended to the dispatch list, a new always-initialized RI store field, and backward-compatible `ec2.New(..., opts ...Option)` (existing callers unchanged). No existing EC2 op behavior changes. Deterministic via `config.Clock`/`FakeClock`.

## Coverage

No `docs/coverage` delta: RI is wire-only inside the EC2 handler, whose op surface the generator derives from the compute driver method set — consistent with VPC ops served by the same handler being counted under the networking driver. Adding a compute-driver method for a pure billing instrument would be the wrong architecture.

## Tests

Real `aws-sdk-go-v2/service/ec2` client against in-process cloudemu (httptest): offerings catalog, immediate purchase → active now + commitment feed, **future purchase → queued → FakeClock-advance past start → active + in feed → advance past end → retired + excluded** (the #944 clock-advance gap), RI+SP union via `cost.Combine`, and modify instant-settle. Plus focused `cost.Combine` unit tests.
