### PR TITLE
feat(dynamodb): on-demand backup + PITR restore

### DIFF
--- a/docs/coverage/aws/dynamodb.md
+++ b/docs/coverage/aws/dynamodb.md
@@ -32,6 +32,23 @@ AWS's `database` service · portable interface `driver.Database` · [AWS index](
 | `UpdateStreamConfig` | Streams / Change Feed |
 | `UpdateTTL` | TTL |
 
+## Optional capabilities
+
+Discovered by type assertion; only some providers implement these.
+
+### Backuper
+
+Backuper is an OPTIONAL capability, discovered by type assertion (like the
+
+| Operation | Description |
+| --- | --- |
+| `CreateBackup` | CreateBackup snapshots the table's schema and items under a new BackupArn. |
+| `DeleteBackup` | DeleteBackup removes the backup identified by backupArn, returning its |
+| `DescribeBackup` | DescribeBackup returns the backup identified by backupArn. |
+| `ListBackups` | ListBackups returns every backup, or only those of tableName when it is |
+| `RestoreTableFromBackup` | RestoreTableFromBackup creates targetTable from the backup's schema and |
+| `RestoreTableToPointInTime` | RestoreTableToPointInTime creates targetTable from sourceTable. The |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -3424,6 +3424,36 @@
     ],
     "optionalCapabilities": [
       {
+        "name": "Backuper",
+        "doc": "Backuper is an OPTIONAL capability, discovered by type assertion (like the",
+        "operations": [
+          {
+            "name": "CreateBackup",
+            "doc": "CreateBackup snapshots the table's schema and items under a new BackupArn."
+          },
+          {
+            "name": "DeleteBackup",
+            "doc": "DeleteBackup removes the backup identified by backupArn, returning its"
+          },
+          {
+            "name": "DescribeBackup",
+            "doc": "DescribeBackup returns the backup identified by backupArn."
+          },
+          {
+            "name": "ListBackups",
+            "doc": "ListBackups returns every backup, or only those of tableName when it is"
+          },
+          {
+            "name": "RestoreTableFromBackup",
+            "doc": "RestoreTableFromBackup creates targetTable from the backup's schema and"
+          },
+          {
+            "name": "RestoreTableToPointInTime",
+            "doc": "RestoreTableToPointInTime creates targetTable from sourceTable. The"
+          }
+        ]
+      },
+      {
         "name": "TableAttributes",
         "doc": "TableAttributes is an OPTIONAL capability, discovered by type assertion (like",
         "operations": [

--- a/providers/aws/dynamodb/backup.go
+++ b/providers/aws/dynamodb/backup.go
@@ -56,7 +56,7 @@ func (m *Mock) CreateBackup(_ context.Context, table, backupName string) (driver
 		CreatedUnix: float64(m.opts.Clock.Now().Unix()),
 		SizeBytes:   size,
 		ItemCount:   int64(len(items)),
-		SourceTable: td.config,
+		SourceTable: deepCopyTableConfig(&td.config),
 	}
 
 	m.backups[info.BackupArn] = &backupData{info: info, items: items}
@@ -197,7 +197,7 @@ func (m *Mock) PITRWindow(_ context.Context, table string) (earliest, latest flo
 // restore does not carry continuous backups or streams forward). Caller holds
 // m.mu.
 func (m *Mock) restoreInto(ctx context.Context, targetTable string, srcCfg *driver.TableConfig, items []map[string]any) {
-	cfg := *srcCfg
+	cfg := deepCopyTableConfig(srcCfg)
 	cfg.Name = targetTable
 	cfg.TableArn = idgen.AWSARN("dynamodb", regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID, "table/"+targetTable)
 	cfg.CreatedAtUnix = float64(m.opts.Clock.Now().Unix())
@@ -226,6 +226,48 @@ func (m *Mock) newBackupID() string {
 	}
 
 	return fmt.Sprintf("%013d-%08x", m.opts.Clock.Now().UnixMilli(), b)
+}
+
+// deepCopyTableConfig returns a copy of cfg whose slice fields (Attributes,
+// GSIs, LSIs and each index's NonKeyAttributes) are fresh, so a backup or a
+// restored table shares no schema state with the live table. Without it, an
+// in-place slice mutation on the source table — e.g. DeleteIndex's append-shift
+// of GSIs — would corrupt the backup and every table restored from it.
+func deepCopyTableConfig(cfg *driver.TableConfig) driver.TableConfig {
+	out := *cfg
+	out.Attributes = append([]driver.AttributeDef(nil), cfg.Attributes...)
+	out.GSIs = deepCopyGSIs(cfg.GSIs)
+	out.LSIs = deepCopyLSIs(cfg.LSIs)
+
+	return out
+}
+
+func deepCopyGSIs(in []driver.GSIConfig) []driver.GSIConfig {
+	if in == nil {
+		return nil
+	}
+
+	out := make([]driver.GSIConfig, len(in))
+	for i := range in {
+		out[i] = in[i]
+		out[i].NonKeyAttributes = append([]string(nil), in[i].NonKeyAttributes...)
+	}
+
+	return out
+}
+
+func deepCopyLSIs(in []driver.LSIConfig) []driver.LSIConfig {
+	if in == nil {
+		return nil
+	}
+
+	out := make([]driver.LSIConfig, len(in))
+	for i := range in {
+		out[i] = in[i]
+		out[i].NonKeyAttributes = append([]string(nil), in[i].NonKeyAttributes...)
+	}
+
+	return out
 }
 
 // deepCopyItem returns a fully independent copy of item, recursing through

--- a/providers/aws/dynamodb/backup.go
+++ b/providers/aws/dynamodb/backup.go
@@ -1,0 +1,270 @@
+package dynamodb
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"sort"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/regionctx"
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
+)
+
+// pitrRetentionDays is the 35-day continuous-backup retention window DynamoDB
+// keeps, bounding a table's EarliestRestorableDateTime.
+const pitrRetentionDays = 35
+
+var _ driver.Backuper = (*Mock)(nil)
+
+// backupData is one stored on-demand backup: its description plus a deep copy of
+// the table's items captured at backup time, so the backup is immune to any
+// later mutation or deletion of the source table.
+type backupData struct {
+	info  driver.BackupInfo
+	items []map[string]any
+}
+
+// CreateBackup snapshots the table's schema and items under a fresh BackupArn.
+func (m *Mock) CreateBackup(_ context.Context, table, backupName string) (driver.BackupInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return driver.BackupInfo{}, cerrors.Newf(cerrors.NotFound, "Table not found: %s", table)
+	}
+
+	items := make([]map[string]any, 0, td.items.Len())
+
+	var size int64
+
+	for _, it := range td.items.All() {
+		items = append(items, deepCopyItem(it))
+		size += int64(itemSizeBytes(it))
+	}
+
+	info := driver.BackupInfo{
+		BackupArn:   td.config.TableArn + "/backup/" + m.newBackupID(),
+		BackupName:  backupName,
+		Status:      driver.BackupStatusAvailable,
+		Type:        driver.BackupTypeUser,
+		CreatedUnix: float64(m.opts.Clock.Now().Unix()),
+		SizeBytes:   size,
+		ItemCount:   int64(len(items)),
+		SourceTable: td.config,
+	}
+
+	m.backups[info.BackupArn] = &backupData{info: info, items: items}
+
+	return info, nil
+}
+
+// DescribeBackup returns the backup identified by backupArn.
+func (m *Mock) DescribeBackup(_ context.Context, backupArn string) (driver.BackupInfo, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	b, ok := m.backups[backupArn]
+	if !ok {
+		return driver.BackupInfo{}, cerrors.Newf(cerrors.NotFound, "Backup not found: %s", backupArn)
+	}
+
+	return b.info, nil
+}
+
+// ListBackups returns every backup (ordered by BackupArn), or only those of
+// tableName when it is non-empty.
+func (m *Mock) ListBackups(_ context.Context, tableName string) ([]driver.BackupInfo, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	out := make([]driver.BackupInfo, 0, len(m.backups))
+
+	for _, b := range m.backups {
+		if tableName != "" && b.info.SourceTable.Name != tableName {
+			continue
+		}
+
+		out = append(out, b.info)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].BackupArn < out[j].BackupArn })
+
+	return out, nil
+}
+
+// DeleteBackup removes the backup identified by backupArn, returning its last
+// description.
+func (m *Mock) DeleteBackup(_ context.Context, backupArn string) (driver.BackupInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	b, ok := m.backups[backupArn]
+	if !ok {
+		return driver.BackupInfo{}, cerrors.Newf(cerrors.NotFound, "Backup not found: %s", backupArn)
+	}
+
+	delete(m.backups, backupArn)
+
+	return b.info, nil
+}
+
+// RestoreTableFromBackup creates targetTable from the backup's schema and item
+// snapshot.
+func (m *Mock) RestoreTableFromBackup(ctx context.Context, backupArn, targetTable string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	b, ok := m.backups[backupArn]
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "Backup not found: %s", backupArn)
+	}
+
+	if _, exists := m.tables[targetTable]; exists {
+		return cerrors.Newf(cerrors.AlreadyExists, "Table already exists: %s", targetTable)
+	}
+
+	m.restoreInto(ctx, targetTable, &b.info.SourceTable, b.items)
+
+	return nil
+}
+
+// RestoreTableToPointInTime creates targetTable from sourceTable's CURRENT item
+// set. The emulator retains no per-second history, so it restores the latest
+// restorable point; useLatest is accepted for wire fidelity but does not change
+// the restored data. It requires PITR (continuous backups) enabled on the
+// source, matching real DynamoDB.
+func (m *Mock) RestoreTableToPointInTime(ctx context.Context, sourceTable, targetTable string, _ bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	src, ok := m.tables[sourceTable]
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "Source table not found: %s", sourceTable)
+	}
+
+	if !src.pitrEnabled {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"Point in time recovery is not enabled for table: %s", sourceTable)
+	}
+
+	if _, exists := m.tables[targetTable]; exists {
+		return cerrors.Newf(cerrors.AlreadyExists, "Table already exists: %s", targetTable)
+	}
+
+	items := make([]map[string]any, 0, src.items.Len())
+	for _, it := range src.items.All() {
+		items = append(items, it)
+	}
+
+	m.restoreInto(ctx, targetTable, &src.config, items)
+
+	return nil
+}
+
+// PITRWindow reports the continuous-backup restorable window for a table: the
+// latest restorable point is now, and the earliest is bounded by the table's
+// creation time and the 35-day retention window. Backs the restorable-window
+// fields of DescribeContinuousBackups.
+func (m *Mock) PITRWindow(_ context.Context, table string) (earliest, latest float64, err error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return 0, 0, cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	now := m.opts.Clock.Now()
+	earliest = td.config.CreatedAtUnix
+
+	if floor := float64(now.Add(-pitrRetentionDays * 24 * time.Hour).Unix()); earliest < floor {
+		earliest = floor
+	}
+
+	return earliest, float64(now.Unix()), nil
+}
+
+// restoreInto materializes a new table named targetTable from a schema snapshot
+// and a set of items, deep-copying each item so the new table shares no state
+// with the backup or the source. The restored table is a NEW resource: it gets
+// its own ARN, id and creation time, and starts with streams disabled (a
+// restore does not carry continuous backups or streams forward). Caller holds
+// m.mu.
+func (m *Mock) restoreInto(ctx context.Context, targetTable string, srcCfg *driver.TableConfig, items []map[string]any) {
+	cfg := *srcCfg
+	cfg.Name = targetTable
+	cfg.TableArn = idgen.AWSARN("dynamodb", regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID, "table/"+targetTable)
+	cfg.CreatedAtUnix = float64(m.opts.Clock.Now().Unix())
+	cfg.TableID = uuidV4()
+	cfg.StreamEnabled = false
+	cfg.StreamViewType = ""
+	cfg.StreamArn = ""
+	cfg.StreamLabel = ""
+
+	td := &tableData{items: memstore.New[map[string]any](), config: cfg}
+
+	for _, it := range items {
+		copied := deepCopyItem(it)
+		td.items.Set(itemKey(cfg, copied), copied)
+	}
+
+	m.tables[targetTable] = td
+}
+
+// newBackupID builds the id segment of a BackupArn: a millisecond timestamp and
+// a short random suffix, mirroring the shape a real DynamoDB backup id carries.
+func (m *Mock) newBackupID() string {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic("dynamodb: crypto/rand failed: " + err.Error())
+	}
+
+	return fmt.Sprintf("%013d-%08x", m.opts.Clock.Now().UnixMilli(), b)
+}
+
+// deepCopyItem returns a fully independent copy of item, recursing through
+// nested maps, lists, binary scalars and the set types so a backup or a
+// restored table can never be mutated through an alias into the source.
+func deepCopyItem(item map[string]any) map[string]any {
+	out := make(map[string]any, len(item))
+	for k, v := range item {
+		out[k] = deepCopyValue(v)
+	}
+
+	return out
+}
+
+func deepCopyValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		return deepCopyItem(t)
+	case []any:
+		out := make([]any, len(t))
+		for i := range t {
+			out[i] = deepCopyValue(t[i])
+		}
+
+		return out
+	case []byte:
+		return append([]byte(nil), t...)
+	case expr.StringSet:
+		return append(expr.StringSet(nil), t...)
+	case expr.NumberSet:
+		return append(expr.NumberSet(nil), t...)
+	case expr.BinarySet:
+		out := make(expr.BinarySet, len(t))
+		for i := range t {
+			out[i] = append([]byte(nil), t[i]...)
+		}
+
+		return out
+	default:
+		return v
+	}
+}

