### PR TITLE
feat(azure-functions): Cosmos DB change-feed trigger delivery

### DIFF
--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -243,6 +243,10 @@ func New(opts ...config.Option) *Provider {
 	// A blob created/updated in a bound container invokes any function whose
 	// function.json declares a blobTrigger binding on that container.
 	p.BlobStorage.SetFunctionTriggerSink(p.Functions)
+	// A Cosmos DB document created/updated in a bound (database, container)
+	// invokes any function whose function.json declares a cosmosDBTrigger
+	// binding on it, mirroring Cosmos's change feed.
+	p.CosmosDB.SetFunctionTriggerSink(p.Functions)
 	p.SQL.SetMonitoring(p.Monitor)
 	p.PostgresFlex.SetMonitoring(p.Monitor)
 	p.MySQLFlex.SetMonitoring(p.Monitor)

--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -484,7 +484,7 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 }
 
 // BatchPutItems stores multiple items in a container.
-func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string]any) error {
+func (m *Mock) BatchPutItems(ctx context.Context, table string, items []map[string]any) error {
 	m.mu.Lock()
 
 	td, exists := m.tables[table]
@@ -493,15 +493,22 @@ func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string
 		return cerrors.Newf(cerrors.NotFound, "container %s not found", table)
 	}
 
+	triggers := make([]map[string]any, 0, len(items))
+
 	for _, item := range items {
 		key := itemKey(td.config, item)
 		oldItem, hadOld := td.items.Get(key)
 		item = maps.Clone(item)
 		td.items.Set(key, item)
 		m.recordStreamEvent(td, oldItem, item, hadOld)
+		triggers = append(triggers, maps.Clone(item))
 	}
 
 	m.mu.Unlock()
+
+	for _, trigger := range triggers {
+		m.dispatchFunctionTrigger(ctx, table, trigger)
+	}
 
 	return nil
 }

--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -63,6 +63,11 @@ type Mock struct {
 	accountAttrs map[string]driver.AccountAttributes
 	opts         *config.Options
 	monitoring   mondriver.Monitoring
+	// functionSink delivers a just-created-or-updated document to any Azure
+	// Function whose function.json declares a matching cosmosDBTrigger
+	// binding, mirroring Cosmos's change feed. Wired via
+	// SetFunctionTriggerSink; nil (the default) disables delivery.
+	functionSink CosmosFunctionTriggerSink
 }
 
 // Compile-time check that Mock satisfies the optional TableAttributes
@@ -262,7 +267,7 @@ func (m *Mock) ListTables(_ context.Context) ([]string, error) {
 }
 
 // PutItem stores an item in a container.
