### PR TITLE
feat(azure-sql): database copy & point-in-time restore via createMode

### DIFF
--- a/providers/azure/sql/databases.go
+++ b/providers/azure/sql/databases.go
@@ -14,7 +14,20 @@ import (
 const (
 	dbStatusCreating = "Creating"
 	dbStatusScaling  = "Scaling"
+
+	// createModeCopy / createModePITR are the Azure SQL createMode values that
+	// provision a new database from an existing source database. Point-in-time
+	// restore is modeled as a copy of the source's current state: in-memory
+	// databases carry no row data, so there is no historical state to rewind to.
+	createModeCopy = "Copy"
+	createModePITR = "PointInTimeRestore"
 )
+
+// isSourceCopyMode reports whether a createMode provisions a database from an
+// existing source database (properties.sourceDatabaseId).
+func isSourceCopyMode(mode string) bool {
+	return mode == createModeCopy || mode == createModePITR
+}
 
 // dbKey is the storage key for a logical database: "server/name".
 func dbKey(server, name string) string { return server + "/" + name }
@@ -51,6 +64,15 @@ func (m *Mock) CreateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 	key := dbKey(cfg.Server, cfg.Name)
 	if _, ok := m.databases.Get(key); ok {
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "database %q already exists on server %q", cfg.Name, cfg.Server)
+	}
+
+	// A Copy / PointInTimeRestore create seeds the new database from an existing
+	// source. Resolved before the elastic-pool check so a missing source is
+	// reported as its own NotFound rather than a pool error.
+	if isSourceCopyMode(cfg.CreateMode) {
+		if err := m.applyCopySource(&cfg); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := m.requireElasticPool(cfg.Server, cfg.ElasticPoolID); err != nil {
@@ -101,6 +123,50 @@ func (m *Mock) CreateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 	out := db
 
 	return &out, nil
+}
+
+// applyCopySource resolves the copy/restore source database named by
+// cfg.SourceDatabaseID and seeds cfg with the source's properties that the
+// request left unset (collation, charset, SKU). The result is an independent,
+// standalone database — the source's elastic-pool membership is not inherited.
+// The caller holds m.mu, so the source read is on the already-locked store.
+func (m *Mock) applyCopySource(cfg *rdsdriver.DatabaseConfig) error {
+	if cfg.SourceDatabaseID == "" {
+		return cerrors.Newf(cerrors.InvalidArgument, "createMode %q requires sourceDatabaseId", cfg.CreateMode)
+	}
+
+	srcServer, srcName, ok := rdsdriver.SourceDatabaseRef(cfg.SourceDatabaseID)
+	if !ok {
+		// A bare name refers to a database on the same server.
+		srcServer, srcName = cfg.Server, cfg.SourceDatabaseID
+	}
+
+	src, ok := m.databases.Get(dbKey(srcServer, srcName))
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "source database %q not found on server %q", srcName, srcServer)
+	}
+
+	if cfg.Collation == "" {
+		cfg.Collation = src.Collation
+	}
+
+	if cfg.Charset == "" {
+		cfg.Charset = src.Charset
+	}
+
+	if cfg.SKUName == "" {
+		cfg.SKUName = src.SKUName
+	}
+
+	if cfg.SKUTier == "" {
+		cfg.SKUTier = src.SKUTier
+	}
+
+	if cfg.SKUCapacity == 0 {
+		cfg.SKUCapacity = src.SKUCapacity
+	}
+
+	return nil
 }
 
 // UpdateDatabase applies a fully-merged desired state to an existing logical

--- a/providers/azure/sql/sql_test.go
+++ b/providers/azure/sql/sql_test.go
@@ -853,6 +853,59 @@ func TestDescribeResultsDoNotAliasStore(t *testing.T) {
 	}
 }
 
