### PR TITLE
feat(cloudlogging): log bucket lifecycle with locked/retention guards

### DIFF
--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -6884,10 +6884,16 @@
         "doc": "GCPLogging is an optional interface implemented by the GCP logging backend for",
         "operations": [
           {
+            "name": "CreateBucket"
+          },
+          {
             "name": "CreateLogMetric"
           },
           {
             "name": "CreateSink"
+          },
+          {
+            "name": "DeleteBucket"
           },
           {
             "name": "DeleteLogMetric"
@@ -6896,16 +6902,25 @@
             "name": "DeleteSink"
           },
           {
+            "name": "GetBucket"
+          },
+          {
             "name": "GetLogMetric"
           },
           {
             "name": "GetSink"
           },
           {
+            "name": "ListBuckets"
+          },
+          {
             "name": "ListLogMetrics"
           },
           {
             "name": "ListSinks"
+          },
+          {
+            "name": "UpdateBucket"
           },
           {
             "name": "UpdateLogMetric"

--- a/docs/coverage/gcp/cloudlogging.md
+++ b/docs/coverage/gcp/cloudlogging.md
@@ -35,14 +35,19 @@ GCPLogging is an optional interface implemented by the GCP logging backend for
 
 | Operation | Description |
 | --- | --- |
+| `CreateBucket` |  |
 | `CreateLogMetric` |  |
 | `CreateSink` |  |
+| `DeleteBucket` |  |
 | `DeleteLogMetric` |  |
 | `DeleteSink` |  |
+| `GetBucket` |  |
 | `GetLogMetric` |  |
 | `GetSink` |  |
+| `ListBuckets` |  |
 | `ListLogMetrics` |  |
 | `ListSinks` |  |
+| `UpdateBucket` |  |
 | `UpdateLogMetric` |  |
 | `UpdateSink` |  |
 

--- a/providers/gcp/cloudlogging/buckets.go
+++ b/providers/gcp/cloudlogging/buckets.go
@@ -1,0 +1,256 @@
+package cloudlogging
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// defaultBucketID and requiredBucketID are the two special log buckets Cloud
+// Logging auto-provisions for every project in the "global" location. Neither
+// can be deleted; _Required additionally cannot be modified at all and starts
+// locked with a much longer retention, mirroring the bucket that captures
+// Admin Activity / mandatory audit logs in real GCP.
+const (
+	defaultBucketID  = "_Default"
+	requiredBucketID = "_Required"
+	globalLocation   = "global"
+	anyLocation      = "-"
+
+	defaultBucketRetentionDays  = 30
+	requiredBucketRetentionDays = 400
+
+	bucketLifecycleActive = "ACTIVE"
+)
+
+func bucketKey(project, location, name string) string {
+	return project + "/" + location + "/" + name
+}
+
+// ensureDefaultBuckets lazily provisions the _Default and _Required buckets
+// for a project's "global" location the first time any bucket call touches it,
+// mirroring how a real Cloud Logging project always has both from creation.
+// SetIfAbsent makes first-touch safe under concurrent callers and never
+// clobbers a bucket that already exists (e.g. one restored from a snapshot).
+func (m *Mock) ensureDefaultBuckets(project, location string) {
+	if location != globalLocation {
+		return
+	}
+
+	now := m.opts.Clock.Now().UTC()
+
+	specs := []struct {
+		name      string
+		retention int32
+		locked    bool
+	}{
+		{defaultBucketID, defaultBucketRetentionDays, false},
+		{requiredBucketID, requiredBucketRetentionDays, true},
+	}
+
+	for _, spec := range specs {
+		m.buckets.SetIfAbsent(bucketKey(project, location, spec.name), &driver.LogBucket{
+			Name:           spec.name,
+			Location:       location,
+			RetentionDays:  spec.retention,
+			Locked:         spec.locked,
+			LifecycleState: bucketLifecycleActive,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		})
+	}
+}
+
+// CreateBucket creates a user-defined log bucket under project/location. The
+// reserved ids _Default and _Required always exist already and cannot be
+// created through this call.
+func (m *Mock) CreateBucket(_ context.Context, project, location string, bucket *driver.LogBucket) (*driver.LogBucket, error) {
+	if bucket.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "bucket id is required")
+	}
+
+	if bucket.Name == defaultBucketID || bucket.Name == requiredBucketID {
+		return nil, errors.Newf(errors.InvalidArgument, "bucket id %q is reserved", bucket.Name)
+	}
+
+	m.ensureDefaultBuckets(project, location)
+
+	key := bucketKey(project, location, bucket.Name)
+	if m.buckets.Has(key) {
+		return nil, errors.Newf(errors.AlreadyExists, "bucket %q already exists", bucket.Name)
+	}
+
+	retention := bucket.RetentionDays
+	if retention == 0 {
+		retention = defaultBucketRetentionDays
+	}
+
+	now := m.opts.Clock.Now().UTC()
+
+	stored := *bucket
+	stored.Location = location
+	stored.RetentionDays = retention
+	stored.LifecycleState = bucketLifecycleActive
+	stored.CreatedAt = now
+	stored.UpdatedAt = now
+
+	m.buckets.Set(key, &stored)
+
+	result := stored
+
+	return &result, nil
+}
+
+// GetBucket returns the bucket named name under project/location.
+func (m *Mock) GetBucket(_ context.Context, project, location, name string) (*driver.LogBucket, error) {
+	m.ensureDefaultBuckets(project, location)
+
+	b, ok := m.buckets.Get(bucketKey(project, location, name))
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "bucket %q not found", name)
+	}
+
+	result := *b
+
+	return &result, nil
+}
+
+// ListBuckets lists all buckets under project/location, in name order.
+// location "-" lists buckets across every location, mirroring the wildcard
+// real Cloud Logging (and gcloud) accepts.
+func (m *Mock) ListBuckets(_ context.Context, project, location string) ([]driver.LogBucket, error) {
+	prefix := project + "/"
+
+	if location == anyLocation {
+		m.ensureDefaultBuckets(project, globalLocation)
+	} else {
+		m.ensureDefaultBuckets(project, location)
+		prefix = bucketKey(project, location, "")
+	}
+
+	buckets := make([]driver.LogBucket, 0)
+
+	for key, b := range m.buckets.All() {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+
+		buckets = append(buckets, *b)
+	}
+
+	sort.Slice(buckets, func(i, j int) bool { return buckets[i].Name < buckets[j].Name })
+
+	return buckets, nil
+}
+
+// UpdateBucket applies a partial update to an existing bucket's mutable
+// fields, atomically under the store lock so the guard checks and the write
+// cannot be split by a concurrent update. See applyBucketUpdate for the
+// invariants enforced.
+func (m *Mock) UpdateBucket(_ context.Context, project, location, name string, update driver.BucketUpdate) (*driver.LogBucket, error) {
+	m.ensureDefaultBuckets(project, location)
+
+	key := bucketKey(project, location, name)
+	now := m.opts.Clock.Now().UTC()
+
+	var (
+		result   driver.LogBucket
+		guardErr error
+	)
+
+	found := m.buckets.Update(key, func(existing *driver.LogBucket) *driver.LogBucket {
+		next, err := applyBucketUpdate(existing, update, name, now)
+		if err != nil {
+			guardErr = err
+			return existing
+		}
+
+		result = *next
+
+		return next
+	})
+
+	if !found {
+		return nil, errors.Newf(errors.NotFound, "bucket %q not found", name)
+	}
+
+	if guardErr != nil {
+		return nil, guardErr
+	}
+
+	return &result, nil
+}
+
+// applyBucketUpdate computes the new value of existing for a partial update.
+// _Required cannot be modified at all; a locked bucket's retention cannot be
+// reduced, and a locked bucket can never be unlocked — both are
+// FailedPrecondition, mirroring real Cloud Logging.
+func applyBucketUpdate(existing *driver.LogBucket, update driver.BucketUpdate, name string, now time.Time) (*driver.LogBucket, error) {
+	if existing.Name == requiredBucketID {
+		return nil, errors.Newf(errors.FailedPrecondition, "bucket %q cannot be modified", name)
+	}
+
+	updated := *existing
+
+	if update.SetRetentionDays {
+		if existing.Locked && update.RetentionDays < existing.RetentionDays {
+			return nil, errors.Newf(errors.FailedPrecondition,
+				"retention period of locked bucket %q cannot be reduced", name)
+		}
+
+		updated.RetentionDays = update.RetentionDays
+	}
+
+	if update.SetDescription {
+		updated.Description = update.Description
+	}
+
+	if update.SetLocked {
+		if existing.Locked && !update.Locked {
+			return nil, errors.Newf(errors.FailedPrecondition, "bucket %q is locked and cannot be unlocked", name)
+		}
+
+		updated.Locked = update.Locked
+	}
+
+	updated.UpdatedAt = now
+
+	return &updated, nil
+}
+
+// DeleteBucket removes a user-defined bucket, atomically checking the guard
+// (reserved id, locked) and deleting under the store lock so a concurrent
+// lock/unlock cannot race the delete. _Default and _Required can never be
+// deleted; neither can a locked bucket (real Cloud Logging requires
+// unlocking first, which this API does not support once a bucket is locked).
+func (m *Mock) DeleteBucket(_ context.Context, project, location, name string) error {
+	m.ensureDefaultBuckets(project, location)
+
+	key := bucketKey(project, location, name)
+
+	var guardErr error
+
+	found := m.buckets.UpdateOrDelete(key, func(b *driver.LogBucket) (*driver.LogBucket, bool) {
+		if b.Name == defaultBucketID || b.Name == requiredBucketID {
+			guardErr = errors.Newf(errors.FailedPrecondition, "bucket %q cannot be deleted", name)
+			return b, true
+		}
+
+		if b.Locked {
+			guardErr = errors.Newf(errors.FailedPrecondition, "locked bucket %q cannot be deleted", name)
+			return b, true
+		}
+
+		return nil, false
+	})
+
+	if !found {
+		return errors.Newf(errors.NotFound, "bucket %q not found", name)
+	}
+
+	return guardErr
+}

