### PR TITLE
fix(network): enforce delete/in-use guards at the provider layer (Azure + GCP)

### DIFF
--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -197,11 +197,34 @@ func (m *Mock) CreateVPC(_ context.Context, cfg driver.VPCConfig) (*driver.VPCIn
 	return &info, nil
 }
 
-// DeleteVPC deletes the virtual network with the given ID.
+// DeleteVPC deletes the virtual network with the given ID, cascade-deleting its
+// child subnets. Real Azure removes a VNet's subnets along with it (they are
+// child resources of the VNet), so a caller that reaches the driver directly —
+// the typed Go API or the in-process library — gets the same cascade the ARM
+// wire performs, rather than leaving globally-addressable subnet rows orphaned.
+//
+// The subnet scan reads the subnets store while the delete writes the vnets
+// store — two independent memstores whose per-store locks cannot span both, so a
+// subnet created against this vnet in the same instant may survive the cascade.
+// Real Azure has the same eventual-consistency window; the emulator does not
+// model a cross-store lock, so the narrow gap is accepted.
+//
+// The subnet-in-use-by-NIC guard is not enforced here: that association is an
+// ARM-only concept the cross-cloud driver does not represent (a NIC stores an
+// opaque ARM subnet id), so it stays in the wire layer where the ARM path is
+// resolvable.
 func (m *Mock) DeleteVPC(_ context.Context, id string) error {
-	if !m.vpcs.Delete(id) {
+	if !m.vpcs.Has(id) {
 		return cerrors.Newf(cerrors.NotFound, "vnet %q not found", id)
 	}
+
+	for sid, s := range m.subnets.All() {
+		if s.VPCID == id {
+			m.subnets.Delete(sid)
+		}
+	}
+
+	m.vpcs.Delete(id)
 
 	return nil
 }

--- a/providers/azure/vnet/vnet_test.go
+++ b/providers/azure/vnet/vnet_test.go
@@ -1399,3 +1399,38 @@ func TestTagMutation(t *testing.T) {
 		require.Error(t, m.RemoveSecurityGroupTags(ctx, "nsg-nope", []string{"k"}))
 	})
 }
+
+// TestDeleteVPCCascadesSubnets covers the provider-layer cascade: deleting a
+// virtual network removes its child subnets (as real Azure does), so a typed-API
+// or in-process-library caller does not leave orphaned, globally-addressable
+// subnet rows behind — the same behavior the ARM wire performs.
+func TestDeleteVPCCascadesSubnets(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	sub1, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpc.ID, CIDRBlock: "10.0.1.0/24"})
+	require.NoError(t, err)
+	sub2, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpc.ID, CIDRBlock: "10.0.2.0/24"})
+	require.NoError(t, err)
+
+	// A subnet on a different vnet must survive the cascade.
+	other, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "172.16.0.0/16"})
+	require.NoError(t, err)
+	otherSub, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: other.ID, CIDRBlock: "172.16.1.0/24"})
+	require.NoError(t, err)
+
+	require.NoError(t, m.DeleteVPC(ctx, vpc.ID))
+
+	got, err := m.DescribeSubnets(ctx, []string{sub1.ID, sub2.ID})
+	require.NoError(t, err)
+	assert.Empty(t, got, "child subnets should be cascade-deleted with the vnet")
+
+	survivors, err := m.DescribeSubnets(ctx, []string{otherSub.ID})
+	require.NoError(t, err)
+	assert.Len(t, survivors, 1, "another vnet's subnet must not be deleted")
+
+	require.Error(t, m.DeleteVPC(ctx, "vnet-missing"))
+}

--- a/providers/gcp/vpc/vpc.go
+++ b/providers/gcp/vpc/vpc.go
@@ -106,13 +106,51 @@ func (m *Mock) CreateVPC(_ context.Context, cfg driver.VPCConfig) (*driver.VPCIn
 	return &info, nil
 }
 
