### PR TITLE
feat(azure-compute): single-VM redeploy and reimage

### DIFF
--- a/server/azure/virtualmachines/handler.go
+++ b/server/azure/virtualmachines/handler.go
@@ -14,11 +14,12 @@
 //	POST   .../virtualMachines/{name}/start  — Start
 //	POST   .../virtualMachines/{name}/powerOff — Stop
 //	POST   .../virtualMachines/{name}/restart — Restart
+//	POST   .../virtualMachines/{name}/redeploy — Redeploy (power-cycle to a new host)
+//	POST   .../virtualMachines/{name}/reimage  — Reimage (reset OS disk; VM ends running)
 //	POST   .../virtualMachines/{name}/retrieveBootDiagnosticsData — boot-diagnostics URIs
 //	GET    .../virtualMachines/{name}/bootDiagnostics/serialConsoleLog — serial-log bytes
 //
-// Less-used operations (capture, deallocate, instance view, redeploy, etc.)
-// are not yet wired and will return 501 Not Implemented.
+// Remaining less-used operations return 501 Not Implemented.
 package virtualmachines
 
 import (
@@ -53,6 +54,7 @@ const (
 	actionDeallocate = "deallocate"
 	actionRestart    = "restart"
 	actionReimage    = "reimage"
+	actionRedeploy   = "redeploy"
 )
 
 // Handler serves ARM JSON requests for Microsoft.Compute/virtualMachines.
@@ -208,6 +210,10 @@ func (h *Handler) servePostAction(w http.ResponseWriter, r *http.Request, rp azu
 		h.deallocate(w, r, rp)
 	case actionRestart:
 		h.restart(w, r, rp)
+	case actionRedeploy:
+		h.redeploy(w, r, rp)
+	case actionReimage:
+		h.reimage(w, r, rp)
 	case "generalize":
 		h.generalize(w, r, rp)
 	case "capture":

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -785,6 +785,57 @@ func (h *Handler) restart(w http.ResponseWriter, r *http.Request, rp azurearm.Re
 	h.lifecycleAction(w, r, rp, h.compute.RebootInstances)
 }
 
+// redeploy handles POST virtualMachines/{name}/redeploy. Real Azure powers the
+// VM off, relocates it to a fresh host, and powers it back on; the net
+// observable effect is a brief power cycle that leaves the VM running with
+// provisioningState Succeeded and no data loss. We model that by power-cycling
+// the VM back to the running state, reusing the existing lifecycle plumbing so
+// the same running metrics are emitted.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) redeploy(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	h.powerCycleToRunning(w, r, rp)
+}
+
+// reimage handles POST virtualMachines/{name}/reimage. Real Azure reinstalls
+// the OS by resetting the OS disk to its original image and leaves the VM
+// running. We model the observable power/state transition (VM ends running,
+// provisioningState Succeeded); OS-disk-reset fidelity is deferred to the Azure
+// OS-disk PR, which is the work that first materializes the OS disk as a
+// tracked resource for the emulator to reset.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) reimage(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	h.powerCycleToRunning(w, r, rp)
+}
+
+// powerCycleToRunning is the shared body for redeploy/reimage: it takes the VM
+// through a power cycle that ends in the running state. A running VM is
+// rebooted (running→restarting→running); a stopped/deallocated one is started.
+// Returns 202 + async polling header so real Azure SDK pollers terminate.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) powerCycleToRunning(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	inst, err := findByName(r.Context(), h.compute, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if powerCode(inst) == stateRunning {
+		err = h.compute.RebootInstances(r.Context(), []string{inst.ID})
+	} else {
+		err = h.compute.StartInstances(r.Context(), []string{inst.ID})
+	}
+
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, rp.SubResource+"-"+rp.ResourceName)
+}
+
 // generalize handles POST virtualMachines/{name}/generalize. It marks the VM
 // as generalized (OS-specific state removed), a precondition for capturing it
 // into a reusable image. Real Azure returns 200 OK with no body.

