### PR TITLE
fix(gcp-firestore): isolate documents per project and named database

### DIFF
--- a/server/gcp/firestore/firestore_lifecycle_test.go
+++ b/server/gcp/firestore/firestore_lifecycle_test.go
@@ -259,7 +259,10 @@ func TestDatabaseLifecycle(t *testing.T) {
 	}
 
 	// Drop the table underneath the SDK; collection ops now surface NotFound.
-	if err := h.fs.DeleteTable(ctx, "users"); err != nil {
+	// The handler namespaces the driver table by project and database
+	// ("{project}\x00{database}\x00{collection}"), so drop that exact key — the
+	// SDK's REST client targets the default database.
+	if err := h.fs.DeleteTable(ctx, dbProject+"\x00(default)\x00users"); err != nil {
 		t.Fatalf("DeleteTable: %v", err)
 	}
 

--- a/server/gcp/firestore/firestore_namespace_isolation_test.go
+++ b/server/gcp/firestore/firestore_namespace_isolation_test.go
@@ -1,0 +1,245 @@
+// These tests assert Firestore's per-(project, database) namespace isolation:
+// a document written under one project/database must never be visible under a
+// different project or a different (default vs named) database, even when the
+// collection path and document id are identical. Cross-project isolation is
+// exercised with the REAL cloud.google.com/go/firestore REST SDK (two clients,
+// distinct project ids, one server). Cross-database isolation is exercised over
+// raw REST — the REST SDK constructor hard-codes the "(default)" database, so
+// named databases are only reachable at the wire level.
+package firestore_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gcpfirestore "cloud.google.com/go/firestore"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// newIsolationServer boots a fresh emulator + GCP server shared by every client
+// in a test. Collections are created lazily by the handler on first write, so
+// nothing is pre-declared here.
+func newIsolationServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Firestore: cloudP.Firestore})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+func newRESTClientForProject(t *testing.T, ts *httptest.Server, project string) *gcpfirestore.Client {
+	t.Helper()
+
+	client, err := gcpfirestore.NewRESTClient(context.Background(), project,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewRESTClient(%s): %v", project, err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+// TestCrossProjectDocumentIsolation writes the same collection/doc under two
+// different projects through the real SDK and asserts each project sees only
+// its own document — the historical bug collapsed both projects into one
+// collection namespace, so project B could read (and clobber) project A's data.
+func TestCrossProjectDocumentIsolation(t *testing.T) {
+	ts := newIsolationServer(t)
+	ctx := context.Background()
+
+	clientA := newRESTClientForProject(t, ts, "project-a")
+	clientB := newRESTClientForProject(t, ts, "project-b")
+
+	// Both write cities/SF, with distinct payloads.
+	if _, err := clientA.Collection("cities").Doc("SF").Set(ctx, map[string]any{"owner": "A"}); err != nil {
+		t.Fatalf("A Set: %v", err)
+	}
+
+	if _, err := clientB.Collection("cities").Doc("SF").Set(ctx, map[string]any{"owner": "B"}); err != nil {
+		t.Fatalf("B Set: %v", err)
+	}
+
+	// Each project must read back its OWN value, never the other's.
+	snapA, err := clientA.Collection("cities").Doc("SF").Get(ctx)
+	if err != nil {
+		t.Fatalf("A Get: %v", err)
+	}
+
+	if got := snapA.Data()["owner"]; got != "A" {
+		t.Errorf("project A sees owner=%v, want A (cross-project bleed)", got)
+	}
+
+	snapB, err := clientB.Collection("cities").Doc("SF").Get(ctx)
+	if err != nil {
+		t.Fatalf("B Get: %v", err)
+	}
+
+	if got := snapB.Data()["owner"]; got != "B" {
+		t.Errorf("project B sees owner=%v, want B (cross-project bleed)", got)
+	}
+
+	// A document that exists ONLY under project A must be absent under project B.
+	if _, err := clientA.Collection("secrets").Doc("only-a").Set(ctx, map[string]any{"v": 1}); err != nil {
+		t.Fatalf("A Set secret: %v", err)
+	}
+
+	if _, err := clientB.Collection("secrets").Doc("only-a").Get(ctx); err == nil {
+		t.Fatal("project B could read a document written only under project A (cross-project leak)")
+	}
+
+	// Listing project B's cities must not surface project A's exclusive docs.
+	if _, err := clientA.Collection("cities").Doc("LA").Set(ctx, map[string]any{"owner": "A"}); err != nil {
+		t.Fatalf("A Set LA: %v", err)
+	}
+
+	seenB := listDocIDs(t, ctx, clientB.Collection("cities"))
+	if seenB["LA"] {
+		t.Errorf("project B list saw LA, which belongs only to project A: %v", seenB)
+	}
+
+	if !seenB["SF"] {
+		t.Errorf("project B list missing its own SF: %v", seenB)
+	}
+}
+
+func listDocIDs(t *testing.T, ctx context.Context, coll *gcpfirestore.CollectionRef) map[string]bool {
+	t.Helper()
+
+	seen := map[string]bool{}
+	it := coll.Documents(ctx)
+
+	for {
+		s, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("list iterator: %v", err)
+		}
+
+		seen[s.Ref.ID] = true
+	}
+
+	return seen
+}
+
+// TestCrossDatabaseDocumentIsolation writes the same collection/doc under the
+// default database and a named database of the SAME project, over raw REST, and
+// asserts each database sees only its own document. The historical bug ignored
+// the database id in the storage key, collapsing "(default)" and named
+// databases into one namespace.
+func TestCrossDatabaseDocumentIsolation(t *testing.T) {
+	ts := newIsolationServer(t)
+
+	const project = "shared-project"
+
+	// Write cities/SF with distinct payloads under two databases.
+	restCreate(t, ts, project, "(default)", "cities", "SF", map[string]any{"db": "default"})
+	restCreate(t, ts, project, "named1", "cities", "SF", map[string]any{"db": "named1"})
+
+	// Each database reads back its OWN value.
+	if got := restGetField(t, ts, project, "(default)", "cities", "SF"); got != "default" {
+		t.Errorf("(default) db sees db=%v, want default (cross-database bleed)", got)
+	}
+
+	if got := restGetField(t, ts, project, "named1", "cities", "SF"); got != "named1" {
+		t.Errorf("named1 db sees db=%v, want named1 (cross-database bleed)", got)
+	}
+
+	// A doc written only under named1 must be absent under (default).
+	restCreate(t, ts, project, "named1", "secrets", "only-named", map[string]any{"v": "x"})
+
+	if status := restGetStatus(t, ts, project, "(default)", "secrets", "only-named"); status != http.StatusNotFound {
+		t.Errorf("(default) db read of a named1-only document returned %d, want 404 (cross-database leak)", status)
+	}
+}
+
+// restBaseURL builds the documents-root URL for a project/database.
+func restBaseURL(ts *httptest.Server, project, database, coll, doc string) string {
+	return ts.URL + "/v1/projects/" + project + "/databases/" + database + "/documents/" + coll + "/" + doc
+}
+
+func restCreate(t *testing.T, ts *httptest.Server, project, database, coll, doc string, fields map[string]any) {
+	t.Helper()
+
+	body := map[string]any{"fields": map[string]any{}}
+	for k, v := range fields {
+		s, _ := v.(string)
+		body["fields"].(map[string]any)[k] = map[string]any{"stringValue": s}
+	}
+
+	buf, _ := json.Marshal(body)
+
+	url := ts.URL + "/v1/projects/" + project + "/databases/" + database + "/documents/" + coll + "?documentId=" + doc
+
+	resp, err := ts.Client().Post(url, "application/json", bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("create %s/%s/%s/%s: %v", project, database, coll, doc, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		out, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create %s/%s/%s/%s: status %d: %s", project, database, coll, doc, resp.StatusCode, out)
+	}
+}
+
+func restGetStatus(t *testing.T, ts *httptest.Server, project, database, coll, doc string) int {
+	t.Helper()
+
+	resp, err := ts.Client().Get(restBaseURL(ts, project, database, coll, doc))
+	if err != nil {
+		t.Fatalf("get %s/%s/%s/%s: %v", project, database, coll, doc, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	return resp.StatusCode
+}
+
+func restGetField(t *testing.T, ts *httptest.Server, project, database, coll, doc string) string {
+	t.Helper()
+
+	resp, err := ts.Client().Get(restBaseURL(ts, project, database, coll, doc))
+	if err != nil {
+		t.Fatalf("get %s/%s/%s/%s: %v", project, database, coll, doc, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		out, _ := io.ReadAll(resp.Body)
+		t.Fatalf("get %s/%s/%s/%s: status %d: %s", project, database, coll, doc, resp.StatusCode, out)
+	}
+
+	var decoded struct {
+		Fields map[string]struct {
+			StringValue string `json:"stringValue"`
+		} `json:"fields"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode get %s/%s/%s/%s: %v", project, database, coll, doc, err)
+	}
+
+	return decoded.Fields["db"].StringValue
+}

--- a/server/gcp/firestore/handler.go
+++ b/server/gcp/firestore/handler.go
@@ -385,7 +385,7 @@ func (h *Handler) stageUpdate(
 		return nil, nil, false
 	}
 
-	existing, exists, gerr := h.stagedExisting(r.Context(), overlay, p.collection, id)
+	existing, exists, gerr := h.stagedExisting(r.Context(), overlay, p.tableKey(), id)
 	if gerr != nil {
 		writeErr(w, gerr)
 		return nil, nil, false
@@ -408,7 +408,7 @@ func (h *Handler) stageUpdate(
 
 	stampTimes(item, existing, now)
 
-	return &stagedWrite{table: p.collection, id: id, item: item}, results, true
+	return &stagedWrite{table: p.tableKey(), id: id, item: item}, results, true
 }
 
 // applyStaged persists the staged writes, grouped by collection so each
@@ -478,7 +478,7 @@ func (h *Handler) stageDelete(
 		return nil, false
 	}
 
-	existing, exists, gerr := h.stagedExisting(r.Context(), overlay, p.collection, id)
+	existing, exists, gerr := h.stagedExisting(r.Context(), overlay, p.tableKey(), id)
 	if gerr != nil {
 		writeErr(w, gerr)
 		return nil, false
@@ -489,7 +489,7 @@ func (h *Handler) stageDelete(
 		return nil, false
 	}
 
-	return &stagedWrite{table: p.collection, id: id, isDelete: true}, true
+	return &stagedWrite{table: p.tableKey(), id: id, isDelete: true}, true
 }
 
 // existingUpdateTime reads the stored commit timestamp of a document, returning
@@ -721,7 +721,7 @@ func (h *Handler) batchGet(w http.ResponseWriter, r *http.Request, _ string) {
 			continue
 		}
 
-		item, gerr := h.db.GetItem(r.Context(), p.collection, map[string]any{fieldID: id})
+		item, gerr := h.db.GetItem(r.Context(), p.tableKey(), map[string]any{fieldID: id})
 		if gerr != nil {
 			entries = append(entries, batchGetResponseEntry{Missing: docName, ReadTime: now})
 			continue
@@ -956,7 +956,7 @@ func (h *Handler) runQuery(w http.ResponseWriter, r *http.Request, base string) 
 	// grammar fidelity (type-aware, AND/OR/NOT, IN/array-contains, unary). A
 	// never-written collection has no driver table; real Firestore returns an
 	// empty result set rather than an error, so treat NotFound as empty.
-	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: p.collection, Limit: allResults})
+	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: p.tableKey(), Limit: allResults})
 	if err != nil {
 		if cerrors.IsNotFound(err) {
 			streamQueryResults(w, nil, p)
@@ -1074,6 +1074,29 @@ func (p firestorePath) parentPath() string {
 	return joinPath(p.collection, p.documentID)
 }
 
+// nsSep separates the project and database namespace components from the
+// collection path inside a driver table key. A NUL byte can never appear in a
+// Firestore project id, database id, or collection path (all UTF-8 text without
+// NUL), so it cannot collide with any real path content.
+const nsSep = "\x00"
+
+// namespacePrefix is the driver-table-key prefix that scopes a collection to a
+// single (project, database). Documents under different projects — or under the
+// same project but different databases, including the default database
+// "(default)" vs a named database — resolve to distinct prefixes and therefore
+// never share a collection namespace.
+func (p firestorePath) namespacePrefix() string {
+	return p.project + nsSep + p.database + nsSep
+}
+
+// tableKey returns the driver "table" this location's collection maps to,
+// namespaced by project and database. Every driver read/write/list/query/delete
+// must key on this — not on the bare collection path — so a document written
+// under project A / database X is invisible under project B or database Y.
+func (p firestorePath) tableKey() string {
+	return p.namespacePrefix() + p.collection
+}
+
 // joinPath joins two path segments with "/", tolerating either being empty.
 func joinPath(a, b string) string {
 	switch {
@@ -1173,7 +1196,7 @@ func (h *Handler) createDocument(w http.ResponseWriter, r *http.Request, p fires
 	// CreateDocument with an explicit id must fail if that id already exists,
 	// rather than silently overwriting (real Firestore returns ALREADY_EXISTS).
 	if explicitID {
-		if _, err := h.db.GetItem(r.Context(), p.collection, map[string]any{fieldID: docID}); err == nil {
+		if _, err := h.db.GetItem(r.Context(), p.tableKey(), map[string]any{fieldID: docID}); err == nil {
 			writeError(w, http.StatusConflict, "ALREADY_EXISTS",
 				"document "+docID+" already exists")
 
@@ -1187,9 +1210,9 @@ func (h *Handler) createDocument(w http.ResponseWriter, r *http.Request, p fires
 
 	// Firestore creates a collection lazily on first write; the driver requires
 	// the "table" to exist, so ensure it before writing.
-	h.ensureCollection(r.Context(), p.collection)
+	h.ensureCollection(r.Context(), p.tableKey())
 
-	if err := h.db.PutItem(r.Context(), p.collection, item); err != nil {
+	if err := h.db.PutItem(r.Context(), p.tableKey(), item); err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -1199,13 +1222,14 @@ func (h *Handler) createDocument(w http.ResponseWriter, r *http.Request, p fires
 
 // ensureCollection lazily creates a Firestore collection (driver table keyed on
 // the reserved document-id field) so a first write doesn't fail with "collection
-// not found". An already-exists result is benign.
-func (h *Handler) ensureCollection(ctx context.Context, collection string) {
-	_ = h.db.CreateTable(ctx, dbdriver.TableConfig{Name: collection, PartitionKey: fieldID})
+// not found". table is the namespaced driver key (project + database +
+// collection). An already-exists result is benign.
+func (h *Handler) ensureCollection(ctx context.Context, table string) {
+	_ = h.db.CreateTable(ctx, dbdriver.TableConfig{Name: table, PartitionKey: fieldID})
 }
 
 func (h *Handler) getDocument(w http.ResponseWriter, r *http.Request, p firestorePath) {
-	item, err := h.db.GetItem(r.Context(), p.collection, map[string]any{fieldID: p.documentID})
+	item, err := h.db.GetItem(r.Context(), p.tableKey(), map[string]any{fieldID: p.documentID})
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -1221,7 +1245,7 @@ func (h *Handler) getDocument(w http.ResponseWriter, r *http.Request, p firestor
 func (h *Handler) listDocuments(w http.ResponseWriter, r *http.Request, p firestorePath) {
 	// Fetch the whole collection, then order + page in the handler so orderBy
 	// stays correct across page boundaries.
-	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: p.collection, Limit: allResults})
+	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: p.tableKey(), Limit: allResults})
 	if err != nil {
 		// A never-written (sub)collection has no driver table; real Firestore
 		// lists it as empty rather than erroring.
@@ -1359,7 +1383,7 @@ func (h *Handler) updateDocument(w http.ResponseWriter, r *http.Request, p fires
 		return
 	}
 
-	existing, err := h.db.GetItem(r.Context(), p.collection, map[string]any{fieldID: p.documentID})
+	existing, err := h.db.GetItem(r.Context(), p.tableKey(), map[string]any{fieldID: p.documentID})
 	if err != nil && !cerrors.IsNotFound(err) {
 		writeErr(w, err)
 		return
@@ -1378,7 +1402,7 @@ func (h *Handler) updateDocument(w http.ResponseWriter, r *http.Request, p fires
 
 	stampTimes(item, existing, time.Now().UTC())
 
-	if err := h.db.PutItem(r.Context(), p.collection, item); err != nil {
+	if err := h.db.PutItem(r.Context(), p.tableKey(), item); err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -1387,7 +1411,7 @@ func (h *Handler) updateDocument(w http.ResponseWriter, r *http.Request, p fires
 }
 
 func (h *Handler) deleteDocument(w http.ResponseWriter, r *http.Request, p firestorePath) {
-	if err := h.db.DeleteItem(r.Context(), p.collection, map[string]any{fieldID: p.documentID}); err != nil {
+	if err := h.db.DeleteItem(r.Context(), p.tableKey(), map[string]any{fieldID: p.documentID}); err != nil {
 		writeErr(w, err)
 		return
 	}

--- a/server/gcp/firestore/transaction.go
+++ b/server/gcp/firestore/transaction.go
@@ -86,7 +86,7 @@ func (h *Handler) listCollectionIDs(w http.ResponseWriter, r *http.Request, base
 		return
 	}
 
-	ids := immediateCollectionIDs(names, parent.parentPath())
+	ids := immediateCollectionIDs(names, parent.namespacePrefix(), parent.parentPath())
 	sort.Strings(ids)
 
 	page, pgerr := pagination.Paginate(ids, req.PageToken, req.PageSize)
@@ -101,26 +101,32 @@ func (h *Handler) listCollectionIDs(w http.ResponseWriter, r *http.Request, base
 	})
 }
 
-// immediateCollectionIDs filters the driver table names (each a full parent
-// path like "cities" or "cities/SF/landmarks") to the collection ids that are
-// immediate children of parent, returning only each match's final path segment.
-// A parent of "" selects the top-level collections. This scopes the result to
-// the requested document so an unrelated document's subcollections never leak.
-func immediateCollectionIDs(tables []string, parent string) []string {
+// immediateCollectionIDs filters the driver table names (each a namespaced key
+// "{project}\x00{database}\x00{parentPath}" where parentPath is a full path like
+// "cities" or "cities/SF/landmarks") to the collection ids that are immediate
+// children of parent within the given project/database namespace, returning only
+// each match's final path segment. Tables outside nsPrefix (a different project
+// or database) are skipped, so a query never leaks another tenant's collections.
+// A parent of "" selects the namespace's top-level collections.
+func immediateCollectionIDs(tables []string, nsPrefix, parent string) []string {
 	seen := make(map[string]struct{}, len(tables))
 
 	ids := make([]string, 0, len(tables))
 
 	for _, t := range tables {
-		rest := t
+		if !strings.HasPrefix(t, nsPrefix) {
+			continue
+		}
+
+		rest := t[len(nsPrefix):]
 
 		if parent != "" {
 			prefix := parent + "/"
-			if !strings.HasPrefix(t, prefix) {
+			if !strings.HasPrefix(rest, prefix) {
 				continue
 			}
 
-			rest = t[len(prefix):]
+			rest = rest[len(prefix):]
 		}
 
 		// An immediate child collection is a single segment under the parent;


### PR DESCRIPTION
## Problem

The GCP Firestore wire handler keyed every driver table on the bare collection path (`p.collection`), ignoring the project and database ids parsed from the request URL. Real Firestore paths are `projects/{project}/databases/{database}/documents/{collection}/{doc}`, but the emulator collapsed:

- different **projects** (project A vs project B), and
- different **databases** within a project (the default `(default)` vs any named database)

into a single collection namespace. Two clients writing `cities/SF` under different projects or databases clobbered each other, and one tenant could read another's documents — a cross-tenant / cross-database data collision.

## Fix

- Fold **project + database + collection** into the driver table key via a new `firestorePath.tableKey()` (namespace separated by NUL, which never appears in a project/database id or collection path).
- Route every driver read/write/list/query/delete path (create/get/update/delete document, `:commit` staged writes, `:batchGet`, `:runQuery`, `listDocuments`) through `tableKey()` instead of the bare collection.
- `listCollectionIds` now scopes the `ListTables` result to the request's namespace prefix so it never leaks another project's or database's collections.
- Document CRUD/query/collection semantics within a namespace are unchanged; the collection path is still used verbatim for the returned resource `name`.

## Tests

- `TestCrossProjectDocumentIsolation` — real `cloud.google.com/go/firestore` REST SDK, two clients with distinct project ids against one server: each project reads back only its own `cities/SF`, a project-A-only document is absent under project B, and listing does not surface the other project's docs.
- `TestCrossDatabaseDocumentIsolation` — same project, `(default)` vs a named database over raw REST (the REST SDK constructor hard-codes `(default)`): each database reads back only its own document, and a named-db-only document 404s under the default database.
- Updated the lifecycle test's driver-level table drop to target the namespaced key.

Gates: `go build ./...`, `gofmt -l` clean, `go test ./server/gcp/... ./providers/gcp/... -race` green, coveragegen diff-clean, `go mod tidy` clean, golangci-lint 0 new issues.