### PR TITLE
feat(memorydb): snapshot restore/copy/delete

### DIFF
--- a/providers/aws/memorydb/clusters.go
+++ b/providers/aws/memorydb/clusters.go
@@ -661,16 +661,20 @@ func (m *Mock) FailoverShard(_ context.Context, clusterName, shardName string) (
 	return &out, nil
 }
 
-// ListAllowedNodeTypeUpdates returns the scale-up/scale-down node types.
+// ListAllowedNodeTypeUpdates returns the scale-up/scale-down node types available
+// to the cluster, derived from its current node type's family.
 func (m *Mock) ListAllowedNodeTypeUpdates(_ context.Context, clusterName string) (scaleUp, scaleDown []string, err error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if !m.clusters.Has(clusterName) {
+	c, ok := m.clusters.Get(clusterName)
+	if !ok {
 		return nil, nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", clusterName)
 	}
 
-	return []string{"db.r7g.large", "db.r7g.xlarge"}, []string{"db.t4g.medium"}, nil
+	up, down := allowedNodeTypeUpdates(c.NodeType)
+
+	return up, down, nil
 }
 
 // splitHostPort splits a "host:port" endpoint into its parts.

--- a/providers/aws/memorydb/memorydb_test.go
+++ b/providers/aws/memorydb/memorydb_test.go
@@ -99,11 +99,17 @@ func TestClusterLifecycleAndTopology(t *testing.T) {
 		t.Errorf("FailoverShard: %v", err)
 	}
 
+	// c1 uses the default db.t4g.small — the smallest node in its family, so it
+	// can only scale up (to db.t4g.medium) and has nothing to scale down to.
 	up, down, err := m.ListAllowedNodeTypeUpdates(ctx, "c1")
 	requireNoError(t, err)
 
-	if len(up) == 0 || len(down) == 0 {
-		t.Errorf("node-type updates empty: up=%v down=%v", up, down)
+	if len(up) != 1 || up[0] != "db.t4g.medium" {
+		t.Errorf("scale-up = %v, want [db.t4g.medium]", up)
+	}
+
+	if len(down) != 0 {
+		t.Errorf("scale-down = %v, want empty for the smallest node type", down)
 	}
 
 	// Delete cluster + verify ACL detached.

--- a/providers/aws/memorydb/multi_region.go
+++ b/providers/aws/memorydb/multi_region.go
@@ -150,16 +150,21 @@ func (m *Mock) DeleteMultiRegionCluster(_ context.Context, name string) (*mdbdri
 	return &out, nil
 }
 
-// ListAllowedMultiRegionClusterUpdates returns allowed node-type updates.
+// ListAllowedMultiRegionClusterUpdates returns the node types the multi-region
+// cluster may scale up to, derived from its current node type's family. The
+// multi-region API surfaces scale-up targets only.
 func (m *Mock) ListAllowedMultiRegionClusterUpdates(_ context.Context, name string) ([]string, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if !m.multiRegion.Has(name) {
+	mrc, ok := m.multiRegion.Get(name)
+	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "multi-region cluster %q not found", name)
 	}
 
-	return []string{"db.r7g.large", "db.r7g.xlarge"}, nil
+	scaleUp, _ := allowedNodeTypeUpdates(mrc.NodeType)
+
+	return scaleUp, nil
 }
 
 // DescribeMultiRegionParameterGroups returns the default multi-region parameter

--- a/providers/aws/memorydb/node_types.go
+++ b/providers/aws/memorydb/node_types.go
@@ -1,0 +1,51 @@
+package memorydb
+
+// nodeTypeFamilies returns the MemoryDB node-type families, each ordered from the
+// smallest to the largest node in the family. Scaling in MemoryDB moves a cluster
+// to a different node within the same family, so the allowed scale-up / scale-down
+// targets for a given node type are the entries above / below it in its family.
+//
+// Modeling scaling as within-family is a deliberate simplification: real MemoryDB
+// also permits some cross-family moves, but the family ladder captures the
+// behavior a client depends on — the current type is never offered back, larger
+// types appear only under scale-up, smaller only under scale-down, and the ends of
+// each ladder (the smallest / largest node) correctly offer nothing in one
+// direction.
+func nodeTypeFamilies() [][]string {
+	return [][]string{
+		{"db.t4g.small", "db.t4g.medium"},
+		{
+			"db.r6g.large", "db.r6g.xlarge", "db.r6g.2xlarge", "db.r6g.4xlarge",
+			"db.r6g.8xlarge", "db.r6g.12xlarge", "db.r6g.16xlarge",
+		},
+		{"db.r6gd.xlarge", "db.r6gd.2xlarge", "db.r6gd.4xlarge", "db.r6gd.8xlarge"},
+		{
+			"db.r7g.large", "db.r7g.xlarge", "db.r7g.2xlarge", "db.r7g.4xlarge",
+			"db.r7g.8xlarge", "db.r7g.12xlarge", "db.r7g.16xlarge",
+		},
+	}
+}
+
+// allowedNodeTypeUpdates returns the node types a cluster of the given current
+// node type may scale up to (larger nodes in its family) and scale down to
+// (smaller nodes in its family). A node type outside the known families yields
+// empty lists rather than an error, matching the API's tolerance of custom types.
+// Both results are non-nil so they serialize as JSON arrays.
+func allowedNodeTypeUpdates(current string) (scaleUp, scaleDown []string) {
+	scaleUp, scaleDown = []string{}, []string{}
+
+	for _, fam := range nodeTypeFamilies() {
+		for i, nt := range fam {
+			if nt != current {
+				continue
+			}
+
+			scaleUp = append(scaleUp, fam[i+1:]...)
+			scaleDown = append(scaleDown, fam[:i]...)
+
+			return scaleUp, scaleDown
+		}
+	}
+
+	return scaleUp, scaleDown
+}

--- a/providers/aws/memorydb/node_types_test.go
+++ b/providers/aws/memorydb/node_types_test.go
@@ -1,0 +1,114 @@
+package memorydb
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+func TestAllowedNodeTypeUpdatesFamilyLadder(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  string
+		wantUp   []string
+		wantDown []string
+	}{
+		{
+			name:     "mid-family offers both directions",
+			current:  "db.r6g.xlarge",
+			wantUp:   []string{"db.r6g.2xlarge", "db.r6g.4xlarge", "db.r6g.8xlarge", "db.r6g.12xlarge", "db.r6g.16xlarge"},
+			wantDown: []string{"db.r6g.large"},
+		},
+		{
+			name:     "smallest node scales up only",
+			current:  "db.t4g.small",
+			wantUp:   []string{"db.t4g.medium"},
+			wantDown: []string{},
+		},
+		{
+			name:     "largest node scales down only",
+			current:  "db.r7g.16xlarge",
+			wantUp:   []string{},
+			wantDown: []string{"db.r7g.large", "db.r7g.xlarge", "db.r7g.2xlarge", "db.r7g.4xlarge", "db.r7g.8xlarge", "db.r7g.12xlarge"},
+		},
+		{
+			name:     "unknown node type yields empty non-nil lists",
+			current:  "db.custom.mega",
+			wantUp:   []string{},
+			wantDown: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			up, down := allowedNodeTypeUpdates(tc.current)
+
+			if up == nil || down == nil {
+				t.Fatalf("results must be non-nil: up=%v down=%v", up, down)
+			}
+
+			if slices.Contains(up, tc.current) || slices.Contains(down, tc.current) {
+				t.Errorf("current type %q must not be offered: up=%v down=%v", tc.current, up, down)
+			}
+
+			if !slices.Equal(up, tc.wantUp) {
+				t.Errorf("scale-up = %v, want %v", up, tc.wantUp)
+			}
+
+			if !slices.Equal(down, tc.wantDown) {
+				t.Errorf("scale-down = %v, want %v", down, tc.wantDown)
+			}
+		})
+	}
+}
+
+func TestListAllowedNodeTypeUpdatesUsesClusterNodeType(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "ha", NodeType: "db.r6g.large"}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	up, down, err := m.ListAllowedNodeTypeUpdates(ctx, "ha")
+	requireNoError(t, err)
+
+	if len(down) != 0 {
+		t.Errorf("db.r6g.large is the smallest in its family; scale-down = %v, want empty", down)
+	}
+
+	if !slices.Contains(up, "db.r6g.xlarge") {
+		t.Errorf("scale-up = %v, want it to contain db.r6g.xlarge", up)
+	}
+
+	if _, _, err := m.ListAllowedNodeTypeUpdates(ctx, "missing"); err == nil {
+		t.Error("expected NotFound for a missing cluster")
+	}
+}
+
+func TestListAllowedMultiRegionClusterUpdatesUsesNodeType(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	mrc, err := m.CreateMultiRegionCluster(ctx, mdbdriver.CreateMultiRegionClusterConfig{
+		NameSuffix: "app", NodeType: "db.r7g.large", NumShards: 1,
+	})
+	requireNoError(t, err)
+
+	up, err := m.ListAllowedMultiRegionClusterUpdates(ctx, mrc.Name)
+	requireNoError(t, err)
+
+	if slices.Contains(up, "db.r7g.large") {
+		t.Errorf("scale-up must not offer the current node type: %v", up)
+	}
+
+	if !slices.Contains(up, "db.r7g.xlarge") {
+		t.Errorf("scale-up = %v, want it to contain db.r7g.xlarge", up)
+	}
+
+	if _, err := m.ListAllowedMultiRegionClusterUpdates(ctx, "missing"); err == nil {
+		t.Error("expected NotFound for a missing multi-region cluster")
+	}
+}


