### PR TITLE
feat(iam): virtual MFA device lifecycle

### DIFF
--- a/providers/aws/iam/iam.go
+++ b/providers/aws/iam/iam.go
@@ -204,6 +204,13 @@ func (m *Mock) DeleteUser(_ context.Context, name string) error {
 		}
 	}
 
+	for _, d := range m.mfaDevices.All() {
+		if d.UserName == name {
+			return errors.Newf(errors.FailedPrecondition,
+				"cannot delete user %q: an MFA device is still enabled (deactivate it first)", name)
+		}
+	}
+
 	m.users.Delete(name)
 	delete(m.userPolicies, name)
 	delete(m.userInlinePolicies, name)

--- a/providers/aws/iam/mfa_device.go
+++ b/providers/aws/iam/mfa_device.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"context"
+	"sort"
 
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
@@ -9,8 +10,8 @@ import (
 )
 
 // mfaDeviceData is a stored MFA device. UserName is empty until the virtual
-// device is assigned to a user via EnableMFADevice (not yet emulated), so a
-// freshly created virtual device is unassigned and absent from ListMFADevices.
+// device is assigned to a user via EnableMFADevice, so a freshly created
+// virtual device is unassigned and absent from ListMFADevices.
 type mfaDeviceData struct {
 	SerialNumber string
 	UserName     string
@@ -69,6 +70,157 @@ func (m *Mock) ListMFADevices(_ context.Context, userName string) ([]driver.MFAD
 			EnableDate:   d.EnableDate,
 		})
 	}
