### PR TITLE
feat(cloudwatchlogs): PutLogEvents chronological order and batch-span validation

### DIFF
--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -22,6 +22,12 @@ import (
 
 const defaultLogLimit = 100
 
+// putLogEventsMaxBatchSpan bounds how far apart the oldest and newest event
+// timestamps in a single PutLogEvents batch may be. Real CloudWatch Logs: a
+// batch of log events in a single request cannot span more than 24 hours,
+// otherwise the PutLogEvents operation fails.
+const putLogEventsMaxBatchSpan = 24 * time.Hour
+
 // Compile-time check that Mock implements driver.Logging.
 var _ driver.Logging = (*Mock)(nil)
 
@@ -241,6 +247,14 @@ func (m *Mock) PutLogEvents(ctx context.Context, groupName, streamName string, e
 		return errors.Newf(errors.NotFound, "log stream %q not found in group %q", streamName, groupName)
 	}
 
+	if len(events) == 0 {
+		return errors.New(errors.InvalidArgument, "logEvents cannot be empty")
+	}
+
+	if err := validatePutLogEventsBatch(events); err != nil {
+		return err
+	}
+
 	ingestedAt := m.opts.Clock.Now().UTC()
 
 	copied := make([]driver.LogEvent, len(events))
@@ -267,20 +281,14 @@ func (m *Mock) PutLogEvents(ctx context.Context, groupName, streamName string, e
 	// The sort is stable, so equal timestamps retain ingestion order.
 	sortLogEventsAscending(s.events)
 
-	if len(events) > 0 {
-		earliest := events[0].Timestamp
-		for i := range events {
-			if events[i].Timestamp.Before(earliest) {
-				earliest = events[i].Timestamp
-			}
-		}
-
-		if s.info.FirstEvent == "" {
-			s.info.FirstEvent = earliest.UTC().Format(time.RFC3339)
-		}
-
-		s.info.LastEvent = events[len(events)-1].Timestamp.UTC().Format(time.RFC3339)
+	// events is already validated non-empty and chronologically ascending (see
+	// validatePutLogEventsBatch above), so events[0] is this batch's earliest
+	// timestamp and events[len(events)-1] its latest.
+	if s.info.FirstEvent == "" {
+		s.info.FirstEvent = events[0].Timestamp.UTC().Format(time.RFC3339)
 	}
+
+	s.info.LastEvent = events[len(events)-1].Timestamp.UTC().Format(time.RFC3339)
 
 	s.mu.Unlock()
 
@@ -295,6 +303,33 @@ func (m *Mock) PutLogEvents(ctx context.Context, groupName, streamName string, e
 
 	m.evaluateMetricFilters(g, events)
 	m.deliverToSubscriptions(ctx, g, streamName, copied)
+
+	return nil
+}
+
+// validatePutLogEventsBatch enforces the two structural constraints real
+// CloudWatch Logs applies to a PutLogEvents batch before ingesting anything:
+// the events must be in chronological (non-decreasing) timestamp order, and
+// the oldest and newest event in the batch must not be more than 24 hours
+// apart. Both are hard failures — the whole batch is rejected and nothing is
+// written — unlike the per-event too-old/too-new rejection real CloudWatch
+// Logs also applies (surfaced via PutLogEventsOutput.RejectedLogEventsInfo),
+// which this emulator does not model: that check is relative to wall-clock
+// time, and event timestamps here are caller-supplied and not tied to the
+// mock's clock, so silently dropping "future" events would reject events
+// legitimate callers routinely backdate or postdate in tests.
+func validatePutLogEventsBatch(events []driver.LogEvent) error {
+	for i := 1; i < len(events); i++ {
+		if events[i].Timestamp.Before(events[i-1].Timestamp) {
+			return errors.New(errors.InvalidArgument,
+				"log events in a single PutLogEvents request must be in chronological order")
+		}
+	}
+
+	if events[len(events)-1].Timestamp.Sub(events[0].Timestamp) > putLogEventsMaxBatchSpan {
+		return errors.New(errors.InvalidArgument,
+			"the log events in a single PutLogEvents request cannot span more than 24 hours")
+	}
 
 	return nil
 }

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs_test.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs_test.go
@@ -354,6 +354,66 @@ func TestPutLogEvents(t *testing.T) {
 		err = m.PutLogEvents(ctx, "grp", "no-stream", nil)
 		require.Error(t, err)
 	})
+
+	t.Run("empty batch rejected", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{})
+		require.Error(t, err)
+		assert.True(t, errors.IsInvalidArgument(err))
+	})
+
+	t.Run("out of order batch rejected", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime.Add(time.Second), Message: "second"},
+			{Timestamp: baseTime, Message: "first"},
+		})
+		require.Error(t, err)
+		assert.True(t, errors.IsInvalidArgument(err))
+
+		// Nothing from the rejected batch was ingested.
+		got, gerr := m.GetLogEvents(ctx, &driver.LogQueryInput{LogGroup: "test-group", LogStream: "test-stream"})
+		require.NoError(t, gerr)
+		assert.Empty(t, got)
+	})
+
+	t.Run("batch spanning more than 24 hours rejected", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "early"},
+			{Timestamp: baseTime.Add(25 * time.Hour), Message: "too late"},
+		})
+		require.Error(t, err)
+		assert.True(t, errors.IsInvalidArgument(err))
+	})
+
+	t.Run("batch spanning exactly 24 hours accepted", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "early"},
+			{Timestamp: baseTime.Add(24 * time.Hour), Message: "late"},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("equal timestamps within a batch accepted", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "one"},
+			{Timestamp: baseTime, Message: "two"},
+		})
+		require.NoError(t, err)
+	})
 }
 
 func TestGetLogEvents(t *testing.T) {

--- a/server/aws/cloudwatchlogs/sdk_roundtrip_test.go
+++ b/server/aws/cloudwatchlogs/sdk_roundtrip_test.go
@@ -675,3 +675,75 @@ func TestSDKLogsErrors(t *testing.T) {
 		t.Fatalf("DeleteLogGroup(missing): got %v, want ResourceNotFoundException", err)
 	}
 }
