### PR TITLE
feat(gcs): HMAC keys + settable uniform bucket-level access

### DIFF
--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -97,6 +97,13 @@ type bucketMeta struct {
 	metageneration int64
 	updated        string
 	iamPolicy      []byte
+	// ublaEnabled / ublaLockedTime / publicAccessPrevention hold the bucket's
+	// iamConfiguration (Uniform Bucket-Level Access + Public Access Prevention).
+	// ublaLockedTime is stamped when UBLA is enabled and cleared when disabled,
+	// mirroring the 90-day lock window real GCS reports.
+	ublaEnabled            bool
+	ublaLockedTime         string
+	publicAccessPrevention string
 	// gcsLifecycleRaw is the bucket's lifecycle configuration stored verbatim as
 	// GCS JSON ({"rule":[...]}), preserving every rule condition the wire layer
 	// received. It is the authoritative source for EvaluateLifecycle and
@@ -120,6 +127,9 @@ type Mock struct {
 	// notifGen is the source of unique, monotonically increasing notification
 	// config ids (numeric strings, as real GCS mints).
 	notifGen atomic.Int64
+	// hmacKeys holds project-scoped service-account HMAC keys keyed by access id
+	// (Projects.hmacKeys). Lazily created in New so the store is always non-nil.
+	hmacKeys *memstore.Store[*hmacKeyRecord]
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -147,8 +157,9 @@ func (m *Mock) emitMetric(ctx context.Context, metricName string, value float64,
 // New creates a new GCS mock.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		buckets: memstore.New[*bucketMeta](),
-		opts:    opts,
+		buckets:  memstore.New[*bucketMeta](),
+		opts:     opts,
+		hmacKeys: memstore.New[*hmacKeyRecord](),
 	}
 }
 

--- a/providers/gcp/gcs/hmac.go
+++ b/providers/gcp/gcs/hmac.go
@@ -1,0 +1,211 @@
+package gcs
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"sort"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+const (
+	hmacStateActive   = "ACTIVE"
+	hmacStateInactive = "INACTIVE"
+
+	// hmacAccessIDBytes / hmacSecretBytes size the random material behind a
+	// key's access id and secret. Real GCS access ids are ~61 chars ("GOOG1E" +
+	// base32) and secrets are 40-char base64; these approximate that shape.
+	hmacAccessIDBytes = 24
+	hmacSecretBytes   = 30
+	hmacAccessPrefix  = "GOOG1E"
+)
+
+// hmacKeyStore mirrors the server-side capability the GCS wire handler
+// type-asserts for; declaring it here compile-checks the Mock keeps the exact
+// signatures the handler needs.
+var _ interface {
+	CreateHMACKeyGCS(ctx context.Context, projectID, serviceAccountEmail string) (metadata []byte, secret string, err error)
+	ListHMACKeysGCS(ctx context.Context, projectID, serviceAccountEmail string, showDeleted bool) ([]byte, error)
+	GetHMACKeyGCS(ctx context.Context, projectID, accessID string) ([]byte, error)
+	UpdateHMACKeyStateGCS(ctx context.Context, projectID, accessID, state string) ([]byte, error)
+	DeleteHMACKeyGCS(ctx context.Context, projectID, accessID string) error
+} = (*Mock)(nil)
+
+// hmacKeyRecord is one stored service-account HMAC key. The secret is retained
+// only so a snapshot/restore preserves it; it is returned over the wire once, at
+// create time.
+type hmacKeyRecord struct {
+	AccessID            string `json:"accessId"`
+	Secret              string `json:"secret"`
+	ProjectID           string `json:"projectId"`
+	ServiceAccountEmail string `json:"serviceAccountEmail"`
+	State               string `json:"state"`
+	TimeCreated         string `json:"timeCreated"`
+	Updated             string `json:"updated"`
+	Etag                string `json:"etag"`
+}
+
+// hmacMetaJSON is the metadata contract exchanged with the wire handler (which
+// unmarshals a matching struct and renders the storage#hmacKeyMetadata
+// resource). The secret is never part of it.
+type hmacMetaJSON struct {
+	AccessID            string `json:"accessId"`
+	ProjectID           string `json:"projectId"`
+	ServiceAccountEmail string `json:"serviceAccountEmail"`
+	State               string `json:"state"`
+	TimeCreated         string `json:"timeCreated"`
+	Updated             string `json:"updated"`
+	Etag                string `json:"etag"`
+}
+
+func (r *hmacKeyRecord) meta() hmacMetaJSON {
+	return hmacMetaJSON{
+		AccessID:            r.AccessID,
+		ProjectID:           r.ProjectID,
+		ServiceAccountEmail: r.ServiceAccountEmail,
+		State:               r.State,
+		TimeCreated:         r.TimeCreated,
+		Updated:             r.Updated,
+		Etag:                r.Etag,
+	}
+}
+
+// CreateHMACKeyGCS mints a new ACTIVE HMAC key for a service account and returns
+// its metadata JSON plus the secret (surfaced exactly once, at create).
+func (m *Mock) CreateHMACKeyGCS(
+	_ context.Context, projectID, serviceAccountEmail string,
+) (metadata []byte, secret string, err error) {
+	if serviceAccountEmail == "" {
+		return nil, "", cerrors.New(cerrors.InvalidArgument, "serviceAccountEmail is required")
+	}
+
+	now := m.opts.Clock.Now().UTC().Format(gcsTimeFormat)
+	rec := &hmacKeyRecord{
+		AccessID:            hmacAccessPrefix + randomToken(hmacAccessIDBytes),
+		Secret:              randomToken(hmacSecretBytes),
+		ProjectID:           projectID,
+		ServiceAccountEmail: serviceAccountEmail,
+		State:               hmacStateActive,
+		TimeCreated:         now,
+		Updated:             now,
+	}
+	rec.Etag = rec.AccessID
+
+	m.hmacKeys.Set(rec.AccessID, rec)
+
+	meta, err := json.Marshal(rec.meta())
+	if err != nil {
+		return nil, "", err
+	}
+
+	return meta, rec.Secret, nil
+}
+
+// ListHMACKeysGCS returns the metadata (JSON array) of the project's HMAC keys,
+// optionally filtered to a single service account. Deleted keys are pruned on
+// delete, so showDeleted has no additional entries to surface here.
+func (m *Mock) ListHMACKeysGCS(_ context.Context, projectID, serviceAccountEmail string, _ bool) ([]byte, error) {
+	metas := make([]hmacMetaJSON, 0)
+
+	for _, rec := range m.hmacKeys.All() {
+		if rec.ProjectID != projectID {
+			continue
+		}
+
+		if serviceAccountEmail != "" && rec.ServiceAccountEmail != serviceAccountEmail {
+			continue
+		}
+
+		metas = append(metas, rec.meta())
+	}
+
+	sort.Slice(metas, func(i, j int) bool { return metas[i].AccessID < metas[j].AccessID })
+
+	return json.Marshal(metas)
+}
+
+// GetHMACKeyGCS returns one key's metadata JSON, or NotFound.
+func (m *Mock) GetHMACKeyGCS(_ context.Context, projectID, accessID string) ([]byte, error) {
+	rec, ok := m.hmacKeys.Get(accessID)
+	if !ok || rec.ProjectID != projectID {
+		return nil, cerrors.Newf(cerrors.NotFound, "hmac key %q not found", accessID)
+	}
+
+	return json.Marshal(rec.meta())
+}
+
+// UpdateHMACKeyStateGCS transitions a key between ACTIVE and INACTIVE and returns
+// its updated metadata JSON.
+func (m *Mock) UpdateHMACKeyStateGCS(_ context.Context, projectID, accessID, state string) ([]byte, error) {
+	if state != hmacStateActive && state != hmacStateInactive {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid HMAC key state %q", state)
+	}
+
+	var (
+		out    []byte
+		opErr  error
+		outErr error
+	)
+
+	found := m.hmacKeys.Update(accessID, func(rec *hmacKeyRecord) *hmacKeyRecord {
+		if rec.ProjectID != projectID {
+			opErr = cerrors.Newf(cerrors.NotFound, "hmac key %q not found", accessID)
+			return rec
+		}
+
+		next := *rec
+		next.State = state
+		next.Updated = m.opts.Clock.Now().UTC().Format(gcsTimeFormat)
+		out, outErr = json.Marshal(next.meta())
+
+		return &next
+	})
+
+	switch {
+	case !found:
+		return nil, cerrors.Newf(cerrors.NotFound, "hmac key %q not found", accessID)
+	case opErr != nil:
+		return nil, opErr
+	case outErr != nil:
+		return nil, outErr
+	}
+
+	return out, nil
+}
+
+// DeleteHMACKeyGCS removes a key. Real GCS requires the key be INACTIVE first;
+// deleting an ACTIVE key is rejected.
+func (m *Mock) DeleteHMACKeyGCS(_ context.Context, projectID, accessID string) error {
+	var opErr error
+
+	found := m.hmacKeys.UpdateOrDelete(accessID, func(rec *hmacKeyRecord) (*hmacKeyRecord, bool) {
+		if rec.ProjectID != projectID {
+			opErr = cerrors.Newf(cerrors.NotFound, "hmac key %q not found", accessID)
+			return rec, true
+		}
+
+		if rec.State != hmacStateInactive {
+			opErr = cerrors.New(cerrors.InvalidArgument, "cannot delete an ACTIVE HMAC key; set it to INACTIVE first")
+			return rec, true
+		}
+
+		return rec, false
+	})
+
+	if !found {
+		return cerrors.Newf(cerrors.NotFound, "hmac key %q not found", accessID)
+	}
+
+	return opErr
+}
+
+// randomToken returns an uppercase, URL-safe token derived from n random bytes,
+// suitable for the synthetic access ids and secrets these keys carry.
+func randomToken(n int) string {
+	buf := make([]byte, n)
+	_, _ = rand.Read(buf)
+
+	return base64.RawURLEncoding.EncodeToString(buf)
+}

--- a/providers/gcp/gcs/hmac_ubla_test.go
+++ b/providers/gcp/gcs/hmac_ubla_test.go
@@ -1,0 +1,215 @@
+package gcs
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testProject = "test-project"
+	testSA      = "svc@test-project.iam.gserviceaccount.com"
+)
+
+func decodeHMACMeta(t *testing.T, raw []byte) hmacMetaJSON {
+	t.Helper()
+
+	var m hmacMetaJSON
+	require.NoError(t, json.Unmarshal(raw, &m))
+
+	return m
+}
+
+// TestHMACKeyCRUD walks create -> get -> update -> delete and the delete guard.
+func TestHMACKeyCRUD(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	metaRaw, secret, err := m.CreateHMACKeyGCS(ctx, testProject, testSA)
+	require.NoError(t, err)
+	assert.NotEmpty(t, secret)
+
+	meta := decodeHMACMeta(t, metaRaw)
+	assert.NotEmpty(t, meta.AccessID)
+	assert.Equal(t, hmacStateActive, meta.State)
+	assert.Equal(t, testSA, meta.ServiceAccountEmail)
+	assert.Equal(t, testProject, meta.ProjectID)
+
+	// Get returns metadata (no secret in the metadata contract).
+	gotRaw, err := m.GetHMACKeyGCS(ctx, testProject, meta.AccessID)
+	require.NoError(t, err)
+	assert.Equal(t, meta.AccessID, decodeHMACMeta(t, gotRaw).AccessID)
+
+	// A key under a different project is invisible.
+	_, err = m.GetHMACKeyGCS(ctx, "other-project", meta.AccessID)
+	assert.True(t, cerrors.IsNotFound(err))
+
+	// Deleting an ACTIVE key is rejected.
+	err = m.DeleteHMACKeyGCS(ctx, testProject, meta.AccessID)
+	require.Error(t, err)
+	assert.True(t, cerrors.IsInvalidArgument(err))
+
+	// Deactivate, then delete succeeds.
+	updRaw, err := m.UpdateHMACKeyStateGCS(ctx, testProject, meta.AccessID, hmacStateInactive)
+	require.NoError(t, err)
+	assert.Equal(t, hmacStateInactive, decodeHMACMeta(t, updRaw).State)
+
+	require.NoError(t, m.DeleteHMACKeyGCS(ctx, testProject, meta.AccessID))
+
+	_, err = m.GetHMACKeyGCS(ctx, testProject, meta.AccessID)
+	assert.True(t, cerrors.IsNotFound(err))
+}
+
+func TestHMACKeyValidation(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, _, err := m.CreateHMACKeyGCS(ctx, testProject, "")
+	assert.True(t, cerrors.IsInvalidArgument(err))
+
+	meta, _, err := m.CreateHMACKeyGCS(ctx, testProject, testSA)
+	require.NoError(t, err)
+
+	accessID := decodeHMACMeta(t, meta).AccessID
+	_, err = m.UpdateHMACKeyStateGCS(ctx, testProject, accessID, "BOGUS")
+	assert.True(t, cerrors.IsInvalidArgument(err))
+}
+
+func TestHMACKeyListFiltersByProjectAndAccount(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, _, err := m.CreateHMACKeyGCS(ctx, testProject, testSA)
+	require.NoError(t, err)
+	_, _, err = m.CreateHMACKeyGCS(ctx, testProject, "other@test-project.iam.gserviceaccount.com")
+	require.NoError(t, err)
+	_, _, err = m.CreateHMACKeyGCS(ctx, "proj-2", testSA)
+	require.NoError(t, err)
+
+	raw, err := m.ListHMACKeysGCS(ctx, testProject, "", false)
+	require.NoError(t, err)
+
+	var all []hmacMetaJSON
+	require.NoError(t, json.Unmarshal(raw, &all))
+	assert.Len(t, all, 2)
+
+	raw, err = m.ListHMACKeysGCS(ctx, testProject, testSA, false)
+	require.NoError(t, err)
+
+	var filtered []hmacMetaJSON
+	require.NoError(t, json.Unmarshal(raw, &filtered))
+	require.Len(t, filtered, 1)
+	assert.Equal(t, testSA, filtered[0].ServiceAccountEmail)
+}
+
+// TestBucketIAMConfigRoundTrip proves UBLA + PAP persist and that enabling UBLA
+// stamps a lockedTime that clears on disable.
+func TestBucketIAMConfigRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "b1"))
+
+	enabled, locked, pap, err := m.BucketIAMConfigGCS(ctx, "b1")
+	require.NoError(t, err)
+	assert.False(t, enabled)
+	assert.Empty(t, locked)
+	assert.Empty(t, pap)
+
+	on := true
+	require.NoError(t, m.SetBucketIAMConfigGCS(ctx, "b1", &on, "enforced"))
+
+	enabled, locked, pap, err = m.BucketIAMConfigGCS(ctx, "b1")
+	require.NoError(t, err)
+	assert.True(t, enabled)
+	assert.NotEmpty(t, locked)
+	assert.Equal(t, "enforced", pap)
+
+	off := false
+	require.NoError(t, m.SetBucketIAMConfigGCS(ctx, "b1", &off, ""))
+
+	enabled, locked, pap, err = m.BucketIAMConfigGCS(ctx, "b1")
+	require.NoError(t, err)
+	assert.False(t, enabled)
+	assert.Empty(t, locked)
+	// PAP is a separate field and is untouched by clearing UBLA.
+	assert.Equal(t, "enforced", pap)
+}
+
+func TestBucketIAMConfigNotFound(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, _, _, err := m.BucketIAMConfigGCS(ctx, "nope")
+	assert.True(t, cerrors.IsNotFound(err))
+
+	on := true
+	err = m.SetBucketIAMConfigGCS(ctx, "nope", &on, "")
+	assert.True(t, cerrors.IsNotFound(err))
+}
+
+// TestHMACConcurrentCreate hammers concurrent creates to prove the store stays
+// consistent under -race.
+func TestHMACConcurrentCreate(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	const n = 50
+
+	var wg sync.WaitGroup
+
+	wg.Add(n)
+
+	for range n {
+		go func() {
+			defer wg.Done()
+
+			_, _, err := m.CreateHMACKeyGCS(ctx, testProject, testSA)
+			assert.NoError(t, err)
+		}()
+	}
+
+	wg.Wait()
+
+	raw, err := m.ListHMACKeysGCS(ctx, testProject, "", false)
+	require.NoError(t, err)
+
+	var keys []hmacMetaJSON
+	require.NoError(t, json.Unmarshal(raw, &keys))
+	assert.Len(t, keys, n)
+}
+
+// TestHMACKeySurvivesSnapshot proves HMAC keys and bucket iamConfiguration
+// round-trip through a snapshot/restore.
+func TestHMACKeySurvivesSnapshot(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateBucket(ctx, "b1"))
+	on := true
+	require.NoError(t, m.SetBucketIAMConfigGCS(ctx, "b1", &on, "enforced"))
+
+	metaRaw, _, err := m.CreateHMACKeyGCS(ctx, testProject, testSA)
+	require.NoError(t, err)
+	accessID := decodeHMACMeta(t, metaRaw).AccessID
+
+	data, err := m.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	restored := newTestMock()
+	require.NoError(t, restored.Restore(ctx, data))
+
+	gotRaw, err := restored.GetHMACKeyGCS(ctx, testProject, accessID)
+	require.NoError(t, err)
+	assert.Equal(t, accessID, decodeHMACMeta(t, gotRaw).AccessID)
+
+	enabled, locked, pap, err := restored.BucketIAMConfigGCS(ctx, "b1")
+	require.NoError(t, err)
+	assert.True(t, enabled)
+	assert.NotEmpty(t, locked)
+	assert.Equal(t, "enforced", pap)
+}

