### PR TITLE
fix(gcp-clouddns): close TOCTOU races in record mutation and changes.create atomicity

### DIFF
--- a/providers/gcp/clouddns/concurrency_test.go
+++ b/providers/gcp/clouddns/concurrency_test.go
@@ -1,0 +1,188 @@
+package clouddns
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+)
+
+// TestCreateRecordConcurrentSameKeyExactlyOneWins locks the fix for a
+// Get-then-naked-mutate race: CreateRecord used to check m.records.Has(key)
+// and then call m.records.Set(key, rec) as two separate operations, so two
+// concurrent callers targeting the same name+type could both observe
+// "absent" and both write, silently losing one of the two record sets
+// instead of the second returning AlreadyExists. CreateRecord now goes
+// through the store's atomic SetIfAbsent, so under a race exactly one
+// caller must succeed. Must stay clean under `go test -race`.
+func TestCreateRecordConcurrentSameKeyExactlyOneWins(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("CreateZone: %v", err)
+	}
+
+	const workers = 16
+
+	var (
+		wg      sync.WaitGroup
+		oks     atomic.Int32
+		exists  atomic.Int32
+		unknown atomic.Int32
+	)
+
+	for w := range workers {
+		wg.Add(1)
+
+		go func(w int) {
+			defer wg.Done()
+
+			_, err := m.CreateRecord(ctx, driver.RecordConfig{
+				ZoneID: zone.ID, Name: "www.example.com", Type: "A", TTL: 300,
+				Values: []string{"192.0.2." + strconv.Itoa(w)},
+			})
+
+			switch {
+			case err == nil:
+				oks.Add(1)
+			case isAlreadyExists(err):
+				exists.Add(1)
+			default:
+				unknown.Add(1)
+			}
+		}(w)
+	}
+
+	wg.Wait()
+
+	if unknown.Load() != 0 {
+		t.Fatalf("unexpected error kind from %d calls", unknown.Load())
+	}
+
+	if oks.Load() != 1 {
+		t.Fatalf("successful creates = %d, want exactly 1 (got %d AlreadyExists)", oks.Load(), exists.Load())
+	}
+
+	if exists.Load() != workers-1 {
+		t.Fatalf("AlreadyExists count = %d, want %d", exists.Load(), workers-1)
+	}
+
+	records, err := m.ListRecords(ctx, zone.ID)
+	if err != nil {
+		t.Fatalf("ListRecords: %v", err)
+	}
+
+	found := 0
+	for i := range records {
+		if records[i].Name == "www.example.com" && records[i].Type == "A" {
+			found++
+		}
+	}
+
+	if found != 1 {
+		t.Fatalf("stored record sets for www.example.com/A = %d, want 1", found)
+	}
+
+	zoneInfo, err := m.GetZone(ctx, zone.ID)
+	if err != nil {
+		t.Fatalf("GetZone: %v", err)
+	}
+
+	if zoneInfo.RecordCount != 1 {
+		t.Fatalf("RecordCount = %d, want 1 (no double-counted create)", zoneInfo.RecordCount)
+	}
+}
+
+// TestUpdateRecordConcurrentWithDeleteNeverResurrects locks the fix for the
+// second Get-then-naked-mutate race: UpdateRecord used to Get the record to
+// check it exists and then unconditionally Set the new value, so a
+// DeleteRecord landing in that window would be silently undone by the
+// in-flight update. UpdateRecord now goes through the store's atomic Update,
+// which only writes if the key is still present. Must stay clean under
+// `go test -race`.
+func TestUpdateRecordConcurrentWithDeleteNeverResurrects(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("CreateZone: %v", err)
+	}
+
+	const iters = 200
+
+	for i := range iters {
+		name := "churn.example.com"
+
+		if _, err := m.CreateRecord(ctx, driver.RecordConfig{
+			ZoneID: zone.ID, Name: name, Type: "A", TTL: 300, Values: []string{"192.0.2.1"},
+		}); err != nil {
+			t.Fatalf("CreateRecord iter %d: %v", i, err)
+		}
+
+		var wg sync.WaitGroup
+
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+
+			_, _ = m.UpdateRecord(ctx, driver.RecordConfig{
+				ZoneID: zone.ID, Name: name, Type: "A", TTL: 600, Values: []string{"192.0.2.2"},
+			})
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			_ = m.DeleteRecord(ctx, zone.ID, name, "A")
+		}()
+
+		wg.Wait()
+
+		// Whatever the outcome (delete-then-update racing to NotFound, or
+		// update-then-delete), the record must not be left resurrected with a
+		// dangling entry the zone's RecordCount disagrees with.
+		rec, getErr := m.GetRecord(ctx, zone.ID, name, "A")
+
+		records, listErr := m.ListRecords(ctx, zone.ID)
+		if listErr != nil {
+			t.Fatalf("ListRecords iter %d: %v", i, listErr)
+		}
+
+		present := getErr == nil
+		if present != (rec != nil) {
+			t.Fatalf("iter %d: GetRecord/rec mismatch", i)
+		}
+
+		count := 0
+		for j := range records {
+			if records[j].Name == name && records[j].Type == "A" {
+				count++
+			}
+		}
+
+		if present && count != 1 {
+			t.Fatalf("iter %d: record present but ListRecords shows %d entries", i, count)
+		}
+
+		if !present && count != 0 {
+			t.Fatalf("iter %d: record absent but ListRecords shows %d entries", i, count)
+		}
+
+		// Clean up whichever state won, for the next iteration.
+		_ = m.DeleteRecord(ctx, zone.ID, name, "A")
+	}
+}
+
+// isAlreadyExists reports whether err's message indicates the cerrors
+// AlreadyExists case CreateRecord returns on a key collision.
+func isAlreadyExists(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "already exists")
+}

