### PR TITLE
feat(aws-db): async lifecycle (settle) for ElastiCache, Redshift, MemoryDB, Keyspaces

### DIFF
--- a/providers/aws/elasticache/async_settle_test.go
+++ b/providers/aws/elasticache/async_settle_test.go
@@ -1,0 +1,126 @@
+package elasticache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
+	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newAsyncMock builds an ElastiCache mock with AsyncSettle enabled and a
+// FakeClock so create/modify report their real transient states deterministically.
+func newAsyncMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("us-east-1"),
+		config.WithAsyncSettle(),
+	)
+
+	return New(opts), fc
+}
+
+// TestAsyncSettleCacheClusterCreateModify pins the AsyncSettle transitions for a
+// cache cluster: creating then available on create, modifying then available on
+// modify, observed through both Get and List.
+func TestAsyncSettleCacheClusterCreateModify(t *testing.T) {
+	m, fc := newAsyncMock()
+	ctx := context.Background()
+
+	created, err := m.CreateCache(ctx, driver.CacheConfig{Name: "c1"})
+	require.NoError(t, err)
+	assert.Equal(t, statusCreating, created.Status)
+
+	got, err := m.GetCache(ctx, "c1")
+	require.NoError(t, err)
+	assert.Equal(t, statusCreating, got.Status)
+
+	list, err := m.ListCaches(ctx, scope.Scope{})
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, statusCreating, list[0].Status)
+
+	// Still transient one instant before the window elapses.
+	fc.Advance(settle.DefaultCacheSettle - time.Millisecond)
+	got, _ = m.GetCache(ctx, "c1")
+	assert.Equal(t, statusCreating, got.Status)
+
+	// Past the window: terminal available.
+	fc.Advance(time.Millisecond)
+	got, _ = m.GetCache(ctx, "c1")
+	assert.Equal(t, statusAvailable, got.Status)
+
+	// Modify → modifying → available.
+	modified, err := m.ModifyCache(ctx, driver.ModifyCacheConfig{Name: "c1", NodeType: "cache.m5.large"})
+	require.NoError(t, err)
+	assert.Equal(t, statusModifying, modified.Status)
+
+	got, _ = m.GetCache(ctx, "c1")
+	assert.Equal(t, statusModifying, got.Status)
+
+	fc.Advance(settle.DefaultCacheModifySettle)
+	got, _ = m.GetCache(ctx, "c1")
+	assert.Equal(t, statusAvailable, got.Status)
+}
+
+// TestAsyncSettleReplicationGroupCreateModify pins the transitions for a
+// replication group: creating then available on create, modifying then available
+// on modify, observed through DescribeReplicationGroups.
+func TestAsyncSettleReplicationGroupCreateModify(t *testing.T) {
+	m, fc := newAsyncMock()
+	ctx := context.Background()
+
+	created, err := m.CreateReplicationGroup(ctx, driver.ReplicationGroupConfig{ID: "rg1"})
+	require.NoError(t, err)
+	assert.Equal(t, statusCreating, created.Status)
+
+	groups, err := m.DescribeReplicationGroups(ctx, []string{"rg1"})
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, statusCreating, groups[0].Status)
+
+	fc.Advance(settle.DefaultCacheSettle)
+	groups, _ = m.DescribeReplicationGroups(ctx, nil)
+	require.Len(t, groups, 1)
+	assert.Equal(t, statusAvailable, groups[0].Status)
+
+	// Modify → modifying → available.
+	modified, err := m.ModifyReplicationGroup(ctx, "rg1", 2)
+	require.NoError(t, err)
+	assert.Equal(t, statusModifying, modified.Status)
+
+	fc.Advance(settle.DefaultCacheModifySettle)
+	groups, _ = m.DescribeReplicationGroups(ctx, []string{"rg1"})
+	require.Len(t, groups, 1)
+	assert.Equal(t, statusAvailable, groups[0].Status)
+}
+
+// TestAsyncSettleDefaultOff confirms the default (AsyncSettle unset) path is
+// byte-for-byte synchronous: create and modify are observed as available
+// immediately, with no transient state.
+func TestAsyncSettleDefaultOff(t *testing.T) {
+	m, _ := newTestMock() // no WithAsyncSettle
+	ctx := context.Background()
+
+	created, err := m.CreateCache(ctx, driver.CacheConfig{Name: "c1"})
+	require.NoError(t, err)
+	assert.Equal(t, statusAvailable, created.Status)
+
+	got, err := m.GetCache(ctx, "c1")
+	require.NoError(t, err)
+	assert.Equal(t, statusAvailable, got.Status)
+
+	modified, err := m.ModifyCache(ctx, driver.ModifyCacheConfig{Name: "c1", NodeType: "cache.m5.large"})
+	require.NoError(t, err)
+	assert.Equal(t, statusAvailable, modified.Status)
+
+	rg, err := m.CreateReplicationGroup(ctx, driver.ReplicationGroupConfig{ID: "rg1"})
+	require.NoError(t, err)
+	assert.Equal(t, statusAvailable, rg.Status)
+}

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/internal/regionctx"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	cacheengine "github.com/stackshy/cloudemu/v2/services/cache/cacheengine"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
@@ -72,6 +73,11 @@ const (
 	engineMemcached = "memcached"
 	defaultNodeType = "cache.t3.micro"
 	statusAvailable = "available"
+	// statusCreating and statusModifying are the real ElastiCache transient
+	// states a cluster/replication group reports (under AsyncSettle) on create and
+	// modify before settling to available.
+	statusCreating  = "creating"
+	statusModifying = "modifying"
 
 	defaultRedisVersion     = "7.1"
 	defaultMemcachedVersion = "1.6.22"
@@ -184,6 +190,15 @@ type Mock struct {
 	opts              *config.Options
 	monitoring        mondriver.Monitoring
 
+	// cacheSettle / rgSettle overlay a transient creating/modifying window over a
+	// cache cluster's / replication group's stored "available" status so
+	// create/modify report the real ElastiCache intermediate state before
+	// settling. Both are no-ops unless config.Options.AsyncSettle is set
+	// (SettleDuration returns 0 → inactive window → historical synchronous
+	// behavior). Each Set carries its own lock.
+	cacheSettle *settle.Set
+	rgSettle    *settle.Set
+
 	tagMu     sync.Mutex
 	tagsByARN map[string]map[string]string
 }
@@ -227,9 +242,23 @@ func New(opts *config.Options) *Mock {
 		replicationGroups: memstore.New[driver.ReplicationGroup](),
 		parameterGroups:   memstore.New[ParameterGroup](),
 		snapshots:         memstore.New[driver.Snapshot](),
+		cacheSettle:       settle.NewSet(),
+		rgSettle:          settle.NewSet(),
 		tagsByARN:         make(map[string]map[string]string),
 		opts:              opts,
 	}
+}
+
+// settleCacheStatus overlays a cache cluster's settle window (keyed by name)
+// onto its stored terminal status.
+func (m *Mock) settleCacheStatus(name, final string) string {
+	return m.cacheSettle.State(name, m.opts.Clock.Now(), final)
+}
+
+// settleRGStatus overlays a replication group's settle window (keyed by id)
+// onto its stored terminal status.
+func (m *Mock) settleRGStatus(id, final string) string {
+	return m.rgSettle.State(id, m.opts.Clock.Now(), final)
 }
 
 // CreateCache creates a new ElastiCache cluster.