--- a/providers/gcp/gcs/iamconfig.go
+++ b/providers/gcp/gcs/iamconfig.go
@@ -1,0 +1,71 @@
+package gcs
+
+import (
+	"context"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// ublaLockDays is how far ahead GCS stamps a bucket's uniform bucket-level
+// access lockedTime when UBLA is enabled — the window during which it can still
+// be disabled before becoming permanent.
+const ublaLockDays = 90
+
+// iamConfigStore mirrors the server-side capability the GCS wire handler
+// type-asserts for; declaring it here compile-checks the Mock keeps the exact
+// signatures the handler needs.
+var _ interface {
+	SetBucketIAMConfigGCS(ctx context.Context, bucket string, ublaEnabled *bool, publicAccessPrevention string) error
+	BucketIAMConfigGCS(ctx context.Context, bucket string) (enabled bool, lockedTime, publicAccessPrevention string, err error)
+} = (*Mock)(nil)
+
+// SetBucketIAMConfigGCS updates the bucket's iamConfiguration. A non-nil
+// ublaEnabled toggles Uniform Bucket-Level Access, stamping lockedTime on
+// enable and clearing it on disable; a non-empty publicAccessPrevention sets
+// that field. Both are left unchanged when their argument is nil/empty, matching
+// the JSON merge-patch the Buckets.patch endpoint applies.
+func (m *Mock) SetBucketIAMConfigGCS(_ context.Context, bucket string, ublaEnabled *bool, publicAccessPrevention string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	if ublaEnabled != nil {
+		if *ublaEnabled {
+			bkt.ublaEnabled = true
+			// Preserve an existing lock window across a redundant enable; stamp a
+			// fresh one only on the enable transition.
+			if bkt.ublaLockedTime == "" {
+				lock := m.opts.Clock.Now().UTC().Add(ublaLockDays * gcsHoursPerDay * time.Hour)
+				bkt.ublaLockedTime = lock.Format(gcsTimeFormat)
+			}
+		} else {
+			bkt.ublaEnabled = false
+			bkt.ublaLockedTime = ""
+		}
+	}
+
+	if publicAccessPrevention != "" {
+		bkt.publicAccessPrevention = publicAccessPrevention
+	}
+
+	return nil
+}
+
+// BucketIAMConfigGCS returns the bucket's UBLA enablement, its lockedTime (empty
+// when UBLA is off), and its public-access-prevention setting.
+func (m *Mock) BucketIAMConfigGCS(_ context.Context, bucket string) (enabled bool, lockedTime, publicAccessPrevention string, err error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return false, "", "", cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	return bkt.ublaEnabled, bkt.ublaLockedTime, bkt.publicAccessPrevention, nil
+}

--- a/providers/gcp/gcs/snapshot.go
+++ b/providers/gcp/gcs/snapshot.go
@@ -21,27 +21,31 @@ type gcsSnapshot struct {
 	Buckets  map[string]*bucketSnapshot `json:"buckets,omitempty"`
 	Gen      int64                      `json:"gen,omitempty"`
 	NotifGen int64                      `json:"notifGen,omitempty"`
+	HMACKeys map[string]*hmacKeyRecord  `json:"hmacKeys,omitempty"`
 }
 
 type bucketSnapshot struct {
-	Name           string                                  `json:"name"`
-	Region         string                                  `json:"region,omitempty"`
-	CreatedAt      string                                  `json:"createdAt,omitempty"`
-	Versioning     bool                                    `json:"versioning,omitempty"`
-	Lifecycle      *driver.LifecycleConfig                 `json:"lifecycle,omitempty"`
-	LifecycleRaw   []byte                                  `json:"lifecycleRaw,omitempty"`
-	Policy         *driver.BucketPolicy                    `json:"policy,omitempty"`
-	CORS           *driver.CORSConfig                      `json:"cors,omitempty"`
-	Encryption     *driver.EncryptionConfig                `json:"encryption,omitempty"`
-	Tags           map[string]string                       `json:"tags,omitempty"`
-	Location       string                                  `json:"location,omitempty"`
-	StorageClass   string                                  `json:"storageClass,omitempty"`
-	Metageneration int64                                   `json:"metageneration,omitempty"`
-	Updated        string                                  `json:"updated,omitempty"`
-	IAMPolicy      []byte                                  `json:"iamPolicy,omitempty"`
-	Objects        map[string]*objectSnapshot              `json:"objects,omitempty"`
-	Versions       map[string][]*objectSnapshot            `json:"versions,omitempty"`
-	Notifications  map[string]driver.GCSNotificationConfig `json:"notifications,omitempty"`
+	Name                   string                                  `json:"name"`
+	Region                 string                                  `json:"region,omitempty"`
+	CreatedAt              string                                  `json:"createdAt,omitempty"`
+	Versioning             bool                                    `json:"versioning,omitempty"`
+	Lifecycle              *driver.LifecycleConfig                 `json:"lifecycle,omitempty"`
+	LifecycleRaw           []byte                                  `json:"lifecycleRaw,omitempty"`
+	Policy                 *driver.BucketPolicy                    `json:"policy,omitempty"`
+	CORS                   *driver.CORSConfig                      `json:"cors,omitempty"`
+	Encryption             *driver.EncryptionConfig                `json:"encryption,omitempty"`
+	Tags                   map[string]string                       `json:"tags,omitempty"`
+	Location               string                                  `json:"location,omitempty"`
+	StorageClass           string                                  `json:"storageClass,omitempty"`
+	Metageneration         int64                                   `json:"metageneration,omitempty"`
+	Updated                string                                  `json:"updated,omitempty"`
+	IAMPolicy              []byte                                  `json:"iamPolicy,omitempty"`
+	UBLAEnabled            bool                                    `json:"ublaEnabled,omitempty"`
+	UBLALockedTime         string                                  `json:"ublaLockedTime,omitempty"`
+	PublicAccessPrevention string                                  `json:"publicAccessPrevention,omitempty"`
+	Objects                map[string]*objectSnapshot              `json:"objects,omitempty"`
+	Versions               map[string][]*objectSnapshot            `json:"versions,omitempty"`
+	Notifications          map[string]driver.GCSNotificationConfig `json:"notifications,omitempty"`
 }
 
 // objectSnapshot mirrors gcsObject (all exported already), but Data is dropped
@@ -81,6 +85,15 @@ func (m *Mock) Snapshot(_ context.Context, includeAssets bool) (json.RawMessage,
 		snap.Buckets[name] = snapshotBucket(bkt, includeAssets)
 	}
 
+	if keys := m.hmacKeys.All(); len(keys) > 0 {
+		snap.HMACKeys = make(map[string]*hmacKeyRecord, len(keys))
+
+		for id, rec := range keys {
+			cp := *rec
+			snap.HMACKeys[id] = &cp
+		}
+	}
+
 	return json.Marshal(snap)
 }
 