--- a/providers/aws/dynamodb/backup_test.go
+++ b/providers/aws/dynamodb/backup_test.go
@@ -163,3 +163,89 @@ func TestPITRWindow(t *testing.T) {
 	_, _, err = m.PITRWindow(ctx, "ghost")
 	assertError(t, err, true)
 }
+
+// TestBackupSchemaIndependence guards that a backup and every table restored
+// from it own their schema slices outright: an in-place GSI mutation on the
+// source table (DeleteIndex's append-shift, CreateIndex's append-grow) must not
+// leak into the backup's SourceTable or a restored table's indexes.
+func TestBackupSchemaIndependence(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	requireNoError(t, m.CreateTable(ctx, driver.TableConfig{
+		Name:         "products",
+		PartitionKey: "pk",
+		SortKey:      "sk",
+		Attributes: []driver.AttributeDef{
+			{Name: "pk", Type: "S"}, {Name: "sk", Type: "S"},
+			{Name: "g1pk", Type: "S"}, {Name: "g2pk", Type: "S"}, {Name: "lsk", Type: "S"},
+		},
+		GSIs: []driver.GSIConfig{
+			{Name: "idx1", PartitionKey: "g1pk", Projection: "INCLUDE", NonKeyAttributes: []string{"n1"}},
+			{Name: "idx2", PartitionKey: "g2pk", Projection: "ALL"},
+		},
+		LSIs: []driver.LSIConfig{
+			{Name: "lsi1", SortKey: "lsk", Projection: "INCLUDE", NonKeyAttributes: []string{"n2"}},
+		},
+	}))
+
+	info, err := m.CreateBackup(ctx, "products", "b")
+	requireNoError(t, err)
+	requireNoError(t, m.RestoreTableFromBackup(ctx, info.BackupArn, "restored1"))
+	requireNoError(t, m.RestoreTableFromBackup(ctx, info.BackupArn, "restored2"))
+
+	// Mutate the SOURCE schema in place — the append-shift previously corrupted
+	// the backing array shared with the backup; the append-grow exercises the
+	// same aliasing on growth.
+	requireNoError(t, m.DeleteIndex(ctx, "products", "idx1"))
+	_, err = m.CreateIndex(ctx, "products", driver.GSIConfig{Name: "idx3", PartitionKey: "g2pk"})
+	requireNoError(t, err)
+
+	// Mutate a RESTORED table in place — this must not leak back into the backup
+	// or into a sibling restore (which would happen if restore aliased the
+	// backup's slices).
+	requireNoError(t, m.DeleteIndex(ctx, "restored1", "idx2"))
+
+	// The backup's schema must be untouched: both original GSIs, uncorrupted,
+	// with their own NonKeyAttributes, plus the LSI and attribute definitions.
+	got, err := m.DescribeBackup(ctx, info.BackupArn)
+	requireNoError(t, err)
+	assertEqual(t, 2, len(got.SourceTable.GSIs))
+	assertEqual(t, "idx1", got.SourceTable.GSIs[0].Name)
+	assertEqual(t, "idx2", got.SourceTable.GSIs[1].Name)
+	assertEqual(t, 1, len(got.SourceTable.GSIs[0].NonKeyAttributes))
+	assertEqual(t, "n1", got.SourceTable.GSIs[0].NonKeyAttributes[0])
+	assertEqual(t, 1, len(got.SourceTable.LSIs))
+	assertEqual(t, "n2", got.SourceTable.LSIs[0].NonKeyAttributes[0])
+	assertEqual(t, 5, len(got.SourceTable.Attributes))
+
+	// The untouched sibling restore must still show both original GSIs, its LSI
+	// and its attribute definitions.
+	assertGSINames(t, m, "restored2", "idx1", "idx2")
+
+	rcfg, err := m.DescribeTable(ctx, "restored2")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(rcfg.LSIs))
+	assertEqual(t, "n2", rcfg.LSIs[0].NonKeyAttributes[0])
+	assertEqual(t, 5, len(rcfg.Attributes))
+}
+
+// assertGSINames asserts a table's GSIs are exactly the given names.
+func assertGSINames(t *testing.T, m *Mock, table string, want ...string) {
+	t.Helper()
+
+	idxs, err := m.ListIndexes(context.Background(), table)
+	requireNoError(t, err)
+	assertEqual(t, len(want), len(idxs))
+
+	got := map[string]bool{}
+	for _, ix := range idxs {
+		got[ix.Name] = true
+	}
+
+	for _, name := range want {
+		if !got[name] {
+			t.Fatalf("table %q missing GSI %q; has %v", table, name, got)
+		}
+	}
+}