+
+	return result, nil
+}
+
+// EnableMFADevice associates a virtual MFA device with a user (IAM
+// EnableMFADevice). Real IAM requires two consecutive, distinct codes from the
+// device; this emulator does not verify the codes against the seed but still
+// rejects an empty or identical pair, matching AWS's InvalidInput shape for
+// obviously malformed input. A device already enabled for a different user is
+// rejected as EntityAlreadyExists; re-enabling for the same user just refreshes
+// EnableDate.
+func (m *Mock) EnableMFADevice(_ context.Context, userName, serialNumber, authCode1, authCode2 string) error {
+	if !m.users.Has(userName) {
+		return errors.Newf(errors.NotFound, "user %q not found", userName)
+	}
+
+	if authCode1 == "" || authCode2 == "" {
+		return errors.Newf(errors.InvalidArgument, "AuthenticationCode1 and AuthenticationCode2 are required")
+	}
+
+	if authCode1 == authCode2 {
+		return errors.Newf(errors.InvalidArgument,
+			"AuthenticationCode1 and AuthenticationCode2 must be two consecutive, different codes from the device")
+	}
+
+	now := m.opts.Clock.Now().UTC().Format(timeFormat)
+
+	var conflict error
+
+	ok := m.mfaDevices.Update(serialNumber, func(d *mfaDeviceData) *mfaDeviceData {
+		if d.UserName != "" && d.UserName != userName {
+			conflict = errors.Newf(errors.AlreadyExists,
+				"MFA device %q is already assigned to user %q", serialNumber, d.UserName)
+
+			return d
+		}
+
+		d.UserName = userName
+		d.EnableDate = now
+
+		return d
+	})
+	if !ok {
+		return errors.Newf(errors.NotFound, "MFA device %q not found", serialNumber)
+	}
+
+	return conflict
+}
+
+// DeactivateMFADevice removes a virtual MFA device's association with a user
+// (IAM DeactivateMFADevice). The device record itself survives, unassigned,
+// so it can be re-enabled or deleted afterward.
+func (m *Mock) DeactivateMFADevice(_ context.Context, userName, serialNumber string) error {
+	if !m.users.Has(userName) {
+		return errors.Newf(errors.NotFound, "user %q not found", userName)
+	}
+
+	var mismatch bool
+
+	ok := m.mfaDevices.Update(serialNumber, func(d *mfaDeviceData) *mfaDeviceData {
+		if d.UserName != userName {
+			mismatch = true
+
+			return d
+		}
+
+		d.UserName = ""
+		d.EnableDate = ""
+
+		return d
+	})
+	if !ok || mismatch {
+		return errors.Newf(errors.NotFound, "MFA device %q not found for user %q", serialNumber, userName)
+	}
+
+	return nil
+}
+
+// DeleteVirtualMFADevice removes a virtual MFA device (IAM
+// DeleteVirtualMFADevice). Deleting a device still enabled for a user is
+// rejected as DeleteConflict; DeactivateMFADevice must run first. The check
+// and the delete happen under a single store lock via UpdateOrDelete so a
+// concurrent EnableMFADevice cannot race a delete of the same device.
+func (m *Mock) DeleteVirtualMFADevice(_ context.Context, serialNumber string) error {
+	var conflict error
+
+	ok := m.mfaDevices.UpdateOrDelete(serialNumber, func(d *mfaDeviceData) (*mfaDeviceData, bool) {
+		if d.UserName != "" {
+			conflict = errors.Newf(errors.FailedPrecondition,
+				"cannot delete MFA device %q: it is still enabled for user %q (deactivate it first)",
+				serialNumber, d.UserName)
+
+			return d, true
+		}
+
+		return d, false
+	})
+	if !ok {
+		return errors.Newf(errors.NotFound, "MFA device %q not found", serialNumber)
+	}
+
+	return conflict
+}
+
+// mfaAssignmentStatusAssigned, mfaAssignmentStatusUnassigned, and
+// mfaAssignmentStatusAny are the three values IAM's ListVirtualMFADevices
+// AssignmentStatus filter accepts; an empty filter behaves as Any.
+const (
+	mfaAssignmentStatusAssigned   = "Assigned"
+	mfaAssignmentStatusUnassigned = "Unassigned"
+	mfaAssignmentStatusAny        = "Any"
+)
+
+// ListVirtualMFADevices returns every virtual MFA device in the account,
+// optionally filtered by assignment status (IAM ListVirtualMFADevices).
+func (m *Mock) ListVirtualMFADevices(_ context.Context, assignmentStatus string) ([]driver.VirtualMFADeviceMetadata, error) {
+	switch assignmentStatus {
+	case "", mfaAssignmentStatusAny, mfaAssignmentStatusAssigned, mfaAssignmentStatusUnassigned:
+	default:
+		return nil, errors.Newf(errors.InvalidArgument, "invalid AssignmentStatus %q", assignmentStatus)
+	}
+
+	var result []driver.VirtualMFADeviceMetadata
+
+	for _, d := range m.mfaDevices.All() {
+		assigned := d.UserName != ""
+
+		switch assignmentStatus {
+		case mfaAssignmentStatusAssigned:
+			if !assigned {
+				continue
+			}
+		case mfaAssignmentStatusUnassigned:
+			if assigned {
+				continue
+			}
+		}
+
+		meta := driver.VirtualMFADeviceMetadata{SerialNumber: d.SerialNumber, EnableDate: d.EnableDate}
+
+		if assigned {
+			if u, ok := m.users.Get(d.UserName); ok {
+				info := toUserInfo(u)
+				meta.AssignedUser = &info
+			}
+		}
+
+		result = append(result, meta)
+	}
+
+	sort.Slice(result, func(i, j int) bool { return result[i].SerialNumber < result[j].SerialNumber })
 
 	return result, nil
 }