### PR DESCRIPTION
## Summary

While auditing the AWS **MemoryDB snapshot** surface for the world-case Database tail, I found snapshots are **already fully complete and correct**: `CreateSnapshot` / `DescribeSnapshots` / `CopySnapshot` / `DeleteSnapshot`, restore-into-a-new-cluster via `CreateCluster` with `SnapshotName` (`applySnapshotShape`), and final-snapshot-on-delete all exist and are deep-copy-safe (`ClusterConfiguration` is all scalar fields; `Tags` cloned via `copyTags`; restore rebuilds shards fresh). No gap there.

So this PR implements the **highest-value remaining real-user-observable MemoryDB gap** the Database audit lists — **G-MDB-2**: `ListAllowedNodeTypeUpdates` (and the multi-region `ListAllowedMultiRegionClusterUpdates`) returned a **hardcoded static list** that ignored the cluster's actual node type. A client on a `db.r6g.large` cluster was told it could scale up to `db.r7g.large`/`db.r7g.xlarge` and down to `db.t4g.medium` — nonsense for that cluster.

(The audit's other two MemoryDB gaps are lower value: G-MDB-1 transient states is **already implemented** via `internal/settle`; G-MDB-3 FailoverShard role-flip is **not observable through the real SDK** — the MemoryDB `Node` shape has no role field — so it fails the real-user-test bar.)

## What changed

- New `providers/aws/memorydb/node_types.go` with a MemoryDB node-type **family catalog** (t4g / r6g / r6gd / r7g, each ordered smallest→largest) and `allowedNodeTypeUpdates(current)`, which returns the larger nodes in the same family as scale-up targets and the smaller ones as scale-down targets.
- `ListAllowedNodeTypeUpdates` now derives its answer from the cluster's real `NodeType`; `ListAllowedMultiRegionClusterUpdates` likewise from the multi-region cluster's `NodeType` (scale-up only, matching the API).
- Correctness properties: the current type is never offered back; the smallest node in a family scales up only; the largest scales down only; an unknown/custom type yields empty (non-nil) lists rather than an error.

## Tests

- New `node_types_test.go`: table-driven family-ladder coverage (mid-family, smallest, largest, unknown) plus both driver methods (real node type in/out, current-type exclusion, NotFound).
- Updated the existing cluster test to assert the correct behavior for the default `db.t4g.small` (scale-up = `db.t4g.medium`, scale-down empty).

## Gates

`go build ./...`, full `go test ./...` (exit 0), `-race` on the two packages, broad `go test ./providers/aws/... ./server/aws/...`, `golangci-lint` on touched packages (0 issues), gofmt clean, coveragegen (no doc diff — behavior change, not a new op), `go mod tidy` clean.
