### PR TITLE
feat(gcs): enforce retention policy + bucket lock + object holds (WORM)

### DIFF
--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -62,6 +62,15 @@ type gcsObject struct {
 	ContentDisposition string
 	ContentLanguage    string
 	StorageClass       string
+	// TemporaryHold / EventBasedHold are the object's WORM holds. While either is
+	// set the object cannot be deleted or overwritten regardless of retention.
+	TemporaryHold  bool
+	EventBasedHold bool
+	// RetentionRef is the RFC3339 instant from which the bucket retention period
+	// is measured for this object. It starts at Created and is reset to "now" when
+	// an eventBasedHold is released, restarting the retention clock. Empty falls
+	// back to Created.
+	RetentionRef string
 }
 
 type gcsMultipartUpload struct {
@@ -104,6 +113,14 @@ type bucketMeta struct {
 	ublaEnabled            bool
 	ublaLockedTime         string
 	publicAccessPrevention string
+	// retentionPeriod / retentionEffectiveTime / retentionLocked hold the bucket
+	// retention policy (WORM). A period > 0 means objects cannot be deleted or
+	// overwritten until (now - object.RetentionRef) >= period. retentionLocked
+	// makes the policy permanent: it can then only be increased, never shortened
+	// or removed.
+	retentionPeriod        int64
+	retentionEffectiveTime string
+	retentionLocked        bool
 	// gcsLifecycleRaw is the bucket's lifecycle configuration stored verbatim as
 	// GCS JSON ({"rule":[...]}), preserving every rule condition the wire layer
 	// received. It is the authoritative source for EvaluateLifecycle and
@@ -220,7 +237,8 @@ func toInfo(o *gcsObject, cloneMeta bool) driver.ObjectInfo {
 		MD5: o.MD5, CRC32C: o.CRC32C,
 		CacheControl: o.CacheControl, ContentEncoding: o.ContentEncoding,
 		ContentDisposition: o.ContentDisposition, ContentLanguage: o.ContentLanguage,
-		StorageClass: o.StorageClass,
+		StorageClass:  o.StorageClass,
+		TemporaryHold: o.TemporaryHold, EventBasedHold: o.EventBasedHold,
 	}
 }
 
@@ -306,6 +324,14 @@ func (m *Mock) putObject(
 		return nil, err
 	}
 
+	// An overwrite of a retained-or-held live object is blocked (WORM) — real GCS
+	// refuses to replace it until retention elapses and every hold is released.
+	if exists {
+		if err := objectImmutable(m, bkt, current); err != nil {
+			return nil, err
+		}
+	}
+
 	dataCopy := make([]byte, len(data))
 	copy(dataCopy, data)
 
@@ -341,6 +367,7 @@ func (m *Mock) putObject(
 		ETag:               fmt.Sprintf("%x", sha256.Sum256(data)),
 		LastModified:       now,
 		Created:            now,
+		RetentionRef:       now,
 		Metadata:           metaCopy,
 		Generation:         m.gen.Add(1),
 		Metageneration:     1,
@@ -359,6 +386,7 @@ func (m *Mock) putObject(
 	m.emitMetric(ctx, "network/received_bytes_count", float64(len(data)), dims)
 
 	info := toInfo(obj, true)
+	info.RetentionExpiration = retentionExpiration(bkt, obj)
 
 	return &info, nil
 }
@@ -526,6 +554,11 @@ func (m *Mock) deleteObject(ctx context.Context, bucket, key string, generation 
 		return cerrors.Newf(cerrors.NotFound, "object %q not found in bucket %q", key, bucket)
 	}
 
+	// A retained-or-held live object cannot be deleted (WORM).
+	if err := objectImmutable(m, bkt, current); err != nil {
+		return err
+	}
+
 	// Versioning-enabled live delete archives the current generation (it becomes
 	// noncurrent) — real GCS retains it, listable via versions=true.
 	if bkt.versioning {
@@ -559,6 +592,10 @@ func (m *Mock) deleteGeneration(
 	ctx context.Context, bkt *bucketMeta, bucket, key string, gen int64, current *gcsObject, liveExists bool,
 ) error {
 	if liveExists && current.Generation == gen {
+		if err := objectImmutable(m, bkt, current); err != nil {
+			return err
+		}
+
 		bkt.objects.Delete(key)
 		m.purgeIfGone(ctx, bkt, bucket, key)
 		m.emitMetric(ctx, "api/request_count", 1, map[string]string{"bucket_name": bucket})
@@ -572,6 +609,11 @@ func (m *Mock) deleteGeneration(
 	for i, v := range versions {
 		if v.Generation != gen {
 			continue
+		}
+
+		if err := m.immutableLocked(bkt, v); err != nil {
+			bkt.mu.Unlock()
+			return err
 		}
 
 		bkt.versions[key] = append(versions[:i], versions[i+1:]...)
@@ -631,7 +673,10 @@ func (m *Mock) GetObjectGCS(ctx context.Context, bucket, key string, generation 
 	m.emitMetric(ctx, "api/request_count", 1, dims)
 	m.emitMetric(ctx, "network/sent_bytes_count", float64(obj.Size), dims)
 
-	return &driver.Object{Info: toInfo(obj, true), Data: dataCopy}, nil
+	info := toInfo(obj, true)
+	info.RetentionExpiration = retentionExpiration(bkt, obj)
+
+	return &driver.Object{Info: info, Data: dataCopy}, nil
 }
 
 // HeadObjectGCS returns an object's info, selecting a specific generation when
@@ -648,6 +693,7 @@ func (m *Mock) HeadObjectGCS(_ context.Context, bucket, key string, generation *
 	}
 
 	info := toInfo(obj, true)
+	info.RetentionExpiration = retentionExpiration(bkt, obj)
 
 	return &info, nil
 }
@@ -816,6 +862,13 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 		return cerrors.Newf(cerrors.NotFound, "destination bucket %q not found", dstBucket)
 	}
 
+	// Overwriting a retained-or-held destination object is blocked (WORM).
+	if dstCur, dstOK := dstBkt.objects.Get(dstKey); dstOK {
+		if err := objectImmutable(m, dstBkt, dstCur); err != nil {
+			return err
+		}
+	}
+
 	dataCopy := make([]byte, len(srcObj.Data))
 	copy(dataCopy, srcObj.Data)
 
@@ -844,7 +897,7 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 
 	dstBkt.objects.Set(dstKey, &gcsObject{
 		Key: dstKey, Data: stored, Size: srcObj.Size, ContentType: srcObj.ContentType,
-		ETag: srcObj.ETag, LastModified: copyNow, Created: copyNow,
+		ETag: srcObj.ETag, LastModified: copyNow, Created: copyNow, RetentionRef: copyNow,
 		Metadata: meta, Generation: m.gen.Add(1), Metageneration: 1,
 		MD5: srcObj.MD5, CRC32C: srcObj.CRC32C,
 		CacheControl: srcObj.CacheControl, ContentEncoding: srcObj.ContentEncoding,
@@ -1016,6 +1069,15 @@ func (m *Mock) CompleteMultipartUpload(
 	md5b64, crc32cb64 := checksums(data)
 
 	current, exists := bkt.objects.Get(key)
+
+	// Completing a multipart upload over a retained-or-held object is an
+	// overwrite, which WORM blocks.
+	if exists {
+		if err := objectImmutable(m, bkt, current); err != nil {
+			return err
+		}
+	}
+
 	archiveVersion(bkt, key, current, exists)
 
 	completeNow := m.opts.Clock.Now().UTC().Format(gcsTimeFormat)
@@ -1028,6 +1090,7 @@ func (m *Mock) CompleteMultipartUpload(
 		ETag:           fmt.Sprintf("%x", sha256.Sum256(data)),
 		LastModified:   completeNow,
 		Created:        completeNow,
+		RetentionRef:   completeNow,
 		Metadata:       make(map[string]string),
 		Generation:     m.gen.Add(1),
 		Metageneration: 1,
@@ -1372,9 +1435,25 @@ func (m *Mock) UpdateObjectGCS(
 	applyStringUpdate(&next.ContentDisposition, upd.ContentDisposition)
 	applyStringUpdate(&next.ContentLanguage, upd.ContentLanguage)
 
+	if upd.TemporaryHold != nil {
+		next.TemporaryHold = *upd.TemporaryHold
+	}
+
+	// Releasing an event-based hold (true→false) restarts the retention clock:
+	// the object's retention reference resets to now, so the full retention period
+	// must elapse again before it can be deleted or overwritten.
+	if upd.EventBasedHold != nil {
+		if cur.EventBasedHold && !*upd.EventBasedHold {
+			next.RetentionRef = next.LastModified
+		}
+
+		next.EventBasedHold = *upd.EventBasedHold
+	}
+
 	bkt.objects.Set(key, &next)
 
 	info := toInfo(&next, true)
+	info.RetentionExpiration = retentionExpiration(bkt, &next)
 
 	return &info, nil
 }

--- a/providers/gcp/gcs/retention.go
+++ b/providers/gcp/gcs/retention.go
@@ -1,0 +1,178 @@
+package gcs
+
+import (
+	"context"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// retentionStore mirrors the server-side capability the GCS wire handler
+// type-asserts for the bucket retention policy (WORM). Declaring it here
+// compile-checks the Mock keeps the exact signatures the handler needs.
+var _ interface {
+	SetBucketRetentionPolicyGCS(ctx context.Context, bucket string, periodSeconds int64) error
+	LockBucketRetentionPolicyGCS(ctx context.Context, bucket string) error
+	BucketRetentionPolicyGCS(ctx context.Context, bucket string) (*driver.GCSRetentionPolicy, error)
+} = (*Mock)(nil)
+
+// SetBucketRetentionPolicyGCS sets or updates the bucket retention period (in
+// seconds). A locked policy can only be increased — attempting to shorten or
+// remove it returns a *driver.GCSImmutableError. A period of 0 on an unlocked
+// bucket removes the policy. effectiveTime is stamped once, when the policy is
+// first established, and preserved across later increases.
+func (m *Mock) SetBucketRetentionPolicyGCS(_ context.Context, bucket string, periodSeconds int64) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	if bkt.retentionLocked && periodSeconds < bkt.retentionPeriod {
+		return &driver.GCSImmutableError{
+			Reason:  "retentionPolicyNotMet",
+			Message: "cannot shorten or remove a locked retention policy",
+		}
+	}
+
+	if periodSeconds <= 0 {
+		bkt.retentionPeriod = 0
+		bkt.retentionEffectiveTime = ""
+
+		return nil
+	}
+
+	if bkt.retentionEffectiveTime == "" {
+		bkt.retentionEffectiveTime = m.opts.Clock.Now().UTC().Format(gcsTimeFormat)
+	}
+
+	bkt.retentionPeriod = periodSeconds
+
+	return nil
+}
+
+// LockBucketRetentionPolicyGCS makes the bucket's current retention policy
+// permanent. Locking a bucket without a retention policy is rejected.
+func (m *Mock) LockBucketRetentionPolicyGCS(_ context.Context, bucket string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	if bkt.retentionPeriod <= 0 {
+		return cerrors.Newf(cerrors.FailedPrecondition, "bucket %q has no retention policy to lock", bucket)
+	}
+
+	bkt.retentionLocked = true
+
+	return nil
+}
+
+// BucketRetentionPolicyGCS returns the bucket's retention policy, or nil when no
+// policy is set.
+func (m *Mock) BucketRetentionPolicyGCS(_ context.Context, bucket string) (*driver.GCSRetentionPolicy, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	if bkt.retentionPeriod <= 0 {
+		return nil, nil //nolint:nilnil // no policy is a valid, non-error state
+	}
+
+	return &driver.GCSRetentionPolicy{
+		RetentionPeriod: bkt.retentionPeriod,
+		EffectiveTime:   bkt.retentionEffectiveTime,
+		IsLocked:        bkt.retentionLocked,
+	}, nil
+}
+
+// objectImmutable takes bkt.mu and delegates to immutableLocked. Callers that
+// do not already hold bkt.mu use this variant. It returns a
+// *driver.GCSImmutableError when the object is protected, else nil.
+func objectImmutable(m *Mock, bkt *bucketMeta, obj *gcsObject) error {
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	return m.immutableLocked(bkt, obj)
+}
+
+// immutableLocked reports whether obj is protected by an active hold or an
+// unelapsed retention period. The caller MUST hold bkt.mu. Object hold flags are
+// immutable per generation (written copy-on-write), so reading them without the
+// lock is safe; the retention period/effectiveTime are bkt.mu-guarded.
+func (m *Mock) immutableLocked(bkt *bucketMeta, obj *gcsObject) error {
+	if obj.TemporaryHold {
+		return &driver.GCSImmutableError{
+			Reason:  "objectUnderActiveHold",
+			Message: "object is under an active temporary hold and cannot be deleted or overwritten",
+		}
+	}
+
+	if obj.EventBasedHold {
+		return &driver.GCSImmutableError{
+			Reason:  "objectUnderActiveHold",
+			Message: "object is under an active event-based hold and cannot be deleted or overwritten",
+		}
+	}
+
+	if bkt.retentionPeriod <= 0 {
+		return nil
+	}
+
+	ref := retentionRefTime(obj)
+	expiry := ref.Add(time.Duration(bkt.retentionPeriod) * time.Second)
+
+	if m.opts.Clock.Now().UTC().Before(expiry) {
+		return &driver.GCSImmutableError{
+			Reason: "retentionPolicyNotMet",
+			Message: "object is subject to the bucket's retention policy and cannot be deleted or " +
+				"overwritten until " + expiry.UTC().Format(gcsTimeFormat),
+		}
+	}
+
+	return nil
+}
+
+// retentionExpiration returns the object's retentionExpirationTime under the
+// bucket's current retention policy, or "" when the bucket has no policy or an
+// event-based hold is currently pinning the object (its clock is paused). It
+// acquires bkt.mu to read the retention period.
+func retentionExpiration(bkt *bucketMeta, obj *gcsObject) string {
+	bkt.mu.Lock()
+	defer bkt.mu.Unlock()
+
+	if bkt.retentionPeriod <= 0 || obj.EventBasedHold {
+		return ""
+	}
+
+	ref := retentionRefTime(obj)
+
+	return ref.Add(time.Duration(bkt.retentionPeriod) * time.Second).UTC().Format(gcsTimeFormat)
+}
+
+// retentionRefTime resolves the instant from which retention is measured for an
+// object: its RetentionRef (reset when an event-based hold is released), falling
+// back to Created, then to the zero time when neither parses.
+func retentionRefTime(obj *gcsObject) time.Time {
+	for _, s := range []string{obj.RetentionRef, obj.Created} {
+		if s == "" {
+			continue
+		}
+
+		if t, err := time.Parse(gcsTimeFormat, s); err == nil {
+			return t
+		}
+	}
+
+	return time.Time{}
+}

--- a/providers/gcp/gcs/retention_test.go
+++ b/providers/gcp/gcs/retention_test.go
@@ -1,0 +1,187 @@
+package gcs
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newClockedMock returns a Mock plus the FakeClock backing it, so retention
+// math can be driven deterministically by advancing time.
+func newClockedMock(t *testing.T) (*Mock, *config.FakeClock) {
+	t.Helper()
+
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithRegion("us-central1"), config.WithProjectID("test-project"))
+
+	return New(opts), clk
+}
+
+func isImmutable(err error) bool {
+	var immErr *driver.GCSImmutableError
+
+	return errors.As(err, &immErr)
+}
+
+func mustPut(t *testing.T, m *Mock, bucket, key string) {
+	t.Helper()
+
+	_, err := m.PutObjectGCS(context.Background(), bucket, key, []byte("payload"), "text/plain", nil, nil, driver.GCSPrecondition{})
+	require.NoError(t, err)
+}
+
+// TestRetentionPolicyBlocksDeleteUntilElapsed proves an object cannot be deleted
+// before its retention period elapses, and can be deleted once the FakeClock is
+// advanced past it.
+func TestRetentionPolicyBlocksDeleteUntilElapsed(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newClockedMock(t)
+
+	require.NoError(t, m.CreateBucket(ctx, "b"))
+	mustPut(t, m, "b", "obj")
+
+	const period = int64(3600) // 1 hour
+
+	require.NoError(t, m.SetBucketRetentionPolicyGCS(ctx, "b", period))
+
+	// Delete before the period elapses is blocked.
+	err := m.DeleteObjectGCS(ctx, "b", "obj", nil, driver.GCSPrecondition{})
+	require.Error(t, err)
+	assert.True(t, isImmutable(err), "expected GCSImmutableError, got %v", err)
+
+	// Halfway through — still blocked.
+	clk.Advance(30 * time.Minute)
+	assert.True(t, isImmutable(m.DeleteObjectGCS(ctx, "b", "obj", nil, driver.GCSPrecondition{})))
+
+	// Past the period — delete succeeds.
+	clk.Advance(31 * time.Minute)
+	require.NoError(t, m.DeleteObjectGCS(ctx, "b", "obj", nil, driver.GCSPrecondition{}))
+}
+
+// TestRetentionPolicyBlocksOverwrite proves a retained object cannot be
+// overwritten until its retention elapses.
+func TestRetentionPolicyBlocksOverwrite(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newClockedMock(t)
+
+	require.NoError(t, m.CreateBucket(ctx, "b"))
+	mustPut(t, m, "b", "obj")
+	require.NoError(t, m.SetBucketRetentionPolicyGCS(ctx, "b", 3600))
+
+	_, err := m.PutObjectGCS(ctx, "b", "obj", []byte("new"), "text/plain", nil, nil, driver.GCSPrecondition{})
+	require.Error(t, err)
+	assert.True(t, isImmutable(err))
+
+	// Copy overwrite is blocked too.
+	require.NoError(t, m.CreateBucket(ctx, "src"))
+	mustPut(t, m, "src", "s")
+	err = m.CopyObject(ctx, "b", "obj", driver.CopySource{Bucket: "src", Key: "s"})
+	require.Error(t, err)
+	assert.True(t, isImmutable(err))
+
+	clk.Advance(2 * time.Hour)
+	_, err = m.PutObjectGCS(ctx, "b", "obj", []byte("new"), "text/plain", nil, nil, driver.GCSPrecondition{})
+	require.NoError(t, err)
+}
+
+// TestRetentionLockCannotShortenOrRemove proves a locked retention policy can
+// only be increased, never shortened or removed.
+func TestRetentionLockCannotShortenOrRemove(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newClockedMock(t)
+
+	require.NoError(t, m.CreateBucket(ctx, "b"))
+	require.NoError(t, m.SetBucketRetentionPolicyGCS(ctx, "b", 3600))
+	require.NoError(t, m.LockBucketRetentionPolicyGCS(ctx, "b"))
+
+	pol, err := m.BucketRetentionPolicyGCS(ctx, "b")
+	require.NoError(t, err)
+	require.NotNil(t, pol)
+	assert.True(t, pol.IsLocked)
+	assert.Equal(t, int64(3600), pol.RetentionPeriod)
+
+	// Shorten is rejected.
+	assert.True(t, isImmutable(m.SetBucketRetentionPolicyGCS(ctx, "b", 60)))
+	// Remove (period 0) is rejected.
+	assert.True(t, isImmutable(m.SetBucketRetentionPolicyGCS(ctx, "b", 0)))
+
+	// Increase is allowed.
+	require.NoError(t, m.SetBucketRetentionPolicyGCS(ctx, "b", 7200))
+
+	pol, err = m.BucketRetentionPolicyGCS(ctx, "b")
+	require.NoError(t, err)
+	assert.Equal(t, int64(7200), pol.RetentionPeriod)
+}
+
+// TestTemporaryHoldBlocksDeleteAndOverwrite proves a temporary hold blocks
+// deletion/overwrite even when no retention applies (or after it elapses), and
+// releasing it re-enables both.
+func TestTemporaryHoldBlocksDeleteAndOverwrite(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newClockedMock(t)
+
+	require.NoError(t, m.CreateBucket(ctx, "b"))
+	mustPut(t, m, "b", "obj")
+
+	setHold(t, m, "b", "obj", boolPtr(true), nil)
+
+	// Blocked regardless of elapsed time.
+	clk.Advance(24 * time.Hour)
+	assert.True(t, isImmutable(m.DeleteObjectGCS(ctx, "b", "obj", nil, driver.GCSPrecondition{})))
+
+	_, err := m.PutObjectGCS(ctx, "b", "obj", []byte("x"), "text/plain", nil, nil, driver.GCSPrecondition{})
+	assert.True(t, isImmutable(err))
+
+	// Release the hold — delete now succeeds.
+	setHold(t, m, "b", "obj", boolPtr(false), nil)
+	require.NoError(t, m.DeleteObjectGCS(ctx, "b", "obj", nil, driver.GCSPrecondition{}))
+}
+
+// TestEventBasedHoldBlocksAndResetsRetentionClock proves an event-based hold
+// blocks deletion and, on release, restarts the retention clock from the release
+// instant.
+func TestEventBasedHoldBlocksAndResetsRetentionClock(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newClockedMock(t)
+
+	require.NoError(t, m.CreateBucket(ctx, "b"))
+	mustPut(t, m, "b", "obj")
+	require.NoError(t, m.SetBucketRetentionPolicyGCS(ctx, "b", 3600))
+
+	// Put the object under an event-based hold.
+	setHold(t, m, "b", "obj", nil, boolPtr(true))
+
+	// Blocked while held, even after the original retention window would elapse.
+	clk.Advance(2 * time.Hour)
+	assert.True(t, isImmutable(m.DeleteObjectGCS(ctx, "b", "obj", nil, driver.GCSPrecondition{})))
+
+	// Release the hold — the retention clock restarts from now, so the object is
+	// still retained for a fresh full period.
+	setHold(t, m, "b", "obj", nil, boolPtr(false))
+	assert.True(t, isImmutable(m.DeleteObjectGCS(ctx, "b", "obj", nil, driver.GCSPrecondition{})),
+		"retention clock must restart on event-based hold release")
+
+	// Not yet elapsed halfway into the fresh window.
+	clk.Advance(30 * time.Minute)
+	assert.True(t, isImmutable(m.DeleteObjectGCS(ctx, "b", "obj", nil, driver.GCSPrecondition{})))
+
+	// Past the fresh full period from release — delete succeeds.
+	clk.Advance(31 * time.Minute)
+	require.NoError(t, m.DeleteObjectGCS(ctx, "b", "obj", nil, driver.GCSPrecondition{}))
+}
+
+func setHold(t *testing.T, m *Mock, bucket, key string, temp, event *bool) {
+	t.Helper()
+
+	_, err := m.UpdateObjectGCS(context.Background(), bucket, key, driver.GCSObjectUpdate{
+		TemporaryHold:  temp,
+		EventBasedHold: event,
+	}, driver.GCSPrecondition{})
+	require.NoError(t, err)
+}

--- a/providers/gcp/gcs/snapshot.go
+++ b/providers/gcp/gcs/snapshot.go
@@ -43,6 +43,9 @@ type bucketSnapshot struct {
 	UBLAEnabled            bool                                    `json:"ublaEnabled,omitempty"`
 	UBLALockedTime         string                                  `json:"ublaLockedTime,omitempty"`
 	PublicAccessPrevention string                                  `json:"publicAccessPrevention,omitempty"`
+	RetentionPeriod        int64                                   `json:"retentionPeriod,omitempty"`
+	RetentionEffectiveTime string                                  `json:"retentionEffectiveTime,omitempty"`
+	RetentionLocked        bool                                    `json:"retentionLocked,omitempty"`
 	Objects                map[string]*objectSnapshot              `json:"objects,omitempty"`
 	Versions               map[string][]*objectSnapshot            `json:"versions,omitempty"`
 	Notifications          map[string]driver.GCSNotificationConfig `json:"notifications,omitempty"`
@@ -70,6 +73,9 @@ type objectSnapshot struct {
 	ContentDisposition string            `json:"contentDisposition,omitempty"`
 	ContentLanguage    string            `json:"contentLanguage,omitempty"`
 	StorageClass       string            `json:"storageClass,omitempty"`
+	TemporaryHold      bool              `json:"temporaryHold,omitempty"`
+	EventBasedHold     bool              `json:"eventBasedHold,omitempty"`
+	RetentionRef       string            `json:"retentionRef,omitempty"`
 }
 
 // Snapshot captures every bucket's state as JSON. When includeAssets is false
@@ -106,6 +112,9 @@ func snapshotBucket(bkt *bucketMeta, includeAssets bool) *bucketSnapshot {
 		Metageneration: bkt.metageneration, Updated: bkt.updated, IAMPolicy: bkt.iamPolicy,
 		UBLAEnabled: bkt.ublaEnabled, UBLALockedTime: bkt.ublaLockedTime,
 		PublicAccessPrevention: bkt.publicAccessPrevention,
+		RetentionPeriod:        bkt.retentionPeriod,
+		RetentionEffectiveTime: bkt.retentionEffectiveTime,
+		RetentionLocked:        bkt.retentionLocked,
 		Objects:                make(map[string]*objectSnapshot, bkt.objects.Len()),
 	}
 
@@ -158,6 +167,8 @@ func objectToSnapshot(obj *gcsObject, includeAssets bool) *objectSnapshot {
 		MD5: obj.MD5, CRC32C: obj.CRC32C, CacheControl: obj.CacheControl,
 		ContentEncoding: obj.ContentEncoding, ContentDisposition: obj.ContentDisposition,
 		ContentLanguage: obj.ContentLanguage, StorageClass: obj.StorageClass,
+		TemporaryHold: obj.TemporaryHold, EventBasedHold: obj.EventBasedHold,
+		RetentionRef: obj.RetentionRef,
 	}
 }
 
@@ -211,6 +222,9 @@ func restoreBucket(bs *bucketSnapshot) *bucketMeta {
 		metageneration: metagen, updated: bs.Updated, iamPolicy: bs.IAMPolicy,
 		ublaEnabled: bs.UBLAEnabled, ublaLockedTime: bs.UBLALockedTime,
 		publicAccessPrevention: bs.PublicAccessPrevention,
+		retentionPeriod:        bs.RetentionPeriod,
+		retentionEffectiveTime: bs.RetentionEffectiveTime,
+		retentionLocked:        bs.RetentionLocked,
 		versions:               restoreVersions(bs.Versions),
 		notifications:          bs.Notifications,
 	}
@@ -250,5 +264,7 @@ func snapshotToObject(os *objectSnapshot) *gcsObject {
 		MD5: os.MD5, CRC32C: os.CRC32C, CacheControl: os.CacheControl,
 		ContentEncoding: os.ContentEncoding, ContentDisposition: os.ContentDisposition,
 		ContentLanguage: os.ContentLanguage, StorageClass: os.StorageClass,
+		TemporaryHold: os.TemporaryHold, EventBasedHold: os.EventBasedHold,
+		RetentionRef: os.RetentionRef,
 	}
 }

--- a/server/gcp/gcs/gcs_retention_test.go
+++ b/server/gcp/gcs/gcs_retention_test.go
@@ -1,0 +1,288 @@
+// Package gcs_test — suite cell STORAGE / gcp / sdk-compat.
+//
+// Real cloud.google.com/go/storage SDK journeys for bucket retention policies +
+// bucket lock and object temporary/event-based holds (WORM), driven against the
+// emulator's GCP HTTP server with a FakeClock so retention expiry is
+// deterministic.
+package gcs_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// newRetentionClient boots a fresh emulator whose GCS driver is backed by a
+// FakeClock (returned) so retention math can be advanced deterministically.
+func newRetentionClient(t *testing.T) (context.Context, *storage.Client, *config.FakeClock) {
+	t.Helper()
+
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	cloudP := cloudemu.NewGCP(config.WithClock(clk))
+	srv := gcpserver.New(gcpserver.Drivers{Storage: cloudP.GCS})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	client, err := storage.NewClient(ctx,
+		option.WithEndpoint(ts.URL+"/storage/v1/"),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("storage.NewClient: %v", err)
+	}
+
+	client.SetRetry(storage.WithPolicy(storage.RetryNever))
+	t.Cleanup(func() { _ = client.Close() })
+
+	return ctx, client, clk
+}
+
+func writeRetObject(t *testing.T, ctx context.Context, bkt *storage.BucketHandle, key string) {
+	t.Helper()
+
+	w := bkt.Object(key).NewWriter(ctx)
+	if _, err := w.Write([]byte("payload")); err != nil {
+		t.Fatalf("Write %q: %v", key, err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close %q: %v", key, err)
+	}
+}
+
+func assertForbidden(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected a 403 error, got nil")
+	}
+
+	var apiErr *googleapi.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *googleapi.Error, got %T: %v", err, err)
+	}
+
+	if apiErr.Code != http.StatusForbidden {
+		t.Fatalf("HTTP status = %d, want 403; err=%v", apiErr.Code, err)
+	}
+}
+
+// TestGCSRetentionPolicyBlocksDeleteUntilElapsed proves a bucket retention
+// policy set through the real SDK blocks object deletion until the FakeClock is
+// advanced past the retention period, and that the policy round-trips.
+func TestGCSRetentionPolicyBlocksDeleteUntilElapsed(t *testing.T) {
+	ctx, client, clk := newRetentionClient(t)
+
+	bkt := client.Bucket("worm-bucket")
+	if err := bkt.Create(ctx, e2eProject, nil); err != nil {
+		t.Fatalf("Create bucket: %v", err)
+	}
+
+	if _, err := bkt.Update(ctx, storage.BucketAttrsToUpdate{
+		RetentionPolicy: &storage.RetentionPolicy{RetentionPeriod: time.Hour},
+	}); err != nil {
+		t.Fatalf("set retention policy: %v", err)
+	}
+
+	attrs, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("bucket Attrs: %v", err)
+	}
+
+	if attrs.RetentionPolicy == nil || attrs.RetentionPolicy.RetentionPeriod != time.Hour {
+		t.Fatalf("retention policy did not round-trip: %+v", attrs.RetentionPolicy)
+	}
+
+	if attrs.RetentionPolicy.EffectiveTime.IsZero() {
+		t.Error("retention policy EffectiveTime is zero, want a stamped time")
+	}
+
+	writeRetObject(t, ctx, bkt, "obj")
+
+	// Delete before the period elapses is forbidden.
+	assertForbidden(t, bkt.Object("obj").Delete(ctx))
+
+	// Advance past the period — delete now succeeds.
+	clk.Advance(2 * time.Hour)
+
+	if err := bkt.Object("obj").Delete(ctx); err != nil {
+		t.Fatalf("Delete after retention elapsed: %v", err)
+	}
+}
+
+// TestGCSRetentionPolicyBlocksOverwrite proves a retained object cannot be
+// overwritten before its retention elapses.
+func TestGCSRetentionPolicyBlocksOverwrite(t *testing.T) {
+	ctx, client, clk := newRetentionClient(t)
+
+	bkt := client.Bucket("worm-overwrite")
+	if err := bkt.Create(ctx, e2eProject, nil); err != nil {
+		t.Fatalf("Create bucket: %v", err)
+	}
+
+	if _, err := bkt.Update(ctx, storage.BucketAttrsToUpdate{
+		RetentionPolicy: &storage.RetentionPolicy{RetentionPeriod: time.Hour},
+	}); err != nil {
+		t.Fatalf("set retention policy: %v", err)
+	}
+
+	writeRetObject(t, ctx, bkt, "obj")
+
+	// Overwrite before the period elapses is forbidden.
+	w := bkt.Object("obj").NewWriter(ctx)
+	_, _ = w.Write([]byte("new"))
+	assertForbidden(t, w.Close())
+
+	clk.Advance(2 * time.Hour)
+	writeRetObject(t, ctx, bkt, "obj") // now allowed
+}
+
+// TestGCSRetentionLockCannotShorten proves a locked retention policy cannot be
+// shortened but can be increased.
+func TestGCSRetentionLockCannotShorten(t *testing.T) {
+	ctx, client, _ := newRetentionClient(t)
+
+	bkt := client.Bucket("worm-locked")
+	if err := bkt.Create(ctx, e2eProject, nil); err != nil {
+		t.Fatalf("Create bucket: %v", err)
+	}
+
+	if _, err := bkt.Update(ctx, storage.BucketAttrsToUpdate{
+		RetentionPolicy: &storage.RetentionPolicy{RetentionPeriod: time.Hour},
+	}); err != nil {
+		t.Fatalf("set retention policy: %v", err)
+	}
+
+	attrs, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs: %v", err)
+	}
+
+	// Lock the policy (requires a metageneration precondition).
+	if err := bkt.If(storage.BucketConditions{MetagenerationMatch: attrs.MetaGeneration}).LockRetentionPolicy(ctx); err != nil {
+		t.Fatalf("LockRetentionPolicy: %v", err)
+	}
+
+	locked, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs after lock: %v", err)
+	}
+
+	if locked.RetentionPolicy == nil || !locked.RetentionPolicy.IsLocked {
+		t.Fatalf("policy not reported locked: %+v", locked.RetentionPolicy)
+	}
+
+	// Shortening a locked policy is forbidden.
+	_, err = bkt.Update(ctx, storage.BucketAttrsToUpdate{
+		RetentionPolicy: &storage.RetentionPolicy{RetentionPeriod: 30 * time.Minute},
+	})
+	assertForbidden(t, err)
+
+	// Increasing it is allowed.
+	if _, err := bkt.Update(ctx, storage.BucketAttrsToUpdate{
+		RetentionPolicy: &storage.RetentionPolicy{RetentionPeriod: 2 * time.Hour},
+	}); err != nil {
+		t.Fatalf("increase locked retention: %v", err)
+	}
+}
+
+// TestGCSTemporaryHoldBlocksDelete proves a temporary hold blocks deletion and
+// overwrite regardless of retention, and releasing it re-enables both.
+func TestGCSTemporaryHoldBlocksDelete(t *testing.T) {
+	ctx, client, _ := newRetentionClient(t)
+
+	bkt := client.Bucket("hold-temp")
+	if err := bkt.Create(ctx, e2eProject, nil); err != nil {
+		t.Fatalf("Create bucket: %v", err)
+	}
+
+	writeRetObject(t, ctx, bkt, "obj")
+
+	obj := bkt.Object("obj")
+
+	if _, err := obj.Update(ctx, storage.ObjectAttrsToUpdate{TemporaryHold: true}); err != nil {
+		t.Fatalf("set temporary hold: %v", err)
+	}
+
+	attrs, err := obj.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("obj Attrs: %v", err)
+	}
+
+	if !attrs.TemporaryHold {
+		t.Error("TemporaryHold did not round-trip as true")
+	}
+
+	// Delete + overwrite are forbidden while held.
+	assertForbidden(t, obj.Delete(ctx))
+
+	w := obj.NewWriter(ctx)
+	_, _ = w.Write([]byte("x"))
+	assertForbidden(t, w.Close())
+
+	// Release the hold — delete now succeeds.
+	if _, err := obj.Update(ctx, storage.ObjectAttrsToUpdate{TemporaryHold: false}); err != nil {
+		t.Fatalf("release temporary hold: %v", err)
+	}
+
+	if err := obj.Delete(ctx); err != nil {
+		t.Fatalf("Delete after hold released: %v", err)
+	}
+}
+
+// TestGCSEventBasedHoldResetsRetentionClock proves an event-based hold blocks
+// deletion and, once released, restarts the retention clock from the release
+// instant.
+func TestGCSEventBasedHoldResetsRetentionClock(t *testing.T) {
+	ctx, client, clk := newRetentionClient(t)
+
+	bkt := client.Bucket("hold-event")
+	if err := bkt.Create(ctx, e2eProject, nil); err != nil {
+		t.Fatalf("Create bucket: %v", err)
+	}
+
+	if _, err := bkt.Update(ctx, storage.BucketAttrsToUpdate{
+		RetentionPolicy: &storage.RetentionPolicy{RetentionPeriod: time.Hour},
+	}); err != nil {
+		t.Fatalf("set retention policy: %v", err)
+	}
+
+	writeRetObject(t, ctx, bkt, "obj")
+	obj := bkt.Object("obj")
+
+	if _, err := obj.Update(ctx, storage.ObjectAttrsToUpdate{EventBasedHold: true}); err != nil {
+		t.Fatalf("set event-based hold: %v", err)
+	}
+
+	// Blocked while held even after the original retention window would elapse.
+	clk.Advance(2 * time.Hour)
+	assertForbidden(t, obj.Delete(ctx))
+
+	// Release the hold — the retention clock restarts from now.
+	if _, err := obj.Update(ctx, storage.ObjectAttrsToUpdate{EventBasedHold: false}); err != nil {
+		t.Fatalf("release event-based hold: %v", err)
+	}
+
+	// Still retained for a fresh full period from the release instant.
+	assertForbidden(t, obj.Delete(ctx))
+
+	clk.Advance(2 * time.Hour)
+	if err := obj.Delete(ctx); err != nil {
+		t.Fatalf("Delete after fresh retention elapsed: %v", err)
+	}
+}

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -498,35 +498,51 @@ func (h *Handler) patchBucket(w http.ResponseWriter, r *http.Request, name strin
 }
 
 // applyBucketConfig applies the mutable configuration fields present in a
-// Buckets.patch/update body (versioning, labels, lifecycle, iamConfiguration),
-// each only when supplied. It returns the first error encountered.
+// Buckets.patch/update body (versioning, labels, lifecycle, iamConfiguration,
+// retentionPolicy), each only when supplied. It returns the first error
+// encountered. Each field is guarded by a small closure so adding another
+// configuration field does not raise the function's cyclomatic complexity.
 func (h *Handler) applyBucketConfig(ctx context.Context, name string, body *bucketResource) error {
-	if body.Versioning != nil {
-		if err := h.bucket.SetBucketVersioning(ctx, name, body.Versioning.Enabled); err != nil {
-			return err
-		}
+	appliers := []func() error{
+		func() error {
+			if body.Versioning == nil {
+				return nil
+			}
+
+			return h.bucket.SetBucketVersioning(ctx, name, body.Versioning.Enabled)
+		},
+		func() error {
+			if body.Labels == nil {
+				return nil
+			}
+
+			return h.bucket.PutBucketTagging(ctx, name, body.Labels)
+		},
+		func() error {
+			if body.Lifecycle == nil {
+				return nil
+			}
+
+			return h.putLifecycle(ctx, name, body.Lifecycle)
+		},
+		func() error {
+			if body.IamConfiguration == nil {
+				return nil
+			}
+
+			return h.applyIAMConfig(ctx, name, body.IamConfiguration)
+		},
+		func() error {
+			if body.RetentionPolicy == nil {
+				return nil
+			}
+
+			return h.applyRetention(ctx, name, body.RetentionPolicy)
+		},
 	}
 
-	if body.Labels != nil {
-		if err := h.bucket.PutBucketTagging(ctx, name, body.Labels); err != nil {
-			return err
-		}
-	}
-
-	if body.Lifecycle != nil {
-		if err := h.putLifecycle(ctx, name, body.Lifecycle); err != nil {
-			return err
-		}
-	}
-
-	if body.IamConfiguration != nil {
-		if err := h.applyIAMConfig(ctx, name, body.IamConfiguration); err != nil {
-			return err
-		}
-	}
-
-	if body.RetentionPolicy != nil {
-		if err := h.applyRetention(ctx, name, body.RetentionPolicy); err != nil {
+	for _, apply := range appliers {
+		if err := apply(); err != nil {
 			return err
 		}
 	}

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -105,6 +105,10 @@ type Handler struct {
 	// keys; nil makes the /projects/{p}/hmacKeys endpoints report not-implemented.
 	hmac hmacKeyStore
 
+	// retention is the optional capability persisting a bucket's retention policy
+	// (WORM); nil makes retentionPolicy absent and unsettable.
+	retention retentionStore
+
 	// publisher emits object-change events to Pub/Sub for matching bucket
 	// notification configs. Nil (the default) makes object events a no-op, so
 	// object writes/deletes still succeed without Pub/Sub wired.
@@ -139,6 +143,7 @@ func New(b storagedriver.Bucket) *Handler {
 	lifecycle, _ := b.(lifecycleRawStore)
 	iamCfg, _ := b.(iamConfigStore)
 	hmac, _ := b.(hmacKeyStore)
+	retention, _ := b.(retentionStore)
 
 	return &Handler{
 		bucket:    b,
@@ -146,6 +151,7 @@ func New(b storagedriver.Bucket) *Handler {
 		lifecycle: lifecycle,
 		iamCfg:    iamCfg,
 		hmac:      hmac,
+		retention: retention,
 		resumable: make(map[string]*resumableSession),
 	}
 }
@@ -260,6 +266,8 @@ func (h *Handler) serveBucketSubcollection(w http.ResponseWriter, r *http.Reques
 		h.bucketIAM(w, r, parts[1])
 	case subresNotificationConfigs:
 		h.notificationCollection(w, r, parts[1])
+	case "lockRetentionPolicy":
+		h.lockRetentionPolicy(w, r, parts[1])
 	default:
 		writeError(w, http.StatusNotFound, "notFound", "unknown sub-collection")
 	}
@@ -339,6 +347,7 @@ func (h *Handler) createBucket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_ = h.applyIAMConfig(r.Context(), body.Name, body.IamConfiguration)
+	_ = h.applyRetention(r.Context(), body.Name, body.RetentionPolicy)
 
 	writeJSON(w, http.StatusOK, h.bucketView(r, body.Name, time.Now().UTC().Format(time.RFC3339)))
 }
@@ -409,6 +418,10 @@ func (h *Handler) bucketView(r *http.Request, name, created string) bucketResour
 		res.Lifecycle = lc
 	}
 
+	if rp := h.retentionView(r.Context(), name); rp != nil {
+		res.RetentionPolicy = rp
+	}
+
 	return res
 }
 
@@ -469,7 +482,7 @@ func (h *Handler) patchBucket(w http.ResponseWriter, r *http.Request, name strin
 	}
 
 	if err := h.applyBucketConfig(r.Context(), name, &body); err != nil {
-		writeErr(w, err)
+		writePreconditionOrErr(w, err)
 		return
 	}
 
@@ -508,6 +521,12 @@ func (h *Handler) applyBucketConfig(ctx context.Context, name string, body *buck
 
 	if body.IamConfiguration != nil {
 		if err := h.applyIAMConfig(ctx, name, body.IamConfiguration); err != nil {
+			return err
+		}
+	}
+
+	if body.RetentionPolicy != nil {
+		if err := h.applyRetention(ctx, name, body.RetentionPolicy); err != nil {
 			return err
 		}
 	}
@@ -1009,6 +1028,18 @@ func writePreconditionOrErr(w http.ResponseWriter, err error) {
 		return
 	}
 
+	var immErr *storagedriver.GCSImmutableError
+	if errors.As(err, &immErr) {
+		reason := immErr.Reason
+		if reason == "" {
+			reason = "retentionPolicyNotMet"
+		}
+
+		writeError(w, http.StatusForbidden, reason, immErr.Error())
+
+		return
+	}
+
 	writeErr(w, err)
 }
 
@@ -1221,6 +1252,8 @@ func (h *Handler) updateObject(w http.ResponseWriter, r *http.Request, bucket, k
 		ContentDisposition: body.ContentDisposition,
 		ContentLanguage:    body.ContentLanguage,
 		Metadata:           body.Metadata,
+		TemporaryHold:      body.TemporaryHold,
+		EventBasedHold:     body.EventBasedHold,
 	}, parsePrecondition(r.URL.Query()))
 	if err != nil {
 		writePreconditionOrErr(w, err)
@@ -1599,27 +1632,30 @@ func toObjectResource(info *storagedriver.ObjectInfo, bucket string, r *http.Req
 	}
 
 	return objectResource{
-		Kind:               "storage#object",
-		ID:                 bucket + "/" + info.Key + "/" + genStr,
-		Name:               info.Key,
-		Bucket:             bucket,
-		Generation:         genStr,
-		Metageneration:     strconv.FormatInt(metageneration, 10),
-		ContentType:        info.ContentType,
-		Size:               strconv.FormatInt(info.Size, 10),
-		MD5Hash:            info.MD5,
-		CRC32C:             info.CRC32C,
-		ETag:               info.ETag,
-		StorageClass:       storageClass,
-		CacheControl:       info.CacheControl,
-		ContentEncoding:    info.ContentEncoding,
-		ContentDisposition: info.ContentDisposition,
-		ContentLanguage:    info.ContentLanguage,
-		TimeCreated:        created,
-		Updated:            info.LastModified,
-		Metadata:           info.Metadata,
-		SelfLink:           selfLink(r, "/storage/v1/b/"+bucket+"/o/"+info.Key),
-		MediaLink:          selfLink(r, "/storage/v1/b/"+bucket+"/o/"+info.Key+"?alt=media"),
+		Kind:                    "storage#object",
+		ID:                      bucket + "/" + info.Key + "/" + genStr,
+		Name:                    info.Key,
+		Bucket:                  bucket,
+		Generation:              genStr,
+		Metageneration:          strconv.FormatInt(metageneration, 10),
+		ContentType:             info.ContentType,
+		Size:                    strconv.FormatInt(info.Size, 10),
+		MD5Hash:                 info.MD5,
+		CRC32C:                  info.CRC32C,
+		ETag:                    info.ETag,
+		StorageClass:            storageClass,
+		CacheControl:            info.CacheControl,
+		ContentEncoding:         info.ContentEncoding,
+		ContentDisposition:      info.ContentDisposition,
+		ContentLanguage:         info.ContentLanguage,
+		TimeCreated:             created,
+		Updated:                 info.LastModified,
+		Metadata:                info.Metadata,
+		TemporaryHold:           info.TemporaryHold,
+		EventBasedHold:          info.EventBasedHold,
+		RetentionExpirationTime: info.RetentionExpiration,
+		SelfLink:                selfLink(r, "/storage/v1/b/"+bucket+"/o/"+info.Key),
+		MediaLink:               selfLink(r, "/storage/v1/b/"+bucket+"/o/"+info.Key+"?alt=media"),
 	}
 }
 

--- a/server/gcp/gcs/retention.go
+++ b/server/gcp/gcs/retention.go
@@ -1,0 +1,82 @@
+package gcs
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// retentionStore is the optional capability that persists a bucket's retention
+// policy (WORM) — set/lock/read — so Buckets.patch of retentionPolicy and the
+// Buckets.lockRetentionPolicy endpoint round-trip and are enforced on
+// delete/overwrite. Nil makes retentionPolicy absent and unsettable.
+type retentionStore interface {
+	SetBucketRetentionPolicyGCS(ctx context.Context, bucket string, periodSeconds int64) error
+	LockBucketRetentionPolicyGCS(ctx context.Context, bucket string) error
+	BucketRetentionPolicyGCS(ctx context.Context, bucket string) (*storagedriver.GCSRetentionPolicy, error)
+}
+
+// applyRetention persists an incoming retentionPolicy block (from create or
+// patch). A nil block leaves the policy untouched (GCS merge-patch semantics; a
+// JSON null also decodes to nil, so removal-by-null is not distinguishable and
+// is a known limitation). A shorten/remove of a locked policy returns the
+// backing *GCSImmutableError.
+func (h *Handler) applyRetention(ctx context.Context, bucket string, rp *retentionPolicy) error {
+	if h.retention == nil || rp == nil {
+		return nil
+	}
+
+	period, err := strconv.ParseInt(rp.RetentionPeriod, 10, 64)
+	if err != nil {
+		// A malformed/empty retentionPeriod is treated as removal (period 0).
+		period = 0
+	}
+
+	return h.retention.SetBucketRetentionPolicyGCS(ctx, bucket, period)
+}
+
+// retentionView renders a bucket's stored retention policy, or nil when the
+// bucket has no policy (or no backing store).
+func (h *Handler) retentionView(ctx context.Context, bucket string) *retentionPolicy {
+	if h.retention == nil {
+		return nil
+	}
+
+	pol, err := h.retention.BucketRetentionPolicyGCS(ctx, bucket)
+	if err != nil || pol == nil {
+		return nil
+	}
+
+	return &retentionPolicy{
+		RetentionPeriod: strconv.FormatInt(pol.RetentionPeriod, 10),
+		EffectiveTime:   pol.EffectiveTime,
+		IsLocked:        pol.IsLocked,
+	}
+}
+
+// lockRetentionPolicy handles POST /b/{bucket}/lockRetentionPolicy, making the
+// bucket's retention policy permanent (it can then only be increased).
+func (h *Handler) lockRetentionPolicy(w http.ResponseWriter, r *http.Request, bucket string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+		return
+	}
+
+	if h.retention == nil {
+		writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "retention policy not supported")
+		return
+	}
+
+	if err := h.retention.LockBucketRetentionPolicyGCS(r.Context(), bucket); err != nil {
+		writePreconditionOrErr(w, err)
+		return
+	}
+
+	if h.ext != nil {
+		_ = h.ext.TouchBucket(r.Context(), bucket)
+	}
+
+	writeJSON(w, http.StatusOK, h.bucketView(r, bucket, ""))
+}

--- a/server/gcp/gcs/types.go
+++ b/server/gcp/gcs/types.go
@@ -15,6 +15,7 @@ type bucketResource struct {
 	Labels           map[string]string `json:"labels,omitempty"`
 	Lifecycle        *bucketLifecycle  `json:"lifecycle,omitempty"`
 	IamConfiguration *iamConfiguration `json:"iamConfiguration,omitempty"`
+	RetentionPolicy  *retentionPolicy  `json:"retentionPolicy,omitempty"`
 	Metageneration   string            `json:"metageneration,omitempty"`
 	Etag             string            `json:"etag,omitempty"`
 	TimeCreated      string            `json:"timeCreated,omitempty"`
@@ -62,6 +63,15 @@ type iamConfiguration struct {
 	PublicAccessPrevention   string                    `json:"publicAccessPrevention,omitempty"`
 }
 
+// retentionPolicy is the bucket retentionPolicy sub-resource (WORM). GCS encodes
+// retentionPeriod as a string-typed int64 (seconds); effectiveTime is RFC3339;
+// isLocked reports whether the policy has been made permanent.
+type retentionPolicy struct {
+	RetentionPeriod string `json:"retentionPeriod,omitempty"`
+	EffectiveTime   string `json:"effectiveTime,omitempty"`
+	IsLocked        bool   `json:"isLocked,omitempty"`
+}
+
 type uniformBucketLevelAccess struct {
 	Enabled bool `json:"enabled"`
 	// LockedTime is when UBLA becomes permanent; GCS stamps it ~90 days out when
@@ -75,27 +85,30 @@ type bucketsListResponse struct {
 }
 
 type objectResource struct {
-	Kind               string            `json:"kind"`
-	ID                 string            `json:"id"`
-	Name               string            `json:"name"`
-	Bucket             string            `json:"bucket"`
-	Generation         string            `json:"generation"`
-	Metageneration     string            `json:"metageneration"`
-	ContentType        string            `json:"contentType,omitempty"`
-	Size               string            `json:"size"`
-	MD5Hash            string            `json:"md5Hash,omitempty"`
-	CRC32C             string            `json:"crc32c,omitempty"`
-	ETag               string            `json:"etag,omitempty"`
-	StorageClass       string            `json:"storageClass,omitempty"`
-	CacheControl       string            `json:"cacheControl,omitempty"`
-	ContentEncoding    string            `json:"contentEncoding,omitempty"`
-	ContentDisposition string            `json:"contentDisposition,omitempty"`
-	ContentLanguage    string            `json:"contentLanguage,omitempty"`
-	TimeCreated        string            `json:"timeCreated,omitempty"`
-	Updated            string            `json:"updated,omitempty"`
-	Metadata           map[string]string `json:"metadata,omitempty"`
-	SelfLink           string            `json:"selfLink,omitempty"`
-	MediaLink          string            `json:"mediaLink,omitempty"`
+	Kind                    string            `json:"kind"`
+	ID                      string            `json:"id"`
+	Name                    string            `json:"name"`
+	Bucket                  string            `json:"bucket"`
+	Generation              string            `json:"generation"`
+	Metageneration          string            `json:"metageneration"`
+	ContentType             string            `json:"contentType,omitempty"`
+	Size                    string            `json:"size"`
+	MD5Hash                 string            `json:"md5Hash,omitempty"`
+	CRC32C                  string            `json:"crc32c,omitempty"`
+	ETag                    string            `json:"etag,omitempty"`
+	StorageClass            string            `json:"storageClass,omitempty"`
+	CacheControl            string            `json:"cacheControl,omitempty"`
+	ContentEncoding         string            `json:"contentEncoding,omitempty"`
+	ContentDisposition      string            `json:"contentDisposition,omitempty"`
+	ContentLanguage         string            `json:"contentLanguage,omitempty"`
+	TimeCreated             string            `json:"timeCreated,omitempty"`
+	Updated                 string            `json:"updated,omitempty"`
+	Metadata                map[string]string `json:"metadata,omitempty"`
+	TemporaryHold           bool              `json:"temporaryHold,omitempty"`
+	EventBasedHold          bool              `json:"eventBasedHold,omitempty"`
+	RetentionExpirationTime string            `json:"retentionExpirationTime,omitempty"`
+	SelfLink                string            `json:"selfLink,omitempty"`
+	MediaLink               string            `json:"mediaLink,omitempty"`
 }
 
 type objectsListResponse struct {
@@ -115,6 +128,8 @@ type objectPatchBody struct {
 	ContentDisposition *string            `json:"contentDisposition"`
 	ContentLanguage    *string            `json:"contentLanguage"`
 	Metadata           map[string]*string `json:"metadata"`
+	TemporaryHold      *bool              `json:"temporaryHold"`
+	EventBasedHold     *bool              `json:"eventBasedHold"`
 }
 
 // composeRequest is the Objects: compose request body.

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -445,6 +445,16 @@ type ObjectInfo struct {
 	// PutObject and echoed on GET/HEAD. Empty when unset; providers that don't
 	// model it leave it empty.
 	Expires string
+	// TemporaryHold / EventBasedHold report the GCS object WORM holds. While
+	// either is set the object cannot be deleted or overwritten. Zero for
+	// providers that don't model holds.
+	TemporaryHold  bool
+	EventBasedHold bool
+	// RetentionExpiration is the GCS retentionExpirationTime — the RFC3339 instant
+	// before which the object cannot be deleted or overwritten under the bucket's
+	// retention policy. Empty when the bucket has no retention policy (or an
+	// eventBasedHold is currently pinning the object).
+	RetentionExpiration string
 }
 
 // Object is an object with its data.
@@ -905,6 +915,26 @@ func (e *GCSPreconditionError) Error() string {
 	return e.Message
 }
 
+// GCSImmutableError signals a delete or overwrite blocked by a bucket retention
+// policy that has not yet elapsed or by an active object hold (temporaryHold /
+// eventBasedHold). Real GCS answers 403 Forbidden with a reason such as
+// "retentionPolicyNotMet"; providers return this typed error and the GCS handler
+// matches it with errors.As to emit the exact 403.
+type GCSImmutableError struct {
+	// Reason is the GCS error reason (e.g. "retentionPolicyNotMet").
+	Reason string
+	// Message is the human-readable explanation returned to the caller.
+	Message string
+}
+
+func (e *GCSImmutableError) Error() string {
+	if e.Message == "" {
+		return "object is immutable (retention policy or hold)"
+	}
+
+	return e.Message
+}
+
 // GCSObjectUpdate carries the mutable properties an Objects: patch/update sets.
 // A nil pointer field leaves that property unchanged; a nil Metadata map leaves
 // custom metadata unchanged, while a non-nil map is merged (a nil value deletes
@@ -916,6 +946,11 @@ type GCSObjectUpdate struct {
 	ContentDisposition *string
 	ContentLanguage    *string
 	Metadata           map[string]*string
+	// TemporaryHold / EventBasedHold set or clear the object's WORM holds
+	// (Objects: patch). A nil pointer leaves the hold unchanged. Releasing an
+	// eventBasedHold (true→false) resets the object's retention clock.
+	TemporaryHold  *bool
+	EventBasedHold *bool
 }
 
 // GCSObjectAttrs carries the object system properties settable at INSERT time
@@ -927,6 +962,17 @@ type GCSObjectAttrs struct {
 	ContentDisposition string
 	ContentLanguage    string
 	StorageClass       string
+}
+
+// GCSRetentionPolicy is a bucket retention policy (WORM). RetentionPeriod is in
+// seconds; objects cannot be deleted or overwritten until they are older than
+// it. EffectiveTime is when the policy took effect; IsLocked reports whether it
+// has been made permanent (it can then only be increased, never shortened or
+// removed).
+type GCSRetentionPolicy struct {
+	RetentionPeriod int64
+	EffectiveTime   string
+	IsLocked        bool
 }
 
 // GCSComposeSource names one source component of an Objects: compose request.


### PR DESCRIPTION
## Summary

Adds Google Cloud Storage WORM (Write-Once-Read-Many) enforcement — the GCS half of cross-provider immutability (S3 Object Lock landed in #985):

- **Bucket retention policy** — `retentionPolicy{retentionPeriod, effectiveTime, isLocked}`, set via `Buckets.patch` and read back on GET. An object cannot be deleted or overwritten until `(now - retentionRef) >= retentionPeriod`.
- **Lock Retention Policy** — `POST /b/{bucket}/lockRetentionPolicy` makes the policy permanent. A locked policy can only be **increased** — shortening or removing it is rejected with 403.
- **Object holds** — `temporaryHold` and `eventBasedHold`, set via `Objects.patch`. While either is set the object cannot be deleted or overwritten regardless of retention. Releasing an `eventBasedHold` **restarts the retention clock** from the release instant.

## Enforcement

A retained (period not elapsed) or held (either hold set) object is protected on **every** delete and overwrite path — `PutObject`/insert (media, multipart-related, resumable), `CopyObject`/rewrite, `Compose`, S3-style multipart-complete, live delete, and generation-addressed delete — returning `403 Forbidden` with reason `retentionPolicyNotMet` / `objectUnderActiveHold`. Retention math is driven by `config.Clock` (FakeClock), so expiry is deterministic.

## Design

- Bucket retention lives in a provider-side `retentionStore` capability type-asserted by the GCS handler (mirroring the existing `iamConfigStore`/`hmacKeyStore` pattern), so S3/Azure are untouched.
- Object holds ride the existing `GCSObjectUpdate` path; `ObjectInfo` carries `TemporaryHold`/`EventBasedHold`/`RetentionExpiration` back to the wire.
- New typed `driver.GCSImmutableError` → 403 in the GCS handler.
- Deep-copy / write-locked COW throughout; `-race` clean. Snapshot/restore extended to persist retention + holds.
- Coexists with versioning, lifecycle (#980), and HMAC/UBLA (#988).

## Tests (real cloud.google.com/go/storage SDK + deterministic FakeClock)

- delete before retention blocked → advance clock → delete succeeds
- overwrite of a retained object blocked
- lock retention → cannot shorten/remove, can increase
- `temporaryHold` blocks delete + overwrite; release re-enables
- `eventBasedHold` blocks + restarts the retention clock on release

## Known limitation

Removing an unlocked retention policy via a `retentionPolicy: null` merge-patch is indistinguishable from an absent field over the wire, so removal-by-null is a no-op (explicit `retentionPeriod: 0` removes it). Noted inline.

## Gates
build ./... · gofmt clean · `go test ./server/gcp/gcs/... ./providers/gcp/gcs/... ./persist/... -race` · broad `go test ./server/gcp/...` · golangci-lint 0 new · coveragegen diff clean · go mod tidy clean — all green.
