### PR TITLE
feat(azure-db): async lifecycle (settle) for Azure SQL + MySQL/PostgreSQL Flexible Server

### DIFF
--- a/providers/azure/mysqlflex/async_settle_test.go
+++ b/providers/azure/mysqlflex/async_settle_test.go
@@ -1,0 +1,121 @@
+package mysqlflex
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// newAsyncMock builds a MySQL Flexible Server mock with AsyncSettle enabled and
+// a FakeClock so create/modify report their real transient states deterministically.
+func newAsyncMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("eastus"),
+		config.WithAccountID("sub-1"),
+		config.WithAsyncSettle(),
+	)
+
+	return New(opts), fc
+}
+
+// TestAsyncSettleCreateModify pins the AsyncSettle transitions: a server reports
+// creating (→ wire Starting) then available (→ Ready) on create, modifying (→
+// wire Updating) then available on modify — all driven by the FakeClock. A stop
+// transition clears any pending create window.
+func TestAsyncSettleCreateModify(t *testing.T) {
+	m, fc := newAsyncMock()
+	ctx := context.Background()
+
+	created, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "srv1"})
+	if err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+
+	if created.State != rdsdriver.StateCreating {
+		t.Fatalf("create response State = %q, want creating", created.State)
+	}
+
+	got, err := m.DescribeInstances(ctx, []string{"srv1"})
+	if err != nil || got[0].State != rdsdriver.StateCreating {
+		t.Fatalf("describe before settle = %q (err %v), want creating", got[0].State, err)
+	}
+
+	fc.Advance(settle.DefaultAzureDBSettle - time.Millisecond)
+
+	got, _ = m.DescribeInstances(ctx, []string{"srv1"})
+	if got[0].State != rdsdriver.StateCreating {
+		t.Fatalf("describe just before settle = %q, want creating", got[0].State)
+	}
+
+	fc.Advance(time.Millisecond)
+
+	got, _ = m.DescribeInstances(ctx, []string{"srv1"})
+	if got[0].State != rdsdriver.StateAvailable {
+		t.Fatalf("describe after settle = %q, want available", got[0].State)
+	}
+
+	// Modify → modifying → available.
+	modified, err := m.ModifyInstance(ctx, "srv1", rdsdriver.ModifyInstanceInput{InstanceClass: "Standard_D2ds_v4"})
+	if err != nil || modified.State != rdsdriver.StateModifying {
+		t.Fatalf("modify response State = %q (err %v), want modifying", modified.State, err)
+	}
+
+	got, _ = m.DescribeInstances(ctx, []string{"srv1"})
+	if got[0].State != rdsdriver.StateModifying {
+		t.Fatalf("describe during modify = %q, want modifying", got[0].State)
+	}
+
+	fc.Advance(settle.DefaultAzureDBSettle)
+
+	got, _ = m.DescribeInstances(ctx, []string{"srv1"})
+	if got[0].State != rdsdriver.StateAvailable {
+		t.Fatalf("describe after modify settle = %q, want available", got[0].State)
+	}
+
+	// A stop transition clears the create window immediately.
+	if _, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "srv2"}); err != nil {
+		t.Fatalf("CreateInstance srv2: %v", err)
+	}
+
+	if err := m.StopInstance(ctx, "srv2"); err != nil {
+		t.Fatalf("StopInstance: %v", err)
+	}
+
+	got, _ = m.DescribeInstances(ctx, []string{"srv2"})
+	if got[0].State != rdsdriver.StateStopped {
+		t.Fatalf("stopped srv2 = %q, want stopped (window must be cleared)", got[0].State)
+	}
+}
+
+// TestAsyncSettleDefaultOff confirms the default (AsyncSettle unset) path is
+// byte-for-byte synchronous: create and modify are observed as available
+// immediately, with no transient state.
+func TestAsyncSettleDefaultOff(t *testing.T) {
+	m := newTestMock() // no WithAsyncSettle
+	ctx := context.Background()
+
+	created, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "srv1"})
+	if err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+
+	if created.State != rdsdriver.StateAvailable {
+		t.Fatalf("create response State = %q, want available (settle off)", created.State)
+	}
+
+	got, _ := m.DescribeInstances(ctx, []string{"srv1"})
+	if got[0].State != rdsdriver.StateAvailable {
+		t.Fatalf("describe = %q, want available (settle off)", got[0].State)
+	}
+
+	modified, err := m.ModifyInstance(ctx, "srv1", rdsdriver.ModifyInstanceInput{InstanceClass: "Standard_D2ds_v4"})
+	if err != nil || modified.State != rdsdriver.StateAvailable {
+		t.Fatalf("modify response State = %q (err %v), want available (settle off)", modified.State, err)
+	}
+}

--- a/providers/azure/mysqlflex/mysqlflex.go
+++ b/providers/azure/mysqlflex/mysqlflex.go
@@ -19,6 +19,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	dbengine "github.com/stackshy/cloudemu/v2/services/relationaldb/dbengine"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
@@ -59,6 +60,13 @@ type Mock struct {
 	firewallRules  *memstore.Store[rdsdriver.FirewallRule]
 	configurations *memstore.Store[rdsdriver.Configuration]
 
+	// instSettle overlays a transient Starting / Updating window over a server's
+	// stored available state so create/modify/restart report the real Azure
+	// MySQL Flex ServerState before settling to Ready. A no-op unless
+	// config.Options.AsyncSettle is set (SettleDuration returns 0 → inactive
+	// window → the historical synchronous behavior). The Set carries its own lock.
+	instSettle *settle.Set
+
 	opts       *config.Options
 	monitoring mondriver.Monitoring
 }
@@ -71,8 +79,16 @@ func New(opts *config.Options) *Mock {
 		databases:      memstore.New[rdsdriver.Database](),
 		firewallRules:  memstore.New[rdsdriver.FirewallRule](),
 		configurations: memstore.New[rdsdriver.Configuration](),
+		instSettle:     settle.NewSet(),
 		opts:           opts,
 	}
+}
+
+// settleState overlays the server's settle window (if any) onto its stored
+// terminal state: the transient value while the window is active and unelapsed,
+// otherwise final. Absent window → final.
+func (m *Mock) settleState(id, final string) string {
+	return m.instSettle.State(id, m.opts.Clock.Now(), final)
 }
 
 // SetMonitoring wires an Azure Monitor backend for auto-metric emission.
