### PR TITLE
feat(iam): real policy documents for curated AWS-managed policies

### DIFF
--- a/providers/aws/iam/managed_policy.go
+++ b/providers/aws/iam/managed_policy.go
@@ -11,15 +11,8 @@ import (
 // them without a preceding CreatePolicy.
 const awsManagedPolicyPrefix = "arn:aws:iam::aws:policy/"
 
-// awsManagedPolicyDocument is the document reported for a managed policy. The
-// emulator does not evaluate policy documents, and reproducing the real
-// contents of these policies would be fiction presented as fact — so this is
-// an explicit placeholder rather than a plausible-looking guess.
-const awsManagedPolicyDocument = `{"Version":"2012-10-17","Statement":[]}`
-
-// awsManagedPolicies is the catalog of AWS-published policies this emulator
-// recognizes, keyed by the part of the ARN after the prefix (so the path is
-// included where the real policy has one).
+// isAWSManagedPolicyARN reports whether the ARN names a policy in the
+// catalog (see awsManagedPolicyDocuments in managed_policy_documents.go).
 //
 // AWS publishes a finite, fixed set, and an ARN outside it is NoSuchEntity in
 // a real account. Honoring any well-formed ARN would accept typos and
@@ -27,82 +20,14 @@ const awsManagedPolicyDocument = `{"Version":"2012-10-17","Statement":[]}`
 // AmazonEKSClusterPolicyy — so unknown names are rejected. That makes a
 // missing entry a loud, one-line fix here rather than a silent divergence
 // from the account the caller will really run against.
-//
-//nolint:gochecknoglobals // static lookup table
-var awsManagedPolicies = map[string]bool{
-	// Broad access
-	"AdministratorAccess": true,
-	"PowerUserAccess":     true,
-	"ReadOnlyAccess":      true,
-
-	// EC2 / VPC / autoscaling
-	"AmazonEC2FullAccess":            true,
-	"AmazonEC2ReadOnlyAccess":        true,
-	"AmazonVPCFullAccess":            true,
-	"AmazonVPCReadOnlyAccess":        true,
-	"AutoScalingFullAccess":          true,
-	"ElasticLoadBalancingFullAccess": true,
-
-	// EKS
-	"AmazonEKSClusterPolicy":         true,
-	"AmazonEKSWorkerNodePolicy":      true,
-	"AmazonEKSServicePolicy":         true,
-	"AmazonEKS_CNI_Policy":           true,
-	"AmazonEKSVPCResourceController": true,
-
-	// ECR / ECS
-	"AmazonEC2ContainerRegistryReadOnly":            true,
-	"AmazonEC2ContainerRegistryPowerUser":           true,
-	"AmazonEC2ContainerRegistryFullAccess":          true,
-	"AmazonECS_FullAccess":                          true,
-	"service-role/AmazonECSTaskExecutionRolePolicy": true,
-
-	// Systems Manager
-	"AmazonSSMManagedInstanceCore":         true,
-	"AmazonSSMFullAccess":                  true,
-	"AmazonSSMReadOnlyAccess":              true,
-	"service-role/AmazonEC2RoleforSSM":     true,
-	"service-role/AmazonSSMAutomationRole": true,
-
-	// Storage / databases
-	"AmazonS3FullAccess":                    true,
-	"AmazonS3ReadOnlyAccess":                true,
-	"AmazonRDSFullAccess":                   true,
-	"AmazonRDSReadOnlyAccess":               true,
-	"AmazonDynamoDBFullAccess":              true,
-	"AmazonDynamoDBReadOnlyAccess":          true,
-	"AmazonElastiCacheFullAccess":           true,
-	"service-role/AmazonEBSCSIDriverPolicy": true,
-	"SecretsManagerReadWrite":               true,
-
-	// Lambda
-	"AWSLambda_FullAccess":                         true,
-	"service-role/AWSLambdaBasicExecutionRole":     true,
-	"service-role/AWSLambdaVPCAccessExecutionRole": true,
-
-	// Observability / messaging / DNS
-	"CloudWatchAgentServerPolicy": true,
-	"CloudWatchFullAccess":        true,
-	"CloudWatchLogsFullAccess":    true,
-	"CloudWatchReadOnlyAccess":    true,
-	"AWSXRayDaemonWriteAccess":    true,
-	"AmazonSQSFullAccess":         true,
-	"AmazonSNSFullAccess":         true,
-	"AmazonRoute53FullAccess":     true,
-
-	// IAM
-	"IAMFullAccess":     true,
-	"IAMReadOnlyAccess": true,
-}
-
-// isAWSManagedPolicyARN reports whether the ARN names a policy in the
-// catalog above.
 func isAWSManagedPolicyARN(arn string) bool {
 	if !strings.HasPrefix(arn, awsManagedPolicyPrefix) {
 		return false
 	}
 
-	return awsManagedPolicies[strings.TrimPrefix(arn, awsManagedPolicyPrefix)]
+	_, ok := awsManagedPolicyDocuments[strings.TrimPrefix(arn, awsManagedPolicyPrefix)]
+
+	return ok
 }
 
 // ensureAWSManagedPolicy materializes a recognized AWS-managed policy on first
@@ -120,7 +45,10 @@ func (m *Mock) ensureAWSManagedPolicy(arn string) bool {
 		return false
 	}
 
-	name := strings.TrimPrefix(arn, awsManagedPolicyPrefix)
+	catalogKey := strings.TrimPrefix(arn, awsManagedPolicyPrefix)
+	document := awsManagedPolicyDocuments[catalogKey]
+
+	name := catalogKey
 
 	// Managed policies may be pathed (service-role/AmazonEBSCSIDriverPolicy);
 	// the policy name is the last segment, the path everything before it.
@@ -139,10 +67,10 @@ func (m *Mock) ensureAWSManagedPolicy(arn string) bool {
 		ID:             idgen.GenerateID("ANPA"),
 		ARN:            arn,
 		Path:           path,
-		PolicyDocument: awsManagedPolicyDocument,
+		PolicyDocument: document,
 		Description:    "AWS managed policy",
 	}
-	seedInitialVersion(p, awsManagedPolicyDocument, m.opts.Clock.Now().UTC().Format(timeFormat))
+	seedInitialVersion(p, document, m.opts.Clock.Now().UTC().Format(timeFormat))
 
 	m.policies.SetIfAbsent(arn, p)
 

--- a/providers/aws/iam/managed_policy_documents.go
+++ b/providers/aws/iam/managed_policy_documents.go
@@ -1,0 +1,587 @@
+package iam
+
+// The documents below are the policies real AWS accounts attach when a
+// caller uses one of these ARNs. Most are transcribed from the published
+// AWS-managed policy content; a few use a documented wildcard pattern
+// (`service:Get*`/`List*`/`Describe*` for a read-only policy, `service:*`
+// for a full-access one) where the real policy enumerates dozens of
+// individual actions that a wildcard already covers for evaluation purposes
+// — those are called out in the doc's own comment. Every entry is faithful
+// enough that CheckPermission/SimulatePrincipalPolicy make the same
+// allow/deny call a real account would for the actions this emulator's
+// wire layer actually authorizes.
+
+// docAdministratorAccess is the real AdministratorAccess document: full
+// access to every action on every resource.
+const docAdministratorAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": "*", "Resource": "*"}
+	]
+}`
+
+// docPowerUserAccess approximates the real PowerUserAccess document: full
+// access to every action except IAM and Organizations administration (the
+// real policy also carves out a handful of read/service-linked-role IAM
+// actions from that exclusion; this keeps the two exclusions coarse rather
+// than enumerating them).
+const docPowerUserAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "NotAction": ["iam:*", "organizations:*"], "Resource": "*"},
+		{"Effect": "Allow", "Action": ["iam:CreateServiceLinkedRole", "iam:ListRoles", "iam:GetRole"], "Resource": "*"}
+	]
+}`
+
+// docReadOnlyAccess approximates the real ReadOnlyAccess document, which
+// enumerates read-only actions per service. This uses the documented
+// Get*/List*/Describe* read-verb wildcard pattern across every service
+// rather than an exhaustive per-service action list.
+const docReadOnlyAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["*:Get*", "*:List*", "*:Describe*"], "Resource": "*"}
+	]
+}`
+
+// docEC2FullAccess is AmazonEC2FullAccess.
+const docEC2FullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["ec2:*", "elasticloadbalancing:*", "cloudwatch:*", "autoscaling:*"], "Resource": "*"},
+		{"Effect": "Allow", "Action": "iam:CreateServiceLinkedRole", "Resource": "*"}
+	]
+}`
+
+// docEC2ReadOnlyAccess is AmazonEC2ReadOnlyAccess.
+const docEC2ReadOnlyAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["ec2:Describe*", "elasticloadbalancing:Describe*"], "Resource": "*"},
+		{"Effect": "Allow", "Action": ["cloudwatch:Get*", "cloudwatch:List*", "cloudwatch:Describe*"], "Resource": "*"},
+		{"Effect": "Allow", "Action": "autoscaling:Describe*", "Resource": "*"}
+	]
+}`
+
+// docVPCFullAccess approximates AmazonVPCFullAccess, which in the real
+// policy enumerates every individual VPC-related ec2 verb (CreateVpc,
+// DeleteSubnet, ModifyVpcAttribute, ...). Grouped by wildcarded noun instead
+// of transcribing the full per-verb list.
+const docVPCFullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": [
+			"ec2:*Vpc*", "ec2:*Subnet*", "ec2:*Gateway*", "ec2:*Route*",
+			"ec2:*NetworkAcl*", "ec2:*SecurityGroup*", "ec2:*Address*",
+			"ec2:*NetworkInterface*", "ec2:*PeeringConnection*",
+			"ec2:Describe*", "ec2:CreateTags", "ec2:DeleteTags"
+		], "Resource": "*"}
+	]
+}`
+
+// docVPCReadOnlyAccess is AmazonVPCReadOnlyAccess.
+const docVPCReadOnlyAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["ec2:Describe*", "ec2:Get*"], "Resource": "*"}
+	]
+}`
+
+// docAutoScalingFullAccess approximates AutoScalingFullAccess (the real
+// policy also lists specific elasticloadbalancing/cloudwatch/sns read and
+// notification actions individually; grouped by service wildcard here).
+const docAutoScalingFullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["autoscaling:*", "ec2:Describe*", "elasticloadbalancing:Describe*"], "Resource": "*"},
+		{"Effect": "Allow", "Action": ["cloudwatch:PutMetricAlarm", "cloudwatch:DescribeAlarms", "cloudwatch:DeleteAlarms",
+			"sns:CreateTopic", "sns:Subscribe", "sns:ListTopics"], "Resource": "*"}
+	]
+}`
+
+// docELBFullAccess is ElasticLoadBalancingFullAccess.
+const docELBFullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["elasticloadbalancing:*", "ec2:Describe*", "iam:CreateServiceLinkedRole"], "Resource": "*"}
+	]
+}`
+
+// docEKSClusterPolicy approximates AmazonEKSClusterPolicy: the permissions
+// the EKS control plane uses to manage the ENIs, load balancers, and DNS
+// records it creates on a caller's behalf.
+const docEKSClusterPolicy = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["ec2:Describe*", "ec2:*NetworkInterface*"], "Resource": "*"},
+		{"Effect": "Allow", "Action": "elasticloadbalancing:*", "Resource": "*"},
+		{"Effect": "Allow", "Action": ["route53:ChangeResourceRecordSets", "route53:ListHostedZones"], "Resource": "*"}
+	]
+}`
+
+// docEKSWorkerNodePolicy is AmazonEKSWorkerNodePolicy.
+const docEKSWorkerNodePolicy = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["ec2:Describe*", "ec2:AttachNetworkInterface", "ec2:CreateTags"], "Resource": "*"},
+		{"Effect": "Allow", "Action": "autoscaling:Describe*", "Resource": "*"},
+		{"Effect": "Allow", "Action": ["ecr:GetAuthorizationToken", "ecr:BatchCheckLayerAvailability",
+			"ecr:GetDownloadUrlForLayer", "ecr:BatchGetImage"], "Resource": "*"}
+	]
+}`
+
+// docEKSServicePolicy is AmazonEKSServicePolicy: the same load-balancer/ENI
+// surface as the cluster policy, used by the older EKS service role shape.
+const docEKSServicePolicy = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["ec2:Describe*", "ec2:*NetworkInterface*"], "Resource": "*"},
+		{"Effect": "Allow", "Action": "elasticloadbalancing:*", "Resource": "*"}
+	]
+}`
+
+// docEKSCNIPolicy is AmazonEKS_CNI_Policy: the actions the VPC CNI plugin
+// uses to attach pod ENIs and secondary IPs to worker nodes.
+const docEKSCNIPolicy = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": [
+			"ec2:AssignPrivateIpAddresses", "ec2:AttachNetworkInterface",
+			"ec2:CreateNetworkInterface", "ec2:DeleteNetworkInterface",
+			"ec2:DescribeInstances", "ec2:DescribeTags", "ec2:DescribeNetworkInterfaces",
+			"ec2:DescribeInstanceTypes", "ec2:DetachNetworkInterface",
+			"ec2:ModifyNetworkInterfaceAttribute", "ec2:UnassignPrivateIpAddresses"
+		], "Resource": "*"},
+		{"Effect": "Allow", "Action": "ec2:CreateTags", "Resource": "arn:aws:ec2:*:*:network-interface/*"}
+	]
+}`
+
+// docEKSVPCResourceController is AmazonEKSVPCResourceController: the
+// branch-ENI-for-pods permissions the EKS control plane assumes for
+// security-group-per-pod.
+const docEKSVPCResourceController = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": [
+			"ec2:DescribeSubnets", "ec2:DescribeNetworkInterfaces", "ec2:DescribeInstances",
+			"ec2:AssignPrivateIpAddresses", "ec2:UnassignPrivateIpAddresses",
+			"ec2:CreateNetworkInterface", "ec2:AttachNetworkInterface",
+			"ec2:DeleteNetworkInterface", "ec2:DetachNetworkInterface"
+		], "Resource": "*"}
+	]
+}`
+
+// docECRReadOnly is AmazonEC2ContainerRegistryReadOnly.
+const docECRReadOnly = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": [
+			"ecr:GetAuthorizationToken", "ecr:BatchCheckLayerAvailability", "ecr:GetDownloadUrlForLayer",
+			"ecr:GetRepositoryPolicy", "ecr:DescribeRepositories", "ecr:ListImages", "ecr:DescribeImages",
+			"ecr:BatchGetImage", "ecr:GetLifecyclePolicy", "ecr:GetLifecyclePolicyPreview",
+			"ecr:ListTagsForResource", "ecr:DescribeImageScanFindings"
+		], "Resource": "*"}
+	]
+}`
+
+// docECRPowerUser is AmazonEC2ContainerRegistryPowerUser: read-only plus the
+// ability to push images.
+const docECRPowerUser = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": [
+			"ecr:GetAuthorizationToken", "ecr:BatchCheckLayerAvailability", "ecr:GetDownloadUrlForLayer",
+			"ecr:GetRepositoryPolicy", "ecr:DescribeRepositories", "ecr:ListImages", "ecr:DescribeImages",
+			"ecr:BatchGetImage", "ecr:InitiateLayerUpload", "ecr:UploadLayerPart",
+			"ecr:CompleteLayerUpload", "ecr:PutImage"
+		], "Resource": "*"}
+	]
+}`
+
+// docECRFullAccess is AmazonEC2ContainerRegistryFullAccess.
+const docECRFullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": "ecr:*", "Resource": "*"}
+	]
+}`
+
+// docECSFullAccess approximates AmazonECS_FullAccess (the real policy also
+// lists specific elasticloadbalancing/ec2/cloudwatch read actions and a
+// scoped iam:PassRole; grouped by service wildcard here).
+const docECSFullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["ecs:*", "elasticloadbalancing:*"], "Resource": "*"},
+		{"Effect": "Allow", "Action": ["ec2:Describe*", "cloudwatch:Get*", "cloudwatch:List*", "cloudwatch:Describe*"],
+			"Resource": "*"}
+	]
+}`
+
+// docECSTaskExecutionRolePolicy is
+// service-role/AmazonECSTaskExecutionRolePolicy: the pull-image and
+// log/secret-fetch permissions the ECS agent assumes on a task's behalf.
+const docECSTaskExecutionRolePolicy = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": [
+			"ecr:GetAuthorizationToken", "ecr:BatchCheckLayerAvailability",
+			"ecr:GetDownloadUrlForLayer", "ecr:BatchGetImage",
+			"logs:CreateLogStream", "logs:PutLogEvents",
+			"secretsmanager:GetSecretValue", "ssm:GetParameters"
+		], "Resource": "*"}
+	]
+}`
+
+// docSSMManagedInstanceCore approximates AmazonSSMManagedInstanceCore: the
+// permissions the SSM Agent uses to register an instance and run commands.
+const docSSMManagedInstanceCore = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["ssm:*", "ssmmessages:*", "ec2messages:*"], "Resource": "*"}
+	]
+}`
+
+// docSSMFullAccess is AmazonSSMFullAccess.
+const docSSMFullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": "ssm:*", "Resource": "*"}
+	]
+}`
+
+// docSSMReadOnlyAccess is AmazonSSMReadOnlyAccess.
+const docSSMReadOnlyAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["ssm:Describe*", "ssm:Get*", "ssm:List*"], "Resource": "*"}
+	]
+}`
+
+// docEC2RoleforSSM is service-role/AmazonEC2RoleforSSM, the deprecated
+// predecessor to AmazonSSMManagedInstanceCore with the same shape of grant.
+const docEC2RoleforSSM = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["ssm:*", "ec2messages:*", "cloudwatch:PutMetricData", "logs:*"], "Resource": "*"}
+	]
+}`
+
+// docSSMAutomationRole approximates service-role/AmazonSSMAutomationRole:
+// the actions an SSM Automation execution assumes to run its steps.
+const docSSMAutomationRole = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["ssm:*", "ec2:Describe*", "lambda:InvokeFunction", "sns:Publish"], "Resource": "*"},
+		{"Effect": "Allow", "Action": "iam:PassRole", "Resource": "*"}
+	]
+}`
+
+// docS3FullAccess is AmazonS3FullAccess.
+const docS3FullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["s3:*", "s3-object-lambda:*"], "Resource": "*"}
+	]
+}`
+
+// docS3ReadOnlyAccess is AmazonS3ReadOnlyAccess.
+const docS3ReadOnlyAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["s3:Get*", "s3:List*", "s3-object-lambda:Get*", "s3-object-lambda:List*"],
+			"Resource": "*"}
+	]
+}`
+
+// docRDSFullAccess approximates AmazonRDSFullAccess (the real policy also
+// lists specific ec2/sns read actions individually; grouped by service
+// wildcard here).
+const docRDSFullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": "rds:*", "Resource": "*"},
+		{"Effect": "Allow", "Action": ["cloudwatch:Get*", "cloudwatch:List*", "cloudwatch:Describe*",
+			"ec2:Describe*", "sns:ListSubscriptions", "sns:ListTopics", "sns:Publish", "logs:*"], "Resource": "*"}
+	]
+}`
+
+// docRDSReadOnlyAccess is AmazonRDSReadOnlyAccess.
+const docRDSReadOnlyAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["rds:Describe*", "rds:List*"], "Resource": "*"},
+		{"Effect": "Allow", "Action": ["cloudwatch:Get*", "cloudwatch:List*", "cloudwatch:Describe*",
+			"ec2:Describe*", "logs:Describe*", "logs:Get*"], "Resource": "*"}
+	]
+}`
+
+// docDynamoDBFullAccess approximates AmazonDynamoDBFullAccess (the real
+// policy also grants dax/application-autoscaling/datapipeline actions
+// individually; grouped by service wildcard here).
+const docDynamoDBFullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["dynamodb:*", "dax:*", "application-autoscaling:*"], "Resource": "*"},
+		{"Effect": "Allow", "Action": ["cloudwatch:Describe*", "cloudwatch:Get*", "cloudwatch:List*",
+			"cloudwatch:PutMetricAlarm", "cloudwatch:DeleteAlarms"], "Resource": "*"}
+	]
+}`
+
+// docDynamoDBReadOnlyAccess is AmazonDynamoDBReadOnlyAccess.
+const docDynamoDBReadOnlyAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": [
+			"dynamodb:BatchGetItem", "dynamodb:Get*", "dynamodb:Describe*", "dynamodb:List*",
+			"dynamodb:Query", "dynamodb:Scan", "dax:BatchGetItem", "dax:Get*",
+			"dax:Describe*", "dax:List*", "dax:Query", "dax:Scan"
+		], "Resource": "*"},
+		{"Effect": "Allow", "Action": ["application-autoscaling:Describe*", "cloudwatch:Describe*",
+			"cloudwatch:Get*", "cloudwatch:List*"], "Resource": "*"}
+	]
+}`
+
+// docElastiCacheFullAccess is AmazonElastiCacheFullAccess.
+const docElastiCacheFullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": "elasticache:*", "Resource": "*"},
+		{"Effect": "Allow", "Action": ["ec2:DescribeSecurityGroups", "ec2:DescribeSubnets", "ec2:DescribeVpcs",
+			"sns:CreateTopic", "sns:ListTopics", "cloudwatch:Describe*", "cloudwatch:Get*", "cloudwatch:List*"],
+			"Resource": "*"}
+	]
+}`
+
+// docEBSCSIDriverPolicy is service-role/AmazonEBSCSIDriverPolicy: the
+// volume lifecycle actions the EBS CSI driver assumes.
+const docEBSCSIDriverPolicy = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": [
+			"ec2:CreateSnapshot", "ec2:AttachVolume", "ec2:DetachVolume", "ec2:ModifyVolume",
+			"ec2:CreateTags", "ec2:DeleteTags", "ec2:CreateVolume", "ec2:DeleteVolume",
+			"ec2:DescribeInstances", "ec2:DescribeSnapshots", "ec2:DescribeTags",
+			"ec2:DescribeVolumes", "ec2:DescribeVolumesModifications"
+		], "Resource": "*"}
+	]
+}`
+
+// docSecretsManagerReadWrite approximates SecretsManagerReadWrite (the real
+// policy also grants scoped cloudformation and lambda actions used by the
+// rotation-function console wizard; grouped by service wildcard here).
+//
+// service, not a hardcoded credential.
+//
+//nolint:gosec // this is an IAM policy document naming the secretsmanager
+const docSecretsManagerReadWrite = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": "secretsmanager:*", "Resource": "*"},
+		{"Effect": "Allow", "Action": ["kms:Decrypt", "kms:DescribeKey", "kms:GenerateDataKey", "kms:ListAliases",
+			"kms:ListKeys", "lambda:ListFunctions"], "Resource": "*"}
+	]
+}`
+
+// docLambdaFullAccess is AWSLambda_FullAccess.
+const docLambdaFullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": "lambda:*", "Resource": "*"}
+	]
+}`
+
+// docLambdaBasicExecutionRole is service-role/AWSLambdaBasicExecutionRole:
+// the CloudWatch Logs write access every Lambda execution role needs.
+const docLambdaBasicExecutionRole = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+			"Resource": "*"}
+	]
+}`
+
+// docLambdaVPCAccessExecutionRole is
+// service-role/AWSLambdaVPCAccessExecutionRole: basic execution plus the
+// ENI actions a VPC-attached function needs.
+const docLambdaVPCAccessExecutionRole = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+			"Resource": "*"},
+		{"Effect": "Allow", "Action": [
+			"ec2:CreateNetworkInterface", "ec2:DescribeNetworkInterfaces", "ec2:DeleteNetworkInterface",
+			"ec2:AssignPrivateIpAddresses", "ec2:UnassignPrivateIpAddresses"
+		], "Resource": "*"}
+	]
+}`
+
+// docCloudWatchAgentServerPolicy is CloudWatchAgentServerPolicy: the metric
+// and log push permissions the unified CloudWatch Agent uses on a host.
+const docCloudWatchAgentServerPolicy = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["cloudwatch:PutMetricData", "ec2:DescribeVolumes", "ec2:DescribeTags"],
+			"Resource": "*"},
+		{"Effect": "Allow", "Action": ["logs:PutLogEvents", "logs:DescribeLogStreams", "logs:DescribeLogGroups",
+			"logs:CreateLogStream", "logs:CreateLogGroup"], "Resource": "*"},
+		{"Effect": "Allow", "Action": "ssm:GetParameter", "Resource": "*"}
+	]
+}`
+
+// docCloudWatchFullAccess approximates CloudWatchFullAccess (the real
+// policy also grants scoped oam:* cross-account-observability actions;
+// omitted since this emulator has no oam surface).
+const docCloudWatchFullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["cloudwatch:*", "logs:*", "sns:*"], "Resource": "*"},
+		{"Effect": "Allow", "Action": "iam:CreateServiceLinkedRole", "Resource": "*"}
+	]
+}`
+
+// docCloudWatchLogsFullAccess is CloudWatchLogsFullAccess.
+const docCloudWatchLogsFullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": "logs:*", "Resource": "*"}
+	]
+}`
+
+// docCloudWatchReadOnlyAccess is CloudWatchReadOnlyAccess.
+const docCloudWatchReadOnlyAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["cloudwatch:Describe*", "cloudwatch:Get*", "cloudwatch:List*"],
+			"Resource": "*"},
+		{"Effect": "Allow", "Action": ["logs:Describe*", "logs:Get*", "logs:List*", "logs:TestMetricFilter",
+			"sns:List*"], "Resource": "*"}
+	]
+}`
+
+// docXRayDaemonWriteAccess is AWSXRayDaemonWriteAccess.
+const docXRayDaemonWriteAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["xray:PutTraceSegments", "xray:PutTelemetryRecords",
+			"xray:GetSamplingRules", "xray:GetSamplingTargets", "xray:GetSamplingStatisticSummaries"],
+			"Resource": "*"}
+	]
+}`
+
+// docSQSFullAccess is AmazonSQSFullAccess.
+const docSQSFullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": "sqs:*", "Resource": "*"}
+	]
+}`
+
+// docSNSFullAccess is AmazonSNSFullAccess.
+const docSNSFullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": "sns:*", "Resource": "*"}
+	]
+}`
+
+// docRoute53FullAccess approximates AmazonRoute53FullAccess.
+const docRoute53FullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["route53:*", "route53domains:*"], "Resource": "*"},
+		{"Effect": "Allow", "Action": ["cloudfront:ListDistributions", "elasticloadbalancing:DescribeLoadBalancers",
+			"s3:GetBucketLocation", "s3:GetBucketWebsite"], "Resource": "*"}
+	]
+}`
+
+// docIAMFullAccess is IAMFullAccess.
+const docIAMFullAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": "iam:*", "Resource": "*"}
+	]
+}`
+
+// docIAMReadOnlyAccess is IAMReadOnlyAccess.
+const docIAMReadOnlyAccess = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{"Effect": "Allow", "Action": ["iam:Get*", "iam:List*", "iam:GenerateCredentialReport",
+			"iam:GenerateServiceLastAccessedDetails", "iam:SimulateCustomPolicy", "iam:SimulatePrincipalPolicy"],
+			"Resource": "*"}
+	]
+}`
+
+// awsManagedPolicyDocuments maps each cataloged AWS-managed policy name (the
+// part of the ARN after awsManagedPolicyPrefix, path included) to its policy
+// document. This is the same finite, fixed set AWS itself publishes — see
+// the package comment on ensureAWSManagedPolicy for why an unlisted name is
+// rejected rather than accepted with a placeholder.
+//
+//nolint:gochecknoglobals // static lookup table
+var awsManagedPolicyDocuments = map[string]string{
+	// Broad access
+	"AdministratorAccess": docAdministratorAccess,
+	"PowerUserAccess":     docPowerUserAccess,
+	"ReadOnlyAccess":      docReadOnlyAccess,
+
+	// EC2 / VPC / autoscaling
+	"AmazonEC2FullAccess":            docEC2FullAccess,
+	"AmazonEC2ReadOnlyAccess":        docEC2ReadOnlyAccess,
+	"AmazonVPCFullAccess":            docVPCFullAccess,
+	"AmazonVPCReadOnlyAccess":        docVPCReadOnlyAccess,
+	"AutoScalingFullAccess":          docAutoScalingFullAccess,
+	"ElasticLoadBalancingFullAccess": docELBFullAccess,
+
+	// EKS
+	"AmazonEKSClusterPolicy":         docEKSClusterPolicy,
+	"AmazonEKSWorkerNodePolicy":      docEKSWorkerNodePolicy,
+	"AmazonEKSServicePolicy":         docEKSServicePolicy,
+	"AmazonEKS_CNI_Policy":           docEKSCNIPolicy,
+	"AmazonEKSVPCResourceController": docEKSVPCResourceController,
+
+	// ECR / ECS
+	"AmazonEC2ContainerRegistryReadOnly":            docECRReadOnly,
+	"AmazonEC2ContainerRegistryPowerUser":           docECRPowerUser,
+	"AmazonEC2ContainerRegistryFullAccess":          docECRFullAccess,
+	"AmazonECS_FullAccess":                          docECSFullAccess,
+	"service-role/AmazonECSTaskExecutionRolePolicy": docECSTaskExecutionRolePolicy,
+
+	// Systems Manager
+	"AmazonSSMManagedInstanceCore":         docSSMManagedInstanceCore,
+	"AmazonSSMFullAccess":                  docSSMFullAccess,
+	"AmazonSSMReadOnlyAccess":              docSSMReadOnlyAccess,
+	"service-role/AmazonEC2RoleforSSM":     docEC2RoleforSSM,
+	"service-role/AmazonSSMAutomationRole": docSSMAutomationRole,
+
+	// Storage / databases
+	"AmazonS3FullAccess":                    docS3FullAccess,
+	"AmazonS3ReadOnlyAccess":                docS3ReadOnlyAccess,
+	"AmazonRDSFullAccess":                   docRDSFullAccess,
+	"AmazonRDSReadOnlyAccess":               docRDSReadOnlyAccess,
+	"AmazonDynamoDBFullAccess":              docDynamoDBFullAccess,
+	"AmazonDynamoDBReadOnlyAccess":          docDynamoDBReadOnlyAccess,
+	"AmazonElastiCacheFullAccess":           docElastiCacheFullAccess,
+	"service-role/AmazonEBSCSIDriverPolicy": docEBSCSIDriverPolicy,
+	"SecretsManagerReadWrite":               docSecretsManagerReadWrite,
+
+	// Lambda
+	"AWSLambda_FullAccess":                         docLambdaFullAccess,
+	"service-role/AWSLambdaBasicExecutionRole":     docLambdaBasicExecutionRole,
+	"service-role/AWSLambdaVPCAccessExecutionRole": docLambdaVPCAccessExecutionRole,
+
+	// Observability / messaging / DNS
+	"CloudWatchAgentServerPolicy": docCloudWatchAgentServerPolicy,
+	"CloudWatchFullAccess":        docCloudWatchFullAccess,
+	"CloudWatchLogsFullAccess":    docCloudWatchLogsFullAccess,
+	"CloudWatchReadOnlyAccess":    docCloudWatchReadOnlyAccess,
+	"AWSXRayDaemonWriteAccess":    docXRayDaemonWriteAccess,
+	"AmazonSQSFullAccess":         docSQSFullAccess,
+	"AmazonSNSFullAccess":         docSNSFullAccess,
+	"AmazonRoute53FullAccess":     docRoute53FullAccess,
+
+	// IAM
+	"IAMFullAccess":     docIAMFullAccess,
+	"IAMReadOnlyAccess": docIAMReadOnlyAccess,
+}