@@ -308,7 +337,15 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 	m.caches.Set(cfg.Name, cd)
 	m.seedTags(info.ARN, tags)
 
+	// Under AsyncSettle a fresh cluster reports creating until the window elapses,
+	// matching real ElastiCache (CreateCacheCluster → creating → available). With
+	// the default (AsyncSettle off) SettleDuration is 0 → inactive window →
+	// available immediately, so nothing changes for existing callers.
+	m.cacheSettle.Begin(cfg.Name, statusCreating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultCacheSettle))
+
 	result := info
+	result.Status = m.settleCacheStatus(cfg.Name, result.Status)
 
 	return &result, nil
 }
@@ -344,7 +381,14 @@ func (m *Mock) ModifyCache(_ context.Context, cfg driver.ModifyCacheConfig) (*dr
 
 	m.caches.Set(cfg.Name, cd)
 
+	// Under AsyncSettle a modified cluster briefly reports modifying before
+	// settling back to available (ModifyCacheCluster → modifying → available); a
+	// no-op when settle is off.
+	m.cacheSettle.Begin(cfg.Name, statusModifying, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultCacheModifySettle))
+
 	result := cd.info
+	result.Status = m.settleCacheStatus(cfg.Name, result.Status)
 
 	return &result, nil
 }
@@ -379,6 +423,7 @@ func (m *Mock) DeleteCache(ctx context.Context, name string) error {
 	}
 
 	m.caches.Delete(name)
+	m.cacheSettle.Clear(name)
 
 	return nil
 }
@@ -391,6 +436,7 @@ func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, erro
 	}
 
 	result := cd.info
+	result.Status = m.settleCacheStatus(name, result.Status)
 
 	return &result, nil
 }
@@ -400,11 +446,15 @@ func (m *Mock) ListCaches(_ context.Context, filter scope.Scope) ([]driver.Cache
 	all := m.caches.SortedValues()
 
 	caches := make([]driver.CacheInfo, 0, len(all))
+
 	for _, cd := range all {
 		if !cd.info.Scope.Matches(filter) {
 			continue
 		}
-		caches = append(caches, cd.info)
+
+		info := cd.info
+		info.Status = m.settleCacheStatus(info.Name, info.Status)
+		caches = append(caches, info)
 	}
 
 	return caches, nil
@@ -431,7 +481,11 @@ func (m *Mock) UpdateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 
 	m.caches.Set(cfg.Name, cd)
 
+	m.cacheSettle.Begin(cfg.Name, statusModifying, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultCacheModifySettle))
+
 	result := cd.info
+	result.Status = m.settleCacheStatus(cfg.Name, result.Status)
 
 	return &result, nil
 }

--- a/providers/aws/elasticache/replication_group.go
+++ b/providers/aws/elasticache/replication_group.go
@@ -10,6 +10,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/internal/regionctx"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	cacheengine "github.com/stackshy/cloudemu/v2/services/cache/cacheengine"
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
 )
@@ -91,7 +92,15 @@ func (m *Mock) CreateReplicationGroup(
 
 	m.replicationGroups.Set(cfg.ID, rg)
 
-	return &rg, nil
+	// Under AsyncSettle a fresh group reports creating until the window elapses
+	// (CreateReplicationGroup → creating → available); a no-op when settle is off.
+	m.rgSettle.Begin(cfg.ID, statusCreating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultCacheSettle))
+
+	result := rg
+	result.Status = m.settleRGStatus(cfg.ID, result.Status)
+
+	return &result, nil
 }
 
 // maxReplicationGroupNodes bounds the member-cluster count a replication group
@@ -178,7 +187,12 @@ func (m *Mock) DescribeReplicationGroups(
 	_ context.Context, ids []string,
 ) ([]cachedriver.ReplicationGroup, error) {
 	if len(ids) == 0 {
-		return m.replicationGroups.SortedValues(), nil
+		all := m.replicationGroups.SortedValues()
+		for i := range all {
+			all[i].Status = m.settleRGStatus(all[i].ID, all[i].Status)
+		}
+
+		return all, nil
 	}
 
 	out := make([]cachedriver.ReplicationGroup, 0, len(ids))
@@ -190,6 +204,7 @@ func (m *Mock) DescribeReplicationGroups(
 				"ReplicationGroupNotFoundFault: replication group %q not found", id)
 		}
 
