### PR TITLE
feat(aws-ec2): materialize root EBS volume + DeleteOnTermination cascade

### DIFF
--- a/features/chaos/wrappers_test.go
+++ b/features/chaos/wrappers_test.go
@@ -434,6 +434,7 @@ type computeConfigCompat = struct {
 	Identity               *computedriver.ManagedIdentity
 	NetworkInterfaces      []computedriver.AzureNICRef
 	PrivateIP              string
+	BlockDeviceMappings    []computedriver.BlockDeviceMapping
 }
 
 // computeInstanceConfig reproduces the helper used elsewhere in the package

--- a/internal/memstore/store.go
+++ b/internal/memstore/store.go
@@ -110,6 +110,31 @@ func (s *Store[V]) Update(key string, fn func(V) V) bool {
 	return true
 }
 
+// UpdateOrDelete atomically applies fn to the value at key under the store
+// lock, so the decision and the resulting mutation cannot be split by a
+// concurrent writer. fn returns the replacement value and a keep flag: when keep
+// is false the key is removed, otherwise the returned value is stored. Returns
+// false if the key does not exist (fn is not called). This is the compare-and-
+// act primitive for "delete this entry only if it still satisfies a predicate",
+// where a plain Get-then-Delete would race.
+func (s *Store[V]) UpdateOrDelete(key string, fn func(V) (V, bool)) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	v, ok := s.items[key]
+	if !ok {
+		return false
+	}
+
+	if nv, keep := fn(v); keep {
+		s.items[key] = nv
+	} else {
+		delete(s.items, key)
+	}
+
+	return true
+}
+
 // SetIfAbsent stores a value only if the key does not already exist. Returns true if set.
 func (s *Store[V]) SetIfAbsent(key string, value V) bool {
 	s.mu.Lock()

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -919,6 +919,34 @@ func (m *Mock) rollbackInstances(ctx context.Context, created []*instanceData) {
 		// Drop any backing profile association so a rolled-back launch leaves no
 		// orphaned association behind.
 		m.deleteAssociationsForInstance(inst.ID)
+		// Delete the root/data EBS volumes materialized for this instance, so a
+		// rolled-back launch leaves no volume stuck in-use against a gone instance.
+		m.deleteInstanceVolumes(inst.ID)
+	}
+}
+
+// deleteInstanceVolumes removes every EBS volume attached to instanceID. It
+// backs rollback of a partially-launched batch: the just-materialized root/data
+// volumes must be torn down along with the instance record. The check-and-delete
+// runs under the store lock (UpdateOrDelete) so it cannot race a concurrent
+// attach/detach on the same volume.
+func (m *Mock) deleteInstanceVolumes(instanceID string) {
+	for _, volID := range m.volumes.Keys() {
+		var deleted bool
+
+		m.volumes.UpdateOrDelete(volID, func(v *driver.VolumeInfo) (*driver.VolumeInfo, bool) {
+			if v.AttachedTo != instanceID {
+				return v, true
+			}
+
+			deleted = true
+
+			return v, false
+		})
+
+		if deleted {
+			m.volSettle.Delete(volID)
+		}
 	}
 }
 
@@ -1722,33 +1750,37 @@ func (m *Mock) detachTerminatedVolumes(instanceIDs []string) {
 		terminated[id] = true
 	}
 
