### PR TITLE
fix(redshift): final-snapshot on delete + subnet/parameter group in-use guards

### DIFF
--- a/providers/aws/redshift/redshift.go
+++ b/providers/aws/redshift/redshift.go
@@ -259,13 +259,39 @@ func (m *Mock) DescribeClusterParameterGroups(_ context.Context, names []string)
 	return out, nil
 }
 
-// DeleteClusterParameterGroup removes a redshift cluster parameter group.
+// DeleteClusterParameterGroup removes a redshift cluster parameter group. Real
+// Redshift refuses while any cluster still references the group
+// (InvalidClusterParameterGroupStateFault); deleting it out from under a live
+// cluster would strand that cluster's configuration. The in-use scan and the
+// delete run under one lock so a concurrent CreateCluster cannot slip a
+// referencing cluster in between them.
 func (m *Mock) DeleteClusterParameterGroup(_ context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if user, ok := m.clusterParameterGroupInUseBy(name); ok {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"cluster parameter group %q is in use by cluster %q", name, user)
+	}
+
 	if !m.parameterGroups.Delete(name) {
 		return cerrors.Newf(cerrors.NotFound, "parameter group %q not found", name)
 	}
 
 	return nil
+}
+
+// clusterParameterGroupInUseBy names a cluster still referencing the given
+// parameter group, if any. Callers must hold m.mu.
+func (m *Mock) clusterParameterGroupInUseBy(name string) (string, bool) {
+	clusters := m.clusters.All()
+	for id := range clusters {
+		if clusters[id].DBClusterParameterGroupName == name {
+			return id, true
+		}
+	}
+
+	return "", false
 }
 
 // CreateClusterSubnetGroup registers a redshift cluster subnet group.
@@ -313,13 +339,39 @@ func (m *Mock) DescribeClusterSubnetGroups(_ context.Context, names []string) ([
 	return out, nil
 }
 
-// DeleteClusterSubnetGroup removes a redshift cluster subnet group.
+// DeleteClusterSubnetGroup removes a redshift cluster subnet group. Real
+// Redshift refuses while any cluster is still placed in the group
+// (ClusterSubnetGroupInUseFault); deleting it out from under a live cluster
+// would strand that cluster in a group that no longer exists. The in-use scan
+// and the delete run under one lock so a concurrent CreateCluster cannot slip a
+// referencing cluster in between them.
 func (m *Mock) DeleteClusterSubnetGroup(_ context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if user, ok := m.clusterSubnetGroupInUseBy(name); ok {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"cluster subnet group %q is in use by cluster %q", name, user)
+	}
+
 	if !m.subnetGroups.Delete(name) {
 		return cerrors.Newf(cerrors.NotFound, "subnet group %q not found", name)
 	}
 
 	return nil
+}
+
+// clusterSubnetGroupInUseBy names a cluster still placed in the given subnet
+// group, if any. Callers must hold m.mu.
+func (m *Mock) clusterSubnetGroupInUseBy(name string) (string, bool) {
+	clusters := m.clusters.All()
+	for id := range clusters {
+		if clusters[id].SubnetGroupName == name {
+			return id, true
+		}
+	}
+
+	return "", false
 }
 
 // SetMonitoring wires a CloudWatch-style backend for auto-metric emission.

--- a/providers/aws/redshift/redshift_test.go
+++ b/providers/aws/redshift/redshift_test.go
@@ -336,6 +336,97 @@ func TestInstanceOpsRejected(t *testing.T) {
 	}
 }
 
