### PR TITLE
feat(azure-blob): Get Page Ranges + Find Blobs by Tags

### DIFF
--- a/docs/coverage/azure/blobstorage.md
+++ b/docs/coverage/azure/blobstorage.md
@@ -85,6 +85,25 @@ AzureBlobExtensions is an OPTIONAL Azure-specific blob data-plane capability,
 | `SetContainerMetadata` | SetContainerMetadata replaces a container's metadata (Set Container |
 | `StageBlock` | StageBlock buffers an uncommitted block (Put Block, ?comp=block) for a blob |
 
+### AzureFindBlobsByTags
+
+AzureFindBlobsByTags is an OPTIONAL Azure-specific capability, discovered by
+
+| Operation | Description |
+| --- | --- |
+| `FindBlobsByTags` |  |
+
+### AzurePageBlob
+
+AzurePageBlob is an OPTIONAL Azure-specific capability, discovered by type
+
+| Operation | Description |
+| --- | --- |
+| `ClearPage` | ClearPage zeroes the inclusive byte range [start,end] of a page blob and |
+| `CreatePageBlob` | CreatePageBlob creates an empty page blob of size bytes (a multiple of 512) |
+| `GetPageRanges` | GetPageRanges returns the page blob's written ranges (Get Page Ranges, |
+| `PutPage` | PutPage writes data over the inclusive byte range [start,end] of a page blob |
+
 ### AzureSoftDeleteBlob
 
 AzureSoftDeleteBlob is an OPTIONAL Azure-specific capability, discovered by

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -12531,6 +12531,37 @@
         ]
       },
       {
+        "name": "AzureFindBlobsByTags",
+        "doc": "AzureFindBlobsByTags is an OPTIONAL Azure-specific capability, discovered by",
+        "operations": [
+          {
+            "name": "FindBlobsByTags"
+          }
+        ]
+      },
+      {
+        "name": "AzurePageBlob",
+        "doc": "AzurePageBlob is an OPTIONAL Azure-specific capability, discovered by type",
+        "operations": [
+          {
+            "name": "ClearPage",
+            "doc": "ClearPage zeroes the inclusive byte range [start,end] of a page blob and"
+          },
+          {
+            "name": "CreatePageBlob",
+            "doc": "CreatePageBlob creates an empty page blob of size bytes (a multiple of 512)"
+          },
+          {
+            "name": "GetPageRanges",
+            "doc": "GetPageRanges returns the page blob's written ranges (Get Page Ranges,"
+          },
+          {
+            "name": "PutPage",
+            "doc": "PutPage writes data over the inclusive byte range [start,end] of a page blob"
+          }
+        ]
+      },
+      {
         "name": "AzureSoftDeleteBlob",
         "doc": "AzureSoftDeleteBlob is an OPTIONAL Azure-specific capability, discovered by",
         "operations": [

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -84,6 +84,11 @@ type blobObject struct {
 	mu sync.Mutex
 	// appendBlocks counts committed Append Block operations (append blobs only).
 	appendBlocks int
+	// pages tracks which 512-byte pages of a page blob currently hold written
+	// (non-cleared) data, keyed by zero-based page index. nil for non-page blobs.
+	// Get Page Ranges coalesces the set into contiguous byte ranges; Put Page adds
+	// indices and Clear Page removes them. Guarded by mu alongside Data.
+	pages map[int64]bool
 
 	// Lease Blob state. leaseState is one of leaseStateAvailable (""),
 	// leaseStateLeased, leaseStateBreaking, or leaseStateBroken; a "leased" or

--- a/providers/azure/blobstorage/findblobs.go
+++ b/providers/azure/blobstorage/findblobs.go
@@ -1,0 +1,86 @@
+package blobstorage
+
+import (
+	"context"
+	"maps"
+	"sort"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// Compile-time check that Mock satisfies the optional AzureFindBlobsByTags
+// capability the blob wire handler reaches by type assertion.
+var _ driver.AzureFindBlobsByTags = (*Mock)(nil)
+
+// FindBlobsByTags returns every live blob whose index tags satisfy all of the
+// equality conditions in match. A blank container searches the whole account;
+// otherwise the search is scoped to that one container. Results are ordered by
+// container then blob name so a listing is deterministic.
+func (m *Mock) FindBlobsByTags(_ context.Context, container string, match map[string]string) ([]driver.TaggedBlob, error) {
+	var names []string
+
+	if container == "" {
+		names = m.containers.Keys()
+	} else {
+		if _, ok := m.containers.Get(container); !ok {
+			return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
+		}
+
+		names = []string{container}
+	}
+
+	sort.Strings(names)
+
+	var out []driver.TaggedBlob
+
+	for _, name := range names {
+		ctr, ok := m.containers.Get(name)
+		if !ok {
+			continue
+		}
+
+		out = append(out, matchingBlobs(name, ctr, match)...)
+	}
+
+	return out, nil
+}
+
+// matchingBlobs collects the live blobs in one container whose tags satisfy
+// every condition in match, ordered by blob name.
+func matchingBlobs(container string, ctr *containerMeta, match map[string]string) []driver.TaggedBlob {
+	keys := ctr.objects.Keys()
+	sort.Strings(keys)
+
+	var out []driver.TaggedBlob
+
+	for _, key := range keys {
+		obj, ok := ctr.objects.Get(key)
+		if !ok || !tagsSatisfy(obj.Tags, match) {
+			continue
+		}
+
+		out = append(out, driver.TaggedBlob{
+			Container: container, Name: key, Tags: maps.Clone(obj.Tags),
+		})
+	}
+
+	return out
+}
+
+// tagsSatisfy reports whether tags contains every key/value pair in match. An
+// empty match is satisfied by any blob that carries at least one tag (Azure's
+// Find Blobs by Tags only ever returns tagged blobs).
+func tagsSatisfy(tags, match map[string]string) bool {
+	if len(tags) == 0 {
+		return false
+	}
+
+	for k, v := range match {
+		if tags[k] != v {
+			return false
+		}
+	}
+
+	return true
+}

--- a/providers/azure/blobstorage/findblobs_test.go
+++ b/providers/azure/blobstorage/findblobs_test.go
@@ -1,0 +1,61 @@
+package blobstorage
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindBlobsByTags(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+	require.NoError(t, m.CreateBucket(ctx, "c2"))
+
+	put := func(container, key string, tags map[string]string) {
+		require.NoError(t, m.PutObject(ctx, container, key, []byte("x"), "text/plain", nil))
+		if tags != nil {
+			require.NoError(t, m.PutObjectTagging(ctx, container, key, tags))
+		}
+	}
+
+	put("c1", "a", map[string]string{"env": "prod", "team": "red"})
+	put("c1", "b", map[string]string{"env": "dev"})
+	put("c1", "notag", nil)
+	put("c2", "c", map[string]string{"env": "prod"})
+
+	refs := func(container string, match map[string]string) []string {
+		res, err := m.FindBlobsByTags(ctx, container, match)
+		require.NoError(t, err)
+
+		out := make([]string, 0, len(res))
+		for _, b := range res {
+			out = append(out, b.Container+"/"+b.Name)
+		}
+
+		sort.Strings(out)
+
+		return out
+	}
+
+	// Account-wide env=prod spans both containers.
+	assert.Equal(t, []string{"c1/a", "c2/c"}, refs("", map[string]string{"env": "prod"}))
+
+	// Multi-term AND narrows to one blob.
+	assert.Equal(t, []string{"c1/a"}, refs("", map[string]string{"env": "prod", "team": "red"}))
+
+	// Container-scoped search.
+	assert.Equal(t, []string{"c1/a"}, refs("c1", map[string]string{"env": "prod"}))
+
+	// An untagged blob never matches an empty query.
+	all := refs("c1", map[string]string{})
+	assert.NotContains(t, all, "c1/notag")
+	assert.ElementsMatch(t, []string{"c1/a", "c1/b"}, all)
+
+	// Unknown container errors.
+	_, err := m.FindBlobsByTags(ctx, "missing", map[string]string{"env": "prod"})
+	require.Error(t, err)
+}

--- a/providers/azure/blobstorage/pageblob.go
+++ b/providers/azure/blobstorage/pageblob.go
@@ -1,0 +1,230 @@
+package blobstorage
+
+import (
+	"context"
+	"maps"
+	"net/http"
+	"sort"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+const (
+	// blobTypePage is the Azure page-blob type.
+	blobTypePage = "PageBlob"
+	// pageSize is the fixed Azure page-blob page size, in bytes. Page blobs are
+	// created at a size that is a multiple of it and every Put Page / Clear Page
+	// range must be aligned to it.
+	pageSize = 512
+)
+
+// Compile-time check that Mock satisfies the optional AzurePageBlob capability
+// the blob wire handler reaches by type assertion.
+var _ driver.AzurePageBlob = (*Mock)(nil)
+
+// CreatePageBlob creates an empty page blob of size bytes, all pages zeroed.
+func (m *Mock) CreatePageBlob(
+	_ context.Context, container, blob string, size int64, props *driver.BlobProperties, metadata map[string]string,
+) (*driver.ObjectInfo, error) {
+	ctr, ok := m.containers.Get(container)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
+	}
+
+	if size < 0 || size%pageSize != 0 {
+		return nil, &driver.BlobOpError{
+			Status: http.StatusBadRequest, Code: "InvalidHeaderValue",
+			Message: "x-ms-blob-content-length must be a non-negative multiple of 512",
+		}
+	}
+
+	contentType := octetStream
+	if props != nil && props.ContentType != "" {
+		contentType = props.ContentType
+	}
+
+	obj := &blobObject{
+		Key: blob, Data: make([]byte, size), Size: size, ContentType: contentType,
+		LastModified: m.opts.Clock.Now().UTC().Format(blobTimeFormat),
+		Metadata:     maps.Clone(metadata), BlobType: blobTypePage,
+		pages: make(map[int64]bool),
+	}
+
+	if props != nil {
+		obj.ContentEncoding = props.ContentEncoding
+		obj.ContentLanguage = props.ContentLanguage
+		obj.ContentDisposition = props.ContentDisposition
+		obj.CacheControl = props.CacheControl
+	}
+
+	obj.ETag = computeBlobETag(obj)
+
+	m.carryOverLease(ctr, blob, obj)
+	m.recordVersion(ctr, obj)
+	ctr.objects.Set(blob, obj)
+
+	info := objectInfo(obj)
+
+	return &info, nil
+}
+
+// PutPage writes data over the inclusive byte range [start,end] of a page blob.
+func (m *Mock) PutPage(
+	_ context.Context, container, blob string, start, end int64, data []byte,
+) (*driver.ObjectInfo, error) {
+	ctr, obj, err := m.pageBlob(container, blob)
+	if err != nil {
+		return nil, err
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	if err := validatePageRange(start, end, obj.Size); err != nil {
+		return nil, err
+	}
+
+	if int64(len(data)) != end-start+1 {
+		return nil, &driver.BlobOpError{
+			Status: http.StatusBadRequest, Code: "InvalidHeaderValue",
+			Message: "Content-Length does not match the x-ms-range span",
+		}
+	}
+
+	copy(obj.Data[start:end+1], data)
+	setPages(obj, start, end, true)
+
+	m.finishPageWrite(ctr, container, obj, int64(len(data)))
+
+	out := objectInfo(obj)
+
+	return &out, nil
+}
+
+// ClearPage zeroes the inclusive byte range [start,end] of a page blob.
+func (m *Mock) ClearPage(_ context.Context, container, blob string, start, end int64) (*driver.ObjectInfo, error) {
+	ctr, obj, err := m.pageBlob(container, blob)
+	if err != nil {
+		return nil, err
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	if err := validatePageRange(start, end, obj.Size); err != nil {
+		return nil, err
+	}
+
+	for i := start; i <= end; i++ {
+		obj.Data[i] = 0
+	}
+
+	setPages(obj, start, end, false)
+
+	m.finishPageWrite(ctr, container, obj, 0)
+
+	out := objectInfo(obj)
+
+	return &out, nil
+}
+
+// GetPageRanges returns the page blob's written ranges (ordered, coalesced) and
+// its total size.
+func (m *Mock) GetPageRanges(_ context.Context, container, blob string) ([]driver.PageRange, int64, error) {
+	_, obj, err := m.pageBlob(container, blob)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	return coalescePages(obj.pages), obj.Size, nil
+}
+
+// pageBlob fetches a container and one of its live page blobs, erroring if the
+// container or blob is absent or the blob is not a page blob.
+func (m *Mock) pageBlob(container, blob string) (*containerMeta, *blobObject, error) {
+	ctr, obj, err := m.getContainerBlob(container, blob)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if obj.BlobType != blobTypePage {
+		return nil, nil, &driver.BlobOpError{
+			Status: http.StatusConflict, Code: "InvalidBlobType",
+			Message: "The blob type is invalid for this operation.",
+		}
+	}
+
+	return ctr, obj, nil
+}
+
+// finishPageWrite stamps the blob's last-modified/ETag, records a version, and
+// emits a transaction metric after a Put Page / Clear Page mutation. The caller
+// must hold obj.mu.
+func (m *Mock) finishPageWrite(ctr *containerMeta, container string, obj *blobObject, ingress int64) {
+	obj.LastModified = m.opts.Clock.Now().UTC().Format(blobTimeFormat)
+	obj.ETag = computeBlobETag(obj)
+
+	m.recordVersion(ctr, obj)
+	m.emitMetric(container, map[string]float64{"Transactions": 1, "Ingress": float64(ingress)})
+}
+
+// validatePageRange enforces the Azure page-range rules: start/end aligned to
+// the 512-byte page boundary and the whole range inside the blob.
+func validatePageRange(start, end, size int64) error {
+	if start < 0 || end < start || start%pageSize != 0 || (end+1)%pageSize != 0 || end >= size {
+		return &driver.BlobOpError{
+			Status: http.StatusRequestedRangeNotSatisfiable, Code: "InvalidPageRange",
+			Message: "The page range specified is invalid.",
+		}
+	}
+
+	return nil
+}
+
+// setPages marks (or clears) every page index covered by the inclusive byte
+// range [start,end] in obj.pages. The caller must hold obj.mu.
+func setPages(obj *blobObject, start, end int64, written bool) {
+	for page := start / pageSize; page <= end/pageSize; page++ {
+		if written {
+			obj.pages[page] = true
+		} else {
+			delete(obj.pages, page)
+		}
+	}
+}
+
+// coalescePages turns the set of written page indices into contiguous byte
+// ranges ordered by Start, merging adjacent pages into a single range.
+func coalescePages(pages map[int64]bool) []driver.PageRange {
+	if len(pages) == 0 {
+		return nil
+	}
+
+	idx := make([]int64, 0, len(pages))
+	for page := range pages {
+		idx = append(idx, page)
+	}
+
+	sort.Slice(idx, func(i, j int) bool { return idx[i] < idx[j] })
+
+	var ranges []driver.PageRange
+
+	runStart, prev := idx[0], idx[0]
+	for _, page := range idx[1:] {
+		if page == prev+1 {
+			prev = page
+			continue
+		}
+
+		ranges = append(ranges, driver.PageRange{Start: runStart * pageSize, End: (prev+1)*pageSize - 1})
+		runStart, prev = page, page
+	}
+
+	ranges = append(ranges, driver.PageRange{Start: runStart * pageSize, End: (prev+1)*pageSize - 1})
+
+	return ranges
+}

--- a/providers/azure/blobstorage/pageblob_test.go
+++ b/providers/azure/blobstorage/pageblob_test.go
@@ -1,0 +1,111 @@
+package blobstorage
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPageBlobCreateAndGetRanges(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+
+	info, err := m.CreatePageBlob(ctx, "c1", "pb", 2048, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2048), info.Size)
+	assert.Equal(t, blobTypePage, info.BlobType)
+
+	ranges, size, err := m.GetPageRanges(ctx, "c1", "pb")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2048), size)
+	assert.Empty(t, ranges)
+
+	// Write two non-adjacent pages: 0-511 and 1024-1535.
+	_, err = m.PutPage(ctx, "c1", "pb", 0, 511, bytes.Repeat([]byte{1}, 512))
+	require.NoError(t, err)
+	_, err = m.PutPage(ctx, "c1", "pb", 1024, 1535, bytes.Repeat([]byte{2}, 512))
+	require.NoError(t, err)
+
+	ranges, _, err = m.GetPageRanges(ctx, "c1", "pb")
+	require.NoError(t, err)
+	require.Len(t, ranges, 2)
+	assert.Equal(t, int64(0), ranges[0].Start)
+	assert.Equal(t, int64(511), ranges[0].End)
+	assert.Equal(t, int64(1024), ranges[1].Start)
+	assert.Equal(t, int64(1535), ranges[1].End)
+
+	// Content reflects the writes over a zero background.
+	obj, err := m.GetObject(ctx, "c1", "pb")
+	require.NoError(t, err)
+	require.Len(t, obj.Data, 2048)
+	assert.Equal(t, bytes.Repeat([]byte{1}, 512), obj.Data[0:512])
+	assert.Equal(t, make([]byte, 512), obj.Data[512:1024])
+	assert.Equal(t, bytes.Repeat([]byte{2}, 512), obj.Data[1024:1536])
+}
+
+func TestPageBlobClearAndCoalesce(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+	_, err := m.CreatePageBlob(ctx, "c1", "pb", 2048, nil, nil)
+	require.NoError(t, err)
+
+	// Two adjacent pages coalesce into one range.
+	_, err = m.PutPage(ctx, "c1", "pb", 0, 511, bytes.Repeat([]byte{1}, 512))
+	require.NoError(t, err)
+	_, err = m.PutPage(ctx, "c1", "pb", 512, 1023, bytes.Repeat([]byte{1}, 512))
+	require.NoError(t, err)
+
+	ranges, _, err := m.GetPageRanges(ctx, "c1", "pb")
+	require.NoError(t, err)
+	require.Len(t, ranges, 1)
+	assert.Equal(t, int64(0), ranges[0].Start)
+	assert.Equal(t, int64(1023), ranges[0].End)
+
+	// Clearing the first page splits the run and zeroes those bytes.
+	_, err = m.ClearPage(ctx, "c1", "pb", 0, 511)
+	require.NoError(t, err)
+
+	ranges, _, err = m.GetPageRanges(ctx, "c1", "pb")
+	require.NoError(t, err)
+	require.Len(t, ranges, 1)
+	assert.Equal(t, int64(512), ranges[0].Start)
+	assert.Equal(t, int64(1023), ranges[0].End)
+
+	obj, err := m.GetObject(ctx, "c1", "pb")
+	require.NoError(t, err)
+	assert.Equal(t, make([]byte, 512), obj.Data[0:512])
+}
+
+func TestPageBlobValidation(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+
+	// Non-512-multiple size is rejected.
+	_, err := m.CreatePageBlob(ctx, "c1", "bad", 1000, nil, nil)
+	require.Error(t, err)
+
+	_, err = m.CreatePageBlob(ctx, "c1", "pb", 1024, nil, nil)
+	require.NoError(t, err)
+
+	// Misaligned range is rejected.
+	_, err = m.PutPage(ctx, "c1", "pb", 10, 521, bytes.Repeat([]byte{1}, 512))
+	require.Error(t, err)
+
+	// Out-of-bounds range is rejected.
+	_, err = m.PutPage(ctx, "c1", "pb", 1024, 1535, bytes.Repeat([]byte{1}, 512))
+	require.Error(t, err)
+
+	// A page op on a non-page (block) blob is rejected.
+	require.NoError(t, m.PutObject(ctx, "c1", "block", []byte("x"), "text/plain", nil))
+	_, err = m.PutPage(ctx, "c1", "block", 0, 511, bytes.Repeat([]byte{1}, 512))
+	require.Error(t, err)
+
+	_, _, err = m.GetPageRanges(ctx, "c1", "block")
+	require.Error(t, err)
+}

--- a/providers/azure/blobstorage/pageblob_test.go
+++ b/providers/azure/blobstorage/pageblob_test.go
@@ -81,6 +81,44 @@ func TestPageBlobClearAndCoalesce(t *testing.T) {
 	assert.Equal(t, make([]byte, 512), obj.Data[0:512])
 }
 
+func TestPageBlobRangesSurviveSnapshotRestore(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+	_, err := m.CreatePageBlob(ctx, "c1", "pb", 2048, nil, nil)
+	require.NoError(t, err)
+
+	// Two non-adjacent written ranges plus distinct page contents.
+	_, err = m.PutPage(ctx, "c1", "pb", 0, 511, bytes.Repeat([]byte{0xAB}, 512))
+	require.NoError(t, err)
+	_, err = m.PutPage(ctx, "c1", "pb", 1024, 1535, bytes.Repeat([]byte{0xCD}, 512))
+	require.NoError(t, err)
+
+	before, _, err := m.GetPageRanges(ctx, "c1", "pb")
+	require.NoError(t, err)
+	require.Len(t, before, 2)
+
+	data, err := m.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	restored := newTestMock()
+	require.NoError(t, restored.Restore(ctx, data))
+
+	// The written-range map survives the round-trip: exactly the same two ranges.
+	after, size, err := restored.GetPageRanges(ctx, "c1", "pb")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2048), size)
+	assert.Equal(t, before, after)
+
+	// And the bytes match.
+	obj, err := restored.GetObject(ctx, "c1", "pb")
+	require.NoError(t, err)
+	require.Len(t, obj.Data, 2048)
+	assert.Equal(t, bytes.Repeat([]byte{0xAB}, 512), obj.Data[0:512])
+	assert.Equal(t, make([]byte, 512), obj.Data[512:1024])
+	assert.Equal(t, bytes.Repeat([]byte{0xCD}, 512), obj.Data[1024:1536])
+}
+
 func TestPageBlobValidation(t *testing.T) {
 	ctx := context.Background()
 	m := newTestMock()

--- a/providers/azure/blobstorage/snapshot.go
+++ b/providers/azure/blobstorage/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
@@ -69,6 +70,7 @@ type blobObjectSnapshot struct {
 	CacheControl          string             `json:"cacheControl,omitempty"`
 	CommittedBlocks       []driver.BlockInfo `json:"committedBlocks,omitempty"`
 	AppendBlocks          int                `json:"appendBlocks,omitempty"`
+	Pages                 map[int64]bool     `json:"pages,omitempty"`
 	LeaseState            string             `json:"leaseState,omitempty"`
 	LeaseID               string             `json:"leaseId,omitempty"`
 	LeaseDurationSec      int32              `json:"leaseDurationSec,omitempty"`
@@ -168,6 +170,7 @@ func snapshotBlob(obj *blobObject, includeAssets bool) *blobObjectSnapshot {
 		DeletedTime: obj.DeletedTime, DeletedRetentionDays: obj.deletedRetentionDays,
 		ContentLanguage: obj.ContentLanguage, ContentDisposition: obj.ContentDisposition,
 		CacheControl: obj.CacheControl, CommittedBlocks: obj.CommittedBlocks, AppendBlocks: obj.appendBlocks,
+		Pages:      maps.Clone(obj.pages),
 		LeaseState: obj.leaseState, LeaseID: obj.leaseID, LeaseDurationSec: obj.leaseDurationSec,
 		LeaseExpiresAt: obj.leaseExpiresAt, LeaseBreakAt: obj.leaseBreakAt,
 		LeaseModTimeAtAcquire: obj.leaseModTimeAtAcquire,
@@ -257,6 +260,7 @@ func restoreBlob(os *blobObjectSnapshot) *blobObject {
 		DeletedTime: os.DeletedTime, deletedRetentionDays: os.DeletedRetentionDays,
 		ContentLanguage: os.ContentLanguage, ContentDisposition: os.ContentDisposition,
 		CacheControl: os.CacheControl, CommittedBlocks: os.CommittedBlocks, appendBlocks: os.AppendBlocks,
+		pages:      maps.Clone(os.Pages),
 		leaseState: os.LeaseState, leaseID: os.LeaseID, leaseDurationSec: os.LeaseDurationSec,
 		leaseExpiresAt: os.LeaseExpiresAt, leaseBreakAt: os.LeaseBreakAt,
 		leaseModTimeAtAcquire: os.LeaseModTimeAtAcquire,

--- a/providers/azure/blobstorage/versioning.go
+++ b/providers/azure/blobstorage/versioning.go
@@ -67,6 +67,7 @@ func cloneBlobObject(obj *blobObject) *blobObject {
 		ContentDisposition: obj.ContentDisposition, CacheControl: obj.CacheControl,
 		CommittedBlocks: append([]driver.BlockInfo(nil), obj.CommittedBlocks...),
 		appendBlocks:    obj.appendBlocks,
+		pages:           maps.Clone(obj.pages),
 	}
 }
 

--- a/server/azure/blobstorage/blob_findbytags_test.go
+++ b/server/azure/blobstorage/blob_findbytags_test.go
@@ -1,0 +1,165 @@
+package blobstorage_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKFindBlobsByTags drives the real azblob client through Find Blobs by
+// Tags at both the account and container scope, asserting the ?where tag query
+// returns exactly the blobs whose index tags match — including a multi-term AND
+// query and an @container-scoped account query.
+func TestSDKFindBlobsByTags(t *testing.T) {
+	ctx := context.Background()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{BlobStorage: cloudP.BlobStorage})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	clientOpts := &azblob.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: ts.Client(), Retry: policy.RetryOptions{MaxRetries: -1}},
+	}
+
+	svcClient, err := azblob.NewClientWithNoCredential(ts.URL+"/", clientOpts)
+	if err != nil {
+		t.Fatalf("NewClientWithNoCredential: %v", err)
+	}
+
+	for _, c := range []string{"c1", "c2"} {
+		if _, err := svcClient.CreateContainer(ctx, c, nil); err != nil {
+			t.Fatalf("CreateContainer %s: %v", c, err)
+		}
+	}
+
+	putTagged(t, ctx, svcClient, "c1", "a", map[string]string{"env": "prod", "team": "red"})
+	putTagged(t, ctx, svcClient, "c1", "b", map[string]string{"env": "dev"})
+	putTagged(t, ctx, svcClient, "c1", "notag", nil)
+	putTagged(t, ctx, svcClient, "c2", "c", map[string]string{"env": "prod"})
+
+	svc := svcClient.ServiceClient()
+
+	// Account-scoped: env=prod spans both containers.
+	assertFound(t, filterService(t, ctx, svc, `"env"='prod'`), []string{"c1/a", "c2/c"})
+
+	// Account-scoped multi-term AND narrows to the single blob with both tags.
+	assertFound(t, filterService(t, ctx, svc, `"env"='prod' AND "team"='red'`), []string{"c1/a"})
+
+	// A blob that carries no tags never matches.
+	assertFound(t, filterService(t, ctx, svc, `"env"='dev'`), []string{"c1/b"})
+
+	// @container narrows an account query to one container.
+	assertFound(t, filterService(t, ctx, svc, `@container='c2' AND "env"='prod'`), []string{"c2/c"})
+
+	// Container-scoped Find Blobs searches only that container.
+	assertFound(t, filterContainer(t, ctx, svc, "c1", `"env"='prod'`), []string{"c1/a"})
+	assertFound(t, filterContainer(t, ctx, svc, "c2", `"env"='prod'`), []string{"c2/c"})
+
+	// The matched blob carries its full tag set in the response.
+	res := filterService(t, ctx, svc, `"team"='red'`)
+	if len(res) != 1 {
+		t.Fatalf("team=red matched %d blobs, want 1", len(res))
+	}
+
+	if got := res[0].tags["env"]; got != "prod" {
+		t.Fatalf("matched blob env tag = %q, want prod", got)
+	}
+}
+
+type matchedBlob struct {
+	ref  string // "container/name"
+	tags map[string]string
+}
+
+func putTagged(t *testing.T, ctx context.Context, c *azblob.Client, container, blob string, tags map[string]string) {
+	t.Helper()
+
+	if _, err := c.UploadBuffer(ctx, container, blob, []byte("body-"+blob), nil); err != nil {
+		t.Fatalf("upload %s/%s: %v", container, blob, err)
+	}
+
+	if len(tags) == 0 {
+		return
+	}
+
+	bc := c.ServiceClient().NewContainerClient(container).NewBlobClient(blob)
+	if _, err := bc.SetTags(ctx, tags, nil); err != nil {
+		t.Fatalf("set tags %s/%s: %v", container, blob, err)
+	}
+}
+
+func filterService(t *testing.T, ctx context.Context, svc *service.Client, where string) []matchedBlob {
+	t.Helper()
+
+	resp, err := svc.FilterBlobs(ctx, where, nil)
+	if err != nil {
+		t.Fatalf("service FilterBlobs %q: %v", where, err)
+	}
+
+	return collectFilter(resp.Blobs)
+}
+
+func filterContainer(t *testing.T, ctx context.Context, svc *service.Client, container, where string) []matchedBlob {
+	t.Helper()
+
+	resp, err := svc.NewContainerClient(container).FilterBlobs(ctx, where, nil)
+	if err != nil {
+		t.Fatalf("container FilterBlobs %s %q: %v", container, where, err)
+	}
+
+	return collectFilter(resp.Blobs)
+}
+
+func collectFilter(items []*service.FilterBlobItem) []matchedBlob {
+	out := make([]matchedBlob, 0, len(items))
+
+	for _, it := range items {
+		mb := matchedBlob{tags: map[string]string{}}
+		if it.ContainerName != nil && it.Name != nil {
+			mb.ref = *it.ContainerName + "/" + *it.Name
+		}
+
+		if it.Tags != nil {
+			for _, tag := range it.Tags.BlobTagSet {
+				if tag.Key != nil && tag.Value != nil {
+					mb.tags[*tag.Key] = *tag.Value
+				}
+			}
+		}
+
+		out = append(out, mb)
+	}
+
+	return out
+}
+
+func assertFound(t *testing.T, got []matchedBlob, want []string) {
+	t.Helper()
+
+	refs := make([]string, 0, len(got))
+	for _, b := range got {
+		refs = append(refs, b.ref)
+	}
+
+	sort.Strings(refs)
+	sort.Strings(want)
+
+	if len(refs) != len(want) {
+		t.Fatalf("matched %v, want %v", refs, want)
+	}
+
+	for i := range want {
+		if refs[i] != want[i] {
+			t.Fatalf("matched %v, want %v", refs, want)
+		}
+	}
+}

--- a/server/azure/blobstorage/blob_pageblob_test.go
+++ b/server/azure/blobstorage/blob_pageblob_test.go
@@ -1,0 +1,222 @@
+package blobstorage_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/pageblob"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKPageBlobGetPageRanges drives the real azblob page-blob client through a
+// create → write two non-adjacent pages → Get Page Ranges → clear one → re-read
+// lifecycle, asserting the reported ranges match exactly the written pages.
+func TestSDKPageBlobGetPageRanges(t *testing.T) {
+	ctx := context.Background()
+
+	cloudP := cloudemu.NewAzure()
+
+	srv := azureserver.New(azureserver.Drivers{BlobStorage: cloudP.BlobStorage})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	clientOpts := &azblob.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	svcClient, err := azblob.NewClientWithNoCredential(ts.URL+"/", clientOpts)
+	if err != nil {
+		t.Fatalf("NewClientWithNoCredential: %v", err)
+	}
+
+	if _, err := svcClient.CreateContainer(ctx, "c1", nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	pbOpts := &pageblob.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	pbClient, err := pageblob.NewClientWithNoCredential(ts.URL+"/c1/pb1", pbOpts)
+	if err != nil {
+		t.Fatalf("pageblob NewClientWithNoCredential: %v", err)
+	}
+
+	// A 2048-byte page blob is four 512-byte pages, all zero, no ranges yet.
+	const blobSize = 2048
+	if _, err := pbClient.Create(ctx, blobSize, nil); err != nil {
+		t.Fatalf("Create page blob: %v", err)
+	}
+
+	if got := getPageRanges(t, ctx, pbClient); len(got) != 0 {
+		t.Fatalf("fresh page blob has %d ranges, want 0", len(got))
+	}
+
+	// Write page 0 (bytes 0-511) and page 2 (bytes 1024-1535): two non-adjacent
+	// runs, so Get Page Ranges must report exactly two ranges.
+	page0 := bytes.Repeat([]byte{0xAB}, 512)
+	page2 := bytes.Repeat([]byte{0xCD}, 512)
+
+	uploadPage(t, ctx, pbClient, 0, page0)
+	uploadPage(t, ctx, pbClient, 1024, page2)
+
+	ranges := getPageRanges(t, ctx, pbClient)
+	wantTwo := []pageblob.PageRange{
+		{Start: ptr64(0), End: ptr64(511)},
+		{Start: ptr64(1024), End: ptr64(1535)},
+	}
+	assertRanges(t, ranges, wantTwo)
+
+	// The blob content reflects both written pages over a zero background.
+	assertPageBlobBody(t, ctx, svcClient, page0, page2)
+
+	// Clearing page 0 leaves only the page-2 range.
+	if _, err := pbClient.ClearPages(ctx, blob.HTTPRange{Offset: 0, Count: 512}, nil); err != nil {
+		t.Fatalf("ClearPages: %v", err)
+	}
+
+	assertRanges(t, getPageRanges(t, ctx, pbClient), []pageblob.PageRange{
+		{Start: ptr64(1024), End: ptr64(1535)},
+	})
+
+	// Page 0 now reads back as zeros; page 2 is untouched.
+	assertPageBlobBody(t, ctx, svcClient, make([]byte, 512), page2)
+}
+
+// TestSDKPageBlobAdjacentPagesCoalesce verifies that two adjacent written pages
+// are reported as a single coalesced range, matching real Azure.
+func TestSDKPageBlobAdjacentPagesCoalesce(t *testing.T) {
+	ctx := context.Background()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{BlobStorage: cloudP.BlobStorage})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	pbOpts := &pageblob.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: ts.Client(), Retry: policy.RetryOptions{MaxRetries: -1}},
+	}
+
+	svcClient, err := azblob.NewClientWithNoCredential(ts.URL+"/",
+		&azblob.ClientOptions{ClientOptions: policy.ClientOptions{Transport: ts.Client(), Retry: policy.RetryOptions{MaxRetries: -1}}})
+	if err != nil {
+		t.Fatalf("NewClientWithNoCredential: %v", err)
+	}
+
+	if _, err := svcClient.CreateContainer(ctx, "c1", nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	pbClient, err := pageblob.NewClientWithNoCredential(ts.URL+"/c1/pb1", pbOpts)
+	if err != nil {
+		t.Fatalf("pageblob NewClientWithNoCredential: %v", err)
+	}
+
+	if _, err := pbClient.Create(ctx, 2048, nil); err != nil {
+		t.Fatalf("Create page blob: %v", err)
+	}
+
+	uploadPage(t, ctx, pbClient, 0, bytes.Repeat([]byte{1}, 512))
+	uploadPage(t, ctx, pbClient, 512, bytes.Repeat([]byte{2}, 512))
+
+	assertRanges(t, getPageRanges(t, ctx, pbClient), []pageblob.PageRange{
+		{Start: ptr64(0), End: ptr64(1023)},
+	})
+}
+
+func uploadPage(t *testing.T, ctx context.Context, c *pageblob.Client, offset int64, data []byte) {
+	t.Helper()
+
+	body := streaming.NopCloser(bytes.NewReader(data))
+	if _, err := c.UploadPages(ctx, body, blob.HTTPRange{Offset: offset, Count: int64(len(data))}, nil); err != nil {
+		t.Fatalf("UploadPages at %d: %v", offset, err)
+	}
+}
+
+func getPageRanges(t *testing.T, ctx context.Context, c *pageblob.Client) []*pageblob.PageRange {
+	t.Helper()
+
+	pager := c.NewGetPageRangesPager(nil)
+
+	var out []*pageblob.PageRange
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("GetPageRanges: %v", err)
+		}
+
+		out = append(out, page.PageRange...)
+	}
+
+	return out
+}
+
+func assertRanges(t *testing.T, got []*pageblob.PageRange, want []pageblob.PageRange) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d page ranges, want %d: %+v", len(got), len(want), dumpRanges(got))
+	}
+
+	for i, w := range want {
+		if got[i].Start == nil || got[i].End == nil || *got[i].Start != *w.Start || *got[i].End != *w.End {
+			t.Fatalf("range %d = %s, want {Start:%d End:%d}", i, dumpRanges(got[i:i+1]), *w.Start, *w.End)
+		}
+	}
+}
+
+func dumpRanges(rs []*pageblob.PageRange) string {
+	out := make([]string, 0, len(rs))
+	for _, r := range rs {
+		s, e := int64(-1), int64(-1)
+		if r.Start != nil {
+			s = *r.Start
+		}
+
+		if r.End != nil {
+			e = *r.End
+		}
+
+		out = append(out, fmt.Sprintf("[%d-%d]", s, e))
+	}
+
+	return strings.Join(out, " ")
+}
+
+func assertPageBlobBody(t *testing.T, ctx context.Context, c *azblob.Client, page0, page2 []byte) {
+	t.Helper()
+
+	dl, err := c.DownloadStream(ctx, "c1", "pb1", nil)
+	if err != nil {
+		t.Fatalf("download page blob: %v", err)
+	}
+
+	body := readAll(t, dl.Body)
+
+	want := make([]byte, 2048)
+	copy(want[0:512], page0)
+	copy(want[1024:1536], page2)
+
+	if body != string(want) {
+		t.Fatalf("page blob body mismatch: len(got)=%d len(want)=%d", len(body), len(want))
+	}
+}
+
+func ptr64(v int64) *int64 { return &v }

