### PR TITLE
feat(cosmos): Mongo-API ARM control plane (mongodbDatabases/collections/throughput)

### DIFF
--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -406,6 +406,13 @@ func New(d Drivers) http.Handler {
 		// the shared databaseAccounts path for the /sqlDatabases sub-tree; the
 		// account handler still serves the account-level path and its actions.
 		srv.Register(cosmosdb.NewARM(cosmosDataPlane))
+		// Cosmos Mongo-API ARM control plane (mongodbDatabases / collections /
+		// throughputSettings). Shares cosmosDataPlane's state like the SQL plane;
+		// its mongodbDatabases sub-tree is disjoint from sqlDatabases, so order
+		// relative to the SQL handler is unconstrained. Registered before
+		// cosmosaccount so it wins the first-match over the shared databaseAccounts
+		// path for the /mongodbDatabases sub-tree.
+		srv.Register(cosmosdb.NewMongoARM(cosmosDataPlane))
 		// Cosmos-account ARM control plane (Microsoft.DocumentDB/databaseAccounts).
 		// Claims only the /providers/Microsoft.DocumentDB/databaseAccounts/
 		// management path — disjoint from the /dbs data plane above and from

--- a/server/azure/cosmosdb/armcommon.go
+++ b/server/azure/cosmosdb/armcommon.go
@@ -28,6 +28,11 @@ type armAPISpec struct {
 	databaseType           string // .../{databasesSegment}
 	databaseThroughputType string // .../{databasesSegment}/throughputSettings
 	childThroughputType    string // .../{databasesSegment}/{childSegment}/throughputSettings
+	// databaseColls/databaseUsers are the SQL database's _colls/_users child
+	// links, set on every SQL database response; the Mongo database resource has
+	// neither, so they are left empty (omitted) for the Mongo plane.
+	databaseColls string
+	databaseUsers string
 }
 
 // Request routing (shared) ---------------------------------------------------
@@ -193,10 +198,12 @@ func armRenderDatabase(h *Handler, rp *azurearm.ResourcePath, db string, spec *a
 		Type: spec.databaseType,
 		Properties: &armDatabaseGetProps{
 			Resource: &armDatabaseGetResource{
-				ID:   db,
-				RID:  "rid-" + dbNS(rp.ResourceName, db),
-				TS:   h.clock.Now().Unix(),
-				ETag: azurearm.ETag(id),
+				ID:    db,
+				RID:   "rid-" + dbNS(rp.ResourceName, db),
+				TS:    h.clock.Now().Unix(),
+				ETag:  azurearm.ETag(id),
+				Colls: spec.databaseColls,
+				Users: spec.databaseUsers,
 			},
 		},
 	}

--- a/server/azure/cosmosdb/armcommon.go
+++ b/server/azure/cosmosdb/armcommon.go
@@ -1,0 +1,412 @@
+package cosmosdb
+
+// Shared ARM (Microsoft.DocumentDB) control-plane logic used by both the SQL-API
+// handler (sqlarm.go) and the Mongo-API handler (mongoarm.go). A Cosmos database
+// and its provisioned throughput are one shared backend entity regardless of the
+// account's API kind — the account's databases set and the offers map back both
+// planes — so the database plane, the throughput plane, and the request-routing
+// and child-resource skeletons are written once here and parameterized per API
+// by armAPISpec plus a few callbacks. Only the child resource itself (a SQL
+// container vs a Mongo collection) has an API-specific shape (partition key +
+// TTL/unique keys vs shard key + indexes), supplied by each handler's callbacks.
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+// armAPISpec names the API-specific path segments and ARM resource-type strings
+// for one Cosmos API family, so the shared planes render the right "type" and
+// build the right resource IDs while operating on the one shared backend.
+type armAPISpec struct {
+	databasesSegment       string // "sqlDatabases" | "mongodbDatabases"
+	childSegment           string // "containers"   | "collections"
+	databaseType           string // .../{databasesSegment}
+	databaseThroughputType string // .../{databasesSegment}/throughputSettings
+	childThroughputType    string // .../{databasesSegment}/{childSegment}/throughputSettings
+}
+
+// Request routing (shared) ---------------------------------------------------
+
+// childOps supplies the two API-specific child-resource entry points (a SQL
+// container or a Mongo collection) to the shared dispatcher.
+type childOps struct {
+	list   func(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db string)
+	single func(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db, child string)
+}
+
+// serveARMSubtree parses an ARM databases-subtree request, verifies the parent
+// account exists, then hands the parsed path to dispatch. Both control planes
+// route through this; only the databases/child segment names and the dispatch
+// closure differ.
+func serveARMSubtree(
+	h *Handler, w http.ResponseWriter, r *http.Request, dbSeg, childSeg, notFound string,
+	dispatch func(rp *azurearm.ResourcePath, t *sqlTarget),
+) {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	target, ok := parseDBSubtree(armTail(r.URL.Path, rp.ResourceName), dbSeg, childSeg)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", notFound)
+		return
+	}
+
+	// Every operation is scoped to a database account; a missing account is
+	// ARM's ParentResourceNotFound.
+	if !h.isAccount(rp.ResourceName) {
+		azurearm.WriteError(w, http.StatusNotFound, "ParentResourceNotFound",
+			"database account "+rp.ResourceName+" not found")
+
+		return
+	}
+
+	dispatch(&rp, &target)
+}
+
+// armDispatch routes a parsed target: database and throughput kinds go to the
+// shared plane, child kinds go to the API-specific callbacks in ops.
+func armDispatch(
+	h *Handler, w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath,
+	t *sqlTarget, spec *armAPISpec, notFound string, ops childOps,
+) {
+	switch t.kind {
+	case kindDBList:
+		armListDatabases(h, w, r, rp, spec)
+	case kindDB:
+		armDatabaseResource(h, w, r, rp, t.db, spec)
+	case kindContainerList:
+		ops.list(w, r, rp, t.db)
+	case kindContainer:
+		ops.single(w, r, rp, t.db, t.container)
+	case kindDBThroughput, kindContainerThroughput:
+		armServeThroughput(h, w, r, rp, t, spec)
+	case kindDBMigrate, kindContainerMigrate:
+		armMigrateThroughput(h, w, r, rp, t, spec)
+	default:
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", notFound)
+	}
+}
+
+// Database plane (shared) -----------------------------------------------------
+
+// armDatabaseResource serves GET/PUT/DELETE on a single database. Delete is
+// idempotent (a cascade over a missing database still answers 204 so the SDK's
+// BeginDelete poller terminates).
+func armDatabaseResource(
+	h *Handler, w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db string, spec *armAPISpec,
+) {
+	switch r.Method {
+	case http.MethodPut:
+		armCreateOrUpdateDatabase(h, w, r, rp, db, spec)
+	case http.MethodGet:
+		if !h.databaseExists(rp.ResourceName, db) {
+			azurearm.WriteError(w, http.StatusNotFound, "NotFound", "database "+db+" not found")
+			return
+		}
+
+		azurearm.WriteJSON(w, http.StatusOK, armRenderDatabase(h, rp, db, spec))
+	case http.MethodDelete:
+		_ = h.cascadeDeleteDatabase(r.Context(), rp.ResourceName, db)
+
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+// armCreateOrUpdateDatabase is the create-or-update contract: a re-PUT of an
+// existing database is not an error, it re-applies database-level throughput.
+func armCreateOrUpdateDatabase(
+	h *Handler, w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db string, spec *armAPISpec,
+) {
+	var body armDatabaseCreateParams
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	if body.Properties == nil || body.Properties.Resource == nil || body.Properties.Resource.ID == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "properties.resource.id is required")
+		return
+	}
+
+	h.registerDatabase(rp.ResourceName, db)
+
+	// Shared (database-level) throughput, keyed by the database's dbNS — the same
+	// key the data plane's offer lookup derives, so it round-trips there too.
+	if st, ok := offerFromOptions(body.Properties.Options); ok {
+		h.setOffer(dbNS(rp.ResourceName, db), st)
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armRenderDatabase(h, rp, db, spec))
+}
+
+// armListDatabases lists every database in the account (both APIs share the one
+// databases set; a single-API account only ever holds one API's databases).
+func armListDatabases(h *Handler, w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, spec *armAPISpec) {
+	if r.Method != http.MethodGet {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	names := databasesInAccount(h, rp.ResourceName)
+
+	out := armDatabaseList{Value: make([]armDatabaseGetResults, 0, len(names))}
+	for _, name := range names {
+		out.Value = append(out.Value, armRenderDatabase(h, rp, name, spec))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+// databasesInAccount returns the sorted database names owned by account.
+func databasesInAccount(h *Handler, account string) []string {
+	h.dbMu.RLock()
+	defer h.dbMu.RUnlock()
+
+	names := make([]string, 0)
+
+	for key := range h.databases {
+		if id, ok := accountDBName(key, account); ok {
+			names = append(names, id)
+		}
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+func armRenderDatabase(h *Handler, rp *azurearm.ResourcePath, db string, spec *armAPISpec) armDatabaseGetResults {
+	id := armDBResourceID(rp, db, spec)
+
+	return armDatabaseGetResults{
+		ID:   id,
+		Name: db,
+		Type: spec.databaseType,
+		Properties: &armDatabaseGetProps{
+			Resource: &armDatabaseGetResource{
+				ID:   db,
+				RID:  "rid-" + dbNS(rp.ResourceName, db),
+				TS:   h.clock.Now().Unix(),
+				ETag: azurearm.ETag(id),
+			},
+		},
+	}
+}
+
+// Child resource skeletons (shared) -------------------------------------------
+
+// singleChildOps supplies the API-specific behavior for a single child resource
+// (SQL container / Mongo collection): PUT create-or-update, GET render, and the
+// extra out-of-driver bookkeeping to drop on DELETE.
+type singleChildOps struct {
+	put     func(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db, child string)
+	render  func(ctx context.Context, rp *azurearm.ResourcePath, db, child string) (any, error)
+	cleanup func(table string)
+}
+
+// armServeChild serves GET/PUT/DELETE on one child resource. DELETE is
+// idempotent (absence is a no-op that still answers 204 so BeginDelete
+// terminates) and drops the child's table, offer, and API-specific attrs.
+func armServeChild(
+	h *Handler, w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db, child string, ops singleChildOps,
+) {
+	switch r.Method {
+	case http.MethodPut:
+		ops.put(w, r, rp, db, child)
+	case http.MethodGet:
+		res, err := ops.render(r.Context(), rp, db, child)
+		if err != nil {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+
+		azurearm.WriteJSON(w, http.StatusOK, res)
+	case http.MethodDelete:
+		table := qualify(rp.ResourceName, db, child)
+		_ = h.db.DeleteTable(r.Context(), table)
+		h.deleteOffer(table)
+		ops.cleanup(table)
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+// armListChildren lists the children (containers/collections) of a database in
+// the shared {"value":[...]} envelope, rendering each via the API-specific
+// render callback. A missing database is ARM's ParentResourceNotFound.
+func armListChildren(
+	h *Handler, w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db, notFound string,
+	render func(ctx context.Context, rp *azurearm.ResourcePath, db, child string) (any, error),
+) {
+	if r.Method != http.MethodGet {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	if !h.databaseExists(rp.ResourceName, db) {
+		azurearm.WriteError(w, http.StatusNotFound, "ParentResourceNotFound", notFound)
+		return
+	}
+
+	tables, err := h.db.ListTables(r.Context())
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	prefix := dbNS(rp.ResourceName, db) + "/"
+
+	value := make([]any, 0)
+
+	for _, t := range tables {
+		if !strings.HasPrefix(t, prefix) {
+			continue
+		}
+
+		if res, cerr := render(r.Context(), rp, db, strings.TrimPrefix(t, prefix)); cerr == nil {
+			value = append(value, res)
+		}
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, map[string]any{"value": value})
+}
+
+// Throughput plane (shared) ---------------------------------------------------
+
+func armServeThroughput(
+	h *Handler, w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, t *sqlTarget, spec *armAPISpec,
+) {
+	key, resType, exists := armThroughputTarget(h, rp, t, spec)
+	if !exists {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "parent resource not found")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		st, ok := h.getOffer(key)
+		if !ok {
+			azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+				"resource does not have dedicated throughput (shared or serverless)")
+
+			return
+		}
+
+		azurearm.WriteJSON(w, http.StatusOK, renderThroughput(st, armThroughputID(rp, t, spec), resType))
+	case http.MethodPut:
+		armUpdateThroughput(h, w, r, rp, t, key, resType, spec)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+func armUpdateThroughput(
+	h *Handler, w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath,
+	t *sqlTarget, key, resType string, spec *armAPISpec,
+) {
+	var body armThroughputUpdateParams
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	var res *armThroughputResource
+	if body.Properties != nil {
+		res = body.Properties.Resource
+	}
+
+	if res == nil {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "properties.resource is required")
+		return
+	}
+
+	st, ok := offerFromThroughput(res.Throughput, res.AutoscaleSettings)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter",
+			"either throughput or autoscaleSettings.maxThroughput is required")
+
+		return
+	}
+
+	h.setOffer(key, st)
+	azurearm.WriteJSON(w, http.StatusOK, renderThroughput(st, armThroughputID(rp, t, spec), resType))
+}
+
+func armMigrateThroughput(
+	h *Handler, w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, t *sqlTarget, spec *armAPISpec,
+) {
+	if r.Method != http.MethodPost {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	key, resType, exists := armThroughputTarget(h, rp, t, spec)
+	if !exists {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "parent resource not found")
+		return
+	}
+
+	st, ok := h.getOffer(key)
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
+			"resource does not have dedicated throughput to migrate")
+
+		return
+	}
+
+	migrated := migrateOffer(st, t.migrate == actionMigrateToAutoscale)
+	h.setOffer(key, migrated)
+
+	azurearm.WriteJSON(w, http.StatusOK, renderThroughput(migrated, armThroughputID(rp, t, spec), resType))
+}
+
+// armThroughputTarget resolves a throughput request to its offer key and
+// response resource type, and reports whether the parent database/child exists.
+func armThroughputTarget(
+	h *Handler, rp *azurearm.ResourcePath, t *sqlTarget, spec *armAPISpec,
+) (key, resType string, exists bool) {
+	if t.container != "" {
+		table := qualify(rp.ResourceName, t.db, t.container)
+		if _, err := h.db.DescribeTable(context.Background(), table); err != nil {
+			return "", "", false
+		}
+
+		return table, spec.childThroughputType, true
+	}
+
+	if !h.databaseExists(rp.ResourceName, t.db) {
+		return "", "", false
+	}
+
+	return dbNS(rp.ResourceName, t.db), spec.databaseThroughputType, true
+}
+
+// Resource IDs ----------------------------------------------------------------
+
+func armDBResourceID(rp *azurearm.ResourcePath, db string, spec *armAPISpec) string {
+	return azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, armProvider, armAccountType, rp.ResourceName) +
+		"/" + spec.databasesSegment + "/" + db
+}
+
+func armChildResourceID(rp *azurearm.ResourcePath, db, child string, spec *armAPISpec) string {
+	return armDBResourceID(rp, db, spec) + "/" + spec.childSegment + "/" + child
+}
+
+// armThroughputID is the ARM ID of a throughputSettings/default child.
+func armThroughputID(rp *azurearm.ResourcePath, t *sqlTarget, spec *armAPISpec) string {
+	base := armDBResourceID(rp, t.db, spec)
+	if t.container != "" {
+		base += "/" + spec.childSegment + "/" + t.container
+	}
+
+	return base + "/throughputSettings/" + throughputName
+}

--- a/server/azure/cosmosdb/armcommon_types.go
+++ b/server/azure/cosmosdb/armcommon_types.go
@@ -1,0 +1,47 @@
+package cosmosdb
+
+// Shared ARM database-plane wire shapes. A Cosmos database carries the same
+// minimal ARM body (properties.resource.id, optional throughput options) whether
+// it is a SQL or a Mongo database, so both control planes decode and render
+// these one set of types (parameterized only by the "type" string in armAPISpec).
+
+type armDatabaseCreateParams struct {
+	Properties *armDatabaseCreateProps `json:"properties"`
+	Location   string                  `json:"location,omitempty"`
+	Tags       map[string]string       `json:"tags,omitempty"`
+}
+
+type armDatabaseCreateProps struct {
+	Resource *armDatabaseIDResource  `json:"resource"`
+	Options  *armCreateUpdateOptions `json:"options,omitempty"`
+}
+
+// armDatabaseIDResource is the create body's resource block: just the database
+// id (Cosmos databases carry no other user-settable resource properties).
+type armDatabaseIDResource struct {
+	ID string `json:"id"`
+}
+
+type armDatabaseGetResults struct {
+	ID         string               `json:"id,omitempty"`
+	Name       string               `json:"name,omitempty"`
+	Type       string               `json:"type,omitempty"`
+	Location   string               `json:"location,omitempty"`
+	Tags       map[string]string    `json:"tags,omitempty"`
+	Properties *armDatabaseGetProps `json:"properties,omitempty"`
+}
+
+type armDatabaseGetProps struct {
+	Resource *armDatabaseGetResource `json:"resource,omitempty"`
+}
+
+type armDatabaseGetResource struct {
+	ID   string `json:"id"`
+	RID  string `json:"_rid,omitempty"`
+	TS   int64  `json:"_ts,omitempty"`
+	ETag string `json:"_etag,omitempty"`
+}
+
+type armDatabaseList struct {
+	Value []armDatabaseGetResults `json:"value"`
+}

--- a/server/azure/cosmosdb/armcommon_types.go
+++ b/server/azure/cosmosdb/armcommon_types.go
@@ -40,6 +40,11 @@ type armDatabaseGetResource struct {
 	RID  string `json:"_rid,omitempty"`
 	TS   int64  `json:"_ts,omitempty"`
 	ETag string `json:"_etag,omitempty"`
+	// Colls/Users are the SQL database's child-resource links (Cosmos
+	// SQLDatabaseGetPropertiesResource carries _colls/_users). The Mongo database
+	// resource has neither, so they stay empty (omitted) for the Mongo plane.
+	Colls string `json:"_colls,omitempty"`
+	Users string `json:"_users,omitempty"`
 }
 
 type armDatabaseList struct {

--- a/server/azure/cosmosdb/handler.go
+++ b/server/azure/cosmosdb/handler.go
@@ -73,6 +73,12 @@ type Handler struct {
 	// bookkeeping needed to enforce it. See container_attrs.go.
 	attrs *attrsStore
 
+	// mongoAttrs tracks the Mongo-API collection properties the generic driver
+	// has no concept of (shard key, indexes, analytical TTL), keyed by the
+	// collection's qualified table name, so the Mongo ARM control plane round-
+	// trips them on a collection read/list. See mongoarm.go.
+	mongoAttrs *mongoAttrStore
+
 	// writeMu serializes item mutations and TTL reaping per container. A create's
 	// uniqueness check and its insert must be one uninterruptible step (see
 	// keyedMutex), and a lazy TTL sweep must not race a concurrent write.
@@ -106,12 +112,13 @@ func New(db dbdriver.Database) *Handler {
 	}
 
 	return &Handler{
-		db:        db,
-		offers:    make(map[string]offerState),
-		databases: make(map[string]struct{}),
-		attrs:     newAttrsStore(clock),
-		writeMu:   newKeyedMutex(),
-		clock:     clock,
+		db:         db,
+		offers:     make(map[string]offerState),
+		databases:  make(map[string]struct{}),
+		attrs:      newAttrsStore(clock),
+		mongoAttrs: newMongoAttrStore(),
+		writeMu:    newKeyedMutex(),
+		clock:      clock,
 	}
 }
 
@@ -206,6 +213,7 @@ func (h *Handler) cascadeDeleteDatabase(ctx context.Context, account, db string)
 
 		h.deleteOffer(t)
 		h.attrs.delete(t)
+		h.mongoAttrs.delete(t)
 	}
 
 	h.deleteOffer(ns) // the database's own shared-throughput offer, if any
@@ -556,6 +564,7 @@ func (h *Handler) PurgeAccount(ctx context.Context, account string) {
 			if strings.HasPrefix(t, prefix) {
 				h.deleteOffer(t)
 				h.attrs.delete(t)
+				h.mongoAttrs.delete(t)
 			}
 		}
 	}

--- a/server/azure/cosmosdb/mongoarm.go
+++ b/server/azure/cosmosdb/mongoarm.go
@@ -1,0 +1,290 @@
+package cosmosdb
+
+// ARM Mongo-API control plane (Microsoft.DocumentDB/databaseAccounts/
+// mongodbDatabases and .../collections, plus their throughputSettings). Real
+// armcosmos MongoDBResourcesClient clients configured with a custom endpoint
+// drive this the same way they drive management.azure.com, so Bicep / Terraform
+// (azurerm_cosmosdb_mongo_database / _mongo_collection) / `az cosmosdb mongodb
+// database create` can manage the Mongo data model.
+//
+// MongoARMHandler shares the data-plane Handler's state exactly as the SQL ARM
+// handler does: Mongo databases live in the same databases set (a real Cosmos
+// account is single-API, so SQL and Mongo databases never coexist on one
+// account and the shared namespace is not a collision), Mongo collections are
+// the same driver tables (keyed by qualify, partitioned by the collection's
+// shard key), and throughput lives in the same offers map. The API-agnostic
+// database and throughput planes are shared from armcommon.go; only the
+// collection shape (shard key + indexes + analytical TTL) is handled here.
+//
+// Create/update/delete/migrate are long-running operations in real Azure; the
+// emulator completes them synchronously (200 with the resource body, or 204 for
+// delete) so the SDK's Begin* pollers terminate on the first response, matching
+// the SQL control plane.
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+const (
+	mongoDatabasesSeg = "mongodbDatabases"
+	collectionsSeg    = "collections"
+
+	typeMongoDatabase             = "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases"
+	typeMongoCollection           = "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections"
+	typeMongoDatabaseThroughput   = "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings"
+	typeMongoCollectionThroughput = "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/throughputSettings"
+
+	// shardKindHash is the shard-key kind real Cosmos reports for a Mongo shard
+	// key (Mongo sharding is hash-based); reconstructed on a collection read.
+	shardKindHash = "Hash"
+)
+
+// mongoAPISpec is the Mongo-API type/segment set for the shared database and
+// throughput planes.
+func mongoAPISpec() *armAPISpec {
+	return &armAPISpec{
+		databasesSegment:       mongoDatabasesSeg,
+		childSegment:           collectionsSeg,
+		databaseType:           typeMongoDatabase,
+		databaseThroughputType: typeMongoDatabaseThroughput,
+		childThroughputType:    typeMongoCollectionThroughput,
+	}
+}
+
+// Mongo collection attrs store -----------------------------------------------
+
+// mongoCollAttrs holds the Mongo collection properties the generic database
+// driver has no concept of, so a collection read/list round-trips them.
+type mongoCollAttrs struct {
+	shardKey             map[string]string
+	indexes              []armMongoIndex
+	analyticalStorageTTL *int32
+}
+
+// mongoAttrStore tracks mongoCollAttrs keyed by the collection's qualified
+// table name (see qualify), mirroring how offers.go and container_attrs.go
+// track out-of-driver container state.
+type mongoAttrStore struct {
+	mu    sync.RWMutex
+	attrs map[string]mongoCollAttrs
+}
+
+func newMongoAttrStore() *mongoAttrStore {
+	return &mongoAttrStore{attrs: make(map[string]mongoCollAttrs)}
+}
+
+func (s *mongoAttrStore) set(table string, a mongoCollAttrs) {
+	s.mu.Lock()
+	s.attrs[table] = a
+	s.mu.Unlock()
+}
+
+func (s *mongoAttrStore) get(table string) (mongoCollAttrs, bool) {
+	s.mu.RLock()
+	a, ok := s.attrs[table]
+	s.mu.RUnlock()
+
+	return a, ok
+}
+
+func (s *mongoAttrStore) delete(table string) {
+	s.mu.Lock()
+	delete(s.attrs, table)
+	s.mu.Unlock()
+}
+
+// MongoARMHandler ------------------------------------------------------------
+
+// MongoARMHandler serves the Microsoft.DocumentDB Mongo sub-resource control
+// plane (mongodbDatabases, collections, throughputSettings) against the shared
+// data-plane Handler.
+type MongoARMHandler struct {
+	h    *Handler
+	spec *armAPISpec
+}
+
+// NewMongoARM returns an ARM Mongo control-plane handler backed by the same
+// data-plane Handler, so control-plane and data-plane state stay unified.
+func NewMongoARM(h *Handler) *MongoARMHandler {
+	return &MongoARMHandler{h: h, spec: mongoAPISpec()}
+}
+
+// Matches claims only the mongodbDatabases sub-tree of a database account. It
+// never claims the account-level path (served by cosmosaccount) nor the /dbs
+// data plane, and it is disjoint from the SQL ARM handler's sqlDatabases tree.
+func (*MongoARMHandler) Matches(r *http.Request) bool {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	return strings.EqualFold(rp.Provider, armProvider) &&
+		strings.EqualFold(rp.ResourceType, armAccountType) &&
+		rp.ResourceName != "" &&
+		strings.EqualFold(rp.SubResource, mongoDatabasesSeg)
+}
+
+// ServeHTTP parses the ARM path, verifies the parent account exists, then
+// dispatches: the database/throughput kinds go to the shared plane, the
+// collection kinds to the Mongo-specific callbacks below.
+func (m *MongoARMHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	serveARMSubtree(m.h, w, r, mongoDatabasesSeg, collectionsSeg, "unsupported Cosmos Mongo resource path",
+		func(rp *azurearm.ResourcePath, t *sqlTarget) {
+			armDispatch(m.h, w, r, rp, t, m.spec, "unsupported Cosmos Mongo resource path", childOps{
+				list:   m.listCollections,
+				single: m.collectionResource,
+			})
+		})
+}
+
+// Collections (Mongo-specific) -----------------------------------------------
+
+func (m *MongoARMHandler) collectionResource(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db, coll string,
+) {
+	armServeChild(m.h, w, r, rp, db, coll, singleChildOps{
+		put:     m.createOrUpdateCollection,
+		render:  m.renderCollectionAny,
+		cleanup: m.h.mongoAttrs.delete,
+	})
+}
+
+// renderCollectionAny adapts renderCollection to the shared render callback.
+func (m *MongoARMHandler) renderCollectionAny(ctx context.Context, rp *azurearm.ResourcePath, db, coll string) (any, error) {
+	return m.renderCollection(ctx, rp, db, coll)
+}
+
+func (m *MongoARMHandler) createOrUpdateCollection(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db, coll string,
+) {
+	if !m.h.databaseExists(rp.ResourceName, db) {
+		azurearm.WriteError(w, http.StatusNotFound, "ParentResourceNotFound", "mongodb database "+db+" not found")
+		return
+	}
+
+	var body armMongoCollectionCreateParams
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	res := body.resourceOrNil()
+	if res == nil || res.ID == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "properties.resource.id is required")
+		return
+	}
+
+	table := qualify(rp.ResourceName, db, coll)
+	pkAttr := shardKeyAttribute(res.ShardKey)
+
+	cfg := dbdriver.TableConfig{Name: table, PartitionKey: pkAttr}
+	if pkAttr != idAttr {
+		cfg.SortKey = idAttr
+	}
+
+	// Create-or-update: an existing collection (AlreadyExists) is not an error —
+	// re-apply its attrs and throughput. The shard key is immutable, so the
+	// existing table config is kept.
+	if err := m.h.db.CreateTable(r.Context(), cfg); err != nil && !cerrors.IsAlreadyExists(err) {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	m.h.mongoAttrs.set(table, mongoCollAttrs{
+		shardKey:             res.ShardKey,
+		indexes:              res.Indexes,
+		analyticalStorageTTL: res.AnalyticalStorageTTL,
+	})
+
+	if st, ok := offerFromOptions(body.Properties.Options); ok {
+		m.h.setOffer(table, st)
+	}
+
+	out, err := m.renderCollection(r.Context(), rp, db, coll)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+func (m *MongoARMHandler) listCollections(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db string) {
+	armListChildren(m.h, w, r, rp, db, "mongodb database "+db+" not found", m.renderCollectionAny)
+}
+
+func (m *MongoARMHandler) renderCollection(
+	ctx context.Context, rp *azurearm.ResourcePath, db, coll string,
+) (armMongoCollectionGetResults, error) {
+	table := qualify(rp.ResourceName, db, coll)
+
+	cfg, err := m.h.db.DescribeTable(ctx, table)
+	if err != nil {
+		return armMongoCollectionGetResults{}, err
+	}
+
+	attrs, _ := m.h.mongoAttrs.get(table)
+
+	// A collection created through the ARM plane carries its shard key in the
+	// attrs store; one materialized only through the driver falls back to the
+	// table's partition key (a single-field hash shard key).
+	shardKey := attrs.shardKey
+	if shardKey == nil && cfg.PartitionKey != "" && cfg.PartitionKey != idAttr {
+		shardKey = map[string]string{cfg.PartitionKey: shardKindHash}
+	}
+
+	id := armChildResourceID(rp, db, coll, m.spec)
+
+	return armMongoCollectionGetResults{
+		ID:   id,
+		Name: coll,
+		Type: typeMongoCollection,
+		Properties: &armMongoCollectionGetProps{
+			Resource: &armMongoCollectionGetResource{
+				ID:                   coll,
+				ShardKey:             shardKey,
+				Indexes:              attrs.indexes,
+				AnalyticalStorageTTL: attrs.analyticalStorageTTL,
+				RID:                  containerRID(table),
+				TS:                   m.h.clock.Now().Unix(),
+				ETag:                 azurearm.ETag(id),
+			},
+		},
+	}, nil
+}
+
+// Helpers --------------------------------------------------------------------
+
+func (b *armMongoCollectionCreateParams) resourceOrNil() *armMongoCollectionResource {
+	if b.Properties == nil {
+		return nil
+	}
+
+	return b.Properties.Resource
+}
+
+// shardKeyAttribute maps a Mongo shard key onto the driver table's partition-key
+// attribute. A Cosmos Mongo shard key is a single field; when several are given
+// the lexicographically-first is used deterministically, and an absent shard key
+// yields an unsharded collection partitioned by its id.
+func shardKeyAttribute(shardKey map[string]string) string {
+	if len(shardKey) == 0 {
+		return idAttr
+	}
+
+	fields := make([]string, 0, len(shardKey))
+	for f := range shardKey {
+		fields = append(fields, f)
+	}
+
+	sort.Strings(fields)
+
+	return fields[0]
+}

--- a/server/azure/cosmosdb/mongoarm_test.go
+++ b/server/azure/cosmosdb/mongoarm_test.go
@@ -1,0 +1,339 @@
+// Real-SDK round-trip tests for the Cosmos Mongo-API ARM control plane: the live
+// armcosmos MongoDBResourcesClient drives mongodbDatabases, collections and their
+// throughputSettings end-to-end, proving IaC/`az`-style management of the Mongo
+// data model and that it shares the one backend with the account control plane
+// (and stays disjoint from the SQL ARM plane on the same server).
+
+package cosmosdb_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// mongoEnv bundles the Mongo + account ARM clients and the live server.
+type mongoEnv struct {
+	mongo *armcosmos.MongoDBResourcesClient
+	acct  *armcosmos.DatabaseAccountsClient
+	ts    *httptest.Server
+}
+
+func newMongoEnv(t *testing.T) mongoEnv {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{CosmosDB: cloudP.CosmosDB})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	mongoClient, err := armcosmos.NewMongoDBResourcesClient("sub-1", armFakeCred{}, opts)
+	require.NoError(t, err)
+
+	acctClient, err := armcosmos.NewDatabaseAccountsClient("sub-1", armFakeCred{}, opts)
+	require.NoError(t, err)
+
+	return mongoEnv{mongo: mongoClient, acct: acctClient, ts: ts}
+}
+
+func (e mongoEnv) createAccount(t *testing.T, rg, name, region string) {
+	t.Helper()
+
+	poller, err := e.acct.BeginCreateOrUpdate(context.Background(), rg, name, armcosmos.DatabaseAccountCreateUpdateParameters{
+		Location: to.Ptr(region),
+		Kind:     to.Ptr(armcosmos.DatabaseAccountKindMongoDB),
+		Properties: &armcosmos.DatabaseAccountCreateUpdateProperties{
+			DatabaseAccountOfferType: to.Ptr("Standard"),
+			Locations: []*armcosmos.Location{
+				{LocationName: to.Ptr(region), FailoverPriority: to.Ptr[int32](0)},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(context.Background(), nil)
+	require.NoError(t, err)
+}
+
+func (e mongoEnv) putDatabase(t *testing.T, rg, acct, db string, opts *armcosmos.CreateUpdateOptions) {
+	t.Helper()
+
+	poller, err := e.mongo.BeginCreateUpdateMongoDBDatabase(context.Background(), rg, acct, db,
+		armcosmos.MongoDBDatabaseCreateUpdateParameters{
+			Properties: &armcosmos.MongoDBDatabaseCreateUpdateProperties{
+				Resource: &armcosmos.MongoDBDatabaseResource{ID: to.Ptr(db)},
+				Options:  opts,
+			},
+		}, nil)
+	require.NoError(t, err)
+
+	_, err = poller.PollUntilDone(context.Background(), nil)
+	require.NoError(t, err)
+}
+
+func (e mongoEnv) putCollection(
+	t *testing.T, rg, acct, db string, res *armcosmos.MongoDBCollectionResource, opts *armcosmos.CreateUpdateOptions,
+) armcosmos.MongoDBCollectionGetResults {
+	t.Helper()
+
+	poller, err := e.mongo.BeginCreateUpdateMongoDBCollection(context.Background(), rg, acct, db, *res.ID,
+		armcosmos.MongoDBCollectionCreateUpdateParameters{
+			Properties: &armcosmos.MongoDBCollectionCreateUpdateProperties{Resource: res, Options: opts},
+		}, nil)
+	require.NoError(t, err)
+
+	out, err := poller.PollUntilDone(context.Background(), nil)
+	require.NoError(t, err)
+
+	return out.MongoDBCollectionGetResults
+}
+
+// TestSDKMongoControlPlaneLifecycle is the full real-user flow: create account ->
+// PUT database -> GET/list -> PUT collection (shard key + index) -> GET/list ->
+// PUT manual throughput -> GET -> migrate to autoscale -> GET -> DELETE database
+// cascades its collection.
+func TestSDKMongoControlPlaneLifecycle(t *testing.T) {
+	ctx := context.Background()
+	env := newMongoEnv(t)
+	env.createAccount(t, "rg-1", "mongo1", "eastus")
+
+	// PUT database.
+	env.putDatabase(t, "rg-1", "mongo1", "appdb", nil)
+
+	// GET database.
+	got, err := env.mongo.GetMongoDBDatabase(ctx, "rg-1", "mongo1", "appdb", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "appdb", *got.Name)
+	require.NotNil(t, got.ID)
+	assert.Contains(t, *got.ID, "/databaseAccounts/mongo1/mongodbDatabases/appdb")
+
+	// List databases.
+	assert.Contains(t, listMongoDatabaseNames(t, env, "rg-1", "mongo1"), "appdb")
+
+	// PUT collection with a shard key + a unique TTL index.
+	coll := env.putCollection(t, "rg-1", "mongo1", "appdb", &armcosmos.MongoDBCollectionResource{
+		ID:       to.Ptr("orders"),
+		ShardKey: map[string]*string{"customerId": to.Ptr("Hash")},
+		Indexes: []*armcosmos.MongoIndex{{
+			Key:     &armcosmos.MongoIndexKeys{Keys: []*string{to.Ptr("_ts")}},
+			Options: &armcosmos.MongoIndexOptions{ExpireAfterSeconds: to.Ptr[int32](2592000), Unique: to.Ptr(false)},
+		}},
+		AnalyticalStorageTTL: to.Ptr[int32](-1),
+	}, nil)
+	require.NotNil(t, coll.Name)
+	assert.Equal(t, "orders", *coll.Name)
+	requireShardKey(t, coll, "customerId")
+
+	// GET collection: shard key + index + analytical TTL round-trip.
+	gotC, err := env.mongo.GetMongoDBCollection(ctx, "rg-1", "mongo1", "appdb", "orders", nil)
+	require.NoError(t, err)
+	requireShardKey(t, gotC.MongoDBCollectionGetResults, "customerId")
+	require.NotNil(t, gotC.Properties.Resource.AnalyticalStorageTTL)
+	assert.Equal(t, int32(-1), *gotC.Properties.Resource.AnalyticalStorageTTL)
+	require.Len(t, gotC.Properties.Resource.Indexes, 1)
+	require.NotNil(t, gotC.Properties.Resource.Indexes[0].Options.ExpireAfterSeconds)
+	assert.Equal(t, int32(2592000), *gotC.Properties.Resource.Indexes[0].Options.ExpireAfterSeconds)
+
+	// List collections.
+	assert.Contains(t, listMongoCollectionNames(t, env, "rg-1", "mongo1", "appdb"), "orders")
+
+	// PUT manual collection throughput.
+	updateMongoCollectionThroughput(t, env, "rg-1", "mongo1", "appdb", "orders",
+		&armcosmos.ThroughputSettingsResource{Throughput: to.Ptr[int32](600)})
+
+	tp, err := env.mongo.GetMongoDBCollectionThroughput(ctx, "rg-1", "mongo1", "appdb", "orders", nil)
+	require.NoError(t, err)
+	require.NotNil(t, tp.Properties.Resource.Throughput)
+	assert.Equal(t, int32(600), *tp.Properties.Resource.Throughput)
+
+	// Migrate to autoscale.
+	mPoller, err := env.mongo.BeginMigrateMongoDBCollectionToAutoscale(ctx, "rg-1", "mongo1", "appdb", "orders", nil)
+	require.NoError(t, err)
+	_, err = mPoller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	tp2, err := env.mongo.GetMongoDBCollectionThroughput(ctx, "rg-1", "mongo1", "appdb", "orders", nil)
+	require.NoError(t, err)
+	require.NotNil(t, tp2.Properties.Resource.AutoscaleSettings)
+	require.NotNil(t, tp2.Properties.Resource.AutoscaleSettings.MaxThroughput)
+	assert.Equal(t, int32(1000), *tp2.Properties.Resource.AutoscaleSettings.MaxThroughput)
+
+	// DELETE database cascades the collection.
+	dPoller, err := env.mongo.BeginDeleteMongoDBDatabase(ctx, "rg-1", "mongo1", "appdb", nil)
+	require.NoError(t, err)
+	_, err = dPoller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	_, err = env.mongo.GetMongoDBCollection(ctx, "rg-1", "mongo1", "appdb", "orders", nil)
+	require.Error(t, err, "collection must 404 after its database is deleted")
+
+	_, err = env.mongo.GetMongoDBDatabase(ctx, "rg-1", "mongo1", "appdb", nil)
+	require.Error(t, err, "database must 404 after delete")
+}
+
+// TestSDKMongoDatabaseSharedThroughput drives database-level shared throughput
+// and its migration to manual.
+func TestSDKMongoDatabaseSharedThroughput(t *testing.T) {
+	ctx := context.Background()
+	env := newMongoEnv(t)
+	env.createAccount(t, "rg-1", "mongo-shared", "eastus")
+
+	env.putDatabase(t, "rg-1", "mongo-shared", "shared", &armcosmos.CreateUpdateOptions{
+		AutoscaleSettings: &armcosmos.AutoscaleSettings{MaxThroughput: to.Ptr[int32](4000)},
+	})
+
+	tp, err := env.mongo.GetMongoDBDatabaseThroughput(ctx, "rg-1", "mongo-shared", "shared", nil)
+	require.NoError(t, err)
+	require.NotNil(t, tp.Properties.Resource.AutoscaleSettings)
+	require.NotNil(t, tp.Properties.Resource.AutoscaleSettings.MaxThroughput)
+	assert.Equal(t, int32(4000), *tp.Properties.Resource.AutoscaleSettings.MaxThroughput)
+
+	// Migrate database throughput to manual.
+	mPoller, err := env.mongo.BeginMigrateMongoDBDatabaseToManualThroughput(ctx, "rg-1", "mongo-shared", "shared", nil)
+	require.NoError(t, err)
+	_, err = mPoller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	tp2, err := env.mongo.GetMongoDBDatabaseThroughput(ctx, "rg-1", "mongo-shared", "shared", nil)
+	require.NoError(t, err)
+	require.NotNil(t, tp2.Properties.Resource.Throughput)
+	assert.Equal(t, int32(4000), *tp2.Properties.Resource.Throughput)
+}
+
+// TestSDKMongoUnshardedCollection asserts a collection created with no shard key
+// is unsharded (no shardKey reported back).
+func TestSDKMongoUnshardedCollection(t *testing.T) {
+	ctx := context.Background()
+	env := newMongoEnv(t)
+	env.createAccount(t, "rg-1", "mongo-u", "eastus")
+	env.putDatabase(t, "rg-1", "mongo-u", "db", nil)
+
+	env.putCollection(t, "rg-1", "mongo-u", "db", &armcosmos.MongoDBCollectionResource{ID: to.Ptr("logs")}, nil)
+
+	got, err := env.mongo.GetMongoDBCollection(ctx, "rg-1", "mongo-u", "db", "logs", nil)
+	require.NoError(t, err)
+	assert.Empty(t, got.Properties.Resource.ShardKey, "an unsharded collection reports no shard key")
+}
+
+// TestSDKMongoCollectionWithoutDatabase asserts a collection cannot be created
+// under a database that does not exist (ARM ParentResourceNotFound).
+func TestSDKMongoCollectionWithoutDatabase(t *testing.T) {
+	ctx := context.Background()
+	env := newMongoEnv(t)
+	env.createAccount(t, "rg-1", "mongo2", "eastus")
+
+	poller, err := env.mongo.BeginCreateUpdateMongoDBCollection(ctx, "rg-1", "mongo2", "ghostdb", "c1",
+		armcosmos.MongoDBCollectionCreateUpdateParameters{
+			Properties: &armcosmos.MongoDBCollectionCreateUpdateProperties{
+				Resource: &armcosmos.MongoDBCollectionResource{ID: to.Ptr("c1")},
+			},
+		}, nil)
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	require.Error(t, err, "creating a collection without its database must fail")
+}
+
+// TestSDKMongoMissingAccount asserts mongodbDatabases operations under a
+// non-existent account are rejected.
+func TestSDKMongoMissingAccount(t *testing.T) {
+	ctx := context.Background()
+	env := newMongoEnv(t)
+
+	_, err := env.mongo.GetMongoDBDatabase(ctx, "rg-1", "no-such-account", "db", nil)
+	require.Error(t, err)
+}
+
+// Helpers --------------------------------------------------------------------
+
+func listMongoDatabaseNames(t *testing.T, env mongoEnv, rg, acct string) []string {
+	t.Helper()
+
+	names := []string{}
+	pager := env.mongo.NewListMongoDBDatabasesPager(rg, acct, nil)
+
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		require.NoError(t, err)
+
+		for _, d := range page.Value {
+			if d.Name != nil {
+				names = append(names, *d.Name)
+			}
+		}
+	}
+
+	return names
+}
+
+func listMongoCollectionNames(t *testing.T, env mongoEnv, rg, acct, db string) []string {
+	t.Helper()
+
+	names := []string{}
+	pager := env.mongo.NewListMongoDBCollectionsPager(rg, acct, db, nil)
+
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		require.NoError(t, err)
+
+		for _, c := range page.Value {
+			if c.Name != nil {
+				names = append(names, *c.Name)
+			}
+		}
+	}
+
+	return names
+}
+
+func updateMongoCollectionThroughput(
+	t *testing.T, env mongoEnv, rg, acct, db, collection string, res *armcosmos.ThroughputSettingsResource,
+) {
+	t.Helper()
+
+	poller, err := env.mongo.BeginUpdateMongoDBCollectionThroughput(context.Background(), rg, acct, db, collection,
+		armcosmos.ThroughputSettingsUpdateParameters{
+			Properties: &armcosmos.ThroughputSettingsUpdateProperties{Resource: res},
+		}, nil)
+	require.NoError(t, err)
+
+	_, err = poller.PollUntilDone(context.Background(), nil)
+	require.NoError(t, err)
+}
+
+func requireShardKey(t *testing.T, c armcosmos.MongoDBCollectionGetResults, wantField string) {
+	t.Helper()
+
+	require.NotNil(t, c.Properties)
+	require.NotNil(t, c.Properties.Resource)
+	require.Contains(t, c.Properties.Resource.ShardKey, wantField)
+}

--- a/server/azure/cosmosdb/mongoarm_test.go
+++ b/server/azure/cosmosdb/mongoarm_test.go
@@ -8,6 +8,8 @@ package cosmosdb_test
 
 import (
 	"context"
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -241,6 +243,34 @@ func TestSDKMongoUnshardedCollection(t *testing.T) {
 	got, err := env.mongo.GetMongoDBCollection(ctx, "rg-1", "mongo-u", "db", "logs", nil)
 	require.NoError(t, err)
 	assert.Empty(t, got.Properties.Resource.ShardKey, "an unsharded collection reports no shard key")
+}
+
+// TestSDKMongoDatabaseNoChildLinks pins that a Mongo database response omits the
+// _colls/_users child links that a SQL database carries — the Cosmos
+// MongoDBDatabaseGetPropertiesResource has neither field (unlike its SQL
+// counterpart; see TestSDKSQLDatabaseChildLinks). Asserted on the raw JSON since
+// the SDK type has no fields to inspect.
+func TestSDKMongoDatabaseNoChildLinks(t *testing.T) {
+	env := newMongoEnv(t)
+	env.createAccount(t, "rg-1", "mongo-links", "eastus")
+	env.putDatabase(t, "rg-1", "mongo-links", "linked", nil)
+
+	url := env.ts.URL + "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.DocumentDB/" +
+		"databaseAccounts/mongo-links/mongodbDatabases/linked?api-version=2024-11-15"
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	require.NoError(t, err)
+
+	resp, err := env.ts.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotContains(t, string(body), "_colls", "a Mongo database must not carry the SQL _colls link")
+	assert.NotContains(t, string(body), "_users", "a Mongo database must not carry the SQL _users link")
 }
 
 // TestSDKMongoCollectionWithoutDatabase asserts a collection cannot be created

--- a/server/azure/cosmosdb/mongoarm_types.go
+++ b/server/azure/cosmosdb/mongoarm_types.go
@@ -1,0 +1,75 @@
+package cosmosdb
+
+// ARM (Microsoft.DocumentDB) Mongo-API control-plane wire shapes, as driven by
+// the armcosmos MongoDBResourcesClient. These mirror the SDK's JSON field names
+// so a real client's Begin*/Get* round-trips against the handler. The database
+// plane reuses the shared armDatabase* shapes (a Mongo database carries the same
+// minimal body as a SQL one); only the collection shape (shard key + indexes +
+// analytical TTL, instead of a SQL container's partition key + TTL/unique keys)
+// is Mongo-specific and lives here.
+
+// Mongo collection index shapes ----------------------------------------------
+
+// armMongoIndexKeys is the field list one index covers (e.g. {"keys":["_id"]}).
+type armMongoIndexKeys struct {
+	Keys []string `json:"keys,omitempty"`
+}
+
+// armMongoIndexOptions carries an index's options: a TTL (expireAfterSeconds)
+// and/or a uniqueness constraint.
+type armMongoIndexOptions struct {
+	ExpireAfterSeconds *int32 `json:"expireAfterSeconds,omitempty"`
+	Unique             *bool  `json:"unique,omitempty"`
+}
+
+// armMongoIndex is one Mongo collection index (keys + options).
+type armMongoIndex struct {
+	Key     *armMongoIndexKeys    `json:"key,omitempty"`
+	Options *armMongoIndexOptions `json:"options,omitempty"`
+}
+
+// Mongo collection -----------------------------------------------------------
+
+type armMongoCollectionCreateParams struct {
+	Properties *armMongoCollectionCreateProps `json:"properties"`
+	Location   string                         `json:"location,omitempty"`
+	Tags       map[string]string              `json:"tags,omitempty"`
+}
+
+type armMongoCollectionCreateProps struct {
+	Resource *armMongoCollectionResource `json:"resource"`
+	Options  *armCreateUpdateOptions     `json:"options,omitempty"`
+}
+
+// armMongoCollectionResource is the create body's resource block: the collection
+// id, an optional single-field shard key ({field: "Hash"}), its indexes, and an
+// optional analytical-store TTL.
+type armMongoCollectionResource struct {
+	ID                   string            `json:"id"`
+	ShardKey             map[string]string `json:"shardKey,omitempty"`
+	Indexes              []armMongoIndex   `json:"indexes,omitempty"`
+	AnalyticalStorageTTL *int32            `json:"analyticalStorageTtl,omitempty"`
+}
+
+type armMongoCollectionGetResults struct {
+	ID         string                      `json:"id,omitempty"`
+	Name       string                      `json:"name,omitempty"`
+	Type       string                      `json:"type,omitempty"`
+	Location   string                      `json:"location,omitempty"`
+	Tags       map[string]string           `json:"tags,omitempty"`
+	Properties *armMongoCollectionGetProps `json:"properties,omitempty"`
+}
+
+type armMongoCollectionGetProps struct {
+	Resource *armMongoCollectionGetResource `json:"resource,omitempty"`
+}
+
+type armMongoCollectionGetResource struct {
+	ID                   string            `json:"id"`
+	ShardKey             map[string]string `json:"shardKey,omitempty"`
+	Indexes              []armMongoIndex   `json:"indexes,omitempty"`
+	AnalyticalStorageTTL *int32            `json:"analyticalStorageTtl,omitempty"`
+	RID                  string            `json:"_rid,omitempty"`
+	TS                   int64             `json:"_ts,omitempty"`
+	ETag                 string            `json:"_etag,omitempty"`
+}

--- a/server/azure/cosmosdb/sqlarm.go
+++ b/server/azure/cosmosdb/sqlarm.go
@@ -67,6 +67,8 @@ func sqlAPISpec() *armAPISpec {
 		databaseType:           typeSQLDatabase,
 		databaseThroughputType: typeSQLDatabaseThroughput,
 		childThroughputType:    typeSQLContainerThrough,
+		databaseColls:          "colls/",
+		databaseUsers:          "users/",
 	}
 }
 

--- a/server/azure/cosmosdb/sqlarm.go
+++ b/server/azure/cosmosdb/sqlarm.go
@@ -11,7 +11,9 @@ package cosmosdb
 // databases set, containers are the same driver tables (keyed by qualify), and
 // throughput lives in the same offers map. A database or container created here
 // is therefore immediately visible to the data plane and vice versa — there are
-// not two disjoint models.
+// not two disjoint models. The API-agnostic database and throughput planes live
+// in armcommon.go and are shared with the Mongo-API control plane (mongoarm.go);
+// only the SQL container shape (partition key + TTL/unique keys) is here.
 //
 // Create/update/delete/migrate are long-running operations in real Azure; the
 // emulator completes them synchronously (200 with the resource body, or 204 for
@@ -21,7 +23,6 @@ package cosmosdb
 import (
 	"context"
 	"net/http"
-	"sort"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -33,6 +34,7 @@ const (
 	armProvider     = "Microsoft.DocumentDB"
 	armAccountType  = "databaseAccounts"
 	sqlDatabasesSeg = "sqlDatabases"
+	containersSeg   = "containers"
 
 	typeSQLDatabase           = "Microsoft.DocumentDB/databaseAccounts/sqlDatabases"
 	typeSQLContainer          = "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers"
@@ -56,17 +58,30 @@ const (
 	minAutoscaleThroughput = 1000
 )
 
+// sqlAPISpec is the SQL-API type/segment set for the shared database and
+// throughput planes.
+func sqlAPISpec() *armAPISpec {
+	return &armAPISpec{
+		databasesSegment:       sqlDatabasesSeg,
+		childSegment:           containersSeg,
+		databaseType:           typeSQLDatabase,
+		databaseThroughputType: typeSQLDatabaseThroughput,
+		childThroughputType:    typeSQLContainerThrough,
+	}
+}
+
 // ARMHandler serves the Microsoft.DocumentDB SQL sub-resource control plane
 // (sqlDatabases, containers, throughputSettings) against the shared data-plane
 // Handler.
 type ARMHandler struct {
-	h *Handler
+	h    *Handler
+	spec *armAPISpec
 }
 
 // NewARM returns an ARM SQL control-plane handler backed by the same data-plane
 // Handler, so control-plane and data-plane state stay unified.
 func NewARM(h *Handler) *ARMHandler {
-	return &ARMHandler{h: h}
+	return &ARMHandler{h: h, spec: sqlAPISpec()}
 }
 
 // Matches claims only the sqlDatabases sub-tree of a database account
@@ -86,7 +101,7 @@ func (*ARMHandler) Matches(r *http.Request) bool {
 		strings.EqualFold(rp.SubResource, sqlDatabasesSeg)
 }
 
-// sqlKind enumerates the addressable resource shapes under the sqlDatabases tree.
+// sqlKind enumerates the addressable resource shapes under a database sub-tree.
 type sqlKind int
 
 const (
@@ -100,7 +115,8 @@ const (
 	kindContainerMigrate
 )
 
-// sqlTarget is a parsed sqlDatabases-subtree request.
+// sqlTarget is a parsed database-subtree request (the "container" field holds
+// the SQL container or Mongo collection name, per the API).
 type sqlTarget struct {
 	kind      sqlKind
 	db        string
@@ -109,58 +125,24 @@ type sqlTarget struct {
 }
 
 // ServeHTTP parses the ARM path, verifies the parent account exists, then
-// dispatches to the addressed resource.
+// dispatches: the database/throughput kinds go to the shared plane, the
+// container kinds to the SQL-specific callbacks below.
 func (a *ARMHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	rp, ok := azurearm.ParsePath(r.URL.Path)
-	if !ok {
-		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
-		return
-	}
-
-	tail := sqlTail(r.URL.Path, rp.ResourceName)
-
-	target, ok := parseSQLTarget(tail)
-	if !ok {
-		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unsupported Cosmos SQL resource path")
-		return
-	}
-
-	// Every sqlDatabases operation is scoped to a database account; a missing
-	// account is ARM's ParentResourceNotFound.
-	if !a.h.isAccount(rp.ResourceName) {
-		azurearm.WriteError(w, http.StatusNotFound, "ParentResourceNotFound",
-			"database account "+rp.ResourceName+" not found")
-
-		return
-	}
-
-	a.dispatch(w, r, &rp, &target)
+	serveARMSubtree(a.h, w, r, sqlDatabasesSeg, containersSeg, "unsupported Cosmos SQL resource path",
+		func(rp *azurearm.ResourcePath, t *sqlTarget) {
+			armDispatch(a.h, w, r, rp, t, a.spec, "unsupported Cosmos SQL resource path", childOps{
+				list:   a.listContainers,
+				single: a.containerResource,
+			})
+		})
 }
 
-// dispatch routes a parsed target to its handler.
-func (a *ARMHandler) dispatch(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, t *sqlTarget) {
-	switch t.kind {
-	case kindDBList:
-		a.listDatabases(w, r, rp)
-	case kindDB:
-		a.databaseResource(w, r, rp, t.db)
-	case kindContainerList:
-		a.listContainers(w, r, rp, t.db)
-	case kindContainer:
-		a.containerResource(w, r, rp, t.db, t.container)
-	case kindDBThroughput, kindContainerThroughput:
-		a.throughputResource(w, r, rp, t)
-	case kindDBMigrate, kindContainerMigrate:
-		a.migrateThroughput(w, r, rp, t)
-	default:
-		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unsupported Cosmos SQL resource path")
-	}
-}
+// Path parsing (shared) -------------------------------------------------------
 
-// sqlTail returns the path segments after .../databaseAccounts/{account}/,
-// starting at "sqlDatabases". ParsePath stops at the sqlDatabases segment, so
-// the deeper container/throughput segments are recovered from the raw path here.
-func sqlTail(urlPath, account string) []string {
+// armTail returns the path segments after .../databaseAccounts/{account}/,
+// starting at the API's databases segment. ParsePath stops at that segment, so
+// the deeper child/throughput segments are recovered from the raw path here.
+func armTail(urlPath, account string) []string {
 	parts := strings.Split(strings.Trim(urlPath, "/"), "/")
 
 	for i := 0; i+1 < len(parts); i++ {
@@ -172,10 +154,12 @@ func sqlTail(urlPath, account string) []string {
 	return nil
 }
 
-// parseSQLTarget classifies the sqlDatabases-subtree segments. seg[0] is always
-// "sqlDatabases" (guaranteed by Matches).
-func parseSQLTarget(seg []string) (sqlTarget, bool) {
-	if len(seg) == 0 || !strings.EqualFold(seg[0], sqlDatabasesSeg) {
+// parseDBSubtree classifies the segments under an API's databases tree. seg[0]
+// is always the databases segment (guaranteed by Matches). dbSeg/childSeg name
+// the API's databases and child collection segments ("sqlDatabases"/"containers"
+// or "mongodbDatabases"/"collections").
+func parseDBSubtree(seg []string, dbSeg, childSeg string) (sqlTarget, bool) {
+	if len(seg) == 0 || !strings.EqualFold(seg[0], dbSeg) {
 		return sqlTarget{}, false
 	}
 
@@ -190,18 +174,18 @@ func parseSQLTarget(seg []string) (sqlTarget, bool) {
 		return sqlTarget{kind: kindDB, db: db}, true
 	}
 
-	switch strings.ToLower(rest[0]) {
-	case "throughputsettings":
+	switch {
+	case strings.EqualFold(rest[0], "throughputSettings"):
 		return parseThroughputTail(db, "", rest, kindDBThroughput, kindDBMigrate)
-	case "containers":
-		return parseContainerTail(db, rest[1:])
+	case strings.EqualFold(rest[0], childSeg):
+		return parseChildTail(db, rest[1:])
 	default:
 		return sqlTarget{}, false
 	}
 }
 
-// parseContainerTail classifies the segments after ".../containers".
-func parseContainerTail(db string, seg []string) (sqlTarget, bool) {
+// parseChildTail classifies the segments after ".../{childSegment}".
+func parseChildTail(db string, seg []string) (sqlTarget, bool) {
 	if len(seg) == 0 {
 		return sqlTarget{kind: kindContainerList, db: db}, true
 	}
@@ -248,134 +232,21 @@ func parseThroughputTail(db, container string, seg []string, plain, migrate sqlK
 	}
 }
 
-// Databases ------------------------------------------------------------------
-
-func (a *ARMHandler) databaseResource(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db string) {
-	switch r.Method {
-	case http.MethodPut:
-		a.createOrUpdateDatabase(w, r, rp, db)
-	case http.MethodGet:
-		if !a.h.databaseExists(rp.ResourceName, db) {
-			azurearm.WriteError(w, http.StatusNotFound, "NotFound", "sql database "+db+" not found")
-			return
-		}
-
-		azurearm.WriteJSON(w, http.StatusOK, a.renderDatabase(rp, db))
-	case http.MethodDelete:
-		// Delete is idempotent: a cascade over a missing database is a no-op that
-		// still answers 204 so the SDK's BeginDelete poller terminates.
-		_ = a.h.cascadeDeleteDatabase(r.Context(), rp.ResourceName, db)
-
-		w.WriteHeader(http.StatusNoContent)
-	default:
-		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
-	}
-}
-
-func (a *ARMHandler) createOrUpdateDatabase(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db string) {
-	var body armSQLDatabaseCreateParams
-	if !azurearm.DecodeJSON(w, r, &body) {
-		return
-	}
-
-	if body.Properties == nil || body.Properties.Resource == nil || body.Properties.Resource.ID == "" {
-		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "properties.resource.id is required")
-		return
-	}
-
-	// registerDatabase is idempotent for the ARM create-or-update contract: a
-	// re-PUT of an existing database is not an error, it re-applies throughput.
-	a.h.registerDatabase(rp.ResourceName, db)
-
-	// Shared (database-level) throughput, keyed by the database's dbNS — exactly
-	// the key the data plane's /offers lookup derives, so it round-trips there.
-	if st, ok := offerFromOptions(body.Properties.Options); ok {
-		a.h.setOffer(dbNS(rp.ResourceName, db), st)
-	}
-
-	azurearm.WriteJSON(w, http.StatusOK, a.renderDatabase(rp, db))
-}
-
-func (a *ARMHandler) listDatabases(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	if r.Method != http.MethodGet {
-		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
-		return
-	}
-
-	names := a.databasesInAccount(rp.ResourceName)
-
-	out := armSQLDatabaseList{Value: make([]armSQLDatabaseGetResults, 0, len(names))}
-	for _, name := range names {
-		out.Value = append(out.Value, a.renderDatabase(rp, name))
-	}
-
-	azurearm.WriteJSON(w, http.StatusOK, out)
-}
-
-// databasesInAccount returns the sorted database names owned by account.
-func (a *ARMHandler) databasesInAccount(account string) []string {
-	a.h.dbMu.RLock()
-	defer a.h.dbMu.RUnlock()
-
-	names := make([]string, 0)
-
-	for key := range a.h.databases {
-		if id, ok := accountDBName(key, account); ok {
-			names = append(names, id)
-		}
-	}
-
-	sort.Strings(names)
-
-	return names
-}
-
-func (a *ARMHandler) renderDatabase(rp *azurearm.ResourcePath, db string) armSQLDatabaseGetResults {
-	id := dbResourceID(rp, db)
-
-	return armSQLDatabaseGetResults{
-		ID:   id,
-		Name: db,
-		Type: typeSQLDatabase,
-		Properties: &armSQLDatabaseGetProps{
-			Resource: &armSQLDatabaseGetResource{
-				ID:    db,
-				RID:   "rid-" + dbNS(rp.ResourceName, db),
-				TS:    a.h.clock.Now().Unix(),
-				ETag:  azurearm.ETag(id),
-				Colls: "colls/",
-				Users: "users/",
-			},
-		},
-	}
-}
-
-// Containers -----------------------------------------------------------------
+// Containers (SQL-specific) ---------------------------------------------------
 
 func (a *ARMHandler) containerResource(
 	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db, container string,
 ) {
-	switch r.Method {
-	case http.MethodPut:
-		a.createOrUpdateContainer(w, r, rp, db, container)
-	case http.MethodGet:
-		res, err := a.renderContainer(r.Context(), rp, db, container)
-		if err != nil {
-			azurearm.WriteCErr(w, err)
-			return
-		}
+	armServeChild(a.h, w, r, rp, db, container, singleChildOps{
+		put:     a.createOrUpdateContainer,
+		render:  a.renderContainerAny,
+		cleanup: a.h.attrs.delete,
+	})
+}
 
-		azurearm.WriteJSON(w, http.StatusOK, res)
-	case http.MethodDelete:
-		table := qualify(rp.ResourceName, db, container)
-		// Idempotent: absence is a no-op that still answers 204.
-		_ = a.h.db.DeleteTable(r.Context(), table)
-		a.h.deleteOffer(table)
-		a.h.attrs.delete(table)
-		w.WriteHeader(http.StatusNoContent)
-	default:
-		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
-	}
+// renderContainerAny adapts renderContainer to the shared render callback.
+func (a *ARMHandler) renderContainerAny(ctx context.Context, rp *azurearm.ResourcePath, db, container string) (any, error) {
+	return a.renderContainer(ctx, rp, db, container)
 }
 
 func (a *ARMHandler) createOrUpdateContainer(
@@ -429,38 +300,7 @@ func (a *ARMHandler) createOrUpdateContainer(
 }
 
 func (a *ARMHandler) listContainers(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, db string) {
-	if r.Method != http.MethodGet {
-		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
-		return
-	}
-
-	if !a.h.databaseExists(rp.ResourceName, db) {
-		azurearm.WriteError(w, http.StatusNotFound, "ParentResourceNotFound", "sql database "+db+" not found")
-		return
-	}
-
-	tables, err := a.h.db.ListTables(r.Context())
-	if err != nil {
-		azurearm.WriteCErr(w, err)
-		return
-	}
-
-	prefix := dbNS(rp.ResourceName, db) + "/"
-
-	out := armSQLContainerList{Value: make([]armSQLContainerGetResults, 0)}
-
-	for _, t := range tables {
-		if !strings.HasPrefix(t, prefix) {
-			continue
-		}
-
-		coll := strings.TrimPrefix(t, prefix)
-		if res, cerr := a.renderContainer(r.Context(), rp, db, coll); cerr == nil {
-			out.Value = append(out.Value, res)
-		}
-	}
-
-	azurearm.WriteJSON(w, http.StatusOK, out)
+	armListChildren(a.h, w, r, rp, db, "sql database "+db+" not found", a.renderContainerAny)
 }
 
 func (a *ARMHandler) renderContainer(
@@ -479,7 +319,7 @@ func (a *ARMHandler) renderContainer(
 	}
 
 	attrs := a.h.attrs.get(table)
-	id := containerResourceID(rp, db, container)
+	id := armChildResourceID(rp, db, container, a.spec)
 
 	return armSQLContainerGetResults{
 		ID:   id,
@@ -500,107 +340,7 @@ func (a *ARMHandler) renderContainer(
 	}, nil
 }
 
-// Throughput -----------------------------------------------------------------
-
-func (a *ARMHandler) throughputResource(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, t *sqlTarget) {
-	key, resType, exists := a.throughputTarget(rp, t)
-	if !exists {
-		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "parent resource not found")
-		return
-	}
-
-	switch r.Method {
-	case http.MethodGet:
-		st, ok := a.h.getOffer(key)
-		if !ok {
-			azurearm.WriteError(w, http.StatusNotFound, "NotFound",
-				"resource does not have dedicated throughput (shared or serverless)")
-
-			return
-		}
-
-		azurearm.WriteJSON(w, http.StatusOK, renderThroughput(st, throughputID(rp, t), resType))
-	case http.MethodPut:
-		a.updateThroughput(w, r, rp, t, key, resType)
-	default:
-		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
-	}
-}
-
-func (a *ARMHandler) updateThroughput(
-	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, t *sqlTarget, key, resType string,
-) {
-	var body armThroughputUpdateParams
-	if !azurearm.DecodeJSON(w, r, &body) {
-		return
-	}
-
-	var res *armThroughputResource
-	if body.Properties != nil {
-		res = body.Properties.Resource
-	}
-
-	if res == nil {
-		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter", "properties.resource is required")
-		return
-	}
-
-	st, ok := offerFromThroughput(res.Throughput, res.AutoscaleSettings)
-	if !ok {
-		azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameter",
-			"either throughput or autoscaleSettings.maxThroughput is required")
-
-		return
-	}
-
-	a.h.setOffer(key, st)
-	azurearm.WriteJSON(w, http.StatusOK, renderThroughput(st, throughputID(rp, t), resType))
-}
-
-func (a *ARMHandler) migrateThroughput(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, t *sqlTarget) {
-	if r.Method != http.MethodPost {
-		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
-		return
-	}
-
-	key, resType, exists := a.throughputTarget(rp, t)
-	if !exists {
-		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "parent resource not found")
-		return
-	}
-
-	st, ok := a.h.getOffer(key)
-	if !ok {
-		azurearm.WriteError(w, http.StatusNotFound, "NotFound",
-			"resource does not have dedicated throughput to migrate")
-
-		return
-	}
-
-	migrated := migrateOffer(st, t.migrate == actionMigrateToAutoscale)
-	a.h.setOffer(key, migrated)
-
-	azurearm.WriteJSON(w, http.StatusOK, renderThroughput(migrated, throughputID(rp, t), resType))
-}
-
-// throughputTarget resolves a throughput request to its offer key and response
-// resource type, and reports whether the parent database/container exists.
-func (a *ARMHandler) throughputTarget(rp *azurearm.ResourcePath, t *sqlTarget) (key, resType string, exists bool) {
-	if t.container != "" {
-		table := qualify(rp.ResourceName, t.db, t.container)
-		if _, err := a.h.db.DescribeTable(context.Background(), table); err != nil {
-			return "", "", false
-		}
-
-		return table, typeSQLContainerThrough, true
-	}
-
-	if !a.h.databaseExists(rp.ResourceName, t.db) {
-		return "", "", false
-	}
-
-	return dbNS(rp.ResourceName, t.db), typeSQLDatabaseThroughput, true
-}
+// Throughput/offer helpers (shared) ------------------------------------------
 
 // migrateOffer converts an offer between manual and autoscale, clamping to the
 // mode's floor. Migrating to the mode it already occupies is a no-op.
@@ -673,7 +413,7 @@ func renderThroughput(st offerState, id, resType string) armThroughputGetResults
 	}
 }
 
-// Resource-ID + small helpers ------------------------------------------------
+// Small helpers ---------------------------------------------------------------
 
 func (b *armSQLContainerCreateParams) resourceOrNil() *armSQLContainerResource {
 	if b.Properties == nil {
@@ -681,25 +421,6 @@ func (b *armSQLContainerCreateParams) resourceOrNil() *armSQLContainerResource {
 	}
 
 	return b.Properties.Resource
-}
-
-func dbResourceID(rp *azurearm.ResourcePath, db string) string {
-	return azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, armProvider, armAccountType, rp.ResourceName) +
-		"/sqlDatabases/" + db
-}
-
-func containerResourceID(rp *azurearm.ResourcePath, db, container string) string {
-	return dbResourceID(rp, db) + "/containers/" + container
-}
-
-// throughputID is the ARM ID of a throughputSettings/default child.
-func throughputID(rp *azurearm.ResourcePath, t *sqlTarget) string {
-	base := dbResourceID(rp, t.db)
-	if t.container != "" {
-		base += "/containers/" + t.container
-	}
-
-	return base + "/throughputSettings/" + throughputName
 }
 
 func int32Ptr(v int32) *int32 { return &v }

--- a/server/azure/cosmosdb/sqlarm_test.go
+++ b/server/azure/cosmosdb/sqlarm_test.go
@@ -207,6 +207,32 @@ func TestSDKSQLControlPlaneLifecycle(t *testing.T) {
 	require.Error(t, err, "database must 404 after delete")
 }
 
+// TestSDKSQLDatabaseChildLinks pins that a SQL database resource always carries
+// its _colls/_users child links on PUT and GET — Cosmos'
+// SQLDatabaseGetPropertiesResource exposes them, so they must not be dropped
+// (the Mongo database resource, by contrast, has neither; see
+// TestSDKMongoDatabaseNoChildLinks).
+func TestSDKSQLDatabaseChildLinks(t *testing.T) {
+	ctx := context.Background()
+	env := newSQLEnv(t)
+	env.createAccount(t, "rg-1", "cosmos-links", "eastus")
+
+	created := env.putDatabase(t, "rg-1", "cosmos-links", "linked", nil)
+	require.NotNil(t, created.Properties)
+	require.NotNil(t, created.Properties.Resource)
+	require.NotNil(t, created.Properties.Resource.Colls)
+	assert.Equal(t, "colls/", *created.Properties.Resource.Colls)
+	require.NotNil(t, created.Properties.Resource.Users)
+	assert.Equal(t, "users/", *created.Properties.Resource.Users)
+
+	got, err := env.sql.GetSQLDatabase(ctx, "rg-1", "cosmos-links", "linked", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.Properties.Resource.Colls)
+	assert.Equal(t, "colls/", *got.Properties.Resource.Colls)
+	require.NotNil(t, got.Properties.Resource.Users)
+	assert.Equal(t, "users/", *got.Properties.Resource.Users)
+}
+
 // TestSDKSQLDatabaseSharedThroughput drives database-level shared throughput and
 // its migration to manual.
 func TestSDKSQLDatabaseSharedThroughput(t *testing.T) {

--- a/server/azure/cosmosdb/sqlarm_types.go
+++ b/server/azure/cosmosdb/sqlarm_types.go
@@ -27,49 +27,6 @@ type armCreateUpdateOptions struct {
 	AutoscaleSettings *armAutoscaleSettings `json:"autoscaleSettings,omitempty"`
 }
 
-// SQL database ---------------------------------------------------------------
-
-type armSQLDatabaseCreateParams struct {
-	Properties *armSQLDatabaseCreateProps `json:"properties"`
-	Location   string                     `json:"location,omitempty"`
-	Tags       map[string]string          `json:"tags,omitempty"`
-}
-
-type armSQLDatabaseCreateProps struct {
-	Resource *armSQLDatabaseResource `json:"resource"`
-	Options  *armCreateUpdateOptions `json:"options,omitempty"`
-}
-
-type armSQLDatabaseResource struct {
-	ID string `json:"id"`
-}
-
-type armSQLDatabaseGetResults struct {
-	ID         string                  `json:"id,omitempty"`
-	Name       string                  `json:"name,omitempty"`
-	Type       string                  `json:"type,omitempty"`
-	Location   string                  `json:"location,omitempty"`
-	Tags       map[string]string       `json:"tags,omitempty"`
-	Properties *armSQLDatabaseGetProps `json:"properties,omitempty"`
-}
-
-type armSQLDatabaseGetProps struct {
-	Resource *armSQLDatabaseGetResource `json:"resource,omitempty"`
-}
-
-type armSQLDatabaseGetResource struct {
-	ID    string `json:"id"`
-	RID   string `json:"_rid,omitempty"`
-	TS    int64  `json:"_ts,omitempty"`
-	ETag  string `json:"_etag,omitempty"`
-	Colls string `json:"_colls,omitempty"`
-	Users string `json:"_users,omitempty"`
-}
-
-type armSQLDatabaseList struct {
-	Value []armSQLDatabaseGetResults `json:"value"`
-}
-
 // SQL container --------------------------------------------------------------
 
 type armSQLContainerCreateParams struct {
@@ -115,10 +72,6 @@ type armSQLContainerGetResource struct {
 	RID             string           `json:"_rid,omitempty"`
 	TS              int64            `json:"_ts,omitempty"`
 	ETag            string           `json:"_etag,omitempty"`
-}
-
-type armSQLContainerList struct {
-	Value []armSQLContainerGetResults `json:"value"`
 }
 
 // Throughput -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the highest-value remaining Cosmos DB control-plane gap after #973 (which landed the **SQL-API** ARM control plane): the **Mongo-API ARM control plane**.

Real `armcosmos.MongoDBResourcesClient` clients — and the IaC tools that ride the same wire (`azurerm_cosmosdb_mongo_database` / `azurerm_cosmosdb_mongo_collection`, `az cosmosdb mongodb ...`, Bicep) — can now manage the Mongo data model, which previously did not exist at the ARM layer at all (Cosmos was SQL-only for control-plane management).

### What's implemented (`server/azure/cosmosdb`)
`Microsoft.DocumentDB/databaseAccounts/{acct}/mongodbDatabases` and `.../collections`, plus their `throughputSettings/default`:

- **mongodbDatabases**: create-or-update / get / list / delete (cascade over collections), optional database-level shared throughput.
- **mongodbCollections**: create-or-update / get / list / delete, with **shard key** (mapped onto the driver table's partition key), **indexes** (incl. TTL/unique index options) and **analyticalStorageTtl** round-tripping, and optional dedicated throughput.
- **throughputSettings**: get / update (manual + autoscale) / `migrateToAutoscale` / `migrateToManualThroughput`, for both databases and collections.

It **shares the one data-plane `Handler` state** exactly as the SQL plane does: Mongo databases live in the same `databases` set, collections are the same driver tables, throughput lives in the same offers map. A real Cosmos account is single-API, so SQL and Mongo databases never coexist on one account and the shared namespace is not a collision. Mongo collection extras (shard key / indexes / analytical TTL) that the generic driver has no concept of are tracked out-of-driver in a new `mongoAttrStore`, mirroring how `offers.go` / `container_attrs.go` track throughput and container attrs; it's cleaned up on collection delete, database cascade and account purge.

LRO handlers answer **synchronously-terminal** (200 with the resource body, 204 for delete), so the SDK's `Begin*` pollers terminate on the first response — matching #973.

### Refactor (no behavior change to #973)
The API-agnostic **database plane**, **throughput plane**, and the **request-routing / child-resource skeletons** are factored out of `sqlarm.go` into `armcommon.go` and reused by both the SQL and Mongo handlers (parameterized by an `armAPISpec` + a few callbacks). This keeps a single backend model per account and avoids duplicating the parallel surfaces. The existing `#973` SQL real-SDK tests are unchanged and still pass.

### Gap closed / deferred
- **Closed:** C8 (partial) — the **MongoDB API ARM control plane** (databases/collections/throughput). This was the SQL-only control-plane gap from the audit (`AUDIT_AZURE` / `WORLD_CASE_DATABASE` §2.1, C8).
- **Deferred (unchanged this PR):** Gremlin / Cassandra / Table API ARM control planes (C8, remaining APIs); Mongo **data plane** (`mongo.cosmos.azure.com` wire); throughput floor validation — min 400 RU manual / 1000 autoscale / 10× band — (C4); out-of-driver Cosmos state → driver/persist (C2); account-plane LRO/consistency/key-rotation (C3/C5/C7). These stay as-is.

## Test plan (real armcosmos SDK, package convention)
`server/azure/cosmosdb/mongoarm_test.go` drives the live `MongoDBResourcesClient` end-to-end:
- full lifecycle: account → PUT database → GET/list → PUT collection (shard key + TTL index) → GET/list (shard key + index + analytical TTL round-trip) → manual throughput → GET → migrate to autoscale → GET → delete database cascades the collection;
- database-level shared throughput + migrate-to-manual;
- unsharded collection reports no shard key;
- collection-without-database → ParentResourceNotFound;
- operations under a missing account are rejected.

The #973 SQL control-plane real-SDK tests continue to pass unchanged.

### Gates (foreground, GOMAXPROCS=2)
- `go build ./...` ✅
- `gofmt -l` (touched) ✅ empty
- `go test ./server/azure/cosmosdb/... ./providers/azure/cosmosdb/... -race` ✅
- broad `go test ./server/azure/... ./providers/azure/...` ✅ (95 pkg ok)
- `golangci-lint` (cosmosdb) ✅ 0 issues (server/azure has one pre-existing gocyclo in an untouched file)
- coveragegen + `git diff docs/coverage` ✅ no change; `go mod tidy` ✅ clean