@@ -150,6 +166,15 @@ func (m *Mock) CreateInstance(ctx context.Context, cfg rdsdriver.InstanceConfig)
 	}
 
 	out := m.finalizeInstance(cfg.ID, inst)
+
+	// Under AsyncSettle a fresh server reports Starting until the window elapses,
+	// matching real Azure MySQL Flex (ServerState has no Creating; a provisioning
+	// server reports Starting → Ready). Default off → SettleDuration 0 → inactive
+	// window → Ready immediately.
+	m.instSettle.Begin(cfg.ID, rdsdriver.StateCreating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultAzureDBSettle))
+
+	out.State = m.settleState(cfg.ID, out.State)
 
 	m.emitInstanceMetrics(cfg.ID, cpuMetricRunning, connectionMetricValue, diskReadOpsRunning, diskWriteOpsRunning)
 
@@ -268,6 +293,7 @@ func (m *Mock) DescribeInstances(_ context.Context, ids []string) ([]rdsdriver.I
 
 		//nolint:gocritic // map values are large structs; copy is unavoidable when materializing the result slice.
 		for _, v := range all {
+			v.State = m.settleState(v.ID, v.State)
 			out = append(out, v)
 		}
 
@@ -282,6 +308,7 @@ func (m *Mock) DescribeInstances(_ context.Context, ids []string) ([]rdsdriver.I
 			return nil, cerrors.Newf(cerrors.NotFound, "MySQL Flexible Server %q not found", id)
 		}
 
+		inst.State = m.settleState(inst.ID, inst.State)
 		out = append(out, inst)
 	}
 
@@ -343,7 +370,13 @@ func (m *Mock) ModifyInstance(
 
 	m.instances.Set(id, inst)
 
+	// Under AsyncSettle a modified server briefly reports Updating before
+	// settling back to Ready; a no-op when settle is off.
+	m.instSettle.Begin(id, rdsdriver.StateModifying, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultAzureDBSettle))
+
 	out := inst
+	out.State = m.settleState(id, out.State)
 
 	return &out, nil
 }
@@ -380,6 +413,7 @@ func (m *Mock) deleteInstanceScoped(ctx context.Context, id string, filter scope
 	}
 
 	m.instances.Delete(id)
+	m.instSettle.Clear(id)
 	m.deleteChildren(id)
 
 	return nil
@@ -439,6 +473,11 @@ func (m *Mock) RebootInstance(_ context.Context, id string) error {
 
 	m.instances.Set(id, inst)
 
+	// A restart briefly reports Updating (StateRebooting → Updating) before
+	// settling back to Ready under AsyncSettle; a no-op when settle is off.
+	m.instSettle.Begin(id, rdsdriver.StateRebooting, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultDBRebootSettle))
+
 	m.emitInstanceMetrics(id, cpuMetricRunning, connectionMetricValue, diskReadOpsRunning, diskWriteOpsRunning)
 
 	return nil
@@ -464,6 +503,10 @@ func (m *Mock) transitionInstance(id, from, to string, cpu, conns, readOps, writ
 
 	inst.State = to
 	m.instances.Set(id, inst)
+
+	// A start/stop transition supersedes any post-create settle window, so the
+	// new terminal state is observed immediately.
+	m.instSettle.Clear(id)
 
 	m.emitInstanceMetrics(id, cpu, conns, readOps, writeOps)
 
@@ -635,9 +678,15 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 
 	m.instances.Set(input.NewInstanceID, inst)
 
+	// A restore provisions a fresh server, so it settles Starting → Ready like a
+	// create under AsyncSettle; a no-op when settle is off.
+	m.instSettle.Begin(input.NewInstanceID, rdsdriver.StateCreating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultAzureDBSettle))
+
 	m.emitInstanceMetrics(input.NewInstanceID, cpuMetricRunning, connectionMetricValue, diskReadOpsRunning, diskWriteOpsRunning)
 
 	out := inst
+	out.State = m.settleState(input.NewInstanceID, out.State)
 
 	return &out, nil
 }

--- a/providers/azure/postgresflex/async_settle_test.go
+++ b/providers/azure/postgresflex/async_settle_test.go
@@ -1,0 +1,121 @@
+package postgresflex
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// newAsyncMock builds a Postgres Flexible Server mock with AsyncSettle enabled
+// and a FakeClock so create/modify report their real transient states
+// deterministically.
+func newAsyncMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("eastus"),
+		config.WithAsyncSettle(),
+	)
+
+	return New(opts), fc
+}
+
+// TestAsyncSettleCreateModify pins the AsyncSettle transitions: a server reports
+// creating (→ wire Starting) then available (→ Ready) on create, modifying (→
+// wire Updating) then available on modify — all driven by the FakeClock. A stop
+// transition clears any pending create window.
+func TestAsyncSettleCreateModify(t *testing.T) {
+	m, fc := newAsyncMock()
+	ctx := context.Background()
+
+	created, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "srv1"})
+	if err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+
+	if created.State != rdsdriver.StateCreating {
+		t.Fatalf("create response State = %q, want creating", created.State)
+	}
+
+	got, err := m.DescribeInstances(ctx, []string{"srv1"})
+	if err != nil || got[0].State != rdsdriver.StateCreating {
+		t.Fatalf("describe before settle = %q (err %v), want creating", got[0].State, err)
+	}
+
+	fc.Advance(settle.DefaultAzureDBSettle - time.Millisecond)
+
+	got, _ = m.DescribeInstances(ctx, []string{"srv1"})
+	if got[0].State != rdsdriver.StateCreating {
+		t.Fatalf("describe just before settle = %q, want creating", got[0].State)
+	}
+
+	fc.Advance(time.Millisecond)
+
+	got, _ = m.DescribeInstances(ctx, []string{"srv1"})
+	if got[0].State != rdsdriver.StateAvailable {
+		t.Fatalf("describe after settle = %q, want available", got[0].State)
+	}
+
+	// Modify → modifying → available.
+	modified, err := m.ModifyInstance(ctx, "srv1", rdsdriver.ModifyInstanceInput{InstanceClass: "Standard_D2ds_v4"})
+	if err != nil || modified.State != rdsdriver.StateModifying {
+		t.Fatalf("modify response State = %q (err %v), want modifying", modified.State, err)
+	}
+
+	got, _ = m.DescribeInstances(ctx, []string{"srv1"})
+	if got[0].State != rdsdriver.StateModifying {
+		t.Fatalf("describe during modify = %q, want modifying", got[0].State)
+	}
+
+	fc.Advance(settle.DefaultAzureDBSettle)
+
+	got, _ = m.DescribeInstances(ctx, []string{"srv1"})
+	if got[0].State != rdsdriver.StateAvailable {
+		t.Fatalf("describe after modify settle = %q, want available", got[0].State)
+	}
+
+	// A stop transition clears the create window immediately.
+	if _, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "srv2"}); err != nil {
+		t.Fatalf("CreateInstance srv2: %v", err)
+	}
+
+	if err := m.StopInstance(ctx, "srv2"); err != nil {
+		t.Fatalf("StopInstance: %v", err)
+	}
+
+	got, _ = m.DescribeInstances(ctx, []string{"srv2"})
+	if got[0].State != rdsdriver.StateStopped {
+		t.Fatalf("stopped srv2 = %q, want stopped (window must be cleared)", got[0].State)
+	}
+}
+
+// TestAsyncSettleDefaultOff confirms the default (AsyncSettle unset) path is
+// byte-for-byte synchronous: create and modify are observed as available
+// immediately, with no transient state.
+func TestAsyncSettleDefaultOff(t *testing.T) {
+	m := newTestMock() // no WithAsyncSettle
+	ctx := context.Background()
+
+	created, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "srv1"})
+	if err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+
+	if created.State != rdsdriver.StateAvailable {
+		t.Fatalf("create response State = %q, want available (settle off)", created.State)
+	}
+
+	got, _ := m.DescribeInstances(ctx, []string{"srv1"})
+	if got[0].State != rdsdriver.StateAvailable {
+		t.Fatalf("describe = %q, want available (settle off)", got[0].State)
+	}
+
+	modified, err := m.ModifyInstance(ctx, "srv1", rdsdriver.ModifyInstanceInput{InstanceClass: "Standard_D2ds_v4"})
+	if err != nil || modified.State != rdsdriver.StateAvailable {
+		t.Fatalf("modify response State = %q (err %v), want available (settle off)", modified.State, err)
+	}
+}

