### PR TITLE
feat(firestore): aggregation queries (:runAggregationQuery COUNT/SUM/AVG)

### DIFF
--- a/server/gcp/firestore/aggregation.go
+++ b/server/gcp/firestore/aggregation.go
@@ -1,0 +1,318 @@
+package firestore
+
+import (
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+// runAggregationQueryRequest mirrors google.firestore.v1.RunAggregationQueryRequest:
+// an underlying structured query plus a set of aggregations to compute over its
+// results.
+type runAggregationQueryRequest struct {
+	StructuredAggregationQuery structuredAggregationQuery `json:"structuredAggregationQuery"`
+}
+
+type structuredAggregationQuery struct {
+	StructuredQuery structuredQuery `json:"structuredQuery"`
+	Aggregations    []aggregation   `json:"aggregations"`
+}
+
+// aggregation is one aliased aggregate operator. Exactly one of Count/Sum/Avg
+// is set per entry.
+type aggregation struct {
+	Alias string    `json:"alias"`
+	Count *countAgg `json:"count"`
+	Sum   *fieldAgg `json:"sum"`
+	Avg   *fieldAgg `json:"avg"`
+}
+
+// countAgg is a COUNT operator; UpTo optionally caps how far the count runs
+// (Firestore's count(up_to)).
+type countAgg struct {
+	UpTo *aggInt64 `json:"upTo"`
+}
+
+// fieldAgg is a SUM or AVG operator over a single document field.
+type fieldAgg struct {
+	Field fieldRef `json:"field"`
+}
+
+// aggInt64 decodes a google.protobuf.Int64Value sent either as a JSON string
+// ("1000", the proto3 JSON mapping the REST client uses) or a bare number.
+type aggInt64 int64
+
+func (a *aggInt64) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), `"`)
+	if s == "" || s == "null" {
+		return nil
+	}
+
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	*a = aggInt64(n)
+
+	return nil
+}
+
+// aggregationResponseEntry mirrors google.firestore.v1.RunAggregationQueryResponse.
+// Firestore aggregation has no GROUP BY, so exactly one entry is streamed.
+type aggregationResponseEntry struct {
+	Result   aggregationResultBody `json:"result"`
+	ReadTime string                `json:"readTime"`
+}
+
+type aggregationResultBody struct {
+	AggregateFields map[string]value `json:"aggregateFields"`
+}
+
+// runAggregationQuery handles POST .../documents:runAggregationQuery. It runs
+// the underlying structured query, then computes COUNT/SUM/AVG over the matched
+// documents and returns a single aggregation result row.
+func (h *Handler) runAggregationQuery(w http.ResponseWriter, r *http.Request, base string) {
+	var req runAggregationQueryRequest
+
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	saq := &req.StructuredAggregationQuery
+
+	if len(saq.StructuredQuery.From) == 0 {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "from clause required")
+		return
+	}
+
+	if len(saq.Aggregations) == 0 {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "at least one aggregation required")
+		return
+	}
+
+	docs, err := h.aggregationMatches(r, base, &saq.StructuredQuery)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	fields, err := computeAggregates(saq.Aggregations, docs)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, []aggregationResponseEntry{{
+		Result:   aggregationResultBody{AggregateFields: fields},
+		ReadTime: time.Now().UTC().Format(time.RFC3339Nano),
+	}})
+}
+
+// aggregationMatches resolves the underlying structured query to the set of
+// documents the aggregates run over: it applies the where clause plus the
+// non-select shaping (order/cursor/offset/limit). Select is intentionally
+// skipped so the aggregated fields survive. A never-written collection has no
+// driver table; real Firestore aggregates to zero rows rather than erroring, so
+// NotFound is treated as an empty match.
+func (h *Handler) aggregationMatches(r *http.Request, base string, q *structuredQuery) ([]map[string]any, error) {
+	p, perr := parseFirestorePath(base)
+	if perr != nil {
+		return nil, cerrors.New(cerrors.InvalidArgument, perr.Error())
+	}
+
+	p.collection = joinPath(p.parentPath(), q.From[0].CollectionID)
+	p.documentID = ""
+
+	node, ferr := buildFilterNode(q.Where)
+	if ferr != nil {
+		return nil, cerrors.New(cerrors.InvalidArgument, ferr.Error())
+	}
+
+	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: p.tableKey(), Limit: allResults})
+	if err != nil {
+		if cerrors.IsNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	matched, merr := filterDocuments(result.Items, node)
+	if merr != nil {
+		return nil, merr
+	}
+
+	shape := *q
+	shape.Select = nil
+
+	return shapeResults(matched, &shape), nil
+}
+
+// computeAggregates evaluates every aggregation against the matched documents,
+// keyed by its alias (Firestore autogenerates "field_<n>" when none is given).
+func computeAggregates(aggs []aggregation, docs []map[string]any) (map[string]value, error) {
+	out := make(map[string]value, len(aggs))
+
+	for i := range aggs {
+		v, err := computeOne(aggs[i], docs)
+		if err != nil {
+			return nil, err
+		}
+
+		out[aggregateAlias(aggs[i], i)] = v
+	}
+
+	return out, nil
+}
+
+func aggregateAlias(a aggregation, i int) string {
+	if a.Alias != "" {
+		return a.Alias
+	}
+
+	return "field_" + strconv.Itoa(i+1)
+}
+
+func computeOne(a aggregation, docs []map[string]any) (value, error) {
+	switch {
+	case a.Count != nil:
+		return countValue(a.Count, len(docs)), nil
+	case a.Sum != nil:
+		return sumValue(a.Sum.Field.FieldPath, docs), nil
+	case a.Avg != nil:
+		return avgValue(a.Avg.Field.FieldPath, docs), nil
+	default:
+		return value{}, cerrors.New(cerrors.InvalidArgument, "aggregation must set one of count/sum/avg")
+	}
+}
+
+// countValue returns the matched-document count, capped at UpTo when the client
+// supplied a non-negative count(up_to) bound.
+func countValue(c *countAgg, n int) value {
+	if c.UpTo != nil {
+		if cap64 := int64(*c.UpTo); cap64 >= 0 && int64(n) > cap64 {
+			n = int(cap64)
+		}
+	}
+
+	return intValue(int64(n))
+}
+
+// sumValue sums the numeric values of a field across the documents, ignoring
+// documents where the field is absent or non-numeric. It returns an integer
+// when every summand is an integer and the total neither overflows int64 nor
+// involves a floating value; otherwise a double (NaN if any value is NaN). An
+// empty numeric set sums to integer 0, matching real Firestore.
+func sumValue(path string, docs []map[string]any) value {
+	intSum, floatSum, sawFloat, overflow, sawNaN := accumulateSum(path, docs)
+
+	switch {
+	case sawNaN:
+		return doubleValue(math.NaN())
+	case sawFloat || overflow:
+		return doubleValue(floatSum)
+	default:
+		return intValue(intSum)
+	}
+}
+
+func accumulateSum(path string, docs []map[string]any) (intSum int64, floatSum float64, sawFloat, overflow, sawNaN bool) {
+	for _, d := range docs {
+		f, isInt, ok := numericField(d, path)
+		if !ok {
+			continue
+		}
+
+		floatSum += f
+
+		if math.IsNaN(f) {
+			sawNaN = true
+		}
+
+		if !isInt {
+			sawFloat = true
+			continue
+		}
+
+		if s, ok := addInt64(intSum, int64(f)); ok {
+			intSum = s
+		} else {
+			overflow = true
+		}
+	}
+
+	return intSum, floatSum, sawFloat, overflow, sawNaN
+}
+
+// avgValue averages the numeric values of a field. It returns a double, or null
+// when no document has a numeric value for the field (matching Firestore, whose
+// average over an empty numeric set is NULL rather than 0).
+func avgValue(path string, docs []map[string]any) value {
+	var sum float64
+
+	count := 0
+
+	for _, d := range docs {
+		f, _, ok := numericField(d, path)
+		if !ok {
+			continue
+		}
+
+		sum += f
+		count++
+	}
+
+	if count == 0 {
+		return nullValue()
+	}
+
+	return doubleValue(sum / float64(count))
+}
+
+// numericField resolves a document field to a float, reporting whether the
+// stored value was an integer (int64) and whether it was numeric at all.
+func numericField(item map[string]any, path string) (f float64, isInt, ok bool) {
+	switch v := resolveField(item, path).(type) {
+	case int64:
+		return float64(v), true, true
+	case float64:
+		return v, false, true
+	default:
+		return 0, false, false
+	}
+}
+
+// addInt64 adds two int64 values, reporting false on signed overflow.
+func addInt64(a, b int64) (int64, bool) {
+	s := a + b
+	if (b > 0 && s < a) || (b < 0 && s > a) {
+		return 0, false
+	}
+
+	return s, true
+}
+
+func intValue(n int64) value {
+	s := strconv.FormatInt(n, 10)
+
+	return value{IntegerValue: &s}
+}
+
+func doubleValue(f float64) value {
+	return value{DoubleValue: &f}
+}
+
+// nullValueName is the sentinel Firestore uses for a NullValue field.
+const nullValueName = "NULL_VALUE"
+
+func nullValue() value {
+	s := nullValueName
+
+	return value{NullValue: &s}
+}