--- a/server/azure/blobstorage/blob_tags_test.go
+++ b/server/azure/blobstorage/blob_tags_test.go
@@ -139,10 +139,10 @@ func TestUnknownCompFailsClosed(t *testing.T) {
 	}
 }
 
-// TestPageBlobFailsClosed proves page-blob create and UploadPages fail closed
-// (page-blob range semantics are not implemented) rather than silently
-// corrupting a blob via the comp fall-through.
-func TestPageBlobFailsClosed(t *testing.T) {
+// TestPageBlobCreateSucceeds proves the page-blob create path is wired (page
+// blobs are now modeled) rather than failing closed. The full page-write and
+// Get Page Ranges lifecycle lives in blob_pageblob_test.go.
+func TestPageBlobCreateSucceeds(t *testing.T) {
 	e := newBlobEnv(t)
 	ctx := context.Background()
 
@@ -152,7 +152,7 @@ func TestPageBlobFailsClosed(t *testing.T) {
 	}
 
 	const pageSize = 512
-	if _, err := pc.Create(ctx, pageSize, nil); err == nil {
-		t.Fatal("page-blob Create should fail closed (page blobs unsupported), got success")
+	if _, err := pc.Create(ctx, pageSize, nil); err != nil {
+		t.Fatalf("page-blob Create: %v", err)
 	}
 }

--- a/server/azure/blobstorage/findblobs.go
+++ b/server/azure/blobstorage/findblobs.go
@@ -1,0 +1,157 @@
+package blobstorage
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// findBlobsByTags handles Find Blobs by Tags: GET /?comp=blobs&where=… at the
+// account level (container == "") and GET
+// /{container}?restype=container&comp=blobs&where=… scoped to one container. It
+// parses the tag-query in ?where, matches live blobs by their index tags, and
+// returns each match with its container, name, and tag set.
+func (h *Handler) findBlobsByTags(w http.ResponseWriter, r *http.Request, container string) {
+	page, ok := h.bucket.(storagedriver.AzureFindBlobsByTags)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "NotImplemented", "find blobs by tags is not supported")
+		return
+	}
+
+	where := r.URL.Query().Get("where")
+
+	whereContainer, match, parseOK := parseTagQuery(where)
+	if !parseOK {
+		writeError(w, http.StatusBadRequest, "InvalidQueryParameterValue",
+			"the ?where tag query is malformed or uses an unsupported operator")
+		return
+	}
+
+	// A container-scoped request wins; an account-scoped one may still be narrowed
+	// by an @container term in the query.
+	scope := container
+	if scope == "" {
+		scope = whereContainer
+	}
+
+	blobs, err := page.FindBlobsByTags(r.Context(), scope, match)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := filterBlobsXML{ServiceEndpoint: serviceEndpoint(r), Where: where}
+	for _, b := range blobs {
+		out.Blobs.Blobs = append(out.Blobs.Blobs, filterBlobXML{
+			Name: b.Name, ContainerName: b.Container, Tags: tagSetXML(b.Tags),
+		})
+	}
+
+	writeXML(w, out)
+}
+
+// tagSetXML renders a blob's tag map as the <Tags><TagSet>… document the Find
+// Blobs by Tags response carries, with keys ordered for determinism.
+func tagSetXML(tags map[string]string) blobTagsXML {
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	out := blobTagsXML{}
+	for _, k := range keys {
+		out.TagSet = append(out.TagSet, tagXML{Key: k, Value: tags[k]})
+	}
+
+	return out
+}
+
+// serviceEndpoint reconstructs the account service endpoint for the
+// EnumerationResults ServiceEndpoint attribute.
+func serviceEndpoint(r *http.Request) string {
+	scheme := "https"
+	if r.TLS == nil {
+		scheme = "http"
+	}
+
+	return scheme + "://" + r.Host + "/"
+}
+
+// parseTagQuery parses an Azure Find Blobs by Tags ?where expression into an
+// optional container scope (from an @container term) and the set of tag equality
+// conditions that must all hold. Conditions are joined by AND; each is
+// "key"='value' (double quotes around the key optional) or @container='name'.
+// Only the '=' operator is supported: a query using a range operator (<, >, <=,
+// >=) yields ok=false so the caller can reject it rather than silently mismatch.
+// An empty or whitespace-only query matches every tagged blob.
+func parseTagQuery(where string) (container string, match map[string]string, ok bool) {
+	match = make(map[string]string)
+
+	if strings.TrimSpace(where) == "" {
+		return "", match, true
+	}
+
+	for _, cond := range splitAnd(where) {
+		if strings.ContainsAny(cond, "<>") {
+			return "", nil, false
+		}
+
+		key, val, found := strings.Cut(cond, "=")
+		if !found {
+			return "", nil, false
+		}
+
+		key = strings.Trim(strings.TrimSpace(key), `"`)
+		val = unquoteTagValue(strings.TrimSpace(val))
+
+		if key == "" {
+			return "", nil, false
+		}
+
+		if key == "@container" {
+			container = val
+			continue
+		}
+
+		match[key] = val
+	}
+
+	return container, match, true
+}
+
+// splitAnd splits a ?where expression on the AND conjunction, case-insensitively
+// and only when AND stands as its own space-delimited token.
+func splitAnd(where string) []string {
+	fields := strings.Fields(where)
+
+	var (
+		parts []string
+		cur   []string
+	)
+
+	for _, f := range fields {
+		if strings.EqualFold(f, "AND") {
+			parts = append(parts, strings.Join(cur, " "))
+			cur = nil
+
+			continue
+		}
+
+		cur = append(cur, f)
+	}
+
+	return append(parts, strings.Join(cur, " "))
+}
+
+// unquoteTagValue strips the single quotes around a tag value and unescapes a
+// doubled single-quote (”) to a literal one, per the Azure query grammar.
+func unquoteTagValue(v string) string {
+	v = strings.TrimPrefix(v, "'")
+	v = strings.TrimSuffix(v, "'")
+
+	return strings.ReplaceAll(v, "''", "'")
+}

