### PR TITLE
feat(lambda): layer versions and layer attachment

### DIFF
--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -85,8 +85,22 @@ type aliasData struct {
 }
 
 type layerData struct {
-	versions *memstore.Store[*driver.LayerVersion]
-	nextVer  int
+	// mu guards nextVer (the monotonic version counter's read-modify-write) and
+	// permissions, the two pieces of layerData mutated in place after the entry
+	// is stored — versions is itself a memstore.Store and is safe on its own.
+	mu          sync.Mutex
+	versions    *memstore.Store[*driver.LayerVersion]
+	nextVer     int
+	permissions map[int]*layerVersionPolicy
+}
+
+// layerVersionPolicy is one layer version's resource-based policy: the set of
+// AddLayerVersionPermission statements keyed by StatementId, plus the revision
+// id that changes on every add/remove (AWS's optimistic-concurrency guard for
+// RevisionId-conditioned Add/RemoveLayerVersionPermission calls).
+type layerVersionPolicy struct {
+	statements map[string]driver.LayerPermissionStatement
+	revisionID string
 }
 
 type funcData struct {

--- a/providers/aws/lambda/lambda_test.go
+++ b/providers/aws/lambda/lambda_test.go
@@ -770,6 +770,104 @@ func TestDeleteLayerVersion(t *testing.T) {
 	})
 }
 
+// TestDeleteLayerVersionDoesNotRenumber pins that a deleted layer version's
+// number is never reused: the monotonic counter keeps incrementing regardless
+// of deletions, matching real Lambda.
+func TestDeleteLayerVersionDoesNotRenumber(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, _ = m.PublishLayerVersion(ctx, driver.LayerConfig{Name: "layer", Content: []byte("v1")})
+	v2, _ := m.PublishLayerVersion(ctx, driver.LayerConfig{Name: "layer", Content: []byte("v2")})
+	assertEqual(t, 2, v2.Version)
+
+	requireNoError(t, m.DeleteLayerVersion(ctx, "layer", 1))
+
+	versions, err := m.ListLayerVersions(ctx, "layer")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(versions))
+	assertEqual(t, 2, versions[0].Version)
+
+	v3, err := m.PublishLayerVersion(ctx, driver.LayerConfig{Name: "layer", Content: []byte("v3")})
+	requireNoError(t, err)
+	assertEqual(t, 3, v3.Version)
+}
+
+// TestPublishLayerVersionMetadata pins that CompatibleArchitectures and
+// LicenseInfo round-trip through PublishLayerVersion/GetLayerVersion.
+func TestPublishLayerVersionMetadata(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	published, err := m.PublishLayerVersion(ctx, driver.LayerConfig{
+		Name:                    "my-layer",
+		Content:                 []byte("v1"),
+		CompatibleRuntimes:      []string{"python3.9"},
+		CompatibleArchitectures: []string{"arm64"},
+		LicenseInfo:             "MIT",
+	})
+	requireNoError(t, err)
+	assertEqual(t, "MIT", published.LicenseInfo)
+	assertEqual(t, 1, len(published.CompatibleArchitectures))
+	assertEqual(t, "arm64", published.CompatibleArchitectures[0])
+
+	got, err := m.GetLayerVersion(ctx, "my-layer", 1)
+	requireNoError(t, err)
+	assertEqual(t, "MIT", got.LicenseInfo)
+	assertEqual(t, "arm64", got.CompatibleArchitectures[0])
+}
+
+// TestPublishLayerVersionConcurrentRaceFree hammers PublishLayerVersion for a
+// single new layer name from many goroutines. Before the SetIfAbsent +
+// per-layer mutex fix, two goroutines racing the first publish could both see
+// the layer as absent and independently create a *layerData, losing whichever
+// one wrote second and letting the version counter restart; concurrent
+// nextVer++ on the surviving layerData could also duplicate a version number.
+// Every published version must be unique and the count must match the number
+// of successful publishes. Must run clean under `go test -race`.
+func TestPublishLayerVersionConcurrentRaceFree(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	const workers = 20
+
+	var wg sync.WaitGroup
+
+	versions := make([]int, workers)
+
+	wg.Add(workers)
+
+	for i := 0; i < workers; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			lv, err := m.PublishLayerVersion(ctx, driver.LayerConfig{Name: "shared-layer", Content: []byte("v")})
+			if err != nil {
+				return
+			}
+
+			versions[i] = lv.Version
+		}(i)
+	}
+
+	wg.Wait()
+
+	seen := make(map[int]bool, workers)
+	for _, v := range versions {
+		if seen[v] {
+			t.Fatalf("duplicate published version %d", v)
+		}
+
+		seen[v] = true
+	}
+
+	assertEqual(t, workers, len(seen))
+
+	all, err := m.ListLayerVersions(ctx, "shared-layer")
+	requireNoError(t, err)
+	assertEqual(t, workers, len(all))
+}
+
 func TestListLayers(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/providers/aws/lambda/layer_permissions.go
+++ b/providers/aws/lambda/layer_permissions.go
@@ -1,0 +1,200 @@
+package lambda
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// resolveLayerVersionARN resolves the layer/version a permission operation
+// targets, returning the version's ARN (the policy Resource) or a NotFound
+// error matching real Lambda's behavior of rejecting a permission call against
+// a layer or version that does not exist.
+func (m *Mock) resolveLayerVersionARN(name string, version int) (string, error) {
+	ld, ok := m.layers.Get(name)
+	if !ok {
+		return "", cerrors.Newf(cerrors.NotFound, "layer %s not found", name)
+	}
+
+	lv, ok := ld.versions.Get(strconv.Itoa(version))
+	if !ok {
+		return "", cerrors.Newf(cerrors.NotFound, "layer %s version %d not found", name, version)
+	}
+
+	return lv.ARN, nil
+}
+
+// validateLayerPermissionStatement checks the required fields of an
+// AddLayerVersionPermission statement, matching the fields real Lambda marks
+// required on the operation.
+func validateLayerPermissionStatement(stmt driver.LayerPermissionStatement) error {
+	if stmt.StatementID == "" {
+		return cerrors.New(cerrors.InvalidArgument, "StatementId is required")
+	}
+
+	if stmt.Action == "" {
+		return cerrors.New(cerrors.InvalidArgument, "Action is required")
+	}
+
+	if stmt.Principal == "" {
+		return cerrors.New(cerrors.InvalidArgument, "Principal is required")
+	}
+
+	return nil
+}
+
+// AddLayerVersionPermission adds a statement to a layer version's resource-based
+// policy, granting another account (or all accounts in an organization, or all
+// AWS accounts) permission to use the layer version. ifMatchRevisionID, when
+// non-empty, must match the policy's current RevisionId or the call fails
+// (AWS's optimistic-concurrency guard against modifying a policy that changed
+// since it was last read). Returns the added statement rendered as the JSON
+// document AWS echoes back, and the policy's new RevisionId.
+//
+// Real Lambda enforces layer version permissions on GetLayerVersion; this
+// emulator accepts any credentials (see server/README auth note), so the
+// policy is stored and returned but never evaluated to deny a caller.
+func (m *Mock) AddLayerVersionPermission(
+	_ context.Context, name string, version int, stmt driver.LayerPermissionStatement, ifMatchRevisionID string,
+) (statementJSON, revisionID string, err error) {
+	if verr := validateLayerPermissionStatement(stmt); verr != nil {
+		return "", "", verr
+	}
+
+	resource, err := m.resolveLayerVersionARN(name, version)
+	if err != nil {
+		return "", "", err
+	}
+
+	ld, _ := m.layers.Get(name)
+
+	ld.mu.Lock()
+	defer ld.mu.Unlock()
+
+	pol := ld.permissions[version]
+	if pol == nil {
+		pol = &layerVersionPolicy{statements: make(map[string]driver.LayerPermissionStatement)}
+	}
+
+	if ifMatchRevisionID != "" && pol.revisionID != ifMatchRevisionID {
+		return "", "", cerrors.New(cerrors.FailedPrecondition,
+			"the RevisionId provided does not match the latest RevisionId for the layer version. "+
+				"Call the GetLayerVersionPolicy API to retrieve the latest RevisionId for your resource")
+	}
+
+	if _, exists := pol.statements[stmt.StatementID]; exists {
+		return "", "", cerrors.Newf(cerrors.AlreadyExists, "statement %s already exists", stmt.StatementID)
+	}
+
+	pol.statements[stmt.StatementID] = stmt
+	pol.revisionID = newRevisionID()
+
+	if ld.permissions == nil {
+		ld.permissions = make(map[int]*layerVersionPolicy)
+	}
+
+	ld.permissions[version] = pol
+
+	doc, err := json.Marshal(layerStatementJSON(stmt, resource))
+	if err != nil {
+		return "", "", err
+	}
+
+	return string(doc), pol.revisionID, nil
+}
+
+// RemoveLayerVersionPermission drops a statement from a layer version's
+// resource-based policy. ifMatchRevisionID, when non-empty, must match the
+// policy's current RevisionId or the call fails.
+func (m *Mock) RemoveLayerVersionPermission(_ context.Context, name string, version int, statementID, ifMatchRevisionID string) error {
+	ld, ok := m.layers.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "layer %s not found", name)
+	}
+
+	ld.mu.Lock()
+	defer ld.mu.Unlock()
+
+	pol := ld.permissions[version]
+	if pol == nil {
+		return cerrors.Newf(cerrors.NotFound, "no policy for layer %s version %d", name, version)
+	}
+
+	if _, exists := pol.statements[statementID]; !exists {
+		return cerrors.Newf(cerrors.NotFound, "statement %s not found", statementID)
+	}
+
+	if ifMatchRevisionID != "" && pol.revisionID != ifMatchRevisionID {
+		return cerrors.New(cerrors.FailedPrecondition,
+			"the RevisionId provided does not match the latest RevisionId for the layer version. "+
+				"Call the GetLayerVersionPolicy API to retrieve the latest RevisionId for your resource")
+	}
+
+	delete(pol.statements, statementID)
+	pol.revisionID = newRevisionID()
+
+	return nil
+}
+
+// GetLayerVersionPolicy returns a layer version's resource-based policy as a
+// JSON document (the shape the AWS SDK expects: an IAM policy with Sid/
+// Principal/Action/Resource per statement), plus its current RevisionId.
+// Returns NotFound when the layer version has no policy statements, matching
+// real Lambda.
+func (m *Mock) GetLayerVersionPolicy(_ context.Context, name string, version int) (policy, revisionID string, err error) {
+	resource, err := m.resolveLayerVersionARN(name, version)
+	if err != nil {
+		return "", "", err
+	}
+
+	ld, _ := m.layers.Get(name)
+
+	ld.mu.Lock()
+	defer ld.mu.Unlock()
+
+	pol := ld.permissions[version]
+	if pol == nil || len(pol.statements) == 0 {
+		return "", "", cerrors.Newf(cerrors.NotFound, "no policy for layer %s version %d", name, version)
+	}
+
+	statements := make([]map[string]any, 0, len(pol.statements))
+	for _, s := range pol.statements {
+		statements = append(statements, layerStatementJSON(s, resource))
+	}
+
+	doc, err := json.Marshal(map[string]any{
+		"Version":   "2012-10-17",
+		"Id":        "default",
+		"Statement": statements,
+	})
+	if err != nil {
+		return "", "", err
+	}
+
+	return string(doc), pol.revisionID, nil
+}
+
+// layerStatementJSON renders one layer-version-policy statement in the IAM
+// shape AWS returns. An OrganizationId scopes the grant with a
+// StringEquals/aws:PrincipalOrgID condition, matching AddLayerVersionPermission
+// semantics.
+func layerStatementJSON(s driver.LayerPermissionStatement, resource string) map[string]any {
+	stmt := map[string]any{
+		"Sid":       s.StatementID,
+		"Effect":    "Allow",
+		"Principal": principalJSON(s.Principal),
+		"Action":    s.Action,
+		"Resource":  resource,
+	}
+
+	if s.OrganizationID != "" {
+		stmt["Condition"] = map[string]any{
+			"StringEquals": map[string]string{"aws:PrincipalOrgID": s.OrganizationID},
+		}
+	}
+
+	return stmt
+}

