### PR TITLE
refactor(settle): add settle.Set keyed-window helper + adopt in RDS

### DIFF
--- a/internal/settle/settle.go
+++ b/internal/settle/settle.go
@@ -14,7 +14,10 @@
 // any settling was configured.
 package settle
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 // Default settle durations per resource type. They are deliberately small so a
 // real SDK waiter (whose minimum poll delay is 15-30s) succeeds on its first
@@ -28,6 +31,14 @@ const (
 	DefaultCertificateSettle = 2 * time.Second // ACM PENDING_VALIDATION->ISSUED
 	DefaultExecutionSettle   = 1 * time.Second // SFN RUNNING->SUCCEEDED
 	DefaultLBSettle          = 2 * time.Second // ELBv2 provisioning->active
+
+	DefaultCacheSettle       = 2 * time.Second // ElastiCache/Redis/Memorystore creating->available
+	DefaultCacheModifySettle = 1 * time.Second // cache modifying->available
+	DefaultClusterSettle     = 3 * time.Second // Redshift/MemoryDB/Bigtable creating->available
+	DefaultWarehouseResize   = 2 * time.Second // Redshift resizing->available
+	DefaultCloudSQLSettle    = 3 * time.Second // Cloud SQL PENDING_CREATE->RUNNABLE
+	DefaultAzureDBSettle     = 3 * time.Second // Azure SQL/flex Creating->Succeeded/Ready
+	DefaultKeyspacesSettle   = 2 * time.Second // Keyspaces table CREATING->ACTIVE
 )
 
 // Window is a read-time overlay describing a resource still settling into its
@@ -67,4 +78,75 @@ func (w Window) Observe(now time.Time, final string) string {
 // 100 once settled).
 func (w Window) Settled(now time.Time) bool {
 	return !(w.active && now.Before(w.ReadyAt))
+}
+
+// Set is a keyed collection of settle Windows — one per resource id. A provider
+// holds one Set per resource kind whose stored struct is a SHARED driver type
+// (so a per-struct settle field is unavailable): the RDS instSettle/snapSettle
+// pattern, generalized. All methods are safe for concurrent use; the zero value
+// is not usable — construct with NewSet. Set wraps the proven Window primitive
+// and imports only "sync" and "time" — callers pass now (from config.Clock) so
+// settle stays dependency-free.
+type Set struct {
+	mu sync.RWMutex
+	m  map[string]Window
+}
+
+// NewSet returns an empty, ready-to-use Set.
+func NewSet() *Set {
+	return &Set{m: map[string]Window{}}
+}
+
+// Begin records that id is settling from intermediate to its (stored) final
+// state over createdAt+d. A non-positive d clears any window for id — i.e. the
+// resource is immediately observed as final. This is the single opt-in call:
+// set.Begin(id, StateCreating, now, m.opts.SettleDuration(settle.DefaultX)).
+func (s *Set) Begin(id, intermediate string, createdAt time.Time, d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if d <= 0 {
+		delete(s.m, id)
+
+		return
+	}
+
+	s.m[id] = Pending(intermediate, createdAt, d)
+}
+
+// State overlays id's window onto final: the intermediate value while the
+// window is active and unelapsed, else final. Absent id -> final. This is the
+// read-path call that replaces a bare final on Describe/List/Get.
+func (s *Set) State(id string, now time.Time, final string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if w, ok := s.m[id]; ok {
+		return w.Observe(now, final)
+	}
+
+	return final
+}
+
+// Settled reports whether id's window has elapsed (or none exists). For
+// progress fields and LRO done-flags (snapshot PercentProgress, Bigtable
+// operation.done).
+func (s *Set) Settled(id string, now time.Time) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if w, ok := s.m[id]; ok {
+		return w.Settled(now)
+	}
+
+	return true
+}
+
+// Clear drops id's window (on delete, or when a terminal state is reached and
+// the window is no longer needed). Idempotent.
+func (s *Set) Clear(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.m, id)
 }

--- a/internal/settle/settle_test.go
+++ b/internal/settle/settle_test.go
@@ -1,9 +1,11 @@
 package settle_test
 
 import (
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/internal/settle"
 )
 
