### PR TITLE
feat(gke): cluster & node pool lifecycle

### DIFF
--- a/internal/settle/settle.go
+++ b/internal/settle/settle.go
@@ -39,6 +39,10 @@ const (
 	DefaultCloudSQLSettle    = 3 * time.Second // Cloud SQL PENDING_CREATE->RUNNABLE
 	DefaultAzureDBSettle     = 3 * time.Second // Azure SQL/flex Creating->Succeeded/Ready
 	DefaultKeyspacesSettle   = 2 * time.Second // Keyspaces table CREATING->ACTIVE
+
+	DefaultGKEClusterSettle   = 3 * time.Second // GKE cluster PROVISIONING->RUNNING
+	DefaultGKENodePoolSettle  = 2 * time.Second // GKE node pool PROVISIONING->RUNNING
+	DefaultGKEReconcileSettle = 1 * time.Second // GKE node pool RECONCILING->RUNNING (resize/mutate)
 )
 
 // Window is a read-time overlay describing a resource still settling into its

--- a/providers/gcp/gke/async_settle_test.go
+++ b/providers/gcp/gke/async_settle_test.go
@@ -1,0 +1,226 @@
+package gke
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
+)
+
+// newAsyncMock builds a GKE mock with AsyncSettle enabled and a FakeClock so
+// create/mutate calls report their real transient GKE states deterministically.
+func newAsyncMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("us-central1"),
+		config.WithProjectID("mock-project"),
+		config.WithAsyncSettle(),
+	)
+
+	return New(opts), fc
+}
+
+// TestAsyncSettleClusterCreate pins the AsyncSettle transitions for
+// CreateCluster: the cluster and its bootstrap default node pool report
+// PROVISIONING (and the create operation reports RUNNING) until the cluster
+// settle window elapses, then RUNNING/DONE.
+func TestAsyncSettleClusterCreate(t *testing.T) {
+	m, fc := newAsyncMock()
+	ctx := context.Background()
+
+	c, op, err := m.CreateCluster(ctx, &CreateClusterInput{Name: "prod", Location: "us-central1"})
+	requireNoError(t, err)
+
+	if c.Status != statusProvisioning {
+		t.Fatalf("create response Status = %q, want %q", c.Status, statusProvisioning)
+	}
+
+	if op.Status != opStatusRunning {
+		t.Fatalf("create response op.Status = %q, want %q", op.Status, opStatusRunning)
+	}
+
+	got, err := m.GetCluster(ctx, "us-central1", "prod")
+	requireNoError(t, err)
+
+	if got.Status != statusProvisioning {
+		t.Fatalf("GetCluster before settle = %q, want %q", got.Status, statusProvisioning)
+	}
+
+	pool, err := m.GetNodePool(ctx, "us-central1", "prod", "default-pool")
+	requireNoError(t, err)
+
+	if pool.Status != statusProvisioning {
+		t.Fatalf("GetNodePool before settle = %q, want %q", pool.Status, statusProvisioning)
+	}
+
+	opGot, err := m.GetOperation(ctx, "us-central1", op.Name)
+	requireNoError(t, err)
+
+	if opGot.Status != opStatusRunning {
+		t.Fatalf("GetOperation before settle = %q, want %q", opGot.Status, opStatusRunning)
+	}
+
+	// Still transient one instant before the window elapses.
+	fc.Advance(settle.DefaultGKEClusterSettle - time.Millisecond)
+
+	got, _ = m.GetCluster(ctx, "us-central1", "prod")
+	if got.Status != statusProvisioning {
+		t.Fatalf("GetCluster just before settle = %q, want %q", got.Status, statusProvisioning)
+	}
+
+	// Past the window: cluster, node pool, and operation all settle together.
+	fc.Advance(time.Millisecond)
+
+	got, _ = m.GetCluster(ctx, "us-central1", "prod")
+	if got.Status != statusRunning {
+		t.Fatalf("GetCluster after settle = %q, want %q", got.Status, statusRunning)
+	}
+
+	pool, _ = m.GetNodePool(ctx, "us-central1", "prod", "default-pool")
+	if pool.Status != statusRunning {
+		t.Fatalf("GetNodePool after settle = %q, want %q", pool.Status, statusRunning)
+	}
+
+	opGot, _ = m.GetOperation(ctx, "us-central1", op.Name)
+	if opGot.Status != opStatusDone {
+		t.Fatalf("GetOperation after settle = %q, want %q", opGot.Status, opStatusDone)
+	}
+}
+
+// TestAsyncSettleNodePoolCreate pins the standalone CreateNodePool transition:
+// PROVISIONING -> RUNNING over the node-pool settle window, independent of the
+// (already-settled) parent cluster.
+func TestAsyncSettleNodePoolCreate(t *testing.T) {
+	m, fc := newAsyncMock()
+	ctx := context.Background()
+
+	_, _, err := m.CreateCluster(ctx, &CreateClusterInput{Name: "host", Location: "us-central1"})
+	requireNoError(t, err)
+
+	fc.Advance(settle.DefaultGKEClusterSettle)
+
+	np, op, err := m.CreateNodePool(ctx, "us-central1", "host", &NodePoolSpec{Name: "extra", InitialNodeCount: int64Ptr(1)})
+	requireNoError(t, err)
+
+	if np.Status != statusProvisioning {
+		t.Fatalf("CreateNodePool response Status = %q, want %q", np.Status, statusProvisioning)
+	}
+
+	if op.Status != opStatusRunning {
+		t.Fatalf("CreateNodePool response op.Status = %q, want %q", op.Status, opStatusRunning)
+	}
+
+	fc.Advance(settle.DefaultGKENodePoolSettle)
+
+	got, err := m.GetNodePool(ctx, "us-central1", "host", "extra")
+	requireNoError(t, err)
+
+	if got.Status != statusRunning {
+		t.Fatalf("GetNodePool after settle = %q, want %q", got.Status, statusRunning)
+	}
+}
+
+// TestAsyncSettleNodePoolResize pins SetNodePoolSize: the node count applies
+// immediately (currentNodeCount is never gated by the settle window) while the
+// pool's status briefly reports RECONCILING before settling back to RUNNING.
+func TestAsyncSettleNodePoolResize(t *testing.T) {
+	m, fc := newAsyncMock()
+	ctx := context.Background()
+
+	_, _, err := m.CreateCluster(ctx, &CreateClusterInput{Name: "host", Location: "us-central1", InitialNodeCount: int64Ptr(1)})
+	requireNoError(t, err)
+
+	fc.Advance(settle.DefaultGKEClusterSettle)
+
+	op, err := m.SetNodePoolSize(ctx, "us-central1", "host", "default-pool", 3)
+	requireNoError(t, err)
+
+	if op.Status != opStatusRunning {
+		t.Fatalf("SetNodePoolSize response op.Status = %q, want %q", op.Status, opStatusRunning)
+	}
+
+	got, err := m.GetNodePool(ctx, "us-central1", "host", "default-pool")
+	requireNoError(t, err)
+
+	if got.NodeCount != 3 {
+		t.Fatalf("NodeCount = %d, want 3 (applied immediately, not gated by settle)", got.NodeCount)
+	}
+
+	if got.Status != statusReconciling {
+		t.Fatalf("Status during resize = %q, want %q", got.Status, statusReconciling)
+	}
+
+	fc.Advance(settle.DefaultGKEReconcileSettle)
+
+	got, _ = m.GetNodePool(ctx, "us-central1", "host", "default-pool")
+	if got.Status != statusRunning {
+		t.Fatalf("Status after resize settle = %q, want %q", got.Status, statusRunning)
+	}
+
+	if got.NodeCount != 3 {
+		t.Fatalf("NodeCount after settle = %d, want 3", got.NodeCount)
+	}
+}
+
+// TestAsyncSettleCancelSupersedesWindow proves a cancel is observed
+// immediately even while a create's settle window is still open.
+func TestAsyncSettleCancelSupersedesWindow(t *testing.T) {
+	m, _ := newAsyncMock()
+	ctx := context.Background()
+
+	_, op, err := m.CreateCluster(ctx, &CreateClusterInput{Name: "prod", Location: "us-central1"})
+	requireNoError(t, err)
+
+	if err := m.CancelOperation(ctx, "us-central1", op.Name); err != nil {
+		t.Fatalf("CancelOperation: %v", err)
+	}
+
+	got, err := m.GetOperation(ctx, "us-central1", op.Name)
+	requireNoError(t, err)
+
+	if got.Status != opStatusAborting {
+		t.Fatalf("GetOperation after cancel = %q, want %q (must not be masked by the pending RUNNING window)", got.Status, opStatusAborting)
+	}
+}
+
+// TestAsyncSettleDefaultOff confirms the default (AsyncSettle unset) path is
+// byte-for-byte synchronous: cluster, node pool, and operation report their
+// terminal state immediately, with no transient state.
+func TestAsyncSettleDefaultOff(t *testing.T) {
+	m := newTestMock() // no WithAsyncSettle
+	ctx := context.Background()
+
+	c, op, err := m.CreateCluster(ctx, &CreateClusterInput{Name: "prod", Location: "us-central1"})
+	requireNoError(t, err)
+
+	if c.Status != statusRunning {
+		t.Fatalf("create response Status = %q, want %q (settle off)", c.Status, statusRunning)
+	}
+
+	if op.Status != opStatusDone {
+		t.Fatalf("create response op.Status = %q, want %q (settle off)", op.Status, opStatusDone)
+	}
+
+	np, npOp, err := m.CreateNodePool(ctx, "us-central1", "prod", &NodePoolSpec{Name: "extra"})
+	requireNoError(t, err)
+
+	if np.Status != statusRunning || npOp.Status != opStatusDone {
+		t.Fatalf("CreateNodePool response = (%q, %q), want (%q, %q) (settle off)",
+			np.Status, npOp.Status, statusRunning, opStatusDone)
+	}
+
+	resizeOp, err := m.SetNodePoolSize(ctx, "us-central1", "prod", "extra", 5)
+	requireNoError(t, err)
+
+	if resizeOp.Status != opStatusDone {
+		t.Fatalf("SetNodePoolSize response op.Status = %q, want %q (settle off)", resizeOp.Status, opStatusDone)
+	}
+
+	got, _ := m.GetNodePool(ctx, "us-central1", "prod", "extra")
+	if got.Status != statusRunning || got.NodeCount != 5 {
+		t.Fatalf("GetNodePool after resize = (%q, %d), want (%q, 5) (settle off)", got.Status, got.NodeCount, statusRunning)
+	}
+}

