### PR TITLE
feat(azure-blob): soft-delete + undelete

### DIFF
--- a/docs/coverage/azure/blobstorage.md
+++ b/docs/coverage/azure/blobstorage.md
@@ -85,6 +85,16 @@ AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
 | `SetContainerMetadata` | SetContainerMetadata replaces a container's metadata (Set Container |
 | `StageBlock` | StageBlock buffers an uncommitted block (Put Block, ?comp=block) for a blob |
 
+### AzureSoftDeleteBlob
+
+AzureSoftDeleteBlob is an OPTIONAL Azure-specific capability, discovered by
+
+| Operation | Description |
+| --- | --- |
+| `ListDeletedBlobs` | ListDeletedBlobs returns the soft-deleted blobs matching opts, so a List |
+| `SoftDeleteEnabled` | SoftDeleteEnabled reports whether soft delete is currently in effect for |
+| `UndeleteBlob` | UndeleteBlob restores a soft-deleted blob to active (PUT ?comp=undelete). |
+
 ### AzureVersionedBlob
 
 AzureVersionedBlob is an OPTIONAL Azure-specific capability, discovered by

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -12531,6 +12531,24 @@
         ]
       },
       {
+        "name": "AzureSoftDeleteBlob",
+        "doc": "AzureSoftDeleteBlob is an OPTIONAL Azure-specific capability, discovered by",
+        "operations": [
+          {
+            "name": "ListDeletedBlobs",
+            "doc": "ListDeletedBlobs returns the soft-deleted blobs matching opts, so a List"
+          },
+          {
+            "name": "SoftDeleteEnabled",
+            "doc": "SoftDeleteEnabled reports whether soft delete is currently in effect for"
+          },
+          {
+            "name": "UndeleteBlob",
+            "doc": "UndeleteBlob restores a soft-deleted blob to active (PUT ?comp=undelete)."
+          }
+        ]
+      },
+      {
         "name": "AzureVersionedBlob",
         "doc": "AzureVersionedBlob is an OPTIONAL Azure-specific capability, discovered by",
         "operations": [

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -58,6 +58,14 @@ type blobObject struct {
 	// AccessTier is the blob access tier (Hot/Cool/Cold/Archive), set by Set Blob
 	// Tier; empty when unset.
 	AccessTier string
+	// DeletedTime is when this blob was soft-deleted (blob time format, UTC),
+	// stamped when it moves into the container's soft-deleted store. Empty on a
+	// live blob.
+	DeletedTime string
+	// deletedRetentionDays is the account retention window (days) captured at
+	// soft-delete time, used to count down RemainingRetentionDays independent of a
+	// later policy change. Zero on a live blob.
+	deletedRetentionDays int
 	// Content* are additional system properties settable via Set Blob Properties.
 	ContentEncoding    string
 	ContentLanguage    string
@@ -134,6 +142,11 @@ type containerMeta struct {
 	// container level so a version survives a base-blob overwrite or delete,
 	// matching real Azure version lifetime.
 	versions *memstore.Store[*blobObject]
+	// softDeleted holds soft-deleted blobs keyed by blob name when the account
+	// delete-retention policy is enabled. A Delete Blob moves the live blob here
+	// (retaining its bytes) instead of removing it; Undelete Blob moves it back,
+	// and the retention window purges it lazily.
+	softDeleted *memstore.Store[*blobObject]
 	// mu guards snapshotSeq/versionSeq (and any future container-scoped counters).
 	mu          sync.Mutex
 	snapshotSeq int
@@ -326,14 +339,15 @@ func (m *Mock) CreateBucket(_ context.Context, name string) error {
 	}
 
 	m.containers.Set(name, &containerMeta{
-		Name:       name,
-		Region:     m.opts.Region,
-		CreatedAt:  m.opts.Clock.Now().UTC().Format(blobTimeFormat),
-		objects:    memstore.New[*blobObject](),
-		multiparts: memstore.New[*blobMultipartUpload](),
-		staging:    memstore.New[*blockStaging](),
-		snapshots:  memstore.New[*blobObject](),
-		versions:   memstore.New[*blobObject](),
+		Name:        name,
+		Region:      m.opts.Region,
+		CreatedAt:   m.opts.Clock.Now().UTC().Format(blobTimeFormat),
+		objects:     memstore.New[*blobObject](),
+		multiparts:  memstore.New[*blobMultipartUpload](),
+		staging:     memstore.New[*blockStaging](),
+		snapshots:   memstore.New[*blobObject](),
+		versions:    memstore.New[*blobObject](),
+		softDeleted: memstore.New[*blobObject](),
 	})
 
 	return nil
@@ -535,6 +549,18 @@ func (m *Mock) DeleteObject(ctx context.Context, bucket, key string) error {
 	obj, ok := ctr.objects.Get(key)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "blob %q not found in container %q", key, bucket)
+	}
+
+	// When soft delete is in effect, a Delete Blob retains the blob (bytes and
+	// all) in the container's soft-deleted store rather than removing it, so
+	// Undelete can restore it within the retention window. The active byte purge
+	// below is skipped precisely because the bytes must survive.
+	if retentionDays, soft := m.softDeleteActive(); soft {
+		m.softDeleteObject(ctr, key, obj, retentionDays)
+		m.emitMetric(bucket, map[string]float64{"Transactions": 1})
+		m.emitBlobDeleted(ctx, obj, bucket)
+
+		return nil
 	}
 
 	ctr.objects.Delete(key)

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -148,6 +148,12 @@ type containerMeta struct {
 	// and the retention window purges it lazily.
 	softDeleted *memstore.Store[*blobObject]
 	// mu guards snapshotSeq/versionSeq (and any future container-scoped counters).
+	// It ALSO serializes every objects↔softDeleted transition (soft delete and
+	// Undelete) so a blob is atomically moved between the two stores: without one
+	// lock spanning both writes, a racing Delete and Undelete on the same blob can
+	// interleave their independent per-store writes and leave the blob in NEITHER
+	// store (permanent data loss). Held only across the two-store mutation, never
+	// while emitting metrics/events.
 	mu          sync.Mutex
 	snapshotSeq int
 	versionSeq  int

--- a/providers/azure/blobstorage/snapshot.go
+++ b/providers/azure/blobstorage/snapshot.go
@@ -43,6 +43,7 @@ type containerSnapshot struct {
 	Objects        map[string]*blobObjectSnapshot `json:"objects,omitempty"`
 	Snapshots      map[string]*blobObjectSnapshot `json:"snapshots,omitempty"`
 	Versions       map[string]*blobObjectSnapshot `json:"versions,omitempty"`
+	SoftDeleted    map[string]*blobObjectSnapshot `json:"softDeleted,omitempty"`
 }
 
 // blobObjectSnapshot mirrors blobObject, promoting its meaningful unexported
@@ -60,6 +61,8 @@ type blobObjectSnapshot struct {
 	BlobType              string             `json:"blobType,omitempty"`
 	VersionID             string             `json:"versionId,omitempty"`
 	AccessTier            string             `json:"accessTier,omitempty"`
+	DeletedTime           string             `json:"deletedTime,omitempty"`
+	DeletedRetentionDays  int                `json:"deletedRetentionDays,omitempty"`
 	ContentEncoding       string             `json:"contentEncoding,omitempty"`
 	ContentLanguage       string             `json:"contentLanguage,omitempty"`
 	ContentDisposition    string             `json:"contentDisposition,omitempty"`
@@ -119,9 +122,10 @@ func snapshotContainer(c *containerMeta, includeAssets bool) *containerSnapshot 
 		Versioning: c.versioning, Lifecycle: c.lifecycle, Policy: c.policy,
 		CORS: c.corsConfig, Encryption: c.encryption, Tags: c.tags,
 		Metadata: c.metadata, PublicAccess: c.publicAccess, AccessPolicies: c.accessPolicies,
-		Objects:   make(map[string]*blobObjectSnapshot, c.objects.Len()),
-		Snapshots: make(map[string]*blobObjectSnapshot, c.snapshots.Len()),
-		Versions:  make(map[string]*blobObjectSnapshot, c.versions.Len()),
+		Objects:     make(map[string]*blobObjectSnapshot, c.objects.Len()),
+		Snapshots:   make(map[string]*blobObjectSnapshot, c.snapshots.Len()),
+		Versions:    make(map[string]*blobObjectSnapshot, c.versions.Len()),
+		SoftDeleted: make(map[string]*blobObjectSnapshot, c.softDeleted.Len()),
 	}
 
 	c.mu.Lock()
@@ -141,6 +145,10 @@ func snapshotContainer(c *containerMeta, includeAssets bool) *containerSnapshot 
 		cs.Versions[key] = snapshotBlob(obj, includeAssets)
 	}
 
+	for key, obj := range c.softDeleted.All() {
+		cs.SoftDeleted[key] = snapshotBlob(obj, includeAssets)
+	}
+
 	return cs
 }
 
@@ -157,6 +165,7 @@ func snapshotBlob(obj *blobObject, includeAssets bool) *blobObjectSnapshot {
 		Key: obj.Key, Data: data, Size: obj.Size, ContentType: obj.ContentType,
 		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata, Tags: obj.Tags,
 		BlobType: obj.BlobType, VersionID: obj.VersionID, AccessTier: obj.AccessTier, ContentEncoding: obj.ContentEncoding,
+		DeletedTime: obj.DeletedTime, DeletedRetentionDays: obj.deletedRetentionDays,
 		ContentLanguage: obj.ContentLanguage, ContentDisposition: obj.ContentDisposition,
 		CacheControl: obj.CacheControl, CommittedBlocks: obj.CommittedBlocks, AppendBlocks: obj.appendBlocks,
 		LeaseState: obj.leaseState, LeaseID: obj.leaseID, LeaseDurationSec: obj.leaseDurationSec,
@@ -216,6 +225,7 @@ func restoreContainer(cs *containerSnapshot) *containerMeta {
 		staging:     memstore.New[*blockStaging](),
 		snapshots:   memstore.New[*blobObject](),
 		versions:    memstore.New[*blobObject](),
+		softDeleted: memstore.New[*blobObject](),
 		snapshotSeq: cs.SnapshotSeq,
 		versionSeq:  cs.VersionSeq,
 	}
@@ -232,6 +242,10 @@ func restoreContainer(cs *containerSnapshot) *containerMeta {
 		c.versions.Set(key, restoreBlob(os))
 	}
 
+	for key, os := range cs.SoftDeleted {
+		c.softDeleted.Set(key, restoreBlob(os))
+	}
+
 	return c
 }
 
@@ -240,6 +254,7 @@ func restoreBlob(os *blobObjectSnapshot) *blobObject {
 		Key: os.Key, Data: os.Data, Size: os.Size, ContentType: os.ContentType,
 		ETag: os.ETag, LastModified: os.LastModified, Metadata: os.Metadata, Tags: os.Tags,
 		BlobType: os.BlobType, VersionID: os.VersionID, AccessTier: os.AccessTier, ContentEncoding: os.ContentEncoding,
+		DeletedTime: os.DeletedTime, deletedRetentionDays: os.DeletedRetentionDays,
 		ContentLanguage: os.ContentLanguage, ContentDisposition: os.ContentDisposition,
 		CacheControl: os.CacheControl, CommittedBlocks: os.CommittedBlocks, appendBlocks: os.AppendBlocks,
 		leaseState: os.LeaseState, leaseID: os.LeaseID, leaseDurationSec: os.LeaseDurationSec,

--- a/providers/azure/blobstorage/softdelete.go
+++ b/providers/azure/blobstorage/softdelete.go
@@ -1,0 +1,143 @@
+package blobstorage
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// Compile-time check that Mock satisfies the optional AzureSoftDeleteBlob
+// capability the blob wire handler reaches by type assertion.
+var _ driver.AzureSoftDeleteBlob = (*Mock)(nil)
+
+// softDeleteActive reports whether a Delete Blob should soft-delete rather than
+// hard-delete, returning the retention window (days) to stamp on the retained
+// blob. Soft delete engages only when the account delete-retention policy is
+// enabled with a positive day count AND account versioning is off: with
+// versioning on, retained versions are the recovery mechanism, so a delete
+// leaves them intact instead of soft-deleting the base blob.
+func (m *Mock) softDeleteActive() (retentionDays int, active bool) {
+	props, _ := m.blobServiceProps.Get(AccountName)
+
+	if !props.DeleteRetentionEnabled || props.DeleteRetentionDays <= 0 || props.IsVersioningEnabled {
+		return 0, false
+	}
+
+	return props.DeleteRetentionDays, true
+}
+
+// SoftDeleteEnabled implements driver.AzureSoftDeleteBlob.
+func (m *Mock) SoftDeleteEnabled(_ context.Context) (bool, error) {
+	_, active := m.softDeleteActive()
+
+	return active, nil
+}
+
+// softDeleteObject moves a live blob into the container's soft-deleted store,
+// stamping the deletion time and the retention window so RemainingRetentionDays
+// can count down. The caller has already confirmed soft delete is active.
+func (m *Mock) softDeleteObject(ctr *containerMeta, key string, obj *blobObject, retentionDays int) {
+	retained := cloneBlobObject(obj)
+	retained.DeletedTime = m.opts.Clock.Now().UTC().Format(blobTimeFormat)
+	retained.deletedRetentionDays = retentionDays
+
+	ctr.objects.Delete(key)
+	ctr.softDeleted.Set(key, retained)
+}
+
+// remainingRetentionDays returns the whole days left before a soft-deleted blob
+// is permanently purged, and whether it has already expired (window elapsed).
+func remainingRetentionDays(obj *blobObject, now time.Time) (remaining int, expired bool) {
+	deleted, err := time.Parse(blobTimeFormat, obj.DeletedTime)
+	if err != nil {
+		// A soft-deleted record always carries a parseable DeletedTime; treat an
+		// unparseable one as freshly deleted rather than silently purging it.
+		return obj.deletedRetentionDays, false
+	}
+
+	const hoursPerDay = 24
+
+	elapsedDays := int(now.Sub(deleted).Hours()) / hoursPerDay
+	remaining = obj.deletedRetentionDays - elapsedDays
+
+	return remaining, remaining <= 0
+}
+
+// UndeleteBlob implements driver.AzureSoftDeleteBlob, restoring a soft-deleted
+// blob to active. It is a no-op success when the blob is already active (nothing
+// soft-deleted), and NotFound when neither an active nor a live soft-deleted
+// blob of that name exists.
+func (m *Mock) UndeleteBlob(_ context.Context, container, blob string) error {
+	ctr, ok := m.containers.Get(container)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", container)
+	}
+
+	retained, ok := ctr.softDeleted.Get(blob)
+	if !ok {
+		if ctr.objects.Has(blob) {
+			return nil // already active — Undelete is a no-op
+		}
+
+		return cerrors.Newf(cerrors.NotFound, "blob %q not found in container %q", blob, container)
+	}
+
+	if _, expired := remainingRetentionDays(retained, m.opts.Clock.Now().UTC()); expired {
+		ctr.softDeleted.Delete(blob)
+
+		return cerrors.Newf(cerrors.NotFound, "blob %q not found in container %q", blob, container)
+	}
+
+	restored := cloneBlobObject(retained)
+	restored.DeletedTime = ""
+	restored.deletedRetentionDays = 0
+
+	ctr.objects.Set(blob, restored)
+	ctr.softDeleted.Delete(blob)
+
+	return nil
+}
+
+// ListDeletedBlobs implements driver.AzureSoftDeleteBlob, returning the
+// soft-deleted blobs matching opts.Prefix, sorted by name. Records whose
+// retention window has elapsed are purged and omitted (lazy expiry — there is no
+// background sweeper).
+func (m *Mock) ListDeletedBlobs(
+	_ context.Context, container string, opts driver.ListOptions,
+) (*driver.DeletedBlobListResult, error) {
+	ctr, ok := m.containers.Get(container)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
+	}
+
+	now := m.opts.Clock.Now().UTC()
+
+	var blobs []driver.DeletedBlob
+
+	for _, key := range ctr.softDeleted.Keys() {
+		obj, objOk := ctr.softDeleted.Get(key)
+		if !objOk || !matchesPrefix(obj.Key, opts.Prefix) {
+			continue
+		}
+
+		remaining, expired := remainingRetentionDays(obj, now)
+		if expired {
+			ctr.softDeleted.Delete(key)
+
+			continue
+		}
+
+		blobs = append(blobs, driver.DeletedBlob{
+			Info:                   objectInfo(obj),
+			DeletedTime:            obj.DeletedTime,
+			RemainingRetentionDays: remaining,
+		})
+	}
+
+	sort.Slice(blobs, func(i, j int) bool { return blobs[i].Info.Key < blobs[j].Info.Key })
+
+	return &driver.DeletedBlobListResult{Blobs: blobs}, nil
+}

--- a/providers/azure/blobstorage/softdelete.go
+++ b/providers/azure/blobstorage/softdelete.go
@@ -39,10 +39,19 @@ func (m *Mock) SoftDeleteEnabled(_ context.Context) (bool, error) {
 // softDeleteObject moves a live blob into the container's soft-deleted store,
 // stamping the deletion time and the retention window so RemainingRetentionDays
 // can count down. The caller has already confirmed soft delete is active.
+//
+// The objects.Delete + softDeleted.Set pair runs under ctr.mu — the same lock
+// UndeleteBlob takes for the reverse move — so the blob is transferred between
+// the two stores atomically. Without it a racing Delete and Undelete on the same
+// blob could interleave their per-store writes and drop the blob from BOTH
+// stores (permanent loss).
 func (m *Mock) softDeleteObject(ctr *containerMeta, key string, obj *blobObject, retentionDays int) {
 	retained := cloneBlobObject(obj)
 	retained.DeletedTime = m.opts.Clock.Now().UTC().Format(blobTimeFormat)
 	retained.deletedRetentionDays = retentionDays
+
+	ctr.mu.Lock()
+	defer ctr.mu.Unlock()
 
 	ctr.objects.Delete(key)
 	ctr.softDeleted.Set(key, retained)
@@ -75,6 +84,14 @@ func (m *Mock) UndeleteBlob(_ context.Context, container, blob string) error {
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "container %q not found", container)
 	}
+
+	// The whole read-check-move runs under ctr.mu — the same lock softDeleteObject
+	// takes — so the soft-deleted lookup and the softDeleted→objects transfer are
+	// one atomic critical section against a racing Delete on the same blob. The
+	// objects.Set precedes softDeleted.Delete so a concurrent reader sees the blob
+	// in both stores at worst, never in neither.
+	ctr.mu.Lock()
+	defer ctr.mu.Unlock()
 
 	retained, ok := ctr.softDeleted.Get(blob)
 	if !ok {

--- a/providers/azure/blobstorage/softdelete_test.go
+++ b/providers/azure/blobstorage/softdelete_test.go
@@ -1,0 +1,209 @@
+package blobstorage
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// enableSoftDelete turns on the account delete-retention policy (days) for the
+// single account the data plane models.
+func enableSoftDelete(t *testing.T, m *Mock, days int) {
+	t.Helper()
+	require.NoError(t, m.SetBlobServiceProperties(context.Background(), AccountName,
+		driver.BlobServiceProperties{DeleteRetentionEnabled: true, DeleteRetentionDays: days}))
+}
+
+func TestSoftDeleteRetainsAndUndeletes(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newMock()
+	enableSoftDelete(t, m, 7)
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+
+	active, err := m.SoftDeleteEnabled(ctx)
+	require.NoError(t, err)
+	assert.True(t, active)
+
+	require.NoError(t, m.PutObject(ctx, "c1", "k1", []byte("hello"), "text/plain", nil))
+
+	// Delete retains the blob: base read now fails, but it surfaces under the
+	// deleted listing with the full retention window remaining.
+	require.NoError(t, m.DeleteObject(ctx, "c1", "k1"))
+
+	_, err = m.HeadObject(ctx, "c1", "k1")
+	require.Error(t, err)
+	assert.True(t, cerrors.IsNotFound(err))
+
+	del, err := m.ListDeletedBlobs(ctx, "c1", driver.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, del.Blobs, 1)
+	assert.Equal(t, "k1", del.Blobs[0].Info.Key)
+	assert.Equal(t, 7, del.Blobs[0].RemainingRetentionDays)
+	assert.NotEmpty(t, del.Blobs[0].DeletedTime)
+
+	// The live listing omits it.
+	live, err := m.ListObjects(ctx, "c1", driver.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, live.Objects)
+
+	// Undelete restores it to active with its bytes intact.
+	require.NoError(t, m.UndeleteBlob(ctx, "c1", "k1"))
+
+	got, err := m.GetObject(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(got.Data))
+
+	del, err = m.ListDeletedBlobs(ctx, "c1", driver.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, del.Blobs)
+}
+
+func TestSoftDeleteDisabledHardDeletes(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+
+	active, err := m.SoftDeleteEnabled(ctx)
+	require.NoError(t, err)
+	assert.False(t, active)
+
+	require.NoError(t, m.PutObject(ctx, "c1", "k1", []byte("hello"), "text/plain", nil))
+	require.NoError(t, m.DeleteObject(ctx, "c1", "k1"))
+
+	del, err := m.ListDeletedBlobs(ctx, "c1", driver.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, del.Blobs)
+
+	// Undelete has nothing to restore -> NotFound.
+	err = m.UndeleteBlob(ctx, "c1", "k1")
+	require.Error(t, err)
+	assert.True(t, cerrors.IsNotFound(err))
+}
+
+// TestSoftDeleteRetentionExpiry advances the fake clock past the retention
+// window: the soft-deleted blob is then purged from the deleted listing and can
+// no longer be undeleted.
+func TestSoftDeleteRetentionExpiry(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newMock()
+	enableSoftDelete(t, m, 3)
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+
+	require.NoError(t, m.PutObject(ctx, "c1", "k1", []byte("hello"), "text/plain", nil))
+	require.NoError(t, m.DeleteObject(ctx, "c1", "k1"))
+
+	// One day in: two days remain.
+	clk.Advance(24 * time.Hour)
+	del, err := m.ListDeletedBlobs(ctx, "c1", driver.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, del.Blobs, 1)
+	assert.Equal(t, 2, del.Blobs[0].RemainingRetentionDays)
+
+	// Past the window: purged and un-undeletable.
+	clk.Advance(3 * 24 * time.Hour)
+	del, err = m.ListDeletedBlobs(ctx, "c1", driver.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, del.Blobs)
+
+	err = m.UndeleteBlob(ctx, "c1", "k1")
+	require.Error(t, err)
+	assert.True(t, cerrors.IsNotFound(err))
+}
+
+// TestSoftDeleteVersioningTakesPrecedence confirms that when versioning is also
+// enabled a delete keeps versions (not soft delete) as the recovery path.
+func TestSoftDeleteVersioningTakesPrecedence(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newMock()
+	require.NoError(t, m.SetBlobServiceProperties(ctx, AccountName, driver.BlobServiceProperties{
+		IsVersioningEnabled: true, DeleteRetentionEnabled: true, DeleteRetentionDays: 7,
+	}))
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+
+	active, err := m.SoftDeleteEnabled(ctx)
+	require.NoError(t, err)
+	assert.False(t, active, "versioning takes precedence over soft delete")
+
+	require.NoError(t, m.PutObject(ctx, "c1", "k1", []byte("v1"), "text/plain", nil))
+	require.NoError(t, m.DeleteObject(ctx, "c1", "k1"))
+
+	// The version is retained; nothing lands in the soft-deleted store.
+	vers, err := m.ListBlobVersions(ctx, "c1", driver.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, vers.Versions, 1)
+
+	del, err := m.ListDeletedBlobs(ctx, "c1", driver.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, del.Blobs)
+}
+
+// TestSoftDeletePersistRoundTrip confirms a soft-deleted blob survives a
+// Snapshot/Restore and can still be undeleted afterward.
+func TestSoftDeletePersistRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newMock()
+	enableSoftDelete(t, m, 5)
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+	require.NoError(t, m.PutObject(ctx, "c1", "k1", []byte("hello"), "text/plain", nil))
+	require.NoError(t, m.DeleteObject(ctx, "c1", "k1"))
+
+	snap, err := m.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	m2, _ := newMock()
+	require.NoError(t, m2.Restore(ctx, snap))
+
+	del, err := m2.ListDeletedBlobs(ctx, "c1", driver.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, del.Blobs, 1)
+	assert.Equal(t, "k1", del.Blobs[0].Info.Key)
+
+	require.NoError(t, m2.UndeleteBlob(ctx, "c1", "k1"))
+	got, err := m2.GetObject(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(got.Data))
+}
+
+// TestSoftDeleteConcurrent exercises concurrent deletes and undeletes across
+// distinct blobs under -race to prove the soft-delete store is write-safe.
+func TestSoftDeleteConcurrent(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newMock()
+	enableSoftDelete(t, m, 7)
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+
+	const n = 20
+
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = "k" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+		require.NoError(t, m.PutObject(ctx, "c1", keys[i], []byte("v"), "text/plain", nil))
+	}
+
+	var wg sync.WaitGroup
+	for _, k := range keys {
+		wg.Add(1)
+		go func(key string) {
+			defer wg.Done()
+			_ = m.DeleteObject(ctx, "c1", key)
+			_ = m.UndeleteBlob(ctx, "c1", key)
+		}(k)
+	}
+	wg.Wait()
+
+	// Every blob is active again; none is left soft-deleted.
+	del, err := m.ListDeletedBlobs(ctx, "c1", driver.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, del.Blobs)
+
+	live, err := m.ListObjects(ctx, "c1", driver.ListOptions{MaxKeys: n})
+	require.NoError(t, err)
+	assert.Len(t, live.Objects, n)
+}

--- a/providers/azure/blobstorage/softdelete_test.go
+++ b/providers/azure/blobstorage/softdelete_test.go
@@ -207,3 +207,75 @@ func TestSoftDeleteConcurrent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, live.Objects, n)
 }