--- a/providers/gcp/cloudlogging/cloudlogging.go
+++ b/providers/gcp/cloudlogging/cloudlogging.go
@@ -49,6 +49,10 @@ type Mock struct {
 	// can hold resources for more than one project.
 	sinks   *memstore.Store[*driver.LogSink]
 	metrics *memstore.Store[*driver.LogBasedMetric]
+
+	// buckets backs the GCP-only projects.locations.buckets surface, keyed by
+	// "{project}/{location}/{name}".
+	buckets *memstore.Store[*driver.LogBucket]
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -80,6 +84,7 @@ func New(opts *config.Options) *Mock {
 		opts:    opts,
 		sinks:   memstore.New[*driver.LogSink](),
 		metrics: memstore.New[*driver.LogBasedMetric](),
+		buckets: memstore.New[*driver.LogBucket](),
 	}
 }
 
@@ -577,26 +582,36 @@ func (m *Mock) DescribeSubscriptionFilters(_ context.Context, logGroup string) (
 
 // UpdateLogGroup replaces the mutable fields of an existing log group —
 // ARM CreateOrUpdate-on-existing semantics (retention and tags come from
-// the request; identity and CreatedAt are preserved).
+// the request; identity and CreatedAt are preserved). The read-modify-write
+// runs under the store's lock (via Update) rather than mutating the stored
+// *logGroup's info in place, so a concurrent GetLogGroup can never observe a
+// torn write.
 func (m *Mock) UpdateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
-	g, ok := m.groups.Get(cfg.Name)
-	if !ok {
+	var result driver.LogGroupInfo
+
+	found := m.groups.Update(cfg.Name, func(g *logGroup) *logGroup {
+		updated := *g
+
+		if cfg.RetentionDays != 0 {
+			updated.info.RetentionDays = cfg.RetentionDays
+		}
+
+		if cfg.Tags != nil {
+			updated.info.Tags = maps.Clone(cfg.Tags)
+		}
+
+		if !cfg.Scope.IsZero() {
+			updated.info.Scope = cfg.Scope
+		}
+
+		result = updated.info
+
+		return &updated
+	})
+
+	if !found {
 		return nil, errors.Newf(errors.NotFound, "log group %q not found", cfg.Name)
 	}
-
-	if cfg.RetentionDays != 0 {
-		g.info.RetentionDays = cfg.RetentionDays
-	}
-	if cfg.Tags != nil {
-		g.info.Tags = maps.Clone(cfg.Tags)
-	}
-	if !cfg.Scope.IsZero() {
-		g.info.Scope = cfg.Scope
-	}
-
-	m.groups.Set(cfg.Name, g)
-
-	result := g.info
 
 	return &result, nil
 }

--- a/providers/gcp/cloudlogging/cloudlogging.go
+++ b/providers/gcp/cloudlogging/cloudlogging.go
@@ -265,9 +265,14 @@ func (m *Mock) PutLogEvents(ctx context.Context, groupName, streamName string, e
 		totalBytes += int64(len(e.Message))
 	}
 
+	// Copy-on-write: never mutate the stored *logGroup's info in place, or a
+	// concurrent GetLogGroup/ListLogGroups reading g.info without the store
+	// lock could observe a torn write.
 	m.groups.Update(groupName, func(lg *logGroup) *logGroup {
-		lg.info.StoredBytes += totalBytes
-		return lg
+		updated := *lg
+		updated.info.StoredBytes += totalBytes
+
+		return &updated
 	})
 
 	dims := map[string]string{"log_group": groupName}

--- a/providers/gcp/cloudlogging/concurrency_test.go
+++ b/providers/gcp/cloudlogging/concurrency_test.go
@@ -1,0 +1,59 @@
+package cloudlogging
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/logging/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPutLogEventsConcurrentWithGetLogGroupRace locks the fix for a
+// Get-then-naked-mutate race: PutLogEvents used to fetch the stored *logGroup
+// and then mutate its info.StoredBytes field in place, so a concurrent
+// GetLogGroup/ListLogGroups reading that same info struct without the
+// store's own lock could observe a torn write. PutLogEvents now
+// copy-on-writes the logGroup before mutating and replaces it via
+// memstore.Update, so this must stay clean under `go test -race`.
+func TestPutLogEventsConcurrentWithGetLogGroupRace(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	setupGroupAndStream(t, m)
+
+	const (
+		iters   = 200
+		message = "hello"
+	)
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		for range iters {
+			_ = m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+				{Message: message},
+			})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for range iters {
+			_, _ = m.GetLogGroup(ctx, "test-group")
+			_, _ = m.ListLogGroups(ctx, scope.Scope{})
+		}
+	}()
+
+	wg.Wait()
+
+	info, err := m.GetLogGroup(ctx, "test-group")
+	require.NoError(t, err)
+	require.Equal(t, int64(iters*len(message)), info.StoredBytes)
+}

