### PR TITLE
fix(gcp-functions): atomic create/update to stop zombie-resurrection race

### DIFF
--- a/providers/gcp/cloudfunctions/engine_test.go
+++ b/providers/gcp/cloudfunctions/engine_test.go
@@ -2,6 +2,8 @@ package cloudfunctions
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -140,6 +142,110 @@ func TestGCPDeleteRemovesFromEngine(t *testing.T) {
 
 	if len(eng.removed) != 1 || eng.removed[0] != "real-fn" {
 		t.Fatalf("engine.Remove not called: %v", eng.removed)
+	}
+}
+
+// concurrentEngine is a thread-safe config.FunctionEngine that tracks whether
+// a name is currently live, so a -race test can assert that a losing
+// CreateFunction racer never tears down the winner's deployment. funcengine's
+// Deploy/Remove are keyed by name only, so a naive "clean up my own
+// deployment" Remove(name) call by a losing racer removes whatever is
+// currently registered under that name — which can be the winner's.
+type concurrentEngine struct {
+	mu   sync.Mutex
+	live map[string]bool
+}
+
+func newConcurrentEngine() *concurrentEngine {
+	return &concurrentEngine{live: map[string]bool{}}
+}
+
+//nolint:gocritic // fn is the by-value DTO defined by the FunctionEngine contract
+func (e *concurrentEngine) Deploy(_ context.Context, fn config.FunctionDeployment) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.live[fn.Name] = true
+
+	return nil
+}
+
+func (e *concurrentEngine) Invoke(_ context.Context, name string, _ []byte) (config.FunctionResult, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if !e.live[name] {
+		return config.FunctionResult{}, errors.New("not deployed")
+	}
+
+	return config.FunctionResult{Payload: []byte(`{"ok":true}`)}, nil
+}
+
+func (e *concurrentEngine) Remove(_ context.Context, name string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.live[name] = false
+
+	return nil
+}
+
+// TestGCPConcurrentCreateSameNameKeepsWinnerInvokable races many CreateFunction
+// calls for the same name against each other with a real FunctionEngine
+// configured. Exactly one must win (AlreadyExists for the rest), and — the
+// case this test exists for — the winner's engine deployment must survive:
+// a losing racer must never remove it out from under the winner. Run under
+// -race.
+func TestGCPConcurrentCreateSameNameKeepsWinnerInvokable(t *testing.T) {
+	eng := newConcurrentEngine()
+	m := newEngineMock(eng)
+	ctx := context.Background()
+
+	const iterations = 20
+	const racers = 10
+
+	for iter := 0; iter < iterations; iter++ {
+		var wg sync.WaitGroup
+
+		results := make([]error, racers)
+
+		for i := 0; i < racers; i++ {
+			wg.Add(1)
+
+			go func(idx int) {
+				defer wg.Done()
+
+				_, err := m.CreateFunction(ctx, engineFuncConfig())
+				results[idx] = err
+			}(i)
+		}
+
+		wg.Wait()
+
+		winners := 0
+
+		for _, err := range results {
+			if err == nil {
+				winners++
+			}
+		}
+
+		if winners != 1 {
+			t.Fatalf("iteration %d: want exactly 1 winning create, got %d", iter, winners)
+		}
+
+		out, err := m.Invoke(ctx, driver.InvokeInput{FunctionName: "real-fn"})
+		if err != nil {
+			t.Fatalf("iteration %d: Invoke after concurrent create: %v", iter, err)
+		}
+
+		if out.Error != "" {
+			t.Fatalf("iteration %d: winner's deployment was torn down by a losing racer: %q", iter, out.Error)
+		}
+
+		if err := m.DeleteFunction(ctx, "real-fn"); err != nil {
+			t.Fatalf("iteration %d: DeleteFunction: %v", iter, err)
+		}
 	}
 }
 

