### PR TITLE
feat(azuredns): record-set etag/If-Match/If-None-Match concurrency

### DIFF
--- a/providers/azure/dns/dns.go
+++ b/providers/azure/dns/dns.go
@@ -3,8 +3,12 @@ package dns
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
 	"maps"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -23,6 +27,22 @@ type Mock struct {
 	records      *memstore.Store[driver.RecordInfo]
 	healthChecks *memstore.Store[driver.HealthCheckInfo]
 	opts         *config.Options
+
+	// recordsMu serializes the read-check-mint-write sequence every
+	// record-set-mutating method performs, so a concurrent write can never
+	// observe a stale existence/etag check and then land its own write past it
+	// — the classic TOCTOU a bare memstore Get followed by a separate Set/Delete
+	// call would allow. It is a plain package-level mutex rather than a
+	// per-record lock: DNS record-set write volume is low, and a single lock
+	// keeps the CreateOrUpdate atomicity (existence + If-Match/If-None-Match
+	// check + write, all-or-nothing) trivially easy to reason about.
+	recordsMu sync.Mutex
+	// etagSeq mints a fresh, distinct ETag on every record-set write, so a
+	// document's etag changes on each mutation and an If-Match/If-None-Match
+	// precondition has something to detect. Azure's real etags are opaque
+	// tokens SDKs only compare for equality, so a rotating synthetic value
+	// round-trips correctly without a real version counter.
+	etagSeq atomic.Uint64
 }
 
 // New creates a new Azure DNS mock with the given configuration options.
@@ -33,6 +53,18 @@ func New(opts *config.Options) *Mock {
 		healthChecks: memstore.New[driver.HealthCheckInfo](),
 		opts:         opts,
 	}
+}
+
+// nextETag mints a fresh, GUID-shaped entity tag distinct from any previously
+// minted one, matching the look of the deterministic etags azurearm.ETag
+// produces elsewhere in the wire layer. It is computed here rather than by
+// importing that wire-layer helper: a provider must not depend on the server
+// package that wraps it (see the three-layer architecture in CLAUDE.md).
+func (m *Mock) nextETag(key string) string {
+	seq := m.etagSeq.Add(1)
+	h := sha256.Sum256(fmt.Appendf(nil, "%s/%d", key, seq))
+
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", h[0:4], h[4:6], h[6:8], h[8:10], h[10:16])
 }
 
 // cnameType is the DNS CNAME record type. Azure enforces CNAME coexistence
@@ -164,21 +196,11 @@ func (m *Mock) UpdateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateRecord(_ context.Context, cfg driver.RecordConfig) (*driver.RecordInfo, error) {
-	if _, ok := m.zones.Get(cfg.ZoneID); !ok {
-		return nil, cerrors.Newf(cerrors.NotFound, "zone %q not found", cfg.ZoneID)
-	}
+	m.recordsMu.Lock()
+	defer m.recordsMu.Unlock()
 
-	if cfg.Name == "" {
-		return nil, cerrors.New(cerrors.InvalidArgument, "record name is required")
-	}
-
-	if cfg.Type == "" {
-		return nil, cerrors.New(cerrors.InvalidArgument, "record type is required")
-	}
-
-	if m.hasCNAMEConflict(cfg.ZoneID, cfg.Name, cfg.Type) {
-		return nil, cerrors.Newf(cerrors.InvalidArgument,
-			"a CNAME record set cannot coexist with another record set of a different type at name %q", cfg.Name)
+	if err := m.validateRecordCfg(&cfg); err != nil {
+		return nil, err
 	}
 
 	key := recordKey(cfg.ZoneID, cfg.Name, cfg.Type, cfg.SetID)
@@ -187,22 +209,7 @@ func (m *Mock) CreateRecord(_ context.Context, cfg driver.RecordConfig) (*driver
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "record %q already exists in zone %q", cfg.Name, cfg.ZoneID)
 	}
 
-	values := make([]string, len(cfg.Values))
-	copy(values, cfg.Values)
-
-	weight := copyWeight(cfg.Weight)
-
-	rec := driver.RecordInfo{
-		ZoneID: cfg.ZoneID,
-		Name:   cfg.Name,
-		Type:   cfg.Type,
-		TTL:    cfg.TTL,
-		Values: values,
-		Weight: weight,
-		SetID:  cfg.SetID,
-		SOA:    copySOA(cfg.SOA),
-	}
-
+	rec := m.buildRecordInfo(&cfg, key)
 	m.records.Set(key, rec)
 
 	// Update zone record count.
@@ -214,6 +221,52 @@ func (m *Mock) CreateRecord(_ context.Context, cfg driver.RecordConfig) (*driver
 	result := rec
 
 	return &result, nil
+}
+
+// validateRecordCfg checks the invariants every record-set write (create,
+// update, and the atomic upsert) must satisfy: the owning zone exists, a name
+// and type are supplied, and the write does not violate Azure's CNAME
+// coexistence rule.
+func (m *Mock) validateRecordCfg(cfg *driver.RecordConfig) error {
+	if _, ok := m.zones.Get(cfg.ZoneID); !ok {
+		return cerrors.Newf(cerrors.NotFound, "zone %q not found", cfg.ZoneID)
+	}
+
+	if cfg.Name == "" {
+		return cerrors.New(cerrors.InvalidArgument, "record name is required")
+	}
+
+	if cfg.Type == "" {
+		return cerrors.New(cerrors.InvalidArgument, "record type is required")
+	}
+
+	if m.hasCNAMEConflict(cfg.ZoneID, cfg.Name, cfg.Type) {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"a CNAME record set cannot coexist with another record set of a different type at name %q", cfg.Name)
+	}
+
+	return nil
+}
+
+// buildRecordInfo copies cfg's mutable fields into a fresh RecordInfo and
+// mints it a new ETag distinct from whatever the key previously held, so every
+// successful write — create or update — changes the record set's etag the way
+// real Azure DNS does.
+func (m *Mock) buildRecordInfo(cfg *driver.RecordConfig, key string) driver.RecordInfo {
+	values := make([]string, len(cfg.Values))
+	copy(values, cfg.Values)
+
+	return driver.RecordInfo{
+		ZoneID: cfg.ZoneID,
+		Name:   cfg.Name,
+		Type:   cfg.Type,
+		TTL:    cfg.TTL,
+		Values: values,
+		Weight: copyWeight(cfg.Weight),
+		SetID:  cfg.SetID,
+		SOA:    copySOA(cfg.SOA),
+		ETag:   m.nextETag(key),
+	}
 }
 
 // hasCNAMEConflict reports whether creating a record of recordType at name
