### PR TITLE
feat(ecr): wire StartLifecyclePolicyPreview / GetLifecyclePolicyPreview

### DIFF
--- a/providers/aws/ecr/ecr.go
+++ b/providers/aws/ecr/ecr.go
@@ -466,7 +466,50 @@ func (m *Mock) EvaluateLifecyclePolicy(_ context.Context, repository string) ([]
 		return []string{}, nil
 	}
 
-	return evaluateRules(rd, m.opts.Clock.Now()), nil
+	results := previewRules(rd, rd.policy, m.opts.Clock.Now())
+	digests := make([]string, 0, len(results))
+
+	for _, res := range results {
+		digests = append(digests, res.Digest)
+	}
+
+	return digests, nil
+}
+
+// PreviewLifecyclePolicy evaluates a lifecycle policy against the
+// repository's current images and returns full per-image detail (digest,
+// tags, push time, and the priority of the rule that matched) — the data
+// ECR's GetLifecyclePolicyPreview needs. When override is non-nil it is
+// evaluated instead of (without replacing) the repository's stored policy,
+// matching StartLifecyclePolicyPreview's optional lifecyclePolicyText
+// override.
+//
+// AWS-specific: StartLifecyclePolicyPreview/GetLifecyclePolicyPreview have no
+// equivalent in Azure ACR or GCP Artifact Registry, so this is not part of the
+// shared ContainerRegistry driver interface — the ECR wire handler reaches it
+// via type assertion, the same pattern used for PutImageTagMutability and
+// PutImageScanningConfiguration above.
+func (m *Mock) PreviewLifecyclePolicy(
+	_ context.Context, repository string, override *driver.LifecyclePolicy,
+) ([]driver.LifecyclePreviewResult, string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, "", apiErrf(excRepositoryNotFound, "repository %q not found", repository)
+	}
+
+	policy := rd.policy
+	if override != nil {
+		policy = override
+	}
+
+	if policy == nil {
+		return nil, "", apiErrf(excLifecyclePolicyNotFound, "no lifecycle policy for repository %q", repository)
+	}
+
+	return previewRules(rd, policy, m.opts.Clock.Now()), policy.Document, nil
 }
 
 // StartImageScan starts a vulnerability scan on an image in an ECR repository.
@@ -628,34 +671,49 @@ func generateScanResult(repository, digest string, now time.Time) *driver.ScanRe
 	}
 }
 
-// evaluateRules applies lifecycle rules sorted by priority and returns digests to expire.
-func evaluateRules(rd *repoData, now time.Time) []string {
-	rules := rd.policy.Rules
-	sorted := make([]driver.LifecycleRule, len(rules))
-	copy(sorted, rules)
+// previewRules evaluates policy's rules in priority order against rd's images
+// and returns full detail for every image an "expire" action would remove.
+// Once an image matches a rule it is excluded from the pool considered by
+// lower-priority rules, matching real ECR: each image is expired by at most
+// one rule — the one with the lowest rulePriority that matches it — so a
+// broad low-priority rule never re-claims an image a narrower high-priority
+// rule already spared or expired.
+func previewRules(rd *repoData, policy *driver.LifecyclePolicy, now time.Time) []driver.LifecyclePreviewResult {
+	rules := make([]driver.LifecycleRule, len(policy.Rules))
+	copy(rules, policy.Rules)
 
-	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Priority < sorted[j].Priority })
+	sort.Slice(rules, func(i, j int) bool { return rules[i].Priority < rules[j].Priority })
 
-	expired := make(map[string]bool)
+	claimed := make(map[string]bool)
 