--- a/server/gcp/firestore/firestore_aggregation_test.go
+++ b/server/gcp/firestore/firestore_aggregation_test.go
@@ -1,0 +1,326 @@
+// These tests drive Firestore aggregation queries (:runAggregationQuery)
+// end to end. COUNT/SUM/AVG are exercised through the real
+// cloud.google.com/go/firestore REST SDK; the count(up_to) bound and the
+// per-(project, database) namespace isolation of aggregation are exercised over
+// raw REST (the SDK's NewAggregationQuery has no up_to knob and its constructor
+// hard-codes the "(default)" database).
+package firestore_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	gcpfirestore "cloud.google.com/go/firestore"
+	firestorepb "cloud.google.com/go/firestore/apiv1/firestorepb"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+// newAggServer boots a fresh emulator + GCP server with the given collections
+// pre-created as driver tables, and returns both the raw httptest server and a
+// real Firestore REST SDK client pointed at it (aggregation tests need both the
+// SDK and raw REST for count(up_to)).
+func newAggServer(t *testing.T, project string, colls ...string) (context.Context, *httptest.Server, *gcpfirestore.Client) {
+	t.Helper()
+
+	ctx := context.Background()
+	cloudP := cloudemu.NewGCP()
+
+	for _, c := range colls {
+		if err := cloudP.Firestore.CreateTable(ctx, dbdriver.TableConfig{Name: c, PartitionKey: "\x00id"}); err != nil {
+			t.Fatalf("CreateTable(%s): %v", c, err)
+		}
+	}
+
+	srv := gcpserver.New(gcpserver.Drivers{Firestore: cloudP.Firestore})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := gcpfirestore.NewRESTClient(ctx, project,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	return ctx, ts, client
+}
+
+// seedAggregationCities writes a small, mixed-type cities collection through the
+// real SDK: population is always an integer, area always a double, and score is
+// present on only two docs (one int, one double) to exercise
+// missing-field-skipping and the integer/double result typing of SUM.
+func seedAggregationCities(t *testing.T, ctx context.Context, coll *gcpfirestore.CollectionRef) {
+	t.Helper()
+
+	docs := map[string]map[string]any{
+		"SF":  {"population": 800000, "region": "us", "area": 121.4, "score": 10},
+		"LA":  {"population": 4000000, "region": "us", "area": 1302.0, "score": 2.5},
+		"NYC": {"population": 8000000, "region": "us", "area": 783.8},
+		"BER": {"population": 3600000, "region": "eu", "area": 891.7},
+	}
+
+	for id, fields := range docs {
+		if _, err := coll.Doc(id).Set(ctx, fields); err != nil {
+			t.Fatalf("Set %s: %v", id, err)
+		}
+	}
+}
+
+func aggInteger(t *testing.T, res map[string]interface{}, alias string) int64 {
+	t.Helper()
+
+	v, ok := res[alias].(*firestorepb.Value)
+	if !ok {
+		t.Fatalf("aggregate %q: value type %T, want *firestorepb.Value", alias, res[alias])
+	}
+
+	if _, ok := v.GetValueType().(*firestorepb.Value_IntegerValue); !ok {
+		t.Fatalf("aggregate %q: value %v is not an integerValue", alias, v)
+	}
+
+	return v.GetIntegerValue()
+}
+
+func aggDouble(t *testing.T, res map[string]interface{}, alias string) float64 {
+	t.Helper()
+
+	v, ok := res[alias].(*firestorepb.Value)
+	if !ok {
+		t.Fatalf("aggregate %q: value type %T, want *firestorepb.Value", alias, res[alias])
+	}
+
+	if _, ok := v.GetValueType().(*firestorepb.Value_DoubleValue); !ok {
+		t.Fatalf("aggregate %q: value %v is not a doubleValue", alias, v)
+	}
+
+	return v.GetDoubleValue()
+}
+
+// TestDatabaseAggregation drives COUNT/SUM/AVG over the whole collection and a
+// filtered subset through the real SDK, asserting both the values and their
+// integer-vs-double result typing.
+func TestDatabaseAggregation(t *testing.T) {
+	ctx, _, client := newAggServer(t, dbProject, "cities")
+	coll := client.Collection("cities")
+	seedAggregationCities(t, ctx, coll)
+
+	// Whole-collection aggregates in a single query.
+	res, err := coll.NewAggregationQuery().
+		WithCount("count").
+		WithSum("population", "pop_sum").
+		WithAvg("population", "pop_avg").
+		WithSum("area", "area_sum").
+		Get(ctx)
+	if err != nil {
+		t.Fatalf("aggregation Get: %v", err)
+	}
+
+	if got := aggInteger(t, res, "count"); got != 4 {
+		t.Errorf("count = %d, want 4", got)
+	}
+
+	// All populations are integers -> integer result.
+	if got := aggInteger(t, res, "pop_sum"); got != 16_400_000 {
+		t.Errorf("sum(population) = %d, want 16400000", got)
+	}
+
+	if got := aggDouble(t, res, "pop_avg"); got != 4_100_000 {
+		t.Errorf("avg(population) = %v, want 4100000", got)
+	}
+
+	// All areas are doubles -> double result.
+	if got := aggDouble(t, res, "area_sum"); math.Abs(got-3098.9) > 1e-6 {
+		t.Errorf("sum(area) = %v, want 3098.9", got)
+	}
+
+	// SUM/AVG over a field present on only two docs, mixing an int and a double
+	// summand -> double result, missing docs skipped.
+	mres, err := coll.NewAggregationQuery().WithSum("score", "score_sum").WithAvg("score", "score_avg").Get(ctx)
+	if err != nil {
+		t.Fatalf("mixed aggregation Get: %v", err)
+	}
+
+	if got := aggDouble(t, mres, "score_sum"); math.Abs(got-12.5) > 1e-6 {
+		t.Errorf("sum(score) = %v, want 12.5 (double, mixed int+float)", got)
+	}
+
+	if got := aggDouble(t, mres, "score_avg"); math.Abs(got-6.25) > 1e-6 {
+		t.Errorf("avg(score) = %v, want 6.25 (only two docs have score)", got)
+	}
+
+	// Filtered aggregation: region == "us" keeps SF/LA/NYC.
+	usQuery := coll.Where("region", "==", "us")
+	fres, err := usQuery.NewAggregationQuery().WithCount("count").WithSum("population", "pop_sum").Get(ctx)
+	if err != nil {
+		t.Fatalf("filtered aggregation Get: %v", err)
+	}
+
+	if got := aggInteger(t, fres, "count"); got != 3 {
+		t.Errorf("filtered count = %d, want 3", got)
+	}
+
+	if got := aggInteger(t, fres, "pop_sum"); got != 12_800_000 {
+		t.Errorf("filtered sum(population) = %d, want 12800000", got)
+	}
+}
+
+// TestDatabaseAggregationEmptyAndNull asserts Firestore's empty-set semantics:
+// COUNT and SUM over no matching documents are integer 0, but AVG over a set
+// with no numeric values is NULL (not 0).
+func TestDatabaseAggregationEmptyAndNull(t *testing.T) {
+	ctx, _, client := newAggServer(t, dbProject, "cities")
+	coll := client.Collection("cities")
+	seedAggregationCities(t, ctx, coll)
+
+	emptyQuery := coll.Where("region", "==", "antarctica")
+	empty := emptyQuery.NewAggregationQuery()
+
+	res, err := empty.WithCount("count").WithSum("population", "pop_sum").WithAvg("population", "pop_avg").Get(ctx)
+	if err != nil {
+		t.Fatalf("empty aggregation Get: %v", err)
+	}
+
+	if got := aggInteger(t, res, "count"); got != 0 {
+		t.Errorf("count over empty set = %d, want 0", got)
+	}
+
+	if got := aggInteger(t, res, "pop_sum"); got != 0 {
+		t.Errorf("sum over empty set = %d, want integer 0", got)
+	}
+
+	v, ok := res["pop_avg"].(*firestorepb.Value)
+	if !ok {
+		t.Fatalf("avg value type %T, want *firestorepb.Value", res["pop_avg"])
+	}
+
+	if _, isNull := v.GetValueType().(*firestorepb.Value_NullValue); !isNull {
+		t.Errorf("avg over empty numeric set = %v, want nullValue", v)
+	}
+}
+
+// restAggregateCount posts a raw :runAggregationQuery counting a collection,
+// optionally with a count(up_to) bound, and returns the integer count.
+func restAggregateCount(t *testing.T, ts *httptest.Server, project, database, coll, upTo string) int64 {
+	t.Helper()
+
+	count := map[string]any{}
+	if upTo != "" {
+		count["upTo"] = upTo
+	}
+
+	body := map[string]any{
+		"structuredAggregationQuery": map[string]any{
+			"structuredQuery": map[string]any{
+				"from": []map[string]any{{"collectionId": coll}},
+			},
+			"aggregations": []map[string]any{
+				{"alias": "c", "count": count},
+			},
+		},
+	}
+
+	buf, _ := json.Marshal(body)
+	url := ts.URL + "/v1/projects/" + project + "/databases/" + database + "/documents:runAggregationQuery"
+
+	resp, err := ts.Client().Post(url, "application/json", bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("runAggregationQuery %s/%s: %v", project, database, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		out, _ := io.ReadAll(resp.Body)
+		t.Fatalf("runAggregationQuery %s/%s: status %d: %s", project, database, resp.StatusCode, out)
+	}
+
+	var decoded []struct {
+		Result struct {
+			AggregateFields map[string]struct {
+				IntegerValue string `json:"integerValue"`
+			} `json:"aggregateFields"`
+		} `json:"result"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode aggregation response: %v", err)
+	}
+
+	if len(decoded) != 1 {
+		t.Fatalf("aggregation response has %d rows, want 1", len(decoded))
+	}
+
+	raw := decoded[0].Result.AggregateFields["c"].IntegerValue
+
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		t.Fatalf("parse count %q: %v", raw, err)
+	}
+
+	return n
+}
+
+// TestDatabaseAggregationCountUpTo asserts count(up_to) caps the returned count
+// at the requested bound (raw REST, since the SDK has no up_to knob).
+func TestDatabaseAggregationCountUpTo(t *testing.T) {
+	ctx, ts, client := newAggServer(t, dbProject, "cities")
+	coll := client.Collection("cities")
+	seedAggregationCities(t, ctx, coll)
+
+	// Four docs; an unbounded count sees all four, a count(up_to: 2) caps at 2.
+	if got := restAggregateCount(t, ts, dbProject, "(default)", "cities", ""); got != 4 {
+		t.Errorf("unbounded count = %d, want 4", got)
+	}
+
+	if got := restAggregateCount(t, ts, dbProject, "(default)", "cities", "2"); got != 2 {
+		t.Errorf("count(up_to: 2) = %d, want 2", got)
+	}
+
+	// A bound above the true count returns the true count, not the bound.
+	if got := restAggregateCount(t, ts, dbProject, "(default)", "cities", "10"); got != 4 {
+		t.Errorf("count(up_to: 10) = %d, want 4", got)
+	}
+}
+
+// TestAggregationCrossDatabaseIsolation runs :runAggregationQuery against the
+// same collection under two databases of one project and asserts each database
+// counts only its own documents — confirming the #969 (project, database)
+// namespace keying still holds on the aggregation path.
+func TestAggregationCrossDatabaseIsolation(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Firestore: cloudP.Firestore})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	const project = "agg-iso-project"
+
+	// Two docs under (default), three under named1.
+	restCreate(t, ts, project, "(default)", "cities", "SF", map[string]any{"db": "default"})
+	restCreate(t, ts, project, "(default)", "cities", "LA", map[string]any{"db": "default"})
+	restCreate(t, ts, project, "named1", "cities", "A", map[string]any{"db": "named1"})
+	restCreate(t, ts, project, "named1", "cities", "B", map[string]any{"db": "named1"})
+	restCreate(t, ts, project, "named1", "cities", "C", map[string]any{"db": "named1"})
+
+	if got := restAggregateCount(t, ts, project, "(default)", "cities", ""); got != 2 {
+		t.Errorf("(default) db count = %d, want 2 (cross-database bleed)", got)
+	}
+
+	if got := restAggregateCount(t, ts, project, "named1", "cities", ""); got != 3 {
+		t.Errorf("named1 db count = %d, want 3 (cross-database bleed)", got)
+	}
+}

--- a/server/gcp/firestore/handler.go
+++ b/server/gcp/firestore/handler.go
@@ -158,7 +158,7 @@ func splitActionSuffix(path string) (action, base string, ok bool) {
 
 // serveAction handles the batch write/read endpoints used by Firestore's
 // REST API. Real Firestore's gRPC API uses individual RPCs; the REST API
-// bundles them under :commit / :batchGet / :runQuery.
+// bundles them under :commit / :batchGet / :runQuery / :runAggregationQuery.
 func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, base, action string) {
 	if r.Method != http.MethodPost {
 		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
@@ -172,6 +172,8 @@ func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, base, acti
 		h.batchGet(w, r, base)
 	case "runQuery":
 		h.runQuery(w, r, base)
+	case "runAggregationQuery":
+		h.runAggregationQuery(w, r, base)
 	case "beginTransaction":
 		h.beginTransaction(w, r)
 	case "rollback":


### PR DESCRIPTION
## Summary

Closes the highest-value remaining GCP Firestore data-plane gap after the #969 namespace-isolation fix: **aggregation queries** (`documents:runAggregationQuery`), which real users reach through `cloud.google.com/go/firestore`'s `NewAggregationQuery()` (`.WithCount` / `.WithSum` / `.WithAvg`) and every other Firestore SDK/CLI. Previously the emulator returned `501 UNIMPLEMENTED` for this action, so `Query.Get()` on an aggregation failed.

## What this closes (Firestore audit gap F3, aggregation half)

- New `:runAggregationQuery` wire action, dispatched alongside `:runQuery`.
- **COUNT** — honors `count(up_to)` (caps the returned count at the bound; returns the true count when the bound is higher).
- **SUM** — sums a field across matched docs; integer result when every summand is an integer and the total neither overflows int64 nor mixes in a floating value, otherwise a double (NaN if any value is NaN). Absent/non-numeric fields are skipped; an empty numeric set sums to integer `0`.
- **AVG** — averages the numeric values; returns a double, or `null` over an empty numeric set (matching real Firestore, whose average of no numeric values is NULL, not 0).
- The underlying structured query is fully reused: `where` (AND/OR/IN/array-contains/unary), `orderBy`, cursors, `offset`, `limit` all apply before aggregating. `select` is intentionally skipped so aggregated fields survive.
- Multiple aliased aggregations per request; empty aliases autogenerate `field_<n>`.
- Keyed on the `(project, database)` namespace via `tableKey()` — **the #969 isolation fix is preserved** (an added test confirms per-database counts do not bleed).

## Testing (real SDK + raw REST, foreground)

`server/gcp/firestore/firestore_aggregation_test.go`:
- `TestDatabaseAggregation` — real SDK COUNT/SUM/AVG over a whole collection and a filtered subset, asserting values and integer-vs-double result typing (all-int SUM -> integer, all-float and mixed int+float SUM -> double, missing fields skipped).
- `TestDatabaseAggregationEmptyAndNull` — empty COUNT/SUM -> integer 0, empty AVG -> null.
- `TestDatabaseAggregationCountUpTo` — `count(up_to)` capping over raw REST (the SDK has no up_to knob).
- `TestAggregationCrossDatabaseIsolation` — same collection under `(default)` and a named database counts only its own docs (#969 guard on the aggregation path).

Gates (foreground, GOMAXPROCS=2): `go build ./...`, `gofmt -l` clean, `go test ./providers/gcp/firestore/... ./server/gcp/firestore/... -race`, broad `go test ./providers/gcp/... ./server/gcp/...`, golangci-lint (0 new issues on touched pkgs), `go run ./internal/coveragegen` + `git diff --exit-code docs/coverage` clean, `go mod tidy` clean.

## Deferred (remaining Firestore F2/F3/F4 items, not in this PR)

- `collectionGroup` queries (`allDescendants`) — the other half of F3.
- Firestore Admin API (databases.create/get/list, composite/single-field index CRUD + build state, field TTL policy, export/import to GCS, backup schedules) — F2.
- Real 20-char auto-IDs — F4 (cosmetic).
