### PR TITLE
feat(azure-compute): materialize OS + implicit data disks, deleteOption cascade

### DIFF
--- a/docs/coverage/azure/virtualmachines.md
+++ b/docs/coverage/azure/virtualmachines.md
@@ -58,6 +58,14 @@ AzureDiskAccessor is an optional Azure-only capability for the managed-disk
 | `GrantDiskAccess` | GrantDiskAccess issues a time-bounded SAS URI granting the requested |
 | `RevokeDiskAccess` | RevokeDiskAccess revokes any SAS access previously granted to the disk. |
 
+### AzureDiskDeleteOptioner
+
+AzureDiskDeleteOptioner is an optional Azure-only capability that records a
+
+| Operation | Description |
+| --- | --- |
+| `SetDiskDeleteOnTermination` | SetDiskDeleteOnTermination records whether the volume is deleted (true) or |
+
 ### AzureDiskUpdater
 
 AzureDiskUpdater is an optional Azure-only capability for an in-place managed

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -2344,6 +2344,16 @@
         ]
       },
       {
+        "name": "AzureDiskDeleteOptioner",
+        "doc": "AzureDiskDeleteOptioner is an optional Azure-only capability that records a",
+        "operations": [
+          {
+            "name": "SetDiskDeleteOnTermination",
+            "doc": "SetDiskDeleteOnTermination records whether the volume is deleted (true) or"
+          }
+        ]
+      },
+      {
         "name": "AzureDiskUpdater",
         "doc": "AzureDiskUpdater is an optional Azure-only capability for an in-place managed",
         "operations": [

--- a/providers/azure/virtualmachines/disk_delete_option_test.go
+++ b/providers/azure/virtualmachines/disk_delete_option_test.go
@@ -1,0 +1,128 @@
+package virtualmachines
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/services/compute/driver"
+)
+
+// attachDiskWithDeleteOption creates a managed disk, attaches it to instanceID
+// at device, and records its deleteOption (deleteOnTermination) — the sequence
+// the Azure VM wire handler runs when materializing an OS/data disk.
+func attachDiskWithDeleteOption(
+	ctx context.Context, t *testing.T, m *Mock, instanceID, device string, deleteOnTermination bool,
+) string {
+	t.Helper()
+
+	vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 32, VolumeType: "Premium_LRS"})
+	require.NoError(t, err)
+	require.NoError(t, m.AttachVolume(ctx, vol.ID, instanceID, device))
+	require.NoError(t, m.SetDiskDeleteOnTermination(ctx, vol.ID, deleteOnTermination))
+
+	return vol.ID
+}
+
+// TestTerminateDeleteOptionCascade verifies the VM-delete disk cascade honors
+// each attachment's deleteOption: a DeleteOnTermination=true disk is deleted
+// with the VM while a =false disk is detached (returned to available with its
+// attachment cleared).
+func TestTerminateDeleteOptionCascade(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	insts, err := m.RunInstances(ctx, driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_D2s_v3"}, 1)
+	require.NoError(t, err)
+	vmID := insts[0].ID
+
+	deleteVol := attachDiskWithDeleteOption(ctx, t, m, vmID, "osdisk", true)
+	keepVol := attachDiskWithDeleteOption(ctx, t, m, vmID, "0", false)
+
+	require.NoError(t, m.TerminateInstances(ctx, []string{vmID}))
+
+	vols, err := m.DescribeVolumes(ctx, nil)
+	require.NoError(t, err)
+
+	byID := make(map[string]driver.VolumeInfo, len(vols))
+	for _, v := range vols {
+		byID[v.ID] = v
+	}
+
+	// The DeleteOnTermination=true disk is gone.
+	_, stillThere := byID[deleteVol]
+	assert.False(t, stillThere, "deleteOption=Delete disk should be deleted on VM terminate")
+
+	// The DeleteOnTermination=false disk survives, detached.
+	survivor, ok := byID[keepVol]
+	require.True(t, ok, "deleteOption=Detach disk should survive VM terminate")
+	assert.Equal(t, stateAvailable, survivor.State)
+	assert.Empty(t, survivor.AttachedTo)
+	assert.False(t, survivor.DeleteOnTermination, "detach clears the delete-on-termination flag")
+}
+
+// TestConcurrentTerminateAndDetachNoRace exercises the terminate-vs-detach cascade
+// under -race: for many VMs each holding a DeleteOnTermination=true disk, one
+// goroutine terminates the VM while another concurrently detaches its disk. Every
+// mutation goes through the store lock, so there is no data race, and the outcome
+// is always consistent — a disk that survives (detach won the race) is Unattached,
+// never left half-mutated.
+func TestConcurrentTerminateAndDetachNoRace(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	const n = 40
+
+	type pair struct {
+		vmID  string
+		volID string
+	}
+
+	pairs := make([]pair, 0, n)
+
+	for i := 0; i < n; i++ {
+		insts, err := m.RunInstances(ctx, driver.InstanceConfig{
+			ImageID:      "img-1",
+			InstanceType: "Standard_D2s_v3",
+			Tags:         map[string]string{"n": fmt.Sprintf("%d", i)},
+		}, 1)
+		require.NoError(t, err)
+
+		volID := attachDiskWithDeleteOption(ctx, t, m, insts[0].ID, "osdisk", true)
+		pairs = append(pairs, pair{vmID: insts[0].ID, volID: volID})
+	}
+
+	var wg sync.WaitGroup
+
+	for _, p := range pairs {
+		wg.Add(2)
+
+		go func(vmID string) {
+			defer wg.Done()
+
+			_ = m.TerminateInstances(ctx, []string{vmID})
+		}(p.vmID)
+
+		go func(volID string) {
+			defer wg.Done()
+
+			_ = m.DetachVolume(ctx, volID, "", "")
+		}(p.volID)
+	}
+
+	wg.Wait()
+
+	// The store must be self-consistent: any disk that survived the race is
+	// detached (available, no attachment), never corrupted.
+	vols, err := m.DescribeVolumes(ctx, nil)
+	require.NoError(t, err)
+
+	for _, v := range vols {
+		assert.Equal(t, stateAvailable, v.State, "surviving disk %s must be available", v.ID)
+		assert.Empty(t, v.AttachedTo, "surviving disk %s must have no attachment", v.ID)
+	}
+}

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -31,13 +31,14 @@ import (
 // Compile-time checks that Mock implements driver.Compute and, when a real
 // compute engine is wired, the optional driver.ConsoleReader capability.
 var (
-	_ driver.Compute            = (*Mock)(nil)
-	_ driver.ConsoleReader      = (*Mock)(nil)
-	_ driver.AzureVMController  = (*Mock)(nil)
-	_ driver.AzureDiskUpdater   = (*Mock)(nil)
-	_ driver.KeyPairGenerator   = (*Mock)(nil)
-	_ driver.AzureDiskAccessor  = (*Mock)(nil)
-	_ driver.AzureSSHKeyUpdater = (*Mock)(nil)
+	_ driver.Compute                 = (*Mock)(nil)
+	_ driver.ConsoleReader           = (*Mock)(nil)
+	_ driver.AzureVMController       = (*Mock)(nil)
+	_ driver.AzureDiskUpdater        = (*Mock)(nil)
+	_ driver.KeyPairGenerator        = (*Mock)(nil)
+	_ driver.AzureDiskAccessor       = (*Mock)(nil)
+	_ driver.AzureSSHKeyUpdater      = (*Mock)(nil)
+	_ driver.AzureDiskDeleteOptioner = (*Mock)(nil)
 )
 
 const (
@@ -880,6 +881,11 @@ func (m *Mock) TerminateInstances(ctx context.Context, instanceIDs []string) err
 		return err
 	}
 
+	// Cascade the attached managed disks per each attachment's ARM deleteOption
+	// (recorded as VolumeInfo.DeleteOnTermination): a disk with the flag set is
+	// deleted with the VM, one without it is detached (returned to Unattached).
+	m.cascadeTerminatedVolumes(instanceIDs)
+
 	// Tear down the real backing for any engine-backed instances. Every id is now
 	// Terminated (transitionInstances verified they exist), so this is best-effort:
 	// continue through the whole batch and aggregate errors, otherwise one
@@ -915,6 +921,40 @@ func (m *Mock) TerminateInstances(ctx context.Context, instanceIDs []string) err
 	}
 
 	return errors.Join(errs...)
+}
+
+// cascadeTerminatedVolumes settles every managed disk attached to a
+// now-terminated instance per its ARM deleteOption: a disk whose attachment set
+// DeleteOnTermination=true is DELETED with the VM, one without it is returned to
+// the Unattached state (attachment cleared). The delete-vs-detach decision and
+// the mutation happen under one store-lock span (UpdateOrDelete re-reads the
+// attachment at mutation time) so a concurrent DetachVolume that cleared the
+// attachment first is observed here and the disk is not wrongly deleted.
+func (m *Mock) cascadeTerminatedVolumes(instanceIDs []string) {
+	terminated := make(map[string]bool, len(instanceIDs))
+	for _, id := range instanceIDs {
+		terminated[id] = true
+	}
+
+	for _, volID := range m.volumes.Keys() {
+		m.volumes.UpdateOrDelete(volID, func(v *driver.VolumeInfo) (*driver.VolumeInfo, bool) {
+			if v.AttachedTo == "" || !terminated[v.AttachedTo] {
+				return v, true
+			}
+
+			if v.DeleteOnTermination {
+				return v, false
+			}
+
+			cp := *v
+			cp.State = stateAvailable
+			cp.AttachedTo = ""
+			cp.Device = ""
+			cp.DeleteOnTermination = false
+
+			return &cp, true
+		})
+	}
 }
 
 // GetConsoleOutput returns the console output the configured compute engine
