### PR TITLE
fix(serve): apply --latency on the wire path (per-request middleware)

### DIFF
--- a/server/serverkit/latency_test.go
+++ b/server/serverkit/latency_test.go
@@ -1,0 +1,84 @@
+package serverkit
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestLatencyDelaysProviderRequestsNotAdmin is the regression guard for the
+// --latency no-op bug: with a latency configured, an emulated provider request
+// must be delayed by at least that duration on the wire path, while an admin
+// control-plane request (/_cloudemu/health) must NOT be — latency simulation is
+// for the emulated cloud APIs, not the control plane.
+func TestLatencyDelaysProviderRequestsNotAdmin(t *testing.T) {
+	const latency = 40 * time.Millisecond
+
+	app := newTestApp(t, Config{
+		Providers: []string{"aws"},
+		Host:      "127.0.0.1",
+		Ports:     map[string]string{"aws": "0"},
+		Admin:     true,
+		Latency:   latency,
+		Out:       io.Discard,
+	})
+
+	srv := httptest.NewServer(app.handlerFor(app.backends["aws"], app.seedFor("aws")))
+	defer srv.Close()
+
+	// A real round-trip to a provider endpoint must be delayed by >= latency.
+	start := time.Now()
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("provider request: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if elapsed := time.Since(start); elapsed < latency {
+		t.Fatalf("provider request took %v, want >= %v (latency not applied on the wire path)", elapsed, latency)
+	}
+
+	// The admin control plane must be answered without the latency delay.
+	start = time.Now()
+	resp, err = http.Get(srv.URL + "/_cloudemu/health")
+	if err != nil {
+		t.Fatalf("admin request: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("admin health status = %d, want 200", resp.StatusCode)
+	}
+
+	if elapsed := time.Since(start); elapsed >= latency {
+		t.Fatalf("admin health took %v, want < %v (control plane must not be delayed)", elapsed, latency)
+	}
+}
+
+// TestLatencyZeroAddsNoDelay asserts the middleware is a true no-op when latency
+// is unset: the handler is returned unchanged, so there is zero overhead on the
+// hot path.
+func TestLatencyZeroAddsNoDelay(t *testing.T) {
+	app := newTestApp(t, Config{
+		Providers: []string{"aws"},
+		Host:      "127.0.0.1",
+		Ports:     map[string]string{"aws": "0"},
+		Out:       io.Discard,
+	})
+
+	srv := httptest.NewServer(app.backends["aws"])
+	defer srv.Close()
+
+	start := time.Now()
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("provider request: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if elapsed := time.Since(start); elapsed >= 25*time.Millisecond {
+		t.Fatalf("provider request took %v with latency=0; want no added delay", elapsed)
+	}
+}

--- a/server/serverkit/middleware.go
+++ b/server/serverkit/middleware.go
@@ -52,6 +52,33 @@ func (a *App) wrapDirty(h http.Handler) http.Handler {
 	})
 }
 
