### PR TITLE
feat(rds): AddRoleToDBCluster / RemoveRoleFromDBCluster + AssociatedRoles

### DIFF
--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -9414,6 +9414,18 @@
         ]
       },
       {
+        "name": "ClusterRoles",
+        "doc": "ClusterRoles is an OPTIONAL capability to associate and disassociate IAM",
+        "operations": [
+          {
+            "name": "AddRoleToDBCluster"
+          },
+          {
+            "name": "RemoveRoleFromDBCluster"
+          }
+        ]
+      },
+      {
         "name": "Configurations",
         "doc": "Configurations is an OPTIONAL capability for reading and setting server",
         "operations": [

--- a/providers/aws/rds/cluster_roles.go
+++ b/providers/aws/rds/cluster_roles.go
@@ -1,0 +1,84 @@
+package rds
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+var _ rdsdriver.ClusterRoles = (*Mock)(nil)
+
+// clusterRoleStatusActive is the association state a freshly added role reports.
+// Real Aurora transitions PENDING -> ACTIVE; the emulator settles immediately.
+const clusterRoleStatusActive = "ACTIVE"
+
+// AddRoleToDBCluster associates an IAM role with an Aurora DB cluster. Roles are
+// keyed by RoleArn: re-adding the same ARN is rejected, matching real RDS
+// (DBClusterRoleAlreadyExists). The association is recorded on the cluster's
+// AssociatedRoles under a single write-locked span with copy-on-write of the
+// slice so a concurrently-described cluster never sees a mutated store value.
+func (m *Mock) AddRoleToDBCluster(_ context.Context, clusterID, roleARN, featureName string) error {
+	if roleARN == "" {
+		return cerrors.New(cerrors.InvalidArgument, "RoleArn is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cluster, ok := m.clusters.Get(clusterID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "DB cluster %q not found", clusterID)
+	}
+
+	for i := range cluster.AssociatedRoles {
+		if cluster.AssociatedRoles[i].RoleARN == roleARN {
+			return cerrors.Newf(cerrors.AlreadyExists,
+				"IAM role %q is already associated with the cluster", roleARN)
+		}
+	}
+
+	roles := cloneSlice(cluster.AssociatedRoles)
+	roles = append(roles, rdsdriver.DBClusterRole{
+		RoleARN:     roleARN,
+		FeatureName: featureName,
+		Status:      clusterRoleStatusActive,
+	})
+	cluster.AssociatedRoles = roles
+
+	m.clusters.Set(clusterID, cluster)
+
+	return nil
+}
+
+// RemoveRoleFromDBCluster disassociates an IAM role from an Aurora DB cluster.
+// Removing a role that is not associated is rejected (DBClusterRoleNotFound).
+// The remaining roles are rebuilt into a fresh slice so a slice previously
+// handed out by DescribeClusters is never clobbered underneath its caller.
+func (m *Mock) RemoveRoleFromDBCluster(_ context.Context, clusterID, roleARN, _ string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cluster, ok := m.clusters.Get(clusterID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "DB cluster %q not found", clusterID)
+	}
+
+	kept := make([]rdsdriver.DBClusterRole, 0, len(cluster.AssociatedRoles))
+
+	for i := range cluster.AssociatedRoles {
+		if cluster.AssociatedRoles[i].RoleARN != roleARN {
+			kept = append(kept, cluster.AssociatedRoles[i])
+		}
+	}
+
+	if len(kept) == len(cluster.AssociatedRoles) {
+		return cerrors.Newf(cerrors.NotFound,
+			"IAM role %q is not associated with the cluster", roleARN)
+	}
+
+	cluster.AssociatedRoles = kept
+	m.clusters.Set(clusterID, cluster)
+
+	return nil
+}

--- a/providers/aws/rds/cluster_roles_test.go
+++ b/providers/aws/rds/cluster_roles_test.go
@@ -1,0 +1,117 @@
+package rds
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+func TestAddRemoveRoleToDBCluster(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	if _, err := m.CreateCluster(ctx, rdsdriver.ClusterConfig{ID: "cl", Engine: "aurora-mysql"}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	const s3Role = "arn:aws:iam::123456789012:role/s3-import"
+
+	if err := m.AddRoleToDBCluster(ctx, "cl", s3Role, "s3Import"); err != nil {
+		t.Fatalf("AddRoleToDBCluster: %v", err)
+	}
+
+	got, err := m.DescribeClusters(ctx, []string{"cl"})
+	if err != nil {
+		t.Fatalf("DescribeClusters: %v", err)
+	}
+
+	if len(got[0].AssociatedRoles) != 1 {
+		t.Fatalf("AssociatedRoles = %+v, want one", got[0].AssociatedRoles)
+	}
+
+	role := got[0].AssociatedRoles[0]
+	if role.RoleARN != s3Role || role.FeatureName != "s3Import" || role.Status != clusterRoleStatusActive {
+		t.Fatalf("role = %+v, want {%s s3Import ACTIVE}", role, s3Role)
+	}
+
+	// A second role coexists (keyed by ARN).
+	const lambdaRole = "arn:aws:iam::123456789012:role/lambda"
+	if err := m.AddRoleToDBCluster(ctx, "cl", lambdaRole, "Lambda"); err != nil {
+		t.Fatalf("AddRoleToDBCluster second: %v", err)
+	}
+
+	if err := m.RemoveRoleFromDBCluster(ctx, "cl", s3Role, ""); err != nil {
+		t.Fatalf("RemoveRoleFromDBCluster: %v", err)
+	}
+
+	got, _ = m.DescribeClusters(ctx, []string{"cl"})
+	if len(got[0].AssociatedRoles) != 1 || got[0].AssociatedRoles[0].RoleARN != lambdaRole {
+		t.Fatalf("after remove AssociatedRoles = %+v, want only lambda", got[0].AssociatedRoles)
+	}
+}
+
+func TestAddRoleToDBClusterGuards(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	if _, err := m.CreateCluster(ctx, rdsdriver.ClusterConfig{ID: "cl", Engine: "aurora-mysql"}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	const role = "arn:aws:iam::123456789012:role/r"
+
+	// Missing RoleArn.
+	if err := m.AddRoleToDBCluster(ctx, "cl", "", "s3Import"); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("empty RoleArn: want InvalidArgument, got %v", err)
+	}
+
+	// Unknown cluster.
+	if err := m.AddRoleToDBCluster(ctx, "ghost", role, ""); !cerrors.IsNotFound(err) {
+		t.Fatalf("add on missing cluster: want NotFound, got %v", err)
+	}
+
+	if err := m.AddRoleToDBCluster(ctx, "cl", role, ""); err != nil {
+		t.Fatalf("AddRoleToDBCluster: %v", err)
+	}
+
+	// Duplicate association.
+	if err := m.AddRoleToDBCluster(ctx, "cl", role, ""); !cerrors.IsAlreadyExists(err) {
+		t.Fatalf("duplicate role: want AlreadyExists, got %v", err)
+	}
+
+	// Remove a role that is not associated.
+	if err := m.RemoveRoleFromDBCluster(ctx, "cl", "arn:aws:iam::123456789012:role/other", ""); !cerrors.IsNotFound(err) {
+		t.Fatalf("remove unassociated role: want NotFound, got %v", err)
+	}
+
+	// Remove on unknown cluster.
+	if err := m.RemoveRoleFromDBCluster(ctx, "ghost", role, ""); !cerrors.IsNotFound(err) {
+		t.Fatalf("remove on missing cluster: want NotFound, got %v", err)
+	}
+}
+
+// TestDescribeClustersRolesCloned proves DescribeClusters hands back an
+// independent copy of the AssociatedRoles slice: mutating a returned value must
+// not leak into a subsequent Describe.
+func TestDescribeClustersRolesCloned(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	if _, err := m.CreateCluster(ctx, rdsdriver.ClusterConfig{ID: "cl", Engine: "aurora-mysql"}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if err := m.AddRoleToDBCluster(ctx, "cl", "arn:aws:iam::123456789012:role/r", "s3Import"); err != nil {
+		t.Fatalf("AddRoleToDBCluster: %v", err)
+	}
+
+	first, _ := m.DescribeClusters(ctx, []string{"cl"})
+	first[0].AssociatedRoles[0].Status = "TAMPERED"
+
+	second, _ := m.DescribeClusters(ctx, []string{"cl"})
+	if second[0].AssociatedRoles[0].Status != clusterRoleStatusActive {
+		t.Fatalf("store leaked mutation: status = %q", second[0].AssociatedRoles[0].Status)
+	}
+}

--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -316,6 +316,7 @@ func cloneCluster(c rdsdriver.Cluster) rdsdriver.Cluster {
 	c.Members = cloneSlice(c.Members)
 	c.VPCSecurityGroups = cloneSlice(c.VPCSecurityGroups)
 	c.AvailabilityZones = cloneSlice(c.AvailabilityZones)
+	c.AssociatedRoles = cloneSlice(c.AssociatedRoles)
 
 	return c
 }

--- a/server/aws/rds/aurora.go
+++ b/server/aws/rds/aurora.go
@@ -63,6 +63,25 @@ type failoverDBClusterResponse struct {
 	Metadata responseMetadata `xml:"ResponseMetadata"`
 }
 
+// ---- cluster IAM role association XML ----
+//
+// AddRoleToDBCluster / RemoveRoleFromDBCluster return an empty result body in
+// real RDS; the effect is observed via DescribeDBClusters AssociatedRoles.
+
+type addRoleToDBClusterResponse struct {
+	XMLName  xml.Name         `xml:"AddRoleToDBClusterResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   struct{}         `xml:"AddRoleToDBClusterResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type removeRoleFromDBClusterResponse struct {
+	XMLName  xml.Name         `xml:"RemoveRoleFromDBClusterResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   struct{}         `xml:"RemoveRoleFromDBClusterResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
 // ---- global cluster XML ----
 
 type globalClusterMemberXML struct {
@@ -132,6 +151,12 @@ func (h *Handler) clusterEndpointsCap() (rdsdriver.ClusterEndpoints, bool) {
 
 func (h *Handler) clusterFailoverCap() (rdsdriver.ClusterFailover, bool) {
 	c, ok := h.db.(rdsdriver.ClusterFailover)
+
+	return c, ok
+}
+
+func (h *Handler) clusterRolesCap() (rdsdriver.ClusterRoles, bool) {
+	c, ok := h.db.(rdsdriver.ClusterRoles)
 
 	return c, ok
 }
@@ -293,6 +318,48 @@ func (h *Handler) failoverDBCluster(w http.ResponseWriter, r *http.Request) {
 	awsquery.WriteXMLResponse(w, failoverDBClusterResponse{
 		Xmlns:    Namespace,
 		Result:   dbClusterResult{DBCluster: toClusterXML(cluster)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+//nolint:dupl // structurally mirrors removeRoleFromDBCluster by design.
+func (h *Handler) addRoleToDBCluster(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.clusterRolesCap()
+	if !ok {
+		writeUnsupported(w, "cluster IAM role association")
+		return
+	}
+
+	err := store.AddRoleToDBCluster(r.Context(),
+		r.Form.Get("DBClusterIdentifier"), r.Form.Get("RoleArn"), r.Form.Get("FeatureName"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, addRoleToDBClusterResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+//nolint:dupl // structurally mirrors addRoleToDBCluster by design.
+func (h *Handler) removeRoleFromDBCluster(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.clusterRolesCap()
+	if !ok {
+		writeUnsupported(w, "cluster IAM role association")
+		return
+	}
+
+	err := store.RemoveRoleFromDBCluster(r.Context(),
+		r.Form.Get("DBClusterIdentifier"), r.Form.Get("RoleArn"), r.Form.Get("FeatureName"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, removeRoleFromDBClusterResponse{
+		Xmlns:    Namespace,
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/rds/clusterroles_sdk_roundtrip_test.go
+++ b/server/aws/rds/clusterroles_sdk_roundtrip_test.go
@@ -1,0 +1,112 @@
+package rds_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+)
+
+// TestSDKRDSClusterRoleAssociation exercises AddRoleToDBCluster /
+// RemoveRoleFromDBCluster end to end against the real aws-sdk-go-v2 client and
+// verifies the associations surface in DescribeDBClusters.AssociatedRoles.
+func TestSDKRDSClusterRoleAssociation(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBCluster(ctx, &awsrds.CreateDBClusterInput{
+		DBClusterIdentifier: aws.String("roles-cl"),
+		Engine:              aws.String("aurora-mysql"),
+	}); err != nil {
+		t.Fatalf("CreateDBCluster: %v", err)
+	}
+
+	const s3Role = "arn:aws:iam::123456789012:role/s3-import"
+
+	if _, err := client.AddRoleToDBCluster(ctx, &awsrds.AddRoleToDBClusterInput{
+		DBClusterIdentifier: aws.String("roles-cl"),
+		RoleArn:             aws.String(s3Role),
+		FeatureName:         aws.String("s3Import"),
+	}); err != nil {
+		t.Fatalf("AddRoleToDBCluster: %v", err)
+	}
+
+	desc, err := client.DescribeDBClusters(ctx, &awsrds.DescribeDBClustersInput{
+		DBClusterIdentifier: aws.String("roles-cl"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBClusters: %v", err)
+	}
+
+	roles := desc.DBClusters[0].AssociatedRoles
+	if len(roles) != 1 {
+		t.Fatalf("AssociatedRoles = %+v, want one", roles)
+	}
+
+	if aws.ToString(roles[0].RoleArn) != s3Role ||
+		aws.ToString(roles[0].FeatureName) != "s3Import" ||
+		aws.ToString(roles[0].Status) != "ACTIVE" {
+		t.Fatalf("role = %+v, want {%s s3Import ACTIVE}", roles[0], s3Role)
+	}
+
+	// Re-adding the same ARN is rejected.
+	_, err = client.AddRoleToDBCluster(ctx, &awsrds.AddRoleToDBClusterInput{
+		DBClusterIdentifier: aws.String("roles-cl"),
+		RoleArn:             aws.String(s3Role),
+	})
+
+	var already *rdstypes.DBClusterRoleAlreadyExistsFault
+	if !errors.As(err, &already) {
+		t.Fatalf("duplicate add: got %v, want DBClusterRoleAlreadyExistsFault", err)
+	}
+
+	// Remove and confirm the list is empty again.
+	if _, err := client.RemoveRoleFromDBCluster(ctx, &awsrds.RemoveRoleFromDBClusterInput{
+		DBClusterIdentifier: aws.String("roles-cl"),
+		RoleArn:             aws.String(s3Role),
+	}); err != nil {
+		t.Fatalf("RemoveRoleFromDBCluster: %v", err)
+	}
+
+	desc, err = client.DescribeDBClusters(ctx, &awsrds.DescribeDBClustersInput{
+		DBClusterIdentifier: aws.String("roles-cl"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBClusters after remove: %v", err)
+	}
+
+	if len(desc.DBClusters[0].AssociatedRoles) != 0 {
+		t.Fatalf("AssociatedRoles after remove = %+v, want empty", desc.DBClusters[0].AssociatedRoles)
+	}
+
+	// Removing an unassociated role reports DBClusterRoleNotFound.
+	_, err = client.RemoveRoleFromDBCluster(ctx, &awsrds.RemoveRoleFromDBClusterInput{
+		DBClusterIdentifier: aws.String("roles-cl"),
+		RoleArn:             aws.String(s3Role),
+	})
+
+	var notFound *rdstypes.DBClusterRoleNotFoundFault
+	if !errors.As(err, &notFound) {
+		t.Fatalf("remove unassociated: got %v, want DBClusterRoleNotFoundFault", err)
+	}
+}
+
+// TestSDKRDSAddRoleUnknownCluster verifies an add against a missing cluster is a
+// typed DBClusterNotFoundFault.
+func TestSDKRDSAddRoleUnknownCluster(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.AddRoleToDBCluster(ctx, &awsrds.AddRoleToDBClusterInput{
+		DBClusterIdentifier: aws.String("ghost"),
+		RoleArn:             aws.String("arn:aws:iam::123456789012:role/r"),
+	})
+
+	var notFound *rdstypes.DBClusterNotFoundFault
+	if !errors.As(err, &notFound) {
+		t.Fatalf("add on missing cluster: got %v, want DBClusterNotFoundFault", err)
+	}
+}

--- a/server/aws/rds/handler.go
+++ b/server/aws/rds/handler.go
@@ -100,6 +100,8 @@ var rdsActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup
 	"ModifyDBClusterEndpoint":            {},
 	"DeleteDBClusterEndpoint":            {},
 	"FailoverDBCluster":                  {},
+	"AddRoleToDBCluster":                 {},
+	"RemoveRoleFromDBCluster":            {},
 	"CreateGlobalCluster":                {},
 	"DescribeGlobalClusters":             {},
 	"ModifyGlobalCluster":                {},
@@ -314,6 +316,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.deleteDBClusterEndpoint(w, r)
 	case "FailoverDBCluster":
 		h.failoverDBCluster(w, r)
+	case "AddRoleToDBCluster":
+		h.addRoleToDBCluster(w, r)
+	case "RemoveRoleFromDBCluster":
+		h.removeRoleFromDBCluster(w, r)
 	case "CreateGlobalCluster":
 		h.createGlobalCluster(w, r)
 	case "DescribeGlobalClusters":
@@ -402,6 +408,7 @@ func matchFault(msg string, table []faultMapping, fallback string) string {
 //
 //nolint:gochecknoglobals // ordered static lookup table
 var notFoundFaults = []faultMapping{
+	{"IAM role", "DBClusterRoleNotFound"},
 	{"db subnet group", "DBSubnetGroupNotFoundFault"},
 	{"parameter group", "DBParameterGroupNotFound"},
 	{"option group", "OptionGroupNotFoundFault"},
@@ -417,6 +424,7 @@ var notFoundFaults = []faultMapping{
 
 //nolint:gochecknoglobals // ordered static lookup table
 var alreadyExistsFaults = []faultMapping{
+	{"IAM role", "DBClusterRoleAlreadyExists"},
 	{"db subnet group", "DBSubnetGroupAlreadyExists"},
 	{"parameter group", "DBParameterGroupAlreadyExists"},
 	{"option group", "OptionGroupAlreadyExistsFault"},

--- a/server/aws/rds/xml.go
+++ b/server/aws/rds/xml.go
@@ -163,7 +163,18 @@ type dbClusterXML struct {
 	ClusterCreateTime   string                `xml:"ClusterCreateTime,omitempty"`
 	DBClusterMembers    *dbClusterMembersXML  `xml:"DBClusterMembers,omitempty"`
 	VpcSecurityGroups   *vpcSecurityGroupsXML `xml:"VpcSecurityGroups,omitempty"`
+	AssociatedRoles     *associatedRolesXML   `xml:"AssociatedRoles,omitempty"`
 	TagList             *tagListXML           `xml:"TagList,omitempty"`
+}
+
+type dbClusterRoleXML struct {
+	RoleArn     string `xml:"RoleArn"`
+	FeatureName string `xml:"FeatureName,omitempty"`
+	Status      string `xml:"Status,omitempty"`
+}
+
+type associatedRolesXML struct {
+	DBClusterRole []dbClusterRoleXML `xml:"DBClusterRole"`
 }
 
 type dbSnapshotXML struct {
@@ -530,8 +541,26 @@ func toClusterXML(cluster *rdsdriver.Cluster) dbClusterXML {
 		ClusterCreateTime:   cluster.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
 		DBClusterMembers:    &members,
 		VpcSecurityGroups:   toVpcSGsXML(cluster.VPCSecurityGroups),
+		AssociatedRoles:     toAssociatedRolesXML(cluster.AssociatedRoles),
 		TagList:             toTagListXML(cluster.Tags),
 	}
+}
+
+func toAssociatedRolesXML(roles []rdsdriver.DBClusterRole) *associatedRolesXML {
+	if len(roles) == 0 {
+		return nil
+	}
+
+	out := &associatedRolesXML{DBClusterRole: make([]dbClusterRoleXML, 0, len(roles))}
+	for i := range roles {
+		out.DBClusterRole = append(out.DBClusterRole, dbClusterRoleXML{
+			RoleArn:     roles[i].RoleARN,
+			FeatureName: roles[i].FeatureName,
+			Status:      roles[i].Status,
+		})
+	}
+
+	return out
 }
 
 func toAvailabilityZonesXML(azs []string) *availabilityZonesXML {

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -369,9 +369,23 @@ type Cluster struct {
 	Location  string
 	CreatedAt time.Time
 	Tags      map[string]string
+	// AssociatedRoles are the IAM roles associated with an Aurora DB cluster for
+	// integrations such as S3 import/export, Lambda, or Comprehend (AWS RDS
+	// DBCluster AssociatedRoles). Empty for non-AWS engines and clusters without
+	// role associations.
+	AssociatedRoles []DBClusterRole
 	// Scope records where an Azure SQL logical server lives (subscription/
 	// resource group). Zero for AWS/GCP and unscoped portable callers.
 	Scope scope.Scope
+}
+
+// DBClusterRole is an IAM role associated with an Aurora DB cluster (AWS RDS
+// DBClusterRole). FeatureName names the integration the role authorizes (e.g.
+// "s3Import"); Status reports the association state (ACTIVE/PENDING/INVALID).
+type DBClusterRole struct {
+	RoleARN     string
+	FeatureName string
+	Status      string
 }
 
 // SnapshotConfig configures an instance snapshot.
@@ -1348,6 +1362,15 @@ type ClusterEndpoints interface {
 // specific member, discovered by type assertion.
 type ClusterFailover interface {
 	FailoverDBCluster(ctx context.Context, clusterID, targetInstanceID string) (*Cluster, error)
+}
+
+// ClusterRoles is an OPTIONAL capability to associate and disassociate IAM
+// roles with an Aurora DB cluster (AWS RDS AddRoleToDBCluster /
+// RemoveRoleFromDBCluster), discovered by type assertion. The associations are
+// reported in Cluster.AssociatedRoles.
+type ClusterRoles interface {
+	AddRoleToDBCluster(ctx context.Context, clusterID, roleARN, featureName string) error
+	RemoveRoleFromDBCluster(ctx context.Context, clusterID, roleARN, featureName string) error
 }
 
 // GlobalClusterMember is a cluster participating in an Aurora global cluster.


### PR DESCRIPTION
## Summary

Closes the highest-value open Aurora cluster gap: **IAM role association**. Before this change the RDS wire recognized ~74 actions but `AddRoleToDBCluster` / `RemoveRoleFromDBCluster` were entirely absent, and `DescribeDBClusters` never returned `AssociatedRoles`. This is the surface behind Terraform `aws_rds_cluster_role_association` and every Aurora integration that grants the cluster an IAM role (S3 `LOAD DATA FROM S3` / `SELECT INTO OUTFILE S3`, Lambda, Comprehend, SageMaker).

## What was closed

- **`AddRoleToDBCluster`** and **`RemoveRoleFromDBCluster`** — new optional `ClusterRoles` capability on the shared `relationaldb` driver, implemented in `providers/aws/rds`, dispatched + gated in `server/aws/rds`.
- **`AssociatedRoles`** now surfaces in `DescribeDBClusters` (`RoleArn` / `FeatureName` / `Status`), settling to `ACTIVE` synchronously (consistent with the rest of the RDS mock).
- Faithful RDS semantics: roles keyed by `RoleArn`; re-adding the same ARN → `DBClusterRoleAlreadyExists`; removing an unassociated role → `DBClusterRoleNotFound`; missing `RoleArn` → `InvalidParameterValue`; unknown cluster → `DBClusterNotFoundFault`. Fault codes match exactly what aws-sdk-go-v2 deserializes to its typed faults.
- Concurrency-safe: single write-locked span, copy-on-write of the roles slice; `DescribeClusters` deep-copies `AssociatedRoles` so a returned value never aliases the store (covered by a `-race` test that tampers with a returned slice).

## Tests (real aws-sdk-go-v2)

- `server/aws/rds/clusterroles_sdk_roundtrip_test.go` — add → describe → duplicate-add guard → remove → remove-unassociated guard → add-on-missing-cluster, all through the real SDK client with typed-fault assertions.
- `providers/aws/rds/cluster_roles_test.go` — provider-level lifecycle, guard cases, and slice-clone isolation.

## Deferred

- Role association **quota** (`DBClusterRoleQuotaExceeded`, real soft-limit of 5) is not enforced.
- Instance-level `AddRoleToDBInstance` / `RemoveRoleFromDBInstance` (SQL Server / Oracle) is a separate, symmetric surface, out of scope here.
- Role `Status` does not transition through `PENDING`; the emulator settles to `ACTIVE` immediately, matching the rest of the RDS mock.

## Gates

build ./... · gofmt clean · `go test ./providers/aws/rds/... ./server/aws/rds/... -race` green · broad `go test ./providers/aws/... ./server/aws/...` green · golangci-lint 0 new on touched pkgs · coveragegen regenerated (`ClusterRoles` capability) · `go mod tidy` clean.