--- a/providers/aws/lambda/layer_permissions_test.go
+++ b/providers/aws/lambda/layer_permissions_test.go
@@ -1,0 +1,247 @@
+package lambda
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+func publishTestLayer(t *testing.T, m *Mock) *driver.LayerVersion {
+	t.Helper()
+
+	lv, err := m.PublishLayerVersion(context.Background(), driver.LayerConfig{
+		Name: "my-layer", Content: []byte("v1"),
+	})
+	requireNoError(t, err)
+
+	return lv
+}
+
+func TestAddLayerVersionPermission(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	lv := publishTestLayer(t, m)
+
+	t.Run("success", func(t *testing.T) {
+		stmtJSON, revisionID, err := m.AddLayerVersionPermission(ctx, "my-layer", lv.Version, driver.LayerPermissionStatement{
+			StatementID: "xaccount", Action: "lambda:GetLayerVersion", Principal: "111111111111",
+		}, "")
+		requireNoError(t, err)
+		assertNotEmpty(t, revisionID)
+
+		if !strings.Contains(stmtJSON, "xaccount") || !strings.Contains(stmtJSON, "lambda:GetLayerVersion") {
+			t.Fatalf("statement JSON = %q, want it to carry the Sid and Action", stmtJSON)
+		}
+	})
+
+	t.Run("duplicate statement id", func(t *testing.T) {
+		_, _, err := m.AddLayerVersionPermission(ctx, "my-layer", lv.Version, driver.LayerPermissionStatement{
+			StatementID: "xaccount", Action: "lambda:GetLayerVersion", Principal: "222222222222",
+		}, "")
+		assertError(t, err, true)
+	})
+
+	t.Run("missing statement id", func(t *testing.T) {
+		_, _, err := m.AddLayerVersionPermission(ctx, "my-layer", lv.Version, driver.LayerPermissionStatement{
+			Action: "lambda:GetLayerVersion", Principal: "111111111111",
+		}, "")
+		assertError(t, err, true)
+	})
+
+	t.Run("missing action", func(t *testing.T) {
+		_, _, err := m.AddLayerVersionPermission(ctx, "my-layer", lv.Version, driver.LayerPermissionStatement{
+			StatementID: "s2", Principal: "111111111111",
+		}, "")
+		assertError(t, err, true)
+	})
+
+	t.Run("missing principal", func(t *testing.T) {
+		_, _, err := m.AddLayerVersionPermission(ctx, "my-layer", lv.Version, driver.LayerPermissionStatement{
+			StatementID: "s3", Action: "lambda:GetLayerVersion",
+		}, "")
+		assertError(t, err, true)
+	})
+
+	t.Run("layer not found", func(t *testing.T) {
+		_, _, err := m.AddLayerVersionPermission(ctx, "nope", 1, driver.LayerPermissionStatement{
+			StatementID: "s4", Action: "lambda:GetLayerVersion", Principal: "111111111111",
+		}, "")
+		assertError(t, err, true)
+	})
+
+	t.Run("version not found", func(t *testing.T) {
+		_, _, err := m.AddLayerVersionPermission(ctx, "my-layer", 99, driver.LayerPermissionStatement{
+			StatementID: "s5", Action: "lambda:GetLayerVersion", Principal: "111111111111",
+		}, "")
+		assertError(t, err, true)
+	})
+
+	t.Run("revision mismatch", func(t *testing.T) {
+		_, _, err := m.AddLayerVersionPermission(ctx, "my-layer", lv.Version, driver.LayerPermissionStatement{
+			StatementID: "s6", Action: "lambda:GetLayerVersion", Principal: "111111111111",
+		}, "not-the-real-revision")
+		assertError(t, err, true)
+	})
+}
+
+func TestGetLayerVersionPolicy(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	lv := publishTestLayer(t, m)
+
+	t.Run("no policy", func(t *testing.T) {
+		_, _, err := m.GetLayerVersionPolicy(ctx, "my-layer", lv.Version)
+		assertError(t, err, true)
+	})
+
+	_, addedRevision, err := m.AddLayerVersionPermission(ctx, "my-layer", lv.Version, driver.LayerPermissionStatement{
+		StatementID: "public", Action: "lambda:GetLayerVersion", Principal: "*", OrganizationID: "o-example",
+	}, "")
+	requireNoError(t, err)
+
+	t.Run("returns the policy document", func(t *testing.T) {
+		policy, revisionID, gerr := m.GetLayerVersionPolicy(ctx, "my-layer", lv.Version)
+		requireNoError(t, gerr)
+		assertEqual(t, addedRevision, revisionID)
+
+		for _, want := range []string{"public", "PrincipalOrgID", "o-example", "2012-10-17"} {
+			if !strings.Contains(policy, want) {
+				t.Fatalf("policy = %q, want it to contain %q", policy, want)
+			}
+		}
+	})
+
+	t.Run("layer not found", func(t *testing.T) {
+		_, _, err := m.GetLayerVersionPolicy(ctx, "nope", 1)
+		assertError(t, err, true)
+	})
+
+	t.Run("version not found", func(t *testing.T) {
+		_, _, err := m.GetLayerVersionPolicy(ctx, "my-layer", 99)
+		assertError(t, err, true)
+	})
+}
+
+func TestRemoveLayerVersionPermission(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	lv := publishTestLayer(t, m)
+
+	_, revisionID, err := m.AddLayerVersionPermission(ctx, "my-layer", lv.Version, driver.LayerPermissionStatement{
+		StatementID: "xaccount", Action: "lambda:GetLayerVersion", Principal: "111111111111",
+	}, "")
+	requireNoError(t, err)
+
+	t.Run("revision mismatch", func(t *testing.T) {
+		err := m.RemoveLayerVersionPermission(ctx, "my-layer", lv.Version, "xaccount", "stale-revision")
+		assertError(t, err, true)
+	})
+
+	t.Run("statement not found", func(t *testing.T) {
+		err := m.RemoveLayerVersionPermission(ctx, "my-layer", lv.Version, "nope", "")
+		assertError(t, err, true)
+	})
+
+	t.Run("layer not found", func(t *testing.T) {
+		err := m.RemoveLayerVersionPermission(ctx, "nope", 1, "xaccount", "")
+		assertError(t, err, true)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		err := m.RemoveLayerVersionPermission(ctx, "my-layer", lv.Version, "xaccount", revisionID)
+		requireNoError(t, err)
+
+		_, _, err = m.GetLayerVersionPolicy(ctx, "my-layer", lv.Version)
+		assertError(t, err, true) // no statements left -> no policy
+	})
+}
+
+// TestLayerVersionDeleteDropsPermissions pins that DeleteLayerVersion also
+// drops the deleted version's resource policy, so a future GetLayerVersionPolicy
+// on that version number correctly reports NotFound rather than a stale policy.
+func TestLayerVersionDeleteDropsPermissions(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	lv := publishTestLayer(t, m)
+
+	_, _, err := m.AddLayerVersionPermission(ctx, "my-layer", lv.Version, driver.LayerPermissionStatement{
+		StatementID: "s", Action: "lambda:GetLayerVersion", Principal: "111111111111",
+	}, "")
+	requireNoError(t, err)
+
+	requireNoError(t, m.DeleteLayerVersion(ctx, "my-layer", lv.Version))
+
+	_, _, err = m.GetLayerVersionPolicy(ctx, "my-layer", lv.Version)
+	assertError(t, err, true)
+}
+
+// TestAddLayerVersionPermissionCOWIndependence mutates the LayerPermissionStatement
+// passed into AddLayerVersionPermission after the call returns, and independently
+// mutates the returned statement JSON string's backing bytes are not shared —
+// proving the stored statement is a value copy, not an alias of caller state.
+func TestAddLayerVersionPermissionCOWIndependence(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	lv := publishTestLayer(t, m)
+
+	stmt := driver.LayerPermissionStatement{StatementID: "s", Action: "lambda:GetLayerVersion", Principal: "111111111111"}
+
+	_, _, err := m.AddLayerVersionPermission(ctx, "my-layer", lv.Version, stmt, "")
+	requireNoError(t, err)
+
+	// Mutating the local stmt after the call must not affect the stored policy.
+	stmt.Principal = "mutated"
+
+	policy, _, err := m.GetLayerVersionPolicy(ctx, "my-layer", lv.Version)
+	requireNoError(t, err)
+
+	if strings.Contains(policy, "mutated") {
+		t.Fatalf("stored policy aliases caller's statement: %q", policy)
+	}
+}
+
+// TestLayerVersionPermissionConcurrentRaceFree hammers a single layer version's
+// resource policy with concurrent Add/Get/RemoveLayerVersionPermission calls.
+// Every one of these paths reads or mutates layerData.permissions under
+// layerData.mu; without it the -race detector flags a data race. Must run clean
+// under `go test -race`.
+func TestLayerVersionPermissionConcurrentRaceFree(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	lv := publishTestLayer(t, m)
+
+	const (
+		workers    = 8
+		iterations = 30
+	)
+
+	var wg sync.WaitGroup
+
+	run := func(fn func()) {
+		defer wg.Done()
+
+		for i := 0; i < iterations; i++ {
+			fn()
+		}
+	}
+
+	wg.Add(4 * workers)
+
+	for w := 0; w < workers; w++ {
+		go run(func() {
+			_, _, _ = m.AddLayerVersionPermission(ctx, "my-layer", lv.Version, driver.LayerPermissionStatement{
+				StatementID: "concurrent", Action: "lambda:GetLayerVersion", Principal: "111111111111",
+			}, "")
+		})
+		go run(func() {
+			_ = m.RemoveLayerVersionPermission(ctx, "my-layer", lv.Version, "concurrent", "")
+		})
+		go run(func() { _, _, _ = m.GetLayerVersionPolicy(ctx, "my-layer", lv.Version) })
+		go run(func() { _, _ = m.ListLayerVersions(ctx, "my-layer") })
+	}
+
+	wg.Wait()
+}

