### PR TITLE
feat(azuremonitor): metric alert + action group lifecycle and referential integrity

### DIFF
--- a/server/azure/monitor/handler.go
+++ b/server/azure/monitor/handler.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
@@ -182,6 +183,20 @@ func (h *Handler) list(w http.ResponseWriter, rp *azurearm.ResourcePath, kind st
 }
 
 func (h *Handler) delete(w http.ResponseWriter, rp *azurearm.ResourcePath, kind string) {
+	// Deleting an action group still referenced by a metricAlert or
+	// activityLogAlert is rejected, matching real Azure Monitor: a breach could
+	// no longer resolve the action group, and matching the azurelb backend-pool
+	// in-use guard convention (409/FailedPrecondition, not a silently dangling
+	// reference).
+	if kind == typeActionGroup {
+		if ref := h.actionGroupInUse(actionGroupID(rp)); ref != "" {
+			azurearm.WriteCErr(w, cerrors.Newf(cerrors.FailedPrecondition,
+				"action group %q is in use by %s and cannot be deleted", rp.ResourceName, ref))
+
+			return
+		}
+	}
+
 	// Azure DELETE is idempotent: a missing metricAlert/actionGroup/activityLogAlert
 	// returns 204 No Content ("resource does not exist"), not a 404 error body.
 	if !h.store.delete(rp.Subscription, rp.ResourceGroup, kind, rp.ResourceName) {
@@ -239,12 +254,17 @@ func (h *Handler) patch(w http.ResponseWriter, r *http.Request, rp *azurearm.Res
 }
 
 // applySideEffects runs the driver-side wiring a resource's stored properties
-// imply: metricAlerts register/refresh the evaluated alarm, actionGroups
-// register/refresh their receivers. Other kinds (activityLogAlerts,
-// autoscaleSettings) are pure round-trip resources with no side effect.
+// imply: metricAlerts validate their action-group references then
+// register/refresh the evaluated alarm, actionGroups register/refresh their
+// receivers. Other kinds (activityLogAlerts, autoscaleSettings) are pure
+// round-trip resources with no side effect.
 func (h *Handler) applySideEffects(r *http.Request, rp *azurearm.ResourcePath, kind string, props map[string]any) error {
 	switch kind {
 	case typeAlerts:
+		if err := h.validateActionGroupRefs(actionGroupIDs(props)); err != nil {
+			return err
+		}
+
 		return h.registerAlarm(r, rp.ResourceName, props)
 	case typeActionGroup:
 		h.registerActionGroup(rp, props)

--- a/server/azure/monitor/referential.go
+++ b/server/azure/monitor/referential.go
@@ -13,7 +13,13 @@ import (
 // resource, mirroring real Azure Monitor's rejection of a metric alert rule
 // linked to an action group that doesn't exist (the same reference-validation
 // convention already applied to gcplb/azurelb create/update: 400
-// InvalidArgument, not a silent no-op deferred to breach time).
+// InvalidArgument, not a silent no-op deferred to breach time). ARM resource
+// ids are case-insensitive, so this resolves each id by scanning the stored
+// action groups and comparing canonical ids with strings.EqualFold — the same
+// pattern actionGroupInUse uses below — rather than an exact-case store.get(),
+// which would reject a reference that differs only in casing even though
+// RegisterActionGroup/fireActionGroups (providers/azure/monitor/actiongroups.go)
+// already resolve such a reference case-insensitively at breach time.
 func (h *Handler) validateActionGroupRefs(ids []string) error {
 	for _, id := range ids {
 		agRP, ok := azurearm.ParsePath(id)
@@ -21,12 +27,25 @@ func (h *Handler) validateActionGroupRefs(ids []string) error {
 			return cerrors.Newf(cerrors.InvalidArgument, "actionGroupId %q is not a valid action group resource id", id)
 		}
 
-		if _, ok := h.store.get(agRP.Subscription, agRP.ResourceGroup, typeActionGroup, agRP.ResourceName); !ok {
+		if !h.actionGroupExists(id) {
 			return cerrors.Newf(cerrors.InvalidArgument, "action group %q not found", id)
 		}
 	}
 
 	return nil
+}
+
+// actionGroupExists reports whether agID resolves to a stored actionGroups
+// resource, comparing canonical ARM ids case-insensitively.
+func (h *Handler) actionGroupExists(agID string) bool {
+	for key := range h.store.allOfKind(typeActionGroup) {
+		candidate := azurearm.BuildResourceID(key.subscription, key.resourceGroup, providerName, typeActionGroup, key.name)
+		if strings.EqualFold(candidate, agID) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // activityLogActionGroupIDs extracts properties.actions.actionGroups[].

--- a/server/azure/monitor/referential.go
+++ b/server/azure/monitor/referential.go
@@ -1,0 +1,95 @@
+package monitor
+
+import (
+	"fmt"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+// validateActionGroupRefs rejects a metricAlert create/update whose
+// properties.actions[].actionGroupId does not resolve to a stored actionGroups
+// resource, mirroring real Azure Monitor's rejection of a metric alert rule
+// linked to an action group that doesn't exist (the same reference-validation
+// convention already applied to gcplb/azurelb create/update: 400
+// InvalidArgument, not a silent no-op deferred to breach time).
+func (h *Handler) validateActionGroupRefs(ids []string) error {
+	for _, id := range ids {
+		agRP, ok := azurearm.ParsePath(id)
+		if !ok || canonicalType(agRP.ResourceType) != typeActionGroup || agRP.ResourceName == "" {
+			return cerrors.Newf(cerrors.InvalidArgument, "actionGroupId %q is not a valid action group resource id", id)
+		}
+
+		if _, ok := h.store.get(agRP.Subscription, agRP.ResourceGroup, typeActionGroup, agRP.ResourceName); !ok {
+			return cerrors.Newf(cerrors.InvalidArgument, "action group %q not found", id)
+		}
+	}
+
+	return nil
+}
+
+// activityLogActionGroupIDs extracts properties.actions.actionGroups[].
+// actionGroupId from an activityLogAlert definition — the nested shape real
+// Microsoft.Insights/activityLogAlerts use to link action groups, distinct
+// from a metricAlert's flat properties.actions[].actionGroupId.
+func activityLogActionGroupIDs(props map[string]any) []string {
+	actions, ok := props["actions"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	groups, ok := actions["actionGroups"].([]any)
+	if !ok {
+		return nil
+	}
+
+	ids := make([]string, 0, len(groups))
+
+	for _, g := range groups {
+		item, ok := g.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if id := stringField(item, "actionGroupId"); id != "" {
+			ids = append(ids, id)
+		}
+	}
+
+	return ids
+}
+
+// actionGroupInUse reports what still references the action group with ARM
+// resource id agID — a metric alert or an activity-log alert — across the
+// whole store (not scoped to the action group's own resource group, since a
+// referencing alert can live in a different one). Returns "" when nothing
+// references it, matching the azurelb poolReferencedBy convention: an empty
+// string means "safe to delete".
+func (h *Handler) actionGroupInUse(agID string) string {
+	for key, res := range h.store.allOfKind(typeAlerts) {
+		if idsContain(actionGroupIDs(res.Properties), agID) {
+			return fmt.Sprintf("metric alert %q", key.name)
+		}
+	}
+
+	for key, res := range h.store.allOfKind(typeActivityLog) {
+		if idsContain(activityLogActionGroupIDs(res.Properties), agID) {
+			return fmt.Sprintf("activity log alert %q", key.name)
+		}
+	}
+
+	return ""
+}
+
+// idsContain reports whether target appears in ids, comparing ARM resource ids
+// case-insensitively (real ARM ids are case-insensitive).
+func idsContain(ids []string, target string) bool {
+	for _, id := range ids {
+		if strings.EqualFold(id, target) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/azure/monitor/referential_test.go
+++ b/server/azure/monitor/referential_test.go
@@ -80,6 +80,75 @@ func TestMetricAlertPatchRejectsUnknownActionGroup(t *testing.T) {
 	}
 }
 
+// TestMetricAlertAcceptsCaseInsensitiveActionGroupRef is the regression for the
+// case-sensitivity false-rejection: real ARM resource ids are case-insensitive,
+// and providers/azure/monitor's RegisterActionGroup/fireActionGroups already
+// resolve an actionGroupId case-insensitively at breach time (actiongroups.go).
+// A metricAlert PUT referencing an existing action group with different casing
+// in the resource-group and action-group-name segments must succeed, not be
+// rejected as "not found".
+func TestMetricAlertAcceptsCaseInsensitiveActionGroupRef(t *testing.T) {
+	srv := newInsightsServer(t)
+	ctx := context.Background()
+
+	agClient := srv.actionGroups(t)
+
+	if _, err := agClient.CreateOrUpdate(ctx, "rg-1", "ag1", armmonitor.ActionGroupResource{
+		Location:   to.Ptr("global"),
+		Properties: &armmonitor.ActionGroup{GroupShortName: to.Ptr("ag1"), Enabled: to.Ptr(true)},
+	}, nil); err != nil {
+		t.Fatalf("action group CreateOrUpdate: %v", err)
+	}
+
+	// Same action group, different casing in the resourceGroups and
+	// actionGroups name segments of the ARM id.
+	const differentCaseAgID = "/subscriptions/sub-1/resourceGroups/RG-1/providers/microsoft.insights/actionGroups/AG1"
+
+	rule := metricAlertResource(80)
+	rule.Properties.Actions = []*armmonitor.MetricAlertAction{{ActionGroupID: to.Ptr(differentCaseAgID)}}
+
+	alertClient := srv.metricAlerts(t)
+
+	if _, err := alertClient.CreateOrUpdate(ctx, "rg-1", "cpu-alert", rule, nil); err != nil {
+		t.Fatalf("CreateOrUpdate with differently-cased actionGroupId = %v, want success", err)
+	}
+}
+
+// TestMetricAlertPatchAcceptsCaseInsensitiveActionGroupRef is the PATCH-path
+// counterpart of TestMetricAlertAcceptsCaseInsensitiveActionGroupRef: adding a
+// differently-cased actionGroupId reference via Update (PATCH) must also
+// succeed.
+func TestMetricAlertPatchAcceptsCaseInsensitiveActionGroupRef(t *testing.T) {
+	srv := newInsightsServer(t)
+	ctx := context.Background()
+
+	agClient := srv.actionGroups(t)
+
+	if _, err := agClient.CreateOrUpdate(ctx, "rg-1", "ag1", armmonitor.ActionGroupResource{
+		Location:   to.Ptr("global"),
+		Properties: &armmonitor.ActionGroup{GroupShortName: to.Ptr("ag1"), Enabled: to.Ptr(true)},
+	}, nil); err != nil {
+		t.Fatalf("action group CreateOrUpdate: %v", err)
+	}
+
+	alertClient := srv.metricAlerts(t)
+
+	if _, err := alertClient.CreateOrUpdate(ctx, "rg-1", "cpu-alert", metricAlertResource(80), nil); err != nil {
+		t.Fatalf("CreateOrUpdate: %v", err)
+	}
+
+	const differentCaseAgID = "/subscriptions/sub-1/resourceGroups/RG-1/providers/microsoft.insights/actionGroups/AG1"
+
+	_, err := alertClient.Update(ctx, "rg-1", "cpu-alert", armmonitor.MetricAlertResourcePatch{
+		Properties: &armmonitor.MetricAlertPropertiesPatch{
+			Actions: []*armmonitor.MetricAlertAction{{ActionGroupID: to.Ptr(differentCaseAgID)}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Update with differently-cased actionGroupId = %v, want success", err)
+	}
+}
+
 // TestActionGroupDeleteGuardedByMetricAlert covers the in-use delete guard: an
 // action group referenced by a metric alert's actions[] cannot be deleted
 // until the alert is removed or repointed, matching the azurelb backend-pool

--- a/server/azure/monitor/referential_test.go
+++ b/server/azure/monitor/referential_test.go
@@ -1,0 +1,177 @@
+package monitor_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+)
+
+// respStatus unwraps err as an *azcore.ResponseError and returns its HTTP
+// status code, failing the test if err isn't one (mirrors the azurelb
+// sdk_roundtrip/lb_subresource convention for asserting SDK error responses).
+func respStatus(t *testing.T, err error) int {
+	t.Helper()
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("error %v is not an *azcore.ResponseError", err)
+	}
+
+	return respErr.StatusCode
+}
+
+// TestMetricAlertRejectsUnknownActionGroup covers the referential-integrity
+// gap: a metric alert whose actions[].actionGroupId does not resolve to a
+// stored action group must be rejected (400), not silently stored to fail
+// resolving only later, at breach time.
+func TestMetricAlertRejectsUnknownActionGroup(t *testing.T) {
+	client := newInsightsServer(t).metricAlerts(t)
+	ctx := context.Background()
+
+	const missingAgID = "/subscriptions/sub-1/resourceGroups/rg-1/providers/microsoft.insights/actionGroups/does-not-exist"
+
+	rule := metricAlertResource(80)
+	rule.Properties.Actions = []*armmonitor.MetricAlertAction{{ActionGroupID: to.Ptr(missingAgID)}}
+
+	_, err := client.CreateOrUpdate(ctx, "rg-1", "cpu-alert", rule, nil)
+	if err == nil {
+		t.Fatal("CreateOrUpdate with unknown actionGroupId succeeded, want an error")
+	}
+
+	if status := respStatus(t, err); status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", status)
+	}
+
+	// The rejected alert must not be persisted.
+	if _, getErr := client.Get(ctx, "rg-1", "cpu-alert", nil); getErr == nil {
+		t.Fatal("Get succeeded for a metric alert that failed validation, want NotFound")
+	}
+}
+
+// TestMetricAlertPatchRejectsUnknownActionGroup covers the same referential
+// check on PATCH (Update): re-pointing an already-valid alert at a
+// nonexistent action group must be rejected too, not only on first create.
+func TestMetricAlertPatchRejectsUnknownActionGroup(t *testing.T) {
+	client := newInsightsServer(t).metricAlerts(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateOrUpdate(ctx, "rg-1", "cpu-alert", metricAlertResource(80), nil); err != nil {
+		t.Fatalf("CreateOrUpdate: %v", err)
+	}
+
+	const missingAgID = "/subscriptions/sub-1/resourceGroups/rg-1/providers/microsoft.insights/actionGroups/does-not-exist"
+
+	_, err := client.Update(ctx, "rg-1", "cpu-alert", armmonitor.MetricAlertResourcePatch{
+		Properties: &armmonitor.MetricAlertPropertiesPatch{
+			Actions: []*armmonitor.MetricAlertAction{{ActionGroupID: to.Ptr(missingAgID)}},
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("Update with unknown actionGroupId succeeded, want an error")
+	}
+
+	if status := respStatus(t, err); status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", status)
+	}
+}
+
+// TestActionGroupDeleteGuardedByMetricAlert covers the in-use delete guard: an
+// action group referenced by a metric alert's actions[] cannot be deleted
+// until the alert is removed or repointed, matching the azurelb backend-pool
+// in-use guard convention (409, not a dangling reference).
+func TestActionGroupDeleteGuardedByMetricAlert(t *testing.T) {
+	srv := newInsightsServer(t)
+	ctx := context.Background()
+
+	agClient := srv.actionGroups(t)
+
+	if _, err := agClient.CreateOrUpdate(ctx, "rg-1", "ag1", armmonitor.ActionGroupResource{
+		Location:   to.Ptr("global"),
+		Properties: &armmonitor.ActionGroup{GroupShortName: to.Ptr("ag1"), Enabled: to.Ptr(true)},
+	}, nil); err != nil {
+		t.Fatalf("action group CreateOrUpdate: %v", err)
+	}
+
+	const agID = "/subscriptions/sub-1/resourceGroups/rg-1/providers/microsoft.insights/actionGroups/ag1"
+
+	alertClient := srv.metricAlerts(t)
+
+	rule := metricAlertResource(80)
+	rule.Properties.Actions = []*armmonitor.MetricAlertAction{{ActionGroupID: to.Ptr(agID)}}
+
+	if _, err := alertClient.CreateOrUpdate(ctx, "rg-1", "cpu-alert", rule, nil); err != nil {
+		t.Fatalf("metric alert CreateOrUpdate: %v", err)
+	}
+
+	if _, err := agClient.Delete(ctx, "rg-1", "ag1", nil); err == nil {
+		t.Fatal("Delete of an in-use action group succeeded, want an error")
+	} else if status := respStatus(t, err); status != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", status)
+	}
+
+	if _, err := alertClient.Delete(ctx, "rg-1", "cpu-alert", nil); err != nil {
+		t.Fatalf("metric alert Delete: %v", err)
+	}
+
+	if _, err := agClient.Delete(ctx, "rg-1", "ag1", nil); err != nil {
+		t.Fatalf("action group Delete after releasing reference: %v", err)
+	}
+}
+
+// TestActionGroupDeleteGuardedByActivityLogAlert covers the same in-use guard
+// for the other reference shape: an activityLogAlert's nested
+// properties.actions.actionGroups[].actionGroupId.
+func TestActionGroupDeleteGuardedByActivityLogAlert(t *testing.T) {
+	srv := newInsightsServer(t)
+	ctx := context.Background()
+
+	agClient := srv.actionGroups(t)
+
+	if _, err := agClient.CreateOrUpdate(ctx, "rg-1", "ag1", armmonitor.ActionGroupResource{
+		Location:   to.Ptr("global"),
+		Properties: &armmonitor.ActionGroup{GroupShortName: to.Ptr("ag1"), Enabled: to.Ptr(true)},
+	}, nil); err != nil {
+		t.Fatalf("action group CreateOrUpdate: %v", err)
+	}
+
+	const agID = "/subscriptions/sub-1/resourceGroups/rg-1/providers/microsoft.insights/actionGroups/ag1"
+
+	alaClient := srv.activityLogAlerts(t)
+
+	if _, err := alaClient.CreateOrUpdate(ctx, "rg-1", "ala1", armmonitor.ActivityLogAlertResource{
+		Location: to.Ptr("global"),
+		Properties: &armmonitor.AlertRuleProperties{
+			Enabled: to.Ptr(true),
+			Scopes:  []*string{to.Ptr("/subscriptions/sub-1")},
+			Condition: &armmonitor.AlertRuleAllOfCondition{
+				AllOf: []*armmonitor.AlertRuleAnyOfOrLeafCondition{{
+					Field: to.Ptr("category"), Equals: to.Ptr("Administrative"),
+				}},
+			},
+			Actions: &armmonitor.ActionList{
+				ActionGroups: []*armmonitor.ActivityLogAlertActionGroup{{ActionGroupID: to.Ptr(agID)}},
+			},
+		},
+	}, nil); err != nil {
+		t.Fatalf("activity log alert CreateOrUpdate: %v", err)
+	}
+
+	if _, err := agClient.Delete(ctx, "rg-1", "ag1", nil); err == nil {
+		t.Fatal("Delete of an in-use action group succeeded, want an error")
+	} else if status := respStatus(t, err); status != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", status)
+	}
+
+	if _, err := alaClient.Delete(ctx, "rg-1", "ala1", nil); err != nil {
+		t.Fatalf("activity log alert Delete: %v", err)
+	}
+
+	if _, err := agClient.Delete(ctx, "rg-1", "ag1", nil); err != nil {
+		t.Fatalf("action group Delete after releasing reference: %v", err)
+	}
+}

--- a/server/azure/monitor/resources_test.go
+++ b/server/azure/monitor/resources_test.go
@@ -183,6 +183,13 @@ func TestMetricAlertActionsWireActionGroup(t *testing.T) {
 
 	const actionGroupID = "/subscriptions/sub-1/resourceGroups/rg-1/providers/microsoft.insights/actionGroups/ag1"
 
+	const agURL = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Insights/actionGroups/ag1" + apiVer
+
+	agBody := `{"location":"global","properties":{"groupShortName":"ag1","enabled":true}}`
+	if code, _ := doJSON(t, ts, http.MethodPut, agURL, agBody); code != http.StatusCreated {
+		t.Fatalf("PUT actionGroup status = %d, want 201", code)
+	}
+
 	const url = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Insights/metricAlerts/cpu-notify" + apiVer
 
 	body := `{

--- a/server/azure/monitor/store.go
+++ b/server/azure/monitor/store.go
@@ -74,6 +74,27 @@ func (s *resourceStore) delete(subscription, resourceGroup, kind, name string) b
 	return true
 }
 
+// allOfKind returns every stored resource of one kind across ALL subscriptions
+// and resource groups, keyed by its full resourceKey. Referential-integrity
+// checks (e.g. is an action group still referenced by any metricAlert or
+// activityLogAlert) must consider the whole store, not one scope: a metric
+// alert can name an action group id from a different resource group than its
+// own, exactly like the actual scope segments in an ARM resource id.
+func (s *resourceStore) allOfKind(kind string) map[resourceKey]*armResource {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make(map[resourceKey]*armResource)
+
+	for k, v := range s.m {
+		if k.kind == kind {
+			out[k] = v
+		}
+	}
+
+	return out
+}
+
 // all returns the stored resources of one kind scoped to one subscription,
 // keyed by name. When resourceGroup is non-empty the result is further scoped
 // to that resource group (a "list by resource group" request); an empty


### PR DESCRIPTION
## Gap investigated

Azure Monitor's ARM lifecycle (`server/azure/monitor`) already covers metricAlerts, actionGroups, activityLogAlerts and autoscaleSettings CRUD, PUT/PATCH nil-mask merge, idempotent DELETE, resource-group scoped list/store isolation, and end-to-end action-group firing (email/webhook/SMS receivers, real webhook POST, alarm evaluation via the shared driver). What was missing: referential integrity between metricAlerts/activityLogAlerts and the action groups they name.

- `properties.actions[].actionGroupId` on a metricAlert was stored and wired into `AlarmActions` with no check the id resolved to anything — a typo'd or deleted action group silently produced a rule that would never deliver, discoverable only at breach time (`fireActionGroups` already no-ops on an unresolved id).
- `actionGroups` DELETE unregistered the group's receivers with no check whether a metricAlert or activityLogAlert still referenced it, leaving a dangling reference.

## What this PR adds

- `validateActionGroupRefs`: metricAlerts PUT and PATCH now reject (400 `InvalidParameter`) when `actions[].actionGroupId` doesn't resolve to a stored `actionGroups` resource, checked before the resource is persisted or wired into the alarm engine.
- `actionGroupInUse`: `actionGroups` DELETE now rejects (409 `PreconditionFailed`) when the group is still referenced by a metricAlert (`actions[].actionGroupId`) or an activityLogAlert (`actions.actionGroups[].actionGroupId`), scanning across all resource groups/subscriptions since a reference can cross scope — mirrors the azurelb backend-pool in-use guard and gcplb create/update reference-validation conventions already in the codebase.
- `resourceStore.allOfKind` — a whole-store scan by resource kind, backing the in-use check.

Covered with wire-level and real armmonitor SDK tests: rejection on create and on patch, delete-guard for both metricAlert and activityLogAlert references (409 then a successful delete once the reference is released), plus updated the pre-existing `TestMetricAlertActionsWireActionGroup` to provision its referenced action group first (it previously relied on a dangling reference real Azure would also reject).

## Deferred

- Actual alert *evaluation*/firing semantics, autoscale execution, diagnostic-setting routing, and Log Analytics KQL are unchanged (already covered or explicitly out of scope).
- PATCH tag semantics are left as merge (not replace): armmonitor's `Update` is a generic properties+tags merge-patch endpoint, distinct from the Microsoft.Network family's dedicated `UpdateTags` operation that replaces wholesale — changing this would contradict the existing, correct `TestSDKMetricAlertPatchMergesAndPreserves` regression.