--- a/providers/azure/postgresflex/postgresflex.go
+++ b/providers/azure/postgresflex/postgresflex.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	dbengine "github.com/stackshy/cloudemu/v2/services/relationaldb/dbengine"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
@@ -60,6 +61,13 @@ type Mock struct {
 	firewallRules  *memstore.Store[rdsdriver.FirewallRule]
 	configurations *memstore.Store[rdsdriver.Configuration]
 
+	// instSettle overlays a transient Starting / Updating window over a server's
+	// stored available state so create/modify/restart report the real Azure
+	// Postgres Flex ServerState before settling to Ready. A no-op unless
+	// config.Options.AsyncSettle is set (SettleDuration returns 0 → inactive
+	// window → the historical synchronous behavior). The Set carries its own lock.
+	instSettle *settle.Set
+
 	opts       *config.Options
 	monitoring mondriver.Monitoring
 }
@@ -72,8 +80,16 @@ func New(opts *config.Options) *Mock {
 		databases:      memstore.New[rdsdriver.Database](),
 		firewallRules:  memstore.New[rdsdriver.FirewallRule](),
 		configurations: memstore.New[rdsdriver.Configuration](),
+		instSettle:     settle.NewSet(),
 		opts:           opts,
 	}
+}
+
+// settleState overlays the server's settle window (if any) onto its stored
+// terminal state: the transient value while the window is active and unelapsed,
+// otherwise final. Absent window → final.
+func (m *Mock) settleState(id, final string) string {
+	return m.instSettle.State(id, m.opts.Clock.Now(), final)
 }
 
 // SetMonitoring wires an Azure-Monitor-style backend for auto-metric emission.
@@ -161,6 +177,15 @@ func (m *Mock) CreateInstance(ctx context.Context, cfg rdsdriver.InstanceConfig)
 	}
 
 	out := m.finalizeInstance(cfg.ID, inst)
+
+	// Under AsyncSettle a fresh server reports Starting until the window elapses,
+	// matching real Azure Postgres Flex (ServerState has no Creating; a
+	// provisioning server reports Starting → Ready). Default off → SettleDuration
+	// 0 → inactive window → Ready immediately.
+	m.instSettle.Begin(cfg.ID, rdsdriver.StateCreating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultAzureDBSettle))
+
+	out.State = m.settleState(cfg.ID, out.State)
 
 	m.emitServerMetrics(cfg.ID, cpuMetricRunning, connRunning)
 
@@ -279,6 +304,7 @@ func (m *Mock) DescribeInstances(_ context.Context, ids []string) ([]rdsdriver.I
 
 		//nolint:gocritic // map values are large structs; copy is unavoidable when materializing the result slice.
 		for _, v := range all {
+			v.State = m.settleState(v.ID, v.State)
 			out = append(out, v)
 		}
 
@@ -293,6 +319,7 @@ func (m *Mock) DescribeInstances(_ context.Context, ids []string) ([]rdsdriver.I
 			return nil, cerrors.Newf(cerrors.NotFound, "Postgres Flex server %q not found", id)
 		}
 
+		inst.State = m.settleState(inst.ID, inst.State)
 		out = append(out, inst)
 	}
 
@@ -353,7 +380,13 @@ func (m *Mock) ModifyInstance(
 
 	m.instances.Set(id, inst)
 
+	// Under AsyncSettle a modified server briefly reports Updating before
+	// settling back to Ready; a no-op when settle is off.
+	m.instSettle.Begin(id, rdsdriver.StateModifying, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultAzureDBSettle))
+
 	out := inst
+	out.State = m.settleState(id, out.State)
 
 	return &out, nil
 }
@@ -390,6 +423,7 @@ func (m *Mock) deleteInstanceScoped(ctx context.Context, id string, filter scope
 	}
 
 	m.instances.Delete(id)
+	m.instSettle.Clear(id)
 	m.deleteChildren(id)
 
 	return nil
