### PR TITLE
feat(iam): deletion referential-integrity guards

### DIFF
--- a/providers/aws/iam/iam.go
+++ b/providers/aws/iam/iam.go
@@ -387,9 +387,11 @@ func (m *Mock) CreatePolicy(_ context.Context, cfg driver.PolicyConfig) (*driver
 
 // DeletePolicy deletes the IAM policy with the given ARN. Like real IAM it
 // refuses (DeleteConflict) while the policy is still attached to any user or
-// role — the caller must detach it everywhere first.
+// role, or while non-default versions still exist — the caller must detach it
+// everywhere and delete non-default versions (DeletePolicyVersion) first.
 func (m *Mock) DeletePolicy(_ context.Context, arn string) error {
-	if !m.policies.Has(arn) {
+	p, ok := m.policies.Get(arn)
+	if !ok {
 		return errors.Newf(errors.NotFound, "policy %q not found", arn)
 	}
 
@@ -399,6 +401,11 @@ func (m *Mock) DeletePolicy(_ context.Context, arn string) error {
 	if m.policyAttachmentCountLocked(arn) > 0 {
 		return errors.Newf(errors.FailedPrecondition,
 			"cannot delete policy %q: still attached to one or more users or roles (detach it first)", arn)
+	}
+
+	if len(p.versions) > 1 {
+		return errors.Newf(errors.FailedPrecondition,
+			"cannot delete policy %q: non-default versions still exist (delete them with DeletePolicyVersion first)", arn)
 	}
 
 	m.policies.Delete(arn)

--- a/providers/aws/iam/iam_test.go
+++ b/providers/aws/iam/iam_test.go
@@ -211,6 +211,37 @@ func TestDeletePolicy(t *testing.T) {
 	assertError(t, m.DeletePolicy(ctx, "arn:nonexistent"), true)
 }
 
+func TestDeletePolicyWithNonDefaultVersions(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "pol1", PolicyDocument: "{}"})
+	requireNoError(t, err)
+
+	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{
+		PolicyARN:      p.ARN,
+		PolicyDocument: "{}",
+		SetAsDefault:   false,
+	})
+	requireNoError(t, err)
+
+	// A non-default version still exists: real IAM refuses the delete.
+	assertError(t, m.DeletePolicy(ctx, p.ARN), true)
+
+	versions, err := m.ListPolicyVersions(ctx, p.ARN)
+	requireNoError(t, err)
+
+	for _, v := range versions {
+		if v.IsDefaultVersion {
+			continue
+		}
+
+		requireNoError(t, m.DeletePolicyVersion(ctx, p.ARN, v.VersionID))
+	}
+
+	// Only the default version remains: the delete now succeeds.
+	requireNoError(t, m.DeletePolicy(ctx, p.ARN))
+}
+
 func TestAttachUserPolicy(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/server/aws/iam/deletion_guards_test.go
+++ b/server/aws/iam/deletion_guards_test.go
@@ -135,3 +135,53 @@ func TestSDKDeleteGroupWithMember(t *testing.T) {
 		t.Fatalf("GetGroup after refused delete: %v", err)
 	}
 }
+
+// TestSDKDeletePolicyWithNonDefaultVersion locks in that DeletePolicy fails
+// with DeleteConflictException while a non-default version still exists,
+// matching API_DeletePolicy (the caller must delete every non-default version
+// with DeletePolicyVersion first; the default version is removed implicitly
+// by DeletePolicy itself).
+func TestSDKDeletePolicyWithNonDefaultVersion(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	policy, err := client.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String("versioned-pol"),
+		PolicyDocument: aws.String(samplePolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	arn := aws.ToString(policy.Policy.Arn)
+
+	version, err := client.CreatePolicyVersion(ctx, &iam.CreatePolicyVersionInput{
+		PolicyArn:      aws.String(arn),
+		PolicyDocument: aws.String(samplePolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicyVersion: %v", err)
+	}
+
+	_, err = client.DeletePolicy(ctx, &iam.DeletePolicyInput{PolicyArn: aws.String(arn)})
+
+	var conflict *iamtypes.DeleteConflictException
+	if !errors.As(err, &conflict) {
+		t.Fatalf("DeletePolicy with non-default version: want DeleteConflictException, got %v", err)
+	}
+
+	// Policy must survive the refused delete.
+	if _, err := client.GetPolicy(ctx, &iam.GetPolicyInput{PolicyArn: aws.String(arn)}); err != nil {
+		t.Fatalf("GetPolicy after refused delete: %v", err)
+	}
+
+	if _, err := client.DeletePolicyVersion(ctx, &iam.DeletePolicyVersionInput{
+		PolicyArn: aws.String(arn), VersionId: version.PolicyVersion.VersionId,
+	}); err != nil {
+		t.Fatalf("DeletePolicyVersion: %v", err)
+	}
+
+	if _, err := client.DeletePolicy(ctx, &iam.DeletePolicyInput{PolicyArn: aws.String(arn)}); err != nil {
+		t.Fatalf("DeletePolicy after removing non-default version: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

WORLD-CASE IAM depth pass: AWS IAM deletion / referential-integrity guards, verified empirically against `providers/aws/iam` + `server/aws/iam`.

Already enforced (verified by reading + running the existing suite):
- `DeleteUser` — rejects with managed policies attached, inline policies, group membership, or access keys (`providers/aws/iam/iam.go` `DeleteUser`)
- `DeleteRole` — rejects with managed/inline policies attached or still referenced by an instance profile (`DeleteRole`)
- `DeleteGroup` — rejects with member users, managed policies, or inline policies (`DeleteGroup`)
- `DeleteInstanceProfile` — rejects while a role is still associated (`DeleteInstanceProfile`)
- `DeletePolicy` — rejects while still attached to any user or role (`DeletePolicy`, pre-existing)
- `DeletePolicyVersion` — already refuses to delete the default version
- `CreatePolicyVersion` — already caps at 5 versions

Login profiles and signing certificates aren't modeled anywhere in the driver, so those DeleteUser checks have no feature to guard.

Missing (the one real gap found, and what this PR adds):
- `DeletePolicy` did **not** check for remaining non-default policy versions. Real IAM's `DeletePolicy` is a `DeleteConflictException` while non-default versions exist — the caller must remove them with `DeletePolicyVersion` first (the default version is removed implicitly when the policy itself is deleted). Confirmed empirically: before this change, `DeletePolicy` on a policy with a non-default version succeeded silently.

## Changes

- `providers/aws/iam/iam.go`: `DeletePolicy` now also rejects (`FailedPrecondition` → wire `DeleteConflict`/409) when `len(p.versions) > 1`.
- `providers/aws/iam/iam_test.go`: provider-level test for the new guard.
- `server/aws/iam/deletion_guards_test.go`: real-SDK (`aws-sdk-go-v2/service/iam`) end-to-end test — create policy + non-default version, `DeletePolicy` → `DeleteConflictException`, `DeletePolicyVersion` removes it, `DeletePolicy` then succeeds.

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers/aws/iam/... ./server/aws/iam/... -race -count=1`
- [x] `go test ./providers/aws/... ./server/aws/...`
- [x] `gofmt -l` on touched files — clean
- [x] `golangci-lint run ./providers/aws/iam/... ./server/aws/iam/...` — 0 new issues (pre-existing findings are on untouched lines)
- [x] `go generate ./...` + `git diff --exit-code docs/coverage` — clean, no driver signature change
- [x] `go mod tidy` — no changes