+		rg.Status = m.settleRGStatus(id, rg.Status)
 		out = append(out, rg)
 	}
 
@@ -213,7 +228,15 @@ func (m *Mock) ModifyReplicationGroup(
 
 	m.replicationGroups.Set(id, rg)
 
-	return &rg, nil
+	// Under AsyncSettle a modified group briefly reports modifying before settling
+	// back to available; a no-op when settle is off.
+	m.rgSettle.Begin(id, statusModifying, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultCacheModifySettle))
+
+	result := rg
+	result.Status = m.settleRGStatus(id, result.Status)
+
+	return &result, nil
 }
 
 // DeleteReplicationGroup deletes a replication group. When
@@ -242,6 +265,7 @@ func (m *Mock) DeleteReplicationGroup(
 	if opts.RetainPrimaryCluster {
 		m.retainPrimaryCluster(&rg)
 		m.replicationGroups.Delete(id)
+		m.rgSettle.Clear(id)
 
 		return nil
 	}
@@ -252,6 +276,7 @@ func (m *Mock) DeleteReplicationGroup(
 	}
 
 	m.replicationGroups.Delete(id)
+	m.rgSettle.Clear(id)
 
 	return nil
 }

--- a/providers/aws/keyspaces/async_settle_test.go
+++ b/providers/aws/keyspaces/async_settle_test.go
@@ -1,0 +1,140 @@
+package keyspaces
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
+	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
+)
+
+// newAsyncMock builds a Keyspaces mock with AsyncSettle enabled and a FakeClock
+// so create/update report their real transient table states deterministically.
+func newAsyncMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("us-east-1"),
+		config.WithAccountID("123456789012"),
+		config.WithAsyncSettle(),
+	)
+
+	return New(opts), fc
+}
+
+func tableStatus(t *testing.T, m *Mock, keyspace, table string) string {
+	t.Helper()
+
+	got, err := m.GetTable(context.Background(), keyspace, table)
+	if err != nil {
+		t.Fatalf("get table: %v", err)
+	}
+
+	return got.Status
+}
+
+// TestAsyncSettleCreateUpdate pins the AsyncSettle transitions: a table reports
+// CREATING then ACTIVE on create, and UPDATING then ACTIVE on update.
+func TestAsyncSettleCreateUpdate(t *testing.T) {
+	m, fc := newAsyncMock()
+	ctx := context.Background()
+	mustKeyspace(t, m, "app")
+
+	created, err := m.CreateTable(ctx, ksdriver.CreateTableConfig{
+		KeyspaceName: "app", Name: "t1", SchemaDefinition: sampleSchema(),
+	})
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	if created.Status != ksdriver.StatusCreating {
+		t.Fatalf("create status = %q, want %q", created.Status, ksdriver.StatusCreating)
+	}
+
+	if got := tableStatus(t, m, "app", "t1"); got != ksdriver.StatusCreating {
+		t.Fatalf("get status = %q, want %q", got, ksdriver.StatusCreating)
+	}
+
+	// List observes the transient state too.
+	list, err := m.ListTables(ctx, "app")
+	if err != nil {
+		t.Fatalf("list tables: %v", err)
+	}
+
+	if len(list) != 1 || list[0].Status != ksdriver.StatusCreating {
+		t.Fatalf("list status = %+v, want one CREATING", list)
+	}
+
+	// Still transient one instant before the window elapses.
+	fc.Advance(settle.DefaultKeyspacesSettle - time.Millisecond)
+
+	if got := tableStatus(t, m, "app", "t1"); got != ksdriver.StatusCreating {
+		t.Fatalf("pre-settle status = %q, want %q", got, ksdriver.StatusCreating)
+	}
+
+	// Past the window: terminal ACTIVE.
+	fc.Advance(time.Millisecond)
+
+	if got := tableStatus(t, m, "app", "t1"); got != ksdriver.StatusActive {
+		t.Fatalf("settled status = %q, want %q", got, ksdriver.StatusActive)
+	}
+
+	// Update → UPDATING → ACTIVE.
+	updated, err := m.UpdateTable(ctx, ksdriver.UpdateTableConfig{
+		KeyspaceName: "app", Name: "t1", Comment: "changed",
+	})
+	if err != nil {
+		t.Fatalf("update table: %v", err)
+	}
+
+	if updated.Status != ksdriver.StatusUpdating {
+		t.Fatalf("update status = %q, want %q", updated.Status, ksdriver.StatusUpdating)
+	}
+
+	if got := tableStatus(t, m, "app", "t1"); got != ksdriver.StatusUpdating {
+		t.Fatalf("post-update get status = %q, want %q", got, ksdriver.StatusUpdating)
+	}
+
+	fc.Advance(settle.DefaultKeyspacesSettle)
+
+	if got := tableStatus(t, m, "app", "t1"); got != ksdriver.StatusActive {
+		t.Fatalf("post-update settled status = %q, want %q", got, ksdriver.StatusActive)
+	}
+}
+
+// TestAsyncSettleDefaultOff confirms the default (AsyncSettle unset) path is
+// byte-for-byte synchronous: create and update are observed as ACTIVE
+// immediately, with no transient state.
+func TestAsyncSettleDefaultOff(t *testing.T) {
+	m := newTestMock() // no WithAsyncSettle
+	ctx := context.Background()
+	mustKeyspace(t, m, "app")
+
+	created, err := m.CreateTable(ctx, ksdriver.CreateTableConfig{
+		KeyspaceName: "app", Name: "t1", SchemaDefinition: sampleSchema(),
+	})
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	if created.Status != ksdriver.StatusActive {
+		t.Fatalf("create status = %q, want %q", created.Status, ksdriver.StatusActive)
+	}
+
+	if got := tableStatus(t, m, "app", "t1"); got != ksdriver.StatusActive {
+		t.Fatalf("get status = %q, want %q", got, ksdriver.StatusActive)
+	}
+
+	updated, err := m.UpdateTable(ctx, ksdriver.UpdateTableConfig{
+		KeyspaceName: "app", Name: "t1", Comment: "changed",
+	})
+	if err != nil {
+		t.Fatalf("update table: %v", err)
+	}
+
+	if updated.Status != ksdriver.StatusActive {
+		t.Fatalf("update status = %q, want %q", updated.Status, ksdriver.StatusActive)
+	}
+}

