### PR TITLE
feat(elasticache): snapshot restore, copy, and delete

### DIFF
--- a/docs/coverage/aws/elasticache.md
+++ b/docs/coverage/aws/elasticache.md
@@ -46,7 +46,9 @@ Snapshots is an OPTIONAL capability, discovered by type assertion.
 
 | Operation | Description |
 | --- | --- |
+| `CopySnapshot` | CopySnapshot deep-copies an existing snapshot to a new name, so mutating |
 | `CreateSnapshot` |  |
+| `DeleteSnapshot` | DeleteSnapshot removes a snapshot and returns its last state (marked |
 | `DescribeSnapshots` |  |
 
 ### SubnetGroups

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -1683,7 +1683,15 @@
         "doc": "Snapshots is an OPTIONAL capability, discovered by type assertion.",
         "operations": [
           {
+            "name": "CopySnapshot",
+            "doc": "CopySnapshot deep-copies an existing snapshot to a new name, so mutating"
+          },
+          {
             "name": "CreateSnapshot"
+          },
+          {
+            "name": "DeleteSnapshot",
+            "doc": "DeleteSnapshot removes a snapshot and returns its last state (marked"
           },
           {
             "name": "DescribeSnapshots"

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -230,6 +230,13 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 		return nil, errors.Newf(errors.AlreadyExists, "cache %q already exists", cfg.Name)
 	}
 
+	// A restore (SnapshotName set) seeds the unset config fields from the
+	// snapshot before defaults are applied, so the new cluster reproduces the
+	// source's engine/version/node-type/count/port.
+	if err := m.seedCacheRestore(&cfg); err != nil {
+		return nil, err
+	}
+
 	engine := cfg.Engine
 	if engine == "" {
 		engine = defaultEngine
@@ -257,10 +264,7 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 	region := regionctx.RegionOr(ctx, m.opts.Region)
 	endpoint := clusterEndpoint(cfg.Name, region, engine, resolvePort(engine, cfg.Port))
 
-	tags := make(map[string]string, len(cfg.Tags))
-	for k, v := range cfg.Tags {
-		tags[k] = v
-	}
+	tags := maps.Clone(cfg.Tags)
 
 	info := driver.CacheInfo{
 		Name:               cfg.Name,

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -131,6 +131,18 @@ func (m *Mock) requireSubnetGroup(name string) error {
 	return nil
 }
 
+// cloneTags returns an independent copy of the supplied tag map, never nil, so a
+// cache's Tags field is always a usable (possibly empty) map. maps.Clone would
+// propagate a nil source through as nil, breaking that invariant.
+func cloneTags(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+
+	return out
+}
+
 // cacheARN builds an ElastiCache cluster ARN in the given region.
 func (m *Mock) cacheARN(region, name string) string {
 	return "arn:aws:elasticache:" + region + ":" + m.opts.AccountID + ":cluster:" + name
@@ -264,7 +276,7 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 	region := regionctx.RegionOr(ctx, m.opts.Region)
 	endpoint := clusterEndpoint(cfg.Name, region, engine, resolvePort(engine, cfg.Port))
 
-	tags := maps.Clone(cfg.Tags)
+	tags := cloneTags(cfg.Tags)
 
 	info := driver.CacheInfo{
 		Name:               cfg.Name,

--- a/providers/aws/elasticache/replication_group.go
+++ b/providers/aws/elasticache/replication_group.go
@@ -31,6 +31,12 @@ func (m *Mock) CreateReplicationGroup(
 			"ReplicationGroupAlreadyExists: replication group %q already exists", cfg.ID)
 	}
 
+	// A restore (SnapshotName set) seeds the unset config fields from the
+	// snapshot before defaults are applied.
+	if err := m.seedReplicationGroupRestore(&cfg); err != nil {
+		return nil, err
+	}
+
 	engine := cfg.Engine
 	if engine == "" {
 		engine = defaultEngine

--- a/providers/aws/elasticache/snapshot.go
+++ b/providers/aws/elasticache/snapshot.go
@@ -130,6 +130,147 @@ func paramGroupName(engine string) string {
 	return "default." + engine
 }
 
+// CopySnapshot deep-copies an existing snapshot to a new name. Real ElastiCache
+// lowercases both names, rejects a missing source with SnapshotNotFoundFault, and
+// a duplicate target with SnapshotAlreadyExistsFault. The copy is a wholly
+// independent record: the driver.Snapshot value is copied by value (it holds no
+// slice/map fields), stamped with a fresh name/ARN/create-time and Source
+// "copied", so later mutation of either snapshot cannot corrupt the other.
+func (m *Mock) CopySnapshot(ctx context.Context, cfg cachedriver.CopySnapshotConfig) (*cachedriver.Snapshot, error) {
+	source := strings.ToLower(cfg.SourceSnapshotName)
+	target := strings.ToLower(cfg.TargetSnapshotName)
+
+	if target == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "TargetSnapshotName is required")
+	}
+
+	src, ok := m.snapshots.Get(source)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound,
+			"SnapshotNotFoundFault: snapshot %q not found", source)
+	}
+
+	region := regionctx.RegionOr(ctx, m.opts.Region)
+
+	dst := src
+	dst.Name = target
+	dst.Source = "copied"
+	dst.Status = statusAvailable
+	dst.CreatedAt = m.opts.Clock.Now().UTC()
+	dst.ARN = m.snapshotARN(arnRegion(src.ARN, region), target)
+
+	// SetIfAbsent is the atomic create-if-new guard: a concurrent copy to the same
+	// target loses the race and reports the duplicate, never silently overwrites.
+	if !m.snapshots.SetIfAbsent(target, dst) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists,
+			"SnapshotAlreadyExistsFault: snapshot %q already exists", target)
+	}
+
+	return &dst, nil
+}
+
+// DeleteSnapshot removes a snapshot and returns its last state marked
+// "deleting", as real ElastiCache does (the delete is asynchronous there). A
+// missing snapshot reports SnapshotNotFoundFault.
+func (m *Mock) DeleteSnapshot(_ context.Context, name string) (*cachedriver.Snapshot, error) {
+	key := strings.ToLower(name)
+
+	snap, ok := m.snapshots.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound,
+			"SnapshotNotFoundFault: snapshot %q not found", key)
+	}
+
+	// Gate the response on the delete winning: if a concurrent caller removed the
+	// snapshot between the Get and here, report the not-found it now is.
+	if !m.snapshots.Delete(key) {
+		return nil, cerrors.Newf(cerrors.NotFound,
+			"SnapshotNotFoundFault: snapshot %q not found", key)
+	}
+
+	snap.Status = "deleting"
+
+	return &snap, nil
+}
+
+// restoreSeed seeds the config fields of a cache cluster or replication group
+// restore from the named snapshot, filling only the fields the request left
+// unset (an explicit request value always wins). A blank name is not a restore
+// (nil, nil); a named-but-missing snapshot reports SnapshotNotFoundFault.
+func (m *Mock) restoreSeed(name string) (*cachedriver.Snapshot, error) {
+	key := strings.ToLower(name)
+	if key == "" {
+		return nil, nil
+	}
+
+	snap, ok := m.snapshots.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound,
+			"SnapshotNotFoundFault: snapshot %q not found", key)
+	}
+
+	return &snap, nil
+}
+
+// seedCacheRestore fills a CreateCacheCluster config from its SnapshotName, so a
+// restore reproduces the source cluster's shape unless the request overrides a
+// field. It is a no-op when the request names no snapshot.
+func (m *Mock) seedCacheRestore(cfg *cachedriver.CacheConfig) error {
+	snap, err := m.restoreSeed(cfg.SnapshotName)
+	if err != nil || snap == nil {
+		return err
+	}
+
+	if cfg.Engine == "" {
+		cfg.Engine = snap.Engine
+	}
+
+	if cfg.NodeType == "" {
+		cfg.NodeType = snap.NodeType
+	}
+
+	if cfg.EngineVersion == "" {
+		cfg.EngineVersion = snap.EngineVersion
+	}
+
+	if cfg.NumCacheNodes == 0 {
+		cfg.NumCacheNodes = snap.NumCacheNodes
+	}
+
+	if cfg.Port == 0 {
+		cfg.Port = snap.Port
+	}
+
+	return nil
+}
+
+// seedReplicationGroupRestore fills a CreateReplicationGroup config from its
+// SnapshotName, mirroring seedCacheRestore for the replication-group surface.
+func (m *Mock) seedReplicationGroupRestore(cfg *cachedriver.ReplicationGroupConfig) error {
+	snap, err := m.restoreSeed(cfg.SnapshotName)
+	if err != nil || snap == nil {
+		return err
+	}
+
+	if cfg.Engine == "" {
+		cfg.Engine = snap.Engine
+	}
+
+	if cfg.NodeType == "" {
+		cfg.NodeType = snap.NodeType
+	}
+
+	if cfg.EngineVersion == "" {
+		cfg.EngineVersion = snap.EngineVersion
+	}
+
+	if cfg.NumCacheNodes == 0 {
+		cfg.NumCacheNodes = snap.NumCacheNodes
+	}
+
+	return nil
+}
+
 // DescribeSnapshots returns all snapshots, narrowed by the non-empty filter
 // fields. An explicit SnapshotName that matches nothing reports
 // SnapshotNotFoundFault, as real ElastiCache does.