+func TestCreateDatabaseCopy(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateCluster(ctx, rdsdriver.ClusterConfig{ID: "srv"}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{
+		Server: "srv", Name: "src", Collation: "SQL_Latin1_General_CP1_CI_AS",
+		SKUName: "S3", SKUTier: "Standard", SKUCapacity: 100,
+	}); err != nil {
+		t.Fatalf("CreateDatabase source: %v", err)
+	}
+
+	// Bare-name source reference on the same server; inherits unset properties.
+	copyDB, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{
+		Server: "srv", Name: "copy", CreateMode: "Copy", SourceDatabaseID: "src",
+	})
+	if err != nil {
+		t.Fatalf("CreateDatabase copy: %v", err)
+	}
+
+	assertEqual(t, "SQL_Latin1_General_CP1_CI_AS", copyDB.Collation)
+	assertEqual(t, "S3", copyDB.SKUName)
+	assertEqual(t, "Standard", copyDB.SKUTier)
+	assertEqual(t, 100, copyDB.SKUCapacity)
+
+	// The copy is independent: deleting the source does not remove it.
+	if err := m.DeleteDatabase(ctx, "srv", "src"); err != nil {
+		t.Fatalf("DeleteDatabase source: %v", err)
+	}
+
+	if _, err := m.GetDatabase(ctx, "srv", "copy"); err != nil {
+		t.Fatalf("copy vanished after source delete: %v", err)
+	}
+
+	// Copy from a nonexistent source is NotFound.
+	if _, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{
+		Server: "srv", Name: "orphan", CreateMode: "Copy",
+		SourceDatabaseID: "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Sql/servers/srv/databases/ghost",
+	}); err == nil {
+		t.Error("copy from nonexistent source: expected NotFound")
+	}
+
+	// Copy without a source id is InvalidArgument.
+	if _, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{
+		Server: "srv", Name: "nosrc", CreateMode: "Copy",
+	}); err == nil {
+		t.Error("copy without sourceDatabaseId: expected InvalidArgument")
+	}
+}
+
 func TestCreateDatabaseValidatesElasticPool(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/server/azure/sql/database_copy_sdk_test.go
+++ b/server/azure/sql/database_copy_sdk_test.go
@@ -1,0 +1,251 @@
+package sql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
+)
+
+// seedServerAndSource creates a logical server plus a source database with a
+// distinctive collation and SKU, returning the source database's ARM ID so a
+// copy/restore create can reference it.
+func seedServerAndSource(t *testing.T, servers *armsql.ServersClient, dbs *armsql.DatabasesClient) string {
+	t.Helper()
+
+	ctx := context.Background()
+
+	srvPoller, err := servers.BeginCreateOrUpdate(ctx, "rg-1", "srv1", armsql.Server{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("server BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := srvPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("server PollUntilDone: %v", err)
+	}
+
+	srcPoller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "sourcedb", armsql.Database{
+		Location: to.Ptr("eastus"),
+		SKU:      &armsql.SKU{Name: to.Ptr("S3")},
+		Properties: &armsql.DatabaseProperties{
+			Collation: to.Ptr("SQL_Latin1_General_CP1_CI_AS"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("source BeginCreateOrUpdate: %v", err)
+	}
+
+	srcResp, err := srcPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("source PollUntilDone: %v", err)
+	}
+
+	if srcResp.Database.ID == nil {
+		t.Fatal("source database missing ID")
+	}
+
+	return *srcResp.Database.ID
+}
+
+// TestSDKAzureSQLDatabaseCopy exercises a real armsql CreateMode=Copy create:
+// the copy is a new, independent database seeded from the source's properties.
+func TestSDKAzureSQLDatabaseCopy(t *testing.T) {
+	servers, dbs := newSDKClients(t)
+	ctx := context.Background()
+
+	sourceID := seedServerAndSource(t, servers, dbs)
+
+	copyPoller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "copydb", armsql.Database{
+		Location: to.Ptr("eastus"),
+		Properties: &armsql.DatabaseProperties{
+			CreateMode:       to.Ptr(armsql.CreateModeCopy),
+			SourceDatabaseID: to.Ptr(sourceID),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("copy BeginCreateOrUpdate: %v", err)
+	}
+
+	copyResp, err := copyPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("copy PollUntilDone: %v", err)
+	}
+
+	if copyResp.Database.Name == nil || *copyResp.Database.Name != "copydb" {
+		t.Fatalf("got copy name %v, want copydb", copyResp.Database.Name)
+	}
+
+	// The copy inherits the source's collation and SKU (request left them unset).
+	if copyResp.Database.Properties == nil || copyResp.Database.Properties.Collation == nil ||
+		*copyResp.Database.Properties.Collation != "SQL_Latin1_General_CP1_CI_AS" {
+		t.Fatalf("copy did not inherit source collation: %+v", copyResp.Database.Properties)
+	}
+
+	if copyResp.Database.SKU == nil || copyResp.Database.SKU.Name == nil || *copyResp.Database.SKU.Name != "S3" {
+		t.Fatalf("copy did not inherit source SKU: %+v", copyResp.Database.SKU)
+	}
+
+	// The copy is independent: deleting the source leaves the copy intact.
+	delPoller, err := dbs.BeginDelete(ctx, "rg-1", "srv1", "sourcedb", nil)
+	if err != nil {
+		t.Fatalf("source BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("source delete PollUntilDone: %v", err)
+	}
+
+	got, err := dbs.Get(ctx, "rg-1", "srv1", "copydb", nil)
+	if err != nil {
+		t.Fatalf("copy Get after source delete: %v", err)
+	}
+
+	if got.Database.Name == nil || *got.Database.Name != "copydb" {
+		t.Fatal("copy vanished after source delete")
+	}
+}
+
+// TestSDKAzureSQLDatabaseCopyOverride confirms an explicit SKU/collation on the
+// copy request overrides the source's values.
+func TestSDKAzureSQLDatabaseCopyOverride(t *testing.T) {
+	servers, dbs := newSDKClients(t)
+	ctx := context.Background()
+
+	sourceID := seedServerAndSource(t, servers, dbs)
+
+	poller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "copydb", armsql.Database{
+		Location: to.Ptr("eastus"),
+		SKU:      &armsql.SKU{Name: to.Ptr("S6")},
+		Properties: &armsql.DatabaseProperties{
+			CreateMode:       to.Ptr(armsql.CreateModeCopy),
+			SourceDatabaseID: to.Ptr(sourceID),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("copy BeginCreateOrUpdate: %v", err)
+	}
+
+	resp, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("copy PollUntilDone: %v", err)
+	}
+
+	if resp.Database.SKU == nil || resp.Database.SKU.Name == nil || *resp.Database.SKU.Name != "S6" {
+		t.Fatalf("explicit SKU not honored on copy: %+v", resp.Database.SKU)
+	}
+}
+
+// TestSDKAzureSQLDatabasePointInTimeRestore exercises CreateMode=PointInTimeRestore,
+// modeled as a copy of the source's current state.
+func TestSDKAzureSQLDatabasePointInTimeRestore(t *testing.T) {
+	servers, dbs := newSDKClients(t)
+	ctx := context.Background()
+
+	sourceID := seedServerAndSource(t, servers, dbs)
+
+	poller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "restored", armsql.Database{
+		Location: to.Ptr("eastus"),
+		Properties: &armsql.DatabaseProperties{
+			CreateMode:       to.Ptr(armsql.CreateModePointInTimeRestore),
+			SourceDatabaseID: to.Ptr(sourceID),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("PITR BeginCreateOrUpdate: %v", err)
+	}
+
+	resp, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("PITR PollUntilDone: %v", err)
+	}
+
+	if resp.Database.Name == nil || *resp.Database.Name != "restored" {
+		t.Fatalf("got restored name %v, want restored", resp.Database.Name)
+	}
+
+	if resp.Database.Properties == nil || resp.Database.Properties.Collation == nil ||
+		*resp.Database.Properties.Collation != "SQL_Latin1_General_CP1_CI_AS" {
+		t.Fatal("PITR did not inherit source collation")
+	}
+}
+
+// TestSDKAzureSQLDatabaseCopyMissingSource confirms a copy pointing at a
+// nonexistent source fails (SourceDatabaseNotFound), not a silent empty create.
+func TestSDKAzureSQLDatabaseCopyMissingSource(t *testing.T) {
+	servers, dbs := newSDKClients(t)
+	ctx := context.Background()
+
+	// Server exists, source database does not.
+	srvPoller, err := servers.BeginCreateOrUpdate(ctx, "rg-1", "srv1", armsql.Server{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("server BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := srvPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("server PollUntilDone: %v", err)
+	}
+
+	missingID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Sql/servers/srv1/databases/ghost"
+
+	poller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "copydb", armsql.Database{
+		Location: to.Ptr("eastus"),
+		Properties: &armsql.DatabaseProperties{
+			CreateMode:       to.Ptr(armsql.CreateModeCopy),
+			SourceDatabaseID: to.Ptr(missingID),
+		},
+	}, nil)
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("expected error copying from a nonexistent source")
+	}
+
+	if !strings.Contains(err.Error(), "SourceDatabaseNotFound") {
+		t.Fatalf("expected SourceDatabaseNotFound, got %v", err)
+	}
+
+	// The target database must not have been created.
+	if _, gErr := dbs.Get(ctx, "rg-1", "srv1", "copydb", nil); gErr == nil {
+		t.Fatal("copy target was created despite missing source")
+	}
+}
+
+// TestSDKAzureSQLDatabaseCopyNoSourceID confirms Copy without a sourceDatabaseId
+// is rejected (400) rather than creating an empty database.
+func TestSDKAzureSQLDatabaseCopyNoSourceID(t *testing.T) {
+	servers, dbs := newSDKClients(t)
+	ctx := context.Background()
+
+	srvPoller, err := servers.BeginCreateOrUpdate(ctx, "rg-1", "srv1", armsql.Server{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("server BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := srvPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("server PollUntilDone: %v", err)
+	}
+
+	poller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "copydb", armsql.Database{
+		Location: to.Ptr("eastus"),
+		Properties: &armsql.DatabaseProperties{
+			CreateMode: to.Ptr(armsql.CreateModeCopy),
+		},
+	}, nil)
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("expected error for Copy without sourceDatabaseId")
+	}
+}

--- a/server/azure/sql/operations.go
+++ b/server/azure/sql/operations.go
@@ -192,6 +192,8 @@ func dbCfgFromBody(body *armDatabase, rp *azurearm.ResourcePath) rdsdriver.Datab
 	if body.Properties != nil {
 		cfg.Collation = body.Properties.Collation
 		cfg.ElasticPoolID = body.Properties.ElasticPoolID
+		cfg.CreateMode = body.Properties.CreateMode
+		cfg.SourceDatabaseID = body.Properties.SourceDatabaseID
 
 		if body.Properties.ZoneRedundant != nil {
 			cfg.ZoneRedundant = *body.Properties.ZoneRedundant
@@ -220,10 +222,11 @@ func (h *Handler) putDatabase(w http.ResponseWriter, r *http.Request, rp *azurea
 	}
 
 	if cerrors.IsNotFound(err) {
-		// CreateDatabase raises NotFound for two distinct causes: a missing
-		// parent server, or (once the server exists) an elasticPoolId that
-		// doesn't resolve to a pool on it. Disambiguate by server existence.
-		h.writeDatabaseNotFound(r.Context(), w, rp.ResourceName, err)
+		// CreateDatabase raises NotFound for three distinct causes: a missing
+		// parent server, a Copy/PointInTimeRestore sourceDatabaseId that doesn't
+		// resolve, or (once the server exists) an elasticPoolId that doesn't
+		// resolve to a pool on it. Disambiguate by server existence + copy mode.
+		h.writeDatabaseNotFound(r.Context(), w, rp.ResourceName, &cfg, err)
 		return
 	}
 
@@ -239,9 +242,9 @@ func (h *Handler) putDatabase(w http.ResponseWriter, r *http.Request, rp *azurea
 	}
 
 	if cerrors.IsNotFound(err) {
-		// Same disambiguation as above: replaceDatabase's own elastic-pool
-		// pre-check also raises NotFound.
-		h.writeDatabaseNotFound(r.Context(), w, rp.ResourceName, err)
+		// replaceDatabase's only NotFound is its elastic-pool pre-check (the
+		// copy path never runs on the update half), so pass no cfg.
+		h.writeDatabaseNotFound(r.Context(), w, rp.ResourceName, nil, err)
 		return
 	}
 
@@ -254,10 +257,19 @@ func (h *Handler) putDatabase(w http.ResponseWriter, r *http.Request, rp *azurea
 // server whose referenced elastic pool doesn't exist (real Azure answers 400
 // TargetElasticPoolDoesNotExist — see
 // https://learn.microsoft.com/en-us/rest/api/sql/databases/create-or-update).
-func (h *Handler) writeDatabaseNotFound(ctx context.Context, w http.ResponseWriter, server string, err error) {
+func (h *Handler) writeDatabaseNotFound(
+	ctx context.Context, w http.ResponseWriter, server string, cfg *rdsdriver.DatabaseConfig, err error,
+) {
 	clusters, dErr := h.db.DescribeClusters(ctx, []string{server})
 	if dErr != nil || len(clusters) == 0 {
 		azurearm.WriteParentNotFound(w, err)
+		return
+	}
+
+	// Server exists: a Copy/PointInTimeRestore whose sourceDatabaseId is set
+	// resolved the source before the pool check, so the NotFound is the source.
+	if cfg != nil && cfg.SourceDatabaseID != "" {
+		azurearm.WriteError(w, http.StatusNotFound, "SourceDatabaseNotFound", err.Error())
 		return
 	}
 

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -561,6 +561,16 @@ type DatabaseConfig struct {
 	// bare pool name or a full ARM resource ID); empty for a standalone
 	// database. Set via properties.elasticPoolId on the ARM request body.
 	ElasticPoolID string
+	// CreateMode selects how the database is provisioned (Azure SQL
+	// properties.createMode). Empty / "Default" is a new empty database, while
+	// "Copy" and "PointInTimeRestore" provision a new, independent database
+	// seeded from an existing source database named by SourceDatabaseID. Other
+	// providers leave it empty.
+	CreateMode string
+	// SourceDatabaseID is the source a Copy / PointInTimeRestore create derives
+	// from: a full ARM database resource ID (".../servers/{s}/databases/{d}")
+	// or a bare database name on the same server. Ignored for a Default create.
+	SourceDatabaseID string
 }
 
 // Database is a logical database hosted by a managed server (Azure MySQL /
@@ -804,6 +814,34 @@ func ElasticPoolName(id string) string {
 	}
 
 	return id
+}
+
+// SourceDatabaseRef extracts the source server and database name from an Azure
+// SQL sourceDatabaseId, a full ARM resource ID of the form
+// ".../servers/{server}/databases/{database}". Returns ok=false when id is not
+// a database resource ID (e.g. a bare database name), so a caller can fall back
+// to treating it as a same-server reference. Shared by the provider (which owns
+// the database store) and the wire server so both parse the id identically.
+func SourceDatabaseRef(id string) (server, database string, ok bool) {
+	const dbMarker = "/databases/"
+
+	const srvMarker = "/servers/"
+
+	di := strings.LastIndex(id, dbMarker)
+	si := strings.Index(id, srvMarker)
+
+	if di < 0 || si < 0 || si >= di {
+		return "", "", false
+	}
+
+	server = id[si+len(srvMarker) : di]
+	database = id[di+len(dbMarker):]
+
+	if server == "" || database == "" || strings.Contains(server, "/") || strings.Contains(database, "/") {
+		return "", "", false
+	}
+
+	return server, database, true
 }
 
 // FailoverGroupConfig describes a failover group to create (Azure SQL).

--- a/services/relationaldb/driver/source_database_ref_test.go
+++ b/services/relationaldb/driver/source_database_ref_test.go
@@ -1,0 +1,58 @@
+package driver
+
+import "testing"
+
+func TestSourceDatabaseRef(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		wantServer string
+		wantDB     string
+		wantOK     bool
+	}{
+		{
+			name:       "full arm id",
+			id:         "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Sql/servers/srv1/databases/db1",
+			wantServer: "srv1",
+			wantDB:     "db1",
+			wantOK:     true,
+		},
+		{
+			name:   "bare name",
+			id:     "sourcedb",
+			wantOK: false,
+		},
+		{
+			name:   "servers segment only",
+			id:     "/providers/Microsoft.Sql/servers/srv1",
+			wantOK: false,
+		},
+		{
+			name:   "databases before servers",
+			id:     "/databases/db1/servers/srv1",
+			wantOK: false,
+		},
+		{
+			name:   "empty",
+			id:     "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, db, ok := SourceDatabaseRef(tt.id)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+
+			if !ok {
+				return
+			}
+
+			if server != tt.wantServer || db != tt.wantDB {
+				t.Fatalf("got (%q, %q), want (%q, %q)", server, db, tt.wantServer, tt.wantDB)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes the highest-value remaining Azure SQL (S4) gap: **database copy and point-in-time restore via `properties.createMode`**.

The wire layer already decoded `createMode` / `sourceDatabaseId` / `restorePointInTime` but silently dropped them, so a real armsql `CreateMode=Copy` request produced an empty, unrelated database. Now:

- **`CreateMode=Copy`** and **`CreateMode=PointInTimeRestore`** resolve the source named by `sourceDatabaseId` (full ARM `.../servers/{s}/databases/{d}` id or a bare same-server name) and provision a new, **independent** database seeded from the source's `collation` / `charset` / SKU when the request omits them. Explicit values on the copy request override the inherited ones. PITR is modeled as a copy of the source's current state (in-memory databases carry no row data to rewind).
- The copy is standalone — it does not inherit the source's elastic-pool membership.
- **Guard/error cases:** a `sourceDatabaseId` that doesn't resolve returns `SourceDatabaseNotFound` (404); a `Copy` with no `sourceDatabaseId` returns 400. Both fail **before** any store mutation, so the target database is never half-created. Source resolution runs before the elastic-pool check so the missing-source 404 is never mis-reported as a pool error.

Concurrency-safe: source lookup happens under the existing `CreateDatabase` write lock (no `Get()`+naked-mutate); `-race` clean.

## What changed

- `services/relationaldb/driver/driver.go` — `DatabaseConfig.CreateMode` / `SourceDatabaseID`; shared `SourceDatabaseRef(id)` parser.
- `providers/azure/sql/databases.go` — copy/restore source resolution + property inheritance in `CreateDatabase`.
- `server/azure/sql/operations.go` — pass `createMode` / `sourceDatabaseId` through `dbCfgFromBody`; disambiguate `SourceDatabaseNotFound` vs parent-server vs elastic-pool 404.

## Closed / deferred

- **Closed:** Azure SQL database copy + point-in-time restore (createMode Copy / PointInTimeRestore) — the copy/restore portion of S4.
- **Deferred (out of scope / needs cross-cutting work):**
  - `CreateMode=Secondary` geo-replicas + the `replicationLinks` sub-resource — the `.../databases/{d}/replicationLinks/{linkId}` path is 5 segments deep and `azurearm.ParsePath` captures only 4, so per-link GET/DELETE can't be routed without changing the shared ARM parser (outside this PR's scope).
  - `CreateMode=Restore` of a dropped database — requires modeling `restorableDroppedDatabases`.
  - Short-term / long-term backup retention policies on ARM (S6), server-level CMK/TDE protector (S7), auditing policies (S5).

## Tests (real armsql SDK)

`server/azure/sql/database_copy_sdk_test.go`: Copy (inheritance + independence after source delete), Copy with explicit-SKU override, PointInTimeRestore, missing-source (`SourceDatabaseNotFound` + target not created), Copy-without-sourceId. Plus provider-level `TestCreateDatabaseCopy` and a `SourceDatabaseRef` table test. #971 TDE and #981 default-off settle regressions confirmed green.