--- a/providers/aws/keyspaces/keyspaces.go
+++ b/providers/aws/keyspaces/keyspaces.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
 )
 
@@ -32,6 +33,15 @@ type Mock struct {
 	// tags holds tag maps keyed by resource ARN.
 	tags map[string]map[string]string
 
+	// tableSettle overlays a transient CREATING/UPDATING/RESTORING window (keyed by
+	// "keyspace/table") over a table's stored "ACTIVE" status so
+	// create/update/restore report the real Keyspaces intermediate state before
+	// settling. It is a no-op unless config.Options.AsyncSettle is set
+	// (SettleDuration returns 0 → inactive window → historical synchronous
+	// behavior). The Set has its own lock. Keyspaces themselves expose no status in
+	// the API, so only tables are overlaid.
+	tableSettle *settle.Set
+
 	opts *config.Options
 }
 
@@ -39,11 +49,12 @@ type Mock struct {
 // that real Amazon Keyspaces provisions.
 func New(opts *config.Options) *Mock {
 	m := &Mock{
-		keyspaces: memstore.New[ksdriver.Keyspace](),
-		tables:    memstore.New[ksdriver.Table](),
-		udts:      memstore.New[ksdriver.UDT](),
-		tags:      make(map[string]map[string]string),
-		opts:      opts,
+		keyspaces:   memstore.New[ksdriver.Keyspace](),
+		tables:      memstore.New[ksdriver.Table](),
+		udts:        memstore.New[ksdriver.UDT](),
+		tags:        make(map[string]map[string]string),
+		tableSettle: settle.NewSet(),
+		opts:        opts,
 	}
 
 	for _, sys := range []string{"system", "system_schema", "system_multiregion_info"} {

--- a/providers/aws/keyspaces/tables.go
+++ b/providers/aws/keyspaces/tables.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
 )
 
@@ -154,7 +155,15 @@ func (m *Mock) CreateTable(_ context.Context, cfg ksdriver.CreateTableConfig) (*
 	m.setTags(t.ARN, cfg.Tags)
 	m.registerTableUDTRefs(cfg.KeyspaceName, cfg.Name, &t.SchemaDefinition)
 
+	// Under AsyncSettle a fresh table reports CREATING until the window elapses,
+	// matching real Keyspaces (CreateTable → CREATING → ACTIVE). With the default
+	// (AsyncSettle off) SettleDuration is 0 → inactive window → ACTIVE immediately,
+	// so nothing changes for existing callers.
+	m.tableSettle.Begin(key, ksdriver.StatusCreating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultKeyspacesSettle))
+
 	out := cloneTable(&t)
+	m.overlayTableStatus(&out)
 
 	return &out, nil
 }
@@ -185,6 +194,14 @@ func resolveEncryption(e ksdriver.EncryptionSpecification) ksdriver.EncryptionSp
 	return e
 }
 
+// overlayTableStatus overlays a table's settle window (keyed by "keyspace/table")
+// onto its Status field: the transient value while the window is active and
+// unelapsed, otherwise the stored terminal status. A no-op when no window exists
+// (default AsyncSettle-off path).
+func (m *Mock) overlayTableStatus(t *ksdriver.Table) {
+	t.Status = m.tableSettle.State(tableKey(t.KeyspaceName, t.Name), m.opts.Clock.Now(), t.Status)
+}
+
 func (m *Mock) getTableLocked(keyspace, table string) (ksdriver.Table, error) {
 	t, ok := m.tables.Get(tableKey(keyspace, table))
 	if !ok {
@@ -205,13 +222,12 @@ func (m *Mock) GetTable(_ context.Context, keyspace, table string) (*ksdriver.Ta
 	}
 
 	out := cloneTable(&t)
+	m.overlayTableStatus(&out)
 
 	return &out, nil
 }
 
 // ListTables returns all tables in a keyspace, deterministically ordered.
-//
-//nolint:dupl // the per-keyspace prefix filter mirrors ListTypes by design.
 func (m *Mock) ListTables(_ context.Context, keyspace string) ([]ksdriver.Table, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -226,7 +242,9 @@ func (m *Mock) ListTables(_ context.Context, keyspace string) ([]ksdriver.Table,
 
 	for i := range all {
 		if strings.HasPrefix(tableKey(all[i].KeyspaceName, all[i].Name), prefix) {
-			out = append(out, cloneTable(&all[i]))
+			ct := cloneTable(&all[i])
+			m.overlayTableStatus(&ct)
+			out = append(out, ct)
 		}
 	}
 
@@ -278,9 +296,16 @@ func (m *Mock) UpdateTable(_ context.Context, cfg ksdriver.UpdateTableConfig) (*
 		t.AutoScaling = cloneAutoScaling(cfg.AutoScaling)
 	}
 
-	m.tables.Set(tableKey(cfg.KeyspaceName, cfg.Name), t)
+	key := tableKey(cfg.KeyspaceName, cfg.Name)
+	m.tables.Set(key, t)
+
+	// Under AsyncSettle an updated table briefly reports UPDATING before settling
+	// back to ACTIVE (UpdateTable → UPDATING → ACTIVE); a no-op when settle is off.
+	m.tableSettle.Begin(key, ksdriver.StatusUpdating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultKeyspacesSettle))
 
 	out := cloneTable(&t)
+	m.overlayTableStatus(&out)
 
 	return &out, nil
 }
@@ -306,6 +331,7 @@ func (m *Mock) DeleteTable(_ context.Context, keyspace, table string) error {
 	}
 
 	m.tables.Delete(key)
+	m.tableSettle.Clear(key)
 	delete(m.tags, t.ARN)
 	m.unregisterTableUDTRefs(keyspace, table)
 
@@ -367,7 +393,13 @@ func (m *Mock) RestoreTable(_ context.Context, cfg ksdriver.RestoreTableConfig) 
 	m.setTags(restored.ARN, cfg.Tags)
 	m.registerTableUDTRefs(cfg.TargetKeyspace, cfg.TargetTable, &restored.SchemaDefinition)
 
+	// A restored table reports RESTORING until the window elapses (RestoreTable →
+	// RESTORING → ACTIVE); a no-op when settle is off.
+	m.tableSettle.Begin(targetKey, ksdriver.StatusRestoring, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultKeyspacesSettle))
+
 	out := cloneTable(&restored)
