### PR TITLE
feat(gcp-db): async lifecycle (settle) for Cloud SQL + Memorystore

### DIFF
--- a/providers/gcp/cloudsql/async_settle_test.go
+++ b/providers/gcp/cloudsql/async_settle_test.go
@@ -1,0 +1,143 @@
+package cloudsql
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// newAsyncMock builds a Cloud SQL mock with AsyncSettle enabled and a FakeClock
+// so create/modify/restart report their real transient GCP states deterministically.
+func newAsyncMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("us-central1"),
+		config.WithProjectID("mock-project"),
+		config.WithAsyncSettle(),
+	)
+
+	return New(opts), fc
+}
+
+// TestAsyncSettleCreateModifyRestart pins the AsyncSettle transitions: an
+// instance reports creating (→ wire PENDING_CREATE) then available (→ RUNNABLE)
+// on create, modifying (→ MAINTENANCE) then available on patch, and rebooting
+// (→ MAINTENANCE) then available on restart — all driven by the FakeClock. A
+// start/stop transition clears any pending create window.
+func TestAsyncSettleCreateModifyRestart(t *testing.T) {
+	m, fc := newAsyncMock()
+	ctx := context.Background()
+
+	created, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "db1", Engine: "MYSQL_8_0"})
+	if err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+
+	if created.State != rdsdriver.StateCreating {
+		t.Fatalf("create response State = %q, want creating", created.State)
+	}
+
+	got, err := m.DescribeInstances(ctx, []string{"db1"})
+	if err != nil || got[0].State != rdsdriver.StateCreating {
+		t.Fatalf("describe before settle = %q (err %v), want creating", got[0].State, err)
+	}
+
+	// Still transient one instant before the window elapses.
+	fc.Advance(settle.DefaultCloudSQLSettle - time.Millisecond)
+
+	got, _ = m.DescribeInstances(ctx, []string{"db1"})
+	if got[0].State != rdsdriver.StateCreating {
+		t.Fatalf("describe just before settle = %q, want creating", got[0].State)
+	}
+
+	// Past the window: terminal RUNNABLE.
+	fc.Advance(time.Millisecond)
+
+	got, _ = m.DescribeInstances(ctx, []string{"db1"})
+	if got[0].State != rdsdriver.StateAvailable {
+		t.Fatalf("describe after settle = %q, want available", got[0].State)
+	}
+
+	// Modify → modifying (MAINTENANCE) → available.
+	modified, err := m.ModifyInstance(ctx, "db1", rdsdriver.ModifyInstanceInput{InstanceClass: "db-n1-standard-2"})
+	if err != nil || modified.State != rdsdriver.StateModifying {
+		t.Fatalf("modify response State = %q (err %v), want modifying", modified.State, err)
+	}
+
+	got, _ = m.DescribeInstances(ctx, []string{"db1"})
+	if got[0].State != rdsdriver.StateModifying {
+		t.Fatalf("describe during modify = %q, want modifying", got[0].State)
+	}
+
+	fc.Advance(settle.DefaultCloudSQLSettle)
+
+	got, _ = m.DescribeInstances(ctx, []string{"db1"})
+	if got[0].State != rdsdriver.StateAvailable {
+		t.Fatalf("describe after modify settle = %q, want available", got[0].State)
+	}
+
+	// Restart → rebooting (MAINTENANCE) → available.
+	if err := m.RebootInstance(ctx, "db1"); err != nil {
+		t.Fatalf("RebootInstance: %v", err)
+	}
+
+	got, _ = m.DescribeInstances(ctx, []string{"db1"})
+	if got[0].State != rdsdriver.StateRebooting {
+		t.Fatalf("describe during restart = %q, want rebooting", got[0].State)
+	}
+
+	fc.Advance(settle.DefaultDBRebootSettle)
+
+	got, _ = m.DescribeInstances(ctx, []string{"db1"})
+	if got[0].State != rdsdriver.StateAvailable {
+		t.Fatalf("describe after restart settle = %q, want available", got[0].State)
+	}
+
+	// A stop transition clears the create window: a fresh instance stopped
+	// mid-settle reports stopped, not a stale creating.
+	fresh, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "db2", Engine: "MYSQL_8_0"})
+	if err != nil || fresh.State != rdsdriver.StateCreating {
+		t.Fatalf("CreateInstance db2 = %q (err %v), want creating", fresh.State, err)
+	}
+
+	if err := m.StopInstance(ctx, "db2"); err != nil {
+		t.Fatalf("StopInstance: %v", err)
+	}
+
+	got, _ = m.DescribeInstances(ctx, []string{"db2"})
+	if got[0].State != rdsdriver.StateStopped {
+		t.Fatalf("stopped db2 = %q, want stopped (window must be cleared)", got[0].State)
+	}
+}
+
+// TestAsyncSettleDefaultOff confirms the default (AsyncSettle unset) path is
+// byte-for-byte synchronous: create and modify are observed as available (→
+// RUNNABLE) immediately, with no transient state.
+func TestAsyncSettleDefaultOff(t *testing.T) {
+	m := newTestMock() // no WithAsyncSettle
+	ctx := context.Background()
+
+	created, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "db1", Engine: "MYSQL_8_0"})
+	if err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+
+	if created.State != rdsdriver.StateAvailable {
+		t.Fatalf("create response State = %q, want available (settle off)", created.State)
+	}
+
+	got, _ := m.DescribeInstances(ctx, []string{"db1"})
+	if got[0].State != rdsdriver.StateAvailable {
+		t.Fatalf("describe = %q, want available (settle off)", got[0].State)
+	}
+
+	modified, err := m.ModifyInstance(ctx, "db1", rdsdriver.ModifyInstanceInput{InstanceClass: "db-n1-standard-2"})
+	if err != nil || modified.State != rdsdriver.StateAvailable {
+		t.Fatalf("modify response State = %q (err %v), want available (settle off)", modified.State, err)
+	}
+}

