### PR TITLE
feat(s3): enforce Object Lock retention (GOVERNANCE/COMPLIANCE) + legal hold

### DIFF
--- a/docs/coverage/aws/s3.md
+++ b/docs/coverage/aws/s3.md
@@ -63,6 +63,61 @@ ObjectCopier is an OPTIONAL capability (discovered by type assertion, like
 | --- | --- |
 | `CopyObjectV2` |  |
 
+### ObjectLockBucket
+
+ObjectLockBucket is an OPTIONAL S3-specific capability (discovered by type
+
+| Operation | Description |
+| --- | --- |
+| `AbortMultipartUpload` |  |
+| `CompleteMultipartUpload` |  |
+| `CopyObject` |  |
+| `CreateBucket` |  |
+| `CreateMultipartUpload` | Multipart uploads |
+| `DeleteBucket` |  |
+| `DeleteBucketPolicy` |  |
+| `DeleteBucketTagging` |  |
+| `DeleteCORSConfig` |  |
+| `DeleteObject` |  |
+| `DeleteObjectTagging` |  |
+| `DeleteObjectVersion` | DeleteObjectVersion removes a specific version when versionID != "". |
+| `DeleteObjectVersionWithBypass` | DeleteObjectVersionWithBypass is DeleteObjectVersion with Object Lock |
+| `EnableObjectLock` | EnableObjectLock marks a bucket Object-Lock-enabled and turns on versioning |
+| `EvaluateLifecycle` |  |
+| `GeneratePresignedURL` | Presigned URLs |
+| `GetBucketPolicy` |  |
+| `GetBucketTagging` |  |
+| `GetBucketVersioning` |  |
+| `GetCORSConfig` |  |
+| `GetEncryptionConfig` |  |
+| `GetLifecycleConfig` |  |
+| `GetObject` |  |
+| `GetObjectLegalHold` | GetObjectLegalHold reports whether legal hold is ON for a version (current |
+| `GetObjectRetention` | GetObjectRetention returns the retention on a version (the current version |
+| `GetObjectTagging` |  |
+| `GetObjectVersion` | GetObjectVersion / HeadObjectVersion fetch a specific version by ID. A |
+| `HeadObject` |  |
+| `HeadObjectVersion` |  |
+| `ListBuckets` |  |
+| `ListMultipartUploads` |  |
+| `ListObjectVersions` | ListObjectVersions returns the full version history matching opts. |
+| `ListObjects` |  |
+| `ListParts` | ListParts returns the parts buffered so far for an in-progress upload, |
+| `ObjectLockEnabled` | ObjectLockEnabled reports whether the bucket was created with Object Lock |
+| `PutBucketPolicy` | Bucket Policy |
+| `PutBucketTagging` | Bucket Tagging |
+| `PutCORSConfig` | CORS |
+| `PutEncryptionConfig` | Encryption |
+| `PutLifecycleConfig` | Lifecycle policies |
+| `PutObject` |  |
+| `PutObjectLegalHold` | PutObjectLegalHold sets legal hold ON/OFF for a version (current when |
+| `PutObjectRetention` | PutObjectRetention sets the retention on a version (current when |
+| `PutObjectTagging` | Object Tagging |
+| `SetBucketVersioning` | Versioning |
+| `SetVersioningStatus` | SetVersioningStatus sets the bucket's versioning status: "Enabled" or |
+| `UploadPart` |  |
+| `VersioningStatus` |  |
+
 ### RawBucketConfig
 
 RawBucketConfig is an OPTIONAL capability (discovered by type assertion, like

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -12683,6 +12683,177 @@
         ]
       },
       {
+        "name": "ObjectLockBucket",
+        "doc": "ObjectLockBucket is an OPTIONAL S3-specific capability (discovered by type",
+        "operations": [
+          {
+            "name": "AbortMultipartUpload"
+          },
+          {
+            "name": "CompleteMultipartUpload"
+          },
+          {
+            "name": "CopyObject"
+          },
+          {
+            "name": "CreateBucket"
+          },
+          {
+            "name": "CreateMultipartUpload",
+            "doc": "Multipart uploads"
+          },
+          {
+            "name": "DeleteBucket"
+          },
+          {
+            "name": "DeleteBucketPolicy"
+          },
+          {
+            "name": "DeleteBucketTagging"
+          },
+          {
+            "name": "DeleteCORSConfig"
+          },
+          {
+            "name": "DeleteObject"
+          },
+          {
+            "name": "DeleteObjectTagging"
+          },
+          {
+            "name": "DeleteObjectVersion",
+            "doc": "DeleteObjectVersion removes a specific version when versionID != \"\"."
+          },
+          {
+            "name": "DeleteObjectVersionWithBypass",
+            "doc": "DeleteObjectVersionWithBypass is DeleteObjectVersion with Object Lock"
+          },
+          {
+            "name": "EnableObjectLock",
+            "doc": "EnableObjectLock marks a bucket Object-Lock-enabled and turns on versioning"
+          },
+          {
+            "name": "EvaluateLifecycle"
+          },
+          {
+            "name": "GeneratePresignedURL",
+            "doc": "Presigned URLs"
+          },
+          {
+            "name": "GetBucketPolicy"
+          },
+          {
+            "name": "GetBucketTagging"
+          },
+          {
+            "name": "GetBucketVersioning"
+          },
+          {
+            "name": "GetCORSConfig"
+          },
+          {
+            "name": "GetEncryptionConfig"
+          },
+          {
+            "name": "GetLifecycleConfig"
+          },
+          {
+            "name": "GetObject"
+          },
+          {
+            "name": "GetObjectLegalHold",
+            "doc": "GetObjectLegalHold reports whether legal hold is ON for a version (current"
+          },
+          {
+            "name": "GetObjectRetention",
+            "doc": "GetObjectRetention returns the retention on a version (the current version"
+          },
+          {
+            "name": "GetObjectTagging"
+          },
+          {
+            "name": "GetObjectVersion",
+            "doc": "GetObjectVersion / HeadObjectVersion fetch a specific version by ID. A"
+          },
+          {
+            "name": "HeadObject"
+          },
+          {
+            "name": "HeadObjectVersion"
+          },
+          {
+            "name": "ListBuckets"
+          },
+          {
+            "name": "ListMultipartUploads"
+          },
+          {
+            "name": "ListObjectVersions",
+            "doc": "ListObjectVersions returns the full version history matching opts."
+          },
+          {
+            "name": "ListObjects"
+          },
+          {
+            "name": "ListParts",
+            "doc": "ListParts returns the parts buffered so far for an in-progress upload,"
+          },
+          {
+            "name": "ObjectLockEnabled",
+            "doc": "ObjectLockEnabled reports whether the bucket was created with Object Lock"
+          },
+          {
+            "name": "PutBucketPolicy",
+            "doc": "Bucket Policy"
+          },
+          {
+            "name": "PutBucketTagging",
+            "doc": "Bucket Tagging"
+          },
+          {
+            "name": "PutCORSConfig",
+            "doc": "CORS"
+          },
+          {
+            "name": "PutEncryptionConfig",
+            "doc": "Encryption"
+          },
+          {
+            "name": "PutLifecycleConfig",
+            "doc": "Lifecycle policies"
+          },
+          {
+            "name": "PutObject"
+          },
+          {
+            "name": "PutObjectLegalHold",
+            "doc": "PutObjectLegalHold sets legal hold ON/OFF for a version (current when"
+          },
+          {
+            "name": "PutObjectRetention",
+            "doc": "PutObjectRetention sets the retention on a version (current when"
+          },
+          {
+            "name": "PutObjectTagging",
+            "doc": "Object Tagging"
+          },
+          {
+            "name": "SetBucketVersioning",
+            "doc": "Versioning"
+          },
+          {
+            "name": "SetVersioningStatus",
+            "doc": "SetVersioningStatus sets the bucket's versioning status: \"Enabled\" or"
+          },
+          {
+            "name": "UploadPart"
+          },
+          {
+            "name": "VersioningStatus"
+          }
+        ]
+      },
+      {
         "name": "RawBucketConfig",
         "doc": "RawBucketConfig is an OPTIONAL capability (discovered by type assertion, like",
         "operations": [

--- a/providers/aws/s3/object_lock_test.go
+++ b/providers/aws/s3/object_lock_test.go
@@ -116,21 +116,46 @@ func TestObjectLockLegalHoldBlocksDelete(t *testing.T) {
 	requireNoError(t, err)
 }
 
+// setObjectLockForTest stamps lock state directly on a stored object and its
+// current version. Real S3 only allows Object Lock on a versioning-enabled
+// (object-lock-enabled) bucket, so this white-box helper is the only way to
+// construct a locked object on an unversioned/suspended bucket — the exact state
+// the in-place-overwrite and top-level-delete WORM guards defend against (e.g.
+// after a snapshot/restore of a crafted state).
+func setObjectLockForTest(t *testing.T, m *Mock, bucket, key string, l objectLock) {
+	t.Helper()
+
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		t.Fatalf("bucket %q not found", bucket)
+	}
+
+	bkt.versionsMu.Lock()
+	defer bkt.versionsMu.Unlock()
+
+	if obj, has := bkt.objects.Get(key); has {
+		obj.lock = l
+	}
+
+	if v := currentVersionLocked(bkt, key); v != nil {
+		v.lock = l
+	}
+}
+
 // TestObjectLockOverwriteBlocked covers overwrite protection: on a bucket where a
-// write replaces the current object's bytes in place (suspended versioning), a
-// protected object cannot be overwritten.
+// write replaces the current object's bytes in place (unversioned), a protected
+// object cannot be overwritten.
 func TestObjectLockOverwriteBlocked(t *testing.T) {
 	m, fc := newLockMock()
 	ctx := context.Background()
 
 	requireNoError(t, m.CreateBucket(ctx, "b"))
-	requireNoError(t, m.SetVersioningStatus(ctx, "b", "Suspended"))
 	requireNoError(t, m.PutObject(ctx, "b", "k", []byte("v1"), "", nil))
 
-	requireNoError(t, m.PutObjectRetention(ctx, "b", "k", "",
-		driver.ObjectRetention{Mode: driver.ObjectLockCompliance, RetainUntilDate: fc.Now().Add(time.Hour)}, false))
+	setObjectLockForTest(t, m, "b", "k",
+		objectLock{retentionMode: driver.ObjectLockCompliance, retainUntil: fc.Now().Add(time.Hour)})
 
-	// Overwriting the protected null version in place is refused.
+	// Overwriting the protected object in place is refused.
 	assertPermissionDenied(t, m.PutObject(ctx, "b", "k", []byte("v2"), "", nil))
 
 	// The original bytes survive.
@@ -141,6 +166,101 @@ func TestObjectLockOverwriteBlocked(t *testing.T) {
 	// After the retention elapses, overwrite is permitted again.
 	fc.Advance(2 * time.Hour)
 	requireNoError(t, m.PutObject(ctx, "b", "k", []byte("v2"), "", nil))
+}
+
+// TestObjectLockTopLevelDeleteBlockedUnversioned covers the WORM guard on a
+// top-level (no versionId) delete of an in-place object: it must not destroy a
+// COMPLIANCE-locked or legal-held object's bytes. (Defense-in-depth — real S3
+// cannot reach this state, so the lock is crafted white-box.)
+func TestObjectLockTopLevelDeleteBlockedUnversioned(t *testing.T) {
+	m, fc := newLockMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateBucket(ctx, "b"))
+
+	// COMPLIANCE retention: top-level delete blocked, even with governance bypass.
+	requireNoError(t, m.PutObject(ctx, "b", "comp", []byte("v1"), "", nil))
+	setObjectLockForTest(t, m, "b", "comp",
+		objectLock{retentionMode: driver.ObjectLockCompliance, retainUntil: fc.Now().Add(time.Hour)})
+
+	assertPermissionDenied(t, m.DeleteObject(ctx, "b", "comp"))
+	_, _, err := m.DeleteObjectVersionWithBypass(ctx, "b", "comp", "", true)
+	assertPermissionDenied(t, err)
+
+	got, err := m.GetObject(ctx, "b", "comp")
+	requireNoError(t, err)
+	assertEqual(t, "v1", string(got.Data))
+
+	// Legal hold: top-level delete blocked, cannot be bypassed.
+	requireNoError(t, m.PutObject(ctx, "b", "lh", []byte("v1"), "", nil))
+	setObjectLockForTest(t, m, "b", "lh", objectLock{legalHold: true})
+
+	assertPermissionDenied(t, m.DeleteObject(ctx, "b", "lh"))
+	_, _, err = m.DeleteObjectVersionWithBypass(ctx, "b", "lh", "", true)
+	assertPermissionDenied(t, err)
+
+	// After the COMPLIANCE retention elapses, the delete is permitted.
+	fc.Advance(2 * time.Hour)
+	requireNoError(t, m.DeleteObject(ctx, "b", "comp"))
+}
+
+// TestObjectLockTopLevelDeleteBlockedSuspended covers the WORM guard on a
+// top-level delete against the versioning-suspended null-version branch.
+func TestObjectLockTopLevelDeleteBlockedSuspended(t *testing.T) {
+	m, fc := newLockMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateBucket(ctx, "b"))
+	requireNoError(t, m.SetVersioningStatus(ctx, "b", "Suspended"))
+	requireNoError(t, m.PutObject(ctx, "b", "k", []byte("v1"), "", nil))
+
+	setObjectLockForTest(t, m, "b", "k",
+		objectLock{retentionMode: driver.ObjectLockCompliance, retainUntil: fc.Now().Add(time.Hour)})
+
+	// Top-level delete would replace the null version with a null delete marker,
+	// destroying the protected bytes — it must be refused.
+	assertPermissionDenied(t, m.DeleteObject(ctx, "b", "k"))
+
+	got, err := m.GetObject(ctx, "b", "k")
+	requireNoError(t, err)
+	assertEqual(t, "v1", string(got.Data))
+}
+
+// TestObjectLockSuspendRejected covers that versioning cannot be suspended on an
+// Object-Lock-enabled bucket.
+func TestObjectLockSuspendRejected(t *testing.T) {
+	m, _ := newLockMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateBucket(ctx, "b"))
+	requireNoError(t, m.EnableObjectLock(ctx, "b"))
+
+	if err := m.SetVersioningStatus(ctx, "b", "Suspended"); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("SetVersioningStatus Suspended = %v, want FailedPrecondition", err)
+	}
+
+	// Re-enabling is fine.
+	requireNoError(t, m.SetVersioningStatus(ctx, "b", "Enabled"))
+}
+
+// TestObjectLockRetentionRequiresLockBucket covers that retention/legal hold can
+// only be set on an Object-Lock-enabled bucket.
+func TestObjectLockRetentionRequiresLockBucket(t *testing.T) {
+	m, fc := newLockMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateBucket(ctx, "plain"))
+	requireNoError(t, m.PutObject(ctx, "plain", "k", []byte("v1"), "", nil))
+
+	err := m.PutObjectRetention(ctx, "plain", "k", "",
+		driver.ObjectRetention{Mode: driver.ObjectLockCompliance, RetainUntilDate: fc.Now().Add(time.Hour)}, false)
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("PutObjectRetention on non-lock bucket = %v, want FailedPrecondition", err)
+	}
+
+	if err := m.PutObjectLegalHold(ctx, "plain", "k", "", true); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("PutObjectLegalHold on non-lock bucket = %v, want FailedPrecondition", err)
+	}
 }
 
 // TestObjectLockEnabledOverwriteMakesNewVersion covers that on an object-lock