+	m.overlayTableStatus(&out)
 
 	return &out, nil
 }

--- a/providers/aws/keyspaces/udt.go
+++ b/providers/aws/keyspaces/udt.go
@@ -171,8 +171,6 @@ func (m *Mock) GetType(_ context.Context, keyspace, name string) (*ksdriver.UDT,
 }
 
 // ListTypes returns the type names of a keyspace, deterministically ordered.
-//
-//nolint:dupl // the per-keyspace prefix filter mirrors ListTables by design.
 func (m *Mock) ListTypes(_ context.Context, keyspace string) ([]ksdriver.UDT, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/providers/aws/memorydb/async_settle_test.go
+++ b/providers/aws/memorydb/async_settle_test.go
@@ -1,0 +1,125 @@
+package memorydb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+// newAsyncMock builds a MemoryDB mock with AsyncSettle enabled and a FakeClock so
+// create/update report their real transient states deterministically.
+func newAsyncMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("us-east-1"),
+		config.WithAccountID("123456789012"),
+		config.WithAsyncSettle(),
+	)
+
+	return New(opts), fc
+}
+
+func clusterStatus(t *testing.T, m *Mock, name string) string {
+	t.Helper()
+
+	got, err := m.DescribeClusters(context.Background(), []string{name})
+	if err != nil {
+		t.Fatalf("describe cluster: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("describe returned %d clusters, want 1", len(got))
+	}
+
+	return got[0].Status
+}
+
+// TestAsyncSettleCreateUpdate pins the AsyncSettle transitions: a cluster reports
+// creating then available on create, and updating then available on update.
+func TestAsyncSettleCreateUpdate(t *testing.T) {
+	m, fc := newAsyncMock()
+	ctx := context.Background()
+
+	created, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "c1", NumShards: 1})
+	if err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if created.Status != mdbdriver.StatusCreating {
+		t.Fatalf("create status = %q, want %q", created.Status, mdbdriver.StatusCreating)
+	}
+
+	if got := clusterStatus(t, m, "c1"); got != mdbdriver.StatusCreating {
+		t.Fatalf("describe status = %q, want %q", got, mdbdriver.StatusCreating)
+	}
+
+	// Still transient one instant before the window elapses.
+	fc.Advance(settle.DefaultClusterSettle - time.Millisecond)
+
+	if got := clusterStatus(t, m, "c1"); got != mdbdriver.StatusCreating {
+		t.Fatalf("pre-settle status = %q, want %q", got, mdbdriver.StatusCreating)
+	}
+
+	// Past the window: terminal available.
+	fc.Advance(time.Millisecond)
+
+	if got := clusterStatus(t, m, "c1"); got != mdbdriver.StatusAvailable {
+		t.Fatalf("settled status = %q, want %q", got, mdbdriver.StatusAvailable)
+	}
+
+	// Update → updating → available.
+	newNode := "db.r6g.large"
+	updated, err := m.UpdateCluster(ctx, mdbdriver.UpdateClusterConfig{Name: "c1", NodeType: newNode})
+	if err != nil {
+		t.Fatalf("update cluster: %v", err)
+	}
+
+	if updated.Status != mdbdriver.StatusUpdating {
+		t.Fatalf("update status = %q, want %q", updated.Status, mdbdriver.StatusUpdating)
+	}
+
+	if got := clusterStatus(t, m, "c1"); got != mdbdriver.StatusUpdating {
+		t.Fatalf("post-update describe status = %q, want %q", got, mdbdriver.StatusUpdating)
+	}
+
+	fc.Advance(settle.DefaultCacheModifySettle)
+
+	if got := clusterStatus(t, m, "c1"); got != mdbdriver.StatusAvailable {
+		t.Fatalf("post-update settled status = %q, want %q", got, mdbdriver.StatusAvailable)
+	}
+}
+
+// TestAsyncSettleDefaultOff confirms the default (AsyncSettle unset) path is
+// byte-for-byte synchronous: create and update are observed as available
+// immediately, with no transient state.
+func TestAsyncSettleDefaultOff(t *testing.T) {
+	m := newTestMock() // no WithAsyncSettle
+	ctx := context.Background()
+
+	created, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "c1", NumShards: 1})
+	if err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if created.Status != mdbdriver.StatusAvailable {
+		t.Fatalf("create status = %q, want %q", created.Status, mdbdriver.StatusAvailable)
+	}
+
+	if got := clusterStatus(t, m, "c1"); got != mdbdriver.StatusAvailable {
+		t.Fatalf("describe status = %q, want %q", got, mdbdriver.StatusAvailable)
+	}
+
+	updated, err := m.UpdateCluster(ctx, mdbdriver.UpdateClusterConfig{Name: "c1", NodeType: "db.r6g.large"})
+	if err != nil {
+		t.Fatalf("update cluster: %v", err)
+	}
+
+	if updated.Status != mdbdriver.StatusAvailable {
+		t.Fatalf("update status = %q, want %q", updated.Status, mdbdriver.StatusAvailable)
+	}
+}