-func (m *Mock) PutItem(_ context.Context, table string, item map[string]any) error {
+func (m *Mock) PutItem(ctx context.Context, table string, item map[string]any) error {
 	m.mu.Lock()
 
 	td, exists := m.tables[table]
@@ -276,9 +281,11 @@ func (m *Mock) PutItem(_ context.Context, table string, item map[string]any) err
 	item = maps.Clone(item)
 	td.items.Set(key, item)
 	m.recordStreamEvent(td, oldItem, item, hadOld)
+	trigger := maps.Clone(item)
 	m.mu.Unlock()
 
 	m.emitMetric(table, map[string]float64{"TotalRequests": 1, "TotalRequestUnits": 1})
+	m.dispatchFunctionTrigger(ctx, table, trigger)
 
 	return nil
 }
@@ -313,7 +320,7 @@ func (m *Mock) GetItem(_ context.Context, table string, key map[string]any) (map
 // UpdateItem applies partial updates to an existing document in a container.
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
-func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[string]any, error) {
+func (m *Mock) UpdateItem(ctx context.Context, input driver.UpdateItemInput) (map[string]any, error) {
 	m.mu.Lock()
 
 	td, exists := m.tables[input.Table]
@@ -340,9 +347,11 @@ func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[
 
 	td.items.Set(k, updated)
 	m.recordStreamEvent(td, oldItem, updated, true)
+	trigger := maps.Clone(updated)
 	m.mu.Unlock()
 
 	m.emitMetric(input.Table, map[string]float64{"TotalRequests": 1, "TotalRequestUnits": 1})
+	m.dispatchFunctionTrigger(ctx, input.Table, trigger)
 
 	return maps.Clone(updated), nil
 }

--- a/providers/azure/cosmosdb/function_trigger.go
+++ b/providers/azure/cosmosdb/function_trigger.go
@@ -1,0 +1,101 @@
+package cosmosdb
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+)
+
+// CosmosFunctionTriggerSink delivers a just-created-or-updated Cosmos
+// document to any Azure Function whose function.json declares a
+// cosmosDBTrigger input binding on the document's (databaseName,
+// containerName), mirroring Cosmos's change feed. The Azure Functions
+// provider implements it. It is wired per Mock instance via
+// SetFunctionTriggerSink, mirroring how blobstorage.BlobFunctionTriggerSink
+// wires Blob Storage delivery and servicebus.FunctionTriggerSink wires Queue
+// Storage / Service Bus delivery (see providers/azure/blobstorage,
+// providers/azure/servicebus).
+type CosmosFunctionTriggerSink interface {
+	DeliverCosmosFunctionTrigger(ctx context.Context, database, container string, body []byte)
+}
+
+// SetFunctionTriggerSink wires the Azure Functions provider as the
+// destination for this Cosmos DB mock's automatic cosmosDBTrigger deliveries:
+// a document created or updated asks sink to invoke any function bound to the
+// document's (database, container). Real Cosmos change feed fires on
+// document create and update only, never delete, so DeleteItem never calls
+// dispatchFunctionTrigger. A nil sink disables delivery (the default), so any
+// deployment that does not wire Azure Functions is unaffected.
+func (m *Mock) SetFunctionTriggerSink(sink CosmosFunctionTriggerSink) {
+	m.functionSink = sink
+}
+
+// dispatchFunctionTrigger forwards a just-written document to any Azure
+// Function bound to its (database, container) by a cosmosDBTrigger binding.
+// It is a no-op when no sink is wired, or when table carries no
+// database/container identity to match against (see cosmosDatabaseContainer)
+// — the generic driver.Database interface this mock implements has a flat
+// table namespace, so a table created without going through the Cosmos SQL
+// data-plane wire handler's account/database/container encoding
+// (server/azure/cosmosdb's qualify) has no (database, container) pair to
+// address.
+//
+// Called with no store lock held — PutItem/UpdateItem snapshot item and
+// release m.mu before calling this — so a function invoked by the trigger may
+// itself write back into Cosmos DB without deadlocking. item must already be
+// a snapshot the caller owns exclusively; this method does not clone it
+// again.
+//
+// Real Cosmos change feed delivers a BATCH of changed documents per lease
+// checkpoint; this emulator delivers one document per write, wrapped in a
+// single-element JSON array, an accurate enough shape for a function bound
+// against the SDK's typical array-of-documents change-feed parameter, and an
+// acceptable emulator simplification for synchronous per-write delivery.
+// Lease container / checkpoint mechanics are not modeled.
+func (m *Mock) dispatchFunctionTrigger(ctx context.Context, table string, item map[string]any) {
+	if m.functionSink == nil {
+		return
+	}
+
+	database, container, ok := cosmosDatabaseContainer(table)
+	if !ok {
+		return
+	}
+
+	body, err := json.Marshal([]map[string]any{item})
+	if err != nil {
+		return
+	}
+
+	m.functionSink.DeliverCosmosFunctionTrigger(ctx, database, container, body)
+}
+
+// cosmosDatabaseContainer extracts a document's (database, container) pair
+// from its driver table name, mirroring how server/azure/cosmosdb's qualify
+// encodes it as the table name's last two "/"-separated segments
+// ("{account}/{database}/{container}", with the account segment omitted for
+// the default account). Cosmos account, database and container identifiers
+// cannot contain "/", so the decoding is unambiguous. A table name with fewer
+// than two segments — e.g. one created directly through the flat
+// driver.Database API rather than the Cosmos SQL wire layer — carries no
+// database identity and returns ok=false.
+func cosmosDatabaseContainer(table string) (database, container string, ok bool) {
+	idx := strings.LastIndexByte(table, '/')
+	if idx < 0 {
+		return "", "", false
+	}
+
+	container = table[idx+1:]
+	rest := table[:idx]
+
+	database = rest
+	if di := strings.LastIndexByte(rest, '/'); di >= 0 {
+		database = rest[di+1:]
+	}
+
+	if database == "" || container == "" {
+		return "", "", false
+	}
+
+	return database, container, true
+}

--- a/providers/azure/cosmosdb/function_trigger.go
+++ b/providers/azure/cosmosdb/function_trigger.go
@@ -40,11 +40,11 @@ func (m *Mock) SetFunctionTriggerSink(sink CosmosFunctionTriggerSink) {
 // (server/azure/cosmosdb's qualify) has no (database, container) pair to
 // address.
 //
-// Called with no store lock held — PutItem/UpdateItem snapshot item and
-// release m.mu before calling this — so a function invoked by the trigger may
-// itself write back into Cosmos DB without deadlocking. item must already be
-// a snapshot the caller owns exclusively; this method does not clone it
-// again.
+// Called with no store lock held — PutItem/UpdateItem/BatchPutItems snapshot
+// item(s) and release m.mu before calling this — so a function invoked by
+// the trigger may itself write back into Cosmos DB without deadlocking. item
+// must already be a snapshot the caller owns exclusively; this method does
+// not clone it again.
 //
 // Real Cosmos change feed delivers a BATCH of changed documents per lease
 // checkpoint; this emulator delivers one document per write, wrapped in a

--- a/providers/azure/cosmosdb/function_trigger_test.go
+++ b/providers/azure/cosmosdb/function_trigger_test.go
@@ -1,0 +1,148 @@
+package cosmosdb
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeCosmosSink records every DeliverCosmosFunctionTrigger call it observes,
+// standing in for the Azure Functions provider in tests that only exercise
+// the Cosmos DB mock's dispatch, not real function matching/invocation.
+type fakeCosmosSink struct {
+	mu    sync.Mutex
+	calls []cosmosSinkCall
+}
+
+type cosmosSinkCall struct {
+	database  string
+	container string
+	body      string
+}
+
+func (f *fakeCosmosSink) DeliverCosmosFunctionTrigger(_ context.Context, database, container string, body []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.calls = append(f.calls, cosmosSinkCall{database: database, container: container, body: string(body)})
+}
+
+func (f *fakeCosmosSink) snapshot() []cosmosSinkCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return append([]cosmosSinkCall(nil), f.calls...)
+}
+
+func TestPutItemDispatchesCosmosFunctionTrigger(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	sink := &fakeCosmosSink{}
+	m.SetFunctionTriggerSink(sink)
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "acct/orders-db/orders", PartitionKey: "id"}))
+
+	require.NoError(t, m.PutItem(ctx, "acct/orders-db/orders", map[string]any{"id": "1", "status": "new"}))
+
+	calls := sink.snapshot()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "orders-db", calls[0].database)
+	assert.Equal(t, "orders", calls[0].container)
+	assert.JSONEq(t, `[{"id":"1","status":"new"}]`, calls[0].body)
+}
+
+func TestUpdateItemDispatchesCosmosFunctionTrigger(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	sink := &fakeCosmosSink{}
+	m.SetFunctionTriggerSink(sink)
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "acct/orders-db/orders", PartitionKey: "id"}))
+	require.NoError(t, m.PutItem(ctx, "acct/orders-db/orders", map[string]any{"id": "1", "status": "new"}))
+
+	_, err := m.UpdateItem(ctx, driver.UpdateItemInput{
+		Table: "acct/orders-db/orders",
+		Key:   map[string]any{"id": "1"},
+		Actions: []driver.UpdateAction{
+			{Action: "SET", Field: "status", Value: "shipped"},
+		},
+	})
+	require.NoError(t, err)
+
+	calls := sink.snapshot()
+	require.Len(t, calls, 2, "PutItem then UpdateItem should each dispatch once")
+	assert.Equal(t, "orders-db", calls[1].database)
+	assert.Equal(t, "orders", calls[1].container)
+	assert.JSONEq(t, `[{"id":"1","status":"shipped"}]`, calls[1].body)
+}
+
+func TestDeleteItemDoesNotDispatchCosmosFunctionTrigger(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	sink := &fakeCosmosSink{}
+	m.SetFunctionTriggerSink(sink)
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "acct/orders-db/orders", PartitionKey: "id"}))
+	require.NoError(t, m.PutItem(ctx, "acct/orders-db/orders", map[string]any{"id": "1"}))
+	require.NoError(t, m.DeleteItem(ctx, "acct/orders-db/orders", map[string]any{"id": "1"}))
+
+	calls := sink.snapshot()
+	require.Len(t, calls, 1, "only the PutItem should have dispatched; delete must not fire a cosmosDBTrigger")
+}
+
+func TestPutItemNoDispatchWithoutSink(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "acct/orders-db/orders", PartitionKey: "id"}))
+
+	// A nil sink (the default) must not panic and must simply skip delivery.
+	require.NoError(t, m.PutItem(ctx, "acct/orders-db/orders", map[string]any{"id": "1"}))
+}
+
+func TestPutItemNoDispatchForUnqualifiedTable(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	sink := &fakeCosmosSink{}
+	m.SetFunctionTriggerSink(sink)
+
+	// A table created directly through the flat driver.Database API (no
+	// account/database/container encoding) carries no database identity.
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "flat-table", PartitionKey: "id"}))
+	require.NoError(t, m.PutItem(ctx, "flat-table", map[string]any{"id": "1"}))
+
+	assert.Empty(t, sink.snapshot())
+}
+
+func TestCosmosDatabaseContainer(t *testing.T) {
+	tests := []struct {
+		name          string
+		table         string
+		wantDatabase  string
+		wantContainer string
+		wantOK        bool
+	}{
+		{name: "account qualified", table: "acct/db1/coll1", wantDatabase: "db1", wantContainer: "coll1", wantOK: true},
+		{name: "default account", table: "db1/coll1", wantDatabase: "db1", wantContainer: "coll1", wantOK: true},
+		{name: "no separator", table: "flat", wantOK: false},
+		{name: "empty", table: "", wantOK: false},
+		{name: "trailing slash", table: "db1/", wantOK: false},
+		{name: "leading slash", table: "/coll1", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, container, ok := cosmosDatabaseContainer(tt.table)
+			assert.Equal(t, tt.wantOK, ok)
+
+			if tt.wantOK {
+				assert.Equal(t, tt.wantDatabase, db)
+				assert.Equal(t, tt.wantContainer, container)
+			}
+		})
+	}
+}