-	var toDelete []string
-
 	for _, volID := range m.volumes.Keys() {
-		vol, ok := m.volumes.Get(volID)
-		if !ok || vol.AttachedTo == "" || !terminated[vol.AttachedTo] {
-			continue
-		}
+		var deleted bool
 
-		if vol.DeleteOnTermination {
-			toDelete = append(toDelete, volID)
-			continue
-		}
+		// The delete-vs-detach decision and the mutation must happen under one
+		// lock so a concurrent DetachVolume that clears the attachment first is
+		// observed here and the volume is NOT wrongly deleted. UpdateOrDelete
+		// re-reads the attachment at mutation time: a volume no longer attached to
+		// a terminating instance (e.g. just detached) survives unchanged.
+		m.volumes.UpdateOrDelete(volID, func(v *driver.VolumeInfo) (*driver.VolumeInfo, bool) {
+			if v.AttachedTo == "" || !terminated[v.AttachedTo] {
+				return v, true
+			}
 
-		m.volumes.Update(volID, func(v *driver.VolumeInfo) *driver.VolumeInfo {
+			if v.DeleteOnTermination {
+				deleted = true
+
+				return v, false
+			}
+
 			cp := *v
 			cp.State = stateAvailable
 			cp.AttachedTo = ""
 			cp.Device = ""
 			cp.DeleteOnTermination = false
 
-			return &cp
+			return &cp, true
 		})
-	}
 
-	for _, volID := range toDelete {
-		m.volumes.Delete(volID)
-		m.volSettle.Delete(volID)
+		if deleted {
+			m.volSettle.Delete(volID)
+		}
 	}
 }
 

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -67,6 +67,12 @@ const (
 	// imageRootDeviceSize is the default root EBS volume size (GiB) recorded in
 	// an AMI's block device mapping when created from a running instance.
 	imageRootDeviceSize = 8
+	// defaultRootDeviceName is the device the root EBS volume attaches at when a
+	// launch supplies no block device mapping for it.
+	defaultRootDeviceName = "/dev/sda1"
+	// defaultVolumeType is the EBS volume type used for a launch-materialized
+	// volume that names none (matching the CreateVolume default).
+	defaultVolumeType = "gp3"
 	// rsaKeyBits is the modulus size for generated RSA key pairs.
 	rsaKeyBits = 2048
 	// keyTypeRSA / keyTypeEd25519 are the two key-pair algorithms the mock
@@ -714,9 +720,75 @@ func (m *Mock) launchInstances(ctx context.Context, cfg driver.InstanceConfig, c
 		if vpcID != "" {
 			m.materializePrimaryENI(ctx, id, cfg.SubnetID, sg)
 		}
+
+		// Materialize the instance's root EBS volume (and any client-supplied
+		// data volumes) as real volume resources attached to it, so
+		// DescribeVolumes / DescribeInstances report the backing disks real EC2
+		// creates at launch, and TerminateInstances can honor DeleteOnTermination.
+		m.materializeInstanceVolumes(cfg, id)
 	}
 
 	return results, nil
+}
+
+// materializeInstanceVolumes creates the backing EBS volume resources for a
+// just-launched instance: one per client-supplied BlockDeviceMapping (attached
+// at its device with its DeleteOnTermination), plus a synthesized default root
+// volume (/dev/sda1, 8 GiB, gp3, DeleteOnTermination=true) when the launch names
+// no boot mapping — matching real EC2, where every instance has a root volume.
+//
+//nolint:gocritic // hugeParam: cfg mirrors the launchInstances signature.
+func (m *Mock) materializeInstanceVolumes(cfg driver.InstanceConfig, instanceID string) {
+	az := m.opts.Region + "a"
+	now := m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z")
+
+	bootCreated := false
+
+	for _, bdm := range cfg.BlockDeviceMappings {
+		device := bdm.DeviceName
+		size := bdm.Size
+
+		if bdm.Boot {
+			bootCreated = true
+
+			if device == "" {
+				device = defaultRootDeviceName
+			}
+		}
+
+		if size == 0 {
+			size = imageRootDeviceSize
+		}
+
+		volType := bdm.Type
+		if volType == "" {
+			volType = defaultVolumeType
+		}
+
+		m.createAttachedVolume(instanceID, device, volType, size, bdm.AutoDelete, az, now)
+	}
+
+	if !bootCreated {
+		m.createAttachedVolume(instanceID, defaultRootDeviceName, defaultVolumeType, imageRootDeviceSize, true, az, now)
+	}
+}
+
+// createAttachedVolume stores a new EBS volume already in-use and attached to
+// instanceID at device, carrying the attachment-scoped DeleteOnTermination flag.
+func (m *Mock) createAttachedVolume(instanceID, device, volType string, size int, deleteOnTermination bool, az, now string) {
+	id := fmt.Sprintf("vol-%012d", m.volCounter.Add(1))
+
+	m.volumes.Set(id, &driver.VolumeInfo{
+		ID:                  id,
+		Size:                size,
+		VolumeType:          volType,
+		State:               stateInUse,
+		AvailabilityZone:    az,
+		AttachedTo:          instanceID,
+		Device:              device,
+		CreatedAt:           now,
+		DeleteOnTermination: deleteOnTermination,
+	})
 }
 
 // renderInstancesByID renders the current state of the given instance ids fresh
@@ -1627,6 +1699,7 @@ func (m *Mock) DetachVolume(_ context.Context, volumeID, instanceID, device stri
 		cp.State = stateAvailable
 		cp.AttachedTo = ""
 		cp.Device = ""
+		cp.DeleteOnTermination = false
 
 		return &cp
 	})
@@ -1637,31 +1710,45 @@ func (m *Mock) DetachVolume(_ context.Context, volumeID, instanceID, device stri
 	return detachErr
 }
 
