### PR TITLE
fix(route53): serialize zone-mutating batches, protect apex SOA/NS from deletion

### DIFF
--- a/server/aws/route53/apex_protection_test.go
+++ b/server/aws/route53/apex_protection_test.go
@@ -1,0 +1,123 @@
+package route53_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
+	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+// TestSDKApexSOANSProtected pins that ChangeResourceRecordSets rejects a batch
+// that would delete the zone's mandatory apex SOA or NS record set outright,
+// matching real Route 53's "A HostedZone must contain exactly one SOA record"
+// / "...must contain at least one NS record for the zone itself"
+// InvalidChangeBatch errors — while still allowing an in-place edit (a DELETE
+// paired with a CREATE of the same record set in one batch) since the batch's
+// net effect still leaves the apex record standing.
+func TestSDKApexSOANSProtected(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+	zoneID := createRoutingZone(t, client, "apex.com.")
+
+	soa, ns := apexRecordSets(t, client, zoneID)
+
+	// A bare DELETE of the apex SOA (exact match) is rejected.
+	_, err := client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{
+			Changes: []r53types.Change{{Action: r53types.ChangeActionDelete, ResourceRecordSet: soa}},
+		},
+	})
+
+	var badBatch *r53types.InvalidChangeBatch
+	if !errors.As(err, &badBatch) {
+		t.Fatalf("DELETE apex SOA = %v, want InvalidChangeBatch", err)
+	}
+
+	// A bare DELETE of the apex NS is rejected the same way.
+	_, err = client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{
+			Changes: []r53types.Change{{Action: r53types.ChangeActionDelete, ResourceRecordSet: ns}},
+		},
+	})
+	if !errors.As(err, &badBatch) {
+		t.Fatalf("DELETE apex NS = %v, want InvalidChangeBatch", err)
+	}
+
+	// Both rejected batches must leave the zone untouched: still exactly the
+	// seeded SOA + NS record sets, nothing partially applied.
+	rrsets, err := client.ListResourceRecordSets(ctx, &awsr53.ListResourceRecordSetsInput{HostedZoneId: aws.String(zoneID)})
+	if err != nil {
+		t.Fatalf("ListResourceRecordSets: %v", err)
+	}
+
+	if got := len(rrsets.ResourceRecordSets); got != 2 {
+		t.Fatalf("record set count after rejected apex deletes = %d, want 2 (SOA+NS)", got)
+	}
+
+	// An in-place edit — DELETE the current SOA and CREATE its replacement in
+	// the same batch — is allowed: the batch's net effect still leaves an SOA
+	// record standing.
+	edited := *soa
+	edited.ResourceRecords = []r53types.ResourceRecord{{
+		Value: aws.String(aws.ToString(soa.ResourceRecords[0].Value) + "-edited"),
+	}}
+
+	_, err = client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{Changes: []r53types.Change{
+			{Action: r53types.ChangeActionDelete, ResourceRecordSet: soa},
+			{Action: r53types.ChangeActionCreate, ResourceRecordSet: &edited},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("DELETE+CREATE apex SOA (edit) = %v, want success", err)
+	}
+
+	// An UPSERT of the apex NS is likewise allowed.
+	editedNS := *ns
+	editedNS.ResourceRecords = append(append([]r53types.ResourceRecord(nil), ns.ResourceRecords...),
+		r53types.ResourceRecord{Value: aws.String("ns-extra.awsdns-00.com.")})
+
+	_, err = client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{
+			Changes: []r53types.Change{{Action: r53types.ChangeActionUpsert, ResourceRecordSet: &editedNS}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UPSERT apex NS (edit) = %v, want success", err)
+	}
+}
+
+// apexRecordSets returns the zone's auto-seeded apex SOA and NS record sets,
+// failing the test if either is missing.
+func apexRecordSets(t *testing.T, client *awsr53.Client, zoneID string) (soa, ns *r53types.ResourceRecordSet) {
+	t.Helper()
+
+	rrsets, err := client.ListResourceRecordSets(context.Background(), &awsr53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if err != nil {
+		t.Fatalf("ListResourceRecordSets: %v", err)
+	}
+
+	for i := range rrsets.ResourceRecordSets {
+		switch rrsets.ResourceRecordSets[i].Type {
+		case r53types.RRTypeSoa:
+			soa = &rrsets.ResourceRecordSets[i]
+		case r53types.RRTypeNs:
+			ns = &rrsets.ResourceRecordSets[i]
+		}
+	}
+
+	if soa == nil || ns == nil {
+		t.Fatalf("expected auto-seeded SOA and NS record sets, got %d record sets", len(rrsets.ResourceRecordSets))
+	}
+
+	return soa, ns
+}

--- a/server/aws/route53/change_batch_atomicity_test.go
+++ b/server/aws/route53/change_batch_atomicity_test.go
@@ -1,0 +1,116 @@
+package route53_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
+	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+// concurrentContenders is the number of goroutines racing to consume the same
+// contested record set. It must be large enough that, absent serialization
+// between validating a batch and applying it, at least one goroutine would
+// observe (and act on) a stale read of the contested record.
+const concurrentContenders = 25
+
+// TestSDKChangeResourceRecordSetsBatchAtomicUnderConcurrency proves
+// ChangeResourceRecordSets is atomic even when two batches race against the
+// same zone: every batch either applies in full or leaves no trace, never
+// partially. Each of concurrentContenders goroutines submits a two-change
+// batch — CREATE a goroutine-unique record, then DELETE a single shared
+// record that only one batch can win — against the same zone at once. Without
+// serializing a batch's validate-then-apply against concurrent writers, a
+// losing goroutine could have its CREATE applied before its DELETE fails on
+// the now-missing shared record, returning an error to the caller while
+// leaving its "rolled back" record behind. This locks that exactly one
+// goroutine wins, and every loser's record is absent.
+func TestSDKChangeResourceRecordSetsBatchAtomicUnderConcurrency(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+	zoneID := createRoutingZone(t, client, "atomic.com.")
+
+	const contestedName = "contested.atomic.com."
+
+	changeRecordSet(t, client, zoneID, r53types.ChangeActionCreate, &r53types.ResourceRecordSet{
+		Name: aws.String(contestedName), Type: r53types.RRTypeA, TTL: aws.Int64(60),
+		ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("198.51.100.1")}},
+	})
+
+	var wg sync.WaitGroup
+
+	start := make(chan struct{})
+	wins := make([]bool, concurrentContenders)
+
+	for i := range concurrentContenders {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+			<-start
+
+			uniqueName := fmt.Sprintf("racer-%d.atomic.com.", i)
+
+			_, err := client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+				HostedZoneId: aws.String(zoneID),
+				ChangeBatch: &r53types.ChangeBatch{Changes: []r53types.Change{
+					{
+						Action: r53types.ChangeActionCreate,
+						ResourceRecordSet: &r53types.ResourceRecordSet{
+							Name: aws.String(uniqueName), Type: r53types.RRTypeA, TTL: aws.Int64(60),
+							ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("198.51.100.2")}},
+						},
+					},
+					{
+						Action: r53types.ChangeActionDelete,
+						ResourceRecordSet: &r53types.ResourceRecordSet{
+							Name: aws.String(contestedName), Type: r53types.RRTypeA, TTL: aws.Int64(60),
+							ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("198.51.100.1")}},
+						},
+					},
+				}},
+			})
+
+			wins[i] = err == nil
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	rrsets, err := client.ListResourceRecordSets(ctx, &awsr53.ListResourceRecordSetsInput{HostedZoneId: aws.String(zoneID)})
+	if err != nil {
+		t.Fatalf("ListResourceRecordSets: %v", err)
+	}
+
+	present := make(map[string]bool, len(rrsets.ResourceRecordSets))
+	for i := range rrsets.ResourceRecordSets {
+		present[aws.ToString(rrsets.ResourceRecordSets[i].Name)] = true
+	}
+
+	winners := 0
+
+	for i := range concurrentContenders {
+		uniqueName := fmt.Sprintf("racer-%d.atomic.com.", i)
+		if wins[i] {
+			winners++
+
+			if !present[uniqueName] {
+				t.Errorf("goroutine %d reported success but its record %q is missing", i, uniqueName)
+			}
+		} else if present[uniqueName] {
+			t.Errorf("goroutine %d reported failure but its record %q was created anyway (partial apply)", i, uniqueName)
+		}
+	}
+
+	if winners != 1 {
+		t.Errorf("winning goroutines = %d, want exactly 1", winners)
+	}
+
+	if present[contestedName] {
+		t.Errorf("contested record %q should have been deleted by the winner", contestedName)
+	}
+}