@@ -245,14 +298,44 @@ func (m *Mock) hasCNAMEConflict(zoneID, name, recordType string) bool {
 
 // DeleteRecord deletes a DNS record set from the specified zone.
 func (m *Mock) DeleteRecord(_ context.Context, zoneID, name, recordType string) error {
+	m.recordsMu.Lock()
+	defer m.recordsMu.Unlock()
+
+	return m.deleteRecordLocked(zoneID, name, recordType, "")
+}
+
+// DeleteRecordAtomic implements Azure DNS RecordSets.Delete's optional If-Match
+// precondition: a non-empty ifMatch rejects the delete with FailedPrecondition
+// if the record set's current ETag does not equal it, checked and acted on
+// under the same recordsMu lock as every other record-set write so the check
+// cannot be raced by a concurrent update. Like UpsertRecordAtomic, it is
+// Azure-specific and lives outside the shared driver.DNS interface.
+func (m *Mock) DeleteRecordAtomic(_ context.Context, zoneID, name, recordType, ifMatch string) error {
+	m.recordsMu.Lock()
+	defer m.recordsMu.Unlock()
+
+	return m.deleteRecordLocked(zoneID, name, recordType, ifMatch)
+}
+
+// deleteRecordLocked is the shared body of DeleteRecord and DeleteRecordAtomic,
+// called with recordsMu already held. ifMatch is checked only against the
+// single-record-set (no set ID) match: a weighted record set's several set-ID
+// entries under the same name+type have no single etag an If-Match could
+// meaningfully compare against, so that batch-delete path ignores it.
+func (m *Mock) deleteRecordLocked(zoneID, name, recordType, ifMatch string) error {
 	if _, ok := m.zones.Get(zoneID); !ok {
 		return cerrors.Newf(cerrors.NotFound, "zone %q not found", zoneID)
 	}
 
 	key := recordKey(zoneID, name, recordType, "")
 
-	// Try without set ID first. If not found, search for any matching record with a set ID.
-	if m.records.Delete(key) {
+	if existing, ok := m.records.Get(key); ok {
+		if ifMatch != "" && existing.ETag != ifMatch {
+			return cerrors.Newf(cerrors.FailedPrecondition,
+				"etag mismatch for record set %q of type %q in zone %q", name, recordType, zoneID)
+		}
+
+		m.records.Delete(key)
 		m.zones.Update(zoneID, func(z driver.ZoneInfo) driver.ZoneInfo {
 			z.RecordCount--
 			return z
@@ -339,6 +422,9 @@ func (m *Mock) ListRecords(_ context.Context, zoneID string) ([]driver.RecordInf
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) UpdateRecord(_ context.Context, cfg driver.RecordConfig) (*driver.RecordInfo, error) {
+	m.recordsMu.Lock()
+	defer m.recordsMu.Unlock()
+
 	if _, ok := m.zones.Get(cfg.ZoneID); !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "zone %q not found", cfg.ZoneID)
 	}
@@ -349,26 +435,80 @@ func (m *Mock) UpdateRecord(_ context.Context, cfg driver.RecordConfig) (*driver
 		return nil, cerrors.Newf(cerrors.NotFound, "record %q of type %q not found in zone %q", cfg.Name, cfg.Type, cfg.ZoneID)
 	}
 
-	values := make([]string, len(cfg.Values))
-	copy(values, cfg.Values)
-
-	weight := copyWeight(cfg.Weight)
-
-	rec := driver.RecordInfo{
-		ZoneID: cfg.ZoneID,
-		Name:   cfg.Name,
-		Type:   cfg.Type,
-		TTL:    cfg.TTL,
-		Values: values,
-		Weight: weight,
-		SetID:  cfg.SetID,
-		SOA:    copySOA(cfg.SOA),
-	}
-
+	rec := m.buildRecordInfo(&cfg, key)
 	m.records.Set(key, rec)
 	result := rec
 
 	return &result, nil
+}
+
+// wildcardETag is the If-None-Match value Azure DNS (and HTTP conditional
+// requests generally) uses to mean "any representation" — i.e. "succeed only
+// if no record set currently exists at this key".
+const wildcardETag = "*"
+
+// UpsertRecordAtomic implements Azure DNS RecordSets.CreateOrUpdate's ETag
+// optimistic-concurrency semantics in a single atomic step: an empty
+// ifNoneMatch/ifMatch pair is an unconditional upsert; ifNoneMatch == "*"
+// makes the call create-only, rejecting it with FailedPrecondition if a record
+// set already exists at the key; a non-empty ifMatch makes it a conditional
+// update, rejecting it with FailedPrecondition if the record set is missing or
+// its current ETag does not equal ifMatch. It is Azure-specific — If-Match/
+// If-None-Match preconditions are an ARM wire concept with no AWS Route 53 or
+// GCP Cloud DNS equivalent — so it lives outside the shared driver.DNS
+// interface rather than as a new interface method those providers would also
+// have to implement.
+//
+// The whole read-check-mint-write sequence runs under recordsMu, the same lock
+// CreateRecord/UpdateRecord/DeleteRecord take, so a concurrent write against the
+// same key can never slip between this call's precondition check and its store
+// — the exact TOCTOU class a separate Get followed by a Create-or-Update call
+// would allow.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) UpsertRecordAtomic(
+	_ context.Context, cfg driver.RecordConfig, ifMatch, ifNoneMatch string,
+) (info *driver.RecordInfo, created bool, err error) {
+	m.recordsMu.Lock()
+	defer m.recordsMu.Unlock()
+
+	if verr := m.validateRecordCfg(&cfg); verr != nil {
+		return nil, false, verr
+	}
+
+	key := recordKey(cfg.ZoneID, cfg.Name, cfg.Type, cfg.SetID)
+	existing, exists := m.records.Get(key)
+
+	if ifNoneMatch == wildcardETag && exists {
+		return nil, false, cerrors.Newf(cerrors.FailedPrecondition,
+			"record set %q of type %q already exists in zone %q", cfg.Name, cfg.Type, cfg.ZoneID)
+	}
+
+	if ifMatch != "" {
+		if !exists {
+			return nil, false, cerrors.Newf(cerrors.NotFound,
+				"record %q of type %q not found in zone %q", cfg.Name, cfg.Type, cfg.ZoneID)
+		}
+
+		if existing.ETag != ifMatch {
+			return nil, false, cerrors.Newf(cerrors.FailedPrecondition,
+				"etag mismatch for record set %q of type %q in zone %q", cfg.Name, cfg.Type, cfg.ZoneID)
+		}
+	}
+
+	rec := m.buildRecordInfo(&cfg, key)
+	m.records.Set(key, rec)
+
+	if !exists {
+		m.zones.Update(cfg.ZoneID, func(z driver.ZoneInfo) driver.ZoneInfo {
+			z.RecordCount++
+			return z
+		})
+	}
+
+	result := rec
+
+	return &result, !exists, nil
 }
 
 // copyWeight returns a deep copy of a weight pointer.

--- a/providers/azure/dns/etag_concurrency_test.go
+++ b/providers/azure/dns/etag_concurrency_test.go
@@ -1,0 +1,211 @@
+package dns
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	driver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+)
+
+// TestUpsertRecordAtomicIfNoneMatchCreateOnly locks Azure DNS's create-only
+// precondition: If-None-Match:"*" must succeed the first time a record set is
+// written and fail FailedPrecondition on a second call at the same key, since
+// the record set already exists by then.
+func TestUpsertRecordAtomicIfNoneMatchCreateOnly(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("create zone: %v", err)
+	}
+
+	cfg := driver.RecordConfig{ZoneID: zone.ID, Name: "www", Type: "A", TTL: 300, Values: []string{"192.0.2.1"}}
+
+	info, created, err := m.UpsertRecordAtomic(ctx, cfg, "", wildcardETag)
+	if err != nil {
+		t.Fatalf("first create-only upsert: %v", err)
+	}
+	if !created {
+		t.Fatal("first upsert should report created=true")
+	}
+	if info.ETag == "" {
+		t.Fatal("created record set has empty ETag")
+	}
+
+	_, _, err = m.UpsertRecordAtomic(ctx, cfg, "", wildcardETag)
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("second create-only upsert: err=%v, want FailedPrecondition", err)
+	}
+}
+
+// TestUpsertRecordAtomicIfMatch locks Azure DNS's conditional-update
+// precondition: a stale If-Match is rejected FailedPrecondition without
+// mutating the record, and the current etag succeeds and mints a new one.
+func TestUpsertRecordAtomicIfMatch(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("create zone: %v", err)
+	}
+
+	cfg := driver.RecordConfig{ZoneID: zone.ID, Name: "www", Type: "A", TTL: 300, Values: []string{"192.0.2.1"}}
+
+	initial, _, err := m.UpsertRecordAtomic(ctx, cfg, "", "")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// A stale If-Match must be rejected and must not change the stored record.
+	cfg.Values = []string{"192.0.2.99"}
+
+	_, _, err = m.UpsertRecordAtomic(ctx, cfg, "not-the-current-etag", "")
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("stale If-Match: err=%v, want FailedPrecondition", err)
+	}
+
+	unchanged, err := m.GetRecord(ctx, zone.ID, "www", "A")
+	if err != nil {
+		t.Fatalf("GetRecord after rejected update: %v", err)
+	}
+	if unchanged.ETag != initial.ETag || unchanged.Values[0] != "192.0.2.1" {
+		t.Fatalf("record mutated despite stale If-Match: %+v", unchanged)
+	}
+
+	// The current etag must succeed and mint a new, different one.
+	updated, _, err := m.UpsertRecordAtomic(ctx, cfg, initial.ETag, "")
+	if err != nil {
+		t.Fatalf("current If-Match update: %v", err)
+	}
+	if updated.ETag == initial.ETag {
+		t.Fatal("successful update did not rotate the ETag")
+	}
+	if updated.Values[0] != "192.0.2.99" {
+		t.Fatalf("update did not apply: %+v", updated)
+	}
+
+	// If-Match against a record set that does not exist at all is NotFound, not
+	// FailedPrecondition.
+	missingCfg := driver.RecordConfig{ZoneID: zone.ID, Name: "missing", Type: "A", TTL: 300, Values: []string{"192.0.2.1"}}
+	if _, _, err = m.UpsertRecordAtomic(ctx, missingCfg, "some-etag", ""); !cerrors.IsNotFound(err) {
+		t.Fatalf("If-Match on missing record: err=%v, want NotFound", err)
+	}
+}
+
+// TestDeleteRecordAtomicIfMatch locks Azure DNS RecordSets.Delete's optional
+// If-Match precondition: a stale etag is rejected and the record survives; the
+// current etag deletes it.
+func TestDeleteRecordAtomicIfMatch(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("create zone: %v", err)
+	}
+
+	info, err := m.CreateRecord(ctx, driver.RecordConfig{
+		ZoneID: zone.ID, Name: "www", Type: "A", TTL: 300, Values: []string{"192.0.2.1"},
+	})
+	if err != nil {
+		t.Fatalf("create record: %v", err)
+	}
+
+	if err = m.DeleteRecordAtomic(ctx, zone.ID, "www", "A", "stale-etag"); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("stale If-Match delete: err=%v, want FailedPrecondition", err)
+	}
+
+	if _, err = m.GetRecord(ctx, zone.ID, "www", "A"); err != nil {
+		t.Fatalf("record should survive a rejected delete: %v", err)
+	}
+
+	if err = m.DeleteRecordAtomic(ctx, zone.ID, "www", "A", info.ETag); err != nil {
+		t.Fatalf("current If-Match delete: %v", err)
+	}
+
+	if _, err = m.GetRecord(ctx, zone.ID, "www", "A"); !cerrors.IsNotFound(err) {
+		t.Fatalf("record should be gone after delete: err=%v", err)
+	}
+}
+
+// TestUpsertRecordAtomicConcurrencyCreateOnly is the concurrency regression for
+// the ETag CAS: N goroutines race UpsertRecordAtomic with If-None-Match:"*" at
+// the same record-set key starting from an empty store. Exactly one may
+// succeed — the whole point of the create-only precondition — and every loser
+// must see FailedPrecondition, never a silent double-create or a lost update.
+// Run with -race -count=20 to catch the TOCTOU class of bug a separate
+// check-then-write (rather than one lock covering both) would allow.
+func TestUpsertRecordAtomicConcurrencyCreateOnly(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("create zone: %v", err)
+	}
+
+	const goroutines = 32
+
+	var (
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		succeeds int
+		fails    int
+	)
+
+	for range goroutines {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			cfg := driver.RecordConfig{
+				ZoneID: zone.ID, Name: "race", Type: "A", TTL: 300,
+				Values: []string{"192.0.2.1"},
+			}
+
+			_, _, uerr := m.UpsertRecordAtomic(ctx, cfg, "", wildcardETag)
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			switch {
+			case uerr == nil:
+				succeeds++
+			case cerrors.IsFailedPrecondition(uerr):
+				fails++
+			default:
+				t.Errorf("unexpected error: %v", uerr)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if succeeds != 1 {
+		t.Fatalf("succeeds = %d, want exactly 1", succeeds)
+	}
+	if fails != goroutines-1 {
+		t.Fatalf("fails = %d, want %d", fails, goroutines-1)
+	}
+
+	rec, err := m.GetRecord(ctx, zone.ID, "race", "A")
+	if err != nil {
+		t.Fatalf("GetRecord after race: %v", err)
+	}
+	if rec.ETag == "" {
+		t.Fatal("winning record has empty ETag")
+	}
+
+	zoneAfter, err := m.GetZone(ctx, zone.ID)
+	if err != nil {
+		t.Fatalf("GetZone after race: %v", err)
+	}
+	if zoneAfter.RecordCount != 1 {
+		t.Fatalf("zone record count = %d, want 1 (no double-count from a racing loser)", zoneAfter.RecordCount)
+	}
+}

--- a/server/azure/dns/etag_precondition_sdk_test.go
+++ b/server/azure/dns/etag_precondition_sdk_test.go
@@ -1,0 +1,190 @@
+package dns_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
+)
+
+// TestSDKAzureDNSRecordSetETagLifecycle is the end-to-end regression for record-
+// set ETag optimistic concurrency: a fresh zone already carries the auto SOA+NS
+// with real etags, a plain CreateOrUpdate mints one, If-None-Match:"*" makes a
+// second CreateOrUpdate at the same name create-only (412 once it already
+// exists), a stale If-Match is rejected 412 without mutating the record, and the
+// current etag succeeds and rotates to a new one.
+func TestSDKAzureDNSRecordSetETagLifecycle(t *testing.T) {
+	zones, records := newDNSClients(t)
+	ctx := context.Background()
+
+	const zone = "etag.com"
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, zone, armdns.Zone{Location: to.Ptr("global")}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	// The auto-created apex SOA and NS already carry real, non-empty etags.
+	list := records.NewListByDNSZonePager(testRG, zone, nil)
+
+	var sawSOAEtag, sawNSEtag bool
+
+	for list.More() {
+		page, err := list.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListByDNSZone: %v", err)
+		}
+
+		for _, rs := range page.Value {
+			if rs.Etag == nil || *rs.Etag == "" {
+				t.Fatalf("auto-created record set %+v has empty etag", rs)
+			}
+
+			switch {
+			case rs.Type != nil && *rs.Type == "Microsoft.Network/dnsZones/SOA":
+				sawSOAEtag = true
+			case rs.Type != nil && *rs.Type == "Microsoft.Network/dnsZones/NS":
+				sawNSEtag = true
+			}
+		}
+	}
+
+	if !sawSOAEtag || !sawNSEtag {
+		t.Fatalf("expected auto SOA and NS record sets with etags, sawSOAEtag=%v sawNSEtag=%v", sawSOAEtag, sawNSEtag)
+	}
+
+	// A plain CreateOrUpdate (no precondition) mints an etag.
+	created, err := records.CreateOrUpdate(ctx, testRG, zone, "www", armdns.RecordTypeA, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL:      to.Ptr(int64(300)),
+			ARecords: []*armdns.ARecord{{IPv4Address: to.Ptr("192.0.2.1")}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.CreateOrUpdate (initial): %v", err)
+	}
+	if created.Etag == nil || *created.Etag == "" {
+		t.Fatal("created record set has empty etag")
+	}
+
+	firstEtag := *created.Etag
+
+	// If-None-Match:"*" against an existing record set is rejected 412.
+	_, err = records.CreateOrUpdate(ctx, testRG, zone, "www", armdns.RecordTypeA, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL:      to.Ptr(int64(300)),
+			ARecords: []*armdns.ARecord{{IPv4Address: to.Ptr("192.0.2.2")}},
+		},
+	}, &armdns.RecordSetsClientCreateOrUpdateOptions{IfNoneMatch: to.Ptr("*")})
+	if !isStatus(err, 412) {
+		t.Fatalf("create-only over an existing record set: got %v, want 412", err)
+	}
+
+	// A stale If-Match is rejected 412 and must not mutate the record.
+	_, err = records.CreateOrUpdate(ctx, testRG, zone, "www", armdns.RecordTypeA, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL:      to.Ptr(int64(300)),
+			ARecords: []*armdns.ARecord{{IPv4Address: to.Ptr("192.0.2.3")}},
+		},
+	}, &armdns.RecordSetsClientCreateOrUpdateOptions{IfMatch: to.Ptr("not-the-real-etag")})
+	if !isStatus(err, 412) {
+		t.Fatalf("stale If-Match update: got %v, want 412", err)
+	}
+
+	unchanged, err := records.Get(ctx, testRG, zone, "www", armdns.RecordTypeA, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.Get after rejected update: %v", err)
+	}
+	if unchanged.Etag == nil || *unchanged.Etag != firstEtag {
+		t.Fatalf("etag changed despite rejected update: got %v, want %v", unchanged.Etag, firstEtag)
+	}
+	if len(unchanged.Properties.ARecords) != 1 || *unchanged.Properties.ARecords[0].IPv4Address != "192.0.2.1" {
+		t.Fatalf("record value changed despite rejected update: %+v", unchanged.Properties.ARecords)
+	}
+
+	// The current etag succeeds and rotates to a new one.
+	updated, err := records.CreateOrUpdate(ctx, testRG, zone, "www", armdns.RecordTypeA, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL:      to.Ptr(int64(300)),
+			ARecords: []*armdns.ARecord{{IPv4Address: to.Ptr("192.0.2.4")}},
+		},
+	}, &armdns.RecordSetsClientCreateOrUpdateOptions{IfMatch: to.Ptr(firstEtag)})
+	if err != nil {
+		t.Fatalf("update with current If-Match: %v", err)
+	}
+	if updated.Etag == nil || *updated.Etag == firstEtag {
+		t.Fatalf("etag did not rotate on successful update: got %v", updated.Etag)
+	}
+	if len(updated.Properties.ARecords) != 1 || *updated.Properties.ARecords[0].IPv4Address != "192.0.2.4" {
+		t.Fatalf("update did not apply: %+v", updated.Properties.ARecords)
+	}
+}
+
+// TestSDKAzureDNSDeleteRecordSetIfMatch is the delete-side counterpart: a stale
+// If-Match on RecordSets.Delete is rejected 412 and the record survives; the
+// current etag deletes it.
+func TestSDKAzureDNSDeleteRecordSetIfMatch(t *testing.T) {
+	zones, records := newDNSClients(t)
+	ctx := context.Background()
+
+	const zone = "etag-delete.com"
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, zone, armdns.Zone{Location: to.Ptr("global")}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	created, err := records.CreateOrUpdate(ctx, testRG, zone, "www", armdns.RecordTypeA, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL:      to.Ptr(int64(300)),
+			ARecords: []*armdns.ARecord{{IPv4Address: to.Ptr("192.0.2.1")}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.CreateOrUpdate: %v", err)
+	}
+
+	if _, err = records.Delete(ctx, testRG, zone, "www", armdns.RecordTypeA,
+		&armdns.RecordSetsClientDeleteOptions{IfMatch: to.Ptr("stale-etag")}); !isStatus(err, 412) {
+		t.Fatalf("delete with stale If-Match: got %v, want 412", err)
+	}
+
+	if _, err = records.Get(ctx, testRG, zone, "www", armdns.RecordTypeA, nil); err != nil {
+		t.Fatalf("record should survive a rejected delete: %v", err)
+	}
+
+	if _, err = records.Delete(ctx, testRG, zone, "www", armdns.RecordTypeA,
+		&armdns.RecordSetsClientDeleteOptions{IfMatch: created.Etag}); err != nil {
+		t.Fatalf("delete with current If-Match: %v", err)
+	}
+
+	if _, err = records.Get(ctx, testRG, zone, "www", armdns.RecordTypeA, nil); !isStatus(err, 404) {
+		t.Fatalf("record should be gone: got %v, want 404", err)
+	}
+}
+
+// TestSDKAzureDNSCreateOrUpdateIfNoneMatchNewRecord asserts If-None-Match:"*"
+// succeeds — as a plain create — the first time a record set is written, only
+// failing once one already exists at that name+type.
+func TestSDKAzureDNSCreateOrUpdateIfNoneMatchNewRecord(t *testing.T) {
+	zones, records := newDNSClients(t)
+	ctx := context.Background()
+
+	const zone = "etag-create.com"
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, zone, armdns.Zone{Location: to.Ptr("global")}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	created, err := records.CreateOrUpdate(ctx, testRG, zone, "fresh", armdns.RecordTypeA, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL:      to.Ptr(int64(300)),
+			ARecords: []*armdns.ARecord{{IPv4Address: to.Ptr("192.0.2.9")}},
+		},
+	}, &armdns.RecordSetsClientCreateOrUpdateOptions{IfNoneMatch: to.Ptr("*")})
+	if err != nil {
+		t.Fatalf("create-only against an absent record set: %v", err)
+	}
+	if created.Etag == nil || *created.Etag == "" {
+		t.Fatal("created record set has empty etag")
+	}
+}