-// detachTerminatedVolumes returns every EBS volume attached to a now-terminated
-// instance to the `available` state (attachment cleared). Real EC2 detaches
-// volumes with DeleteOnTermination=false back to available on terminate; user-
-// attached volumes carry that default, so all of them detach here. Each volume
-// is updated with a copy-on-write fresh pointer under the store lock so a
-// concurrent DescribeVolumes/AttachVolume never races.
+// detachTerminatedVolumes settles every EBS volume attached to a now-terminated
+// instance, matching real EC2's terminate cascade: a volume with
+// DeleteOnTermination=true (the root volume's default) is DELETED, and one with
+// DeleteOnTermination=false is returned to `available` with its attachment
+// cleared. The detach path updates a copy-on-write fresh pointer under the store
+// lock so a concurrent DescribeVolumes/AttachVolume never races.
 func (m *Mock) detachTerminatedVolumes(instanceIDs []string) {
 	terminated := make(map[string]bool, len(instanceIDs))
 	for _, id := range instanceIDs {
 		terminated[id] = true
 	}
 
-	for _, volID := range m.volumes.Keys() {
-		m.volumes.Update(volID, func(v *driver.VolumeInfo) *driver.VolumeInfo {
-			if v.AttachedTo == "" || !terminated[v.AttachedTo] {
-				return v
-			}
+	var toDelete []string
 
+	for _, volID := range m.volumes.Keys() {
+		vol, ok := m.volumes.Get(volID)
+		if !ok || vol.AttachedTo == "" || !terminated[vol.AttachedTo] {
+			continue
+		}
+
+		if vol.DeleteOnTermination {
+			toDelete = append(toDelete, volID)
+			continue
+		}
+
+		m.volumes.Update(volID, func(v *driver.VolumeInfo) *driver.VolumeInfo {
 			cp := *v
 			cp.State = stateAvailable
 			cp.AttachedTo = ""
 			cp.Device = ""
+			cp.DeleteOnTermination = false
 
 			return &cp
 		})
+	}
+
+	for _, volID := range toDelete {
+		m.volumes.Delete(volID)
+		m.volSettle.Delete(volID)
 	}
 }
 

--- a/providers/aws/ec2/root_volume_cascade_test.go
+++ b/providers/aws/ec2/root_volume_cascade_test.go
@@ -1,0 +1,128 @@
+package ec2
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+// rootVolumeOf returns the id of the EBS volume the mock materialized for and
+// attached to instanceID, or "" if none is found.
+func rootVolumeOf(t *testing.T, m *Mock, instanceID string) string {
+	t.Helper()
+
+	vols, err := m.DescribeVolumes(context.Background(), nil)
+	requireNoError(t, err)
+
+	for i := range vols {
+		if vols[i].AttachedTo == instanceID {
+			return vols[i].ID
+		}
+	}
+
+	return ""
+}
+
+// TestTerminateVsDetachVolumeNoDataLoss guards the terminate cascade's
+// delete-vs-detach decision against a TOCTOU race with a concurrent
+// DetachVolume. The invariant: if DetachVolume reports success, the volume must
+// survive terminate — a successful detach can never be silently deleted. Run
+// under -race; a split read-then-delete would fail this in a fraction of trials.
+func TestTerminateVsDetachVolumeNoDataLoss(t *testing.T) {
+	ctx := context.Background()
+
+	const trials = 800
+
+	for trial := 0; trial < trials; trial++ {
+		m := newTestMock()
+
+		run, err := m.RunInstances(ctx, defaultConfig(), 1)
+		requireNoError(t, err)
+
+		instID := run[0].ID
+
+		volID := rootVolumeOf(t, m, instID)
+		assertNotEmpty(t, volID)
+
+		var (
+			wg        sync.WaitGroup
+			detachErr error
+		)
+
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+
+			detachErr = m.DetachVolume(ctx, volID, instID, "")
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			_ = m.TerminateInstances(ctx, []string{instID})
+		}()
+
+		wg.Wait()
+
+		_, describeErr := m.DescribeVolumes(ctx, []string{volID})
+		gone := describeErr != nil
+
+		if detachErr == nil && gone {
+			t.Fatalf("trial %d: DetachVolume succeeded but volume %s was deleted by terminate (data loss)",
+				trial, volID)
+		}
+	}
+}
+
+// TestTerminateCascadeDeletesRootVolume pins the single-threaded cascade: the
+// root volume (DeleteOnTermination=true) is deleted on terminate, while a
+// separately created (unattached) volume is untouched.
+func TestTerminateCascadeDeletesRootVolume(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	run, err := m.RunInstances(ctx, defaultConfig(), 1)
+	requireNoError(t, err)
+
+	instID := run[0].ID
+	rootID := rootVolumeOf(t, m, instID)
+	assertNotEmpty(t, rootID)
+
+	// A DeleteOnTermination=false volume attached after launch must survive.
+	keep, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	requireNoError(t, err)
+	requireNoError(t, m.AttachVolume(ctx, keep.ID, instID, "/dev/sdh"))
+
+	requireNoError(t, m.TerminateInstances(ctx, []string{instID}))
+
+	if _, err := m.DescribeVolumes(ctx, []string{rootID}); err == nil {
+		t.Fatalf("root volume %s should be deleted on terminate", rootID)
+	}
+
+	kept, err := m.DescribeVolumes(ctx, []string{keep.ID})
+	requireNoError(t, err)
+	assertEqual(t, "available", kept[0].State)
+	assertEqual(t, "", kept[0].AttachedTo)
+}
+
+// TestRunInstancesRollbackDeletesVolumes proves a mid-batch launch failure
+// leaves no orphaned volumes: every volume materialized for an
+// already-provisioned instance is torn down along with the instance record.
+func TestRunInstancesRollbackDeletesVolumes(t *testing.T) {
+	ctx := context.Background()
+	eng := &fakeComputeEngine{ip: "10.1.1.1", failProvisionOn: 3}
+	m := newEngineMock(eng)
+
+	instances, err := m.RunInstances(ctx, defaultConfig(), 5)
+	assertTrue(t, err != nil, "a mid-batch provision failure must surface an error")
+	assertTrue(t, instances == nil, "no instances should be returned on a rolled-back batch")
+
+	// Instances 1 and 2 were provisioned (and materialized a root volume each)
+	// before the 3rd failed; rollback must delete those volumes.
+	vols, derr := m.DescribeVolumes(ctx, nil)
+	requireNoError(t, derr)
+	assertEqual(t, 0, len(vols))
+}

--- a/server/aws/costexplorer/state_aware_cost_test.go
+++ b/server/aws/costexplorer/state_aware_cost_test.go
@@ -136,8 +136,9 @@ func TestSDKCostDropsOnTerminate(t *testing.T) {
 }
 
 // TestSDKCostDropsOnStop proves a stopped instance is not billed for compute:
-// stopping both instances drops the compute cost to zero (a real stopped
-// instance pays only for its EBS, which this estate has none of).
+// stopping both instances drops the total below the running estate, but the
+// root EBS volumes each instance launches with keep billing (a real stopped
+// instance still pays for its EBS storage), so the total stays above zero.
 func TestSDKCostDropsOnStop(t *testing.T) {
 	ctx := context.Background()
 	ceClient, ec2Client := newStateAwareClients(t)
@@ -154,7 +155,11 @@ func TestSDKCostDropsOnStop(t *testing.T) {
 	}
 
 	after := monthlyTotal(t, ceClient)
-	if after != 0 {
-		t.Fatalf("total after stopping all = %v, want 0 (stopped compute is not billed)", after)
+	if after >= before {
+		t.Fatalf("total after stopping all = %v, want < %v (compute no longer billed)", after, before)
+	}
+
+	if after <= 0 {
+		t.Fatalf("total after stopping all = %v, want > 0 (root EBS volumes still billed)", after)
 	}
 }

--- a/server/aws/ec2/operations.go
+++ b/server/aws/ec2/operations.go
@@ -61,6 +61,8 @@ const (
 	primaryDeviceIndex = 0
 	// internalDNSSuffix is the private-DNS suffix EC2 uses in us-east-1.
 	internalDNSSuffix = ".ec2.internal"
+	// rootDeviceDefault is the root device name used when an AMI reports none.
+	rootDeviceDefault = "/dev/sda1"
 )
 
 // runInstances handles Action=RunInstances.
@@ -83,6 +85,7 @@ func (h *Handler) runInstances(w http.ResponseWriter, r *http.Request) {
 	}
 
 	applyRunInstancesForm(&cfg, form)
+	cfg.BlockDeviceMappings = h.parseRunBlockDeviceMappings(r.Context(), form, cfg.ImageID)
 
 	instances, err := h.compute.RunInstances(r.Context(), cfg, count)
 	if err != nil {
@@ -187,6 +190,75 @@ func applyRunInstancesForm(cfg *computedriver.InstanceConfig, form url.Values) {
 	if tags := mergeTagSpecs(awsquery.TagSpecs(form), "instance"); len(tags) > 0 {
 		cfg.Tags = tags
 	}
+}
+
+// parseRunBlockDeviceMappings reads the RunInstances BlockDeviceMapping.N.*
+// groups into provider-neutral mappings and guarantees exactly one boot mapping
+// so the provider materializes a root volume. The boot mapping is the one whose
+// device name matches the AMI's root device (defaulting to /dev/sda1); a launch
+// that names no such mapping gets a synthesized boot mapping. DeleteOnTermination
+// defaults to true for launch-time mappings, matching real EC2.
+func (h *Handler) parseRunBlockDeviceMappings(
+	ctx context.Context, form url.Values, imageID string,
+) []computedriver.BlockDeviceMapping {
+	rootDevice := h.rootDeviceName(ctx, imageID)
+
+	out := make([]computedriver.BlockDeviceMapping, 0)
+	bootSeen := false
+
+	for _, i := range awsquery.CollectIndices(form, "BlockDeviceMapping") {
+		base := "BlockDeviceMapping." + strconv.Itoa(i)
+
+		// A mapping without an Ebs block (e.g. a NoDevice / ephemeral entry) does
+		// not create an EBS volume; skip it.
+		device := form.Get(base + ".DeviceName")
+		if device == "" {
+			continue
+		}
+
+		size, _ := strconv.Atoi(form.Get(base + ".Ebs.VolumeSize"))
+
+		deleteOnTermination := true
+		if v := form.Get(base + ".Ebs.DeleteOnTermination"); v != "" {
+			deleteOnTermination = v == formTrue
+		}
+
+		boot := device == rootDevice
+		bootSeen = bootSeen || boot
+
+		out = append(out, computedriver.BlockDeviceMapping{
+			DeviceName: device,
+			Boot:       boot,
+			AutoDelete: deleteOnTermination,
+			Size:       size,
+			Type:       form.Get(base + ".Ebs.VolumeType"),
+		})
+	}
+
+	if !bootSeen {
+		out = append(out, computedriver.BlockDeviceMapping{
+			DeviceName: rootDevice,
+			Boot:       true,
+			AutoDelete: true,
+		})
+	}
+
+	return out
+}
+
+// rootDeviceName resolves the root device name of the launch AMI, falling back
+// to /dev/sda1 when the image is unknown or reports none.
+func (h *Handler) rootDeviceName(ctx context.Context, imageID string) string {
+	if imageID == "" || h.compute == nil {
+		return rootDeviceDefault
+	}
+
+	imgs, err := h.compute.DescribeImages(ctx, []string{imageID})
+	if err != nil || len(imgs) == 0 || imgs[0].RootDeviceName == "" {
+		return rootDeviceDefault
+	}
+
+	return imgs[0].RootDeviceName
 }
 
 // reservationIDFor returns the instance's reservation id, falling back to a
@@ -970,7 +1042,7 @@ func instanceBlockDevices(vols []computedriver.VolumeInfo) []instanceBlockDevice
 				VolumeID:            v.ID,
 				Status:              eniAttachedStatus,
 				AttachTime:          v.CreatedAt,
-				DeleteOnTermination: false,
+				DeleteOnTermination: v.DeleteOnTermination,
 			},
 		})
 	}

