### PR TITLE
fix(gcs): enforce etag optimistic concurrency on bucket setIamPolicy

### DIFF
--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -12686,7 +12686,12 @@
             "doc": "BucketAttrsGCS returns the bucket's GCS-specific attributes."
           },
           {
-            "name": "BucketIAMPolicy"
+            "name": "BucketIAMPolicy",
+            "doc": "BucketIAMPolicy returns the bucket's IAM policy document verbatim"
+          },
+          {
+            "name": "CompareAndSetBucketIAMPolicy",
+            "doc": "CompareAndSetBucketIAMPolicy atomically applies a setIamPolicy write"
           },
           {
             "name": "ComposeObjectGCS",
@@ -12731,10 +12736,6 @@
           {
             "name": "SetBucketAttrsGCS",
             "doc": "SetBucketAttrsGCS records the bucket's location and default storage class"
-          },
-          {
-            "name": "SetBucketIAMPolicy",
-            "doc": "SetBucketIAMPolicy / BucketIAMPolicy persist and return the bucket's IAM"
           },
           {
             "name": "TouchBucket",

--- a/docs/coverage/gcp/gcs.md
+++ b/docs/coverage/gcp/gcs.md
@@ -54,7 +54,8 @@ GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type
 | Operation | Description |
 | --- | --- |
 | `BucketAttrsGCS` | BucketAttrsGCS returns the bucket's GCS-specific attributes. |
-| `BucketIAMPolicy` |  |
+| `BucketIAMPolicy` | BucketIAMPolicy returns the bucket's IAM policy document verbatim |
+| `CompareAndSetBucketIAMPolicy` | CompareAndSetBucketIAMPolicy atomically applies a setIamPolicy write |
 | `ComposeObjectGCS` | ComposeObjectGCS concatenates the source objects' bytes (in order) into |
 | `CreateNotificationConfig` | CreateNotificationConfig registers a Pub/Sub notification config on a |
 | `DeleteNotificationConfig` | DeleteNotificationConfig removes a bucket's notification config by id |
@@ -66,7 +67,6 @@ GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type
 | `ListObjectGenerations` | ListObjectGenerations returns every generation (current + archived) of the |
 | `PutObjectGCS` | PutObjectGCS writes an object honoring pre (a failed condition returns a |
 | `SetBucketAttrsGCS` | SetBucketAttrsGCS records the bucket's location and default storage class |
-| `SetBucketIAMPolicy` | SetBucketIAMPolicy / BucketIAMPolicy persist and return the bucket's IAM |
 | `TouchBucket` | TouchBucket bumps the bucket's metageneration and updated timestamp, |
 | `UpdateObjectGCS` | UpdateObjectGCS mutates an existing object's system properties and/or |
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	cloud.google.com/go/compute v1.60.0
 	cloud.google.com/go/eventarc v1.18.0
 	cloud.google.com/go/firestore v1.22.0
+	cloud.google.com/go/iam v1.7.0
 	cloud.google.com/go/storage v1.62.1
 	github.com/Azure/azure-kusto-go v0.16.1
 	github.com/Azure/azure-sdk-for-go/sdk/ai/azopenai v0.7.2
@@ -134,7 +135,6 @@ require (
 	cloud.google.com/go/auth v0.22.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
-	cloud.google.com/go/iam v1.7.0 // indirect
 	cloud.google.com/go/longrunning v0.9.0 // indirect
 	cloud.google.com/go/monitoring v1.27.0 // indirect
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect

--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -1659,19 +1659,32 @@ func (m *Mock) TouchBucket(_ context.Context, bucket string) error {
 	return nil
 }
 
-// SetBucketIAMPolicy persists the bucket's IAM policy document verbatim.
-func (m *Mock) SetBucketIAMPolicy(_ context.Context, bucket string, policyJSON []byte) error {
+// CompareAndSetBucketIAMPolicy atomically checks expectedEtag against the
+// bucket's current stored IAM policy etag and, only on a match (or an empty
+// expectedEtag, an unconditional write), replaces the policy — see
+// driver.GCSExtensions for why the check and the write must share one lock.
+func (m *Mock) CompareAndSetBucketIAMPolicy(_ context.Context, bucket, expectedEtag string, policyJSON []byte) ([]byte, error) {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
-		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
 	}
 
 	bkt.mu.Lock()
 	defer bkt.mu.Unlock()
 
-	bkt.iamPolicy = append([]byte(nil), policyJSON...)
+	currentEtag := bucketIAMPolicyEtag(bkt.iamPolicy)
+	if expectedEtag != "" && expectedEtag != currentEtag {
+		return nil, &driver.GCSPreconditionError{Message: "conditionNotMet: bucket IAM policy etag mismatch"}
+	}
 
-	return nil
+	stamped, err := withIAMEtag(policyJSON, nextIAMEtag(currentEtag))
+	if err != nil {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid IAM policy document: %v", err)
+	}
+
+	bkt.iamPolicy = stamped
+
+	return append([]byte(nil), bkt.iamPolicy...), nil
 }
 
 // BucketIAMPolicy returns the bucket's IAM policy document, or NotFound when

--- a/providers/gcp/gcs/iam_policy_etag.go
+++ b/providers/gcp/gcs/iam_policy_etag.go
@@ -1,6 +1,9 @@
 package gcs
 
-import "encoding/base64"
+import (
+	"encoding/base64"
+	"encoding/json"
+)
 
 const (
 	// iamEtagTag is the protobuf tag byte for field 1 (varint wire type) —
@@ -19,6 +22,35 @@ const (
 	// whose IAM policy was never explicitly set (etag "CAE=").
 	iamEtagInitialVersion = 1
 )
+
+// bucketIAMPolicyEtag returns the etag of a bucket's stored IAM policy
+// document, or the initial-version etag when the bucket has none (raw nil).
+func bucketIAMPolicyEtag(raw []byte) string {
+	if raw != nil {
+		var cur struct {
+			Etag string `json:"etag"`
+		}
+
+		if json.Unmarshal(raw, &cur) == nil && cur.Etag != "" {
+			return cur.Etag
+		}
+	}
+
+	return encodeIAMEtag(iamEtagInitialVersion)
+}
+
+// withIAMEtag returns raw with its top-level "etag" field overwritten,
+// leaving every other field (bindings, their conditions included) untouched.
+func withIAMEtag(raw []byte, etag string) ([]byte, error) {
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, err
+	}
+
+	doc["etag"] = etag
+
+	return json.Marshal(doc)
+}
 
 // nextIAMEtag mints the etag that follows prevEtag, incrementing its encoded
 // version. A prevEtag that isn't in the expected format (e.g. one this

--- a/server/gcp/gcs/gcs_bucket_iam_test.go
+++ b/server/gcp/gcs/gcs_bucket_iam_test.go
@@ -1,0 +1,165 @@
+// Package gcs_test — suite cell STORAGE / gcp / sdk-compat.
+//
+// Real cloud.google.com/go/storage SDK journeys for bucket-level IAM
+// (Buckets: setIamPolicy/getIamPolicy) against the emulator's GCP HTTP
+// server: a fresh bucket reads back an empty-but-valid policy, a set policy
+// persists in the default in-memory backend and round-trips on get, and a
+// stale-etag set is rejected like real GCS's optimistic concurrency.
+package gcs_test
+
+import (
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/iam"
+	"google.golang.org/api/googleapi"
+)
+
+// TestGCSBucketIAMPolicyRoundTrips proves setIamPolicy persists bindings in
+// the default in-memory backend (no real-engine extension configured) and
+// getIamPolicy reads them back, with the etag changing on every write.
+func TestGCSBucketIAMPolicyRoundTrips(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := client.Bucket("iam-bucket")
+
+	if err := bkt.Create(ctx, e2eProject, nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// A fresh bucket reads back an empty-but-valid policy, not an error.
+	policy, err := bkt.IAM().Policy(ctx)
+	if err != nil {
+		t.Fatalf("Policy (fresh bucket): %v", err)
+	}
+
+	if roles := policy.Roles(); len(roles) != 0 {
+		t.Fatalf("fresh bucket policy should have no bindings, got %v", roles)
+	}
+
+	initialEtag := policyEtag(t, policy)
+	if initialEtag == "" {
+		t.Fatalf("fresh bucket policy should carry a stable etag")
+	}
+
+	// setIamPolicy grants a binding.
+	policy.Add("allUsers", "roles/storage.objectViewer")
+
+	if err := bkt.IAM().SetPolicy(ctx, policy); err != nil {
+		t.Fatalf("SetPolicy: %v", err)
+	}
+
+	// getIamPolicy must reflect the binding — this is the persistence bug:
+	// without it, the bindings set above would come back empty.
+	after, err := bkt.IAM().Policy(ctx)
+	if err != nil {
+		t.Fatalf("Policy (after set): %v", err)
+	}
+
+	members := after.Members("roles/storage.objectViewer")
+	if len(members) != 1 || members[0] != "allUsers" {
+		t.Fatalf("binding did not persist: got members %v", members)
+	}
+
+	afterEtag := policyEtag(t, after)
+	if afterEtag == initialEtag {
+		t.Fatalf("etag should change on setIamPolicy, stayed %q", afterEtag)
+	}
+
+	// A second update on top of the fresh read succeeds and further changes
+	// the etag.
+	after.Add("user:alice@example.com", "roles/storage.objectAdmin")
+
+	if err := bkt.IAM().SetPolicy(ctx, after); err != nil {
+		t.Fatalf("SetPolicy (second update): %v", err)
+	}
+
+	final, err := bkt.IAM().Policy(ctx)
+	if err != nil {
+		t.Fatalf("Policy (final): %v", err)
+	}
+
+	if members := final.Members("roles/storage.objectAdmin"); len(members) != 1 {
+		t.Fatalf("second binding did not persist: got %v", members)
+	}
+
+	if members := final.Members("roles/storage.objectViewer"); len(members) != 1 {
+		t.Fatalf("first binding should still be present: got %v", members)
+	}
+
+	if finalEtag := policyEtag(t, final); finalEtag == afterEtag {
+		t.Fatalf("etag should change again, stayed %q", finalEtag)
+	}
+}
+
+// TestGCSBucketIAMPolicyStaleEtagRejected proves a setIamPolicy built from a
+// stale read (someone else changed the policy in between) is rejected with a
+// precondition error instead of silently clobbering the newer policy.
+func TestGCSBucketIAMPolicyStaleEtagRejected(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := client.Bucket("iam-stale-bucket")
+
+	if err := bkt.Create(ctx, e2eProject, nil); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	stale, err := bkt.IAM().Policy(ctx)
+	if err != nil {
+		t.Fatalf("Policy (stale read): %v", err)
+	}
+
+	// Someone else updates the policy first, advancing the etag.
+	fresh, err := bkt.IAM().Policy(ctx)
+	if err != nil {
+		t.Fatalf("Policy (fresh read): %v", err)
+	}
+
+	fresh.Add("allUsers", "roles/storage.objectViewer")
+
+	if err := bkt.IAM().SetPolicy(ctx, fresh); err != nil {
+		t.Fatalf("SetPolicy (winning writer): %v", err)
+	}
+
+	// The stale writer's set, built from the pre-update etag, must fail.
+	stale.Add("user:bob@example.com", "roles/storage.objectAdmin")
+
+	err = bkt.IAM().SetPolicy(ctx, stale)
+	if err == nil {
+		t.Fatalf("SetPolicy with a stale etag should have failed")
+	}
+
+	var gErr *googleapi.Error
+	if !errors.As(err, &gErr) {
+		t.Fatalf("expected a googleapi.Error, got %T: %v", err, err)
+	}
+
+	if gErr.Code != 412 {
+		t.Fatalf("expected 412 Precondition Failed, got %d: %v", gErr.Code, gErr)
+	}
+
+	// The winning writer's binding must be intact — the stale write must not
+	// have partially applied.
+	final, err := bkt.IAM().Policy(ctx)
+	if err != nil {
+		t.Fatalf("Policy (final): %v", err)
+	}
+
+	if members := final.Members("roles/storage.objectViewer"); len(members) != 1 {
+		t.Fatalf("winning writer's binding should be intact: got %v", members)
+	}
+
+	if members := final.Members("roles/storage.objectAdmin"); len(members) != 0 {
+		t.Fatalf("stale writer's binding must not have applied: got %v", members)
+	}
+}
+
+// policyEtag reaches into the SDK's *iam.Policy via its InternalProto to
+// read the wire etag it round-tripped from the server.
+func policyEtag(t *testing.T, policy *iam.Policy) string {
+	t.Helper()
+
+	if policy.InternalProto == nil {
+		t.Fatalf("policy has no InternalProto")
+	}
+
+	return string(policy.InternalProto.Etag)
+}

--- a/server/gcp/gcs/gcs_bucket_iam_test.go
+++ b/server/gcp/gcs/gcs_bucket_iam_test.go
@@ -3,16 +3,29 @@
 // Real cloud.google.com/go/storage SDK journeys for bucket-level IAM
 // (Buckets: setIamPolicy/getIamPolicy) against the emulator's GCP HTTP
 // server: a fresh bucket reads back an empty-but-valid policy, a set policy
-// persists in the default in-memory backend and round-trips on get, and a
-// stale-etag set is rejected like real GCS's optimistic concurrency.
+// persists in the default in-memory backend and round-trips on get, a
+// stale-etag set is rejected like real GCS's optimistic concurrency, and N
+// concurrent setIamPolicy calls starting from the same etag can't all "win"
+// (the TOCTOU a separate get-then-set pair would allow).
 package gcs_test
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 
 	"cloud.google.com/go/iam"
+	"cloud.google.com/go/storage"
 	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
 )
 
 // TestGCSBucketIAMPolicyRoundTrips proves setIamPolicy persists bindings in
@@ -162,4 +175,116 @@ func policyEtag(t *testing.T, policy *iam.Policy) string {
 	}
 
 	return string(policy.InternalProto.Etag)
+}
+
+// concurrentSetIAMWriters is how many goroutines race to setIamPolicy from
+// the same starting etag in TestGCSBucketIAMPolicyConcurrentSetIsAtomic.
+const concurrentSetIAMWriters = 10
+
+// TestGCSBucketIAMPolicyConcurrentSetIsAtomic proves the etag precondition
+// check and the write happen atomically: N goroutines all submit a
+// setIamPolicy built from the SAME starting etag (each with its own distinct
+// binding, replacing the whole policy). A separate read-etag-then-write pair
+// would let every one of them pass the check before any of them writes,
+// silently losing all but the last write applied; the atomic compare-and-set
+// must let exactly one of them win and every loser must see a 412.
+func TestGCSBucketIAMPolicyConcurrentSetIsAtomic(t *testing.T) {
+	ctx := context.Background()
+
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Storage: cloudP.GCS})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := storage.NewClient(ctx,
+		option.WithEndpoint(ts.URL+"/storage/v1/"),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	client.SetRetry(storage.WithPolicy(storage.RetryNever))
+	t.Cleanup(func() { _ = client.Close() })
+
+	const bucketName = "iam-concurrent-bucket"
+
+	bkt := client.Bucket(bucketName)
+	if cErr := bkt.Create(ctx, e2eProject, nil); cErr != nil {
+		t.Fatalf("Create: %v", cErr)
+	}
+
+	initial, err := bkt.IAM().Policy(ctx)
+	if err != nil {
+		t.Fatalf("Policy (initial): %v", err)
+	}
+
+	etag0 := policyEtag(t, initial)
+	iamURL := ts.URL + "/storage/v1/b/" + bucketName + "/iam"
+
+	statuses := make([]int, concurrentSetIAMWriters)
+
+	var wg sync.WaitGroup
+
+	for i := range concurrentSetIAMWriters {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			member := fmt.Sprintf("user:writer-%d@example.com", i)
+			body := fmt.Sprintf(
+				`{"bindings":[{"role":"roles/storage.objectViewer","members":["%s"]}],"etag":%q}`,
+				member, etag0,
+			)
+
+			req, rErr := http.NewRequestWithContext(ctx, http.MethodPut, iamURL, strings.NewReader(body))
+			if rErr != nil {
+				t.Errorf("writer %d: NewRequest: %v", i, rErr)
+				return
+			}
+
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, dErr := ts.Client().Do(req)
+			if dErr != nil {
+				t.Errorf("writer %d: Do: %v", i, dErr)
+				return
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			statuses[i] = resp.StatusCode
+		}(i)
+	}
+
+	wg.Wait()
+
+	successes := 0
+
+	for i, code := range statuses {
+		switch code {
+		case http.StatusOK:
+			successes++
+		case http.StatusPreconditionFailed:
+			// expected for every loser
+		default:
+			t.Errorf("writer %d: unexpected status %d", i, code)
+		}
+	}
+
+	if successes != 1 {
+		t.Fatalf("expected exactly 1 of %d concurrent setIamPolicy calls from the same etag to "+
+			"succeed, got %d — a lost update slipped through the TOCTOU window", concurrentSetIAMWriters, successes)
+	}
+
+	final, err := bkt.IAM().Policy(ctx)
+	if err != nil {
+		t.Fatalf("Policy (final): %v", err)
+	}
+
+	members := final.Members("roles/storage.objectViewer")
+	if len(members) != 1 {
+		t.Fatalf("expected exactly the single winning binding to persist, got %v", members)
+	}
 }

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -612,52 +612,31 @@ func (h *Handler) setBucketIAM(w http.ResponseWriter, r *http.Request, name stri
 		return
 	}
 
-	// A client that read the policy first (the normal read-modify-write flow)
-	// echoes back the etag it saw; a mismatch means someone else changed the
-	// policy in between, so the write is rejected like real GCS does.
-	currentEtag := h.currentBucketIAMEtag(r.Context(), name)
-	if policy.Etag != "" && policy.Etag != currentEtag {
-		writeError(w, http.StatusPreconditionFailed, "conditionNotMet",
-			"bucket "+name+"'s IAM policy was modified concurrently")
-		return
-	}
-
-	// Stamp the server-controlled fields (kind/resourceId/etag) onto the
-	// client's document without disturbing anything else it sent — bindings,
-	// their (currently unmodeled) conditions included — so it round-trips
-	// verbatim on the next getIamPolicy.
-	out, sErr := stampIAMPolicy(raw, name, nextIAMEtag(currentEtag))
+	// Stamp the server-controlled kind/resourceId now; the etag placeholder
+	// (the client's own, possibly stale, etag) is overwritten below by the
+	// backend with the real, atomically minted value.
+	prepared, sErr := stampIAMPolicy(raw, name, policy.Etag)
 	if sErr != nil {
 		writeError(w, http.StatusBadRequest, "invalid", sErr.Error())
 		return
 	}
 
-	if h.ext != nil {
-		if pErr := h.ext.SetBucketIAMPolicy(r.Context(), name, out); pErr != nil {
-			writeErr(w, pErr)
-			return
-		}
+	if h.ext == nil {
+		writeRawJSON(w, prepared)
+		return
+	}
+
+	// The etag precondition check and the write happen atomically in the
+	// backend (one lock spans read-compare-write), so concurrent setIamPolicy
+	// calls that all read the same etag can't all "win" the way a separate
+	// getIamPolicy-then-setIamPolicy pair here would allow (a lost update).
+	out, pErr := h.ext.CompareAndSetBucketIAMPolicy(r.Context(), name, policy.Etag, prepared)
+	if pErr != nil {
+		writePreconditionOrErr(w, pErr)
+		return
 	}
 
 	writeRawJSON(w, out)
-}
-
-// currentBucketIAMEtag returns the etag of the bucket's stored IAM policy, or
-// the GCS default etag when none has been set yet.
-func (h *Handler) currentBucketIAMEtag(ctx context.Context, name string) string {
-	if h.ext != nil {
-		if raw, err := h.ext.BucketIAMPolicy(ctx, name); err == nil {
-			var cur struct {
-				Etag string `json:"etag"`
-			}
-
-			if json.Unmarshal(raw, &cur) == nil && cur.Etag != "" {
-				return cur.Etag
-			}
-		}
-	}
-
-	return defaultIAMPolicy(name).Etag
 }
 
 // stampIAMPolicy overwrites kind/resourceId/etag on the client-supplied

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -612,14 +612,72 @@ func (h *Handler) setBucketIAM(w http.ResponseWriter, r *http.Request, name stri
 		return
 	}
 
+	// A client that read the policy first (the normal read-modify-write flow)
+	// echoes back the etag it saw; a mismatch means someone else changed the
+	// policy in between, so the write is rejected like real GCS does.
+	currentEtag := h.currentBucketIAMEtag(r.Context(), name)
+	if policy.Etag != "" && policy.Etag != currentEtag {
+		writeError(w, http.StatusPreconditionFailed, "conditionNotMet",
+			"bucket "+name+"'s IAM policy was modified concurrently")
+		return
+	}
+
+	// Stamp the server-controlled fields (kind/resourceId/etag) onto the
+	// client's document without disturbing anything else it sent — bindings,
+	// their (currently unmodeled) conditions included — so it round-trips
+	// verbatim on the next getIamPolicy.
+	out, sErr := stampIAMPolicy(raw, name, nextIAMEtag(currentEtag))
+	if sErr != nil {
+		writeError(w, http.StatusBadRequest, "invalid", sErr.Error())
+		return
+	}
+
 	if h.ext != nil {
-		if sErr := h.ext.SetBucketIAMPolicy(r.Context(), name, raw); sErr != nil {
-			writeErr(w, sErr)
+		if pErr := h.ext.SetBucketIAMPolicy(r.Context(), name, out); pErr != nil {
+			writeErr(w, pErr)
 			return
 		}
 	}
 
-	writeRawJSON(w, raw)
+	writeRawJSON(w, out)
+}
+
+// currentBucketIAMEtag returns the etag of the bucket's stored IAM policy, or
+// the GCS default etag when none has been set yet.
+func (h *Handler) currentBucketIAMEtag(ctx context.Context, name string) string {
+	if h.ext != nil {
+		if raw, err := h.ext.BucketIAMPolicy(ctx, name); err == nil {
+			var cur struct {
+				Etag string `json:"etag"`
+			}
+
+			if json.Unmarshal(raw, &cur) == nil && cur.Etag != "" {
+				return cur.Etag
+			}
+		}
+	}
+
+	return defaultIAMPolicy(name).Etag
+}
+
+// stampIAMPolicy overwrites kind/resourceId/etag on the client-supplied
+// policy document — real GCS always sets these itself, ignoring whatever the
+// client sent — while leaving every other field untouched.
+func stampIAMPolicy(raw []byte, bucket, etag string) ([]byte, error) {
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, err
+	}
+
+	doc["kind"] = "storage#policy"
+	doc["resourceId"] = "projects/_/buckets/" + bucket
+	doc["etag"] = etag
+
+	if _, ok := doc["bindings"]; !ok {
+		doc["bindings"] = []iamPolicyBind{}
+	}
+
+	return json.Marshal(doc)
 }
 
 // testIAMPermissions serves /b/{bucket}/iam/testPermissions — the mock grants
@@ -666,7 +724,7 @@ func writeRawJSON(w http.ResponseWriter, raw []byte) {
 	w.WriteHeader(http.StatusOK)
 	// raw is an IAM policy document validated as JSON before storage and served
 	// as application/json, not HTML — no XSS surface.
-	_, _ = w.Write(raw) //nolint:gosec // validated JSON policy, served as application/json
+	_, _ = w.Write(raw)
 }
 
 // upload handles POST /upload/storage/v1/b/{bucket}/o, dispatching on

--- a/server/gcp/gcs/iampolicy_etag.go
+++ b/server/gcp/gcs/iampolicy_etag.go
@@ -1,0 +1,76 @@
+package gcs
+
+import "encoding/base64"
+
+const (
+	// iamEtagTag is the protobuf tag byte for field 1 (varint wire type) —
+	// real GCS bucket IAM policy etags are base64 of a single-field protobuf
+	// message carrying a monotonically increasing version, e.g. "CAE=" decodes
+	// to tag 0x08 (field 1, varint) followed by the varint-encoded value 1.
+	iamEtagTag = 0x08
+	// varintContinuationBit marks that a varint byte is followed by more
+	// payload bytes.
+	varintContinuationBit = 0x80
+	// varintPayloadMask extracts the 7 payload bits of one varint byte.
+	varintPayloadMask = 0x7f
+	// varintPayloadBits is how many bits of payload one varint byte carries.
+	varintPayloadBits = 7
+	// iamEtagInitialVersion is the version real GCS reports for a bucket
+	// whose IAM policy was never explicitly set (etag "CAE=").
+	iamEtagInitialVersion = 1
+)
+
+// nextIAMEtag mints the etag that follows prevEtag, incrementing its encoded
+// version. A prevEtag that isn't in the expected format (e.g. one this
+// emulator never minted) is treated as the initial version, so the result is
+// still a well-formed, freshly incremented etag.
+func nextIAMEtag(prevEtag string) string {
+	version, ok := decodeIAMEtagVersion(prevEtag)
+	if !ok {
+		version = iamEtagInitialVersion
+	}
+
+	return encodeIAMEtag(version + 1)
+}
+
+// encodeIAMEtag base64-encodes a protobuf field-1 varint carrying version.
+func encodeIAMEtag(version uint64) string {
+	b := []byte{iamEtagTag}
+
+	for version >= varintContinuationBit {
+		// version&varintPayloadMask|varintContinuationBit is masked to the
+		// low 8 bits (0x00-0xff), so the byte conversion never truncates.
+		b = append(b, byte(version&varintPayloadMask|varintContinuationBit)) //nolint:gosec // masked to a single byte above
+		version >>= varintPayloadBits
+	}
+
+	b = append(b, byte(version))
+
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+// decodeIAMEtagVersion reverses encodeIAMEtag, reporting ok=false for any
+// etag not in that format (opaque values a real client should never
+// construct, but a defensive fallback keeps setIamPolicy from erroring on
+// one).
+func decodeIAMEtagVersion(etag string) (uint64, bool) {
+	b, err := base64.StdEncoding.DecodeString(etag)
+	if err != nil || len(b) < 2 || b[0] != iamEtagTag {
+		return 0, false
+	}
+
+	var version uint64
+
+	var shift uint
+
+	for _, c := range b[1:] {
+		version |= uint64(c&varintPayloadMask) << shift
+		if c&varintContinuationBit == 0 {
+			return version, true
+		}
+
+		shift += varintPayloadBits
+	}
+
+	return 0, false
+}

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -1164,10 +1164,22 @@ type GCSExtensions interface {
 	// TouchBucket bumps the bucket's metageneration and updated timestamp,
 	// called after any bucket configuration change.
 	TouchBucket(ctx context.Context, bucket string) error
-	// SetBucketIAMPolicy / BucketIAMPolicy persist and return the bucket's IAM
-	// policy document verbatim (Buckets: setIamPolicy / getIamPolicy).
-	SetBucketIAMPolicy(ctx context.Context, bucket string, policyJSON []byte) error
+	// BucketIAMPolicy returns the bucket's IAM policy document verbatim
+	// (Buckets: getIamPolicy).
 	BucketIAMPolicy(ctx context.Context, bucket string) ([]byte, error)
+	// CompareAndSetBucketIAMPolicy atomically applies a setIamPolicy write
+	// (Buckets: setIamPolicy). When expectedEtag is non-empty it must match
+	// the bucket's current stored policy etag, or the write is rejected with
+	// *GCSPreconditionError (real GCS's 412 conditionNotMet); an empty
+	// expectedEtag is an unconditional write. The etag check and the write
+	// happen under a single lock, so concurrent setIamPolicy calls that all
+	// read the same etag can't all "win" — the lost update a separate
+	// BucketIAMPolicy-then-CompareAndSetBucketIAMPolicy pair would allow.
+	// policyJSON is the client's validated document (kind/resourceId already
+	// stamped by the caller, etag a placeholder); the implementation mints
+	// the real etag from the bucket's actual current state and returns the
+	// final stored document.
+	CompareAndSetBucketIAMPolicy(ctx context.Context, bucket, expectedEtag string, policyJSON []byte) ([]byte, error)
 
 	// CreateNotificationConfig registers a Pub/Sub notification config on a
 	// bucket (Notifications: insert), returning the stored config with its


### PR DESCRIPTION
## Bug

`Buckets.setIamPolicy` accepted the client's policy document unconditionally: it never compared the request's `etag` against the currently stored policy, and never minted a new etag on write. A stale read-modify-write (the normal IAM update pattern) silently clobbered a concurrent change instead of failing, and `getIamPolicy` kept returning the same etag after every write, so callers had no signal that the policy had changed.

Investigation note: bucket IAM policy *persistence* itself (setIamPolicy/getIamPolicy round-tripping bindings in the default in-memory backend) already works today — it was fixed in #637 (`providers/gcp/gcs` `SetBucketIAMPolicy`/`BucketIAMPolicy`, snapshotted via `bkt.iamPolicy`). Verified with a real `cloud.google.com/go/storage` client before starting: a fresh bucket, a `setIamPolicy` with a binding, and `getIamPolicy` already round-tripped correctly. The etag/optimistic-concurrency gap above is the real remaining correctness bug in this surface.

## Fix

- Added `CompareAndSetBucketIAMPolicy(ctx, bucket, expectedEtag, policyJSON) ([]byte, error)` to `GCSExtensions`, replacing `SetBucketIAMPolicy`. In `providers/gcp/gcs`, the etag comparison and the write happen atomically under a single `bkt.mu.Lock()` — mirroring how `PutObjectGCS` already applies its precondition atomically server-side. A mismatched non-empty etag returns `*GCSPreconditionError` → `412 conditionNotMet`; an empty etag is an unconditional write.
- `setBucketIAM` (`server/gcp/gcs/handler.go`) now calls only this one atomic op, instead of composing a separate "read current etag" + "write" pair — the earlier version of this PR had exactly that TOCTOU: N concurrent `setIamPolicy` calls starting from the same etag could all pass the check before any of them wrote, silently losing all but the last write.
- Etag minting (`providers/gcp/gcs/iam_policy_etag.go`, moved from the wire layer since it must run inside the same critical section as the compare) uses the same encoding real GCS uses — base64 of a protobuf field-1 varint — consistent with the existing default etag `"CAE="` (version 1).
- `stampIAMPolicy` (wire layer) still overwrites `kind`/`resourceId` on the client's JSON document and leaves everything else — including binding conditions the portable `iamPolicyBind` type doesn't model — untouched, so nothing is silently dropped on write.

## Tests

`server/gcp/gcs/gcs_bucket_iam_test.go`, driven through the real `cloud.google.com/go/storage` SDK:
- fresh bucket → empty-but-valid policy with a stable etag (not an error)
- `setIamPolicy` → binding persists on `getIamPolicy`, etag changes on every write
- a `setIamPolicy` built from a stale read is rejected with `412`, and the concurrent winning write is left intact
- **concurrency**: N goroutines fire raw concurrent PUTs from the same starting etag (each with a distinct binding, replacing the whole policy) — exactly 1 succeeds, the rest get `412`, and the final policy contains only the winner's binding. Run under `-race -count=20`, all green.

## Deferred

- IAM policy version 3 / binding conditions (not modeled by `iamPolicyBind`, though preserved verbatim on the wire by `stampIAMPolicy`)
- Object-level ACLs
- Unifying `testIamPermissions` behavior across services