### PR TITLE
fix(aws-elbv2): DeleteListener cascades its rules (no orphan leak)

### DIFF
--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -650,10 +650,24 @@ func cloneActions(actions []driver.RuleAction) []driver.RuleAction {
 	return append([]driver.RuleAction(nil), actions...)
 }
 
-// DeleteListener deletes a listener by ARN.
+// DeleteListener deletes a listener by ARN and, with it, the rules under that
+// listener. Rules are children of the listener in real ELBv2, so deleting the
+// listener removes them; leaving them behind would leak them for the life of
+// the process (their parent listener is gone, so nothing ever reaches them) and
+// DescribeRules on the deleted listener already returns ListenerNotFound. This
+// mirrors the LB→listener→rule cascade in DeleteLoadBalancer.
 func (m *Mock) DeleteListener(_ context.Context, arn string) error {
 	if !m.listeners.Delete(arn) {
 		return errors.Newf(errors.NotFound, "listener %q not found", arn)
+	}
+
+	// Cascade to the listener's rules. Range over a snapshot and delete each key
+	// through the store's own write-locked Delete so the mutation stays atomic
+	// per key (no Get-then-separate-Delete race).
+	for rkey, r := range m.rules.All() {
+		if r.ListenerARN == arn {
+			m.rules.Delete(rkey)
+		}
 	}
 
 	return nil

--- a/providers/aws/elbv2/elb_test.go
+++ b/providers/aws/elbv2/elb_test.go
@@ -211,6 +211,31 @@ func TestDeleteListener(t *testing.T) {
 	assertError(t, m.DeleteListener(ctx, "arn:nope"), true)
 }
 
+func TestDeleteListenerCascadesRules(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	lb := createTestLB(m)
+
+	victim, _ := m.CreateListener(ctx, driver.ListenerConfig{LBARN: lb.ARN, Protocol: "HTTP", Port: 80})
+	survivor, _ := m.CreateListener(ctx, driver.ListenerConfig{LBARN: lb.ARN, Protocol: "HTTPS", Port: 443})
+
+	_, _ = m.CreateRule(ctx, driver.RuleConfig{ListenerARN: victim.ARN, Priority: 10})
+	_, _ = m.CreateRule(ctx, driver.RuleConfig{ListenerARN: victim.ARN, Priority: 20})
+	_, _ = m.CreateRule(ctx, driver.RuleConfig{ListenerARN: survivor.ARN, Priority: 10})
+
+	requireNoError(t, m.DeleteListener(ctx, victim.ARN))
+
+	// The victim's rules are gone with it: DescribeRules on the deleted listener
+	// is ListenerNotFound, so no orphaned rule remains queryable.
+	_, err := m.DescribeRules(ctx, victim.ARN)
+	assertError(t, err, true)
+
+	// The sibling listener's rule is untouched (default rule + the one created).
+	survivorRules, err := m.DescribeRules(ctx, survivor.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(survivorRules))
+}
+
 func TestDescribeListeners(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/server/aws/elbv2/delete_listener_cascade_sdk_test.go
+++ b/server/aws/elbv2/delete_listener_cascade_sdk_test.go
@@ -1,0 +1,147 @@
+package elbv2_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKDeleteListenerCascadesRules proves DeleteListener removes the listener
+// AND the rules under it (rules are children of the listener in real ELBv2), so
+// no orphaned rule leaks. It also proves rules on a sibling listener of the same
+// load balancer are untouched, and that deleting a missing listener is
+// ListenerNotFound.
+func TestSDKDeleteListenerCascadesRules(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbARN, tgARN := setupLBAndTG(t, client, "cascade-alb", "cascade-tg")
+
+	// Two listeners on the same load balancer; only the first is deleted.
+	victimARN := createForwardListener(t, client, lbARN, tgARN, 80)
+	survivorARN := createForwardListener(t, client, lbARN, tgARN, 8080)
+
+	// Two rules under the victim listener, one under the survivor.
+	victimRule1 := createForwardRule(t, client, victimARN, tgARN, 10)
+	victimRule2 := createForwardRule(t, client, victimARN, tgARN, 20)
+	survivorRule := createForwardRule(t, client, survivorARN, tgARN, 10)
+
+	if _, err := client.DeleteListener(ctx, &elb.DeleteListenerInput{
+		ListenerArn: aws.String(victimARN),
+	}); err != nil {
+		t.Fatalf("DeleteListener: %v", err)
+	}
+
+	// The listener is gone from the load balancer's listing.
+	listeners, err := client.DescribeListeners(ctx, &elb.DescribeListenersInput{
+		LoadBalancerArn: aws.String(lbARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeListeners: %v", err)
+	}
+
+	if len(listeners.Listeners) != 1 ||
+		aws.ToString(listeners.Listeners[0].ListenerArn) != survivorARN {
+		t.Fatalf("after delete listeners = %+v, want only the survivor %s",
+			listeners.Listeners, survivorARN)
+	}
+
+	// DescribeRules on the deleted listener is ListenerNotFound — its rules are
+	// not queryable through their (now gone) parent.
+	_, err = client.DescribeRules(ctx, &elb.DescribeRulesInput{
+		ListenerArn: aws.String(victimARN),
+	})
+	assertListenerNotFound(t, err, "DescribeRules on deleted listener")
+
+	// The victim's rules do not leak into the surviving listener's rule listing.
+	survivorRules, err := client.DescribeRules(ctx, &elb.DescribeRulesInput{
+		ListenerArn: aws.String(survivorARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeRules(survivor): %v", err)
+	}
+
+	for _, r := range survivorRules.Rules {
+		arn := aws.ToString(r.RuleArn)
+		if arn == victimRule1 || arn == victimRule2 {
+			t.Fatalf("orphaned rule %s leaked into survivor listener", arn)
+		}
+	}
+
+	// The survivor's own non-default rule is still present.
+	if !rulePresent(survivorRules.Rules, survivorRule) {
+		t.Fatalf("survivor rule %s missing after sibling listener delete", survivorRule)
+	}
+
+	// Deleting a listener that does not exist is ListenerNotFound.
+	_, err = client.DeleteListener(ctx, &elb.DeleteListenerInput{
+		ListenerArn: aws.String(victimARN),
+	})
+	assertListenerNotFound(t, err, "DeleteListener on missing listener")
+}
+
+func createForwardListener(t *testing.T, client *elb.Client, lbARN, tgARN string, port int32) string {
+	t.Helper()
+
+	out, err := client.CreateListener(context.Background(), &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(port),
+		DefaultActions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener(port %d): %v", port, err)
+	}
+
+	return aws.ToString(out.Listeners[0].ListenerArn)
+}
+
+func createForwardRule(t *testing.T, client *elb.Client, listenerARN, tgARN string, priority int32) string {
+	t.Helper()
+
+	out, err := client.CreateRule(context.Background(), &elb.CreateRuleInput{
+		ListenerArn: aws.String(listenerARN),
+		Priority:    aws.Int32(priority),
+		Conditions: []elbtypes.RuleCondition{{
+			Field:  aws.String("path-pattern"),
+			Values: []string{fmt.Sprintf("/p%d/*", priority)},
+		}},
+		Actions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateRule(priority %d): %v", priority, err)
+	}
+
+	return aws.ToString(out.Rules[0].RuleArn)
+}
+
+func rulePresent(rules []elbtypes.Rule, arn string) bool {
+	for _, r := range rules {
+		if aws.ToString(r.RuleArn) == arn {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertListenerNotFound(t *testing.T, err error, where string) {
+	t.Helper()
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ListenerNotFound" {
+		t.Fatalf("%s: err = %v, want ListenerNotFound", where, err)
+	}
+}


### PR DESCRIPTION
## Summary

`DeleteListener` deleted the listener but left its rules in the store, leaking them for the life of the process (the parent listener is gone, so nothing ever reaches them). The `DeleteLoadBalancer` path already cascades LB→listener→rule; `DeleteListener` did not.

## Change

- `providers/aws/elbv2/elb.go`: after deleting the listener, cascade to its rules — range a snapshot and delete each key through the store's write-locked `Delete` (atomic per key, no Get-then-separate-Delete race). Deleting a missing listener still returns ListenerNotFound.

## Behavior

- `DescribeRules` on a deleted listener already returns ListenerNotFound; the rules no longer leak into any listing.
- A sibling listener's rules on the same load balancer are unaffected.

## Tests

- Provider unit test `TestDeleteListenerCascadesRules`.
- Real aws-sdk-go-v2 test `TestSDKDeleteListenerCascadesRules`: LB → 2 listeners → rules; delete one listener; assert its rules are gone, DescribeRules → ListenerNotFound, sibling rules intact, missing-listener delete → ListenerNotFound.