### PR TITLE
feat(azure): enforce Management Locks (CanNotDelete / ReadOnly)

### DIFF
--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -226,6 +226,11 @@ const defaultTenantID = "11111111-1111-1111-1111-111111111111"
 func New(d Drivers) http.Handler {
 	srv := server.New()
 
+	// Management locks are constructed once and shared: the same instance is
+	// registered as the CRUD handler and handed to the enforcement gate below,
+	// so the gate reads the exact store callers write to.
+	locksHandler := locks.New()
+
 	tenantID := d.TenantID
 	if tenantID == "" {
 		tenantID = defaultTenantID
@@ -258,9 +263,9 @@ func New(d Drivers) http.Handler {
 	// substring test on /providers/microsoft.authorization/locks — a path no
 	// resource handler produces — so registering it early shadows nothing. Locks
 	// are a pure management-plane concept with no backing driver, so the handler
-	// is always registered (like subscriptions/tenants). CRUD + round-trip only;
-	// enforcement (blocking deletes/writes on locked resources) is out of scope.
-	srv.Register(locks.New())
+	// is always registered (like subscriptions/tenants). This same instance
+	// backs the always-on enforcement gate wired via SetPreDispatch below.
+	srv.Register(locksHandler)
 
 	// Build the per-service handlers that own resource-group-scoped resources up
 	// front so they can be handed to the resource-group cascade below and then
@@ -685,13 +690,21 @@ func New(d Drivers) http.Handler {
 		srv.Register(blobstorage.New(d.BlobStorage))
 	}
 
-	// Opt-in claims-based bearer authentication. Installed only when enabled, so
-	// the default request path is byte-for-byte unchanged. Registered on the raw
-	// server so the pre-dispatch gate runs before handler matching (and before
-	// the unmodeled-property overlay below wraps the response).
+	// Pre-dispatch chokepoint. Two hooks share the single slot, composed so both
+	// run before handler matching (and before the unmodeled-property overlay
+	// wraps the response):
+	//   - Opt-in claims-based bearer authentication (nil unless EnforceAuth), so
+	//     the default request path is byte-for-byte unchanged when it is off.
+	//   - Always-on management-lock enforcement, matching real Azure which has no
+	//     enforce toggle. It is inert until a caller creates a lock.
+	// Auth runs first for fidelity (authenticate, then evaluate locks); since
+	// neither mutates the body the order is behaviorally irrelevant.
+	var authGate preDispatch
 	if d.EnforceAuth {
-		srv.SetPreDispatch(newAuthGate(config.RealClock{}))
+		authGate = newAuthGate(config.RealClock{})
 	}
+
+	srv.SetPreDispatch(composePreDispatch(authGate, newLockGate(locksHandler)))
 
 	// When the monitoring backend can record Activity Log events, observe every
 	// served ARM request and log a management event so the Activity Log API

--- a/server/azure/lockgate.go
+++ b/server/azure/lockgate.go
@@ -1,0 +1,110 @@
+package azure
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/azure/locks"
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+// preDispatch is the shape of a server pre-dispatch hook: it may rewrite the
+// request and, by returning proceed=false after writing a response, stop
+// dispatch.
+type preDispatch = func(http.ResponseWriter, *http.Request) (*http.Request, bool)
+
+// newLockGate builds the management-lock enforcement pre-dispatch hook. It is
+// the single chokepoint that applies Azure lock semantics to every resource
+// type at once, before handler matching — no per-handler edits.
+//
+// Classification (see the lock design):
+//   - Non-control-plane paths (not under /subscriptions/) are data plane and
+//     exempt — locks are control-plane only.
+//   - GET/HEAD (reads) are always allowed.
+//   - The locks API itself is self-exempt (h.Matches), so a caller can always
+//     create, read or delete a lock — including to remove a lock and unlock a
+//     scope it would otherwise cover.
+//   - Any other mutating method (DELETE/PUT/PATCH/POST) is checked against the
+//     covering locks; a blocked request gets a 409 ScopeLocked and stops.
+//
+// The gate reads only method and path, never the body, so it composes cleanly
+// with the auth gate in either order.
+func newLockGate(h *locks.Handler) preDispatch {
+	return func(w http.ResponseWriter, r *http.Request) (*http.Request, bool) {
+		if !isControlPlane(r.URL.Path) {
+			return r, true
+		}
+
+		switch r.Method {
+		case http.MethodGet, http.MethodHead:
+			return r, true
+		}
+
+		// The locks management API is always allowed, so a scope can be unlocked.
+		if h.Matches(r) {
+			return r, true
+		}
+
+		lockedScope, _, blocked := h.Enforce(r.URL.Path, r.Method)
+		if !blocked {
+			return r, true
+		}
+
+		azurearm.WriteError(w, http.StatusConflict, "ScopeLocked", fmt.Sprintf(
+			"The scope '%s' cannot perform '%s' operation because the following scope(s) are locked: "+
+				"'%s'. Please remove the lock and try again.",
+			r.URL.Path, operationNoun(r.Method), lockedScope))
+
+		return r, false
+	}
+}
+
+// isControlPlane reports whether a request path is an ARM control-plane path
+// (under /subscriptions/). Data-plane URLs (blob/queue/table/Cosmos data) do
+// not carry this prefix, giving the control-plane-only exemption for free.
+func isControlPlane(urlPath string) bool {
+	return strings.HasPrefix(strings.ToLower(urlPath), "/subscriptions/")
+}
+
+// RBAC-style operation nouns Azure uses in the ScopeLocked message.
+const (
+	opDelete = "delete"
+	opAction = "action"
+	opWrite  = "write"
+)
+
+// operationNoun maps an HTTP method to the RBAC-style operation noun Azure uses
+// in the ScopeLocked message: delete, write (PUT/PATCH) or action (POST).
+func operationNoun(method string) string {
+	switch strings.ToUpper(method) {
+	case http.MethodDelete:
+		return opDelete
+	case http.MethodPost:
+		return opAction
+	default:
+		return opWrite
+	}
+}
+
+// composePreDispatch chains pre-dispatch hooks left to right: each may rewrite
+// the request (the next hook sees the rewrite) and any may stop dispatch. Nil
+// hooks are skipped, so an absent auth gate adds nothing. Mirrors the AWS
+// server's helper so the auth gate and the lock gate coexist on the single
+// SetPreDispatch slot.
+func composePreDispatch(hooks ...preDispatch) preDispatch {
+	return func(w http.ResponseWriter, r *http.Request) (*http.Request, bool) {
+		for _, hook := range hooks {
+			if hook == nil {
+				continue
+			}
+
+			var proceed bool
+			if r, proceed = hook(w, r); !proceed {
+				return r, false
+			}
+		}
+
+		return r, true
+	}
+}

--- a/server/azure/lockgate_test.go
+++ b/server/azure/lockgate_test.go
@@ -1,0 +1,131 @@
+package azure
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/server/azure/locks"
+)
+
+// seedGateLock creates a lock in h by driving its own PUT handler, exactly as a
+// caller would over the wire, so the gate reads the same store state.
+func seedGateLock(t *testing.T, h *locks.Handler, scope, name, level string) {
+	t.Helper()
+
+	body := `{"properties":{"level":"` + level + `"}}`
+	url := scope + "/providers/Microsoft.Authorization/locks/" + name
+	req := httptest.NewRequest(http.MethodPut, url, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated && rec.Code != http.StatusOK {
+		t.Fatalf("seed lock %q: status %d", name, rec.Code)
+	}
+}
+
+func TestIsControlPlane(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/subscriptions/S1/resourceGroups/rg1", true},
+		{"/SUBSCRIPTIONS/S1/resourceGroups/rg1", true},
+		{"/mycontainer/blob.txt", false},
+		{"/", false},
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		if got := isControlPlane(tc.path); got != tc.want {
+			t.Errorf("isControlPlane(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestOperationNoun(t *testing.T) {
+	tests := map[string]string{
+		http.MethodDelete: "delete",
+		http.MethodPut:    "write",
+		http.MethodPatch:  "write",
+		http.MethodPost:   "action",
+	}
+
+	for method, want := range tests {
+		if got := operationNoun(method); got != want {
+			t.Errorf("operationNoun(%s) = %q, want %q", method, got, want)
+		}
+	}
+}
+
+const (
+	gateRG  = "/subscriptions/S1/resourceGroups/rg1"
+	gateVM  = "/subscriptions/S1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
+	dataURL = "/mycontainer/blob.txt"
+)
+
+func TestLockGate(t *testing.T) {
+	tests := []struct {
+		name        string
+		lockLevel   string // "" = no lock
+		method      string
+		path        string
+		wantProceed bool
+	}{
+		{"no lock allows delete", "", http.MethodDelete, gateVM, true},
+		{"cannotdelete blocks delete", "CanNotDelete", http.MethodDelete, gateVM, false},
+		{"cannotdelete allows put", "CanNotDelete", http.MethodPut, gateVM, true},
+		{"readonly blocks put", "ReadOnly", http.MethodPut, gateVM, false},
+		{"readonly blocks post", "ReadOnly", http.MethodPost, gateVM, false},
+		{"readonly allows get", "ReadOnly", http.MethodGet, gateVM, true},
+		{"data plane exempt", "ReadOnly", http.MethodDelete, dataURL, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := locks.New()
+			if tc.lockLevel != "" {
+				seedGateLock(t, h, gateRG, "lk", tc.lockLevel)
+			}
+
+			gate := newLockGate(h)
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+
+			_, proceed := gate(rec, req)
+			if proceed != tc.wantProceed {
+				t.Fatalf("proceed = %v, want %v", proceed, tc.wantProceed)
+			}
+
+			if !tc.wantProceed {
+				if rec.Code != http.StatusConflict {
+					t.Fatalf("status = %d, want 409", rec.Code)
+				}
+
+				if !strings.Contains(rec.Body.String(), "ScopeLocked") {
+					t.Fatalf("body missing ScopeLocked: %s", rec.Body.String())
+				}
+			}
+		})
+	}
+}
+
+// TestLockGateSelfExemption proves the locks API is always allowed on a locked
+// scope, so a caller can delete a lock to unlock — even a DELETE of a lock
+// living under a ReadOnly-locked scope.
+func TestLockGateSelfExemption(t *testing.T) {
+	h := locks.New()
+	seedGateLock(t, h, gateRG, "ro", "ReadOnly")
+
+	gate := newLockGate(h)
+	rec := httptest.NewRecorder()
+
+	lockPath := gateRG + "/providers/Microsoft.Authorization/locks/ro"
+	req := httptest.NewRequest(http.MethodDelete, lockPath, nil)
+
+	if _, proceed := gate(rec, req); !proceed {
+		t.Fatal("DELETE of a lock under a ReadOnly scope must be allowed (self-exemption)")
+	}
+}

--- a/server/azure/locks/enforce_test.go
+++ b/server/azure/locks/enforce_test.go
@@ -1,0 +1,135 @@
+package locks
+
+import (
+	"net/http"
+	"testing"
+)
+
+// seedLock stores a lock directly in the handler's store, bypassing the wire
+// layer, so Enforce can be unit-tested without a server.
+func seedLock(h *Handler, scope, name, level string) {
+	h.store.put(scope, name, level, "")
+}
+
+const (
+	sub   = "/subscriptions/S1"
+	rg    = "/subscriptions/S1/resourceGroups/rg1"
+	vm    = "/subscriptions/S1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
+	vm2   = "/subscriptions/S1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2"
+	vmB   = "/subscriptions/S1/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vmb"
+	sub10 = "/subscriptions/S10/resourceGroups/rg1"
+)
+
+func TestEnforceLevelsAndMethods(t *testing.T) {
+	tests := []struct {
+		name        string
+		lockScope   string
+		lockLevel   string
+		reqPath     string
+		method      string
+		wantBlocked bool
+	}{
+		// CanNotDelete: blocks DELETE only.
+		{"cannotdelete blocks delete", rg, levelCanNotDelete, vm, http.MethodDelete, true},
+		{"cannotdelete allows put", rg, levelCanNotDelete, vm, http.MethodPut, false},
+		{"cannotdelete allows patch", rg, levelCanNotDelete, vm, http.MethodPatch, false},
+		{"cannotdelete allows post", rg, levelCanNotDelete, vm, http.MethodPost, false},
+		{"cannotdelete allows get", rg, levelCanNotDelete, vm, http.MethodGet, false},
+
+		// ReadOnly: blocks DELETE + PUT + PATCH + POST.
+		{"readonly blocks delete", rg, levelReadOnly, vm, http.MethodDelete, true},
+		{"readonly blocks put", rg, levelReadOnly, vm, http.MethodPut, true},
+		{"readonly blocks patch", rg, levelReadOnly, vm, http.MethodPatch, true},
+		{"readonly blocks post", rg, levelReadOnly, vm, http.MethodPost, true},
+		{"readonly allows get", rg, levelReadOnly, vm, http.MethodGet, false},
+		{"readonly allows head", rg, levelReadOnly, vm, http.MethodHead, false},
+
+		// Case-insensitive level matching.
+		{"lowercase level blocks", rg, "readonly", vm, http.MethodPut, true},
+
+		// Inheritance: subscription lock covers a resource beneath it.
+		{"subscription lock covers resource delete", sub, levelCanNotDelete, vm, http.MethodDelete, true},
+		{"subscription readonly covers resource write", sub, levelReadOnly, vm, http.MethodPut, true},
+
+		// Lock at resource scope covers the resource itself and its extensions.
+		{"resource lock blocks own delete", vm, levelCanNotDelete, vm, http.MethodDelete, true},
+		{"resource lock blocks extension write", vm, levelReadOnly,
+			vm + "/providers/microsoft.insights/diagnosticSettings/ds1", http.MethodPut, true},
+
+		// Sibling isolation: a lock on vm1 does not affect vm2.
+		{"sibling resource unaffected", vm, levelReadOnly, vm2, http.MethodPut, false},
+		{"sibling rg unaffected", rg, levelReadOnly, vmB, http.MethodDelete, false},
+
+		// Segment-boundary: /subscriptions/S1 must NOT match /subscriptions/S10.
+		{"S1 lock does not match S10", sub, levelCanNotDelete, sub10, http.MethodDelete, false},
+
+		// No lock at all.
+		{"no lock allows delete", "", "", vm, http.MethodDelete, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := New()
+			if tc.lockScope != "" {
+				seedLock(h, tc.lockScope, "lk", tc.lockLevel)
+			}
+
+			_, _, blocked := h.Enforce(tc.reqPath, tc.method)
+			if blocked != tc.wantBlocked {
+				t.Fatalf("Enforce(%q, %s) blocked = %v, want %v", tc.reqPath, tc.method, blocked, tc.wantBlocked)
+			}
+		})
+	}
+}
+
+// TestEnforceDeleteBlockedByDescendantLock proves that deleting a container
+// (resource group) is blocked when a lock sits on a resource inside it, even
+// though no lock covers the RG scope itself — the RG-delete-with-locked-child
+// asymmetry.
+func TestEnforceDeleteBlockedByDescendantLock(t *testing.T) {
+	h := New()
+	seedLock(h, vm, "child-lock", levelCanNotDelete)
+
+	lockedScope, _, blocked := h.Enforce(rg, http.MethodDelete)
+	if !blocked {
+		t.Fatal("RG delete with a locked child: want blocked, got allowed")
+	}
+
+	if lockedScope != vm {
+		t.Fatalf("blocking scope = %q, want the child %q", lockedScope, vm)
+	}
+
+	// A write to the RG is NOT blocked by a CanNotDelete child lock.
+	if _, _, b := h.Enforce(rg, http.MethodPut); b {
+		t.Fatal("RG write with a CanNotDelete child lock: want allowed, got blocked")
+	}
+}
+
+// TestEnforceMostRestrictiveWins proves that when both a CanNotDelete and a
+// ReadOnly lock cover a path, a write still finds the ReadOnly and blocks.
+func TestEnforceMostRestrictiveWins(t *testing.T) {
+	h := New()
+	seedLock(h, rg, "nodel", levelCanNotDelete)
+	seedLock(h, sub, "ro", levelReadOnly)
+
+	if _, _, blocked := h.Enforce(vm, http.MethodPut); !blocked {
+		t.Fatal("write covered by CanNotDelete + ReadOnly: want blocked (ReadOnly wins), got allowed")
+	}
+}
+
+// TestEnforceMessageNamesMostSpecificLock proves the tightest (longest-scope)
+// covering lock is reported for the error message.
+func TestEnforceMessageNamesMostSpecificLock(t *testing.T) {
+	h := New()
+	seedLock(h, sub, "sub-lock", levelReadOnly)
+	seedLock(h, rg, "rg-lock", levelReadOnly)
+
+	lockedScope, _, blocked := h.Enforce(vm, http.MethodPatch)
+	if !blocked {
+		t.Fatal("want blocked")
+	}
+
+	if lockedScope != rg {
+		t.Fatalf("reported scope = %q, want the more specific %q", lockedScope, rg)
+	}
+}

--- a/server/azure/locks/enforcement_e2e_test.go
+++ b/server/azure/locks/enforcement_e2e_test.go
@@ -1,0 +1,233 @@
+package locks_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armlocks"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// newEnforceServer starts one Azure wire server both the armlocks and
+// armresources clients talk to, so a lock created via one client enforces
+// against control-plane operations issued via the other.
+func newEnforceServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.DriversFrom(cloudP))
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+func newLocksClient(t *testing.T, ts *httptest.Server) *armlocks.ManagementLocksClient {
+	t.Helper()
+
+	c, err := armlocks.NewManagementLocksClient(testSub, fakeCred{}, armClientOptions(ts))
+	if err != nil {
+		t.Fatalf("new locks client: %v", err)
+	}
+
+	return c
+}
+
+func newRGClient(t *testing.T, ts *httptest.Server) *armresources.ResourceGroupsClient {
+	t.Helper()
+
+	c, err := armresources.NewResourceGroupsClient(testSub, fakeCred{}, armClientOptions(ts))
+	if err != nil {
+		t.Fatalf("new rg client: %v", err)
+	}
+
+	return c
+}
+
+func assertScopeLocked(t *testing.T, op string, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("%s: want ScopeLocked error, got nil", op)
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("%s: want *azcore.ResponseError, got %T: %v", op, err, err)
+	}
+
+	if respErr.StatusCode != http.StatusConflict || respErr.ErrorCode != "ScopeLocked" {
+		t.Fatalf("%s: want 409 ScopeLocked, got %d %q", op, respErr.StatusCode, respErr.ErrorCode)
+	}
+}
+
+func createRG(t *testing.T, rgClient *armresources.ResourceGroupsClient, name string) {
+	t.Helper()
+
+	if _, err := rgClient.CreateOrUpdate(context.Background(), name,
+		armresources.ResourceGroup{Location: to.Ptr("eastus")}, nil); err != nil {
+		t.Fatalf("create rg %q: %v", name, err)
+	}
+}
+
+func deleteRG(t *testing.T, rgClient *armresources.ResourceGroupsClient, name string) error {
+	t.Helper()
+
+	poller, err := rgClient.BeginDelete(context.Background(), name, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = poller.PollUntilDone(context.Background(), nil)
+
+	return err
+}
+
+// TestEnforceCanNotDeleteE2E: a CanNotDelete lock on an RG blocks its delete
+// with 409 ScopeLocked, still allows writes, and unlocking (delete the lock via
+// the locks API) restores the delete.
+func TestEnforceCanNotDeleteE2E(t *testing.T) {
+	ts := newEnforceServer(t)
+	locksClient := newLocksClient(t, ts)
+	rgClient := newRGClient(t, ts)
+	ctx := context.Background()
+
+	const rg, lockName = "rg-cnd", "no-delete"
+
+	createRG(t, rgClient, rg)
+
+	if _, err := locksClient.CreateOrUpdateAtResourceGroupLevel(ctx, rg, lockName,
+		armlocks.ManagementLockObject{Properties: &armlocks.ManagementLockProperties{
+			Level: to.Ptr(armlocks.LockLevelCanNotDelete),
+		}}, nil); err != nil {
+		t.Fatalf("create lock: %v", err)
+	}
+
+	assertScopeLocked(t, "delete under CanNotDelete", deleteRG(t, rgClient, rg))
+
+	// CanNotDelete allows modify: a PUT update of the RG succeeds.
+	if _, err := rgClient.CreateOrUpdate(ctx, rg,
+		armresources.ResourceGroup{Location: to.Ptr("eastus"), Tags: map[string]*string{"k": to.Ptr("v")}},
+		nil); err != nil {
+		t.Fatalf("write under CanNotDelete should succeed: %v", err)
+	}
+
+	// Unlock via the locks API (must succeed despite covering itself)...
+	if _, err := locksClient.DeleteAtResourceGroupLevel(ctx, rg, lockName, nil); err != nil {
+		t.Fatalf("delete lock: %v", err)
+	}
+
+	// ...and the delete now succeeds.
+	if err := deleteRG(t, rgClient, rg); err != nil {
+		t.Fatalf("delete after unlock should succeed: %v", err)
+	}
+}
+
+// TestEnforceReadOnlyE2E: a ReadOnly lock on an RG blocks write (PUT), tag
+// update (PATCH) and delete with 409 ScopeLocked, while reads still succeed.
+func TestEnforceReadOnlyE2E(t *testing.T) {
+	ts := newEnforceServer(t)
+	locksClient := newLocksClient(t, ts)
+	rgClient := newRGClient(t, ts)
+	ctx := context.Background()
+
+	const rg, lockName = "rg-ro", "read-only"
+
+	createRG(t, rgClient, rg)
+
+	if _, err := locksClient.CreateOrUpdateAtResourceGroupLevel(ctx, rg, lockName,
+		armlocks.ManagementLockObject{Properties: &armlocks.ManagementLockProperties{
+			Level: to.Ptr(armlocks.LockLevelReadOnly),
+		}}, nil); err != nil {
+		t.Fatalf("create lock: %v", err)
+	}
+
+	_, putErr := rgClient.CreateOrUpdate(ctx, rg,
+		armresources.ResourceGroup{Location: to.Ptr("eastus"), Tags: map[string]*string{"k": to.Ptr("v")}}, nil)
+	assertScopeLocked(t, "PUT under ReadOnly", putErr)
+
+	_, patchErr := rgClient.Update(ctx, rg,
+		armresources.ResourceGroupPatchable{Tags: map[string]*string{"k": to.Ptr("v")}}, nil)
+	assertScopeLocked(t, "PATCH under ReadOnly", patchErr)
+
+	assertScopeLocked(t, "DELETE under ReadOnly", deleteRG(t, rgClient, rg))
+
+	// Reads are always allowed.
+	if _, err := rgClient.Get(ctx, rg, nil); err != nil {
+		t.Fatalf("GET under ReadOnly should succeed: %v", err)
+	}
+}
+
+// TestEnforceInheritanceE2E: a lock at subscription scope blocks a resource
+// (resource-group) delete beneath it — inheritance flows downward.
+func TestEnforceInheritanceE2E(t *testing.T) {
+	ts := newEnforceServer(t)
+	locksClient := newLocksClient(t, ts)
+	rgClient := newRGClient(t, ts)
+	ctx := context.Background()
+
+	const rg, lockName = "rg-inh", "sub-lock"
+
+	createRG(t, rgClient, rg)
+
+	if _, err := locksClient.CreateOrUpdateAtSubscriptionLevel(ctx, lockName,
+		armlocks.ManagementLockObject{Properties: &armlocks.ManagementLockProperties{
+			Level: to.Ptr(armlocks.LockLevelCanNotDelete),
+		}}, nil); err != nil {
+		t.Fatalf("create subscription lock: %v", err)
+	}
+
+	assertScopeLocked(t, "RG delete under subscription lock", deleteRG(t, rgClient, rg))
+
+	// Removing the subscription lock restores the delete.
+	if _, err := locksClient.DeleteAtSubscriptionLevel(ctx, lockName, nil); err != nil {
+		t.Fatalf("delete subscription lock: %v", err)
+	}
+
+	if err := deleteRG(t, rgClient, rg); err != nil {
+		t.Fatalf("delete after unlock should succeed: %v", err)
+	}
+}
+
+// TestEnforceDataPlaneExemptE2E: locks are control-plane only. Even with a
+// ReadOnly lock on the whole subscription, a data-plane-style path (not under
+// /subscriptions/) is never answered with ScopeLocked.
+func TestEnforceDataPlaneExemptE2E(t *testing.T) {
+	ts := newEnforceServer(t)
+	locksClient := newLocksClient(t, ts)
+	ctx := context.Background()
+
+	if _, err := locksClient.CreateOrUpdateAtSubscriptionLevel(ctx, "ro",
+		armlocks.ManagementLockObject{Properties: &armlocks.ManagementLockProperties{
+			Level: to.Ptr(armlocks.LockLevelReadOnly),
+		}}, nil); err != nil {
+		t.Fatalf("create subscription lock: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, ts.URL+"/mycontainer/blob.txt", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("data-plane request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode == http.StatusConflict {
+		t.Fatalf("data-plane path was blocked with 409: %s", body)
+	}
+}

--- a/server/azure/locks/locks.go
+++ b/server/azure/locks/locks.go
@@ -17,12 +17,14 @@
 // string, so the At{Subscription,ResourceGroup,Resource}Level and ByScope SDK
 // variants all route through the same code path.
 //
-// SCOPE BOUNDARY: this handler implements the management-plane CRUD and a
-// faithful round-trip of level/notes plus discoverability of the locks
-// themselves. It does NOT enforce the locks — a CanNotDelete or ReadOnly lock
-// does not (yet) block deletes or writes on the locked resource. Enforcement is
-// a cross-cutting change spanning every Azure delete/write path and is tracked
-// as follow-up work.
+// ENFORCEMENT: this handler owns the CRUD/round-trip surface above and, via
+// Enforce, the lock-evaluation policy consumed by the server's pre-dispatch
+// gate (server/azure/lockgate.go). A CanNotDelete lock blocks DELETE on its
+// scope and everything under it; a ReadOnly lock additionally blocks
+// PUT/PATCH/POST (writes and actions). GET/HEAD are always allowed. The gate is
+// the single chokepoint applying this to every Azure resource type — no
+// per-handler edits. Keeping the method→level policy here (not in the gate)
+// keeps all lock semantics cohesive and unit-testable without a server.
 //
 // Locks are a pure management-plane concept with no per-provider driver
 // counterpart (there is no AWS/GCP analog), so the handler owns its own
@@ -47,6 +49,11 @@ const (
 
 	// armType is the ARM resource type reported on every lock.
 	armType = "Microsoft.Authorization/locks"
+
+	// The two Azure lock levels. Compared case-insensitively since SDKs and
+	// hand-built requests vary the casing.
+	levelCanNotDelete = "CanNotDelete"
+	levelReadOnly     = "ReadOnly"
 )
 
 // Handler serves Microsoft.Authorization/locks ARM requests from an in-memory
@@ -58,6 +65,95 @@ type Handler struct {
 // New returns a locks handler with an empty in-memory store.
 func New() *Handler {
 	return &Handler{store: newStore()}
+}
+
+// Enforce evaluates the management locks covering a control-plane request and
+// reports whether they forbid the given HTTP method.
+//
+// resourcePath is the request URL path (query already stripped by net/http);
+// method is the HTTP verb. A DELETE is blocked by any covering lock (both
+// levels block delete) or by any lock on a descendant scope (deleting a
+// container that holds a locked child is blocked wholesale, matching Azure). A
+// PUT/PATCH/POST (write or action) is blocked only by a ReadOnly lock covering
+// the path or an ancestor. GET/HEAD are never passed here by the gate.
+//
+// It returns the blocking lock's original-cased scope and level plus
+// blocked=true; the most specific (longest-scope) blocking lock is chosen so
+// the error message names the tightest lock. When no lock blocks, blocked is
+// false and the strings are empty. "Most restrictive wins" falls out: a write
+// covered by both levels still finds the ReadOnly and blocks.
+func (h *Handler) Enforce(resourcePath, method string) (lockedScope, level string, blocked bool) {
+	path := normalizeScope(resourcePath)
+
+	switch strings.ToUpper(method) {
+	case http.MethodDelete:
+		if l, ok := mostSpecificBlocking(h.store.covering(path), blocksDelete); ok {
+			return l.scope, l.level, true
+		}
+
+		// A delete of a container (RG/subscription/parent resource) is blocked
+		// if any lock sits at or below the target — reuse the downward list.
+		if l, ok := mostSpecificBlocking(h.store.list(path), blocksDelete); ok {
+			return l.scope, l.level, true
+		}
+	case http.MethodPut, http.MethodPatch, http.MethodPost:
+		if l, ok := mostSpecificBlocking(h.store.covering(path), blocksWrite); ok {
+			return l.scope, l.level, true
+		}
+	}
+
+	return "", "", false
+}
+
+// blocksDelete reports whether a lock of the given level blocks a DELETE. Both
+// levels do.
+func blocksDelete(level string) bool {
+	return strings.EqualFold(level, levelCanNotDelete) || strings.EqualFold(level, levelReadOnly)
+}
+
+// blocksWrite reports whether a lock of the given level blocks a
+// PUT/PATCH/POST. Only ReadOnly does.
+func blocksWrite(level string) bool {
+	return strings.EqualFold(level, levelReadOnly)
+}
+
+// mostSpecificBlocking returns the blocking lock with the longest scope (ties
+// broken by scope then name for determinism) among those whose level satisfies
+// the predicate. The longest scope is the tightest lock, giving the most
+// faithful error message.
+func mostSpecificBlocking(candidates []storedLock, blocks func(string) bool) (storedLock, bool) {
+	var (
+		best  storedLock
+		found bool
+	)
+
+	for _, l := range candidates {
+		if !blocks(l.level) {
+			continue
+		}
+
+		if !found || moreSpecific(l, best) {
+			best = l
+			found = true
+		}
+	}
+
+	return best, found
+}
+
+// moreSpecific reports whether lock a should be preferred over b as the named
+// blocking lock: a longer scope wins; equal-length scopes break to the
+// lexicographically smaller (scope, name) so the choice is stable.
+func moreSpecific(a, b storedLock) bool {
+	if len(a.scope) != len(b.scope) {
+		return len(a.scope) > len(b.scope)
+	}
+
+	if a.scope != b.scope {
+		return a.scope < b.scope
+	}
+
+	return a.name < b.name
 }
 
 // Matches claims any path carrying the /providers/Microsoft.Authorization/locks

--- a/server/azure/locks/store.go
+++ b/server/azure/locks/store.go
@@ -74,6 +74,31 @@ func (s *store) delete(scope, name string) bool {
 	return true
 }
 
+// covering returns every lock at path or at any ancestor scope above it — the
+// upward complement of list. A stored lock at scope L covers path P iff
+// P == L or P starts with L+"/" (a segment-boundary prefix), which yields
+// subscription→resource-group→resource inheritance and extension-resource
+// inheritance without enumerating ancestors. The trailing-slash boundary keeps
+// /subscriptions/S1 from matching /subscriptions/S10. Comparison is
+// case-insensitive, matching how scopes are keyed.
+func (s *store) covering(path string) []storedLock {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	want := strings.ToLower(path)
+
+	var out []storedLock
+
+	for _, l := range s.locks {
+		got := strings.ToLower(l.scope)
+		if want == got || strings.HasPrefix(want, got+"/") {
+			out = append(out, l)
+		}
+	}
+
+	return out
+}
+
 // list returns every lock at scope and — mirroring real Azure's inheritance —
 // at any child scope beneath it, ordered deterministically by (scope, name). A
 // subscription-scope list therefore surfaces resource-group and resource locks;


### PR DESCRIPTION
## Summary

The Azure Management Locks handler (`server/azure/locks/`) previously stored and echoed locks but did not enforce them. This makes locks behave like real Azure ARM.

- **Single chokepoint:** a new lock-enforcement pre-dispatch hook installed in `server/azure/azure.go` via `SetPreDispatch`, composed with the existing (opt-in) auth gate through a new Azure `composePreDispatch`. One gate covers all ~24 Azure resource types with zero per-handler edits. The `locks.New()` instance is hoisted and shared between the CRUD handler and the gate.
- **Semantics:** `CanNotDelete` blocks DELETE; `ReadOnly` blocks DELETE + PUT + PATCH + POST. GET/HEAD always allowed. Downward inheritance via segment-boundary prefix match (`scope+"/"`, so `/subscriptions/S1` does not match `/subscriptions/S10`). RG/subscription DELETE also fails on a descendant lock. Most-restrictive-wins.
- **Exemptions:** data-plane (non-`/subscriptions/`) paths and the locks API itself are exempt, so a scope can always be unlocked. Admin plane is exempt for free (fronted outside the Azure handler). Always-on — Azure has no toggle.
- **Error:** HTTP 409, code `ScopeLocked`, verbatim Azure message.
- The method→level policy lives inside the locks package (`Handler.Enforce` + `store.covering`), keeping lock semantics cohesive and unit-testable.

## Tests

- Unit: `Enforce`/`covering` across levels × methods × inheritance; gate classification + self-exemption.
- Real-SDK e2e (`armlocks` + `armresources`): CanNotDelete blocks delete / allows write / unlock restores; ReadOnly blocks PUT/PATCH/DELETE / allows GET; subscription-scope inheritance; data-plane exemption.

Full `go test ./...` green; lint clean on touched packages; coverage and go.mod unchanged.