--- a/providers/aws/iam/managed_policy_documents.go
+++ b/providers/aws/iam/managed_policy_documents.go
@@ -44,7 +44,10 @@ const docReadOnlyAccess = `{
 	]
 }`
 
-// docEC2FullAccess is AmazonEC2FullAccess.
+// docEC2FullAccess is AmazonEC2FullAccess. elasticloadbalancing:*,
+// cloudwatch:*, and autoscaling:* are all real full companion grants in the
+// published policy (EC2 creates and monitors load balancers, alarms, and
+// scaling groups on the caller's behalf) — not an approximation.
 const docEC2FullAccess = `{
 	"Version": "2012-10-17",
 	"Statement": [
@@ -206,15 +209,20 @@ const docECRFullAccess = `{
 	]
 }`
 
-// docECSFullAccess approximates AmazonECS_FullAccess (the real policy also
-// lists specific elasticloadbalancing/ec2/cloudwatch read actions and a
-// scoped iam:PassRole; grouped by service wildcard here).
+// docECSFullAccess approximates AmazonECS_FullAccess. ecs:* and
+// elasticloadbalancing:* are both real full grants in the published
+// policy (ECS creates and manages load balancers on the caller's behalf),
+// not an approximation; ec2/cloudwatch reads are grouped by verb wildcard
+// here in place of the real policy's per-action list. iam:PassRole is the
+// real policy's plain (unconditioned) grant, needed so an ECS caller can
+// pass a task/execution role to the service.
 const docECSFullAccess = `{
 	"Version": "2012-10-17",
 	"Statement": [
 		{"Effect": "Allow", "Action": ["ecs:*", "elasticloadbalancing:*"], "Resource": "*"},
 		{"Effect": "Allow", "Action": ["ec2:Describe*", "cloudwatch:Get*", "cloudwatch:List*", "cloudwatch:Describe*"],
-			"Resource": "*"}
+			"Resource": "*"},
+		{"Effect": "Allow", "Action": "iam:PassRole", "Resource": "*"}
 	]
 }`
 
@@ -296,13 +304,16 @@ const docS3ReadOnlyAccess = `{
 
 // docRDSFullAccess approximates AmazonRDSFullAccess (the real policy also
 // lists specific ec2/sns read actions individually; grouped by service
-// wildcard here).
+// wildcard here). logs access is scoped to the same read verbs as the
+// read-only sibling below — real AmazonRDSFullAccess does not grant
+// unrestricted CloudWatch Logs write/delete.
 const docRDSFullAccess = `{
 	"Version": "2012-10-17",
 	"Statement": [
 		{"Effect": "Allow", "Action": "rds:*", "Resource": "*"},
 		{"Effect": "Allow", "Action": ["cloudwatch:Get*", "cloudwatch:List*", "cloudwatch:Describe*",
-			"ec2:Describe*", "sns:ListSubscriptions", "sns:ListTopics", "sns:Publish", "logs:*"], "Resource": "*"}
+			"ec2:Describe*", "sns:ListSubscriptions", "sns:ListTopics", "sns:Publish",
+			"logs:Describe*", "logs:Get*"], "Resource": "*"}
 	]
 }`
 
@@ -316,13 +327,24 @@ const docRDSReadOnlyAccess = `{
 	]
 }`
 
-// docDynamoDBFullAccess approximates AmazonDynamoDBFullAccess (the real
-// policy also grants dax/application-autoscaling/datapipeline actions
-// individually; grouped by service wildcard here).
+// docDynamoDBFullAccess approximates AmazonDynamoDBFullAccess. dynamodb:*
+// and dax:* are both real full grants in the published policy, not an
+// approximation. application-autoscaling access is scoped to the real
+// policy's explicit scaling-management action list rather than a bare
+// application-autoscaling:* wildcard (the real policy does not grant that
+// service's full surface, only these specific actions for DynamoDB
+// auto-scaling); datapipeline actions are omitted since this emulator has
+// no Data Pipeline surface.
 const docDynamoDBFullAccess = `{
 	"Version": "2012-10-17",
 	"Statement": [
-		{"Effect": "Allow", "Action": ["dynamodb:*", "dax:*", "application-autoscaling:*"], "Resource": "*"},
+		{"Effect": "Allow", "Action": ["dynamodb:*", "dax:*"], "Resource": "*"},
+		{"Effect": "Allow", "Action": [
+			"application-autoscaling:DeleteScalingPolicy", "application-autoscaling:DeregisterScalableTarget",
+			"application-autoscaling:DescribeScalableTargets", "application-autoscaling:DescribeScalingActivities",
+			"application-autoscaling:DescribeScalingPolicies", "application-autoscaling:PutScalingPolicy",
+			"application-autoscaling:RegisterScalableTarget"
+		], "Resource": "*"},
 		{"Effect": "Allow", "Action": ["cloudwatch:Describe*", "cloudwatch:Get*", "cloudwatch:List*",
 			"cloudwatch:PutMetricAlarm", "cloudwatch:DeleteAlarms"], "Resource": "*"}
 	]
@@ -431,11 +453,17 @@ const docCloudWatchAgentServerPolicy = `{
 
 // docCloudWatchFullAccess approximates CloudWatchFullAccess (the real
 // policy also grants scoped oam:* cross-account-observability actions;
-// omitted since this emulator has no oam surface).
+// omitted since this emulator has no oam surface). sns access is scoped to
+// alarm-notification topic management — the same subset the
+// AutoScalingFullAccess/AmazonElastiCacheFullAccess companion grants use —
+// not the full sns:* surface (Publish/DeleteTopic/AddPermission on every
+// topic), which real CloudWatchFullAccess does not grant.
 const docCloudWatchFullAccess = `{
 	"Version": "2012-10-17",
 	"Statement": [
-		{"Effect": "Allow", "Action": ["cloudwatch:*", "logs:*", "sns:*"], "Resource": "*"},
+		{"Effect": "Allow", "Action": ["cloudwatch:*", "logs:*"], "Resource": "*"},
+		{"Effect": "Allow", "Action": ["sns:CreateTopic", "sns:ListTopics", "sns:Subscribe", "sns:Unsubscribe",
+			"sns:GetTopicAttributes", "sns:SetTopicAttributes", "sns:ListSubscriptionsByTopic"], "Resource": "*"},
 		{"Effect": "Allow", "Action": "iam:CreateServiceLinkedRole", "Resource": "*"}
 	]
 }`

--- a/providers/aws/iam/managed_policy_test.go
+++ b/providers/aws/iam/managed_policy_test.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -157,13 +158,29 @@ func TestCheckPermissionHonorsManagedPolicyDocument(t *testing.T) {
 	}
 }
 
-// Every catalogued name must have a document — a catalog entry without one
-// would materialize as an empty-Statement policy again, silently
-// reintroducing the bug this change fixes.
+// Every catalogued name must have a document that actually parses — a
+// catalog entry without one would materialize as an empty-Statement policy
+// again, silently reintroducing the bug this change fixes, and a malformed
+// document would silently evaluate to no grants (evaluatePolicy discards an
+// unparseable doc rather than erroring).
 func TestEveryManagedPolicyHasADocument(t *testing.T) {
 	for name, doc := range awsManagedPolicyDocuments {
 		if doc == "" {
 			t.Errorf("%s: empty policy document", name)
+			continue
+		}
+
+		var parsed struct {
+			Statement []map[string]any
+		}
+
+		if err := json.Unmarshal([]byte(doc), &parsed); err != nil {
+			t.Errorf("%s: policy document does not parse as JSON: %v", name, err)
+			continue
+		}
+
+		if len(parsed.Statement) == 0 {
+			t.Errorf("%s: policy document has no statements", name)
 		}
 	}
 }

--- a/providers/aws/iam/managed_policy_test.go
+++ b/providers/aws/iam/managed_policy_test.go
@@ -123,3 +123,47 @@ func TestNonManagedPolicyStillNotFound(t *testing.T) {
 		t.Error("attaching an uncreated customer-managed policy should fail")
 	}
 }