--- a/providers/gcp/cloudlogging/snapshot.go
+++ b/providers/gcp/cloudlogging/snapshot.go
@@ -14,15 +14,17 @@ var _ snapshot.Snapshottable = (*Mock)(nil)
 
 // cloudloggingSnapshot is the full serialized state of the GCP Cloud Logging
 // mock: every log group (with its streams, metric filters, and subscription
-// filters), plus the GCP-native export sinks and log-based metrics. The stored
-// *logGroup/*logStream have unexported layouts, so they are promoted to exported
-// snapshot forms; sinks and metrics hold fully-exported driver values and
-// round-trip through the generic memstore helper. The wired *config.Options and
-// monitoring backend are intentionally not serialized.
+// filters), plus the GCP-native export sinks, log-based metrics, and buckets.
+// The stored *logGroup/*logStream have unexported layouts, so they are
+// promoted to exported snapshot forms; sinks, metrics, and buckets hold
+// fully-exported driver values and round-trip through the generic memstore
+// helper. The wired *config.Options and monitoring backend are intentionally
+// not serialized.
 type cloudloggingSnapshot struct {
 	Groups  map[string]*logGroupSnapshot `json:"groups,omitempty"`
 	Sinks   json.RawMessage              `json:"sinks,omitempty"`
 	Metrics json.RawMessage              `json:"metrics,omitempty"`
+	Buckets json.RawMessage              `json:"buckets,omitempty"`
 }
 
 // logGroupSnapshot mirrors logGroup, promoting its nested stream store and the
@@ -61,6 +63,10 @@ func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
 	}
 
 	if err := dumpInto(&snap.Metrics, m.metrics.Snapshot); err != nil {
+		return nil, err
+	}
+
+	if err := dumpInto(&snap.Buckets, m.buckets.Snapshot); err != nil {
 		return nil, err
 	}
 
