### PR TITLE
feat(azure-functions): Service Bus topic/subscription trigger delivery

### DIFF
--- a/providers/azure/functions/queue_trigger.go
+++ b/providers/azure/functions/queue_trigger.go
@@ -27,22 +27,56 @@ func (m *Mock) DeliverFunctionTrigger(ctx context.Context, bindingType, queueNam
 		return
 	}
 
-	for _, app := range m.appsBoundToQueue(bindingType, queueName) {
+	match := func(b map[string]any) bool {
+		qn, _ := b["queueName"].(string)
+		return qn == queueName
+	}
+
+	for _, app := range m.appsBoundBy(bindingType, match) {
 		_ = m.InvokeExternal(ctx, app, body)
 	}
 }
 
-// appsBoundToQueue returns, sorted for deterministic delivery order, the names of
-// the function apps that have at least one deployed function whose bindings
-// include a matching input trigger.
-func (m *Mock) appsBoundToQueue(bindingType, queueName string) []string {
+// DeliverTopicFunctionTrigger invokes every deployed function whose
+// function.json declares a serviceBusTrigger binding on (topicName,
+// subscriptionName), passing body as the invocation payload. It is the
+// topic/subscription counterpart of DeliverFunctionTrigger: a message
+// published to a Service Bus topic is fanned out to each subscription, and a
+// function bound to one subscription fires once per message that subscription
+// receives. See DeliverFunctionTrigger for delivery semantics (synchronous,
+// recursion-guarded).
+func (m *Mock) DeliverTopicFunctionTrigger(ctx context.Context, bindingType, topicName, subscriptionName string, body []byte) {
+	if bindingType == "" || topicName == "" || subscriptionName == "" {
+		return
+	}
+
+	if recursionguard.Depth(ctx) >= recursionguard.MaxDepth {
+		return
+	}
+
+	match := func(b map[string]any) bool {
+		tn, _ := b["topicName"].(string)
+		sn, _ := b["subscriptionName"].(string)
+
+		return tn == topicName && sn == subscriptionName
+	}
+
+	for _, app := range m.appsBoundBy(bindingType, match) {
+		_ = m.InvokeExternal(ctx, app, body)
+	}
+}
+
+// appsBoundBy returns, sorted for deterministic delivery order, the names of
+// the function apps that have at least one deployed, non-disabled function
+// whose bindings include an input trigger of bindingType satisfying match.
+func (m *Mock) appsBoundBy(bindingType string, match func(b map[string]any) bool) []string {
 	m.sitesMu.RLock()
 	defer m.sitesMu.RUnlock()
 
 	var apps []string
 
 	for _, meta := range m.sites.All() {
-		if siteHasQueueTrigger(meta, bindingType, queueName) {
+		if siteHasTrigger(meta, bindingType, match) {
 			apps = append(apps, meta.Name)
 		}
 	}
@@ -52,15 +86,15 @@ func (m *Mock) appsBoundToQueue(bindingType, queueName string) []string {
 	return apps
 }
 
-// siteHasQueueTrigger reports whether any non-disabled function of the site
+// siteHasTrigger reports whether any non-disabled function of the site
 // declares a matching trigger binding.
-func siteHasQueueTrigger(meta *SiteMeta, bindingType, queueName string) bool {
+func siteHasTrigger(meta *SiteMeta, bindingType string, match func(b map[string]any) bool) bool {
 	for _, fn := range meta.Functions {
 		if fn.IsDisabled {
 			continue
 		}
 
-		if bindingMatchesQueue(fn.Config, bindingType, queueName) {
+		if bindingMatches(fn.Config, bindingType, match) {
 			return true
 		}
 	}
@@ -68,11 +102,11 @@ func siteHasQueueTrigger(meta *SiteMeta, bindingType, queueName string) bool {
 	return false
 }
 
-// bindingMatchesQueue reports whether a deployed function's function.json config
-// declares an input trigger of bindingType bound to queueName. Azure discovers
+// bindingMatches reports whether a deployed function's function.json config
+// declares an input trigger of bindingType satisfying match. Azure discovers
 // these bindings from the deployed code; here they arrive verbatim in the ARM
 // CreateFunction body's "config" object.
-func bindingMatchesQueue(config map[string]any, bindingType, queueName string) bool {
+func bindingMatches(config map[string]any, bindingType string, match func(b map[string]any) bool) bool {
 	bindings, ok := config["bindings"].([]any)
 	if !ok {
 		return false
@@ -94,7 +128,7 @@ func bindingMatchesQueue(config map[string]any, bindingType, queueName string) b
 			continue
 		}
 
-		if qn, _ := b["queueName"].(string); qn == queueName {
+		if match(b) {
 			return true
 		}
 	}

--- a/providers/azure/functions/queue_trigger_test.go
+++ b/providers/azure/functions/queue_trigger_test.go
@@ -27,6 +27,23 @@ func queueTriggerConfig(bindingType, queueName string) map[string]any {
 	}
 }
 
+// topicTriggerConfig builds a function.json-shaped config declaring a single
+// serviceBusTrigger input trigger binding on (topicName, subscriptionName).
+func topicTriggerConfig(topicName, subscriptionName string) map[string]any {
+	return map[string]any{
+		"bindings": []any{
+			map[string]any{
+				"name":             "item",
+				"type":             "serviceBusTrigger",
+				"direction":        "in",
+				"topicName":        topicName,
+				"subscriptionName": subscriptionName,
+				"connection":       "AzureWebJobsServiceBus",
+			},
+		},
+	}
+}
+
 // seedTriggeredApp creates the portable function app plus its SiteMeta and one
 // deployed function carrying the supplied binding config, then registers a Go
 // handler that records each invocation's payload. The returned pointers observe
@@ -143,6 +160,89 @@ func TestDeliverFunctionTriggerRecursionGuard(t *testing.T) {
 
 	ctx := recursionguard.WithDepth(context.Background(), recursionguard.MaxDepth)
 	m.DeliverFunctionTrigger(ctx, "queueTrigger", "loop", []byte("x"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(count), "delivery at MaxDepth must be dropped")
+}
+
+func TestDeliverTopicFunctionTriggerInvokesBoundApp(t *testing.T) {
+	m := newTestMock()
+	count, last := seedTriggeredApp(t, m, "orders-app", topicTriggerConfig("orders", "billing"))
+
+	m.DeliverTopicFunctionTrigger(context.Background(), "serviceBusTrigger", "orders", "billing", []byte("hello"))
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(count), "bound function should fire exactly once")
+	assert.Equal(t, "hello", string(*last), "function should receive the delivered message body")
+}
+
+func TestDeliverTopicFunctionTriggerNoMatch(t *testing.T) {
+	m := newTestMock()
+	count, _ := seedTriggeredApp(t, m, "orders-app", topicTriggerConfig("orders", "billing"))
+
+	// A different topic, a different subscription of the same topic, the wrong
+	// binding type, and empty inputs must all no-op.
+	m.DeliverTopicFunctionTrigger(context.Background(), "serviceBusTrigger", "shipping", "billing", []byte("x"))
+	m.DeliverTopicFunctionTrigger(context.Background(), "serviceBusTrigger", "orders", "audit", []byte("x"))
+	m.DeliverTopicFunctionTrigger(context.Background(), "queueTrigger", "orders", "billing", []byte("x"))
+	m.DeliverTopicFunctionTrigger(context.Background(), "", "orders", "billing", []byte("x"))
+	m.DeliverTopicFunctionTrigger(context.Background(), "serviceBusTrigger", "", "billing", []byte("x"))
+	m.DeliverTopicFunctionTrigger(context.Background(), "serviceBusTrigger", "orders", "", []byte("x"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(count))
+}
+
+func TestDeliverTopicFunctionTriggerSkipsDisabledFunction(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "disabled-app", Runtime: "node"})
+	require.NoError(t, err)
+	_, err = m.UpsertSiteMeta(ctx, SiteMeta{Name: "disabled-app", Subscription: "sub", ResourceGroup: "rg"})
+	require.NoError(t, err)
+	_, _, err = m.CreateSiteFunction(ctx, "disabled-app", SiteFunction{
+		Name: "fn1", Config: topicTriggerConfig("orders", "billing"), IsDisabled: true,
+	})
+	require.NoError(t, err)
+
+	var count int32
+
+	m.RegisterHandler("disabled-app", func(_ context.Context, p []byte) ([]byte, error) {
+		atomic.AddInt32(&count, 1)
+
+		return p, nil
+	})
+
+	m.DeliverTopicFunctionTrigger(ctx, "serviceBusTrigger", "orders", "billing", []byte("x"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&count), "a disabled function must not fire")
+}
+
+func TestDeliverTopicFunctionTriggerOutputBindingIgnored(t *testing.T) {
+	m := newTestMock()
+
+	// An output ("out") binding to the topic is not a trigger and must not fire.
+	cfg := map[string]any{
+		"bindings": []any{
+			map[string]any{
+				"name": "out", "type": "serviceBusTrigger", "direction": "out",
+				"topicName": "orders", "subscriptionName": "billing",
+			},
+		},
+	}
+	count, _ := seedTriggeredApp(t, m, "producer-app", cfg)
+
+	m.DeliverTopicFunctionTrigger(context.Background(), "serviceBusTrigger", "orders", "billing", []byte("x"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(count))
+}
+
+// TestDeliverTopicFunctionTriggerRecursionGuard proves a re-entrant delivery
+// already at MaxDepth is dropped without invoking the function.
+func TestDeliverTopicFunctionTriggerRecursionGuard(t *testing.T) {
+	m := newTestMock()
+	count, _ := seedTriggeredApp(t, m, "loop-app", topicTriggerConfig("loop-topic", "loop-sub"))
+
+	ctx := recursionguard.WithDepth(context.Background(), recursionguard.MaxDepth)
+	m.DeliverTopicFunctionTrigger(ctx, "serviceBusTrigger", "loop-topic", "loop-sub", []byte("x"))
 
 	assert.Equal(t, int32(0), atomic.LoadInt32(count), "delivery at MaxDepth must be dropped")
 }

--- a/providers/azure/servicebus/function_trigger_sink_test.go
+++ b/providers/azure/servicebus/function_trigger_sink_test.go
@@ -73,3 +73,105 @@ func TestFIFODuplicateDoesNotDispatch(t *testing.T) {
 
 	assert.Equal(t, 1, sink.calls, "duplicate send must not dispatch a second trigger")
 }
+
+// recordingTopicSink extends recordingSink with the optional
+// TopicFunctionTriggerSink method so dispatchFunctionTrigger's type assertion
+// picks it for a topic-subscription backing queue.
+type recordingTopicSink struct {
+	recordingSink
+	topicCalls int
+	binding    string
+	topic      string
+	sub        string
+	lastBody   string
+}
+
+func (s *recordingTopicSink) DeliverTopicFunctionTrigger(
+	_ context.Context, bindingType, topicName, subscriptionName string, body []byte,
+) {
+	s.topicCalls++
+	s.binding = bindingType
+	s.topic = topicName
+	s.sub = subscriptionName
+	s.lastBody = string(body)
+}
+
+// createSubQueue creates a queue named after the "{ns}/{topic}/subscriptions/{sub}"
+// convention server/azure/servicebus's createSubQueue uses for a topic
+// subscription's backing store.
+func createSubQueue(t *testing.T, m *Mock, topic, sub string) string {
+	t.Helper()
+
+	ctx := context.Background()
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "test-ns/" + topic + "/subscriptions/" + sub})
+	require.NoError(t, err)
+
+	return info.URL
+}
+
+// TestSendMessageDispatchesTopicFunctionTriggerSink proves a message sent to a
+// topic subscription's backing queue dispatches DeliverTopicFunctionTrigger
+// with the parsed topic and subscription, not DeliverFunctionTrigger.
+func TestSendMessageDispatchesTopicFunctionTriggerSink(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+	url := createSubQueue(t, m, "orders", "all")
+
+	sink := &recordingTopicSink{}
+	m.SetFunctionTriggerSink(sink, "serviceBusTrigger")
+
+	_, err := m.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "payload"})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, sink.topicCalls)
+	assert.Equal(t, "serviceBusTrigger", sink.binding)
+	assert.Equal(t, "orders", sink.topic)
+	assert.Equal(t, "all", sink.sub)
+	assert.Equal(t, "payload", sink.lastBody)
+	assert.Equal(t, 0, sink.calls, "a subscription delivery must not also fire the queue-shaped trigger")
+}
+
+// TestSendMessageTopicFallsBackToQueueSinkWithoutTopicSupport proves a sink that
+// only implements FunctionTriggerSink still fires (with the raw composite
+// queue name) when dispatching a subscription-backed send, so a queue-only test
+// double or sink keeps working unchanged.
+func TestSendMessageTopicFallsBackToQueueSinkWithoutTopicSupport(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+	url := createSubQueue(t, m, "orders", "all")
+
+	sink := &recordingSink{}
+	m.SetFunctionTriggerSink(sink, "serviceBusTrigger")
+
+	_, err := m.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "payload"})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, sink.calls)
+	assert.Equal(t, "test-ns/orders/subscriptions/all", sink.queue)
+}
+
+// TestSendMessageTopicDuplicateDoesNotDispatch mirrors
+// TestFIFODuplicateDoesNotDispatch for the topic/subscription dispatch path.
+func TestSendMessageTopicDuplicateDoesNotDispatch(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{
+		Name:                       "test-ns/orders/subscriptions/all",
+		RequiresDuplicateDetection: true,
+	})
+	require.NoError(t, err)
+
+	sink := &recordingTopicSink{}
+	m.SetFunctionTriggerSink(sink, "serviceBusTrigger")
+
+	in := driver.SendMessageInput{QueueURL: info.URL, Body: "x", SystemProperties: map[string]string{"MessageId": "m1"}}
+
+	_, err = m.SendMessage(ctx, in)
+	require.NoError(t, err)
+
+	_, err = m.SendMessage(ctx, in)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, sink.topicCalls, "duplicate send must not dispatch a second topic trigger")
+}