--- a/providers/aws/lambda/layers.go
+++ b/providers/aws/lambda/layers.go
@@ -15,21 +15,31 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
 )
 
-// PublishLayerVersion publishes a new version of a layer.
+// PublishLayerVersion publishes a new version of a layer. Version numbers are
+// monotonically increasing per layer name and are never reused — even after
+// DeleteLayerVersion removes the highest version, the next publish continues
+// from where the counter left off.
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) PublishLayerVersion(ctx context.Context, cfg driver.LayerConfig) (*driver.LayerVersion, error) {
 	ld, ok := m.layers.Get(cfg.Name)
 	if !ok {
-		ld = &layerData{
-			versions: memstore.New[*driver.LayerVersion](),
-			nextVer:  initialVersion,
+		newLd := &layerData{versions: memstore.New[*driver.LayerVersion](), nextVer: initialVersion}
+		// Two concurrent first-publish calls for the same new layer name would
+		// otherwise both see !ok and race to Set, losing whichever layerData (and
+		// its independent version counter) writes second. SetIfAbsent makes the
+		// creation atomic; the loser re-fetches the winner's layerData.
+		if m.layers.SetIfAbsent(cfg.Name, newLd) {
+			ld = newLd
+		} else {
+			ld, _ = m.layers.Get(cfg.Name)
 		}
-		m.layers.Set(cfg.Name, ld)
 	}
 
+	ld.mu.Lock()
 	ver := ld.nextVer
 	ld.nextVer++
+	ld.mu.Unlock()
 
 	hash := sha256.Sum256(cfg.Content)
 	shaStr := fmt.Sprintf("%x", hash)
@@ -40,14 +50,16 @@ func (m *Mock) PublishLayerVersion(ctx context.Context, cfg driver.LayerConfig) 
 	)
 
 	lv := &driver.LayerVersion{
-		Name:               cfg.Name,
-		Version:            ver,
-		Description:        cfg.Description,
-		ContentSHA256:      shaStr,
-		ContentSize:        int64(len(cfg.Content)),
-		CompatibleRuntimes: cfg.CompatibleRuntimes,
-		CreatedAt:          m.opts.Clock.Now().UTC().Format(time.RFC3339),
-		ARN:                arn,
+		Name:                    cfg.Name,
+		Version:                 ver,
+		Description:             cfg.Description,
+		ContentSHA256:           shaStr,
+		ContentSize:             int64(len(cfg.Content)),
+		CompatibleRuntimes:      cfg.CompatibleRuntimes,
+		CompatibleArchitectures: cfg.CompatibleArchitectures,
+		LicenseInfo:             cfg.LicenseInfo,
+		CreatedAt:               m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		ARN:                     arn,
 	}
 
 	ld.versions.Set(strconv.Itoa(ver), lv)
@@ -109,6 +121,13 @@ func (m *Mock) DeleteLayerVersion(_ context.Context, name string, version int) e
 	}
 
 	ld.versions.Delete(verStr)
+
+	// Drop the deleted version's resource policy along with it — a future
+	// publish never reuses this version number, so the policy can never be
+	// referenced again.
+	ld.mu.Lock()
+	delete(ld.permissions, version)
+	ld.mu.Unlock()
 
 	return nil
 }

--- a/providers/aws/lambda/snapshot.go
+++ b/providers/aws/lambda/snapshot.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
+	"strconv"
 
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/internal/snapshot"
@@ -70,10 +72,19 @@ type versionSnapshot struct {
 }
 
 // layerSnapshot mirrors layerData; its version store holds a fully-exported
-// *driver.LayerVersion and round-trips through the generic helper.
+// *driver.LayerVersion and round-trips through the generic helper. Permissions
+// mirrors the layerVersionPolicy map, keyed by version number (as a string,
+// since JSON object keys must be strings).
 type layerSnapshot struct {
-	Versions json.RawMessage `json:"versions,omitempty"`
-	NextVer  int             `json:"nextVer,omitempty"`
+	Versions    json.RawMessage                        `json:"versions,omitempty"`
+	NextVer     int                                    `json:"nextVer,omitempty"`
+	Permissions map[string]*layerVersionPolicySnapshot `json:"permissions,omitempty"`
+}
+
+// layerVersionPolicySnapshot mirrors layerVersionPolicy.
+type layerVersionPolicySnapshot struct {
+	Statements map[string]driver.LayerPermissionStatement `json:"statements,omitempty"`
+	RevisionID string                                     `json:"revisionId,omitempty"`
 }
 
 // Snapshot captures the mock's entire state as JSON. includeAssets is unused —
@@ -104,7 +115,9 @@ func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
 				return nil, fmt.Errorf("lambda: snapshot layer versions: %w", err)
 			}
 
-			snap.Layers[name] = &layerSnapshot{Versions: vers, NextVer: ld.nextVer}
+			snap.Layers[name] = &layerSnapshot{
+				Versions: vers, NextVer: ld.nextVer, Permissions: snapshotLayerPermissions(ld),
+			}
 		}
 	}
 
@@ -116,6 +129,27 @@ func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
 	snap.Mappings = mappings
 
 	return json.Marshal(snap)
