### PR TITLE
feat(gcp-functions): Pub/Sub trigger delivery to gen2 functions

### DIFF
--- a/server/gcp/cloudfunctions/pubsubtrigger.go
+++ b/server/gcp/cloudfunctions/pubsubtrigger.go
@@ -2,43 +2,153 @@ package cloudfunctions
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
 	sdrv "github.com/stackshy/cloudemu/v2/services/serverless/driver"
 )
 
+// pubsubCloudEventType is the CloudEvent type Eventarc stamps on a gen2 Cloud
+// Function's Pub/Sub trigger delivery — the same value real GCP requires on
+// EventTrigger.EventType for a Pub/Sub-triggered gen2 function.
+const pubsubCloudEventType = "google.cloud.pubsub.topic.v1.messagePublished"
+
+// pubsubMessageEvent mirrors the JSON shape the pubsub handler marshals as
+// InvokeForTopic's event parameter (the flat pubsub.pubsubMessage: data,
+// attributes, messageId, publishTime, orderingKey). It is redeclared here
+// (server/gcp/pubsub does not export a message type) so InvokeForTopic can
+// decode the fields it needs to rebuild the gen2 CloudEvent envelope below.
+type pubsubMessageEvent struct {
+	Data        string            `json:"data"`
+	Attributes  map[string]string `json:"attributes,omitempty"`
+	OrderingKey string            `json:"orderingKey,omitempty"`
+	MessageID   string            `json:"messageId,omitempty"`
+	PublishTime string            `json:"publishTime,omitempty"`
+}
+
+// gen2PubsubEvent is the structured-mode CloudEvent body a real gen2
+// Eventarc-backed Pub/Sub trigger receives: the CloudEvents envelope
+// (specversion/type/source/id/time) wrapping the Pub/Sub MessagePublishedData
+// payload ({message, subscription}). Real Eventarc delivers binary-mode
+// CloudEvents (ce-* as HTTP headers, the bare data as the request body), but
+// driver.InvokeInput carries a payload only — no headers — so structured mode,
+// the whole envelope as one JSON body, is the closest self-contained
+// equivalent the emulator's invoke contract can deliver.
+type gen2PubsubEvent struct {
+	SpecVersion     string              `json:"specversion"`
+	Type            string              `json:"type"`
+	Source          string              `json:"source"`
+	ID              string              `json:"id"`
+	Time            string              `json:"time,omitempty"`
+	DataContentType string              `json:"datacontenttype"`
+	Data            gen2PubsubEventData `json:"data"`
+}
+
+// gen2PubsubEventData is the Pub/Sub MessagePublishedData shape: the message
+// plus the (Eventarc-managed) subscription it was delivered through.
+type gen2PubsubEventData struct {
+	Message      pubsubMessageEvent `json:"message"`
+	Subscription string             `json:"subscription"`
+}
+
 // InvokeForTopic delivers a published Pub/Sub message to every Cloud Function
 // whose eventTrigger targets the topic: gen1 functions whose