--- a/providers/aws/dynamodb/backup_test.go
+++ b/providers/aws/dynamodb/backup_test.go
@@ -1,0 +1,165 @@
+package dynamodb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+// seedItem writes one item into a table, failing the test on error.
+func seedItem(t *testing.T, m *Mock, table string, item map[string]any) {
+	t.Helper()
+	requireNoError(t, m.PutItem(context.Background(), table, item))
+}
+
+func TestCreateBackupSnapshotsItems(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	createTestTable(m, "orders")
+	seedItem(t, m, "orders", map[string]any{"pk": "a", "sk": "1", "v": "x"})
+	seedItem(t, m, "orders", map[string]any{"pk": "b", "sk": "1"})
+
+	info, err := m.CreateBackup(ctx, "orders", "nightly")
+	requireNoError(t, err)
+	assertNotEmpty(t, info.BackupArn)
+	assertEqual(t, "nightly", info.BackupName)
+	assertEqual(t, driver.BackupStatusAvailable, info.Status)
+	assertEqual(t, driver.BackupTypeUser, info.Type)
+	assertEqual(t, int64(2), info.ItemCount)
+
+	// Mutating the source table after the backup must not change the backup.
+	requireNoError(t, m.DeleteItem(ctx, "orders", map[string]any{"pk": "a", "sk": "1"}))
+
+	got, err := m.DescribeBackup(ctx, info.BackupArn)
+	requireNoError(t, err)
+	assertEqual(t, int64(2), got.ItemCount)
+}
+
+func TestCreateBackupMissingTable(t *testing.T) {
+	m := newTestMock()
+	_, err := m.CreateBackup(context.Background(), "ghost", "b")
+	assertError(t, err, true)
+}
+
+func TestRestoreTableFromBackupIsIndependent(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	createTestTable(m, "src")
+	seedItem(t, m, "src", map[string]any{"pk": "a", "sk": "1", "v": "orig"})
+
+	info, err := m.CreateBackup(ctx, "src", "b")
+	requireNoError(t, err)
+
+	requireNoError(t, m.RestoreTableFromBackup(ctx, info.BackupArn, "dst"))
+
+	restored, err := m.GetItem(ctx, "dst", map[string]any{"pk": "a", "sk": "1"})
+	requireNoError(t, err)
+	assertEqual(t, "orig", restored["v"])
+
+	// The restored table is a new resource with its own ARN.
+	srcCfg, err := m.DescribeTable(ctx, "src")
+	requireNoError(t, err)
+	dstCfg, err := m.DescribeTable(ctx, "dst")
+	requireNoError(t, err)
+	if srcCfg.TableArn == dstCfg.TableArn {
+		t.Fatalf("restored table must have a distinct ARN, both are %q", dstCfg.TableArn)
+	}
+
+	// Writing into the restored table must not leak into the source.
+	seedItem(t, m, "dst", map[string]any{"pk": "z", "sk": "1"})
+	if _, err := m.GetItem(ctx, "src", map[string]any{"pk": "z", "sk": "1"}); err == nil {
+		t.Fatal("write to restored table leaked into source table")
+	}
+}
+
+func TestRestoreTableFromBackupErrors(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	createTestTable(m, "src")
+	createTestTable(m, "exists")
+
+	info, err := m.CreateBackup(ctx, "src", "b")
+	requireNoError(t, err)
+
+	// Unknown backup ARN.
+	assertError(t, m.RestoreTableFromBackup(ctx, "arn:aws:dynamodb:us-east-1:0:table/x/backup/nope", "t"), true)
+	// Target already exists.
+	assertError(t, m.RestoreTableFromBackup(ctx, info.BackupArn, "exists"), true)
+}
+
+func TestDeleteBackup(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	createTestTable(m, "src")
+
+	info, err := m.CreateBackup(ctx, "src", "b")
+	requireNoError(t, err)
+
+	_, err = m.DeleteBackup(ctx, info.BackupArn)
+	requireNoError(t, err)
+
+	_, err = m.DescribeBackup(ctx, info.BackupArn)
+	assertError(t, err, true)
+	// Deleting a missing backup is an error.
+	_, err = m.DeleteBackup(ctx, info.BackupArn)
+	assertError(t, err, true)
+}
+
+func TestListBackupsFiltersByTable(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	createTestTable(m, "t1")
+	createTestTable(m, "t2")
+
+	_, err := m.CreateBackup(ctx, "t1", "b1")
+	requireNoError(t, err)
+	_, err = m.CreateBackup(ctx, "t2", "b2")
+	requireNoError(t, err)
+
+	all, err := m.ListBackups(ctx, "")
+	requireNoError(t, err)
+	assertEqual(t, 2, len(all))
+
+	only, err := m.ListBackups(ctx, "t1")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(only))
+	assertEqual(t, "t1", only[0].SourceTable.Name)
+}
+
+func TestRestoreTableToPointInTimeRequiresPITR(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	createTestTable(m, "src")
+	seedItem(t, m, "src", map[string]any{"pk": "a", "sk": "1", "v": "1"})
+
+	// PITR disabled: rejected.
+	assertError(t, m.RestoreTableToPointInTime(ctx, "src", "dst", true), true)
+
+	requireNoError(t, m.SetPITR(ctx, "src", true))
+	requireNoError(t, m.RestoreTableToPointInTime(ctx, "src", "dst", true))
+
+	got, err := m.GetItem(ctx, "dst", map[string]any{"pk": "a", "sk": "1"})
+	requireNoError(t, err)
+	assertEqual(t, "1", got["v"])
+
+	// Target already exists.
+	assertError(t, m.RestoreTableToPointInTime(ctx, "src", "dst", true), true)
+	// Missing source.
+	assertError(t, m.RestoreTableToPointInTime(ctx, "ghost", "x", true), true)
+}
+
+func TestPITRWindow(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	createTestTable(m, "src")
+
+	earliest, latest, err := m.PITRWindow(ctx, "src")
+	requireNoError(t, err)
+	if latest < earliest {
+		t.Fatalf("latest %v must be >= earliest %v", latest, earliest)
+	}
+
+	_, _, err = m.PITRWindow(ctx, "ghost")
+	assertError(t, err, true)
+}

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -80,6 +80,11 @@ type Mock struct {
 	// (token -> request fingerprint + time) so a replay short-circuits instead of
 	// re-applying; guarded by m.mu. Mirrors the SQS FIFO deduplicationIndex.
 	txIdempotency map[string]txIdempotencyRecord
+	// backups holds on-demand table backups keyed by BackupArn: each captures a
+	// table's schema and a deep copy of its items at backup time, so restoring
+	// replays them into a new table regardless of later mutations. Guarded by
+	// m.mu; see backup.go.
+	backups map[string]*backupData
 }
 
 // StreamEventInvoker delivers a DynamoDB Streams event batch to whatever Lambda
