### PR TITLE
feat(gcp-cloudrun): invoke a deployed Cloud Run service over its URL

### DIFF
--- a/docs/coverage/README.md
+++ b/docs/coverage/README.md
@@ -23,7 +23,7 @@ code does not implement. Machine-readable: [`coverage.json`](./coverage.json).
 | `cloudasset` | — | — | [Cloudasset](./gcp/cloudasset.md) | — | 11 |
 | `cloudbilling` | — | — | [Cloudbilling](./gcp/cloudbilling.md) | — | 14 |
 | `cloudformation` | [CloudFormation](./aws/cloudformation.md) | — | — | — | 9 |
-| `cloudrun` | — | — | [CloudRun](./gcp/cloudrun.md) | — | 16 |
+| `cloudrun` | — | — | [CloudRun](./gcp/cloudrun.md) | — | 18 |
 | `cloudsql` | — | — | [CloudSQL](./gcp/cloudsql.md) | — | 21 |
 | `cloudtrail` | [CloudTrail](./aws/cloudtrail.md) | — | — | — | 60 |
 | `compute` | [EC2](./aws/ec2.md) | [VirtualMachines](./azure/virtualmachines.md) | [GCE](./gcp/gce.md) | — | 37 |

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -1890,6 +1890,10 @@
         "doc": "GetService returns a service by name (bare service id or a fully"
       },
       {
+        "name": "Invoke",
+        "doc": "Invoke executes the named service (bare id or fully qualified name)"
+      },
+      {
         "name": "ListExecutions",
         "doc": "ListExecutions returns every stored execution of the named job."
       },
