### PR TITLE
feat(lambda): provisioned concurrency configuration

### DIFF
--- a/providers/aws/lambda/concurrency.go
+++ b/providers/aws/lambda/concurrency.go
@@ -7,11 +7,24 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
 )
 
-// PutFunctionConcurrency sets reserved concurrency for a function.
+// PutFunctionConcurrency sets reserved concurrency for a function. Real Lambda
+// blocks lowering reserved concurrency below the sum of provisioned
+// concurrency already configured across the function's versions/aliases (see
+// DeleteFunctionConcurrency for the same guard on full removal), since
+// provisioned concurrency is carved out of the reserved budget.
 func (m *Mock) PutFunctionConcurrency(_ context.Context, cfg driver.ConcurrencyConfig) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	fd, ok := m.funcs.Get(cfg.FunctionName)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
+	}
+
+	if provisioned := sumProvisionedConcurrency(&fd); cfg.ReservedConcurrentExecutions < provisioned {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"ReservedConcurrentExecutions %d is less than the provisioned concurrency (%d) already "+
+				"configured for function %s", cfg.ReservedConcurrentExecutions, provisioned, cfg.FunctionName)
 	}
 
 	fd.concurrency = &driver.ConcurrencyConfig{
@@ -39,11 +52,23 @@ func (m *Mock) GetFunctionConcurrency(_ context.Context, functionName string) (*
 	return &result, nil
 }
 
-// DeleteFunctionConcurrency removes the concurrency configuration for a function.
+// DeleteFunctionConcurrency removes the concurrency configuration for a
+// function. Real Lambda blocks removing reserved concurrency entirely while
+// any provisioned concurrency is still configured on the function (the same
+// invariant PutFunctionConcurrency enforces for lowering it).
 func (m *Mock) DeleteFunctionConcurrency(_ context.Context, functionName string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	fd, ok := m.funcs.Get(functionName)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	if provisioned := sumProvisionedConcurrency(&fd); provisioned > 0 {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"cannot remove reserved concurrency for function %s: %d provisioned concurrency is still configured",
+			functionName, provisioned)
 	}
 
 	fd.concurrency = nil

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -109,6 +109,12 @@ type funcData struct {
 	// qualifier (normalized via policyKey: "" and "$LATEST" collapse to the
 	// unqualified function config), matching AWS's per-version/alias scoping.
 	eventInvokeConfigs map[string]driver.EventInvokeConfig
+	// provisionedConcurrencyConfigs holds the provisioned-concurrency config
+	// keyed by qualifier (a published version or alias name — unlike
+	// eventInvokeConfigs, $LATEST/unqualified is rejected outright rather than
+	// normalized, since real Lambda cannot attach provisioned concurrency to
+	// the mutable $LATEST code).
+	provisionedConcurrencyConfigs map[string]driver.ProvisionedConcurrencyConfig
 }
 
 // Mock is an in-memory mock implementation of AWS Lambda.

--- a/providers/aws/lambda/provisioned_concurrency.go
+++ b/providers/aws/lambda/provisioned_concurrency.go
@@ -1,0 +1,172 @@
+package lambda
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// statusReady is the terminal Status a provisioned-concurrency allocation
+// reports once it settles. The emulator has no real cold-start pool, so a Put
+// allocates synchronously and is READY immediately — there is no IN_PROGRESS
+// window to observe.
+const statusReady = "READY"
+
+// minProvisionedConcurrentExecutions is the minimum ProvisionedConcurrentExecutions
+// PutProvisionedConcurrencyConfig accepts; a value below it is rejected with
+// InvalidParameterValueException, matching real Lambda.
+const minProvisionedConcurrentExecutions = 1
+
+// PutFunctionProvisionedConcurrencyConfig sets (replacing any existing) the
+// provisioned-concurrency configuration for a published version or alias
+// qualifier. Real Lambda rejects an unqualified/$LATEST target — provisioned
+// concurrency can only attach to an immutable qualifier, because $LATEST's
+// code can change underneath it — and rejects a requested amount that exceeds
+// the function's reserved concurrency (when reserved concurrency is
+// configured), since provisioned concurrency is carved out of that budget.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) PutFunctionProvisionedConcurrencyConfig(
+	_ context.Context, cfg driver.ProvisionedConcurrencyConfig,
+) (*driver.ProvisionedConcurrencyConfig, error) {
+	if cfg.RequestedProvisionedConcurrentExecutions < minProvisionedConcurrentExecutions {
+		return nil, cerrors.Newf(cerrors.InvalidArgument,
+			"ProvisionedConcurrentExecutions %d must be >= %d",
+			cfg.RequestedProvisionedConcurrentExecutions, minProvisionedConcurrentExecutions)
+	}
+
+	if cfg.Qualifier == "" || cfg.Qualifier == latestVersion {
+		return nil, cerrors.New(cerrors.InvalidArgument,
+			"ProvisionedConcurrencyConfig cannot be applied to $LATEST; specify a published version or alias")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fd, ok := m.funcs.Get(cfg.FunctionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
+	}
+
+	if _, err := m.resolveQualifier(&fd, cfg.Qualifier, nil); err != nil {
+		return nil, err
+	}
+
+	if fd.concurrency != nil && cfg.RequestedProvisionedConcurrentExecutions > fd.concurrency.ReservedConcurrentExecutions {
+		return nil, cerrors.Newf(cerrors.InvalidArgument,
+			"ProvisionedConcurrentExecutions %d exceeds the reserved concurrency (%d) configured for function %s",
+			cfg.RequestedProvisionedConcurrentExecutions, fd.concurrency.ReservedConcurrentExecutions, cfg.FunctionName)
+	}
+
+	stored := driver.ProvisionedConcurrencyConfig{
+		FunctionName:                             cfg.FunctionName,
+		Qualifier:                                cfg.Qualifier,
+		FunctionArn:                              qualifiedARN(fd.info.ARN, cfg.Qualifier),
+		RequestedProvisionedConcurrentExecutions: cfg.RequestedProvisionedConcurrentExecutions,
+		AvailableProvisionedConcurrentExecutions: cfg.RequestedProvisionedConcurrentExecutions,
+		AllocatedProvisionedConcurrentExecutions: cfg.RequestedProvisionedConcurrentExecutions,
+		Status:                                   statusReady,
+		LastModified:                             m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+
+	setProvisionedConcurrencyConfig(&fd, stored)
+	m.funcs.Set(cfg.FunctionName, fd)
+
+	result := stored
+
+	return &result, nil
+}
+
+// GetFunctionProvisionedConcurrencyConfig returns the provisioned-concurrency
+// config for a function's version/alias, or NotFound
+// (ProvisionedConcurrencyConfigNotFoundException on the wire) when none is set.
+func (m *Mock) GetFunctionProvisionedConcurrencyConfig(
+	_ context.Context, functionName, qualifier string,
+) (*driver.ProvisionedConcurrencyConfig, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	cfg, ok := fd.provisionedConcurrencyConfigs[qualifier]
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound,
+			"no provisioned concurrency config for function %s qualifier %s", functionName, qualifier)
+	}
+
+	result := cfg
+
+	return &result, nil
+}
+
+// DeleteFunctionProvisionedConcurrencyConfig removes the provisioned-concurrency
+// config for a function's version/alias.
+func (m *Mock) DeleteFunctionProvisionedConcurrencyConfig(_ context.Context, functionName, qualifier string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	if _, exists := fd.provisionedConcurrencyConfigs[qualifier]; !exists {
+		return cerrors.Newf(cerrors.NotFound,
+			"no provisioned concurrency config for function %s qualifier %s", functionName, qualifier)
+	}
+
+	next := make(map[string]driver.ProvisionedConcurrencyConfig, len(fd.provisionedConcurrencyConfigs))
+
+	for k, v := range fd.provisionedConcurrencyConfigs {
+		if k != qualifier {
+			next[k] = v
+		}
+	}
+
+	fd.provisionedConcurrencyConfigs = next
+	m.funcs.Set(functionName, fd)
+
+	return nil
+}
+
+// ListFunctionProvisionedConcurrencyConfigs returns every provisioned-concurrency
+// config set on a function (one per qualifier), backing AWS
+// ListProvisionedConcurrencyConfigs.
+func (m *Mock) ListFunctionProvisionedConcurrencyConfigs(
+	_ context.Context, functionName string,
+) ([]driver.ProvisionedConcurrencyConfig, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	out := make([]driver.ProvisionedConcurrencyConfig, 0, len(fd.provisionedConcurrencyConfigs))
+	for _, cfg := range fd.provisionedConcurrencyConfigs {
+		out = append(out, cfg)
+	}
+
+	return out, nil
+}
+
+// setProvisionedConcurrencyConfig stores cfg under its qualifier key using
+// copy-on-write: a fresh map is built so a concurrent reader holding an
+// earlier funcData copy still sees an immutable snapshot (-race clean).
+//
+//nolint:gocritic // hugeParam: cfg mirrors the driver value type stored by value.
+func setProvisionedConcurrencyConfig(fd *funcData, cfg driver.ProvisionedConcurrencyConfig) {
+	next := make(map[string]driver.ProvisionedConcurrencyConfig, len(fd.provisionedConcurrencyConfigs)+1)
+
+	for k, v := range fd.provisionedConcurrencyConfigs {
+		next[k] = v
+	}
+
+	next[cfg.Qualifier] = cfg
+	fd.provisionedConcurrencyConfigs = next
+}

