### PR TITLE
fix(azurelb): guard backend-pool delete in use, replace tags on UpdateTags

### DIFF
--- a/providers/azure/loadbalancer/azure_load_balancer.go
+++ b/providers/azure/loadbalancer/azure_load_balancer.go
@@ -2,6 +2,7 @@ package loadbalancer
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -136,14 +137,29 @@ func (m *Mock) UpsertAzureLBBackendPool(_ context.Context, rg, name, poolName st
 }
 
 // DeleteAzureLBBackendPool removes a single backend pool by name, leaving
-// every other child untouched.
+// every other child untouched. Returns FailedPrecondition (ARM
+// InUseDeleteCannotProceed, surfaced as 409) if a load balancing rule or
+// outbound rule on the same load balancer still references the pool — a
+// standalone child DELETE bypasses the whole-LB reference validation a
+// full-replace PUT goes through (validateAzureLB), so this is the only guard
+// stopping a rule from being left pointing at a pool that no longer exists.
 func (m *Mock) DeleteAzureLBBackendPool(_ context.Context, rg, name, poolName string) error {
-	poolMissing := false
+	var (
+		poolMissing bool
+		inUse       error
+	)
 
 	ok := m.azureLBs.Update(azureLBKey(rg, name), func(lb driver.AzureLoadBalancer) driver.AzureLoadBalancer {
 		idx := indexOfString(lb.BackendPools, poolName)
 		if idx == -1 {
 			poolMissing = true
+
+			return lb
+		}
+
+		if ref := poolReferencedBy(&lb, poolName); ref != "" {
+			inUse = cerrors.Newf(cerrors.FailedPrecondition,
+				"backend address pool %q is in use by %s and cannot be deleted", poolName, ref)
 
 			return lb
 		}
@@ -160,7 +176,29 @@ func (m *Mock) DeleteAzureLBBackendPool(_ context.Context, rg, name, poolName st
 		return cerrors.Newf(cerrors.NotFound, "backend address pool %q not found", poolName)
 	}
 
+	if inUse != nil {
+		return inUse
+	}
+
 	return nil
+}
+
+// poolReferencedBy returns a description of the first sibling load balancing
+// rule or outbound rule that references poolName, or "" if none does.
+func poolReferencedBy(lb *driver.AzureLoadBalancer, poolName string) string {
+	for i := range lb.Rules {
+		if strings.EqualFold(lb.Rules[i].BackendPoolName, poolName) {
+			return fmt.Sprintf("load balancing rule %q", lb.Rules[i].Name)
+		}
+	}
+
+	for i := range lb.OutboundRules {
+		if strings.EqualFold(lb.OutboundRules[i].BackendPoolName, poolName) {
+			return fmt.Sprintf("outbound rule %q", lb.OutboundRules[i].Name)
+		}
+	}
+
+	return ""
 }
 
 // UpsertAzureLBNatRule creates or replaces a single inbound NAT rule by name,

--- a/providers/azure/loadbalancer/lb_test.go
+++ b/providers/azure/loadbalancer/lb_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -661,4 +662,86 @@ func TestUpsertAzureLBNatRuleConcurrent(t *testing.T) {
 	lb, err := m.GetAzureLoadBalancer(ctx, rg, name)
 	require.NoError(t, err)
 	assert.Len(t, lb.NatRules, n, "every concurrently-added inbound NAT rule must survive")
+}
+
+// TestDeleteAzureLBBackendPoolInUseByRule proves the standalone backend-pool
+// DELETE rejects a pool still referenced by a load balancing rule instead of
+// silently leaving the rule pointing at a pool that no longer exists — the
+// whole-LB PUT path rejects this via validateAzureLB, but a standalone DELETE
+// bypasses that validation entirely, so the driver itself must guard it.
+func TestDeleteAzureLBBackendPoolInUseByRule(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	const rg, name = "rg1", "lb-pool-inuse"
+
+	_, err := m.CreateOrUpdateAzureLoadBalancer(ctx, rg, name, driver.AzureLoadBalancer{
+		Location:     "eastus",
+		SKUName:      "Standard",
+		Frontends:    []driver.AzureLBFrontend{{Name: "fe1", PrivateIPAddress: "10.0.0.4"}},
+		BackendPools: []string{"pool-a"},
+		Rules: []driver.AzureLBRule{{
+			Name: "rule-1", Protocol: "Tcp", FrontendPort: 80, BackendPort: 80,
+			FrontendName: "fe1", BackendPoolName: "pool-a",
+		}},
+	})
+	require.NoError(t, err)
+
+	err = m.DeleteAzureLBBackendPool(ctx, rg, name, "pool-a")
+	require.Error(t, err)
+	assert.True(t, cerrors.IsFailedPrecondition(err), "got %v", err)
+
+	lb, err := m.GetAzureLoadBalancer(ctx, rg, name)
+	require.NoError(t, err)
+	assert.Contains(t, lb.BackendPools, "pool-a", "pool referenced by a rule must survive the rejected delete")
+}
+
+// TestDeleteAzureLBBackendPoolInUseByOutboundRule is the outbound-rule twin of
+// the load-balancing-rule guard above.
+func TestDeleteAzureLBBackendPoolInUseByOutboundRule(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	const rg, name = "rg1", "lb-pool-inuse-outbound"
+
+	_, err := m.CreateOrUpdateAzureLoadBalancer(ctx, rg, name, driver.AzureLoadBalancer{
+		Location:     "eastus",
+		SKUName:      "Standard",
+		Frontends:    []driver.AzureLBFrontend{{Name: "fe1", PrivateIPAddress: "10.0.0.4"}},
+		BackendPools: []string{"pool-a"},
+		OutboundRules: []driver.AzureLBOutboundRule{{
+			Name: "out-1", Protocol: "All", BackendPoolName: "pool-a", FrontendNames: []string{"fe1"},
+		}},
+	})
+	require.NoError(t, err)
+
+	err = m.DeleteAzureLBBackendPool(ctx, rg, name, "pool-a")
+	require.Error(t, err)
+	assert.True(t, cerrors.IsFailedPrecondition(err), "got %v", err)
+
+	lb, err := m.GetAzureLoadBalancer(ctx, rg, name)
+	require.NoError(t, err)
+	assert.Contains(t, lb.BackendPools, "pool-a", "pool referenced by an outbound rule must survive the rejected delete")
+}
+
+// TestDeleteAzureLBBackendPoolUnreferencedSucceeds proves the guard does not
+// false-positive: a pool with no rule or outbound rule pointing at it deletes
+// cleanly.
+func TestDeleteAzureLBBackendPoolUnreferencedSucceeds(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	const rg, name = "rg1", "lb-pool-free"
+
+	_, err := m.CreateOrUpdateAzureLoadBalancer(ctx, rg, name, driver.AzureLoadBalancer{
+		Location: "eastus", SKUName: "Standard", BackendPools: []string{"pool-a", "pool-b"},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, m.DeleteAzureLBBackendPool(ctx, rg, name, "pool-a"))
+
+	lb, err := m.GetAzureLoadBalancer(ctx, rg, name)
+	require.NoError(t, err)
+	assert.NotContains(t, lb.BackendPools, "pool-a")
+	assert.Contains(t, lb.BackendPools, "pool-b")
 }

--- a/server/azure/loadbalancer/case_patch_defaults_test.go
+++ b/server/azure/loadbalancer/case_patch_defaults_test.go
@@ -111,9 +111,11 @@ func TestSDKAzureLBCaseInsensitiveAddressing(t *testing.T) {
 	}
 }
 
-// TestSDKAzureLBUpdateTags proves PATCH LoadBalancers.UpdateTags merges the
-// supplied tags into the stored load balancer (keeping existing tags) and
-// returns 200 with the updated resource.
+// TestSDKAzureLBUpdateTags proves PATCH LoadBalancers.UpdateTags REPLACES the
+// stored tag collection wholesale — a tag present before the PATCH but absent
+// from its body is dropped, not kept — and returns 200 with the updated
+// resource. This matches every other Microsoft.Network UpdateTags handler in
+// this server (armnetwork's *Client.UpdateTags does not merge).
 func TestSDKAzureLBUpdateTags(t *testing.T) {
 	client := newLBClient(t)
 	ctx := context.Background()
@@ -138,16 +140,20 @@ func TestSDKAzureLBUpdateTags(t *testing.T) {
 	}
 
 	tags := updated.Tags
-	if tags["env"] == nil || *tags["env"] != "test" {
-		t.Fatalf("merged tags lost env: %v", tags)
+	if _, present := tags["env"]; present {
+		t.Fatalf("replaced tags kept env, want it dropped (not in the PATCH body): %v", tags)
 	}
 
 	if tags["team"] == nil || *tags["team"] != "platform" {
-		t.Fatalf("merged tags team = %v, want platform (overwritten)", tags["team"])
+		t.Fatalf("replaced tags team = %v, want platform", tags["team"])
 	}
 
 	if tags["cost"] == nil || *tags["cost"] != "42" {
-		t.Fatalf("merged tags missing cost: %v", tags)
+		t.Fatalf("replaced tags missing cost: %v", tags)
+	}
+
+	if len(tags) != 2 {
+		t.Fatalf("replaced tags = %v, want exactly {team, cost}", tags)
 	}
 }
 

--- a/server/azure/loadbalancer/lb_subresource_test.go
+++ b/server/azure/loadbalancer/lb_subresource_test.go
@@ -581,6 +581,63 @@ func TestSDKLBDuplicatePoolNameRejected(t *testing.T) {
 	}
 }
 
+// HIGH: a standalone backendAddressPools DELETE must be rejected with 409
+// when a loadBalancingRule on the same load balancer still references the
+// pool — the pool, the rule, and the parent must all survive the rejected
+// attempt.
+func TestSDKLBBackendPoolDeleteInUseRejected(t *testing.T) {
+	c := newLBSubClients(t)
+	ctx := context.Background()
+	const lbName = "lb-pool-inuse"
+
+	poller, err := c.lb.BeginCreateOrUpdate(ctx, testRG, lbName, armnetwork.LoadBalancer{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{
+			FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{{Name: to.Ptr("fe-1")}},
+			BackendAddressPools:      []*armnetwork.BackendAddressPool{{Name: to.Ptr("pool-a")}},
+			LoadBalancingRules: []*armnetwork.LoadBalancingRule{{
+				Name: to.Ptr("rule-1"),
+				Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+					Protocol:                to.Ptr(armnetwork.TransportProtocolTCP),
+					FrontendPort:            to.Ptr(int32(80)),
+					BackendPort:             to.Ptr(int32(80)),
+					FrontendIPConfiguration: &armnetwork.SubResource{ID: to.Ptr(lbChildID2(lbName, "frontendIPConfigurations", "fe-1"))},
+					BackendAddressPool:      &armnetwork.SubResource{ID: to.Ptr(lbChildID2(lbName, "backendAddressPools", "pool-a"))},
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("seed BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("seed poll: %v", err)
+	}
+
+	_, err = c.pools.BeginDelete(ctx, testRG, lbName, "pool-a", nil)
+	if err == nil {
+		t.Fatal("BeginDelete pool-a still referenced by rule-1: want error, got nil")
+	}
+
+	if status := respStatus(t, err); status != http.StatusConflict {
+		t.Fatalf("in-use pool delete status = %d, want 409", status)
+	}
+
+	got, err := c.lb.Get(ctx, testRG, lbName, nil)
+	if err != nil {
+		t.Fatalf("Get after rejected delete: %v, want the parent to still exist", err)
+	}
+
+	if len(got.Properties.BackendAddressPools) != 1 || *got.Properties.BackendAddressPools[0].Name != "pool-a" {
+		t.Fatalf("pools after rejected delete = %+v, want pool-a untouched", got.Properties.BackendAddressPools)
+	}
+
+	if len(got.Properties.LoadBalancingRules) != 1 || *got.Properties.LoadBalancingRules[0].Name != "rule-1" {
+		t.Fatalf("rules after rejected pool delete = %+v, want rule-1 untouched", got.Properties.LoadBalancingRules)
+	}
+}
+
 // lbChildID2 builds a child resource id under lbName (distinct helper name
 // from lb_e2e_test.go's lbChildID, which hardcodes "lb-full").
 func lbChildID2(lbName, child, name string) string {

--- a/server/azure/loadbalancer/operations.go
+++ b/server/azure/loadbalancer/operations.go
@@ -76,10 +76,14 @@ func (h *Handler) getLoadBalancer(w http.ResponseWriter, r *http.Request, rp *az
 }
 
 // updateLoadBalancerTags handles PATCH .../loadBalancers/{name} —
-// LoadBalancers.UpdateTags. The body carries only a tags map; the tags are
-// MERGED into the stored load balancer (existing tags are kept, matching keys
-// overwritten) and every child is preserved. Returns 200 with the updated load
-// balancer, matching the SDK's synchronous UpdateTags.
+// LoadBalancers.UpdateTags. Real armnetwork UpdateTags REPLACES the tag
+// collection wholesale (it does not merge — an omitted existing key is
+// dropped), matching every other Microsoft.Network UpdateTags handler in this
+// server (see server/azure/vnet/network_updatetags.go); every child of the
+// load balancer is left untouched. A request body with the tags field
+// entirely omitted (nil map, as opposed to an explicit empty object) is a
+// no-op. Returns 200 with the updated load balancer, matching the SDK's
+// synchronous UpdateTags.
 func (h *Handler) updateLoadBalancerTags(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body loadBalancerJSON
 	if !azurearm.DecodeJSON(w, r, &body) {
@@ -98,36 +102,18 @@ func (h *Handler) updateLoadBalancerTags(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	merged := *stored
-	merged.Tags = mergeTags(stored.Tags, stripInternalTags(body.Tags))
+	replaced := *stored
+	if body.Tags != nil {
+		replaced.Tags = stripInternalTags(body.Tags)
+	}
 
-	updated, err := az.CreateOrUpdateAzureLoadBalancer(r.Context(), rp.ResourceGroup, rp.ResourceName, merged)
+	updated, err := az.CreateOrUpdateAzureLoadBalancer(r.Context(), rp.ResourceGroup, rp.ResourceName, replaced)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, toLBJSON(rp, updated, h.poolMembers(r.Context(), rp.Subscription)))
-}
-
-// mergeTags returns base with every key in overlay applied on top (overlay
-// wins on conflict). Neither input is mutated.
-func mergeTags(base, overlay map[string]string) map[string]string {
-	if len(base) == 0 && len(overlay) == 0 {
-		return nil
-	}
-
-	out := make(map[string]string, len(base)+len(overlay))
-
-	for k, v := range base {
-		out[k] = v
-	}
-
-	for k, v := range overlay {
-		out[k] = v
-	}
-
-	return out
 }
 
 // deleteLoadBalancer removes the load balancer from both the native store and

--- a/services/loadbalancer/driver/azure_load_balancer.go
+++ b/services/loadbalancer/driver/azure_load_balancer.go
@@ -134,7 +134,9 @@ type AzureLoadBalancers interface {
 	UpsertAzureLBBackendPool(ctx context.Context, rg, name, poolName string) (*AzureLoadBalancer, error)
 	// DeleteAzureLBBackendPool removes a single backend pool by name, leaving
 	// every other child untouched. Returns NotFound if the parent load
-	// balancer or the pool itself does not exist.
+	// balancer or the pool itself does not exist, and FailedPrecondition if a
+	// load balancing rule or outbound rule on the load balancer still
+	// references the pool.
 	DeleteAzureLBBackendPool(ctx context.Context, rg, name, poolName string) error
 
 	// UpsertAzureLBNatRule creates or replaces a single inbound NAT rule by


### PR DESCRIPTION
## Summary

Azure Load Balancer already had thorough sub-resource referential-integrity coverage (whole-LB PUT validates every rule/NAT-rule/NAT-pool/outbound-rule reference against sibling frontends/pools/probes in the same body — see `server/azure/loadbalancer/validate.go`) and per-child CRUD routing for backendAddressPools/inboundNatRules. This PR closes two gaps found while auditing that surface against real ARM semantics.

**Present already (verified, not touched):** whole-LB PUT/GET/LIST/DELETE, standalone backendAddressPools/inboundNatRules PUT/GET/LIST/DELETE, Get/List-only enforcement (405) on probes/loadBalancingRules/outboundRules/frontendIPConfigurations, duplicate-name + dangling-reference rejection on whole-LB PUT, backend-pool membership projected from NIC ipConfigurations, rule/probe defaults (idleTimeoutInMinutes, loadDistribution, intervalInSeconds, numberOfProbes), case-insensitive addressing.

**Fixed:**
- `DeleteAzureLBBackendPool` (standalone `backendAddressPools` DELETE) now rejects with `FailedPrecondition`/409 when a `loadBalancingRule` or `outboundRule` on the same load balancer still references the pool. Previously it deleted unconditionally, leaving a rule pointing at a pool that no longer exists — the whole-LB PUT path already catches this via `validateAzureLB`, but the standalone child DELETE bypassed that validation entirely.
- `LoadBalancers.UpdateTags` (PATCH) now REPLACES the stored tag collection wholesale instead of merging. Real `armnetwork` `UpdateTags` replaces, not merges, matching every other `Microsoft.Network` UpdateTags handler in this server (`server/azure/vnet/network_updatetags.go`). The tags field being entirely omitted from the PATCH body remains a no-op.

**Deferred (out of scope for this PR):** Gateway LB SKU, cross-region LB, actual health-probe evaluation against backend targets, outbound SNAT port allocation precision.

## Test plan
- [x] `go build ./...`
- [x] `go test ./providers/azure/loadbalancer/... ./server/azure/loadbalancer/... ./persist/... -race -count=1`
- [x] `go test ./providers/azure/... ./server/azure/...`
- [x] `gofmt -l` on touched files (clean)
- [x] `golangci-lint run` on touched packages — 0 new issues
- [x] `go generate ./...` + `git diff docs/coverage` — clean
- [x] `go mod tidy` — clean
- [x] New SDK e2e test: standalone pool DELETE against a pool referenced by a rule → 409, pool/rule/parent survive
- [x] New provider tests: in-use-by-rule, in-use-by-outbound-rule, unreferenced-delete-succeeds
- [x] Updated `TestSDKAzureLBUpdateTags` to assert replace (not merge) semantics