+
+// blobInLive reports whether the blob is present in the live objects store.
+func blobInLive(t *testing.T, ctx context.Context, m *Mock, container, blob string) bool {
+	t.Helper()
+	_, err := m.HeadObject(ctx, container, blob)
+
+	return err == nil
+}
+
+// blobInDeleted reports whether the blob is present in the soft-deleted store.
+func blobInDeleted(t *testing.T, ctx context.Context, m *Mock, container, blob string) bool {
+	t.Helper()
+	del, err := m.ListDeletedBlobs(ctx, container, driver.ListOptions{})
+	require.NoError(t, err)
+
+	for i := range del.Blobs {
+		if del.Blobs[i].Info.Key == blob {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestSoftDeleteSameKeyConcurrentNoLoss hammers the SAME blob key with racing
+// Delete-then-Undelete and Undelete-then-Delete sequences. The objects↔softDeleted
+// transition must be atomic under ctr.mu, so after every round the blob lands in
+// EXACTLY ONE store — never dropped from both (permanent loss) and never absent.
+// Repeated many rounds to surface the interleaving a distinct-key race can't.
+func TestSoftDeleteSameKeyConcurrentNoLoss(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		rounds  = 50
+		workers = 8
+		iters   = 25
+	)
+
+	for r := range rounds {
+		m, _ := newMock()
+		enableSoftDelete(t, m, 7)
+		require.NoError(t, m.CreateBucket(ctx, "c1"))
+		require.NoError(t, m.PutObject(ctx, "c1", "k1", []byte("hello"), "text/plain", nil))
+
+		var wg sync.WaitGroup
+		for w := range workers {
+			wg.Add(1)
+
+			go func(worker int) {
+				defer wg.Done()
+
+				for range iters {
+					if worker%2 == 0 {
+						_ = m.DeleteObject(ctx, "c1", "k1")
+						_ = m.UndeleteBlob(ctx, "c1", "k1")
+					} else {
+						_ = m.UndeleteBlob(ctx, "c1", "k1")
+						_ = m.DeleteObject(ctx, "c1", "k1")
+					}
+				}
+			}(w)
+		}
+
+		wg.Wait()
+
+		inLive := blobInLive(t, ctx, m, "c1", "k1")
+		inDeleted := blobInDeleted(t, ctx, m, "c1", "k1")
+		require.Truef(t, inLive != inDeleted,
+			"round %d: blob must be in exactly one store, never lost/double (live=%v deleted=%v)",
+			r, inLive, inDeleted)
+	}
+}

--- a/server/azure/blobstorage/blob_softdelete_test.go
+++ b/server/azure/blobstorage/blob_softdelete_test.go
@@ -1,0 +1,235 @@
+package blobstorage_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+
+	"github.com/stackshy/cloudemu/v2"
+	blobprovider "github.com/stackshy/cloudemu/v2/providers/azure/blobstorage"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// newSoftDeleteClient stands up an Azure blob wire server whose account has the
+// given Blob service properties, returning a real azblob client pointed at it.
+func newSoftDeleteClient(t *testing.T, props storagedriver.BlobServiceProperties) *azblob.Client {
+	t.Helper()
+
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	if err := cloudP.BlobStorage.SetBlobServiceProperties(ctx, blobprovider.AccountName, props); err != nil {
+		t.Fatalf("set blob service properties: %v", err)
+	}
+
+	srv := azureserver.New(azureserver.Drivers{BlobStorage: cloudP.BlobStorage})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := azblob.NewClientWithNoCredential(ts.URL+"/", &azblob.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewClientWithNoCredential: %v", err)
+	}
+
+	return client
+}
+
+// listDeleted returns the soft-deleted blobs of a container (List Blobs
+// include=deleted), keyed by name with their reported remaining retention days.
+func listDeleted(t *testing.T, ctx context.Context, ctr *container.Client) map[string]int32 {
+	t.Helper()
+
+	pager := ctr.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
+		Include: container.ListBlobsInclude{Deleted: true},
+	})
+
+	out := make(map[string]int32)
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("list include=deleted: %v", err)
+		}
+
+		for _, b := range page.Segment.BlobItems {
+			if b.Deleted == nil || !*b.Deleted {
+				continue
+			}
+
+			var remaining int32
+			if b.Properties != nil && b.Properties.RemainingRetentionDays != nil {
+				remaining = *b.Properties.RemainingRetentionDays
+			}
+
+			out[*b.Name] = remaining
+		}
+	}
+
+	return out
+}
+
+// TestSDKBlobSoftDelete drives the real azblob client through the soft-delete
+// lifecycle: with the account delete-retention policy enabled a Delete Blob
+// retains the blob (a normal list omits it, include=deleted surfaces it with a
+// remaining-retention countdown), and Undelete Blob restores it.
+func TestSDKBlobSoftDelete(t *testing.T) {
+	ctx := context.Background()
+
+	client := newSoftDeleteClient(t, storagedriver.BlobServiceProperties{
+		DeleteRetentionEnabled: true,
+		DeleteRetentionDays:    7,
+	})
+
+	if _, err := client.CreateContainer(ctx, "c1", nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	if _, err := client.UploadBuffer(ctx, "c1", "k1", []byte("hello"), nil); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+
+	// Delete with soft delete on -> retained, not removed.
+	if _, err := client.DeleteBlob(ctx, "c1", "k1", nil); err != nil {
+		t.Fatalf("delete blob: %v", err)
+	}
+
+	ctr := client.ServiceClient().NewContainerClient("c1")
+
+	// A normal list omits the soft-deleted blob.
+	if names := listBlobNames(t, ctx, ctr); len(names) != 0 {
+		t.Fatalf("normal list after delete = %v, want empty", names)
+	}
+
+	// A direct download of the soft-deleted blob fails (it is not active).
+	if _, err := client.DownloadStream(ctx, "c1", "k1", nil); err == nil {
+		t.Fatalf("download of soft-deleted blob should fail")
+	}
+
+	// include=deleted surfaces it with a remaining-retention countdown.
+	deleted := listDeleted(t, ctx, ctr)
+	if remaining, ok := deleted["k1"]; !ok {
+		t.Fatalf("soft-deleted blob k1 missing from include=deleted listing: %v", deleted)
+	} else if remaining != 7 {
+		t.Fatalf("RemainingRetentionDays = %d, want 7", remaining)
+	}
+
+	// Undelete restores the blob to active.
+	if _, err := ctr.NewBlobClient("k1").Undelete(ctx, nil); err != nil {
+		t.Fatalf("undelete: %v", err)
+	}
+
+	assertBlobBody(t, ctx, client, "c1", "k1", "hello")
+
+	if names := listBlobNames(t, ctx, ctr); len(names) != 1 || names[0] != "k1" {
+		t.Fatalf("list after undelete = %v, want [k1]", names)
+	}
+
+	if got := listDeleted(t, ctx, ctr); len(got) != 0 {
+		t.Fatalf("include=deleted after undelete = %v, want empty", got)
+	}
+}
+
+// TestSDKBlobSoftDeleteDisabledHardDeletes confirms that with no delete
+// retention policy a Delete Blob is a permanent hard delete (unchanged
+// behavior): the blob is gone and nothing surfaces under include=deleted.
+func TestSDKBlobSoftDeleteDisabledHardDeletes(t *testing.T) {
+	ctx := context.Background()
+
+	client := newSoftDeleteClient(t, storagedriver.BlobServiceProperties{})
+
+	if _, err := client.CreateContainer(ctx, "c1", nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	if _, err := client.UploadBuffer(ctx, "c1", "k1", []byte("hello"), nil); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+
+	if _, err := client.DeleteBlob(ctx, "c1", "k1", nil); err != nil {
+		t.Fatalf("delete blob: %v", err)
+	}
+
+	ctr := client.ServiceClient().NewContainerClient("c1")
+
+	if got := listDeleted(t, ctx, ctr); len(got) != 0 {
+		t.Fatalf("include=deleted with soft delete off = %v, want empty (hard delete)", got)
+	}
+
+	// Undelete of a hard-deleted blob has nothing to restore.
+	if _, err := ctr.NewBlobClient("k1").Undelete(ctx, nil); err == nil {
+		t.Fatalf("undelete of hard-deleted blob should fail")
+	}
+}
+
+// TestSDKBlobSoftDeleteCoexistsWithVersioning confirms that when versioning is
+// also enabled, deleting a blob keeps the version-based recovery path intact
+// (the version stays listable) rather than diverting to soft delete.
+func TestSDKBlobSoftDeleteCoexistsWithVersioning(t *testing.T) {
+	ctx := context.Background()
+
+	client := newSoftDeleteClient(t, storagedriver.BlobServiceProperties{
+		IsVersioningEnabled:    true,
+		DeleteRetentionEnabled: true,
+		DeleteRetentionDays:    7,
+	})
+
+	if _, err := client.CreateContainer(ctx, "c1", nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	up, err := client.UploadBuffer(ctx, "c1", "k1", []byte("v1"), nil)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if up.VersionID == nil || *up.VersionID == "" {
+		t.Fatalf("versioning enabled but upload returned no version id")
+	}
+
+	if _, err := client.DeleteBlob(ctx, "c1", "k1", nil); err != nil {
+		t.Fatalf("delete blob: %v", err)
+	}
+
+	ctr := client.ServiceClient().NewContainerClient("c1")
+
+	// With versioning on, the version is retained and listable; the base blob is
+	// not soft-deleted (versions are the recovery mechanism).
+	if got := listVersions(t, ctx, ctr); len(got) != 1 {
+		t.Fatalf("versions after delete = %d, want 1 (retained)", len(got))
+	}
+
+	if got := listDeleted(t, ctx, ctr); len(got) != 0 {
+		t.Fatalf("include=deleted with versioning on = %v, want empty", got)
+	}
+}
+
+// listBlobNames returns the live blob names of a container in listing order.
+func listBlobNames(t *testing.T, ctx context.Context, ctr *container.Client) []string {
+	t.Helper()
+
+	pager := ctr.NewListBlobsFlatPager(nil)
+
+	var names []string
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("list blobs: %v", err)
+		}
+
+		for _, b := range page.Segment.BlobItems {
+			names = append(names, *b.Name)
+		}
+	}
+
+	return names
+}

--- a/server/azure/blobstorage/handler.go
+++ b/server/azure/blobstorage/handler.go
@@ -511,6 +511,15 @@ func appendLiveBlobs(dst []blobXML, objects []storagedriver.ObjectInfo, includeM
 // include=deleted response, each marked Deleted=true with its DeletedTime and
 // RemainingRetentionDays, and re-sorts the combined blob list by name so live
 // and soft-deleted blobs interleave as real Azure returns them.
+//
+// Limitation (deferred): the soft-deleted set is appended on top of the already
+// maxresults-bounded live page rather than folded into one merged, uniformly
+// paginated live+deleted stream. Real Azure paginates the combined stream and
+// carries the deleted tail forward in the continuation marker; here the marker
+// tracks only the live listing, so a page can exceed maxresults by the deleted
+// count and the deleted tail is not itself continued. This matches real behavior
+// for the common small-container case; full merged-stream pagination is future
+// work (it needs a marker scheme that encodes both stream positions).
 func (*Handler) appendDeletedBlobs(
 	r *http.Request, ext storagedriver.AzureSoftDeleteBlob, container, prefix string, out *listBlobsResult,
 ) error {

--- a/server/azure/blobstorage/handler.go
+++ b/server/azure/blobstorage/handler.go
@@ -29,8 +29,10 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -67,6 +69,7 @@ const (
 	compLease       = "lease"
 	compTags        = "tags"
 	compPage        = "page"
+	compUndelete    = "undelete"
 
 	// blobTypePageBlob is the Azure page-blob type; cloudemu does not implement
 	// page-blob range semantics, so a page-blob create/write fails closed.
@@ -239,6 +242,11 @@ func (h *Handler) putBlobOp(w http.ResponseWriter, r *http.Request, container, b
 func (h *Handler) putBlobComp(w http.ResponseWriter, r *http.Request, container, blob, comp string) {
 	if comp == compTags {
 		h.setBlobTags(w, r, container, blob)
+		return
+	}
+
+	if comp == compUndelete {
+		h.undeleteBlob(w, r, container, blob)
 		return
 	}
 
@@ -450,9 +458,27 @@ func (h *Handler) listBlobs(w http.ResponseWriter, r *http.Request, container st
 	}
 
 	includeMetadata := includesOption(q.Get("include"), "metadata")
+	out.Blobs.Blobs = appendLiveBlobs(nil, result.Objects, includeMetadata)
 
-	for i := range result.Objects {
-		obj := &result.Objects[i]
+	for _, p := range result.CommonPrefixes {
+		out.Blobs.BlobPrefixes = append(out.Blobs.BlobPrefixes, blobPrefixXML{Name: p})
+	}
+
+	if ext, ok := h.bucket.(storagedriver.AzureSoftDeleteBlob); ok && includesOption(q.Get("include"), "deleted") {
+		if err := h.appendDeletedBlobs(r, ext, container, opts.Prefix, &out); err != nil {
+			writeErr(w, err)
+			return
+		}
+	}
+
+	writeXML(w, out)
+}
+
+// appendLiveBlobs renders each listed live blob as a blobXML, attaching metadata
+// when the caller asked for include=metadata.
+func appendLiveBlobs(dst []blobXML, objects []storagedriver.ObjectInfo, includeMetadata bool) []blobXML {
+	for i := range objects {
+		obj := &objects[i]
 
 		blobType := obj.BlobType
 		if blobType == "" {
@@ -475,14 +501,66 @@ func (h *Handler) listBlobs(w http.ResponseWriter, r *http.Request, container st
 			bx.Metadata = &metadataXML{Items: obj.Metadata}
 		}
 
-		out.Blobs.Blobs = append(out.Blobs.Blobs, bx)
+		dst = append(dst, bx)
 	}
 
-	for _, p := range result.CommonPrefixes {
-		out.Blobs.BlobPrefixes = append(out.Blobs.BlobPrefixes, blobPrefixXML{Name: p})
+	return dst
+}
+
+// appendDeletedBlobs merges the container's soft-deleted blobs into a List Blobs
+// include=deleted response, each marked Deleted=true with its DeletedTime and
+// RemainingRetentionDays, and re-sorts the combined blob list by name so live
+// and soft-deleted blobs interleave as real Azure returns them.
+func (*Handler) appendDeletedBlobs(
+	r *http.Request, ext storagedriver.AzureSoftDeleteBlob, container, prefix string, out *listBlobsResult,
+) error {
+	res, err := ext.ListDeletedBlobs(r.Context(), container, storagedriver.ListOptions{Prefix: prefix})
+	if err != nil {
+		return err
 	}
 
-	writeXML(w, out)
+	deletedTrue := true
+
+	for i := range res.Blobs {
+		d := &res.Blobs[i]
+		remaining := clampRetentionDays(d.RemainingRetentionDays)
+
+		out.Blobs.Blobs = append(out.Blobs.Blobs, blobXML{
+			Name: d.Info.Key,
+			Properties: blobPropsXML{
+				LastModified:           httpDate(d.Info.LastModified),
+				ETag:                   fmt.Sprintf("%q", d.Info.ETag),
+				ContentLength:          d.Info.Size,
+				ContentType:            d.Info.ContentType,
+				BlobType:               blobTypeBlockBlob,
+				DeletedTime:            httpDate(d.DeletedTime),
+				RemainingRetentionDays: &remaining,
+			},
+			Deleted: &deletedTrue,
+		})
+	}
+
+	sort.Slice(out.Blobs.Blobs, func(i, j int) bool {
+		return out.Blobs.Blobs[i].Name < out.Blobs.Blobs[j].Name
+	})
+
+	return nil
+}
+
+// clampRetentionDays narrows a non-negative day count to the int32 the wire
+// field carries, saturating at the int32 max (a remaining-retention window can
+// never approach that, so this only exists to keep the conversion provably
+// overflow-free).
+func clampRetentionDays(days int) int32 {
+	if days < 0 {
+		return 0
+	}
+
+	if days > math.MaxInt32 {
+		return math.MaxInt32
+	}
+
+	return int32(days)
 }
 
 // listBlobVersions serves GET /{container}?restype=container&comp=list&include=versions,
@@ -1176,6 +1254,23 @@ func (h *Handler) deleteBlobVersion(w http.ResponseWriter, r *http.Request, cont
 	}
 
 	w.WriteHeader(http.StatusAccepted)
+}
+
+// undeleteBlob serves PUT /{container}/{blob}?comp=undelete, restoring a
+// soft-deleted blob to active. Requires the AzureSoftDeleteBlob capability.
+func (h *Handler) undeleteBlob(w http.ResponseWriter, r *http.Request, container, blob string) {
+	ext, ok := h.bucket.(storagedriver.AzureSoftDeleteBlob)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "NotImplemented", "blob soft delete not supported")
+		return
+	}
+
+	if err := ext.UndeleteBlob(r.Context(), container, blob); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
 func (h *Handler) copyBlob(w http.ResponseWriter, r *http.Request, container, blob string) {

--- a/server/azure/blobstorage/types.go
+++ b/server/azure/blobstorage/types.go
@@ -55,6 +55,9 @@ type blobXML struct {
 	// include=versions response; a plain listing leaves both empty.
 	VersionID        string `xml:"VersionId,omitempty"`
 	IsCurrentVersion *bool  `xml:"IsCurrentVersion,omitempty"`
+	// Deleted is emitted only for a soft-deleted blob in a List Blobs
+	// include=deleted response; a live blob leaves it nil.
+	Deleted *bool `xml:"Deleted,omitempty"`
 }
 
 type blobPropsXML struct {
@@ -64,6 +67,10 @@ type blobPropsXML struct {
 	ContentType   string `xml:"Content-Type"`
 	BlobType      string `xml:"BlobType"`
 	AccessTier    string `xml:"AccessTier,omitempty"`
+	// DeletedTime and RemainingRetentionDays are emitted only for a soft-deleted
+	// blob (List Blobs include=deleted); a live blob leaves both empty.
+	DeletedTime            string `xml:"DeletedTime,omitempty"`
+	RemainingRetentionDays *int32 `xml:"RemainingRetentionDays,omitempty"`
 }
 
 type blobPrefixXML struct {

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -333,6 +333,55 @@ type AzureVersionedBlob interface {
 	ListBlobVersions(ctx context.Context, container string, opts ListOptions) (*VersionListResult, error)
 }
 
+// DeletedBlob is one soft-deleted blob reported by ListDeletedBlobs (List Blobs
+// include=deleted). It carries the blob's info together with the soft-delete
+// bookkeeping the wire layer echoes: when it was deleted and how many retention
+// days remain before it is permanently purged.
+type DeletedBlob struct {
+	Info ObjectInfo
+	// DeletedTime is when the blob was soft-deleted (blob time format, UTC).
+	DeletedTime string
+	// RemainingRetentionDays is the whole days left in the retention window
+	// before the soft-deleted blob is permanently removed.
+	RemainingRetentionDays int
+}
+
+// DeletedBlobListResult is the result of a ListDeletedBlobs operation.
+type DeletedBlobListResult struct {
+	Blobs []DeletedBlob
+}
+
+// AzureSoftDeleteBlob is an OPTIONAL Azure-specific capability, discovered by
+// type assertion, that models blob soft delete. When the account-level delete
+// retention policy is enabled (Set Blob Service Properties,
+// deleteRetentionPolicy.enabled/days) a Delete Blob retains the blob instead of
+// removing it: it disappears from a normal List but reappears under List Blobs
+// include=deleted with Deleted=true, a DeletedTime, and a RemainingRetentionDays
+// countdown, and Undelete Blob (PUT ?comp=undelete) restores it. After the
+// retention window elapses the blob is permanently gone.
+//
+// It is distinct from the S3 delete-marker model and from Azure blob versioning:
+// soft delete engages only when the account retention policy is on AND versioning
+// is off (with versioning enabled, retained versions are the recovery mechanism,
+// so a delete leaves the versions intact instead of soft-deleting the base blob).
+// S3/GCS don't implement it.
+//
+// Note: soft-deleted bytes are captured in memory at delete time; combining an
+// external StorageEngine with soft delete captures soft-deleted metadata only.
+type AzureSoftDeleteBlob interface {
+	// SoftDeleteEnabled reports whether soft delete is currently in effect for
+	// the data plane (the account retention policy is enabled and versioning off).
+	SoftDeleteEnabled(ctx context.Context) (bool, error)
+	// UndeleteBlob restores a soft-deleted blob to active (PUT ?comp=undelete).
+	// It is a no-op success when the blob is already active, and NotFound when no
+	// active or soft-deleted blob of that name exists.
+	UndeleteBlob(ctx context.Context, container, blob string) error
+	// ListDeletedBlobs returns the soft-deleted blobs matching opts, so a List
+	// Blobs include=deleted can render each with Deleted=true and its retention
+	// bookkeeping.
+	ListDeletedBlobs(ctx context.Context, container string, opts ListOptions) (*DeletedBlobListResult, error)
+}
+
 // BucketAttributes is an OPTIONAL capability, discovered by type assertion (like
 // the networking NetworkInterfaces capability): a provider whose buckets map to
 // a richer resource (Azure storage accounts) exposes their SKU/kind/access-tier


### PR DESCRIPTION
## Summary

Adds Azure Blob **soft delete** to the blob data plane, gated on the account-level delete-retention policy (`deleteRetentionPolicy.enabled/days`, already round-tripped via the ARM `blobServices/default` sub-resource).

When soft delete is in effect:
- **Delete Blob** retains the blob (bytes and all) instead of removing it.
- A normal **List Blobs** omits it; **List Blobs `include=deleted`** surfaces it with `Deleted=true`, a `DeletedTime`, and a `RemainingRetentionDays` countdown.
- **Undelete Blob** (`PUT ?comp=undelete`) restores it to active.
- After the retention window elapses the blob is purged lazily (via `config.Clock`, FakeClock-deterministic).

With soft delete **disabled**, Delete Blob remains a permanent hard delete (unchanged).

## Design
- New optional `AzureSoftDeleteBlob` driver capability, discovered by type assertion — mirrors the #968 `AzureVersionedBlob` pattern. S3/GCS are untouched.
- Soft-deleted blobs live in a per-container `softDeleted` store (persisted in Snapshot/Restore).

## Coexistence with versioning (#968)
Soft delete engages only when the retention policy is on **and** account versioning is off. With versioning enabled, a delete keeps the retained versions as the recovery mechanism (unchanged), rather than diverting to soft delete — verified by a dedicated test.

## Tests
Real `azblob` SDK wire tests (delete→list include=deleted→undelete; hard-delete when disabled; versioning coexistence) plus provider-level tests covering retention-window expiry, persist round-trip, and a concurrent `-race` delete/undelete sweep. Full `go test ./...` green; `docs/coverage` regenerated.