### PR TITLE
fix(sts): GetCallerIdentity reflects the presented credentials

### DIFF
--- a/providers/aws/iam/iam.go
+++ b/providers/aws/iam/iam.go
@@ -1317,9 +1317,10 @@ func (m *Mock) AccessKeyByID(_ context.Context, id string) (driver.AccessKeyAuth
 		return driver.AccessKeyAuth{}, false
 	}
 
-	var userARN string
+	var userARN, userID string
 	if u, found := m.users.Get(ak.UserName); found {
 		userARN = u.ARN
+		userID = u.ID
 	}
 
 	return driver.AccessKeyAuth{
@@ -1327,6 +1328,7 @@ func (m *Mock) AccessKeyByID(_ context.Context, id string) (driver.AccessKeyAuth
 		SecretAccessKey: ak.SecretAccessKey,
 		UserName:        ak.UserName,
 		UserARN:         userARN,
+		UserID:          userID,
 		AccountID:       m.opts.AccountID,
 	}, true
 }

--- a/server/authctx/authctx.go
+++ b/server/authctx/authctx.go
@@ -17,11 +17,17 @@ type Principal struct {
 	UserName    string
 	ARN         string
 	AccountID   string
+	// UserID is the caller's unique id (an IAM user's "AIDA..." value), when
+	// known. Empty for a temporary STS credential, whose identity the STS
+	// handler tracks separately.
+	UserID string
 }
 
 type principalKey struct{}
 
 // WithPrincipal returns a copy of ctx carrying p.
+//
+//nolint:gocritic // hugeParam: Principal is passed by value to keep this small, stable public signature.
 func WithPrincipal(ctx context.Context, p Principal) context.Context {
 	return context.WithValue(ctx, principalKey{}, p)
 }

--- a/server/aws/authgate.go
+++ b/server/aws/authgate.go
@@ -143,6 +143,7 @@ func resolverLookup(r *http.Request, resolver iamdriver.AccessKeyResolver) sigv4
 			UserName:    info.UserName,
 			ARN:         info.UserARN,
 			AccountID:   info.AccountID,
+			UserID:      info.UserID,
 		}, true
 	}
 }

--- a/server/aws/sts/handler.go
+++ b/server/aws/sts/handler.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
@@ -64,11 +65,28 @@ type Handler struct {
 	accountID string
 	region    string
 	trust     roleTrustEvaluator
+	// resolver, when the wired IAM driver supports it, resolves a presented
+	// long-term (AKIA) access key id to its owning IAM user so
+	// GetCallerIdentity can reflect that user instead of a constant.
+	resolver iamdriver.AccessKeyResolver
 	// sessions, when set, records the temporary credentials this handler mints
 	// so the SigV4 authentication gate can verify signatures made with them. It
 	// is wired only when EnforceAuth is on; left nil the handler returns the
 	// fixed synthetic credentials it always has (auth-off byte-for-byte).
 	sessions *SessionStore
+
+	// identities records, for a temporary (ASIA) access key id this handler has
+	// minted, the caller identity it represents (an AssumedRoleUser, a
+	// FederatedUser, or the resolved caller for GetSessionToken), so a later
+	// GetCallerIdentity call made with that access key reflects the operation
+	// that minted it rather than a constant. It is populated regardless of
+	// EnforceAuth. With EnforceAuth off every mint shares cloudemu's one fixed
+	// synthetic access key id (see mintCredentials), so this map holds a single
+	// entry that reflects whichever operation minted most recently — a known
+	// limitation of the unauthenticated default. With EnforceAuth on each mint
+	// gets a unique key, so entries never collide.
+	identMu    sync.RWMutex
+	identities map[string]callerIdentity
 }
 
 // SetSessions wires the temporary-credential store. When set, AssumeRole /
@@ -90,12 +108,40 @@ func New(accountID, region string, iam iamdriver.IAM) *Handler {
 		region = defaultRegion
 	}
 
-	h := &Handler{accountID: accountID, region: region}
+	h := &Handler{accountID: accountID, region: region, identities: make(map[string]callerIdentity)}
 	if te, ok := iam.(roleTrustEvaluator); ok {
 		h.trust = te
 	}
 
