### PR TITLE
feat(azure-network): PATCH (UpdateTags) for gateways, Public IP Prefixes, ASG

### DIFF
--- a/server/azure/vnet/application_security_group.go
+++ b/server/azure/vnet/application_security_group.go
@@ -111,30 +111,38 @@ func (*Handler) createASG(w http.ResponseWriter, r *http.Request, rp azurearm.Re
 }
 
 // patchASG applies an ARM UpdateTags PATCH (ApplicationSecurityGroupsClient.
-// UpdateTags — a synchronous 200): the body's tags are merged into the stored
-// set, the ASG's other fields are left intact, and the full resource is
-// returned. A PATCH on a missing ASG is a 404.
+// UpdateTags — a synchronous 200): the body's tags REPLACE the stored set
+// wholesale (tags:{} wipes them), the ASG's other fields are left intact, and
+// the full resource is returned. The get-modify-put is guarded by patchMu so a
+// concurrent PATCH cannot drop the write. A PATCH on a missing ASG is a 404.
 //
-//nolint:gocritic,dupl // rp is request-scoped; mirrors patchPublicIPPrefix's tag-merge over a distinct resource type
-func (*Handler) patchASG(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+//nolint:gocritic,dupl // rp is request-scoped; mirrors patchLNGateway's tag-replace over a distinct resource type
+func (h *Handler) patchASG(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
 	svc netdriver.AzureApplicationSecurityGroups,
 ) {
-	existing, ok := svc.GetAzureApplicationSecurityGroup(r.Context(), rp.ResourceGroup, rp.ResourceName)
-	if !ok {
-		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
-			"application security group "+rp.ResourceName+" not found")
-
-		return
-	}
-
 	var req armTagsObject
 
 	if !azurearm.DecodeJSON(w, r, &req) {
 		return
 	}
 
-	existing.Tags = mergedTagMap(existing.Tags, req.Tags)
+	h.patchMu.Lock()
+
+	existing, ok := svc.GetAzureApplicationSecurityGroup(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if !ok {
+		h.patchMu.Unlock()
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"application security group "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	if req.Tags != nil {
+		existing.Tags = replacementTags(req.Tags)
+	}
+
 	stored := svc.PutAzureApplicationSecurityGroup(r.Context(), existing)
+	h.patchMu.Unlock()
 
 	azurearm.WriteJSON(w, http.StatusOK, asgResponseFrom(stored, rp))
 }

--- a/server/azure/vnet/application_security_group.go
+++ b/server/azure/vnet/application_security_group.go
@@ -69,6 +69,8 @@ func (h *Handler) routeASG(w http.ResponseWriter, r *http.Request, rp azurearm.R
 	switch r.Method {
 	case http.MethodPut:
 		h.createASG(w, r, rp, svc)
+	case http.MethodPatch:
+		h.patchASG(w, r, rp, svc)
 	case http.MethodGet:
 		h.getASG(w, r, rp, svc)
 	case http.MethodDelete:
@@ -104,6 +106,35 @@ func (*Handler) createASG(w http.ResponseWriter, r *http.Request, rp azurearm.Re
 		Location:      loc,
 		Tags:          req.Tags,
 	})
+
+	azurearm.WriteJSON(w, http.StatusOK, asgResponseFrom(stored, rp))
+}
+
+// patchASG applies an ARM UpdateTags PATCH (ApplicationSecurityGroupsClient.
+// UpdateTags — a synchronous 200): the body's tags are merged into the stored
+// set, the ASG's other fields are left intact, and the full resource is
+// returned. A PATCH on a missing ASG is a 404.
+//
+//nolint:gocritic,dupl // rp is request-scoped; mirrors patchPublicIPPrefix's tag-merge over a distinct resource type
+func (*Handler) patchASG(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureApplicationSecurityGroups,
+) {
+	existing, ok := svc.GetAzureApplicationSecurityGroup(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"application security group "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	var req armTagsObject
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	existing.Tags = mergedTagMap(existing.Tags, req.Tags)
+	stored := svc.PutAzureApplicationSecurityGroup(r.Context(), existing)
 
 	azurearm.WriteJSON(w, http.StatusOK, asgResponseFrom(stored, rp))
 }

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -1993,6 +1993,36 @@ func writeAcceptedAsync(w http.ResponseWriter, r *http.Request, sub, opID string
 
 // Tag helpers.
 
+// armTagsObject is the ARM UpdateTags PATCH body ({"tags": {...}}) — the
+// TagsObject the armnetwork *Client.UpdateTags / BeginUpdateTags methods send.
+// Only tags are updatable through this operation; the resource's properties are
+// left intact.
+type armTagsObject struct {
+	Tags map[string]string `json:"tags,omitempty"`
+}
+
+// mergedTagMap merges an UpdateTags PATCH body's tags into the stored set:
+// supplied keys are added or overwritten while every other existing tag is
+// preserved. It returns a fresh map (nil when the result is empty) so the stored
+// set is never aliased to the request or the existing record.
+func mergedTagMap(existing, incoming map[string]string) map[string]string {
+	out := make(map[string]string, len(existing)+len(incoming))
+
+	for k, v := range existing {
+		out[k] = v
+	}
+
+	for k, v := range incoming {
+		out[k] = v
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
 func mergeTags(in map[string]string, key, val string) map[string]string {
 	out := make(map[string]string, len(in)+1)
 

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -22,8 +22,10 @@ package vnet
 
 import (
 	"context"
+	"maps"
 	"net/http"
 	"strings"
+	"sync"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
@@ -85,7 +87,12 @@ const (
 
 // Handler serves Microsoft.Network ARM requests against a networking driver.
 type Handler struct {
-	net netdriver.Networking
+	// patchMu serializes the read-modify-write UpdateTags PATCH handlers so two
+	// concurrent PATCHes to the same resource cannot drop a write (the driver's
+	// Get and Put are individually locked, but the get-then-put across them is
+	// not atomic). It guards only that get-modify-put window.
+	patchMu sync.Mutex
+	net     netdriver.Networking
 }
 
 // New returns a network handler.
@@ -2001,26 +2008,19 @@ type armTagsObject struct {
 	Tags map[string]string `json:"tags,omitempty"`
 }
 
-// mergedTagMap merges an UpdateTags PATCH body's tags into the stored set:
-// supplied keys are added or overwritten while every other existing tag is
-// preserved. It returns a fresh map (nil when the result is empty) so the stored
-// set is never aliased to the request or the existing record.
-func mergedTagMap(existing, incoming map[string]string) map[string]string {
-	out := make(map[string]string, len(existing)+len(incoming))
-
-	for k, v := range existing {
-		out[k] = v
-	}
-
-	for k, v := range incoming {
-		out[k] = v
-	}
-
-	if len(out) == 0 {
+// replacementTags normalizes an UpdateTags PATCH body's tags for wholesale
+// replacement — real Azure's resource-level UpdateTags SETS the tag collection,
+// it does not merge (the merge/replace/delete modes live only on the generic
+// Microsoft.Resources/tags API). A populated map replaces the stored set (cloned
+// so the store never aliases the request); a present-but-empty map ({}) wipes it
+// (nil). The caller applies this only when the body carried a tags key, so an
+// absent tags key leaves the stored set untouched.
+func replacementTags(in map[string]string) map[string]string {
+	if len(in) == 0 {
 		return nil
 	}
 
-	return out
+	return maps.Clone(in)
 }
 
 func mergeTags(in map[string]string, key, val string) map[string]string {

--- a/server/azure/vnet/network_gateway.go
+++ b/server/azure/vnet/network_gateway.go
@@ -197,6 +197,8 @@ func (h *Handler) routeVNGateway(w http.ResponseWriter, r *http.Request, rp azur
 	switch r.Method {
 	case http.MethodPut:
 		h.createVNGateway(w, r, rp, svc)
+	case http.MethodPatch:
+		h.patchVNGateway(w, r, rp, svc)
 	case http.MethodGet:
 		h.getVNGateway(w, r, rp, svc)
 	case http.MethodDelete:
@@ -206,7 +208,7 @@ func (h *Handler) routeVNGateway(w http.ResponseWriter, r *http.Request, rp azur
 	}
 }
 
-//nolint:gocritic // rp is a request-scoped value
+//nolint:gocritic,dupl // rp is request-scoped; the capability-gated create shape is mirrored by createPrivateLinkService
 func (*Handler) createVNGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
 	svc netdriver.AzureNetworkGateways,
 ) {
@@ -297,6 +299,37 @@ func toRecordBgp(in *bgpSettings) *netdriver.AzureGatewayBgpSettings {
 		BgpPeeringAddress: in.BgpPeeringAddress,
 		PeerWeight:        in.PeerWeight,
 	}
+}
+
+// patchVNGateway applies an ARM UpdateTags PATCH (VirtualNetworkGateways
+// Client.BeginUpdateTags — an LRO): the body's tags are merged into the stored
+// set, the gateway's other fields are left intact, and the full resource is
+// returned. A sync 200 with a terminal provisioningState completes the poller
+// immediately (the same convention the create uses). A PATCH on a missing
+// gateway is a 404.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) patchVNGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkGateways,
+) {
+	existing, ok := svc.GetAzureVirtualNetworkGateway(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"virtual network gateway "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	var req armTagsObject
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	existing.Tags = mergedTagMap(existing.Tags, req.Tags)
+	stored := svc.PutAzureVirtualNetworkGateway(r.Context(), existing)
+
+	writeAcceptedAsync(w, r, rp.Subscription, "vng-updatetags-"+rp.ResourceName, vngResponseFrom(stored, rp))
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -431,6 +464,8 @@ func (h *Handler) routeLNGateway(w http.ResponseWriter, r *http.Request, rp azur
 	switch r.Method {
 	case http.MethodPut:
 		h.createLNGateway(w, r, rp, svc)
+	case http.MethodPatch:
+		h.patchLNGateway(w, r, rp, svc)
 	case http.MethodGet:
 		h.getLNGateway(w, r, rp, svc)
 	case http.MethodDelete:
@@ -477,6 +512,35 @@ func (*Handler) createLNGateway(w http.ResponseWriter, r *http.Request, rp azure
 	stored := svc.PutAzureLocalNetworkGateway(r.Context(), rec)
 
 	writeAcceptedAsync(w, r, rp.Subscription, "lng-create-"+rp.ResourceName, lngResponseFrom(stored, rp))
+}
+
+// patchLNGateway applies an ARM UpdateTags PATCH (LocalNetworkGatewaysClient.
+// UpdateTags — a synchronous 200): the body's tags are merged into the stored
+// set, the gateway's other fields are left intact, and the full resource is
+// returned. A PATCH on a missing gateway is a 404.
+//
+//nolint:gocritic,dupl // rp is request-scoped; the tag-merge shape is shared by the sibling patch handlers
+func (*Handler) patchLNGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkGateways,
+) {
+	existing, ok := svc.GetAzureLocalNetworkGateway(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"local network gateway "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	var req armTagsObject
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	existing.Tags = mergedTagMap(existing.Tags, req.Tags)
+	stored := svc.PutAzureLocalNetworkGateway(r.Context(), existing)
+
+	azurearm.WriteJSON(w, http.StatusOK, lngResponseFrom(stored, rp))
 }
 
 //nolint:gocritic // rp is a request-scoped value
@@ -571,6 +635,8 @@ func (h *Handler) routeConnection(w http.ResponseWriter, r *http.Request, rp azu
 	switch r.Method {
 	case http.MethodPut:
 		h.createConnection(w, r, rp, svc)
+	case http.MethodPatch:
+		h.patchConnection(w, r, rp, svc)
 	case http.MethodGet:
 		h.getConnection(w, r, rp, svc)
 	case http.MethodDelete:
@@ -618,6 +684,37 @@ func (*Handler) createConnection(w http.ResponseWriter, r *http.Request, rp azur
 	stored := svc.PutAzureVirtualNetworkGatewayConnection(r.Context(), rec)
 
 	writeAcceptedAsync(w, r, rp.Subscription, "conn-create-"+rp.ResourceName, connResponseFrom(stored, rp))
+}
+
+// patchConnection applies an ARM UpdateTags PATCH (VirtualNetworkGateway
+// ConnectionsClient.BeginUpdateTags — an LRO): the body's tags are merged into
+// the stored set, the connection's other fields are left intact, and the full
+// resource is returned. A sync 200 with a terminal provisioningState completes
+// the poller immediately (the same convention the create uses). A PATCH on a
+// missing connection is a 404.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) patchConnection(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzureNetworkGateways,
+) {
+	existing, ok := svc.GetAzureVirtualNetworkGatewayConnection(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"connection "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	var req armTagsObject
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	existing.Tags = mergedTagMap(existing.Tags, req.Tags)
+	stored := svc.PutAzureVirtualNetworkGatewayConnection(r.Context(), existing)
+
+	writeAcceptedAsync(w, r, rp.Subscription, "conn-updatetags-"+rp.ResourceName, connResponseFrom(stored, rp))
 }
 
 //nolint:gocritic // rp is a request-scoped value

--- a/server/azure/vnet/network_gateway.go
+++ b/server/azure/vnet/network_gateway.go
@@ -302,32 +302,40 @@ func toRecordBgp(in *bgpSettings) *netdriver.AzureGatewayBgpSettings {
 }
 
 // patchVNGateway applies an ARM UpdateTags PATCH (VirtualNetworkGateways
-// Client.BeginUpdateTags — an LRO): the body's tags are merged into the stored
-// set, the gateway's other fields are left intact, and the full resource is
-// returned. A sync 200 with a terminal provisioningState completes the poller
-// immediately (the same convention the create uses). A PATCH on a missing
-// gateway is a 404.
+// Client.BeginUpdateTags — an LRO): the body's tags REPLACE the stored set
+// wholesale (tags:{} wipes them), the gateway's other fields are left intact,
+// and the full resource is returned. A sync 200 with a terminal
+// provisioningState completes the poller immediately (the same convention the
+// create uses). The get-modify-put is guarded by patchMu so a concurrent PATCH
+// cannot drop the write. A PATCH on a missing gateway is a 404.
 //
 //nolint:gocritic // rp is a request-scoped value
-func (*Handler) patchVNGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+func (h *Handler) patchVNGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
 	svc netdriver.AzureNetworkGateways,
 ) {
-	existing, ok := svc.GetAzureVirtualNetworkGateway(r.Context(), rp.ResourceGroup, rp.ResourceName)
-	if !ok {
-		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
-			"virtual network gateway "+rp.ResourceName+" not found")
-
-		return
-	}
-
 	var req armTagsObject
 
 	if !azurearm.DecodeJSON(w, r, &req) {
 		return
 	}
 
-	existing.Tags = mergedTagMap(existing.Tags, req.Tags)
+	h.patchMu.Lock()
+
+	existing, ok := svc.GetAzureVirtualNetworkGateway(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if !ok {
+		h.patchMu.Unlock()
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"virtual network gateway "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	if req.Tags != nil {
+		existing.Tags = replacementTags(req.Tags)
+	}
+
 	stored := svc.PutAzureVirtualNetworkGateway(r.Context(), existing)
+	h.patchMu.Unlock()
 
 	writeAcceptedAsync(w, r, rp.Subscription, "vng-updatetags-"+rp.ResourceName, vngResponseFrom(stored, rp))
 }
@@ -515,30 +523,39 @@ func (*Handler) createLNGateway(w http.ResponseWriter, r *http.Request, rp azure
 }
 
 // patchLNGateway applies an ARM UpdateTags PATCH (LocalNetworkGatewaysClient.
-// UpdateTags — a synchronous 200): the body's tags are merged into the stored
-// set, the gateway's other fields are left intact, and the full resource is
-// returned. A PATCH on a missing gateway is a 404.
+// UpdateTags — a synchronous 200): the body's tags REPLACE the stored set
+// wholesale (tags:{} wipes them), the gateway's other fields are left intact,
+// and the full resource is returned. The get-modify-put is guarded by patchMu so
+// a concurrent PATCH cannot drop the write. A PATCH on a missing gateway is a
+// 404.
 //
-//nolint:gocritic,dupl // rp is request-scoped; the tag-merge shape is shared by the sibling patch handlers
-func (*Handler) patchLNGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+//nolint:gocritic,dupl // rp is request-scoped; mirrors patchASG's tag-replace over a distinct resource type
+func (h *Handler) patchLNGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
 	svc netdriver.AzureNetworkGateways,
 ) {
-	existing, ok := svc.GetAzureLocalNetworkGateway(r.Context(), rp.ResourceGroup, rp.ResourceName)
-	if !ok {
-		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
-			"local network gateway "+rp.ResourceName+" not found")
-
-		return
-	}
-
 	var req armTagsObject
 
 	if !azurearm.DecodeJSON(w, r, &req) {
 		return
 	}
 
-	existing.Tags = mergedTagMap(existing.Tags, req.Tags)
+	h.patchMu.Lock()
+
+	existing, ok := svc.GetAzureLocalNetworkGateway(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if !ok {
+		h.patchMu.Unlock()
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"local network gateway "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	if req.Tags != nil {
+		existing.Tags = replacementTags(req.Tags)
+	}
+
 	stored := svc.PutAzureLocalNetworkGateway(r.Context(), existing)
+	h.patchMu.Unlock()
 
 	azurearm.WriteJSON(w, http.StatusOK, lngResponseFrom(stored, rp))
 }
@@ -687,32 +704,40 @@ func (*Handler) createConnection(w http.ResponseWriter, r *http.Request, rp azur
 }
 
 // patchConnection applies an ARM UpdateTags PATCH (VirtualNetworkGateway
-// ConnectionsClient.BeginUpdateTags — an LRO): the body's tags are merged into
-// the stored set, the connection's other fields are left intact, and the full
-// resource is returned. A sync 200 with a terminal provisioningState completes
-// the poller immediately (the same convention the create uses). A PATCH on a
-// missing connection is a 404.
+// ConnectionsClient.BeginUpdateTags — an LRO): the body's tags REPLACE the
+// stored set wholesale (tags:{} wipes them), the connection's other fields are
+// left intact, and the full resource is returned. A sync 200 with a terminal
+// provisioningState completes the poller immediately (the same convention the
+// create uses). The get-modify-put is guarded by patchMu so a concurrent PATCH
+// cannot drop the write. A PATCH on a missing connection is a 404.
 //
 //nolint:gocritic // rp is a request-scoped value
-func (*Handler) patchConnection(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+func (h *Handler) patchConnection(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
 	svc netdriver.AzureNetworkGateways,
 ) {
-	existing, ok := svc.GetAzureVirtualNetworkGatewayConnection(r.Context(), rp.ResourceGroup, rp.ResourceName)
-	if !ok {
-		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
-			"connection "+rp.ResourceName+" not found")
-
-		return
-	}
-
 	var req armTagsObject
 
 	if !azurearm.DecodeJSON(w, r, &req) {
 		return
 	}
 
-	existing.Tags = mergedTagMap(existing.Tags, req.Tags)
+	h.patchMu.Lock()
+
+	existing, ok := svc.GetAzureVirtualNetworkGatewayConnection(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if !ok {
+		h.patchMu.Unlock()
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"connection "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	if req.Tags != nil {
+		existing.Tags = replacementTags(req.Tags)
+	}
+
 	stored := svc.PutAzureVirtualNetworkGatewayConnection(r.Context(), existing)
+	h.patchMu.Unlock()
 
 	writeAcceptedAsync(w, r, rp.Subscription, "conn-updatetags-"+rp.ResourceName, connResponseFrom(stored, rp))
 }

--- a/server/azure/vnet/network_updatetags_test.go
+++ b/server/azure/vnet/network_updatetags_test.go
@@ -2,6 +2,10 @@ package vnet_test
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -11,9 +15,11 @@ import (
 )
 
 // TestSDKApplicationSecurityGroupUpdateTags drives the real armnetwork
-// ApplicationSecurityGroupsClient.UpdateTags (a synchronous PATCH): the supplied
-// tag is merged into the existing set, the ASG's other fields survive, the full
-// resource comes back, and UpdateTags on a missing ASG is a 404.
+// ApplicationSecurityGroupsClient.UpdateTags (a synchronous PATCH). Resource-level
+// UpdateTags REPLACES the tag set wholesale (it does not merge): the supplied tag
+// becomes the only tag, the create-time tag is gone, the ASG's other fields
+// survive, the full resource comes back, a raw tags:{} PATCH wipes all tags, and
+// UpdateTags on a missing ASG is a 404.
 func TestSDKApplicationSecurityGroupUpdateTags(t *testing.T) {
 	ts := newVNetServer(t)
 	ctx := context.Background()
@@ -36,9 +42,10 @@ func TestSDKApplicationSecurityGroupUpdateTags(t *testing.T) {
 		t.Fatalf("UpdateTags: %v", err)
 	}
 
-	// Merge: the new tag is added and the create-time tag is preserved.
-	assertTag(t, updated.Tags, "env", "prod")
+	// Replace: the new tag is the only tag; the create-time tag is gone.
 	assertTag(t, updated.Tags, "team", "net")
+	assertNoTag(t, updated.Tags, "env")
+	assertTagCount(t, updated.Tags, 1)
 
 	// Full resource: name, location and provisioningState come back on the PATCH.
 	if updated.Name == nil || *updated.Name != "asg-tag" {
@@ -54,14 +61,21 @@ func TestSDKApplicationSecurityGroupUpdateTags(t *testing.T) {
 		t.Errorf("provisioningState=%v want Succeeded", updated.Properties)
 	}
 
-	// A follow-up GET reflects the merged set (the merge was persisted, not echoed).
+	// A follow-up GET reflects the replaced set (the replace was persisted).
 	got, err := client.Get(ctx, "rg-1", "asg-tag", nil)
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
 
-	assertTag(t, got.Tags, "env", "prod")
 	assertTag(t, got.Tags, "team", "net")
+	assertNoTag(t, got.Tags, "env")
+
+	// A raw tags:{} PATCH wipes every tag. The SDK's TagsObject drops an empty map
+	// via omitempty, so tags:{} can only be exercised over the wire directly.
+	wiped := rawTagsPatch(t, ts,
+		"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/applicationSecurityGroups/asg-tag",
+		`{"tags":{}}`)
+	assertTagCount(t, ptrTags(wiped), 0)
 
 	_, err = client.UpdateTags(ctx, "rg-1", "missing", armnetwork.TagsObject{
 		Tags: map[string]*string{"team": to.Ptr("net")},
@@ -70,9 +84,9 @@ func TestSDKApplicationSecurityGroupUpdateTags(t *testing.T) {
 }
 
 // TestSDKPublicIPPrefixUpdateTags drives PublicIPPrefixesClient.UpdateTags (a
-// synchronous PATCH): the tag merges while the prefix's properties (prefixLength,
-// synthesized ipPrefix, sku) are left intact, and UpdateTags on a missing prefix
-// is a 404.
+// synchronous PATCH): the tag set is replaced wholesale while the prefix's
+// properties (prefixLength, synthesized ipPrefix, sku) are left intact, a raw
+// tags:{} PATCH wipes the tags, and UpdateTags on a missing prefix is a 404.
 func TestSDKPublicIPPrefixUpdateTags(t *testing.T) {
 	ts := newVNetServer(t)
 	ctx := context.Background()
@@ -106,8 +120,9 @@ func TestSDKPublicIPPrefixUpdateTags(t *testing.T) {
 		t.Fatalf("UpdateTags: %v", err)
 	}
 
-	assertTag(t, updated.Tags, "env", "prod")
 	assertTag(t, updated.Tags, "team", "net")
+	assertNoTag(t, updated.Tags, "env")
+	assertTagCount(t, updated.Tags, 1)
 
 	// Properties untouched by an UpdateTags PATCH.
 	if updated.Properties == nil || updated.Properties.PrefixLength == nil ||
@@ -124,6 +139,11 @@ func TestSDKPublicIPPrefixUpdateTags(t *testing.T) {
 		t.Errorf("sku=%v want Standard (must survive UpdateTags)", updated.SKU)
 	}
 
+	wiped := rawTagsPatch(t, ts,
+		"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/publicIPPrefixes/pfx-tag",
+		`{"tags":{}}`)
+	assertTagCount(t, ptrTags(wiped), 0)
+
 	_, err = client.UpdateTags(ctx, "rg-1", "missing", armnetwork.TagsObject{
 		Tags: map[string]*string{"team": to.Ptr("net")},
 	}, nil)
@@ -133,8 +153,9 @@ func TestSDKPublicIPPrefixUpdateTags(t *testing.T) {
 // TestSDKNetworkGatewaysUpdateTags drives UpdateTags across all three gateway
 // families: VirtualNetworkGatewaysClient.BeginUpdateTags (LRO),
 // LocalNetworkGatewaysClient.UpdateTags (sync) and
-// VirtualNetworkGatewayConnectionsClient.BeginUpdateTags (LRO). Each merges a tag
-// while its properties survive; UpdateTags on a missing resource is a 404.
+// VirtualNetworkGatewayConnectionsClient.BeginUpdateTags (LRO). Each replaces the
+// tag set wholesale while its properties survive; a raw tags:{} PATCH wipes the
+// gateway's tags; UpdateTags on a missing resource is a 404.
 func TestSDKNetworkGatewaysUpdateTags(t *testing.T) {
 	ts := newVNetServer(t)
 	ctx := context.Background()
@@ -145,16 +166,16 @@ func TestSDKNetworkGatewaysUpdateTags(t *testing.T) {
 	subnetID := seedGatewayPrerequisites(t, ctx, opts, rg)
 	pipID := "/subscriptions/sub-1/resourceGroups/" + rg + "/providers/Microsoft.Network/publicIPAddresses/gw-pip"
 
-	vngID := patchVNGatewayTags(t, ctx, opts, rg, subnetID, pipID)
-	lngID := patchLNGatewayTags(t, ctx, opts, rg)
+	vngID := patchVNGatewayTags(t, ctx, ts, opts, rg, subnetID, pipID)
+	lngID := patchLNGatewayTags(t, ctx, ts, opts, rg)
 	patchConnectionTags(t, ctx, opts, rg, vngID, lngID)
 }
 
-// patchVNGatewayTags creates a virtual network gateway with a tag, merges a
-// second via BeginUpdateTags, asserts both tags plus a preserved property, checks
-// the 404 path, and returns the gateway id.
+// patchVNGatewayTags creates a virtual network gateway with a tag, replaces it
+// via BeginUpdateTags, asserts the replacement plus a preserved property, wipes
+// the tags with a raw tags:{} PATCH, checks the 404 path, and returns the id.
 func patchVNGatewayTags(
-	t *testing.T, ctx context.Context, opts *arm.ClientOptions, rg, subnetID, pipID string,
+	t *testing.T, ctx context.Context, ts *httptest.Server, opts *arm.ClientOptions, rg, subnetID, pipID string,
 ) string {
 	t.Helper()
 
@@ -194,13 +215,19 @@ func patchVNGatewayTags(
 
 	updated := pollDone(t, tagsP)
 
-	assertTag(t, updated.Tags, "env", "prod")
 	assertTag(t, updated.Tags, "team", "net")
+	assertNoTag(t, updated.Tags, "env")
+	assertTagCount(t, updated.Tags, 1)
 
 	if updated.Properties == nil || updated.Properties.GatewayType == nil ||
 		*updated.Properties.GatewayType != armnetwork.VirtualNetworkGatewayTypeVPN {
 		t.Errorf("gatewayType=%v want Vpn (property must survive UpdateTags)", updated.Properties)
 	}
+
+	wiped := rawTagsPatch(t, ts,
+		"/subscriptions/sub-1/resourceGroups/"+rg+"/providers/Microsoft.Network/virtualNetworkGateways/vng-tag",
+		`{"tags":{}}`)
+	assertTagCount(t, ptrTags(wiped), 0)
 
 	_, err = client.BeginUpdateTags(ctx, rg, "missing", armnetwork.TagsObject{
 		Tags: map[string]*string{"team": to.Ptr("net")},
@@ -210,10 +237,10 @@ func patchVNGatewayTags(
 	return *created.ID
 }
 
-// patchLNGatewayTags creates a local network gateway with a tag, merges a second
-// via the synchronous UpdateTags, asserts both tags plus a preserved property,
-// checks the 404 path, and returns the gateway id.
-func patchLNGatewayTags(t *testing.T, ctx context.Context, opts *arm.ClientOptions, rg string) string {
+// patchLNGatewayTags creates a local network gateway with a tag, replaces it via
+// the synchronous UpdateTags, asserts the replacement plus a preserved property,
+// wipes the tags with a raw tags:{} PATCH, checks the 404 path, and returns the id.
+func patchLNGatewayTags(t *testing.T, ctx context.Context, ts *httptest.Server, opts *arm.ClientOptions, rg string) string {
 	t.Helper()
 
 	client, err := armnetwork.NewLocalNetworkGatewaysClient("sub-1", fakeCred{}, opts)
@@ -241,13 +268,19 @@ func patchLNGatewayTags(t *testing.T, ctx context.Context, opts *arm.ClientOptio
 		t.Fatalf("lng UpdateTags: %v", err)
 	}
 
-	assertTag(t, updated.Tags, "env", "prod")
 	assertTag(t, updated.Tags, "team", "net")
+	assertNoTag(t, updated.Tags, "env")
+	assertTagCount(t, updated.Tags, 1)
 
 	if updated.Properties == nil || updated.Properties.GatewayIPAddress == nil ||
 		*updated.Properties.GatewayIPAddress != "203.0.113.10" {
 		t.Errorf("gatewayIpAddress=%v want 203.0.113.10 (property must survive UpdateTags)", updated.Properties)
 	}
+
+	wiped := rawTagsPatch(t, ts,
+		"/subscriptions/sub-1/resourceGroups/"+rg+"/providers/Microsoft.Network/localNetworkGateways/lng-tag",
+		`{"tags":{}}`)
+	assertTagCount(t, ptrTags(wiped), 0)
 
 	_, err = client.UpdateTags(ctx, rg, "missing", armnetwork.TagsObject{
 		Tags: map[string]*string{"team": to.Ptr("net")},
@@ -258,7 +291,7 @@ func patchLNGatewayTags(t *testing.T, ctx context.Context, opts *arm.ClientOptio
 }
 
 // patchConnectionTags creates a connection between the two gateways with a tag,
-// merges a second via BeginUpdateTags, asserts both tags plus a preserved
+// replaces it via BeginUpdateTags, asserts the replacement plus a preserved
 // property, and checks the 404 path.
 func patchConnectionTags(t *testing.T, ctx context.Context, opts *arm.ClientOptions, rg, vngID, lngID string) {
 	t.Helper()
@@ -293,8 +326,9 @@ func patchConnectionTags(t *testing.T, ctx context.Context, opts *arm.ClientOpti
 
 	updated := pollDone(t, tagsP)
 
-	assertTag(t, updated.Tags, "env", "prod")
 	assertTag(t, updated.Tags, "team", "net")
+	assertNoTag(t, updated.Tags, "env")
+	assertTagCount(t, updated.Tags, 1)
 
 	if updated.Properties == nil || updated.Properties.ConnectionType == nil ||
 		*updated.Properties.ConnectionType != armnetwork.VirtualNetworkGatewayConnectionTypeIPsec {
@@ -323,6 +357,53 @@ func mustBeginPrefix(
 	return p
 }
 
+// rawTagsPatch sends a raw ARM UpdateTags PATCH with the given JSON body to the
+// resource at armPath. The armnetwork TagsObject drops an empty tags map via
+// omitempty, so a tags:{} wipe can only be exercised over the wire directly. It
+// asserts a 200 and returns the decoded response tags.
+func rawTagsPatch(t *testing.T, ts *httptest.Server, armPath, body string) map[string]string {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodPatch, ts.URL+armPath+"?api-version=2023-09-01", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build PATCH %s: %v", armPath, err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("PATCH %s: %v", armPath, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PATCH %s: status %d want 200", armPath, resp.StatusCode)
+	}
+
+	var decoded struct {
+		Tags map[string]string `json:"tags"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode PATCH %s response: %v", armPath, err)
+	}
+
+	return decoded.Tags
+}
+
+// ptrTags lifts a plain tag map to the *string-valued shape the assert helpers
+// take, so a raw-PATCH response can reuse them.
+func ptrTags(in map[string]string) map[string]*string {
+	out := make(map[string]*string, len(in))
+	for k, v := range in {
+		out[k] = to.Ptr(v)
+	}
+
+	return out
+}
+
 // assertTag fails the test unless tags[key] is present and equal to want.
 func assertTag(t *testing.T, tags map[string]*string, key, want string) {
 	t.Helper()
@@ -335,6 +416,24 @@ func assertTag(t *testing.T, tags map[string]*string, key, want string) {
 
 	if *got != want {
 		t.Errorf("tags[%s]=%q want %q", key, *got, want)
+	}
+}
+
+// assertNoTag fails the test if tags[key] is present.
+func assertNoTag(t *testing.T, tags map[string]*string, key string) {
+	t.Helper()
+
+	if _, ok := tags[key]; ok {
+		t.Errorf("tags[%s] present, want absent after replace (tags=%v)", key, derefTags(tags))
+	}
+}
+
+// assertTagCount fails the test unless tags has exactly n entries.
+func assertTagCount(t *testing.T, tags map[string]*string, n int) {
+	t.Helper()
+
+	if len(tags) != n {
+		t.Errorf("tag count=%d want %d (tags=%v)", len(tags), n, derefTags(tags))
 	}
 }
 

--- a/server/azure/vnet/network_updatetags_test.go
+++ b/server/azure/vnet/network_updatetags_test.go
@@ -1,0 +1,351 @@
+package vnet_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// TestSDKApplicationSecurityGroupUpdateTags drives the real armnetwork
+// ApplicationSecurityGroupsClient.UpdateTags (a synchronous PATCH): the supplied
+// tag is merged into the existing set, the ASG's other fields survive, the full
+// resource comes back, and UpdateTags on a missing ASG is a 404.
+func TestSDKApplicationSecurityGroupUpdateTags(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	client, err := armnetwork.NewApplicationSecurityGroupsClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pollDone(t, mustBeginASG(t, ctx, client, "rg-1", "asg-tag", armnetwork.ApplicationSecurityGroup{
+		Location: to.Ptr("westus2"),
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+	}))
+
+	updated, err := client.UpdateTags(ctx, "rg-1", "asg-tag", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("UpdateTags: %v", err)
+	}
+
+	// Merge: the new tag is added and the create-time tag is preserved.
+	assertTag(t, updated.Tags, "env", "prod")
+	assertTag(t, updated.Tags, "team", "net")
+
+	// Full resource: name, location and provisioningState come back on the PATCH.
+	if updated.Name == nil || *updated.Name != "asg-tag" {
+		t.Errorf("name=%v want asg-tag", updated.Name)
+	}
+
+	if updated.Location == nil || *updated.Location != "westus2" {
+		t.Errorf("location=%v want westus2 (property must survive UpdateTags)", updated.Location)
+	}
+
+	if updated.Properties == nil || updated.Properties.ProvisioningState == nil ||
+		*updated.Properties.ProvisioningState != armnetwork.ProvisioningStateSucceeded {
+		t.Errorf("provisioningState=%v want Succeeded", updated.Properties)
+	}
+
+	// A follow-up GET reflects the merged set (the merge was persisted, not echoed).
+	got, err := client.Get(ctx, "rg-1", "asg-tag", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	assertTag(t, got.Tags, "env", "prod")
+	assertTag(t, got.Tags, "team", "net")
+
+	_, err = client.UpdateTags(ctx, "rg-1", "missing", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	assertNotFound(t, err, "ASG UpdateTags on missing")
+}
+
+// TestSDKPublicIPPrefixUpdateTags drives PublicIPPrefixesClient.UpdateTags (a
+// synchronous PATCH): the tag merges while the prefix's properties (prefixLength,
+// synthesized ipPrefix, sku) are left intact, and UpdateTags on a missing prefix
+// is a 404.
+func TestSDKPublicIPPrefixUpdateTags(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	client, err := armnetwork.NewPublicIPPrefixesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const prefixLength = int32(28)
+
+	created := pollDone(t, mustBeginPrefix(t, ctx, client, "rg-1", "pfx-tag", armnetwork.PublicIPPrefix{
+		Location: to.Ptr("eastus"),
+		SKU: &armnetwork.PublicIPPrefixSKU{
+			Name: to.Ptr(armnetwork.PublicIPPrefixSKUNameStandard),
+			Tier: to.Ptr(armnetwork.PublicIPPrefixSKUTierRegional),
+		},
+		Tags: map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armnetwork.PublicIPPrefixPropertiesFormat{
+			PrefixLength: to.Ptr(prefixLength),
+		},
+	}))
+
+	wantIPPrefix := *created.Properties.IPPrefix
+
+	updated, err := client.UpdateTags(ctx, "rg-1", "pfx-tag", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("UpdateTags: %v", err)
+	}
+
+	assertTag(t, updated.Tags, "env", "prod")
+	assertTag(t, updated.Tags, "team", "net")
+
+	// Properties untouched by an UpdateTags PATCH.
+	if updated.Properties == nil || updated.Properties.PrefixLength == nil ||
+		*updated.Properties.PrefixLength != prefixLength {
+		t.Errorf("prefixLength=%v want %d (property must survive UpdateTags)", updated.Properties, prefixLength)
+	}
+
+	if updated.Properties.IPPrefix == nil || *updated.Properties.IPPrefix != wantIPPrefix {
+		t.Errorf("ipPrefix=%v want %s (unchanged)", updated.Properties.IPPrefix, wantIPPrefix)
+	}
+
+	if updated.SKU == nil || updated.SKU.Name == nil ||
+		*updated.SKU.Name != armnetwork.PublicIPPrefixSKUNameStandard {
+		t.Errorf("sku=%v want Standard (must survive UpdateTags)", updated.SKU)
+	}
+
+	_, err = client.UpdateTags(ctx, "rg-1", "missing", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	assertNotFound(t, err, "public IP prefix UpdateTags on missing")
+}
+
+// TestSDKNetworkGatewaysUpdateTags drives UpdateTags across all three gateway
+// families: VirtualNetworkGatewaysClient.BeginUpdateTags (LRO),
+// LocalNetworkGatewaysClient.UpdateTags (sync) and
+// VirtualNetworkGatewayConnectionsClient.BeginUpdateTags (LRO). Each merges a tag
+// while its properties survive; UpdateTags on a missing resource is a 404.
+func TestSDKNetworkGatewaysUpdateTags(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	const rg = "rg-gwtag"
+
+	subnetID := seedGatewayPrerequisites(t, ctx, opts, rg)
+	pipID := "/subscriptions/sub-1/resourceGroups/" + rg + "/providers/Microsoft.Network/publicIPAddresses/gw-pip"
+
+	vngID := patchVNGatewayTags(t, ctx, opts, rg, subnetID, pipID)
+	lngID := patchLNGatewayTags(t, ctx, opts, rg)
+	patchConnectionTags(t, ctx, opts, rg, vngID, lngID)
+}
+
+// patchVNGatewayTags creates a virtual network gateway with a tag, merges a
+// second via BeginUpdateTags, asserts both tags plus a preserved property, checks
+// the 404 path, and returns the gateway id.
+func patchVNGatewayTags(
+	t *testing.T, ctx context.Context, opts *arm.ClientOptions, rg, subnetID, pipID string,
+) string {
+	t.Helper()
+
+	client, err := armnetwork.NewVirtualNetworkGatewaysClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	create, err := client.BeginCreateOrUpdate(ctx, rg, "vng-tag", armnetwork.VirtualNetworkGateway{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armnetwork.VirtualNetworkGatewayPropertiesFormat{
+			GatewayType: to.Ptr(armnetwork.VirtualNetworkGatewayTypeVPN),
+			VPNType:     to.Ptr(armnetwork.VPNTypeRouteBased),
+			IPConfigurations: []*armnetwork.VirtualNetworkGatewayIPConfiguration{{
+				Name: to.Ptr("gwipconfig"),
+				Properties: &armnetwork.VirtualNetworkGatewayIPConfigurationPropertiesFormat{
+					PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+					Subnet:                    &armnetwork.SubResource{ID: to.Ptr(subnetID)},
+					PublicIPAddress:           &armnetwork.SubResource{ID: to.Ptr(pipID)},
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("vng BeginCreateOrUpdate: %v", err)
+	}
+
+	created := pollDone(t, create)
+
+	tagsP, err := client.BeginUpdateTags(ctx, rg, "vng-tag", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("vng BeginUpdateTags: %v", err)
+	}
+
+	updated := pollDone(t, tagsP)
+
+	assertTag(t, updated.Tags, "env", "prod")
+	assertTag(t, updated.Tags, "team", "net")
+
+	if updated.Properties == nil || updated.Properties.GatewayType == nil ||
+		*updated.Properties.GatewayType != armnetwork.VirtualNetworkGatewayTypeVPN {
+		t.Errorf("gatewayType=%v want Vpn (property must survive UpdateTags)", updated.Properties)
+	}
+
+	_, err = client.BeginUpdateTags(ctx, rg, "missing", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	assertNotFound(t, err, "vng UpdateTags on missing")
+
+	return *created.ID
+}
+
+// patchLNGatewayTags creates a local network gateway with a tag, merges a second
+// via the synchronous UpdateTags, asserts both tags plus a preserved property,
+// checks the 404 path, and returns the gateway id.
+func patchLNGatewayTags(t *testing.T, ctx context.Context, opts *arm.ClientOptions, rg string) string {
+	t.Helper()
+
+	client, err := armnetwork.NewLocalNetworkGatewaysClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	create, err := client.BeginCreateOrUpdate(ctx, rg, "lng-tag", armnetwork.LocalNetworkGateway{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armnetwork.LocalNetworkGatewayPropertiesFormat{
+			GatewayIPAddress: to.Ptr("203.0.113.10"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("lng BeginCreateOrUpdate: %v", err)
+	}
+
+	created := pollDone(t, create)
+
+	updated, err := client.UpdateTags(ctx, rg, "lng-tag", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("lng UpdateTags: %v", err)
+	}
+
+	assertTag(t, updated.Tags, "env", "prod")
+	assertTag(t, updated.Tags, "team", "net")
+
+	if updated.Properties == nil || updated.Properties.GatewayIPAddress == nil ||
+		*updated.Properties.GatewayIPAddress != "203.0.113.10" {
+		t.Errorf("gatewayIpAddress=%v want 203.0.113.10 (property must survive UpdateTags)", updated.Properties)
+	}
+
+	_, err = client.UpdateTags(ctx, rg, "missing", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	assertNotFound(t, err, "lng UpdateTags on missing")
+
+	return *created.ID
+}
+
+// patchConnectionTags creates a connection between the two gateways with a tag,
+// merges a second via BeginUpdateTags, asserts both tags plus a preserved
+// property, and checks the 404 path.
+func patchConnectionTags(t *testing.T, ctx context.Context, opts *arm.ClientOptions, rg, vngID, lngID string) {
+	t.Helper()
+
+	client, err := armnetwork.NewVirtualNetworkGatewayConnectionsClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	create, err := client.BeginCreateOrUpdate(ctx, rg, "conn-tag", armnetwork.VirtualNetworkGatewayConnection{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armnetwork.VirtualNetworkGatewayConnectionPropertiesFormat{
+			ConnectionType:         to.Ptr(armnetwork.VirtualNetworkGatewayConnectionTypeIPsec),
+			VirtualNetworkGateway1: &armnetwork.VirtualNetworkGateway{ID: to.Ptr(vngID)},
+			LocalNetworkGateway2:   &armnetwork.LocalNetworkGateway{ID: to.Ptr(lngID)},
+			SharedKey:              to.Ptr("s3cr3t-psk"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("conn BeginCreateOrUpdate: %v", err)
+	}
+
+	pollDone(t, create)
+
+	tagsP, err := client.BeginUpdateTags(ctx, rg, "conn-tag", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("conn BeginUpdateTags: %v", err)
+	}
+
+	updated := pollDone(t, tagsP)
+
+	assertTag(t, updated.Tags, "env", "prod")
+	assertTag(t, updated.Tags, "team", "net")
+
+	if updated.Properties == nil || updated.Properties.ConnectionType == nil ||
+		*updated.Properties.ConnectionType != armnetwork.VirtualNetworkGatewayConnectionTypeIPsec {
+		t.Errorf("connectionType=%v want IPsec (property must survive UpdateTags)", updated.Properties)
+	}
+
+	_, err = client.BeginUpdateTags(ctx, rg, "missing", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	assertNotFound(t, err, "conn UpdateTags on missing")
+}
+
+// mustBeginPrefix starts a public IP prefix create, failing the test on a
+// dispatch error before the poll.
+func mustBeginPrefix(
+	t *testing.T, ctx context.Context, client *armnetwork.PublicIPPrefixesClient,
+	rg, name string, body armnetwork.PublicIPPrefix,
+) *runtime.Poller[armnetwork.PublicIPPrefixesClientCreateOrUpdateResponse] {
+	t.Helper()
+
+	p, err := client.BeginCreateOrUpdate(ctx, rg, name, body, nil)
+	if err != nil {
+		t.Fatalf("prefix BeginCreateOrUpdate %s/%s: %v", rg, name, err)
+	}
+
+	return p
+}
+
+// assertTag fails the test unless tags[key] is present and equal to want.
+func assertTag(t *testing.T, tags map[string]*string, key, want string) {
+	t.Helper()
+
+	got, ok := tags[key]
+	if !ok || got == nil {
+		t.Errorf("tags[%s] missing, want %q (tags=%v)", key, want, derefTags(tags))
+		return
+	}
+
+	if *got != want {
+		t.Errorf("tags[%s]=%q want %q", key, *got, want)
+	}
+}
+
+// derefTags renders a tag map for error messages.
+func derefTags(in map[string]*string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		if v != nil {
+			out[k] = *v
+		}
+	}
+
+	return out
+}

--- a/server/azure/vnet/private_link.go
+++ b/server/azure/vnet/private_link.go
@@ -399,7 +399,7 @@ func (h *Handler) routePrivateLinkService(w http.ResponseWriter, r *http.Request
 	}
 }
 
-//nolint:gocritic // rp is a request-scoped value
+//nolint:gocritic,dupl // rp is request-scoped; the capability-gated create shape is mirrored by createVNGateway
 func (*Handler) createPrivateLinkService(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
 	svc netdriver.AzurePrivateLink,
 ) {

--- a/server/azure/vnet/public_ip_prefix.go
+++ b/server/azure/vnet/public_ip_prefix.go
@@ -95,6 +95,8 @@ func (h *Handler) routePublicIPPrefix(w http.ResponseWriter, r *http.Request, rp
 	switch r.Method {
 	case http.MethodPut:
 		h.createPublicIPPrefix(w, r, rp, svc)
+	case http.MethodPatch:
+		h.patchPublicIPPrefix(w, r, rp, svc)
 	case http.MethodGet:
 		h.getPublicIPPrefix(w, r, rp, svc)
 	case http.MethodDelete:
@@ -142,6 +144,35 @@ func (h *Handler) createPublicIPPrefix(w http.ResponseWriter, r *http.Request, r
 
 	writeAcceptedAsync(w, r, rp.Subscription, "pipprefix-create-"+rp.ResourceName,
 		h.publicIPPrefixResponse(r.Context(), stored, rp))
+}
+
+// patchPublicIPPrefix applies an ARM UpdateTags PATCH (PublicIPPrefixesClient.
+// UpdateTags — a synchronous 200): the body's tags are merged into the stored
+// set, the prefix's other fields are left intact, and the full resource is
+// returned. A PATCH on a missing prefix is a 404.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) patchPublicIPPrefix(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
+	svc netdriver.AzurePublicIPPrefixes,
+) {
+	existing, ok := svc.GetAzurePublicIPPrefix(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"public IP prefix "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	var req armTagsObject
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	existing.Tags = mergedTagMap(existing.Tags, req.Tags)
+	stored := svc.PutAzurePublicIPPrefix(r.Context(), existing)
+
+	azurearm.WriteJSON(w, http.StatusOK, h.publicIPPrefixResponse(r.Context(), stored, rp))
 }
 
 //nolint:gocritic // rp is a request-scoped value

--- a/server/azure/vnet/public_ip_prefix.go
+++ b/server/azure/vnet/public_ip_prefix.go
@@ -147,30 +147,38 @@ func (h *Handler) createPublicIPPrefix(w http.ResponseWriter, r *http.Request, r
 }
 
 // patchPublicIPPrefix applies an ARM UpdateTags PATCH (PublicIPPrefixesClient.
-// UpdateTags — a synchronous 200): the body's tags are merged into the stored
-// set, the prefix's other fields are left intact, and the full resource is
-// returned. A PATCH on a missing prefix is a 404.
+// UpdateTags — a synchronous 200): the body's tags REPLACE the stored set
+// wholesale (tags:{} wipes them), the prefix's other fields are left intact, and
+// the full resource is returned. The get-modify-put is guarded by patchMu so a
+// concurrent PATCH cannot drop the write. A PATCH on a missing prefix is a 404.
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) patchPublicIPPrefix(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath,
 	svc netdriver.AzurePublicIPPrefixes,
 ) {
-	existing, ok := svc.GetAzurePublicIPPrefix(r.Context(), rp.ResourceGroup, rp.ResourceName)
-	if !ok {
-		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
-			"public IP prefix "+rp.ResourceName+" not found")
-
-		return
-	}
-
 	var req armTagsObject
 
 	if !azurearm.DecodeJSON(w, r, &req) {
 		return
 	}
 
-	existing.Tags = mergedTagMap(existing.Tags, req.Tags)
+	h.patchMu.Lock()
+
+	existing, ok := svc.GetAzurePublicIPPrefix(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if !ok {
+		h.patchMu.Unlock()
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"public IP prefix "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	if req.Tags != nil {
+		existing.Tags = replacementTags(req.Tags)
+	}
+
 	stored := svc.PutAzurePublicIPPrefix(r.Context(), existing)
+	h.patchMu.Unlock()
 
 	azurearm.WriteJSON(w, http.StatusOK, h.publicIPPrefixResponse(r.Context(), stored, rp))
 }


### PR DESCRIPTION
## Summary

Adds the ARM **UpdateTags** PATCH to the `Microsoft.Network` wire handlers that were previously create-or-update (PUT) only, bringing them to real-Azure `*Client.UpdateTags` / `BeginUpdateTags` parity:

- **Public IP Prefixes** (`publicIPPrefixes`) — `PublicIPPrefixesClient.UpdateTags` (sync 200)
- **Application Security Groups** (`applicationSecurityGroups`) — `ApplicationSecurityGroupsClient.UpdateTags` (sync 200)
- **Network gateways** — `virtualNetworkGateways` (`BeginUpdateTags`, LRO), `localNetworkGateways` (`UpdateTags`, sync), `connections` (`BeginUpdateTags`, LRO)

## Why

Real Azure clients (and IaC tooling) update tags on these resources with a `TagsObject` PATCH (`{"tags": {...}}`) rather than a full CreateOrUpdate. Previously any PATCH fell through to 405 Method Not Allowed. Each PATCH now merges the supplied tags into the stored set, leaves the resource's properties intact, and returns the full resource with the same shape as GET; a PATCH on a missing resource is a 404. Read-modify-write runs against the existing `Get`/`Put` driver methods, so no driver interface widens.

## Private Link — intentionally not patched

`privateEndpoints` and `privateLinkServices` were in the original scope but are **skipped**: neither `PrivateEndpointsClient` nor `PrivateLinkServicesClient` exposes a resource-level `UpdateTags` in real Azure (armnetwork). Adding a PATCH there would invent behavior the real API does not have.

## Tests

New SDK round-trip tests (`network_updatetags_test.go`) drive the real armnetwork `UpdateTags` / `BeginUpdateTags` clients across all patched families, proving: tag merge preserves existing tags, resource properties survive the PATCH, the full resource is returned, and UpdateTags on a missing resource is a 404.