### PR TITLE
feat(eks): async cluster & node group state machine

### DIFF
--- a/providers/aws/eks/async_settle_test.go
+++ b/providers/aws/eks/async_settle_test.go
@@ -1,0 +1,224 @@
+package eks
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
+	eksdriver "github.com/stackshy/cloudemu/v2/providers/aws/eks/driver"
+)
+
+// newAsyncMock builds an EKS mock with AsyncSettle enabled and a FakeClock so
+// create/update report their real transient states deterministically.
+func newAsyncMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("us-east-1"),
+		config.WithAccountID("123456789012"),
+		config.WithAsyncSettle(),
+	)
+
+	return New(opts), fc
+}
+
+func clusterStatus(t *testing.T, m *Mock, name string) string {
+	t.Helper()
+
+	got, err := m.DescribeCluster(context.Background(), name)
+	if err != nil {
+		t.Fatalf("describe cluster: %v", err)
+	}
+
+	return got.Status
+}
+
+func nodegroupStatus(t *testing.T, m *Mock, clusterName, nodegroupName string) string {
+	t.Helper()
+
+	got, err := m.DescribeNodegroup(context.Background(), clusterName, nodegroupName)
+	if err != nil {
+		t.Fatalf("describe nodegroup: %v", err)
+	}
+
+	return got.Status
+}
+
+// TestAsyncSettleClusterCreateUpdate pins the AsyncSettle transitions for a
+// cluster: CREATING then ACTIVE on create, UPDATING then ACTIVE on update, and
+// a rejected overlapping update while the window is still open.
+func TestAsyncSettleClusterCreateUpdate(t *testing.T) {
+	m, fc := newAsyncMock()
+	ctx := context.Background()
+
+	created, err := m.CreateCluster(ctx, eksdriver.ClusterConfig{Name: "c1", Version: "1.30"})
+	if err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if created.Status != eksdriver.ClusterStatusCreating {
+		t.Fatalf("create status = %q, want %q", created.Status, eksdriver.ClusterStatusCreating)
+	}
+
+	if got := clusterStatus(t, m, "c1"); got != eksdriver.ClusterStatusCreating {
+		t.Fatalf("describe status = %q, want %q", got, eksdriver.ClusterStatusCreating)
+	}
+
+	// A cluster-level update is rejected while creation is still settling.
+	if _, err := m.UpdateClusterVersion(ctx, "c1", "1.31"); err == nil {
+		t.Fatal("expected UpdateClusterVersion to reject a cluster that is still CREATING")
+	}
+
+	// Nodegroup creation is rejected too: the cluster isn't ACTIVE yet.
+	if _, err := m.CreateNodegroup(ctx, eksdriver.NodegroupConfig{ClusterName: "c1", NodegroupName: "ng1"}); err == nil {
+		t.Fatal("expected CreateNodegroup to reject a cluster that is not ACTIVE")
+	}
+
+	// Still transient one instant before the window elapses.
+	fc.Advance(settle.DefaultClusterSettle - time.Millisecond)
+
+	if got := clusterStatus(t, m, "c1"); got != eksdriver.ClusterStatusCreating {
+		t.Fatalf("pre-settle status = %q, want %q", got, eksdriver.ClusterStatusCreating)
+	}
+
+	// Past the window: terminal ACTIVE.
+	fc.Advance(time.Millisecond)
+
+	if got := clusterStatus(t, m, "c1"); got != eksdriver.ClusterStatusActive {
+		t.Fatalf("settled status = %q, want %q", got, eksdriver.ClusterStatusActive)
+	}
+
+	// Update -> UPDATING -> ACTIVE.
+	updated, err := m.UpdateClusterVersion(ctx, "c1", "1.31")
+	if err != nil {
+		t.Fatalf("update cluster version: %v", err)
+	}
+
+	if updated.Status != "Successful" {
+		t.Fatalf("update record status = %q, want Successful", updated.Status)
+	}
+
+	if got := clusterStatus(t, m, "c1"); got != eksdriver.ClusterStatusUpdating {
+		t.Fatalf("post-update describe status = %q, want %q", got, eksdriver.ClusterStatusUpdating)
+	}
+
+	// A second update is rejected while the first is still settling.
+	if _, err := m.UpdateClusterConfig(ctx, "c1", eksdriver.VPCConfig{}, nil); err == nil {
+		t.Fatal("expected UpdateClusterConfig to reject an overlapping update")
+	}
+
+	fc.Advance(settle.DefaultClusterSettle)
+
+	if got := clusterStatus(t, m, "c1"); got != eksdriver.ClusterStatusActive {
+		t.Fatalf("post-update settled status = %q, want %q", got, eksdriver.ClusterStatusActive)
+	}
+}
+
+// TestAsyncSettleNodegroupCreateUpdate pins the AsyncSettle transitions for a
+// nodegroup: CREATING then ACTIVE on create, UPDATING then ACTIVE on config
+// update, and a rejected overlapping update while the window is still open.
+func TestAsyncSettleNodegroupCreateUpdate(t *testing.T) {
+	m, fc := newAsyncMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, eksdriver.ClusterConfig{Name: "c1", Version: "1.30"})
+	if err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	fc.Advance(settle.DefaultClusterSettle)
+
+	created, err := m.CreateNodegroup(ctx, eksdriver.NodegroupConfig{
+		ClusterName:   "c1",
+		NodegroupName: "ng1",
+		ScalingConfig: eksdriver.NodegroupScalingConfig{MinSize: 1, MaxSize: 3, DesiredSize: 2},
+	})
+	if err != nil {
+		t.Fatalf("create nodegroup: %v", err)
+	}
+
+	if created.Status != eksdriver.NodegroupStatusCreating {
+		t.Fatalf("create status = %q, want %q", created.Status, eksdriver.NodegroupStatusCreating)
+	}
+
+	if got := nodegroupStatus(t, m, "c1", "ng1"); got != eksdriver.NodegroupStatusCreating {
+		t.Fatalf("describe status = %q, want %q", got, eksdriver.NodegroupStatusCreating)
+	}
+
+	// An update is rejected while creation is still settling.
+	if _, err := m.UpdateNodegroupConfig(ctx, "c1", "ng1", eksdriver.NodegroupConfigUpdate{}); err == nil {
+		t.Fatal("expected UpdateNodegroupConfig to reject a nodegroup that is still CREATING")
+	}
+
+	fc.Advance(settle.DefaultClusterSettle)
+
+	if got := nodegroupStatus(t, m, "c1", "ng1"); got != eksdriver.NodegroupStatusActive {
+		t.Fatalf("settled status = %q, want %q", got, eksdriver.NodegroupStatusActive)
+	}
+
+	scaling := eksdriver.NodegroupScalingConfig{MinSize: 2, MaxSize: 5, DesiredSize: 4}
+
+	upd, err := m.UpdateNodegroupConfig(ctx, "c1", "ng1", eksdriver.NodegroupConfigUpdate{Scaling: &scaling})
+	if err != nil {
+		t.Fatalf("update nodegroup config: %v", err)
+	}
+
+	if upd.Status != "Successful" {
+		t.Fatalf("update record status = %q, want Successful", upd.Status)
+	}
+
+	if got := nodegroupStatus(t, m, "c1", "ng1"); got != eksdriver.NodegroupStatusUpdating {
+		t.Fatalf("post-update describe status = %q, want %q", got, eksdriver.NodegroupStatusUpdating)
+	}
+
+	fc.Advance(settle.DefaultClusterSettle)
+
+	got, err := m.DescribeNodegroup(ctx, "c1", "ng1")
+	if err != nil {
+		t.Fatalf("describe nodegroup: %v", err)
+	}
+
+	if got.Status != eksdriver.NodegroupStatusActive {
+		t.Fatalf("settled status = %q, want %q", got.Status, eksdriver.NodegroupStatusActive)
+	}
+
+	if got.ScalingConfig.DesiredSize != 4 {
+		t.Fatalf("desiredSize = %d, want 4", got.ScalingConfig.DesiredSize)
+	}
+}
+
+// TestAsyncSettleDefaultOff confirms the default (AsyncSettle unset) path is
+// byte-for-byte synchronous: create and update are observed as ACTIVE
+// immediately, with no transient state and no overlapping-update rejection.
+func TestAsyncSettleDefaultOff(t *testing.T) {
+	m := newTestMock() // no WithAsyncSettle
+	ctx := context.Background()
+
+	created, err := m.CreateCluster(ctx, eksdriver.ClusterConfig{Name: "c1", Version: "1.30"})
+	if err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if created.Status != eksdriver.ClusterStatusActive {
+		t.Fatalf("create status = %q, want %q", created.Status, eksdriver.ClusterStatusActive)
+	}
+
+	ng, err := m.CreateNodegroup(ctx, eksdriver.NodegroupConfig{ClusterName: "c1", NodegroupName: "ng1"})
+	if err != nil {
+		t.Fatalf("create nodegroup: %v", err)
+	}
+
+	if ng.Status != eksdriver.NodegroupStatusActive {
+		t.Fatalf("nodegroup create status = %q, want %q", ng.Status, eksdriver.NodegroupStatusActive)
+	}
+
+	if _, err := m.UpdateClusterVersion(ctx, "c1", "1.31"); err != nil {
+		t.Fatalf("update cluster version: %v", err)
+	}
+
+	if got := clusterStatus(t, m, "c1"); got != eksdriver.ClusterStatusActive {
+		t.Fatalf("post-update status = %q, want %q", got, eksdriver.ClusterStatusActive)
+	}
+}