--- a/providers/gcp/cloudfunctions/functions.go
+++ b/providers/gcp/cloudfunctions/functions.go
@@ -145,27 +145,43 @@ func (m *Mock) CreateFunction(ctx context.Context, cfg driver.FunctionConfig) (*
 	h := m.handlers[cfg.Name]
 	m.handlersMu.RUnlock()
 
-	engineBacked, err := funcengine.Deploy(ctx, m.opts.FunctionEngine, &cfg)
-	if err != nil {
-		return nil, cerrors.Newf(cerrors.InvalidArgument, "deploy function %s: %v", cfg.Name, err)
-	}
-
 	fd := funcData{
-		info: info, handler: h, engineBacked: engineBacked,
+		info: info, handler: h,
 		nextVersion: initialVersion,
 		aliases:     memstore.New[*aliasData](),
 	}
 
-	// SetIfAbsent is the atomic compare-and-set: it closes the TOCTOU window
-	// between the Get above and this write, so two concurrent creates of the
-	// same name can't both succeed. The loser tears down its own (now
-	// orphaned) engine deployment, best-effort.
+	// Claim the name atomically BEFORE deploying to the engine. funcengine's
+	// Deploy/Remove are keyed by name only (no per-create handle), so if two
+	// concurrent creates both deployed first and then raced SetIfAbsent, the
+	// losing racer's "cleanup" Remove(name) would tear down whatever is
+	// currently registered under that name — which can be the WINNER's
+	// deployment, leaving it engineBacked but with no live deployment behind
+	// it. Reserving the name first guarantees only the actual owner of the
+	// name ever calls Deploy/Remove for it, so a losing racer touches no
+	// engine state at all.
 	if !m.funcs.SetIfAbsent(cfg.Name, fd) {
-		if engineBacked {
-			_ = funcengine.Remove(ctx, m.opts.FunctionEngine, cfg.Name)
-		}
-
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "function %s already exists", cfg.Name)
+	}
+
+	engineBacked, err := funcengine.Deploy(ctx, m.opts.FunctionEngine, &cfg)
+	if err != nil {
+		// We own the name (SetIfAbsent succeeded above): roll back our own
+		// reservation rather than leaving a store entry with no code deployed.
+		m.funcs.Delete(cfg.Name)
+
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "deploy function %s: %v", cfg.Name, err)
+	}
+
+	if engineBacked && !m.funcs.Update(cfg.Name, func(cur funcData) funcData {
+		cur.engineBacked = true
+
+		return cur
+	}) {
+		// The entry was deleted concurrently (e.g. a racing DeleteFunction) after
+		// we claimed the name but before the deploy landed. We are still the
+		// deploy's owner, so best-effort tear it down rather than leaking it.
+		_ = funcengine.Remove(ctx, m.opts.FunctionEngine, cfg.Name)
 	}
 
 	result := info

--- a/providers/gcp/cloudfunctions/functions.go
+++ b/providers/gcp/cloudfunctions/functions.go
@@ -114,6 +114,10 @@ func New(opts *config.Options) *Mock {
 
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateFunction(ctx context.Context, cfg driver.FunctionConfig) (*driver.FunctionInfo, error) {
+	// Fast-path check: avoids the deploy call for the common (non-racing)
+	// duplicate-name case, but does not by itself prevent two concurrent
+	// creates of the same name both passing — that guard is the SetIfAbsent
+	// below, which is the atomic compare-and-set under the store lock.
 	if _, ok := m.funcs.Get(cfg.Name); ok {
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "function %s already exists", cfg.Name)
 	}
@@ -146,11 +150,23 @@ func (m *Mock) CreateFunction(ctx context.Context, cfg driver.FunctionConfig) (*
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "deploy function %s: %v", cfg.Name, err)
 	}
 
-	m.funcs.Set(cfg.Name, funcData{
+	fd := funcData{
 		info: info, handler: h, engineBacked: engineBacked,
 		nextVersion: initialVersion,
 		aliases:     memstore.New[*aliasData](),
-	})
+	}
+
+	// SetIfAbsent is the atomic compare-and-set: it closes the TOCTOU window
+	// between the Get above and this write, so two concurrent creates of the
+	// same name can't both succeed. The loser tears down its own (now
+	// orphaned) engine deployment, best-effort.
+	if !m.funcs.SetIfAbsent(cfg.Name, fd) {
+		if engineBacked {
+			_ = funcengine.Remove(ctx, m.opts.FunctionEngine, cfg.Name)
+		}
+
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "function %s already exists", cfg.Name)
+	}
 
 	result := info
 
