### PR TITLE
feat(azure-functions): Blob Storage trigger delivery

### DIFF
--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -240,6 +240,9 @@ func New(opts ...config.Option) *Provider {
 	p.QueueStorage.SetFunctionTriggerSink(p.Functions, "queueTrigger")
 	p.ServiceBus.SetFunctionTriggerSink(p.Functions, "serviceBusTrigger")
 	p.BlobStorage.SetEventGridPublisher(p.EventGrid)
+	// A blob created/updated in a bound container invokes any function whose
+	// function.json declares a blobTrigger binding on that container.
+	p.BlobStorage.SetFunctionTriggerSink(p.Functions)
 	p.SQL.SetMonitoring(p.Monitor)
 	p.PostgresFlex.SetMonitoring(p.Monitor)
 	p.MySQLFlex.SetMonitoring(p.Monitor)

--- a/providers/azure/blobstorage/blob_extensions.go
+++ b/providers/azure/blobstorage/blob_extensions.go
@@ -130,6 +130,7 @@ func (m *Mock) CommitBlockList(
 
 	m.emitMetric(container, map[string]float64{"Transactions": 1, "Ingress": float64(len(data))})
 	m.emitBlobCreatedAPI(ctx, obj, container, blobEventAPIPutBlockList)
+	m.dispatchFunctionTrigger(ctx, obj, container)
 
 	info := objectInfo(obj)
 

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -207,6 +207,11 @@ type Mock struct {
 	// blobEventSeq backs the monotonically increasing sequencer stamped on each
 	// emitted blob event (Event Grid's per-blob ordering token).
 	blobEventSeq atomic.Uint64
+	// functionSink, when wired, receives a just-written blob's content on every
+	// create/update so any Azure Function with a blobTrigger binding on the
+	// blob's container can be invoked. nil in library/typed use, where blob
+	// writes simply skip trigger delivery. See function_trigger.go.
+	functionSink BlobFunctionTriggerSink
 }
 
 // Compile-time check that Mock satisfies the optional BucketAttributes
@@ -488,6 +493,7 @@ func (m *Mock) putBlockBlobInternal(
 
 	m.emitMetric(bucket, map[string]float64{"Transactions": 1, "Ingress": float64(size)})
 	m.emitBlobCreated(ctx, obj, bucket)
+	m.dispatchFunctionTrigger(ctx, obj, bucket)
 
 	info := objectInfo(obj)
 
@@ -809,6 +815,7 @@ func (m *Mock) copyBlobInternal(
 
 	m.emitMetric(dstBucket, map[string]float64{"Transactions": 1})
 	m.emitBlobCreatedAPI(ctx, dstObj, dstBucket, blobEventAPICopyBlob)
+	m.dispatchFunctionTrigger(ctx, dstObj, dstBucket)
 
 	info := objectInfo(dstObj)
 

--- a/providers/azure/blobstorage/function_trigger.go
+++ b/providers/azure/blobstorage/function_trigger.go
@@ -1,0 +1,46 @@
+package blobstorage
+
+import "context"
+
+// BlobFunctionTriggerSink delivers a just-written blob's content to any Azure
+// Function whose function.json declares a blobTrigger input binding on the
+// blob's container. The Azure Functions provider implements it. It is wired
+// per Mock instance via SetFunctionTriggerSink, mirroring how
+// servicebus.FunctionTriggerSink wires Queue Storage / Service Bus delivery
+// (see providers/azure/servicebus) and how SetEventGridPublisher wires Blob
+// Storage event emission.
+type BlobFunctionTriggerSink interface {
+	DeliverBlobFunctionTrigger(ctx context.Context, container, blobName string, body []byte)
+}
+
+// SetFunctionTriggerSink wires the Azure Functions provider as the
+// destination for this blob surface's automatic blobTrigger deliveries: a
+// successful blob create or update asks sink to invoke any function bound to
+// the written blob's container. Real Azure's blobTrigger fires on blob create
+// and update only, never on delete, so no delete path calls
+// dispatchFunctionTrigger (see DeleteObject). A nil sink disables delivery
+// (the default), so every non-Azure-Functions deployment is unaffected. This
+// is the cross-service seam, analogous to Event Grid's SetEventGridPublisher.
+func (m *Mock) SetFunctionTriggerSink(sink BlobFunctionTriggerSink) {
+	m.functionSink = sink
+}
+
+// dispatchFunctionTrigger forwards a just-written blob to any Azure Function
+// bound to its container by a blobTrigger path binding. It is a no-op when no
+// sink is wired (the default). Called after the container/blob store has
+// already been updated and with no lock held, mirroring emitBlobEvent: a
+// function invoked by the trigger may write back into Blob Storage, and
+// dispatch must never fail or block the write that already succeeded, so a
+// failure loading the blob's bytes for delivery is swallowed.
+func (m *Mock) dispatchFunctionTrigger(ctx context.Context, obj *blobObject, container string) {
+	if m.functionSink == nil {
+		return
+	}
+
+	data, err := m.loadObjectData(ctx, container, obj)
+	if err != nil {
+		return
+	}
+
+	m.functionSink.DeliverBlobFunctionTrigger(ctx, container, obj.Key, data)
+}

--- a/providers/azure/functions/blob_trigger.go
+++ b/providers/azure/functions/blob_trigger.go
@@ -1,0 +1,73 @@
+package functions
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+)
+
+// blobTriggerType is the function.json trigger type a blobTrigger binding
+// declares, as stamped by the ARM CreateFunction body's "config.bindings".
+const blobTriggerType = "blobTrigger"
+
+// DeliverBlobFunctionTrigger invokes every deployed function whose
+// function.json declares a blobTrigger input binding whose path names
+// container, passing the written blob's content as the invocation payload. It
+// is the cross-service seam the Azure Blob Storage mock calls after a
+// successful blob create/update (see providers/azure/blobstorage's
+// BlobFunctionTriggerSink), mirroring DeliverFunctionTrigger for Queue
+// Storage / Service Bus.
+//
+// Real Azure's blobTrigger fires on blob create and update, never on delete,
+// so the Blob Storage mock only calls this from its write paths. Delivery is
+// synchronous and recursion-guarded exactly like DeliverFunctionTrigger: a
+// function that writes back into its own trigger container would otherwise
+// invoke itself unbounded.
+func (m *Mock) DeliverBlobFunctionTrigger(ctx context.Context, container, blobName string, body []byte) {
+	if container == "" {
+		return
+	}
+
+	if recursionguard.Depth(ctx) >= recursionguard.MaxDepth {
+		return
+	}
+
+	match := func(b map[string]any) bool {
+		path, _ := b["path"].(string)
+		return blobTriggerPathMatches(path, container, blobName)
+	}
+
+	for _, app := range m.appsBoundBy(blobTriggerType, match) {
+		_ = m.InvokeExternal(ctx, app, body)
+	}
+}
+
+// blobTriggerPathMatches reports whether a blobTrigger binding's path (e.g.
+// "samples-workitems/{name}" or "samples-workitems/logs/{name}.txt") matches
+// a written blob: the path's first segment must equal container, and when a
+// second segment is present, its literal prefix before the first "{" token
+// (if any) must prefix blobName. A bare container path, or one whose second
+// segment is entirely a token, matches every blob in the container.
+//
+// This covers the container match Azure always enforces; it does not evaluate
+// the full token-capture grammar (e.g. "{name}.{ext}" multi-token patterns),
+// which is deferred as binding-data extraction is not needed for delivery.
+func blobTriggerPathMatches(path, container, blobName string) bool {
+	path = strings.TrimPrefix(path, "/")
+
+	head, rest, hasRest := strings.Cut(path, "/")
+	if head != container {
+		return false
+	}
+
+	if !hasRest {
+		return true
+	}
+
+	if idx := strings.IndexByte(rest, '{'); idx >= 0 {
+		rest = rest[:idx]
+	}
+
+	return strings.HasPrefix(blobName, rest)
+}

--- a/providers/azure/functions/blob_trigger_test.go
+++ b/providers/azure/functions/blob_trigger_test.go
@@ -1,0 +1,127 @@
+package functions
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+	"github.com/stretchr/testify/assert"
+)
+
+// blobTriggerConfig builds a function.json-shaped config declaring a single
+// blobTrigger input binding on path.
+func blobTriggerConfig(path string) map[string]any {
+	return map[string]any{
+		"bindings": []any{
+			map[string]any{
+				"name":       "blob",
+				"type":       "blobTrigger",
+				"direction":  "in",
+				"path":       path,
+				"connection": "AzureWebJobsStorage",
+			},
+		},
+	}
+}
+
+func TestDeliverBlobFunctionTriggerInvokesBoundApp(t *testing.T) {
+	m := newTestMock()
+	count, last := seedTriggeredApp(t, m, "blob-app", blobTriggerConfig("images/{name}"))
+
+	m.DeliverBlobFunctionTrigger(context.Background(), "images", "cat.png", []byte("bytes"))
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(count), "bound function should fire exactly once")
+	assert.Equal(t, "bytes", string(*last), "function should receive the blob content")
+}
+
+func TestDeliverBlobFunctionTriggerNoMatch(t *testing.T) {
+	m := newTestMock()
+	count, _ := seedTriggeredApp(t, m, "blob-app", blobTriggerConfig("images/{name}"))
+
+	// A different container, an empty container, and an empty binding path must
+	// all no-op.
+	m.DeliverBlobFunctionTrigger(context.Background(), "docs", "cat.png", []byte("x"))
+	m.DeliverBlobFunctionTrigger(context.Background(), "", "cat.png", []byte("x"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(count))
+}
+
+func TestDeliverBlobFunctionTriggerBareContainerMatchesEveryBlob(t *testing.T) {
+	m := newTestMock()
+	count, _ := seedTriggeredApp(t, m, "blob-app", blobTriggerConfig("images"))
+
+	m.DeliverBlobFunctionTrigger(context.Background(), "images", "anything.jpg", []byte("x"))
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(count))
+}
+
+func TestDeliverBlobFunctionTriggerLiteralPrefixConstrainsBlobName(t *testing.T) {
+	m := newTestMock()
+	count, _ := seedTriggeredApp(t, m, "blob-app", blobTriggerConfig("images/logs/{name}.txt"))
+
+	// The prefix before the first token ("logs/") must match the blob name.
+	m.DeliverBlobFunctionTrigger(context.Background(), "images", "logs/access.txt", []byte("x"))
+	assert.Equal(t, int32(1), atomic.LoadInt32(count))
+
+	m.DeliverBlobFunctionTrigger(context.Background(), "images", "other/access.txt", []byte("x"))
+	assert.Equal(t, int32(1), atomic.LoadInt32(count), "a blob outside the literal prefix must not fire")
+}
+
+func TestDeliverBlobFunctionTriggerSkipsDisabledFunction(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "disabled-app", Runtime: "node"})
+	assert.NoError(t, err)
+
+	_, err = m.UpsertSiteMeta(ctx, SiteMeta{Name: "disabled-app", Subscription: "sub", ResourceGroup: "rg"})
+	assert.NoError(t, err)
+
+	_, _, err = m.CreateSiteFunction(ctx, "disabled-app", SiteFunction{
+		Name: "fn1", Config: blobTriggerConfig("images/{name}"), IsDisabled: true,
+	})
+	assert.NoError(t, err)
+
+	var count int32
+
+	m.RegisterHandler("disabled-app", func(_ context.Context, p []byte) ([]byte, error) {
+		atomic.AddInt32(&count, 1)
+
+		return p, nil
+	})
+
+	m.DeliverBlobFunctionTrigger(ctx, "images", "cat.png", []byte("x"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&count), "a disabled function must not fire")
+}
+
+func TestDeliverBlobFunctionTriggerOutputBindingIgnored(t *testing.T) {
+	m := newTestMock()
+
+	// An output ("out") binding to the container is not a trigger and must not
+	// fire.
+	cfg := map[string]any{
+		"bindings": []any{
+			map[string]any{"name": "out", "type": "blobTrigger", "direction": "out", "path": "images/{name}"},
+		},
+	}
+	count, _ := seedTriggeredApp(t, m, "producer-app", cfg)
+
+	m.DeliverBlobFunctionTrigger(context.Background(), "images", "cat.png", []byte("x"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(count))
+}
+
+// TestDeliverBlobFunctionTriggerRecursionGuard proves a re-entrant delivery
+// already at MaxDepth is dropped without invoking the function.
+func TestDeliverBlobFunctionTriggerRecursionGuard(t *testing.T) {
+	m := newTestMock()
+	count, _ := seedTriggeredApp(t, m, "loop-app", blobTriggerConfig("loop/{name}"))
+
+	ctx := recursionguard.WithDepth(context.Background(), recursionguard.MaxDepth)
+	m.DeliverBlobFunctionTrigger(ctx, "loop", "again.txt", []byte("x"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(count), "delivery at MaxDepth must be dropped")
+}

--- a/server/azure/functions_blob_trigger_test.go
+++ b/server/azure/functions_blob_trigger_test.go
@@ -1,0 +1,380 @@
+package azure_test
+
+// Real-user end-to-end proof that an Azure Functions blobTrigger binding
+// actually fires: a function app declares a blobTrigger binding whose path
+// names a container via ARM, then a blob written to that container with the
+// real azblob SDK synchronously invokes the function with the blob's content
+// as its payload. This is the Blob Storage counterpart of
+// TestQueueStorageTriggerInvokesFunction (#997) and
+// TestServiceBusTopicTriggerInvokesFunction (#1001): before this wiring a
+// blobTrigger binding round-tripped as CRUD only and no blob write ever
+// reached the function. Real Azure's blobTrigger fires on blob create/update
+// only, never on delete.
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+)
+
+// blobFuncAppBase returns the ARM base path of a function app used by these
+// tests.
+func blobFuncAppBase(app string) string {
+	return "/subscriptions/sub-bt/resourceGroups/rg-bt/providers/Microsoft.Web/sites/" + app
+}
+
+// createBlobTriggeredApp creates a function app plus one deployed function
+// declaring a blobTrigger binding on path.
+func createBlobTriggeredApp(t *testing.T, ts *httptest.Server, app, path string) {
+	t.Helper()
+
+	base := blobFuncAppBase(app)
+	armPut(t, ts, base+"?api-version=2022-03-01", `{"location":"eastus","properties":{"siteConfig":{}}}`)
+	armPut(t, ts, base+"/functions/consume?api-version=2022-03-01",
+		`{"properties":{"config":{"bindings":[`+
+			`{"name":"blob","type":"blobTrigger","direction":"in",`+
+			`"path":"`+path+`","connection":"AzureWebJobsStorage"}]}}}`)
+}
+
+// newBlobClient returns a real azblob client pointed at ts.
+func newBlobClient(t *testing.T, ts *httptest.Server) *azblob.Client {
+	t.Helper()
+
+	client, err := azblob.NewClientWithNoCredential(ts.URL+"/", &azblob.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: ts.Client(), Retry: policy.RetryOptions{MaxRetries: -1}},
+	})
+	if err != nil {
+		t.Fatalf("azblob.NewClientWithNoCredential: %v", err)
+	}
+
+	return client
+}
+
+func TestBlobStorageTriggerInvokesFunction(t *testing.T) {
+	ts, p := newFullAzureServerWithProvider(t)
+	ctx := context.Background()
+
+	const (
+		app       = "bt-app"
+		container = "images"
+	)
+
+	createBlobTriggeredApp(t, ts, app, container+"/{name}")
+
+	got := make(chan string, 1)
+	p.Functions.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		select {
+		case got <- string(payload):
+		default:
+		}
+
+		return payload, nil
+	})
+
+	blobClient := newBlobClient(t, ts)
+	if _, err := blobClient.CreateContainer(ctx, container, nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	const content = "cat-bytes"
+	if _, err := blobClient.UploadBuffer(ctx, container, "cat.png", []byte(content), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	// Delivery is synchronous, so the function has fired by the time the upload
+	// returns.
+	select {
+	case body := <-got:
+		if body != content {
+			t.Fatalf("function received %q, want %q", body, content)
+		}
+	default:
+		t.Fatal("blob-triggered function was not invoked")
+	}
+}
+
+// TestBlobStorageTriggerUnboundContainerDoesNotFire proves a blob written to a
+// container no function is bound to invokes nothing (the write still
+// succeeds).
+func TestBlobStorageTriggerUnboundContainerDoesNotFire(t *testing.T) {
+	ts, p := newFullAzureServerWithProvider(t)
+	ctx := context.Background()
+
+	const app = "bt-app2"
+
+	createBlobTriggeredApp(t, ts, app, "bound-container/{name}")
+
+	fired := make(chan struct{}, 1)
+	p.Functions.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		fired <- struct{}{}
+
+		return payload, nil
+	})
+
+	blobClient := newBlobClient(t, ts)
+	if _, err := blobClient.CreateContainer(ctx, "other-container", nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	if _, err := blobClient.UploadBuffer(ctx, "other-container", "x", []byte("x"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	select {
+	case <-fired:
+		t.Fatal("function fired for a container it is not bound to")
+	default:
+	}
+}
+
+// TestBlobStorageTriggerDeleteDoesNotFire proves that, matching real Azure, a
+// blob DELETE never fires a blobTrigger: the bound function fires once on
+// create, then not again when that same blob is deleted.
+func TestBlobStorageTriggerDeleteDoesNotFire(t *testing.T) {
+	ts, p := newFullAzureServerWithProvider(t)
+	ctx := context.Background()
+
+	const (
+		app       = "bt-app3"
+		container = "images3"
+	)
+
+	createBlobTriggeredApp(t, ts, app, container+"/{name}")
+
+	var invocations int32
+
+	p.Functions.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		atomic.AddInt32(&invocations, 1)
+
+		return payload, nil
+	})
+
+	blobClient := newBlobClient(t, ts)
+	if _, err := blobClient.CreateContainer(ctx, container, nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	if _, err := blobClient.UploadBuffer(ctx, container, "k", []byte("v"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&invocations); got != 1 {
+		t.Fatalf("invocations after create = %d, want 1", got)
+	}
+
+	if _, err := blobClient.DeleteBlob(ctx, container, "k", nil); err != nil {
+		t.Fatalf("DeleteBlob: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&invocations); got != 1 {
+		t.Fatalf("invocations after delete = %d, want it to stay at 1 (delete must not fire a blobTrigger)", got)
+	}
+}
+
+// TestBlobStorageTriggerOverwriteFires proves a blob UPDATE (overwrite) fires
+// the trigger again, matching real Azure's blobTrigger create-AND-update
+// semantics.
+func TestBlobStorageTriggerOverwriteFires(t *testing.T) {
+	ts, p := newFullAzureServerWithProvider(t)
+	ctx := context.Background()
+
+	const (
+		app       = "bt-app4"
+		container = "images4"
+	)
+
+	createBlobTriggeredApp(t, ts, app, container+"/{name}")
+
+	var invocations int32
+
+	p.Functions.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		atomic.AddInt32(&invocations, 1)
+
+		return payload, nil
+	})
+
+	blobClient := newBlobClient(t, ts)
+	if _, err := blobClient.CreateContainer(ctx, container, nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	if _, err := blobClient.UploadBuffer(ctx, container, "k", []byte("v1"), nil); err != nil {
+		t.Fatalf("first UploadBuffer: %v", err)
+	}
+
+	if _, err := blobClient.UploadBuffer(ctx, container, "k", []byte("v2"), nil); err != nil {
+		t.Fatalf("second UploadBuffer (overwrite): %v", err)
+	}
+
+	if got := atomic.LoadInt32(&invocations); got != 2 {
+		t.Fatalf("invocations after create+overwrite = %d, want 2", got)
+	}
+}
+
+// TestBlobStorageTriggerDisabledFunctionSkipped proves a disabled deployed
+// function does not fire even though its binding matches the written
+// container.
+func TestBlobStorageTriggerDisabledFunctionSkipped(t *testing.T) {
+	ts, p := newFullAzureServerWithProvider(t)
+	ctx := context.Background()
+
+	const (
+		app       = "bt-disabled-app"
+		container = "images5"
+	)
+
+	base := blobFuncAppBase(app)
+	armPut(t, ts, base+"?api-version=2022-03-01", `{"location":"eastus","properties":{"siteConfig":{}}}`)
+	armPut(t, ts, base+"/functions/consume?api-version=2022-03-01",
+		`{"properties":{"isDisabled":true,"config":{"bindings":[`+
+			`{"name":"blob","type":"blobTrigger","direction":"in",`+
+			`"path":"`+container+`/{name}","connection":"AzureWebJobsStorage"}]}}}`)
+
+	fired := make(chan struct{}, 1)
+	p.Functions.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		fired <- struct{}{}
+
+		return payload, nil
+	})
+
+	blobClient := newBlobClient(t, ts)
+	if _, err := blobClient.CreateContainer(ctx, container, nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	if _, err := blobClient.UploadBuffer(ctx, container, "k", []byte("v"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	select {
+	case <-fired:
+		t.Fatal("a disabled function must not fire")
+	default:
+	}
+}
+
+// TestBlobStorageTriggerRecursionGuard proves a function that writes back into
+// its own trigger container terminates at recursionguard.MaxDepth rather than
+// recursing unbounded, mirroring TestServiceBusTopicTriggerRecursionGuard. The
+// handler forwards the ctx it was invoked with into its own PutObject call (a
+// direct provider call, not a fresh HTTP round trip) — that ctx-carried depth
+// is the channel the guard rides on.
+func TestBlobStorageTriggerRecursionGuard(t *testing.T) {
+	ts, p := newFullAzureServerWithProvider(t)
+	ctx := context.Background()
+
+	const (
+		app       = "bt-loop-app"
+		container = "loop-container"
+	)
+
+	createBlobTriggeredApp(t, ts, app, container+"/{name}")
+
+	blobClient := newBlobClient(t, ts)
+	if _, err := blobClient.CreateContainer(ctx, container, nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	var invocations int32
+
+	p.Functions.RegisterHandler(app, func(ctx context.Context, payload []byte) ([]byte, error) {
+		atomic.AddInt32(&invocations, 1)
+
+		err := p.BlobStorage.PutObject(ctx, container, "again.txt", payload, "text/plain", nil)
+
+		return payload, err
+	})
+
+	// The single top-level write that starts the chain.
+	if _, err := blobClient.UploadBuffer(ctx, container, "seed.txt", []byte("seed"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&invocations); got != int32(recursionguard.MaxDepth) {
+		t.Fatalf("handler invoked %d times, want exactly %d (recursive-loop guard did not bound the chain)",
+			got, recursionguard.MaxDepth)
+	}
+}
+
+// TestBlobAndQueueStorageTriggersCoexist proves the #997 Queue Storage
+// queueTrigger path still fires unchanged alongside a new blobTrigger, with no
+// cross-fire between them.
+func TestBlobAndQueueStorageTriggersCoexist(t *testing.T) {
+	ts, p := newFullAzureServerWithProvider(t)
+	ctx := context.Background()
+
+	const (
+		queueApp  = "bt-queue-app"
+		queue     = "jobs"
+		blobApp   = "bt-blob-app"
+		container = "images6"
+	)
+
+	createQueueStorageTriggeredApp(t, ts, queueApp, queue)
+	createBlobTriggeredApp(t, ts, blobApp, container+"/{name}")
+
+	queueGot := make(chan string, 1)
+	p.Functions.RegisterHandler(queueApp, func(_ context.Context, payload []byte) ([]byte, error) {
+		queueGot <- string(payload)
+		return payload, nil
+	})
+
+	blobGot := make(chan string, 1)
+	p.Functions.RegisterHandler(blobApp, func(_ context.Context, payload []byte) ([]byte, error) {
+		blobGot <- string(payload)
+		return payload, nil
+	})
+
+	createStorageQueue(t, ts, queue)
+	blobClient := newBlobClient(t, ts)
+
+	if _, err := blobClient.CreateContainer(ctx, container, nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	qc := newStorageQueueClient(t, ts, queue)
+	if _, err := qc.EnqueueMessage(ctx, "queue-payload", nil); err != nil {
+		t.Fatalf("EnqueueMessage: %v", err)
+	}
+
+	if _, err := blobClient.UploadBuffer(ctx, container, "k", []byte("blob-payload"), nil); err != nil {
+		t.Fatalf("UploadBuffer: %v", err)
+	}
+
+	select {
+	case body := <-queueGot:
+		if body != "queue-payload" {
+			t.Fatalf("queue-bound function received %q, want queue-payload", body)
+		}
+	default:
+		t.Fatal("queue-bound queueTrigger function was not invoked (#997 regression)")
+	}
+
+	select {
+	case body := <-blobGot:
+		if body != "blob-payload" {
+			t.Fatalf("blob-bound function received %q, want blob-payload", body)
+		}
+	default:
+		t.Fatal("blob-bound blobTrigger function was not invoked")
+	}
+
+	// Neither function received the other's payload.
+	select {
+	case <-queueGot:
+		t.Fatal("queue-bound function fired a second time (cross-fire from the blob write)")
+	default:
+	}
+
+	select {
+	case <-blobGot:
+		t.Fatal("blob-bound function fired a second time (cross-fire from the queue publish)")
+	default:
+	}
+}


### PR DESCRIPTION
## Summary
A blob written to a container bound by a `blobTrigger` path binding now invokes any deployed function bound to it, delivering the blob's content as the invocation payload. This is the Blob Storage analog of the Queue Storage (#997) and Service Bus topic/subscription (#1001) trigger delivery work.

- Fires on blob create and update (PutBlob, Put Block List commit, Copy Blob).
- Never fires on delete, matching real Azure blobTrigger semantics (classic polling/EventGrid source triggers only on create/update).
- Container matching (`path`'s first segment) is exact; a second path segment constrains the blob name by its literal prefix before the first `{token}` (e.g. `container/logs/{name}.txt` requires the blob to start with `logs/`).
- New `blobstorage.BlobFunctionTriggerSink`, wired from `providers/azure/azure.go` (`p.BlobStorage.SetFunctionTriggerSink(p.Functions)`), dispatched after the blob write with no lock held — mirrors `servicebus.FunctionTriggerSink` and reuses the same `appsBoundBy`/`bindingMatches`/`InvokeExternal` machinery and recursion guard as the queue/topic triggers.
- Disabled functions and output bindings are skipped, matching the existing queue/topic behavior.

## Deferred
- Full token-capture pattern binding data extraction (multi-token patterns like `{name}.{ext}`) — only a literal prefix before the first token is enforced.
- Timer, Cosmos DB change feed, and Event Hub triggers — separate later items.

## Test plan
- [x] Provider-level unit tests (`providers/azure/functions/blob_trigger_test.go`): match/no-match, bare-container wildcard, literal-prefix constraint, disabled function skipped, output binding ignored, recursion guard at `MaxDepth`.
- [x] Real-user end-to-end tests (`server/azure/functions_blob_trigger_test.go`) booting the full Azure wire server with the real `azblob` SDK: bound container fires with blob content, unbound container does not fire, delete does not fire, overwrite fires again, disabled function skipped, recursion-bounded self-write, and a queue+blob coexistence test proving #997 is unaffected.
- [x] `go build ./...`, `go test ./server/azure/... ./providers/azure/...` (including `-race` on the touched packages), `gofmt -l`, `golangci-lint run` on touched packages (no new findings), `go generate ./...` (no `docs/coverage` diff), `go mod tidy` (no changes).