--- a/providers/azure/cosmosdb/function_trigger_test.go
+++ b/providers/azure/cosmosdb/function_trigger_test.go
@@ -2,6 +2,7 @@ package cosmosdb
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 	"testing"
 
@@ -78,6 +79,39 @@ func TestUpdateItemDispatchesCosmosFunctionTrigger(t *testing.T) {
 	assert.Equal(t, "orders-db", calls[1].database)
 	assert.Equal(t, "orders", calls[1].container)
 	assert.JSONEq(t, `[{"id":"1","status":"shipped"}]`, calls[1].body)
+}
+
+func TestBatchPutItemsDispatchesCosmosFunctionTrigger(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	sink := &fakeCosmosSink{}
+	m.SetFunctionTriggerSink(sink)
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "acct/orders-db/orders", PartitionKey: "id"}))
+
+	items := []map[string]any{
+		{"id": "1", "status": "new"},
+		{"id": "2", "status": "new"},
+		{"id": "3", "status": "new"},
+	}
+	require.NoError(t, m.BatchPutItems(ctx, "acct/orders-db/orders", items))
+
+	calls := sink.snapshot()
+	require.Len(t, calls, len(items), "BatchPutItems should dispatch once per item")
+
+	gotIDs := make([]string, len(calls))
+
+	for i, call := range calls {
+		assert.Equal(t, "orders-db", call.database)
+		assert.Equal(t, "orders", call.container)
+
+		var docs []map[string]any
+		require.NoError(t, json.Unmarshal([]byte(call.body), &docs))
+		require.Len(t, docs, 1, "each dispatch should carry a single-element array")
+		gotIDs[i], _ = docs[0]["id"].(string)
+	}
+
+	assert.ElementsMatch(t, []string{"1", "2", "3"}, gotIDs)
 }
 
 func TestDeleteItemDoesNotDispatchCosmosFunctionTrigger(t *testing.T) {

--- a/providers/azure/functions/cosmos_trigger.go
+++ b/providers/azure/functions/cosmos_trigger.go
@@ -1,0 +1,46 @@
+package functions
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+)
+
+// cosmosDBTriggerType is the function.json trigger type a cosmosDBTrigger
+// binding declares, as stamped by the ARM CreateFunction body's
+// "config.bindings".
+const cosmosDBTriggerType = "cosmosDBTrigger"
+
+// DeliverCosmosFunctionTrigger invokes every deployed function whose
+// function.json declares a cosmosDBTrigger input binding on (database,
+// container), passing body (the changed document, wrapped in a JSON array by
+// the caller) as the invocation payload. It is the cross-service seam the
+// Azure Cosmos DB mock calls after a successful document create/update (see
+// providers/azure/cosmosdb's CosmosFunctionTriggerSink), mirroring
+// DeliverBlobFunctionTrigger for Blob Storage.
+//
+// Real Azure's cosmosDBTrigger (Cosmos change feed) fires on document create
+// and update, never on delete, so the Cosmos DB mock only calls this from its
+// write paths. Delivery is synchronous and recursion-guarded exactly like the
+// other triggers: a function that writes back into its own monitored
+// container would otherwise invoke itself unbounded.
+func (m *Mock) DeliverCosmosFunctionTrigger(ctx context.Context, database, container string, body []byte) {
+	if database == "" || container == "" {
+		return
+	}
+
+	if recursionguard.Depth(ctx) >= recursionguard.MaxDepth {
+		return
+	}
+
+	match := func(b map[string]any) bool {
+		dn, _ := b["databaseName"].(string)
+		cn, _ := b["containerName"].(string)
+
+		return dn == database && cn == container
+	}
+
+	for _, app := range m.appsBoundBy(cosmosDBTriggerType, match) {
+		_ = m.InvokeExternal(ctx, app, body)
+	}
+}

