### PR TITLE
feat(lambda): async-invoke failure delivers to DLQ / on-failure destination

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -315,6 +315,11 @@ func New(opts ...config.Option) *Provider {
 	// SNS -> Lambda fan-out: publishes invoke lambda-protocol subscriptions with
 	// the SNS Records event (reuses the shared InvokeExternal choke point).
 	p.SNS.SetLambdaInvoker(p.Lambda)
+	// Lambda async failure -> DLQ / destination: a failed asynchronous (Event)
+	// invoke routes its event to the function's DeadLetterConfig queue/topic and
+	// its OnFailure/OnSuccess async destinations via the SQS/SNS mocks. Re-entry
+	// is bounded by the shared InvokeExternal recursion guard.
+	p.Lambda.SetAsyncDestinationTargets(p.SQS, p.SNS)
 	// EventBridge -> targets: matched rules deliver events to their first-class
 	// target types — SQS queues, Lambda functions (ASYNC), SNS topics, and Step
 	// Functions state machines (ASYNC). Lambda reuses the shared InvokeExternal

--- a/providers/aws/lambda/async_delivery.go
+++ b/providers/aws/lambda/async_delivery.go
@@ -1,0 +1,232 @@
+package lambda
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// asyncSQSDeliverer enqueues a failed/finished asynchronous invocation's event
+// into an SQS queue by ARN. The AWS SQS mock satisfies it via DeliverExternal,
+// enabling real DeadLetterConfig / OnFailure-destination delivery to SQS.
+type asyncSQSDeliverer interface {
+	DeliverExternal(ctx context.Context, queueARN, body string) error
+}
+
+// asyncSNSPublisher publishes a failed/finished asynchronous invocation's event
+// to an SNS topic by ARN. The AWS SNS mock satisfies it via PublishExternal.
+type asyncSNSPublisher interface {
+	PublishExternal(ctx context.Context, topicARN, message string) error
+}
+
+// SetAsyncDestinationTargets wires the SQS and SNS backends a failed asynchronous
+// invoke routes its event to: the function's DeadLetterConfig queue/topic and its
+// DestinationConfig OnFailure/OnSuccess targets. Either may be nil — routing to
+// that transport is then skipped, so a library user without SQS/SNS wired is
+// unaffected. Called once at provider wiring time, before any invoke.
+func (m *Mock) SetAsyncDestinationTargets(sqs asyncSQSDeliverer, sns asyncSNSPublisher) {
+	m.dlqSQS = sqs
+	m.dlqSNS = sns
+}
+
+// defaultMaxRetryAttempts is the AWS default number of asynchronous-invoke
+// retries (0-2) before the event is routed to the DLQ / OnFailure destination.
+const defaultMaxRetryAttempts = 2
+
+// routeAsyncDestinations routes a finished asynchronous (Event) invocation to its
+// configured destinations. A failure (out.Error set — a handler or engine error)
+// goes to the DeadLetterConfig queue/topic and the OnFailure destination once
+// retries are exhausted; a success may go to the OnSuccess destination. It is
+// called only for InvokeType=Event, so synchronous invokes are never affected.
+//
+// Delivery re-enters Lambda only through SQS/SNS -> InvokeExternal, whose
+// recursion guard bounds a DLQ-that-triggers-its-own-function loop; this method
+// adds no invoke of its own, so it needs no guard.
+//
+// Retries are not actually re-run: the stub/handler/engine outcome is
+// deterministic in the emulator, so re-invoking would only duplicate side
+// effects and metrics. The failure is treated as retries-exhausted immediately,
+// which matches the observable outcome (the event lands in the DLQ/destination).
+func (m *Mock) routeAsyncDestinations(
+	ctx context.Context, fd *funcData, input driver.InvokeInput, executedVersion string, out *driver.InvokeOutput,
+) {
+	cfg := lookupEventInvokeConfig(fd, input.Qualifier)
+
+	if out.Error != "" {
+		// DeadLetterConfig: the DLQ message body is the original event, matching
+		// real Lambda (which carries the error detail in SQS/SNS message
+		// attributes, a channel the cross-service seam does not expose).
+		if dl := fd.awsConfig.DeadLetterConfig; dl != nil && dl.TargetArn != "" {
+			m.deliverToTarget(ctx, dl.TargetArn, string(eventBody(input.Payload)))
+		}
+
+		if dest := failureDestination(cfg.DestinationConfig); dest != "" {
+			m.deliverToTarget(ctx, dest, m.destinationEnvelope(fd, input, executedVersion, out, false))
+		}
+
+		return
+	}
+
+	if dest := successDestination(cfg.DestinationConfig); dest != "" {
+		m.deliverToTarget(ctx, dest, m.destinationEnvelope(fd, input, executedVersion, out, true))
+	}
+}
+
+// deliverToTarget routes a delivery to the transport named by the target ARN's
+// service field: an SQS queue or an SNS topic. Lambda/EventBridge destination
+// ARNs are accepted by the config API but not delivered here (out of scope for
+// this pass); an unknown/unwired transport is a best-effort no-op, mirroring the
+// asynchronous, decoupled behavior of real destinations (a bad target never
+// fails the invocation).
+func (m *Mock) deliverToTarget(ctx context.Context, targetARN, body string) {
+	switch arnService(targetARN) {
+	case "sqs":
+		if m.dlqSQS != nil {
+			_ = m.dlqSQS.DeliverExternal(ctx, targetARN, body)
+		}
+	case "sns":
+		if m.dlqSNS != nil {
+			_ = m.dlqSNS.PublishExternal(ctx, targetARN, body)
+		}
+	}
+}
+
+// failureDestination returns the OnFailure destination ARN from a
+// DestinationConfig, or "" when none is configured.
+func failureDestination(dc *driver.DestinationConfig) string {
+	if dc != nil && dc.OnFailure != nil {
+		return dc.OnFailure.Destination
+	}
+
+	return ""
+}
+
+// successDestination returns the OnSuccess destination ARN, or "" when none.
+func successDestination(dc *driver.DestinationConfig) string {
+	if dc != nil && dc.OnSuccess != nil {
+		return dc.OnSuccess.Destination
+	}
+
+	return ""
+}
+
+// arnService extracts the service field (index 2) from an ARN
+// (arn:aws:<service>:region:account:resource); "" for a non-ARN string.
+func arnService(arn string) string {
+	parts := strings.SplitN(arn, ":", 6) //nolint:mnd // ARN has 6 colon-separated fields.
+	if len(parts) < 3 || parts[0] != "arn" {
+		return ""
+	}
+
+	return parts[2]
+}
+
+// eventBody returns the invocation event payload, substituting an empty JSON
+// object for an empty payload so the DLQ message is always valid JSON.
+func eventBody(payload []byte) []byte {
+	if len(payload) == 0 {
+		return []byte("{}")
+	}
+
+	return payload
+}
+
+// destinationEnvelope builds the AWS Lambda async-destination event that wraps a
+// finished invocation's request/response with its outcome (the shape delivered
+// to an OnSuccess/OnFailure destination). success selects the Success vs
+// RetriesExhausted condition and the response context.
+func (m *Mock) destinationEnvelope(
+	fd *funcData, input driver.InvokeInput, executedVersion string, out *driver.InvokeOutput, success bool,
+) string {
+	condition := "RetriesExhausted"
+	if success {
+		condition = "Success"
+	}
+
+	respCtx := map[string]any{
+		"statusCode":      out.StatusCode,
+		"executedVersion": executedVersion,
+	}
+	if !success {
+		respCtx["functionError"] = "Unhandled"
+	}
+
+	envelope := map[string]any{
+		"version":   "1.0",
+		"timestamp": m.opts.Clock.Now().UTC().Format(timeFormat),
+		"requestContext": map[string]any{
+			"requestId":              newRequestID(),
+			"functionArn":            qualifiedARN(fd.info.ARN, executedVersion),
+			"condition":              condition,
+			"approximateInvokeCount": approximateInvokeCount(fd, input.Qualifier),
+		},
+		"requestPayload":  json.RawMessage(eventBody(input.Payload)),
+		"responseContext": respCtx,
+		"responsePayload": json.RawMessage(responsePayload(out, success)),
+	}
+
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		return string(eventBody(input.Payload))
+	}
+
+	return string(body)
+}
+
+// responsePayload renders the destination envelope's responsePayload: the
+// handler result on success (or {} when empty), or the Lambda error object on
+// failure.
+func responsePayload(out *driver.InvokeOutput, success bool) []byte {
+	if success {
+		return eventBody(out.Payload)
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"errorType":    "HandlerError",
+		"errorMessage": out.Error,
+	})
+	if err != nil {
+		return []byte(`{"errorMessage":"unknown error"}`)
+	}
+
+	return body
+}
+
+// approximateInvokeCount is the total number of attempts Lambda reports it made
+// before routing to the destination: the configured retry attempts plus the
+// initial invocation.
+func approximateInvokeCount(fd *funcData, qualifier string) int {
+	cfg := lookupEventInvokeConfig(fd, qualifier)
+
+	retries := defaultMaxRetryAttempts
+	if cfg.MaximumRetryAttempts != nil {
+		retries = *cfg.MaximumRetryAttempts
+	}
+
+	return retries + 1
+}
+
+// qualifiedARN appends a version/alias qualifier to a function ARN, mirroring the
+// functionArn real Lambda reports in the destination envelope.
+func qualifiedARN(arn, qualifier string) string {
+	if qualifier == "" {
+		return arn
+	}
+
+	return arn + ":" + qualifier
+}
+
+// newRequestID generates a random hex request id for the destination envelope's
+// requestContext (a stand-in for the invocation's AWS request id).
+func newRequestID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "00000000000000000000000000000000"
+	}
+
+	return hex.EncodeToString(b[:])
+}

