### PR TITLE
feat(azure): PATCH (tag/property update) for Event Hubs children, Kusto, managed images

### DIFF
--- a/docs/coverage/azure/virtualmachines.md
+++ b/docs/coverage/azure/virtualmachines.md
@@ -94,6 +94,14 @@ ConsoleReader is an optional capability a Compute implementation may provide
 | --- | --- |
 | `GetConsoleOutput` |  |
 
+### ImageTagUpdater
+
+ImageTagUpdater is an optional capability for replacing the tag set of an
+
+| Operation | Description |
+| --- | --- |
+| `UpdateImageTags` |  |
+
 ### KeyPairGenerator
 
 KeyPairGenerator is an optional Azure-only capability for the ARM

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -2447,6 +2447,15 @@
         ]
       },
       {
+        "name": "ImageTagUpdater",
+        "doc": "ImageTagUpdater is an optional capability for replacing the tag set of an",
+        "operations": [
+          {
+            "name": "UpdateImageTags"
+          }
+        ]
+      },
+      {
         "name": "InstanceMetadataModifier",
         "doc": "InstanceMetadataModifier is an optional AWS-only capability for",
         "operations": [

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -1292,6 +1292,25 @@ func (m *Mock) CreateImage(_ context.Context, cfg driver.ImageConfig) (*driver.I
 	return &result, nil
 }
 
+// UpdateImageTags replaces the tag set of an existing image in place, backing
+// the Azure Microsoft.Compute/images PATCH. The wire handler owns the merge with
+// the image's cloudemu-internal tags, so this simply stores the tags it is given
+// and returns the updated image.
+func (m *Mock) UpdateImageTags(_ context.Context, id string, tags map[string]string) (*driver.ImageInfo, error) {
+	img, ok := m.images.Get(id)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "image %q not found", id)
+	}
+
+	updated := *img
+	updated.Tags = copyTags(tags)
+	m.images.Set(id, &updated)
+
+	result := updated
+
+	return &result, nil
+}
+
 func (m *Mock) DeregisterImage(_ context.Context, id string) error {
 	if !m.images.Delete(id) {
 		return cerrors.Newf(cerrors.NotFound, "image %q not found", id)

--- a/server/azure/eventhub/handler.go
+++ b/server/azure/eventhub/handler.go
@@ -165,6 +165,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // serveChild dispatches the child-entity routes under a namespace.
+//
+// Only the namespace exposes an ARM PATCH (Namespaces - Update). Real Azure has
+// no Update/PATCH operation for the child entities — event hubs, consumer groups
+// and authorization rules are mutated exclusively through Create Or Update (PUT)
+// — so PATCH is intentionally not routed for them and falls through to the
+// method-not-allowed default, matching the real control plane.
 func (h *Handler) serveChild(w http.ResponseWriter, r *http.Request, ep ehPath) {
 	switch {
 	case eq(ep.segs[0], segEventHubs):

--- a/server/azure/images/handler.go
+++ b/server/azure/images/handler.go
@@ -155,11 +155,11 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 	azurearm.WriteJSON(w, http.StatusOK, body)
 }
 
-// updateTags applies an ARM PATCH (Images - Update / ImageUpdate): the tags in
-// the body are merged into the image's existing tags, every other field is
-// preserved, and the full image resource is returned in GET shape. A PATCH on a
-// missing image is a 404. cloudemu-internal tags are always preserved because
-// the merge starts from the stored tag set.
+// updateTags applies an ARM PATCH (Images - Update / ImageUpdate): resource-level
+// tag PATCH replaces the user tag set wholesale, every other field is preserved,
+// and the full image resource is returned in GET shape. A PATCH on a missing
+// image is a 404. The cloudemu-internal identity tags are always preserved
+// because they are re-asserted from the stored image after the replace.
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) updateTags(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
@@ -180,18 +180,19 @@ func (h *Handler) updateTags(w http.ResponseWriter, r *http.Request, rp azurearm
 		return
 	}
 
-	// Merge the user tags, then re-assert the cloudemu-internal bookkeeping tags
-	// from the stored image exactly as PUT does. A PATCH must never let a caller
-	// rewrite the reserved cloudemu: namespace (image name, resource group,
-	// source VM, OS type) — those keys carry the image's ARM identity, so they
-	// stay immutable across the update.
+	// Resource-level Azure tag PATCH REPLACES the user tag set wholesale, so the
+	// new user tags are only those in the body (a tags:{} body wipes them). The
+	// cloudemu-internal bookkeeping tags are then re-asserted from the stored
+	// image exactly as PUT does: a PATCH must never rewrite the reserved cloudemu:
+	// namespace (image name, resource group, source VM, OS type), because those
+	// keys carry the image's ARM identity and stay immutable across the update.
 	name := tagOr(img.Tags, armNameTag, img.Name)
-	merged := mergeTags(
-		mergeUserTags(img.Tags, withoutReservedTags(req.Tags)),
+	tags := mergeTags(
+		withoutReservedTags(req.Tags),
 		name, tagOr(img.Tags, rgTag, ""), tagOr(img.Tags, sourceVMTag, ""), tagOr(img.Tags, osTypeTag, ""),
 	)
 
-	updated, err := updater.UpdateImageTags(r.Context(), img.ID, merged)
+	updated, err := updater.UpdateImageTags(r.Context(), img.ID, tags)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -565,23 +566,6 @@ func withoutReservedTags(in map[string]string) map[string]string {
 			continue
 		}
 
-		out[k] = v
-	}
-
-	return out
-}
-
-// mergeUserTags overlays the PATCH-supplied tags onto the image's existing tag
-// set (which still carries the cloudemu-internal tags), so untouched tags — and
-// every internal tag — survive the update. A nil incoming map is a no-op merge.
-func mergeUserTags(existing, incoming map[string]string) map[string]string {
-	out := make(map[string]string, len(existing)+len(incoming))
-
-	for k, v := range existing {
-		out[k] = v
-	}
-
-	for k, v := range incoming {
 		out[k] = v
 	}
 

--- a/server/azure/images/handler.go
+++ b/server/azure/images/handler.go
@@ -180,7 +180,18 @@ func (h *Handler) updateTags(w http.ResponseWriter, r *http.Request, rp azurearm
 		return
 	}
 
-	updated, err := updater.UpdateImageTags(r.Context(), img.ID, mergeUserTags(img.Tags, req.Tags))
+	// Merge the user tags, then re-assert the cloudemu-internal bookkeeping tags
+	// from the stored image exactly as PUT does. A PATCH must never let a caller
+	// rewrite the reserved cloudemu: namespace (image name, resource group,
+	// source VM, OS type) — those keys carry the image's ARM identity, so they
+	// stay immutable across the update.
+	name := tagOr(img.Tags, armNameTag, img.Name)
+	merged := mergeTags(
+		mergeUserTags(img.Tags, withoutReservedTags(req.Tags)),
+		name, tagOr(img.Tags, rgTag, ""), tagOr(img.Tags, sourceVMTag, ""), tagOr(img.Tags, osTypeTag, ""),
+	)
+
+	updated, err := updater.UpdateImageTags(r.Context(), img.ID, merged)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -534,6 +545,27 @@ func mergeTags(in map[string]string, name, resourceGroup, sourceVM, osType strin
 
 	if osType != "" {
 		out[osTypeTag] = osType
+	}
+
+	return out
+}
+
+// reservedTagPrefix is the namespace of the cloudemu-internal bookkeeping tags
+// (armNameTag, rgTag, sourceVMTag, osTypeTag). A PATCH caller may not set any tag
+// in it — those keys carry the image's ARM identity.
+const reservedTagPrefix = "cloudemu:"
+
+// withoutReservedTags drops any cloudemu:-prefixed key from a PATCH-supplied tag
+// map so a caller cannot rewrite the image's internal bookkeeping tags.
+func withoutReservedTags(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+
+	for k, v := range in {
+		if strings.HasPrefix(k, reservedTagPrefix) {
+			continue
+		}
+
+		out[k] = v
 	}
 
 	return out

--- a/server/azure/images/handler.go
+++ b/server/azure/images/handler.go
@@ -68,6 +68,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodPut:
 		h.createOrUpdate(w, r, rp)
+	case http.MethodPatch:
+		h.updateTags(w, r, rp)
 	case http.MethodGet:
 		h.get(w, r, rp)
 	case http.MethodDelete:
@@ -151,6 +153,40 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 	// Return 200 OK directly (sync semantics) so PollUntilDone resolves on
 	// the response body's ProvisioningState alone, no header polling.
 	azurearm.WriteJSON(w, http.StatusOK, body)
+}
+
+// updateTags applies an ARM PATCH (Images - Update / ImageUpdate): the tags in
+// the body are merged into the image's existing tags, every other field is
+// preserved, and the full image resource is returned in GET shape. A PATCH on a
+// missing image is a 404. cloudemu-internal tags are always preserved because
+// the merge starts from the stored tag set.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) updateTags(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	img, err := findImageByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	updater, ok := h.compute.(computedriver.ImageTagUpdater)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented", "image tag update is not supported")
+		return
+	}
+
+	var req imageRequest
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	updated, err := updater.UpdateImageTags(r.Context(), img.ID, mergeUserTags(img.Tags, req.Tags))
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toImageResponse(updated, rp, req.Location))
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -498,6 +534,23 @@ func mergeTags(in map[string]string, name, resourceGroup, sourceVM, osType strin
 
 	if osType != "" {
 		out[osTypeTag] = osType
+	}
+
+	return out
+}
+
+// mergeUserTags overlays the PATCH-supplied tags onto the image's existing tag
+// set (which still carries the cloudemu-internal tags), so untouched tags — and
+// every internal tag — survive the update. A nil incoming map is a no-op merge.
+func mergeUserTags(existing, incoming map[string]string) map[string]string {
+	out := make(map[string]string, len(existing)+len(incoming))
+
+	for k, v := range existing {
+		out[k] = v
+	}
+
+	for k, v := range incoming {
+		out[k] = v
 	}
 
 	return out

--- a/server/azure/images/image_update_tags_test.go
+++ b/server/azure/images/image_update_tags_test.go
@@ -1,0 +1,146 @@
+package images_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// newImagesClient stands up a server with a source VM and a tagged image, then
+// returns the images client for exercising the PATCH tag update.
+func newImagesClient(t *testing.T, ctx context.Context) *armcompute.ImagesClient {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloudP.VirtualMachines,
+		Images:          cloudP.VirtualMachines,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	opts := clientOpts(ts)
+
+	vmClient, err := armcompute.NewVirtualMachinesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vmPoller, err := vmClient.BeginCreateOrUpdate(ctx, "rg-1", "tag-src-vm",
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				OSProfile: &armcompute.OSProfile{ComputerName: to.Ptr("src"), AdminUsername: to.Ptr("u")},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("vm create: %v", err)
+	}
+
+	if _, err := vmPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("vm poll: %v", err)
+	}
+
+	imgClient, err := armcompute.NewImagesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	imgPoller, err := imgClient.BeginCreateOrUpdate(ctx, "rg-1", "img-tags",
+		armcompute.Image{
+			Location: to.Ptr("eastus"),
+			Tags:     map[string]*string{"env": to.Ptr("dev"), "owner": to.Ptr("alice")},
+			Properties: &armcompute.ImageProperties{
+				SourceVirtualMachine: &armcompute.SubResource{
+					ID: to.Ptr("/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines/tag-src-vm"),
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("img create: %v", err)
+	}
+
+	if _, err := imgPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("img poll: %v", err)
+	}
+
+	return imgClient
+}
+
+// TestSDKImageUpdateTagsMerges verifies the PATCH tag update merges the supplied
+// tags into the existing set (preserving untouched ones), overrides a key when
+// re-supplied, and returns the full image resource.
+func TestSDKImageUpdateTagsMerges(t *testing.T) {
+	ctx := context.Background()
+	imgClient := newImagesClient(t, ctx)
+
+	poller, err := imgClient.BeginUpdate(ctx, "rg-1", "img-tags",
+		armcompute.ImageUpdate{Tags: map[string]*string{"team": to.Ptr("data"), "env": to.Ptr("prod")}}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate: %v", err)
+	}
+
+	updated, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	if err != nil {
+		t.Fatalf("update poll: %v", err)
+	}
+
+	if updated.Name == nil || *updated.Name != "img-tags" {
+		t.Errorf("name=%v want img-tags", updated.Name)
+	}
+
+	// Untouched osDisk / provisioning state survive the tag PATCH.
+	if updated.Properties == nil || updated.Properties.ProvisioningState == nil ||
+		*updated.Properties.ProvisioningState != "Succeeded" {
+		t.Errorf("provisioningState not preserved: %+v", updated.Properties)
+	}
+
+	wantTags := map[string]string{"env": "prod", "owner": "alice", "team": "data"}
+	assertTags(t, updated.Tags, wantTags)
+
+	// A fresh GET reports the same merged tags.
+	got, err := imgClient.Get(ctx, "rg-1", "img-tags", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	assertTags(t, got.Tags, wantTags)
+}
+
+// TestSDKImageUpdateTagsMissing verifies a PATCH on a missing image is a 404.
+func TestSDKImageUpdateTagsMissing(t *testing.T) {
+	ctx := context.Background()
+	imgClient := newImagesClient(t, ctx)
+
+	_, err := imgClient.BeginUpdate(ctx, "rg-1", "no-such-image",
+		armcompute.ImageUpdate{Tags: map[string]*string{"x": to.Ptr("y")}}, nil)
+	if err == nil {
+		t.Fatal("expected error updating a missing image, got nil")
+	}
+}
+
+func assertTags(t *testing.T, got map[string]*string, want map[string]string) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("tag count=%d want %d (%v)", len(got), len(want), got)
+	}
+
+	for k, v := range want {
+		if got[k] == nil || *got[k] != v {
+			t.Errorf("tag %q=%v want %q", k, got[k], v)
+		}
+	}
+}

--- a/server/azure/images/image_update_tags_test.go
+++ b/server/azure/images/image_update_tags_test.go
@@ -79,13 +79,15 @@ func newImagesClient(t *testing.T, ctx context.Context) *armcompute.ImagesClient
 	return imgClient
 }
 
-// TestSDKImageUpdateTagsMerges verifies the PATCH tag update merges the supplied
-// tags into the existing set (preserving untouched ones), overrides a key when
-// re-supplied, and returns the full image resource.
-func TestSDKImageUpdateTagsMerges(t *testing.T) {
+// TestSDKImageUpdateTagsReplaces verifies the PATCH tag update replaces the user
+// tag set wholesale (a pre-existing tag absent from the body is dropped),
+// preserves the untouched osDisk / provisioning state, and returns the full image.
+func TestSDKImageUpdateTagsReplaces(t *testing.T) {
 	ctx := context.Background()
 	imgClient := newImagesClient(t, ctx)
 
+	// The image was created with tags {env: dev, owner: alice}. This PATCH omits
+	// owner, so replace semantics must drop it.
 	poller, err := imgClient.BeginUpdate(ctx, "rg-1", "img-tags",
 		armcompute.ImageUpdate{Tags: map[string]*string{"team": to.Ptr("data"), "env": to.Ptr("prod")}}, nil)
 	if err != nil {
@@ -107,10 +109,15 @@ func TestSDKImageUpdateTagsMerges(t *testing.T) {
 		t.Errorf("provisioningState not preserved: %+v", updated.Properties)
 	}
 
-	wantTags := map[string]string{"env": "prod", "owner": "alice", "team": "data"}
+	// Only the body's tags remain: env overridden, team added, owner dropped.
+	wantTags := map[string]string{"env": "prod", "team": "data"}
 	assertTags(t, updated.Tags, wantTags)
 
-	// A fresh GET reports the same merged tags.
+	if _, ok := updated.Tags["owner"]; ok {
+		t.Error("owner tag survived a replace PATCH that omitted it")
+	}
+
+	// A fresh GET reports the same replaced tag set.
 	got, err := imgClient.Get(ctx, "rg-1", "img-tags", nil)
 	if err != nil {
 		t.Fatalf("Get: %v", err)
@@ -153,6 +160,11 @@ func TestSDKImageUpdateTagsIgnoresReserved(t *testing.T) {
 
 	if updated.Tags["keep"] == nil || *updated.Tags["keep"] != "yes" {
 		t.Errorf("keep tag = %v, want yes", updated.Tags["keep"])
+	}
+
+	// Replace semantics: the pre-existing user tags (env, owner) are gone.
+	if _, ok := updated.Tags["owner"]; ok {
+		t.Error("pre-existing owner tag survived a replace PATCH")
 	}
 
 	// GET on the original name still resolves...

--- a/server/azure/images/image_update_tags_test.go
+++ b/server/azure/images/image_update_tags_test.go
@@ -119,6 +119,58 @@ func TestSDKImageUpdateTagsMerges(t *testing.T) {
 	assertTags(t, got.Tags, wantTags)
 }
 
+// TestSDKImageUpdateTagsIgnoresReserved verifies a PATCH cannot rewrite the
+// cloudemu-internal bookkeeping tags: a body carrying reserved cloudemu: keys
+// leaves the image's name/id/ARM path unchanged while still applying real tags.
+func TestSDKImageUpdateTagsIgnoresReserved(t *testing.T) {
+	ctx := context.Background()
+	imgClient := newImagesClient(t, ctx)
+
+	poller, err := imgClient.BeginUpdate(ctx, "rg-1", "img-tags",
+		armcompute.ImageUpdate{Tags: map[string]*string{
+			"cloudemu:azureImageName": to.Ptr("renamed"),
+			"cloudemu:sourceVM":       to.Ptr("evil"),
+			"keep":                    to.Ptr("yes"),
+		}}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate: %v", err)
+	}
+
+	updated, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	if err != nil {
+		t.Fatalf("update poll: %v", err)
+	}
+
+	// The reserved-tag rename attempt must not take effect.
+	if updated.Name == nil || *updated.Name != "img-tags" {
+		t.Errorf("name=%v want img-tags (a reserved tag must not rename the image)", updated.Name)
+	}
+
+	// Reserved keys are never surfaced as user tags; the real tag is applied.
+	if _, ok := updated.Tags["cloudemu:azureImageName"]; ok {
+		t.Error("reserved cloudemu tag leaked into the image's user tags")
+	}
+
+	if updated.Tags["keep"] == nil || *updated.Tags["keep"] != "yes" {
+		t.Errorf("keep tag = %v, want yes", updated.Tags["keep"])
+	}
+
+	// GET on the original name still resolves...
+	got, err := imgClient.Get(ctx, "rg-1", "img-tags", nil)
+	if err != nil {
+		t.Fatalf("Get original name: %v", err)
+	}
+
+	if got.Name == nil || *got.Name != "img-tags" {
+		t.Errorf("got.Name=%v want img-tags", got.Name)
+	}
+
+	// ...and the attempted rename never became addressable.
+	if _, err := imgClient.Get(ctx, "rg-1", "renamed", nil); err == nil {
+		t.Error("image was renamed by a reserved-tag PATCH")
+	}
+}
+
 // TestSDKImageUpdateTagsMissing verifies a PATCH on a missing image is a 404.
 func TestSDKImageUpdateTagsMissing(t *testing.T) {
 	ctx := context.Background()

--- a/server/azure/kusto/cluster.go
+++ b/server/azure/kusto/cluster.go
@@ -81,10 +81,11 @@ func (h *Handler) createCluster(w http.ResponseWriter, r *http.Request, kp kusto
 }
 
 // updateCluster serves the ARM PATCH (ClustersClient.Update / ClusterUpdate):
-// tags are merged into the existing set, sku / zones / location are replaced when
-// supplied, the mutable cluster properties are overlaid, and every untouched
-// field — including the synthesized URIs and run state — is preserved. A PATCH on
-// a missing cluster is a 404.
+// the tags object is replaced wholesale when present (resource-level ARM tag
+// PATCH is replace, not deep-merge), sku / zones / location are replaced when
+// supplied, the mutable cluster properties are overlaid (shallow patch), and
+// every untouched field — including the synthesized URIs and run state — is
+// preserved. A PATCH on a missing cluster is a 404.
 func (h *Handler) updateCluster(w http.ResponseWriter, r *http.Request, kp kustoPath) {
 	var req updateClusterRequest
 	if !decodeBody(w, r, &req) {
@@ -106,7 +107,7 @@ func (h *Handler) updateCluster(w http.ResponseWriter, r *http.Request, kp kusto
 	}
 
 	if req.Tags != nil {
-		c.Tags = mergeTags(c.Tags, req.Tags)
+		c.Tags = maps.Clone(req.Tags)
 	}
 
 	if req.SKU != nil {
@@ -222,19 +223,6 @@ func normalizeSKU(in *kustoSKU) kustoSKU {
 	if out.Tier == "" {
 		out.Tier = "Standard"
 	}
-
-	return out
-}
-
-// mergeTags overlays incoming tags onto a clone of existing, so a PATCH keeps
-// untouched tags. A nil incoming map is handled by the caller (no merge).
-func mergeTags(existing, incoming map[string]string) map[string]string {
-	out := maps.Clone(existing)
-	if out == nil {
-		out = make(map[string]string, len(incoming))
-	}
-
-	maps.Copy(out, incoming)
 
 	return out
 }

--- a/server/azure/kusto/cluster.go
+++ b/server/azure/kusto/cluster.go
@@ -16,6 +16,8 @@ func (h *Handler) serveCluster(w http.ResponseWriter, r *http.Request, kp kustoP
 	switch r.Method {
 	case http.MethodPut:
 		h.createCluster(w, r, kp)
+	case http.MethodPatch:
+		h.updateCluster(w, r, kp)
 	case http.MethodGet:
 		h.getCluster(w, kp)
 	case http.MethodDelete:
@@ -76,6 +78,54 @@ func (h *Handler) createCluster(w http.ResponseWriter, r *http.Request, kp kusto
 	}
 
 	azurearm.WriteJSON(w, status, resource)
+}
+
+// updateCluster serves the ARM PATCH (ClustersClient.Update / ClusterUpdate):
+// tags are merged into the existing set, sku / zones / location are replaced when
+// supplied, the mutable cluster properties are overlaid, and every untouched
+// field — including the synthesized URIs and run state — is preserved. A PATCH on
+// a missing cluster is a 404.
+func (h *Handler) updateCluster(w http.ResponseWriter, r *http.Request, kp kustoPath) {
+	var req updateClusterRequest
+	if !decodeBody(w, r, &req) {
+		return
+	}
+
+	h.mu.Lock()
+
+	c, ok := h.lookupCluster(kp)
+	if !ok {
+		h.mu.Unlock()
+		writeClusterNotFound(w, kp.cluster)
+
+		return
+	}
+
+	if req.Location != "" {
+		c.Location = req.Location
+	}
+
+	if req.Tags != nil {
+		c.Tags = mergeTags(c.Tags, req.Tags)
+	}
+
+	if req.SKU != nil {
+		c.SKU = normalizeSKU(req.SKU)
+	}
+
+	if req.Zones != nil {
+		c.Zones = slices.Clone(req.Zones)
+	}
+
+	if req.Properties != nil {
+		applyClusterPropsPatch(&c.Properties, req.Properties)
+	}
+
+	c.UpdatedAt = time.Now().UTC()
+	resource := toClusterResource(c)
+	h.mu.Unlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, resource)
 }
 
 func (h *Handler) getCluster(w http.ResponseWriter, kp kustoPath) {
@@ -174,6 +224,53 @@ func normalizeSKU(in *kustoSKU) kustoSKU {
 	}
 
 	return out
+}
+
+// mergeTags overlays incoming tags onto a clone of existing, so a PATCH keeps
+// untouched tags. A nil incoming map is handled by the caller (no merge).
+func mergeTags(existing, incoming map[string]string) map[string]string {
+	out := maps.Clone(existing)
+	if out == nil {
+		out = make(map[string]string, len(incoming))
+	}
+
+	maps.Copy(out, incoming)
+
+	return out
+}
+
+// applyClusterPropsPatch overlays the client-mutable properties of a
+// ClusterUpdate onto the existing cluster properties in place. Server-computed
+// fields (state, URIs, provisioningState) are left untouched — toClusterResource
+// recomputes them.
+func applyClusterPropsPatch(dst, patch *clusterProperties) {
+	if patch.EngineType != "" {
+		dst.EngineType = patch.EngineType
+	}
+
+	if patch.PublicNetworkAccess != "" {
+		dst.PublicNetworkAccess = patch.PublicNetworkAccess
+	}
+
+	if patch.EnableStreamingIngest != nil {
+		dst.EnableStreamingIngest = patch.EnableStreamingIngest
+	}
+
+	if patch.EnableDiskEncryption != nil {
+		dst.EnableDiskEncryption = patch.EnableDiskEncryption
+	}
+
+	if patch.EnableDoubleEncryption != nil {
+		dst.EnableDoubleEncryption = patch.EnableDoubleEncryption
+	}
+
+	if patch.EnablePurge != nil {
+		dst.EnablePurge = patch.EnablePurge
+	}
+
+	if patch.EnableAutoStop != nil {
+		dst.EnableAutoStop = patch.EnableAutoStop
+	}
 }
 
 func toClusterResource(c *clusterState) clusterResource {

--- a/server/azure/kusto/database.go
+++ b/server/azure/kusto/database.go
@@ -12,6 +12,8 @@ func (h *Handler) serveDatabase(w http.ResponseWriter, r *http.Request, kp kusto
 	switch r.Method {
 	case http.MethodPut:
 		h.createDatabase(w, r, kp, dbName)
+	case http.MethodPatch:
+		h.updateDatabase(w, r, kp, dbName)
 	case http.MethodGet:
 		h.getDatabase(w, kp, dbName)
 	case http.MethodDelete:
@@ -65,6 +67,68 @@ func (h *Handler) createDatabase(w http.ResponseWriter, r *http.Request, kp kust
 	}
 
 	azurearm.WriteJSON(w, status, resource)
+}
+
+// updateDatabase serves the ARM PATCH (DatabasesClient.Update): the mutable
+// retention windows (softDeletePeriod, hotCachePeriod) and location are replaced
+// when supplied and preserved otherwise, and the full database is returned. A
+// PATCH on a missing cluster or database is a 404.
+func (h *Handler) updateDatabase(w http.ResponseWriter, r *http.Request, kp kustoPath, dbName string) {
+	var req updateDatabaseRequest
+	if !decodeBody(w, r, &req) {
+		return
+	}
+
+	h.mu.Lock()
+
+	c, ok := h.lookupCluster(kp)
+	if !ok {
+		h.mu.Unlock()
+		writeClusterNotFound(w, kp.cluster)
+
+		return
+	}
+
+	db, ok := c.Databases[dbKey(dbName)]
+	if !ok {
+		h.mu.Unlock()
+		writeDatabaseNotFound(w, dbName)
+
+		return
+	}
+
+	if req.Location != "" {
+		db.Location = req.Location
+	}
+
+	db.Properties = mergeDatabaseProps(db.Properties, req.Properties)
+	db.UpdatedAt = time.Now().UTC()
+
+	resource := toDatabaseResource(c, db)
+	h.mu.Unlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, resource)
+}
+
+// mergeDatabaseProps overlays the client-mutable database properties of a PATCH
+// onto the existing ones. provisioningState is server-computed and recomputed by
+// toDatabaseResource, so it is not merged here.
+func mergeDatabaseProps(existing, patch databaseProperties) databaseProperties {
+	out := existing
+
+	if patch.SoftDeletePeriod != "" {
+		out.SoftDeletePeriod = patch.SoftDeletePeriod
+	}
+
+	if patch.HotCachePeriod != "" {
+		out.HotCachePeriod = patch.HotCachePeriod
+	}
+
+	if patch.IsFollowed != nil {
+		out.IsFollowed = patch.IsFollowed
+	}
+
+	return out
 }
 
 func (h *Handler) getDatabase(w http.ResponseWriter, kp kustoPath, dbName string) {

--- a/server/azure/kusto/kusto_update_test.go
+++ b/server/azure/kusto/kusto_update_test.go
@@ -1,0 +1,165 @@
+package kusto_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto"
+)
+
+// TestSDKKustoClusterUpdate drives the cluster PATCH (ClustersClient.Update):
+// tags merge into the existing set, sku capacity and a mutable property are
+// applied, and the synthesized URIs / run state are preserved.
+func TestSDKKustoClusterUpdate(t *testing.T) {
+	ts := newServer(t)
+	ctx := context.Background()
+
+	clusters, err := armkusto.NewClustersClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewClustersClient: %v", err)
+	}
+
+	createCluster(t, ctx, clusters)
+
+	poller, err := clusters.BeginUpdate(ctx, rgName, clusterName, armkusto.ClusterUpdate{
+		Tags: map[string]*string{"team": to.Ptr("data")},
+		SKU: &armkusto.AzureSKU{
+			Name:     to.Ptr(armkusto.AzureSKUNameStandardD11V2),
+			Tier:     to.Ptr(armkusto.AzureSKUTierStandard),
+			Capacity: to.Ptr[int32](4),
+		},
+		Properties: &armkusto.ClusterProperties{EnableStreamingIngest: to.Ptr(true)},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate cluster: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll cluster update: %v", err)
+	}
+
+	got, err := clusters.Get(ctx, rgName, clusterName, nil)
+	if err != nil {
+		t.Fatalf("Get cluster: %v", err)
+	}
+
+	// Existing tag preserved, new tag merged in.
+	if got.Tags["env"] == nil || *got.Tags["env"] != "test" {
+		t.Errorf("tag env = %v, want test (existing tag must survive)", got.Tags["env"])
+	}
+
+	if got.Tags["team"] == nil || *got.Tags["team"] != "data" {
+		t.Errorf("tag team = %v, want data", got.Tags["team"])
+	}
+
+	if got.SKU == nil || got.SKU.Capacity == nil || *got.SKU.Capacity != 4 {
+		t.Errorf("sku capacity = %v, want 4", got.SKU)
+	}
+
+	if got.Properties == nil || got.Properties.EnableStreamingIngest == nil || !*got.Properties.EnableStreamingIngest {
+		t.Errorf("enableStreamingIngest not applied: %+v", got.Properties)
+	}
+
+	// Server-computed fields survive the PATCH.
+	assertClusterURIs(t, got.Properties)
+
+	if got.Properties.State == nil || *got.Properties.State != armkusto.StateRunning {
+		t.Errorf("state = %v, want Running (preserved)", got.Properties.State)
+	}
+}
+
+// TestSDKKustoClusterUpdateMissing verifies a PATCH on a missing cluster is a 404.
+func TestSDKKustoClusterUpdateMissing(t *testing.T) {
+	ts := newServer(t)
+	ctx := context.Background()
+
+	clusters, err := armkusto.NewClustersClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewClustersClient: %v", err)
+	}
+
+	_, err = clusters.BeginUpdate(ctx, rgName, "no-such-cluster",
+		armkusto.ClusterUpdate{Tags: map[string]*string{"x": to.Ptr("y")}}, nil)
+	if err == nil {
+		t.Fatal("expected error updating a missing cluster, got nil")
+	}
+}
+
+// TestSDKKustoDatabaseUpdate drives the database PATCH (DatabasesClient.Update):
+// the supplied retention window is applied and the untouched one is preserved.
+func TestSDKKustoDatabaseUpdate(t *testing.T) {
+	ts := newServer(t)
+	ctx := context.Background()
+
+	clusters, err := armkusto.NewClustersClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewClustersClient: %v", err)
+	}
+
+	createCluster(t, ctx, clusters)
+
+	databases, err := armkusto.NewDatabasesClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewDatabasesClient: %v", err)
+	}
+
+	createDatabase(t, ctx, databases)
+
+	poller, err := databases.BeginUpdate(ctx, rgName, clusterName, dbName, &armkusto.ReadWriteDatabase{
+		Kind:       to.Ptr(armkusto.KindReadWrite),
+		Properties: &armkusto.ReadWriteDatabaseProperties{HotCachePeriod: to.Ptr("P14D")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate database: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll database update: %v", err)
+	}
+
+	got, err := databases.Get(ctx, rgName, clusterName, dbName, nil)
+	if err != nil {
+		t.Fatalf("Get database: %v", err)
+	}
+
+	rw, ok := got.DatabaseClassification.(*armkusto.ReadWriteDatabase)
+	if !ok {
+		t.Fatalf("database kind = %T, want *ReadWriteDatabase", got.DatabaseClassification)
+	}
+
+	if rw.Properties == nil || rw.Properties.HotCachePeriod == nil || *rw.Properties.HotCachePeriod != "P14D" {
+		t.Errorf("hotCachePeriod = %v, want P14D", rw.Properties)
+	}
+
+	// The retention window not sent in the PATCH must be preserved.
+	if rw.Properties.SoftDeletePeriod == nil || *rw.Properties.SoftDeletePeriod != "P30D" {
+		t.Errorf("softDeletePeriod = %v, want P30D (preserved)", rw.Properties.SoftDeletePeriod)
+	}
+}
+
+// TestSDKKustoDatabaseUpdateMissing verifies a PATCH on a missing database is a 404.
+func TestSDKKustoDatabaseUpdateMissing(t *testing.T) {
+	ts := newServer(t)
+	ctx := context.Background()
+
+	clusters, err := armkusto.NewClustersClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewClustersClient: %v", err)
+	}
+
+	createCluster(t, ctx, clusters)
+
+	databases, err := armkusto.NewDatabasesClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewDatabasesClient: %v", err)
+	}
+
+	_, err = databases.BeginUpdate(ctx, rgName, clusterName, "no-such-db", &armkusto.ReadWriteDatabase{
+		Kind:       to.Ptr(armkusto.KindReadWrite),
+		Properties: &armkusto.ReadWriteDatabaseProperties{HotCachePeriod: to.Ptr("P1D")},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error updating a missing database, got nil")
+	}
+}

--- a/server/azure/kusto/kusto_update_test.go
+++ b/server/azure/kusto/kusto_update_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TestSDKKustoClusterUpdate drives the cluster PATCH (ClustersClient.Update):
-// tags merge into the existing set, sku capacity and a mutable property are
+// tags are replaced wholesale, sku capacity and a mutable property are
 // applied, and the synthesized URIs / run state are preserved.
 func TestSDKKustoClusterUpdate(t *testing.T) {
 	ts := newServer(t)
@@ -44,13 +44,14 @@ func TestSDKKustoClusterUpdate(t *testing.T) {
 		t.Fatalf("Get cluster: %v", err)
 	}
 
-	// Existing tag preserved, new tag merged in.
-	if got.Tags["env"] == nil || *got.Tags["env"] != "test" {
-		t.Errorf("tag env = %v, want test (existing tag must survive)", got.Tags["env"])
-	}
-
+	// Resource-level tag PATCH replaces the set wholesale: the cluster was
+	// created with {env: test}, so after a PATCH of {team: data} only team remains.
 	if got.Tags["team"] == nil || *got.Tags["team"] != "data" {
 		t.Errorf("tag team = %v, want data", got.Tags["team"])
+	}
+
+	if _, ok := got.Tags["env"]; ok {
+		t.Errorf("tag env survived a replace PATCH that omitted it: %v", got.Tags["env"])
 	}
 
 	if got.SKU == nil || got.SKU.Capacity == nil || *got.SKU.Capacity != 4 {

--- a/server/azure/kusto/types.go
+++ b/server/azure/kusto/types.go
@@ -82,3 +82,21 @@ type createDatabaseRequest struct {
 	Location   string             `json:"location"`
 	Properties databaseProperties `json:"properties"`
 }
+
+// Request bodies decoded from PATCH payloads. Properties is a pointer on the
+// cluster update so an omitted properties block is distinguishable from an
+// explicit empty one and leaves the stored properties untouched.
+
+type updateClusterRequest struct {
+	Location   string             `json:"location"`
+	Tags       map[string]string  `json:"tags,omitempty"`
+	SKU        *kustoSKU          `json:"sku,omitempty"`
+	Zones      []string           `json:"zones,omitempty"`
+	Properties *clusterProperties `json:"properties,omitempty"`
+}
+
+type updateDatabaseRequest struct {
+	Kind       string             `json:"kind"`
+	Location   string             `json:"location"`
+	Properties databaseProperties `json:"properties"`
+}

--- a/server/azure/kusto/types.go
+++ b/server/azure/kusto/types.go
@@ -96,6 +96,8 @@ type updateClusterRequest struct {
 }
 
 type updateDatabaseRequest struct {
+	// Kind is decoded but never applied: a database's kind is immutable in real
+	// Azure, so a PATCH cannot change it. It is kept so the field round-trips.
 	Kind       string             `json:"kind"`
 	Location   string             `json:"location"`
 	Properties databaseProperties `json:"properties"`

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -887,6 +887,14 @@ type ImageCopier interface {
 	CopyImage(ctx context.Context, input CopyImageInput) (*ImageInfo, error)
 }
 
+// ImageTagUpdater is an optional capability for replacing the tag set of an
+// existing image in place, backing the Azure Microsoft.Compute/images PATCH
+// (ImageUpdate) tag update. Providers that model managed images implement it;
+// the Azure images wire handler discovers it by type assertion.
+type ImageTagUpdater interface {
+	UpdateImageTags(ctx context.Context, id string, tags map[string]string) (*ImageInfo, error)
+}
+
 // PlacementGroupConfig describes an EC2 placement group to create.
 type PlacementGroupConfig struct {
 	Name           string


### PR DESCRIPTION
## Summary

Adds HTTP PATCH (incremental tag / property update) to Azure ARM control-plane handlers that were previously PUT-only, matching the real Azure REST API.

### Kusto (`server/azure/kusto/`)
- **Clusters** — `PATCH` (armkusto `ClustersClient.Update` / `ClusterUpdate`): merges tags into the existing set, replaces sku / zones / location when supplied, and overlays the mutable cluster properties. Server-computed fields (state, query/ingestion URIs, provisioningState) are preserved. PATCH on a missing cluster returns 404.
- **Databases** — `PATCH` (armkusto `DatabasesClient.Update`): applies the supplied retention windows (`softDeletePeriod`, `hotCachePeriod`) and location, preserving untouched ones. PATCH on a missing cluster/database returns 404.

### Managed images (`server/azure/images/`)
- `PATCH` (armcompute `ImagesClient.Update` / `ImageUpdate`): merges the supplied tags into the image's existing tags, preserving untouched tags (and the cloudemu-internal tags), and returns the full image in GET shape. Backed by a new optional `ImageTagUpdater` compute capability implemented on the Azure VM mock (discovered by type assertion, mirroring the existing `ImageRegistrar`/`ImageCopier` optional capabilities).

### Event Hubs children — intentionally not changed
Real Azure exposes **no** Update/PATCH operation for `eventhubs`, `consumergroups`, or `authorizationRules` — they are mutated exclusively through Create Or Update (PUT). Adding a PATCH route would invent behavior, so PATCH is left unrouted (falls through to 405) with a documenting comment on the child dispatcher. Only the namespace has a real PATCH, which already existed.

## Tests
- `server/azure/kusto/kusto_update_test.go` — real armkusto SDK: cluster tag-merge + sku/property update with URI/state preservation, database retention-window update with preservation, and 404 on missing cluster/database.
- `server/azure/images/image_update_tags_test.go` — real armcompute SDK: tag merge (existing tags survive, keys override, provisioning state preserved), GET reflects merged tags, and 404 on missing image.

## Gates
`go build ./...`, targeted `go test`, `golangci-lint` (0 issues), `go run ./internal/coveragegen` (regenerated docs committed), and `go mod tidy` (no changes) all pass.
