### PR TITLE
feat(aws-ec2): CreateImage honors NoReboot + BDMs, snapshot-backed AMIs

### DIFF
--- a/providers/aws/ec2/create_image_test.go
+++ b/providers/aws/ec2/create_image_test.go
@@ -99,6 +99,7 @@ func TestCreateImageWithOptionsOverrideAndSuppress(t *testing.T) {
 			DeviceName: defaultRootDeviceName, VolumeSize: 30, VolumeType: "gp3", DeleteOnTermination: false,
 		}},
 		[]string{"/dev/sdf"},
+		[]string{defaultRootDeviceName}, // client explicitly sent DeleteOnTermination=false
 	)
 	requireNoError(t, err)
 
@@ -115,6 +116,49 @@ func TestCreateImageWithOptionsOverrideAndSuppress(t *testing.T) {
 	assertNotEmpty(t, root.SnapshotID)
 }
 
+// TestCreateImageWithOptionsPreservesUnsetDoT pins the Packer/Terraform
+// root-resize pattern: a client BDM override that sets only VolumeSize (and does
+// not send DeleteOnTermination) must resize the AMI's root device while keeping
+// the source volume's DeleteOnTermination (true for a default root) rather than
+// silently clearing it to false. When the client DOES send DeleteOnTermination,
+// it is applied.
+func TestCreateImageWithOptionsPreservesUnsetDoT(t *testing.T) {
+	ctx := context.Background()
+
+	// Size-only override (no device in dotSet): source DoT (true) preserved.
+	t.Run("unset preserves source", func(t *testing.T) {
+		m := newTestMock()
+		id := runWithVolumes(t, m)
+
+		img, err := m.CreateImageWithOptions(ctx, driver.ImageConfig{InstanceID: id, Name: "resize"}, true,
+			[]driver.ImageBlockDeviceMapping{{DeviceName: defaultRootDeviceName, VolumeSize: 100}},
+			nil, nil, // DeleteOnTermination not sent
+		)
+		requireNoError(t, err)
+
+		root := bdmByDevice(img.BlockDeviceMappings)[defaultRootDeviceName]
+		assertEqual(t, 100, root.VolumeSize)
+		assertTrue(t, root.DeleteOnTermination,
+			"size-only override must preserve source DeleteOnTermination=true")
+	})
+
+	// Explicit DeleteOnTermination=false (device in dotSet): applied.
+	t.Run("explicit false applies", func(t *testing.T) {
+		m := newTestMock()
+		id := runWithVolumes(t, m)
+
+		img, err := m.CreateImageWithOptions(ctx, driver.ImageConfig{InstanceID: id, Name: "detach"}, true,
+			[]driver.ImageBlockDeviceMapping{{DeviceName: defaultRootDeviceName, DeleteOnTermination: false}},
+			nil, []string{defaultRootDeviceName},
+		)
+		requireNoError(t, err)
+
+		root := bdmByDevice(img.BlockDeviceMappings)[defaultRootDeviceName]
+		assertTrue(t, !root.DeleteOnTermination,
+			"explicit DeleteOnTermination=false must be applied")
+	})
+}
+
 // TestCreateImageWithOptionsAddsMapping pins that a client mapping for a device
 // that has no backing volume is appended to the AMI's block device mapping.
 func TestCreateImageWithOptionsAddsMapping(t *testing.T) {
@@ -125,7 +169,7 @@ func TestCreateImageWithOptionsAddsMapping(t *testing.T) {
 
 	img, err := m.CreateImageWithOptions(ctx, driver.ImageConfig{InstanceID: id, Name: "add"}, true,
 		[]driver.ImageBlockDeviceMapping{{DeviceName: "/dev/sdg", VolumeSize: 50, DeleteOnTermination: true}},
-		nil,
+		nil, []string{"/dev/sdg"},
 	)
 	requireNoError(t, err)
 
@@ -159,7 +203,7 @@ func TestCreateImageRebootHonorsNoReboot(t *testing.T) {
 	// NoReboot=true: no reboot, no new lifecycle metrics.
 	before := metricCount(mon)
 
-	_, err := m.CreateImageWithOptions(ctx, driver.ImageConfig{InstanceID: id, Name: "noreboot"}, true, nil, nil)
+	_, err := m.CreateImageWithOptions(ctx, driver.ImageConfig{InstanceID: id, Name: "noreboot"}, true, nil, nil, nil)
 	requireNoError(t, err)
 
 	if got := metricCount(mon); got != before {
@@ -170,7 +214,7 @@ func TestCreateImageRebootHonorsNoReboot(t *testing.T) {
 	// batch (5 datums), and remains running.
 	before = metricCount(mon)
 
-	_, err = m.CreateImageWithOptions(ctx, driver.ImageConfig{InstanceID: id, Name: "reboot"}, false, nil, nil)
+	_, err = m.CreateImageWithOptions(ctx, driver.ImageConfig{InstanceID: id, Name: "reboot"}, false, nil, nil, nil)
 	requireNoError(t, err)
 
 	if got := metricCount(mon) - before; got != 5 {

--- a/providers/aws/ec2/create_image_test.go
+++ b/providers/aws/ec2/create_image_test.go
@@ -1,0 +1,191 @@
+package ec2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+// bdmByDevice indexes an image's block device mappings by device name.
+func bdmByDevice(bdms []driver.ImageBlockDeviceMapping) map[string]driver.ImageBlockDeviceMapping {
+	out := make(map[string]driver.ImageBlockDeviceMapping, len(bdms))
+	for _, b := range bdms {
+		out[b.DeviceName] = b
+	}
+
+	return out
+}
+
+// runWithVolumes launches one instance backed by a boot volume plus the given
+// extra data volumes, returning its id.
+func runWithVolumes(t *testing.T, m *Mock, extra ...driver.BlockDeviceMapping) string {
+	t.Helper()
+
+	cfg := defaultConfig()
+	cfg.BlockDeviceMappings = append([]driver.BlockDeviceMapping{
+		{DeviceName: defaultRootDeviceName, Boot: true, AutoDelete: true, Size: 8, Type: "gp3"},
+	}, extra...)
+
+	insts, err := m.RunInstances(context.Background(), cfg, 1)
+	requireNoError(t, err)
+
+	return insts[0].ID
+}
+
+// TestCreateImageSnapshotsAttachedVolumes pins that the base CreateImage backs
+// the AMI with a real snapshot of every attached volume (root + data), and that
+// each referenced snapshot exists and points back at its source volume.
+func TestCreateImageSnapshotsAttachedVolumes(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	id := runWithVolumes(t, m, driver.BlockDeviceMapping{
+		DeviceName: "/dev/sdf", AutoDelete: false, Size: 20, Type: "gp2",
+	})
+
+	img, err := m.CreateImage(ctx, driver.ImageConfig{InstanceID: id, Name: "multi"})
+	requireNoError(t, err)
+
+	if len(img.BlockDeviceMappings) != 2 {
+		t.Fatalf("BlockDeviceMappings = %d, want 2", len(img.BlockDeviceMappings))
+	}
+
+	byDev := bdmByDevice(img.BlockDeviceMappings)
+
+	root := byDev[defaultRootDeviceName]
+	assertNotEmpty(t, root.SnapshotID)
+	assertEqual(t, 8, root.VolumeSize)
+	assertTrue(t, root.DeleteOnTermination, "root DeleteOnTermination should be true")
+
+	data := byDev["/dev/sdf"]
+	assertNotEmpty(t, data.SnapshotID)
+	assertEqual(t, 20, data.VolumeSize)
+	assertEqual(t, "gp2", data.VolumeType)
+	assertTrue(t, !data.DeleteOnTermination, "data DeleteOnTermination should be false")
+
+	// Every referenced snapshot must exist and point back at an attached volume.
+	vols, err := m.DescribeVolumes(ctx, nil)
+	requireNoError(t, err)
+
+	volByDevice := make(map[string]string)
+	for i := range vols {
+		if vols[i].AttachedTo == id {
+			volByDevice[vols[i].Device] = vols[i].ID
+		}
+	}
+
+	for _, b := range img.BlockDeviceMappings {
+		snaps, err := m.DescribeSnapshots(ctx, []string{b.SnapshotID})
+		requireNoError(t, err)
+		assertEqual(t, 1, len(snaps))
+		assertEqual(t, volByDevice[b.DeviceName], snaps[0].VolumeID)
+	}
+}
+
+// TestCreateImageWithOptionsOverrideAndSuppress pins that a client
+// BlockDeviceMapping override replaces an attached volume's size / type /
+// DeleteOnTermination on the AMI, and a NoDevice entry suppresses its device.
+func TestCreateImageWithOptionsOverrideAndSuppress(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	id := runWithVolumes(t, m, driver.BlockDeviceMapping{
+		DeviceName: "/dev/sdf", AutoDelete: false, Size: 20, Type: "gp2",
+	})
+
+	img, err := m.CreateImageWithOptions(ctx, driver.ImageConfig{InstanceID: id, Name: "override"}, true,
+		[]driver.ImageBlockDeviceMapping{{
+			DeviceName: defaultRootDeviceName, VolumeSize: 30, VolumeType: "gp3", DeleteOnTermination: false,
+		}},
+		[]string{"/dev/sdf"},
+	)
+	requireNoError(t, err)
+
+	if len(img.BlockDeviceMappings) != 1 {
+		t.Fatalf("BlockDeviceMappings = %d, want 1 (data device suppressed)", len(img.BlockDeviceMappings))
+	}
+
+	root := img.BlockDeviceMappings[0]
+	assertEqual(t, defaultRootDeviceName, root.DeviceName)
+	assertEqual(t, 30, root.VolumeSize)
+	assertEqual(t, "gp3", root.VolumeType)
+	assertTrue(t, !root.DeleteOnTermination, "override should have set DeleteOnTermination false")
+	// The override keeps the backing snapshot taken from the real volume.
+	assertNotEmpty(t, root.SnapshotID)
+}
+
+// TestCreateImageWithOptionsAddsMapping pins that a client mapping for a device
+// that has no backing volume is appended to the AMI's block device mapping.
+func TestCreateImageWithOptionsAddsMapping(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	id := runWithVolumes(t, m)
+
+	img, err := m.CreateImageWithOptions(ctx, driver.ImageConfig{InstanceID: id, Name: "add"}, true,
+		[]driver.ImageBlockDeviceMapping{{DeviceName: "/dev/sdg", VolumeSize: 50, DeleteOnTermination: true}},
+		nil,
+	)
+	requireNoError(t, err)
+
+	byDev := bdmByDevice(img.BlockDeviceMappings)
+	if _, ok := byDev[defaultRootDeviceName]; !ok {
+		t.Fatalf("root mapping missing: %+v", img.BlockDeviceMappings)
+	}
+
+	added, ok := byDev["/dev/sdg"]
+	if !ok {
+		t.Fatalf("added mapping /dev/sdg missing: %+v", img.BlockDeviceMappings)
+	}
+
+	assertEqual(t, 50, added.VolumeSize)
+	assertEqual(t, defaultVolumeType, added.VolumeType) // defaulted when client omits type
+	assertEqual(t, "", added.SnapshotID)                // a brand-new device has no snapshot
+}
+
+// TestCreateImageRebootHonorsNoReboot pins that CreateImage reboots a running
+// source instance (emitting lifecycle metrics) when NoReboot is false, and does
+// not when NoReboot is true. The instance stays running either way.
+func TestCreateImageRebootHonorsNoReboot(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	mon := &captureMonitoring{}
+	m.SetMonitoring(mon)
+
+	id := runWithVolumes(t, m)
+
+	// NoReboot=true: no reboot, no new lifecycle metrics.
+	before := metricCount(mon)
+
+	_, err := m.CreateImageWithOptions(ctx, driver.ImageConfig{InstanceID: id, Name: "noreboot"}, true, nil, nil)
+	requireNoError(t, err)
+
+	if got := metricCount(mon); got != before {
+		t.Fatalf("NoReboot=true emitted %d metric datums, want 0", got-before)
+	}
+
+	// NoReboot=false: the running instance is rebooted, emitting one lifecycle
+	// batch (5 datums), and remains running.
+	before = metricCount(mon)
+
+	_, err = m.CreateImageWithOptions(ctx, driver.ImageConfig{InstanceID: id, Name: "reboot"}, false, nil, nil)
+	requireNoError(t, err)
+
+	if got := metricCount(mon) - before; got != 5 {
+		t.Fatalf("NoReboot=false emitted %d metric datums, want 5 (reboot lifecycle batch)", got)
+	}
+
+	insts, err := m.DescribeInstances(ctx, []string{id}, nil, driver.DescribeInstancesOptions{})
+	requireNoError(t, err)
+	assertEqual(t, "running", insts[0].State)
+}
+
+// metricCount returns the number of metric datums captured so far.
+func metricCount(c *captureMonitoring) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return len(c.data)
+}

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -1948,7 +1948,7 @@ func containsPermission[T comparable](set []T, want T) bool {
 //
 //nolint:gocritic // hugeParam: cfg mirrors the driver-interface signature.
 func (m *Mock) CreateImage(ctx context.Context, cfg driver.ImageConfig) (*driver.ImageInfo, error) {
-	return m.createImage(ctx, &cfg, true, nil, nil)
+	return m.createImage(ctx, &cfg, true, nil, nil, nil)
 }
 
 // CreateImageWithOptions is the AWS EC2 CreateImage capability the wire layer
@@ -1956,23 +1956,24 @@ func (m *Mock) CreateImage(ctx context.Context, cfg driver.ImageConfig) (*driver
 // NoReboot flag (a running source instance is rebooted as part of image
 // creation unless NoReboot is true, matching real EC2's default) and client
 // BlockDeviceMapping overrides: an override for an attached volume's device
-// replaces its size/type/DeleteOnTermination (and snapshot, if the client names
-// one), a mapping for a new device is added, and a device listed in noDevices
-// (BlockDeviceMapping.N.NoDevice) is suppressed.
+// replaces its size/type/snapshot and, only when the client actually sent it
+// (device listed in dotSetDevices), its DeleteOnTermination; a mapping for a new
+// device is added; and a device listed in noDevices (BlockDeviceMapping.N.NoDevice)
+// is suppressed.
 //
 //nolint:gocritic // hugeParam: cfg param type is fixed by server/aws/ec2's awsImageCreator interface.
 func (m *Mock) CreateImageWithOptions(
 	ctx context.Context, cfg driver.ImageConfig, noReboot bool,
-	overrides []driver.ImageBlockDeviceMapping, noDevices []string,
+	overrides []driver.ImageBlockDeviceMapping, noDevices, dotSetDevices []string,
 ) (*driver.ImageInfo, error) {
-	return m.createImage(ctx, &cfg, noReboot, overrides, noDevices)
+	return m.createImage(ctx, &cfg, noReboot, overrides, noDevices, dotSetDevices)
 }
 
 // createImage is the shared CreateImage engine behind both the base and the
 // AWS-wire (option-carrying) entry points.
 func (m *Mock) createImage(
 	ctx context.Context, cfg *driver.ImageConfig, noReboot bool,
-	overrides []driver.ImageBlockDeviceMapping, noDevices []string,
+	overrides []driver.ImageBlockDeviceMapping, noDevices, dotSetDevices []string,
 ) (*driver.ImageInfo, error) {
 	inst, ok := m.instances.Get(cfg.InstanceID)
 	if !ok {
@@ -1990,7 +1991,9 @@ func (m *Mock) createImage(
 	id := fmt.Sprintf("ami-%012d", m.amiCounter.Add(1))
 	now := m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z")
 
-	bdms := applyImageBDMOverrides(m.snapshotAttachedVolumes(cfg.InstanceID, id, now), overrides, noDevices)
+	bdms := applyImageBDMOverrides(
+		m.snapshotAttachedVolumes(cfg.InstanceID, id, now), overrides, noDevices, dotSetDevices,
+	)
 
 	img := &driver.ImageInfo{
 		ID:                  id,
@@ -2081,14 +2084,21 @@ func (m *Mock) snapshotForImage(volumeID, amiID string, size int, encrypted bool
 // applyImageBDMOverrides folds the client-supplied CreateImage block device
 // mappings onto the snapshot-derived base: a NoDevice entry suppresses its
 // device, an override for an existing device replaces its non-zero size / set
-// type / snapshot and its DeleteOnTermination, and a mapping for a new device is
-// appended.
+// type / snapshot (and, only for a device in dotSet, its DeleteOnTermination),
+// and a mapping for a new device is appended. A device absent from dotSet keeps
+// the source volume's DeleteOnTermination, so a partial size-only override does
+// not silently clear it.
 func applyImageBDMOverrides(
-	base, overrides []driver.ImageBlockDeviceMapping, noDevices []string,
+	base, overrides []driver.ImageBlockDeviceMapping, noDevices, dotSetDevices []string,
 ) []driver.ImageBlockDeviceMapping {
 	suppressed := make(map[string]bool, len(noDevices))
 	for _, d := range noDevices {
 		suppressed[d] = true
+	}
+
+	dotSet := make(map[string]bool, len(dotSetDevices))
+	for _, d := range dotSetDevices {
+		dotSet[d] = true
 	}
 
 	result := make([]driver.ImageBlockDeviceMapping, 0, len(base)+len(overrides))
@@ -2109,7 +2119,7 @@ func applyImageBDMOverrides(
 		}
 
 		if i, ok := idx[o.DeviceName]; ok {
-			mergeImageBDMOverride(&result[i], o)
+			mergeImageBDMOverride(&result[i], o, dotSet[o.DeviceName])
 			continue
 		}
 
@@ -2126,7 +2136,9 @@ func applyImageBDMOverrides(
 
 // mergeImageBDMOverride applies a client override onto an existing mapping,
 // keeping the backing snapshot and any attribute the client left unset.
-func mergeImageBDMOverride(dst *driver.ImageBlockDeviceMapping, o driver.ImageBlockDeviceMapping) {
+// DeleteOnTermination is overwritten only when the client actually sent it
+// (dotSet), so an override that omits it preserves the source volume's value.
+func mergeImageBDMOverride(dst *driver.ImageBlockDeviceMapping, o driver.ImageBlockDeviceMapping, dotSet bool) {
 	if o.VolumeSize > 0 {
 		dst.VolumeSize = o.VolumeSize
 	}
@@ -2139,7 +2151,9 @@ func mergeImageBDMOverride(dst *driver.ImageBlockDeviceMapping, o driver.ImageBl
 		dst.SnapshotID = o.SnapshotID
 	}
 
-	dst.DeleteOnTermination = o.DeleteOnTermination
+	if dotSet {
+		dst.DeleteOnTermination = o.DeleteOnTermination
+	}
 }
 
 // imageRootDeviceName picks the AMI's root device: the conventional

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1939,50 +1940,74 @@ func containsPermission[T comparable](set []T, want T) bool {
 
 // CreateImage creates a machine image from an instance.
 //
+// CreateImage creates an AMI from an instance. It is the base (portable) path:
+// it snapshots each of the instance's attached EBS volumes and references those
+// snapshots from the image's block device mapping, but never reboots the source
+// instance and applies no client block-device overrides. The AWS wire layer's
+// NoReboot / BlockDeviceMapping.N fidelity comes in through CreateImageWithOptions.
+//
 //nolint:gocritic // hugeParam: cfg mirrors the driver-interface signature.
-func (m *Mock) CreateImage(_ context.Context, cfg driver.ImageConfig) (*driver.ImageInfo, error) {
-	if _, ok := m.instances.Get(cfg.InstanceID); !ok {
+func (m *Mock) CreateImage(ctx context.Context, cfg driver.ImageConfig) (*driver.ImageInfo, error) {
+	return m.createImage(ctx, &cfg, true, nil, nil)
+}
+
+// CreateImageWithOptions is the AWS EC2 CreateImage capability the wire layer
+// reaches through server/aws/ec2's awsImageCreator interface. It honors the
+// NoReboot flag (a running source instance is rebooted as part of image
+// creation unless NoReboot is true, matching real EC2's default) and client
+// BlockDeviceMapping overrides: an override for an attached volume's device
+// replaces its size/type/DeleteOnTermination (and snapshot, if the client names
+// one), a mapping for a new device is added, and a device listed in noDevices
+// (BlockDeviceMapping.N.NoDevice) is suppressed.
+//
+//nolint:gocritic // hugeParam: cfg param type is fixed by server/aws/ec2's awsImageCreator interface.
+func (m *Mock) CreateImageWithOptions(
+	ctx context.Context, cfg driver.ImageConfig, noReboot bool,
+	overrides []driver.ImageBlockDeviceMapping, noDevices []string,
+) (*driver.ImageInfo, error) {
+	return m.createImage(ctx, &cfg, noReboot, overrides, noDevices)
+}
+
+// createImage is the shared CreateImage engine behind both the base and the
+// AWS-wire (option-carrying) entry points.
+func (m *Mock) createImage(
+	ctx context.Context, cfg *driver.ImageConfig, noReboot bool,
+	overrides []driver.ImageBlockDeviceMapping, noDevices []string,
+) (*driver.ImageInfo, error) {
+	inst, ok := m.instances.Get(cfg.InstanceID)
+	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "instance %q not found", cfg.InstanceID)
+	}
+
+	// Real EC2 reboots a running instance before snapshotting so its filesystem
+	// is flushed, unless NoReboot is set. A stopped instance is never rebooted.
+	if !noReboot && inst.readState() == compute.StateRunning {
+		if err := m.transitionInstances(ctx, []string{cfg.InstanceID}, rebootTransition); err != nil {
+			return nil, err
+		}
 	}
 
 	id := fmt.Sprintf("ami-%012d", m.amiCounter.Add(1))
 	now := m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z")
 
-	// A real CreateImage snapshots the instance's root volume and references
-	// that snapshot from the AMI's block device mapping.
-	snapID := fmt.Sprintf("snap-%012d", m.snapCounter.Add(1))
-	m.snapshots.Set(snapID, &driver.SnapshotInfo{
-		ID:          snapID,
-		State:       "completed",
-		Description: "Created by CreateImage for " + id,
-		Size:        imageRootDeviceSize,
-		CreatedAt:   now,
-		OwnerID:     m.opts.AccountID,
-		Progress:    "100%",
-	})
+	bdms := applyImageBDMOverrides(m.snapshotAttachedVolumes(cfg.InstanceID, id, now), overrides, noDevices)
 
 	img := &driver.ImageInfo{
-		ID:                 id,
-		Name:               cfg.Name,
-		State:              stateAvailable,
-		Description:        cfg.Description,
-		CreatedAt:          now,
-		Tags:               copyTags(cfg.Tags),
-		OwnerID:            m.opts.AccountID,
-		Architecture:       "x86_64",
-		RootDeviceType:     "ebs",
-		RootDeviceName:     "/dev/sda1",
-		VirtualizationType: "hvm",
-		Hypervisor:         "xen",
-		ImageType:          "machine",
-		PlatformDetails:    "Linux/UNIX",
-		BlockDeviceMappings: []driver.ImageBlockDeviceMapping{{
-			DeviceName:          "/dev/sda1",
-			SnapshotID:          snapID,
-			VolumeSize:          imageRootDeviceSize,
-			VolumeType:          "gp2",
-			DeleteOnTermination: true,
-		}},
+		ID:                  id,
+		Name:                cfg.Name,
+		State:               stateAvailable,
+		Description:         cfg.Description,
+		CreatedAt:           now,
+		Tags:                copyTags(cfg.Tags),
+		OwnerID:             m.opts.AccountID,
+		Architecture:        "x86_64",
+		RootDeviceType:      "ebs",
+		RootDeviceName:      imageRootDeviceName(bdms),
+		VirtualizationType:  "hvm",
+		Hypervisor:          "xen",
+		ImageType:           "machine",
+		PlatformDetails:     "Linux/UNIX",
+		BlockDeviceMappings: bdms,
 	}
 
 	m.images.Set(id, img)
@@ -1990,6 +2015,148 @@ func (m *Mock) CreateImage(_ context.Context, cfg driver.ImageConfig) (*driver.I
 	result := *img
 
 	return &result, nil
+}
+
+// snapshotAttachedVolumes snapshots every EBS volume attached to instanceID and
+// returns one block device mapping per snapshot, ordered by device name for
+// determinism. An instance with no materialized volumes still yields a single
+// snapshot-backed root mapping so DescribeImages reports a realistic AMI.
+func (m *Mock) snapshotAttachedVolumes(instanceID, amiID, now string) []driver.ImageBlockDeviceMapping {
+	attached := make([]*driver.VolumeInfo, 0)
+
+	for _, volID := range m.volumes.Keys() {
+		if v, ok := m.volumes.Get(volID); ok && v.AttachedTo == instanceID {
+			attached = append(attached, v)
+		}
+	}
+
+	sort.Slice(attached, func(i, j int) bool { return attached[i].Device < attached[j].Device })
+
+	bdms := make([]driver.ImageBlockDeviceMapping, 0, len(attached))
+
+	for _, v := range attached {
+		snapID := m.snapshotForImage(v.ID, amiID, v.Size, v.Encrypted, now)
+		bdms = append(bdms, driver.ImageBlockDeviceMapping{
+			DeviceName:          v.Device,
+			SnapshotID:          snapID,
+			VolumeSize:          v.Size,
+			VolumeType:          v.VolumeType,
+			DeleteOnTermination: v.DeleteOnTermination,
+		})
+	}
+
+	if len(bdms) == 0 {
+		snapID := m.snapshotForImage("", amiID, imageRootDeviceSize, false, now)
+		bdms = append(bdms, driver.ImageBlockDeviceMapping{
+			DeviceName:          defaultRootDeviceName,
+			SnapshotID:          snapID,
+			VolumeSize:          imageRootDeviceSize,
+			VolumeType:          defaultVolumeType,
+			DeleteOnTermination: true,
+		})
+	}
+
+	return bdms
+}
+
+// snapshotForImage stores a completed snapshot of volumeID for the AMI being
+// created and returns its id.
+func (m *Mock) snapshotForImage(volumeID, amiID string, size int, encrypted bool, now string) string {
+	snapID := fmt.Sprintf("snap-%012d", m.snapCounter.Add(1))
+	m.snapshots.Set(snapID, &driver.SnapshotInfo{
+		ID:          snapID,
+		VolumeID:    volumeID,
+		State:       "completed",
+		Description: "Created by CreateImage for " + amiID,
+		Size:        size,
+		CreatedAt:   now,
+		OwnerID:     m.opts.AccountID,
+		Progress:    "100%",
+		Encrypted:   encrypted,
+	})
+
+	return snapID
+}
+
+// applyImageBDMOverrides folds the client-supplied CreateImage block device
+// mappings onto the snapshot-derived base: a NoDevice entry suppresses its
+// device, an override for an existing device replaces its non-zero size / set
+// type / snapshot and its DeleteOnTermination, and a mapping for a new device is
+// appended.
+func applyImageBDMOverrides(
+	base, overrides []driver.ImageBlockDeviceMapping, noDevices []string,
+) []driver.ImageBlockDeviceMapping {
+	suppressed := make(map[string]bool, len(noDevices))
+	for _, d := range noDevices {
+		suppressed[d] = true
+	}
+
+	result := make([]driver.ImageBlockDeviceMapping, 0, len(base)+len(overrides))
+	idx := make(map[string]int, len(base))
+
+	for _, b := range base {
+		if suppressed[b.DeviceName] {
+			continue
+		}
+
+		idx[b.DeviceName] = len(result)
+		result = append(result, b)
+	}
+
+	for _, o := range overrides {
+		if suppressed[o.DeviceName] {
+			continue
+		}
+
+		if i, ok := idx[o.DeviceName]; ok {
+			mergeImageBDMOverride(&result[i], o)
+			continue
+		}
+
+		if o.VolumeType == "" {
+			o.VolumeType = defaultVolumeType
+		}
+
+		idx[o.DeviceName] = len(result)
+		result = append(result, o)
+	}
+
+	return result
+}
+
+// mergeImageBDMOverride applies a client override onto an existing mapping,
+// keeping the backing snapshot and any attribute the client left unset.
+func mergeImageBDMOverride(dst *driver.ImageBlockDeviceMapping, o driver.ImageBlockDeviceMapping) {
+	if o.VolumeSize > 0 {
+		dst.VolumeSize = o.VolumeSize
+	}
+
+	if o.VolumeType != "" {
+		dst.VolumeType = o.VolumeType
+	}
+
+	if o.SnapshotID != "" {
+		dst.SnapshotID = o.SnapshotID
+	}
+
+	dst.DeleteOnTermination = o.DeleteOnTermination
+}
+
+// imageRootDeviceName picks the AMI's root device: the conventional
+// defaultRootDeviceName when present, otherwise the first (device-sorted)
+// mapping, falling back to the default when there are none.
+func imageRootDeviceName(bdms []driver.ImageBlockDeviceMapping) string {
+	for _, b := range bdms {
+		if b.DeviceName == defaultRootDeviceName {
+			return b.DeviceName
+		}
+	}
+
+	if len(bdms) > 0 {
+		return bdms[0].DeviceName
+	}
+
+	return defaultRootDeviceName
 }
 
 // DeregisterImage deregisters a machine image.

--- a/server/aws/ec2/image.go
+++ b/server/aws/ec2/image.go
@@ -1,6 +1,7 @@
 package ec2
 
 import (
+	"context"
 	"encoding/xml"
 	"net/http"
 	"strconv"
@@ -65,15 +66,19 @@ type deregisterImageResponseXML struct {
 	Return    bool     `xml:"return"`
 }
 
-func (h *Handler) createImage(w http.ResponseWriter, r *http.Request) {
-	cfg := computedriver.ImageConfig{
-		InstanceID:  r.Form.Get("InstanceId"),
-		Name:        r.Form.Get("Name"),
-		Description: r.Form.Get("Description"),
-		Tags:        mergeTagSpecs(awsquery.TagSpecs(r.Form), "image"),
-	}
+// awsImageCreator is the AWS-specific CreateImage capability: it carries the
+// NoReboot flag and client BlockDeviceMapping.N overrides that the base
+// computedriver.Compute.CreateImage does not model. The AWS EC2 provider
+// implements it; a driver that does not falls back to the base CreateImage.
+type awsImageCreator interface {
+	CreateImageWithOptions(
+		ctx context.Context, cfg computedriver.ImageConfig, noReboot bool,
+		overrides []computedriver.ImageBlockDeviceMapping, noDevices []string,
+	) (*computedriver.ImageInfo, error)
+}
 
-	info, err := h.compute.CreateImage(r.Context(), cfg)
+func (h *Handler) createImage(w http.ResponseWriter, r *http.Request) {
+	info, err := h.createImageInfo(r)
 	if err != nil {
 		writeImageErr(w, err)
 		return
@@ -84,6 +89,59 @@ func (h *Handler) createImage(w http.ResponseWriter, r *http.Request) {
 		RequestID: awsquery.RequestID,
 		ImageID:   info.ID,
 	})
+}
+
+// createImageInfo routes to the AWS CreateImage capability (honoring NoReboot +
+// client BlockDeviceMapping.N) when the driver implements it, and otherwise to
+// the base CreateImage.
+func (h *Handler) createImageInfo(r *http.Request) (*computedriver.ImageInfo, error) {
+	cfg := computedriver.ImageConfig{
+		InstanceID:  r.Form.Get("InstanceId"),
+		Name:        r.Form.Get("Name"),
+		Description: r.Form.Get("Description"),
+		Tags:        mergeTagSpecs(awsquery.TagSpecs(r.Form), "image"),
+	}
+
+	creator, ok := h.compute.(awsImageCreator)
+	if !ok {
+		return h.compute.CreateImage(r.Context(), cfg)
+	}
+
+	overrides, noDevices := parseCreateImageBlockDeviceMappings(r)
+
+	return creator.CreateImageWithOptions(
+		r.Context(), cfg, r.Form.Get("NoReboot") == formTrue, overrides, noDevices,
+	)
+}
+
+// parseCreateImageBlockDeviceMappings reads the CreateImage BlockDeviceMapping.N
+// query groups into client overrides and the set of NoDevice suppressions. A
+// group carrying BlockDeviceMapping.N.NoDevice suppresses its DeviceName; every
+// other group is an override (of an attached volume's device) or an added
+// mapping. The DeleteOnTermination value is taken as the client sent it.
+func parseCreateImageBlockDeviceMappings(
+	r *http.Request,
+) (overrides []computedriver.ImageBlockDeviceMapping, noDevices []string) {
+	for _, i := range awsquery.CollectIndices(r.Form, "BlockDeviceMapping") {
+		base := "BlockDeviceMapping." + strconv.Itoa(i)
+		device := r.Form.Get(base + ".DeviceName")
+
+		if r.Form.Has(base + ".NoDevice") {
+			noDevices = append(noDevices, device)
+			continue
+		}
+
+		size, _ := strconv.Atoi(r.Form.Get(base + ".Ebs.VolumeSize"))
+		overrides = append(overrides, computedriver.ImageBlockDeviceMapping{
+			DeviceName:          device,
+			SnapshotID:          r.Form.Get(base + ".Ebs.SnapshotId"),
+			VolumeSize:          size,
+			VolumeType:          r.Form.Get(base + ".Ebs.VolumeType"),
+			DeleteOnTermination: r.Form.Get(base+".Ebs.DeleteOnTermination") == formTrue,
+		})
+	}
+
+	return overrides, noDevices
 }
 
 type registerImageResponseXML struct {

--- a/server/aws/ec2/image.go
+++ b/server/aws/ec2/image.go
@@ -73,7 +73,7 @@ type deregisterImageResponseXML struct {
 type awsImageCreator interface {
 	CreateImageWithOptions(
 		ctx context.Context, cfg computedriver.ImageConfig, noReboot bool,
-		overrides []computedriver.ImageBlockDeviceMapping, noDevices []string,
+		overrides []computedriver.ImageBlockDeviceMapping, noDevices, dotSetDevices []string,
 	) (*computedriver.ImageInfo, error)
 }
 
@@ -107,21 +107,24 @@ func (h *Handler) createImageInfo(r *http.Request) (*computedriver.ImageInfo, er
 		return h.compute.CreateImage(r.Context(), cfg)
 	}
 
-	overrides, noDevices := parseCreateImageBlockDeviceMappings(r)
+	overrides, noDevices, dotSetDevices := parseCreateImageBlockDeviceMappings(r)
 
 	return creator.CreateImageWithOptions(
-		r.Context(), cfg, r.Form.Get("NoReboot") == formTrue, overrides, noDevices,
+		r.Context(), cfg, r.Form.Get("NoReboot") == formTrue, overrides, noDevices, dotSetDevices,
 	)
 }
 
 // parseCreateImageBlockDeviceMappings reads the CreateImage BlockDeviceMapping.N
-// query groups into client overrides and the set of NoDevice suppressions. A
-// group carrying BlockDeviceMapping.N.NoDevice suppresses its DeviceName; every
-// other group is an override (of an attached volume's device) or an added
-// mapping. The DeleteOnTermination value is taken as the client sent it.
+// query groups into client overrides, the set of NoDevice suppressions, and the
+// set of devices whose DeleteOnTermination the client actually sent. A group
+// carrying BlockDeviceMapping.N.NoDevice suppresses its DeviceName; every other
+// group is an override (of an attached volume's device) or an added mapping. A
+// device is listed in dotSetDevices only when Ebs.DeleteOnTermination was
+// present in the request, so an override that omits it preserves the source
+// volume's DeleteOnTermination rather than silently clearing it.
 func parseCreateImageBlockDeviceMappings(
 	r *http.Request,
-) (overrides []computedriver.ImageBlockDeviceMapping, noDevices []string) {
+) (overrides []computedriver.ImageBlockDeviceMapping, noDevices, dotSetDevices []string) {
 	for _, i := range awsquery.CollectIndices(r.Form, "BlockDeviceMapping") {
 		base := "BlockDeviceMapping." + strconv.Itoa(i)
 		device := r.Form.Get(base + ".DeviceName")
@@ -129,6 +132,10 @@ func parseCreateImageBlockDeviceMappings(
 		if r.Form.Has(base + ".NoDevice") {
 			noDevices = append(noDevices, device)
 			continue
+		}
+
+		if r.Form.Has(base + ".Ebs.DeleteOnTermination") {
+			dotSetDevices = append(dotSetDevices, device)
 		}
 
 		size, _ := strconv.Atoi(r.Form.Get(base + ".Ebs.VolumeSize"))
@@ -141,7 +148,7 @@ func parseCreateImageBlockDeviceMappings(
 		})
 	}
 
-	return overrides, noDevices
+	return overrides, noDevices, dotSetDevices
 }
 
 type registerImageResponseXML struct {

--- a/server/aws/ec2/image_test.go
+++ b/server/aws/ec2/image_test.go
@@ -393,3 +393,120 @@ func TestModifyImageAttributeLaunchPermission(t *testing.T) {
 		t.Error("image Public = false after launchPermission group=all, want true")
 	}
 }
+
+// findBDM returns the block device mapping for device, or nil.
+func findBDM(bdms []ec2types.BlockDeviceMapping, device string) *ec2types.BlockDeviceMapping {
+	for i := range bdms {
+		if aws.ToString(bdms[i].DeviceName) == device {
+			return &bdms[i]
+		}
+	}
+
+	return nil
+}
+
+// TestCreateImageBlockDeviceMappingOverrides drives a real aws-sdk-go-v2 client
+// through CreateImage with NoReboot=true, a client override of the root device's
+// size + DeleteOnTermination, and a NoDevice suppression of an attached data
+// volume — pinning that DescribeImages reflects the override, the data device is
+// gone, and the root mapping is backed by a snapshot that DescribeSnapshots finds.
+func TestCreateImageBlockDeviceMappingOverrides(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-base"),
+		InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+		BlockDeviceMappings: []ec2types.BlockDeviceMapping{{
+			DeviceName: aws.String("/dev/sdf"),
+			Ebs: &ec2types.EbsBlockDevice{
+				VolumeSize:          aws.Int32(20),
+				VolumeType:          ec2types.VolumeTypeGp2,
+				DeleteOnTermination: aws.Bool(false),
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+	instID := aws.ToString(run.Instances[0].InstanceId)
+
+	img, err := client.CreateImage(ctx, &ec2.CreateImageInput{
+		InstanceId: aws.String(instID),
+		Name:       aws.String("override-ami"),
+		NoReboot:   aws.Bool(true),
+		BlockDeviceMappings: []ec2types.BlockDeviceMapping{
+			{
+				DeviceName: aws.String("/dev/sda1"),
+				Ebs: &ec2types.EbsBlockDevice{
+					VolumeSize:          aws.Int32(40),
+					DeleteOnTermination: aws.Bool(false),
+				},
+			},
+			{DeviceName: aws.String("/dev/sdf"), NoDevice: aws.String("")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateImage: %v", err)
+	}
+
+	desc, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{ImageIds: []string{aws.ToString(img.ImageId)}})
+	if err != nil {
+		t.Fatalf("DescribeImages: %v", err)
+	}
+	im := desc.Images[0]
+
+	if findBDM(im.BlockDeviceMappings, "/dev/sdf") != nil {
+		t.Errorf("NoDevice did not suppress /dev/sdf: %+v", im.BlockDeviceMappings)
+	}
+
+	root := findBDM(im.BlockDeviceMappings, "/dev/sda1")
+	if root == nil || root.Ebs == nil {
+		t.Fatalf("root /dev/sda1 mapping missing: %+v", im.BlockDeviceMappings)
+	}
+	if got := aws.ToInt32(root.Ebs.VolumeSize); got != 40 {
+		t.Errorf("root VolumeSize = %d, want 40 (client override)", got)
+	}
+	if aws.ToBool(root.Ebs.DeleteOnTermination) {
+		t.Error("root DeleteOnTermination = true, want false (client override)")
+	}
+
+	snapID := aws.ToString(root.Ebs.SnapshotId)
+	if snapID == "" {
+		t.Fatal("root mapping has no backing snapshot id")
+	}
+
+	snaps, err := client.DescribeSnapshots(ctx, &ec2.DescribeSnapshotsInput{SnapshotIds: []string{snapID}})
+	if err != nil {
+		t.Fatalf("DescribeSnapshots(%s): %v", snapID, err)
+	}
+	if len(snaps.Snapshots) != 1 {
+		t.Fatalf("DescribeSnapshots = %d, want 1", len(snaps.Snapshots))
+	}
+}
+
+// TestCreateImageNoRebootFalseKeepsInstanceRunning pins that the default
+// (NoReboot unset -> reboot) CreateImage reboots the source instance yet leaves
+// it running, so a subsequent DescribeInstances still reports it available.
+func TestCreateImageNoRebootFalseKeepsInstanceRunning(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+	instID := launchInstanceForImage(t, ctx, client)
+
+	if _, err := client.CreateImage(ctx, &ec2.CreateImageInput{
+		InstanceId: aws.String(instID),
+		Name:       aws.String("reboot-ami"),
+	}); err != nil {
+		t.Fatalf("CreateImage(NoReboot=false): %v", err)
+	}
+
+	desc, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{InstanceIds: []string{instID}})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+	if got := desc.Reservations[0].Instances[0].State.Name; got != ec2types.InstanceStateNameRunning {
+		t.Fatalf("instance state after rebooting CreateImage = %q, want running", got)
+	}
+}

--- a/server/aws/ec2/image_test.go
+++ b/server/aws/ec2/image_test.go
@@ -487,6 +487,46 @@ func TestCreateImageBlockDeviceMappingOverrides(t *testing.T) {
 	}
 }
 
+// TestCreateImageRootResizePreservesDeleteOnTermination pins the common
+// Packer/Terraform root-resize pattern through the real SDK: a CreateImage BDM
+// override that sets only Ebs.VolumeSize (no DeleteOnTermination) resizes the
+// AMI's root device yet keeps the source volume's DeleteOnTermination=true,
+// rather than silently clearing it to false.
+func TestCreateImageRootResizePreservesDeleteOnTermination(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+	instID := launchInstanceForImage(t, ctx, client)
+
+	img, err := client.CreateImage(ctx, &ec2.CreateImageInput{
+		InstanceId: aws.String(instID),
+		Name:       aws.String("resize-ami"),
+		NoReboot:   aws.Bool(true),
+		BlockDeviceMappings: []ec2types.BlockDeviceMapping{{
+			DeviceName: aws.String("/dev/sda1"),
+			Ebs:        &ec2types.EbsBlockDevice{VolumeSize: aws.Int32(100)}, // DeleteOnTermination left nil
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateImage: %v", err)
+	}
+
+	desc, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{ImageIds: []string{aws.ToString(img.ImageId)}})
+	if err != nil {
+		t.Fatalf("DescribeImages: %v", err)
+	}
+
+	root := findBDM(desc.Images[0].BlockDeviceMappings, "/dev/sda1")
+	if root == nil || root.Ebs == nil {
+		t.Fatalf("root /dev/sda1 mapping missing: %+v", desc.Images[0].BlockDeviceMappings)
+	}
+	if got := aws.ToInt32(root.Ebs.VolumeSize); got != 100 {
+		t.Errorf("root VolumeSize = %d, want 100", got)
+	}
+	if !aws.ToBool(root.Ebs.DeleteOnTermination) {
+		t.Error("root DeleteOnTermination = false after size-only override, want true (source preserved)")
+	}
+}
+
 // TestCreateImageNoRebootFalseKeepsInstanceRunning pins that the default
 // (NoReboot unset -> reboot) CreateImage reboots the source instance yet leaves
 // it running, so a subsequent DescribeInstances still reports it available.


### PR DESCRIPTION
## Summary

Brings AWS EC2 `CreateImage` to real-cloud fidelity (world-case compute PR8).

- **Snapshot-backed AMIs**: now that RunInstances materializes real root/data EBS volumes (#960), CreateImage snapshots *each* attached volume and references those snapshots from the AMI's block device mapping (`Ebs.SnapshotId`). DescribeImages shows a realistic snapshot-backed BDM and the AMI→snapshot in-use guard works. Replaces the old single synthetic 8 GiB root snapshot.
- **NoReboot**: when `NoReboot=false` (the EC2 default), a running source instance is rebooted as part of image creation (same state-machine + lifecycle-metric path as RebootInstances); `NoReboot=true` leaves it untouched. A stopped instance is never rebooted.
- **Client BlockDeviceMapping.N**: overrides an attached volume's size/type/DeleteOnTermination (and snapshot, if named), adds a new mapping, or suppresses one via `NoDevice`.

## Design

The base `Compute.CreateImage` keeps the portable/Azure/GCP contract unchanged. AWS-specific NoReboot + client-BDM handling is reached through a new `awsImageCreator` optional capability declared in `server/aws/ec2` and implemented by the EC2 mock — no change to `services/compute/driver`. RegisterImage/CopyImage already fit the snapshot-backed model and are unchanged.

## Tests

- Provider (`providers/aws/ec2/create_image_test.go`): multi-volume snapshotting + snapshot↔volume linkage, override/suppress, add-new-mapping, and NoReboot reboot semantics (metric emission) — all `-race`.
- Wire, real aws-sdk-go-v2 (`server/aws/ec2/image_test.go`): CreateImage with NoReboot + root-size/DoT override + NoDevice suppression reflected in DescribeImages, snapshot found in DescribeSnapshots; default (reboot) path leaves the instance running.

## Gates
build, gofmt, `go test ./providers/aws/... ./server/aws/... -race`, golangci-lint (0 new), coveragegen (no diff), `go mod tidy` (clean) — all green.