@@ -127,6 +132,7 @@ func New(opts *config.Options) *Mock {
 		tables:        make(map[string]*tableData),
 		opts:          opts,
 		txIdempotency: make(map[string]txIdempotencyRecord),
+		backups:       make(map[string]*backupData),
 	}
 }
 
@@ -191,16 +197,23 @@ func validateKeyNotEmpty(keyName string, val any) error {
 // is the sum of each attribute's name length (UTF-8 bytes) and value size. AWS
 // rejects an oversized write with a ValidationException.
 func validateItemSize(item map[string]any) error {
+	if itemSizeBytes(item) > maxItemSizeBytes {
+		return cerrors.New(cerrors.InvalidArgument, "Item size has exceeded the maximum allowed size")
+	}
+
+	return nil
+}
+
+// itemSizeBytes approximates the on-the-wire byte size DynamoDB attributes to an
+// item — the sum of each attribute's name length and value size. It backs both
+// the 400 KB item-ceiling check and a backup's reported SizeBytes.
+func itemSizeBytes(item map[string]any) int {
 	total := 0
 	for name, val := range item {
 		total += len(name) + valueSize(val)
 	}
 
-	if total > maxItemSizeBytes {
-		return cerrors.New(cerrors.InvalidArgument, "Item size has exceeded the maximum allowed size")
-	}
-
-	return nil
+	return total
 }
 
 // elementOverhead is the 1 byte DynamoDB charges per List or Map element, on

--- a/providers/aws/dynamodb/snapshot.go
+++ b/providers/aws/dynamodb/snapshot.go
@@ -19,7 +19,15 @@ var _ snapshot.Snapshottable = (*Mock)(nil)
 // flag. Items are keyed by their internal store key so they restore under the
 // same identity.
 type dynamoSnapshot struct {
-	Tables map[string]*tableSnapshot `json:"tables,omitempty"`
+	Tables  map[string]*tableSnapshot  `json:"tables,omitempty"`
+	Backups map[string]*backupSnapshot `json:"backups,omitempty"`
+}
+
+// backupSnapshot is one on-demand backup's serialized state: its description
+// (including the source-table schema) and the item set captured at backup time.
+type backupSnapshot struct {
+	Info  driver.BackupInfo `json:"info"`
+	Items []map[string]any  `json:"items,omitempty"`
 }
 
 type tableSnapshot struct {
@@ -54,6 +62,13 @@ func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
 		}
 	}
 