+}
+
+// snapshotLayerPermissions captures ld's per-version resource policies, keyed
+// by version number as a string.
+func snapshotLayerPermissions(ld *layerData) map[string]*layerVersionPolicySnapshot {
+	ld.mu.Lock()
+	defer ld.mu.Unlock()
+
+	if len(ld.permissions) == 0 {
+		return nil
+	}
+
+	out := make(map[string]*layerVersionPolicySnapshot, len(ld.permissions))
+	for ver, pol := range ld.permissions {
+		out[strconv.Itoa(ver)] = &layerVersionPolicySnapshot{
+			Statements: maps.Clone(pol.statements),
+			RevisionID: pol.revisionID,
+		}
+	}
+
+	return out
 }
 
 func snapshotFunc(fd *funcData) *funcSnapshot {
@@ -157,11 +191,9 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 	}
 
 	for name, ls := range snap.Layers {
-		ld := &layerData{versions: memstore.New[*driver.LayerVersion](), nextVer: ls.NextVer}
-		if len(ls.Versions) > 0 {
-			if err := ld.versions.LoadSnapshot(ls.Versions); err != nil {
-				return fmt.Errorf("lambda: restore layer versions: %w", err)
-			}
+		ld, err := restoreLayerData(ls)
+		if err != nil {
+			return err
 		}
 
 		m.layers.Set(name, ld)
@@ -174,6 +206,37 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 	}
 
 	return nil
+}
+
+// restoreLayerData rebuilds one layer's *layerData from its snapshot: the
+// version store, the monotonic version counter, and any per-version resource
+// policies (skipping a policy entry whose key isn't a valid version number —
+// snapshot JSON tampered with out of band, never produced by Snapshot itself).
+func restoreLayerData(ls *layerSnapshot) (*layerData, error) {
+	ld := &layerData{versions: memstore.New[*driver.LayerVersion](), nextVer: ls.NextVer}
+
+	if len(ls.Versions) > 0 {
+		if err := ld.versions.LoadSnapshot(ls.Versions); err != nil {
+			return nil, fmt.Errorf("lambda: restore layer versions: %w", err)
+		}
+	}
+
+	if len(ls.Permissions) == 0 {
+		return ld, nil
+	}
+
+	ld.permissions = make(map[int]*layerVersionPolicy, len(ls.Permissions))
+
+	for verStr, ps := range ls.Permissions {
+		ver, err := strconv.Atoi(verStr)
+		if err != nil {
+			continue
+		}
+
+		ld.permissions[ver] = &layerVersionPolicy{statements: ps.Statements, revisionID: ps.RevisionID}
+	}
+
+	return ld, nil
 }
 
 func (m *Mock) restoreFunc(name string, fs *funcSnapshot) funcData {

--- a/providers/aws/lambda/snapshot_test.go
+++ b/providers/aws/lambda/snapshot_test.go
@@ -3,6 +3,7 @@ package lambda
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
@@ -194,5 +195,81 @@ func TestSnapshotRoundTripProvisionedConcurrency(t *testing.T) {
 
 	if got.RequestedProvisionedConcurrentExecutions != 4 {
 		t.Fatalf("restored requested = %d, want 4", got.RequestedProvisionedConcurrentExecutions)
+	}
+}
+
+// TestSnapshotRoundTripLayers proves a snapshot/restore round-trip preserves a
+// layer's published versions (with their CompatibleArchitectures/LicenseInfo
+// metadata), the monotonic version counter (so a post-restore publish still
+// continues from where it left off rather than reusing a deleted version
+// number), and a layer version's resource-based policy (statements + the
+// RevisionId optimistic-concurrency guard).
+func TestSnapshotRoundTripLayers(t *testing.T) {
+	ctx := context.Background()
+	src := newTestMock()
+
+	_, err := src.PublishLayerVersion(ctx, driver.LayerConfig{
+		Name: "my-layer", Content: []byte("v1"),
+		CompatibleRuntimes: []string{"python3.9"}, CompatibleArchitectures: []string{"arm64"}, LicenseInfo: "MIT",
+	})
+	if err != nil {
+		t.Fatalf("PublishLayerVersion v1: %v", err)
+	}
+
+	v2, err := src.PublishLayerVersion(ctx, driver.LayerConfig{Name: "my-layer", Content: []byte("v2")})
+	if err != nil {
+		t.Fatalf("PublishLayerVersion v2: %v", err)
+	}
+
+	if err := src.DeleteLayerVersion(ctx, "my-layer", 1); err != nil {
+		t.Fatalf("DeleteLayerVersion: %v", err)
+	}
+
+	_, wantRevision, err := src.AddLayerVersionPermission(ctx, "my-layer", v2.Version, driver.LayerPermissionStatement{
+		StatementID: "xaccount", Action: "lambda:GetLayerVersion", Principal: "111111111111",
+	}, "")
+	if err != nil {
+		t.Fatalf("AddLayerVersionPermission: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newTestMock()
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	got, err := dst.GetLayerVersion(ctx, "my-layer", v2.Version)
+	if err != nil || got.LicenseInfo != "" {
+		// v2 was published without metadata; v1 (which carried it) was deleted
+		// before the snapshot, so it must not resurface here.
+		t.Fatalf("restored v2 = %+v, err %v", got, err)
+	}
+
+	if _, err := dst.GetLayerVersion(ctx, "my-layer", 1); err == nil {
+		t.Fatal("deleted version 1 resurfaced after restore")
+	}
+
+	// The version counter must have survived the round-trip: a post-restore
+	// publish continues at 3, not 2 (which would collide with the still-live v2).
+	v3, err := dst.PublishLayerVersion(ctx, driver.LayerConfig{Name: "my-layer", Content: []byte("v3")})
+	if err != nil {
+		t.Fatalf("PublishLayerVersion after restore: %v", err)
+	}
+
+	if v3.Version != v2.Version+1 {
+		t.Fatalf("post-restore published version = %d, want %d", v3.Version, v2.Version+1)
+	}
+
+	policy, gotRevision, err := dst.GetLayerVersionPolicy(ctx, "my-layer", v2.Version)
+	if err != nil || gotRevision != wantRevision {
+		t.Fatalf("restored policy revision = %q err %v, want %q", gotRevision, err, wantRevision)
+	}
+
+	if !strings.Contains(policy, "xaccount") {
+		t.Fatalf("restored policy = %q, want it to contain the xaccount statement", policy)
 	}
 }

--- a/providers/azure/functions/layers.go
+++ b/providers/azure/functions/layers.go
@@ -38,14 +38,16 @@ func (m *Mock) PublishLayerVersion(_ context.Context, cfg driver.LayerConfig) (*
 	)
 
 	lv := &driver.LayerVersion{
-		Name:               cfg.Name,
-		Version:            ver,
-		Description:        cfg.Description,
-		ContentSHA256:      shaStr,
-		ContentSize:        int64(len(cfg.Content)),
-		CompatibleRuntimes: cfg.CompatibleRuntimes,
-		CreatedAt:          m.opts.Clock.Now().UTC().Format(time.RFC3339),
-		ARN:                arn,
+		Name:                    cfg.Name,
+		Version:                 ver,
+		Description:             cfg.Description,
+		ContentSHA256:           shaStr,
+		ContentSize:             int64(len(cfg.Content)),
+		CompatibleRuntimes:      cfg.CompatibleRuntimes,
+		CompatibleArchitectures: cfg.CompatibleArchitectures,
+		LicenseInfo:             cfg.LicenseInfo,
+		CreatedAt:               m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		ARN:                     arn,
 	}
 
 	ld.versions.Set(strconv.Itoa(ver), lv)

--- a/providers/gcp/cloudfunctions/layers.go
+++ b/providers/gcp/cloudfunctions/layers.go
@@ -38,14 +38,16 @@ func (m *Mock) PublishLayerVersion(_ context.Context, cfg driver.LayerConfig) (*
 	)
 
 	lv := &driver.LayerVersion{
-		Name:               cfg.Name,
-		Version:            ver,
-		Description:        cfg.Description,
-		ContentSHA256:      shaStr,
-		ContentSize:        int64(len(cfg.Content)),
-		CompatibleRuntimes: cfg.CompatibleRuntimes,
-		CreatedAt:          m.opts.Clock.Now().UTC().Format(time.RFC3339),
-		ARN:                arn,
+		Name:                    cfg.Name,
+		Version:                 ver,
+		Description:             cfg.Description,
+		ContentSHA256:           shaStr,
+		ContentSize:             int64(len(cfg.Content)),
+		CompatibleRuntimes:      cfg.CompatibleRuntimes,
+		CompatibleArchitectures: cfg.CompatibleArchitectures,
+		LicenseInfo:             cfg.LicenseInfo,
+		CreatedAt:               m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		ARN:                     arn,
 	}
 
 	ld.versions.Set(strconv.Itoa(ver), lv)

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -9,8 +9,10 @@
 // delete), and resource policies (AddPermission / GetPolicy /
 // RemovePermission), and tagging (TagResource / UntagResource / ListTags at
 // the /2017-03-31/tags prefix). Reserved concurrency (Put/Get/Delete
-// FunctionConcurrency), layers (Publish/Get/List/Delete layer versions and
-// ListLayers), and event source mappings are also wired through.
+// FunctionConcurrency), layers (Publish/Get/List/Delete layer versions,
+// GetLayerVersionByArn, ListLayers, and layer-version resource policies via
+// Add/Get/RemoveLayerVersionPermission), and event source mappings are also
+// wired through.
 package lambda
 
 import (
@@ -160,6 +162,20 @@ type policyManager interface {
 	AddPermission(ctx context.Context, functionName, qualifier string, stmt sdrv.PermissionStatement) error
 	RemovePermission(ctx context.Context, functionName, qualifier, statementID string) error
 	GetPolicy(ctx context.Context, functionName, qualifier string) (string, error)
+}
+
+// layerPolicyManager is the AWS-specific layer-version resource-policy surface
+// (AddLayerVersionPermission / GetLayerVersionPolicy /
+// RemoveLayerVersionPermission). Like policyManager, it's not part of the
+// portable Serverless driver — layer version permissions are a Lambda concept —
+// so the handler type-asserts for it rather than requiring every cloud's
+// function provider to implement it.
+type layerPolicyManager interface {
+	AddLayerVersionPermission(
+		ctx context.Context, name string, version int, stmt sdrv.LayerPermissionStatement, revisionID string,
+	) (statementJSON, newRevisionID string, err error)
+	RemoveLayerVersionPermission(ctx context.Context, name string, version int, statementID, revisionID string) error
+	GetLayerVersionPolicy(ctx context.Context, name string, version int) (policy, revisionID string, err error)
 }
 
 // functionTagger is the AWS-specific Lambda tagging surface (not part of the
@@ -552,6 +568,11 @@ func (h *Handler) serveConfiguration(w http.ResponseWriter, r *http.Request, nam
 		return
 	}
 
+	if err := h.validateLayers(r.Context(), req.Layers); err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	cfg := sdrv.FunctionConfig{
 		Name:        name,
 		Runtime:     req.Runtime,
@@ -872,6 +893,11 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := h.validateLayers(r.Context(), req.Layers); err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	cfg := sdrv.FunctionConfig{
 		Name:        req.FunctionName,
 		Runtime:     req.Runtime,
@@ -988,6 +1014,25 @@ func (h *Handler) publishConfiguration(
 	}
 
 	return toVersionConfiguration(info, ver, awsCfg), nil
+}
+
+// validateLayers checks that every layer version ARN a CreateFunction /
+// UpdateFunctionConfiguration request references actually exists, matching
+// real Lambda, which rejects an unknown or malformed layer version ARN with
+// InvalidParameterValueException instead of silently accepting it.
+func (h *Handler) validateLayers(ctx context.Context, arns []string) error {
+	for _, arn := range arns {
+		name, version, ok := parseLayerARN(arn)
+		if !ok {
+			return cerrors.Newf(cerrors.InvalidArgument, "Layer version %s is not a valid layer version ARN", arn)
+		}
+
+		if _, err := h.fn.GetLayerVersion(ctx, name, version); err != nil {
+			return cerrors.Newf(cerrors.InvalidArgument, "Layer version %s does not exist", arn)
+		}
+	}
+
+	return nil
 }
 
 // resolveLayers maps the requested layer ARNs to the echoed Layers list,
@@ -1505,6 +1550,8 @@ func writeErr(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusConflict, "ResourceConflictException", msg)
 	case cerrors.IsInvalidArgument(err):
 		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", msg)
+	case cerrors.IsFailedPrecondition(err):
+		writeError(w, http.StatusPreconditionFailed, "PreconditionFailedException", msg)
 	case cerrors.IsThrottled(err):
 		writeThrottle(w, msg)
 	default:

--- a/server/aws/lambda/layer_lifecycle_e2e_test.go
+++ b/server/aws/lambda/layer_lifecycle_e2e_test.go
@@ -1,0 +1,245 @@
+package lambda_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKLambdaLayerLifecycle drives the full AWS Lambda Layers real-user
+// workflow against the emulator through a real aws-sdk-go-v2 client: publish
+// two versions (monotonic numbering), look them up by name+version and by
+// ARN, list/paginate/filter, delete the older version and confirm the counter
+// never reuses it, round-trip a layer version's resource-based policy, attach
+// a layer to a function, and reject a function that references a layer
+// version that doesn't exist.
+func TestSDKLambdaLayerLifecycle(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	v1, err := client.PublishLayerVersion(ctx, &awslambda.PublishLayerVersionInput{
+		LayerName:               aws.String("shared-deps"),
+		Description:             aws.String("first"),
+		CompatibleRuntimes:      []lambdatypes.Runtime{lambdatypes.RuntimePython39},
+		CompatibleArchitectures: []lambdatypes.Architecture{lambdatypes.ArchitectureArm64},
+		LicenseInfo:             aws.String("MIT"),
+		Content:                 &lambdatypes.LayerVersionContentInput{ZipFile: zipWith(t, "lib.txt", "v1")},
+	})
+	if err != nil {
+		t.Fatalf("PublishLayerVersion v1: %v", err)
+	}
+
+	if v1.Version != 1 {
+		t.Fatalf("v1.Version = %d, want 1", v1.Version)
+	}
+
+	v2, err := client.PublishLayerVersion(ctx, &awslambda.PublishLayerVersionInput{
+		LayerName: aws.String("shared-deps"),
+		Content:   &lambdatypes.LayerVersionContentInput{ZipFile: zipWith(t, "lib2.txt", "v2")},
+	})
+	if err != nil {
+		t.Fatalf("PublishLayerVersion v2: %v", err)
+	}
+
+	if v2.Version != 2 {
+		t.Fatalf("v2.Version = %d, want 2", v2.Version)
+	}
+
+	v2Arn := aws.ToString(v2.LayerVersionArn)
+
+	t.Run("GetLayerVersion and GetLayerVersionByArn agree", func(t *testing.T) {
+		byName, err := client.GetLayerVersion(ctx, &awslambda.GetLayerVersionInput{
+			LayerName: aws.String("shared-deps"), VersionNumber: aws.Int64(1),
+		})
+		if err != nil {
+			t.Fatalf("GetLayerVersion: %v", err)
+		}
+
+		if aws.ToString(byName.LicenseInfo) != "MIT" || len(byName.CompatibleArchitectures) != 1 {
+			t.Fatalf("GetLayerVersion(1) = %+v, want LicenseInfo MIT and one CompatibleArchitecture", byName)
+		}
+
+		byArn, err := client.GetLayerVersionByArn(ctx, &awslambda.GetLayerVersionByArnInput{Arn: aws.String(v2Arn)})
+		if err != nil {
+			t.Fatalf("GetLayerVersionByArn: %v", err)
+		}
+
+		if byArn.Version != 2 || aws.ToString(byArn.LayerVersionArn) != v2Arn {
+			t.Fatalf("GetLayerVersionByArn = %+v, want version 2 arn %s", byArn, v2Arn)
+		}
+	})
+
+	t.Run("ListLayerVersions and ListLayers see both versions", func(t *testing.T) {
+		lv, err := client.ListLayerVersions(ctx, &awslambda.ListLayerVersionsInput{LayerName: aws.String("shared-deps")})
+		if err != nil {
+			t.Fatalf("ListLayerVersions: %v", err)
+		}
+
+		if len(lv.LayerVersions) != 2 {
+			t.Fatalf("LayerVersions = %+v, want 2", lv.LayerVersions)
+		}
+
+		ll, err := client.ListLayers(ctx, &awslambda.ListLayersInput{})
+		if err != nil {
+			t.Fatalf("ListLayers: %v", err)
+		}
+
+		if len(ll.Layers) != 1 || ll.Layers[0].LatestMatchingVersion.Version != 2 {
+			t.Fatalf("ListLayers = %+v, want one layer latest version 2", ll.Layers)
+		}
+	})
+
+	t.Run("filters exclude a non-matching runtime", func(t *testing.T) {
+		lv, err := client.ListLayerVersions(ctx, &awslambda.ListLayerVersionsInput{
+			LayerName: aws.String("shared-deps"), CompatibleRuntime: lambdatypes.RuntimeNodejs18x,
+		})
+		if err != nil {
+			t.Fatalf("ListLayerVersions filtered: %v", err)
+		}
+
+		if len(lv.LayerVersions) != 0 {
+			t.Fatalf("filtered LayerVersions = %+v, want none (v1's runtime is python3.9, not nodejs18.x)", lv.LayerVersions)
+		}
+	})
+
+	t.Run("delete does not renumber", func(t *testing.T) {
+		if _, err := client.DeleteLayerVersion(ctx, &awslambda.DeleteLayerVersionInput{
+			LayerName: aws.String("shared-deps"), VersionNumber: aws.Int64(1),
+		}); err != nil {
+			t.Fatalf("DeleteLayerVersion: %v", err)
+		}
+
+		lv, err := client.ListLayerVersions(ctx, &awslambda.ListLayerVersionsInput{LayerName: aws.String("shared-deps")})
+		if err != nil {
+			t.Fatalf("ListLayerVersions after delete: %v", err)
+		}
+
+		if len(lv.LayerVersions) != 1 || lv.LayerVersions[0].Version != 2 {
+			t.Fatalf("LayerVersions after delete = %+v, want only version 2", lv.LayerVersions)
+		}
+
+		v3, err := client.PublishLayerVersion(ctx, &awslambda.PublishLayerVersionInput{
+			LayerName: aws.String("shared-deps"),
+			Content:   &lambdatypes.LayerVersionContentInput{ZipFile: zipWith(t, "lib3.txt", "v3")},
+		})
+		if err != nil {
+			t.Fatalf("PublishLayerVersion v3: %v", err)
+		}
+
+		if v3.Version != 3 {
+			t.Fatalf("v3.Version = %d, want 3 (must not reuse deleted version 1)", v3.Version)
+		}
+	})
+
+	var policyRevision string
+
+	t.Run("layer version permission round trip", func(t *testing.T) {
+		add, err := client.AddLayerVersionPermission(ctx, &awslambda.AddLayerVersionPermissionInput{
+			LayerName:     aws.String("shared-deps"),
+			VersionNumber: aws.Int64(2),
+			StatementId:   aws.String("xaccount"),
+			Action:        aws.String("lambda:GetLayerVersion"),
+			Principal:     aws.String("111111111111"),
+		})
+		if err != nil {
+			t.Fatalf("AddLayerVersionPermission: %v", err)
+		}
+
+		if aws.ToString(add.RevisionId) == "" || !strings.Contains(aws.ToString(add.Statement), "xaccount") {
+			t.Fatalf("AddLayerVersionPermission response = %+v, want a RevisionId and Statement carrying the Sid", add)
+		}
+
+		policyRevision = aws.ToString(add.RevisionId)
+
+		policy, err := client.GetLayerVersionPolicy(ctx, &awslambda.GetLayerVersionPolicyInput{
+			LayerName: aws.String("shared-deps"), VersionNumber: aws.Int64(2),
+		})
+		if err != nil {
+			t.Fatalf("GetLayerVersionPolicy: %v", err)
+		}
+
+		if aws.ToString(policy.RevisionId) != policyRevision || !strings.Contains(aws.ToString(policy.Policy), "111111111111") {
+			t.Fatalf("GetLayerVersionPolicy = %+v, want revision %s and the granted principal", policy, policyRevision)
+		}
+
+		if _, err := client.RemoveLayerVersionPermission(ctx, &awslambda.RemoveLayerVersionPermissionInput{
+			LayerName: aws.String("shared-deps"), VersionNumber: aws.Int64(2),
+			StatementId: aws.String("xaccount"), RevisionId: aws.String(policyRevision),
+		}); err != nil {
+			t.Fatalf("RemoveLayerVersionPermission: %v", err)
+		}
+
+		if _, err := client.GetLayerVersionPolicy(ctx, &awslambda.GetLayerVersionPolicyInput{
+			LayerName: aws.String("shared-deps"), VersionNumber: aws.Int64(2),
+		}); err == nil {
+			t.Fatal("GetLayerVersionPolicy after removing the only statement: want NotFound, got nil error")
+		}
+	})
+
+	t.Run("CreateFunction with a valid layer succeeds and echoes it", func(t *testing.T) {
+		_, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+			FunctionName: aws.String("uses-layer"),
+			Runtime:      lambdatypes.RuntimeGo1x,
+			Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+			Handler:      aws.String("main"),
+			Code:         &lambdatypes.FunctionCode{ZipFile: zipWith(t, "main.go", "code")},
+			Layers:       []string{v2Arn},
+		})
+		if err != nil {
+			t.Fatalf("CreateFunction with a valid layer: %v", err)
+		}
+
+		cfg, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+			FunctionName: aws.String("uses-layer"),
+		})
+		if err != nil {
+			t.Fatalf("GetFunctionConfiguration: %v", err)
+		}
+
+		if len(cfg.Layers) != 1 || aws.ToString(cfg.Layers[0].Arn) != v2Arn || cfg.Layers[0].CodeSize == 0 {
+			t.Fatalf("GetFunctionConfiguration.Layers = %+v, want one entry with Arn %s and non-zero CodeSize", cfg.Layers, v2Arn)
+		}
+	})
+
+	t.Run("CreateFunction with a bogus layer arn is rejected", func(t *testing.T) {
+		bogusArn := "arn:aws:lambda:us-east-1:000000000000:layer:shared-deps:999"
+
+		_, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+			FunctionName: aws.String("bad-layer-fn"),
+			Runtime:      lambdatypes.RuntimeGo1x,
+			Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+			Handler:      aws.String("main"),
+			Code:         &lambdatypes.FunctionCode{ZipFile: []byte("code")},
+			Layers:       []string{bogusArn},
+		})
+
+		var apiErr smithy.APIError
+		if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValueException" {
+			t.Fatalf("CreateFunction with a bogus layer arn err = %v, want InvalidParameterValueException", err)
+		}
+
+		if _, gerr := client.GetFunction(ctx, &awslambda.GetFunctionInput{FunctionName: aws.String("bad-layer-fn")}); gerr == nil {
+			t.Fatal("function with a bogus layer arn was created despite the rejected request")
+		}
+	})
+
+	t.Run("UpdateFunctionConfiguration with a bogus layer arn is rejected", func(t *testing.T) {
+		bogusArn := "arn:aws:lambda:us-east-1:000000000000:layer:does-not-exist:1"
+
+		_, err := client.UpdateFunctionConfiguration(ctx, &awslambda.UpdateFunctionConfigurationInput{
+			FunctionName: aws.String("uses-layer"),
+			Layers:       []string{bogusArn},
+		})
+
+		var apiErr smithy.APIError
+		if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValueException" {
+			t.Fatalf("UpdateFunctionConfiguration with a bogus layer arn err = %v, want InvalidParameterValueException", err)
+		}
+	})
+}