+	if resolver, ok := iam.(iamdriver.AccessKeyResolver); ok {
+		h.resolver = resolver
+	}
+
 	return h
+}
+
+// rememberIdentity records the caller identity a just-minted temporary access
+// key id represents. A blank key or an identity with nothing to report is a
+// no-op.
+func (h *Handler) rememberIdentity(accessKeyID string, id callerIdentity) {
+	if accessKeyID == "" || (id.arn == "" && id.userID == "") {
+		return
+	}
+
+	h.identMu.Lock()
+	h.identities[accessKeyID] = id
+	h.identMu.Unlock()
+}
+
+// identityFor returns the caller identity recorded for a temporary access key
+// id, if any.
+func (h *Handler) identityFor(accessKeyID string) (callerIdentity, bool) {
+	h.identMu.RLock()
+	defer h.identMu.RUnlock()
+
+	id, ok := h.identities[accessKeyID]
+
+	return id, ok
 }
 
 const (

--- a/server/aws/sts/identity_test.go
+++ b/server/aws/sts/identity_test.go
@@ -1,0 +1,179 @@
+package sts_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awssts "github.com/aws/aws-sdk-go-v2/service/sts"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+// stsClientWithCreds is like stsClient but signs requests with the given
+// access key/secret instead of the fixed "test"/"test" pair, so a test can
+// prove GetCallerIdentity reflects the presented credential.
+func stsClientWithCreds(t *testing.T, url, akid, secret string) *awssts.Client {
+	t.Helper()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion(testRegion),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(akid, secret, ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return awssts.NewFromConfig(cfg, func(o *awssts.Options) {
+		o.BaseEndpoint = aws.String(url)
+	})
+}
+
+// TestGetCallerIdentityReflectsIAMUser proves GetCallerIdentity reports the
+// IAM user owning the presented access key — not a hardcoded identity —  by
+// creating a real user + access key through the IAM driver and calling
+// GetCallerIdentity with the real aws-sdk-go-v2 STS client signed with that
+// key.
+func TestGetCallerIdentityReflectsIAMUser(t *testing.T) {
+	ctx := context.Background()
+	cloud := cloudemu.NewAWS()
+
+	if _, err := cloud.IAM.CreateUser(ctx, iamdriver.UserConfig{Name: "alice"}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	ak, err := cloud.IAM.CreateAccessKey(ctx, iamdriver.AccessKeyConfig{UserName: "alice"})
+	if err != nil {
+		t.Fatalf("CreateAccessKey: %v", err)
+	}
+
+	ts := newServer(t, awsserver.Drivers{
+		STS:       true,
+		IAM:       cloud.IAM,
+		AccountID: testAccountID,
+		Region:    testRegion,
+	})
+
+	out, err := stsClientWithCreds(t, ts.URL, ak.AccessKeyID, ak.SecretAccessKey).
+		GetCallerIdentity(ctx, &awssts.GetCallerIdentityInput{})
+	if err != nil {
+		t.Fatalf("GetCallerIdentity: %v", err)
+	}
+
+	wantArn := "arn:aws:iam::" + testAccountID + ":user/alice"
+	if got := aws.ToString(out.Arn); got != wantArn {
+		t.Errorf("Arn = %q, want %q", got, wantArn)
+	}
+
+	if aws.ToString(out.UserId) == "AIDACLOUDEMU0000000000" {
+		t.Error("UserId is the hardcoded placeholder, not derived from the real IAM user")
+	}
+
+	if aws.ToString(out.Account) != testAccountID {
+		t.Errorf("Account = %q, want %q", aws.ToString(out.Account), testAccountID)
+	}
+}
+
+// TestGetCallerIdentityReflectsAssumedRole proves that after AssumeRole, using
+// the returned temporary credentials to call GetCallerIdentity reports the
+// assumed-role ARN, not the caller's own or a hardcoded identity.
+func TestGetCallerIdentityReflectsAssumedRole(t *testing.T) {
+	ctx := context.Background()
+
+	ts := newServer(t, awsserver.Drivers{
+		STS:       true,
+		AccountID: testAccountID,
+		Region:    testRegion,
+	})
+
+	const roleArn = "arn:aws:iam::123456789012:role/DeployRole"
+
+	assumed, err := stsClient(t, ts.URL).AssumeRole(ctx, &awssts.AssumeRoleInput{
+		RoleArn:         aws.String(roleArn),
+		RoleSessionName: aws.String("e2e-session"),
+	})
+	if err != nil {
+		t.Fatalf("AssumeRole: %v", err)
+	}
+
+	creds := assumed.Credentials
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion(testRegion),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			aws.ToString(creds.AccessKeyId), aws.ToString(creds.SecretAccessKey), aws.ToString(creds.SessionToken),
+		)),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	assumedClient := awssts.NewFromConfig(cfg, func(o *awssts.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+
+	ident, err := assumedClient.GetCallerIdentity(ctx, &awssts.GetCallerIdentityInput{})
+	if err != nil {
+		t.Fatalf("GetCallerIdentity (assumed role): %v", err)
+	}
+
+	wantArn := "arn:aws:sts::" + testAccountID + ":assumed-role/DeployRole/e2e-session"
+	if got := aws.ToString(ident.Arn); got != wantArn {
+		t.Errorf("Arn = %q, want %q", got, wantArn)
+	}
+}
+
+// TestGetCallerIdentityDistinctForDistinctKeys proves two different presented
+// access keys resolve to two different identities — GetCallerIdentity is not
+// collapsing every caller onto one constant.
+func TestGetCallerIdentityDistinctForDistinctKeys(t *testing.T) {
+	ctx := context.Background()
+	cloud := cloudemu.NewAWS()
+
+	for _, name := range []string{"bob", "carol"} {
+		if _, err := cloud.IAM.CreateUser(ctx, iamdriver.UserConfig{Name: name}); err != nil {
+			t.Fatalf("CreateUser(%s): %v", name, err)
+		}
+	}
+
+	bobKey, err := cloud.IAM.CreateAccessKey(ctx, iamdriver.AccessKeyConfig{UserName: "bob"})
+	if err != nil {
+		t.Fatalf("CreateAccessKey(bob): %v", err)
+	}
+
+	carolKey, err := cloud.IAM.CreateAccessKey(ctx, iamdriver.AccessKeyConfig{UserName: "carol"})
+	if err != nil {
+		t.Fatalf("CreateAccessKey(carol): %v", err)
+	}
+
+	ts := newServer(t, awsserver.Drivers{
+		STS:       true,
+		IAM:       cloud.IAM,
+		AccountID: testAccountID,
+		Region:    testRegion,
+	})
+
+	bobIdent, err := stsClientWithCreds(t, ts.URL, bobKey.AccessKeyID, bobKey.SecretAccessKey).
+		GetCallerIdentity(ctx, &awssts.GetCallerIdentityInput{})
+	if err != nil {
+		t.Fatalf("GetCallerIdentity(bob): %v", err)
+	}
+
+	carolIdent, err := stsClientWithCreds(t, ts.URL, carolKey.AccessKeyID, carolKey.SecretAccessKey).
+		GetCallerIdentity(ctx, &awssts.GetCallerIdentityInput{})
+	if err != nil {
+		t.Fatalf("GetCallerIdentity(carol): %v", err)
+	}
+
+	if aws.ToString(bobIdent.Arn) == aws.ToString(carolIdent.Arn) {
+		t.Errorf("bob and carol resolved to the same Arn %q; identity is a constant", aws.ToString(bobIdent.Arn))
+	}
+
+	if aws.ToString(bobIdent.UserId) == aws.ToString(carolIdent.UserId) {
+		t.Errorf("bob and carol resolved to the same UserId %q; identity is a constant", aws.ToString(bobIdent.UserId))
+	}
+}

--- a/server/aws/sts/operations.go
+++ b/server/aws/sts/operations.go
@@ -1,12 +1,16 @@
 package sts
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/stackshy/cloudemu/v2/server/authctx"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	"github.com/stackshy/cloudemu/v2/server/wire/sigv4"
 )
 
 // callerUserName is the synthetic IAM user name reported by GetCallerIdentity.
@@ -21,18 +25,122 @@ const defaultSessionName = "cloudemu-session"
 // value in the future is all any SDK requires.
 const sessionDuration = time.Hour
 
-// getCallerIdentity reports the configured account, a synthetic user ARN, and a
-// synthetic user id. This is the call most SDK init paths make.
-func (h *Handler) getCallerIdentity(w http.ResponseWriter, _ *http.Request) {
+// getCallerIdentity reports the configured account and the caller identity
+// resolved from the request's presented credentials (see
+// Handler.resolveCallerIdentity), reflecting an IAM user's own access key, an
+// assumed-role/federated session this handler minted, or — failing those — a
+// synthetic identity derived from the presented access key id so distinct
+// callers are not all collapsed onto one fake identity.
+func (h *Handler) getCallerIdentity(w http.ResponseWriter, r *http.Request) {
+	id := h.resolveCallerIdentity(r)
+
 	awsquery.WriteXMLResponse(w, getCallerIdentityResponse{
 		Xmlns: Namespace,
 		Result: getCallerIdentityResult{
 			Account: h.accountID,
-			Arn:     "arn:aws:iam::" + h.accountID + ":user/" + callerUserName,
-			UserID:  "AIDACLOUDEMU0000000000",
+			Arn:     id.arn,
+			UserID:  id.userID,
 		},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
+}
+
+// callerIdentity is the Arn/UserId pair GetCallerIdentity reports for a
+// caller, and what a minted temporary credential set is remembered under (see
+// Handler.identities) so a later GetCallerIdentity call made with those
+// credentials reflects it.
+type callerIdentity struct {
+	arn    string
+	userID string
+}
+
+// resolveCallerIdentity derives the caller identity for r, in priority order:
+//
+//  1. A principal the SigV4 authentication gate already verified (EnforceAuth
+//     on) and resolved to a real IAM user's ARN.
+//  2. No presented credentials at all: the fixed placeholder identity (keeps
+//     an unsigned/anonymous call's response unchanged).
+//  3. A temporary access key id this handler itself minted (AssumeRole,
+//     AssumeRoleWithWebIdentity, AssumeRoleWithSAML, GetFederationToken, or
+//     GetSessionToken): the identity recorded for it at mint time.
+//  4. A long-term access key id a wired IAM driver recognizes: that key's
+//     owning user.
+//  5. Otherwise: a synthetic-but-stable identity derived from the presented
+//     access key id, so distinct callers are not all collapsed onto one fake
+//     identity even when cloudemu cannot resolve who they are.
+//
+// cloudemu's wire layer parses SigV4 material but does not verify it unless
+// EnforceAuth is on, so outside that mode this reports who the request claims
+// to be, not a cryptographically proven identity — matching AWS's own
+// GetCallerIdentity semantics of reflecting the presented credential.
+func (h *Handler) resolveCallerIdentity(r *http.Request) callerIdentity {
+	if p, ok := authctx.PrincipalFrom(r.Context()); ok && p.ARN != "" {
+		return callerIdentity{arn: p.ARN, userID: firstNonEmpty(p.UserID, syntheticUserID(p.AccessKeyID))}
+	}
+
+	akid := sigv4.AccessKeyID(r)
+	if akid == "" {
+		return h.defaultCallerIdentity()
+	}
+
+	if id, ok := h.identityFor(akid); ok {
+		return id
+	}
+
+	if h.resolver != nil {
+		if info, ok := h.resolver.AccessKeyByID(r.Context(), akid); ok && info.UserARN != "" {
+			return callerIdentity{arn: info.UserARN, userID: firstNonEmpty(info.UserID, syntheticUserID(akid))}
+		}
+	}
+
+	return h.syntheticCallerIdentity(akid)
+}
+
+// defaultCallerIdentity is the well-formed placeholder GetCallerIdentity
+// reports for a request that presents no SigV4 credentials at all, preserving
+// the prior fixed response for that case.
+func (h *Handler) defaultCallerIdentity() callerIdentity {
+	return callerIdentity{
+		arn:    "arn:aws:iam::" + h.accountID + ":user/" + callerUserName,
+		userID: "AIDACLOUDEMU0000000000",
+	}
+}
+
+// syntheticCallerIdentity derives a stable identity from a presented access
+// key id cloudemu cannot otherwise resolve, so distinct callers still get
+// distinct (if fake) identities instead of all collapsing onto one constant.
+func (h *Handler) syntheticCallerIdentity(akid string) callerIdentity {
+	return callerIdentity{
+		arn:    "arn:aws:iam::" + h.accountID + ":user/" + strings.ReplaceAll(akid, "/", "-"),
+		userID: syntheticUserID(akid),
+	}
+}
+
+// syntheticUserIDHexLen is the number of hex characters (from a SHA-256 digest
+// of the access key id) appended after the AIDA prefix, matching real IAM
+// unique ids' length.
+const syntheticUserIDHexLen = 16
+
+// syntheticUserID deterministically derives an AIDA-style unique id from an
+// access key id, so the same presented key always reports the same synthetic
+// UserId and two different keys practically never collide.
+func syntheticUserID(akid string) string {
+	if akid == "" {
+		return "AIDACLOUDEMU0000000000"
+	}
+
+	sum := sha256.Sum256([]byte(akid))
+
+	return "AIDA" + strings.ToUpper(hex.EncodeToString(sum[:]))[:syntheticUserIDHexLen]
+}
+
+// firstNonEmpty returns a if non-empty, else b.
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+
+	return b
 }
 
 // assumeRole returns synthetic temporary credentials and an AssumedRoleUser
@@ -62,8 +170,9 @@ func (h *Handler) assumeRole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	assumedArn := "arn:aws:sts::" + h.accountID + ":assumed-role/" + roleName + "/" + sessionName
+	assumedRoleID := assumedRoleIDPrefix + ":" + sessionName
 
-	creds, ok := h.mintCredentials(w, durationFromForm(r))
+	creds, ok := h.mintCredentials(w, durationFromForm(r), callerIdentity{arn: assumedArn, userID: assumedRoleID})
 	if !ok {
 		return
 	}
@@ -73,13 +182,19 @@ func (h *Handler) assumeRole(w http.ResponseWriter, r *http.Request) {
 		Result: assumeRoleResult{
 			Credentials: creds,
 			AssumedRoleUser: assumedRoleUser{
-				AssumedRoleID: "AROACLOUDEMU0000000000:" + sessionName,
+				AssumedRoleID: assumedRoleID,
 				Arn:           assumedArn,
 			},
 		},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
+
+// assumedRoleIDPrefix is the synthetic AssumedRoleId prefix (real STS uses the
+// "AROA" prefix followed by a unique id) reported by every AssumeRole-family
+// operation, and used to derive the identity a minted session is recorded
+// under for GetCallerIdentity.
+const assumedRoleIDPrefix = "AROACLOUDEMU0000000000"
 
 // trustAllows reports whether the caller may assume roleName. With no trust
 // evaluator wired it stays permissive (standalone init-creds behavior). With one
@@ -114,7 +229,9 @@ func (h *Handler) assumeRoleWithWebIdentity(w http.ResponseWriter, r *http.Reque
 		provider = "cloudemu.local"
 	}
 
-	creds, ok := h.mintCredentials(w, durationFromForm(r))
+	assumedRoleID := assumedRoleIDPrefix + ":" + sessionName
+
+	creds, ok := h.mintCredentials(w, durationFromForm(r), callerIdentity{arn: assumedArn, userID: assumedRoleID})
 	if !ok {
 		return
 	}
@@ -124,7 +241,7 @@ func (h *Handler) assumeRoleWithWebIdentity(w http.ResponseWriter, r *http.Reque
 		Result: assumeRoleWithWebIdentityResult{
 			Credentials: creds,
 			AssumedRoleUser: assumedRoleUser{
-				AssumedRoleID: "AROACLOUDEMU0000000000:" + sessionName,
+				AssumedRoleID: assumedRoleID,
 				Arn:           assumedArn,
 			},
 			SubjectFromWebIdentityToken: "cloudemu-web-identity-subject",
@@ -141,8 +258,9 @@ func (h *Handler) assumeRoleWithSAML(w http.ResponseWriter, r *http.Request) {
 	roleName := roleNameFromArn(r.Form.Get("RoleArn"))
 	sessionName := "cloudemu-saml-session"
 	assumedArn := "arn:aws:sts::" + h.accountID + ":assumed-role/" + roleName + "/" + sessionName
+	assumedRoleID := assumedRoleIDPrefix + ":" + sessionName
 
-	creds, ok := h.mintCredentials(w, durationFromForm(r))
+	creds, ok := h.mintCredentials(w, durationFromForm(r), callerIdentity{arn: assumedArn, userID: assumedRoleID})
 	if !ok {
 		return
 	}
@@ -152,7 +270,7 @@ func (h *Handler) assumeRoleWithSAML(w http.ResponseWriter, r *http.Request) {
 		Result: assumeRoleWithSAMLResult{
 			Credentials: creds,
 			AssumedRoleUser: assumedRoleUser{
-				AssumedRoleID: "AROACLOUDEMU0000000000:" + sessionName,
+				AssumedRoleID: assumedRoleID,
 				Arn:           assumedArn,
 			},
 			Subject:       "cloudemu-saml-subject",
@@ -173,7 +291,10 @@ func (h *Handler) getFederationToken(w http.ResponseWriter, r *http.Request) {
 		name = "cloudemu-federated"
 	}
 
-	creds, ok := h.mintCredentials(w, durationFromForm(r))
+	fedArn := "arn:aws:sts::" + h.accountID + ":federated-user/" + name
+	fedUserID := h.accountID + ":" + name
+
+	creds, ok := h.mintCredentials(w, durationFromForm(r), callerIdentity{arn: fedArn, userID: fedUserID})
 	if !ok {
 		return
 	}
@@ -183,8 +304,8 @@ func (h *Handler) getFederationToken(w http.ResponseWriter, r *http.Request) {
 		Result: getFederationTokenResult{
 			Credentials: creds,
 			FederatedUser: federatedUser{
-				FederatedUserID: h.accountID + ":" + name,
-				Arn:             "arn:aws:sts::" + h.accountID + ":federated-user/" + name,
+				FederatedUserID: fedUserID,
+				Arn:             fedArn,
 			},
 		},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
@@ -226,9 +347,12 @@ func durationFromForm(r *http.Request) time.Duration {
 	return sessionDuration
 }
 
-// getSessionToken returns synthetic temporary credentials.
+// getSessionToken returns temporary credentials for the caller's own
+// identity — a GetSessionToken session represents the same caller, not a role
+// or a federated user, so the minted credentials are recorded under the
+// identity resolveCallerIdentity resolves for the request that asked for them.
 func (h *Handler) getSessionToken(w http.ResponseWriter, r *http.Request) {
-	creds, ok := h.mintCredentials(w, durationFromForm(r))
+	creds, ok := h.mintCredentials(w, durationFromForm(r), h.resolveCallerIdentity(r))
 	if !ok {
 		return
 	}
@@ -244,8 +368,10 @@ func (h *Handler) getSessionToken(w http.ResponseWriter, r *http.Request) {
 // the future. When a session store is wired (EnforceAuth on) it mints unique,
 // verifiable credentials and records their secret so the auth gate can verify a
 // signature made with them; otherwise it returns the fixed synthetic values it
-// always has (default, auth-off behavior is byte-for-byte unchanged).
-func (h *Handler) synthCredentials(dur time.Duration) (credentials, error) {
+// always has (default, auth-off behavior is byte-for-byte unchanged). Either
+// way, the returned access key id is recorded under identity so a later
+// GetCallerIdentity call made with these credentials reflects it.
+func (h *Handler) synthCredentials(dur time.Duration, identity callerIdentity) (credentials, error) {
 	if dur <= 0 {
 		dur = sessionDuration
 	}
@@ -256,6 +382,8 @@ func (h *Handler) synthCredentials(dur time.Duration) (credentials, error) {
 			return credentials{}, err
 		}
 
+		h.rememberIdentity(sess.AccessKeyID, identity)
+
 		return credentials{
 			AccessKeyID:     sess.AccessKeyID,
 			SecretAccessKey: sess.SecretAccessKey,
@@ -264,19 +392,23 @@ func (h *Handler) synthCredentials(dur time.Duration) (credentials, error) {
 		}, nil
 	}
 
+	const fixedAccessKeyID = "ASIACLOUDEMU000000000"
+
+	h.rememberIdentity(fixedAccessKeyID, identity)
+
 	return credentials{
-		AccessKeyID:     "ASIACLOUDEMU000000000",
+		AccessKeyID:     fixedAccessKeyID,
 		SecretAccessKey: "cloudemuSecretAccessKey0000000000000000",
 		SessionToken:    "cloudemu-session-token",
 		Expiration:      time.Now().UTC().Add(dur).Format(time.RFC3339),
 	}, nil
 }
 
-// mintCredentials builds temporary credentials for a handler, writing a
-// InternalFailure error response and reporting ok=false when credential
-// generation fails closed (a crypto/rand read error).
-func (h *Handler) mintCredentials(w http.ResponseWriter, dur time.Duration) (credentials, bool) {
-	creds, err := h.synthCredentials(dur)
+// mintCredentials builds temporary credentials representing identity for a
+// handler, writing an InternalFailure error response and reporting ok=false
+// when credential generation fails closed (a crypto/rand read error).
+func (h *Handler) mintCredentials(w http.ResponseWriter, dur time.Duration, identity callerIdentity) (credentials, bool) {
+	creds, err := h.synthCredentials(dur, identity)
 	if err != nil {
 		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure",
 			"could not generate temporary credentials")

--- a/services/iam/driver/driver.go
+++ b/services/iam/driver/driver.go
@@ -185,15 +185,19 @@ type VirtualMFADeviceInfo struct {
 }
 
 // AccessKeyAuth carries the secret and owning principal for one access key id.
-// It is used only by the AWS SigV4 request-authentication gate to verify an
-// incoming signature and resolve the caller; the secret never leaves the
+// It is used by the AWS SigV4 request-authentication gate to verify an
+// incoming signature and resolve the caller, and by STS GetCallerIdentity to
+// reflect the presented credential's owning user; the secret never leaves the
 // server. It is AWS-only, so it is not referenced by the IAM interface below.
 type AccessKeyAuth struct {
 	AccessKeyID     string
 	SecretAccessKey string
 	UserName        string
 	UserARN         string
-	AccountID       string
+	// UserID is the owning user's unique id (the "AIDA..." value CreateUser
+	// generates), reported by GetCallerIdentity as UserId.
+	UserID    string
+	AccountID string
 }
 
 // AccessKeyResolver is an optional capability: an IAM implementation that can


### PR DESCRIPTION
## Bug

STS `GetCallerIdentity` returned a hardcoded fake identity (fixed Account/Arn/UserId) regardless of the credentials presented in the request. The wire layer parses SigV4 material without verifying it (unless `EnforceAuth` is on), but the presented access key id / session token still identifies who is calling — real AWS's `GetCallerIdentity` reflects that.

## Fix

`GetCallerIdentity` now derives an identity from the request, in priority order:

1. A principal the SigV4 authentication gate already verified (`EnforceAuth` on).
2. No presented credentials at all: the prior fixed placeholder identity (unchanged for anonymous/unsigned calls).
3. A temporary (`ASIA`) access key id this STS handler itself minted — reflects the AssumedRoleUser/FederatedUser/caller identity recorded when `AssumeRole`, `AssumeRoleWithWebIdentity`, `AssumeRoleWithSAML`, `GetFederationToken`, or `GetSessionToken` minted it.
4. A long-term (`AKIA`) access key id a wired IAM driver recognizes: that key's owning IAM user (real `Arn`/`UserId`, from `AccessKeyByID`).
5. Otherwise: a synthetic-but-stable identity deterministically derived (SHA-256) from the presented access key id, so distinct/unknown callers are not all collapsed onto one constant.

`services/iam/driver.AccessKeyAuth` and `server/authctx.Principal` gained a `UserID` field so a resolved IAM user's real unique id (`AIDA...`) flows through instead of a synthesized one.

### What's derived vs synthesized

- IAM user + access key → real ARN and UserId.
- AssumeRole-family/GetFederationToken/GetSessionToken temp creds → the exact identity STS computed when minting them.
- Unrecognized access key id → deterministic per-key synthetic ARN/UserId (not real, but stable and distinct per key).

### Deferred

- With `EnforceAuth` off, all temp credentials share cloudemu's one fixed synthetic `ASIA` access key id (pre-existing, locked in by `TestSTSCredentialsGatedByEnforceAuth`), so the identity-tracking map holds a single most-recently-minted entry in that mode — a known limitation of the unauthenticated default, not something this PR changes.
- Full SigV4 signature verification and managed-policy-doc fidelity are unrelated, separate work.