### PR TITLE
fix(pubsub): enforce etag optimistic concurrency on topic/subscription setIamPolicy

### DIFF
--- a/server/gcp/pubsub/iam.go
+++ b/server/gcp/pubsub/iam.go
@@ -1,10 +1,6 @@
 package pubsub
 
-import (
-	"encoding/base64"
-	"net/http"
-	"strconv"
-)
+import "net/http"
 
 // ---------- IAM ----------
 //
@@ -12,6 +8,13 @@ import (
 // surface (getIamPolicy/setIamPolicy/testIamPermissions), which
 // google_pubsub_topic_iam_* / google_pubsub_subscription_iam_* Terraform
 // resources depend on. Policies are stored per-resource and round-trip verbatim.
+//
+// setIamPolicy enforces the same etag optimistic-concurrency contract real
+// Pub/Sub does: a request that carries an etag must match the resource's
+// current one or the write is rejected (409 ABORTED) instead of silently
+// clobbering a concurrent change; an empty etag is an unconditional write.
+// reasonAborted mirrors server/gcp/iam's service-account-level policy conflict.
+const reasonAborted = "ABORTED"
 
 func (h *Handler) serveIam(w http.ResponseWriter, r *http.Request, resType, name, action string) {
 	switch action {
@@ -37,7 +40,7 @@ func (h *Handler) getIamPolicy(w http.ResponseWriter, r *http.Request, resType, 
 	h.mu.RUnlock()
 
 	if pol == nil {
-		pol = &iamPolicy{Version: 1, Etag: h.nextEtag()}
+		pol = &iamPolicy{Version: 1, Etag: policyEtag(nil)}
 	}
 
 	writeJSON(w, http.StatusOK, pol)
@@ -59,10 +62,27 @@ func (h *Handler) setIamPolicy(w http.ResponseWriter, r *http.Request, resType, 
 		pol.Version = 1
 	}
 
-	pol.Etag = h.nextEtag()
-
+	// The etag precondition check and the write happen atomically under one
+	// h.mu.Lock() (read-compare-write in a single critical section), so
+	// concurrent setIamPolicy calls that all read the same starting etag
+	// can't all "win" the way a separate getIamPolicy-then-setIamPolicy pair
+	// here would allow (a lost update) — mirrors providers/gcp/gcs's
+	// CompareAndSetBucketIAMPolicy for bucket IAM (#1014).
 	h.mu.Lock()
+
+	currentEtag := policyEtag(h.loadPolicy(resType, name))
+	if req.Policy.Etag != "" && req.Policy.Etag != currentEtag {
+		h.mu.Unlock()
+		writeError(w, http.StatusConflict, reasonAborted,
+			"there were concurrent policy changes; please retry the whole "+
+				"read-modify-write with the new etag")
+
+		return
+	}
+
+	pol.Etag = nextIAMEtag(currentEtag)
 	h.storePolicy(resType, name, &pol)
+
 	h.mu.Unlock()
 
 	writeJSON(w, http.StatusOK, pol)
@@ -127,8 +147,4 @@ func (h *Handler) storePolicy(resType, name string, pol *iamPolicy) {
 			s.iam = pol
 		}
 	}
-}
-
-func (h *Handler) nextEtag() string {
-	return base64.StdEncoding.EncodeToString([]byte("etag-" + strconv.FormatUint(h.ackCounter.Add(1), 10)))
 }

--- a/server/gcp/pubsub/iam_policy_etag.go
+++ b/server/gcp/pubsub/iam_policy_etag.go
@@ -1,0 +1,91 @@
+package pubsub
+
+import "encoding/base64"
+
+const (
+	// iamEtagTag is the protobuf tag byte for field 1 (varint wire type) —
+	// mirrors the encoding real Google IAM policy etags use (and the one
+	// providers/gcp/gcs mints for bucket IAM policy etags): base64 of a
+	// single-field protobuf message carrying a monotonically increasing
+	// version, e.g. "CAE=" decodes to tag 0x08 (field 1, varint) followed by
+	// the varint-encoded value 1.
+	iamEtagTag = 0x08
+	// varintContinuationBit marks that a varint byte is followed by more
+	// payload bytes.
+	varintContinuationBit = 0x80
+	// varintPayloadMask extracts the 7 payload bits of one varint byte.
+	varintPayloadMask = 0x7f
+	// varintPayloadBits is how many bits of payload one varint byte carries.
+	varintPayloadBits = 7
+	// iamEtagInitialVersion is the version reported for a topic or
+	// subscription whose IAM policy was never explicitly set (etag "CAE=").
+	iamEtagInitialVersion = 1
+)
+
+// policyEtag returns pol's etag, or the deterministic initial-version etag
+// when pol is nil (no policy has ever been set) or carries no etag of its
+// own. A stable default lets getIamPolicy on an unset resource be called
+// repeatedly without minting a new etag each time (which would make it
+// impossible for a client to safely read-modify-write against it).
+func policyEtag(pol *iamPolicy) string {
+	if pol != nil && pol.Etag != "" {
+		return pol.Etag
+	}
+
+	return encodeIAMEtag(iamEtagInitialVersion)
+}
+
+// nextIAMEtag mints the etag that follows prevEtag, incrementing its encoded
+// version. A prevEtag that isn't in the expected format (e.g. one this
+// emulator never minted) is treated as the initial version, so the result is
+// still a well-formed, freshly incremented etag.
+func nextIAMEtag(prevEtag string) string {
+	version, ok := decodeIAMEtagVersion(prevEtag)
+	if !ok {
+		version = iamEtagInitialVersion
+	}
+
+	return encodeIAMEtag(version + 1)
+}
+
+// encodeIAMEtag base64-encodes a protobuf field-1 varint carrying version.
+func encodeIAMEtag(version uint64) string {
+	b := []byte{iamEtagTag}
+
+	for version >= varintContinuationBit {
+		// version&varintPayloadMask|varintContinuationBit is masked to the
+		// low 8 bits (0x00-0xff), so the byte conversion never truncates.
+		b = append(b, byte(version&varintPayloadMask|varintContinuationBit)) //nolint:gosec // masked to a single byte above
+		version >>= varintPayloadBits
+	}
+
+	b = append(b, byte(version))
+
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+// decodeIAMEtagVersion reverses encodeIAMEtag, reporting ok=false for any
+// etag not in that format (opaque values a real client should never
+// construct, but a defensive fallback keeps setIamPolicy from erroring on
+// one).
+func decodeIAMEtagVersion(etag string) (uint64, bool) {
+	b, err := base64.StdEncoding.DecodeString(etag)
+	if err != nil || len(b) < 2 || b[0] != iamEtagTag {
+		return 0, false
+	}
+
+	var version uint64
+
+	var shift uint
+
+	for _, c := range b[1:] {
+		version |= uint64(c&varintPayloadMask) << shift
+		if c&varintContinuationBit == 0 {
+			return version, true
+		}
+
+		shift += varintPayloadBits
+	}
+
+	return 0, false
+}

--- a/server/gcp/pubsub/sdk_iam_etag_test.go
+++ b/server/gcp/pubsub/sdk_iam_etag_test.go
@@ -1,0 +1,288 @@
+package pubsub_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+	pubsubv1 "google.golang.org/api/pubsub/v1"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// TestSDKPubSubTopicIAMPolicyEtagRoundTrips proves getIamPolicy returns a
+// stable etag for an unset policy (repeat reads must not mint a new one each
+// time), and every setIamPolicy advances it.
+func TestSDKPubSubTopicIAMPolicyEtagRoundTrips(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/etag-rt")
+	const res = "projects/demo/topics/etag-rt"
+
+	first, err := svc.Projects.Topics.GetIamPolicy(res).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("GetIamPolicy: %v", err)
+	}
+
+	second, err := svc.Projects.Topics.GetIamPolicy(res).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("GetIamPolicy (repeat): %v", err)
+	}
+
+	if first.Etag == "" || first.Etag != second.Etag {
+		t.Fatalf("unset policy etag should be stable across reads, got %q then %q", first.Etag, second.Etag)
+	}
+
+	set, err := svc.Projects.Topics.SetIamPolicy(res, &pubsubv1.SetIamPolicyRequest{
+		Policy: &pubsubv1.Policy{
+			Bindings: []*pubsubv1.Binding{{Role: "roles/pubsub.viewer", Members: []string{"user:a@b.com"}}},
+		},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("SetIamPolicy: %v", err)
+	}
+
+	if set.Etag == "" || set.Etag == first.Etag {
+		t.Fatalf("etag should change on setIamPolicy, got %q (was %q)", set.Etag, first.Etag)
+	}
+
+	// A second unconditional set (no etag on the request) further advances it.
+	set2, err := svc.Projects.Topics.SetIamPolicy(res, &pubsubv1.SetIamPolicyRequest{
+		Policy: &pubsubv1.Policy{
+			Bindings: []*pubsubv1.Binding{{Role: "roles/pubsub.editor", Members: []string{"user:c@d.com"}}},
+		},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("SetIamPolicy (second): %v", err)
+	}
+
+	if set2.Etag == "" || set2.Etag == set.Etag {
+		t.Fatalf("etag should change again, stayed %q", set2.Etag)
+	}
+}
+
+// TestSDKPubSubTopicIAMPolicyStaleEtagRejected proves a setIamPolicy built
+// from a stale read (someone else changed the policy in between) is rejected
+// with a conflict instead of silently clobbering the newer policy.
+func TestSDKPubSubTopicIAMPolicyStaleEtagRejected(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/etag-stale")
+	const res = "projects/demo/topics/etag-stale"
+
+	stale, err := svc.Projects.Topics.GetIamPolicy(res).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("GetIamPolicy (stale read): %v", err)
+	}
+
+	// Someone else updates the policy first, advancing the etag.
+	if _, wErr := svc.Projects.Topics.SetIamPolicy(res, &pubsubv1.SetIamPolicyRequest{
+		Policy: &pubsubv1.Policy{
+			Etag:     stale.Etag,
+			Bindings: []*pubsubv1.Binding{{Role: "roles/pubsub.viewer", Members: []string{"user:winner@example.com"}}},
+		},
+	}).Context(ctx).Do(); wErr != nil {
+		t.Fatalf("SetIamPolicy (winning writer): %v", wErr)
+	}
+
+	// The stale writer's set, built from the pre-update etag, must fail.
+	_, err = svc.Projects.Topics.SetIamPolicy(res, &pubsubv1.SetIamPolicyRequest{
+		Policy: &pubsubv1.Policy{
+			Etag:     stale.Etag,
+			Bindings: []*pubsubv1.Binding{{Role: "roles/pubsub.admin", Members: []string{"user:loser@example.com"}}},
+		},
+	}).Context(ctx).Do()
+	if err == nil {
+		t.Fatalf("SetIamPolicy with a stale etag should have failed")
+	}
+
+	var gErr *googleapi.Error
+	if !errors.As(err, &gErr) {
+		t.Fatalf("expected a googleapi.Error, got %T: %v", err, err)
+	}
+
+	if gErr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 Conflict, got %d: %v", gErr.Code, gErr)
+	}
+
+	// The winning writer's binding must be intact — the stale write must not
+	// have partially applied.
+	final, err := svc.Projects.Topics.GetIamPolicy(res).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("GetIamPolicy (final): %v", err)
+	}
+
+	if len(final.Bindings) != 1 || final.Bindings[0].Members[0] != "user:winner@example.com" {
+		t.Fatalf("winning writer's binding should be intact, unaffected by the stale write: %+v", final.Bindings)
+	}
+}
+
+// TestSDKPubSubSubscriptionIAMPolicyStaleEtagRejected mirrors the topic case
+// for subscriptions.setIamPolicy.
+func TestSDKPubSubSubscriptionIAMPolicyStaleEtagRejected(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/etag-sub-t")
+	mustSub(t, svc, "projects/demo/subscriptions/etag-sub-s",
+		&pubsubv1.Subscription{Topic: "projects/demo/topics/etag-sub-t"})
+
+	const res = "projects/demo/subscriptions/etag-sub-s"
+
+	stale, err := svc.Projects.Subscriptions.GetIamPolicy(res).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("GetIamPolicy (stale read): %v", err)
+	}
+
+	if _, wErr := svc.Projects.Subscriptions.SetIamPolicy(res, &pubsubv1.SetIamPolicyRequest{
+		Policy: &pubsubv1.Policy{
+			Etag:     stale.Etag,
+			Bindings: []*pubsubv1.Binding{{Role: "roles/pubsub.subscriber", Members: []string{"user:winner@example.com"}}},
+		},
+	}).Context(ctx).Do(); wErr != nil {
+		t.Fatalf("SetIamPolicy (winning writer): %v", wErr)
+	}
+
+	_, err = svc.Projects.Subscriptions.SetIamPolicy(res, &pubsubv1.SetIamPolicyRequest{
+		Policy: &pubsubv1.Policy{
+			Etag:     stale.Etag,
+			Bindings: []*pubsubv1.Binding{{Role: "roles/pubsub.editor", Members: []string{"user:loser@example.com"}}},
+		},
+	}).Context(ctx).Do()
+	if err == nil {
+		t.Fatalf("SetIamPolicy with a stale etag should have failed")
+	}
+
+	var gErr *googleapi.Error
+	if !errors.As(err, &gErr) {
+		t.Fatalf("expected a googleapi.Error, got %T: %v", err, err)
+	}
+
+	if gErr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 Conflict, got %d: %v", gErr.Code, gErr)
+	}
+
+	final, err := svc.Projects.Subscriptions.GetIamPolicy(res).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("GetIamPolicy (final): %v", err)
+	}
+
+	if len(final.Bindings) != 1 || final.Bindings[0].Members[0] != "user:winner@example.com" {
+		t.Fatalf("winning writer's binding should be intact: %+v", final.Bindings)
+	}
+}
+
+// concurrentSetIAMWriters is how many goroutines race to setIamPolicy from
+// the same starting etag in the concurrency tests below.
+const concurrentSetIAMWriters = 10
+
+// TestSDKPubSubTopicIAMPolicyConcurrentSetIsAtomic proves the etag
+// precondition check and the write happen atomically: N goroutines all
+// submit a setIamPolicy built from the SAME starting etag (each with its own
+// distinct binding, replacing the whole policy). A separate
+// read-etag-then-write pair would let every one of them pass the check
+// before any of them writes, silently losing all but the last write applied;
+// the atomic compare-and-set must let exactly one of them win and every
+// loser must see a 409.
+func TestSDKPubSubTopicIAMPolicyConcurrentSetIsAtomic(t *testing.T) {
+	ctx := context.Background()
+
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{PubSub: cloudP.PubSub})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := pubsubv1.NewService(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	const topicName = "projects/demo/topics/etag-concurrent"
+
+	mustTopic(t, svc, topicName)
+
+	initial, err := svc.Projects.Topics.GetIamPolicy(topicName).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("GetIamPolicy (initial): %v", err)
+	}
+
+	etag0 := initial.Etag
+	iamURL := ts.URL + "/v1/" + topicName + ":setIamPolicy"
+
+	statuses := make([]int, concurrentSetIAMWriters)
+
+	var wg sync.WaitGroup
+
+	for i := range concurrentSetIAMWriters {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			member := fmt.Sprintf("user:writer-%d@example.com", i)
+			body := fmt.Sprintf(
+				`{"policy":{"bindings":[{"role":"roles/pubsub.viewer","members":["%s"]}],"etag":%q}}`,
+				member, etag0,
+			)
+
+			req, rErr := http.NewRequestWithContext(ctx, http.MethodPost, iamURL, strings.NewReader(body))
+			if rErr != nil {
+				t.Errorf("writer %d: NewRequest: %v", i, rErr)
+				return
+			}
+
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, dErr := ts.Client().Do(req)
+			if dErr != nil {
+				t.Errorf("writer %d: Do: %v", i, dErr)
+				return
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			statuses[i] = resp.StatusCode
+		}(i)
+	}
+
+	wg.Wait()
+
+	successes := 0
+
+	for i, code := range statuses {
+		switch code {
+		case http.StatusOK:
+			successes++
+		case http.StatusConflict:
+			// expected for every loser
+		default:
+			t.Errorf("writer %d: unexpected status %d", i, code)
+		}
+	}
+
+	if successes != 1 {
+		t.Fatalf("expected exactly 1 of %d concurrent setIamPolicy calls from the same etag to "+
+			"succeed, got %d — a lost update slipped through the TOCTOU window", concurrentSetIAMWriters, successes)
+	}
+
+	final, err := svc.Projects.Topics.GetIamPolicy(topicName).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("GetIamPolicy (final): %v", err)
+	}
+
+	if len(final.Bindings) != 1 {
+		t.Fatalf("expected exactly the single winning binding to persist, got %v", final.Bindings)
+	}
+}