--- a/providers/aws/iam/mfa_device_test.go
+++ b/providers/aws/iam/mfa_device_test.go
@@ -1,0 +1,153 @@
+package iam
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/iam/driver"
+)
+
+func TestVirtualMFADeviceLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateUser(ctx, driver.UserConfig{Name: "alice"})
+	requireNoError(t, err)
+
+	dev, err := m.CreateVirtualMFADevice(ctx, "alice-mfa", "")
+	requireNoError(t, err)
+	assertEqual(t, "arn:aws:iam::123456789012:mfa/alice-mfa", dev.SerialNumber)
+
+	// Duplicate name is rejected.
+	_, err = m.CreateVirtualMFADevice(ctx, "alice-mfa", "")
+	assertError(t, err, true)
+	if !errors.IsAlreadyExists(err) {
+		t.Fatalf("duplicate create error = %v, want AlreadyExists", err)
+	}
+
+	// A freshly created device is unassigned: absent from ListMFADevices and
+	// listed as Unassigned by ListVirtualMFADevices.
+	devices, err := m.ListMFADevices(ctx, "alice")
+	requireNoError(t, err)
+	assertEqual(t, 0, len(devices))
+
+	unassigned, err := m.ListVirtualMFADevices(ctx, "Unassigned")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(unassigned))
+	assertEqual(t, dev.SerialNumber, unassigned[0].SerialNumber)
+	if unassigned[0].AssignedUser != nil {
+		t.Fatalf("unassigned device reports an assigned user: %+v", unassigned[0].AssignedUser)
+	}
+
+	// Two identical codes are rejected without reaching the device lookup.
+	err = m.EnableMFADevice(ctx, "alice", dev.SerialNumber, "111111", "111111")
+	assertError(t, err, true)
+	if !errors.IsInvalidArgument(err) {
+		t.Fatalf("equal-codes error = %v, want InvalidArgument", err)
+	}
+
+	// Enabling for an unknown user is NotFound.
+	err = m.EnableMFADevice(ctx, "ghost", dev.SerialNumber, "111111", "222222")
+	assertError(t, err, true)
+	if !errors.IsNotFound(err) {
+		t.Fatalf("unknown-user error = %v, want NotFound", err)
+	}
+
+	// Enabling an unknown serial is NotFound.
+	err = m.EnableMFADevice(ctx, "alice", "arn:aws:iam::123456789012:mfa/ghost", "111111", "222222")
+	assertError(t, err, true)
+	if !errors.IsNotFound(err) {
+		t.Fatalf("unknown-serial error = %v, want NotFound", err)
+	}
+
+	// Enable succeeds and shows up in ListMFADevices for the user.
+	requireNoError(t, m.EnableMFADevice(ctx, "alice", dev.SerialNumber, "111111", "222222"))
+
+	devices, err = m.ListMFADevices(ctx, "alice")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(devices))
+	assertEqual(t, dev.SerialNumber, devices[0].SerialNumber)
+	if devices[0].EnableDate == "" {
+		t.Fatal("EnableDate is empty after EnableMFADevice")
+	}
+
+	assigned, err := m.ListVirtualMFADevices(ctx, "Assigned")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(assigned))
+	if assigned[0].AssignedUser == nil || assigned[0].AssignedUser.Name != "alice" {
+		t.Fatalf("assigned device's user = %+v, want alice", assigned[0].AssignedUser)
+	}
+
+	// A second user cannot enable the same, already-assigned device.
+	_, err = m.CreateUser(ctx, driver.UserConfig{Name: "bob"})
+	requireNoError(t, err)
+
+	err = m.EnableMFADevice(ctx, "bob", dev.SerialNumber, "333333", "444444")
+	assertError(t, err, true)
+	if !errors.IsAlreadyExists(err) {
+		t.Fatalf("cross-user enable error = %v, want AlreadyExists", err)
+	}
+
+	// DeleteUser is blocked while the device is still enabled.
+	err = m.DeleteUser(ctx, "alice")
+	assertError(t, err, true)
+	if !errors.IsFailedPrecondition(err) {
+		t.Fatalf("delete-user-with-mfa error = %v, want FailedPrecondition", err)
+	}
+
+	// Deleting an enabled device is a DeleteConflict (FailedPrecondition).
+	err = m.DeleteVirtualMFADevice(ctx, dev.SerialNumber)
+	assertError(t, err, true)
+	if !errors.IsFailedPrecondition(err) {
+		t.Fatalf("delete-enabled-device error = %v, want FailedPrecondition", err)
+	}
+
+	// Deactivating for the wrong user is NotFound.
+	err = m.DeactivateMFADevice(ctx, "bob", dev.SerialNumber)
+	assertError(t, err, true)
+	if !errors.IsNotFound(err) {
+		t.Fatalf("deactivate-wrong-user error = %v, want NotFound", err)
+	}
+
+	requireNoError(t, m.DeactivateMFADevice(ctx, "alice", dev.SerialNumber))
+
+	devices, err = m.ListMFADevices(ctx, "alice")
+	requireNoError(t, err)
+	assertEqual(t, 0, len(devices))
+
+	// Now that it's deactivated, DeleteUser and DeleteVirtualMFADevice both succeed.
+	requireNoError(t, m.DeleteVirtualMFADevice(ctx, dev.SerialNumber))
+
+	// Deleting an already-deleted device is NotFound.
+	err = m.DeleteVirtualMFADevice(ctx, dev.SerialNumber)
+	assertError(t, err, true)
+	if !errors.IsNotFound(err) {
+		t.Fatalf("delete-missing-device error = %v, want NotFound", err)
+	}
+
+	requireNoError(t, m.DeleteUser(ctx, "alice"))
+}
+
+func TestListVirtualMFADevicesInvalidAssignmentStatus(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.ListVirtualMFADevices(ctx, "Bogus")
+	assertError(t, err, true)
+	if !errors.IsInvalidArgument(err) {
+		t.Fatalf("invalid AssignmentStatus error = %v, want InvalidArgument", err)
+	}
+
+	// The empty filter and "Any" both return everything.
+	_, err = m.CreateVirtualMFADevice(ctx, "any-mfa", "")
+	requireNoError(t, err)
+
+	all, err := m.ListVirtualMFADevices(ctx, "")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(all))
+
+	all, err = m.ListVirtualMFADevices(ctx, "Any")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(all))
+}