+// TestDeleteClusterSubnetGroupInUseGuard proves a subnet group referenced by a
+// live cluster cannot be deleted, and that deleting the cluster releases it.
+func TestDeleteClusterSubnetGroupInUseGuard(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateClusterSubnetGroup(ctx, "sng", "desc", []string{"subnet-1"}); err != nil {
+		t.Fatalf("create subnet group: %v", err)
+	}
+
+	if _, err := m.CreateCluster(ctx, rdbdriver.ClusterConfig{
+		ID: "cl1", MasterUsername: "admin", SubnetGroupName: "sng",
+	}); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	// In use → rejected; the group survives.
+	if err := m.DeleteClusterSubnetGroup(ctx, "sng"); err == nil {
+		t.Fatal("expected in-use subnet group delete to be rejected")
+	}
+
+	if sngs, err := m.DescribeClusterSubnetGroups(ctx, []string{"sng"}); err != nil || len(sngs) != 1 {
+		t.Fatalf("subnet group should still exist: %+v, err %v", sngs, err)
+	}
+
+	if err := m.DeleteCluster(ctx, "cl1"); err != nil {
+		t.Fatalf("delete cluster: %v", err)
+	}
+
+	// Released → delete succeeds.
+	if err := m.DeleteClusterSubnetGroup(ctx, "sng"); err != nil {
+		t.Fatalf("delete released subnet group: %v", err)
+	}
+}
+
+// TestDeleteClusterParameterGroupInUseGuard proves a parameter group referenced
+// by a live cluster cannot be deleted, and that deleting the cluster frees it.
+func TestDeleteClusterParameterGroupInUseGuard(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateClusterParameterGroup(ctx, "pg", "redshift-1.0", "desc"); err != nil {
+		t.Fatalf("create parameter group: %v", err)
+	}
+
+	if _, err := m.CreateCluster(ctx, rdbdriver.ClusterConfig{
+		ID: "cl1", MasterUsername: "admin", DBClusterParameterGroupName: "pg",
+	}); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if err := m.DeleteClusterParameterGroup(ctx, "pg"); err == nil {
+		t.Fatal("expected in-use parameter group delete to be rejected")
+	}
+
+	if pgs, err := m.DescribeClusterParameterGroups(ctx, []string{"pg"}); err != nil || len(pgs) != 1 {
+		t.Fatalf("parameter group should still exist: %+v, err %v", pgs, err)
+	}
+
+	if err := m.DeleteCluster(ctx, "cl1"); err != nil {
+		t.Fatalf("delete cluster: %v", err)
+	}
+
+	if err := m.DeleteClusterParameterGroup(ctx, "pg"); err != nil {
+		t.Fatalf("delete released parameter group: %v", err)
+	}
+}
+
+// TestDeleteUnreferencedGroupsSucceed proves the in-use guard never blocks a
+// group nothing references.
+func TestDeleteUnreferencedGroupsSucceed(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateClusterSubnetGroup(ctx, "sng", "desc", []string{"subnet-1"}); err != nil {
+		t.Fatalf("create subnet group: %v", err)
+	}
+
+	if _, err := m.CreateClusterParameterGroup(ctx, "pg", "redshift-1.0", "desc"); err != nil {
+		t.Fatalf("create parameter group: %v", err)
+	}
+
+	if err := m.DeleteClusterSubnetGroup(ctx, "sng"); err != nil {
+		t.Fatalf("delete unreferenced subnet group: %v", err)
+	}
+
+	if err := m.DeleteClusterParameterGroup(ctx, "pg"); err != nil {
+		t.Fatalf("delete unreferenced parameter group: %v", err)
+	}
+}
+
 // requireNoError fails the test immediately if err is non-nil.
 func requireNoError(t *testing.T, err error) {
 	t.Helper()

--- a/server/aws/redshift/cluster_delete_teardown_sdk_roundtrip_test.go
+++ b/server/aws/redshift/cluster_delete_teardown_sdk_roundtrip_test.go
@@ -1,0 +1,191 @@
+package redshift_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsredshift "github.com/aws/aws-sdk-go-v2/service/redshift"
+	"github.com/aws/smithy-go"
+)
+
+// createWarehouse creates a minimal available cluster the teardown tests act on.
+func createWarehouse(t *testing.T, client *awsredshift.Client, id string) {
+	t.Helper()
+
+	if _, err := client.CreateCluster(context.Background(), &awsredshift.CreateClusterInput{
+		ClusterIdentifier:  aws.String(id),
+		MasterUsername:     aws.String("admin"),
+		MasterUserPassword: aws.String("Sup3rSecret!"),
+		NodeType:           aws.String("ra3.xlplus"),
+		DBName:             aws.String("dev"),
+	}); err != nil {
+		t.Fatalf("CreateCluster(%s): %v", id, err)
+	}
+}
+
+func errorCode(err error) string {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.ErrorCode()
+	}
+
+	return ""
+}
+
+// TestSDKRedshiftDeleteClusterFinalSnapshot proves DeleteCluster honors the
+// final-snapshot flags exactly as real Redshift does: a final snapshot is
+// required (and taken, visible as a manual snapshot) unless the caller opts out
+// with SkipFinalClusterSnapshot.
+func TestSDKRedshiftDeleteClusterFinalSnapshot(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	// (1) SkipFinalClusterSnapshot=false + a FinalClusterSnapshotIdentifier →
+	// the cluster is removed and a manual snapshot appears.
+	createWarehouse(t, client, "wh-final")
+
+	if _, err := client.DeleteCluster(ctx, &awsredshift.DeleteClusterInput{
+		ClusterIdentifier:              aws.String("wh-final"),
+		SkipFinalClusterSnapshot:       aws.Bool(false),
+		FinalClusterSnapshotIdentifier: aws.String("wh-final-snap"),
+	}); err != nil {
+		t.Fatalf("DeleteCluster with final snapshot: %v", err)
+	}
+
+	snaps, err := client.DescribeClusterSnapshots(ctx, &awsredshift.DescribeClusterSnapshotsInput{
+		SnapshotIdentifier: aws.String("wh-final-snap"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeClusterSnapshots: %v", err)
+	}
+
+	if len(snaps.Snapshots) != 1 {
+		t.Fatalf("got %d snapshots, want 1 final snapshot", len(snaps.Snapshots))
+	}
+
+	if aws.ToString(snaps.Snapshots[0].SnapshotType) != "manual" {
+		t.Fatalf("final snapshot type = %q, want manual", aws.ToString(snaps.Snapshots[0].SnapshotType))
+	}
+
+	if _, err := client.DescribeClusters(ctx, &awsredshift.DescribeClustersInput{
+		ClusterIdentifier: aws.String("wh-final"),
+	}); errorCode(err) != "ClusterNotFound" {
+		t.Fatalf("DescribeClusters after delete = %v, want ClusterNotFound", err)
+	}
+
+	// (2) SkipFinalClusterSnapshot=false + NO identifier → rejected, cluster
+	// survives, no snapshot written.
+	createWarehouse(t, client, "wh-noid")
+
+	_, err = client.DeleteCluster(ctx, &awsredshift.DeleteClusterInput{
+		ClusterIdentifier:        aws.String("wh-noid"),
+		SkipFinalClusterSnapshot: aws.Bool(false),
+	})
+	if errorCode(err) != "InvalidParameterCombination" {
+		t.Fatalf("DeleteCluster without identifier = %v, want InvalidParameterCombination", err)
+	}
+
+	if got, derr := client.DescribeClusters(ctx, &awsredshift.DescribeClustersInput{
+		ClusterIdentifier: aws.String("wh-noid"),
+	}); derr != nil || len(got.Clusters) != 1 {
+		t.Fatalf("cluster should survive a rejected delete: %+v, err %v", got, derr)
+	}
+
+	// (3) SkipFinalClusterSnapshot=true → deleted, no new snapshot.
+	createWarehouse(t, client, "wh-skip")
+
+	if _, err := client.DeleteCluster(ctx, &awsredshift.DeleteClusterInput{
+		ClusterIdentifier:        aws.String("wh-skip"),
+		SkipFinalClusterSnapshot: aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("DeleteCluster skip final snapshot: %v", err)
+	}
+
+	all, err := client.DescribeClusterSnapshots(ctx, &awsredshift.DescribeClusterSnapshotsInput{})
+	if err != nil {
+		t.Fatalf("DescribeClusterSnapshots (all): %v", err)
+	}
+
+	// Only the "wh-final-snap" from case (1) should exist; skip left none behind.
+	if len(all.Snapshots) != 1 {
+		t.Fatalf("got %d snapshots after skip-final delete, want 1", len(all.Snapshots))
+	}
+}
+
+// TestSDKRedshiftGroupInUseGuards proves a subnet group / parameter group
+// referenced by a live cluster cannot be torn down (real Redshift in-use
+// faults), and that the delete succeeds once the cluster is gone.
+func TestSDKRedshiftGroupInUseGuards(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateClusterSubnetGroup(ctx, &awsredshift.CreateClusterSubnetGroupInput{
+		ClusterSubnetGroupName: aws.String("sng"),
+		Description:            aws.String("desc"),
+		SubnetIds:              []string{"subnet-1"},
+	}); err != nil {
+		t.Fatalf("CreateClusterSubnetGroup: %v", err)
+	}
+
+	if _, err := client.CreateClusterParameterGroup(ctx, &awsredshift.CreateClusterParameterGroupInput{
+		ParameterGroupName:   aws.String("pg"),
+		ParameterGroupFamily: aws.String("redshift-1.0"),
+		Description:          aws.String("desc"),
+	}); err != nil {
+		t.Fatalf("CreateClusterParameterGroup: %v", err)
+	}
+
+	if _, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:         aws.String("wh"),
+		MasterUsername:            aws.String("admin"),
+		MasterUserPassword:        aws.String("Sup3rSecret!"),
+		NodeType:                  aws.String("ra3.xlplus"),
+		ClusterSubnetGroupName:    aws.String("sng"),
+		ClusterParameterGroupName: aws.String("pg"),
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	// In use → each delete faults with its own code; the group survives.
+	_, err := client.DeleteClusterSubnetGroup(ctx, &awsredshift.DeleteClusterSubnetGroupInput{
+		ClusterSubnetGroupName: aws.String("sng"),
+	})
+	if errorCode(err) != "ClusterSubnetGroupInUseFault" {
+		t.Fatalf("DeleteClusterSubnetGroup in use = %v, want ClusterSubnetGroupInUseFault", err)
+	}
+
+	_, err = client.DeleteClusterParameterGroup(ctx, &awsredshift.DeleteClusterParameterGroupInput{
+		ParameterGroupName: aws.String("pg"),
+	})
+	if errorCode(err) != "InvalidClusterParameterGroupStateFault" {
+		t.Fatalf("DeleteClusterParameterGroup in use = %v, want InvalidClusterParameterGroupStateFault", err)
+	}
+
+	if _, err := client.DescribeClusterSubnetGroups(ctx, &awsredshift.DescribeClusterSubnetGroupsInput{
+		ClusterSubnetGroupName: aws.String("sng"),
+	}); err != nil {
+		t.Fatalf("subnet group should still exist: %v", err)
+	}
+
+	// Drop the cluster (skip its own final snapshot), then the groups delete.
+	if _, err := client.DeleteCluster(ctx, &awsredshift.DeleteClusterInput{
+		ClusterIdentifier:        aws.String("wh"),
+		SkipFinalClusterSnapshot: aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("DeleteCluster: %v", err)
+	}
+
+	if _, err := client.DeleteClusterSubnetGroup(ctx, &awsredshift.DeleteClusterSubnetGroupInput{
+		ClusterSubnetGroupName: aws.String("sng"),
+	}); err != nil {
+		t.Fatalf("DeleteClusterSubnetGroup after cluster gone: %v", err)
+	}
+
+	if _, err := client.DeleteClusterParameterGroup(ctx, &awsredshift.DeleteClusterParameterGroupInput{
+		ParameterGroupName: aws.String("pg"),
+	}); err != nil {
+		t.Fatalf("DeleteClusterParameterGroup after cluster gone: %v", err)
+	}
+}

--- a/server/aws/redshift/handler.go
+++ b/server/aws/redshift/handler.go
@@ -219,7 +219,7 @@ func writeErr(w http.ResponseWriter, err error) {
 	case cerrors.IsInvalidArgument(err):
 		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", msg)
 	case cerrors.IsFailedPrecondition(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidClusterState", msg)
+		awsquery.WriteXMLError(w, http.StatusBadRequest, invalidStateCode(err), msg)
 	default:
 		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", msg)
 	}
@@ -240,6 +240,23 @@ func notFoundCode(err error) string {
 		return "ClusterNotFound"
 	default:
 		return "ResourceNotFoundFault"
+	}
+}
+
+// invalidStateCode picks the AWS-shaped fault code for a failed-precondition
+// error by its message: an in-use subnet or parameter group has its own fault
+// code, everything else is a generic invalid cluster state (wrong-state reboot,
+// pause/resume, start/stop).
+func invalidStateCode(err error) string {
+	msg := err.Error()
+
+	switch {
+	case strings.Contains(msg, "subnet group"):
+		return "ClusterSubnetGroupInUseFault"
+	case strings.Contains(msg, "parameter group"):
+		return "InvalidClusterParameterGroupStateFault"
+	default:
+		return "InvalidClusterState"
 	}
 }
 

--- a/server/aws/redshift/operations.go
+++ b/server/aws/redshift/operations.go
@@ -165,8 +165,37 @@ func (h *Handler) deleteCluster(w http.ResponseWriter, r *http.Request) {
 	last := clusters[0]
 	last.State = rdbdriver.StateDeleting
 
+	// Unless SkipFinalClusterSnapshot is set, real Redshift takes a final manual
+	// snapshot before removing the cluster and requires a
+	// FinalClusterSnapshotIdentifier to name it (InvalidParameterCombination
+	// otherwise). The snapshot is visible in DescribeClusterSnapshots afterwards.
+	var finalID string
+
+	if !formBool(r.Form.Get("SkipFinalClusterSnapshot")) {
+		finalID = r.Form.Get("FinalClusterSnapshotIdentifier")
+		if finalID == "" {
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterCombination",
+				"FinalClusterSnapshotIdentifier is required unless SkipFinalClusterSnapshot is true")
+
+			return
+		}
+
+		if _, err := h.db.CreateClusterSnapshot(r.Context(),
+			rdbdriver.ClusterSnapshotConfig{ID: finalID, ClusterID: id}); err != nil {
+			writeErr(w, err)
+			return
+		}
+	}
+
 	if err := h.db.DeleteCluster(r.Context(), id); err != nil {
+		// DeleteCluster can still fail (engine deprovision, race); roll the final
+		// snapshot back so a rejected delete leaves no phantom snapshot behind.
+		if finalID != "" {
+			_ = h.db.DeleteClusterSnapshot(r.Context(), finalID)
+		}
+
 		writeErr(w, err)
+
 		return
 	}
 


### PR DESCRIPTION
## Summary

Closes two AWS Redshift teardown-correctness gaps (G-RS-1 / G-RS-2) where the emulator diverged from real Redshift.

### G-RS-1 — DeleteCluster ignored the final-snapshot flags
`DeleteCluster` now honors `SkipFinalClusterSnapshot` / `FinalClusterSnapshotIdentifier`, matching real Redshift:
- `SkipFinalClusterSnapshot=false` (the default) **requires** a `FinalClusterSnapshotIdentifier` — otherwise `InvalidParameterCombination`.
- When provided, a final **manual** snapshot is taken before the cluster is removed and is visible in `DescribeClusterSnapshots`.
- `SkipFinalClusterSnapshot=true` deletes with no snapshot.
- If the delete is rejected after the snapshot was written, the snapshot is rolled back (no phantom snapshot) — mirroring the RDS `DeleteDBInstance` pattern.

The final snapshot reuses `CreateClusterSnapshot`, which already deep-copies the cluster's config/slice fields, so later cluster mutation cannot corrupt the snapshot.

### G-RS-2 — no in-use guard on subnet / parameter group delete
`DeleteClusterSubnetGroup` and `DeleteClusterParameterGroup` now reject deletion while any live cluster still references the group (`ClusterSubnetGroupInUseFault` / `InvalidClusterParameterGroupStateFault`), via a lock-guarded reverse lookup over clusters — the same teardown guard RDS/ElastiCache/MemoryDB already enforce. Deleting an unreferenced group still succeeds; deleting the referencing cluster frees the group.

## Tests
- Provider: in-use guards for both group types + unreferenced-delete-succeeds.
- Wire (real aws-sdk-go-v2): final-snapshot required / taken-as-manual / skip paths, and both in-use faults with post-cluster-delete release.

## Gates
`go build ./...`, `gofmt -l` clean, `go test ./providers/aws/redshift/... ./server/aws/redshift/... -race` and broad `./providers/aws/... ./server/aws/...` green, golangci-lint 0 new issues on touched pkgs, coveragegen no diff, `go mod tidy` clean.

Scope: `providers/aws/redshift` + `server/aws/redshift` only.