### PR TITLE
feat(aks): managed cluster start/stop and last-System-pool guard

### DIFF
--- a/docs/coverage/README.md
+++ b/docs/coverage/README.md
@@ -11,7 +11,7 @@ code does not implement. Machine-readable: [`coverage.json`](./coverage.json).
 | Service | AWS | Azure | GCP | OCI | Operations |
 | --- | --- | --- | --- | --- | --- |
 | `acm` | [ACM](./aws/acm.md) | — | — | — | 17 |
-| `aks` | — | [AKS](./azure/aks.md) | — | — | 16 |
+| `aks` | — | [AKS](./azure/aks.md) | — | — | 18 |
 | `apigateway` | [APIGateway](./aws/apigateway.md) | — | — | — | 15 |
 | `azureai` | — | [AI](./azure/ai.md) | — | — | 92 |
 | `azuresearch` | — | [Search](./azure/search.md) | — | — | 53 |

--- a/docs/coverage/azure/README.md
+++ b/docs/coverage/azure/README.md
@@ -7,7 +7,7 @@ Services cloudemu emulates for Azure, by native name. Back to the [cross-provide
 | --- | --- | --- |
 | [ACR](./acr.md) | `containerregistry` | 15 |
 | [AI](./ai.md) | `azureai` | 92 |
-| [AKS](./aks.md) | — (provider-native) | 16 |
+| [AKS](./aks.md) | — (provider-native) | 18 |
 | [BlobStorage](./blobstorage.md) | `storage` | 35 |
 | [Cache](./cache.md) | `cache` | 17 |
 | [ContainerApps](./containerapps.md) | — (provider-native) | 19 |

--- a/docs/coverage/azure/aks.md
+++ b/docs/coverage/azure/aks.md
@@ -3,7 +3,7 @@
 
 provider-native `aks` wire service (Azure-only) · no portable driver · [Azure index](./README.md)
 
-## Operations (16)
+## Operations (18)
 
 | Operation | Description |
 | --- | --- |
@@ -22,6 +22,8 @@ provider-native `aks` wire service (Azure-only) · no portable driver · [Azure 
 | `ListClustersByResourceGroup` |  |
 | `ListMaintenanceConfigs` |  |
 | `RotateClusterCertificates` |  |
+| `StartCluster` |  |
+| `StopCluster` |  |
 | `UpdateClusterTags` |  |
 
 ## Not in scope

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -109,6 +109,12 @@
         "name": "RotateClusterCertificates"
       },
       {
+        "name": "StartCluster"
+      },
+      {
+        "name": "StopCluster"
+      },
+      {
         "name": "UpdateClusterTags"
       }
     ],