+// wrapLatency delays every emulated wire request by the configured --latency
+// duration, so the standalone/Docker path honors the same artificial-latency
+// simulation the typed library's portable layer applies per op. It is applied
+// inside the backend swap chain (like wrapDirty), BEFORE the admin Control fronts
+// the backend, so the /_cloudemu control plane (health/reset/snapshot/...) is
+// never delayed — latency simulation is for the emulated cloud APIs, not the
+// control plane. When latency is unset (0) the handler is returned unchanged, so
+// there is zero overhead on the hot path. The sleep is a real per-request
+// time.Sleep — that is the point of latency simulation — and honors request
+// cancellation so a client that gives up doesn't pin the goroutine for the full
+// delay.
+func (a *App) wrapLatency(h http.Handler) http.Handler {
+	d := a.cfg.Latency
+	if d <= 0 {
+		return h
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(d):
+		case <-r.Context().Done():
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}
+
 // statusWriter captures the first response status for logging while remaining a
 // transparent http.ResponseWriter. Write is not overridden — it promotes from
 // the embedded writer, so a handler that writes a body without an explicit

--- a/server/serverkit/serverkit.go
+++ b/server/serverkit/serverkit.go
@@ -501,7 +501,7 @@ func (a *App) swapFresh() []closer {
 		// it. Wrapping here (not in buildServers) keeps admin/health probes — which
 		// Control answers before reaching this backend — from dirtying an idle
 		// emulator.
-		a.k8sBackend.Swap(a.wrapVCR(a.wrapDirty(wrap(k8s, "kubernetes", a.cfg.LogRequests)), "kubernetes"))
+		a.k8sBackend.Swap(a.wrapLatency(a.wrapVCR(a.wrapDirty(wrap(k8s, "kubernetes", a.cfg.LogRequests)), "kubernetes")))
 	}
 
 	for p, h := range fresh {
@@ -545,7 +545,7 @@ func (a *App) buildProvider(p string, k8s *kubernetes.APIServer) builtProvider {
 		cloud.EKS.SetK8sAPI(k8s)
 
 		return builtProvider{
-			handler:   a.wrapVCR(a.wrapDirty(wrap(awsserver.New(d), providerAWS, a.cfg.LogRequests)), providerAWS),
+			handler:   a.wrapLatency(a.wrapVCR(a.wrapDirty(wrap(awsserver.New(d), providerAWS, a.cfg.LogRequests)), providerAWS)),
 			target:    seed.Target{Storage: cloud.S3, Database: cloud.DynamoDB, Secrets: cloud.SecretsManager, Compute: cloud.EC2},
 			snap:      cloud.SnapshotServices(),
 			discovery: cloud.ResourceDiscovery,
@@ -559,7 +559,7 @@ func (a *App) buildProvider(p string, k8s *kubernetes.APIServer) builtProvider {
 		cloud.GKE.SetK8sAPI(k8s)
 
 		return builtProvider{
-			handler:   a.wrapVCR(a.wrapDirty(wrap(gcpserver.New(d), providerGCP, a.cfg.LogRequests)), providerGCP),
+			handler:   a.wrapLatency(a.wrapVCR(a.wrapDirty(wrap(gcpserver.New(d), providerGCP, a.cfg.LogRequests)), providerGCP)),
 			target:    seed.Target{Storage: cloud.GCS, Database: cloud.Firestore, Secrets: cloud.SecretManager, Compute: cloud.GCE},
 			snap:      cloud.SnapshotServices(),
 			discovery: cloud.ResourceDiscovery,
@@ -580,7 +580,7 @@ func (a *App) buildProvider(p string, k8s *kubernetes.APIServer) builtProvider {
 		cloud.AKS.SetK8sAPI(k8s)
 
 		return builtProvider{
-			handler:   a.wrapVCR(a.wrapDirty(wrap(azureserver.New(d), providerAzure, a.cfg.LogRequests)), providerAzure),
+			handler:   a.wrapLatency(a.wrapVCR(a.wrapDirty(wrap(azureserver.New(d), providerAzure, a.cfg.LogRequests)), providerAzure)),
 			target:    seed.Target{Storage: cloud.BlobStorage, Database: cloud.CosmosDB, Secrets: cloud.KeyVault, Compute: cloud.VirtualMachines},
 			snap:      cloud.SnapshotServices(),
 			discovery: cloud.ResourceDiscovery,
@@ -593,7 +593,7 @@ func (a *App) buildProvider(p string, k8s *kubernetes.APIServer) builtProvider {
 		// OCI has no managed-Kubernetes service, so no SetK8sAPI here, and its
 		// *Provider carries no engines to close.
 		return builtProvider{
-			handler: a.wrapVCR(a.wrapDirty(wrap(ociserver.New(d), providerOCI, a.cfg.LogRequests)), providerOCI),
+			handler: a.wrapLatency(a.wrapVCR(a.wrapDirty(wrap(ociserver.New(d), providerOCI, a.cfg.LogRequests)), providerOCI)),
 			target: seed.Target{
 				Storage: cloud.ObjectStorage, Database: cloud.NoSQL,
 				Secrets: cloud.Vault, Compute: cloud.Compute,


### PR DESCRIPTION
## Bug

`cloudemu serve --latency 50ms` was a silent no-op on the wire/Docker path: requests still returned in ~2ms despite the documented "artificial latency added to every emulated call".

## Root cause

The flag parses and plumbs correctly (`config.WithLatency` → `Options.Latency`, appended into `baseOpts` in `server/serverkit/serverkit.go`), but **nothing on the wire path reads `Options.Latency`**. The wire server binds the raw provider mocks (`DriversFrom` → `*s3.Mock` etc.), bypassing the portable `services/*` layer — the only place a per-op `time.Sleep(latency)` exists. So the sleep never ran for `serve`/Docker clients.

## Fix

Add a `wrapLatency` middleware in serverkit that, when `Config.Latency > 0`, sleeps that duration once per incoming wire request before serving it. It is wired into the **same backend wrap chain** that already wraps every provider handler (`wrapLatency(wrapVCR(wrapDirty(wrap(...))))`), so it applies uniformly across AWS/Azure/GCP/OCI and the Kubernetes data plane.

- **Admin-exempt**: the chain lives inside the admin backend, and `admin.Control.ServeHTTP` intercepts `/_cloudemu/*` (health/reset/snapshot/...) before delegating to the wrapped backend — so the control plane is never delayed. Latency simulation is for the emulated cloud APIs, not the control plane.
- Per-request fixed delay (matches "added to every call").
- Honors request cancellation (`select` on `time.After` vs `r.Context().Done()`) so a client that gives up doesn't pin the goroutine for the full delay.
- Zero overhead when latency is unset (handler returned unchanged).

## Tests

`server/serverkit/latency_test.go`:
- `TestLatencyDelaysProviderRequestsNotAdmin` — real httptest round-trip to a provider endpoint takes >= the configured 40ms; `/_cloudemu/health` is not delayed.
- `TestLatencyZeroAddsNoDelay` — latency=0 adds no measurable delay.

## Related follow-up (not in this PR)

The same `Options.Latency` is also unread on the **typed Go library path** (provider mocks don't sleep). This PR scopes the fix to the wire/`serve` path (what `--latency` drives). The library-path gap is a separate follow-up rather than changing every provider mock.
