### PR TITLE
feat(gcp-iam): service-account key disable and enable

### DIFF
--- a/server/gcp/iam/errors_sdk_test.go
+++ b/server/gcp/iam/errors_sdk_test.go
@@ -60,6 +60,26 @@ func TestSDKGCPIAMKeyNotFoundIsTyped(t *testing.T) {
 	assertGoogleAPIError(t, err, 404)
 }
 
+func TestSDKGCPIAMKeyDisableNotFoundIsTyped(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/" + testProject
+	if _, err := svc.Projects.ServiceAccounts.Create(parent, &iamv1.CreateServiceAccountRequest{
+		AccountId: "key-disable-test",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("CreateServiceAccount: %v", err)
+	}
+
+	email := "key-disable-test@" + testProject + ".iam.gserviceaccount.com"
+	keyName := "projects/-/serviceAccounts/" + email + "/keys/no-such-key"
+
+	_, err := svc.Projects.ServiceAccounts.Keys.Disable(keyName,
+		&iamv1.DisableServiceAccountKeyRequest{}).Context(ctx).Do()
+
+	assertGoogleAPIError(t, err, 404)
+}
+
 func TestSDKGCPIAMDuplicateServiceAccountIsConflict(t *testing.T) {
 	svc := newSDKService(t)
 	ctx := context.Background()

--- a/server/gcp/iam/handler.go
+++ b/server/gcp/iam/handler.go
@@ -14,6 +14,8 @@
 //	GET    /v1/projects/{p}/serviceAccounts/{email}/keys/{keyId}                  — Get key
 //	GET    /v1/projects/{p}/serviceAccounts/{email}/keys                          — List keys
 //	DELETE /v1/projects/{p}/serviceAccounts/{email}/keys/{keyId}                  — Delete key
+//	POST   /v1/projects/{p}/serviceAccounts/{email}/keys/{keyId}:disable          — Disable key
+//	POST   /v1/projects/{p}/serviceAccounts/{email}/keys/{keyId}:enable           — Enable key
 //	POST   /v1/projects/{p}/roles                                                 — Create role
 //	GET    /v1/projects/{p}/roles/{roleId}                                        — Get role
 //	GET    /v1/projects/{p}/roles                                                 — List roles
@@ -52,10 +54,11 @@ const (
 
 // Handler serves iam.googleapis.com v1 REST requests against the IAM driver.
 //
-// Service-account resource policies, the enabled/disabled bit, policy etag
-// versions and soft-deleted resources have no place in the portable IAM
-// driver, so they're tracked here keyed by SA email / role id. The driver
-// hard-deletes, so undelete is served from these local tombstones.
+// Service-account resource policies, the enabled/disabled bit, per-key
+// disabled bit, policy etag versions and soft-deleted resources have no
+// place in the portable IAM driver, so they're tracked here keyed by SA
+// email / role id / key id. The driver hard-deletes, so undelete is served
+// from these local tombstones.
 type Handler struct {
 	iam iamdriver.IAM
 
@@ -63,6 +66,7 @@ type Handler struct {
 	saPolicy      map[string]*iamPolicy   // SA email -> resource policy
 	policyVersion map[string]int          // SA email -> monotonic policy etag version
 	disabled      map[string]bool         // SA email -> disabled
+	keyDisabled   map[string]bool         // key id -> disabled
 	deletedSA     map[string]*deletedSA   // SA email -> soft-deleted account
 	deletedRole   map[string]*deletedRole // role id -> soft-deleted role
 }
@@ -89,6 +93,7 @@ func New(drv iamdriver.IAM) *Handler {
 		saPolicy:      make(map[string]*iamPolicy),
 		policyVersion: make(map[string]int),
 		disabled:      make(map[string]bool),
+		keyDisabled:   make(map[string]bool),
 		deletedSA:     make(map[string]*deletedSA),
 		deletedRole:   make(map[string]*deletedRole),
 	}
@@ -183,8 +188,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // routeServiceAccounts dispatches the /serviceAccounts/* surface.
 func (h *Handler) routeServiceAccounts(w http.ResponseWriter, r *http.Request, rt *route) {
 	// One-off ":method" calls (getIamPolicy, signBlob, …) are POSTs on a
-	// specific service account.
-	if rt.verb != "" && rt.name != "" {
+	// specific service account. A verb on a keys sub-resource (…/keys/{id}:disable)
+	// parses into the same rt.verb + rt.name shape but must be routed to the
+	// key-level dispatch below instead, so this only fires when there's no
+	// sub-resource in play.
+	if rt.verb != "" && rt.name != "" && rt.subKind == "" {
 		h.routeSAVerb(w, r, rt)
 		return
 	}
@@ -192,28 +200,10 @@ func (h *Handler) routeServiceAccounts(w http.ResponseWriter, r *http.Request, r
 	switch {
 	// Collection: POST create, GET list.
 	case rt.name == "":
-		switch r.Method {
-		case http.MethodPost:
-			h.createServiceAccount(w, r, rt.project)
-		case http.MethodGet:
-			h.listServiceAccounts(w, r, rt.project)
-		default:
-			writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed",
-				"unsupported verb on serviceAccounts collection: "+r.Method)
-		}
+		h.routeServiceAccountsCollection(w, r, rt.project)
 	// Single SA: GET / DELETE / PATCH.
 	case rt.subKind == "":
-		switch r.Method {
-		case http.MethodGet:
-			h.getServiceAccount(w, r, rt.project, rt.name)
-		case http.MethodDelete:
-			h.deleteServiceAccount(w, r, rt.name)
-		case http.MethodPatch:
-			h.updateServiceAccount(w, r, rt.project, rt.name)
-		default:
-			writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed",
-				"unsupported verb on serviceAccount: "+r.Method)
-		}
+		h.routeSingleServiceAccount(w, r, rt)
 	// SA keys sub-resource.
 	case rt.subKind == keysSeg:
 		h.routeServiceAccountKeys(w, r, rt)
@@ -223,7 +213,42 @@ func (h *Handler) routeServiceAccounts(w http.ResponseWriter, r *http.Request, r
 	}
 }
 
+// routeServiceAccountsCollection dispatches the /serviceAccounts collection
+// endpoint: POST create, GET list.
+func (h *Handler) routeServiceAccountsCollection(w http.ResponseWriter, r *http.Request, project string) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createServiceAccount(w, r, project)
+	case http.MethodGet:
+		h.listServiceAccounts(w, r, project)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed",
+			"unsupported verb on serviceAccounts collection: "+r.Method)
+	}
+}
+
+// routeSingleServiceAccount dispatches GET / DELETE / PATCH on one SA.
+func (h *Handler) routeSingleServiceAccount(w http.ResponseWriter, r *http.Request, rt *route) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getServiceAccount(w, r, rt.project, rt.name)
+	case http.MethodDelete:
+		h.deleteServiceAccount(w, r, rt.name)
+	case http.MethodPatch:
+		h.updateServiceAccount(w, r, rt.project, rt.name)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed",
+			"unsupported verb on serviceAccount: "+r.Method)
+	}
+}
+
 func (h *Handler) routeServiceAccountKeys(w http.ResponseWriter, r *http.Request, rt *route) {
+	// One-off ":method" calls (disable, enable) are POSTs on a specific key.
+	if rt.verb != "" && rt.subName != "" {
+		h.routeKeyVerb(w, r, rt)
+		return
+	}
+
 	switch rt.subName {
 	case "":
 		switch r.Method {

--- a/server/gcp/iam/operations.go
+++ b/server/gcp/iam/operations.go
@@ -414,8 +414,9 @@ func (h *Handler) createKey(w http.ResponseWriter, r *http.Request, project, ema
 	}
 
 	// privateKeyData is the base64 credentials file, returned once at create.
+	// A freshly created key is never disabled.
 	keyFile := buildKeyFileData(project, email, k.AccessKeyID, k.SecretAccessKey)
-	writeJSON(w, toKeyJSON(project, email, k.AccessKeyID, keyFile, k.CreatedAt))
+	writeJSON(w, toKeyJSON(project, email, k.AccessKeyID, keyFile, k.CreatedAt, false))
 }
 
 func (h *Handler) getKey(w http.ResponseWriter, r *http.Request, project, email, keyID string) {
@@ -429,7 +430,7 @@ func (h *Handler) getKey(w http.ResponseWriter, r *http.Request, project, email,
 		if keys[i].AccessKeyID == keyID {
 			// Empty private-key body on GET — GCP only returns the private
 			// material once at create time.
-			writeJSON(w, toKeyJSON(project, email, keyID, "", keys[i].CreatedAt))
+			writeJSON(w, toKeyJSON(project, email, keyID, "", keys[i].CreatedAt, h.isKeyDisabled(keyID)))
 			return
 		}
 	}
@@ -448,7 +449,7 @@ func (h *Handler) listKeys(w http.ResponseWriter, r *http.Request, project, emai
 	out := listKeysResponse{Keys: make([]serviceAccountKey, 0, len(keys))}
 	for i := range keys {
 		out.Keys = append(out.Keys,
-			toKeyJSON(project, email, keys[i].AccessKeyID, "", keys[i].CreatedAt))
+			toKeyJSON(project, email, keys[i].AccessKeyID, "", keys[i].CreatedAt, h.isKeyDisabled(keys[i].AccessKeyID)))
 	}
 
 	writeJSON(w, out)
@@ -460,7 +461,20 @@ func (h *Handler) deleteKey(w http.ResponseWriter, r *http.Request, email, keyID
 		return
 	}
 
+	h.mu.Lock()
+	delete(h.keyDisabled, keyID)
+	h.mu.Unlock()
+
 	writeJSON(w, struct{}{})
+}
+
+// isKeyDisabled reports whether keyID currently carries the disabled bit set
+// via keys.disable (and not since cleared by keys.enable).
+func (h *Handler) isKeyDisabled(keyID string) bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	return h.keyDisabled[keyID]
 }
 
 // --- helpers ---
@@ -550,8 +564,9 @@ func toRoleJSON(project, roleID string, props *roleProps) role {
 // toKeyJSON builds the wire envelope for a service-account key. private is
 // only populated on create (GCP returns the private key material exactly
 // once); GET / LIST pass an empty string. createdAt (RFC3339) drives the
-// validity window; a zero value means "now".
-func toKeyJSON(project, email, keyID, private, createdAt string) serviceAccountKey {
+// validity window; a zero value means "now". disabled reflects the handler's
+// local keys.disable/enable tracking, since the driver has no such field.
+func toKeyJSON(project, email, keyID, private, createdAt string, disabled bool) serviceAccountKey {
 	validAfter := createdAt
 	if validAfter == "" {
 		validAfter = time.Now().UTC().Format(time.RFC3339)
@@ -562,7 +577,7 @@ func toKeyJSON(project, email, keyID, private, createdAt string) serviceAccountK
 		validBefore = t.AddDate(keyValidityYears, 0, 0).UTC().Format(time.RFC3339)
 	}
 
-	return serviceAccountKey{
+	out := serviceAccountKey{
 		Name: "projects/" + project + "/serviceAccounts/" + email +
 			"/keys/" + keyID,
 		PrivateKeyType:  "TYPE_GOOGLE_CREDENTIALS_FILE",
@@ -572,7 +587,14 @@ func toKeyJSON(project, email, keyID, private, createdAt string) serviceAccountK
 		ValidBeforeTime: validBefore,
 		KeyOrigin:       "GOOGLE_PROVIDED",
 		KeyType:         "USER_MANAGED",
+		Disabled:        disabled,
 	}
+
+	if disabled {
+		out.DisableReason = keyDisableReasonUserInitiated
+	}
+
+	return out
 }
 
 // buildKeyFileData returns the base64-encoded service-account credentials file

--- a/server/gcp/iam/sdk_iam_compat_test.go
+++ b/server/gcp/iam/sdk_iam_compat_test.go
@@ -249,6 +249,85 @@ func TestSDKGCPIAMListReflectsDisabled(t *testing.T) {
 	}
 }
 
+// TestSDKGCPIAMKeyDisableEnable guards SA-key lifecycle depth: Keys.Disable
+// sets disabled=true (with a disableReason) on Get and List, and Keys.Enable
+// clears it again — mirroring projects.serviceAccounts.keys.disable/enable.
+func TestSDKGCPIAMKeyDisableEnable(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	email := createSA(t, svc, "key-toggle-sa")
+	saResource := "projects/-/serviceAccounts/" + email
+
+	created, err := svc.Projects.ServiceAccounts.Keys.Create(saResource,
+		&iamv1.CreateServiceAccountKeyRequest{}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Keys.Create: %v", err)
+	}
+
+	if created.Disabled {
+		t.Fatal("freshly created key reports disabled=true")
+	}
+
+	if _, err := svc.Projects.ServiceAccounts.Keys.Disable(created.Name,
+		&iamv1.DisableServiceAccountKeyRequest{}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Keys.Disable: %v", err)
+	}
+
+	got, err := svc.Projects.ServiceAccounts.Keys.Get(created.Name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Keys.Get after Disable: %v", err)
+	}
+
+	if !got.Disabled {
+		t.Fatal("Get did not reflect disabled=true after Keys.Disable")
+	}
+
+	if got.DisableReason == "" {
+		t.Fatal("disabled key has no disableReason")
+	}
+
+	listed, err := svc.Projects.ServiceAccounts.Keys.List(saResource).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Keys.List after Disable: %v", err)
+	}
+
+	var listedKey *iamv1.ServiceAccountKey
+
+	for _, k := range listed.Keys {
+		if k.Name == created.Name {
+			listedKey = k
+			break
+		}
+	}
+
+	if listedKey == nil {
+		t.Fatalf("key %s missing from List", created.Name)
+	}
+
+	if !listedKey.Disabled {
+		t.Fatal("List did not reflect disabled=true after Keys.Disable")
+	}
+
+	if _, err := svc.Projects.ServiceAccounts.Keys.Enable(created.Name,
+		&iamv1.EnableServiceAccountKeyRequest{}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Keys.Enable: %v", err)
+	}
+
+	got, err = svc.Projects.ServiceAccounts.Keys.Get(created.Name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Keys.Get after Enable: %v", err)
+	}
+
+	if got.Disabled {
+		t.Fatal("Get still reports disabled=true after Keys.Enable")
+	}
+
+	if got.DisableReason != "" {
+		t.Fatalf("re-enabled key still has disableReason %q", got.DisableReason)
+	}
+}
+
 // TestSDKGCPIAMKeyFileAndValidity guards the MEDIUM finding: Keys.Create returns
 // a base64 credentials file (parseable service_account JSON) and populated
 // validAfterTime/validBeforeTime.

--- a/server/gcp/iam/types.go
+++ b/server/gcp/iam/types.go
@@ -96,6 +96,8 @@ type serviceAccountKey struct {
 	ValidBeforeTime string `json:"validBeforeTime,omitempty"`
 	KeyOrigin       string `json:"keyOrigin,omitempty"`
 	KeyType         string `json:"keyType,omitempty"`
+	Disabled        bool   `json:"disabled,omitempty"`
+	DisableReason   string `json:"disableReason,omitempty"`
 }
 
 // listKeysResponse is the wire shape for the SA key list response.

--- a/server/gcp/iam/verbs.go
+++ b/server/gcp/iam/verbs.go
@@ -12,6 +12,16 @@ import (
 	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
 )
 
+const (
+	disableVerb = "disable"
+	enableVerb  = "enable"
+
+	// keyDisableReasonUserInitiated mirrors the real GCP enum value stamped on
+	// a key disabled via the disable() method (as opposed to automatic
+	// rotation-driven disablement, which cloudemu does not model).
+	keyDisableReasonUserInitiated = "SERVICE_ACCOUNT_KEY_DISABLE_REASON_USER_INITIATED"
+)
+
 // iamPolicy is the GCP IAM Policy resource returned by getIamPolicy /
 // setIamPolicy. Bindings are stored verbatim so a set/get round-trips.
 type iamPolicy struct {
@@ -68,9 +78,9 @@ func (h *Handler) dispatchSAVerb(w http.ResponseWriter, r *http.Request, rt *rou
 		h.signJwt(w, r, rt.name)
 	case "generateAccessToken":
 		h.generateAccessToken(w, r)
-	case "enable":
+	case enableVerb:
 		h.setDisabled(w, rt.name, false)
-	case "disable":
+	case disableVerb:
 		h.setDisabled(w, rt.name, true)
 	default:
 		writeError(w, http.StatusNotFound, "notFound", "unknown method: "+rt.verb)
@@ -329,6 +339,62 @@ func (*Handler) generateAccessToken(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) setDisabled(w http.ResponseWriter, email string, disabled bool) {
 	h.mu.Lock()
 	h.disabled[email] = disabled
+	h.mu.Unlock()
+
+	writeJSON(w, map[string]any{})
+}
+
+// routeKeyVerb dispatches the one-off ":method" service-account-key calls
+// (disable, enable). Both are POSTs on a specific key, mirroring
+// projects.serviceAccounts.keys.disable/enable in the real API.
+func (h *Handler) routeKeyVerb(w http.ResponseWriter, r *http.Request, rt *route) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed",
+			"method "+rt.verb+" requires POST")
+
+		return
+	}
+
+	switch rt.verb {
+	case disableVerb:
+		h.setKeyDisabled(w, r, rt.name, rt.subName, true)
+	case enableVerb:
+		h.setKeyDisabled(w, r, rt.name, rt.subName, false)
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown method: "+rt.verb)
+	}
+}
+
+// setKeyDisabled toggles the disabled bit on an existing SA key, matching
+// real GCP's projects.serviceAccounts.keys.disable/enable, which return an
+// empty body on success. The driver has no update path for access keys, so
+// the bit is tracked here (like the SA-level disabled bit) rather than
+// mutated in the driver store.
+func (h *Handler) setKeyDisabled(w http.ResponseWriter, r *http.Request, email, keyID string, disabled bool) {
+	keys, err := h.iam.ListAccessKeys(r.Context(), email)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	found := false
+
+	for i := range keys {
+		if keys[i].AccessKeyID == keyID {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		writeError(w, http.StatusNotFound, "NOT_FOUND",
+			"service account key "+keyID+" not found")
+
+		return
+	}
+
+	h.mu.Lock()
+	h.keyDisabled[keyID] = disabled
 	h.mu.Unlock()
 
 	writeJSON(w, map[string]any{})


### PR DESCRIPTION
## Summary

GCP IAM depth pass on service-account key lifecycle.

Investigation found most of the requested world-case IAM surface already implemented on `main`/`development`:
- SA enable/disable (`serviceAccounts:enable`/`:disable`, `disabled` field) — already present.
- SA soft-delete + undelete (with tombstone) — already present.
- Custom-role soft-delete + undelete + `stage` field (via patch) — already present.

The verified gap: real GCP recently added a `disabled` bit to service-account **keys** (`projects.serviceAccounts.keys.disable`/`.enable`, `ServiceAccountKey.Disabled`/`DisableReason`), and cloudemu had no equivalent. This PR adds it:

- `disabled` (+ `disableReason`) surfaced on key Create/Get/List, matching the real `google.golang.org/api/iam/v1` wire shape.
- `POST .../keys/{keyId}:disable` and `:enable`, tracked in the handler (mirroring the existing SA-level disabled-bit pattern, since the portable IAM driver has no update path for access keys).
- Fixes a routing bug this surfaced: a verb on a keys sub-resource (`.../keys/{id}:disable`) was being swallowed by the SA-level verb dispatch, since both parse into the same `rt.verb`/`rt.name` shape — split the routing so key-scoped verbs go to a dedicated dispatcher.

## Test plan

- [x] `go build ./...`
- [x] `go test ./server/gcp/iam/... ./providers/gcp/iam/... ./persist/... -race -count=1`
- [x] `go test ./providers/gcp/... ./server/gcp/...`
- [x] `gofmt -l` on touched files (clean)
- [x] `golangci-lint run ./server/gcp/iam/...` (0 issues)
- [x] `go generate ./...` — no diff in `docs/coverage` (no driver interface changed)
- [x] `go mod tidy` — no diff
- [x] New real-user e2e tests via `google.golang.org/api/iam/v1`: create key, disable it, Get/List show `disabled:true` plus `disableReason`, then enable it and Get shows `disabled:false`; disable on a nonexistent key returns 404.