--- a/server/aws/route53/handler.go
+++ b/server/aws/route53/handler.go
@@ -21,6 +21,7 @@ package route53
 import (
 	"net/http"
 	"strings"
+	"sync"
 
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
 )
@@ -51,6 +52,21 @@ const (
 // Handler serves Route 53 REST requests against a dns driver.
 type Handler struct {
 	dns dnsdriver.DNS
+
+	// zoneMu serializes the two operations that read a zone's record-set state
+	// and then act on it in a separate step: ChangeResourceRecordSets (validate
+	// the whole batch against current records, then apply every change) and
+	// DeleteHostedZone (check the zone holds only the apex SOA/NS, then delete
+	// it). The underlying memstore only guarantees each individual Get/Set/
+	// Delete call is atomic, not a read-then-act sequence spanning several
+	// calls — without this lock, two concurrent requests against the same zone
+	// could interleave between the check and the mutation (e.g. a batch
+	// validated as safe gets partially applied around a concurrent DELETE, or
+	// DeleteHostedZone deletes a zone a concurrent ChangeResourceRecordSets just
+	// added a record to). cloudemu's Route 53 handler is not on a hot path, so a
+	// single handler-wide lock is preferred over a per-zone lock map and its
+	// bookkeeping.
+	zoneMu sync.Mutex
 }
 
 // New returns a Route 53 handler backed by d.

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -169,6 +169,13 @@ func markerPage[T any](items []T, marker string, maxItems int, id func(T) string
 func (h *Handler) deleteHostedZone(w http.ResponseWriter, r *http.Request, id string) {
 	zoneID := trimZonePrefix(id)
 
+	// Hold the zone lock across the empty-check and the delete: without it, a
+	// concurrent ChangeResourceRecordSets could add a record to this zone
+	// between the check below and DeleteZone, silently discarding a record the
+	// caller believed it had just created.
+	h.zoneMu.Lock()
+	defer h.zoneMu.Unlock()
+
 	zone, err := h.dns.GetZone(r.Context(), zoneID)
 	if err != nil {
 		writeErr(w, err)
@@ -245,6 +252,15 @@ func (h *Handler) changeResourceRecordSets(w http.ResponseWriter, r *http.Reques
 		rr := &req.ChangeBatch.Changes[i].ResourceRecordSet
 		rr.Name = ensureTrailingDot(rr.Name)
 	}
+
+	// Hold the zone lock across validation and apply: two concurrent batches
+	// against the same zone must not interleave between "validated against
+	// current records" and "applied" — that would let a batch that was valid
+	// against a stale snapshot partially apply alongside another writer,
+	// breaking the all-or-nothing guarantee this handler documents. It also
+	// serializes against DeleteHostedZone's own check-then-delete.
+	h.zoneMu.Lock()
+	defer h.zoneMu.Unlock()
 
 	// The hosted zone must exist before the change batch is validated: a change
 	// against a missing zone is NoSuchHostedZone (404), not the batch-level
@@ -392,6 +408,30 @@ func (h *Handler) validateChangeBatch(r *http.Request, zone *dnsdriver.ZoneInfo,
 		if err := validateChange(&changes[i], zone.Name, present, byKey); err != nil {
 			return err
 		}
+	}
+
+	return validateApexRecordsSurvive(zone.Name, present)
+}
+
+// validateApexRecordsSurvive checks the batch's net effect (present, folded by
+// validateChange over every change) still leaves the zone's mandatory apex SOA
+// and NS record sets standing. Real Route 53 rejects a batch that would delete
+// either outright — "A HostedZone must contain exactly one SOA record" and "...
+// must contain at least one NS record for the zone itself" — while still
+// allowing a DELETE+CREATE (or UPSERT) of either within the same batch, since
+// that nets to present. present only holds keys touched by CreateZone's seeded
+// SOA/NS or by this batch, so an apex key absent from present means it was
+// never seeded (a pre-existing edge case this guard does not apply to) and is
+// left alone.
+func validateApexRecordsSurvive(zoneName string, present map[string]bool) error {
+	soaKey := rrSetKey(zoneName, "SOA", "")
+	if seeded, touched := present[soaKey]; touched && !seeded {
+		return cerrors.New(cerrors.FailedPrecondition, "A HostedZone must contain exactly one SOA record")
+	}
+
+	nsKey := rrSetKey(zoneName, "NS", "")
+	if seeded, touched := present[nsKey]; touched && !seeded {
+		return cerrors.New(cerrors.FailedPrecondition, "A HostedZone must contain at least one NS record for the zone itself")
 	}
 
 	return nil


### PR DESCRIPTION
## Gap list (investigation)

Route 53 hosted-zone/record-set lifecycle was already deep: CreateHostedZone auto-seeds the apex SOA+NS, DeleteHostedZone rejects a non-empty zone (HostedZoneNotEmpty), ChangeResourceRecordSets validates CREATE-exists/DELETE-exact-match/UPSERT semantics and rejects an invalid batch as a whole (InvalidChangeBatch), GetChange reports INSYNC, ListResourceRecordSets paginates in real DNS-name order, and weighted/latency/failover/geo/multivalue/alias routing all round-trip. Two real gaps remained:

- **Batch atomicity was only single-request-safe, not concurrency-safe.** `changeResourceRecordSets` validated the whole batch against a `ListRecords` snapshot, then applied each change in a second pass — with no lock held across the two steps. Two concurrent batches against the same zone could interleave: one batch's first change applies, then its second change fails against state a concurrent writer just changed, leaving the caller an error but a partially-applied batch. `DeleteHostedZone` had the same check-then-act gap against its own empty-zone guard. Reproduced deterministically with a decorator-based test that pauses a reader mid-validate: without a lock, the "loser" batch's CREATE landed even though its overall response was `InvalidChangeBatch`.
- **The apex SOA/NS record sets could be deleted outright.** Real Route 53 rejects a batch that would delete them ("A HostedZone must contain exactly one SOA record" / "...must contain at least one NS record for the zone itself"), while still allowing an in-place edit (DELETE+CREATE, or UPSERT) within the same batch.

## What changed

- `server/aws/route53/handler.go`: added a handler-wide `zoneMu sync.Mutex`.
- `server/aws/route53/operations.go`: `changeResourceRecordSets` and `deleteHostedZone` now hold `zoneMu` across their read-then-mutate sequence, making batch validation+apply and the empty-zone check+delete atomic against concurrent requests. `validateChangeBatch` now checks the batch's net effect still leaves the apex SOA and NS record sets standing, rejecting a bare DELETE of either as `InvalidChangeBatch`.
- New tests: `apex_protection_test.go` (apex SOA/NS delete rejected, edit via DELETE+CREATE/UPSERT allowed) and `change_batch_atomicity_test.go` (25 goroutines racing a contested DELETE against the same zone under `-race`; exactly one wins and no loser's record is left behind).

## Deferred

- ALIAS-target validation against the referenced resource, and health-check-driven failover evaluation, are out of scope for this pass (already-existing routing-policy round-trip was left untouched).