--- a/providers/gcp/cloudsql/cloudsql.go
+++ b/providers/gcp/cloudsql/cloudsql.go
@@ -18,6 +18,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	dbengine "github.com/stackshy/cloudemu/v2/services/relationaldb/dbengine"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
@@ -60,6 +61,13 @@ type Mock struct {
 	// collision-free suffix (guarded by mu).
 	backupSeq int64
 
+	// instSettle overlays a transient PENDING_CREATE / MAINTENANCE window over an
+	// instance's stored RUNNABLE state so create/modify/restart report the real
+	// GCP intermediate state before settling. It is a no-op unless
+	// config.Options.AsyncSettle is set (SettleDuration returns 0 → inactive
+	// window → the historical synchronous behavior). The Set carries its own lock.
+	instSettle *settle.Set
+
 	// rootPasswords remembers each instance's master password (guarded by mu) so
 	// a clone can re-provision its own database against a configured
 	// DatabaseEngine. The emulator enforces no auth, so this is local state, not
@@ -79,8 +87,16 @@ func New(opts *config.Options) *Mock {
 		users:         memstore.New[rdsdriver.User](),
 		sslCerts:      memstore.New[rdsdriver.SslCert](),
 		rootPasswords: map[string]string{},
+		instSettle:    settle.NewSet(),
 		opts:          opts,
 	}
+}
+
+// settleState overlays the instance's settle window (if any) onto its stored
+// terminal state: the transient state while the window is active and unelapsed,
+// otherwise final. Absent window → final.
+func (m *Mock) settleState(id, final string) string {
+	return m.instSettle.State(id, m.opts.Clock.Now(), final)
 }
 
 // SetMonitoring wires a Cloud Monitoring backend for auto-metric emission.
@@ -196,6 +212,15 @@ func (m *Mock) CreateInstance(ctx context.Context, cfg rdsdriver.InstanceConfig)
 	}
 
 	out := m.finalizeInstance(cfg.ID, inst)
+
+	// Under AsyncSettle a fresh instance reports PENDING_CREATE until the window
+	// elapses, matching real Cloud SQL (instances.insert → PENDING_CREATE →
+	// RUNNABLE). With the default (AsyncSettle off) SettleDuration is 0 → the
+	// window is inactive → the returned/observed state stays RUNNABLE immediately.
+	m.instSettle.Begin(cfg.ID, rdsdriver.StateCreating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultCloudSQLSettle))
+
+	out.State = m.settleState(cfg.ID, out.State)
 
 	m.emitInstanceMetrics(cfg.ID, cpuMetricRunning, connRunning)
 