@@ -91,7 +104,9 @@ func snapshotBucket(bkt *bucketMeta, includeAssets bool) *bucketSnapshot {
 		CORS: bkt.corsConfig, Encryption: bkt.encryption, Tags: bkt.tags,
 		Location: bkt.location, StorageClass: bkt.storageClass,
 		Metageneration: bkt.metageneration, Updated: bkt.updated, IAMPolicy: bkt.iamPolicy,
-		Objects: make(map[string]*objectSnapshot, bkt.objects.Len()),
+		UBLAEnabled: bkt.ublaEnabled, UBLALockedTime: bkt.ublaLockedTime,
+		PublicAccessPrevention: bkt.publicAccessPrevention,
+		Objects:                make(map[string]*objectSnapshot, bkt.objects.Len()),
 	}
 
 	for key, obj := range bkt.objects.All() {
@@ -171,6 +186,11 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 		m.buckets.Set(name, restoreBucket(bs))
 	}
 
+	for id, rec := range snap.HMACKeys {
+		cp := *rec
+		m.hmacKeys.Set(id, &cp)
+	}
+
 	return nil
 }
 
@@ -189,8 +209,10 @@ func restoreBucket(bs *bucketSnapshot) *bucketMeta {
 		encryption: bs.Encryption, tags: bs.Tags,
 		location: bs.Location, storageClass: bs.StorageClass,
 		metageneration: metagen, updated: bs.Updated, iamPolicy: bs.IAMPolicy,
-		versions:      restoreVersions(bs.Versions),
-		notifications: bs.Notifications,
+		ublaEnabled: bs.UBLAEnabled, ublaLockedTime: bs.UBLALockedTime,
+		publicAccessPrevention: bs.PublicAccessPrevention,
+		versions:               restoreVersions(bs.Versions),
+		notifications:          bs.Notifications,
 	}
 
 	for key, os := range bs.Objects {

--- a/server/gcp/gcs/gcs_hmac_ubla_test.go
+++ b/server/gcp/gcs/gcs_hmac_ubla_test.go
@@ -1,0 +1,227 @@
+// Package gcs_test — suite cell STORAGE / gcp / sdk-compat.
+//
+// Real cloud.google.com/go/storage SDK journeys for service-account HMAC keys
+// (Projects.hmacKeys) and settable Uniform Bucket-Level Access + Public Access
+// Prevention (bucket iamConfiguration), driven against the emulator's GCP HTTP
+// server.
+package gcs_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/iterator"
+)
+
+const hmacServiceAccount = "svc@e2e-project.iam.gserviceaccount.com"
+
+// TestGCSHMACKeyLifecycle walks the full real-user HMAC journey:
+// create -> list -> get -> deactivate -> delete, and proves an ACTIVE key
+// cannot be deleted while an INACTIVE one can.
+func TestGCSHMACKeyLifecycle(t *testing.T) {
+	ctx, client := newStorageClient(t)
+
+	key, err := client.CreateHMACKey(ctx, e2eProject, hmacServiceAccount)
+	if err != nil {
+		t.Fatalf("CreateHMACKey: %v", err)
+	}
+
+	if key.AccessID == "" {
+		t.Fatal("CreateHMACKey returned empty AccessID")
+	}
+
+	if key.Secret == "" {
+		t.Fatal("CreateHMACKey returned empty Secret (must be surfaced once at create)")
+	}
+
+	if key.State != storage.Active {
+		t.Errorf("new key State = %q, want ACTIVE", key.State)
+	}
+
+	if key.ServiceAccountEmail != hmacServiceAccount {
+		t.Errorf("ServiceAccountEmail = %q, want %q", key.ServiceAccountEmail, hmacServiceAccount)
+	}
+
+	// List reflects the created key.
+	assertHMACKeyListed(t, ctx, client, key.AccessID)
+
+	handle := client.HMACKeyHandle(e2eProject, key.AccessID)
+
+	got, err := handle.Get(ctx)
+	if err != nil {
+		t.Fatalf("HMACKeyHandle.Get: %v", err)
+	}
+
+	if got.Secret != "" {
+		t.Error("Get must not return the secret")
+	}
+
+	if got.AccessID != key.AccessID {
+		t.Errorf("Get AccessID = %q, want %q", got.AccessID, key.AccessID)
+	}
+
+	// Deleting an ACTIVE key is rejected.
+	if delErr := handle.Delete(ctx); delErr == nil {
+		t.Fatal("Delete of an ACTIVE key succeeded, want error")
+	} else {
+		assertHTTPStatus(t, delErr, 400)
+	}
+
+	// Deactivate, then delete succeeds.
+	updated, err := handle.Update(ctx, storage.HMACKeyAttrsToUpdate{State: storage.Inactive})
+	if err != nil {
+		t.Fatalf("Update to INACTIVE: %v", err)
+	}
+
+	if updated.State != storage.Inactive {
+		t.Errorf("updated State = %q, want INACTIVE", updated.State)
+	}
+
+	if delErr := handle.Delete(ctx); delErr != nil {
+		t.Fatalf("Delete of an INACTIVE key: %v", delErr)
+	}
+
+	// Gone.
+	if _, getErr := handle.Get(ctx); getErr == nil {
+		t.Fatal("Get after delete succeeded, want not-found")
+	} else {
+		assertHTTPStatus(t, getErr, 404)
+	}
+}
+
+func assertHMACKeyListed(t *testing.T, ctx context.Context, client *storage.Client, accessID string) {
+	t.Helper()
+
+	it := client.ListHMACKeys(ctx, e2eProject)
+
+	for {
+		md, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("ListHMACKeys: %v", err)
+		}
+
+		if md.AccessID == accessID {
+			return
+		}
+	}
+
+	t.Fatalf("access id %q not found in ListHMACKeys", accessID)
+}
+
+// TestGCSHMACKeyServiceAccountRequired proves a create with no service account
+// is rejected.
+func TestGCSHMACKeyServiceAccountRequired(t *testing.T) {
+	ctx, client := newStorageClient(t)
+
+	if _, err := client.CreateHMACKey(ctx, e2eProject, ""); err == nil {
+		t.Fatal("CreateHMACKey with empty service account succeeded, want error")
+	}
+}
+
+// TestGCSUniformBucketLevelAccessRoundTrips proves UBLA enabled via a bucket
+// patch is persisted and read back with its lockedTime — instead of being
+// dropped by a hardcoded iamConfiguration.
+func TestGCSUniformBucketLevelAccessRoundTrips(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "ubla-bucket")
+
+	before, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs: %v", err)
+	}
+
+	if before.UniformBucketLevelAccess.Enabled {
+		t.Fatal("UBLA enabled by default, want disabled")
+	}
+
+	if _, err = bkt.Update(ctx, storage.BucketAttrsToUpdate{
+		UniformBucketLevelAccess: &storage.UniformBucketLevelAccess{Enabled: true},
+	}); err != nil {
+		t.Fatalf("enable UBLA: %v", err)
+	}
+
+	after, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs after enable: %v", err)
+	}
+
+	if !after.UniformBucketLevelAccess.Enabled {
+		t.Fatal("UBLA not enabled after update")
+	}
+
+	if after.UniformBucketLevelAccess.LockedTime.IsZero() {
+		t.Error("UBLA LockedTime is zero, want a lock window when enabled")
+	}
+
+	// Disabling clears it.
+	if _, err = bkt.Update(ctx, storage.BucketAttrsToUpdate{
+		UniformBucketLevelAccess: &storage.UniformBucketLevelAccess{Enabled: false},
+	}); err != nil {
+		t.Fatalf("disable UBLA: %v", err)
+	}
+
+	off, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs after disable: %v", err)
+	}
+
+	if off.UniformBucketLevelAccess.Enabled {
+		t.Error("UBLA still enabled after disable")
+	}
+
+	if !off.UniformBucketLevelAccess.LockedTime.IsZero() {
+		t.Error("UBLA LockedTime not cleared after disable")
+	}
+}
+
+// TestGCSPublicAccessPreventionRoundTrips proves publicAccessPrevention is
+// settable and read back (default inherited).
+func TestGCSPublicAccessPreventionRoundTrips(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "pap-bucket")
+
+	def, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs: %v", err)
+	}
+
+	if def.PublicAccessPrevention != storage.PublicAccessPreventionInherited &&
+		def.PublicAccessPrevention != storage.PublicAccessPreventionUnknown {
+		t.Errorf("default PublicAccessPrevention = %v, want inherited/unknown", def.PublicAccessPrevention)
+	}
+
+	if _, err = bkt.Update(ctx, storage.BucketAttrsToUpdate{
+		PublicAccessPrevention: storage.PublicAccessPreventionEnforced,
+	}); err != nil {
+		t.Fatalf("set PAP enforced: %v", err)
+	}
+
+	after, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs after PAP: %v", err)
+	}
+
+	if after.PublicAccessPrevention != storage.PublicAccessPreventionEnforced {
+		t.Errorf("PublicAccessPrevention = %v, want enforced", after.PublicAccessPrevention)
+	}
+}
+
+func assertHTTPStatus(t *testing.T, err error, want int) {
+	t.Helper()
+
+	var apiErr *googleapi.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error %v is not a *googleapi.Error", err)
+	}
+
+	if apiErr.Code != want {
+		t.Errorf("HTTP status = %d, want %d (err: %v)", apiErr.Code, want, err)
+	}
+}

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -21,6 +21,7 @@ package gcs
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -70,6 +71,8 @@ const (
 	// pathBO is /b/{bucket}/o = 3 segments.
 	pathBO = 3
 
+	// collectionProjects is the /projects/{project}/... top-level collection.
+	collectionProjects = "projects"
 	// subresIAM is the /b/{bucket}/iam sub-collection segment.
 	subresIAM = "iam"
 	// subresNotificationConfigs is the /b/{bucket}/notificationConfigs segment.
@@ -92,6 +95,15 @@ type Handler struct {
 	// configuration verbatim (every rule condition), nil when the backing driver
 	// only supports the age-only portable driver.LifecycleConfig.
 	lifecycle lifecycleRawStore
+
+	// iamCfg is the optional capability that persists a bucket's iamConfiguration
+	// (Uniform Bucket-Level Access + Public Access Prevention); nil falls back to
+	// the read-only GCS defaults.
+	iamCfg iamConfigStore
+
+	// hmac is the optional capability backing project-scoped service-account HMAC
+	// keys; nil makes the /projects/{p}/hmacKeys endpoints report not-implemented.
+	hmac hmacKeyStore
 
 	// publisher emits object-change events to Pub/Sub for matching bucket
 	// notification configs. Nil (the default) makes object events a no-op, so
@@ -125,8 +137,17 @@ type resumableSession struct {
 func New(b storagedriver.Bucket) *Handler {
 	ext, _ := b.(storagedriver.GCSExtensions)
 	lifecycle, _ := b.(lifecycleRawStore)
+	iamCfg, _ := b.(iamConfigStore)
+	hmac, _ := b.(hmacKeyStore)
 
-	return &Handler{bucket: b, ext: ext, lifecycle: lifecycle, resumable: make(map[string]*resumableSession)}
+	return &Handler{
+		bucket:    b,
+		ext:       ext,
+		lifecycle: lifecycle,
+		iamCfg:    iamCfg,
+		hmac:      hmac,
+		resumable: make(map[string]*resumableSession),
+	}
 }
 
 // Matches returns true for /storage/v1/, /upload/storage/v1/, and direct
@@ -202,6 +223,17 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rest := strings.TrimPrefix(r.URL.Path, jsonAPIPrefix)
 	parts := strings.Split(rest, "/")
 
+	if len(parts) > 0 && parts[0] == collectionProjects {
+		h.projectRoute(w, r, parts)
+		return
+	}
+
+	h.serveBucketAPI(w, r, parts)
+}
+
+// serveBucketAPI dispatches the /storage/v1/b[/...] bucket + object JSON API
+// routes.
+func (h *Handler) serveBucketAPI(w http.ResponseWriter, r *http.Request, parts []string) {
 	if len(parts) == 0 || parts[0] != "b" {
 		writeError(w, http.StatusNotFound, "notFound", "unknown collection")
 		return
@@ -213,30 +245,38 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case pathBucket:
 		h.bucketResource(w, r, parts[1])
 	case pathBO:
-		// /b/{bucket}/o — list objects; /b/{bucket}/iam — bucket IAM policy.
-		switch parts[2] {
-		case "o":
-			h.listObjects(w, r, parts[1])
-		case subresIAM:
-			h.bucketIAM(w, r, parts[1])
-		case subresNotificationConfigs:
-			h.notificationCollection(w, r, parts[1])
-		default:
-			writeError(w, http.StatusNotFound, "notFound", "unknown sub-collection")
-		}
+		h.serveBucketSubcollection(w, r, parts)
 	default:
-		// /b/{bucket}/o/{obj}[/...], /b/{bucket}/iam/testPermissions, or
-		// /b/{bucket}/notificationConfigs/{id}.
-		switch {
-		case parts[2] == "o":
-			h.objectOp(w, r, parts[1], strings.Join(parts[3:], "/"))
-		case parts[2] == subresIAM && parts[3] == "testPermissions":
-			h.testIAMPermissions(w, r, parts[1])
-		case parts[2] == subresNotificationConfigs:
-			h.notificationResourceOp(w, r, parts[1], parts[3])
-		default:
-			writeError(w, http.StatusNotFound, "notFound", "unknown sub-collection")
-		}
+		h.serveBucketSubresource(w, r, parts)
+	}
+}
+
+// serveBucketSubcollection routes /b/{bucket}/{o|iam|notificationConfigs}.
+func (h *Handler) serveBucketSubcollection(w http.ResponseWriter, r *http.Request, parts []string) {
+	switch parts[2] {
+	case "o":
+		h.listObjects(w, r, parts[1])
+	case subresIAM:
+		h.bucketIAM(w, r, parts[1])
+	case subresNotificationConfigs:
+		h.notificationCollection(w, r, parts[1])
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown sub-collection")
+	}
+}
+
+// serveBucketSubresource routes the deep paths: /b/{bucket}/o/{obj}[/...],
+// /b/{bucket}/iam/testPermissions, and /b/{bucket}/notificationConfigs/{id}.
+func (h *Handler) serveBucketSubresource(w http.ResponseWriter, r *http.Request, parts []string) {
+	switch {
+	case parts[2] == "o":
+		h.objectOp(w, r, parts[1], strings.Join(parts[3:], "/"))
+	case parts[2] == subresIAM && parts[3] == "testPermissions":
+		h.testIAMPermissions(w, r, parts[1])
+	case parts[2] == subresNotificationConfigs:
+		h.notificationResourceOp(w, r, parts[1], parts[3])
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown sub-collection")
 	}
 }
 
@@ -298,6 +338,8 @@ func (h *Handler) createBucket(w http.ResponseWriter, r *http.Request) {
 		_ = h.putLifecycle(r.Context(), body.Name, body.Lifecycle)
 	}
 
+	_ = h.applyIAMConfig(r.Context(), body.Name, body.IamConfiguration)
+
 	writeJSON(w, http.StatusOK, h.bucketView(r, body.Name, time.Now().UTC().Format(time.RFC3339)))
 }
 
@@ -352,7 +394,7 @@ func (h *Handler) bucketView(r *http.Request, name, created string) bucketResour
 		Etag:             name + "/" + strconv.FormatInt(metageneration, 10),
 		TimeCreated:      created,
 		Updated:          updated,
-		IamConfiguration: &iamConfiguration{PublicAccessPrevention: "inherited"},
+		IamConfiguration: h.iamConfigView(r.Context(), name),
 	}
 
 	if enabled, err := h.bucket.GetBucketVersioning(r.Context(), name); err == nil && enabled {
@@ -426,25 +468,9 @@ func (h *Handler) patchBucket(w http.ResponseWriter, r *http.Request, name strin
 		return
 	}
 
-	if body.Versioning != nil {
-		if err := h.bucket.SetBucketVersioning(r.Context(), name, body.Versioning.Enabled); err != nil {
-			writeErr(w, err)
-			return
-		}
-	}
-
-	if body.Labels != nil {
-		if err := h.bucket.PutBucketTagging(r.Context(), name, body.Labels); err != nil {
-			writeErr(w, err)
-			return
-		}
-	}
-
-	if body.Lifecycle != nil {
-		if err := h.putLifecycle(r.Context(), name, body.Lifecycle); err != nil {
-			writeErr(w, err)
-			return
-		}
+	if err := h.applyBucketConfig(r.Context(), name, &body); err != nil {
+		writeErr(w, err)
+		return
 	}
 
 	if h.ext != nil {
@@ -456,6 +482,37 @@ func (h *Handler) patchBucket(w http.ResponseWriter, r *http.Request, name strin
 	}
 
 	writeJSON(w, http.StatusOK, h.bucketView(r, name, ""))
+}
+
+// applyBucketConfig applies the mutable configuration fields present in a
+// Buckets.patch/update body (versioning, labels, lifecycle, iamConfiguration),
+// each only when supplied. It returns the first error encountered.
+func (h *Handler) applyBucketConfig(ctx context.Context, name string, body *bucketResource) error {
+	if body.Versioning != nil {
+		if err := h.bucket.SetBucketVersioning(ctx, name, body.Versioning.Enabled); err != nil {
+			return err
+		}
+	}
+
+	if body.Labels != nil {
+		if err := h.bucket.PutBucketTagging(ctx, name, body.Labels); err != nil {
+			return err
+		}
+	}
+
+	if body.Lifecycle != nil {
+		if err := h.putLifecycle(ctx, name, body.Lifecycle); err != nil {
+			return err
+		}
+	}
+
+	if body.IamConfiguration != nil {
+		if err := h.applyIAMConfig(ctx, name, body.IamConfiguration); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (h *Handler) deleteBucket(w http.ResponseWriter, r *http.Request, name string) {

--- a/server/gcp/gcs/hmac.go
+++ b/server/gcp/gcs/hmac.go
@@ -1,0 +1,226 @@
+package gcs
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+)
+
+// hmacKeyStore is the optional capability that persists project-scoped
+// service-account HMAC keys (the S3-interoperability credentials GCS mints at
+// /storage/v1/projects/{project}/hmacKeys). It exchanges metadata as JSON so the
+// wire layer stays decoupled from the driver's record type; the create secret is
+// returned separately, surfaced to the client exactly once.
+type hmacKeyStore interface {
+	CreateHMACKeyGCS(ctx context.Context, projectID, serviceAccountEmail string) (metadata []byte, secret string, err error)
+	ListHMACKeysGCS(ctx context.Context, projectID, serviceAccountEmail string, showDeleted bool) ([]byte, error)
+	GetHMACKeyGCS(ctx context.Context, projectID, accessID string) ([]byte, error)
+	UpdateHMACKeyStateGCS(ctx context.Context, projectID, accessID, state string) ([]byte, error)
+	DeleteHMACKeyGCS(ctx context.Context, projectID, accessID string) error
+}
+
+// subresHMACKeys is the /projects/{project}/hmacKeys sub-collection segment.
+const subresHMACKeys = "hmacKeys"
+
+// hmacKeyMetadata is the storage#hmacKeyMetadata resource. The data fields carry
+// json tags matching the driver's exchange struct so a provider metadata blob
+// unmarshals straight into it; the handler then stamps kind/id/selfLink.
+type hmacKeyMetadata struct {
+	Kind                string `json:"kind"`
+	ID                  string `json:"id,omitempty"`
+	AccessID            string `json:"accessId"`
+	ProjectID           string `json:"projectId"`
+	ServiceAccountEmail string `json:"serviceAccountEmail"`
+	State               string `json:"state"`
+	TimeCreated         string `json:"timeCreated,omitempty"`
+	Updated             string `json:"updated,omitempty"`
+	Etag                string `json:"etag,omitempty"`
+	SelfLink            string `json:"selfLink,omitempty"`
+}
+
+// hmacKeyResource is the storage#hmacKey create response: the metadata plus the
+// secret, which GCS returns only here.
+type hmacKeyResource struct {
+	Kind     string          `json:"kind"`
+	Metadata hmacKeyMetadata `json:"metadata"`
+	Secret   string          `json:"secret"`
+}
+
+type hmacKeysListResponse struct {
+	Kind  string            `json:"kind"`
+	Items []hmacKeyMetadata `json:"items,omitempty"`
+}
+
+// projectRoute dispatches /projects/{project}/hmacKeys[/{accessId}] requests.
+func (h *Handler) projectRoute(w http.ResponseWriter, r *http.Request, parts []string) {
+	// parts is ["projects", project, "hmacKeys", accessId?].
+	if len(parts) < pathBO || parts[2] != subresHMACKeys {
+		writeError(w, http.StatusNotFound, "notFound", "unknown project resource")
+		return
+	}
+
+	project := parts[1]
+
+	switch len(parts) {
+	case pathBO:
+		h.hmacCollection(w, r, project)
+	case pathBOObj:
+		h.hmacResource(w, r, project, parts[3])
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown hmacKeys resource")
+	}
+}
+
+// hmacCollection serves /projects/{project}/hmacKeys — POST creates a key, GET
+// lists keys.
+func (h *Handler) hmacCollection(w http.ResponseWriter, r *http.Request, project string) {
+	if h.hmac == nil {
+		writeError(w, http.StatusNotImplemented, "notImplemented", "HMAC keys not supported")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPost:
+		h.createHMACKey(w, r, project)
+	case http.MethodGet:
+		h.listHMACKeys(w, r, project)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+	}
+}
+
+// hmacResource serves /projects/{project}/hmacKeys/{accessId} — GET metadata,
+// PUT state update, DELETE.
+func (h *Handler) hmacResource(w http.ResponseWriter, r *http.Request, project, accessID string) {
+	if h.hmac == nil {
+		writeError(w, http.StatusNotImplemented, "notImplemented", "HMAC keys not supported")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getHMACKey(w, r, project, accessID)
+	case http.MethodPut, http.MethodPost:
+		h.updateHMACKey(w, r, project, accessID)
+	case http.MethodDelete:
+		h.deleteHMACKey(w, r, project, accessID)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+	}
+}
+
+func (h *Handler) createHMACKey(w http.ResponseWriter, r *http.Request, project string) {
+	email := r.URL.Query().Get("serviceAccountEmail")
+	if email == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "serviceAccountEmail query parameter required")
+		return
+	}
+
+	metaRaw, secret, err := h.hmac.CreateHMACKeyGCS(r.Context(), project, email)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	meta, err := renderHMACMeta(metaRaw, r, project)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, hmacKeyResource{Kind: "storage#hmacKey", Metadata: meta, Secret: secret})
+}
+
+func (h *Handler) listHMACKeys(w http.ResponseWriter, r *http.Request, project string) {
+	q := r.URL.Query()
+	showDeleted, _ := strconv.ParseBool(q.Get("showDeletedKeys"))
+
+	raw, err := h.hmac.ListHMACKeysGCS(r.Context(), project, q.Get("serviceAccountEmail"), showDeleted)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	var metas []hmacKeyMetadata
+	if uErr := json.Unmarshal(raw, &metas); uErr != nil {
+		writeErr(w, uErr)
+		return
+	}
+
+	for i := range metas {
+		stampHMACMeta(&metas[i], r, project)
+	}
+
+	writeJSON(w, http.StatusOK, hmacKeysListResponse{Kind: "storage#hmacKeysMetadata", Items: metas})
+}
+
+func (h *Handler) getHMACKey(w http.ResponseWriter, r *http.Request, project, accessID string) {
+	raw, err := h.hmac.GetHMACKeyGCS(r.Context(), project, accessID)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeHMACMeta(w, r, project, raw)
+}
+
+func (h *Handler) updateHMACKey(w http.ResponseWriter, r *http.Request, project, accessID string) {
+	var body struct {
+		State string `json:"state"`
+	}
+
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	raw, err := h.hmac.UpdateHMACKeyStateGCS(r.Context(), project, accessID, body.State)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeHMACMeta(w, r, project, raw)
+}
+
+func (h *Handler) deleteHMACKey(w http.ResponseWriter, r *http.Request, project, accessID string) {
+	if err := h.hmac.DeleteHMACKeyGCS(r.Context(), project, accessID); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// writeHMACMeta renders a provider metadata blob into the wire resource and
+// writes it.
+func writeHMACMeta(w http.ResponseWriter, r *http.Request, project string, raw []byte) {
+	meta, err := renderHMACMeta(raw, r, project)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, meta)
+}
+
+// renderHMACMeta unmarshals a driver metadata blob and stamps the wire-only
+// fields (kind/id/selfLink).
+func renderHMACMeta(raw []byte, r *http.Request, project string) (hmacKeyMetadata, error) {
+	var meta hmacKeyMetadata
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return hmacKeyMetadata{}, err
+	}
+
+	stampHMACMeta(&meta, r, project)
+
+	return meta, nil
+}
+
+// stampHMACMeta fills the wire-derived kind/id/selfLink fields on a metadata
+// value whose data fields were populated from the driver.
+func stampHMACMeta(meta *hmacKeyMetadata, r *http.Request, project string) {
+	meta.Kind = "storage#hmacKeyMetadata"
+	meta.ID = meta.ProjectID + "/" + meta.AccessID
+	meta.SelfLink = selfLink(r, "/storage/v1/projects/"+project+"/hmacKeys/"+meta.AccessID)
+}