-// eventTrigger.resource is the topic, and gen2 functions whose
-// eventTrigger.pubsubTopic is the topic. Each matching function is invoked with
-// the message as its event (the legacy Pub/Sub {data, attributes, messageId,
-// publishTime} shape). Best-effort — a missing or failing function is swallowed
-// so a publish never fails. It implements the pubsub handler's FunctionInvoker.
+// eventTrigger.resource is the topic get the message as their event (the
+// legacy Pub/Sub {data, attributes, messageId, publishTime} shape); gen2
+// functions whose eventTrigger.pubsubTopic is the topic get the CloudEvent
+// envelope a real Eventarc-backed trigger delivers (see gen2PubsubEvent).
+// Best-effort — a missing or failing function is swallowed so a publish never
+// fails. It implements the pubsub handler's FunctionInvoker.
+//
+// ctx carries the re-entrant delivery depth (internal/recursionguard): a
+// function invoked from here that republishes to its own trigger topic would
+// otherwise recurse synchronously and unbounded (Publish -> InvokeForTopic ->
+// Invoke -> handler -> Publish -> ...), so once the depth reaches
+// recursionguard.MaxDepth this whole delivery hop is dropped.
 func (h *Handler) InvokeForTopic(ctx context.Context, project, topic string, event []byte) {
+	depth := recursionguard.Depth(ctx)
+	if depth >= recursionguard.MaxDepth {
+		return
+	}
+
+	ctx = recursionguard.WithDepth(ctx, depth+1)
+
+	gen1Targets, gen2Targets := h.pubsubTargetsLocked(project, topic)
+
+	for _, name := range gen1Targets {
+		_, _ = h.fn.Invoke(ctx, sdrv.InvokeInput{FunctionName: name, Payload: event, InvokeType: "Event"})
+	}
+
+	h.invokeGen2Targets(ctx, project, topic, gen2Targets, event)
+}
+
+// pubsubTargetsLocked snapshots the gen1 and gen2 function (short) names whose
+// eventTrigger targets topic.
+func (h *Handler) pubsubTargetsLocked(project, topic string) (gen1, gen2 []string) {
 	fullTopic := "projects/" + project + "/topics/" + topic
 
 	h.mu.RLock()
-	targets := make([]string, 0)
+	defer h.mu.RUnlock()
 
 	for key, meta := range h.gen1Meta {
 		if gen1PubsubTriggerMatches(meta.eventTrigger, topic, fullTopic) {
-			targets = append(targets, lastSegment(key))
+			gen1 = append(gen1, lastSegment(key))
 		}
 	}
 
 	for _, fn := range h.gen2 {
 		if fn.EventTrigger != nil && topicRefMatches(fn.EventTrigger.PubsubTopic, topic, fullTopic) {
-			targets = append(targets, lastSegment(fn.Name))
+			gen2 = append(gen2, lastSegment(fn.Name))
 		}
 	}
-	h.mu.RUnlock()
+
+	return gen1, gen2
+}
+
+// invokeGen2Targets decodes event into the flat message fields and invokes
+// each gen2 target with the CloudEvent-wrapped payload a real Eventarc
+// delivery carries. A malformed event (never produced by the pubsub handler,
+// but defensive) drops gen2 delivery only; the gen1 delivery above already
+// completed unaffected.
+func (h *Handler) invokeGen2Targets(ctx context.Context, project, topic string, targets []string, event []byte) {
+	if len(targets) == 0 {
+		return
+	}
+
+	var msg pubsubMessageEvent
+	if err := json.Unmarshal(event, &msg); err != nil {
+		return
+	}
 
 	for _, name := range targets {
-		_, _ = h.fn.Invoke(ctx, sdrv.InvokeInput{
-			FunctionName: name,
-			Payload:      event,
-			InvokeType:   "Event",
-		})
+		payload, err := json.Marshal(buildGen2PubsubEvent(project, topic, name, msg))
+		if err != nil {
+			continue
+		}
+
+		_, _ = h.fn.Invoke(ctx, sdrv.InvokeInput{FunctionName: name, Payload: payload, InvokeType: "Event"})
+	}
+}
+
+// buildGen2PubsubEvent wraps a published message into the CloudEvent shape a
+// gen2 function's Pub/Sub eventTrigger delivers. subscription is a synthetic
+// Eventarc-managed subscription name: real GCP auto-creates one per trigger
+// (eventarc-<region>-<trigger>-sub-<suffix>), and CloudEmu does not model
+// Eventarc trigger resources, so a stable name is derived from the target
+// function so repeated invocations for the same function are consistent.
+func buildGen2PubsubEvent(project, topic, function string, msg pubsubMessageEvent) gen2PubsubEvent {
+	return gen2PubsubEvent{
+		SpecVersion:     "1.0",
+		Type:            pubsubCloudEventType,
+		Source:          "//pubsub.googleapis.com/projects/" + project + "/topics/" + topic,
+		ID:              msg.MessageID,
+		Time:            msg.PublishTime,
+		DataContentType: "application/json",
+		Data: gen2PubsubEventData{
+			Message:      msg,
+			Subscription: "projects/" + project + "/subscriptions/eventarc-" + function + "-sub-000",
+		},
 	}
 }
 