@@ -447,6 +481,11 @@ func (m *Mock) RebootInstance(_ context.Context, id string) error {
 
 	m.instances.Set(id, inst)
 
+	// A restart briefly reports Updating (StateRebooting → Updating) before
+	// settling back to Ready under AsyncSettle; a no-op when settle is off.
+	m.instSettle.Begin(id, rdsdriver.StateRebooting, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultDBRebootSettle))
+
 	m.emitServerMetrics(id, cpuMetricRunning, connRunning)
 
 	return nil
@@ -472,6 +511,10 @@ func (m *Mock) transitionInstance(id, from, to string, cpu, conns float64, verb 
 
 	inst.State = to
 	m.instances.Set(id, inst)
+
+	// A start/stop transition supersedes any post-create settle window, so the
+	// new terminal state is observed immediately.
+	m.instSettle.Clear(id)
 
 	m.emitServerMetrics(id, cpu, conns)
 
@@ -643,9 +686,15 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 
 	m.instances.Set(input.NewInstanceID, inst)
 
+	// A restore provisions a fresh server, so it settles Starting → Ready like a
+	// create under AsyncSettle; a no-op when settle is off.
+	m.instSettle.Begin(input.NewInstanceID, rdsdriver.StateCreating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultAzureDBSettle))
+
 	m.emitServerMetrics(input.NewInstanceID, cpuMetricRunning, connRunning)
 
 	out := inst
+	out.State = m.settleState(input.NewInstanceID, out.State)
 
 	return &out, nil
 }

--- a/providers/azure/sql/async_settle_test.go
+++ b/providers/azure/sql/async_settle_test.go
@@ -1,0 +1,195 @@
+package sql
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// newAsyncMock builds an Azure SQL mock with AsyncSettle enabled and a FakeClock
+// so create/modify report their real transient states deterministically.
+func newAsyncMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("eastus"),
+		config.WithAsyncSettle(),
+	)
+
+	return New(opts), fc
+}
+
+// TestAsyncSettleInstanceCreateModify pins the AsyncSettle transitions on the
+// portable relationaldb Instance path: a database reports creating on create
+// and modifying on modify, then settles to available, all driven by the
+// FakeClock. A stop transition clears any pending create window.
+func TestAsyncSettleInstanceCreateModify(t *testing.T) {
+	m, fc := newAsyncMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateCluster(ctx, rdsdriver.ClusterConfig{ID: "srv1"}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	created, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "db1", ClusterID: "srv1"})
+	if err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+
+	if created.State != rdsdriver.StateCreating {
+		t.Fatalf("create response State = %q, want creating", created.State)
+	}
+
+	got, err := m.DescribeInstances(ctx, []string{"srv1/db1"})
+	if err != nil || got[0].State != rdsdriver.StateCreating {
+		t.Fatalf("describe before settle = %q (err %v), want creating", got[0].State, err)
+	}
+
+	// Still transient one instant before the window elapses.
+	fc.Advance(settle.DefaultAzureDBSettle - time.Millisecond)
+
+	got, _ = m.DescribeInstances(ctx, []string{"srv1/db1"})
+	if got[0].State != rdsdriver.StateCreating {
+		t.Fatalf("describe just before settle = %q, want creating", got[0].State)
+	}
+
+	// Past the window: terminal available.
+	fc.Advance(time.Millisecond)
+
+	got, _ = m.DescribeInstances(ctx, []string{"srv1/db1"})
+	if got[0].State != rdsdriver.StateAvailable {
+		t.Fatalf("describe after settle = %q, want available", got[0].State)
+	}
+
+	// Modify → modifying → available.
+	modified, err := m.ModifyInstance(ctx, "srv1/db1", rdsdriver.ModifyInstanceInput{InstanceClass: "GP_Gen5_4"})
+	if err != nil || modified.State != rdsdriver.StateModifying {
+		t.Fatalf("modify response State = %q (err %v), want modifying", modified.State, err)
+	}
+
+	got, _ = m.DescribeInstances(ctx, []string{"srv1/db1"})
+	if got[0].State != rdsdriver.StateModifying {
+		t.Fatalf("describe during modify = %q, want modifying", got[0].State)
+	}
+
+	fc.Advance(settle.DefaultAzureDBSettle)
+
+	got, _ = m.DescribeInstances(ctx, []string{"srv1/db1"})
+	if got[0].State != rdsdriver.StateAvailable {
+		t.Fatalf("describe after modify settle = %q, want available", got[0].State)
+	}
+
+	// A stop transition clears the settle window immediately.
+	fresh, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "db2", ClusterID: "srv1"})
+	if err != nil || fresh.State != rdsdriver.StateCreating {
+		t.Fatalf("CreateInstance db2 = %q (err %v), want creating", fresh.State, err)
+	}
+
+	if err := m.StopInstance(ctx, "srv1/db2"); err != nil {
+		t.Fatalf("StopInstance: %v", err)
+	}
+
+	got, _ = m.DescribeInstances(ctx, []string{"srv1/db2"})
+	if got[0].State != rdsdriver.StateStopped {
+		t.Fatalf("stopped db2 = %q, want stopped (window must be cleared)", got[0].State)
+	}
+}
+
+// TestAsyncSettleDatabaseStatus pins the AsyncSettle transitions on the wire
+// Databases-capability path: a database reports status Creating on create and
+// Scaling on update, then settles to "" (the wire reports terminal Online).
+func TestAsyncSettleDatabaseStatus(t *testing.T) {
+	m, fc := newAsyncMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateCluster(ctx, rdsdriver.ClusterConfig{ID: "srv1"}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "srv1", Name: "app"}); err != nil {
+		t.Fatalf("CreateDatabase: %v", err)
+	}
+
+	if s := m.DatabaseTransientStatus("srv1", "app"); s != dbStatusCreating {
+		t.Fatalf("status before settle = %q, want Creating", s)
+	}
+
+	fc.Advance(settle.DefaultAzureDBSettle - time.Millisecond)
+
+	if s := m.DatabaseTransientStatus("srv1", "app"); s != dbStatusCreating {
+		t.Fatalf("status just before settle = %q, want Creating", s)
+	}
+
+	fc.Advance(time.Millisecond)
+
+	if s := m.DatabaseTransientStatus("srv1", "app"); s != "" {
+		t.Fatalf("status after settle = %q, want empty (Online)", s)
+	}
+
+	// Update → Scaling → "".
+	if _, err := m.UpdateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "srv1", Name: "app", SKUName: "GP_Gen5_4"}); err != nil {
+		t.Fatalf("UpdateDatabase: %v", err)
+	}
+
+	if s := m.DatabaseTransientStatus("srv1", "app"); s != dbStatusScaling {
+		t.Fatalf("status during update = %q, want Scaling", s)
+	}
+
+	fc.Advance(settle.DefaultAzureDBSettle)
+
+	if s := m.DatabaseTransientStatus("srv1", "app"); s != "" {
+		t.Fatalf("status after update settle = %q, want empty (Online)", s)
+	}
+
+	// Delete clears the window.
+	if err := m.DeleteDatabase(ctx, "srv1", "app"); err != nil {
+		t.Fatalf("DeleteDatabase: %v", err)
+	}
+
+	if s := m.DatabaseTransientStatus("srv1", "app"); s != "" {
+		t.Fatalf("status after delete = %q, want empty", s)
+	}
+}
+
+// TestAsyncSettleDefaultOff confirms the default (AsyncSettle unset) path is
+// byte-for-byte synchronous: create and modify are observed as available (and a
+// database's status stays terminal Online, i.e. empty transient) immediately.
+func TestAsyncSettleDefaultOff(t *testing.T) {
+	m := newTestMock() // no WithAsyncSettle
+	ctx := context.Background()
+
+	if _, err := m.CreateCluster(ctx, rdsdriver.ClusterConfig{ID: "srv1"}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	created, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "db1", ClusterID: "srv1"})
+	if err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+
+	if created.State != rdsdriver.StateAvailable {
+		t.Fatalf("create response State = %q, want available (settle off)", created.State)
+	}
+
+	got, _ := m.DescribeInstances(ctx, []string{"srv1/db1"})
+	if got[0].State != rdsdriver.StateAvailable {
+		t.Fatalf("describe = %q, want available (settle off)", got[0].State)
+	}
+
+	modified, err := m.ModifyInstance(ctx, "srv1/db1", rdsdriver.ModifyInstanceInput{InstanceClass: "GP_Gen5_4"})
+	if err != nil || modified.State != rdsdriver.StateAvailable {
+		t.Fatalf("modify response State = %q (err %v), want available (settle off)", modified.State, err)
+	}
+
+	if _, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "srv1", Name: "app"}); err != nil {
+		t.Fatalf("CreateDatabase: %v", err)
+	}
+
+	if s := m.DatabaseTransientStatus("srv1", "app"); s != "" {
+		t.Fatalf("database status = %q, want empty/Online (settle off)", s)
+	}
+}

