### PR TITLE
feat(elbv2): target health state machine

### DIFF
--- a/internal/settle/settle.go
+++ b/internal/settle/settle.go
@@ -45,6 +45,9 @@ const (
 	DefaultGKEReconcileSettle = 1 * time.Second // GKE node pool RECONCILING->RUNNING (resize/mutate)
 	DefaultECSTaskStartSettle = 2 * time.Second // ECS task PROVISIONING/PENDING->RUNNING
 	DefaultECSTaskStopSettle  = 1 * time.Second // ECS task STOPPING/DEPROVISIONING->STOPPED
+
+	DefaultTargetHealthSettle = 2 * time.Second // ELBv2 target initial->healthy
+	DefaultTargetDrainSettle  = 2 * time.Second // ELBv2 target draining->removed
 )
 
 // Window is a read-time overlay describing a resource still settling into its

--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -91,6 +91,16 @@ type Mock struct {
 	healthSettle *settle.Set
 	drainSettle  *settle.Set
 
+	// healthArmed marks (by settleKey) every target whose healthSettle window
+	// has been started. Real ELBv2 only begins health checking once a target
+	// group is referenced by a listener, so the window must not start at
+	// RegisterTargets time — a target sitting on an unattached target group for
+	// an arbitrary time must not burn its health-check clock. Instead
+	// observeTargetHealth arms it lazily, the first time it observes the group
+	// as referenced, and this set makes that a one-time transition: once armed,
+	// later calls only read the window, never restart it. Guarded by healthMu.
+	healthArmed map[string]struct{}
+
 	attrsMu sync.RWMutex
 	attrs   map[string]driver.LBAttributes // lbARN -> attributes
 
@@ -115,6 +125,7 @@ func New(opts *config.Options) *Mock {
 		health:       make(map[string]map[targetKey]*driver.TargetHealth),
 		healthSettle: settle.NewSet(),
 		drainSettle:  settle.NewSet(),
+		healthArmed:  make(map[string]struct{}),
 		attrs:        make(map[string]driver.LBAttributes),
 		tgAttrs:      make(map[string]map[string]string),
 	}
@@ -450,6 +461,7 @@ func (m *Mock) DeleteTargetGroup(_ context.Context, arn string) error {
 		sk := settleKey(arn, k)
 		m.healthSettle.Clear(sk)
 		m.drainSettle.Clear(sk)
+		delete(m.healthArmed, sk)
 	}
 
 	delete(m.health, arn)
@@ -1211,12 +1223,16 @@ func mergedTargetGroupAttributes(overrides map[string]string) map[string]string 
 
 // RegisterTargets registers targets with a target group.
 //
-// A freshly registered target starts "initial" and settles to "healthy" after
-// the target-health settle window elapses (immediately when async settling is
-// off — see internal/settle). Re-registering a target that is currently
-// draining (a rolling deploy scaling an instance back in before its drain
-// window elapsed) cancels the drain and restarts registration, matching real
-// ELBv2: RegisterTargets on an in-service target resets its health tracking.
+// A freshly registered target starts "initial". It does NOT start its
+// initial->healthy settle window here: real ELBv2 only begins health checking
+// once the target group is referenced by a listener, so a target sitting on
+// an unattached target group for an arbitrary time must not burn its
+// health-check clock. observeTargetHealth arms the window lazily, the first
+// time DescribeTargetHealth observes the group as referenced. Re-registering a
+// target that is currently draining (a rolling deploy scaling an instance
+// back in before its drain window elapsed) cancels the drain and restarts
+// registration — including the arm bit — matching real ELBv2: RegisterTargets
+// on an in-service target resets its health tracking.
 func (m *Mock) RegisterTargets(_ context.Context, targetGroupARN string, targets []driver.Target) error {
 	if _, ok := m.tgs.Get(targetGroupARN); !ok {
 		return errors.Newf(errors.NotFound, "target group %q not found", targetGroupARN)
@@ -1230,8 +1246,6 @@ func (m *Mock) RegisterTargets(_ context.Context, targetGroupARN string, targets
 		tgHealth = make(map[targetKey]*driver.TargetHealth)
 		m.health[targetGroupARN] = tgHealth
 	}
-
-	now := m.opts.Clock.Now()
 
 	for _, t := range targets {
 		key := keyFor(t)
@@ -1248,7 +1262,8 @@ func (m *Mock) RegisterTargets(_ context.Context, targetGroupARN string, targets
 		}
 
 		m.drainSettle.Clear(sk)
-		m.healthSettle.Begin(sk, targetStateInitial, now, m.opts.SettleDuration(settle.DefaultTargetHealthSettle))
+		m.healthSettle.Clear(sk)
+		delete(m.healthArmed, sk)
 	}
 
 	return nil
@@ -1336,6 +1351,7 @@ func (m *Mock) beginDraining(
 ) {
 	sk := settleKey(targetGroupARN, key)
 	m.healthSettle.Clear(sk)
+	delete(m.healthArmed, sk)
 
 	drainDur := m.opts.SettleDuration(settle.DefaultTargetDrainSettle)
 	if drainDur <= 0 {
@@ -1424,6 +1440,15 @@ func (m *Mock) observeTargetHealth(
 			return unused, true
 		}
 
+		// Arm the settle window the first time the group is observed as
+		// referenced — never before, and never again once armed. This is what
+		// keeps a target on a not-yet-attached target group from burning its
+		// health-check clock while it waits.
+		if _, armed := m.healthArmed[sk]; !armed {
+			m.healthSettle.Begin(sk, targetStateInitial, now, m.opts.SettleDuration(settle.DefaultTargetHealthSettle))
+			m.healthArmed[sk] = struct{}{}
+		}
+
 		observed := *th
 		observed.State = m.healthSettle.State(sk, now, targetStateHealthy)
 
@@ -1473,6 +1498,7 @@ func (m *Mock) SetTargetHealth(_ context.Context, targetGroupARN, targetID, stat
 		sk := settleKey(targetGroupARN, k)
 		m.healthSettle.Clear(sk)
 		m.drainSettle.Clear(sk)
+		delete(m.healthArmed, sk)
 	}
 
 	if !found {

--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -4,8 +4,10 @@ package elbv2
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/errors"
@@ -36,9 +38,17 @@ const (
 	lbStateActive       = "active"
 )
 
-// targetStateInitial is the health state a target holds between registration and
-// its first successful health check.
-const targetStateInitial = "initial"
+// Target health states the mock manages automatically. "initial" is the state
+// a target holds between registration and its first successful health check;
+// "healthy" is what it settles to; "draining" is what a deregistered target
+// holds until its deregistration delay elapses and it is removed. "unhealthy"
+// and any other value are caller-set via SetTargetHealth and never assigned by
+// the automatic register/deregister lifecycle.
+const (
+	targetStateInitial  = "initial"
+	targetStateHealthy  = "healthy"
+	targetStateDraining = "draining"
+)
 
 // targetKey is the identity of a registered target within a target group.
 // AWS lets the same instance ID or IP be registered multiple times with
@@ -55,6 +65,13 @@ func keyFor(t driver.Target) targetKey {
 	return targetKey{id: t.ID, port: t.Port}
 }
 
+// settleKey builds the composite key a target's settle windows are stored
+// under: a target's identity is only unique within its target group, so the
+// key must combine both.
+func settleKey(targetGroupARN string, k targetKey) string {
+	return targetGroupARN + "|" + k.id + "|" + strconv.Itoa(k.port)
+}
+
 // Mock is an in-memory mock implementation of the AWS ELB service.
 type Mock struct {
 	lbs       *memstore.Store[driver.LBInfo]
@@ -66,6 +83,13 @@ type Mock struct {
 
 	healthMu sync.RWMutex
 	health   map[string]map[targetKey]*driver.TargetHealth // tgARN -> (id,port) -> health
+
+	// healthSettle overlays each target's initial->healthy transition and
+	// drainSettle overlays draining->removed, both keyed by settleKey. Neither
+	// is snapshotted (see snapshot.go): a restored target reports its stored
+	// (final) state immediately, matching the lbSettle convention above.
+	healthSettle *settle.Set
+	drainSettle  *settle.Set
 
 	attrsMu sync.RWMutex
 	attrs   map[string]driver.LBAttributes // lbARN -> attributes
@@ -82,15 +106,17 @@ type Mock struct {
 // New creates a new ELB mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		lbs:       memstore.New[driver.LBInfo](),
-		lbSettle:  memstore.New[settle.Window](),
-		tgs:       memstore.New[driver.TargetGroupInfo](),
-		listeners: memstore.New[driver.ListenerInfo](),
-		rules:     memstore.New[driver.RuleInfo](),
-		opts:      opts,
-		health:    make(map[string]map[targetKey]*driver.TargetHealth),
-		attrs:     make(map[string]driver.LBAttributes),
-		tgAttrs:   make(map[string]map[string]string),
+		lbs:          memstore.New[driver.LBInfo](),
+		lbSettle:     memstore.New[settle.Window](),
+		tgs:          memstore.New[driver.TargetGroupInfo](),
+		listeners:    memstore.New[driver.ListenerInfo](),
+		rules:        memstore.New[driver.RuleInfo](),
+		opts:         opts,
+		health:       make(map[string]map[targetKey]*driver.TargetHealth),
+		healthSettle: settle.NewSet(),
+		drainSettle:  settle.NewSet(),
+		attrs:        make(map[string]driver.LBAttributes),
+		tgAttrs:      make(map[string]map[string]string),
 	}
 }
 
@@ -417,8 +443,15 @@ func (m *Mock) DeleteTargetGroup(_ context.Context, arn string) error {
 
 	m.tgs.Delete(arn)
 
-	// Clean up health data.
+	// Clean up health data and any in-flight settle windows for its targets, so
+	// a target group name that gets recreated does not inherit a stale window.
 	m.healthMu.Lock()
+	for k := range m.health[arn] {
+		sk := settleKey(arn, k)
+		m.healthSettle.Clear(sk)
+		m.drainSettle.Clear(sk)
+	}
+
 	delete(m.health, arn)
 	m.healthMu.Unlock()
 
@@ -1177,6 +1210,13 @@ func mergedTargetGroupAttributes(overrides map[string]string) map[string]string 
 }
 
 // RegisterTargets registers targets with a target group.
+//
+// A freshly registered target starts "initial" and settles to "healthy" after
+// the target-health settle window elapses (immediately when async settling is
+// off — see internal/settle). Re-registering a target that is currently
+// draining (a rolling deploy scaling an instance back in before its drain
+// window elapsed) cancels the drain and restarts registration, matching real
+// ELBv2: RegisterTargets on an in-service target resets its health tracking.
 func (m *Mock) RegisterTargets(_ context.Context, targetGroupARN string, targets []driver.Target) error {
 	if _, ok := m.tgs.Get(targetGroupARN); !ok {
 		return errors.Newf(errors.NotFound, "target group %q not found", targetGroupARN)
@@ -1191,8 +1231,13 @@ func (m *Mock) RegisterTargets(_ context.Context, targetGroupARN string, targets
 		m.health[targetGroupARN] = tgHealth
 	}
 
+	now := m.opts.Clock.Now()
+
 	for _, t := range targets {
-		tgHealth[keyFor(t)] = &driver.TargetHealth{
+		key := keyFor(t)
+		sk := settleKey(targetGroupARN, key)
+
+		tgHealth[key] = &driver.TargetHealth{
 			Target: driver.Target{
 				ID:   t.ID,
 				Port: t.Port,
@@ -1201,12 +1246,22 @@ func (m *Mock) RegisterTargets(_ context.Context, targetGroupARN string, targets
 			Reason:      "Elb.RegistrationInProgress",
 			Description: "Target registration is in progress",
 		}
+
+		m.drainSettle.Clear(sk)
+		m.healthSettle.Begin(sk, targetStateInitial, now, m.opts.SettleDuration(settle.DefaultTargetHealthSettle))
 	}
 
 	return nil
 }
 
 // DeregisterTargets removes targets from a target group.
+//
+// A deregistered target does not vanish immediately: real ELBv2 holds it
+// "draining" (Target.DeregistrationInProgress) for its deregistration delay so
+// in-flight connections finish, then removes it. beginDraining starts that
+// window; when async settling is off the window elapses instantly, so the
+// target disappears from this call's Describe onward — the historical
+// synchronous behavior.
 func (m *Mock) DeregisterTargets(_ context.Context, targetGroupARN string, targets []driver.Target) error {
 	if _, ok := m.tgs.Get(targetGroupARN); !ok {
 		return errors.Newf(errors.NotFound, "target group %q not found", targetGroupARN)
@@ -1220,10 +1275,12 @@ func (m *Mock) DeregisterTargets(_ context.Context, targetGroupARN string, targe
 		return nil
 	}
 
+	now := m.opts.Clock.Now()
+
 	for _, t := range targets {
 		key := keyFor(t)
 		if _, ok := tgHealth[key]; ok {
-			delete(tgHealth, key)
+			m.beginDraining(tgHealth, targetGroupARN, key, now)
 			continue
 		}
 
@@ -1236,18 +1293,20 @@ func (m *Mock) DeregisterTargets(_ context.Context, targetGroupARN string, targe
 		// target is a no-op ("If the specified target does not exist, the
 		// action returns successfully").
 		if t.Port == 0 {
-			deleteSolePortMatch(tgHealth, t.ID)
+			if match, ok := solePortMatch(tgHealth, t.ID); ok {
+				m.beginDraining(tgHealth, targetGroupARN, match, now)
+			}
 		}
 	}
 
 	return nil
 }
 
-// deleteSolePortMatch removes the single entry registered under id, when
-// exactly one exists. Two or more entries for the same id (different port
-// overrides) are left untouched — disambiguating them requires the caller to
-// specify the port, matching real ELBv2 semantics.
-func deleteSolePortMatch(tgHealth map[targetKey]*driver.TargetHealth, id string) {
+// solePortMatch reports the single entry registered under id, when exactly one
+// exists. Two or more entries for the same id (different port overrides) are
+// left untouched — disambiguating them requires the caller to specify the
+// port, matching real ELBv2 semantics.
+func solePortMatch(tgHealth map[targetKey]*driver.TargetHealth, id string) (targetKey, bool) {
 	var match targetKey
 
 	count := 0
@@ -1261,20 +1320,46 @@ func deleteSolePortMatch(tgHealth map[targetKey]*driver.TargetHealth, id string)
 		count++
 
 		if count > 1 {
-			return
+			return targetKey{}, false
 		}
 	}
 
-	if count == 1 {
-		delete(tgHealth, match)
+	return match, count == 1
+}
+
+// beginDraining transitions a registered target to "draining" and starts its
+// deregistration-delay settle window. When that window is inactive (async
+// settling off), the target is removed immediately instead — the caller must
+// hold healthMu.
+func (m *Mock) beginDraining(
+	tgHealth map[targetKey]*driver.TargetHealth, targetGroupARN string, key targetKey, now time.Time,
+) {
+	sk := settleKey(targetGroupARN, key)
+	m.healthSettle.Clear(sk)
+
+	drainDur := m.opts.SettleDuration(settle.DefaultTargetDrainSettle)
+	if drainDur <= 0 {
+		delete(tgHealth, key)
+		m.drainSettle.Clear(sk)
+
+		return
 	}
+
+	th := tgHealth[key]
+	th.State = targetStateDraining
+	th.Reason = "Target.DeregistrationInProgress"
+	th.Description = "Target deregistration is in progress"
+
+	m.drainSettle.Begin(sk, targetStateDraining, now, drainDur)
 }
 
 // DescribeTargetHealth returns the health status of all targets in a target
-// group. A freshly registered target reports "initial" on its first describe
-// and then advances to "healthy", mirroring real ELBv2's registration
-// transition so target-health waiters make progress instead of hanging on a
-// permanently "initial" state.
+// group. The stored State field is a marker: "initial" and "draining" mean the
+// target is under the mock's automatic register/deregister lifecycle and its
+// reported state is computed from the relevant settle window; any other value
+// (e.g. set via SetTargetHealth) passes through unchanged. A target whose
+// deregistration-delay window has elapsed is removed here, lazily, on the next
+// read.
 func (m *Mock) DescribeTargetHealth(_ context.Context, targetGroupARN string) ([]driver.TargetHealth, error) {
 	if _, ok := m.tgs.Get(targetGroupARN); !ok {
 		return nil, errors.Newf(errors.NotFound, "target group %q not found", targetGroupARN)
@@ -1289,39 +1374,75 @@ func (m *Mock) DescribeTargetHealth(_ context.Context, targetGroupARN string) ([
 	}
 
 	// A target group not forwarded to by any listener (default action or rule)
-	// on a load balancer reports every target as "unused" / Target.NotInUse and
-	// does not advance — real ELBv2 only begins health checks once a listener
-	// routes to the group. An explicitly set state (e.g. ECS SetTargetHealth) is
-	// left untouched; only the automatic initial->healthy progression is gated.
+	// on a load balancer reports every registering target as "unused" /
+	// Target.NotInUse and does not advance — real ELBv2 only begins health
+	// checks once a listener routes to the group. An explicitly set state
+	// (e.g. ECS SetTargetHealth) is left untouched; only the automatic
+	// initial->healthy progression is gated.
 	referenced := m.targetGroupReferenced(targetGroupARN)
+	now := m.opts.Clock.Now()
 
 	results := make([]driver.TargetHealth, 0, len(tgHealth))
-	for _, th := range tgHealth {
-		if !referenced && th.State == targetStateInitial {
-			unused := *th
-			unused.State = "unused"
-			unused.Reason = "Target.NotInUse"
-			unused.Description = "Target group is not configured to receive traffic from the load balancer"
-			results = append(results, unused)
 
+	for k, th := range tgHealth {
+		observed, keep := m.observeTargetHealth(targetGroupARN, k, th, referenced, now)
+		if !keep {
+			delete(tgHealth, k)
 			continue
 		}
 
-		results = append(results, *th)
-
-		// Advance after the state is captured so the caller sees "initial"
-		// once and "healthy" on the next poll.
-		if th.State == targetStateInitial {
-			th.State = "healthy"
-			th.Reason = ""
-			th.Description = ""
-		}
+		results = append(results, observed)
 	}
 
 	return results, nil
 }
 
-// SetTargetHealth sets the health state of a specific target in a target group.
+// observeTargetHealth computes the health entry to report for one target
+// without mutating the stored record, and reports keep=false once a fully
+// elapsed drain window means the target has been removed from service.
+func (m *Mock) observeTargetHealth(
+	targetGroupARN string, k targetKey, th *driver.TargetHealth, referenced bool, now time.Time,
+) (driver.TargetHealth, bool) {
+	sk := settleKey(targetGroupARN, k)
+
+	switch th.State {
+	case targetStateDraining:
+		if m.drainSettle.State(sk, now, "") == "" {
+			m.drainSettle.Clear(sk)
+			return driver.TargetHealth{}, false
+		}
+
+		return *th, true
+
+	case targetStateInitial:
+		if !referenced {
+			unused := *th
+			unused.State = "unused"
+			unused.Reason = "Target.NotInUse"
+			unused.Description = "Target group is not configured to receive traffic from the load balancer"
+
+			return unused, true
+		}
+
+		observed := *th
+		observed.State = m.healthSettle.State(sk, now, targetStateHealthy)
+
+		if observed.State == targetStateHealthy {
+			observed.Reason = ""
+			observed.Description = ""
+		}
+
+		return observed, true
+
+	default:
+		return *th, true
+	}
+}
+
+// SetTargetHealth sets the health state of a specific target in a target
+// group, taking it out of the automatic register/deregister lifecycle: its
+// state no longer advances via the initial->healthy or draining->removed
+// settle windows until the target is re-registered or deregistered again.
 func (m *Mock) SetTargetHealth(_ context.Context, targetGroupARN, targetID, state string) error {
 	if _, ok := m.tgs.Get(targetGroupARN); !ok {
 		return errors.Newf(errors.NotFound, "target group %q not found", targetGroupARN)
@@ -1348,6 +1469,10 @@ func (m *Mock) SetTargetHealth(_ context.Context, targetGroupARN, targetID, stat
 		th.State = state
 		th.Reason = ""
 		found = true
+
+		sk := settleKey(targetGroupARN, k)
+		m.healthSettle.Clear(sk)
+		m.drainSettle.Clear(sk)
 	}
 
 	if !found {

--- a/providers/aws/elbv2/elb_test.go
+++ b/providers/aws/elbv2/elb_test.go
@@ -439,6 +439,138 @@ func TestCreateLoadBalancerSettlesProvisioningToActive(t *testing.T) {
 	assertEqual(t, "active", got[0].State)
 }
 
+// newAsyncTestMock returns a Mock with AsyncSettle enabled and the FakeClock
+// the test controls, for exercising the target-health settle windows below.
+func newAsyncTestMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithAsyncSettle(),
+		config.WithRegion("us-east-1"), config.WithAccountID("123456789012"))
+
+	return New(opts), fc
+}
+
+// attachListener creates a load balancer and a listener forwarding to tg, so
+// tg's targets are "in use" and begin health checking.
+func attachListener(t *testing.T, m *Mock, tg *driver.TargetGroupInfo) {
+	t.Helper()
+
+	lb := createTestLB(m)
+	_, err := m.CreateListener(context.Background(), driver.ListenerConfig{
+		LBARN: lb.ARN, Protocol: "HTTP", Port: 80,
+		DefaultActions: []driver.RuleAction{{Type: "forward", TargetGroupARN: tg.ARN}},
+	})
+	requireNoError(t, err)
+}
+
+// TestRegisterTargetsSettlesInitialToHealthy verifies the AWS-realistic
+// initial->healthy transition when async settling is enabled: a freshly
+// registered target is observed as "initial" until the settle window
+// elapses, then "healthy". Driven purely by the clock, no wall-clock sleep.
+func TestRegisterTargetsSettlesInitialToHealthy(t *testing.T) {
+	m, fc := newAsyncTestMock()
+	ctx := context.Background()
+	tg := createTestTG(m)
+	attachListener(t, m, tg)
+
+	requireNoError(t, m.RegisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-1", Port: 80}}))
+
+	health, err := m.DescribeTargetHealth(ctx, tg.ARN)
+	requireNoError(t, err)
+	assertEqual(t, "initial", health[0].State)
+	assertEqual(t, "Elb.RegistrationInProgress", health[0].Reason)
+
+	fc.Advance(5 * time.Second)
+
+	health, err = m.DescribeTargetHealth(ctx, tg.ARN)
+	requireNoError(t, err)
+	assertEqual(t, "healthy", health[0].State)
+	assertEqual(t, "", health[0].Reason)
+}
+
+// TestDeregisterTargetsSettlesDrainingToRemoved verifies the AWS-realistic
+// draining->removed transition when async settling is enabled: a
+// deregistered target is observed as "draining" (Target.DeregistrationInProgress)
+// until its deregistration-delay settle window elapses, then disappears from
+// DescribeTargetHealth entirely.
+func TestDeregisterTargetsSettlesDrainingToRemoved(t *testing.T) {
+	m, fc := newAsyncTestMock()
+	ctx := context.Background()
+	tg := createTestTG(m)
+	attachListener(t, m, tg)
+
+	requireNoError(t, m.RegisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-1", Port: 80}}))
+	fc.Advance(5 * time.Second) // settle to healthy first
+
+	requireNoError(t, m.DeregisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-1", Port: 80}}))
+
+	health, err := m.DescribeTargetHealth(ctx, tg.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(health))
+	assertEqual(t, "draining", health[0].State)
+	assertEqual(t, "Target.DeregistrationInProgress", health[0].Reason)
+
+	fc.Advance(5 * time.Second)
+
+	health, err = m.DescribeTargetHealth(ctx, tg.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 0, len(health))
+}
+
+// TestRegisterTargetsCancelsDraining verifies that re-registering a target
+// that is currently draining cancels the drain and restarts it at "initial",
+// matching real ELBv2: a target scaled back in before its deregistration
+// delay elapsed rejoins service instead of being removed mid-drain.
+func TestRegisterTargetsCancelsDraining(t *testing.T) {
+	m, fc := newAsyncTestMock()
+	ctx := context.Background()
+	tg := createTestTG(m)
+	attachListener(t, m, tg)
+
+	requireNoError(t, m.RegisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-1", Port: 80}}))
+	fc.Advance(5 * time.Second)
+	requireNoError(t, m.DeregisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-1", Port: 80}}))
+
+	health, err := m.DescribeTargetHealth(ctx, tg.ARN)
+	requireNoError(t, err)
+	assertEqual(t, "draining", health[0].State)
+
+	requireNoError(t, m.RegisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-1", Port: 80}}))
+
+	health, err = m.DescribeTargetHealth(ctx, tg.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(health))
+	assertEqual(t, "initial", health[0].State)
+
+	// Advancing well past the (canceled) drain window must not remove it —
+	// only the fresh registration's own window governs it now.
+	fc.Advance(5 * time.Second)
+
+	health, err = m.DescribeTargetHealth(ctx, tg.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(health))
+	assertEqual(t, "healthy", health[0].State)
+}
+
+// TestSetTargetHealthStopsAutoProgression verifies that an explicit
+// SetTargetHealth call takes a target out of the automatic settle-driven
+// lifecycle: it does not later flip to "healthy" or drain away on its own.
+func TestSetTargetHealthStopsAutoProgression(t *testing.T) {
+	m, fc := newAsyncTestMock()
+	ctx := context.Background()
+	tg := createTestTG(m)
+	attachListener(t, m, tg)
+
+	requireNoError(t, m.RegisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-1", Port: 80}}))
+	requireNoError(t, m.SetTargetHealth(ctx, tg.ARN, "i-1", "unhealthy"))
+
+	fc.Advance(10 * time.Second)
+
+	health, err := m.DescribeTargetHealth(ctx, tg.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(health))
+	assertEqual(t, "unhealthy", health[0].State)
+}
+
 func TestSetTargetHealth(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/providers/aws/elbv2/elb_test.go
+++ b/providers/aws/elbv2/elb_test.go
@@ -487,6 +487,49 @@ func TestRegisterTargetsSettlesInitialToHealthy(t *testing.T) {
 	assertEqual(t, "", health[0].Reason)
 }
 
+// TestRegisterTargetsBeforeListenerAttachArmsOnAttach is the regression case
+// for a common IaC ordering — aws_lb_target_group_attachment applied before
+// the listener/rule that routes to it is wired up. A target registered on a
+// target group with no listener must not start its initial->healthy settle
+// window at registration time: real ELBv2 only begins health checking once
+// the group is referenced by a listener, so time passing while the group sits
+// unattached must not count toward the window. Advancing the clock well past
+// the settle duration BEFORE attaching a listener, then attaching, must still
+// observe "initial" on the next Describe — the window starts from the attach
+// (first-referenced-observation) point, not from registration.
+func TestRegisterTargetsBeforeListenerAttachArmsOnAttach(t *testing.T) {
+	m, fc := newAsyncTestMock()
+	ctx := context.Background()
+	tg := createTestTG(m)
+
+	requireNoError(t, m.RegisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-1", Port: 80}}))
+
+	// No listener yet: unused, and the clock advancing must not arm anything.
+	health, err := m.DescribeTargetHealth(ctx, tg.ARN)
+	requireNoError(t, err)
+	assertEqual(t, "unused", health[0].State)
+
+	fc.Advance(10 * time.Second) // well past DefaultTargetHealthSettle (2s)
+
+	// Now attach a listener. If the window had (incorrectly) started at
+	// RegisterTargets time, it would already be elapsed and this describe
+	// would report "healthy" immediately, never "initial".
+	attachListener(t, m, tg)
+
+	health, err = m.DescribeTargetHealth(ctx, tg.ARN)
+	requireNoError(t, err)
+	assertEqual(t, "initial", health[0].State)
+	assertEqual(t, "Elb.RegistrationInProgress", health[0].Reason)
+
+	// The window armed on attach; advancing past its duration now settles it.
+	fc.Advance(3 * time.Second) // past DefaultTargetHealthSettle (2s)
+
+	health, err = m.DescribeTargetHealth(ctx, tg.ARN)
+	requireNoError(t, err)
+	assertEqual(t, "healthy", health[0].State)
+	assertEqual(t, "", health[0].Reason)
+}
+
 // TestDeregisterTargetsSettlesDrainingToRemoved verifies the AWS-realistic
 // draining->removed transition when async settling is enabled: a
 // deregistered target is observed as "draining" (Target.DeregistrationInProgress)

--- a/server/aws/elbv2/async_settle_test.go
+++ b/server/aws/elbv2/async_settle_test.go
@@ -1,0 +1,159 @@
+package elbv2_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+
+	"github.com/stackshy/cloudemu/v2"
+	cloudconfig "github.com/stackshy/cloudemu/v2/config"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newAsyncELBv2 wires a full in-process AWS server with AsyncSettle enabled and
+// a FakeClock the test controls, and returns a real aws-sdk-go-v2 ELBv2 client
+// plus the clock. This exercises the actual wire protocol a real user hits.
+func newAsyncELBv2(t *testing.T) (*elb.Client, *cloudconfig.FakeClock) {
+	t.Helper()
+
+	fc := cloudconfig.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	cloud := cloudemu.NewAWS(cloudconfig.WithClock(fc), cloudconfig.WithAsyncSettle())
+	ts := httptest.NewServer(awsserver.New(awsserver.DriversFrom(cloud)))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	cfg.BaseEndpoint = aws.String(ts.URL)
+
+	return elb.NewFromConfig(cfg), fc
+}
+
+// TestAsyncSettleWireELBv2TargetHealth pins the target-health state machine a
+// real SDK client sees through the wire when AsyncSettle is on: a registered
+// target reports "initial" until its settle window elapses, then "healthy";
+// a deregistered target reports "draining" until its own window elapses, then
+// disappears from DescribeTargetHealth entirely. Both transitions are driven
+// purely by the FakeClock, matching the ec2/rds/ecs async-settle wire tests.
+func TestAsyncSettleWireELBv2TargetHealth(t *testing.T) {
+	ctx := context.Background()
+	client, fc := newAsyncELBv2(t)
+
+	lbOut, err := client.CreateLoadBalancer(ctx, &elb.CreateLoadBalancerInput{
+		Name: aws.String("async-alb"), Type: elbtypes.LoadBalancerTypeEnumApplication,
+		Subnets: []string{"subnet-a"},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer: %v", err)
+	}
+
+	tgOut, err := client.CreateTargetGroup(ctx, &elb.CreateTargetGroupInput{
+		Name: aws.String("async-tg"), Protocol: elbtypes.ProtocolEnumHttp,
+		Port: aws.Int32(80), VpcId: aws.String("vpc-1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	tgARN := aws.ToString(tgOut.TargetGroups[0].TargetGroupArn)
+
+	if _, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: lbOut.LoadBalancers[0].LoadBalancerArn,
+		Protocol:        elbtypes.ProtocolEnumHttp, Port: aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type: elbtypes.ActionTypeEnumForward, TargetGroupArn: aws.String(tgARN),
+		}},
+	}); err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	if _, err := client.RegisterTargets(ctx, &elb.RegisterTargetsInput{
+		TargetGroupArn: aws.String(tgARN),
+		Targets:        []elbtypes.TargetDescription{{Id: aws.String("i-1"), Port: aws.Int32(80)}},
+	}); err != nil {
+		t.Fatalf("RegisterTargets: %v", err)
+	}
+
+	// Registered but the settle window hasn't elapsed: initial.
+	before, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(tgARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeTargetHealth (before settle): %v", err)
+	}
+
+	th := before.TargetHealthDescriptions[0].TargetHealth
+	if th.State != elbtypes.TargetHealthStateEnumInitial {
+		t.Fatalf("state before settle = %q, want initial", th.State)
+	}
+
+	if th.Reason != elbtypes.TargetHealthReasonEnumRegistrationInProgress {
+		t.Fatalf("reason before settle = %q, want Elb.RegistrationInProgress", th.Reason)
+	}
+
+	fc.Advance(3 * time.Second) // past DefaultTargetHealthSettle (2s)
+
+	after, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(tgARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeTargetHealth (after settle): %v", err)
+	}
+
+	if s := after.TargetHealthDescriptions[0].TargetHealth.State; s != elbtypes.TargetHealthStateEnumHealthy {
+		t.Fatalf("state after settle = %q, want healthy", s)
+	}
+
+	// Deregister: the target must drain, not vanish immediately.
+	if _, err := client.DeregisterTargets(ctx, &elb.DeregisterTargetsInput{
+		TargetGroupArn: aws.String(tgARN),
+		Targets:        []elbtypes.TargetDescription{{Id: aws.String("i-1"), Port: aws.Int32(80)}},
+	}); err != nil {
+		t.Fatalf("DeregisterTargets: %v", err)
+	}
+
+	draining, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(tgARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeTargetHealth (draining): %v", err)
+	}
+
+	if len(draining.TargetHealthDescriptions) != 1 {
+		t.Fatalf("draining descriptions = %d, want 1", len(draining.TargetHealthDescriptions))
+	}
+
+	dth := draining.TargetHealthDescriptions[0].TargetHealth
+	if dth.State != elbtypes.TargetHealthStateEnumDraining {
+		t.Fatalf("state after deregister = %q, want draining", dth.State)
+	}
+
+	if dth.Reason != elbtypes.TargetHealthReasonEnumDeregistrationInProgress {
+		t.Fatalf("reason after deregister = %q, want Target.DeregistrationInProgress", dth.Reason)
+	}
+
+	fc.Advance(3 * time.Second) // past DefaultTargetDrainSettle (2s)
+
+	removed, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(tgARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeTargetHealth (after drain): %v", err)
+	}
+
+	if n := len(removed.TargetHealthDescriptions); n != 0 {
+		t.Fatalf("descriptions after drain settles = %d, want 0", n)
+	}
+}

--- a/server/aws/elbv2/modify_test.go
+++ b/server/aws/elbv2/modify_test.go
@@ -452,7 +452,12 @@ func TestSDKSetSecurityGroupsAndSubnets(t *testing.T) {
 
 // TestSDKTargetHealthAdvances proves a freshly registered target reports
 // "initial" (with the AWS reason code) and then advances to "healthy".
-func TestSDKTargetHealthAdvances(t *testing.T) {
+// TestSDKTargetHealthDefaultsToHealthy proves that outside AsyncSettle a
+// registered target reports healthy immediately — the synchronous default
+// every resource in cloudemu uses unless a caller opts into realistic
+// intermediate states. See TestAsyncSettleWireELBv2TargetHealth for the
+// initial->healthy->draining->removed progression under AsyncSettle.
+func TestSDKTargetHealthDefaultsToHealthy(t *testing.T) {
 	client := newSDKClient(t)
 	ctx := context.Background()
 
@@ -468,8 +473,7 @@ func TestSDKTargetHealthAdvances(t *testing.T) {
 
 	tgARN := aws.ToString(tgOut.TargetGroups[0].TargetGroupArn)
 
-	// A target group only begins health checks once a listener forwards to it;
-	// attach one so the initial->healthy progression is exercised.
+	// A target group only begins health checks once a listener forwards to it.
 	attachListener(t, client, ctx, "th-alb", tgARN)
 
 	if _, err := client.RegisterTargets(ctx, &elb.RegisterTargetsInput{
@@ -479,32 +483,36 @@ func TestSDKTargetHealthAdvances(t *testing.T) {
 		t.Fatalf("RegisterTargets: %v", err)
 	}
 
-	first, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
+	out, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
 		TargetGroupArn: aws.String(tgARN),
 	})
 	if err != nil {
-		t.Fatalf("DescribeTargetHealth #1: %v", err)
+		t.Fatalf("DescribeTargetHealth: %v", err)
 	}
 
-	th := first.TargetHealthDescriptions[0].TargetHealth
-	if th.State != elbtypes.TargetHealthStateEnumInitial {
-		t.Errorf("first state = %q, want initial", th.State)
+	th := out.TargetHealthDescriptions[0].TargetHealth
+	if th.State != elbtypes.TargetHealthStateEnumHealthy {
+		t.Errorf("state = %q, want healthy", th.State)
 	}
 
-	if th.Reason != elbtypes.TargetHealthReasonEnumRegistrationInProgress {
-		t.Errorf("reason = %q, want Elb.RegistrationInProgress", th.Reason)
+	// DeregisterTargets removes the target immediately, again the synchronous
+	// default.
+	if _, err := client.DeregisterTargets(ctx, &elb.DeregisterTargetsInput{
+		TargetGroupArn: aws.String(tgARN),
+		Targets:        []elbtypes.TargetDescription{{Id: aws.String("i-1"), Port: aws.Int32(80)}},
+	}); err != nil {
+		t.Fatalf("DeregisterTargets: %v", err)
 	}
 
-	second, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
+	after, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
 		TargetGroupArn: aws.String(tgARN),
 	})
 	if err != nil {
-		t.Fatalf("DescribeTargetHealth #2: %v", err)
+		t.Fatalf("DescribeTargetHealth after deregister: %v", err)
 	}
 
-	if second.TargetHealthDescriptions[0].TargetHealth.State != elbtypes.TargetHealthStateEnumHealthy {
-		t.Errorf("second state = %q, want healthy",
-			second.TargetHealthDescriptions[0].TargetHealth.State)
+	if n := len(after.TargetHealthDescriptions); n != 0 {
+		t.Errorf("descriptions after deregister = %d, want 0", n)
 	}
 }
 
@@ -565,8 +573,8 @@ func TestSDKDescribeTargetHealthUnregisteredTarget(t *testing.T) {
 		t.Fatal("registered target i-1 missing from response")
 	}
 
-	if reg.TargetHealth.State != elbtypes.TargetHealthStateEnumInitial {
-		t.Errorf("registered state = %q, want initial", reg.TargetHealth.State)
+	if reg.TargetHealth.State != elbtypes.TargetHealthStateEnumHealthy {
+		t.Errorf("registered state = %q, want healthy", reg.TargetHealth.State)
 	}
 
 	nr, ok := byID["i-missing"]

--- a/server/aws/elbv2/sdk_weighted_forward_test.go
+++ b/server/aws/elbv2/sdk_weighted_forward_test.go
@@ -243,27 +243,18 @@ func TestSDKELBUnusedHealthUntilAttached(t *testing.T) {
 		t.Fatalf("CreateListener: %v", err)
 	}
 
-	// First poll after attach reports initial, next reports healthy.
-	first, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
+	// Outside AsyncSettle the target reports healthy immediately once attached
+	// (the synchronous default); see TestAsyncSettleWireELBv2TargetHealth for
+	// the timed initial->healthy progression.
+	after, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
 		TargetGroupArn: aws.String(tgARN),
 	})
 	if err != nil {
-		t.Fatalf("DescribeTargetHealth (attached, first): %v", err)
+		t.Fatalf("DescribeTargetHealth (attached): %v", err)
 	}
 
-	if s := first.TargetHealthDescriptions[0].TargetHealth.State; s != elbtypes.TargetHealthStateEnumInitial {
-		t.Fatalf("first attached state = %q, want initial", s)
-	}
-
-	second, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
-		TargetGroupArn: aws.String(tgARN),
-	})
-	if err != nil {
-		t.Fatalf("DescribeTargetHealth (attached, second): %v", err)
-	}
-
-	if s := second.TargetHealthDescriptions[0].TargetHealth.State; s != elbtypes.TargetHealthStateEnumHealthy {
-		t.Fatalf("second attached state = %q, want healthy", s)
+	if s := after.TargetHealthDescriptions[0].TargetHealth.State; s != elbtypes.TargetHealthStateEnumHealthy {
+		t.Fatalf("attached state = %q, want healthy", s)
 	}
 }
 


### PR DESCRIPTION
## Summary

Deepens AWS ELBv2 target-group health lifecycle toward real-cloud parity.

**Present (verified before this change):** LB create/describe/delete with provisioning->active settling; target group CRUD + ModifyTargetGroup health-check fields; listener CRUD with forward/redirect/fixed-response default actions; CreateRule with conditions/priority + PriorityInUse on collision; SetRulePriorities (atomic, validates before writing); referential guards (DeleteTargetGroup -> ResourceInUse when referenced by a listener or rule); RegisterTargets/DeregisterTargets -> TargetGroupNotFound on a missing group; DescribeTargetHealth "unused"/Target.NotInUse when a target group isn't attached to any listener.

**Missing (this PR):**
- `DeregisterTargets` deleted a target immediately — no `draining` state at all. Real ELBv2 holds a deregistered target `draining` (`Target.DeregistrationInProgress`) for its deregistration delay before removing it.
- The `initial`->`healthy` transition was a "read mutates stored state" hack (first `DescribeTargetHealth` call after register always returned `initial`, every call after always `healthy`) — not driven by a clock, and not gated behind the codebase's `AsyncSettle` convention that every other async transition (LB provisioning, EC2 pending->running, RDS creating->available, ...) already follows.

## What changed

- `internal/settle`: two new default durations, `DefaultTargetHealthSettle` and `DefaultTargetDrainSettle`.
- `providers/aws/elbv2`: `RegisterTargets`/`DeregisterTargets`/`DescribeTargetHealth` now use `settle.Set` windows keyed per (target group, target). Outside `AsyncSettle` (the default) both transitions complete immediately — a registered target reads `healthy` right away and a deregistered target is gone right away, preserving today's synchronous behavior. With `AsyncSettle` on, a registered target reads `initial` (`Elb.RegistrationInProgress`) until the window elapses, then `healthy`; a deregistered target reads `draining` (`Target.DeregistrationInProgress`) until its window elapses, then disappears from `DescribeTargetHealth`.
- Re-registering a target that is currently draining cancels the drain and restarts it at `initial`, matching real ELBv2 (a target scaled back in before its deregistration delay elapses rejoins service).
- `SetTargetHealth` now also clears any in-flight settle window, so an explicit override stays put instead of later auto-progressing.
- `DeleteTargetGroup` clears any leftover settle windows for its targets.
- New `server/aws/elbv2/async_settle_test.go` (FakeClock-driven, real aws-sdk-go-v2 client over the wire) covering the full initial->healthy->draining->removed cycle, matching the ec2/rds/ecs async-settle test convention. Existing wire tests that asserted the old "initial on first read" default behavior were updated to assert the new synchronous-by-default `healthy`/removed behavior.

## Deferred

- The implicit per-listener default rule is never materialized as a `RuleInfo` (`IsDefault` is always false, `DescribeRules` never returns it, and it can't be deleted-guarded) — real gap, out of scope for this PR to keep it cohesive.
- SSL policies / WAF association, precise connection-draining timeout semantics tied to the actual `deregistration_delay.timeout_seconds` attribute value (this PR uses a fixed short settle duration under `AsyncSettle`, consistent with how every other resource's settle window works in this codebase).

## Test plan
- [x] `go build ./...`
- [x] `go test ./providers/aws/elbv2/... ./server/aws/elbv2/... ./persist/... -race -count=1`
- [x] `go test ./providers/aws/... ./server/aws/...`
- [x] `gofmt -l` on touched files (clean)
- [x] `golangci-lint run` on touched packages — 0 new issues (19 pre-existing, unchanged)
- [x] `go generate ./...` + `git diff docs/coverage` (clean, no driver signature changed)
- [x] `go mod tidy` (no changes)