### PR TITLE
fix(azure-sql): preserve TDE state across database updates

### DIFF
--- a/providers/azure/sql/databases.go
+++ b/providers/azure/sql/databases.go
@@ -79,6 +79,50 @@ func (m *Mock) CreateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 	return &out, nil
 }
 
+// UpdateDatabase applies a fully-merged desired state to an existing logical
+// database in place, implementing the relationaldb DatabaseUpdater optional
+// capability. It is the update half of the wire CreateOrUpdate/PATCH: the
+// caller has already merged the request body over the stored record, so cfg
+// carries the resolved final values for every mutable field.
+//
+// Crucially it does NOT touch the transparentDataEncryption record: a database
+// whose TDE was set to Disabled keeps that state across an unrelated property
+// update (real Azure never re-enables TDE on a database PATCH). The mutation is
+// a write-locked COW Update, so it is safe under concurrent access and never
+// re-materializes TDE the way a delete+recreate upsert would.
+//
+//nolint:gocritic // cfg matches the DatabaseUpdater capability interface signature.
+func (m *Mock) UpdateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (*rdsdriver.Database, error) {
+	if cfg.Server == "" || cfg.Name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "server and database name are required")
+	}
+
+	var updated rdsdriver.Database
+
+	ok := m.databases.Update(dbKey(cfg.Server, cfg.Name), func(db rdsdriver.Database) rdsdriver.Database {
+		db.Charset = cfg.Charset
+		db.Collation = cfg.Collation
+		db.Location = orDefault(cfg.Location, db.Location)
+		db.Tags = copyTags(cfg.Tags)
+		db.SKUName = cfg.SKUName
+		db.SKUTier = cfg.SKUTier
+		db.SKUCapacity = cfg.SKUCapacity
+		db.ZoneRedundant = cfg.ZoneRedundant
+		db.ElasticPoolID = cfg.ElasticPoolID
+		updated = db
+
+		return db
+	})
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "database %q not found on server %q", cfg.Name, cfg.Server)
+	}
+
+	out := updated
+	out.Tags = copyTags(updated.Tags)
+
+	return &out, nil
+}
+
 // GetDatabase returns a logical database, or NotFound.
 func (m *Mock) GetDatabase(_ context.Context, server, name string) (*rdsdriver.Database, error) {
 	m.mu.RLock()

--- a/providers/azure/sql/sql.go
+++ b/providers/azure/sql/sql.go
@@ -46,7 +46,10 @@ const (
 	dtuRunning         = 50.0
 )
 
-var _ rdsdriver.RelationalDB = (*Mock)(nil)
+var (
+	_ rdsdriver.RelationalDB    = (*Mock)(nil)
+	_ rdsdriver.DatabaseUpdater = (*Mock)(nil)
+)
 
 // Mock is the in-memory Azure SQL implementation.
 type Mock struct {

--- a/server/azure/sql/cascade_elasticpool_sdk_test.go
+++ b/server/azure/sql/cascade_elasticpool_sdk_test.go
@@ -180,10 +180,9 @@ func TestSDKAzureSQLDatabaseElasticPoolMembership(t *testing.T) {
 // TestSDKAzureSQLDatabaseUpdateBadElasticPoolPreservesDatabase is the HIGH
 // regression: a PUT against an EXISTING database that references an
 // elasticPoolId which doesn't resolve must fail the request without deleting
-// the database. replaceDatabase upserts by deleting the stored record and
-// re-creating it merged with the request body — before the fix, the delete
-// ran first, so a bad pool reference on the re-create half permanently lost a
-// database that already existed.
+// the database. replaceDatabase validates the merged elasticPoolId before it
+// applies any change, so a bad pool reference leaves the existing database
+// exactly as it was.
 func TestSDKAzureSQLDatabaseUpdateBadElasticPoolPreservesDatabase(t *testing.T) {
 	cf := newFactory(t)
 	ctx := context.Background()

--- a/server/azure/sql/operations.go
+++ b/server/azure/sql/operations.go
@@ -285,15 +285,18 @@ func mergeDatabaseFields(existing *rdsdriver.Database, body *armDatabase, cfg *r
 	return merged
 }
 
-// replaceDatabase merges the request body over the stored database and
-// re-creates it, so a PUT/PATCH against an existing database changes sku/tier/
-// HA while leaving omitted fields intact.
+// replaceDatabase merges the request body over the stored database and applies
+// the result in place, so a PUT/PATCH against an existing database changes
+// sku/tier/HA while leaving omitted fields intact.
 //
-// The merged elasticPoolId is validated before DeleteDatabase runs: a request
-// that references a nonexistent pool must fail the update with no side
-// effect, not delete the database out from under a bad request (CreateDatabase
-// re-validates the pool too, but only after the delete below would already
-// have happened).
+// It updates the record in place via the DatabaseUpdater capability rather than
+// deleting and re-creating it. A delete+recreate upsert dropped the database's
+// transparentDataEncryption record and re-materialized it as Enabled on the
+// re-create, silently re-enabling TDE on a database the user had disabled it on.
+// The in-place update leaves the TDE sub-resource untouched.
+//
+// The merged elasticPoolId is validated before the update: a request that
+// references a nonexistent pool must fail with no side effect.
 func replaceDatabase(
 	ctx context.Context, db rdsdriver.Databases, body *armDatabase, cfg *rdsdriver.DatabaseConfig,
 ) (*rdsdriver.Database, error) {
@@ -308,11 +311,12 @@ func replaceDatabase(
 		return nil, err
 	}
 
-	if err := db.DeleteDatabase(ctx, cfg.Server, cfg.Name); err != nil {
-		return nil, err
+	updater, ok := db.(rdsdriver.DatabaseUpdater)
+	if !ok {
+		return nil, cerrors.New(cerrors.InvalidArgument, "database update is not supported by this provider")
 	}
 
-	return db.CreateDatabase(ctx, rdsdriver.DatabaseConfig{
+	return updater.UpdateDatabase(ctx, rdsdriver.DatabaseConfig{
 		Server:        merged.Server,
 		Name:          merged.Name,
 		Charset:       merged.Charset,

--- a/server/azure/sql/tde_sdk_test.go
+++ b/server/azure/sql/tde_sdk_test.go
@@ -106,3 +106,73 @@ func TestSDKAzureSQLTransparentDataEncryption(t *testing.T) {
 		t.Fatalf("got list name %v, want current", page.Value[0].Name)
 	}
 }
+
+// TestSDKAzureSQLTDESurvivesDatabaseUpdate is the S1 regression: a database
+// whose TDE was set to Disabled must keep that state across an unrelated
+// property update. A delete+recreate upsert dropped the TDE record and
+// re-materialized it as Enabled; the in-place update leaves it untouched.
+func TestSDKAzureSQLTDESurvivesDatabaseUpdate(t *testing.T) {
+	cf := seedTDEDatabase(t)
+	ctx := context.Background()
+	tde := cf.NewTransparentDataEncryptionsClient()
+	dbs := cf.NewDatabasesClient()
+
+	// Disable TDE via the transparentDataEncryption/current sub-resource.
+	if _, err := tde.CreateOrUpdate(ctx, "rg-1", "srv1", "appdb",
+		armsql.TransparentDataEncryptionNameCurrent,
+		armsql.LogicalDatabaseTransparentDataEncryption{
+			Properties: &armsql.TransparentDataEncryptionProperties{
+				State: to.Ptr(armsql.TransparentDataEncryptionStateDisabled),
+			},
+		}, nil); err != nil {
+		t.Fatalf("disable TDE: %v", err)
+	}
+
+	// PATCH an unrelated property (tags) on the database.
+	patchPoller, err := dbs.BeginUpdate(ctx, "rg-1", "srv1", "appdb", armsql.DatabaseUpdate{
+		Tags: map[string]*string{"env": to.Ptr("prod")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate: %v", err)
+	}
+
+	if _, err := patchPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("BeginUpdate PollUntilDone: %v", err)
+	}
+
+	// TDE must still be Disabled — not silently reset to Enabled.
+	got, err := tde.Get(ctx, "rg-1", "srv1", "appdb", armsql.TransparentDataEncryptionNameCurrent, nil)
+	if err != nil {
+		t.Fatalf("Get after PATCH: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.State == nil {
+		t.Fatal("expected TDE state set after PATCH")
+	}
+
+	if *got.Properties.State != armsql.TransparentDataEncryptionStateDisabled {
+		t.Fatalf("got state %q after unrelated PATCH, want Disabled", *got.Properties.State)
+	}
+
+	// A PUT (CreateOrUpdate) against the existing database must also preserve it.
+	putPoller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "appdb", armsql.Database{
+		Location: to.Ptr("eastus"),
+		SKU:      &armsql.SKU{Name: to.Ptr("GP_Gen5_4"), Tier: to.Ptr("GeneralPurpose")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate (PUT): %v", err)
+	}
+
+	if _, err := putPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("PUT PollUntilDone: %v", err)
+	}
+
+	got, err = tde.Get(ctx, "rg-1", "srv1", "appdb", armsql.TransparentDataEncryptionNameCurrent, nil)
+	if err != nil {
+		t.Fatalf("Get after PUT: %v", err)
+	}
+
+	if *got.Properties.State != armsql.TransparentDataEncryptionStateDisabled {
+		t.Fatalf("got state %q after PUT, want Disabled", *got.Properties.State)
+	}
+}


### PR DESCRIPTION
## Problem

A database whose Transparent Data Encryption (TDE) was set to Disabled had it silently reset to Enabled on any database CreateOrUpdate/PATCH. The wire `replaceDatabase` upsert deleted the stored database (dropping its `transparentDataEncryption/current` record) and re-created it, which re-materialized TDE as Enabled. A user who disabled TDE (or held any non-default state) lost it whenever they updated an unrelated property (tags, SKU, etc.).

## Fix

- Added an in-place `UpdateDatabase` to the Azure SQL provider implementing the existing `relationaldb.DatabaseUpdater` optional capability. It mutates the database record via a write-locked memstore COW `Update`, leaving the separate TDE store untouched.
- Reworked wire `replaceDatabase` to merge the request body and apply it via `UpdateDatabase` instead of delete+recreate. The elastic-pool pre-validation still runs before any mutation, so a bad pool reference is still a no-op.
- New brand-default behavior is unchanged: a freshly created database still defaults to TDE Enabled (Azure's real default).

## Tests

- New `TestSDKAzureSQLTDESurvivesDatabaseUpdate` (real `armsql` SDK): create DB (TDE Enabled by default) → disable TDE via `transparentDataEncryption/current` → PATCH tags and PUT a new SKU → TDE still Disabled.
- Existing TDE and elastic-pool preservation tests still pass.