### PR TITLE
feat(azure-network): UpdateTags PATCH for vnet, NSG, route table, public IP, NAT gateway, NIC

### DIFF
--- a/docs/coverage/azure/vnet.md
+++ b/docs/coverage/azure/vnet.md
@@ -135,6 +135,18 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | `UpsertAzureNSGRule` | UpsertAzureNSGRule creates or replaces a single custom security rule by |
 | `UpsertAzureVNetPeering` | UpsertAzureVNetPeering creates or replaces a single virtualNetworkPeerings |
 
+### AzureNetworkTagReplacer
+
+AzureNetworkTagReplacer replaces the entire stored tag collection on the core
+
+| Operation | Description |
+| --- | --- |
+| `ReplaceAddressTags` | ReplaceAddressTags sets the public IP address's tags, keyed by its |
+| `ReplaceNATGatewayTags` | ReplaceNATGatewayTags sets the NAT gateway's tags, keyed by its driver id. |
+| `ReplaceNetworkInterfaceTags` | ReplaceNetworkInterfaceTags sets the network interface's tags, keyed by the |
+| `ReplaceSecurityGroupTags` | ReplaceSecurityGroupTags sets the network security group's tags, keyed by |
+| `ReplaceVPCTags` | ReplaceVPCTags sets the virtual network's tags, keyed by its driver id. |
+
 ### AzurePrivateLink
 
 AzurePrivateLink is the Azure-only Private Link surface. Each resource type is

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -7743,6 +7743,32 @@
         ]
       },
       {
+        "name": "AzureNetworkTagReplacer",
+        "doc": "AzureNetworkTagReplacer replaces the entire stored tag collection on the core",
+        "operations": [
+          {
+            "name": "ReplaceAddressTags",
+            "doc": "ReplaceAddressTags sets the public IP address's tags, keyed by its"
+          },
+          {
+            "name": "ReplaceNATGatewayTags",
+            "doc": "ReplaceNATGatewayTags sets the NAT gateway's tags, keyed by its driver id."
+          },
+          {
+            "name": "ReplaceNetworkInterfaceTags",
+            "doc": "ReplaceNetworkInterfaceTags sets the network interface's tags, keyed by the"
+          },
+          {
+            "name": "ReplaceSecurityGroupTags",
+            "doc": "ReplaceSecurityGroupTags sets the network security group's tags, keyed by"
+          },
+          {
+            "name": "ReplaceVPCTags",
+            "doc": "ReplaceVPCTags sets the virtual network's tags, keyed by its driver id."
+          }
+        ]
+      },
+      {
         "name": "AzurePrivateLink",
         "doc": "AzurePrivateLink is the Azure-only Private Link surface. Each resource type is",
         "operations": [

--- a/providers/azure/vnet/tag_replace.go
+++ b/providers/azure/vnet/tag_replace.go
@@ -1,0 +1,81 @@
+package vnet
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// This file implements driver.AzureNetworkTagReplacer: the wholesale tag
+// replacement the ARM resource-level UpdateTags PATCH needs (it SETS tags, it
+// does not merge). Each method swaps in a fresh copy of the supplied map under
+// the store's lock so concurrent readers iterating the old map are unaffected,
+// and returns NotFound when the resource is absent. The wire handler folds any
+// wire-internal cloudemu: anchor tags into the map it passes, so those survive.
+
+// ReplaceVPCTags sets the virtual network's tags wholesale.
+func (m *Mock) ReplaceVPCTags(_ context.Context, id string, tags map[string]string) error {
+	if !m.vpcs.Update(id, func(v *vpcData) *vpcData {
+		v.Tags = copyTags(tags)
+		return v
+	}) {
+		return cerrors.Newf(cerrors.NotFound, "virtual network %q not found", id)
+	}
+
+	return nil
+}
+
+// ReplaceSecurityGroupTags sets the network security group's tags wholesale.
+func (m *Mock) ReplaceSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
+	if !m.securityGroups.Update(id, func(sg *sgData) *sgData {
+		sg.Tags = copyTags(tags)
+		return sg
+	}) {
+		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", id)
+	}
+
+	return nil
+}
+
+// ReplaceNATGatewayTags sets the NAT gateway's tags wholesale.
+func (m *Mock) ReplaceNATGatewayTags(_ context.Context, id string, tags map[string]string) error {
+	if !m.natGateways.Update(id, func(n *natGatewayData) *natGatewayData {
+		n.Tags = copyTags(tags)
+		return n
+	}) {
+		return cerrors.Newf(cerrors.NotFound, "NAT gateway %q not found", id)
+	}
+
+	return nil
+}
+
+// ReplaceAddressTags sets the public IP address's tags wholesale, keyed by its
+// Elastic-IP allocation id.
+func (m *Mock) ReplaceAddressTags(_ context.Context, allocationID string, tags map[string]string) error {
+	if !m.eips.Update(allocationID, func(e *eipData) *eipData {
+		e.Tags = copyTags(tags)
+		return e
+	}) {
+		return cerrors.Newf(cerrors.NotFound, "public IP %q not found", allocationID)
+	}
+
+	return nil
+}
+
+// ReplaceNetworkInterfaceTags sets the network interface's tags wholesale, keyed
+// by the (resourceGroup, name) ARM addressing pair. It takes nicMu (the same
+// lock CreateOrUpdateNetworkInterface holds) so a concurrent NIC write cannot
+// interleave with the tag replacement.
+func (m *Mock) ReplaceNetworkInterfaceTags(_ context.Context, resourceGroup, name string, tags map[string]string) error {
+	m.nicMu.Lock()
+	defer m.nicMu.Unlock()
+
+	if !m.nics.Update(nicKey(resourceGroup, name), func(n *nicData) *nicData {
+		n.Tags = copyTags(tags)
+		return n
+	}) {
+		return cerrors.Newf(cerrors.NotFound, "network interface %q not found", name)
+	}
+
+	return nil
+}

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -33,17 +33,22 @@ import (
 )
 
 const (
-	providerName     = "Microsoft.Network"
-	typeVNet         = "virtualNetworks"
-	typeNSG          = "networkSecurityGroups"
-	typeRouteTable   = "routeTables"
-	typePublicIP     = "publicIPAddresses"
-	typeLocations    = "locations"
-	armNameTag       = "cloudemu:azureNetName"
-	armSubnetTag     = "cloudemu:azureSubnet"
-	armNSGTag        = "cloudemu:azureNSGName"
-	armPublicIPTag   = "cloudemu:azurePublicIP"
-	armPublicIPRGTag = "cloudemu:azurePublicIPResourceGroup"
+	providerName   = "Microsoft.Network"
+	typeVNet       = "virtualNetworks"
+	typeNSG        = "networkSecurityGroups"
+	typeRouteTable = "routeTables"
+	typePublicIP   = "publicIPAddresses"
+	typeLocations  = "locations"
+	// internalTagPrefix marks the wire-internal bookkeeping tags (ARM name /
+	// resource-group anchors, association references) the (rg, name) lookups
+	// depend on; stripInternal hides them from responses and an UpdateTags PATCH
+	// preserves them across a wholesale user-tag replacement.
+	internalTagPrefix = "cloudemu:"
+	armNameTag        = "cloudemu:azureNetName"
+	armSubnetTag      = "cloudemu:azureSubnet"
+	armNSGTag         = "cloudemu:azureNSGName"
+	armPublicIPTag    = "cloudemu:azurePublicIP"
+	armPublicIPRGTag  = "cloudemu:azurePublicIPResourceGroup"
 	// armVNetRGTag / armNSGRGTag record the resource group a virtual network or
 	// network security group was created under. The cross-cloud networking
 	// driver has a single flat namespace, so without this a resource is globally
@@ -264,6 +269,8 @@ func (h *Handler) routeVNet(w http.ResponseWriter, r *http.Request, rp azurearm.
 	switch r.Method {
 	case http.MethodPut:
 		h.createVNet(w, r, rp)
+	case http.MethodPatch:
+		h.patchVNet(w, r, rp)
 	case http.MethodGet:
 		h.getVNet(w, r, rp)
 	case http.MethodDelete:
@@ -312,6 +319,8 @@ func (h *Handler) routeNSG(w http.ResponseWriter, r *http.Request, rp azurearm.R
 	switch r.Method {
 	case http.MethodPut:
 		h.createNSG(w, r, rp)
+	case http.MethodPatch:
+		h.patchNSG(w, r, rp)
 	case http.MethodGet:
 		h.getNSG(w, r, rp)
 	case http.MethodDelete:
@@ -581,7 +590,7 @@ func (h *Handler) getVNet(w http.ResponseWriter, r *http.Request, rp azurearm.Re
 	azurearm.WriteJSON(w, http.StatusOK, h.vnetResponse(r.Context(), info, rp))
 }
 
-//nolint:gocritic,dupl // rp is request-scoped; mirrors listNSGs over a distinct resource type by design
+//nolint:gocritic // rp is request-scoped; mirrors listNSGs over a distinct resource type by design
 func (h *Handler) listVNets(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	infos, err := h.net.DescribeVPCs(r.Context(), nil)
 	if err != nil {
@@ -797,6 +806,8 @@ func (h *Handler) purgeVNets(ctx context.Context, resourceGroup string) error {
 
 // purgeNSGs deletes every network security group (with its metadata) in the
 // resource group, returning the first delete error encountered.
+//
+//nolint:dupl // mirrors purgeRouteTables over a distinct resource type and store by design
 func (h *Handler) purgeNSGs(ctx context.Context, resourceGroup string) error {
 	nsgs, err := h.net.DescribeSecurityGroups(ctx, nil)
 	if err != nil {
@@ -1329,7 +1340,7 @@ func (h *Handler) getNSG(w http.ResponseWriter, r *http.Request, rp azurearm.Res
 	azurearm.WriteJSON(w, http.StatusOK, h.nsgResponse(r.Context(), info, rp))
 }
 
-//nolint:gocritic,dupl // rp is request-scoped; mirrors listVNets over a distinct resource type by design
+//nolint:gocritic // rp is request-scoped; mirrors listVNets over a distinct resource type by design
 func (h *Handler) listNSGs(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	infos, err := h.net.DescribeSecurityGroups(r.Context(), nil)
 	if err != nil {
@@ -1394,7 +1405,7 @@ func (h *Handler) deleteNSG(w http.ResponseWriter, r *http.Request, rp azurearm.
 
 // PublicIP operations.
 
-//nolint:gocritic // rp is a request-scoped value
+//nolint:gocritic,dupl // rp is request-scoped; the per-resource routers are the same method switch over a distinct type by design
 func (h *Handler) routePublicIP(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	if rp.ResourceName == "" {
 		h.listPublicIPs(w, r, rp)
@@ -1404,6 +1415,8 @@ func (h *Handler) routePublicIP(w http.ResponseWriter, r *http.Request, rp azure
 	switch r.Method {
 	case http.MethodPut:
 		h.createPublicIP(w, r, rp)
+	case http.MethodPatch:
+		h.patchPublicIP(w, r, rp)
 	case http.MethodGet:
 		h.getPublicIP(w, r, rp)
 	case http.MethodDelete:
@@ -2076,7 +2089,7 @@ func stripInternal(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
 
 	for k, v := range in {
-		if strings.HasPrefix(k, "cloudemu:") {
+		if strings.HasPrefix(k, internalTagPrefix) {
 			continue
 		}
 

--- a/server/azure/vnet/nat_gateway.go
+++ b/server/azure/vnet/nat_gateway.go
@@ -65,7 +65,7 @@ type natGatewayListResponse struct {
 
 // routeNATGateway dispatches Microsoft.Network/natGateways requests.
 //
-//nolint:gocritic // rp is a request-scoped value
+//nolint:gocritic,dupl // rp is request-scoped; the per-resource routers are the same method switch over a distinct type by design
 func (h *Handler) routeNATGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	if rp.ResourceName == "" {
 		h.listNATGateways(w, r, rp)
@@ -75,6 +75,8 @@ func (h *Handler) routeNATGateway(w http.ResponseWriter, r *http.Request, rp azu
 	switch r.Method {
 	case http.MethodPut:
 		h.createNATGateway(w, r, rp)
+	case http.MethodPatch:
+		h.patchNATGateway(w, r, rp)
 	case http.MethodGet:
 		h.getNATGateway(w, r, rp)
 	case http.MethodDelete:

--- a/server/azure/vnet/network_core_updatetags_test.go
+++ b/server/azure/vnet/network_core_updatetags_test.go
@@ -1,0 +1,414 @@
+package vnet_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// The core Azure VNet-family resources (virtualNetworks, networkSecurityGroups,
+// routeTables, publicIPAddresses, natGateways, networkInterfaces) each expose a
+// synchronous armnetwork *Client.UpdateTags PATCH. Resource-level UpdateTags
+// REPLACES the tag collection wholesale (it does not merge): the supplied tag
+// becomes the only tag, the create-time tag is gone, the resource's other
+// properties survive, the full resource is returned, a raw tags:{} PATCH wipes
+// every tag, and UpdateTags on a missing resource is a 404. (subnets are not
+// independently taggable in Azure, so they have no UpdateTags path.)
+
+func TestSDKVirtualNetworkUpdateTags(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	client, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp, err := client.BeginCreateOrUpdate(ctx, "rg-1", "vnet-tag", armnetwork.VirtualNetwork{
+		Location: to.Ptr("westus2"),
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	pollDone(t, cp)
+
+	updated, err := client.UpdateTags(ctx, "rg-1", "vnet-tag", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("UpdateTags: %v", err)
+	}
+
+	assertTag(t, updated.Tags, "team", "net")
+	assertNoTag(t, updated.Tags, "env")
+	assertTagCount(t, updated.Tags, 1)
+
+	if updated.Location == nil || *updated.Location != "westus2" {
+		t.Errorf("location=%v want westus2 (property must survive UpdateTags)", updated.Location)
+	}
+
+	if updated.Properties == nil || updated.Properties.AddressSpace == nil ||
+		len(updated.Properties.AddressSpace.AddressPrefixes) != 1 ||
+		*updated.Properties.AddressSpace.AddressPrefixes[0] != "10.0.0.0/16" {
+		t.Errorf("addressSpace=%v want [10.0.0.0/16] (property must survive UpdateTags)", updated.Properties)
+	}
+
+	got, err := client.Get(ctx, "rg-1", "vnet-tag", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	assertTag(t, got.Tags, "team", "net")
+	assertNoTag(t, got.Tags, "env")
+
+	wiped := rawTagsPatch(t, ts,
+		"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/virtualNetworks/vnet-tag",
+		`{"tags":{}}`)
+	assertTagCount(t, ptrTags(wiped), 0)
+
+	_, err = client.UpdateTags(ctx, "rg-1", "missing", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	assertNotFound(t, err, "virtual network UpdateTags on missing")
+}
+
+func TestSDKNetworkSecurityGroupUpdateTags(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	client, err := armnetwork.NewSecurityGroupsClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp, err := client.BeginCreateOrUpdate(ctx, "rg-1", "nsg-tag", armnetwork.SecurityGroup{
+		Location: to.Ptr("westus2"),
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	pollDone(t, cp)
+
+	updated, err := client.UpdateTags(ctx, "rg-1", "nsg-tag", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("UpdateTags: %v", err)
+	}
+
+	assertTag(t, updated.Tags, "team", "net")
+	assertNoTag(t, updated.Tags, "env")
+	assertTagCount(t, updated.Tags, 1)
+
+	if updated.Location == nil || *updated.Location != "westus2" {
+		t.Errorf("location=%v want westus2 (property must survive UpdateTags)", updated.Location)
+	}
+
+	wiped := rawTagsPatch(t, ts,
+		"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/networkSecurityGroups/nsg-tag",
+		`{"tags":{}}`)
+	assertTagCount(t, ptrTags(wiped), 0)
+
+	_, err = client.UpdateTags(ctx, "rg-1", "missing", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	assertNotFound(t, err, "network security group UpdateTags on missing")
+}
+
+func TestSDKRouteTableUpdateTags(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	client, err := armnetwork.NewRouteTablesClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp, err := client.BeginCreateOrUpdate(ctx, "rg-1", "rt-tag", armnetwork.RouteTable{
+		Location: to.Ptr("westus2"),
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armnetwork.RouteTablePropertiesFormat{
+			Routes: []*armnetwork.Route{{
+				Name: to.Ptr("r1"),
+				Properties: &armnetwork.RoutePropertiesFormat{
+					AddressPrefix: to.Ptr("10.1.0.0/16"),
+					NextHopType:   to.Ptr(armnetwork.RouteNextHopTypeVnetLocal),
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	pollDone(t, cp)
+
+	updated, err := client.UpdateTags(ctx, "rg-1", "rt-tag", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("UpdateTags: %v", err)
+	}
+
+	assertTag(t, updated.Tags, "team", "net")
+	assertNoTag(t, updated.Tags, "env")
+	assertTagCount(t, updated.Tags, 1)
+
+	if updated.Properties == nil || len(updated.Properties.Routes) != 1 ||
+		updated.Properties.Routes[0].Properties == nil ||
+		updated.Properties.Routes[0].Properties.AddressPrefix == nil ||
+		*updated.Properties.Routes[0].Properties.AddressPrefix != "10.1.0.0/16" {
+		t.Errorf("routes=%v want one 10.1.0.0/16 route (property must survive UpdateTags)", updated.Properties)
+	}
+
+	wiped := rawTagsPatch(t, ts,
+		"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/routeTables/rt-tag",
+		`{"tags":{}}`)
+	assertTagCount(t, ptrTags(wiped), 0)
+
+	_, err = client.UpdateTags(ctx, "rg-1", "missing", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	assertNotFound(t, err, "route table UpdateTags on missing")
+}
+
+func TestSDKPublicIPAddressUpdateTags(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	client, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp, err := client.BeginCreateOrUpdate(ctx, "rg-1", "pip-tag", armnetwork.PublicIPAddress{
+		Location: to.Ptr("westus2"),
+		SKU:      &armnetwork.PublicIPAddressSKU{Name: to.Ptr(armnetwork.PublicIPAddressSKUNameStandard)},
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	pollDone(t, cp)
+
+	updated, err := client.UpdateTags(ctx, "rg-1", "pip-tag", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("UpdateTags: %v", err)
+	}
+
+	assertTag(t, updated.Tags, "team", "net")
+	assertNoTag(t, updated.Tags, "env")
+	assertTagCount(t, updated.Tags, 1)
+
+	if updated.SKU == nil || updated.SKU.Name == nil ||
+		*updated.SKU.Name != armnetwork.PublicIPAddressSKUNameStandard {
+		t.Errorf("sku=%v want Standard (property must survive UpdateTags)", updated.SKU)
+	}
+
+	if updated.Properties == nil || updated.Properties.PublicIPAllocationMethod == nil ||
+		*updated.Properties.PublicIPAllocationMethod != armnetwork.IPAllocationMethodStatic {
+		t.Errorf("allocationMethod=%v want Static (property must survive UpdateTags)", updated.Properties)
+	}
+
+	wiped := rawTagsPatch(t, ts,
+		"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/publicIPAddresses/pip-tag",
+		`{"tags":{}}`)
+	assertTagCount(t, ptrTags(wiped), 0)
+
+	_, err = client.UpdateTags(ctx, "rg-1", "missing", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	assertNotFound(t, err, "public IP address UpdateTags on missing")
+}
+
+func TestSDKNatGatewayUpdateTags(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	pips, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pp, err := pips.BeginCreateOrUpdate(ctx, "rg-1", "pip-nat", armnetwork.PublicIPAddress{
+		Location: to.Ptr("westus2"),
+		SKU:      &armnetwork.PublicIPAddressSKU{Name: to.Ptr(armnetwork.PublicIPAddressSKUNameStandard)},
+		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create pip: %v", err)
+	}
+
+	pollDone(t, pp)
+
+	pipID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/publicIPAddresses/pip-nat"
+
+	client, err := armnetwork.NewNatGatewaysClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	np, err := client.BeginCreateOrUpdate(ctx, "rg-1", "nat-tag", armnetwork.NatGateway{
+		Location: to.Ptr("westus2"),
+		SKU:      &armnetwork.NatGatewaySKU{Name: to.Ptr(armnetwork.NatGatewaySKUNameStandard)},
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armnetwork.NatGatewayPropertiesFormat{
+			PublicIPAddresses: []*armnetwork.SubResource{{ID: to.Ptr(pipID)}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	pollDone(t, np)
+
+	updated, err := client.UpdateTags(ctx, "rg-1", "nat-tag", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("UpdateTags: %v", err)
+	}
+
+	assertTag(t, updated.Tags, "team", "net")
+	assertNoTag(t, updated.Tags, "env")
+	assertTagCount(t, updated.Tags, 1)
+
+	// The bound public IP survives the tag replacement.
+	if updated.Properties == nil || len(updated.Properties.PublicIPAddresses) != 1 ||
+		updated.Properties.PublicIPAddresses[0].ID == nil ||
+		*updated.Properties.PublicIPAddresses[0].ID != pipID {
+		t.Errorf("publicIpAddresses=%v want [%s] (property must survive UpdateTags)", updated.Properties, pipID)
+	}
+
+	wiped := rawTagsPatch(t, ts,
+		"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/natGateways/nat-tag",
+		`{"tags":{}}`)
+	assertTagCount(t, ptrTags(wiped), 0)
+
+	_, err = client.UpdateTags(ctx, "rg-1", "missing", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	assertNotFound(t, err, "NAT gateway UpdateTags on missing")
+}
+
+func TestSDKNetworkInterfaceUpdateTags(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	subnetID := seedNICSubnet(t, ctx, opts)
+
+	client, err := armnetwork.NewInterfacesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	np, err := client.BeginCreateOrUpdate(ctx, "rg-1", "nic-tag", armnetwork.Interface{
+		Location: to.Ptr("westus2"),
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{{
+				Name: to.Ptr("ipconfig1"),
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					Subnet:                    &armnetwork.Subnet{ID: to.Ptr(subnetID)},
+					PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+					Primary:                   to.Ptr(true),
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	pollDone(t, np)
+
+	updated, err := client.UpdateTags(ctx, "rg-1", "nic-tag", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("UpdateTags: %v", err)
+	}
+
+	assertTag(t, updated.Tags, "team", "net")
+	assertNoTag(t, updated.Tags, "env")
+	assertTagCount(t, updated.Tags, 1)
+
+	// The ipConfiguration (subnet binding) survives the tag replacement.
+	if updated.Properties == nil || len(updated.Properties.IPConfigurations) != 1 ||
+		updated.Properties.IPConfigurations[0].Properties == nil ||
+		updated.Properties.IPConfigurations[0].Properties.Subnet == nil ||
+		updated.Properties.IPConfigurations[0].Properties.Subnet.ID == nil ||
+		*updated.Properties.IPConfigurations[0].Properties.Subnet.ID != subnetID {
+		t.Errorf("ipConfigurations=%v want subnet %s (property must survive UpdateTags)", updated.Properties, subnetID)
+	}
+
+	wiped := rawTagsPatch(t, ts,
+		"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/networkInterfaces/nic-tag",
+		`{"tags":{}}`)
+	assertTagCount(t, ptrTags(wiped), 0)
+
+	_, err = client.UpdateTags(ctx, "rg-1", "missing", armnetwork.TagsObject{
+		Tags: map[string]*string{"team": to.Ptr("net")},
+	}, nil)
+	assertNotFound(t, err, "network interface UpdateTags on missing")
+}
+
+// seedNICSubnet creates a vnet + subnet a NIC can bind to and returns the
+// subnet's ARM resource id.
+func seedNICSubnet(t *testing.T, ctx context.Context, opts *arm.ClientOptions) string {
+	t.Helper()
+
+	vnets, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vp, err := vnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-nic", armnetwork.VirtualNetwork{
+		Location: to.Ptr("westus2"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("vnet create: %v", err)
+	}
+
+	pollDone(t, vp)
+
+	subnets, err := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sp, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-nic", "subnet-1", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.0/24")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("subnet create: %v", err)
+	}
+
+	pollDone(t, sp)
+
+	return "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/" +
+		"virtualNetworks/vnet-nic/subnets/subnet-1"
+}

--- a/server/azure/vnet/network_core_updatetags_test.go
+++ b/server/azure/vnet/network_core_updatetags_test.go
@@ -373,6 +373,131 @@ func TestSDKNetworkInterfaceUpdateTags(t *testing.T) {
 	assertNotFound(t, err, "network interface UpdateTags on missing")
 }
 
+// TestSDKVirtualNetworkUpdateTagsAnchorImmutable proves a caller cannot hijack a
+// resource's identity by smuggling a cloudemu:-prefixed key into an UpdateTags
+// PATCH: the reserved key is stripped, a normal user tag in the same PATCH still
+// applies, and an independent Get(rg, name) still resolves (not 404) with
+// identity intact — before and after a tags:{} wipe.
+func TestSDKVirtualNetworkUpdateTagsAnchorImmutable(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	client, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp, err := client.BeginCreateOrUpdate(ctx, "rg-1", "vnet-victim", armnetwork.VirtualNetwork{
+		Location: to.Ptr("westus2"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	pollDone(t, cp)
+
+	// A PATCH that tries to overwrite the name anchor (and another reserved key)
+	// alongside a legitimate user tag.
+	resp := rawTagsPatch(t, ts,
+		"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/virtualNetworks/vnet-victim",
+		`{"tags":{"cloudemu:azureNetName":"hijacked","cloudemu:evil":"x","team":"net"}}`)
+
+	// The reserved keys never surface; the user tag does.
+	if _, bad := resp["cloudemu:azureNetName"]; bad {
+		t.Errorf("reserved key leaked into response tags: %v", resp)
+	}
+
+	assertTag(t, ptrTags(resp), "team", "net")
+
+	// The resource is still resolvable by (rg, name) — the hijack did not orphan it.
+	got, err := client.Get(ctx, "rg-1", "vnet-victim", nil)
+	if err != nil {
+		t.Fatalf("Get after collision PATCH: %v (resource orphaned)", err)
+	}
+
+	if got.Name == nil || *got.Name != "vnet-victim" {
+		t.Errorf("name=%v want vnet-victim (identity must survive)", got.Name)
+	}
+
+	assertTag(t, got.Tags, "team", "net")
+
+	if _, bad := got.Tags["cloudemu:azureNetName"]; bad {
+		t.Errorf("reserved key leaked into stored tags: %v", got.Tags)
+	}
+
+	// A tags:{} wipe clears user tags but the anchor survives — still resolvable.
+	rawTagsPatch(t, ts,
+		"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/virtualNetworks/vnet-victim",
+		`{"tags":{}}`)
+
+	wiped, err := client.Get(ctx, "rg-1", "vnet-victim", nil)
+	if err != nil {
+		t.Fatalf("Get after wipe: %v (resource orphaned)", err)
+	}
+
+	assertTagCount(t, wiped.Tags, 0)
+}
+
+// TestSDKNetworkSecurityGroupUpdateTagsAnchorImmutable is the NSG counterpart of
+// the VNet anchor-immutability test.
+func TestSDKNetworkSecurityGroupUpdateTagsAnchorImmutable(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	client, err := armnetwork.NewSecurityGroupsClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp, err := client.BeginCreateOrUpdate(ctx, "rg-1", "nsg-victim", armnetwork.SecurityGroup{
+		Location: to.Ptr("westus2"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	pollDone(t, cp)
+
+	resp := rawTagsPatch(t, ts,
+		"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/networkSecurityGroups/nsg-victim",
+		`{"tags":{"cloudemu:azureNSGName":"hijacked","cloudemu:evil":"x","team":"net"}}`)
+
+	if _, bad := resp["cloudemu:azureNSGName"]; bad {
+		t.Errorf("reserved key leaked into response tags: %v", resp)
+	}
+
+	assertTag(t, ptrTags(resp), "team", "net")
+
+	got, err := client.Get(ctx, "rg-1", "nsg-victim", nil)
+	if err != nil {
+		t.Fatalf("Get after collision PATCH: %v (resource orphaned)", err)
+	}
+
+	if got.Name == nil || *got.Name != "nsg-victim" {
+		t.Errorf("name=%v want nsg-victim (identity must survive)", got.Name)
+	}
+
+	assertTag(t, got.Tags, "team", "net")
+
+	if _, bad := got.Tags["cloudemu:azureNSGName"]; bad {
+		t.Errorf("reserved key leaked into stored tags: %v", got.Tags)
+	}
+
+	rawTagsPatch(t, ts,
+		"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/networkSecurityGroups/nsg-victim",
+		`{"tags":{}}`)
+
+	wiped, err := client.Get(ctx, "rg-1", "nsg-victim", nil)
+	if err != nil {
+		t.Fatalf("Get after wipe: %v (resource orphaned)", err)
+	}
+
+	assertTagCount(t, wiped.Tags, 0)
+}
+
 // seedNICSubnet creates a vnet + subnet a NIC can bind to and returns the
 // subnet's ARM resource id.
 func seedNICSubnet(t *testing.T, ctx context.Context, opts *arm.ClientOptions) string {

--- a/server/azure/vnet/network_interface.go
+++ b/server/azure/vnet/network_interface.go
@@ -125,6 +125,8 @@ func (h *Handler) routeNIC(w http.ResponseWriter, r *http.Request, rp azurearm.R
 	switch r.Method {
 	case http.MethodPut:
 		h.createNIC(w, r, rp, svc)
+	case http.MethodPatch:
+		h.patchNIC(w, r, rp, svc)
 	case http.MethodGet:
 		h.getNIC(w, r, rp, svc)
 	case http.MethodDelete:

--- a/server/azure/vnet/network_updatetags.go
+++ b/server/azure/vnet/network_updatetags.go
@@ -27,17 +27,30 @@ import (
 // UpdateTags replacement, so a PATCH that SETS the user-facing tags never drops
 // the bookkeeping the (rg, name) lookup depends on. replacement is the caller's
 // new user tag set (nil to wipe them); the result is nil when nothing remains.
+//
+// The resource's identity anchors are immutable across any PATCH: a caller's
+// cloudemu:-prefixed keys are stripped from the replacement FIRST (so user input
+// can never introduce a reserved key), and the STORED anchors are re-asserted
+// LAST (so they always win even against a stray reserved key). The resource must
+// always remain resolvable by (rg, name) after any UpdateTags, including a wipe.
 func preserveInternalTags(existing, replacement map[string]string) map[string]string {
 	out := make(map[string]string, len(existing)+len(replacement))
 
+	// User tags first, with reserved cloudemu: keys dropped so a caller can never
+	// overwrite (or introduce) an identity anchor.
+	for k, v := range replacement {
+		if strings.HasPrefix(k, internalTagPrefix) {
+			continue
+		}
+
+		out[k] = v
+	}
+
+	// Re-assert the stored anchors last so they always win — identity survives.
 	for k, v := range existing {
 		if strings.HasPrefix(k, internalTagPrefix) {
 			out[k] = v
 		}
-	}
-
-	for k, v := range replacement {
-		out[k] = v
 	}
 
 	if len(out) == 0 {

--- a/server/azure/vnet/network_updatetags.go
+++ b/server/azure/vnet/network_updatetags.go
@@ -1,0 +1,285 @@
+package vnet
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// ARM UpdateTags PATCH handlers for the core VNet-family resources
+// (virtualNetworks, networkSecurityGroups, routeTables, publicIPAddresses,
+// natGateways, networkInterfaces). Each armnetwork *Client.UpdateTags is a
+// synchronous PATCH that answers 200 with the full resource, and REPLACES the
+// tag collection wholesale — it does not merge (tags:{} wipes every tag). The
+// resource's other properties are left intact. subnets are NOT independently
+// taggable in Azure (their tags live on the parent virtual network), so they get
+// no UpdateTags handler.
+//
+// The get-modify-put is serialized by h.patchMu so two concurrent PATCHes cannot
+// drop each other's write; the actual store mutation is a single atomic driver
+// call. Wire-internal cloudemu: anchor tags are preserved so the (rg, name)
+// lookup keeps resolving after the user tags are replaced.
+
+// preserveInternalTags folds a resource's wire-internal cloudemu: anchor tags
+// (name / resource-group anchors and association references) into a wholesale
+// UpdateTags replacement, so a PATCH that SETS the user-facing tags never drops
+// the bookkeeping the (rg, name) lookup depends on. replacement is the caller's
+// new user tag set (nil to wipe them); the result is nil when nothing remains.
+func preserveInternalTags(existing, replacement map[string]string) map[string]string {
+	out := make(map[string]string, len(existing)+len(replacement))
+
+	for k, v := range existing {
+		if strings.HasPrefix(k, internalTagPrefix) {
+			out[k] = v
+		}
+	}
+
+	for k, v := range replacement {
+		out[k] = v
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
+// tagReplacer returns the wholesale-tag-replacement surface if the networking
+// driver implements it (the Azure provider does).
+func (h *Handler) tagReplacer() (netdriver.AzureNetworkTagReplacer, bool) {
+	svc, ok := h.net.(netdriver.AzureNetworkTagReplacer)
+
+	return svc, ok
+}
+
+//nolint:gocritic,dupl // rp is request-scoped; UpdateTags handlers share one get-modify-put shape over distinct types by design
+func (h *Handler) patchVNet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	var req armTagsObject
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	svc, ok := h.tagReplacer()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented", "UpdateTags is not supported by this networking driver")
+		return
+	}
+
+	h.patchMu.Lock()
+
+	info, err := findVNetInGroup(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		h.patchMu.Unlock()
+		azurearm.WriteCErr(w, err)
+
+		return
+	}
+
+	if req.Tags != nil {
+		_ = svc.ReplaceVPCTags(r.Context(), info.ID, preserveInternalTags(info.Tags, req.Tags))
+
+		if refreshed, rerr := findVNetInGroup(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName); rerr == nil {
+			info = refreshed
+		}
+	}
+
+	h.patchMu.Unlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, h.vnetResponse(r.Context(), info, rp))
+}
+
+//nolint:gocritic,dupl // rp is request-scoped; UpdateTags handlers share one get-modify-put shape over distinct types by design
+func (h *Handler) patchNSG(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	var req armTagsObject
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	svc, ok := h.tagReplacer()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented", "UpdateTags is not supported by this networking driver")
+		return
+	}
+
+	h.patchMu.Lock()
+
+	info, err := findNSGInGroup(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		h.patchMu.Unlock()
+		azurearm.WriteCErr(w, err)
+
+		return
+	}
+
+	if req.Tags != nil {
+		_ = svc.ReplaceSecurityGroupTags(r.Context(), info.ID, preserveInternalTags(info.Tags, req.Tags))
+
+		if refreshed, rerr := findNSGInGroup(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName); rerr == nil {
+			info = refreshed
+		}
+	}
+
+	h.patchMu.Unlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, h.nsgResponse(r.Context(), info, rp))
+}
+
+//nolint:gocritic,dupl // rp is request-scoped; UpdateTags handlers share one get-modify-put shape over distinct types by design
+func (h *Handler) patchPublicIP(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	var req armTagsObject
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	svc, ok := h.tagReplacer()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented", "UpdateTags is not supported by this networking driver")
+		return
+	}
+
+	h.patchMu.Lock()
+
+	info, err := findPublicIPByName(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		h.patchMu.Unlock()
+		azurearm.WriteCErr(w, err)
+
+		return
+	}
+
+	if req.Tags != nil {
+		_ = svc.ReplaceAddressTags(r.Context(), info.AllocationID, preserveInternalTags(info.Tags, req.Tags))
+
+		if refreshed, rerr := findPublicIPByName(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName); rerr == nil {
+			info = refreshed
+		}
+	}
+
+	h.patchMu.Unlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, h.toPublicIPResponse(r.Context(), info, rp, defaultLoc))
+}
+
+//nolint:gocritic,dupl // rp is request-scoped; UpdateTags handlers share one get-modify-put shape over distinct types by design
+func (h *Handler) patchNATGateway(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	var req armTagsObject
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	svc, ok := h.tagReplacer()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented", "UpdateTags is not supported by this networking driver")
+		return
+	}
+
+	h.patchMu.Lock()
+
+	info, err := findNATGatewayByName(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		h.patchMu.Unlock()
+		azurearm.WriteCErr(w, err)
+
+		return
+	}
+
+	if req.Tags != nil {
+		_ = svc.ReplaceNATGatewayTags(r.Context(), info.ID, preserveInternalTags(info.Tags, req.Tags))
+
+		if refreshed, rerr := findNATGatewayByName(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName); rerr == nil {
+			info = refreshed
+		}
+	}
+
+	h.patchMu.Unlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, h.natGatewayResponse(r.Context(), info, rp, defaultLoc))
+}
+
+// patchRouteTable replaces a route table's tags. Route-table tags live in the
+// Azure route-table metadata store (not the cross-cloud anchor), and hold only
+// user tags, so the replacement needs no internal-anchor preservation.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) patchRouteTable(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	var req armTagsObject
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	meta, ok := h.azureMeta()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented", "UpdateTags is not supported by this networking driver")
+		return
+	}
+
+	h.patchMu.Lock()
+
+	info, err := h.findRouteTableInGroup(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		h.patchMu.Unlock()
+		azurearm.WriteCErr(w, err)
+
+		return
+	}
+
+	if req.Tags != nil {
+		md, _ := meta.GetAzureRouteTableMetadata(r.Context(), info.ID)
+		md.Tags = replacementTags(req.Tags)
+		_ = meta.PutAzureRouteTableMetadata(r.Context(), info.ID, md)
+	}
+
+	h.patchMu.Unlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, h.routeTableResponse(r.Context(), info, rp))
+}
+
+// patchNIC replaces a network interface's tags. NIC tags are user-only (the NIC
+// store is keyed by (rg, name), not by anchor tags), so no internal-anchor
+// preservation is needed.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) patchNIC(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath, svc netdriver.AzureNetworkInterfaces) {
+	var req armTagsObject
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	replacer, ok := h.tagReplacer()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented", "UpdateTags is not supported by this networking driver")
+		return
+	}
+
+	h.patchMu.Lock()
+
+	if _, err := svc.GetNetworkInterface(r.Context(), rp.ResourceGroup, rp.ResourceName); err != nil {
+		h.patchMu.Unlock()
+		azurearm.WriteCErr(w, err)
+
+		return
+	}
+
+	if req.Tags != nil {
+		_ = replacer.ReplaceNetworkInterfaceTags(r.Context(), rp.ResourceGroup, rp.ResourceName, replacementTags(req.Tags))
+	}
+
+	nic, err := svc.GetNetworkInterface(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	h.patchMu.Unlock()
+
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toNICResponse(nic, rp))
+}

--- a/server/azure/vnet/route_table.go
+++ b/server/azure/vnet/route_table.go
@@ -16,7 +16,7 @@ import (
 // the ARM-specific fields (region, routes, user tags) round-trip through the
 // Azure route-table metadata store.
 
-//nolint:gocritic // rp is a request-scoped value
+//nolint:gocritic,dupl // rp is request-scoped; the per-resource routers are the same method switch over a distinct type by design
 func (h *Handler) routeRouteTable(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	if rp.ResourceName == "" {
 		h.listRouteTables(w, r, rp)
@@ -26,6 +26,8 @@ func (h *Handler) routeRouteTable(w http.ResponseWriter, r *http.Request, rp azu
 	switch r.Method {
 	case http.MethodPut:
 		h.createRouteTable(w, r, rp)
+	case http.MethodPatch:
+		h.patchRouteTable(w, r, rp)
 	case http.MethodGet:
 		h.getRouteTable(w, r, rp)
 	case http.MethodDelete:

--- a/services/networking/driver/azure_network_tags.go
+++ b/services/networking/driver/azure_network_tags.go
@@ -1,0 +1,32 @@
+package driver
+
+import "context"
+
+// AzureNetworkTagReplacer replaces the entire stored tag collection on the core
+// Azure VNet-family resources, backing the ARM resource-level UpdateTags PATCH
+// (Microsoft.Network's *Client.UpdateTags), which SETS the tag set wholesale
+// rather than merging. It is an OPTIONAL, type-asserted capability that only the
+// Azure provider implements (the same pattern as AzureNetworkMetadata /
+// AzureNetworkInterfaces); AWS and GCP do not.
+//
+// Each method overwrites the resource's tags with exactly the supplied map (a
+// nil or empty map clears them) in a single atomic store update, and returns
+// NotFound when the resource is absent. The VNet-family resources anchored in
+// the cross-cloud store carry wire-internal cloudemu: tags the (resourceGroup,
+// name) lookup depends on; the wire handler folds those anchors into the map it
+// passes here, so the replace never drops them.
+type AzureNetworkTagReplacer interface {
+	// ReplaceVPCTags sets the virtual network's tags, keyed by its driver id.
+	ReplaceVPCTags(ctx context.Context, id string, tags map[string]string) error
+	// ReplaceSecurityGroupTags sets the network security group's tags, keyed by
+	// its driver id.
+	ReplaceSecurityGroupTags(ctx context.Context, id string, tags map[string]string) error
+	// ReplaceNATGatewayTags sets the NAT gateway's tags, keyed by its driver id.
+	ReplaceNATGatewayTags(ctx context.Context, id string, tags map[string]string) error
+	// ReplaceAddressTags sets the public IP address's tags, keyed by its
+	// Elastic-IP allocation id.
+	ReplaceAddressTags(ctx context.Context, allocationID string, tags map[string]string) error
+	// ReplaceNetworkInterfaceTags sets the network interface's tags, keyed by the
+	// (resourceGroup, name) ARM addressing pair the NIC store uses.
+	ReplaceNetworkInterfaceTags(ctx context.Context, resourceGroup, name string, tags map[string]string) error
+}


### PR DESCRIPTION
## Summary

Adds ARM resource-level `UpdateTags` (synchronous PATCH) to the core Azure VNet-family resources that previously returned 405: virtualNetworks, networkSecurityGroups, routeTables, publicIPAddresses, natGateways, networkInterfaces. This unblocks `azurerm_*` Terraform tag drift, which drives tag updates through `UpdateTags`.

## Semantics — REPLACE, not merge

Resource-level Azure `UpdateTags` takes a bare `TagsObject` and SETS the tag collection wholesale (it does not merge — merge/replace/delete modes live only on the generic `Microsoft.Resources/tags` API). Mirrors the already-merged gateway/public-IP-prefix/ASG sweep:

- PATCH `{tags:{...}}` REPLACES the tag set, preserves all other properties, returns the full resource, answers a synchronous 200 (all six clients use sync `UpdateTags`, not `BeginUpdateTags`).
- `tags:{}` wipes every tag.
- PATCH on a missing resource → 404.
- Wire-internal `cloudemu:` anchor tags (the name/resource-group/association bookkeeping the (rg, name) lookup depends on) are preserved across the user-tag replacement.

## Subnets

Subnets are NOT independently taggable in real Azure — their tags live on the parent virtual network — so they are intentionally skipped (no UpdateTags handler).

## Architecture

- New optional, type-asserted `AzureNetworkTagReplacer` capability (Azure-only, same pattern as `AzureNetworkMetadata` / `AzureNetworkInterfaces`); AWS/GCP are unaffected.
- Each store mutation is a single atomic driver call; the wire get-modify-put is serialized by the handler-level `patchMu` so concurrent PATCHes cannot lose updates (`-race` clean).
- Route-table tags route through the existing route-table metadata store; NIC tags through the NIC store.

## Tests

Real `armnetwork` SDK per resource: create → `UpdateTags` replaces a pre-existing tag (old gone, new present) with properties preserved and full resource returned; raw `tags:{}` wipe (the SDK drops empty maps); PATCH on missing → 404.