--- a/providers/aws/eks/eks.go
+++ b/providers/aws/eks/eks.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/internal/regionctx"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	eksdriver "github.com/stackshy/cloudemu/v2/providers/aws/eks/driver"
 	"github.com/stackshy/cloudemu/v2/services/kubernetes"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
@@ -89,6 +90,17 @@ type Mock struct {
 	k8sAPI *kubernetes.APIServer
 	// k8sUIDs maps cluster name → the UID we registered with k8sAPI.
 	k8sUIDs map[string]string
+
+	// clusterSettle overlays a transient CREATING/UPDATING window (keyed by
+	// cluster name) over a cluster's stored ACTIVE status, matching real EKS
+	// (CreateCluster / UpdateClusterVersion / UpdateClusterConfig -> transient
+	// -> ACTIVE). It is a no-op unless config.Options.AsyncSettle is set
+	// (SettleDuration returns 0 -> inactive window -> the historical
+	// synchronous behavior). The Set has its own lock.
+	clusterSettle *settle.Set
+	// nodegroupSettle is the nodegroup analog of clusterSettle, keyed by
+	// nodegroupKey(clusterName, nodegroupName).
+	nodegroupSettle *settle.Set
 }
 
 // New creates a new AWS EKS mock.
@@ -101,6 +113,8 @@ func New(opts *config.Options) *Mock {
 		updates:         memstore.New[eksdriver.ClusterUpdate](),
 		opts:            opts,
 		k8sUIDs:         make(map[string]string),
+		clusterSettle:   settle.NewSet(),
+		nodegroupSettle: settle.NewSet(),
 	}
 }
 
