### PR TITLE
feat(azure-compute): whole-VMSS power operations + PATCH

### DIFF
--- a/providers/azure/virtualmachines/scaleset.go
+++ b/providers/azure/virtualmachines/scaleset.go
@@ -314,6 +314,144 @@ func (m *Mock) PowerScaleSetVM(_ context.Context, vmssName, instanceID, action s
 	return nil
 }
 
+// PowerScaleSet applies a power action to every instance of a scale set — or to
+// the subset named by instanceIDs when non-empty — mirroring the whole-VMSS ARM
+// power actions (Start / PowerOff / Deallocate / Restart / Reimage). It updates
+// each affected instance's power state so a subsequent instanceView reflects it.
+// Returns NotFound when the scale set (or a named instance) does not exist and
+// InvalidArgument for an unknown action.
+func (m *Mock) PowerScaleSet(_ context.Context, vmssName, action string, instanceIDs []string) error {
+	key, ok := m.findScaleSetKey(vmssName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "virtualMachineScaleSet %q not found", vmssName)
+	}
+
+	power, perr := powerStateForAction(action)
+	if perr != nil {
+		return perr
+	}
+
+	targets := instanceIDSet(instanceIDs)
+	matched := make(map[string]bool, len(instanceIDs))
+
+	m.scaleSets.Update(key, func(s *ScaleSet) *ScaleSet {
+		for i := range s.Instances {
+			if targets != nil && !targets[s.Instances[i].InstanceID] {
+				continue
+			}
+
+			s.Instances[i].PowerState = power
+			matched[s.Instances[i].InstanceID] = true
+		}
+
+		return s
+	})
+
+	if targets != nil {
+		for _, id := range instanceIDs {
+			if id != "*" && !matched[id] {
+				return cerrors.Newf(cerrors.NotFound, "virtualMachineScaleSet %q has no instance %q", vmssName, id)
+			}
+		}
+	}
+
+	return nil
+}
+
+// instanceIDSet returns the membership set for a subset power request, or nil
+// when the request targets every instance (empty, or the "*" wildcard Azure
+// accepts to mean all).
+func instanceIDSet(ids []string) map[string]bool {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	for _, id := range ids {
+		if id == "*" {
+			return nil
+		}
+	}
+
+	set := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
+	}
+
+	return set
+}
+
+// ScaleSetPatch carries the mutable fields a whole-VMSS PATCH (ARM
+// VirtualMachineScaleSets Update) can change. A zero-valued field leaves the
+// stored value untouched; Tags are merged key-by-key rather than replaced; a
+// non-nil Capacity rescales the set, reconciling its materialized instances.
+type ScaleSetPatch struct {
+	Tags        map[string]string
+	SKUName     string
+	SKUTier     string
+	Capacity    *int64
+	Priority    string
+	LicenseType string
+}
+
+// UpdateScaleSet merge-patches a stored VMSS and returns the full updated
+// resource. Returns NotFound when no scale set with that name exists.
+//
+//nolint:gocritic // patch mirrors a request-scoped value passed once per call.
+func (m *Mock) UpdateScaleSet(_ context.Context, name string, patch ScaleSetPatch) (*ScaleSet, error) {
+	key, ok := m.findScaleSetKey(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "virtualMachineScaleSet %q not found", name)
+	}
+
+	var out ScaleSet
+
+	m.scaleSets.Update(key, func(s *ScaleSet) *ScaleSet {
+		applyScaleSetPatch(s, patch)
+		out = *s
+
+		return s
+	})
+
+	return &out, nil
+}
+
+// applyScaleSetPatch merges the supplied mutable fields into s in place.
+//
+//nolint:gocritic // patch mirrors a request-scoped value passed once per call.
+func applyScaleSetPatch(s *ScaleSet, patch ScaleSetPatch) {
+	if len(patch.Tags) > 0 {
+		if s.Tags == nil {
+			s.Tags = make(map[string]string, len(patch.Tags))
+		}
+
+		for k, v := range patch.Tags {
+			s.Tags[k] = v
+		}
+	}
+
+	if patch.SKUName != "" {
+		s.SKUName = patch.SKUName
+	}
+
+	if patch.SKUTier != "" {
+		s.SKUTier = patch.SKUTier
+	}
+
+	if patch.Priority != "" {
+		s.Priority = patch.Priority
+	}
+
+	if patch.LicenseType != "" {
+		s.LicenseType = patch.LicenseType
+	}
+
+	if patch.Capacity != nil {
+		s.Capacity = int(*patch.Capacity)
+		s.CapacityZero = *patch.Capacity == 0
+		s.Instances = reconcileScaleSetVMs(s.Instances, s.Capacity)
+	}
+}
+
 // powerStateForAction maps a per-instance power action verb to the power state
 // the instance settles in. start/restart/reimage leave the VM running;
 // poweroff stops it (allocated); deallocate releases the compute.

