### PR TITLE
feat(gcp-compute): materialize boot disk + autoDelete cascade + unified attachDisk

### DIFF
--- a/providers/gcp/compute/boot_disk_test.go
+++ b/providers/gcp/compute/boot_disk_test.go
@@ -1,0 +1,80 @@
+package compute
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+// TestRemoveInstanceAutoDeleteCascade proves RemoveInstance (GCP instances.delete)
+// deletes a disk attached with DeleteOnTermination=true (autoDelete) and detaches
+// — but keeps — one attached with DeleteOnTermination=false.
+func TestRemoveInstanceAutoDeleteCascade(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	insts, err := m.RunInstances(ctx, driver.InstanceConfig{ImageID: "img-1", InstanceType: "n1-standard-1"}, 1)
+	require.NoError(t, err)
+	instID := insts[0].ID
+
+	boot, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10, AvailabilityZone: "us-central1-a"})
+	require.NoError(t, err)
+
+	data, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 20, AvailabilityZone: "us-central1-a"})
+	require.NoError(t, err)
+
+	require.NoError(t, m.AttachDiskGCP(instID, boot.ID, "boot", true))
+	require.NoError(t, m.AttachDiskGCP(instID, data.ID, "data", false))
+
+	require.NoError(t, m.RemoveInstance(ctx, instID))
+
+	// autoDelete=true disk is gone.
+	gone, err := m.DescribeVolumes(ctx, []string{boot.ID})
+	require.NoError(t, err)
+	assert.Empty(t, gone, "autoDelete=true disk should be deleted with the instance")
+
+	// autoDelete=false disk survives, detached and available.
+	kept, err := m.DescribeVolumes(ctx, []string{data.ID})
+	require.NoError(t, err)
+	require.Len(t, kept, 1)
+	assert.Equal(t, stateAvailable, kept[0].State)
+	assert.Empty(t, kept[0].AttachedTo)
+	assert.False(t, kept[0].DeleteOnTermination)
+}
+
+// TestAttachDiskGCPSetsDeleteOnTermination proves the attach flips the driver
+// volume to in-use and records the autoDelete flag, and that a plain AttachVolume
+// leaves it false.
+func TestAttachDiskGCPSetsDeleteOnTermination(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	insts, err := m.RunInstances(ctx, driver.InstanceConfig{ImageID: "img-1", InstanceType: "n1-standard-1"}, 1)
+	require.NoError(t, err)
+	instID := insts[0].ID
+
+	vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10, AvailabilityZone: "us-central1-a"})
+	require.NoError(t, err)
+
+	require.NoError(t, m.AttachDiskGCP(instID, vol.ID, "data", true))
+
+	got, err := m.DescribeVolumes(ctx, []string{vol.ID})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, stateInUse, got[0].State)
+	assert.Equal(t, instID, got[0].AttachedTo)
+	assert.True(t, got[0].DeleteOnTermination)
+
+	// Detach clears the attachment and the auto-delete flag.
+	require.NoError(t, m.DetachVolume(ctx, vol.ID, "", ""))
+
+	got, err = m.DescribeVolumes(ctx, []string{vol.ID})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, stateAvailable, got[0].State)
+	assert.False(t, got[0].DeleteOnTermination)
+}

--- a/providers/gcp/compute/gce.go
+++ b/providers/gcp/compute/gce.go
@@ -323,10 +323,15 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 			inst.engineBacked = true
 		}
 
-		m.instances.Set(id, inst)
+		// Settle to Running on the record BEFORE publishing it to the store, so a
+		// concurrent reader (e.g. disks.list ranging DescribeInstances) never
+		// observes an in-place field write on the stored pointer. The state machine
+		// is keyed by id, independent of the record pointer.
 		m.sm.SetState(id, compute.StatePending)
 		_ = m.sm.Transition(id, compute.StateRunning)
 		inst.State = compute.StateRunning
+
+		m.instances.Set(id, inst)
 		results = append(results, toInstance(inst))
 		created = append(created, inst)
 		m.emitInstanceMetrics(ctx, id, inst.LaunchTime, tags[gcpZoneTagKey])
@@ -473,10 +478,43 @@ func (m *Mock) RemoveInstance(ctx context.Context, instanceID string) error {
 		return err
 	}
 
+	// Honor GCP's autoDelete cascade: a disk attached with autoDelete=true is
+	// deleted with the instance, one with autoDelete=false is detached and
+	// survives (matching real instances.delete).
+	m.settleInstanceDisks(instanceID)
+
 	m.instances.Delete(instanceID)
 	m.sm.Remove(instanceID)
 
 	return nil
+}
+
+// settleInstanceDisks applies GCP's instance-delete disk cascade to every disk
+// attached to instanceID: a disk with DeleteOnTermination=true (autoDelete) is
+// DELETED, and one with DeleteOnTermination=false is returned to `available`
+// with its attachment cleared. The decision and mutation happen under one store
+// lock (UpdateOrDelete) so a concurrent DetachVolume that clears the attachment
+// first is observed and the disk is not wrongly deleted.
+func (m *Mock) settleInstanceDisks(instanceID string) {
+	for _, volID := range m.volumes.Keys() {
+		m.volumes.UpdateOrDelete(volID, func(v *driver.VolumeInfo) (*driver.VolumeInfo, bool) {
+			if v.AttachedTo != instanceID {
+				return v, true
+			}
+
+			if v.DeleteOnTermination {
+				return v, false
+			}
+
+			cp := *v
+			cp.State = stateAvailable
+			cp.AttachedTo = ""
+			cp.Device = ""
+			cp.DeleteOnTermination = false
+
+			return &cp, true
+		})
+	}
 }
 
 // MutateInstanceGCP applies a GCP-specific instance mutation used by the GCE