--- a/server/azure/blobstorage/handler.go
+++ b/server/azure/blobstorage/handler.go
@@ -69,10 +69,13 @@ const (
 	compLease       = "lease"
 	compTags        = "tags"
 	compPage        = "page"
+	compPageList    = "pagelist"
 	compUndelete    = "undelete"
+	// compBlobs is the ?comp= value for Find Blobs by Tags (GET /?comp=blobs and
+	// GET /{container}?restype=container&comp=blobs).
+	compBlobs = "blobs"
 
-	// blobTypePageBlob is the Azure page-blob type; cloudemu does not implement
-	// page-blob range semantics, so a page-blob create/write fails closed.
+	// blobTypePageBlob is the Azure page-blob type.
 	blobTypePageBlob = "PageBlob"
 
 	// compACL is the ?comp= value for Set/Get Container ACL
@@ -115,6 +118,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case container == "" && q.Get("comp") == compList:
 		h.listContainers(w, r)
+	case container == "" && q.Get("comp") == compBlobs:
+		h.findBlobsByTags(w, r, "")
 	case container == "":
 		writeError(w, http.StatusNotImplemented, "NotImplemented", "operation not supported on root")
 	case blob == "" && q.Get("restype") == "container":
@@ -164,6 +169,8 @@ func (h *Handler) containerOp(w http.ResponseWriter, r *http.Request, container 
 		switch q.Get("comp") {
 		case compList:
 			h.listBlobs(w, r, container, q)
+		case compBlobs:
+			h.findBlobsByTags(w, r, container)
 		case compACL:
 			h.getContainerACL(w, r, container)
 		default:
@@ -186,6 +193,11 @@ func (h *Handler) blobOp(w http.ResponseWriter, r *http.Request, container, blob
 
 		if ext, ok := h.bucket.(storagedriver.AzureBlobExtensions); ok && r.URL.Query().Get("comp") == compBlockList {
 			h.getBlockList(w, r, ext, container, blob)
+			return
+		}
+
+		if r.URL.Query().Get("comp") == compPageList {
+			h.getPageRanges(w, r, container, blob)
 			return
 		}
 
@@ -225,11 +237,15 @@ func (h *Handler) putBlobOp(w http.ResponseWriter, r *http.Request, container, b
 		return
 	}
 
-	// Page blobs are not implemented; fail closed rather than silently creating
-	// a block blob (which would misreport page-blob support and, on an existing
-	// blob, clobber it).
 	if strings.EqualFold(blobType, blobTypePageBlob) {
+		if page, ok := h.bucket.(storagedriver.AzurePageBlob); ok {
+			h.createPageBlob(w, r, page, container, blob)
+			return
+		}
+		// Fail closed rather than silently creating a block blob (which would
+		// misreport page-blob support and, on an existing blob, clobber it).
 		writeError(w, http.StatusNotImplemented, "NotImplemented", "page blobs are not supported")
+
 		return
 	}
 
@@ -255,7 +271,13 @@ func (h *Handler) putBlobComp(w http.ResponseWriter, r *http.Request, container,
 	}
 
 	if comp == compPage {
+		if page, ok := h.bucket.(storagedriver.AzurePageBlob); ok {
+			h.putPage(w, r, page, container, blob)
+			return
+		}
+
 		writeError(w, http.StatusNotImplemented, "NotImplemented", "page blobs are not supported")
+
 		return
 	}
 

--- a/server/azure/blobstorage/pageblob.go
+++ b/server/azure/blobstorage/pageblob.go
@@ -1,0 +1,181 @@
+package blobstorage
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// pageWrite is the Azure page-write header name and its two actions.
+const (
+	pageWriteHeader = "X-Ms-Page-Write"
+	pageWriteUpdate = "update"
+	pageWriteClear  = "clear"
+)
+
+// createPageBlob handles PUT /{container}/{blob} with x-ms-blob-type: PageBlob,
+// creating an empty page blob of the size named by x-ms-blob-content-length.
+func (h *Handler) createPageBlob(
+	w http.ResponseWriter, r *http.Request, page storagedriver.AzurePageBlob, container, blob string,
+) {
+	if h.checkLease(w, r, container, blob) {
+		return
+	}
+
+	if h.conditionFailed(w, r, container, blob, true) {
+		return
+	}
+
+	size, err := strconv.ParseInt(r.Header.Get("X-Ms-Blob-Content-Length"), 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidHeaderValue",
+			"x-ms-blob-content-length must be a non-negative multiple of 512")
+		return
+	}
+
+	props := &storagedriver.BlobProperties{ContentType: r.Header.Get("X-Ms-Blob-Content-Type")}
+	if cp := blobContentProps(r); cp != nil {
+		props.ContentEncoding = cp.ContentEncoding
+		props.CacheControl = cp.CacheControl
+		props.ContentLanguage = cp.ContentLanguage
+		props.ContentDisposition = cp.ContentDisposition
+	}
+
+	info, err := page.CreatePageBlob(r.Context(), container, blob, size, props, extractMetadata(r.Header))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeWriteResult(w, info, http.StatusCreated)
+}
+
+// putPage handles PUT /{container}/{blob}?comp=page, dispatching on
+// x-ms-page-write: update (write the request body over a range) or clear (zero a
+// range).
+func (h *Handler) putPage(
+	w http.ResponseWriter, r *http.Request, page storagedriver.AzurePageBlob, container, blob string,
+) {
+	if h.checkLease(w, r, container, blob) {
+		return
+	}
+
+	if h.conditionFailed(w, r, container, blob, false) {
+		return
+	}
+
+	start, end, ok := parsePageRange(pageRangeHeader(r))
+	if !ok {
+		writeError(w, http.StatusRequestedRangeNotSatisfiable, "InvalidPageRange",
+			"the x-ms-range header is missing or malformed")
+		return
+	}
+
+	switch strings.ToLower(r.Header.Get(pageWriteHeader)) {
+	case pageWriteClear:
+		clearPage(w, r, page, container, blob, start, end)
+	case pageWriteUpdate, "":
+		updatePage(w, r, page, container, blob, start, end)
+	default:
+		writeError(w, http.StatusBadRequest, "InvalidHeaderValue",
+			"x-ms-page-write must be 'update' or 'clear'")
+	}
+}
+
+// updatePage writes the request body over the [start,end] page range.
+func updatePage(
+	w http.ResponseWriter, r *http.Request, page storagedriver.AzurePageBlob, container, blob string, start, end int64,
+) {
+	data, ok := readLimitedBody(w, r)
+	if !ok {
+		return
+	}
+
+	info, err := page.PutPage(r.Context(), container, blob, start, end, data)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeWriteResult(w, info, http.StatusCreated)
+}
+
+// clearPage zeroes the [start,end] page range.
+func clearPage(
+	w http.ResponseWriter, r *http.Request, page storagedriver.AzurePageBlob, container, blob string, start, end int64,
+) {
+	info, err := page.ClearPage(r.Context(), container, blob, start, end)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeWriteResult(w, info, http.StatusCreated)
+}
+
+// getPageRanges handles GET /{container}/{blob}?comp=pagelist (Get Page Ranges),
+// returning the page blob's written byte ranges as a <PageList> document.
+func (h *Handler) getPageRanges(w http.ResponseWriter, r *http.Request, container, blob string) {
+	page, ok := h.bucket.(storagedriver.AzurePageBlob)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "NotImplemented", "page blobs are not supported")
+		return
+	}
+
+	ranges, size, err := page.GetPageRanges(r.Context(), container, blob)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := pageListXML{}
+	for _, pr := range ranges {
+		out.PageRange = append(out.PageRange, pageRangeXML{Start: pr.Start, End: pr.End})
+	}
+
+	w.Header().Set("X-Ms-Blob-Content-Length", strconv.FormatInt(size, 10))
+	writeXML(w, out)
+}
+
+// pageRangeHeader returns the range spec for a page op, preferring x-ms-range
+// and falling back to the standard Range header.
+func pageRangeHeader(r *http.Request) string {
+	if h := r.Header.Get("X-Ms-Range"); h != "" {
+		return h
+	}
+
+	return r.Header.Get("Range")
+}
+
+// parsePageRange parses an inclusive "bytes=start-end" page-range spec. Unlike a
+// read range, both bounds are required (a page write always names a bounded
+// range) and no clamping to a blob size happens here — bounds/alignment are the
+// provider's to validate. ok is false for a missing or malformed spec.
+func parsePageRange(header string) (start, end int64, ok bool) {
+	const prefix = "bytes="
+
+	if !strings.HasPrefix(header, prefix) {
+		return 0, 0, false
+	}
+
+	spec := strings.TrimSpace(strings.TrimPrefix(header, prefix))
+
+	startStr, endStr, found := strings.Cut(spec, "-")
+	if !found {
+		return 0, 0, false
+	}
+
+	start, err := strconv.ParseInt(strings.TrimSpace(startStr), 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	end, err = strconv.ParseInt(strings.TrimSpace(endStr), 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	return start, end, true
+}

--- a/server/azure/blobstorage/types.go
+++ b/server/azure/blobstorage/types.go
@@ -130,6 +130,39 @@ type tagXML struct {
 	Value string `xml:"Value"`
 }
 
+// pageListXML is the body for GET /{container}/{blob}?comp=pagelist (Get Page
+// Ranges): the ordered, coalesced byte ranges of a page blob that hold data.
+type pageListXML struct {
+	XMLName    xml.Name       `xml:"PageList"`
+	PageRange  []pageRangeXML `xml:"PageRange"`
+	NextMarker string         `xml:"NextMarker,omitempty"`
+}
+
+type pageRangeXML struct {
+	Start int64 `xml:"Start"`
+	End   int64 `xml:"End"`
+}
+
+// filterBlobsXML is the body for a Find Blobs by Tags response (GET /?comp=blobs
+// and GET /{container}?restype=container&comp=blobs).
+type filterBlobsXML struct {
+	XMLName         xml.Name        `xml:"EnumerationResults"`
+	ServiceEndpoint string          `xml:"ServiceEndpoint,attr,omitempty"`
+	Where           string          `xml:"Where"`
+	Blobs           filterBlobsList `xml:"Blobs"`
+	NextMarker      string          `xml:"NextMarker"`
+}
+
+type filterBlobsList struct {
+	Blobs []filterBlobXML `xml:"Blob"`
+}
+
+type filterBlobXML struct {
+	Name          string      `xml:"Name"`
+	ContainerName string      `xml:"ContainerName"`
+	Tags          blobTagsXML `xml:"Tags"`
+}
+
 // signedIdentifiersXML is the request/response body for PUT and GET
 // /{container}?restype=container&comp=acl.
 type signedIdentifiersXML struct {

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -382,6 +382,69 @@ type AzureSoftDeleteBlob interface {
 	ListDeletedBlobs(ctx context.Context, container string, opts ListOptions) (*DeletedBlobListResult, error)
 }
 
+// PageRange is one contiguous [Start,End] byte span (inclusive) of a page blob
+// that currently holds written data, as reported by Get Page Ranges.
+type PageRange struct {
+	Start int64
+	End   int64
+}
+
+// AzurePageBlob is an OPTIONAL Azure-specific capability, discovered by type
+// assertion, that models page blobs — fixed-capacity blobs written in 512-byte
+// pages at arbitrary offsets (the backing type for Azure managed disks). A page
+// blob is created empty at a declared size (all pages read as zeros); Put Page
+// writes an aligned range, Clear Page zeroes one, and Get Page Ranges reports
+// the ranges that currently hold written data (adjacent written pages coalesced
+// into one range). All ranges are aligned to the 512-byte page boundary.
+//
+// It is distinct from block/append blobs: those grow by staging or appending
+// whole blocks, whereas a page blob is a random-access fixed-size byte array.
+// S3/GCS don't implement it.
+//
+// Note: page bytes are captured in memory; a page blob is not offloaded to an
+// external StorageEngine.
+type AzurePageBlob interface {
+	// CreatePageBlob creates an empty page blob of size bytes (a multiple of 512)
+	// with all pages zero-valued and no written ranges (Put Blob,
+	// x-ms-blob-type: PageBlob, x-ms-blob-content-length: size). props may be nil.
+	CreatePageBlob(
+		ctx context.Context, container, blob string, size int64, props *BlobProperties, metadata map[string]string,
+	) (*ObjectInfo, error)
+	// PutPage writes data over the inclusive byte range [start,end] of a page blob
+	// (Put Page, ?comp=page, x-ms-page-write: update). start and end must align to
+	// the 512-byte page boundary (start%512==0, (end+1)%512==0), lie within the
+	// blob, and len(data) must equal end-start+1.
+	PutPage(ctx context.Context, container, blob string, start, end int64, data []byte) (*ObjectInfo, error)
+	// ClearPage zeroes the inclusive byte range [start,end] of a page blob and
+	// drops it from the written ranges (Clear Page, ?comp=page,
+	// x-ms-page-write: clear). Same alignment/bounds rules as PutPage.
+	ClearPage(ctx context.Context, container, blob string, start, end int64) (*ObjectInfo, error)
+	// GetPageRanges returns the page blob's written ranges (Get Page Ranges,
+	// GET ?comp=pagelist), coalesced and ordered by Start, together with the
+	// blob's total size.
+	GetPageRanges(ctx context.Context, container, blob string) (ranges []PageRange, blobSize int64, err error)
+}
+
+// TaggedBlob is one blob returned by FindBlobsByTags: its container, name, and
+// the full index-tag set that matched the query.
+type TaggedBlob struct {
+	Container string
+	Name      string
+	Tags      map[string]string
+}
+
+// AzureFindBlobsByTags is an OPTIONAL Azure-specific capability, discovered by
+// type assertion, that searches blobs by their index tags (Find Blobs by Tags,
+// GET /?comp=blobs&where=… at the account level or
+// GET /{container}?restype=container&comp=blobs&where=… scoped to one
+// container). It returns every live blob whose tags satisfy all of the
+// equality conditions in match; an empty match matches every tagged blob.
+// container is "" for an account-wide search or a container name to scope it.
+// The tags themselves are the ones set via Set Blob Tags (PutObjectTagging).
+type AzureFindBlobsByTags interface {
+	FindBlobsByTags(ctx context.Context, container string, match map[string]string) ([]TaggedBlob, error)
+}
+
 // BucketAttributes is an OPTIONAL capability, discovered by type assertion (like
 // the networking NetworkInterfaces capability): a provider whose buckets map to
 // a richer resource (Azure storage accounts) exposes their SKU/kind/access-tier


### PR DESCRIPTION
## Summary

Completes the Azure Blob page-blob and tag-search surface flagged in the object-storage world-case audit:

- **Get Page Ranges** (`GET /{container}/{blob}?comp=pagelist`) — with a real page-blob write model. Page blobs were previously unmodeled (create/write failed closed). Now:
  - Create page blob (`PUT`, `x-ms-blob-type: PageBlob`, `x-ms-blob-content-length`) — fixed-size, 512-aligned, zero-filled.
  - Put Page (`?comp=page`, `x-ms-page-write: update`) and Clear Page (`x-ms-page-write: clear`) over 512-aligned byte ranges.
  - Get Page Ranges returns the written ranges, ordered and with adjacent pages coalesced into a single range.
- **Find Blobs by Tags** (`GET /?comp=blobs&where=…` at account scope, `GET /{container}?restype=container&comp=blobs&where=…` at container scope) — parses the `where` tag query (equality conditions joined by `AND`, optional `@container` scope) and returns matching live blobs with their index tags.

Both are new optional driver capabilities (`AzurePageBlob`, `AzureFindBlobsByTags`) discovered by type assertion, so S3/GCS are untouched. They coexist with the already-merged blob versioning and soft-delete. The page-blob written-range map is threaded through `cloneBlobObject` (versions/snapshots) and the hand-maintained persist snapshot/restore path so it survives `cloudemu snapshot` / restart-restore.

## Testing

- Real azblob SDK e2e (wire): page-blob create → write two non-adjacent pages → Get Page Ranges (exact ranges) → Clear Page → re-read; adjacent-page coalescing; Find Blobs by Tags at account + container scope, multi-term `AND`, and `@container` scoping.
- Provider-level tests for range validation, coalescing, clear semantics, tag matching, and a Snapshot→Restore round-trip proving the written-range map (and bytes) survive.
- `go build ./...`, `go test ./providers/azure/blobstorage/... ./server/azure/blobstorage/... ./persist/... -race`, broad `go test ./server/azure/...`, gofmt clean, 0 new golangci-lint issues on touched packages, `go mod tidy` clean, `docs/coverage/` regenerated (no drift).

## Deferrals

- **Get Page Ranges Diff** (`prevsnapshot=`, `ClearRange` output) is not implemented — only the base written-range listing.
- **Get Page Ranges range scoping** — a scoping `?range=` / `x-ms-range` header is ignored; the full-blob range list is returned (the common case).
- **Find Blobs by Tags `where` operators** — equality (`=`) with `AND` and an optional `@container` scope are supported; range operators (`<`, `>`, `<=`, `>=`) are rejected rather than silently mismatched.
- **Find Blobs by Tags pagination** — no `maxresults`/marker pagination; all matches are returned in one page.
- **`splitAnd` edge case** — a tag *value* containing the literal token `AND` (or `<`/`>`) can be mis-split/rejected; real-world tag queries use these as the boolean/operator syntax, not as values.
