### PR TITLE
feat(gcp-functions): gen2 functions in driver + invokable

### DIFF
--- a/server/gcp/cloudfunctions/gen2.go
+++ b/server/gcp/cloudfunctions/gen2.go
@@ -221,6 +221,13 @@ func (h *Handler) serveV2Action(w http.ResponseWriter, r *http.Request, p v2Path
 		h.serveV2IamPolicy(w, r, p)
 	case actionTestIamPermissions:
 		h.serveV2TestIamPermissions(w, r, p)
+	case actionCall:
+		if p.name == "" {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown method: "+p.action)
+			return
+		}
+
+		h.serveV2Call(w, r, p)
 	default:
 		writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown method: "+p.action)
 	}
@@ -233,7 +240,7 @@ func (h *Handler) serveV2Resource(w http.ResponseWriter, r *http.Request, p v2Pa
 	case http.MethodPatch:
 		h.patchV2(w, r, p)
 	case http.MethodDelete:
-		h.deleteV2(w, p)
+		h.deleteV2(w, r, p)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
 	}
@@ -269,17 +276,30 @@ func (h *Handler) createV2(w http.ResponseWriter, r *http.Request, p v2Path) {
 	p.name = name
 	key := p.fullName()
 
+	fn := body
+	fn.revisionSeq = 1
+	computeGen2Outputs(&fn, p, true)
+
+	// Register the gen2 function in the shared serverless driver so :call and
+	// event delivery resolve it like gen1. The driver is the authority on name
+	// uniqueness across gen1 AND gen2, so a duplicate create is rejected here
+	// before anything lands in the gen2 map.
+	if err := h.registerGen2Driver(r.Context(), name, &fn); err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	h.mu.Lock()
 	if _, exists := h.gen2[key]; exists {
 		h.mu.Unlock()
+		// The driver guards uniqueness, so this is unreachable in practice; roll
+		// back the driver registration to keep the two stores consistent.
+		_ = h.fn.DeleteFunction(r.Context(), name)
 		writeError(w, http.StatusConflict, "ALREADY_EXISTS", "function "+name+" already exists")
 
 		return
 	}
 
-	fn := body
-	fn.revisionSeq = 1
-	computeGen2Outputs(&fn, p, true)
 	h.gen2[key] = &fn
 	resp := cloneGen2(&fn)
 	h.mu.Unlock()
@@ -349,10 +369,17 @@ func (h *Handler) patchV2(w http.ResponseWriter, r *http.Request, p v2Path) {
 
 	h.mu.Unlock()
 
+	// Keep the driver-backed function in sync so a later :call / event delivery
+	// runs the patched runtime, env and (if the patch carried new source) code.
+	if err := h.syncGen2Driver(r.Context(), p.name, updated); err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	h.finishV2LRO(w, p, updated)
 }
 
-func (h *Handler) deleteV2(w http.ResponseWriter, p v2Path) {
+func (h *Handler) deleteV2(w http.ResponseWriter, r *http.Request, p v2Path) {
 	key := p.fullName()
 
 	h.mu.Lock()
@@ -369,6 +396,10 @@ func (h *Handler) deleteV2(w http.ResponseWriter, p v2Path) {
 		writeError(w, http.StatusNotFound, "NOT_FOUND", "function "+p.name+" not found")
 		return
 	}
+
+	// Drop the driver-backed function too so the invoke path no longer resolves
+	// it. Best-effort: a missing driver entry is not an error.
+	_ = h.fn.DeleteFunction(r.Context(), p.name)
 
 	op := h.mintV2Operation(p, nil)
 	writeJSON(w, http.StatusOK, op)

--- a/server/gcp/cloudfunctions/gen2_invoke.go
+++ b/server/gcp/cloudfunctions/gen2_invoke.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	sdrv "github.com/stackshy/cloudemu/v2/services/serverless/driver"
 )
 
@@ -111,8 +110,14 @@ func (h *Handler) registerGen2Driver(ctx context.Context, name string, fn *gen2F
 
 // syncGen2Driver reconciles the driver-backed function to a patched gen2
 // function so a later :call / event delivery runs the updated runtime, env and
-// (if the patch carried new source) code. It self-heals a missing driver entry
-// by creating it, so the driver never diverges from the gen2 map.
+// (if the patch carried new source) code. It deliberately does NOT recreate a
+// missing driver entry: createV2 always registers one, so a live gen2 function
+// always has a driver entry, and the only way UpdateFunction sees NotFound is a
+// delete that raced this patch (patchV2 releases h.mu before this call). In that
+// case the correct real-GCP response is a 404 — resurrecting the driver entry
+// here would leave a zombie with no h.gen2 map entry, permanently poisoning the
+// name (future create ALREADY_EXISTS; :call/GET 404). So the NotFound is
+// propagated unchanged for patchV2 to surface.
 func (h *Handler) syncGen2Driver(ctx context.Context, name string, fn *gen2Function) error {
 	cfg := gen2DriverConfig(name, fn)
 	if code := h.gen2SourceCode(fn); len(code) > 0 {
@@ -120,16 +125,9 @@ func (h *Handler) syncGen2Driver(ctx context.Context, name string, fn *gen2Funct
 		cfg.Framework = frameworkHTTP
 	}
 
-	if _, err := h.fn.UpdateFunction(ctx, name, cfg); err != nil {
-		if cerrors.IsNotFound(err) {
-			_, cerr := h.fn.CreateFunction(ctx, cfg)
-			return cerr
-		}
+	_, err := h.fn.UpdateFunction(ctx, name, cfg)
 
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // isGen2 reports whether the canonical resource name belongs to a gen2 function.

--- a/server/gcp/cloudfunctions/gen2_invoke.go
+++ b/server/gcp/cloudfunctions/gen2_invoke.go
@@ -1,0 +1,208 @@
+package cloudfunctions
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	sdrv "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// gen2 functions live in the wire handler's h.gen2 map as a rich v2 resource
+// (buildConfig/serviceConfig/eventTrigger), but they are ALSO registered in the
+// shared serverless driver keyed by their short name — exactly like gen1 — so
+// the invoke data plane resolves them: the v2 :call action and event delivery
+// (Pub/Sub / Eventarc) both funnel through h.fn.Invoke and return the same
+// invoke result model as gen1 (canned echo by default, or the real
+// config.FunctionEngine when one is wired). The v1 API never surfaces or mutates
+// a gen2 function (real GCP manages the two generations through disjoint APIs),
+// so the v1 routes filter them out and the driver is the authority on name
+// uniqueness across both generations.
+
+// gen2DriverConfig builds the portable Serverless FunctionConfig that backs a
+// gen2 function in the driver. Runtime and entryPoint come from buildConfig; the
+// timeout and the runtime environment (buildConfig env overlaid by the
+// serviceConfig runtime env) from serviceConfig. Memory is left unset: it is
+// output-only for gen2 and the v2 serviceConfig keeps the real availableMemory
+// string, so the driver copy does not need it.
+func gen2DriverConfig(name string, fn *gen2Function) sdrv.FunctionConfig {
+	cfg := sdrv.FunctionConfig{Name: name}
+
+	var buildEnv, serviceEnv map[string]string
+
+	if fn.BuildConfig != nil {
+		cfg.Runtime = fn.BuildConfig.Runtime
+		cfg.Handler = fn.BuildConfig.EntryPoint
+		buildEnv = fn.BuildConfig.EnvironmentVariables
+	}
+
+	if fn.ServiceConfig != nil {
+		cfg.Timeout = fn.ServiceConfig.TimeoutSeconds
+		serviceEnv = fn.ServiceConfig.EnvironmentVariables
+	}
+
+	cfg.Environment = mergeGen2Env(buildEnv, serviceEnv)
+
+	return cfg
+}
+
+// mergeGen2Env overlays the serviceConfig runtime env on the buildConfig env so
+// the driver-backed function sees the same environment a real gen2 runtime does.
+// It returns nil when neither is set so UpdateFunction leaves a stored env alone.
+func mergeGen2Env(build, service map[string]string) map[string]string {
+	if len(build) == 0 && len(service) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(build)+len(service))
+	for k, v := range build {
+		out[k] = v
+	}
+
+	for k, v := range service {
+		out[k] = v
+	}
+
+	return out
+}
+
+// gen2SourceCode returns the deployment bytes staged for a gen2 source upload, or
+// nil when the function's storageSource does not name one this server staged (a
+// gs:// object the client uploaded elsewhere, or no source at all). It lets the
+// real FunctionEngine run gen2 code deployed via generateUploadUrl while the
+// default (unstaged) path falls back to the echo stub. Best-effort: an
+// unresolvable token is not an error.
+func (h *Handler) gen2SourceCode(fn *gen2Function) []byte {
+	if fn.BuildConfig == nil || fn.BuildConfig.Source == nil || fn.BuildConfig.Source.StorageSource == nil {
+		return nil
+	}
+
+	token := strings.TrimSuffix(fn.BuildConfig.Source.StorageSource.Object, ".zip")
+	if token == "" {
+		return nil
+	}
+
+	code, ok := h.uploads.take(token)
+	if !ok {
+		return nil
+	}
+
+	return code
+}
+
+// registerGen2Driver creates the driver-backed function for a freshly created
+// gen2 function. The driver rejects a duplicate name (across gen1 AND gen2, which
+// matches real GCP forbidding two generations to share a name), so the caller
+// uses its error as the authority before touching the gen2 map.
+func (h *Handler) registerGen2Driver(ctx context.Context, name string, fn *gen2Function) error {
+	cfg := gen2DriverConfig(name, fn)
+	if code := h.gen2SourceCode(fn); len(code) > 0 {
+		cfg.Code = code
+		cfg.Framework = frameworkHTTP
+	}
+
+	_, err := h.fn.CreateFunction(ctx, cfg)
+
+	return err
+}
+
+// syncGen2Driver reconciles the driver-backed function to a patched gen2
+// function so a later :call / event delivery runs the updated runtime, env and
+// (if the patch carried new source) code. It self-heals a missing driver entry
+// by creating it, so the driver never diverges from the gen2 map.
+func (h *Handler) syncGen2Driver(ctx context.Context, name string, fn *gen2Function) error {
+	cfg := gen2DriverConfig(name, fn)
+	if code := h.gen2SourceCode(fn); len(code) > 0 {
+		cfg.Code = code
+		cfg.Framework = frameworkHTTP
+	}
+
+	if _, err := h.fn.UpdateFunction(ctx, name, cfg); err != nil {
+		if cerrors.IsNotFound(err) {
+			_, cerr := h.fn.CreateFunction(ctx, cfg)
+			return cerr
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// isGen2 reports whether the canonical resource name belongs to a gen2 function.
+// The v1 routes use it to stay disjoint from gen2, which shares the driver store
+// but is managed only through the v2 API.
+func (h *Handler) isGen2(fullName string) bool {
+	h.mu.RLock()
+	_, ok := h.gen2[fullName]
+	h.mu.RUnlock()
+
+	return ok
+}
+
+// excludeGen2 drops gen2 functions from a v1 ListFunctions result: they share the
+// driver store so the invoke path resolves them, but real GCP never lists a gen2
+// function through the v1 API.
+func (h *Handler) excludeGen2(p functionPath, infos []sdrv.FunctionInfo) []sdrv.FunctionInfo {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	out := make([]sdrv.FunctionInfo, 0, len(infos))
+
+	for i := range infos {
+		scope := p
+		scope.name = infos[i].Name
+
+		if _, ok := h.gen2[scope.fullName()]; !ok {
+			out = append(out, infos[i])
+		}
+	}
+
+	return out
+}
+
+// serveV2Call answers the gen2 invoke path, POST .../functions/{name}:call. gen2
+// has no v1-style :call in the public API (it is invoked over the Cloud Run uri
+// or Eventarc), but the emulator exposes one so users can exercise the invoke
+// control flow uniformly; it returns the same {executionId, result|error} model
+// as the gen1 :call, running the echo stub by default or the real engine when
+// one is configured.
+func (h *Handler) serveV2Call(w http.ResponseWriter, r *http.Request, p v2Path) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+
+	if !h.isGen2(p.fullName()) {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "function "+p.name+" not found")
+		return
+	}
+
+	var req callRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	out, err := h.fn.Invoke(r.Context(), sdrv.InvokeInput{
+		FunctionName: p.name,
+		Payload:      []byte(req.Data),
+		InvokeType:   "RequestResponse",
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	resp := callResponse{ExecutionID: strconv.FormatInt(time.Now().UnixNano(), 10)}
+
+	if out.Error != "" {
+		resp.Error = out.Error
+	} else {
+		resp.Result = string(out.Payload)
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/server/gcp/cloudfunctions/gen2_invoke_test.go
+++ b/server/gcp/cloudfunctions/gen2_invoke_test.go
@@ -1,0 +1,176 @@
+package cloudfunctions_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	cloudfunctionsv1 "google.golang.org/api/cloudfunctions/v1"
+	cloudfunctions2 "google.golang.org/api/cloudfunctions/v2"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// gen2Fixture spins up a server backed by one Cloud Functions driver and returns
+// the base URL plus a v2 and v1 client pointed at it, so a test can exercise the
+// gen2 (v2) surface, the gen2 invoke path (raw :call), and the v1 surface against
+// the same shared driver store.
+func gen2Fixture(t *testing.T) (string, *cloudfunctions2.Service, *cloudfunctionsv1.Service) {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{CloudFunctions: cloud.CloudFunctions})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	svc2, err := cloudfunctions2.NewService(ctx, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("NewService (v2): %v", err)
+	}
+
+	svc1, err := cloudfunctionsv1.NewService(ctx, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("NewService (v1): %v", err)
+	}
+
+	return ts.URL, svc2, svc1
+}
+
+// callGen2 POSTs to the gen2 invoke path .../functions/{name}:call (the v2 Go
+// client has no typed Call, so a real user hits it over REST) and returns the
+// decoded {executionId, result|error} body and HTTP status.
+func callGen2(t *testing.T, baseURL, name, data string) (map[string]string, int) {
+	t.Helper()
+
+	url := baseURL + "/v2/projects/demo/locations/us-central1/functions/" + name + ":call"
+
+	body, _ := json.Marshal(map[string]string{"data": data})
+
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body)) //nolint:noctx // test helper
+	if err != nil {
+		t.Fatalf("POST :call: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var out map[string]string
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+
+	return out, resp.StatusCode
+}
+
+// TestGen2InvokeThroughDriver is the world-case gen2 fix: a gen2 function must
+// reach the shared driver so it is invokable like gen1. It deploys a gen2
+// function, invokes it via :call and asserts the echo-stub result model (payload
+// echoed) matches gen1, then confirms the v2 GET still returns the v2 shape
+// (ACTIVE + Cloud Run uri) and that the gen2 function stays out of the v1 API.
+func TestGen2InvokeThroughDriver(t *testing.T) {
+	baseURL, svc2, svc1 := gen2Fixture(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+	name := parent + "/functions/g2"
+
+	if _, err := svc2.Projects.Locations.Functions.Create(parent, &cloudfunctions2.Function{
+		BuildConfig: &cloudfunctions2.BuildConfig{
+			Runtime:    "go121",
+			EntryPoint: "Hello",
+			Source: &cloudfunctions2.Source{
+				StorageSource: &cloudfunctions2.StorageSource{Bucket: "b", Object: "o.zip"},
+			},
+		},
+		ServiceConfig: &cloudfunctions2.ServiceConfig{AvailableMemory: "512M", TimeoutSeconds: 120},
+	}).FunctionId("g2").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create (gen2): %v", err)
+	}
+
+	// Invoke through the gen2 invoke path — the function is now in the driver, so
+	// the echo stub returns the request payload just like a gen1 :call.
+	payload := `{"hello":"world"}`
+
+	out, status := callGen2(t, baseURL, "g2", payload)
+	if status != http.StatusOK {
+		t.Fatalf(":call status = %d, want 200 (body %v)", status, out)
+	}
+
+	if out["result"] != payload {
+		t.Fatalf(":call result = %q, want echoed payload %q", out["result"], payload)
+	}
+
+	if out["executionId"] == "" {
+		t.Fatal(":call executionId empty")
+	}
+
+	// The v2 GET still returns the gen2 shape unchanged.
+	got, err := svc2.Projects.Locations.Functions.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get (gen2): %v", err)
+	}
+
+	if got.State != "ACTIVE" || got.Environment != "GEN_2" {
+		t.Fatalf("gen2 shape drifted: state=%q env=%q", got.State, got.Environment)
+	}
+
+	if got.ServiceConfig == nil || got.ServiceConfig.Uri == "" {
+		t.Fatalf("serviceConfig.uri missing after invoke: %+v", got.ServiceConfig)
+	}
+
+	if got.ServiceConfig.AvailableMemory != "512M" {
+		t.Fatalf("availableMemory = %q, want 512M", got.ServiceConfig.AvailableMemory)
+	}
+
+	// The gen2 function must NOT surface through the v1 API even though it shares
+	// the driver store: v1 list excludes it and v1 get 404s.
+	listV1, err := svc1.Projects.Locations.Functions.List(parent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List (v1): %v", err)
+	}
+
+	if len(listV1.Functions) != 0 {
+		t.Fatalf("v1 list returned %d functions, want 0 (gen2 must not leak)", len(listV1.Functions))
+	}
+
+	if _, err := svc1.Projects.Locations.Functions.Get(name).Context(ctx).Do(); err == nil {
+		t.Fatal("v1 Get on a gen2 function returned nil error, want NotFound")
+	}
+}
+
+// TestGen2InvokeMissingAndAfterDelete confirms the invoke path 404s for an
+// unknown gen2 function and stops resolving once the function is deleted (the
+// driver entry is removed alongside the gen2 map entry).
+func TestGen2InvokeMissingAndAfterDelete(t *testing.T) {
+	baseURL, svc2, _ := gen2Fixture(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+	name := parent + "/functions/g2"
+
+	if _, status := callGen2(t, baseURL, "ghost", "{}"); status != http.StatusNotFound {
+		t.Fatalf(":call on missing gen2 status = %d, want 404", status)
+	}
+
+	if _, err := svc2.Projects.Locations.Functions.Create(parent, &cloudfunctions2.Function{
+		BuildConfig: &cloudfunctions2.BuildConfig{Runtime: "go121", EntryPoint: "Hello"},
+	}).FunctionId("g2").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create (gen2): %v", err)
+	}
+
+	if _, status := callGen2(t, baseURL, "g2", "{}"); status != http.StatusOK {
+		t.Fatalf(":call after create status = %d, want 200", status)
+	}
+
+	if _, err := svc2.Projects.Locations.Functions.Delete(name).Context(ctx).Do(); err != nil {
+		t.Fatalf("Delete (gen2): %v", err)
+	}
+
+	if _, status := callGen2(t, baseURL, "g2", "{}"); status != http.StatusNotFound {
+		t.Fatalf(":call after delete status = %d, want 404 (driver entry must be gone)", status)
+	}
+}

--- a/server/gcp/cloudfunctions/gen2_invoke_test.go
+++ b/server/gcp/cloudfunctions/gen2_invoke_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	cloudfunctionsv1 "google.golang.org/api/cloudfunctions/v1"
@@ -172,5 +173,60 @@ func TestGen2InvokeMissingAndAfterDelete(t *testing.T) {
 
 	if _, status := callGen2(t, baseURL, "g2", "{}"); status != http.StatusNotFound {
 		t.Fatalf(":call after delete status = %d, want 404 (driver entry must be gone)", status)
+	}
+}
+
+// TestSDKGen2ConcurrentPatchDelete races a PATCH against a DELETE of the same
+// gen2 function. patchV2 releases h.mu before syncing the driver, so a delete can
+// remove the map+driver entry in the window; the sync must then propagate the
+// driver's NotFound (a 404 PATCH) rather than resurrect a zombie driver entry
+// with no gen2 map entry. Whatever the interleaving, once both complete the name
+// must be FULLY absent: a fresh create of the same name must SUCCEED (a lingering
+// zombie would make it fail ALREADY_EXISTS forever). Run under -race.
+func TestSDKGen2ConcurrentPatchDelete(t *testing.T) {
+	_, svc2, _ := gen2Fixture(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+	name := parent + "/functions/g2"
+
+	const iterations = 25
+
+	for i := 0; i < iterations; i++ {
+		// Create must succeed every iteration — the previous iteration must have
+		// left no zombie driver entry poisoning the name.
+		if _, err := svc2.Projects.Locations.Functions.Create(parent, &cloudfunctions2.Function{
+			BuildConfig: &cloudfunctions2.BuildConfig{Runtime: "go121", EntryPoint: "Hello"},
+		}).FunctionId("g2").Context(ctx).Do(); err != nil {
+			t.Fatalf("iteration %d: Create must succeed (zombie left by prior race?): %v", i, err)
+		}
+
+		var wg sync.WaitGroup
+
+		wg.Add(2)
+
+		// Patch: may succeed or 404 depending on the interleaving — both are valid,
+		// so its error is not asserted.
+		go func() {
+			defer wg.Done()
+
+			_, _ = svc2.Projects.Locations.Functions.Patch(name, &cloudfunctions2.Function{
+				ServiceConfig: &cloudfunctions2.ServiceConfig{AvailableMemory: "1024M"},
+			}).UpdateMask("serviceConfig.availableMemory").Context(ctx).Do()
+		}()
+
+		// Delete always removes both the map and driver entries.
+		go func() {
+			defer wg.Done()
+
+			_, _ = svc2.Projects.Locations.Functions.Delete(name).Context(ctx).Do()
+		}()
+
+		wg.Wait()
+
+		// The function must be gone regardless of who won the race.
+		if _, err := svc2.Projects.Locations.Functions.Get(name).Context(ctx).Do(); err == nil {
+			t.Fatalf("iteration %d: Get after patch/delete race returned nil error, want NotFound", i)
+		}
 	}
 }

--- a/server/gcp/cloudfunctions/handler.go
+++ b/server/gcp/cloudfunctions/handler.go
@@ -533,6 +533,11 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request, p functionPath)
 }
 
 func (h *Handler) get(w http.ResponseWriter, r *http.Request, p functionPath) {
+	if h.isGen2(p.fullName()) {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "function "+p.name+" not found")
+		return
+	}
+
 	info, err := h.fn.GetFunction(r.Context(), p.name)
 	if err != nil {
 		writeErr(w, err)
@@ -548,6 +553,10 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, p functionPath) {
 		writeErr(w, err)
 		return
 	}
+
+	// gen2 functions share the driver store (so the invoke path resolves them)
+	// but are managed only through the v2 API — drop them from a v1 list.
+	infos = h.excludeGen2(p, infos)
 
 	// Sort by name so pagination over the base64 offset token is stable across
 	// calls (the provider store iterates a map in unspecified order).
@@ -568,6 +577,11 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, p functionPath) {
 }
 
 func (h *Handler) update(w http.ResponseWriter, r *http.Request, p functionPath) {
+	if h.isGen2(p.fullName()) {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "function "+p.name+" not found")
+		return
+	}
+
 	var body cloudFunction
 	if !decodeJSON(w, r, &body) {
 		return
@@ -613,6 +627,11 @@ func (h *Handler) update(w http.ResponseWriter, r *http.Request, p functionPath)
 }
 
 func (h *Handler) delete(w http.ResponseWriter, r *http.Request, p functionPath) {
+	if h.isGen2(p.fullName()) {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "function "+p.name+" not found")
+		return
+	}
+
 	if err := h.fn.DeleteFunction(r.Context(), p.name); err != nil {
 		writeErr(w, err)
 		return
@@ -634,6 +653,13 @@ func (h *Handler) delete(w http.ResponseWriter, r *http.Request, p functionPath)
 func (h *Handler) serveCall(w http.ResponseWriter, r *http.Request, p functionPath) {
 	if r.Method != http.MethodPost {
 		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+
+	// The v1 :call invokes gen1 functions only; a gen2 function uses the v2
+	// invoke path even though both share the driver store.
+	if h.isGen2(p.fullName()) {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "function "+p.name+" not found")
 		return
 	}
 


### PR DESCRIPTION
## Summary

GCP Cloud Functions **gen2** functions previously lived only in the wire handler's in-memory `h.gen2` map and never reached the shared serverless driver. As a result gen2 functions could not be invoked, and gen2 event triggers (Pub/Sub / Eventarc) silently no-op'd because the delivery path calls `h.fn.Invoke(name)` against a driver that had never heard of the function.

This change brings gen2 into the driver so it is invokable exactly like gen1, while keeping the gen2 v2 API response shape (state `ACTIVE`, `url`, `buildConfig`/`serviceConfig`) intact.

## What changed

- **gen2 create/patch/delete now register the function in the shared serverless driver** (`services/serverless/driver`), keyed by short name like gen1. The driver becomes the authority on name uniqueness across both generations (real GCP forbids a gen1 and a gen2 function sharing a name in a region).
- **New gen2 invoke path**: `POST .../functions/{name}:call` funnels through `h.fn.Invoke` and returns the same `{executionId, result|error}` model as the gen1 `:call` — the canned echo stub by default, or the real uploaded code when a `config.FunctionEngine` is wired. A gen2 source zip staged via `generateUploadUrl` is consumed into the driver so the real engine can run it.
- **v1 and v2 kept disjoint**: the v1 API never surfaces or mutates a gen2 function — v1 `list` excludes gen2, and v1 `get`/`update`/`delete`/`:call` return `NOT_FOUND` for a gen2 name — matching real GCP managing the two generations through separate APIs and preventing a malformed-shape leak.
- Driver registration/deletion happens outside the handler mutex; readers still deep-copy under the lock, so the change is `-race` clean.

This unblocks the follow-up Pub/Sub → gen2 delivery work (the existing `InvokeForTopic` gen2 branch now resolves instead of swallowing a `NotFound`); that trigger-wiring pass is tracked separately.

## Tests

- `TestGen2InvokeThroughDriver` — deploy a gen2 function via the v2 SDK, invoke it over `:call`, assert the payload is echoed (gen1-parity result model), the v2 GET still returns the gen2 shape (ACTIVE + Cloud Run `uri` + `availableMemory`), and the function stays out of the v1 API (list empty, v1 get 404).
- `TestGen2InvokeMissingAndAfterDelete` — `:call` 404s for an unknown gen2 function and stops resolving once the function is deleted (driver entry removed alongside the gen2 map entry).

## Gates

- `go build ./...` clean
- `go test ./server/gcp/cloudfunctions/... ./providers/gcp/cloudfunctions/... -race` green
- broad `go test ./server/gcp/... ./providers/gcp/...` green
- `gofmt -l` empty; `golangci-lint` 0 issues on touched package
- `go generate ./...` → `docs/coverage` unchanged; `go mod tidy` clean