--- a/providers/azure/servicebus/servicebus.go
+++ b/providers/azure/servicebus/servicebus.go
@@ -107,6 +107,17 @@ type FunctionTriggerSink interface {
 	DeliverFunctionTrigger(ctx context.Context, bindingType, queueName string, body []byte)
 }
 
+// TopicFunctionTriggerSink is an optional extension of FunctionTriggerSink for
+// Service Bus topic/subscription delivery: a serviceBusTrigger binding may bind
+// a (topicName, subscriptionName) pair instead of a queueName, and a message
+// published to the topic is fanned out to each subscription's own backing
+// store (see server/azure/servicebus's topic send). dispatchFunctionTrigger
+// type-asserts for this interface, so a sink that only implements
+// FunctionTriggerSink (e.g. a queue-only test double) keeps working unchanged.
+type TopicFunctionTriggerSink interface {
+	DeliverTopicFunctionTrigger(ctx context.Context, bindingType, topicName, subscriptionName string, body []byte)
+}
+
 // Mock is an in-memory mock implementation of the Azure Service Bus service.
 type Mock struct {
 	queues     *memstore.Store[*queueData]
@@ -428,6 +439,12 @@ func (m *Mock) enqueueLocked(qd *queueData, input *driver.SendMessageInput) (enq
 // provider so any function bound to this queue fires. It is a no-op when no sink
 // is wired (the default, and every non-Azure-Functions deployment). Called after
 // the queue lock is released; see SendMessage.
+//
+// A queue backing a topic subscription (see subscriptionEntity) is dispatched as
+// a topic/subscription trigger instead of a queueName trigger when the sink
+// supports it, since that queue is an internal fan-out target a serviceBusTrigger
+// binding never names directly (real Azure Functions binds (topicName,
+// subscriptionName) for a topic, not the internal per-subscription store).
 func (m *Mock) dispatchFunctionTrigger(ctx context.Context, queueName string, msg *sbMessage) {
 	m.mu.RLock()
 	sink := m.funcSink
@@ -438,7 +455,35 @@ func (m *Mock) dispatchFunctionTrigger(ctx context.Context, queueName string, ms
 		return
 	}
 
+	if topic, sub, ok := subscriptionEntity(queueName); ok {
+		if topicSink, ok := sink.(TopicFunctionTriggerSink); ok {
+			topicSink.DeliverTopicFunctionTrigger(ctx, bindingType, topic, sub, []byte(msg.Body))
+			return
+		}
+	}
+
 	sink.DeliverFunctionTrigger(ctx, bindingType, queueName, []byte(msg.Body))
+}
+
+// subscriptionEntitySegments is the segment count of the
+// "{namespace}/{topic}/subscriptions/{sub}" entity name a topic subscription's
+// backing queue is created with (see server/azure/servicebus's
+// createSubQueue), used by subscriptionEntity to recognize it.
+const subscriptionEntitySegments = 4
+
+// subscriptionEntity reports whether name is a topic subscription's backing
+// queue name and, if so, the topic and subscription it belongs to. Service Bus
+// namespace, topic and subscription names cannot contain "/", so the 4-segment
+// shape unambiguously identifies this internal addressing convention.
+func subscriptionEntity(name string) (topic, sub string, ok bool) {
+	const subSegment = "subscriptions"
+
+	segs := strings.Split(name, "/")
+	if len(segs) != subscriptionEntitySegments || segs[2] != subSegment {
+		return "", "", false
+	}
+
+	return segs[1], segs[3], true
 }
 
 // findSendDuplicate reports an already-accepted message id when input is a FIFO

--- a/server/azure/functions_servicebus_topic_trigger_test.go
+++ b/server/azure/functions_servicebus_topic_trigger_test.go
@@ -1,0 +1,318 @@
+package azure_test
+
+// Real-user end-to-end proof that an Azure Service Bus TOPIC/SUBSCRIPTION
+// trigger actually fires the bound function: a function app declares a
+// serviceBusTrigger binding on (topicName, subscriptionName) via ARM, then a
+// message published to that topic with the real Service Bus REST data plane
+// synchronously invokes the function with the copy delivered to THAT
+// subscription. This is the topic/subscription counterpart of
+// TestQueueStorageTriggerInvokesFunction (queue-bound queueTrigger) and closes
+// the gap left by #997, which only wired queueName-bound serviceBusTrigger
+// bindings.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+)
+
+// sbFuncAppBase returns the ARM base path of a function app used by these tests.
+func sbFuncAppBase(app string) string {
+	return "/subscriptions/sub-sbt/resourceGroups/rg-sbt/providers/Microsoft.Web/sites/" + app
+}
+
+// createSBTopicTriggeredApp creates a function app plus one deployed function
+// declaring a serviceBusTrigger binding on (topicName, subscriptionName).
+func createSBTopicTriggeredApp(t *testing.T, ts *httptest.Server, app, topic, sub string) {
+	t.Helper()
+
+	base := sbFuncAppBase(app)
+	armPut(t, ts, base+"?api-version=2022-03-01", `{"location":"eastus","properties":{"siteConfig":{}}}`)
+	armPut(t, ts, base+"/functions/consume?api-version=2022-03-01",
+		`{"properties":{"config":{"bindings":[`+
+			`{"name":"item","type":"serviceBusTrigger","direction":"in",`+
+			`"topicName":"`+topic+`","subscriptionName":"`+sub+`","connection":"AzureWebJobsServiceBus"}]}}}`)
+}
+
+// createSBTopicSub creates a topic and one subscription under the shared
+// routing-test namespace (seedSBNamespace/nsScope, from
+// queue_servicebus_routing_test.go).
+func createSBTopicSub(t *testing.T, ts *httptest.Server, topic, sub string) {
+	t.Helper()
+
+	sbDo(t, ts, http.MethodPut, nsScope()+"/topics/"+topic+sbAPIVer, `{"properties":{}}`, http.StatusOK)
+	sbDo(t, ts, http.MethodPut, nsScope()+"/topics/"+topic+"/subscriptions/"+sub+sbAPIVer, `{"properties":{}}`, http.StatusOK)
+}
+
+func TestServiceBusTopicTriggerInvokesFunction(t *testing.T) {
+	ts, p := newFullAzureServerWithProvider(t)
+
+	const (
+		app   = "sbt-app"
+		topic = "orders"
+		sub   = "billing"
+	)
+
+	createSBTopicTriggeredApp(t, ts, app, topic, sub)
+
+	got := make(chan string, 1)
+	p.Functions.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		select {
+		case got <- string(payload):
+		default:
+		}
+
+		return payload, nil
+	})
+
+	seedSBNamespace(t, ts)
+	createSBTopicSub(t, ts, topic, sub)
+
+	sbDo(t, ts, http.MethodPost, "/"+sbNS+"/"+topic+"/messages", "topic-payload", http.StatusCreated)
+
+	// Delivery is synchronous, so the function has fired by the time the
+	// publish HTTP call returns.
+	select {
+	case body := <-got:
+		if body != "topic-payload" {
+			t.Fatalf("function received %q, want topic-payload", body)
+		}
+	default:
+		t.Fatal("topic/subscription-triggered function was not invoked")
+	}
+}
+
+// TestServiceBusTopicTriggerWrongTargetDoesNotFire proves a function bound to
+// (topicA, subA) does not fire for a message published to a different topic, or
+// to a different subscription of the SAME topic.
+func TestServiceBusTopicTriggerWrongTargetDoesNotFire(t *testing.T) {
+	ts, p := newFullAzureServerWithProvider(t)
+
+	const (
+		app        = "sbt-app2"
+		boundTopic = "orders"
+		boundSub   = "billing"
+	)
+
+	createSBTopicTriggeredApp(t, ts, app, boundTopic, boundSub)
+
+	fired := make(chan struct{}, 1)
+	p.Functions.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		fired <- struct{}{}
+		return payload, nil
+	})
+
+	seedSBNamespace(t, ts)
+
+	// A different topic entirely, with a subscription of the SAME name.
+	createSBTopicSub(t, ts, "shipping", boundSub)
+	sbDo(t, ts, http.MethodPost, "/"+sbNS+"/shipping/messages", "x", http.StatusCreated)
+
+	// The SAME topic, but a different subscription.
+	createSBTopicSub(t, ts, boundTopic, "audit")
+	sbDo(t, ts, http.MethodPost, "/"+sbNS+"/"+boundTopic+"/messages", "y", http.StatusCreated)
+
+	select {
+	case <-fired:
+		t.Fatal("function fired for a topic/subscription it is not bound to")
+	default:
+	}
+}
+
+// createQueueStorageTriggeredApp creates a function app plus one deployed
+// function declaring a Queue Storage queueTrigger binding, mirroring #997's
+// TestQueueStorageTriggerInvokesFunction.
+func createQueueStorageTriggeredApp(t *testing.T, ts *httptest.Server, app, queue string) {
+	t.Helper()
+
+	base := sbFuncAppBase(app)
+	armPut(t, ts, base+"?api-version=2022-03-01", `{"location":"eastus","properties":{"siteConfig":{}}}`)
+	armPut(t, ts, base+"/functions/consume?api-version=2022-03-01",
+		`{"properties":{"config":{"bindings":[`+
+			`{"name":"item","type":"queueTrigger","direction":"in",`+
+			`"queueName":"`+queue+`","connection":"AzureWebJobsStorage"}]}}}`)
+}
+
+// TestServiceBusQueueAndTopicTriggersCoexist proves the #997 Queue Storage
+// queueTrigger path still fires unchanged alongside a new Service Bus
+// topic/subscription trigger, with no cross-fire between them. (The
+// queueName-bound serviceBusTrigger path is not exercised here — real
+// ARM-provisioned Service Bus queues are stored namespace-prefixed
+// (server/azure/servicebus/queue.go:72, "{namespace}/{queue}"), which
+// bindingMatchesQueue's bare queueName comparison never matches; that gap
+// predates this change and is out of scope for topic/subscription delivery.)
+func TestServiceBusQueueAndTopicTriggersCoexist(t *testing.T) {
+	ts, p := newFullAzureServerWithProvider(t)
+	ctx := context.Background()
+
+	const (
+		queueApp = "sbt-queue-app"
+		queue    = "jobs"
+		topicApp = "sbt-topic-app"
+		topic    = "orders"
+		sub      = "billing"
+	)
+
+	createQueueStorageTriggeredApp(t, ts, queueApp, queue)
+	createSBTopicTriggeredApp(t, ts, topicApp, topic, sub)
+
+	queueGot := make(chan string, 1)
+	p.Functions.RegisterHandler(queueApp, func(_ context.Context, payload []byte) ([]byte, error) {
+		queueGot <- string(payload)
+		return payload, nil
+	})
+
+	topicGot := make(chan string, 1)
+	p.Functions.RegisterHandler(topicApp, func(_ context.Context, payload []byte) ([]byte, error) {
+		topicGot <- string(payload)
+		return payload, nil
+	})
+
+	seedSBNamespace(t, ts)
+	createStorageQueue(t, ts, queue)
+	createSBTopicSub(t, ts, topic, sub)
+
+	qc := newStorageQueueClient(t, ts, queue)
+	if _, err := qc.EnqueueMessage(ctx, "queue-payload", nil); err != nil {
+		t.Fatalf("EnqueueMessage: %v", err)
+	}
+
+	sbDo(t, ts, http.MethodPost, "/"+sbNS+"/"+topic+"/messages", "topic-payload", http.StatusCreated)
+
+	select {
+	case body := <-queueGot:
+		if body != "queue-payload" {
+			t.Fatalf("queue-bound function received %q, want queue-payload", body)
+		}
+	default:
+		t.Fatal("queue-bound queueTrigger function was not invoked (#997 regression)")
+	}
+
+	select {
+	case body := <-topicGot:
+		if body != "topic-payload" {
+			t.Fatalf("topic-bound function received %q, want topic-payload", body)
+		}
+	default:
+		t.Fatal("topic/subscription-bound function was not invoked")
+	}
+
+	// Neither function received the other's message.
+	select {
+	case <-queueGot:
+		t.Fatal("queue-bound function fired a second time (cross-fire from the topic publish)")
+	default:
+	}
+
+	select {
+	case <-topicGot:
+		t.Fatal("topic-bound function fired a second time (cross-fire from the queue publish)")
+	default:
+	}
+}
+
+// TestServiceBusTopicTriggerDisabledFunctionSkipped proves a disabled deployed
+// function does not fire even though its binding matches the published topic
+// and subscription.
+func TestServiceBusTopicTriggerDisabledFunctionSkipped(t *testing.T) {
+	ts, p := newFullAzureServerWithProvider(t)
+
+	const (
+		app   = "sbt-disabled-app"
+		topic = "orders"
+		sub   = "billing"
+	)
+
+	base := sbFuncAppBase(app)
+	armPut(t, ts, base+"?api-version=2022-03-01", `{"location":"eastus","properties":{"siteConfig":{}}}`)
+	armPut(t, ts, base+"/functions/consume?api-version=2022-03-01",
+		`{"properties":{"isDisabled":true,"config":{"bindings":[`+
+			`{"name":"item","type":"serviceBusTrigger","direction":"in",`+
+			`"topicName":"`+topic+`","subscriptionName":"`+sub+`","connection":"AzureWebJobsServiceBus"}]}}}`)
+
+	fired := make(chan struct{}, 1)
+	p.Functions.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		fired <- struct{}{}
+		return payload, nil
+	})
+
+	seedSBNamespace(t, ts)
+	createSBTopicSub(t, ts, topic, sub)
+
+	sbDo(t, ts, http.MethodPost, "/"+sbNS+"/"+topic+"/messages", "x", http.StatusCreated)
+
+	select {
+	case <-fired:
+		t.Fatal("a disabled function must not fire")
+	default:
+	}
+}
+
+// TestServiceBusTopicTriggerRecursionGuard proves a function that re-publishes
+// to its own trigger topic terminates at recursionguard.MaxDepth rather than
+// recursing unbounded, mirroring
+// TestS3LambdaNotificationWriteBackDoesNotRecurseUnbounded. The handler
+// forwards the ctx it was invoked with into its own SendMessage call (a direct
+// provider call, not a fresh HTTP round trip) — that ctx-carried depth is the
+// channel the guard rides on.
+func TestServiceBusTopicTriggerRecursionGuard(t *testing.T) {
+	ts, p := newFullAzureServerWithProvider(t)
+	ctx := context.Background()
+
+	const (
+		app   = "sbt-loop-app"
+		topic = "loop-topic"
+		sub   = "loop-sub"
+	)
+
+	createSBTopicTriggeredApp(t, ts, app, topic, sub)
+
+	seedSBNamespace(t, ts)
+	createSBTopicSub(t, ts, topic, sub)
+
+	// Resolve the subscription's backing driver queue URL so the handler can
+	// re-publish directly through the provider. The prefix also matches the
+	// subscription's paired $DeadLetterQueue store, so pick the exact name.
+	entityName := sbNS + "/" + topic + "/subscriptions/" + sub
+
+	infos, err := p.ServiceBus.ListQueues(ctx, entityName)
+	if err != nil {
+		t.Fatalf("ListQueues: %v", err)
+	}
+
+	var subQueueURL string
+
+	for _, info := range infos {
+		if info.Name == entityName {
+			subQueueURL = info.URL
+			break
+		}
+	}
+
+	if subQueueURL == "" {
+		t.Fatalf("no queue named %q among %d ListQueues results", entityName, len(infos))
+	}
+
+	var invocations int32
+
+	p.Functions.RegisterHandler(app, func(ctx context.Context, payload []byte) ([]byte, error) {
+		atomic.AddInt32(&invocations, 1)
+
+		_, err := p.ServiceBus.SendMessage(ctx, mqdriver.SendMessageInput{QueueURL: subQueueURL, Body: string(payload)})
+
+		return payload, err
+	})
+
+	// The single top-level publish that starts the chain.
+	sbDo(t, ts, http.MethodPost, "/"+sbNS+"/"+topic+"/messages", "seed", http.StatusCreated)
+
+	if got := atomic.LoadInt32(&invocations); got != int32(recursionguard.MaxDepth) {
+		t.Fatalf("handler invoked %d times, want exactly %d (recursive-loop guard did not bound the chain)",
+			got, recursionguard.MaxDepth)
+	}
+}