--- a/providers/azure/aks/aks.go
+++ b/providers/azure/aks/aks.go
@@ -38,6 +38,16 @@ const (
 	defaultPoolType      = "VirtualMachineScaleSets"
 	defaultNodeImage     = "AKSUbuntu-2204gen2containerd-202401.09.0"
 	poolPowerRunning     = "Running"
+	poolPowerStopped     = "Stopped"
+	// clusterPowerRunning / clusterPowerStopped are the ARM powerState.code
+	// values a managed cluster reports; provisioningStateSucceeded is the
+	// terminal provisioningState every mutating op settles to synchronously.
+	clusterPowerRunning        = "Running"
+	clusterPowerStopped        = "Stopped"
+	provisioningStateSucceeded = "Succeeded"
+	// agentPoolModeSystem is the AgentPool.Mode value AKS requires at least
+	// one pool to carry at all times; DeleteAgentPool enforces that rule.
+	agentPoolModeSystem = "System"
 	// Network-profile defaults the real AKS service synthesizes when a create
 	// omits properties.networkProfile entirely.
 	defaultNetworkPlugin   = "kubenet"
@@ -477,8 +487,13 @@ func (m *Mock) CreateOrUpdateCluster(_ context.Context, input ClusterInput) (*Ma
 //nolint:gocritic // input is a value-type mirror of the public CreateOrUpdate body.
 func resolveClusterFields(cluster *ManagedCluster, input ClusterInput, existing bool) {
 	cluster.Location = mergeStr(cluster.Location, input.Location, "", existing)
-	cluster.ProvisioningState = "Succeeded"
-	cluster.PowerState = "Running"
+	cluster.ProvisioningState = provisioningStateSucceeded
+	// A create starts Running; an update leaves whatever power state Start/Stop
+	// last set (real AKS keeps a stopped cluster stopped across most PUTs).
+	if !existing {
+		cluster.PowerState = clusterPowerRunning
+	}
+
 	cluster.Tier = mergeStr(cluster.Tier, input.Tier, "Free", existing)
 	cluster.KubernetesVersion = mergeStr(cluster.KubernetesVersion, input.KubernetesVersion, defaultK8sVersion, existing)
 	cluster.DNSPrefix = mergeStr(cluster.DNSPrefix, input.DNSPrefix, input.Name+"-dns", existing)
@@ -650,7 +665,7 @@ func buildAgentPool(rg, cluster, clusterVersion string, in AgentPoolInput, now t
 		OSType:                 defaultIfEmpty(in.OSType, "Linux"),
 		Mode:                   defaultIfEmpty(in.Mode, "User"),
 		OrchestratorVer:        defaultIfEmpty(in.OrchestratorVer, defaultIfEmpty(clusterVersion, defaultK8sVersion)),
-		ProvisioningState:      "Succeeded",
+		ProvisioningState:      provisioningStateSucceeded,
 		ScaleSetPriority:       defaultIfEmpty(in.ScaleSetPriority, "Regular"),
 		NodeLabels:             copyLabels(in.NodeLabels),
 		NodeTaints:             copyTaints(in.NodeTaints),
@@ -882,6 +897,66 @@ func (m *Mock) RotateClusterCertificates(_ context.Context, rg, name string) err
 	return nil
 }
 
+// StartCluster starts a stopped managed cluster
+// (Microsoft.ContainerService/.../start), restoring the control plane and
+// every agent pool's VMs to Running. Idempotent: starting an already-running
+// cluster succeeds and leaves it unchanged.
+func (m *Mock) StartCluster(_ context.Context, rg, name string) (*ManagedCluster, error) {
+	return m.setClusterPower(rg, name, clusterPowerRunning, poolPowerRunning)
+}
+
+// StopCluster stops a managed cluster (Microsoft.ContainerService/.../stop),
+// deallocating the control plane and every agent pool's VMs while preserving
+// cluster and workload state — real AKS does not bill a stopped cluster.
+// Idempotent: stopping an already-stopped cluster succeeds and leaves it
+// unchanged.
+func (m *Mock) StopCluster(_ context.Context, rg, name string) (*ManagedCluster, error) {
+	return m.setClusterPower(rg, name, clusterPowerStopped, poolPowerStopped)
+}
+
+// setClusterPower is the shared body for StartCluster/StopCluster: it sets
+// the cluster's powerState.code, settles provisioningState back to Succeeded,
+// and mirrors the transition onto every attached agent pool.
+func (m *Mock) setClusterPower(rg, name, clusterState, poolState string) (*ManagedCluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := clusterKey(rg, name)
+
+	cluster, ok := m.clusters.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "managed cluster %q not found in resource group %q", name, rg)
+	}
+
+	cluster.PowerState = clusterState
+	cluster.ProvisioningState = provisioningStateSucceeded
+	cluster.UpdatedAt = m.opts.Clock.Now().UTC()
+	m.clusters.Set(key, cluster)
+	m.setPoolsPowerState(rg, name, poolState)
+
+	out := cluster
+
+	return &out, nil
+}
+
+// setPoolsPowerState updates PowerState on every pool attached to a cluster,
+// mirroring the control plane's power transition down onto its agent pools.
+// Caller must hold m.mu (write).
+func (m *Mock) setPoolsPowerState(rg, cluster, state string) {
+	prefix := rg + "/" + cluster + "/"
+
+	for _, k := range m.pools.Keys() {
+		if !strings.HasPrefix(k, prefix) {
+			continue
+		}
+
+		if p, ok := m.pools.Get(k); ok {
+			p.PowerState = state
+			m.pools.Set(k, p)
+		}
+	}
+}
+
 // CreateOrUpdateAgentPool creates or replaces an agent pool on a cluster.
 //
 //nolint:gocritic // in mirrors the public AgentPoolInput surface; pointer would invite caller mutation.
@@ -950,15 +1025,27 @@ func (m *Mock) GetAgentPool(_ context.Context, rg, cluster, pool string) (*Agent
 	return &out, nil
 }
 
-// DeleteAgentPool removes an agent pool.
+// DeleteAgentPool removes an agent pool. Deleting the last System-mode pool
+// on a cluster is rejected: real AKS requires every cluster to retain at
+// least one System pool so the control plane always has somewhere to
+// schedule its own components.
 func (m *Mock) DeleteAgentPool(_ context.Context, rg, cluster, pool string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	key := poolKey(rg, cluster, pool)
-	if !m.pools.Delete(key) {
+
+	ap, ok := m.pools.Get(key)
+	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "agent pool %q not found on cluster %q", pool, cluster)
 	}
+
+	if strings.EqualFold(ap.Mode, agentPoolModeSystem) && m.systemPoolCount(rg, cluster) <= 1 {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"agent pool %q is the last System-mode pool on cluster %q; AKS requires at least one", pool, cluster)
+	}
+
+	m.pools.Delete(key)
 
 	cKey := clusterKey(rg, cluster)
 	if c, ok := m.clusters.Get(cKey); ok {
@@ -967,6 +1054,17 @@ func (m *Mock) DeleteAgentPool(_ context.Context, rg, cluster, pool string) erro
 	}
 
 	return nil