@@ -680,6 +718,18 @@ func (m *Mock) ResizeVolumeGCP(volumeID string, sizeGb int) error {
 }
 
 func (m *Mock) AttachVolume(_ context.Context, volumeID, instanceID, device string) error {
+	return m.AttachDiskGCP(instanceID, volumeID, device, false)
+}
+
+// AttachDiskGCP attaches an existing disk to an instance, flipping the driver
+// volume to in-use and recording the attachment-scoped auto-delete flag
+// (GCP autoDelete ⟷ VolumeInfo.DeleteOnTermination). It is the single attach
+// path the GCE wire handler drives for instances.insert boot/data disks and for
+// instances.attachDisk, so a disk's driver state and the instance's disks[] view
+// never diverge. GCP-specific; reached via a type assertion from the GCE handler.
+// The read-modify-write runs inside memstore.Store.Update (write-locked) and is
+// copy-on-write, so a concurrent DescribeVolumes never races the mutation.
+func (m *Mock) AttachDiskGCP(instanceID, volumeID, device string, autoDelete bool) error {
 	var opErr error
 
 	found := m.volumes.Update(volumeID, func(old *driver.VolumeInfo) *driver.VolumeInfo {
@@ -697,6 +747,7 @@ func (m *Mock) AttachVolume(_ context.Context, volumeID, instanceID, device stri
 		clone.State = stateInUse
 		clone.AttachedTo = instanceID
 		clone.Device = device
+		clone.DeleteOnTermination = autoDelete
 
 		return &clone
 	})
@@ -722,6 +773,7 @@ func (m *Mock) DetachVolume(_ context.Context, volumeID, _, _ string) error {
 		clone.State = stateAvailable
 		clone.AttachedTo = ""
 		clone.Device = ""
+		clone.DeleteOnTermination = false
 
 		return &clone
 	})

--- a/server/gcp/compute/boot_disk_sdk_test.go
+++ b/server/gcp/compute/boot_disk_sdk_test.go
@@ -1,0 +1,340 @@
+package compute_test
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/iterator"
+)
+
+// TestSDKInsertMaterializesBootDisk proves instances.insert creates the boot
+// disk as a real Disk resource: disks.get returns it, attached to the instance,
+// with the size / type / sourceImage the initializeParams asked for.
+func TestSDKInsertMaterializesBootDisk(t *testing.T) {
+	client, ts, ctx := newInstancesEnv(t)
+	disks := newDisksSDKClient(t, ts)
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name:        ptrStr("boot-vm"),
+		MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+		Disks: []*computepb.AttachedDisk{{
+			Boot:       ptrBool(true),
+			AutoDelete: ptrBool(true),
+			InitializeParams: &computepb.AttachedDiskInitializeParams{
+				SourceImage: ptrStr("projects/debian-cloud/global/images/family/debian-12"),
+				DiskSizeGb:  ptrInt64(20),
+				DiskType:    ptrStr("zones/" + testZone + "/diskTypes/pd-ssd"),
+			},
+		}},
+	})
+
+	// The boot disk defaults to the instance's name in real GCP.
+	got, err := disks.Get(ctx, &computepb.GetDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "boot-vm",
+	})
+	if err != nil {
+		t.Fatalf("disks.Get(boot-vm): %v", err)
+	}
+
+	if got.GetSizeGb() != 20 {
+		t.Errorf("sizeGb=%d want 20", got.GetSizeGb())
+	}
+
+	if !strings.HasSuffix(got.GetType(), "/diskTypes/pd-ssd") {
+		t.Errorf("type=%q want .../diskTypes/pd-ssd", got.GetType())
+	}
+
+	if !strings.HasSuffix(got.GetSourceImage(), "/family/debian-12") {
+		t.Errorf("sourceImage=%q want .../family/debian-12", got.GetSourceImage())
+	}
+
+	users := got.GetUsers()
+	if len(users) != 1 || !strings.HasSuffix(users[0], "/instances/boot-vm") {
+		t.Errorf("users=%v want one link ending /instances/boot-vm", users)
+	}
+}
+
+// TestSDKInsertMaterializesAdditionalDisk proves a second initializeParams disk
+// in the insert body is materialized alongside the boot disk.
+func TestSDKInsertMaterializesAdditionalDisk(t *testing.T) {
+	client, ts, ctx := newInstancesEnv(t)
+	disks := newDisksSDKClient(t, ts)
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name:        ptrStr("multi-vm"),
+		MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+		Disks: []*computepb.AttachedDisk{
+			{
+				Boot:       ptrBool(true),
+				AutoDelete: ptrBool(true),
+				InitializeParams: &computepb.AttachedDiskInitializeParams{
+					SourceImage: ptrStr("projects/debian-cloud/global/images/family/debian-12"),
+				},
+			},
+			{
+				AutoDelete: ptrBool(true),
+				DeviceName: ptrStr("data"),
+				InitializeParams: &computepb.AttachedDiskInitializeParams{
+					DiskName:   ptrStr("multi-vm-data"),
+					DiskSizeGb: ptrInt64(50),
+				},
+			},
+		},
+	})
+
+	for _, name := range []string{"multi-vm", "multi-vm-data"} {
+		if _, err := disks.Get(ctx, &computepb.GetDiskRequest{
+			Project: testProject, Zone: testZone, Disk: name,
+		}); err != nil {
+			t.Errorf("disks.Get(%s): %v — disk should have materialized", name, err)
+		}
+	}
+}
+
+// TestSDKDeleteHonorsAutoDelete proves instances.delete deletes an autoDelete=true
+// disk (the boot disk) and detaches — but keeps — an autoDelete=false disk.
+func TestSDKDeleteHonorsAutoDelete(t *testing.T) {
+	client, ts, ctx := newInstancesEnv(t)
+	disks := newDisksSDKClient(t, ts)
+
+	insertDisk(t, disks, &computepb.Disk{Name: ptrStr("keep-disk"), SizeGb: ptrInt64(10)})
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name:        ptrStr("cascade-vm"),
+		MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+		Disks: []*computepb.AttachedDisk{{
+			Boot:       ptrBool(true),
+			AutoDelete: ptrBool(true),
+			InitializeParams: &computepb.AttachedDiskInitializeParams{
+				SourceImage: ptrStr("projects/debian-cloud/global/images/family/debian-12"),
+			},
+		}},
+	})
+
+	// Attach keep-disk with autoDelete=false.
+	attachOp, err := client.AttachDisk(ctx, &computepb.AttachDiskInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "cascade-vm",
+		AttachedDiskResource: &computepb.AttachedDisk{
+			DeviceName: ptrStr("keep"),
+			AutoDelete: ptrBool(false),
+			Source:     ptrStr("zones/" + testZone + "/disks/keep-disk"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("AttachDisk: %v", err)
+	}
+
+	if err := attachOp.Wait(ctx); err != nil {
+		t.Fatalf("AttachDisk wait: %v", err)
+	}
+
+	delOp, err := client.Delete(ctx, &computepb.DeleteInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "cascade-vm",
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Fatalf("Delete wait: %v", err)
+	}
+
+	// Boot disk (autoDelete=true) is gone.
+	if _, err := disks.Get(ctx, &computepb.GetDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "cascade-vm",
+	}); err == nil {
+		t.Error("boot disk survived delete, want autoDelete cascade to remove it")
+	}
+
+	// keep-disk (autoDelete=false) survives, detached (no users).
+	kept, err := disks.Get(ctx, &computepb.GetDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "keep-disk",
+	})
+	if err != nil {
+		t.Fatalf("keep-disk should survive: %v", err)
+	}
+
+	if users := kept.GetUsers(); len(users) != 0 {
+		t.Errorf("keep-disk users=%v want empty (detached on delete)", users)
+	}
+}
+
+// TestSDKAttachDetachFlipsDriverVolume proves attach/detach round-trip through
+// the unified disk model: after attach the disk reports the instance in users[];
+// after detach it is released and can be deleted.
+func TestSDKAttachDetachFlipsDriverVolume(t *testing.T) {
+	client, ts, ctx := newInstancesEnv(t)
+	disks := newDisksSDKClient(t, ts)
+
+	insertDisk(t, disks, &computepb.Disk{Name: ptrStr("roundtrip-disk"), SizeGb: ptrInt64(10)})
+
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name:        ptrStr("rt-vm"),
+		MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+	})
+
+	attachOp, err := client.AttachDisk(ctx, &computepb.AttachDiskInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "rt-vm",
+		AttachedDiskResource: &computepb.AttachedDisk{
+			DeviceName: ptrStr("data"),
+			Source:     ptrStr("zones/" + testZone + "/disks/roundtrip-disk"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("AttachDisk: %v", err)
+	}
+
+	if err := attachOp.Wait(ctx); err != nil {
+		t.Fatalf("AttachDisk wait: %v", err)
+	}
+
+	attached, err := disks.Get(ctx, &computepb.GetDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "roundtrip-disk",
+	})
+	if err != nil {
+		t.Fatalf("Get after attach: %v", err)
+	}
+
+	if users := attached.GetUsers(); len(users) != 1 || !strings.HasSuffix(users[0], "/instances/rt-vm") {
+		t.Errorf("after attach users=%v want [.../instances/rt-vm]", users)
+	}
+
+	detachOp, err := client.DetachDisk(ctx, &computepb.DetachDiskInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "rt-vm", DeviceName: "data",
+	})
+	if err != nil {
+		t.Fatalf("DetachDisk: %v", err)
+	}
+
+	if err := detachOp.Wait(ctx); err != nil {
+		t.Fatalf("DetachDisk wait: %v", err)
+	}
+
+	released, err := disks.Get(ctx, &computepb.GetDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "roundtrip-disk",
+	})
+	if err != nil {
+		t.Fatalf("Get after detach: %v", err)
+	}
+
+	if users := released.GetUsers(); len(users) != 0 {
+		t.Errorf("after detach users=%v want empty", users)
+	}
+
+	// A released disk can be deleted (the in-use guard no longer blocks it).
+	delOp, err := disks.Delete(ctx, &computepb.DeleteDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "roundtrip-disk",
+	})
+	if err != nil {
+		t.Fatalf("Delete after detach: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Fatalf("Delete after detach wait: %v", err)
+	}
+}
+
+// TestSDKInsertDeleteRaceWithDiskList hammers instances.insert + delete (each
+// materializing then cascading a boot disk) concurrently with disks.list, so the
+// suite catches any data race between the copy-on-write disk mutations and the
+// ranging list read under `go test -race`.
+func TestSDKInsertDeleteRaceWithDiskList(t *testing.T) {
+	client, ts, ctx := newInstancesEnv(t)
+	disks := newDisksSDKClient(t, ts)
+
+	const (
+		workers = 6
+		iters   = 12
+	)
+
+	var wg sync.WaitGroup
+
+	for w := range workers {
+		wg.Add(1)
+
+		go func(w int) {
+			defer wg.Done()
+
+			for i := range iters {
+				name := ptrStr("race-vm-" + strconv.Itoa(w) + "-" + strconv.Itoa(i))
+
+				insOp, err := client.Insert(ctx, &computepb.InsertInstanceRequest{
+					Project: testProject, Zone: testZone,
+					InstanceResource: &computepb.Instance{
+						Name:        name,
+						MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+						Disks: []*computepb.AttachedDisk{{
+							Boot:       ptrBool(true),
+							AutoDelete: ptrBool(true),
+							InitializeParams: &computepb.AttachedDiskInitializeParams{
+								SourceImage: ptrStr("projects/debian-cloud/global/images/family/debian-12"),
+							},
+						}},
+					},
+				})
+				if err != nil {
+					t.Errorf("Insert: %v", err)
+					return
+				}
+
+				_ = insOp.Wait(ctx)
+
+				delOp, err := client.Delete(ctx, &computepb.DeleteInstanceRequest{
+					Project: testProject, Zone: testZone, Instance: *name,
+				})
+				if err != nil {
+					t.Errorf("Delete: %v", err)
+					return
+				}
+
+				_ = delOp.Wait(ctx)
+			}
+		}(w)
+	}
+
+	// Concurrent readers ranging the disk store.
+	for range workers {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range iters * 2 {
+				it := disks.List(ctx, &computepb.ListDisksRequest{Project: testProject, Zone: testZone})
+				for {
+					if _, err := it.Next(); err != nil {
+						break
+					}
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Every autoDelete boot disk was cascaded on its instance's delete, so the
+	// disk store settles empty.
+	it := disks.List(ctx, &computepb.ListDisksRequest{Project: testProject, Zone: testZone})
+
+	count := 0
+
+	for {
+		_, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("final List: %v", err)
+		}
+
+		count++
+	}
+
+	if count != 0 {
+		t.Errorf("disks left after all deletes = %d, want 0 (autoDelete cascade leaked)", count)
+	}
+}

--- a/server/gcp/compute/boot_disk_sdk_test.go
+++ b/server/gcp/compute/boot_disk_sdk_test.go
@@ -1,11 +1,13 @@
 package compute_test
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
 
+	gcpcompute "cloud.google.com/go/compute/apiv1"
 	"cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/api/iterator"
 )
@@ -92,6 +94,105 @@ func TestSDKInsertMaterializesAdditionalDisk(t *testing.T) {
 			t.Errorf("disks.Get(%s): %v — disk should have materialized", name, err)
 		}
 	}