@@ -122,7 +128,11 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 		return err
 	}
 
-	return loadInto(snap.Metrics, m.metrics.LoadSnapshot)
+	if err := loadInto(snap.Metrics, m.metrics.LoadSnapshot); err != nil {
+		return err
+	}
+
+	return loadInto(snap.Buckets, m.buckets.LoadSnapshot)
 }
 
 func restoreGroup(gs *logGroupSnapshot) (*logGroup, error) {

--- a/server/gcp/cloudlogging/buckets.go
+++ b/server/gcp/cloudlogging/buckets.go
@@ -1,0 +1,178 @@
+package cloudlogging
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// logBucketJSON is the Cloud Logging LogBucket resource shape.
+type logBucketJSON struct {
+	Name           string `json:"name,omitempty"`
+	Description    string `json:"description,omitempty"`
+	RetentionDays  int32  `json:"retentionDays,omitempty"`
+	Locked         bool   `json:"locked,omitempty"`
+	LifecycleState string `json:"lifecycleState,omitempty"`
+	CreateTime     string `json:"createTime,omitempty"`
+	UpdateTime     string `json:"updateTime,omitempty"`
+}
+
+type listBucketsResponse struct {
+	Buckets       []logBucketJSON `json:"buckets"`
+	NextPageToken string          `json:"nextPageToken,omitempty"`
+}
+
+// bucketNameFor builds the fully-qualified bucket resource name:
+// "projects/{project}/locations/{location}/buckets/{name}".
+func bucketNameFor(project, location, name string) string {
+	return "projects/" + project + "/locations/" + location + "/buckets/" + name
+}
+
+func toBucketJSON(project, location string, b *logdriver.LogBucket) logBucketJSON {
+	out := logBucketJSON{
+		Name:           bucketNameFor(project, location, b.Name),
+		Description:    b.Description,
+		RetentionDays:  b.RetentionDays,
+		Locked:         b.Locked,
+		LifecycleState: b.LifecycleState,
+	}
+
+	if !b.CreatedAt.IsZero() {
+		out.CreateTime = b.CreatedAt.UTC().Format(time.RFC3339Nano)
+	}
+
+	if !b.UpdatedAt.IsZero() {
+		out.UpdateTime = b.UpdatedAt.UTC().Format(time.RFC3339Nano)
+	}
+
+	return out
+}
+
+// writeBucket writes a single bucket or the driver error that produced it.
+func writeBucket(w http.ResponseWriter, project, location string, b *logdriver.LogBucket, err error) {
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toBucketJSON(project, location, b))
+}
+
+// routeBuckets serves the projects.locations.buckets collection:
+// GET/POST .../locations/{l}/buckets and GET/PATCH/DELETE .../buckets/{id}.
+func (h *Handler) routeBuckets(w http.ResponseWriter, r *http.Request, project, location, tail string) {
+	gcp, ok := h.gcpBackend(w)
+	if !ok {
+		return
+	}
+
+	if tail == "/" {
+		switch r.Method {
+		case http.MethodPost:
+			createBucket(w, r, gcp, project, location)
+		case http.MethodGet:
+			listBuckets(w, r, gcp, project, location)
+		default:
+			writeMethodNotAllowed(w)
+		}
+
+		return
+	}
+
+	bucketID := strings.TrimPrefix(tail, "/")
+
+	switch r.Method {
+	case http.MethodGet:
+		b, err := gcp.GetBucket(r.Context(), project, location, bucketID)
+		writeBucket(w, project, location, b, err)
+	case http.MethodPatch, http.MethodPut:
+		updateBucket(w, r, gcp, project, location, bucketID)
+	case http.MethodDelete:
+		deleteResource(w, gcp.DeleteBucket(r.Context(), project, location, bucketID))
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+// createBucket maps CreateBucket. The bucket id is a required "bucketId" query
+// param (the body's own name field is empty on create, matching the real API).
+func createBucket(w http.ResponseWriter, r *http.Request, gcp logdriver.GCPLogging, project, location string) {
+	var body logBucketJSON
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	bucketID := r.URL.Query().Get("bucketId")
+	if bucketID == "" {
+		bucketID = body.Name
+	}
+
+	b, err := gcp.CreateBucket(r.Context(), project, location, &logdriver.LogBucket{
+		Name:          bucketID,
+		Description:   body.Description,
+		RetentionDays: body.RetentionDays,
+	})
+	writeBucket(w, project, location, b, err)
+}
+
+func listBuckets(w http.ResponseWriter, r *http.Request, gcp logdriver.GCPLogging, project, location string) {
+	buckets, err := gcp.ListBuckets(r.Context(), project, location)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]logBucketJSON, 0, len(buckets))
+	for i := range buckets {
+		out = append(out, toBucketJSON(project, buckets[i].Location, &buckets[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listBucketsResponse{Buckets: out})
+}
+
+// updateBucket maps UpdateBucket (PATCH). When the caller sends an
+// updateMask, only the named fields are applied. A caller with no mask falls
+// back to a presence heuristic (retentionDays/locked apply only when
+// non-zero/true), so a plain full-body PUT-style call cannot silently zero
+// out retention or unlock a bucket it never meant to touch.
+func updateBucket(w http.ResponseWriter, r *http.Request, gcp logdriver.GCPLogging, project, location, bucketID string) {
+	var body logBucketJSON
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	mask := r.URL.Query().Get("updateMask")
+
+	update := logdriver.BucketUpdate{
+		Description:   body.Description,
+		RetentionDays: body.RetentionDays,
+		Locked:        body.Locked,
+	}
+
+	if mask == "" {
+		update.SetDescription = true
+		update.SetRetentionDays = body.RetentionDays != 0
+		update.SetLocked = body.Locked
+	} else {
+		update.SetDescription = maskHas(mask, "description")
+		update.SetRetentionDays = maskHas(mask, "retentionDays") || maskHas(mask, "retention_days")
+		update.SetLocked = maskHas(mask, "locked")
+	}
+
+	b, err := gcp.UpdateBucket(r.Context(), project, location, bucketID, update)
+	writeBucket(w, project, location, b, err)
+}
+
+// maskHas reports whether the comma-separated updateMask names field exactly.
+func maskHas(mask, field string) bool {
+	for _, p := range strings.Split(mask, ",") {
+		if strings.TrimSpace(p) == field {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/gcp/cloudlogging/buckets.go
+++ b/server/gcp/cloudlogging/buckets.go
@@ -153,7 +153,7 @@ func updateBucket(w http.ResponseWriter, r *http.Request, gcp logdriver.GCPLoggi
 	}
 
 	if mask == "" {
-		update.SetDescription = true
+		update.SetDescription = body.Description != ""
 		update.SetRetentionDays = body.RetentionDays != 0
 		update.SetLocked = body.Locked
 	} else {

--- a/server/gcp/cloudlogging/buckets_sdk_test.go
+++ b/server/gcp/cloudlogging/buckets_sdk_test.go
@@ -88,6 +88,52 @@ func TestSDKBucketsLifecycle(t *testing.T) {
 	}
 }
 
+// TestSDKBucketsPatchNoMaskPreservesDescription guards a mask-less Patch (the
+// Go SDK does not require .UpdateMask()): a caller touching only
+// retentionDays must not silently wipe the existing description. This
+// exercises updateBucket's presence-heuristic fallback, which previously set
+// SetDescription unconditionally to true regardless of whether the body
+// actually carried a description.
+func TestSDKBucketsPatchNoMaskPreservesDescription(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+
+	parent := "projects/" + testProject + "/locations/global"
+	bucketName := parent + "/buckets/no-mask-bucket"
+
+	if _, err := svc.Projects.Locations.Buckets.Create(parent, &logging.LogBucket{
+		Description:   "important",
+		RetentionDays: 14,
+	}).BucketId("no-mask-bucket").Context(ctx).Do(); err != nil {
+		t.Fatalf("Buckets.Create: %v", err)
+	}
+
+	// No .UpdateMask() call: only RetentionDays is set on the body.
+	updated, err := svc.Projects.Locations.Buckets.Patch(bucketName, &logging.LogBucket{
+		RetentionDays: 30,
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Buckets.Patch(no mask): %v", err)
+	}
+
+	if updated.RetentionDays != 30 {
+		t.Errorf("updated retentionDays = %d, want 30", updated.RetentionDays)
+	}
+
+	if updated.Description != "important" {
+		t.Errorf("mask-less patch wiped description: got %q, want %q", updated.Description, "important")
+	}
+
+	got, err := svc.Projects.Locations.Buckets.Get(bucketName).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Buckets.Get: %v", err)
+	}
+
+	if got.Description != "important" {
+		t.Errorf("get description after mask-less patch = %q, want %q", got.Description, "important")
+	}
+}
+
 // TestSDKBucketsLockedGuards guards the locked-bucket invariants: retention
 // cannot be reduced, the bucket cannot be unlocked, and it cannot be deleted.
 func TestSDKBucketsLockedGuards(t *testing.T) {

--- a/server/gcp/cloudlogging/buckets_sdk_test.go
+++ b/server/gcp/cloudlogging/buckets_sdk_test.go
@@ -1,0 +1,210 @@
+package cloudlogging_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+	logging "google.golang.org/api/logging/v2"
+)
+
+// TestSDKBucketsLifecycle guards create/get/list/patch/delete of a
+// user-defined log bucket, including a dup create and a get of a missing one.
+func TestSDKBucketsLifecycle(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+
+	parent := "projects/" + testProject + "/locations/global"
+	bucketName := parent + "/buckets/my-bucket"
+
+	created, err := svc.Projects.Locations.Buckets.Create(parent, &logging.LogBucket{
+		Description:   "app logs",
+		RetentionDays: 14,
+	}).BucketId("my-bucket").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Buckets.Create: %v", err)
+	}
+
+	if created.Name != bucketName {
+		t.Errorf("created bucket name = %q, want %q", created.Name, bucketName)
+	}
+
+	if created.RetentionDays != 14 {
+		t.Errorf("created retentionDays = %d, want 14", created.RetentionDays)
+	}
+
+	if created.LifecycleState != "ACTIVE" {
+		t.Errorf("created lifecycleState = %q, want ACTIVE", created.LifecycleState)
+	}
+
+	if _, err := svc.Projects.Locations.Buckets.Create(parent, &logging.LogBucket{}).
+		BucketId("my-bucket").Context(ctx).Do(); err == nil {
+		t.Fatal("Buckets.Create(dup): want error, got nil")
+	}
+
+	got, err := svc.Projects.Locations.Buckets.Get(bucketName).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Buckets.Get: %v", err)
+	}
+
+	if got.Description != "app logs" {
+		t.Errorf("get description = %q, want %q", got.Description, "app logs")
+	}
+
+	list, err := svc.Projects.Locations.Buckets.List(parent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Buckets.List: %v", err)
+	}
+
+	// _Default and _Required are auto-provisioned alongside the user bucket.
+	if len(list.Buckets) != 3 {
+		t.Fatalf("Buckets.List = %d buckets, want 3 (_Default, _Required, my-bucket): %+v",
+			len(list.Buckets), list.Buckets)
+	}
+
+	updated, err := svc.Projects.Locations.Buckets.Patch(bucketName, &logging.LogBucket{
+		RetentionDays: 30,
+	}).UpdateMask("retentionDays").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Buckets.Patch(retentionDays): %v", err)
+	}
+
+	if updated.RetentionDays != 30 {
+		t.Errorf("updated retentionDays = %d, want 30", updated.RetentionDays)
+	}
+
+	if updated.Description != "app logs" {
+		t.Errorf("patch with a narrow mask clobbered description: %q", updated.Description)
+	}
+
+	if _, err := svc.Projects.Locations.Buckets.Delete(bucketName).Context(ctx).Do(); err != nil {
+		t.Fatalf("Buckets.Delete: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Buckets.Get(bucketName).Context(ctx).Do(); err == nil {
+		t.Fatal("Buckets.Get(deleted): want error, got nil")
+	}
+}
+
+// TestSDKBucketsLockedGuards guards the locked-bucket invariants: retention
+// cannot be reduced, the bucket cannot be unlocked, and it cannot be deleted.
+func TestSDKBucketsLockedGuards(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+
+	parent := "projects/" + testProject + "/locations/global"
+	bucketName := parent + "/buckets/locked-bucket"
+
+	if _, err := svc.Projects.Locations.Buckets.Create(parent, &logging.LogBucket{
+		RetentionDays: 60,
+	}).BucketId("locked-bucket").Context(ctx).Do(); err != nil {
+		t.Fatalf("Buckets.Create: %v", err)
+	}
+
+	locked, err := svc.Projects.Locations.Buckets.Patch(bucketName, &logging.LogBucket{
+		Locked: true,
+	}).UpdateMask("locked").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Buckets.Patch(locked): %v", err)
+	}
+
+	if !locked.Locked {
+		t.Fatal("bucket did not report locked=true after locking")
+	}
+
+	_, err = svc.Projects.Locations.Buckets.Patch(bucketName, &logging.LogBucket{
+		RetentionDays: 10,
+	}).UpdateMask("retentionDays").Context(ctx).Do()
+	assertConflict(t, "Patch(reduce retention on locked bucket)", err)
+
+	_, err = svc.Projects.Locations.Buckets.Patch(bucketName, &logging.LogBucket{
+		Locked: false,
+	}).UpdateMask("locked").Context(ctx).Do()
+	assertConflict(t, "Patch(unlock a locked bucket)", err)
+
+	// Raising retention on a locked bucket is still allowed.
+	raised, err := svc.Projects.Locations.Buckets.Patch(bucketName, &logging.LogBucket{
+		RetentionDays: 90,
+	}).UpdateMask("retentionDays").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Buckets.Patch(raise retention on locked bucket): %v", err)
+	}
+
+	if raised.RetentionDays != 90 {
+		t.Errorf("raised retentionDays = %d, want 90", raised.RetentionDays)
+	}
+
+	_, err = svc.Projects.Locations.Buckets.Delete(bucketName).Context(ctx).Do()
+	assertConflict(t, "Delete(locked bucket)", err)
+}
+
+// TestSDKBucketsSpecialBuckets guards the _Default/_Required auto-provisioned
+// buckets: neither can be deleted, _Required cannot be modified at all, and
+// creating a bucket under either reserved id is rejected.
+func TestSDKBucketsSpecialBuckets(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+
+	parent := "projects/" + testProject + "/locations/global"
+
+	def, err := svc.Projects.Locations.Buckets.Get(parent + "/buckets/_Default").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Buckets.Get(_Default): %v", err)
+	}
+
+	if def.RetentionDays != 30 {
+		t.Errorf("_Default retentionDays = %d, want 30", def.RetentionDays)
+	}
+
+	required, err := svc.Projects.Locations.Buckets.Get(parent + "/buckets/_Required").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Buckets.Get(_Required): %v", err)
+	}
+
+	if required.RetentionDays != 400 {
+		t.Errorf("_Required retentionDays = %d, want 400", required.RetentionDays)
+	}
+
+	if !required.Locked {
+		t.Error("_Required is not reported as locked")
+	}
+
+	if _, err := svc.Projects.Locations.Buckets.Delete(parent + "/buckets/_Default").Context(ctx).Do(); err == nil {
+		t.Fatal("Buckets.Delete(_Default): want error, got nil")
+	}
+
+	if _, err := svc.Projects.Locations.Buckets.Delete(parent + "/buckets/_Required").Context(ctx).Do(); err == nil {
+		t.Fatal("Buckets.Delete(_Required): want error, got nil")
+	}
+
+	_, err = svc.Projects.Locations.Buckets.Patch(parent+"/buckets/_Required", &logging.LogBucket{
+		RetentionDays: 500,
+	}).UpdateMask("retentionDays").Context(ctx).Do()
+	assertConflict(t, "Patch(_Required)", err)
+
+	if _, err := svc.Projects.Locations.Buckets.Create(parent, &logging.LogBucket{}).
+		BucketId("_Default").Context(ctx).Do(); err == nil {
+		t.Fatal("Buckets.Create(_Default): want error, got nil")
+	}
+}
+
+// assertConflict fails t unless err is a googleapi.Error with a 409 status —
+// the mapping for both AlreadyExists and FailedPrecondition (see gcprest.WriteCErr).
+func assertConflict(t *testing.T, op string, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("%s: want error, got nil", op)
+	}
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) {
+		t.Fatalf("%s: err = %v, want *googleapi.Error", op, err)
+	}
+
+	if gerr.Code != http.StatusConflict {
+		t.Fatalf("%s: status = %d, want %d", op, gerr.Code, http.StatusConflict)
+	}
+}