@@ -1904,6 +1908,10 @@
       {
         "name": "ListServices",
         "doc": "ListServices returns every stored service."
+      },
+      {
+        "name": "RegisterHandler",
+        "doc": "RegisterHandler plugs a Go handler in for the named service (bare id),"
       },
       {
         "name": "RunJob",

--- a/docs/coverage/gcp/README.md
+++ b/docs/coverage/gcp/README.md
@@ -12,7 +12,7 @@ Services cloudemu emulates for GCP, by native name. Back to the [cross-provider 
 | [CloudFunctions](./cloudfunctions.md) | `serverless` | 27 |
 | [CloudLogging](./cloudlogging.md) | `logging` | 17 |
 | [CloudMonitoring](./cloudmonitoring.md) | `monitoring` | 12 |
-| [CloudRun](./cloudrun.md) | `cloudrun` | 16 |
+| [CloudRun](./cloudrun.md) | `cloudrun` | 18 |
 | [CloudSQL](./cloudsql.md) | — (provider-native) | 21 |
 | [Cloudasset](./cloudasset.md) | — (provider-native) | 11 |
 | [Cloudbilling](./cloudbilling.md) | — (provider-native) | 14 |

--- a/docs/coverage/gcp/cloudrun.md
+++ b/docs/coverage/gcp/cloudrun.md
@@ -3,7 +3,7 @@
 
 GCP's `cloudrun` service · portable interface `driver.CloudRun` · [GCP index](./README.md)
 
-## Operations (16)
+## Operations (18)
 
 | Operation | Description |
 | --- | --- |
@@ -16,10 +16,12 @@ GCP's `cloudrun` service · portable interface `driver.CloudRun` · [GCP index](
 | `GetJob` | GetJob returns a job by name. name may be the bare job id or a fully |
 | `GetRevision` | GetRevision returns a revision by name (bare revision id or a fully |
 | `GetService` | GetService returns a service by name (bare service id or a fully |
+| `Invoke` | Invoke executes the named service (bare id or fully qualified name) |
 | `ListExecutions` | ListExecutions returns every stored execution of the named job. |
 | `ListJobs` | ListJobs returns every stored job. |
 | `ListRevisions` | ListRevisions returns every stored revision of the named service. |
 | `ListServices` | ListServices returns every stored service. |
+| `RegisterHandler` | RegisterHandler plugs a Go handler in for the named service (bare id), |
 | `RunJob` | RunJob creates and runs one Execution of the named job, blocking until |
 | `UpdateJob` | UpdateJob applies an in-place update to an existing job, bumping its |
 | `UpdateService` | UpdateService applies an in-place update, materializing a new Revision |

--- a/providers/gcp/cloudrun/cloudrun.go
+++ b/providers/gcp/cloudrun/cloudrun.go
@@ -53,7 +53,11 @@ type Mock struct {
 	// consults to tear down real containers; an absent entry means the job's
 	// executions were synthetic (no engine wired).
 	engineHandles *memstore.Store[[]string]
-	opts          *config.Options
+	// handlersMu guards handlers, a Go handler registered per service id
+	// standing in for its container image (see Invoke/RegisterHandler).
+	handlersMu sync.RWMutex
+	handlers   map[string]driver.HandlerFunc
+	opts       *config.Options
 }
 
 // New creates a Cloud Run mock with the given options. opts.ContainerEngine,
@@ -65,6 +69,7 @@ func New(opts *config.Options) *Mock {
 		services:      memstore.New[*driver.Service](),
 		revisions:     memstore.New[*driver.Revision](),
 		engineHandles: memstore.New[[]string](),
+		handlers:      make(map[string]driver.HandlerFunc),
 		opts:          opts,
 	}
 }

--- a/providers/gcp/cloudrun/invoke.go
+++ b/providers/gcp/cloudrun/invoke.go
@@ -1,0 +1,88 @@
+package cloudrun
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/cloudrun/driver"
+)
+
+const (
+	invokeStatusOK    = 200
+	invokeStatusError = 500
+	contentTypeHeader = "Content-Type"
+	textPlainHeader   = "text/plain; charset=utf-8"
+)
+
+// Invoke executes the named service against req. When a Go handler was
+// registered for the service via RegisterHandler it runs; otherwise Invoke
+// returns a canned/echo stub response — 200 echoing req.Body back when the
+// caller sent one, or a short greeting naming the service when the request
+// carried no body. This mirrors the no-handler echo stub the Cloud Functions
+// and Lambda mocks return, since CloudEmu has no runtime for the container
+// images a real Cloud Run service would execute.
+//
+//nolint:gocritic // hugeParam: req is passed by value to satisfy the CloudRun driver interface.
+func (m *Mock) Invoke(ctx context.Context, name string, req driver.InvokeRequest) (*driver.InvokeResponse, error) {
+	id := lastSegment(name)
+
+	m.mu.Lock()
+	_, ok := m.services.Get(id)
+	m.mu.Unlock()
+
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "service %q not found", id)
+	}
+
+	m.handlersMu.RLock()
+	h := m.handlers[id]
+	m.handlersMu.RUnlock()
+
+	if h == nil {
+		resp := stubInvoke(id, &req)
+
+		return &resp, nil
+	}
+
+	resp, err := h(ctx, req)
+	if err != nil {
+		return &driver.InvokeResponse{StatusCode: invokeStatusError, Body: []byte(err.Error())}, nil
+	}
+
+	return &resp, nil
+}
+
+// RegisterHandler plugs a Go handler in for the named service id, standing in
+// for its container image. Registering nil clears a previously registered
+// handler, reverting the service to the echo stub.
+func (m *Mock) RegisterHandler(name string, handler driver.HandlerFunc) {
+	m.handlersMu.Lock()
+	defer m.handlersMu.Unlock()
+
+	if handler == nil {
+		delete(m.handlers, name)
+		return
+	}
+
+	m.handlers[name] = handler
+}
+
+// stubInvoke builds the no-handler canned response: an echo of the request
+// body (preserving its Content-Type when the caller sent one) when a body was
+// sent, or a short plain-text greeting naming the service otherwise.
+func stubInvoke(name string, req *driver.InvokeRequest) driver.InvokeResponse {
+	if len(req.Body) > 0 {
+		headers := map[string][]string{}
+		if ct, ok := req.Headers[contentTypeHeader]; ok && len(ct) > 0 {
+			headers[contentTypeHeader] = []string{ct[0]}
+		}
+
+		return driver.InvokeResponse{StatusCode: invokeStatusOK, Headers: headers, Body: req.Body}
+	}
+
+	return driver.InvokeResponse{
+		StatusCode: invokeStatusOK,
+		Headers:    map[string][]string{contentTypeHeader: {textPlainHeader}},
+		Body:       []byte("Hello from Cloud Run service \"" + name + "\"!\n"),
+	}
+}