--- a/providers/gcp/clouddns/dns.go
+++ b/providers/gcp/clouddns/dns.go
@@ -233,10 +233,6 @@ func (m *Mock) CreateRecord(_ context.Context, cfg driver.RecordConfig) (*driver
 
 	key := recordKey(cfg.ZoneID, cfg.Name, cfg.Type, cfg.SetID)
 
-	if m.records.Has(key) {
-		return nil, cerrors.Newf(cerrors.AlreadyExists, "resource record set %q already exists in zone %q", cfg.Name, cfg.ZoneID)
-	}
-
 	values := make([]string, len(cfg.Values))
 	copy(values, cfg.Values)
 
@@ -257,7 +253,13 @@ func (m *Mock) CreateRecord(_ context.Context, cfg driver.RecordConfig) (*driver
 		SetID:  cfg.SetID,
 	}
 
-	m.records.Set(key, rec)
+	// SetIfAbsent makes the existence-check-then-create a single atomic
+	// operation under the store's lock, so two concurrent CreateRecord calls
+	// racing on the same key can never both succeed (a Has-then-Set pair
+	// would let both callers observe "absent" before either writes).
+	if !m.records.SetIfAbsent(key, rec) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "resource record set %q already exists in zone %q", cfg.Name, cfg.ZoneID)
+	}
 
 	// Update zone record count.
 	m.zones.Update(cfg.ZoneID, func(z driver.ZoneInfo) driver.ZoneInfo {
@@ -372,10 +374,6 @@ func (m *Mock) UpdateRecord(_ context.Context, cfg driver.RecordConfig) (*driver
 
 	key := recordKey(cfg.ZoneID, cfg.Name, cfg.Type, cfg.SetID)
 
-	if _, ok := m.records.Get(key); !ok {
-		return nil, cerrors.Newf(cerrors.NotFound, "resource record set %q of type %q not found in zone %q", cfg.Name, cfg.Type, cfg.ZoneID)
-	}
-
 	values := make([]string, len(cfg.Values))
 	copy(values, cfg.Values)
 
@@ -396,7 +394,12 @@ func (m *Mock) UpdateRecord(_ context.Context, cfg driver.RecordConfig) (*driver
 		SetID:  cfg.SetID,
 	}
 
-	m.records.Set(key, rec)
+	// Update replaces the value only if the key still exists, all under the
+	// store's lock — a Get-then-Set pair could let a concurrent DeleteRecord
+	// land in between, silently resurrecting a record the caller just deleted.
+	if !m.records.Update(key, func(driver.RecordInfo) driver.RecordInfo { return rec }) {
+		return nil, cerrors.Newf(cerrors.NotFound, "resource record set %q of type %q not found in zone %q", cfg.Name, cfg.Type, cfg.ZoneID)
+	}
 
 	result := rec
 

--- a/server/gcp/clouddns/concurrency_sdk_test.go
+++ b/server/gcp/clouddns/concurrency_sdk_test.go
@@ -3,6 +3,7 @@ package clouddns_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -12,13 +13,14 @@ import (
 )
 
 // TestSDKChangesCreateConcurrentSameAdditionExactlyOneWins locks
-// changes.create's atomicity under concurrency: two callers racing to add the
-// SAME name+type record set to the same zone must not both succeed (Cloud
-// DNS rejects the loser with alreadyExists), and the zone must end up with
-// exactly one record set at that name+type — never zero (lost) and never
-// duplicated. Before the fix, createChange validated the whole batch and only
-// then applied it with no lock spanning the two steps, so two concurrent
-// requests could both pass validation against the same pre-change state.
+// changes.create's atomicity for the SAME name+type record set: two callers
+// racing to add it must not both succeed (Cloud DNS rejects the loser with
+// alreadyExists), and the zone must end up with exactly one record set —
+// never zero (lost) and never duplicated. Note this same-key case is actually
+// guaranteed by CreateRecord's atomic SetIfAbsent (providers/gcp/clouddns)
+// regardless of applyMu, since both additions land on the same store key; see
+// TestSDKChangesCreateConcurrentCNAMEExclusivityAcrossKeys below for the
+// cross-key case that only applyMu protects.
 func TestSDKChangesCreateConcurrentSameAdditionExactlyOneWins(t *testing.T) {
 	svc := newDNSService(t)
 	ctx := context.Background()
@@ -84,15 +86,15 @@ func TestSDKChangesCreateConcurrentSameAdditionExactlyOneWins(t *testing.T) {
 	}
 }
 
-// TestSDKDeleteZoneConcurrentWithChangesCreateNeverLosesRecord locks the
-// applyMu lock added to serialize managedZones.delete's empty-check-then-
-// delete span against changes.create: a concurrent changes.create adding a
-// record must not be able to land in the window between delete's check and
-// its call to the driver — every outcome must be consistent (either the
-// added record survives because delete saw it and refused with
-// containerNotEmpty, or delete won the race and the add then targets a
-// deleted zone), never a zone deleted while a record the check should have
-// seen silently disappears without a trace.
+// TestSDKDeleteZoneConcurrentWithChangesCreateNeverLosesRecord exercises
+// managedZones.delete racing a changes.create on the same zone: every outcome
+// must be consistent (either the added record survives because delete saw it
+// and refused with containerNotEmpty, or delete won the race and the add then
+// targets a deleted zone), never a zone deleted while a record the check
+// should have seen silently disappears without a trace. This scenario is
+// covered by applyMu but does not reliably falsify on its own if applyMu is
+// removed — see TestSDKChangesCreateConcurrentCNAMEExclusivityAcrossKeys for
+// the test that does.
 func TestSDKDeleteZoneConcurrentWithChangesCreateNeverLosesRecord(t *testing.T) {
 	svc := newDNSService(t)
 	ctx := context.Background()
@@ -157,6 +159,77 @@ func TestSDKDeleteZoneConcurrentWithChangesCreateNeverLosesRecord(t *testing.T) 
 
 		if len(rrsets.Rrsets) != 1 {
 			t.Fatalf("addition reported success but rrset count = %d, want 1", len(rrsets.Rrsets))
+		}
+	}
+}
+
+// TestSDKChangesCreateConcurrentCNAMEExclusivityAcrossKeys is the test that
+// actually falsifies on a reverted applyMu. A CNAME addition and an A
+// addition for the SAME name land on different dns driver store keys
+// (recordKey folds in the record type), so CreateRecord's per-key
+// SetIfAbsent — which is what protects the same-key case above — cannot see
+// or prevent this collision. Cloud DNS forbids a name from carrying both a
+// CNAME and any other record type; checkCNAME enforces that by reading the
+// zone's current records before a batch applies. Without applyMu serializing
+// changes.create's validate-then-apply span, two concurrent batches (one
+// adding the CNAME, one adding the A) can each read the pre-change state —
+// neither sees the other's not-yet-applied addition — conclude there's no
+// conflict, and both apply, leaving the zone with both. With applyMu in
+// place, the second batch to run always observes the first's already-applied
+// record and is rejected.
+func TestSDKChangesCreateConcurrentCNAMEExclusivityAcrossKeys(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	if _, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+		Name: "cname-exclusivity", DnsName: "cname-exclusivity.example.com.",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("ManagedZones.Create: %v", err)
+	}
+
+	const trials = 100
+
+	var wg sync.WaitGroup
+
+	for i := range trials {
+		name := fmt.Sprintf("race%d.cname-exclusivity.example.com.", i)
+
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+
+			_, _ = svc.Changes.Create(testProject, "cname-exclusivity", &dns.Change{
+				Additions: []*dns.ResourceRecordSet{
+					{Name: name, Type: "CNAME", Ttl: 300, Rrdatas: []string{"target.example.com."}},
+				},
+			}).Context(ctx).Do()
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			_, _ = svc.Changes.Create(testProject, "cname-exclusivity", &dns.Change{
+				Additions: []*dns.ResourceRecordSet{
+					{Name: name, Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1"}},
+				},
+			}).Context(ctx).Do()
+		}()
+	}
+
+	wg.Wait()
+
+	for i := range trials {
+		name := fmt.Sprintf("race%d.cname-exclusivity.example.com.", i)
+
+		rrsets, err := svc.ResourceRecordSets.List(testProject, "cname-exclusivity").Name(name).Context(ctx).Do()
+		if err != nil {
+			t.Fatalf("ResourceRecordSets.List(%s): %v", name, err)
+		}
+
+		if len(rrsets.Rrsets) > 1 {
+			t.Fatalf("name %s has %d record sets, want at most 1 (CNAME exclusivity violated): %+v",
+				name, len(rrsets.Rrsets), rrsets.Rrsets)
 		}
 	}
 }

--- a/server/gcp/clouddns/concurrency_sdk_test.go
+++ b/server/gcp/clouddns/concurrency_sdk_test.go
@@ -1,0 +1,162 @@
+package clouddns_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	dns "google.golang.org/api/dns/v1"
+	"google.golang.org/api/googleapi"
+)
+
+// TestSDKChangesCreateConcurrentSameAdditionExactlyOneWins locks
+// changes.create's atomicity under concurrency: two callers racing to add the
+// SAME name+type record set to the same zone must not both succeed (Cloud
+// DNS rejects the loser with alreadyExists), and the zone must end up with
+// exactly one record set at that name+type — never zero (lost) and never
+// duplicated. Before the fix, createChange validated the whole batch and only
+// then applied it with no lock spanning the two steps, so two concurrent
+// requests could both pass validation against the same pre-change state.
+func TestSDKChangesCreateConcurrentSameAdditionExactlyOneWins(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	if _, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+		Name: "concurrent-add", DnsName: "concurrent-add.example.com.",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("ManagedZones.Create: %v", err)
+	}
+
+	const workers = 12
+
+	var (
+		wg     sync.WaitGroup
+		oks    atomic.Int32
+		exists atomic.Int32
+		other  atomic.Int32
+	)
+
+	for range workers {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			_, err := svc.Changes.Create(testProject, "concurrent-add", &dns.Change{
+				Additions: []*dns.ResourceRecordSet{
+					{Name: "www.concurrent-add.example.com.", Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1"}},
+				},
+			}).Context(ctx).Do()
+
+			var gerr *googleapi.Error
+
+			switch {
+			case err == nil:
+				oks.Add(1)
+			case errors.As(err, &gerr) && gerr.Code == 409:
+				exists.Add(1)
+			default:
+				other.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if other.Load() != 0 {
+		t.Fatalf("unexpected error kind from %d calls", other.Load())
+	}
+
+	if oks.Load() != 1 {
+		t.Fatalf("successful changes.create = %d, want exactly 1 (rejected=%d)", oks.Load(), exists.Load())
+	}
+
+	rrsets, err := svc.ResourceRecordSets.List(testProject, "concurrent-add").
+		Name("www.concurrent-add.example.com.").Type("A").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("ResourceRecordSets.List: %v", err)
+	}
+
+	if len(rrsets.Rrsets) != 1 {
+		t.Fatalf("rrsets for www.concurrent-add.example.com./A = %d, want 1", len(rrsets.Rrsets))
+	}
+}
+
+// TestSDKDeleteZoneConcurrentWithChangesCreateNeverLosesRecord locks the
+// applyMu lock added to serialize managedZones.delete's empty-check-then-
+// delete span against changes.create: a concurrent changes.create adding a
+// record must not be able to land in the window between delete's check and
+// its call to the driver — every outcome must be consistent (either the
+// added record survives because delete saw it and refused with
+// containerNotEmpty, or delete won the race and the add then targets a
+// deleted zone), never a zone deleted while a record the check should have
+// seen silently disappears without a trace.
+func TestSDKDeleteZoneConcurrentWithChangesCreateNeverLosesRecord(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	if _, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+		Name: "concurrent-del", DnsName: "concurrent-del.example.com.",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("ManagedZones.Create: %v", err)
+	}
+
+	var wg sync.WaitGroup
+
+	var addErr, delErr error
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		_, err := svc.Changes.Create(testProject, "concurrent-del", &dns.Change{
+			Additions: []*dns.ResourceRecordSet{
+				{Name: "www.concurrent-del.example.com.", Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1"}},
+			},
+		}).Context(ctx).Do()
+		addErr = err
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		delErr = svc.ManagedZones.Delete(testProject, "concurrent-del").Context(ctx).Do()
+	}()
+
+	wg.Wait()
+
+	zoneGone := delErr == nil
+
+	if zoneGone {
+		// Delete won: it must have seen an empty zone, so the add must have
+		// failed against a zone that no longer exists (never silently applied
+		// to a zone delete then claimed was empty).
+		if addErr == nil {
+			t.Fatalf("zone was deleted but the concurrent record addition also reported success")
+		}
+
+		return
+	}
+
+	// The add won (or both landed with the delete rejected): the zone must
+	// still exist, and if the addition succeeded the record must be present.
+	_, getErr := svc.ManagedZones.Get(testProject, "concurrent-del").Context(ctx).Do()
+	if getErr != nil {
+		t.Fatalf("zone missing after delete was rejected: %v", getErr)
+	}
+
+	if addErr == nil {
+		rrsets, err := svc.ResourceRecordSets.List(testProject, "concurrent-del").
+			Name("www.concurrent-del.example.com.").Type("A").Context(ctx).Do()
+		if err != nil {
+			t.Fatalf("ResourceRecordSets.List: %v", err)
+		}
+
+		if len(rrsets.Rrsets) != 1 {
+			t.Fatalf("addition reported success but rrset count = %d, want 1", len(rrsets.Rrsets))
+		}
+	}
+}