--- a/providers/gcp/gke/gke.go
+++ b/providers/gcp/gke/gke.go
@@ -21,8 +21,26 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/internal/settle"
 	"github.com/stackshy/cloudemu/v2/services/kubernetes"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// Cluster and node pool status values (real GKE clusterStatus / nodePoolStatus
+// enums). PROVISIONING_ERROR, ERROR, and DEGRADED are not modeled — the mock
+// has no failure injection for the control-plane provisioning path.
+const (
+	statusProvisioning = "PROVISIONING"
+	statusRunning      = "RUNNING"
+	statusReconciling  = "RECONCILING"
+)
+
+// Operation status values (real GKE Operation.status enum). PENDING is not
+// modeled — the mock starts every operation directly in RUNNING.
+const (
+	opStatusRunning  = "RUNNING"
+	opStatusDone     = "DONE"
+	opStatusAborting = "ABORTING"
 )
 
 // Default versions reported by clusters/node pools and getServerConfig.
@@ -126,6 +144,18 @@ type Mock struct {
 	nodePools  *memstore.Store[NodePool] // keyed by clusterName + "/" + nodePoolName
 	operations *memstore.Store[Operation]
 
+	// clusterSettle/nodePoolSettle/opSettle overlay a transient
+	// PROVISIONING/RECONCILING/RUNNING window over a cluster's, node pool's, or
+	// operation's stored terminal status, so create/mutate calls report the real
+	// GKE intermediate state before settling — matching how real Container Engine
+	// Operations poll RUNNING before DONE while the target resource is still
+	// PROVISIONING/RECONCILING. Each Set is a no-op unless config.Options.
+	// AsyncSettle is set (SettleDuration returns 0 -> inactive window -> the
+	// historical synchronous behavior). The Sets carry their own locks.
+	clusterSettle  *settle.Set
+	nodePoolSettle *settle.Set
+	opSettle       *settle.Set
+
 	opts       *config.Options
 	monitoring mondriver.Monitoring
 
@@ -141,12 +171,33 @@ type Mock struct {
 // New creates a new GKE mock.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		clusters:   memstore.New[Cluster](),
-		nodePools:  memstore.New[NodePool](),
-		operations: memstore.New[Operation](),
-		opts:       opts,
-		k8sUIDs:    make(map[string]string),
+		clusters:       memstore.New[Cluster](),
+		nodePools:      memstore.New[NodePool](),
+		operations:     memstore.New[Operation](),
+		clusterSettle:  settle.NewSet(),
+		nodePoolSettle: settle.NewSet(),
+		opSettle:       settle.NewSet(),
+		opts:           opts,
+		k8sUIDs:        make(map[string]string),
 	}
+}
+
+// clusterState overlays a cluster's settle window (if any) onto its stored
+// terminal status.
+func (m *Mock) clusterState(key, final string) string {
+	return m.clusterSettle.State(key, m.opts.Clock.Now(), final)
+}
+
+// nodePoolState overlays a node pool's settle window (if any) onto its stored
+// terminal status.
+func (m *Mock) nodePoolState(key, final string) string {
+	return m.nodePoolSettle.State(key, m.opts.Clock.Now(), final)
+}
+
+// opState overlays an operation's settle window (if any) onto its stored
+// terminal status.
+func (m *Mock) opState(name, final string) string {
+	return m.opSettle.State(name, m.opts.Clock.Now(), final)
 }
 
 // SetMonitoring wires a Cloud Monitoring backend for auto-metric emission.