@@ -57,4 +59,108 @@ func TestZeroWindowIsInactive(t *testing.T) {
 	if got := disabled.Observe(base, "available"); got != "available" {
 		t.Fatalf("d<=0 Observe = %q, want available", got)
 	}
+}
+
+func TestSetBeginStateAdvanceClear(t *testing.T) {
+	t.Parallel()
+
+	fc := config.NewFakeClock(base)
+	s := settle.NewSet()
+
+	// Absent id: State returns final, Settled reports done.
+	if got := s.State("db1", fc.Now(), "available"); got != "available" {
+		t.Fatalf("absent State = %q, want available", got)
+	}
+	if !s.Settled("db1", fc.Now()) {
+		t.Fatal("absent Settled = false, want true")
+	}
+
+	s.Begin("db1", "creating", fc.Now(), 2*time.Second)
+
+	// Immediately after Begin: intermediate observed, not settled.
+	if got := s.State("db1", fc.Now(), "available"); got != "creating" {
+		t.Fatalf("at begin State = %q, want creating", got)
+	}
+	if s.Settled("db1", fc.Now()) {
+		t.Fatal("at begin Settled = true, want false")
+	}
+
+	// Before ReadyAt: still intermediate.
+	fc.Advance(2*time.Second - time.Millisecond)
+	if got := s.State("db1", fc.Now(), "available"); got != "creating" {
+		t.Fatalf("before readyAt State = %q, want creating", got)
+	}
+
+	// At/after ReadyAt: final, settled.
+	fc.Advance(time.Millisecond)
+	if got := s.State("db1", fc.Now(), "available"); got != "available" {
+		t.Fatalf("after readyAt State = %q, want available", got)
+	}
+	if !s.Settled("db1", fc.Now()) {
+		t.Fatal("after readyAt Settled = false, want true")
+	}
+
+	// Clear drops the window: State returns final regardless of clock.
+	s.Begin("db2", "creating", fc.Now(), time.Hour)
+	if got := s.State("db2", fc.Now(), "available"); got != "creating" {
+		t.Fatalf("db2 before clear State = %q, want creating", got)
+	}
+	s.Clear("db2")
+	if got := s.State("db2", fc.Now(), "available"); got != "available" {
+		t.Fatalf("db2 after clear State = %q, want available", got)
+	}
+	// Clear is idempotent.
+	s.Clear("db2")
+}
+
+func TestSetBeginNonPositiveClears(t *testing.T) {
+	t.Parallel()
+
+	s := settle.NewSet()
+
+	// A live window then a d<=0 Begin must clear it (opt-out / re-create).
+	s.Begin("db1", "creating", base, time.Hour)
+	if got := s.State("db1", base, "available"); got != "creating" {
+		t.Fatalf("live window State = %q, want creating", got)
+	}
+
+	s.Begin("db1", "creating", base, 0)
+	if got := s.State("db1", base, "available"); got != "available" {
+		t.Fatalf("after d=0 Begin State = %q, want available", got)
+	}
+
+	// Negative duration on an absent id is a harmless no-op.
+	s.Begin("db2", "creating", base, -time.Second)
+	if got := s.State("db2", base, "available"); got != "available" {
+		t.Fatalf("after d<0 Begin State = %q, want available", got)
+	}
+}
+
+func TestSetConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	s := settle.NewSet()
+
+	const workers = 8
+
+	var wg sync.WaitGroup
+
+	wg.Add(workers)
+
+	for i := 0; i < workers; i++ {
+		go func(n int) {
+			defer wg.Done()
+
+			id := "db" + string(rune('a'+n))
+
+			for j := 0; j < 1000; j++ {
+				s.Begin(id, "creating", base, time.Duration(j)*time.Second)
+				_ = s.State(id, base.Add(time.Duration(j)*time.Second), "available")
+				_ = s.Settled(id, base)
+				s.Clear(id)
+			}
+		}(i)
+	}
+
+	wg.Wait()
 }