--- a/providers/azure/sql/databases.go
+++ b/providers/azure/sql/databases.go
@@ -4,11 +4,29 @@ import (
 	"context"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// Azure SQL Database ARM status values (properties.status). A database is
+// Creating on first provision and Scaling while a service-objective/SKU change
+// applies, then settles to Online. See armsql.DatabaseStatus.
+const (
+	dbStatusCreating = "Creating"
+	dbStatusScaling  = "Scaling"
 )
 
 // dbKey is the storage key for a logical database: "server/name".
 func dbKey(server, name string) string { return server + "/" + name }
+
+// DatabaseTransientStatus returns the ARM database status to report while a
+// create/update settle window is active ("Creating" / "Scaling"), or "" once
+// the database has settled (the wire layer then reports the terminal "Online").
+// Always "" unless config.Options.AsyncSettle is set. It is the read-through the
+// wire handler consults so a real armsql client observes the intermediate state.
+func (m *Mock) DatabaseTransientStatus(server, name string) string {
+	return m.dbSettle.State(dbKey(server, name), m.opts.Clock.Now(), "")
+}
 
 // CreateDatabase creates a logical database on a SQL server, implementing the
 // relationaldb Databases optional capability. SKU/tier default to the common
@@ -65,6 +83,12 @@ func (m *Mock) CreateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 	}
 	m.databases.Set(key, db)
 
+	// Under AsyncSettle the database reports status Creating until the window
+	// elapses (real Azure SQL: Creating → Online). Default off → SettleDuration
+	// 0 → inactive window → Online immediately.
+	m.dbSettle.Begin(key, dbStatusCreating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultAzureDBSettle))
+
 	// Azure SQL databases are encrypted at rest by default: a create
 	// materializes the transparentDataEncryption/current sub-resource as
 	// Enabled so a Get on it round-trips without a separate PUT.
@@ -117,6 +141,12 @@ func (m *Mock) UpdateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 		return nil, cerrors.Newf(cerrors.NotFound, "database %q not found on server %q", cfg.Name, cfg.Server)
 	}
 
+	// Under AsyncSettle an updated database briefly reports status Scaling (a
+	// service-objective/SKU change) before settling back to Online; a no-op when
+	// settle is off.
+	m.dbSettle.Begin(dbKey(cfg.Server, cfg.Name), dbStatusScaling, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultAzureDBSettle))
+
 	out := updated
 	out.Tags = copyTags(updated.Tags)
 
@@ -168,6 +198,7 @@ func (m *Mock) DeleteDatabase(_ context.Context, server, name string) error {
 	}
 
 	m.tde.Delete(dbKey(server, name))
+	m.dbSettle.Clear(dbKey(server, name))
 
 	return nil
 }

--- a/providers/azure/sql/sql.go
+++ b/providers/azure/sql/sql.go
@@ -31,6 +31,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
@@ -79,6 +80,16 @@ type Mock struct {
 	// transparent-data-encryption records, key = "server/database"
 	tde *memstore.Store[rdsdriver.TransparentDataEncryption]
 
+	// instSettle overlays a transient Creating / Updating window over a database
+	// instance's stored available state on the portable relationaldb path
+	// (keyed "server/database"). dbSettle overlays the ARM database status
+	// (Creating / Scaling → Online) on the wire Databases-capability path (keyed
+	// "server/name"). Both are no-ops unless config.Options.AsyncSettle is set
+	// (SettleDuration returns 0 → inactive window → historical synchronous
+	// behavior); each Set carries its own lock.
+	instSettle *settle.Set
+	dbSettle   *settle.Set
+
 	opts       *config.Options
 	monitoring mondriver.Monitoring
 }
@@ -98,8 +109,17 @@ func New(opts *config.Options) *Mock {
 		tde:              memstore.New[rdsdriver.TransparentDataEncryption](),
 		managedInstances: memstore.New[rdsdriver.ManagedInstance](),
 		managedDatabases: memstore.New[rdsdriver.ManagedDatabase](),
+		instSettle:       settle.NewSet(),
+		dbSettle:         settle.NewSet(),
 		opts:             opts,
 	}
