### PR TITLE
feat(gcp-cloudsql): reject deleting/stopping a primary with live read replicas

### DIFF
--- a/providers/gcp/cloudsql/cloudsql.go
+++ b/providers/gcp/cloudsql/cloudsql.go
@@ -499,6 +499,14 @@ func (m *Mock) DeleteInstance(ctx context.Context, id string) error {
 			"Cloud SQL instance %q has deletion protection enabled", id)
 	}
 
+	// A primary with live read replicas cannot be deleted; real Cloud SQL rejects
+	// the delete until every replica is promoted or removed first, rather than
+	// silently orphaning them.
+	if reps := m.liveReplicas(&inst); len(reps) > 0 {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"Cloud SQL instance %q cannot be deleted because it has read replicas %v; delete or promote them first", id, reps)
+	}
+
 	// Tear down the real database backing the instance, if any.
 	if err := dbengine.Deprovision(ctx, m.opts.DatabaseEngine, &inst); err != nil {
 		return err
@@ -561,13 +569,57 @@ func (m *Mock) deleteChildren(instance string) {
 // StartInstance moves a stopped instance back to runnable. In Cloud SQL this
 // corresponds to setting settings.activationPolicy=ALWAYS.
 func (m *Mock) StartInstance(_ context.Context, id string) error {
-	return m.transitionInstance(id, rdsdriver.StateStopped, rdsdriver.StateAvailable, cpuMetricRunning, connRunning, "start")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.transitionInstanceLocked(id, rdsdriver.StateStopped, rdsdriver.StateAvailable, cpuMetricRunning, connRunning, "start")
 }
 
 // StopInstance moves a runnable instance to stopped. In Cloud SQL this
-// corresponds to setting settings.activationPolicy=NEVER.
+// corresponds to setting settings.activationPolicy=NEVER. Real Cloud SQL refuses
+// to stop an instance that is a read replica, or a primary that still has read
+// replicas — the guard and transition run under one lock so a replica cannot be
+// attached in the window between the check and the state change.
 func (m *Mock) StopInstance(_ context.Context, id string) error {
-	return m.transitionInstance(id, rdsdriver.StateAvailable, rdsdriver.StateStopped, cpuMetricStopped, 0, "stop")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	inst, ok := m.instances.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "Cloud SQL instance %q not found", id)
+	}
+
+	if inst.ReadReplicaSource != "" {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"Cloud SQL instance %q is a read replica and cannot be stopped; promote or delete it instead", id)
+	}
+
+	if reps := m.liveReplicas(&inst); len(reps) > 0 {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"Cloud SQL instance %q cannot be stopped because it has read replicas %v; delete them first", id, reps)
+	}
+
+	return m.transitionInstanceLocked(id, rdsdriver.StateAvailable, rdsdriver.StateStopped, cpuMetricStopped, 0, "stop")
+}
+
+// liveReplicas returns the ids of inst's read replicas that still exist in the
+// store. The caller holds the lock. ReadReplicaTargets is kept in sync by
+// linkReplica / unlinkReplicas / PromoteReplica, but filtering to rows that are
+// still present keeps the guard correct even if a stale id ever lingered.
+func (m *Mock) liveReplicas(inst *rdsdriver.Instance) []string {
+	if len(inst.ReadReplicaTargets) == 0 {
+		return nil
+	}
+
+	live := make([]string, 0, len(inst.ReadReplicaTargets))
+
+	for _, replicaID := range inst.ReadReplicaTargets {
+		if _, ok := m.instances.Get(replicaID); ok {
+			live = append(live, replicaID)
+		}
+	}
+
+	return live
 }
 
 // RebootInstance cycles an instance through rebooting. In Cloud SQL this
@@ -598,10 +650,9 @@ func (m *Mock) RebootInstance(_ context.Context, id string) error {
 	return nil
 }
 
