### PR TITLE
feat(azure-containerapps): revisions, activate/deactivate/restart, traffic split

### DIFF
--- a/docs/coverage/README.md
+++ b/docs/coverage/README.md
@@ -28,7 +28,7 @@ code does not implement. Machine-readable: [`coverage.json`](./coverage.json).
 | `cloudtrail` | [CloudTrail](./aws/cloudtrail.md) | — | — | — | 60 |
 | `compute` | [EC2](./aws/ec2.md) | [VirtualMachines](./azure/virtualmachines.md) | [GCE](./gcp/gce.md) | — | 37 |
 | `configservice` | [Config](./aws/config.md) | — | — | — | 102 |
-| `containerapps` | — | [ContainerApps](./azure/containerapps.md) | — | — | 14 |
+| `containerapps` | — | [ContainerApps](./azure/containerapps.md) | — | — | 19 |
 | `containerinstances` | — | [ContainerInstances](./azure/containerinstances.md) | — | — | 10 |
 | `containerregistry` | [ECR](./aws/ecr.md) | [ACR](./azure/acr.md) | [ArtifactRegistry](./gcp/artifactregistry.md) | — | 15 |
 | `cosmosaccount` | — | [Cosmosaccount](./azure/cosmosaccount.md) | — | — | 10 |