+}
+
+// settleInstState overlays an instance's settle window (if any) onto its stored
+// terminal state: the transient value while the window is active and unelapsed,
+// otherwise final. Absent window → final.
+func (m *Mock) settleInstState(server, database, final string) string {
+	return m.instSettle.State(instanceKey(server, database), m.opts.Clock.Now(), final)
 }
 
 // SetMonitoring wires an Azure-Monitor-style backend for auto-metric emission.
@@ -257,9 +277,16 @@ func (m *Mock) CreateInstance(_ context.Context, cfg rdsdriver.InstanceConfig) (
 	server.Members = append(server.Members, cfg.ID)
 	m.clusters.Set(cfg.ClusterID, server)
 
+	// Under AsyncSettle a fresh database reports creating until the window
+	// elapses, matching real Azure SQL (status Creating → Online). Default off →
+	// SettleDuration 0 → inactive window → available immediately.
+	m.instSettle.Begin(instanceKey(cfg.ClusterID, cfg.ID), rdsdriver.StateCreating,
+		m.opts.Clock.Now(), m.opts.SettleDuration(settle.DefaultAzureDBSettle))
+
 	m.emitDatabaseMetrics(cfg.ClusterID, cfg.ID, cpuMetricRunning, dtuRunning)
 
 	out := cloneInstance(inst)
+	out.State = m.settleInstState(cfg.ClusterID, cfg.ID, out.State)
 
 	return &out, nil
 }
@@ -278,7 +305,9 @@ func (m *Mock) DescribeInstances(_ context.Context, ids []string) ([]rdsdriver.I
 
 		//nolint:gocritic // map values are large structs; copy is unavoidable when materializing the result slice.
 		for _, v := range all {
-			out = append(out, cloneInstance(v))
+			c := cloneInstance(v)
+			c.State = m.settleInstState(c.ClusterID, c.ID, c.State)
+			out = append(out, c)
 		}
 
 		return out, nil
@@ -292,7 +321,9 @@ func (m *Mock) DescribeInstances(_ context.Context, ids []string) ([]rdsdriver.I
 			return nil, err
 		}
 
-		out = append(out, cloneInstance(inst))
+		c := cloneInstance(inst)
+		c.State = m.settleInstState(c.ClusterID, c.ID, c.State)
+		out = append(out, c)
 	}
 
 	return out, nil
@@ -364,7 +395,13 @@ func (m *Mock) ModifyInstance(
 
 	m.instances.Set(instanceKey(inst.ClusterID, inst.ID), inst)
 
+	// Under AsyncSettle a modified database briefly reports updating before
+	// settling back to available; a no-op when settle is off.
+	m.instSettle.Begin(instanceKey(inst.ClusterID, inst.ID), rdsdriver.StateModifying,
+		m.opts.Clock.Now(), m.opts.SettleDuration(settle.DefaultAzureDBSettle))
+
 	out := cloneInstance(inst)
+	out.State = m.settleInstState(inst.ClusterID, inst.ID, out.State)
 
 	return &out, nil
 }
@@ -380,6 +417,7 @@ func (m *Mock) DeleteInstance(_ context.Context, id string) error {
 	}
 
 	m.instances.Delete(instanceKey(inst.ClusterID, inst.ID))
+	m.instSettle.Clear(instanceKey(inst.ClusterID, inst.ID))
 
 	cluster, ok := m.clusters.Get(inst.ClusterID)
 	if ok {
@@ -441,6 +479,10 @@ func (m *Mock) transitionInstance(id, from, to string, cpu, dtu float64, verb st
 
 	inst.State = to
 	m.instances.Set(instanceKey(inst.ClusterID, inst.ID), inst)
+
+	// A start/stop transition supersedes any post-create settle window, so the
+	// new terminal state is observed immediately.
+	m.instSettle.Clear(instanceKey(inst.ClusterID, inst.ID))
 
 	m.emitDatabaseMetrics(inst.ClusterID, inst.ID, cpu, dtu)
 
@@ -749,9 +791,15 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 		m.clusters.Set(server, cluster)
 	}
 
+	// A restore provisions a fresh database, so it settles creating → available
+	// like a create under AsyncSettle; a no-op when settle is off.
+	m.instSettle.Begin(instanceKey(server, dbName), rdsdriver.StateCreating,
+		m.opts.Clock.Now(), m.opts.SettleDuration(settle.DefaultAzureDBSettle))
+
 	m.emitDatabaseMetrics(server, dbName, cpuMetricRunning, dtuRunning)
 
 	out := cloneInstance(inst)
+	out.State = m.settleInstState(server, dbName, out.State)
 
 	return &out, nil
 }