--- a/providers/azure/functions/cosmos_trigger_test.go
+++ b/providers/azure/functions/cosmos_trigger_test.go
@@ -1,0 +1,111 @@
+package functions
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+	"github.com/stretchr/testify/assert"
+)
+
+// cosmosTriggerConfig builds a function.json-shaped config declaring a
+// single cosmosDBTrigger input binding on (database, container).
+func cosmosTriggerConfig(database, container string) map[string]any {
+	return map[string]any{
+		"bindings": []any{
+			map[string]any{
+				"name":          "docs",
+				"type":          "cosmosDBTrigger",
+				"direction":     "in",
+				"databaseName":  database,
+				"containerName": container,
+				"connection":    "CosmosDBConnection",
+			},
+		},
+	}
+}
+
+func TestDeliverCosmosFunctionTriggerInvokesBoundApp(t *testing.T) {
+	m := newTestMock()
+	count, last := seedTriggeredApp(t, m, "cosmos-app", cosmosTriggerConfig("orders-db", "orders"))
+
+	m.DeliverCosmosFunctionTrigger(context.Background(), "orders-db", "orders", []byte(`[{"id":"1"}]`))
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(count), "bound function should fire exactly once")
+	assert.Equal(t, `[{"id":"1"}]`, string(*last), "function should receive the changed document array")
+}
+
+func TestDeliverCosmosFunctionTriggerNoMatch(t *testing.T) {
+	m := newTestMock()
+	count, _ := seedTriggeredApp(t, m, "cosmos-app", cosmosTriggerConfig("orders-db", "orders"))
+
+	// A different container, a different database, an empty database and an
+	// empty container must all no-op.
+	m.DeliverCosmosFunctionTrigger(context.Background(), "orders-db", "invoices", []byte("x"))
+	m.DeliverCosmosFunctionTrigger(context.Background(), "other-db", "orders", []byte("x"))
+	m.DeliverCosmosFunctionTrigger(context.Background(), "", "orders", []byte("x"))
+	m.DeliverCosmosFunctionTrigger(context.Background(), "orders-db", "", []byte("x"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(count))
+}
+
+func TestDeliverCosmosFunctionTriggerSkipsDisabledFunction(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "disabled-app", Runtime: "node"})
+	assert.NoError(t, err)
+
+	_, err = m.UpsertSiteMeta(ctx, SiteMeta{Name: "disabled-app", Subscription: "sub", ResourceGroup: "rg"})
+	assert.NoError(t, err)
+
+	_, _, err = m.CreateSiteFunction(ctx, "disabled-app", SiteFunction{
+		Name: "fn1", Config: cosmosTriggerConfig("orders-db", "orders"), IsDisabled: true,
+	})
+	assert.NoError(t, err)
+
+	var count int32
+
+	m.RegisterHandler("disabled-app", func(_ context.Context, p []byte) ([]byte, error) {
+		atomic.AddInt32(&count, 1)
+
+		return p, nil
+	})
+
+	m.DeliverCosmosFunctionTrigger(ctx, "orders-db", "orders", []byte("x"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&count), "a disabled function must not fire")
+}
+
+func TestDeliverCosmosFunctionTriggerOutputBindingIgnored(t *testing.T) {
+	m := newTestMock()
+
+	// An output binding to the container is not a trigger and must not fire.
+	cfg := map[string]any{
+		"bindings": []any{
+			map[string]any{
+				"name": "out", "type": "cosmosDBTrigger", "direction": "out",
+				"databaseName": "orders-db", "containerName": "orders",
+			},
+		},
+	}
+	count, _ := seedTriggeredApp(t, m, "producer-app", cfg)
+
+	m.DeliverCosmosFunctionTrigger(context.Background(), "orders-db", "orders", []byte("x"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(count))
+}
+
+// TestDeliverCosmosFunctionTriggerRecursionGuard proves a re-entrant delivery
+// already at MaxDepth is dropped without invoking the function.
+func TestDeliverCosmosFunctionTriggerRecursionGuard(t *testing.T) {
+	m := newTestMock()
+	count, _ := seedTriggeredApp(t, m, "loop-app", cosmosTriggerConfig("loop-db", "loop"))
+
+	ctx := recursionguard.WithDepth(context.Background(), recursionguard.MaxDepth)
+	m.DeliverCosmosFunctionTrigger(ctx, "loop-db", "loop", []byte("x"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(count), "delivery at MaxDepth must be dropped")
+}

--- a/server/azure/functions_cosmos_trigger_test.go
+++ b/server/azure/functions_cosmos_trigger_test.go
@@ -1,0 +1,426 @@
+package azure_test
+
+// Real-user end-to-end proof that an Azure Functions cosmosDBTrigger binding
+// actually fires: a function app declares a cosmosDBTrigger binding naming a
+// (databaseName, containerName) via ARM, then a document created or replaced
+// in that container with the real azcosmos SDK synchronously invokes the
+// function with the changed document (wrapped in a single-element JSON
+// array, mirroring Cosmos's change-feed batch shape) as its payload. This is
+// the Cosmos DB counterpart of TestQueueStorageTriggerInvokesFunction (#997),
+// TestServiceBusTopicTriggerInvokesFunction (#1001) and
+// TestBlobStorageTriggerInvokesFunction (#1003): before this wiring a
+// cosmosDBTrigger binding round-tripped as CRUD only and no document write
+// ever reached the function. Real Cosmos change feed fires on document
+// create and update only, never on delete.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	azureprovider "github.com/stackshy/cloudemu/v2/providers/azure"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// newFullAzureTLSServerWithProvider boots the full production Azure server
+// over TLS (the Cosmos SDK's usual transport) over a caller-held provider, so
+// the test can register a Go handler to observe that a function was actually
+// invoked and, for the recursion test, call back into the held provider
+// in-process.
+func newFullAzureTLSServerWithProvider(t *testing.T) (*httptest.Server, *azureprovider.Provider) {
+	t.Helper()
+
+	p := cloudemu.NewAzure()
+	ts := httptest.NewTLSServer(azureserver.NewFromProvider(p))
+	t.Cleanup(ts.Close)
+
+	return ts, p
+}
+
+// cosmosFuncAppBase returns the ARM base path of a function app used by
+// these tests.
+func cosmosFuncAppBase(app string) string {
+	return "/subscriptions/sub-ct/resourceGroups/rg-ct/providers/Microsoft.Web/sites/" + app
+}
+
+// createCosmosTriggeredApp creates a function app plus one deployed function
+// declaring a cosmosDBTrigger binding on (database, container).
+func createCosmosTriggeredApp(t *testing.T, ts *httptest.Server, app, database, container string) {
+	t.Helper()
+
+	base := cosmosFuncAppBase(app)
+	armPut(t, ts, base+"?api-version=2022-03-01", `{"location":"eastus","properties":{"siteConfig":{}}}`)
+	armPut(t, ts, base+"/functions/consume?api-version=2022-03-01",
+		`{"properties":{"config":{"bindings":[`+
+			`{"name":"docs","type":"cosmosDBTrigger","direction":"in",`+
+			`"databaseName":"`+database+`","containerName":"`+container+`",`+
+			`"leaseContainerName":"leases","connectionStringSetting":"CosmosDBConnection"}]}}}`)
+}
+
+// newCosmosDataClient returns a real azcosmos client pointed at ts, matching
+// server/azure/cosmos_blob_dispatch_test.go's TLS setup (dispatchKey is
+// defined there, in this same package).
+func newCosmosDataClient(t *testing.T, ts *httptest.Server) *azcosmos.Client {
+	t.Helper()
+
+	cred, err := azcosmos.NewKeyCredential(dispatchKey)
+	if err != nil {
+		t.Fatalf("NewKeyCredential: %v", err)
+	}
+
+	client, err := azcosmos.NewClientWithKey(ts.URL, cred, &azcosmos.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewClientWithKey: %v", err)
+	}
+
+	return client
+}
+
+// makeCosmosContainer creates database/container (partition key path "/pk")
+// through client and returns the container client.
+func makeCosmosContainer(ctx context.Context, t *testing.T, client *azcosmos.Client, database, container string) *azcosmos.ContainerClient {
+	t.Helper()
+
+	if _, err := client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: database}, nil); err != nil {
+		t.Fatalf("CreateDatabase(%s): %v", database, err)
+	}
+
+	db, err := client.NewDatabase(database)
+	if err != nil {
+		t.Fatalf("NewDatabase(%s): %v", database, err)
+	}
+
+	if _, err := db.CreateContainer(ctx, azcosmos.ContainerProperties{
+		ID:                     container,
+		PartitionKeyDefinition: azcosmos.PartitionKeyDefinition{Paths: []string{"/pk"}},
+	}, nil); err != nil {
+		t.Fatalf("CreateContainer(%s): %v", container, err)
+	}
+
+	cc, err := db.NewContainer(container)
+	if err != nil {
+		t.Fatalf("NewContainer(%s): %v", container, err)
+	}
+
+	return cc
+}
+
+func TestCosmosDBTriggerInvokesFunction(t *testing.T) {
+	ts, p := newFullAzureTLSServerWithProvider(t)
+	ctx := context.Background()
+
+	const (
+		app       = "ct-app"
+		database  = "orders-db"
+		container = "orders"
+	)
+
+	createCosmosTriggeredApp(t, ts, app, database, container)
+
+	got := make(chan string, 1)
+	p.Functions.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		select {
+		case got <- string(payload):
+		default:
+		}
+
+		return payload, nil
+	})
+
+	cc := makeCosmosContainer(ctx, t, newCosmosDataClient(t, ts), database, container)
+
+	doc, _ := json.Marshal(map[string]any{"id": "o1", "pk": "team-a", "status": "new"})
+	if _, err := cc.CreateItem(ctx, azcosmos.NewPartitionKeyString("team-a"), doc, nil); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	// Delivery is synchronous, so the function has fired by the time the
+	// create returns.
+	select {
+	case body := <-got:
+		var docs []map[string]any
+		if err := json.Unmarshal([]byte(body), &docs); err != nil {
+			t.Fatalf("unmarshal trigger payload %q: %v", body, err)
+		}
+
+		if len(docs) != 1 {
+			t.Fatalf("trigger payload has %d documents, want 1 (a single-element array per write)", len(docs))
+		}
+
+		if docs[0]["id"] != "o1" || docs[0]["status"] != "new" {
+			t.Fatalf("triggered document = %v, want id=o1 status=new", docs[0])
+		}
+	default:
+		t.Fatal("cosmosDBTrigger function was not invoked")
+	}
+}
+
+// TestCosmosDBTriggerDifferentContainerDoesNotFire proves a document written
+// to a container the function is not bound to invokes nothing, even within
+// the same database.
+func TestCosmosDBTriggerDifferentContainerDoesNotFire(t *testing.T) {
+	ts, p := newFullAzureTLSServerWithProvider(t)
+	ctx := context.Background()
+
+	const (
+		app      = "ct-app2"
+		database = "orders-db2"
+	)
+
+	createCosmosTriggeredApp(t, ts, app, database, "orders")
+
+	fired := make(chan struct{}, 1)
+	p.Functions.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		fired <- struct{}{}
+		return payload, nil
+	})
+
+	client := newCosmosDataClient(t, ts)
+	cc := makeCosmosContainer(ctx, t, client, database, "shipments")
+
+	doc, _ := json.Marshal(map[string]any{"id": "s1", "pk": "team-a"})
+	if _, err := cc.CreateItem(ctx, azcosmos.NewPartitionKeyString("team-a"), doc, nil); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	select {
+	case <-fired:
+		t.Fatal("function fired for a container it is not bound to")
+	default:
+	}
+}
+
+// TestCosmosDBTriggerDifferentDatabaseDoesNotFire proves a document written
+// to a same-named container in a different database invokes nothing: both
+// databaseName and containerName must match.
+func TestCosmosDBTriggerDifferentDatabaseDoesNotFire(t *testing.T) {
+	ts, p := newFullAzureTLSServerWithProvider(t)
+	ctx := context.Background()
+
+	const app = "ct-app3"
+
+	createCosmosTriggeredApp(t, ts, app, "orders-db3", "orders")
+
+	fired := make(chan struct{}, 1)
+	p.Functions.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		fired <- struct{}{}
+		return payload, nil
+	})
+
+	client := newCosmosDataClient(t, ts)
+	cc := makeCosmosContainer(ctx, t, client, "other-db3", "orders")
+
+	doc, _ := json.Marshal(map[string]any{"id": "o1", "pk": "team-a"})
+	if _, err := cc.CreateItem(ctx, azcosmos.NewPartitionKeyString("team-a"), doc, nil); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	select {
+	case <-fired:
+		t.Fatal("function fired for a database it is not bound to")
+	default:
+	}
+}
+
+// TestCosmosDBTriggerDeleteDoesNotFire proves that, matching real Cosmos
+// change feed, a document DELETE never fires a cosmosDBTrigger: the bound
+// function fires once on create, then not again when that same document is
+// deleted.
+func TestCosmosDBTriggerDeleteDoesNotFire(t *testing.T) {
+	ts, p := newFullAzureTLSServerWithProvider(t)
+	ctx := context.Background()
+
+	const (
+		app       = "ct-app4"
+		database  = "orders-db4"
+		container = "orders"
+	)
+
+	createCosmosTriggeredApp(t, ts, app, database, container)
+
+	var invocations int32
+
+	p.Functions.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		atomic.AddInt32(&invocations, 1)
+		return payload, nil
+	})
+
+	client := newCosmosDataClient(t, ts)
+	cc := makeCosmosContainer(ctx, t, client, database, container)
+
+	pk := azcosmos.NewPartitionKeyString("team-a")
+
+	doc, _ := json.Marshal(map[string]any{"id": "o1", "pk": "team-a"})
+	if _, err := cc.CreateItem(ctx, pk, doc, nil); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&invocations); got != 1 {
+		t.Fatalf("invocations after create = %d, want 1", got)
+	}
+
+	if _, err := cc.DeleteItem(ctx, pk, "o1", nil); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&invocations); got != 1 {
+		t.Fatalf("invocations after delete = %d, want it to stay at 1 (delete must not fire a cosmosDBTrigger)", got)
+	}
+}
+
+// TestCosmosDBTriggerReplaceFires proves a document UPDATE (replace) fires
+// the trigger again, matching real Cosmos change feed's create-AND-update
+// semantics.
+func TestCosmosDBTriggerReplaceFires(t *testing.T) {
+	ts, p := newFullAzureTLSServerWithProvider(t)
+	ctx := context.Background()
+
+	const (
+		app       = "ct-app5"
+		database  = "orders-db5"
+		container = "orders"
+	)
+
+	createCosmosTriggeredApp(t, ts, app, database, container)
+
+	var invocations int32
+
+	p.Functions.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		atomic.AddInt32(&invocations, 1)
+		return payload, nil
+	})
+
+	client := newCosmosDataClient(t, ts)
+	cc := makeCosmosContainer(ctx, t, client, database, container)
+
+	pk := azcosmos.NewPartitionKeyString("team-a")
+
+	doc, _ := json.Marshal(map[string]any{"id": "o1", "pk": "team-a", "status": "new"})
+	if _, err := cc.CreateItem(ctx, pk, doc, nil); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	doc, _ = json.Marshal(map[string]any{"id": "o1", "pk": "team-a", "status": "shipped"})
+	if _, err := cc.ReplaceItem(ctx, pk, "o1", doc, nil); err != nil {
+		t.Fatalf("ReplaceItem: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&invocations); got != 2 {
+		t.Fatalf("invocations after create+replace = %d, want 2", got)
+	}
+}
+
+// TestCosmosDBTriggerDisabledFunctionSkipped proves a disabled deployed
+// function does not fire even though its binding matches the written
+// (database, container).
+func TestCosmosDBTriggerDisabledFunctionSkipped(t *testing.T) {
+	ts, p := newFullAzureTLSServerWithProvider(t)
+	ctx := context.Background()
+
+	const (
+		app       = "ct-disabled-app"
+		database  = "orders-db6"
+		container = "orders"
+	)
+
+	base := cosmosFuncAppBase(app)
+	armPut(t, ts, base+"?api-version=2022-03-01", `{"location":"eastus","properties":{"siteConfig":{}}}`)
+	armPut(t, ts, base+"/functions/consume?api-version=2022-03-01",
+		`{"properties":{"isDisabled":true,"config":{"bindings":[`+
+			`{"name":"docs","type":"cosmosDBTrigger","direction":"in",`+
+			`"databaseName":"`+database+`","containerName":"`+container+`",`+
+			`"connectionStringSetting":"CosmosDBConnection"}]}}}`)
+
+	fired := make(chan struct{}, 1)
+	p.Functions.RegisterHandler(app, func(_ context.Context, payload []byte) ([]byte, error) {
+		fired <- struct{}{}
+		return payload, nil
+	})
+
+	client := newCosmosDataClient(t, ts)
+	cc := makeCosmosContainer(ctx, t, client, database, container)
+
+	doc, _ := json.Marshal(map[string]any{"id": "o1", "pk": "team-a"})
+	if _, err := cc.CreateItem(ctx, azcosmos.NewPartitionKeyString("team-a"), doc, nil); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	select {
+	case <-fired:
+		t.Fatal("a disabled function must not fire")
+	default:
+	}
+}
+
+// TestCosmosDBTriggerRecursionGuard proves a function that writes back into
+// its own monitored container terminates at recursionguard.MaxDepth rather
+// than recursing unbounded, mirroring TestBlobStorageTriggerRecursionGuard.
+// The handler forwards the ctx it was invoked with into a direct
+// p.CosmosDB.PutItem call (not a fresh HTTP round trip through the real SDK —
+// an HTTP hop cannot carry ctx's depth value, only the DepthHeader-based
+// webhook path can) so that ctx-carried depth is the channel the guard rides
+// on, exactly like the blobTrigger recursion test's direct PutObject call.
+// The table name mirrors server/azure/cosmosdb's qualify() encoding for the
+// default (unaccounted) account: "{database}/{container}".
+func TestCosmosDBTriggerRecursionGuard(t *testing.T) {
+	ts, p := newFullAzureTLSServerWithProvider(t)
+	ctx := context.Background()
+
+	const (
+		app       = "ct-loop-app"
+		database  = "loop-db"
+		container = "loop-container"
+	)
+
+	createCosmosTriggeredApp(t, ts, app, database, container)
+
+	client := newCosmosDataClient(t, ts)
+	_ = makeCosmosContainer(ctx, t, client, database, container)
+
+	table := database + "/" + container
+
+	var invocations int32
+
+	p.Functions.RegisterHandler(app, func(ctx context.Context, payload []byte) ([]byte, error) {
+		atomic.AddInt32(&invocations, 1)
+
+		err := p.CosmosDB.PutItem(ctx, table, map[string]any{"id": "again", "pk": "team-a"})
+
+		return payload, err
+	})
+
+	// The single top-level write that starts the chain.
+	seed, _ := json.Marshal(map[string]any{"id": "seed", "pk": "team-a"})
+
+	cc, err := client.NewDatabase(database)
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	seedContainer, err := cc.NewContainer(container)
+	if err != nil {
+		t.Fatalf("NewContainer: %v", err)
+	}
+
+	if _, err := seedContainer.CreateItem(ctx, azcosmos.NewPartitionKeyString("team-a"), seed, nil); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&invocations); got != int32(recursionguard.MaxDepth) {
+		t.Fatalf("handler invoked %d times, want exactly %d (recursive-loop guard did not bound the chain)",
+			got, recursionguard.MaxDepth)
+	}
+}


