### PR TITLE
feat(lambda): function URL configuration and URL invoke

### DIFF
--- a/providers/aws/lambda/functionurl.go
+++ b/providers/aws/lambda/functionurl.go
@@ -5,6 +5,9 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
@@ -17,10 +20,33 @@ const (
 	defaultAuthType   = "NONE"
 )
 
-// CreateFunctionURLConfig provisions the (single) Function URL for a function.
+// authTypeAWSIAM is the other AuthType a Function URL config accepts besides
+// defaultAuthType ("NONE"). The wire layer accepts any credentials regardless
+// of AuthType — SigV4/bearer tokens are parsed but never verified, matching
+// the rest of cloudemu — so AWS_IAM is stored and reported faithfully but adds
+// no additional enforcement on invoke.
+const authTypeAWSIAM = "AWS_IAM"
+
+// invokeModeResponseStream is the other InvokeMode a Function URL config
+// accepts besides defaultInvokeMode ("BUFFERED"). The emulator has no chunked/
+// streaming execution engine, so RESPONSE_STREAM is stored and reported
+// faithfully but invoked the same as BUFFERED.
+const invokeModeResponseStream = "RESPONSE_STREAM"
+
+// CreateFunctionURLConfig provisions a Function URL for a function, scoped to
+// $LATEST or an alias qualifier (a numbered version is rejected — see
+// isVersionQualifier). Only one URL config may exist per (function, qualifier).
 //
 //nolint:gocritic // hugeParam: matches the functionURLManager interface signature.
 func (m *Mock) CreateFunctionURLConfig(_ context.Context, cfg driver.FunctionURLConfig) (*driver.FunctionURLConfig, error) {
+	if err := validateAuthType(cfg.AuthType); err != nil {
+		return nil, err
+	}
+
+	if err := validateInvokeMode(cfg.InvokeMode); err != nil {
+		return nil, err
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -29,8 +55,14 @@ func (m *Mock) CreateFunctionURLConfig(_ context.Context, cfg driver.FunctionURL
 		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
 	}
 
-	if fd.urlConfig != nil {
-		return nil, cerrors.Newf(cerrors.AlreadyExists, "function url config for %s already exists", cfg.FunctionName)
+	if err := validateFunctionURLQualifier(&fd, cfg.Qualifier); err != nil {
+		return nil, err
+	}
+
+	key := policyKey(cfg.Qualifier)
+	if _, exists := fd.urlConfigs[key]; exists {
+		return nil, cerrors.Newf(cerrors.AlreadyExists,
+			"function url config for %s (qualifier %s) already exists", cfg.FunctionName, key)
 	}
 
 	now := m.opts.Clock.Now().UTC().Format(timeFormat)
@@ -45,44 +77,56 @@ func (m *Mock) CreateFunctionURLConfig(_ context.Context, cfg driver.FunctionURL
 		invokeMode = defaultInvokeMode
 	}
 
-	url := &driver.FunctionURLConfig{
+	stored := &driver.FunctionURLConfig{
 		FunctionName: cfg.FunctionName,
-		FunctionArn:  fd.info.ARN,
+		Qualifier:    cfg.Qualifier,
+		FunctionArn:  qualifiedARN(fd.info.ARN, cfg.Qualifier),
 		FunctionURL:  functionURL(arnRegion(fd.info.ARN, m.opts.Region)),
 		AuthType:     authType,
 		InvokeMode:   invokeMode,
-		Cors:         cfg.Cors,
+		Cors:         cloneFunctionURLCors(cfg.Cors),
 		CreationTime: now,
 		LastModified: now,
 	}
-	fd.urlConfig = url
+
+	setFunctionURLConfig(&fd, key, stored)
 	m.funcs.Set(cfg.FunctionName, fd)
 
-	result := *url
-
-	return &result, nil
+	return cloneFunctionURLConfig(stored), nil
 }
 
-// GetFunctionURLConfig returns the Function URL for a function.
-func (m *Mock) GetFunctionURLConfig(_ context.Context, functionName string) (*driver.FunctionURLConfig, error) {
+// GetFunctionURLConfig returns the Function URL config for a function's
+// qualifier ("" and "$LATEST" both mean the unqualified $LATEST URL).
+func (m *Mock) GetFunctionURLConfig(_ context.Context, functionName, qualifier string) (*driver.FunctionURLConfig, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	fd, ok := m.funcs.Get(functionName)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
 	}
 
-	if fd.urlConfig == nil {
+	cfg, ok := fd.urlConfigs[policyKey(qualifier)]
+	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "function url config for %s not found", functionName)
 	}
 
-	result := *fd.urlConfig
-
-	return &result, nil
+	return cloneFunctionURLConfig(cfg), nil
 }
 
-// UpdateFunctionURLConfig mutates AuthType/InvokeMode/Cors on an existing URL.
+// UpdateFunctionURLConfig mutates AuthType/InvokeMode/Cors on an existing URL
+// config, leaving unset fields unchanged.
 //
 //nolint:gocritic // hugeParam: matches the functionURLManager interface signature.
 func (m *Mock) UpdateFunctionURLConfig(_ context.Context, cfg driver.FunctionURLConfig) (*driver.FunctionURLConfig, error) {
+	if err := validateAuthType(cfg.AuthType); err != nil {
+		return nil, err
+	}
+
+	if err := validateInvokeMode(cfg.InvokeMode); err != nil {
+		return nil, err
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -91,11 +135,14 @@ func (m *Mock) UpdateFunctionURLConfig(_ context.Context, cfg driver.FunctionURL
 		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
 	}
 
-	if fd.urlConfig == nil {
+	key := policyKey(cfg.Qualifier)
+
+	existing, ok := fd.urlConfigs[key]
+	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "function url config for %s not found", cfg.FunctionName)
 	}
 
-	updated := *fd.urlConfig
+	updated := *existing
 
 	if cfg.AuthType != "" {
 		updated.AuthType = cfg.AuthType
@@ -106,20 +153,19 @@ func (m *Mock) UpdateFunctionURLConfig(_ context.Context, cfg driver.FunctionURL
 	}
 
 	if cfg.Cors != nil {
-		updated.Cors = cfg.Cors
+		updated.Cors = cloneFunctionURLCors(cfg.Cors)
 	}
 
 	updated.LastModified = m.opts.Clock.Now().UTC().Format(timeFormat)
-	fd.urlConfig = &updated
+
+	setFunctionURLConfig(&fd, key, &updated)
 	m.funcs.Set(cfg.FunctionName, fd)
 
-	result := updated
-
-	return &result, nil
+	return cloneFunctionURLConfig(&updated), nil
 }
 
-// DeleteFunctionURLConfig removes a function's URL.
-func (m *Mock) DeleteFunctionURLConfig(_ context.Context, functionName string) error {
+// DeleteFunctionURLConfig removes a function's URL config for a qualifier.
+func (m *Mock) DeleteFunctionURLConfig(_ context.Context, functionName, qualifier string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -128,29 +174,79 @@ func (m *Mock) DeleteFunctionURLConfig(_ context.Context, functionName string) e
 		return cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
 	}
 
-	if fd.urlConfig == nil {
+	key := policyKey(qualifier)
+	if _, exists := fd.urlConfigs[key]; !exists {
 		return cerrors.Newf(cerrors.NotFound, "function url config for %s not found", functionName)
 	}
 
-	fd.urlConfig = nil
+	next := make(map[string]*driver.FunctionURLConfig, len(fd.urlConfigs))
+
+	for k, v := range fd.urlConfigs {
+		if k != key {
+			next[k] = v
+		}
+	}
+
+	fd.urlConfigs = next
 	m.funcs.Set(functionName, fd)
 
 	return nil
 }
 
-// ListFunctionURLConfigs returns the Function URL configs for a function (zero
-// or one, since a function has at most one URL for the $LATEST qualifier).
+// ListFunctionURLConfigs returns every Function URL config set on a function
+// (one per qualifier).
 func (m *Mock) ListFunctionURLConfigs(_ context.Context, functionName string) ([]driver.FunctionURLConfig, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	fd, ok := m.funcs.Get(functionName)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
 	}
 
-	if fd.urlConfig == nil {
-		return []driver.FunctionURLConfig{}, nil
+	out := make([]driver.FunctionURLConfig, 0, len(fd.urlConfigs))
+	for _, cfg := range fd.urlConfigs {
+		out = append(out, *cloneFunctionURLConfig(cfg))
 	}
 
-	return []driver.FunctionURLConfig{*fd.urlConfig}, nil
+	return out, nil
+}
+
+// ResolveFunctionURL finds the Function URL config whose generated FunctionURL
+// host matches host (case-insensitive, no port), for the invoke-via-URL wire
+// path: the server extracts the Host header from an inbound request and hands
+// it here to identify which function/qualifier that URL was assigned to.
+func (m *Mock) ResolveFunctionURL(_ context.Context, host string) (*driver.FunctionURLConfig, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	host = strings.ToLower(host)
+
+	for _, name := range m.funcs.Keys() {
+		fd, ok := m.funcs.Get(name)
+		if !ok {
+			continue
+		}
+
+		for _, cfg := range fd.urlConfigs {
+			if functionURLHost(cfg.FunctionURL) == host {
+				return cloneFunctionURLConfig(cfg), nil
+			}
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "no function url found for host %s", host)
+}
+
+// functionURLHost extracts the lowercase host from a generated FunctionURL
+// (https://<url-id>.lambda-url.<region>.on.aws/), or "" if u isn't a valid URL.
+func functionURLHost(u string) string {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return ""
+	}
+
+	return strings.ToLower(parsed.Hostname())
 }
 
 // functionURL synthesizes a Lambda Function URL of the real shape
@@ -162,4 +258,100 @@ func functionURL(region string) string {
 	}
 
 	return fmt.Sprintf("https://%s.lambda-url.%s.on.aws/", hex.EncodeToString(b[:8])+hex.EncodeToString(b[8:]), region)
+}
+
+// isVersionQualifier reports whether qualifier names a published numeric
+// version ("1", "2", ...) rather than $LATEST or an alias. Real Lambda rejects
+// a Function URL config targeting a specific version: the URL must point at
+// $LATEST (the function's live code) or an alias, since a numbered version is
+// immutable and repointing traffic (e.g. blue/green) only makes sense through
+// an alias.
+func isVersionQualifier(qualifier string) bool {
+	if qualifier == "" || qualifier == latestVersion {
+		return false
+	}
+
+	_, err := strconv.Atoi(qualifier)
+
+	return err == nil
+}
+
+// validateFunctionURLQualifier enforces the qualifiers a Function URL config
+// may target: unqualified/$LATEST, or an alias that exists on fd. A numbered
+// version, or an alias name that doesn't exist, is rejected.
+func validateFunctionURLQualifier(fd *funcData, qualifier string) error {
+	if isVersionQualifier(qualifier) {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"FunctionUrlConfig cannot target a numbered version (%s); use $LATEST or an alias", qualifier)
+	}
+
+	if qualifier == "" || qualifier == latestVersion {
+		return nil
+	}
+
+	if _, ok := fd.aliases.Get(qualifier); !ok {
+		return cerrors.Newf(cerrors.NotFound, "function alias %s not found", qualifier)
+	}
+
+	return nil
+}
+
+// validateAuthType rejects an AuthType other than the two real Lambda accepts.
+func validateAuthType(authType string) error {
+	if authType == "" || authType == defaultAuthType || authType == authTypeAWSIAM {
+		return nil
+	}
+
+	return cerrors.Newf(cerrors.InvalidArgument, "AuthType must be %s or %s, got %s",
+		defaultAuthType, authTypeAWSIAM, authType)
+}
+
+// validateInvokeMode rejects an InvokeMode other than the two real Lambda
+// accepts.
+func validateInvokeMode(invokeMode string) error {
+	if invokeMode == "" || invokeMode == defaultInvokeMode || invokeMode == invokeModeResponseStream {
+		return nil
+	}
+
+	return cerrors.Newf(cerrors.InvalidArgument, "InvokeMode must be %s or %s, got %s",
+		defaultInvokeMode, invokeModeResponseStream, invokeMode)
+}
+
+// setFunctionURLConfig stores cfg under its normalized qualifier key using
+// copy-on-write: a fresh map is built so a concurrent reader holding an
+// earlier funcData copy still sees an immutable snapshot (-race clean).
+func setFunctionURLConfig(fd *funcData, key string, cfg *driver.FunctionURLConfig) {
+	next := make(map[string]*driver.FunctionURLConfig, len(fd.urlConfigs)+1)
+
+	for k, v := range fd.urlConfigs {
+		next[k] = v
+	}
+
+	next[key] = cfg
+	fd.urlConfigs = next
+}
+
+// cloneFunctionURLCors deep-copies a CORS config so stored state and a
+// returned/snapshot copy never share the pointer or its slice fields.
+func cloneFunctionURLCors(c *driver.FunctionURLCors) *driver.FunctionURLCors {
+	if c == nil {
+		return nil
+	}
+
+	clone := *c
+	clone.AllowHeaders = append([]string(nil), c.AllowHeaders...)
+	clone.AllowMethods = append([]string(nil), c.AllowMethods...)
+	clone.AllowOrigins = append([]string(nil), c.AllowOrigins...)
+	clone.ExposeHeaders = append([]string(nil), c.ExposeHeaders...)
+
+	return &clone
+}
+
+// cloneFunctionURLConfig deep-copies cfg so stored state and a returned/
+// snapshot copy never share the Cors pointer.
+func cloneFunctionURLConfig(cfg *driver.FunctionURLConfig) *driver.FunctionURLConfig {
+	clone := *cfg
+	clone.Cors = cloneFunctionURLCors(cfg.Cors)
+
+	return &clone
 }

--- a/providers/aws/lambda/functionurl_test.go
+++ b/providers/aws/lambda/functionurl_test.go
@@ -1,0 +1,353 @@
+package lambda
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+func TestFunctionURLConfigRoundTrip(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	created, err := m.CreateFunctionURLConfig(ctx, driver.FunctionURLConfig{
+		FunctionName: "my-func",
+		AuthType:     "NONE",
+		Cors:         &driver.FunctionURLCors{AllowOrigins: []string{"*"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateFunctionURLConfig: %v", err)
+	}
+
+	if !strings.HasPrefix(created.FunctionURL, "https://") || !strings.Contains(created.FunctionURL, ".lambda-url.us-east-1.on.aws/") {
+		t.Fatalf("FunctionURL = %q, want the real Lambda Function URL shape", created.FunctionURL)
+	}
+
+	if created.InvokeMode != defaultInvokeMode {
+		t.Fatalf("InvokeMode = %q, want default %q", created.InvokeMode, defaultInvokeMode)
+	}
+
+	// $LATEST/unqualified: FunctionArn carries no trailing qualifier suffix.
+	if strings.Contains(created.FunctionArn, ":$LATEST") {
+		t.Fatalf("FunctionArn = %q, unexpected $LATEST qualifier suffix", created.FunctionArn)
+	}
+
+	got, err := m.GetFunctionURLConfig(ctx, "my-func", "")
+	if err != nil {
+		t.Fatalf("GetFunctionURLConfig: %v", err)
+	}
+
+	if got.FunctionURL != created.FunctionURL {
+		t.Fatalf("Get FunctionURL = %q, want %q", got.FunctionURL, created.FunctionURL)
+	}
+
+	// "$LATEST" and "" are the same qualifier.
+	gotLatest, err := m.GetFunctionURLConfig(ctx, "my-func", latestVersion)
+	if err != nil {
+		t.Fatalf("GetFunctionURLConfig($LATEST): %v", err)
+	}
+
+	if gotLatest.FunctionURL != created.FunctionURL {
+		t.Fatalf("$LATEST FunctionURL = %q, want %q", gotLatest.FunctionURL, created.FunctionURL)
+	}
+
+	updated, err := m.UpdateFunctionURLConfig(ctx, driver.FunctionURLConfig{
+		FunctionName: "my-func",
+		AuthType:     authTypeAWSIAM,
+	})
+	if err != nil {
+		t.Fatalf("UpdateFunctionURLConfig: %v", err)
+	}
+
+	if updated.AuthType != authTypeAWSIAM {
+		t.Fatalf("AuthType after update = %q, want %q", updated.AuthType, authTypeAWSIAM)
+	}
+
+	if updated.Cors == nil || len(updated.Cors.AllowOrigins) != 1 {
+		t.Fatalf("Cors after update = %+v, want unchanged from create", updated.Cors)
+	}
+
+	list, err := m.ListFunctionURLConfigs(ctx, "my-func")
+	if err != nil {
+		t.Fatalf("ListFunctionURLConfigs: %v", err)
+	}
+
+	if len(list) != 1 {
+		t.Fatalf("ListFunctionURLConfigs = %d, want 1", len(list))
+	}
+
+	if err := m.DeleteFunctionURLConfig(ctx, "my-func", ""); err != nil {
+		t.Fatalf("DeleteFunctionURLConfig: %v", err)
+	}
+
+	if _, err := m.GetFunctionURLConfig(ctx, "my-func", ""); !errors.IsNotFound(err) {
+		t.Fatalf("Get after delete err = %v, want NotFound", err)
+	}
+}
+
+func TestFunctionURLConfigPerQualifier(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	if _, err := m.PublishVersion(ctx, "my-func", "v1"); err != nil {
+		t.Fatalf("PublishVersion: %v", err)
+	}
+
+	if _, err := m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "my-func", Name: "live", FunctionVersion: "1",
+	}); err != nil {
+		t.Fatalf("CreateAlias: %v", err)
+	}
+
+	latestCfg, err := m.CreateFunctionURLConfig(ctx, driver.FunctionURLConfig{FunctionName: "my-func"})
+	if err != nil {
+		t.Fatalf("CreateFunctionURLConfig($LATEST): %v", err)
+	}
+
+	aliasCfg, err := m.CreateFunctionURLConfig(ctx, driver.FunctionURLConfig{FunctionName: "my-func", Qualifier: "live"})
+	if err != nil {
+		t.Fatalf("CreateFunctionURLConfig(live): %v", err)
+	}
+
+	if latestCfg.FunctionURL == aliasCfg.FunctionURL {
+		t.Fatal("the $LATEST and alias URL configs got the same FunctionURL")
+	}
+
+	if aliasCfg.FunctionArn != qualifiedARN(latestCfg.FunctionArn, "live") {
+		t.Fatalf("alias FunctionArn = %q, want a :live-qualified ARN", aliasCfg.FunctionArn)
+	}
+
+	list, err := m.ListFunctionURLConfigs(ctx, "my-func")
+	if err != nil {
+		t.Fatalf("ListFunctionURLConfigs: %v", err)
+	}
+
+	if len(list) != 2 {
+		t.Fatalf("ListFunctionURLConfigs = %d, want 2 (one per qualifier)", len(list))
+	}
+
+	// Deleting the alias's URL leaves $LATEST's untouched.
+	if err := m.DeleteFunctionURLConfig(ctx, "my-func", "live"); err != nil {
+		t.Fatalf("DeleteFunctionURLConfig(live): %v", err)
+	}
+
+	if _, err := m.GetFunctionURLConfig(ctx, "my-func", ""); err != nil {
+		t.Fatalf("GetFunctionURLConfig($LATEST) after deleting the alias's config: %v", err)
+	}
+
+	if _, err := m.GetFunctionURLConfig(ctx, "my-func", "live"); !errors.IsNotFound(err) {
+		t.Fatalf("GetFunctionURLConfig(live) after delete err = %v, want NotFound", err)
+	}
+}
+
+func TestFunctionURLConfigRejectsVersionQualifier(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	if _, err := m.PublishVersion(ctx, "my-func", "v1"); err != nil {
+		t.Fatalf("PublishVersion: %v", err)
+	}
+
+	if _, err := m.CreateFunctionURLConfig(ctx, driver.FunctionURLConfig{
+		FunctionName: "my-func", Qualifier: "1",
+	}); !errors.IsInvalidArgument(err) {
+		t.Fatalf("CreateFunctionURLConfig(qualifier=1) err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestFunctionURLConfigRejectsUnknownAlias(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	if _, err := m.CreateFunctionURLConfig(ctx, driver.FunctionURLConfig{
+		FunctionName: "my-func", Qualifier: "no-such-alias",
+	}); !errors.IsNotFound(err) {
+		t.Fatalf("CreateFunctionURLConfig(unknown alias) err = %v, want NotFound", err)
+	}
+}
+
+func TestFunctionURLConfigDuplicateConflicts(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	if _, err := m.CreateFunctionURLConfig(ctx, driver.FunctionURLConfig{FunctionName: "my-func"}); err != nil {
+		t.Fatalf("first CreateFunctionURLConfig: %v", err)
+	}
+
+	if _, err := m.CreateFunctionURLConfig(ctx, driver.FunctionURLConfig{FunctionName: "my-func"}); !errors.IsAlreadyExists(err) {
+		t.Fatalf("second CreateFunctionURLConfig err = %v, want AlreadyExists", err)
+	}
+}
+
+func TestFunctionURLConfigInvalidAuthTypeAndInvokeMode(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	if _, err := m.CreateFunctionURLConfig(ctx, driver.FunctionURLConfig{
+		FunctionName: "my-func", AuthType: "BOGUS",
+	}); !errors.IsInvalidArgument(err) {
+		t.Fatalf("CreateFunctionURLConfig(bad AuthType) err = %v, want InvalidArgument", err)
+	}
+
+	if _, err := m.CreateFunctionURLConfig(ctx, driver.FunctionURLConfig{
+		FunctionName: "my-func", InvokeMode: "BOGUS",
+	}); !errors.IsInvalidArgument(err) {
+		t.Fatalf("CreateFunctionURLConfig(bad InvokeMode) err = %v, want InvalidArgument", err)
+	}
+}
+
+// TestFunctionURLConfigCOWIndependence confirms a caller mutating a returned
+// config's Cors slices never disturbs the stored state — the copy-on-write
+// contract every funcData map field in this package follows.
+func TestFunctionURLConfigCOWIndependence(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	created, err := m.CreateFunctionURLConfig(ctx, driver.FunctionURLConfig{
+		FunctionName: "my-func",
+		Cors:         &driver.FunctionURLCors{AllowOrigins: []string{"https://example.com"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateFunctionURLConfig: %v", err)
+	}
+
+	created.Cors.AllowOrigins[0] = "mutated"
+	created.AuthType = "mutated"
+
+	got, err := m.GetFunctionURLConfig(ctx, "my-func", "")
+	if err != nil {
+		t.Fatalf("GetFunctionURLConfig: %v", err)
+	}
+
+	if got.Cors.AllowOrigins[0] != "https://example.com" {
+		t.Fatalf("stored AllowOrigins = %q, want unaffected by caller mutation", got.Cors.AllowOrigins[0])
+	}
+
+	if got.AuthType != defaultAuthType {
+		t.Fatalf("stored AuthType = %q, want unaffected by caller mutation", got.AuthType)
+	}
+}
+
+func TestFunctionURLConfigConcurrent(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	if _, err := m.PublishVersion(ctx, "my-func", "v1"); err != nil {
+		t.Fatalf("PublishVersion: %v", err)
+	}
+
+	const aliasCount = 8
+
+	var wg sync.WaitGroup
+
+	for i := range aliasCount {
+		name := aliasName(i)
+
+		if _, err := m.CreateAlias(ctx, driver.AliasConfig{
+			FunctionName: "my-func", Name: name, FunctionVersion: "1",
+		}); err != nil {
+			t.Fatalf("CreateAlias(%s): %v", name, err)
+		}
+
+		wg.Add(1)
+
+		go func(qualifier string) {
+			defer wg.Done()
+
+			if _, err := m.CreateFunctionURLConfig(ctx, driver.FunctionURLConfig{
+				FunctionName: "my-func", Qualifier: qualifier,
+			}); err != nil {
+				t.Errorf("CreateFunctionURLConfig(%s): %v", qualifier, err)
+			}
+
+			if _, err := m.GetFunctionURLConfig(ctx, "my-func", qualifier); err != nil {
+				t.Errorf("GetFunctionURLConfig(%s): %v", qualifier, err)
+			}
+		}(name)
+	}
+
+	wg.Wait()
+
+	list, err := m.ListFunctionURLConfigs(ctx, "my-func")
+	if err != nil {
+		t.Fatalf("ListFunctionURLConfigs: %v", err)
+	}
+
+	if len(list) != aliasCount {
+		t.Fatalf("ListFunctionURLConfigs = %d, want %d", len(list), aliasCount)
+	}
+}
+
+func aliasName(i int) string {
+	const base = 'a'
+	return "alias-" + string(rune(base+i))
+}
+
+func TestResolveFunctionURL(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFunction(ctx, defaultFuncConfig()); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	created, err := m.CreateFunctionURLConfig(ctx, driver.FunctionURLConfig{FunctionName: "my-func"})
+	if err != nil {
+		t.Fatalf("CreateFunctionURLConfig: %v", err)
+	}
+
+	parsed, err := url.Parse(created.FunctionURL)
+	if err != nil {
+		t.Fatalf("parse FunctionURL: %v", err)
+	}
+
+	resolved, err := m.ResolveFunctionURL(ctx, strings.ToUpper(parsed.Hostname()))
+	if err != nil {
+		t.Fatalf("ResolveFunctionURL: %v", err)
+	}
+
+	if resolved.FunctionName != "my-func" {
+		t.Fatalf("resolved FunctionName = %q, want my-func", resolved.FunctionName)
+	}
+
+	if _, err := m.ResolveFunctionURL(ctx, "nonexistent.lambda-url.us-east-1.on.aws"); !errors.IsNotFound(err) {
+		t.Fatalf("ResolveFunctionURL(unknown host) err = %v, want NotFound", err)
+	}
+}

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -100,8 +100,13 @@ type funcData struct {
 	// policies is the resource-based policy keyed by qualifier (normalized via
 	// policyKey: "" and "$LATEST" collapse to the unqualified function policy),
 	// then by statement id. AWS keeps a separate policy per version/alias.
-	policies  map[string]map[string]driver.PermissionStatement
-	urlConfig *driver.FunctionURLConfig // Lambda Function URL, nil until created
+	policies map[string]map[string]driver.PermissionStatement
+	// urlConfigs holds the Function URL config keyed by qualifier (normalized
+	// via policyKey: "" and "$LATEST" collapse to the unqualified $LATEST URL,
+	// an alias name is kept as-is), matching AWS's one-URL-per-(function,
+	// qualifier) scoping. Real Lambda rejects a numbered-version qualifier
+	// outright — see validateFunctionURLQualifier.
+	urlConfigs map[string]*driver.FunctionURLConfig
 	// awsConfig holds the AWS-only settings (VpcConfig/DeadLetterConfig/
 	// TracingConfig) applied through the AWSConfigurable optional interface.
 	awsConfig driver.AWSFunctionConfig

--- a/providers/aws/lambda/snapshot.go
+++ b/providers/aws/lambda/snapshot.go
@@ -41,8 +41,9 @@ type funcSnapshot struct {
 	Aliases      map[string]driver.Alias                          `json:"aliases,omitempty"`
 	Concurrency  *driver.ConcurrencyConfig                        `json:"concurrency,omitempty"`
 	Policies     map[string]map[string]driver.PermissionStatement `json:"policies,omitempty"`
-	URLConfig    *driver.FunctionURLConfig                        `json:"urlConfig,omitempty"`
-	AWSConfig    driver.AWSFunctionConfig                         `json:"awsConfig"`
+	// URLConfigs is the Function URL config per qualifier (see funcData.urlConfigs).
+	URLConfigs map[string]*driver.FunctionURLConfig `json:"urlConfigs,omitempty"`
+	AWSConfig  driver.AWSFunctionConfig             `json:"awsConfig"`
 	// EventInvokeConfigs is the async-invoke config per qualifier (retries,
 	// event age, OnSuccess/OnFailure destinations).
 	EventInvokeConfigs map[string]driver.EventInvokeConfig `json:"eventInvokeConfigs,omitempty"`
@@ -114,7 +115,7 @@ func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
 func snapshotFunc(fd *funcData) *funcSnapshot {
 	fs := &funcSnapshot{
 		Info: fd.info, EngineBacked: fd.engineBacked, NextVersion: fd.nextVersion,
-		Concurrency: fd.concurrency, Policies: fd.policies, URLConfig: fd.urlConfig,
+		Concurrency: fd.concurrency, Policies: fd.policies, URLConfigs: fd.urlConfigs,
 		AWSConfig: fd.awsConfig, EventInvokeConfigs: fd.eventInvokeConfigs,
 		ProvisionedConcurrencyConfigs: fd.provisionedConcurrencyConfigs,
 	}
@@ -173,7 +174,7 @@ func (m *Mock) restoreFunc(name string, fs *funcSnapshot) funcData {
 	fd := funcData{
 		info: fs.Info, engineBacked: fs.EngineBacked, nextVersion: fs.NextVersion,
 		aliases: memstore.New[*aliasData](), concurrency: fs.Concurrency,
-		policies: fs.Policies, urlConfig: fs.URLConfig, awsConfig: fs.AWSConfig,
+		policies: fs.Policies, urlConfigs: fs.URLConfigs, awsConfig: fs.AWSConfig,
 		eventInvokeConfigs:            fs.EventInvokeConfigs,
 		provisionedConcurrencyConfigs: fs.ProvisionedConcurrencyConfigs,
 	}

--- a/providers/aws/lambda/snapshot.go
+++ b/providers/aws/lambda/snapshot.go
@@ -43,7 +43,13 @@ type funcSnapshot struct {
 	Policies     map[string]map[string]driver.PermissionStatement `json:"policies,omitempty"`
 	// URLConfigs is the Function URL config per qualifier (see funcData.urlConfigs).
 	URLConfigs map[string]*driver.FunctionURLConfig `json:"urlConfigs,omitempty"`
-	AWSConfig  driver.AWSFunctionConfig             `json:"awsConfig"`
+	// URLConfig is the legacy single-URL shape a snapshot taken before Function
+	// URLs gained qualifier scoping used ("urlConfig", singular). Never written
+	// (snapshotFunc only populates URLConfigs), but still read on restore so an
+	// old on-disk snapshot's Function URL config isn't silently dropped — see
+	// restoreFunc.
+	URLConfig *driver.FunctionURLConfig `json:"urlConfig,omitempty"`
+	AWSConfig driver.AWSFunctionConfig  `json:"awsConfig"`
 	// EventInvokeConfigs is the async-invoke config per qualifier (retries,
 	// event age, OnSuccess/OnFailure destinations).
 	EventInvokeConfigs map[string]driver.EventInvokeConfig `json:"eventInvokeConfigs,omitempty"`
@@ -174,7 +180,7 @@ func (m *Mock) restoreFunc(name string, fs *funcSnapshot) funcData {
 	fd := funcData{
 		info: fs.Info, engineBacked: fs.EngineBacked, nextVersion: fs.NextVersion,
 		aliases: memstore.New[*aliasData](), concurrency: fs.Concurrency,
-		policies: fs.Policies, urlConfigs: fs.URLConfigs, awsConfig: fs.AWSConfig,
+		policies: fs.Policies, urlConfigs: legacyURLConfigs(fs), awsConfig: fs.AWSConfig,
 		eventInvokeConfigs:            fs.EventInvokeConfigs,
 		provisionedConcurrencyConfigs: fs.ProvisionedConcurrencyConfigs,
 	}
@@ -197,4 +203,17 @@ func (m *Mock) restoreFunc(name string, fs *funcSnapshot) funcData {
 	}
 
 	return fd
+}
+
+// legacyURLConfigs returns fs.URLConfigs, migrating a pre-qualifier-scoping
+// snapshot's legacy singular "urlConfig" field (fs.URLConfig) into the new
+// per-qualifier map when the snapshot predates it — otherwise a Function URL
+// config in an old on-disk snapshot would silently vanish on restore, since
+// the new map field simply isn't present in that JSON.
+func legacyURLConfigs(fs *funcSnapshot) map[string]*driver.FunctionURLConfig {
+	if len(fs.URLConfigs) > 0 || fs.URLConfig == nil {
+		return fs.URLConfigs
+	}
+
+	return map[string]*driver.FunctionURLConfig{policyKey(fs.URLConfig.Qualifier): fs.URLConfig}
 }

--- a/providers/aws/lambda/snapshot_test.go
+++ b/providers/aws/lambda/snapshot_test.go
@@ -2,6 +2,7 @@ package lambda
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
@@ -41,6 +42,11 @@ func TestSnapshotRoundTripLambda(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("CreateEventSourceMapping: %v", err)
+	}
+
+	urlCfg, err := src.CreateFunctionURLConfig(ctx, driver.FunctionURLConfig{FunctionName: cfg.Name})
+	if err != nil {
+		t.Fatalf("CreateFunctionURLConfig: %v", err)
 	}
 
 	raw, err := src.Snapshot(ctx, true)
@@ -89,6 +95,61 @@ func TestSnapshotRoundTripLambda(t *testing.T) {
 	gotESM, err := dst.GetEventSourceMapping(ctx, esm.UUID)
 	if err != nil || gotESM.FunctionArn == "" {
 		t.Fatalf("restored esm = %+v, err %v", gotESM, err)
+	}
+
+	gotURLCfg, err := dst.GetFunctionURLConfig(ctx, cfg.Name, "")
+	if err != nil || gotURLCfg.FunctionURL != urlCfg.FunctionURL {
+		t.Fatalf("restored function url config = %+v, err %v, want FunctionURL %q", gotURLCfg, err, urlCfg.FunctionURL)
+	}
+}
+
+// TestSnapshotRestoreLegacyFunctionURLConfig proves Restore migrates a
+// snapshot taken before Function URLs gained qualifier scoping — which
+// serialized the config under the singular "urlConfig" key instead of today's
+// per-qualifier "urlConfigs" map — so an old on-disk snapshot's Function URL
+// config isn't silently dropped.
+func TestSnapshotRestoreLegacyFunctionURLConfig(t *testing.T) {
+	ctx := context.Background()
+
+	legacy := map[string]any{
+		"funcs": map[string]any{
+			"my-func": map[string]any{
+				"info": map[string]any{
+					"Name": "my-func",
+					"ARN":  "arn:aws:lambda:us-east-1:000000000000:function:my-func",
+				},
+				"awsConfig": map[string]any{},
+				"urlConfig": map[string]any{
+					"FunctionName": "my-func",
+					"Qualifier":    "",
+					"FunctionArn":  "arn:aws:lambda:us-east-1:000000000000:function:my-func",
+					"FunctionURL":  "https://legacyid123456.lambda-url.us-east-1.on.aws/",
+					"AuthType":     "NONE",
+					"InvokeMode":   "BUFFERED",
+					"CreationTime": "2025-01-01T00:00:00Z",
+					"LastModified": "2025-01-01T00:00:00Z",
+				},
+			},
+		},
+	}
+
+	raw, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("marshal legacy snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore legacy snapshot: %v", err)
+	}
+
+	got, err := dst.GetFunctionURLConfig(ctx, "my-func", "")
+	if err != nil {
+		t.Fatalf("GetFunctionURLConfig after restoring a legacy singular-urlConfig snapshot: %v", err)
+	}
+
+	if got.FunctionURL != "https://legacyid123456.lambda-url.us-east-1.on.aws/" {
+		t.Fatalf("restored FunctionURL = %q, want the legacy snapshot's URL", got.FunctionURL)
 	}
 }
 

--- a/server/aws/lambda/functionurl.go
+++ b/server/aws/lambda/functionurl.go
@@ -13,10 +13,18 @@ import (
 // type-asserts for it rather than requiring every cloud to implement it.
 type functionURLManager interface {
 	CreateFunctionURLConfig(ctx context.Context, cfg sdrv.FunctionURLConfig) (*sdrv.FunctionURLConfig, error)
-	GetFunctionURLConfig(ctx context.Context, functionName string) (*sdrv.FunctionURLConfig, error)
+	GetFunctionURLConfig(ctx context.Context, functionName, qualifier string) (*sdrv.FunctionURLConfig, error)
 	UpdateFunctionURLConfig(ctx context.Context, cfg sdrv.FunctionURLConfig) (*sdrv.FunctionURLConfig, error)
-	DeleteFunctionURLConfig(ctx context.Context, functionName string) error
+	DeleteFunctionURLConfig(ctx context.Context, functionName, qualifier string) error
 	ListFunctionURLConfigs(ctx context.Context, functionName string) ([]sdrv.FunctionURLConfig, error)
+}
+
+// functionURLResolver is the AWS-specific surface behind an invoke made
+// through a generated Function URL's host, rather than the control-plane path
+// every other Lambda operation uses. Asserted the same way as
+// functionURLManager.
+type functionURLResolver interface {
+	ResolveFunctionURL(ctx context.Context, host string) (*sdrv.FunctionURLConfig, error)
 }
 
 // corsJSON is the AWS Cors shape shared by the Function URL request and response.
@@ -115,10 +123,11 @@ func (h *Handler) serveFunctionURL(w http.ResponseWriter, r *http.Request) {
 	}
 
 	name := parts[0]
+	qualifier := r.URL.Query().Get("Qualifier")
 
 	switch parts[1] {
 	case "url":
-		serveFunctionURLItem(w, r, mgr, name)
+		serveFunctionURLItem(w, r, mgr, name, qualifier)
 	case "urls":
 		listFunctionURLConfigs(w, r, mgr, name)
 	default:
@@ -126,15 +135,17 @@ func (h *Handler) serveFunctionURL(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// serveFunctionURLItem handles POST/GET/PUT/DELETE on .../{name}/url.
-func serveFunctionURLItem(w http.ResponseWriter, r *http.Request, mgr functionURLManager, name string) {
+// serveFunctionURLItem handles POST/GET/PUT/DELETE on .../{name}/url. All four
+// operations accept the target qualifier ("" and "$LATEST" both mean the
+// unqualified $LATEST URL) as the Qualifier query parameter, not the body.
+func serveFunctionURLItem(w http.ResponseWriter, r *http.Request, mgr functionURLManager, name, qualifier string) {
 	switch r.Method {
 	case http.MethodPost:
-		writeFunctionURL(w, r, mgr.CreateFunctionURLConfig, name, http.StatusCreated)
+		writeFunctionURL(w, r, mgr.CreateFunctionURLConfig, name, qualifier, http.StatusCreated)
 	case http.MethodPut:
-		writeFunctionURL(w, r, mgr.UpdateFunctionURLConfig, name, http.StatusOK)
+		writeFunctionURL(w, r, mgr.UpdateFunctionURLConfig, name, qualifier, http.StatusOK)
 	case http.MethodGet:
-		u, err := mgr.GetFunctionURLConfig(r.Context(), name)
+		u, err := mgr.GetFunctionURLConfig(r.Context(), name, qualifier)
 		if err != nil {
 			writeErr(w, err)
 			return
@@ -142,7 +153,7 @@ func serveFunctionURLItem(w http.ResponseWriter, r *http.Request, mgr functionUR
 
 		writeJSON(w, http.StatusOK, toFunctionURLResponse(u))
 	case http.MethodDelete:
-		if err := mgr.DeleteFunctionURLConfig(r.Context(), name); err != nil {
+		if err := mgr.DeleteFunctionURLConfig(r.Context(), name, qualifier); err != nil {
 			writeErr(w, err)
 			return
 		}
@@ -158,7 +169,7 @@ func serveFunctionURLItem(w http.ResponseWriter, r *http.Request, mgr functionUR
 func writeFunctionURL(
 	w http.ResponseWriter, r *http.Request,
 	fn func(context.Context, sdrv.FunctionURLConfig) (*sdrv.FunctionURLConfig, error),
-	name string, status int,
+	name, qualifier string, status int,
 ) {
 	var req functionURLRequest
 	if !decodeJSON(w, r, &req) {
@@ -167,6 +178,7 @@ func writeFunctionURL(
 
 	u, err := fn(r.Context(), sdrv.FunctionURLConfig{
 		FunctionName: name,
+		Qualifier:    qualifier,
 		AuthType:     req.AuthType,
 		InvokeMode:   req.InvokeMode,
 		Cors:         toCorsDriver(req.Cors),

--- a/server/aws/lambda/functionurl_invoke.go
+++ b/server/aws/lambda/functionurl_invoke.go
@@ -1,0 +1,300 @@
+package lambda
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	sdrv "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// Function URL invoke constants: the payload format version and static
+// requestContext fields every invoke event carries. Real Lambda supports only
+// payload format 2.0 for Function URLs (the same envelope shape as an HTTP API
+// v2 integration), always routed through a single "$default" route/stage.
+const (
+	functionURLPayloadVersion  = "2.0"
+	functionURLDefaultRoute    = "$default"
+	functionURLAnonymousCaller = "anonymous" // AuthType is parsed, never verified — see functionurl.go.
+)
+
+// functionURLTimeFormat is the requestContext.time format real API Gateway /
+// Function URL events use: a Common Log Format-style timestamp.
+const functionURLTimeFormat = "02/Jan/2006:15:04:05 +0000"
+
+// functionURLRequestEvent is the Lambda Function URL invoke event, payload
+// format version 2.0 (the same shape API Gateway HTTP APIs send):
+// https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html
+type functionURLRequestEvent struct {
+	Version               string                    `json:"version"`
+	RouteKey              string                    `json:"routeKey"`
+	RawPath               string                    `json:"rawPath"`
+	RawQueryString        string                    `json:"rawQueryString"`
+	Cookies               []string                  `json:"cookies,omitempty"`
+	Headers               map[string]string         `json:"headers"`
+	QueryStringParameters map[string]string         `json:"queryStringParameters,omitempty"`
+	RequestContext        functionURLRequestContext `json:"requestContext"`
+	Body                  string                    `json:"body,omitempty"`
+	IsBase64Encoded       bool                      `json:"isBase64Encoded"`
+}
+
+// functionURLRequestContext is requestContext in functionURLRequestEvent.
+type functionURLRequestContext struct {
+	AccountID    string                 `json:"accountId"`
+	APIID        string                 `json:"apiId"`
+	DomainName   string                 `json:"domainName"`
+	DomainPrefix string                 `json:"domainPrefix"`
+	HTTP         functionURLRequestHTTP `json:"http"`
+	RequestID    string                 `json:"requestId"`
+	RouteKey     string                 `json:"routeKey"`
+	Stage        string                 `json:"stage"`
+	Time         string                 `json:"time"`
+	TimeEpoch    int64                  `json:"timeEpoch"`
+}
+
+// functionURLRequestHTTP is requestContext.http in functionURLRequestEvent.
+type functionURLRequestHTTP struct {
+	Method    string `json:"method"`
+	Path      string `json:"path"`
+	Protocol  string `json:"protocol"`
+	SourceIP  string `json:"sourceIp"`
+	UserAgent string `json:"userAgent"`
+}
+
+// functionURLInvokeResponse is the shape a Function URL handler returns to
+// control the HTTP response. Real Lambda flips into this structured
+// translation only when the returned JSON object carries a "statusCode" key;
+// StatusCode is a pointer so its presence/absence in the payload is
+// distinguishable from a zero value.
+type functionURLInvokeResponse struct {
+	StatusCode      *int              `json:"statusCode"`
+	Headers         map[string]string `json:"headers,omitempty"`
+	Cookies         []string          `json:"cookies,omitempty"`
+	Body            string            `json:"body"`
+	IsBase64Encoded bool              `json:"isBase64Encoded"`
+}
+
+// serveFunctionURLInvoke handles a request addressed to a generated Function
+// URL host (<url-id>.lambda-url.<region>.on.aws), translating it into a
+// payload-format-2.0 invoke event and funneling it through the same
+// h.fn.Invoke choke point the control-plane /invocations path uses.
+func (h *Handler) serveFunctionURLInvoke(w http.ResponseWriter, r *http.Request) {
+	resolver, ok := h.fn.(functionURLResolver)
+	if !ok {
+		http.Error(w, "function urls not supported", http.StatusNotImplemented)
+		return
+	}
+
+	host := requestHost(r.Host)
+
+	cfg, err := resolver.ResolveFunctionURL(r.Context(), host)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "no function is configured for this url")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusRequestEntityTooLarge, "RequestEntityTooLargeException", err.Error())
+		return
+	}
+
+	payload, err := json.Marshal(buildFunctionURLEvent(r, host, body))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "ServiceException", err.Error())
+		return
+	}
+
+	out, err := h.fn.Invoke(r.Context(), sdrv.InvokeInput{
+		FunctionName: cfg.FunctionName,
+		Qualifier:    cfg.Qualifier,
+		Payload:      payload,
+		InvokeType:   "RequestResponse",
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeFunctionURLInvokeResponse(w, out)
+}
+
+// buildFunctionURLEvent translates an inbound HTTP request into the payload-
+// format-2.0 Function URL invoke event.
+func buildFunctionURLEvent(r *http.Request, host string, body []byte) functionURLRequestEvent {
+	headers, cookies := extractCookies(canonicalHeaders(r.Header))
+	bodyStr, isBase64 := encodeFunctionURLBody(body)
+	urlID, _, _ := strings.Cut(host, functionURLHostMarker)
+	now := time.Now().UTC()
+	path := r.URL.EscapedPath()
+
+	return functionURLRequestEvent{
+		Version:               functionURLPayloadVersion,
+		RouteKey:              functionURLDefaultRoute,
+		RawPath:               path,
+		RawQueryString:        r.URL.RawQuery,
+		Cookies:               cookies,
+		Headers:               headers,
+		QueryStringParameters: queryStringParameters(r.URL.Query()),
+		RequestContext: functionURLRequestContext{
+			AccountID:    functionURLAnonymousCaller,
+			APIID:        urlID,
+			DomainName:   host,
+			DomainPrefix: urlID,
+			HTTP: functionURLRequestHTTP{
+				Method:    r.Method,
+				Path:      path,
+				Protocol:  r.Proto,
+				SourceIP:  sourceIP(r.RemoteAddr),
+				UserAgent: r.Header.Get("User-Agent"),
+			},
+			RequestID: newFunctionURLRequestID(),
+			RouteKey:  functionURLDefaultRoute,
+			Stage:     functionURLDefaultRoute,
+			Time:      now.Format(functionURLTimeFormat),
+			TimeEpoch: now.UnixMilli(),
+		},
+		Body:            bodyStr,
+		IsBase64Encoded: isBase64,
+	}
+}
+
+// canonicalHeaders lower-cases header names and comma-joins multi-value
+// headers, matching the payload-2.0 headers map real Lambda sends.
+func canonicalHeaders(h http.Header) map[string]string {
+	out := make(map[string]string, len(h))
+	for k, vals := range h {
+		out[strings.ToLower(k)] = strings.Join(vals, ",")
+	}
+
+	return out
+}
+
+// extractCookies pulls the Cookie header (if any) out of headers and splits it
+// into the top-level cookies array, matching payload-2.0's convention of
+// surfacing cookies separately rather than as a raw header.
+func extractCookies(headers map[string]string) (remaining map[string]string, cookies []string) {
+	raw, ok := headers["cookie"]
+	if !ok {
+		return headers, nil
+	}
+
+	delete(headers, "cookie")
+
+	for _, part := range strings.Split(raw, "; ") {
+		if part != "" {
+			cookies = append(cookies, part)
+		}
+	}
+
+	return headers, cookies
+}
+
+// queryStringParameters comma-joins multi-value query parameters into the
+// single-valued map payload-2.0 uses (unlike the multi-value maps of payload
+// format 1.0).
+func queryStringParameters(q url.Values) map[string]string {
+	if len(q) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(q))
+	for k, vals := range q {
+		out[k] = strings.Join(vals, ",")
+	}
+
+	return out
+}
+
+// sourceIP extracts the client IP from RemoteAddr, dropping the port.
+func sourceIP(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return remoteAddr
+	}
+
+	return host
+}
+
+// encodeFunctionURLBody returns the request body as a UTF-8 string, or
+// base64-encoded with isBase64Encoded=true when it isn't valid UTF-8 (binary
+// payloads), matching real Lambda's encoding rule for Function URL events.
+func encodeFunctionURLBody(body []byte) (string, bool) {
+	if len(body) == 0 {
+		return "", false
+	}
+
+	if utf8.Valid(body) {
+		return string(body), false
+	}
+
+	return base64.StdEncoding.EncodeToString(body), true
+}
+
+// newFunctionURLRequestID generates a random hex request id for the invoke
+// event's requestContext, standing in for the invocation's real AWS request id.
+func newFunctionURLRequestID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "00000000000000000000000000000000"
+	}
+
+	return hex.EncodeToString(b[:])
+}
+
+// writeFunctionURLInvokeResponse translates the handler's InvokeOutput into
+// the HTTP response a real Function URL sends. A handler error becomes a 502
+// with the fixed body real Lambda returns for a Function URL invoke — unlike
+// the raw Invoke API, which reports a handler error via the
+// X-Amz-Function-Error header on an HTTP 200. A response payload with a
+// "statusCode" key is translated per the structured
+// {statusCode,headers,cookies,body,isBase64Encoded} contract; any other
+// payload (no such key present) is returned as-is with a 200, matching real
+// Function URL BUFFERED behavior for a handler that returns a bare value.
+func writeFunctionURLInvokeResponse(w http.ResponseWriter, out *sdrv.InvokeOutput) {
+	if out.Error != "" {
+		w.Header().Set("Content-Type", contentTypeJSON)
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"message":"Internal Server Error"}`))
+
+		return
+	}
+
+	var resp functionURLInvokeResponse
+	if err := json.Unmarshal(out.Payload, &resp); err != nil || resp.StatusCode == nil {
+		w.Header().Set("Content-Type", contentTypeJSON)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(out.Payload)
+
+		return
+	}
+
+	for k, v := range resp.Headers {
+		w.Header().Set(k, v)
+	}
+
+	for _, c := range resp.Cookies {
+		w.Header().Add("Set-Cookie", c)
+	}
+
+	body := []byte(resp.Body)
+
+	if resp.IsBase64Encoded {
+		if decoded, err := base64.StdEncoding.DecodeString(resp.Body); err == nil {
+			body = decoded
+		}
+	}
+
+	w.WriteHeader(*resp.StatusCode)
+	_, _ = w.Write(body)
+}

--- a/server/aws/lambda/functionurl_invoke_test.go
+++ b/server/aws/lambda/functionurl_invoke_test.go
@@ -1,0 +1,351 @@
+package lambda_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/aws/smithy-go"
+	"github.com/stackshy/cloudemu/v2"
+	awsprovider "github.com/stackshy/cloudemu/v2/providers/aws"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newFunctionURLTestServer sets up an aws-sdk-go-v2 Lambda client plus the
+// underlying httptest.Server, so invoke-via-URL tests can dial the same
+// listener a real Function URL's generated host is DNS-resolved to and set
+// the Host header to that generated host by hand.
+func newFunctionURLTestServer(t *testing.T) (*awslambda.Client, *awsprovider.Provider, *httptest.Server) {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{Lambda: cloud.Lambda})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	client := awslambda.NewFromConfig(cfg, func(o *awslambda.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+
+	return client, cloud, ts
+}
+
+// invokeEvent is the subset of the payload-format-2.0 Function URL request
+// event this test cares about.
+type invokeEvent struct {
+	Version        string            `json:"version"`
+	RouteKey       string            `json:"routeKey"`
+	RawPath        string            `json:"rawPath"`
+	RawQueryString string            `json:"rawQueryString"`
+	Headers        map[string]string `json:"headers"`
+	RequestContext struct {
+		HTTP struct {
+			Method   string `json:"method"`
+			Path     string `json:"path"`
+			SourceIP string `json:"sourceIp"`
+		} `json:"http"`
+		Stage    string `json:"stage"`
+		RouteKey string `json:"routeKey"`
+	} `json:"requestContext"`
+	Body            string `json:"body"`
+	IsBase64Encoded bool   `json:"isBase64Encoded"`
+}
+
+// dialFunctionURL issues an HTTP request against ts using rawURL's path/query
+// but the httptest server's actual host:port, while sending rawURL's own host
+// as the Host header — exactly how a real client resolves
+// <url-id>.lambda-url.<region>.on.aws to an IP and presents that hostname over
+// the wire.
+func dialFunctionURL(t *testing.T, ts *httptest.Server, method, rawURL string, body []byte) *http.Response {
+	t.Helper()
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse function url: %v", err)
+	}
+
+	target, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("parse test server url: %v", err)
+	}
+
+	parsed.Scheme = target.Scheme
+	parsed.Host = target.Host
+
+	req, err := http.NewRequestWithContext(context.Background(), method, parsed.String(), bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	req.Host = mustParseHost(t, rawURL)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+
+	return resp
+}
+
+func mustParseHost(t *testing.T, rawURL string) string {
+	t.Helper()
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+
+	return parsed.Host
+}
+
+// TestFunctionURLInvokeStructuredResponse covers a handler that returns the
+// structured {statusCode,headers,body} shape: the response must carry the
+// given status/headers/body, and the request the handler received must be a
+// well-formed payload-2.0 event.
+func TestFunctionURLInvokeStructuredResponse(t *testing.T) {
+	client, cloud, ts := newFunctionURLTestServer(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "urlinvoke-structured")
+
+	var received invokeEvent
+
+	cloud.Lambda.RegisterHandler("urlinvoke-structured", func(_ context.Context, payload []byte) ([]byte, error) {
+		if err := json.Unmarshal(payload, &received); err != nil {
+			t.Errorf("unmarshal invoke event: %v", err)
+		}
+
+		return json.Marshal(map[string]any{
+			"statusCode": 201,
+			"headers":    map[string]string{"X-Handler": "yes"},
+			"body":       "hello from handler",
+		})
+	})
+
+	created, err := client.CreateFunctionUrlConfig(ctx, &awslambda.CreateFunctionUrlConfigInput{
+		FunctionName: aws.String("urlinvoke-structured"),
+		AuthType:     lambdatypes.FunctionUrlAuthTypeNone,
+	})
+	if err != nil {
+		t.Fatalf("CreateFunctionUrlConfig: %v", err)
+	}
+
+	functionURL := aws.ToString(created.FunctionUrl) + "foo/bar?a=1&b=2"
+
+	resp := dialFunctionURL(t, ts, http.MethodPost, functionURL, []byte(`{"ping":"pong"}`))
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", resp.StatusCode, body)
+	}
+
+	if string(body) != "hello from handler" {
+		t.Fatalf("body = %q, want %q", body, "hello from handler")
+	}
+
+	if got := resp.Header.Get("X-Handler"); got != "yes" {
+		t.Fatalf("X-Handler header = %q, want yes", got)
+	}
+
+	if received.Version != "2.0" {
+		t.Fatalf("event version = %q, want 2.0", received.Version)
+	}
+
+	if received.RouteKey != "$default" || received.RequestContext.RouteKey != "$default" || received.RequestContext.Stage != "$default" {
+		t.Fatalf("event routeKey/stage = %+v, want $default everywhere", received)
+	}
+
+	if received.RequestContext.HTTP.Method != http.MethodPost {
+		t.Fatalf("event http.method = %q, want POST", received.RequestContext.HTTP.Method)
+	}
+
+	if received.RawPath != "/foo/bar" || received.RequestContext.HTTP.Path != "/foo/bar" {
+		t.Fatalf("event rawPath/http.path = %q/%q, want /foo/bar", received.RawPath, received.RequestContext.HTTP.Path)
+	}
+
+	if received.RawQueryString != "a=1&b=2" {
+		t.Fatalf("event rawQueryString = %q, want a=1&b=2", received.RawQueryString)
+	}
+
+	if received.Body != `{"ping":"pong"}` {
+		t.Fatalf("event body = %q, want the request body verbatim", received.Body)
+	}
+
+	if received.IsBase64Encoded {
+		t.Fatal("event isBase64Encoded = true for a UTF-8 body, want false")
+	}
+}
+
+// TestFunctionURLInvokeBareResponse covers a handler that returns a plain
+// object with no "statusCode" key: real Function URLs treat the whole return
+// value as the response body with a 200, rather than trying to interpret it
+// as the structured shape.
+func TestFunctionURLInvokeBareResponse(t *testing.T) {
+	client, cloud, ts := newFunctionURLTestServer(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "urlinvoke-bare")
+
+	cloud.Lambda.RegisterHandler("urlinvoke-bare", func(context.Context, []byte) ([]byte, error) {
+		return json.Marshal(map[string]any{"message": "ok"})
+	})
+
+	created, err := client.CreateFunctionUrlConfig(ctx, &awslambda.CreateFunctionUrlConfigInput{
+		FunctionName: aws.String("urlinvoke-bare"),
+		AuthType:     lambdatypes.FunctionUrlAuthTypeNone,
+	})
+	if err != nil {
+		t.Fatalf("CreateFunctionUrlConfig: %v", err)
+	}
+
+	resp := dialFunctionURL(t, ts, http.MethodGet, aws.ToString(created.FunctionUrl), nil)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+	}
+
+	var decoded map[string]string
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("response body isn't JSON: %v (%s)", err, body)
+	}
+
+	if decoded["message"] != "ok" {
+		t.Fatalf("body = %q, want the handler's bare object verbatim", body)
+	}
+}
+
+// TestFunctionURLInvokeHandlerError covers a handler that raises: real
+// Function URLs return 502 with a fixed body, unlike the raw Invoke API's 200
+// + X-Amz-Function-Error.
+func TestFunctionURLInvokeHandlerError(t *testing.T) {
+	client, cloud, ts := newFunctionURLTestServer(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "urlinvoke-error")
+
+	cloud.Lambda.RegisterHandler("urlinvoke-error", func(context.Context, []byte) ([]byte, error) {
+		return nil, errors.New("boom")
+	})
+
+	created, err := client.CreateFunctionUrlConfig(ctx, &awslambda.CreateFunctionUrlConfigInput{
+		FunctionName: aws.String("urlinvoke-error"),
+		AuthType:     lambdatypes.FunctionUrlAuthTypeNone,
+	})
+	if err != nil {
+		t.Fatalf("CreateFunctionUrlConfig: %v", err)
+	}
+
+	resp := dialFunctionURL(t, ts, http.MethodGet, aws.ToString(created.FunctionUrl), nil)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", resp.StatusCode)
+	}
+}
+
+// TestFunctionURLQualifierScoping covers Function URL configs on an alias
+// qualifier, rejecting a numbered-version qualifier, and the duplicate-create
+// conflict for the same (function, qualifier).
+func TestFunctionURLQualifierScoping(t *testing.T) {
+	client, _, _ := newFunctionURLTestServer(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "urlquals")
+
+	if _, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
+		FunctionName: aws.String("urlquals"),
+	}); err != nil {
+		t.Fatalf("PublishVersion: %v", err)
+	}
+
+	if _, err := client.CreateAlias(ctx, &awslambda.CreateAliasInput{
+		FunctionName:    aws.String("urlquals"),
+		Name:            aws.String("live"),
+		FunctionVersion: aws.String("1"),
+	}); err != nil {
+		t.Fatalf("CreateAlias: %v", err)
+	}
+
+	aliasURL, err := client.CreateFunctionUrlConfig(ctx, &awslambda.CreateFunctionUrlConfigInput{
+		FunctionName: aws.String("urlquals"),
+		Qualifier:    aws.String("live"),
+		AuthType:     lambdatypes.FunctionUrlAuthTypeNone,
+	})
+	if err != nil {
+		t.Fatalf("CreateFunctionUrlConfig(live): %v", err)
+	}
+
+	latestURL, err := client.CreateFunctionUrlConfig(ctx, &awslambda.CreateFunctionUrlConfigInput{
+		FunctionName: aws.String("urlquals"),
+		AuthType:     lambdatypes.FunctionUrlAuthTypeNone,
+	})
+	if err != nil {
+		t.Fatalf("CreateFunctionUrlConfig($LATEST): %v", err)
+	}
+
+	if aws.ToString(aliasURL.FunctionUrl) == aws.ToString(latestURL.FunctionUrl) {
+		t.Fatal("the alias and $LATEST Function URLs must differ")
+	}
+
+	// A numbered-version qualifier is rejected.
+	_, err = client.CreateFunctionUrlConfig(ctx, &awslambda.CreateFunctionUrlConfigInput{
+		FunctionName: aws.String("urlquals"),
+		Qualifier:    aws.String("1"),
+		AuthType:     lambdatypes.FunctionUrlAuthTypeNone,
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValueException" {
+		t.Fatalf("CreateFunctionUrlConfig(qualifier=1) err = %v, want InvalidParameterValueException", err)
+	}
+
+	// Creating the same (function, qualifier) twice conflicts.
+	_, err = client.CreateFunctionUrlConfig(ctx, &awslambda.CreateFunctionUrlConfigInput{
+		FunctionName: aws.String("urlquals"),
+		Qualifier:    aws.String("live"),
+		AuthType:     lambdatypes.FunctionUrlAuthTypeNone,
+	})
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ResourceConflictException" {
+		t.Fatalf("duplicate CreateFunctionUrlConfig(live) err = %v, want ResourceConflictException", err)
+	}
+
+	list, err := client.ListFunctionUrlConfigs(ctx, &awslambda.ListFunctionUrlConfigsInput{
+		FunctionName: aws.String("urlquals"),
+	})
+	if err != nil {
+		t.Fatalf("ListFunctionUrlConfigs: %v", err)
+	}
+
+	if len(list.FunctionUrlConfigs) != 2 {
+		t.Fatalf("FunctionUrlConfigs = %d, want 2 (one per qualifier)", len(list.FunctionUrlConfigs))
+	}
+}

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"sort"
 	"strings"
@@ -59,6 +60,30 @@ const layersPrefix = "/2018-10-31/layers"
 // function sub-resource (.../{name}/url and .../{name}/urls) but versioned under
 // 2021-10-31, so it needs its own Matches clause.
 const functionURLPrefix = "/2021-10-31/functions"
+
+// functionURLHostMarker identifies an inbound request as an invoke through a
+// generated Function URL rather than a control-plane call: real Lambda
+// Function URLs are addressed by a unique per-config host
+// (<url-id>.lambda-url.<region>.on.aws), not by path, so this routes on the
+// Host header instead of the URL path every other Lambda operation uses.
+const functionURLHostMarker = ".lambda-url."
+
+// isFunctionURLHost reports whether host (an incoming request's Host header,
+// optionally with a port) addresses a generated Function URL.
+func isFunctionURLHost(host string) bool {
+	return strings.Contains(requestHost(host), functionURLHostMarker)
+}
+
+// requestHost strips an optional port from an HTTP Host header and lower-cases
+// the remainder.
+func requestHost(host string) string {
+	h, _, err := net.SplitHostPort(host)
+	if err != nil {
+		h = host
+	}
+
+	return strings.ToLower(h)
+}
 
 // Function code-signing-config sub-resource (GetFunctionCodeSigningConfig et al).
 // Versioned under 2020-06-30 on the {name}/code-signing-config sub-resource, so
@@ -196,9 +221,11 @@ func New(fn sdrv.Serverless, opts ...Option) *Handler {
 }
 
 // Matches returns true for any URL under /2015-03-31/functions — that's the
-// Lambda control-plane prefix the SDK uses for every operation in our MVP.
+// Lambda control-plane prefix the SDK uses for every operation in our MVP —
+// plus a request addressed to a generated Function URL host.
 func (*Handler) Matches(r *http.Request) bool {
-	return strings.HasPrefix(r.URL.Path, pathPrefix) ||
+	return isFunctionURLHost(r.Host) ||
+		strings.HasPrefix(r.URL.Path, pathPrefix) ||
 		strings.HasPrefix(r.URL.Path, tagsPrefix) ||
 		strings.HasPrefix(r.URL.Path, esmPrefix) ||
 		strings.HasPrefix(r.URL.Path, concurrencyWritePrefix) ||
@@ -215,6 +242,11 @@ func (*Handler) Matches(r *http.Request) bool {
 //	/2015-03-31/functions/{name}                GET=get, DELETE=delete
 //	/2015-03-31/functions/{name}/invocations    POST=invoke
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if isFunctionURLHost(r.Host) {
+		h.serveFunctionURLInvoke(w, r)
+		return
+	}
+
 	if h.routePrefixed(w, r) {
 		return
 	}


### PR DESCRIPTION
## Summary

Extends AWS Lambda Function URLs.

**Pre-existing** (from earlier serverless work): the Function URL config CRUD wire path (`CreateFunctionUrlConfig`/`Get`/`Update`/`Delete`/`ListFunctionUrlConfigs` at `/2021-10-31/functions/{name}/url[s]`) and the `driver.FunctionURLConfig`/`FunctionURLCors` types (already carrying a `Qualifier` field, unused). This gave a single Function URL per function with no qualifier scoping, no qualifier validation, and no way to actually invoke through the generated URL.

**Added in this PR:**
- Qualifier scoping: a Function URL config is now stored per `(function, qualifier)` — `$LATEST`/unqualified and an alias each get their own URL/config, mirroring the `eventInvokeConfigs`/`provisionedConcurrencyConfigs` copy-on-write map pattern. `Create`/`Get`/`Update`/`Delete` read the qualifier from the `Qualifier` query parameter, matching the real API.
- Validation: a numbered-version qualifier is rejected (`InvalidParameterValueException`) — a Function URL can only target `$LATEST` or an alias, matching real Lambda. An unknown alias qualifier is `ResourceNotFoundException`; a duplicate `(function, qualifier)` create is `ResourceConflictException`. `AuthType`/`InvokeMode` are validated against their two accepted values.
- Invoke via URL: a request whose Host header addresses a generated `<url-id>.lambda-url.<region>.on.aws` host is routed (regardless of path) to a new handler that builds a payload-format-2.0 invoke event (`version`, `routeKey`, `rawPath`, `rawQueryString`, `headers`, `cookies`, `queryStringParameters`, `requestContext.http`, `body`/`isBase64Encoded`) and funnels it through the existing `Invoke` choke point (same path `/invocations` uses). The response is translated back to HTTP: a `{statusCode,headers,cookies,body,isBase64Encoded}` payload is used structurally; any other payload (no `statusCode` key) is returned as-is with a 200, matching real Function URL BUFFERED behavior; a handler error becomes a 502 with the fixed body real Lambda returns.
- `AuthType: AWS_IAM` is parsed and stored but not enforced — consistent with the rest of cloudemu's wire layer (SigV4/bearer tokens are parsed, never verified).
- Snapshot round-trip updated for the new per-qualifier map.

**Deferred** (out of scope for this PR): `RESPONSE_STREAM` `InvokeMode` is stored/returned faithfully but always invoked as BUFFERED — the emulator has no chunked-streaming execution engine. ESM knobs and Lambda Layers are separate items.

## Test plan
- [x] `go build ./...`
- [x] `go test ./providers/aws/lambda/... ./server/aws/lambda/... ./persist/... ./services/serverless/... -race -count=1`
- [x] `go test ./providers/aws/... ./server/aws/...`
- [x] `gofmt -l` on touched files (empty)
- [x] `golangci-lint run ./providers/aws/lambda/... ./server/aws/lambda/...` (0 issues)
- [x] `go generate ./...` + `git diff --exit-code docs/coverage` (no diff — AWS-only optional interface)
- [x] `go mod tidy` (no changes)
- [x] New tests: qualifier round-trip/scoping, numbered-version rejection, unknown-alias rejection, duplicate-create conflict, AuthType/InvokeMode validation, COW independence, concurrent per-qualifier creates (`-race`), and an invoke-via-URL e2e (structured response, bare response, handler error) using a real HTTP request against the running server with the SDK-generated Function URL