-// DeleteVPC deletes the VPC network with the given ID.
+// DeleteVPC deletes the VPC network with the given ID. Real GCP refuses to
+// delete a network that still has child resources — subnetworks or firewall
+// rules — answering resourceInUseByAnotherResource; the children must be removed
+// first. Enforcing this in the driver (not only in the wire handler) means the
+// typed Go API and the in-process library get the same protection an SDK/CLI
+// caller does, matching how the AWS VPC provider guards DeleteVPC.
+//
+// The dependency scan reads the subnets and firewall (security-group) stores
+// while the delete writes the networks store — independent memstores whose
+// per-store locks cannot span all three, so a child inserted in the same instant
+// may slip past the check. Real GCP has the same eventual-consistency window;
+// the emulator does not model a cross-store lock, so the narrow gap is accepted.
 func (m *Mock) DeleteVPC(_ context.Context, id string) error {
-	if !m.vpcs.Delete(id) {
+	if !m.vpcs.Has(id) {
 		return cerrors.Newf(cerrors.NotFound, "VPC %q not found", id)
 	}
 
+	if dep, blocked := m.networkDependency(id); blocked {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"the network %q is already being used by %s", id, dep)
+	}
+
+	m.vpcs.Delete(id)
+
 	return nil
+}
+
+// networkDependency reports the first child resource that blocks deleting the
+// network — a subnetwork or a firewall rule — or ("", false) when none remains.
+// Both persist their parent as the driver VPC id (CreateSubnet / CreateSecurity-
+// Group set VPCID), so a direct id match is sufficient.
+func (m *Mock) networkDependency(id string) (string, bool) {
+	for _, s := range m.subnets.All() {
+		if s.VPCID == id {
+			return "subnetwork " + s.ID, true
+		}
+	}
+
+	for _, sg := range m.securityGroups.All() {
+		if sg.VPCID == id {
+			return "firewall " + sg.ID, true
+		}
+	}
+
+	return "", false
 }
 
 // DescribeVPCs returns VPCs matching the given IDs, or all VPCs if ids is empty.

--- a/providers/gcp/vpc/vpc_test.go
+++ b/providers/gcp/vpc/vpc_test.go
@@ -1509,3 +1509,60 @@ func TestTagMutation(t *testing.T) {
 		require.Error(t, m.RemoveSecurityGroupTags(ctx, "fw-nope", []string{"k"}))
 	})
 }
+
+// TestDeleteVPCInUseByChild covers the provider-layer delete guard: a network
+// referenced by a subnetwork or a firewall rule cannot be deleted (typed-API
+// callers get the same protection as an SDK/CLI caller), and the delete succeeds
+// once the child is removed or when the network is unreferenced.
+func TestDeleteVPCInUseByChild(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("blocked by subnetwork", func(t *testing.T) {
+		m := newTestMock()
+
+		vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		require.NoError(t, err)
+
+		sub, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpc.ID, CIDRBlock: "10.0.1.0/24"})
+		require.NoError(t, err)
+
+		err = m.DeleteVPC(ctx, vpc.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already being used")
+		assert.Contains(t, err.Error(), "subnetwork")
+
+		// The network must still exist (delete rejected, not partially applied).
+		vpcs, err := m.DescribeVPCs(ctx, []string{vpc.ID})
+		require.NoError(t, err)
+		assert.Len(t, vpcs, 1)
+
+		// Delete the child, then the network deletes cleanly.
+		require.NoError(t, m.DeleteSubnet(ctx, sub.ID))
+		require.NoError(t, m.DeleteVPC(ctx, vpc.ID))
+	})
+
+	t.Run("blocked by firewall", func(t *testing.T) {
+		m := newTestMock()
+
+		vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		require.NoError(t, err)
+
+		fw, err := m.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{Name: "allow-ssh", VPCID: vpc.ID})
+		require.NoError(t, err)
+
+		err = m.DeleteVPC(ctx, vpc.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "firewall")
+
+		require.NoError(t, m.DeleteSecurityGroup(ctx, fw.ID))
+		require.NoError(t, m.DeleteVPC(ctx, vpc.ID))
+	})
+
+	t.Run("unreferenced network deletes", func(t *testing.T) {
+		m := newTestMock()
+
+		vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		require.NoError(t, err)
+		require.NoError(t, m.DeleteVPC(ctx, vpc.ID))
+	})
+}

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -645,14 +645,12 @@ func (h *Handler) deleteVNet(w http.ResponseWriter, r *http.Request, rp azurearm
 		return
 	}
 