--- a/server/aws/lambda/layers.go
+++ b/server/aws/lambda/layers.go
@@ -2,6 +2,8 @@ package lambda
 
 import (
 	"net/http"
+	"net/url"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -19,10 +21,11 @@ type layerContentInput struct {
 // publishLayerVersionRequest is the body of PublishLayerVersion
 // (POST .../layers/{name}/versions).
 type publishLayerVersionRequest struct {
-	Description        string             `json:"Description"`
-	Content            *layerContentInput `json:"Content"`
-	CompatibleRuntimes []string           `json:"CompatibleRuntimes"`
-	LicenseInfo        string             `json:"LicenseInfo"`
+	Description             string             `json:"Description"`
+	Content                 *layerContentInput `json:"Content"`
+	CompatibleRuntimes      []string           `json:"CompatibleRuntimes"`
+	CompatibleArchitectures []string           `json:"CompatibleArchitectures"`
+	LicenseInfo             string             `json:"LicenseInfo"`
 }
 
 // layerContentOutput is the LayerVersionContentOutput shape.
@@ -32,28 +35,30 @@ type layerContentOutput struct {
 	CodeSize   int64  `json:"CodeSize,omitempty"`
 }
 
-// layerVersionResponse is the shared shape for PublishLayerVersion and
-// GetLayerVersion.
+// layerVersionResponse is the shared shape for PublishLayerVersion,
+// GetLayerVersion and GetLayerVersionByArn.
 type layerVersionResponse struct {
-	Content            *layerContentOutput `json:"Content,omitempty"`
-	LayerArn           string              `json:"LayerArn,omitempty"`
-	LayerVersionArn    string              `json:"LayerVersionArn,omitempty"`
-	Description        string              `json:"Description,omitempty"`
-	CreatedDate        string              `json:"CreatedDate,omitempty"`
-	Version            int64               `json:"Version"`
-	CompatibleRuntimes []string            `json:"CompatibleRuntimes,omitempty"`
-	LicenseInfo        string              `json:"LicenseInfo,omitempty"`
+	Content                 *layerContentOutput `json:"Content,omitempty"`
+	LayerArn                string              `json:"LayerArn,omitempty"`
+	LayerVersionArn         string              `json:"LayerVersionArn,omitempty"`
+	Description             string              `json:"Description,omitempty"`
+	CreatedDate             string              `json:"CreatedDate,omitempty"`
+	Version                 int64               `json:"Version"`
+	CompatibleRuntimes      []string            `json:"CompatibleRuntimes,omitempty"`
+	CompatibleArchitectures []string            `json:"CompatibleArchitectures,omitempty"`
+	LicenseInfo             string              `json:"LicenseInfo,omitempty"`
 }
 
-// layerVersionListItem is the LayerVersionsListItem shape (no Content) used by
-// ListLayerVersions and as the LatestMatchingVersion of ListLayers.
+// layerVersionListItem is the LayerVersionsListItem shape (no Content, no
+// LicenseInfo) used by ListLayerVersions and as the LatestMatchingVersion of
+// ListLayers.
 type layerVersionListItem struct {
-	LayerVersionArn    string   `json:"LayerVersionArn,omitempty"`
-	Version            int64    `json:"Version"`
-	Description        string   `json:"Description,omitempty"`
-	CreatedDate        string   `json:"CreatedDate,omitempty"`
-	CompatibleRuntimes []string `json:"CompatibleRuntimes,omitempty"`
-	LicenseInfo        string   `json:"LicenseInfo,omitempty"`
+	LayerVersionArn         string   `json:"LayerVersionArn,omitempty"`
+	Version                 int64    `json:"Version"`
+	Description             string   `json:"Description,omitempty"`
+	CreatedDate             string   `json:"CreatedDate,omitempty"`
+	CompatibleRuntimes      []string `json:"CompatibleRuntimes,omitempty"`
+	CompatibleArchitectures []string `json:"CompatibleArchitectures,omitempty"`
 }
 
 // layersListItem is the LayersListItem shape returned by ListLayers.
@@ -61,6 +66,16 @@ type layersListItem struct {
 	LayerName             string               `json:"LayerName,omitempty"`
 	LayerArn              string               `json:"LayerArn,omitempty"`
 	LatestMatchingVersion layerVersionListItem `json:"LatestMatchingVersion"`
+}
+
+// addLayerVersionPermissionRequest is the body of AddLayerVersionPermission
+// (POST .../layers/{name}/versions/{version}/policy).
+type addLayerVersionPermissionRequest struct {
+	StatementID    string `json:"StatementId"`
+	Action         string `json:"Action"`
+	Principal      string `json:"Principal"`
+	OrganizationID string `json:"OrganizationId"`
+	RevisionID     string `json:"RevisionId"`
 }
 
 // layerARN strips the trailing :{version} to yield the version-less layer ARN.
@@ -75,54 +90,107 @@ func toLayerVersionResponse(lv *sdrv.LayerVersion) layerVersionResponse {
 			CodeSha256: lv.ContentSHA256,
 			CodeSize:   lv.ContentSize,
 		},
-		LayerArn:           layerARN(lv),
-		LayerVersionArn:    lv.ARN,
-		Description:        lv.Description,
-		CreatedDate:        lv.CreatedAt,
-		Version:            int64(lv.Version),
-		CompatibleRuntimes: lv.CompatibleRuntimes,
+		LayerArn:                layerARN(lv),
+		LayerVersionArn:         lv.ARN,
+		Description:             lv.Description,
+		CreatedDate:             lv.CreatedAt,
+		Version:                 int64(lv.Version),
+		CompatibleRuntimes:      lv.CompatibleRuntimes,
+		CompatibleArchitectures: lv.CompatibleArchitectures,
+		LicenseInfo:             lv.LicenseInfo,
 	}
 }
 
 func toLayerVersionListItem(lv *sdrv.LayerVersion) layerVersionListItem {
 	return layerVersionListItem{
-		LayerVersionArn:    lv.ARN,
-		Version:            int64(lv.Version),
-		Description:        lv.Description,
-		CreatedDate:        lv.CreatedAt,
-		CompatibleRuntimes: lv.CompatibleRuntimes,
+		LayerVersionArn:         lv.ARN,
+		Version:                 int64(lv.Version),
+		Description:             lv.Description,
+		CreatedDate:             lv.CreatedAt,
+		CompatibleRuntimes:      lv.CompatibleRuntimes,
+		CompatibleArchitectures: lv.CompatibleArchitectures,
 	}
 }
 