--- a/server/azure/dns/handler.go
+++ b/server/azure/dns/handler.go
@@ -32,6 +32,7 @@
 package dns
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -54,6 +55,28 @@ const (
 // Handler serves Microsoft.Network/dnsZones ARM requests against a dns driver.
 type Handler struct {
 	dns dnsdriver.DNS
+}
+
+// atomicRecordUpserter is the optional capability the Azure dns.Mock exposes
+// for a single-lock CreateOrUpdate that atomically evaluates a record set's
+// If-Match/If-None-Match preconditions against its current ETag before minting
+// a fresh one and writing — closing the TOCTOU a separate GetRecord followed by
+// a Create-or-Update call would leave open between two concurrent PUTs. The
+// production Azure dns.Mock always implements it; createOrUpdateRecordSet falls
+// back to the plain (non-atomic, precondition-less) two-call upsert for any
+// driver that doesn't, so the handler stays usable against a minimal test
+// double too.
+type atomicRecordUpserter interface {
+	UpsertRecordAtomic(ctx context.Context, cfg dnsdriver.RecordConfig, ifMatch, ifNoneMatch string) (
+		info *dnsdriver.RecordInfo, created bool, err error)
+}
+
+// conditionalRecordDeleter is the optional capability the Azure dns.Mock
+// exposes for a Delete that honors RecordSets.Delete's If-Match precondition.
+// deleteRecordSet falls back to the plain unconditional DeleteRecord (silently
+// ignoring any If-Match header) for a driver that doesn't implement it.
+type conditionalRecordDeleter interface {
+	DeleteRecordAtomic(ctx context.Context, zoneID, name, recordType, ifMatch string) error
 }
 
 // New returns an Azure DNS handler backed by d.

--- a/server/azure/dns/operations.go
+++ b/server/azure/dns/operations.go
@@ -176,9 +176,22 @@ func (h *Handler) createOrUpdateRecordSet(w http.ResponseWriter, r *http.Request
 		SOA:    soaConfigFromProps(body.Properties),
 	}
 
-	info, created, err := h.upsertRecord(r, &cfg)
+	ifMatch := r.Header.Get(headerIfMatch)
+	ifNoneMatch := r.Header.Get(headerIfNoneMatch)
+
+	info, created, err := h.upsertRecord(r, &cfg, ifMatch, ifNoneMatch)
 	if err != nil {
+		if cerrors.IsFailedPrecondition(err) {
+			// A record-set ETag precondition (If-Match/If-None-Match) failure is
+			// HTTP 412, not the 409 azurearm.WriteCErr maps FailedPrecondition to
+			// for other ARM resources — real Azure DNS, and the armdns SDK's
+			// poller, expect 412 specifically for a stale/mismatched etag.
+			azurearm.WriteError(w, http.StatusPreconditionFailed, "PreconditionFailed", err.Error())
+			return
+		}
+
 		azurearm.WriteCErr(w, err)
+
 		return
 	}
 
@@ -193,11 +206,20 @@ func (h *Handler) createOrUpdateRecordSet(w http.ResponseWriter, r *http.Request
 	azurearm.WriteJSON(w, status, toRecordSetJSON(rp, rp.ResourceName, info))
 }
 
-// upsertRecord updates the record if it already exists, otherwise creates it —
-// Azure's RecordSets.CreateOrUpdate is upsert semantics. The bool reports
-// whether the record set was newly created (true) or updated in place (false),
-// so the caller can pick the 201/200 status Azure returns.
-func (h *Handler) upsertRecord(r *http.Request, cfg *dnsdriver.RecordConfig) (*dnsdriver.RecordInfo, bool, error) {
+// upsertRecord performs Azure's RecordSets.CreateOrUpdate: an upsert honoring
+// any If-Match/If-None-Match precondition the request carries. When the driver
+// exposes UpsertRecordAtomic (the production Azure dns.Mock always does), the
+// whole existence-check + precondition-check + write runs as one atomic
+// operation under the driver's own lock. Otherwise it falls back to a plain
+// two-call upsert with no precondition support, for a minimal driver double
+// that hasn't implemented the atomic capability.
+func (h *Handler) upsertRecord(
+	r *http.Request, cfg *dnsdriver.RecordConfig, ifMatch, ifNoneMatch string,
+) (*dnsdriver.RecordInfo, bool, error) {
+	if au, ok := h.dns.(atomicRecordUpserter); ok {
+		return au.UpsertRecordAtomic(r.Context(), *cfg, ifMatch, ifNoneMatch)
+	}
+
 	if _, err := h.dns.GetRecord(r.Context(), cfg.ZoneID, cfg.Name, cfg.Type); err == nil {
 		info, uerr := h.dns.UpdateRecord(r.Context(), *cfg)
 		return info, false, uerr
@@ -347,9 +369,17 @@ func (h *Handler) deleteRecordSet(w http.ResponseWriter, r *http.Request, rp *az
 		return
 	}
 
-	derr := h.dns.DeleteRecord(r.Context(), zoneID, rp.SubResourceName, recordType)
+	derr := h.deleteRecord(r, zoneID, rp.SubResourceName, recordType)
 	if derr != nil && !cerrors.IsNotFound(derr) {
+		if cerrors.IsFailedPrecondition(derr) {
+			// See createOrUpdateRecordSet: an etag precondition failure is 412,
+			// not the 409 azurearm.WriteCErr maps FailedPrecondition to.
+			azurearm.WriteError(w, http.StatusPreconditionFailed, "PreconditionFailed", derr.Error())
+			return
+		}
+
 		azurearm.WriteCErr(w, derr)
+
 		return
 	}
 
@@ -361,6 +391,20 @@ func (h *Handler) deleteRecordSet(w http.ResponseWriter, r *http.Request, rp *az
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+// deleteRecord performs Azure's RecordSets.Delete, honoring the request's
+// If-Match precondition when the driver exposes DeleteRecordAtomic (the
+// production Azure dns.Mock always does). It falls back to the plain
+// unconditional DeleteRecord, ignoring If-Match, for a driver that doesn't.
+func (h *Handler) deleteRecord(r *http.Request, zoneID, name, recordType string) error {
+	ifMatch := r.Header.Get(headerIfMatch)
+
+	if cd, ok := h.dns.(conditionalRecordDeleter); ok {
+		return cd.DeleteRecordAtomic(r.Context(), zoneID, name, recordType, ifMatch)
+	}
+
+	return h.dns.DeleteRecord(r.Context(), zoneID, name, recordType)
 }
 
 // listRecordSets backs RecordSets.ListByDnsZone / ListAllByDnsZone: every

--- a/server/azure/dns/types.go
+++ b/server/azure/dns/types.go
@@ -47,6 +47,12 @@ const (
 	// servers (ns1-NN...).
 	nameServerShardCount = 99
 
+	// headerIfMatch and headerIfNoneMatch are the conditional-request headers
+	// the armdns SDK sets from RecordSetsClientCreateOrUpdateOptions.IfMatch /
+	// IfNoneMatch, carrying a record set's optimistic-concurrency precondition.
+	headerIfMatch     = "If-Match"
+	headerIfNoneMatch = "If-None-Match"
+
 	// SOA record defaults Azure stamps on the auto-created apex SOA. host and
 	// email are stored per-zone (host = the zone's first name server); the
 	// timing fields are fixed platform defaults.
@@ -479,11 +485,21 @@ func toRecordSetJSON(rp *azurearm.ResourcePath, zone string, rec *dnsdriver.Reco
 	props := toRecordSetProperties(rec)
 	props.Fqdn = recordFqdn(rec.Name, zone)
 
+	// A record set written since this pass always carries a driver-minted ETag
+	// that rotates on every create/update. Records restored from a snapshot
+	// taken before ETag support existed leave it empty; fall back to the old
+	// deterministic hash so they still read back a stable (if non-rotating)
+	// etag rather than an empty one.
+	etag := rec.ETag
+	if etag == "" {
+		etag = azurearm.ETag(id)
+	}
+
 	return recordSetJSON{
 		ID:         id,
 		Name:       rec.Name,
 		Type:       recordSetTypePrefix + rec.Type,
-		Etag:       azurearm.ETag(id),
+		Etag:       etag,
 		Properties: props,
 	}
 }

--- a/services/dns/driver/driver.go
+++ b/services/dns/driver/driver.go
@@ -164,6 +164,10 @@ type RecordInfo struct {
 	// SOA carries the editable Azure SOA timing fields as stored. Nil for
 	// non-SOA records and for the auto-created apex SOA.
 	SOA *SOARecord
+	// ETag is the Azure DNS record set's current entity tag, minted fresh on
+	// every create/update so an If-Match/If-None-Match precondition on a later
+	// write has something to compare against. Other providers leave it empty.
+	ETag string
 }
 
 // HealthCheckConfig describes a health check to create.


### PR DESCRIPTION
## Summary

Deepens Azure DNS (Microsoft.Network/dnsZones) record-set lifecycle toward real ARM concurrency semantics.

**Gap found:** record-set `etag` in the wire response was a deterministic hash of the resource ID (`azurearm.ETag(id)`) — stable forever, never rotating, and no If-Match/If-None-Match precondition was evaluated on writes. Zone/record CRUD, apex SOA+NS auto-provisioning, apex-delete protection, SOA PATCH-merge, and CNAME coexistence were already solid (verified empirically).

**Added:**
- `driver.RecordInfo.ETag` — minted fresh on every create/update.
- `RecordSets.CreateOrUpdate`: `If-None-Match:"*"` → create-only (412 if the record set already exists); `If-Match:"<etag>"` → conditional update (412 on stale/mismatched etag); no header → unconditional upsert (unchanged behavior).
- `RecordSets.Delete`: honors `If-Match` the same way (412 on stale etag).
- The whole existence-check + precondition-check + write runs atomically under one lock in the provider (`UpsertRecordAtomic` / `DeleteRecordAtomic`), closing the TOCTOU a separate `GetRecord` + `Create/UpdateRecord` call would leave open between two concurrent PUTs. The wire handler reaches this atomic path via an optional-capability type assertion, falling back to the old two-call upsert for a driver that doesn't implement it.
- `CreateRecord`/`UpdateRecord` (used by the PATCH path and apex auto-provisioning) also mint a fresh etag on every write, so PATCH responses and the auto-created SOA/NS carry real, non-empty etags too.

**Deferred:** private-zone vnet links, alias record sets to Azure resources, DNSSEC.

## Test plan
- New provider-level tests: create-only precondition, stale/current If-Match on update and delete, NotFound vs FailedPrecondition distinction.
- Concurrency regression: 32 goroutines racing `UpsertRecordAtomic` with `If-None-Match:"*"` at the same key — exactly 1 succeeds, the rest see `FailedPrecondition`, zone record count stays 1. Run `-race -count=20`, all green.
- New real-SDK (`armdns`) e2e tests: auto SOA+NS carry etags, plain CreateOrUpdate mints one, `If-None-Match:"*"` against an existing set is 412, a stale `If-Match` is 412 and doesn't mutate, the current etag succeeds and rotates, `RecordSets.Delete` with stale/current `If-Match`.
- Full `providers/azure/...` and `server/azure/...` suites pass; AWS Route 53 / GCP Cloud DNS untouched and still green (the driver field addition is optional, consistent with existing provider-specific fields like `SOA`/`AliasTarget`).
- `go generate ./...` — no `docs/coverage` diff. `go mod tidy` — no changes.