--- a/providers/aws/s3/object_lock_test.go
+++ b/providers/aws/s3/object_lock_test.go
@@ -1,0 +1,276 @@
+package s3
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+func newLockMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return New(opts), fc
+}
+
+// currentVersionID returns the version id of key's current object.
+func currentVersionID(t *testing.T, m *Mock, bucket, key string) string {
+	t.Helper()
+
+	obj, err := m.GetObject(context.Background(), bucket, key)
+	requireNoError(t, err)
+
+	return obj.Info.VersionID
+}
+
+func assertPermissionDenied(t *testing.T, err error) {
+	t.Helper()
+
+	if !cerrors.IsPermissionDenied(err) {
+		t.Fatalf("expected PermissionDenied, got %v", err)
+	}
+}
+
+// TestObjectLockComplianceBlocksDelete covers a COMPLIANCE retention: the version
+// cannot be permanently deleted (even with governance bypass) until the retain
+// date elapses, after which the delete succeeds.
+func TestObjectLockComplianceBlocksDelete(t *testing.T) {
+	m, fc := newLockMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateBucket(ctx, "b"))
+	requireNoError(t, m.EnableObjectLock(ctx, "b"))
+	requireNoError(t, m.PutObject(ctx, "b", "k", []byte("v1"), "", nil))
+
+	vid := currentVersionID(t, m, "b", "k")
+	until := fc.Now().Add(time.Hour)
+
+	requireNoError(t, m.PutObjectRetention(ctx, "b", "k", vid,
+		driver.ObjectRetention{Mode: driver.ObjectLockCompliance, RetainUntilDate: until}, false))
+
+	_, _, err := m.DeleteObjectVersion(ctx, "b", "k", vid)
+	assertPermissionDenied(t, err)
+
+	// COMPLIANCE cannot be bypassed by anyone.
+	_, _, err = m.DeleteObjectVersionWithBypass(ctx, "b", "k", vid, true)
+	assertPermissionDenied(t, err)
+
+	// After the retain date, the delete is permitted.
+	fc.Advance(2 * time.Hour)
+
+	_, _, err = m.DeleteObjectVersion(ctx, "b", "k", vid)
+	requireNoError(t, err)
+}
+
+// TestObjectLockGovernanceBypass covers a GOVERNANCE retention: blocked without
+// bypass, permitted with x-amz-bypass-governance-retention.
+func TestObjectLockGovernanceBypass(t *testing.T) {
+	m, fc := newLockMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateBucket(ctx, "b"))
+	requireNoError(t, m.EnableObjectLock(ctx, "b"))
+	requireNoError(t, m.PutObject(ctx, "b", "k", []byte("v1"), "", nil))
+
+	vid := currentVersionID(t, m, "b", "k")
+
+	requireNoError(t, m.PutObjectRetention(ctx, "b", "k", vid,
+		driver.ObjectRetention{Mode: driver.ObjectLockGovernance, RetainUntilDate: fc.Now().Add(time.Hour)}, false))
+
+	_, _, err := m.DeleteObjectVersion(ctx, "b", "k", vid)
+	assertPermissionDenied(t, err)
+
+	_, _, err = m.DeleteObjectVersionWithBypass(ctx, "b", "k", vid, true)
+	requireNoError(t, err)
+}
+
+// TestObjectLockLegalHoldBlocksDelete covers legal hold: it blocks a delete
+// regardless of retention (and cannot be bypassed) until turned OFF.
+func TestObjectLockLegalHoldBlocksDelete(t *testing.T) {
+	m, _ := newLockMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateBucket(ctx, "b"))
+	requireNoError(t, m.EnableObjectLock(ctx, "b"))
+	requireNoError(t, m.PutObject(ctx, "b", "k", []byte("v1"), "", nil))
+
+	vid := currentVersionID(t, m, "b", "k")
+
+	requireNoError(t, m.PutObjectLegalHold(ctx, "b", "k", vid, true))
+
+	on, err := m.GetObjectLegalHold(ctx, "b", "k", vid)
+	requireNoError(t, err)
+	assertEqual(t, true, on)
+
+	// No retention set, yet the delete is blocked by legal hold — even with bypass.
+	_, _, err = m.DeleteObjectVersionWithBypass(ctx, "b", "k", vid, true)
+	assertPermissionDenied(t, err)
+
+	requireNoError(t, m.PutObjectLegalHold(ctx, "b", "k", vid, false))
+
+	_, _, err = m.DeleteObjectVersion(ctx, "b", "k", vid)
+	requireNoError(t, err)
+}
+
+// TestObjectLockOverwriteBlocked covers overwrite protection: on a bucket where a
+// write replaces the current object's bytes in place (suspended versioning), a
+// protected object cannot be overwritten.
+func TestObjectLockOverwriteBlocked(t *testing.T) {
+	m, fc := newLockMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateBucket(ctx, "b"))
+	requireNoError(t, m.SetVersioningStatus(ctx, "b", "Suspended"))
+	requireNoError(t, m.PutObject(ctx, "b", "k", []byte("v1"), "", nil))
+
+	requireNoError(t, m.PutObjectRetention(ctx, "b", "k", "",
+		driver.ObjectRetention{Mode: driver.ObjectLockCompliance, RetainUntilDate: fc.Now().Add(time.Hour)}, false))
+
+	// Overwriting the protected null version in place is refused.
+	assertPermissionDenied(t, m.PutObject(ctx, "b", "k", []byte("v2"), "", nil))
+
+	// The original bytes survive.
+	obj, err := m.GetObject(ctx, "b", "k")
+	requireNoError(t, err)
+	assertEqual(t, "v1", string(obj.Data))
+
+	// After the retention elapses, overwrite is permitted again.
+	fc.Advance(2 * time.Hour)
+	requireNoError(t, m.PutObject(ctx, "b", "k", []byte("v2"), "", nil))
+}
+
+// TestObjectLockEnabledOverwriteMakesNewVersion covers that on an object-lock
+// (versioning-enabled) bucket a PUT is a fresh version and never destroys the
+// protected version's bytes, so it is always allowed.
+func TestObjectLockEnabledOverwriteMakesNewVersion(t *testing.T) {
+	m, fc := newLockMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateBucket(ctx, "b"))
+	requireNoError(t, m.EnableObjectLock(ctx, "b"))
+	requireNoError(t, m.PutObject(ctx, "b", "k", []byte("v1"), "", nil))
+
+	v1 := currentVersionID(t, m, "b", "k")
+	requireNoError(t, m.PutObjectRetention(ctx, "b", "k", v1,
+		driver.ObjectRetention{Mode: driver.ObjectLockCompliance, RetainUntilDate: fc.Now().Add(time.Hour)}, false))
+
+	// A new PUT succeeds (new version); the locked v1 is preserved.
+	requireNoError(t, m.PutObject(ctx, "b", "k", []byte("v2"), "", nil))
+
+	vl, err := m.ListObjectVersions(ctx, "b", driver.ListOptions{})
+	requireNoError(t, err)
+	assertEqual(t, 2, len(vl.Versions))
+
+	// The locked v1 still cannot be deleted.
+	_, _, err = m.DeleteObjectVersion(ctx, "b", "k", v1)
+	assertPermissionDenied(t, err)
+}
+
+// TestObjectLockTopLevelDeleteMarker covers that a top-level delete (no version
+// id) records a delete marker and leaves the protected version intact.
+func TestObjectLockTopLevelDeleteMarker(t *testing.T) {
+	m, fc := newLockMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateBucket(ctx, "b"))
+	requireNoError(t, m.EnableObjectLock(ctx, "b"))
+	requireNoError(t, m.PutObject(ctx, "b", "k", []byte("v1"), "", nil))
+
+	v1 := currentVersionID(t, m, "b", "k")
+	requireNoError(t, m.PutObjectRetention(ctx, "b", "k", v1,
+		driver.ObjectRetention{Mode: driver.ObjectLockCompliance, RetainUntilDate: fc.Now().Add(time.Hour)}, false))
+
+	vid, marker, err := m.DeleteObjectVersion(ctx, "b", "k", "")
+	requireNoError(t, err)
+	assertEqual(t, true, marker)
+	if vid == "" {
+		t.Fatal("expected a delete-marker version id")
+	}
+
+	// The protected version is still present in the history.
+	if findVersion := (func() bool {
+		vl, lErr := m.ListObjectVersions(ctx, "b", driver.ListOptions{})
+		requireNoError(t, lErr)
+		for _, v := range vl.Versions {
+			if v.VersionID == v1 {
+				return true
+			}
+		}
+		return false
+	})(); !findVersion {
+		t.Fatal("protected version was removed by a top-level delete")
+	}
+}
+
+// TestObjectLockRetentionModificationRules covers the retention change rules:
+// COMPLIANCE can only be extended; GOVERNANCE can be shortened only with bypass.
+func TestObjectLockRetentionModificationRules(t *testing.T) {
+	m, fc := newLockMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateBucket(ctx, "b"))
+	requireNoError(t, m.EnableObjectLock(ctx, "b"))
+
+	requireNoError(t, m.PutObject(ctx, "b", "comp", []byte("v"), "", nil))
+	compVID := currentVersionID(t, m, "b", "comp")
+	base := fc.Now().Add(time.Hour)
+	requireNoError(t, m.PutObjectRetention(ctx, "b", "comp", compVID,
+		driver.ObjectRetention{Mode: driver.ObjectLockCompliance, RetainUntilDate: base}, false))
+
+	// Extending COMPLIANCE is allowed.
+	requireNoError(t, m.PutObjectRetention(ctx, "b", "comp", compVID,
+		driver.ObjectRetention{Mode: driver.ObjectLockCompliance, RetainUntilDate: base.Add(time.Hour)}, false))
+
+	// Shortening COMPLIANCE is refused, even with bypass.
+	assertPermissionDenied(t, m.PutObjectRetention(ctx, "b", "comp", compVID,
+		driver.ObjectRetention{Mode: driver.ObjectLockCompliance, RetainUntilDate: base}, true))
+
+	requireNoError(t, m.PutObject(ctx, "b", "gov", []byte("v"), "", nil))
+	govVID := currentVersionID(t, m, "b", "gov")
+	requireNoError(t, m.PutObjectRetention(ctx, "b", "gov", govVID,
+		driver.ObjectRetention{Mode: driver.ObjectLockGovernance, RetainUntilDate: base.Add(time.Hour)}, false))
+
+	// Shortening GOVERNANCE without bypass is refused; with bypass it succeeds.
+	assertPermissionDenied(t, m.PutObjectRetention(ctx, "b", "gov", govVID,
+		driver.ObjectRetention{Mode: driver.ObjectLockGovernance, RetainUntilDate: base}, false))
+	requireNoError(t, m.PutObjectRetention(ctx, "b", "gov", govVID,
+		driver.ObjectRetention{Mode: driver.ObjectLockGovernance, RetainUntilDate: base}, true))
+}
+
+// TestObjectLockRetentionSnapshotRoundTrip covers that retention/legal-hold
+// survive a Snapshot/Restore cycle.
+func TestObjectLockRetentionSnapshotRoundTrip(t *testing.T) {
+	m, fc := newLockMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateBucket(ctx, "b"))
+	requireNoError(t, m.EnableObjectLock(ctx, "b"))
+	requireNoError(t, m.PutObject(ctx, "b", "k", []byte("v1"), "", nil))
+
+	vid := currentVersionID(t, m, "b", "k")
+	until := fc.Now().Add(time.Hour)
+	requireNoError(t, m.PutObjectRetention(ctx, "b", "k", vid,
+		driver.ObjectRetention{Mode: driver.ObjectLockCompliance, RetainUntilDate: until}, false))
+
+	snap, err := m.Snapshot(ctx, true)
+	requireNoError(t, err)
+
+	restored, _ := newLockMock()
+	requireNoError(t, restored.Restore(ctx, snap))
+
+	enabled, err := restored.ObjectLockEnabled(ctx, "b")
+	requireNoError(t, err)
+	assertEqual(t, true, enabled)
+
+	ret, err := restored.GetObjectRetention(ctx, "b", "k", vid)
+	requireNoError(t, err)
+	assertEqual(t, driver.ObjectLockCompliance, ret.Mode)
+
+	// The restored version is still protected.
+	_, _, err = restored.DeleteObjectVersion(ctx, "b", "k", vid)
+	assertPermissionDenied(t, err)
+}

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -603,6 +603,13 @@ func objectLockDeniedError() error {
 		"Access Denied because object protected by object lock.")
 }
 