--- a/providers/gcp/cloudrun/invoke_test.go
+++ b/providers/gcp/cloudrun/invoke_test.go
@@ -1,0 +1,145 @@
+package cloudrun
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/cloudrun/driver"
+)
+
+func TestInvokeNoHandlerEchoesBody(t *testing.T) {
+	m := newMock(t, nil)
+	ctx := context.Background()
+
+	if _, err := m.CreateService(ctx, svcCfg()); err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	resp, err := m.Invoke(ctx, "web", driver.InvokeRequest{
+		Method:  "POST",
+		Path:    "/",
+		Headers: map[string][]string{"Content-Type": {"application/json"}},
+		Body:    []byte(`{"hello":"world"}`),
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("statusCode = %d, want 200", resp.StatusCode)
+	}
+
+	if string(resp.Body) != `{"hello":"world"}` {
+		t.Fatalf("body = %q, want echo", resp.Body)
+	}
+
+	if got := resp.Headers["Content-Type"]; len(got) != 1 || got[0] != "application/json" {
+		t.Fatalf("content-type = %v, want echoed application/json", got)
+	}
+}
+
+func TestInvokeNoHandlerNoBodyReturnsGreeting(t *testing.T) {
+	m := newMock(t, nil)
+	ctx := context.Background()
+
+	if _, err := m.CreateService(ctx, svcCfg()); err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	resp, err := m.Invoke(ctx, "web", driver.InvokeRequest{Method: "GET", Path: "/"})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("statusCode = %d, want 200", resp.StatusCode)
+	}
+
+	if len(resp.Body) == 0 {
+		t.Fatal("body empty, want a canned greeting")
+	}
+}
+
+func TestInvokeUnknownServiceNotFound(t *testing.T) {
+	m := newMock(t, nil)
+
+	if _, err := m.Invoke(context.Background(), "missing", driver.InvokeRequest{}); err == nil {
+		t.Fatal("Invoke: want NotFound error for unknown service")
+	}
+}
+
+func TestInvokeRegisteredHandlerRuns(t *testing.T) {
+	m := newMock(t, nil)
+	ctx := context.Background()
+
+	if _, err := m.CreateService(ctx, svcCfg()); err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	var gotReq driver.InvokeRequest
+
+	m.RegisterHandler("web", func(_ context.Context, req driver.InvokeRequest) (driver.InvokeResponse, error) {
+		gotReq = req
+
+		return driver.InvokeResponse{StatusCode: 201, Body: []byte("handled")}, nil
+	})
+
+	resp, err := m.Invoke(ctx, "web", driver.InvokeRequest{Method: "PUT", Path: "/items/1", Body: []byte("in")})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	if resp.StatusCode != 201 || string(resp.Body) != "handled" {
+		t.Fatalf("resp = %+v", resp)
+	}
+
+	if gotReq.Method != "PUT" || gotReq.Path != "/items/1" || string(gotReq.Body) != "in" {
+		t.Fatalf("handler saw = %+v", gotReq)
+	}
+}
+
+func TestInvokeRegisteredHandlerErrorReturns500(t *testing.T) {
+	m := newMock(t, nil)
+	ctx := context.Background()
+
+	if _, err := m.CreateService(ctx, svcCfg()); err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	m.RegisterHandler("web", func(context.Context, driver.InvokeRequest) (driver.InvokeResponse, error) {
+		return driver.InvokeResponse{}, errors.New("boom")
+	})
+
+	resp, err := m.Invoke(ctx, "web", driver.InvokeRequest{})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	if resp.StatusCode != 500 {
+		t.Fatalf("statusCode = %d, want 500", resp.StatusCode)
+	}
+}
+
+func TestRegisterHandlerNilClearsHandler(t *testing.T) {
+	m := newMock(t, nil)
+	ctx := context.Background()
+
+	if _, err := m.CreateService(ctx, svcCfg()); err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	m.RegisterHandler("web", func(context.Context, driver.InvokeRequest) (driver.InvokeResponse, error) {
+		return driver.InvokeResponse{StatusCode: 201}, nil
+	})
+	m.RegisterHandler("web", nil)
+
+	resp, err := m.Invoke(ctx, "web", driver.InvokeRequest{})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("statusCode = %d, want 200 (echo stub after clearing handler)", resp.StatusCode)
+	}
+}

--- a/providers/gcp/cloudrun/invoke_test.go
+++ b/providers/gcp/cloudrun/invoke_test.go
@@ -143,3 +143,38 @@ func TestRegisterHandlerNilClearsHandler(t *testing.T) {
 		t.Fatalf("statusCode = %d, want 200 (echo stub after clearing handler)", resp.StatusCode)
 	}
 }