--- a/server/azure/virtualmachines/redeploy_reimage_test.go
+++ b/server/azure/virtualmachines/redeploy_reimage_test.go
@@ -1,0 +1,138 @@
+package virtualmachines_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// powerStateFromInstanceView pulls the PowerState/<code> suffix out of a VM's
+// instance view statuses via the real SDK.
+func powerStateFromInstanceView(t *testing.T, ts *httptest.Server, name string) string {
+	t.Helper()
+
+	client := newSDKClient(t, ts)
+
+	view, err := client.InstanceView(context.Background(), "rg-1", name, nil)
+	if err != nil {
+		t.Fatalf("InstanceView %s: %v", name, err)
+	}
+
+	for _, s := range view.Statuses {
+		if s.Code == nil {
+			continue
+		}
+
+		if code := *s.Code; strings.HasPrefix(code, "PowerState/") {
+			return strings.TrimPrefix(code, "PowerState/")
+		}
+	}
+
+	return ""
+}
+
+// TestSDKRedeployReimage drives the single-VM redeploy and reimage actions with
+// a real armcompute client: both are long-running operations whose pollers must
+// complete (no 202 hang) and leave the VM running.
+func TestSDKRedeployReimage(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newSDKClient(t, ts)
+	ctx := context.Background()
+
+	createSDKVM(t, client, "rr-vm")
+
+	// Redeploy a running VM: power-cycle, ends running.
+	redeployPoller, err := client.BeginRedeploy(ctx, "rg-1", "rr-vm", nil)
+	if err != nil {
+		t.Fatalf("BeginRedeploy: %v", err)
+	}
+
+	if _, err := redeployPoller.PollUntilDone(ctx,
+		&runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("Redeploy poll: %v", err)
+	}
+
+	if got := powerStateFromInstanceView(t, ts, "rr-vm"); got != "running" {
+		t.Errorf("after redeploy powerState=%q want running", got)
+	}
+
+	// Reimage: resets the OS disk (OS-disk-reset fidelity deferred), VM ends
+	// running.
+	reimagePoller, err := client.BeginReimage(ctx, "rg-1", "rr-vm", nil)
+	if err != nil {
+		t.Fatalf("BeginReimage: %v", err)
+	}
+
+	if _, err := reimagePoller.PollUntilDone(ctx,
+		&runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("Reimage poll: %v", err)
+	}
+
+	if got := powerStateFromInstanceView(t, ts, "rr-vm"); got != "running" {
+		t.Errorf("after reimage powerState=%q want running", got)
+	}
+}
+
+// TestSDKRedeployReimageFromDeallocated verifies redeploy/reimage bring a
+// stopped VM back up to running, matching the real-cloud observable that the
+// VM ends powered on.
+func TestSDKRedeployReimageFromDeallocated(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newSDKClient(t, ts)
+	ctx := context.Background()
+
+	createSDKVM(t, client, "rr-dealloc")
+	deallocateSDKVM(t, client, "rr-dealloc")
+
+	poller, err := client.BeginRedeploy(ctx, "rg-1", "rr-dealloc", nil)
+	if err != nil {
+		t.Fatalf("BeginRedeploy: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx,
+		&runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("Redeploy poll: %v", err)
+	}
+
+	if got := powerStateFromInstanceView(t, ts, "rr-dealloc"); got != "running" {
+		t.Errorf("after redeploy of deallocated VM powerState=%q want running", got)
+	}
+}
+
+// TestSDKRedeployReimageMissingVM verifies redeploy/reimage of a non-existent VM
+// surface a 404 rather than a poller hang or a 501.
+func TestSDKRedeployReimageMissingVM(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newSDKClient(t, ts)
+	ctx := context.Background()
+
+	if _, err := client.BeginRedeploy(ctx, "rg-1", "ghost", nil); !isNotFound(err) {
+		t.Errorf("BeginRedeploy on missing VM err=%v, want 404", err)
+	}
+
+	if _, err := client.BeginReimage(ctx, "rg-1", "ghost", nil); !isNotFound(err) {
+		t.Errorf("BeginReimage on missing VM err=%v, want 404", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the single-VM `redeploy` and `reimage` POST actions on `Microsoft.Compute/virtualMachines`, which previously returned 501.

- `POST .../virtualMachines/{vm}/redeploy` — models the real-Azure power cycle (power off, relocate to a new host, power back on): the VM is rebooted if running, or started if stopped/deallocated, and ends **running** with provisioningState Succeeded and no data loss.
- `POST .../virtualMachines/{vm}/reimage` — models the observable power/state transition (VM ends **running**, provisioningState Succeeded).
- Both answer the armcompute `BeginRedeploy` / `BeginReimage` pollers synchronously-terminal (202 + async op status → Succeeded), exactly like the other VM power actions. A missing VM returns 404.

Implemented in the wire handler by composing existing driver power-transition + state-machine plumbing (`RebootInstances` / `StartInstances`); no changes to the shared compute driver.

## Tests

Real `armcompute` SDK e2e: `BeginRedeploy`/`BeginReimage` `PollUntilDone` complete with the VM running (from both running and deallocated start states); redeploy/reimage of a non-existent VM surface 404.

## Deferred

OS-disk-reset fidelity for `reimage` (resetting the OS disk to its original image) is deferred to the Azure OS-disk PR, which first materializes the OS disk as a tracked resource.