@@ -239,12 +290,35 @@ func (m *Mock) recordOperation(opType, location, target string) Operation {
 		Name:          idgen.GenerateID("operation-"),
 		Location:      location,
 		OperationType: opType,
-		Status:        "DONE",
+		Status:        opStatusDone,
 		TargetLink:    target,
 		StartTime:     now,
 		EndTime:       now,
 	}
 	m.operations.Set(op.Name, op)
+
+	return op
+}
+
+// recordOperationAsync behaves like recordOperation but additionally opens an
+// opSettle window so GetOperation/ListOperations report the intermediate
+// RUNNING status until dur elapses — mirroring how a real GKE LRO polls RUNNING
+// while its target cluster/node pool is still PROVISIONING/RECONCILING. now and
+// dur are shared with the caller's resource-level settle.Set.Begin call so both
+// windows open and close in lockstep. A non-positive dur (AsyncSettle off)
+// leaves the operation observed DONE immediately, unchanged from before.
+func (m *Mock) recordOperationAsync(opType, location, target string, now time.Time, dur time.Duration) Operation {
+	op := Operation{
+		Name:          idgen.GenerateID("operation-"),
+		Location:      location,
+		OperationType: opType,
+		Status:        opStatusDone,
+		TargetLink:    target,
+		StartTime:     now,
+		EndTime:       now,
+	}
+	m.operations.Set(op.Name, op)
+	m.opSettle.Begin(op.Name, opStatusRunning, now, dur)
 
 	return op
 }