+	if len(m.backups) > 0 {
+		snap.Backups = make(map[string]*backupSnapshot, len(m.backups))
+		for arn, b := range m.backups {
+			snap.Backups[arn] = &backupSnapshot{Info: b.info, Items: b.items}
+		}
+	}
+
 	return json.Marshal(snap)
 }
 
@@ -85,6 +100,15 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 		}
 
 		m.tables[name] = td
+	}
+
+	for arn, bs := range snap.Backups {
+		items := make([]map[string]any, len(bs.Items))
+		for i, item := range bs.Items {
+			items[i] = expr.RetypeItem(item)
+		}
+
+		m.backups[arn] = &backupData{info: bs.Info, items: items}
 	}
 
 	return nil

--- a/server/aws/dynamodb/backup.go
+++ b/server/aws/dynamodb/backup.go
@@ -1,0 +1,355 @@
+package dynamodb
+
+import (
+	"context"
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+// pitrWindower is the optional provider capability reporting a table's
+// continuous-backup restorable window (earliest/latest restorable time). A
+// provider without it simply omits those fields from DescribeContinuousBackups.
+type pitrWindower interface {
+	PITRWindow(ctx context.Context, table string) (earliest, latest float64, err error)
+}
+
+// routeBackups dispatches the on-demand backup and PITR-restore operations.
+// Without them CreateBackup/RestoreTableFromBackup/RestoreTableToPointInTime and
+// friends return UnknownOperationException and no DR flow works.
+func (h *Handler) routeBackups(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateBackup":
+		h.createBackup(w, r)
+	case "DescribeBackup":
+		h.describeBackup(w, r)
+	case "ListBackups":
+		h.listBackups(w, r)
+	case "DeleteBackup":
+		h.deleteBackup(w, r)
+	case "RestoreTableFromBackup":
+		h.restoreTableFromBackup(w, r)
+	case "RestoreTableToPointInTime":
+		h.restoreTableToPointInTime(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// backuper returns the driver's Backuper capability, writing an error response
+// and returning false when the driver does not implement it.
+func (h *Handler) backuper(w http.ResponseWriter) (dbdriver.Backuper, bool) {
+	b, ok := h.db.(dbdriver.Backuper)
+	if !ok {
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"UnknownOperationException", "backups are not supported by this driver")
+
+		return nil, false
+	}
+
+	return b, true
+}
+
+func (h *Handler) createBackup(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		TableName  string `json:"TableName"`
+		BackupName string `json:"BackupName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	b, ok := h.backuper(w)
+	if !ok {
+		return
+	}
+
+	info, err := b.CreateBackup(r.Context(), req.TableName, req.BackupName)
+	if err != nil {
+		writeBackupErr(w, err, "TableNotFoundException")
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"BackupDetails": backupDetails(&info)})
+}
+
+func (h *Handler) describeBackup(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		BackupArn string `json:"BackupArn"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	b, ok := h.backuper(w)
+	if !ok {
+		return
+	}
+
+	info, err := b.DescribeBackup(r.Context(), req.BackupArn)
+	if err != nil {
+		writeBackupErr(w, err, "BackupNotFoundException")
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"BackupDescription": backupDescription(&info)})
+}
+
+func (h *Handler) listBackups(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		TableName               string `json:"TableName"`
+		Limit                   *int   `json:"Limit"`
+		ExclusiveStartBackupArn string `json:"ExclusiveStartBackupArn"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	b, ok := h.backuper(w)
+	if !ok {
+		return
+	}
+
+	infos, err := b.ListBackups(r.Context(), req.TableName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	infos = backupsAfter(infos, req.ExclusiveStartBackupArn)
+	wire.WriteJSON(w, listBackupsResponse(infos, req.Limit))
+}
+
+// backupsAfter drops every backup whose ARN is at or before start, resuming an
+// ExclusiveStartBackupArn page; infos is already ordered by ARN ascending.
+func backupsAfter(infos []dbdriver.BackupInfo, start string) []dbdriver.BackupInfo {
+	if start == "" {
+		return infos
+	}
+
+	for i := range infos {
+		if infos[i].BackupArn > start {
+			return infos[i:]
+		}
+	}
+
+	return nil
+}
+
+// listBackupsResponse renders one ListBackups page, setting LastEvaluatedBackupArn
+// when Limit truncates the result.
+func listBackupsResponse(infos []dbdriver.BackupInfo, limit *int) map[string]any {
+	truncated := limit != nil && *limit > 0 && *limit < len(infos)
+	if truncated {
+		infos = infos[:*limit]
+	}
+
+	summaries := make([]map[string]any, 0, len(infos))
+	for i := range infos {
+		summaries = append(summaries, backupSummary(&infos[i]))
+	}
+
+	resp := map[string]any{"BackupSummaries": summaries}
+	if truncated && len(infos) > 0 {
+		resp["LastEvaluatedBackupArn"] = infos[len(infos)-1].BackupArn
+	}
+
+	return resp
+}
+
+func (h *Handler) deleteBackup(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		BackupArn string `json:"BackupArn"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	b, ok := h.backuper(w)
+	if !ok {
+		return
+	}
+
+	info, err := b.DeleteBackup(r.Context(), req.BackupArn)
+	if err != nil {
+		writeBackupErr(w, err, "BackupNotFoundException")
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"BackupDescription": backupDescription(&info)})
+}
+
+func (h *Handler) restoreTableFromBackup(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		TargetTableName string `json:"TargetTableName"`
+		BackupArn       string `json:"BackupArn"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	b, ok := h.backuper(w)
+	if !ok {
+		return
+	}
+
+	if err := b.RestoreTableFromBackup(r.Context(), req.BackupArn, req.TargetTableName); err != nil {
+		writeBackupErr(w, err, "BackupNotFoundException")
+		return
+	}
+
+	h.writeRestoredTable(w, r, req.TargetTableName)
+}
+
+func (h *Handler) restoreTableToPointInTime(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		SourceTableName         string `json:"SourceTableName"`
+		TargetTableName         string `json:"TargetTableName"`
+		UseLatestRestorableTime bool   `json:"UseLatestRestorableTime"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	b, ok := h.backuper(w)
+	if !ok {
+		return
+	}
+
+	err := b.RestoreTableToPointInTime(r.Context(), req.SourceTableName, req.TargetTableName, req.UseLatestRestorableTime)
+	if err != nil {
+		writeBackupErr(w, err, "TableNotFoundException")
+		return
+	}
+
+	h.writeRestoredTable(w, r, req.TargetTableName)
+}
+
+// writeRestoredTable re-describes a freshly restored table and returns it as the
+// TableDescription the restore operations echo.
+func (h *Handler) writeRestoredTable(w http.ResponseWriter, r *http.Request, table string) {
+	full, err := h.db.DescribeTable(r.Context(), table)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"TableDescription": tableDescription(full)})
+}
+
+// pitrRecoveryDescription builds the PointInTimeRecoveryDescription block. When
+// PITR is enabled it also carries the restorable window (earliest/latest) via
+// the optional pitrWindower capability.
+func (h *Handler) pitrRecoveryDescription(ctx context.Context, table string, enabled bool) map[string]any {
+	status := statusDisabled
+	if enabled {
+		status = statusEnabled
+	}
+
+	desc := map[string]any{"PointInTimeRecoveryStatus": status}
+
+	if enabled {
+		if wdw, ok := h.db.(pitrWindower); ok {
+			if earliest, latest, err := wdw.PITRWindow(ctx, table); err == nil {
+				desc["EarliestRestorableDateTime"] = earliest
+				desc["LatestRestorableDateTime"] = latest
+			}
+		}
+	}
+
+	return desc
+}
+
+// writeBackupErr maps a provider error to the DynamoDB-specific exception the
+// caller expects: a not-found becomes notFoundEx (BackupNotFoundException or
+// TableNotFoundException depending on the operation), an already-exists becomes
+// TableAlreadyExistsException, and a failed-precondition (PITR off) becomes
+// PointInTimeRecoveryUnavailableException.
+func writeBackupErr(w http.ResponseWriter, err error, notFoundEx string) {
+	switch {
+	case cerrors.IsNotFound(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, notFoundEx, errMessage(err))
+	case cerrors.IsAlreadyExists(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "TableAlreadyExistsException", errMessage(err))
+	case cerrors.IsFailedPrecondition(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "PointInTimeRecoveryUnavailableException", errMessage(err))
+	default:
+		writeErr(w, err)
+	}
+}
+
+// backupDetails renders the BackupDetails block common to CreateBackup,
+// DescribeBackup and DeleteBackup responses.
+func backupDetails(info *dbdriver.BackupInfo) map[string]any {
+	return map[string]any{
+		"BackupArn":              info.BackupArn,
+		"BackupName":             info.BackupName,
+		"BackupSizeBytes":        info.SizeBytes,
+		"BackupStatus":           info.Status,
+		"BackupType":             info.Type,
+		"BackupCreationDateTime": info.CreatedUnix,
+	}
+}
+
+// backupSummary renders one ListBackups BackupSummaries entry.
+func backupSummary(info *dbdriver.BackupInfo) map[string]any {
+	src := info.SourceTable
+
+	return map[string]any{
+		"TableName":              src.Name,
+		"TableId":                src.TableID,
+		"TableArn":               src.TableArn,
+		"BackupArn":              info.BackupArn,
+		"BackupName":             info.BackupName,
+		"BackupCreationDateTime": info.CreatedUnix,
+		"BackupStatus":           info.Status,
+		"BackupType":             info.Type,
+		"BackupSizeBytes":        info.SizeBytes,
+	}
+}
+
+// backupDescription renders the BackupDescription block (BackupDetails plus the
+// source table's schema) DescribeBackup and DeleteBackup return.
+func backupDescription(info *dbdriver.BackupInfo) map[string]any {
+	src := info.SourceTable
+
+	billing := src.BillingMode
+	if billing == "" {
+		billing = billingProvisioned
+	}
+
+	keySchema := []map[string]string{{"AttributeName": src.PartitionKey, "KeyType": keyTypeHash}}
+	if src.SortKey != "" {
+		keySchema = append(keySchema, map[string]string{"AttributeName": src.SortKey, "KeyType": keyTypeRange})
+	}
+
+	sourceDetails := map[string]any{
+		"TableName":             src.Name,
+		"TableId":               src.TableID,
+		"TableArn":              src.TableArn,
+		"TableSizeBytes":        info.SizeBytes,
+		"KeySchema":             keySchema,
+		"TableCreationDateTime": src.CreatedAtUnix,
+		"ItemCount":             info.ItemCount,
+		"BillingMode":           billing,
+		"ProvisionedThroughput": map[string]any{
+			"ReadCapacityUnits":  src.ReadCapacityUnits,
+			"WriteCapacityUnits": src.WriteCapacityUnits,
+		},
+	}
+
+	return map[string]any{
+		"BackupDetails":      backupDetails(info),
+		"SourceTableDetails": sourceDetails,
+	}
+}