-func (m *Mock) transitionInstance(id, from, to string, cpu, conns float64, verb string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
+// transitionInstanceLocked performs a guarded state transition (idempotent when
+// the instance is already in the target state). The caller holds the write lock.
+func (m *Mock) transitionInstanceLocked(id, from, to string, cpu, conns float64, verb string) error {
 	inst, ok := m.instances.Get(id)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "Cloud SQL instance %q not found", id)

--- a/providers/gcp/cloudsql/cloudsql_test.go
+++ b/providers/gcp/cloudsql/cloudsql_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/providers/gcp/monitoring"
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
@@ -478,16 +479,75 @@ func TestDeleteInstanceUnlinksReplicas(t *testing.T) {
 		t.Errorf("master still lists a deleted replica: %v", got[0].ReadReplicaTargets)
 	}
 
-	// Deleting the master clears the source pointer on its surviving replica.
+	// A master with a live read replica cannot be deleted; real Cloud SQL requires
+	// the replicas be promoted or removed first rather than orphaning them.
 	mk("replica2", "master")
 
-	if err := m.DeleteInstance(ctx, "master"); err != nil {
-		t.Fatalf("DeleteInstance master: %v", err)
+	err := m.DeleteInstance(ctx, "master")
+	if err == nil {
+		t.Fatal("DeleteInstance master with a live replica: expected FailedPrecondition")
 	}
 
-	got, _ = m.DescribeInstances(ctx, []string{"replica2"})
-	if got[0].ReadReplicaSource != "" {
-		t.Errorf("replica still points at a deleted master: %q", got[0].ReadReplicaSource)
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("DeleteInstance master: got %v, want FailedPrecondition", err)
+	}
+
+	// Promoting the replica detaches it, after which the master deletes cleanly.
+	if err := m.PromoteReplica(ctx, "replica2"); err != nil {
+		t.Fatalf("PromoteReplica replica2: %v", err)
+	}
+
+	if err := m.DeleteInstance(ctx, "master"); err != nil {
+		t.Fatalf("DeleteInstance master after promote: %v", err)
+	}
+}
+
+func TestStopInstanceReplicaGuards(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	mk := func(id, master string) {
+		if _, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{
+			ID: id, Engine: "POSTGRES_15", MasterInstanceName: master,
+		}); err != nil {
+			t.Fatalf("CreateInstance %q: %v", id, err)
+		}
+	}
+
+	mk("primary", "")
+	mk("replica", "primary")
+
+	// A primary that still has a replica cannot be stopped.
+	if err := m.StopInstance(ctx, "primary"); err == nil {
+		t.Fatal("StopInstance on a primary with a replica: expected FailedPrecondition")
+	} else if !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("StopInstance primary: got %v, want FailedPrecondition", err)
+	}
+
+	// A read replica cannot be stopped on its own.
+	if err := m.StopInstance(ctx, "replica"); err == nil {
+		t.Fatal("StopInstance on a read replica: expected FailedPrecondition")
+	} else if !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("StopInstance replica: got %v, want FailedPrecondition", err)
+	}
+
+	// The primary is still RUNNABLE after the rejected stops.
+	got, _ := m.DescribeInstances(ctx, []string{"primary"})
+	if got[0].State != rdsdriver.StateAvailable {
+		t.Fatalf("primary state = %q, want %q", got[0].State, rdsdriver.StateAvailable)
+	}
+
+	// Promote the replica, then the primary stops and starts cleanly.
+	if err := m.PromoteReplica(ctx, "replica"); err != nil {
+		t.Fatalf("PromoteReplica: %v", err)
+	}
+
+	if err := m.StopInstance(ctx, "primary"); err != nil {
+		t.Fatalf("StopInstance primary after promote: %v", err)
+	}
+
+	if err := m.StartInstance(ctx, "primary"); err != nil {
+		t.Fatalf("StartInstance primary: %v", err)
 	}
 }
 