--- a/providers/aws/memorydb/clusters.go
+++ b/providers/aws/memorydb/clusters.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	cacheengine "github.com/stackshy/cloudemu/v2/services/cache/cacheengine"
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
 	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
@@ -253,6 +254,8 @@ func (m *Mock) CreateCluster(ctx context.Context, cfg mdbdriver.CreateClusterCon
 
 	// No engine wired in: the synthetic cluster is complete as reserved.
 	if m.opts.CacheEngine == nil {
+		m.overlayClusterStatus(reserved)
+
 		return reserved, nil
 	}
 
@@ -264,6 +267,7 @@ func (m *Mock) CreateCluster(ctx context.Context, cfg mdbdriver.CreateClusterCon
 	}
 
 	out := m.finalizeClusterEngine(reserved, host, port)
+	m.overlayClusterStatus(&out)
 
 	return &out, nil
 }
@@ -366,6 +370,14 @@ func (m *Mock) reserveCluster(cfg *mdbdriver.CreateClusterConfig) (*mdbdriver.Cl
 	m.emitClusterMetrics(cfg.Name)
 	m.recordClusterEvent(cfg.Name, "Cluster created")
 
+	// Under AsyncSettle a fresh cluster reports creating until the window elapses,
+	// matching real MemoryDB (CreateCluster → creating → available). With the
+	// default (AsyncSettle off) SettleDuration is 0 → inactive window → available
+	// immediately, so nothing changes for existing callers. The stored row keeps
+	// the terminal status; only the read-path copy is overlaid.
+	m.clusterSettle.Begin(cfg.Name, mdbdriver.StatusCreating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultClusterSettle))
+
 	out := cloneCluster(&cluster)
 
 	return &out, nil