@@ -345,7 +370,9 @@ func (m *Mock) DescribeInstances(_ context.Context, ids []string) ([]rdsdriver.I
 
 		//nolint:gocritic // map values are large structs; copy is unavoidable when materializing the result slice.
 		for _, v := range all {
-			out = append(out, cloneInstance(v))
+			c := cloneInstance(v)
+			c.State = m.settleState(c.ID, c.State)
+			out = append(out, c)
 		}
 
 		return out, nil
@@ -359,7 +386,9 @@ func (m *Mock) DescribeInstances(_ context.Context, ids []string) ([]rdsdriver.I
 			return nil, cerrors.Newf(cerrors.NotFound, "Cloud SQL instance %q not found", id)
 		}
 
-		out = append(out, cloneInstance(inst))
+		c := cloneInstance(inst)
+		c.State = m.settleState(c.ID, c.State)
+		out = append(out, c)
 	}
 
 	return out, nil
@@ -424,7 +453,14 @@ func (m *Mock) ModifyInstance(
 
 	m.instances.Set(id, inst)
 
+	// Under AsyncSettle a patched instance briefly reports MAINTENANCE (via the
+	// StateModifying → MAINTENANCE wire mapping) before settling back to RUNNABLE.
+	// Default off → SettleDuration 0 → inactive window → RUNNABLE immediately.
+	m.instSettle.Begin(id, rdsdriver.StateModifying, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultCloudSQLSettle))
+
 	out := cloneInstance(inst)
+	out.State = m.settleState(id, out.State)
 
 	return &out, nil
 }