@@ -319,6 +393,8 @@ func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Clu
 		return nil, nil, cerrors.Newf(cerrors.AlreadyExists, "cluster %q already exists", input.Name)
 	}
 
+	now := m.opts.Clock.Now().UTC()
+
 	cluster := Cluster{
 		Name:              input.Name,
 		ID:                idgen.SyntheticGUID(key),
@@ -334,8 +410,8 @@ func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Clu
 		LoggingService:    defaultIfEmpty(input.LoggingService, "logging.googleapis.com/kubernetes"),
 		MonitoringService: defaultIfEmpty(input.MonitoringService, "monitoring.googleapis.com/kubernetes"),
 		ResourceLabels:    copyLabels(input.ResourceLabels),
-		Status:            "RUNNING",
-		CreatedAt:         m.opts.Clock.Now().UTC(),
+		Status:            statusRunning,
+		CreatedAt:         now,
 	}
 
 	// Bootstrap default node pool when none specified — matches real GKE. The
@@ -361,9 +437,18 @@ func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Clu
 		pools = []NodePoolSpec{spec}
 	}
 
+	// The bootstrap/explicit node pools provision alongside the cluster in real
+	// GKE, so they share the cluster's settle window rather than their own
+	// standalone CreateNodePool window.
+	settleDur := m.opts.SettleDuration(settle.DefaultGKEClusterSettle)
+
 	for i := range pools {
-		np := nodePoolFromSpec(&pools[i], input.Name, input.Location, m.opts.Clock.Now().UTC())
-		m.nodePools.Set(nodePoolKey(input.Location, input.Name, np.Name), np)
+		np := nodePoolFromSpec(&pools[i], input.Name, input.Location, now)
+		npKey := nodePoolKey(input.Location, input.Name, np.Name)
+
+		m.nodePools.Set(npKey, np)
+		m.nodePoolSettle.Begin(npKey, statusProvisioning, now, settleDur)
+
 		cluster.NodePoolNames = append(cluster.NodePoolNames, np.Name)
 	}
 
@@ -376,13 +461,16 @@ func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Clu
 	}
 
 	m.clusters.Set(key, cluster)
+	m.clusterSettle.Begin(key, statusProvisioning, now, settleDur)
 
-	op := m.recordOperation("CREATE_CLUSTER", input.Location,
-		"projects/"+m.opts.ProjectID+"/locations/"+input.Location+"/clusters/"+input.Name)
+	op := m.recordOperationAsync("CREATE_CLUSTER", input.Location,
+		"projects/"+m.opts.ProjectID+"/locations/"+input.Location+"/clusters/"+input.Name, now, settleDur)
 
 	m.emitClusterMetrics(input.Name)
 
 	out := cluster
+	out.Status = m.clusterState(key, out.Status)
+	op.Status = m.opState(op.Name, op.Status)
 
 	return &out, &op, nil
 }