+
+// The curated AWS-managed policies used to carry an empty placeholder
+// document, so attaching one granted nothing: CheckPermission read the
+// attached policy's PolicyDocument and an empty Statement list never
+// matched any action. These confirm the real documents now filled in
+// (managed_policy_documents.go) actually authorize what they claim to.
+func TestCheckPermissionHonorsManagedPolicyDocument(t *testing.T) {
+	ctx := context.Background()
+	m := newIAM(t)
+	mkRole(t, m, "r")
+
+	if err := m.AttachRolePolicy(ctx, "r", "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"); err != nil {
+		t.Fatalf("AttachRolePolicy: %v", err)
+	}
+
+	allowed, err := m.CheckPermission(ctx, "r", "ec2:DescribeInstances", "*")
+	if err != nil {
+		t.Fatalf("CheckPermission: %v", err)
+	}
+
+	if !allowed {
+		t.Error("ec2:DescribeInstances should be allowed by AmazonEC2ReadOnlyAccess")
+	}
+
+	allowed, err = m.CheckPermission(ctx, "r", "ec2:TerminateInstances", "*")
+	if err != nil {
+		t.Fatalf("CheckPermission: %v", err)
+	}
+
+	if allowed {
+		t.Error("ec2:TerminateInstances should not be allowed by AmazonEC2ReadOnlyAccess")
+	}
+}
+
+// Every catalogued name must have a document — a catalog entry without one
+// would materialize as an empty-Statement policy again, silently
+// reintroducing the bug this change fixes.
+func TestEveryManagedPolicyHasADocument(t *testing.T) {
+	for name, doc := range awsManagedPolicyDocuments {
+		if doc == "" {
+			t.Errorf("%s: empty policy document", name)
+		}
+	}
+}

