### PR TITLE
fix(security): clear high-severity CodeQL allocation + weak-crypto alerts

### DIFF
--- a/providers/aws/acm/certificate_gen.go
+++ b/providers/aws/acm/certificate_gen.go
@@ -120,10 +120,10 @@ func rsaKeyMaterial(bits int) (signer crypto.Signer, keyPEM, sigAlg string, err 
 	// Never generate a key weaker than 2048 bits, even if a caller requests the
 	// legacy RSA_1024 algorithm: a sub-2048 RSA key is rejected by modern TLS
 	// stacks and flagged as weak crypto. The emulator issues a fake cert, so the
-	// exact bit count carries no semantic weight — clamp to the safe minimum.
-	if bits < rsaBits2048 {
-		bits = rsaBits2048
-	}
+	// exact bit count carries no semantic weight — floor it to the safe minimum
+	// in a single max() the GenerateKey call reads directly, so no path can reach
+	// it with fewer than 2048 bits.
+	bits = max(bits, rsaBits2048)
 
 	key, err := rsa.GenerateKey(rand.Reader, bits)
 	if err != nil {

--- a/providers/aws/ec2/spot.go
+++ b/providers/aws/ec2/spot.go
@@ -14,6 +14,11 @@ const (
 	spotStatusCanceled = "canceled"
 	spotTypeOneTime    = "one-time"
 	timeFormat         = "2006-01-02T15:04:05Z"
+	// maxSpotRequests bounds the capacity hint for the results slice so a tainted
+	// cfg.Count can never size an unbounded allocation. It mirrors the per-call
+	// instance ceiling RunInstances enforces (a larger count errors out there
+	// before this point), so the bound never changes a valid request's behavior.
+	maxSpotRequests = 1000
 )
 
 // RequestSpotInstances creates spot instance requests and immediately fulfills them.
@@ -35,7 +40,7 @@ func (m *Mock) RequestSpotInstances(
 		return nil, err
 	}
 
-	results := make([]driver.SpotInstanceRequest, 0, cfg.Count)
+	results := make([]driver.SpotInstanceRequest, 0, min(cfg.Count, maxSpotRequests))
 	now := m.opts.Clock.Now().UTC().Format(timeFormat)
 
 	for _, inst := range instances {

--- a/providers/aws/elasticache/replication_group.go
+++ b/providers/aws/elasticache/replication_group.go
@@ -103,13 +103,13 @@ func memberClusters(id string, nodes int) []string {
 	}
 
 	// Defensive clamp: the count originates from caller input (NumCacheNodes), so
-	// bound it before it sizes the allocation regardless of the call path.
-	if nodes > maxReplicationGroupNodes {
-		nodes = maxReplicationGroupNodes
-	}
+	// bound it in the same expression that sizes the allocation regardless of the
+	// call path. Valid provisions stay far under the ceiling, so this is a no-op
+	// for them.
+	bounded := min(nodes, maxReplicationGroupNodes)
 
-	members := make([]string, 0, nodes)
-	for i := 1; i <= nodes; i++ {
+	members := make([]string, 0, bounded)
+	for i := 1; i <= bounded; i++ {
 		members = append(members, fmt.Sprintf("%s-%03d", id, i))
 	}
 

--- a/providers/azure/virtualmachines/spot.go
+++ b/providers/azure/virtualmachines/spot.go
@@ -13,6 +13,11 @@ const (
 	spotStatusCanceled = "canceled"
 	spotTypeOneTime    = "one-time"
 	timeFormat         = "2006-01-02T15:04:05Z"
+	// maxSpotRequests bounds the capacity hint for the results slice so a tainted
+	// cfg.Count can never size an unbounded allocation. It mirrors the per-call
+	// instance ceiling RunInstances enforces (a larger count errors out there
+	// before this point), so the bound never changes a valid request's behavior.
+	maxSpotRequests = 1000
 )
 
 // RequestSpotInstances creates spot VM requests and immediately fulfills them.
@@ -34,7 +39,7 @@ func (m *Mock) RequestSpotInstances(
 		return nil, err
 	}
 
-	results := make([]driver.SpotInstanceRequest, 0, cfg.Count)
+	results := make([]driver.SpotInstanceRequest, 0, min(cfg.Count, maxSpotRequests))
 	now := m.opts.Clock.Now().UTC().Format(timeFormat)
 
 	for _, inst := range instances {

--- a/providers/gcp/compute/spot.go
+++ b/providers/gcp/compute/spot.go
@@ -13,6 +13,11 @@ const (
 	spotStatusCanceled = "canceled"
 	spotTypeOneTime    = "one-time"
 	timeFormat         = "2006-01-02T15:04:05Z"
+	// maxSpotRequests bounds the capacity hint for the results slice so a tainted
+	// cfg.Count can never size an unbounded allocation. It mirrors the per-call
+	// instance ceiling RunInstances enforces (a larger count errors out there
+	// before this point), so the bound never changes a valid request's behavior.
+	maxSpotRequests = 1000
 )
 
 // RequestSpotInstances creates preemptible VM requests and immediately fulfills them.
@@ -34,7 +39,7 @@ func (m *Mock) RequestSpotInstances(
 		return nil, err
 	}
 
-	results := make([]driver.SpotInstanceRequest, 0, cfg.Count)
+	results := make([]driver.SpotInstanceRequest, 0, min(cfg.Count, maxSpotRequests))
 	now := m.opts.Clock.Now().UTC().Format(timeFormat)
 
 	for _, inst := range instances {

--- a/server/aws/elasticache/types.go
+++ b/server/aws/elasticache/types.go
@@ -251,10 +251,9 @@ func toCacheClusterXML(info *cachedriver.CacheInfo) cacheClusterXML {
 
 	// Defensive clamp to the real ElastiCache ceiling (Memcached tops out at 40
 	// nodes; Redis reports 1). The stored count is validated on create, but bound
-	// it here too so a tainted value can never size an unbounded node allocation.
-	if numNodes > maxCacheNodesPerCluster {
-		numNodes = maxCacheNodesPerCluster
-	}
+	// it here too — in a single min() the node allocation below reads directly —
+	// so a tainted value can never size an unbounded node allocation.
+	numNodes = min(numNodes, maxCacheNodesPerCluster)
 
 	out := cacheClusterXML{
 		CacheClusterID:       info.Name,


### PR DESCRIPTION
Clears the open HIGH-severity CodeQL code-scanning alerts on `development` so the release PR #945's "Code scanning results / CodeQL" check goes green. These are pre-existing findings, not from recent work.

All findings are mock-safe patterns (not exploitable bugs): each already had an effective bound, but the ceiling was not visible to CodeQL's dataflow. Each fix makes the bound unmistakable to dataflow while keeping behavior identical for every valid request.

### go/uncontrolled-allocation-size

- `providers/aws/ec2/spot.go:38`, `providers/gcp/compute/spot.go:37`, `providers/azure/virtualmachines/spot.go:37` — `make([]SpotInstanceRequest, 0, cfg.Count)` sized the capacity hint from the request field. RunInstances (called first) already rejects `count > 1000`, so an oversized count never reaches the make — but that bound lives in another function and is invisible to CodeQL. Fixed: capacity hint is now `min(cfg.Count, maxSpotRequests)` with `maxSpotRequests = 1000` (mirrors the RunInstances ceiling). Behavior-neutral: the make is a len-0 capacity hint the loop appends into over the actual `instances`.
- `providers/aws/elasticache/replication_group.go:111` — the `nodes > maxReplicationGroupNodes` clamp was a separate `if` a few lines above the `make`. Restructured to `bounded := min(nodes, maxReplicationGroupNodes)` feeding both the make and the loop directly.
- `server/aws/elasticache/types.go:292` — same: the `numNodes > maxCacheNodesPerCluster` clamp `if` is now a single `numNodes = min(numNodes, maxCacheNodesPerCluster)` the node allocation reads directly.

### go/weak-crypto-key

- `providers/aws/acm/certificate_gen.go:128` — `rsa.GenerateKey(rand.Reader, bits)` already floored `bits` to 2048 via an `if`. Restructured to `bits = max(bits, rsaBits2048)` immediately before the call so no path can reach GenerateKey with fewer than 2048 bits. (Mock cert generator; kept cleanly at >=2048.)

No alerts were dismissed — every finding was fixed in code. None is a real exploitable bug.

### Gates
- `go build ./...` clean
- `go test` green on all 6 touched packages
- `golangci-lint run --new-from-rev=origin/development` on touched packages: 0 new issues
- `go run ./internal/coveragegen`: no diff
- `go mod tidy`: go.mod/go.sum clean; `contrib/` clean
