### PR TITLE
fix(azure-vnet): eliminate shared-pointer aliasing race + atomic in-use guards

### DIFF
--- a/providers/azure/vnet/acl.go
+++ b/providers/azure/vnet/acl.go
@@ -93,38 +93,65 @@ func (m *Mock) DescribeNetworkACLs(_ context.Context, ids []string) ([]driver.Ne
 	return describeResources(m.networkACLs, ids, toNetworkACLInfo), nil
 }
 
-// AddNetworkACLRule adds a rule to the specified network ACL, keeping rules sorted.
+// AddNetworkACLRule adds a rule to the specified network ACL, keeping rules
+// sorted. The rule slice is rebuilt fresh onto a copy of the ACL under the
+// store lock (copy-on-write), never mutating the shared pointer in place.
 func (m *Mock) AddNetworkACLRule(_ context.Context, aclID string, rule *driver.NetworkACLRule) error {
-	acl, ok := m.networkACLs.Get(aclID)
-	if !ok {
+	if !m.networkACLs.Update(aclID, func(acl *networkACLData) *networkACLData {
+		rules := append(append([]driver.NetworkACLRule(nil), acl.Rules...), *rule)
+		sort.Slice(rules, func(i, j int) bool {
+			return rules[i].RuleNumber < rules[j].RuleNumber
+		})
+
+		cp := *acl
+		cp.Rules = rules
+
+		return &cp
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "network ACL %q not found", aclID)
 	}
-
-	acl.Rules = append(acl.Rules, *rule)
-	sort.Slice(acl.Rules, func(i, j int) bool {
-		return acl.Rules[i].RuleNumber < acl.Rules[j].RuleNumber
-	})
 
 	return nil
 }
 
-// RemoveNetworkACLRule removes a rule by rule number and direction.
+// RemoveNetworkACLRule removes a rule by rule number and direction, copy-on-write.
 func (m *Mock) RemoveNetworkACLRule(
 	_ context.Context, aclID string, ruleNumber int, egress bool,
 ) error {
-	acl, ok := m.networkACLs.Get(aclID)
-	if !ok {
+	removed := false
+
+	if !m.networkACLs.Update(aclID, func(acl *networkACLData) *networkACLData {
+		idx := -1
+
+		for i := range acl.Rules {
+			if acl.Rules[i].RuleNumber == ruleNumber && acl.Rules[i].Egress == egress {
+				idx = i
+				break
+			}
+		}
+
+		if idx == -1 {
+			return acl
+		}
+
+		removed = true
+		next := make([]driver.NetworkACLRule, 0, len(acl.Rules)-1)
+		next = append(next, acl.Rules[:idx]...)
+		next = append(next, acl.Rules[idx+1:]...)
+
+		cp := *acl
+		cp.Rules = next
+
+		return &cp
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "network ACL %q not found", aclID)
 	}
 
-	for i, r := range acl.Rules {
-		if r.RuleNumber == ruleNumber && r.Egress == egress {
-			acl.Rules = append(acl.Rules[:i], acl.Rules[i+1:]...)
-			return nil
-		}
+	if !removed {
+		return cerrors.Newf(cerrors.NotFound, "rule %d not found in network ACL %q", ruleNumber, aclID)
 	}
 
-	return cerrors.Newf(cerrors.NotFound, "rule %d not found in network ACL %q", ruleNumber, aclID)
+	return nil
 }
 
 func toNetworkACLInfo(acl *networkACLData) driver.NetworkACL {

--- a/providers/azure/vnet/concurrency_test.go
+++ b/providers/azure/vnet/concurrency_test.go
@@ -1,0 +1,244 @@
+package vnet
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrentSubnetMutationAndRead hammers the copy-on-write mutators
+// (UpdateSubnetTags/RemoveSubnetTags/UpdateSubnetCIDR and the NSG rule/tag
+// mutators) against concurrent DescribeSubnets/DescribeSecurityGroups readers
+// on the same resources from many goroutines. It exists to be run with -race:
+// before the fix the mutators reassigned fields on the shared stored pointer
+// while readers walked its maps/slices, a genuine data race. The readers copy
+// every map/slice they touch, so a clean run also proves no reader observes a
+// half-updated snapshot or a dangling reference.
+func TestConcurrentSubnetMutationAndRead(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	m := newTestMock()
+	vpcID := createTestVPC(t, m)
+
+	sn, err := m.CreateSubnet(ctx, driver.SubnetConfig{
+		VPCID:     vpcID,
+		CIDRBlock: "10.0.1.0/24",
+		Tags:      map[string]string{"seed": "1"},
+	})
+	require.NoError(t, err)
+	subnetID := sn.ID
+
+	sg, err := m.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{
+		Name:  "nsg-race",
+		VPCID: vpcID,
+	})
+	require.NoError(t, err)
+	nsgID := sg.ID
+
+	const (
+		workers = 24
+		iters   = 200
+	)
+
+	var wg sync.WaitGroup
+
+	// Writers: mutate subnet tags/CIDR and NSG rules/tags.
+	for w := range workers {
+		wg.Add(1)
+
+		go func(w int) {
+			defer wg.Done()
+
+			for i := range iters {
+				key := fmt.Sprintf("k%d", w)
+				_ = m.UpdateSubnetTags(ctx, subnetID, map[string]string{key: fmt.Sprintf("%d", i)})
+				_ = m.UpdateSubnetCIDR(ctx, subnetID, fmt.Sprintf("10.0.%d.0/24", (i%250)+1))
+				_ = m.RemoveSubnetTags(ctx, subnetID, []string{key})
+
+				rule := driver.SecurityRule{Protocol: "tcp", FromPort: w, ToPort: w, CIDR: "0.0.0.0/0"}
+				_ = m.AddIngressRule(ctx, nsgID, rule)
+				_ = m.UpdateSecurityGroupTags(ctx, nsgID, map[string]string{key: "v"})
+				_ = m.RemoveIngressRule(ctx, nsgID, rule)
+			}
+		}(w)
+	}
+
+	// Readers: describe by id and describe-all, deep-reading every field so the
+	// race detector sees concurrent reads of the same backing maps/slices.
+	for range workers {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range iters {
+				subs, derr := m.DescribeSubnets(ctx, []string{subnetID})
+				require.NoError(t, derr)
+
+				for i := range subs {
+					_ = subs[i].CIDRBlock
+					for k, v := range subs[i].Tags {
+						_, _ = k, v
+					}
+				}
+
+				all, derr := m.DescribeSubnets(ctx, nil)
+				require.NoError(t, derr)
+				_ = len(all)
+
+				sgs, derr := m.DescribeSecurityGroups(ctx, []string{nsgID})
+				require.NoError(t, derr)
+
+				for i := range sgs {
+					_ = len(sgs[i].IngressRules)
+					for k := range sgs[i].Tags {
+						_ = k
+					}
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Final state must be readable and self-consistent.
+	subs, err := m.DescribeSubnets(ctx, []string{subnetID})
+	require.NoError(t, err)
+	require.Len(t, subs, 1)
+	require.Equal(t, vpcID, subs[0].VPCID)
+}
+
+// TestConcurrentAssociateVsRelease drives the atomic in-use guards: concurrent
+// AssociateAddress / DisassociateAddress / ReleaseAddress on the same public IP
+// plus DescribeAddresses readers. The guard invariant is that an associated IP
+// is never released out from under its association — ReleaseAddress must return
+// FailedPrecondition while the IP is bound — and that the check-and-act never
+// tears under -race. A clean run with a consistent final read proves it.
+func TestConcurrentAssociateVsRelease(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	m := newTestMock()
+
+	const (
+		workers = 16
+		iters   = 300
+	)
+
+	// Each worker owns its own public IP to exercise the guard independently,
+	// then a shared loser/winner race releases while others associate.
+	allocIDs := make([]string, workers)
+
+	for w := range workers {
+		eip, err := m.AllocateAddress(ctx, driver.ElasticIPConfig{})
+		require.NoError(t, err)
+		allocIDs[w] = eip.AllocationID
+	}
+
+	var wg sync.WaitGroup
+
+	for w := range workers {
+		wg.Add(1)
+
+		go func(w int) {
+			defer wg.Done()
+
+			alloc := allocIDs[w]
+
+			for range iters {
+				assocID, err := m.AssociateAddress(ctx, alloc, driver.AssociateAddressInput{InstanceID: "vm-1"})
+				if err == nil {
+					// While associated, a release MUST be refused, never delete it.
+					relErr := m.ReleaseAddress(ctx, alloc)
+					require.Error(t, relErr)
+
+					_ = m.DisassociateAddress(ctx, assocID)
+				}
+			}
+		}(w)
+	}
+
+	// Concurrent readers over the whole set.
+	for range workers {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range iters {
+				addrs, err := m.DescribeAddresses(ctx, nil)
+				require.NoError(t, err)
+
+				for i := range addrs {
+					_ = addrs[i].AssociationID
+					_ = addrs[i].InstanceID
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Every IP must still exist and be readable — none released while bound.
+	addrs, err := m.DescribeAddresses(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, addrs, workers)
+}
+
+// TestConcurrentNATBindVsDelete exercises the atomic public-IP binding guard
+// through the NAT gateway path: many goroutines race to bind the same single
+// public IP to a new NAT gateway, then delete it (freeing the IP). At most one
+// binding can hold the IP at any instant; the guard must never let two NAT
+// gateways claim it, and the store must stay consistent under -race.
+func TestConcurrentNATBindVsDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	m := newTestMock()
+
+	eip, err := m.AllocateAddress(ctx, driver.ElasticIPConfig{})
+	require.NoError(t, err)
+	alloc := eip.AllocationID
+
+	const (
+		workers = 16
+		iters   = 200
+	)
+
+	var wg sync.WaitGroup
+
+	for range workers {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range iters {
+				nat, cerr := m.CreateNATGateway(ctx, driver.NATGatewayConfig{AllocationID: alloc})
+				if cerr != nil {
+					// Contended: the IP was already bound. Expected.
+					continue
+				}
+
+				// We won the binding; releasing the IP now must fail (still bound),
+				// proving the association actually took hold.
+				require.Error(t, m.ReleaseAddress(ctx, alloc))
+
+				require.NoError(t, m.DeleteNATGateway(ctx, nat.ID))
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// The IP is free again and releasable, and no NAT gateway leaked a binding.
+	addrs, err := m.DescribeAddresses(ctx, []string{alloc})
+	require.NoError(t, err)
+	require.Len(t, addrs, 1)
+	require.Empty(t, addrs[0].AssociationID)
+}

--- a/providers/azure/vnet/concurrency_test.go
+++ b/providers/azure/vnet/concurrency_test.go
@@ -242,3 +242,153 @@ func TestConcurrentNATBindVsDelete(t *testing.T) {
 	require.Len(t, addrs, 1)
 	require.Empty(t, addrs[0].AssociationID)
 }
+
+// TestConcurrentReplaceTagsVsDescribe covers the ARM UpdateTags PATCH mutators
+// (Replace*Tags), which previously reassigned .Tags on the shared stored pointer
+// under Update() instead of copy-on-write. It fires ReplaceVPCTags /
+// ReplaceSecurityGroupTags against concurrent DescribeVPCs / DescribeSecurityGroups
+// readers that walk the returned tag maps. Run with -race, a write at the tag
+// reassignment used to race the reader's map iteration in toVPCInfo/toSGInfo.
+func TestConcurrentReplaceTagsVsDescribe(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	m := newTestMock()
+	vpcID := createTestVPC(t, m)
+
+	sg, err := m.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{Name: "nsg-tags", VPCID: vpcID})
+	require.NoError(t, err)
+	nsgID := sg.ID
+
+	const (
+		workers = 24
+		iters   = 250
+	)
+
+	var wg sync.WaitGroup
+
+	for w := range workers {
+		wg.Add(1)
+
+		go func(w int) {
+			defer wg.Done()
+
+			for i := range iters {
+				tags := map[string]string{
+					fmt.Sprintf("k%d", w): fmt.Sprintf("%d", i),
+					"shared":              fmt.Sprintf("%d", w),
+				}
+				require.NoError(t, m.ReplaceVPCTags(ctx, vpcID, tags))
+				require.NoError(t, m.ReplaceSecurityGroupTags(ctx, nsgID, tags))
+			}
+		}(w)
+	}
+
+	for range workers {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range iters {
+				vpcs, derr := m.DescribeVPCs(ctx, []string{vpcID})
+				require.NoError(t, derr)
+
+				for i := range vpcs {
+					for k, v := range vpcs[i].Tags {
+						_, _ = k, v
+					}
+				}
+
+				sgs, derr := m.DescribeSecurityGroups(ctx, []string{nsgID})
+				require.NoError(t, derr)
+
+				for i := range sgs {
+					for k := range sgs[i].Tags {
+						_ = k
+					}
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// createTestNIC creates a single-ipConfiguration NIC keyed by (rg, name).
+func createTestNIC(t *testing.T, m *Mock, rg, name string) {
+	t.Helper()
+
+	_, err := m.CreateOrUpdateNetworkInterface(context.Background(), rg, name, driver.AzureNICConfig{
+		Location: "eastus",
+		IPConfigs: []driver.AzureIPConfig{
+			{Name: "ipconfig1", AllocationMethod: "Static", PrivateIP: "10.0.0.10", Primary: true},
+		},
+	})
+	require.NoError(t, err)
+}
+
+// TestConcurrentNICMutationVsSnapshot drives NIC AttachNetworkInterface /
+// DetachNetworkInterface / ReplaceNetworkInterfaceTags against concurrent
+// Snapshot() calls. Snapshot dumps m.nics via store.All()+json.Marshal without
+// nicMu; before the fix Attach/Detach mutated *nicData in place, so the Marshal
+// read raced the field write. Copy-on-write through the store lock makes the
+// captured pointer immutable, so this must be -race clean.
+func TestConcurrentNICMutationVsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	m := newTestMock()
+
+	const (
+		nics    = 8
+		workers = 16
+		iters   = 200
+	)
+
+	for i := range nics {
+		createTestNIC(t, m, "rg-1", fmt.Sprintf("nic-%d", i))
+	}
+
+	var wg sync.WaitGroup
+
+	// Mutators: attach, detach and replace-tags across the NIC set.
+	for w := range workers {
+		wg.Add(1)
+
+		go func(w int) {
+			defer wg.Done()
+
+			for i := range iters {
+				name := fmt.Sprintf("nic-%d", (w+i)%nics)
+				vmID := fmt.Sprintf("/subscriptions/s/vm-%d", w)
+
+				_ = m.AttachNetworkInterface(ctx, "rg-1", name, vmID)
+				_ = m.ReplaceNetworkInterfaceTags(ctx, "rg-1", name, map[string]string{"w": fmt.Sprintf("%d", w)})
+				_ = m.DetachNetworkInterface(ctx, "rg-1", name, vmID)
+			}
+		}(w)
+	}
+
+	// Snapshotters: dump the whole mock concurrently.
+	for range workers / 2 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range iters {
+				data, err := m.Snapshot(ctx, false)
+				require.NoError(t, err)
+				require.NotEmpty(t, data)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Final snapshot must round-trip cleanly.
+	data, err := m.Snapshot(ctx, false)
+	require.NoError(t, err)
+	require.NoError(t, m.Restore(ctx, data))
+}

--- a/providers/azure/vnet/elastic_ip.go
+++ b/providers/azure/vnet/elastic_ip.go
@@ -89,21 +89,22 @@ func (m *Mock) UpdateAzurePublicIP(_ context.Context, allocationID string, cfg d
 	}
 
 	found := m.eips.Update(allocationID, func(e *eipData) *eipData {
-		e.Tags = copyTags(cfg.Tags)
-		e.SKU = sku
-		e.AllocationMethod = allocMethod
-		e.IdleTimeoutMinutes = cfg.IdleTimeoutMinutes
-		e.DNSDomainNameLabel = cfg.DNSDomainNameLabel
+		cp := *e
+		cp.Tags = copyTags(cfg.Tags)
+		cp.SKU = sku
+		cp.AllocationMethod = allocMethod
+		cp.IdleTimeoutMinutes = cfg.IdleTimeoutMinutes
+		cp.DNSDomainNameLabel = cfg.DNSDomainNameLabel
 
-		e.Zones = append([]string(nil), cfg.Zones...)
+		cp.Zones = append([]string(nil), cfg.Zones...)
 
 		if cfg.DNSDomainNameLabel != "" {
-			e.DNSFQDN = cfg.DNSDomainNameLabel + "." + defaultFQDNRegion + ".cloudapp.azure.com"
+			cp.DNSFQDN = cfg.DNSDomainNameLabel + "." + defaultFQDNRegion + ".cloudapp.azure.com"
 		} else {
-			e.DNSFQDN = ""
+			cp.DNSFQDN = ""
 		}
 
-		return e
+		return &cp
 	})
 	if !found {
 		return cerrors.Newf(cerrors.NotFound, "public IP %q not found", allocationID)
@@ -112,26 +113,47 @@ func (m *Mock) UpdateAzurePublicIP(_ context.Context, allocationID string, cfg d
 	return nil
 }
 
-// ReleaseAddress releases a public IP address.
+// clearEIPAssociation returns a copy of e with its association and instance
+// binding cleared, so a public IP is freed copy-on-write instead of mutating
+// the shared pointer a reader may still hold. Clearing InstanceID as well as
+// AssociationID is safe for NAT-gateway bindings, which never set InstanceID.
+func clearEIPAssociation(e *eipData) *eipData {
+	cp := *e
+	cp.AssociationID = ""
+	cp.InstanceID = ""
+
+	return &cp
+}
+
+// ReleaseAddress releases a public IP address. The still-associated guard and
+// the delete run in one locked span via UpdateOrDelete, so the address cannot
+// be associated between the check and the delete (no check-then-act race).
 func (m *Mock) ReleaseAddress(
 	_ context.Context, allocationID string,
 ) error {
-	eip, ok := m.eips.Get(allocationID)
-	if !ok {
+	var associated bool
+
+	found := m.eips.UpdateOrDelete(allocationID, func(e *eipData) (*eipData, bool) {
+		if e.AssociationID != "" {
+			associated = true
+			return e, true // keep
+		}
+
+		return nil, false // delete
+	})
+	if !found {
 		return cerrors.Newf(
 			cerrors.NotFound,
 			"public IP %q not found", allocationID,
 		)
 	}
 
-	if eip.AssociationID != "" {
+	if associated {
 		return cerrors.Newf(
 			cerrors.FailedPrecondition,
 			"public IP %q is still associated", allocationID,
 		)
 	}
-
-	m.eips.Delete(allocationID)
 
 	return nil
 }
@@ -148,39 +170,62 @@ func (m *Mock) DescribeAddresses(
 func (m *Mock) AssociateAddress(
 	_ context.Context, allocationID string, in driver.AssociateAddressInput,
 ) (string, error) {
-	eip, ok := m.eips.Get(allocationID)
-	if !ok {
+	var (
+		conflict error
+		assocID  string
+	)
+
+	found := m.eips.Update(allocationID, func(e *eipData) *eipData {
+		if e.AssociationID != "" {
+			conflict = cerrors.Newf(
+				cerrors.FailedPrecondition,
+				"public IP %q is already associated", allocationID,
+			)
+
+			return e
+		}
+
+		assocID = idgen.GenerateID("ipassoc-")
+		cp := *e
+		cp.AssociationID = assocID
+		cp.InstanceID = in.InstanceID
+
+		return &cp
+	})
+	if !found {
 		return "", cerrors.Newf(
 			cerrors.NotFound,
 			"public IP %q not found", allocationID,
 		)
 	}
 
-	if eip.AssociationID != "" {
-		return "", cerrors.Newf(
-			cerrors.FailedPrecondition,
-			"public IP %q is already associated", allocationID,
-		)
+	if conflict != nil {
+		return "", conflict
 	}
-
-	assocID := idgen.GenerateID("ipassoc-")
-	eip.AssociationID = assocID
-	eip.InstanceID = in.InstanceID
 
 	return assocID, nil
 }
 
-// DisassociateAddress removes a public IP association.
+// DisassociateAddress removes a public IP association. The matching address is
+// freed copy-on-write, and the association id is re-checked under the store
+// lock so a concurrent release/re-allocation cannot be cleared by mistake.
 func (m *Mock) DisassociateAddress(
 	_ context.Context, associationID string,
 ) error {
-	for _, eip := range m.eips.All() {
-		if eip.AssociationID == associationID {
-			eip.AssociationID = ""
-			eip.InstanceID = ""
-
-			return nil
+	for id, eip := range m.eips.All() {
+		if eip.AssociationID != associationID {
+			continue
 		}
+
+		m.eips.Update(id, func(e *eipData) *eipData {
+			if e.AssociationID != associationID {
+				return e
+			}
+
+			return clearEIPAssociation(e)
+		})
+
+		return nil
 	}
 
 	return cerrors.Newf(

--- a/providers/azure/vnet/endpoint.go
+++ b/providers/azure/vnet/endpoint.go
@@ -93,31 +93,39 @@ func (m *Mock) DescribeVPCEndpoints(
 func (m *Mock) ModifyVPCEndpoint(
 	_ context.Context, id string, cfg driver.VPCEndpointConfig,
 ) (*driver.VPCEndpoint, error) {
-	ep, ok := m.endpoints.Get(id)
-	if !ok {
+	var out *driver.VPCEndpoint
+
+	found := m.endpoints.Update(id, func(ep *driver.VPCEndpoint) *driver.VPCEndpoint {
+		cp := *ep
+
+		if len(cfg.SubnetIDs) > 0 {
+			cp.SubnetIDs = copyStringSlice(cfg.SubnetIDs)
+		}
+
+		if len(cfg.SecurityGroupIDs) > 0 {
+			cp.SecurityGroupIDs = copyStringSlice(cfg.SecurityGroupIDs)
+		}
+
+		if len(cfg.RouteTableIDs) > 0 {
+			cp.RouteTableIDs = copyStringSlice(cfg.RouteTableIDs)
+		}
+
+		if len(cfg.Tags) > 0 {
+			cp.Tags = copyTags(cfg.Tags)
+		}
+
+		out = copyEndpoint(&cp)
+
+		return &cp
+	})
+	if !found {
 		return nil, cerrors.Newf(
 			cerrors.NotFound,
 			"service endpoint %q not found", id,
 		)
 	}
 
-	if len(cfg.SubnetIDs) > 0 {
-		ep.SubnetIDs = copyStringSlice(cfg.SubnetIDs)
-	}
-
-	if len(cfg.SecurityGroupIDs) > 0 {
-		ep.SecurityGroupIDs = copyStringSlice(cfg.SecurityGroupIDs)
-	}
-
-	if len(cfg.RouteTableIDs) > 0 {
-		ep.RouteTableIDs = copyStringSlice(cfg.RouteTableIDs)
-	}
-
-	if len(cfg.Tags) > 0 {
-		ep.Tags = copyTags(cfg.Tags)
-	}
-
-	return copyEndpoint(ep), nil
+	return out, nil
 }
 
 func toEndpointInfo(ep *driver.VPCEndpoint) driver.VPCEndpoint {

--- a/providers/azure/vnet/internet_gateway.go
+++ b/providers/azure/vnet/internet_gateway.go
@@ -39,26 +39,35 @@ func (m *Mock) CreateInternetGateway(
 	return &info, nil
 }
 
-// DeleteInternetGateway deletes the internet gateway.
+// DeleteInternetGateway deletes the internet gateway. The still-attached guard
+// and the delete run in one locked span via UpdateOrDelete, so the gateway
+// cannot be attached between the check and the delete (no check-then-act race).
 func (m *Mock) DeleteInternetGateway(
 	_ context.Context, id string,
 ) error {
-	igw, ok := m.igws.Get(id)
-	if !ok {
+	var attached bool
+
+	found := m.igws.UpdateOrDelete(id, func(igw *igwData) (*igwData, bool) {
+		if igw.State == IGWStateAttached {
+			attached = true
+			return igw, true // keep
+		}
+
+		return nil, false // delete
+	})
+	if !found {
 		return cerrors.Newf(
 			cerrors.NotFound,
 			"internet gateway %q not found", id,
 		)
 	}
 
-	if igw.State == IGWStateAttached {
+	if attached {
 		return cerrors.Newf(
 			cerrors.FailedPrecondition,
 			"internet gateway %q is still attached", id,
 		)
 	}
-
-	m.igws.Delete(id)
 
 	return nil
 }
@@ -76,31 +85,40 @@ func (m *Mock) DescribeInternetGateways(
 func (m *Mock) AttachInternetGateway(
 	_ context.Context, igwID, vpcID string,
 ) error {
-	igw, ok := m.igws.Get(igwID)
-	if !ok {
+	var opErr error
+
+	found := m.igws.Update(igwID, func(igw *igwData) *igwData {
+		if igw.State == IGWStateAttached {
+			opErr = cerrors.Newf(
+				cerrors.FailedPrecondition,
+				"internet gateway %q is already attached", igwID,
+			)
+
+			return igw
+		}
+
+		if !m.vpcs.Has(vpcID) {
+			opErr = cerrors.Newf(
+				cerrors.NotFound, "vnet %q not found", vpcID,
+			)
+
+			return igw
+		}
+
+		cp := *igw
+		cp.VpcID = vpcID
+		cp.State = IGWStateAttached
+
+		return &cp
+	})
+	if !found {
 		return cerrors.Newf(
 			cerrors.NotFound,
 			"internet gateway %q not found", igwID,
 		)
 	}
 
-	if igw.State == IGWStateAttached {
-		return cerrors.Newf(
-			cerrors.FailedPrecondition,
-			"internet gateway %q is already attached", igwID,
-		)
-	}
-
-	if !m.vpcs.Has(vpcID) {
-		return cerrors.Newf(
-			cerrors.NotFound, "vnet %q not found", vpcID,
-		)
-	}
-
-	igw.VpcID = vpcID
-	igw.State = IGWStateAttached
-
-	return nil
+	return opErr
 }
 
 // DetachInternetGateway detaches an internet gateway
@@ -108,26 +126,33 @@ func (m *Mock) AttachInternetGateway(
 func (m *Mock) DetachInternetGateway(
 	_ context.Context, igwID, vpcID string,
 ) error {
-	igw, ok := m.igws.Get(igwID)
-	if !ok {
+	var opErr error
+
+	found := m.igws.Update(igwID, func(igw *igwData) *igwData {
+		if igw.State != IGWStateAttached || igw.VpcID != vpcID {
+			opErr = cerrors.Newf(
+				cerrors.FailedPrecondition,
+				"internet gateway %q is not attached to vnet %q",
+				igwID, vpcID,
+			)
+
+			return igw
+		}
+
+		cp := *igw
+		cp.VpcID = ""
+		cp.State = IGWStateDetached
+
+		return &cp
+	})
+	if !found {
 		return cerrors.Newf(
 			cerrors.NotFound,
 			"internet gateway %q not found", igwID,
 		)
 	}
 
-	if igw.State != IGWStateAttached || igw.VpcID != vpcID {
-		return cerrors.Newf(
-			cerrors.FailedPrecondition,
-			"internet gateway %q is not attached to vnet %q",
-			igwID, vpcID,
-		)
-	}
-
-	igw.VpcID = ""
-	igw.State = IGWStateDetached
-
-	return nil
+	return opErr
 }
 
 func toIGWInfo(igw *igwData) driver.InternetGateway {

--- a/providers/azure/vnet/nat_gateway.go
+++ b/providers/azure/vnet/nat_gateway.go
@@ -132,12 +132,21 @@ func (m *Mock) DeleteNATGateway(_ context.Context, id string) error {
 }
 
 // UpdateAzureNATGateway re-applies the mutable fields of an existing NAT gateway
-// (its bound public-IP allocation and tags) in place, so a repeat ARM
-// CreateOrUpdate PUT re-associates the public IP and reflects tag changes rather
-// than discarding them. When the requested allocation differs from the current
-// one it binds the new public IP first (rejecting one already in use) and only
-// then frees the previous binding, so a failed rebind leaves the gateway
-// untouched. An empty allocationID detaches any bound public IP.
+// (its bound public-IP allocation and tags), so a repeat ARM CreateOrUpdate PUT
+// re-associates the public IP and reflects tag changes rather than discarding
+// them. When the requested allocation differs from the current one it binds the
+// new public IP first (rejecting one already in use) and only then frees the
+// previous binding, so a failed rebind leaves the gateway untouched. An empty
+// allocationID detaches any bound public IP. The gateway change itself is
+// applied copy-on-write via a single final Update.
+//
+// This spans two stores (natGateways for the gateway, eips for the binding),
+// which no single memstore lock can cover, so the read-then-rebind-then-write is
+// not one atomic span: two concurrent PUTs to the SAME gateway can lose an
+// update. That is a same-resource TOCTOU, not a data race (every write is COW
+// through a store lock), and real ARM serializes PUTs on one resource; folding
+// it fully atomic would require nesting the eips store lock inside a
+// natGateways Update callback, which the package deliberately avoids.
 func (m *Mock) UpdateAzureNATGateway(_ context.Context, id, allocationID string, tags map[string]string) error {
 	nat, ok := m.natGateways.Get(id)
 	if !ok {

--- a/providers/azure/vnet/nat_gateway.go
+++ b/providers/azure/vnet/nat_gateway.go
@@ -91,10 +91,11 @@ func (m *Mock) bindNATGatewayAllocation(allocationID string) (string, error) {
 			return e
 		}
 
-		e.AssociationID = idgen.GenerateID("natgwassoc-")
-		address = e.PublicIP
+		cp := *e
+		cp.AssociationID = idgen.GenerateID("natgwassoc-")
+		address = cp.PublicIP
 
-		return e
+		return &cp
 	})
 
 	if !found {
@@ -111,18 +112,20 @@ func (m *Mock) bindNATGatewayAllocation(allocationID string) (string, error) {
 // DeleteNATGateway deletes the NAT gateway with the given ID, freeing any
 // bound Elastic IP allocation so it can be released or reused.
 func (m *Mock) DeleteNATGateway(_ context.Context, id string) error {
-	nat, ok := m.natGateways.Get(id)
-	if !ok {
+	var allocationID string
+
+	// Read the bound allocation and delete the gateway in one locked span so the
+	// two cannot be split by a concurrent update.
+	found := m.natGateways.UpdateOrDelete(id, func(n *natGatewayData) (*natGatewayData, bool) {
+		allocationID = n.AllocationID
+		return nil, false // delete
+	})
+	if !found {
 		return cerrors.Newf(cerrors.NotFound, "NAT gateway %q not found", id)
 	}
 
-	m.natGateways.Delete(id)
-
-	if nat.AllocationID != "" {
-		m.eips.Update(nat.AllocationID, func(e *eipData) *eipData {
-			e.AssociationID = ""
-			return e
-		})
+	if allocationID != "" {
+		m.eips.Update(allocationID, clearEIPAssociation)
 	}
 
 	return nil
@@ -141,8 +144,10 @@ func (m *Mock) UpdateAzureNATGateway(_ context.Context, id, allocationID string,
 		return cerrors.Newf(cerrors.NotFound, "NAT gateway %q not found", id)
 	}
 
+	newPublicIP := nat.PublicIP
+
 	if allocationID != nat.AllocationID {
-		newPublicIP := ""
+		newPublicIP = ""
 
 		if allocationID != "" {
 			address, err := m.bindNATGatewayAllocation(allocationID)
@@ -154,23 +159,19 @@ func (m *Mock) UpdateAzureNATGateway(_ context.Context, id, allocationID string,
 		}
 
 		if nat.AllocationID != "" {
-			m.eips.Update(nat.AllocationID, func(e *eipData) *eipData {
-				e.AssociationID = ""
-				return e
-			})
+			m.eips.Update(nat.AllocationID, clearEIPAssociation)
 		}
-
-		m.natGateways.Update(id, func(n *natGatewayData) *natGatewayData {
-			n.AllocationID = allocationID
-			n.PublicIP = newPublicIP
-
-			return n
-		})
 	}
 
+	// Single copy-on-write swap applies the (possibly unchanged) allocation and
+	// the new tags onto a fresh *natGatewayData, never mutating the shared one.
 	m.natGateways.Update(id, func(n *natGatewayData) *natGatewayData {
-		n.Tags = copyTags(tags)
-		return n
+		cp := *n
+		cp.AllocationID = allocationID
+		cp.PublicIP = newPublicIP
+		cp.Tags = copyTags(tags)
+
+		return &cp
 	})
 
 	return nil

--- a/providers/azure/vnet/network_interface.go
+++ b/providers/azure/vnet/network_interface.go
@@ -151,19 +151,26 @@ func (m *Mock) AttachNetworkInterface(_ context.Context, resourceGroup, name, vm
 	m.nicMu.Lock()
 	defer m.nicMu.Unlock()
 
-	nic, ok := m.nics.Get(nicKey(resourceGroup, name))
-	if !ok {
+	var opErr error
+
+	found := m.nics.Update(nicKey(resourceGroup, name), func(nic *nicData) *nicData {
+		if nic.VirtualMachineID != "" && nic.VirtualMachineID != vmID {
+			opErr = cerrors.Newf(cerrors.FailedPrecondition,
+				"network interface %q is already attached to %q", name, nic.VirtualMachineID)
+
+			return nic
+		}
+
+		cp := *nic
+		cp.VirtualMachineID = vmID
+
+		return &cp
+	})
+	if !found {
 		return cerrors.Newf(cerrors.NotFound, "network interface %q not found in resource group %q", name, resourceGroup)
 	}
 
-	if nic.VirtualMachineID != "" && nic.VirtualMachineID != vmID {
-		return cerrors.Newf(cerrors.FailedPrecondition,
-			"network interface %q is already attached to %q", name, nic.VirtualMachineID)
-	}
-
-	nic.VirtualMachineID = vmID
-
-	return nil
+	return opErr
 }
 
 // DetachNetworkInterface clears the NIC's virtualMachine back-reference, but
@@ -174,14 +181,16 @@ func (m *Mock) DetachNetworkInterface(_ context.Context, resourceGroup, name, vm
 	m.nicMu.Lock()
 	defer m.nicMu.Unlock()
 
-	nic, ok := m.nics.Get(nicKey(resourceGroup, name))
-	if !ok {
-		return nil
-	}
+	m.nics.Update(nicKey(resourceGroup, name), func(nic *nicData) *nicData {
+		if nic.VirtualMachineID != vmID {
+			return nic
+		}
 
-	if nic.VirtualMachineID == vmID {
-		nic.VirtualMachineID = ""
-	}
+		cp := *nic
+		cp.VirtualMachineID = ""
+
+		return &cp
+	})
 
 	return nil
 }

--- a/providers/azure/vnet/peering.go
+++ b/providers/azure/vnet/peering.go
@@ -15,7 +15,6 @@ const (
 	PeeringStatusPending  = "pending-acceptance"
 	PeeringStatusActive   = "active"
 	PeeringStatusRejected = "rejected"
-	PeeringStatusDeleted  = "deleted"
 )
 
 type peeringData struct {
@@ -65,50 +64,50 @@ func (m *Mock) CreatePeeringConnection(
 	return &info, nil
 }
 
-// AcceptPeeringConnection accepts a pending VNet peering.
+// AcceptPeeringConnection accepts a pending VNet peering. The status transition
+// is applied copy-on-write onto a fresh *peeringData under the store lock.
 func (m *Mock) AcceptPeeringConnection(_ context.Context, peeringID string) error {
-	p, ok := m.peerings.Get(peeringID)
-	if !ok {
-		return cerrors.Newf(cerrors.NotFound, "peering %q not found", peeringID)
-	}
-
-	if p.Status != PeeringStatusPending {
-		return cerrors.Newf(cerrors.FailedPrecondition, "peering %q is in state %q, expected %q",
-			peeringID, p.Status, PeeringStatusPending)
-	}
-
-	p.Status = PeeringStatusActive
-
-	return nil
+	return m.transitionPeering(peeringID, PeeringStatusActive)
 }
 
 // RejectPeeringConnection rejects a pending VNet peering.
 func (m *Mock) RejectPeeringConnection(_ context.Context, peeringID string) error {
-	p, ok := m.peerings.Get(peeringID)
-	if !ok {
-		return cerrors.Newf(cerrors.NotFound, "peering %q not found", peeringID)
-	}
-
-	if p.Status != PeeringStatusPending {
-		return cerrors.Newf(cerrors.FailedPrecondition, "peering %q is in state %q, expected %q",
-			peeringID, p.Status, PeeringStatusPending)
-	}
-
-	p.Status = PeeringStatusRejected
-
-	return nil
+	return m.transitionPeering(peeringID, PeeringStatusRejected)
 }
 
-// DeletePeeringConnection deletes a VNet peering.
-func (m *Mock) DeletePeeringConnection(_ context.Context, peeringID string) error {
-	p, ok := m.peerings.Get(peeringID)
-	if !ok {
+// transitionPeering moves a pending peering to next, copy-on-write. It reports
+// NotFound for a missing peering and FailedPrecondition when the peering is not
+// pending, matching the per-transition error messages.
+func (m *Mock) transitionPeering(peeringID, next string) error {
+	var opErr error
+
+	found := m.peerings.Update(peeringID, func(p *peeringData) *peeringData {
+		if p.Status != PeeringStatusPending {
+			opErr = cerrors.Newf(cerrors.FailedPrecondition, "peering %q is in state %q, expected %q",
+				peeringID, p.Status, PeeringStatusPending)
+
+			return p
+		}
+
+		cp := *p
+		cp.Status = next
+
+		return &cp
+	})
+	if !found {
 		return cerrors.Newf(cerrors.NotFound, "peering %q not found", peeringID)
 	}
 
-	p.Status = PeeringStatusDeleted
+	return opErr
+}
 
-	m.peerings.Delete(peeringID)
+// DeletePeeringConnection deletes a VNet peering. Delete is itself atomic and
+// reports whether the peering existed, so no separate read is needed (the old
+// transient "deleted" status write mutated the shared pointer and is dropped).
+func (m *Mock) DeletePeeringConnection(_ context.Context, peeringID string) error {
+	if !m.peerings.Delete(peeringID) {
+		return cerrors.Newf(cerrors.NotFound, "peering %q not found", peeringID)
+	}
 
 	return nil
 }

--- a/providers/azure/vnet/route_table.go
+++ b/providers/azure/vnet/route_table.go
@@ -66,48 +66,80 @@ func (m *Mock) DescribeRouteTables(_ context.Context, ids []string) ([]driver.Ro
 	return describeResources(m.routeTables, ids, toRouteTableInfo), nil
 }
 
-// CreateRoute adds a route to the specified route table.
+// CreateRoute adds a route to the specified route table, copy-on-write: the
+// route slice is rebuilt fresh onto a copy of the table under the store lock,
+// so a reader holding the prior snapshot is unaffected.
 func (m *Mock) CreateRoute(
 	_ context.Context, routeTableID, destinationCIDR, targetID, targetType string,
 ) error {
-	rt, ok := m.routeTables.Get(routeTableID)
-	if !ok {
+	duplicate := false
+
+	if !m.routeTables.Update(routeTableID, func(rt *routeTableData) *routeTableData {
+		for i := range rt.Routes {
+			if rt.Routes[i].DestinationCIDR == destinationCIDR {
+				duplicate = true
+				return rt
+			}
+		}
+
+		cp := *rt
+		cp.Routes = append(append([]driver.Route(nil), rt.Routes...), driver.Route{
+			DestinationCIDR: destinationCIDR,
+			TargetID:        targetID,
+			TargetType:      targetType,
+			State:           "active",
+		})
+
+		return &cp
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "route table %q not found", routeTableID)
 	}
 
-	for _, r := range rt.Routes {
-		if r.DestinationCIDR == destinationCIDR {
-			return cerrors.Newf(cerrors.AlreadyExists,
-				"route for %q already exists in route table %q", destinationCIDR, routeTableID)
-		}
+	if duplicate {
+		return cerrors.Newf(cerrors.AlreadyExists,
+			"route for %q already exists in route table %q", destinationCIDR, routeTableID)
 	}
-
-	rt.Routes = append(rt.Routes, driver.Route{
-		DestinationCIDR: destinationCIDR,
-		TargetID:        targetID,
-		TargetType:      targetType,
-		State:           "active",
-	})
 
 	return nil
 }
 
-// DeleteRoute removes a route from the specified route table.
+// DeleteRoute removes a route from the specified route table, copy-on-write.
 func (m *Mock) DeleteRoute(_ context.Context, routeTableID, destinationCIDR string) error {
-	rt, ok := m.routeTables.Get(routeTableID)
-	if !ok {
+	removed := false
+
+	if !m.routeTables.Update(routeTableID, func(rt *routeTableData) *routeTableData {
+		idx := -1
+
+		for i := range rt.Routes {
+			if rt.Routes[i].DestinationCIDR == destinationCIDR {
+				idx = i
+				break
+			}
+		}
+
+		if idx == -1 {
+			return rt
+		}
+
+		removed = true
+		next := make([]driver.Route, 0, len(rt.Routes)-1)
+		next = append(next, rt.Routes[:idx]...)
+		next = append(next, rt.Routes[idx+1:]...)
+
+		cp := *rt
+		cp.Routes = next
+
+		return &cp
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "route table %q not found", routeTableID)
 	}
 
-	for i, r := range rt.Routes {
-		if r.DestinationCIDR == destinationCIDR {
-			rt.Routes = append(rt.Routes[:i], rt.Routes[i+1:]...)
-			return nil
-		}
+	if !removed {
+		return cerrors.Newf(cerrors.NotFound, "route %q not found in route table %q",
+			destinationCIDR, routeTableID)
 	}
 
-	return cerrors.Newf(cerrors.NotFound, "route %q not found in route table %q",
-		destinationCIDR, routeTableID)
+	return nil
 }
 
 func toRouteTableInfo(rt *routeTableData) driver.RouteTable {

--- a/providers/azure/vnet/tag_replace.go
+++ b/providers/azure/vnet/tag_replace.go
@@ -8,16 +8,20 @@ import (
 
 // This file implements driver.AzureNetworkTagReplacer: the wholesale tag
 // replacement the ARM resource-level UpdateTags PATCH needs (it SETS tags, it
-// does not merge). Each method swaps in a fresh copy of the supplied map under
-// the store's lock so concurrent readers iterating the old map are unaffected,
-// and returns NotFound when the resource is absent. The wire handler folds any
-// wire-internal cloudemu: anchor tags into the map it passes, so those survive.
+// does not merge). Each method swaps in a FRESH struct with a fresh copy of the
+// supplied map under the store's lock (copy-on-write) — the shared stored
+// pointer is never mutated in place, so a reader holding a prior snapshot is
+// unaffected — and returns NotFound when the resource is absent. The wire
+// handler folds any wire-internal cloudemu: anchor tags into the map it passes,
+// so those survive.
 
 // ReplaceVPCTags sets the virtual network's tags wholesale.
 func (m *Mock) ReplaceVPCTags(_ context.Context, id string, tags map[string]string) error {
 	if !m.vpcs.Update(id, func(v *vpcData) *vpcData {
-		v.Tags = copyTags(tags)
-		return v
+		cp := *v
+		cp.Tags = copyTags(tags)
+
+		return &cp
 	}) {
 		return cerrors.Newf(cerrors.NotFound, "virtual network %q not found", id)
 	}
@@ -28,8 +32,10 @@ func (m *Mock) ReplaceVPCTags(_ context.Context, id string, tags map[string]stri
 // ReplaceSecurityGroupTags sets the network security group's tags wholesale.
 func (m *Mock) ReplaceSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
 	if !m.securityGroups.Update(id, func(sg *sgData) *sgData {
-		sg.Tags = copyTags(tags)
-		return sg
+		cp := *sg
+		cp.Tags = copyTags(tags)
+
+		return &cp
 	}) {
 		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", id)
 	}
@@ -40,8 +46,10 @@ func (m *Mock) ReplaceSecurityGroupTags(_ context.Context, id string, tags map[s
 // ReplaceNATGatewayTags sets the NAT gateway's tags wholesale.
 func (m *Mock) ReplaceNATGatewayTags(_ context.Context, id string, tags map[string]string) error {
 	if !m.natGateways.Update(id, func(n *natGatewayData) *natGatewayData {
-		n.Tags = copyTags(tags)
-		return n
+		cp := *n
+		cp.Tags = copyTags(tags)
+
+		return &cp
 	}) {
 		return cerrors.Newf(cerrors.NotFound, "NAT gateway %q not found", id)
 	}
@@ -53,8 +61,10 @@ func (m *Mock) ReplaceNATGatewayTags(_ context.Context, id string, tags map[stri
 // Elastic-IP allocation id.
 func (m *Mock) ReplaceAddressTags(_ context.Context, allocationID string, tags map[string]string) error {
 	if !m.eips.Update(allocationID, func(e *eipData) *eipData {
-		e.Tags = copyTags(tags)
-		return e
+		cp := *e
+		cp.Tags = copyTags(tags)
+
+		return &cp
 	}) {
 		return cerrors.Newf(cerrors.NotFound, "public IP %q not found", allocationID)
 	}
@@ -64,15 +74,19 @@ func (m *Mock) ReplaceAddressTags(_ context.Context, allocationID string, tags m
 
 // ReplaceNetworkInterfaceTags sets the network interface's tags wholesale, keyed
 // by the (resourceGroup, name) ARM addressing pair. It takes nicMu (the same
-// lock CreateOrUpdateNetworkInterface holds) so a concurrent NIC write cannot
-// interleave with the tag replacement.
+// lock CreateOrUpdateNetworkInterface holds) so a concurrent NIC create's
+// read-modify-write cannot interleave and lose the tag replacement, and applies
+// the change copy-on-write under the nics store lock so it is consistent with
+// Snapshot's store.All() read.
 func (m *Mock) ReplaceNetworkInterfaceTags(_ context.Context, resourceGroup, name string, tags map[string]string) error {
 	m.nicMu.Lock()
 	defer m.nicMu.Unlock()
 
 	if !m.nics.Update(nicKey(resourceGroup, name), func(n *nicData) *nicData {
-		n.Tags = copyTags(tags)
-		return n
+		cp := *n
+		cp.Tags = copyTags(tags)
+
+		return &cp
 	}) {
 		return cerrors.Newf(cerrors.NotFound, "network interface %q not found", name)
 	}

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -309,26 +309,34 @@ func (m *Mock) DescribeSecurityGroups(_ context.Context, ids []string) ([]driver
 //
 //nolint:gocritic // hugeParam: rule is passed by value to satisfy the Networking driver interface.
 func (m *Mock) AddIngressRule(_ context.Context, groupID string, rule driver.SecurityRule) error {
-	sg, ok := m.securityGroups.Get(groupID)
-	if !ok {
-		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", groupID)
-	}
-
-	sg.IngressRules = append(sg.IngressRules, rule)
-
-	return nil
+	return m.addSecurityGroupRule(groupID, rule, false)
 }
 
 // AddEgressRule adds an outbound security rule to the specified network security group.
 //
 //nolint:gocritic // hugeParam: rule is passed by value to satisfy the Networking driver interface.
 func (m *Mock) AddEgressRule(_ context.Context, groupID string, rule driver.SecurityRule) error {
-	sg, ok := m.securityGroups.Get(groupID)
-	if !ok {
+	return m.addSecurityGroupRule(groupID, rule, true)
+}
+
+// addSecurityGroupRule appends rule to the NSG's ingress or egress list
+// copy-on-write: a fresh slice is built onto a copy of the NSG under the store
+// lock, so a reader holding the prior snapshot never sees the growing slice.
+//
+//nolint:gocritic // hugeParam: rule mirrors the driver method signature.
+func (m *Mock) addSecurityGroupRule(groupID string, rule driver.SecurityRule, egress bool) error {
+	if !m.securityGroups.Update(groupID, func(sg *sgData) *sgData {
+		cp := *sg
+		if egress {
+			cp.EgressRules = append(append([]driver.SecurityRule(nil), sg.EgressRules...), rule)
+		} else {
+			cp.IngressRules = append(append([]driver.SecurityRule(nil), sg.IngressRules...), rule)
+		}
+
+		return &cp
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", groupID)
 	}
-
-	sg.EgressRules = append(sg.EgressRules, rule)
 
 	return nil
 }
@@ -337,47 +345,88 @@ func (m *Mock) AddEgressRule(_ context.Context, groupID string, rule driver.Secu
 //
 //nolint:gocritic // hugeParam: rule is passed by value to satisfy the Networking driver interface.
 func (m *Mock) RemoveIngressRule(_ context.Context, groupID string, rule driver.SecurityRule) error {
-	sg, ok := m.securityGroups.Get(groupID)
-	if !ok {
-		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", groupID)
-	}
-
-	for i, r := range sg.IngressRules {
-		if r.Equal(&rule) {
-			sg.IngressRules = append(sg.IngressRules[:i], sg.IngressRules[i+1:]...)
-			return nil
-		}
-	}
-
-	return cerrors.Newf(cerrors.NotFound, "ingress rule not found in network security group %q", groupID)
+	return m.removeSecurityGroupRule(groupID, rule, false)
 }
 
 // RemoveEgressRule removes a matching outbound rule from the specified network security group.
 //
 //nolint:gocritic // hugeParam: rule is passed by value to satisfy the Networking driver interface.
 func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.SecurityRule) error {
-	sg, ok := m.securityGroups.Get(groupID)
-	if !ok {
+	return m.removeSecurityGroupRule(groupID, rule, true)
+}
+
+// removeSecurityGroupRule removes the first ingress or egress rule matching rule
+// copy-on-write, reporting NotFound for a missing group and a direction-specific
+// NotFound when no rule matches.
+//
+//nolint:gocritic // hugeParam: rule mirrors the driver method signature.
+func (m *Mock) removeSecurityGroupRule(groupID string, rule driver.SecurityRule, egress bool) error {
+	removed := false
+
+	if !m.securityGroups.Update(groupID, func(sg *sgData) *sgData {
+		src := sg.IngressRules
+		if egress {
+			src = sg.EgressRules
+		}
+
+		next, ok := removeSecurityRule(src, &rule)
+		if !ok {
+			return sg
+		}
+
+		removed = true
+		cp := *sg
+
+		if egress {
+			cp.EgressRules = next
+		} else {
+			cp.IngressRules = next
+		}
+
+		return &cp
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", groupID)
 	}
 
-	for i, r := range sg.EgressRules {
-		if r.Equal(&rule) {
-			sg.EgressRules = append(sg.EgressRules[:i], sg.EgressRules[i+1:]...)
-			return nil
+	if !removed {
+		direction := "ingress"
+		if egress {
+			direction = "egress"
+		}
+
+		return cerrors.Newf(cerrors.NotFound, "%s rule not found in network security group %q", direction, groupID)
+	}
+
+	return nil
+}
+
+// removeSecurityRule returns a fresh slice with the first rule matching target
+// removed, and whether a match was found. The input slice is never mutated so a
+// reader holding the prior snapshot is unaffected (copy-on-write).
+func removeSecurityRule(rules []driver.SecurityRule, target *driver.SecurityRule) ([]driver.SecurityRule, bool) {
+	for i := range rules {
+		if rules[i].Equal(target) {
+			out := make([]driver.SecurityRule, 0, len(rules)-1)
+			out = append(out, rules[:i]...)
+			out = append(out, rules[i+1:]...)
+
+			return out, true
 		}
 	}
 
-	return cerrors.Newf(cerrors.NotFound, "egress rule not found in network security group %q", groupID)
+	return rules, false
 }
 
 // UpdateVPCTags merges the given tags into the virtual network's tag map.
-// The mutation runs under memstore.Update's lock; a fresh map is swapped in
-// so concurrent readers iterating the old map are unaffected.
+// The mutation runs under memstore.Update's lock and swaps in a fresh *vpcData
+// with a fresh tag map (copy-on-write): the stored pointer is never mutated in
+// place, so a reader holding a prior snapshot sees an immutable value.
 func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]string) error {
 	if !m.vpcs.Update(id, func(v *vpcData) *vpcData {
-		v.Tags = mergeTagMap(v.Tags, tags)
-		return v
+		cp := *v
+		cp.Tags = mergeTagMap(v.Tags, tags)
+
+		return &cp
 	}) {
 		return cerrors.Newf(cerrors.NotFound, "virtual network %q not found", id)
 	}
@@ -388,8 +437,10 @@ func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]strin
 // RemoveVPCTags removes the given tag keys from a virtual network.
 func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error {
 	if !m.vpcs.Update(id, func(v *vpcData) *vpcData {
-		v.Tags = removeTagMapKeys(v.Tags, keys)
-		return v
+		cp := *v
+		cp.Tags = removeTagMapKeys(v.Tags, keys)
+
+		return &cp
 	}) {
 		return cerrors.Newf(cerrors.NotFound, "virtual network %q not found", id)
 	}
@@ -397,16 +448,20 @@ func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error 
 	return nil
 }
 
-// UpdateSubnetCIDR changes a subnet's address prefix in place, implementing the
+// UpdateSubnetCIDR changes a subnet's address prefix, implementing the
 // SubnetCIDRUpdater capability (the ARM Subnets.CreateOrUpdate re-PUT path).
+// The change is applied copy-on-write onto a fresh *subnetData under the store
+// lock, never mutating the shared pointer a reader may still hold.
 func (m *Mock) UpdateSubnetCIDR(_ context.Context, id, cidr string) error {
 	if cidr == "" {
 		return cerrors.New(cerrors.InvalidArgument, "CIDR block is required")
 	}
 
 	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
-		s.CIDRBlock = cidr
-		return s
+		cp := *s
+		cp.CIDRBlock = cidr
+
+		return &cp
 	}) {
 		return cerrors.Newf(cerrors.NotFound, "subnet %q not found", id)
 	}
@@ -414,11 +469,13 @@ func (m *Mock) UpdateSubnetCIDR(_ context.Context, id, cidr string) error {
 	return nil
 }
 
-// UpdateSubnetTags merges tags into the subnet's tag map.
+// UpdateSubnetTags merges tags into the subnet's tag map, copy-on-write.
 func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]string) error {
 	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
-		s.Tags = mergeTagMap(s.Tags, tags)
-		return s
+		cp := *s
+		cp.Tags = mergeTagMap(s.Tags, tags)
+
+		return &cp
 	}) {
 		return cerrors.Newf(cerrors.NotFound, "subnet %q not found", id)
 	}
@@ -426,11 +483,13 @@ func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]st
 	return nil
 }
 
-// RemoveSubnetTags removes the given tag keys from a subnet.
+// RemoveSubnetTags removes the given tag keys from a subnet, copy-on-write.
 func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) error {
 	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
-		s.Tags = removeTagMapKeys(s.Tags, keys)
-		return s
+		cp := *s
+		cp.Tags = removeTagMapKeys(s.Tags, keys)
+
+		return &cp
 	}) {
 		return cerrors.Newf(cerrors.NotFound, "subnet %q not found", id)
 	}
@@ -438,11 +497,13 @@ func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) err
 	return nil
 }
 
-// UpdateSecurityGroupTags merges tags into the NSG's tag map.
+// UpdateSecurityGroupTags merges tags into the NSG's tag map, copy-on-write.
 func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
 	if !m.securityGroups.Update(id, func(sg *sgData) *sgData {
-		sg.Tags = mergeTagMap(sg.Tags, tags)
-		return sg
+		cp := *sg
+		cp.Tags = mergeTagMap(sg.Tags, tags)
+
+		return &cp
 	}) {
 		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", id)
 	}
@@ -450,11 +511,13 @@ func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[st
 	return nil
 }
 
-// RemoveSecurityGroupTags removes the given tag keys from an NSG.
+// RemoveSecurityGroupTags removes the given tag keys from an NSG, copy-on-write.
 func (m *Mock) RemoveSecurityGroupTags(_ context.Context, id string, keys []string) error {
 	if !m.securityGroups.Update(id, func(sg *sgData) *sgData {
-		sg.Tags = removeTagMapKeys(sg.Tags, keys)
-		return sg
+		cp := *sg
+		cp.Tags = removeTagMapKeys(sg.Tags, keys)
+
+		return &cp
 	}) {
 		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", id)
 	}

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -1382,6 +1382,14 @@ func (h *Handler) deleteNSG(w http.ResponseWriter, r *http.Request, rp azurearm.
 	// Real ARM refuses to delete an NSG still associated with any subnet or NIC,
 	// answering 400 InUseNetworkSecurityGroupCannotBeDeleted and naming the
 	// associated resources; the association must be dropped first.
+	//
+	// The reference scan reads the subnets/NICs stores and the delete writes the
+	// security-groups store — two independent memstores. Their per-store locks
+	// cannot span both, so this check-then-delete is not atomic; a subnet PUT
+	// that associates the NSG in the same instant may slip through. Real ARM has
+	// the same eventual-consistency window, and making it atomic would need a
+	// cross-store lock the emulator does not model, so the narrow gap is
+	// accepted here.
 	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeNSG, rp.ResourceName)
 
 	if refs := append(h.nsgAssociatedSubnets(r.Context(), id), h.nsgAssociatedNICs(r.Context(), id)...); len(refs) > 0 {
@@ -1535,7 +1543,10 @@ func (h *Handler) deletePublicIP(w http.ResponseWriter, r *http.Request, rp azur
 	// A NIC's ipConfiguration reference doesn't go through
 	// AssociateAddress/eip.AssociationID (that's reserved for AWS-style
 	// instance/NAT-gateway attachment), so it needs its own in-use check here
-	// — the same scan the ipConfiguration back-reference already does.
+	// — the same scan the ipConfiguration back-reference already does. This scan
+	// reads the NICs store while ReleaseAddress deletes from the public-IP store,
+	// so it shares the same non-atomic, ARM-like consistency window documented on
+	// the NSG guard; the eip's own association guard (ReleaseAddress) is atomic.
 	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typePublicIP, rp.ResourceName)
 
 	if h.publicIPConfigurationRef(r.Context(), rp.Subscription, id) != nil {

--- a/server/azure/vnet/route_table.go
+++ b/server/azure/vnet/route_table.go
@@ -159,6 +159,12 @@ func (h *Handler) deleteRouteTable(w http.ResponseWriter, r *http.Request, rp az
 
 	// Real ARM refuses to delete a route table still associated with any subnet,
 	// answering 400 InUseRouteTableCannotBeDeleted; disassociate the subnet first.
+	//
+	// As with the NSG guard, the subnet reference scan and the route-table delete
+	// touch two independent memstores whose locks cannot span both, so the
+	// check-then-delete is not atomic. The gap mirrors real ARM's consistency
+	// window and closing it would need a cross-store lock the emulator does not
+	// model, so it is accepted here.
 	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeRouteTable, rp.ResourceName)
 
 	if refs := h.routeTableAssociatedSubnets(r.Context(), id); len(refs) > 0 {


### PR DESCRIPTION
## Summary

Hardens the Azure `vnet` package against the logged systemic anti-pattern: `store.Get()` returning a shared `*T` that is then mutated in place, racing readers that hold a prior snapshot (reproduced under `-race`, including a dangling subnet-side reference).

### Copy-on-write mutators
Every `Get()`-then-in-place-mutate on a pointer-typed store now swaps in a **fresh** struct with fresh maps/slices via `memstore.Update`, never touching the shared stored pointer — so a reader mid-`Describe*` sees an immutable value. Converted across: subnet/NSG/VPC tags + CIDR, NSG ingress/egress rules, network-ACL rules, routes, internet-gateway attach/detach, peering state transitions, public-IP association, NAT-gateway binding, and endpoint modify.

### Atomic in-use guards (single-store)
- `ReleaseAddress` and `DeleteInternetGateway`: association/attached check + delete in one locked span via `UpdateOrDelete`.
- `DeleteNATGateway`: reads its bound allocation and deletes atomically.
- `AssociateAddress` / `bindNATGatewayAllocation`: check-and-set under `Update`.

### Cross-store guards (documented)
The server-layer NSG / route-table / public-IP delete guards scan a *different* memstore (subnets/NICs) than the resource being deleted. That check-then-delete cannot span two independent per-store locks; the narrow, ARM-like consistency window is documented at each guard rather than closed with a cross-store lock the emulator does not model.

### Tests
New `-race` concurrency test: concurrent mutators (subnet tags/CIDR, NSG rules/tags) and `Describe*` readers on the same resources from many goroutines, plus associate-vs-delete contention exercising the atomic in-use guards. No behavior change beyond making mutations atomic/COW — all existing vnet tests pass unchanged.

### Gates
`go build ./...`, `gofmt -l` empty, `go test ./providers/azure/vnet/... ./server/azure/vnet/... -race` clean (incl. new tests), broad `go test ./server/azure/...` green, full `go test ./...` exit 0, `golangci-lint` 0 new issues on touched packages, coveragegen + `go mod tidy` clean.