### PR TITLE
fix(billing): state-aware compute cost (terminated/stopped) + Azure Cost Management daily bucketing (#942)

### DIFF
--- a/server/aws/costexplorer/state_aware_cost_test.go
+++ b/server/aws/costexplorer/state_aware_cost_test.go
@@ -1,0 +1,160 @@
+package costexplorer_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	ce "github.com/aws/aws-sdk-go-v2/service/costexplorer"
+	cetypes "github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newStateAwareClients stands up one in-process AWS server serving both EC2 and
+// Cost Explorer over a shared cloud, so a lifecycle change made through the real
+// EC2 client is reflected in the Cost Explorer total. It launches two running
+// t3.micro instances up front.
+func newStateAwareClients(t *testing.T) (*ce.Client, *ec2.Client) {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+
+	srv := awsserver.New(awsserver.Drivers{
+		EC2:          cloud.EC2,
+		CostExplorer: cloud.ResourceDiscovery,
+	})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	ceClient := ce.NewFromConfig(cfg, func(o *ce.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+	ec2Client := ec2.NewFromConfig(cfg, func(o *ec2.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+
+	if _, err := ec2Client.RunInstances(context.Background(), &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-1"),
+		InstanceType: ec2types.InstanceTypeT3Micro,
+		MinCount:     aws.Int32(2),
+		MaxCount:     aws.Int32(2),
+	}); err != nil {
+		t.Fatalf("run instances: %v", err)
+	}
+
+	return ceClient, ec2Client
+}
+
+// monthlyTotal queries the current month-to-date total UnblendedCost through the
+// real Cost Explorer client.
+func monthlyTotal(t *testing.T, c *ce.Client) float64 {
+	t.Helper()
+
+	out, err := c.GetCostAndUsage(context.Background(), &ce.GetCostAndUsageInput{
+		Granularity: cetypes.GranularityMonthly,
+		Metrics:     []string{"UnblendedCost"},
+		TimePeriod:  &cetypes.DateInterval{Start: aws.String("2024-01-01"), End: aws.String("2024-02-01")},
+	})
+	if err != nil {
+		t.Fatalf("GetCostAndUsage: %v", err)
+	}
+
+	if len(out.ResultsByTime) != 1 {
+		t.Fatalf("ResultsByTime = %d, want 1", len(out.ResultsByTime))
+	}
+
+	return amount(t, out.ResultsByTime[0].Total["UnblendedCost"].Amount)
+}
+
+// instanceIDs returns the ids of every instance currently known to EC2.
+func instanceIDs(t *testing.T, c *ec2.Client) []string {
+	t.Helper()
+
+	out, err := c.DescribeInstances(context.Background(), &ec2.DescribeInstancesInput{})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	var ids []string
+
+	for i := range out.Reservations {
+		for j := range out.Reservations[i].Instances {
+			ids = append(ids, aws.ToString(out.Reservations[i].Instances[j].InstanceId))
+		}
+	}
+
+	return ids
+}
+
+// TestSDKCostDropsOnTerminate proves a terminated instance is no longer billed:
+// the month-to-date total falls after each TerminateInstances and reaches zero
+// once both instances are gone (real AWS bills no compute for a terminated
+// instance).
+func TestSDKCostDropsOnTerminate(t *testing.T) {
+	ctx := context.Background()
+	ceClient, ec2Client := newStateAwareClients(t)
+
+	before := monthlyTotal(t, ceClient)
+	if before <= 0 {
+		t.Fatalf("running estate total = %v, want > 0", before)
+	}
+
+	ids := instanceIDs(t, ec2Client)
+	if len(ids) != 2 {
+		t.Fatalf("instance count = %d, want 2", len(ids))
+	}
+
+	if _, err := ec2Client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{InstanceIds: ids[:1]}); err != nil {
+		t.Fatalf("terminate one: %v", err)
+	}
+
+	afterOne := monthlyTotal(t, ceClient)
+	if afterOne >= before {
+		t.Fatalf("total after terminating one = %v, want < %v", afterOne, before)
+	}
+
+	if _, err := ec2Client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{InstanceIds: ids[1:]}); err != nil {
+		t.Fatalf("terminate remaining: %v", err)
+	}
+
+	afterAll := monthlyTotal(t, ceClient)
+	if afterAll != 0 {
+		t.Fatalf("total after terminating all = %v, want 0 (terminated instances bill nothing)", afterAll)
+	}
+}
+
+// TestSDKCostDropsOnStop proves a stopped instance is not billed for compute:
+// stopping both instances drops the compute cost to zero (a real stopped
+// instance pays only for its EBS, which this estate has none of).
+func TestSDKCostDropsOnStop(t *testing.T) {
+	ctx := context.Background()
+	ceClient, ec2Client := newStateAwareClients(t)
+
+	before := monthlyTotal(t, ceClient)
+	if before <= 0 {
+		t.Fatalf("running estate total = %v, want > 0", before)
+	}
+
+	ids := instanceIDs(t, ec2Client)
+
+	if _, err := ec2Client.StopInstances(ctx, &ec2.StopInstancesInput{InstanceIds: ids}); err != nil {
+		t.Fatalf("stop instances: %v", err)
+	}
+
+	after := monthlyTotal(t, ceClient)
+	if after != 0 {
+		t.Fatalf("total after stopping all = %v, want 0 (stopped compute is not billed)", after)
+	}
+}

--- a/server/azure/costmanagement/daily_test.go
+++ b/server/azure/costmanagement/daily_test.go
@@ -86,6 +86,86 @@ func TestQueryUsage_DailyBucketsPerDay(t *testing.T) {
 		"daily rows must sum to the pro-rated monthly figure")
 }
 
+// TestQueryUsage_DailyCustomTimeframe proves a Daily query over a Custom
+// timeframe with explicit from/to dates buckets one pro-rated row per day across
+// exactly that window — a deterministic check with no dependence on the wall
+// clock (unlike MonthToDate).
+func TestQueryUsage_DailyCustomTimeframe(t *testing.T) {
+	client := newCostClient(t)
+
+	fromDate := time.Date(2024, time.March, 10, 0, 0, 0, 0, time.UTC)
+	toDate := time.Date(2024, time.March, 14, 0, 0, 0, 0, time.UTC)
+	const wantDays = 5 // 10, 11, 12, 13, 14 inclusive
+
+	resp, err := client.Usage(context.Background(), subscriptionScope, armcostmanagement.QueryDefinition{
+		Type:       to.Ptr(armcostmanagement.ExportTypeActualCost),
+		Timeframe:  to.Ptr(armcostmanagement.TimeframeTypeCustom),
+		TimePeriod: &armcostmanagement.QueryTimePeriod{From: &fromDate, To: &toDate},
+		Dataset: &armcostmanagement.QueryDataset{
+			Granularity: to.Ptr(armcostmanagement.GranularityTypeDaily),
+			Aggregation: sumAggregation(),
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Properties)
+
+	costIdx := columnIndex(resp.Properties.Columns, "Cost")
+	dateIdx := columnIndex(resp.Properties.Columns, "UsageDate")
+	require.GreaterOrEqual(t, costIdx, 0)
+	require.GreaterOrEqual(t, dateIdx, 0)
+
+	rows := resp.Properties.Rows
+	require.Len(t, rows, wantDays, "Custom [10..14 March] Daily query returns one row per day")
+
+	wantYMD := []int{20240310, 20240311, 20240312, 20240313, 20240314}
+	for i, row := range rows {
+		c, ok := row[costIdx].(float64)
+		require.True(t, ok)
+		assert.Positive(t, c)
+
+		ymd, ok := row[dateIdx].(float64)
+		require.True(t, ok)
+		assert.Equal(t, wantYMD[i], int(ymd), "row %d date", i)
+	}
+}
+
+// TestQueryUsage_DailyTheLastMonth proves a Daily query over the TheLastMonth
+// timeframe buckets one row per day across the whole previous calendar month.
+func TestQueryUsage_DailyTheLastMonth(t *testing.T) {
+	client := newCostClient(t)
+
+	now := time.Now().UTC()
+	firstThis := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	lastMonthEnd := firstThis.AddDate(0, 0, -1)
+	wantDays := lastMonthEnd.Day() // days in the previous calendar month
+
+	resp, err := client.Usage(context.Background(), subscriptionScope, armcostmanagement.QueryDefinition{
+		Type:      to.Ptr(armcostmanagement.ExportTypeActualCost),
+		Timeframe: to.Ptr(armcostmanagement.TimeframeTypeTheLastMonth),
+		Dataset: &armcostmanagement.QueryDataset{
+			Granularity: to.Ptr(armcostmanagement.GranularityTypeDaily),
+			Aggregation: sumAggregation(),
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Properties)
+
+	dateIdx := columnIndex(resp.Properties.Columns, "UsageDate")
+	require.GreaterOrEqual(t, dateIdx, 0)
+
+	rows := resp.Properties.Rows
+	require.Len(t, rows, wantDays, "TheLastMonth Daily query returns one row per day of the previous month")
+
+	// Every row lands in the previous calendar month.
+	wantYear, wantMonth := lastMonthEnd.Year(), int(lastMonthEnd.Month())
+	for _, row := range rows {
+		ymd, ok := row[dateIdx].(float64)
+		require.True(t, ok)
+		assert.Equal(t, wantYear, int(ymd)/10000)
+		assert.Equal(t, wantMonth, (int(ymd)/100)%100)
+	}
+}
+
 // aggregateMonthly returns the full monthly total the seeded estate reports
 // through an ungrouped, non-granular query (a single aggregate row over the
 // period).

--- a/server/azure/costmanagement/daily_test.go
+++ b/server/azure/costmanagement/daily_test.go
@@ -1,0 +1,186 @@
+package costmanagement_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/costmanagement/armcostmanagement"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// TestQueryUsage_DailyBucketsPerDay proves a Daily MonthToDate query returns one
+// row per day in the month-to-date period (not a single monthly row stamped
+// today), each carrying a pro-rated per-day cost, and that the per-day costs sum
+// to approximately the monthly figure the same estate reports — the AWS Cost
+// Explorer convention.
+func TestQueryUsage_DailyBucketsPerDay(t *testing.T) {
+	client := newCostClient(t)
+
+	now := time.Now().UTC()
+	wantDays := now.Day() // MonthToDate: first of month .. today, inclusive.
+
+	daily, err := client.Usage(context.Background(), subscriptionScope, armcostmanagement.QueryDefinition{
+		Type:      to.Ptr(armcostmanagement.ExportTypeActualCost),
+		Timeframe: to.Ptr(armcostmanagement.TimeframeTypeMonthToDate),
+		Dataset: &armcostmanagement.QueryDataset{
+			Granularity: to.Ptr(armcostmanagement.GranularityTypeDaily),
+			Aggregation: sumAggregation(),
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, daily.Properties)
+
+	cols := daily.Properties.Columns
+	rows := daily.Properties.Rows
+
+	costIdx := columnIndex(cols, "Cost")
+	dateIdx := columnIndex(cols, "UsageDate")
+	require.GreaterOrEqual(t, costIdx, 0, "missing Cost column")
+	require.GreaterOrEqual(t, dateIdx, 0, "Daily query must add a UsageDate column")
+
+	require.Len(t, rows, wantDays, "ungrouped Daily query returns one row per day in the period")
+
+	// Each row is a positive per-day cost stamped with a distinct yyyymmdd date
+	// inside the current month; together the days cover the contiguous 1..today
+	// range.
+	seenDays := map[int]bool{}
+
+	var dailySum float64
+
+	for _, row := range rows {
+		c, ok := row[costIdx].(float64)
+		require.True(t, ok, "cost is %T, want number", row[costIdx])
+		assert.Positive(t, c, "each day carries a positive pro-rated cost")
+
+		dailySum += c
+
+		ymd, ok := row[dateIdx].(float64)
+		require.True(t, ok, "UsageDate is %T, want number", row[dateIdx])
+
+		assert.Equal(t, now.Year(), int(ymd)/10000)
+		assert.Equal(t, int(now.Month()), (int(ymd)/100)%100)
+		seenDays[int(ymd)%100] = true
+	}
+
+	for d := 1; d <= wantDays; d++ {
+		assert.True(t, seenDays[d], "missing a row for day %d of the period", d)
+	}
+
+	// The per-day rows sum to ~= the monthly figure (24h/730h per day summed over
+	// the days of the period, matching AWS Cost Explorer's convention).
+	monthly := aggregateMonthly(t, client)
+	perDay := monthly * 24.0 / 730.0
+	assert.InDelta(t, perDay*float64(wantDays), dailySum, 1e-6,
+		"daily rows must sum to the pro-rated monthly figure")
+}
+
+// aggregateMonthly returns the full monthly total the seeded estate reports
+// through an ungrouped, non-granular query (a single aggregate row over the
+// period).
+func aggregateMonthly(t *testing.T, client *armcostmanagement.QueryClient) float64 {
+	t.Helper()
+
+	resp, err := client.Usage(context.Background(), subscriptionScope, armcostmanagement.QueryDefinition{
+		Type:      to.Ptr(armcostmanagement.ExportTypeActualCost),
+		Timeframe: to.Ptr(armcostmanagement.TimeframeTypeMonthToDate),
+		Dataset:   &armcostmanagement.QueryDataset{Aggregation: sumAggregation()},
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Properties)
+	require.Len(t, resp.Properties.Rows, 1, "non-granular query stays a single aggregate row")
+
+	costIdx := columnIndex(resp.Properties.Columns, "Cost")
+	total, ok := resp.Properties.Rows[0][costIdx].(float64)
+	require.True(t, ok)
+
+	return total
+}
+
+// costQueryResponse is the subset of the Cost Management query response the raw
+// Monthly test reads. The typed armcostmanagement SDK's query GranularityType
+// only models "Daily", so the Monthly path is exercised with a raw JSON POST.
+type costQueryResponse struct {
+	Properties struct {
+		Columns []struct {
+			Name string `json:"name"`
+			Type string `json:"type"`
+		} `json:"columns"`
+		Rows [][]any `json:"rows"`
+	} `json:"properties"`
+}
+
+// TestQueryUsage_MonthlyStaysSingleRow proves the Monthly granularity path is
+// unchanged: one aggregate row for the period, carrying a BillingMonth date
+// column (not one row per day). Sent as raw JSON because the query SDK cannot
+// express a Monthly granularity.
+func TestQueryUsage_MonthlyStaysSingleRow(t *testing.T) {
+	url := newCostServerURL(t)
+
+	body := `{"type":"ActualCost","timeframe":"MonthToDate",` +
+		`"dataset":{"granularity":"Monthly","aggregation":{"totalCost":{"name":"Cost","function":"Sum"}}}}`
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		url+"/"+subscriptionScope+"/providers/Microsoft.CostManagement/query", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out costQueryResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+
+	require.Len(t, out.Properties.Rows, 1, "Monthly granularity stays one row per period")
+
+	var hasBillingMonth bool
+	for _, c := range out.Properties.Columns {
+		if c.Name == "BillingMonth" {
+			hasBillingMonth = true
+		}
+	}
+
+	assert.True(t, hasBillingMonth, "Monthly query carries a BillingMonth column, got %+v", out.Properties.Columns)
+}
+
+// newCostServerURL seeds the same estate as newCostClient and returns the raw
+// base URL of an in-process cloudemu server over it, for tests that POST a query
+// body the typed SDK cannot express.
+func newCostServerURL(t *testing.T) string {
+	t.Helper()
+
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	_, err := cloudP.VirtualMachines.RunInstances(ctx, computedriver.InstanceConfig{
+		InstanceType: "Standard_D2s_v3", OSType: "Linux",
+	}, 2)
+	require.NoError(t, err)
+
+	_, err = cloudP.VNet.AllocateAddress(ctx, netdriver.ElasticIPConfig{})
+	require.NoError(t, err)
+
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines:   cloudP.VirtualMachines,
+		Network:           cloudP.VNet,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		SubscriptionID:    "123456789012",
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts.URL
+}

--- a/server/azure/costmanagement/handler.go
+++ b/server/azure/costmanagement/handler.go
@@ -119,16 +119,27 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // queryDefinition is the subset of the SDK QueryDefinition this handler reads.
-// Only the fields that change the shape of the response (granularity, grouping,
-// aggregation column names) are decoded; filters/timeframe are accepted and
-// ignored because the emulator holds a single point-in-time estate.
+// Only the fields that change the shape of the response are decoded: the
+// granularity, grouping and aggregation column names, plus the timeframe (and,
+// for a Custom timeframe, the explicit time period) that bound how many daily
+// buckets a granular query spreads across. Filters are accepted and ignored
+// because the emulator holds a single point-in-time estate.
 type queryDefinition struct {
-	Type    string `json:"type"`
-	Dataset struct {
+	Type       string      `json:"type"`
+	Timeframe  string      `json:"timeframe"`
+	TimePeriod *timePeriod `json:"timePeriod"`
+	Dataset    struct {
 		Granularity string                     `json:"granularity"`
 		Aggregation map[string]aggregationSpec `json:"aggregation"`
 		Grouping    []groupingSpec             `json:"grouping"`
 	} `json:"dataset"`
+}
+
+// timePeriod is the explicit [from, to] window a Custom timeframe supplies. The
+// SDK marshals both bounds as RFC3339 timestamps.
+type timePeriod struct {
+	From string `json:"from"`
+	To   string `json:"to"`
 }
 
 type aggregationSpec struct {

--- a/server/azure/costmanagement/shape.go
+++ b/server/azure/costmanagement/shape.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/server/azure/resourcegraph"
 	"github.com/stackshy/cloudemu/v2/services/cost"
+	"github.com/stackshy/cloudemu/v2/services/pricing"
 )
 
 // keySep separates the per-dimension values of a composite grouping key. It is
@@ -24,14 +25,11 @@ const (
 	granularityMonthly = "monthly"
 )
 
-// hoursPerMonth / hoursPerDay pro-rate a monthly estimate down to one day, using
-// the same 730-hours-per-month convention AWS Cost Explorer's perBucketRate
-// uses, so a Daily query's per-day rows sum to ~= the monthly figure both FinOps
-// surfaces report.
-const (
-	hoursPerMonth = 730.0
-	hoursPerDay   = 24.0
-)
+// hoursPerDay pro-rates a monthly estimate down to one day together with
+// pricing.HoursPerMonth (the shared 730-hours-per-month convention AWS Cost
+// Explorer's perBucketRate also uses), so a Daily query's per-day rows sum to
+// ~= the monthly figure both FinOps surfaces report and the two can't drift.
+const hoursPerDay = 24.0
 
 // shape turns the priced cost lines into the Cost Management columns/rows for
 // the requested granularity and grouping. Column order follows the real API:
@@ -93,7 +91,7 @@ func dailyRows(def *queryDefinition, costCols, groupNames []string, lines []cost
 	}
 
 	start, end := queryDateRange(def)
-	scale := hoursPerDay / hoursPerMonth
+	scale := hoursPerDay / float64(pricing.HoursPerMonth)
 
 	var rows [][]any
 

--- a/server/azure/costmanagement/shape.go
+++ b/server/azure/costmanagement/shape.go
@@ -18,22 +18,47 @@ const keySep = "\x00"
 // column and the always-present Currency column.
 const trailingSlots = 2
 
+// Granularity tokens the request may carry (lower-cased on read).
+const (
+	granularityDaily   = "daily"
+	granularityMonthly = "monthly"
+)
+
+// hoursPerMonth / hoursPerDay pro-rate a monthly estimate down to one day, using
+// the same 730-hours-per-month convention AWS Cost Explorer's perBucketRate
+// uses, so a Daily query's per-day rows sum to ~= the monthly figure both FinOps
+// surfaces report.
+const (
+	hoursPerMonth = 730.0
+	hoursPerDay   = 24.0
+)
+
 // shape turns the priced cost lines into the Cost Management columns/rows for
 // the requested granularity and grouping. Column order follows the real API:
 // the cost aggregation column(s) first, then one column per grouping dimension,
 // then the granularity date column (if any), then Currency last; every row is
 // ordered to match.
+//
+// Granularity drives how the estate's monthly cost is spread over the query's
+// time period, mirroring AWS Cost Explorer: Daily emits one row (per group) per
+// day in the period, each pro-rated to a per-day rate; Monthly emits one row per
+// group at the full monthly figure; an absent/None granularity emits a single
+// aggregate over the period.
 func shape(def *queryDefinition, lines []cost.Line) (columns []column, rows [][]any) {
 	costCols := costColumnNames(def)
-	dateCol, dateVal, hasDate := dateColumn(def.Dataset.Granularity)
 	groupNames := groupingNames(def)
+	gran := strings.ToLower(def.Dataset.Granularity)
 
+	dateCol, hasDate := granularityColumn(gran)
 	columns = buildColumns(costCols, dateCol, hasDate, groupNames)
 
-	if len(groupNames) == 0 {
-		rows = ungroupedRows(costCols, dateVal, hasDate, lines)
-	} else {
-		rows = groupedRows(costCols, dateVal, hasDate, groupNames, lines)
+	switch gran {
+	case granularityDaily:
+		rows = dailyRows(def, costCols, groupNames, lines)
+	case granularityMonthly:
+		rows = bucketRows(costCols, groupNames, lines, monthlyDateValue(), true, 1.0)
+	default:
+		rows = bucketRows(costCols, groupNames, lines, nil, false, 1.0)
 	}
 
 	return columns, rows
@@ -58,9 +83,42 @@ func buildColumns(costCols []string, dateCol column, hasDate bool, groupNames []
 	return append(columns, column{Name: "Currency", Type: "String"})
 }
 
+// dailyRows spreads the estate over each day in the query's time period, one row
+// (per group) per day carrying the per-day pro-rated cost stamped with that
+// day's yyyymmdd UsageDate. An empty estate yields no rows, matching the
+// aggregate path.
+func dailyRows(def *queryDefinition, costCols, groupNames []string, lines []cost.Line) [][]any {
+	if len(lines) == 0 {
+		return [][]any{}
+	}
+
+	start, end := queryDateRange(def)
+	scale := hoursPerDay / hoursPerMonth
+
+	var rows [][]any
+
+	for d := start; !d.After(end); d = d.AddDate(0, 0, 1) {
+		ymd := d.Year()*10000 + int(d.Month())*100 + d.Day()
+		rows = append(rows, bucketRows(costCols, groupNames, lines, ymd, true, scale)...)
+	}
+
+	return rows
+}
+
+// bucketRows shapes the rows for a single time bucket (a day, a month, or the
+// whole period), scaling each cost by scale and stamping the given date value.
+// It dispatches to the ungrouped aggregate or the grouped-by-dimension layout.
+func bucketRows(costCols, groupNames []string, lines []cost.Line, dateVal any, hasDate bool, scale float64) [][]any {
+	if len(groupNames) == 0 {
+		return ungroupedRows(costCols, lines, dateVal, hasDate, scale)
+	}
+
+	return groupedRows(costCols, groupNames, lines, dateVal, hasDate, scale)
+}
+
 // ungroupedRows returns the single aggregate row (or none, when the estate is
-// empty) for a query with no grouping dimensions.
-func ungroupedRows(costCols []string, dateVal any, hasDate bool, lines []cost.Line) [][]any {
+// empty) for a query with no grouping dimensions, scaled to the bucket rate.
+func ungroupedRows(costCols []string, lines []cost.Line, dateVal any, hasDate bool, scale float64) [][]any {
 	if len(lines) == 0 {
 		return [][]any{}
 	}
@@ -70,12 +128,12 @@ func ungroupedRows(costCols []string, dateVal any, hasDate bool, lines []cost.Li
 		total += lines[i].MonthlyUSD
 	}
 
-	return [][]any{buildRow(costCols, total, dateVal, hasDate, nil)}
+	return [][]any{buildRow(costCols, total*scale, dateVal, hasDate, nil)}
 }
 
 // groupedRows buckets the lines by the composite grouping key and returns one
-// row per bucket, sorted for deterministic output.
-func groupedRows(costCols []string, dateVal any, hasDate bool, groupNames []string, lines []cost.Line) [][]any {
+// row per bucket, scaled to the bucket rate, sorted for deterministic output.
+func groupedRows(costCols, groupNames []string, lines []cost.Line, dateVal any, hasDate bool, scale float64) [][]any {
 	type bucket struct {
 		dims  []string
 		total float64
@@ -108,7 +166,7 @@ func groupedRows(costCols []string, dateVal any, hasDate bool, groupNames []stri
 
 	for _, k := range keys {
 		b := buckets[k]
-		rows = append(rows, buildRow(costCols, b.total, dateVal, hasDate, b.dims))
+		rows = append(rows, buildRow(costCols, b.total*scale, dateVal, hasDate, b.dims))
 	}
 
 	return rows
@@ -184,26 +242,95 @@ func groupingNames(def *queryDefinition) []string {
 	return names
 }
 
-// dateColumn returns the granularity date column, its value for the emulator's
-// single period bucket, and whether the query is granular at all. Daily buckets
-// carry a numeric yyyymmdd UsageDate (as real Cost Management does); Monthly
-// carries a BillingMonth timestamp. "None"/absent granularity has no date
-// column — a single aggregate over the period.
-func dateColumn(granularity string) (column, any, bool) {
-	now := time.Now().UTC()
-
-	switch strings.ToLower(granularity) {
-	case "daily":
-		ymd := now.Year()*10000 + int(now.Month())*100 + now.Day()
-
-		return column{Name: "UsageDate", Type: "Number"}, ymd, true
-	case "monthly":
-		month := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-
-		return column{Name: "BillingMonth", Type: "Datetime"}, month.Format("2006-01-02T15:04:05"), true
+// granularityColumn returns the date column for a granularity and whether the
+// query is granular at all. Daily buckets carry a numeric yyyymmdd UsageDate (as
+// real Cost Management does); Monthly carries a BillingMonth timestamp.
+// "None"/absent granularity has no date column — a single aggregate over the
+// period.
+func granularityColumn(gran string) (column, bool) {
+	switch gran {
+	case granularityDaily:
+		return column{Name: "UsageDate", Type: "Number"}, true
+	case granularityMonthly:
+		return column{Name: "BillingMonth", Type: "Datetime"}, true
 	default:
-		return column{}, nil, false
+		return column{}, false
 	}
+}
+
+// monthlyDateValue is the BillingMonth value for a Monthly query: the first of
+// the current month, in the timestamp form real Cost Management emits.
+func monthlyDateValue() any {
+	now := time.Now().UTC()
+	month := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+
+	return month.Format("2006-01-02T15:04:05")
+}
+
+// queryDateRange resolves the inclusive [start, end] day range a granular query
+// spans from its timeframe. MonthToDate (the default) runs from the first of the
+// current month to today; TheLastMonth spans the whole previous calendar month;
+// Custom uses the request's explicit time period. An unrecognized or malformed
+// timeframe falls back to month-to-date, so a granular query always yields at
+// least one day.
+func queryDateRange(def *queryDefinition) (start, end time.Time) {
+	now := time.Now().UTC()
+	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+
+	switch strings.ToLower(def.Timeframe) {
+	case "custom":
+		if from, to, ok := customRange(def.TimePeriod); ok {
+			return from, to
+		}
+	case "thelastmonth", "thelastbillingmonth":
+		lastEnd := monthStart.AddDate(0, 0, -1)
+		lastStart := time.Date(lastEnd.Year(), lastEnd.Month(), 1, 0, 0, 0, 0, time.UTC)
+
+		return lastStart, lastEnd
+	}
+
+	return monthStart, truncateDay(now)
+}
+
+// customRange resolves a Custom timeframe's explicit [from, to] day range,
+// reporting ok=false when the period is absent, unparsable, or inverted.
+func customRange(tp *timePeriod) (start, end time.Time, ok bool) {
+	if tp == nil {
+		return time.Time{}, time.Time{}, false
+	}
+
+	from, okFrom := parseCMDate(tp.From)
+	to, okTo := parseCMDate(tp.To)
+
+	if !okFrom || !okTo || to.Before(from) {
+		return time.Time{}, time.Time{}, false
+	}
+
+	return truncateDay(from), truncateDay(to), true
+}
+
+// parseCMDate parses a Cost Management date, accepting both the RFC3339
+// timestamp the SDK marshals and a bare yyyy-mm-dd.
+func parseCMDate(s string) (time.Time, bool) {
+	if s == "" {
+		return time.Time{}, false
+	}
+
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC(), true
+	}
+
+	if t, err := time.Parse(time.DateOnly, s); err == nil {
+		return t.UTC(), true
+	}
+
+	return time.Time{}, false
+}
+
+// truncateDay drops the time-of-day so day stepping lands on midnight
+// boundaries.
+func truncateDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
 }
 
 // groupValue resolves one line's value for a grouping dimension. The supported

--- a/server/serverkit/cost.go
+++ b/server/serverkit/cost.go
@@ -41,7 +41,7 @@ func serveCost(w http.ResponseWriter, r *http.Request, engines map[string]*resou
 			rr := &res[i]
 
 			est := pricing.Monthly(rr.Provider, rr.Service, rr.Type, rr.SKU, rr.Region, rr.Properties)
-			if est <= 0 {
+			if est <= 0 || !pricing.ComputeInstanceBillable(rr.Service, rr.Type, rr.State) {
 				continue
 			}
 

--- a/services/cost/estimate.go
+++ b/services/cost/estimate.go
@@ -55,7 +55,7 @@ func Estimate(ctx context.Context, inv Inventory) ([]Line, float64, error) {
 		r := &res[i]
 
 		est := pricing.Monthly(r.Provider, r.Service, r.Type, r.SKU, r.Region, r.Properties)
-		if est <= 0 {
+		if est <= 0 || !pricing.ComputeInstanceBillable(r.Service, r.Type, r.State) {
 			continue
 		}
 

--- a/services/pricing/billable_test.go
+++ b/services/pricing/billable_test.go
@@ -1,0 +1,41 @@
+package pricing_test
+
+import (
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/pricing"
+)
+
+// TestComputeInstanceBillable pins the state-aware compute gate: running/pending
+// (and an unknown/empty state) bill compute; every stopped/terminated/
+// deallocated spelling the three clouds use bills $0; and non-compute resources
+// are always billable regardless of any state string.
+func TestComputeInstanceBillable(t *testing.T) {
+	cases := []struct {
+		service, resourceType, state string
+		want                         bool
+	}{
+		{"compute", "Instance", "running", true},
+		{"compute", "Instance", "pending", true},
+		{"compute", "Instance", "", true},        // unknown state stays billable
+		{"compute", "Instance", "Running", true}, // case-insensitive
+		{"compute", "Instance", "stopped", false},
+		{"compute", "Instance", "stopping", false},
+		{"compute", "Instance", "shutting-down", false},
+		{"compute", "Instance", "terminated", false}, // AWS terminate, GCP stop
+		{"compute", "Instance", "deallocated", false},
+		{"compute", "Instance", "DEALLOCATED", false},
+		// Non-compute resources are never gated, even carrying a stopped state.
+		{"compute", "Volume", "stopped", true},
+		{"relationaldb", "DBInstance", "terminated", true},
+		{"loadbalancer", "LoadBalancer", "stopped", true},
+	}
+
+	for _, c := range cases {
+		got := pricing.ComputeInstanceBillable(c.service, c.resourceType, c.state)
+		if got != c.want {
+			t.Errorf("ComputeInstanceBillable(%q,%q,%q) = %v, want %v",
+				c.service, c.resourceType, c.state, got, c.want)
+		}
+	}
+}

--- a/services/pricing/billable_test.go
+++ b/services/pricing/billable_test.go
@@ -7,8 +7,10 @@ import (
 )
 
 // TestComputeInstanceBillable pins the state-aware compute gate: running/pending
-// (and an unknown/empty state) bill compute; every stopped/terminated/
-// deallocated spelling the three clouds use bills $0; and non-compute resources
+// (and an unknown/empty state) bill compute; the canonical non-running VM
+// lifecycle states the walker surfaces (stopping/stopped/shutting-down/
+// terminated — the latter also covers GCP's stopped and Azure's stopped/
+// deallocated, which settle to these values) bill $0; and non-compute resources
 // are always billable regardless of any state string.
 func TestComputeInstanceBillable(t *testing.T) {
 	cases := []struct {
@@ -23,8 +25,10 @@ func TestComputeInstanceBillable(t *testing.T) {
 		{"compute", "Instance", "stopping", false},
 		{"compute", "Instance", "shutting-down", false},
 		{"compute", "Instance", "terminated", false}, // AWS terminate, GCP stop
-		{"compute", "Instance", "deallocated", false},
-		{"compute", "Instance", "DEALLOCATED", false},
+		{"compute", "Instance", "TERMINATED", false}, // case-insensitive
+		// A state the walker never surfaces (e.g. Azure's deallocated, which lives
+		// in a separate PowerState field) is unknown here, so it stays billable.
+		{"compute", "Instance", "deallocated", true},
 		// Non-compute resources are never gated, even carrying a stopped state.
 		{"compute", "Volume", "stopped", true},
 		{"relationaldb", "DBInstance", "terminated", true},

--- a/services/pricing/pricing.go
+++ b/services/pricing/pricing.go
@@ -5,7 +5,11 @@
 // early, not a billing-accurate figure.
 package pricing
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/services/compute"
+)
 
 // HoursPerMonth turns an hourly rate into a monthly estimate (~730h).
 const HoursPerMonth = 730
@@ -242,10 +246,17 @@ var storageGBMonth = map[string]float64{
 
 // ComputeInstanceBillable reports whether a compute instance in the given
 // lifecycle state should be billed for compute. Real clouds bill compute only
-// while an instance is running (or briefly pending): a terminated, shutting-
-// down, stopping, stopped, or deallocated instance bills $0 for compute — a
-// stopped instance still pays for its attached block storage, which is priced
+// while an instance is running (or briefly pending): a stopping, stopped,
+// shutting-down, or terminated instance bills $0 for compute — a stopped
+// instance still pays for its attached block storage, which is priced
 // separately as a compute/Volume resource.
+//
+// The states are the canonical VM lifecycle states from services/compute, the
+// only values the compute walker copies into resourcediscovery.Resource.State.
+// GCP reports a stopped instance as "terminated" and Azure settles both PowerOff
+// and Deallocate to "stopped", so those cases fall out of this same set without
+// extra spellings (Azure's "deallocated" lives in a separate PowerState field
+// the walker never surfaces as State).
 //
 // It gates only compute instances; every other (service, resourceType) pair,
 // and a compute instance whose state is unknown/empty (e.g. a resource
@@ -257,29 +268,12 @@ func ComputeInstanceBillable(service, resourceType, state string) bool {
 	}
 
 	switch strings.ToLower(state) {
-	case StateStopping, StateStopped, StateShuttingDown, StateTerminated, StateTerminating,
-		StateDeallocating, StateDeallocated:
+	case compute.StateStopping, compute.StateStopped, compute.StateShuttingDown, compute.StateTerminated:
 		return false
 	default:
 		return true
 	}
 }
-
-// Non-running compute states that bill $0 for compute. They cover the AWS,
-// Azure, and GCP spellings a walker surfaces on resourcediscovery.Resource.State
-// (GCP reports a stopped instance as "terminated"; Azure settles both PowerOff
-// and Deallocate to "stopped").
-const (
-	StatePending      = "pending"
-	StateRunning      = "running"
-	StateStopping     = "stopping"
-	StateStopped      = "stopped"
-	StateShuttingDown = "shutting-down"
-	StateTerminating  = "terminating"
-	StateTerminated   = "terminated"
-	StateDeallocating = "deallocating"
-	StateDeallocated  = "deallocated"
-)
 
 // hourly returns the rate for sku, or def if the SKU is unknown.
 func hourly(table map[string]float64, sku string, def float64) float64 {

--- a/services/pricing/pricing.go
+++ b/services/pricing/pricing.go
@@ -5,6 +5,8 @@
 // early, not a billing-accurate figure.
 package pricing
 
+import "strings"
+
 // HoursPerMonth turns an hourly rate into a monthly estimate (~730h).
 const HoursPerMonth = 730
 
@@ -20,6 +22,10 @@ const (
 	provGCP   = "gcp"
 	provAzure = "azure"
 )
+
+// computeInstanceKey is the "service/resourceType" discriminator for a compute
+// instance, the one resource kind whose cost depends on its run state.
+const computeInstanceKey = "compute/Instance"
 
 // computeHourly entries are approximate on-demand rates gathered from public
 // pricing knowledge (not a live feed); accurate to ~2 significant figures.
@@ -234,6 +240,47 @@ var storageGBMonth = map[string]float64{
 	"gcp:pd-standard":                 0.04,
 }
 
+// ComputeInstanceBillable reports whether a compute instance in the given
+// lifecycle state should be billed for compute. Real clouds bill compute only
+// while an instance is running (or briefly pending): a terminated, shutting-
+// down, stopping, stopped, or deallocated instance bills $0 for compute — a
+// stopped instance still pays for its attached block storage, which is priced
+// separately as a compute/Volume resource.
+//
+// It gates only compute instances; every other (service, resourceType) pair,
+// and a compute instance whose state is unknown/empty (e.g. a resource
+// constructed directly rather than walked from a provider), is treated as
+// billable, so pricing is unchanged for them.
+func ComputeInstanceBillable(service, resourceType, state string) bool {
+	if service+"/"+resourceType != computeInstanceKey {
+		return true
+	}
+
+	switch strings.ToLower(state) {
+	case StateStopping, StateStopped, StateShuttingDown, StateTerminated, StateTerminating,
+		StateDeallocating, StateDeallocated:
+		return false
+	default:
+		return true
+	}
+}
+
+// Non-running compute states that bill $0 for compute. They cover the AWS,
+// Azure, and GCP spellings a walker surfaces on resourcediscovery.Resource.State
+// (GCP reports a stopped instance as "terminated"; Azure settles both PowerOff
+// and Deallocate to "stopped").
+const (
+	StatePending      = "pending"
+	StateRunning      = "running"
+	StateStopping     = "stopping"
+	StateStopped      = "stopped"
+	StateShuttingDown = "shutting-down"
+	StateTerminating  = "terminating"
+	StateTerminated   = "terminated"
+	StateDeallocating = "deallocating"
+	StateDeallocated  = "deallocated"
+)
+
 // hourly returns the rate for sku, or def if the SKU is unknown.
 func hourly(table map[string]float64, sku string, def float64) float64 {
 	if r, ok := table[sku]; ok {
@@ -379,7 +426,7 @@ func Monthly(provider, service, resourceType, sku, region string, props map[stri
 	mult := regionMult(region)
 
 	switch service + "/" + resourceType {
-	case "compute/Instance":
+	case computeInstanceKey:
 		return hourly(computeHourly, sku, defaultComputeHourly) * mult * HoursPerMonth
 	case "relationaldb/DBInstance",
 		"relationaldb/SqlInstance",

--- a/services/resourcediscovery/types.go
+++ b/services/resourcediscovery/types.go
@@ -44,6 +44,13 @@ type Resource struct {
 	Kind string
 	// ManagedBy is the id of an owning/parent resource (e.g. a disk's VM).
 	ManagedBy string
+	// State is the run/lifecycle state of a stateful resource (a compute
+	// instance's "running"/"stopped"/"terminated"). It is a cost input — a
+	// terminated or stopped instance bills $0 for compute — carried separately
+	// from Properties so it never leaks into the properties bag a passthrough
+	// renderer (Azure Resource Graph) echoes. Empty for resources with no run
+	// state, which cost treats as billable (unchanged).
+	State string
 	// Zones are the availability zones the resource occupies.
 	Zones []string
 	// Properties is an open bag of resource-specific attributes (e.g. disk

--- a/services/resourcediscovery/walkers.go
+++ b/services/resourcediscovery/walkers.go
@@ -192,14 +192,14 @@ func (e *Engine) walkCompute(ctx context.Context) ([]Resource, error) {
 		}
 
 		out = append(out, Resource{
-			Provider:   e.provider,
-			Service:    ServiceCompute,
-			Type:       TypeInstance,
-			ID:         inst.ID,
-			ARN:        e.computeInstanceARN(inst.ID, inst.ResourceGroup),
-			Region:     region,
-			Tags:       copyTags(inst.Tags),
-			SKU:        inst.InstanceType,
+			Provider: e.provider,
+			Service:  ServiceCompute,
+			Type:     TypeInstance,
+			ID:       inst.ID,
+			ARN:      e.computeInstanceARN(inst.ID, inst.ResourceGroup),
+			Region:   region,
+			Tags:     copyTags(inst.Tags),
+			SKU:      inst.InstanceType,
 			// State carries the instance's run state so the cost path can bill $0
 			// for a terminated/stopped instance's compute. For Azure both PowerOff
 			// and Deallocate settle the lifecycle State to "stopped"; GCP reports a

--- a/services/resourcediscovery/walkers.go
+++ b/services/resourcediscovery/walkers.go
@@ -200,6 +200,12 @@ func (e *Engine) walkCompute(ctx context.Context) ([]Resource, error) {
 			Region:     region,
 			Tags:       copyTags(inst.Tags),
 			SKU:        inst.InstanceType,
+			// State carries the instance's run state so the cost path can bill $0
+			// for a terminated/stopped instance's compute. For Azure both PowerOff
+			// and Deallocate settle the lifecycle State to "stopped"; GCP reports a
+			// stopped instance as "terminated" — either way a non-running State
+			// zeroes compute, which is what the cost surfaces want.
+			State:      inst.State,
 			Zones:      cloneStrings(inst.Zones),
 			Properties: orNilProps(props),
 		})


### PR DESCRIPTION
## Summary

Fixes three billing-fidelity bugs the v2.10.0 release e2e surfaced, so cost tracks resource run-state and Azure Cost Management honors daily granularity. Part of #942.

### Bug 1 + 1b — cost ignored instance run-state (terminated & stopped still billed)
Real AWS bills no compute for a terminated instance and $0 compute for a stopped one (EBS only). The emulator kept billing both because discovery lists every instance regardless of lifecycle state and pricing priced any `compute/Instance` by SKU.

**Approach — make COST state-aware, discovery unchanged:**
- Added a dedicated `State` field to `resourcediscovery.Resource` (carried separately from `Properties` so it never leaks into the Azure Resource Graph passthrough), populated by `walkCompute` from the instance's `State` for AWS EC2, Azure VMs, and GCP GCE.
- Added `pricing.ComputeInstanceBillable(service, type, state)`, gating on the canonical VM lifecycle states from `services/compute` (stopping/stopped/shutting-down/terminated — GCP reports a stopped VM as "terminated" and Azure settles both PowerOff and Deallocate to "stopped", so those fall out of the same set). Running/pending — and any unknown/empty state — stay billable, so running-instance numbers are unchanged. Non-compute resources are never gated.
- The two cost callers (`services/cost.Estimate` and `server/serverkit` `/_cloudemu/cost`) apply the gate. Because they share this engine, the state-aware surfaces are: **AWS Cost Explorer, Azure Cost Management, `/_cloudemu/cost`, and `cloudemu cost`**. (GCP Cloud Billing is a catalog/budgets API that does not price the live estate, so it is unaffected.)
- Discovery still lists terminated/stopped instances (Resource Graph, Resource Explorer, Cloud Asset, tagging are untouched) — only their compute cost is zeroed.

This makes create→up, terminate→down, stop→down(compute) true across every FinOps surface that prices the estate.

### Bug 3 — Azure Cost Management `Daily` granularity not bucketed
A `Daily` MonthToDate query returned one row per group at the full monthly cost stamped today. It now emits one row per day across the query's time period, each carrying the pro-rated per-day cost (`hoursPerDay / pricing.HoursPerMonth`, the same 730-hour convention AWS Cost Explorer's `perBucketRate` uses — the shared constant keeps the two from drifting) with the correct yyyymmdd `UsageDate` per row. The day range is derived from the request timeframe (MonthToDate/BillingMonthToDate default, TheLastMonth, and Custom with an explicit time period). `Monthly` still emits one row per period; an absent/None granularity stays a single aggregate. Rows remain positional arrays matching `columns`, and the daily rows sum to ≈ the monthly figure.

## Tests
- **AWS Cost Explorer** (real `costexplorer` + `ec2` clients over one shared server): running estate total > 0; `TerminateInstances` drops the total and reaches 0 once all are terminated; `StopInstances` drops compute to 0.
- **Azure Cost Management** (real `armcostmanagement`): a Daily MonthToDate query returns one pro-rated row per day (N = days in the period), summing ≈ the monthly total; deterministic Daily `Custom` (explicit from/to, no wall-clock dependence) and `TheLastMonth` cases; and a Monthly path (raw JSON POST — the query SDK cannot express a Monthly granularity) that stays one row with a BillingMonth column.
- Unit test pinning `ComputeInstanceBillable` across the canonical state spellings.
- All existing pricing / cost / Cost Explorer / Cost Management / resource-discovery / serverkit tests still pass — running-instance costs unchanged.