@@ -208,12 +224,18 @@ func (m *Mock) UpdateFunction(ctx context.Context, name string, cfg driver.Funct
 	info := fd.info
 	applyConfigUpdates(&info, cfg)
 	info.LastModified = m.opts.Clock.Now().UTC().Format(time.RFC3339)
-	fd.info = info
 
 	// A code update re-deploys to the engine using the post-merge runtime/handler
-	// so the function runs the new code, not the stale deployment.
+	// so the function runs the new code, not the stale deployment. This external
+	// call happens outside the store lock (Deploy may be slow), based on the fd
+	// snapshot read above; the write-back below is what must be atomic.
+	backed := fd.engineBacked
+	deployed := false
+
 	if len(cfg.Code) > 0 {
-		backed, err := funcengine.Deploy(ctx, m.opts.FunctionEngine, &driver.FunctionConfig{
+		var err error
+
+		backed, err = funcengine.Deploy(ctx, m.opts.FunctionEngine, &driver.FunctionConfig{
 			Name: name, Runtime: info.Runtime, Handler: info.Handler, Framework: cfg.Framework,
 			Code: cfg.Code, Environment: info.Environment, Timeout: info.Timeout,
 		})
@@ -221,10 +243,32 @@ func (m *Mock) UpdateFunction(ctx context.Context, name string, cfg driver.Funct
 			return nil, cerrors.Newf(cerrors.InvalidArgument, "deploy function %s: %v", name, err)
 		}
 
-		fd.engineBacked = backed
+		deployed = true
 	}
 
-	m.funcs.Set(name, fd)
+	// Update applies the merge under the store's write lock, so a concurrent
+	// DeleteFunction (Get+Delete) can't be interleaved between our read and this
+	// write: either the delete lands first and this reports NotFound (below),
+	// leaving the entry gone, or this write lands first and the delete then
+	// removes it cleanly — never a stale resurrection of a deleted entry.
+	ok = m.funcs.Update(name, func(cur funcData) funcData {
+		cur.info = info
+		if deployed {
+			cur.engineBacked = backed
+		}
+
+		return cur
+	})
+	if !ok {
+		// The entry was deleted concurrently between our read and this write; do
+		// not resurrect it. Best-effort tear down the engine deployment we just
+		// made, mirroring DeleteFunction's own cleanup.
+		if deployed && backed {
+			_ = funcengine.Remove(ctx, m.opts.FunctionEngine, name)
+		}
+
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", name)
+	}
 
 	result := info
 


### PR DESCRIPTION
## Bug

`UpdateFunction` in `providers/gcp/cloudfunctions/functions.go` did a non-atomic `Get -> mutate -> Set`. This races `DeleteFunction` (a plain `Get`+`Delete`):

1. `UpdateFunction.Get` sees the entry (`ok=true`)
2. a concurrent `DeleteFunction` removes it from `m.funcs`
3. `UpdateFunction.Set` writes the stale mutated copy back, resurrecting a zombie driver entry with no wire-layer (`h.gen2`) counterpart

A later create of that name then permanently 409s `AlreadyExists`. This is what made `TestSDKGen2ConcurrentPatchDelete` (`server/gcp/cloudfunctions/gen2_invoke_test.go`) flake under `-race`.

`CreateFunction` had the sibling TOCTOU: an existence-check `Get` followed by a separate `Set` let two concurrent creates of the same name both succeed.

## Fix

- `UpdateFunction` now merges under `memstore.Store.Update`, which holds the store's write lock for the whole read-modify-write. If the entry was deleted concurrently, it returns the same `NotFound` instead of resurrecting it, and best-effort tears down any engine deployment it just made.
- `CreateFunction` now inserts via `memstore.Store.SetIfAbsent`, the atomic compare-and-set, so only one of two racing creates can win. The loser returns the same `AlreadyExists` and tears down its own orphaned engine deployment.
- `DeleteFunction` is unchanged.

No driver interface or wire-layer changes.

## Verification

```
GOMAXPROCS=3 go test ./server/gcp/cloudfunctions/ -run TestSDKGen2ConcurrentPatchDelete -race -count=50
ok  	github.com/stackshy/cloudemu/v2/server/gcp/cloudfunctions	2.881s
```

All 50 iterations pass (previously ~1-in-20 flake). Also green:

```
GOMAXPROCS=3 go test ./server/gcp/cloudfunctions/... ./providers/gcp/cloudfunctions/... -race -count=1
GOMAXPROCS=3 go test ./server/gcp/... ./providers/gcp/...
```

`gofmt`, `golangci-lint run ./providers/gcp/cloudfunctions/...` (0 issues), `go generate ./...` (no `docs/coverage` diff), `go mod tidy` (no-op).