### PR DESCRIPTION
## Summary

Extends #997's native trigger delivery (queueTrigger / queueName-bound serviceBusTrigger) to Service Bus topic/subscription bindings. A `serviceBusTrigger` binding may declare `topicName` + `subscriptionName` instead of `queueName`; a message published to a topic fans out to each subscription's own backing store, and a function bound to that (topic, subscription) pair now fires with the delivered copy.

`dispatchFunctionTrigger` (providers/azure/servicebus) recognizes a subscription's backing queue name (the `{namespace}/{topic}/subscriptions/{sub}` convention `server/azure/servicebus`'s `createSubQueue` already uses) and dispatches through a new `TopicFunctionTriggerSink` (an optional extension of `FunctionTriggerSink`) instead of the bare-queueName path. The Azure Functions provider implements `DeliverTopicFunctionTrigger`, reusing the same `InvokeExternal` / recursion-guard choke point as the queue path — disabled functions and output bindings are skipped, delivery is synchronous, and a self-referential republish is bounded at `recursionguard.MaxDepth`.

The existing queue/queueName-bound delivery path is unchanged.

## Deferred

- The `queueName`-bound `serviceBusTrigger` path is still not reachable for real ARM-provisioned Service Bus queues (as opposed to Queue Storage queues): those queues are stored namespace-prefixed (`server/azure/servicebus/queue.go:72`, `"{namespace}/{queue}"`), while the binding match compares against a bare `queueName`. This is a pre-existing gap that predates this change; not touched here.
- Timer / Cosmos DB / Event Hub triggers are separate follow-up items.

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers/azure/functions/ ./providers/azure/servicebus/ ./server/azure/ ./server/azure/functions/ ./server/azure/servicebus/ -race -count=1`
- [x] `go test ./server/azure/... ./providers/azure/...`
- [x] `gofmt -l` on touched files (clean)
- [x] `golangci-lint run ./providers/azure/functions/... ./providers/azure/servicebus/...` (0 issues)
- [x] `go generate ./...` + `git diff docs/coverage` (no diff)
- [x] `go mod tidy` (no changes)
- [x] Real-user e2e: full production Azure server, ARM-declared function app with a `serviceBusTrigger(topicName, subscriptionName)` binding, message published via the real Service Bus REST data plane fires the function; negatives for a different topic/subscription, a disabled function, and a bounded self-republish recursion; a Queue Storage `queueTrigger` function still fires unaffected alongside it