--- a/providers/aws/lambda/event_invoke_config.go
+++ b/providers/aws/lambda/event_invoke_config.go
@@ -1,0 +1,270 @@
+package lambda
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// AWS async-invoke config bounds (PutFunctionEventInvokeConfig): retries are
+// 0-2, and the maximum event age is 60-21600 seconds (1 minute to 6 hours). An
+// out-of-range value is rejected with InvalidParameterValueException.
+const (
+	minRetryAttempts   = 0
+	maxRetryAttempts   = 2
+	minEventAgeSeconds = 60
+	maxEventAgeSeconds = 21600
+)
+
+// PutFunctionEventInvokeConfig sets (replacing any existing) the asynchronous-
+// invocation configuration for a function version/alias: MaximumRetryAttempts,
+// MaximumEventAgeInSeconds and the OnSuccess/OnFailure DestinationConfig. It
+// backs AWS PutFunctionEventInvokeConfig (Terraform
+// aws_lambda_function_event_invoke_config).
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) PutFunctionEventInvokeConfig(
+	_ context.Context, cfg driver.EventInvokeConfig,
+) (*driver.EventInvokeConfig, error) {
+	if err := validateEventInvokeConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fd, ok := m.funcs.Get(cfg.FunctionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
+	}
+
+	if _, err := m.resolveQualifier(&fd, cfg.Qualifier, nil); err != nil {
+		return nil, err
+	}
+
+	stored := driver.EventInvokeConfig{
+		FunctionName:             cfg.FunctionName,
+		Qualifier:                cfg.Qualifier,
+		FunctionArn:              qualifiedARN(fd.info.ARN, cfg.Qualifier),
+		MaximumRetryAttempts:     cloneIntPtr(cfg.MaximumRetryAttempts),
+		MaximumEventAgeInSeconds: cloneIntPtr(cfg.MaximumEventAgeInSeconds),
+		DestinationConfig:        cloneDestinationConfig(cfg.DestinationConfig),
+		LastModified:             m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+
+	setEventInvokeConfig(&fd, stored)
+	m.funcs.Set(cfg.FunctionName, fd)
+
+	result := cloneEventInvokeConfig(stored)
+
+	return &result, nil
+}
+
+// UpdateFunctionEventInvokeConfig merges the supplied non-nil fields onto an
+// existing async-invoke config (AWS UpdateFunctionEventInvokeConfig's PATCH
+// semantics), leaving unset fields unchanged. An update with no prior config
+// creates one, matching AWS.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) UpdateFunctionEventInvokeConfig(
+	_ context.Context, cfg driver.EventInvokeConfig,
+) (*driver.EventInvokeConfig, error) {
+	if err := validateEventInvokeConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fd, ok := m.funcs.Get(cfg.FunctionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
+	}
+
+	if _, err := m.resolveQualifier(&fd, cfg.Qualifier, nil); err != nil {
+		return nil, err
+	}
+
+	merged := lookupEventInvokeConfig(&fd, cfg.Qualifier)
+	merged.FunctionName = cfg.FunctionName
+	merged.Qualifier = cfg.Qualifier
+	merged.FunctionArn = qualifiedARN(fd.info.ARN, cfg.Qualifier)
+
+	if cfg.MaximumRetryAttempts != nil {
+		merged.MaximumRetryAttempts = cloneIntPtr(cfg.MaximumRetryAttempts)
+	}
+
+	if cfg.MaximumEventAgeInSeconds != nil {
+		merged.MaximumEventAgeInSeconds = cloneIntPtr(cfg.MaximumEventAgeInSeconds)
+	}
+
+	if cfg.DestinationConfig != nil {
+		merged.DestinationConfig = cloneDestinationConfig(cfg.DestinationConfig)
+	}
+
+	merged.LastModified = m.opts.Clock.Now().UTC().Format(timeFormat)
+
+	setEventInvokeConfig(&fd, merged)
+	m.funcs.Set(cfg.FunctionName, fd)
+
+	result := cloneEventInvokeConfig(merged)
+
+	return &result, nil
+}
+
+// GetFunctionEventInvokeConfig returns the async-invoke config for a function
+// version/alias, or NotFound (ResourceNotFoundException) when none is set.
+func (m *Mock) GetFunctionEventInvokeConfig(
+	_ context.Context, functionName, qualifier string,
+) (*driver.EventInvokeConfig, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	cfg, ok := fd.eventInvokeConfigs[policyKey(qualifier)]
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound,
+			"no event invoke config for function %s", functionName)
+	}
+
+	result := cloneEventInvokeConfig(cfg)
+
+	return &result, nil
+}
+
+// DeleteFunctionEventInvokeConfig removes the async-invoke config for a function
+// version/alias, reverting it to the default (2 retries, no destinations).
+func (m *Mock) DeleteFunctionEventInvokeConfig(_ context.Context, functionName, qualifier string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	key := policyKey(qualifier)
+	if _, exists := fd.eventInvokeConfigs[key]; !exists {
+		return cerrors.Newf(cerrors.NotFound, "no event invoke config for function %s", functionName)
+	}
+
+	next := make(map[string]driver.EventInvokeConfig, len(fd.eventInvokeConfigs))
+
+	for k, v := range fd.eventInvokeConfigs {
+		if k != key {
+			next[k] = v
+		}
+	}
+
+	fd.eventInvokeConfigs = next
+	m.funcs.Set(functionName, fd)
+
+	return nil
+}
+
+// ListFunctionEventInvokeConfigs returns every async-invoke config set on a
+// function (one per qualifier), backing AWS ListFunctionEventInvokeConfigs.
+func (m *Mock) ListFunctionEventInvokeConfigs(
+	_ context.Context, functionName string,
+) ([]driver.EventInvokeConfig, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	out := make([]driver.EventInvokeConfig, 0, len(fd.eventInvokeConfigs))
+	for _, cfg := range fd.eventInvokeConfigs {
+		out = append(out, cloneEventInvokeConfig(cfg))
+	}
+
+	return out, nil
+}
+
+// setEventInvokeConfig stores cfg under its qualifier key using copy-on-write: a
+// fresh map is built so a concurrent Invoke reading an earlier funcData copy
+// still sees an immutable snapshot (-race clean).
+//
+//nolint:gocritic // hugeParam: cfg mirrors the driver value type stored by value.
+func setEventInvokeConfig(fd *funcData, cfg driver.EventInvokeConfig) {
+	next := make(map[string]driver.EventInvokeConfig, len(fd.eventInvokeConfigs)+1)
+
+	for k, v := range fd.eventInvokeConfigs {
+		next[k] = v
+	}
+
+	next[policyKey(cfg.Qualifier)] = cfg
+	fd.eventInvokeConfigs = next
+}
+
+// lookupEventInvokeConfig returns the async-invoke config for a qualifier, or a
+// zero-value config (defaults) when none is set. Read-only; safe to call on a
+// funcData copy without the mock lock.
+func lookupEventInvokeConfig(fd *funcData, qualifier string) driver.EventInvokeConfig {
+	return fd.eventInvokeConfigs[policyKey(qualifier)]
+}
+
+// validateEventInvokeConfig enforces the AWS bounds on retries and event age.
+//
+//nolint:gocritic // hugeParam: cfg mirrors the method value receiver.
+func validateEventInvokeConfig(cfg driver.EventInvokeConfig) error {
+	if r := cfg.MaximumRetryAttempts; r != nil && (*r < minRetryAttempts || *r > maxRetryAttempts) {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"MaximumRetryAttempts %d must be >= %d and <= %d", *r, minRetryAttempts, maxRetryAttempts)
+	}
+
+	if a := cfg.MaximumEventAgeInSeconds; a != nil && (*a < minEventAgeSeconds || *a > maxEventAgeSeconds) {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"MaximumEventAgeInSeconds %d must be >= %d and <= %d", *a, minEventAgeSeconds, maxEventAgeSeconds)
+	}
+
+	return nil
+}
+
+func cloneIntPtr(p *int) *int {
+	if p == nil {
+		return nil
+	}
+
+	v := *p
+
+	return &v
+}
+
+func cloneDestination(d *driver.Destination) *driver.Destination {
+	if d == nil {
+		return nil
+	}
+
+	return &driver.Destination{Destination: d.Destination}
+}
+
+func cloneDestinationConfig(dc *driver.DestinationConfig) *driver.DestinationConfig {
+	if dc == nil {
+		return nil
+	}
+
+	return &driver.DestinationConfig{
+		OnSuccess: cloneDestination(dc.OnSuccess),
+		OnFailure: cloneDestination(dc.OnFailure),
+	}
+}
+
+// cloneEventInvokeConfig deep-copies a config so stored state and returned/
+// snapshot copies never share the pointer fields.
+//
+//nolint:gocritic // hugeParam: cfg mirrors the driver value type.
+func cloneEventInvokeConfig(cfg driver.EventInvokeConfig) driver.EventInvokeConfig {
+	cfg.MaximumRetryAttempts = cloneIntPtr(cfg.MaximumRetryAttempts)
+	cfg.MaximumEventAgeInSeconds = cloneIntPtr(cfg.MaximumEventAgeInSeconds)
+	cfg.DestinationConfig = cloneDestinationConfig(cfg.DestinationConfig)
+
+	return cfg
+}

