### PR TITLE
feat(dynamodb): async table/GSI status (CREATING→ACTIVE, UPDATING→ACTIVE)

### DIFF
--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -17,6 +18,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
 	"github.com/stackshy/cloudemu/v2/internal/regionctx"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	"github.com/stackshy/cloudemu/v2/services/database/driver"
 	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
@@ -65,6 +67,29 @@ type tableData struct {
 	pitrEnabled   bool
 }
 
+// DynamoDB table/GSI lifecycle states and their settle durations. A real table
+// reports CREATING on create and UPDATING on an UpdateTable before reaching
+// ACTIVE; a GSI reports CREATING while it back-fills. The overlay is a read-time
+// window (see internal/settle) gated behind config.Options.AsyncSettle: with the
+// default (off) SettleDuration returns 0, the window is inactive and every read
+// reports ACTIVE immediately — byte-for-byte the historical behavior.
+const (
+	statusActive   = "ACTIVE"
+	statusCreating = "CREATING"
+	statusUpdating = "UPDATING"
+
+	settleTableCreate = 2 * time.Second // table CREATING->ACTIVE
+	settleTableUpdate = 2 * time.Second // table UPDATING->ACTIVE (throughput/billing change)
+	settleGSICreate   = 2 * time.Second // GSI CREATING->ACTIVE
+)
+
+// gsiSettleKey is the key under which a table's GSI settle window is stored,
+// namespacing the index by its table so identically named indexes on different
+// tables never collide.
+func gsiSettleKey(table, index string) string {
+	return table + "\x00" + index
+}
+
 // Mock is an in-memory mock implementation of DynamoDB.
 type Mock struct {
 	mu            sync.RWMutex
@@ -72,6 +97,12 @@ type Mock struct {
 	opts          *config.Options
 	monitoring    mondriver.Monitoring
 	streamInvoker StreamEventInvoker
+	// tableSettle overlays a CREATING/UPDATING window onto a table's stored
+	// ACTIVE status; gsiSettle does the same for each GSI (keyed by
+	// gsiSettleKey). Both are self-locking and independent of m.mu, so read-path
+	// accessors need no provider lock. Inactive unless config.AsyncSettle is set.
+	tableSettle *settle.Set
+	gsiSettle   *settle.Set
 	// pendingStream buffers stream records captured under m.mu so their delivery
 	// runs after the lock is released (a mapped Lambda may write back into
 	// DynamoDB); guarded by m.mu.
@@ -133,6 +164,8 @@ func New(opts *config.Options) *Mock {
 		opts:          opts,
 		txIdempotency: make(map[string]txIdempotencyRecord),
 		backups:       make(map[string]*backupData),
+		tableSettle:   settle.NewSet(),
+		gsiSettle:     settle.NewSet(),
 	}
 }
 
@@ -364,6 +397,15 @@ func (m *Mock) CreateTable(ctx context.Context, cfg driver.TableConfig) error {
 	td.config = cfg
 	m.tables[cfg.Name] = td
 
+	now := m.opts.Clock.Now()
+	m.tableSettle.Begin(cfg.Name, statusCreating, now, m.opts.SettleDuration(settleTableCreate))
+
+	gsiDur := m.opts.SettleDuration(settleGSICreate)
+
+	for _, gsi := range cfg.GSIs {
+		m.gsiSettle.Begin(gsiSettleKey(cfg.Name, gsi.Name), statusCreating, now, gsiDur)
+	}
+
 	return nil
 }
 
@@ -411,8 +453,15 @@ func (m *Mock) DeleteTable(_ context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.tables[name]; !exists {
+	td, exists := m.tables[name]
+	if !exists {
 		return cerrors.Newf(cerrors.NotFound, "table %s not found", name)
+	}
+
+	m.tableSettle.Clear(name)
+
+	for _, gsi := range td.config.GSIs {
+		m.gsiSettle.Clear(gsiSettleKey(name, gsi.Name))
 	}
 
 	delete(m.tables, name)
@@ -1165,6 +1214,8 @@ func (m *Mock) UpdateThroughput(_ context.Context, table, billingMode string, rc
 		td.config.WriteCapacityUnits = wcu
 	}
 
+	m.tableSettle.Begin(table, statusUpdating, m.opts.Clock.Now(), m.opts.SettleDuration(settleTableUpdate))
+
 	return nil
 }
 
@@ -1525,11 +1576,15 @@ func (m *Mock) CreateIndex(_ context.Context, table string, cfg driver.GSIConfig
 
 	td.config.GSIs = append(td.config.GSIs, cfg)
 
+	now := m.opts.Clock.Now()
+	key := gsiSettleKey(table, cfg.Name)
+	m.gsiSettle.Begin(key, statusCreating, now, m.opts.SettleDuration(settleGSICreate))
+
 	return &driver.IndexInfo{
 		Name:         cfg.Name,
 		PartitionKey: cfg.PartitionKey,
 		SortKey:      cfg.SortKey,
-		Status:       "ACTIVE",
+		Status:       m.gsiSettle.State(key, now, statusActive),
 	}, nil
 }
 
@@ -1546,6 +1601,9 @@ func (m *Mock) DeleteIndex(_ context.Context, table, indexName string) error {
 	for i, gsi := range td.config.GSIs {
 		if gsi.Name == indexName {
 			td.config.GSIs = append(td.config.GSIs[:i], td.config.GSIs[i+1:]...)
+
+			m.gsiSettle.Clear(gsiSettleKey(table, indexName))
+
 			return nil
 		}
 	}
@@ -1569,12 +1627,28 @@ func (m *Mock) DescribeIndex(_ context.Context, table, indexName string) (*drive
 				Name:         gsi.Name,
 				PartitionKey: gsi.PartitionKey,
 				SortKey:      gsi.SortKey,
-				Status:       "ACTIVE",
+				Status:       m.gsiSettle.State(gsiSettleKey(table, indexName), m.opts.Clock.Now(), statusActive),
 			}, nil
 		}
 	}
 
 	return nil, cerrors.Newf(cerrors.NotFound, "index %s not found", indexName)
+}
+
+// TableStatus reports a table's lifecycle status, overlaying any active
+// CREATING/UPDATING settle window onto the stored ACTIVE state. It is the
+// read-path accessor the DynamoDB wire handler calls (via an optional
+// capability interface) instead of hardcoding "ACTIVE"; absent a window (the
+// AsyncSettle-off default, or after the window elapses) it returns ACTIVE.
+func (m *Mock) TableStatus(table string) string {
+	return m.tableSettle.State(table, m.opts.Clock.Now(), statusActive)
+}
+
+// GSIStatus reports a Global Secondary Index's lifecycle status, overlaying any
+// active CREATING settle window onto the stored ACTIVE state. Companion to
+// TableStatus for the wire handler's GlobalSecondaryIndexes block.
+func (m *Mock) GSIStatus(table, index string) string {
+	return m.gsiSettle.State(gsiSettleKey(table, index), m.opts.Clock.Now(), statusActive)
 }
 
 // ListIndexes returns all Global Secondary Indexes for a table.