--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -118,11 +118,12 @@ type Mock struct {
 
 	// instSettle / snapSettle overlay a "creating"/"rebooting" window over an
 	// instance's or snapshot's stored (available) State on the Describe surface,
-	// keyed by id and guarded by mu. They live beside the stores rather than on
-	// the shared rdsdriver structs (which Azure flexible-server/SQL also use),
-	// keeping settling AWS-internal. Absent = report the stored State directly.
-	instSettle map[string]settle.Window
-	snapSettle map[string]settle.Window
+	// keyed by id. They live beside the stores rather than on the shared
+	// rdsdriver structs (which Azure flexible-server/SQL also use), keeping
+	// settling AWS-internal. Each settle.Set carries its own lock; absent =
+	// report the stored State directly.
+	instSettle *settle.Set
+	snapSettle *settle.Set
 
 	opts           *config.Options
 	subnetResolver SubnetResolver
@@ -147,30 +148,22 @@ func New(opts *config.Options) *Mock {
 		clusterCreds:       map[string]clusterCred{},
 		groupTags:          map[string]map[string]string{},
 		rootPasswords:      map[string]string{},
-		instSettle:         map[string]settle.Window{},
-		snapSettle:         map[string]settle.Window{},
+		instSettle:         settle.NewSet(),
+		snapSettle:         settle.NewSet(),
 		opts:               opts,
 	}
 }
 
 // settleInstanceState overlays the instance's settle window (if any) onto its
-// stored final state. The caller must hold at least m.mu.RLock.
+// stored final state.
 func (m *Mock) settleInstanceState(id, final string) string {
-	if w, ok := m.instSettle[id]; ok {
-		return w.Observe(m.opts.Clock.Now(), final)
-	}
-
-	return final
+	return m.instSettle.State(id, m.opts.Clock.Now(), final)
 }
 
 // settleSnapshotState overlays the snapshot's settle window (if any) onto its
-// stored final state. The caller must hold at least m.mu.RLock.
+// stored final state.
 func (m *Mock) settleSnapshotState(id, final string) string {
-	if w, ok := m.snapSettle[id]; ok {
-		return w.Observe(m.opts.Clock.Now(), final)
-	}
-
-	return final
+	return m.snapSettle.State(id, m.opts.Clock.Now(), final)
 }
 
 // SetMonitoring wires a CloudWatch-style backend for auto-metric emission.
