### PR TITLE
feat(gcplb): reference validation across the LB chain on create/update

### DIFF
--- a/server/gcp/loadbalancer/backendservices_sdk_test.go
+++ b/server/gcp/loadbalancer/backendservices_sdk_test.go
@@ -206,7 +206,22 @@ func TestSDKGCPBackendServiceBackendsRoundTrip(t *testing.T) {
 
 	client := newBackendServicesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
 
-	group := "projects/" + testProject + "/zones/us-central1-a/instanceGroups/ig-1"
+	igClient, err := gcpcompute.NewInstanceGroupsRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewInstanceGroupsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = igClient.Close() })
+
+	waitOp(ctx, t, "instanceGroup Insert", func() (*gcpcompute.Operation, error) {
+		return igClient.Insert(ctx, &computepb.InsertInstanceGroupRequest{
+			Project:               testProject,
+			Zone:                  testZone,
+			InstanceGroupResource: &computepb.InstanceGroup{Name: ptrStr("ig-1")},
+		})
+	})
+
+	group := "projects/" + testProject + "/zones/" + testZone + "/instanceGroups/ig-1"
 
 	op, err := client.Insert(ctx, &computepb.InsertBackendServiceRequest{
 		Project: testProject,

--- a/server/gcp/loadbalancer/forwardingrules_sdk_test.go
+++ b/server/gcp/loadbalancer/forwardingrules_sdk_test.go
@@ -118,6 +118,20 @@ func TestSDKGCPForwardingRuleTargetRoundTrip(t *testing.T) {
 
 	client := newForwardingRulesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
 
+	proxyClient, err := gcpcompute.NewTargetHttpProxiesRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewTargetHttpProxiesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = proxyClient.Close() })
+
+	waitOp(ctx, t, "targetHttpProxy Insert", func() (*gcpcompute.Operation, error) {
+		return proxyClient.Insert(ctx, &computepb.InsertTargetHttpProxyRequest{
+			Project:                 testProject,
+			TargetHttpProxyResource: &computepb.TargetHttpProxy{Name: ptrStr("web-proxy")},
+		})
+	})
+
 	target := "projects/" + testProject + "/global/targetHttpProxies/web-proxy"
 
 	op, err := client.Insert(ctx, &computepb.InsertGlobalForwardingRuleRequest{

--- a/server/gcp/loadbalancer/l7frontend.go
+++ b/server/gcp/loadbalancer/l7frontend.go
@@ -108,6 +108,11 @@ func (h *Handler) setProxyField(w http.ResponseWriter, r *http.Request, rp gcpre
 		return
 	}
 
+	if err := h.validateProxySetRequest(r.Context(), rp, &req, list); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
 	err := store.UpdateGCPResource(r.Context(), rp.ResourceType, scopeKeyOf(rp), rp.ResourceName,
 		func(res *lbdriver.GCPResource) {
 			if res.Body == nil {

--- a/server/gcp/loadbalancer/operations.go
+++ b/server/gcp/loadbalancer/operations.go
@@ -207,16 +207,25 @@ func (h *Handler) instanceGroupMembers(ctx context.Context, group string) []stri
 // parseGroupRef splits an instance-group reference into (collection, scope,
 // name). A ".../zones/{z}/instanceGroups/{n}" reference maps to the zonal
 // instanceGroups collection scoped by zone; ".../regions/{r}/instanceGroups/{n}"
-// to regionInstanceGroups scoped by region. Any other shape returns "".
+// to regionInstanceGroups scoped by region. The segment immediately before the
+// name must literally be "instanceGroups" — a NEG self-link
+// (".../zones/{z}/networkEndpointGroups/{n}", the standard backends[].group for
+// Cloud Run/Functions behind an HTTPS LB) also carries a zones/regions scope
+// segment but must NOT be misclassified as an instance group. Any other shape
+// returns "".
 func parseGroupRef(ref string) (collection, scope, name string) {
 	parts := strings.Split(ref, "/")
 
-	for i := 0; i+1 < len(parts); i++ {
+	for i := 0; i+3 < len(parts); i++ {
+		if parts[i+2] != "instanceGroups" {
+			continue
+		}
+
 		switch parts[i] {
 		case gcprest.ScopeZones:
-			return resourceInstanceGroups, parts[i+1], lastPathSegment(ref)
+			return resourceInstanceGroups, parts[i+1], parts[i+3]
 		case gcprest.ScopeRegions:
-			return resourceRegionInstanceGroups, parts[i+1], lastPathSegment(ref)
+			return resourceRegionInstanceGroups, parts[i+1], parts[i+3]
 		}
 	}
 

--- a/server/gcp/loadbalancer/operations.go
+++ b/server/gcp/loadbalancer/operations.go
@@ -41,6 +41,11 @@ func (h *Handler) insertBackendService(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
+	if err := h.validateBackendRefs(r.Context(), req.Backends); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
 	tags := backendServiceTags(&req)
 	tags[bsCreationTag] = time.Now().UTC().Format(time.RFC3339)
 	tags[bsNameTag] = req.Name
@@ -86,6 +91,11 @@ func (h *Handler) patchBackendService(w http.ResponseWriter, r *http.Request, rp
 	}
 
 	if err := h.validateHealthCheckRefs(r.Context(), rp, req.HealthChecks); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.validateBackendRefs(r.Context(), req.Backends); err != nil {
 		gcprest.WriteCErr(w, err)
 		return
 	}
@@ -305,6 +315,11 @@ func (h *Handler) insertForwardingRule(w http.ResponseWriter, r *http.Request, r
 	}
 
 	if _, err := h.findLBByName(r.Context(), rp, req.Name); conflictIfExists(w, err, "forwarding rule "+req.Name+" already exists") {
+		return
+	}
+
+	if err := h.validateForwardingRuleTarget(r.Context(), rp, req.Target); err != nil {
+		gcprest.WriteCErr(w, err)
 		return
 	}
 

--- a/server/gcp/loadbalancer/referenceintegrity_sdk_test.go
+++ b/server/gcp/loadbalancer/referenceintegrity_sdk_test.go
@@ -587,3 +587,167 @@ func TestSDKGCPBackendServiceInvalidBalancingMode(t *testing.T) {
 
 	assertInvalidArgument(t, err)
 }
+
+// TestSDKGCPURLMapBackendBucketRefNotRejected guards against a false-reject: a
+// url-map's defaultService may legitimately name a backendBuckets/{name}
+// self-link (standard CDN/static-content routing, e.g.
+// google_compute_backend_bucket.self_link). Backend buckets have no driver
+// model here, so the reference must be left unvalidated rather than rejected
+// as a dangling backend-service reference.
+func TestSDKGCPURLMapBackendBucketRefNotRejected(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	um, err := gcpcompute.NewUrlMapsRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewUrlMapsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = um.Close() })
+
+	bucketRef := "projects/" + testProject + "/global/backendBuckets/static-assets"
+
+	insOp, err := um.Insert(ctx, &computepb.InsertUrlMapRequest{
+		Project: testProject,
+		UrlMapResource: &computepb.UrlMap{
+			Name:           ptrStr("bucket-map"),
+			DefaultService: ptrStr(bucketRef),
+		},
+	})
+	if err != nil {
+		t.Fatalf("UrlMap Insert with a backendBucket defaultService: %v", err)
+	}
+
+	if err := insOp.Wait(ctx); err != nil {
+		t.Fatalf("UrlMap Insert wait: %v", err)
+	}
+
+	got, err := um.Get(ctx, &computepb.GetUrlMapRequest{Project: testProject, UrlMap: "bucket-map"})
+	if err != nil {
+		t.Fatalf("UrlMap Get: %v", err)
+	}
+
+	if got.GetDefaultService() != bucketRef {
+		t.Errorf("defaultService = %q, want %q", got.GetDefaultService(), bucketRef)
+	}
+}
+
+// TestSDKGCPBackendServiceNEGRefNotRejected guards against a false-reject: a
+// backend service's backends[].group may legitimately name a network endpoint
+// group self-link (".../zones/{z}/networkEndpointGroups/{n}"), the standard
+// backend for Cloud Run/Functions behind an HTTPS load balancer. NEGs have no
+// driver model here, so the reference must be left unvalidated rather than
+// misclassified as a dangling instance-group reference.
+func TestSDKGCPBackendServiceNEGRefNotRejected(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	bs := newBackendServicesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+
+	negRef := "projects/" + testProject + "/zones/" + testZone + "/networkEndpointGroups/cr-neg"
+
+	insOp, err := bs.Insert(ctx, &computepb.InsertBackendServiceRequest{
+		Project: testProject,
+		BackendServiceResource: &computepb.BackendService{
+			Name:     ptrStr("bs-neg"),
+			Protocol: ptrStr("HTTP"),
+			Backends: []*computepb.Backend{{Group: ptrStr(negRef), BalancingMode: ptrStr("RATE")}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BackendService Insert with a NEG group: %v", err)
+	}
+
+	if err := insOp.Wait(ctx); err != nil {
+		t.Fatalf("BackendService Insert wait: %v", err)
+	}
+
+	got, err := bs.Get(ctx, &computepb.GetBackendServiceRequest{Project: testProject, BackendService: "bs-neg"})
+	if err != nil {
+		t.Fatalf("BackendService Get: %v", err)
+	}
+
+	if len(got.GetBackends()) != 1 || got.GetBackends()[0].GetGroup() != negRef {
+		t.Errorf("backends = %v, want one referencing %q", got.GetBackends(), negRef)
+	}
+}
+
+// TestSDKGCPTargetHTTPSProxyDanglingSslCertRef covers B2(c): a target HTTPS
+// proxy whose sslCertificates[] names a missing certificate is rejected, both
+// on insert and via setSslCertificates; once the certificate exists, both
+// succeed.
+func TestSDKGCPTargetHTTPSProxyDanglingSslCertRef(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	proxy, err := gcpcompute.NewTargetHttpsProxiesRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewTargetHttpsProxiesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = proxy.Close() })
+
+	ghostCert := "projects/" + testProject + "/global/sslCertificates/ghost-cert"
+
+	insOp, err := proxy.Insert(ctx, &computepb.InsertTargetHttpsProxyRequest{
+		Project: testProject,
+		TargetHttpsProxyResource: &computepb.TargetHttpsProxy{
+			Name:            ptrStr("https-proxy-dangling"),
+			SslCertificates: []string{ghostCert},
+		},
+	})
+	if err == nil {
+		err = insOp.Wait(ctx)
+	}
+
+	assertInvalidArgument(t, err)
+
+	waitOp(ctx, t, "targetHttpsProxy Insert", func() (*gcpcompute.Operation, error) {
+		return proxy.Insert(ctx, &computepb.InsertTargetHttpsProxyRequest{
+			Project:                  testProject,
+			TargetHttpsProxyResource: &computepb.TargetHttpsProxy{Name: ptrStr("https-proxy-empty")},
+		})
+	})
+
+	setOp, err := proxy.SetSslCertificates(ctx, &computepb.SetSslCertificatesTargetHttpsProxyRequest{
+		Project:          testProject,
+		TargetHttpsProxy: "https-proxy-empty",
+		TargetHttpsProxiesSetSslCertificatesRequestResource: &computepb.TargetHttpsProxiesSetSslCertificatesRequest{
+			SslCertificates: []string{ghostCert},
+		},
+	})
+	if err == nil {
+		err = setOp.Wait(ctx)
+	}
+
+	assertInvalidArgument(t, err)
+
+	certClient, err := gcpcompute.NewSslCertificatesRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewSslCertificatesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = certClient.Close() })
+
+	waitOp(ctx, t, "sslCertificate Insert", func() (*gcpcompute.Operation, error) {
+		return certClient.Insert(ctx, &computepb.InsertSslCertificateRequest{
+			Project: testProject,
+			SslCertificateResource: &computepb.SslCertificate{
+				Name:        ptrStr("real-cert"),
+				Certificate: ptrStr("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"),
+			},
+		})
+	})
+
+	realCert := "projects/" + testProject + "/global/sslCertificates/real-cert"
+
+	waitOp(ctx, t, "targetHttpsProxy SetSslCertificates with a real cert", func() (*gcpcompute.Operation, error) {
+		return proxy.SetSslCertificates(ctx, &computepb.SetSslCertificatesTargetHttpsProxyRequest{
+			Project:          testProject,
+			TargetHttpsProxy: "https-proxy-empty",
+			TargetHttpsProxiesSetSslCertificatesRequestResource: &computepb.TargetHttpsProxiesSetSslCertificatesRequest{
+				SslCertificates: []string{realCert},
+			},
+		})
+	})
+}

--- a/server/gcp/loadbalancer/referenceintegrity_sdk_test.go
+++ b/server/gcp/loadbalancer/referenceintegrity_sdk_test.go
@@ -311,3 +311,279 @@ func TestSDKGCPBackendServiceDeleteNotInUse(t *testing.T) {
 		t.Fatalf("Delete wait: %v", err)
 	}
 }
+
+// assertInvalidArgument fails unless err is a 400 googleapi.Error.
+func assertInvalidArgument(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("dangling reference: want error, got nil")
+	}
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) {
+		t.Fatalf("error = %v, want a googleapi.Error", err)
+	}
+
+	if gerr.Code != 400 {
+		t.Errorf("error code = %d, want 400 (%v)", gerr.Code, err)
+	}
+}
+
+// TestSDKGCPURLMapDanglingBackendServiceRef covers B2(a): a url-map whose
+// defaultService names a missing backend service is rejected on both insert and
+// update, while a reference to an existing backend service succeeds.
+func TestSDKGCPURLMapDanglingBackendServiceRef(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	bs := newBackendServicesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+
+	um, err := gcpcompute.NewUrlMapsRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewUrlMapsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = um.Close() })
+
+	// Dangling reference on insert → rejected.
+	insOp, err := um.Insert(ctx, &computepb.InsertUrlMapRequest{
+		Project: testProject,
+		UrlMapResource: &computepb.UrlMap{
+			Name:           ptrStr("map-dangling"),
+			DefaultService: ptrStr("projects/" + testProject + "/global/backendServices/ghost-bs"),
+		},
+	})
+	if err == nil {
+		err = insOp.Wait(ctx)
+	}
+
+	assertInvalidArgument(t, err)
+
+	// Existing reference → accepted.
+	insertBS(ctx, t, bs, "real-bs")
+
+	realSvc := "projects/" + testProject + "/global/backendServices/real-bs"
+
+	insertUMOp, err := um.Insert(ctx, &computepb.InsertUrlMapRequest{
+		Project:        testProject,
+		UrlMapResource: &computepb.UrlMap{Name: ptrStr("map-real"), DefaultService: ptrStr(realSvc)},
+	})
+	if err != nil {
+		t.Fatalf("UrlMap Insert with a real backend service: %v", err)
+	}
+
+	if err := insertUMOp.Wait(ctx); err != nil {
+		t.Fatalf("UrlMap Insert wait: %v", err)
+	}
+
+	// Dangling reference on update → rejected.
+	updOp, err := um.Update(ctx, &computepb.UpdateUrlMapRequest{
+		Project: testProject,
+		UrlMap:  "map-real",
+		UrlMapResource: &computepb.UrlMap{
+			Name:           ptrStr("map-real"),
+			DefaultService: ptrStr("projects/" + testProject + "/global/backendServices/ghost-bs-2"),
+		},
+	})
+	if err == nil {
+		err = updOp.Wait(ctx)
+	}
+
+	assertInvalidArgument(t, err)
+}
+
+// TestSDKGCPTargetHTTPProxyDanglingURLMapRef covers B2(b): a target HTTP proxy
+// whose urlMap names a missing url-map is rejected, both on insert and via
+// setUrlMap; once the url-map exists, both succeed.
+func TestSDKGCPTargetHTTPProxyDanglingURLMapRef(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	proxy, err := gcpcompute.NewTargetHttpProxiesRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewTargetHttpProxiesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = proxy.Close() })
+
+	// Dangling reference on insert → rejected.
+	insOp, err := proxy.Insert(ctx, &computepb.InsertTargetHttpProxyRequest{
+		Project: testProject,
+		TargetHttpProxyResource: &computepb.TargetHttpProxy{
+			Name:   ptrStr("proxy-dangling"),
+			UrlMap: ptrStr("projects/" + testProject + "/global/urlMaps/ghost-map"),
+		},
+	})
+	if err == nil {
+		err = insOp.Wait(ctx)
+	}
+
+	assertInvalidArgument(t, err)
+
+	// Create the proxy empty, then setUrlMap against a still-missing map → rejected.
+	waitOp(ctx, t, "targetHttpProxy Insert", func() (*gcpcompute.Operation, error) {
+		return proxy.Insert(ctx, &computepb.InsertTargetHttpProxyRequest{
+			Project:                 testProject,
+			TargetHttpProxyResource: &computepb.TargetHttpProxy{Name: ptrStr("proxy-empty")},
+		})
+	})
+
+	setOp, err := proxy.SetUrlMap(ctx, &computepb.SetUrlMapTargetHttpProxyRequest{
+		Project:         testProject,
+		TargetHttpProxy: "proxy-empty",
+		UrlMapReferenceResource: &computepb.UrlMapReference{
+			UrlMap: ptrStr("projects/" + testProject + "/global/urlMaps/ghost-map-2"),
+		},
+	})
+	if err == nil {
+		err = setOp.Wait(ctx)
+	}
+
+	assertInvalidArgument(t, err)
+
+	// A real url-map (no backend service needed for this insert since it omits
+	// defaultService) makes both paths succeed.
+	um, err := gcpcompute.NewUrlMapsRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewUrlMapsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = um.Close() })
+
+	waitOp(ctx, t, "urlMap Insert", func() (*gcpcompute.Operation, error) {
+		return um.Insert(ctx, &computepb.InsertUrlMapRequest{
+			Project:        testProject,
+			UrlMapResource: &computepb.UrlMap{Name: ptrStr("real-map")},
+		})
+	})
+
+	waitOp(ctx, t, "targetHttpProxy SetUrlMap", func() (*gcpcompute.Operation, error) {
+		return proxy.SetUrlMap(ctx, &computepb.SetUrlMapTargetHttpProxyRequest{
+			Project:                 testProject,
+			TargetHttpProxy:         "proxy-empty",
+			UrlMapReferenceResource: &computepb.UrlMapReference{UrlMap: ptrStr("projects/" + testProject + "/global/urlMaps/real-map")},
+		})
+	})
+}
+
+// TestSDKGCPForwardingRuleDanglingTargetRef covers B2(d): a global forwarding
+// rule whose target names a missing target-http-proxy is rejected; once the
+// proxy exists, the insert succeeds.
+func TestSDKGCPForwardingRuleDanglingTargetRef(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	fr := newForwardingRulesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+
+	target := "projects/" + testProject + "/global/targetHttpProxies/ghost-proxy"
+
+	insOp, err := fr.Insert(ctx, &computepb.InsertGlobalForwardingRuleRequest{
+		Project: testProject,
+		ForwardingRuleResource: &computepb.ForwardingRule{
+			Name:       ptrStr("fr-dangling"),
+			IPProtocol: ptrStr("TCP"),
+			PortRange:  ptrStr("80"),
+			Target:     ptrStr(target),
+		},
+	})
+	if err == nil {
+		err = insOp.Wait(ctx)
+	}
+
+	assertInvalidArgument(t, err)
+
+	proxy, err := gcpcompute.NewTargetHttpProxiesRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewTargetHttpProxiesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = proxy.Close() })
+
+	waitOp(ctx, t, "targetHttpProxy Insert", func() (*gcpcompute.Operation, error) {
+		return proxy.Insert(ctx, &computepb.InsertTargetHttpProxyRequest{
+			Project:                 testProject,
+			TargetHttpProxyResource: &computepb.TargetHttpProxy{Name: ptrStr("ghost-proxy")},
+		})
+	})
+
+	waitOp(ctx, t, "forwardingRule Insert with a real target", func() (*gcpcompute.Operation, error) {
+		return fr.Insert(ctx, &computepb.InsertGlobalForwardingRuleRequest{
+			Project: testProject,
+			ForwardingRuleResource: &computepb.ForwardingRule{
+				Name:       ptrStr("fr-real"),
+				IPProtocol: ptrStr("TCP"),
+				PortRange:  ptrStr("80"),
+				Target:     ptrStr(target),
+			},
+		})
+	})
+}
+
+// TestSDKGCPBackendServiceBackendGroupRefValidation covers B2(e): a backend
+// service whose backends[].group names a missing instance group is rejected,
+// while a reference to an existing one succeeds.
+func TestSDKGCPBackendServiceBackendGroupRefValidation(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	bs := newBackendServicesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+
+	ghostGroup := "projects/" + testProject + "/zones/" + testZone + "/instanceGroups/ghost-ig"
+
+	insOp, err := bs.Insert(ctx, &computepb.InsertBackendServiceRequest{
+		Project: testProject,
+		BackendServiceResource: &computepb.BackendService{
+			Name:     ptrStr("bs-ghost-group"),
+			Protocol: ptrStr("HTTP"),
+			Backends: []*computepb.Backend{{Group: ptrStr(ghostGroup)}},
+		},
+	})
+	if err == nil {
+		err = insOp.Wait(ctx)
+	}
+
+	assertInvalidArgument(t, err)
+}
+
+// TestSDKGCPBackendServiceInvalidBalancingMode covers B2(f): a backend service
+// whose backends[].balancingMode is not one of the GCP-recognized values is
+// rejected.
+func TestSDKGCPBackendServiceInvalidBalancingMode(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	bs := newBackendServicesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+
+	igClient, err := gcpcompute.NewInstanceGroupsRESTClient(ctx, clientOpts(ts)...)
+	if err != nil {
+		t.Fatalf("NewInstanceGroupsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = igClient.Close() })
+
+	waitOp(ctx, t, "instanceGroup Insert", func() (*gcpcompute.Operation, error) {
+		return igClient.Insert(ctx, &computepb.InsertInstanceGroupRequest{
+			Project:               testProject,
+			Zone:                  testZone,
+			InstanceGroupResource: &computepb.InstanceGroup{Name: ptrStr("mode-ig")},
+		})
+	})
+
+	group := "projects/" + testProject + "/zones/" + testZone + "/instanceGroups/mode-ig"
+
+	insOp, err := bs.Insert(ctx, &computepb.InsertBackendServiceRequest{
+		Project: testProject,
+		BackendServiceResource: &computepb.BackendService{
+			Name:     ptrStr("bs-bad-mode"),
+			Protocol: ptrStr("HTTP"),
+			Backends: []*computepb.Backend{{Group: ptrStr(group), BalancingMode: ptrStr("NONSENSE")}},
+		},
+	})
+	if err == nil {
+		err = insOp.Wait(ctx)
+	}
+
+	assertInvalidArgument(t, err)
+}

--- a/server/gcp/loadbalancer/refvalidation.go
+++ b/server/gcp/loadbalancer/refvalidation.go
@@ -80,7 +80,12 @@ func collectRefs(v any, fields map[string]bool, out *[]namedRef) {
 
 // validateURLMapServiceRefs rejects a url-map body whose defaultService, or any
 // nested pathMatchers[].defaultService / pathRules[].service, names a backend
-// service that does not exist in the same scope.
+// service that does not exist in the same scope. The same fields can also
+// legitimately name a backendBuckets/{name} self-link (standard CDN/static-
+// content routing, e.g. google_compute_backend_bucket.self_link) — backend
+// buckets have no driver model here, so any ref that doesn't resolve to the
+// backendServices collection is left unvalidated rather than falsely rejected,
+// mirroring targetCollectionFor's allowlist for forwarding-rule targets.
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) validateURLMapServiceRefs(ctx context.Context, rp gcprest.ResourcePath, body map[string]any) error {
@@ -89,6 +94,10 @@ func (h *Handler) validateURLMapServiceRefs(ctx context.Context, rp gcprest.Reso
 	collectRefs(body, map[string]bool{"service": true, "defaultService": true}, &refs)
 
 	for _, ref := range refs {
+		if !isBackendServiceRef(ref.value) {
+			continue
+		}
+
 		if _, err := h.findTGByName(ctx, rp, backendServiceName(ref.value)); err != nil {
 			if cerrors.IsNotFound(err) {
 				return invalidRefErr(ref.field, ref.value, "backend service")
@@ -99,6 +108,15 @@ func (h *Handler) validateURLMapServiceRefs(ctx context.Context, rp gcprest.Reso
 	}
 
 	return nil
+}
+
+// isBackendServiceRef reports whether ref names the backendServices
+// collection — either a bare name (no path separators, the common case for a
+// same-scope reference) or a self-link/relative path containing
+// "/backendServices/". Anything else (e.g. a backendBuckets self-link) is left
+// unvalidated.
+func isBackendServiceRef(ref string) bool {
+	return !strings.Contains(ref, "/") || strings.Contains(ref, "/backendServices/")
 }
 
 // validateProxyRefs rejects a target-proxy body whose urlMap, or (https proxies

--- a/server/gcp/loadbalancer/refvalidation.go
+++ b/server/gcp/loadbalancer/refvalidation.go
@@ -1,0 +1,262 @@
+package loadbalancer
+
+// Upstream reference validation for the L7 front-end chain. Real GCP rejects a
+// create/patch/set-action whose reference names a resource that does not exist
+// in the same scope (400 invalid, "Invalid value for field ..."). This file
+// centralizes those checks alongside the reference-integrity delete guards in
+// l7frontend.go so no create/update in the chain can point at a resource that
+// isn't there:
+//
+//	urlMap.defaultService / pathMatchers[].defaultService / pathRules[].service → backendService
+//	targetHttp(s)Proxy.urlMap                                                   → urlMap
+//	targetHttpsProxy.sslCertificates[]                                          → sslCertificate
+//	forwardingRule.target                                                      → targetHttp(s)Proxy / targetPool
+//	backendService.backends[].group                                            → instanceGroup / regionInstanceGroup
+import (
+	"context"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+)
+
+// validGCPBalancingModes are the GCP-recognized backendService.backends[].balancingMode
+// values; an omitted mode defaults to UTILIZATION in real GCP and is accepted here too.
+//
+//nolint:gochecknoglobals // immutable lookup table, not mutable state
+var validGCPBalancingModes = map[string]bool{
+	"":            true,
+	"UTILIZATION": true,
+	"RATE":        true,
+	"CONNECTION":  true,
+}
+
+// validateGCPResourceRefs rejects an opaque-resource create/patch body whose
+// upstream reference names a resource that does not exist in the same scope.
+// It is a no-op for collections without a validated upstream reference (a
+// health check, target pool, ssl certificate, or instance group has none).
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) validateGCPResourceRefs(ctx context.Context, rp gcprest.ResourcePath, body map[string]any) error {
+	switch rp.ResourceType {
+	case resourceURLMaps:
+		return h.validateURLMapServiceRefs(ctx, rp, body)
+	case resourceTargetHTTPProxies, resourceTargetHTTPSProxies:
+		return h.validateProxyRefs(ctx, rp, body)
+	default:
+		return nil
+	}
+}
+
+// namedRef is one upstream reference found while walking a request body: the
+// JSON field it came from (for the error message) and the reference value.
+type namedRef struct {
+	field string
+	value string
+}
+
+// collectRefs walks v (a decoded JSON body) collecting every string value of a
+// member whose key is in fields, recursing into maps and slices so a url-map's
+// nested pathMatchers[].pathRules[].service is found alongside its top-level
+// defaultService.
+func collectRefs(v any, fields map[string]bool, out *[]namedRef) {
+	switch t := v.(type) {
+	case map[string]any:
+		for k, val := range t {
+			if fields[k] {
+				if s, ok := val.(string); ok && s != "" {
+					*out = append(*out, namedRef{field: k, value: s})
+				}
+			}
+
+			collectRefs(val, fields, out)
+		}
+	case []any:
+		for _, e := range t {
+			collectRefs(e, fields, out)
+		}
+	}
+}
+
+// validateURLMapServiceRefs rejects a url-map body whose defaultService, or any
+// nested pathMatchers[].defaultService / pathRules[].service, names a backend
+// service that does not exist in the same scope.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) validateURLMapServiceRefs(ctx context.Context, rp gcprest.ResourcePath, body map[string]any) error {
+	var refs []namedRef
+
+	collectRefs(body, map[string]bool{"service": true, "defaultService": true}, &refs)
+
+	for _, ref := range refs {
+		if _, err := h.findTGByName(ctx, rp, backendServiceName(ref.value)); err != nil {
+			if cerrors.IsNotFound(err) {
+				return invalidRefErr(ref.field, ref.value, "backend service")
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateProxyRefs rejects a target-proxy body whose urlMap, or (https proxies
+// only) sslCertificates[], names a resource that does not exist in the same
+// scope.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) validateProxyRefs(ctx context.Context, rp gcprest.ResourcePath, body map[string]any) error {
+	if ref, ok := body[fieldURLMap].(string); ok && ref != "" {
+		if err := h.requireGCPResource(ctx, rp, resourceURLMaps, ref, fieldURLMap); err != nil {
+			return err
+		}
+	}
+
+	if rp.ResourceType != resourceTargetHTTPSProxies {
+		return nil
+	}
+
+	certs, _ := body[fieldSslCertificates].([]any)
+
+	for _, c := range certs {
+		ref, ok := c.(string)
+		if !ok || ref == "" {
+			continue
+		}
+
+		if err := h.requireGCPResource(ctx, rp, resourceSslCertificates, ref, fieldSslCertificates); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateProxySetRequest rejects a setUrlMap/setSslCertificates action body
+// whose reference names a resource that does not exist in the same scope.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) validateProxySetRequest(ctx context.Context, rp gcprest.ResourcePath, req *setProxyRequest, list bool) error {
+	if !list {
+		if req.URLMap == "" {
+			return nil
+		}
+
+		return h.requireGCPResource(ctx, rp, resourceURLMaps, req.URLMap, fieldURLMap)
+	}
+
+	for _, cert := range req.SslCertificates {
+		if cert == "" {
+			continue
+		}
+
+		if err := h.requireGCPResource(ctx, rp, resourceSslCertificates, cert, fieldSslCertificates); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// requireGCPResource rejects when ref (a self-link or bare name) does not
+// resolve to an existing collection resource in rp's scope. A driver with no
+// GCP resource store leaves the reference unvalidated rather than blocking
+// every create.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) requireGCPResource(ctx context.Context, rp gcprest.ResourcePath, collection, ref, field string) error {
+	store, ok := h.gcpStore()
+	if !ok {
+		return nil
+	}
+
+	name := lastPathSegment(ref)
+
+	_, err := store.GetGCPResource(ctx, collection, scopeKeyOf(rp), name)
+	if err == nil {
+		return nil
+	}
+
+	if cerrors.IsNotFound(err) {
+		return invalidRefErr(field, ref, singularOf(collection))
+	}
+
+	return err
+}
+
+// invalidRefErr renders the GCP "Invalid value for field" InvalidArgument
+// rejection for a dangling upstream reference.
+func invalidRefErr(field, ref, noun string) error {
+	return cerrors.Newf(cerrors.InvalidArgument,
+		"Invalid value for field 'resource.%s': '%s'. The referenced %s resource cannot be found.", field, ref, noun)
+}
+
+// validateForwardingRuleTarget rejects a forwarding rule whose target names a
+// target-proxy or target-pool resource that does not exist in the same scope.
+// Only the collections this handler implements are recognized; a reference to
+// an unimplemented target type (targetSslProxies, targetTcpProxies, …) is left
+// unvalidated rather than falsely rejected.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) validateForwardingRuleTarget(ctx context.Context, rp gcprest.ResourcePath, target string) error {
+	if target == "" {
+		return nil
+	}
+
+	collection := targetCollectionFor(target)
+	if collection == "" {
+		return nil
+	}
+
+	return h.requireGCPResource(ctx, rp, collection, target, "target")
+}
+
+// targetCollectionFor extracts the collection segment of a forwarding rule's
+// target reference, recognizing only the collections this handler implements.
+func targetCollectionFor(ref string) string {
+	for _, c := range []string{resourceTargetHTTPProxies, resourceTargetHTTPSProxies, resourceTargetPools} {
+		if strings.Contains(ref, "/"+c+"/") {
+			return c
+		}
+	}
+
+	return ""
+}
+
+// validateBackendRefs rejects a backend-service create/patch whose backends[]
+// names an instance group that does not exist, or sets an unrecognized
+// balancingMode. NEG and other non-instance-group backend shapes are not
+// modeled by the opaque instance-group store, so only instance-group
+// references (zonal/regional) are checked.
+func (h *Handler) validateBackendRefs(ctx context.Context, backends []backend) error {
+	store, ok := h.gcpStore()
+
+	for i := range backends {
+		if !validGCPBalancingModes[backends[i].BalancingMode] {
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"Invalid value for field 'resource.backends[%d].balancingMode': '%s'.", i, backends[i].BalancingMode)
+		}
+
+		if !ok || backends[i].Group == "" {
+			continue
+		}
+
+		collection, scope, name := parseGroupRef(backends[i].Group)
+		if collection == "" {
+			continue
+		}
+
+		if _, err := store.GetGCPResource(ctx, collection, scope, name); err != nil {
+			if cerrors.IsNotFound(err) {
+				return cerrors.Newf(cerrors.InvalidArgument,
+					"Invalid value for field 'resource.backends[%d].group': '%s'. The referenced instance group resource cannot be found.",
+					i, backends[i].Group)
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}

--- a/server/gcp/loadbalancer/resources.go
+++ b/server/gcp/loadbalancer/resources.go
@@ -106,6 +106,11 @@ func (h *Handler) mutateGCPResource(w http.ResponseWriter, r *http.Request, rp g
 		return
 	}
 
+	if err := h.validateGCPResourceRefs(r.Context(), rp, body); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
 	err := store.UpdateGCPResource(r.Context(), rp.ResourceType, scopeKeyOf(rp), rp.ResourceName,
 		func(res *lbdriver.GCPResource) { applyBody(res, body, merge) })
 	if err != nil {
@@ -153,6 +158,11 @@ func (h *Handler) insertGCPResource(w http.ResponseWriter, r *http.Request, rp g
 	name, _ := body["name"].(string)
 	if name == "" {
 		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "name required")
+		return
+	}
+
+	if err := h.validateGCPResourceRefs(r.Context(), rp, body); err != nil {
+		gcprest.WriteCErr(w, err)
 		return
 	}
 

--- a/server/gcp/loadbalancer/urlmaps_sdk_test.go
+++ b/server/gcp/loadbalancer/urlmaps_sdk_test.go
@@ -25,6 +25,9 @@ func TestSDKGCPURLMapRoundTrip(t *testing.T) {
 
 	t.Cleanup(func() { _ = client.Close() })
 
+	bsClient := newBackendServicesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+	insertBS(ctx, t, bsClient, "web-bs")
+
 	defaultSvc := "projects/" + testProject + "/global/backendServices/web-bs"
 
 	op, err := client.Insert(ctx, &computepb.InsertUrlMapRequest{
@@ -108,6 +111,10 @@ func TestSDKGCPURLMapUpdate(t *testing.T) {
 	}
 
 	t.Cleanup(func() { _ = client.Close() })
+
+	bsClient := newBackendServicesClient(t, ts.URL, option.WithHTTPClient(ts.Client()))
+	insertBS(ctx, t, bsClient, "bs-a")
+	insertBS(ctx, t, bsClient, "bs-b")
 
 	svcA := "projects/" + testProject + "/global/backendServices/bs-a"
 	svcB := "projects/" + testProject + "/global/backendServices/bs-b"


### PR DESCRIPTION
## Summary

The GCP load-balancer handler already enforces `resourceInUseByAnotherResource` delete guards across the chain (healthCheck/urlMap/proxy/instanceGroup/backendService), and validates `backendService.healthChecks[]` on create/patch. This PR closes the other half: reference validation on create/update/set-action, so a resource in the chain can never be created pointing at something that doesn't exist.

Newly validated (400 `InvalidArgument`, "Invalid value for field ..."):
- `urlMap.defaultService` / `pathMatchers[].defaultService` / `pathRules[].service` → must name an existing `backendService`
- `targetHttp(s)Proxy.urlMap` (insert and `setUrlMap`) → must name an existing `urlMap`
- `targetHttpsProxy.sslCertificates[]` (insert and `setSslCertificates`) → must name an existing `sslCertificate`
- `forwardingRule.target` → must name an existing `targetHttpProxy` / `targetHttpsProxy` / `targetPool` (an unimplemented target type, e.g. `targetTcpProxies`, is left unvalidated rather than falsely rejected)
- `backendService.backends[].group` (insert and patch) → must name an existing instance group
- `backendService.backends[].balancingMode` → must be `UTILIZATION` / `RATE` / `CONNECTION` (or empty)

Three pre-existing SDK tests relied on dangling references that real GCP would also reject (a urlMap's `defaultService`, a forwardingRule's `target`, a backendService's `backends[].group`); they now provision the referenced resource first, matching real usage.

## Present vs missing (gap list from investigation)

Already implemented before this PR:
- Delete guards: healthCheck←backendService, urlMap←proxy, sslCertificate←proxy, proxy←forwardingRule, instanceGroup←backendService, backendService←forwardingRule/urlMap
- `backendService.healthChecks[]` create/patch validation

Added by this PR: the remaining upstream reference validations listed above.

Deferred (out of scope for this pass, no cohesive path found without new modeling):
- URL-map path-matcher/path-rule evaluation (routing logic itself, not just ref validation)
- Actual health-check probing (health checks are stored/round-tripped but never evaluated)
- SSL policies, Cloud CDN cache behavior
- `targetTcpProxies` / `targetSslProxies` / backend buckets (unimplemented resource types)

## Test plan

- [x] New SDK tests in `referenceintegrity_sdk_test.go` covering each validated reference (dangling → 400, then real reference → success) for urlMap, target proxy (insert + setUrlMap), forwarding rule target, backend group, and balancing mode
- [x] `go test ./server/gcp/loadbalancer/... ./providers/gcp/loadbalancer/... ./persist/... -race -count=1`
- [x] `go test ./providers/gcp/... ./server/gcp/...`
- [x] `gofmt -l` clean on touched files
- [x] `golangci-lint run` — 0 new issues (2 pre-existing `nolintlint` warnings in `operations.go`, unchanged from base)
- [x] `go generate ./...` + `git diff docs/coverage` clean (no driver interface change)
- [x] `go mod tidy` clean