@@ -417,7 +505,7 @@ func nodePoolFromSpec(spec *NodePoolSpec, clusterName, location string, now time
 		AutoscalingOn:  spec.AutoscalingOn,
 		AutoUpgrade:    autoUpgrade,
 		AutoRepair:     autoRepair,
-		Status:         "RUNNING",
+		Status:         statusRunning,
 		CreatedAt:      now,
 	}
 }
@@ -427,13 +515,16 @@ func (m *Mock) GetCluster(_ context.Context, location, name string) (*Cluster, e
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	c, ok := m.clusters.Get(clusterKey(location, name))
+	key := clusterKey(location, name)
+
+	c, ok := m.clusters.Get(key)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found in %q", name, location)
 	}
 
 	out := c
 	out.LabelFingerprint = labelFingerprint(out.ResourceLabels)
+	out.Status = m.clusterState(key, out.Status)
 
 	return &out, nil
 }
@@ -447,12 +538,13 @@ func (m *Mock) ListClusters(_ context.Context, location string) ([]Cluster, erro
 	out := make([]Cluster, 0, len(all))
 
 	//nolint:gocritic // map values are sized for accuracy.
-	for _, c := range all {
+	for k, c := range all {
 		if location != "" && location != "-" && c.Location != location {
 			continue
 		}
 
 		c.LabelFingerprint = labelFingerprint(c.ResourceLabels)
+		c.Status = m.clusterState(k, c.Status)
 		out = append(out, c)
 	}
 
@@ -547,11 +639,13 @@ func (m *Mock) DeleteCluster(_ context.Context, location, name string) (*Operati
 	}
 
 	m.clusters.Delete(key)
+	m.clusterSettle.Clear(key)
 
 	prefix := location + "/" + name + "/"
 	for _, k := range m.nodePools.Keys() {
 		if hasPrefix(k, prefix) {
 			m.nodePools.Delete(k)
+			m.nodePoolSettle.Clear(k)
 		}
 	}
 
@@ -701,16 +795,23 @@ func (m *Mock) CreateNodePool(
 		return nil, nil, cerrors.Newf(cerrors.AlreadyExists, "node pool %q already exists in cluster %q", spec.Name, clusterName)
 	}
 
-	np := nodePoolFromSpec(spec, clusterName, location, m.opts.Clock.Now().UTC())
+	now := m.opts.Clock.Now().UTC()
+
+	np := nodePoolFromSpec(spec, clusterName, location, now)
 	m.nodePools.Set(npKey, np)
+
+	settleDur := m.opts.SettleDuration(settle.DefaultGKENodePoolSettle)
+	m.nodePoolSettle.Begin(npKey, statusProvisioning, now, settleDur)
 
 	cluster.NodePoolNames = append(cluster.NodePoolNames, np.Name)
 	m.clusters.Set(cKey, cluster)
 
-	op := m.recordOperation("CREATE_NODE_POOL", location,
-		"projects/"+m.opts.ProjectID+"/locations/"+location+"/clusters/"+clusterName+"/nodePools/"+spec.Name)
+	op := m.recordOperationAsync("CREATE_NODE_POOL", location,
+		"projects/"+m.opts.ProjectID+"/locations/"+location+"/clusters/"+clusterName+"/nodePools/"+spec.Name, now, settleDur)
 
 	out := np
+	out.Status = m.nodePoolState(npKey, out.Status)
+	op.Status = m.opState(op.Name, op.Status)
 
 	return &out, &op, nil
 }
@@ -720,12 +821,15 @@ func (m *Mock) GetNodePool(_ context.Context, location, clusterName, name string
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	np, ok := m.nodePools.Get(nodePoolKey(location, clusterName, name))
+	key := nodePoolKey(location, clusterName, name)
+
+	np, ok := m.nodePools.Get(key)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "node pool %q not found in cluster %q", name, clusterName)
 	}
 
 	out := np
+	out.Status = m.nodePoolState(key, out.Status)
 
 	return &out, nil
 }
