### PR TITLE
feat(ecs): task & service lifecycle — task state machine

### DIFF
--- a/internal/settle/settle.go
+++ b/internal/settle/settle.go
@@ -39,6 +39,9 @@ const (
 	DefaultCloudSQLSettle    = 3 * time.Second // Cloud SQL PENDING_CREATE->RUNNABLE
 	DefaultAzureDBSettle     = 3 * time.Second // Azure SQL/flex Creating->Succeeded/Ready
 	DefaultKeyspacesSettle   = 2 * time.Second // Keyspaces table CREATING->ACTIVE
+
+	DefaultECSTaskStartSettle = 2 * time.Second // ECS task PROVISIONING/PENDING->RUNNING
+	DefaultECSTaskStopSettle  = 1 * time.Second // ECS task STOPPING/DEPROVISIONING->STOPPED
 )
 
 // Window is a read-time overlay describing a resource still settling into its

--- a/providers/aws/ecs/container_instances.go
+++ b/providers/aws/ecs/container_instances.go
@@ -162,6 +162,10 @@ func (m *Mock) DeregisterContainerInstance(
 // stopTasksOnInstance marks every non-stopped task placed on the given instance
 // STOPPED. The caller holds placeMu (so this must not call StopTask, which also
 // takes it); capacity is not released because the instance is being removed.
+// This is an administrative teardown, not a user StopTask, so it clears (rather
+// than replaces) any launch-settle window a task may still be in: without this
+// a task force-stopped mid-launch-transient would keep reporting its stale
+// PROVISIONING/PENDING lastStatus instead of the STOPPED set here.
 func (m *Mock) stopTasksOnInstance(instanceARN string) {
 	for _, t := range m.tasks.SortedValues() {
 		if t.ContainerInstanceARN != instanceARN || t.LastStatus == statusStopped {
@@ -179,6 +183,7 @@ func (m *Mock) stopTasksOnInstance(instanceARN string) {
 		}
 
 		m.tasks.Set(updated.ARN, &updated)
+		m.taskSettle.Clear(updated.ARN)
 	}
 }
 

--- a/providers/aws/ecs/ecs.go
+++ b/providers/aws/ecs/ecs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	"github.com/stackshy/cloudemu/v2/services/ecs/driver"
 	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
 )
@@ -26,6 +27,15 @@ const (
 	statusPending  = "PENDING"
 	statusStopped  = "STOPPED"
 	defaultCluster = "default"
+
+	// taskStatusProvisioning is the Fargate-only launch transient: the ENI is
+	// still being attached. taskStatusDeprovisioning is its stop-side mirror:
+	// the ENI is being detached. taskStatusStopping is the EC2/EXTERNAL stop
+	// transient (statusPending already covers the EC2/EXTERNAL launch
+	// transient). All three are overlaid read-time states — see taskSettle.
+	taskStatusProvisioning   = "PROVISIONING"
+	taskStatusDeprovisioning = "DEPROVISIONING"
+	taskStatusStopping       = "STOPPING"
 )
 
 // Mock is an in-memory mock implementation of Amazon ECS.
@@ -49,6 +59,14 @@ type Mock struct {
 	// it. A present entry is the "engine-backed" marker consulted by StopTask and
 	// ExecuteCommand; absent means the task is a synthetic (engine-less) task.
 	engineHandles *memstore.Store[string]
+
+	// taskSettle overlays a realistic lastStatus transient (PROVISIONING/PENDING
+	// on launch, STOPPING/DEPROVISIONING on stop) onto a task's already-final
+	// stored LastStatus for a short window after RunTask/StopTask, when
+	// opts.AsyncSettle is enabled. It is a read-time overlay only: internal
+	// bookkeeping (capacity release, service reconciliation counts) always uses
+	// the stored final state, never this overlay. See internal/settle.
+	taskSettle *settle.Set
 
 	logs logdriver.Logging // optional: awslogs surfacing target (CloudWatch Logs)
 
@@ -88,6 +106,7 @@ func New(opts *config.Options) *Mock {
 		settings:      memstore.New[*driver.AccountSetting](),
 		attributes:    memstore.New[*driver.Attribute](),
 		engineHandles: memstore.New[string](),
+		taskSettle:    settle.NewSet(),
 		opts:          opts,
 	}
 }

--- a/providers/aws/ecs/lifecycle_settle_test.go
+++ b/providers/aws/ecs/lifecycle_settle_test.go
@@ -162,6 +162,55 @@ func TestStopTaskSettlesStoppingToStopped(t *testing.T) {
 	assert.Equal(t, statusStopped, described[0].LastStatus)
 }
 
+// TestRepeatedStopTaskDoesNotRestartSettleWindow verifies StopTask is
+// idempotent on an already-stopped task: once a task has settled to STOPPED, a
+// second StopTask call must not restart the stop-settle window — neither its
+// own response nor an immediate DescribeTasks may report the
+// DEPROVISIONING/STOPPING transient again for a terminal task.
+func TestRepeatedStopTaskDoesNotRestartSettleWindow(t *testing.T) {
+	m, fc := newSettleMock()
+	ctx := context.Background()
+
+	td, err := m.RegisterTaskDefinition(ctx, driver.RegisterTaskDefinitionInput{
+		Family:                  "web",
+		RequiresCompatibilities: []string{launchFargate},
+		NetworkMode:             networkModeAwsvpc,
+		CPU:                     "256",
+		Memory:                  "512",
+		ContainerDefinitions:    []driver.ContainerDefinition{{Name: "app", Image: "nginx:latest"}},
+	})
+	require.NoError(t, err)
+
+	tasks, _, err := m.RunTask(ctx, driver.RunTaskInput{
+		TaskDefinition: td.ARN,
+		LaunchType:     launchFargate,
+		NetworkConfiguration: &driver.NetworkConfiguration{
+			AwsVpcConfiguration: &driver.AwsVpcConfiguration{Subnets: []string{"subnet-1"}},
+		},
+	})
+	require.NoError(t, err)
+	fc.Advance(settle.DefaultECSTaskStartSettle)
+
+	_, err = m.StopTask(ctx, "default", tasks[0].ARN, "first stop")
+	require.NoError(t, err)
+
+	fc.Advance(settle.DefaultECSTaskStopSettle)
+	described, _, err := m.DescribeTasks(ctx, "default", []string{tasks[0].ARN})
+	require.NoError(t, err)
+	require.Equal(t, statusStopped, described[0].LastStatus)
+
+	// A second StopTask on the already-stopped task must be a clean idempotent
+	// no-op: its own response reports STOPPED (not a fresh DEPROVISIONING), and
+	// an immediate DescribeTasks agrees — the task never "un-stops".
+	again, err := m.StopTask(ctx, "default", tasks[0].ARN, "second stop")
+	require.NoError(t, err)
+	assert.Equal(t, statusStopped, again.LastStatus)
+
+	described, _, err = m.DescribeTasks(ctx, "default", []string{tasks[0].ARN})
+	require.NoError(t, err)
+	assert.Equal(t, statusStopped, described[0].LastStatus)
+}
+
 // TestServiceReconciliationUnaffectedBySettle verifies a service's
 // running/pending counts reflect the tasks' already-final state immediately —
 // the settle transient is a read-time overlay on DescribeTasks/ListTasks only,

--- a/providers/aws/ecs/lifecycle_settle_test.go
+++ b/providers/aws/ecs/lifecycle_settle_test.go
@@ -1,0 +1,262 @@
+package ecs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
+	"github.com/stackshy/cloudemu/v2/services/ecs/driver"
+)
+
+// settleEpoch is a fixed base time so the FakeClock-driven settle assertions
+// below are deterministic.
+var settleEpoch = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) //nolint:gochecknoglobals // test fixture
+
+// newSettleMock builds an ECS mock with AsyncSettle enabled and a FakeClock the
+// test can advance to observe the task lifecycle transients.
+func newSettleMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(settleEpoch)
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"), config.WithAsyncSettle())
+
+	return New(opts), fc
+}
+
+// registerSimpleTaskDef registers a minimal single-container task definition
+// and returns its ARN.
+func registerSimpleTaskDef(t *testing.T, m *Mock, ctx context.Context, family string) string {
+	t.Helper()
+
+	td, err := m.RegisterTaskDefinition(ctx, driver.RegisterTaskDefinitionInput{
+		Family: family,
+		ContainerDefinitions: []driver.ContainerDefinition{
+			{Name: "app", Image: "nginx:latest"},
+		},
+	})
+	require.NoError(t, err)
+
+	return td.ARN
+}
+
+// TestRunTaskEC2SettlesPendingToRunning verifies an EC2-launched task reports
+// the PENDING launch transient until its settle window elapses, then RUNNING,
+// when AsyncSettle is enabled.
+func TestRunTaskEC2SettlesPendingToRunning(t *testing.T) {
+	m, fc := newSettleMock()
+	ctx := context.Background()
+
+	tdARN := registerSimpleTaskDef(t, m, ctx, "web")
+	_, err := m.CreateCluster(ctx, driver.CreateClusterInput{Name: "prod"})
+	require.NoError(t, err)
+	_, err = m.RegisterContainerInstance(ctx, driver.RegisterContainerInstanceInput{
+		Cluster: "prod",
+		TotalResources: []driver.Resource{
+			{Name: "CPU", Type: "INTEGER", IntegerValue: 4096},
+			{Name: "MEMORY", Type: "INTEGER", IntegerValue: 8192},
+		},
+	})
+	require.NoError(t, err)
+
+	tasks, failures, err := m.RunTask(ctx, driver.RunTaskInput{Cluster: "prod", TaskDefinition: tdARN})
+	require.NoError(t, err)
+	require.Empty(t, failures)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, statusPending, tasks[0].LastStatus)
+
+	taskARN := tasks[0].ARN
+
+	described, _, err := m.DescribeTasks(ctx, "prod", []string{taskARN})
+	require.NoError(t, err)
+	require.Len(t, described, 1)
+	assert.Equal(t, statusPending, described[0].LastStatus)
+
+	fc.Advance(settle.DefaultECSTaskStartSettle - time.Millisecond)
+	described, _, err = m.DescribeTasks(ctx, "prod", []string{taskARN})
+	require.NoError(t, err)
+	assert.Equal(t, statusPending, described[0].LastStatus)
+
+	fc.Advance(time.Millisecond)
+	described, _, err = m.DescribeTasks(ctx, "prod", []string{taskARN})
+	require.NoError(t, err)
+	assert.Equal(t, statusRunning, described[0].LastStatus)
+}
+
+// TestRunTaskFargateSettlesProvisioningToRunning verifies a Fargate task
+// reports PROVISIONING (not the EC2 PENDING) as its launch transient.
+func TestRunTaskFargateSettlesProvisioningToRunning(t *testing.T) {
+	m, fc := newSettleMock()
+	ctx := context.Background()
+
+	td, err := m.RegisterTaskDefinition(ctx, driver.RegisterTaskDefinitionInput{
+		Family:                  "web",
+		RequiresCompatibilities: []string{launchFargate},
+		NetworkMode:             networkModeAwsvpc,
+		CPU:                     "256",
+		Memory:                  "512",
+		ContainerDefinitions:    []driver.ContainerDefinition{{Name: "app", Image: "nginx:latest"}},
+	})
+	require.NoError(t, err)
+
+	tasks, failures, err := m.RunTask(ctx, driver.RunTaskInput{
+		TaskDefinition: td.ARN,
+		LaunchType:     launchFargate,
+		NetworkConfiguration: &driver.NetworkConfiguration{
+			AwsVpcConfiguration: &driver.AwsVpcConfiguration{Subnets: []string{"subnet-1"}},
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, failures)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, taskStatusProvisioning, tasks[0].LastStatus)
+
+	fc.Advance(settle.DefaultECSTaskStartSettle)
+	described, _, err := m.DescribeTasks(ctx, "default", []string{tasks[0].ARN})
+	require.NoError(t, err)
+	assert.Equal(t, statusRunning, described[0].LastStatus)
+}
+
+// TestStopTaskSettlesStoppingToStopped verifies StopTask reports the STOPPING
+// transient before STOPPED, matching real ECS: desiredStatus flips to STOPPED
+// synchronously but lastStatus lags until the container actually stops.
+func TestStopTaskSettlesStoppingToStopped(t *testing.T) {
+	m, fc := newSettleMock()
+	ctx := context.Background()
+
+	td, err := m.RegisterTaskDefinition(ctx, driver.RegisterTaskDefinitionInput{
+		Family:                  "web",
+		RequiresCompatibilities: []string{launchFargate},
+		NetworkMode:             networkModeAwsvpc,
+		CPU:                     "256",
+		Memory:                  "512",
+		ContainerDefinitions:    []driver.ContainerDefinition{{Name: "app", Image: "nginx:latest"}},
+	})
+	require.NoError(t, err)
+
+	tasks, _, err := m.RunTask(ctx, driver.RunTaskInput{
+		TaskDefinition: td.ARN,
+		LaunchType:     launchFargate,
+		NetworkConfiguration: &driver.NetworkConfiguration{
+			AwsVpcConfiguration: &driver.AwsVpcConfiguration{Subnets: []string{"subnet-1"}},
+		},
+	})
+	require.NoError(t, err)
+	fc.Advance(settle.DefaultECSTaskStartSettle)
+
+	stopped, err := m.StopTask(ctx, "default", tasks[0].ARN, "user request")
+	require.NoError(t, err)
+	assert.Equal(t, taskStatusDeprovisioning, stopped.LastStatus)
+	assert.Equal(t, statusStopped, stopped.DesiredStatus)
+	assert.Equal(t, "user request", stopped.StoppedReason)
+
+	described, _, err := m.DescribeTasks(ctx, "default", []string{tasks[0].ARN})
+	require.NoError(t, err)
+	assert.Equal(t, taskStatusDeprovisioning, described[0].LastStatus)
+
+	fc.Advance(settle.DefaultECSTaskStopSettle)
+	described, _, err = m.DescribeTasks(ctx, "default", []string{tasks[0].ARN})
+	require.NoError(t, err)
+	assert.Equal(t, statusStopped, described[0].LastStatus)
+}
+
+// TestServiceReconciliationUnaffectedBySettle verifies a service's
+// running/pending counts reflect the tasks' already-final state immediately —
+// the settle transient is a read-time overlay on DescribeTasks/ListTasks only,
+// never on the scheduler's own internal bookkeeping.
+func TestServiceReconciliationUnaffectedBySettle(t *testing.T) {
+	m, _ := newSettleMock()
+	ctx := context.Background()
+
+	td, err := m.RegisterTaskDefinition(ctx, driver.RegisterTaskDefinitionInput{
+		Family:                  "web",
+		RequiresCompatibilities: []string{launchFargate},
+		NetworkMode:             networkModeAwsvpc,
+		CPU:                     "256",
+		Memory:                  "512",
+		ContainerDefinitions:    []driver.ContainerDefinition{{Name: "app", Image: "nginx:latest"}},
+	})
+	require.NoError(t, err)
+	_, err = m.CreateCluster(ctx, driver.CreateClusterInput{Name: "prod"})
+	require.NoError(t, err)
+
+	svc, err := m.CreateService(ctx, driver.CreateServiceInput{
+		ServiceName: "api", Cluster: "prod", TaskDefinition: td.ARN, DesiredCount: 2, LaunchType: launchFargate,
+		NetworkConfiguration: &driver.NetworkConfiguration{
+			AwsVpcConfiguration: &driver.AwsVpcConfiguration{Subnets: []string{"subnet-1"}},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, svc.RunningCount)
+	assert.Equal(t, 0, svc.PendingCount)
+
+	// Meanwhile a direct DescribeTasks poll for one of the service's tasks still
+	// observes the PROVISIONING launch transient.
+	tasks, err := m.ListTasks(ctx, "prod", "", "", "api")
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+	assert.Equal(t, taskStatusProvisioning, tasks[0].LastStatus)
+}
+
+// TestForceDeregisterInstanceClearsSettleWindow verifies a task force-stopped
+// by deregistering its container instance mid-launch-transient reports STOPPED
+// immediately, not a stale PENDING/PROVISIONING.
+func TestForceDeregisterInstanceClearsSettleWindow(t *testing.T) {
+	m, _ := newSettleMock()
+	ctx := context.Background()
+
+	tdARN := registerSimpleTaskDef(t, m, ctx, "web")
+	_, err := m.CreateCluster(ctx, driver.CreateClusterInput{Name: "prod"})
+	require.NoError(t, err)
+	ci, err := m.RegisterContainerInstance(ctx, driver.RegisterContainerInstanceInput{
+		Cluster: "prod",
+		TotalResources: []driver.Resource{
+			{Name: "CPU", Type: "INTEGER", IntegerValue: 4096},
+			{Name: "MEMORY", Type: "INTEGER", IntegerValue: 8192},
+		},
+	})
+	require.NoError(t, err)
+
+	tasks, failures, err := m.RunTask(ctx, driver.RunTaskInput{Cluster: "prod", TaskDefinition: tdARN})
+	require.NoError(t, err)
+	require.Empty(t, failures)
+	require.Equal(t, statusPending, tasks[0].LastStatus)
+
+	_, err = m.DeregisterContainerInstance(ctx, "prod", ci.ARN, true)
+	require.NoError(t, err)
+
+	described, _, err := m.DescribeTasks(ctx, "prod", []string{tasks[0].ARN})
+	require.NoError(t, err)
+	assert.Equal(t, statusStopped, described[0].LastStatus)
+}
+
+// TestAsyncSettleDefaultOffTaskLifecycle guards the blast radius: with the
+// default options (AsyncSettle off) RunTask/StopTask report their final
+// RUNNING/STOPPED status immediately, exactly as before this change.
+func TestAsyncSettleDefaultOffTaskLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	tdARN := registerSimpleTaskDef(t, m, ctx, "web")
+	_, err := m.CreateCluster(ctx, driver.CreateClusterInput{Name: "prod"})
+	require.NoError(t, err)
+	_, err = m.RegisterContainerInstance(ctx, driver.RegisterContainerInstanceInput{
+		Cluster: "prod",
+		TotalResources: []driver.Resource{
+			{Name: "CPU", Type: "INTEGER", IntegerValue: 4096},
+			{Name: "MEMORY", Type: "INTEGER", IntegerValue: 8192},
+		},
+	})
+	require.NoError(t, err)
+
+	tasks, failures, err := m.RunTask(ctx, driver.RunTaskInput{Cluster: "prod", TaskDefinition: tdARN})
+	require.NoError(t, err)
+	require.Empty(t, failures)
+	assert.Equal(t, statusRunning, tasks[0].LastStatus)
+
+	stopped, err := m.StopTask(ctx, "prod", tasks[0].ARN, "done")
+	require.NoError(t, err)
+	assert.Equal(t, statusStopped, stopped.LastStatus)
+}

--- a/providers/aws/ecs/snapshot.go
+++ b/providers/aws/ecs/snapshot.go
@@ -16,8 +16,10 @@ var _ snapshot.Snapshottable = (*Mock)(nil)
 // "cluster/name", "family:revision" composite keys survive unchanged, so a
 // restore is transparent to clients. The dynamic-host-port counter is preserved
 // so newly placed bridge-mode ports do not collide with restored ones. The
-// mutexes and the optional wired deps (launcher, logs, registrar) are not
-// serialized.
+// mutexes, the optional wired deps (launcher, logs, registrar), and the
+// in-flight taskSettle transients are not serialized — a settle window is a
+// sub-few-second overlay, so a restored task is simply observed in its final
+// state, matching how EC2 excludes its own settle windows.
 type ecsSnapshot struct {
 	Clusters      json.RawMessage `json:"clusters,omitempty"`
 	TaskDefs      json.RawMessage `json:"taskDefs,omitempty"`

--- a/providers/aws/ecs/tasks.go
+++ b/providers/aws/ecs/tasks.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/regionctx"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	"github.com/stackshy/cloudemu/v2/services/container/containerengine"
 	"github.com/stackshy/cloudemu/v2/services/ecs/driver"
 )
@@ -86,6 +87,10 @@ func (m *Mock) RunTask(ctx context.Context, in driver.RunTaskInput) ([]driver.Ta
 			continue
 		}
 
+		// The response reflects what a caller polling DescribeTasks would see
+		// right now: the launch-settle transient (PROVISIONING/PENDING) rather
+		// than the task's already-final RUNNING, when AsyncSettle is enabled.
+		m.overlayStatus(task)
 		tasks = append(tasks, *task)
 	}
 
@@ -226,6 +231,7 @@ func (m *Mock) launchTask(ctx context.Context, spec *taskSpec, pendingOnShortfal
 		m.placeFargate(task, spec.netCfg, spec.platformVersion)
 		m.backTaskWithEngine(ctx, task, spec)
 		m.tasks.Set(task.ARN, task)
+		m.beginLaunchSettle(task)
 		clone := cloneTask(task)
 
 		return &clone, nil
@@ -248,9 +254,69 @@ func (m *Mock) launchTask(ctx context.Context, spec *taskSpec, pendingOnShortfal
 	task.LastStatus = statusRunning
 	m.backTaskWithEngine(ctx, task, spec)
 	m.tasks.Set(task.ARN, task)
+	m.beginLaunchSettle(task)
 	clone := cloneTask(task)
 
 	return &clone, nil
+}
+
+// beginLaunchSettle starts the task's launch settle window — a realistic
+// lastStatus transient shown before the task's already-final RUNNING becomes
+// wire-visible: PROVISIONING while a Fargate task's ENI attaches, PENDING for
+// EC2/EXTERNAL placement (matching AWS's own vocabulary for each launch type).
+// A task whose engine backing already drove it to a terminal state before this
+// call (e.g. a RunToCompletion container that exited immediately) never shows a
+// launch transient, matching real ECS: it skips straight from launch to
+// STOPPED. The window is inactive (immediately observed as final) unless
+// opts.AsyncSettle is enabled.
+func (m *Mock) beginLaunchSettle(task *driver.Task) {
+	if task.LastStatus != statusRunning {
+		return
+	}
+
+	intermediate := statusPending
+	if task.LaunchType == launchFargate {
+		intermediate = taskStatusProvisioning
+	}
+
+	m.taskSettle.Begin(task.ARN, intermediate, m.opts.Clock.Now(), m.opts.SettleDuration(settle.DefaultECSTaskStartSettle))
+}
+
+// beginStopSettle starts the task's stop settle window — a realistic
+// lastStatus transient shown before the task's already-final STOPPED becomes
+// wire-visible: DEPROVISIONING while a Fargate task's ENI detaches, STOPPING
+// for EC2/EXTERNAL. The window is inactive (immediately observed as final)
+// unless opts.AsyncSettle is enabled.
+func (m *Mock) beginStopSettle(task *driver.Task) {
+	intermediate := taskStatusStopping
+	if task.LaunchType == launchFargate {
+		intermediate = taskStatusDeprovisioning
+	}
+
+	m.taskSettle.Begin(task.ARN, intermediate, m.opts.Clock.Now(), m.opts.SettleDuration(settle.DefaultECSTaskStopSettle))
+}
+
+// overlayStatus rewrites t.LastStatus in place with the current settle
+// observation for t.ARN. It is applied only at the wire-response boundary
+// (RunTask/StopTask/ListTasks/DescribeTasks) on an already-cloned task value,
+// never on a record still held by a store, so it can never leak the transient
+// into internal bookkeeping (capacity release, service running/pending counts)
+// which always reads the stored final state directly.
+func (m *Mock) overlayStatus(t *driver.Task) {
+	t.LastStatus = m.taskSettle.State(t.ARN, m.opts.Clock.Now(), t.LastStatus)
+}
+
+// observedTask clones t (a stored record) and overlays its wire-visible
+// lastStatus with the current settle observation, so a caller polling
+// DescribeTasks/ListTasks shortly after RunTask/StopTask sees the realistic
+// PROVISIONING/PENDING or STOPPING/DEPROVISIONING transient (when AsyncSettle
+// is enabled) before the terminal RUNNING/STOPPED — matching the
+// aws-sdk-go-v2 TasksRunning/TasksStopped waiters.
+func (m *Mock) observedTask(t *driver.Task) driver.Task {
+	out := cloneTask(t)
+	m.overlayStatus(&out)
+
+	return out
 }
 
 // markContainers sets every container's last status. A container marked
@@ -450,8 +516,10 @@ func (m *Mock) StopTask(ctx context.Context, cluster, task, reason string) (*dri
 	}
 
 	m.tasks.Set(updated.ARN, &updated)
+	m.beginStopSettle(&updated)
 
 	out := cloneTask(&updated)
+	m.overlayStatus(&out)
 
 	return &out, nil
 }
@@ -488,7 +556,7 @@ func (m *Mock) ListTasks(_ context.Context, cluster, family, desiredStatus, serv
 			continue
 		}
 
-		out = append(out, cloneTask(t))
+		out = append(out, m.observedTask(t))
 	}
 
 	return out, nil