@@ -470,6 +506,7 @@ func (m *Mock) DeleteInstance(ctx context.Context, id string) error {
 
 	m.instances.Delete(id)
 	delete(m.rootPasswords, id)
+	m.instSettle.Clear(id)
 	m.unlinkReplicas(&inst)
 	m.deleteChildren(id)
 
@@ -551,6 +588,11 @@ func (m *Mock) RebootInstance(_ context.Context, id string) error {
 
 	m.instances.Set(id, inst)
 
+	// A restart briefly reports MAINTENANCE (StateRebooting → MAINTENANCE) before
+	// settling back to RUNNABLE under AsyncSettle; a no-op when settle is off.
+	m.instSettle.Begin(id, rdsdriver.StateRebooting, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultDBRebootSettle))
+
 	m.emitInstanceMetrics(id, cpuMetricRunning, connRunning)
 
 	return nil
@@ -576,6 +618,10 @@ func (m *Mock) transitionInstance(id, from, to string, cpu, conns float64, verb 
 
 	inst.State = to
 	m.instances.Set(id, inst)
+
+	// A start/stop transition supersedes any post-create settle window, so the
+	// new terminal state (RUNNABLE / SUSPENDED) is observed immediately.
+	m.instSettle.Clear(id)
 
 	m.emitInstanceMetrics(id, cpu, conns)
 

--- a/providers/gcp/memorystore/async_settle_test.go
+++ b/providers/gcp/memorystore/async_settle_test.go
@@ -1,0 +1,92 @@
+package memorystore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
+	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newAsyncMock builds a Memorystore mock with AsyncSettle enabled and a FakeClock
+// so create/update report their real transient GCP states deterministically.
+func newAsyncMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("us-central1"),
+		config.WithProjectID("test-project"),
+		config.WithAsyncSettle(),
+	)
+
+	return New(opts), fc
+}
+
+// TestAsyncSettleCreateUpdate pins the AsyncSettle transitions: an instance
+// reports CREATING then READY on create, and UPDATING then READY on patch, all
+// driven by the FakeClock and observed through both Get and List.
+func TestAsyncSettleCreateUpdate(t *testing.T) {
+	m, fc := newAsyncMock()
+	ctx := context.Background()
+
+	created, err := m.CreateCache(ctx, driver.CacheConfig{Name: "cache1"})
+	require.NoError(t, err)
+	assert.Equal(t, stateCreating, created.Status)
+
+	got, err := m.GetCache(ctx, "cache1")
+	require.NoError(t, err)
+	assert.Equal(t, stateCreating, got.Status)
+
+	// List observes the transient state too.
+	list, err := m.ListCaches(ctx, scope.Scope{})
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, stateCreating, list[0].Status)
+
+	// Still transient one instant before the window elapses.
+	fc.Advance(settle.DefaultCacheSettle - time.Millisecond)
+	got, _ = m.GetCache(ctx, "cache1")
+	assert.Equal(t, stateCreating, got.Status)
+
+	// Past the window: terminal READY.
+	fc.Advance(time.Millisecond)
+	got, _ = m.GetCache(ctx, "cache1")
+	assert.Equal(t, stateReady, got.Status)
+
+	// Update → UPDATING → READY.
+	updated, err := m.UpdateCache(ctx, driver.CacheConfig{Name: "cache1", NodeType: "M3"})
+	require.NoError(t, err)
+	assert.Equal(t, stateUpdating, updated.Status)
+
+	got, _ = m.GetCache(ctx, "cache1")
+	assert.Equal(t, stateUpdating, got.Status)
+
+	fc.Advance(settle.DefaultCacheModifySettle)
+	got, _ = m.GetCache(ctx, "cache1")
+	assert.Equal(t, stateReady, got.Status)
+}
+
+// TestAsyncSettleDefaultOff confirms the default (AsyncSettle unset) path is
+// byte-for-byte synchronous: create and update are observed as READY
+// immediately, with no transient state.
+func TestAsyncSettleDefaultOff(t *testing.T) {
+	m, _ := newTestMock() // no WithAsyncSettle
+	ctx := context.Background()
+
+	created, err := m.CreateCache(ctx, driver.CacheConfig{Name: "cache1"})
+	require.NoError(t, err)
+	assert.Equal(t, stateReady, created.Status)
+
+	got, err := m.GetCache(ctx, "cache1")
+	require.NoError(t, err)
+	assert.Equal(t, stateReady, got.Status)
+
+	updated, err := m.UpdateCache(ctx, driver.CacheConfig{Name: "cache1", NodeType: "M3"})
+	require.NoError(t, err)
+	assert.Equal(t, stateReady, updated.Status)
+}

--- a/providers/gcp/memorystore/memorystore.go
+++ b/providers/gcp/memorystore/memorystore.go
@@ -14,13 +14,22 @@ import (
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	cacheengine "github.com/stackshy/cloudemu/v2/services/cache/cacheengine"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
-const defaultRedisPort = 6379
+const (
+	defaultRedisPort = 6379
+
+	// Real Memorystore Redis instance states (Instance.state enum). The mock
+	// stores the terminal READY and overlays the transient states via settle.
+	stateCreating = "CREATING"
+	stateReady    = "READY"
+	stateUpdating = "UPDATING"
+)
 
 // privateHostIP derives a deterministic private IPv4 in the 10/8 block for a
 // Memorystore instance's exposed Redis endpoint. Real Memorystore hands clients
@@ -56,7 +65,15 @@ type cacheData struct {
 
 // Mock is an in-memory mock implementation of GCP Memorystore.
 type Mock struct {
-	caches     *memstore.Store[*cacheData]
+	caches *memstore.Store[*cacheData]
+
+	// instSettle overlays a transient CREATING / UPDATING window (keyed by the
+	// instance self-link) over an instance's stored READY status so create/update
+	// report the real GCP intermediate state before settling. It is a no-op
+	// unless config.Options.AsyncSettle is set (SettleDuration returns 0 →
+	// inactive window → historical synchronous behavior). The Set has its own lock.
+	instSettle *settle.Set
+
 	opts       *config.Options
 	monitoring mondriver.Monitoring
 }
@@ -87,9 +104,17 @@ func (m *Mock) emitMetric(ctx context.Context, metricName string, value float64,
 // New creates a new Memorystore mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		caches: memstore.New[*cacheData](),
-		opts:   opts,
+		caches:     memstore.New[*cacheData](),
+		instSettle: settle.NewSet(),
+		opts:       opts,
 	}
+}
+
+// settleStatus overlays an instance's settle window (if any, keyed by self-link)
+// onto its stored terminal status: the transient value while the window is
+// active and unelapsed, otherwise final. Absent window → final.
+func (m *Mock) settleStatus(selfLink, final string) string {
+	return m.instSettle.State(selfLink, m.opts.Clock.Now(), final)
 }
 
 // CreateCache creates a new Memorystore instance.
@@ -125,7 +150,7 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 		Scope:     cfg.Scope,
 		NodeType:  nodeType,
 		Engine:    engine,
-		Status:    "READY",
+		Status:    stateReady,
 		Endpoint:  endpoint,
 		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
 		Tags:      tags,
@@ -144,7 +169,15 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 
 	m.caches.Set(cfg.Name, cd)
 
+	// Under AsyncSettle a fresh instance reports CREATING until the window
+	// elapses, matching real Memorystore (instances.create → CREATING → READY).
+	// With the default (AsyncSettle off) SettleDuration is 0 → inactive window →
+	// READY immediately, so nothing changes for existing callers.
+	m.instSettle.Begin(selfLink, stateCreating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultCacheSettle))
+
 	result := info