+// findLayerVersion is the ListLayers/GetLayerVersionByArn "find" query value
+// that selects the by-Arn lookup on the layers collection endpoint.
+const findLayerVersion = "LayerVersion"
+
 // serveLayers dispatches the /2018-10-31/layers paths: the layers collection
-// (GET=ListLayers), the per-layer versions collection (POST=PublishLayerVersion,
-// GET=ListLayerVersions), and a specific version (GET/DELETE).
+// (GET=ListLayers, or GET?find=LayerVersion&Arn=...=GetLayerVersionByArn), the
+// per-layer versions collection (POST=PublishLayerVersion,
+// GET=ListLayerVersions), a specific version (GET/DELETE), and a version's
+// resource policy (POST/GET=.../policy, DELETE=.../policy/{statementId}).
 func (h *Handler) serveLayers(w http.ResponseWriter, r *http.Request) {
 	rest := strings.TrimPrefix(strings.TrimPrefix(r.URL.Path, layersPrefix), "/")
 
 	if rest == "" {
-		if r.Method != http.MethodGet {
-			writeError(w, http.StatusMethodNotAllowed, "InvalidRequestException", "method not allowed")
-			return
-		}
-
-		h.listLayers(w, r)
-
+		h.serveLayersCollection(w, r)
 		return
 	}
 
-	parts := strings.Split(rest, "/")
+	h.serveLayerSubpath(w, r, strings.Split(rest, "/"))
+}
 