--- a/server/azure/mysqlflex/types.go
+++ b/server/azure/mysqlflex/types.go
@@ -137,7 +137,9 @@ func serverState(state string) string {
 		return stateReady
 	case rdsdriver.StateStopped:
 		return stateStopped
-	case rdsdriver.StateStarting:
+	// The ARM ServerState enum has no "Creating"; a provisioning server reports
+	// Starting until it settles to Ready (async lifecycle, AsyncSettle only).
+	case rdsdriver.StateCreating, rdsdriver.StateStarting:
 		return stateStarting
 	case rdsdriver.StateStopping:
 		return stateStopping

--- a/server/azure/postgresflex/types.go
+++ b/server/azure/postgresflex/types.go
@@ -124,11 +124,13 @@ func serverState(s string) string {
 		return stateReady
 	case rdsdriver.StateStopped:
 		return stateStopped
-	case rdsdriver.StateStarting:
+	// The ARM ServerState enum has no "Creating"; a provisioning server reports
+	// Starting until it settles to Ready (async lifecycle, AsyncSettle only).
+	case rdsdriver.StateCreating, rdsdriver.StateStarting:
 		return stateStarting
 	case rdsdriver.StateStopping:
 		return stateStopping
-	case rdsdriver.StateModifying, rdsdriver.StateRebooting, rdsdriver.StateCreating:
+	case rdsdriver.StateModifying, rdsdriver.StateRebooting:
 		return stateUpdating
 	case rdsdriver.StateDeleting:
 		return stateDropping

--- a/server/azure/sql/async_settle_sdk_test.go
+++ b/server/azure/sql/async_settle_sdk_test.go
@@ -1,0 +1,199 @@
+package sql_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
+	sqlprovider "github.com/stackshy/cloudemu/v2/providers/azure/sql"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// newAsyncFactory stands up the Azure SQL wire handler over a provider with
+// AsyncSettle enabled and a FakeClock, so a real armsql SDK client observes the
+// transient database status (Creating / Scaling) before the settle window
+// elapses. The FakeClock is returned so the test can advance it past the window.
+func newAsyncFactory(t *testing.T) (*armsql.ClientFactory, *config.FakeClock) {
+	t.Helper()
+
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("eastus"),
+		config.WithAsyncSettle(),
+	)
+
+	srv := azureserver.New(azureserver.Drivers{SQL: sqlprovider.New(opts)})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+
+	armOpts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	cf, err := armsql.NewClientFactory("sub-1", fakeCred{}, armOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return cf, fc
+}
+
+// TestSDKAzureSQLDatabaseAsyncSettle drives the real armsql SDK against the wire
+// handler and asserts a database's status surfaces the real Azure SQL
+// transitions: Creating → Online on create, Scaling → Online on update.
+func TestSDKAzureSQLDatabaseAsyncSettle(t *testing.T) {
+	cf, fc := newAsyncFactory(t)
+	servers := cf.NewServersClient()
+	dbs := cf.NewDatabasesClient()
+	ctx := context.Background()
+
+	srvPoller, err := servers.BeginCreateOrUpdate(ctx, "rg-1", "srv1", armsql.Server{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("Server BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := srvPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Server PollUntilDone: %v", err)
+	}
+
+	// Create the database: the create response already reports Creating.
+	dbPoller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "appdb", armsql.Database{
+		Location: to.Ptr("eastus"),
+		SKU:      &armsql.SKU{Name: to.Ptr("S0")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("DB BeginCreateOrUpdate: %v", err)
+	}
+
+	dbResp, err := dbPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("DB PollUntilDone: %v", err)
+	}
+
+	if got := dbStatusOf(t, dbResp.Database); got != armsql.DatabaseStatusCreating {
+		t.Fatalf("create response status = %q, want Creating", got)
+	}
+
+	// A Get before the window elapses still reports Creating.
+	got, err := dbs.Get(ctx, "rg-1", "srv1", "appdb", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if s := dbStatusOf(t, got.Database); s != armsql.DatabaseStatusCreating {
+		t.Fatalf("get before settle status = %q, want Creating", s)
+	}
+
+	// Advance past the settle window: the database is now Online.
+	fc.Advance(settle.DefaultAzureDBSettle)
+
+	got, err = dbs.Get(ctx, "rg-1", "srv1", "appdb", nil)
+	if err != nil {
+		t.Fatalf("Get after settle: %v", err)
+	}
+
+	if s := dbStatusOf(t, got.Database); s != armsql.DatabaseStatusOnline {
+		t.Fatalf("get after settle status = %q, want Online", s)
+	}
+
+	// Update (SKU change): the database briefly reports Scaling, then Online.
+	patchPoller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "appdb", armsql.Database{
+		SKU: &armsql.SKU{Name: to.Ptr("S2")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Update BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := patchPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Update PollUntilDone: %v", err)
+	}
+
+	got, err = dbs.Get(ctx, "rg-1", "srv1", "appdb", nil)
+	if err != nil {
+		t.Fatalf("Get during update: %v", err)
+	}
+
+	if s := dbStatusOf(t, got.Database); s != armsql.DatabaseStatusScaling {
+		t.Fatalf("get during update status = %q, want Scaling", s)
+	}
+
+	fc.Advance(settle.DefaultAzureDBSettle)
+
+	got, err = dbs.Get(ctx, "rg-1", "srv1", "appdb", nil)
+	if err != nil {
+		t.Fatalf("Get after update settle: %v", err)
+	}
+
+	if s := dbStatusOf(t, got.Database); s != armsql.DatabaseStatusOnline {
+		t.Fatalf("get after update settle status = %q, want Online", s)
+	}
+}
+
+// TestSDKAzureSQLDatabaseDefaultOff confirms the default (AsyncSettle unset)
+// path reports the terminal Online status synchronously via the real SDK.
+func TestSDKAzureSQLDatabaseDefaultOff(t *testing.T) {
+	servers, dbs := newSDKClients(t) // default provider, no AsyncSettle
+	ctx := context.Background()
+
+	srvPoller, err := servers.BeginCreateOrUpdate(ctx, "rg-1", "srv1", armsql.Server{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("Server BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := srvPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Server PollUntilDone: %v", err)
+	}
+
+	dbPoller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "appdb", armsql.Database{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("DB BeginCreateOrUpdate: %v", err)
+	}
+
+	dbResp, err := dbPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("DB PollUntilDone: %v", err)
+	}
+
+	if got := dbStatusOf(t, dbResp.Database); got != armsql.DatabaseStatusOnline {
+		t.Fatalf("create response status = %q, want Online (settle off)", got)
+	}
+}
+
+// dbStatusOf extracts the database status, failing the test when it is absent.
+func dbStatusOf(t *testing.T, db armsql.Database) armsql.DatabaseStatus {
+	t.Helper()
+
+	if db.Properties == nil || db.Properties.Status == nil {
+		t.Fatalf("database status missing")
+	}
+
+	return *db.Properties.Status
+}

--- a/server/azure/sql/operations.go
+++ b/server/azure/sql/operations.go
@@ -155,6 +155,27 @@ func (h *Handler) databases() (rdsdriver.Databases, bool) {
 	return d, ok
 }
 
+// databaseStatuser is the optional provider capability that reports a
+// database's transient ARM status (Creating / Scaling) while an async settle
+// window is active. Providers that don't implement it (settle disabled or not
+// adopted) leave the status empty, so read responses report the terminal
+// Online. Kept an assertion (not a required interface method) so the wire
+// layer stays decoupled from the settle overlay.
+type databaseStatuser interface {
+	DatabaseTransientStatus(server, name string) string
+}
+
+// databaseStatus returns the transient status the provider reports for a
+// database, or "" when the provider doesn't expose one.
+func (h *Handler) databaseStatus(server, name string) string {
+	s, ok := h.db.(databaseStatuser)
+	if !ok {
+		return ""
+	}
+
+	return s.DatabaseTransientStatus(server, name)
+}
+
 func dbCfgFromBody(body *armDatabase, rp *azurearm.ResourcePath) rdsdriver.DatabaseConfig {
 	cfg := rdsdriver.DatabaseConfig{
 		Server:   rp.ResourceName,
@@ -194,7 +215,7 @@ func (h *Handler) putDatabase(w http.ResponseWriter, r *http.Request, rp *azurea
 
 	out, err := db.CreateDatabase(r.Context(), cfg)
 	if err == nil {
-		azurearm.WriteJSON(w, http.StatusOK, toARMDatabase(out, rp))
+		azurearm.WriteJSON(w, http.StatusOK, toARMDatabase(out, rp, h.databaseStatus(out.Server, out.Name)))
 		return
 	}
 
@@ -213,7 +234,7 @@ func (h *Handler) putDatabase(w http.ResponseWriter, r *http.Request, rp *azurea
 
 	out, err = replaceDatabase(r.Context(), db, &body, &cfg)
 	if err == nil {
-		azurearm.WriteJSON(w, http.StatusOK, toARMDatabase(out, rp))
+		azurearm.WriteJSON(w, http.StatusOK, toARMDatabase(out, rp, h.databaseStatus(out.Server, out.Name)))
 		return
 	}
 
@@ -351,14 +372,14 @@ func requireElasticPool(ctx context.Context, db rdsdriver.Databases, server, poo
 	return err
 }
 
-func (*Handler) getDatabase(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db rdsdriver.Databases) {
+func (h *Handler) getDatabase(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db rdsdriver.Databases) {
 	out, err := db.GetDatabase(r.Context(), rp.ResourceName, rp.SubResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toARMDatabase(out, rp))
+	azurearm.WriteJSON(w, http.StatusOK, toARMDatabase(out, rp, h.databaseStatus(out.Server, out.Name)))
 }
 
 func (*Handler) deleteDatabase(
@@ -374,7 +395,7 @@ func (*Handler) deleteDatabase(
 	w.WriteHeader(http.StatusOK)
 }
 
-func (*Handler) listDatabases(
+func (h *Handler) listDatabases(
 	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db rdsdriver.Databases,
 ) {
 	items, err := db.ListDatabases(r.Context(), rp.ResourceName)
@@ -385,7 +406,7 @@ func (*Handler) listDatabases(
 
 	out := make([]armDatabase, 0, len(items))
 	for i := range items {
-		out = append(out, toARMDatabase(&items[i], rp))
+		out = append(out, toARMDatabase(&items[i], rp, h.databaseStatus(items[i].Server, items[i].Name)))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, armList[armDatabase]{Value: out})

--- a/server/azure/sql/types.go
+++ b/server/azure/sql/types.go
@@ -86,8 +86,16 @@ func toARMServer(cluster *rdsdriver.Cluster, subscription, resourceGroup string)
 // toARMDatabase converts a portable Database (Databases capability) to ARM JSON.
 // SKU.name plus properties.currentSku / zoneRedundant are echoed so SKU/tier
 // and HA are observable to both the armsql SDK and Resource Graph discovery.
-func toARMDatabase(db *rdsdriver.Database, rp *azurearm.ResourcePath) armDatabase {
+//
+// status is the transient ARM status (Creating / Scaling) reported while a
+// create/update settle window is active; empty means the database has settled,
+// so read responses report the terminal Online.
+func toARMDatabase(db *rdsdriver.Database, rp *azurearm.ResourcePath, status string) armDatabase {
 	zoneRedundant := db.ZoneRedundant
+
+	if status == "" {
+		status = dbStatusOnline
+	}
 
 	return armDatabase{
 		ID:       armDatabaseID(rp.Subscription, rp.ResourceGroup, db.Server, db.Name),
@@ -97,7 +105,7 @@ func toARMDatabase(db *rdsdriver.Database, rp *azurearm.ResourcePath) armDatabas
 		Tags:     db.Tags,
 		SKU:      &armSKU{Name: db.SKUName, Tier: db.SKUTier, Capacity: db.SKUCapacity},
 		Properties: &armDatabaseProps{
-			Status:                      dbStatusOnline,
+			Status:                      status,
 			Collation:                   db.Collation,
 			DatabaseID:                  databaseGUID(db),
 			CurrentServiceObjectiveName: db.SKUName,


### PR DESCRIPTION
## Summary

Adopts the `internal/settle` async-lifecycle overlay (`settle.Set`, #974) in the Azure SQL provider and the Azure MySQL / PostgreSQL Flexible Server providers, mirroring the RDS (#974) and GCP Cloud SQL / Memorystore (#977) adoptions. Create/update now report real transient provisioning states instead of jumping synchronously to Ready/Online.

## Transient states (verified against the Azure SDK enums)

- **Azure SQL database** (wire / armsql `DatabasesClient`): create -> `Creating`, update -> `Scaling`, then terminal `Online`.
- **Azure SQL instance** (portable relationaldb path): create -> creating, modify/restore -> modifying/creating, then available.
- **MySQL / PostgreSQL Flexible Server** (armmysql / armpostgresql): create -> `Starting` (the `ServerState` enum has no `Creating`), modify/restart -> `Updating`, then `Ready`.

Each op follows the three-touch recipe (Begin on create/modify/restore, State overlay on every read path, Clear on delete and on start/stop transitions).

## Gated, default-off

Everything is gated behind the existing `config.Options.AsyncSettle` / `SettleDuration` knob. **With the default (AsyncSettle off) the settle window is 0 -> inactive overlay -> the historical synchronous behavior is byte-for-byte unchanged.** No new flag; no existing test flips. State is driven by `config.Clock` (FakeClock-deterministic in tests).

## Tests

- Provider-level FakeClock tests per package (create/modify -> transient -> advance -> terminal) plus a `TestAsyncSettleDefaultOff` in each proving the default path stays synchronous.
- Real-SDK wire test (`server/azure/sql`) driving the armsql `DatabasesClient`: create -> `Creating` -> advance clock -> `Online`, update -> `Scaling` -> `Online`, plus a default-off variant.

No shared driver-interface change, no `docs/coverage` change, `go mod tidy` clean. The wire read-through is an optional `databaseStatuser` capability assertion, so the wire layer stays decoupled from the settle overlay.