### PR TITLE
feat(azure-functions): Queue Storage trigger delivery invokes the function

### DIFF
--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -234,6 +234,11 @@ func New(opts ...config.Option) *Provider {
 	p.EventGrid.SetMonitoring(p.Monitor)
 	p.EventGrid.SetServiceBusDeliverer(p.ServiceBus)
 	p.EventGrid.SetFunctionInvoker(p.Functions)
+	// Native trigger delivery: a message enqueued to a Storage queue or Service
+	// Bus queue invokes any function whose function.json declares the matching
+	// trigger binding (queueTrigger / serviceBusTrigger) for that queue.
+	p.QueueStorage.SetFunctionTriggerSink(p.Functions, "queueTrigger")
+	p.ServiceBus.SetFunctionTriggerSink(p.Functions, "serviceBusTrigger")
 	p.BlobStorage.SetEventGridPublisher(p.EventGrid)
 	p.SQL.SetMonitoring(p.Monitor)
 	p.PostgresFlex.SetMonitoring(p.Monitor)

--- a/providers/azure/functions/queue_trigger.go
+++ b/providers/azure/functions/queue_trigger.go
@@ -1,0 +1,103 @@
+package functions
+
+import (
+	"context"
+	"sort"
+
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+)
+
+// DeliverFunctionTrigger invokes every deployed function whose function.json
+// declares an input trigger binding of bindingType (queueTrigger for Queue
+// Storage, serviceBusTrigger for Service Bus) bound to queueName, passing body
+// as the invocation payload. It is the cross-service seam the Azure Queue
+// Storage / Service Bus mocks call when a message is enqueued, mirroring how
+// Event Grid delivery calls InvokeExternal.
+//
+// Delivery is synchronous and recursion-guarded: a function that re-enqueues to
+// its own trigger queue would otherwise invoke itself unbounded. InvokeExternal
+// increments the ctx depth per invocation and drops once recursionguard.MaxDepth
+// is reached; the early check here also short-circuits the binding scan.
+func (m *Mock) DeliverFunctionTrigger(ctx context.Context, bindingType, queueName string, body []byte) {
+	if bindingType == "" || queueName == "" {
+		return
+	}
+
+	if recursionguard.Depth(ctx) >= recursionguard.MaxDepth {
+		return
+	}
+
+	for _, app := range m.appsBoundToQueue(bindingType, queueName) {
+		_ = m.InvokeExternal(ctx, app, body)
+	}
+}
+
+// appsBoundToQueue returns, sorted for deterministic delivery order, the names of
+// the function apps that have at least one deployed function whose bindings
+// include a matching input trigger.
+func (m *Mock) appsBoundToQueue(bindingType, queueName string) []string {
+	m.sitesMu.RLock()
+	defer m.sitesMu.RUnlock()
+
+	var apps []string
+
+	for _, meta := range m.sites.All() {
+		if siteHasQueueTrigger(meta, bindingType, queueName) {
+			apps = append(apps, meta.Name)
+		}
+	}
+
+	sort.Strings(apps)
+
+	return apps
+}
+
+// siteHasQueueTrigger reports whether any non-disabled function of the site
+// declares a matching trigger binding.
+func siteHasQueueTrigger(meta *SiteMeta, bindingType, queueName string) bool {
+	for _, fn := range meta.Functions {
+		if fn.IsDisabled {
+			continue
+		}
+
+		if bindingMatchesQueue(fn.Config, bindingType, queueName) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// bindingMatchesQueue reports whether a deployed function's function.json config
+// declares an input trigger of bindingType bound to queueName. Azure discovers
+// these bindings from the deployed code; here they arrive verbatim in the ARM
+// CreateFunction body's "config" object.
+func bindingMatchesQueue(config map[string]any, bindingType, queueName string) bool {
+	bindings, ok := config["bindings"].([]any)
+	if !ok {
+		return false
+	}
+
+	for _, raw := range bindings {
+		b, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if t, _ := b["type"].(string); t != bindingType {
+			continue
+		}
+
+		// A *Trigger binding is direction "in"; treat an omitted direction as "in"
+		// (trigger bindings always are) and skip an explicit output binding.
+		if dir, ok := b["direction"].(string); ok && dir != "in" {
+			continue
+		}
+
+		if qn, _ := b["queueName"].(string); qn == queueName {
+			return true
+		}
+	}
+
+	return false
+}

--- a/providers/azure/functions/queue_trigger_test.go
+++ b/providers/azure/functions/queue_trigger_test.go
@@ -1,0 +1,148 @@
+package functions
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// queueTriggerConfig builds a function.json-shaped config declaring a single
+// input trigger binding of the given type bound to queueName.
+func queueTriggerConfig(bindingType, queueName string) map[string]any {
+	return map[string]any{
+		"bindings": []any{
+			map[string]any{
+				"name":       "item",
+				"type":       bindingType,
+				"direction":  "in",
+				"queueName":  queueName,
+				"connection": "AzureWebJobsStorage",
+			},
+		},
+	}
+}
+
+// seedTriggeredApp creates the portable function app plus its SiteMeta and one
+// deployed function carrying the supplied binding config, then registers a Go
+// handler that records each invocation's payload. The returned pointers observe
+// invocations.
+func seedTriggeredApp(
+	t *testing.T, m *Mock, app string, cfg map[string]any,
+) (*int32, *[]byte) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: app, Runtime: "node"})
+	require.NoError(t, err)
+
+	_, err = m.UpsertSiteMeta(ctx, SiteMeta{Name: app, Subscription: "sub", ResourceGroup: "rg"})
+	require.NoError(t, err)
+
+	_, _, err = m.CreateSiteFunction(ctx, app, SiteFunction{Name: "fn1", Config: cfg})
+	require.NoError(t, err)
+
+	var count int32
+
+	var last []byte
+
+	m.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		atomic.AddInt32(&count, 1)
+		last = append([]byte(nil), payload...)
+
+		return payload, nil
+	})
+
+	return &count, &last
+}
+
+func TestDeliverFunctionTriggerInvokesBoundApp(t *testing.T) {
+	m := newTestMock()
+	count, last := seedTriggeredApp(t, m, "orders-app", queueTriggerConfig("queueTrigger", "orders"))
+
+	m.DeliverFunctionTrigger(context.Background(), "queueTrigger", "orders", []byte("hello"))
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(count), "bound function should fire exactly once")
+	assert.Equal(t, "hello", string(*last), "function should receive the enqueued message body")
+}
+
+func TestDeliverFunctionTriggerNoMatch(t *testing.T) {
+	m := newTestMock()
+	count, _ := seedTriggeredApp(t, m, "orders-app", queueTriggerConfig("queueTrigger", "orders"))
+
+	// Different queue name, wrong binding type, and empty inputs must all no-op.
+	m.DeliverFunctionTrigger(context.Background(), "queueTrigger", "other-queue", []byte("x"))
+	m.DeliverFunctionTrigger(context.Background(), "serviceBusTrigger", "orders", []byte("x"))
+	m.DeliverFunctionTrigger(context.Background(), "", "orders", []byte("x"))
+	m.DeliverFunctionTrigger(context.Background(), "queueTrigger", "", []byte("x"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(count))
+}
+
+func TestDeliverFunctionTriggerServiceBusBinding(t *testing.T) {
+	m := newTestMock()
+	count, _ := seedTriggeredApp(t, m, "sb-app", queueTriggerConfig("serviceBusTrigger", "jobs"))
+
+	m.DeliverFunctionTrigger(context.Background(), "serviceBusTrigger", "jobs", []byte("j"))
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(count))
+}
+
+func TestDeliverFunctionTriggerSkipsDisabledFunction(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "disabled-app", Runtime: "node"})
+	require.NoError(t, err)
+	_, err = m.UpsertSiteMeta(ctx, SiteMeta{Name: "disabled-app", Subscription: "sub", ResourceGroup: "rg"})
+	require.NoError(t, err)
+	_, _, err = m.CreateSiteFunction(ctx, "disabled-app", SiteFunction{
+		Name: "fn1", Config: queueTriggerConfig("queueTrigger", "orders"), IsDisabled: true,
+	})
+	require.NoError(t, err)
+
+	var count int32
+
+	m.RegisterHandler("disabled-app", func(_ context.Context, p []byte) ([]byte, error) {
+		atomic.AddInt32(&count, 1)
+
+		return p, nil
+	})
+
+	m.DeliverFunctionTrigger(ctx, "queueTrigger", "orders", []byte("x"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&count), "a disabled function must not fire")
+}
+
+func TestDeliverFunctionTriggerOutputBindingIgnored(t *testing.T) {
+	m := newTestMock()
+
+	// An output ("out") binding to the queue is not a trigger and must not fire.
+	cfg := map[string]any{
+		"bindings": []any{
+			map[string]any{"name": "out", "type": "queue", "direction": "out", "queueName": "orders"},
+		},
+	}
+	count, _ := seedTriggeredApp(t, m, "producer-app", cfg)
+
+	m.DeliverFunctionTrigger(context.Background(), "queueTrigger", "orders", []byte("x"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(count))
+}
+
+// TestDeliverFunctionTriggerRecursionGuard proves a re-entrant delivery already
+// at MaxDepth is dropped without invoking the function.
+func TestDeliverFunctionTriggerRecursionGuard(t *testing.T) {
+	m := newTestMock()
+	count, _ := seedTriggeredApp(t, m, "loop-app", queueTriggerConfig("queueTrigger", "loop"))
+
+	ctx := recursionguard.WithDepth(context.Background(), recursionguard.MaxDepth)
+	m.DeliverFunctionTrigger(ctx, "queueTrigger", "loop", []byte("x"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(count), "delivery at MaxDepth must be dropped")
+}

--- a/providers/azure/servicebus/function_trigger_sink_test.go
+++ b/providers/azure/servicebus/function_trigger_sink_test.go
@@ -1,0 +1,75 @@
+package servicebus
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingSink struct {
+	calls    int
+	binding  string
+	queue    string
+	lastBody string
+}
+
+func (s *recordingSink) DeliverFunctionTrigger(_ context.Context, bindingType, queueName string, body []byte) {
+	s.calls++
+	s.binding = bindingType
+	s.queue = queueName
+	s.lastBody = string(body)
+}
+
+func TestSendMessageDispatchesFunctionTriggerSink(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+	url := createStdQueue(t, m)
+
+	sink := &recordingSink{}
+	m.SetFunctionTriggerSink(sink, "queueTrigger")
+
+	_, err := m.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "payload"})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, sink.calls)
+	assert.Equal(t, "queueTrigger", sink.binding)
+	assert.Equal(t, "test-queue", sink.queue, "the sink receives the queue name, not its URL")
+	assert.Equal(t, "payload", sink.lastBody)
+}
+
+func TestSendMessageNoSinkIsNoop(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+	url := createStdQueue(t, m)
+
+	// No sink wired: enqueue must still succeed.
+	_, err := m.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "payload"})
+	require.NoError(t, err)
+}
+
+// TestFIFODuplicateDoesNotDispatch proves a silently-accepted duplicate send
+// (not re-enqueued) fires no trigger sink.
+func TestFIFODuplicateDoesNotDispatch(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "jobs.fifo", FIFO: true})
+	require.NoError(t, err)
+
+	sink := &recordingSink{}
+	m.SetFunctionTriggerSink(sink, "serviceBusTrigger")
+
+	in := driver.SendMessageInput{QueueURL: info.URL, Body: "x", GroupID: "g", DeduplicationID: "d1"}
+
+	_, err = m.SendMessage(ctx, in)
+	require.NoError(t, err)
+
+	// Same DeduplicationID within the window: accepted but not re-enqueued.
+	_, err = m.SendMessage(ctx, in)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, sink.calls, "duplicate send must not dispatch a second trigger")
+}