@@ -511,7 +579,7 @@ func (m *Mock) DescribeTasks(_ context.Context, cluster string, ids []string) ([
 
 	for _, id := range ids {
 		if t, ok := m.resolveTask(id); ok && clusterNameFromARN(t.ClusterARN) == want {
-			found = append(found, cloneTask(t))
+			found = append(found, m.observedTask(t))
 			continue
 		}
 

--- a/providers/aws/ecs/tasks.go
+++ b/providers/aws/ecs/tasks.go
@@ -468,7 +468,10 @@ func (m *Mock) networkBindingsFor(networkMode string, mappings []driver.PortMapp
 // StopTask marks a task STOPPED, releasing any container-instance capacity it
 // reserved back to the instance. Releasing is guarded by placeMu (shared with
 // placement) and skipped for an already-stopped task, so a repeated StopTask can
-// never double-credit an instance.
+// never double-credit an instance. The stop-settle window is guarded the same
+// way: a repeated StopTask on an already-stopped task must not restart it,
+// matching real ECS's idempotent StopTask (an already-stopped task is returned
+// as-is, never "un-stopping" back to a transient).
 func (m *Mock) StopTask(ctx context.Context, cluster, task, reason string) (*driver.Task, error) {
 	m.placeMu.Lock()
 	defer m.placeMu.Unlock()
@@ -495,8 +498,16 @@ func (m *Mock) StopTask(ctx context.Context, cluster, task, reason string) (*dri
 		m.engineHandles.Delete(t.ARN)
 	}
 
+	// alreadyStopped is computed once from the task's stored (final) status,
+	// before this call's own mutation below, and gates both the capacity
+	// release and the settle-window start: a repeated StopTask on an
+	// already-stopped task must neither double-credit the instance nor restart
+	// the stop-settle window (which would make a terminal task report
+	// DEPROVISIONING/STOPPING again).
+	alreadyStopped := t.LastStatus == statusStopped
+
 	// Release reserved capacity exactly once, before flipping the task to STOPPED.
-	if t.LastStatus != statusStopped && t.ContainerInstanceARN != "" {
+	if !alreadyStopped && t.ContainerInstanceARN != "" {
 		if td, tdOK := m.resolveTaskDef(t.TaskDefinitionARN); tdOK {
 			cpu, memory := requiredResources(td)
 			m.release(t.ContainerInstanceARN, cpu, memory)
@@ -516,7 +527,10 @@ func (m *Mock) StopTask(ctx context.Context, cluster, task, reason string) (*dri
 	}
 
 	m.tasks.Set(updated.ARN, &updated)
-	m.beginStopSettle(&updated)
+
+	if !alreadyStopped {
+		m.beginStopSettle(&updated)
+	}
 
 	out := cloneTask(&updated)
 	m.overlayStatus(&out)

--- a/server/aws/ecs/async_settle_test.go
+++ b/server/aws/ecs/async_settle_test.go
@@ -1,0 +1,186 @@
+package ecs_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	cloudconfig "github.com/stackshy/cloudemu/v2/config"
+	awsprovider "github.com/stackshy/cloudemu/v2/providers/aws"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newAsyncECS wires a full in-process AWS server with AsyncSettle enabled and a
+// FakeClock the test controls, and returns a real aws-sdk-go-v2 ECS client
+// alongside the clock and the provider (for seeding EC2 capacity). This
+// exercises the actual wire protocol a real user hits.
+func newAsyncECS(t *testing.T) (*awsecs.Client, *awsprovider.Provider, *cloudconfig.FakeClock) {
+	t.Helper()
+
+	fc := cloudconfig.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	cloud := cloudemu.NewAWS(cloudconfig.WithClock(fc), cloudconfig.WithAsyncSettle())
+	srv := awsserver.New(awsserver.Drivers{ECS: cloud.ECS})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	cfg.BaseEndpoint = aws.String(ts.URL)
+
+	return awsecs.NewFromConfig(cfg), cloud, fc
+}
+
+// TestAsyncSettleWireECSTaskLifecycle pins that a real SDK client sees the
+// PENDING->RUNNING and STOPPING->STOPPED task-lifecycle transients through the
+// wire when AsyncSettle is on, driven by the FakeClock. This is the real-user
+// counterpart to the provider-level settle tests.
+func TestAsyncSettleWireECSTaskLifecycle(t *testing.T) {
+	ctx := context.Background()
+	client, cloud, fc := newAsyncECS(t)
+
+	if _, err := client.CreateCluster(ctx, &awsecs.CreateClusterInput{ClusterName: aws.String("prod")}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := client.RegisterTaskDefinition(ctx, &awsecs.RegisterTaskDefinitionInput{
+		Family: aws.String("web"),
+		ContainerDefinitions: []ecstypes.ContainerDefinition{{
+			Name: aws.String("nginx"), Image: aws.String("nginx:latest"), Essential: aws.Bool(true),
+		}},
+	}); err != nil {
+		t.Fatalf("RegisterTaskDefinition: %v", err)
+	}
+
+	// Seed EC2 capacity so the default-launch-type task places onto an instance.
+	cloud.ECS.SeedContainerInstance("prod", "i-0task")
+
+	run, err := client.RunTask(ctx, &awsecs.RunTaskInput{
+		Cluster: aws.String("prod"), TaskDefinition: aws.String("web"),
+	})
+	if err != nil {
+		t.Fatalf("RunTask: %v", err)
+	}
+
+	if len(run.Tasks) != 1 {
+		t.Fatalf("RunTask = %d tasks, want 1", len(run.Tasks))
+	}
+
+	// The RunTask response reports the EC2 launch transient, as real ECS does:
+	// the task has not yet reached RUNNING.
+	if got := aws.ToString(run.Tasks[0].LastStatus); got != "PENDING" {
+		t.Fatalf("RunTask task status = %q, want PENDING", got)
+	}
+
+	taskARN := aws.ToString(run.Tasks[0].TaskArn)
+
+	desc, err := client.DescribeTasks(ctx, &awsecs.DescribeTasksInput{Cluster: aws.String("prod"), Tasks: []string{taskARN}})
+	if err != nil {
+		t.Fatalf("DescribeTasks: %v", err)
+	}
+
+	if got := aws.ToString(desc.Tasks[0].LastStatus); got != "PENDING" {
+		t.Fatalf("describe before settle = %q, want PENDING", got)
+	}
+
+	fc.Advance(3 * time.Second) // past DefaultECSTaskStartSettle (2s)
+
+	desc, err = client.DescribeTasks(ctx, &awsecs.DescribeTasksInput{Cluster: aws.String("prod"), Tasks: []string{taskARN}})
+	if err != nil {
+		t.Fatalf("DescribeTasks: %v", err)
+	}
+
+	if got := aws.ToString(desc.Tasks[0].LastStatus); got != "RUNNING" {
+		t.Fatalf("describe after settle = %q, want RUNNING", got)
+	}
+
+	stopped, err := client.StopTask(ctx, &awsecs.StopTaskInput{
+		Cluster: aws.String("prod"), Task: aws.String(taskARN), Reason: aws.String("done"),
+	})
+	if err != nil {
+		t.Fatalf("StopTask: %v", err)
+	}
+
+	// The StopTask response reports the stop transient: desiredStatus flips to
+	// STOPPED synchronously but lastStatus lags until the container settles.
+	if got := aws.ToString(stopped.Task.LastStatus); got != "STOPPING" {
+		t.Fatalf("StopTask task status = %q, want STOPPING", got)
+	}
+
+	if got := aws.ToString(stopped.Task.DesiredStatus); got != "STOPPED" {
+		t.Fatalf("StopTask desiredStatus = %q, want STOPPED", got)
+	}
+
+	fc.Advance(2 * time.Second) // past DefaultECSTaskStopSettle (1s)
+
+	desc, err = client.DescribeTasks(ctx, &awsecs.DescribeTasksInput{Cluster: aws.String("prod"), Tasks: []string{taskARN}})
+	if err != nil {
+		t.Fatalf("DescribeTasks: %v", err)
+	}
+
+	if got := aws.ToString(desc.Tasks[0].LastStatus); got != "STOPPED" {
+		t.Fatalf("describe after stop settle = %q, want STOPPED", got)
+	}
+}
+
+// TestAsyncSettleWireECSFargateProvisioning pins the Fargate-specific launch
+// transient: PROVISIONING (ENI attachment) rather than the EC2 PENDING.
+func TestAsyncSettleWireECSFargateProvisioning(t *testing.T) {
+	ctx := context.Background()
+	client, _, fc := newAsyncECS(t)
+
+	if _, err := client.RegisterTaskDefinition(ctx, &awsecs.RegisterTaskDefinitionInput{
+		Family:                  aws.String("web"),
+		RequiresCompatibilities: []ecstypes.Compatibility{ecstypes.CompatibilityFargate},
+		NetworkMode:             ecstypes.NetworkModeAwsvpc,
+		Cpu:                     aws.String("256"),
+		Memory:                  aws.String("512"),
+		ContainerDefinitions: []ecstypes.ContainerDefinition{{
+			Name: aws.String("nginx"), Image: aws.String("nginx:latest"), Essential: aws.Bool(true),
+		}},
+	}); err != nil {
+		t.Fatalf("RegisterTaskDefinition: %v", err)
+	}
+
+	run, err := client.RunTask(ctx, &awsecs.RunTaskInput{
+		TaskDefinition: aws.String("web"),
+		LaunchType:     ecstypes.LaunchTypeFargate,
+		NetworkConfiguration: &ecstypes.NetworkConfiguration{
+			AwsvpcConfiguration: &ecstypes.AwsVpcConfiguration{Subnets: []string{"subnet-1"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunTask: %v", err)
+	}
+
+	if got := aws.ToString(run.Tasks[0].LastStatus); got != "PROVISIONING" {
+		t.Fatalf("Fargate RunTask task status = %q, want PROVISIONING", got)
+	}
+
+	taskARN := aws.ToString(run.Tasks[0].TaskArn)
+
+	fc.Advance(3 * time.Second)
+
+	desc, err := client.DescribeTasks(ctx, &awsecs.DescribeTasksInput{Tasks: []string{taskARN}})
+	if err != nil {
+		t.Fatalf("DescribeTasks: %v", err)
+	}
+
+	if got := aws.ToString(desc.Tasks[0].LastStatus); got != "RUNNING" {
+		t.Fatalf("describe after settle = %q, want RUNNING", got)
+	}
+}


### PR DESCRIPTION
## Summary

ECS's control plane (clusters, task definitions with revisions/INACTIVE deregistration, RunTask/StopTask, CreateService/UpdateService desired-count reconciliation, DescribeTasks/DescribeServices) was already implemented in depth — that part pre-existed and is untouched here. The gap this PR closes: every task transition settled *synchronously* to its final state (RunTask -> RUNNING immediately, StopTask -> STOPPED immediately), with no PROVISIONING/PENDING or STOPPING/DEPROVISIONING transient a real user polling DescribeTasks (or an SDK waiter) would observe.

## What was added

- A task lifecycle state machine using the existing `internal/settle` house pattern (the same one EC2/RDS/DynamoDB/etc. already use), gated by `opts.AsyncSettle` (default off — unchanged synchronous behavior):
  - **Launch transient**: PROVISIONING (Fargate — ENI attach) or PENDING (EC2/EXTERNAL) before the already-final RUNNING becomes wire-visible.
  - **Stop transient**: DEPROVISIONING (Fargate — ENI detach) or STOPPING (EC2/EXTERNAL) before the already-final STOPPED becomes wire-visible. `desiredStatus` still flips to STOPPED synchronously, matching real ECS's own desiredStatus/lastStatus split.
- The overlay applies at the wire-response boundary only: `RunTask`, `StopTask`, `ListTasks`, `DescribeTasks`. Internal bookkeeping (EC2 capacity release, service running/pending reconciliation counts) always reads the stored final state, so service convergence stays synchronous and correct regardless of the transient.
- `DeregisterContainerInstance(force=true)` clears any in-flight launch window on the tasks it force-stops, so a task killed mid-transient reports STOPPED immediately rather than a stale PROVISIONING/PENDING.
- Two new settle durations in `internal/settle`: `DefaultECSTaskStartSettle` (2s) and `DefaultECSTaskStopSettle` (1s).

## Tests

- `providers/aws/ecs/lifecycle_settle_test.go`: FakeClock-driven provider-level tests for EC2/Fargate launch transients, the stop transient, service-reconciliation isolation from the overlay, the force-deregister window-clear, and an explicit AsyncSettle-off regression guard.
- `server/aws/ecs/async_settle_test.go`: real `aws-sdk-go-v2/service/ecs` client against the actual wire server, proving RunTask/StopTask/DescribeTasks show the transients end-to-end for both EC2 and Fargate.

## Deferred

- Cluster-level `runningTasksCount`/`pendingTasksCount` (DescribeClusters) still reflect the stored final state rather than the overlay — kept consistent with service reconciliation being synchronous-authoritative.
- Per-container `lastStatus` is not overlaid, only the task-level status (matches what the real SDK waiters — TasksRunning/TasksStopped — actually poll on).
- Engine-backed (real container engine) task transitions and the essential-container-exit fast path are unaffected — those already reflect real observed engine state and never had a synthetic transient to begin with.