@@ -743,6 +847,7 @@ func (m *Mock) ListNodePools(_ context.Context, location, clusterName string) ([
 	//nolint:gocritic // map values are sized for accuracy.
 	for k, np := range all {
 		if hasPrefix(k, prefix) {
+			np.Status = m.nodePoolState(k, np.Status)
 			out = append(out, np)
 		}
 	}
@@ -787,6 +892,7 @@ func (m *Mock) DeleteNodePool(_ context.Context, location, clusterName, name str
 	}
 
 	m.nodePools.Delete(npKey)
+	m.nodePoolSettle.Clear(npKey)
 
 	if cluster, ok := m.clusters.Get(clusterKey(location, clusterName)); ok {
 		cluster.NodePoolNames = removeString(cluster.NodePoolNames, name)
@@ -837,6 +943,12 @@ func (m *Mock) RollbackNodePool(_ context.Context, location, clusterName, name s
 	})
 }
 
+// mutateNodePool applies fn to a node pool and records the operation it
+// triggers. Real GKE surfaces RECONCILING while any node-pool mutation (resize,
+// autoscaling toggle, management change, upgrade/rollback) is in flight, so a
+// brief RECONCILING settle window overlays the pool's status here too — the
+// mutated field (e.g. NodeCount) itself is applied immediately so a synchronous
+// currentNodeCount read reflects the new value right away.
 func (m *Mock) mutateNodePool(
 	location, clusterName, name, opType string, fn func(*NodePool),
 ) (*Operation, error) {
@@ -853,8 +965,13 @@ func (m *Mock) mutateNodePool(
 	fn(&np)
 	m.nodePools.Set(key, np)
 
-	op := m.recordOperation(opType, location,
-		"projects/"+m.opts.ProjectID+"/locations/"+location+"/clusters/"+clusterName+"/nodePools/"+name)
+	now := m.opts.Clock.Now().UTC()
+	settleDur := m.opts.SettleDuration(settle.DefaultGKEReconcileSettle)
+	m.nodePoolSettle.Begin(key, statusReconciling, now, settleDur)
+
+	op := m.recordOperationAsync(opType, location,
+		"projects/"+m.opts.ProjectID+"/locations/"+location+"/clusters/"+clusterName+"/nodePools/"+name, now, settleDur)
+	op.Status = m.opState(op.Name, op.Status)
 
 	return &op, nil
 }
@@ -872,6 +989,7 @@ func (m *Mock) GetOperation(_ context.Context, _, name string) (*Operation, erro
 	}
 
 	out := op
+	out.Status = m.opState(name, out.Status)
 
 	return &out, nil
 }
@@ -901,6 +1019,7 @@ func (m *Mock) ListOperations(_ context.Context, location string) ([]Operation, 
 			continue
 		}
 
+		op.Status = m.opState(op.Name, op.Status)
 		out = append(out, op)
 	}
 
@@ -921,8 +1040,11 @@ func (m *Mock) CancelOperation(_ context.Context, _, name string) error {
 		return cerrors.Newf(cerrors.NotFound, "operation %q not found", name)
 	}
 
-	op.Status = "ABORTING"
+	op.Status = opStatusAborting
 	m.operations.Set(name, op)
+	// A cancel supersedes any pending settle window: the ABORTING status must be
+	// observed immediately, not masked by a still-open RUNNING overlay.
+	m.opSettle.Clear(name)
 
 	return nil
 }