--- a/providers/azure/servicebus/servicebus.go
+++ b/providers/azure/servicebus/servicebus.go
@@ -97,6 +97,16 @@ type sessionState struct {
 // FunctionTrigger is a function that gets called when a message is sent to a queue.
 type FunctionTrigger func(queueURL string, message driver.Message)
 
+// FunctionTriggerSink delivers a message enqueued to a queue to any Azure
+// Function bound to that queue by a trigger binding (queueTrigger for Queue
+// Storage, serviceBusTrigger for Service Bus). The Azure Functions provider
+// implements it. It is wired per Mock instance via SetFunctionTriggerSink so the
+// distinct Queue Storage and Service Bus instances each dispatch their own
+// binding type, mirroring how Event Grid delivery calls InvokeExternal.
+type FunctionTriggerSink interface {
+	DeliverFunctionTrigger(ctx context.Context, bindingType, queueName string, body []byte)
+}
+
 // Mock is an in-memory mock implementation of the Azure Service Bus service.
 type Mock struct {
 	queues     *memstore.Store[*queueData]
@@ -104,6 +114,11 @@ type Mock struct {
 	mu         sync.RWMutex
 	triggers   map[string]FunctionTrigger // queueURL -> trigger
 	monitoring mondriver.Monitoring
+	// funcSink and triggerBinding wire automatic Azure Function trigger delivery:
+	// on each enqueue, funcSink is asked to invoke any function whose function.json
+	// declares a triggerBinding-typed binding for the queue. Both are guarded by mu.
+	funcSink       FunctionTriggerSink
+	triggerBinding string
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -156,6 +171,21 @@ func (m *Mock) RemoveTrigger(queueURL string) {
 	defer m.mu.Unlock()
 
 	delete(m.triggers, queueURL)
+}
+
+// SetFunctionTriggerSink wires the Azure Functions provider as the destination
+// for this queue surface's automatic trigger deliveries. bindingType is the
+// function.json trigger type this surface fires — "queueTrigger" for Queue
+// Storage, "serviceBusTrigger" for Service Bus — so only functions bound with
+// the matching trigger are invoked. A nil sink disables trigger delivery (the
+// default). This is the cross-service seam, analogous to Event Grid's
+// SetFunctionInvoker.
+func (m *Mock) SetFunctionTriggerSink(sink FunctionTriggerSink, bindingType string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.funcSink = sink
+	m.triggerBinding = bindingType
 }
 
 // DeliverExternal enqueues body into the queue or topic whose name matches the
@@ -317,49 +347,98 @@ func (m *Mock) ListQueues(_ context.Context, prefix string) ([]driver.QueueInfo,
 // SendMessage sends a message to the specified Service Bus queue.
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
-func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*driver.SendMessageOutput, error) {
+func (m *Mock) SendMessage(ctx context.Context, input driver.SendMessageInput) (*driver.SendMessageOutput, error) {
 	qd, ok := m.queues.Get(input.QueueURL)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "queue %q not found", input.QueueURL)
 	}
 
+	res, err := m.enqueueLocked(qd, &input)
+	if err != nil {
+		return nil, err
+	}
+
+	// A duplicate send is silently accepted but not re-enqueued, so it fires no
+	// trigger and emits no incoming-message metric.
+	if res.msg == nil {
+		return &driver.SendMessageOutput{MessageID: res.dupID}, nil
+	}
+
+	// Triggers run AFTER the queue lock is released: a function invoked by a
+	// trigger may re-enqueue to this same queue, which would deadlock on the
+	// non-reentrant qd.mu if fired while it is still held. The recursion guard
+	// threaded through ctx bounds any self-referential enqueue→invoke→enqueue
+	// chain (see dispatchFunctionTrigger / lambda.InvokeExternal).
+	m.fireTrigger(input.QueueURL, res.msg)
+	m.dispatchFunctionTrigger(ctx, res.queueName, res.msg)
+
+	m.emitMetric(res.queueName, map[string]float64{
+		"IncomingMessages": 1, "Size": float64(len(input.Body)),
+	})
+
+	return &driver.SendMessageOutput{
+		MessageID:  res.msg.ID,
+		ExpiresAt:  res.msg.ExpiresAt,
+		PopReceipt: res.msg.ReceiptHandle,
+	}, nil
+}
+
+// enqueueResult carries what SendMessage needs after the queue lock is released:
+// the stored message and the queue's name for trigger dispatch. A nil msg with a
+// non-empty dupID means the send was a silently-accepted duplicate that was not
+// re-enqueued (so it fires no trigger).
+type enqueueResult struct {
+	msg       *sbMessage
+	queueName string
+	dupID     string
+}
+
+// enqueueLocked validates and appends one message under the queue lock.
+func (m *Mock) enqueueLocked(qd *queueData, input *driver.SendMessageInput) (enqueueResult, error) {
 	qd.mu.Lock()
 	defer qd.mu.Unlock()
 
-	if err := validateFIFORequirements(qd, &input); err != nil {
-		return nil, err
+	if err := validateFIFORequirements(qd, input); err != nil {
+		return enqueueResult{}, err
 	}
 
 	// A session-enabled entity requires every message to carry a SessionId (real
 	// Azure rejects a session-less send with InvalidOperation → 400).
 	sessionID := input.SystemProperties["SessionId"]
 	if qd.requiresSession && sessionID == "" {
-		return nil, cerrors.New(cerrors.InvalidArgument, "SessionId is required for a session-enabled entity")
+		return enqueueResult{}, cerrors.New(cerrors.InvalidArgument, "SessionId is required for a session-enabled entity")
 	}
 
 	now := m.opts.Clock.Now()
 
 	// A repeat DeduplicationID (FIFO) or MessageId (Service Bus dup-detection)
 	// inside the window is silently accepted but not re-enqueued.
-	if existingID, found := findSendDuplicate(qd, &input, now); found {
-		return &driver.SendMessageOutput{MessageID: existingID}, nil
+	if existingID, found := findSendDuplicate(qd, input, now); found {
+		return enqueueResult{queueName: qd.info.Name, dupID: existingID}, nil
 	}
 
-	msg := buildSendMessage(&input, sessionID, now, qd.delaySeconds)
+	msg := buildSendMessage(input, sessionID, now, qd.delaySeconds)
 	qd.messages = append(qd.messages, msg)
-	recordSendDedup(qd, &input, now)
+	recordSendDedup(qd, input, now)
 
-	m.fireTrigger(input.QueueURL, msg)
+	return enqueueResult{msg: msg, queueName: qd.info.Name}, nil
+}
 
-	m.emitMetric(qd.info.Name, map[string]float64{
-		"IncomingMessages": 1, "Size": float64(len(input.Body)),
-	})
+// dispatchFunctionTrigger forwards a just-enqueued message to the Azure Functions
+// provider so any function bound to this queue fires. It is a no-op when no sink
+// is wired (the default, and every non-Azure-Functions deployment). Called after
+// the queue lock is released; see SendMessage.
+func (m *Mock) dispatchFunctionTrigger(ctx context.Context, queueName string, msg *sbMessage) {
+	m.mu.RLock()
+	sink := m.funcSink
+	bindingType := m.triggerBinding
+	m.mu.RUnlock()
 
-	return &driver.SendMessageOutput{
-		MessageID:  msg.ID,
-		ExpiresAt:  msg.ExpiresAt,
-		PopReceipt: msg.ReceiptHandle,
-	}, nil
+	if sink == nil {
+		return
+	}
+
+	sink.DeliverFunctionTrigger(ctx, bindingType, queueName, []byte(msg.Body))
 }
 
 // findSendDuplicate reports an already-accepted message id when input is a FIFO

--- a/server/azure/functions_queue_trigger_test.go
+++ b/server/azure/functions_queue_trigger_test.go
@@ -1,0 +1,145 @@
+package azure_test
+
+// Real-user end-to-end proof that an Azure Queue Storage trigger actually FIRES
+// the bound function: a function app declares a queueTrigger binding for queue
+// Q via ARM, then a message enqueued to Q with the real azqueue SDK synchronously
+// invokes the function with the message as its payload. Before this wiring the
+// binding round-tripped as CRUD only and no message ever reached the function.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureprovider "github.com/stackshy/cloudemu/v2/providers/azure"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// newFullAzureServerWithProvider boots the full production Azure server over a
+// caller-held provider, so the test can register a Go handler to observe that a
+// function was actually invoked.
+func newFullAzureServerWithProvider(t *testing.T) (*httptest.Server, *azureprovider.Provider) {
+	t.Helper()
+
+	p := cloudemu.NewAzure()
+	ts := httptest.NewServer(azureserver.NewFromProvider(p))
+	t.Cleanup(ts.Close)
+
+	return ts, p
+}
+
+// armPut issues a raw ARM PUT (the SDK's BeginCreateFunction only accepts 201,
+// so a raw client keeps the test independent of that status quirk).
+func armPut(t *testing.T, ts *httptest.Server, path, body string) {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, ts.URL+path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request %s: %v", path, err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("PUT %s: %v", path, err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		t.Fatalf("PUT %s = %d, want 200/201", path, resp.StatusCode)
+	}
+}
+
+func TestQueueStorageTriggerInvokesFunction(t *testing.T) {
+	ts, p := newFullAzureServerWithProvider(t)
+	ctx := context.Background()
+
+	const (
+		app   = "qt-app"
+		queue = "qt-queue"
+	)
+
+	base := "/subscriptions/sub-qt/resourceGroups/rg-qt/providers/Microsoft.Web/sites/" + app
+
+	// 1. Create the function app.
+	armPut(t, ts, base+"?api-version=2022-03-01", `{"location":"eastus","properties":{"siteConfig":{}}}`)
+
+	// 2. Deploy a function that declares a queueTrigger binding for the queue.
+	armPut(t, ts, base+"/functions/consume?api-version=2022-03-01",
+		`{"properties":{"config":{"bindings":[`+
+			`{"name":"item","type":"queueTrigger","direction":"in",`+
+			`"queueName":"`+queue+`","connection":"AzureWebJobsStorage"}]}}}`)
+
+	// Observe invocation via a registered handler on the held provider.
+	got := make(chan string, 1)
+	p.Functions.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		select {
+		case got <- string(payload):
+		default:
+		}
+
+		return payload, nil
+	})
+
+	// 3. Create the Storage queue and enqueue a message with the real SDK.
+	createStorageQueue(t, ts, queue)
+	qc := newStorageQueueClient(t, ts, queue)
+
+	const payload = "order-42"
+	if _, err := qc.EnqueueMessage(ctx, payload, nil); err != nil {
+		t.Fatalf("EnqueueMessage: %v", err)
+	}
+
+	// Delivery is synchronous, so the function has fired by the time enqueue
+	// returns.
+	select {
+	case body := <-got:
+		if body != payload {
+			t.Fatalf("function received %q, want %q", body, payload)
+		}
+	default:
+		t.Fatal("queue-triggered function was not invoked")
+	}
+}
+
+// TestQueueStorageTriggerUnboundQueueDoesNotFire proves a message on a queue no
+// function is bound to invokes nothing (the enqueue still succeeds).
+func TestQueueStorageTriggerUnboundQueueDoesNotFire(t *testing.T) {
+	ts, p := newFullAzureServerWithProvider(t)
+	ctx := context.Background()
+
+	const app = "qt-app2"
+	base := "/subscriptions/sub-qt/resourceGroups/rg-qt/providers/Microsoft.Web/sites/" + app
+
+	armPut(t, ts, base+"?api-version=2022-03-01", `{"location":"eastus","properties":{"siteConfig":{}}}`)
+	armPut(t, ts, base+"/functions/consume?api-version=2022-03-01",
+		`{"properties":{"config":{"bindings":[`+
+			`{"name":"item","type":"queueTrigger","direction":"in",`+
+			`"queueName":"bound-queue","connection":"AzureWebJobsStorage"}]}}}`)
+
+	fired := make(chan struct{}, 1)
+	p.Functions.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		fired <- struct{}{}
+
+		return payload, nil
+	})
+
+	// Enqueue to a DIFFERENT queue than the binding names.
+	createStorageQueue(t, ts, "other-queue")
+	qc := newStorageQueueClient(t, ts, "other-queue")
+
+	if _, err := qc.EnqueueMessage(ctx, "x", nil); err != nil {
+		t.Fatalf("EnqueueMessage: %v", err)
+	}
+
+	select {
+	case <-fired:
+		t.Fatal("function fired for a queue it is not bound to")
+	default:
+	}
+}