--- a/server/aws/iam/handler.go
+++ b/server/aws/iam/handler.go
@@ -112,6 +112,10 @@ var iamActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup
 	"DeleteAccountPasswordPolicy":    {},
 	"CreateVirtualMFADevice":         {},
 	"ListMFADevices":                 {},
+	"EnableMFADevice":                {},
+	"DeactivateMFADevice":            {},
+	"DeleteVirtualMFADevice":         {},
+	"ListVirtualMFADevices":          {},
 }
 
 // roleTagManager is the AWS-specific role-tagging surface, asserted against the
@@ -363,6 +367,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.createVirtualMFADevice(w, r)
 	case "ListMFADevices":
 		h.listMFADevices(w, r)
+	case "EnableMFADevice":
+		h.enableMFADevice(w, r)
+	case "DeactivateMFADevice":
+		h.deactivateMFADevice(w, r)
+	case "DeleteVirtualMFADevice":
+		h.deleteVirtualMFADevice(w, r)
+	case "ListVirtualMFADevices":
+		h.listVirtualMFADevices(w, r)
 	default:
 		awsquery.WriteXMLError(w, http.StatusBadRequest,
 			"InvalidAction", "unknown IAM action: "+r.Form.Get("Action"))

--- a/server/aws/iam/mfa_device.go
+++ b/server/aws/iam/mfa_device.go
@@ -15,6 +15,10 @@ import (
 type mfaDeviceManager interface {
 	CreateVirtualMFADevice(ctx context.Context, name, path string) (*iamdriver.VirtualMFADeviceInfo, error)
 	ListMFADevices(ctx context.Context, userName string) ([]iamdriver.MFADeviceInfo, error)
+	EnableMFADevice(ctx context.Context, userName, serialNumber, authCode1, authCode2 string) error
+	DeactivateMFADevice(ctx context.Context, userName, serialNumber string) error
+	DeleteVirtualMFADevice(ctx context.Context, serialNumber string) error
+	ListVirtualMFADevices(ctx context.Context, assignmentStatus string) ([]iamdriver.VirtualMFADeviceMetadata, error)
 }
 
 // The seed and QR-code payloads are blob fields the SDK base64-decodes on the
@@ -108,6 +112,139 @@ func (h *Handler) listMFADevices(w http.ResponseWriter, r *http.Request) {
 	awsquery.WriteXMLResponse(w, listMFADevicesResponse{
 		Xmlns:    Namespace,
 		Result:   listMFADevicesResult{MFADevices: out, IsTruncated: false},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+type enableMFADeviceResponse struct {
+	XMLName  xml.Name         `xml:"EnableMFADeviceResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+func (h *Handler) enableMFADevice(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.iam.(mfaDeviceManager)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "MFA devices not supported")
+		return
+	}
+
+	err := mgr.EnableMFADevice(r.Context(),
+		r.Form.Get("UserName"), r.Form.Get("SerialNumber"), r.Form.Get("AuthenticationCode1"), r.Form.Get("AuthenticationCode2"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, enableMFADeviceResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+type deactivateMFADeviceResponse struct {
+	XMLName  xml.Name         `xml:"DeactivateMFADeviceResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+func (h *Handler) deactivateMFADevice(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.iam.(mfaDeviceManager)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "MFA devices not supported")
+		return
+	}
+
+	if err := mgr.DeactivateMFADevice(r.Context(), r.Form.Get("UserName"), r.Form.Get("SerialNumber")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deactivateMFADeviceResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+type deleteVirtualMFADeviceResponse struct {
+	XMLName  xml.Name         `xml:"DeleteVirtualMFADeviceResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+func (h *Handler) deleteVirtualMFADevice(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.iam.(mfaDeviceManager)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "MFA devices not supported")
+		return
+	}
+
+	if err := mgr.DeleteVirtualMFADevice(r.Context(), r.Form.Get("SerialNumber")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteVirtualMFADeviceResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// virtualMFADeviceMetadataXML is the list-shape AWS uses for
+// ListVirtualMFADevices: unlike virtualMFADeviceXML it carries no seed/QR
+// payload and instead reports the assigned user (omitted for an unassigned
+// device).
+type virtualMFADeviceMetadataXML struct {
+	SerialNumber string   `xml:"SerialNumber"`
+	EnableDate   string   `xml:"EnableDate,omitempty"`
+	User         *userXML `xml:"User,omitempty"`
+}
+
+type virtualMFADevicesListXML struct {
+	Member []virtualMFADeviceMetadataXML `xml:"member,omitempty"`
+}
+
+type listVirtualMFADevicesResponse struct {
+	XMLName  xml.Name                    `xml:"ListVirtualMFADevicesResponse"`
+	Xmlns    string                      `xml:"xmlns,attr"`
+	Result   listVirtualMFADevicesResult `xml:"ListVirtualMFADevicesResult"`
+	Metadata responseMetadata            `xml:"ResponseMetadata"`
+}
+
+type listVirtualMFADevicesResult struct {
+	VirtualMFADevices virtualMFADevicesListXML `xml:"VirtualMFADevices"`
+	IsTruncated       bool                     `xml:"IsTruncated"`
+}
+
+func (h *Handler) listVirtualMFADevices(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.iam.(mfaDeviceManager)
+	if !ok {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAction", "MFA devices not supported")
+		return
+	}
+
+	devices, err := mgr.ListVirtualMFADevices(r.Context(), r.Form.Get("AssignmentStatus"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := virtualMFADevicesListXML{Member: make([]virtualMFADeviceMetadataXML, 0, len(devices))}
+
+	for i := range devices {
+		meta := virtualMFADeviceMetadataXML{SerialNumber: devices[i].SerialNumber, EnableDate: devices[i].EnableDate}
+
+		if devices[i].AssignedUser != nil {
+			u := toUserXML(devices[i].AssignedUser)
+			meta.User = &u
+		}
+
+		out.Member = append(out.Member, meta)
+	}
+
+	awsquery.WriteXMLResponse(w, listVirtualMFADevicesResponse{
+		Xmlns:    Namespace,
+		Result:   listVirtualMFADevicesResult{VirtualMFADevices: out, IsTruncated: false},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/iam/mfa_device_test.go
+++ b/server/aws/iam/mfa_device_test.go
@@ -2,11 +2,13 @@ package iam_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 )
 
 func TestSDKCreateVirtualMFADevice(t *testing.T) {
@@ -56,5 +58,184 @@ func TestSDKListMFADevices(t *testing.T) {
 	// Listing devices for an unknown user is NoSuchEntity.
 	if _, err := client.ListMFADevices(ctx, &iam.ListMFADevicesInput{UserName: aws.String("ghost")}); err == nil {
 		t.Fatal("ListMFADevices for unknown user: expected error, got nil")
+	}
+}
+
+// TestSDKVirtualMFADeviceLifecycle drives the full real-user flow through the
+// aws-sdk-go-v2 IAM client: create, enable, observe it in both ListMFADevices
+// and ListVirtualMFADevices, then the delete-conflict/deactivate/delete tail.
+func TestSDKVirtualMFADeviceLifecycle(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("lifecycle-user")}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	created, err := client.CreateVirtualMFADevice(ctx, &iam.CreateVirtualMFADeviceInput{
+		VirtualMFADeviceName: aws.String("lifecycle-mfa"),
+	})
+	if err != nil {
+		t.Fatalf("CreateVirtualMFADevice: %v", err)
+	}
+
+	serial := created.VirtualMFADevice.SerialNumber
+
+	// A second create with the same name is EntityAlreadyExists.
+	_, err = client.CreateVirtualMFADevice(ctx, &iam.CreateVirtualMFADeviceInput{
+		VirtualMFADeviceName: aws.String("lifecycle-mfa"),
+	})
+	if err == nil {
+		t.Fatal("duplicate CreateVirtualMFADevice: expected error, got nil")
+	}
+
+	var eae *types.EntityAlreadyExistsException
+	if !errors.As(err, &eae) {
+		t.Fatalf("duplicate create error = %T, want *EntityAlreadyExistsException: %v", err, err)
+	}
+
+	// The emulator accepts any two distinct codes.
+	_, err = client.EnableMFADevice(ctx, &iam.EnableMFADeviceInput{
+		UserName:            aws.String("lifecycle-user"),
+		SerialNumber:        serial,
+		AuthenticationCode1: aws.String("111111"),
+		AuthenticationCode2: aws.String("222222"),
+	})
+	if err != nil {
+		t.Fatalf("EnableMFADevice: %v", err)
+	}
+
+	listed, err := client.ListMFADevices(ctx, &iam.ListMFADevicesInput{UserName: aws.String("lifecycle-user")})
+	if err != nil {
+		t.Fatalf("ListMFADevices: %v", err)
+	}
+
+	if len(listed.MFADevices) != 1 || aws.ToString(listed.MFADevices[0].SerialNumber) != aws.ToString(serial) {
+		t.Fatalf("ListMFADevices after enable = %+v, want one entry for %s", listed.MFADevices, aws.ToString(serial))
+	}
+
+	virtual, err := client.ListVirtualMFADevices(ctx, &iam.ListVirtualMFADevicesInput{
+		AssignmentStatus: types.AssignmentStatusTypeAssigned,
+	})
+	if err != nil {
+		t.Fatalf("ListVirtualMFADevices(Assigned): %v", err)
+	}
+
+	if len(virtual.VirtualMFADevices) != 1 {
+		t.Fatalf("ListVirtualMFADevices(Assigned) returned %d devices, want 1", len(virtual.VirtualMFADevices))
+	}
+
+	if virtual.VirtualMFADevices[0].User == nil || aws.ToString(virtual.VirtualMFADevices[0].User.UserName) != "lifecycle-user" {
+		t.Fatalf("assigned device's user = %v, want lifecycle-user", virtual.VirtualMFADevices[0].User)
+	}
+
+	// Deleting an enabled device is a DeleteConflict.
+	_, err = client.DeleteVirtualMFADevice(ctx, &iam.DeleteVirtualMFADeviceInput{SerialNumber: serial})
+	if err == nil {
+		t.Fatal("DeleteVirtualMFADevice on an enabled device: expected error, got nil")
+	}
+
+	var dce *types.DeleteConflictException
+	if !errors.As(err, &dce) {
+		t.Fatalf("delete-enabled-device error = %T, want *DeleteConflictException: %v", err, err)
+	}
+
+	// Deactivate, then the delete succeeds.
+	if _, err := client.DeactivateMFADevice(ctx, &iam.DeactivateMFADeviceInput{
+		UserName:     aws.String("lifecycle-user"),
+		SerialNumber: serial,
+	}); err != nil {
+		t.Fatalf("DeactivateMFADevice: %v", err)
+	}
+
+	listed, err = client.ListMFADevices(ctx, &iam.ListMFADevicesInput{UserName: aws.String("lifecycle-user")})
+	if err != nil {
+		t.Fatalf("ListMFADevices after deactivate: %v", err)
+	}
+
+	if len(listed.MFADevices) != 0 {
+		t.Fatalf("ListMFADevices after deactivate = %+v, want empty", listed.MFADevices)
+	}
+
+	if _, err := client.DeleteVirtualMFADevice(ctx, &iam.DeleteVirtualMFADeviceInput{SerialNumber: serial}); err != nil {
+		t.Fatalf("DeleteVirtualMFADevice after deactivate: %v", err)
+	}
+
+	// Deleting a user that still has an enabled device is blocked; deleting a
+	// clean user succeeds.
+	guard, err := client.CreateVirtualMFADevice(ctx, &iam.CreateVirtualMFADeviceInput{
+		VirtualMFADeviceName: aws.String("guard-mfa"),
+	})
+	if err != nil {
+		t.Fatalf("CreateVirtualMFADevice (guard): %v", err)
+	}
+
+	if _, err := client.EnableMFADevice(ctx, &iam.EnableMFADeviceInput{
+		UserName:            aws.String("lifecycle-user"),
+		SerialNumber:        guard.VirtualMFADevice.SerialNumber,
+		AuthenticationCode1: aws.String("111111"),
+		AuthenticationCode2: aws.String("222222"),
+	}); err != nil {
+		t.Fatalf("EnableMFADevice (guard): %v", err)
+	}
+
+	_, err = client.DeleteUser(ctx, &iam.DeleteUserInput{UserName: aws.String("lifecycle-user")})
+	if err == nil {
+		t.Fatal("DeleteUser with an enabled MFA device: expected error, got nil")
+	}
+
+	var dce2 *types.DeleteConflictException
+	if !errors.As(err, &dce2) {
+		t.Fatalf("delete-user-with-mfa error = %T, want *DeleteConflictException: %v", err, err)
+	}
+}
+
+// TestSDKMFADeviceNotFoundErrors pins the NoSuchEntity error shape for the
+// negative paths on each new operation.
+func TestSDKMFADeviceNotFoundErrors(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("nf-user")}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	cases := map[string]func() error{
+		"EnableMFADevice unknown device": func() error {
+			_, err := client.EnableMFADevice(ctx, &iam.EnableMFADeviceInput{
+				UserName:            aws.String("nf-user"),
+				SerialNumber:        aws.String("arn:aws:iam::123456789012:mfa/ghost"),
+				AuthenticationCode1: aws.String("111111"),
+				AuthenticationCode2: aws.String("222222"),
+			})
+			return err
+		},
+		"DeactivateMFADevice unknown device": func() error {
+			_, err := client.DeactivateMFADevice(ctx, &iam.DeactivateMFADeviceInput{
+				UserName:     aws.String("nf-user"),
+				SerialNumber: aws.String("arn:aws:iam::123456789012:mfa/ghost"),
+			})
+			return err
+		},
+		"DeleteVirtualMFADevice unknown device": func() error {
+			_, err := client.DeleteVirtualMFADevice(ctx, &iam.DeleteVirtualMFADeviceInput{
+				SerialNumber: aws.String("arn:aws:iam::123456789012:mfa/ghost"),
+			})
+			return err
+		},
+	}
+
+	for name, do := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := do()
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			var nse *types.NoSuchEntityException
+			if !errors.As(err, &nse) {
+				t.Fatalf("error = %T, want *NoSuchEntityException: %v", err, err)
+			}
+		})
 	}
 }

--- a/services/iam/driver/driver.go
+++ b/services/iam/driver/driver.go
@@ -184,6 +184,16 @@ type VirtualMFADeviceInfo struct {
 	QRCodePNG        []byte
 }
 
+// VirtualMFADeviceMetadata describes a virtual MFA device as returned by
+// ListVirtualMFADevices. Unlike VirtualMFADeviceInfo it carries no seed/QR
+// payload (real AWS omits both from the list response) and instead reports
+// the assigned user, nil for a device that has not been enabled. AWS-only.
+type VirtualMFADeviceMetadata struct {
+	SerialNumber string
+	EnableDate   string
+	AssignedUser *UserInfo
+}
+
 // AccessKeyAuth carries the secret and owning principal for one access key id.
 // It is used by the AWS SigV4 request-authentication gate to verify an
 // incoming signature and resolve the caller, and by STS GetCallerIdentity to


### PR DESCRIPTION
## Gap list

Both virtual MFA devices and service-linked roles already had partial coverage. Checked file:line before picking a theme:

- `providers/aws/iam/mfa_device.go` / `server/aws/iam/mfa_device.go`: CreateVirtualMFADevice and ListMFADevices existed; EnableMFADevice, DeactivateMFADevice, DeleteVirtualMFADevice, ListVirtualMFADevices did not (the code comment on `mfaDeviceData` literally said "not yet emulated").
- `providers/aws/iam/service_linked_role.go` / `server/aws/iam/service_linked_role.go`: CreateServiceLinkedRole existed; DeleteServiceLinkedRole/GetServiceLinkedRoleDeletionStatus were also missing, but left untouched to keep this PR to one theme.

## What's added

Completes the virtual MFA device lifecycle:

- `EnableMFADevice` — associates a device with a user (rejects empty/identical auth codes, rejects assigning a device already enabled for a different user as EntityAlreadyExists).
- `DeactivateMFADevice` — clears the association.
- `DeleteVirtualMFADevice` — deletes an unassigned device; rejects a still-enabled device as DeleteConflict.
- `ListVirtualMFADevices` — lists devices, filterable by `AssignmentStatus` (Assigned/Unassigned/Any).
- `DeleteUser` now rejects deletion while the user still has an enabled MFA device (DeleteConflict), mirroring the existing access-key/policy/group guards.

Mutations go through `memstore.Store.Update`/`UpdateOrDelete` so the enabled-check and the mutation/delete happen under one lock (no get-then-mutate races).

## Deferred

- `DeleteServiceLinkedRole` / `GetServiceLinkedRoleDeletionStatus` — separate theme, left for a follow-up PR.