@@ -1135,41 +1175,81 @@ func (m *Mock) DescribeVolumes(_ context.Context, ids []string) ([]driver.Volume
 }
 
 func (m *Mock) AttachVolume(_ context.Context, volumeID, instanceID, device string) error {
-	vol, ok := m.volumes.Get(volumeID)
-	if !ok {
-		return cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)
-	}
-
-	if vol.State == stateInUse {
-		return cerrors.Newf(cerrors.FailedPrecondition, "disk %q already attached", volumeID)
-	}
-
 	if _, ok := m.instances.Get(instanceID); !ok {
 		return cerrors.Newf(cerrors.NotFound, "VM %q not found", instanceID)
 	}
 
-	vol.State = stateInUse
-	vol.AttachedTo = instanceID
-	vol.Device = device
+	// The in-use precondition and the mutation must happen under one store-lock
+	// span (copy-on-write) so a concurrent AttachVolume/DetachVolume on the same
+	// disk cannot race between the check and the write.
+	var attachErr error
 
-	return nil
-}
+	ok := m.volumes.Update(volumeID, func(v *driver.VolumeInfo) *driver.VolumeInfo {
+		if v.State == stateInUse {
+			attachErr = cerrors.Newf(cerrors.FailedPrecondition, "disk %q already attached", volumeID)
+			return v
+		}
 
-// DetachVolume detaches a managed disk. instanceID/device are accepted for
-// driver-interface parity with AWS; Azure detaches by disk id alone.
-func (m *Mock) DetachVolume(_ context.Context, volumeID, _, _ string) error {
-	vol, ok := m.volumes.Get(volumeID)
+		cp := *v
+		cp.State = stateInUse
+		cp.AttachedTo = instanceID
+		cp.Device = device
+
+		return &cp
+	})
+
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)
 	}
 
-	if vol.State != "in-use" {
-		return cerrors.Newf(cerrors.FailedPrecondition, "disk %q is not attached", volumeID)
+	return attachErr
+}
+
+// DetachVolume detaches a managed disk. instanceID/device are accepted for
+// driver-interface parity with AWS; Azure detaches by disk id alone. The
+// attachment-scoped DeleteOnTermination flag is cleared on detach (a disk that
+// survives its VM is no longer slated for cascade deletion).
+func (m *Mock) DetachVolume(_ context.Context, volumeID, _, _ string) error {
+	var detachErr error
+
+	ok := m.volumes.Update(volumeID, func(v *driver.VolumeInfo) *driver.VolumeInfo {
+		if v.State != stateInUse {
+			detachErr = cerrors.Newf(cerrors.FailedPrecondition, "disk %q is not attached", volumeID)
+			return v
+		}
+
+		cp := *v
+		cp.State = stateAvailable
+		cp.AttachedTo = ""
+		cp.Device = ""
+		cp.DeleteOnTermination = false
+
+		return &cp
+	})
+
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)
 	}
 
-	vol.State = stateAvailable
-	vol.AttachedTo = ""
-	vol.Device = ""
+	return detachErr
+}
+
+// SetDiskDeleteOnTermination records a disk attachment's ARM deleteOption on the
+// volume (deleteOption "Delete" ⟷ deleteOnTermination true), so VM delete can
+// cascade: a true flag deletes the disk with the VM, a false one detaches it.
+// It backs the AzureDiskDeleteOptioner capability; the Azure VM wire handler
+// calls it after attaching each OS / data disk a VM's storageProfile references.
+func (m *Mock) SetDiskDeleteOnTermination(_ context.Context, volumeID string, deleteOnTermination bool) error {
+	ok := m.volumes.Update(volumeID, func(v *driver.VolumeInfo) *driver.VolumeInfo {
+		cp := *v
+		cp.DeleteOnTermination = deleteOnTermination
+
+		return &cp
+	})
+
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)
+	}
 
 	return nil
 }

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -3,6 +3,7 @@ package virtualmachines
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"sort"
 	"strconv"