--- a/server/gcp/pubsub/gen2_trigger_test.go
+++ b/server/gcp/pubsub/gen2_trigger_test.go
@@ -1,0 +1,277 @@
+package pubsub_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	cloudfunctions2 "google.golang.org/api/cloudfunctions/v2"
+	"google.golang.org/api/option"
+	pubsubv1 "google.golang.org/api/pubsub/v1"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	"github.com/stackshy/cloudemu/v2/server"
+	"github.com/stackshy/cloudemu/v2/server/gcp/cloudfunctions"
+	"github.com/stackshy/cloudemu/v2/server/gcp/pubsub"
+)
+
+// gen2FnParent is the v2 Cloud Functions parent every test below deploys
+// under.
+const gen2FnParent = "projects/" + project + "/locations/us-central1"
+
+// gen2PubsubCloudEvent mirrors the structured-mode CloudEvent body a gen2
+// Pub/Sub-triggered function receives (cloudfunctions.gen2PubsubEvent,
+// redeclared here since that's an unexported wire-package type).
+type gen2PubsubCloudEvent struct {
+	SpecVersion     string `json:"specversion"`
+	Type            string `json:"type"`
+	Source          string `json:"source"`
+	ID              string `json:"id"`
+	Time            string `json:"time"`
+	DataContentType string `json:"datacontenttype"`
+	Data            struct {
+		Message struct {
+			Data        string            `json:"data"`
+			Attributes  map[string]string `json:"attributes"`
+			MessageID   string            `json:"messageId"`
+			PublishTime string            `json:"publishTime"`
+		} `json:"message"`
+		Subscription string `json:"subscription"`
+	} `json:"data"`
+}
+
+// gen2Clients returns real Pub/Sub v1 and Cloud Functions v2 SDK clients
+// pointed at srvURL.
+func gen2Clients(t *testing.T, srvURL string) (*pubsubv1.Service, *cloudfunctions2.Service) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	psSvc, err := pubsubv1.NewService(ctx, option.WithEndpoint(srvURL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("pubsubv1.NewService: %v", err)
+	}
+
+	cfSvc, err := cloudfunctions2.NewService(ctx, option.WithEndpoint(srvURL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("cloudfunctions2.NewService: %v", err)
+	}
+
+	return psSvc, cfSvc
+}
+
+// createGen2PubsubFunction deploys a gen2 function whose eventTrigger binds
+// topic, mirroring how google_cloudfunctions2_function.event_trigger is
+// configured for a Pub/Sub trigger.
+func createGen2PubsubFunction(t *testing.T, cfSvc *cloudfunctions2.Service, name, topic string) {
+	t.Helper()
+
+	_, err := cfSvc.Projects.Locations.Functions.Create(gen2FnParent, &cloudfunctions2.Function{
+		BuildConfig: &cloudfunctions2.BuildConfig{Runtime: "go121", EntryPoint: "Handle"},
+		EventTrigger: &cloudfunctions2.EventTrigger{
+			EventType:   "google.cloud.pubsub.topic.v1.messagePublished",
+			PubsubTopic: "projects/" + project + "/topics/" + topic,
+		},
+	}).FunctionId(name).Context(context.Background()).Do()
+	if err != nil {
+		t.Fatalf("Create gen2 function %s: %v", name, err)
+	}
+}
+
+func publishMessage(t *testing.T, psSvc *pubsubv1.Service, topic, data string, attrs map[string]string) {
+	t.Helper()
+
+	_, err := psSvc.Projects.Topics.Publish("projects/"+project+"/topics/"+topic, &pubsubv1.PublishRequest{
+		Messages: []*pubsubv1.PubsubMessage{
+			{Data: base64.StdEncoding.EncodeToString([]byte(data)), Attributes: attrs},
+		},
+	}).Context(context.Background()).Do()
+	if err != nil {
+		t.Fatalf("Publish to %s: %v", topic, err)
+	}
+}
+
+// TestGen2FunctionFiresOnPubsubTrigger is the world-case delivery test: a gen2
+// function with a Pub/Sub eventTrigger fires with the CloudEvent shape a real
+// Eventarc-backed trigger delivers ({specversion, type, source, id, time,
+// data: {message: {...}, subscription}}), not the flat gen1 legacy shape.
+func TestGen2FunctionFiresOnPubsubTrigger(t *testing.T) {
+	srv, cloud := newServerWithFunctions(t)
+	psSvc, cfSvc := gen2Clients(t, srv.URL)
+
+	doRequest(t, srv, http.MethodPut, topicURL("orders"), `{}`)
+	createGen2PubsubFunction(t, cfSvc, "on-order", "orders")
+
+	var (
+		mu       sync.Mutex
+		payloads [][]byte
+	)
+
+	cloud.CloudFunctions.RegisterHandler("on-order", func(_ context.Context, payload []byte) ([]byte, error) {
+		mu.Lock()
+		payloads = append(payloads, append([]byte(nil), payload...))
+		mu.Unlock()
+
+		return nil, nil
+	})
+
+	publishMessage(t, psSvc, "orders", "order-42", map[string]string{"region": "us"})
+
+	got := waitForBytes(t, &mu, &payloads, 1)
+
+	var evt gen2PubsubCloudEvent
+	if err := json.Unmarshal(got[0], &evt); err != nil {
+		t.Fatalf("decode CloudEvent: %v (raw %s)", err, got[0])
+	}
+
+	if evt.SpecVersion != "1.0" {
+		t.Errorf("specversion = %q, want 1.0", evt.SpecVersion)
+	}
+
+	if evt.Type != "google.cloud.pubsub.topic.v1.messagePublished" {
+		t.Errorf("type = %q, want google.cloud.pubsub.topic.v1.messagePublished", evt.Type)
+	}
+
+	if evt.Source != "//pubsub.googleapis.com/projects/"+project+"/topics/orders" {
+		t.Errorf("source = %q", evt.Source)
+	}
+
+	if evt.ID == "" {
+		t.Error("id empty")
+	}
+
+	if evt.Data.Subscription == "" {
+		t.Error("data.subscription empty")
+	}
+
+	data, err := base64.StdEncoding.DecodeString(evt.Data.Message.Data)
+	if err != nil {
+		t.Fatalf("decode message.data: %v", err)
+	}
+
+	if string(data) != "order-42" {
+		t.Errorf("message.data = %q, want order-42", data)
+	}
+
+	if evt.Data.Message.MessageID == "" {
+		t.Error("message.messageId empty")
+	}
+
+	if evt.Data.Message.PublishTime == "" {
+		t.Error("message.publishTime empty")
+	}
+
+	if evt.Data.Message.Attributes["region"] != "us" {
+		t.Errorf("message.attributes = %v, want region=us", evt.Data.Message.Attributes)
+	}
+}
+
+// TestGen2FunctionDoesNotFireForUnboundTopic confirms a publish to a topic no
+// gen2 function's eventTrigger names never invokes it.
+func TestGen2FunctionDoesNotFireForUnboundTopic(t *testing.T) {
+	srv, cloud := newServerWithFunctions(t)
+	psSvc, cfSvc := gen2Clients(t, srv.URL)
+
+	doRequest(t, srv, http.MethodPut, topicURL("bound"), `{}`)
+	doRequest(t, srv, http.MethodPut, topicURL("other"), `{}`)
+	createGen2PubsubFunction(t, cfSvc, "on-bound", "bound")
+
+	var invocations int
+
+	cloud.CloudFunctions.RegisterHandler("on-bound", func(_ context.Context, _ []byte) ([]byte, error) {
+		invocations++
+		return nil, nil
+	})
+
+	publishMessage(t, psSvc, "other", "irrelevant", nil)
+
+	if invocations != 0 {
+		t.Fatalf("invocations = %d, want 0 (publish to an unbound topic must not fire)", invocations)
+	}
+}
+
+// TestGen2FunctionDoesNotFireAfterDelete confirms a publish after the gen2
+// function is deleted no longer invokes it (the driver entry is removed
+// alongside the gen2 map entry, per #996).
+func TestGen2FunctionDoesNotFireAfterDelete(t *testing.T) {
+	srv, cloud := newServerWithFunctions(t)
+	psSvc, cfSvc := gen2Clients(t, srv.URL)
+
+	doRequest(t, srv, http.MethodPut, topicURL("deletable"), `{}`)
+	createGen2PubsubFunction(t, cfSvc, "on-deletable", "deletable")
+
+	var invocations int
+
+	cloud.CloudFunctions.RegisterHandler("on-deletable", func(_ context.Context, _ []byte) ([]byte, error) {
+		invocations++
+		return nil, nil
+	})
+
+	if _, err := cfSvc.Projects.Locations.Functions.
+		Delete(gen2FnParent + "/functions/on-deletable").Context(context.Background()).Do(); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	publishMessage(t, psSvc, "deletable", "too-late", nil)
+
+	if invocations != 0 {
+		t.Fatalf("invocations = %d, want 0 (a deleted function must not fire)", invocations)
+	}
+}
+
+// TestGen2PubsubTriggerRecursionBounded confirms a gen2 function that
+// republishes to its own trigger topic terminates at recursionguard.MaxDepth
+// instead of recursing unbounded (Publish -> InvokeForTopic -> Invoke ->
+// handler -> Publish -> ...), mirroring the AWS S3 -> Lambda and DynamoDB
+// Streams -> Lambda write-back regression tests. It wires the pubsub and
+// cloudfunctions wire handlers directly (rather than through
+// newServerWithFunctions) so the handler can drive the recursive publish
+// in-process through the exact same PublishToTopic entrypoint GCS
+// object-change notifications use, keeping ctx (and its recursion depth)
+// flowing on one goroutine's call stack — the scenario the guard exists for.
+func TestGen2PubsubTriggerRecursionBounded(t *testing.T) {
+	cloud := cloudemu.NewGCP()
+
+	psHandler := pubsub.New(cloud.PubSub)
+	cfHandler := cloudfunctions.New(cloud.CloudFunctions)
+	psHandler.SetFunctionInvoker(cfHandler)
+
+	srv := httptest.NewServer(server.New(cfHandler, psHandler))
+	t.Cleanup(srv.Close)
+
+	doRequest(t, srv, http.MethodPut, topicURL("loopback"), `{}`)
+
+	_, cfSvc := gen2Clients(t, srv.URL)
+	createGen2PubsubFunction(t, cfSvc, "on-loopback", "loopback")
+
+	var (
+		mu          sync.Mutex
+		invocations int
+	)
+
+	cloud.CloudFunctions.RegisterHandler("on-loopback", func(ctx context.Context, _ []byte) ([]byte, error) {
+		mu.Lock()
+		invocations++
+		mu.Unlock()
+
+		psHandler.PublishToTopic(ctx, project, "loopback", []byte("again"), nil)
+
+		return nil, nil
+	})
+
+	psHandler.PublishToTopic(context.Background(), project, "loopback", []byte("start"), nil)
+
+	mu.Lock()
+	got := invocations
+	mu.Unlock()
+
+	if got != recursionguard.MaxDepth {
+		t.Fatalf("handler invoked %d times, want exactly %d (recursive-loop guard did not bound the chain)",
+			got, recursionguard.MaxDepth)
+	}
+}


### PR DESCRIPTION
## Summary

Gen2 Cloud Functions with a Pub/Sub `eventTrigger` were invoked with the exact same flat legacy message shape as gen1 (`{data, attributes, messageId, publishTime}`), not the CloudEvent envelope a real Eventarc-backed gen2 trigger actually delivers. `InvokeForTopic` (the wire-layer choke point PubSub -> Cloud Functions delivery already funneled through, per #803/#996) now shapes gen2 deliveries as the structured-mode CloudEvent body:

```json
{
  "specversion": "1.0",
  "type": "google.cloud.pubsub.topic.v1.messagePublished",
  "source": "//pubsub.googleapis.com/projects/{project}/topics/{topic}",
  "id": "<messageId>",
  "time": "<publishTime>",
  "datacontenttype": "application/json",
  "data": {
    "message": {"data": "<base64>", "messageId": "...", "publishTime": "...", "attributes": {...}},
    "subscription": "projects/{project}/subscriptions/eventarc-{function}-sub-000"
  }
}
```

gen1 event-triggered functions are unaffected — they keep receiving the flat legacy shape.

Also adds a recursion guard (`internal/recursionguard`, `MaxDepth`) around this delivery path, which had none: a gen2 function that republishes to its own trigger topic now terminates at 16 invocations instead of recursing unbounded, mirroring the existing AWS S3/DynamoDB -> Lambda and Azure Event Grid write-back guards.

## What's deferred

- GCS object-change triggers and gen1 HTTPS serving — separate, later PRs (out of scope here).
- Pub/Sub **push subscriptions** whose endpoint loops back into the emulator (the webhook-style delivery path, distinct from eventTrigger function delivery) have no recursion-depth propagation across that HTTP hop yet — `httpPushDeliverer` doesn't stamp/read `recursionguard.DepthHeader` the way Azure Event Grid's WebHook delivery does. Not addressed here since this PR's scope is the eventTrigger -> gen2 function path specifically.
- The gen2 CloudEvent's `subscription` field is a synthetic, stable-per-function name (`eventarc-<function>-sub-000`); CloudEmu does not model Eventarc trigger resources, so this is the closest reasonable approximation.

## Test plan

- New `TestGen2FunctionFiresOnPubsubTrigger` boots the full production GCP server, deploys a gen2 function with a Pub/Sub `eventTrigger` via the real `cloudfunctions/v2` SDK, publishes via the real `pubsub/v1` SDK, and asserts the CloudEvent envelope shape end-to-end (decoded base64 data, messageId, attributes, subscription).
- `TestGen2FunctionDoesNotFireForUnboundTopic` / `TestGen2FunctionDoesNotFireAfterDelete` cover the negatives.
- `TestGen2PubsubTriggerRecursionBounded` drives a self-republishing function to confirm it stops at exactly `recursionguard.MaxDepth`.
- `go build ./...`, targeted + broad `go test ./server/gcp/... ./providers/gcp/...` (incl. `-race`), `gofmt -l`, `golangci-lint` on touched packages, `go generate ./...` (no `docs/coverage` diff — wire-only change), and `go mod tidy` (no diff) all pass.