### PR DESCRIPTION
## Summary

Azure Functions had a rich control plane but weak triggers: only Event Grid → Function was wired, and event-source / binding config was CRUD-only with no delivery loop, so Queue Storage / Service Bus triggers never actually fired the function. This PR wires the highest-value native trigger delivery.

When a message is enqueued to a queue that a function's `function.json` binds via a `queueTrigger` (Azure Queue Storage) or `serviceBusTrigger` (Service Bus) binding, the bound function is now actually invoked with the message body as its payload — running the same invoke model gen1 uses (canned-echo stub / registered Go handler / real engine).

## What changed

- **`providers/azure/servicebus`** — added a `FunctionTriggerSink` cross-service seam (analogous to Event Grid's `SetFunctionInvoker`). `SendMessage` now dispatches to the sink on each real enqueue, **after** releasing the queue lock (a triggered function that re-enqueues to the same queue would otherwise deadlock on the non-reentrant `qd.mu`). The enqueue path was refactored into `enqueueLocked` returning an `enqueueResult`; a silently-accepted duplicate fires no trigger. The pre-existing per-queue `SetTrigger` library primitive is untouched.
- **`providers/azure/functions`** — implemented `DeliverFunctionTrigger`, which scans each deployed function's `function.json` bindings for a matching input trigger (`type` + `queueName`, skipping disabled functions and output bindings) and invokes each owning app via the existing `InvokeExternal` choke point. Delivery is synchronous and recursion-guarded (`recursionguard`, mirroring `lambda.InvokeExternal`).
- **`providers/azure/azure.go`** — wired `QueueStorage → queueTrigger` and `ServiceBus → serviceBusTrigger`. Both surfaces are the same clean seam, so Service Bus triggers ship alongside Queue Storage.

## Tests

- Provider unit tests: binding match / no-match, Service Bus binding, disabled-function skip, output-binding ignored, recursion guard; sink dispatch on enqueue and no dispatch on duplicate; `-race` clean.
- Real-user end-to-end (`server/azure`, full production server via `NewFromProvider`): declare a function app + a `queueTrigger` binding over ARM, enqueue with the real **azqueue** SDK, and assert the function is invoked with the message payload; plus an unbound-queue negative test.

## Deferred

Timer triggers (no external source event) and Cosmos change-feed / Event Hub triggers are out of scope for this PR.