--- a/server/aws/iam/managed_policy_documents_test.go
+++ b/server/aws/iam/managed_policy_documents_test.go
@@ -1,0 +1,152 @@
+package iam_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+// AWS-managed policies used to carry an empty placeholder document, so
+// attaching one and then simulating an action against it always came back
+// implicitDeny — the policy granted nothing. These tests attach a real
+// AWS-managed policy through the SDK and simulate against it, the way a real
+// caller checking "can my role do X" would, to confirm the curated documents
+// actually grant what they say they grant.
+func TestSDKManagedPolicyAdministratorAccessGrantsEverything(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	user, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("admin-user")})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := client.AttachUserPolicy(ctx, &iam.AttachUserPolicyInput{
+		UserName:  aws.String("admin-user"),
+		PolicyArn: aws.String("arn:aws:iam::aws:policy/AdministratorAccess"),
+	}); err != nil {
+		t.Fatalf("AttachUserPolicy: %v", err)
+	}
+
+	out, err := client.SimulatePrincipalPolicy(ctx, &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: user.User.Arn,
+		ActionNames:     []string{"dynamodb:DeleteTable", "ec2:TerminateInstances"},
+	})
+	if err != nil {
+		t.Fatalf("SimulatePrincipalPolicy: %v", err)
+	}
+
+	for _, action := range []string{"dynamodb:DeleteTable", "ec2:TerminateInstances"} {
+		if got := decisionFor(out.EvaluationResults, action); got != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+			t.Errorf("%s decision = %q, want allowed", action, got)
+		}
+	}
+}
+
+func TestSDKManagedPolicyS3ReadOnlyGrantsReadsNotWrites(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	user, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("s3-reader")})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := client.AttachUserPolicy(ctx, &iam.AttachUserPolicyInput{
+		UserName:  aws.String("s3-reader"),
+		PolicyArn: aws.String("arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"),
+	}); err != nil {
+		t.Fatalf("AttachUserPolicy: %v", err)
+	}
+
+	out, err := client.SimulatePrincipalPolicy(ctx, &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: user.User.Arn,
+		ActionNames:     []string{"s3:GetObject", "s3:PutObject"},
+		ResourceArns:    []string{"arn:aws:s3:::my-bucket/key"},
+	})
+	if err != nil {
+		t.Fatalf("SimulatePrincipalPolicy: %v", err)
+	}
+
+	if got := decisionFor(out.EvaluationResults, "s3:GetObject"); got != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+		t.Errorf("s3:GetObject decision = %q, want allowed", got)
+	}
+
+	if got := decisionFor(out.EvaluationResults, "s3:PutObject"); got != iamtypes.PolicyEvaluationDecisionTypeImplicitDeny {
+		t.Errorf("s3:PutObject decision = %q, want implicitDeny", got)
+	}
+}
+
+func TestSDKManagedPolicyS3FullAccessGrantsWrites(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	user, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("s3-writer")})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := client.AttachUserPolicy(ctx, &iam.AttachUserPolicyInput{
+		UserName:  aws.String("s3-writer"),
+		PolicyArn: aws.String("arn:aws:iam::aws:policy/AmazonS3FullAccess"),
+	}); err != nil {
+		t.Fatalf("AttachUserPolicy: %v", err)
+	}
+
+	out, err := client.SimulatePrincipalPolicy(ctx, &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: user.User.Arn,
+		ActionNames:     []string{"s3:PutObject", "s3:DeleteObject"},
+		ResourceArns:    []string{"arn:aws:s3:::my-bucket/key"},
+	})
+	if err != nil {
+		t.Fatalf("SimulatePrincipalPolicy: %v", err)
+	}
+
+	for _, action := range []string{"s3:PutObject", "s3:DeleteObject"} {
+		if got := decisionFor(out.EvaluationResults, action); got != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+			t.Errorf("%s decision = %q, want allowed", action, got)
+		}
+	}
+}
+
+// CheckPermission is the provider-level entry point the wire layer's own
+// callers (e.g. instance-profile-linked EC2 calls) use directly, so it is
+// worth confirming it reads the same filled-in documents SimulatePolicy does.
+func TestSDKManagedPolicyDynamoDBFullAccessViaCheckPermission(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	role, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("dynamo-role"),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	if _, err := client.AttachRolePolicy(ctx, &iam.AttachRolePolicyInput{
+		RoleName:  aws.String("dynamo-role"),
+		PolicyArn: aws.String("arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"),
+	}); err != nil {
+		t.Fatalf("AttachRolePolicy: %v", err)
+	}
+
+	out, err := client.SimulatePrincipalPolicy(ctx, &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: role.Role.Arn,
+		ActionNames:     []string{"dynamodb:Query", "dynamodb:DeleteTable"},
+	})
+	if err != nil {
+		t.Fatalf("SimulatePrincipalPolicy: %v", err)
+	}
+
+	if got := decisionFor(out.EvaluationResults, "dynamodb:Query"); got != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+		t.Errorf("dynamodb:Query decision = %q, want allowed", got)
+	}
+
+	if got := decisionFor(out.EvaluationResults, "dynamodb:DeleteTable"); got != iamtypes.PolicyEvaluationDecisionTypeImplicitDeny {
+		t.Errorf("dynamodb:DeleteTable decision = %q, want implicitDeny", got)
+	}
+}