@@ -528,8 +542,17 @@ func (m *Mock) CreateCluster(ctx context.Context, cfg eksdriver.ClusterConfig) (
 
 	m.emitClusterMetrics(cfg.Name)
 
+	// Under AsyncSettle a fresh cluster reports CREATING until the window
+	// elapses, matching real EKS (CreateCluster -> CREATING -> ACTIVE). With
+	// the default (AsyncSettle off) SettleDuration is 0 -> inactive window ->
+	// ACTIVE immediately, so nothing changes for existing callers. The stored
+	// row keeps the terminal status; only the read-path copy is overlaid.
+	m.clusterSettle.Begin(cfg.Name, eksdriver.ClusterStatusCreating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultClusterSettle))
+
 	out := cluster
 	m.withK8sEndpoint(&out)
+	m.overlayClusterStatus(&out)
 
 	return &out, nil
 }
@@ -563,6 +586,29 @@ func (m *Mock) withK8sEndpoint(c *eksdriver.Cluster) {
 	// with ServingTLSConfig, so a caller can validate what it dials.
 }
 
+// clusterStatusLocked returns c's current status, overlaid with any active
+// clusterSettle window (CREATING/UPDATING until it elapses, then the stored
+// terminal status). Caller must hold at least an RLock on m.mu.
+func (m *Mock) clusterStatusLocked(c *eksdriver.Cluster) string {
+	return m.clusterSettle.State(c.Name, m.opts.Clock.Now(), c.Status)
+}
+
+// overlayClusterStatus mutates c.Status in place to the settle-overlaid value.
+// Caller must hold at least an RLock on m.mu.
+func (m *Mock) overlayClusterStatus(c *eksdriver.Cluster) {
+	c.Status = m.clusterStatusLocked(c)
+}
+
+// nodegroupStatusLocked is the nodegroup analog of clusterStatusLocked.
+func (m *Mock) nodegroupStatusLocked(ng *eksdriver.Nodegroup) string {
+	return m.nodegroupSettle.State(nodegroupKey(ng.ClusterName, ng.NodegroupName), m.opts.Clock.Now(), ng.Status)
+}
+
+// overlayNodegroupStatus is the nodegroup analog of overlayClusterStatus.
+func (m *Mock) overlayNodegroupStatus(ng *eksdriver.Nodegroup) {
+	ng.Status = m.nodegroupStatusLocked(ng)
+}
+
 // DescribeCluster looks up a cluster by name.
 func (m *Mock) DescribeCluster(_ context.Context, name string) (*eksdriver.Cluster, error) {
 	m.mu.RLock()
@@ -575,6 +621,7 @@ func (m *Mock) DescribeCluster(_ context.Context, name string) (*eksdriver.Clust
 
 	out := c
 	m.withK8sEndpoint(&out)
+	m.overlayClusterStatus(&out)
 
 	return &out, nil
 }
@@ -603,6 +650,11 @@ func (m *Mock) UpdateClusterConfig(
 		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", name)
 	}
 
+	if status := m.clusterStatusLocked(&c); status != eksdriver.ClusterStatusActive {
+		return nil, resourceInUseErrf(
+			"cluster %q already has a pending update (status %s); only one update is allowed at a time", name, status)
+	}
+
 	if len(cfg.SubnetIDs) > 0 {
 		c.VPCConfig.SubnetIDs = copyStrings(cfg.SubnetIDs)
 	}
@@ -623,6 +675,9 @@ func (m *Mock) UpdateClusterConfig(
 	}
 
 	m.clusters.Set(name, c)
+
+	m.clusterSettle.Begin(name, eksdriver.ClusterStatusUpdating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultClusterSettle))
 
 	return m.recordUpdate(&eksdriver.ClusterUpdate{
 		ID:          newUpdateID(),
@@ -647,8 +702,16 @@ func (m *Mock) UpdateClusterVersion(_ context.Context, name, version string) (*e
 		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", name)
 	}
 
+	if status := m.clusterStatusLocked(&c); status != eksdriver.ClusterStatusActive {
+		return nil, resourceInUseErrf(
+			"cluster %q already has a pending update (status %s); only one update is allowed at a time", name, status)
+	}
+
 	c.Version = version
 	m.clusters.Set(name, c)
+
+	m.clusterSettle.Begin(name, eksdriver.ClusterStatusUpdating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultClusterSettle))
 
 	return m.recordUpdate(&eksdriver.ClusterUpdate{
 		ID:          newUpdateID(),
@@ -696,6 +759,7 @@ func (m *Mock) DeleteCluster(_ context.Context, name string) (*eksdriver.Cluster
 	c.Status = eksdriver.ClusterStatusDeleting
 
 	m.clusters.Delete(name)
+	m.clusterSettle.Clear(name)
 
 	// Resolve the endpoint before deregistering: the response describes the
 	// cluster as it was, and reading afterwards yields the not-implemented
@@ -781,6 +845,11 @@ func (m *Mock) CreateNodegroup(_ context.Context, cfg eksdriver.NodegroupConfig)
 		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cfg.ClusterName)
 	}
 
+	if status := m.clusterStatusLocked(&parent); status != eksdriver.ClusterStatusActive {
+		return nil, resourceInUseErrf(
+			"cluster %q is not ACTIVE (currently %s); cannot create a nodegroup", cfg.ClusterName, status)
+	}
+
 	key := nodegroupKey(cfg.ClusterName, cfg.NodegroupName)
 	if _, ok := m.nodegroups.Get(key); ok {
 		return nil, cerrors.Newf(cerrors.AlreadyExists,
@@ -831,7 +900,15 @@ func (m *Mock) CreateNodegroup(_ context.Context, cfg eksdriver.NodegroupConfig)
 
 	m.nodegroups.Set(key, ng)
 
+	// Under AsyncSettle a fresh nodegroup reports CREATING until the window
+	// elapses, matching real EKS. With the default (AsyncSettle off)
+	// SettleDuration is 0 -> inactive window -> ACTIVE immediately, so nothing
+	// changes for existing callers.
+	m.nodegroupSettle.Begin(key, eksdriver.NodegroupStatusCreating, now,
+		m.opts.SettleDuration(settle.DefaultClusterSettle))
+
 	out := ng
+	m.overlayNodegroupStatus(&out)
 
 	return &out, nil
 }
@@ -848,6 +925,7 @@ func (m *Mock) DescribeNodegroup(_ context.Context, clusterName, nodegroupName s
 	}
 
 	out := ng
+	m.overlayNodegroupStatus(&out)
 
 	return &out, nil
 }
@@ -893,6 +971,12 @@ func (m *Mock) UpdateNodegroupConfig(
 			"nodegroup %q not found in cluster %q", nodegroupName, clusterName)
 	}
 
+	if status := m.nodegroupStatusLocked(&ng); status != eksdriver.NodegroupStatusActive {
+		return nil, resourceInUseErrf(
+			"nodegroup %q already has a pending update (status %s); only one update is allowed at a time",
+			nodegroupName, status)
+	}
+
 	if upd.Scaling != nil {
 		if err := validateScaling(*upd.Scaling); err != nil {
 			return nil, err
@@ -906,6 +990,9 @@ func (m *Mock) UpdateNodegroupConfig(
 	ng.ModifiedAt = m.opts.Clock.Now().UTC()
 
 	m.nodegroups.Set(key, ng)
+
+	m.nodegroupSettle.Begin(key, eksdriver.NodegroupStatusUpdating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultClusterSettle))
 
 	return m.recordUpdate(&eksdriver.ClusterUpdate{
 		ID:            newUpdateID(),
@@ -932,6 +1019,12 @@ func (m *Mock) UpdateNodegroupVersion(
 			"nodegroup %q not found in cluster %q", nodegroupName, clusterName)
 	}
 
+	if status := m.nodegroupStatusLocked(&ng); status != eksdriver.NodegroupStatusActive {
+		return nil, resourceInUseErrf(
+			"nodegroup %q already has a pending update (status %s); only one update is allowed at a time",
+			nodegroupName, status)
+	}
+
 	if version != "" {
 		ng.Version = version
 	}
@@ -943,6 +1036,9 @@ func (m *Mock) UpdateNodegroupVersion(
 	ng.ModifiedAt = m.opts.Clock.Now().UTC()
 
 	m.nodegroups.Set(key, ng)
+
+	m.nodegroupSettle.Begin(key, eksdriver.NodegroupStatusUpdating, m.opts.Clock.Now(),
+		m.opts.SettleDuration(settle.DefaultClusterSettle))
 
 	return m.recordUpdate(&eksdriver.ClusterUpdate{
 		ID:            newUpdateID(),
@@ -970,6 +1066,7 @@ func (m *Mock) DeleteNodegroup(_ context.Context, clusterName, nodegroupName str
 	ng.Status = eksdriver.NodegroupStatusDeleting
 
 	m.nodegroups.Delete(key)
+	m.nodegroupSettle.Clear(key)
 
 	out := ng
 

--- a/server/aws/eks/async_settle_test.go
+++ b/server/aws/eks/async_settle_test.go
@@ -1,0 +1,142 @@
+package eks_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	cloudconfig "github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newAsyncSDKClient builds an EKS SDK client backed by a cloudemu server with
+// AsyncSettle enabled and a FakeClock the test can advance, so create/update
+// report their real transient states deterministically over the wire.
+func newAsyncSDKClient(t *testing.T) (*awseks.Client, *cloudconfig.FakeClock) {
+	t.Helper()
+
+	fc := cloudconfig.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	cloud := cloudemu.NewAWS(cloudconfig.WithClock(fc), cloudconfig.WithAsyncSettle())
+
+	ts := httptest.NewServer(awsserver.New(awsserver.Drivers{EKS: cloud.EKS}))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")))
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	client := awseks.NewFromConfig(cfg, func(o *awseks.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+
+	return client, fc
+}
+
+// TestAsyncSettleWireEKSClusterAndNodegroup pins that a real SDK client sees a
+// cluster as CREATING (then ACTIVE), rejects a nodegroup on a cluster that
+// isn't ACTIVE yet, and sees a nodegroup as CREATING (then ACTIVE) too — all
+// over the wire, driven purely by a FakeClock.
+func TestAsyncSettleWireEKSClusterAndNodegroup(t *testing.T) {
+	client, fc := newAsyncSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateCluster(ctx, &awseks.CreateClusterInput{
+		Name:               aws.String("c1"),
+		RoleArn:            aws.String("arn:aws:iam::1:role/r"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{SubnetIds: []string{"subnet-1"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if created.Cluster.Status != ekstypes.ClusterStatusCreating {
+		t.Fatalf("create status = %q, want CREATING", created.Cluster.Status)
+	}
+
+	desc, err := client.DescribeCluster(ctx, &awseks.DescribeClusterInput{Name: aws.String("c1")})
+	if err != nil {
+		t.Fatalf("DescribeCluster: %v", err)
+	}
+
+	if desc.Cluster.Status != ekstypes.ClusterStatusCreating {
+		t.Fatalf("describe status = %q, want CREATING", desc.Cluster.Status)
+	}
+
+	// A managed node group cannot be created while the cluster is still
+	// CREATING — real EKS requires ACTIVE.
+	_, err = client.CreateNodegroup(ctx, &awseks.CreateNodegroupInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("ng1"),
+		NodeRole:      aws.String("arn:aws:iam::1:role/r"),
+		Subnets:       []string{"subnet-1"},
+	})
+
+	var inUse *ekstypes.ResourceInUseException
+	if !errors.As(err, &inUse) {
+		t.Fatalf("CreateNodegroup(cluster CREATING) err = %v, want ResourceInUseException", err)
+	}
+
+	fc.Advance(settle.DefaultClusterSettle)
+
+	desc, err = client.DescribeCluster(ctx, &awseks.DescribeClusterInput{Name: aws.String("c1")})
+	if err != nil {
+		t.Fatalf("DescribeCluster after settle: %v", err)
+	}
+
+	if desc.Cluster.Status != ekstypes.ClusterStatusActive {
+		t.Fatalf("settled status = %q, want ACTIVE", desc.Cluster.Status)
+	}
+
+	// Now that the cluster is ACTIVE, node group creation succeeds and itself
+	// starts in CREATING.
+	ngOut, err := client.CreateNodegroup(ctx, &awseks.CreateNodegroupInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("ng1"),
+		NodeRole:      aws.String("arn:aws:iam::1:role/r"),
+		Subnets:       []string{"subnet-1"},
+	})
+	if err != nil {
+		t.Fatalf("CreateNodegroup: %v", err)
+	}
+
+	if ngOut.Nodegroup.Status != ekstypes.NodegroupStatusCreating {
+		t.Fatalf("nodegroup create status = %q, want CREATING", ngOut.Nodegroup.Status)
+	}
+
+	ngDesc, err := client.DescribeNodegroup(ctx, &awseks.DescribeNodegroupInput{
+		ClusterName: aws.String("c1"), NodegroupName: aws.String("ng1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeNodegroup: %v", err)
+	}
+
+	if ngDesc.Nodegroup.Status != ekstypes.NodegroupStatusCreating {
+		t.Fatalf("nodegroup describe status = %q, want CREATING", ngDesc.Nodegroup.Status)
+	}
+
+	fc.Advance(settle.DefaultClusterSettle)
+
+	ngDesc, err = client.DescribeNodegroup(ctx, &awseks.DescribeNodegroupInput{
+		ClusterName: aws.String("c1"), NodegroupName: aws.String("ng1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeNodegroup after settle: %v", err)
+	}
+
+	if ngDesc.Nodegroup.Status != ekstypes.NodegroupStatusActive {
+		t.Fatalf("nodegroup settled status = %q, want ACTIVE", ngDesc.Nodegroup.Status)
+	}
+}


### PR DESCRIPTION
## Summary

EKS control-plane CRUD (clusters, managed node groups, Fargate profiles, add-ons), cascade-delete guards, and tagging already existed and were well covered. The gap: every create/update settled synchronously to ACTIVE, with no observable CREATING/UPDATING window — unlike real EKS, whose lifecycle transitions are genuinely async and pollable via DescribeCluster/DescribeNodegroup.

This wires the existing `internal/settle` overlay (the same pattern MemoryDB/Redshift/RDS/ACM use) into EKS clusters and node groups:

- `CreateCluster`/`CreateNodegroup` report `CREATING` until the settle window elapses, then `ACTIVE`. Opt-in via `config.WithAsyncSettle()`; default (off) stays byte-for-byte synchronous.
- `UpdateClusterVersion`/`UpdateClusterConfig`/`UpdateNodegroupConfig`/`UpdateNodegroupVersion` report `UPDATING` the same way, and now reject an overlapping update with `ResourceInUseException` while a prior create/update is still settling — matching real EKS's "only one update at a time" rule.
- `CreateNodegroup` now requires the parent cluster to be `ACTIVE` (`ResourceInUseException` otherwise), matching real EKS instead of silently allowing a nodegroup on a still-creating cluster.
- Settle windows are cleared on `DeleteCluster`/`DeleteNodegroup`.

## Deferred

- Same settle treatment for Fargate profiles and add-ons (currently still synchronous ACTIVE).
- An OIDC/access-entries depth pass.
- Wiring the cluster to the in-memory Kubernetes data plane's real lifecycle (see feasibility note below).

## Kubectl data-plane integration feasibility

`providers/aws/eks/eks.go` already has the seam: `Mock.k8sAPI *kubernetes.APIServer` plus `SetK8sAPI`/`withK8sEndpoint` register a real in-memory apiserver per cluster and advertise its endpoint once wired in (currently unused by the default wiring — `Endpoint` falls back to a `*-DATAPLANE-NOT-IMPLEMENTED` sentinel). A follow-up that calls `SetK8sAPI` from the provider factory and ties the new CREATING/ACTIVE cluster state machine to the apiserver's readiness (e.g. don't expose the k8s endpoint until the cluster's settle window elapses) looks straightforward — the plumbing is already there, just not connected end-to-end.

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers/aws/eks/... ./server/aws/eks/... -race -count=1`
- [x] `go test ./providers/aws/... ./server/aws/...`
- [x] `gofmt -l` on touched files (clean)
- [x] `golangci-lint run --new-from-rev=5fb1e2b7 ./providers/aws/eks/... ./server/aws/eks/...` — 0 new issues
- [x] `go generate ./...` — `docs/coverage` unchanged (no driver interface change)
- [x] `go mod tidy` — no changes
- [x] New provider-level tests (`providers/aws/eks/async_settle_test.go`): CREATING→ACTIVE, UPDATING→ACTIVE, overlapping-update rejection, cluster-not-ACTIVE nodegroup rejection, and a default-off synchronous-behavior pin
- [x] New wire-level SDK test (`server/aws/eks/async_settle_test.go`, real `aws-sdk-go-v2/service/eks` client): CreateCluster→CREATING, CreateNodegroup on a still-creating cluster→ResourceInUseException, settle→ACTIVE, CreateNodegroup→CREATING→ACTIVE over the wire