### PR TITLE
feat(gcp-compute): setLabels on disks/images/snapshots + disk createSnapshot

### DIFF
--- a/providers/gcp/compute/gce.go
+++ b/providers/gcp/compute/gce.go
@@ -485,26 +485,22 @@ func (m *Mock) RemoveInstance(ctx context.Context, instanceID string) error {
 // GCP verbs apply to running VMs. set entries are merged into the tag map,
 // remove keys are deleted, and machineType replaces the instance type when
 // non-empty. GCP-specific; reached via a type assertion from the GCE handler.
+//
+// The read-modify-write runs inside memstore.Store.Update (write-locked) and is
+// copy-on-write, so a concurrent DescribeInstances (which ranges the tag map)
+// never races with an in-place mutation.
 func (m *Mock) MutateInstanceGCP(instanceID string, set map[string]string, remove []string, machineType string) error {
-	inst, ok := m.instances.Get(instanceID)
-	if !ok {
+	if !m.instances.Update(instanceID, func(old *instanceData) *instanceData {
+		clone := *old
+		clone.Tags = mergeTags(clone.Tags, set, remove)
+
+		if machineType != "" {
+			clone.InstanceType = machineType
+		}
+
+		return &clone
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
-	}
-
-	if inst.Tags == nil {
-		inst.Tags = make(map[string]string)
-	}
-
-	for k, v := range set {
-		inst.Tags[k] = v
-	}
-
-	for _, k := range remove {
-		delete(inst.Tags, k)
-	}
-
-	if machineType != "" {
-		inst.InstanceType = machineType
 	}
 
 	return nil
@@ -669,56 +665,71 @@ func (m *Mock) DescribeVolumes(_ context.Context, ids []string) ([]driver.Volume
 // GCP forbids shrinking, so the wire handler rejects smaller sizes before this
 // is reached. GCP-specific; reached via a type assertion from the GCE handler.
 func (m *Mock) ResizeVolumeGCP(volumeID string, sizeGb int) error {
-	vol, ok := m.volumes.Get(volumeID)
-	if !ok {
-		return cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)
-	}
+	if !m.volumes.Update(volumeID, func(old *driver.VolumeInfo) *driver.VolumeInfo {
+		clone := *old
+		if sizeGb > clone.Size {
+			clone.Size = sizeGb
+		}
 
-	if sizeGb > vol.Size {
-		vol.Size = sizeGb
+		return &clone
+	}) {
+		return cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)
 	}
 
 	return nil
 }
 
 func (m *Mock) AttachVolume(_ context.Context, volumeID, instanceID, device string) error {
-	vol, ok := m.volumes.Get(volumeID)
-	if !ok {
+	var opErr error
+
+	found := m.volumes.Update(volumeID, func(old *driver.VolumeInfo) *driver.VolumeInfo {
+		if old.State == stateInUse {
+			opErr = cerrors.Newf(cerrors.FailedPrecondition, "disk %q already attached", volumeID)
+			return old
+		}
+
+		if _, ok := m.instances.Get(instanceID); !ok {
+			opErr = cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
+			return old
+		}
+
+		clone := *old
+		clone.State = stateInUse
+		clone.AttachedTo = instanceID
+		clone.Device = device
+
+		return &clone
+	})
+	if !found {
 		return cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)
 	}
 
-	if vol.State == stateInUse {
-		return cerrors.Newf(cerrors.FailedPrecondition, "disk %q already attached", volumeID)
-	}
-
-	if _, ok := m.instances.Get(instanceID); !ok {
-		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
-	}
-
-	vol.State = stateInUse
-	vol.AttachedTo = instanceID
-	vol.Device = device
-
-	return nil
+	return opErr
 }
 
 // DetachVolume detaches a persistent disk. instanceID/device are accepted for
 // driver-interface parity with AWS; GCP detaches by disk id alone.
 func (m *Mock) DetachVolume(_ context.Context, volumeID, _, _ string) error {
-	vol, ok := m.volumes.Get(volumeID)
-	if !ok {
+	var opErr error
+
+	found := m.volumes.Update(volumeID, func(old *driver.VolumeInfo) *driver.VolumeInfo {
+		if old.State != stateInUse {
+			opErr = cerrors.Newf(cerrors.FailedPrecondition, "disk %q is not attached", volumeID)
+			return old
+		}
+
+		clone := *old
+		clone.State = stateAvailable
+		clone.AttachedTo = ""
+		clone.Device = ""
+
+		return &clone
+	})
+	if !found {
 		return cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)
 	}
 
-	if vol.State != "in-use" {
-		return cerrors.Newf(cerrors.FailedPrecondition, "disk %q is not attached", volumeID)
-	}
-
-	vol.State = stateAvailable
-	vol.AttachedTo = ""
-	vol.Device = ""
-
-	return nil
+	return opErr
 }
 
 func (m *Mock) CreateSnapshot(_ context.Context, cfg driver.SnapshotConfig) (*driver.SnapshotInfo, error) {
@@ -780,29 +791,47 @@ func (m *Mock) SetSnapshotLabelsGCP(snapshotID string, set map[string]string, re
 // setStoreLabels replaces the user labels on the store record identified by id:
 // set entries are written and remove keys deleted on the tag map returned by
 // tagsPtr. Returns NotFound (kind names the resource) when no record matches.
+//
+// The read-modify-write runs inside memstore.Store.Update (write-locked) and is
+// copy-on-write: it clones the record and installs a fresh tag map, so a
+// concurrent reader holding the previous pointer never observes an in-place map
+// mutation (which would trip Go's concurrent map access under go test -race).
 func setStoreLabels[T any](
 	store *memstore.Store[*T], id string, tagsPtr func(*T) *map[string]string,
 	set map[string]string, remove []string, kind string,
 ) error {
-	rec, ok := store.Get(id)
-	if !ok {
+	if !store.Update(id, func(old *T) *T {
+		clone := *old
+		tp := tagsPtr(&clone)
+		*tp = mergeTags(*tp, set, remove)
+
+		return &clone
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "%s %q not found", kind, id)
 	}
 
-	tp := tagsPtr(rec)
-	if *tp == nil {
-		*tp = make(map[string]string, len(set))
+	return nil
+}
+
+// mergeTags returns a NEW map: a copy of src with set entries written and remove
+// keys deleted. src is never mutated (copy-on-write), so a reader still holding
+// it is unaffected. The result is always non-nil.
+func mergeTags(src, set map[string]string, remove []string) map[string]string {
+	out := make(map[string]string, len(src)+len(set))
+
+	for k, v := range src {
+		out[k] = v
 	}
 
 	for k, v := range set {
-		(*tp)[k] = v
+		out[k] = v
 	}
 
 	for _, k := range remove {
-		delete(*tp, k)
+		delete(out, k)
 	}
 
-	return nil
+	return out
 }
 
 //nolint:gocritic // hugeParam: cfg mirrors the driver-interface signature.

--- a/providers/gcp/compute/gce.go
+++ b/providers/gcp/compute/gce.go
@@ -754,6 +754,57 @@ func (m *Mock) DescribeSnapshots(_ context.Context, ids []string) ([]driver.Snap
 	return describeResources(m.snapshots, ids), nil
 }
 
+// SetVolumeLabelsGCP replaces a disk's user labels: set entries are written and
+// remove keys deleted on the disk's tag map (internal cloudemu tags are left
+// untouched — the wire layer only passes user labels). GCP-specific; reached via
+// a type assertion from the GCE wire handler for disks.setLabels.
+func (m *Mock) SetVolumeLabelsGCP(volumeID string, set map[string]string, remove []string) error {
+	return setStoreLabels(m.volumes, volumeID, func(v *driver.VolumeInfo) *map[string]string { return &v.Tags },
+		set, remove, "disk")
+}
+
+// SetImageLabelsGCP replaces an image's user labels. GCP-specific; reached via a
+// type assertion from the GCE wire handler for images.setLabels.
+func (m *Mock) SetImageLabelsGCP(imageID string, set map[string]string, remove []string) error {
+	return setStoreLabels(m.images, imageID, func(v *driver.ImageInfo) *map[string]string { return &v.Tags },
+		set, remove, "image")
+}
+
+// SetSnapshotLabelsGCP replaces a snapshot's user labels. GCP-specific; reached
+// via a type assertion from the GCE wire handler for snapshots.setLabels.
+func (m *Mock) SetSnapshotLabelsGCP(snapshotID string, set map[string]string, remove []string) error {
+	return setStoreLabels(m.snapshots, snapshotID, func(v *driver.SnapshotInfo) *map[string]string { return &v.Tags },
+		set, remove, "snapshot")
+}
+
+// setStoreLabels replaces the user labels on the store record identified by id:
+// set entries are written and remove keys deleted on the tag map returned by
+// tagsPtr. Returns NotFound (kind names the resource) when no record matches.
+func setStoreLabels[T any](
+	store *memstore.Store[*T], id string, tagsPtr func(*T) *map[string]string,
+	set map[string]string, remove []string, kind string,
+) error {
+	rec, ok := store.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "%s %q not found", kind, id)
+	}
+
+	tp := tagsPtr(rec)
+	if *tp == nil {
+		*tp = make(map[string]string, len(set))
+	}
+
+	for k, v := range set {
+		(*tp)[k] = v
+	}
+
+	for _, k := range remove {
+		delete(*tp, k)
+	}
+
+	return nil
+}
+
 //nolint:gocritic // hugeParam: cfg mirrors the driver-interface signature.
 func (m *Mock) CreateImage(_ context.Context, cfg driver.ImageConfig) (*driver.ImageInfo, error) {
 	// GCP images are created from a disk, snapshot, or import — not from a

--- a/providers/gcp/compute/mutation_concurrency_test.go
+++ b/providers/gcp/compute/mutation_concurrency_test.go
@@ -1,0 +1,123 @@
+package compute
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+// TestGCPMutatorsConcurrentWithReads hammers the write-locked GCP mutators
+// (disk setLabels, MutateInstanceGCP, ResizeVolumeGCP, AttachVolume/
+// DetachVolume) concurrently with Describe reads that RANGE the tag maps. It
+// must stay clean under `go test -race`: the mutators are copy-on-write inside
+// memstore.Store.Update, so a reader holding a previous record pointer never
+// observes an in-place map mutation. The pre-fix Get-then-naked-mutate tripped
+// Go's concurrent map access — an unrecoverable process crash.
+func TestGCPMutatorsConcurrentWithReads(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	vol, err := m.CreateVolume(ctx, driver.VolumeConfig{
+		Size: 10, AvailabilityZone: "us-central1-a",
+		Tags: map[string]string{"cloudemu:gcpDiskName": "d1", "seed": "x"},
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+
+	insts, err := m.RunInstances(ctx, driver.InstanceConfig{
+		ImageID: "img-1", InstanceType: "n1-standard-1", Tags: map[string]string{"seed": "y"},
+	}, 1)
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	instID := insts[0].ID
+
+	const (
+		workers = 8
+		iters   = 200
+	)
+
+	var wg sync.WaitGroup
+
+	spawn := func(fn func(w int)) {
+		for w := range workers {
+			wg.Add(1)
+
+			go func(w int) {
+				defer wg.Done()
+				fn(w)
+			}(w)
+		}
+	}
+
+	// Disk label writers (copy-on-write replacement of the tag map).
+	spawn(func(w int) {
+		for i := range iters {
+			_ = m.SetVolumeLabelsGCP(vol.ID, map[string]string{"env": strconv.Itoa(w), "k": strconv.Itoa(i)}, nil)
+		}
+	})
+
+	// Instance tag writers.
+	spawn(func(_ int) {
+		for i := range iters {
+			_ = m.MutateInstanceGCP(instID, map[string]string{"lbl": strconv.Itoa(i)}, nil, "")
+		}
+	})
+
+	// Resize + attach/detach churn on the same disk.
+	spawn(func(_ int) {
+		for i := range iters {
+			_ = m.ResizeVolumeGCP(vol.ID, 10+i)
+			_ = m.AttachVolume(ctx, vol.ID, instID, "dev")
+			_ = m.DetachVolume(ctx, vol.ID, "", "")
+		}
+	})
+
+	// Readers that iterate the tag maps and read scalar fields.
+	spawn(func(_ int) {
+		for range iters {
+			vols, _ := m.DescribeVolumes(ctx, nil)
+			for j := range vols {
+				for range vols[j].Tags {
+				}
+
+				_ = vols[j].Size
+				_ = vols[j].State
+			}
+
+			got, _ := m.DescribeInstances(ctx, nil, nil)
+			for j := range got {
+				for range got[j].Tags {
+				}
+			}
+		}
+	})
+
+	wg.Wait()
+
+	// Final state is consistent: the disk survives with its seed label intact
+	// (setLabels only ever added keys here) and a grown size; the instance
+	// remains present.
+	vols, err := m.DescribeVolumes(ctx, []string{vol.ID})
+	if err != nil || len(vols) != 1 {
+		t.Fatalf("DescribeVolumes final: err=%v n=%d", err, len(vols))
+	}
+
+	if vols[0].Tags["seed"] != "x" {
+		t.Errorf("seed label lost: %v", vols[0].Tags)
+	}
+
+	if vols[0].Size < 10 {
+		t.Errorf("final size=%d want >=10", vols[0].Size)
+	}
+
+	got, err := m.DescribeInstances(ctx, []string{instID}, nil)
+	if err != nil || len(got) != 1 {
+		t.Fatalf("DescribeInstances final: err=%v n=%d", err, len(got))
+	}
+}

--- a/server/gcp/compute/disks.go
+++ b/server/gcp/compute/disks.go
@@ -43,6 +43,7 @@ type diskResponse struct {
 	SourceImageID     string            `json:"sourceImageId,omitempty"`
 	Users             []string          `json:"users,omitempty"`
 	Labels            map[string]string `json:"labels,omitempty"`
+	LabelFingerprint  string            `json:"labelFingerprint,omitempty"`
 	CreationTimestamp string            `json:"creationTimestamp,omitempty"`
 }
 
@@ -224,6 +225,125 @@ func (h *Handler) resizeDisk(w http.ResponseWriter, r *http.Request, rp gcprest.
 	gcprest.WriteJSON(w, http.StatusOK, op)
 }
 
+// resourceLabelMutator is the GCP-local capability the GCE Mock implements to
+// replace user labels on disks, images, and snapshots (the setLabels verb).
+// Reached via a type assertion so the shared compute driver stays unchanged.
+type resourceLabelMutator interface {
+	SetVolumeLabelsGCP(id string, set map[string]string, remove []string) error
+	SetImageLabelsGCP(id string, set map[string]string, remove []string) error
+	SetSnapshotLabelsGCP(id string, set map[string]string, remove []string) error
+}
+
+// applyResourceSetLabels enforces the labelFingerprint optimistic-concurrency
+// check (a stale/mismatched fingerprint → 412 conditionNotMet), computes which
+// existing user labels the new set drops, invokes mutate to replace the label
+// set on the underlying resource, and returns a DONE Operation. GCP setLabels
+// REPLACES the label set, so labels absent from body.Labels are removed.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) applyResourceSetLabels(
+	w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath,
+	body setLabelsRequest, currentTags map[string]string, resourceType string,
+	mutate func(set map[string]string, remove []string) error,
+) {
+	if !fingerprintMatches(body.LabelFingerprint, labelFingerprintFor(userLabels(currentTags))) {
+		writeConditionNotMet(w, "labelFingerprint")
+		return
+	}
+
+	var remove []string
+
+	for k := range userLabels(currentTags) {
+		if _, keep := body.Labels[k]; !keep {
+			remove = append(remove, k)
+		}
+	}
+
+	if err := mutate(body.Labels, remove); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := h.ops.RecordDone(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
+		resourceType, rp.ResourceName, "setLabels")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// setDiskLabels handles POST .../zones/{z}/disks/{disk}/setLabels, replacing the
+// disk's user labels under labelFingerprint optimistic-concurrency.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) setDiskLabels(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	var body setLabelsRequest
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	vol, err := findDiskByName(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	labeler, ok := h.compute.(resourceLabelMutator)
+	if !ok {
+		writeNotImplemented(w, "disk setLabels")
+		return
+	}
+
+	h.applyResourceSetLabels(w, r, rp, body, vol.Tags, resourceDisks,
+		func(set map[string]string, remove []string) error {
+			return labeler.SetVolumeLabelsGCP(vol.ID, set, remove)
+		})
+}
+
+// createSnapshotFromDisk handles POST .../zones/{z}/disks/{disk}/createSnapshot:
+// the disk-scoped snapshot verb. The source disk comes from the URL; the body
+// carries the new snapshot's name and labels. The snapshot is global and
+// appears in snapshots.list/get with its sourceDisk set to the disk's self-link.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) createSnapshotFromDisk(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	var req snapshotRequest
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.Name == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "snapshot name required")
+		return
+	}
+
+	vol, err := findDiskByName(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	if _, err := findSnapshotByName(r.Context(), h.compute, req.Name); conflictIfExists(w, err, "snapshot "+req.Name+" already exists") {
+		return
+	}
+
+	sourceDisk := "projects/" + rp.Project + "/zones/" + rp.ScopeName + "/disks/" + rp.ResourceName
+
+	cfg := computedriver.SnapshotConfig{
+		VolumeID:    vol.ID,
+		Description: req.Name,
+		Tags:        mergeSnapshotTags(req.Labels, req.Name, sourceDisk),
+	}
+
+	if _, err := h.compute.CreateSnapshot(r.Context(), cfg); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := h.ops.RecordDone(hostFromRequest(r), rp.Project, gcprest.ScopeZones, rp.ScopeName,
+		"disks", rp.ResourceName, "createSnapshot")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
 // disksScopedList is one zone's bucket in an aggregated disk list.
 type disksScopedList struct {
 	Disks   []diskResponse     `json:"disks,omitempty"`
@@ -335,6 +455,7 @@ func toDiskResponse(vol *computedriver.VolumeInfo, rp gcprest.ResourcePath, host
 		SourceImage:       sourceImage,
 		Users:             users,
 		Labels:            userLabels(vol.Tags),
+		LabelFingerprint:  labelFingerprintFor(userLabels(vol.Tags)),
 		CreationTimestamp: vol.CreatedAt,
 	}
 

--- a/server/gcp/compute/handler.go
+++ b/server/gcp/compute/handler.go
@@ -36,6 +36,10 @@ const (
 	resourceMachineTyp = "machineTypes"
 )
 
+// actionSetLabels is the lowercased setLabels verb, shared by the instance,
+// disk, image, and snapshot POST-action routers.
+const actionSetLabels = "setlabels"
+
 // Handler serves GCP Compute Engine REST requests for instances and zone
 // operations.
 type Handler struct {
@@ -166,6 +170,11 @@ func (h *Handler) serveSnapshotsRoute(w http.ResponseWriter, r *http.Request, rp
 		return
 	}
 
+	if r.Method == http.MethodPost && strings.EqualFold(rp.Action, "setLabels") {
+		h.setSnapshotLabels(w, r, rp)
+		return
+	}
+
 	switch r.Method {
 	case http.MethodGet:
 		h.getSnapshot(w, r, rp)
@@ -188,6 +197,11 @@ func (h *Handler) serveImagesRoute(w http.ResponseWriter, r *http.Request, rp gc
 			writeNotImplemented(w, r.Method+" "+r.URL.Path)
 		}
 
+		return
+	}
+
+	if r.Method == http.MethodPost && strings.EqualFold(rp.Action, "setLabels") {
+		h.setImageLabels(w, r, rp)
 		return
 	}
 
@@ -216,8 +230,8 @@ func (h *Handler) serveDisksRoute(w http.ResponseWriter, r *http.Request, rp gcp
 		return
 	}
 
-	if r.Method == http.MethodPost && strings.EqualFold(rp.Action, "resize") {
-		h.resizeDisk(w, r, rp)
+	if r.Method == http.MethodPost && rp.Action != "" {
+		h.serveDiskAction(w, r, rp)
 		return
 	}
 
@@ -226,6 +240,22 @@ func (h *Handler) serveDisksRoute(w http.ResponseWriter, r *http.Request, rp gcp
 		h.getDisk(w, r, rp)
 	case http.MethodDelete:
 		h.deleteDisk(w, r, rp)
+	default:
+		writeNotImplemented(w, r.Method+" "+r.URL.Path)
+	}
+}
+
+// serveDiskAction routes the POST disk verbs (resize/setLabels/createSnapshot).
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) serveDiskAction(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	switch strings.ToLower(rp.Action) {
+	case "resize":
+		h.resizeDisk(w, r, rp)
+	case actionSetLabels:
+		h.setDiskLabels(w, r, rp)
+	case "createsnapshot":
+		h.createSnapshotFromDisk(w, r, rp)
 	default:
 		writeNotImplemented(w, r.Method+" "+r.URL.Path)
 	}
@@ -290,7 +320,7 @@ func (h *Handler) dispatchInstanceVerb(w http.ResponseWriter, r *http.Request, r
 		h.stopInstance(w, r, rp)
 	case "reset":
 		h.resetInstance(w, r, rp)
-	case "setlabels":
+	case actionSetLabels:
 		h.setLabels(w, r, rp)
 	case "setmetadata":
 		h.setMetadata(w, r, rp)

--- a/server/gcp/compute/images.go
+++ b/server/gcp/compute/images.go
@@ -44,6 +44,7 @@ type imageResponse struct {
 	Family            string            `json:"family,omitempty"`
 	DiskSizeGb        string            `json:"diskSizeGb,omitempty"`
 	Labels            map[string]string `json:"labels,omitempty"`
+	LabelFingerprint  string            `json:"labelFingerprint,omitempty"`
 	CreationTimestamp string            `json:"creationTimestamp,omitempty"`
 }
 
@@ -152,6 +153,34 @@ func (h *Handler) deleteImage(w http.ResponseWriter, r *http.Request, rp gcprest
 	gcprest.WriteJSON(w, http.StatusOK, op)
 }
 
+// setImageLabels handles POST .../global/images/{image}/setLabels, replacing
+// the image's user labels under labelFingerprint optimistic-concurrency.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) setImageLabels(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	var body setLabelsRequest
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	img, err := findImageByName(r.Context(), h.compute, rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	labeler, ok := h.compute.(resourceLabelMutator)
+	if !ok {
+		writeNotImplemented(w, "image setLabels")
+		return
+	}
+
+	h.applyResourceSetLabels(w, r, rp, body, img.Tags, resourceImages,
+		func(set map[string]string, remove []string) error {
+			return labeler.SetImageLabelsGCP(img.ID, set, remove)
+		})
+}
+
 // imageSourceDescription records the source the image was built from so a read
 // reflects it. Falls back to the image name when no source was given (import).
 func imageSourceDescription(req *imageRequest) string {
@@ -201,6 +230,7 @@ func toImageResponse(img *computedriver.ImageInfo, rp gcprest.ResourcePath, host
 		Family:            img.Tags[gcpImageFamilyTag],
 		DiskSizeGb:        img.Tags[gcpImageDiskSizeGbTag],
 		Labels:            userLabels(img.Tags),
+		LabelFingerprint:  labelFingerprintFor(userLabels(img.Tags)),
 		CreationTimestamp: img.CreatedAt,
 	}
 

--- a/server/gcp/compute/setlabels_createsnapshot_sdk_test.go
+++ b/server/gcp/compute/setlabels_createsnapshot_sdk_test.go
@@ -1,0 +1,302 @@
+package compute_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/compute/apiv1/computepb"
+)
+
+// TestSDKDiskSetLabels proves disks.setLabels REPLACES the disk's label set
+// (a dropped key disappears) under labelFingerprint optimistic-concurrency,
+// using a real cloud.google.com/go DisksClient.
+func TestSDKDiskSetLabels(t *testing.T) {
+	ts := newGCPServer(t)
+	disks := newDisksSDKClient(t, ts)
+	ctx := context.Background()
+
+	insertDisk(t, disks, &computepb.Disk{
+		Name:   ptrStr("lbl-disk"),
+		SizeGb: ptrInt64(16),
+		Labels: map[string]string{"env": "prod", "team": "core"},
+	})
+
+	got, err := disks.Get(ctx, &computepb.GetDiskRequest{Project: testProject, Zone: testZone, Disk: "lbl-disk"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	// Replace the label set: keep env (new value), drop team, add owner.
+	setOp, err := disks.SetLabels(ctx, &computepb.SetLabelsDiskRequest{
+		Project: testProject, Zone: testZone, Resource: "lbl-disk",
+		ZoneSetLabelsRequestResource: &computepb.ZoneSetLabelsRequest{
+			LabelFingerprint: ptrStr(got.GetLabelFingerprint()),
+			Labels:           map[string]string{"env": "staging", "owner": "nitin"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SetLabels: %v", err)
+	}
+
+	if err := setOp.Wait(ctx); err != nil {
+		t.Fatalf("SetLabels wait: %v", err)
+	}
+
+	after, err := disks.Get(ctx, &computepb.GetDiskRequest{Project: testProject, Zone: testZone, Disk: "lbl-disk"})
+	if err != nil {
+		t.Fatalf("Get after SetLabels: %v", err)
+	}
+
+	labels := after.GetLabels()
+	if labels["env"] != "staging" || labels["owner"] != "nitin" {
+		t.Errorf("labels=%v want env=staging owner=nitin", labels)
+	}
+
+	if _, dropped := labels["team"]; dropped {
+		t.Errorf("labels=%v: team should have been replaced away (setLabels replaces the set)", labels)
+	}
+
+	if after.GetLabelFingerprint() == got.GetLabelFingerprint() {
+		t.Error("labelFingerprint did not change after replacing labels")
+	}
+}
+
+// TestSDKDiskSetLabelsStaleFingerprint proves a wrong labelFingerprint loses the
+// optimistic-concurrency check with a 412 conditionNotMet.
+func TestSDKDiskSetLabelsStaleFingerprint(t *testing.T) {
+	ts := newGCPServer(t)
+	disks := newDisksSDKClient(t, ts)
+	ctx := context.Background()
+
+	insertDisk(t, disks, &computepb.Disk{
+		Name:   ptrStr("stale-disk"),
+		SizeGb: ptrInt64(16),
+		Labels: map[string]string{"env": "prod"},
+	})
+
+	_, err := disks.SetLabels(ctx, &computepb.SetLabelsDiskRequest{
+		Project: testProject, Zone: testZone, Resource: "stale-disk",
+		ZoneSetLabelsRequestResource: &computepb.ZoneSetLabelsRequest{
+			LabelFingerprint: ptrStr("bogus-stale-fingerprint"),
+			Labels:           map[string]string{"env": "staging"},
+		},
+	})
+	if err == nil {
+		t.Fatal("SetLabels with stale fingerprint succeeded, want 412 conditionNotMet")
+	}
+
+	if !strings.Contains(err.Error(), "412") && !strings.Contains(err.Error(), "conditionNotMet") {
+		t.Errorf("SetLabels error = %v, want 412/conditionNotMet", err)
+	}
+}
+
+// TestSDKDiskSetLabelsNotFound proves setLabels on a missing disk is a 404.
+func TestSDKDiskSetLabelsNotFound(t *testing.T) {
+	ts := newGCPServer(t)
+	disks := newDisksSDKClient(t, ts)
+	ctx := context.Background()
+
+	_, err := disks.SetLabels(ctx, &computepb.SetLabelsDiskRequest{
+		Project: testProject, Zone: testZone, Resource: "ghost-disk",
+		ZoneSetLabelsRequestResource: &computepb.ZoneSetLabelsRequest{
+			Labels: map[string]string{"env": "staging"},
+		},
+	})
+	if err == nil {
+		t.Fatal("SetLabels on missing disk succeeded, want 404")
+	}
+
+	if !strings.Contains(err.Error(), "404") && !strings.Contains(err.Error(), "not found") {
+		t.Errorf("SetLabels error = %v, want 404/not found", err)
+	}
+}
+
+// TestSDKImageSetLabels proves images.setLabels replaces the image's label set.
+func TestSDKImageSetLabels(t *testing.T) {
+	ts := newGCPServer(t)
+	disks := newDisksSDKClient(t, ts)
+	images := newImagesSDKClient(t, ts)
+	ctx := context.Background()
+
+	insertDisk(t, disks, &computepb.Disk{Name: ptrStr("img-src-disk"), SizeGb: ptrInt64(20)})
+
+	imgOp, err := images.Insert(ctx, &computepb.InsertImageRequest{
+		Project: testProject,
+		ImageResource: &computepb.Image{
+			Name:       ptrStr("lbl-image"),
+			SourceDisk: ptrStr("projects/" + testProject + "/zones/" + testZone + "/disks/img-src-disk"),
+			Labels:     map[string]string{"env": "prod", "team": "core"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("image Insert: %v", err)
+	}
+
+	if err := imgOp.Wait(ctx); err != nil {
+		t.Fatalf("image Insert wait: %v", err)
+	}
+
+	got, err := images.Get(ctx, &computepb.GetImageRequest{Project: testProject, Image: "lbl-image"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	setOp, err := images.SetLabels(ctx, &computepb.SetLabelsImageRequest{
+		Project: testProject, Resource: "lbl-image",
+		GlobalSetLabelsRequestResource: &computepb.GlobalSetLabelsRequest{
+			LabelFingerprint: ptrStr(got.GetLabelFingerprint()),
+			Labels:           map[string]string{"env": "staging"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SetLabels: %v", err)
+	}
+
+	if err := setOp.Wait(ctx); err != nil {
+		t.Fatalf("SetLabels wait: %v", err)
+	}
+
+	after, err := images.Get(ctx, &computepb.GetImageRequest{Project: testProject, Image: "lbl-image"})
+	if err != nil {
+		t.Fatalf("Get after SetLabels: %v", err)
+	}
+
+	labels := after.GetLabels()
+	if labels["env"] != "staging" {
+		t.Errorf("labels=%v want env=staging", labels)
+	}
+
+	if _, dropped := labels["team"]; dropped {
+		t.Errorf("labels=%v: team should have been replaced away", labels)
+	}
+}
+
+// TestSDKSnapshotSetLabels proves snapshots.setLabels replaces the label set.
+func TestSDKSnapshotSetLabels(t *testing.T) {
+	ts := newGCPServer(t)
+	disks := newDisksSDKClient(t, ts)
+	snaps := newSnapshotsSDKClient(t, ts)
+	ctx := context.Background()
+
+	insertDisk(t, disks, &computepb.Disk{Name: ptrStr("snap-lbl-src"), SizeGb: ptrInt64(24)})
+
+	snapOp, err := snaps.Insert(ctx, &computepb.InsertSnapshotRequest{
+		Project: testProject,
+		SnapshotResource: &computepb.Snapshot{
+			Name:       ptrStr("lbl-snap"),
+			SourceDisk: ptrStr("projects/" + testProject + "/zones/" + testZone + "/disks/snap-lbl-src"),
+			Labels:     map[string]string{"env": "prod", "team": "core"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("snapshot Insert: %v", err)
+	}
+
+	if err := snapOp.Wait(ctx); err != nil {
+		t.Fatalf("snapshot Insert wait: %v", err)
+	}
+
+	got, err := snaps.Get(ctx, &computepb.GetSnapshotRequest{Project: testProject, Snapshot: "lbl-snap"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	setOp, err := snaps.SetLabels(ctx, &computepb.SetLabelsSnapshotRequest{
+		Project: testProject, Resource: "lbl-snap",
+		GlobalSetLabelsRequestResource: &computepb.GlobalSetLabelsRequest{
+			LabelFingerprint: ptrStr(got.GetLabelFingerprint()),
+			Labels:           map[string]string{"env": "staging"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SetLabels: %v", err)
+	}
+
+	if err := setOp.Wait(ctx); err != nil {
+		t.Fatalf("SetLabels wait: %v", err)
+	}
+
+	after, err := snaps.Get(ctx, &computepb.GetSnapshotRequest{Project: testProject, Snapshot: "lbl-snap"})
+	if err != nil {
+		t.Fatalf("Get after SetLabels: %v", err)
+	}
+
+	labels := after.GetLabels()
+	if labels["env"] != "staging" {
+		t.Errorf("labels=%v want env=staging", labels)
+	}
+
+	if _, dropped := labels["team"]; dropped {
+		t.Errorf("labels=%v: team should have been replaced away", labels)
+	}
+}
+
+// TestSDKDiskCreateSnapshot proves the disk-scoped createSnapshot verb produces
+// a global snapshot whose sourceDisk points at the disk and whose labels match
+// the create request, visible through snapshots.get.
+func TestSDKDiskCreateSnapshot(t *testing.T) {
+	ts := newGCPServer(t)
+	disks := newDisksSDKClient(t, ts)
+	snaps := newSnapshotsSDKClient(t, ts)
+	ctx := context.Background()
+
+	insertDisk(t, disks, &computepb.Disk{Name: ptrStr("cs-disk"), SizeGb: ptrInt64(50)})
+
+	const wantSource = "projects/" + testProject + "/zones/" + testZone + "/disks/cs-disk"
+
+	csOp, err := disks.CreateSnapshot(ctx, &computepb.CreateSnapshotDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "cs-disk",
+		SnapshotResource: &computepb.Snapshot{
+			Name:   ptrStr("cs-snap"),
+			Labels: map[string]string{"purpose": "backup"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	if err := csOp.Wait(ctx); err != nil {
+		t.Fatalf("CreateSnapshot wait: %v", err)
+	}
+
+	got, err := snaps.Get(ctx, &computepb.GetSnapshotRequest{Project: testProject, Snapshot: "cs-snap"})
+	if err != nil {
+		t.Fatalf("Get: %v (disk-scoped snapshot should be visible in snapshots.get)", err)
+	}
+
+	if got.GetName() != "cs-snap" {
+		t.Errorf("name=%q want cs-snap", got.GetName())
+	}
+
+	if got.GetSourceDisk() != wantSource {
+		t.Errorf("sourceDisk=%q want %q", got.GetSourceDisk(), wantSource)
+	}
+
+	if got.GetDiskSizeGb() != 50 {
+		t.Errorf("diskSizeGb=%d want 50 (inherited from source disk)", got.GetDiskSizeGb())
+	}
+
+	if got.GetLabels()["purpose"] != "backup" {
+		t.Errorf("labels=%v want purpose=backup", got.GetLabels())
+	}
+}
+
+// TestSDKDiskCreateSnapshotNotFound proves createSnapshot on a missing disk is a 404.
+func TestSDKDiskCreateSnapshotNotFound(t *testing.T) {
+	ts := newGCPServer(t)
+	disks := newDisksSDKClient(t, ts)
+	ctx := context.Background()
+
+	_, err := disks.CreateSnapshot(ctx, &computepb.CreateSnapshotDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "ghost-disk",
+		SnapshotResource: &computepb.Snapshot{Name: ptrStr("ghost-snap")},
+	})
+	if err == nil {
+		t.Fatal("CreateSnapshot on missing disk succeeded, want 404")
+	}
+
+	if !strings.Contains(err.Error(), "404") && !strings.Contains(err.Error(), "not found") {
+		t.Errorf("CreateSnapshot error = %v, want 404/not found", err)
+	}
+}

--- a/server/gcp/compute/snapshots.go
+++ b/server/gcp/compute/snapshots.go
@@ -36,6 +36,7 @@ type snapshotResponse struct {
 	Status            string            `json:"status"`
 	SelfLink          string            `json:"selfLink"`
 	Labels            map[string]string `json:"labels,omitempty"`
+	LabelFingerprint  string            `json:"labelFingerprint,omitempty"`
 	CreationTimestamp string            `json:"creationTimestamp,omitempty"`
 }
 
@@ -146,6 +147,35 @@ func (h *Handler) deleteSnapshot(w http.ResponseWriter, r *http.Request, rp gcpr
 	gcprest.WriteJSON(w, http.StatusOK, op)
 }
 
+// setSnapshotLabels handles POST .../global/snapshots/{snapshot}/setLabels,
+// replacing the snapshot's user labels under labelFingerprint optimistic-
+// concurrency.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) setSnapshotLabels(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	var body setLabelsRequest
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	snap, err := findSnapshotByName(r.Context(), h.compute, rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	labeler, ok := h.compute.(resourceLabelMutator)
+	if !ok {
+		writeNotImplemented(w, "snapshot setLabels")
+		return
+	}
+
+	h.applyResourceSetLabels(w, r, rp, body, snap.Tags, resourceSnapshots,
+		func(set map[string]string, remove []string) error {
+			return labeler.SetSnapshotLabelsGCP(snap.ID, set, remove)
+		})
+}
+
 func findSnapshotByName(ctx context.Context, c computedriver.Compute, name string) (*computedriver.SnapshotInfo, error) {
 	snaps, err := c.DescribeSnapshots(ctx, nil)
 	if err != nil {
@@ -209,6 +239,7 @@ func toSnapshotResponse(snap *computedriver.SnapshotInfo, rp gcprest.ResourcePat
 		Status:            "READY",
 		SelfLink:          gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "snapshots", name),
 		Labels:            userLabels(snap.Tags),
+		LabelFingerprint:  labelFingerprintFor(userLabels(snap.Tags)),
 		CreationTimestamp: snap.CreatedAt,
 	}
 


### PR DESCRIPTION
## Summary

Adds the missing GCP Compute label + snapshot verbs identified in the world-case compute pass (GCP smaller-gaps section):

- `POST .../zones/{z}/disks/{disk}/setLabels`
- `POST .../global/images/{image}/setLabels`
- `POST .../global/snapshots/{snapshot}/setLabels`
- `POST .../zones/{z}/disks/{disk}/createSnapshot` (disk-scoped snapshot creation)

## Behavior

- **setLabels** takes `{labels, labelFingerprint}` and REPLACES the label set (keys absent from the new set are dropped), matching real GCP. Guarded by `labelFingerprint` optimistic concurrency — a stale/mismatched fingerprint returns 412 conditionNotMet. setLabels on a missing resource returns 404.
- Disk/image/snapshot GET now returns `labelFingerprint` (previously omitted), so SDK clients can round-trip the fingerprint into setLabels.
- **disks.createSnapshot** creates a global snapshot from the disk named in the URL, linking `sourceDisk` and carrying the request's `name`/`labels`; the snapshot shows up in `snapshots.list`/`get` and inherits the disk's size. createSnapshot on a missing disk returns 404.

## Architecture fit

- Implemented entirely within the GCP provider and GCP wire handlers. The shared `services/compute/driver/` package is NOT touched.
- Label mutation is a GCP-local optional capability (`SetVolumeLabelsGCP` / `SetImageLabelsGCP` / `SetSnapshotLabelsGCP` on the GCE Mock), reached from the wire layer via a type assertion — the same pattern as the existing `MutateInstanceGCP` / `ResizeVolumeGCP` capabilities.
- Mutations return already-DONE Operations, consistent with every other GCP compute mutation.

## Tests

New real-SDK tests (`cloud.google.com/go/compute`) covering disk/image/snapshot setLabels replace semantics, stale-fingerprint 412, missing-resource 404, and disk-scoped createSnapshot (sourceDisk + labels + inherited size, plus missing-disk 404).