@@ -23,9 +24,24 @@ const armNameTag = "cloudemu:azureName"
 // volume, and an attached volume's driver Device (the LUN we pass to
 // AttachVolume) can be echoed back on GET/LIST/CreateOrUpdate/Update.
 const (
-	diskARMNameTag = "cloudemu:azureDiskName"
-	diskRGTag      = "cloudemu:azureRG"
+	diskARMNameTag      = "cloudemu:azureDiskName"
+	diskRGTag           = "cloudemu:azureRG"
+	diskCreateOptionTag = "cloudemu:createOption"
 )
+
+// osDiskDevice is the driver Device marker a materialized OS disk is attached
+// at, distinguishing it from data disks (which attach at a numeric LUN). It is
+// non-numeric so parseLUN excludes the OS disk from data-disk reconciliation and
+// from the storageProfile.dataDisks response.
+const osDiskDevice = "osdisk"
+
+// createOptionAttach references an existing managed disk rather than
+// provisioning a new one.
+const createOptionAttach = "Attach"
+
+// deleteOptionDelete is the ARM deleteOption that cascades a disk's deletion
+// with its VM (the alternative, "Detach", is the default and leaves the disk).
+const deleteOptionDelete = "Delete"
 
 // URL schemes for building absolute self-referential URLs (async operation
 // status, boot-diagnostics serial log) against the incoming request.
@@ -120,10 +136,17 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 		return
 	}
 
+	// Materialize the VM's OS managed disk as a real Microsoft.Compute/disks
+	// resource so the disks API returns it, attached to the VM.
+	if err := h.materializeOSDisk(r.Context(), rp, instances[0].ID, req.Properties.StorageProfile); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
 	// storageProfile.dataDisks is the VM's complete desired data-disk state on