--- a/server/gcp/cloudlogging/handler.go
+++ b/server/gcp/cloudlogging/handler.go
@@ -11,20 +11,24 @@
 //
 // Driver -> wire mapping:
 //
-//	POST   /v2/entries:write              — WriteLogEntries -> (lazy CreateLogGroup) + PutLogEvents
-//	POST   /v2/entries:list               — ListLogEntries  -> GetLogEvents
-//	GET    /v2/projects/{p}/logs          — ListLogs        -> ListLogGroups
-//	DELETE /v2/projects/{p}/logs/{logid}  — DeleteLog       -> DeleteLogGroup
+//	POST   /v2/entries:write                                  — WriteLogEntries -> (lazy CreateLogGroup) + PutLogEvents
+//	POST   /v2/entries:list                                   — ListLogEntries  -> GetLogEvents
+//	GET    /v2/projects/{p}/logs                               — ListLogs        -> ListLogGroups
+//	DELETE /v2/projects/{p}/logs/{logid}                       — DeleteLog       -> DeleteLogGroup
+//	POST   /v2/projects/{p}/locations/{l}/buckets              — CreateBucket    -> GCPLogging.CreateBucket
+//	GET    /v2/projects/{p}/locations/{l}/buckets              — ListBuckets     -> GCPLogging.ListBuckets
+//	GET    /v2/projects/{p}/locations/{l}/buckets/{b}          — GetBucket       -> GCPLogging.GetBucket
+//	PATCH  /v2/projects/{p}/locations/{l}/buckets/{b}          — UpdateBucket    -> GCPLogging.UpdateBucket
+//	DELETE /v2/projects/{p}/locations/{l}/buckets/{b}          — DeleteBucket    -> GCPLogging.DeleteBucket
 //
