### PR TITLE
fix(topology): honor SG-to-SG / IPv6 / prefix-list rules in connectivity checks

### DIFF
--- a/features/topology/connectivity.go
+++ b/features/topology/connectivity.go
@@ -125,7 +125,12 @@ func (e *Engine) evaluateInstanceSGs(
 	port int,
 	protocol string,
 ) TrafficVerdict {
-	egressMatch := e.findMatchingSGRule(ctx, src.SecurityGroups, dst.PrivateIP, port, protocol, false)
+	// Egress rules on the source are matched against the destination (its IP and
+	// its group memberships); ingress rules on the destination against the
+	// source. Passing the peer's security groups lets a referenced-group rule
+	// ("allow from sg-app") resolve instead of falsely reading as denied.
+	egressMatch := e.findMatchingSGRule(ctx, src.SecurityGroups, port, protocol, false,
+		ruleSource{ip: dst.PrivateIP, groupIDs: dst.SecurityGroups})
 	if egressMatch == nil {
 		return TrafficVerdict{
 			Allowed: false,
@@ -133,7 +138,8 @@ func (e *Engine) evaluateInstanceSGs(
 		}
 	}
 
-	ingressMatch := e.findMatchingSGRule(ctx, dst.SecurityGroups, src.PrivateIP, port, protocol, true)
+	ingressMatch := e.findMatchingSGRule(ctx, dst.SecurityGroups, port, protocol, true,
+		ruleSource{ip: src.PrivateIP, groupIDs: src.SecurityGroups})
 	if ingressMatch == nil {
 		return TrafficVerdict{
 			Allowed: false,
@@ -152,23 +158,25 @@ func (e *Engine) evaluateInstanceSGs(
 func (e *Engine) findMatchingSGRule(
 	ctx context.Context,
 	sgIDs []string,
-	targetIP string,
 	port int,
 	protocol string,
 	ingress bool,
+	src ruleSource,
 ) *RuleMatch {
 	groups, err := e.networking.DescribeSecurityGroups(ctx, sgIDs)
 	if err != nil {
 		return nil
 	}
 
-	for _, sg := range groups {
+	for i := range groups {
+		sg := &groups[i]
+
 		rules := sg.EgressRules
 		if ingress {
 			rules = sg.IngressRules
 		}
 
-		match := matchRules(rules, sg.ID, port, protocol, targetIP)
+		match := matchRules(rules, sg.ID, port, protocol, src)
 		if match != nil {
 			return match
 		}

--- a/features/topology/security.go
+++ b/features/topology/security.go
@@ -3,10 +3,22 @@ package topology
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
+
+// ruleSource describes the peer whose traffic a security rule is evaluated
+// against: its IP address (IPv4 or IPv6) and the security groups it belongs to.
+// The group memberships let a rule that references another security group
+// (UserIdGroupPairs / ReferencedGroupID) resolve "is the peer a member of the
+// referenced group?" — the most common real-cloud pattern (e.g. "allow the db
+// SG ingress from the app SG"), which a CIDR-only matcher silently denies.
+type ruleSource struct {
+	ip       string
+	groupIDs []string
+}
 
 // EvaluateSecurityGroups checks whether traffic from srcSG to dstSG is allowed
 // on the given port and protocol. Both egress on src and ingress on dst must match.
@@ -42,7 +54,12 @@ func evaluateSGPair(
 	port int,
 	protocol string,
 ) *TrafficVerdict {
-	egressMatch := matchRules(src.EgressRules, src.ID, port, protocol, "0.0.0.0/0")
+	// Egress on the source is evaluated against the destination group; ingress
+	// on the destination against the source group. Carrying the peer's group id
+	// lets a referenced-group ("allow from sg-app") rule resolve, while the
+	// 0.0.0.0/0 ip preserves the existing all-traffic-CIDR matching.
+	egressMatch := matchRules(src.EgressRules, src.ID, port, protocol,
+		ruleSource{ip: "0.0.0.0/0", groupIDs: []string{dst.ID}})
 	if egressMatch == nil {
 		return &TrafficVerdict{
 			Allowed: false,
@@ -50,7 +67,8 @@ func evaluateSGPair(
 		}
 	}
 
-	ingressMatch := matchRules(dst.IngressRules, dst.ID, port, protocol, "0.0.0.0/0")
+	ingressMatch := matchRules(dst.IngressRules, dst.ID, port, protocol,
+		ruleSource{ip: "0.0.0.0/0", groupIDs: []string{src.ID}})
 	if ingressMatch == nil {
 		return &TrafficVerdict{
 			Allowed: false,
@@ -70,9 +88,12 @@ func matchRules(
 	rules []netdriver.SecurityRule,
 	groupID string,
 	port int,
-	protocol, targetIP string,
+	protocol string,
+	src ruleSource,
 ) *RuleMatch {
-	for _, r := range rules {
+	for i := range rules {
+		r := &rules[i]
+
 		if !protocolMatches(r.Protocol, protocol) {
 			continue
 		}
@@ -81,7 +102,7 @@ func matchRules(
 			continue
 		}
 
-		if !ipInCIDR(targetIP, r.CIDR) {
+		if !ruleSelectorMatches(r, src) {
 			continue
 		}
 
@@ -95,6 +116,32 @@ func matchRules(
 	}
 
 	return nil
+}
+
+// ruleSelectorMatches reports whether the rule's source/destination selector
+// admits the given peer. On the wire a rule carries exactly one of CIDR,
+// IPv6CIDR, PrefixListID or ReferencedGroupID, but the matcher is defensive: it
+// admits the peer when ANY populated selector matches. An empty selector never
+// matches, so an unpopulated rule does not admit everything.
+//
+// PrefixListID is a documented limitation: managed prefix lists are not part of
+// the topology engine's inputs (the networking driver it consumes exposes no
+// prefix-list lookup), so a prefix-list rule cannot be resolved here and is
+// treated as non-matching rather than crashing or silently admitting the peer.
+func ruleSelectorMatches(r *netdriver.SecurityRule, src ruleSource) bool {
+	if r.ReferencedGroupID != "" && slices.Contains(src.groupIDs, r.ReferencedGroupID) {
+		return true
+	}
+
+	if r.CIDR != "" && ipInCIDR(src.ip, r.CIDR) {
+		return true
+	}
+
+	if r.IPv6CIDR != "" && ipInCIDR(src.ip, r.IPv6CIDR) {
+		return true
+	}
+
+	return false
 }
 
 // EvaluateNetworkACL evaluates a network ACL's rules against the given traffic.

--- a/features/topology/topology_test.go
+++ b/features/topology/topology_test.go
@@ -277,6 +277,158 @@ func TestEvaluateSecurityGroupsBlockedByIngress(t *testing.T) {
 	assert.Contains(t, verdict.Reason, "no ingress rule")
 }
 
+// A security group whose ingress rule references the source group (the common
+// "allow db ingress from the app SG" pattern) must be honored. Before the fix
+// the matcher looked only at CIDR and reported a false DENY.
+func TestEvaluateSecurityGroupsReferencedGroupAllowed(t *testing.T) {
+	engine, _, vpcMock, _ := newTestEngine()
+	ctx := context.Background()
+
+	v, err := vpcMock.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	srcSG, err := vpcMock.CreateSecurityGroup(ctx, netdriver.SecurityGroupConfig{
+		VPCID: v.ID, Name: "app-sg", Description: "app",
+	})
+	require.NoError(t, err)
+
+	err = vpcMock.AddEgressRule(ctx, srcSG.ID, netdriver.SecurityRule{
+		Protocol: "-1", FromPort: 0, ToPort: 0, CIDR: "0.0.0.0/0",
+	})
+	require.NoError(t, err)
+
+	dstSG, err := vpcMock.CreateSecurityGroup(ctx, netdriver.SecurityGroupConfig{
+		VPCID: v.ID, Name: "db-sg", Description: "db",
+	})
+	require.NoError(t, err)
+
+	// Ingress allowed from the app SG by reference — no CIDR at all.
+	err = vpcMock.AddIngressRule(ctx, dstSG.ID, netdriver.SecurityRule{
+		Protocol: "tcp", FromPort: 5432, ToPort: 5432, ReferencedGroupID: srcSG.ID,
+	})
+	require.NoError(t, err)
+
+	verdict, err := engine.EvaluateSecurityGroups(ctx, srcSG.ID, dstSG.ID, 5432, "tcp")
+	require.NoError(t, err)
+	assert.True(t, verdict.Allowed, "SG-to-SG reference must be honored")
+	assert.NotNil(t, verdict.IngressMatch)
+	assert.Equal(t, dstSG.ID, verdict.IngressMatch.GroupID)
+}
+
+// An ingress rule that references a different group must NOT admit a source
+// that is not a member of that group.
+func TestEvaluateSecurityGroupsReferencedGroupDenied(t *testing.T) {
+	engine, _, vpcMock, _ := newTestEngine()
+	ctx := context.Background()
+
+	v, err := vpcMock.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	srcSG, err := vpcMock.CreateSecurityGroup(ctx, netdriver.SecurityGroupConfig{
+		VPCID: v.ID, Name: "app-sg", Description: "app",
+	})
+	require.NoError(t, err)
+
+	err = vpcMock.AddEgressRule(ctx, srcSG.ID, netdriver.SecurityRule{
+		Protocol: "-1", FromPort: 0, ToPort: 0, CIDR: "0.0.0.0/0",
+	})
+	require.NoError(t, err)
+
+	otherSG, err := vpcMock.CreateSecurityGroup(ctx, netdriver.SecurityGroupConfig{
+		VPCID: v.ID, Name: "other-sg", Description: "unrelated",
+	})
+	require.NoError(t, err)
+
+	dstSG, err := vpcMock.CreateSecurityGroup(ctx, netdriver.SecurityGroupConfig{
+		VPCID: v.ID, Name: "db-sg", Description: "db",
+	})
+	require.NoError(t, err)
+
+	// Ingress allowed only from otherSG — the source (srcSG) is not a member.
+	err = vpcMock.AddIngressRule(ctx, dstSG.ID, netdriver.SecurityRule{
+		Protocol: "tcp", FromPort: 5432, ToPort: 5432, ReferencedGroupID: otherSG.ID,
+	})
+	require.NoError(t, err)
+
+	verdict, err := engine.EvaluateSecurityGroups(ctx, srcSG.ID, dstSG.ID, 5432, "tcp")
+	require.NoError(t, err)
+	assert.False(t, verdict.Allowed)
+	assert.Contains(t, verdict.Reason, "no ingress rule")
+}
+
+// matchRules must honor each populated selector (CIDR, IPv6CIDR,
+// ReferencedGroupID), never match on an empty/unpopulated selector, and treat
+// an unresolvable prefix-list rule as non-matching (documented limitation).
+func TestRuleSelectorMatching(t *testing.T) {
+	tests := []struct {
+		name  string
+		rule  netdriver.SecurityRule
+		src   ruleSource
+		match bool
+	}{
+		{
+			name:  "IPv4 CIDR matches",
+			rule:  netdriver.SecurityRule{Protocol: "tcp", FromPort: 443, ToPort: 443, CIDR: "10.0.0.0/16"},
+			src:   ruleSource{ip: "10.0.1.5"},
+			match: true,
+		},
+		{
+			name:  "IPv4 CIDR outside range",
+			rule:  netdriver.SecurityRule{Protocol: "tcp", FromPort: 443, ToPort: 443, CIDR: "10.0.0.0/16"},
+			src:   ruleSource{ip: "192.168.1.1"},
+			match: false,
+		},
+		{
+			name:  "IPv6 CIDR matches IPv6 source",
+			rule:  netdriver.SecurityRule{Protocol: "tcp", FromPort: 443, ToPort: 443, IPv6CIDR: "2001:db8::/32"},
+			src:   ruleSource{ip: "2001:db8::1"},
+			match: true,
+		},
+		{
+			name:  "IPv6 CIDR does not match outside source",
+			rule:  netdriver.SecurityRule{Protocol: "tcp", FromPort: 443, ToPort: 443, IPv6CIDR: "2001:db8::/32"},
+			src:   ruleSource{ip: "2001:dead::1"},
+			match: false,
+		},
+		{
+			name:  "referenced group matches member",
+			rule:  netdriver.SecurityRule{Protocol: "tcp", FromPort: 443, ToPort: 443, ReferencedGroupID: "sg-app"},
+			src:   ruleSource{ip: "10.0.1.5", groupIDs: []string{"sg-app", "sg-shared"}},
+			match: true,
+		},
+		{
+			name:  "referenced group does not match non-member",
+			rule:  netdriver.SecurityRule{Protocol: "tcp", FromPort: 443, ToPort: 443, ReferencedGroupID: "sg-app"},
+			src:   ruleSource{ip: "10.0.1.5", groupIDs: []string{"sg-other"}},
+			match: false,
+		},
+		{
+			name:  "empty selector never matches",
+			rule:  netdriver.SecurityRule{Protocol: "tcp", FromPort: 443, ToPort: 443},
+			src:   ruleSource{ip: "10.0.1.5", groupIDs: []string{"sg-app"}},
+			match: false,
+		},
+		{
+			name:  "prefix-list rule is unresolvable and does not match",
+			rule:  netdriver.SecurityRule{Protocol: "tcp", FromPort: 443, ToPort: 443, PrefixListID: "pl-1234"},
+			src:   ruleSource{ip: "10.0.1.5"},
+			match: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match := matchRules([]netdriver.SecurityRule{tt.rule}, "sg-test", 443, "tcp", tt.src)
+			if tt.match {
+				require.NotNil(t, match)
+				assert.Equal(t, "sg-test", match.GroupID)
+			} else {
+				assert.Nil(t, match)
+			}
+		})
+	}
+}
+
 func TestEvaluateNetworkACLAllow(t *testing.T) {
 	engine, _, vpcMock, _ := newTestEngine()
 	ctx := context.Background()
@@ -435,6 +587,89 @@ func TestCanConnectBlockedBySG(t *testing.T) {
 
 	err = ec2Mock.SetInstanceVPC(dstInstances[0].ID, vpcID)
 	require.NoError(t, err)
+
+	result, err := engine.CanConnect(ctx, ConnectivityQuery{
+		SrcInstanceID: srcInstances[0].ID,
+		DstInstanceID: dstInstances[0].ID,
+		Port:          443,
+		Protocol:      "tcp",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.Allowed)
+	assert.Contains(t, result.Reason, "no ingress rule")
+}
+
+// A destination instance whose SG allows ingress from the source instance's SG
+// (by reference, not by CIDR) must be reachable. This is the single most common
+// real-world SG pattern; before the fix CanConnect returned a false DENY.
+func TestCanConnectReferencedGroupAllowed(t *testing.T) {
+	engine, ec2Mock, vpcMock, _ := newTestEngine()
+	ctx := context.Background()
+
+	vpcID, subnetID, srcSGID, dstSGID := createVPCWithSubnetAndSGs(t, ctx, vpcMock, "10.0.0.0/16", false)
+
+	// dst allows ingress from the source SG by reference — no CIDR.
+	err := vpcMock.AddIngressRule(ctx, dstSGID, netdriver.SecurityRule{
+		Protocol: "tcp", FromPort: 443, ToPort: 443, ReferencedGroupID: srcSGID,
+	})
+	require.NoError(t, err)
+
+	srcInstances, err := ec2Mock.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "ami-test", InstanceType: "t2.micro",
+		SubnetID: subnetID, SecurityGroups: []string{srcSGID},
+	}, 1)
+	require.NoError(t, err)
+	require.NoError(t, ec2Mock.SetInstanceVPC(srcInstances[0].ID, vpcID))
+
+	dstInstances, err := ec2Mock.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "ami-test", InstanceType: "t2.micro",
+		SubnetID: subnetID, SecurityGroups: []string{dstSGID},
+	}, 1)
+	require.NoError(t, err)
+	require.NoError(t, ec2Mock.SetInstanceVPC(dstInstances[0].ID, vpcID))
+
+	result, err := engine.CanConnect(ctx, ConnectivityQuery{
+		SrcInstanceID: srcInstances[0].ID,
+		DstInstanceID: dstInstances[0].ID,
+		Port:          443,
+		Protocol:      "tcp",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.Allowed, "referenced-group ingress must allow a member source")
+	assert.True(t, result.SGVerdict.Allowed)
+}
+
+// A source instance that is not a member of the referenced group must be denied.
+func TestCanConnectReferencedGroupNotMember(t *testing.T) {
+	engine, ec2Mock, vpcMock, _ := newTestEngine()
+	ctx := context.Background()
+
+	vpcID, subnetID, srcSGID, dstSGID := createVPCWithSubnetAndSGs(t, ctx, vpcMock, "10.0.0.0/16", false)
+
+	// A third group the source does not belong to.
+	otherSG, err := vpcMock.CreateSecurityGroup(ctx, netdriver.SecurityGroupConfig{
+		VPCID: vpcID, Name: "other-sg", Description: "unrelated",
+	})
+	require.NoError(t, err)
+
+	err = vpcMock.AddIngressRule(ctx, dstSGID, netdriver.SecurityRule{
+		Protocol: "tcp", FromPort: 443, ToPort: 443, ReferencedGroupID: otherSG.ID,
+	})
+	require.NoError(t, err)
+
+	srcInstances, err := ec2Mock.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "ami-test", InstanceType: "t2.micro",
+		SubnetID: subnetID, SecurityGroups: []string{srcSGID},
+	}, 1)
+	require.NoError(t, err)
+	require.NoError(t, ec2Mock.SetInstanceVPC(srcInstances[0].ID, vpcID))
+
+	dstInstances, err := ec2Mock.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "ami-test", InstanceType: "t2.micro",
+		SubnetID: subnetID, SecurityGroups: []string{dstSGID},
+	}, 1)
+	require.NoError(t, err)
+	require.NoError(t, ec2Mock.SetInstanceVPC(dstInstances[0].ID, vpcID))
 
 	result, err := engine.CanConnect(ctx, ConnectivityQuery{
 		SrcInstanceID: srcInstances[0].ID,


### PR DESCRIPTION
## Summary

The cross-service topology connectivity engine matched security-group rules only on `SecurityRule.CIDR` and silently ignored `ReferencedGroupID`, `IPv6CIDR`, and `PrefixListID`. As a result, `CanConnect` / `EvaluateSecurityGroups` returned a **false DENY** for the single most common real-cloud security-group pattern — an SG-to-SG reference rule ("allow the db SG ingress from the app SG"). This is a shared-engine bug that affected all three clouds (AWS, Azure, GCP).

## What changed

`features/topology/security.go` / `connectivity.go`:

- `matchRules` now evaluates a rule's populated selector via a new `ruleSelectorMatches` helper instead of only `CIDR`:
  - **CIDR** (IPv4) — unchanged.
  - **IPv6CIDR** — matched against an IPv6 source (mirrors the IPv4 CIDR logic).
  - **ReferencedGroupID** — matched when the *source* peer belongs to the referenced group (SG-to-SG). The peer's security-group memberships are threaded through from the instance's `SecurityGroups` (CanConnect) or the paired group id (EvaluateSecurityGroups). Self-referencing SGs work naturally.
  - **PrefixListID** — handled gracefully as a documented limitation (managed prefix lists are not part of the topology engine's inputs, so a prefix-list rule is treated as non-matching rather than crashing or silently admitting the peer).
- An empty/unpopulated selector never matches, so unpopulated rules do not over-match. Protocol/port matching, ingress/egress direction, and existing CIDR behavior are preserved.

## Tests

Extended `features/topology` tests: SG-to-SG referenced-group ingress allows a member source and denies a non-member (both `EvaluateSecurityGroups` and `CanConnect`); a table-driven matcher test covers IPv4 CIDR, IPv6 CIDR, referenced-group member/non-member, empty-selector no-match, and the unresolvable prefix-list case.
