### PR TITLE
feat(secretsmanager): rotation configuration lifecycle

### DIFF
--- a/providers/aws/secretsmanager/secretsmanager.go
+++ b/providers/aws/secretsmanager/secretsmanager.go
@@ -34,7 +34,25 @@ type secretData struct {
 	// resourcePolicy is the JSON resource-based policy attached to the secret
 	// (PutResourcePolicy); empty when none is set.
 	resourcePolicy string
-	mu             sync.RWMutex
+	// rotationEnabled mirrors DescribeSecret's RotationEnabled: set true by
+	// RotateSecret, cleared by CancelRotateSecret. The configured
+	// rotationLambdaARN/rotationRules are left in place across a cancel, matching
+	// real Secrets Manager, so a later RotateSecret can re-enable rotation
+	// without re-supplying them.
+	rotationEnabled bool
+	// rotationLambdaARN is the Lambda function ARN configured via RotateSecret.
+	// The emulator does not invoke it (no rotation Lambda runtime); it is stored
+	// and echoed for DescribeSecret/ListSecrets parity.
+	rotationLambdaARN string
+	rotationRules     driver.SecretRotationRules
+	// rotationConfiguredAt is the time rotation was last (re)configured, the
+	// NextRotationDate baseline before any rotation has actually run.
+	rotationConfiguredAt time.Time
+	// lastRotatedDate is the time RotateSecret last actually advanced the
+	// version (zero when the secret has never been rotated, including when
+	// rotation was only configured with RotateImmediately=false).
+	lastRotatedDate time.Time
+	mu              sync.RWMutex
 }
 
 // DeleteSecret recovery-window bounds, matching the real service.

--- a/providers/aws/secretsmanager/snapshot.go
+++ b/providers/aws/secretsmanager/snapshot.go
@@ -30,6 +30,13 @@ type secretSnapshot struct {
 	// ResourcePolicy is the JSON resource-based policy attached to the secret,
 	// preserved across snapshot/restore.
 	ResourcePolicy string `json:"resourcePolicy,omitempty"`
+	// Rotation* preserve the RotateSecret/CancelRotateSecret configuration
+	// across snapshot/restore.
+	RotationEnabled      bool                       `json:"rotationEnabled,omitempty"`
+	RotationLambdaARN    string                     `json:"rotationLambdaARN,omitempty"`
+	RotationRules        driver.SecretRotationRules `json:"rotationRules,omitempty"`
+	RotationConfiguredAt time.Time                  `json:"rotationConfiguredAt,omitempty"`
+	LastRotatedDate      time.Time                  `json:"lastRotatedDate,omitempty"`
 }
 
 // Snapshot captures every secret's full state as JSON. includeAssets is unused —
@@ -41,12 +48,17 @@ func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
 	for name, sd := range m.secrets.All() {
 		sd.mu.RLock()
 		snap.Secrets[name] = &secretSnapshot{
-			Info:           sd.info,
-			Versions:       sd.versions,
-			Stages:         sd.stages,
-			DeletedAt:      sd.deletedAt,
-			RecoveryWindow: sd.recoveryWindow,
-			ResourcePolicy: sd.resourcePolicy,
+			Info:                 sd.info,
+			Versions:             sd.versions,
+			Stages:               sd.stages,
+			DeletedAt:            sd.deletedAt,
+			RecoveryWindow:       sd.recoveryWindow,
+			ResourcePolicy:       sd.resourcePolicy,
+			RotationEnabled:      sd.rotationEnabled,
+			RotationLambdaARN:    sd.rotationLambdaARN,
+			RotationRules:        sd.rotationRules,
+			RotationConfiguredAt: sd.rotationConfiguredAt,
+			LastRotatedDate:      sd.lastRotatedDate,
 		}
 		sd.mu.RUnlock()
 	}