### PR DESCRIPTION
## Summary

- Pub/Sub topic/subscription `setIamPolicy` ignored the request policy's etag entirely — it minted a fresh etag on every write and let a stale-etag write silently clobber a concurrent change (a lost update). `getIamPolicy` also minted a new etag on every call for an unset policy, so a client couldn't reliably read-modify-write against one.
- Mirrors the `CompareAndSetBucketIAMPolicy` fix from #1014 for GCS bucket IAM: the etag check and the write now happen atomically under a single `h.mu.Lock()` (no separate read-then-write, no TOCTOU window). A non-empty, mismatched etag is rejected with 409 ABORTED; an empty etag is an unconditional write, matching real Pub/Sub semantics.
- Unset policies now report a stable default etag (same protobuf-field-1-varint base64 encoding GCS's bucket IAM etag uses), minted deterministically instead of from an incrementing counter.

## Test plan

- [x] `TestSDKPubSubTopicIAMPolicyEtagRoundTrips` — unset-policy etag is stable across repeat reads, and each `setIamPolicy` advances it
- [x] `TestSDKPubSubTopicIAMPolicyStaleEtagRejected` / `TestSDKPubSubSubscriptionIAMPolicyStaleEtagRejected` — a stale-etag write is rejected with 409 and the winning writer's binding is left intact
- [x] `TestSDKPubSubTopicIAMPolicyConcurrentSetIsAtomic` — 10 goroutines racing `setIamPolicy` from the same starting etag: exactly 1 succeeds, run with `-race -count=20`
- [x] `go build ./...`, `go test ./providers/gcp/... ./server/gcp/... ./persist/... -race`, `golangci-lint run` (0 new issues), `go generate ./...` (docs/coverage clean), `go mod tidy` (no changes)