+}
+
+// TestSDKInsertBadDiskSourceNoOrphan proves an insert that references a
+// nonexistent disk source creates NOTHING: it fails with 404, no instance and no
+// phantom disk are left behind, and a retry with the same name (with a valid
+// boot disk) then succeeds. Guards against the partial-failure orphan where the
+// instance is committed before disk materialization aborts.
+func TestSDKInsertBadDiskSourceNoOrphan(t *testing.T) {
+	client, ts, ctx := newInstancesEnv(t)
+	disks := newDisksSDKClient(t, ts)
+
+	_, err := client.Insert(ctx, &computepb.InsertInstanceRequest{
+		Project: testProject, Zone: testZone,
+		InstanceResource: &computepb.Instance{
+			Name:        ptrStr("orphan-vm"),
+			MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+			Disks: []*computepb.AttachedDisk{
+				{
+					Boot:       ptrBool(true),
+					AutoDelete: ptrBool(true),
+					InitializeParams: &computepb.AttachedDiskInitializeParams{
+						SourceImage: ptrStr("projects/debian-cloud/global/images/family/debian-12"),
+					},
+				},
+				{
+					DeviceName: ptrStr("data"),
+					Source:     ptrStr("zones/" + testZone + "/disks/does-not-exist"),
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("insert with a missing disk source succeeded, want 404 notFound")
+	}
+
+	if !strings.Contains(err.Error(), "notFound") && !strings.Contains(err.Error(), "404") {
+		t.Errorf("err=%v want notFound/404", err)
+	}
+
+	// No instance was created.
+	if _, err := client.Get(ctx, &computepb.GetInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "orphan-vm",
+	}); err == nil {
+		t.Error("orphan-vm exists after a failed insert, want NotFound (no instance committed)")
+	}
+
+	// No phantom boot disk was left behind (boot disk would default to the name).
+	if _, err := disks.Get(ctx, &computepb.GetDiskRequest{
+		Project: testProject, Zone: testZone, Disk: "orphan-vm",
+	}); err == nil {
+		t.Error("a disk named orphan-vm exists after a failed insert, want none")
+	}
+
+	if names := listDiskNames(ctx, t, disks); len(names) != 0 {
+		t.Errorf("disks after failed insert = %v, want none", names)
+	}
+
+	// A retry with the same name and a valid disk set now succeeds.
+	mustInsert(t, client, testZone, &computepb.Instance{
+		Name:        ptrStr("orphan-vm"),
+		MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+		Disks: []*computepb.AttachedDisk{{
+			Boot:       ptrBool(true),
+			AutoDelete: ptrBool(true),
+			InitializeParams: &computepb.AttachedDiskInitializeParams{
+				SourceImage: ptrStr("projects/debian-cloud/global/images/family/debian-12"),
+			},
+		}},
+	})
+
+	if _, err := client.Get(ctx, &computepb.GetInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: "orphan-vm",
+	}); err != nil {
+		t.Fatalf("retry insert with same name failed: %v", err)
+	}
+}
+
+// listDiskNames returns every disk name in the test zone.
+func listDiskNames(ctx context.Context, t *testing.T, disks *gcpcompute.DisksClient) []string {
+	t.Helper()
+
+	var names []string
+
+	it := disks.List(ctx, &computepb.ListDisksRequest{Project: testProject, Zone: testZone})
+
+	for {
+		d, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+
+		names = append(names, d.GetName())
+	}
+
+	return names
 }
 
 // TestSDKDeleteHonorsAutoDelete proves instances.delete deletes an autoDelete=true

--- a/server/gcp/compute/disks.go
+++ b/server/gcp/compute/disks.go
@@ -466,28 +466,44 @@ func toDiskResponse(vol *computedriver.VolumeInfo, rp gcprest.ResourcePath, host
 	return resp
 }
 
-// diskUsersByName scans instances and maps each disk name to the self-links of
-// the instances it is attached to, so a disk read reflects its users[] (kept
-// consistent with the instance-side disks[] populated by attachDisk).
+// diskUsersByName maps each disk name to the self-links of the instances it is
+// attached to, derived from the driver volume store's attachment state
+// (VolumeInfo.AttachedTo). Since insert and attachDisk both flip the driver
+// volume to in-use, this is the single source of truth for a disk's users[] —
+// consistent with the instance-side disks[] and the in-use delete guard.
 func (h *Handler) diskUsersByName(ctx context.Context, host, project string) map[string][]string {
+	vols, err := h.compute.DescribeVolumes(ctx, nil)
+	if err != nil {
+		return nil
+	}
+
 	instances, err := h.compute.DescribeInstances(ctx, nil, nil)
 	if err != nil {
 		return nil
 	}
 
-	out := make(map[string][]string)
+	linkByID := make(map[string]string, len(instances))
 
 	for i := range instances {
 		instName := tagOr(instances[i].Tags, gcpNameTag, "")
 		zone := tagOr(instances[i].Tags, keyZone, "")
-		link := gcprest.SelfLink(host, project, gcprest.ScopeZones, zone, "instances", instName)
+		linkByID[instances[i].ID] = gcprest.SelfLink(host, project, gcprest.ScopeZones, zone, "instances", instName)
+	}
 
-		attached := decodeDisks(instances[i].Tags)
-		for j := range attached {
-			if dn := lastSegment(attached[j].Source); dn != "" {
-				out[dn] = append(out[dn], link)
-			}
+	out := make(map[string][]string)
+
+	for i := range vols {
+		if vols[i].AttachedTo == "" {
+			continue
 		}
+
+		link, ok := linkByID[vols[i].AttachedTo]
+		if !ok {
+			continue
+		}
+
+		name := tagOr(vols[i].Tags, gcpDiskNameTag, vols[i].ID)
+		out[name] = append(out[name], link)
 	}
 
 	return out

--- a/server/gcp/compute/disks.go
+++ b/server/gcp/compute/disks.go
@@ -149,10 +149,10 @@ func (h *Handler) deleteDisk(w http.ResponseWriter, r *http.Request, rp gcprest.
 	}
 
 	// Real GCP refuses to delete a disk still attached to an instance, returning
-	// 400 resourceInUseByAnotherResource. attachDisk only records the disk in the
-	// instance's disks[] (it never flips the driver volume state), so reuse the
-	// same instance scan that populates users[] on a read and reject while any
-	// instance still references this disk. Delete succeeds once the disk detaches.
+	// 400 resourceInUseByAnotherResource. attach flips the driver volume to
+	// in-use (AttachedTo), so the same volume-store scan that populates users[]
+	// on a read is the authoritative attachment view: reject while any instance
+	// still references this disk. Delete succeeds once the disk detaches.
 	host := hostFromRequest(r)
 	if users := h.diskUsersByName(r.Context(), host, rp.Project); len(users[rp.ResourceName]) > 0 {
 		diskLink := gcprest.SelfLink(host, rp.Project, gcprest.ScopeZones, rp.ScopeName, "disks", rp.ResourceName)

--- a/server/gcp/compute/instance_actions.go
+++ b/server/gcp/compute/instance_actions.go
@@ -1,6 +1,7 @@
 package compute
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"strings"
@@ -119,7 +120,9 @@ func (h *Handler) setMachineType(w http.ResponseWriter, r *http.Request, rp gcpr
 	h.applyMutation(w, r, rp, inst.ID, "setMachineType", nil, nil, machineTypeShort(body.MachineType))
 }
 
-// attachDisk handles POST .../instances/{name}/attachDisk.
+// attachDisk handles POST .../instances/{name}/attachDisk. It flips the backing
+// driver volume to in-use (recording autoDelete) and records the attachment in
+// the instance's disks[], so the disk store and the instance view stay in sync.
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) attachDisk(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
@@ -134,13 +137,30 @@ func (h *Handler) attachDisk(w http.ResponseWriter, r *http.Request, rp gcprest.
 		return
 	}
 
-	disks := append(decodeDisks(inst.Tags), disk)
+	existing := decodeDisks(inst.Tags)
+
+	attacher, ok := h.compute.(instanceDiskAttacher)
+	if !ok {
+		writeNotImplemented(w, "instance attachDisk")
+		return
+	}
+
+	if err := h.resolveAndAttachDisk(
+		r.Context(), inst.ID, rp.ResourceName, len(existing), &disk, rp, hostFromRequest(r), attacher,
+	); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	disks := append(existing, disk)
 
 	h.applyMutation(w, r, rp, inst.ID, "attachDisk",
 		map[string]string{keyDisks: encodeJSON(disks)}, nil, "")
 }
 
-// detachDisk handles POST .../instances/{name}/detachDisk?deviceName=...
+// detachDisk handles POST .../instances/{name}/detachDisk?deviceName=... It flips
+// the backing driver volume back to available (clearing its attachment) and
+// removes the disk from the instance's disks[].
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) detachDisk(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
@@ -156,16 +176,52 @@ func (h *Handler) detachDisk(w http.ResponseWriter, r *http.Request, rp gcprest.
 		return
 	}
 
-	kept := make([]attachedDisk, 0)
+	current := decodeDisks(inst.Tags)
+	kept := make([]attachedDisk, 0, len(current))
 
-	for _, d := range decodeDisks(inst.Tags) {
-		if d.DeviceName != device {
-			kept = append(kept, d)
+	var detached *attachedDisk
+
+	for i := range current {
+		if current[i].DeviceName == device {
+			detached = &current[i]
+			continue
 		}
+
+		kept = append(kept, current[i])
+	}
+
+	if detached == nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "no attached disk with deviceName "+device)
+		return
+	}
+
+	if err := h.detachDriverVolume(r.Context(), inst.ID, detached, rp.ScopeName); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
 	}
 
 	h.applyMutation(w, r, rp, inst.ID, "detachDisk",
 		map[string]string{keyDisks: encodeJSON(kept)}, nil, "")
+}
+
+// detachDriverVolume flips the driver volume backing a detached disks[] entry
+// back to available. The disk is resolved by its recorded source (or, lacking
+// one, its device name); a volume that cannot be resolved is a no-op so a
+// disks[]-only entry never blocks the detach.
+func (h *Handler) detachDriverVolume(
+	ctx context.Context, instanceID string, d *attachedDisk, zone string,
+) error {
+	name := lastSegment(d.Source)
+	if name == "" {
+		name = d.DeviceName
+	}
+
+	vol, err := findDiskByName(ctx, h.compute, name, zone)
+	if err != nil {
+		return nil //nolint:nilerr // a disks[]-only entry with no backing volume needs no driver detach.
+	}
+
+	return h.compute.DetachVolume(ctx, vol.ID, instanceID, d.DeviceName)
 }
 
 // applyMutation runs a GCP-specific instance mutation through the mutator

--- a/server/gcp/compute/instances.go
+++ b/server/gcp/compute/instances.go
@@ -78,10 +78,180 @@ func (h *Handler) insertInstance(w http.ResponseWriter, r *http.Request, rp gcpr
 		return
 	}
 
+	// Materialize the boot disk (and any additional disks in the request) as real
+	// Disk resources attached to the instance, so disks.get/list return them and
+	// instances.delete can honor each disk's autoDelete flag.
+	if err := h.materializeInsertDisks(r.Context(), instances[0].ID, &req, rp, hostFromRequest(r)); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
 	op := h.ops.RecordDone(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
 		"instances", req.Name, "insert")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// instanceDiskAttacher is a GCP-local capability the GCE Mock implements: it
+// attaches an existing disk (by driver volume ID) to an instance, flipping the
+// driver volume to in-use and recording the attachment-scoped auto-delete flag
+// (autoDelete ⟷ VolumeInfo.DeleteOnTermination). The same path backs both
+// instances.insert boot/data disks and instances.attachDisk, so the disk store
+// and the instance's disks[] view stay consistent.
+type instanceDiskAttacher interface {
+	AttachDiskGCP(instanceID, volumeID, device string, autoDelete bool) error
+}
+
+// materializeInsertDisks turns each entry in the instance's disks[] into a real
+// Disk resource attached to the just-created instance. A disk with
+// initializeParams is created fresh; a disk with only a source references an
+// existing disk. Each is attached carrying its autoDelete flag, and the disks[]
+// tag is rewritten with resolved deviceName/source so a read and disks.get agree.
+// When the driver does not expose the GCP disk capabilities (a non-GCE Compute),
+// materialization is skipped and the raw disks[] round-trips as before.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) materializeInsertDisks(
+	ctx context.Context, instanceID string, req *instanceRequest, rp gcprest.ResourcePath, host string,
+) error {
+	if len(req.Disks) == 0 {
+		return nil
+	}
+
+	attacher, ok := h.compute.(instanceDiskAttacher)
+	mutator, mok := h.compute.(instanceMutator)
+
+	if !ok || !mok {
+		return nil
+	}
+
+	for i := range req.Disks {
+		if err := h.resolveAndAttachDisk(ctx, instanceID, req.Name, i, &req.Disks[i], rp, host, attacher); err != nil {
+			return err
+		}
+	}
+
+	return mutator.MutateInstanceGCP(instanceID, map[string]string{keyDisks: encodeJSON(req.Disks)}, nil, "")
+}
+
+// resolveAndAttachDisk materializes/looks-up the Disk resource backing a single
+// disks[] entry and attaches it to the instance, then fills the entry's resolved
+// deviceName/source so the instance response and disks.get line up. It is shared
+// by instances.insert and instances.attachDisk.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) resolveAndAttachDisk(
+	ctx context.Context, instanceID, instanceName string, index int, d *attachedDisk,
+	rp gcprest.ResourcePath, host string, attacher instanceDiskAttacher,
+) error {
+	if d.DeviceName == "" {
+		d.DeviceName = deviceNameFor(d.Boot, instanceName, index)
+	}
+
+	diskName := insertDiskName(d, instanceName, index)
+
+	volID, err := h.diskVolumeID(ctx, diskName, d, rp)
+	if err != nil {
+		return err
+	}
+
+	if err := attacher.AttachDiskGCP(instanceID, volID, d.DeviceName, d.AutoDelete); err != nil {
+		return err
+	}
+
+	d.Source = gcprest.SelfLink(host, rp.Project, gcprest.ScopeZones, rp.ScopeName, "disks", diskName)
+
+	return nil
+}
+
+// diskVolumeID resolves the driver volume ID for a disks[] entry: an existing
+// disk named by source is looked up, otherwise a fresh disk is created from the
+// entry's initializeParams (size/type/sourceImage).
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) diskVolumeID(
+	ctx context.Context, diskName string, d *attachedDisk, rp gcprest.ResourcePath,
+) (string, error) {
+	if d.InitializeParams == nil && d.Source != "" {
+		vol, err := findDiskByName(ctx, h.compute, lastSegment(d.Source), rp.ScopeName)
+		if err != nil {
+			return "", err
+		}
+
+		return vol.ID, nil
+	}
+
+	cfg := computedriver.VolumeConfig{
+		Size:             initializeDiskSize(d),
+		VolumeType:       initializeDiskType(d),
+		AvailabilityZone: rp.ScopeName,
+		Tags:             mergeDiskTags(nil, diskName, initializeSourceImage(d)),
+	}
+
+	vol, err := h.compute.CreateVolume(ctx, cfg)
+	if err != nil {
+		return "", err
+	}
+
+	return vol.ID, nil
+}
+
+// insertDiskName resolves the Disk resource name for a disks[] entry: an
+// explicit initializeParams.diskName, else the source disk's name, else the
+// instance name for the boot disk (GCP's default), else an indexed data-disk
+// name.
+func insertDiskName(d *attachedDisk, instanceName string, index int) string {
+	if d.InitializeParams != nil && d.InitializeParams.DiskName != "" {
+		return d.InitializeParams.DiskName
+	}
+
+	if d.Source != "" {
+		return lastSegment(d.Source)
+	}
+
+	if d.Boot {
+		return instanceName
+	}
+
+	return instanceName + "-disk-" + strconv.Itoa(index)
+}
+
+// initializeDiskSize parses the requested disk size (GiB), defaulting to GCP's
+// 10 GiB when the request names none.
+func initializeDiskSize(d *attachedDisk) int {
+	const defaultSizeGb = 10
+
+	if d.InitializeParams != nil && d.InitializeParams.DiskSizeGb != "" {
+		if n, err := strconv.Atoi(d.InitializeParams.DiskSizeGb); err == nil && n > 0 {
+			return n
+		}
+	}
+
+	if d.DiskSizeGb != "" {
+		if n, err := strconv.Atoi(d.DiskSizeGb); err == nil && n > 0 {
+			return n
+		}
+	}
+
+	return defaultSizeGb
+}
+
+// initializeDiskType resolves the disk type (e.g. "pd-ssd") from initializeParams.
+func initializeDiskType(d *attachedDisk) string {
+	if d.InitializeParams != nil && d.InitializeParams.DiskType != "" {
+		return lastSegment(d.InitializeParams.DiskType)
+	}
+
+	return lastSegment(d.Type)
+}
+
+// initializeSourceImage resolves the source image a fresh disk is created from.
+func initializeSourceImage(d *attachedDisk) string {
+	if d.InitializeParams != nil {
+		return d.InitializeParams.SourceImage
+	}
+
+	return ""
 }
 
 // getInstance handles GET .../instances/{name}.

