### PR TITLE
feat(cosmos): SQL database/container/throughput ARM control plane

### DIFF
--- a/docs/sdk-server.md
+++ b/docs/sdk-server.md
@@ -194,6 +194,7 @@ All handlers speak ARM JSON over HTTPS unless noted.
 | **Disks / Snapshots / Images / SSH Public Keys** | `Microsoft.Compute/{disks,snapshots,images,sshPublicKeys}` — full CRUD |
 | **Blob Storage** *(data plane)* | Containers + Blobs: Create/Delete/List, PutBlob, GetBlob, DeleteBlob, CopyBlob |
 | **Cosmos DB** *(data plane)* | Databases, Containers, Documents — full CRUD with `x-ms-documentdb-*` headers |
+| **Cosmos DB (SQL ARM control plane)** | `Microsoft.DocumentDB/databaseAccounts/{acct}/sqlDatabases[/containers]` — SQL databases (CreateUpdate/Get/List/Delete, cascading container delete), containers (CreateUpdate/Get/List/Delete with partitionKey, defaultTtl, uniqueKeyPolicy, indexingPolicy), and `throughputSettings/default` at database and container level (Get/Update manual RU/s or autoscale maxThroughput + migrateToAutoscale/migrateToManualThroughput). Real `armcosmos` `SQLResources` clients round-trip end-to-end, including the LRO pollers, so Terraform/Bicep/`az cosmosdb sql` can manage the data model. Shares state with the Cosmos data plane above — a control-plane database/container/throughput is visible to data-plane clients and vice versa. |
 | **Virtual Network** | `Microsoft.Network/{virtualNetworks,networkSecurityGroups,publicIPAddresses,networkInterfaces}` — CRUD + nested subnets; NICs bind a subnet and get a private IP |
 | **Azure Monitor** | `microsoft.insights/metricAlerts` and metric data ingest/read |
 | **Functions** | `Microsoft.Web/sites` (Function Apps): CreateOrUpdate, Get, List, Delete + non-ARM `/api/{name}` invoke |

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -399,6 +399,13 @@ func New(d Drivers) http.Handler {
 	if d.CosmosDB != nil {
 		cosmosDataPlane := cosmosdb.New(d.CosmosDB)
 		srv.Register(cosmosDataPlane)
+		// Cosmos SQL-API ARM control plane (sqlDatabases / containers /
+		// throughputSettings). Shares cosmosDataPlane's state so a control-plane
+		// database/container/throughput is visible on the data plane and vice
+		// versa. Registered BEFORE cosmosaccount so it wins the first-match over
+		// the shared databaseAccounts path for the /sqlDatabases sub-tree; the
+		// account handler still serves the account-level path and its actions.
+		srv.Register(cosmosdb.NewARM(cosmosDataPlane))
 		// Cosmos-account ARM control plane (Microsoft.DocumentDB/databaseAccounts).
 		// Claims only the /providers/Microsoft.DocumentDB/databaseAccounts/
 		// management path — disjoint from the /dbs data plane above and from

--- a/server/azure/cosmosdb/handler.go
+++ b/server/azure/cosmosdb/handler.go
@@ -155,6 +155,68 @@ func (h *Handler) databaseExists(account, db string) bool {
 	return ok
 }
 
+// registerDatabase records that database (account, db) exists, returning false
+// when it already did. The data-plane create maps that to a 409; the ARM
+// control plane treats create-or-update as idempotent and ignores it. Both
+// planes share this one databases set, so a database created through either is
+// visible to the other.
+func (h *Handler) registerDatabase(account, db string) bool {
+	key := dbNS(account, db)
+
+	h.dbMu.Lock()
+	defer h.dbMu.Unlock()
+
+	if _, exists := h.databases[key]; exists {
+		return false
+	}
+
+	h.databases[key] = struct{}{}
+
+	return true
+}
+
+// cascadeDeleteDatabase removes database (account, db) and every container
+// table, offer and TTL/attrs entry beneath it, mirroring real Cosmos's
+// database-delete cascade. Because the driver namespace is flat and keyed by
+// qualify(account, db, coll), the database's containers are exactly the tables
+// whose name starts with the account-qualified "{ns}/" prefix. Returns NotFound
+// when the database doesn't exist. Shared by the data-plane DELETE /dbs/{db} and
+// the ARM BeginDeleteSQLDatabase so both tear a database down identically.
+func (h *Handler) cascadeDeleteDatabase(ctx context.Context, account, db string) error {
+	if !h.databaseExists(account, db) {
+		return cerrors.New(cerrors.NotFound, "database not found")
+	}
+
+	tables, err := h.db.ListTables(ctx)
+	if err != nil {
+		return err
+	}
+
+	ns := dbNS(account, db)
+	prefix := ns + "/"
+
+	for _, t := range tables {
+		if !strings.HasPrefix(t, prefix) {
+			continue
+		}
+
+		if derr := h.db.DeleteTable(ctx, t); derr != nil {
+			return derr
+		}
+
+		h.deleteOffer(t)
+		h.attrs.delete(t)
+	}
+
+	h.deleteOffer(ns) // the database's own shared-throughput offer, if any
+
+	h.dbMu.Lock()
+	delete(h.databases, ns)
+	h.dbMu.Unlock()
+
+	return nil
+}
+
 // splitAccount separates an optional leading /{account} segment from the Cosmos
 // resource path. The real azcosmos SDK derives the account from the
 // {account}.documents.azure.com host; the emulator collapses every account onto
@@ -374,17 +436,12 @@ func (h *Handler) createDatabase(w http.ResponseWriter, r *http.Request, account
 
 	key := dbNS(account, body.ID)
 
-	h.dbMu.Lock()
-	if _, exists := h.databases[key]; exists {
-		h.dbMu.Unlock()
+	if !h.registerDatabase(account, body.ID) {
 		writeError(w, http.StatusConflict, "Conflict",
 			"Database with specified id already exists.")
 
 		return
 	}
-
-	h.databases[key] = struct{}{}
-	h.dbMu.Unlock()
 
 	// A database created with ThroughputProperties (shared, database-level
 	// provisioned throughput) gets its own offer, keyed by the same _rid
@@ -454,43 +511,13 @@ func (h *Handler) databaseResource(w http.ResponseWriter, r *http.Request, accou
 	}
 }
 
-// deleteDatabase removes a database and every container inside it. Because the
-// driver namespace is flat and keyed by qualify(account, db, coll), the
-// database's containers are exactly the tables whose name starts with the
-// account-qualified "{ns}/" prefix.
+// deleteDatabase removes a database and every container inside it, via the
+// shared cascadeDeleteDatabase helper (also used by the ARM control plane).
 func (h *Handler) deleteDatabase(w http.ResponseWriter, r *http.Request, account, db string) {
-	if !h.databaseExists(account, db) {
-		writeError(w, http.StatusNotFound, "NotFound", "database not found")
-		return
-	}
-
-	tables, err := h.db.ListTables(r.Context())
-	if err != nil {
+	if err := h.cascadeDeleteDatabase(r.Context(), account, db); err != nil {
 		writeErr(w, err)
 		return
 	}
-
-	ns := dbNS(account, db)
-	prefix := ns + "/"
-
-	for _, t := range tables {
-		if !strings.HasPrefix(t, prefix) {
-			continue
-		}
-
-		if derr := h.db.DeleteTable(r.Context(), t); derr != nil {
-			writeErr(w, derr)
-			return
-		}
-
-		h.deleteOffer(t)
-		h.attrs.delete(t)
-	}
-
-	h.deleteOffer(ns) // the database's own shared-throughput offer, if any
-	h.dbMu.Lock()
-	delete(h.databases, ns)
-	h.dbMu.Unlock()
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/server/azure/cosmosdb/offers.go
+++ b/server/azure/cosmosdb/offers.go
@@ -43,6 +43,27 @@ func (h *Handler) deleteOffer(coll string) {
 	h.offerMu.Unlock()
 }
 
+// setOffer stores the provisioned throughput for the resource named by key (a
+// container's qualified table name, or a database's dbNS), under the same
+// containerRID-derived key the data plane and the SDK's /offers lookup use. This
+// is how the ARM control plane's throughput write becomes visible to the data
+// plane and vice versa — both planes share the one offers map.
+func (h *Handler) setOffer(key string, st offerState) {
+	h.offerMu.Lock()
+	h.offers[containerRID(key)] = st
+	h.offerMu.Unlock()
+}
+
+// getOffer returns the provisioned throughput for the resource named by key, or
+// ok=false when none is provisioned (a shared/serverless resource).
+func (h *Handler) getOffer(key string) (offerState, bool) {
+	h.offerMu.RLock()
+	st, ok := h.offers[containerRID(key)]
+	h.offerMu.RUnlock()
+
+	return st, ok
+}
+
 // parseOfferHeaders reads the manual (x-ms-offer-throughput) or autoscale
 // (x-ms-cosmos-offer-autopilot-settings) throughput headers the SDK sets on a
 // container create.

--- a/server/azure/cosmosdb/sqlarm.go
+++ b/server/azure/cosmosdb/sqlarm.go
@@ -1,0 +1,705 @@
+package cosmosdb
+
+// ARM SQL-API control plane (Microsoft.DocumentDB/databaseAccounts/sqlDatabases
+// and .../containers, plus their throughputSettings). Real armcosmos
+// SQLResourcesClient clients configured with a custom endpoint drive this the
+// same way they drive management.azure.com, so Bicep / Terraform /
+// `az cosmosdb sql database create` can manage the Cosmos data model that was
+// previously reachable only through the documents.azure.com data plane.
+//
+// ARMHandler shares the data-plane Handler's state: databases live in the same
+// databases set, containers are the same driver tables (keyed by qualify), and
+// throughput lives in the same offers map. A database or container created here
+// is therefore immediately visible to the data plane and vice versa — there are
+// not two disjoint models.
+//
+// Create/update/delete/migrate are long-running operations in real Azure; the
+// emulator completes them synchronously (200 with the resource body, or 204 for
+// delete) so the SDK's Begin* pollers terminate on the first response, matching
+// how the account control plane already answers its LROs.
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+const (
+	armProvider     = "Microsoft.DocumentDB"
+	armAccountType  = "databaseAccounts"
+	sqlDatabasesSeg = "sqlDatabases"
+
+	typeSQLDatabase           = "Microsoft.DocumentDB/databaseAccounts/sqlDatabases"
+	typeSQLContainer          = "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers"
+	typeSQLDatabaseThroughput = "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/throughputSettings"
+	typeSQLContainerThrough   = "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings"
+
+	throughputName = "default"
+
+	// The two throughput-migration action verbs, lowercased for matching.
+	actionMigrateToAutoscale = "migratetoautoscale"
+	actionMigrateToManual    = "migratetomanualthroughput"
+
+	// Segment counts under ".../throughputSettings": [throughputSettings,
+	// default] is the plain resource; a third segment is the migrate action.
+	throughputPlainDepth   = 2
+	throughputMigrateDepth = 3
+
+	// Provisioned-throughput floors real Cosmos enforces: 400 RU/s manual,
+	// 1000 RU/s autoscale max. Used when migrating between the two modes.
+	minManualThroughput    = 400
+	minAutoscaleThroughput = 1000
+)
+
+// ARMHandler serves the Microsoft.DocumentDB SQL sub-resource control plane
+// (sqlDatabases, containers, throughputSettings) against the shared data-plane
+// Handler.
+type ARMHandler struct {
+	h *Handler
+}
+
+// NewARM returns an ARM SQL control-plane handler backed by the same data-plane
+// Handler, so control-plane and data-plane state stay unified.
+func NewARM(h *Handler) *ARMHandler {
+	return &ARMHandler{h: h}
+}
+
+// Matches claims only the sqlDatabases sub-tree of a database account
+// (.../databaseAccounts/{acct}/sqlDatabases/...). It never claims the
+// account-level path (create/get/delete/listKeys), which the cosmosaccount
+// handler serves, nor the /dbs data plane. Registered before cosmosaccount so it
+// wins the first-match over the shared databaseAccounts path.
+func (*ARMHandler) Matches(r *http.Request) bool {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	return strings.EqualFold(rp.Provider, armProvider) &&
+		strings.EqualFold(rp.ResourceType, armAccountType) &&
+		rp.ResourceName != "" &&
+		strings.EqualFold(rp.SubResource, sqlDatabasesSeg)
+}
+
+// sqlKind enumerates the addressable resource shapes under the sqlDatabases tree.
+type sqlKind int
+
+const (
+	kindDBList sqlKind = iota
+	kindDB
+	kindDBThroughput
+	kindDBMigrate
+	kindContainerList
+	kindContainer
+	kindContainerThroughput
+	kindContainerMigrate
+)
+
+// sqlTarget is a parsed sqlDatabases-subtree request.
+type sqlTarget struct {
+	kind      sqlKind
+	db        string
+	container string
+	migrate   string // "migratetoautoscale" | "migratetomanualthroughput"
+}
+
+// ServeHTTP parses the ARM path, verifies the parent account exists, then
+// dispatches to the addressed resource.
+func (a *ARMHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	tail := sqlTail(r.URL.Path, rp.ResourceName)
+
+	target, ok := parseSQLTarget(tail)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unsupported Cosmos SQL resource path")
+		return
+	}
+
+	// Every sqlDatabases operation is scoped to a database account; a missing
+	// account is ARM's ParentResourceNotFound.
+	if !a.h.isAccount(rp.ResourceName) {
+		azurearm.WriteError(w, http.StatusNotFound, "ParentResourceNotFound",
+			"database account "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	a.dispatch(w, r, &rp, &target)
+}
+
+// dispatch routes a parsed target to its handler.
+func (a *ARMHandler) dispatch(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, t *sqlTarget) {
+	switch t.kind {
+	case kindDBList:
+		a.listDatabases(w, r, rp)
+	case kindDB:
+		a.databaseResource(w, r, rp, t.db)
+	case kindContainerList:
+		a.listContainers(w, r, rp, t.db)
+	case kindContainer:
+		a.containerResource(w, r, rp, t.db, t.container)
+	case kindDBThroughput, kindContainerThroughput:
+		a.throughputResource(w, r, rp, t)
+	case kindDBMigrate, kindContainerMigrate:
+		a.migrateThroughput(w, r, rp, t)
+	default:
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unsupported Cosmos SQL resource path")
+	}
+}
+
+// sqlTail returns the path segments after .../databaseAccounts/{account}/,
+// starting at "sqlDatabases". ParsePath stops at the sqlDatabases segment, so
+// the deeper container/throughput segments are recovered from the raw path here.
+func sqlTail(urlPath, account string) []string {
+	parts := strings.Split(strings.Trim(urlPath, "/"), "/")
+
+	for i := 0; i+1 < len(parts); i++ {
+		if strings.EqualFold(parts[i], armAccountType) && parts[i+1] == account {
+			return parts[i+2:]
+		}
+	}
+
+	return nil
+}
+
+// parseSQLTarget classifies the sqlDatabases-subtree segments. seg[0] is always
+// "sqlDatabases" (guaranteed by Matches).
+func parseSQLTarget(seg []string) (sqlTarget, bool) {
+	if len(seg) == 0 || !strings.EqualFold(seg[0], sqlDatabasesSeg) {
+		return sqlTarget{}, false
+	}
+
+	if len(seg) == 1 {
+		return sqlTarget{kind: kindDBList}, true
+	}
+
+	db := seg[1]
+	rest := seg[2:]
+
+	if len(rest) == 0 {
+		return sqlTarget{kind: kindDB, db: db}, true
+	}
+
+	switch strings.ToLower(rest[0]) {
+	case "throughputsettings":
+		return parseThroughputTail(db, "", rest, kindDBThroughput, kindDBMigrate)
+	case "containers":
+		return parseContainerTail(db, rest[1:])
+	default:
+		return sqlTarget{}, false
+	}
+}
+
+// parseContainerTail classifies the segments after ".../containers".
+func parseContainerTail(db string, seg []string) (sqlTarget, bool) {
+	if len(seg) == 0 {
+		return sqlTarget{kind: kindContainerList, db: db}, true
+	}
+
+	container := seg[0]
+	rest := seg[1:]
+
+	if len(rest) == 0 {
+		return sqlTarget{kind: kindContainer, db: db, container: container}, true
+	}
+
+	if strings.EqualFold(rest[0], "throughputSettings") {
+		return parseThroughputTail(db, container, rest, kindContainerThroughput, kindContainerMigrate)
+	}
+
+	return sqlTarget{}, false
+}
+
+// parseThroughputTail classifies ".../throughputSettings/default[/migrate...]".
+func parseThroughputTail(db, container string, seg []string, plain, migrate sqlKind) (sqlTarget, bool) {
+	// seg[0] == "throughputSettings"; the sole named child is "default".
+	if len(seg) < 2 || !strings.EqualFold(seg[1], throughputName) {
+		return sqlTarget{}, false
+	}
+
+	base := sqlTarget{db: db, container: container}
+
+	switch len(seg) {
+	case throughputPlainDepth:
+		base.kind = plain
+		return base, true
+	case throughputMigrateDepth:
+		action := strings.ToLower(seg[2])
+		if action != actionMigrateToAutoscale && action != actionMigrateToManual {
+			return sqlTarget{}, false
+		}
+
+		base.kind = migrate
+		base.migrate = action
+
+		return base, true
+	default:
+		return sqlTarget{}, false
+	}
+}
+
+// Databases ------------------------------------------------------------------
+
+func (a *ARMHandler) databaseResource(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db string) {
+	switch r.Method {
+	case http.MethodPut:
+		a.createOrUpdateDatabase(w, r, rp, db)
+	case http.MethodGet:
+		if !a.h.databaseExists(rp.ResourceName, db) {
+			azurearm.WriteError(w, http.StatusNotFound, "NotFound", "sql database "+db+" not found")
+			return
+		}
+
+		azurearm.WriteJSON(w, http.StatusOK, a.renderDatabase(rp, db))
+	case http.MethodDelete:
+		// Delete is idempotent: a cascade over a missing database is a no-op that
+		// still answers 204 so the SDK's BeginDelete poller terminates.
+		_ = a.h.cascadeDeleteDatabase(r.Context(), rp.ResourceName, db)
+
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+func (a *ARMHandler) createOrUpdateDatabase(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db string) {
+	var body armSQLDatabaseCreateParams
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	if body.Properties == nil || body.Properties.Resource == nil || body.Properties.Resource.ID == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "properties.resource.id is required")
+		return
+	}
+
+	// registerDatabase is idempotent for the ARM create-or-update contract: a
+	// re-PUT of an existing database is not an error, it re-applies throughput.
+	a.h.registerDatabase(rp.ResourceName, db)
+
+	// Shared (database-level) throughput, keyed by the database's dbNS — exactly
+	// the key the data plane's /offers lookup derives, so it round-trips there.
+	if st, ok := offerFromOptions(body.Properties.Options); ok {
+		a.h.setOffer(dbNS(rp.ResourceName, db), st)
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, a.renderDatabase(rp, db))
+}
+
+func (a *ARMHandler) listDatabases(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodGet {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	names := a.databasesInAccount(rp.ResourceName)
+
+	out := armSQLDatabaseList{Value: make([]armSQLDatabaseGetResults, 0, len(names))}
+	for _, name := range names {
+		out.Value = append(out.Value, a.renderDatabase(rp, name))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+// databasesInAccount returns the sorted database names owned by account.
+func (a *ARMHandler) databasesInAccount(account string) []string {
+	a.h.dbMu.RLock()
+	defer a.h.dbMu.RUnlock()
+
+	names := make([]string, 0)
+
+	for key := range a.h.databases {
+		if id, ok := accountDBName(key, account); ok {
+			names = append(names, id)
+		}
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+func (a *ARMHandler) renderDatabase(rp *azurearm.ResourcePath, db string) armSQLDatabaseGetResults {
+	id := dbResourceID(rp, db)
+
+	return armSQLDatabaseGetResults{
+		ID:   id,
+		Name: db,
+		Type: typeSQLDatabase,
+		Properties: &armSQLDatabaseGetProps{
+			Resource: &armSQLDatabaseGetResource{
+				ID:    db,
+				RID:   "rid-" + dbNS(rp.ResourceName, db),
+				TS:    a.h.clock.Now().Unix(),
+				ETag:  azurearm.ETag(id),
+				Colls: "colls/",
+				Users: "users/",
+			},
+		},
+	}
+}
+
+// Containers -----------------------------------------------------------------
+
+func (a *ARMHandler) containerResource(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db, container string,
+) {
+	switch r.Method {
+	case http.MethodPut:
+		a.createOrUpdateContainer(w, r, rp, db, container)
+	case http.MethodGet:
+		res, err := a.renderContainer(r.Context(), rp, db, container)
+		if err != nil {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+
+		azurearm.WriteJSON(w, http.StatusOK, res)
+	case http.MethodDelete:
+		table := qualify(rp.ResourceName, db, container)
+		// Idempotent: absence is a no-op that still answers 204.
+		_ = a.h.db.DeleteTable(r.Context(), table)
+		a.h.deleteOffer(table)
+		a.h.attrs.delete(table)
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+func (a *ARMHandler) createOrUpdateContainer(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db, container string,
+) {
+	if !a.h.databaseExists(rp.ResourceName, db) {
+		azurearm.WriteError(w, http.StatusNotFound, "ParentResourceNotFound", "sql database "+db+" not found")
+		return
+	}
+
+	var body armSQLContainerCreateParams
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	res := body.resourceOrNil()
+	if res == nil || res.ID == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "properties.resource.id is required")
+		return
+	}
+
+	table := qualify(rp.ResourceName, db, container)
+	pkAttr := partitionKeyAttribute(res.PartitionKey)
+
+	cfg := dbdriver.TableConfig{Name: table, PartitionKey: pkAttr}
+	if pkAttr != idAttr {
+		cfg.SortKey = idAttr
+	}
+
+	// Create-or-update: an existing container (AlreadyExists) is not an error —
+	// re-apply its attrs and throughput. The partition key is immutable, so the
+	// existing table config is kept.
+	if err := a.h.db.CreateTable(r.Context(), cfg); err != nil && !cerrors.IsAlreadyExists(err) {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	a.h.attrs.set(table, res.DefaultTTL, res.UniqueKeyPolicy, res.IndexingPolicy)
+
+	if st, ok := offerFromOptions(body.Properties.Options); ok {
+		a.h.setOffer(table, st)
+	}
+
+	out, err := a.renderContainer(r.Context(), rp, db, container)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+func (a *ARMHandler) listContainers(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db string) {
+	if r.Method != http.MethodGet {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	if !a.h.databaseExists(rp.ResourceName, db) {
+		azurearm.WriteError(w, http.StatusNotFound, "ParentResourceNotFound", "sql database "+db+" not found")
+		return
+	}
+
+	tables, err := a.h.db.ListTables(r.Context())
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	prefix := dbNS(rp.ResourceName, db) + "/"
+
+	out := armSQLContainerList{Value: make([]armSQLContainerGetResults, 0)}
+
+	for _, t := range tables {
+		if !strings.HasPrefix(t, prefix) {
+			continue
+		}
+
+		coll := strings.TrimPrefix(t, prefix)
+		if res, cerr := a.renderContainer(r.Context(), rp, db, coll); cerr == nil {
+			out.Value = append(out.Value, res)
+		}
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+func (a *ARMHandler) renderContainer(
+	ctx context.Context, rp *azurearm.ResourcePath, db, container string,
+) (armSQLContainerGetResults, error) {
+	table := qualify(rp.ResourceName, db, container)
+
+	cfg, err := a.h.db.DescribeTable(ctx, table)
+	if err != nil {
+		return armSQLContainerGetResults{}, err
+	}
+
+	pk := defaultPartitionKey()
+	if cfg.PartitionKey != "" {
+		pk = &partitionKeyDef{Paths: []string{"/" + cfg.PartitionKey}, Kind: "Hash"}
+	}
+
+	attrs := a.h.attrs.get(table)
+	id := containerResourceID(rp, db, container)
+
+	return armSQLContainerGetResults{
+		ID:   id,
+		Name: container,
+		Type: typeSQLContainer,
+		Properties: &armSQLContainerGetProps{
+			Resource: &armSQLContainerGetResource{
+				ID:              container,
+				PartitionKey:    pk,
+				DefaultTTL:      attrs.defaultTTL,
+				UniqueKeyPolicy: uniqueKeyPolicyFromDef(attrs.uniqueKeys),
+				IndexingPolicy:  attrs.indexingPolicy,
+				RID:             containerRID(table),
+				TS:              a.h.clock.Now().Unix(),
+				ETag:            azurearm.ETag(id),
+			},
+		},
+	}, nil
+}
+
+// Throughput -----------------------------------------------------------------
+
+func (a *ARMHandler) throughputResource(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, t *sqlTarget) {
+	key, resType, exists := a.throughputTarget(rp, t)
+	if !exists {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "parent resource not found")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		st, ok := a.h.getOffer(key)
+		if !ok {
+			azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+				"resource does not have dedicated throughput (shared or serverless)")
+
+			return
+		}
+
+		azurearm.WriteJSON(w, http.StatusOK, renderThroughput(st, throughputID(rp, t), resType))
+	case http.MethodPut:
+		a.updateThroughput(w, r, rp, t, key, resType)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+func (a *ARMHandler) updateThroughput(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, t *sqlTarget, key, resType string,
+) {
+	var body armThroughputUpdateParams
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	var res *armThroughputResource
+	if body.Properties != nil {
+		res = body.Properties.Resource
+	}
+
+	if res == nil {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "properties.resource is required")
+		return
+	}
+
+	st, ok := offerFromThroughput(res.Throughput, res.AutoscaleSettings)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter",
+			"either throughput or autoscaleSettings.maxThroughput is required")
+
+		return
+	}
+
+	a.h.setOffer(key, st)
+	azurearm.WriteJSON(w, http.StatusOK, renderThroughput(st, throughputID(rp, t), resType))
+}
+
+func (a *ARMHandler) migrateThroughput(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, t *sqlTarget) {
+	if r.Method != http.MethodPost {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	key, resType, exists := a.throughputTarget(rp, t)
+	if !exists {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "parent resource not found")
+		return
+	}
+
+	st, ok := a.h.getOffer(key)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"resource does not have dedicated throughput to migrate")
+
+		return
+	}
+
+	migrated := migrateOffer(st, t.migrate == actionMigrateToAutoscale)
+	a.h.setOffer(key, migrated)
+
+	azurearm.WriteJSON(w, http.StatusOK, renderThroughput(migrated, throughputID(rp, t), resType))
+}
+
+// throughputTarget resolves a throughput request to its offer key and response
+// resource type, and reports whether the parent database/container exists.
+func (a *ARMHandler) throughputTarget(rp *azurearm.ResourcePath, t *sqlTarget) (key, resType string, exists bool) {
+	if t.container != "" {
+		table := qualify(rp.ResourceName, t.db, t.container)
+		if _, err := a.h.db.DescribeTable(context.Background(), table); err != nil {
+			return "", "", false
+		}
+
+		return table, typeSQLContainerThrough, true
+	}
+
+	if !a.h.databaseExists(rp.ResourceName, t.db) {
+		return "", "", false
+	}
+
+	return dbNS(rp.ResourceName, t.db), typeSQLDatabaseThroughput, true
+}
+
+// migrateOffer converts an offer between manual and autoscale, clamping to the
+// mode's floor. Migrating to the mode it already occupies is a no-op.
+func migrateOffer(st offerState, toAutoscale bool) offerState {
+	if toAutoscale {
+		if st.autoscale {
+			return st
+		}
+
+		maxRU := st.manualThroughput
+		if maxRU < minAutoscaleThroughput {
+			maxRU = minAutoscaleThroughput
+		}
+
+		return offerState{autoscale: true, autoscaleMax: maxRU}
+	}
+
+	if !st.autoscale {
+		return st
+	}
+
+	manual := st.autoscaleMax
+	if manual < minManualThroughput {
+		manual = minManualThroughput
+	}
+
+	return offerState{manualThroughput: manual}
+}
+
+// offerFromOptions reads throughput from a create's options block.
+func offerFromOptions(o *armCreateUpdateOptions) (offerState, bool) {
+	if o == nil {
+		return offerState{}, false
+	}
+
+	return offerFromThroughput(o.Throughput, o.AutoscaleSettings)
+}
+
+// offerFromThroughput builds an offerState from a manual value or an autoscale
+// ceiling. Autoscale wins when both are somehow present (real Cosmos rejects
+// that combination; preferring autoscale keeps a single, well-defined outcome).
+func offerFromThroughput(manual *int32, auto *armAutoscaleSettings) (offerState, bool) {
+	if auto != nil && auto.MaxThroughput != nil && *auto.MaxThroughput > 0 {
+		return offerState{autoscale: true, autoscaleMax: *auto.MaxThroughput}, true
+	}
+
+	if manual != nil && *manual > 0 {
+		return offerState{manualThroughput: *manual}, true
+	}
+
+	return offerState{}, false
+}
+
+// renderThroughput builds the ThroughputSettings response for an offer.
+func renderThroughput(st offerState, id, resType string) armThroughputGetResults {
+	res := &armThroughputGetResource{MinimumThroughput: "400"}
+
+	if st.autoscale {
+		res.AutoscaleSettings = &armAutoscaleSettingsResource{MaxThroughput: int32Ptr(st.autoscaleMax)}
+		res.MinimumThroughput = "1000"
+	} else {
+		res.Throughput = int32Ptr(st.manualThroughput)
+	}
+
+	return armThroughputGetResults{
+		ID:         id,
+		Name:       throughputName,
+		Type:       resType,
+		Properties: &armThroughputGetProps{Resource: res},
+	}
+}
+
+// Resource-ID + small helpers ------------------------------------------------
+
+func (b *armSQLContainerCreateParams) resourceOrNil() *armSQLContainerResource {
+	if b.Properties == nil {
+		return nil
+	}
+
+	return b.Properties.Resource
+}
+
+func dbResourceID(rp *azurearm.ResourcePath, db string) string {
+	return azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, armProvider, armAccountType, rp.ResourceName) +
+		"/sqlDatabases/" + db
+}
+
+func containerResourceID(rp *azurearm.ResourcePath, db, container string) string {
+	return dbResourceID(rp, db) + "/containers/" + container
+}
+
+// throughputID is the ARM ID of a throughputSettings/default child.
+func throughputID(rp *azurearm.ResourcePath, t *sqlTarget) string {
+	base := dbResourceID(rp, t.db)
+	if t.container != "" {
+		base += "/containers/" + t.container
+	}
+
+	return base + "/throughputSettings/" + throughputName
+}
+
+func int32Ptr(v int32) *int32 { return &v }

--- a/server/azure/cosmosdb/sqlarm_test.go
+++ b/server/azure/cosmosdb/sqlarm_test.go
@@ -1,0 +1,397 @@
+// Real-SDK round-trip tests for the Cosmos SQL-API ARM control plane: the live
+// armcosmos SQLResourcesClient drives sqlDatabases, containers and their
+// throughputSettings end-to-end, and the tests prove the control plane and the
+// azcosmos data plane share one model (a control-plane container is reachable by
+// a data-plane client, and vice versa).
+
+package cosmosdb_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+type armFakeCred struct{}
+
+func (armFakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+// sqlEnv bundles the two ARM clients and the live server so a test can also
+// point a data-plane azcosmos client at the same backend.
+type sqlEnv struct {
+	sql   *armcosmos.SQLResourcesClient
+	acct  *armcosmos.DatabaseAccountsClient
+	ts    *httptest.Server
+	baseU string
+}
+
+func newSQLEnv(t *testing.T) sqlEnv {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{CosmosDB: cloudP.CosmosDB})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	sqlClient, err := armcosmos.NewSQLResourcesClient("sub-1", armFakeCred{}, opts)
+	require.NoError(t, err)
+
+	acctClient, err := armcosmos.NewDatabaseAccountsClient("sub-1", armFakeCred{}, opts)
+	require.NoError(t, err)
+
+	return sqlEnv{sql: sqlClient, acct: acctClient, ts: ts, baseU: ts.URL}
+}
+
+func (e sqlEnv) createAccount(t *testing.T, rg, name, region string) {
+	t.Helper()
+
+	poller, err := e.acct.BeginCreateOrUpdate(context.Background(), rg, name, armcosmos.DatabaseAccountCreateUpdateParameters{
+		Location: to.Ptr(region),
+		Kind:     to.Ptr(armcosmos.DatabaseAccountKindGlobalDocumentDB),
+		Properties: &armcosmos.DatabaseAccountCreateUpdateProperties{
+			DatabaseAccountOfferType: to.Ptr("Standard"),
+			Locations: []*armcosmos.Location{
+				{LocationName: to.Ptr(region), FailoverPriority: to.Ptr[int32](0)},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(context.Background(), nil)
+	require.NoError(t, err)
+}
+
+func (e sqlEnv) putDatabase(t *testing.T, rg, acct, db string, opts *armcosmos.CreateUpdateOptions) armcosmos.SQLDatabaseGetResults {
+	t.Helper()
+
+	poller, err := e.sql.BeginCreateUpdateSQLDatabase(context.Background(), rg, acct, db,
+		armcosmos.SQLDatabaseCreateUpdateParameters{
+			Properties: &armcosmos.SQLDatabaseCreateUpdateProperties{
+				Resource: &armcosmos.SQLDatabaseResource{ID: to.Ptr(db)},
+				Options:  opts,
+			},
+		}, nil)
+	require.NoError(t, err)
+
+	res, err := poller.PollUntilDone(context.Background(), nil)
+	require.NoError(t, err)
+
+	return res.SQLDatabaseGetResults
+}
+
+func (e sqlEnv) putContainer(
+	t *testing.T, rg, acct, db string, res *armcosmos.SQLContainerResource, opts *armcosmos.CreateUpdateOptions,
+) armcosmos.SQLContainerGetResults {
+	t.Helper()
+
+	poller, err := e.sql.BeginCreateUpdateSQLContainer(context.Background(), rg, acct, db, *res.ID,
+		armcosmos.SQLContainerCreateUpdateParameters{
+			Properties: &armcosmos.SQLContainerCreateUpdateProperties{Resource: res, Options: opts},
+		}, nil)
+	require.NoError(t, err)
+
+	out, err := poller.PollUntilDone(context.Background(), nil)
+	require.NoError(t, err)
+
+	return out.SQLContainerGetResults
+}
+
+// TestSDKSQLControlPlaneLifecycle is the full real-user flow: create account ->
+// PUT database -> GET/list -> PUT container -> GET/list -> PUT manual throughput
+// -> GET -> migrate to autoscale -> GET -> DELETE database cascades its
+// container.
+func TestSDKSQLControlPlaneLifecycle(t *testing.T) {
+	ctx := context.Background()
+	env := newSQLEnv(t)
+	env.createAccount(t, "rg-1", "cosmos1", "eastus")
+
+	// PUT database.
+	created := env.putDatabase(t, "rg-1", "cosmos1", "appdb", nil)
+	require.NotNil(t, created.Name)
+	assert.Equal(t, "appdb", *created.Name)
+
+	// GET database.
+	got, err := env.sql.GetSQLDatabase(ctx, "rg-1", "cosmos1", "appdb", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "appdb", *got.Name)
+	require.NotNil(t, got.ID)
+	assert.Contains(t, *got.ID, "/databaseAccounts/cosmos1/sqlDatabases/appdb")
+
+	// List databases.
+	assert.Contains(t, listDatabaseNames(t, env, "rg-1", "cosmos1"), "appdb")
+
+	// PUT container with a custom partition key + default TTL.
+	cont := env.putContainer(t, "rg-1", "cosmos1", "appdb", &armcosmos.SQLContainerResource{
+		ID:           to.Ptr("users"),
+		PartitionKey: &armcosmos.ContainerPartitionKey{Paths: []*string{to.Ptr("/pk")}, Kind: to.Ptr(armcosmos.PartitionKindHash)},
+		DefaultTTL:   to.Ptr[int32](3600),
+	}, nil)
+	require.NotNil(t, cont.Name)
+	assert.Equal(t, "users", *cont.Name)
+	requireContainerPartitionKey(t, cont, "/pk")
+
+	// GET container.
+	gotC, err := env.sql.GetSQLContainer(ctx, "rg-1", "cosmos1", "appdb", "users", nil)
+	require.NoError(t, err)
+	requireContainerPartitionKey(t, gotC.SQLContainerGetResults, "/pk")
+	require.NotNil(t, gotC.Properties.Resource.DefaultTTL)
+	assert.Equal(t, int32(3600), *gotC.Properties.Resource.DefaultTTL)
+
+	// List containers.
+	assert.Contains(t, listContainerNames(t, env, "rg-1", "cosmos1", "appdb"), "users")
+
+	// PUT manual container throughput.
+	updateContainerThroughput(t, env, "rg-1", "cosmos1", "appdb", "users",
+		&armcosmos.ThroughputSettingsResource{Throughput: to.Ptr[int32](800)})
+
+	tp, err := env.sql.GetSQLContainerThroughput(ctx, "rg-1", "cosmos1", "appdb", "users", nil)
+	require.NoError(t, err)
+	require.NotNil(t, tp.Properties.Resource.Throughput)
+	assert.Equal(t, int32(800), *tp.Properties.Resource.Throughput)
+
+	// Migrate to autoscale.
+	mPoller, err := env.sql.BeginMigrateSQLContainerToAutoscale(ctx, "rg-1", "cosmos1", "appdb", "users", nil)
+	require.NoError(t, err)
+	_, err = mPoller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	tp2, err := env.sql.GetSQLContainerThroughput(ctx, "rg-1", "cosmos1", "appdb", "users", nil)
+	require.NoError(t, err)
+	require.NotNil(t, tp2.Properties.Resource.AutoscaleSettings)
+	require.NotNil(t, tp2.Properties.Resource.AutoscaleSettings.MaxThroughput)
+	assert.Equal(t, int32(1000), *tp2.Properties.Resource.AutoscaleSettings.MaxThroughput)
+
+	// DELETE database cascades the container.
+	dPoller, err := env.sql.BeginDeleteSQLDatabase(ctx, "rg-1", "cosmos1", "appdb", nil)
+	require.NoError(t, err)
+	_, err = dPoller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	_, err = env.sql.GetSQLContainer(ctx, "rg-1", "cosmos1", "appdb", "users", nil)
+	require.Error(t, err, "container must 404 after its database is deleted")
+
+	_, err = env.sql.GetSQLDatabase(ctx, "rg-1", "cosmos1", "appdb", nil)
+	require.Error(t, err, "database must 404 after delete")
+}
+
+// TestSDKSQLDatabaseSharedThroughput drives database-level shared throughput and
+// its migration to manual.
+func TestSDKSQLDatabaseSharedThroughput(t *testing.T) {
+	ctx := context.Background()
+	env := newSQLEnv(t)
+	env.createAccount(t, "rg-1", "cosmos-shared", "eastus")
+
+	env.putDatabase(t, "rg-1", "cosmos-shared", "shared", &armcosmos.CreateUpdateOptions{
+		AutoscaleSettings: &armcosmos.AutoscaleSettings{MaxThroughput: to.Ptr[int32](4000)},
+	})
+
+	tp, err := env.sql.GetSQLDatabaseThroughput(ctx, "rg-1", "cosmos-shared", "shared", nil)
+	require.NoError(t, err)
+	require.NotNil(t, tp.Properties.Resource.AutoscaleSettings)
+	require.NotNil(t, tp.Properties.Resource.AutoscaleSettings.MaxThroughput)
+	assert.Equal(t, int32(4000), *tp.Properties.Resource.AutoscaleSettings.MaxThroughput)
+
+	// Migrate database throughput to manual.
+	mPoller, err := env.sql.BeginMigrateSQLDatabaseToManualThroughput(ctx, "rg-1", "cosmos-shared", "shared", nil)
+	require.NoError(t, err)
+	_, err = mPoller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	tp2, err := env.sql.GetSQLDatabaseThroughput(ctx, "rg-1", "cosmos-shared", "shared", nil)
+	require.NoError(t, err)
+	require.NotNil(t, tp2.Properties.Resource.Throughput)
+	assert.Equal(t, int32(4000), *tp2.Properties.Resource.Throughput)
+}
+
+// TestSDKSQLContainerWithoutDatabase asserts a container cannot be created under
+// a database that does not exist (ARM ParentResourceNotFound).
+func TestSDKSQLContainerWithoutDatabase(t *testing.T) {
+	ctx := context.Background()
+	env := newSQLEnv(t)
+	env.createAccount(t, "rg-1", "cosmos2", "eastus")
+
+	poller, err := env.sql.BeginCreateUpdateSQLContainer(ctx, "rg-1", "cosmos2", "ghostdb", "c1",
+		armcosmos.SQLContainerCreateUpdateParameters{
+			Properties: &armcosmos.SQLContainerCreateUpdateProperties{
+				Resource: &armcosmos.SQLContainerResource{
+					ID:           to.Ptr("c1"),
+					PartitionKey: &armcosmos.ContainerPartitionKey{Paths: []*string{to.Ptr("/pk")}},
+				},
+			},
+		}, nil)
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	require.Error(t, err, "creating a container without its database must fail")
+}
+
+// TestSDKSQLMissingAccount asserts sqlDatabases operations under a non-existent
+// account are rejected.
+func TestSDKSQLMissingAccount(t *testing.T) {
+	ctx := context.Background()
+	env := newSQLEnv(t)
+
+	_, err := env.sql.GetSQLDatabase(ctx, "rg-1", "no-such-account", "db", nil)
+	require.Error(t, err)
+}
+
+// TestSDKSQLControlPlaneUnifiesDataPlane proves the two planes share one model:
+// a container created through the ARM control plane is reachable (and writable)
+// by a data-plane azcosmos client, and a database created on the data plane is
+// visible through an ARM GET.
+func TestSDKSQLControlPlaneUnifiesDataPlane(t *testing.T) {
+	ctx := context.Background()
+	env := newSQLEnv(t)
+	env.createAccount(t, "rg-1", "cosmos3", "eastus")
+
+	// Control plane: create database + container.
+	env.putDatabase(t, "rg-1", "cosmos3", "shared", nil)
+	env.putContainer(t, "rg-1", "cosmos3", "shared", &armcosmos.SQLContainerResource{
+		ID:           to.Ptr("events"),
+		PartitionKey: &armcosmos.ContainerPartitionKey{Paths: []*string{to.Ptr("/pk")}, Kind: to.Ptr(armcosmos.PartitionKindHash)},
+	}, nil)
+
+	// Data plane: the same container is reachable and writable.
+	dp := newDataPlaneClient(t, env, "cosmos3")
+
+	cont, err := dp.NewContainer("shared", "events")
+	require.NoError(t, err)
+
+	doc := map[string]any{"id": "e1", "pk": "team-a", "kind": "click"}
+	docBytes, _ := json.Marshal(doc)
+
+	_, err = cont.CreateItem(ctx, azcosmos.NewPartitionKeyString("team-a"), docBytes, nil)
+	require.NoError(t, err, "a control-plane container must accept data-plane writes")
+
+	// Reverse: a data-plane-created database is visible to the ARM control plane.
+	_, err = dp.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: "dpdb"}, nil)
+	require.NoError(t, err)
+
+	got, err := env.sql.GetSQLDatabase(ctx, "rg-1", "cosmos3", "dpdb", nil)
+	require.NoError(t, err, "a data-plane database must be visible via ARM GET")
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "dpdb", *got.Name)
+}
+
+// Helpers --------------------------------------------------------------------
+
+func newDataPlaneClient(t *testing.T, env sqlEnv, account string) *azcosmos.Client {
+	t.Helper()
+
+	cred, err := azcosmos.NewKeyCredential(fakeKey)
+	require.NoError(t, err)
+
+	opts := &azcosmos.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: env.ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	// The account's documentEndpoint carries the account as a path segment
+	// (baseURL/{account}/), which the data plane peels back off.
+	client, err := azcosmos.NewClientWithKey(env.baseU+"/"+account, cred, opts)
+	require.NoError(t, err)
+
+	return client
+}
+
+func listDatabaseNames(t *testing.T, env sqlEnv, rg, acct string) []string {
+	t.Helper()
+
+	names := []string{}
+	pager := env.sql.NewListSQLDatabasesPager(rg, acct, nil)
+
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		require.NoError(t, err)
+
+		for _, d := range page.Value {
+			if d.Name != nil {
+				names = append(names, *d.Name)
+			}
+		}
+	}
+
+	return names
+}
+
+func listContainerNames(t *testing.T, env sqlEnv, rg, acct, db string) []string {
+	t.Helper()
+
+	names := []string{}
+	pager := env.sql.NewListSQLContainersPager(rg, acct, db, nil)
+
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		require.NoError(t, err)
+
+		for _, c := range page.Value {
+			if c.Name != nil {
+				names = append(names, *c.Name)
+			}
+		}
+	}
+
+	return names
+}
+
+func updateContainerThroughput(
+	t *testing.T, env sqlEnv, rg, acct, db, container string, res *armcosmos.ThroughputSettingsResource,
+) {
+	t.Helper()
+
+	poller, err := env.sql.BeginUpdateSQLContainerThroughput(context.Background(), rg, acct, db, container,
+		armcosmos.ThroughputSettingsUpdateParameters{
+			Properties: &armcosmos.ThroughputSettingsUpdateProperties{Resource: res},
+		}, nil)
+	require.NoError(t, err)
+
+	_, err = poller.PollUntilDone(context.Background(), nil)
+	require.NoError(t, err)
+}
+
+func requireContainerPartitionKey(t *testing.T, c armcosmos.SQLContainerGetResults, wantPath string) {
+	t.Helper()
+
+	require.NotNil(t, c.Properties)
+	require.NotNil(t, c.Properties.Resource)
+	require.NotNil(t, c.Properties.Resource.PartitionKey)
+	require.Len(t, c.Properties.Resource.PartitionKey.Paths, 1)
+	require.NotNil(t, c.Properties.Resource.PartitionKey.Paths[0])
+	assert.Equal(t, wantPath, *c.Properties.Resource.PartitionKey.Paths[0])
+}

--- a/server/azure/cosmosdb/sqlarm_types.go
+++ b/server/azure/cosmosdb/sqlarm_types.go
@@ -1,0 +1,157 @@
+package cosmosdb
+
+// ARM (Microsoft.DocumentDB) SQL-API control-plane wire shapes, as driven by the
+// armcosmos SQLResourcesClient. These mirror the SDK's JSON field names
+// (camelCase) so a real client's Begin*/Get* round-trips against the handler.
+//
+// Databases, containers and their throughput share the very state the Cosmos
+// data plane uses (the handler's databases set, driver tables and offers map),
+// so a resource created through this control plane is immediately visible to the
+// data plane and vice versa.
+
+// armAutoscaleSettings is the request-side autoscale block: a single
+// maxThroughput ceiling. Present on a create's options or a throughput update.
+type armAutoscaleSettings struct {
+	MaxThroughput *int32 `json:"maxThroughput,omitempty"`
+}
+
+// armAutoscaleSettingsResource is the response-side autoscale block.
+type armAutoscaleSettingsResource struct {
+	MaxThroughput *int32 `json:"maxThroughput,omitempty"`
+}
+
+// armCreateUpdateOptions carries the throughput a database/container is created
+// with: either manual (Throughput) or autoscale (AutoscaleSettings), never both.
+type armCreateUpdateOptions struct {
+	Throughput        *int32                `json:"throughput,omitempty"`
+	AutoscaleSettings *armAutoscaleSettings `json:"autoscaleSettings,omitempty"`
+}
+
+// SQL database ---------------------------------------------------------------
+
+type armSQLDatabaseCreateParams struct {
+	Properties *armSQLDatabaseCreateProps `json:"properties"`
+	Location   string                     `json:"location,omitempty"`
+	Tags       map[string]string          `json:"tags,omitempty"`
+}
+
+type armSQLDatabaseCreateProps struct {
+	Resource *armSQLDatabaseResource `json:"resource"`
+	Options  *armCreateUpdateOptions `json:"options,omitempty"`
+}
+
+type armSQLDatabaseResource struct {
+	ID string `json:"id"`
+}
+
+type armSQLDatabaseGetResults struct {
+	ID         string                  `json:"id,omitempty"`
+	Name       string                  `json:"name,omitempty"`
+	Type       string                  `json:"type,omitempty"`
+	Location   string                  `json:"location,omitempty"`
+	Tags       map[string]string       `json:"tags,omitempty"`
+	Properties *armSQLDatabaseGetProps `json:"properties,omitempty"`
+}
+
+type armSQLDatabaseGetProps struct {
+	Resource *armSQLDatabaseGetResource `json:"resource,omitempty"`
+}
+
+type armSQLDatabaseGetResource struct {
+	ID    string `json:"id"`
+	RID   string `json:"_rid,omitempty"`
+	TS    int64  `json:"_ts,omitempty"`
+	ETag  string `json:"_etag,omitempty"`
+	Colls string `json:"_colls,omitempty"`
+	Users string `json:"_users,omitempty"`
+}
+
+type armSQLDatabaseList struct {
+	Value []armSQLDatabaseGetResults `json:"value"`
+}
+
+// SQL container --------------------------------------------------------------
+
+type armSQLContainerCreateParams struct {
+	Properties *armSQLContainerCreateProps `json:"properties"`
+	Location   string                      `json:"location,omitempty"`
+	Tags       map[string]string           `json:"tags,omitempty"`
+}
+
+type armSQLContainerCreateProps struct {
+	Resource *armSQLContainerResource `json:"resource"`
+	Options  *armCreateUpdateOptions  `json:"options,omitempty"`
+}
+
+// armSQLContainerResource reuses the data plane's partitionKeyDef and
+// uniqueKeyPolicy shapes so the two planes agree on container structure.
+type armSQLContainerResource struct {
+	ID              string           `json:"id"`
+	PartitionKey    *partitionKeyDef `json:"partitionKey,omitempty"`
+	DefaultTTL      *int32           `json:"defaultTtl,omitempty"`
+	UniqueKeyPolicy *uniqueKeyPolicy `json:"uniqueKeyPolicy,omitempty"`
+	IndexingPolicy  map[string]any   `json:"indexingPolicy,omitempty"`
+}
+
+type armSQLContainerGetResults struct {
+	ID         string                   `json:"id,omitempty"`
+	Name       string                   `json:"name,omitempty"`
+	Type       string                   `json:"type,omitempty"`
+	Location   string                   `json:"location,omitempty"`
+	Tags       map[string]string        `json:"tags,omitempty"`
+	Properties *armSQLContainerGetProps `json:"properties,omitempty"`
+}
+
+type armSQLContainerGetProps struct {
+	Resource *armSQLContainerGetResource `json:"resource,omitempty"`
+}
+
+type armSQLContainerGetResource struct {
+	ID              string           `json:"id"`
+	PartitionKey    *partitionKeyDef `json:"partitionKey,omitempty"`
+	DefaultTTL      *int32           `json:"defaultTtl,omitempty"`
+	UniqueKeyPolicy *uniqueKeyPolicy `json:"uniqueKeyPolicy,omitempty"`
+	IndexingPolicy  map[string]any   `json:"indexingPolicy,omitempty"`
+	RID             string           `json:"_rid,omitempty"`
+	TS              int64            `json:"_ts,omitempty"`
+	ETag            string           `json:"_etag,omitempty"`
+}
+
+type armSQLContainerList struct {
+	Value []armSQLContainerGetResults `json:"value"`
+}
+
+// Throughput -----------------------------------------------------------------
+
+type armThroughputUpdateParams struct {
+	Properties *armThroughputUpdateProps `json:"properties"`
+}
+
+type armThroughputUpdateProps struct {
+	Resource *armThroughputResource `json:"resource"`
+}
+
+type armThroughputResource struct {
+	Throughput        *int32                `json:"throughput,omitempty"`
+	AutoscaleSettings *armAutoscaleSettings `json:"autoscaleSettings,omitempty"`
+}
+
+type armThroughputGetResults struct {
+	ID         string                 `json:"id,omitempty"`
+	Name       string                 `json:"name,omitempty"`
+	Type       string                 `json:"type,omitempty"`
+	Properties *armThroughputGetProps `json:"properties,omitempty"`
+}
+
+type armThroughputGetProps struct {
+	Resource *armThroughputGetResource `json:"resource,omitempty"`
+}
+
+type armThroughputGetResource struct {
+	Throughput        *int32                        `json:"throughput,omitempty"`
+	AutoscaleSettings *armAutoscaleSettingsResource `json:"autoscaleSettings,omitempty"`
+	MinimumThroughput string                        `json:"minimumThroughput,omitempty"`
+	RID               string                        `json:"_rid,omitempty"`
+	TS                int64                         `json:"_ts,omitempty"`
+	ETag              string                        `json:"_etag,omitempty"`
+}


### PR DESCRIPTION
## Summary

Closes the C1 IaC-blocking gap: Cosmos DB SQL databases, containers and throughput existed **only** on the documents.azure.com data plane, so Bicep / Terraform / `az cosmosdb sql database create` could not manage them. This adds the `Microsoft.DocumentDB/databaseAccounts/{acct}/sqlDatabases` ARM control plane the real `armcosmos` SQLResourcesClient drives.

## What's added

New `cosmosdb.ARMHandler` (registered before the account handler so it wins the `/sqlDatabases` sub-tree first-match), serving:

- **sqlDatabases** — PUT (create/update), GET, DELETE (cascades containers), list
- **containers** — PUT (partitionKey, defaultTtl, uniqueKeyPolicy, indexingPolicy), GET, DELETE, list
- **throughputSettings/default** — GET/PUT manual RU/s or autoscale maxThroughput, at database and container level
- **migrateToAutoscale / migrateToManualThroughput** — both levels

LROs complete synchronously (200 with body, 204 for delete) so `Begin*` pollers terminate on the first response, matching the existing account control plane.

## Unified model (not two disjoint stores)

The ARM handler **shares the data-plane Handler's state**: databases live in the same databases set, containers are the same driver tables (keyed by `qualify`), and throughput lives in the same offers map. A control-plane-created database/container/throughput is immediately visible to the azcosmos data plane and vice versa — proven by a round-trip test. The database-delete cascade is factored into a shared helper used by both planes.

## Tests

Real `armcosmos` SDK end-to-end: create account → PUT database → GET/list → PUT container (partition key) → GET/list → PUT manual throughput → migrate to autoscale → DELETE database cascades its container (GET 404). Plus: container-without-database rejected, ops on a missing account rejected, and both-directions data-plane/control-plane unification.

## Gates

`go build ./...`, `gofmt -l` (empty), `go test ./server/azure/cosmosdb/... ./providers/azure/cosmosdb/... ./persist/... -race`, broad `go test ./server/azure/...`, `golangci-lint` (0 issues, touched pkgs), coveragegen (no diff — driver interfaces unchanged), `go mod tidy` (clean) all pass.