--- a/server/aws/dynamodb/dynamodb_backup_test.go
+++ b/server/aws/dynamodb/dynamodb_backup_test.go
@@ -1,0 +1,190 @@
+// dynamodb_backup_test.go — real-user-journey tests for DynamoDB on-demand
+// backups and PITR restore, driving the genuine aws-sdk-go-v2 DynamoDB client
+// against the emulator's HTTP server (httptest). Assertions are made on
+// SDK-decoded responses and SDK-visible typed errors.
+package dynamodb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDDBBackupLifecycle: create a table with items, back it up, describe/list
+// the backup, restore it into a new table with identical schema + items, then
+// delete the backup and observe the typed 404.
+func TestDDBBackupLifecycle(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "orders", "id", "")
+	suiteDDBPut(t, client, "orders", map[string]ddbtypes.AttributeValue{
+		"id": sAttr("o-1"), "total": nAttr("42"),
+	})
+	suiteDDBPut(t, client, "orders", map[string]ddbtypes.AttributeValue{
+		"id": sAttr("o-2"), "total": nAttr("7"),
+	})
+
+	backup, err := client.CreateBackup(ctx, &dynamodb.CreateBackupInput{
+		TableName:  aws.String("orders"),
+		BackupName: aws.String("nightly"),
+	})
+	require.NoError(t, err)
+	arn := aws.ToString(backup.BackupDetails.BackupArn)
+	require.NotEmpty(t, arn)
+	assert.Equal(t, ddbtypes.BackupStatusAvailable, backup.BackupDetails.BackupStatus)
+	assert.Equal(t, "nightly", aws.ToString(backup.BackupDetails.BackupName))
+
+	desc, err := client.DescribeBackup(ctx, &dynamodb.DescribeBackupInput{BackupArn: aws.String(arn)})
+	require.NoError(t, err)
+	assert.Equal(t, ddbtypes.BackupStatusAvailable, desc.BackupDescription.BackupDetails.BackupStatus)
+	assert.Equal(t, "orders", aws.ToString(desc.BackupDescription.SourceTableDetails.TableName))
+	assert.Equal(t, int64(2), aws.ToInt64(desc.BackupDescription.SourceTableDetails.ItemCount))
+
+	list, err := client.ListBackups(ctx, &dynamodb.ListBackupsInput{TableName: aws.String("orders")})
+	require.NoError(t, err)
+	require.Len(t, list.BackupSummaries, 1)
+	assert.Equal(t, arn, aws.ToString(list.BackupSummaries[0].BackupArn))
+
+	_, err = client.RestoreTableFromBackup(ctx, &dynamodb.RestoreTableFromBackupInput{
+		BackupArn:       aws.String(arn),
+		TargetTableName: aws.String("orders-restored"),
+	})
+	require.NoError(t, err)
+
+	rdesc, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("orders-restored")})
+	require.NoError(t, err)
+	require.Len(t, rdesc.Table.KeySchema, 1)
+	assert.Equal(t, "id", aws.ToString(rdesc.Table.KeySchema[0].AttributeName))
+
+	got := suiteDDBGet(t, client, "orders-restored", map[string]ddbtypes.AttributeValue{"id": sAttr("o-1")})
+	require.NotNil(t, got.Item)
+	assert.Equal(t, "42", attrN(t, got.Item, "total"))
+
+	// The restored table is independent: mutating the source doesn't touch it.
+	suiteDDBPut(t, client, "orders", map[string]ddbtypes.AttributeValue{"id": sAttr("o-3")})
+	absent := suiteDDBGet(t, client, "orders-restored", map[string]ddbtypes.AttributeValue{"id": sAttr("o-3")})
+	assert.Nil(t, absent.Item)
+
+	_, err = client.DeleteBackup(ctx, &dynamodb.DeleteBackupInput{BackupArn: aws.String(arn)})
+	require.NoError(t, err)
+
+	_, err = client.DescribeBackup(ctx, &dynamodb.DescribeBackupInput{BackupArn: aws.String(arn)})
+	var bnf *ddbtypes.BackupNotFoundException
+	require.ErrorAs(t, err, &bnf, "DescribeBackup on a deleted backup should be BackupNotFoundException")
+}
+
+// TestDDBCreateBackupMissingTable: backing up a table that does not exist is a
+// typed TableNotFoundException.
+func TestDDBCreateBackupMissingTable(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+
+	_, err := client.CreateBackup(context.Background(), &dynamodb.CreateBackupInput{
+		TableName:  aws.String("ghost"),
+		BackupName: aws.String("bkp"),
+	})
+
+	var tnf *ddbtypes.TableNotFoundException
+	require.ErrorAs(t, err, &tnf)
+}
+
+// TestDDBRestoreFromBackupTargetExists: restoring onto an existing table name is
+// a typed TableAlreadyExistsException.
+func TestDDBRestoreFromBackupTargetExists(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "src", "id", "")
+	suiteDDBCreateTable(t, client, "existing", "id", "")
+
+	backup, err := client.CreateBackup(ctx, &dynamodb.CreateBackupInput{
+		TableName:  aws.String("src"),
+		BackupName: aws.String("bkp"),
+	})
+	require.NoError(t, err)
+
+	_, err = client.RestoreTableFromBackup(ctx, &dynamodb.RestoreTableFromBackupInput{
+		BackupArn:       backup.BackupDetails.BackupArn,
+		TargetTableName: aws.String("existing"),
+	})
+
+	var exists *ddbtypes.TableAlreadyExistsException
+	require.ErrorAs(t, err, &exists)
+}
+
+// TestDDBRestoreFromMissingBackup: restoring an unknown BackupArn is a typed
+// BackupNotFoundException.
+func TestDDBRestoreFromMissingBackup(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+
+	_, err := client.RestoreTableFromBackup(context.Background(), &dynamodb.RestoreTableFromBackupInput{
+		BackupArn:       aws.String("arn:aws:dynamodb:us-east-1:000000000000:table/x/backup/nope"),
+		TargetTableName: aws.String("t"),
+	})
+
+	var bnf *ddbtypes.BackupNotFoundException
+	require.ErrorAs(t, err, &bnf)
+}
+
+// TestDDBPITRRestore: enabling continuous backups surfaces the restorable
+// window, RestoreTableToPointInTime clones the current data into a new table,
+// and restoring without PITR enabled is a typed PointInTimeRecoveryUnavailable
+// error.
+func TestDDBPITRRestore(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "ledger", "id", "")
+	suiteDDBPut(t, client, "ledger", map[string]ddbtypes.AttributeValue{"id": sAttr("a"), "v": sAttr("1")})
+
+	// PITR off: RestoreTableToPointInTime is rejected.
+	_, err := client.RestoreTableToPointInTime(ctx, &dynamodb.RestoreTableToPointInTimeInput{
+		SourceTableName:         aws.String("ledger"),
+		TargetTableName:         aws.String("ledger-pit"),
+		UseLatestRestorableTime: aws.Bool(true),
+	})
+	var unavailable *ddbtypes.PointInTimeRecoveryUnavailableException
+	require.ErrorAs(t, err, &unavailable, "restore without PITR should be PointInTimeRecoveryUnavailableException")
+
+	_, err = client.UpdateContinuousBackups(ctx, &dynamodb.UpdateContinuousBackupsInput{
+		TableName: aws.String("ledger"),
+		PointInTimeRecoverySpecification: &ddbtypes.PointInTimeRecoverySpecification{
+			PointInTimeRecoveryEnabled: aws.Bool(true),
+		},
+	})
+	require.NoError(t, err)
+
+	cont, err := client.DescribeContinuousBackups(ctx, &dynamodb.DescribeContinuousBackupsInput{
+		TableName: aws.String("ledger"),
+	})
+	require.NoError(t, err)
+	pitr := cont.ContinuousBackupsDescription.PointInTimeRecoveryDescription
+	assert.Equal(t, ddbtypes.PointInTimeRecoveryStatusEnabled, pitr.PointInTimeRecoveryStatus)
+	require.NotNil(t, pitr.EarliestRestorableDateTime)
+	require.NotNil(t, pitr.LatestRestorableDateTime)
+
+	_, err = client.RestoreTableToPointInTime(ctx, &dynamodb.RestoreTableToPointInTimeInput{
+		SourceTableName:         aws.String("ledger"),
+		TargetTableName:         aws.String("ledger-pit"),
+		UseLatestRestorableTime: aws.Bool(true),
+	})
+	require.NoError(t, err)
+
+	got := suiteDDBGet(t, client, "ledger-pit", map[string]ddbtypes.AttributeValue{"id": sAttr("a")})
+	require.NotNil(t, got.Item)
+	assert.Equal(t, "1", attrS(t, got.Item, "v"))
+
+	// Restoring onto an existing table name is rejected.
+	_, err = client.RestoreTableToPointInTime(ctx, &dynamodb.RestoreTableToPointInTimeInput{
+		SourceTableName:         aws.String("ledger"),
+		TargetTableName:         aws.String("ledger-pit"),
+		UseLatestRestorableTime: aws.Bool(true),
+	})
+	var exists *ddbtypes.TableAlreadyExistsException
+	require.ErrorAs(t, err, &exists)
+}

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -188,7 +188,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
 
 	if h.routeTables(w, r, op) || h.routeItems(w, r, op) || h.routeBatch(w, r, op) ||