--- a/server/gcp/compute/instances.go
+++ b/server/gcp/compute/instances.go
@@ -56,6 +56,16 @@ func (h *Handler) insertInstance(w http.ResponseWriter, r *http.Request, rp gcpr
 		return
 	}
 
+	// Pre-flight the disks that reference an existing disk by source, BEFORE any
+	// instance/disk is created: real GCP creates NO instance when a referenced
+	// disk source is missing or already attached, so a retry with the same name
+	// still succeeds. Validating up front (rather than rolling back after) keeps
+	// the store free of orphaned instances or half-materialized disks.
+	if err := h.validateDiskSources(r.Context(), req.Disks, rp.ScopeName); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
 	subnet := firstSubnet(req.NetworkInterfaces)
 
 	cfg := computedriver.InstanceConfig{
@@ -100,6 +110,40 @@ func (h *Handler) insertInstance(w http.ResponseWriter, r *http.Request, rp gcpr
 // and the instance's disks[] view stay consistent.
 type instanceDiskAttacher interface {
 	AttachDiskGCP(instanceID, volumeID, device string, autoDelete bool) error
+}
+
+// driverVolumeInUse is the driver VolumeInfo.State value for an attached disk.
+const driverVolumeInUse = "in-use"
+
+// validateDiskSources pre-flights the source-referenced disks[] entries before
+// the instance is created: a source that names a missing disk fails with 404,
+// and one that names an already-attached disk fails with a precondition error —
+// in both cases leaving no instance or disk behind, matching real GCP. Entries
+// with initializeParams create a fresh disk during materialization and need no
+// pre-flight. Skipped when the driver is not a GCE mock (materialization is a
+// no-op there anyway).
+func (h *Handler) validateDiskSources(ctx context.Context, disks []attachedDisk, zone string) error {
+	if _, ok := h.compute.(instanceDiskAttacher); !ok {
+		return nil
+	}
+
+	for i := range disks {
+		if disks[i].InitializeParams != nil || disks[i].Source == "" {
+			continue
+		}
+
+		vol, err := findDiskByName(ctx, h.compute, lastSegment(disks[i].Source), zone)
+		if err != nil {
+			return err
+		}
+
+		if vol.State == driverVolumeInUse {
+			return cerrors.Newf(cerrors.FailedPrecondition,
+				"disk %q is already attached to another instance", lastSegment(disks[i].Source))
+		}
+	}
+
+	return nil
 }
 
 // materializeInsertDisks turns each entry in the instance's disks[] into a real

--- a/server/gcp/compute/instances_sdk_test.go
+++ b/server/gcp/compute/instances_sdk_test.go
@@ -247,9 +247,15 @@ func TestSDKGCEInstanceSetMetadata(t *testing.T) {
 	}
 }
 
-// TestSDKGCEInstanceAttachDetachDisk covers finding #5.
+// TestSDKGCEInstanceAttachDetachDisk covers finding #5. attachDisk/detachDisk go
+// through the unified disk model, so the source disk must exist (real GCP 404s on
+// an unknown source); the attach flips the driver volume to in-use and detach
+// releases it.
 func TestSDKGCEInstanceAttachDetachDisk(t *testing.T) {
-	client, _, ctx := newInstancesEnv(t)
+	client, ts, ctx := newInstancesEnv(t)
+
+	disks := newDisksSDKClient(t, ts)
+	insertDisk(t, disks, &computepb.Disk{Name: ptrStr("data-disk"), SizeGb: ptrInt64(10)})
 
 	mustInsert(t, client, testZone, &computepb.Instance{
 		Name:        ptrStr("ad-vm"),

--- a/server/gcp/compute/types.go
+++ b/server/gcp/compute/types.go
@@ -49,6 +49,7 @@ type attachedDisk struct {
 }
 
 type diskInitializeParams struct {
+	DiskName    string `json:"diskName,omitempty"`
 	SourceImage string `json:"sourceImage,omitempty"`
 	DiskType    string `json:"diskType,omitempty"`
 	DiskSizeGb  string `json:"diskSizeGb,omitempty"`


### PR DESCRIPTION
## Summary

Closes the biggest GCP Compute realism gap: the boot disk is now a real Disk resource, delete honors `autoDelete`, and the wire-only `attachDisk` is unified with the driver volume model.

### What changed
- **instances.insert** materializes the boot disk (and any additional `initializeParams` disks) as real `compute#disk` resources attached to the instance, so `disks.get`/`disks.list` return them with the requested size / type / sourceImage. Boot disk defaults to the instance name (real GCP).
- **attachDisk / detachDisk** now flip the driver volume state through a single `AttachDiskGCP` / `DetachVolume` path (the JSON-only attach is retired). `autoDelete` is recorded as `VolumeInfo.DeleteOnTermination`. Attaching an unknown source now 404s, matching real GCP.
- **instances.delete** honors the cascade: `autoDelete=true` disks are deleted, `autoDelete=false` disks detach and survive. Implemented provider-side from the volume store (mirrors the AWS #960 terminate cascade) under a single `UpdateOrDelete` lock span.
- **disk users[]** and the in-use delete guard now derive from the authoritative volume store (`AttachedTo`), consistent with the instance's `disks[]`.
- Fixes a latent `RunInstances` data race (in-place `State` write after the store `Set`) newly exposed by `disks.list` ranging `DescribeInstances`; the record now settles to Running before publishing.

### Tests
Real `cloud.google.com/go/compute` SDK tests: insert → `disks.get` boot disk (size/type/sourceImage/users), extra initializeParams disk materializes, delete cascade (autoDelete=true gone, autoDelete=false survives detached), attach/detach round-trip flipping driver state, and a `-race` insert/delete-vs-`disks.list` concurrency test. Provider-level cascade + attach tests.

### Gates
build · gofmt · `-race` (server+provider compute) · broad `./server/gcp/... ./providers/gcp/...` · golangci-lint 0 issues · coveragegen clean · go mod tidy clean.