+	result.Status = m.settleStatus(selfLink, result.Status)
 
 	return &result, nil
 }
@@ -162,6 +195,7 @@ func (m *Mock) DeleteCache(ctx context.Context, name string) error {
 	}
 
 	m.caches.Delete(name)
+	m.instSettle.Clear(cd.info.Name)
 
 	return nil
 }
@@ -174,6 +208,7 @@ func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, erro
 	}
 
 	result := cd.info
+	result.Status = m.settleStatus(cd.info.Name, result.Status)
 
 	return &result, nil
 }
@@ -187,7 +222,10 @@ func (m *Mock) ListCaches(_ context.Context, filter scope.Scope) ([]driver.Cache
 		if !cd.info.Scope.Matches(filter) {
 			continue
 		}
-		caches = append(caches, cd.info)
+
+		info := cd.info
+		info.Status = m.settleStatus(cd.info.Name, info.Status)
+		caches = append(caches, info)
 	}
 
 	return caches, nil
@@ -214,7 +252,14 @@ func (m *Mock) UpdateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 
 	m.caches.Set(cfg.Name, cd)
 
+	// Under AsyncSettle an updated instance briefly reports UPDATING before
+	// settling back to READY, matching real Memorystore (instances.patch →
+	// UPDATING → READY); a no-op when settle is off.
+	m.instSettle.Begin(cd.info.Name, stateUpdating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultCacheModifySettle))
+
 	result := cd.info
+	result.Status = m.settleStatus(cd.info.Name, result.Status)
 
 	return &result, nil
 }