@@ -64,12 +76,17 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 
 	for name, ss := range snap.Secrets {
 		m.secrets.Set(name, &secretData{
-			info:           ss.Info,
-			versions:       ss.Versions,
-			stages:         ss.Stages,
-			deletedAt:      ss.DeletedAt,
-			recoveryWindow: ss.RecoveryWindow,
-			resourcePolicy: ss.ResourcePolicy,
+			info:                 ss.Info,
+			versions:             ss.Versions,
+			stages:               ss.Stages,
+			deletedAt:            ss.DeletedAt,
+			recoveryWindow:       ss.RecoveryWindow,
+			resourcePolicy:       ss.ResourcePolicy,
+			rotationEnabled:      ss.RotationEnabled,
+			rotationLambdaARN:    ss.RotationLambdaARN,
+			rotationRules:        ss.RotationRules,
+			rotationConfiguredAt: ss.RotationConfiguredAt,
+			lastRotatedDate:      ss.LastRotatedDate,
 		})
 	}
 

--- a/providers/aws/secretsmanager/staging.go
+++ b/providers/aws/secretsmanager/staging.go
@@ -337,11 +337,21 @@ func (m *Mock) RestoreSecret(_ context.Context, name string) (*driver.SecretInfo
 	return &result, nil
 }
 
