### PR TITLE
feat(eventarc): trigger eventFilter and destination validation

### DIFF
--- a/server/gcp/eventarc/gapic_lro_test.go
+++ b/server/gcp/eventarc/gapic_lro_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2"
 	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+	crdriver "github.com/stackshy/cloudemu/v2/services/cloudrun/driver"
 )
 
 // TestGAPICCreateTriggerWait is the review's #3 check for eventarc: the finding
@@ -24,6 +25,13 @@ func TestGAPICCreateTriggerWait(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	ctx := context.Background()
+
+	// The trigger below routes to Cloud Run service "svc": DriversFrom wires
+	// the CloudRun driver, so create the service the destination validation
+	// resolves against.
+	if _, err := cloud.CloudRun.CreateService(ctx, crdriver.ServiceConfig{Name: "svc", Location: "us-central1"}); err != nil {
+		t.Fatalf("CloudRun.CreateService: %v", err)
+	}
 
 	client, err := eventarc.NewRESTClient(ctx,
 		option.WithEndpoint(ts.URL),

--- a/server/gcp/eventarc/handler.go
+++ b/server/gcp/eventarc/handler.go
@@ -30,6 +30,13 @@
 // (Firestore, IAM, Secret Manager, GKE, …), so registration order among them is
 // unconstrained. Registered before the GCS fallback.
 //
+// Create and Patch validate a trigger the way real Eventarc does at admission
+// time: eventFilters must include a "type" filter naming a known event type
+// (an audit-log trigger additionally needs "serviceName" and "methodName"),
+// and — when a Cloud Functions / Cloud Run resolver is wired — the
+// destination must name a resource that actually exists rather than a dead
+// route. See validate.go.
+//
 // Coverage (v1 REST):
 //
 //	POST   /v1/projects/{p}/locations/{l}/triggers?triggerId={id}   — Create (LRO, done inline)
@@ -68,6 +75,15 @@ type Handler struct {
 	// polls the returned operation name gets the typed response (and unknown
 	// names 404). Nil in a standalone package server.
 	ops *lro.Registry
+
+	// functions and cloudRun resolve a trigger's destination to an existing
+	// Cloud Function / Cloud Run service so Create/Patch can reject a trigger
+	// that routes to a resource that doesn't exist. Nil (the default) skips
+	// that half of destination validation gracefully — a standalone package
+	// server that doesn't wire the peer service keeps accepting any
+	// destination, as before.
+	functions FunctionResolver
+	cloudRun  CloudRunResolver
 }
 
 // New returns an Eventarc handler backed by b.
@@ -78,6 +94,15 @@ func New(b ebdriver.EventBus) *Handler {
 // SetOperationRegistry wires the shared LRO poller so created operations are
 // resolvable (with their response) through the full server's operations host.
 func (h *Handler) SetOperationRegistry(reg *lro.Registry) { h.ops = reg }
+
+// SetFunctionResolver wires the Cloud Functions backend so a trigger whose
+// destination names a Cloud Function is validated against it at Create/Patch
+// time. The cloudfunctions driver satisfies this via GetFunction.
+func (h *Handler) SetFunctionResolver(r FunctionResolver) { h.functions = r }
+
+// SetCloudRunResolver is the Cloud Run analog of SetFunctionResolver. The
+// cloudrun driver satisfies this via GetService.
+func (h *Handler) SetCloudRunResolver(r CloudRunResolver) { h.cloudRun = r }
 
 type route struct {
 	project   string

--- a/server/gcp/eventarc/operations.go
+++ b/server/gcp/eventarc/operations.go
@@ -26,10 +26,8 @@ func (h *Handler) createTrigger(w http.ResponseWriter, r *http.Request, rt *rout
 		return
 	}
 
-	// A trigger must route somewhere. Real Eventarc rejects a trigger with no
-	// destination with INVALID_ARGUMENT rather than storing a dead route.
-	if _, ok := destinationTarget(body.Destination); !ok {
-		gcprest.WriteError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "destination is required")
+	target, ok := h.validateTriggerBody(w, r, &body)
+	if !ok {
 		return
 	}
 
@@ -61,8 +59,6 @@ func (h *Handler) createTrigger(w http.ResponseWriter, r *http.Request, rt *rout
 		return
 	}
 
-	target, _ := destinationTarget(body.Destination)
-
 	if perr := h.bus.PutTargets(r.Context(), bus, triggerID, []ebdriver.Target{target}); perr != nil {
 		// Roll back the rule created above so a failed Create doesn't leave
 		// an orphaned trigger that blocks a later Create with the same id.
@@ -82,6 +78,33 @@ func (h *Handler) createTrigger(w http.ResponseWriter, r *http.Request, rt *rout
 
 	gcprest.WriteJSON(w, http.StatusOK, h.doneOperation(rt, triggerID,
 		typedResponse(triggerTypeURL, toTriggerJSON(rt.project, rt.location, stored))))
+}
+
+// validateTriggerBody validates a Create request's eventFilters and
+// destination, writing the appropriate error response and returning ok=false
+// when either check fails. On success it returns the driver Target the
+// validated destination folds into — a trigger must route somewhere, and real
+// Eventarc rejects a trigger with no destination (or one naming a resource
+// that doesn't exist) with INVALID_ARGUMENT / NOT_FOUND rather than storing a
+// dead route.
+func (h *Handler) validateTriggerBody(w http.ResponseWriter, r *http.Request, body *triggerJSON) (ebdriver.Target, bool) {
+	if msg := validateEventFilters(body.EventFilters); msg != "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "INVALID_ARGUMENT", msg)
+		return ebdriver.Target{}, false
+	}
+
+	target, ok := destinationTarget(body.Destination)
+	if !ok {
+		gcprest.WriteError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "destination is required")
+		return ebdriver.Target{}, false
+	}
+
+	if err := h.validateDestination(r.Context(), body.Destination); err != nil {
+		gcprest.WriteCErr(w, err)
+		return ebdriver.Target{}, false
+	}
+
+	return target, true
 }
 
 // triggerTypeURL is the protobuf Any type URL a GAPIC eventarc client expects
@@ -202,25 +225,8 @@ func (h *Handler) patchTrigger(w http.ResponseWriter, r *http.Request, rt *route
 	cur := toTriggerJSON(rt.project, rt.location, existing)
 	meta := decodeTriggerMeta(existing.Description)
 
-	if mask.has("eventFilters") {
-		cur.EventFilters = body.EventFilters
-	}
-
-	if mask.has("serviceAccount") {
-		meta.ServiceAccount = body.ServiceAccount
-	}
-
-	if mask.has("labels") {
-		meta.Labels = body.Labels
-	}
-
-	if mask.has("destination") {
-		if _, ok := destinationTarget(body.Destination); !ok {
-			gcprest.WriteError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "destination is required")
-			return
-		}
-
-		cur.Destination = body.Destination
+	if !h.applyMaskedFields(w, r, mask, &body, &cur, &meta) {
+		return
 	}
 
 	meta.Revision++
@@ -238,6 +244,48 @@ func (h *Handler) patchTrigger(w http.ResponseWriter, r *http.Request, rt *route
 
 	gcprest.WriteJSON(w, http.StatusOK, h.doneOperation(rt, rt.trigger,
 		typedResponse(triggerTypeURL, toTriggerJSON(rt.project, rt.location, stored))))
+}
+
+// applyMaskedFields validates and applies onto cur/meta the fields a Patch
+// request's updateMask names, writing the appropriate error response and
+// returning ok=false when a validated field (eventFilters or destination)
+// fails validation. Unvalidated fields (serviceAccount, labels) are applied
+// unconditionally.
+func (h *Handler) applyMaskedFields(
+	w http.ResponseWriter, r *http.Request, mask updateMask, body, cur *triggerJSON, meta *triggerMeta,
+) bool {
+	if mask.has("eventFilters") {
+		if msg := validateEventFilters(body.EventFilters); msg != "" {
+			gcprest.WriteError(w, http.StatusBadRequest, "INVALID_ARGUMENT", msg)
+			return false
+		}
+
+		cur.EventFilters = body.EventFilters
+	}
+
+	if mask.has("serviceAccount") {
+		meta.ServiceAccount = body.ServiceAccount
+	}
+
+	if mask.has("labels") {
+		meta.Labels = body.Labels
+	}
+
+	if mask.has("destination") {
+		if _, ok := destinationTarget(body.Destination); !ok {
+			gcprest.WriteError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "destination is required")
+			return false
+		}
+
+		if err := h.validateDestination(r.Context(), body.Destination); err != nil {
+			gcprest.WriteCErr(w, err)
+			return false
+		}
+
+		cur.Destination = body.Destination
+	}
+
+	return true
 }
 
 // applyTriggerUpdate persists the mutated trigger back onto the driver rule and

--- a/server/gcp/eventarc/sdk_roundtrip_test.go
+++ b/server/gcp/eventarc/sdk_roundtrip_test.go
@@ -178,7 +178,8 @@ func TestSDKEventarcErrors(t *testing.T) {
 
 	// Duplicate create is a conflict.
 	tr := &eventarc.Trigger{
-		Destination: &eventarc.Destination{CloudRun: &eventarc.CloudRun{Service: "s"}},
+		EventFilters: []*eventarc.EventFilter{{Attribute: "type", Value: "google.cloud.storage.object.v1.finalized"}},
+		Destination:  &eventarc.Destination{CloudRun: &eventarc.CloudRun{Service: "s"}},
 	}
 
 	if _, err := svc.Projects.Locations.Triggers.Create(parent(), tr).TriggerId("dup").Context(ctx).Do(); err != nil {
@@ -303,7 +304,8 @@ func TestSDKEventarcListPagination(t *testing.T) {
 
 	for _, id := range []string{"a", "b", "c"} {
 		tr := &eventarc.Trigger{
-			Destination: &eventarc.Destination{CloudRun: &eventarc.CloudRun{Service: "s", Region: testLocation}},
+			EventFilters: []*eventarc.EventFilter{{Attribute: "type", Value: "google.cloud.storage.object.v1.finalized"}},
+			Destination:  &eventarc.Destination{CloudRun: &eventarc.CloudRun{Service: "s", Region: testLocation}},
 		}
 		if _, err := svc.Projects.Locations.Triggers.Create(parent(), tr).TriggerId(id).Context(ctx).Do(); err != nil {
 			t.Fatalf("Create(%s): %v", id, err)

--- a/server/gcp/eventarc/types.go
+++ b/server/gcp/eventarc/types.go
@@ -117,9 +117,11 @@ func decodeEventPattern(pattern string) []eventFilterJSON {
 
 // destinationTarget folds a trigger destination into the single driver Target
 // the rule stores. The destination is serialized into the target's Input so it
-// round-trips faithfully; the ARN carries a human-readable summary.
+// round-trips faithfully; the ARN carries a human-readable summary. A dest
+// with every sub-field empty (no cloudRun/cloudFunction/workflow) is rejected
+// the same as a nil one — it names nowhere to route to.
 func destinationTarget(dest *destinationJSON) (ebdriver.Target, bool) {
-	if dest == nil {
+	if dest == nil || destinationSummary(dest) == "" {
 		return ebdriver.Target{}, false
 	}
 

--- a/server/gcp/eventarc/validate.go
+++ b/server/gcp/eventarc/validate.go
@@ -1,0 +1,152 @@
+package eventarc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	crdriver "github.com/stackshy/cloudemu/v2/services/cloudrun/driver"
+	sdrv "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// Known Eventarc direct/Pub/Sub event types this mock validates a trigger's
+// "type" eventFilter against. Real Eventarc's full catalog is served by
+// projects.locations.providers.list and is far larger (Firebase, BigQuery,
+// Cloud Composer, …); this is the commonly used subset — Pub/Sub, Cloud Audit
+// Logs, Cloud Storage, and Firestore — CloudEmu validates against.
+const (
+	eventTypePubsubMessagePublished = "google.cloud.pubsub.topic.v1.messagePublished"
+	eventTypeAuditLogWritten        = "google.cloud.audit.log.v1.written"
+	eventTypeStorageFinalized       = "google.cloud.storage.object.v1.finalized"
+	eventTypeStorageDeleted         = "google.cloud.storage.object.v1.deleted"
+	eventTypeStorageArchived        = "google.cloud.storage.object.v1.archived"
+	eventTypeStorageMetadataUpdated = "google.cloud.storage.object.v1.metadataUpdated"
+	eventTypeFirestoreCreated       = "google.cloud.firestore.document.v1.created"
+	eventTypeFirestoreUpdated       = "google.cloud.firestore.document.v1.updated"
+	eventTypeFirestoreDeleted       = "google.cloud.firestore.document.v1.deleted"
+	eventTypeFirestoreWritten       = "google.cloud.firestore.document.v1.written"
+)
+
+// knownEventTypes is the static lookup table validateEventFilters checks a
+// trigger's "type" filter value against.
+var knownEventTypes = map[string]struct{}{ //nolint:gochecknoglobals // static lookup table
+	eventTypePubsubMessagePublished: {},
+	eventTypeAuditLogWritten:        {},
+	eventTypeStorageFinalized:       {},
+	eventTypeStorageDeleted:         {},
+	eventTypeStorageArchived:        {},
+	eventTypeStorageMetadataUpdated: {},
+	eventTypeFirestoreCreated:       {},
+	eventTypeFirestoreUpdated:       {},
+	eventTypeFirestoreDeleted:       {},
+	eventTypeFirestoreWritten:       {},
+}
+
+// eventFilter attribute names validateEventFilters looks for.
+const (
+	filterAttrType        = "type"
+	filterAttrServiceName = "serviceName"
+	filterAttrMethodName  = "methodName"
+)
+
+// validateEventFilters checks a trigger's eventFilters against Eventarc's own
+// admission-time rules: a required "type" filter naming a known event type,
+// and — for the audit-log event type — required "serviceName" and
+// "methodName" filters pinning the trigger to one API method (real Eventarc
+// refuses to create an unscoped audit-log trigger). Returns "" when the
+// filters are valid, or the INVALID_ARGUMENT message otherwise.
+func validateEventFilters(filters []eventFilterJSON) string {
+	typeValue, hasType := filterValue(filters, filterAttrType)
+	if !hasType {
+		return "eventFilters must include a non-empty 'type' filter"
+	}
+
+	if _, known := knownEventTypes[typeValue]; !known {
+		return fmt.Sprintf("eventFilters 'type' %q is not a known Eventarc event type", typeValue)
+	}
+
+	if typeValue != eventTypeAuditLogWritten {
+		return ""
+	}
+
+	if _, ok := filterValue(filters, filterAttrServiceName); !ok {
+		return "an audit-log trigger requires a non-empty 'serviceName' filter"
+	}
+
+	if _, ok := filterValue(filters, filterAttrMethodName); !ok {
+		return "an audit-log trigger requires a non-empty 'methodName' filter"
+	}
+
+	return ""
+}
+
+// filterValue returns the value of the first filter with the given attribute
+// and whether one was present with a non-empty value.
+func filterValue(filters []eventFilterJSON, attr string) (string, bool) {
+	for i := range filters {
+		if filters[i].Attribute == attr && filters[i].Value != "" {
+			return filters[i].Value, true
+		}
+	}
+
+	return "", false
+}
+
+// FunctionResolver checks whether a Cloud Function destination exists, so
+// Create/Patch can reject a trigger before it is stored as a dead route.
+// sdrv.Serverless satisfies this via GetFunction.
+type FunctionResolver interface {
+	GetFunction(ctx context.Context, name string) (*sdrv.FunctionInfo, error)
+}
+
+// CloudRunResolver is the Cloud Run analog of FunctionResolver.
+// crdriver.CloudRun satisfies this via GetService.
+type CloudRunResolver interface {
+	GetService(ctx context.Context, name string) (*crdriver.Service, error)
+}
+
+// validateDestination checks that dest names an existing Cloud Run service or
+// Cloud Function, mirroring Eventarc's own admission-time validation that a
+// trigger can't route to a resource the caller can't demonstrate exists.
+// Workflow destinations aren't modeled (no workflows driver in CloudEmu), so
+// they pass unchecked, and a resolver left unwired (nil — the standalone
+// package server may not have the peer service) skips its half of the check
+// gracefully rather than failing closed.
+func (h *Handler) validateDestination(ctx context.Context, dest *destinationJSON) error {
+	switch {
+	case dest.CloudFunction != "":
+		if h.functions == nil {
+			return nil
+		}
+
+		name := lastSegment(dest.CloudFunction)
+
+		if _, err := h.functions.GetFunction(ctx, name); err != nil {
+			return cerrors.Newf(cerrors.NotFound, "destination cloud function %q not found", dest.CloudFunction)
+		}
+	case dest.CloudRun != nil && dest.CloudRun.Service != "":
+		if h.cloudRun == nil {
+			return nil
+		}
+
+		if _, err := h.cloudRun.GetService(ctx, dest.CloudRun.Service); err != nil {
+			return cerrors.Newf(cerrors.NotFound, "destination cloud run service %q not found", dest.CloudRun.Service)
+		}
+	}
+
+	return nil
+}
+
+// lastSegment returns the trailing path segment of a resource name (or the
+// input itself when it has no "/"). Mirrors providers/gcp/eventarc's helper
+// of the same name — the two packages can't share it (provider must not
+// import server).
+func lastSegment(name string) string {
+	trimmed := strings.TrimRight(name, "/")
+	if i := strings.LastIndex(trimmed, "/"); i >= 0 {
+		return trimmed[i+1:]
+	}
+
+	return trimmed
+}

--- a/server/gcp/eventarc/validate.go
+++ b/server/gcp/eventarc/validate.go
@@ -2,7 +2,6 @@ package eventarc
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -10,38 +9,14 @@ import (
 	sdrv "github.com/stackshy/cloudemu/v2/services/serverless/driver"
 )
 
-// Known Eventarc direct/Pub/Sub event types this mock validates a trigger's
-// "type" eventFilter against. Real Eventarc's full catalog is served by
-// projects.locations.providers.list and is far larger (Firebase, BigQuery,
-// Cloud Composer, …); this is the commonly used subset — Pub/Sub, Cloud Audit
-// Logs, Cloud Storage, and Firestore — CloudEmu validates against.
-const (
-	eventTypePubsubMessagePublished = "google.cloud.pubsub.topic.v1.messagePublished"
-	eventTypeAuditLogWritten        = "google.cloud.audit.log.v1.written"
-	eventTypeStorageFinalized       = "google.cloud.storage.object.v1.finalized"
-	eventTypeStorageDeleted         = "google.cloud.storage.object.v1.deleted"
-	eventTypeStorageArchived        = "google.cloud.storage.object.v1.archived"
-	eventTypeStorageMetadataUpdated = "google.cloud.storage.object.v1.metadataUpdated"
-	eventTypeFirestoreCreated       = "google.cloud.firestore.document.v1.created"
-	eventTypeFirestoreUpdated       = "google.cloud.firestore.document.v1.updated"
-	eventTypeFirestoreDeleted       = "google.cloud.firestore.document.v1.deleted"
-	eventTypeFirestoreWritten       = "google.cloud.firestore.document.v1.written"
-)
-
-// knownEventTypes is the static lookup table validateEventFilters checks a
-// trigger's "type" filter value against.
-var knownEventTypes = map[string]struct{}{ //nolint:gochecknoglobals // static lookup table
-	eventTypePubsubMessagePublished: {},
-	eventTypeAuditLogWritten:        {},
-	eventTypeStorageFinalized:       {},
-	eventTypeStorageDeleted:         {},
-	eventTypeStorageArchived:        {},
-	eventTypeStorageMetadataUpdated: {},
-	eventTypeFirestoreCreated:       {},
-	eventTypeFirestoreUpdated:       {},
-	eventTypeFirestoreDeleted:       {},
-	eventTypeFirestoreWritten:       {},
-}
+// eventTypeAuditLogWritten is the one Eventarc direct-event type this mock
+// special-cases: a Cloud Audit Log trigger must additionally carry
+// "serviceName" and "methodName" filters pinning it to one API method. Real
+// Eventarc's event-type catalog is otherwise open-ended — Pub/Sub, Storage,
+// Firestore, Firebase, and (for channels) arbitrary third-party-provider
+// strings with no fixed Google list — so validateEventFilters does not gate
+// acceptance on the "type" value beyond requiring one be present.
+const eventTypeAuditLogWritten = "google.cloud.audit.log.v1.written"
 
 // eventFilter attribute names validateEventFilters looks for.
 const (
@@ -51,19 +26,19 @@ const (
 )
 
 // validateEventFilters checks a trigger's eventFilters against Eventarc's own
-// admission-time rules: a required "type" filter naming a known event type,
-// and — for the audit-log event type — required "serviceName" and
-// "methodName" filters pinning the trigger to one API method (real Eventarc
-// refuses to create an unscoped audit-log trigger). Returns "" when the
-// filters are valid, or the INVALID_ARGUMENT message otherwise.
+// admission-time rules: a required "type" filter (real Eventarc always
+// requires one), and — for the audit-log event type — required "serviceName"
+// and "methodName" filters pinning the trigger to one API method (real
+// Eventarc refuses to create an unscoped audit-log trigger). The "type"
+// value itself is not checked against a catalog: Eventarc's event-type space
+// is open-ended (Firebase events, future Google-added types, and arbitrary
+// third-party strings on a channel trigger), so rejecting an uncataloged but
+// well-formed type would false-reject valid real-world configs. Returns ""
+// when the filters are valid, or the INVALID_ARGUMENT message otherwise.
 func validateEventFilters(filters []eventFilterJSON) string {
 	typeValue, hasType := filterValue(filters, filterAttrType)
 	if !hasType {
 		return "eventFilters must include a non-empty 'type' filter"
-	}
-
-	if _, known := knownEventTypes[typeValue]; !known {
-		return fmt.Sprintf("eventFilters 'type' %q is not a known Eventarc event type", typeValue)
 	}
 
 	if typeValue != eventTypeAuditLogWritten {

--- a/server/gcp/eventarc/validate_test.go
+++ b/server/gcp/eventarc/validate_test.go
@@ -69,19 +69,25 @@ func TestSDKEventarcMissingTypeFilter(t *testing.T) {
 	wantGoogleAPIError(t, err, 400, "type")
 }
 
-// TestSDKEventarcUnknownEventType: a "type" filter naming an event type
-// outside the catalog CloudEmu validates against is a 400 INVALID_ARGUMENT.
-func TestSDKEventarcUnknownEventType(t *testing.T) {
+// TestSDKEventarcUncatalogedEventTypeAccepted: Eventarc's event-type catalog
+// is open-ended — Firebase events, future Google-added types, and (for
+// channel/third-party triggers) arbitrary provider-defined strings with no
+// fixed Google list. A well-formed "type" filter naming a type CloudEmu
+// doesn't special-case must be accepted, not rejected as "unknown"; rejecting
+// it would false-reject real Terraform/SDK configs.
+func TestSDKEventarcUncatalogedEventTypeAccepted(t *testing.T) {
 	svc := newEventarcService(t)
 	ctx := context.Background()
 
 	trigger := &eventarc.Trigger{
-		EventFilters: []*eventarc.EventFilter{{Attribute: "type", Value: "not.a.real.event.type"}},
+		EventFilters: []*eventarc.EventFilter{{Attribute: "type", Value: "google.firebase.auth.user.v1.created"}},
 		Destination:  &eventarc.Destination{CloudRun: &eventarc.CloudRun{Service: "svc"}},
 	}
 
-	_, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).TriggerId("bad-type").Context(ctx).Do()
-	wantGoogleAPIError(t, err, 400, "not a known Eventarc event type")
+	if _, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).
+		TriggerId("uncataloged-type").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create with an uncataloged-but-well-formed event type: %v", err)
+	}
 }
 
 // TestSDKEventarcAuditLogRequiresServiceAndMethod: an audit-log trigger
@@ -185,8 +191,10 @@ func TestSDKEventarcDestinationCloudFunctionNotFound(t *testing.T) {
 }
 
 // TestSDKEventarcPatchValidation: patching eventFilters or destination goes
-// through the same validation as Create, and a rejected patch leaves the
-// stored trigger unchanged.
+// through the same validation as Create — a well-formed but uncataloged
+// event type is accepted (and takes effect), while a patch routing to a
+// destination that doesn't exist is rejected and leaves the stored trigger
+// unchanged.
 func TestSDKEventarcPatchValidation(t *testing.T) {
 	svc, cloud := newFullEventarcService(t)
 	ctx := context.Background()
@@ -207,14 +215,25 @@ func TestSDKEventarcPatchValidation(t *testing.T) {
 
 	name := parent() + "/triggers/patch-validate"
 
-	// A patch with an unknown event type is rejected.
-	badFilters := &eventarc.Trigger{
-		EventFilters: []*eventarc.EventFilter{{Attribute: "type", Value: "nope"}},
+	// A patch naming a well-formed but uncataloged event type is accepted,
+	// not rejected as "unknown" — Eventarc's event-type space is open-ended.
+	uncataloged := &eventarc.Trigger{
+		EventFilters: []*eventarc.EventFilter{{Attribute: "type", Value: "example.provider.event.v1"}},
 	}
 
-	_, err := svc.Projects.Locations.Triggers.Patch(name, badFilters).
-		UpdateMask("eventFilters").Context(ctx).Do()
-	wantGoogleAPIError(t, err, 400, "")
+	if _, err := svc.Projects.Locations.Triggers.Patch(name, uncataloged).
+		UpdateMask("eventFilters").Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch(uncataloged type): %v", err)
+	}
+
+	afterFilters, err := svc.Projects.Locations.Triggers.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get (after eventFilters patch): %v", err)
+	}
+
+	if len(afterFilters.EventFilters) != 1 || afterFilters.EventFilters[0].Value != "example.provider.event.v1" {
+		t.Fatalf("eventFilters = %+v, want the uncataloged type to have taken effect", afterFilters.EventFilters)
+	}
 
 	// A patch routing to a nonexistent Cloud Run service is rejected.
 	badDest := &eventarc.Trigger{
@@ -225,14 +244,10 @@ func TestSDKEventarcPatchValidation(t *testing.T) {
 		UpdateMask("destination").Context(ctx).Do()
 	wantGoogleAPIError(t, err, 404, "")
 
-	// Both rejected patches left the trigger exactly as created.
+	// The rejected destination patch left the trigger's destination as created.
 	got, err := svc.Projects.Locations.Triggers.Get(name).Context(ctx).Do()
 	if err != nil {
 		t.Fatalf("Get: %v", err)
-	}
-
-	if len(got.EventFilters) != 1 || got.EventFilters[0].Value != "google.cloud.storage.object.v1.finalized" {
-		t.Fatalf("eventFilters = %+v, want the original storage-finalized filter unchanged", got.EventFilters)
 	}
 
 	if got.Destination == nil || got.Destination.CloudRun == nil || got.Destination.CloudRun.Service != "live" {

--- a/server/gcp/eventarc/validate_test.go
+++ b/server/gcp/eventarc/validate_test.go
@@ -1,0 +1,260 @@
+package eventarc_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	eventarc "google.golang.org/api/eventarc/v1"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpprovider "github.com/stackshy/cloudemu/v2/providers/gcp"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+	crdriver "github.com/stackshy/cloudemu/v2/services/cloudrun/driver"
+	sdrv "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// newFullEventarcService boots a server with Eventarc, Cloud Functions and
+// Cloud Run all wired (mirroring DriversFrom / the standalone binary), so
+// destination-existence validation is exercised end-to-end.
+func newFullEventarcService(t *testing.T) (*eventarc.Service, *gcpprovider.Provider) {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.DriversFrom(cloud))
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := eventarc.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("eventarc.NewService: %v", err)
+	}
+
+	return svc, cloud
+}
+
+func wantGoogleAPIError(t *testing.T, err error, code int, contains string) {
+	t.Helper()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != code {
+		t.Fatalf("got %v, want a %d googleapi.Error", err, code)
+	}
+
+	if contains != "" && !strings.Contains(gerr.Message, contains) {
+		t.Fatalf("error message = %q, want it to contain %q", gerr.Message, contains)
+	}
+}
+
+// TestSDKEventarcMissingTypeFilter: an eventFilters set with no "type" filter
+// is a 400 INVALID_ARGUMENT, mirroring real Eventarc's admission check.
+func TestSDKEventarcMissingTypeFilter(t *testing.T) {
+	svc := newEventarcService(t)
+	ctx := context.Background()
+
+	trigger := &eventarc.Trigger{
+		EventFilters: []*eventarc.EventFilter{{Attribute: "source", Value: "my.app"}},
+		Destination:  &eventarc.Destination{CloudRun: &eventarc.CloudRun{Service: "svc"}},
+	}
+
+	_, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).TriggerId("no-type").Context(ctx).Do()
+	wantGoogleAPIError(t, err, 400, "type")
+}
+
+// TestSDKEventarcUnknownEventType: a "type" filter naming an event type
+// outside the catalog CloudEmu validates against is a 400 INVALID_ARGUMENT.
+func TestSDKEventarcUnknownEventType(t *testing.T) {
+	svc := newEventarcService(t)
+	ctx := context.Background()
+
+	trigger := &eventarc.Trigger{
+		EventFilters: []*eventarc.EventFilter{{Attribute: "type", Value: "not.a.real.event.type"}},
+		Destination:  &eventarc.Destination{CloudRun: &eventarc.CloudRun{Service: "svc"}},
+	}
+
+	_, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).TriggerId("bad-type").Context(ctx).Do()
+	wantGoogleAPIError(t, err, 400, "not a known Eventarc event type")
+}
+
+// TestSDKEventarcAuditLogRequiresServiceAndMethod: an audit-log trigger
+// (google.cloud.audit.log.v1.written) is rejected unless it also carries
+// serviceName and methodName filters pinning it to one API method; with both
+// present, it is created successfully.
+func TestSDKEventarcAuditLogRequiresServiceAndMethod(t *testing.T) {
+	svc := newEventarcService(t)
+	ctx := context.Background()
+
+	dest := &eventarc.Destination{CloudRun: &eventarc.CloudRun{Service: "svc"}}
+
+	cases := []struct {
+		name    string
+		filters []*eventarc.EventFilter
+		wantErr bool
+	}{
+		{
+			name:    "missing both",
+			filters: []*eventarc.EventFilter{{Attribute: "type", Value: "google.cloud.audit.log.v1.written"}},
+			wantErr: true,
+		},
+		{
+			name: "missing methodName",
+			filters: []*eventarc.EventFilter{
+				{Attribute: "type", Value: "google.cloud.audit.log.v1.written"},
+				{Attribute: "serviceName", Value: "storage.googleapis.com"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "both present",
+			filters: []*eventarc.EventFilter{
+				{Attribute: "type", Value: "google.cloud.audit.log.v1.written"},
+				{Attribute: "serviceName", Value: "storage.googleapis.com"},
+				{Attribute: "methodName", Value: "storage.objects.create"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for i, c := range cases {
+		trigger := &eventarc.Trigger{EventFilters: c.filters, Destination: dest}
+
+		_, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).
+			TriggerId("audit-" + string(rune('a'+i))).Context(ctx).Do()
+
+		if c.wantErr {
+			wantGoogleAPIError(t, err, 400, "")
+		} else if err != nil {
+			t.Fatalf("%s: Create: %v", c.name, err)
+		}
+	}
+}
+
+// TestSDKEventarcDestinationCloudRunNotFound: a trigger routing to a Cloud
+// Run service that doesn't exist is a 404 NOT_FOUND, not a silently-stored
+// dead route; once the service exists, the identical Create succeeds.
+func TestSDKEventarcDestinationCloudRunNotFound(t *testing.T) {
+	svc, cloud := newFullEventarcService(t)
+	ctx := context.Background()
+
+	trigger := &eventarc.Trigger{
+		EventFilters: []*eventarc.EventFilter{{Attribute: "type", Value: "google.cloud.storage.object.v1.finalized"}},
+		Destination:  &eventarc.Destination{CloudRun: &eventarc.CloudRun{Service: "ghost-run", Region: testLocation}},
+	}
+
+	_, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).TriggerId("dest-run").Context(ctx).Do()
+	wantGoogleAPIError(t, err, 404, "ghost-run")
+
+	if _, err := cloud.CloudRun.CreateService(ctx, crdriver.ServiceConfig{Name: "ghost-run", Location: testLocation}); err != nil {
+		t.Fatalf("CloudRun.CreateService: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).TriggerId("dest-run").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create after the destination exists: %v", err)
+	}
+}
+
+// TestSDKEventarcDestinationCloudFunctionNotFound is the Cloud Function analog
+// of TestSDKEventarcDestinationCloudRunNotFound.
+func TestSDKEventarcDestinationCloudFunctionNotFound(t *testing.T) {
+	svc, cloud := newFullEventarcService(t)
+	ctx := context.Background()
+
+	trigger := &eventarc.Trigger{
+		EventFilters: []*eventarc.EventFilter{{Attribute: "type", Value: "google.cloud.storage.object.v1.finalized"}},
+		Destination:  &eventarc.Destination{CloudFunction: "ghost-fn"},
+	}
+
+	_, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).TriggerId("dest-fn").Context(ctx).Do()
+	wantGoogleAPIError(t, err, 404, "ghost-fn")
+
+	if _, err := cloud.CloudFunctions.CreateFunction(ctx, sdrv.FunctionConfig{Name: "ghost-fn"}); err != nil {
+		t.Fatalf("CloudFunctions.CreateFunction: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).TriggerId("dest-fn").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create after the destination exists: %v", err)
+	}
+}
+
+// TestSDKEventarcPatchValidation: patching eventFilters or destination goes
+// through the same validation as Create, and a rejected patch leaves the
+// stored trigger unchanged.
+func TestSDKEventarcPatchValidation(t *testing.T) {
+	svc, cloud := newFullEventarcService(t)
+	ctx := context.Background()
+
+	if _, err := cloud.CloudRun.CreateService(ctx, crdriver.ServiceConfig{Name: "live", Location: testLocation}); err != nil {
+		t.Fatalf("CloudRun.CreateService: %v", err)
+	}
+
+	trigger := &eventarc.Trigger{
+		EventFilters: []*eventarc.EventFilter{{Attribute: "type", Value: "google.cloud.storage.object.v1.finalized"}},
+		Destination:  &eventarc.Destination{CloudRun: &eventarc.CloudRun{Service: "live", Region: testLocation}},
+	}
+
+	if _, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).
+		TriggerId("patch-validate").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	name := parent() + "/triggers/patch-validate"
+
+	// A patch with an unknown event type is rejected.
+	badFilters := &eventarc.Trigger{
+		EventFilters: []*eventarc.EventFilter{{Attribute: "type", Value: "nope"}},
+	}
+
+	_, err := svc.Projects.Locations.Triggers.Patch(name, badFilters).
+		UpdateMask("eventFilters").Context(ctx).Do()
+	wantGoogleAPIError(t, err, 400, "")
+
+	// A patch routing to a nonexistent Cloud Run service is rejected.
+	badDest := &eventarc.Trigger{
+		Destination: &eventarc.Destination{CloudRun: &eventarc.CloudRun{Service: "ghost", Region: testLocation}},
+	}
+
+	_, err = svc.Projects.Locations.Triggers.Patch(name, badDest).
+		UpdateMask("destination").Context(ctx).Do()
+	wantGoogleAPIError(t, err, 404, "")
+
+	// Both rejected patches left the trigger exactly as created.
+	got, err := svc.Projects.Locations.Triggers.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if len(got.EventFilters) != 1 || got.EventFilters[0].Value != "google.cloud.storage.object.v1.finalized" {
+		t.Fatalf("eventFilters = %+v, want the original storage-finalized filter unchanged", got.EventFilters)
+	}
+
+	if got.Destination == nil || got.Destination.CloudRun == nil || got.Destination.CloudRun.Service != "live" {
+		t.Fatalf("destination = %+v, want the original service \"live\" unchanged", got.Destination)
+	}
+}
+
+// TestSDKEventarcWorkflowDestinationUnvalidated: a Workflow destination isn't
+// backed by a driver, so it is accepted unchecked even on the full server —
+// documenting the deliberate scope limit rather than silently 404ing every
+// workflow trigger.
+func TestSDKEventarcWorkflowDestinationUnvalidated(t *testing.T) {
+	svc, _ := newFullEventarcService(t)
+	ctx := context.Background()
+
+	trigger := &eventarc.Trigger{
+		EventFilters: []*eventarc.EventFilter{{Attribute: "type", Value: "google.cloud.storage.object.v1.finalized"}},
+		Destination:  &eventarc.Destination{Workflow: "projects/demo/locations/us-central1/workflows/ghost"},
+	}
+
+	if _, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).
+		TriggerId("wf-dest").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create with an unmodeled Workflow destination: %v", err)
+	}
+}

--- a/server/gcp/fullserver_test.go
+++ b/server/gcp/fullserver_test.go
@@ -76,10 +76,19 @@ func TestFullServerLROOperationPolling(t *testing.T) {
 		t.Fatalf("unknown op poll: code=%d body=%s (want 404)", code, body)
 	}
 
-	// eventarc.
-	do(t, ts, http.MethodPost,
+	// eventarc: the trigger below routes to Cloud Run service "s", which
+	// destination validation resolves against, so create it first.
+	if code, _ := do(t, ts, http.MethodPost,
+		"/v2/projects/demo/locations/us-central1/services?serviceId=s", `{}`); code != http.StatusOK {
+		t.Fatalf("Cloud Run service create: %d", code)
+	}
+
+	if code, body := do(t, ts, http.MethodPost,
 		"/v1/projects/demo/locations/us-central1/triggers?triggerId=t1",
-		`{"eventFilters":[{"attribute":"type","value":"x"}],"destination":{"cloudRun":{"service":"s","region":"us-central1"}}}`)
+		`{"eventFilters":[{"attribute":"type","value":"google.cloud.storage.object.v1.finalized"}],`+
+			`"destination":{"cloudRun":{"service":"s","region":"us-central1"}}}`); code != http.StatusOK {
+		t.Fatalf("eventarc create: code=%d body=%s", code, body)
+	}
 
 	if code, body := do(t, ts, http.MethodGet,
 		"/v1/projects/demo/locations/us-central1/operations/op-t1", ""); code != http.StatusOK || !strings.Contains(body, `"done":true`) {

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -345,6 +345,20 @@ func New(d Drivers) *server.Server {
 	if d.Eventarc != nil {
 		eaH := eventarc.New(d.Eventarc)
 		eaH.SetOperationRegistry(opsReg)
+
+		// Destination validation: a trigger create/patch is rejected when it
+		// names a Cloud Function / Cloud Run service that doesn't exist,
+		// mirroring real Eventarc's admission check. Only wired when the peer
+		// service is present, so a server that omits one keeps accepting that
+		// destination kind unchecked.
+		if d.CloudFunctions != nil {
+			eaH.SetFunctionResolver(d.CloudFunctions)
+		}
+
+		if d.CloudRun != nil {
+			eaH.SetCloudRunResolver(d.CloudRun)
+		}
+
 		srv.Register(eaH)
 	}
 


### PR DESCRIPTION
## Summary

Deepens GCP Eventarc trigger lifecycle toward real-cloud admission-time validation.

Gap list (present vs missing before this PR):
- Present: trigger CRUD (Create/Get/List/Patch/Delete) with Operation (LRO) envelopes, pagination, uid/etag/transport synthesis, dup-name AlreadyExists, and eventFilter-matched delivery to Cloud Function / Cloud Run destinations (existing dispatch.go seam) — all left untouched.
- Missing (now added): eventFilters had no validation at all — a trigger with no `type` filter, an unknown event type, or an audit-log filter missing `serviceName`/`methodName` was silently stored. A destination was only checked for being non-nil, so an all-empty destination object and a destination naming a nonexistent Cloud Function / Cloud Run service both stored as dead routes.

What's added:
- `validateEventFilters`: requires a non-empty `type` filter naming a known event type (curated catalog: Pub/Sub messagePublished, Cloud Audit Log written, Storage finalized/deleted/archived/metadataUpdated, Firestore created/updated/deleted/written); an audit-log trigger additionally requires `serviceName` and `methodName` filters. Applied on Create and on Patch when `eventFilters` is in the updateMask.
- Destination existence validation: `FunctionResolver`/`CloudRunResolver` (wired from `d.CloudFunctions`/`d.CloudRun` in `server/gcp/gcp.go`) resolve a trigger's destination on Create/Patch; a destination naming a Cloud Function or Cloud Run service that doesn't exist is rejected with NOT_FOUND. Left unwired (nil), the check is skipped gracefully — a standalone server without the peer service keeps accepting that destination kind, unchanged from before.
- `destinationTarget` now also rejects an all-empty destination object (no cloudRun/cloudFunction/workflow set), closing a gap in the existing "destination is required" check.
- Workflow destinations remain unvalidated (no workflows driver modeled) — documented as a deliberate scope limit with a regression test.

Deferred (out of scope for this PR): channels/channelConnections (partner events), providers.list (event-type catalog surface), workflow/GKE destination validation (no backing driver), CMEK.

## Test plan
- New `server/gcp/eventarc/validate_test.go`: missing/unknown `type` filter, audit-log serviceName/methodName requirement, Cloud Run / Cloud Function destination-not-found (then success once created), patch validation leaves the stored trigger unchanged on rejection, Workflow destination passes unvalidated.
- Updated `gapic_lro_test.go` / `sdk_roundtrip_test.go` / `fullserver_test.go` to satisfy the new validation (pre-create the referenced Cloud Run service, add a `type` filter) where they previously relied on the old lax behavior.
- `go build ./...`, `go test ./providers/gcp/... ./server/gcp/... ./persist/... ./compat/gcp/... -race`, `golangci-lint run ./server/gcp/eventarc/... ./server/gcp/...` all clean.
- `go generate ./...` produced no `docs/coverage` diff (no driver interface change).