@@ -1587,13 +1661,15 @@ func (m *Mock) ListIndexes(_ context.Context, table string) ([]driver.IndexInfo,
 		return nil, cerrors.Newf(cerrors.NotFound, "table %s not found", table)
 	}
 
+	now := m.opts.Clock.Now()
 	indexes := make([]driver.IndexInfo, 0, len(td.config.GSIs))
+
 	for _, gsi := range td.config.GSIs {
 		indexes = append(indexes, driver.IndexInfo{
 			Name:         gsi.Name,
 			PartitionKey: gsi.PartitionKey,
 			SortKey:      gsi.SortKey,
-			Status:       "ACTIVE",
+			Status:       m.gsiSettle.State(gsiSettleKey(table, gsi.Name), now, statusActive),
 		})
 	}
 

--- a/providers/aws/dynamodb/dynamodb_settle_test.go
+++ b/providers/aws/dynamodb/dynamodb_settle_test.go
@@ -1,0 +1,138 @@
+package dynamodb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+// settleEpoch is a fixed base time so the FakeClock-driven settle assertions are
+// deterministic.
+var settleEpoch = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) //nolint:gochecknoglobals // test fixture
+
+func newSettleMock(t *testing.T) (*Mock, *config.FakeClock) {
+	t.Helper()
+
+	fc := config.NewFakeClock(settleEpoch)
+
+	return New(config.NewOptions(config.WithClock(fc), config.WithAsyncSettle())), fc
+}
+
+// TestTableStatusCreatingToActive verifies a created table reports CREATING
+// until its settle window elapses, then ACTIVE, when async settling is on.
+func TestTableStatusCreatingToActive(t *testing.T) {
+	m, fc := newSettleMock(t)
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "pk"}))
+
+	assertEqual(t, statusCreating, m.TableStatus("t1"))
+
+	fc.Advance(settleTableCreate - time.Millisecond)
+	assertEqual(t, statusCreating, m.TableStatus("t1"))
+
+	fc.Advance(time.Millisecond)
+	assertEqual(t, statusActive, m.TableStatus("t1"))
+}
+
+// TestTableStatusUpdatingToActive verifies UpdateThroughput drives the table
+// through UPDATING back to ACTIVE.
+func TestTableStatusUpdatingToActive(t *testing.T) {
+	m, fc := newSettleMock(t)
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "pk"}))
+	fc.Advance(settleTableCreate)
+	assertEqual(t, statusActive, m.TableStatus("t1"))
+
+	requireNoError(t, m.UpdateThroughput(ctx, "t1", "PROVISIONED", 10, 10))
+	assertEqual(t, statusUpdating, m.TableStatus("t1"))
+
+	fc.Advance(settleTableUpdate)
+	assertEqual(t, statusActive, m.TableStatus("t1"))
+}
+
+// TestGSIStatusCreatingToActive verifies a GSI added via CreateIndex reports
+// CREATING until its window elapses, then ACTIVE — independent of the table.
+func TestGSIStatusCreatingToActive(t *testing.T) {
+	m, fc := newSettleMock(t)
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "pk"}))
+	fc.Advance(settleTableCreate)
+
+	info, err := m.CreateIndex(ctx, "t1", driver.GSIConfig{Name: "gsi1", PartitionKey: "gk"})
+	requireNoError(t, err)
+	assertEqual(t, statusCreating, info.Status)
+	assertEqual(t, statusCreating, m.GSIStatus("t1", "gsi1"))
+	// The table itself stays ACTIVE while its index back-fills.
+	assertEqual(t, statusActive, m.TableStatus("t1"))
+
+	fc.Advance(settleGSICreate)
+	assertEqual(t, statusActive, m.GSIStatus("t1", "gsi1"))
+
+	desc, err := m.DescribeIndex(ctx, "t1", "gsi1")
+	requireNoError(t, err)
+	assertEqual(t, statusActive, desc.Status)
+}
+
+// TestCreateTimeGSIStatusCreating verifies a GSI declared at CreateTable time
+// also settles from CREATING to ACTIVE.
+func TestCreateTimeGSIStatusCreating(t *testing.T) {
+	m, fc := newSettleMock(t)
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateTable(ctx, driver.TableConfig{
+		Name: "t1", PartitionKey: "pk",
+		GSIs: []driver.GSIConfig{{Name: "gsi1", PartitionKey: "gk"}},
+	}))
+
+	assertEqual(t, statusCreating, m.GSIStatus("t1", "gsi1"))
+
+	fc.Advance(settleGSICreate)
+	assertEqual(t, statusActive, m.GSIStatus("t1", "gsi1"))
+}
+
+// TestSettleWindowsClearedOnDelete verifies deleting a table drops its table and
+// GSI windows so a re-created same-named table starts a fresh window.
+func TestSettleWindowsClearedOnDelete(t *testing.T) {
+	m, _ := newSettleMock(t)
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateTable(ctx, driver.TableConfig{
+		Name: "t1", PartitionKey: "pk",
+		GSIs: []driver.GSIConfig{{Name: "gsi1", PartitionKey: "gk"}},
+	}))
+	requireNoError(t, m.DeleteTable(ctx, "t1"))
+
+	// With the windows cleared, the absent table/GSI both fall back to ACTIVE.
+	assertEqual(t, statusActive, m.TableStatus("t1"))
+	assertEqual(t, statusActive, m.GSIStatus("t1", "gsi1"))
+}
+
+// TestAsyncSettleDefaultOff guards the blast radius: with the default options
+// (AsyncSettle off) a table and its GSI are ACTIVE the instant they are created,
+// exactly as before.
+func TestAsyncSettleDefaultOff(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateTable(ctx, driver.TableConfig{
+		Name: "t1", PartitionKey: "pk",
+		GSIs: []driver.GSIConfig{{Name: "gsi1", PartitionKey: "gk"}},
+	}))
+
+	assertEqual(t, statusActive, m.TableStatus("t1"))
+	assertEqual(t, statusActive, m.GSIStatus("t1", "gsi1"))
+
+	info, err := m.CreateIndex(ctx, "t1", driver.GSIConfig{Name: "gsi2", PartitionKey: "gk2"})
+	requireNoError(t, err)
+	assertEqual(t, statusActive, info.Status)
+	assertEqual(t, statusActive, m.GSIStatus("t1", "gsi2"))
+
+	requireNoError(t, m.UpdateThroughput(ctx, "t1", "PROVISIONED", 5, 5))
+	assertEqual(t, statusActive, m.TableStatus("t1"))
+}