-	// PUT (real Azure's full-replace semantics): attach every referenced
-	// managed disk not yet attached.
-	if err := h.applyDataDisks(r.Context(), instances[0].ID, dataDisksOf(req.Properties.StorageProfile), true); err != nil {
+	// PUT (real Azure's full-replace semantics): materialize+attach every
+	// implicit disk and attach every referenced managed disk not yet attached.
+	if err := h.applyDataDisks(r.Context(), rp, instances[0].ID, dataDisksOf(req.Properties.StorageProfile), true); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
@@ -198,10 +221,17 @@ func (h *Handler) updateExisting(
 		existing = updated
 	}
 
+	// A re-PUT ensures the OS disk exists (idempotent: a no-op when already
+	// materialized, aside from refreshing its deleteOption).
+	if err := h.materializeOSDisk(r.Context(), rp, existing.ID, req.Properties.StorageProfile); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
 	// storageProfile.dataDisks is the VM's complete desired data-disk state on
-	// PUT: attach newly-referenced managed disks and detach any previously
+	// PUT: materialize+attach newly-referenced disks and detach any previously
 	// attached disk whose LUN is no longer present in the request.
-	if err := h.applyDataDisks(r.Context(), existing.ID, dataDisksOf(req.Properties.StorageProfile), true); err != nil {
+	if err := h.applyDataDisks(r.Context(), rp, existing.ID, dataDisksOf(req.Properties.StorageProfile), true); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
@@ -257,7 +287,7 @@ func (h *Handler) update(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 	// nil for an omitted array and a non-nil (possibly empty) slice for a present
 	// one, so presence is a sufficient declarative-vs-merge discriminator.
 	if err = h.applyDataDisks(
-		r.Context(), inst.ID, dataDisksOf(req.Properties.StorageProfile), dataDisksPresent(req.Properties.StorageProfile),
+		r.Context(), rp, inst.ID, dataDisksOf(req.Properties.StorageProfile), dataDisksPresent(req.Properties.StorageProfile),
 	); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -300,8 +330,13 @@ func dataDisksPresent(s *storageProfile) bool {
 // CreateOrUpdate always uses full-replace; PATCH Update uses full-replace when
 // the request supplies a dataDisks array and merge-patch when it omits one.
 // Both modes attach any entry whose managedDisk.id resolves to a disk not yet
-// attached at that LUN.
-func (h *Handler) applyDataDisks(ctx context.Context, instanceID string, disks []dataDisk, declarative bool) error {
+// attached at that LUN, and materialize a brand-new managed disk for any entry
+// whose createOption is implicit (Empty/FromImage/Copy/Restore).
+//
+//nolint:gocritic // rp is a request-scoped value threaded through the disk apply chain.
+func (h *Handler) applyDataDisks(
+	ctx context.Context, rp azurearm.ResourcePath, instanceID string, disks []dataDisk, declarative bool,
+) error {
 	vols, err := h.compute.DescribeVolumes(ctx, nil)
 	if err != nil {
 		return err
@@ -313,7 +348,7 @@ func (h *Handler) applyDataDisks(ctx context.Context, instanceID string, disks [
 	for i := range disks {
 		seen[disks[i].Lun] = true
 
-		if err := h.applyDataDisk(ctx, instanceID, &disks[i], vols, attached); err != nil {
+		if err := h.applyDataDisk(ctx, rp, instanceID, &disks[i], vols, attached); err != nil {
 			return err
 		}
 	}
@@ -326,12 +361,14 @@ func (h *Handler) applyDataDisks(ctx context.Context, instanceID string, disks [
 }
 
 // applyDataDisk applies one storageProfile.dataDisks entry: detaches the disk
-// currently attached at d.Lun when d.ToBeDetached is set, otherwise attaches
-// the managed disk resolveAttachDiskID resolves d to — a no-op when that disk
-// is already attached at d.Lun, or when d falls into one of
-// resolveAttachDiskID's DEFERRED createOption cases and resolves to "".
+// currently attached at d.Lun when d.ToBeDetached is set, otherwise attaches the
+// disk d references (createOption Attach) or materializes+attaches a brand-new
+// managed disk (createOption Empty/FromImage/Copy/Restore).
+//
+//nolint:gocritic // rp is a request-scoped value threaded through the disk apply chain.
 func (h *Handler) applyDataDisk(
-	ctx context.Context, instanceID string, d *dataDisk, vols []computedriver.VolumeInfo, attached map[int]string,
+	ctx context.Context, rp azurearm.ResourcePath, instanceID string,
+	d *dataDisk, vols []computedriver.VolumeInfo, attached map[int]string,
 ) error {
 	if d.ToBeDetached {
 		volID, ok := attached[d.Lun]
@@ -348,20 +385,74 @@ func (h *Handler) applyDataDisk(
 		return nil
 	}
 
-	return h.attachDataDisk(ctx, instanceID, d, vols, attached)
+	if isImplicitCreateOption(d.CreateOption) {
+		return h.attachImplicitDataDisk(ctx, rp, instanceID, d, attached)
+	}
+
+	return h.attachExistingDataDisk(ctx, instanceID, d, vols, attached)
 }
 
-// attachDataDisk attaches the managed disk resolveAttachDiskID resolves d to.
-// Real Azure's dataDisks are keyed by lun: re-declaring a lun with a
-// different managedDisk.id implicitly detaches whatever disk currently
-// occupies it (clearing that disk's managedBy/diskState) before attaching the
-// new one, rather than mapping two disks onto one lun. When attached[d.Lun]
-// already holds a different volume, we detach it first and update the attached
-// bookkeeping so the rest of this reconciliation pass (and detachUnlistedDisks)
-// sees the new occupant, not the stale one. A no-op when the resolved disk is
-// already attached at d.Lun, or when d falls into one of resolveAttachDiskID's
-// DEFERRED createOption cases and resolves to "".
-func (h *Handler) attachDataDisk(
+// isImplicitCreateOption reports whether a dataDisk/osDisk createOption
+// provisions a brand-new managed disk (as opposed to Attach, which references an
+// existing one). An empty/unknown createOption is not implicit, so such an entry
+// is skipped rather than materialized.
+func isImplicitCreateOption(opt string) bool {
+	switch strings.ToLower(opt) {
+	case "empty", "fromimage", "copy", "restore":
+		return true
+	default:
+		return false
+	}
+}
+
+// attachImplicitDataDisk materializes a brand-new managed disk for an implicit
+// createOption (Empty/FromImage/Copy/Restore) and attaches it at d.Lun. It is
+// idempotent: when a disk is already attached at d.Lun (e.g. a re-PUT re-sending
+// the same implicit entry) it re-materializes nothing and only refreshes the
+// attachment's deleteOption, so a repeated PUT does not pile up phantom disks.
+//
+//nolint:gocritic // rp is a request-scoped value threaded through the disk apply chain.
+func (h *Handler) attachImplicitDataDisk(
+	ctx context.Context, rp azurearm.ResourcePath, instanceID string, d *dataDisk, attached map[int]string,
+) error {
+	if volID, ok := attached[d.Lun]; ok {
+		return h.applyDiskDeleteOption(ctx, volID, d.DeleteOption)
+	}
+
+	name := d.Name
+	if name == "" {
+		name = fmt.Sprintf("%s_datadisk_%d", rp.ResourceName, d.Lun)
+	}
+
+	vol, err := h.compute.CreateVolume(ctx, computedriver.VolumeConfig{
+		Size:       d.DiskSizeGB,
+		VolumeType: managedDiskStorageType(d.ManagedDisk),
+		Tags:       diskMaterializeTags(name, rp.ResourceGroup, d.CreateOption),
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := h.compute.AttachVolume(ctx, vol.ID, instanceID, strconv.Itoa(d.Lun)); err != nil {
+		return err
+	}
+
+	attached[d.Lun] = vol.ID
+
+	return h.applyDiskDeleteOption(ctx, vol.ID, d.DeleteOption)
+}
+
+// attachExistingDataDisk attaches the pre-existing managed disk d references
+// (createOption Attach). Real Azure's dataDisks are keyed by lun: re-declaring a
+// lun with a different managedDisk.id implicitly detaches whatever disk
+// currently occupies it (clearing that disk's managedBy/diskState) before
+// attaching the new one, rather than mapping two disks onto one lun. When
+// attached[d.Lun] already holds a different volume, we detach it first and
+// update the attached bookkeeping so the rest of this reconciliation pass (and
+// detachUnlistedDisks) sees the new occupant, not the stale one. A no-op when d
+// resolves to "" (an empty/unknown createOption). The attachment's deleteOption
+// is recorded on the disk either way, so a re-declared attachment stays in sync.
+func (h *Handler) attachExistingDataDisk(
 	ctx context.Context, instanceID string, d *dataDisk, vols []computedriver.VolumeInfo, attached map[int]string,
 ) error {
 	volID, err := resolveAttachDiskID(d, vols)
@@ -369,8 +460,12 @@ func (h *Handler) attachDataDisk(
 		return err
 	}
 
-	if volID == "" || attached[d.Lun] == volID {
+	if volID == "" {
 		return nil
+	}
+
+	if attached[d.Lun] == volID {
+		return h.applyDiskDeleteOption(ctx, volID, d.DeleteOption)
 	}
 
 	if prevVolID, ok := attached[d.Lun]; ok && prevVolID != volID {
@@ -385,31 +480,136 @@ func (h *Handler) attachDataDisk(
 
 	attached[d.Lun] = volID
 
-	return nil
+	return h.applyDiskDeleteOption(ctx, volID, d.DeleteOption)
 }
 
-// detachAttachedVolumes detaches every volume the instance currently holds,
-// clearing each disk's managedBy/diskState (returning it to Unattached). Used on
-// VM delete so surviving managed disks (deleteOption=Detach) don't dangle at the
-// deleted VM. It reuses the driver's DetachVolume — the same call applyDataDisks
-// uses — rather than duplicating detach bookkeeping.
-func (h *Handler) detachAttachedVolumes(ctx context.Context, instanceID string) error {
+// applyDiskDeleteOption records an attachment's ARM deleteOption on the disk so
+// VM delete can cascade (Delete → delete the disk, Detach → keep it). It maps
+// deleteOption onto the shared VolumeInfo.DeleteOnTermination via the optional
+// AzureDiskDeleteOptioner capability; a driver without it is a no-op.
+func (h *Handler) applyDiskDeleteOption(ctx context.Context, volID, deleteOption string) error {
+	optioner, ok := h.compute.(computedriver.AzureDiskDeleteOptioner)
+	if !ok {
+		return nil
+	}
+
+	return optioner.SetDiskDeleteOnTermination(ctx, volID, strings.EqualFold(deleteOption, deleteOptionDelete))
+}
+
+// managedDiskStorageType returns the storageAccountType (disk SKU) an ARM
+// managedDisk block requests, or "" when unset (CreateVolume then defaults it).
+func managedDiskStorageType(m *managedDiskParameters) string {
+	if m == nil {
+		return ""
+	}
+
+	return m.StorageAccountType
+}
+
+// diskMaterializeTags builds the cloudemu-internal tag set that lets the disks
+// wire handler render a materialized OS/data disk as a Microsoft.Compute/disks
+// resource: its ARM name, resource group, and createOption.
+func diskMaterializeTags(name, resourceGroup, createOption string) map[string]string {
+	tags := map[string]string{diskARMNameTag: name}
+
+	if resourceGroup != "" {
+		tags[diskRGTag] = resourceGroup
+	}
+
+	if createOption != "" {
+		tags[diskCreateOptionTag] = createOption
+	}
+
+	return tags
+}
+
+// materializeOSDisk creates and attaches the VM's OS managed disk as a real
+// Microsoft.Compute/disks resource from storageProfile.osDisk, so the disks API
+// returns it. createOption Attach references an existing disk; Empty/FromImage
+// (or an unset createOption, treated as FromImage) provisions a new one. It is
+// idempotent: a re-PUT that finds the OS disk already attached only refreshes
+// the attachment's deleteOption. A request with no osDisk is a no-op.
+//
+//nolint:gocritic // rp is a request-scoped value.
+func (h *Handler) materializeOSDisk(
+	ctx context.Context, rp azurearm.ResourcePath, instanceID string, sp *storageProfile,
+) error {
+	if sp == nil || sp.OSDisk == nil {
+		return nil
+	}
+
+	od := sp.OSDisk
+
 	vols, err := h.compute.DescribeVolumes(ctx, nil)
 	if err != nil {
 		return err
 	}
 
-	for i := range vols {
-		if vols[i].AttachedTo != instanceID {
-			continue
+	if volID, ok := osDiskOf(vols, instanceID); ok {
+		return h.applyDiskDeleteOption(ctx, volID, od.DeleteOption)
+	}
+
+	volID, err := h.resolveOrCreateOSDisk(ctx, rp, od, vols)
+	if err != nil || volID == "" {
+		return err
+	}
+
+	if err := h.compute.AttachVolume(ctx, volID, instanceID, osDiskDevice); err != nil {
+		return err
+	}
+
+	return h.applyDiskDeleteOption(ctx, volID, od.DeleteOption)
+}
+
+// resolveOrCreateOSDisk resolves the volume backing the OS disk: an Attach
+// createOption references an existing managed disk by managedDisk.id, while any
+// other createOption (defaulting to FromImage) provisions a brand-new disk named
+// {vmName}_osdisk when the request supplies no name.
+//
+//nolint:gocritic // rp is a request-scoped value.
+func (h *Handler) resolveOrCreateOSDisk(
+	ctx context.Context, rp azurearm.ResourcePath, od *osDisk, vols []computedriver.VolumeInfo,
+) (string, error) {
+	if strings.EqualFold(od.CreateOption, createOptionAttach) {
+		if od.ManagedDisk == nil || od.ManagedDisk.ID == "" {
+			return "", cerrors.New(cerrors.InvalidArgument, "osDisk createOption Attach requires managedDisk.id")
 		}
 
-		if err := h.compute.DetachVolume(ctx, vols[i].ID, "", ""); err != nil {
-			return err
+		return resolveManagedDiskVolID(od.ManagedDisk.ID, vols)
+	}
+
+	name := od.Name
+	if name == "" {
+		name = rp.ResourceName + "_osdisk"
+	}
+
+	createOption := od.CreateOption
+	if createOption == "" {
+		createOption = "FromImage"
+	}
+
+	vol, err := h.compute.CreateVolume(ctx, computedriver.VolumeConfig{
+		Size:       od.DiskSizeGB,
+		VolumeType: managedDiskStorageType(od.ManagedDisk),
+		Tags:       diskMaterializeTags(name, rp.ResourceGroup, createOption),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return vol.ID, nil
+}
+
+// osDiskOf returns the id of the OS disk currently attached to instanceID (the
+// volume attached at the osDiskDevice marker), reporting false when none is.
+func osDiskOf(vols []computedriver.VolumeInfo, instanceID string) (string, bool) {
+	for i := range vols {
+		if vols[i].AttachedTo == instanceID && vols[i].Device == osDiskDevice {
+			return vols[i].ID, true
 		}
 	}
 
-	return nil
+	return "", false
 }
 
 // detachUnlistedDisks detaches every attached disk whose LUN is absent from
@@ -462,14 +662,11 @@ func parseLUN(device string) (int, bool) {
 
 // resolveAttachDiskID resolves the volume ID a dataDisk entry's managedDisk.id
 // references. Only createOption "Attach" references an existing managed disk;
-// Empty/FromImage/Copy/Restore implicitly provision a brand-new disk from the
-// VM's storageProfile, which cloudemu does not yet create (DEFERRED — create
-// the managed disk first via PUT .../disks/{name}, then reference it here with
-// createOption "Attach"). Such entries resolve to "" and are silently skipped
-// rather than erroring, so a request that also sets an unsupported implicit
-// disk alongside a supported Attach entry still succeeds for the latter.
+// implicit createOptions (Empty/FromImage/Copy/Restore) are materialized
+// elsewhere (attachImplicitDataDisk), so this resolves them to "" and they are
+// skipped here rather than erroring.
 func resolveAttachDiskID(d *dataDisk, vols []computedriver.VolumeInfo) (string, error) {
-	if !strings.EqualFold(d.CreateOption, "Attach") {
+	if !strings.EqualFold(d.CreateOption, createOptionAttach) {
 		return "", nil
 	}
 
@@ -478,9 +675,16 @@ func resolveAttachDiskID(d *dataDisk, vols []computedriver.VolumeInfo) (string, 
 			"dataDisk lun %d: createOption Attach requires managedDisk.id", d.Lun)
 	}
 
-	pp, ok := azurearm.ParsePath(d.ManagedDisk.ID)
+	return resolveManagedDiskVolID(d.ManagedDisk.ID, vols)
+}
+
+// resolveManagedDiskVolID finds the driver volume backing an ARM managed-disk id
+// (matched by its azureDiskName / azureRG tags). Returns NotFound when no volume
+// carries that name, InvalidArgument when the id is malformed.
+func resolveManagedDiskVolID(managedDiskID string, vols []computedriver.VolumeInfo) (string, error) {
+	pp, ok := azurearm.ParsePath(managedDiskID)
 	if !ok || pp.ResourceName == "" {
-		return "", cerrors.Newf(cerrors.InvalidArgument, "malformed managed disk id %q", d.ManagedDisk.ID)
+		return "", cerrors.Newf(cerrors.InvalidArgument, "malformed managed disk id %q", managedDiskID)
 	}
 
 	for i := range vols {
@@ -613,15 +817,10 @@ func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 		return
 	}
 
-	// A deleted VM's attached data disks default to deleteOption=Detach: the disk
-	// survives but must be released. Detach every volume the VM held first so each
-	// disk's managedBy/diskState is cleared (returned to Unattached) rather than
-	// left dangling at the now-deleted VM, matching real Azure.
-	if err := h.detachAttachedVolumes(r.Context(), inst.ID); err != nil {
-		azurearm.WriteCErr(w, err)
-		return
-	}
-
+	// TerminateInstances cascades the VM's attached managed disks per each
+	// attachment's deleteOption (recorded as VolumeInfo.DeleteOnTermination):
+	// a "Delete" disk is deleted with the VM, a "Detach" disk is released
+	// (returned to Unattached) rather than left dangling — matching real Azure.
 	if err := h.compute.TerminateInstances(r.Context(), []string{inst.ID}); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -637,11 +836,11 @@ func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 // an exact match. Resource-group comparison is case-insensitive, matching ARM.
 // The subscription is unused (the emulator is single-estate).
 //
-// Each VM's attached data disks are detached first — the same release the
-// single-VM delete() path does — so a cascade-deleted VM clears its disks'
-// managedBy/diskState (deleteOption=Detach) rather than leaving them dangling at
-// the now-deleted VM. Detach is best-effort: a single failure is recorded but
-// does not stop the remaining teardown.
+// Each VM's attached managed disks cascade per their deleteOption inside
+// TerminateInstances — the same release the single-VM delete() path relies on —
+// so a cascade-deleted VM deletes its "Delete" disks and releases its "Detach"
+// disks (returned to Unattached) rather than leaving them dangling at the
+// now-deleted VM.
 func (h *Handler) PurgeResourceGroup(ctx context.Context, _, resourceGroup string) error {
 	var firstErr error
 
@@ -656,9 +855,9 @@ func (h *Handler) PurgeResourceGroup(ctx context.Context, _, resourceGroup strin
 	return firstErr
 }
 
-// purgeInstances detaches and terminates every virtual machine under the given
-// resource group — the VM half of the cascade. Detach is best-effort per VM so
-// one failure does not stop the rest.
+// purgeInstances terminates every virtual machine under the given resource
+// group — the VM half of the cascade. TerminateInstances cascades each VM's
+// attached disks per their deleteOption.
 func (h *Handler) purgeInstances(ctx context.Context, resourceGroup string) error {
 	instances, err := h.compute.DescribeInstances(ctx, nil, nil)
 	if err != nil {
@@ -677,19 +876,7 @@ func (h *Handler) purgeInstances(ctx context.Context, resourceGroup string) erro
 		return nil
 	}
 
-	var firstErr error
-
-	for _, id := range ids {
-		if derr := h.detachAttachedVolumes(ctx, id); derr != nil && firstErr == nil {
-			firstErr = derr
-		}
-	}
-
-	if terr := h.compute.TerminateInstances(ctx, ids); terr != nil && firstErr == nil {
-		firstErr = terr
-	}
-
-	return firstErr
+	return h.compute.TerminateInstances(ctx, ids)
 }
 
 // purgeScaleSets deletes every virtual machine scale set under the given

--- a/server/azure/virtualmachines/osdisk_materialize_test.go
+++ b/server/azure/virtualmachines/osdisk_materialize_test.go
@@ -1,0 +1,251 @@
+package virtualmachines_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+)
+
+// TestSDKVMOSDiskMaterialized verifies that creating a VM whose storageProfile
+// declares an osDisk materializes a real Microsoft.Compute/disks resource: a
+// real azure-sdk-for-go DisksClient can Get the OS disk, and it reports the
+// requested size, createOption, SKU, Attached state, and a managedBy pointing
+// back at the VM — the disks API returned nothing for a VM's OS disk before.
+func TestSDKVMOSDiskMaterialized(t *testing.T) {
+	vmClient, diskClient := newDataDiskTestServer(t)
+	ctx := context.Background()
+
+	vm := createVMWithOSDisk(ctx, t, vmClient, "vm-os", "vm-os_osdisk",
+		armcompute.DiskDeleteOptionTypesDelete, nil)
+
+	osDisk, err := diskClient.Get(ctx, "rg-1", "vm-os_osdisk", nil)
+	if err != nil {
+		t.Fatalf("Get OS disk: %v", err)
+	}
+
+	if osDisk.Properties == nil || osDisk.Properties.DiskSizeGB == nil || *osDisk.Properties.DiskSizeGB != 64 {
+		t.Errorf("OS disk diskSizeGB=%v, want 64", osDiskSize(osDisk))
+	}
+
+	if osDisk.Properties.DiskState == nil || *osDisk.Properties.DiskState != armcompute.DiskStateAttached {
+		t.Errorf("OS disk diskState=%v, want Attached", diskStateOf(osDisk))
+	}
+
+	if osDisk.ManagedBy == nil || *osDisk.ManagedBy != *vm.ID {
+		t.Errorf("OS disk managedBy=%v, want %v", derefStr(osDisk.ManagedBy), *vm.ID)
+	}
+
+	if osDisk.Properties.CreationData == nil || osDisk.Properties.CreationData.CreateOption == nil ||
+		*osDisk.Properties.CreationData.CreateOption != armcompute.DiskCreateOptionFromImage {
+		t.Errorf("OS disk createOption=%v, want FromImage", createOptionOf(osDisk))
+	}
+
+	if osDisk.SKU == nil || osDisk.SKU.Name == nil || *osDisk.SKU.Name != armcompute.DiskStorageAccountTypesPremiumLRS {
+		t.Errorf("OS disk sku=%v, want Premium_LRS", osDiskSKU(osDisk))
+	}
+
+	// The OS disk is not reported as a data disk (it attaches at a non-LUN
+	// device), so a GET on the VM shows no data disks.
+	got, err := vmClient.Get(ctx, "rg-1", "vm-os", nil)
+	if err != nil {
+		t.Fatalf("Get VM: %v", err)
+	}
+
+	assertDataDiskLUNs(t, got.Properties.StorageProfile)
+}
+
+// TestSDKVMImplicitEmptyDataDisk verifies that a VM created with a
+// storageProfile.dataDisks entry using createOption=Empty materializes a real
+// managed disk (not just a silent skip): the disks API returns the new disk at
+// its LUN, sized and attached, and the VM's dataDisks reflects the LUN.
+func TestSDKVMImplicitEmptyDataDisk(t *testing.T) {
+	vmClient, diskClient := newDataDiskTestServer(t)
+	ctx := context.Background()
+
+	poller, err := vmClient.BeginCreateOrUpdate(ctx, "rg-1", "vm-empty",
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				StorageProfile: &armcompute.StorageProfile{
+					DataDisks: []*armcompute.DataDisk{{
+						Lun:          to.Ptr[int32](2),
+						Name:         to.Ptr("vm-empty_data2"),
+						CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesEmpty),
+						DiskSizeGB:   to.Ptr[int32](128),
+						ManagedDisk: &armcompute.ManagedDiskParameters{
+							StorageAccountType: to.Ptr(armcompute.StorageAccountTypesStandardSSDLRS),
+						},
+					}},
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate VM: %v", err)
+	}
+
+	vm, err := pollUntilDone(ctx, poller)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate poll: %v", err)
+	}
+
+	// The implicit Empty disk must now exist as a real disk resource.
+	dataDisk, err := diskClient.Get(ctx, "rg-1", "vm-empty_data2", nil)
+	if err != nil {
+		t.Fatalf("Get implicit data disk: %v", err)
+	}
+
+	if dataDisk.Properties == nil || dataDisk.Properties.DiskSizeGB == nil || *dataDisk.Properties.DiskSizeGB != 128 {
+		t.Errorf("data disk diskSizeGB=%v, want 128", osDiskSize(dataDisk))
+	}
+
+	if dataDisk.Properties.DiskState == nil || *dataDisk.Properties.DiskState != armcompute.DiskStateAttached {
+		t.Errorf("data disk diskState=%v, want Attached", diskStateOf(dataDisk))
+	}
+
+	if dataDisk.ManagedBy == nil || *dataDisk.ManagedBy != *vm.ID {
+		t.Errorf("data disk managedBy=%v, want %v", derefStr(dataDisk.ManagedBy), *vm.ID)
+	}
+
+	// And it is attached to the VM at lun 2.
+	got, err := vmClient.Get(ctx, "rg-1", "vm-empty", nil)
+	if err != nil {
+		t.Fatalf("Get VM: %v", err)
+	}
+
+	assertDataDiskLUNs(t, got.Properties.StorageProfile, 2)
+}
+
+// TestSDKVMDeleteDeleteOptionCascade verifies the deleteOption cascade on VM
+// delete: an OS disk with deleteOption=Delete is deleted with the VM (Get 404s),
+// while an implicit data disk with deleteOption=Detach survives, returned to the
+// Unattached state with its managedBy cleared.
+func TestSDKVMDeleteDeleteOptionCascade(t *testing.T) {
+	vmClient, diskClient := newDataDiskTestServer(t)
+	ctx := context.Background()
+
+	dataDisks := []*armcompute.DataDisk{{
+		Lun:          to.Ptr[int32](0),
+		Name:         to.Ptr("vm-cascade_keep0"),
+		CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesEmpty),
+		DiskSizeGB:   to.Ptr[int32](16),
+		DeleteOption: to.Ptr(armcompute.DiskDeleteOptionTypesDetach),
+	}}
+
+	createVMWithOSDisk(ctx, t, vmClient, "vm-cascade", "vm-cascade_osdisk",
+		armcompute.DiskDeleteOptionTypesDelete, dataDisks)
+
+	// Both disks exist and are attached before delete.
+	if _, err := diskClient.Get(ctx, "rg-1", "vm-cascade_osdisk", nil); err != nil {
+		t.Fatalf("OS disk should exist before delete: %v", err)
+	}
+
+	if _, err := diskClient.Get(ctx, "rg-1", "vm-cascade_keep0", nil); err != nil {
+		t.Fatalf("data disk should exist before delete: %v", err)
+	}
+
+	delPoller, err := vmClient.BeginDelete(ctx, "rg-1", "vm-cascade", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete poll: %v", err)
+	}
+
+	// The OS disk (deleteOption=Delete) is gone.
+	if _, err := diskClient.Get(ctx, "rg-1", "vm-cascade_osdisk", nil); !isNotFound(err) {
+		t.Errorf("OS disk after delete: err=%v, want 404 NotFound", err)
+	}
+
+	// The data disk (deleteOption=Detach) survives, now Unattached.
+	survivor, err := diskClient.Get(ctx, "rg-1", "vm-cascade_keep0", nil)
+	if err != nil {
+		t.Fatalf("data disk should survive Detach: %v", err)
+	}
+
+	if survivor.Properties == nil || survivor.Properties.DiskState == nil ||
+		*survivor.Properties.DiskState != armcompute.DiskStateUnattached {
+		t.Errorf("survivor diskState=%v, want Unattached", diskStateOf(survivor))
+	}
+
+	if survivor.ManagedBy != nil && *survivor.ManagedBy != "" {
+		t.Errorf("survivor managedBy=%v after VM delete, want empty", *survivor.ManagedBy)
+	}
+}
+
+// createVMWithOSDisk creates a VM with a Premium_LRS FromImage OS disk named
+// osDiskName carrying deleteOption, plus any data disks, and returns the VM.
+func createVMWithOSDisk(
+	ctx context.Context, t *testing.T, vmClient *armcompute.VirtualMachinesClient,
+	vmName, osDiskName string, osDeleteOption armcompute.DiskDeleteOptionTypes, dataDisks []*armcompute.DataDisk,
+) armcompute.VirtualMachine {
+	t.Helper()
+
+	poller, err := vmClient.BeginCreateOrUpdate(ctx, "rg-1", vmName,
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				StorageProfile: &armcompute.StorageProfile{
+					ImageReference: &armcompute.ImageReference{
+						Publisher: to.Ptr("Canonical"), Offer: to.Ptr("UbuntuServer"),
+						SKU: to.Ptr("22.04-LTS"), Version: to.Ptr("latest"),
+					},
+					OSDisk: &armcompute.OSDisk{
+						Name:         to.Ptr(osDiskName),
+						OSType:       to.Ptr(armcompute.OperatingSystemTypesLinux),
+						CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesFromImage),
+						DiskSizeGB:   to.Ptr[int32](64),
+						DeleteOption: to.Ptr(osDeleteOption),
+						ManagedDisk: &armcompute.ManagedDiskParameters{
+							StorageAccountType: to.Ptr(armcompute.StorageAccountTypesPremiumLRS),
+						},
+					},
+					DataDisks: dataDisks,
+				},
+				OSProfile: &armcompute.OSProfile{ComputerName: to.Ptr(vmName), AdminUsername: to.Ptr("azureuser")},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate %s: %v", vmName, err)
+	}
+
+	vm, err := pollUntilDone(ctx, poller)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate %s poll: %v", vmName, err)
+	}
+
+	return vm
+}
+
+func osDiskSize(d armcompute.DisksClientGetResponse) string {
+	if d.Properties == nil || d.Properties.DiskSizeGB == nil {
+		return "<nil>"
+	}
+
+	return strconv.Itoa(int(*d.Properties.DiskSizeGB))
+}
+
+func createOptionOf(d armcompute.DisksClientGetResponse) string {
+	if d.Properties == nil || d.Properties.CreationData == nil || d.Properties.CreationData.CreateOption == nil {
+		return "<nil>"
+	}
+
+	return string(*d.Properties.CreationData.CreateOption)
+}
+
+func osDiskSKU(d armcompute.DisksClientGetResponse) string {
+	if d.SKU == nil || d.SKU.Name == nil {
+		return "<nil>"
+	}
+
+	return string(*d.SKU.Name)
+}

--- a/server/azure/virtualmachines/types.go
+++ b/server/azure/virtualmachines/types.go
@@ -68,9 +68,19 @@ type storageProfile struct {
 	DataDisks      []dataDisk      `json:"dataDisks,omitempty"`
 }
 
-// osDisk carries the OS-disk shape; we only model osType, a cost input.
+// osDisk carries the ARM storageProfile.osDisk shape. Beyond osType (a cost
+// input), we model the fields needed to materialize the VM's OS managed disk as
+// a real Microsoft.Compute/disks resource on create: its name, createOption
+// (FromImage/Empty/Attach), size, managedDisk.storageAccountType, and the
+// deleteOption that drives the VM-delete cascade.
 type osDisk struct {
-	OSType string `json:"osType,omitempty"`
+	OSType       string                 `json:"osType,omitempty"`
+	Name         string                 `json:"name,omitempty"`
+	CreateOption string                 `json:"createOption,omitempty"`
+	DiskSizeGB   int                    `json:"diskSizeGB,omitempty"`
+	Caching      string                 `json:"caching,omitempty"`
+	ManagedDisk  *managedDiskParameters `json:"managedDisk,omitempty"`
+	DeleteOption string                 `json:"deleteOption,omitempty"`
 }
 
 // dataDisk mirrors armcompute.DataDisk: one entry of storageProfile.dataDisks,
@@ -86,6 +96,11 @@ type dataDisk struct {
 	ManagedDisk  *managedDiskParameters `json:"managedDisk,omitempty"`
 	ToBeDetached bool                   `json:"toBeDetached,omitempty"`
 	DetachOption string                 `json:"detachOption,omitempty"`
+	// DeleteOption ("Delete"/"Detach") drives the VM-delete cascade for this
+	// attachment: "Delete" deletes the managed disk with the VM, "Detach" (the
+	// ARM default) leaves it. It is recorded on the attached volume via
+	// AzureDiskDeleteOptioner.
+	DeleteOption string `json:"deleteOption,omitempty"`
 }
 
 // managedDiskParameters references an existing Microsoft.Compute/disks

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -798,6 +798,22 @@ type AzureDiskUpdater interface {
 	UpdateVolume(ctx context.Context, id string, cfg VolumeConfig) (*VolumeInfo, error)
 }
 
+// AzureDiskDeleteOptioner is an optional Azure-only capability that records a
+// disk attachment's ARM deleteOption on the attached volume, mapped onto the
+// shared VolumeInfo.DeleteOnTermination (deleteOption "Delete" ⟷ true). The
+// Azure VM wire handler sets it after attaching each OS / data disk a VM's
+// storageProfile references, so VM delete can cascade per real Azure's
+// deleteOption: a "Delete" disk is deleted with the VM, a "Detach" disk survives
+// (returned to Unattached). deleteOption is attachment-scoped, so DetachVolume
+// clears the flag. Only the Azure VM mock implements it; the wire handler
+// type-asserts for it, so AWS/GCP are unaffected.
+type AzureDiskDeleteOptioner interface {
+	// SetDiskDeleteOnTermination records whether the volume is deleted (true) or
+	// detached (false) when the VM it is attached to is deleted. Returns NotFound
+	// when volumeID is unknown.
+	SetDiskDeleteOnTermination(ctx context.Context, volumeID string, deleteOnTermination bool) error
+}
+
 // AzureDiskAccessor is an optional Azure-only capability for the managed-disk
 // beginGetAccess / endGetAccess actions (DisksClient.BeginGrantAccess /
 // BeginRevokeAccess): a time-bounded SAS URI is issued for exporting or


### PR DESCRIPTION
## Summary

Closes the Azure half of the compute "boot disk + auto-delete cascade" spine (world-case Compute PR5), building on the shared driver fields landed by #960.

### OS disk materialization
VM create (PUT) now materializes the OS managed disk from `storageProfile.osDisk` as a real `Microsoft.Compute/disks` resource — honoring `createOption` (FromImage/Empty/Attach), name, `diskSizeGB`, and `managedDisk.storageAccountType` — attached to the VM. The disks API `get`/`list` now returns a VM's OS disk (it returned nothing before), with `managedBy` pointing at the VM and `diskState=Attached`.

### Implicit data disks
`storageProfile.dataDisks` entries with an implicit `createOption` (Empty/FromImage/Copy/Restore) now create + attach a brand-new managed disk at their LUN. Previously only `Attach` (a pre-existing disk) worked; implicit entries were silently skipped. Idempotent on re-PUT (no phantom disks pile up).

### deleteOption cascade
VM delete now honors each attachment's ARM `deleteOption`, mapped onto the shared `VolumeInfo.DeleteOnTermination` (`Delete` ⟷ true): a `Delete` disk is deleted with the VM, a `Detach` disk survives (returned to Unattached). The cascade lives in the Azure provider's `TerminateInstances` via `memstore.UpdateOrDelete` (atomic delete-vs-detach, race-clean). `AttachVolume`/`DetachVolume` were converted to copy-on-write `Update`, and `DetachVolume` clears the flag (attachment-scoped). Resource-group purge inherits the same cascade.

New optional driver capability `AzureDiskDeleteOptioner.SetDiskDeleteOnTermination` records the deleteOption on the attached volume; the wire handler type-asserts for it (AWS/GCP unaffected).

### reimage OS-disk reset (bonus)
Left as a no-op on the resource: disk contents are not modeled, so there is nothing to reset — the now-tracked OS disk correctly persists across a reimage power-cycle.

## Tests
- Real `armcompute` e2e (`server/azure/virtualmachines/osdisk_materialize_test.go`): OS disk materialized + queryable via `DisksClient.Get` (size/createOption/SKU/Attached/managedBy); implicit `Empty` data disk created + attached at its LUN; VM delete cascade — `Delete` OS disk 404s, `Detach` data disk survives Unattached.
- Provider `-race` concurrency (`providers/azure/virtualmachines/disk_delete_option_test.go`): functional delete-vs-detach cascade, plus concurrent Terminate-vs-Detach across many VMs with no data race and a self-consistent store.

## Gates
`go build ./...`, `gofmt -l` (clean), `go test -race` on touched packages + broad `./server/azure/... ./providers/azure/... ./services/compute/...`, `golangci-lint` (0 issues), `coveragegen` regenerated, `go mod tidy` clean, `persist` completeness green.