-	const (
-		partsVersions = 2 // /layers/{name}/versions
-		partsVersion  = 3 // /layers/{name}/versions/{version}
-	)
+// serveLayersCollection handles the bare /2018-10-31/layers endpoint:
+// GET=ListLayers, or GET?find=LayerVersion&Arn=...=GetLayerVersionByArn.
+func (h *Handler) serveLayersCollection(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "InvalidRequestException", "method not allowed")
+		return
+	}
 
-	switch {
-	case len(parts) == partsVersions && parts[1] == subVersions:
-		h.serveLayerVersions(w, r, parts[0])
-	case len(parts) == partsVersion && parts[1] == subVersions:
-		h.serveLayerVersion(w, r, parts[0], parts[2])
+	if r.URL.Query().Get("find") == findLayerVersion {
+		h.getLayerVersionByArn(w, r)
+		return
+	}
+
+	h.listLayers(w, r)
+}
+
+// Segment counts for a /2018-10-31/layers/{name}/... path with the layers
+// prefix stripped and split on "/".
+const (
+	partsVersions   = 2 // /layers/{name}/versions
+	partsVersion    = 3 // /layers/{name}/versions/{version}
+	partsPolicy     = 4 // /layers/{name}/versions/{version}/policy
+	partsPolicyStmt = 5 // /layers/{name}/versions/{version}/policy/{statementId}
+)
+
+// serveLayerSubpath routes a /2018-10-31/layers/{name}/... path to the
+// per-layer versions collection, a specific version, or (via
+// serveLayerVersionPolicyPath) a version's resource policy.
+func (h *Handler) serveLayerSubpath(w http.ResponseWriter, r *http.Request, parts []string) {
+	if len(parts) < partsVersions || parts[1] != subVersions {
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "unsupported Lambda layers path")
+		return
+	}
+
+	name := parts[0]
+
+	switch len(parts) {
+	case partsVersions:
+		h.serveLayerVersions(w, r, name)
+	case partsVersion:
+		h.serveLayerVersion(w, r, name, parts[2])
+	default:
+		h.serveLayerVersionPolicyPath(w, r, name, parts)
+	}
+}
+
+// serveLayerVersionPolicyPath routes the .../policy and
+// .../policy/{statementId} tails of a layer-version path.
+func (h *Handler) serveLayerVersionPolicyPath(w http.ResponseWriter, r *http.Request, name string, parts []string) {
+	if parts[3] != subPolicy {
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "unsupported Lambda layers path")
+		return
+	}
+
+	switch len(parts) {
+	case partsPolicy:
+		h.serveLayerVersionPolicy(w, r, name, parts[2])
+	case partsPolicyStmt:
+		h.serveRemoveLayerVersionPermission(w, r, name, parts[2], parts[4])
 	default:
 		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "unsupported Lambda layers path")
 	}
@@ -133,59 +201,108 @@ func (h *Handler) serveLayers(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) serveLayerVersions(w http.ResponseWriter, r *http.Request, name string) {
 	switch r.Method {
 	case http.MethodPost:
-		var req publishLayerVersionRequest
-		if !decodeJSON(w, r, &req) {
-			return
-		}
-
-		cfg := sdrv.LayerConfig{
-			Name:               name,
-			Description:        req.Description,
-			CompatibleRuntimes: req.CompatibleRuntimes,
-		}
-		if req.Content != nil {
-			cfg.Content = req.Content.ZipFile
-		}
-
-		lv, err := h.fn.PublishLayerVersion(r.Context(), cfg)
-		if err != nil {
-			writeErr(w, err)
-			return
-		}
-
-		// Stage the zip bytes so a function importing this layer can have its
-		// files overlaid into the deployment package at CreateFunction.
-		if req.Content != nil {
-			h.putLayerContent(lv.Name, lv.Version, req.Content.ZipFile)
-		}
-
-		resp := toLayerVersionResponse(lv)
-		resp.LicenseInfo = req.LicenseInfo
-		writeJSON(w, http.StatusCreated, resp)
+		h.publishLayerVersion(w, r, name)
 	case http.MethodGet:
-		vers, err := h.fn.ListLayerVersions(r.Context(), name)
-		if err != nil {
-			writeErr(w, err)
-			return
-		}
-
-		items := make([]layerVersionListItem, 0, len(vers))
-		for i := range vers {
-			items = append(items, toLayerVersionListItem(&vers[i]))
-		}
-
-		writeJSON(w, http.StatusOK, map[string]any{"LayerVersions": items})
+		h.listLayerVersions(w, r, name)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "InvalidRequestException", "method not allowed")
 	}
 }
 
+// publishLayerVersion handles POST .../layers/{name}/versions.
+func (h *Handler) publishLayerVersion(w http.ResponseWriter, r *http.Request, name string) {
+	var req publishLayerVersionRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	cfg := sdrv.LayerConfig{
+		Name:                    name,
+		Description:             req.Description,
+		CompatibleRuntimes:      req.CompatibleRuntimes,
+		CompatibleArchitectures: req.CompatibleArchitectures,
+		LicenseInfo:             req.LicenseInfo,
+	}
+	if req.Content != nil {
+		cfg.Content = req.Content.ZipFile
+	}
+
+	lv, err := h.fn.PublishLayerVersion(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	// Stage the zip bytes so a function importing this layer can have its files
+	// overlaid into the deployment package at CreateFunction.
+	if req.Content != nil {
+		h.putLayerContent(lv.Name, lv.Version, req.Content.ZipFile)
+	}
+
+	writeJSON(w, http.StatusCreated, toLayerVersionResponse(lv))
+}
+
+// listLayerVersions handles GET .../layers/{name}/versions (ListLayerVersions),
+// applying the CompatibleRuntime/CompatibleArchitecture filters and
+// Marker/MaxItems pagination real Lambda supports. Results are already
+// descending-by-version (matching AWS's latest-first order), which keeps Marker
+// offsets stable across paginated calls.
+func (h *Handler) listLayerVersions(w http.ResponseWriter, r *http.Request, name string) {
+	vers, err := h.fn.ListLayerVersions(r.Context(), name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	vers = filterLayerVersions(vers, r.URL.Query())
+
+	start, end, nextMarker, truncated := pageWindow(len(vers), r.URL.Query())
+
+	items := make([]layerVersionListItem, 0, end-start)
+	for i := start; i < end; i++ {
+		items = append(items, toLayerVersionListItem(&vers[i]))
+	}
+
+	body := map[string]any{"LayerVersions": items}
+	if truncated {
+		body["NextMarker"] = nextMarker
+	}
+
+	writeJSON(w, http.StatusOK, body)
+}
+
+// filterLayerVersions keeps only the versions matching the CompatibleRuntime
+// and/or CompatibleArchitecture query parameters, when present.
+func filterLayerVersions(vers []sdrv.LayerVersion, form url.Values) []sdrv.LayerVersion {
+	runtime := form.Get("CompatibleRuntime")
+	arch := form.Get("CompatibleArchitecture")
+
+	if runtime == "" && arch == "" {
+		return vers
+	}
+
+	out := vers[:0]
+
+	for i := range vers {
+		if runtime != "" && !slices.Contains(vers[i].CompatibleRuntimes, runtime) {
+			continue
+		}
+
+		if arch != "" && !slices.Contains(vers[i].CompatibleArchitectures, arch) {
+			continue
+		}
+
+		out = append(out, vers[i])
+	}
+
+	return out
+}
+
 // serveLayerVersion handles GET (GetLayerVersion) and DELETE
 // (DeleteLayerVersion) on .../layers/{name}/versions/{version}.
 func (h *Handler) serveLayerVersion(w http.ResponseWriter, r *http.Request, name, versionStr string) {
-	version, err := strconv.Atoi(versionStr)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", "invalid layer version number")
+	version, ok := parseLayerVersionNumber(w, versionStr)
+	if !ok {
 		return
 	}
 
@@ -210,14 +327,51 @@ func (h *Handler) serveLayerVersion(w http.ResponseWriter, r *http.Request, name
 	}
 }
 
+// parseLayerVersionNumber parses a layer version path segment, writing an
+// InvalidParameterValueException and returning ok=false on a malformed value.
+func parseLayerVersionNumber(w http.ResponseWriter, versionStr string) (version int, ok bool) {
+	version, err := strconv.Atoi(versionStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", "invalid layer version number")
+		return 0, false
+	}
+
+	return version, true
+}
+
+// getLayerVersionByArn handles GET /2018-10-31/layers?find=LayerVersion&Arn=...
+// (GetLayerVersionByArn), the SDK's alternate lookup that resolves a full layer
+// version ARN without requiring the caller to already know the layer name and
+// version number separately.
+func (h *Handler) getLayerVersionByArn(w http.ResponseWriter, r *http.Request) {
+	arn := r.URL.Query().Get("Arn")
+
+	name, version, ok := parseLayerARN(arn)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", "invalid layer version ARN")
+		return
+	}
+
+	lv, err := h.fn.GetLayerVersion(r.Context(), name, version)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toLayerVersionResponse(lv))
+}
+
 // listLayers handles GET /2018-10-31/layers (ListLayers), returning the latest