-// Export sinks (projects.sinks) and log-based metrics (projects.metrics) — GCP
-// resource surfaces with no cross-provider equivalent — are served through the
-// optional driver.GCPLogging interface, which the GCP backend implements.
+// Export sinks (projects.sinks), log-based metrics (projects.metrics), and log
+// buckets (projects.locations.buckets) — GCP resource surfaces with no
+// cross-provider equivalent — are served through the optional
+// driver.GCPLogging interface, which the GCP backend implements.
 //
 // The /v2/ URL space is disjoint from the /v1/projects/ family (Firestore, IAM,
 // …), /compute/v1/, and /dns/v1/, so registration order relative to them is
 // unconstrained. Registered before the GCS fallback for consistency.
-//
-// Out of scope for this slice: log buckets (projects.locations.buckets).
 package cloudlogging
 
 import (
@@ -42,7 +46,9 @@ const (
 	logsCollection    = "logs"
 	sinksCollection   = "sinks"
 	metricsCollection = "metrics"
+	bucketsCollection = "buckets"
 	projectsSeg       = "projects"
+	locationsSeg      = "locations"
 )
 
 // defaultStream is the implicit log stream every Cloud Logging write lands in.
@@ -67,6 +73,10 @@ func New(l logdriver.Logging) *Handler {
 func (*Handler) Matches(r *http.Request) bool {
 	p := r.URL.Path
 	if p == entriesWrite || p == entriesList {
+		return true
+	}
+
+	if _, _, _, ok := bucketsPath(p); ok {
 		return true
 	}
 
@@ -99,6 +109,32 @@ func collectionPath(p, collection string) string {
 	return "/" + strings.Join(parts[collectionSegments:], "/")
 }
 
+// bucketsPath parses a Cloud Logging buckets URL of the form
+// "/v2/projects/{project}/locations/{location}/buckets[/{bucketID}]". ok is
+// false when p is not under this shape; tail is "/" for the bare collection.
+func bucketsPath(p string) (project, location, tail string, ok bool) {
+	if !strings.HasPrefix(p, basePrefix) {
+		return "", "", "", false
+	}
+
+	// projects/{p}/locations/{l}/buckets[/{tail}...] — at least the five
+	// leading segments must be present.
+	const bucketsSegments = 5
+
+	parts := strings.Split(strings.TrimPrefix(p, basePrefix), "/")
+	if len(parts) < bucketsSegments || parts[0] != projectsSeg || parts[2] != locationsSeg || parts[4] != bucketsCollection {
+		return "", "", "", false
+	}
+
+	project, location = parts[1], parts[3]
+
+	if len(parts) == bucketsSegments {
+		return project, location, "/", true
+	}
+
+	return project, location, "/" + strings.Join(parts[bucketsSegments:], "/"), true
+}
+
 // ServeHTTP routes on the path and method.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
@@ -107,6 +143,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	case entriesList:
 		h.serveEntriesList(w, r)
+		return
+	}
+
+	if project, location, tail, ok := bucketsPath(r.URL.Path); ok {
+		h.routeBuckets(w, r, project, location, tail)
 		return
 	}
 

--- a/services/logging/driver/gcp.go
+++ b/services/logging/driver/gcp.go
@@ -35,10 +35,44 @@ type LogBasedMetric struct {
 	UpdatedAt      time.Time
 }
 
+// LogBucket is a Cloud Logging bucket (logging.projects.locations.buckets): a
+// retention container that log entries are stored in, either directly or via a
+// sink's destination. Every project auto-provisions two special buckets in the
+// "global" location — _Default and _Required — which can never be deleted;
+// _Required additionally can never be modified at all. A bucket may be locked,
+// which is a one-way transition: once locked, its retention period can only be
+// increased (never reduced) and it cannot be deleted or unlocked. It has no
+// cross-provider equivalent, so it lives on the optional GCPLogging interface
+// rather than the portable Logging interface.
+type LogBucket struct {
+	Name           string
+	Location       string
+	Description    string
+	RetentionDays  int32
+	Locked         bool
+	LifecycleState string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// BucketUpdate describes a partial update (PATCH) to a log bucket's mutable
+// fields. Each Set* flag mirrors whether the wire layer's updateMask (or, for a
+// mask-less caller, a presence heuristic) named that field, so a field the
+// caller did not intend to touch is left unchanged rather than reset to its
+// Go zero value.
+type BucketUpdate struct {
+	Description      string
+	SetDescription   bool
+	RetentionDays    int32
+	SetRetentionDays bool
+	Locked           bool
+	SetLocked        bool
+}
+
 // GCPLogging is an optional interface implemented by the GCP logging backend for
-// Cloud Logging resource surfaces (export sinks, log-based metrics) that have no
-// portable, cross-provider equivalent. The Cloud Logging wire handler type-asserts
-// for it; AWS and Azure backends do not implement it.
+// Cloud Logging resource surfaces (export sinks, log-based metrics, buckets)
+// that have no portable, cross-provider equivalent. The Cloud Logging wire
+// handler type-asserts for it; AWS and Azure backends do not implement it.
 type GCPLogging interface {
 	CreateSink(ctx context.Context, project string, sink *LogSink) (*LogSink, error)
 	GetSink(ctx context.Context, project, name string) (*LogSink, error)
@@ -51,4 +85,10 @@ type GCPLogging interface {
 	ListLogMetrics(ctx context.Context, project string) ([]LogBasedMetric, error)
 	UpdateLogMetric(ctx context.Context, project string, metric *LogBasedMetric) (*LogBasedMetric, error)
 	DeleteLogMetric(ctx context.Context, project, name string) error
+
+	CreateBucket(ctx context.Context, project, location string, bucket *LogBucket) (*LogBucket, error)
+	GetBucket(ctx context.Context, project, location, name string) (*LogBucket, error)
+	ListBuckets(ctx context.Context, project, location string) ([]LogBucket, error)
+	UpdateBucket(ctx context.Context, project, location, name string, update BucketUpdate) (*LogBucket, error)
+	DeleteBucket(ctx context.Context, project, location, name string) error
 }


### PR DESCRIPTION
## Summary

Deepens GCP Cloud Logging with `projects.locations.buckets` — previously entirely absent from the wire server (explicitly noted as out of scope in `server/gcp/cloudlogging/handler.go`).

**Gap found (present vs missing):**
- Present already: log sinks CRUD (`projects.sinks`) and log-based metrics CRUD (`projects.metrics`), both full lifecycle with dup-name `AlreadyExists`, auto writer identity, update/delete.
- Present already: `entries.write` / `entries.list` with severity/labels/jsonPayload, timestamp ordering, paging, filter by `logName`.
- Missing entirely: log buckets (`projects.locations.buckets`) — no driver methods, no wire routes.

**Added:**
- `driver.GCPLogging`: `CreateBucket`/`GetBucket`/`ListBuckets`/`UpdateBucket`/`DeleteBucket`, plus a `LogBucket` type and a `BucketUpdate` partial-update type (explicit `Set*` flags so an update never silently clears/unlocks a field it wasn't asked to touch).
- Provider (`providers/gcp/cloudlogging/buckets.go`): every project auto-provisions `_Default` (30-day retention) and `_Required` (400-day, locked) in the `global` location on first touch. `_Default`/`_Required` can never be deleted; `_Required` can never be modified at all. A locked bucket's retention can only be raised, never reduced, and a locked bucket can never be unlocked or deleted — all guards run atomically under the store lock via `memstore.Update`/`UpdateOrDelete` (no get-then-mutate).
- Wire handler (`server/gcp/cloudlogging/buckets.go` + routing in `handler.go`): `POST/GET /v2/projects/{p}/locations/{l}/buckets`, `GET/PATCH/DELETE .../buckets/{b}`, honoring `updateMask` (with a presence-heuristic fallback for a mask-less caller).
- Snapshot/restore and `persist` completeness updated for the new store.
- `docs/coverage` regenerated for the new `GCPLogging` operations.

**Also fixed:** a pre-existing data race in `UpdateLogGroup`, which mutated a stored `*logGroup`'s `info` fields in place instead of going through `memstore.Update`, racing a concurrent `GetLogGroup`.

**Deferred:** Log Analytics/SQL views, `_Required`/CMEK settings depth, real routing of sink destinations, log-based metric evaluation against ingested entries.

## Test plan
- New real-SDK (`google.golang.org/api/logging/v2`) e2e tests: bucket create/get/list/patch/delete, dup create, locked-bucket retention-reduce/unlock/delete guards (all `FAILED_PRECONDITION` → 409), `_Default`/`_Required` provisioning and immutability.
- `go build ./...`, `go vet`, `go test -race` on the touched packages + `persist`, broad `go test ./providers/gcp/... ./server/gcp/...` — all green.
- `gofmt -l` clean; `golangci-lint run --new-from-rev=origin/development` on touched packages — 0 new issues.
- `go generate ./...` — `docs/coverage` regenerated and committed.
- `go mod tidy` — no changes.