### PR TITLE
feat(azure-blob): immutability policy + legal hold (WORM)

### DIFF
--- a/docs/coverage/azure/blobstorage.md
+++ b/docs/coverage/azure/blobstorage.md
@@ -93,6 +93,17 @@ AzureFindBlobsByTags is an OPTIONAL Azure-specific capability, discovered by
 | --- | --- |
 | `FindBlobsByTags` |  |
 
+### AzureImmutableBlob
+
+AzureImmutableBlob is an OPTIONAL Azure-specific capability, discovered by
+
+| Operation | Description |
+| --- | --- |
+| `BlobImmutability` | BlobImmutability reports the blob's current immutability policy and legal |
+| `DeleteBlobImmutabilityPolicy` | DeleteBlobImmutabilityPolicy removes the blob's immutability policy |
+| `SetBlobImmutabilityPolicy` | SetBlobImmutabilityPolicy sets (or updates) the blob's time-based |
+| `SetBlobLegalHold` | SetBlobLegalHold sets or clears the blob's legal hold. |
+
 ### AzurePageBlob
 
 AzurePageBlob is an OPTIONAL Azure-specific capability, discovered by type

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -12552,6 +12552,28 @@
         ]
       },
       {
+        "name": "AzureImmutableBlob",
+        "doc": "AzureImmutableBlob is an OPTIONAL Azure-specific capability, discovered by",
+        "operations": [
+          {
+            "name": "BlobImmutability",
+            "doc": "BlobImmutability reports the blob's current immutability policy and legal"
+          },
+          {
+            "name": "DeleteBlobImmutabilityPolicy",
+            "doc": "DeleteBlobImmutabilityPolicy removes the blob's immutability policy"
+          },
+          {
+            "name": "SetBlobImmutabilityPolicy",
+            "doc": "SetBlobImmutabilityPolicy sets (or updates) the blob's time-based"
+          },
+          {
+            "name": "SetBlobLegalHold",
+            "doc": "SetBlobLegalHold sets or clears the blob's legal hold."
+          }
+        ]
+      },
+      {
         "name": "AzurePageBlob",
         "doc": "AzurePageBlob is an OPTIONAL Azure-specific capability, discovered by type",
         "operations": [

--- a/providers/azure/blobstorage/blob_extensions.go
+++ b/providers/azure/blobstorage/blob_extensions.go
@@ -81,6 +81,11 @@ func (m *Mock) CommitBlockList(
 		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
 	}
 
+	// Immutable storage (WORM): overwriting a protected blob is blocked.
+	if err := m.enforceImmutable(ctr, blob); err != nil {
+		return nil, err
+	}
+
 	existing, _ := ctr.objects.Get(blob)
 
 	data, blockInfos, committedData, err := assembleBlocks(ctr, blob, blocks, existing)
@@ -397,6 +402,11 @@ func (m *Mock) AppendBlock(
 
 	obj.mu.Lock()
 	defer obj.mu.Unlock()
+
+	// Immutable storage (WORM): appending to a protected append blob is blocked.
+	if berr := immutabilityBlock(obj, m.opts.Clock.Now().UTC()); berr != nil {
+		return 0, 0, nil, berr
+	}
 
 	offset = obj.Size
 	obj.Data = append(obj.Data, data...)

--- a/providers/azure/blobstorage/blob_extensions.go
+++ b/providers/azure/blobstorage/blob_extensions.go
@@ -368,6 +368,12 @@ func (m *Mock) CreateAppendBlob(
 		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
 	}
 
+	// Immutable storage (WORM): re-creating an append blob over a protected key
+	// would replace its content with empty — block it. A fresh key passes.
+	if err := m.enforceImmutable(ctr, blob); err != nil {
+		return nil, err
+	}
+
 	if contentType == "" {
 		contentType = octetStream
 	}

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -103,6 +103,15 @@ type blobObject struct {
 	// Acquire/Renew, used to detect "blob modified since lease" on a Renew of
 	// an expired-but-unreleased lease.
 	leaseModTimeAtAcquire string
+
+	// Immutable-storage (WORM) state, guarded by mu. immutabilityMode is one of
+	// driver.BlobImmutabilityUnlocked/Locked (empty when no time-based policy is
+	// set); immutabilityExpiry is its retain-until instant. legalHold, when true,
+	// protects the blob independent of any policy. While the blob has an unexpired
+	// policy OR a legal hold, delete and overwrite are blocked.
+	immutabilityMode   string
+	immutabilityExpiry time.Time
+	legalHold          bool
 }
 
 type blobMultipartUpload struct {
@@ -437,6 +446,11 @@ func (m *Mock) putBlockBlobInternal(
 		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
 	}
 
+	// Immutable storage (WORM): overwriting a protected blob is blocked.
+	if err := m.enforceImmutable(ctr, key); err != nil {
+		return nil, err
+	}
+
 	size := int64(len(data))
 	meta := maps.Clone(metadata)
 
@@ -560,6 +574,12 @@ func (m *Mock) DeleteObject(ctx context.Context, bucket, key string) error {
 	obj, ok := ctr.objects.Get(key)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "blob %q not found in container %q", key, bucket)
+	}
+
+	// Immutable storage (WORM): an unexpired immutability policy or an active
+	// legal hold blocks the delete before any soft-delete/purge runs.
+	if err := m.enforceImmutable(ctr, key); err != nil {
+		return err
 	}
 
 	// When soft delete is in effect, a Delete Blob retains the blob (bytes and
@@ -751,6 +771,11 @@ func (m *Mock) copyBlobInternal(
 	dstCtr, ok := m.containers.Get(dstBucket)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "destination container %q not found", dstBucket)
+	}
+
+	// Immutable storage (WORM): overwriting a protected destination blob is blocked.
+	if err := m.enforceImmutable(dstCtr, dstKey); err != nil {
+		return nil, err
 	}
 
 	meta := maps.Clone(srcObj.Metadata)

--- a/providers/azure/blobstorage/immutability.go
+++ b/providers/azure/blobstorage/immutability.go
@@ -1,0 +1,160 @@
+package blobstorage
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// Compile-time check that Mock satisfies the optional AzureImmutableBlob
+// capability the blob wire handler reaches by type assertion.
+var _ driver.AzureImmutableBlob = (*Mock)(nil)
+
+// immutabilityBlock reports the WORM error blocking a delete or overwrite of
+// obj, or nil when the blob is not currently protected. A legal hold protects
+// the blob unconditionally; a time-based policy protects it until its
+// retain-until instant elapses. The caller must hold obj.mu.
+func immutabilityBlock(obj *blobObject, now time.Time) error {
+	if obj.legalHold {
+		return &driver.BlobOpError{
+			Status:  http.StatusConflict,
+			Code:    "BlobImmutableDueToLegalHold",
+			Message: "This operation is not permitted as the blob is immutable due to one or more legal holds.",
+		}
+	}
+
+	if obj.immutabilityMode != "" && now.Before(obj.immutabilityExpiry) {
+		return &driver.BlobOpError{
+			Status:  http.StatusConflict,
+			Code:    "BlobImmutableDueToPolicy",
+			Message: "This operation is not permitted as the blob is immutable due to a policy.",
+		}
+	}
+
+	return nil
+}
+
+// enforceImmutable returns the WORM error blocking a delete/overwrite of the
+// named blob, or nil when it is absent or not currently protected. It takes the
+// blob's own lock for the read so it never races an in-flight policy/legal-hold
+// change on the same blob.
+func (m *Mock) enforceImmutable(ctr *containerMeta, key string) error {
+	obj, ok := ctr.objects.Get(key)
+	if !ok {
+		return nil
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	return immutabilityBlock(obj, m.opts.Clock.Now().UTC())
+}
+
+// SetBlobImmutabilityPolicy implements driver.AzureImmutableBlob, setting or
+// updating the blob's time-based retention policy. The retain-until date must be
+// in the future. A Locked policy may only be extended and can never revert to
+// Unlocked; an Unlocked policy may be raised, lowered, or promoted to Locked.
+func (m *Mock) SetBlobImmutabilityPolicy(
+	_ context.Context, container, blob string, policy driver.BlobImmutabilityPolicy,
+) (driver.BlobImmutabilityPolicy, error) {
+	mode := policy.Mode
+	if mode == "" {
+		mode = driver.BlobImmutabilityUnlocked
+	}
+
+	if mode != driver.BlobImmutabilityUnlocked && mode != driver.BlobImmutabilityLocked {
+		return driver.BlobImmutabilityPolicy{}, cerrors.Newf(cerrors.InvalidArgument,
+			"invalid immutability policy mode %q: must be Unlocked or Locked", policy.Mode)
+	}
+
+	obj, err := m.getBlobObject(container, blob)
+	if err != nil {
+		return driver.BlobImmutabilityPolicy{}, err
+	}
+
+	if !policy.ExpiryTime.After(m.opts.Clock.Now().UTC()) {
+		return driver.BlobImmutabilityPolicy{}, cerrors.New(cerrors.InvalidArgument,
+			"immutability policy retain-until date must be in the future")
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	if obj.immutabilityMode == driver.BlobImmutabilityLocked {
+		if mode != driver.BlobImmutabilityLocked {
+			return driver.BlobImmutabilityPolicy{}, cerrors.New(cerrors.FailedPrecondition,
+				"a locked immutability policy cannot be changed to unlocked")
+		}
+
+		if policy.ExpiryTime.Before(obj.immutabilityExpiry) {
+			return driver.BlobImmutabilityPolicy{}, cerrors.New(cerrors.FailedPrecondition,
+				"a locked immutability policy retain-until date can only be extended")
+		}
+	}
+
+	obj.immutabilityMode = mode
+	obj.immutabilityExpiry = policy.ExpiryTime
+
+	return driver.BlobImmutabilityPolicy{ExpiryTime: obj.immutabilityExpiry, Mode: obj.immutabilityMode}, nil
+}
+
+// DeleteBlobImmutabilityPolicy implements driver.AzureImmutableBlob, removing an
+// Unlocked immutability policy. A Locked policy can never be deleted. Removing a
+// policy that was never set is a no-op success.
+func (m *Mock) DeleteBlobImmutabilityPolicy(_ context.Context, container, blob string) error {
+	obj, err := m.getBlobObject(container, blob)
+	if err != nil {
+		return err
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	if obj.immutabilityMode == driver.BlobImmutabilityLocked {
+		return &driver.BlobOpError{
+			Status:  http.StatusConflict,
+			Code:    "BlobImmutableDueToPolicy",
+			Message: "This operation is not permitted as the blob is immutable due to a policy.",
+		}
+	}
+
+	obj.immutabilityMode = ""
+	obj.immutabilityExpiry = time.Time{}
+
+	return nil
+}
+
+// SetBlobLegalHold implements driver.AzureImmutableBlob, setting or clearing the
+// blob's legal hold.
+func (m *Mock) SetBlobLegalHold(_ context.Context, container, blob string, hold bool) error {
+	obj, err := m.getBlobObject(container, blob)
+	if err != nil {
+		return err
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	obj.legalHold = hold
+
+	return nil
+}
+
+// BlobImmutability implements driver.AzureImmutableBlob, reporting the blob's
+// current immutability policy and legal hold for Get Blob Properties.
+func (m *Mock) BlobImmutability(
+	_ context.Context, container, blob string,
+) (driver.BlobImmutabilityPolicy, bool, error) {
+	obj, err := m.getBlobObject(container, blob)
+	if err != nil {
+		return driver.BlobImmutabilityPolicy{}, false, err
+	}
+
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+
+	return driver.BlobImmutabilityPolicy{ExpiryTime: obj.immutabilityExpiry, Mode: obj.immutabilityMode}, obj.legalHold, nil
+}

--- a/providers/azure/blobstorage/immutability_test.go
+++ b/providers/azure/blobstorage/immutability_test.go
@@ -1,0 +1,120 @@
+package blobstorage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+func TestImmutabilityPolicyBlocksDeleteAndOverwrite(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+	require.NoError(t, m.PutObject(ctx, "c1", "k1", []byte("v1"), "text/plain", nil))
+
+	until := clk.Now().Add(24 * time.Hour)
+	got, err := m.SetBlobImmutabilityPolicy(ctx, "c1", "k1",
+		driver.BlobImmutabilityPolicy{ExpiryTime: until, Mode: driver.BlobImmutabilityUnlocked})
+	require.NoError(t, err)
+	assert.Equal(t, driver.BlobImmutabilityUnlocked, got.Mode)
+	assert.True(t, got.ExpiryTime.Equal(until))
+
+	// Within the window: delete and overwrite are blocked.
+	assert.Error(t, m.DeleteObject(ctx, "c1", "k1"))
+	_, err = m.PutBlockBlob(ctx, "c1", "k1", []byte("v2"), nil, nil)
+	assert.Error(t, err)
+
+	// Original content survives.
+	obj, err := m.GetObject(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, "v1", string(obj.Data))
+
+	// After the window elapses, both are allowed.
+	clk.Advance(25 * time.Hour)
+	_, err = m.PutBlockBlob(ctx, "c1", "k1", []byte("v2"), nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, m.DeleteObject(ctx, "c1", "k1"))
+}
+
+func TestImmutabilityPolicyPastDateRejected(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+	require.NoError(t, m.PutObject(ctx, "c1", "k1", []byte("v1"), "text/plain", nil))
+
+	_, err := m.SetBlobImmutabilityPolicy(ctx, "c1", "k1",
+		driver.BlobImmutabilityPolicy{ExpiryTime: clk.Now().Add(-time.Hour), Mode: driver.BlobImmutabilityUnlocked})
+	assert.Error(t, err)
+}
+
+func TestImmutabilityLockedOnlyExtends(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+	require.NoError(t, m.PutObject(ctx, "c1", "k1", []byte("v1"), "text/plain", nil))
+
+	base := clk.Now().Add(48 * time.Hour)
+	_, err := m.SetBlobImmutabilityPolicy(ctx, "c1", "k1",
+		driver.BlobImmutabilityPolicy{ExpiryTime: base, Mode: driver.BlobImmutabilityLocked})
+	require.NoError(t, err)
+
+	// Shorten -> rejected.
+	_, err = m.SetBlobImmutabilityPolicy(ctx, "c1", "k1",
+		driver.BlobImmutabilityPolicy{ExpiryTime: clk.Now().Add(time.Hour), Mode: driver.BlobImmutabilityLocked})
+	assert.Error(t, err)
+
+	// Revert to unlocked -> rejected.
+	_, err = m.SetBlobImmutabilityPolicy(ctx, "c1", "k1",
+		driver.BlobImmutabilityPolicy{ExpiryTime: clk.Now().Add(96 * time.Hour), Mode: driver.BlobImmutabilityUnlocked})
+	assert.Error(t, err)
+
+	// Delete of a locked policy -> rejected.
+	assert.Error(t, m.DeleteBlobImmutabilityPolicy(ctx, "c1", "k1"))
+
+	// Extend -> allowed.
+	_, err = m.SetBlobImmutabilityPolicy(ctx, "c1", "k1",
+		driver.BlobImmutabilityPolicy{ExpiryTime: clk.Now().Add(96 * time.Hour), Mode: driver.BlobImmutabilityLocked})
+	require.NoError(t, err)
+}
+
+func TestLegalHoldBlocksIndependentOfPolicy(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+	require.NoError(t, m.PutObject(ctx, "c1", "k1", []byte("v1"), "text/plain", nil))
+
+	require.NoError(t, m.SetBlobLegalHold(ctx, "c1", "k1", true))
+
+	assert.Error(t, m.DeleteObject(ctx, "c1", "k1"))
+	_, err := m.PutBlockBlob(ctx, "c1", "k1", []byte("v2"), nil, nil)
+	assert.Error(t, err)
+
+	policy, hold, err := m.BlobImmutability(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.True(t, hold)
+	assert.Empty(t, policy.Mode)
+
+	require.NoError(t, m.SetBlobLegalHold(ctx, "c1", "k1", false))
+	require.NoError(t, m.DeleteObject(ctx, "c1", "k1"))
+}
+
+func TestUnlockedPolicyDeletable(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+	require.NoError(t, m.PutObject(ctx, "c1", "k1", []byte("v1"), "text/plain", nil))
+
+	_, err := m.SetBlobImmutabilityPolicy(ctx, "c1", "k1",
+		driver.BlobImmutabilityPolicy{ExpiryTime: clk.Now().Add(24 * time.Hour), Mode: driver.BlobImmutabilityUnlocked})
+	require.NoError(t, err)
+
+	require.NoError(t, m.DeleteBlobImmutabilityPolicy(ctx, "c1", "k1"))
+
+	// Policy gone -> delete allowed within what was the window.
+	require.NoError(t, m.DeleteObject(ctx, "c1", "k1"))
+}

--- a/providers/azure/blobstorage/immutability_test.go
+++ b/providers/azure/blobstorage/immutability_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/storage/driver"
 )
 
@@ -101,6 +102,114 @@ func TestLegalHoldBlocksIndependentOfPolicy(t *testing.T) {
 
 	require.NoError(t, m.SetBlobLegalHold(ctx, "c1", "k1", false))
 	require.NoError(t, m.DeleteObject(ctx, "c1", "k1"))
+}
+
+// protect sets an unlocked immutability policy expiring in 24h on an existing
+// blob and returns the expiry, so a test can later advance the clock past it.
+func protectWithPolicy(t *testing.T, m *Mock, clk *config.FakeClock, container, blob string) time.Time {
+	t.Helper()
+	until := clk.Now().Add(24 * time.Hour)
+	_, err := m.SetBlobImmutabilityPolicy(context.Background(), container, blob,
+		driver.BlobImmutabilityPolicy{ExpiryTime: until, Mode: driver.BlobImmutabilityUnlocked})
+	require.NoError(t, err)
+	return until
+}
+
+// TestPageBlobPathsRespectImmutability proves none of the page-blob write paths
+// (CreatePageBlob overwrite, PutPage, ClearPage) can destroy or overwrite a
+// blob protected by a policy or a legal hold, and that each succeeds once the
+// protection lifts.
+func TestPageBlobPathsRespectImmutability(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+
+	// A protected page blob with one written page.
+	_, err := m.CreatePageBlob(ctx, "c1", "pb", 1024, nil, nil)
+	require.NoError(t, err)
+	_, err = m.PutPage(ctx, "c1", "pb", 0, 511, make([]byte, 512))
+	require.NoError(t, err)
+	protectWithPolicy(t, m, clk, "c1", "pb")
+
+	// CreatePageBlob over the protected key is blocked; the blob survives.
+	_, err = m.CreatePageBlob(ctx, "c1", "pb", 2048, nil, nil)
+	assert.Error(t, err)
+	info, err := m.HeadObject(ctx, "c1", "pb")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1024), info.Size)
+
+	// PutPage / ClearPage on the protected page blob are blocked.
+	_, err = m.PutPage(ctx, "c1", "pb", 512, 1023, make([]byte, 512))
+	assert.Error(t, err)
+	_, err = m.ClearPage(ctx, "c1", "pb", 0, 511)
+	assert.Error(t, err)
+
+	// After the window elapses, page writes proceed.
+	clk.Advance(25 * time.Hour)
+	_, err = m.PutPage(ctx, "c1", "pb", 512, 1023, make([]byte, 512))
+	require.NoError(t, err)
+	_, err = m.ClearPage(ctx, "c1", "pb", 0, 511)
+	require.NoError(t, err)
+	_, err = m.CreatePageBlob(ctx, "c1", "pb", 2048, nil, nil)
+	require.NoError(t, err)
+}
+
+// TestPageAndAppendCreateBlockedByLegalHold proves a legal hold (no time window)
+// blocks the create-overwrite and page-write paths, independent of any policy.
+func TestPageAndAppendCreateBlockedByLegalHold(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+
+	// A protected page blob under legal hold.
+	_, err := m.CreatePageBlob(ctx, "c1", "pb", 1024, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, m.SetBlobLegalHold(ctx, "c1", "pb", true))
+
+	_, err = m.CreatePageBlob(ctx, "c1", "pb", 2048, nil, nil)
+	assert.Error(t, err)
+	_, err = m.PutPage(ctx, "c1", "pb", 0, 511, make([]byte, 512))
+	assert.Error(t, err)
+	_, err = m.ClearPage(ctx, "c1", "pb", 0, 511)
+	assert.Error(t, err)
+
+	// Clearing the hold restores mutability.
+	require.NoError(t, m.SetBlobLegalHold(ctx, "c1", "pb", false))
+	_, err = m.PutPage(ctx, "c1", "pb", 0, 511, make([]byte, 512))
+	require.NoError(t, err)
+
+	// A protected block blob cannot be replaced by an append blob create.
+	require.NoError(t, m.PutObject(ctx, "c1", "ab", []byte("original"), "text/plain", nil))
+	require.NoError(t, m.SetBlobLegalHold(ctx, "c1", "ab", true))
+	_, err = m.CreateAppendBlob(ctx, "c1", "ab", "text/plain", nil)
+	assert.Error(t, err)
+	obj, err := m.GetObject(ctx, "c1", "ab")
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(obj.Data))
+
+	require.NoError(t, m.SetBlobLegalHold(ctx, "c1", "ab", false))
+	_, err = m.CreateAppendBlob(ctx, "c1", "ab", "text/plain", nil)
+	require.NoError(t, err)
+}
+
+// TestAppendBlobCreateBlockedByPolicy proves CreateAppendBlob over a
+// policy-protected blob is blocked and succeeds once the window elapses.
+func TestAppendBlobCreateBlockedByPolicy(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+	require.NoError(t, m.PutObject(ctx, "c1", "ab", []byte("original"), "text/plain", nil))
+	protectWithPolicy(t, m, clk, "c1", "ab")
+
+	_, err := m.CreateAppendBlob(ctx, "c1", "ab", "text/plain", nil)
+	assert.Error(t, err)
+	obj, err := m.GetObject(ctx, "c1", "ab")
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(obj.Data))
+
+	clk.Advance(25 * time.Hour)
+	_, err = m.CreateAppendBlob(ctx, "c1", "ab", "text/plain", nil)
+	require.NoError(t, err)
 }
 
 func TestUnlockedPolicyDeletable(t *testing.T) {

--- a/providers/azure/blobstorage/pageblob.go
+++ b/providers/azure/blobstorage/pageblob.go
@@ -32,6 +32,12 @@ func (m *Mock) CreatePageBlob(
 		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", container)
 	}
 
+	// Immutable storage (WORM): re-creating a page blob over a protected key
+	// would replace its content with zero bytes — block it. A fresh key passes.
+	if err := m.enforceImmutable(ctr, blob); err != nil {
+		return nil, err
+	}
+
 	if size < 0 || size%pageSize != 0 {
 		return nil, &driver.BlobOpError{
 			Status: http.StatusBadRequest, Code: "InvalidHeaderValue",
@@ -81,6 +87,11 @@ func (m *Mock) PutPage(
 	obj.mu.Lock()
 	defer obj.mu.Unlock()
 
+	// Immutable storage (WORM): writing pages over a protected blob is blocked.
+	if berr := immutabilityBlock(obj, m.opts.Clock.Now().UTC()); berr != nil {
+		return nil, berr
+	}
+
 	if err := validatePageRange(start, end, obj.Size); err != nil {
 		return nil, err
 	}
@@ -111,6 +122,11 @@ func (m *Mock) ClearPage(_ context.Context, container, blob string, start, end i
 
 	obj.mu.Lock()
 	defer obj.mu.Unlock()
+
+	// Immutable storage (WORM): clearing pages of a protected blob is blocked.
+	if berr := immutabilityBlock(obj, m.opts.Clock.Now().UTC()); berr != nil {
+		return nil, berr
+	}
 
 	if err := validatePageRange(start, end, obj.Size); err != nil {
 		return nil, err

--- a/providers/azure/blobstorage/snapshot.go
+++ b/providers/azure/blobstorage/snapshot.go
@@ -77,6 +77,9 @@ type blobObjectSnapshot struct {
 	LeaseExpiresAt        time.Time          `json:"leaseExpiresAt,omitempty"`
 	LeaseBreakAt          time.Time          `json:"leaseBreakAt,omitempty"`
 	LeaseModTimeAtAcquire string             `json:"leaseModTimeAtAcquire,omitempty"`
+	ImmutabilityMode      string             `json:"immutabilityMode,omitempty"`
+	ImmutabilityExpiry    time.Time          `json:"immutabilityExpiry,omitempty"`
+	LegalHold             bool               `json:"legalHold,omitempty"`
 }
 
 // Snapshot captures every container's state as JSON. When includeAssets is false
@@ -174,6 +177,9 @@ func snapshotBlob(obj *blobObject, includeAssets bool) *blobObjectSnapshot {
 		LeaseState: obj.leaseState, LeaseID: obj.leaseID, LeaseDurationSec: obj.leaseDurationSec,
 		LeaseExpiresAt: obj.leaseExpiresAt, LeaseBreakAt: obj.leaseBreakAt,
 		LeaseModTimeAtAcquire: obj.leaseModTimeAtAcquire,
+		ImmutabilityMode:      obj.immutabilityMode,
+		ImmutabilityExpiry:    obj.immutabilityExpiry,
+		LegalHold:             obj.legalHold,
 	}
 }
 
@@ -264,5 +270,8 @@ func restoreBlob(os *blobObjectSnapshot) *blobObject {
 		leaseState: os.LeaseState, leaseID: os.LeaseID, leaseDurationSec: os.LeaseDurationSec,
 		leaseExpiresAt: os.LeaseExpiresAt, leaseBreakAt: os.LeaseBreakAt,
 		leaseModTimeAtAcquire: os.LeaseModTimeAtAcquire,
+		immutabilityMode:      os.ImmutabilityMode,
+		immutabilityExpiry:    os.ImmutabilityExpiry,
+		legalHold:             os.LegalHold,
 	}
 }

--- a/providers/azure/blobstorage/versioning.go
+++ b/providers/azure/blobstorage/versioning.go
@@ -68,6 +68,11 @@ func cloneBlobObject(obj *blobObject) *blobObject {
 		CommittedBlocks: append([]driver.BlockInfo(nil), obj.CommittedBlocks...),
 		appendBlocks:    obj.appendBlocks,
 		pages:           maps.Clone(obj.pages),
+		// Immutable-storage state travels with the copy so a soft-deleted or
+		// restored blob keeps its WORM protection.
+		immutabilityMode:   obj.immutabilityMode,
+		immutabilityExpiry: obj.immutabilityExpiry,
+		legalHold:          obj.legalHold,
 	}
 }
 

--- a/server/azure/blobstorage/blob_immutability_test.go
+++ b/server/azure/blobstorage/blob_immutability_test.go
@@ -1,0 +1,247 @@
+package blobstorage_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// immutabilityFixture spins up the Azure blob data plane behind a FakeClock and
+// returns the service client plus the clock, so tests can drive the WORM
+// retention window deterministically.
+func immutabilityFixture(t *testing.T) (*azblob.Client, *config.FakeClock) {
+	t.Helper()
+
+	fc := config.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	cloudP := cloudemu.NewAzure(config.WithClock(fc))
+
+	srv := azureserver.New(azureserver.Drivers{BlobStorage: cloudP.BlobStorage})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	clientOpts := &azblob.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	svcClient, err := azblob.NewClientWithNoCredential(ts.URL+"/", clientOpts)
+	if err != nil {
+		t.Fatalf("NewClientWithNoCredential: %v", err)
+	}
+
+	return svcClient, fc
+}
+
+func requireImmutableError(t *testing.T, err error, wantCode string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("expected %s error, got nil", wantCode)
+	}
+
+	if !bloberror.HasCode(err, bloberror.Code(wantCode)) {
+		t.Fatalf("error = %v, want code %s", err, wantCode)
+	}
+}
+
+// TestSDKBlobImmutabilityPolicy drives the real azblob client through a
+// time-based retention immutability policy: an unlocked policy blocks delete and
+// overwrite within its window, both are permitted again once the retain-until
+// date elapses (FakeClock advanced), and Get Blob Properties echoes the policy.
+func TestSDKBlobImmutabilityPolicy(t *testing.T) {
+	ctx := context.Background()
+
+	svcClient, fc := immutabilityFixture(t)
+
+	if _, err := svcClient.CreateContainer(ctx, "c1", nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	if _, err := svcClient.UploadBuffer(ctx, "c1", "doc", []byte("original"), nil); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+
+	blobClient := svcClient.ServiceClient().NewContainerClient("c1").NewBlobClient("doc")
+
+	until := fc.Now().Add(24 * time.Hour)
+
+	setResp, err := blobClient.SetImmutabilityPolicy(ctx, until, &blob.SetImmutabilityPolicyOptions{
+		Mode: to.Ptr(blob.ImmutabilityPolicySettingUnlocked),
+	})
+	if err != nil {
+		t.Fatalf("SetImmutabilityPolicy: %v", err)
+	}
+
+	if setResp.ImmutabilityPolicyMode == nil || !strings.EqualFold(string(*setResp.ImmutabilityPolicyMode), "unlocked") {
+		t.Fatalf("set policy mode = %v, want unlocked", setResp.ImmutabilityPolicyMode)
+	}
+
+	// Get Blob Properties echoes the policy headers.
+	props, err := blobClient.GetProperties(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetProperties: %v", err)
+	}
+
+	if props.ImmutabilityPolicyMode == nil || !strings.EqualFold(string(*props.ImmutabilityPolicyMode), "unlocked") {
+		t.Fatalf("props policy mode = %v, want unlocked", props.ImmutabilityPolicyMode)
+	}
+
+	if props.ImmutabilityPolicyExpiresOn == nil || !props.ImmutabilityPolicyExpiresOn.Equal(until.UTC().Truncate(time.Second)) {
+		t.Fatalf("props expiry = %v, want %v", props.ImmutabilityPolicyExpiresOn, until.UTC().Truncate(time.Second))
+	}
+
+	// Within the window: delete and overwrite are both blocked.
+	if _, err := svcClient.DeleteBlob(ctx, "c1", "doc", nil); !isBlocked(err) {
+		t.Fatalf("delete within window = %v, want blocked", err)
+	}
+
+	requireImmutableError(t,
+		mustErr(svcClient.UploadBuffer(ctx, "c1", "doc", []byte("overwrite"), nil)),
+		"BlobImmutableDueToPolicy")
+
+	// The original content is untouched by the blocked overwrite.
+	assertBlobBody(t, ctx, svcClient, "c1", "doc", "original")
+
+	// Advance past the retain-until date: WORM protection lifts.
+	fc.Advance(25 * time.Hour)
+
+	if _, err := svcClient.UploadBuffer(ctx, "c1", "doc", []byte("now-editable"), nil); err != nil {
+		t.Fatalf("overwrite after expiry: %v", err)
+	}
+
+	if _, err := svcClient.DeleteBlob(ctx, "c1", "doc", nil); err != nil {
+		t.Fatalf("delete after expiry: %v", err)
+	}
+}
+
+// TestSDKBlobImmutabilityLocked verifies a locked policy can only be extended,
+// never shortened or deleted, while still blocking delete within its window.
+func TestSDKBlobImmutabilityLocked(t *testing.T) {
+	ctx := context.Background()
+
+	svcClient, fc := immutabilityFixture(t)
+
+	if _, err := svcClient.CreateContainer(ctx, "c1", nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	if _, err := svcClient.UploadBuffer(ctx, "c1", "ledger", []byte("record"), nil); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+
+	blobClient := svcClient.ServiceClient().NewContainerClient("c1").NewBlobClient("ledger")
+
+	locked := fc.Now().Add(48 * time.Hour)
+
+	if _, err := blobClient.SetImmutabilityPolicy(ctx, locked, &blob.SetImmutabilityPolicyOptions{
+		Mode: to.Ptr(blob.ImmutabilityPolicySettingLocked),
+	}); err != nil {
+		t.Fatalf("SetImmutabilityPolicy(locked): %v", err)
+	}
+
+	// Shortening a locked policy is rejected.
+	if _, err := blobClient.SetImmutabilityPolicy(ctx, fc.Now().Add(1*time.Hour), &blob.SetImmutabilityPolicyOptions{
+		Mode: to.Ptr(blob.ImmutabilityPolicySettingLocked),
+	}); err == nil {
+		t.Fatalf("shortening a locked policy should fail")
+	}
+
+	// Deleting a locked policy is rejected.
+	if _, err := blobClient.DeleteImmutabilityPolicy(ctx, nil); err == nil {
+		t.Fatalf("deleting a locked policy should fail")
+	}
+
+	// Extending a locked policy is allowed.
+	if _, err := blobClient.SetImmutabilityPolicy(ctx, fc.Now().Add(96*time.Hour), &blob.SetImmutabilityPolicyOptions{
+		Mode: to.Ptr(blob.ImmutabilityPolicySettingLocked),
+	}); err != nil {
+		t.Fatalf("extending a locked policy: %v", err)
+	}
+
+	// Delete is still blocked within the (extended) window.
+	if _, err := svcClient.DeleteBlob(ctx, "c1", "ledger", nil); !isBlocked(err) {
+		t.Fatalf("delete under locked policy = %v, want blocked", err)
+	}
+}
+
+// TestSDKBlobLegalHold verifies a legal hold blocks delete and overwrite
+// independent of any retention window, and lifting it restores mutability.
+func TestSDKBlobLegalHold(t *testing.T) {
+	ctx := context.Background()
+
+	svcClient, _ := immutabilityFixture(t)
+
+	if _, err := svcClient.CreateContainer(ctx, "c1", nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	if _, err := svcClient.UploadBuffer(ctx, "c1", "held", []byte("evidence"), nil); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+
+	blobClient := svcClient.ServiceClient().NewContainerClient("c1").NewBlobClient("held")
+
+	holdResp, err := blobClient.SetLegalHold(ctx, true, nil)
+	if err != nil {
+		t.Fatalf("SetLegalHold(true): %v", err)
+	}
+
+	if holdResp.LegalHold == nil || !*holdResp.LegalHold {
+		t.Fatalf("set legal hold response = %v, want true", holdResp.LegalHold)
+	}
+
+	// Under legal hold, delete and overwrite are blocked (no time window applies).
+	if _, err := svcClient.DeleteBlob(ctx, "c1", "held", nil); !isBlocked(err) {
+		t.Fatalf("delete under legal hold = %v, want blocked", err)
+	}
+
+	requireImmutableError(t,
+		mustErr(svcClient.UploadBuffer(ctx, "c1", "held", []byte("tamper"), nil)),
+		"BlobImmutableDueToLegalHold")
+
+	// Get Blob Properties reports the hold.
+	props, err := blobClient.GetProperties(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetProperties: %v", err)
+	}
+
+	if props.LegalHold == nil || !*props.LegalHold {
+		t.Fatalf("props legal hold = %v, want true", props.LegalHold)
+	}
+
+	// Clearing the hold restores mutability.
+	if _, err := blobClient.SetLegalHold(ctx, false, nil); err != nil {
+		t.Fatalf("SetLegalHold(false): %v", err)
+	}
+
+	if _, err := svcClient.DeleteBlob(ctx, "c1", "held", nil); err != nil {
+		t.Fatalf("delete after clearing hold: %v", err)
+	}
+}
+
+// isBlocked reports whether err is one of the two Azure WORM-block errors.
+func isBlocked(err error) bool {
+	return bloberror.HasCode(err,
+		bloberror.Code("BlobImmutableDueToPolicy"),
+		bloberror.Code("BlobImmutableDueToLegalHold"))
+}
+
+// mustErr discards a first (response) return value so a one-line call can be fed
+// to requireImmutableError.
+func mustErr[T any](_ T, err error) error {
+	return err
+}

--- a/server/azure/blobstorage/handler.go
+++ b/server/azure/blobstorage/handler.go
@@ -71,6 +71,11 @@ const (
 	compPage        = "page"
 	compPageList    = "pagelist"
 	compUndelete    = "undelete"
+	// compImmutabilityPolicies / compLegalHold select the blob-level immutable
+	// storage (WORM) sub-operations: Set/Delete Blob Immutability Policy
+	// (?comp=immutabilityPolicies) and Set Blob Legal Hold (?comp=legalhold).
+	compImmutabilityPolicies = "immutabilityPolicies"
+	compLegalHold            = "legalhold"
 	// compBlobs is the ?comp= value for Find Blobs by Tags (GET /?comp=blobs and
 	// GET /{container}?restype=container&comp=blobs).
 	compBlobs = "blobs"
@@ -263,6 +268,16 @@ func (h *Handler) putBlobComp(w http.ResponseWriter, r *http.Request, container,
 
 	if comp == compUndelete {
 		h.undeleteBlob(w, r, container, blob)
+		return
+	}
+
+	if comp == compImmutabilityPolicies {
+		h.setBlobImmutabilityPolicy(w, r, container, blob)
+		return
+	}
+
+	if comp == compLegalHold {
+		h.setBlobLegalHold(w, r, container, blob)
 		return
 	}
 
@@ -932,6 +947,7 @@ func (h *Handler) getBlob(w http.ResponseWriter, r *http.Request, container, blo
 		return
 	}
 
+	h.writeImmutabilityHeaders(w, r, container, blob)
 	serveBlobContent(w, r, &obj.Info, obj.Data)
 }
 
@@ -1169,6 +1185,7 @@ func (h *Handler) headBlob(w http.ResponseWriter, r *http.Request, container, bl
 		return
 	}
 
+	h.writeImmutabilityHeaders(w, r, container, blob)
 	writeBlobHeaders(w, info, info.Size)
 	w.WriteHeader(http.StatusOK)
 }
@@ -1234,6 +1251,11 @@ func setIfNonEmpty(w http.ResponseWriter, key, v string) {
 }
 
 func (h *Handler) deleteBlob(w http.ResponseWriter, r *http.Request, container, blob string) {
+	if r.URL.Query().Get("comp") == compImmutabilityPolicies {
+		h.deleteBlobImmutabilityPolicy(w, r, container, blob)
+		return
+	}
+
 	if versionID := r.URL.Query().Get("versionid"); versionID != "" {
 		h.deleteBlobVersion(w, r, container, blob, versionID)
 		return

--- a/server/azure/blobstorage/immutability.go
+++ b/server/azure/blobstorage/immutability.go
@@ -1,0 +1,145 @@
+package blobstorage
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+const (
+	headerImmutabilityUntil = "X-Ms-Immutability-Policy-Until-Date"
+	headerImmutabilityMode  = "X-Ms-Immutability-Policy-Mode"
+	headerLegalHold         = "X-Ms-Legal-Hold"
+)
+
+// setBlobImmutabilityPolicy handles PUT /{container}/{blob}?comp=immutabilityPolicies,
+// setting the blob's time-based retention immutability policy (Set Blob
+// Immutability Policy). The retain-until date comes from
+// x-ms-immutability-policy-until-date (RFC1123) and the mode from
+// x-ms-immutability-policy-mode (default Unlocked).
+func (h *Handler) setBlobImmutabilityPolicy(w http.ResponseWriter, r *http.Request, container, blob string) {
+	ext, ok := h.bucket.(storagedriver.AzureImmutableBlob)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "NotImplemented", "blob immutability policies are not supported")
+		return
+	}
+
+	untilRaw := r.Header.Get(headerImmutabilityUntil)
+	if untilRaw == "" {
+		writeError(w, http.StatusBadRequest, "MissingRequiredHeader",
+			"x-ms-immutability-policy-until-date is required")
+
+		return
+	}
+
+	until, err := http.ParseTime(strings.TrimSpace(untilRaw))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidHeaderValue",
+			"x-ms-immutability-policy-until-date must be an RFC1123 date")
+
+		return
+	}
+
+	policy, err := ext.SetBlobImmutabilityPolicy(r.Context(), container, blob, storagedriver.BlobImmutabilityPolicy{
+		ExpiryTime: until.UTC(),
+		Mode:       normalizeImmutabilityMode(r.Header.Get(headerImmutabilityMode)),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeImmutabilityPolicyHeaders(w, policy)
+	w.WriteHeader(http.StatusOK)
+}
+
+// deleteBlobImmutabilityPolicy handles DELETE /{container}/{blob}?comp=immutabilityPolicies,
+// removing an Unlocked immutability policy (Delete Blob Immutability Policy).
+func (h *Handler) deleteBlobImmutabilityPolicy(w http.ResponseWriter, r *http.Request, container, blob string) {
+	ext, ok := h.bucket.(storagedriver.AzureImmutableBlob)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "NotImplemented", "blob immutability policies are not supported")
+		return
+	}
+
+	if err := ext.DeleteBlobImmutabilityPolicy(r.Context(), container, blob); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// setBlobLegalHold handles PUT /{container}/{blob}?comp=legalhold, setting or
+// clearing the blob's legal hold (Set Blob Legal Hold) from x-ms-legal-hold.
+func (h *Handler) setBlobLegalHold(w http.ResponseWriter, r *http.Request, container, blob string) {
+	ext, ok := h.bucket.(storagedriver.AzureImmutableBlob)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "NotImplemented", "blob legal hold is not supported")
+		return
+	}
+
+	hold, err := strconv.ParseBool(strings.TrimSpace(r.Header.Get(headerLegalHold)))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidHeaderValue", "x-ms-legal-hold must be true or false")
+		return
+	}
+
+	if err := ext.SetBlobLegalHold(r.Context(), container, blob, hold); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.Header().Set(headerLegalHold, strconv.FormatBool(hold))
+	w.WriteHeader(http.StatusOK)
+}
+
+// writeImmutabilityHeaders sets the immutable-storage response headers
+// (x-ms-immutability-policy-until-date / -mode, x-ms-legal-hold) on a Get Blob /
+// Get Blob Properties response when the driver tracks blob immutability and the
+// blob carries a policy or hold. A missing capability or blob is silently
+// skipped — the read itself still succeeds.
+func (h *Handler) writeImmutabilityHeaders(w http.ResponseWriter, r *http.Request, container, blob string) {
+	ext, ok := h.bucket.(storagedriver.AzureImmutableBlob)
+	if !ok {
+		return
+	}
+
+	policy, legalHold, err := ext.BlobImmutability(r.Context(), container, blob)
+	if err != nil {
+		return
+	}
+
+	writeImmutabilityPolicyHeaders(w, policy)
+
+	if legalHold {
+		w.Header().Set(headerLegalHold, strconv.FormatBool(legalHold))
+	}
+}
+
+// writeImmutabilityPolicyHeaders emits the time-based policy headers for a
+// non-empty policy, using the lowercase mode value real Azure returns.
+func writeImmutabilityPolicyHeaders(w http.ResponseWriter, policy storagedriver.BlobImmutabilityPolicy) {
+	if policy.Mode == "" || policy.ExpiryTime.IsZero() {
+		return
+	}
+
+	w.Header().Set(headerImmutabilityUntil, policy.ExpiryTime.UTC().Format(http.TimeFormat))
+	w.Header().Set(headerImmutabilityMode, strings.ToLower(policy.Mode))
+}
+
+// normalizeImmutabilityMode maps the x-ms-immutability-policy-mode header
+// (case-insensitive, default Unlocked) to the driver's canonical mode value. An
+// unrecognized value is passed through so the driver rejects it.
+func normalizeImmutabilityMode(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "unlocked":
+		return storagedriver.BlobImmutabilityUnlocked
+	case "locked":
+		return storagedriver.BlobImmutabilityLocked
+	default:
+		return v
+	}
+}

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -382,6 +382,65 @@ type AzureSoftDeleteBlob interface {
 	ListDeletedBlobs(ctx context.Context, container string, opts ListOptions) (*DeletedBlobListResult, error)
 }
 
+// Blob-level immutability policy modes (x-ms-immutability-policy-mode). An empty
+// mode means no time-based immutability policy is set on the blob.
+const (
+	// BlobImmutabilityUnlocked is an editable time-based retention policy: the
+	// retain-until date may be increased or decreased, and the policy deleted.
+	BlobImmutabilityUnlocked = "Unlocked"
+	// BlobImmutabilityLocked is a permanent time-based retention policy: the
+	// retain-until date may only be extended (never shortened), and the policy
+	// can never be removed.
+	BlobImmutabilityLocked = "Locked"
+)
+
+// BlobImmutabilityPolicy is a blob-level (version-level) time-based retention
+// immutability policy: a retain-until instant and a mode (Unlocked/Locked). A
+// zero value (empty Mode, zero ExpiryTime) means no policy is set. While the
+// current time is before ExpiryTime the blob is protected from delete and
+// overwrite (WORM).
+type BlobImmutabilityPolicy struct {
+	ExpiryTime time.Time
+	Mode       string
+}
+
+// AzureImmutableBlob is an OPTIONAL Azure-specific capability, discovered by
+// type assertion, that ENFORCES blob immutable storage (WORM): a time-based
+// retention immutability policy (Set/Delete Blob Immutability Policy,
+// ?comp=immutabilityPolicies) and a legal hold (Set Blob Legal Hold,
+// ?comp=legalhold). While a blob has an unexpired immutability policy OR a legal
+// hold set, Delete Blob and any overwrite are rejected with the Azure 409
+// BlobImmutableDueToPolicy / BlobImmutableDueToLegalHold error. An Unlocked
+// policy may have its retain-until date raised or lowered and may be deleted; a
+// Locked policy may only be extended and can never be removed. S3/GCS don't
+// implement it (they carry their own object-lock/retention capabilities).
+//
+// Note: real Azure blob-level immutability builds on versioning, where an
+// overwrite creates a new version and leaves the protected version intact;
+// cloudemu models the container-level WORM semantics the world-case targets —
+// while protected, both delete and overwrite of the blob are blocked.
+type AzureImmutableBlob interface {
+	// SetBlobImmutabilityPolicy sets (or updates) the blob's time-based
+	// retention immutability policy and returns the effective policy. Setting a
+	// policy in the past is rejected. On an Unlocked policy the retain-until date
+	// may be raised or lowered and the mode may be promoted to Locked; on a
+	// Locked policy the date may only be extended and the mode can never revert
+	// to Unlocked — a disallowed change returns a FailedPrecondition error.
+	SetBlobImmutabilityPolicy(
+		ctx context.Context, container, blob string, policy BlobImmutabilityPolicy,
+	) (BlobImmutabilityPolicy, error)
+	// DeleteBlobImmutabilityPolicy removes the blob's immutability policy
+	// (allowed only while it is Unlocked; a Locked policy returns a
+	// FailedPrecondition error).
+	DeleteBlobImmutabilityPolicy(ctx context.Context, container, blob string) error
+	// SetBlobLegalHold sets or clears the blob's legal hold.
+	SetBlobLegalHold(ctx context.Context, container, blob string, hold bool) error
+	// BlobImmutability reports the blob's current immutability policy and legal
+	// hold, so Get Blob Properties can echo the x-ms-immutability-policy-* and
+	// x-ms-legal-hold headers.
+	BlobImmutability(ctx context.Context, container, blob string) (policy BlobImmutabilityPolicy, legalHold bool, err error)
+}
+
 // PageRange is one contiguous [Start,End] byte span (inclusive) of a page blob
 // that currently holds written data, as reported by Get Page Ranges.
 type PageRange struct {

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -430,8 +430,8 @@ type AzureImmutableBlob interface {
 		ctx context.Context, container, blob string, policy BlobImmutabilityPolicy,
 	) (BlobImmutabilityPolicy, error)
 	// DeleteBlobImmutabilityPolicy removes the blob's immutability policy
-	// (allowed only while it is Unlocked; a Locked policy returns a
-	// FailedPrecondition error).
+	// (allowed only while it is Unlocked; a Locked policy returns a 409
+	// BlobImmutableDueToPolicy error).
 	DeleteBlobImmutabilityPolicy(ctx context.Context, container, blob string) error
 	// SetBlobLegalHold sets or clears the blob's legal hold.
 	SetBlobLegalHold(ctx context.Context, container, blob string, hold bool) error


### PR DESCRIPTION
## Summary

Adds Azure Blob **immutable storage (WORM)** enforcement — the Azure half of the cross-provider WORM theme (S3 Object Lock #985, GCS retention #993 already merged).

Implements **blob-level (data-plane)** immutability via a new optional `AzureImmutableBlob` capability:

- **Time-based retention immutability policy** — `PUT/DELETE /{container}/{blob}?comp=immutabilityPolicies` (`x-ms-immutability-policy-until-date` RFC1123 + `x-ms-immutability-policy-mode` Unlocked/Locked). An Unlocked policy may be raised, lowered, or promoted to Locked, and deleted; a **Locked** policy may only be **extended** and can **never** be shortened, reverted, or removed.
- **Legal hold** — `PUT /{container}/{blob}?comp=legalhold` (`x-ms-legal-hold: true|false`).
- **Enforcement** — while a blob has an unexpired immutability policy **or** an active legal hold, **delete and overwrite are blocked** with the real Azure `409 BlobImmutableDueToPolicy` / `BlobImmutableDueToLegalHold` errors. Enforced across Delete Blob, Put Blob, Put Block List, Copy Blob, and Append Block.
- **Read echo** — Get Blob / Get Blob Properties emit `x-ms-immutability-policy-until-date/-mode` and `x-ms-legal-hold`.

Uses `config.Clock` throughout so the retention window is deterministic. New WORM fields on `blobObject` are guarded by the object mutex (locked reads on every enforcement check) and promoted into the persist snapshot.

### Level shipped vs deferred
- **Shipped:** blob-level (data-plane) immutability policy + legal hold — the in-scope data-plane surface.
- **Deferred:** container-level default immutability policy + container legal hold, which live in the ARM management plane (`server/azure/storageaccount`, out of scope for this PR).

### Note on semantics
Real Azure blob-level immutability builds on versioning, where an overwrite mints a new version and leaves the protected version intact. cloudemu models the container-level WORM semantics the world-case targets: while protected, both delete and overwrite of the blob are blocked.

## Tests
- Real `azblob` SDK e2e (`server/azure/blobstorage/blob_immutability_test.go`): unlocked policy blocks delete + overwrite within window and both are permitted once the FakeClock advances past retain-until; locked policy can be extended but not shortened/deleted; legal hold blocks delete + overwrite independent of any window, and lifting it restores mutability; Get Blob Properties echoes policy + hold.
- Provider-level unit tests (`providers/azure/blobstorage/immutability_test.go`).
- Regenerated `docs/coverage/`.

Gates: `go build ./...`, `gofmt` clean, `-race` clean on blobstorage + persist, broad `go test ./server/azure/...`, golangci-lint 0 new on touched packages, `go mod tidy` clean, coverage diff committed.