--- a/providers/aws/lambda/provisioned_concurrency.go
+++ b/providers/aws/lambda/provisioned_concurrency.go
@@ -20,11 +20,16 @@ const minProvisionedConcurrentExecutions = 1
 
 // PutFunctionProvisionedConcurrencyConfig sets (replacing any existing) the
 // provisioned-concurrency configuration for a published version or alias
-// qualifier. Real Lambda rejects an unqualified/$LATEST target — provisioned
-// concurrency can only attach to an immutable qualifier, because $LATEST's
-// code can change underneath it — and rejects a requested amount that exceeds
-// the function's reserved concurrency (when reserved concurrency is
-// configured), since provisioned concurrency is carved out of that budget.
+// qualifier. Real Lambda rejects a target that resolves to $LATEST —
+// provisioned concurrency can only attach to an immutable qualifier, because
+// $LATEST's code can change underneath it — whether that's the literal
+// unqualified/"$LATEST" qualifier or an alias whose own FunctionVersion is
+// $LATEST (a valid CreateAlias target). It also rejects a weighted alias
+// (RoutingConfig.AdditionalVersionWeights set), since provisioned concurrency
+// cannot attach to a target split across versions, and rejects a requested
+// amount that exceeds the function's reserved concurrency (when reserved
+// concurrency is configured), since provisioned concurrency is carved out of
+// that budget.
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) PutFunctionProvisionedConcurrencyConfig(
@@ -36,11 +41,6 @@ func (m *Mock) PutFunctionProvisionedConcurrencyConfig(
 			cfg.RequestedProvisionedConcurrentExecutions, minProvisionedConcurrentExecutions)
 	}
 
-	if cfg.Qualifier == "" || cfg.Qualifier == latestVersion {
-		return nil, cerrors.New(cerrors.InvalidArgument,
-			"ProvisionedConcurrencyConfig cannot be applied to $LATEST; specify a published version or alias")
-	}
-
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -49,8 +49,20 @@ func (m *Mock) PutFunctionProvisionedConcurrencyConfig(
 		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
 	}
 