--- a/server/gcp/clouddns/handler.go
+++ b/server/gcp/clouddns/handler.go
@@ -56,6 +56,17 @@ type Handler struct {
 	// index within this per-zone log. Guarded by mu.
 	mu      sync.Mutex
 	changes map[string][]changeJSON
+
+	// applyMu serializes changes.create's validate-then-apply span and
+	// managedZones.delete's empty-check-then-delete span, both against
+	// concurrent callers and against each other. The dns driver has no
+	// multi-key transaction primitive, so Changes.create's atomic
+	// all-or-nothing semantics — and delete's refusal on a non-empty zone —
+	// only hold if no other wire-layer mutation can land in the window between
+	// a handler's validation read and its apply. Distinct from mu, which only
+	// guards the change-log slice: holding this lock across a call that
+	// (via recordChange) also takes mu would self-deadlock.
+	applyMu sync.Mutex
 }
 
 // New returns a Cloud DNS handler backed by d.

--- a/server/gcp/clouddns/operations.go
+++ b/server/gcp/clouddns/operations.go
@@ -275,6 +275,11 @@ func (h *Handler) deleteZone(w http.ResponseWriter, r *http.Request, rt route) {
 		return
 	}
 
+	// Hold applyMu across the empty-check and the delete so a concurrent
+	// changes.create cannot slip a record into the zone between the two.
+	h.applyMu.Lock()
+	defer h.applyMu.Unlock()
+
 	// Cloud DNS refuses to delete a zone that still holds user record sets; only
 	// the auto-created apex SOA/NS may remain. Anything else → 400 containerNotEmpty.
 	if ok := h.rejectIfNotEmpty(w, r, id); !ok {
@@ -338,18 +343,24 @@ func (h *Handler) createChange(w http.ResponseWriter, r *http.Request, rt route)
 		return
 	}
 