+// objectLockMissingError is returned by a retention/legal-hold write on a bucket
+// that was not created with Object Lock enabled; the wire layer renders it as
+// 400 InvalidRequest.
+func objectLockMissingError() error {
+	return cerrors.New(cerrors.FailedPrecondition, "Bucket is missing Object Lock Configuration")
+}
+
 // evalPutPrecondition reports whether a conditional PutObject may proceed. It
 // runs under versionsMu, reading the current object (a delete marker leaves no
 // current object, so the key reads as absent). If-None-Match: "*" requires the
@@ -715,8 +722,12 @@ func (m *Mock) DeleteObject(ctx context.Context, bucket, key string) error {
 	}
 
 	bkt.versionsMu.Lock()
-	vid, deleteMarker, existed := m.deleteTopLevelLocked(bkt, key)
+	vid, deleteMarker, existed, err := m.deleteTopLevelLocked(bkt, key, false)
 	bkt.versionsMu.Unlock()
+
+	if err != nil {
+		return err
+	}
 
 	// On an unversioned bucket, deleting a missing key is NotFound (the wire
 	// handler maps that to an idempotent 204). A versioned bucket always records
@@ -745,12 +756,18 @@ func (m *Mock) DeleteObject(ctx context.Context, bucket, key string) error {
 }
 
 // deleteTopLevelLocked applies a top-level (no versionId) delete. On Enabled it
