### PR TITLE
feat(eventgrid): deliver to StorageQueue subscription destinations

### DIFF
--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -234,6 +234,7 @@ func New(opts ...config.Option) *Provider {
 	p.EventGrid.SetMonitoring(p.Monitor)
 	p.EventGrid.SetServiceBusDeliverer(p.ServiceBus)
 	p.EventGrid.SetFunctionInvoker(p.Functions)
+	p.EventGrid.SetStorageQueueDeliverer(p.QueueStorage)
 	// Native trigger delivery: a message enqueued to a Storage queue or Service
 	// Bus queue invokes any function whose function.json declares the matching
 	// trigger binding (queueTrigger / serviceBusTrigger) for that queue.

--- a/providers/azure/eventgrid/delivery.go
+++ b/providers/azure/eventgrid/delivery.go
@@ -17,16 +17,17 @@ import (
 // ARM EventSubscriptionDestination.endpointType values this mock delivers to.
 // WebHook POSTs the event envelope over HTTP; ServiceBusQueue/ServiceBusTopic
 // enqueue it into the peer Service Bus queue/topic; AzureFunction invokes the
-// peer Functions app with it. EventHub, StorageQueue, and HybridConnection
-// destinations are still parsed and round-trip on the subscription resource
-// (the raw ARM properties JSON is echoed verbatim regardless of type) but are
-// not delivered to: they have no peer mock in this codebase and are left as a
-// follow-up (see PR notes).
+// peer Functions app with it; StorageQueue enqueues into the peer Azure Queue
+// Storage queue. EventHub and HybridConnection destinations are still parsed
+// and round-trip on the subscription resource (the raw ARM properties JSON is
+// echoed verbatim regardless of type) but are not delivered to: they have no
+// peer mock in this codebase and are left as a follow-up (see PR notes).
 const (
 	endpointTypeWebHook         = "WebHook"
 	endpointTypeServiceBusQueue = "ServiceBusQueue"
 	endpointTypeServiceBusTopic = "ServiceBusTopic"
 	endpointTypeAzureFunction   = "AzureFunction"
+	endpointTypeStorageQueue    = "StorageQueue"
 )
 
 // defaultDataVersion is the dataVersion Event Grid stamps on a delivered event
@@ -61,7 +62,8 @@ const webhookDeliveryTimeout = 10 * time.Second
 type subscriptionDestination struct {
 	EndpointType string
 	EndpointURL  string // WebHook
-	ResourceID   string // ServiceBusQueue/Topic, EventHub, AzureFunction, StorageQueue, HybridConnection
+	ResourceID   string // ServiceBusQueue/Topic, EventHub, AzureFunction; storage account for StorageQueue
+	QueueName    string // StorageQueue: the queue name under ResourceID's storage account
 }
 
 // parseSubscriptionDestination extracts the "destination" object from a raw
@@ -77,6 +79,7 @@ func parseSubscriptionDestination(rawProperties string) subscriptionDestination 
 			Properties   struct {
 				EndpointURL string `json:"endpointUrl"`
 				ResourceID  string `json:"resourceId"`
+				QueueName   string `json:"queueName"`
 			} `json:"properties"`
 		} `json:"destination"`
 	}
@@ -89,6 +92,7 @@ func parseSubscriptionDestination(rawProperties string) subscriptionDestination 
 		EndpointType: body.Destination.EndpointType,
 		EndpointURL:  body.Destination.Properties.EndpointURL,
 		ResourceID:   body.Destination.Properties.ResourceID,
+		QueueName:    body.Destination.Properties.QueueName,
 	}
 }
 