-	// Cascade-delete the child subnets so they stop being globally addressable
-	// once their parent network is gone.
-	h.deleteChildSubnets(r.Context(), info.ID)
-
 	if meta, ok := h.azureMeta(); ok {
 		meta.DeleteAzureVNetMetadata(r.Context(), info.ID)
 	}
 
+	// DeleteVPC cascade-deletes the child subnets at the driver layer (the single
+	// source of truth), so they stop being globally addressable with their parent.
 	if err := h.net.DeleteVPC(r.Context(), info.ID); err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -777,6 +775,8 @@ func (h *Handler) purgePublicIPs(ctx context.Context, resourceGroup string) erro
 
 // purgeVNets deletes every virtual network (with its subnets and metadata) in
 // the resource group, returning the first delete error encountered.
+//
+//nolint:dupl // mirrors purgeNSGs over a distinct resource type and store by design
 func (h *Handler) purgeVNets(ctx context.Context, resourceGroup string) error {
 	vpcs, err := h.net.DescribeVPCs(ctx, nil)
 	if err != nil {
@@ -790,12 +790,11 @@ func (h *Handler) purgeVNets(ctx context.Context, resourceGroup string) error {
 			continue
 		}
 
-		h.deleteChildSubnets(ctx, vpcs[i].ID)
-
 		if meta, ok := h.azureMeta(); ok {
 			meta.DeleteAzureVNetMetadata(ctx, vpcs[i].ID)
 		}
 
+		// DeleteVPC cascade-deletes the vnet's child subnets at the driver layer.
 		if derr := h.net.DeleteVPC(ctx, vpcs[i].ID); derr != nil && firstErr == nil {
 			firstErr = derr
 		}
@@ -831,20 +830,6 @@ func (h *Handler) purgeNSGs(ctx context.Context, resourceGroup string) error {
 	}
 
 	return firstErr
-}
-
-// deleteChildSubnets removes every subnet that belongs to the given vnet.
-func (h *Handler) deleteChildSubnets(ctx context.Context, vpcID string) {
-	subs, err := h.net.DescribeSubnets(ctx, nil)
-	if err != nil {
-		return
-	}
-
-	for i := range subs {
-		if subs[i].VPCID == vpcID {
-			_ = h.net.DeleteSubnet(ctx, subs[i].ID)
-		}
-	}
 }
 
 // vnetSubnetInUse reports whether any network interface's ipConfiguration

--- a/server/gcp/vpc/handler.go
+++ b/server/gcp/vpc/handler.go
@@ -423,10 +423,14 @@ func (h *Handler) deleteNetwork(w http.ResponseWriter, r *http.Request, rp gcpre
 	// or firewall (see vpc.Mock.DeleteVPC), so the guard is authoritative at the
 	// driver layer and protects every caller, not just the wire. Real GCP answers
 	// 400 resourceInUseByAnotherResource rather than the generic 409 conditionNotMet
-	// WriteCErr maps FailedPrecondition to, so translate that one case here.
+	// WriteCErr maps FailedPrecondition to, so translate that one case here — and
+	// re-derive the child's user-facing name so the message names the resource the
+	// caller typed, not the provider error's internal driver id.
 	if err := h.net.DeleteVPC(r.Context(), v.ID); err != nil {
 		if cerrors.IsFailedPrecondition(err) {
-			gcprest.WriteError(w, http.StatusBadRequest, "resourceInUseByAnotherResource", err.Error())
+			gcprest.WriteError(w, http.StatusBadRequest, "resourceInUseByAnotherResource",
+				h.networkInUseMessage(r.Context(), v.ID, rp.ResourceName))
+
 			return
 		}
 
@@ -1178,6 +1182,42 @@ func findSubnetByName(ctx context.Context, n netdriver.Networking, name, region 
 	}
 
 	return nil, cerrors.Newf(cerrors.NotFound, "subnetwork %s not found", name)
+}
+
+// networkInUseMessage renders the user-facing resourceInUseByAnotherResource
+// body for a network delete the provider rejected, naming the first referencing
+// child (subnetwork, then firewall) by the real resource name the caller typed
+// rather than the internal driver id the provider's error carries. The guard
+// itself lives in the provider (vpc.Mock.DeleteVPC); this only re-derives the
+// name for the message. If the child was removed between the reject and this
+// scan, it falls back to a generic phrasing.
+func (h *Handler) networkInUseMessage(ctx context.Context, vpcID, netName string) string {
+	usedBy := func(child string) string {
+		return "The network resource '" + netName + "' is already being used by '" + child + "'"
+	}
+
+	if subs, err := h.net.DescribeSubnets(ctx, nil); err == nil {
+		for i := range subs {
+			if subs[i].VPCID == vpcID {
+				return usedBy(tagOr(subs[i].Tags, subnetNameTag, subs[i].ID))
+			}
+		}
+	}
+
+	if fws, err := h.net.DescribeSecurityGroups(ctx, nil); err == nil {
+		for i := range fws {
+			if fws[i].VPCID == vpcID {
+				name := fws[i].Name
+				if name == "" {
+					name = tagOr(fws[i].Tags, firewallNameTag, fws[i].ID)
+				}
+
+				return usedBy(name)
+			}
+		}
+	}
+
+	return "The network resource '" + netName + "' is already being used by another resource"
 }
 
 // These mirror the tag keys the compute wire handler stamps on each instance

--- a/server/gcp/vpc/handler.go
+++ b/server/gcp/vpc/handler.go
@@ -419,21 +419,19 @@ func (h *Handler) deleteNetwork(w http.ResponseWriter, r *http.Request, rp gcpre
 		return
 	}
 
-	// Real GCP refuses to delete a network that still has subnetworks; the
-	// deletion would otherwise orphan them. Scan for live subnets on this
-	// network and reject with resourceInUseByAnotherResource.
-	if sub, scanErr := h.subnetOnNetwork(r.Context(), v.ID, rp.ResourceName); scanErr != nil {
-		gcprest.WriteCErr(w, scanErr)
-		return
-	} else if sub != "" {
-		gcprest.WriteError(w, http.StatusBadRequest, "resourceInUseByAnotherResource",
-			"The network resource '"+rp.ResourceName+"' is already being used by '"+sub+"'")
-
-		return
-	}
-
+	// The provider refuses to delete a network still referenced by a subnetwork
+	// or firewall (see vpc.Mock.DeleteVPC), so the guard is authoritative at the
+	// driver layer and protects every caller, not just the wire. Real GCP answers
+	// 400 resourceInUseByAnotherResource rather than the generic 409 conditionNotMet
+	// WriteCErr maps FailedPrecondition to, so translate that one case here.
 	if err := h.net.DeleteVPC(r.Context(), v.ID); err != nil {
+		if cerrors.IsFailedPrecondition(err) {
+			gcprest.WriteError(w, http.StatusBadRequest, "resourceInUseByAnotherResource", err.Error())
+			return
+		}
+
 		gcprest.WriteCErr(w, err)
+
 		return
 	}
 
@@ -1180,24 +1178,6 @@ func findSubnetByName(ctx context.Context, n netdriver.Networking, name, region 
 	}
 
 	return nil, cerrors.Newf(cerrors.NotFound, "subnetwork %s not found", name)
-}
-
-// subnetOnNetwork returns the name of the first subnetwork attached to the
-// given network (by driver VPC ID or by the stored network-name tag), or "" if
-// none. It underpins the delete-in-use guard for networks.
-func (h *Handler) subnetOnNetwork(ctx context.Context, vpcID, netName string) (string, error) {
-	infos, err := h.net.DescribeSubnets(ctx, nil)
-	if err != nil {
-		return "", err
-	}
-
-	for i := range infos {
-		if infos[i].VPCID == vpcID || tagOr(infos[i].Tags, subnetNetworkTag, "") == netName {
-			return tagOr(infos[i].Tags, subnetNameTag, infos[i].ID), nil
-		}
-	}
-
-	return "", nil
 }
 
 // These mirror the tag keys the compute wire handler stamps on each instance

--- a/server/gcp/vpc/networks_semantics_test.go
+++ b/server/gcp/vpc/networks_semantics_test.go
@@ -147,6 +147,69 @@ func TestSDKNetworkDeleteInUse(t *testing.T) {
 	}
 }
 
