### PR TITLE
feat(gcs): full lifecycle rule conditions (numNewerVersions/isLive/createdBefore/…)

### DIFF
--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -89,13 +89,19 @@ type bucketMeta struct {
 	tags       map[string]string
 
 	// mu guards the GCS-specific mutable fields below (location/storageClass,
-	// metageneration/updated, iamPolicy, and the archived version history).
+	// metageneration/updated, iamPolicy, lifecycle, and the archived version
+	// history).
 	mu             sync.Mutex
 	location       string
 	storageClass   string
 	metageneration int64
 	updated        string
 	iamPolicy      []byte
+	// gcsLifecycleRaw is the bucket's lifecycle configuration stored verbatim as
+	// GCS JSON ({"rule":[...]}), preserving every rule condition the wire layer
+	// received. It is the authoritative source for EvaluateLifecycle and
+	// ApplyLifecycleGCS; lifecycle (the portable subset) mirrors its age rules.
+	gcsLifecycleRaw []byte
 	// versions holds archived (non-current) object generations keyed by object
 	// key, oldest-first, populated on overwrite when versioning is enabled.
 	versions map[string][]*gcsObject
@@ -872,91 +878,6 @@ func (m *Mock) GeneratePresignedURL(_ context.Context, req driver.PresignedURLRe
 	)
 
 	return &driver.PresignedURL{URL: url, Method: req.Method, ExpiresAt: expiresAt}, nil
-}
-
-func (m *Mock) PutLifecycleConfig(_ context.Context, bucket string, cfg driver.LifecycleConfig) error {
-	bkt, ok := m.buckets.Get(bucket)
-	if !ok {
-		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
-	}
-
-	cfgCopy := driver.LifecycleConfig{Rules: make([]driver.LifecycleRule, len(cfg.Rules))}
-	copy(cfgCopy.Rules, cfg.Rules)
-	bkt.lifecycle = &cfgCopy
-
-	return nil
-}
-
-func (m *Mock) GetLifecycleConfig(_ context.Context, bucket string) (*driver.LifecycleConfig, error) {
-	bkt, ok := m.buckets.Get(bucket)
-	if !ok {
-		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
-	}
-
-	if bkt.lifecycle == nil {
-		return nil, cerrors.Newf(cerrors.NotFound, "no lifecycle configuration for bucket %q", bucket)
-	}
-
-	return bkt.lifecycle, nil
-}
-
-func (m *Mock) EvaluateLifecycle(_ context.Context, bucket string) ([]string, error) {
-	bkt, ok := m.buckets.Get(bucket)
-	if !ok {
-		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
-	}
-
-	if bkt.lifecycle == nil {
-		return nil, nil
-	}
-
-	now := m.opts.Clock.Now().UTC()
-	expired := collectExpiredGCSKeys(bkt, now)
-	sort.Strings(expired)
-
-	return expired, nil
-}
-
-func collectExpiredGCSKeys(bkt *bucketMeta, now time.Time) []string {
-	var result []string
-
-	for _, key := range bkt.objects.Keys() {
-		obj, objOk := bkt.objects.Get(key)
-		if !objOk {
-			continue
-		}
-
-		if gcsObjectExpired(obj, bkt.lifecycle, now) {
-			result = append(result, key)
-		}
-	}
-
-	return result
-}
-
-func gcsObjectExpired(obj *gcsObject, cfg *driver.LifecycleConfig, now time.Time) bool {
-	modified, err := time.Parse(gcsTimeFormat, obj.LastModified)
-	if err != nil {
-		return false
-	}
-
-	age := now.Sub(modified)
-
-	for _, rule := range cfg.Rules {
-		if !rule.Enabled {
-			continue
-		}
-
-		if rule.Prefix != "" && !strings.HasPrefix(obj.Key, rule.Prefix) {
-			continue
-		}
-
-		if rule.ExpirationDays > 0 && age >= time.Duration(rule.ExpirationDays)*gcsHoursPerDay*time.Hour {
-			return true
-		}
-	}
-
-	return false
 }
 
 func (m *Mock) CreateMultipartUpload(

--- a/providers/gcp/gcs/lifecycle.go
+++ b/providers/gcp/gcs/lifecycle.go
@@ -1,0 +1,505 @@
+package gcs
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// lifecycleRawStore mirrors the server-side capability the GCS wire handler
+// type-asserts for; declaring it here gives a compile-time guarantee the Mock
+// keeps the exact signatures the handler needs.
+var _ interface {
+	SetLifecycleGCS(ctx context.Context, bucket string, doc []byte) error
+	GetLifecycleGCS(ctx context.Context, bucket string) ([]byte, bool, error)
+} = (*Mock)(nil)
+
+const (
+	actionDelete   = "Delete"
+	actionSetClass = "SetStorageClass"
+)
+
+// gcsLifecycleDoc mirrors the GCS JSON lifecycle object ({"rule":[...]}) so the
+// evaluator can interpret the full set of rule conditions the wire layer stored
+// verbatim (https://cloud.google.com/storage/docs/lifecycle#conditions).
+type gcsLifecycleDoc struct {
+	Rule []gcsLifecycleRule `json:"rule"`
+}
+
+type gcsLifecycleRule struct {
+	Action    gcsLifecycleAction    `json:"action"`
+	Condition gcsLifecycleCondition `json:"condition"`
+}
+
+type gcsLifecycleAction struct {
+	Type         string `json:"type"`
+	StorageClass string `json:"storageClass,omitempty"`
+}
+
+type gcsLifecycleCondition struct {
+	Age                     *int     `json:"age,omitempty"`
+	CreatedBefore           string   `json:"createdBefore,omitempty"`
+	CustomTimeBefore        string   `json:"customTimeBefore,omitempty"`
+	DaysSinceCustomTime     *int     `json:"daysSinceCustomTime,omitempty"`
+	DaysSinceNoncurrentTime *int     `json:"daysSinceNoncurrentTime,omitempty"`
+	NoncurrentTimeBefore    string   `json:"noncurrentTimeBefore,omitempty"`
+	IsLive                  *bool    `json:"isLive,omitempty"`
+	MatchesStorageClass     []string `json:"matchesStorageClass,omitempty"`
+	NumNewerVersions        *int     `json:"numNewerVersions,omitempty"`
+	MatchesPrefix           []string `json:"matchesPrefix,omitempty"`
+	MatchesSuffix           []string `json:"matchesSuffix,omitempty"`
+}
+
+// SetLifecycleGCS stores the bucket's lifecycle configuration verbatim (doc is
+// GCS JSON, {"rule":[...]}), preserving every condition. It also derives the
+// portable age-only subset so GetLifecycleConfig stays coherent.
+func (m *Mock) SetLifecycleGCS(_ context.Context, bucket string, doc []byte) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	raw := append([]byte(nil), doc...)
+	derived := deriveLifecycleConfig(raw)
+
+	bkt.mu.Lock()
+	bkt.gcsLifecycleRaw = raw
+	bkt.lifecycle = derived
+	bkt.mu.Unlock()
+
+	return nil
+}
+
+// GetLifecycleGCS returns the verbatim lifecycle JSON for a bucket, reporting
+// ok=false when none is set.
+func (m *Mock) GetLifecycleGCS(_ context.Context, bucket string) (doc []byte, ok bool, err error) {
+	bkt, found := m.buckets.Get(bucket)
+	if !found {
+		return nil, false, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	if len(bkt.gcsLifecycleRaw) == 0 {
+		return nil, false, nil
+	}
+
+	return append([]byte(nil), bkt.gcsLifecycleRaw...), true, nil
+}
+
+// deriveLifecycleConfig projects the verbatim GCS lifecycle onto the portable
+// driver.LifecycleConfig (age-based Delete/SetStorageClass only) so the typed
+// GetLifecycleConfig surfaces something coherent. Returns nil when the doc has
+// no rules.
+func deriveLifecycleConfig(raw []byte) *driver.LifecycleConfig {
+	var doc gcsLifecycleDoc
+	if err := json.Unmarshal(raw, &doc); err != nil || len(doc.Rule) == 0 {
+		return nil
+	}
+
+	cfg := &driver.LifecycleConfig{Rules: make([]driver.LifecycleRule, 0, len(doc.Rule))}
+
+	for i := range doc.Rule {
+		r := &doc.Rule[i]
+		rule := driver.LifecycleRule{ID: strconv.Itoa(i), Enabled: true}
+
+		if len(r.Condition.MatchesPrefix) > 0 {
+			rule.Prefix = r.Condition.MatchesPrefix[0]
+		}
+
+		age := 0
+		if r.Condition.Age != nil {
+			age = *r.Condition.Age
+		}
+
+		switch r.Action.Type {
+		case actionDelete:
+			rule.ExpirationDays = age
+		case actionSetClass:
+			rule.TransitionDays = age
+			rule.TransitionStorageClass = r.Action.StorageClass
+		}
+
+		cfg.Rules = append(cfg.Rules, rule)
+	}
+
+	return cfg
+}
+
+// PutLifecycleConfig sets the portable (age-only) lifecycle configuration. It
+// clears any verbatim GCS config so the portable rules become authoritative.
+func (m *Mock) PutLifecycleConfig(_ context.Context, bucket string, cfg driver.LifecycleConfig) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	cfgCopy := driver.LifecycleConfig{Rules: make([]driver.LifecycleRule, len(cfg.Rules))}
+	copy(cfgCopy.Rules, cfg.Rules)
+
+	bkt.mu.Lock()
+	bkt.lifecycle = &cfgCopy
+	bkt.gcsLifecycleRaw = nil
+	bkt.mu.Unlock()
+
+	return nil
+}
+
+// GetLifecycleConfig returns the portable lifecycle configuration.
+func (m *Mock) GetLifecycleConfig(_ context.Context, bucket string) (*driver.LifecycleConfig, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.mu.Lock()
+	cfg := bkt.lifecycle
+	bkt.mu.Unlock()
+
+	if cfg == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no lifecycle configuration for bucket %q", bucket)
+	}
+
+	return cfg, nil
+}
+
+// EvaluateLifecycle reports the live-object keys eligible for a Delete action
+// under the bucket's lifecycle rules. It is non-destructive (real GCS runs the
+// sweep asynchronously; ApplyLifecycleGCS performs the destructive pass). When
+// a verbatim GCS config is present its full condition set is honored; otherwise
+// the portable age/prefix rules are used.
+func (m *Mock) EvaluateLifecycle(_ context.Context, bucket string) ([]string, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	now := m.opts.Clock.Now().UTC()
+
+	bkt.mu.Lock()
+	raw := bkt.gcsLifecycleRaw
+	portable := bkt.lifecycle
+	bkt.mu.Unlock()
+
+	if len(raw) > 0 {
+		return evaluateRichLive(bkt, raw, now), nil
+	}
+
+	if portable == nil {
+		return nil, nil
+	}
+
+	return evaluatePortableLive(bkt, portable, now), nil
+}
+
+// evaluateRichLive returns the sorted live keys a Delete rule expires under the
+// verbatim GCS lifecycle conditions.
+func evaluateRichLive(bkt *bucketMeta, raw []byte, now time.Time) []string {
+	var doc gcsLifecycleDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil
+	}
+
+	var result []string
+
+	for _, key := range bkt.objects.Keys() {
+		obj, objOk := bkt.objects.Get(key)
+		if !objOk {
+			continue
+		}
+
+		if liveObjectExpires(obj, doc.Rule, now) {
+			result = append(result, key)
+		}
+	}
+
+	sort.Strings(result)
+
+	return result
+}
+
+// evaluatePortableLive is the age/prefix fallback used when no verbatim GCS
+// config is stored (e.g. lifecycle set through the typed PutLifecycleConfig).
+func evaluatePortableLive(bkt *bucketMeta, cfg *driver.LifecycleConfig, now time.Time) []string {
+	var result []string
+
+	for _, key := range bkt.objects.Keys() {
+		obj, objOk := bkt.objects.Get(key)
+		if !objOk {
+			continue
+		}
+
+		if portableObjectExpired(obj, cfg, now) {
+			result = append(result, key)
+		}
+	}
+
+	sort.Strings(result)
+
+	return result
+}
+
+func portableObjectExpired(obj *gcsObject, cfg *driver.LifecycleConfig, now time.Time) bool {
+	modified, err := time.Parse(gcsTimeFormat, obj.LastModified)
+	if err != nil {
+		return false
+	}
+
+	age := now.Sub(modified)
+
+	for _, rule := range cfg.Rules {
+		if !rule.Enabled {
+			continue
+		}
+
+		if rule.Prefix != "" && !strings.HasPrefix(obj.Key, rule.Prefix) {
+			continue
+		}
+
+		if rule.ExpirationDays > 0 && age >= daysDuration(rule.ExpirationDays) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// liveObjectExpires reports whether a live object matches any Delete rule.
+func liveObjectExpires(obj *gcsObject, rules []gcsLifecycleRule, now time.Time) bool {
+	for i := range rules {
+		if rules[i].Action.Type != actionDelete {
+			continue
+		}
+
+		if matchesLive(obj, &rules[i].Condition, now) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// matchesLive evaluates a rule's conditions against a live object. Conditions
+// are ANDed; a condition that only applies to noncurrent versions
+// (numNewerVersions / daysSinceNoncurrentTime / noncurrentTimeBefore) or that
+// cannot be evaluated for lack of state (customTime) makes the rule non-matching
+// for a live object, so the emulator never over-deletes.
+func matchesLive(obj *gcsObject, c *gcsLifecycleCondition, now time.Time) bool {
+	if c.IsLive != nil && !*c.IsLive {
+		return false
+	}
+
+	if c.NumNewerVersions != nil || c.DaysSinceNoncurrentTime != nil || c.NoncurrentTimeBefore != "" {
+		return false
+	}
+
+	return commonConditionsMatch(obj, c, now) && conditionIsEvaluable(c)
+}
+
+// matchesNoncurrent evaluates a rule's conditions against a noncurrent version,
+// where newer is the number of newer versions of the same object (including the
+// live one). numNewerVersions is the versioning-aware condition; other
+// conditions are ANDed with it.
+func matchesNoncurrent(obj *gcsObject, c *gcsLifecycleCondition, newer int, now time.Time) bool {
+	if c.IsLive != nil && *c.IsLive {
+		return false
+	}
+
+	if c.NumNewerVersions != nil && newer < *c.NumNewerVersions {
+		return false
+	}
+
+	return commonConditionsMatch(obj, c, now) && conditionIsEvaluable(c)
+}
+
+// commonConditionsMatch checks the conditions shared by live and noncurrent
+// objects: age, createdBefore, matchesStorageClass, matchesPrefix, matchesSuffix.
+func commonConditionsMatch(obj *gcsObject, c *gcsLifecycleCondition, now time.Time) bool {
+	created, err := time.Parse(gcsTimeFormat, objectCreated(obj))
+	if err != nil {
+		return false
+	}
+
+	return ageConditionsMatch(created, c, now) && classAndNameMatch(obj, c)
+}
+
+func ageConditionsMatch(created time.Time, c *gcsLifecycleCondition, now time.Time) bool {
+	if c.Age != nil && now.Sub(created) < daysDuration(*c.Age) {
+		return false
+	}
+
+	if c.CreatedBefore != "" {
+		before, err := time.Parse(time.DateOnly, c.CreatedBefore)
+		if err != nil || !created.Before(before) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func classAndNameMatch(obj *gcsObject, c *gcsLifecycleCondition) bool {
+	if len(c.MatchesStorageClass) > 0 && !containsFold(c.MatchesStorageClass, obj.StorageClass) {
+		return false
+	}
+
+	if len(c.MatchesPrefix) > 0 && !anyPrefix(obj.Key, c.MatchesPrefix) {
+		return false
+	}
+
+	if len(c.MatchesSuffix) > 0 && !anySuffix(obj.Key, c.MatchesSuffix) {
+		return false
+	}
+
+	return true
+}
+
+// conditionIsEvaluable reports whether every condition present on the rule is
+// one the emulator can evaluate. customTime-based conditions have no backing
+// object state, so a rule carrying them is treated as non-matching rather than
+// silently ignoring the unmet guard.
+func conditionIsEvaluable(c *gcsLifecycleCondition) bool {
+	return c.DaysSinceCustomTime == nil && c.CustomTimeBefore == ""
+}
+
+// ApplyLifecycleGCS performs the destructive lifecycle pass over noncurrent
+// object versions: it deletes noncurrent versions matching a Delete rule
+// (numNewerVersions and the other version-applicable conditions), the way real
+// GCS prunes old versions on a versioned bucket. It returns the deleted version
+// identifiers ("key#generation"), sorted. Live objects are left untouched (use
+// EvaluateLifecycle to report live expirations). The pass is Clock-driven for
+// deterministic tests.
+func (m *Mock) ApplyLifecycleGCS(_ context.Context, bucket string) ([]string, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	now := m.opts.Clock.Now().UTC()
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	if len(bkt.gcsLifecycleRaw) == 0 {
+		return nil, nil
+	}
+
+	var doc gcsLifecycleDoc
+	if err := json.Unmarshal(bkt.gcsLifecycleRaw, &doc); err != nil {
+		return nil, nil
+	}
+
+	var deleted []string
+
+	for key := range bkt.versions {
+		liveExists := bkt.objects.Has(key)
+		deleted = append(deleted, pruneKeyVersions(bkt, key, liveExists, doc.Rule, now)...)
+	}
+
+	sort.Strings(deleted)
+
+	return deleted, nil
+}
+
+// pruneKeyVersions deletes the noncurrent versions of one key that match a
+// Delete rule, keeping the survivors in archival order. bkt.mu is held by the
+// caller.
+func pruneKeyVersions(bkt *bucketMeta, key string, liveExists bool, rules []gcsLifecycleRule, now time.Time) []string {
+	versions := bkt.versions[key]
+	total := len(versions)
+
+	live := 0
+	if liveExists {
+		live = 1
+	}
+
+	kept := versions[:0:0]
+
+	var deleted []string
+
+	for i, v := range versions {
+		// Versions newer than v: the archived ones after it (total-1-i) plus the
+		// live version, if any.
+		newer := (total - 1 - i) + live
+		if noncurrentVersionMatches(v, rules, newer, now) {
+			deleted = append(deleted, key+"#"+strconv.FormatInt(v.Generation, 10))
+
+			continue
+		}
+
+		kept = append(kept, v)
+	}
+
+	if len(kept) == 0 {
+		delete(bkt.versions, key)
+	} else {
+		bkt.versions[key] = kept
+	}
+
+	return deleted
+}
+
+func noncurrentVersionMatches(obj *gcsObject, rules []gcsLifecycleRule, newer int, now time.Time) bool {
+	for i := range rules {
+		if rules[i].Action.Type != actionDelete {
+			continue
+		}
+
+		if matchesNoncurrent(obj, &rules[i].Condition, newer, now) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// objectCreated returns the object's creation timestamp, falling back to its
+// last-modified stamp when Created is unset (older snapshots / copy paths).
+func objectCreated(obj *gcsObject) string {
+	if obj.Created != "" {
+		return obj.Created
+	}
+
+	return obj.LastModified
+}
+
+func daysDuration(days int) time.Duration {
+	return time.Duration(days) * gcsHoursPerDay * time.Hour
+}
+
+func containsFold(list []string, want string) bool {
+	for _, s := range list {
+		if strings.EqualFold(s, want) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func anyPrefix(key string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(key, p) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func anySuffix(key string, suffixes []string) bool {
+	for _, s := range suffixes {
+		if strings.HasSuffix(key, s) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/providers/gcp/gcs/lifecycle.go
+++ b/providers/gcp/gcs/lifecycle.go
@@ -362,11 +362,16 @@ func classAndNameMatch(obj *gcsObject, c *gcsLifecycleCondition) bool {
 }
 
 // conditionIsEvaluable reports whether every condition present on the rule is
-// one the emulator can evaluate. customTime-based conditions have no backing
-// object state, so a rule carrying them is treated as non-matching rather than
-// silently ignoring the unmet guard.
+// one the emulator can evaluate. customTime and noncurrent-time conditions have
+// no backing object state (the emulator does not track an object's custom time
+// or the instant a version became noncurrent), so a rule carrying any of them is
+// treated as non-matching rather than silently ignoring the unmet guard — the
+// conservative choice that avoids deleting versions the condition has not
+// actually cleared. These fields still round-trip verbatim; only their
+// evaluation is suppressed.
 func conditionIsEvaluable(c *gcsLifecycleCondition) bool {
-	return c.DaysSinceCustomTime == nil && c.CustomTimeBefore == ""
+	return c.DaysSinceCustomTime == nil && c.CustomTimeBefore == "" &&
+		c.DaysSinceNoncurrentTime == nil && c.NoncurrentTimeBefore == ""
 }
 
 // ApplyLifecycleGCS performs the destructive lifecycle pass over noncurrent

--- a/providers/gcp/gcs/lifecycle_conditions_test.go
+++ b/providers/gcp/gcs/lifecycle_conditions_test.go
@@ -246,6 +246,59 @@ func TestApplyLifecycleNumNewerVersions(t *testing.T) {
 	assert.Empty(t, deleted)
 }
 
+// TestApplyLifecycleNoncurrentTimeConservative guards against over-deletion:
+// the emulator has no backing state for when a version became noncurrent, so a
+// Delete rule keyed ONLY on daysSinceNoncurrentTime / noncurrentTimeBefore must
+// match NOTHING on the destructive pass (conservative), while still round-tripping
+// the condition verbatim.
+func TestApplyLifecycleNoncurrentTimeConservative(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		cond gcsLifecycleCondition
+	}{
+		{"daysSinceNoncurrentTime only", gcsLifecycleCondition{DaysSinceNoncurrentTime: intPtr(30)}},
+		{"noncurrentTimeBefore only", gcsLifecycleCondition{NoncurrentTimeBefore: "2026-01-01"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newMock(t)
+
+			const bucket = "e2e-lc-nct"
+			require.NoError(t, m.CreateBucket(ctx, bucket))
+			require.NoError(t, m.SetBucketVersioning(ctx, bucket, true))
+
+			// One archived (noncurrent) generation plus a live version.
+			require.NoError(t, m.PutObject(ctx, bucket, "obj", []byte("v1"), "text/plain", nil))
+			require.NoError(t, m.PutObject(ctx, bucket, "obj", []byte("v2"), "text/plain", nil))
+
+			bkt, ok := m.buckets.Get(bucket)
+			require.True(t, ok)
+			require.Len(t, bkt.versions["obj"], 1)
+
+			doc := marshalLifecycle(t, gcsLifecycleRule{
+				Action:    gcsLifecycleAction{Type: "Delete"},
+				Condition: tc.cond,
+			})
+			require.NoError(t, m.SetLifecycleGCS(ctx, bucket, doc))
+
+			// Destructive pass deletes nothing: no backing noncurrent-time state.
+			deleted, err := m.ApplyLifecycleGCS(ctx, bucket)
+			require.NoError(t, err)
+			assert.Empty(t, deleted, "noncurrent-time-only rule must not delete any version")
+			assert.Len(t, bkt.versions["obj"], 1, "noncurrent version must survive")
+
+			// The condition still round-trips verbatim.
+			got, present, err := m.GetLifecycleGCS(ctx, bucket)
+			require.NoError(t, err)
+			require.True(t, present)
+			assert.JSONEq(t, string(doc), string(got))
+		})
+	}
+}
+
 // TestApplyLifecycleNoConfig is a no-op when no verbatim config is set.
 func TestApplyLifecycleNoConfig(t *testing.T) {
 	ctx := context.Background()

--- a/providers/gcp/gcs/lifecycle_conditions_test.go
+++ b/providers/gcp/gcs/lifecycle_conditions_test.go
@@ -1,0 +1,263 @@
+// Package gcs e2e suite tests: STORAGE / gcp / portable lifecycle conditions.
+//
+// These tests exercise the full GCS lifecycle rule condition set beyond age:
+// verbatim round-trip through SetLifecycleGCS/GetLifecycleGCS, the extended
+// live-object EvaluateLifecycle (createdBefore/matchesStorageClass/prefix/
+// suffix/isLive), and the versioning-aware ApplyLifecycleGCS pass
+// (numNewerVersions), all driven by the deterministic fake clock.
+package gcs
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+func intPtr(v int) *int    { return &v }
+func boolPtr(v bool) *bool { return &v }
+
+// marshalLifecycle renders rules into the GCS lifecycle JSON the wire layer
+// stores verbatim.
+func marshalLifecycle(t *testing.T, rules ...gcsLifecycleRule) []byte {
+	t.Helper()
+
+	doc, err := json.Marshal(gcsLifecycleDoc{Rule: rules})
+	require.NoError(t, err)
+
+	return doc
+}
+
+// TestLifecycleRawRoundTrip stores a config carrying every standard condition
+// and reads it back byte-for-byte, and confirms the portable projection.
+func TestLifecycleRawRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newMock(t)
+
+	const bucket = "e2e-lc-roundtrip"
+	require.NoError(t, m.CreateBucket(ctx, bucket))
+
+	doc := marshalLifecycle(t,
+		gcsLifecycleRule{
+			Action: gcsLifecycleAction{Type: "Delete"},
+			Condition: gcsLifecycleCondition{
+				Age:                     intPtr(30),
+				CreatedBefore:           "2026-01-01",
+				NumNewerVersions:        intPtr(3),
+				IsLive:                  boolPtr(false),
+				MatchesStorageClass:     []string{"NEARLINE", "COLDLINE"},
+				MatchesPrefix:           []string{"logs/"},
+				MatchesSuffix:           []string{".tmp"},
+				DaysSinceNoncurrentTime: intPtr(7),
+			},
+		},
+		gcsLifecycleRule{
+			Action:    gcsLifecycleAction{Type: "SetStorageClass", StorageClass: "COLDLINE"},
+			Condition: gcsLifecycleCondition{Age: intPtr(90)},
+		},
+	)
+
+	require.NoError(t, m.SetLifecycleGCS(ctx, bucket, doc))
+
+	got, ok, err := m.GetLifecycleGCS(ctx, bucket)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.JSONEq(t, string(doc), string(got), "lifecycle must round-trip verbatim")
+
+	// Portable projection surfaces the age subset (no NotFound).
+	cfg, err := m.GetLifecycleConfig(ctx, bucket)
+	require.NoError(t, err)
+	require.Len(t, cfg.Rules, 2)
+	assert.Equal(t, 30, cfg.Rules[0].ExpirationDays)
+	assert.Equal(t, "logs/", cfg.Rules[0].Prefix)
+	assert.Equal(t, 90, cfg.Rules[1].TransitionDays)
+	assert.Equal(t, "COLDLINE", cfg.Rules[1].TransitionStorageClass)
+
+	// Unset bucket: not found; missing bucket: not found.
+	_, ok, err = m.GetLifecycleGCS(ctx, "e2e-lc-none")
+	require.Error(t, err)
+	assert.False(t, ok)
+}
+
+// TestEvaluateLifecycleRichConditions checks the live-object evaluator honors
+// createdBefore, matchesStorageClass, prefix/suffix and isLive — not just age —
+// and never over-deletes on unevaluable (customTime) conditions.
+func TestEvaluateLifecycleRichConditions(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newMock(t)
+
+	const bucket = "e2e-lc-eval"
+	require.NoError(t, m.CreateBucket(ctx, bucket))
+
+	// Two objects, distinct storage classes, created at t0.
+	_, err := m.PutObjectGCS(ctx, bucket, "logs/a.log", []byte("a"), "text/plain", nil,
+		&driver.GCSObjectAttrs{StorageClass: "NEARLINE"}, driver.GCSPrecondition{})
+	require.NoError(t, err)
+	_, err = m.PutObjectGCS(ctx, bucket, "logs/b.txt", []byte("b"), "text/plain", nil,
+		&driver.GCSObjectAttrs{StorageClass: "STANDARD"}, driver.GCSPrecondition{})
+	require.NoError(t, err)
+
+	t.Run("matchesStorageClass + prefix", func(t *testing.T) {
+		doc := marshalLifecycle(t, gcsLifecycleRule{
+			Action: gcsLifecycleAction{Type: "Delete"},
+			Condition: gcsLifecycleCondition{
+				MatchesStorageClass: []string{"NEARLINE"},
+				MatchesPrefix:       []string{"logs/"},
+			},
+		})
+		require.NoError(t, m.SetLifecycleGCS(ctx, bucket, doc))
+
+		expired, evErr := m.EvaluateLifecycle(ctx, bucket)
+		require.NoError(t, evErr)
+		assert.Equal(t, []string{"logs/a.log"}, expired, "only the NEARLINE object matches")
+	})
+
+	t.Run("suffix match", func(t *testing.T) {
+		doc := marshalLifecycle(t, gcsLifecycleRule{
+			Action:    gcsLifecycleAction{Type: "Delete"},
+			Condition: gcsLifecycleCondition{MatchesSuffix: []string{".txt"}},
+		})
+		require.NoError(t, m.SetLifecycleGCS(ctx, bucket, doc))
+
+		expired, evErr := m.EvaluateLifecycle(ctx, bucket)
+		require.NoError(t, evErr)
+		assert.Equal(t, []string{"logs/b.txt"}, expired)
+	})
+
+	t.Run("createdBefore", func(t *testing.T) {
+		// Objects created 2026-07-18; a cutoff the next day matches both.
+		doc := marshalLifecycle(t, gcsLifecycleRule{
+			Action:    gcsLifecycleAction{Type: "Delete"},
+			Condition: gcsLifecycleCondition{CreatedBefore: "2026-07-19"},
+		})
+		require.NoError(t, m.SetLifecycleGCS(ctx, bucket, doc))
+
+		expired, evErr := m.EvaluateLifecycle(ctx, bucket)
+		require.NoError(t, evErr)
+		assert.Equal(t, []string{"logs/a.log", "logs/b.txt"}, expired)
+
+		// A cutoff on the creation date itself matches nothing (before is strict).
+		doc = marshalLifecycle(t, gcsLifecycleRule{
+			Action:    gcsLifecycleAction{Type: "Delete"},
+			Condition: gcsLifecycleCondition{CreatedBefore: "2026-07-18"},
+		})
+		require.NoError(t, m.SetLifecycleGCS(ctx, bucket, doc))
+
+		expired, evErr = m.EvaluateLifecycle(ctx, bucket)
+		require.NoError(t, evErr)
+		assert.Empty(t, expired)
+	})
+
+	t.Run("isLive false skips live objects", func(t *testing.T) {
+		doc := marshalLifecycle(t, gcsLifecycleRule{
+			Action:    gcsLifecycleAction{Type: "Delete"},
+			Condition: gcsLifecycleCondition{IsLive: boolPtr(false), Age: intPtr(0)},
+		})
+		require.NoError(t, m.SetLifecycleGCS(ctx, bucket, doc))
+
+		expired, evErr := m.EvaluateLifecycle(ctx, bucket)
+		require.NoError(t, evErr)
+		assert.Empty(t, expired, "isLive:false targets noncurrent versions, not live objects")
+	})
+
+	t.Run("age condition with clock", func(t *testing.T) {
+		doc := marshalLifecycle(t, gcsLifecycleRule{
+			Action:    gcsLifecycleAction{Type: "Delete"},
+			Condition: gcsLifecycleCondition{Age: intPtr(10)},
+		})
+		require.NoError(t, m.SetLifecycleGCS(ctx, bucket, doc))
+
+		expired, evErr := m.EvaluateLifecycle(ctx, bucket)
+		require.NoError(t, evErr)
+		assert.Empty(t, expired, "not old enough yet")
+
+		clk.Advance(11 * 24 * time.Hour)
+
+		expired, evErr = m.EvaluateLifecycle(ctx, bucket)
+		require.NoError(t, evErr)
+		assert.Equal(t, []string{"logs/a.log", "logs/b.txt"}, expired)
+	})
+
+	t.Run("unevaluable customTime never matches", func(t *testing.T) {
+		doc := marshalLifecycle(t, gcsLifecycleRule{
+			Action:    gcsLifecycleAction{Type: "Delete"},
+			Condition: gcsLifecycleCondition{DaysSinceCustomTime: intPtr(0)},
+		})
+		require.NoError(t, m.SetLifecycleGCS(ctx, bucket, doc))
+
+		expired, evErr := m.EvaluateLifecycle(ctx, bucket)
+		require.NoError(t, evErr)
+		assert.Empty(t, expired, "customTime has no backing state; rule must not fire")
+	})
+
+	// Evaluation stays non-destructive.
+	_, err = m.GetObject(ctx, bucket, "logs/a.log")
+	require.NoError(t, err)
+}
+
+// TestApplyLifecycleNumNewerVersions drives the destructive versioning-aware
+// pass: overwriting a key on a versioned bucket archives prior generations, and
+// a Delete rule with numNewerVersions prunes the excess noncurrent versions.
+func TestApplyLifecycleNumNewerVersions(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newMock(t)
+
+	const bucket = "e2e-lc-nnv"
+	require.NoError(t, m.CreateBucket(ctx, bucket))
+	require.NoError(t, m.SetBucketVersioning(ctx, bucket, true))
+
+	// Four generations of the same key: live = v4; noncurrent = [v1, v2, v3].
+	for _, body := range []string{"v1", "v2", "v3", "v4"} {
+		require.NoError(t, m.PutObject(ctx, bucket, "obj", []byte(body), "text/plain", nil))
+	}
+
+	bkt, ok := m.buckets.Get(bucket)
+	require.True(t, ok)
+	require.Len(t, bkt.versions["obj"], 3, "three archived generations before pruning")
+
+	// Delete noncurrent versions with >=2 newer versions (including live).
+	doc := marshalLifecycle(t, gcsLifecycleRule{
+		Action:    gcsLifecycleAction{Type: "Delete"},
+		Condition: gcsLifecycleCondition{NumNewerVersions: intPtr(2)},
+	})
+	require.NoError(t, m.SetLifecycleGCS(ctx, bucket, doc))
+
+	deleted, err := m.ApplyLifecycleGCS(ctx, bucket)
+	require.NoError(t, err)
+	assert.Len(t, deleted, 2, "the two oldest noncurrent versions have >=2 newer versions")
+
+	// Exactly one noncurrent version survives (the newest, with 1 newer).
+	require.Len(t, bkt.versions["obj"], 1)
+
+	// Live object is untouched.
+	live, err := m.GetObject(ctx, bucket, "obj")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("v4"), live.Data)
+
+	// Idempotent second pass deletes nothing more.
+	deleted, err = m.ApplyLifecycleGCS(ctx, bucket)
+	require.NoError(t, err)
+	assert.Empty(t, deleted)
+}
+
+// TestApplyLifecycleNoConfig is a no-op when no verbatim config is set.
+func TestApplyLifecycleNoConfig(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newMock(t)
+
+	const bucket = "e2e-lc-apply-empty"
+	require.NoError(t, m.CreateBucket(ctx, bucket))
+
+	deleted, err := m.ApplyLifecycleGCS(ctx, bucket)
+	require.NoError(t, err)
+	assert.Empty(t, deleted)
+
+	_, err = m.ApplyLifecycleGCS(ctx, "no-such-bucket")
+	requireCode(t, err, cerrors.NotFound)
+}

--- a/providers/gcp/gcs/snapshot.go
+++ b/providers/gcp/gcs/snapshot.go
@@ -29,6 +29,7 @@ type bucketSnapshot struct {
 	CreatedAt      string                                  `json:"createdAt,omitempty"`
 	Versioning     bool                                    `json:"versioning,omitempty"`
 	Lifecycle      *driver.LifecycleConfig                 `json:"lifecycle,omitempty"`
+	LifecycleRaw   []byte                                  `json:"lifecycleRaw,omitempty"`
 	Policy         *driver.BucketPolicy                    `json:"policy,omitempty"`
 	CORS           *driver.CORSConfig                      `json:"cors,omitempty"`
 	Encryption     *driver.EncryptionConfig                `json:"encryption,omitempty"`
@@ -86,7 +87,7 @@ func (m *Mock) Snapshot(_ context.Context, includeAssets bool) (json.RawMessage,
 func snapshotBucket(bkt *bucketMeta, includeAssets bool) *bucketSnapshot {
 	bs := &bucketSnapshot{
 		Name: bkt.Name, Region: bkt.Region, CreatedAt: bkt.CreatedAt,
-		Versioning: bkt.versioning, Lifecycle: bkt.lifecycle, Policy: bkt.policy,
+		Versioning: bkt.versioning, Lifecycle: bkt.lifecycle, LifecycleRaw: bkt.gcsLifecycleRaw, Policy: bkt.policy,
 		CORS: bkt.corsConfig, Encryption: bkt.encryption, Tags: bkt.tags,
 		Location: bkt.location, StorageClass: bkt.storageClass,
 		Metageneration: bkt.metageneration, Updated: bkt.updated, IAMPolicy: bkt.iamPolicy,
@@ -184,7 +185,7 @@ func restoreBucket(bs *bucketSnapshot) *bucketMeta {
 		objects:    memstore.New[*gcsObject](),
 		multiparts: memstore.New[*gcsMultipartUpload](),
 		versioning: bs.Versioning,
-		lifecycle:  bs.Lifecycle, policy: bs.Policy, corsConfig: bs.CORS,
+		lifecycle:  bs.Lifecycle, gcsLifecycleRaw: bs.LifecycleRaw, policy: bs.Policy, corsConfig: bs.CORS,
 		encryption: bs.Encryption, tags: bs.Tags,
 		location: bs.Location, storageClass: bs.StorageClass,
 		metageneration: metagen, updated: bs.Updated, iamPolicy: bs.IAMPolicy,

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -88,6 +88,11 @@ type Handler struct {
 	// object patch, versioned listing, and bucket location/IAM/metageneration.
 	ext storagedriver.GCSExtensions
 
+	// lifecycle is the optional capability that persists a bucket's lifecycle
+	// configuration verbatim (every rule condition), nil when the backing driver
+	// only supports the age-only portable driver.LifecycleConfig.
+	lifecycle lifecycleRawStore
+
 	// publisher emits object-change events to Pub/Sub for matching bucket
 	// notification configs. Nil (the default) makes object events a no-op, so
 	// object writes/deletes still succeed without Pub/Sub wired.
@@ -119,8 +124,9 @@ type resumableSession struct {
 // New returns a GCS handler backed by b.
 func New(b storagedriver.Bucket) *Handler {
 	ext, _ := b.(storagedriver.GCSExtensions)
+	lifecycle, _ := b.(lifecycleRawStore)
 
-	return &Handler{bucket: b, ext: ext, resumable: make(map[string]*resumableSession)}
+	return &Handler{bucket: b, ext: ext, lifecycle: lifecycle, resumable: make(map[string]*resumableSession)}
 }
 
 // Matches returns true for /storage/v1/, /upload/storage/v1/, and direct
@@ -289,7 +295,7 @@ func (h *Handler) createBucket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if body.Lifecycle != nil {
-		_ = h.bucket.PutLifecycleConfig(r.Context(), body.Name, toLifecycleConfig(body.Lifecycle))
+		_ = h.putLifecycle(r.Context(), body.Name, body.Lifecycle)
 	}
 
 	writeJSON(w, http.StatusOK, h.bucketView(r, body.Name, time.Now().UTC().Format(time.RFC3339)))
@@ -357,8 +363,8 @@ func (h *Handler) bucketView(r *http.Request, name, created string) bucketResour
 		res.Labels = labels
 	}
 
-	if cfg, err := h.bucket.GetLifecycleConfig(r.Context(), name); err == nil && cfg != nil && len(cfg.Rules) > 0 {
-		res.Lifecycle = fromLifecycleConfig(cfg)
+	if lc := h.lifecycleView(r.Context(), name); lc != nil {
+		res.Lifecycle = lc
 	}
 
 	return res
@@ -411,53 +417,6 @@ func locationType(location string) string {
 	}
 }
 
-// toLifecycleConfig converts the GCS lifecycle JSON into the driver's rule set.
-// Delete → object expiration; SetStorageClass → a class transition.
-func toLifecycleConfig(lc *bucketLifecycle) storagedriver.LifecycleConfig {
-	cfg := storagedriver.LifecycleConfig{Rules: make([]storagedriver.LifecycleRule, 0, len(lc.Rule))}
-
-	for i, r := range lc.Rule {
-		rule := storagedriver.LifecycleRule{
-			ID:      strconv.Itoa(i),
-			Enabled: true,
-		}
-
-		switch r.Action.Type {
-		case "Delete":
-			rule.ExpirationDays = r.Condition.Age
-		case "SetStorageClass":
-			rule.TransitionDays = r.Condition.Age
-			rule.TransitionStorageClass = r.Action.StorageClass
-		}
-
-		cfg.Rules = append(cfg.Rules, rule)
-	}
-
-	return cfg
-}
-
-// fromLifecycleConfig renders the driver's lifecycle rules back into GCS JSON.
-func fromLifecycleConfig(cfg *storagedriver.LifecycleConfig) *bucketLifecycle {
-	lc := &bucketLifecycle{Rule: make([]lifecycleRule, 0, len(cfg.Rules))}
-
-	for _, rule := range cfg.Rules {
-		switch {
-		case rule.TransitionStorageClass != "":
-			lc.Rule = append(lc.Rule, lifecycleRule{
-				Action:    lifecycleAction{Type: "SetStorageClass", StorageClass: rule.TransitionStorageClass},
-				Condition: lifecycleCondition{Age: rule.TransitionDays},
-			})
-		case rule.ExpirationDays > 0:
-			lc.Rule = append(lc.Rule, lifecycleRule{
-				Action:    lifecycleAction{Type: "Delete"},
-				Condition: lifecycleCondition{Age: rule.ExpirationDays},
-			})
-		}
-	}
-
-	return lc
-}
-
 // patchBucket applies a bucket configuration update (versioning + labels),
 // which real clients set via Buckets.Patch/Update. Without this the driver's
 // versioning/label capabilities are unreachable over the wire.
@@ -482,7 +441,7 @@ func (h *Handler) patchBucket(w http.ResponseWriter, r *http.Request, name strin
 	}
 
 	if body.Lifecycle != nil {
-		if err := h.bucket.PutLifecycleConfig(r.Context(), name, toLifecycleConfig(body.Lifecycle)); err != nil {
+		if err := h.putLifecycle(r.Context(), name, body.Lifecycle); err != nil {
 			writeErr(w, err)
 			return
 		}

--- a/server/gcp/gcs/lifecycle.go
+++ b/server/gcp/gcs/lifecycle.go
@@ -1,0 +1,110 @@
+package gcs
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// lifecycleRawStore is the optional capability that persists a bucket's
+// lifecycle configuration verbatim as GCS JSON, preserving every rule condition
+// (numNewerVersions, isLive, createdBefore, matchesStorageClass, …) rather than
+// the age-only subset the portable driver.LifecycleConfig can express.
+type lifecycleRawStore interface {
+	SetLifecycleGCS(ctx context.Context, bucket string, doc []byte) error
+	GetLifecycleGCS(ctx context.Context, bucket string) ([]byte, bool, error)
+}
+
+// putLifecycle stores lc for the named bucket. When the backing driver supports
+// verbatim lifecycle storage every condition is preserved; otherwise it falls
+// back to the age-only portable config so nothing regresses.
+func (h *Handler) putLifecycle(ctx context.Context, bucket string, lc *bucketLifecycle) error {
+	if h.lifecycle != nil {
+		doc, err := json.Marshal(lc)
+		if err != nil {
+			return err
+		}
+
+		return h.lifecycle.SetLifecycleGCS(ctx, bucket, doc)
+	}
+
+	return h.bucket.PutLifecycleConfig(ctx, bucket, toLifecycleConfig(lc))
+}
+
+// lifecycleView renders the stored lifecycle configuration for a bucket, or nil
+// when none is set. It prefers the verbatim capability, falling back to the
+// portable config so a lifecycle set through the typed API still surfaces.
+func (h *Handler) lifecycleView(ctx context.Context, bucket string) *bucketLifecycle {
+	if h.lifecycle != nil {
+		if doc, ok, err := h.lifecycle.GetLifecycleGCS(ctx, bucket); err == nil && ok && len(doc) > 0 {
+			var lc bucketLifecycle
+			if json.Unmarshal(doc, &lc) == nil && len(lc.Rule) > 0 {
+				return &lc
+			}
+		}
+	}
+
+	if cfg, err := h.bucket.GetLifecycleConfig(ctx, bucket); err == nil && cfg != nil && len(cfg.Rules) > 0 {
+		return fromLifecycleConfig(cfg)
+	}
+
+	return nil
+}
+
+// toLifecycleConfig converts the GCS lifecycle JSON into the driver's rule set,
+// the fallback path when the driver lacks verbatim lifecycle storage. Only the
+// age-based Delete/SetStorageClass subset survives this projection.
+func toLifecycleConfig(lc *bucketLifecycle) storagedriver.LifecycleConfig {
+	cfg := storagedriver.LifecycleConfig{Rules: make([]storagedriver.LifecycleRule, 0, len(lc.Rule))}
+
+	for i := range lc.Rule {
+		r := &lc.Rule[i]
+		rule := storagedriver.LifecycleRule{ID: strconv.Itoa(i), Enabled: true}
+
+		age := 0
+		if r.Condition.Age != nil {
+			age = *r.Condition.Age
+		}
+
+		switch r.Action.Type {
+		case "Delete":
+			rule.ExpirationDays = age
+		case "SetStorageClass":
+			rule.TransitionDays = age
+			rule.TransitionStorageClass = r.Action.StorageClass
+		}
+
+		cfg.Rules = append(cfg.Rules, rule)
+	}
+
+	return cfg
+}
+
+// fromLifecycleConfig renders the driver's lifecycle rules back into GCS JSON
+// (the fallback read path).
+func fromLifecycleConfig(cfg *storagedriver.LifecycleConfig) *bucketLifecycle {
+	lc := &bucketLifecycle{Rule: make([]lifecycleRule, 0, len(cfg.Rules))}
+
+	for i := range cfg.Rules {
+		rule := &cfg.Rules[i]
+
+		switch {
+		case rule.TransitionStorageClass != "":
+			age := rule.TransitionDays
+			lc.Rule = append(lc.Rule, lifecycleRule{
+				Action:    lifecycleAction{Type: "SetStorageClass", StorageClass: rule.TransitionStorageClass},
+				Condition: lifecycleCondition{Age: &age},
+			})
+		case rule.ExpirationDays > 0:
+			age := rule.ExpirationDays
+			lc.Rule = append(lc.Rule, lifecycleRule{
+				Action:    lifecycleAction{Type: "Delete"},
+				Condition: lifecycleCondition{Age: &age},
+			})
+		}
+	}
+
+	return lc
+}

--- a/server/gcp/gcs/lifecycle_conditions_test.go
+++ b/server/gcp/gcs/lifecycle_conditions_test.go
@@ -1,0 +1,153 @@
+// Package gcp_test — suite cell STORAGE / gcp / sdk-compat lifecycle conditions.
+//
+// Drives the real cloud.google.com/go/storage SDK against the emulator to
+// prove the full GCS lifecycle rule condition set (numNewerVersions, isLive,
+// createdBefore, matchesStorageClass, matchesPrefix/Suffix, age) round-trips
+// through Create/Update -> Attrs, rather than collapsing to age-only.
+package gcs_test
+
+import (
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+)
+
+// TestLifecycleConditionsRoundTrip sets a lifecycle whose rules exercise the
+// versioning-aware and date/class conditions, then reads them back and asserts
+// every condition survives.
+func TestLifecycleConditionsRoundTrip(t *testing.T) {
+	ctx, client := newStorageClient(t)
+
+	created := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	attrs := &storage.BucketAttrs{
+		VersioningEnabled: true,
+		Lifecycle: storage.Lifecycle{Rules: []storage.LifecycleRule{
+			{
+				Action: storage.LifecycleAction{Type: storage.DeleteAction},
+				Condition: storage.LifecycleCondition{
+					NumNewerVersions: 3,
+					Liveness:         storage.Archived,
+					CreatedBefore:    created,
+				},
+			},
+			{
+				Action: storage.LifecycleAction{Type: storage.SetStorageClassAction, StorageClass: "COLDLINE"},
+				Condition: storage.LifecycleCondition{
+					AgeInDays:             60,
+					Liveness:              storage.Live,
+					MatchesStorageClasses: []string{"STANDARD", "NEARLINE"},
+					MatchesPrefix:         []string{"logs/"},
+					MatchesSuffix:         []string{".log"},
+				},
+			},
+		}},
+	}
+
+	b := client.Bucket("e2e-lc-conditions")
+	if err := b.Create(ctx, e2eProject, attrs); err != nil {
+		t.Fatalf("Create bucket with lifecycle: %v", err)
+	}
+
+	got, err := b.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("bucket Attrs: %v", err)
+	}
+
+	if len(got.Lifecycle.Rules) != 2 {
+		t.Fatalf("lifecycle rules = %d, want 2 (conditions dropped?): %+v", len(got.Lifecycle.Rules), got.Lifecycle.Rules)
+	}
+
+	r0 := got.Lifecycle.Rules[0]
+	if r0.Action.Type != storage.DeleteAction {
+		t.Errorf("rule0 action = %q, want Delete", r0.Action.Type)
+	}
+
+	if r0.Condition.NumNewerVersions != 3 {
+		t.Errorf("rule0 NumNewerVersions = %d, want 3", r0.Condition.NumNewerVersions)
+	}
+
+	if r0.Condition.Liveness != storage.Archived {
+		t.Errorf("rule0 Liveness = %v, want Archived (isLive:false)", r0.Condition.Liveness)
+	}
+
+	if !r0.Condition.CreatedBefore.Equal(created) {
+		t.Errorf("rule0 CreatedBefore = %v, want %v", r0.Condition.CreatedBefore, created)
+	}
+
+	r1 := got.Lifecycle.Rules[1]
+	if r1.Action.Type != storage.SetStorageClassAction || r1.Action.StorageClass != "COLDLINE" {
+		t.Errorf("rule1 action = %+v, want SetStorageClass COLDLINE", r1.Action)
+	}
+
+	if r1.Condition.AgeInDays != 60 {
+		t.Errorf("rule1 AgeInDays = %d, want 60", r1.Condition.AgeInDays)
+	}
+
+	if r1.Condition.Liveness != storage.Live {
+		t.Errorf("rule1 Liveness = %v, want Live (isLive:true)", r1.Condition.Liveness)
+	}
+
+	if !equalStrings(r1.Condition.MatchesStorageClasses, []string{"STANDARD", "NEARLINE"}) {
+		t.Errorf("rule1 MatchesStorageClasses = %v, want [STANDARD NEARLINE]", r1.Condition.MatchesStorageClasses)
+	}
+
+	if !equalStrings(r1.Condition.MatchesPrefix, []string{"logs/"}) {
+		t.Errorf("rule1 MatchesPrefix = %v, want [logs/]", r1.Condition.MatchesPrefix)
+	}
+
+	if !equalStrings(r1.Condition.MatchesSuffix, []string{".log"}) {
+		t.Errorf("rule1 MatchesSuffix = %v, want [.log]", r1.Condition.MatchesSuffix)
+	}
+}
+
+// TestLifecycleConditionsUpdate confirms conditions also survive the PATCH
+// (Bucket.Update) path, not just Create.
+func TestLifecycleConditionsUpdate(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	b := mustCreateBucket(t, ctx, client, "e2e-lc-update")
+
+	lc := storage.Lifecycle{Rules: []storage.LifecycleRule{{
+		Action: storage.LifecycleAction{Type: storage.DeleteAction},
+		Condition: storage.LifecycleCondition{
+			NumNewerVersions: 5,
+			MatchesPrefix:    []string{"tmp/"},
+		},
+	}}}
+
+	if _, err := b.Update(ctx, storage.BucketAttrsToUpdate{Lifecycle: &lc}); err != nil {
+		t.Fatalf("bucket Update(Lifecycle): %v", err)
+	}
+
+	got, err := b.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs after update: %v", err)
+	}
+
+	if len(got.Lifecycle.Rules) != 1 {
+		t.Fatalf("lifecycle rules = %d, want 1", len(got.Lifecycle.Rules))
+	}
+
+	if got.Lifecycle.Rules[0].Condition.NumNewerVersions != 5 {
+		t.Errorf("NumNewerVersions = %d, want 5 (dropped on PATCH?)", got.Lifecycle.Rules[0].Condition.NumNewerVersions)
+	}
+
+	if !equalStrings(got.Lifecycle.Rules[0].Condition.MatchesPrefix, []string{"tmp/"}) {
+		t.Errorf("MatchesPrefix = %v, want [tmp/]", got.Lifecycle.Rules[0].Condition.MatchesPrefix)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/server/gcp/gcs/types.go
+++ b/server/gcp/gcs/types.go
@@ -39,8 +39,22 @@ type lifecycleAction struct {
 	StorageClass string `json:"storageClass,omitempty"`
 }
 
+// lifecycleCondition carries the full set of GCS lifecycle rule conditions
+// (https://cloud.google.com/storage/docs/lifecycle#conditions). Age and the
+// day-count conditions are pointers so an explicit 0 round-trips distinctly
+// from an absent condition.
 type lifecycleCondition struct {
-	Age int `json:"age,omitempty"`
+	Age                     *int     `json:"age,omitempty"`
+	CreatedBefore           string   `json:"createdBefore,omitempty"`
+	CustomTimeBefore        string   `json:"customTimeBefore,omitempty"`
+	DaysSinceCustomTime     *int     `json:"daysSinceCustomTime,omitempty"`
+	DaysSinceNoncurrentTime *int     `json:"daysSinceNoncurrentTime,omitempty"`
+	NoncurrentTimeBefore    string   `json:"noncurrentTimeBefore,omitempty"`
+	IsLive                  *bool    `json:"isLive,omitempty"`
+	MatchesStorageClass     []string `json:"matchesStorageClass,omitempty"`
+	NumNewerVersions        *int     `json:"numNewerVersions,omitempty"`
+	MatchesPrefix           []string `json:"matchesPrefix,omitempty"`
+	MatchesSuffix           []string `json:"matchesSuffix,omitempty"`
 }
 
 type iamConfiguration struct {


### PR DESCRIPTION
## Summary

GCS bucket lifecycle rules previously round-tripped only the `age` condition — every other condition (`numNewerVersions`, `isLive`, `createdBefore`, `matchesStorageClass`, `matchesPrefix`/`matchesSuffix`, `daysSince*`, `customTimeBefore`, `noncurrentTimeBefore`) was silently dropped on PUT and never re-emitted, so Terraform / `gsutil lifecycle` configs drifted. This PR makes the full standard condition set faithful **and** extends the evaluator.

### Round-trip (the core fix)
- `lifecycleCondition` (wire) now carries all standard GCS conditions.
- A new optional capability (`SetLifecycleGCS`/`GetLifecycleGCS`) stores the lifecycle **verbatim** as GCS JSON in the provider, so every condition survives PUT→GET exactly (mirrors the S3 `RawBucketConfig` verbatim pattern). Persisted in snapshots. Falls back to the age-only portable projection when the driver lacks the capability.

### Evaluation (also evaluated, not just stored)
CloudEmu already evaluated `age` (report-only `EvaluateLifecycle`). Extended:
- `EvaluateLifecycle` (non-destructive, live objects) now honors `age`, `createdBefore`, `matchesStorageClass`, `matchesPrefix`/`matchesSuffix`, and `isLive`.
- New `ApplyLifecycleGCS` performs the **destructive versioning-aware pass**: deletes noncurrent versions matching a `Delete` rule with `numNewerVersions` (and the other version-applicable conditions), Clock-driven for deterministic tests.
- Conservative by design: a rule carrying a condition the emulator can't evaluate (`customTime*`) never matches, so it never over-deletes.

### Tests
- Provider: verbatim round-trip + portable projection; rich live evaluation (class/prefix/suffix/createdBefore/age/isLive/unevaluable); `numNewerVersions` destructive pruning over versioned objects (FakeClock).
- Wire (real `cloud.google.com/go/storage` SDK): `numNewerVersions` + `isLive` + `createdBefore` + `matchesStorageClass` round-trip through both Create and Update (PATCH).

Scope: `providers/gcp/gcs` + `server/gcp/gcs` only. No driver-interface or `docs/coverage` change.

## Gates
- `go build ./...`, `gofmt -l` clean
- `go test ./providers/gcp/gcs/... ./server/gcp/gcs/... -race` — pass
- broad `go test ./providers/gcp/... ./server/gcp/... ./persist/... ./services/storage/... .` — pass
- `golangci-lint` touched pkgs — 0 new issues
- `go run ./internal/coveragegen` — no diff; `go mod tidy` — clean