### PR TITLE
feat(artifactregistry): enforce immutableTags on packages.tags write ops

### DIFF
--- a/providers/gcp/artifactregistry/artifactregistry.go
+++ b/providers/gcp/artifactregistry/artifactregistry.go
@@ -357,14 +357,52 @@ func (m *Mock) TagImage(_ context.Context, repository, sourceRef, targetTag stri
 	return nil
 }
 
-// UntagImage removes a single tag from an image, leaving the image (and its
-// other tags) intact. This is a GCP-specific extension, not part of the
-// shared driver.ContainerRegistry interface: Artifact Registry's native
-// packages.tags.delete removes just the tag, whereas the shared interface's
-// DeleteImage removes the whole image (AWS ECR / Azure ACR have no equivalent
-// "delete a single tag" operation). The GCP wire handler reaches it through an
-// optional interface assertion, the same pattern used by UpdateRepository.
-func (m *Mock) UntagImage(_ context.Context, repository, digest, tag string) error {
+// findTaggedImage resolves repository/digest and requires tag to be present
+// on that image, returning NotFound otherwise. Callers must hold m.mu (for
+// read or write) for the duration of any check-then-act sequence built on top
+// of it, so a concurrent repository patch or tag mutation cannot slip between
+// the check and the act.
+func (m *Mock) findTaggedImage(repository, digest, tag string) (*repoData, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img, ok := rd.images.Get(digest)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "image %q not found in repository %q", digest, repository)
+	}
+
+	if !hasTag(img.detail.Tags, tag) {
+		return nil, errors.Newf(errors.NotFound, "tag %q not found on image %q in repository %q", tag, digest, repository)
+	}
+
+	return rd, nil
+}
+
+// repoImmutableTags reports whether rd's dockerConfig.immutableTags is
+// enabled. The GCP wire layer folds that flag into the repository's reserved
+// Tags (see driver.ImmutableTagsReservedTag) since the shared Repository
+// struct has no dedicated field for it.
+func repoImmutableTags(rd *repoData) bool {
+	return rd.info.Tags[driver.ImmutableTagsReservedTag] == driver.ImmutableTagsReservedValue
+}
+
+// CreateTag atomically creates a new tag on the image at digest: the
+// existence check and the write happen under one lock acquisition, so two
+// concurrent creates of the same not-yet-used tag id cannot both succeed (the
+// loser gets AlreadyExists) the way composing a separate read-only check with
+// a separately-locked TagImage call would allow. This is a GCP-specific
+// extension, not part of the shared driver.ContainerRegistry interface, since
+// AWS ECR / Azure ACR have no equivalent "create if absent" tag operation. A
+// brand-new tag id is always allowed, even when the repository has
+// immutableTags enabled: only mutating an existing tag (patch/delete) is
+// blocked.
+func (m *Mock) CreateTag(_ context.Context, repository, digest, tag string) error {
+	if tag == "" {
+		return errors.New(errors.InvalidArgument, "target tag cannot be empty")
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -373,23 +411,75 @@ func (m *Mock) UntagImage(_ context.Context, repository, digest, tag string) err
 		return errors.Newf(errors.NotFound, "repository %q not found", repository)
 	}
 
-	removed := false
-
-	updated := rd.images.Update(digest, func(img *imageData) *imageData {
-		filtered := removeTag(img.detail.Tags, tag)
-		removed = len(filtered) != len(img.detail.Tags)
-		img.detail.Tags = filtered
-
-		return img
-	})
-
-	if !updated {
+	img, ok := rd.images.Get(digest)
+	if !ok {
 		return errors.Newf(errors.NotFound, "image %q not found in repository %q", digest, repository)
 	}
 
-	if !removed {
-		return errors.Newf(errors.NotFound, "tag %q not found on image %q in repository %q", tag, digest, repository)
+	if hasTag(img.detail.Tags, tag) {
+		return errors.Newf(errors.AlreadyExists, "tag %q already exists", tag)
 	}
+
+	updateTagIndex(rd, digest, tag)
+	rd.info.ImageCount = rd.images.Len()
+
+	return nil
+}
+
+// PatchTag atomically validates a packages.tags.patch request: the image and
+// tag must exist, and the repository must not have immutableTags enabled.
+// The provider's package/version model allows exactly one version per
+// package, so there is nothing further to persist once the wire layer has
+// confirmed the requested version resolves to that same version — but the
+// immutableTags gate must still be evaluated under the same lock a mutation
+// would use, or a concurrent repository patch could flip the flag between the
+// wire layer's check and its response. This is a GCP-specific extension, not
+// part of the shared driver.ContainerRegistry interface.
+func (m *Mock) PatchTag(_ context.Context, repository, digest, tag string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, err := m.findTaggedImage(repository, digest, tag)
+	if err != nil {
+		return err
+	}
+
+	if repoImmutableTags(rd) {
+		return errors.Newf(errors.FailedPrecondition,
+			"repository %q has immutable tags; tag %q cannot be updated", repository, tag)
+	}
+
+	return nil
+}
+
+// UntagImage removes a single tag from an image, leaving the image (and its
+// other tags) intact. The existence checks, the immutableTags gate, and the
+// removal all happen under one lock acquisition, so a concurrent repository
+// patch cannot flip immutableTags between the check and the removal. This is
+// a GCP-specific extension, not part of the shared driver.ContainerRegistry
+// interface: Artifact Registry's native packages.tags.delete removes just the
+// tag, whereas the shared interface's DeleteImage removes the whole image
+// (AWS ECR / Azure ACR have no equivalent "delete a single tag" operation).
+// The GCP wire handler reaches it through an optional interface assertion,
+// the same pattern used by UpdateRepository.
+func (m *Mock) UntagImage(_ context.Context, repository, digest, tag string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, err := m.findTaggedImage(repository, digest, tag)
+	if err != nil {
+		return err
+	}
+
+	if repoImmutableTags(rd) {
+		return errors.Newf(errors.FailedPrecondition,
+			"repository %q has immutable tags; tag %q cannot be deleted", repository, tag)
+	}
+
+	rd.images.Update(digest, func(img *imageData) *imageData {
+		img.detail.Tags = removeTag(img.detail.Tags, tag)
+		return img
+	})
 
 	return nil
 }

--- a/providers/gcp/artifactregistry/artifactregistry.go
+++ b/providers/gcp/artifactregistry/artifactregistry.go
@@ -357,6 +357,43 @@ func (m *Mock) TagImage(_ context.Context, repository, sourceRef, targetTag stri
 	return nil
 }
 
+// UntagImage removes a single tag from an image, leaving the image (and its
+// other tags) intact. This is a GCP-specific extension, not part of the
+// shared driver.ContainerRegistry interface: Artifact Registry's native
+// packages.tags.delete removes just the tag, whereas the shared interface's
+// DeleteImage removes the whole image (AWS ECR / Azure ACR have no equivalent
+// "delete a single tag" operation). The GCP wire handler reaches it through an
+// optional interface assertion, the same pattern used by UpdateRepository.
+func (m *Mock) UntagImage(_ context.Context, repository, digest, tag string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	removed := false
+
+	updated := rd.images.Update(digest, func(img *imageData) *imageData {
+		filtered := removeTag(img.detail.Tags, tag)
+		removed = len(filtered) != len(img.detail.Tags)
+		img.detail.Tags = filtered
+
+		return img
+	})
+
+	if !updated {
+		return errors.Newf(errors.NotFound, "image %q not found in repository %q", digest, repository)
+	}
+
+	if !removed {
+		return errors.Newf(errors.NotFound, "tag %q not found on image %q in repository %q", tag, digest, repository)
+	}
+
+	return nil
+}
+
 // PutLifecyclePolicy sets a cleanup policy on an Artifact Registry repository.
 func (m *Mock) PutLifecyclePolicy(_ context.Context, repository string, policy driver.LifecyclePolicy) error {
 	m.mu.Lock()

--- a/providers/gcp/artifactregistry/artifactregistry_test.go
+++ b/providers/gcp/artifactregistry/artifactregistry_test.go
@@ -485,6 +485,39 @@ func TestTagImageEmptyTagRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "empty")
 }
 
+func TestUntagImage(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "untag-repo")
+	img := pushTestImage(t, m, "untag-repo", "v1")
+	require.NoError(t, m.TagImage(ctx, "untag-repo", "v1", "latest"))
+
+	t.Run("removes only the given tag", func(t *testing.T) {
+		require.NoError(t, m.UntagImage(ctx, "untag-repo", img.Digest, "latest"))
+
+		detail, err := m.GetImage(ctx, "untag-repo", img.Digest)
+		require.NoError(t, err)
+		assert.Contains(t, detail.Tags, "v1")
+		assert.NotContains(t, detail.Tags, "latest")
+	})
+
+	t.Run("tag not found", func(t *testing.T) {
+		err := m.UntagImage(ctx, "untag-repo", img.Digest, "missing")
+		require.Error(t, err)
+	})
+
+	t.Run("image not found", func(t *testing.T) {
+		err := m.UntagImage(ctx, "untag-repo", "sha256:nonexistent", "v1")
+		require.Error(t, err)
+	})
+
+	t.Run("repository not found", func(t *testing.T) {
+		err := m.UntagImage(ctx, "nonexistent", img.Digest, "v1")
+		require.Error(t, err)
+	})
+}
+
 func TestImageTagMutability(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/server/gcp/artifactregistry/handler.go
+++ b/server/gcp/artifactregistry/handler.go
@@ -17,7 +17,11 @@
 //	GET    .../repositories/{id}/packages                 — List packages (paged)
 //	GET    .../repositories/{id}/packages/{pkg}           — Get package
 //	GET    .../repositories/{id}/packages/{pkg}/versions  — List versions (paged)
+//	DELETE .../repositories/{id}/packages/{pkg}/versions/{v} — Delete version
 //	GET    .../repositories/{id}/packages/{pkg}/tags      — List tags (paged)
+//	POST   .../packages/{pkg}/tags?tagId={id}             — Create tag
+//	PATCH  .../packages/{pkg}/tags/{id}                   — Patch tag (blocked by immutableTags)
+//	DELETE .../packages/{pkg}/tags/{id}                   — Delete tag (blocked by immutableTags)
 //	GET    .../repositories/{id}/files                    — List files (paged)
 //
 // The driver has no location dimension, so {l} is accepted and echoed but not

--- a/server/gcp/artifactregistry/subcollections.go
+++ b/server/gcp/artifactregistry/subcollections.go
@@ -34,16 +34,7 @@ func (h *Handler) servePackages(w http.ResponseWriter, r *http.Request, rt *rout
 	case versionsSeg:
 		h.serveVersions(w, r, rt)
 	case tagsSeg:
-		if !requireGet(w, r, "tags") {
-			return
-		}
-
-		if rt.pkgSubID != "" {
-			h.getTag(w, r, rt)
-			return
-		}
-
-		h.listTags(w, r, rt)
+		h.serveTags(w, r, rt)
 	case "":
 		h.servePackage(w, r, rt)
 	default:

--- a/server/gcp/artifactregistry/tags.go
+++ b/server/gcp/artifactregistry/tags.go
@@ -2,9 +2,13 @@
 // delete) that subcollections.go left read-only, plus the enforcement of a
 // Docker repository's dockerConfig.immutableTags flag. Real Artifact Registry
 // blocks re-pointing or deleting a tag once immutable tags are enabled (create
-// of a brand-new tag id is always allowed); this file is the only place that
-// checks the flag, since createRepository/patchRepository merely persist it
-// (see operations.go) without enforcing anything.
+// of a brand-new tag id is always allowed). The existence checks and the
+// immutableTags gate are evaluated atomically inside the provider's
+// CreateTag/PatchTag/UntagImage (one lock acquisition each), not composed here
+// from separate GetRepository/TagImage calls: a wire-layer check-then-act
+// would leave a window for a concurrent repository patch to flip
+// immutableTags, or for two concurrent creates of the same tag id to both
+// succeed.
 package artifactregistry
 
 import (
@@ -12,13 +16,27 @@ import (
 	"net/http"
 	"strings"
 
-	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 )
 
-// tagUnsetter is the optional GCP-only driver extension for removing a single
-// tag without deleting the underlying package/version (packages.tags.delete).
-// Only the GCP Artifact Registry mock implements it.
+// tagCreator is the optional GCP-only driver extension for atomically
+// creating a new tag (packages.tags.create). Only the GCP Artifact Registry
+// mock implements it.
+type tagCreator interface {
+	CreateTag(ctx context.Context, repository, digest, tag string) error
+}
+
+// tagPatcher is the optional GCP-only driver extension for atomically
+// validating a tag patch (packages.tags.patch), including the immutableTags
+// gate. Only the GCP Artifact Registry mock implements it.
+type tagPatcher interface {
+	PatchTag(ctx context.Context, repository, digest, tag string) error
+}
+
+// tagUnsetter is the optional GCP-only driver extension for atomically
+// removing a single tag without deleting the underlying package/version
+// (packages.tags.delete), including the immutableTags gate. Only the GCP
+// Artifact Registry mock implements it.
 type tagUnsetter interface {
 	UntagImage(ctx context.Context, repository, digest, tag string) error
 }
@@ -60,7 +78,8 @@ func (h *Handler) serveTagsCollection(w http.ResponseWriter, r *http.Request, rt
 
 // createTag implements packages.tags.create. A brand-new tag id is always
 // allowed, even on an immutable-tags repository; only mutating an existing
-// tag (patch/delete) is blocked.
+// tag (patch/delete) is blocked. The existence-check-then-write is delegated
+// to the provider's CreateTag so it happens under one lock acquisition.
 func (h *Handler) createTag(w http.ResponseWriter, r *http.Request, rt *route) {
 	img, ok := h.findImage(w, r, rt)
 	if !ok {
@@ -73,11 +92,6 @@ func (h *Handler) createTag(w http.ResponseWriter, r *http.Request, rt *route) {
 		return
 	}
 
-	if containsTagName(img.Tags, tagID) {
-		gcprest.WriteError(w, http.StatusConflict, "alreadyExists", "tag "+tagID+" already exists")
-		return
-	}
-
 	var body tagsJSON
 	if !gcprest.DecodeJSON(w, r, &body) {
 		return
@@ -87,7 +101,13 @@ func (h *Handler) createTag(w http.ResponseWriter, r *http.Request, rt *route) {
 		return
 	}
 
-	if err := h.registry.TagImage(r.Context(), rt.repository, img.Digest, tagID); err != nil {
+	creator, ok := h.registry.(tagCreator)
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "tags.create unsupported")
+		return
+	}
+
+	if err := creator.CreateTag(r.Context(), rt.repository, img.Digest, tagID); err != nil {
 		gcprest.WriteCErr(w, err)
 		return
 	}
@@ -98,16 +118,12 @@ func (h *Handler) createTag(w http.ResponseWriter, r *http.Request, rt *route) {
 // patchTag implements packages.tags.patch. The mock's package/version model
 // is one version per package, so a tag under package {pkg} only ever
 // resolves to version {pkg}; a patch can therefore only confirm that version
-// (a differing one 404s as not found), but the immutableTags gate below is
-// still fully meaningful and is what real clients probe.
+// (a differing one 404s as not found), but the immutableTags gate — checked
+// atomically inside the provider's PatchTag — is still fully meaningful and
+// is what real clients probe.
 func (h *Handler) patchTag(w http.ResponseWriter, r *http.Request, rt *route) {
 	img, ok := h.findImage(w, r, rt)
 	if !ok {
-		return
-	}
-
-	if !containsTagName(img.Tags, rt.pkgSubID) {
-		gcprest.WriteError(w, http.StatusNotFound, "notFound", "tag "+rt.pkgSubID+" not found")
 		return
 	}
 
@@ -120,26 +136,26 @@ func (h *Handler) patchTag(w http.ResponseWriter, r *http.Request, rt *route) {
 		return
 	}
 
-	if !h.rejectIfImmutable(w, r, rt, "updated") {
+	patcher, ok := h.registry.(tagPatcher)
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "tags.patch unsupported")
+		return
+	}
+
+	if err := patcher.PatchTag(r.Context(), rt.repository, img.Digest, rt.pkgSubID); err != nil {
+		gcprest.WriteCErr(w, err)
 		return
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, toTagJSON(rt, rt.pkgSubID, img.Digest))
 }
 
-// deleteTag implements packages.tags.delete, blocked by immutableTags.
+// deleteTag implements packages.tags.delete. The existence check and the
+// immutableTags gate are evaluated atomically inside the provider's
+// UntagImage, under the same lock as the removal itself.
 func (h *Handler) deleteTag(w http.ResponseWriter, r *http.Request, rt *route) {
 	img, ok := h.findImage(w, r, rt)
 	if !ok {
-		return
-	}
-
-	if !containsTagName(img.Tags, rt.pkgSubID) {
-		gcprest.WriteError(w, http.StatusNotFound, "notFound", "tag "+rt.pkgSubID+" not found")
-		return
-	}
-
-	if !h.rejectIfImmutable(w, r, rt, "deleted") {
 		return
 	}
 
@@ -155,26 +171,6 @@ func (h *Handler) deleteTag(w http.ResponseWriter, r *http.Request, rt *route) {
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, map[string]any{})
-}
-
-// rejectIfImmutable writes a FAILED_PRECONDITION response and returns false
-// when the tag's repository has dockerConfig.immutableTags enabled; verb
-// names the blocked action ("updated"/"deleted") in the error message.
-func (h *Handler) rejectIfImmutable(w http.ResponseWriter, r *http.Request, rt *route, verb string) bool {
-	repo, err := h.registry.GetRepository(r.Context(), rt.repository)
-	if err != nil {
-		gcprest.WriteCErr(w, err)
-		return false
-	}
-
-	if repo.Tags[immutableTagsTag] != trueTag {
-		return true
-	}
-
-	gcprest.WriteCErr(w, cerrors.Newf(cerrors.FailedPrecondition,
-		"repository %q has immutable tags; tag %q cannot be %s", rt.repository, rt.pkgSubID, verb))
-
-	return false
 }
 
 // checkTagVersion validates that versionRef names an existing version under
@@ -218,15 +214,4 @@ func parseVersionRef(ref string) (pkg, version string, ok bool) {
 	}
 
 	return pkg, version, true
-}
-
-// containsTagName reports whether tag is present in tags.
-func containsTagName(tags []string, tag string) bool {
-	for _, t := range tags {
-		if t == tag {
-			return true
-		}
-	}
-
-	return false
 }

--- a/server/gcp/artifactregistry/tags.go
+++ b/server/gcp/artifactregistry/tags.go
@@ -1,0 +1,232 @@
+// tags.go implements the packages.tags write operations (create, patch,
+// delete) that subcollections.go left read-only, plus the enforcement of a
+// Docker repository's dockerConfig.immutableTags flag. Real Artifact Registry
+// blocks re-pointing or deleting a tag once immutable tags are enabled (create
+// of a brand-new tag id is always allowed); this file is the only place that
+// checks the flag, since createRepository/patchRepository merely persist it
+// (see operations.go) without enforcing anything.
+package artifactregistry
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+)
+
+// tagUnsetter is the optional GCP-only driver extension for removing a single
+// tag without deleting the underlying package/version (packages.tags.delete).
+// Only the GCP Artifact Registry mock implements it.
+type tagUnsetter interface {
+	UntagImage(ctx context.Context, repository, digest, tag string) error
+}
+
+// serveTags dispatches the tags sub-collection: GET lists or gets a tag, POST
+// creates one (tags.create), PATCH re-points an existing one (tags.patch),
+// and DELETE removes one (tags.delete).
+func (h *Handler) serveTags(w http.ResponseWriter, r *http.Request, rt *route) {
+	if rt.pkgSubID == "" {
+		h.serveTagsCollection(w, r, rt)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getTag(w, r, rt)
+	case http.MethodPatch:
+		h.patchTag(w, r, rt)
+	case http.MethodDelete:
+		h.deleteTag(w, r, rt)
+	default:
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported tag operation")
+	}
+}
+
+// serveTagsCollection handles the tags collection itself: GET lists, POST
+// creates (tagId supplied as a query parameter, since the resource has no id
+// yet).
+func (h *Handler) serveTagsCollection(w http.ResponseWriter, r *http.Request, rt *route) {
+	switch r.Method {
+	case http.MethodGet:
+		h.listTags(w, r, rt)
+	case http.MethodPost:
+		h.createTag(w, r, rt)
+	default:
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported tags operation")
+	}
+}
+
+// createTag implements packages.tags.create. A brand-new tag id is always
+// allowed, even on an immutable-tags repository; only mutating an existing
+// tag (patch/delete) is blocked.
+func (h *Handler) createTag(w http.ResponseWriter, r *http.Request, rt *route) {
+	img, ok := h.findImage(w, r, rt)
+	if !ok {
+		return
+	}
+
+	tagID := r.URL.Query().Get("tagId")
+	if tagID == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "tagId is required")
+		return
+	}
+
+	if containsTagName(img.Tags, tagID) {
+		gcprest.WriteError(w, http.StatusConflict, "alreadyExists", "tag "+tagID+" already exists")
+		return
+	}
+
+	var body tagsJSON
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	if !checkTagVersion(w, rt, body.Version, img.Digest) {
+		return
+	}
+
+	if err := h.registry.TagImage(r.Context(), rt.repository, img.Digest, tagID); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toTagJSON(rt, tagID, img.Digest))
+}
+
+// patchTag implements packages.tags.patch. The mock's package/version model
+// is one version per package, so a tag under package {pkg} only ever
+// resolves to version {pkg}; a patch can therefore only confirm that version
+// (a differing one 404s as not found), but the immutableTags gate below is
+// still fully meaningful and is what real clients probe.
+func (h *Handler) patchTag(w http.ResponseWriter, r *http.Request, rt *route) {
+	img, ok := h.findImage(w, r, rt)
+	if !ok {
+		return
+	}
+
+	if !containsTagName(img.Tags, rt.pkgSubID) {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "tag "+rt.pkgSubID+" not found")
+		return
+	}
+
+	var body tagsJSON
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	if body.Version != "" && !checkTagVersion(w, rt, body.Version, img.Digest) {
+		return
+	}
+
+	if !h.rejectIfImmutable(w, r, rt, "updated") {
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toTagJSON(rt, rt.pkgSubID, img.Digest))
+}
+
+// deleteTag implements packages.tags.delete, blocked by immutableTags.
+func (h *Handler) deleteTag(w http.ResponseWriter, r *http.Request, rt *route) {
+	img, ok := h.findImage(w, r, rt)
+	if !ok {
+		return
+	}
+
+	if !containsTagName(img.Tags, rt.pkgSubID) {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "tag "+rt.pkgSubID+" not found")
+		return
+	}
+
+	if !h.rejectIfImmutable(w, r, rt, "deleted") {
+		return
+	}
+
+	unsetter, ok := h.registry.(tagUnsetter)
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "tags.delete unsupported")
+		return
+	}
+
+	if err := unsetter.UntagImage(r.Context(), rt.repository, img.Digest, rt.pkgSubID); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, map[string]any{})
+}
+
+// rejectIfImmutable writes a FAILED_PRECONDITION response and returns false
+// when the tag's repository has dockerConfig.immutableTags enabled; verb
+// names the blocked action ("updated"/"deleted") in the error message.
+func (h *Handler) rejectIfImmutable(w http.ResponseWriter, r *http.Request, rt *route, verb string) bool {
+	repo, err := h.registry.GetRepository(r.Context(), rt.repository)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return false
+	}
+
+	if repo.Tags[immutableTagsTag] != trueTag {
+		return true
+	}
+
+	gcprest.WriteCErr(w, cerrors.Newf(cerrors.FailedPrecondition,
+		"repository %q has immutable tags; tag %q cannot be %s", rt.repository, rt.pkgSubID, verb))
+
+	return false
+}
+
+// checkTagVersion validates that versionRef names an existing version under
+// the same package (rt.pkg), i.e. the digest the package's single image
+// carries. Writes a 404 and returns false otherwise.
+func checkTagVersion(w http.ResponseWriter, rt *route, versionRef, wantDigest string) bool {
+	if versionRef == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "version is required")
+		return false
+	}
+
+	pkg, version, ok := parseVersionRef(versionRef)
+	if !ok || pkg != rt.pkg || version != wantDigest {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "version "+versionRef+" not found")
+		return false
+	}
+
+	return true
+}
+
+const (
+	tagPackagesMarker = "/packages/"
+	tagVersionsMarker = "/versions/"
+)
+
+// parseVersionRef extracts the package and version ids from a Tag.version
+// resource name (".../packages/{pkg}/versions/{version}").
+func parseVersionRef(ref string) (pkg, version string, ok bool) {
+	pi := strings.Index(ref, tagPackagesMarker)
+	vi := strings.Index(ref, tagVersionsMarker)
+
+	if pi < 0 || vi < 0 || vi < pi {
+		return "", "", false
+	}
+
+	pkg = ref[pi+len(tagPackagesMarker) : vi]
+	version = ref[vi+len(tagVersionsMarker):]
+
+	if pkg == "" || version == "" {
+		return "", "", false
+	}
+
+	return pkg, version, true
+}
+
+// containsTagName reports whether tag is present in tags.
+func containsTagName(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/gcp/artifactregistry/tags_lifecycle_test.go
+++ b/server/gcp/artifactregistry/tags_lifecycle_test.go
@@ -1,0 +1,195 @@
+package artifactregistry_test
+
+import (
+	"context"
+	"testing"
+
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+	ar "google.golang.org/api/artifactregistry/v1"
+)
+
+// setupTaggedRepo creates a repository (optionally with dockerConfig.immutableTags)
+// and seeds one image tagged v1, returning the package/version resource name
+// (which doubles as the version id in this model, since a package has exactly
+// one version keyed by its digest).
+func setupTaggedRepo(t *testing.T, svc *ar.Service, reg crdriver.ContainerRegistry, repoID string, immutable bool) (pkgName, digest string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	var docker *ar.DockerRepositoryConfig
+	if immutable {
+		docker = &ar.DockerRepositoryConfig{ImmutableTags: true}
+	}
+
+	if _, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{
+		Format:       "DOCKER",
+		DockerConfig: docker,
+	}).RepositoryId(repoID).Context(ctx).Do(); err != nil {
+		t.Fatalf("Create repository: %v", err)
+	}
+
+	img, err := reg.PutImage(ctx, &crdriver.ImageManifest{
+		Repository: repoID,
+		Tag:        "v1",
+		Digest:     "sha256:" + repoID,
+		SizeBytes:  1024,
+	})
+	if err != nil {
+		t.Fatalf("seed PutImage: %v", err)
+	}
+
+	return testParent + "/repositories/" + repoID + "/packages/" + img.Digest, img.Digest
+}
+
+// TestSDKArtifactRegistryTagsCreate guards packages.tags.create: a brand-new
+// tag id targeting the package's own version succeeds and is visible via
+// Tags.Get; a duplicate tag id is ALREADY_EXISTS; a version referencing a
+// different (nonexistent) package is NOT_FOUND.
+func TestSDKArtifactRegistryTagsCreate(t *testing.T) {
+	svc, reg := newARService(t)
+	ctx := context.Background()
+
+	pkgName, digest := setupTaggedRepo(t, svc, reg, "tagcreate", false)
+
+	created, err := svc.Projects.Locations.Repositories.Packages.Tags.
+		Create(pkgName, &ar.Tag{Version: pkgName + "/versions/" + digest}).
+		TagId("release").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Tags.Create: %v", err)
+	}
+
+	if created.Version != pkgName+"/versions/"+digest {
+		t.Fatalf("created tag version=%q want %s", created.Version, pkgName+"/versions/"+digest)
+	}
+
+	got, err := svc.Projects.Locations.Repositories.Packages.Tags.Get(pkgName + "/tags/release").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Tags.Get after create: %v", err)
+	}
+
+	if got.Name != pkgName+"/tags/release" {
+		t.Fatalf("Tags.Get name=%q want %s/tags/release", got.Name, pkgName)
+	}
+
+	_, err = svc.Projects.Locations.Repositories.Packages.Tags.
+		Create(pkgName, &ar.Tag{Version: pkgName + "/versions/" + digest}).
+		TagId("release").Context(ctx).Do()
+	assertGoogleAPICode(t, err, 409)
+
+	_, err = svc.Projects.Locations.Repositories.Packages.Tags.
+		Create(pkgName, &ar.Tag{Version: pkgName + "/versions/sha256:doesnotexist"}).
+		TagId("bad-version").Context(ctx).Do()
+	assertGoogleAPICode(t, err, 404)
+}
+
+// TestSDKArtifactRegistryTagsDeleteImmutableGuard guards the immutableTags
+// enforcement B-finding: a Docker repository created with
+// dockerConfig.immutableTags=true rejects tags.delete with FAILED_PRECONDITION
+// (mapped to HTTP 409 by the shared gcprest codec), while an identical
+// non-immutable repository allows it.
+func TestSDKArtifactRegistryTagsDeleteImmutableGuard(t *testing.T) {
+	svc, reg := newARService(t)
+	ctx := context.Background()
+
+	t.Run("immutable repo blocks delete", func(t *testing.T) {
+		pkgName, _ := setupTaggedRepo(t, svc, reg, "immdelete", true)
+
+		_, err := svc.Projects.Locations.Repositories.Packages.Tags.Delete(pkgName + "/tags/v1").Context(ctx).Do()
+		assertGoogleAPICode(t, err, 409)
+
+		// The tag must still be there after the rejected delete.
+		if _, err := svc.Projects.Locations.Repositories.Packages.Tags.
+			Get(pkgName + "/tags/v1").Context(ctx).Do(); err != nil {
+			t.Fatalf("tag should survive a blocked delete: %v", err)
+		}
+	})
+
+	t.Run("mutable repo allows delete", func(t *testing.T) {
+		pkgName, _ := setupTaggedRepo(t, svc, reg, "mutdelete", false)
+
+		if _, err := svc.Projects.Locations.Repositories.Packages.Tags.
+			Delete(pkgName + "/tags/v1").Context(ctx).Do(); err != nil {
+			t.Fatalf("Tags.Delete on mutable repo: %v", err)
+		}
+
+		_, err := svc.Projects.Locations.Repositories.Packages.Tags.Get(pkgName + "/tags/v1").Context(ctx).Do()
+		assertGoogleAPICode(t, err, 404)
+
+		// The version/package itself must survive an untag.
+		if _, err := svc.Projects.Locations.Repositories.Packages.Versions.
+			Get(pkgName + "/versions/" + lastSegment(pkgName)).Context(ctx).Do(); err != nil {
+			t.Fatalf("version should survive tags.delete: %v", err)
+		}
+	})
+
+	t.Run("delete of unknown tag is not found", func(t *testing.T) {
+		pkgName, _ := setupTaggedRepo(t, svc, reg, "missingtag", false)
+
+		_, err := svc.Projects.Locations.Repositories.Packages.Tags.
+			Delete(pkgName + "/tags/ghost").Context(ctx).Do()
+		assertGoogleAPICode(t, err, 404)
+	})
+}
+
+// TestSDKArtifactRegistryTagsPatchImmutableGuard guards packages.tags.patch:
+// blocked by FAILED_PRECONDITION on an immutable-tags repository, allowed
+// (confirming the same version) on a mutable one, and NOT_FOUND when the
+// patch targets a version outside the tag's own package.
+func TestSDKArtifactRegistryTagsPatchImmutableGuard(t *testing.T) {
+	svc, reg := newARService(t)
+	ctx := context.Background()
+
+	t.Run("immutable repo blocks patch", func(t *testing.T) {
+		pkgName, digest := setupTaggedRepo(t, svc, reg, "immpatch", true)
+
+		_, err := svc.Projects.Locations.Repositories.Packages.Tags.
+			Patch(pkgName+"/tags/v1", &ar.Tag{Version: pkgName + "/versions/" + digest}).
+			UpdateMask("version").Context(ctx).Do()
+		assertGoogleAPICode(t, err, 409)
+	})
+
+	t.Run("mutable repo allows patch to the same version", func(t *testing.T) {
+		pkgName, digest := setupTaggedRepo(t, svc, reg, "mutpatch", false)
+
+		patched, err := svc.Projects.Locations.Repositories.Packages.Tags.
+			Patch(pkgName+"/tags/v1", &ar.Tag{Version: pkgName + "/versions/" + digest}).
+			UpdateMask("version").Context(ctx).Do()
+		if err != nil {
+			t.Fatalf("Tags.Patch: %v", err)
+		}
+
+		if patched.Version != pkgName+"/versions/"+digest {
+			t.Fatalf("patched version=%q want %s", patched.Version, pkgName+"/versions/"+digest)
+		}
+	})
+
+	t.Run("patch referencing a foreign version is not found", func(t *testing.T) {
+		pkgName, _ := setupTaggedRepo(t, svc, reg, "patchforeign", false)
+
+		_, err := svc.Projects.Locations.Repositories.Packages.Tags.
+			Patch(pkgName+"/tags/v1", &ar.Tag{Version: pkgName + "/versions/sha256:elsewhere"}).
+			UpdateMask("version").Context(ctx).Do()
+		assertGoogleAPICode(t, err, 404)
+	})
+
+	t.Run("patch of an unknown tag is not found", func(t *testing.T) {
+		pkgName, digest := setupTaggedRepo(t, svc, reg, "patchmissing", false)
+
+		_, err := svc.Projects.Locations.Repositories.Packages.Tags.
+			Patch(pkgName+"/tags/ghost", &ar.Tag{Version: pkgName + "/versions/" + digest}).
+			UpdateMask("version").Context(ctx).Do()
+		assertGoogleAPICode(t, err, 404)
+	})
+}
+
+// lastSegment returns the final "/"-delimited segment of a resource name.
+func lastSegment(name string) string {
+	for i := len(name) - 1; i >= 0; i-- {
+		if name[i] == '/' {
+			return name[i+1:]
+		}
+	}
+
+	return name
+}