+
+// TestSDKPutLogEventsBatchValidation locks real CloudWatch Logs' PutLogEvents
+// batch constraints: events in a single request must be in chronological
+// order, and the oldest and newest event in a request cannot span more than
+// 24 hours. Either violation is a hard InvalidParameterException that rejects
+// the whole batch — nothing from it is ingested.
+func TestSDKPutLogEventsBatchValidation(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String("/pv/g")}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	if _, err := client.CreateLogStream(ctx, &cwl.CreateLogStreamInput{
+		LogGroupName: aws.String("/pv/g"), LogStreamName: aws.String("s1"),
+	}); err != nil {
+		t.Fatalf("CreateLogStream: %v", err)
+	}
+
+	base := time.Now().UTC().Truncate(time.Millisecond)
+
+	_, err := client.PutLogEvents(ctx, &cwl.PutLogEventsInput{
+		LogGroupName:  aws.String("/pv/g"),
+		LogStreamName: aws.String("s1"),
+		LogEvents: []cwltypes.InputLogEvent{
+			{Timestamp: aws.Int64(base.Add(time.Second).UnixMilli()), Message: aws.String("second")},
+			{Timestamp: aws.Int64(base.UnixMilli()), Message: aws.String("first")},
+		},
+	})
+
+	var invalid *cwltypes.InvalidParameterException
+	if !errors.As(err, &invalid) {
+		t.Fatalf("out-of-order PutLogEvents: got %v, want InvalidParameterException", err)
+	}
+
+	_, err = client.PutLogEvents(ctx, &cwl.PutLogEventsInput{
+		LogGroupName:  aws.String("/pv/g"),
+		LogStreamName: aws.String("s1"),
+		LogEvents: []cwltypes.InputLogEvent{
+			{Timestamp: aws.Int64(base.UnixMilli()), Message: aws.String("early")},
+			{Timestamp: aws.Int64(base.Add(25 * time.Hour).UnixMilli()), Message: aws.String("too late")},
+		},
+	})
+	if !errors.As(err, &invalid) {
+		t.Fatalf("batch spanning >24h PutLogEvents: got %v, want InvalidParameterException", err)
+	}
+
+	// Neither rejected batch ingested anything.
+	got, gerr := client.GetLogEvents(ctx, &cwl.GetLogEventsInput{
+		LogGroupName: aws.String("/pv/g"), LogStreamName: aws.String("s1"),
+	})
+	if gerr != nil {
+		t.Fatalf("GetLogEvents: %v", gerr)
+	}
+
+	if len(got.Events) != 0 {
+		t.Fatalf("GetLogEvents after rejected batches = %d events, want 0: %+v", len(got.Events), got.Events)
+	}
+
+	// A well-formed batch (chronological, within 24h) still succeeds.
+	if _, err := client.PutLogEvents(ctx, &cwl.PutLogEventsInput{
+		LogGroupName:  aws.String("/pv/g"),
+		LogStreamName: aws.String("s1"),
+		LogEvents: []cwltypes.InputLogEvent{
+			{Timestamp: aws.Int64(base.UnixMilli()), Message: aws.String("ok1")},
+			{Timestamp: aws.Int64(base.Add(time.Second).UnixMilli()), Message: aws.String("ok2")},
+		},
+	}); err != nil {
+		t.Fatalf("well-formed PutLogEvents: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Real CloudWatch Logs enforces two structural constraints on a `PutLogEvents` batch that CloudEmu previously ignored: events in a single request must be in chronological order, and the oldest and newest event in the batch must not span more than 24 hours. Either violation is a hard `InvalidParameterException` — nothing from the batch is ingested. An empty `logEvents` list is also now rejected, matching the API's shape validation.

## Gap list (investigation)

Present and already correct (not touched):
- CreateLogGroup/DeleteLogGroup/DescribeLogGroups, retention (`PutRetentionPolicy`, valid values enforced), tags, `ResourceAlreadyExistsException`/`ResourceNotFoundException`
- CreateLogStream/DeleteLogStream/DescribeLogStreams, cascading delete of a group's streams
- GetLogEvents/FilterLogEvents ordering and pagination
- Metric filters → CloudWatch metric emission on matching `PutLogEvents` calls
- Subscription filters → Lambda/Kinesis/Firehose delivery
- `nextSequenceToken` is a static placeholder and never validated — this matches real CloudWatch Logs' 2023 behavior change (sequence tokens are now ignored), so it was left as-is

Missing (fixed in this PR):
- `PutLogEvents` accepted a batch in any order and of any timestamp span

Deferred (real gaps, out of scope here):
- `DeleteRetentionPolicy` operation is not wired (only `PutRetentionPolicy` exists)
- Per-event `RejectedLogEventsInfo` (too-old/too-new relative to wall-clock `now`) is not modeled — this is intentionally skipped because event timestamps in this codebase's existing tests are caller-supplied and routinely backdated/postdated relative to the mock clock; adding wall-clock-relative rejection would silently break that established test convention and diverge from the "no phantom cutoff" retention design already locked in by `TestRetentionUnsetNeverDrops`
- CloudWatch Logs Insights queries, export tasks, data protection policies, live tail: not modeled

## What changed

- `providers/aws/cloudwatchlogs/cloudwatchlogs.go`: `PutLogEvents` now rejects an empty batch, and validates the batch is chronologically ordered and spans ≤24 hours before writing anything, under the same stream lock as the append (no partial writes, no TOCTOU). The now-redundant earliest-timestamp scan for `FirstEvent` was removed since the incoming batch is guaranteed ascending.
- Tests: provider-level table cases (empty batch, out-of-order, >24h span, exactly-24h boundary, equal timestamps) and a real aws-sdk-go-v2 wire-level test (`TestSDKPutLogEventsBatchValidation`) asserting `InvalidParameterException` and that nothing from a rejected batch is ingested.

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers/aws/cloudwatchlogs/... ./server/aws/cloudwatchlogs/... ./persist/... -race -count=1`
- [x] `go test ./providers/aws/... ./server/aws/...`
- [x] `gofmt -l` on touched files (clean)
- [x] `golangci-lint run` on touched packages (0 new issues)
- [x] `go generate ./...` + `git diff --exit-code docs/coverage` (clean — no driver interface change)
- [x] `go mod tidy` (no changes)