--- a/server/aws/dynamodb/dynamodb_settle_test.go
+++ b/server/aws/dynamodb/dynamodb_settle_test.go
@@ -1,0 +1,194 @@
+// dynamodb_settle_test.go — real-user tests for asynchronous DynamoDB
+// table/GSI lifecycle status (CREATING/UPDATING -> ACTIVE). They drive the
+// genuine aws-sdk-go-v2 client against the emulator with async settling enabled
+// and a FakeClock, so an immediate DescribeTable observes the transient status
+// and advancing the clock resolves it to ACTIVE. A default-off case guards the
+// unchanged synchronous behavior.
+package dynamodb_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stackshy/cloudemu/v2"
+	emuconfig "github.com/stackshy/cloudemu/v2/config"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// settleWindow mirrors the provider's unexported table/GSI settle durations
+// (all 2s); advancing the FakeClock by it resolves a transient status to ACTIVE.
+const settleWindow = 2 * time.Second
+
+func newSettleDDBEnv(t *testing.T) (*dynamodb.Client, *emuconfig.FakeClock) {
+	t.Helper()
+
+	fc := emuconfig.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	provider := cloudemu.NewAWS(emuconfig.WithClock(fc), emuconfig.WithAsyncSettle())
+	srv := awsserver.New(awsserver.Drivers{DynamoDB: provider.DynamoDB})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	require.NoError(t, err)
+
+	client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+		o.HTTPClient = &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+	})
+
+	return client, fc
+}
+
+func describeStatus(t *testing.T, client *dynamodb.Client, table string) ddbtypes.TableStatus {
+	t.Helper()
+
+	out, err := client.DescribeTable(context.Background(), &dynamodb.DescribeTableInput{TableName: aws.String(table)})
+	require.NoError(t, err)
+
+	return out.Table.TableStatus
+}
+
+// TestSettleTableCreateStatus: a real CreateTable reports CREATING, an immediate
+// DescribeTable still sees CREATING, and once the clock advances past the window
+// it reads ACTIVE.
+func TestSettleTableCreateStatus(t *testing.T) {
+	client, fc := newSettleDDBEnv(t)
+	ctx := context.Background()
+
+	out, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:            aws.String("orders"),
+		KeySchema:            []ddbtypes.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash}},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS}},
+		BillingMode:          ddbtypes.BillingModePayPerRequest,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ddbtypes.TableStatusCreating, out.TableDescription.TableStatus)
+
+	assert.Equal(t, ddbtypes.TableStatusCreating, describeStatus(t, client, "orders"))
+
+	fc.Advance(settleWindow)
+	assert.Equal(t, ddbtypes.TableStatusActive, describeStatus(t, client, "orders"))
+}
+
+// TestSettleTableUpdateStatus: an UpdateTable throughput change drives the table
+// through UPDATING back to ACTIVE.
+func TestSettleTableUpdateStatus(t *testing.T) {
+	client, fc := newSettleDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:            aws.String("orders"),
+		KeySchema:            []ddbtypes.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash}},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS}},
+		BillingMode:          ddbtypes.BillingModePayPerRequest,
+	})
+	require.NoError(t, err)
+	fc.Advance(settleWindow)
+	require.Equal(t, ddbtypes.TableStatusActive, describeStatus(t, client, "orders"))
+
+	upd, err := client.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+		TableName:   aws.String("orders"),
+		BillingMode: ddbtypes.BillingModeProvisioned,
+		ProvisionedThroughput: &ddbtypes.ProvisionedThroughput{
+			ReadCapacityUnits:  aws.Int64(10),
+			WriteCapacityUnits: aws.Int64(10),
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ddbtypes.TableStatusUpdating, upd.TableDescription.TableStatus)
+	assert.Equal(t, ddbtypes.TableStatusUpdating, describeStatus(t, client, "orders"))
+
+	fc.Advance(settleWindow)
+	assert.Equal(t, ddbtypes.TableStatusActive, describeStatus(t, client, "orders"))
+}
+
+// TestSettleGSICreateStatus: a GSI added via UpdateTable reports IndexStatus
+// CREATING until the window elapses, then ACTIVE, while the table stays ACTIVE.
+func TestSettleGSICreateStatus(t *testing.T) {
+	client, fc := newSettleDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String("orders"),
+		KeySchema: []ddbtypes.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash}},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+	})
+	require.NoError(t, err)
+	fc.Advance(settleWindow)
+
+	_, err = client.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+		TableName: aws.String("orders"),
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("gk"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		GlobalSecondaryIndexUpdates: []ddbtypes.GlobalSecondaryIndexUpdate{{
+			Create: &ddbtypes.CreateGlobalSecondaryIndexAction{
+				IndexName:  aws.String("by-gk"),
+				KeySchema:  []ddbtypes.KeySchemaElement{{AttributeName: aws.String("gk"), KeyType: ddbtypes.KeyTypeHash}},
+				Projection: &ddbtypes.Projection{ProjectionType: ddbtypes.ProjectionTypeAll},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	out, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("orders")})
+	require.NoError(t, err)
+	require.Len(t, out.Table.GlobalSecondaryIndexes, 1)
+	assert.Equal(t, ddbtypes.IndexStatusCreating, out.Table.GlobalSecondaryIndexes[0].IndexStatus)
+	assert.Equal(t, ddbtypes.TableStatusActive, out.Table.TableStatus)
+
+	fc.Advance(settleWindow)
+	out, err = client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("orders")})
+	require.NoError(t, err)
+	assert.Equal(t, ddbtypes.IndexStatusActive, out.Table.GlobalSecondaryIndexes[0].IndexStatus)
+}
+
+// TestSettleDefaultOff guards the blast radius: with the default options
+// (async settling off) a real CreateTable reports ACTIVE immediately, exactly as
+// before this change.
+func TestSettleDefaultOff(t *testing.T) {
+	provider := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{DynamoDB: provider.DynamoDB})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	require.NoError(t, err)
+
+	client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+		o.HTTPClient = &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+	})
+	ctx := context.Background()
+
+	out, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:            aws.String("orders"),
+		KeySchema:            []ddbtypes.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash}},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS}},
+		BillingMode:          ddbtypes.BillingModePayPerRequest,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ddbtypes.TableStatusActive, out.TableDescription.TableStatus)
+	assert.Equal(t, ddbtypes.TableStatusActive, describeStatus(t, client, "orders"))
+}

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -311,7 +311,7 @@ func (h *Handler) createTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wire.WriteJSON(w, map[string]any{"TableDescription": tableDescription(full)})
+	wire.WriteJSON(w, map[string]any{"TableDescription": h.describeTableShape(full)})
 }
 
 // buildCreateConfig maps a decoded CreateTable request onto a driver