+	// Hold applyMu across validation and apply so a concurrent changes.create
+	// (or managedZones.delete) on the same zone cannot invalidate a decision
+	// this call already made — the dns driver has no multi-key transaction
+	// primitive, so this lock is what makes the batch's all-or-nothing
+	// semantics hold under concurrency, not just single-threaded.
+	h.applyMu.Lock()
+	defer h.applyMu.Unlock()
+
 	info, err := h.dns.GetZone(r.Context(), id)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
 	}
 
-	// Cloud DNS applies a change atomically. The dns driver has no batch/
-	// transaction primitive, so validate the whole batch up front — deletions
-	// resolve and don't strip the apex, additions don't collide, and no name is
-	// left with a CNAME beside another type — before any mutation, so a bad batch
-	// fails cleanly without half-applying. (A concurrent writer between validation
-	// and apply could still race; a true fix needs a driver-level transaction.)
+	// Cloud DNS applies a change atomically: validate the whole batch up front —
+	// deletions resolve and don't strip the apex, additions don't collide, and no
+	// name is left with a CNAME beside another type — before any mutation, so a
+	// bad batch fails cleanly without half-applying.
 	if !h.checkDeletions(w, r, id, apexDNSName(info), &req) ||
 		!h.checkAdditions(w, r, id, &req) ||
 		!h.checkCNAME(w, r, id, &req) {


### PR DESCRIPTION
## Summary

GCP Cloud DNS's managed-zone/rrset/changes.create surface is already deep (auto NS/SOA seeding, delete-when-empty guard, changes.create batch validation with deletion-match/addition-collision/CNAME-coexistence checks, changes.list/get log, private zones, DNSSEC). This PR closes the concurrency gaps left in that implementation:

- `providers/gcp/clouddns/dns.go`: `CreateRecord` did `Has(key)` then `Set(key, ...)` as two separate store calls — two concurrent creates of the same name+type could both observe "absent" and both write, so the loser's `AlreadyExists` never actually fired and one of the two writes was silently lost. Now uses the store's atomic `SetIfAbsent`. `UpdateRecord` did `Get` (existence check) then unconditional `Set` — a concurrent `DeleteRecord` landing in between would be silently undone. Now uses the store's atomic `Update`, which only writes if the key still exists.
- `server/gcp/clouddns/operations.go` / `handler.go`: `changes.create` validated a batch (deletions resolve, additions don't collide, no CNAME coexistence violation) and only then applied it, with no lock spanning the two steps — the code's own comment flagged this as an open race. Same for `managedZones.delete`'s empty-check-then-delete. Added a handler-level `applyMu` serializing both spans, so Cloud DNS's atomic all-or-nothing changes.create semantics and the delete-when-empty guard hold under concurrent requests, not just single-threaded ones.

## What was verified present (no change needed)

- Zone auto NS/SOA seeding on create, delete-when-empty (`containerNotEmpty`) guard
- changes.create: deletion-must-match-exactly (TTL + rrdatas), addition-collision detection, apex NS/SOA deletion protection, CNAME-coexistence rejection, changes.list/get replay log
- Record types are unrestricted strings (A/AAAA/CNAME/MX/TXT/NS/SOA/SRV/CAA all pass through), private zones with visibility networks, DNSSEC config round-trip

## Testing

- `providers/gcp/clouddns/concurrency_test.go`: concurrent `CreateRecord`/`UpdateRecord` races against the same key, run under `-race`
- `server/gcp/clouddns/concurrency_sdk_test.go`: concurrent `changes.create` on the same rrset, and concurrent `changes.create` vs `managedZones.delete`, driven through the real `google.golang.org/api/dns/v1` SDK
- Verified each new test reproduces the pre-fix bug when the corresponding fix is reverted (confirmed with `GOMAXPROCS=8 -race`), then passes reliably with the fix in place

## Deferred (out of scope for this PR)

- Zone-name-uniqueness check in `CreateZone` (scan-then-Set across the zones store) has the same class of TOCTOU race, but fixing it needs a secondary project+name index rather than a single-key store primitive — separate change.
- DNSSEC key generation/signing, private-zone network reachability enforcement, geo/weighted routing policies at the wire layer — unimplemented, unrelated to this PR's theme.