--- a/server/gcp/gcs/iamconfig.go
+++ b/server/gcp/gcs/iamconfig.go
@@ -1,0 +1,63 @@
+package gcs
+
+import "context"
+
+// defaultPublicAccessPrevention is what GCS reports for a bucket that never set
+// the field explicitly.
+const defaultPublicAccessPrevention = "inherited"
+
+// iamConfigStore is the optional capability that persists a bucket's
+// iamConfiguration — Uniform Bucket-Level Access (with its lockedTime) and
+// Public Access Prevention — so a Buckets.patch of these round-trips on GET
+// instead of reading back a hardcoded default.
+type iamConfigStore interface {
+	SetBucketIAMConfigGCS(ctx context.Context, bucket string, ublaEnabled *bool, publicAccessPrevention string) error
+	BucketIAMConfigGCS(ctx context.Context, bucket string) (enabled bool, lockedTime, publicAccessPrevention string, err error)
+}
+
+// applyIAMConfig persists an incoming iamConfiguration block (from create or
+// patch). A nil block leaves the bucket's config untouched.
+func (h *Handler) applyIAMConfig(ctx context.Context, bucket string, cfg *iamConfiguration) error {
+	if h.iamCfg == nil || cfg == nil {
+		return nil
+	}
+
+	var ubla *bool
+
+	if cfg.UniformBucketLevelAccess != nil {
+		enabled := cfg.UniformBucketLevelAccess.Enabled
+		ubla = &enabled
+	}
+
+	if ubla == nil && cfg.PublicAccessPrevention == "" {
+		return nil
+	}
+
+	return h.iamCfg.SetBucketIAMConfigGCS(ctx, bucket, ubla, cfg.PublicAccessPrevention)
+}
+
+// iamConfigView renders a bucket's stored iamConfiguration, falling back to the
+// GCS defaults (UBLA disabled, publicAccessPrevention "inherited") when the
+// backing driver doesn't persist it.
+func (h *Handler) iamConfigView(ctx context.Context, bucket string) *iamConfiguration {
+	cfg := &iamConfiguration{PublicAccessPrevention: defaultPublicAccessPrevention}
+
+	if h.iamCfg == nil {
+		return cfg
+	}
+
+	enabled, lockedTime, pap, err := h.iamCfg.BucketIAMConfigGCS(ctx, bucket)
+	if err != nil {
+		return cfg
+	}
+
+	if pap != "" {
+		cfg.PublicAccessPrevention = pap
+	}
+
+	if enabled {
+		cfg.UniformBucketLevelAccess = &uniformBucketLevelAccess{Enabled: true, LockedTime: lockedTime}
+	}
+
+	return cfg
+}