### PR DESCRIPTION
## Summary
A document created or updated in a Cosmos DB container bound by a `cosmosDBTrigger` binding now invokes any deployed function bound to it, delivering the changed document as the invocation payload — the Cosmos analog of the queue/topic/blob trigger delivery from #997/#1001/#1003.

- New `CosmosFunctionTriggerSink` on the Cosmos DB mock (`providers/azure/cosmosdb`), dispatched from `PutItem`/`UpdateItem` after the store write with no lock held (the changed document is snapshotted under the lock first, so a concurrent write can't cause a torn read).
- New `DeliverCosmosFunctionTrigger` on the Azure Functions mock (`providers/azure/functions`), reusing the existing `appsBoundBy`/`bindingMatches`/`InvokeExternal` machinery and recursion guard, matching a `cosmosDBTrigger` binding's `databaseName`+`containerName` against the changed document.
- Fires on document create (`PutItem`) and update (`PutItem`/`UpdateItem`); delete never fires, matching real Cosmos change feed semantics.
- The changed document is delivered wrapped in a single-element JSON array, matching the change feed's batch shape.
- Wired via `p.CosmosDB.SetFunctionTriggerSink(p.Functions)` in `providers/azure/azure.go`, same place the blob/queue/Service Bus sinks are wired.

**Architecture note:** the generic `services/database/driver.Database` interface (shared with DynamoDB/Firestore) has a flat table namespace with no database/container concept — that hierarchy only exists as an encoding the Cosmos SQL wire handler (`server/azure/cosmosdb`) applies to the table name (`{account}/{database}/{container}`, see `qualify`). The dispatch decodes a document's `(database, container)` from the table name's last two `/`-separated segments, which is unambiguous since those identifiers can't contain `/`. A table written directly through the flat driver API (bypassing the Cosmos wire layer's encoding) has no database identity to match against and simply never fires — an existing limitation of how Cosmos's database/container split is modeled in this codebase, not a new one.

## Deferred
- Lease container / checkpoint mechanics (not modeled; delivery is synchronous per write, like the other triggers).
- Delivering more than one document per write — real change feed batches multiple changes per lease checkpoint; this emulator delivers one document per write as a single-element array, an acceptable emulator simplification.
- Timer trigger, Event Hub trigger.
- All-versions-and-deletes change feed mode (standard change feed only; deletes never fire).

## Test plan
- [x] `go build ./...`
- [x] `go test ./providers/azure/functions/ ./providers/azure/cosmosdb/ ./server/azure/... ./providers/azure/... -race -count=1` — all pass
- [x] New real-user e2e tests in `server/azure/functions_cosmos_trigger_test.go`: full server boot, ARM-declared function app with a `cosmosDBTrigger` binding, real `azcosmos` SDK document create/replace/delete, cross-container/cross-database negatives, disabled-function skip, recursion-bounded loop test
- [x] `gofmt -l` clean on touched files
- [x] `golangci-lint` — 0 new issues on touched packages
- [x] `go generate ./...` — no `docs/coverage` diff
- [x] `go mod tidy` — no changes