### PR TITLE
ci(docker): publish multi-arch (amd64+arm64) images so arm64 hosts run natively

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,9 @@ jobs:
         id: date
         run: echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -45,6 +48,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -89,6 +93,9 @@ jobs:
             type=semver,pattern={{version}},suffix=-engines
             type=semver,pattern={{major}}.{{minor}},suffix=-engines
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -97,6 +104,7 @@ jobs:
         with:
           context: .
           file: contrib/server/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 # syntax=docker/dockerfile:1
 
 # --- build stage -------------------------------------------------------------
-FROM golang:1.25 AS build
+# Pin the build stage to the runner's native arch ($BUILDPLATFORM) and
+# cross-compile to the requested target ($TARGETOS/$TARGETARCH) so a
+# multi-platform build stays native-speed instead of emulating each arch.
+FROM --platform=$BUILDPLATFORM golang:1.25 AS build
 
 WORKDIR /src
 
@@ -15,9 +18,11 @@ COPY . .
 ARG VERSION=docker
 ARG COMMIT=none
 ARG DATE=unknown
+ARG TARGETOS
+ARG TARGETARCH
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 go build -trimpath \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath \
     -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE} -X main.builtBy=docker" \
     -o /out/cloudemu ./cmd/cloudemu
 

--- a/contrib/server/Dockerfile
+++ b/contrib/server/Dockerfile
@@ -7,7 +7,10 @@
 #   docker build -f contrib/server/Dockerfile -t cloudemu-server .
 
 # --- build stage -------------------------------------------------------------
-FROM golang:1.25 AS build
+# Pin the build stage to the runner's native arch ($BUILDPLATFORM) and
+# cross-compile to the requested target ($TARGETOS/$TARGETARCH) so a
+# multi-platform build stays native-speed instead of emulating each arch.
+FROM --platform=$BUILDPLATFORM golang:1.25 AS build
 
 WORKDIR /src
 
@@ -18,10 +21,12 @@ COPY . .
 # embedded-postgres runs a real (glibc) Postgres binary at runtime, so keep CGO
 # off for a portable Go binary but target a glibc runtime base below.
 ARG VERSION=docker
+ARG TARGETOS
+ARG TARGETARCH
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     cd contrib/server && \
-    CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" \
     -o /out/cloudemu-server .
 
 # --- runtime stage -----------------------------------------------------------


### PR DESCRIPTION
## Problem

The GHCR container images (`ghcr.io/stackshy/cloudemu` and the `:engines` variant) are published **amd64-only**. On Apple-Silicon (arm64) hosts, Docker Desktop runs them under QEMU emulation and shows the warning: *"Image may have poor performance, or fail, if run via emulation."* The release binaries are already dual-arch via GoReleaser; only the container images lagged.

**Root cause:** both `docker/build-push-action@v6` steps in `.github/workflows/docker.yml` (root image + `:engines`) had no `platforms:` field and no `docker/setup-qemu-action`, so each built only the runner's arch (amd64).

## Fix

**Dockerfiles cross-compile** (`Dockerfile` root + `contrib/server/Dockerfile`):
- Build stage pinned to `FROM --platform=$BUILDPLATFORM golang:1.25 AS build`.
- Added `ARG TARGETOS TARGETARCH`; the `go build` now passes `GOOS=$TARGETOS GOARCH=$TARGETARCH`.
- This keeps the build native-speed on the amd64 runner while producing arm64 binaries (no emulated Go compile). The distroless / debian final stages are arch-agnostic and buildx selects the right base per target. All existing ldflags / VERSION-COMMIT-DATE build-args / CGO_ENABLED=0 behavior preserved.

**docker.yml** (both `publish` and `publish-engines` jobs):
- Added a `docker/setup-qemu-action@v3` step before Buildx.
- Added `platforms: linux/amd64,linux/arm64` to the `build-push-action` `with:` block.
- gha cache config (engines scoped separately), tags, labels, and build-args unchanged.

Result: each published tag becomes a multi-arch manifest, so arm64 hosts pull a native variant and the current amd64-only image is superseded on the next publish (release tag).

## Validation

- `actionlint .github/workflows/docker.yml` — clean.
- YAML parses (ruby YAML).
- `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build` succeeds for both `./cmd/cloudemu` and `contrib/server` — no CGO/arch-specific dependency blocks arm64.
- Real `docker buildx build --platform linux/amd64,linux/arm64` (BUILD ONLY, no push) succeeds green for **both** Dockerfiles, each exporting a manifest list with amd64 + arm64 manifests.
- `go build ./...` clean.

True end-to-end confirmation is the next release publish producing the multi-arch manifest on GHCR.