--- a/server/gcp/gcs/types.go
+++ b/server/gcp/gcs/types.go
@@ -64,6 +64,9 @@ type iamConfiguration struct {
 
 type uniformBucketLevelAccess struct {
 	Enabled bool `json:"enabled"`
+	// LockedTime is when UBLA becomes permanent; GCS stamps it ~90 days out when
+	// UBLA is enabled and omits it when disabled.
+	LockedTime string `json:"lockedTime,omitempty"`
 }
 
 type bucketsListResponse struct {


### PR DESCRIPTION
## Summary

Closes the GCS storage tail from the world-case object-storage audit (PR-7): service-account **HMAC keys** and settable **uniform bucket-level access (UBLA)** / **public access prevention**, both previously missing.

### HMAC keys (`/storage/v1/projects/{project}/hmacKeys`)
- Full CRUD over the real GCS JSON API: create (returns access-id + secret once), list (filter by service account), get metadata, update state (ACTIVE/INACTIVE), delete.
- Delete enforces the real-cloud guard: an ACTIVE key cannot be deleted (400); it must be set INACTIVE first.
- Project-scoped, keyed by access id; secret is surfaced only at create.

### Uniform Bucket-Level Access + Public Access Prevention
- `iamConfiguration.uniformBucketLevelAccess.enabled` is now settable via bucket create/patch and round-trips on GET, with a `lockedTime` stamped when enabled (cleared on disable) — instead of the previous hardcoded `iamConfiguration` that silently dropped the setting (a Terraform diff source).
- `publicAccessPrevention` is settable and round-trips (default `inherited`).

### Design
- Both are provider-backed **optional capabilities** discovered by type assertion (same pattern as the existing lifecycle capability), so the wire layer stays decoupled from the driver's record type and no shared driver interface changed.
- State is snapshot-persisted (bucket iamConfiguration fields + a project HMAC-key store) and concurrency-safe via memstore write-locked updates (`Update`/`UpdateOrDelete` for the compare-and-act delete guard).
- Scope limited to `server/gcp/gcs` + `providers/gcp/gcs`.

## Tests
- Real `cloud.google.com/go/storage` SDK journeys: HMAC create→list→get→deactivate→delete (delete-active rejected, delete-inactive ok); UBLA enable via bucket patch reflects enabled + lockedTime on GET; publicAccessPrevention round-trip.
- Provider-level unit tests incl. project/account list filtering, validation, a concurrent-create `-race` stress, and snapshot/restore round-trip.

## Gates
- `go build ./...`, `gofmt -l` empty, `go test ./server/gcp/gcs/... ./providers/gcp/gcs/... -race`, broad `go test ./server/gcp/...`, full `go test ./...` (exit 0), golangci-lint (0 new issues), coveragegen + `docs/coverage` clean, `go mod tidy` clean.