-// appends a delete marker; on Suspended it overwrites the null version with a
-// null delete marker; unversioned removes the current object. Returns the
-// affected version id, whether a delete marker was created, and whether
-// anything existed to delete (always true when a marker is recorded). Callers
-// hold versionsMu.
-func (m *Mock) deleteTopLevelLocked(bkt *bucketMeta, key string) (versionID string, deleteMarker, existed bool) {
+// appends a delete marker (leaving every existing version — including protected
+// ones — intact, so no lock check applies); on Suspended it overwrites the null
+// version with a null delete marker; unversioned removes the current object.
+// The Suspended and unversioned branches DESTROY the current object's bytes, so
+// they honor Object Lock: a protected current object cannot be removed (bypass
+// lifts only a GOVERNANCE retention). Returns the affected version id, whether a
+// delete marker was created, whether anything existed to delete (always true
+// when a marker is recorded), and an Object-Lock denial error. Callers hold
+// versionsMu.
+func (m *Mock) deleteTopLevelLocked(
+	bkt *bucketMeta, key string, bypassGovernance bool,
+) (versionID string, deleteMarker, existed bool, err error) {
 	now := m.opts.Clock.Now().UTC().Format(s3TimeFormat)
 
 	switch bkt.versionStatus {
@@ -758,18 +775,46 @@ func (m *Mock) deleteTopLevelLocked(bkt *bucketMeta, key string) (versionID stri
 		vid := newVersionID()
 		bkt.appendVersion(key, &s3Version{versionID: vid, deleteMarker: true, lastModified: now})
 		bkt.objects.Delete(key)
-		return vid, true, true
+
+		return vid, true, true, nil
 	case versioningSuspended:
+		if err := m.checkTopLevelDeleteLocked(bkt, key, bypassGovernance); err != nil {
+			return "", false, false, err
+		}
+
 		bkt.replaceNullVersion(key, &s3Version{versionID: nullVersionID, deleteMarker: true, lastModified: now})
 		bkt.objects.Delete(key)
-		return nullVersionID, true, true
+
+		return nullVersionID, true, true, nil
 	default:
 		if !bkt.objects.Has(key) {
-			return "", false, false
+			return "", false, false, nil
 		}
+
+		if err := m.checkTopLevelDeleteLocked(bkt, key, bypassGovernance); err != nil {
+			return "", false, false, err
+		}
+
 		bkt.objects.Delete(key)
-		return "", false, true
+
+		return "", false, true, nil
 	}
+}
+
+// checkTopLevelDeleteLocked refuses a top-level delete that would destroy a
+// protected current object's bytes (Suspended null version / unversioned
+// object). Callers hold versionsMu.
+func (m *Mock) checkTopLevelDeleteLocked(bkt *bucketMeta, key string, bypassGovernance bool) error {
+	cur, ok := bkt.objects.Get(key)
+	if !ok {
+		return nil
+	}
+
+	if cur.lock.blocksDelete(m.opts.Clock.Now(), bypassGovernance) {
+		return objectLockDeniedError()
+	}
+
+	return nil
 }
 
 func (m *Mock) HeadObject(_ context.Context, bucket, key string) (*driver.ObjectInfo, error) {
@@ -1433,26 +1478,10 @@ func (m *Mock) CompleteMultipartUpload(ctx context.Context, bucket, key, uploadI
 		return cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
 	}
 
-	mp.mu.Lock()
-	for _, p := range parts {
-		stored, exists := mp.parts[p.PartNumber]
-		if !exists {
-			mp.mu.Unlock()
-			return cerrors.Newf(cerrors.InvalidArgument, "part %d not found in upload %q", p.PartNumber, uploadID)
-		}
-
-		// Real S3 validates each supplied part ETag against the stored part and
-		// rejects a mismatch with InvalidPart. An empty client ETag skips the
-		// check (some callers omit it); a non-empty one must match the stored
-		// part's MD5, case-insensitively.
-		if p.ETag != "" && !strings.EqualFold(strings.Trim(p.ETag, `"`), md5Hex(stored)) {
-			mp.mu.Unlock()
-			return cerrors.Newf(cerrors.InvalidArgument, "part %d ETag does not match the uploaded part in upload %q", p.PartNumber, uploadID)
-		}
+	ordered, err := validateAndOrderParts(mp, parts, uploadID)
+	if err != nil {
+		return err
 	}
-
-	ordered := orderedPartData(mp.parts, parts)
-	mp.mu.Unlock()
 
 	var data []byte
 	for _, p := range ordered {
@@ -1496,6 +1525,33 @@ func (m *Mock) CompleteMultipartUpload(ctx context.Context, bucket, key, uploadI
 	m.notifyObjectCreated(ctx, bkt, bucket, key, int64(len(data)), obj.ETag, obj.VersionID)
 
 	return nil
+}
+
+// validateAndOrderParts checks every requested part exists and (when the caller
+// supplied an ETag) matches the stored part, then returns the parts' bytes in
+// ascending PartNumber order. It holds mp.mu for the duration so a concurrent
+// UploadPart cannot race the validation.
+func validateAndOrderParts(mp *multipartUpload, parts []driver.UploadPart, uploadID string) ([][]byte, error) {
+	mp.mu.Lock()
+	defer mp.mu.Unlock()
+
+	for _, p := range parts {
+		stored, exists := mp.parts[p.PartNumber]
+		if !exists {
+			return nil, cerrors.Newf(cerrors.InvalidArgument, "part %d not found in upload %q", p.PartNumber, uploadID)
+		}
+
+		// Real S3 validates each supplied part ETag against the stored part and
+		// rejects a mismatch with InvalidPart. An empty client ETag skips the
+		// check (some callers omit it); a non-empty one must match the stored
+		// part's MD5, case-insensitively.
+		if p.ETag != "" && !strings.EqualFold(strings.Trim(p.ETag, `"`), md5Hex(stored)) {
+			return nil, cerrors.Newf(cerrors.InvalidArgument,
+				"part %d ETag does not match the uploaded part in upload %q", p.PartNumber, uploadID)
+		}
+	}
+
+	return orderedPartData(mp.parts, parts), nil
 }
 
 // orderedPartData returns each requested part's bytes in ascending PartNumber
@@ -1588,8 +1644,16 @@ func (m *Mock) SetVersioningStatus(_ context.Context, bucket, status string) err
 	}
 
 	bkt.versionsMu.Lock()
+	defer bkt.versionsMu.Unlock()
+
+	// Object Lock requires versioning to stay Enabled; real S3 rejects a suspend
+	// on a lock-enabled bucket with InvalidBucketState.
+	if bkt.objectLockEnabled && status == versioningSuspended {
+		return cerrors.New(cerrors.FailedPrecondition,
+			"An Object Lock configuration is present on this bucket, so the versioning state cannot be changed.")
+	}
+
 	bkt.versionStatus = status
-	bkt.versionsMu.Unlock()
 
 	return nil
 }
@@ -1700,7 +1764,11 @@ func (m *Mock) deleteObjectVersion(
 	defer bkt.versionsMu.Unlock()
 
 	if versionID == "" {
-		vid, marker, existed := m.deleteTopLevelLocked(bkt, key)
+		vid, marker, existed, err := m.deleteTopLevelLocked(bkt, key, bypassGovernance)
+		if err != nil {
+			return "", false, err
+		}
+
 		if !existed {
 			// Unversioned bucket, key never existed: a no-op idempotent delete,
 			// matching real S3 — nothing was removed, so no event fires.
@@ -1857,6 +1925,10 @@ func (m *Mock) PutObjectRetention(
 	bkt.versionsMu.Lock()
 	defer bkt.versionsMu.Unlock()
 
+	if !bkt.objectLockEnabled {
+		return objectLockMissingError()
+	}
+
 	lock, inHistory, err := lockTargetLocked(bkt, key, versionID)
 	if err != nil {
 		return err
@@ -1921,6 +1993,10 @@ func (m *Mock) PutObjectLegalHold(_ context.Context, bucket, key, versionID stri
 
 	bkt.versionsMu.Lock()
 	defer bkt.versionsMu.Unlock()
+
+	if !bkt.objectLockEnabled {
+		return objectLockMissingError()
+	}
 
 	lock, inHistory, err := lockTargetLocked(bkt, key, versionID)
 	if err != nil {

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -39,7 +39,47 @@ var (
 	_ driver.ObjectCopier      = (*Mock)(nil)
 	_ driver.RegionalBucket    = (*Mock)(nil)
 	_ driver.SystemPropsBucket = (*Mock)(nil)
+	_ driver.ObjectLockBucket  = (*Mock)(nil)
 )
+
+// objectLock is the S3 Object Lock state carried by a single object version: a
+// retention mode (GOVERNANCE/COMPLIANCE, empty when none) with its RetainUntil
+// instant, and an independent legal-hold flag. The zero value is unprotected.
+type objectLock struct {
+	retentionMode string
+	retainUntil   time.Time
+	legalHold     bool
+}
+
+// protectsOverwrite reports whether the version's lock forbids destroying its
+// bytes in place (a suspended/unversioned overwrite or a permanent delete before
+// bypass is considered): legal hold ON, or a retention period not yet elapsed.
+func (l objectLock) protectsOverwrite(now time.Time) bool {
+	if l.legalHold {
+		return true
+	}
+
+	return l.retentionMode != "" && now.Before(l.retainUntil)
+}
+
+// blocksDelete reports whether the version's lock forbids a permanent delete.
+// Legal hold and an active COMPLIANCE retention always block; an active
+// GOVERNANCE retention blocks unless bypassGovernance is set.
+func (l objectLock) blocksDelete(now time.Time, bypassGovernance bool) bool {
+	if l.legalHold {
+		return true
+	}
+
+	if l.retentionMode == "" || !now.Before(l.retainUntil) {
+		return false
+	}
+
+	if l.retentionMode == driver.ObjectLockGovernance && bypassGovernance {
+		return false
+	}
+
+	return true
+}
 
 type s3Object struct {
 	Key string
@@ -60,6 +100,9 @@ type s3Object struct {
 	// Content-Encoding, Content-Disposition, Content-Language, Expires) and the
 	// object's storage class, recorded on PutObject and echoed back on read.
 	SystemProps driver.ObjectSystemProps
+	// lock is the object's S3 Object Lock state (retention + legal hold) for the
+	// current version; mirrors the latest version's lock on a versioned bucket.
+	lock objectLock
 }
 
 // s3Version is one entry in a key's version history (a stored object or a
@@ -74,6 +117,8 @@ type s3Version struct {
 	metadata     map[string]string
 	deleteMarker bool
 	storageClass string
+	// lock is the version's S3 Object Lock state (retention + legal hold).
+	lock objectLock
 }
 
 type multipartUpload struct {
@@ -97,6 +142,10 @@ type bucketMeta struct {
 	objects    *memstore.Store[*s3Object]
 	lifecycle  *driver.LifecycleConfig
 	multiparts *memstore.Store[*multipartUpload]
+	// objectLockEnabled records whether the bucket was created with S3 Object
+	// Lock enabled (x-amz-bucket-object-lock-enabled), which also forces
+	// versioning on. Guarded by versionsMu (set alongside versionStatus).
+	objectLockEnabled bool
 	// versionStatus is "" (never configured), "Enabled", or "Suspended".
 	// versionsMu guards versionStatus and the versions history map; versions
 	// maps a key to its ordered (oldest-first) version chain.
@@ -377,7 +426,9 @@ func (m *Mock) PutObjectWithSystemProps(
 		obj.SystemProps = *props
 	}
 
-	m.storeObject(bkt, key, obj)
+	if err := m.storeObject(bkt, key, obj); err != nil {
+		return err
+	}
 
 	return m.afterPut(ctx, bkt, bucket, key, obj, data, contentType, metadata)
 }
@@ -472,11 +523,11 @@ func newVersionID() string { return idgen.GenerateID("") }
 
 // storeObject records key's current object under versionsMu (see
 // storeObjectLocked for the versioning behavior).
-func (m *Mock) storeObject(bkt *bucketMeta, key string, obj *s3Object) {
+func (m *Mock) storeObject(bkt *bucketMeta, key string, obj *s3Object) error {
 	bkt.versionsMu.Lock()
 	defer bkt.versionsMu.Unlock()
 
-	m.storeObjectLocked(bkt, key, obj)
+	return m.storeObjectLocked(bkt, key, obj)
 }
 
 // storeObjectConditional evaluates an If-None-Match / If-Match precondition
@@ -490,16 +541,20 @@ func (m *Mock) storeObjectConditional(bkt *bucketMeta, key string, obj *s3Object
 		return err
 	}
 
-	m.storeObjectLocked(bkt, key, obj)
-
-	return nil
+	return m.storeObjectLocked(bkt, key, obj)
 }
 
 // storeObjectLocked records key's current object; the caller must hold
 // versionsMu. On a versioned bucket it also appends/overwrites the version
 // history (stamping obj.VersionID). Enabled appends a fresh version; Suspended
 // overwrites the reusable "null" version; an unversioned bucket keeps no history.
-func (m *Mock) storeObjectLocked(bkt *bucketMeta, key string, obj *s3Object) {
+//
+// Object Lock: on a Suspended/unversioned bucket a write replaces the current
+// object's bytes in place, so if that object is protected (legal hold or an
+// unexpired retention) the overwrite is refused. On an Enabled bucket every
+// write is a fresh version and the protected version is preserved, so no check
+// is needed.
+func (m *Mock) storeObjectLocked(bkt *bucketMeta, key string, obj *s3Object) error {
 	// When an engine holds the bytes, the version record keeps only metadata +
 	// size; its bytes live in the engine under the version id (dropData).
 	dropData := m.opts.StorageEngine != nil
@@ -509,11 +564,43 @@ func (m *Mock) storeObjectLocked(bkt *bucketMeta, key string, obj *s3Object) {
 		obj.VersionID = newVersionID()
 		bkt.appendVersion(key, versionFromObject(obj, dropData))
 	case versioningSuspended:
+		if err := m.checkOverwriteLocked(bkt, key); err != nil {
+			return err
+		}
+
 		obj.VersionID = nullVersionID
 		bkt.replaceNullVersion(key, versionFromObject(obj, dropData))
+	default:
+		if err := m.checkOverwriteLocked(bkt, key); err != nil {
+			return err
+		}
 	}
 
 	bkt.objects.Set(key, obj)
+
+	return nil
+}
+
+// checkOverwriteLocked refuses an in-place overwrite that would destroy a
+// protected current object's bytes. Callers hold versionsMu.
+func (m *Mock) checkOverwriteLocked(bkt *bucketMeta, key string) error {
+	cur, ok := bkt.objects.Get(key)
+	if !ok {
+		return nil
+	}
+
+	if cur.lock.protectsOverwrite(m.opts.Clock.Now()) {
+		return objectLockDeniedError()
+	}
+
+	return nil
+}
+
+// objectLockDeniedError is the error a protected-object delete/overwrite returns;
+// the S3 wire layer renders it as 403 AccessDenied.
+func objectLockDeniedError() error {
+	return cerrors.New(cerrors.PermissionDenied,
+		"Access Denied because object protected by object lock.")
 }
 
 // evalPutPrecondition reports whether a conditional PutObject may proceed. It
@@ -561,6 +648,7 @@ func versionFromObject(obj *s3Object, dropData bool) *s3Version {
 		lastModified: obj.LastModified,
 		metadata:     obj.Metadata,
 		storageClass: obj.SystemProps.StorageClass,
+		lock:         obj.lock,
 	}
 }
 
@@ -879,7 +967,10 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 		ETag: srcObj.ETag, LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
 		Metadata: meta, Tags: maps.Clone(srcObj.Tags), SystemProps: srcObj.SystemProps,
 	}
-	m.storeObject(dstBkt, dstKey, dstObj)
+
+	if err := m.storeObject(dstBkt, dstKey, dstObj); err != nil {
+		return err
+	}
 
 	if m.opts.StorageEngine != nil {
 		if err := storageengine.Copy(ctx, m.opts.StorageEngine,
@@ -973,7 +1064,10 @@ func (m *Mock) CopyObjectV2(ctx context.Context, req *driver.CopyObjectRequest) 
 		ETag: src.etag, LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
 		Metadata: maps.Clone(metadata), Tags: maps.Clone(tags), SystemProps: copyDstSystemProps(req, src),
 	}
-	m.storeObject(dstBkt, req.DstKey, dstObj)
+
+	if err := m.storeObject(dstBkt, req.DstKey, dstObj); err != nil {
+		return nil, err
+	}
 
 	if err := m.engineStore(ctx, req.DstBucket, req.DstKey, dstObj.VersionID, contentType, dataCopy, metadata); err != nil {
 		return nil, err
@@ -1377,7 +1471,10 @@ func (m *Mock) CompleteMultipartUpload(ctx context.Context, bucket, key, uploadI
 		Metadata:     make(map[string]string),
 		Tags:         maps.Clone(mp.tags),
 	}
-	m.storeObject(bkt, key, obj)
+
+	if err := m.storeObject(bkt, key, obj); err != nil {
+		return err
+	}
 
 	// Only the assembled object goes to the engine; the individual parts stay in
 	// memory until the upload completes.
@@ -1575,8 +1672,25 @@ func (m *Mock) HeadObjectVersion(ctx context.Context, bucket, key, versionID str
 
 // DeleteObjectVersion removes a specific version, or (versionID == "") performs
 // a top-level delete (delete marker on Enabled). Returns the affected version
-// id and whether it was/created a delete marker.
+// id and whether it was/created a delete marker. Object Lock protection is
+// enforced: a protected version cannot be permanently removed (a top-level
+// delete still records a delete marker, leaving protected versions intact).
 func (m *Mock) DeleteObjectVersion(ctx context.Context, bucket, key, versionID string) (deletedID string, deleteMarker bool, err error) {
+	return m.deleteObjectVersion(ctx, bucket, key, versionID, false)
+}
+
+// DeleteObjectVersionWithBypass implements driver.ObjectLockBucket: like
+// DeleteObjectVersion, but bypassGovernance lifts a GOVERNANCE retention block
+// (never COMPLIANCE, never a legal hold).
+func (m *Mock) DeleteObjectVersionWithBypass(
+	ctx context.Context, bucket, key, versionID string, bypassGovernance bool,
+) (deletedID string, deleteMarker bool, err error) {
+	return m.deleteObjectVersion(ctx, bucket, key, versionID, bypassGovernance)
+}
+
+func (m *Mock) deleteObjectVersion(
+	ctx context.Context, bucket, key, versionID string, bypassGovernance bool,
+) (deletedID string, deleteMarker bool, err error) {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
 		return "", false, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
@@ -1616,6 +1730,11 @@ func (m *Mock) DeleteObjectVersion(ctx context.Context, bucket, key, versionID s
 		return "", false, cerrors.Newf(cerrors.NotFound, "version %q of %q not found", versionID, key)
 	}
 
+	// Object Lock: a protected version cannot be permanently removed.
+	if removed.lock.blocksDelete(m.opts.Clock.Now(), bypassGovernance) {
+		return "", false, objectLockDeniedError()
+	}
+
 	bkt.versions[key] = append(chain[:idx], chain[idx+1:]...)
 	if len(bkt.versions[key]) == 0 {
 		delete(bkt.versions, key)
@@ -1631,6 +1750,190 @@ func (m *Mock) DeleteObjectVersion(ctx context.Context, bucket, key, versionID s
 	m.notifyObjectRemoved(ctx, bkt, bucket, key, versionID, false)
 
 	return versionID, removed.deleteMarker, nil
+}
+
+// ObjectLockEnabled implements driver.ObjectLockBucket: reports whether the
+// bucket was created with Object Lock enabled.
+func (m *Mock) ObjectLockEnabled(_ context.Context, bucket string) (bool, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return false, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.versionsMu.Lock()
+	defer bkt.versionsMu.Unlock()
+
+	return bkt.objectLockEnabled, nil
+}
+
+// EnableObjectLock implements driver.ObjectLockBucket: marks the bucket
+// Object-Lock-enabled and turns versioning on (Object Lock requires it).
+func (m *Mock) EnableObjectLock(_ context.Context, bucket string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.versionsMu.Lock()
+	defer bkt.versionsMu.Unlock()
+
+	bkt.objectLockEnabled = true
+	bkt.versionStatus = versioningEnabled
+
+	return nil
+}
+
+// currentVersionLocked returns key's current (latest non-delete-marker) version,
+// or nil when the newest version is a delete marker or no history exists.
+// Callers hold versionsMu.
+func currentVersionLocked(bkt *bucketMeta, key string) *s3Version {
+	chain := bkt.versions[key]
+	if len(chain) == 0 {
+		return nil
+	}
+
+	latest := chain[len(chain)-1]
+	if latest.deleteMarker {
+		return nil
+	}
+
+	return latest
+}
+
+// lockTargetLocked resolves the lock state of the version a retention/legal-hold
+// op addresses (the current version when versionID==""), returning a pointer to
+// mutate and whether the target lives in the version history (so the caller can
+// refresh the current object). Callers hold versionsMu.
+func lockTargetLocked(bkt *bucketMeta, key, versionID string) (lock *objectLock, inHistory bool, err error) {
+	if versionID != "" {
+		if v := findVersion(bkt, key, versionID); v != nil && !v.deleteMarker {
+			return &v.lock, true, nil
+		}
+
+		return nil, false, cerrors.Newf(cerrors.NotFound, "version %q of %q not found", versionID, key)
+	}
+
+	if v := currentVersionLocked(bkt, key); v != nil {
+		return &v.lock, true, nil
+	}
+
+	if obj, ok := bkt.objects.Get(key); ok {
+		return &obj.lock, false, nil
+	}
+
+	return nil, false, cerrors.Newf(cerrors.NotFound, "object %q not found in bucket %q", key, bkt.Name)
+}
+
+// GetObjectRetention implements driver.ObjectLockBucket.
+func (m *Mock) GetObjectRetention(_ context.Context, bucket, key, versionID string) (driver.ObjectRetention, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return driver.ObjectRetention{}, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.versionsMu.Lock()
+	defer bkt.versionsMu.Unlock()
+
+	lock, _, err := lockTargetLocked(bkt, key, versionID)
+	if err != nil {
+		return driver.ObjectRetention{}, err
+	}
+
+	return driver.ObjectRetention{Mode: lock.retentionMode, RetainUntilDate: lock.retainUntil}, nil
+}
+
+// PutObjectRetention implements driver.ObjectLockBucket. First-setting or
+// extending a retention is always allowed; shortening, removing, or downgrading
+// an active GOVERNANCE retention requires bypassGovernance, and an active
+// COMPLIANCE retention can never be shortened, removed, or downgraded.
+func (m *Mock) PutObjectRetention(
+	_ context.Context, bucket, key, versionID string, ret driver.ObjectRetention, bypassGovernance bool,
+) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.versionsMu.Lock()
+	defer bkt.versionsMu.Unlock()
+
+	lock, inHistory, err := lockTargetLocked(bkt, key, versionID)
+	if err != nil {
+		return err
+	}
+
+	existing := driver.ObjectRetention{Mode: lock.retentionMode, RetainUntilDate: lock.retainUntil}
+	if !retentionChangeAllowed(existing, ret, m.opts.Clock.Now(), bypassGovernance) {
+		return objectLockDeniedError()
+	}
+
+	lock.retentionMode = ret.Mode
+	lock.retainUntil = ret.RetainUntilDate
+
+	if inHistory {
+		m.recomputeCurrentLocked(bkt, key)
+	}
+
+	return nil
+}
+
+// retentionChangeAllowed applies the S3 Object Lock retention-modification rules.
+func retentionChangeAllowed(existing, next driver.ObjectRetention, now time.Time, bypassGovernance bool) bool {
+	// No active retention (unset or already elapsed): any change is allowed.
+	if existing.Mode == "" || !now.Before(existing.RetainUntilDate) {
+		return true
+	}
+
+	// Extending in the same mode is always allowed.
+	if next.Mode == existing.Mode && !next.RetainUntilDate.Before(existing.RetainUntilDate) {
+		return true
+	}
+
+	// Any shorten/remove/downgrade of an active retention: COMPLIANCE never,
+	// GOVERNANCE only with bypass.
+	return existing.Mode == driver.ObjectLockGovernance && bypassGovernance
+}
+
+// GetObjectLegalHold implements driver.ObjectLockBucket.
+func (m *Mock) GetObjectLegalHold(_ context.Context, bucket, key, versionID string) (bool, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return false, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.versionsMu.Lock()
+	defer bkt.versionsMu.Unlock()
+
+	lock, _, err := lockTargetLocked(bkt, key, versionID)
+	if err != nil {
+		return false, err
+	}
+
+	return lock.legalHold, nil
+}
+
+// PutObjectLegalHold implements driver.ObjectLockBucket.
+func (m *Mock) PutObjectLegalHold(_ context.Context, bucket, key, versionID string, on bool) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.versionsMu.Lock()
+	defer bkt.versionsMu.Unlock()
+
+	lock, inHistory, err := lockTargetLocked(bkt, key, versionID)
+	if err != nil {
+		return err
+	}
+
+	lock.legalHold = on
+
+	if inHistory {
+		m.recomputeCurrentLocked(bkt, key)
+	}
+
+	return nil
 }
 
 // ListObjectVersions returns the full version history matching opts, newest
@@ -1745,7 +2048,7 @@ func objectFromVersion(key string, v *s3Version) *s3Object {
 	return &s3Object{
 		Key: key, Data: v.data, Size: v.size, ContentType: v.contentType,
 		ETag: v.etag, LastModified: v.lastModified, Metadata: maps.Clone(v.metadata),
-		VersionID: v.versionID,
+		VersionID: v.versionID, lock: v.lock,
 	}
 }
 

--- a/providers/aws/s3/snapshot.go
+++ b/providers/aws/s3/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/internal/snapshot"
@@ -28,6 +29,7 @@ type bucketSnapshot struct {
 	Region        string                        `json:"region,omitempty"`
 	CreatedAt     string                        `json:"createdAt,omitempty"`
 	VersionStatus string                        `json:"versionStatus,omitempty"`
+	ObjectLock    bool                          `json:"objectLock,omitempty"`
 	Tags          map[string]string             `json:"tags,omitempty"`
 	Lifecycle     *driver.LifecycleConfig       `json:"lifecycle,omitempty"`
 	Policy        *driver.BucketPolicy          `json:"policy,omitempty"`
@@ -52,6 +54,46 @@ type objectSnapshot struct {
 	Metadata     map[string]string `json:"metadata,omitempty"`
 	Tags         map[string]string `json:"tags,omitempty"`
 	VersionID    string            `json:"versionId,omitempty"`
+	Lock         *lockSnapshot     `json:"lock,omitempty"`
+}
+
+// lockSnapshot serializes an object version's S3 Object Lock state.
+type lockSnapshot struct {
+	RetentionMode string `json:"retentionMode,omitempty"`
+	RetainUntil   string `json:"retainUntil,omitempty"`
+	LegalHold     bool   `json:"legalHold,omitempty"`
+}
+
+// lockToSnapshot serializes an objectLock, returning nil when it is unset so
+// unprotected objects add nothing to the snapshot.
+func lockToSnapshot(l objectLock) *lockSnapshot {
+	if l.retentionMode == "" && l.retainUntil.IsZero() && !l.legalHold {
+		return nil
+	}
+
+	ls := &lockSnapshot{RetentionMode: l.retentionMode, LegalHold: l.legalHold}
+	if !l.retainUntil.IsZero() {
+		ls.RetainUntil = l.retainUntil.UTC().Format(time.RFC3339Nano)
+	}
+
+	return ls
+}
+
+// lockFromSnapshot rebuilds an objectLock from its serialized form.
+func lockFromSnapshot(ls *lockSnapshot) objectLock {
+	if ls == nil {
+		return objectLock{}
+	}
+
+	l := objectLock{retentionMode: ls.RetentionMode, legalHold: ls.LegalHold}
+
+	if ls.RetainUntil != "" {
+		if t, err := time.Parse(time.RFC3339Nano, ls.RetainUntil); err == nil {
+			l.retainUntil = t
+		}
+	}
+
+	return l
 }
 
 // versionSnapshot is one entry in a key's version history (a stored version or a
@@ -66,6 +108,7 @@ type versionSnapshot struct {
 	LastModified string            `json:"lastModified,omitempty"`
 	Metadata     map[string]string `json:"metadata,omitempty"`
 	DeleteMarker bool              `json:"deleteMarker,omitempty"`
+	Lock         *lockSnapshot     `json:"lock,omitempty"`
 }
 
 // Snapshot captures every bucket's state as JSON. When includeAssets is false
@@ -97,6 +140,7 @@ func snapshotBucket(bkt *bucketMeta, includeAssets bool) *bucketSnapshot {
 			Key: obj.Key, Data: assetBytes(obj.Data, includeAssets), Size: obj.Size,
 			ContentType: obj.ContentType, ETag: obj.ETag, LastModified: obj.LastModified,
 			Metadata: obj.Metadata, Tags: obj.Tags, VersionID: obj.VersionID,
+			Lock: lockToSnapshot(obj.lock),
 		}
 	}
 
@@ -111,6 +155,7 @@ func snapshotBucketVersions(bkt *bucketMeta, bs *bucketSnapshot, includeAssets b
 	defer bkt.versionsMu.Unlock()
 
 	bs.VersionStatus = bkt.versionStatus
+	bs.ObjectLock = bkt.objectLockEnabled
 
 	if len(bkt.versions) == 0 {
 		return
@@ -125,7 +170,7 @@ func snapshotBucketVersions(bkt *bucketMeta, bs *bucketSnapshot, includeAssets b
 			out = append(out, &versionSnapshot{
 				VersionID: v.versionID, Data: assetBytes(v.data, includeAssets), Size: v.size,
 				ContentType: v.contentType, ETag: v.etag, LastModified: v.lastModified,
-				Metadata: v.metadata, DeleteMarker: v.deleteMarker,
+				Metadata: v.metadata, DeleteMarker: v.deleteMarker, Lock: lockToSnapshot(v.lock),
 			})
 		}
 
@@ -177,10 +222,11 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 func restoreBucket(bs *bucketSnapshot) *bucketMeta {
 	bkt := &bucketMeta{
 		Name: bs.Name, Region: bs.Region, CreatedAt: bs.CreatedAt,
-		objects:       memstore.New[*s3Object](),
-		multiparts:    memstore.New[*multipartUpload](),
-		versionStatus: bs.VersionStatus,
-		lifecycle:     bs.Lifecycle, policy: bs.Policy, corsConfig: bs.CORS,
+		objects:           memstore.New[*s3Object](),
+		multiparts:        memstore.New[*multipartUpload](),
+		objectLockEnabled: bs.ObjectLock,
+		versionStatus:     bs.VersionStatus,
+		lifecycle:         bs.Lifecycle, policy: bs.Policy, corsConfig: bs.CORS,
 		encryption: bs.Encryption, tags: bs.Tags, notifications: bs.Notifications,
 		rawConfigs: bs.RawConfigs,
 	}
@@ -189,7 +235,7 @@ func restoreBucket(bs *bucketSnapshot) *bucketMeta {
 		bkt.objects.Set(key, &s3Object{
 			Key: os.Key, Data: os.Data, Size: os.Size, ContentType: os.ContentType,
 			ETag: os.ETag, LastModified: os.LastModified, Metadata: os.Metadata,
-			Tags: os.Tags, VersionID: os.VersionID,
+			Tags: os.Tags, VersionID: os.VersionID, lock: lockFromSnapshot(os.Lock),
 		})
 	}
 
@@ -212,6 +258,7 @@ func restoreBucketVersions(bkt *bucketMeta, bs *bucketSnapshot) {
 			out = append(out, &s3Version{
 				versionID: v.VersionID, data: v.Data, size: v.Size, contentType: v.ContentType,
 				etag: v.ETag, lastModified: v.LastModified, metadata: v.Metadata, deleteMarker: v.DeleteMarker,
+				lock: lockFromSnapshot(v.Lock),
 			})
 		}
 

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -64,6 +64,11 @@ type Handler struct {
 	// properties (Cache-Control, Content-Encoding, …) and storage class; the
 	// handler then records them on PutObject and reflects them on read.
 	sysProps driver.SystemPropsBucket
+	// objectLock is set when the driver enforces S3 Object Lock (per-version
+	// retention + legal hold); the handler then honors the ?retention/?legal-hold
+	// sub-resources, the object-lock request headers, x-amz-bucket-object-lock-
+	// enabled on create, and WORM protection on delete/overwrite.
+	objectLock driver.ObjectLockBucket
 }
 
 // New returns an S3 handler backed by b.
@@ -91,6 +96,10 @@ func New(b driver.Bucket) *Handler {
 
 	if sp, ok := b.(driver.SystemPropsBucket); ok {
 		h.sysProps = sp
+	}
+
+	if ol, ok := b.(driver.ObjectLockBucket); ok {
+		h.objectLock = ol
 	}
 
 	return h
@@ -401,6 +410,15 @@ func (h *Handler) createBucket(w http.ResponseWriter, r *http.Request, bucket st
 		return
 	}
 
+	// x-amz-bucket-object-lock-enabled: true enables S3 Object Lock (and, as real
+	// S3 requires, versioning) on the new bucket so retention/legal hold can be set.
+	if h.objectLock != nil && strings.EqualFold(r.Header.Get("X-Amz-Bucket-Object-Lock-Enabled"), "true") {
+		if err := h.objectLock.EnableObjectLock(r.Context(), bucket); err != nil {
+			writeErr(w, err)
+			return
+		}
+	}
+
 	w.Header().Set("Location", "/"+bucket)
 	w.WriteHeader(http.StatusOK)
 }
@@ -574,6 +592,12 @@ func (h *Handler) objectOp(w http.ResponseWriter, r *http.Request, bucket, key s
 	case q.Has("tagging"):
 		h.objectTaggingOp(w, r, bucket, key)
 		return
+	case q.Has("retention"):
+		h.objectRetentionOp(w, r, bucket, key)
+		return
+	case q.Has("legal-hold"):
+		h.objectLegalHoldOp(w, r, bucket, key)
+		return
 	case q.Has("uploads"):
 		// POST /{bucket}/{key}?uploads => CreateMultipartUpload. Any other method
 		// is rejected rather than falling through to a plain object PUT/GET/DELETE.
@@ -639,6 +663,12 @@ func (h *Handler) putObject(w http.ResponseWriter, r *http.Request, bucket, key 
 	// x-amz-tagging sets the object's tag set at upload time; apply it so
 	// GetObjectTagging returns it (real S3 stores it atomically with the object).
 	if !h.applyPutTagging(w, r, bucket, key) {
+		return
+	}
+
+	// x-amz-object-lock-mode / -retain-until-date / -legal-hold stamp Object Lock
+	// on the just-written version (real S3 stores it atomically with the object).
+	if !h.applyPutObjectLock(w, r, bucket, key, versionID) {
 		return
 	}
 
@@ -772,6 +802,7 @@ func (h *Handler) getObject(w http.ResponseWriter, r *http.Request, bucket, key 
 	}
 
 	writeObjectHeaders(w, &obj.Info, int64(len(obj.Data)))
+	h.writeObjectLockHeaders(w, r, bucket, key, versionID)
 	w.Header().Set("Accept-Ranges", "bytes")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(obj.Data) //nolint:gosec // writing raw object bytes, not HTML
@@ -912,6 +943,7 @@ func (h *Handler) headObject(w http.ResponseWriter, r *http.Request, bucket, key
 	}
 
 	writeObjectHeaders(w, info, info.Size)
+	h.writeObjectLockHeaders(w, r, bucket, key, versionID)
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -1134,7 +1166,9 @@ func (h *Handler) deleteObject(w http.ResponseWriter, r *http.Request, bucket, k
 	if h.versioned != nil {
 		// Versioned driver: a top-level delete (no versionId) appends a delete
 		// marker on an Enabled bucket; ?versionId permanently removes a version.
-		vid, marker, err := h.versioned.DeleteObjectVersion(r.Context(), bucket, key, versionID)
+		// When Object Lock is enforced, a protected version is refused (403
+		// AccessDenied); x-amz-bypass-governance-retention lifts a GOVERNANCE block.
+		vid, marker, err := h.deleteVersion(r, bucket, key, versionID)
 		if err != nil && (!cerrors.IsNotFound(err) || bucketMissing(err)) {
 			writeErr(w, err)
 			return
@@ -1158,6 +1192,29 @@ func (h *Handler) deleteObject(w http.ResponseWriter, r *http.Request, bucket, k
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// bypassGovernanceHeader is the S3 header a caller sends to remove a
+// GOVERNANCE-mode object-lock protection (never COMPLIANCE, never a legal hold).
+//
+//nolint:gosec // G101 false positive: an HTTP header name, not a credential
+const bypassGovernanceHeader = "X-Amz-Bypass-Governance-Retention"
+
+// bypassGovernance reports whether the request asks to bypass GOVERNANCE
+// retention (x-amz-bypass-governance-retention: true).
+func bypassGovernance(r *http.Request) bool {
+	return strings.EqualFold(r.Header.Get(bypassGovernanceHeader), "true")
+}
+
+// deleteVersion removes a version through the object-lock-aware path when the
+// driver enforces Object Lock (honoring x-amz-bypass-governance-retention),
+// falling back to the plain versioned delete otherwise.
+func (h *Handler) deleteVersion(r *http.Request, bucket, key, versionID string) (vid string, marker bool, err error) {
+	if h.objectLock != nil {
+		return h.objectLock.DeleteObjectVersionWithBypass(r.Context(), bucket, key, versionID, bypassGovernance(r))
+	}
+
+	return h.versioned.DeleteObjectVersion(r.Context(), bucket, key, versionID)
 }
 
 // maxDeleteBody caps a DeleteObjects request body. Real S3 allows up to 1000
@@ -1209,14 +1266,21 @@ func (h *Handler) deleteObjects(w http.ResponseWriter, r *http.Request, bucket s
 	}
 
 	result := deleteResultXML{Xmlns: xmlns}
+	bypass := bypassGovernance(r)
 
 	for _, obj := range req.Objects {
-		vid, marker, derr := h.deleteOneObject(r.Context(), bucket, obj.Key, obj.VersionID)
+		vid, marker, derr := h.deleteOneObject(r.Context(), bucket, obj.Key, obj.VersionID, bypass)
 		switch {
 		case derr != nil && bucketMissing(derr):
 			// A missing bucket aborts the whole batch, as in real S3.
 			writeErr(w, derr)
 			return
+		case derr != nil && cerrors.IsPermissionDenied(derr):
+			// Object Lock refused this key; report the AccessDenied per-key and
+			// continue the batch, as real S3 does.
+			result.Errors = append(result.Errors, deleteErrorXML{
+				Key: obj.Key, Code: "AccessDenied", Message: cerrors.Message(derr),
+			})
 		case derr != nil:
 			result.Errors = append(result.Errors, deleteErrorXML{
 				Key: obj.Key, Code: "InternalError", Message: cerrors.Message(derr),
@@ -1279,11 +1343,17 @@ func (h *Handler) aclOp(w http.ResponseWriter, r *http.Request) {
 }
 
 // deleteOneObject deletes a single key for the batch path, honoring versioning
-// and treating a missing key as success (idempotent).
-func (h *Handler) deleteOneObject(ctx context.Context, bucket, key, versionID string) (vid string, marker bool, err error) {
-	if h.versioned != nil {
+// and Object Lock (bypass lifts a GOVERNANCE block) and treating a missing key
+// as success (idempotent).
+func (h *Handler) deleteOneObject(
+	ctx context.Context, bucket, key, versionID string, bypass bool,
+) (vid string, marker bool, err error) {
+	switch {
+	case h.objectLock != nil:
+		vid, marker, err = h.objectLock.DeleteObjectVersionWithBypass(ctx, bucket, key, versionID, bypass)
+	case h.versioned != nil:
 		vid, marker, err = h.versioned.DeleteObjectVersion(ctx, bucket, key, versionID)
-	} else {
+	default:
 		err = h.bucket.DeleteObject(ctx, bucket, key)
 	}
 
@@ -2409,6 +2479,9 @@ func writeErr(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusConflict, "BucketAlreadyOwnedByYou", msg)
 	case cerrors.IsInvalidArgument(err):
 		writeError(w, http.StatusBadRequest, "InvalidArgument", msg)
+	case cerrors.IsPermissionDenied(err):
+		// Object Lock (WORM) protection blocks a delete/overwrite/retention change.
+		writeError(w, http.StatusForbidden, "AccessDenied", msg)
 	case cerrors.IsFailedPrecondition(err):
 		// Deleting a non-empty bucket is a client error in real S3, not a
 		// server fault — and a 5xx would trigger SDK retry backoff.

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -580,40 +580,7 @@ func (h *Handler) listObjects(w http.ResponseWriter, r *http.Request, bucket str
 }
 
 func (h *Handler) objectOp(w http.ResponseWriter, r *http.Request, bucket, key string) {
-	q := r.URL.Query()
-
-	switch {
-	case q.Has("attributes"):
-		// GET /{bucket}/{key}?attributes => GetObjectAttributes. Without this it
-		// falls through to getObject and the SDK decodes an object body as the
-		// attributes response, reading zero-valued attributes.
-		h.getObjectAttributes(w, r, bucket, key)
-		return
-	case q.Has("tagging"):
-		h.objectTaggingOp(w, r, bucket, key)
-		return
-	case q.Has("retention"):
-		h.objectRetentionOp(w, r, bucket, key)
-		return
-	case q.Has("legal-hold"):
-		h.objectLegalHoldOp(w, r, bucket, key)
-		return
-	case q.Has("uploads"):
-		// POST /{bucket}/{key}?uploads => CreateMultipartUpload. Any other method
-		// is rejected rather than falling through to a plain object PUT/GET/DELETE.
-		if r.Method == http.MethodPost {
-			h.createMultipartUpload(w, r, bucket, key)
-			return
-		}
-		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed on ?uploads")
-		return
-	case q.Has("uploadId"):
-		h.multipartUploadOp(w, r, bucket, key, q.Get("uploadId"))
-		return
-	case q.Has("acl"):
-		// GET returns a canned ACL; a PUT/DELETE is a no-op so it does NOT fall
-		// through to putObject and overwrite the object with the ACL body.
-		h.aclOp(w, r)
+	if h.objectSubresourceOp(w, r, bucket, key) {
 		return
 	}
 
@@ -633,6 +600,46 @@ func (h *Handler) objectOp(w http.ResponseWriter, r *http.Request, bucket, key s
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
+}
+
+// objectSubresourceOp dispatches the object-level sub-resource operations
+// selected by a query key (?attributes, ?tagging, ?retention, ?legal-hold,
+// ?uploads, ?uploadId, ?acl). It returns true when it handled the request; false
+// lets objectOp fall through to the plain method switch (GET/PUT/HEAD/DELETE).
+func (h *Handler) objectSubresourceOp(w http.ResponseWriter, r *http.Request, bucket, key string) bool {
+	q := r.URL.Query()
+
+	switch {
+	case q.Has("attributes"):
+		// GET /{bucket}/{key}?attributes => GetObjectAttributes. Without this it
+		// falls through to getObject and the SDK decodes an object body as the
+		// attributes response, reading zero-valued attributes.
+		h.getObjectAttributes(w, r, bucket, key)
+	case q.Has("tagging"):
+		h.objectTaggingOp(w, r, bucket, key)
+	case q.Has("retention"):
+		h.objectRetentionOp(w, r, bucket, key)
+	case q.Has("legal-hold"):
+		h.objectLegalHoldOp(w, r, bucket, key)
+	case q.Has("uploads"):
+		// POST /{bucket}/{key}?uploads => CreateMultipartUpload. Any other method
+		// is rejected rather than falling through to a plain object PUT/GET/DELETE.
+		if r.Method == http.MethodPost {
+			h.createMultipartUpload(w, r, bucket, key)
+		} else {
+			writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed on ?uploads")
+		}
+	case q.Has("uploadId"):
+		h.multipartUploadOp(w, r, bucket, key, q.Get("uploadId"))
+	case q.Has("acl"):
+		// GET returns a canned ACL; a PUT/DELETE is a no-op so it does NOT fall
+		// through to putObject and overwrite the object with the ACL body.
+		h.aclOp(w, r)
+	default:
+		return false
+	}
+
+	return true
 }
 
 func (h *Handler) putObject(w http.ResponseWriter, r *http.Request, bucket, key string) {
@@ -2145,8 +2152,17 @@ func (h *Handler) putBucketVersioning(w http.ResponseWriter, r *http.Request, bu
 	} else {
 		err = h.bucket.SetBucketVersioning(r.Context(), bucket, body.Status == "Enabled")
 	}
+
 	if err != nil {
+		// Suspending versioning on an Object-Lock-enabled bucket is rejected by
+		// real S3 with 409 InvalidBucketState.
+		if cerrors.IsFailedPrecondition(err) {
+			writeError(w, http.StatusConflict, "InvalidBucketState", cerrors.Message(err))
+			return
+		}
+
 		writeErr(w, err)
+
 		return
 	}
 

--- a/server/aws/s3/object_lock.go
+++ b/server/aws/s3/object_lock.go
@@ -7,9 +7,23 @@ import (
 	"strings"
 	"time"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	"github.com/stackshy/cloudemu/v2/services/storage/driver"
 )
+
+// writeObjectLockErr maps a retention/legal-hold driver error: a bucket that was
+// not created with Object Lock enabled surfaces as 400 InvalidRequest (real S3);
+// everything else (a WORM protection denial → 403 AccessDenied, missing
+// bucket/key → NoSuchBucket/NoSuchKey) follows the standard mapping.
+func writeObjectLockErr(w http.ResponseWriter, err error) {
+	if cerrors.IsFailedPrecondition(err) {
+		writeError(w, http.StatusBadRequest, "InvalidRequest", cerrors.Message(err))
+		return
+	}
+
+	writeErr(w, err)
+}
 
 // Object Lock request/response headers and status values.
 const (
@@ -103,7 +117,7 @@ func (h *Handler) putObjectRetention(w http.ResponseWriter, r *http.Request, buc
 
 	versionID := r.URL.Query().Get("versionId")
 	if err := h.objectLock.PutObjectRetention(r.Context(), bucket, key, versionID, ret, bypassGovernance(r)); err != nil {
-		writeErr(w, err)
+		writeObjectLockErr(w, err)
 		return
 	}
 
@@ -171,7 +185,7 @@ func (h *Handler) putObjectLegalHold(w http.ResponseWriter, r *http.Request, buc
 	on := strings.EqualFold(doc.Status, legalHoldOn)
 
 	if err := h.objectLock.PutObjectLegalHold(r.Context(), bucket, key, versionID, on); err != nil {
-		writeErr(w, err)
+		writeObjectLockErr(w, err)
 		return
 	}
 
@@ -222,14 +236,14 @@ func (h *Handler) applyPutObjectLock(w http.ResponseWriter, r *http.Request, buc
 		}
 
 		if err := h.objectLock.PutObjectRetention(r.Context(), bucket, key, versionID, ret, bypassGovernance(r)); err != nil {
-			writeErr(w, err)
+			writeObjectLockErr(w, err)
 			return false
 		}
 	}
 
 	if lh := r.Header.Get(hdrObjectLockLegalHold); lh != "" {
 		if err := h.objectLock.PutObjectLegalHold(r.Context(), bucket, key, versionID, strings.EqualFold(lh, legalHoldOn)); err != nil {
-			writeErr(w, err)
+			writeObjectLockErr(w, err)
 			return false
 		}
 	}

--- a/server/aws/s3/object_lock.go
+++ b/server/aws/s3/object_lock.go
@@ -1,0 +1,256 @@
+package s3
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// Object Lock request/response headers and status values.
+const (
+	hdrObjectLockMode       = "X-Amz-Object-Lock-Mode"
+	hdrObjectLockRetainDate = "X-Amz-Object-Lock-Retain-Until-Date"
+	hdrObjectLockLegalHold  = "X-Amz-Object-Lock-Legal-Hold"
+
+	legalHoldOn  = "ON"
+	legalHoldOff = "OFF"
+
+	// retainUntilLayout is the ISO8601 form S3 emits for a retain-until date
+	// (millisecond precision, UTC).
+	retainUntilLayout = "2006-01-02T15:04:05.000Z"
+)
+
+// objectLockRetentionXML is the Retention document (PUT/GET ?retention).
+type objectLockRetentionXML struct {
+	XMLName         xml.Name `xml:"Retention"`
+	Xmlns           string   `xml:"xmlns,attr,omitempty"`
+	Mode            string   `xml:"Mode,omitempty"`
+	RetainUntilDate string   `xml:"RetainUntilDate,omitempty"`
+}
+
+// objectLockLegalHoldXML is the LegalHold document (PUT/GET ?legal-hold).
+type objectLockLegalHoldXML struct {
+	XMLName xml.Name `xml:"LegalHold"`
+	Xmlns   string   `xml:"xmlns,attr,omitempty"`
+	Status  string   `xml:"Status,omitempty"`
+}
+
+// parseRetainUntil parses the retain-until-date sent by clients, accepting the
+// RFC3339 forms the SDK emits and S3's millisecond ISO8601 form.
+func parseRetainUntil(s string) (time.Time, bool) {
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, retainUntilLayout} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC(), true
+		}
+	}
+
+	return time.Time{}, false
+}
+
+// objectRetentionOp answers GET/PUT /{bucket}/{key}?retention. Without an
+// Object-Lock-capable driver it is a no-op accept (GET reports none), so a write
+// never falls through to overwrite the object.
+func (h *Handler) objectRetentionOp(w http.ResponseWriter, r *http.Request, bucket, key string) {
+	if h.objectLock == nil {
+		if r.Method == http.MethodGet {
+			writeError(w, http.StatusNotFound, "NoSuchObjectLockConfiguration",
+				"The specified object does not have an ObjectLock configuration")
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+
+		return
+	}
+
+	if r.Method == http.MethodPut {
+		h.putObjectRetention(w, r, bucket, key)
+		return
+	}
+
+	h.getObjectRetention(w, r, bucket, key)
+}
+
+func (h *Handler) putObjectRetention(w http.ResponseWriter, r *http.Request, bucket, key string) {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxConfigBody))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "MalformedXML", "could not read request body")
+		return
+	}
+
+	var doc objectLockRetentionXML
+	if err := xml.Unmarshal(body, &doc); err != nil {
+		writeError(w, http.StatusBadRequest, "MalformedXML", "malformed Retention request")
+		return
+	}
+
+	ret := driver.ObjectRetention{Mode: doc.Mode}
+
+	if doc.RetainUntilDate != "" {
+		until, ok := parseRetainUntil(doc.RetainUntilDate)
+		if !ok {
+			writeError(w, http.StatusBadRequest, "InvalidArgument", "invalid RetainUntilDate")
+			return
+		}
+
+		ret.RetainUntilDate = until
+	}
+
+	versionID := r.URL.Query().Get("versionId")
+	if err := h.objectLock.PutObjectRetention(r.Context(), bucket, key, versionID, ret, bypassGovernance(r)); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) getObjectRetention(w http.ResponseWriter, r *http.Request, bucket, key string) {
+	versionID := r.URL.Query().Get("versionId")
+
+	ret, err := h.objectLock.GetObjectRetention(r.Context(), bucket, key, versionID)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if ret.Mode == "" {
+		writeError(w, http.StatusNotFound, "NoSuchObjectLockConfiguration",
+			"The specified object does not have a Retention configuration")
+		return
+	}
+
+	wire.WriteXML(w, http.StatusOK, objectLockRetentionXML{
+		Xmlns:           xmlns,
+		Mode:            ret.Mode,
+		RetainUntilDate: ret.RetainUntilDate.UTC().Format(retainUntilLayout),
+	})
+}
+
+// objectLegalHoldOp answers GET/PUT /{bucket}/{key}?legal-hold.
+func (h *Handler) objectLegalHoldOp(w http.ResponseWriter, r *http.Request, bucket, key string) {
+	if h.objectLock == nil {
+		if r.Method == http.MethodGet {
+			writeError(w, http.StatusNotFound, "NoSuchObjectLockConfiguration",
+				"The specified object does not have an ObjectLock configuration")
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+
+		return
+	}
+
+	if r.Method == http.MethodPut {
+		h.putObjectLegalHold(w, r, bucket, key)
+		return
+	}
+
+	h.getObjectLegalHold(w, r, bucket, key)
+}
+
+func (h *Handler) putObjectLegalHold(w http.ResponseWriter, r *http.Request, bucket, key string) {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxConfigBody))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "MalformedXML", "could not read request body")
+		return
+	}
+
+	var doc objectLockLegalHoldXML
+	if err := xml.Unmarshal(body, &doc); err != nil {
+		writeError(w, http.StatusBadRequest, "MalformedXML", "malformed LegalHold request")
+		return
+	}
+
+	versionID := r.URL.Query().Get("versionId")
+	on := strings.EqualFold(doc.Status, legalHoldOn)
+
+	if err := h.objectLock.PutObjectLegalHold(r.Context(), bucket, key, versionID, on); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) getObjectLegalHold(w http.ResponseWriter, r *http.Request, bucket, key string) {
+	versionID := r.URL.Query().Get("versionId")
+
+	on, err := h.objectLock.GetObjectLegalHold(r.Context(), bucket, key, versionID)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	status := legalHoldOff
+	if on {
+		status = legalHoldOn
+	}
+
+	wire.WriteXML(w, http.StatusOK, objectLockLegalHoldXML{Xmlns: xmlns, Status: status})
+}
+
+// applyPutObjectLock stamps the object-lock request headers
+// (x-amz-object-lock-mode / -retain-until-date / -legal-hold) onto the version
+// just written by PutObject. It returns false (after writing the error) when a
+// header is malformed or the driver rejects the setting; a request with no
+// object-lock headers is a no-op success.
+func (h *Handler) applyPutObjectLock(w http.ResponseWriter, r *http.Request, bucket, key, versionID string) bool {
+	if h.objectLock == nil {
+		return true
+	}
+
+	mode := r.Header.Get(hdrObjectLockMode)
+	retainStr := r.Header.Get(hdrObjectLockRetainDate)
+
+	if mode != "" || retainStr != "" {
+		ret := driver.ObjectRetention{Mode: mode}
+
+		if retainStr != "" {
+			until, ok := parseRetainUntil(retainStr)
+			if !ok {
+				writeError(w, http.StatusBadRequest, "InvalidArgument", "invalid x-amz-object-lock-retain-until-date")
+				return false
+			}
+
+			ret.RetainUntilDate = until
+		}
+
+		if err := h.objectLock.PutObjectRetention(r.Context(), bucket, key, versionID, ret, bypassGovernance(r)); err != nil {
+			writeErr(w, err)
+			return false
+		}
+	}
+
+	if lh := r.Header.Get(hdrObjectLockLegalHold); lh != "" {
+		if err := h.objectLock.PutObjectLegalHold(r.Context(), bucket, key, versionID, strings.EqualFold(lh, legalHoldOn)); err != nil {
+			writeErr(w, err)
+			return false
+		}
+	}
+
+	return true
+}
+
+// writeObjectLockHeaders echoes an object version's Object Lock state on
+// GET/HEAD (x-amz-object-lock-mode / -retain-until-date / -legal-hold). It is
+// best-effort — a read error or absent lock simply omits the headers.
+func (h *Handler) writeObjectLockHeaders(w http.ResponseWriter, r *http.Request, bucket, key, versionID string) {
+	if h.objectLock == nil {
+		return
+	}
+
+	if ret, err := h.objectLock.GetObjectRetention(r.Context(), bucket, key, versionID); err == nil && ret.Mode != "" {
+		w.Header().Set(hdrObjectLockMode, ret.Mode)
+		w.Header().Set(hdrObjectLockRetainDate, ret.RetainUntilDate.UTC().Format(retainUntilLayout))
+	}
+
+	if on, err := h.objectLock.GetObjectLegalHold(r.Context(), bucket, key, versionID); err == nil && on {
+		w.Header().Set(hdrObjectLockLegalHold, legalHoldOn)
+	}
+}

--- a/server/aws/s3/object_lock_sdk_test.go
+++ b/server/aws/s3/object_lock_sdk_test.go
@@ -1,0 +1,264 @@
+package s3_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newLockSDKClient builds an S3 SDK client backed by a FakeClock the test can
+// advance, so retain-until-date expiry is deterministic.
+func newLockSDKClient(t *testing.T) (*awss3.Client, *config.FakeClock) {
+	t.Helper()
+
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	cloud := cloudemu.NewAWS(config.WithClock(fc))
+	srv := awsserver.New(awsserver.Drivers{S3: cloud.S3})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	client := awss3.NewFromConfig(cfg, func(o *awss3.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+		o.UsePathStyle = true
+	})
+
+	return client, fc
+}
+
+// lockEpoch is the FakeClock's start; retain-until dates are expressed relative
+// to it so advancing the clock crosses them deterministically.
+func lockEpoch() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) }
+
+func mustCreateObjectLockBucket(t *testing.T, client *awss3.Client, bucket string) {
+	t.Helper()
+
+	_, err := client.CreateBucket(context.Background(), &awss3.CreateBucketInput{
+		Bucket:                     aws.String(bucket),
+		ObjectLockEnabledForBucket: aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("CreateBucket(object-lock): %v", err)
+	}
+}
+
+// assertAccessDenied asserts the SDK error is an S3 AccessDenied (403).
+func assertAccessDenied(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected AccessDenied error, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "AccessDenied" {
+		t.Fatalf("expected AccessDenied, got %v", err)
+	}
+}
+
+// TestSDKObjectLockComplianceBlocksDelete drives the real aws-sdk-go-v2 flow: a
+// COMPLIANCE-retained version cannot be deleted until the retain date passes.
+func TestSDKObjectLockComplianceBlocksDelete(t *testing.T) {
+	client, fc := newLockSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateObjectLockBucket(t, client, "compliance")
+
+	until := lockEpoch().Add(time.Hour)
+	put, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket:                    aws.String("compliance"),
+		Key:                       aws.String("k"),
+		Body:                      bytes.NewReader([]byte("v1")),
+		ObjectLockMode:            types.ObjectLockModeCompliance,
+		ObjectLockRetainUntilDate: aws.Time(until),
+	})
+	if err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	vid := aws.ToString(put.VersionId)
+	if vid == "" {
+		t.Fatal("PutObject returned no version id")
+	}
+
+	// GetObjectRetention round-trips the mode.
+	ret, err := client.GetObjectRetention(ctx, &awss3.GetObjectRetentionInput{
+		Bucket: aws.String("compliance"), Key: aws.String("k"), VersionId: aws.String(vid),
+	})
+	if err != nil {
+		t.Fatalf("GetObjectRetention: %v", err)
+	}
+	if ret.Retention == nil || ret.Retention.Mode != types.ObjectLockRetentionModeCompliance {
+		t.Fatalf("GetObjectRetention mode = %v, want COMPLIANCE", ret.Retention)
+	}
+
+	// Deleting the retained version is refused, even with governance bypass.
+	_, err = client.DeleteObject(ctx, &awss3.DeleteObjectInput{
+		Bucket: aws.String("compliance"), Key: aws.String("k"), VersionId: aws.String(vid),
+		BypassGovernanceRetention: aws.Bool(true),
+	})
+	assertAccessDenied(t, err)
+
+	// After the retain date, the delete succeeds.
+	fc.Advance(2 * time.Hour)
+
+	if _, err := client.DeleteObject(ctx, &awss3.DeleteObjectInput{
+		Bucket: aws.String("compliance"), Key: aws.String("k"), VersionId: aws.String(vid),
+	}); err != nil {
+		t.Fatalf("DeleteObject after expiry: %v", err)
+	}
+}
+
+// TestSDKObjectLockGovernanceBypass verifies GOVERNANCE retention blocks a delete
+// but x-amz-bypass-governance-retention permits it.
+func TestSDKObjectLockGovernanceBypass(t *testing.T) {
+	client, _ := newLockSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateObjectLockBucket(t, client, "governance")
+
+	put, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket:                    aws.String("governance"),
+		Key:                       aws.String("k"),
+		Body:                      bytes.NewReader([]byte("v1")),
+		ObjectLockMode:            types.ObjectLockModeGovernance,
+		ObjectLockRetainUntilDate: aws.Time(lockEpoch().Add(time.Hour)),
+	})
+	if err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+	vid := aws.ToString(put.VersionId)
+
+	_, err = client.DeleteObject(ctx, &awss3.DeleteObjectInput{
+		Bucket: aws.String("governance"), Key: aws.String("k"), VersionId: aws.String(vid),
+	})
+	assertAccessDenied(t, err)
+
+	if _, err := client.DeleteObject(ctx, &awss3.DeleteObjectInput{
+		Bucket: aws.String("governance"), Key: aws.String("k"), VersionId: aws.String(vid),
+		BypassGovernanceRetention: aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("DeleteObject with bypass: %v", err)
+	}
+}
+
+// TestSDKObjectLockLegalHold verifies legal hold blocks a delete regardless of
+// retention, until it is turned OFF.
+func TestSDKObjectLockLegalHold(t *testing.T) {
+	client, _ := newLockSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateObjectLockBucket(t, client, "legalhold")
+
+	put, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket:                    aws.String("legalhold"),
+		Key:                       aws.String("k"),
+		Body:                      bytes.NewReader([]byte("v1")),
+		ObjectLockLegalHoldStatus: types.ObjectLockLegalHoldStatusOn,
+	})
+	if err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+	vid := aws.ToString(put.VersionId)
+
+	lh, err := client.GetObjectLegalHold(ctx, &awss3.GetObjectLegalHoldInput{
+		Bucket: aws.String("legalhold"), Key: aws.String("k"), VersionId: aws.String(vid),
+	})
+	if err != nil {
+		t.Fatalf("GetObjectLegalHold: %v", err)
+	}
+	if lh.LegalHold == nil || lh.LegalHold.Status != types.ObjectLockLegalHoldStatusOn {
+		t.Fatalf("legal hold = %v, want ON", lh.LegalHold)
+	}
+
+	// Blocked even with bypass (bypass is only for governance retention).
+	_, err = client.DeleteObject(ctx, &awss3.DeleteObjectInput{
+		Bucket: aws.String("legalhold"), Key: aws.String("k"), VersionId: aws.String(vid),
+		BypassGovernanceRetention: aws.Bool(true),
+	})
+	assertAccessDenied(t, err)
+
+	if _, err := client.PutObjectLegalHold(ctx, &awss3.PutObjectLegalHoldInput{
+		Bucket: aws.String("legalhold"), Key: aws.String("k"), VersionId: aws.String(vid),
+		LegalHold: &types.ObjectLockLegalHold{Status: types.ObjectLockLegalHoldStatusOff},
+	}); err != nil {
+		t.Fatalf("PutObjectLegalHold OFF: %v", err)
+	}
+
+	if _, err := client.DeleteObject(ctx, &awss3.DeleteObjectInput{
+		Bucket: aws.String("legalhold"), Key: aws.String("k"), VersionId: aws.String(vid),
+	}); err != nil {
+		t.Fatalf("DeleteObject after legal hold off: %v", err)
+	}
+}
+
+// TestSDKObjectLockTopLevelDeleteMarker verifies a top-level DeleteObject (no
+// version id) on a locked object still records a delete marker, leaving the
+// protected version intact.
+func TestSDKObjectLockTopLevelDeleteMarker(t *testing.T) {
+	client, _ := newLockSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateObjectLockBucket(t, client, "marker")
+
+	put, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket:                    aws.String("marker"),
+		Key:                       aws.String("k"),
+		Body:                      bytes.NewReader([]byte("v1")),
+		ObjectLockMode:            types.ObjectLockModeCompliance,
+		ObjectLockRetainUntilDate: aws.Time(lockEpoch().Add(time.Hour)),
+	})
+	if err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+	lockedVID := aws.ToString(put.VersionId)
+
+	del, err := client.DeleteObject(ctx, &awss3.DeleteObjectInput{
+		Bucket: aws.String("marker"), Key: aws.String("k"),
+	})
+	if err != nil {
+		t.Fatalf("DeleteObject (top-level): %v", err)
+	}
+	if !aws.ToBool(del.DeleteMarker) {
+		t.Fatalf("top-level delete did not create a delete marker")
+	}
+
+	// The locked version is still listed.
+	vers, err := client.ListObjectVersions(ctx, &awss3.ListObjectVersionsInput{Bucket: aws.String("marker")})
+	if err != nil {
+		t.Fatalf("ListObjectVersions: %v", err)
+	}
+	found := false
+	for _, v := range vers.Versions {
+		if aws.ToString(v.VersionId) == lockedVID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("locked version missing after top-level delete")
+	}
+}

--- a/server/aws/s3/object_lock_sdk_test.go
+++ b/server/aws/s3/object_lock_sdk_test.go
@@ -3,7 +3,6 @@ package s3_test
 import (
 	"bytes"
 	"context"
-	"errors"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -13,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
-	smithy "github.com/aws/smithy-go"
 
 	"github.com/stackshy/cloudemu/v2"
 	"github.com/stackshy/cloudemu/v2/config"
@@ -67,17 +65,11 @@ func mustCreateObjectLockBucket(t *testing.T, client *awss3.Client, bucket strin
 }
 
 // assertAccessDenied asserts the SDK error is an S3 AccessDenied (403).
+// assertAPICode is defined in copy_sdk_test.go (same package).
 func assertAccessDenied(t *testing.T, err error) {
 	t.Helper()
 
-	if err == nil {
-		t.Fatal("expected AccessDenied error, got nil")
-	}
-
-	var apiErr smithy.APIError
-	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "AccessDenied" {
-		t.Fatalf("expected AccessDenied, got %v", err)
-	}
+	assertAPICode(t, err, "AccessDenied")
 }
 
 // TestSDKObjectLockComplianceBlocksDelete drives the real aws-sdk-go-v2 flow: a
@@ -261,4 +253,50 @@ func TestSDKObjectLockTopLevelDeleteMarker(t *testing.T) {
 	if !found {
 		t.Fatal("locked version missing after top-level delete")
 	}
+}
+
+// TestSDKObjectLockSuspendRejected verifies versioning cannot be suspended on an
+// Object-Lock-enabled bucket (real S3: 409 InvalidBucketState).
+func TestSDKObjectLockSuspendRejected(t *testing.T) {
+	client, _ := newLockSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateObjectLockBucket(t, client, "nosuspend")
+
+	_, err := client.PutBucketVersioning(ctx, &awss3.PutBucketVersioningInput{
+		Bucket:                  aws.String("nosuspend"),
+		VersioningConfiguration: &types.VersioningConfiguration{Status: types.BucketVersioningStatusSuspended},
+	})
+	assertAPICode(t, err, "InvalidBucketState")
+}
+
+// TestSDKObjectLockRetentionRequiresLockBucket verifies retention cannot be set
+// on a bucket that was not created with Object Lock enabled (real S3: 400
+// InvalidRequest).
+func TestSDKObjectLockRetentionRequiresLockBucket(t *testing.T) {
+	client, _ := newLockSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateBucket(t, client, "plainbucket")
+
+	if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket: aws.String("plainbucket"), Key: aws.String("k"), Body: bytes.NewReader([]byte("v1")),
+	}); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	_, err := client.PutObjectRetention(ctx, &awss3.PutObjectRetentionInput{
+		Bucket: aws.String("plainbucket"), Key: aws.String("k"),
+		Retention: &types.ObjectLockRetention{
+			Mode:            types.ObjectLockRetentionModeCompliance,
+			RetainUntilDate: aws.Time(lockEpoch().Add(time.Hour)),
+		},
+	})
+	assertAPICode(t, err, "InvalidRequest")
+
+	_, err = client.PutObjectLegalHold(ctx, &awss3.PutObjectLegalHoldInput{
+		Bucket: aws.String("plainbucket"), Key: aws.String("k"),
+		LegalHold: &types.ObjectLockLegalHold{Status: types.ObjectLockLegalHoldStatusOn},
+	})
+	assertAPICode(t, err, "InvalidRequest")
 }

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -528,6 +528,73 @@ type VersionedBucket interface {
 	ListObjectVersions(ctx context.Context, bucket string, opts ListOptions) (*VersionListResult, error)
 }
 
+// Object-lock retention modes (S3 Object Lock). GOVERNANCE can be bypassed by a
+// principal holding s3:BypassGovernanceRetention; COMPLIANCE can be bypassed by
+// no one, not even the root account, until the retention period elapses.
+const (
+	ObjectLockGovernance = "GOVERNANCE"
+	ObjectLockCompliance = "COMPLIANCE"
+)
+
+// ObjectRetention is an S3 Object Lock retention setting on a single object
+// version: a Mode (GOVERNANCE or COMPLIANCE) and the UTC instant until which the
+// version is retained. A zero value (empty Mode, zero RetainUntilDate) means no
+// retention is configured.
+type ObjectRetention struct {
+	Mode            string
+	RetainUntilDate time.Time
+}
+
+// ObjectLockBucket is an OPTIONAL S3-specific capability (discovered by type
+// assertion, like VersionedBucket) that ENFORCES S3 Object Lock (WORM). Retention
+// (GOVERNANCE/COMPLIANCE + RetainUntilDate) and legal hold are recorded per
+// object version; while a version is protected — legal hold ON, or a retention
+// period that has not elapsed — its bytes cannot be permanently deleted or
+// overwritten. A GOVERNANCE retention (but not the version's legal hold) can be
+// lifted with s3:BypassGovernanceRetention; a COMPLIANCE retention cannot be
+// shortened, removed, or bypassed by anyone until it expires. Object Lock builds
+// on versioning, so it layers on VersionedBucket. Providers without it keep the
+// plain versioned behavior with no WORM protection.
+type ObjectLockBucket interface {
+	VersionedBucket
+
+	// ObjectLockEnabled reports whether the bucket was created with Object Lock
+	// enabled (x-amz-bucket-object-lock-enabled), so retention/legal hold may be
+	// configured on its objects.
+	ObjectLockEnabled(ctx context.Context, bucket string) (bool, error)
+	// EnableObjectLock marks a bucket Object-Lock-enabled and turns on versioning
+	// (Object Lock requires it). Idempotent.
+	EnableObjectLock(ctx context.Context, bucket string) error
+
+	// GetObjectRetention returns the retention on a version (the current version
+	// when versionID==""). A zero ObjectRetention means none is set.
+	GetObjectRetention(ctx context.Context, bucket, key, versionID string) (ObjectRetention, error)
+	// PutObjectRetention sets the retention on a version (current when
+	// versionID==""). First-setting or extending a retention is always allowed;
+	// shortening, removing, or downgrading an ACTIVE GOVERNANCE retention requires
+	// bypassGovernance, and an active COMPLIANCE retention can never be shortened,
+	// removed, or downgraded. A disallowed change returns a PermissionDenied error.
+	PutObjectRetention(
+		ctx context.Context, bucket, key, versionID string, ret ObjectRetention, bypassGovernance bool,
+	) error
+	// GetObjectLegalHold reports whether legal hold is ON for a version (current
+	// when versionID=="").
+	GetObjectLegalHold(ctx context.Context, bucket, key, versionID string) (bool, error)
+	// PutObjectLegalHold sets legal hold ON/OFF for a version (current when
+	// versionID==""). Always allowed.
+	PutObjectLegalHold(ctx context.Context, bucket, key, versionID string, on bool) error
+
+	// DeleteObjectVersionWithBypass is DeleteObjectVersion with Object Lock
+	// enforcement: a protected version cannot be permanently removed, and
+	// bypassGovernance lifts only a GOVERNANCE block (never COMPLIANCE, never a
+	// legal hold). A blocked delete returns a PermissionDenied error. A top-level
+	// delete (versionID=="") still records a delete marker without touching the
+	// protected versions beneath it.
+	DeleteObjectVersionWithBypass(
+		ctx context.Context, bucket, key, versionID string, bypassGovernance bool,
+	) (deletedVersionID string, deleteMarker bool, err error)
+}
+
 // RawBucketConfig is an OPTIONAL capability (discovered by type assertion, like
 // VersionedBucket) a storage provider implements to persist and echo back opaque
 // bucket-configuration sub-resource documents — policy (JSON), cors, encryption,


### PR DESCRIPTION
## Summary

Adds real WORM enforcement to S3 Object Lock. Previously the bucket object-lock config and per-object retention/legal-hold were stored but never enforced — a locked object could still be deleted or overwritten.

Retention (GOVERNANCE/COMPLIANCE + RetainUntilDate) and legal hold are now recorded per object version and enforced at every delete/overwrite path:

- A version under an unexpired retention or with legal hold ON cannot be permanently deleted (explicit `versionId`) or have its bytes overwritten in place.
- A **top-level** `DeleteObject` (no `versionId`) on a versioning-enabled bucket records a delete marker and leaves protected versions intact; on the byte-destroying suspended/unversioned paths it is refused when the current object is protected.
- GOVERNANCE retention is lifted with `x-amz-bypass-governance-retention: true`; COMPLIANCE and legal hold cannot be bypassed by anyone.
- Retention changes follow S3 rules: extend always allowed; shorten/remove/downgrade an active COMPLIANCE retention is never allowed, GOVERNANCE only with bypass.
- Retention/legal hold can only be set on an Object-Lock-enabled bucket (else 400 `InvalidRequest`); versioning cannot be suspended on such a bucket (409 `InvalidBucketState`).
- Blocked delete/overwrite → 403 `AccessDenied`.

## Wire surface

- `?retention` and `?legal-hold` object sub-resources (GET/PUT).
- `x-amz-object-lock-mode` / `-retain-until-date` / `-legal-hold` headers on `PutObject`, echoed on GET/HEAD.
- `x-amz-bucket-object-lock-enabled: true` on `CreateBucket` enables object lock + versioning.
- `x-amz-bypass-governance-retention` honored on `DeleteObject` and batch `DeleteObjects`.

## Design

New optional `driver.ObjectLockBucket` capability (discovered by type assertion, layered on `VersionedBucket`) so only S3 implements it. Enforcement is atomic under the provider's `versionsMu` — no check-then-act gap. Uses `config.Clock` for retain-until comparison. Retention/legal-hold state and the object-lock-enabled flag survive snapshot/restore.

## Tests

- Provider-level (`providers/aws/s3/object_lock_test.go`): COMPLIANCE/GOVERNANCE/legal-hold blocking on explicit-version and top-level (unversioned + suspended) deletes, FakeClock expiry, bypass semantics, overwrite protection, top-level delete marker on enabled buckets, retention-modification rules, suspend-rejected, retention-requires-lock-bucket, snapshot round-trip.
- Real-SDK end-to-end (`server/aws/s3/object_lock_sdk_test.go`) with aws-sdk-go-v2: object-lock bucket create, COMPLIANCE delete blocked then allowed after FakeClock advance, GOVERNANCE bypass, legal hold on/off, top-level delete marker, suspend → InvalidBucketState, retention on non-lock bucket → InvalidRequest.

## Deferred

Bucket default-retention auto-application onto new object versions (bucket-level `ObjectLockConfiguration` default) — the config round-trips via RawBucketConfig but is not auto-stamped; explicit per-object retention (headers + `?retention`) is the enforced path.