--- a/server/gcp/artifactregistry/tags_lifecycle_test.go
+++ b/server/gcp/artifactregistry/tags_lifecycle_test.go
@@ -2,10 +2,14 @@ package artifactregistry_test
 
 import (
 	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
 	ar "google.golang.org/api/artifactregistry/v1"
+	"google.golang.org/api/googleapi"
 )
 
 // setupTaggedRepo creates a repository (optionally with dockerConfig.immutableTags)
@@ -81,6 +85,91 @@ func TestSDKArtifactRegistryTagsCreate(t *testing.T) {
 		Create(pkgName, &ar.Tag{Version: pkgName + "/versions/sha256:doesnotexist"}).
 		TagId("bad-version").Context(ctx).Do()
 	assertGoogleAPICode(t, err, 404)
+}
+
+// TestSDKArtifactRegistryTagsCreateOnImmutableRepoAllowed guards that a
+// brand-new tag id is always allowed even when the repository has
+// dockerConfig.immutableTags enabled — only mutating an existing tag
+// (patch/delete) is blocked, not creating one.
+func TestSDKArtifactRegistryTagsCreateOnImmutableRepoAllowed(t *testing.T) {
+	svc, reg := newARService(t)
+	ctx := context.Background()
+
+	pkgName, digest := setupTaggedRepo(t, svc, reg, "immcreate", true)
+
+	created, err := svc.Projects.Locations.Repositories.Packages.Tags.
+		Create(pkgName, &ar.Tag{Version: pkgName + "/versions/" + digest}).
+		TagId("release").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Tags.Create of a new tag id on an immutable-tags repo should succeed: %v", err)
+	}
+
+	if created.Version != pkgName+"/versions/"+digest {
+		t.Fatalf("created tag version=%q want %s", created.Version, pkgName+"/versions/"+digest)
+	}
+
+	if _, err := svc.Projects.Locations.Repositories.Packages.Tags.
+		Get(pkgName + "/tags/release").Context(ctx).Do(); err != nil {
+		t.Fatalf("Tags.Get after create: %v", err)
+	}
+}
+
+// TestSDKArtifactRegistryTagsCreateConcurrentDuplicate guards that the
+// existence-check-then-write in packages.tags.create is atomic: N concurrent
+// creates of the same not-yet-used tag id must yield exactly one success and
+// N-1 ALREADY_EXISTS conflicts, never more than one success. Run with -race.
+func TestSDKArtifactRegistryTagsCreateConcurrentDuplicate(t *testing.T) {
+	svc, reg := newARService(t)
+	ctx := context.Background()
+
+	pkgName, digest := setupTaggedRepo(t, svc, reg, "racecreate", false)
+
+	const n = 20
+
+	var (
+		wg         sync.WaitGroup
+		successes  int32
+		conflicts  int32
+		unexpected int32
+	)
+
+	for range n {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			_, err := svc.Projects.Locations.Repositories.Packages.Tags.
+				Create(pkgName, &ar.Tag{Version: pkgName + "/versions/" + digest}).
+				TagId("race").Context(ctx).Do()
+
+			var gerr *googleapi.Error
+
+			switch {
+			case err == nil:
+				atomic.AddInt32(&successes, 1)
+			case errors.As(err, &gerr) && gerr.Code == 409:
+				atomic.AddInt32(&conflicts, 1)
+			default:
+				atomic.AddInt32(&unexpected, 1)
+				t.Errorf("unexpected error: %v", err)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if unexpected != 0 {
+		t.Fatalf("got %d unexpected errors", unexpected)
+	}
+
+	if successes != 1 {
+		t.Fatalf("got %d successful concurrent creates, want exactly 1 (conflicts=%d)", successes, conflicts)
+	}
+
+	if conflicts != n-1 {
+		t.Fatalf("got %d conflicts, want %d", conflicts, n-1)
+	}
 }
 
 // TestSDKArtifactRegistryTagsDeleteImmutableGuard guards the immutableTags

--- a/server/gcp/artifactregistry/types.go
+++ b/server/gcp/artifactregistry/types.go
@@ -173,7 +173,7 @@ const (
 	descriptionTag    = "cloudemu:gcpArDescription"
 	modeTag           = "cloudemu:gcpArMode"
 	kmsKeyTag         = "cloudemu:gcpArKmsKeyName"
-	immutableTagsTag  = "cloudemu:gcpArImmutableTags"
+	immutableTagsTag  = crdriver.ImmutableTagsReservedTag
 	cleanupPolicyTag  = "cloudemu:gcpArCleanupPolicies"
 	cleanupDryRunTag  = "cloudemu:gcpArCleanupPolicyDryRun"
 	reservedTagPrefix = "cloudemu:"

--- a/services/containerregistry/driver/driver.go
+++ b/services/containerregistry/driver/driver.go
@@ -27,6 +27,18 @@ type Repository struct {
 	ScanOnPush bool
 }
 
+// ImmutableTagsReservedTag is the reserved Repository.Tags key GCP Artifact
+// Registry uses to persist dockerConfig.immutableTags: the shared Repository
+// struct has no dedicated field for it (ImageTagMutability above is AWS ECR's
+// own, differently-shaped mechanism), so the GCP provider folds the flag into
+// Tags under this key and reads it back to enforce immutableTags on
+// packages.tags write operations. AWS ECR / Azure ACR do not use this key.
+const ImmutableTagsReservedTag = "cloudemu:gcpArImmutableTags"
+
+// ImmutableTagsReservedValue is the Tags value that marks
+// ImmutableTagsReservedTag as enabled.
+const ImmutableTagsReservedValue = "true"
+
 // RepositoryConfig describes a repository to create.
 type RepositoryConfig struct {
 	Name               string


### PR DESCRIPTION
## Gap found

GCP Artifact Registry investigation showed the repository CRUD/IAM/list surface is mature, but two things were shallow:

- `dockerConfig.immutableTags` round-tripped on create/get/patch (already fixed in an earlier PR) but was never **enforced** anywhere.
- The native `packages/{p}/tags` sub-collection was **read-only** (list/get only) — `tags.create`, `tags.patch`, `tags.delete` all 404'd, so there was no way to exercise immutable-tag enforcement through the real `artifactregistry/v1` client at all.

## What this PR adds

- `packages.tags.create`: creates a new tag id pointing at an existing version under the same package. A brand-new tag id is always allowed (matching real AR); the referenced version must resolve to the package's own version or the call is `NOT_FOUND`; a duplicate tag id is `ALREADY_EXISTS`.
- `packages.tags.patch` / `packages.tags.delete`: rejected with `FAILED_PRECONDITION` when the repository has `dockerConfig.immutableTags=true`, matching real Artifact Registry ("you cannot update a tag to point to a new image" / "you cannot delete a tag"). Allowed on mutable repositories.
- A new GCP-only `UntagImage` extension on the Artifact Registry provider mock (not part of the shared `ContainerRegistry` driver interface used by AWS ECR / Azure ACR) removes a single tag without deleting the underlying package/version — the shared interface only supports deleting a whole image.

## Deferred / out of scope

- The provider's package/version model is one version per package (package id == image digest), inherited from the shared ECR/ACR-style driver. Re-pointing a tag to a genuinely different version of the *same* package name isn't representable without a broader multi-version-per-package model; that would require touching the shared `containerregistry` driver (and therefore AWS ECR / Azure ACR), which is out of scope here.
- `cleanupPolicies` are still stored/round-tripped only, not evaluated at the wire layer (the provider does have `EvaluateLifecyclePolicy`, but it isn't wired to any wire-level endpoint or dry-run response). Left as a separate follow-up.