@@ -108,19 +112,20 @@ type deliveryEvent struct {
 
 // deliverToTargets delivers event to every matched subscription's destination,
 // dispatched by the destination's endpointType: WebHook (HTTP POST),
-// ServiceBusQueue/ServiceBusTopic (enqueue into the peer Service Bus), and
-// AzureFunction (invoke the peer Functions app). All destinations receive the
-// same rendered EventGridEvent envelope. Delivery is synchronous (mirroring how
-// AWS EventBridge's deliverToTargets runs in-line in this codebase) but
-// decoupled from the caller's context so a client that cancels its publish
-// request doesn't abort in-flight deliveries. The caller ctx's re-entrant
-// delivery depth is carried forward so a self-referential chain (a WebHook that
-// points back at this emulator, or a Function that re-publishes) stays bounded —
-// the cap is enforced in postWebhook / functions.InvokeExternal, mirroring
-// lambda.InvokeExternal. EventHub, StorageQueue, and HybridConnection
-// destinations are parsed and round-trip on the subscription resource but are
-// not delivered to (no peer mock; see PR notes). Filters are already applied by
-// matchedRuleData, so every rd here is a filter-matched subscription.
+// ServiceBusQueue/ServiceBusTopic (enqueue into the peer Service Bus),
+// AzureFunction (invoke the peer Functions app), and StorageQueue (enqueue into
+// the peer Azure Queue Storage queue). All destinations receive the same
+// rendered EventGridEvent envelope. Delivery is synchronous (mirroring how AWS
+// EventBridge's deliverToTargets runs in-line in this codebase) but decoupled
+// from the caller's context so a client that cancels its publish request
+// doesn't abort in-flight deliveries. The caller ctx's re-entrant delivery
+// depth is carried forward so a self-referential chain (a WebHook that points
+// back at this emulator, or a Function that re-publishes) stays bounded — the
+// cap is enforced in postWebhook / functions.InvokeExternal, mirroring
+// lambda.InvokeExternal. EventHub and HybridConnection destinations are parsed
+// and round-trip on the subscription resource but are not delivered to (no
+// peer mock; see PR notes). Filters are already applied by matchedRuleData, so
+// every rd here is a filter-matched subscription.
 func (m *Mock) deliverToTargets(ctx context.Context, matched []*ruleData, event *driver.Event, topicARN string) {
 	if len(matched) == 0 {
 		return
@@ -162,29 +167,58 @@ func (m *Mock) deliverToTargets(ctx context.Context, matched []*ruleData, event 
 // dispatchDestination routes one rendered envelope to a single subscription
 // destination by its endpointType. A nil peer (the injector was never wired) or
 // an unresolvable resource id is skipped gracefully — never a panic — matching
-// how EventBridge's dispatchTarget silently ignores an unwired sink.
+// how EventBridge's dispatchTarget silently ignores an unwired sink. Each
+// endpointType's dispatch is split into its own small method to keep this
+// switch's cyclomatic complexity low.
 func (m *Mock) dispatchDestination(ctx context.Context, dest subscriptionDestination, body []byte) {
 	switch dest.EndpointType {
 	case endpointTypeWebHook:
-		if dest.EndpointURL != "" {
-			m.postWebhook(ctx, dest.EndpointURL, body)
-		}
+		m.dispatchWebHook(ctx, dest, body)
 	case endpointTypeServiceBusQueue, endpointTypeServiceBusTopic:
-		if m.serviceBus == nil {
-			return
-		}
-
-		if name := resourceLeafName(dest.ResourceID); name != "" {
-			_ = m.serviceBus.DeliverExternal(ctx, name, string(body))
-		}
+		m.dispatchServiceBus(ctx, dest, body)
 	case endpointTypeAzureFunction:
-		if m.functions == nil {
-			return
-		}
+		m.dispatchAzureFunction(ctx, dest, body)
+	case endpointTypeStorageQueue:
+		m.dispatchStorageQueue(ctx, dest, body)
+	}
+}
 
-		if app := functionAppName(dest.ResourceID); app != "" {
-			_ = m.functions.InvokeExternal(ctx, app, body)
-		}
+func (m *Mock) dispatchWebHook(ctx context.Context, dest subscriptionDestination, body []byte) {
+	if dest.EndpointURL != "" {
+		m.postWebhook(ctx, dest.EndpointURL, body)
+	}
+}
+
+func (m *Mock) dispatchServiceBus(ctx context.Context, dest subscriptionDestination, body []byte) {
+	if m.serviceBus == nil {
+		return
+	}
+
+	if name := resourceLeafName(dest.ResourceID); name != "" {
+		_ = m.serviceBus.DeliverExternal(ctx, name, string(body))
+	}
+}
+
+func (m *Mock) dispatchAzureFunction(ctx context.Context, dest subscriptionDestination, body []byte) {
+	if m.functions == nil {
+		return
+	}
+
+	if app := functionAppName(dest.ResourceID); app != "" {
+		_ = m.functions.InvokeExternal(ctx, app, body)
+	}
+}
+
+// dispatchStorageQueue delivers to a StorageQueue destination, resolved by
+// dest.QueueName (the queue's own name) rather than dest.ResourceID (which
+// addresses the containing storage account, not the queue).
+func (m *Mock) dispatchStorageQueue(ctx context.Context, dest subscriptionDestination, body []byte) {
+	if m.storageQueue == nil {
+		return
+	}
+
+	if dest.QueueName != "" {
+		_ = m.storageQueue.DeliverExternal(ctx, dest.QueueName, string(body))
 	}
 }
 

--- a/providers/azure/eventgrid/eventgrid.go
+++ b/providers/azure/eventgrid/eventgrid.go
@@ -86,6 +86,11 @@ type Mock struct {
 	httpClient  *http.Client
 	serviceBus  ServiceBusDeliverer
 	functions   FunctionInvoker
+	// storageQueue delivers to StorageQueue destinations. It reuses the same
+	// ServiceBusDeliverer contract as serviceBus (DeliverExternal(ctx, name,
+	// body) enqueues by name) because the Azure Queue Storage provider is the
+	// same servicebus.Mock implementation, wired as a distinct instance.
+	storageQueue ServiceBusDeliverer
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -103,6 +108,12 @@ func (m *Mock) SetServiceBusDeliverer(d ServiceBusDeliverer) {
 // AzureFunction subscription destinations.
 func (m *Mock) SetFunctionInvoker(i FunctionInvoker) {
 	m.functions = i
+}
+
+// SetStorageQueueDeliverer wires the Azure Queue Storage backend so PutEvents
+// delivers to StorageQueue subscription destinations.
+func (m *Mock) SetStorageQueueDeliverer(d ServiceBusDeliverer) {
+	m.storageQueue = d
 }
 
 func (m *Mock) emitMetric(topicName string, metrics map[string]float64) {

--- a/providers/azure/eventgrid/storagequeue_delivery_test.go
+++ b/providers/azure/eventgrid/storagequeue_delivery_test.go
@@ -1,0 +1,172 @@
+package eventgrid
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/providers/azure/servicebus"
+	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// storageQueueDestinationJSON builds the raw ARM EventSubscription properties
+// for a StorageQueue destination (armeventgrid
+// StorageQueueEventSubscriptionDestinationProperties: resourceId is the
+// storage account, queueName is the queue under it — distinct fields, unlike
+// ServiceBusQueue/Topic's single resourceId).
+func storageQueueDestinationJSON(storageAccountResourceID, queueName, subjectBeginsWith string) string {
+	props := map[string]any{
+		"destination": map[string]any{
+			"endpointType": endpointTypeStorageQueue,
+			"properties": map[string]any{
+				"resourceId": storageAccountResourceID,
+				"queueName":  queueName,
+			},
+		},
+	}
+
+	if subjectBeginsWith != "" {
+		props["filter"] = map[string]any{"subjectBeginsWith": subjectBeginsWith}
+	}
+
+	b, _ := json.Marshal(props)
+
+	return string(b)
+}
+
+// TestPutEventsDeliversToStorageQueue proves a StorageQueue destination
+// enqueues the event envelope into the peer Azure Queue Storage queue, named by
+// the destination's queueName field (not the storage-account resourceId).
+func TestPutEventsDeliversToStorageQueue(t *testing.T) {
+	ctx := context.Background()
+
+	qs := servicebus.New(newPeerOpts())
+	queue, err := qs.CreateQueue(ctx, mqdriver.QueueConfig{Name: "orders-sq"})
+	require.NoError(t, err)
+
+	m, _ := newTestMock()
+	m.SetStorageQueueDeliverer(qs)
+
+	createTestTopic(t, m, "orders")
+
+	storageAccountID := "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/mystorage"
+
+	_, err = m.PutRule(ctx, &ebdriver.RuleConfig{
+		Name:        "sub-sq",
+		EventBus:    "orders",
+		Description: storageQueueDestinationJSON(storageAccountID, "orders-sq", ""),
+	})
+	require.NoError(t, err)
+
+	_, err = m.PutEvents(ctx, []ebdriver.Event{{
+		EventBus:   "orders",
+		DetailType: "Order.Created",
+		Detail:     `{"total":42}`,
+		Subject:    "orders/1",
+	}})
+	require.NoError(t, err)
+
+	msgs, err := qs.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{QueueURL: queue.URL, MaxMessages: 10})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	var batch []deliveryEvent
+	require.NoError(t, json.Unmarshal([]byte(msgs[0].Body), &batch))
+	require.Len(t, batch, 1)
+	assert.Equal(t, "Order.Created", batch[0].EventType)
+	assert.Equal(t, "orders/1", batch[0].Subject)
+	assert.JSONEq(t, `{"total":42}`, string(batch[0].Data))
+}
+
+// TestPutEventsStorageQueueHonorsFilter proves a non-matching subscription
+// filter suppresses delivery to a StorageQueue destination, exactly as it does
+// for the other destination types.
+func TestPutEventsStorageQueueHonorsFilter(t *testing.T) {
+	ctx := context.Background()
+
+	qs := servicebus.New(newPeerOpts())
+	queue, err := qs.CreateQueue(ctx, mqdriver.QueueConfig{Name: "orders-sq"})
+	require.NoError(t, err)
+
+	m, _ := newTestMock()
+	m.SetStorageQueueDeliverer(qs)
+
+	createTestTopic(t, m, "orders")
+
+	storageAccountID := "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/mystorage"
+
+	_, err = m.PutRule(ctx, &ebdriver.RuleConfig{
+		Name:        "sub-sq",
+		EventBus:    "orders",
+		Description: storageQueueDestinationJSON(storageAccountID, "orders-sq", "orders/"),
+	})
+	require.NoError(t, err)
+
+	_, err = m.PutEvents(ctx, []ebdriver.Event{{
+		EventBus:   "orders",
+		DetailType: "Invoice.Created",
+		Subject:    "invoices/1",
+	}})
+	require.NoError(t, err)
+
+	msgs, err := qs.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{QueueURL: queue.URL, MaxMessages: 10})
+	require.NoError(t, err)
+	assert.Empty(t, msgs, "a non-matching subject must not be delivered to the Storage Queue")
+}
+
+// TestPutEventsStorageQueueNilPeerNoPanic proves a StorageQueue destination is
+// skipped gracefully (no panic, publish still succeeds) when no peer is wired.
+func TestPutEventsStorageQueueNilPeerNoPanic(t *testing.T) {
+	ctx := context.Background()
+
+	m, _ := newTestMock()
+	createTestTopic(t, m, "orders")
+
+	storageAccountID := "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/mystorage"
+
+	_, err := m.PutRule(ctx, &ebdriver.RuleConfig{
+		Name:        "sub-sq",
+		EventBus:    "orders",
+		Description: storageQueueDestinationJSON(storageAccountID, "missing-q", ""),
+	})
+	require.NoError(t, err)
+
+	result, err := m.PutEvents(ctx, []ebdriver.Event{{
+		EventBus: "orders", DetailType: "Order.Created", Subject: "orders/1",
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.SuccessCount)
+}
+
+// TestPutEventsStorageQueueMissingQueueNoPanic proves a StorageQueue
+// destination naming a queue that doesn't exist on the peer is skipped
+// gracefully (DeliverExternal returns NotFound, which the dispatcher ignores),
+// matching the best-effort-sink behavior of the other destination types.
+func TestPutEventsStorageQueueMissingQueueNoPanic(t *testing.T) {
+	ctx := context.Background()
+
+	qs := servicebus.New(newPeerOpts())
+
+	m, _ := newTestMock()
+	m.SetStorageQueueDeliverer(qs)
+
+	createTestTopic(t, m, "orders")
+
+	storageAccountID := "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/mystorage"
+
+	_, err := m.PutRule(ctx, &ebdriver.RuleConfig{
+		Name:        "sub-sq",
+		EventBus:    "orders",
+		Description: storageQueueDestinationJSON(storageAccountID, "missing-q", ""),
+	})
+	require.NoError(t, err)
+
+	result, err := m.PutEvents(ctx, []ebdriver.Event{{
+		EventBus: "orders", DetailType: "Order.Created", Subject: "orders/1",
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.SuccessCount)
+}


### PR DESCRIPTION
## Summary

Investigated Azure Event Grid's current depth (custom topics, event subscriptions, filter matching, PATCH, system topics, domains — all already mature: subject prefix/suffix matching, includedEventTypes, the full advanced-filter operator set (StringIn/BeginsWith/Contains/..., NumberIn/GreaterThan/..., BoolEquals, IsNullOrUndefined), topic-NotFound validation on subscription create, and WebHook/ServiceBusQueue/ServiceBusTopic/AzureFunction delivery). The one real gap found: a **StorageQueue** subscription destination parsed and round-tripped on the resource but was never delivered to, even though the Azure Queue Storage peer mock already exists in the provider factory (`QueueStorage`, wired for the Functions `queueTrigger` binding) — it was simply never connected as an Event Grid delivery sink.

## What changed

- `providers/azure/eventgrid/delivery.go`: parse the StorageQueue destination's `queueName` field (distinct from `resourceId`, which addresses the storage account, not the queue — matches `armeventgrid.StorageQueueEventSubscriptionDestinationProperties`); dispatch to it via the same `ServiceBusDeliverer.DeliverExternal` seam already used for ServiceBusQueue/Topic. Split `dispatchDestination`'s switch into small per-endpointType methods to keep cyclomatic complexity in check.
- `providers/azure/eventgrid/eventgrid.go`: add `SetStorageQueueDeliverer`, mirroring `SetServiceBusDeliverer`/`SetFunctionInvoker`.
- `providers/azure/azure.go`: wire `p.EventGrid.SetStorageQueueDeliverer(p.QueueStorage)`.
- `providers/azure/eventgrid/storagequeue_delivery_test.go`: delivery, filter-suppression, nil-peer, and missing-queue coverage, mirroring the existing ServiceBus/Function delivery tests.

## Deferred

- EventHub and HybridConnection destinations: still no peer mock (no Event Hubs data-plane / Hybrid Connections backend in this codebase), so they remain parse/round-trip-only, as before.
- Domains and system-topics delivery depth, dead-letter execution, and retry-policy execution were investigated and found already correctly modeled/deferred at the same level as the rest of the codebase; not touched here to keep this PR cohesive.