+
+// TestDeleteServiceEvictsHandler covers a redeploy flow: RegisterHandler on a
+// service, DeleteService it, then CreateService again under the same id. The
+// new service must get the documented no-handler echo stub, not silently
+// inherit the deleted deployment's handler (handlers are keyed by bare
+// service id, independent of the services store DeleteService clears).
+func TestDeleteServiceEvictsHandler(t *testing.T) {
+	m := newMock(t, nil)
+	ctx := context.Background()
+
+	if _, err := m.CreateService(ctx, svcCfg()); err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	m.RegisterHandler("web", func(context.Context, driver.InvokeRequest) (driver.InvokeResponse, error) {
+		return driver.InvokeResponse{StatusCode: 201, Body: []byte("stale handler")}, nil
+	})
+
+	if err := m.DeleteService(ctx, "web"); err != nil {
+		t.Fatalf("DeleteService: %v", err)
+	}
+
+	if _, err := m.CreateService(ctx, svcCfg()); err != nil {
+		t.Fatalf("CreateService (redeploy): %v", err)
+	}
+
+	resp, err := m.Invoke(ctx, "web", driver.InvokeRequest{})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	if resp.StatusCode != 200 || string(resp.Body) == "stale handler" {
+		t.Fatalf("resp = %+v, want the echo stub (200, greeting), not the stale handler's response", resp)
+	}
+}

--- a/providers/gcp/cloudrun/services.go
+++ b/providers/gcp/cloudrun/services.go
@@ -136,14 +136,18 @@ func applyUpdate(svc *driver.Service, cfg *driver.ServiceConfig) {
 	mergeServiceConfig(svc, cfg, newFieldMask(cfg.UpdateMask))
 }
 
-// DeleteService removes a service and all of its revisions.
+// DeleteService removes a service, all of its revisions, and any Go handler
+// registered for it (see RegisterHandler) — otherwise a redeployed service
+// reusing the same id would silently inherit the old deployment's handler
+// instead of the documented no-handler echo stub.
 func (m *Mock) DeleteService(_ context.Context, name string) error {
 	id := lastSegment(name)
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	if !m.services.Has(id) {
+		m.mu.Unlock()
+
 		return cerrors.Newf(cerrors.NotFound, "service %q not found", id)
 	}
 
@@ -154,6 +158,12 @@ func (m *Mock) DeleteService(_ context.Context, name string) error {
 			m.revisions.Delete(key)
 		}
 	}
+
+	m.mu.Unlock()
+
+	m.handlersMu.Lock()
+	delete(m.handlers, id)
+	m.handlersMu.Unlock()
 
 	return nil
 }

--- a/server/gcp/cloudrun/handler.go
+++ b/server/gcp/cloudrun/handler.go
@@ -29,6 +29,14 @@
 //
 // All mutating endpoints return google.longrunning.Operation envelopes with
 // done=true so SDK pollers terminate on the first response.