-	if _, err := m.resolveQualifier(&fd, cfg.Qualifier, nil); err != nil {
+	resolved, err := m.resolveQualifier(&fd, cfg.Qualifier, nil)
+	if err != nil {
 		return nil, err
+	}
+
+	if resolved == latestVersion {
+		return nil, cerrors.New(cerrors.InvalidArgument,
+			"ProvisionedConcurrencyConfig cannot be applied to $LATEST or an alias pointing at $LATEST; "+
+				"specify a published version or an alias that targets one")
+	}
+
+	if aliasHasWeightedRouting(&fd, cfg.Qualifier) {
+		return nil, cerrors.New(cerrors.InvalidArgument,
+			"ProvisionedConcurrencyConfig cannot be applied to a weighted alias")
 	}
 
 	if fd.concurrency != nil && cfg.RequestedProvisionedConcurrentExecutions > fd.concurrency.ReservedConcurrentExecutions {
@@ -169,4 +181,37 @@ func setProvisionedConcurrencyConfig(fd *funcData, cfg driver.ProvisionedConcurr
 
 	next[cfg.Qualifier] = cfg
 	fd.provisionedConcurrencyConfigs = next
+}
+
+// aliasHasWeightedRouting reports whether qualifier names an alias with a
+// weighted RoutingConfig (AdditionalVersionWeights set) — provisioned
+// concurrency cannot attach to a target split across versions. A qualifier
+// that names a version (not an alias) or an unweighted alias returns false.
+// ad is a shared pointer held in the aliases store, so its alias field is read
+// under ad.mu, the same guard UpdateAlias/GetAlias/ListAliases use.
+func aliasHasWeightedRouting(fd *funcData, qualifier string) bool {
+	ad, ok := fd.aliases.Get(qualifier)
+	if !ok {
+		return false
+	}
+
+	ad.mu.Lock()
+	defer ad.mu.Unlock()
+
+	return ad.alias.RoutingConfig != nil && len(ad.alias.RoutingConfig.AdditionalVersionWeights) > 0
+}
+
+// sumProvisionedConcurrency totals the RequestedProvisionedConcurrentExecutions
+// across every qualifier's provisioned-concurrency config on fd. Reserved
+// concurrency can never be set (or fully removed) below this total, since
+// provisioned concurrency is carved out of the reserved budget — see
+// PutFunctionConcurrency and DeleteFunctionConcurrency.
+func sumProvisionedConcurrency(fd *funcData) int {
+	var total int
+
+	for _, cfg := range fd.provisionedConcurrencyConfigs {
+		total += cfg.RequestedProvisionedConcurrentExecutions
+	}
+
+	return total
 }

--- a/providers/aws/lambda/provisioned_concurrency_test.go
+++ b/providers/aws/lambda/provisioned_concurrency_test.go
@@ -1,0 +1,238 @@
+package lambda
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// createPublishedFunc creates my-func and publishes version "1", returning that
+// version.
+func createPublishedFunc(t *testing.T, m *Mock) *driver.FunctionVersion {
+	t.Helper()
+
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	ver, err := m.PublishVersion(ctx, "my-func", "v1")
+	if err != nil {
+		t.Fatalf("PublishVersion: %v", err)
+	}
+
+	return ver
+}
+
+func TestProvisionedConcurrencyRoundTrip(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	ver := createPublishedFunc(t, m)
+
+	put, err := m.PutFunctionProvisionedConcurrencyConfig(ctx, driver.ProvisionedConcurrencyConfig{
+		FunctionName:                             "my-func",
+		Qualifier:                                ver.Version,
+		RequestedProvisionedConcurrentExecutions: 5,
+	})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	if put.Status != statusReady {
+		t.Fatalf("Status = %q, want READY", put.Status)
+	}
+
+	if put.RequestedProvisionedConcurrentExecutions != 5 ||
+		put.AvailableProvisionedConcurrentExecutions != 5 ||
+		put.AllocatedProvisionedConcurrentExecutions != 5 {
+		t.Fatalf("Put = %+v, want requested=available=allocated=5", put)
+	}
+
+	got, err := m.GetFunctionProvisionedConcurrencyConfig(ctx, "my-func", ver.Version)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.RequestedProvisionedConcurrentExecutions != 5 {
+		t.Fatalf("Get requested = %d, want 5", got.RequestedProvisionedConcurrentExecutions)
+	}
+
+	list, err := m.ListFunctionProvisionedConcurrencyConfigs(ctx, "my-func")
+	if err != nil || len(list) != 1 {
+		t.Fatalf("List = %v (err %v), want 1 config", list, err)
+	}
+
+	if err := m.DeleteFunctionProvisionedConcurrencyConfig(ctx, "my-func", ver.Version); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if _, err := m.GetFunctionProvisionedConcurrencyConfig(ctx, "my-func", ver.Version); err == nil {
+		t.Fatal("Get after Delete: want NotFound")
+	}
+}
+
+func TestProvisionedConcurrencyRejectsLatest(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	for _, qualifier := range []string{"", latestVersion} {
+		_, err := m.PutFunctionProvisionedConcurrencyConfig(ctx, driver.ProvisionedConcurrencyConfig{
+			FunctionName:                             "my-func",
+			Qualifier:                                qualifier,
+			RequestedProvisionedConcurrentExecutions: 1,
+		})
+		if err == nil {
+			t.Fatalf("qualifier %q: want InvalidArgument for $LATEST/unqualified", qualifier)
+		}
+	}
+}
+
+func TestProvisionedConcurrencyRejectsUnknownQualifier(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	if _, err := m.PutFunctionProvisionedConcurrencyConfig(ctx, driver.ProvisionedConcurrencyConfig{
+		FunctionName:                             "my-func",
+		Qualifier:                                "99",
+		RequestedProvisionedConcurrentExecutions: 1,
+	}); err == nil {
+		t.Fatal("unpublished version 99: want NotFound")
+	}
+}
+
+func TestProvisionedConcurrencyRejectsBelowMinimum(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	ver := createPublishedFunc(t, m)
+
+	if _, err := m.PutFunctionProvisionedConcurrencyConfig(ctx, driver.ProvisionedConcurrencyConfig{
+		FunctionName:                             "my-func",
+		Qualifier:                                ver.Version,
+		RequestedProvisionedConcurrentExecutions: 0,
+	}); err == nil {
+		t.Fatal("requested=0: want InvalidArgument")
+	}
+}
+
+// TestProvisionedConcurrencyBoundByReserved covers the AWS constraint:
+// provisioned concurrency cannot exceed the function's reserved concurrency
+// once one is configured, since it is carved out of that budget.
+func TestProvisionedConcurrencyBoundByReserved(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	ver := createPublishedFunc(t, m)
+
+	if err := m.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{
+		FunctionName:                 "my-func",
+		ReservedConcurrentExecutions: 3,
+	}); err != nil {
+		t.Fatalf("PutFunctionConcurrency: %v", err)
+	}
+
+	// Within the reserved budget: succeeds.
+	if _, err := m.PutFunctionProvisionedConcurrencyConfig(ctx, driver.ProvisionedConcurrencyConfig{
+		FunctionName:                             "my-func",
+		Qualifier:                                ver.Version,
+		RequestedProvisionedConcurrentExecutions: 3,
+	}); err != nil {
+		t.Fatalf("Put within reserved budget: %v", err)
+	}
+
+	if err := m.DeleteFunctionProvisionedConcurrencyConfig(ctx, "my-func", ver.Version); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// Exceeding the reserved budget: rejected.
+	if _, err := m.PutFunctionProvisionedConcurrencyConfig(ctx, driver.ProvisionedConcurrencyConfig{
+		FunctionName:                             "my-func",
+		Qualifier:                                ver.Version,
+		RequestedProvisionedConcurrentExecutions: 4,
+	}); err == nil {
+		t.Fatal("Put over reserved budget: want InvalidArgument")
+	}
+}
+
+func TestProvisionedConcurrencyUnknownFunction(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.PutFunctionProvisionedConcurrencyConfig(ctx, driver.ProvisionedConcurrencyConfig{
+		FunctionName:                             "absent",
+		Qualifier:                                "1",
+		RequestedProvisionedConcurrentExecutions: 1,
+	}); err == nil {
+		t.Fatal("unknown function Put: want NotFound")
+	}
+
+	if _, err := m.GetFunctionProvisionedConcurrencyConfig(ctx, "absent", "1"); err == nil {
+		t.Fatal("unknown function Get: want NotFound")
+	}
+
+	if err := m.DeleteFunctionProvisionedConcurrencyConfig(ctx, "absent", "1"); err == nil {
+		t.Fatal("unknown function Delete: want NotFound")
+	}
+
+	if _, err := m.ListFunctionProvisionedConcurrencyConfigs(ctx, "absent"); err == nil {
+		t.Fatal("unknown function List: want NotFound")
+	}
+}
+
+// TestProvisionedConcurrencyCOWIndependence proves setProvisionedConcurrencyConfig's
+// copy-on-write map means a concurrent reader holding an earlier funcData copy
+// never observes a partially written map -- guards -race cleanliness alongside
+// the concurrent writers below.
+func TestProvisionedConcurrencyCOWIndependence(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	vers := make([]*driver.FunctionVersion, 0, 3)
+
+	for i := 0; i < 3; i++ {
+		ver, err := m.PublishVersion(ctx, "my-func", "")
+		if err != nil {
+			t.Fatalf("PublishVersion: %v", err)
+		}
+
+		vers = append(vers, ver)
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(len(vers))
+
+	for _, ver := range vers {
+		go func(qualifier string) {
+			defer wg.Done()
+
+			if _, err := m.PutFunctionProvisionedConcurrencyConfig(ctx, driver.ProvisionedConcurrencyConfig{
+				FunctionName:                             "my-func",
+				Qualifier:                                qualifier,
+				RequestedProvisionedConcurrentExecutions: 1,
+			}); err != nil {
+				t.Errorf("concurrent Put(%s): %v", qualifier, err)
+			}
+		}(ver.Version)
+	}
+
+	wg.Wait()
+
+	list, err := m.ListFunctionProvisionedConcurrencyConfigs(ctx, "my-func")
+	if err != nil || len(list) != len(vers) {
+		t.Fatalf("List = %v (err %v), want %d configs", list, err, len(vers))
+	}
+}

--- a/providers/aws/lambda/provisioned_concurrency_test.go
+++ b/providers/aws/lambda/provisioned_concurrency_test.go
@@ -163,6 +163,126 @@ func TestProvisionedConcurrencyBoundByReserved(t *testing.T) {
 	}
 }
 
+// TestProvisionedConcurrencyRejectsAliasPointingAtLatest covers the case an
+// unqualified/$LATEST literal check alone misses: an alias whose own
+// FunctionVersion is $LATEST (a valid CreateAlias target) still resolves to
+// $LATEST via resolveQualifier, so PutFunctionProvisionedConcurrencyConfig
+// must reject it exactly like the literal qualifier would.
+func TestProvisionedConcurrencyRejectsAliasPointingAtLatest(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	if _, err := m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "my-func", Name: "dev", FunctionVersion: latestVersion,
+	}); err != nil {
+		t.Fatalf("CreateAlias: %v", err)
+	}
+
+	if _, err := m.PutFunctionProvisionedConcurrencyConfig(ctx, driver.ProvisionedConcurrencyConfig{
+		FunctionName:                             "my-func",
+		Qualifier:                                "dev",
+		RequestedProvisionedConcurrentExecutions: 1,
+	}); err == nil {
+		t.Fatal("alias pointing at $LATEST: want InvalidArgument")
+	}
+}
+
+// TestProvisionedConcurrencyRejectsWeightedAlias covers the AWS constraint
+// that provisioned concurrency cannot attach to a weighted alias, since its
+// traffic is split across multiple versions rather than one fixed target.
+func TestProvisionedConcurrencyRejectsWeightedAlias(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	ver := createPublishedFunc(t, m)
+
+	ver2, err := m.PublishVersion(ctx, "my-func", "")
+	if err != nil {
+		t.Fatalf("PublishVersion: %v", err)
+	}
+
+	if _, err := m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "my-func", Name: "canary", FunctionVersion: ver.Version,
+		RoutingConfig: &driver.AliasRoutingConfig{AdditionalVersionWeights: map[string]float64{ver2.Version: 0.1}},
+	}); err != nil {
+		t.Fatalf("CreateAlias: %v", err)
+	}
+
+	if _, err := m.PutFunctionProvisionedConcurrencyConfig(ctx, driver.ProvisionedConcurrencyConfig{
+		FunctionName:                             "my-func",
+		Qualifier:                                "canary",
+		RequestedProvisionedConcurrentExecutions: 1,
+	}); err == nil {
+		t.Fatal("weighted alias: want InvalidArgument")
+	}
+}
+
+// TestReservedConcurrencyBlockedBelowProvisioned covers the AWS invariant
+// PutFunctionConcurrency/DeleteFunctionConcurrency must preserve once
+// provisioned concurrency exists: reserved concurrency can never be lowered
+// below, or removed while exceeding, the sum of provisioned concurrency
+// already carved out of it.
+func TestReservedConcurrencyBlockedBelowProvisioned(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	ver := createPublishedFunc(t, m)
+
+	if err := m.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{
+		FunctionName:                 "my-func",
+		ReservedConcurrentExecutions: 5,
+	}); err != nil {
+		t.Fatalf("PutFunctionConcurrency(5): %v", err)
+	}
+
+	if _, err := m.PutFunctionProvisionedConcurrencyConfig(ctx, driver.ProvisionedConcurrencyConfig{
+		FunctionName:                             "my-func",
+		Qualifier:                                ver.Version,
+		RequestedProvisionedConcurrentExecutions: 5,
+	}); err != nil {
+		t.Fatalf("Put provisioned=5: %v", err)
+	}
+
+	// Lowering reserved below the provisioned total (5) is rejected.
+	if err := m.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{
+		FunctionName:                 "my-func",
+		ReservedConcurrentExecutions: 1,
+	}); err == nil {
+		t.Fatal("lower reserved below provisioned: want InvalidArgument")
+	}
+
+	// Removing reserved entirely while provisioned concurrency exists is
+	// rejected.
+	if err := m.DeleteFunctionConcurrency(ctx, "my-func"); err == nil {
+		t.Fatal("remove reserved with provisioned still configured: want InvalidArgument")
+	}
+
+	// Reserved concurrency is unchanged after both rejected attempts.
+	got, err := m.GetFunctionConcurrency(ctx, "my-func")
+	if err != nil || got.ReservedConcurrentExecutions != 5 {
+		t.Fatalf("reserved concurrency = %+v, err %v, want unchanged at 5", got, err)
+	}
+
+	// Once the provisioned config is removed, lowering (or removing) reserved
+	// concurrency is allowed again.
+	if err := m.DeleteFunctionProvisionedConcurrencyConfig(ctx, "my-func", ver.Version); err != nil {
+		t.Fatalf("Delete provisioned: %v", err)
+	}
+
+	if err := m.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{
+		FunctionName:                 "my-func",
+		ReservedConcurrentExecutions: 1,
+	}); err != nil {
+		t.Fatalf("lower reserved after provisioned removed: %v", err)
+	}
+
+	if err := m.DeleteFunctionConcurrency(ctx, "my-func"); err != nil {
+		t.Fatalf("remove reserved after provisioned removed: %v", err)
+	}
+}
+
 func TestProvisionedConcurrencyUnknownFunction(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/providers/aws/lambda/snapshot.go
+++ b/providers/aws/lambda/snapshot.go
@@ -46,6 +46,9 @@ type funcSnapshot struct {
 	// EventInvokeConfigs is the async-invoke config per qualifier (retries,
 	// event age, OnSuccess/OnFailure destinations).
 	EventInvokeConfigs map[string]driver.EventInvokeConfig `json:"eventInvokeConfigs,omitempty"`
+	// ProvisionedConcurrencyConfigs is the provisioned-concurrency config per
+	// qualifier (a published version or alias name).
+	ProvisionedConcurrencyConfigs map[string]driver.ProvisionedConcurrencyConfig `json:"provisionedConcurrencyConfigs,omitempty"`
 }
 
 // versionSnapshot mirrors versionData (all fields unexported). Config carries the
@@ -113,6 +116,7 @@ func snapshotFunc(fd *funcData) *funcSnapshot {
 		Info: fd.info, EngineBacked: fd.engineBacked, NextVersion: fd.nextVersion,
 		Concurrency: fd.concurrency, Policies: fd.policies, URLConfig: fd.urlConfig,
 		AWSConfig: fd.awsConfig, EventInvokeConfigs: fd.eventInvokeConfigs,
+		ProvisionedConcurrencyConfigs: fd.provisionedConcurrencyConfigs,
 	}
 
 	for _, v := range fd.versions {
@@ -170,7 +174,8 @@ func (m *Mock) restoreFunc(name string, fs *funcSnapshot) funcData {
 		info: fs.Info, engineBacked: fs.EngineBacked, nextVersion: fs.NextVersion,
 		aliases: memstore.New[*aliasData](), concurrency: fs.Concurrency,
 		policies: fs.Policies, urlConfig: fs.URLConfig, awsConfig: fs.AWSConfig,
-		eventInvokeConfigs: fs.EventInvokeConfigs,
+		eventInvokeConfigs:            fs.EventInvokeConfigs,
+		provisionedConcurrencyConfigs: fs.ProvisionedConcurrencyConfigs,
 	}
 
 	// Re-link the live handler if the host process has registered one for this

--- a/providers/aws/lambda/snapshot_test.go
+++ b/providers/aws/lambda/snapshot_test.go
@@ -91,3 +91,47 @@ func TestSnapshotRoundTripLambda(t *testing.T) {
 		t.Fatalf("restored esm = %+v, err %v", gotESM, err)
 	}
 }
+
+// TestSnapshotRoundTripProvisionedConcurrency proves a snapshot/restore
+// round-trip preserves a function's per-qualifier provisioned-concurrency
+// config.
+func TestSnapshotRoundTripProvisionedConcurrency(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	if _, err := src.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	ver, err := src.PublishVersion(ctx, "my-func", "v1")
+	if err != nil {
+		t.Fatalf("PublishVersion: %v", err)
+	}
+
+	if _, err := src.PutFunctionProvisionedConcurrencyConfig(ctx, driver.ProvisionedConcurrencyConfig{
+		FunctionName:                             "my-func",
+		Qualifier:                                ver.Version,
+		RequestedProvisionedConcurrentExecutions: 4,
+	}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	got, err := dst.GetFunctionProvisionedConcurrencyConfig(ctx, "my-func", ver.Version)
+	if err != nil {
+		t.Fatalf("restored Get: %v", err)
+	}
+
+	if got.RequestedProvisionedConcurrentExecutions != 4 {
+		t.Fatalf("restored requested = %d, want 4", got.RequestedProvisionedConcurrentExecutions)
+	}
+}

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -273,6 +273,8 @@ func (h *Handler) routePrefixed(w http.ResponseWriter, r *http.Request) bool {
 		h.serveFunctionURL(w, r)
 	case strings.HasPrefix(r.URL.Path, eventInvokeConfigPrefix):
 		h.serveEventInvokeConfig(w, r)
+	case isProvisionedConcurrencyPath(r.URL.Path):
+		h.serveProvisionedConcurrency(w, r)
 	case isCodeSigningPath(r.URL.Path):
 		h.serveFunctionCodeSigningConfig(w, r)
 	default:

--- a/server/aws/lambda/provisioned_concurrency.go
+++ b/server/aws/lambda/provisioned_concurrency.go
@@ -1,0 +1,250 @@
+package lambda
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	sdrv "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// provisionedConcurrencySuffix is the function sub-resource path segment
+// Put/Get/DeleteProvisionedConcurrencyConfig share, all under the
+// concurrencyReadPrefix (2019-09-30) version. ListProvisionedConcurrencyConfigs
+// lives on the SAME path (real Lambda distinguishes it with the
+// provisionedConcurrencyListParam query parameter) rather than its own suffix.
+const provisionedConcurrencySuffix = "/provisioned-concurrency"
+
+// provisionedConcurrencyListParam / provisionedConcurrencyListParamAll are the
+// query parameter real Lambda uses to route a GET on the provisioned-concurrency
+// path to ListProvisionedConcurrencyConfigs instead of
+// GetProvisionedConcurrencyConfig.
+const (
+	provisionedConcurrencyListParam    = "List"
+	provisionedConcurrencyListParamAll = "ALL"
+)
+
+// provisionedConcurrencyManager is the AWS-specific provisioned-concurrency
+// surface. It has no Azure/GCP equivalent, so the handler type-asserts for it
+// rather than adding it to the portable Serverless driver, mirroring
+// eventInvokeConfigManager.
+type provisionedConcurrencyManager interface {
+	PutFunctionProvisionedConcurrencyConfig(
+		ctx context.Context, cfg sdrv.ProvisionedConcurrencyConfig,
+	) (*sdrv.ProvisionedConcurrencyConfig, error)
+	GetFunctionProvisionedConcurrencyConfig(
+		ctx context.Context, functionName, qualifier string,
+	) (*sdrv.ProvisionedConcurrencyConfig, error)
+	DeleteFunctionProvisionedConcurrencyConfig(ctx context.Context, functionName, qualifier string) error
+	ListFunctionProvisionedConcurrencyConfigs(
+		ctx context.Context, functionName string,
+	) ([]sdrv.ProvisionedConcurrencyConfig, error)
+}
+
+// provisionedConcurrencyResponse is the AWS Put/GetProvisionedConcurrencyConfig
+// response shape (no FunctionArn — that only appears on the List item shape).
+type provisionedConcurrencyResponse struct {
+	RequestedProvisionedConcurrentExecutions int    `json:"RequestedProvisionedConcurrentExecutions,omitempty"`
+	AvailableProvisionedConcurrentExecutions int    `json:"AvailableProvisionedConcurrentExecutions,omitempty"`
+	AllocatedProvisionedConcurrentExecutions int    `json:"AllocatedProvisionedConcurrentExecutions,omitempty"`
+	Status                                   string `json:"Status,omitempty"`
+	StatusReason                             string `json:"StatusReason,omitempty"`
+	LastModified                             string `json:"LastModified,omitempty"`
+}
+
+// provisionedConcurrencyListItem is the ListProvisionedConcurrencyConfigs item
+// shape: the same fields as provisionedConcurrencyResponse plus FunctionArn.
+type provisionedConcurrencyListItem struct {
+	provisionedConcurrencyResponse
+	FunctionArn string `json:"FunctionArn,omitempty"`
+}
+
+// listProvisionedConcurrencyConfigsResponse is the
+// ListProvisionedConcurrencyConfigs envelope.
+type listProvisionedConcurrencyConfigsResponse struct {
+	ProvisionedConcurrencyConfigs []provisionedConcurrencyListItem `json:"ProvisionedConcurrencyConfigs"`
+	NextMarker                    string                           `json:"NextMarker,omitempty"`
+}
+
+func toProvisionedConcurrencyResponse(c *sdrv.ProvisionedConcurrencyConfig) provisionedConcurrencyResponse {
+	return provisionedConcurrencyResponse{
+		RequestedProvisionedConcurrentExecutions: c.RequestedProvisionedConcurrentExecutions,
+		AvailableProvisionedConcurrentExecutions: c.AvailableProvisionedConcurrentExecutions,
+		AllocatedProvisionedConcurrentExecutions: c.AllocatedProvisionedConcurrentExecutions,
+		Status:                                   c.Status,
+		StatusReason:                             c.StatusReason,
+		LastModified:                             c.LastModified,
+	}
+}
+
+func toProvisionedConcurrencyListItem(c *sdrv.ProvisionedConcurrencyConfig) provisionedConcurrencyListItem {
+	return provisionedConcurrencyListItem{
+		provisionedConcurrencyResponse: toProvisionedConcurrencyResponse(c),
+		FunctionArn:                    c.FunctionArn,
+	}
+}
+
+// isProvisionedConcurrencyPath reports whether path is the
+// .../{name}/provisioned-concurrency sub-resource (2019-09-30).
+func isProvisionedConcurrencyPath(path string) bool {
+	return strings.HasPrefix(path, concurrencyReadPrefix) && strings.HasSuffix(path, provisionedConcurrencySuffix)
+}
+
+// provisionedConcurrencyFunctionName extracts the function name from a
+// provisioned-concurrency path, or false when the path shape doesn't match
+// (e.g. a nested extra segment).
+func provisionedConcurrencyFunctionName(path string) (string, bool) {
+	if !isProvisionedConcurrencyPath(path) {
+		return "", false
+	}
+
+	rest := strings.TrimPrefix(strings.TrimPrefix(path, concurrencyReadPrefix), "/")
+	name := strings.TrimSuffix(rest, provisionedConcurrencySuffix)
+
+	if name == "" || strings.Contains(name, "/") {
+		return "", false
+	}
+
+	return name, true
+}
+
+// serveProvisionedConcurrency dispatches the provisioned-concurrency
+// sub-resource: PUT=Put, DELETE=Delete, GET=Get (or List when the List=ALL
+// query parameter is present, matching real Lambda's routing on this shared
+// path).
+func (h *Handler) serveProvisionedConcurrency(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.fn.(provisionedConcurrencyManager)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "InvalidRequestException", "provisioned concurrency not supported")
+		return
+	}
+
+	name, ok := provisionedConcurrencyFunctionName(r.URL.Path)
+	if !ok {
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "unsupported Lambda path")
+		return
+	}
+
+	if r.Method == http.MethodGet && r.URL.Query().Get(provisionedConcurrencyListParam) == provisionedConcurrencyListParamAll {
+		listProvisionedConcurrencyConfigs(w, r, mgr, name)
+		return
+	}
+
+	qualifier := r.URL.Query().Get("Qualifier")
+
+	switch r.Method {
+	case http.MethodPut:
+		putProvisionedConcurrency(w, r, mgr, name, qualifier)
+	case http.MethodGet:
+		h.getProvisionedConcurrency(w, r, mgr, name, qualifier)
+	case http.MethodDelete:
+		h.deleteProvisionedConcurrency(w, r, mgr, name, qualifier)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "InvalidRequestException", "method not allowed")
+	}
+}
+
+// putProvisionedConcurrency handles PUT: it always creates/replaces the
+// config, so the function's existence (or a $LATEST/reserved-concurrency
+// violation) surfaces as the provider's own error.
+func putProvisionedConcurrency(
+	w http.ResponseWriter, r *http.Request, mgr provisionedConcurrencyManager, name, qualifier string,
+) {
+	var req struct {
+		ProvisionedConcurrentExecutions int `json:"ProvisionedConcurrentExecutions"`
+	}
+
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	cfg, err := mgr.PutFunctionProvisionedConcurrencyConfig(r.Context(), sdrv.ProvisionedConcurrencyConfig{
+		FunctionName:                             name,
+		Qualifier:                                qualifier,
+		RequestedProvisionedConcurrentExecutions: req.ProvisionedConcurrentExecutions,
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusAccepted, toProvisionedConcurrencyResponse(cfg))
+}
+
+// getProvisionedConcurrency checks the function exists first so a subsequent
+// NotFound from the provider is unambiguously "no config for this qualifier"
+// (ProvisionedConcurrencyConfigNotFoundException) rather than "function
+// missing" (ResourceNotFoundException) — real Lambda distinguishes the two.
+func (h *Handler) getProvisionedConcurrency(
+	w http.ResponseWriter, r *http.Request, mgr provisionedConcurrencyManager, name, qualifier string,
+) {
+	if _, err := h.fn.GetFunction(r.Context(), name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	cfg, err := mgr.GetFunctionProvisionedConcurrencyConfig(r.Context(), name, qualifier)
+	if err != nil {
+		writeProvisionedConcurrencyNotFound(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toProvisionedConcurrencyResponse(cfg))
+}
+
+// deleteProvisionedConcurrency applies the same function-exists-first check as
+// getProvisionedConcurrency so a Delete's NotFound is reported as the specific
+// ProvisionedConcurrencyConfigNotFoundException.
+func (h *Handler) deleteProvisionedConcurrency(
+	w http.ResponseWriter, r *http.Request, mgr provisionedConcurrencyManager, name, qualifier string,
+) {
+	if _, err := h.fn.GetFunction(r.Context(), name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if err := mgr.DeleteFunctionProvisionedConcurrencyConfig(r.Context(), name, qualifier); err != nil {
+		writeProvisionedConcurrencyNotFound(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// writeProvisionedConcurrencyNotFound emits the 404
+// ProvisionedConcurrencyConfigNotFoundException real Lambda returns when a
+// function exists but has no provisioned-concurrency config for the requested
+// qualifier — distinct from the generic ResourceNotFoundException a missing
+// function reports.
+func writeProvisionedConcurrencyNotFound(w http.ResponseWriter, err error) {
+	writeError(w, http.StatusNotFound, "ProvisionedConcurrencyConfigNotFoundException", cerrors.Message(err))
+}
+
+// listProvisionedConcurrencyConfigs renders ListProvisionedConcurrencyConfigs,
+// sorting by qualifier so Marker offsets stay stable across paginated calls
+// (the driver returns configs in map-iteration order, which is unstable).
+func listProvisionedConcurrencyConfigs(
+	w http.ResponseWriter, r *http.Request, mgr provisionedConcurrencyManager, name string,
+) {
+	configs, err := mgr.ListFunctionProvisionedConcurrencyConfigs(r.Context(), name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	sort.Slice(configs, func(i, j int) bool { return configs[i].Qualifier < configs[j].Qualifier })
+
+	start, end, nextMarker, _ := pageWindow(len(configs), r.URL.Query())
+
+	items := make([]provisionedConcurrencyListItem, 0, end-start)
+	for i := start; i < end; i++ {
+		items = append(items, toProvisionedConcurrencyListItem(&configs[i]))
+	}
+
+	writeJSON(w, http.StatusOK, listProvisionedConcurrencyConfigsResponse{
+		ProvisionedConcurrencyConfigs: items,
+		NextMarker:                    nextMarker,
+	})
+}

--- a/server/aws/lambda/provisioned_concurrency_sdk_test.go
+++ b/server/aws/lambda/provisioned_concurrency_sdk_test.go
@@ -1,0 +1,193 @@
+package lambda_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+)
+
+// publishVersion publishes a new version of name via the SDK and returns its
+// version number.
+func publishVersion(t *testing.T, client *awslambda.Client, name string) string {
+	t.Helper()
+
+	out, err := client.PublishVersion(context.Background(), &awslambda.PublishVersionInput{
+		FunctionName: aws.String(name),
+	})
+	if err != nil {
+		t.Fatalf("PublishVersion(%s): %v", name, err)
+	}
+
+	return *out.Version
+}
+
+// TestSDKProvisionedConcurrencyLifecycle is the real-user end-to-end flow: a
+// published version gets a provisioned-concurrency config via
+// PutProvisionedConcurrencyConfig, GetProvisionedConcurrencyConfig reports it
+// READY with the requested amount, ListProvisionedConcurrencyConfigs includes
+// it, and DeleteProvisionedConcurrencyConfig removes it (a subsequent Get
+// 404s with ProvisionedConcurrencyConfigNotFoundException).
+func TestSDKProvisionedConcurrencyLifecycle(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	createBasicFunction(t, client, "pc")
+	version := publishVersion(t, client, "pc")
+
+	putOut, err := client.PutProvisionedConcurrencyConfig(ctx, &awslambda.PutProvisionedConcurrencyConfigInput{
+		FunctionName:                    aws.String("pc"),
+		Qualifier:                       aws.String(version),
+		ProvisionedConcurrentExecutions: aws.Int32(3),
+	})
+	if err != nil {
+		t.Fatalf("PutProvisionedConcurrencyConfig: %v", err)
+	}
+
+	if putOut.Status != lambdatypes.ProvisionedConcurrencyStatusEnumReady {
+		t.Fatalf("Put Status = %q, want READY", putOut.Status)
+	}
+
+	if putOut.RequestedProvisionedConcurrentExecutions == nil || *putOut.RequestedProvisionedConcurrentExecutions != 3 {
+		t.Fatalf("Put Requested = %v, want 3", putOut.RequestedProvisionedConcurrentExecutions)
+	}
+
+	getOut, err := client.GetProvisionedConcurrencyConfig(ctx, &awslambda.GetProvisionedConcurrencyConfigInput{
+		FunctionName: aws.String("pc"),
+		Qualifier:    aws.String(version),
+	})
+	if err != nil {
+		t.Fatalf("GetProvisionedConcurrencyConfig: %v", err)
+	}
+
+	if getOut.Status != lambdatypes.ProvisionedConcurrencyStatusEnumReady {
+		t.Fatalf("Get Status = %q, want READY", getOut.Status)
+	}
+
+	if getOut.AllocatedProvisionedConcurrentExecutions == nil || *getOut.AllocatedProvisionedConcurrentExecutions != 3 {
+		t.Fatalf("Get Allocated = %v, want 3", getOut.AllocatedProvisionedConcurrentExecutions)
+	}
+
+	if getOut.AvailableProvisionedConcurrentExecutions == nil || *getOut.AvailableProvisionedConcurrentExecutions != 3 {
+		t.Fatalf("Get Available = %v, want 3", getOut.AvailableProvisionedConcurrentExecutions)
+	}
+
+	listOut, err := client.ListProvisionedConcurrencyConfigs(ctx, &awslambda.ListProvisionedConcurrencyConfigsInput{
+		FunctionName: aws.String("pc"),
+	})
+	if err != nil {
+		t.Fatalf("ListProvisionedConcurrencyConfigs: %v", err)
+	}
+
+	if len(listOut.ProvisionedConcurrencyConfigs) != 1 {
+		t.Fatalf("List = %d configs, want 1", len(listOut.ProvisionedConcurrencyConfigs))
+	}
+
+	if listOut.ProvisionedConcurrencyConfigs[0].FunctionArn == nil {
+		t.Fatal("List item missing FunctionArn")
+	}
+
+	if _, err = client.DeleteProvisionedConcurrencyConfig(ctx, &awslambda.DeleteProvisionedConcurrencyConfigInput{
+		FunctionName: aws.String("pc"),
+		Qualifier:    aws.String(version),
+	}); err != nil {
+		t.Fatalf("DeleteProvisionedConcurrencyConfig: %v", err)
+	}
+
+	_, err = client.GetProvisionedConcurrencyConfig(ctx, &awslambda.GetProvisionedConcurrencyConfigInput{
+		FunctionName: aws.String("pc"),
+		Qualifier:    aws.String(version),
+	})
+	if err == nil {
+		t.Fatal("Get after Delete: want error")
+	}
+
+	var notFound *lambdatypes.ProvisionedConcurrencyConfigNotFoundException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("Get after Delete error = %T %v, want *ProvisionedConcurrencyConfigNotFoundException", err, err)
+	}
+}
+
+// TestSDKProvisionedConcurrencyRejectsLatest guards the real Lambda constraint
+// that provisioned concurrency cannot attach to the mutable $LATEST alias/
+// unqualified function.
+func TestSDKProvisionedConcurrencyRejectsLatest(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	createBasicFunction(t, client, "latest-pc")
+
+	_, err := client.PutProvisionedConcurrencyConfig(ctx, &awslambda.PutProvisionedConcurrencyConfigInput{
+		FunctionName:                    aws.String("latest-pc"),
+		Qualifier:                       aws.String("$LATEST"),
+		ProvisionedConcurrentExecutions: aws.Int32(1),
+	})
+	if err == nil {
+		t.Fatal("Put on $LATEST: want error")
+	}
+
+	var invalid *lambdatypes.InvalidParameterValueException
+	if !errors.As(err, &invalid) {
+		t.Fatalf("Put on $LATEST error = %T %v, want *InvalidParameterValueException", err, err)
+	}
+}
+
+// TestSDKProvisionedConcurrencyBoundByReserved guards the real Lambda
+// constraint that a requested provisioned-concurrency amount cannot exceed the
+// function's reserved concurrency once one is configured.
+func TestSDKProvisionedConcurrencyBoundByReserved(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	createBasicFunction(t, client, "bounded-pc")
+	version := publishVersion(t, client, "bounded-pc")
+
+	if _, err := client.PutFunctionConcurrency(ctx, &awslambda.PutFunctionConcurrencyInput{
+		FunctionName:                 aws.String("bounded-pc"),
+		ReservedConcurrentExecutions: aws.Int32(2),
+	}); err != nil {
+		t.Fatalf("PutFunctionConcurrency: %v", err)
+	}
+
+	_, err := client.PutProvisionedConcurrencyConfig(ctx, &awslambda.PutProvisionedConcurrencyConfigInput{
+		FunctionName:                    aws.String("bounded-pc"),
+		Qualifier:                       aws.String(version),
+		ProvisionedConcurrentExecutions: aws.Int32(3),
+	})
+	if err == nil {
+		t.Fatal("Put exceeding reserved concurrency: want error")
+	}
+
+	var invalid *lambdatypes.InvalidParameterValueException
+	if !errors.As(err, &invalid) {
+		t.Fatalf("Put exceeding reserved error = %T %v, want *InvalidParameterValueException", err, err)
+	}
+}
+
+// TestSDKGetProvisionedConcurrencyConfigNotFound guards that a function with no
+// provisioned-concurrency config on its qualifier reports
+// ProvisionedConcurrencyConfigNotFoundException rather than the generic
+// ResourceNotFoundException a missing function reports.
+func TestSDKGetProvisionedConcurrencyConfigNotFound(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	createBasicFunction(t, client, "no-pc")
+	version := publishVersion(t, client, "no-pc")
+
+	_, err := client.GetProvisionedConcurrencyConfig(ctx, &awslambda.GetProvisionedConcurrencyConfigInput{
+		FunctionName: aws.String("no-pc"),
+		Qualifier:    aws.String(version),
+	})
+	if err == nil {
+		t.Fatal("Get with no config: want error")
+	}
+
+	var notFound *lambdatypes.ProvisionedConcurrencyConfigNotFoundException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("Get with no config error = %T %v, want *ProvisionedConcurrencyConfigNotFoundException", err, err)
+	}
+}

--- a/services/serverless/driver/driver.go
+++ b/services/serverless/driver/driver.go
@@ -122,11 +122,37 @@ type ConcurrencyConfig struct {
 	ReservedConcurrentExecutions int
 }
 
-// ProvisionedConcurrencyConfig configures provisioned concurrency.
+// ProvisionedConcurrencyConfig is a function's provisioned-concurrency
+// configuration (AWS Lambda PutProvisionedConcurrencyConfig), scoped to a
+// published version or alias via Qualifier ($LATEST/unqualified is rejected —
+// provisioned concurrency can only be attached to an immutable qualifier). It
+// has no Azure Functions or GCP Cloud Functions equivalent, so it is kept off
+// the portable Serverless interface and applied/read through an AWS-only
+// optional interface, the same way EventInvokeConfig is.
 type ProvisionedConcurrencyConfig struct {
 	FunctionName string
-	Qualifier    string // version or alias
-	Provisioned  int
+	// Qualifier is the published version number or alias name the config is
+	// attached to.
+	Qualifier string
+	// FunctionArn is the qualified function ARN echoed back in the response.
+	FunctionArn string
+	// RequestedProvisionedConcurrentExecutions is the amount requested by Put.
+	RequestedProvisionedConcurrentExecutions int
+	// AvailableProvisionedConcurrentExecutions is the amount currently usable.
+	// The emulator allocates synchronously, so it always equals Requested once
+	// Status is READY.
+	AvailableProvisionedConcurrentExecutions int
+	// AllocatedProvisionedConcurrentExecutions is the amount actually
+	// allocated. The emulator allocates synchronously, so it always equals
+	// Requested once Status is READY.
+	AllocatedProvisionedConcurrentExecutions int
+	// Status is the allocation status: "IN_PROGRESS", "READY" or "FAILED". The
+	// emulator has no real cold-start pool, so it settles to READY immediately.
+	Status string
+	// StatusReason explains a non-READY Status.
+	StatusReason string
+	// LastModified is the ISO 8601 timestamp of the last Put.
+	LastModified string
 }
 
 // VPCConfig is a function's networking configuration (AWS Lambda VpcConfig).


### PR DESCRIPTION
## Summary
- Adds AWS Lambda provisioned-concurrency configuration: `PutFunctionProvisionedConcurrencyConfig`, `GetFunctionProvisionedConcurrencyConfig`, `DeleteFunctionProvisionedConcurrencyConfig`, `ListFunctionProvisionedConcurrencyConfigs`, wired on the real wire path (`/2019-09-30/functions/{name}/provisioned-concurrency`, List distinguished via the `List=ALL` query param, matching real Lambda's routing on that shared path).
- Provisioned concurrency can only attach to a published version or alias — `$LATEST`/unqualified is rejected with `InvalidParameterValueException` — and a requested amount cannot exceed the function's reserved concurrency once one is configured (also `InvalidParameterValueException`).
- Exposed through an AWS-only optional interface (type-asserted by the handler), keyed per-qualifier with copy-on-write, mirroring the #998 event-invoke-config pattern exactly. The portable cross-cloud Serverless driver is untouched.
- Full persist round-trip: the new per-qualifier map is added to `funcSnapshot`/`snapshotFunc`/`restoreFunc`.
- The emulator has no real cold-start pool, so a Put allocates synchronously and settles to `READY` immediately (`RequestedProvisionedConcurrentExecutions` = `AvailableProvisionedConcurrentExecutions` = `AllocatedProvisionedConcurrentExecutions`).

## Test plan
- [x] Provider unit tests: round-trip, `$LATEST`/unqualified rejection, unknown-qualifier rejection, below-minimum rejection, reserved-concurrency bound, unknown-function errors, COW independence under `-race`.
- [x] Real `aws-sdk-go-v2` end-to-end tests against the wire server: Put → Get (READY, requested amount) → List → Delete → Get 404s with `ProvisionedConcurrencyConfigNotFoundException`; negative cases for `$LATEST` and exceeding reserved concurrency.
- [x] `go build ./...`, `go vet ./...`, `go test ./providers/aws/lambda/... ./server/aws/lambda/... ./persist/... -race`, broad `go test ./providers/aws/... ./server/aws/...`
- [x] `golangci-lint run` clean on touched packages
- [x] `go generate ./...` — no `docs/coverage` diff (AWS-only optional methods aren't part of the generated driver surface)
- [x] `go mod tidy` — no changes

## Deferred
- ESM advanced knobs, Function URL auth, and layers are separate follow-up items (out of scope here).