--- a/server/aws/ec2/root_volume_cascade_test.go
+++ b/server/aws/ec2/root_volume_cascade_test.go
@@ -1,0 +1,195 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// runOne launches a single instance and returns its id.
+func runOne(t *testing.T, client *ec2.Client, bdms ...ec2types.BlockDeviceMapping) string {
+	t.Helper()
+
+	out, err := client.RunInstances(context.Background(), &ec2.RunInstancesInput{
+		ImageId:             aws.String("ami-1"),
+		InstanceType:        ec2types.InstanceTypeT3Micro,
+		MinCount:            aws.Int32(1),
+		MaxCount:            aws.Int32(1),
+		BlockDeviceMappings: bdms,
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	if len(out.Instances) != 1 {
+		t.Fatalf("launched %d instances, want 1", len(out.Instances))
+	}
+
+	return aws.ToString(out.Instances[0].InstanceId)
+}
+
+// volumesFor returns every volume the server reports (optionally by id).
+func volumesFor(t *testing.T, client *ec2.Client, ids ...string) []ec2types.Volume {
+	t.Helper()
+
+	out, err := client.DescribeVolumes(context.Background(), &ec2.DescribeVolumesInput{VolumeIds: ids})
+	if err != nil {
+		t.Fatalf("DescribeVolumes: %v", err)
+	}
+
+	return out.Volumes
+}
+
+// TestRunInstancesMaterializesRootVolume proves a launched instance has a real
+// root EBS volume: DescribeVolumes returns it attached at the root device with
+// DeleteOnTermination=true, and DescribeInstances echoes the same in its
+// blockDeviceMapping (Terraform's aws_instance.root_block_device).
+func TestRunInstancesMaterializesRootVolume(t *testing.T) {
+	client := newEC2(t)
+
+	id := runOne(t, client)
+
+	vols := volumesFor(t, client)
+	if len(vols) != 1 {
+		t.Fatalf("volume count = %d, want 1 (the root volume)", len(vols))
+	}
+
+	root := vols[0]
+	if root.State != ec2types.VolumeStateInUse {
+		t.Errorf("root volume State = %q, want in-use", root.State)
+	}
+	if len(root.Attachments) != 1 {
+		t.Fatalf("root volume attachments = %d, want 1", len(root.Attachments))
+	}
+
+	att := root.Attachments[0]
+	if aws.ToString(att.InstanceId) != id {
+		t.Errorf("attachment InstanceId = %q, want %q", aws.ToString(att.InstanceId), id)
+	}
+	if aws.ToString(att.Device) != "/dev/sda1" {
+		t.Errorf("attachment Device = %q, want /dev/sda1", aws.ToString(att.Device))
+	}
+	if !aws.ToBool(att.DeleteOnTermination) {
+		t.Errorf("root attachment DeleteOnTermination = false, want true")
+	}
+
+	// DescribeInstances must echo the same root block device mapping.
+	di, err := client.DescribeInstances(context.Background(),
+		&ec2.DescribeInstancesInput{InstanceIds: []string{id}})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	inst := di.Reservations[0].Instances[0]
+	if len(inst.BlockDeviceMappings) != 1 {
+		t.Fatalf("instance blockDeviceMappings = %d, want 1", len(inst.BlockDeviceMappings))
+	}
+
+	ebs := inst.BlockDeviceMappings[0].Ebs
+	if ebs == nil || !aws.ToBool(ebs.DeleteOnTermination) {
+		t.Errorf("instance root DeleteOnTermination = false, want true")
+	}
+	if aws.ToString(ebs.VolumeId) != aws.ToString(root.VolumeId) {
+		t.Errorf("instance root volumeId = %q, want %q", aws.ToString(ebs.VolumeId), aws.ToString(root.VolumeId))
+	}
+}
+
+// TestRunInstancesHonorsRootBlockDeviceMapping proves a client-supplied mapping
+// for the root device controls the root volume's size, type, and
+// DeleteOnTermination (Terraform sets these under root_block_device).
+func TestRunInstancesHonorsRootBlockDeviceMapping(t *testing.T) {
+	client := newEC2(t)
+
+	runOne(t, client, ec2types.BlockDeviceMapping{
+		DeviceName: aws.String("/dev/sda1"),
+		Ebs: &ec2types.EbsBlockDevice{
+			VolumeSize:          aws.Int32(30),
+			VolumeType:          ec2types.VolumeTypeGp2,
+			DeleteOnTermination: aws.Bool(false),
+		},
+	})
+
+	vols := volumesFor(t, client)
+	if len(vols) != 1 {
+		t.Fatalf("volume count = %d, want 1", len(vols))
+	}
+
+	root := vols[0]
+	if aws.ToInt32(root.Size) != 30 {
+		t.Errorf("root Size = %d, want 30", aws.ToInt32(root.Size))
+	}
+	if root.VolumeType != ec2types.VolumeTypeGp2 {
+		t.Errorf("root VolumeType = %q, want gp2", root.VolumeType)
+	}
+	if len(root.Attachments) != 1 || aws.ToBool(root.Attachments[0].DeleteOnTermination) {
+		t.Errorf("root DeleteOnTermination = true, want false (client override)")
+	}
+}
+
+// TestTerminateCascadeDeletesDeleteOnTerminationVolumes proves the real EC2
+// terminate cascade: the root volume (DeleteOnTermination=true) and any
+// DeleteOnTermination=true data volume are deleted, while a separately attached
+// DeleteOnTermination=false volume survives as `available`.
+func TestTerminateCascadeDeletesDeleteOnTerminationVolumes(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	// Launch with a root volume (DoT=true default) and a data volume the client
+	// marks DoT=true.
+	id := runOne(t, client, ec2types.BlockDeviceMapping{
+		DeviceName: aws.String("/dev/sdg"),
+		Ebs: &ec2types.EbsBlockDevice{
+			VolumeSize:          aws.Int32(20),
+			DeleteOnTermination: aws.Bool(true),
+		},
+	})
+
+	// Separately create and attach a DoT=false volume (AttachVolume defaults it
+	// to false — the volume must outlive the instance).
+	cre, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(10),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+
+	keepID := aws.ToString(cre.VolumeId)
+
+	if _, err := client.AttachVolume(ctx, &ec2.AttachVolumeInput{
+		VolumeId:   aws.String(keepID),
+		InstanceId: aws.String(id),
+		Device:     aws.String("/dev/sdh"),
+	}); err != nil {
+		t.Fatalf("AttachVolume: %v", err)
+	}
+
+	// Three volumes now exist: root (DoT=true), data (DoT=true), keep (DoT=false).
+	if got := len(volumesFor(t, client)); got != 3 {
+		t.Fatalf("pre-terminate volume count = %d, want 3", got)
+	}
+
+	if _, err := client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{InstanceIds: []string{id}}); err != nil {
+		t.Fatalf("TerminateInstances: %v", err)
+	}
+
+	// Only the DoT=false volume remains, and it is back to available/detached.
+	remaining := volumesFor(t, client)
+	if len(remaining) != 1 {
+		t.Fatalf("post-terminate volume count = %d, want 1 (the DoT=false volume)", len(remaining))
+	}
+
+	kept := remaining[0]
+	if aws.ToString(kept.VolumeId) != keepID {
+		t.Fatalf("surviving volume = %q, want %q", aws.ToString(kept.VolumeId), keepID)
+	}
+	if kept.State != ec2types.VolumeStateAvailable {
+		t.Errorf("surviving volume State = %q, want available", kept.State)
+	}
+	if len(kept.Attachments) != 0 {
+		t.Errorf("surviving volume still has %d attachments, want 0", len(kept.Attachments))
+	}
+}

--- a/server/aws/ec2/volume.go
+++ b/server/aws/ec2/volume.go
@@ -36,11 +36,12 @@ const (
 )
 
 type volumeAttachmentXML struct {
-	VolumeID   string `xml:"volumeId"`
-	InstanceID string `xml:"instanceId"`
-	Device     string `xml:"device"`
-	Status     string `xml:"status"`
-	AttachTime string `xml:"attachTime,omitempty"`
+	VolumeID            string `xml:"volumeId"`
+	InstanceID          string `xml:"instanceId"`
+	Device              string `xml:"device"`
+	Status              string `xml:"status"`
+	AttachTime          string `xml:"attachTime,omitempty"`
+	DeleteOnTermination bool   `xml:"deleteOnTermination"`
 }
 
 type volumeXML struct {
@@ -420,11 +421,12 @@ func toVolumeXML(v *computedriver.VolumeInfo) volumeXML {
 
 	if v.AttachedTo != "" {
 		x.Attachments = []volumeAttachmentXML{{
-			VolumeID:   v.ID,
-			InstanceID: v.AttachedTo,
-			Device:     v.Device,
-			Status:     "attached",
-			AttachTime: v.CreatedAt,
+			VolumeID:            v.ID,
+			InstanceID:          v.AttachedTo,
+			Device:              v.Device,
+			Status:              "attached",
+			AttachTime:          v.CreatedAt,
+			DeleteOnTermination: v.DeleteOnTermination,
 		}}
 	}
 

--- a/server/serverkit/cost_serve_test.go
+++ b/server/serverkit/cost_serve_test.go
@@ -17,6 +17,8 @@ func TestServeCostEstimatesInventory(t *testing.T) {
 	aws := cloudemu.NewAWS()
 
 	// Two running instances → an always-on estimate the cost endpoint should sum.
+	// Each instance also materializes a root EBS volume, so the inventory the
+	// cost endpoint prices is the 2 instances plus their 2 root volumes.
 	if _, err := aws.EC2.RunInstances(ctx, computedriver.InstanceConfig{ImageID: "ami-1", InstanceType: "t3.micro"}, 2); err != nil {
 		t.Fatalf("run instances: %v", err)
 	}
@@ -36,8 +38,9 @@ func TestServeCostEstimatesInventory(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.EstimatedMonthlyUSD <= 0 || len(resp.Resources) != 2 {
-		t.Fatalf("cost = $%.2f over %d resources, want >0 over 2 instances", resp.EstimatedMonthlyUSD, len(resp.Resources))
+	if resp.EstimatedMonthlyUSD <= 0 || len(resp.Resources) != 4 {
+		t.Fatalf("cost = $%.2f over %d resources, want >0 over 2 instances + 2 root volumes",
+			resp.EstimatedMonthlyUSD, len(resp.Resources))
 	}
 }
 

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -61,6 +61,36 @@ type InstanceConfig struct {
 	// address from the referenced subnetwork's CIDR before launch. Ignored by
 	// AWS/Azure.
 	PrivateIP string
+	// BlockDeviceMappings are the client-supplied boot/data disk requests carried
+	// on create (AWS RunInstances BlockDeviceMapping.N, GCP disks[] with
+	// initializeParams, Azure storageProfile.osDisk + dataDisks). The provider
+	// materializes a real backing volume resource for each one, attached to the
+	// launched instance. Provider-neutral and additive: a caller that leaves it
+	// nil (as Azure/GCP do today) keeps the pre-existing behavior — the AWS
+	// provider then synthesizes a single default root volume.
+	BlockDeviceMappings []BlockDeviceMapping
+}
+
+// BlockDeviceMapping is one client-supplied block/boot disk request on instance
+// create. It is provider-neutral: AWS maps it from RunInstances
+// BlockDeviceMapping.N, and it is the shared carrier the GCP boot-disk / Azure
+// OS-disk work builds on. The provider materializes a real volume resource per
+// mapping, attached to the launched instance at DeviceName.
+type BlockDeviceMapping struct {
+	// DeviceName is the device the volume attaches at (e.g. "/dev/sda1").
+	DeviceName string
+	// Boot marks the instance's root/boot device. Exactly one mapping is the
+	// boot device; the provider synthesizes a default root when none is Boot.
+	Boot bool
+	// AutoDelete requests that the volume be deleted when the instance is
+	// terminated/deleted (AWS DeleteOnTermination, GCP autoDelete, Azure
+	// deleteOption=="Delete"). It is carried onto the materialized volume's
+	// VolumeInfo.DeleteOnTermination.
+	AutoDelete bool
+	// Size is the volume size in GiB (0 = provider default).
+	Size int
+	// Type is the volume/disk type (e.g. "gp3"; empty = provider default).
+	Type string
 }
 
 // AzureNICRef identifies a Network Interface (Microsoft.Network/networkInterfaces)
@@ -414,6 +444,14 @@ type VolumeInfo struct {
 	Device           string
 	CreatedAt        string
 	Tags             map[string]string
+	// DeleteOnTermination is the attachment-scoped auto-delete flag: when the
+	// volume is attached and this is true, terminating the owning instance
+	// deletes the volume rather than detaching it (AWS root volume defaults
+	// true; GCP autoDelete; Azure deleteOption=="Delete"). It has meaning only
+	// while AttachedTo is set and is cleared on detach. Zero value (false)
+	// preserves the pre-existing detach-on-terminate behavior for providers that
+	// do not yet set it.
+	DeleteOnTermination bool
 	// IOPS is the provisioned IOPS (io2/gp3, Premium/Ultra disks), when set.
 	IOPS int
 	// Throughput is the provisioned throughput in MB/s, when set.

--- a/services/resourcediscovery/engine_test.go
+++ b/services/resourcediscovery/engine_test.go
@@ -204,6 +204,10 @@ func TestARNShapes(t *testing.T) {
 		case TypeInstance:
 			assert.True(t, strings.HasPrefix(r.ARN, "arn:aws:ec2:us-east-1:123456789012:instance/"),
 				"unexpected instance ARN: %s", r.ARN)
+		case TypeVolume:
+			// Each launched instance materializes a root EBS volume.
+			assert.True(t, strings.HasPrefix(r.ARN, "arn:aws:ec2:us-east-1:123456789012:volume/"),
+				"unexpected volume ARN: %s", r.ARN)
 		case TypeVPC:
 			assert.True(t, strings.HasPrefix(r.ARN, "arn:aws:ec2:us-east-1:123456789012:vpc/"),
 				"unexpected VPC ARN: %s", r.ARN)


### PR DESCRIPTION
## Summary

Makes an AWS EC2 instance own a **real** root EBS volume, and makes terminate honor **DeleteOnTermination** — the biggest realism gap for the compute lifecycle (Terraform `aws_instance.root_block_device`, `terraform destroy`).

### What changed

**Shared boot-disk driver foundation (additive, backward-compatible)** — `services/compute/driver/driver.go`:
- `VolumeInfo.DeleteOnTermination bool` — attachment-scoped auto-delete flag (maps to EC2 DeleteOnTermination / GCP autoDelete / Azure `deleteOption=="Delete"`).
- `InstanceConfig.BlockDeviceMappings []BlockDeviceMapping` (Boot / AutoDelete / Size / Type / DeviceName) — the client-supplied boot/data disk requests carried on create.
- These are the shared fields the upcoming **GCP boot-disk** and **Azure OS-disk** PRs build on. They are zero-value-default and change no method signatures, so Azure/GCP compute compile and behave unchanged (they do not set them yet).

**AWS root/data volume materialization** — `providers/aws/ec2/ec2.go`, `server/aws/ec2/operations.go`:
- `RunInstances` now materializes the root EBS volume (default `/dev/sda1`, 8 GiB, gp3, `DeleteOnTermination=true`) plus any client-supplied `BlockDeviceMapping.N` volumes, attached to the launched instance. Root device name is resolved from the AMI when known.
- `DescribeInstances` and `DescribeVolumes` now report the real per-attachment `DeleteOnTermination` (previously hardcoded false).

**AWS terminate cascade** — `providers/aws/ec2/ec2.go`:
- `TerminateInstances` deletes volumes with `DeleteOnTermination=true` (the root default) and detaches `DeleteOnTermination=false` ones back to `available` — matching real EC2 destroy semantics.

### Real-user tests (real aws-sdk-go-v2 against an in-process server)
`server/aws/ec2/root_volume_cascade_test.go`:
- root volume surfaced by DescribeVolumes + DescribeInstances with DoT=true;
- client root_block_device mapping controls size/type/DoT;
- terminate deletes the root and DoT=true data volumes while a separately-attached DoT=false volume survives as `available`.

### Cascade fix-ups
Because instances now own real root EBS volumes, cost/discovery tests that assumed a volumeless estate were updated to the realistic behavior (a stopped instance still bills for its EBS; discovery enumerates the root volume).

### Gates
`go build ./...`, full `go test ./...`, `gofmt -l` (empty), `golangci-lint` (0 new issues vs development), `coveragegen` (no diff), `go mod tidy` (no diff) — all green. Azure/GCP compute unaffected.