-// RotateSecret rotates a secret by staging a new current version. Real rotation
-// invokes a Lambda to generate the new value; with no Lambda, the emulator
-// carries the current value forward under a fresh version ID so callers see the
-// version advance and AWSPREVIOUS move as they would in production.
-func (m *Mock) RotateSecret(_ context.Context, name string) (*driver.SecretVersion, error) {
+// RotateSecret configures and (by default) runs a rotation. A non-empty
+// rotationLambdaARN or non-zero rules replaces the secret's stored
+// configuration (an empty/zero argument leaves the existing configuration
+// untouched, matching RotateSecret's "reuse the last configured value"
+// semantics); the call always leaves rotation enabled. With rotateImmediately
+// true (the real service's default), a new version is appended carrying the
+// current value forward — real rotation invokes a Lambda to generate the new
+// value; with no Lambda runtime, the emulator carries the value forward
+// unchanged so callers still see the version advance and AWSPREVIOUS move as
+// they would in production. With rotateImmediately false, only the
+// configuration is stored and the version set is untouched, mirroring a
+// schedule-only configure call.
+func (m *Mock) RotateSecret(
+	_ context.Context, name, rotationLambdaARN string, rules driver.SecretRotationRules, rotateImmediately bool,
+) (*driver.SecretVersion, error) {
 	sd, ok := m.secrets.Get(name)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
@@ -355,29 +365,118 @@ func (m *Mock) RotateSecret(_ context.Context, name string) (*driver.SecretVersi
 			"secret is scheduled for deletion, so this operation is not allowed")
 	}
 
+	now := m.opts.Clock.Now().UTC()
+	sd.applyRotationConfig(rotationLambdaARN, rules, now)
+
 	curID, ok := sd.stages[stageCurrent]
 	if !ok {
 		return nil, errors.Newf(errors.FailedPrecondition, "secret %q has no current version to rotate", name)
 	}
 
 	cur, _ := sd.versionByID(curID)
+
+	if !rotateImmediately {
+		return copyVersion(cur), nil
+	}
+
 	data := make([]byte, len(cur.Value))
 	copy(data, cur.Value)
 
-	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
+	nowStr := now.Format(time.RFC3339)
 	versionID := idgen.UUID()
 	sd.versions = append(sd.versions, driver.SecretVersion{
 		VersionID: versionID,
 		Value:     data,
-		CreatedAt: now,
+		CreatedAt: nowStr,
 		Binary:    cur.Binary,
 	})
 	sd.promoteToCurrent(versionID)
-	sd.info.UpdatedAt = now
+	sd.info.UpdatedAt = nowStr
+	sd.lastRotatedDate = now
 
 	result, _ := sd.versionByID(versionID)
 
 	return copyVersion(result), nil
+}
+
+// applyRotationConfig stores the lambda ARN / schedule rules a RotateSecret
+// call configures and marks rotation enabled. An empty rotationLambdaARN or
+// zero-value rules leaves the corresponding existing configuration in place,
+// so a caller re-triggering rotation need not re-supply it. now becomes the
+// NextRotationDate baseline until an actual rotation runs.
+func (sd *secretData) applyRotationConfig(rotationLambdaARN string, rules driver.SecretRotationRules, now time.Time) {
+	if rotationLambdaARN != "" {
+		sd.rotationLambdaARN = rotationLambdaARN
+	}
+
+	if rules != (driver.SecretRotationRules{}) {
+		sd.rotationRules = rules
+	}
+
+	sd.rotationEnabled = true
+	sd.rotationConfiguredAt = now
+}
+
+// CancelRotateSecret turns off automatic rotation. It leaves any configured
+// rotationLambdaARN/rotationRules in place, matching real Secrets Manager,
+// so a later RotateSecret call can re-enable rotation without re-supplying
+// them. It returns the secret's metadata and its current version id, the
+// pair CancelRotateSecretOutput echoes.
+func (m *Mock) CancelRotateSecret(_ context.Context, name string) (*driver.SecretInfo, string, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, "", errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if !sd.deletedAt.IsZero() {
+		return nil, "", errors.New(errors.FailedPrecondition,
+			"secret is scheduled for deletion, so this operation is not allowed")
+	}
+
+	sd.rotationEnabled = false
+
+	info := sd.info
+	versionID := sd.stages[stageCurrent]
+
+	return &info, versionID, nil
+}
+
+// SecretRotationDetails returns a secret's rotation configuration for
+// DescribeSecret/ListSecrets. NextRotationDate is derived from
+// AutomaticallyAfterDays and the more recent of LastRotatedDate or the time
+// rotation was configured; it is empty when AutomaticallyAfterDays is unset.
+func (m *Mock) SecretRotationDetails(_ context.Context, name string) (*driver.SecretRotationInfo, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	info := &driver.SecretRotationInfo{
+		Enabled:   sd.rotationEnabled,
+		LambdaARN: sd.rotationLambdaARN,
+		Rules:     sd.rotationRules,
+	}
+
+	if !sd.lastRotatedDate.IsZero() {
+		info.LastRotatedDate = sd.lastRotatedDate.Format(time.RFC3339)
+	}
+
+	if sd.rotationRules.AutomaticallyAfterDays > 0 && !sd.rotationConfiguredAt.IsZero() {
+		base := sd.rotationConfiguredAt
+		if !sd.lastRotatedDate.IsZero() {
+			base = sd.lastRotatedDate
+		}
+
+		info.NextRotationDate = base.AddDate(0, 0, int(sd.rotationRules.AutomaticallyAfterDays)).Format(time.RFC3339)
+	}
+
+	return info, nil
 }
 
 func copyVersion(v *driver.SecretVersion) *driver.SecretVersion {

--- a/providers/aws/secretsmanager/staging_test.go
+++ b/providers/aws/secretsmanager/staging_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -122,6 +123,103 @@ func TestUpdateSecretReturnsVersionID(t *testing.T) {
 	assert.Empty(t, verID2, "no value change must not create a version")
 }
 
+// TestRotateSecretConfiguresAndRotates verifies RotateSecret stores the
+// lambda ARN/rules, enables rotation, and (RotateImmediately=true) advances
+// the version and stamps LastRotatedDate/NextRotationDate.
+func TestRotateSecretConfiguresAndRotates(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	createTestSecret(t, m, "s", "v1")
+
+	rules := driver.SecretRotationRules{AutomaticallyAfterDays: 30}
+
+	ver, err := m.RotateSecret(ctx, "s", "arn:aws:lambda:us-east-1:123456789012:function:rotate", rules, true)
+	require.NoError(t, err)
+	assert.NotEmpty(t, ver.VersionID)
+
+	details, err := m.SecretRotationDetails(ctx, "s")
+	require.NoError(t, err)
+	assert.True(t, details.Enabled)
+	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:rotate", details.LambdaARN)
+	assert.Equal(t, rules, details.Rules)
+	assert.NotEmpty(t, details.LastRotatedDate)
+	assert.NotEmpty(t, details.NextRotationDate)
+
+	cur, err := m.GetSecretValueStage(ctx, "s", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, ver.VersionID, cur.VersionID)
+}
+
+// TestRotateSecretImmediateFalseConfiguresOnly verifies RotateImmediately=false
+// enables rotation and stores the config without advancing the version.
+func TestRotateSecretImmediateFalseConfiguresOnly(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	createTestSecret(t, m, "s", "v1")
+
+	cur, err := m.GetSecretValueStage(ctx, "s", "", "")
+	require.NoError(t, err)
+
+	ver, err := m.RotateSecret(ctx, "s", "arn:aws:lambda:us-east-1:123456789012:function:rotate",
+		driver.SecretRotationRules{}, false)
+	require.NoError(t, err)
+	assert.Equal(t, cur.VersionID, ver.VersionID, "RotateImmediately=false must not advance the version")
+
+	details, err := m.SecretRotationDetails(ctx, "s")
+	require.NoError(t, err)
+	assert.True(t, details.Enabled)
+	assert.Empty(t, details.LastRotatedDate, "no rotation ran, so LastRotatedDate must stay unset")
+}
+
+// TestRotateSecretReusesConfiguredLambda verifies a second RotateSecret call
+// with no lambda ARN keeps the previously configured one.
+func TestRotateSecretReusesConfiguredLambda(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	createTestSecret(t, m, "s", "v1")
+
+	_, err := m.RotateSecret(ctx, "s", "arn:aws:lambda:us-east-1:123456789012:function:rotate",
+		driver.SecretRotationRules{}, true)
+	require.NoError(t, err)
+
+	_, err = m.RotateSecret(ctx, "s", "", driver.SecretRotationRules{}, true)
+	require.NoError(t, err)
+
+	details, err := m.SecretRotationDetails(ctx, "s")
+	require.NoError(t, err)
+	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:rotate", details.LambdaARN)
+}
+
+// TestCancelRotateSecret verifies CancelRotateSecret disables rotation while
+// keeping the configured lambda ARN in place.
+func TestCancelRotateSecret(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	createTestSecret(t, m, "s", "v1")
+
+	_, err := m.RotateSecret(ctx, "s", "arn:aws:lambda:us-east-1:123456789012:function:rotate",
+		driver.SecretRotationRules{}, true)
+	require.NoError(t, err)
+
+	cur, err := m.GetSecretValueStage(ctx, "s", "", "")
+	require.NoError(t, err)
+
+	info, versionID, err := m.CancelRotateSecret(ctx, "s")
+	require.NoError(t, err)
+	assert.Equal(t, "s", info.Name)
+	assert.Equal(t, cur.VersionID, versionID)
+
+	details, err := m.SecretRotationDetails(ctx, "s")
+	require.NoError(t, err)
+	assert.False(t, details.Enabled)
+	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:rotate", details.LambdaARN,
+		"cancel must not clear the configured lambda ARN")
+}
+
 // TestSnapshotRestoreStages verifies staging labels survive snapshot/restore.
 func TestSnapshotRestoreStages(t *testing.T) {
 	m := newTestMock()
@@ -148,4 +246,32 @@ func TestSnapshotRestoreStages(t *testing.T) {
 	cur, err := restored.GetSecretValueStage(ctx, "s", "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "v2", string(cur.Value))
+}
+
+// TestSnapshotRestoreRotationConfig verifies rotation configuration survives
+// snapshot/restore.
+func TestSnapshotRestoreRotationConfig(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	createTestSecret(t, m, "s", "v1")
+
+	rules := driver.SecretRotationRules{AutomaticallyAfterDays: 14}
+
+	_, err := m.RotateSecret(ctx, "s", "arn:aws:lambda:us-east-1:123456789012:function:rotate", rules, true)
+	require.NoError(t, err)
+
+	data, err := m.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	restored := newTestMock()
+	require.NoError(t, restored.Restore(ctx, data))
+
+	before, err := m.SecretRotationDetails(ctx, "s")
+	require.NoError(t, err)
+
+	after, err := restored.SecretRotationDetails(ctx, "s")
+	require.NoError(t, err)
+
+	assert.Equal(t, before, after)
 }

--- a/server/aws/secretsmanager/handler.go
+++ b/server/aws/secretsmanager/handler.go
@@ -38,11 +38,15 @@ type secretStager interface {
 	SecretVersionStages(ctx context.Context, name string) (map[string][]string, error)
 	SecretDeletionDate(ctx context.Context, name string) (string, bool)
 	SecretMetadata(ctx context.Context, name string) (*secretsdriver.SecretInfo, error)
+	SecretRotationDetails(ctx context.Context, name string) (*secretsdriver.SecretRotationInfo, error)
 	DeleteSecretWithOptions(
 		ctx context.Context, name string, recoveryWindow *int64, force bool,
 	) (*secretsdriver.SecretInfo, string, error)
 	RestoreSecret(ctx context.Context, name string) (*secretsdriver.SecretInfo, error)
-	RotateSecret(ctx context.Context, name string) (*secretsdriver.SecretVersion, error)
+	RotateSecret(
+		ctx context.Context, name, rotationLambdaARN string, rules secretsdriver.SecretRotationRules, rotateImmediately bool,
+	) (*secretsdriver.SecretVersion, error)
+	CancelRotateSecret(ctx context.Context, name string) (*secretsdriver.SecretInfo, string, error)
 	PutSecretValueStaged(
 		ctx context.Context, name string, value []byte, clientRequestToken string, versionStages []string,
 	) (*secretsdriver.SecretVersion, error)
@@ -86,6 +90,7 @@ func New(s secretsdriver.Secrets) *Handler {
 		"UpdateSecretVersionStage": h.updateSecretVersionStage,
 		"RestoreSecret":            h.restoreSecret,
 		"RotateSecret":             h.rotateSecret,
+		"CancelRotateSecret":       h.cancelRotateSecret,
 		"GetRandomPassword":        h.getRandomPassword,
 		"TagResource":              h.tagResource,
 		"UntagResource":            h.untagResource,

--- a/server/aws/secretsmanager/lifecycle_test.go
+++ b/server/aws/secretsmanager/lifecycle_test.go
@@ -182,6 +182,141 @@ func TestSDKRotateSecret(t *testing.T) {
 	}
 }
 
+// TestSDKRotateSecretConfig guards RotateSecret storing RotationLambdaARN and
+// RotationRules and DescribeSecret echoing RotationEnabled/LastRotatedDate.
+func TestSDKRotateSecretConfig(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("rotconfig"), SecretString: aws.String("v"),
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	lambdaARN := "arn:aws:lambda:us-east-1:123456789012:function:rotate"
+
+	if _, err := client.RotateSecret(ctx, &awssm.RotateSecretInput{
+		SecretId:          aws.String("rotconfig"),
+		RotationLambdaARN: aws.String(lambdaARN),
+		RotationRules:     &smtypes.RotationRulesType{AutomaticallyAfterDays: aws.Int64(30)},
+		RotateImmediately: aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("RotateSecret: %v", err)
+	}
+
+	desc, err := client.DescribeSecret(ctx, &awssm.DescribeSecretInput{SecretId: aws.String("rotconfig")})
+	if err != nil {
+		t.Fatalf("DescribeSecret: %v", err)
+	}
+
+	if !aws.ToBool(desc.RotationEnabled) {
+		t.Fatal("RotationEnabled = false, want true after RotateSecret")
+	}
+
+	if aws.ToString(desc.RotationLambdaARN) != lambdaARN {
+		t.Fatalf("RotationLambdaARN = %q, want %q", aws.ToString(desc.RotationLambdaARN), lambdaARN)
+	}
+
+	if desc.RotationRules == nil || aws.ToInt64(desc.RotationRules.AutomaticallyAfterDays) != 30 {
+		t.Fatalf("RotationRules = %+v, want AutomaticallyAfterDays=30", desc.RotationRules)
+	}
+
+	if desc.LastRotatedDate == nil {
+		t.Fatal("LastRotatedDate is nil after an immediate rotation")
+	}
+
+	if desc.NextRotationDate == nil {
+		t.Fatal("NextRotationDate is nil with AutomaticallyAfterDays set")
+	}
+}
+
+// TestSDKRotateSecretDeferred guards RotateImmediately=false configuring
+// rotation without advancing the version.
+func TestSDKRotateSecretDeferred(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("rotdeferred"), SecretString: aws.String("v"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	rot, err := client.RotateSecret(ctx, &awssm.RotateSecretInput{
+		SecretId:          aws.String("rotdeferred"),
+		RotationLambdaARN: aws.String("arn:aws:lambda:us-east-1:123456789012:function:rotate"),
+		RotateImmediately: aws.Bool(false),
+	})
+	if err != nil {
+		t.Fatalf("RotateSecret: %v", err)
+	}
+
+	if aws.ToString(rot.VersionId) != aws.ToString(created.VersionId) {
+		t.Fatal("RotateImmediately=false must not advance the version")
+	}
+
+	desc, err := client.DescribeSecret(ctx, &awssm.DescribeSecretInput{SecretId: aws.String("rotdeferred")})
+	if err != nil {
+		t.Fatalf("DescribeSecret: %v", err)
+	}
+
+	if !aws.ToBool(desc.RotationEnabled) {
+		t.Fatal("RotationEnabled = false, want true after a configure-only RotateSecret")
+	}
+
+	if desc.LastRotatedDate != nil {
+		t.Fatal("LastRotatedDate must stay unset when no rotation actually ran")
+	}
+}
+
+// TestSDKCancelRotateSecret guards CancelRotateSecret disabling rotation while
+// keeping the configured lambda ARN, and rejecting an unknown secret.
+func TestSDKCancelRotateSecret(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("rotcancel"), SecretString: aws.String("v"),
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	lambdaARN := "arn:aws:lambda:us-east-1:123456789012:function:rotate"
+
+	if _, err := client.RotateSecret(ctx, &awssm.RotateSecretInput{
+		SecretId: aws.String("rotcancel"), RotationLambdaARN: aws.String(lambdaARN), RotateImmediately: aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("RotateSecret: %v", err)
+	}
+
+	if _, err := client.CancelRotateSecret(ctx, &awssm.CancelRotateSecretInput{
+		SecretId: aws.String("rotcancel"),
+	}); err != nil {
+		t.Fatalf("CancelRotateSecret: %v", err)
+	}
+
+	desc, err := client.DescribeSecret(ctx, &awssm.DescribeSecretInput{SecretId: aws.String("rotcancel")})
+	if err != nil {
+		t.Fatalf("DescribeSecret: %v", err)
+	}
+
+	if aws.ToBool(desc.RotationEnabled) {
+		t.Fatal("RotationEnabled = true after CancelRotateSecret, want false")
+	}
+
+	if aws.ToString(desc.RotationLambdaARN) != lambdaARN {
+		t.Fatal("CancelRotateSecret must not clear the configured RotationLambdaARN")
+	}
+
+	if _, err := client.CancelRotateSecret(ctx, &awssm.CancelRotateSecretInput{
+		SecretId: aws.String("does-not-exist"),
+	}); err == nil {
+		t.Fatal("CancelRotateSecret on an unknown secret: want error, got nil")
+	}
+}
+
 // TestSDKGetRandomPassword guards GetRandomPassword being dispatched.
 func TestSDKGetRandomPassword(t *testing.T) {
 	client := newSecretsClient(t)

--- a/server/aws/secretsmanager/operations.go
+++ b/server/aws/secretsmanager/operations.go
@@ -125,6 +125,10 @@ func (h *Handler) describeSecret(w http.ResponseWriter, r *http.Request) {
 		if date, deleted := st.SecretDeletionDate(r.Context(), name); deleted {
 			out.DeletedDate = epochSeconds(date)
 		}
+
+		if rot, rerr := st.SecretRotationDetails(r.Context(), name); rerr == nil {
+			applyRotationInfo(&out, rot)
+		}
 	}
 
 	wire.WriteJSON(w, out)
@@ -168,7 +172,7 @@ func (h *Handler) rotateSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req secretIDRequest
+	var req rotateSecretRequest
 	if !wire.DecodeJSON(w, r, &req) {
 		return
 	}
@@ -181,13 +185,44 @@ func (h *Handler) rotateSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ver, err := st.RotateSecret(r.Context(), name)
+	// RotateImmediately defaults to true, matching the real service: an absent
+	// field runs the rotation now rather than only storing the schedule.
+	rotateImmediately := true
+	if req.RotateImmediately != nil {
+		rotateImmediately = *req.RotateImmediately
+	}
+
+	ver, err := st.RotateSecret(r.Context(), name, req.RotationLambdaARN, req.RotationRules.toDriver(), rotateImmediately)
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
 	wire.WriteJSON(w, rotateSecretResponse{ARN: info.ResourceID, Name: info.Name, VersionID: ver.VersionID})
+}
+
+// cancelRotateSecret turns off automatic rotation. The configured
+// RotationLambdaARN/RotationRules are left in place, so a later RotateSecret
+// can re-enable rotation without re-supplying them.
+func (h *Handler) cancelRotateSecret(w http.ResponseWriter, r *http.Request) {
+	st, ok := h.secrets.(secretStager)
+	if !ok {
+		writeErr(w, errNotSupported)
+		return
+	}
+
+	var req secretIDRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	info, versionID, err := st.CancelRotateSecret(r.Context(), resolveSecretID(req.SecretID))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, rotateSecretResponse{ARN: info.ResourceID, Name: info.Name, VersionID: versionID})
 }
 
 func (*Handler) getRandomPassword(w http.ResponseWriter, r *http.Request) {
@@ -234,9 +269,20 @@ func (h *Handler) listSecrets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	st, isStager := h.secrets.(secretStager)
+
 	entries := make([]secretListEntryJSON, 0, end-start)
+
 	for i := start; i < end; i++ {
-		entries = append(entries, toSecretListEntry(&filtered[i]))
+		entry := toSecretListEntry(&filtered[i])
+
+		if isStager {
+			if rot, rerr := st.SecretRotationDetails(r.Context(), filtered[i].Name); rerr == nil {
+				applyRotationInfo(&entry, rot)
+			}
+		}
+
+		entries = append(entries, entry)
 	}
 
 	wire.WriteJSON(w, listSecretsResponse{SecretList: entries, NextToken: next})

--- a/server/aws/secretsmanager/types.go
+++ b/server/aws/secretsmanager/types.go
@@ -34,6 +34,51 @@ type secretListEntryJSON struct {
 	KmsKeyID string `json:"KmsKeyId,omitempty"`
 
 	VersionIDsToStages map[string][]string `json:"VersionIdsToStages,omitempty"`
+
+	// Rotation* mirror RotateSecret/CancelRotateSecret's configuration, echoed
+	// on both DescribeSecret and ListSecrets (real Secrets Manager exposes them
+	// on both).
+	RotationEnabled   bool               `json:"RotationEnabled,omitempty"`
+	RotationLambdaARN string             `json:"RotationLambdaARN,omitempty"`
+	RotationRules     *rotationRulesJSON `json:"RotationRules,omitempty"`
+	LastRotatedDate   float64            `json:"LastRotatedDate,omitempty"`
+	NextRotationDate  float64            `json:"NextRotationDate,omitempty"`
+}
+
+// rotationRulesJSON is the RotateSecret/DescribeSecret RotationRules shape.
+type rotationRulesJSON struct {
+	AutomaticallyAfterDays int64  `json:"AutomaticallyAfterDays,omitempty"`
+	Duration               string `json:"Duration,omitempty"`
+	ScheduleExpression     string `json:"ScheduleExpression,omitempty"`
+}
+
+// toDriver converts the wire rules to the driver's rotation-rules type. The
+// zero value round-trips to the driver's zero value, which RotateSecret reads
+// as "no rules supplied in this request".
+func (r rotationRulesJSON) toDriver() secretsdriver.SecretRotationRules {
+	return secretsdriver.SecretRotationRules{
+		AutomaticallyAfterDays: r.AutomaticallyAfterDays,
+		Duration:               r.Duration,
+		ScheduleExpression:     r.ScheduleExpression,
+	}
+}
+
+// applyRotationInfo copies a secret's rotation configuration onto a
+// DescribeSecret/ListSecrets entry.
+func applyRotationInfo(entry *secretListEntryJSON, info *secretsdriver.SecretRotationInfo) {
+	entry.RotationEnabled = info.Enabled
+	entry.RotationLambdaARN = info.LambdaARN
+
+	if info.Rules != (secretsdriver.SecretRotationRules{}) {
+		entry.RotationRules = &rotationRulesJSON{
+			AutomaticallyAfterDays: info.Rules.AutomaticallyAfterDays,
+			Duration:               info.Rules.Duration,
+			ScheduleExpression:     info.Rules.ScheduleExpression,
+		}
+	}
+
+	entry.LastRotatedDate = epochSeconds(info.LastRotatedDate)
+	entry.NextRotationDate = epochSeconds(info.NextRotationDate)
 }
 
 type versionJSON struct {
@@ -134,6 +179,17 @@ type tagResourceRequest struct {
 type untagResourceRequest struct {
 	SecretID string   `json:"SecretId"`
 	TagKeys  []string `json:"TagKeys"`
+}
+
+type rotateSecretRequest struct {
+	SecretID           string            `json:"SecretId"`
+	ClientRequestToken string            `json:"ClientRequestToken"`
+	RotationLambdaARN  string            `json:"RotationLambdaARN"`
+	RotationRules      rotationRulesJSON `json:"RotationRules"`
+	// RotateImmediately is a pointer so an absent field (nil, defaults to true)
+	// is distinguishable from an explicit false, which configures rotation
+	// without running it now.
+	RotateImmediately *bool `json:"RotateImmediately"`
 }
 
 type updateSecretResponse struct {

--- a/services/secrets/driver/driver.go
+++ b/services/secrets/driver/driver.go
@@ -118,6 +118,26 @@ type SecretVersion struct {
 	Etag string
 }
 
+// SecretRotationRules is the AWS Secrets Manager RotateSecret rotation-schedule
+// configuration (RotationRules on the wire). AutomaticallyAfterDays of 0 means
+// unset.
+type SecretRotationRules struct {
+	AutomaticallyAfterDays int64
+	Duration               string
+	ScheduleExpression     string
+}
+
+// SecretRotationInfo is a secret's AWS Secrets Manager rotation configuration,
+// echoed by DescribeSecret/ListSecrets. LastRotatedDate and NextRotationDate
+// are RFC3339, empty when not applicable.
+type SecretRotationInfo struct {
+	Enabled          bool
+	LambdaARN        string
+	Rules            SecretRotationRules
+	LastRotatedDate  string
+	NextRotationDate string
+}
+
 // Secrets is the interface that secret management provider implementations must satisfy.
 type Secrets interface {
 	CreateSecret(ctx context.Context, config SecretConfig, value []byte) (*SecretInfo, error)


### PR DESCRIPTION
## Summary

Secrets Manager already had thorough version staging (AWSCURRENT/AWSPREVIOUS/AWSPENDING), soft-delete/restore, resource policy, and KMS envelope encryption. The remaining gap was rotation configuration: `RotateSecret` didn't accept or persist `RotationLambdaARN`/`RotationRules`, `CancelRotateSecret` wasn't wired at all, and `DescribeSecret`/`ListSecrets` didn't echo any rotation state.

## What changed

- `RotateSecret` now accepts `RotationLambdaARN`, `RotationRules` (`AutomaticallyAfterDays`/`Duration`/`ScheduleExpression`), and `RotateImmediately`:
  - A non-empty ARN / non-zero rules replaces the stored configuration; an empty/zero argument reuses what's already configured (matching real RotateSecret's "reuse the last configured value" behavior).
  - The call always leaves rotation enabled.
  - `RotateImmediately=true` (default) advances the version, carrying the current value forward under a fresh version id (no Lambda runtime to generate a new value).
  - `RotateImmediately=false` only stores the configuration; the version set is untouched.
- New `CancelRotateSecret` operation: turns rotation off, leaving the configured lambda ARN/rules in place so a later `RotateSecret` can re-enable it without re-supplying them.
- `DescribeSecret`/`ListSecrets` now echo `RotationEnabled`, `RotationLambdaARN`, `RotationRules`, `LastRotatedDate`, and a computed `NextRotationDate` (derived from `AutomaticallyAfterDays` and the more recent of `LastRotatedDate` or when rotation was configured).
- Rotation configuration is Snapshottable (persists across snapshot/restore).

## Deferred

- Actual Lambda invocation during rotation — there's no Lambda runtime to call into; the value is carried forward unchanged instead.
- Real scheduled/background rotation — the emulator is synchronous, so `NextRotationDate` is computed but nothing actually fires on it.
- Cross-region replication (`ReplicateSecretToRegions`) and the resource-policy surface were already out of scope for this change (resource policy already existed; replication untouched).

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers/aws/secretsmanager/... ./server/aws/secretsmanager/... ./persist/... -race -count=1`
- [x] `go test ./providers/aws/... ./server/aws/...`
- [x] `gofmt -l` on touched files (clean)
- [x] `golangci-lint run` on touched packages (0 new issues)
- [x] `go generate ./...` + `git diff docs/coverage` (clean — no driver-interface change)
- [x] `go mod tidy` (no changes)