-		h.routeTags(w, r, op) || h.routeTTL(w, r, op) {
+		h.routeTags(w, r, op) || h.routeTTL(w, r, op) || h.routeBackups(w, r, op) {
 		return
 	}
 
@@ -664,17 +664,12 @@ func (h *Handler) describeContinuousBackups(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	pitr := statusDisabled
-	if h.pitrEnabled(r.Context(), req.TableName) {
-		pitr = statusEnabled
-	}
+	enabled := h.pitrEnabled(r.Context(), req.TableName)
 
 	wire.WriteJSON(w, map[string]any{
 		"ContinuousBackupsDescription": map[string]any{
-			"ContinuousBackupsStatus": statusEnabled,
-			"PointInTimeRecoveryDescription": map[string]any{
-				"PointInTimeRecoveryStatus": pitr,
-			},
+			"ContinuousBackupsStatus":        statusEnabled,
+			"PointInTimeRecoveryDescription": h.pitrRecoveryDescription(r.Context(), req.TableName, enabled),
 		},
 	})
 }

--- a/server/aws/dynamodb/update_table.go
+++ b/server/aws/dynamodb/update_table.go
@@ -222,17 +222,10 @@ func (h *Handler) updateContinuousBackups(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	pitr := statusDisabled
-	if enabled {
-		pitr = statusEnabled
-	}
-
 	wire.WriteJSON(w, map[string]any{
 		"ContinuousBackupsDescription": map[string]any{
-			"ContinuousBackupsStatus": statusEnabled,
-			"PointInTimeRecoveryDescription": map[string]any{
-				"PointInTimeRecoveryStatus": pitr,
-			},
+			"ContinuousBackupsStatus":        statusEnabled,
+			"PointInTimeRecoveryDescription": h.pitrRecoveryDescription(r.Context(), req.TableName, enabled),
 		},
 	})
 }

--- a/services/database/driver/backup.go
+++ b/services/database/driver/backup.go
@@ -1,0 +1,54 @@
+package driver
+
+import "context"
+
+// Backup status/type constants a DynamoDB on-demand backup carries. A backup is
+// synchronous in the emulator, so it lands AVAILABLE immediately, and every
+// backup this surface creates is a user-initiated (USER) backup.
+const (
+	BackupStatusAvailable = "AVAILABLE"
+	BackupTypeUser        = "USER"
+)
+
+// BackupInfo describes a single on-demand table backup. SourceTable is the
+// schema snapshot of the table at backup time (name, keys, attributes, billing
+// mode, throughput, id and ARN), which a DescribeBackup/ListBackups response
+// renders as SourceTableDetails and a RestoreTableFromBackup replays to build
+// the new table. The item data itself is held by the provider, keyed by
+// BackupArn, and never leaves it.
+type BackupInfo struct {
+	BackupArn   string
+	BackupName  string
+	Status      string  // BackupStatusAvailable
+	Type        string  // BackupTypeUser
+	CreatedUnix float64 // backup creation time (Unix seconds)
+	SizeBytes   int64   // approximate on-the-wire size of the backed-up items
+	ItemCount   int64   // number of items captured
+	SourceTable TableConfig
+}
+
+// Backuper is an OPTIONAL capability, discovered by type assertion (like the
+// TableAttributes capability): a provider whose tables support DynamoDB-style
+// on-demand backups and point-in-time recovery restore implements it. Only the
+// AWS DynamoDB mock does; Cosmos DB / Firestore don't and contribute nothing,
+// so the capability stays off the cross-cloud Database interface.
+type Backuper interface {
+	// CreateBackup snapshots the table's schema and items under a new BackupArn.
+	CreateBackup(ctx context.Context, table, backupName string) (BackupInfo, error)
+	// DescribeBackup returns the backup identified by backupArn.
+	DescribeBackup(ctx context.Context, backupArn string) (BackupInfo, error)
+	// ListBackups returns every backup, or only those of tableName when it is
+	// non-empty, ordered by BackupArn.
+	ListBackups(ctx context.Context, tableName string) ([]BackupInfo, error)
+	// DeleteBackup removes the backup identified by backupArn, returning its
+	// last description.
+	DeleteBackup(ctx context.Context, backupArn string) (BackupInfo, error)
+	// RestoreTableFromBackup creates targetTable from the backup's schema and
+	// item snapshot.
+	RestoreTableFromBackup(ctx context.Context, backupArn, targetTable string) error
+	// RestoreTableToPointInTime creates targetTable from sourceTable. The
+	// emulator retains no per-second history, so it restores the source table's
+	// CURRENT item set (the latest restorable point); useLatest is accepted for
+	// wire fidelity but does not change the restored data.
+	RestoreTableToPointInTime(ctx context.Context, sourceTable, targetTable string, useLatest bool) error
+}


### PR DESCRIPTION
## Summary

Adds the DynamoDB on-demand backup + point-in-time-recovery restore surface, the biggest remaining DR gap in the DynamoDB emulator.

New wire operations:
- `CreateBackup`, `DescribeBackup`, `ListBackups`, `DeleteBackup`
- `RestoreTableFromBackup` (new table from a BackupArn — schema + items at backup time)
- `RestoreTableToPointInTime` (new table from a source table)
- `DescribeContinuousBackups` / `UpdateContinuousBackups` now surface the restorable window (`EarliestRestorableDateTime`/`LatestRestorableDateTime`) when PITR is enabled

## Design
- Backups snapshot a table's schema and a **deep copy** of its items under a `BackupArn`, held in the provider and keyed by ARN. Restores materialize an **independent** new table (own ARN/id/creation time), immune to later source mutations.
- Exposed through a new **optional, type-asserted** `driver.Backuper` capability (mirroring the existing GSI/PITR capabilities), so Cosmos DB / Firestore — which share `services/database/driver` — are unaffected and the base `Database` interface is not bloated.
- Backups are captured by `persist/` snapshot/restore.
- Errors map to the real DynamoDB exceptions: `BackupNotFoundException`, `TableNotFoundException`, `TableAlreadyExistsException`, `PointInTimeRecoveryUnavailableException`.

## PITR limitation
The emulator retains no per-second history, so `RestoreTableToPointInTime` restores the source table's **current** item set (the latest restorable point). It still requires PITR enabled on the source, matching real DynamoDB.

## Tests
Real `aws-sdk-go-v2` journeys (httptest) covering the full backup lifecycle, restore independence, PITR enable→window→restore, and every typed-error path, plus provider-level capability tests. Coverage docs regenerated.