@@ -423,6 +435,7 @@ func (m *Mock) rollbackCluster(name, acl, mrc string) {
 	defer m.mu.Unlock()
 
 	m.clusters.Delete(name)
+	m.clusterSettle.Clear(name)
 	m.linkACLCluster(acl, name, false)
 
 	if mrc != "" {
@@ -435,9 +448,18 @@ func (m *Mock) DescribeClusters(_ context.Context, names []string) ([]mdbdriver.
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	return describeByName(m.clusters, names, cloneCluster, func(n string) error {
+	out, err := describeByName(m.clusters, names, cloneCluster, func(n string) error {
 		return cerrors.Newf(cerrors.NotFound, "cluster %q not found", n)
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range out {
+		m.overlayClusterStatus(&out[i])
+	}
+
+	return out, nil
 }
 
 // UpdateCluster applies the non-zero fields of cfg to an existing cluster.
@@ -488,7 +510,14 @@ func (m *Mock) UpdateCluster(_ context.Context, cfg mdbdriver.UpdateClusterConfi
 	m.clusters.Set(cfg.Name, c)
 	m.recordClusterEvent(cfg.Name, "Cluster modified")
 
+	// Under AsyncSettle an updated cluster briefly reports updating before settling
+	// back to available (UpdateCluster → updating → available); a no-op when settle
+	// is off.
+	m.clusterSettle.Begin(cfg.Name, mdbdriver.StatusUpdating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultCacheModifySettle))
+
 	out := cloneCluster(&c)
+	m.overlayClusterStatus(&out)
 
 	return &out, nil
 }
@@ -582,6 +611,7 @@ func (m *Mock) stageClusterDeleteLocked(name, finalSnapshotName string) (mdbdriv
 // holds the lock.
 func (m *Mock) removeClusterLocked(c *mdbdriver.Cluster) *mdbdriver.Cluster {
 	m.clusters.Delete(c.Name)
+	m.clusterSettle.Clear(c.Name)
 	m.linkACLCluster(c.ACLName, c.Name, false)
 
 	if c.MultiRegionClusterName != "" {

--- a/providers/aws/memorydb/memorydb.go
+++ b/providers/aws/memorydb/memorydb.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
@@ -52,6 +53,13 @@ type Mock struct {
 	// events is an append-only lifecycle log surfaced by DescribeEvents.
 	events []mdbdriver.Event
 
+	// clusterSettle overlays a transient creating/updating window (keyed by
+	// cluster name) over a cluster's stored "available" status so create/update
+	// report the real MemoryDB intermediate state before settling. It is a no-op
+	// unless config.Options.AsyncSettle is set (SettleDuration returns 0 → inactive
+	// window → historical synchronous behavior). The Set has its own lock.
+	clusterSettle *settle.Set
+
 	opts       *config.Options
 	monitoring mondriver.Monitoring
 }
@@ -70,6 +78,7 @@ func New(opts *config.Options) *Mock {
 		reservedNodes:   memstore.New[mdbdriver.ReservedNode](),
 		paramOverrides:  make(map[string]map[string]string),
 		tags:            make(map[string]map[string]string),
+		clusterSettle:   settle.NewSet(),
 		opts:            opts,
 	}
 
@@ -89,6 +98,14 @@ func New(opts *config.Options) *Mock {
 // SetMonitoring wires a CloudWatch backend for auto-metric emission.
 func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
 	m.monitoring = mon
+}
+
+// overlayClusterStatus overlays a cluster's settle window (keyed by name) onto
+// its Status field: the transient value while the window is active and
+// unelapsed, otherwise the stored terminal status. A no-op when no window
+// exists (default AsyncSettle-off path).
+func (m *Mock) overlayClusterStatus(c *mdbdriver.Cluster) {
+	c.Status = m.clusterSettle.State(c.Name, m.opts.Clock.Now(), c.Status)
 }
 
 func (m *Mock) arn(resourceType, name string) string {

--- a/providers/aws/redshift/async_settle_test.go
+++ b/providers/aws/redshift/async_settle_test.go
@@ -1,0 +1,124 @@
+package redshift
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
+	rdbdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// newAsyncMock builds a Redshift mock with AsyncSettle enabled and a FakeClock so
+// create/modify report their real transient states deterministically.
+func newAsyncMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("us-east-1"),
+		config.WithAccountID("123456789012"),
+		config.WithAsyncSettle(),
+	)
+
+	return New(opts), fc
+}
+
+func clusterState(t *testing.T, m *Mock, id string) string {
+	t.Helper()
+
+	got, err := m.DescribeClusters(context.Background(), []string{id})
+	if err != nil {
+		t.Fatalf("describe cluster: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("describe returned %d clusters, want 1", len(got))
+	}
+
+	return got[0].State
+}
+
+// TestAsyncSettleCreateModify pins the AsyncSettle transitions: a cluster reports
+// creating then available on create, and modifying then available on modify.
+func TestAsyncSettleCreateModify(t *testing.T) {
+	m, fc := newAsyncMock()
+	ctx := context.Background()
+
+	created, err := m.CreateCluster(ctx, rdbdriver.ClusterConfig{ID: "c1"})
+	if err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if created.State != rdbdriver.StateCreating {
+		t.Fatalf("create state = %q, want %q", created.State, rdbdriver.StateCreating)
+	}
+
+	if got := clusterState(t, m, "c1"); got != rdbdriver.StateCreating {
+		t.Fatalf("describe state = %q, want %q", got, rdbdriver.StateCreating)
+	}
+
+	// Still transient one instant before the window elapses.
+	fc.Advance(settle.DefaultClusterSettle - time.Millisecond)
+
+	if got := clusterState(t, m, "c1"); got != rdbdriver.StateCreating {
+		t.Fatalf("pre-settle state = %q, want %q", got, rdbdriver.StateCreating)
+	}
+
+	// Past the window: terminal available.
+	fc.Advance(time.Millisecond)
+
+	if got := clusterState(t, m, "c1"); got != rdbdriver.StateAvailable {
+		t.Fatalf("settled state = %q, want %q", got, rdbdriver.StateAvailable)
+	}
+
+	// Modify → modifying → available.
+	modified, err := m.ModifyCluster(ctx, "c1", rdbdriver.ModifyInstanceInput{NodeType: "dc2.large"})
+	if err != nil {
+		t.Fatalf("modify cluster: %v", err)
+	}
+
+	if modified.State != rdbdriver.StateModifying {
+		t.Fatalf("modify state = %q, want %q", modified.State, rdbdriver.StateModifying)
+	}
+
+	if got := clusterState(t, m, "c1"); got != rdbdriver.StateModifying {
+		t.Fatalf("post-modify describe state = %q, want %q", got, rdbdriver.StateModifying)
+	}
+
+	fc.Advance(settle.DefaultWarehouseResize)
+
+	if got := clusterState(t, m, "c1"); got != rdbdriver.StateAvailable {
+		t.Fatalf("post-modify settled state = %q, want %q", got, rdbdriver.StateAvailable)
+	}
+}
+
+// TestAsyncSettleDefaultOff confirms the default (AsyncSettle unset) path is
+// byte-for-byte synchronous: create and modify are observed as available
+// immediately, with no transient state.
+func TestAsyncSettleDefaultOff(t *testing.T) {
+	m := newTestMock() // no WithAsyncSettle
+	ctx := context.Background()
+
+	created, err := m.CreateCluster(ctx, rdbdriver.ClusterConfig{ID: "c1"})
+	if err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if created.State != rdbdriver.StateAvailable {
+		t.Fatalf("create state = %q, want %q", created.State, rdbdriver.StateAvailable)
+	}
+
+	if got := clusterState(t, m, "c1"); got != rdbdriver.StateAvailable {
+		t.Fatalf("describe state = %q, want %q", got, rdbdriver.StateAvailable)
+	}
+
+	modified, err := m.ModifyCluster(ctx, "c1", rdbdriver.ModifyInstanceInput{NodeType: "dc2.large"})
+	if err != nil {
+		t.Fatalf("modify cluster: %v", err)
+	}
+
+	if modified.State != rdbdriver.StateAvailable {
+		t.Fatalf("modify state = %q, want %q", modified.State, rdbdriver.StateAvailable)
+	}
+}

--- a/providers/aws/redshift/redshift.go
+++ b/providers/aws/redshift/redshift.go
@@ -19,6 +19,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/relationaldb/dbengine"
 	rdbdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
@@ -88,6 +89,13 @@ type Mock struct {
 	subnetGroups     *memstore.Store[SubnetGroup]
 	tagsByARN        map[string]map[string]string // ResourceName (ARN) -> tags
 
+	// clusterSettle overlays a transient creating/modifying window (keyed by
+	// cluster id) over a cluster's stored "available" state so create/modify report
+	// the real Redshift intermediate state before settling. It is a no-op unless
+	// config.Options.AsyncSettle is set (SettleDuration returns 0 → inactive window
+	// → historical synchronous behavior). The Set has its own lock.
+	clusterSettle *settle.Set
+
 	opts           *config.Options
 	monitoring     mondriver.Monitoring
 	subnetResolver SubnetResolver
@@ -100,8 +108,16 @@ func New(opts *config.Options) *Mock {
 		clusterSnapshots: memstore.New[rdbdriver.ClusterSnapshot](),
 		parameterGroups:  memstore.New[ParameterGroup](),
 		subnetGroups:     memstore.New[SubnetGroup](),
+		clusterSettle:    settle.NewSet(),
 		opts:             opts,
 	}
+}
+
+// settleClusterState overlays a cluster's settle window (keyed by id) onto its
+// stored terminal state: the transient value while the window is active and
+// unelapsed, otherwise final. Absent window → final.
+func (m *Mock) settleClusterState(id, final string) string {
+	return m.clusterSettle.State(id, m.opts.Clock.Now(), final)
 }
 
 // CreateClusterParameterGroup registers a redshift cluster parameter group.
@@ -499,7 +515,15 @@ func (m *Mock) CreateCluster(ctx context.Context, cfg rdbdriver.ClusterConfig) (
 	m.emitClusterMetrics(cfg.ID, cpuUtilizationRunning, databaseConnectionsRun,
 		readIOPSRunning, writeIOPSRunning, networkReceiveThroughput)
 
+	// Under AsyncSettle a fresh cluster reports creating until the window elapses,
+	// matching real Redshift (CreateCluster → creating → available). With the
+	// default (AsyncSettle off) SettleDuration is 0 → inactive window → available
+	// immediately, so nothing changes for existing callers.
+	m.clusterSettle.Begin(cfg.ID, rdbdriver.StateCreating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultClusterSettle))
+
 	out := cluster
+	out.State = m.settleClusterState(cfg.ID, out.State)
 
 	return &out, nil
 }
@@ -639,6 +663,7 @@ func (m *Mock) DescribeClusters(_ context.Context, ids []string) ([]rdbdriver.Cl
 
 		//nolint:gocritic // map values are large structs but we need a flat slice for the API.
 		for _, v := range all {
+			v.State = m.settleClusterState(v.ID, v.State)
 			out = append(out, v)
 		}
 
@@ -653,6 +678,7 @@ func (m *Mock) DescribeClusters(_ context.Context, ids []string) ([]rdbdriver.Cl
 			return nil, cerrors.Newf(cerrors.NotFound, "Redshift cluster %q not found", id)
 		}
 
+		cluster.State = m.settleClusterState(id, cluster.State)
 		out = append(out, cluster)
 	}
 
@@ -683,7 +709,14 @@ func (m *Mock) ModifyCluster(
 
 	m.clusters.Set(id, cluster)
 
+	// Under AsyncSettle a modified cluster briefly reports modifying before
+	// settling back to available (ModifyCluster → modifying → available); a no-op
+	// when settle is off.
+	m.clusterSettle.Begin(id, rdbdriver.StateModifying, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultWarehouseResize))
+
 	out := cluster
+	out.State = m.settleClusterState(id, out.State)
 
 	return &out, nil
 }
@@ -723,6 +756,8 @@ func (m *Mock) DeleteCluster(ctx context.Context, id string) error {
 			return cerrors.Newf(cerrors.NotFound, "Redshift cluster %q not found", id)
 		}
 
+		m.clusterSettle.Clear(id)
+
 		return nil
 	}
 
@@ -744,6 +779,7 @@ func (m *Mock) DeleteCluster(ctx context.Context, id string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.clusters.Delete(id)
+	m.clusterSettle.Clear(id)
 
 	return nil
 }
@@ -843,6 +879,9 @@ func (m *Mock) transitionCluster(id, from, to, verb string) error {
 
 	cluster.State = to
 	m.clusters.Set(id, cluster)
+	// An explicit lifecycle transition (start/stop/pause/resume) supersedes any
+	// still-active create/modify settle window, so drop it.
+	m.clusterSettle.Clear(id)
 
 	return nil
 }
@@ -1006,7 +1045,13 @@ func (m *Mock) RestoreClusterFromSnapshot(
 	m.emitClusterMetrics(input.NewClusterID, cpuUtilizationRunning, databaseConnectionsRun,
 		readIOPSRunning, writeIOPSRunning, networkReceiveThroughput)
 
+	// Restore is a create: report creating until the window elapses (a no-op when
+	// settle is off).
+	m.clusterSettle.Begin(input.NewClusterID, rdbdriver.StateCreating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultClusterSettle))
+
 	out := cluster
+	out.State = m.settleClusterState(input.NewClusterID, out.State)
 
 	return &out, nil
 }


### PR DESCRIPTION
Adopts the `settle.Set` async-lifecycle overlay (merged #974) in the remaining AWS database/cache services so create/modify report real transient states instead of jumping synchronously to the terminal state. This completes the async-lifecycle program (RDS #974, GCP #977, Azure #981 already done).

## What

Each provider Mock gains a `*settle.Set`; create begins a window in the real transient state, modify/update begins a modifying-state window, every read surface (Describe/Get/List) overlays the stored terminal state, and delete clears the window. Real AWS states per service:

- ElastiCache cluster + replication group: `creating`/`modifying` → `available`
- Redshift cluster: `creating`/`modifying` → `available` (create, modify, restore-from-snapshot)
- MemoryDB cluster: `creating`/`updating` → `available`
- Keyspaces table: `CREATING`/`UPDATING`/`RESTORING` → `ACTIVE` (keyspaces expose no status in the API, so only tables are overlaid)

## Gating

Gated behind the existing `config.Options.AsyncSettle`/`SettleDuration` — no new flag. Default (AsyncSettle off) → window duration 0 → inactive window → terminal state observed immediately, byte-for-byte the historical synchronous behavior. A `TestAsyncSettleDefaultOff` per package guards this; the #975 ElastiCache snapshot and #976 Redshift teardown tests are unaffected. Time is driven by `config.Clock` (FakeClock-deterministic). Each Set carries its own lock; -race clean.

Wire handlers pick up the transient state automatically since they read the provider's `Status`/`State` field.