### PR TITLE
feat(gcp-secretmanager): version lifecycle + patch etag optimistic concurrency

### DIFF
--- a/providers/gcp/secretmanager/lifecycle.go
+++ b/providers/gcp/secretmanager/lifecycle.go
@@ -2,6 +2,7 @@ package secretmanager
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/errors"
@@ -28,10 +29,13 @@ func findVersion(sd *secretData, versionID string) (*driver.SecretVersion, bool)
 	return nil, false
 }
 
-// mutateVersion loads a live secret, locates a version, and applies fn to it
-// under the secret's write lock. It centralizes the not-found/deleted checks
-// shared by enable/disable/destroy.
-func (m *Mock) mutateVersion(name, versionID string,
+// mutateVersion loads a live secret, locates a version, checks its etag
+// precondition, and applies fn to it — all under the secret's write lock, so
+// the etag comparison and the mutation happen in one atomic step (a separate
+// check-then-write pair would let two concurrent callers starting from the
+// same etag both pass the check before either wrote). It centralizes the
+// not-found/precondition checks shared by enable/disable/destroy.
+func (m *Mock) mutateVersion(name, versionID, etag string,
 	fn func(v *driver.SecretVersion) error,
 ) (*driver.SecretVersion, error) {
 	sd, ok := m.secrets.Get(name)
@@ -47,6 +51,12 @@ func (m *Mock) mutateVersion(name, versionID string,
 		return nil, errors.Newf(errors.NotFound, "version %q not found for secret %q", versionID, name)
 	}
 
+	if etagMismatch(etag, v.Etag) {
+		return nil, &driver.GCPSecretPreconditionError{
+			Message: fmt.Sprintf("etag mismatch for version %q of secret %q", v.VersionID, name),
+		}
+	}
+
 	if err := fn(v); err != nil {
 		return nil, err
 	}
@@ -57,9 +67,16 @@ func (m *Mock) mutateVersion(name, versionID string,
 	return &result, nil
 }
 
+// etagMismatch reports whether a caller-supplied precondition etag is
+// non-empty and does not match the currently stored one. An empty etag always
+// skips the check, matching real GCP's leniency when the caller omits it.
+func etagMismatch(want, got string) bool {
+	return want != "" && want != got
+}
+
 // EnableSecretVersion moves a version to ENABLED.
-func (m *Mock) EnableSecretVersion(_ context.Context, name, versionID string) (*driver.SecretVersion, error) {
-	return m.mutateVersion(name, versionID, func(v *driver.SecretVersion) error {
+func (m *Mock) EnableSecretVersion(_ context.Context, name, versionID, etag string) (*driver.SecretVersion, error) {
+	return m.mutateVersion(name, versionID, etag, func(v *driver.SecretVersion) error {
 		if v.State == driver.VersionDestroyed {
 			return errors.Newf(errors.FailedPrecondition, "version %q is destroyed", versionID)
 		}
@@ -72,8 +89,8 @@ func (m *Mock) EnableSecretVersion(_ context.Context, name, versionID string) (*
 }
 
 // DisableSecretVersion moves a version to DISABLED.
-func (m *Mock) DisableSecretVersion(_ context.Context, name, versionID string) (*driver.SecretVersion, error) {
-	return m.mutateVersion(name, versionID, func(v *driver.SecretVersion) error {
+func (m *Mock) DisableSecretVersion(_ context.Context, name, versionID, etag string) (*driver.SecretVersion, error) {
+	return m.mutateVersion(name, versionID, etag, func(v *driver.SecretVersion) error {
 		if v.State == driver.VersionDestroyed {
 			return errors.Newf(errors.FailedPrecondition, "version %q is destroyed", versionID)
 		}
@@ -86,8 +103,8 @@ func (m *Mock) DisableSecretVersion(_ context.Context, name, versionID string) (
 }
 
 // DestroySecretVersion moves a version to DESTROYED, wiping its payload.
-func (m *Mock) DestroySecretVersion(_ context.Context, name, versionID string) (*driver.SecretVersion, error) {
-	return m.mutateVersion(name, versionID, func(v *driver.SecretVersion) error {
+func (m *Mock) DestroySecretVersion(_ context.Context, name, versionID, etag string) (*driver.SecretVersion, error) {
+	return m.mutateVersion(name, versionID, etag, func(v *driver.SecretVersion) error {
 		if v.State == driver.VersionDestroyed {
 			return errors.Newf(errors.FailedPrecondition, "version %q is already destroyed", versionID)
 		}
@@ -110,6 +127,10 @@ func (m *Mock) PatchSecret(_ context.Context, name string, patch driver.GCPSecre
 
 	sd.mu.Lock()
 	defer sd.mu.Unlock()
+
+	if etagMismatch(patch.Etag, sd.info.Etag) {
+		return nil, &driver.GCPSecretPreconditionError{Message: fmt.Sprintf("etag mismatch for secret %q", name)}
+	}
 
 	if patch.SetLabels {
 		sd.info.Tags = copyMap(patch.Labels)

--- a/providers/gcp/secretmanager/lifecycle_test.go
+++ b/providers/gcp/secretmanager/lifecycle_test.go
@@ -1,0 +1,184 @@
+package secretmanager
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionLifecycleStateMachine(t *testing.T) {
+	m := newTestMock()
+	info := createTestSecret(t, m, "state-secret", "v1")
+	ctx := context.Background()
+
+	versions, err := m.ListSecretVersions(ctx, info.Name)
+	require.NoError(t, err)
+	require.Len(t, versions, 1)
+
+	v1 := versions[0].VersionID
+	assert.Equal(t, driver.VersionEnabled, versions[0].State)
+
+	dis, err := m.DisableSecretVersion(ctx, info.Name, v1, "")
+	require.NoError(t, err)
+	assert.Equal(t, driver.VersionDisabled, dis.State)
+	assert.Nil(t, dis.Value, "lifecycle response carries metadata only")
+
+	_, err = m.GetSecretValue(ctx, info.Name, v1)
+	require.NoError(t, err, "GetSecretValue does not itself gate on state")
+
+	en, err := m.EnableSecretVersion(ctx, info.Name, v1, "")
+	require.NoError(t, err)
+	assert.Equal(t, driver.VersionEnabled, en.State)
+
+	des, err := m.DestroySecretVersion(ctx, info.Name, v1, "")
+	require.NoError(t, err)
+	assert.Equal(t, driver.VersionDestroyed, des.State)
+	assert.NotEmpty(t, des.DestroyTime)
+
+	// The payload is wiped in the store, not just the response.
+	got, err := m.GetSecretValue(ctx, info.Name, v1)
+	require.NoError(t, err)
+	assert.Empty(t, got.Value)
+}
+
+func TestVersionLifecycleDestroyedIsTerminal(t *testing.T) {
+	m := newTestMock()
+	info := createTestSecret(t, m, "terminal-secret", "v1")
+	ctx := context.Background()
+
+	versions, err := m.ListSecretVersions(ctx, info.Name)
+	require.NoError(t, err)
+	v1 := versions[0].VersionID
+
+	_, err = m.DestroySecretVersion(ctx, info.Name, v1, "")
+	require.NoError(t, err)
+
+	_, err = m.DestroySecretVersion(ctx, info.Name, v1, "")
+	require.Error(t, err)
+	assert.True(t, cerrors.IsFailedPrecondition(err))
+
+	_, err = m.DisableSecretVersion(ctx, info.Name, v1, "")
+	require.Error(t, err)
+	assert.True(t, cerrors.IsFailedPrecondition(err))
+
+	_, err = m.EnableSecretVersion(ctx, info.Name, v1, "")
+	require.Error(t, err)
+	assert.True(t, cerrors.IsFailedPrecondition(err))
+}
+
+func TestVersionLifecycleNotFound(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.DisableSecretVersion(ctx, "no-such-secret", "1", "")
+	require.Error(t, err)
+	assert.True(t, cerrors.IsNotFound(err))
+
+	createTestSecret(t, m, "vnf-secret", "v1")
+
+	_, err = m.DisableSecretVersion(ctx, "vnf-secret", "no-such-version", "")
+	require.Error(t, err)
+	assert.True(t, cerrors.IsNotFound(err))
+}
+
+// TestVersionLifecycleEtagPrecondition proves enable/disable/destroy honor an
+// optional etag precondition, checked atomically alongside the state
+// transition: a mismatched etag is rejected without applying the transition,
+// a matching etag succeeds and mints a fresh one, and an empty etag always
+// skips the check (real GCP's leniency when the caller omits it).
+func TestVersionLifecycleEtagPrecondition(t *testing.T) {
+	m := newTestMock()
+	info := createTestSecret(t, m, "etag-secret", "v1")
+	ctx := context.Background()
+
+	versions, err := m.ListSecretVersions(ctx, info.Name)
+	require.NoError(t, err)
+	v1 := versions[0]
+
+	_, err = m.DisableSecretVersion(ctx, info.Name, v1.VersionID, "stale-etag")
+	require.Error(t, err)
+
+	var preErr *driver.GCPSecretPreconditionError
+	require.True(t, errors.As(err, &preErr), "want a *GCPSecretPreconditionError, got %T", err)
+
+	// The mismatched call must not have applied the transition.
+	unchanged, err := m.ListSecretVersions(ctx, info.Name)
+	require.NoError(t, err)
+	assert.Equal(t, driver.VersionEnabled, unchanged[0].State)
+
+	dis, err := m.DisableSecretVersion(ctx, info.Name, v1.VersionID, v1.Etag)
+	require.NoError(t, err)
+	assert.Equal(t, driver.VersionDisabled, dis.State)
+	assert.NotEqual(t, v1.Etag, dis.Etag, "a successful transition mints a fresh etag")
+
+	// An empty etag always succeeds, regardless of the version's current one.
+	en, err := m.EnableSecretVersion(ctx, info.Name, v1.VersionID, "")
+	require.NoError(t, err)
+	assert.Equal(t, driver.VersionEnabled, en.State)
+}
+
+func TestPatchSecret(t *testing.T) {
+	m := newTestMock()
+	info := createTestSecret(t, m, "patch-secret", "v1")
+	ctx := context.Background()
+
+	updated, err := m.PatchSecret(ctx, info.Name, driver.GCPSecretPatch{
+		Labels:    map[string]string{"team": "platform"},
+		SetLabels: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "platform", updated.Tags["team"])
+	assert.NotEqual(t, info.Etag, updated.Etag, "a successful patch mints a fresh etag")
+}
+
+func TestPatchSecretNotFound(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.PatchSecret(context.Background(), "no-such-secret", driver.GCPSecretPatch{})
+	require.Error(t, err)
+	assert.True(t, cerrors.IsNotFound(err))
+}
+
+// TestPatchSecretEtagPrecondition proves secrets.patch honors an optional
+// etag precondition, independent of which fields the update mask names.
+func TestPatchSecretEtagPrecondition(t *testing.T) {
+	m := newTestMock()
+	info := createTestSecret(t, m, "patch-etag-secret", "v1")
+	ctx := context.Background()
+
+	_, err := m.PatchSecret(ctx, info.Name, driver.GCPSecretPatch{
+		Labels:    map[string]string{"team": "platform"},
+		SetLabels: true,
+		Etag:      "stale-etag",
+	})
+	require.Error(t, err)
+
+	var preErr *driver.GCPSecretPreconditionError
+	require.True(t, errors.As(err, &preErr), "want a *GCPSecretPreconditionError, got %T", err)
+
+	// The mismatched call must not have applied the patch.
+	unchanged, err := m.GetSecret(ctx, info.Name)
+	require.NoError(t, err)
+	assert.Empty(t, unchanged.Tags)
+
+	updated, err := m.PatchSecret(ctx, info.Name, driver.GCPSecretPatch{
+		Labels:    map[string]string{"team": "platform"},
+		SetLabels: true,
+		Etag:      info.Etag,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "platform", updated.Tags["team"])
+
+	// An empty etag always succeeds, regardless of the secret's current one.
+	final, err := m.PatchSecret(ctx, info.Name, driver.GCPSecretPatch{
+		Labels:    map[string]string{"team": "sre"},
+		SetLabels: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "sre", final.Tags["team"])
+}

--- a/server/gcp/secretmanager/handler.go
+++ b/server/gcp/secretmanager/handler.go
@@ -25,6 +25,12 @@
 // id; "latest" is accepted as a version alias, matching real Secret Manager. The
 // driver seeds an initial (empty) version on create, so a freshly created
 // secret carries one more version than the addVersion calls made against it.
+//
+// The version enable/disable/destroy verbs and secrets.patch each accept an
+// optional "etag" optimistic-concurrency precondition: a non-empty etag that
+// doesn't match the resource's currently stored one is rejected with 412
+// conditionNotMet and the request has no effect; an omitted etag always
+// succeeds.
 package secretmanager
 
 import (

--- a/server/gcp/secretmanager/lifecycle_sdk_test.go
+++ b/server/gcp/secretmanager/lifecycle_sdk_test.go
@@ -180,6 +180,72 @@ func TestSDKDestroyedVersionLifecycleIs400(t *testing.T) {
 	}
 }
 
+// TestSDKVersionLifecycleEtagPrecondition proves the enable/disable/destroy
+// verbs honor an optional etag precondition: a stale etag is rejected 412
+// conditionNotMet and leaves the version's state unchanged, the current etag
+// succeeds and mints a fresh one, and an omitted etag always succeeds (audit:
+// version lifecycle etag optimistic concurrency).
+func TestSDKVersionLifecycleEtagPrecondition(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+	name := mustCreateSecret(t, svc, "etag-lifecycle")
+
+	v1, err := svc.Projects.Secrets.AddVersion(name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{Data: encode("secret")},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("AddVersion: %v", err)
+	}
+
+	if v1.Etag == "" {
+		t.Fatal("version Etag empty, want an opaque tag")
+	}
+
+	// A stale etag is rejected 412 conditionNotMet and must not apply the
+	// transition.
+	_, err = svc.Projects.Secrets.Versions.Disable(v1.Name,
+		&sm.DisableSecretVersionRequest{Etag: "stale-etag"}).Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 412 {
+		t.Fatalf("Disable(stale etag): got %v, want 412 conditionNotMet", err)
+	}
+
+	meta, err := svc.Projects.Secrets.Versions.Get(v1.Name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if meta.State != "ENABLED" {
+		t.Fatalf("state after rejected Disable = %q, want ENABLED (unchanged)", meta.State)
+	}
+
+	// The matching current etag succeeds and mints a fresh etag.
+	dis, err := svc.Projects.Secrets.Versions.Disable(v1.Name,
+		&sm.DisableSecretVersionRequest{Etag: v1.Etag}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Disable(matching etag): %v", err)
+	}
+
+	if dis.State != "DISABLED" {
+		t.Fatalf("state after Disable = %q, want DISABLED", dis.State)
+	}
+
+	if dis.Etag == v1.Etag {
+		t.Fatal("etag unchanged after a successful Disable, want a fresh etag")
+	}
+
+	// An omitted etag always succeeds, regardless of the version's current one.
+	en, err := svc.Projects.Secrets.Versions.Enable(v1.Name, &sm.EnableSecretVersionRequest{}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Enable(no etag): %v", err)
+	}
+
+	if en.State != "ENABLED" {
+		t.Fatalf("state after Enable = %q, want ENABLED", en.State)
+	}
+}
+
 // TestSDKDeleteThenRecreateSameID proves GCP secrets.delete is a permanent hard
 // delete: Get 404s afterwards and the same secretId is creatable again with no
 // ALREADY_EXISTS (no recovery window).
@@ -229,6 +295,51 @@ func TestSDKSecretPatch(t *testing.T) {
 
 	if got.Labels["team"] != "platform" {
 		t.Fatalf("persisted labels = %v, want team=platform", got.Labels)
+	}
+}
+
+// TestSDKSecretPatchEtagPrecondition proves secrets.patch honors an optional
+// etag precondition, independent of the update mask (audit: Secrets.patch
+// etag optimistic concurrency).
+func TestSDKSecretPatchEtagPrecondition(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+	name := mustCreateSecret(t, svc, "etag-patch")
+
+	got, err := svc.Projects.Secrets.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	_, err = svc.Projects.Secrets.Patch(name, &sm.Secret{
+		Labels: map[string]string{"team": "platform"},
+		Etag:   "stale-etag",
+	}).UpdateMask("labels").Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 412 {
+		t.Fatalf("Patch(stale etag): got %v, want 412 conditionNotMet", err)
+	}
+
+	unchanged, err := svc.Projects.Secrets.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after rejected Patch: %v", err)
+	}
+
+	if len(unchanged.Labels) != 0 {
+		t.Fatalf("labels after rejected Patch = %v, want unchanged (empty)", unchanged.Labels)
+	}
+
+	updated, err := svc.Projects.Secrets.Patch(name, &sm.Secret{
+		Labels: map[string]string{"team": "platform"},
+		Etag:   got.Etag,
+	}).UpdateMask("labels").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Patch(matching etag): %v", err)
+	}
+
+	if updated.Labels["team"] != "platform" {
+		t.Fatalf("labels = %v, want team=platform", updated.Labels)
 	}
 }
 

--- a/server/gcp/secretmanager/lifecycle_sdk_test.go
+++ b/server/gcp/secretmanager/lifecycle_sdk_test.go
@@ -4,12 +4,42 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
 	sm "google.golang.org/api/secretmanager/v1"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
 )
+
+// newSMServiceRaw is like newSMService but also returns the server's base URL
+// so a test can bypass the SDK and issue a raw HTTP request — needed to
+// reproduce a truly empty request body, which google-api-go-client never
+// sends (it always marshals a zero-value request struct as "{}").
+func newSMServiceRaw(t *testing.T) (*sm.Service, string) {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{SecretManager: cloud.SecretManager})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := sm.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("secretmanager.NewService: %v", err)
+	}
+
+	return svc, ts.URL
+}
 
 // mustCreateSecret creates an empty (GCP-style) secret container.
 func mustCreateSecret(t *testing.T, svc *sm.Service, id string) string {
@@ -243,6 +273,76 @@ func TestSDKVersionLifecycleEtagPrecondition(t *testing.T) {
 
 	if en.State != "ENABLED" {
 		t.Fatalf("state after Enable = %q, want ENABLED", en.State)
+	}
+}
+
+// TestSDKVersionLifecycleEmptyBody proves the enable/disable/destroy verbs
+// succeed on a truly zero-byte request body (http.NoBody), not just the "{}"
+// google-api-go-client always marshals for a zero-value request struct — etag
+// is optional, and a raw HTTP client that never writes a body must still
+// reach the driver rather than 400 on an empty-body JSON decode.
+func TestSDKVersionLifecycleEmptyBody(t *testing.T) {
+	svc, baseURL := newSMServiceRaw(t)
+	ctx := context.Background()
+	name := mustCreateSecret(t, svc, "raw-empty-body")
+
+	v1, err := svc.Projects.Secrets.AddVersion(name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{Data: encode("secret")},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("AddVersion: %v", err)
+	}
+
+	rawPost := func(verb string) *http.Response {
+		t.Helper()
+
+		resp, perr := http.Post(baseURL+"/v1/"+v1.Name+":"+verb, "application/json", http.NoBody)
+		if perr != nil {
+			t.Fatalf("raw POST %s: %v", verb, perr)
+		}
+
+		t.Cleanup(func() { resp.Body.Close() })
+
+		return resp
+	}
+
+	if resp := rawPost("disable"); resp.StatusCode != http.StatusOK {
+		t.Fatalf("raw empty-body Disable: status = %d, want 200", resp.StatusCode)
+	}
+
+	meta, err := svc.Projects.Secrets.Versions.Get(v1.Name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if meta.State != "DISABLED" {
+		t.Fatalf("state after raw empty-body Disable = %q, want DISABLED", meta.State)
+	}
+
+	if resp := rawPost("enable"); resp.StatusCode != http.StatusOK {
+		t.Fatalf("raw empty-body Enable: status = %d, want 200", resp.StatusCode)
+	}
+
+	meta, err = svc.Projects.Secrets.Versions.Get(v1.Name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if meta.State != "ENABLED" {
+		t.Fatalf("state after raw empty-body Enable = %q, want ENABLED", meta.State)
+	}
+
+	if resp := rawPost("destroy"); resp.StatusCode != http.StatusOK {
+		t.Fatalf("raw empty-body Destroy: status = %d, want 200", resp.StatusCode)
+	}
+
+	meta, err = svc.Projects.Secrets.Versions.Get(v1.Name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if meta.State != "DESTROYED" {
+		t.Fatalf("state after raw empty-body Destroy = %q, want DESTROYED", meta.State)
 	}
 }
 

--- a/server/gcp/secretmanager/operations.go
+++ b/server/gcp/secretmanager/operations.go
@@ -1,8 +1,10 @@
 package secretmanager
 
 import (
+	"encoding/json"
 	"errors"
 	"hash/crc32"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -418,8 +420,14 @@ func (h *Handler) mutateVersion(w http.ResponseWriter, r *http.Request, rt route
 		return
 	}
 
+	// etag is optional on real Secret Manager's lifecycle verbs — an omitted
+	// field, and even a truly zero-byte body (some HTTP clients never write a
+	// "{}" the way google-api-go-client does), must still succeed. Unlike
+	// gcprest.DecodeJSON, this tolerates io.EOF instead of answering 400.
 	var req lifecycleVerbRequest
-	if !gcprest.DecodeJSON(w, r, &req) {
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, gcprest.MaxBodyBytes)).Decode(&req); err != nil &&
+		!errors.Is(err, io.EOF) {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "invalid JSON: "+err.Error())
 		return
 	}
 

--- a/server/gcp/secretmanager/operations.go
+++ b/server/gcp/secretmanager/operations.go
@@ -1,6 +1,7 @@
 package secretmanager
 
 import (
+	"errors"
 	"hash/crc32"
 	"net/http"
 	"strconv"
@@ -375,19 +376,50 @@ func (h *Handler) patchSecret(w http.ResponseWriter, r *http.Request, rt route) 
 		patch.SetExpireTime = true
 	}
 
+	patch.Etag = req.Etag
+
 	info, err := h.gcp.PatchSecret(r.Context(), rt.secret, patch)
 	if err != nil {
-		gcprest.WriteCErr(w, err)
+		writeSecretErr(w, err)
 		return
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, toSecretJSON(rt.project, info))
 }
 
+// writePreconditionErr writes GCP's 412 conditionNotMet response for a stale
+// etag precondition (matching GCS/Compute Engine's fingerprint convention
+// elsewhere in cloudemu) and reports whether err was one. The caller maps any
+// other error itself.
+func writePreconditionErr(w http.ResponseWriter, err error) bool {
+	var preErr *secretsdriver.GCPSecretPreconditionError
+	if !errors.As(err, &preErr) {
+		return false
+	}
+
+	gcprest.WriteError(w, http.StatusPreconditionFailed, "conditionNotMet", preErr.Error())
+
+	return true
+}
+
+// writeSecretErr maps a *secretsdriver.GCPSecretPreconditionError to GCP's
+// 412 conditionNotMet response and any other error through the shared
+// gcprest mapping.
+func writeSecretErr(w http.ResponseWriter, err error) {
+	if !writePreconditionErr(w, err) {
+		gcprest.WriteCErr(w, err)
+	}
+}
+
 // mutateVersion applies an enable/disable/destroy lifecycle verb to a version.
 func (h *Handler) mutateVersion(w http.ResponseWriter, r *http.Request, rt route, verb string) {
 	if h.gcp == nil {
 		writeUnsupported(w)
+		return
+	}
+
+	var req lifecycleVerbRequest
+	if !gcprest.DecodeJSON(w, r, &req) {
 		return
 	}
 
@@ -398,17 +430,21 @@ func (h *Handler) mutateVersion(w http.ResponseWriter, r *http.Request, rt route
 
 	switch verb {
 	case verbEnable:
-		ver, err = h.gcp.EnableSecretVersion(r.Context(), rt.secret, driverVersion(rt.version))
+		ver, err = h.gcp.EnableSecretVersion(r.Context(), rt.secret, driverVersion(rt.version), req.Etag)
 	case verbDisable:
-		ver, err = h.gcp.DisableSecretVersion(r.Context(), rt.secret, driverVersion(rt.version))
+		ver, err = h.gcp.DisableSecretVersion(r.Context(), rt.secret, driverVersion(rt.version), req.Etag)
 	case verbDestroy:
-		ver, err = h.gcp.DestroySecretVersion(r.Context(), rt.secret, driverVersion(rt.version))
+		ver, err = h.gcp.DestroySecretVersion(r.Context(), rt.secret, driverVersion(rt.version), req.Etag)
 	default:
 		writeUnsupported(w)
 		return
 	}
 
 	if err != nil {
+		if writePreconditionErr(w, err) {
+			return
+		}
+
 		// An illegal state transition (e.g. destroy/disable/enable on a DESTROYED
 		// version) is FAILED_PRECONDITION, which GCP reports as HTTP 400. The
 		// shared gcprest mapping would turn it into 409, so answer 400 locally

--- a/server/gcp/secretmanager/types.go
+++ b/server/gcp/secretmanager/types.go
@@ -96,7 +96,8 @@ type createSecretRequest struct {
 }
 
 // patchSecretRequest is the body of secrets.patch; the update mask names which
-// fields to apply.
+// fields to apply. Etag is a top-level optimistic-concurrency precondition —
+// not gated by the update mask — honored whenever the caller supplies one.
 type patchSecretRequest struct {
 	Labels         map[string]string `json:"labels"`
 	Annotations    map[string]string `json:"annotations"`
@@ -105,10 +106,17 @@ type patchSecretRequest struct {
 	Rotation       *rotationJSON     `json:"rotation"`
 	Topics         []topicJSON       `json:"topics"`
 	VersionAliases map[string]string `json:"versionAliases"`
+	Etag           string            `json:"etag"`
 }
 
 type addVersionRequest struct {
 	Payload payloadJSON `json:"payload"`
+}
+
+// lifecycleVerbRequest is the body of the version enable/disable/destroy
+// custom methods: an optional etag optimistic-concurrency precondition.
+type lifecycleVerbRequest struct {
+	Etag string `json:"etag"`
 }
 
 type accessResponse struct {

--- a/services/secrets/driver/driver.go
+++ b/services/secrets/driver/driver.go
@@ -162,6 +162,30 @@ type GCPSecretPatch struct {
 	ExpireTime    string
 	TTL           string
 	SetExpireTime bool
+
+	// Etag is the caller-supplied optimistic-concurrency precondition: when
+	// non-empty, the patch is only applied if it matches the secret's currently
+	// stored etag (real GCP's leniency — an empty Etag always skips the check).
+	Etag string
+}
+
+// GCPSecretPreconditionError signals a caller-supplied etag precondition (on a
+// version lifecycle verb or secrets.patch) that did not match the currently
+// stored resource's etag. Real Secret Manager answers 412 Precondition Failed
+// with reason "conditionNotMet", matching GCS/Compute Engine's fingerprint
+// convention elsewhere in cloudemu — which does NOT map to the canonical
+// FailedPrecondition→409 the gcprest default uses, so providers return this
+// typed error and the handler matches it with errors.As to emit the exact 412.
+type GCPSecretPreconditionError struct {
+	Message string
+}
+
+func (e *GCPSecretPreconditionError) Error() string {
+	if e.Message == "" {
+		return "conditionNotMet"
+	}
+
+	return e.Message
 }
 
 // GCPIAMBinding binds an IAM role to a set of members.
@@ -182,16 +206,24 @@ type GCPIAMPolicy struct {
 // providers need not model version lifecycle, secret patch, or IAM semantics.
 type GCPSecrets interface {
 	// EnableSecretVersion moves a version to ENABLED. It is idempotent on an
-	// already-enabled version and fails on a DESTROYED one.
-	EnableSecretVersion(ctx context.Context, name, versionID string) (*SecretVersion, error)
+	// already-enabled version and fails on a DESTROYED one. A non-empty etag
+	// must match the version's currently stored etag or the call fails with a
+	// *GCPSecretPreconditionError; an empty etag always succeeds.
+	EnableSecretVersion(ctx context.Context, name, versionID, etag string) (*SecretVersion, error)
 	// DisableSecretVersion moves a version to DISABLED. It fails on a DESTROYED
-	// version.
-	DisableSecretVersion(ctx context.Context, name, versionID string) (*SecretVersion, error)
+	// version. A non-empty etag must match the version's currently stored etag
+	// or the call fails with a *GCPSecretPreconditionError; an empty etag
+	// always succeeds.
+	DisableSecretVersion(ctx context.Context, name, versionID, etag string) (*SecretVersion, error)
 	// DestroySecretVersion moves a version to DESTROYED, wipes its payload, and
-	// stamps its destroyTime. It fails on an already-DESTROYED version.
-	DestroySecretVersion(ctx context.Context, name, versionID string) (*SecretVersion, error)
+	// stamps its destroyTime. It fails on an already-DESTROYED version. A
+	// non-empty etag must match the version's currently stored etag or the call
+	// fails with a *GCPSecretPreconditionError; an empty etag always succeeds.
+	DestroySecretVersion(ctx context.Context, name, versionID, etag string) (*SecretVersion, error)
 	// PatchSecret applies a partial update (labels, annotations, topics, version
-	// aliases, rotation, expiry) to a secret's metadata, honoring the update mask.
+	// aliases, rotation, expiry) to a secret's metadata, honoring the update
+	// mask. A non-empty patch.Etag must match the secret's currently stored
+	// etag or the call fails with a *GCPSecretPreconditionError.
 	PatchSecret(ctx context.Context, name string, patch GCPSecretPatch) (*SecretInfo, error)
 	// GetSecretIAMPolicy returns the secret's stored IAM policy (an empty
 	// versioned policy when none has been set).


### PR DESCRIPTION
## Summary

Deepens GCP Secret Manager toward real-cloud parity: `Versions.enable` / `Versions.disable` / `Versions.destroy` and `secrets.patch` now honor an optional `etag` optimistic-concurrency precondition (real Secret Manager's field on `EnableSecretVersionRequest` / `DisableSecretVersionRequest` / `DestroySecretVersionRequest` and the `Secret.etag` field on patch).

## Gap list (investigated before picking this)

Already present and correct: full version state machine (ENABLED/DISABLED/DESTROYED, `DestroySecretVersion` wipes payload + stamps `destroyTime`, illegal transitions on a DESTROYED version → 400 FAILED_PRECONDITION), `AccessSecretVersion` gating non-ENABLED versions, `latest` alias resolution, replication/rotation/annotations/topics/version-aliases fields, secret-level IAM (get/set/test), paginated list, hard-delete-and-recreate semantics.

Missing/shallow (verified against `google.golang.org/api/secretmanager/v1`'s generated request types): the version lifecycle verbs and `secrets.patch` never read or enforced their `etag` precondition field — the wire handlers didn't even decode a request body for the verb endpoints. This PR closes that gap.

## What changed

- `services/secrets/driver/driver.go`: `GCPSecrets.{Enable,Disable,Destroy}SecretVersion` take an `etag` parameter; `GCPSecretPatch` gains an `Etag` field; new `GCPSecretPreconditionError` sentinel (mirrors `GCSPreconditionError`) for a stale-etag rejection.
- `providers/gcp/secretmanager/lifecycle.go`: etag check happens atomically under the secret's write lock, alongside the state transition/patch, so a stale-read-then-write race can't slip past it (same discipline as the recent GCS bucket-IAM etag fix).
- `server/gcp/secretmanager`: the lifecycle verbs now decode a body (`{etag}`), `secrets.patch` honors `Secret.etag` independent of the update mask; a precondition mismatch answers 412 `conditionNotMet`, matching GCS/Compute Engine's fingerprint convention elsewhere in cloudemu.
- Provider + real-SDK tests for both the mismatch (412, no-op) and match (success, fresh etag minted) paths, plus an empty-etag-always-succeeds case.

## Deferred (out of scope for this PR)

- IAM policy `etag` concurrency on `setIamPolicy` (separate surface).
- `secrets.delete`'s `?etag=` query-param precondition (would require changing the shared `driver.Secrets` interface, touching the AWS provider too).
- Rotation execution, replication changes, CMEK — pre-existing scope notes.