@@ -469,9 +469,46 @@ func (h *Handler) applyCreateTags(r *http.Request, w http.ResponseWriter, table 
 	return true
 }
 
+// tableStatusReader is the optional provider capability that reports a table's
+// and its GSIs' live lifecycle status (CREATING/UPDATING/ACTIVE). Discovered by
+// type assertion so it stays off the cross-cloud Database interface — only the
+// AWS mock implements it. A provider without it (or with async settling
+// disabled) reports ACTIVE, which is why tableDescription still defaults every
+// status to ACTIVE and this overlay only ever narrows it to a transient value.
+type tableStatusReader interface {
+	TableStatus(table string) string
+	GSIStatus(table, index string) string
+}
+
+// describeTable builds the TableDescription for a table, overlaying the live
+// table/GSI lifecycle status from the optional tableStatusReader capability onto
+// the ACTIVE default tableDescription emits. With async settling off (the
+// default) the accessors return ACTIVE, so the shape is byte-for-byte unchanged.
+func (h *Handler) describeTableShape(cfg *dbdriver.TableConfig) map[string]any {
+	td := tableDescription(cfg)
+
+	reader, ok := h.db.(tableStatusReader)
+	if !ok {
+		return td
+	}
+
+	td["TableStatus"] = reader.TableStatus(cfg.Name)
+
+	if gsis, ok := td["GlobalSecondaryIndexes"].([]map[string]any); ok {
+		for _, gsi := range gsis {
+			name, _ := gsi["IndexName"].(string)
+			gsi["IndexStatus"] = reader.GSIStatus(cfg.Name, name)
+		}
+	}
+
+	return td
+}
+
 // tableDescription builds the DynamoDB TableDescription wire shape that both
 // CreateTable and DescribeTable return, including the fields an IaC client reads