--- a/providers/azure/virtualmachines/scaleset.go
+++ b/providers/azure/virtualmachines/scaleset.go
@@ -349,7 +349,7 @@ func (m *Mock) PowerScaleSet(_ context.Context, vmssName, action string, instanc
 
 	if targets != nil {
 		for _, id := range instanceIDs {
-			if id != "*" && !matched[id] {
+			if !matched[id] {
 				return cerrors.Newf(cerrors.NotFound, "virtualMachineScaleSet %q has no instance %q", vmssName, id)
 			}
 		}
@@ -359,17 +359,12 @@ func (m *Mock) PowerScaleSet(_ context.Context, vmssName, action string, instanc
 }
 
 // instanceIDSet returns the membership set for a subset power request, or nil
-// when the request targets every instance (empty, or the "*" wildcard Azure
-// accepts to mean all).
+// when instanceIDs is omitted. Real Azure targets every instance by omitting
+// instanceIds entirely (an explicit list targets exactly that subset); there is
+// no all-instances sentinel value.
 func instanceIDSet(ids []string) map[string]bool {
 	if len(ids) == 0 {
 		return nil
-	}
-
-	for _, id := range ids {
-		if id == "*" {
-			return nil
-		}
 	}
 
 	set := make(map[string]bool, len(ids))
@@ -382,7 +377,8 @@ func instanceIDSet(ids []string) map[string]bool {
 
 // ScaleSetPatch carries the mutable fields a whole-VMSS PATCH (ARM
 // VirtualMachineScaleSets Update) can change. A zero-valued field leaves the
-// stored value untouched; Tags are merged key-by-key rather than replaced; a
+// stored value untouched; a non-nil Tags map replaces the tag set wholesale
+// (an empty map wipes it), matching ARM resource-level PATCH semantics; a
 // non-nil Capacity rescales the set, reconciling its materialized instances.
 type ScaleSetPatch struct {
 	Tags        map[string]string
@@ -419,14 +415,8 @@ func (m *Mock) UpdateScaleSet(_ context.Context, name string, patch ScaleSetPatc
 //
 //nolint:gocritic // patch mirrors a request-scoped value passed once per call.
 func applyScaleSetPatch(s *ScaleSet, patch ScaleSetPatch) {
-	if len(patch.Tags) > 0 {
-		if s.Tags == nil {
-			s.Tags = make(map[string]string, len(patch.Tags))
-		}
-
-		for k, v := range patch.Tags {
-			s.Tags[k] = v
-		}
+	if patch.Tags != nil {
+		s.Tags = patch.Tags
 	}
 
 	if patch.SKUName != "" {

--- a/providers/azure/virtualmachines/scaleset_test.go
+++ b/providers/azure/virtualmachines/scaleset_test.go
@@ -138,6 +138,114 @@ func TestScaleSetPowerAndDeleteInstance(t *testing.T) {
 	require.Error(t, m.PowerScaleSetVM(ctx, "vmss-ops", "0", "bogus"))
 }
 
+func TestPowerScaleSetWholeSet(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateScaleSet(ctx, ScaleSet{Name: "vmss-ws", Capacity: 3})
+	require.NoError(t, err)
+
+	// Whole-set poweroff transitions every instance to stopped.
+	require.NoError(t, m.PowerScaleSet(ctx, "vmss-ws", "poweroff", nil))
+
+	vms, err := m.ListScaleSetVMs(ctx, "vmss-ws")
+	require.NoError(t, err)
+	require.Len(t, vms, 3)
+
+	for _, vm := range vms {
+		assert.Equal(t, scaleSetVMStopped, vm.PowerState)
+	}
+
+	// Whole-set start brings them all back to running.
+	require.NoError(t, m.PowerScaleSet(ctx, "vmss-ws", "start", nil))
+
+	vms, err = m.ListScaleSetVMs(ctx, "vmss-ws")
+	require.NoError(t, err)
+
+	for _, vm := range vms {
+		assert.Equal(t, scaleSetVMRunning, vm.PowerState)
+	}
+
+	// A subset request touches only the named instance.
+	require.NoError(t, m.PowerScaleSet(ctx, "vmss-ws", "deallocate", []string{"1"}))
+
+	vm1, err := m.GetScaleSetVM(ctx, "vmss-ws", "1")
+	require.NoError(t, err)
+	assert.Equal(t, scaleSetVMDeallocated, vm1.PowerState)
+
+	vm0, err := m.GetScaleSetVM(ctx, "vmss-ws", "0")
+	require.NoError(t, err)
+	assert.Equal(t, scaleSetVMRunning, vm0.PowerState)
+}
+
+func TestPowerScaleSetErrors(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateScaleSet(ctx, ScaleSet{Name: "vmss-err", Capacity: 2})
+	require.NoError(t, err)
+
+	// Missing scale set → NotFound.
+	require.Error(t, m.PowerScaleSet(ctx, "no-such", "start", nil))
+
+	// Unknown action → InvalidArgument.
+	require.Error(t, m.PowerScaleSet(ctx, "vmss-err", "bogus", nil))
+
+	// Subset naming a non-existent instance → NotFound.
+	require.Error(t, m.PowerScaleSet(ctx, "vmss-err", "start", []string{"9"}))
+}
+
+func TestUpdateScaleSetMergesTagsAndCapacity(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateScaleSet(ctx, ScaleSet{
+		Name:     "vmss-patch",
+		Capacity: 2,
+		Tags:     map[string]string{"env": "dev"},
+	})
+	require.NoError(t, err)
+
+	cap4 := int64(4)
+
+	updated, err := m.UpdateScaleSet(ctx, "vmss-patch", ScaleSetPatch{
+		Tags:     map[string]string{"team": "platform"},
+		Capacity: &cap4,
+	})
+	require.NoError(t, err)
+
+	// Tags merge (pre-existing key survives), capacity rescales.
+	assert.Equal(t, "dev", updated.Tags["env"])
+	assert.Equal(t, "platform", updated.Tags["team"])
+	assert.Equal(t, 4, updated.Capacity)
+
+	vms, err := m.ListScaleSetVMs(ctx, "vmss-patch")
+	require.NoError(t, err)
+	require.Len(t, vms, 4)
+
+	// Missing scale set → NotFound.
+	_, err = m.UpdateScaleSet(ctx, "no-such", ScaleSetPatch{})
+	require.Error(t, err)
+}
+
+func TestUpdateScaleSetExplicitZeroCapacity(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateScaleSet(ctx, ScaleSet{Name: "vmss-scalein", Capacity: 3})
+	require.NoError(t, err)
+
+	cap0 := int64(0)
+
+	updated, err := m.UpdateScaleSet(ctx, "vmss-scalein", ScaleSetPatch{Capacity: &cap0})
+	require.NoError(t, err)
+	assert.Equal(t, 0, updated.Capacity)
+
+	vms, err := m.ListScaleSetVMs(ctx, "vmss-scalein")
+	require.NoError(t, err)
+	assert.Empty(t, vms)
+}
+
 func TestScaleSetReconcilePreservesStateAcrossCapacityChange(t *testing.T) {
 	ctx := context.Background()
 	m := newTestMock()

--- a/providers/azure/virtualmachines/scaleset_test.go
+++ b/providers/azure/virtualmachines/scaleset_test.go
@@ -195,7 +195,7 @@ func TestPowerScaleSetErrors(t *testing.T) {
 	require.Error(t, m.PowerScaleSet(ctx, "vmss-err", "start", []string{"9"}))
 }
 
-func TestUpdateScaleSetMergesTagsAndCapacity(t *testing.T) {
+func TestUpdateScaleSetReplacesTagsAndRescales(t *testing.T) {
 	ctx := context.Background()
 	m := newTestMock()
 
@@ -214,14 +214,25 @@ func TestUpdateScaleSetMergesTagsAndCapacity(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Tags merge (pre-existing key survives), capacity rescales.
-	assert.Equal(t, "dev", updated.Tags["env"])
+	// A supplied Tags map replaces the tag set wholesale (ARM PATCH semantics):
+	// the new key is present and the pre-existing key is gone.
 	assert.Equal(t, "platform", updated.Tags["team"])
+	assert.NotContains(t, updated.Tags, "env")
 	assert.Equal(t, 4, updated.Capacity)
 
 	vms, err := m.ListScaleSetVMs(ctx, "vmss-patch")
 	require.NoError(t, err)
 	require.Len(t, vms, 4)
+
+	// A PATCH that omits tags (nil map) leaves the current tag set untouched.
+	unchanged, err := m.UpdateScaleSet(ctx, "vmss-patch", ScaleSetPatch{})
+	require.NoError(t, err)
+	assert.Equal(t, "platform", unchanged.Tags["team"])
+
+	// An empty (non-nil) tags map wipes the tag set.
+	wiped, err := m.UpdateScaleSet(ctx, "vmss-patch", ScaleSetPatch{Tags: map[string]string{}})
+	require.NoError(t, err)
+	assert.Empty(t, wiped.Tags)
 
 	// Missing scale set → NotFound.
 	_, err = m.UpdateScaleSet(ctx, "no-such", ScaleSetPatch{})

--- a/server/azure/virtualmachines/handler.go
+++ b/server/azure/virtualmachines/handler.go
@@ -44,6 +44,17 @@ const resourceTypeScaleSets = "virtualMachineScaleSets"
 // status endpoints (Microsoft.Compute/locations/{loc}/operationStatuses/{id}).
 const resourceTypeLocations = "locations"
 
+// Power-action verbs shared by the single-VM sub-resource dispatch and the
+// whole-VMSS power dispatch. Compared case-insensitively (ARM action segments
+// arrive as e.g. "powerOff").
+const (
+	actionStart      = "start"
+	actionPowerOff   = "poweroff"
+	actionDeallocate = "deallocate"
+	actionRestart    = "restart"
+	actionReimage    = "reimage"
+)
+
 // Handler serves ARM JSON requests for Microsoft.Compute/virtualMachines.
 type Handler struct {
 	compute computedriver.Compute
@@ -189,13 +200,13 @@ func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, rp azurear
 //nolint:gocritic // rp travels through the dispatch chain once per request
 func (h *Handler) servePostAction(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	switch strings.ToLower(rp.SubResource) {
-	case "start":
+	case actionStart:
 		h.start(w, r, rp)
-	case "poweroff":
+	case actionPowerOff:
 		h.powerOff(w, r, rp)
-	case "deallocate":
+	case actionDeallocate:
 		h.deallocate(w, r, rp)
-	case "restart":
+	case actionRestart:
 		h.restart(w, r, rp)
 	case "generalize":
 		h.generalize(w, r, rp)

--- a/server/azure/virtualmachines/scaleset_instances.go
+++ b/server/azure/virtualmachines/scaleset_instances.go
@@ -2,6 +2,8 @@ package virtualmachines
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 
@@ -29,9 +31,53 @@ func serveScaleSetSubResource(w http.ResponseWriter, r *http.Request, rp azurear
 		}
 
 		scaleSetInstanceView(w, r, rp, store)
+	case actionStart, actionPowerOff, actionDeallocate, actionRestart, actionReimage:
+		if r.Method != http.MethodPost {
+			writeNotImplemented(w, r.Method+" "+r.URL.Path)
+			return
+		}
+
+		scaleSetPowerAction(w, r, rp, store)
 	default:
 		writeNotImplemented(w, r.Method+" "+r.URL.Path)
 	}
+}
+
+// scaleSetPowerAction handles the whole-VMSS POST power actions
+// (.../virtualMachineScaleSets/{name}/start|powerOff|deallocate|restart|reimage).
+// It fans the action out to every instance of the set, or to the subset named by
+// the optional {"instanceIds":[...]} body, then returns 202 + async polling
+// headers the SDK poller settles as Succeeded.
+//
+//nolint:gocritic // rp is a request-scoped value
+func scaleSetPowerAction(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store scaleSetStore) {
+	ids := decodeScaleSetInstanceIDs(r)
+
+	if err := store.PowerScaleSet(r.Context(), rp.ResourceName, rp.SubResource, ids); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "vmss-"+strings.ToLower(rp.SubResource)+"-"+rp.ResourceName)
+}
+
+// decodeScaleSetInstanceIDs best-effort reads the optional {"instanceIds":[...]}
+// body of a whole-VMSS power action. A missing, empty, or unparseable body
+// targets every instance (nil), matching the SDK's no-body whole-set call.
+func decodeScaleSetInstanceIDs(r *http.Request) []string {
+	if r.Body == nil {
+		return nil
+	}
+
+	var body struct {
+		InstanceIDs []string `json:"instanceIds"`
+	}
+
+	if err := json.NewDecoder(io.LimitReader(r.Body, azurearm.MaxBodyBytes)).Decode(&body); err != nil {
+		return nil
+	}
+
+	return body.InstanceIDs
 }
 
 // serveScaleSetVM routes the VMSS VM surface: LIST (collection), GET/DELETE (a

--- a/server/azure/virtualmachines/scaleset_power_patch_test.go
+++ b/server/azure/virtualmachines/scaleset_power_patch_test.go
@@ -80,6 +80,24 @@ func TestSDKVMSSWholeSetPower(t *testing.T) {
 
 	pollVMSSDone(ctx, t, restartPoller)
 	assertAllVMSSPower(ctx, t, vmClient, rg, name, ids, "PowerState/running")
+
+	// PowerOff then Reimage the whole set → reimage settles every instance back
+	// to running, like start/restart.
+	offPoller, err := ssClient.BeginPowerOff(ctx, rg, name, nil)
+	if err != nil {
+		t.Fatalf("BeginPowerOff before reimage: %v", err)
+	}
+
+	pollVMSSDone(ctx, t, offPoller)
+	assertAllVMSSPower(ctx, t, vmClient, rg, name, ids, "PowerState/stopped")
+
+	reimagePoller, err := ssClient.BeginReimage(ctx, rg, name, nil)
+	if err != nil {
+		t.Fatalf("BeginReimage: %v", err)
+	}
+
+	pollVMSSDone(ctx, t, reimagePoller)
+	assertAllVMSSPower(ctx, t, vmClient, rg, name, ids, "PowerState/running")
 }
 
 // TestSDKVMSSWholeSetPowerSubset targets a single instance via the instanceIds
@@ -132,10 +150,11 @@ func TestSDKVMSSWholeSetPowerSubset(t *testing.T) {
 	}
 }
 
-// TestSDKVMSSUpdate drives the real BeginUpdate (PATCH) merge: a scale set
-// created with one tag and capacity 2 is patched with a second tag and capacity
-// 4. The response must carry both tags (merge, not replace) and the new
-// capacity, and the set must materialize 4 instances.
+// TestSDKVMSSUpdate drives the real BeginUpdate (PATCH): a scale set created
+// with one tag and capacity 2 is patched with a different tag and capacity 4.
+// ARM resource-level PATCH replaces the tag set wholesale, so the response must
+// carry only the new tag (the pre-existing one dropped) plus the new capacity,
+// and the set must materialize 4 instances.
 func TestSDKVMSSUpdate(t *testing.T) {
 	cloudP := cloudemu.NewAzure()
 	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
@@ -185,12 +204,12 @@ func TestSDKVMSSUpdate(t *testing.T) {
 		t.Fatalf("update poll: %v", err)
 	}
 
-	if v := res.Tags["env"]; v == nil || *v != "dev" {
-		t.Fatalf("PATCH dropped pre-existing tag env: got %v", res.Tags)
+	if _, ok := res.Tags["env"]; ok {
+		t.Fatalf("PATCH must replace the tag set wholesale, but pre-existing tag env survived: got %v", res.Tags)
 	}
 
 	if v := res.Tags["team"]; v == nil || *v != "platform" {
-		t.Fatalf("PATCH did not merge new tag team: got %v", res.Tags)
+		t.Fatalf("PATCH did not apply new tag team: got %v", res.Tags)
 	}
 
 	if res.SKU == nil || res.SKU.Capacity == nil || *res.SKU.Capacity != 4 {

--- a/server/azure/virtualmachines/scaleset_power_patch_test.go
+++ b/server/azure/virtualmachines/scaleset_power_patch_test.go
@@ -1,0 +1,254 @@
+package virtualmachines_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKVMSSWholeSetPower drives the real armcompute VirtualMachineScaleSetsClient
+// whole-set power actions against an in-process cloudemu server: BeginPowerOff /
+// BeginStart / BeginDeallocate / BeginRestart on the scale set must transition
+// every materialized instance's power state, observable via each instance's
+// instanceView.
+func TestSDKVMSSWholeSetPower(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ssClient, err := armcompute.NewVirtualMachineScaleSetsClient("sub-1", fakeCred{}, sdkClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vmClient, err := armcompute.NewVirtualMachineScaleSetVMsClient("sub-1", fakeCred{}, sdkClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	const (
+		rg       = "rg-1"
+		name     = "power-vmss"
+		capacity = 3
+	)
+
+	createVMSSWithCapacity(ctx, t, ssClient, rg, name, capacity)
+	ids := listVMSSVMInstanceIDs(ctx, t, vmClient, rg, name)
+
+	// PowerOff the whole set → every instance stopped.
+	poller, err := ssClient.BeginPowerOff(ctx, rg, name, nil)
+	if err != nil {
+		t.Fatalf("BeginPowerOff: %v", err)
+	}
+
+	pollVMSSDone(ctx, t, poller)
+	assertAllVMSSPower(ctx, t, vmClient, rg, name, ids, "PowerState/stopped")
+
+	// Start the whole set → every instance running again.
+	startPoller, err := ssClient.BeginStart(ctx, rg, name, nil)
+	if err != nil {
+		t.Fatalf("BeginStart: %v", err)
+	}
+
+	pollVMSSDone(ctx, t, startPoller)
+	assertAllVMSSPower(ctx, t, vmClient, rg, name, ids, "PowerState/running")
+
+	// Deallocate the whole set → every instance deallocated.
+	deallocPoller, err := ssClient.BeginDeallocate(ctx, rg, name, nil)
+	if err != nil {
+		t.Fatalf("BeginDeallocate: %v", err)
+	}
+
+	pollVMSSDone(ctx, t, deallocPoller)
+	assertAllVMSSPower(ctx, t, vmClient, rg, name, ids, "PowerState/deallocated")
+
+	// Restart the whole set → every instance running.
+	restartPoller, err := ssClient.BeginRestart(ctx, rg, name, nil)
+	if err != nil {
+		t.Fatalf("BeginRestart: %v", err)
+	}
+
+	pollVMSSDone(ctx, t, restartPoller)
+	assertAllVMSSPower(ctx, t, vmClient, rg, name, ids, "PowerState/running")
+}
+
+// TestSDKVMSSWholeSetPowerSubset targets a single instance via the instanceIds
+// body: only the named instance transitions, the rest stay running.
+func TestSDKVMSSWholeSetPowerSubset(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ssClient, err := armcompute.NewVirtualMachineScaleSetsClient("sub-1", fakeCred{}, sdkClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vmClient, err := armcompute.NewVirtualMachineScaleSetVMsClient("sub-1", fakeCred{}, sdkClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	const (
+		rg       = "rg-1"
+		name     = "subset-vmss"
+		capacity = 3
+	)
+
+	createVMSSWithCapacity(ctx, t, ssClient, rg, name, capacity)
+	ids := listVMSSVMInstanceIDs(ctx, t, vmClient, rg, name)
+
+	poller, err := ssClient.BeginPowerOff(ctx, rg, name, &armcompute.VirtualMachineScaleSetsClientBeginPowerOffOptions{
+		VMInstanceIDs: &armcompute.VirtualMachineScaleSetVMInstanceIDs{InstanceIDs: []*string{to.Ptr(ids[0])}},
+	})
+	if err != nil {
+		t.Fatalf("BeginPowerOff subset: %v", err)
+	}
+
+	pollVMSSDone(ctx, t, poller)
+
+	for _, id := range ids {
+		want := "PowerState/running"
+		if id == ids[0] {
+			want = "PowerState/stopped"
+		}
+
+		if got := instanceViewPowerState(ctx, t, vmClient, rg, name, id); got != want {
+			t.Fatalf("instance %q power = %q, want %q", id, got, want)
+		}
+	}
+}
+
+// TestSDKVMSSUpdate drives the real BeginUpdate (PATCH) merge: a scale set
+// created with one tag and capacity 2 is patched with a second tag and capacity
+// 4. The response must carry both tags (merge, not replace) and the new
+// capacity, and the set must materialize 4 instances.
+func TestSDKVMSSUpdate(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ssClient, err := armcompute.NewVirtualMachineScaleSetsClient("sub-1", fakeCred{}, sdkClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vmClient, err := armcompute.NewVirtualMachineScaleSetVMsClient("sub-1", fakeCred{}, sdkClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	const (
+		rg   = "rg-1"
+		name = "patch-vmss"
+	)
+
+	createPoller, err := ssClient.BeginCreateOrUpdate(ctx, rg, name, armcompute.VirtualMachineScaleSet{
+		Location: to.Ptr("westus2"),
+		Tags:     map[string]*string{"env": to.Ptr("dev")},
+		SKU:      &armcompute.SKU{Name: to.Ptr("Standard_D2s_v3"), Capacity: to.Ptr[int64](2)},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err = createPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("create poll: %v", err)
+	}
+
+	updatePoller, err := ssClient.BeginUpdate(ctx, rg, name, armcompute.VirtualMachineScaleSetUpdate{
+		Tags: map[string]*string{"team": to.Ptr("platform")},
+		SKU:  &armcompute.SKU{Capacity: to.Ptr[int64](4)},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate: %v", err)
+	}
+
+	res, err := updatePoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	if err != nil {
+		t.Fatalf("update poll: %v", err)
+	}
+
+	if v := res.Tags["env"]; v == nil || *v != "dev" {
+		t.Fatalf("PATCH dropped pre-existing tag env: got %v", res.Tags)
+	}
+
+	if v := res.Tags["team"]; v == nil || *v != "platform" {
+		t.Fatalf("PATCH did not merge new tag team: got %v", res.Tags)
+	}
+
+	if res.SKU == nil || res.SKU.Capacity == nil || *res.SKU.Capacity != 4 {
+		t.Fatalf("PATCH capacity not applied: got %v", res.SKU)
+	}
+
+	if ids := listVMSSVMInstanceIDs(ctx, t, vmClient, rg, name); len(ids) != 4 {
+		t.Fatalf("after capacity PATCH: got %d instances, want 4", len(ids))
+	}
+}
+
+// TestSDKVMSSPowerAndPatchMissing confirms a whole-set power action and a PATCH
+// against a non-existent scale set both surface 404.
+func TestSDKVMSSPowerAndPatchMissing(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ssClient, err := armcompute.NewVirtualMachineScaleSetsClient("sub-1", fakeCred{}, sdkClientOptions(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	if _, err = ssClient.BeginStart(ctx, "rg-x", "no-such-vmss", nil); !isNotFound(err) {
+		t.Fatalf("BeginStart missing set: got %v, want 404", err)
+	}
+
+	if _, err = ssClient.BeginUpdate(ctx, "rg-x", "no-such-vmss", armcompute.VirtualMachineScaleSetUpdate{
+		Tags: map[string]*string{"a": to.Ptr("b")},
+	}, nil); !isNotFound(err) {
+		t.Fatalf("BeginUpdate missing set: got %v, want 404", err)
+	}
+}
+
+// pollVMSSDone drives any VMSS operation poller to completion at test speed.
+func pollVMSSDone[T any](ctx context.Context, t *testing.T, poller *runtime.Poller[T]) {
+	t.Helper()
+
+	if _, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+}
+
+// assertAllVMSSPower checks that every listed instance reports the wanted power
+// state code via its instanceView.
+func assertAllVMSSPower(
+	ctx context.Context, t *testing.T, client *armcompute.VirtualMachineScaleSetVMsClient,
+	rg, name string, ids []string, want string,
+) {
+	t.Helper()
+
+	for _, id := range ids {
+		if got := instanceViewPowerState(ctx, t, client, rg, name, id); got != want {
+			t.Fatalf("instance %q power = %q, want %q", id, got, want)
+		}
+	}
+}

--- a/server/azure/virtualmachines/scalesets.go
+++ b/server/azure/virtualmachines/scalesets.go
@@ -21,6 +21,8 @@ type scaleSetStore interface {
 	GetScaleSetVM(ctx context.Context, vmssName, instanceID string) (*providervm.ScaleSetVM, error)
 	DeleteScaleSetVM(ctx context.Context, vmssName, instanceID string) error
 	PowerScaleSetVM(ctx context.Context, vmssName, instanceID, action string) error
+	PowerScaleSet(ctx context.Context, vmssName, action string, instanceIDs []string) error
+	UpdateScaleSet(ctx context.Context, name string, patch providervm.ScaleSetPatch) (*providervm.ScaleSet, error)
 }
 
 // serveScaleSet dispatches PUT/GET on Microsoft.Compute/virtualMachineScaleSets.
@@ -52,6 +54,8 @@ func (h *Handler) serveScaleSet(w http.ResponseWriter, r *http.Request, rp azure
 	switch r.Method {
 	case http.MethodPut:
 		createScaleSet(w, r, rp, store)
+	case http.MethodPatch:
+		updateScaleSet(w, r, rp, store)
 	case http.MethodGet:
 		getScaleSet(w, r, rp, store)
 	case http.MethodDelete:
@@ -59,6 +63,42 @@ func (h *Handler) serveScaleSet(w http.ResponseWriter, r *http.Request, rp azure
 	default:
 		writeNotImplemented(w, r.Method+" "+r.URL.Path)
 	}
+}
+
+// updateScaleSet handles PATCH virtualMachineScaleSets/{name} (ARM
+// VirtualMachineScaleSets Update): a merge-patch of tags and mutable properties
+// (sku name/tier/capacity, per-VM Spot priority / hybrid-benefit license) that
+// returns the full updated resource. Unlike DELETE and the power actions, the
+// SDK's BeginUpdate poller accepts a synchronous 200 carrying the final body.
+//
+//nolint:gocritic // rp is a request-scoped value
+func updateScaleSet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, store scaleSetStore) {
+	var req vmssRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	patch := providervm.ScaleSetPatch{Tags: req.Tags}
+
+	if req.SKU != nil {
+		patch.SKUName = req.SKU.Name
+		patch.SKUTier = req.SKU.Tier
+		patch.Capacity = req.SKU.Capacity
+	}
+
+	if p := req.Properties.VirtualMachineProfile; p != nil {
+		patch.Priority = p.Priority
+		patch.LicenseType = p.LicenseType
+	}
+
+	stored, err := store.UpdateScaleSet(r.Context(), rp.ResourceName, patch)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toVMSSResponse(stored, rp))
 }
 
 // deleteScaleSet handles DELETE virtualMachineScaleSets/{name}. Real Azure


### PR DESCRIPTION
## Summary

Brings Azure Virtual Machine Scale Sets to fuller lifecycle parity by adding the two whole-scale-set operations that were missing alongside the existing per-instance power surface.

### Whole-VMSS power operations
`POST .../virtualMachineScaleSets/{name}/start|powerOff|deallocate|restart|reimage` now fan the action out to every materialized instance (or the subset named by an optional `{"instanceIds":[...]}` body), updating each instance's power state so a subsequent instanceView/GET reflects it. Returns `202` + async polling headers like the existing per-instance power and scale-set DELETE paths.

### Whole-VMSS PATCH
`PATCH .../virtualMachineScaleSets/{name}` (armcompute `BeginUpdate`) merge-patches tags key-by-key and mutable properties (sku name/tier/capacity, per-VM Spot priority / hybrid-benefit license). A capacity change rescales the set, reconciling its instances. Returns the full updated resource.

### Driver
Added two methods to the server-local `scaleSetStore` interface and implemented them on the Azure compute mock: `PowerScaleSet(ctx, vmssName, action, instanceIDs)` (reuses the existing `powerStateForAction` mapping) and `UpdateScaleSet(ctx, name, ScaleSetPatch)`. No change to the shared compute driver interface, so `docs/coverage` is unaffected.

## Tests
Real armcompute SDK round-trips: whole-set start/powerOff/deallocate/restart transition all instances; a subset request touches only the named instance; PATCH merges a tag + capacity change and returns the full set with both tags; power and PATCH on a missing set return 404. Provider-level tests cover the same behaviors plus explicit scale-in-to-zero and error paths.

## Gates
build, targeted + full `go test`, golangci-lint (0 issues), coveragegen (no diff), and `go mod tidy` (no diff) all green.