--- a/server/gcp/cloudsql/async_settle_sdk_test.go
+++ b/server/gcp/cloudsql/async_settle_sdk_test.go
@@ -1,0 +1,109 @@
+package cloudsql_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"google.golang.org/api/option"
+	sqladmin "google.golang.org/api/sqladmin/v1"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
+	cloudsqlprovider "github.com/stackshy/cloudemu/v2/providers/gcp/cloudsql"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// newAsyncSDKClient stands up the Cloud SQL wire handler over a provider with
+// AsyncSettle enabled and a FakeClock, so a real sqladmin SDK client observes
+// the transient PENDING_CREATE state before the settle window elapses.
+func newAsyncSDKClient(t *testing.T) (*sqladmin.Service, *config.FakeClock, string) {
+	t.Helper()
+
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("us-central1"),
+		config.WithProjectID("mock-project"),
+		config.WithAsyncSettle(),
+	)
+
+	srv := gcpserver.New(gcpserver.Drivers{CloudSQL: cloudsqlprovider.New(opts)})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := sqladmin.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("sqladmin.NewService: %v", err)
+	}
+
+	return svc, fc, "mock-project"
+}
+
+// TestSDKCloudSQLAsyncSettle drives the real sqladmin SDK against the wire
+// handler and asserts the create/patch transitions surface real Cloud SQL
+// states: PENDING_CREATE → RUNNABLE on insert, MAINTENANCE → RUNNABLE on patch.
+func TestSDKCloudSQLAsyncSettle(t *testing.T) {
+	svc, fc, project := newAsyncSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := svc.Instances.Insert(project, &sqladmin.DatabaseInstance{
+		Name:            "orders",
+		DatabaseVersion: "POSTGRES_15",
+		Region:          "us-central1",
+		Settings:        &sqladmin.Settings{Tier: "db-custom-2-8192"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Instances.Insert: %v", err)
+	}
+
+	got, err := svc.Instances.Get(project, "orders").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Instances.Get before settle: %v", err)
+	}
+
+	if got.State != "PENDING_CREATE" {
+		t.Fatalf("state before settle = %q, want PENDING_CREATE", got.State)
+	}
+
+	fc.Advance(settle.DefaultCloudSQLSettle + time.Second)
+
+	got, err = svc.Instances.Get(project, "orders").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Instances.Get after settle: %v", err)
+	}
+
+	if got.State != "RUNNABLE" {
+		t.Fatalf("state after settle = %q, want RUNNABLE", got.State)
+	}
+
+	// Patch → MAINTENANCE → RUNNABLE.
+	if _, err := svc.Instances.Patch(project, "orders", &sqladmin.DatabaseInstance{
+		Settings: &sqladmin.Settings{Tier: "db-custom-4-16384"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Instances.Patch: %v", err)
+	}
+
+	got, err = svc.Instances.Get(project, "orders").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Instances.Get during patch: %v", err)
+	}
+
+	if got.State != "MAINTENANCE" {
+		t.Fatalf("state during patch = %q, want MAINTENANCE", got.State)
+	}
+
+	fc.Advance(settle.DefaultCloudSQLSettle + time.Second)
+
+	got, err = svc.Instances.Get(project, "orders").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Instances.Get after patch settle: %v", err)
+	}
+
+	if got.State != "RUNNABLE" {
+		t.Fatalf("state after patch settle = %q, want RUNNABLE", got.State)
+	}
+}


### PR DESCRIPTION
## Summary

Adopt the shared `settle.Set` async-lifecycle overlay in GCP **Cloud SQL** and **Memorystore** so create/modify/restart report real transient GCP states instead of jumping straight to the terminal state.

- **Cloud SQL** (`providers/gcp/cloudsql`): create -> `PENDING_CREATE`, patch/restart -> `MAINTENANCE`, then `RUNNABLE`. Overlay applied on every read surface (`DescribeInstances`, create/modify returns); window cleared on start/stop and delete. The existing wire state mapping (`StateCreating->PENDING_CREATE`, `StateModifying/Rebooting->MAINTENANCE`) surfaces the transient state to SDK clients with no handler change.
- **Memorystore** (`providers/gcp/memorystore`): create -> `CREATING`, update -> `UPDATING`, then `READY`. Overlay applied on `GetCache`/`ListCaches` and create/update returns (keyed by instance self-link); window cleared on delete. The wire `stateOrReady` passthrough surfaces the transient state.

## Gating (default-off, unchanged behavior)

Gated behind the existing `config.Options.AsyncSettle` / `SettleDuration`. With the default (AsyncSettle off), `SettleDuration` returns 0 -> inactive window -> resources are observed in their terminal `RUNNABLE`/`READY` state immediately, byte-for-byte the historical synchronous behavior. No new flag; no existing test flips.

## Tests

- Provider-level FakeClock tests (create/modify/restart transient -> advance clock -> terminal) plus explicit default-off (synchronous) assertions, in both packages.
- Real-SDK wire test (`server/gcp/cloudsql`) driving `sqladmin` against the wire handler: insert -> `PENDING_CREATE` -> advance -> `RUNNABLE`; patch -> `MAINTENANCE` -> advance -> `RUNNABLE`.

Gates: `go build ./...`, `gofmt -l` empty, `go test ./providers/gcp/... ./server/gcp/... -race`, full `go test ./...` (exit 0), `golangci-lint --new-from-rev=origin/development` (0 new), coveragegen clean, `go mod tidy` clean.