--- a/server/gcp/gke/sdk_async_lifecycle_test.go
+++ b/server/gcp/gke/sdk_async_lifecycle_test.go
@@ -1,0 +1,233 @@
+package gke_test
+
+// Real-user end-to-end coverage of the AsyncSettle cluster/node-pool lifecycle
+// through google.golang.org/api/container/v1: create a cluster -> poll its
+// operation RUNNING then DONE -> Get reports RUNNING with endpoint/version
+// present; create a node pool -> Get reports RUNNING with initialNodeCount;
+// SetSize 1->3 -> currentNodeCount reflected; List node pools; Delete a node
+// pool; a node pool lookup on a missing cluster -> NOT_FOUND; Delete the
+// cluster.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"google.golang.org/api/container/v1"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// newAsyncSDKClient builds a GKE SDK client backed by an AsyncSettle-enabled
+// mock and a FakeClock, so the test can deterministically advance past each
+// settle window instead of racing a real timer.
+func newAsyncSDKClient(t *testing.T) (*container.Service, string, *config.FakeClock) {
+	t.Helper()
+
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	cloud := cloudemu.NewGCP(
+		config.WithClock(fc),
+		config.WithRegion("us-central1"),
+		config.WithProjectID("mock-project"),
+		config.WithAsyncSettle(),
+	)
+
+	srv := gcpserver.New(gcpserver.Drivers{
+		GKE: cloud.GKE,
+	})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := container.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("container.NewService: %v", err)
+	}
+
+	return svc, "mock-project", fc
+}
+
+func TestSDKGKEAsyncClusterAndNodePoolLifecycle(t *testing.T) {
+	svc, project, fc := newAsyncSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+	clusterParent := parent(project, loc)
+	clusterFull := clusterName(project, loc, "prod")
+
+	op, err := svc.Projects.Locations.Clusters.Create(clusterParent, &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "prod", InitialNodeCount: 1},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Clusters.Create: %v", err)
+	}
+
+	if op.Status != "RUNNING" {
+		t.Fatalf("create op status = %q, want RUNNING (settling)", op.Status)
+	}
+
+	opFull := clusterParent + "/operations/" + op.Name
+
+	gotOp, err := svc.Projects.Locations.Operations.Get(opFull).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Operations.Get before settle: %v", err)
+	}
+
+	if gotOp.Status != "RUNNING" {
+		t.Fatalf("op status before settle = %q, want RUNNING", gotOp.Status)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.Get(clusterFull).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Clusters.Get before settle: %v", err)
+	}
+
+	if got.Status != "PROVISIONING" {
+		t.Fatalf("cluster status before settle = %q, want PROVISIONING", got.Status)
+	}
+
+	// Advance the FakeClock past the cluster settle window: cluster, its
+	// bootstrap node pool, and the create operation all settle together.
+	fc.Advance(3 * time.Second)
+
+	gotOp, err = svc.Projects.Locations.Operations.Get(opFull).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Operations.Get after settle: %v", err)
+	}
+
+	if gotOp.Status != "DONE" {
+		t.Fatalf("op status after settle = %q, want DONE", gotOp.Status)
+	}
+
+	got, err = svc.Projects.Locations.Clusters.Get(clusterFull).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Clusters.Get after settle: %v", err)
+	}
+
+	if got.Status != "RUNNING" {
+		t.Fatalf("cluster status after settle = %q, want RUNNING", got.Status)
+	}
+
+	if got.Endpoint == "" {
+		t.Fatal("expected a non-empty control-plane endpoint")
+	}
+
+	if got.CurrentMasterVersion == "" || got.CurrentNodeVersion == "" {
+		t.Fatalf("expected non-empty versions, got master=%q node=%q", got.CurrentMasterVersion, got.CurrentNodeVersion)
+	}
+
+	// Create a node pool: PROVISIONING -> RUNNING over its own settle window.
+	npOp, err := svc.Projects.Locations.Clusters.NodePools.Create(clusterFull, &container.CreateNodePoolRequest{
+		NodePool: &container.NodePool{Name: "workers", InitialNodeCount: 1},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("NodePools.Create: %v", err)
+	}
+
+	if npOp.Status != "RUNNING" {
+		t.Fatalf("node pool create op status = %q, want RUNNING (settling)", npOp.Status)
+	}
+
+	npFull := nodePoolName(project, loc, "prod", "workers")
+
+	gotNP, err := svc.Projects.Locations.Clusters.NodePools.Get(npFull).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("NodePools.Get before settle: %v", err)
+	}
+
+	if gotNP.Status != "PROVISIONING" {
+		t.Fatalf("node pool status before settle = %q, want PROVISIONING", gotNP.Status)
+	}
+
+	fc.Advance(2 * time.Second)
+
+	gotNP, err = svc.Projects.Locations.Clusters.NodePools.Get(npFull).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("NodePools.Get after settle: %v", err)
+	}
+
+	if gotNP.Status != "RUNNING" {
+		t.Fatalf("node pool status after settle = %q, want RUNNING", gotNP.Status)
+	}
+
+	if gotNP.InitialNodeCount != 1 {
+		t.Fatalf("node pool initialNodeCount = %d, want 1", gotNP.InitialNodeCount)
+	}
+
+	// SetSize 1 -> 3: currentNodeCount reflects the resize immediately, even
+	// while the pool briefly reports RECONCILING.
+	if _, err := svc.Projects.Locations.Clusters.NodePools.SetSize(npFull, &container.SetNodePoolSizeRequest{
+		NodeCount: 3,
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("NodePools.SetSize: %v", err)
+	}
+
+	gotCluster, err := svc.Projects.Locations.Clusters.Get(clusterFull).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Clusters.Get after resize: %v", err)
+	}
+
+	// default-pool (1 node) + workers (3 nodes) = 4.
+	if gotCluster.CurrentNodeCount != 4 {
+		t.Fatalf("currentNodeCount after resize = %d, want 4", gotCluster.CurrentNodeCount)
+	}
+
+	fc.Advance(time.Second)
+
+	gotNP, err = svc.Projects.Locations.Clusters.NodePools.Get(npFull).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("NodePools.Get after resize settle: %v", err)
+	}
+
+	if gotNP.Status != "RUNNING" {
+		t.Fatalf("node pool status after resize settle = %q, want RUNNING", gotNP.Status)
+	}
+
+	list, err := svc.Projects.Locations.Clusters.NodePools.List(clusterFull).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("NodePools.List: %v", err)
+	}
+
+	if len(list.NodePools) != 2 { // default-pool + workers
+		t.Fatalf("got %d node pools, want 2", len(list.NodePools))
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.NodePools.Delete(npFull).Context(ctx).Do(); err != nil {
+		t.Fatalf("NodePools.Delete: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.NodePools.Get(npFull).Context(ctx).Do(); err == nil {
+		t.Fatal("expected NOT_FOUND after node pool delete")
+	}
+
+	// A node pool lookup on a missing cluster must 404, not panic or leak a
+	// stale entry from the deleted "prod" cluster's key space.
+	missingClusterPool := nodePoolName(project, loc, "does-not-exist", "workers")
+
+	_, err = svc.Projects.Locations.Clusters.NodePools.Get(missingClusterPool).Context(ctx).Do()
+	if err == nil {
+		t.Fatal("expected NOT_FOUND for a node pool under a missing cluster")
+	}
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 NOT_FOUND, got %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.Delete(clusterFull).Context(ctx).Do(); err != nil {
+		t.Fatalf("Clusters.Delete: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.Get(clusterFull).Context(ctx).Do(); err == nil {
+		t.Fatal("expected NOT_FOUND after cluster delete")
+	}
+}


### PR DESCRIPTION
## Summary

Deepens GKE cluster/node-pool lifecycle toward real-cloud parity by overlaying an AsyncSettle status state machine (following the existing `internal/settle` pattern already used by Cloud SQL/Memorystore/GCE) onto the previously-instant control plane:

- **Cluster**: `CreateCluster` now reports `PROVISIONING` (its `CREATE_CLUSTER` Operation reports `RUNNING`) until the settle window elapses, then `RUNNING`/`DONE`. `GetCluster`/`ListClusters` overlay the same window.
- **Node pools**: `CreateNodePool` reports `PROVISIONING` -> `RUNNING` over its own window; pools bootstrapped inline by `CreateCluster` share the cluster's window so they settle together. Any node-pool mutation (`setSize`, `setAutoscaling`, `setManagement`, `UpdateNodePool`, `RollbackNodePool`) briefly reports `RECONCILING` before settling back to `RUNNING`. `currentNodeCount` always reflects the applied node count immediately — never gated by the window, matching how a real user reads back a resize.
- **Operations**: `GetOperation`/`ListOperations` overlay a matching `RUNNING`->`DONE` window on every async-capable op, sharing the same clock instant and duration as the resource it targets so they settle in lockstep. `CancelOperation` clears any pending window so `ABORTING` is observed immediately, not masked by a stale `RUNNING`.
- Off by default: `AsyncSettle` unset keeps every existing test passing byte-for-byte synchronous (`SettleDuration` returns 0 -> windows inactive), matching the house pattern.

Named constants (`statusProvisioning`/`statusRunning`/`statusReconciling`, `opStatusRunning`/`opStatusDone`/`opStatusAborting`) replace the scattered status string literals.

Deferred (out of scope for this PR, left as follow-up):
- Delete transitions (`STOPPING` before removal) — the mock deletes cluster/node-pool records immediately on `DeleteCluster`/`DeleteNodePool`, matching the existing house precedent (Cloud SQL's `DeleteInstance` has no deferred-delete state either).
- Autopilot mode, node auto-provisioning, cluster addons, and kubeconfig/credential plumbing beyond the existing Wave-2 data-plane wiring.
- `PROVISIONING_ERROR`/`ERROR`/`DEGRADED` cluster states and `PENDING` operation state (no failure-injection path for GKE provisioning yet).

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers/gcp/gke/... ./server/gcp/gke/... -race -count=1`
- [x] `go test ./providers/gcp/... ./server/gcp/...`
- [x] `gofmt -l` on touched files (clean)
- [x] `golangci-lint run ./providers/gcp/gke/... ./server/gcp/gke/... ./internal/settle/...` — 0 new issues (one pre-existing `hugeParam` finding on `UpdateClusterInput`, unrelated to this change, confirmed via `git stash`)
- [x] `go generate ./...` + `git diff --exit-code docs/coverage` — clean (no driver interface changed)
- [x] `go mod tidy` — no changes
- [x] New real-user e2e test (`google.golang.org/api/container/v1` against `httptest.NewServer`) drives the full flow with a `FakeClock`: create cluster -> poll op RUNNING then DONE -> get RUNNING with endpoint/version -> create node pool -> get RUNNING with `initialNodeCount` -> `setSize` 1->3 -> `currentNodeCount` reflected -> list node pools -> delete node pool -> node pool on a missing cluster -> 404 -> delete cluster