### PR TITLE
fix(keyvault): gate secret get on disabled/exp/nbf via injected clock

### DIFF
--- a/providers/azure/keyvault/certs_azure.go
+++ b/providers/azure/keyvault/certs_azure.go
@@ -333,8 +333,6 @@ func (m *Mock) mintCertKey(vault, name string, v *certVersion, key *rsa.PrivateK
 
 // GetCertificate returns one certificate version. Empty version returns the
 // current version.
-//
-//nolint:dupl // parallel certificate/secret version accessor; the shared shape is intentional
 func (m *Mock) GetCertificate(_ context.Context, vault, name, version string) (*driver.KVCertificate, error) {
 	cd := liveCert(m.vault(vault).certs, name)
 	if cd == nil {

--- a/providers/azure/keyvault/keyvault_azure.go
+++ b/providers/azure/keyvault/keyvault_azure.go
@@ -106,8 +106,10 @@ func (m *Mock) SetKeyVaultSecret(_ context.Context, vault, name string, params d
 }
 
 // GetKeyVaultSecret returns one secret version. Empty version returns current.
-//
-//nolint:dupl // parallel certificate/secret version accessor; the shared shape is intentional
+// A version that is disabled, not yet valid (nbf) or expired (exp) cannot be
+// retrieved: real Key Vault answers such a get with 403 Forbidden rather than
+// serving an earlier, usable version, so the check applies to whichever
+// version was resolved (current or explicitly named) and never falls back.
 func (m *Mock) GetKeyVaultSecret(_ context.Context, vault, name, version string) (*driver.KVSecret, error) {
 	sd := liveVaultSecret(m.vault(vault).secrets, name)
 	if sd == nil {
@@ -122,9 +124,34 @@ func (m *Mock) GetKeyVaultSecret(_ context.Context, vault, name, version string)
 		return nil, errors.Newf(errors.NotFound, "version %q not found for secret %q", version, name)
 	}
 
+	if err := m.checkVersionUsable(v); err != nil {
+		return nil, err
+	}
+
 	kv := v.toKV(name)
 
 	return &kv, nil
+}
+
+// checkVersionUsable reports whether v may be retrieved right now: it must be
+// enabled and within its notBefore/expires window. Matches real Key Vault,
+// which returns 403 Forbidden for a get against a disabled, not-yet-valid or
+// expired version. The caller must hold sd.mu.
+func (m *Mock) checkVersionUsable(v *secretVersion) error {
+	if !v.enabled {
+		return errors.New(errors.PermissionDenied, "operation get is not allowed on a disabled secret")
+	}
+
+	now := m.opts.Clock.Now().Unix()
+	if v.notBefore != 0 && now < v.notBefore {
+		return errors.New(errors.PermissionDenied, "operation get is not allowed on a not-yet-valid secret")
+	}
+
+	if v.expires != 0 && now >= v.expires {
+		return errors.New(errors.PermissionDenied, "operation get is not allowed on an expired secret")
+	}
+
+	return nil
 }
 
 // ListKeyVaultSecrets returns the current version of each live secret.

--- a/providers/azure/keyvault/keyvault_azure_test.go
+++ b/providers/azure/keyvault/keyvault_azure_test.go
@@ -2,8 +2,11 @@ package keyvault
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/secrets/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,10 +30,19 @@ func TestSetKeyVaultSecretRoundTrip(t *testing.T) {
 	assert.Equal(t, int64(222), kv.NotBefore)
 	assert.Equal(t, "val", kv.Tags["k"])
 
-	got, err := m.GetKeyVaultSecret(ctx, "default", "s", "")
+	// A disabled version cannot be retrieved: real Key Vault answers get with
+	// 403 Forbidden rather than serving it, so GetKeyVaultSecret must error.
+	_, err = m.GetKeyVaultSecret(ctx, "default", "s", "")
+	require.Error(t, err)
+	assert.True(t, errors.IsPermissionDenied(err))
+
+	// Its content type and attributes are still visible through the version
+	// listing projection, which never gates on enabled/exp/nbf.
+	versions, err := m.ListKeyVaultSecretVersions(ctx, "default", "s")
 	require.NoError(t, err)
-	assert.Equal(t, "text/plain", got.ContentType)
-	assert.False(t, got.Enabled)
+	require.Len(t, versions, 1)
+	assert.Equal(t, "text/plain", versions[0].ContentType)
+	assert.False(t, versions[0].Enabled)
 }
 
 func TestUpdateKeyVaultSecretPartial(t *testing.T) {
@@ -119,4 +131,124 @@ func TestKeyVaultBackupRestore(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "secret", string(restored.Value))
 	assert.Equal(t, "text/plain", restored.ContentType)
+}
+
+// keyVaultTestClockNow is the instant newTestMock's FakeClock is pinned to.
+var keyVaultTestClockNow = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) //nolint:gochecknoglobals // read-only test fixture
+
+// TestGetKeyVaultSecretExpiredWindow proves the expired/not-yet-valid gate is
+// driven by the injected clock (deterministic under FakeClock), not wall time,
+// and that the boundaries match real Key Vault: exp is exclusive (blocked at
+// and after exp), nbf is inclusive (usable at and after nbf).
+func TestGetKeyVaultSecretExpiredWindow(t *testing.T) {
+	tests := []struct {
+		name    string
+		attrs   driver.KVAttributes
+		wantErr bool
+	}{
+		{"expired at boundary", driver.KVAttributes{Enabled: true, Expires: keyVaultTestClockNow.Unix()}, true},
+		{"expired in the past", driver.KVAttributes{Enabled: true, Expires: keyVaultTestClockNow.Add(-time.Hour).Unix()}, true},
+		{"not yet valid", driver.KVAttributes{Enabled: true, NotBefore: keyVaultTestClockNow.Add(time.Hour).Unix()}, true},
+		{"valid at nbf boundary", driver.KVAttributes{Enabled: true, NotBefore: keyVaultTestClockNow.Unix()}, false},
+		{"within window", driver.KVAttributes{
+			Enabled: true, NotBefore: keyVaultTestClockNow.Add(-time.Hour).Unix(), Expires: keyVaultTestClockNow.Add(time.Hour).Unix(),
+		}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestMock()
+			ctx := context.Background()
+
+			_, err := m.SetKeyVaultSecret(ctx, "default", "s", driver.KVSetParams{Value: []byte("v"), Attributes: tt.attrs})
+			require.NoError(t, err)
+
+			_, err = m.GetKeyVaultSecret(ctx, "default", "s", "")
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.True(t, errors.IsPermissionDenied(err))
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestGetKeyVaultSecretExpiredWindowSpecificVersion proves the gate applies to
+// an explicitly named version too: real Key Vault never falls back to an
+// earlier, usable version when the requested one is disabled or out of window.
+func TestGetKeyVaultSecretExpiredWindowSpecificVersion(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	first, err := m.SetKeyVaultSecret(ctx, "default", "s", driver.KVSetParams{
+		Value: []byte("v1"), Attributes: driver.KVAttributes{Enabled: true},
+	})
+	require.NoError(t, err)
+
+	_, err = m.SetKeyVaultSecret(ctx, "default", "s", driver.KVSetParams{
+		Value: []byte("v2"), Attributes: driver.KVAttributes{Enabled: false},
+	})
+	require.NoError(t, err)
+
+	// The older, still-enabled version remains directly retrievable by id.
+	got, err := m.GetKeyVaultSecret(ctx, "default", "s", first.Version)
+	require.NoError(t, err)
+	assert.Equal(t, "v1", string(got.Value))
+
+	// The current (disabled) version 403s rather than silently resolving to v1.
+	_, err = m.GetKeyVaultSecret(ctx, "default", "s", "")
+	require.Error(t, err)
+	assert.True(t, errors.IsPermissionDenied(err))
+}
+
+// TestKeyVaultConcurrentDeleteRecover races DeleteKeyVaultSecret against
+// RecoverDeletedKeyVaultSecret on the same secret name under -race, proving the
+// soft-delete/recover state transition (a flag flip guarded by the secret's own
+// mutex, not a move between two stores) can never leave the record lost or
+// duplicated: after every goroutine settles, exactly one of the live or
+// deleted views must resolve the secret.
+func TestKeyVaultConcurrentDeleteRecover(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.SetKeyVaultSecret(ctx, "default", "s", driver.KVSetParams{Value: []byte("v"), Attributes: driver.KVAttributes{Enabled: true}})
+	require.NoError(t, err)
+
+	const rounds = 50
+
+	var wg sync.WaitGroup
+
+	for range rounds {
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			_, _ = m.DeleteKeyVaultSecret(ctx, "default", "s")
+		}()
+
+		go func() {
+			defer wg.Done()
+			_, _ = m.RecoverDeletedKeyVaultSecret(ctx, "default", "s")
+		}()
+	}
+
+	wg.Wait()
+
+	// Whichever operation landed last, the secret is in exactly one of the two
+	// states: retrievable live, or present (once) in the deleted list.
+	_, liveErr := m.GetKeyVaultSecret(ctx, "default", "s", "")
+
+	deletedList, err := m.ListDeletedKeyVaultSecrets(ctx, "default")
+	require.NoError(t, err)
+
+	if liveErr == nil {
+		assert.Empty(t, deletedList, "secret is live but also listed as deleted")
+	} else {
+		require.Len(t, deletedList, 1, "secret must appear exactly once in the deleted list when not live")
+	}
+
+	all, err := m.ListKeyVaultSecrets(ctx, "default")
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(all), 1, "secret must not be duplicated across live entries")
 }

--- a/server/azure/keyvault/certs_operations.go
+++ b/server/azure/keyvault/certs_operations.go
@@ -26,8 +26,6 @@ func writeJSONStatus(w http.ResponseWriter, status int, v any) {
 
 // writeCertErr maps a canonical cloudemu error to a Key Vault certificate error
 // response.
-//
-//nolint:dupl // parallel certificate/secret error mapper; the shared shape is intentional
 func writeCertErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):

--- a/server/azure/keyvault/handler.go
+++ b/server/azure/keyvault/handler.go
@@ -313,8 +313,6 @@ func writeErr(w http.ResponseWriter, status int, code, msg string) {
 }
 
 // writeCErr maps a canonical cloudemu error to a Key Vault error response.
-//
-//nolint:dupl // parallel certificate/secret error mapper; the shared shape is intentional
 func writeCErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
@@ -327,6 +325,11 @@ func writeCErr(w http.ResponseWriter, err error) {
 		writeErr(w, http.StatusConflict, "Conflict", err.Error())
 	case cerrors.IsInvalidArgument(err):
 		writeErr(w, http.StatusBadRequest, "BadParameter", err.Error())
+	case cerrors.IsPermissionDenied(err):
+		// A disabled, not-yet-valid or expired secret version: real Key Vault
+		// answers get with 403 Forbidden rather than falling back to an older
+		// usable version.
+		writeErr(w, http.StatusForbidden, "Forbidden", err.Error())
 	default:
 		writeErr(w, http.StatusInternalServerError, "InternalServerError", err.Error())
 	}

--- a/server/azure/keyvault/operations.go
+++ b/server/azure/keyvault/operations.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
@@ -63,22 +62,12 @@ func (h *Handler) setSecret(w http.ResponseWriter, r *http.Request, name string)
 }
 
 func (h *Handler) getSecret(w http.ResponseWriter, r *http.Request, name, version string) {
+	// Disabled, not-yet-valid and expired gating lives in the driver (against
+	// the injected clock, so it is deterministic under a FakeClock) rather than
+	// here, so it maps through writeCErr like every other driver error.
 	kv, err := h.kv.GetKeyVaultSecret(r.Context(), vaultFromRequest(r), name, version)
 	if err != nil {
 		writeCErr(w, err)
-		return
-	}
-
-	if !kv.Enabled {
-		writeErr(w, http.StatusForbidden, "Forbidden", "Operation get is not allowed on a disabled secret.")
-		return
-	}
-
-	// A secret outside its nbf/exp window is not operable: Key Vault returns 403
-	// on get, just as for a disabled secret.
-	now := time.Now().Unix()
-	if (kv.NotBefore != 0 && now < kv.NotBefore) || (kv.Expires != 0 && now >= kv.Expires) {
-		writeErr(w, http.StatusForbidden, "Forbidden", "Operation get is not allowed on an expired or not-yet-valid secret.")
 		return
 	}
 

--- a/server/azure/keyvault/secret_dataplane_test.go
+++ b/server/azure/keyvault/secret_dataplane_test.go
@@ -120,6 +120,61 @@ func TestSDKKeyVaultExpiryRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSDKKeyVaultExpiredSecretForbidsGet proves an expired secret's current
+// version 403s on get rather than returning the (unusable) value — matching
+// real Key Vault, which never falls back to an earlier version either.
+func TestSDKKeyVaultExpiredSecretForbidsGet(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	past := time.Now().Add(-time.Hour)
+
+	if _, err := client.SetSecret(ctx, "expired", azsecrets.SetSecretParameters{
+		Value:            to.Ptr("v"),
+		SecretAttributes: &azsecrets.SecretAttributes{Expires: to.Ptr(past)},
+	}, nil); err != nil {
+		t.Fatalf("SetSecret: %v", err)
+	}
+
+	_, err := client.GetSecret(ctx, "expired", "", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 403 {
+		t.Fatalf("GetSecret(expired): got %v, want 403", err)
+	}
+
+	if respErr.ErrorCode != "Forbidden" {
+		t.Fatalf("error code = %q, want Forbidden", respErr.ErrorCode)
+	}
+}
+
+// TestSDKKeyVaultNotYetValidSecretForbidsGet mirrors the expired case for a
+// secret whose notBefore window has not opened yet.
+func TestSDKKeyVaultNotYetValidSecretForbidsGet(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	future := time.Now().Add(time.Hour)
+
+	if _, err := client.SetSecret(ctx, "premature", azsecrets.SetSecretParameters{
+		Value:            to.Ptr("v"),
+		SecretAttributes: &azsecrets.SecretAttributes{NotBefore: to.Ptr(future)},
+	}, nil); err != nil {
+		t.Fatalf("SetSecret: %v", err)
+	}
+
+	_, err := client.GetSecret(ctx, "premature", "", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 403 {
+		t.Fatalf("GetSecret(not yet valid): got %v, want 403", err)
+	}
+
+	if respErr.ErrorCode != "Forbidden" {
+		t.Fatalf("error code = %q, want Forbidden", respErr.ErrorCode)
+	}
+}
+
 func TestSDKKeyVaultUpdateSecretProperties(t *testing.T) {
 	client := newSecretsClient(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Investigation found the Key Vault secret data-plane (SetSecret, GetSecret, list/versions, UpdateSecret, soft-delete/GetDeleted/ListDeleted/Recover/Purge, Backup/Restore) already implements the full lifecycle at real-cloud parity, including per-version attributes (enabled/exp/nbf/contentType/tags), the 409 ObjectIsDeletedButRecoverable conflict on a soft-deleted name, and deterministic deletedDate/scheduledPurgeDate via the injected clock.

One real gap: the disabled/expired/not-yet-valid 403 gate on `GET /secrets/{name}[/{version}]` was implemented in the wire handler using `time.Now()` directly instead of the injected `config.Clock`, making it non-deterministic and untestable under `FakeClock`.

## What changed

- Moved the gate from `server/azure/keyvault/operations.go` (wall clock) into `providers/azure/keyvault/keyvault_azure.go`'s `GetKeyVaultSecret` (the provider's already-injected `m.opts.Clock`), which returns a canonical `PermissionDenied` error for a disabled, not-yet-valid, or expired version.
- `writeCErr` now maps `PermissionDenied` to `403 Forbidden`, so the wire layer stays a thin error-code mapper.
- The gate applies to whichever version is resolved (current or an explicitly named version) — matches real Key Vault, which never silently falls back to an earlier usable version.
- Removed two now-stale `//nolint:dupl` directives (on the secrets side and their certificate-handler counterparts) that golangci-lint flagged as unused once the secrets code paths were no longer byte-identical.

## Tests

- Provider-level table test over the exp/nbf boundary (exclusive exp, inclusive nbf) against a `FakeClock`.
- Provider-level test proving the gate applies to an explicitly named version, not just current.
- Concurrent `DeleteKeyVaultSecret`/`RecoverDeletedKeyVaultSecret` race test (`-race`) proving the soft-delete flag flip (guarded by the secret's own mutex) never loses or duplicates the record.
- SDK-level (`azsecrets`) tests for expired and not-yet-valid secrets both 403'ing on Get.

## Deferred

- `nbf <= exp` validation on SetSecret/UpdateSecret (real Key Vault rejects an inverted window at write time) — left out to avoid guessing the exact error shape without a reference to verify against.
- Keys/Certificates data-plane were left untouched; they don't share this get-time gate.