### PR TITLE
feat(gcp-functions): Cloud Storage object trigger delivery to gen2 functions

### DIFF
--- a/server/gcp/cloudfunctions/gcstrigger.go
+++ b/server/gcp/cloudfunctions/gcstrigger.go
@@ -1,0 +1,148 @@
+package cloudfunctions
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	sdrv "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// storageEventFilterAttrBucket is the eventTrigger.eventFilters attribute
+// name a gen2 Cloud Storage trigger binds to a specific bucket, mirroring
+// real GCP (google_cloudfunctions2_function.event_trigger.event_filters
+// { attribute = "bucket", value = "<bucket>" }).
+const storageEventFilterAttrBucket = "bucket"
+
+// storageObjectResource mirrors the JSON shape the gcs handler marshals for
+// an object-change event (server/gcp/gcs does not export its objectResource
+// type, so the fields this package needs are redeclared here). The CloudEvent
+// `data` payload a real Eventarc-backed Cloud Storage trigger delivers IS
+// this resource verbatim — the object's metadata, never its bytes.
+type storageObjectResource struct {
+	Kind           string            `json:"kind"`
+	ID             string            `json:"id"`
+	Name           string            `json:"name"`
+	Bucket         string            `json:"bucket"`
+	Generation     string            `json:"generation"`
+	Metageneration string            `json:"metageneration"`
+	ContentType    string            `json:"contentType,omitempty"`
+	Size           string            `json:"size"`
+	MD5Hash        string            `json:"md5Hash,omitempty"`
+	CRC32C         string            `json:"crc32c,omitempty"`
+	ETag           string            `json:"etag,omitempty"`
+	StorageClass   string            `json:"storageClass,omitempty"`
+	TimeCreated    string            `json:"timeCreated,omitempty"`
+	Updated        string            `json:"updated,omitempty"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
+}
+
+// gen2StorageEvent is the structured-mode CloudEvent envelope a real gen2
+// Eventarc-backed Cloud Storage trigger delivers. Unlike Pub/Sub (whose data
+// wraps {message, subscription}), a storage trigger's data IS the object
+// resource directly. Real Eventarc delivers binary-mode CloudEvents (ce-* as
+// HTTP headers, the bare data as the body), but driver.InvokeInput carries
+// only a payload — no headers — so structured mode is the closest
+// self-contained equivalent the emulator's invoke contract can deliver (same
+// tradeoff as the Pub/Sub gen2 envelope in pubsubtrigger.go).
+type gen2StorageEvent struct {
+	SpecVersion     string                `json:"specversion"`
+	Type            string                `json:"type"`
+	Source          string                `json:"source"`
+	Subject         string                `json:"subject"`
+	ID              string                `json:"id"`
+	Time            string                `json:"time,omitempty"`
+	DataContentType string                `json:"datacontenttype"`
+	Data            storageObjectResource `json:"data"`
+}
+
+// InvokeForObjectEvent delivers a GCS object-change event to every gen2 Cloud
+// Function whose eventTrigger is a Cloud Storage trigger bound to (bucket,
+// eventType) via an eventFilters "bucket" attribute. Only gen2 functions
+// carry a direct storage eventTrigger in this shape; a gen1 storage-triggered
+// function is delivered through the legacy GCS notificationConfig -> Pub/Sub
+// -> function chain instead (server/gcp/gcs's TopicPublisher + this
+// package's InvokeForTopic), so it is out of scope here. Best-effort — a
+// missing or failing function is swallowed so an object write/delete never
+// fails. It implements the gcs handler's FunctionInvoker.
+//
+// ctx carries the re-entrant delivery depth (internal/recursionguard): a
+// function invoked from here that writes to its own trigger bucket would
+// otherwise recurse synchronously and unbounded (PutObject ->
+// InvokeForObjectEvent -> Invoke -> handler -> PutObject -> ...), so once the
+// depth reaches recursionguard.MaxDepth this whole delivery hop is dropped.
+func (h *Handler) InvokeForObjectEvent(ctx context.Context, bucket, eventType string, resource []byte) {
+	depth := recursionguard.Depth(ctx)
+	if depth >= recursionguard.MaxDepth {
+		return
+	}
+
+	ctx = recursionguard.WithDepth(ctx, depth+1)
+
+	targets := h.storageTargetsLocked(bucket, eventType)
+	if len(targets) == 0 {
+		return
+	}
+
+	var res storageObjectResource
+	if err := json.Unmarshal(resource, &res); err != nil {
+		return
+	}
+
+	for _, name := range targets {
+		payload, err := json.Marshal(buildGen2StorageEvent(bucket, eventType, &res))
+		if err != nil {
+			continue
+		}
+
+		_, _ = h.fn.Invoke(ctx, sdrv.InvokeInput{FunctionName: name, Payload: payload, InvokeType: "Event"})
+	}
+}
+
+// storageTargetsLocked snapshots the gen2 function (short) names whose
+// eventTrigger is a Cloud Storage trigger bound to bucket and eventType.
+func (h *Handler) storageTargetsLocked(bucket, eventType string) (names []string) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	for _, fn := range h.gen2 {
+		if gen2StorageTriggerMatches(fn.EventTrigger, bucket, eventType) {
+			names = append(names, lastSegment(fn.Name))
+		}
+	}
+
+	return names
+}
+
+// gen2StorageTriggerMatches reports whether et is a Cloud Storage trigger for
+// eventType bound to bucket via an eventFilters "bucket" attribute.
+func gen2StorageTriggerMatches(et *gen2EventTrigger, bucket, eventType string) bool {
+	if et == nil || et.EventType != eventType {
+		return false
+	}
+
+	for _, f := range et.EventFilters {
+		if f.Attribute == storageEventFilterAttrBucket {
+			return f.Value == bucket
+		}
+	}
+
+	return false
+}
+
+// buildGen2StorageEvent wraps an object resource into the CloudEvent shape a
+// gen2 function's Cloud Storage eventTrigger delivers: source names the
+// bucket (real GCP always uses the "_" wildcard project segment here, never
+// the actual project id), subject names the object.
+func buildGen2StorageEvent(bucket, eventType string, res *storageObjectResource) gen2StorageEvent {
+	return gen2StorageEvent{
+		SpecVersion:     "1.0",
+		Type:            eventType,
+		Source:          "//storage.googleapis.com/projects/_/buckets/" + bucket,
+		Subject:         "objects/" + res.Name,
+		ID:              bucket + "/" + res.Name + "/" + res.Generation,
+		Time:            res.Updated,
+		DataContentType: "application/json",
+		Data:            *res,
+	}
+}

--- a/server/gcp/cloudfunctions/gen2.go
+++ b/server/gcp/cloudfunctions/gen2.go
@@ -71,12 +71,23 @@ type gen2ServiceConfig struct {
 }
 
 type gen2EventTrigger struct {
-	Trigger             string `json:"trigger,omitempty"`
-	TriggerRegion       string `json:"triggerRegion,omitempty"`
-	EventType           string `json:"eventType,omitempty"`
-	PubsubTopic         string `json:"pubsubTopic,omitempty"`
-	ServiceAccountEmail string `json:"serviceAccountEmail,omitempty"`
-	RetryPolicy         string `json:"retryPolicy,omitempty"`
+	Trigger             string            `json:"trigger,omitempty"`
+	TriggerRegion       string            `json:"triggerRegion,omitempty"`
+	EventType           string            `json:"eventType,omitempty"`
+	EventFilters        []gen2EventFilter `json:"eventFilters,omitempty"`
+	PubsubTopic         string            `json:"pubsubTopic,omitempty"`
+	ServiceAccountEmail string            `json:"serviceAccountEmail,omitempty"`
+	RetryPolicy         string            `json:"retryPolicy,omitempty"`
+}
+
+// gen2EventFilter is one eventTrigger.eventFilters entry: a non-Pub/Sub gen2
+// trigger (e.g. Cloud Storage) binds to a specific source resource by
+// filtering on a CloudEvent attribute — a storage trigger filters on
+// attribute "bucket" — rather than the pubsubTopic field Pub/Sub triggers use.
+type gen2EventFilter struct {
+	Attribute string `json:"attribute,omitempty"`
+	Operator  string `json:"operator,omitempty"`
+	Value     string `json:"value,omitempty"`
 }
 
 // listGen2Response is the {functions, nextPageToken} envelope of v2 list.
@@ -700,6 +711,10 @@ func cloneGen2(fn *gen2Function) *gen2Function {
 
 	if fn.EventTrigger != nil {
 		et := *fn.EventTrigger
+		if fn.EventTrigger.EventFilters != nil {
+			et.EventFilters = append([]gen2EventFilter(nil), fn.EventTrigger.EventFilters...)
+		}
+
 		out.EventTrigger = &et
 	}
 

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -414,6 +414,14 @@ func New(d Drivers) *server.Server {
 			gcsHandler.SetPublisher(pubsubHandler)
 		}
 
+		// GCS -> Cloud Functions: an object finalize/delete also invokes any gen2
+		// function whose storage eventTrigger is bound directly to the bucket —
+		// the Eventarc-backed delivery a real gen2 storage trigger uses, separate
+		// from (and requiring no) notificationConfig/topic.
+		if cfHandler != nil {
+			gcsHandler.SetFunctionInvoker(cfHandler)
+		}
+
 		srv.Register(gcsHandler)
 	}
 

--- a/server/gcp/gcs/gcs_functions_trigger_test.go
+++ b/server/gcp/gcs/gcs_functions_trigger_test.go
@@ -1,0 +1,466 @@
+package gcs_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	cloudfunctions2 "google.golang.org/api/cloudfunctions/v2"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	gcpprov "github.com/stackshy/cloudemu/v2/providers/gcp"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// fnTriggerProject / fnTriggerLocation name the project/location every gen2
+// storage-triggered function in this file deploys under.
+const (
+	fnTriggerProject  = "p1"
+	fnTriggerLocation = "us-central1"
+
+	// gen2StorageFinalizedType / gen2StorageDeletedType are the CloudEvent type
+	// strings a real gen2 Cloud Storage eventTrigger uses, matching what a
+	// google_cloudfunctions2_function.event_trigger.event_type is deployed
+	// with in production.
+	gen2StorageFinalizedType = "google.cloud.storage.object.v1.finalized"
+	gen2StorageDeletedType   = "google.cloud.storage.object.v1.deleted"
+)
+
+func fnTriggerParent() string {
+	return "projects/" + fnTriggerProject + "/locations/" + fnTriggerLocation
+}
+
+// fnTriggerEnv boots the FULL production GCP server (every handler, as
+// `cloudemu serve --providers gcp` does) with real Storage and Cloud
+// Functions v2 clients, so the GCS -> Cloud Functions gen2 storage-trigger
+// wiring in server/gcp/gcp.go is exercised exactly as a real user would hit
+// it.
+type fnTriggerEnv struct {
+	ts      *httptest.Server
+	cloud   *gcpprov.Provider
+	storage *storage.Client
+	cf      *cloudfunctions2.Service
+}
+
+func newFnTriggerEnv(t *testing.T) *fnTriggerEnv {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	ts := httptest.NewServer(gcpserver.NewFromProvider(cloud))
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	sc, err := storage.NewClient(ctx,
+		option.WithEndpoint(ts.URL+"/storage/v1/"),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("storage.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = sc.Close() })
+
+	cfSvc, err := cloudfunctions2.NewService(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("cloudfunctions2.NewService: %v", err)
+	}
+
+	return &fnTriggerEnv{ts: ts, cloud: cloud, storage: sc, cf: cfSvc}
+}
+
+func (e *fnTriggerEnv) createBucket(t *testing.T, name string) *storage.BucketHandle {
+	t.Helper()
+
+	b := e.storage.Bucket(name)
+	if err := b.Create(context.Background(), fnTriggerProject, nil); err != nil {
+		t.Fatalf("bucket.Create(%s): %v", name, err)
+	}
+
+	return b
+}
+
+// createStorageTriggerFunction deploys a gen2 function whose eventTrigger
+// binds bucket via an eventFilters "bucket" attribute, mirroring how
+// google_cloudfunctions2_function.event_trigger is configured for a Cloud
+// Storage trigger.
+func (e *fnTriggerEnv) createStorageTriggerFunction(t *testing.T, name, bucket, eventType string) {
+	t.Helper()
+
+	_, err := e.cf.Projects.Locations.Functions.Create(fnTriggerParent(), &cloudfunctions2.Function{
+		BuildConfig: &cloudfunctions2.BuildConfig{Runtime: "go121", EntryPoint: "Handle"},
+		EventTrigger: &cloudfunctions2.EventTrigger{
+			EventType:    eventType,
+			EventFilters: []*cloudfunctions2.EventFilter{{Attribute: "bucket", Value: bucket}},
+		},
+	}).FunctionId(name).Context(context.Background()).Do()
+	if err != nil {
+		t.Fatalf("Create gen2 storage function %s: %v", name, err)
+	}
+}
+
+func (e *fnTriggerEnv) deleteFunction(t *testing.T, name string) {
+	t.Helper()
+
+	if _, err := e.cf.Projects.Locations.Functions.
+		Delete(fnTriggerParent() + "/functions/" + name).Context(context.Background()).Do(); err != nil {
+		t.Fatalf("Delete function %s: %v", name, err)
+	}
+}
+
+// gen2StorageCloudEvent mirrors the structured-mode CloudEvent body a gen2
+// Cloud Storage-triggered function receives (cloudfunctions.gen2StorageEvent,
+// redeclared here since that's an unexported wire-package type).
+type gen2StorageCloudEvent struct {
+	SpecVersion     string `json:"specversion"`
+	Type            string `json:"type"`
+	Source          string `json:"source"`
+	Subject         string `json:"subject"`
+	ID              string `json:"id"`
+	DataContentType string `json:"datacontenttype"`
+	Data            struct {
+		Kind        string `json:"kind"`
+		Name        string `json:"name"`
+		Bucket      string `json:"bucket"`
+		Generation  string `json:"generation"`
+		Size        string `json:"size"`
+		ContentType string `json:"contentType"`
+	} `json:"data"`
+}
+
+// uploadTriggerObject writes content to bucket/key with contentType through
+// the real storage SDK writer.
+func uploadTriggerObject(t *testing.T, b *storage.BucketHandle, key, contentType, content string) {
+	t.Helper()
+
+	w := b.Object(key).NewWriter(context.Background())
+	w.ContentType = contentType
+
+	if _, err := io.Copy(w, strings.NewReader(content)); err != nil {
+		t.Fatalf("write %s: %v", key, err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close %s: %v", key, err)
+	}
+}
+
+// waitForCount polls check (which must do its own locking) until it reports
+// at least want or the deadline lapses, returning whatever count it last
+// observed either way.
+func waitForCount(timeout time.Duration, want int, check func() int) int {
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		if got := check(); got >= want {
+			return got
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return check()
+}
+
+// TestGCSObjectFinalizeInvokesGen2StorageTrigger is the world-case delivery
+// test: a gen2 function with a Cloud Storage eventTrigger (finalized, bound to
+// a specific bucket via eventFilters) fires when an object is uploaded to
+// that bucket, with the CloudEvent shape a real Eventarc-backed trigger
+// delivers — data is the storage#object resource, never the object bytes.
+func TestGCSObjectFinalizeInvokesGen2StorageTrigger(t *testing.T) {
+	e := newFnTriggerEnv(t)
+	b := e.createBucket(t, "b-fin-trigger")
+	e.createStorageTriggerFunction(t, "on-finalize", "b-fin-trigger", gen2StorageFinalizedType)
+
+	var (
+		mu       sync.Mutex
+		payloads [][]byte
+	)
+
+	e.cloud.CloudFunctions.RegisterHandler("on-finalize", func(_ context.Context, payload []byte) ([]byte, error) {
+		mu.Lock()
+		payloads = append(payloads, append([]byte(nil), payload...))
+		mu.Unlock()
+
+		return nil, nil
+	})
+
+	const body = "hello-world"
+
+	uploadTriggerObject(t, b, "trigger.txt", "text/plain", body)
+
+	if n := waitForCount(2*time.Second, 1, func() int {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return len(payloads)
+	}); n < 1 {
+		t.Fatal("gen2 storage-triggered function was not invoked by object upload")
+	}
+
+	mu.Lock()
+	raw := append([]byte(nil), payloads[0]...)
+	mu.Unlock()
+
+	var evt gen2StorageCloudEvent
+	if err := json.Unmarshal(raw, &evt); err != nil {
+		t.Fatalf("decode CloudEvent: %v (raw %s)", err, raw)
+	}
+
+	if evt.SpecVersion != "1.0" {
+		t.Errorf("specversion = %q, want 1.0", evt.SpecVersion)
+	}
+
+	if evt.Type != gen2StorageFinalizedType {
+		t.Errorf("type = %q, want %s", evt.Type, gen2StorageFinalizedType)
+	}
+
+	if evt.Source != "//storage.googleapis.com/projects/_/buckets/b-fin-trigger" {
+		t.Errorf("source = %q", evt.Source)
+	}
+
+	if evt.Subject != "objects/trigger.txt" {
+		t.Errorf("subject = %q, want objects/trigger.txt", evt.Subject)
+	}
+
+	if evt.ID == "" {
+		t.Error("id empty")
+	}
+
+	if evt.Data.Kind != "storage#object" || evt.Data.Bucket != "b-fin-trigger" || evt.Data.Name != "trigger.txt" {
+		t.Errorf("data kind/bucket/name = %q/%q/%q", evt.Data.Kind, evt.Data.Bucket, evt.Data.Name)
+	}
+
+	if evt.Data.Size != strconv.Itoa(len(body)) {
+		t.Errorf("data.size = %q, want %d", evt.Data.Size, len(body))
+	}
+
+	if evt.Data.ContentType != "text/plain" {
+		t.Errorf("data.contentType = %q, want text/plain", evt.Data.ContentType)
+	}
+}
+
+// TestGCSObjectDeleteInvokesGen2StorageTrigger covers the deleted event: a
+// gen2 function bound to (bucket, deleted) fires on Object.Delete and not on
+// the prior upload.
+func TestGCSObjectDeleteInvokesGen2StorageTrigger(t *testing.T) {
+	e := newFnTriggerEnv(t)
+	b := e.createBucket(t, "b-del-trigger")
+	e.createStorageTriggerFunction(t, "on-delete", "b-del-trigger", gen2StorageDeletedType)
+
+	var (
+		mu       sync.Mutex
+		payloads [][]byte
+	)
+
+	e.cloud.CloudFunctions.RegisterHandler("on-delete", func(_ context.Context, payload []byte) ([]byte, error) {
+		mu.Lock()
+		payloads = append(payloads, append([]byte(nil), payload...))
+		mu.Unlock()
+
+		return nil, nil
+	})
+
+	uploadTriggerObject(t, b, "gone.txt", "text/plain", "bye")
+
+	// The finalize event must not fire a function bound only to deleted.
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	preDelete := len(payloads)
+	mu.Unlock()
+
+	if preDelete != 0 {
+		t.Fatalf("upload fired %d invocations, want 0 (only deleted is bound)", preDelete)
+	}
+
+	if err := b.Object("gone.txt").Delete(context.Background()); err != nil {
+		t.Fatalf("Delete object: %v", err)
+	}
+
+	if n := waitForCount(2*time.Second, 1, func() int {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return len(payloads)
+	}); n < 1 {
+		t.Fatal("gen2 storage-triggered function was not invoked by object delete")
+	}
+
+	mu.Lock()
+	raw := append([]byte(nil), payloads[0]...)
+	mu.Unlock()
+
+	var evt gen2StorageCloudEvent
+	if err := json.Unmarshal(raw, &evt); err != nil {
+		t.Fatalf("decode CloudEvent: %v", err)
+	}
+
+	if evt.Type != gen2StorageDeletedType {
+		t.Errorf("type = %q, want %s", evt.Type, gen2StorageDeletedType)
+	}
+
+	if evt.Data.Name != "gone.txt" || evt.Data.Bucket != "b-del-trigger" {
+		t.Errorf("data name/bucket = %q/%q", evt.Data.Name, evt.Data.Bucket)
+	}
+}
+
+// TestGCSObjectFinalizeDoesNotFireForUnboundBucket confirms an object upload
+// to a bucket no gen2 function's eventTrigger names never invokes it.
+func TestGCSObjectFinalizeDoesNotFireForUnboundBucket(t *testing.T) {
+	e := newFnTriggerEnv(t)
+	e.createBucket(t, "b-bound")
+	other := e.createBucket(t, "b-other")
+	e.createStorageTriggerFunction(t, "on-bound", "b-bound", gen2StorageFinalizedType)
+
+	var (
+		mu          sync.Mutex
+		invocations int
+	)
+
+	e.cloud.CloudFunctions.RegisterHandler("on-bound", func(_ context.Context, _ []byte) ([]byte, error) {
+		mu.Lock()
+		invocations++
+		mu.Unlock()
+
+		return nil, nil
+	})
+
+	uploadTriggerObject(t, other, "irrelevant.txt", "text/plain", "x")
+
+	got := waitForCount(300*time.Millisecond, 1, func() int {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return invocations
+	})
+	if got != 0 {
+		t.Fatalf("invocations = %d, want 0 (write to an unbound bucket must not fire)", got)
+	}
+}
+
+// TestGCSObjectFinalizeDoesNotFireAfterFunctionDeleted confirms an upload
+// after the gen2 function is deleted no longer invokes it.
+func TestGCSObjectFinalizeDoesNotFireAfterFunctionDeleted(t *testing.T) {
+	e := newFnTriggerEnv(t)
+	b := e.createBucket(t, "b-deletable")
+	e.createStorageTriggerFunction(t, "on-deletable", "b-deletable", gen2StorageFinalizedType)
+
+	var (
+		mu          sync.Mutex
+		invocations int
+	)
+
+	e.cloud.CloudFunctions.RegisterHandler("on-deletable", func(_ context.Context, _ []byte) ([]byte, error) {
+		mu.Lock()
+		invocations++
+		mu.Unlock()
+
+		return nil, nil
+	})
+
+	e.deleteFunction(t, "on-deletable")
+
+	uploadTriggerObject(t, b, "too-late.txt", "text/plain", "x")
+
+	got := waitForCount(300*time.Millisecond, 1, func() int {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return invocations
+	})
+	if got != 0 {
+		t.Fatalf("invocations = %d, want 0 (a deleted function must not fire)", got)
+	}
+}
+
+// doUploadWithDepth PUTs an object via the media-upload endpoint, stamping
+// recursionguard.DepthHeader with depth. depth 0 omits any header effect
+// (equivalent to an ordinary top-level request), matching how a fresh chain
+// of requests starts at depth 0.
+func doUploadWithDepth(t *testing.T, ts *httptest.Server, bucket, name, contentType, body string, depth int) {
+	t.Helper()
+
+	url := ts.URL + "/upload/storage/v1/b/" + bucket + "/o?uploadType=media&name=" + name
+
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set(recursionguard.DepthHeader, strconv.Itoa(depth))
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("upload = %d: %s", resp.StatusCode, b)
+	}
+}
+
+// TestGCSStorageTriggerRecursionBounded confirms a gen2 function that writes
+// back to its own trigger bucket terminates at recursionguard.MaxDepth
+// instead of recursing unbounded. Invoking a gen2 function is in-process
+// (InvokeForObjectEvent -> Handler.Invoke), but the write-back a real deployed
+// function's storage SDK call performs is a fresh network hop back into this
+// same server, so the handler below plays the role production delivery code
+// plays elsewhere (e.g. Event Grid webhook delivery): it forwards the
+// ctx-carried depth across that hop via recursionguard.DepthHeader, exactly
+// as a well-behaved real function's SDK call crossing back into the emulator
+// would need to for the guard to keep counting instead of resetting to zero
+// each hop.
+func TestGCSStorageTriggerRecursionBounded(t *testing.T) {
+	e := newFnTriggerEnv(t)
+
+	const bucket = "b-loopback"
+
+	e.createBucket(t, bucket)
+	e.createStorageTriggerFunction(t, "on-loopback", bucket, gen2StorageFinalizedType)
+
+	var (
+		mu          sync.Mutex
+		invocations int
+	)
+
+	e.cloud.CloudFunctions.RegisterHandler("on-loopback", func(ctx context.Context, _ []byte) ([]byte, error) {
+		mu.Lock()
+		invocations++
+		mu.Unlock()
+
+		doUploadWithDepth(t, e.ts, bucket, "loop.txt", "text/plain", "again", recursionguard.Depth(ctx))
+
+		return nil, nil
+	})
+
+	doUploadWithDepth(t, e.ts, bucket, "loop.txt", "text/plain", "start", 0)
+
+	got := waitForCount(3*time.Second, recursionguard.MaxDepth, func() int {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return invocations
+	})
+	if got != recursionguard.MaxDepth {
+		t.Fatalf("handler invoked %d times, want exactly %d (recursive-loop guard did not bound the chain)",
+			got, recursionguard.MaxDepth)
+	}
+}

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -114,6 +114,14 @@ type Handler struct {
 	// object writes/deletes still succeed without Pub/Sub wired.
 	publisher TopicPublisher
 
+	// functionInvoker delivers an object-change event directly to every gen2
+	// Cloud Function whose Cloud Storage eventTrigger is bound to the bucket —
+	// the Eventarc-backed delivery a real gen2 storage trigger uses, independent
+	// of the legacy notificationConfig -> Pub/Sub -> function chain publisher
+	// drives above. Nil (the default) makes gen2 storage-trigger delivery a
+	// no-op, so object writes/deletes still succeed without it wired.
+	functionInvoker FunctionInvoker
+
 	// resumable holds in-progress resumable-upload sessions keyed by upload id.
 	// A session buffers the object's bytes as Content-Range chunks arrive over
 	// successive requests, committed through the normal object-write path on the
@@ -214,6 +222,8 @@ func isVersionToken(seg string) bool {
 
 // ServeHTTP routes the request based on URL path shape.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	r = r.WithContext(withDeliveryDepth(r))
+
 	if strings.HasPrefix(r.URL.Path, uploadAPIPrefix) {
 		h.upload(w, r)
 		return

--- a/server/gcp/gcs/notifications.go
+++ b/server/gcp/gcs/notifications.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
 	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
 )
 
@@ -22,6 +24,15 @@ const (
 	// pubsubTopicPrefix is the leading form the storage SDK uses for a
 	// notification's topic: //pubsub.googleapis.com/projects/{p}/topics/{t}.
 	pubsubTopicPrefix = "//pubsub.googleapis.com/"
+
+	// gen2StorageFinalizedType / gen2StorageDeletedType are the CloudEvent type
+	// strings a real Eventarc-backed gen2 Cloud Storage trigger uses on
+	// eventTrigger.eventType (the value a deployed gen2 function's storage
+	// trigger is created with), corresponding to the legacy
+	// eventTypeObjectFinalize / eventTypeObjectDelete notification event types
+	// above.
+	gen2StorageFinalizedType = "google.cloud.storage.object.v1.finalized"
+	gen2StorageDeletedType   = "google.cloud.storage.object.v1.deleted"
 )
 
 // TopicPublisher emits an object-change event to a Pub/Sub topic. The Pub/Sub
@@ -37,6 +48,44 @@ type TopicPublisher interface {
 // default) leaves object-change notifications a no-op.
 func (h *Handler) SetPublisher(p TopicPublisher) {
 	h.publisher = p
+}
+
+// FunctionInvoker delivers a GCS object-change event directly to every gen2
+// Cloud Function whose Cloud Storage eventTrigger is bound to (bucket,
+// eventType) — the Eventarc-backed delivery a real gen2 storage trigger uses.
+// resource is the storage#object resource JSON (an objectResource, marshaled
+// by the caller since the type is unexported). The Cloud Functions handler
+// implements it; the GCS handler calls it best-effort so a slow or missing
+// target never fails an object operation, mirroring TopicPublisher above.
+type FunctionInvoker interface {
+	InvokeForObjectEvent(ctx context.Context, bucket, eventType string, resource []byte)
+}
+
+// SetFunctionInvoker wires the Cloud Functions backend so an object
+// finalize/delete on a bucket with a matching gen2 storage eventTrigger is
+// delivered directly, independent of the notificationConfig -> Pub/Sub chain
+// SetPublisher drives. Nil (the default) leaves gen2 storage-trigger delivery
+// a no-op.
+func (h *Handler) SetFunctionInvoker(fi FunctionInvoker) {
+	h.functionInvoker = fi
+}
+
+// withDeliveryDepth seeds r's context with the re-entrant delivery depth
+// carried on recursionguard.DepthHeader. Invoking a gen2 function is
+// in-process (InvokeForObjectEvent -> Handler.Invoke), so the ctx depth rides
+// the goroutine for that hop; but a function that writes back to its own
+// trigger bucket does so as a fresh network call into this very handler, a
+// hop the in-process ctx can't cross. Reading the depth off the header — the
+// same bridge Event Grid webhook delivery uses — keeps a self-referential
+// write -> invoke -> write chain counting toward recursionguard.MaxDepth
+// instead of resetting to zero (and recursing unbounded) each hop.
+func withDeliveryDepth(r *http.Request) context.Context {
+	ctx := r.Context()
+	if d, err := strconv.Atoi(r.Header.Get(recursionguard.DepthHeader)); err == nil && d > 0 {
+		ctx = recursionguard.WithDepth(ctx, d)
+	}
+
+	return ctx
 }
 
 // notificationResource is the storage#notification JSON shape. The snake_case
@@ -181,10 +230,16 @@ func notificationView(r *http.Request, bucket string, cfg *storagedriver.GCSNoti
 	}
 }
 
-// emitObjectEvent publishes an object-change event to every bucket notification
-// config whose event-type filter and object-name prefix match. Best-effort: a
-// nil publisher, no configs, or a publish failure never affects the object op.
+// emitObjectEvent delivers an object-change event through both fan-out paths
+// a real object write/delete drives: the legacy notificationConfig -> Pub/Sub
+// chain (below) and, independently, a direct delivery to any gen2 Cloud
+// Function whose storage eventTrigger is bound to the bucket (a gen2 storage
+// trigger binds directly to the bucket; it has no notificationConfig or
+// explicit topic). Best-effort throughout: a nil publisher/invoker, no
+// configs/bound functions, or a delivery failure never affects the object op.
 func (h *Handler) emitObjectEvent(r *http.Request, bucket string, res *objectResource, eventType string) {
+	h.emitToFunctions(r.Context(), bucket, res, eventType)
+
 	if h.publisher == nil || h.ext == nil {
 		return
 	}
@@ -196,6 +251,41 @@ func (h *Handler) emitObjectEvent(r *http.Request, bucket string, res *objectRes
 
 	for i := range cfgs {
 		h.emitToConfig(r.Context(), bucket, res, eventType, &cfgs[i])
+	}
+}
+
+// emitToFunctions delivers res to h.functionInvoker as the gen2 CloudEvent
+// type corresponding to the legacy eventType. A nil invoker, an eventType
+// this package has no gen2 mapping for (archived/metadataUpdated are not
+// wired), or a marshal failure is a silent no-op.
+func (h *Handler) emitToFunctions(ctx context.Context, bucket string, res *objectResource, eventType string) {
+	if h.functionInvoker == nil {
+		return
+	}
+
+	gen2Type, ok := gen2FunctionEventType(eventType)
+	if !ok {
+		return
+	}
+
+	data, err := json.Marshal(res)
+	if err != nil {
+		return
+	}
+
+	h.functionInvoker.InvokeForObjectEvent(ctx, bucket, gen2Type, data)
+}
+
+// gen2FunctionEventType maps a legacy GCS notification event type to the
+// CloudEvent type string a gen2 storage eventTrigger uses.
+func gen2FunctionEventType(legacy string) (string, bool) {
+	switch legacy {
+	case eventTypeObjectFinalize:
+		return gen2StorageFinalizedType, true
+	case eventTypeObjectDelete:
+		return gen2StorageDeletedType, true
+	default:
+		return "", false
 	}
 }
 


### PR DESCRIPTION
## Summary
- An object create/overwrite (finalize) or delete on a GCS bucket now invokes every gen2 Cloud Function whose `eventTrigger` is a Cloud Storage trigger bound to that bucket via an `eventFilters` `bucket` attribute, delivering the CloudEvent shape a real Eventarc-backed storage trigger uses (`data` is the `storage#object` resource — the object's metadata, never its bytes; `source` is `//storage.googleapis.com/projects/_/buckets/{bucket}`, `subject` is `objects/{name}`).
- Adds `gen2EventTrigger.EventFilters` (the `eventFilters` shape real gen2 non-Pub/Sub triggers use) alongside the existing `pubsubTopic` field.
- Wires a new `server/gcp/gcs.FunctionInvoker` seam (`GCS -> Cloud Functions`), dispatched independently of and in addition to the existing legacy `notificationConfig -> Pub/Sub -> Cloud Functions` chain; dispatch happens after the object write/delete response is already written, so a function error never fails the object operation.
- Bounds a function that writes back to its own trigger bucket with `internal/recursionguard`. Since invoking a gen2 function is in-process but the write-back is a fresh HTTP hop back into the GCS handler, the depth now also rides `recursionguard.DepthHeader` across that hop (the same bridge Event Grid webhook delivery uses), read at the top of `gcs.Handler.ServeHTTP`.

## Why
Continues the world-case serverless depth pass (mirrors #999's Pub/Sub -> gen2 delivery): gen1/gen2 Cloud Functions could declare a Cloud Storage `eventTrigger`, but no object write/delete ever invoked it — GCS had no direct dispatch to Cloud Functions at all, only the legacy bucket `notificationConfig -> Pub/Sub` path.

## Deferred
- `archived` / `metadataUpdated` gen2 storage event types (finalized/deleted only, per scope).
- gen1 Cloud Storage triggers (gen1 has no direct `bucket` eventFilters shape in real GCP; a gen1 storage trigger is delivered through the existing legacy notificationConfig -> Pub/Sub -> function chain instead).

## Test plan
- [x] `go build ./...`
- [x] `go test ./server/gcp/cloudfunctions/... ./server/gcp/gcs/... ./providers/gcp/gcs/... ./providers/gcp/cloudfunctions/... -race -count=1`
- [x] Broad `go test ./server/gcp/... ./providers/gcp/...`
- [x] `gofmt -l` on touched files (clean)
- [x] `golangci-lint run` on touched packages (0 new issues)
- [x] `go generate ./...` + `git diff --exit-code docs/coverage` (no diff)
- [x] `go mod tidy` (no changes)
- [x] New real-user e2e tests in `server/gcp/gcs/gcs_functions_trigger_test.go`, booting the full production GCP server with real `cloud.google.com/go/storage` and `google.golang.org/api/cloudfunctions/v2` clients: finalize delivery + CloudEvent shape assertions, delete delivery, unbound-bucket negative, deleted-function negative, and a recursion-bounded test asserting exactly `recursionguard.MaxDepth` invocations.