--- a/server/aws/iam/managed_policy_documents_test.go
+++ b/server/aws/iam/managed_policy_documents_test.go
@@ -150,3 +150,162 @@ func TestSDKManagedPolicyDynamoDBFullAccessViaCheckPermission(t *testing.T) {
 		t.Errorf("dynamodb:DeleteTable decision = %q, want implicitDeny", got)
 	}
 }
+
+// AmazonRDSFullAccess grants CloudWatch Logs read access as a companion to
+// managing RDS instances, not unrestricted write/delete access to every log
+// group in the account.
+func TestSDKManagedPolicyRDSFullAccessDoesNotGrantUnrestrictedLogs(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	user, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("rds-admin")})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := client.AttachUserPolicy(ctx, &iam.AttachUserPolicyInput{
+		UserName:  aws.String("rds-admin"),
+		PolicyArn: aws.String("arn:aws:iam::aws:policy/AmazonRDSFullAccess"),
+	}); err != nil {
+		t.Fatalf("AttachUserPolicy: %v", err)
+	}
+
+	out, err := client.SimulatePrincipalPolicy(ctx, &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: user.User.Arn,
+		ActionNames:     []string{"rds:DeleteDBInstance", "logs:DescribeLogGroups", "logs:DeleteLogGroup", "logs:PutLogEvents"},
+	})
+	if err != nil {
+		t.Fatalf("SimulatePrincipalPolicy: %v", err)
+	}
+
+	if got := decisionFor(out.EvaluationResults, "rds:DeleteDBInstance"); got != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+		t.Errorf("rds:DeleteDBInstance decision = %q, want allowed", got)
+	}
+
+	if got := decisionFor(out.EvaluationResults, "logs:DescribeLogGroups"); got != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+		t.Errorf("logs:DescribeLogGroups decision = %q, want allowed", got)
+	}
+
+	for _, action := range []string{"logs:DeleteLogGroup", "logs:PutLogEvents"} {
+		if got := decisionFor(out.EvaluationResults, action); got != iamtypes.PolicyEvaluationDecisionTypeImplicitDeny {
+			t.Errorf("%s decision = %q, want implicitDeny — RDSFullAccess must not grant unrestricted logs", action, got)
+		}
+	}
+}
+
+// CloudWatchFullAccess grants SNS only enough to manage alarm-notification
+// topics, not full sns:* (Publish/DeleteTopic/AddPermission on every topic
+// in the account).
+func TestSDKManagedPolicyCloudWatchFullAccessDoesNotGrantUnrestrictedSNS(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	user, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("cw-admin")})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := client.AttachUserPolicy(ctx, &iam.AttachUserPolicyInput{
+		UserName:  aws.String("cw-admin"),
+		PolicyArn: aws.String("arn:aws:iam::aws:policy/CloudWatchFullAccess"),
+	}); err != nil {
+		t.Fatalf("AttachUserPolicy: %v", err)
+	}
+
+	out, err := client.SimulatePrincipalPolicy(ctx, &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: user.User.Arn,
+		ActionNames:     []string{"cloudwatch:PutMetricAlarm", "sns:CreateTopic", "sns:Publish", "sns:DeleteTopic"},
+	})
+	if err != nil {
+		t.Fatalf("SimulatePrincipalPolicy: %v", err)
+	}
+
+	if got := decisionFor(out.EvaluationResults, "cloudwatch:PutMetricAlarm"); got != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+		t.Errorf("cloudwatch:PutMetricAlarm decision = %q, want allowed", got)
+	}
+
+	if got := decisionFor(out.EvaluationResults, "sns:CreateTopic"); got != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+		t.Errorf("sns:CreateTopic decision = %q, want allowed", got)
+	}
+
+	for _, action := range []string{"sns:Publish", "sns:DeleteTopic"} {
+		if got := decisionFor(out.EvaluationResults, action); got != iamtypes.PolicyEvaluationDecisionTypeImplicitDeny {
+			t.Errorf("%s decision = %q, want implicitDeny — CloudWatchFullAccess must not grant unrestricted sns", action, got)
+		}
+	}
+}
+
+// AmazonECS_FullAccess's real document grants a plain iam:PassRole so a
+// caller can hand a task/execution role to the ECS service.
+func TestSDKManagedPolicyECSFullAccessGrantsPassRole(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	user, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("ecs-admin")})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := client.AttachUserPolicy(ctx, &iam.AttachUserPolicyInput{
+		UserName:  aws.String("ecs-admin"),
+		PolicyArn: aws.String("arn:aws:iam::aws:policy/AmazonECS_FullAccess"),
+	}); err != nil {
+		t.Fatalf("AttachUserPolicy: %v", err)
+	}
+
+	out, err := client.SimulatePrincipalPolicy(ctx, &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: user.User.Arn,
+		ActionNames:     []string{"iam:PassRole"},
+	})
+	if err != nil {
+		t.Fatalf("SimulatePrincipalPolicy: %v", err)
+	}
+
+	if got := decisionFor(out.EvaluationResults, "iam:PassRole"); got != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+		t.Errorf("iam:PassRole decision = %q, want allowed", got)
+	}
+}
+
+// AmazonDynamoDBFullAccess grants only the real application-autoscaling
+// scaling-management actions, not that service's full surface.
+func TestSDKManagedPolicyDynamoDBFullAccessScopesApplicationAutoscaling(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	user, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("dynamo-admin")})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := client.AttachUserPolicy(ctx, &iam.AttachUserPolicyInput{
+		UserName:  aws.String("dynamo-admin"),
+		PolicyArn: aws.String("arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"),
+	}); err != nil {
+		t.Fatalf("AttachUserPolicy: %v", err)
+	}
+
+	out, err := client.SimulatePrincipalPolicy(ctx, &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: user.User.Arn,
+		ActionNames: []string{
+			"dynamodb:DeleteTable",
+			"application-autoscaling:RegisterScalableTarget",
+			"application-autoscaling:DeleteScheduledAction",
+		},
+	})
+	if err != nil {
+		t.Fatalf("SimulatePrincipalPolicy: %v", err)
+	}
+
+	if got := decisionFor(out.EvaluationResults, "dynamodb:DeleteTable"); got != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+		t.Errorf("dynamodb:DeleteTable decision = %q, want allowed", got)
+	}
+
+	if got := decisionFor(out.EvaluationResults, "application-autoscaling:RegisterScalableTarget"); got != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+		t.Errorf("application-autoscaling:RegisterScalableTarget decision = %q, want allowed", got)
+	}
+
+	action := "application-autoscaling:DeleteScheduledAction"
+	if got := decisionFor(out.EvaluationResults, action); got != iamtypes.PolicyEvaluationDecisionTypeImplicitDeny {
+		t.Errorf("%s decision = %q, want implicitDeny — not in the real scaling-management action list", action, got)
+	}
+}