--- a/providers/aws/elasticache/snapshot_test.go
+++ b/providers/aws/elasticache/snapshot_test.go
@@ -135,3 +135,170 @@ func TestDescribeSnapshotsUnknownNameFails(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, cerrors.IsNotFound(err))
 }
+
+func TestCopySnapshotCreatesIndependentCopy(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCache(ctx, driver.CacheConfig{
+		Name: "cluster-1", Engine: "redis", NodeType: "cache.t3.small",
+	})
+	require.NoError(t, err)
+
+	_, err = m.CreateSnapshot(ctx, driver.SnapshotConfig{SnapshotName: "src", CacheClusterID: "cluster-1"})
+	require.NoError(t, err)
+
+	cp, err := m.CopySnapshot(ctx, driver.CopySnapshotConfig{
+		SourceSnapshotName: "SRC", TargetSnapshotName: "Dst",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "dst", cp.Name, "target name should be lowercased")
+	assert.Equal(t, "copied", cp.Source)
+	assert.Equal(t, statusAvailable, cp.Status)
+	assert.Equal(t, "cache.t3.small", cp.NodeType)
+	assert.Contains(t, cp.ARN, ":snapshot:dst")
+
+	// Both source and copy coexist as independent records.
+	all, err := m.DescribeSnapshots(ctx, driver.SnapshotFilter{})
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+}
+
+// TestCopySnapshotDeepCopyIndependence proves the copy shares no mutable state
+// with the source: deleting the source leaves the copy intact, and a later
+// mutation of the source cluster does not reach either snapshot.
+func TestCopySnapshotDeepCopyIndependence(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCache(ctx, driver.CacheConfig{
+		Name: "c1", Engine: "redis", NodeType: "cache.t3.micro",
+	})
+	require.NoError(t, err)
+
+	_, err = m.CreateSnapshot(ctx, driver.SnapshotConfig{SnapshotName: "s1", CacheClusterID: "c1"})
+	require.NoError(t, err)
+
+	_, err = m.CopySnapshot(ctx, driver.CopySnapshotConfig{SourceSnapshotName: "s1", TargetSnapshotName: "s2"})
+	require.NoError(t, err)
+
+	// Mutate the source cluster after both snapshots exist.
+	_, err = m.ModifyCache(ctx, driver.ModifyCacheConfig{Name: "c1", NodeType: "cache.r6g.large"})
+	require.NoError(t, err)
+
+	// Delete the source snapshot; the copy must survive untouched.
+	del, err := m.DeleteSnapshot(ctx, "s1")
+	require.NoError(t, err)
+	assert.Equal(t, "deleting", del.Status)
+
+	_, err = m.DescribeSnapshots(ctx, driver.SnapshotFilter{SnapshotName: "s1"})
+	require.Error(t, err)
+	assert.True(t, cerrors.IsNotFound(err))
+
+	survivor, err := m.DescribeSnapshots(ctx, driver.SnapshotFilter{SnapshotName: "s2"})
+	require.NoError(t, err)
+	require.Len(t, survivor, 1)
+	// The copy still reflects the cluster's shape at snapshot time, not the
+	// post-snapshot mutation.
+	assert.Equal(t, "cache.t3.micro", survivor[0].NodeType)
+}
+
+func TestCopySnapshotMissingSourceFails(t *testing.T) {
+	m, _ := newTestMock()
+
+	_, err := m.CopySnapshot(context.Background(), driver.CopySnapshotConfig{
+		SourceSnapshotName: "ghost", TargetSnapshotName: "dst",
+	})
+	require.Error(t, err)
+	assert.True(t, cerrors.IsNotFound(err))
+}
+
+func TestCopySnapshotDuplicateTargetFails(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCache(ctx, driver.CacheConfig{Name: "c1"})
+	require.NoError(t, err)
+	_, err = m.CreateSnapshot(ctx, driver.SnapshotConfig{SnapshotName: "s1", CacheClusterID: "c1"})
+	require.NoError(t, err)
+	_, err = m.CreateSnapshot(ctx, driver.SnapshotConfig{SnapshotName: "s2", CacheClusterID: "c1"})
+	require.NoError(t, err)
+
+	_, err = m.CopySnapshot(ctx, driver.CopySnapshotConfig{SourceSnapshotName: "s1", TargetSnapshotName: "s2"})
+	require.Error(t, err)
+	assert.True(t, cerrors.IsAlreadyExists(err))
+}
+
+func TestCopySnapshotRequiresTargetName(t *testing.T) {
+	m, _ := newTestMock()
+
+	_, err := m.CopySnapshot(context.Background(), driver.CopySnapshotConfig{SourceSnapshotName: "s1"})
+	require.Error(t, err)
+	assert.True(t, cerrors.IsInvalidArgument(err))
+}
+
+func TestDeleteSnapshotUnknownFails(t *testing.T) {
+	m, _ := newTestMock()
+
+	_, err := m.DeleteSnapshot(context.Background(), "ghost")
+	require.Error(t, err)
+	assert.True(t, cerrors.IsNotFound(err))
+}
+
+func TestRestoreCacheClusterFromSnapshot(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCache(ctx, driver.CacheConfig{
+		Name: "origin", Engine: "redis", NodeType: "cache.r6g.large", EngineVersion: "7.0",
+	})
+	require.NoError(t, err)
+
+	_, err = m.CreateSnapshot(ctx, driver.SnapshotConfig{SnapshotName: "snap", CacheClusterID: "origin"})
+	require.NoError(t, err)
+
+	// Restore into a new cluster, providing no engine/node-type: they seed from
+	// the snapshot.
+	restored, err := m.CreateCache(ctx, driver.CacheConfig{Name: "restored", SnapshotName: "SNAP"})
+	require.NoError(t, err)
+	assert.Equal(t, "redis", restored.Engine)
+	assert.Equal(t, "cache.r6g.large", restored.NodeType)
+	assert.Equal(t, "7.0", restored.EngineVersion)
+	assert.Equal(t, 1, restored.NumCacheNodes)
+
+	// An explicit request field overrides the snapshot's value.
+	override, err := m.CreateCache(ctx, driver.CacheConfig{
+		Name: "override", SnapshotName: "snap", NodeType: "cache.t3.micro",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "cache.t3.micro", override.NodeType)
+	assert.Equal(t, "redis", override.Engine)
+}
+
+func TestRestoreCacheClusterUnknownSnapshotFails(t *testing.T) {
+	m, _ := newTestMock()
+
+	_, err := m.CreateCache(context.Background(), driver.CacheConfig{Name: "restored", SnapshotName: "ghost"})
+	require.Error(t, err)
+	assert.True(t, cerrors.IsNotFound(err))
+}
+
+func TestRestoreReplicationGroupFromSnapshot(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateReplicationGroup(ctx, driver.ReplicationGroupConfig{
+		ID: "rg-src", Engine: "redis", NodeType: "cache.r6g.large",
+	})
+	require.NoError(t, err)
+
+	_, err = m.CreateSnapshot(ctx, driver.SnapshotConfig{SnapshotName: "rgsnap", ReplicationGroupID: "rg-src"})
+	require.NoError(t, err)
+
+	restored, err := m.CreateReplicationGroup(ctx, driver.ReplicationGroupConfig{
+		ID: "rg-restored", SnapshotName: "rgsnap",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "redis", restored.Engine)
+	assert.Equal(t, "cache.r6g.large", restored.NodeType)
+}

--- a/server/aws/elasticache/handler.go
+++ b/server/aws/elasticache/handler.go
@@ -63,6 +63,8 @@ var elastiCacheActions = map[string]struct{}{ //nolint:gochecknoglobals // stati
 	"DeleteReplicationGroup":       {},
 	"CreateSnapshot":               {},
 	"DescribeSnapshots":            {},
+	"CopySnapshot":                 {},
+	"DeleteSnapshot":               {},
 }
 
 // sharedTagActions are the generic tag verbs ElastiCache shares with other
@@ -84,6 +86,8 @@ var sharedTagActions = map[string]struct{}{ //nolint:gochecknoglobals // static 
 var sharedSnapshotActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup table
 	"CreateSnapshot":    {},
 	"DescribeSnapshots": {},
+	"CopySnapshot":      {},
+	"DeleteSnapshot":    {},
 }
 
 // scopeElastiCache is the SigV4 credential-scope service name for ElastiCache.
@@ -198,6 +202,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.createSnapshot(w, r)
 	case "DescribeSnapshots":
 		h.describeSnapshots(w, r)
+	case "CopySnapshot":
+		h.copySnapshot(w, r)
+	case "DeleteSnapshot":
+		h.deleteSnapshot(w, r)
 	default:
 		awsquery.WriteXMLError(w, http.StatusBadRequest,
 			"InvalidAction", "unknown ElastiCache action: "+r.Form.Get("Action"))

--- a/server/aws/elasticache/operations.go
+++ b/server/aws/elasticache/operations.go
@@ -56,6 +56,8 @@ func (h *Handler) createCacheCluster(w http.ResponseWriter, r *http.Request) {
 		SubnetGroupName:    form.Get("CacheSubnetGroupName"),
 		ParameterGroupName: form.Get("CacheParameterGroupName"),
 		Tags:               parseTags(form),
+		SnapshotName:       form.Get("SnapshotName"),
+		SnapshotArns:       awsquery.ListStrings(form, "SnapshotArns.SnapshotArn"),
 	}
 
 	info, err := h.cache.CreateCache(r.Context(), cfg)

--- a/server/aws/elasticache/replication_group.go
+++ b/server/aws/elasticache/replication_group.go
@@ -105,6 +105,8 @@ func (h *Handler) createReplicationGroup(w http.ResponseWriter, r *http.Request)
 		SubnetGroupName:          r.Form.Get("CacheSubnetGroupName"),
 		SecurityGroupIDs:         awsquery.ListStrings(r.Form, "SecurityGroupIds.SecurityGroupId"),
 		AutomaticFailoverEnabled: r.Form.Get("AutomaticFailoverEnabled") == formTrue,
+		SnapshotName:             r.Form.Get("SnapshotName"),
+		SnapshotArns:             awsquery.ListStrings(r.Form, "SnapshotArns.SnapshotArn"),
 	})
 	if err != nil {
 		writeErr(w, err)

--- a/server/aws/elasticache/snapshot.go
+++ b/server/aws/elasticache/snapshot.go
@@ -14,6 +14,7 @@ func (h *Handler) snapshots() (cachedriver.Snapshots, bool) {
 	return s, ok
 }
 
+//nolint:dupl // per-action snapshot handler; the sibling parses a different request and writes a different response envelope
 func (h *Handler) createSnapshot(w http.ResponseWriter, r *http.Request) {
 	store, ok := h.snapshots()
 	if !ok {
@@ -65,6 +66,53 @@ func (h *Handler) describeSnapshots(w http.ResponseWriter, r *http.Request) {
 	awsquery.WriteXMLResponse(w, describeSnapshotsResponse{
 		Xmlns:    Namespace,
 		Result:   describeSnapshotsResult{Snapshots: snapshotsListXML{Snapshot: out}},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+//nolint:dupl // per-action snapshot handler; the sibling parses a different request and writes a different response envelope
+func (h *Handler) copySnapshot(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.snapshots()
+	if !ok {
+		writeUnsupported(w, "snapshots")
+		return
+	}
+
+	snap, err := store.CopySnapshot(r.Context(), cachedriver.CopySnapshotConfig{
+		SourceSnapshotName: r.Form.Get("SourceSnapshotName"),
+		TargetSnapshotName: r.Form.Get("TargetSnapshotName"),
+		TargetBucket:       r.Form.Get("TargetBucket"),
+		KmsKeyID:           r.Form.Get("KmsKeyId"),
+		Tags:               parseTags(r.Form),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, copySnapshotResponse{
+		Xmlns:    Namespace,
+		Result:   snapshotResult{Snapshot: toSnapshotXML(snap)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) deleteSnapshot(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.snapshots()
+	if !ok {
+		writeUnsupported(w, "snapshots")
+		return
+	}
+
+	snap, err := store.DeleteSnapshot(r.Context(), r.Form.Get("SnapshotName"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteSnapshotResponse{
+		Xmlns:    Namespace,
+		Result:   snapshotResult{Snapshot: toSnapshotXML(snap)},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/elasticache/snapshot_restore_sdk_roundtrip_test.go
+++ b/server/aws/elasticache/snapshot_restore_sdk_roundtrip_test.go
@@ -1,0 +1,187 @@
+package elasticache_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+	ectypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+)
+
+// TestSnapshotRestoreCopyDeleteWorldCase drives the full real-user snapshot
+// lifecycle against the wire server with the aws-sdk-go-v2 ElastiCache client:
+// create → snapshot → copy → restore-into-a-new-cluster → mutate the source →
+// prove copy/restore are unaffected → delete. It is the end-to-end proof for
+// the ElastiCache snapshot restore/copy/delete surface.
+func TestSnapshotRestoreCopyDeleteWorldCase(t *testing.T) {
+	ctx := context.Background()
+	c := newSnapshotClient(t)
+
+	mustCreateCluster(t, c, "src-cluster")
+
+	if _, err := c.CreateSnapshot(ctx, &awselasticache.CreateSnapshotInput{
+		SnapshotName:   aws.String("snap-1"),
+		CacheClusterId: aws.String("src-cluster"),
+	}); err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	// Copy the snapshot to a new name; both must then exist independently.
+	copied, err := c.CopySnapshot(ctx, &awselasticache.CopySnapshotInput{
+		SourceSnapshotName: aws.String("snap-1"),
+		TargetSnapshotName: aws.String("snap-copy"),
+	})
+	if err != nil {
+		t.Fatalf("CopySnapshot: %v", err)
+	}
+	if got := aws.ToString(copied.Snapshot.SnapshotSource); got != "copied" {
+		t.Errorf("copy SnapshotSource = %q, want copied", got)
+	}
+	if got := aws.ToString(copied.Snapshot.CacheNodeType); got != "cache.t3.micro" {
+		t.Errorf("copy CacheNodeType = %q, want cache.t3.micro", got)
+	}
+
+	all, err := c.DescribeSnapshots(ctx, &awselasticache.DescribeSnapshotsInput{})
+	if err != nil {
+		t.Fatalf("DescribeSnapshots: %v", err)
+	}
+	if len(all.Snapshots) != 2 {
+		t.Fatalf("after copy DescribeSnapshots returned %d, want 2", len(all.Snapshots))
+	}
+
+	// Restore a brand-new cluster from the copy; its config seeds from the
+	// snapshot even though the request names no engine/node-type.
+	if _, err := c.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("restored-cluster"),
+		SnapshotName:   aws.String("snap-copy"),
+	}); err != nil {
+		t.Fatalf("restore CreateCacheCluster: %v", err)
+	}
+
+	assertClusterShape(t, c, "restored-cluster", "redis", "cache.t3.micro")
+
+	// Mutate the ORIGINAL cluster after snapshot+copy+restore. Deep-copy
+	// independence means neither snapshot nor the restored cluster changes.
+	if _, err := c.ModifyCacheCluster(ctx, &awselasticache.ModifyCacheClusterInput{
+		CacheClusterId:   aws.String("src-cluster"),
+		CacheNodeType:    aws.String("cache.r6g.large"),
+		ApplyImmediately: aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("ModifyCacheCluster: %v", err)
+	}
+
+	for _, name := range []string{"snap-1", "snap-copy"} {
+		got, derr := c.DescribeSnapshots(ctx, &awselasticache.DescribeSnapshotsInput{
+			SnapshotName: aws.String(name),
+		})
+		if derr != nil {
+			t.Fatalf("DescribeSnapshots(%s): %v", name, derr)
+		}
+		if nt := aws.ToString(got.Snapshots[0].CacheNodeType); nt != "cache.t3.micro" {
+			t.Errorf("snapshot %s CacheNodeType = %q after source mutation, want cache.t3.micro", name, nt)
+		}
+	}
+	assertClusterShape(t, c, "restored-cluster", "redis", "cache.t3.micro")
+
+	// Delete one snapshot; the other survives and the deleted one 404s.
+	if _, err := c.DeleteSnapshot(ctx, &awselasticache.DeleteSnapshotInput{
+		SnapshotName: aws.String("snap-1"),
+	}); err != nil {
+		t.Fatalf("DeleteSnapshot: %v", err)
+	}
+
+	_, err = c.DescribeSnapshots(ctx, &awselasticache.DescribeSnapshotsInput{
+		SnapshotName: aws.String("snap-1"),
+	})
+	var notFound *ectypes.SnapshotNotFoundFault
+	if !errors.As(err, &notFound) {
+		t.Fatalf("DescribeSnapshots(snap-1) after delete = %v, want SnapshotNotFoundFault", err)
+	}
+
+	survivor, err := c.DescribeSnapshots(ctx, &awselasticache.DescribeSnapshotsInput{
+		SnapshotName: aws.String("snap-copy"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeSnapshots(snap-copy): %v", err)
+	}
+	if len(survivor.Snapshots) != 1 {
+		t.Fatalf("surviving snapshot count = %d, want 1", len(survivor.Snapshots))
+	}
+}
+
+func TestCopySnapshotMissingSourceReturnsSnapshotNotFoundFault(t *testing.T) {
+	ctx := context.Background()
+	c := newSnapshotClient(t)
+
+	_, err := c.CopySnapshot(ctx, &awselasticache.CopySnapshotInput{
+		SourceSnapshotName: aws.String("ghost"),
+		TargetSnapshotName: aws.String("dst"),
+	})
+	var notFound *ectypes.SnapshotNotFoundFault
+	if !errors.As(err, &notFound) {
+		t.Fatalf("CopySnapshot missing source = %v, want SnapshotNotFoundFault", err)
+	}
+}
+
+func TestCopySnapshotDuplicateTargetReturnsSnapshotAlreadyExistsFault(t *testing.T) {
+	ctx := context.Background()
+	c := newSnapshotClient(t)
+
+	mustCreateCluster(t, c, "cdup")
+	for _, n := range []string{"s1", "s2"} {
+		if _, err := c.CreateSnapshot(ctx, &awselasticache.CreateSnapshotInput{
+			SnapshotName:   aws.String(n),
+			CacheClusterId: aws.String("cdup"),
+		}); err != nil {
+			t.Fatalf("CreateSnapshot(%s): %v", n, err)
+		}
+	}
+
+	_, err := c.CopySnapshot(ctx, &awselasticache.CopySnapshotInput{
+		SourceSnapshotName: aws.String("s1"),
+		TargetSnapshotName: aws.String("s2"),
+	})
+	var already *ectypes.SnapshotAlreadyExistsFault
+	if !errors.As(err, &already) {
+		t.Fatalf("CopySnapshot duplicate target = %v, want SnapshotAlreadyExistsFault", err)
+	}
+}
+
+func TestDeleteSnapshotMissingReturnsSnapshotNotFoundFault(t *testing.T) {
+	ctx := context.Background()
+	c := newSnapshotClient(t)
+
+	_, err := c.DeleteSnapshot(ctx, &awselasticache.DeleteSnapshotInput{
+		SnapshotName: aws.String("ghost"),
+	})
+	var notFound *ectypes.SnapshotNotFoundFault
+	if !errors.As(err, &notFound) {
+		t.Fatalf("DeleteSnapshot missing = %v, want SnapshotNotFoundFault", err)
+	}
+}
+
+// assertClusterShape reads a cluster back through DescribeCacheClusters and
+// asserts its engine and node type.
+func assertClusterShape(t *testing.T, c *awselasticache.Client, id, engine, nodeType string) {
+	t.Helper()
+
+	out, err := c.DescribeCacheClusters(context.Background(), &awselasticache.DescribeCacheClustersInput{
+		CacheClusterId: aws.String(id),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheClusters(%s): %v", id, err)
+	}
+	if len(out.CacheClusters) != 1 {
+		t.Fatalf("DescribeCacheClusters(%s) returned %d, want 1", id, len(out.CacheClusters))
+	}
+
+	cl := out.CacheClusters[0]
+	if got := aws.ToString(cl.Engine); got != engine {
+		t.Errorf("cluster %s Engine = %q, want %q", id, got, engine)
+	}
+	if got := aws.ToString(cl.CacheNodeType); got != nodeType {
+		t.Errorf("cluster %s CacheNodeType = %q, want %q", id, got, nodeType)
+	}
+}

--- a/server/aws/elasticache/types.go
+++ b/server/aws/elasticache/types.go
@@ -157,6 +157,20 @@ type createSnapshotResponse struct {
 	Metadata responseMetadata `xml:"ResponseMetadata"`
 }
 
+type copySnapshotResponse struct {
+	XMLName  xml.Name         `xml:"CopySnapshotResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   snapshotResult   `xml:"CopySnapshotResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type deleteSnapshotResponse struct {
+	XMLName  xml.Name         `xml:"DeleteSnapshotResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   snapshotResult   `xml:"DeleteSnapshotResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
 type snapshotsListXML struct {
 	Snapshot []snapshotXML `xml:"Snapshot,omitempty"`
 }

--- a/services/cache/driver/driver.go
+++ b/services/cache/driver/driver.go
@@ -153,6 +153,15 @@ type CacheConfig struct {
 	// RedisVersion is the requested Azure Redis engine version (`redisVersion`);
 	// empty defaults to the backend's default. Empty for non-Azure callers.
 	RedisVersion string
+
+	// SnapshotName restores the new cache cluster from an existing ElastiCache
+	// snapshot: the cluster's engine, engine version, node type, node count, and
+	// port are seeded from the snapshot for any field the request leaves unset.
+	// SnapshotArns names S3 RDB objects to seed a restore from an external backup;
+	// the in-memory backend accepts them but does not read S3 data. Both are
+	// AWS-only and left empty by other callers.
+	SnapshotName string
+	SnapshotArns []string
 }
 
 // ModifyCacheConfig carries the mutable fields of an AWS ElastiCache
@@ -267,6 +276,14 @@ type ReplicationGroupConfig struct {
 	// AutomaticFailoverEnabled requests automatic failover for the group,
 	// reflected as AutomaticFailover ("enabled"/"disabled") on Describe.
 	AutomaticFailoverEnabled bool
+
+	// SnapshotName restores the new replication group from an existing
+	// ElastiCache snapshot: the group's engine, engine version, node type, and
+	// node count are seeded from the snapshot for any field the request leaves
+	// unset. SnapshotArns names S3 RDB objects to seed from an external backup;
+	// accepted but not read. Both are AWS-only and left empty by other callers.
+	SnapshotName string
+	SnapshotArns []string
 }
 
 // DeleteReplicationGroupOptions carries the optional delete-time behaviors of
@@ -327,12 +344,34 @@ type SnapshotFilter struct {
 	ReplicationGroupID string
 }
 
+// CopySnapshotConfig describes a CopySnapshot request: SourceSnapshotName names
+// the existing snapshot to copy, TargetSnapshotName the new snapshot to create.
+// TargetBucket (an S3 export bucket) and KmsKeyID are accepted for wire fidelity;
+// the in-memory backend records neither S3 objects nor KMS keys.
+type CopySnapshotConfig struct {
+	SourceSnapshotName string
+	TargetSnapshotName string
+	TargetBucket       string
+	KmsKeyID           string
+	Tags               map[string]string
+}
+
 // Snapshots is an OPTIONAL capability, discovered by type assertion.
 // ElastiCache snapshots are an AWS concept (Redis/Valkey only); drivers for other
 // clouds do not model them and answering InvalidAction is the truthful response.
 type Snapshots interface {
 	CreateSnapshot(ctx context.Context, cfg SnapshotConfig) (*Snapshot, error)
 	DescribeSnapshots(ctx context.Context, filter SnapshotFilter) ([]Snapshot, error)
+
+	// CopySnapshot deep-copies an existing snapshot to a new name, so mutating
+	// either the source or the copy leaves the other untouched. A missing source
+	// reports SnapshotNotFoundFault; an existing target reports
+	// SnapshotAlreadyExistsFault.
+	CopySnapshot(ctx context.Context, cfg CopySnapshotConfig) (*Snapshot, error)
+
+	// DeleteSnapshot removes a snapshot and returns its last state (marked
+	// "deleting"). A missing snapshot reports SnapshotNotFoundFault.
+	DeleteSnapshot(ctx context.Context, name string) (*Snapshot, error)
 }
 
 // AccessKeys is an OPTIONAL capability, discovered by type assertion. Azure


### PR DESCRIPTION
## Summary

Closes the biggest ElastiCache functional gap: snapshots were **write-only** (`CreateSnapshot`/`DescribeSnapshots`) — there was no way to restore, copy, or delete them, so backups accumulated permanently and could never seed a new cluster.

This adds the full snapshot lifecycle:

- **CopySnapshot** — deep-copies an existing snapshot to a new name (missing source → `SnapshotNotFoundFault`; existing target → `SnapshotAlreadyExistsFault`, gated atomically via `SetIfAbsent`).
- **DeleteSnapshot** — removes a snapshot, returns its last state marked `deleting` (missing → `SnapshotNotFoundFault`).
- **Restore** — `CreateCacheCluster` / `CreateReplicationGroup` with `SnapshotName` seed the new resource's engine, version, node type, node count, and port from the snapshot for any field the request leaves unset (an explicit request field wins). `SnapshotArns` is accepted for wire fidelity (S3 RDB data is not modeled).

## Design

- New verbs land on the existing **optional** `Snapshots` driver capability (type-asserted, AWS-only) — the base `Cache` interface is untouched, so Azure Redis / Memorystore are unaffected.
- `CopySnapshot` / `DeleteSnapshot` collide with EC2's EBS `CopySnapshot`/`DeleteSnapshot` on the shared query wire; both are scope-gated to `elasticache` (matching the existing `CreateSnapshot`/`DescribeSnapshots` gate) so EBS calls still reach the EC2 handler.
- **Deep-copy independence**: a snapshot copy is a wholly separate record; mutating either the source snapshot, the source cluster, or the copy never corrupts the others (verified by test).

## Tests

- Provider-level (`providers/aws/elasticache`): copy/delete/restore + duplicate/missing faults + a deep-copy-independence test.
- Real-SDK wire round-trip (`server/aws/elasticache`) with aws-sdk-go-v2: create → snapshot → copy → restore-into-a-new-cluster → mutate the source → prove copy/restore unaffected → delete → 404, plus the fault cases.

Gates: `go build`, `gofmt`, `go test -race` (touched pkgs) + broad `./providers/aws/... ./server/aws/...`, golangci-lint (0 new), coveragegen regenerated, `go mod tidy` clean.