@@ -417,9 +410,9 @@ func (m *Mock) reserveInstance(ctx context.Context, cfg rdsdriver.InstanceConfig
 
 	inst := m.newInstance(ctx, cfg)
 	m.instances.Set(cfg.ID, inst)
-	m.instSettle[cfg.ID] = settle.Pending(rdsdriver.StateCreating, m.opts.Clock.Now(),
-		m.opts.SettleDuration(settle.DefaultDBInstanceSettle))
 	m.rootPasswords[cfg.ID] = cfg.MasterUserPassword
+	m.instSettle.Begin(cfg.ID, rdsdriver.StateCreating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultDBInstanceSettle))
 
 	if cfg.ClusterID != "" {
 		cluster, _ := m.clusters.Get(cfg.ClusterID)
@@ -930,7 +923,7 @@ func (m *Mock) DeleteInstance(ctx context.Context, id string) error {
 
 	m.instances.Delete(id)
 	delete(m.rootPasswords, id)
-	delete(m.instSettle, id)
+	m.instSettle.Clear(id)
 
 	return nil
 }
@@ -964,7 +957,7 @@ func (m *Mock) RebootInstance(_ context.Context, id string) error {
 	m.instances.Set(id, inst)
 	// The logical state stays available; a fresh "rebooting" window makes Describe
 	// report the available->rebooting->available transient dip under AsyncSettle.
-	m.instSettle[id] = settle.Pending(rdsdriver.StateRebooting, m.opts.Clock.Now(),
+	m.instSettle.Begin(id, rdsdriver.StateRebooting, m.opts.Clock.Now(),
 		m.opts.SettleDuration(settle.DefaultDBRebootSettle))
 
 	m.emitInstanceMetrics(id, inst.Engine, cpuMetricRunning, connectionsRunning)
@@ -994,7 +987,7 @@ func (m *Mock) transitionInstance(id, from, to string, cpu, conns float64, verb 
 	m.instances.Set(id, inst)
 	// A lifecycle transition (start/stop) supersedes any post-create settle
 	// window so the instance reports its new state, not a stale "creating".
-	delete(m.instSettle, id)
+	m.instSettle.Clear(id)
 
 	m.emitInstanceMetrics(id, inst.Engine, cpu, conns)
 
@@ -1263,11 +1256,11 @@ func (m *Mock) CreateSnapshot(_ context.Context, cfg rdsdriver.SnapshotConfig) (
 
 	now := m.opts.Clock.Now()
 	m.snapshots.Set(cfg.ID, snap)
-	m.snapSettle[cfg.ID] = settle.Pending(rdsdriver.SnapshotCreating, now,
+	m.snapSettle.Begin(cfg.ID, rdsdriver.SnapshotCreating, now,
 		m.opts.SettleDuration(settle.DefaultDBSnapshotSettle))
 	// The source instance briefly reports "backing-up" while the snapshot settles,
 	// matching real RDS; its logical state stays available.
-	m.instSettle[cfg.InstanceID] = settle.Pending(rdsdriver.StateBackingUp, now,
+	m.instSettle.Begin(cfg.InstanceID, rdsdriver.StateBackingUp, now,
 		m.opts.SettleDuration(settle.DefaultDBSnapshotSettle))
 
 	out := snap
@@ -1317,7 +1310,7 @@ func (m *Mock) DeleteSnapshot(_ context.Context, id string) error {
 		return cerrors.Newf(cerrors.NotFound, "DB snapshot %q not found", id)
 	}
 
-	delete(m.snapSettle, id)
+	m.snapSettle.Clear(id)
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds `settle.Set`, a reusable keyed collection of settle `Window`s, and adopts it inside the AWS RDS provider as the reference user. This is the **foundation** for generalizing the RDS-proven async-lifecycle overlay to the ~10 database/cache/compute services whose state machines are synchronous today. **No behavior change** — everything stays gated behind the existing `AsyncSettle` option, which defaults off.

## What changed

- **`internal/settle/settle.go`**
  - New `Set` type: `map[string]Window` guarded by its own `sync.RWMutex`, with `NewSet` / `Begin(id, intermediate, createdAt, d)` / `State(id, now, final)` / `Settled(id, now)` / `Clear(id)`. It wraps the proven `Window.Observe`/`Window.Settled` primitive rather than reimplementing the time logic. An absent id (or a non-positive `d` passed to `Begin`) reports the final state immediately, so a service is a no-op unless it opts in.
  - New default duration constants for the upcoming per-service adoptions (cache/cluster/warehouse/Cloud SQL/Azure DB/Keyspaces).
- **`internal/settle/settle_test.go`** — FakeClock-deterministic unit tests for `Set`: Begin→State shows the intermediate before ReadyAt and the final after `Advance`; `Clear`; `Settled`; `Begin` with `d<=0` clears; and a concurrent-access test (`-race` clean).
- **`providers/aws/rds/rds.go`** — refactor RDS's two hand-rolled `map[string]settle.Window` fields plus the `settleInstanceState`/`settleSnapshotState` helpers onto `settle.Set` (create / reboot / snapshot Begin, delete/transition Clear, Describe State). Pure internal refactor; RDS's existing settle tests pass unchanged.

## Why no behavior change

With `AsyncSettle=false` (the default), every `Begin` receives `d=0` → the window is inactive → `State` returns the stored terminal state unconditionally, exactly as before. `Set` windows are intentionally **not** snapshotted, preserving RDS's existing non-persisted `instSettle`/`snapSettle` behavior.

## Scope

Foundation only. The per-service adoptions (AWS cache+warehouse, GCP, Azure, RDS restore parity) are separate follow-up PRs. No shared driver interface, wire handler, or config-surface change.

## Gates

`go build ./...`, `gofmt -l` (empty), `go test ./... -race` on settle+rds+server/rds, broad `go test ./providers/aws/... ./server/aws/...`, full `go test ./...` (exit 0, 331 ok), `golangci-lint` (0 new — only pre-existing dupl in untouched `parameter_group.go`), `coveragegen` (no `docs/coverage` diff), and `go mod tidy` all clean.