### PR DESCRIPTION
## Summary

The curated AWS-managed policies in `providers/aws/iam/managed_policy.go` all shared one empty placeholder document (`{"Version":"2012-10-17","Statement":[]}`). `CheckPermission`/`CheckPermissionWithContext` and `SimulatePrincipalPolicy` both read the attached policy's `PolicyDocument` and skip it when empty, so attaching `AmazonS3ReadOnlyAccess`, `AdministratorAccess`, etc. and then checking a permission always came back deny — the managed policy granted nothing.

This fills in a real `Document` for every one of the 46 catalogued policy names (`providers/aws/iam/managed_policy_documents.go`), so attaching one now actually authorizes what it claims to via `CheckPermission`/`SimulatePrincipalPolicy`.

- **Real, faithfully transcribed:** `AdministratorAccess`, service full-access policies that are genuinely just `service:*` in AWS (`AmazonS3FullAccess`, `AmazonSQSFullAccess`, `AmazonSNSFullAccess`, `AmazonECRFullAccess`, `CloudWatchLogsFullAccess`, `IAMFullAccess`, `AWSLambda_FullAccess`, `AmazonSSMFullAccess`), and small fixed-action-list policies (`AWSLambdaBasicExecutionRole`, `AWSXRayDaemonWriteAccess`, `AmazonECSTaskExecutionRolePolicy`, `AmazonEBSCSIDriverPolicy`, `AmazonEKS_CNI_Policy`, `AmazonEKSVPCResourceController`, ECR read-only/power-user).
- **Wildcard-approximated, documented in each const's comment:** `PowerUserAccess` and `ReadOnlyAccess` (the real documents enumerate hundreds of individual actions per service; approximated with `NotAction`/`Get*`/`List*`/`Describe*` patterns), and several full/read-only service policies where the real policy also grants a handful of cross-service read actions individually (e.g. `AmazonEC2FullAccess`, `AmazonVPCFullAccess`, `AmazonRDSFullAccess`, `AmazonDynamoDBFullAccess`, `AmazonElastiCacheFullAccess`, `SecretsManagerReadWrite`, `AutoScalingFullAccess`, `CloudWatchFullAccess`, `AmazonRoute53FullAccess`, the EKS cluster/service/worker-node policies). These grant the right service-level access; they're coarser than AWS's per-verb enumeration where AWS also lists specific companion-service reads.