--- a/docs/coverage/azure/README.md
+++ b/docs/coverage/azure/README.md
@@ -10,7 +10,7 @@ Services cloudemu emulates for Azure, by native name. Back to the [cross-provide
 | [AKS](./aks.md) | — (provider-native) | 16 |
 | [BlobStorage](./blobstorage.md) | `storage` | 35 |
 | [Cache](./cache.md) | `cache` | 17 |
-| [ContainerApps](./containerapps.md) | — (provider-native) | 14 |
+| [ContainerApps](./containerapps.md) | — (provider-native) | 19 |
 | [ContainerInstances](./containerinstances.md) | `containerinstances` | 10 |
 | [CosmosDB](./cosmosdb.md) | `database` | 24 |
 | [CosmosPostgreSQL](./cosmospostgresql.md) | `cosmospostgresql` | 34 |

--- a/docs/coverage/azure/containerapps.md
+++ b/docs/coverage/azure/containerapps.md
@@ -3,24 +3,29 @@
 
 provider-native `containerapps` wire service (Azure-only) · no portable driver · [Azure index](./README.md)
 
-## Operations (14)
+## Operations (19)
 
 | Operation | Description |
 | --- | --- |
 | `ARMID` |  |
+| `ActivateRevision` |  |
 | `CreateOrUpdateApp` |  |
 | `CreateOrUpdateEnvironment` |  |
+| `DeactivateRevision` |  |
 | `DeleteApp` |  |
 | `DeleteEnvironment` |  |
 | `DiscoverApps` |  |
 | `DiscoverEnvironments` |  |
 | `GetApp` |  |
 | `GetEnvironment` |  |
+| `GetRevision` |  |
 | `ListAppsByResourceGroup` |  |
 | `ListAppsBySubscription` |  |
 | `ListEnvironmentsByResourceGroup` |  |
 | `ListEnvironmentsBySubscription` |  |
+| `ListRevisions` |  |
 | `PurgeResourceGroup` |  |
+| `RestartRevision` |  |
 
 ## Not in scope
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -2900,10 +2900,16 @@
         "name": "ARMID"
       },
       {
+        "name": "ActivateRevision"
+      },
+      {
         "name": "CreateOrUpdateApp"
       },
       {
         "name": "CreateOrUpdateEnvironment"
+      },
+      {
+        "name": "DeactivateRevision"
       },
       {
         "name": "DeleteApp"
@@ -2924,6 +2930,9 @@
         "name": "GetEnvironment"
       },
       {
+        "name": "GetRevision"
+      },
+      {
         "name": "ListAppsByResourceGroup"
       },
       {
@@ -2936,7 +2945,13 @@
         "name": "ListEnvironmentsBySubscription"
       },
       {
+        "name": "ListRevisions"
+      },
+      {
         "name": "PurgeResourceGroup"
+      },
+      {
+        "name": "RestartRevision"
       }
     ],
     "providers": {

--- a/providers/azure/containerapps/containerapps.go
+++ b/providers/azure/containerapps/containerapps.go
@@ -296,7 +296,9 @@ func (m *Mock) CreateOrUpdateApp(
 	app.Template = cloneTemplate(in.Template)
 	app.Fqdn = m.appFqdnLocked(name, in.EnvironmentID, in.Ingress)
 
-	m.materializeRevisionLocked(&app)
+	if err := m.materializeRevisionLocked(&app); err != nil {
+		return ContainerApp{}, false, err
+	}
 
 	if err := validateTrafficLocked(&app); err != nil {
 		return ContainerApp{}, false, err

--- a/providers/azure/containerapps/containerapps.go
+++ b/providers/azure/containerapps/containerapps.go
@@ -101,15 +101,18 @@ type Template struct {
 }
 
 // Ingress is the app's inbound configuration. Fqdn is synthesized on create.
+// Traffic splits inbound requests across the app's revisions.
 type Ingress struct {
-	External      bool   `json:"external,omitempty"`
-	TargetPort    int32  `json:"targetPort,omitempty"`
-	Transport     string `json:"transport,omitempty"`
-	AllowInsecure bool   `json:"allowInsecure,omitempty"`
+	External      bool            `json:"external,omitempty"`
+	TargetPort    int32           `json:"targetPort,omitempty"`
+	Transport     string          `json:"transport,omitempty"`
+	AllowInsecure bool            `json:"allowInsecure,omitempty"`
+	Traffic       []TrafficWeight `json:"traffic,omitempty"`
 }
 
 // ContainerApp is a stored container app. Fqdn and LatestRevisionName are minted
-// once at create and preserved across updates.
+// once at create and preserved across updates. Revisions is the app's revision
+// history — a new entry is materialized every time the template changes.
 type ContainerApp struct {
 	Subscription       string            `json:"subscription"`
 	ResourceGroup      string            `json:"resourceGroup"`
@@ -123,6 +126,7 @@ type ContainerApp struct {
 	Template           Template          `json:"template"`
 	Fqdn               string            `json:"fqdn,omitempty"`
 	LatestRevisionName string            `json:"latestRevisionName"`
+	Revisions          []Revision        `json:"revisions,omitempty"`
 }
 
 // ARMID returns the fully-qualified ARM id for the container app.
@@ -150,16 +154,25 @@ type AppInput struct {
 
 // Mock is the in-memory backend for Container Apps.
 type Mock struct {
-	mu   sync.RWMutex
-	envs *memstore.Store[Environment]
-	apps *memstore.Store[ContainerApp]
+	mu    sync.RWMutex
+	clock config.Clock
+	envs  *memstore.Store[Environment]
+	apps  *memstore.Store[ContainerApp]
 }
 
-// New creates an empty Container Apps mock.
-func New(_ *config.Options) *Mock {
+// New creates an empty Container Apps mock. The clock stamps revision createdTime
+// values; it falls back to the real clock when opts (or its clock) is nil so the
+// mock stays usable standalone (e.g. New(nil) in tests).
+func New(opts *config.Options) *Mock {
+	clock := config.Clock(config.RealClock{})
+	if opts != nil && opts.Clock != nil {
+		clock = opts.Clock
+	}
+
 	return &Mock{
-		envs: memstore.New[Environment](),
-		apps: memstore.New[ContainerApp](),
+		clock: clock,
+		envs:  memstore.New[Environment](),
+		apps:  memstore.New[ContainerApp](),
 	}
 }
 
@@ -267,7 +280,11 @@ func (m *Mock) CreateOrUpdateApp(
 
 	if created {
 		app = ContainerApp{Subscription: sub, ResourceGroup: rg, Name: name}
-		app.LatestRevisionName = strings.ToLower(name) + "--" + shortHash(app.ARMID())
+	} else {
+		// Get returns a value copy but the revision slice shares its backing
+		// array; clone it so a validation failure below leaves the stored app
+		// untouched (we only Set on success).
+		app.Revisions = cloneRevisions(app.Revisions)
 	}
 
 	app.Location = in.Location
@@ -278,6 +295,12 @@ func (m *Mock) CreateOrUpdateApp(
 	app.SecretNames = append([]string(nil), in.SecretNames...)
 	app.Template = cloneTemplate(in.Template)
 	app.Fqdn = m.appFqdnLocked(name, in.EnvironmentID, in.Ingress)
+
+	m.materializeRevisionLocked(&app)
+
+	if err := validateTrafficLocked(&app); err != nil {
+		return ContainerApp{}, false, err
+	}
 
 	m.apps.Set(k, app)
 
@@ -497,6 +520,7 @@ func cloneIngress(in *Ingress) *Ingress {
 	}
 
 	out := *in
+	out.Traffic = append([]TrafficWeight(nil), in.Traffic...)
 
 	return &out
 }

--- a/providers/azure/containerapps/containerapps_test.go
+++ b/providers/azure/containerapps/containerapps_test.go
@@ -242,7 +242,7 @@ func TestRevisionMaterializedOnTemplateChange(t *testing.T) {
 	base := func(suffix, image string) *containerapps.AppInput {
 		return &containerapps.AppInput{
 			Location: region, EnvironmentID: env.ARMID(), ActiveRevMode: "Multiple",
-			Ingress:  &containerapps.Ingress{External: true, TargetPort: 80},
+			Ingress: &containerapps.Ingress{External: true, TargetPort: 80},
 			Template: containerapps.Template{
 				RevisionSuffix: suffix,
 				Containers:     []containerapps.Container{{Name: "main", Image: image}},
@@ -349,6 +349,84 @@ func TestActivateDeactivateRestartRevision(t *testing.T) {
 
 	if _, err := m.ListRevisions(ctx, sub, rg, "no-app"); err == nil {
 		t.Fatal("ListRevisions on missing app returned nil, want NotFound")
+	}
+}
+
+// TestSingleModeActivateKeepsOneActive proves that in single-revision mode
+// activating a superseded revision makes it THE sole active revision — the state
+// never has two active revisions, which real Azure cannot produce.
+func TestSingleModeActivateKeepsOneActive(t *testing.T) {
+	m := newMock()
+	env := mustEnv(t, m)
+	ctx := context.Background()
+
+	mk := func(suffix string) *containerapps.AppInput {
+		return &containerapps.AppInput{
+			Location: region, EnvironmentID: env.ARMID(), ActiveRevMode: "Single",
+			Template: containerapps.Template{RevisionSuffix: suffix},
+		}
+	}
+
+	mustApp(t, m, mk("v1"))
+	mustApp(t, m, mk("v2")) // v2 supersedes v1 (single mode)
+
+	rev1 := appNm + "--v1"
+
+	if err := m.ActivateRevision(ctx, sub, rg, appNm, rev1); err != nil {
+		t.Fatalf("ActivateRevision v1: %v", err)
+	}
+
+	revs, err := m.ListRevisions(ctx, sub, rg, appNm)
+	if err != nil {
+		t.Fatalf("ListRevisions: %v", err)
+	}
+
+	var active []string
+
+	for i := range revs {
+		if revs[i].Active {
+			active = append(active, revs[i].Name)
+		}
+	}
+
+	if len(active) != 1 || active[0] != rev1 {
+		t.Fatalf("active revisions in single mode = %v, want exactly [%s]", active, rev1)
+	}
+}
+
+// TestDuplicateRevisionSuffixRejected proves that re-using an explicit revision
+// suffix with a different template is rejected, while an identical re-PUT stays
+// idempotent (no error, no duplicate revision).
+func TestDuplicateRevisionSuffixRejected(t *testing.T) {
+	m := newMock()
+	env := mustEnv(t, m)
+	ctx := context.Background()
+
+	mk := func(image string) *containerapps.AppInput {
+		return &containerapps.AppInput{
+			Location: region, EnvironmentID: env.ARMID(),
+			Template: containerapps.Template{
+				RevisionSuffix: "v1",
+				Containers:     []containerapps.Container{{Name: "main", Image: image}},
+			},
+		}
+	}
+
+	mustApp(t, m, mk("nginx:1"))
+
+	// Same suffix, different template -> conflict.
+	if _, _, err := m.CreateOrUpdateApp(ctx, sub, rg, appNm, mk("nginx:2")); err == nil {
+		t.Fatal("reusing suffix v1 with a different template was accepted, want an error")
+	}
+
+	// Identical re-PUT -> idempotent, no duplicate revision.
+	if _, _, err := m.CreateOrUpdateApp(ctx, sub, rg, appNm, mk("nginx:1")); err != nil {
+		t.Fatalf("identical re-PUT rejected: %v", err)
+	}
+
+	revs, err := m.ListRevisions(ctx, sub, rg, appNm)
+	if err != nil || len(revs) != 1 {
+		t.Fatalf("ListRevisions = %v (err %v), want exactly 1 revision", revs, err)
 	}
 }
 

--- a/providers/azure/containerapps/containerapps_test.go
+++ b/providers/azure/containerapps/containerapps_test.go
@@ -221,4 +221,217 @@ func TestSnapshotRoundTrip(t *testing.T) {
 	}
 }
 
+func mustApp(t *testing.T, m *containerapps.Mock, in *containerapps.AppInput) containerapps.ContainerApp {
+	t.Helper()
+
+	app, _, err := m.CreateOrUpdateApp(context.Background(), sub, rg, appNm, in)
+	if err != nil {
+		t.Fatalf("CreateOrUpdateApp: %v", err)
+	}
+
+	return app
+}
+
+// TestRevisionMaterializedOnTemplateChange proves a create mints one revision and
+// a template change mints a second, with both retained in multiple-revisions mode.
+func TestRevisionMaterializedOnTemplateChange(t *testing.T) {
+	m := newMock()
+	env := mustEnv(t, m)
+	ctx := context.Background()
+
+	base := func(suffix, image string) *containerapps.AppInput {
+		return &containerapps.AppInput{
+			Location: region, EnvironmentID: env.ARMID(), ActiveRevMode: "Multiple",
+			Ingress:  &containerapps.Ingress{External: true, TargetPort: 80},
+			Template: containerapps.Template{
+				RevisionSuffix: suffix,
+				Containers:     []containerapps.Container{{Name: "main", Image: image}},
+			},
+		}
+	}
+
+	app := mustApp(t, m, base("v1", "nginx:1"))
+	if app.LatestRevisionName != appNm+"--v1" {
+		t.Fatalf("latestRevisionName = %q, want %s--v1", app.LatestRevisionName, appNm)
+	}
+
+	revs, err := m.ListRevisions(ctx, sub, rg, appNm)
+	if err != nil || len(revs) != 1 {
+		t.Fatalf("ListRevisions after create = %v (err %v), want 1", revs, err)
+	}
+
+	if !revs[0].Active || revs[0].TrafficWeight != 100 {
+		t.Fatalf("first revision active=%v weight=%d, want active=true weight=100", revs[0].Active, revs[0].TrafficWeight)
+	}
+
+	mustApp(t, m, base("v2", "nginx:2"))
+
+	revs, err = m.ListRevisions(ctx, sub, rg, appNm)
+	if err != nil || len(revs) != 2 {
+		t.Fatalf("ListRevisions after update = %v (err %v), want 2", revs, err)
+	}
+
+	// Multiple mode keeps the earlier revision active alongside the new latest.
+	for i := range revs {
+		if !revs[i].Active {
+			t.Fatalf("revision %q inactive in multiple mode, want active", revs[i].Name)
+		}
+	}
+}
+
+// TestSingleModeSupersedesRevision proves single-revision mode deactivates the
+// prior revision when a new one is materialized.
+func TestSingleModeSupersedesRevision(t *testing.T) {
+	m := newMock()
+	env := mustEnv(t, m)
+	ctx := context.Background()
+
+	mk := func(suffix string) *containerapps.AppInput {
+		return &containerapps.AppInput{
+			Location: region, EnvironmentID: env.ARMID(), ActiveRevMode: "Single",
+			Template: containerapps.Template{RevisionSuffix: suffix},
+		}
+	}
+
+	mustApp(t, m, mk("v1"))
+	mustApp(t, m, mk("v2"))
+
+	r1, err := m.GetRevision(ctx, sub, rg, appNm, appNm+"--v1")
+	if err != nil {
+		t.Fatalf("GetRevision v1: %v", err)
+	}
+
+	if r1.Active {
+		t.Fatal("v1 still active in single mode after v2 created, want superseded")
+	}
+
+	r2, err := m.GetRevision(ctx, sub, rg, appNm, appNm+"--v2")
+	if err != nil || !r2.Active {
+		t.Fatalf("v2 active = %v (err %v), want active", r2.Active, err)
+	}
+}
+
+// TestActivateDeactivateRestartRevision covers the three POST verbs and NotFound.
+func TestActivateDeactivateRestartRevision(t *testing.T) {
+	m := newMock()
+	env := mustEnv(t, m)
+	ctx := context.Background()
+	rev := appNm + "--v1"
+
+	mustApp(t, m, &containerapps.AppInput{
+		Location: region, EnvironmentID: env.ARMID(),
+		Template: containerapps.Template{RevisionSuffix: "v1"},
+	})
+
+	if err := m.DeactivateRevision(ctx, sub, rg, appNm, rev); err != nil {
+		t.Fatalf("DeactivateRevision: %v", err)
+	}
+
+	if got, _ := m.GetRevision(ctx, sub, rg, appNm, rev); got.Active {
+		t.Fatal("revision active after deactivate, want false")
+	}
+
+	if err := m.ActivateRevision(ctx, sub, rg, appNm, rev); err != nil {
+		t.Fatalf("ActivateRevision: %v", err)
+	}
+
+	if got, _ := m.GetRevision(ctx, sub, rg, appNm, rev); !got.Active {
+		t.Fatal("revision inactive after activate, want true")
+	}
+
+	if err := m.RestartRevision(ctx, sub, rg, appNm, rev); err != nil {
+		t.Fatalf("RestartRevision: %v", err)
+	}
+
+	if err := m.ActivateRevision(ctx, sub, rg, appNm, appNm+"--missing"); err == nil {
+		t.Fatal("ActivateRevision on missing revision returned nil, want NotFound")
+	}
+
+	if _, err := m.ListRevisions(ctx, sub, rg, "no-app"); err == nil {
+		t.Fatal("ListRevisions on missing app returned nil, want NotFound")
+	}
+}
+
+// TestTrafficWeightValidation proves an ingress split must reference known
+// revisions and sum to 100, and a rejected update leaves the app unchanged.
+func TestTrafficWeightValidation(t *testing.T) {
+	m := newMock()
+	env := mustEnv(t, m)
+	ctx := context.Background()
+
+	mk := func(suffix string, traffic []containerapps.TrafficWeight) *containerapps.AppInput {
+		return &containerapps.AppInput{
+			Location: region, EnvironmentID: env.ARMID(), ActiveRevMode: "Multiple",
+			Ingress:  &containerapps.Ingress{External: true, TargetPort: 80, Traffic: traffic},
+			Template: containerapps.Template{RevisionSuffix: suffix},
+		}
+	}
+
+	mustApp(t, m, mk("v1", nil))
+	mustApp(t, m, mk("v2", nil))
+
+	rev1, rev2 := appNm+"--v1", appNm+"--v2"
+
+	// A balanced split is accepted and reflected in per-revision weights.
+	mustApp(t, m, mk("v2", []containerapps.TrafficWeight{
+		{RevisionName: rev1, Weight: 60}, {RevisionName: rev2, Weight: 40},
+	}))
+
+	r1, _ := m.GetRevision(ctx, sub, rg, appNm, rev1)
+	if r1.TrafficWeight != 60 {
+		t.Fatalf("rev1 weight = %d, want 60", r1.TrafficWeight)
+	}
+
+	// An unbalanced split is rejected...
+	if _, _, err := m.CreateOrUpdateApp(ctx, sub, rg, appNm, mk("v2", []containerapps.TrafficWeight{
+		{RevisionName: rev1, Weight: 60}, {RevisionName: rev2, Weight: 30},
+	})); err == nil {
+		t.Fatal("split summing to 90 accepted, want InvalidArgument")
+	}
+
+	// ...and the prior valid split survives the rejected update.
+	if r1, _ = m.GetRevision(ctx, sub, rg, appNm, rev1); r1.TrafficWeight != 60 {
+		t.Fatalf("rev1 weight after rejected update = %d, want 60 (unchanged)", r1.TrafficWeight)
+	}
+
+	// A split naming an unknown revision is rejected.
+	if _, _, err := m.CreateOrUpdateApp(ctx, sub, rg, appNm, mk("v2", []containerapps.TrafficWeight{
+		{RevisionName: appNm + "--ghost", Weight: 100},
+	})); err == nil {
+		t.Fatal("split referencing unknown revision accepted, want InvalidArgument")
+	}
+}
+
+// TestRevisionsSurviveSnapshot proves the revision history round-trips through a
+// snapshot/restore.
+func TestRevisionsSurviveSnapshot(t *testing.T) {
+	m := newMock()
+	env := mustEnv(t, m)
+	ctx := context.Background()
+
+	mustApp(t, m, &containerapps.AppInput{
+		Location: region, EnvironmentID: env.ARMID(), ActiveRevMode: "Multiple",
+		Template: containerapps.Template{RevisionSuffix: "v1"},
+	})
+	mustApp(t, m, &containerapps.AppInput{
+		Location: region, EnvironmentID: env.ARMID(), ActiveRevMode: "Multiple",
+		Template: containerapps.Template{RevisionSuffix: "v2"},
+	})
+
+	data, err := m.Snapshot(ctx, false)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	restored := newMock()
+	if err := restored.Restore(ctx, data); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	revs, err := restored.ListRevisions(ctx, sub, rg, appNm)
+	if err != nil || len(revs) != 2 {
+		t.Fatalf("restored ListRevisions = %v (err %v), want 2", revs, err)
+	}
+}
+
 func ptr[T any](v T) *T { return &v }

--- a/providers/azure/containerapps/revisions.go
+++ b/providers/azure/containerapps/revisions.go
@@ -66,8 +66,11 @@ type Revision struct {
 
 // materializeRevisionLocked creates or refreshes the revision the app's current
 // template maps to, points LatestRevisionName at it, and reconciles the active
-// flags for the app's active-revisions mode. Callers hold m.mu.
-func (m *Mock) materializeRevisionLocked(app *ContainerApp) {
+// flags for the app's active-revisions mode. Re-using an explicit
+// template.revisionSuffix that already names a revision with a different template
+// is rejected, matching Azure ("revision with suffix ... already exists"); an
+// identical re-PUT stays idempotent. Callers hold m.mu.
+func (m *Mock) materializeRevisionLocked(app *ContainerApp) error {
 	suffix := app.Template.RevisionSuffix
 	if suffix == "" {
 		suffix = templateSuffix(app.Template)
@@ -85,7 +88,11 @@ func (m *Mock) materializeRevisionLocked(app *ContainerApp) {
 	}
 
 	if idx := revisionIndex(app, revName); idx >= 0 {
-		app.Revisions[idx].Template = cloneTemplate(app.Template)
+		if templateSuffix(app.Revisions[idx].Template) != templateSuffix(app.Template) {
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"revision with suffix %q already exists with a different template", suffix)
+		}
+
 		app.Revisions[idx].Fqdn = fqdn
 	} else {
 		app.Revisions = append(app.Revisions, Revision{
@@ -97,6 +104,8 @@ func (m *Mock) materializeRevisionLocked(app *ContainerApp) {
 	}
 
 	reconcileActive(app, revName)
+
+	return nil
 }
 
 // reconcileActive marks the latest revision active. In single-revision mode
@@ -244,6 +253,20 @@ func (m *Mock) setRevisionActive(sub, rg, appName, revName string, active bool) 
 
 	app.Revisions = cloneRevisions(app.Revisions)
 	app.Revisions[idx].Active = active
+
+	// Single-revision mode admits exactly one active revision: activating one
+	// makes it the sole active revision (and the traffic target), so it can
+	// never leave two active at once. Multiple mode flips the one flag alone.
+	if active && !strings.EqualFold(app.ActiveRevMode, modeMultiple) {
+		for i := range app.Revisions {
+			if i != idx {
+				app.Revisions[i].Active = false
+			}
+		}
+
+		app.LatestRevisionName = app.Revisions[idx].Name
+	}
+
 	m.apps.Set(k, app)
 
 	return nil

--- a/providers/azure/containerapps/revisions.go
+++ b/providers/azure/containerapps/revisions.go
@@ -1,0 +1,340 @@
+package containerapps
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+const (
+	// modeMultiple is the activeRevisionsMode value that keeps every revision
+	// active; any other value (including the default "" / "Single") means only
+	// the latest revision stays active.
+	modeMultiple = "Multiple"
+
+	// fullTraffic is the weight an app's ingress traffic split must sum to.
+	fullTraffic = 100
+	// revSuffixLen is how many hex chars of the template hash seed an
+	// auto-generated revision suffix when the template sets none.
+	revSuffixLen = 8
+	// defaultMinReplicas is the replica count reported for an active revision
+	// whose template pins no explicit scale.minReplicas.
+	defaultMinReplicas = 1
+
+	// Revision provisioning/running/health states mirror the armappcontainers
+	// enums a client reads back off a revision.
+	revProvisioned = "Provisioned"
+	revRunning     = "Running"
+	revStopped     = "Stopped"
+	healthHealthy  = "Healthy"
+	healthNone     = "None"
+)
+
+// TrafficWeight is one entry of an app's ingress traffic split: it routes a
+// share of inbound requests to a named revision (or the latest revision).
+type TrafficWeight struct {
+	RevisionName   string `json:"revisionName,omitempty"`
+	Weight         int32  `json:"weight"`
+	Label          string `json:"label,omitempty"`
+	LatestRevision bool   `json:"latestRevision,omitempty"`
+}
+
+// Revision is a point-in-time snapshot of a container app's template. Name,
+// CreatedTime, Active, Fqdn and Template are durable and persisted with the app;
+// the remaining fields are derived at read time from the parent app's
+// scale/ingress and are never stored (json:"-"), so a snapshot cannot capture a
+// stale computed value.
+type Revision struct {
+	Name        string `json:"name"`
+	CreatedTime string `json:"createdTime"`
+	Active      bool   `json:"active"`
+	Fqdn        string `json:"fqdn,omitempty"`
+	Template    Template
+
+	TrafficWeight     int32  `json:"-"`
+	Replicas          int32  `json:"-"`
+	ProvisioningState string `json:"-"`
+	RunningState      string `json:"-"`
+	HealthState       string `json:"-"`
+}
+
+// materializeRevisionLocked creates or refreshes the revision the app's current
+// template maps to, points LatestRevisionName at it, and reconciles the active
+// flags for the app's active-revisions mode. Callers hold m.mu.
+func (m *Mock) materializeRevisionLocked(app *ContainerApp) {
+	suffix := app.Template.RevisionSuffix
+	if suffix == "" {
+		suffix = templateSuffix(app.Template)
+	}
+
+	revName := strings.ToLower(app.Name) + "--" + suffix
+	app.LatestRevisionName = revName
+
+	fqdn := ""
+
+	if app.Ingress != nil {
+		if domain := m.envDomainLocked(app.EnvironmentID); domain != "" {
+			fqdn = revName + "." + domain
+		}
+	}
+
+	if idx := revisionIndex(app, revName); idx >= 0 {
+		app.Revisions[idx].Template = cloneTemplate(app.Template)
+		app.Revisions[idx].Fqdn = fqdn
+	} else {
+		app.Revisions = append(app.Revisions, Revision{
+			Name:        revName,
+			CreatedTime: m.clock.Now().UTC().Format(time.RFC3339Nano),
+			Template:    cloneTemplate(app.Template),
+			Fqdn:        fqdn,
+		})
+	}
+
+	reconcileActive(app, revName)
+}
+
+// reconcileActive marks the latest revision active. In single-revision mode
+// (the default) every other revision is deactivated; in multiple mode the
+// others keep whatever active flag they already carry.
+func reconcileActive(app *ContainerApp, latest string) {
+	multiple := strings.EqualFold(app.ActiveRevMode, modeMultiple)
+
+	for i := range app.Revisions {
+		switch {
+		case strings.EqualFold(app.Revisions[i].Name, latest):
+			app.Revisions[i].Active = true
+		case !multiple:
+			app.Revisions[i].Active = false
+		}
+	}
+}
+
+// validateTrafficLocked enforces Azure's ingress traffic rules: every entry must
+// name an existing revision (or set latestRevision), and the weights must sum to
+// 100. An empty traffic block is valid — Azure then routes 100% to the latest
+// revision. Callers hold m.mu.
+func validateTrafficLocked(app *ContainerApp) error {
+	if app.Ingress == nil || len(app.Ingress.Traffic) == 0 {
+		return nil
+	}
+
+	var sum int32
+
+	for i := range app.Ingress.Traffic {
+		t := app.Ingress.Traffic[i]
+
+		switch {
+		case t.LatestRevision:
+		case t.RevisionName == "":
+			return cerrors.New(cerrors.InvalidArgument,
+				"traffic weight must specify revisionName or set latestRevision")
+		case revisionIndex(app, t.RevisionName) < 0:
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"traffic references unknown revision %q", t.RevisionName)
+		}
+
+		sum += t.Weight
+	}
+
+	if sum != fullTraffic {
+		return cerrors.Newf(cerrors.InvalidArgument, "sum of traffic weights must be 100, got %d", sum)
+	}
+
+	return nil
+}
+
+// ListRevisions returns the revision history of a container app, each with its
+// derived traffic weight and running state. Returns NotFound when the app does
+// not exist.
+func (m *Mock) ListRevisions(_ context.Context, sub, rg, appName string) ([]Revision, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	app, ok := m.apps.Get(key(sub, rg, typeContainerApps, appName))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container app %q not found", appName)
+	}
+
+	out := make([]Revision, 0, len(app.Revisions))
+	for i := range app.Revisions {
+		out = append(out, withDerived(&app, &app.Revisions[i]))
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CreatedTime != out[j].CreatedTime {
+			return out[i].CreatedTime < out[j].CreatedTime
+		}
+
+		return out[i].Name < out[j].Name
+	})
+
+	return out, nil
+}
+
+// GetRevision returns one revision of a container app. Returns NotFound when the
+// app or the revision does not exist.
+func (m *Mock) GetRevision(_ context.Context, sub, rg, appName, revName string) (Revision, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	app, ok := m.apps.Get(key(sub, rg, typeContainerApps, appName))
+	if !ok {
+		return Revision{}, cerrors.Newf(cerrors.NotFound, "container app %q not found", appName)
+	}
+
+	idx := revisionIndex(&app, revName)
+	if idx < 0 {
+		return Revision{}, cerrors.Newf(cerrors.NotFound, "revision %q not found", revName)
+	}
+
+	return withDerived(&app, &app.Revisions[idx]), nil
+}
+
+// ActivateRevision marks a revision active. Returns NotFound when the app or the
+// revision does not exist.
+func (m *Mock) ActivateRevision(_ context.Context, sub, rg, appName, revName string) error {
+	return m.setRevisionActive(sub, rg, appName, revName, true)
+}
+
+// DeactivateRevision marks a revision inactive. Returns NotFound when the app or
+// the revision does not exist.
+func (m *Mock) DeactivateRevision(_ context.Context, sub, rg, appName, revName string) error {
+	return m.setRevisionActive(sub, rg, appName, revName, false)
+}
+
+// RestartRevision restarts a revision's replicas. The emulator holds no live
+// replicas, so this is a no-op beyond validating the app and revision exist.
+func (m *Mock) RestartRevision(_ context.Context, sub, rg, appName, revName string) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	app, ok := m.apps.Get(key(sub, rg, typeContainerApps, appName))
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container app %q not found", appName)
+	}
+
+	if revisionIndex(&app, revName) < 0 {
+		return cerrors.Newf(cerrors.NotFound, "revision %q not found", revName)
+	}
+
+	return nil
+}
+
+func (m *Mock) setRevisionActive(sub, rg, appName, revName string, active bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	k := key(sub, rg, typeContainerApps, appName)
+
+	app, ok := m.apps.Get(k)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container app %q not found", appName)
+	}
+
+	idx := revisionIndex(&app, revName)
+	if idx < 0 {
+		return cerrors.Newf(cerrors.NotFound, "revision %q not found", revName)
+	}
+
+	app.Revisions = cloneRevisions(app.Revisions)
+	app.Revisions[idx].Active = active
+	m.apps.Set(k, app)
+
+	return nil
+}
+
+// withDerived returns a copy of rev with its read-time fields (traffic weight,
+// replica count and provisioning/running/health states) computed from the
+// parent app's ingress and scale.
+func withDerived(app *ContainerApp, rev *Revision) Revision {
+	out := *rev
+	out.TrafficWeight = trafficWeightFor(app, out.Name)
+	out.ProvisioningState = revProvisioned
+
+	if out.Active {
+		out.RunningState = revRunning
+		out.HealthState = healthHealthy
+		out.Replicas = minReplicas(&out.Template)
+	} else {
+		out.RunningState = revStopped
+		out.HealthState = healthNone
+		out.Replicas = 0
+	}
+
+	return out
+}
+
+// trafficWeightFor sums the ingress weights routed to revName. With no explicit
+// traffic block Azure sends 100% to the latest revision, so that is what a
+// revision reports absent configuration.
+func trafficWeightFor(app *ContainerApp, revName string) int32 {
+	if app.Ingress == nil || len(app.Ingress.Traffic) == 0 {
+		if strings.EqualFold(revName, app.LatestRevisionName) {
+			return fullTraffic
+		}
+
+		return 0
+	}
+
+	var sum int32
+
+	for i := range app.Ingress.Traffic {
+		t := app.Ingress.Traffic[i]
+		if strings.EqualFold(t.RevisionName, revName) ||
+			(t.LatestRevision && strings.EqualFold(revName, app.LatestRevisionName)) {
+			sum += t.Weight
+		}
+	}
+
+	return sum
+}
+
+func minReplicas(t *Template) int32 {
+	if t.Scale != nil && t.Scale.MinReplicas != nil {
+		return *t.Scale.MinReplicas
+	}
+
+	return defaultMinReplicas
+}
+
+// revisionIndex returns the index of the revision named revName (case-insensitive)
+// or -1 when the app has no such revision.
+func revisionIndex(app *ContainerApp, revName string) int {
+	for i := range app.Revisions {
+		if strings.EqualFold(app.Revisions[i].Name, revName) {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// templateSuffix derives a stable revision suffix from a template's content, so
+// two identical templates map to the same revision and a changed template mints
+// a new one — mirroring Azure's content-addressed auto suffix.
+func templateSuffix(t Template) string {
+	data, _ := json.Marshal(t)
+	sum := sha256.Sum256(data)
+
+	return hex.EncodeToString(sum[:])[:revSuffixLen]
+}
+
+func cloneRevisions(in []Revision) []Revision {
+	if in == nil {
+		return nil
+	}
+
+	out := make([]Revision, len(in))
+	for i := range in {
+		out[i] = in[i]
+		out[i].Template = cloneTemplate(in[i].Template)
+	}
+
+	return out
+}

--- a/server/azure/containerapps/containerapps_sdk_test.go
+++ b/server/azure/containerapps/containerapps_sdk_test.go
@@ -512,7 +512,9 @@ func assertTrafficSplit(
 		t.Fatalf("rev1 trafficWeight after split = %v, want 50", got.Properties.TrafficWeight)
 	}
 
-	// A split that does not sum to 100 is rejected.
+	// A split that does not sum to 100 is rejected. The template matches the
+	// stored v2 revision, so the request reaches traffic validation rather than
+	// tripping the duplicate-suffix guard.
 	_, err := appClient.BeginCreateOrUpdate(ctx, rgName, appName, armappcontainers.ContainerApp{
 		Location: to.Ptr("eastus"),
 		Properties: &armappcontainers.ContainerAppProperties{
@@ -527,7 +529,11 @@ func assertTrafficSplit(
 					},
 				},
 			},
-			Template: &armappcontainers.Template{RevisionSuffix: to.Ptr("v2")},
+			Template: &armappcontainers.Template{
+				RevisionSuffix: to.Ptr("v2"),
+				Containers:     []*armappcontainers.Container{{Name: to.Ptr("main"), Image: to.Ptr("nginx:2")}},
+				Scale:          &armappcontainers.Scale{MinReplicas: to.Ptr[int32](2)},
+			},
 		},
 	}, nil)
 	if err == nil {

--- a/server/azure/containerapps/containerapps_sdk_test.go
+++ b/server/azure/containerapps/containerapps_sdk_test.go
@@ -333,6 +333,221 @@ func toFloat(v any) float64 {
 	return f
 }
 
+// TestSDKContainerAppRevisions drives the revision/traffic surface with the real
+// armappcontainers ContainerAppsRevisionsClient: creating an app materializes a
+// revision, updating its template mints a second (both listed in multiple-revisions
+// mode), get/activate/deactivate/restart a revision, a traffic split across the
+// two revisions, and the errors on an unbalanced split and a missing revision/app.
+func TestSDKContainerAppRevisions(t *testing.T) {
+	ts := newServer(t)
+	ctx := context.Background()
+
+	envID := seedRevisionEnv(t, ctx, ts)
+
+	appClient, err := armappcontainers.NewContainerAppsClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewContainerAppsClient: %v", err)
+	}
+
+	revClient, err := armappcontainers.NewContainerAppsRevisionsClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewContainerAppsRevisionsClient: %v", err)
+	}
+
+	// Create the app (multiple-revisions mode, suffix v1) -> revision "api--v1".
+	putRevisionApp(t, ctx, appClient, envID, "v1", "nginx:1", nil)
+
+	rev1 := appName + "--v1"
+	rev2 := appName + "--v2"
+
+	assertRevisions(t, ctx, revClient, map[string]bool{rev1: true})
+
+	// A template change mints a second revision; both are active in multiple mode.
+	putRevisionApp(t, ctx, appClient, envID, "v2", "nginx:2", nil)
+	assertRevisions(t, ctx, revClient, map[string]bool{rev1: true, rev2: true})
+
+	// The latest revision carries 100% of traffic with no explicit split.
+	got := getRevision(t, ctx, revClient, rev2)
+	if got.Properties.TrafficWeight == nil || *got.Properties.TrafficWeight != 100 {
+		t.Fatalf("rev2 trafficWeight = %v, want 100", got.Properties.TrafficWeight)
+	}
+
+	assertActivateDeactivate(t, ctx, revClient, rev1)
+
+	if _, err := revClient.RestartRevision(ctx, rgName, appName, rev2, nil); err != nil {
+		t.Fatalf("RestartRevision: %v", err)
+	}
+
+	assertTrafficSplit(t, ctx, appClient, revClient, envID, rev1, rev2)
+	assertRevisionErrors(t, ctx, revClient)
+}
+
+func seedRevisionEnv(t *testing.T, ctx context.Context, ts *httptest.Server) string {
+	t.Helper()
+
+	envClient, err := armappcontainers.NewManagedEnvironmentsClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewManagedEnvironmentsClient: %v", err)
+	}
+
+	return createEnvironment(t, ctx, envClient)
+}
+
+func putRevisionApp(
+	t *testing.T, ctx context.Context, c *armappcontainers.ContainerAppsClient,
+	envID, suffix, image string, traffic []*armappcontainers.TrafficWeight,
+) {
+	t.Helper()
+
+	ingress := &armappcontainers.Ingress{External: to.Ptr(true), TargetPort: to.Ptr[int32](80)}
+	if traffic != nil {
+		ingress.Traffic = traffic
+	}
+
+	poller, err := c.BeginCreateOrUpdate(ctx, rgName, appName, armappcontainers.ContainerApp{
+		Location: to.Ptr("eastus"),
+		Properties: &armappcontainers.ContainerAppProperties{
+			EnvironmentID: to.Ptr(envID),
+			Configuration: &armappcontainers.Configuration{
+				ActiveRevisionsMode: to.Ptr(armappcontainers.ActiveRevisionsModeMultiple),
+				Ingress:             ingress,
+			},
+			Template: &armappcontainers.Template{
+				RevisionSuffix: to.Ptr(suffix),
+				Containers: []*armappcontainers.Container{{
+					Name: to.Ptr("main"), Image: to.Ptr(image),
+				}},
+				Scale: &armappcontainers.Scale{MinReplicas: to.Ptr[int32](2)},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate app (suffix %s): %v", suffix, err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll app create (suffix %s): %v", suffix, err)
+	}
+}
+
+func assertRevisions(
+	t *testing.T, ctx context.Context, c *armappcontainers.ContainerAppsRevisionsClient, wantActive map[string]bool,
+) {
+	t.Helper()
+
+	got := map[string]bool{}
+	pager := c.NewListRevisionsPager(rgName, appName, nil)
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("list revisions: %v", err)
+		}
+
+		for _, rev := range page.Value {
+			got[*rev.Name] = rev.Properties != nil && rev.Properties.Active != nil && *rev.Properties.Active
+		}
+	}
+
+	if len(got) != len(wantActive) {
+		t.Fatalf("revisions = %v, want %v", got, wantActive)
+	}
+
+	for name, active := range wantActive {
+		if gotActive, ok := got[name]; !ok || gotActive != active {
+			t.Fatalf("revision %q active = %v (present %v), want %v", name, gotActive, ok, active)
+		}
+	}
+}
+
+func getRevision(
+	t *testing.T, ctx context.Context, c *armappcontainers.ContainerAppsRevisionsClient, name string,
+) armappcontainers.ContainerAppsRevisionsClientGetRevisionResponse {
+	t.Helper()
+
+	got, err := c.GetRevision(ctx, rgName, appName, name, nil)
+	if err != nil {
+		t.Fatalf("GetRevision %q: %v", name, err)
+	}
+
+	return got
+}
+
+func assertActivateDeactivate(
+	t *testing.T, ctx context.Context, c *armappcontainers.ContainerAppsRevisionsClient, name string,
+) {
+	t.Helper()
+
+	if _, err := c.DeactivateRevision(ctx, rgName, appName, name, nil); err != nil {
+		t.Fatalf("DeactivateRevision %q: %v", name, err)
+	}
+
+	if got := getRevision(t, ctx, c, name); got.Properties.Active == nil || *got.Properties.Active {
+		t.Fatalf("after deactivate, %q active = %v, want false", name, got.Properties.Active)
+	}
+
+	if _, err := c.ActivateRevision(ctx, rgName, appName, name, nil); err != nil {
+		t.Fatalf("ActivateRevision %q: %v", name, err)
+	}
+
+	if got := getRevision(t, ctx, c, name); got.Properties.Active == nil || !*got.Properties.Active {
+		t.Fatalf("after activate, %q active = %v, want true", name, got.Properties.Active)
+	}
+}
+
+func assertTrafficSplit(
+	t *testing.T, ctx context.Context,
+	appClient *armappcontainers.ContainerAppsClient, revClient *armappcontainers.ContainerAppsRevisionsClient,
+	envID, rev1, rev2 string,
+) {
+	t.Helper()
+
+	// A valid 50/50 split across both revisions is accepted.
+	putRevisionApp(t, ctx, appClient, envID, "v2", "nginx:2", []*armappcontainers.TrafficWeight{
+		{RevisionName: to.Ptr(rev1), Weight: to.Ptr[int32](50)},
+		{RevisionName: to.Ptr(rev2), Weight: to.Ptr[int32](50)},
+	})
+
+	if got := getRevision(t, ctx, revClient, rev1); got.Properties.TrafficWeight == nil || *got.Properties.TrafficWeight != 50 {
+		t.Fatalf("rev1 trafficWeight after split = %v, want 50", got.Properties.TrafficWeight)
+	}
+
+	// A split that does not sum to 100 is rejected.
+	_, err := appClient.BeginCreateOrUpdate(ctx, rgName, appName, armappcontainers.ContainerApp{
+		Location: to.Ptr("eastus"),
+		Properties: &armappcontainers.ContainerAppProperties{
+			EnvironmentID: to.Ptr(envID),
+			Configuration: &armappcontainers.Configuration{
+				ActiveRevisionsMode: to.Ptr(armappcontainers.ActiveRevisionsModeMultiple),
+				Ingress: &armappcontainers.Ingress{
+					External: to.Ptr(true), TargetPort: to.Ptr[int32](80),
+					Traffic: []*armappcontainers.TrafficWeight{
+						{RevisionName: to.Ptr(rev1), Weight: to.Ptr[int32](50)},
+						{RevisionName: to.Ptr(rev2), Weight: to.Ptr[int32](40)},
+					},
+				},
+			},
+			Template: &armappcontainers.Template{RevisionSuffix: to.Ptr("v2")},
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("traffic split summing to 90 was accepted, want an error")
+	}
+}
+
+func assertRevisionErrors(t *testing.T, ctx context.Context, c *armappcontainers.ContainerAppsRevisionsClient) {
+	t.Helper()
+
+	if _, err := c.GetRevision(ctx, rgName, appName, appName+"--missing", nil); err == nil {
+		t.Fatal("GetRevision on a missing revision returned nil error, want NotFound")
+	}
+
+	pager := c.NewListRevisionsPager(rgName, "no-such-app", nil)
+	if _, err := pager.NextPage(ctx); err == nil {
+		t.Fatal("ListRevisions on a missing app returned nil error, want NotFound")
+	}
+}
+
 func deleteContainerApp(t *testing.T, ctx context.Context, c *armappcontainers.ContainerAppsClient) {
 	t.Helper()
 

--- a/server/azure/containerapps/handler.go
+++ b/server/azure/containerapps/handler.go
@@ -23,6 +23,14 @@ const (
 	providerName      = "Microsoft.App"
 	typeEnvironments  = "managedEnvironments"
 	typeContainerApps = "containerApps"
+
+	// subResourceRevisions is the sub-resource segment for a container app's
+	// revisions (.../containerApps/{app}/revisions[/{rev}[/{action}]]).
+	subResourceRevisions = "revisions"
+
+	actionActivate   = "activate"
+	actionDeactivate = "deactivate"
+	actionRestart    = "restart"
 )
 
 // Store is the minimal Container Apps backend the handler needs.
@@ -43,6 +51,12 @@ type Store interface {
 	DeleteApp(ctx context.Context, sub, rg, name string) (bool, error)
 	ListAppsByResourceGroup(ctx context.Context, sub, rg string) ([]containerapps.ContainerApp, error)
 	ListAppsBySubscription(ctx context.Context, sub string) ([]containerapps.ContainerApp, error)
+
+	ListRevisions(ctx context.Context, sub, rg, app string) ([]containerapps.Revision, error)
+	GetRevision(ctx context.Context, sub, rg, app, rev string) (containerapps.Revision, error)
+	ActivateRevision(ctx context.Context, sub, rg, app, rev string) error
+	DeactivateRevision(ctx context.Context, sub, rg, app, rev string) error
+	RestartRevision(ctx context.Context, sub, rg, app, rev string) error
 
 	PurgeResourceGroup(ctx context.Context, sub, rg string) error
 }
@@ -165,6 +179,11 @@ func (h *Handler) serveApp(w http.ResponseWriter, r *http.Request, rp *azurearm.
 		return
 	}
 
+	if strings.EqualFold(rp.SubResource, subResourceRevisions) {
+		h.serveRevision(w, r, rp)
+		return
+	}
+
 	switch r.Method {
 	case http.MethodPut, http.MethodPatch:
 		h.putApp(w, r, rp)
@@ -222,6 +241,87 @@ func (h *Handler) deleteApp(w http.ResponseWriter, r *http.Request, rp *azurearm
 func (h *Handler) listApps(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	writeList(w, r, rp,
 		h.store.ListAppsByResourceGroup, h.store.ListAppsBySubscription, toAppResponse)
+}
+
+// serveRevision dispatches the container-app revision sub-resource:
+//
+//	GET  .../revisions               → list
+//	GET  .../revisions/{rev}          → get
+//	POST .../revisions/{rev}/{action} → activate | deactivate | restart
+func (h *Handler) serveRevision(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if rp.SubResourceName == "" {
+		h.listRevisions(w, r, rp)
+		return
+	}
+
+	if rp.SubResourceAction != "" {
+		h.revisionAction(w, r, rp)
+		return
+	}
+
+	if r.Method != http.MethodGet {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	rev, err := h.store.GetRevision(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toRevisionResponse(rp, &rev))
+}
+
+func (h *Handler) listRevisions(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodGet {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	revs, err := h.store.ListRevisions(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := listEnvelope[revisionResponse]{Value: make([]revisionResponse, 0, len(revs))}
+	for i := range revs {
+		out.Value = append(out.Value, toRevisionResponse(rp, &revs[i]))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+// revisionAction runs a POST activate/deactivate/restart on a revision. Each is
+// synchronous in armappcontainers and returns an empty body, so a 200 with no
+// content terminates the SDK call.
+func (h *Handler) revisionAction(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodPost {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	var err error
+
+	switch strings.ToLower(rp.SubResourceAction) {
+	case actionActivate:
+		err = h.store.ActivateRevision(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	case actionDeactivate:
+		err = h.store.DeactivateRevision(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	case actionRestart:
+		err = h.store.RestartRevision(r.Context(), rp.Subscription, rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	default:
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "unknown revision action")
+		return
+	}
+
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
 // writeList serves a collection GET for either resource type: it dispatches to

--- a/server/azure/containerapps/types.go
+++ b/server/azure/containerapps/types.go
@@ -1,6 +1,9 @@
 package containerapps
 
-import "github.com/stackshy/cloudemu/v2/providers/azure/containerapps"
+import (
+	"github.com/stackshy/cloudemu/v2/providers/azure/containerapps"
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
 
 const (
 	provisioningSucceeded = "Succeeded"
@@ -88,11 +91,19 @@ type appConfig struct {
 }
 
 type appIngress struct {
-	Fqdn          string `json:"fqdn,omitempty"`
-	External      bool   `json:"external,omitempty"`
-	TargetPort    int32  `json:"targetPort,omitempty"`
-	Transport     string `json:"transport,omitempty"`
-	AllowInsecure bool   `json:"allowInsecure,omitempty"`
+	Fqdn          string             `json:"fqdn,omitempty"`
+	External      bool               `json:"external,omitempty"`
+	TargetPort    int32              `json:"targetPort,omitempty"`
+	Transport     string             `json:"transport,omitempty"`
+	AllowInsecure bool               `json:"allowInsecure,omitempty"`
+	Traffic       []appTrafficWeight `json:"traffic,omitempty"`
+}
+
+type appTrafficWeight struct {
+	RevisionName   string `json:"revisionName,omitempty"`
+	Weight         int32  `json:"weight,omitempty"`
+	Label          string `json:"label,omitempty"`
+	LatestRevision bool   `json:"latestRevision,omitempty"`
 }
 
 type appSecret struct {
@@ -177,12 +188,21 @@ func toIngressModel(in *appIngress) *containerapps.Ingress {
 		return nil
 	}
 
-	return &containerapps.Ingress{
+	out := &containerapps.Ingress{
 		External:      in.External,
 		TargetPort:    in.TargetPort,
 		Transport:     in.Transport,
 		AllowInsecure: in.AllowInsecure,
 	}
+
+	for i := range in.Traffic {
+		t := in.Traffic[i]
+		out.Traffic = append(out.Traffic, containerapps.TrafficWeight{
+			RevisionName: t.RevisionName, Weight: t.Weight, Label: t.Label, LatestRevision: t.LatestRevision,
+		})
+	}
+
+	return out
 }
 
 func toTemplateModel(t *appTemplate) containerapps.Template {
@@ -249,6 +269,7 @@ func toConfigResponse(a *containerapps.ContainerApp) *appConfig {
 			TargetPort:    a.Ingress.TargetPort,
 			Transport:     a.Ingress.Transport,
 			AllowInsecure: a.Ingress.AllowInsecure,
+			Traffic:       toTrafficResponse(a.Ingress.Traffic),
 		}
 	}
 
@@ -286,6 +307,71 @@ func toTemplateResponse(t *containerapps.Template) *appTemplate {
 	}
 
 	return out
+}
+
+func toTrafficResponse(in []containerapps.TrafficWeight) []appTrafficWeight {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]appTrafficWeight, 0, len(in))
+	for i := range in {
+		out = append(out, appTrafficWeight{
+			RevisionName:   in[i].RevisionName,
+			Weight:         in[i].Weight,
+			Label:          in[i].Label,
+			LatestRevision: in[i].LatestRevision,
+		})
+	}
+
+	return out
+}
+
+// armTypeRevision is the ARM resource type of a container app's revision.
+const armTypeRevision = armTypeContainerApp + "/revisions"
+
+// revisionResponse is the ARM shape of a Microsoft.App containerApps revision.
+type revisionResponse struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Properties revisionRespProps `json:"properties"`
+}
+
+type revisionRespProps struct {
+	CreatedTime       string       `json:"createdTime,omitempty"`
+	Active            bool         `json:"active"`
+	TrafficWeight     int32        `json:"trafficWeight"`
+	Replicas          int32        `json:"replicas"`
+	ProvisioningState string       `json:"provisioningState,omitempty"`
+	RunningState      string       `json:"runningState,omitempty"`
+	HealthState       string       `json:"healthState,omitempty"`
+	Fqdn              string       `json:"fqdn,omitempty"`
+	Template          *appTemplate `json:"template,omitempty"`
+}
+
+// toRevisionResponse projects a stored revision onto its ARM wire shape. The id
+// is the parent app's ARM id with a /revisions/{name} suffix, matching the URL
+// the armappcontainers SDK addresses the revision by.
+func toRevisionResponse(rp *azurearm.ResourcePath, rev *containerapps.Revision) revisionResponse {
+	appID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeContainerApps, rp.ResourceName)
+
+	return revisionResponse{
+		ID:   appID + "/" + subResourceRevisions + "/" + rev.Name,
+		Name: rev.Name,
+		Type: armTypeRevision,
+		Properties: revisionRespProps{
+			CreatedTime:       rev.CreatedTime,
+			Active:            rev.Active,
+			TrafficWeight:     rev.TrafficWeight,
+			Replicas:          rev.Replicas,
+			ProvisioningState: rev.ProvisioningState,
+			RunningState:      rev.RunningState,
+			HealthState:       rev.HealthState,
+			Fqdn:              rev.Fqdn,
+			Template:          toTemplateResponse(&rev.Template),
+		},
+	}
 }
 
 func firstNonEmpty(a, b string) string {


### PR DESCRIPTION
## Summary

Completes the lifecycle of Azure Container Apps (`Microsoft.App`), which had CRUD + tags but no revision/scale/traffic surface. Adds the real-cloud revision and traffic-split operations a user drives through the `armappcontainers` `ContainerAppsRevisionsClient`.

## What changed

- **Revisions as an app sub-resource** (`.../containerApps/{app}/revisions`):
  - `GET .../revisions` (list), `GET .../revisions/{rev}` (get)
  - `POST .../revisions/{rev}/activate|deactivate|restart` (all synchronous, matching the SDK)
- **Revision materialization**: creating or updating an app mints a revision named `{app}--{suffix}` (explicit `template.revisionSuffix`, else a content hash of the template). A template change mints a new revision. `Single` mode (default) supersedes the prior revision; `Multiple` mode retains it.
- **Traffic weights** (`configuration.ingress.traffic[]`): stored and validated on app create/update — each entry must reference an existing revision (or set `latestRevision`) and the weights must sum to 100, else a 400 (matching Azure). A revision reports its derived `trafficWeight` (100% to latest when no split is configured).
- Derived read-time fields (`replicas`, `provisioningState`, `runningState`, `healthState`, `fqdn`) are computed from the parent app's scale/ingress and never persisted.
- Resource Graph discoverability is unchanged; revisions round-trip through snapshot/restore.
- `docs/coverage` regenerated (14 -> 19 operations).

Replicas listing (`.../revisions/{rev}/replicas`) is deferred: the emulator holds no live replica objects, so a faithful replica surface adds little over the `replicas` count already reported on a revision.

## Tests

- Real `armappcontainers` SDK round-trip (`TestSDKContainerAppRevisions`): create -> revision appears; update template -> second revision, both listed; activate/deactivate/restart; 50/50 traffic split accepted; unbalanced split rejected; 404 on missing revision/app.
- Provider-level tests: materialization on template change, single vs multiple mode, activate/deactivate/restart + NotFound, traffic validation (rejected update leaves the app unchanged), snapshot round-trip of revision history.