+// TestSDKNetworkDeleteBlockedByFirewall verifies the provider-layer guard, now
+// authoritative for every caller, also blocks a network delete over the wire
+// while a firewall rule still references the network — real GCP answers
+// resourceInUseByAnotherResource. Deleting the firewall unblocks the network.
+func TestSDKNetworkDeleteBlockedByFirewall(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+	c := newNetClient(t, ts.URL, ts.Client())
+
+	mustInsertNetwork(t, ctx, c, &computepb.Network{
+		Name:                  ptrStr("vpc-fw"),
+		AutoCreateSubnetworks: func() *bool { b := false; return &b }(),
+	})
+
+	fwClient, err := gcpcompute.NewFirewallsRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewFirewallsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = fwClient.Close() })
+
+	fwOp, err := fwClient.Insert(ctx, &computepb.InsertFirewallRequest{
+		Project: testProject,
+		FirewallResource: &computepb.Firewall{
+			Name:         ptrStr("fw-block"),
+			Network:      ptrStr("projects/" + testProject + "/global/networks/vpc-fw"),
+			Allowed:      []*computepb.Allowed{{IPProtocol: ptrStr("tcp"), Ports: []string{"22"}}},
+			SourceRanges: []string{"0.0.0.0/0"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("firewall Insert: %v", err)
+	}
+
+	if err := fwOp.Wait(ctx); err != nil {
+		t.Fatalf("firewall Insert wait: %v", err)
+	}
+
+	if _, err := c.Delete(ctx, &computepb.DeleteNetworkRequest{Project: testProject, Network: "vpc-fw"}); err == nil {
+		t.Fatal("Delete of network with firewall: want error, got nil")
+	}
+
+	// Remove the firewall, then the network deletes cleanly.
+	delFwOp, err := fwClient.Delete(ctx, &computepb.DeleteFirewallRequest{Project: testProject, Firewall: "fw-block"})
+	if err != nil {
+		t.Fatalf("firewall Delete: %v", err)
+	}
+
+	if err := delFwOp.Wait(ctx); err != nil {
+		t.Fatalf("firewall Delete wait: %v", err)
+	}
+
+	delOp, err := c.Delete(ctx, &computepb.DeleteNetworkRequest{Project: testProject, Network: "vpc-fw"})
+	if err != nil {
+		t.Fatalf("network Delete after firewall removed: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Fatalf("network Delete wait: %v", err)
+	}
+}
+
 // TestNetworkListPagination covers the finding that maxResults/pageToken were
 // ignored and nextPageToken never set. Verified over the wire since the SDK
 // iterator transparently follows pages.

--- a/server/gcp/vpc/networks_semantics_test.go
+++ b/server/gcp/vpc/networks_semantics_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	gcpcompute "cloud.google.com/go/compute/apiv1"
@@ -135,8 +136,14 @@ func TestSDKNetworkDeleteInUse(t *testing.T) {
 		t.Fatalf("subnet Insert wait: %v", err)
 	}
 
-	if _, err := c.Delete(ctx, &computepb.DeleteNetworkRequest{Project: testProject, Network: "vpc-inuse"}); err == nil {
+	_, delErr := c.Delete(ctx, &computepb.DeleteNetworkRequest{Project: testProject, Network: "vpc-inuse"})
+	if delErr == nil {
 		t.Fatal("Delete of in-use network: want error, got nil")
+	}
+
+	// The message must name the real resources, not internal driver ids.
+	if msg := delErr.Error(); !strings.Contains(msg, "vpc-inuse") || !strings.Contains(msg, "sub-inuse") {
+		t.Errorf("in-use message %q must contain real names vpc-inuse and sub-inuse", msg)
 	}
 
 	// The subnet must still exist (delete rejected, not partially applied).
@@ -186,8 +193,15 @@ func TestSDKNetworkDeleteBlockedByFirewall(t *testing.T) {
 		t.Fatalf("firewall Insert wait: %v", err)
 	}
 
-	if _, err := c.Delete(ctx, &computepb.DeleteNetworkRequest{Project: testProject, Network: "vpc-fw"}); err == nil {
+	_, delErr := c.Delete(ctx, &computepb.DeleteNetworkRequest{Project: testProject, Network: "vpc-fw"})
+	if delErr == nil {
 		t.Fatal("Delete of network with firewall: want error, got nil")
+	}
+
+	// The message must name the real resources the caller typed, not the
+	// internal driver ids the provider error carries.
+	if msg := delErr.Error(); !strings.Contains(msg, "vpc-fw") || !strings.Contains(msg, "fw-block") {
+		t.Errorf("in-use message %q must contain real names vpc-fw and fw-block", msg)
 	}
 
 	// Remove the firewall, then the network deletes cleanly.


### PR DESCRIPTION
## Summary

Azure and GCP networking enforced their delete/cascade guards **only in the wire handler**, so typed-API and in-process-library callers got zero cascade protection — unlike AWS, which guards in the provider layer so all access paths are protected. This moves the authoritative guards down to the provider layer.

- **GCP** — `vpc.Mock.DeleteVPC` now refuses a network still referenced by a subnetwork or a firewall rule (`FailedPrecondition`). The wire `deleteNetwork` delegates to it and translates the in-use error to `400 resourceInUseByAnotherResource` (preserving the SDK e2e response from #967), re-deriving the child's real user-facing name for the message. This also closes the previously-missing **firewall** reference guard the audit flagged.
- **Azure** — `vnet.Mock.DeleteVPC` now cascade-deletes its child subnets, matching real Azure VNet delete semantics (subnets are child resources). The wire `deleteVNet`/`purgeVNets` delegate the cascade to it (single source of truth); the redundant `deleteChildSubnets` helper is removed.

Typed-API callers are now protected the same way AWS callers are; the wire delegates rather than double-guarding with divergent messages.

## Scope / architecture notes

NSG/route-table/NAT-gateway and NIC in-use guards remain in the Azure wire layer: those are ARM-only associations carried as opaque ARM resource ids that only the wire can resolve to driver ids; pushing them down would leak ARM-path resolution into the provider. Documented in the `DeleteVPC` comments. These are tracked as separate follow-ups (audit item 3).

The GCP route-vs-network delete guard is **not implemented anywhere** (neither wire nor provider) — it is an existing gap, not something this PR moves; tracked as a separate backlog follow-up (audit item 7).

## Tests

- Provider-level (typed-API): GCP network delete blocked by subnetwork / firewall, unblocked after child removed, unreferenced deletes; Azure VNet delete cascades child subnets and spares another VNet's subnet.
- Wire SDK e2e: GCP tests prove a subnet and a firewall each block network delete over the wire (and unblock after removal), and assert the SDK-visible message contains the real resource names (`vpc-fw`/`fw-block`, `vpc-inuse`/`sub-inuse`), not internal driver ids; existing #967 subnet-in-use e2e still green.

## Gates

`go build ./...`, `gofmt -l` empty, `go test ./...` exit 0, targeted `-race` green, `golangci-lint --new-from-rev=origin/development` 0 new issues, `coveragegen` no diff, `go mod tidy` clean.