-	for idx := range sorted {
-		digests := evaluateSingleRule(rd, &sorted[idx], now)
-		for _, d := range digests {
-			expired[d] = true
+	var results []driver.LifecyclePreviewResult
+
+	for idx := range rules {
+		rule := &rules[idx]
+		for _, digest := range matchingDigestsForRule(rd, rule, claimed, now) {
+			claimed[digest] = true
+
+			img, ok := rd.images.Get(digest)
+			if !ok {
+				continue
+			}
+
+			results = append(results, driver.LifecyclePreviewResult{
+				Digest:              digest,
+				Tags:                append([]string(nil), img.detail.Tags...),
+				PushedAt:            img.detail.PushedAt,
+				AppliedRulePriority: rule.Priority,
+			})
 		}
 	}
 
-	result := make([]string, 0, len(expired))
-	for d := range expired {
-		result = append(result, d)
-	}
-
-	return result
+	return results
 }
 
-// evaluateSingleRule evaluates one lifecycle rule and returns matching digests.
-func evaluateSingleRule(rd *repoData, rule *driver.LifecycleRule, now time.Time) []string {
-	images := collectMatchingImages(rd, rule)
+// matchingDigestsForRule returns the digests a single rule would expire,
+// excluding any digest already claimed by a higher-priority rule.
+func matchingDigestsForRule(rd *repoData, rule *driver.LifecycleRule, claimed map[string]bool, now time.Time) []string {
+	images := collectMatchingImages(rd, rule, claimed)
 
 	sort.Slice(images, func(i, j int) bool { return images[i].detail.PushedAt < images[j].detail.PushedAt })
 
@@ -669,13 +727,18 @@ func evaluateSingleRule(rd *repoData, rule *driver.LifecycleRule, now time.Time)
 	}
 }
 
-// collectMatchingImages returns images matching the rule's tag status and pattern.
-func collectMatchingImages(rd *repoData, rule *driver.LifecycleRule) []*imageData {
+// collectMatchingImages returns images matching the rule's tag status and
+// pattern, excluding any digest already claimed by a higher-priority rule.
+func collectMatchingImages(rd *repoData, rule *driver.LifecycleRule, claimed map[string]bool) []*imageData {
 	all := rd.images.All()
 
 	var matched []*imageData
 
-	for _, img := range all {
+	for digest, img := range all {
+		if claimed[digest] {
+			continue
+		}
+
 		if matchesTagRule(img, rule) {
 			matched = append(matched, img)
 		}

--- a/providers/aws/ecr/ecr_test.go
+++ b/providers/aws/ecr/ecr_test.go
@@ -711,6 +711,106 @@ func TestLifecyclePolicyNoPolicy(t *testing.T) {
 	assert.Equal(t, 0, len(expired))
 }
 
+// TestPreviewLifecyclePolicy exercises PreviewLifecyclePolicy's detail beyond
+// what EvaluateLifecyclePolicy exposes: which rule matched each expiring
+// image, and that a higher-priority rule's matches are excluded from a
+// lower-priority rule's counting pool rather than double-counted.
+func TestPreviewLifecyclePolicy(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "preview-repo")
+
+	// Priority 1 matches "prod-*" tags and keeps only the newest one, so it
+	// expires prod-1 and prod-2 (both older than prod-3). Priority 2 matches
+	// everything and keeps 3. Without excluding rule 1's matches from rule 2's
+	// pool, rule 2 would see all 4 images (3 prod-* plus "other") and
+	// additionally re-expire prod-1 or prod-2; with exclusion it sees only the
+	// 2 remaining images (prod-3, other) and expires nothing more, since 2 is
+	// not more than 3.
+	policy := driver.LifecyclePolicy{
+		Rules: []driver.LifecycleRule{
+			{
+				Priority:   1,
+				TagStatus:  "tagged",
+				TagPattern: "prod-*",
+				CountType:  "imageCountMoreThan",
+				CountValue: 1,
+				Action:     "expire",
+			},
+			{
+				Priority:   2,
+				TagStatus:  "any",
+				CountType:  "imageCountMoreThan",
+				CountValue: 3,
+				Action:     "expire",
+			},
+		},
+	}
+
+	require.NoError(t, m.PutLifecyclePolicy(ctx, "preview-repo", policy))
+
+	prod1 := pushTestImage(t, m, "preview-repo", "prod-1")
+	fc.Advance(time.Minute)
+	prod2 := pushTestImage(t, m, "preview-repo", "prod-2")
+	fc.Advance(time.Minute)
+	pushTestImage(t, m, "preview-repo", "prod-3")
+	fc.Advance(time.Minute)
+	pushTestImage(t, m, "preview-repo", "other")
+
+	results, text, err := m.PreviewLifecyclePolicy(ctx, "preview-repo", nil)
+	require.NoError(t, err)
+	assert.Empty(t, text) // no Document was set via PutLifecyclePolicy's driver.LifecyclePolicy directly
+
+	require.Len(t, results, 2)
+
+	byDigest := map[string]driver.LifecyclePreviewResult{}
+	for _, r := range results {
+		byDigest[r.Digest] = r
+	}
+
+	got1, ok1 := byDigest[prod1.Digest]
+	require.True(t, ok1, "prod-1 should be in the expiring set")
+	assert.Equal(t, []string{"prod-1"}, got1.Tags)
+	assert.Equal(t, 1, got1.AppliedRulePriority)
+
+	got2, ok2 := byDigest[prod2.Digest]
+	require.True(t, ok2, "prod-2 should be in the expiring set")
+	assert.Equal(t, []string{"prod-2"}, got2.Tags)
+	assert.Equal(t, 1, got2.AppliedRulePriority)
+
+	t.Run("override policy does not persist", func(t *testing.T) {
+		override := driver.LifecyclePolicy{
+			Rules: []driver.LifecycleRule{
+				{Priority: 1, TagStatus: "any", CountType: "imageCountMoreThan", CountValue: 0, Action: "expire"},
+			},
+		}
+
+		results, _, err := m.PreviewLifecyclePolicy(ctx, "preview-repo", &override)
+		require.NoError(t, err)
+		assert.Len(t, results, 4) // every image expires under the override's countValue 0
+
+		// The stored policy is untouched: re-running without an override still
+		// reports just the two prod-* excess images.
+		results, _, err = m.PreviewLifecyclePolicy(ctx, "preview-repo", nil)
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+	})
+
+	t.Run("no policy and no override", func(t *testing.T) {
+		createTestRepo(t, m, "preview-no-policy-repo")
+
+		_, _, err := m.PreviewLifecyclePolicy(ctx, "preview-no-policy-repo", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no lifecycle policy")
+	})
+
+	t.Run("missing repository", func(t *testing.T) {
+		_, _, err := m.PreviewLifecyclePolicy(ctx, "ghost-repo", nil)
+		require.Error(t, err)
+	})
+}
+
 func TestImageScan(t *testing.T) {
 	m, _ := newTestMock()
 	ctx := context.Background()

--- a/providers/aws/ecr/errors.go
+++ b/providers/aws/ecr/errors.go
@@ -13,6 +13,7 @@ const (
 	excImageNotFound            = "ImageNotFoundException"
 	excScanNotFound             = "ScanNotFoundException"
 	excRepositoryPolicyNotFound = "RepositoryPolicyNotFoundException"
+	excLifecyclePolicyNotFound  = "LifecyclePolicyNotFoundException"
 )
 
 // apiError pairs a canonical cloudemu error with the precise ECR exception name

--- a/server/aws/ecr/handler.go
+++ b/server/aws/ecr/handler.go
@@ -12,6 +12,7 @@ import (
 	stderrors "errors"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -32,11 +33,20 @@ type authTokenProvider interface {
 // Handler serves ECR JSON-RPC requests against a ContainerRegistry driver.
 type Handler struct {
 	registry crdriver.ContainerRegistry
+
+	// previewMu guards previews, the Start/GetLifecyclePolicyPreview result
+	// cache. Real ECR splits that evaluation into an asynchronous Start call
+	// and a polled Get call; the emulator evaluates synchronously in Start and
+	// Get simply replays the cached result, keyed by repository name. This is
+	// wire-flow state (an artifact of the two-call protocol), not resource
+	// state, so it lives here rather than in the provider/persist layer.
+	previewMu sync.Mutex
+	previews  map[string]lifecyclePreviewCache
 }
 
 // New returns an ECR handler backed by reg.
 func New(reg crdriver.ContainerRegistry) *Handler {
-	return &Handler{registry: reg}
+	return &Handler{registry: reg, previews: make(map[string]lifecyclePreviewCache)}
 }
 
 // Matches returns true for ECR-shaped requests, identified by an X-Amz-Target
@@ -45,11 +55,24 @@ func (*Handler) Matches(r *http.Request) bool {
 	return strings.HasPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
 }
 
-// ServeHTTP dispatches ECR operations based on X-Amz-Target.
-//
-//nolint:gocyclo // flat dispatch: one branch per ECR operation
+// ServeHTTP dispatches ECR operations based on X-Amz-Target. The dispatch is
+// split across route* methods, grouped by area (repositories, images, tags,
+// lifecycle policies, scanning), so the operation count can grow without
+// tripping the function-length lint limit.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	switch strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix) {
+	op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+
+	if h.routeRepositories(w, r, op) || h.routeImages(w, r, op) ||
+		h.routeTags(w, r, op) || h.routeLifecycle(w, r, op) || h.routeScanning(w, r, op) {
+		return
+	}
+
+	wire.WriteJSONError(w, http.StatusBadRequest, "UnknownOperationException", "unknown ECR operation: "+op)
+}
+
+// routeRepositories dispatches repository-management operations.
+func (h *Handler) routeRepositories(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
 	case "CreateRepository":
 		h.createRepository(w, r)
 	case "DescribeRepositories":
@@ -60,6 +83,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.putImageTagMutability(w, r)
 	case "PutImageScanningConfiguration":
 		h.putImageScanningConfiguration(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// routeImages dispatches image push/list/describe/delete operations.
+func (h *Handler) routeImages(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
 	case "PutImage":
 		h.putImage(w, r)
 	case "ListImages":
@@ -70,8 +103,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.batchDeleteImage(w, r)
 	case "BatchGetImage":
 		h.batchGetImage(w, r)
-	case "GetAuthorizationToken":
-		h.getAuthorizationToken(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// routeTags dispatches resource tagging and repository-policy operations.
+func (h *Handler) routeTags(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
 	case "TagResource":
 		h.tagResource(w, r)
 	case "UntagResource":
@@ -84,21 +125,47 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.getRepositoryPolicy(w, r)
 	case "DeleteRepositoryPolicy":
 		h.deleteRepositoryPolicy(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// routeLifecycle dispatches lifecycle-policy CRUD and preview operations.
+func (h *Handler) routeLifecycle(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
 	case "PutLifecyclePolicy":
 		h.putLifecyclePolicy(w, r)
 	case "GetLifecyclePolicy":
 		h.getLifecyclePolicy(w, r)
 	case "DeleteLifecyclePolicy":
 		h.deleteLifecyclePolicy(w, r)
+	case "StartLifecyclePolicyPreview":
+		h.startLifecyclePolicyPreview(w, r)
+	case "GetLifecyclePolicyPreview":
+		h.getLifecyclePolicyPreview(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// routeScanning dispatches image-scanning and registry-auth operations.
+func (h *Handler) routeScanning(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "GetAuthorizationToken":
+		h.getAuthorizationToken(w, r)
 	case "StartImageScan":
 		h.startImageScan(w, r)
 	case "DescribeImageScanFindings":
 		h.describeImageScanFindings(w, r)
 	default:
-		op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
-		wire.WriteJSONError(w, http.StatusBadRequest,
-			"UnknownOperationException", "unknown ECR operation: "+op)
+		return false
 	}
+
+	return true
 }
 
 // getAuthorizationToken returns a docker-login credential. The response shape

--- a/server/aws/ecr/lifecycle_preview.go
+++ b/server/aws/ecr/lifecycle_preview.go
@@ -1,0 +1,141 @@
+package ecr
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+// lifecyclePreviewStatus is the only status the emulator ever reports: real
+// ECR evaluates a preview asynchronously (IN_PROGRESS -> COMPLETE/FAILED),
+// but the emulator computes it synchronously inside StartLifecyclePolicyPreview,
+// so it is always immediately COMPLETE.
+const lifecyclePreviewStatus = "COMPLETE"
+
+// lifecyclePreviewer is the AWS-specific StartLifecyclePolicyPreview/
+// GetLifecyclePolicyPreview surface. Azure ACR and GCP Artifact Registry have
+// no lifecycle-preview API, so this is not part of the portable
+// ContainerRegistry driver; the handler reaches it via type assertion, the
+// same pattern used for PutImageTagMutability and PutImageScanningConfiguration.
+type lifecyclePreviewer interface {
+	PreviewLifecyclePolicy(
+		ctx context.Context, repository string, override *crdriver.LifecyclePolicy,
+	) ([]crdriver.LifecyclePreviewResult, string, error)
+}
+
+// lifecyclePreviewCache holds the synchronously computed result of the most
+// recent StartLifecyclePolicyPreview call for one repository, replayed by
+// GetLifecyclePolicyPreview.
+type lifecyclePreviewCache struct {
+	text    string
+	results []crdriver.LifecyclePreviewResult
+}
+
+func (h *Handler) startLifecyclePolicyPreview(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		RepositoryName      string `json:"repositoryName"`
+		LifecyclePolicyText string `json:"lifecyclePolicyText"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	previewer, ok := h.registry.(lifecyclePreviewer)
+	if !ok {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ServerException", "lifecycle policy preview not supported")
+		return
+	}
+
+	var override *crdriver.LifecyclePolicy
+
+	if req.LifecyclePolicyText != "" {
+		parsed, err := parseLifecyclePolicyText(req.LifecyclePolicyText)
+		if err != nil {
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterException", err.Error())
+			return
+		}
+
+		override = &parsed
+	}
+
+	results, text, err := previewer.PreviewLifecyclePolicy(r.Context(), req.RepositoryName, override)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	h.previewMu.Lock()
+	h.previews[req.RepositoryName] = lifecyclePreviewCache{text: text, results: results}
+	h.previewMu.Unlock()
+
+	resp := map[string]any{
+		"repositoryName":      req.RepositoryName,
+		"lifecyclePolicyText": text,
+		"status":              lifecyclePreviewStatus,
+	}
+
+	if repo, err := h.registry.GetRepository(r.Context(), req.RepositoryName); err == nil {
+		resp["registryId"] = repo.RegistryID
+	}
+
+	wire.WriteJSON(w, resp)
+}
+
+func (h *Handler) getLifecyclePolicyPreview(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		RepositoryName string `json:"repositoryName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	// A missing repository always takes precedence over a missing/stale cache
+	// entry, so a repository deleted (and not re-previewed) since Start reports
+	// RepositoryNotFoundException rather than replaying a stale preview.
+	repo, err := h.registry.GetRepository(r.Context(), req.RepositoryName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	h.previewMu.Lock()
+	cache, ok := h.previews[req.RepositoryName]
+	h.previewMu.Unlock()
+
+	if !ok {
+		wire.WriteJSONError(w, http.StatusBadRequest, "LifecyclePolicyPreviewNotFoundException",
+			"no lifecycle policy preview found for repository "+req.RepositoryName+
+				"; call StartLifecyclePolicyPreview first")
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"repositoryName":      req.RepositoryName,
+		"registryId":          repo.RegistryID,
+		"lifecyclePolicyText": cache.text,
+		"status":              lifecyclePreviewStatus,
+		"previewResults":      toLifecyclePreviewResultsJSON(cache.results),
+		"summary":             map[string]any{"expiringImageTotalCount": len(cache.results)},
+	})
+}
+
+func toLifecyclePreviewResultsJSON(results []crdriver.LifecyclePreviewResult) []map[string]any {
+	out := make([]map[string]any, 0, len(results))
+
+	for _, res := range results {
+		out = append(out, map[string]any{
+			"imageDigest":         res.Digest,
+			"imageTags":           res.Tags,
+			"imagePushedAt":       epochSeconds(res.PushedAt),
+			"appliedRulePriority": res.AppliedRulePriority,
+			"action":              map[string]any{"type": "EXPIRE"},
+		})
+	}
+
+	return out
+}

--- a/server/aws/ecr/lifecycle_preview_test.go
+++ b/server/aws/ecr/lifecycle_preview_test.go
@@ -1,0 +1,337 @@
+package ecr_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsecr "github.com/aws/aws-sdk-go-v2/service/ecr"
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+
+	cloudemu "github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newECRClientWithClock is newECRClient with a caller-controlled clock, so
+// age-based lifecycle rules (sinceImagePushed) can be tested deterministically.
+func newECRClientWithClock(t *testing.T, clock config.Clock) *awsecr.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS(config.WithClock(clock))
+	srv := awsserver.New(awsserver.Drivers{ECR: cloud.ECR})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return awsecr.NewFromConfig(cfg, func(o *awsecr.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+}
+
+// countRulePolicyDoc keeps only the 2 most recently pushed tagged images.
+const countRulePolicyDoc = `{"rules":[{"rulePriority":1,"description":"keep 2",` +
+	`"selection":{"tagStatus":"tagged","countType":"imageCountMoreThan","countNumber":2},` +
+	`"action":{"type":"expire"}}]}`
+
+// TestSDKECRLifecyclePolicyPreviewCountRule exercises the real end-to-end flow:
+// PutLifecyclePolicy with a count rule, push more images than the rule keeps,
+// then StartLifecyclePolicyPreview + GetLifecyclePolicyPreview must report the
+// oldest excess image as expiring, with its digest, tags, and the priority of
+// the rule that matched it.
+func TestSDKECRLifecyclePolicyPreviewCountRule(t *testing.T) {
+	// A FakeClock and an advance between each push give the 3 images distinct,
+	// ordered PushedAt timestamps, so which one is "oldest" is unambiguous
+	// (real-clock pushes can land in the same second and tie).
+	fc := config.NewFakeClock(time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC))
+	client := newECRClientWithClock(t, fc)
+	ctx := context.Background()
+
+	mustCreateRepo(ctx, t, client, "preview-count-repo")
+
+	if _, err := client.PutLifecyclePolicy(ctx, &awsecr.PutLifecyclePolicyInput{
+		RepositoryName:      aws.String("preview-count-repo"),
+		LifecyclePolicyText: aws.String(countRulePolicyDoc),
+	}); err != nil {
+		t.Fatalf("PutLifecyclePolicy: %v", err)
+	}
+
+	oldest := mustPutImage(ctx, t, client, "preview-count-repo", sampleManifest+"v1", "v1")
+	fc.Advance(time.Minute)
+	mustPutImage(ctx, t, client, "preview-count-repo", sampleManifest+"v2", "v2")
+	fc.Advance(time.Minute)
+	mustPutImage(ctx, t, client, "preview-count-repo", sampleManifest+"v3", "v3")
+
+	start, err := client.StartLifecyclePolicyPreview(ctx, &awsecr.StartLifecyclePolicyPreviewInput{
+		RepositoryName: aws.String("preview-count-repo"),
+	})
+	if err != nil {
+		t.Fatalf("StartLifecyclePolicyPreview: %v", err)
+	}
+
+	if start.Status != ecrtypes.LifecyclePolicyPreviewStatusComplete {
+		t.Fatalf("Start status = %v, want COMPLETE", start.Status)
+	}
+
+	got, err := client.GetLifecyclePolicyPreview(ctx, &awsecr.GetLifecyclePolicyPreviewInput{
+		RepositoryName: aws.String("preview-count-repo"),
+	})
+	if err != nil {
+		t.Fatalf("GetLifecyclePolicyPreview: %v", err)
+	}
+
+	if got.Status != ecrtypes.LifecyclePolicyPreviewStatusComplete {
+		t.Fatalf("Get status = %v, want COMPLETE", got.Status)
+	}
+
+	if aws.ToInt32(got.Summary.ExpiringImageTotalCount) != 1 {
+		t.Fatalf("expiringImageTotalCount = %d, want 1", aws.ToInt32(got.Summary.ExpiringImageTotalCount))
+	}
+
+	if len(got.PreviewResults) != 1 {
+		t.Fatalf("previewResults = %d entries, want 1", len(got.PreviewResults))
+	}
+
+	result := got.PreviewResults[0]
+
+	if aws.ToString(result.ImageDigest) != aws.ToString(oldest.Image.ImageId.ImageDigest) {
+		t.Fatalf("expiring digest = %s, want the oldest image %s",
+			aws.ToString(result.ImageDigest), aws.ToString(oldest.Image.ImageId.ImageDigest))
+	}
+
+	if len(result.ImageTags) != 1 || result.ImageTags[0] != "v1" {
+		t.Fatalf("expiring imageTags = %v, want [v1]", result.ImageTags)
+	}
+
+	if aws.ToInt32(result.AppliedRulePriority) != 1 {
+		t.Fatalf("appliedRulePriority = %d, want 1", aws.ToInt32(result.AppliedRulePriority))
+	}
+
+	if result.Action == nil || result.Action.Type != ecrtypes.ImageActionTypeExpire {
+		t.Fatalf("action = %v, want EXPIRE", result.Action)
+	}
+}
+
+// TestSDKECRLifecyclePolicyPreviewAgeRule exercises a sinceImagePushed rule on
+// a FakeClock: images pushed more than the threshold ago must be reported as
+// expiring; a recently pushed image must not.
+func TestSDKECRLifecyclePolicyPreviewAgeRule(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC))
+	client := newECRClientWithClock(t, fc)
+	ctx := context.Background()
+
+	mustCreateRepo(ctx, t, client, "preview-age-repo")
+
+	const agePolicyDoc = `{"rules":[{"rulePriority":1,"description":"expire old",` +
+		`"selection":{"tagStatus":"any","countType":"sinceImagePushed","countNumber":30},` +
+		`"action":{"type":"expire"}}]}`
+
+	if _, err := client.PutLifecyclePolicy(ctx, &awsecr.PutLifecyclePolicyInput{
+		RepositoryName:      aws.String("preview-age-repo"),
+		LifecyclePolicyText: aws.String(agePolicyDoc),
+	}); err != nil {
+		t.Fatalf("PutLifecyclePolicy: %v", err)
+	}
+
+	mustPutImage(ctx, t, client, "preview-age-repo", sampleManifest+"old", "old")
+	fc.Advance(31 * 24 * time.Hour)
+	mustPutImage(ctx, t, client, "preview-age-repo", sampleManifest+"new", "new")
+
+	if _, err := client.StartLifecyclePolicyPreview(ctx, &awsecr.StartLifecyclePolicyPreviewInput{
+		RepositoryName: aws.String("preview-age-repo"),
+	}); err != nil {
+		t.Fatalf("StartLifecyclePolicyPreview: %v", err)
+	}
+
+	got, err := client.GetLifecyclePolicyPreview(ctx, &awsecr.GetLifecyclePolicyPreviewInput{
+		RepositoryName: aws.String("preview-age-repo"),
+	})
+	if err != nil {
+		t.Fatalf("GetLifecyclePolicyPreview: %v", err)
+	}
+
+	if len(got.PreviewResults) != 1 {
+		t.Fatalf("previewResults = %d entries, want 1", len(got.PreviewResults))
+	}
+
+	if got.PreviewResults[0].ImageTags[0] != "old" {
+		t.Fatalf("expiring image tag = %v, want [old]", got.PreviewResults[0].ImageTags)
+	}
+}
+
+// TestSDKECRLifecyclePolicyPreviewOverride exercises StartLifecyclePolicyPreview's
+// optional lifecyclePolicyText: a repository with NO stored policy can still be
+// previewed by supplying an ad-hoc policy, and doing so does not persist it (a
+// subsequent GetLifecyclePolicy still reports LifecyclePolicyNotFoundException).
+func TestSDKECRLifecyclePolicyPreviewOverride(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	mustCreateRepo(ctx, t, client, "preview-override-repo")
+
+	mustPutImage(ctx, t, client, "preview-override-repo", sampleManifest+"a", "a")
+	mustPutImage(ctx, t, client, "preview-override-repo", sampleManifest+"b", "b")
+	mustPutImage(ctx, t, client, "preview-override-repo", sampleManifest+"c", "c")
+
+	start, err := client.StartLifecyclePolicyPreview(ctx, &awsecr.StartLifecyclePolicyPreviewInput{
+		RepositoryName:      aws.String("preview-override-repo"),
+		LifecyclePolicyText: aws.String(countRulePolicyDoc),
+	})
+	if err != nil {
+		t.Fatalf("StartLifecyclePolicyPreview with override: %v", err)
+	}
+
+	if aws.ToString(start.LifecyclePolicyText) != countRulePolicyDoc {
+		t.Fatalf("Start echoed lifecyclePolicyText = %q, want the override", aws.ToString(start.LifecyclePolicyText))
+	}
+
+	got, err := client.GetLifecyclePolicyPreview(ctx, &awsecr.GetLifecyclePolicyPreviewInput{
+		RepositoryName: aws.String("preview-override-repo"),
+	})
+	if err != nil {
+		t.Fatalf("GetLifecyclePolicyPreview: %v", err)
+	}
+
+	if len(got.PreviewResults) != 1 {
+		t.Fatalf("previewResults = %d entries, want 1", len(got.PreviewResults))
+	}
+
+	_, err = client.GetLifecyclePolicy(ctx, &awsecr.GetLifecyclePolicyInput{
+		RepositoryName: aws.String("preview-override-repo"),
+	})
+
+	var lcNotFound *ecrtypes.LifecyclePolicyNotFoundException
+	if !errors.As(err, &lcNotFound) {
+		t.Fatalf("GetLifecyclePolicy after override preview: want LifecyclePolicyNotFoundException, got %v", err)
+	}
+}
+
+// TestSDKECRLifecyclePolicyPreviewNoPolicy asserts that previewing a repository
+// with no stored policy and no override reports LifecyclePolicyNotFoundException.
+func TestSDKECRLifecyclePolicyPreviewNoPolicy(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	mustCreateRepo(ctx, t, client, "preview-no-policy-repo")
+
+	_, err := client.StartLifecyclePolicyPreview(ctx, &awsecr.StartLifecyclePolicyPreviewInput{
+		RepositoryName: aws.String("preview-no-policy-repo"),
+	})
+
+	var lcNotFound *ecrtypes.LifecyclePolicyNotFoundException
+	if !errors.As(err, &lcNotFound) {
+		t.Fatalf("Start with no policy: want LifecyclePolicyNotFoundException, got %v", err)
+	}
+}
+
+// TestSDKECRLifecyclePolicyPreviewMissingRepo asserts Start/Get on a repository
+// that does not exist both report RepositoryNotFoundException.
+func TestSDKECRLifecyclePolicyPreviewMissingRepo(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	_, err := client.StartLifecyclePolicyPreview(ctx, &awsecr.StartLifecyclePolicyPreviewInput{
+		RepositoryName: aws.String("ghost-preview-repo"),
+	})
+
+	var repoNotFound *ecrtypes.RepositoryNotFoundException
+	if !errors.As(err, &repoNotFound) {
+		t.Fatalf("Start on missing repo: want RepositoryNotFoundException, got %v", err)
+	}
+
+	_, err = client.GetLifecyclePolicyPreview(ctx, &awsecr.GetLifecyclePolicyPreviewInput{
+		RepositoryName: aws.String("ghost-preview-repo"),
+	})
+	if !errors.As(err, &repoNotFound) {
+		t.Fatalf("Get on missing repo: want RepositoryNotFoundException, got %v", err)
+	}
+}
+
+// TestSDKECRGetLifecyclePolicyPreviewWithoutStart asserts that Get before any
+// Start call reports LifecyclePolicyPreviewNotFoundException, not a stale or
+// empty success response.
+func TestSDKECRGetLifecyclePolicyPreviewWithoutStart(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	mustCreateRepo(ctx, t, client, "preview-unstarted-repo")
+
+	if _, err := client.PutLifecyclePolicy(ctx, &awsecr.PutLifecyclePolicyInput{
+		RepositoryName:      aws.String("preview-unstarted-repo"),
+		LifecyclePolicyText: aws.String(countRulePolicyDoc),
+	}); err != nil {
+		t.Fatalf("PutLifecyclePolicy: %v", err)
+	}
+
+	_, err := client.GetLifecyclePolicyPreview(ctx, &awsecr.GetLifecyclePolicyPreviewInput{
+		RepositoryName: aws.String("preview-unstarted-repo"),
+	})
+
+	var previewNotFound *ecrtypes.LifecyclePolicyPreviewNotFoundException
+	if !errors.As(err, &previewNotFound) {
+		t.Fatalf("Get without Start: want LifecyclePolicyPreviewNotFoundException, got %v", err)
+	}
+}
+
+// TestSDKECRLifecyclePolicyPreviewStaleAfterDelete guards against a
+// delete-then-recreate confusing the wire handler's Start/Get preview cache
+// (keyed by repository name): deleting the repository must invalidate any
+// cached preview, so a repository recreated with the same name starts with no
+// preview rather than replaying the deleted repository's stale result.
+func TestSDKECRLifecyclePolicyPreviewStaleAfterDelete(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	const repoName = "preview-stale-repo"
+
+	mustCreateRepo(ctx, t, client, repoName)
+
+	if _, err := client.PutLifecyclePolicy(ctx, &awsecr.PutLifecyclePolicyInput{
+		RepositoryName:      aws.String(repoName),
+		LifecyclePolicyText: aws.String(countRulePolicyDoc),
+	}); err != nil {
+		t.Fatalf("PutLifecyclePolicy: %v", err)
+	}
+
+	for i := range 3 {
+		mustPutImage(ctx, t, client, repoName, fmt.Sprintf("%s-%d", sampleManifest, i), fmt.Sprintf("v%d", i))
+	}
+
+	if _, err := client.StartLifecyclePolicyPreview(ctx, &awsecr.StartLifecyclePolicyPreviewInput{
+		RepositoryName: aws.String(repoName),
+	}); err != nil {
+		t.Fatalf("StartLifecyclePolicyPreview: %v", err)
+	}
+
+	if _, err := client.DeleteRepository(ctx, &awsecr.DeleteRepositoryInput{
+		RepositoryName: aws.String(repoName),
+		Force:          true,
+	}); err != nil {
+		t.Fatalf("DeleteRepository: %v", err)
+	}
+
+	mustCreateRepo(ctx, t, client, repoName)
+
+	_, err := client.GetLifecyclePolicyPreview(ctx, &awsecr.GetLifecyclePolicyPreviewInput{
+		RepositoryName: aws.String(repoName),
+	})
+
+	var previewNotFound *ecrtypes.LifecyclePolicyPreviewNotFoundException
+	if !errors.As(err, &previewNotFound) {
+		t.Fatalf("Get after delete+recreate: want LifecyclePolicyPreviewNotFoundException (no stale replay), got %v", err)
+	}
+}

--- a/server/aws/ecr/operations.go
+++ b/server/aws/ecr/operations.go
@@ -101,6 +101,13 @@ func (h *Handler) deleteRepository(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A stale lifecycle-policy-preview result must not survive the repository
+	// it was computed against — clear it so a later Get on a same-named
+	// repository (recreated after this delete) cannot replay it.
+	h.previewMu.Lock()
+	delete(h.previews, req.RepositoryName)
+	h.previewMu.Unlock()
+
 	wire.WriteJSON(w, deleteRepositoryResponse{Repository: toRepositoryJSON(repo)})
 }
 

--- a/services/containerregistry/driver/driver.go
+++ b/services/containerregistry/driver/driver.go
@@ -91,6 +91,21 @@ type LifecyclePolicy struct {
 	Document string
 }
 
+// LifecyclePreviewResult describes one image a lifecycle policy evaluation
+// would expire, with enough detail to render AWS ECR's
+// GetLifecyclePolicyPreview response (imageDigest/imageTags/imagePushedAt/
+// appliedRulePriority). AWS-specific — Azure ACR and GCP Artifact Registry
+// have no lifecycle-preview API — so it is not part of the ContainerRegistry
+// interface below; the AWS provider exposes a PreviewLifecyclePolicy method
+// that the ECR wire handler reaches via type assertion (see
+// providers/aws/ecr and server/aws/ecr).
+type LifecyclePreviewResult struct {
+	Digest              string
+	Tags                []string
+	PushedAt            string
+	AppliedRulePriority int
+}
+
 // ScanResult represents an image vulnerability scan result.
 type ScanResult struct {
 	Repository    string


### PR DESCRIPTION
## Summary

AWS ECR was already deep in most respects — CRUD, imageTagMutability enforcement (ImageTagAlreadyExistsException), DeleteRepository-with-images guard (RepositoryNotEmptyException), a real lifecycle-policy rule engine (count/age rules, tag pattern matching via EvaluateLifecyclePolicy), image scanning, and repository policies. One real gap: `StartLifecyclePolicyPreview` / `GetLifecyclePolicyPreview` were never wired on the wire server — a real user could `PutLifecyclePolicy` but had no way to preview which images it would expire; both returned `UnknownOperationException`.

## What changed

- Added `PreviewLifecyclePolicy` to the ECR provider (`providers/aws/ecr`), returning full per-image detail (digest, tags, pushedAt, appliedRulePriority) rather than just digests, and supporting an optional ad-hoc policy override (matching `StartLifecyclePolicyPreview`'s `lifecyclePolicyText` param, which does not persist).
- Fixed rule evaluation so an image already claimed by a higher-priority rule is excluded from a lower-priority rule's matching pool — matches real ECR (each image expires under at most one rule).
- Wired `StartLifecyclePolicyPreview`/`GetLifecyclePolicyPreview` in `server/aws/ecr`: evaluated synchronously (status always `COMPLETE`) and cached per-repository; the cache is invalidated on `DeleteRepository` so a repository recreated with the same name can't replay a stale preview.
- Split ECR's `ServeHTTP` dispatch into grouped `route*` methods (repositories/images/tags/lifecycle/scanning) to stay under the function-length lint limit as operations grow.

## Deferred

- Real ECR also auto-expires images per lifecycle policy in the background (not just on-demand preview). The emulator does not run a background scheduler; `EvaluateLifecyclePolicy`/`PreviewLifecyclePolicy` remain on-demand only, matching the existing architecture.