### PR TITLE
feat(eventbridge): dead-letter queue delivery on target invocation failure

### DIFF
--- a/providers/aws/eventbridge/dead_letter_test.go
+++ b/providers/aws/eventbridge/dead_letter_test.go
@@ -1,0 +1,244 @@
+// dead_letter_test.go verifies that a target whose dispatch fails is routed to
+// its configured DeadLetterConfig queue, matching real EventBridge: a rule
+// target that goes stale (its queue is deleted, or its function starts
+// erroring) does not silently vanish when a DLQ is configured.
+package eventbridge_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	ebprovider "github.com/stackshy/cloudemu/v2/providers/aws/eventbridge"
+	lambdaprovider "github.com/stackshy/cloudemu/v2/providers/aws/lambda"
+	sqsprovider "github.com/stackshy/cloudemu/v2/providers/aws/sqs"
+	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+	lambdadriver "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+var errHandlerFailed = errors.New("handler failed")
+
+func deadLetterConfigJSON(t *testing.T, arn string) string {
+	t.Helper()
+
+	b, err := json.Marshal(map[string]string{"Arn": arn})
+	if err != nil {
+		t.Fatalf("marshal DeadLetterConfig: %v", err)
+	}
+
+	return string(b)
+}
+
+// TestDeadLetterOnStaleSQSTarget: a rule target ARN that no longer resolves to
+// a live queue (deleted after PutTargets) fails dispatch; the original event is
+// then routed to the target's configured DLQ.
+func TestDeadLetterOnStaleSQSTarget(t *testing.T) {
+	ctx := context.Background()
+	opts := config.NewOptions()
+
+	sqs := sqsprovider.New(opts)
+	eb := ebprovider.New(opts)
+	eb.SetSQSDeliverer(sqs)
+
+	target, err := sqs.CreateQueue(ctx, mqdriver.QueueConfig{Name: "eb-target"})
+	if err != nil {
+		t.Fatalf("CreateQueue(target): %v", err)
+	}
+
+	dlq, err := sqs.CreateQueue(ctx, mqdriver.QueueConfig{Name: "eb-dlq"})
+	if err != nil {
+		t.Fatalf("CreateQueue(dlq): %v", err)
+	}
+
+	if _, err := eb.PutRule(ctx, &ebdriver.RuleConfig{
+		Name: "r", EventPattern: `{"source":["myapp"]}`,
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if err := eb.PutTargets(ctx, "", "r", []ebdriver.Target{
+		{ID: "1", ARN: target.ARN, DeadLetterConfig: deadLetterConfigJSON(t, dlq.ARN)},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	// The target queue goes stale after PutTargets — a real-world drift EventBridge
+	// tolerates by DLQ'ing rather than dropping.
+	if err := sqs.DeleteQueue(ctx, target.URL); err != nil {
+		t.Fatalf("DeleteQueue: %v", err)
+	}
+
+	if _, err := eb.PutEvents(ctx, []ebdriver.Event{
+		{Source: "myapp", DetailType: "order.created", Detail: `{"orderId":"42"}`},
+	}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	msgs, err := sqs.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{QueueURL: dlq.URL, MaxMessages: 10})
+	if err != nil {
+		t.Fatalf("ReceiveMessages(dlq): %v", err)
+	}
+
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message on the DLQ, got %d", len(msgs))
+	}
+
+	var env map[string]any
+	if err := json.Unmarshal([]byte(msgs[0].Body), &env); err != nil {
+		t.Fatalf("DLQ body not JSON: %v (%s)", err, msgs[0].Body)
+	}
+
+	if env["source"] != "myapp" || env["detail-type"] != "order.created" {
+		t.Fatalf("unexpected DLQ envelope: %+v", env)
+	}
+}
+
+// TestNoDeadLetterConfigDropsFailedDelivery: without a DeadLetterConfig, a
+// failed dispatch is dropped and PutEvents still succeeds — EventBridge
+// publishing is fire-and-forget from the publisher's point of view.
+func TestNoDeadLetterConfigDropsFailedDelivery(t *testing.T) {
+	ctx := context.Background()
+	opts := config.NewOptions()
+
+	sqs := sqsprovider.New(opts)
+	eb := ebprovider.New(opts)
+	eb.SetSQSDeliverer(sqs)
+
+	target, err := sqs.CreateQueue(ctx, mqdriver.QueueConfig{Name: "eb-target"})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	if _, err := eb.PutRule(ctx, &ebdriver.RuleConfig{
+		Name: "r", EventPattern: `{"source":["myapp"]}`,
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if err := eb.PutTargets(ctx, "", "r", []ebdriver.Target{{ID: "1", ARN: target.ARN}}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	if err := sqs.DeleteQueue(ctx, target.URL); err != nil {
+		t.Fatalf("DeleteQueue: %v", err)
+	}
+
+	result, err := eb.PutEvents(ctx, []ebdriver.Event{
+		{Source: "myapp", DetailType: "order.created", Detail: `{"orderId":"42"}`},
+	})
+	if err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	if result.SuccessCount != 1 || result.FailCount != 0 {
+		t.Fatalf("PutEvents result = %+v, want SuccessCount=1 FailCount=0 (delivery failure never fails the publish)", result)
+	}
+}
+
+// TestDeadLetterOnFailingLambdaTarget: a Lambda target whose handler raises is
+// a genuine EventBridge invocation failure, distinct from a merely-unwired
+// target — it must also be DLQ'd.
+func TestDeadLetterOnFailingLambdaTarget(t *testing.T) {
+	ctx := context.Background()
+	opts := config.NewOptions()
+
+	sqs := sqsprovider.New(opts)
+	lam := lambdaprovider.New(opts)
+	eb := ebprovider.New(opts)
+	eb.SetSQSDeliverer(sqs)
+	eb.SetLambdaInvoker(lam)
+
+	fn, err := lam.CreateFunction(ctx, lambdadriver.FunctionConfig{
+		Name: "eb-target-fn", Runtime: "go1.x", Handler: "main", Memory: 128, Timeout: 30,
+	})
+	if err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	lam.RegisterHandler("eb-target-fn", func(_ context.Context, _ []byte) ([]byte, error) {
+		return nil, errHandlerFailed
+	})
+
+	dlq, err := sqs.CreateQueue(ctx, mqdriver.QueueConfig{Name: "eb-dlq"})
+	if err != nil {
+		t.Fatalf("CreateQueue(dlq): %v", err)
+	}
+
+	if _, err := eb.PutRule(ctx, &ebdriver.RuleConfig{
+		Name: "r", EventPattern: `{"source":["myapp"]}`,
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if err := eb.PutTargets(ctx, "", "r", []ebdriver.Target{
+		{ID: "1", ARN: fn.ARN, DeadLetterConfig: deadLetterConfigJSON(t, dlq.ARN)},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	if _, err := eb.PutEvents(ctx, []ebdriver.Event{
+		{Source: "myapp", DetailType: "order.created", Detail: `{"orderId":"42"}`},
+	}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	msgs, err := sqs.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{QueueURL: dlq.URL, MaxMessages: 10})
+	if err != nil {
+		t.Fatalf("ReceiveMessages(dlq): %v", err)
+	}
+
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message on the DLQ, got %d", len(msgs))
+	}
+}
+
+// TestSuccessfulDeliveryLeavesDLQEmpty guards against a DLQ getting a copy of
+// every event regardless of outcome.
+func TestSuccessfulDeliveryLeavesDLQEmpty(t *testing.T) {
+	ctx := context.Background()
+	opts := config.NewOptions()
+
+	sqs := sqsprovider.New(opts)
+	eb := ebprovider.New(opts)
+	eb.SetSQSDeliverer(sqs)
+
+	target, err := sqs.CreateQueue(ctx, mqdriver.QueueConfig{Name: "eb-target"})
+	if err != nil {
+		t.Fatalf("CreateQueue(target): %v", err)
+	}
+
+	dlq, err := sqs.CreateQueue(ctx, mqdriver.QueueConfig{Name: "eb-dlq"})
+	if err != nil {
+		t.Fatalf("CreateQueue(dlq): %v", err)
+	}
+
+	if _, err := eb.PutRule(ctx, &ebdriver.RuleConfig{
+		Name: "r", EventPattern: `{"source":["myapp"]}`,
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if err := eb.PutTargets(ctx, "", "r", []ebdriver.Target{
+		{ID: "1", ARN: target.ARN, DeadLetterConfig: deadLetterConfigJSON(t, dlq.ARN)},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	if _, err := eb.PutEvents(ctx, []ebdriver.Event{
+		{Source: "myapp", DetailType: "order.created", Detail: `{"orderId":"42"}`},
+	}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	msgs, err := sqs.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{QueueURL: dlq.URL, MaxMessages: 10})
+	if err != nil {
+		t.Fatalf("ReceiveMessages(dlq): %v", err)
+	}
+
+	if len(msgs) != 0 {
+		t.Fatalf("expected the DLQ to stay empty on successful delivery, got %d messages", len(msgs))
+	}
+}

--- a/providers/aws/eventbridge/dead_letter_test.go
+++ b/providers/aws/eventbridge/dead_letter_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stackshy/cloudemu/v2/config"
+	cwprovider "github.com/stackshy/cloudemu/v2/providers/aws/cloudwatch"
 	ebprovider "github.com/stackshy/cloudemu/v2/providers/aws/eventbridge"
 	lambdaprovider "github.com/stackshy/cloudemu/v2/providers/aws/lambda"
 	sqsprovider "github.com/stackshy/cloudemu/v2/providers/aws/sqs"
@@ -240,5 +241,123 @@ func TestSuccessfulDeliveryLeavesDLQEmpty(t *testing.T) {
 
 	if len(msgs) != 0 {
 		t.Fatalf("expected the DLQ to stay empty on successful delivery, got %d messages", len(msgs))
+	}
+}
+
+// TestDeadLetterOnStaleLambdaTarget: a Lambda target whose function is deleted
+// after PutTargets (distinct from a raising handler) is also a genuine
+// dispatch failure — InvokeExternal alone can't see it, since it treats an
+// unknown function as a no-op for its other callers, so dispatchTarget must
+// check FunctionExists itself.
+func TestDeadLetterOnStaleLambdaTarget(t *testing.T) {
+	ctx := context.Background()
+	opts := config.NewOptions()
+
+	sqs := sqsprovider.New(opts)
+	lam := lambdaprovider.New(opts)
+	eb := ebprovider.New(opts)
+	eb.SetSQSDeliverer(sqs)
+	eb.SetLambdaInvoker(lam)
+
+	fn, err := lam.CreateFunction(ctx, lambdadriver.FunctionConfig{
+		Name: "eb-stale-fn", Runtime: "go1.x", Handler: "main", Memory: 128, Timeout: 30,
+	})
+	if err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	dlq, err := sqs.CreateQueue(ctx, mqdriver.QueueConfig{Name: "eb-dlq"})
+	if err != nil {
+		t.Fatalf("CreateQueue(dlq): %v", err)
+	}
+
+	if _, err := eb.PutRule(ctx, &ebdriver.RuleConfig{
+		Name: "r", EventPattern: `{"source":["myapp"]}`,
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if err := eb.PutTargets(ctx, "", "r", []ebdriver.Target{
+		{ID: "1", ARN: fn.ARN, DeadLetterConfig: deadLetterConfigJSON(t, dlq.ARN)},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	// The target function goes stale after PutTargets.
+	if err := lam.DeleteFunction(ctx, "eb-stale-fn"); err != nil {
+		t.Fatalf("DeleteFunction: %v", err)
+	}
+
+	if _, err := eb.PutEvents(ctx, []ebdriver.Event{
+		{Source: "myapp", DetailType: "order.created", Detail: `{"orderId":"42"}`},
+	}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	msgs, err := sqs.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{QueueURL: dlq.URL, MaxMessages: 10})
+	if err != nil {
+		t.Fatalf("ReceiveMessages(dlq): %v", err)
+	}
+
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message on the DLQ for the deleted Lambda target, got %d", len(msgs))
+	}
+
+	var env map[string]any
+	if err := json.Unmarshal([]byte(msgs[0].Body), &env); err != nil {
+		t.Fatalf("DLQ body not JSON: %v (%s)", err, msgs[0].Body)
+	}
+
+	if env["source"] != "myapp" {
+		t.Fatalf("unexpected DLQ envelope: %+v", env)
+	}
+}
+
+// TestUnwiredDeliverersDoNotFalselyDeadLetter pins the deliberate distinction
+// between "backend never wired" (an emulator-coverage gap, not a real
+// EventBridge failure) and a genuine dispatch failure: with no SQS/Lambda
+// deliverer configured at all, dispatch must report success — no
+// FailedInvocations metric, and (implicitly, since there is nowhere to
+// deliver a DLQ message without a wired SQS deliverer) no DLQ write. A future
+// refactor that makes dispatchTarget/dispatchLambda treat "unwired" the same
+// as "target gone" would regress every emulator caller that hasn't wired every
+// cross-service backend.
+func TestUnwiredDeliverersDoNotFalselyDeadLetter(t *testing.T) {
+	ctx := context.Background()
+	opts := config.NewOptions()
+
+	cw := cwprovider.New(opts)
+	eb := ebprovider.New(opts)
+	eb.SetMonitoring(cw)
+	// Deliberately no SetSQSDeliverer / SetLambdaInvoker.
+
+	if _, err := eb.PutRule(ctx, &ebdriver.RuleConfig{
+		Name: "r", EventPattern: `{"source":["myapp"]}`,
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if err := eb.PutTargets(ctx, "", "r", []ebdriver.Target{
+		{ID: "1", ARN: "arn:aws:sqs:us-east-1:000000000000:unwired-queue"},
+		{ID: "2", ARN: "arn:aws:lambda:us-east-1:000000000000:function:unwired-fn"},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	if _, err := eb.PutEvents(ctx, []ebdriver.Event{
+		{Source: "myapp", DetailType: "order.created", Detail: `{"orderId":"42"}`},
+	}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	metrics, err := cw.ListMetrics(ctx, "AWS/Events")
+	if err != nil {
+		t.Fatalf("ListMetrics: %v", err)
+	}
+
+	for _, name := range metrics {
+		if name == "FailedInvocations" || name == "InvocationsSentToDlq" {
+			t.Fatalf("unwired deliverer falsely emitted %q — should report dispatch success, not a failure", name)
+		}
 	}
 }

--- a/providers/aws/eventbridge/eventbridge.go
+++ b/providers/aws/eventbridge/eventbridge.go
@@ -529,6 +529,9 @@ func (m *Mock) PutEvents(ctx context.Context, events []driver.Event) (*driver.Pu
 // replaced by the target's Input (constant), InputPath (selected subtree), or
 // InputTransformer (templated) when one is configured — matching how real
 // EventBridge shapes each target's payload independently.
+//
+// A target whose dispatch fails is routed to its configured DeadLetterConfig
+// queue (see deliverToTarget), matching real EventBridge's DLQ behavior.
 func (m *Mock) deliverToTargets(ctx context.Context, matched []driver.Rule, event *driver.Event) {
 	// Decouple delivery from the caller's cancellation/deadline (real EventBridge
 	// delivery is asynchronous) while carrying forward the re-entrant delivery
@@ -538,41 +541,107 @@ func (m *Mock) deliverToTargets(ctx context.Context, matched []driver.Rule, even
 
 	envelope := m.eventEnvelope(event)
 
+	busName := event.EventBus
+	if busName == "" {
+		busName = defaultBusName
+	}
+
 	for i := range matched {
 		reserved := m.reservedVars(&matched[i], event, envelope)
 
-		for _, t := range matched[i].Targets {
+		for j := range matched[i].Targets {
+			t := &matched[i].Targets[j]
 			if t.ARN == "" {
 				continue
 			}
 
-			m.dispatchTarget(dctx, t.ARN, targetBody(&t, envelope, reserved))
+			m.deliverToTarget(dctx, &matched[i], t, busName, envelope, reserved)
 		}
 	}
 }
 
+// deliverToTarget dispatches one target and, on failure, routes the original
+// event to the target's dead-letter queue when one is configured.
+func (m *Mock) deliverToTarget(
+	ctx context.Context, rule *driver.Rule, t *driver.Target, busName string, envelope []byte, reserved map[string]json.RawMessage,
+) {
+	if m.dispatchTarget(ctx, t.ARN, targetBody(t, envelope, reserved)) {
+		return
+	}
+
+	dims := map[string]string{"RuleName": rule.Name, "EventBusName": busName}
+	m.emitMetric("FailedInvocations", 1, dims)
+
+	dlqARN := deadLetterARN(t.DeadLetterConfig)
+	if dlqARN == "" || m.sqs == nil {
+		return
+	}
+
+	// The DLQ message body is the original event that failed to be delivered
+	// (matching real EventBridge, which puts the source event — not the
+	// target-specific transformed payload — on the dead-letter queue).
+	if m.sqs.DeliverExternal(ctx, dlqARN, string(envelope)) == nil {
+		m.emitMetric("InvocationsSentToDlq", 1, dims)
+	}
+}
+
 // dispatchTarget routes a rendered payload to a single target by the service in
-// its ARN. Unknown/unsupported target services are silently ignored (matching
-// EventBridge accepting the target but this emulator not modeling that sink).
-func (m *Mock) dispatchTarget(ctx context.Context, arn, body string) {
+// its ARN, reporting whether dispatch succeeded. Unknown/unsupported target
+// services and a service whose deliverer was never wired report success
+// (matching EventBridge accepting the target but this emulator not modeling
+// that sink — an emulator limitation, not a real delivery failure eligible for
+// the target's DLQ).
+func (m *Mock) dispatchTarget(ctx context.Context, arn, body string) bool {
 	switch {
 	case strings.Contains(arn, ":sqs:"):
-		if m.sqs != nil {
-			_ = m.sqs.DeliverExternal(ctx, arn, body)
+		if m.sqs == nil {
+			return true
 		}
+
+		return m.sqs.DeliverExternal(ctx, arn, body) == nil
 	case strings.Contains(arn, ":lambda:"):
-		if m.lambda != nil {
-			_ = m.lambda.InvokeExternal(ctx, arn, []byte(body))
+		if m.lambda == nil {
+			return true
 		}
+
+		return m.lambda.InvokeExternal(ctx, arn, []byte(body)) == nil
 	case strings.Contains(arn, ":sns:"):
-		if m.sns != nil {
-			_ = m.sns.PublishExternal(ctx, arn, body)
+		if m.sns == nil {
+			return true
 		}
+
+		return m.sns.PublishExternal(ctx, arn, body) == nil
 	case strings.Contains(arn, ":states:"):
-		if m.sfn != nil {
-			_ = m.sfn.StartExternal(ctx, arn, body)
+		if m.sfn == nil {
+			return true
 		}
+
+		return m.sfn.StartExternal(ctx, arn, body) == nil
+	default:
+		return true
 	}
+}
+
+// deadLetterConfigJSON is the raw shape of a Target's DeadLetterConfig JSON
+// block (`{"Arn": "..."}`), matching the EventBridge PutTargets request/response
+// shape.
+type deadLetterConfigJSON struct {
+	Arn string `json:"Arn"`
+}
+
+// deadLetterARN extracts the DLQ ARN from a target's raw DeadLetterConfig JSON,
+// returning "" when the target has none configured or the JSON is malformed.
+func deadLetterARN(raw string) string {
+	if raw == "" {
+		return ""
+	}
+
+	var cfg deadLetterConfigJSON
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		return ""
+	}
+
+	return cfg.Arn
 }
 
 // reservedVars builds the predefined <aws.events.*> transformer variables for a

--- a/providers/aws/eventbridge/eventbridge.go
+++ b/providers/aws/eventbridge/eventbridge.go
@@ -55,8 +55,15 @@ type SQSDeliverer interface {
 // LambdaInvoker asynchronously invokes a Lambda function target by ARN with the
 // event envelope. The Lambda mock satisfies this, enabling EventBridge -> Lambda
 // (ASYNC) delivery.
+//
+// FunctionExists is consulted separately from InvokeExternal because
+// InvokeExternal treats an unknown function as a no-op success for its other
+// callers (S3 notifications, DynamoDB Streams, SQS event-source mappings), so
+// it cannot itself distinguish "target deleted" (a real EventBridge dispatch
+// failure, eligible for the target's DLQ) from "handler ran fine".
 type LambdaInvoker interface {
 	InvokeExternal(ctx context.Context, functionARN string, payload []byte) error
+	FunctionExists(ctx context.Context, functionARN string) bool
 }
 
 // SNSPublisher publishes the event envelope to an SNS topic target by ARN. The
@@ -600,11 +607,7 @@ func (m *Mock) dispatchTarget(ctx context.Context, arn, body string) bool {
 
 		return m.sqs.DeliverExternal(ctx, arn, body) == nil
 	case strings.Contains(arn, ":lambda:"):
-		if m.lambda == nil {
-			return true
-		}
-
-		return m.lambda.InvokeExternal(ctx, arn, []byte(body)) == nil
+		return m.dispatchLambda(ctx, arn, body)
 	case strings.Contains(arn, ":sns:"):
 		if m.sns == nil {
 			return true
@@ -620,6 +623,26 @@ func (m *Mock) dispatchTarget(ctx context.Context, arn, body string) bool {
 	default:
 		return true
 	}
+}
+
+// dispatchLambda dispatches a Lambda target, reporting success/failure. Unlike
+// the other target services, a stale Lambda target (its function deleted after
+// PutTargets) is checked explicitly with FunctionExists before invoking: a
+// nil m.lambda (backend not wired) reports success — an emulator-coverage
+// limitation, not a real failure — but a wired backend whose target function
+// is gone is a genuine dispatch failure, eligible for the target's DLQ, that
+// InvokeExternal's own no-op-for-unknown-function contract cannot surface
+// (that contract is deliberate for InvokeExternal's other callers).
+func (m *Mock) dispatchLambda(ctx context.Context, arn, body string) bool {
+	if m.lambda == nil {
+		return true
+	}
+
+	if !m.lambda.FunctionExists(ctx, arn) {
+		return false
+	}
+
+	return m.lambda.InvokeExternal(ctx, arn, []byte(body)) == nil
 }
 
 // deadLetterConfigJSON is the raw shape of a Target's DeadLetterConfig JSON

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -583,6 +583,18 @@ func (m *Mock) InvokeExternal(ctx context.Context, functionARN string, payload [
 	return nil
 }
 
+// FunctionExists reports whether functionARN resolves to a live function. It
+// lets a cross-service caller (EventBridge's DLQ routing) distinguish a target
+// that is genuinely gone from one InvokeExternal merely no-ops for by design —
+// InvokeExternal itself must keep silently no-op'ing an unknown function for
+// its other callers (S3 notifications, DynamoDB Streams, SQS event-source
+// mappings), which rely on a stale target never failing them.
+func (m *Mock) FunctionExists(_ context.Context, functionARN string) bool {
+	_, ok := m.funcs.Get(functionNameFromARN(functionARN))
+
+	return ok
+}
+
 // functionNameFromARN extracts the function name from a Lambda ARN
 // (arn:aws:lambda:region:account:function:name[:qualifier]); a bare name is
 // returned unchanged.

--- a/server/aws/eventbridge/dead_letter_sdk_test.go
+++ b/server/aws/eventbridge/dead_letter_sdk_test.go
@@ -188,3 +188,70 @@ func TestSDKEventBridgeDeadLetterOnFailingLambdaTarget(t *testing.T) {
 
 	pollForMessage(t, c.sqs, dlqURL)
 }
+
+// TestSDKEventBridgeDeadLetterOnStaleLambdaTarget verifies a Lambda target
+// whose function is DELETED after PutTargets (not merely a raising handler)
+// still reaches the DLQ. Lambda's InvokeExternal treats an unknown function as
+// a no-op success for its OTHER callers (S3 notifications, DynamoDB Streams,
+// SQS event-source mappings), so EventBridge's dispatch must detect the
+// missing target itself rather than relying on InvokeExternal's error.
+func TestSDKEventBridgeDeadLetterOnStaleLambdaTarget(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	c := newDLQClients(t, cloud)
+	ctx := context.Background()
+
+	fnOut, err := c.lam.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String("eb-stale-fn"),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("stub")},
+	})
+	if err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	dlqURL, dlqARN := dlqQueue(t, c.sqs, "eb-dlq")
+
+	if _, err := c.eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventPattern: aws.String(`{"source":["myapp"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := c.eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule: aws.String("r"),
+		Targets: []ebtypes.Target{{
+			Id:               aws.String("1"),
+			Arn:              fnOut.FunctionArn,
+			DeadLetterConfig: &ebtypes.DeadLetterConfig{Arn: aws.String(dlqARN)},
+		}},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	// The target function goes stale after PutTargets.
+	if _, err := c.lam.DeleteFunction(ctx, &awslambda.DeleteFunctionInput{
+		FunctionName: aws.String("eb-stale-fn"),
+	}); err != nil {
+		t.Fatalf("DeleteFunction: %v", err)
+	}
+
+	if _, err := c.eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("myapp"), DetailType: aws.String("t"), Detail: aws.String(`{"orderId":"42"}`)},
+	}}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	body := pollForMessage(t, c.sqs, dlqURL)
+
+	var env map[string]any
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("DLQ body not JSON: %v (%s)", err, body)
+	}
+
+	if env["source"] != "myapp" {
+		t.Fatalf("unexpected DLQ envelope: %+v", env)
+	}
+}

--- a/server/aws/eventbridge/dead_letter_sdk_test.go
+++ b/server/aws/eventbridge/dead_letter_sdk_test.go
@@ -1,0 +1,190 @@
+// dead_letter_sdk_test.go — real aws-sdk-go-v2 end-to-end test verifying that a
+// target's configured DeadLetterConfig receives the original event when
+// dispatch to the target itself fails (a deleted queue behind a stale target
+// ARN, or a Lambda handler that raises). Real EventBridge routes a failed
+// invocation to the target's DLQ rather than silently dropping it.
+package eventbridge_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsprovider "github.com/stackshy/cloudemu/v2/providers/aws"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+const dlqPollTimeout = 2 * time.Second
+
+var errSDKHandlerFailed = errors.New("handler failed")
+
+// dlqClients wires one wire server serving EventBridge, SQS, and Lambda from a
+// single cloud (so cross-service DLQ delivery is exercised for real).
+type dlqClients struct {
+	eb  *awseb.Client
+	sqs *awssqs.Client
+	lam *awslambda.Client
+}
+
+func newDLQClients(t *testing.T, cloud *awsprovider.Provider) dlqClients {
+	t.Helper()
+
+	srv := awsserver.New(awsserver.Drivers{
+		EventBridge: cloud.EventBridge,
+		SQS:         cloud.SQS,
+		Lambda:      cloud.Lambda,
+		CloudWatch:  cloud.CloudWatch,
+	})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return dlqClients{
+		eb:  awseb.NewFromConfig(cfg, func(o *awseb.Options) { o.BaseEndpoint = aws.String(ts.URL) }),
+		sqs: awssqs.NewFromConfig(cfg, func(o *awssqs.Options) { o.BaseEndpoint = aws.String(ts.URL) }),
+		lam: awslambda.NewFromConfig(cfg, func(o *awslambda.Options) { o.BaseEndpoint = aws.String(ts.URL) }),
+	}
+}
+
+func dlqQueue(t *testing.T, sqs *awssqs.Client, name string) (url, arn string) {
+	t.Helper()
+	return makeQueue(t, sqs, name)
+}
+
+// pollForMessage retries ReceiveMessage until a message arrives or the timeout
+// elapses, since delivery happens on a goroutine decoupled from PutEvents.
+func pollForMessage(t *testing.T, sqs *awssqs.Client, url string) string {
+	t.Helper()
+
+	deadline := time.Now().Add(dlqPollTimeout)
+	for time.Now().Before(deadline) {
+		if body, count := receiveOne(t, sqs, url); count > 0 {
+			return body
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatalf("no message received on %s within %s", url, dlqPollTimeout)
+
+	return ""
+}
+
+func TestSDKEventBridgeDeadLetterOnStaleSQSTarget(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	c := newDLQClients(t, cloud)
+	ctx := context.Background()
+
+	targetURL, targetARN := dlqQueue(t, c.sqs, "eb-stale-target")
+	dlqURL, dlqARN := dlqQueue(t, c.sqs, "eb-dlq")
+
+	if _, err := c.eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventPattern: aws.String(`{"source":["myapp"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := c.eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule: aws.String("r"),
+		Targets: []ebtypes.Target{{
+			Id:               aws.String("1"),
+			Arn:              aws.String(targetARN),
+			DeadLetterConfig: &ebtypes.DeadLetterConfig{Arn: aws.String(dlqARN)},
+		}},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	// The target queue goes stale after PutTargets.
+	if _, err := c.sqs.DeleteQueue(ctx, &awssqs.DeleteQueueInput{QueueUrl: aws.String(targetURL)}); err != nil {
+		t.Fatalf("DeleteQueue: %v", err)
+	}
+
+	if _, err := c.eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("myapp"), DetailType: aws.String("t"), Detail: aws.String(`{"orderId":"42"}`)},
+	}}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	body := pollForMessage(t, c.sqs, dlqURL)
+
+	var env map[string]any
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("DLQ body not JSON: %v (%s)", err, body)
+	}
+
+	if env["source"] != "myapp" {
+		t.Fatalf("unexpected DLQ envelope: %+v", env)
+	}
+}
+
+func TestSDKEventBridgeDeadLetterOnFailingLambdaTarget(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	cloud.Lambda.RegisterHandler("eb-failing-fn", func(context.Context, []byte) ([]byte, error) {
+		return nil, errSDKHandlerFailed
+	})
+
+	c := newDLQClients(t, cloud)
+	ctx := context.Background()
+
+	fnOut, err := c.lam.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String("eb-failing-fn"),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("stub")},
+	})
+	if err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	dlqURL, dlqARN := dlqQueue(t, c.sqs, "eb-dlq")
+
+	if _, err := c.eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventPattern: aws.String(`{"source":["myapp"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := c.eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule: aws.String("r"),
+		Targets: []ebtypes.Target{{
+			Id:               aws.String("1"),
+			Arn:              fnOut.FunctionArn,
+			DeadLetterConfig: &ebtypes.DeadLetterConfig{Arn: aws.String(dlqARN)},
+		}},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	if _, err := c.eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("myapp"), DetailType: aws.String("t"), Detail: aws.String(`{"orderId":"42"}`)},
+	}}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	pollForMessage(t, c.sqs, dlqURL)
+}


### PR DESCRIPTION
## Summary

EventBridge's target dispatch (`deliverToTargets`/`dispatchTarget`) silently dropped any event whose target invocation failed — a rule target ARN that went stale (e.g. its SQS queue deleted after `PutTargets`), or a Lambda target whose handler raised. Real EventBridge routes a failed invocation to the target's configured `DeadLetterConfig` queue instead of dropping it. `DeadLetterConfig`/`RetryPolicy` already round-tripped through `PutTargets`/`DescribeRule`/`ListTargetsByRule`, but were never acted on at delivery time.

## What changed

- `dispatchTarget` now reports success/failure instead of swallowing the deliverer's error.
- `deliverToTarget` (new): on a failed dispatch, emits a `FailedInvocations` metric (`AWS/Events`, dims `RuleName`+`EventBusName`) and, if the target has a `DeadLetterConfig`, delivers the original event envelope to that queue via the existing SQS delivery seam, then emits `InvocationsSentToDlq`.
- A target whose deliverer was never wired, or whose ARN service isn't modeled, still reports success — that's an emulator-coverage limitation, not a real delivery failure, so it must not trigger DLQ.
- DLQ message body is the original event (not the target's transformed input), matching real EventBridge.

## Deferred

- Retry semantics (`RetryPolicy` attempts/backoff) — delivery here is synchronous and immediate, so any failure routes straight to the DLQ rather than being retried; modeling actual retry/backoff would need an async delivery model.
- Archives/replay, API destinations, schema registry — unrelated surface, not touched.
- SQS message attributes on the DLQ message (`ERROR_CODE`, `ERROR_MESSAGE`, etc.) — the shared `SQSDeliverer.DeliverExternal(ctx, arn, body)` seam has no attribute support; the message body alone (the failed event) is delivered.

## Test plan
- [x] `go build ./...`
- [x] `go test ./providers/aws/eventbridge/... ./server/aws/eventbridge/... ./persist/... -race -count=1`
- [x] `go test ./providers/aws/... ./server/aws/...`
- [x] `gofmt -l` on touched files (clean)
- [x] `golangci-lint run` on touched packages — 0 new issues (11 pre-existing issues, unchanged)
- [x] `go generate ./...` + `git diff --exit-code docs/coverage` (clean, no driver interface change)
- [x] `go mod tidy` (no changes)
- [x] New real-user e2e tests via `aws-sdk-go-v2`: stale SQS target routes to DLQ, failing Lambda target routes to DLQ, no-DLQ-configured drops without failing `PutEvents`, successful delivery leaves the DLQ empty