-// version of each layer.
+// matching version of each layer, filtered by CompatibleRuntime/
+// CompatibleArchitecture when given.
 func (h *Handler) listLayers(w http.ResponseWriter, r *http.Request) {
 	layers, err := h.fn.ListLayers(r.Context())
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
+
+	layers = filterLayerVersions(layers, r.URL.Query())
 
 	// Sort by name so Marker offsets stay stable across paginated calls.
 	sort.Slice(layers, func(i, j int) bool { return layers[i].Name < layers[j].Name })
@@ -239,4 +393,84 @@ func (h *Handler) listLayers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, body)
+}
+
+// serveLayerVersionPolicy handles POST (AddLayerVersionPermission) and GET
+// (GetLayerVersionPolicy) on .../layers/{name}/versions/{version}/policy.
+func (h *Handler) serveLayerVersionPolicy(w http.ResponseWriter, r *http.Request, name, versionStr string) {
+	pm, ok := h.fn.(layerPolicyManager)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "InvalidRequestException", "layer version policies not supported")
+		return
+	}
+
+	version, ok := parseLayerVersionNumber(w, versionStr)
+	if !ok {
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPost:
+		addLayerVersionPermission(w, r, pm, name, version)
+	case http.MethodGet:
+		policy, revisionID, err := pm.GetLayerVersionPolicy(r.Context(), name, version)
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]string{"Policy": policy, "RevisionId": revisionID})
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "InvalidRequestException", "method not allowed")
+	}
+}
+
+// addLayerVersionPermission handles the POST case of serveLayerVersionPolicy.
+func addLayerVersionPermission(w http.ResponseWriter, r *http.Request, pm layerPolicyManager, name string, version int) {
+	var req addLayerVersionPermissionRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	stmt := sdrv.LayerPermissionStatement{
+		StatementID: req.StatementID, Action: req.Action,
+		Principal: req.Principal, OrganizationID: req.OrganizationID,
+	}
+
+	stmtJSON, revisionID, err := pm.AddLayerVersionPermission(r.Context(), name, version, stmt, req.RevisionID)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]string{"Statement": stmtJSON, "RevisionId": revisionID})
+}
+
+// serveRemoveLayerVersionPermission handles DELETE
+// .../layers/{name}/versions/{version}/policy/{statementId}
+// (RemoveLayerVersionPermission).
+func (h *Handler) serveRemoveLayerVersionPermission(w http.ResponseWriter, r *http.Request, name, versionStr, statementID string) {
+	if r.Method != http.MethodDelete {
+		writeError(w, http.StatusMethodNotAllowed, "InvalidRequestException", "method not allowed")
+		return
+	}
+
+	pm, ok := h.fn.(layerPolicyManager)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "InvalidRequestException", "layer version policies not supported")
+		return
+	}
+
+	version, ok := parseLayerVersionNumber(w, versionStr)
+	if !ok {
+		return
+	}
+
+	err := pm.RemoveLayerVersionPermission(r.Context(), name, version, statementID, r.URL.Query().Get("RevisionId"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/services/serverless/driver/driver.go
+++ b/services/serverless/driver/driver.go
@@ -102,6 +102,12 @@ type LayerConfig struct {
 	Description        string
 	Content            []byte
 	CompatibleRuntimes []string
+	// CompatibleArchitectures is the list of instruction-set architectures
+	// ("x86_64", "arm64") the layer supports.
+	CompatibleArchitectures []string
+	// LicenseInfo is the layer's software license (an SPDX identifier, a
+	// license URL, or the full license text).
+	LicenseInfo string
 }
 
 // LayerVersion represents a published layer version.
@@ -112,8 +118,30 @@ type LayerVersion struct {
 	ContentSHA256      string
 	ContentSize        int64
 	CompatibleRuntimes []string
-	CreatedAt          string
-	ARN                string
+	// CompatibleArchitectures is the list of instruction-set architectures
+	// ("x86_64", "arm64") the layer supports.
+	CompatibleArchitectures []string
+	// LicenseInfo is the layer's software license.
+	LicenseInfo string
+	CreatedAt   string
+	ARN         string
+}
+
+// LayerPermissionStatement is one statement of a layer version's resource-based
+// policy, added via AddLayerVersionPermission. It grants another account (or an
+// organization, or all accounts) permission to use a published layer version.
+// Layer version permissions are an AWS Lambda-only concept (no Azure Functions
+// or GCP Cloud Functions equivalent), so — like PermissionStatement — the data
+// struct lives on the shared driver package but the methods that manage it are
+// exposed through an AWS-only optional interface (type-asserted by the AWS
+// Lambda server handler) rather than the portable Serverless interface.
+type LayerPermissionStatement struct {
+	StatementID string
+	Action      string
+	Principal   string
+	// OrganizationID, when set with Principal "*", scopes the grant to accounts
+	// within this AWS Organization instead of every AWS account.
+	OrganizationID string
 }
 
 // ConcurrencyConfig configures function concurrency.


### PR DESCRIPTION
## Summary

AWS Lambda Layers depth pass. Layer version lifecycle (PublishLayerVersion, Get/List/DeleteLayerVersion, ListLayers) and function Layers attachment already existed on `development`. This PR fills in the remaining real-AWS surface:

**Added**
- `CompatibleArchitectures` and `LicenseInfo` now persist on a layer version (previously accepted on PublishLayerVersion but dropped instead of stored/returned).
- `GetLayerVersionByArn` (`GET /2018-10-31/layers?find=LayerVersion&Arn=...`).
- Layer version resource-based policies: `AddLayerVersionPermission`, `GetLayerVersionPolicy`, `RemoveLayerVersionPermission`, with `RevisionId` optimistic-concurrency and `OrganizationId`-scoped grants. Stored and echoed back, not enforced — matches this emulator's accept-any-credentials wire layer (same as the existing function-level AddPermission/GetPolicy).
- `CompatibleRuntime`/`CompatibleArchitecture` filters on `ListLayerVersions`/`ListLayers`, and `Marker`/`MaxItems` pagination on `ListLayerVersions` (`ListLayers` already had pagination).
- `CreateFunction`/`UpdateFunctionConfiguration` now validate that every referenced layer version ARN actually exists, rejecting an unknown one with `InvalidParameterValueException` instead of silently accepting it.

**Fixed**
- A pre-existing race in `PublishLayerVersion`'s first-publish path and its version counter: two concurrent publishes for a brand-new layer name could each see the layer as absent and independently create a `layerData`, losing one and its counter, or duplicate a version number. Layer state now has its own per-layer mutex (mirrors the existing `aliasData` pattern) and the first-publish race uses `SetIfAbsent`.
- Layer version policies and the monotonic version counter now round-trip through Snapshot/Restore.

**Pre-existing (unchanged in this PR)**
- Monotonic per-layer version numbering, delete-does-not-renumber, `PublishLayerVersion`/`Get`/`List`/`DeleteLayerVersion`/`ListLayers`, and function `Layers` attach/echo on Create/GetFunctionConfiguration.

**Deferred**
- Event-source-mapping batching knobs (BatchWindow, MaximumBatchingWindow, etc.) are a separate item, out of scope here.

## Test plan
- [x] `go build ./...`
- [x] `go test ./providers/aws/lambda/... ./server/aws/lambda/... ./persist/... ./services/serverless/... -race -count=1`
- [x] `go test ./providers/aws/... ./server/aws/...`
- [x] `gofmt -l` on touched files (empty)
- [x] `golangci-lint run ./providers/aws/lambda/... ./server/aws/lambda/... ./providers/azure/functions/... ./providers/gcp/cloudfunctions/... ./services/serverless/...` (0 issues)
- [x] `go generate ./...` + `git diff docs/coverage` (no diff — AWS-only capability additions)
- [x] `go mod tidy` (no changes to the main module or any contrib submodule)
- [x] Real-user e2e against a real `aws-sdk-go-v2` Lambda client: publish two versions, Get/GetByArn/List/filter, delete v1 + republish confirms v3 (never reuses v1), full Add/Get/RemoveLayerVersionPermission round trip, CreateFunction with a valid layer + GetFunctionConfiguration echo, CreateFunction/UpdateFunctionConfiguration with a bogus layer ARN rejected with InvalidParameterValueException