+}
+
+// systemPoolCount returns how many System-mode pools are currently attached
+// to a cluster. Caller must hold m.mu.
+func (m *Mock) systemPoolCount(rg, cluster string) int {
+	all := m.pools.Filter(func(_ string, p AgentPool) bool {
+		return strings.EqualFold(p.ResourceGroup, rg) && strings.EqualFold(p.ClusterName, cluster) &&
+			strings.EqualFold(p.Mode, agentPoolModeSystem)
+	})
+
+	return len(all)
 }
 
 // ListAgentPools returns all pools attached to a cluster.

--- a/providers/azure/aks/aks_test.go
+++ b/providers/azure/aks/aks_test.go
@@ -144,6 +144,103 @@ func TestAgentPoolLifecycle(t *testing.T) {
 	}
 }
 
+// TestClusterStartStop exercises the power-state lifecycle: stopping a
+// running cluster deallocates every agent pool alongside the control plane,
+// and starting it again restores both. Both actions are idempotent.
+func TestClusterStartStop(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateOrUpdateCluster(ctx, ClusterInput{
+		ResourceGroup: "rg-1",
+		Name:          "k8s-1",
+		Location:      "eastus",
+		AgentPools: []AgentPoolInput{
+			{Name: "system", Count: int32Ptr(2), Mode: "System"},
+		},
+	})
+	requireNoError(t, err)
+
+	stopped, err := m.StopCluster(ctx, "rg-1", "k8s-1")
+	requireNoError(t, err)
+	assertEqual(t, "Stopped", stopped.PowerState)
+	assertEqual(t, "Succeeded", stopped.ProvisioningState)
+
+	pool, err := m.GetAgentPool(ctx, "rg-1", "k8s-1", "system")
+	requireNoError(t, err)
+	assertEqual(t, "Stopped", pool.PowerState)
+
+	// Idempotent: stopping an already-stopped cluster still succeeds.
+	stopped, err = m.StopCluster(ctx, "rg-1", "k8s-1")
+	requireNoError(t, err)
+	assertEqual(t, "Stopped", stopped.PowerState)
+
+	started, err := m.StartCluster(ctx, "rg-1", "k8s-1")
+	requireNoError(t, err)
+	assertEqual(t, "Running", started.PowerState)
+
+	pool, err = m.GetAgentPool(ctx, "rg-1", "k8s-1", "system")
+	requireNoError(t, err)
+	assertEqual(t, "Running", pool.PowerState)
+
+	// Idempotent: starting an already-running cluster still succeeds.
+	started, err = m.StartCluster(ctx, "rg-1", "k8s-1")
+	requireNoError(t, err)
+	assertEqual(t, "Running", started.PowerState)
+}
+
+func TestClusterStartStopRequiresCluster(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.StartCluster(ctx, "rg-1", "ghost"); err == nil {
+		t.Fatal("expected NotFound starting a missing cluster")
+	}
+
+	if _, err := m.StopCluster(ctx, "rg-1", "ghost"); err == nil {
+		t.Fatal("expected NotFound stopping a missing cluster")
+	}
+}
+
+// TestDeleteAgentPoolRejectsLastSystemPool asserts AKS's invariant that every
+// cluster retains at least one System-mode pool: deleting the sole System
+// pool is rejected, but deleting a User pool — or a System pool when another
+// System pool remains — succeeds.
+func TestDeleteAgentPoolRejectsLastSystemPool(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateOrUpdateCluster(ctx, ClusterInput{
+		ResourceGroup: "rg-1",
+		Name:          "k8s-1",
+		AgentPools: []AgentPoolInput{
+			{Name: "system", Count: int32Ptr(2), Mode: "System"},
+			{Name: "userpool", Count: int32Ptr(3), Mode: "User"},
+		},
+	})
+	requireNoError(t, err)
+
+	// Deleting the User pool is unaffected.
+	requireNoError(t, m.DeleteAgentPool(ctx, "rg-1", "k8s-1", "userpool"))
+
+	// Deleting the last System pool is rejected.
+	if err := m.DeleteAgentPool(ctx, "rg-1", "k8s-1", "system"); err == nil {
+		t.Fatal("expected error deleting the last System-mode pool")
+	}
+
+	if _, err := m.GetAgentPool(ctx, "rg-1", "k8s-1", "system"); err != nil {
+		t.Fatalf("system pool should still exist after rejected delete: %v", err)
+	}
+
+	// A second System pool makes either one deletable.
+	_, err = m.CreateOrUpdateAgentPool(ctx, "rg-1", "k8s-1", AgentPoolInput{
+		Name: "system2", Count: int32Ptr(1), Mode: "System",
+	})
+	requireNoError(t, err)
+
+	requireNoError(t, m.DeleteAgentPool(ctx, "rg-1", "k8s-1", "system"))
+}
+
 func TestAgentPoolRequiresCluster(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/server/azure/aks/handler.go
+++ b/server/azure/aks/handler.go
@@ -24,6 +24,8 @@
 //	POST   .../managedClusters/{name}/listClusterUserCredential                                                    — Stub kubeconfig
 //	POST   .../managedClusters/{name}/listClusterMonitoringUserCredential                                          — Stub kubeconfig
 //	POST   .../managedClusters/{name}/rotateClusterCertificates                                                    — Cert rotation no-op
+//	POST   .../managedClusters/{name}/start                                                                        — Start cluster
+//	POST   .../managedClusters/{name}/stop                                                                         — Stop cluster
 //
 // The Kubernetes data plane (Deployments / Services / Pods) is intentionally
 // NOT served — that lands in Wave 2. The kubeconfig blobs we return point
@@ -56,6 +58,9 @@ type Backend interface {
 	ListClusters(ctx context.Context) ([]aks.ManagedCluster, error)
 	RotateClusterCertificates(ctx context.Context, rg, name string) error
 
+	StartCluster(ctx context.Context, rg, name string) (*aks.ManagedCluster, error)
+	StopCluster(ctx context.Context, rg, name string) (*aks.ManagedCluster, error)
+
 	CreateOrUpdateAgentPool(ctx context.Context, rg, cluster string, in aks.AgentPoolInput) (*aks.AgentPool, error)
 	GetAgentPool(ctx context.Context, rg, cluster, pool string) (*aks.AgentPool, error)
 	DeleteAgentPool(ctx context.Context, rg, cluster, pool string) error
@@ -81,7 +86,8 @@ func New(be Backend) *Handler {
 	return &Handler{be: be}
 }
 
-// Matches returns true for ARM Microsoft.ContainerService managedClusters paths.
+// Matches returns true for ARM Microsoft.ContainerService managedClusters
+// paths, plus the locations/operationStatuses paths start/stop cluster poll.
 // AKS uses a mix of "managedClusters" and "managedclusters" in URL templates
 // across SDK operations, so the match is case-insensitive on the resource type.
 func (*Handler) Matches(r *http.Request) bool {
@@ -92,6 +98,11 @@ func (*Handler) Matches(r *http.Request) bool {
 
 	if !strings.EqualFold(rp.Provider, providerName) {
 		return false
+	}
+
+	if strings.EqualFold(rp.ResourceType, resourceTypeLocations) &&
+		strings.EqualFold(rp.SubResource, subOperationStatuses) {
+		return true
 	}
 
 	return strings.EqualFold(rp.ResourceType, resourceTypeManagedClusters)
@@ -105,26 +116,42 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// LRO status poll for start/stop: .../locations/{loc}/operationStatuses/{id}.
+	if strings.EqualFold(rp.ResourceType, resourceTypeLocations) {
+		h.operationStatus(w, r)
+		return
+	}
+
 	// Subscription-scoped or RG-scoped collection: no resourceName.
 	if rp.ResourceName == "" {
 		h.serveClusterCollection(w, r, &rp)
 		return
 	}
 
-	// Sub-resource routing.
+	h.serveClusterSubResource(w, r, &rp)
+}
+
+// serveClusterSubResource routes every named-cluster path: the cluster
+// resource itself (empty sub-resource) and each of its POST actions / nested
+// collections.
+func (h *Handler) serveClusterSubResource(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	switch {
 	case strings.EqualFold(rp.SubResource, "agentPools"):
-		h.serveAgentPoolRoute(w, r, &rp)
+		h.serveAgentPoolRoute(w, r, rp)
 	case strings.EqualFold(rp.SubResource, "maintenanceConfigurations"):
-		h.serveMaintenanceRoute(w, r, &rp)
+		h.serveMaintenanceRoute(w, r, rp)
 	case strings.EqualFold(rp.SubResource, "listClusterAdminCredential"),
 		strings.EqualFold(rp.SubResource, "listClusterUserCredential"),
 		strings.EqualFold(rp.SubResource, "listClusterMonitoringUserCredential"):
-		h.serveListCredentials(w, r, &rp)
+		h.serveListCredentials(w, r, rp)
 	case strings.EqualFold(rp.SubResource, "rotateClusterCertificates"):
-		h.serveRotateCertificates(w, r, &rp)
+		h.serveRotateCertificates(w, r, rp)
+	case strings.EqualFold(rp.SubResource, clusterActionStart):
+		postClusterAction(w, r, rp, h.be.StartCluster)
+	case strings.EqualFold(rp.SubResource, clusterActionStop):
+		postClusterAction(w, r, rp, h.be.StopCluster)
 	case rp.SubResource == "":
-		h.serveCluster(w, r, &rp)
+		h.serveCluster(w, r, rp)
 	default:
 		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
 			"AKS sub-resource not implemented: "+rp.SubResource)

--- a/server/azure/aks/operations.go
+++ b/server/azure/aks/operations.go
@@ -1,6 +1,7 @@
 package aks
 
 import (
+	"context"
 	"net/http"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -182,6 +183,58 @@ func writeIdempotentDelete(w http.ResponseWriter, err error) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// postClusterAction is the shared body for start/stop. Both are long-running
+// actions whose SDK response type carries no fields, so a 202 +
+// Azure-AsyncOperation header pointing at a synthetic status endpoint is
+// enough for the poller to terminate once it observes Succeeded — no final
+// GET or resource body is required.
+func postClusterAction(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath,
+	action func(ctx context.Context, rg, name string) (*aks.ManagedCluster, error),
+) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	if _, err := action(r.Context(), rp.ResourceGroup, rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	opID := rp.ResourceName + "-" + rp.SubResource
+	w.Header().Set("Azure-AsyncOperation", asyncStatusURL(r, rp.Subscription, opID))
+	w.Header().Set("Retry-After", "0")
+	w.WriteHeader(http.StatusAccepted)
+}
+
+// asyncStatusURL builds a self-referential operationStatuses URL for a
+// synthetic operation id, so the request's own scheme/host works on both the
+// plain-HTTP and TLS listeners.
+func asyncStatusURL(r *http.Request, subscription, opID string) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	return scheme + "://" + r.Host +
+		"/subscriptions/" + subscription +
+		"/providers/" + providerName + "/" + resourceTypeLocations + "/eastus/" + subOperationStatuses + "/" + opID +
+		"?api-version=2025-02-01"
+}
+
+// operationStatus answers the LRO poll start/stop point at. The backend is
+// synchronous, so by the time the SDK polls, the action has already
+// completed — every poll reports Succeeded.
+func (*Handler) operationStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, map[string]string{"status": "Succeeded"})
 }
 
 func (h *Handler) listClusters(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {

--- a/server/azure/aks/sdk_power_test.go
+++ b/server/azure/aks/sdk_power_test.go
@@ -1,0 +1,185 @@
+package aks_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
+)
+
+// TestSDKAKSClusterStartStop drives the real armcontainerservice SDK through
+// BeginStop/BeginStart and asserts powerState.code flips on both the cluster
+// and its agent pools, matching real AKS's "stop the whole node fleet"
+// semantics.
+func TestSDKAKSClusterStartStop(t *testing.T) {
+	clusters, pools, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+		Properties: &armcontainerservice.ManagedClusterProperties{
+			AgentPoolProfiles: []*armcontainerservice.ManagedClusterAgentPoolProfile{
+				{
+					Name:   to.Ptr("system"),
+					Count:  to.Ptr[int32](2),
+					VMSize: to.Ptr("Standard_DS2_v2"),
+					Mode:   to.Ptr(armcontainerservice.AgentPoolModeSystem),
+				},
+			},
+		},
+	})
+
+	stopPoller, err := clusters.BeginStop(ctx, "rg-1", "k8s-1", nil)
+	if err != nil {
+		t.Fatalf("BeginStop: %v", err)
+	}
+
+	if _, err := stopPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Stop PollUntilDone: %v", err)
+	}
+
+	props := getClusterProps(t, clusters)
+	if props.PowerState == nil || props.PowerState.Code == nil ||
+		*props.PowerState.Code != armcontainerservice.CodeStopped {
+		t.Fatalf("got powerState %+v, want Stopped", props.PowerState)
+	}
+
+	poolGot, err := pools.Get(ctx, "rg-1", "k8s-1", "system", nil)
+	if err != nil {
+		t.Fatalf("Pool Get: %v", err)
+	}
+
+	if poolGot.Properties.PowerState == nil || poolGot.Properties.PowerState.Code == nil ||
+		*poolGot.Properties.PowerState.Code != armcontainerservice.CodeStopped {
+		t.Fatalf("got pool powerState %+v, want Stopped", poolGot.Properties.PowerState)
+	}
+
+	// Stopping an already-stopped cluster is idempotent (no error).
+	stopAgainPoller, err := clusters.BeginStop(ctx, "rg-1", "k8s-1", nil)
+	if err != nil {
+		t.Fatalf("second BeginStop: %v", err)
+	}
+
+	if _, err := stopAgainPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("second Stop PollUntilDone: %v", err)
+	}
+
+	startPoller, err := clusters.BeginStart(ctx, "rg-1", "k8s-1", nil)
+	if err != nil {
+		t.Fatalf("BeginStart: %v", err)
+	}
+
+	if _, err := startPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Start PollUntilDone: %v", err)
+	}
+
+	props = getClusterProps(t, clusters)
+	if props.PowerState == nil || props.PowerState.Code == nil ||
+		*props.PowerState.Code != armcontainerservice.CodeRunning {
+		t.Fatalf("got powerState %+v, want Running", props.PowerState)
+	}
+
+	poolGot, err = pools.Get(ctx, "rg-1", "k8s-1", "system", nil)
+	if err != nil {
+		t.Fatalf("Pool Get after start: %v", err)
+	}
+
+	if poolGot.Properties.PowerState == nil || poolGot.Properties.PowerState.Code == nil ||
+		*poolGot.Properties.PowerState.Code != armcontainerservice.CodeRunning {
+		t.Fatalf("got pool powerState %+v, want Running", poolGot.Properties.PowerState)
+	}
+}
+
+// TestSDKAKSClusterStartStopMissingCluster asserts start/stop on a managed
+// cluster that was never created returns NotFound.
+func TestSDKAKSClusterStartStopMissingCluster(t *testing.T) {
+	clusters, _, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	if _, err := clusters.BeginStop(ctx, "rg-1", "ghost", nil); err == nil {
+		t.Fatal("expected error stopping a missing cluster")
+	} else {
+		assertResponseCode(t, err, http.StatusNotFound)
+	}
+
+	if _, err := clusters.BeginStart(ctx, "rg-1", "ghost", nil); err == nil {
+		t.Fatal("expected error starting a missing cluster")
+	} else {
+		assertResponseCode(t, err, http.StatusNotFound)
+	}
+}
+
+// TestSDKAKSDeleteLastSystemPoolRejected asserts deleting the sole System-mode
+// agent pool on a cluster fails — AKS requires at least one System pool at
+// all times — while a second System pool makes either deletable.
+func TestSDKAKSDeleteLastSystemPoolRejected(t *testing.T) {
+	clusters, pools, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+		Properties: &armcontainerservice.ManagedClusterProperties{
+			AgentPoolProfiles: []*armcontainerservice.ManagedClusterAgentPoolProfile{
+				{
+					Name:   to.Ptr("system"),
+					Count:  to.Ptr[int32](2),
+					VMSize: to.Ptr("Standard_DS2_v2"),
+					Mode:   to.Ptr(armcontainerservice.AgentPoolModeSystem),
+				},
+			},
+		},
+	})
+
+	if _, err := pools.BeginDelete(ctx, "rg-1", "k8s-1", "system", nil); err == nil {
+		t.Fatal("expected error deleting the last System-mode pool")
+	} else {
+		assertResponseCode(t, err, http.StatusConflict)
+	}
+
+	if _, err := pools.Get(ctx, "rg-1", "k8s-1", "system", nil); err != nil {
+		t.Fatalf("system pool should still exist after rejected delete: %v", err)
+	}
+
+	// Add a second System pool; now the first is deletable.
+	poolPoller, err := pools.BeginCreateOrUpdate(ctx, "rg-1", "k8s-1", "system2", armcontainerservice.AgentPool{
+		Properties: &armcontainerservice.ManagedClusterAgentPoolProfileProperties{
+			Count:  to.Ptr[int32](1),
+			VMSize: to.Ptr("Standard_DS2_v2"),
+			Mode:   to.Ptr(armcontainerservice.AgentPoolModeSystem),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("second system pool BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poolPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("second system pool PollUntilDone: %v", err)
+	}
+
+	delPoller, err := pools.BeginDelete(ctx, "rg-1", "k8s-1", "system", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete after adding a second System pool: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("delete poll after adding a second System pool: %v", err)
+	}
+}
+
+func assertResponseCode(t *testing.T, err error, want int) {
+	t.Helper()
+
+	var respErr *azcore.ResponseError
+
+	if !errors.As(err, &respErr) {
+		t.Fatalf("want *azcore.ResponseError with code %d, got %v", want, err)
+	}
+
+	if respErr.StatusCode != want {
+		t.Fatalf("got HTTP %d, want %d (%v)", respErr.StatusCode, want, err)
+	}
+}

--- a/server/azure/aks/types.go
+++ b/server/azure/aks/types.go
@@ -10,6 +10,15 @@ const (
 	resourceTypeAgentPool          = "Microsoft.ContainerService/managedClusters/agentPools"
 	resourceTypeMaintenanceConfig  = "Microsoft.ContainerService/managedClusters/maintenanceConfigurations"
 	resourceTypeManagedClusterFull = "Microsoft.ContainerService/managedClusters"
+	// resourceTypeLocations and subOperationStatuses identify the synthetic
+	// .../locations/{loc}/operationStatuses/{id} LRO-polling endpoint that
+	// start/stop cluster actions point their Azure-AsyncOperation header at.
+	resourceTypeLocations = "locations"
+	subOperationStatuses  = "operationStatuses"
+	// clusterActionStart and clusterActionStop are the POST sub-resource verbs
+	// for Microsoft.ContainerService/managedClusters/{name}/{start,stop}.
+	clusterActionStart = "start"
+	clusterActionStop  = "stop"
 )
 
 // armManagedCluster mirrors the JSON shape Azure ARM expects for


### PR DESCRIPTION
## Summary
- Adds `POST .../managedClusters/{name}/start` and `.../stop` (Microsoft.ContainerService), driving `powerState.code` between `Running`/`Stopped` on the cluster and mirroring the transition onto every attached agent pool. Idempotent on repeat calls. `ProvisioningState` settles synchronously to `Succeeded`, matching the existing AKS handler's convention (documented in its package comment).
- Wire layer: 202 + `Azure-AsyncOperation` pointing at a synthetic `locations/{loc}/operationStatuses/{id}` endpoint so the real `armcontainerservice` SDK's LRO poller terminates, following the same per-package pattern already used by disks/managedcassandra/etc.
- `DeleteAgentPool` now rejects deleting a cluster's last System-mode agent pool (`FailedPrecondition` → 409), matching AKS's requirement that a cluster always retain at least one System pool. A second System pool makes either deletable.
- `docs/coverage/azure/aks.md` regenerated (16 → 18 operations).

## Gap list (from investigation)
Before this PR, AKS had full managed-cluster and agent-pool CRUD, tags PATCH, maintenance configs, and stub credential/cert-rotation endpoints, but:
- No start/stop cluster support at all (powerState was always hardcoded `Running`).
- No enforcement of the ≥1-System-pool invariant on agent pool deletion.
- `provisioningState`/`powerState` literals were duplicated inline rather than named constants.

## Deferred
- Transient `provisioningState` values (`Creating`/`Starting`/`Stopping`) — the emulator settles synchronously to `Succeeded`, consistent with how CreateOrUpdateCluster already behaved before this PR (no async settle machinery was wired into AKS; adding it is a larger, separate change).
- Blocking most other mutations (agent pool PUT, scaling) while a cluster is stopped — real AKS rejects many of these with `ClusterNotRunning`; out of scope for this pass.
- `listClusterAdminCredential`/kubeconfig content is unaffected by power state (still the existing Wave 1/2 behavior).
- Cluster-creation-time enforcement of "at least one System pool present" — only the deletion-time guard is added here.