+//
+// A deployed service is also invocable directly: a request addressed to its
+// generated *.run.app host (any path, any method — see invoke.go) is routed
+// to the service and executed, independent of the Admin API path above. Real
+// Cloud Run enforces IAM run.invoker on the serving path for a non-public
+// service; CloudEmu accepts any credentials (SigV4/OAuth tokens are parsed,
+// never verified — see server/gcp/gcp.go), so every service is invocable
+// unauthenticated here regardless of its real ingress/IAM configuration.
 package cloudrun
 
 import (
@@ -78,17 +86,28 @@ func New(cr driver.CloudRun) *Handler {
 	return &Handler{cr: cr, policies: make(map[string]*iamPolicy)}
 }
 
-// Matches claims Cloud Run v2 job, service and location-operation paths. The
-// locations+{jobs,services,operations} guard keeps it disjoint from Cloud
-// Logging's /v2/projects/{p}/logs paths.
+// Matches claims Cloud Run v2 job, service and location-operation paths, plus
+// any request addressed to a deployed service's generated *.run.app host. The
+// locations+{jobs,services,operations} guard keeps the Admin API paths
+// disjoint from Cloud Logging's /v2/projects/{p}/logs paths.
 func (*Handler) Matches(r *http.Request) bool {
+	if isServiceHost(r.Host) {
+		return true
+	}
+
 	_, ok := parsePath(r.URL.Path)
 
 	return ok
 }
 
-// ServeHTTP routes by URL shape.
+// ServeHTTP routes by URL shape, or to a service invoke when the request
+// addresses a generated service host.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if isServiceHost(r.Host) {
+		h.serveServiceInvoke(w, r)
+		return
+	}
+
 	p, ok := parsePath(r.URL.Path)
 	if !ok {
 		writeError(w, http.StatusNotFound, "NOT_FOUND", "unsupported path")

--- a/server/gcp/cloudrun/invoke.go
+++ b/server/gcp/cloudrun/invoke.go
@@ -1,0 +1,155 @@
+package cloudrun
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	"github.com/stackshy/cloudemu/v2/services/cloudrun/driver"
+)
+
+// serviceHostMarker identifies an inbound request as an invoke through a
+// deployed service's generated URL rather than an Admin API call: real Cloud
+// Run services are addressed by a host of the form
+// https://{service}-{hash}.{region}.run.app (see services.go's serviceURI),
+// not by the /v2/projects/... Admin API path every other operation in this
+// package uses, so invoke traffic routes on the Host header instead — the
+// same approach the AWS Lambda Function URL handler uses for its own
+// generated *.lambda-url.* hosts.
+const serviceHostMarker = ".run.app"
+
+// isServiceHost reports whether host (an incoming request's Host header,
+// optionally with a port) addresses a generated Cloud Run service URL.
+func isServiceHost(host string) bool {
+	return strings.HasSuffix(requestHost(host), serviceHostMarker)
+}
+
+// requestHost strips an optional port from an HTTP Host header and
+// lower-cases the remainder.
+func requestHost(host string) string {
+	h, _, err := net.SplitHostPort(host)
+	if err != nil {
+		h = host
+	}
+
+	return strings.ToLower(h)
+}
+
+// serveServiceInvoke handles a request addressed to a deployed service's
+// generated host, resolving the service and running it through the CloudRun
+// driver's Invoke choke point (a registered Go handler, or the echo stub —
+// see providers/gcp/cloudrun/invoke.go).
+//
+// ctx carries the re-entrant delivery depth (internal/recursionguard): a
+// service whose handler calls back into its own URL would otherwise recurse
+// unbounded, so once the depth carried on recursionguard.DepthHeader reaches
+// recursionguard.MaxDepth this invoke is refused with 508 Loop Detected
+// instead of running the handler again. A handler that itself calls another
+// (or its own) service URL is responsible for forwarding the incremented
+// depth on that outbound request via recursionguard.DepthHeader, the same
+// bridge Event Grid webhook delivery and the GCS/Pub/Sub trigger paths use to
+// carry the depth across an HTTP hop.
+func (h *Handler) serveServiceInvoke(w http.ResponseWriter, r *http.Request) {
+	host := requestHost(r.Host)
+
+	svc, err := h.resolveServiceByHost(r, host)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	depth := inboundDepth(r)
+	if depth >= recursionguard.MaxDepth {
+		writeError(w, http.StatusLoopDetected, "LOOP_DETECTED",
+			"recursive Cloud Run invocation limit reached for service "+svc.Name)
+
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusRequestEntityTooLarge, "INVALID_ARGUMENT", err.Error())
+		return
+	}
+
+	ctx := recursionguard.WithDepth(r.Context(), depth+1)
+
+	resp, err := h.cr.Invoke(ctx, svc.Name, driver.InvokeRequest{
+		Method:  r.Method,
+		Path:    r.URL.EscapedPath(),
+		Query:   r.URL.RawQuery,
+		Headers: map[string][]string(r.Header),
+		Body:    body,
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeInvokeResponse(w, resp)
+}
+
+// inboundDepth reads the re-entrant delivery depth carried on
+// recursionguard.DepthHeader, defaulting to 0 for the start of a new chain.
+func inboundDepth(r *http.Request) int {
+	d, err := strconv.Atoi(r.Header.Get(recursionguard.DepthHeader))
+	if err != nil || d < 0 {
+		return 0
+	}
+
+	return d
+}
+
+// resolveServiceByHost finds the stored service whose generated URL host
+// matches host, or a NotFound error when none does — the shape a real Cloud
+// Run host that addresses no deployed service would 404 as.
+func (h *Handler) resolveServiceByHost(r *http.Request, host string) (*driver.Service, error) {
+	svcs, err := h.cr.ListServices(r.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range svcs {
+		if uriHost(svcs[i].URI) == host {
+			return &svcs[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "no Cloud Run service found for host %q", host)
+}
+
+// uriHost extracts and lower-cases the host of a service's serving URL.
+func uriHost(uri string) string {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return ""
+	}
+
+	return strings.ToLower(u.Host)
+}
+
+// writeInvokeResponse writes a driver.InvokeResponse to w verbatim: status
+// (defaulting to 200), headers, and body — a real HTTP passthrough rather
+// than the JSON envelope every other Cloud Run Admin API response uses.
+func writeInvokeResponse(w http.ResponseWriter, resp *driver.InvokeResponse) {
+	for k, vals := range resp.Headers {
+		for _, v := range vals {
+			w.Header().Add(k, v)
+		}
+	}
+
+	status := resp.StatusCode
+	if status == 0 {
+		status = http.StatusOK
+	}
+
+	w.WriteHeader(status)
+	_, _ = w.Write(resp.Body)
+}

--- a/server/gcp/cloudrun/invoke_sdk_test.go
+++ b/server/gcp/cloudrun/invoke_sdk_test.go
@@ -1,0 +1,225 @@
+package cloudrun_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/api/option"
+	run "google.golang.org/api/run/v2"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/recursionguard"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+	crdriver "github.com/stackshy/cloudemu/v2/services/cloudrun/driver"
+)
+
+// invokeFixture boots a full in-process GCP server backed by the real
+// cloudemu Cloud Run driver, returns a run/v2 SDK client for the Admin API,
+// and exposes the concrete driver + httptest server so a test can register a
+// Go handler and dial the server directly for the invoke path.
+type invokeFixture struct {
+	run *run.Service
+	cr  crdriver.CloudRun
+	ts  *httptest.Server
+}
+
+func newInvokeFixture(t *testing.T) invokeFixture {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP(config.WithContainerEngine(nil))
+	ts := httptest.NewServer(gcpserver.New(gcpserver.Drivers{CloudRun: cloud.CloudRun}))
+	t.Cleanup(ts.Close)
+
+	sdk, err := run.NewService(context.Background(), option.WithEndpoint(ts.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("run.NewService: %v", err)
+	}
+
+	return invokeFixture{run: sdk, cr: cloud.CloudRun, ts: ts}
+}
+
+// createService deploys serviceID via the real run/v2 SDK and returns its
+// reconciled, generated *.run.app URI — exactly what a real caller would read
+// off the Create response to learn where to invoke the service.
+func (f invokeFixture) createService(t *testing.T, serviceID string) string {
+	t.Helper()
+
+	op, err := f.run.Projects.Locations.Services.Create(parent, sdkService()).
+		ServiceId(serviceID).Context(context.Background()).Do()
+	if err != nil {
+		t.Fatalf("Services.Create: %v", err)
+	}
+
+	var created run.GoogleCloudRunV2Service
+	decodeOpResponse(t, op, &created)
+
+	if created.Uri == "" {
+		t.Fatalf("created service has no uri: %+v", created)
+	}
+
+	return created.Uri
+}
+
+// doInvoke issues method/body against the service's generated URL: it dials
+// this fixture's real httptest server address (there is no real DNS for a
+// *.run.app host) while setting the Host header to the service URL's host, so
+// the wire server's Host-based routing resolves it — mirroring how a real
+// client (curl --resolve, a hosts-file override) would reach a locally run
+// emulator at a cloud-shaped URL. It takes no *testing.T so it is also safe to
+// call from a registered handler running on a server goroutine (t.Fatalf may
+// only be called from the goroutine running the test).
+func (f invokeFixture) doInvoke(
+	ctx context.Context, serviceURI, method, path string, body io.Reader, depth int,
+) (*http.Response, error) {
+	u, err := url.Parse(serviceURI)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, f.ts.URL+path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Host = u.Host
+
+	if depth > 0 {
+		req.Header.Set(recursionguard.DepthHeader, strconv.Itoa(depth))
+	}
+
+	return f.ts.Client().Do(req)
+}
+
+// invoke is doInvoke for use directly from the test goroutine, failing the
+// test on any transport error.
+func (f invokeFixture) invoke(t *testing.T, serviceURI, method, path string, body io.Reader, depth int) *http.Response {
+	t.Helper()
+
+	resp, err := f.doInvoke(context.Background(), serviceURI, method, path, body, depth)
+	if err != nil {
+		t.Fatalf("invoke %s %s: %v", method, path, err)
+	}
+
+	return resp
+}
+
+func TestServiceInvokeEchoesBody(t *testing.T) {
+	f := newInvokeFixture(t)
+	uri := f.createService(t, "echo")
+
+	resp := f.invoke(t, uri, http.MethodPost, "/anything", strings.NewReader(`{"hello":"world"}`), 0)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != `{"hello":"world"}` {
+		t.Fatalf("body = %q, want echo", got)
+	}
+}
+
+func TestServiceInvokeNoBodyReturnsGreeting(t *testing.T) {
+	f := newInvokeFixture(t)
+	uri := f.createService(t, "greet")
+
+	resp := f.invoke(t, uri, http.MethodGet, "/", nil, 0)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	got, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(got), "greet") {
+		t.Fatalf("body = %q, want a greeting naming the service", got)
+	}
+}
+
+func TestServiceInvokeRegisteredHandlerRuns(t *testing.T) {
+	f := newInvokeFixture(t)
+	uri := f.createService(t, "handled")
+
+	var gotMethod, gotPath string
+
+	f.cr.RegisterHandler("handled", func(_ context.Context, req crdriver.InvokeRequest) (crdriver.InvokeResponse, error) {
+		gotMethod, gotPath = req.Method, req.Path
+
+		return crdriver.InvokeResponse{StatusCode: http.StatusCreated, Body: []byte("handled it")}, nil
+	})
+
+	resp := f.invoke(t, uri, http.MethodPut, "/items/42", strings.NewReader("payload"), 0)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", resp.StatusCode)
+	}
+
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != "handled it" {
+		t.Fatalf("body = %q", got)
+	}
+
+	if gotMethod != http.MethodPut || gotPath != "/items/42" {
+		t.Fatalf("handler saw method=%q path=%q", gotMethod, gotPath)
+	}
+}
+
+func TestServiceInvokeUnknownHostNotFound(t *testing.T) {
+	f := newInvokeFixture(t)
+
+	resp := f.invoke(t, "https://nope-0000000000.us-central1.run.app", http.MethodGet, "/", nil, 0)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// TestServiceInvokeSelfCallTerminatesAtRecursionGuard covers a service whose
+// handler calls back into its own URL: left unbounded this recurses
+// synchronously forever, so it must terminate at recursionguard.MaxDepth
+// (mirroring AWS Lambda's own recursive-loop detection) rather than hanging
+// or overflowing the goroutine stack.
+func TestServiceInvokeSelfCallTerminatesAtRecursionGuard(t *testing.T) {
+	f := newInvokeFixture(t)
+	uri := f.createService(t, "loopy")
+
+	var invocations atomic.Int32
+
+	f.cr.RegisterHandler("loopy", func(ctx context.Context, _ crdriver.InvokeRequest) (crdriver.InvokeResponse, error) {
+		invocations.Add(1)
+
+		depth := recursionguard.Depth(ctx)
+
+		resp, err := f.doInvoke(ctx, uri, http.MethodGet, "/", nil, depth)
+		if err != nil {
+			return crdriver.InvokeResponse{}, err
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+
+		return crdriver.InvokeResponse{StatusCode: resp.StatusCode, Body: body}, nil
+	})
+
+	resp := f.invoke(t, uri, http.MethodGet, "/", nil, 0)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusLoopDetected {
+		t.Fatalf("outermost status = %d, want 508 (the innermost hop that hit the guard)", resp.StatusCode)
+	}
+
+	if got := invocations.Load(); got != int32(recursionguard.MaxDepth) {
+		t.Fatalf("handler ran %d times, want exactly recursionguard.MaxDepth (%d)", got, recursionguard.MaxDepth)
+	}
+}

--- a/services/cloudrun/driver/driver.go
+++ b/services/cloudrun/driver/driver.go
@@ -74,6 +74,47 @@ type CloudRun interface {
 
 	// DeleteRevision removes a single revision of a service.
 	DeleteRevision(ctx context.Context, name string) error
+
+	// Invoke executes the named service (bare id or fully qualified name)
+	// against req and returns its HTTP response. Cloud Run services run
+	// container images, which CloudEmu has no runtime for, so Invoke runs the
+	// Go handler registered via RegisterHandler when one is present; otherwise
+	// it returns a successful canned/echo stub response, mirroring how the
+	// Cloud Functions and Lambda mocks answer an Invoke with no registered
+	// handler.
+	Invoke(ctx context.Context, name string, req InvokeRequest) (*InvokeResponse, error)
+
+	// RegisterHandler plugs a Go handler in for the named service (bare id),
+	// standing in for its container image so Invoke actually runs code instead
+	// of returning the echo stub. Registering nil clears a previously
+	// registered handler.
+	RegisterHandler(name string, handler HandlerFunc)
+}
+
+// HandlerFunc is a Go handler standing in for a Cloud Run service's container
+// image. Cloud Run is HTTP request/response, not an event/payload contract
+// like Lambda or Cloud Functions, so the handler receives the inbound HTTP
+// request shape and returns the HTTP response shape directly.
+type HandlerFunc func(ctx context.Context, req InvokeRequest) (InvokeResponse, error)
+
+// InvokeRequest is the portable, transport-neutral shape of the HTTP request
+// delivered to a Cloud Run service. Headers uses canonical HTTP header casing
+// (as produced by Go's net/http.Header) since the wire handler builds it
+// directly from the inbound *http.Request.
+type InvokeRequest struct {
+	Method  string
+	Path    string
+	Query   string // raw query string, without the leading "?"
+	Headers map[string][]string
+	Body    []byte
+}
+
+// InvokeResponse is the HTTP response a Cloud Run service invocation returns.
+// A zero StatusCode is treated as 200 by the wire handler.
+type InvokeResponse struct {
+	StatusCode int
+	Headers    map[string][]string
+	Body       []byte
 }
 
 // JobConfig is the input to CreateJob / UpdateJob — the subset of the Cloud Run


### PR DESCRIPTION
## Summary

Cloud Run services already got a stable `*.run.app` URI on `CreateService`, but there was no way to actually invoke one — the wire server (`server/gcp/cloudrun`) only served the Admin API v2 surface (create/get/list/patch/delete for jobs, services, revisions). This adds an invoke path: an HTTP request whose `Host` matches a deployed service's generated URL is routed to that service and executed, independent of the `/v2/projects/...` Admin API path.

## How the service's "code" is modeled

Cloud Run runs arbitrary container images. CloudEmu's `ContainerEngine` seam only supports run-to-completion workloads (used by Cloud Run Jobs) with no HTTP request/response invoke capability, and there was no registered-handler seam for Cloud Run services (confirmed via `providers/gcp/eventarc/dispatch.go`, whose own comment already noted "Cloud Run has no in-process invoke seam (it models CRUD only)"). So `Invoke` follows the same pattern already used by Cloud Functions and Lambda when no engine is wired:

- `RegisterHandler(name string, handler driver.HandlerFunc)` lets library/test code plug in a Go function standing in for the container image.
- With no handler registered, `Invoke` returns a canned/echo stub: the request body echoed back with its Content-Type preserved (when the caller sent one), or a short greeting naming the service (when it didn't) — mirroring the Cloud Functions/Lambda no-handler echo stub exactly.

`Invoke`/`RegisterHandler` were added directly to `driver.CloudRun` rather than through a type-asserted capability, since that driver already has a single implementation (GCP-only, unlike the shared `Serverless` driver AWS/Azure/GCP all implement) — the type-assertion indirection AWS Function URLs uses exists specifically to keep AWS-only capabilities out of a genuinely cross-cloud interface, which doesn't apply here.

## What's added

- `services/cloudrun/driver`: `HandlerFunc`, `InvokeRequest`/`InvokeResponse` (transport-neutral, no `net/http` dependency), and `Invoke`/`RegisterHandler` on `CloudRun`.
- `providers/gcp/cloudrun/invoke.go`: the `Mock` implementation — registered handler or echo stub.
- `server/gcp/cloudrun/invoke.go`: Host-based routing (`*.run.app` marker, mirroring the Lambda Function URL `.lambda-url.` approach from #1004), resolving the service by matching the request Host against each stored service's URI, then calling `Invoke` with the translated HTTP request/response.
- Recursion guard: a self-invoking service (its handler calls back into its own URL) is bounded by `internal/recursionguard` — the depth carried on `X-Cloudemu-Delivery-Depth` is checked on each inbound invoke, refusing with `508 Loop Detected` once it reaches `MaxDepth`; a handler that calls another/its own service URL forwards the incremented depth on that outbound request, the same bridge already used by Event Grid webhook delivery and the GCS/Pub/Sub trigger paths.
- `docs/coverage`: regenerated for the two new `driver.CloudRun` operations.

## Testing

- `providers/gcp/cloudrun/invoke_test.go`: unit coverage for the echo stub, the greeting fallback, registered handler dispatch, handler errors, unknown service, and clearing a handler.
- `server/gcp/cloudrun/invoke_sdk_test.go`: real-user e2e — boots the full GCP server, creates a service via the real `run/v2` SDK, reads its URI off the response, and dials the running server with the Host header set to that URI's host (there's no real DNS for a `*.run.app` host, so this is the same approach a real client would use against a locally run emulator). Covers echo, greeting, registered handler, unknown-host 404, and the self-call recursion guard (asserts the handler ran exactly `MaxDepth` times and the response terminates with 508), run under `-race`.

## Deferred

- Per-revision/tagged URL invoke (`{tag}---{service}-{hash}...run.app`) — only the primary service URL is wired.
- Cloud Run Jobs have no equivalent invoke surface (they're run-to-completion via `RunJob`, already covered by `ContainerEngine`).
- Real container execution beyond the registered-handler/stub model — would require wiring an HTTP-capable engine, which doesn't exist yet (`ContainerEngine` only supports run-to-completion).