--- a/providers/aws/lambda/event_invoke_config_test.go
+++ b/providers/aws/lambda/event_invoke_config_test.go
@@ -1,0 +1,342 @@
+package lambda
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// fakeSQS / fakeSNS record cross-service async-failure deliveries so tests can
+// assert that a failed asynchronous invoke routed its event to the DLQ /
+// destination.
+type fakeSQS struct {
+	mu   sync.Mutex
+	msgs map[string][]string
+}
+
+func (f *fakeSQS) DeliverExternal(_ context.Context, arn, body string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.msgs == nil {
+		f.msgs = map[string][]string{}
+	}
+
+	f.msgs[arn] = append(f.msgs[arn], body)
+
+	return nil
+}
+
+func (f *fakeSQS) get(arn string) []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.msgs[arn]
+}
+
+type fakeSNS struct {
+	mu   sync.Mutex
+	msgs map[string][]string
+	// onPublish, when set, is called on every publish — used to simulate an
+	// SNS -> Lambda fan-out that re-invokes the failing function (recursion test).
+	onPublish func(ctx context.Context, arn, msg string)
+}
+
+func (f *fakeSNS) PublishExternal(ctx context.Context, arn, message string) error {
+	f.mu.Lock()
+	if f.msgs == nil {
+		f.msgs = map[string][]string{}
+	}
+
+	f.msgs[arn] = append(f.msgs[arn], message)
+	cb := f.onPublish
+	f.mu.Unlock()
+
+	if cb != nil {
+		cb(ctx, arn, message)
+	}
+
+	return nil
+}
+
+func (f *fakeSNS) get(arn string) []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.msgs[arn]
+}
+
+const (
+	dlqSQSARN     = "arn:aws:sqs:us-east-1:000000000000:my-dlq"
+	failSNSARN    = "arn:aws:sns:us-east-1:000000000000:on-failure"
+	successSNSARN = "arn:aws:sns:us-east-1:000000000000:on-success"
+)
+
+func intPtr(v int) *int { return &v }
+
+// createFailingFunc creates my-func with a handler that always errors, so an
+// asynchronous invoke fails and routes to its DLQ / destinations.
+func createFailingFunc(t *testing.T, m *Mock) {
+	t.Helper()
+
+	if _, err := m.CreateFunction(context.Background(), defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	m.RegisterHandler("my-func", func(_ context.Context, _ []byte) ([]byte, error) {
+		return nil, errors.New("boom")
+	})
+}
+
+func TestEventInvokeConfigRoundTrip(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	put, err := m.PutFunctionEventInvokeConfig(ctx, driver.EventInvokeConfig{
+		FunctionName:             "my-func",
+		MaximumRetryAttempts:     intPtr(1),
+		MaximumEventAgeInSeconds: intPtr(3600),
+		DestinationConfig: &driver.DestinationConfig{
+			OnFailure: &driver.Destination{Destination: failSNSARN},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	if put.MaximumRetryAttempts == nil || *put.MaximumRetryAttempts != 1 {
+		t.Fatalf("MaximumRetryAttempts = %v, want 1", put.MaximumRetryAttempts)
+	}
+
+	if !strings.HasSuffix(put.FunctionArn, ":function:my-func") {
+		t.Fatalf("FunctionArn = %q, want unqualified function arn", put.FunctionArn)
+	}
+
+	// Update merges: only change the retries, destinations stay.
+	upd, err := m.UpdateFunctionEventInvokeConfig(ctx, driver.EventInvokeConfig{
+		FunctionName:         "my-func",
+		MaximumRetryAttempts: intPtr(0),
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if *upd.MaximumRetryAttempts != 0 {
+		t.Fatalf("merged MaximumRetryAttempts = %d, want 0", *upd.MaximumRetryAttempts)
+	}
+
+	if upd.DestinationConfig == nil || upd.DestinationConfig.OnFailure == nil {
+		t.Fatal("Update dropped the OnFailure destination")
+	}
+
+	got, err := m.GetFunctionEventInvokeConfig(ctx, "my-func", "")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if *got.MaximumEventAgeInSeconds != 3600 {
+		t.Fatalf("MaximumEventAgeInSeconds = %d, want 3600", *got.MaximumEventAgeInSeconds)
+	}
+
+	list, err := m.ListFunctionEventInvokeConfigs(ctx, "my-func")
+	if err != nil || len(list) != 1 {
+		t.Fatalf("List = %v (err %v), want 1 config", list, err)
+	}
+
+	if err := m.DeleteFunctionEventInvokeConfig(ctx, "my-func", ""); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if _, err := m.GetFunctionEventInvokeConfig(ctx, "my-func", ""); err == nil {
+		t.Fatal("Get after Delete: want NotFound")
+	}
+}
+
+func TestEventInvokeConfigValidation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	if _, err := m.PutFunctionEventInvokeConfig(ctx, driver.EventInvokeConfig{
+		FunctionName: "my-func", MaximumRetryAttempts: intPtr(3),
+	}); err == nil {
+		t.Fatal("retries=3: want InvalidArgument")
+	}
+
+	if _, err := m.PutFunctionEventInvokeConfig(ctx, driver.EventInvokeConfig{
+		FunctionName: "my-func", MaximumEventAgeInSeconds: intPtr(30),
+	}); err == nil {
+		t.Fatal("eventAge=30: want InvalidArgument")
+	}
+
+	if _, err := m.PutFunctionEventInvokeConfig(ctx, driver.EventInvokeConfig{
+		FunctionName: "absent",
+	}); err == nil {
+		t.Fatal("unknown function: want NotFound")
+	}
+}
+
+// TestAsyncFailureDeliversToDLQ covers the headline behavior: a failing async
+// (Event) invoke routes the original event to the DeadLetterConfig SQS queue and
+// the OnFailure destination (with the error), while a successful async invoke
+// does not.
+func TestAsyncFailureDeliversToDLQ(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	sqs, sns := &fakeSQS{}, &fakeSNS{}
+	m.SetAsyncDestinationTargets(sqs, sns)
+
+	createFailingFunc(t, m)
+
+	if err := m.SetFunctionAWSConfig(ctx, "my-func", driver.AWSFunctionConfig{
+		DeadLetterConfig: &driver.DeadLetterConfig{TargetArn: dlqSQSARN},
+	}, true); err != nil {
+		t.Fatalf("SetFunctionAWSConfig: %v", err)
+	}
+
+	if _, err := m.PutFunctionEventInvokeConfig(ctx, driver.EventInvokeConfig{
+		FunctionName: "my-func",
+		DestinationConfig: &driver.DestinationConfig{
+			OnFailure: &driver.Destination{Destination: failSNSARN},
+		},
+	}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// Async invoke: the failing handler makes InvokeExternal report an error, but
+	// the DLQ/destination delivery has already happened inside Invoke.
+	arn := "arn:aws:lambda:us-east-1:000000000000:function:my-func"
+	_ = m.InvokeExternal(ctx, arn, []byte(`{"event":"payload"}`))
+
+	dlq := sqs.get(dlqSQSARN)
+	if len(dlq) != 1 || dlq[0] != `{"event":"payload"}` {
+		t.Fatalf("DLQ messages = %v, want the original event", dlq)
+	}
+
+	failMsgs := sns.get(failSNSARN)
+	if len(failMsgs) != 1 {
+		t.Fatalf("OnFailure messages = %d, want 1", len(failMsgs))
+	}
+
+	if !strings.Contains(failMsgs[0], "RetriesExhausted") || !strings.Contains(failMsgs[0], "boom") {
+		t.Fatalf("OnFailure envelope = %q, want RetriesExhausted + error", failMsgs[0])
+	}
+}
+
+func TestAsyncSuccessSkipsDLQButHitsOnSuccess(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	sqs, sns := &fakeSQS{}, &fakeSNS{}
+	m.SetAsyncDestinationTargets(sqs, sns)
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+	// Succeeding handler.
+	m.RegisterHandler("my-func", func(_ context.Context, p []byte) ([]byte, error) {
+		return p, nil
+	})
+
+	if err := m.SetFunctionAWSConfig(ctx, "my-func", driver.AWSFunctionConfig{
+		DeadLetterConfig: &driver.DeadLetterConfig{TargetArn: dlqSQSARN},
+	}, true); err != nil {
+		t.Fatalf("SetFunctionAWSConfig: %v", err)
+	}
+
+	if _, err := m.PutFunctionEventInvokeConfig(ctx, driver.EventInvokeConfig{
+		FunctionName: "my-func",
+		DestinationConfig: &driver.DestinationConfig{
+			OnSuccess: &driver.Destination{Destination: successSNSARN},
+		},
+	}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	arn := "arn:aws:lambda:us-east-1:000000000000:function:my-func"
+	if err := m.InvokeExternal(ctx, arn, []byte(`{"ok":true}`)); err != nil {
+		t.Fatalf("InvokeExternal: %v", err)
+	}
+
+	if got := sqs.get(dlqSQSARN); len(got) != 0 {
+		t.Fatalf("DLQ received %v on success, want none", got)
+	}
+
+	if got := sns.get(successSNSARN); len(got) != 1 || !strings.Contains(got[0], "Success") {
+		t.Fatalf("OnSuccess messages = %v, want 1 Success envelope", got)
+	}
+}
+
+func TestSyncFailureDoesNotDeliver(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	sqs, sns := &fakeSQS{}, &fakeSNS{}
+	m.SetAsyncDestinationTargets(sqs, sns)
+
+	createFailingFunc(t, m)
+
+	if err := m.SetFunctionAWSConfig(ctx, "my-func", driver.AWSFunctionConfig{
+		DeadLetterConfig: &driver.DeadLetterConfig{TargetArn: dlqSQSARN},
+	}, true); err != nil {
+		t.Fatalf("SetFunctionAWSConfig: %v", err)
+	}
+
+	// A synchronous (RequestResponse) invoke never routes to the DLQ.
+	if _, err := m.Invoke(ctx, driver.InvokeInput{
+		FunctionName: "my-func", InvokeType: "RequestResponse", Payload: []byte(`{}`),
+	}); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	if got := sqs.get(dlqSQSARN); len(got) != 0 {
+		t.Fatalf("DLQ received %v on sync failure, want none", got)
+	}
+}
+
+// TestAsyncFailureDLQRecursionBounded proves the DLQ-that-re-invokes-its-own-
+// function loop terminates at the recursion guard instead of overflowing: the
+// OnFailure SNS "topic" re-invokes the failing function via InvokeExternal on
+// every publish, so each failure re-delivers and re-invokes.
+func TestAsyncFailureDLQRecursionBounded(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	sqs, sns := &fakeSQS{}, &fakeSNS{}
+	arn := "arn:aws:lambda:us-east-1:000000000000:function:my-func"
+	sns.onPublish = func(c context.Context, _, _ string) {
+		_ = m.InvokeExternal(c, arn, []byte(`{"loop":true}`))
+	}
+
+	m.SetAsyncDestinationTargets(sqs, sns)
+	createFailingFunc(t, m)
+
+	if _, err := m.PutFunctionEventInvokeConfig(ctx, driver.EventInvokeConfig{
+		FunctionName: "my-func",
+		DestinationConfig: &driver.DestinationConfig{
+			OnFailure: &driver.Destination{Destination: failSNSARN},
+		},
+	}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// Must return (not stack-overflow); delivery count is bounded by the guard.
+	_ = m.InvokeExternal(ctx, arn, []byte(`{"start":true}`))
+
+	if n := len(sns.get(failSNSARN)); n == 0 || n > recursionguard.MaxDepth+1 {
+		t.Fatalf("OnFailure deliveries = %d, want 1..%d (bounded by recursion guard)", n, recursionguard.MaxDepth+1)
+	}
+}

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -42,6 +42,10 @@ const (
 	// parameters and permissions (including the Qualifier) without running the
 	// function.
 	invokeTypeDryRun = "DryRun"
+	// invokeTypeEvent is the asynchronous (fire-and-forget) invocation type. A
+	// failed Event invoke routes its event to the DLQ / OnFailure destination
+	// after retries are exhausted; a successful one may route to OnSuccess.
+	invokeTypeEvent = "Event"
 	// dryRunStatusCode is the HTTP 204 No Content a successful DryRun reports.
 	dryRunStatusCode = 204
 )
@@ -101,6 +105,10 @@ type funcData struct {
 	// awsConfig holds the AWS-only settings (VpcConfig/DeadLetterConfig/
 	// TracingConfig) applied through the AWSConfigurable optional interface.
 	awsConfig driver.AWSFunctionConfig
+	// eventInvokeConfigs holds the asynchronous-invocation config keyed by
+	// qualifier (normalized via policyKey: "" and "$LATEST" collapse to the
+	// unqualified function config), matching AWS's per-version/alias scoping.
+	eventInvokeConfigs map[string]driver.EventInvokeConfig
 }
 
 // Mock is an in-memory mock implementation of AWS Lambda.
@@ -113,7 +121,15 @@ type Mock struct {
 	handlers   map[string]driver.HandlerFunc
 	monitoring mondriver.Monitoring
 	logs       logdriver.Logging // optional: CloudWatch Logs sink for invocation logs
-	mu         sync.Mutex        // guards PublishVersion read-modify-write on funcData
+	// dlqSQS / dlqSNS are the cross-service seams a failed asynchronous invoke
+	// uses to route its event to the function's DeadLetterConfig queue/topic and
+	// its OnFailure/OnSuccess async destinations. Both are optional: unset means
+	// destination routing is silently skipped (library users without SQS/SNS are
+	// unaffected). Delivery re-enters Lambda only through InvokeExternal, whose
+	// recursion guard bounds any DLQ->function->DLQ loop.
+	dlqSQS asyncSQSDeliverer
+	dlqSNS asyncSNSPublisher
+	mu     sync.Mutex // guards PublishVersion read-modify-write on funcData
 	// inflightMu guards inflight, the number of invocations currently executing
 	// per function name. It backs reserved-concurrency enforcement on Invoke.
 	inflightMu sync.Mutex
@@ -341,9 +357,34 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 
 	defer release()
 
+	out, err := m.runInvocation(ctx, &fd, input, executedVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	// An asynchronous (Event) invocation routes its finished outcome to the
+	// function's async destinations: a failure (a handler/engine error) goes to
+	// the DeadLetterConfig queue/topic and the OnFailure destination once retries
+	// are exhausted; a success may go to the OnSuccess destination. Synchronous
+	// invokes never touch these (the caller gets the result directly).
+	if input.InvokeType == invokeTypeEvent {
+		m.routeAsyncDestinations(ctx, &fd, input, executedVersion, out)
+	}
+
+	return out, nil
+}
+
+// runInvocation runs the function body and returns its InvokeOutput: the real
+// FunctionEngine when one is deployed, the registered Go handler when one is
+// attached, or the echo stub otherwise. It emits the invoke metrics and surfaces
+// the START/END/REPORT logs; the async-destination routing sits above it in
+// Invoke so both the stub/handler and engine paths funnel through one place.
+func (m *Mock) runInvocation(
+	ctx context.Context, fd *funcData, input driver.InvokeInput, executedVersion string,
+) (*driver.InvokeOutput, error) {
 	dims := map[string]string{"FunctionName": input.FunctionName}
 
-	h := m.resolveHandler(&fd, input.FunctionName)
+	h := m.resolveHandler(fd, input.FunctionName)
 
 	if h == nil && fd.engineBacked {
 		return m.invokeEngine(ctx, input, dims, executedVersion)

--- a/providers/aws/lambda/snapshot.go
+++ b/providers/aws/lambda/snapshot.go
@@ -43,6 +43,9 @@ type funcSnapshot struct {
 	Policies     map[string]map[string]driver.PermissionStatement `json:"policies,omitempty"`
 	URLConfig    *driver.FunctionURLConfig                        `json:"urlConfig,omitempty"`
 	AWSConfig    driver.AWSFunctionConfig                         `json:"awsConfig"`
+	// EventInvokeConfigs is the async-invoke config per qualifier (retries,
+	// event age, OnSuccess/OnFailure destinations).
+	EventInvokeConfigs map[string]driver.EventInvokeConfig `json:"eventInvokeConfigs,omitempty"`
 }
 
 // versionSnapshot mirrors versionData (all fields unexported). Config carries the
@@ -109,7 +112,7 @@ func snapshotFunc(fd *funcData) *funcSnapshot {
 	fs := &funcSnapshot{
 		Info: fd.info, EngineBacked: fd.engineBacked, NextVersion: fd.nextVersion,
 		Concurrency: fd.concurrency, Policies: fd.policies, URLConfig: fd.urlConfig,
-		AWSConfig: fd.awsConfig,
+		AWSConfig: fd.awsConfig, EventInvokeConfigs: fd.eventInvokeConfigs,
 	}
 
 	for _, v := range fd.versions {
@@ -167,6 +170,7 @@ func (m *Mock) restoreFunc(name string, fs *funcSnapshot) funcData {
 		info: fs.Info, engineBacked: fs.EngineBacked, nextVersion: fs.NextVersion,
 		aliases: memstore.New[*aliasData](), concurrency: fs.Concurrency,
 		policies: fs.Policies, urlConfig: fs.URLConfig, awsConfig: fs.AWSConfig,
+		eventInvokeConfigs: fs.EventInvokeConfigs,
 	}
 
 	// Re-link the live handler if the host process has registered one for this

--- a/server/aws/lambda/event_invoke_config.go
+++ b/server/aws/lambda/event_invoke_config.go
@@ -1,0 +1,249 @@
+package lambda
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	sdrv "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// eventInvokeConfigPrefix is the Lambda asynchronous-invocation-config API
+// version prefix (PutFunctionEventInvokeConfig et al), a function sub-resource
+// (.../{name}/event-invoke-config) versioned under 2019-09-25 — its own prefix,
+// so it needs a Matches clause.
+const eventInvokeConfigPrefix = "/2019-09-25/functions"
+
+// eventInvokeConfigSuffix / listSuffix are the sub-resource path segments the
+// event-invoke-config routes hang off {name}.
+const (
+	eventInvokeConfigSuffix = "event-invoke-config"
+	eventInvokeListSegment  = "list"
+)
+
+// eventInvokeConfigManager is the AWS-specific asynchronous-invoke-config
+// surface (retries, max event age, OnSuccess/OnFailure destinations). It has no
+// Azure/GCP equivalent, so the handler type-asserts for it rather than adding it
+// to the portable Serverless driver, mirroring functionURLManager.
+type eventInvokeConfigManager interface {
+	PutFunctionEventInvokeConfig(ctx context.Context, cfg sdrv.EventInvokeConfig) (*sdrv.EventInvokeConfig, error)
+	UpdateFunctionEventInvokeConfig(ctx context.Context, cfg sdrv.EventInvokeConfig) (*sdrv.EventInvokeConfig, error)
+	GetFunctionEventInvokeConfig(ctx context.Context, functionName, qualifier string) (*sdrv.EventInvokeConfig, error)
+	DeleteFunctionEventInvokeConfig(ctx context.Context, functionName, qualifier string) error
+	ListFunctionEventInvokeConfigs(ctx context.Context, functionName string) ([]sdrv.EventInvokeConfig, error)
+}
+
+// destinationJSON is the AWS OnSuccess/OnFailure Destination shape.
+type destinationJSON struct {
+	Destination string `json:"Destination"`
+}
+
+// destinationConfigJSON is the AWS DestinationConfig shape shared by the request
+// and response.
+type destinationConfigJSON struct {
+	OnSuccess *destinationJSON `json:"OnSuccess,omitempty"`
+	OnFailure *destinationJSON `json:"OnFailure,omitempty"`
+}
+
+// eventInvokeConfigRequest is the body of Put/UpdateFunctionEventInvokeConfig.
+type eventInvokeConfigRequest struct {
+	MaximumRetryAttempts     *int                   `json:"MaximumRetryAttempts"`
+	MaximumEventAgeInSeconds *int                   `json:"MaximumEventAgeInSeconds"`
+	DestinationConfig        *destinationConfigJSON `json:"DestinationConfig"`
+}
+
+// eventInvokeConfigResponse is the AWS FunctionEventInvokeConfig shape.
+// LastModified is emitted as epoch seconds (the rest-json timestamp default the
+// SDK decodes into *time.Time).
+type eventInvokeConfigResponse struct {
+	FunctionArn              string                 `json:"FunctionArn"`
+	LastModified             float64                `json:"LastModified"`
+	MaximumRetryAttempts     *int                   `json:"MaximumRetryAttempts,omitempty"`
+	MaximumEventAgeInSeconds *int                   `json:"MaximumEventAgeInSeconds,omitempty"`
+	DestinationConfig        *destinationConfigJSON `json:"DestinationConfig,omitempty"`
+}
+
+// listEventInvokeConfigsResponse is the ListFunctionEventInvokeConfigs envelope.
+type listEventInvokeConfigsResponse struct {
+	FunctionEventInvokeConfigs []eventInvokeConfigResponse `json:"FunctionEventInvokeConfigs"`
+}
+
+func toDestinationDriver(d *destinationJSON) *sdrv.Destination {
+	if d == nil {
+		return nil
+	}
+
+	return &sdrv.Destination{Destination: d.Destination}
+}
+
+func toDestinationConfigDriver(dc *destinationConfigJSON) *sdrv.DestinationConfig {
+	if dc == nil {
+		return nil
+	}
+
+	return &sdrv.DestinationConfig{
+		OnSuccess: toDestinationDriver(dc.OnSuccess),
+		OnFailure: toDestinationDriver(dc.OnFailure),
+	}
+}
+
+func toDestinationJSON(d *sdrv.Destination) *destinationJSON {
+	if d == nil {
+		return nil
+	}
+
+	return &destinationJSON{Destination: d.Destination}
+}
+
+func toDestinationConfigJSON(dc *sdrv.DestinationConfig) *destinationConfigJSON {
+	if dc == nil {
+		return nil
+	}
+
+	return &destinationConfigJSON{
+		OnSuccess: toDestinationJSON(dc.OnSuccess),
+		OnFailure: toDestinationJSON(dc.OnFailure),
+	}
+}
+
+func toEventInvokeConfigResponse(c *sdrv.EventInvokeConfig) eventInvokeConfigResponse {
+	return eventInvokeConfigResponse{
+		FunctionArn:              c.FunctionArn,
+		LastModified:             epochSeconds(c.LastModified),
+		MaximumRetryAttempts:     c.MaximumRetryAttempts,
+		MaximumEventAgeInSeconds: c.MaximumEventAgeInSeconds,
+		DestinationConfig:        toDestinationConfigJSON(c.DestinationConfig),
+	}
+}
+
+// epochSeconds converts the driver's RFC3339 LastModified string to epoch
+// seconds for the wire; a blank/unparsable value falls back to 0.
+func epochSeconds(rfc3339 string) float64 {
+	t, err := time.Parse("2006-01-02T15:04:05Z", rfc3339)
+	if err != nil {
+		return 0
+	}
+
+	return float64(t.Unix())
+}
+
+// serveEventInvokeConfig dispatches the Lambda async-invoke-config API under
+// /2019-09-25/functions/{name}/event-invoke-config (PUT=put, POST=update,
+// GET=get, DELETE=delete) and .../event-invoke-config/list (GET=list). The
+// Qualifier query parameter scopes the config to a version or alias.
+func (h *Handler) serveEventInvokeConfig(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.fn.(eventInvokeConfigManager)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "InvalidRequestException", "event invoke config not supported")
+		return
+	}
+
+	rest := strings.TrimPrefix(r.URL.Path, eventInvokeConfigPrefix)
+	rest = strings.TrimPrefix(rest, "/")
+	parts := strings.Split(rest, "/")
+
+	const (
+		itemParts = 2 // {name}/event-invoke-config
+		listParts = 3 // {name}/event-invoke-config/list
+	)
+
+	if len(parts) < itemParts || parts[0] == "" || parts[1] != eventInvokeConfigSuffix {
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "unsupported Lambda path")
+		return
+	}
+
+	name := parts[0]
+
+	if len(parts) == listParts && parts[2] == eventInvokeListSegment {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "InvalidRequestException", "method not allowed")
+			return
+		}
+
+		listEventInvokeConfigs(w, r, mgr, name)
+
+		return
+	}
+
+	if len(parts) != itemParts {
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "unsupported Lambda path")
+		return
+	}
+
+	serveEventInvokeConfigItem(w, r, mgr, name)
+}
+
+// serveEventInvokeConfigItem handles PUT/POST/GET/DELETE on
+// .../{name}/event-invoke-config.
+func serveEventInvokeConfigItem(w http.ResponseWriter, r *http.Request, mgr eventInvokeConfigManager, name string) {
+	qualifier := r.URL.Query().Get("Qualifier")
+
+	switch r.Method {
+	case http.MethodPut:
+		writeEventInvokeConfig(w, r, mgr.PutFunctionEventInvokeConfig, name, qualifier)
+	case http.MethodPost:
+		writeEventInvokeConfig(w, r, mgr.UpdateFunctionEventInvokeConfig, name, qualifier)
+	case http.MethodGet:
+		c, err := mgr.GetFunctionEventInvokeConfig(r.Context(), name, qualifier)
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, toEventInvokeConfigResponse(c))
+	case http.MethodDelete:
+		if err := mgr.DeleteFunctionEventInvokeConfig(r.Context(), name, qualifier); err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "InvalidRequestException", "method not allowed")
+	}
+}
+
+// writeEventInvokeConfig decodes a put/update body and writes the result. The op
+// (put vs update) is supplied as fn so both share the decode/encode path.
+func writeEventInvokeConfig(
+	w http.ResponseWriter, r *http.Request,
+	fn func(context.Context, sdrv.EventInvokeConfig) (*sdrv.EventInvokeConfig, error),
+	name, qualifier string,
+) {
+	var req eventInvokeConfigRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	c, err := fn(r.Context(), sdrv.EventInvokeConfig{
+		FunctionName:             name,
+		Qualifier:                qualifier,
+		MaximumRetryAttempts:     req.MaximumRetryAttempts,
+		MaximumEventAgeInSeconds: req.MaximumEventAgeInSeconds,
+		DestinationConfig:        toDestinationConfigDriver(req.DestinationConfig),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toEventInvokeConfigResponse(c))
+}
+
+// listEventInvokeConfigs renders ListFunctionEventInvokeConfigs. The GET-only
+// method guard sits in the dispatcher (serveEventInvokeConfig).
+func listEventInvokeConfigs(w http.ResponseWriter, r *http.Request, mgr eventInvokeConfigManager, name string) {
+	configs, err := mgr.ListFunctionEventInvokeConfigs(r.Context(), name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	items := make([]eventInvokeConfigResponse, 0, len(configs))
+	for i := range configs {
+		items = append(items, toEventInvokeConfigResponse(&configs[i]))
+	}
+
+	writeJSON(w, http.StatusOK, listEventInvokeConfigsResponse{FunctionEventInvokeConfigs: items})
+}

--- a/server/aws/lambda/event_invoke_config_sdk_test.go
+++ b/server/aws/lambda/event_invoke_config_sdk_test.go
@@ -1,0 +1,236 @@
+package lambda_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/stackshy/cloudemu/v2"
+	awsprovider "github.com/stackshy/cloudemu/v2/providers/aws"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newLambdaSQSClients boots a server serving both the Lambda and SQS wire APIs
+// against one shared AWS cloud, so a Lambda DeadLetterConfig pointed at an SQS
+// queue actually delivers there (cloudemu.NewAWS already wires
+// Lambda.SetAsyncDestinationTargets(SQS, SNS)).
+func newLambdaSQSClients(t *testing.T) (*awslambda.Client, *awssqs.Client, *awsprovider.Provider) {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{Lambda: cloud.Lambda, SQS: cloud.SQS})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	lc := awslambda.NewFromConfig(cfg, func(o *awslambda.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+	sc := awssqs.NewFromConfig(cfg, func(o *awssqs.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+
+	return lc, sc, cloud
+}
+
+// TestSDKAsyncFailureDeliversToDLQ is the real-user end-to-end flow: a function
+// configured to fail, with a DeadLetterConfig pointed at a real SQS queue, is
+// invoked asynchronously (InvocationType=Event) via the aws-sdk-go-v2 client;
+// after retries the failed event lands in the SQS DLQ (observed via
+// ReceiveMessage). An OnFailure destination configured with
+// PutFunctionEventInvokeConfig receives the error envelope too.
+func TestSDKAsyncFailureDeliversToDLQ(t *testing.T) {
+	lc, sc, cloud := newLambdaSQSClients(t)
+	ctx := context.Background()
+
+	// A DLQ queue and a separate OnFailure destination queue.
+	dlqARN := createQueueARN(t, sc, "dlq")
+	failARN := createQueueARN(t, sc, "on-failure")
+
+	if _, err := lc.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName:     aws.String("worker"),
+		Runtime:          lambdatypes.RuntimeGo1x,
+		Role:             aws.String("arn:aws:iam::123456789012:role/test"),
+		Handler:          aws.String("main"),
+		Code:             &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+		DeadLetterConfig: &lambdatypes.DeadLetterConfig{TargetArn: aws.String(dlqARN)},
+	}); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	// OnFailure destination via PutFunctionEventInvokeConfig.
+	if _, err := lc.PutFunctionEventInvokeConfig(ctx, &awslambda.PutFunctionEventInvokeConfigInput{
+		FunctionName:         aws.String("worker"),
+		MaximumRetryAttempts: aws.Int32(1),
+		DestinationConfig: &lambdatypes.DestinationConfig{
+			OnFailure: &lambdatypes.OnFailure{Destination: aws.String(failARN)},
+		},
+	}); err != nil {
+		t.Fatalf("PutFunctionEventInvokeConfig: %v", err)
+	}
+
+	// Round-trip the config through the SDK.
+	got, err := lc.GetFunctionEventInvokeConfig(ctx, &awslambda.GetFunctionEventInvokeConfigInput{
+		FunctionName: aws.String("worker"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionEventInvokeConfig: %v", err)
+	}
+	if got.MaximumRetryAttempts == nil || *got.MaximumRetryAttempts != 1 {
+		t.Fatalf("MaximumRetryAttempts = %v, want 1", got.MaximumRetryAttempts)
+	}
+	if got.DestinationConfig == nil || got.DestinationConfig.OnFailure == nil {
+		t.Fatal("GetFunctionEventInvokeConfig dropped OnFailure destination")
+	}
+
+	// Make the function fail. The wire has no runtime; register a failing Go
+	// handler on the shared cloud (the same seam the sync-invoke SDK test uses).
+	cloud.Lambda.RegisterHandler("worker", func(_ context.Context, _ []byte) ([]byte, error) {
+		return nil, errors.New("kaboom")
+	})
+
+	// Async invoke: fire-and-forget, HTTP 202.
+	resp, err := lc.Invoke(ctx, &awslambda.InvokeInput{
+		FunctionName:   aws.String("worker"),
+		InvocationType: lambdatypes.InvocationTypeEvent,
+		Payload:        []byte(`{"order":42}`),
+	})
+	if err != nil {
+		t.Fatalf("Invoke(Event): %v", err)
+	}
+	if resp.StatusCode != 202 {
+		t.Fatalf("StatusCode = %d, want 202", resp.StatusCode)
+	}
+
+	// The failed event must now be in the SQS DLQ.
+	dlqBody := receiveOne(t, sc, "dlq")
+	if dlqBody != `{"order":42}` {
+		t.Fatalf("DLQ message = %q, want the original event", dlqBody)
+	}
+
+	// The OnFailure destination gets the async-destination envelope with error.
+	failBody := receiveOne(t, sc, "on-failure")
+	if !strings.Contains(failBody, "RetriesExhausted") || !strings.Contains(failBody, "kaboom") {
+		t.Fatalf("OnFailure envelope = %q, want RetriesExhausted + error", failBody)
+	}
+}
+
+// TestSDKAsyncSuccessNoDLQ guards that a successful async invoke does not deliver
+// to the DLQ.
+func TestSDKAsyncSuccessNoDLQ(t *testing.T) {
+	lc, sc, cloud := newLambdaSQSClients(t)
+	ctx := context.Background()
+
+	dlqARN := createQueueARN(t, sc, "dlq")
+
+	if _, err := lc.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName:     aws.String("ok"),
+		Runtime:          lambdatypes.RuntimeGo1x,
+		Role:             aws.String("arn:aws:iam::123456789012:role/test"),
+		Handler:          aws.String("main"),
+		Code:             &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+		DeadLetterConfig: &lambdatypes.DeadLetterConfig{TargetArn: aws.String(dlqARN)},
+	}); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	cloud.Lambda.RegisterHandler("ok", func(_ context.Context, p []byte) ([]byte, error) {
+		return p, nil
+	})
+
+	if _, err := lc.Invoke(ctx, &awslambda.InvokeInput{
+		FunctionName:   aws.String("ok"),
+		InvocationType: lambdatypes.InvocationTypeEvent,
+		Payload:        []byte(`{"n":1}`),
+	}); err != nil {
+		t.Fatalf("Invoke(Event): %v", err)
+	}
+
+	// Give any (erroneous) delivery a chance; then assert the DLQ is empty.
+	msgs, err := sc.ReceiveMessage(ctx, &awssqs.ReceiveMessageInput{
+		QueueUrl:            aws.String(queueURL(t, sc, "dlq")),
+		MaxNumberOfMessages: 1,
+		WaitTimeSeconds:     0,
+	})
+	if err != nil {
+		t.Fatalf("ReceiveMessage: %v", err)
+	}
+	if len(msgs.Messages) != 0 {
+		t.Fatalf("DLQ has %d messages on success, want 0", len(msgs.Messages))
+	}
+}
+
+func createQueueARN(t *testing.T, sc *awssqs.Client, name string) string {
+	t.Helper()
+
+	if _, err := sc.CreateQueue(context.Background(), &awssqs.CreateQueueInput{
+		QueueName: aws.String(name),
+	}); err != nil {
+		t.Fatalf("CreateQueue(%s): %v", name, err)
+	}
+
+	attrs, err := sc.GetQueueAttributes(context.Background(), &awssqs.GetQueueAttributesInput{
+		QueueUrl:       aws.String(queueURL(t, sc, name)),
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameQueueArn},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes(%s): %v", name, err)
+	}
+
+	return attrs.Attributes[string(sqstypes.QueueAttributeNameQueueArn)]
+}
+
+func queueURL(t *testing.T, sc *awssqs.Client, name string) string {
+	t.Helper()
+
+	out, err := sc.GetQueueUrl(context.Background(), &awssqs.GetQueueUrlInput{QueueName: aws.String(name)})
+	if err != nil {
+		t.Fatalf("GetQueueUrl(%s): %v", name, err)
+	}
+
+	return *out.QueueUrl
+}
+
+// receiveOne polls the named queue for a single message body, failing if none
+// arrives.
+func receiveOne(t *testing.T, sc *awssqs.Client, name string) string {
+	t.Helper()
+
+	url := queueURL(t, sc, name)
+
+	for i := 0; i < 20; i++ {
+		out, err := sc.ReceiveMessage(context.Background(), &awssqs.ReceiveMessageInput{
+			QueueUrl:            aws.String(url),
+			MaxNumberOfMessages: 1,
+		})
+		if err != nil {
+			t.Fatalf("ReceiveMessage(%s): %v", name, err)
+		}
+
+		if len(out.Messages) > 0 {
+			return *out.Messages[0].Body
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("no message arrived in queue %s", name)
+
+	return ""
+}

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -205,6 +205,7 @@ func (*Handler) Matches(r *http.Request) bool {
 		strings.HasPrefix(r.URL.Path, concurrencyReadPrefix) ||
 		strings.HasPrefix(r.URL.Path, layersPrefix) ||
 		strings.HasPrefix(r.URL.Path, functionURLPrefix) ||
+		strings.HasPrefix(r.URL.Path, eventInvokeConfigPrefix) ||
 		isCodeSigningPath(r.URL.Path)
 }
 
@@ -270,6 +271,8 @@ func (h *Handler) routePrefixed(w http.ResponseWriter, r *http.Request) bool {
 		h.serveLayers(w, r)
 	case strings.HasPrefix(r.URL.Path, functionURLPrefix):
 		h.serveFunctionURL(w, r)
+	case strings.HasPrefix(r.URL.Path, eventInvokeConfigPrefix):
+		h.serveEventInvokeConfig(w, r)
 	case isCodeSigningPath(r.URL.Path):
 		h.serveFunctionCodeSigningConfig(w, r)
 	default:

--- a/services/serverless/driver/driver.go
+++ b/services/serverless/driver/driver.go
@@ -150,6 +150,49 @@ type TracingConfig struct {
 	Mode string
 }
 
+// Destination is one async-invoke destination target (AWS Lambda Destination):
+// an SQS queue, SNS topic, Lambda function, or EventBridge event bus ARN that a
+// finished asynchronous invocation is routed to.
+type Destination struct {
+	Destination string // target ARN
+}
+
+// DestinationConfig routes the result of an asynchronous invocation (AWS Lambda
+// DestinationConfig): OnSuccess receives successful invocations, OnFailure
+// receives invocations that failed after exhausting their retries. Either may be
+// nil (no destination configured for that outcome).
+type DestinationConfig struct {
+	OnSuccess *Destination
+	OnFailure *Destination
+}
+
+// EventInvokeConfig is a function's asynchronous-invocation configuration (AWS
+// Lambda PutFunctionEventInvokeConfig), scoped to a version or alias via
+// Qualifier. It has no Azure Functions or GCP Cloud Functions equivalent, so it
+// is kept off the portable Serverless interface and applied/read through an
+// AWS-only optional interface, the same way Function URLs and DeadLetterConfig
+// are.
+type EventInvokeConfig struct {
+	FunctionName string
+	// Qualifier scopes the config to a published version or alias; empty (or
+	// "$LATEST") is the unqualified function config.
+	Qualifier string
+	// FunctionArn is the qualified function ARN echoed back in the response.
+	FunctionArn string
+	// MaximumRetryAttempts is the number of times Lambda retries a failed
+	// asynchronous invocation (0-2) before routing the event to the DLQ /
+	// OnFailure destination. Nil means the AWS default of 2.
+	MaximumRetryAttempts *int
+	// MaximumEventAgeInSeconds is how long (60-21600) Lambda keeps an
+	// unprocessed asynchronous event before discarding it. Nil means unset.
+	MaximumEventAgeInSeconds *int
+	// DestinationConfig routes the finished invocation's outcome to an
+	// OnSuccess / OnFailure target. Nil means no destinations configured.
+	DestinationConfig *DestinationConfig
+	// LastModified is the RFC3339 timestamp of the last Put/Update.
+	LastModified string
+}
+
 // EphemeralStorage is a function's /tmp size in MB (AWS Lambda EphemeralStorage).
 // Real Lambda accepts 512–10240 and defaults to 512 when the client omits it.
 type EphemeralStorage struct {


### PR DESCRIPTION
## Summary

AWS Lambda's async-invoke config and DLQ only round-tripped as configuration before this change — a failing asynchronous (`InvocationType=Event`) invoke never actually delivered to the configured dead-letter queue or on-failure destination. This wires that data plane.

## What changed

- **Async-invoke config (`PutFunctionEventInvokeConfig` family).** New AWS-only optional interface (`MaximumRetryAttempts`, `MaximumEventAgeInSeconds`, `DestinationConfig` OnSuccess/OnFailure), stored per qualifier with copy-on-write maps, plus Put/Update/Get/Delete/List wire routes under `2019-09-25/functions/{name}/event-invoke-config`. `LastModified` is emitted as epoch seconds (the rest-json timestamp shape the SDK decodes).
- **DLQ + destination delivery on async failure.** A failing `Event` invoke now routes:
  - the original event to the function's `DeadLetterConfig` SQS queue / SNS topic;
  - the async-destination envelope (with `condition: RetriesExhausted` + the error) to the `OnFailure` destination.
  - A successful `Event` invoke may route to `OnSuccess`. Sync invokes are untouched.
- **Reuses existing seams.** Delivery goes through the SQS `DeliverExternal` / SNS `PublishExternal` cross-service seams, wired in `providers/aws/aws.go` via `Lambda.SetAsyncDestinationTargets(SQS, SNS)`.
- **Recursion-safe.** Delivery re-enters Lambda only through the shared recursion-guarded `InvokeExternal` choke point, so a DLQ whose target re-invokes its own function terminates at `recursionguard.MaxDepth` instead of overflowing. `Invoke` was refactored to funnel the stub/handler/engine paths through one place (`runInvocation`) with the async-destination routing above it. Concurrency-safe (write-locked copy-on-write, `-race` clean).

## Tests

- Provider: config CRUD + validation, DLQ delivery on failure, OnFailure envelope, OnSuccess on success, sync-failure delivers nothing, and a DLQ→function recursion-bounded case.
- Real-user wire (aws-sdk-go-v2 lambda + sqs): a function set to fail with `DeadLetterConfig`→SQS + an `OnFailure`→SQS destination; async `Invoke(Event)` → the failed event appears in the DLQ via `ReceiveMessage` and the error envelope in the destination; a successful async invoke leaves the DLQ empty.