--- a/server/gcp/cloudsql/replica_guards_sdk_test.go
+++ b/server/gcp/cloudsql/replica_guards_sdk_test.go
@@ -1,0 +1,165 @@
+package cloudsql_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+	sqladmin "google.golang.org/api/sqladmin/v1"
+)
+
+// insertReplica creates a read replica of master via a normal insert carrying
+// masterInstanceName, matching how a real sqladmin client provisions a replica.
+func insertReplica(t *testing.T, svc *sqladmin.Service, project, name, master string) {
+	t.Helper()
+
+	if _, err := svc.Instances.Insert(project, &sqladmin.DatabaseInstance{
+		Name:               name,
+		DatabaseVersion:    "POSTGRES_15",
+		Region:             "us-central1",
+		MasterInstanceName: master,
+		Settings:           &sqladmin.Settings{Tier: "db-custom-2-8192"},
+	}).Context(context.Background()).Do(); err != nil {
+		t.Fatalf("replica Insert %q: %v", name, err)
+	}
+}
+
+// requireAPIError asserts err is a googleapi.Error with the wanted HTTP status
+// whose message mentions want, so the test pins the real wire status a client
+// sees (Cloud SQL maps these FAILED_PRECONDITION guards to HTTP 400).
+func requireAPIError(t *testing.T, err error, code int, want string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("expected an error mentioning %q, got nil", want)
+	}
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) {
+		t.Fatalf("expected *googleapi.Error, got %T: %v", err, err)
+	}
+
+	if gerr.Code != code {
+		t.Fatalf("error code = %d, want %d (%v)", gerr.Code, code, err)
+	}
+
+	if !strings.Contains(gerr.Message, want) {
+		t.Fatalf("error message = %q, want it to mention %q", gerr.Message, want)
+	}
+}
+
+// TestSDKCloudSQLDeletePrimaryWithReplicaBlocked drives the real sqladmin SDK:
+// deleting a primary that still has a read replica is rejected, and only
+// succeeds once the replica is removed first — matching real Cloud SQL, which
+// refuses to orphan replicas.
+func TestSDKCloudSQLDeletePrimaryWithReplicaBlocked(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateInstance(t, svc, project, "pg")
+	insertReplica(t, svc, project, "pg-replica", "pg")
+
+	// The primary cannot be deleted while a replica is attached.
+	_, err := svc.Instances.Delete(project, "pg").Context(ctx).Do()
+	requireAPIError(t, err, 400, "replica")
+
+	// The primary is still present after the blocked delete.
+	if _, err := svc.Instances.Get(project, "pg").Context(ctx).Do(); err != nil {
+		t.Fatalf("primary should survive a blocked delete: %v", err)
+	}
+
+	// Deleting the replica first is allowed.
+	if _, err := svc.Instances.Delete(project, "pg-replica").Context(ctx).Do(); err != nil {
+		t.Fatalf("Delete replica: %v", err)
+	}
+
+	// With the replica gone, the primary deletes cleanly.
+	if _, err := svc.Instances.Delete(project, "pg").Context(ctx).Do(); err != nil {
+		t.Fatalf("Delete primary after replica removed: %v", err)
+	}
+}
+
+// TestSDKCloudSQLStopReplicaGuards asserts the real Cloud SQL start/stop rules
+// over the wire: an instance that has read replicas cannot be stopped, an
+// instance that is itself a read replica cannot be stopped, and once the replica
+// is removed the primary stops normally. Stop is emulated by a Patch that sets
+// settings.activationPolicy=NEVER.
+func TestSDKCloudSQLStopReplicaGuards(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateInstance(t, svc, project, "pg")
+	insertReplica(t, svc, project, "pg-replica", "pg")
+
+	stop := func(name string) error {
+		_, err := svc.Instances.Patch(project, name, &sqladmin.DatabaseInstance{
+			Settings: &sqladmin.Settings{ActivationPolicy: "NEVER"},
+		}).Context(ctx).Do()
+
+		return err
+	}
+
+	// A primary that still has a replica cannot be stopped.
+	requireAPIError(t, stop("pg"), 400, "read replicas")
+
+	// A read replica cannot be stopped on its own.
+	requireAPIError(t, stop("pg-replica"), 400, "read replica")
+
+	// Remove the replica, then the primary stops cleanly.
+	if _, err := svc.Instances.Delete(project, "pg-replica").Context(ctx).Do(); err != nil {
+		t.Fatalf("Delete replica: %v", err)
+	}
+
+	if err := stop("pg"); err != nil {
+		t.Fatalf("stop primary after replica removed: %v", err)
+	}
+
+	got, err := svc.Instances.Get(project, "pg").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get primary: %v", err)
+	}
+
+	// Cloud SQL reports a stopped (activationPolicy=NEVER) instance as SUSPENDED.
+	if got.State != "SUSPENDED" {
+		t.Fatalf("primary state = %q, want SUSPENDED", got.State)
+	}
+}
+
+// TestSDKCloudSQLDeletionProtectionBlocksDelete confirms the deletion-protection
+// guard end to end: a protected instance refuses delete with the real error, and
+// clearing settings.deletionProtectionEnabled lets the delete through.
+func TestSDKCloudSQLDeletionProtectionBlocksDelete(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := svc.Instances.Insert(project, &sqladmin.DatabaseInstance{
+		Name:            "guarded",
+		DatabaseVersion: "POSTGRES_15",
+		Region:          "us-central1",
+		Settings: &sqladmin.Settings{
+			Tier:                      "db-custom-2-8192",
+			DeletionProtectionEnabled: true,
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Instances.Insert: %v", err)
+	}
+
+	_, err := svc.Instances.Delete(project, "guarded").Context(ctx).Do()
+	requireAPIError(t, err, 400, "deletion protection")
+
+	// Clear the guard (false is the zero value, so force it onto the wire).
+	if _, err := svc.Instances.Patch(project, "guarded", &sqladmin.DatabaseInstance{
+		Settings: &sqladmin.Settings{
+			DeletionProtectionEnabled: false,
+			ForceSendFields:           []string{"DeletionProtectionEnabled"},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Instances.Patch clear protection: %v", err)
+	}
+
+	if _, err := svc.Instances.Delete(project, "guarded").Context(ctx).Do(); err != nil {
+		t.Fatalf("Delete after clearing protection: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Close the highest-value remaining GCP Cloud SQL lifecycle-guard gaps so the
emulator matches real `sqladmin` cascade/teardown semantics. Scope is limited to
`providers/gcp/cloudsql` + `server/gcp/cloudsql`; the #977 async-settle adoption
in the same package is untouched (default-off unchanged, its SDK test still green).

## Gaps closed

- **Delete a primary that has live read replicas is rejected** (was: `DeleteInstance`
  silently orphaned replicas via `unlinkReplicas`). Real Cloud SQL refuses the
  delete until every replica is promoted or removed first. Maps to HTTP 400
  `FAILED_PRECONDITION` over the wire, alongside the existing deletion-protection guard.
- **Stop an instance that has read replicas is rejected**, and **stopping an
  instance that is itself a read replica is rejected** — the documented GCP
  start/stop rules (a replica follows its primary; a primary with replicas can't
  be stopped). Stop is driven by `settings.activationPolicy=NEVER`; the guard
  returns HTTP 400 `FAILED_PRECONDITION`.

Both guards use a new `liveReplicas` helper that filters `ReadReplicaTargets` to
rows still present in the store. `StartInstance`/`StopInstance` were refactored to
hold the provider write lock across guard + transition (`transitionInstanceLocked`)
so a replica cannot be attached in the window between the check and the state
change — concurrency-safe, `-race` clean.

## Gaps deferred (out of this pass)

- CS3 logical databases/users as real `CREATE DATABASE`/`CREATE USER` in the backing engine.
- CS4 failover swapping a real HA standby (no standby modeled).
- CS5 real PITR/byte-copy restore/clone data.
- CS6 richer LRO (RUNNING) + `rescheduleMaintenance`/`demoteMaster`/`truncateLog`/`connectSettings`.

## Tests (real `sqladmin` SDK)

- `TestSDKCloudSQLDeletePrimaryWithReplicaBlocked` — primary+replica: delete
  primary blocked (400, mentions "replica"), survives; delete replica; then
  primary deletes cleanly.
- `TestSDKCloudSQLStopReplicaGuards` — stop primary-with-replica blocked; stop
  the replica blocked; after removing the replica, primary stops (SUSPENDED).
- `TestSDKCloudSQLDeletionProtectionBlocksDelete` — protected instance delete
  blocked (400), clear the flag, delete succeeds.
- Provider-level `TestStopInstanceReplicaGuards`; updated
  `TestDeleteInstanceUnlinksReplicas` for the new reject-then-promote flow.

## Gates

build ./... · gofmt clean · `go test ./providers/gcp/cloudsql/... ./server/gcp/cloudsql/... -race` · broad `go test ./providers/gcp/... ./server/gcp/...` · full `go test ./...` exit 0 · golangci-lint touched pkgs 0 new (3 remaining are pre-existing in untouched funcs) · `git diff docs/coverage` clean · `go mod tidy` clean.