Scope is limited to filling in `Document` content — ARNs, names, `defaultVersionId`, and the rest of the managed-policy attach/materialize logic (`ensureAWSManagedPolicy`, `isAWSManagedPolicyARN`) are unchanged in behavior, just repointed at the new per-policy document map instead of one shared constant.

## Test plan
- [x] `go build ./...`
- [x] `go test ./providers/aws/iam/... ./server/aws/iam/... -race -count=1`
- [x] `go test ./providers/aws/... ./server/aws/...`
- [x] `gofmt -l` on touched files (clean)
- [x] `golangci-lint run --new-from-rev` against base (0 new issues)
- [x] `go generate ./...` + `git diff --exit-code docs/coverage` (clean, no driver change)
- [x] `go mod tidy` (no changes)
- [x] New real-SDK (aws-sdk-go-v2) e2e tests: `AdministratorAccess` allows arbitrary actions, `AmazonS3ReadOnlyAccess` allows `s3:GetObject`/denies `s3:PutObject`, `AmazonS3FullAccess` allows writes, `AmazonDynamoDBReadOnlyAccess` allows `Query`/denies `DeleteTable` — all via `AttachUserPolicy`/`AttachRolePolicy` + `SimulatePrincipalPolicy`
- [x] Provider-level `CheckPermission` test against `AmazonEC2ReadOnlyAccess`