-// back (ARN, creation time, attribute definitions, billing mode).
+// back (ARN, creation time, attribute definitions, billing mode). It reports
+// every status as ACTIVE; describeTableShape overlays any transient
+// CREATING/UPDATING status from the provider.
 func tableDescription(cfg *dbdriver.TableConfig) map[string]any {
 	keySchema := []map[string]string{{"AttributeName": cfg.PartitionKey, "KeyType": keyTypeHash}}
 	if cfg.SortKey != "" {
@@ -643,7 +680,7 @@ func (h *Handler) describeTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wire.WriteJSON(w, map[string]any{"Table": tableDescription(cfg)})
+	wire.WriteJSON(w, map[string]any{"Table": h.describeTableShape(cfg)})
 }
 
 // describeContinuousBackups reports the table's point-in-time recovery state.

--- a/server/aws/dynamodb/update_table.go
+++ b/server/aws/dynamodb/update_table.go
@@ -81,7 +81,7 @@ func (h *Handler) updateTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wire.WriteJSON(w, map[string]any{"TableDescription": tableDescription(full)})
+	wire.WriteJSON(w, map[string]any{"TableDescription": h.describeTableShape(full)})
 }
 
 func indexDeleteName(del *struct {


### PR DESCRIPTION
## Summary

Models DynamoDB's asynchronous table/GSI lifecycle at the wire layer. Today `TableStatus`/`IndexStatus` are hardcoded `ACTIVE` in the handler; real DynamoDB reports:

- **Table**: `CREATING` on CreateTable → `ACTIVE`; `UPDATING` on an UpdateTable throughput/billing change → `ACTIVE`
- **GSI**: `CREATING` on create/add (table-time or via UpdateTable) → `ACTIVE`

## How

- The DynamoDB provider `Mock` holds two `settle.Set` overlays (table + GSI, keyed by name), begun on create/update and cleared on delete. They are self-locking and independent of `m.mu`, so read-path accessors need no provider lock (race-clean).
- New optional capability `tableStatusReader` (`TableStatus`/`GSIStatus`), discovered by the handler via type assertion like the existing `throughputUpdater`/`pitrController`. The handler resolves live status through it instead of hardcoding `ACTIVE`; a provider without it still reports `ACTIVE`.
- `DescribeIndex`/`ListIndexes`/`CreateIndex` also surface the transient GSI status.

## Gate: default-off, unchanged

Gated behind the existing `config.AsyncSettle` (no new flag). Default off → `SettleDuration` returns 0 → windows inactive → every read reports `ACTIVE` immediately, byte-for-byte the historical behavior. Full `go test ./...` is green with nothing flipped (including the #972 backup tests).

## Tests

- Provider-level (FakeClock, hand-rolled helpers): table CREATING→ACTIVE, UPDATING→ACTIVE, GSI CREATING→ACTIVE (table-time + UpdateTable), windows cleared on delete, and a `TestAsyncSettleDefaultOff` blast-radius guard.
- Real aws-sdk-go-v2 wire tests: CreateTable/DescribeTable observe `CREATING`→advance clock→`ACTIVE`; UpdateTable `UPDATING`→`ACTIVE`; add a GSI `CREATING`→`ACTIVE`; plus a default-off case asserting immediate `ACTIVE`.

Scope: `providers/aws/dynamodb` + `server/aws/dynamodb` only.