### PR TITLE
fix(s3): real-user e2e divergences from AWS

### DIFF
--- a/server/aws/s3/bucket_config.go
+++ b/server/aws/s3/bucket_config.go
@@ -12,10 +12,32 @@ import (
 // subLocation is the ?location sub-resource key (GetBucketLocation).
 const subLocation = "location"
 
+// subLifecycle is the ?lifecycle sub-resource key (Put/GetBucketLifecycleConfiguration).
+const subLifecycle = "lifecycle"
+
 // maxConfigBody caps a bucket-configuration document. Real S3 bucket policies
 // top out at 20 KB; this is a generous ceiling covering cors/lifecycle/website
 // XML as well.
 const maxConfigBody = 2 << 20
+
+// transitionDefaultMinimumObjectSizeHeader is the request/response header real
+// S3 uses to carry PutBucketLifecycleConfiguration's
+// TransitionDefaultMinimumObjectSize setting. Unlike every other lifecycle
+// field it travels as a header rather than XML body, so the byte-for-byte raw
+// echo in writeRawBucketConfig never sees it — it needs separate capture and
+// echo alongside the stored document.
+const transitionDefaultMinimumObjectSizeHeader = "X-Amz-Transition-Default-Minimum-Object-Size"
+
+// transitionDefaultMinimumObjectSizeKey is the internal RawBucketConfig
+// sub-resource name used to persist the header value alongside the lifecycle
+// document. It is not a real S3 query-string sub-resource, just a bookkeeping
+// key in the same opaque per-bucket document store.
+const transitionDefaultMinimumObjectSizeKey = "lifecycle-transition-default-minimum-object-size"
+
+// transitionDefaultMinimumObjectSizeDefault is the value real S3 applies to a
+// general purpose bucket's lifecycle configuration when the header is omitted
+// from the request.
+const transitionDefaultMinimumObjectSizeDefault = "all_storage_classes_128K"
 
 // notConfiguredErr maps a read-only bucket configuration sub-resource (query
 // key) to the AWS error code S3 returns when the bucket has no such
@@ -28,7 +50,7 @@ var notConfiguredErr = map[string]string{
 	"policy":            "NoSuchBucketPolicy",
 	"cors":              "NoSuchCORSConfiguration",
 	"website":           "NoSuchWebsiteConfiguration",
-	"lifecycle":         "NoSuchLifecycleConfiguration",
+	subLifecycle:        "NoSuchLifecycleConfiguration",
 	"replication":       "ReplicationConfigurationNotFoundError",
 	"encryption":        "ServerSideEncryptionConfigurationNotFoundError",
 	"object-lock":       "ObjectLockConfigurationNotFoundError",
@@ -41,7 +63,7 @@ var notConfiguredErr = map[string]string{
 //
 //nolint:gochecknoglobals // static set
 var configSubresources = []string{
-	"policy", "cors", "website", "lifecycle", "replication", "encryption",
+	"policy", "cors", "website", subLifecycle, "replication", "encryption",
 	"object-lock", "publicAccessBlock", "ownershipControls",
 	"requestPayment", "accelerate", "logging", subLocation, "policyStatus",
 }
@@ -98,6 +120,20 @@ func (h *Handler) putBucketConfig(w http.ResponseWriter, r *http.Request, bucket
 		return
 	}
 
+	if sub == subLifecycle {
+		minSize := r.Header.Get(transitionDefaultMinimumObjectSizeHeader)
+		if minSize == "" {
+			minSize = transitionDefaultMinimumObjectSizeDefault
+		}
+
+		if err := h.rawConfig.PutBucketConfig(r.Context(), bucket, transitionDefaultMinimumObjectSizeKey, []byte(minSize)); err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		w.Header().Set(transitionDefaultMinimumObjectSizeHeader, minSize)
+	}
+
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -108,6 +144,10 @@ func (h *Handler) deleteBucketConfig(w http.ResponseWriter, r *http.Request, buc
 		if err := h.rawConfig.DeleteBucketConfig(r.Context(), bucket, sub); err != nil {
 			writeErr(w, err)
 			return
+		}
+
+		if sub == subLifecycle {
+			_ = h.rawConfig.DeleteBucketConfig(r.Context(), bucket, transitionDefaultMinimumObjectSizeKey)
 		}
 	}
 
@@ -138,12 +178,30 @@ func (h *Handler) getBucketConfig(w http.ResponseWriter, r *http.Request, bucket
 
 	if h.rawConfig != nil {
 		if body, err := h.rawConfig.GetBucketConfig(r.Context(), bucket, sub); err == nil {
+			if sub == subLifecycle {
+				w.Header().Set(transitionDefaultMinimumObjectSizeHeader, h.lifecycleTransitionMinSize(r, bucket))
+			}
+
 			writeRawBucketConfig(w, sub, body)
+
 			return
 		}
 	}
 
 	writeConfigDefault(w, sub)
+}
+
+// lifecycleTransitionMinSize returns the TransitionDefaultMinimumObjectSize
+// value stored alongside the bucket's lifecycle document, falling back to the
+// real-S3 default for a general purpose bucket when none was ever recorded
+// (e.g. a document written before this side-channel existed).
+func (h *Handler) lifecycleTransitionMinSize(r *http.Request, bucket string) string {
+	stored, err := h.rawConfig.GetBucketConfig(r.Context(), bucket, transitionDefaultMinimumObjectSizeKey)
+	if err != nil {
+		return transitionDefaultMinimumObjectSizeDefault
+	}
+
+	return string(stored)
 }
 
 // writeRawBucketConfig echoes a persisted configuration document verbatim with

--- a/server/aws/s3/bucket_config_test.go
+++ b/server/aws/s3/bucket_config_test.go
@@ -124,7 +124,13 @@ func TestSDKBucketEncryptionRoundTrip(t *testing.T) {
 
 // TestSDKBucketLifecycleRoundTrip covers the config-persistence gap for
 // PutBucketLifecycleConfiguration: the rule must read back instead of
-// NoSuchLifecycleConfiguration.
+// NoSuchLifecycleConfiguration. It also covers TransitionDefaultMinimumObjectSize,
+// which real S3 carries as a request/response HEADER rather than XML body — the
+// Terraform AWS provider always sends this header (its schema defaults it to
+// all_storage_classes_128K), and polls GetBucketLifecycleConfiguration
+// comparing the full rule set including this field until it matches. Dropping
+// it made every "terraform apply" of aws_s3_bucket_lifecycle_configuration hang
+// for its full 3-minute timeout and then fail outright.
 func TestSDKBucketLifecycleRoundTrip(t *testing.T) {
 	client := newSDKClient(t)
 	ctx := context.Background()
@@ -142,6 +148,7 @@ func TestSDKBucketLifecycleRoundTrip(t *testing.T) {
 				Expiration: &types.LifecycleExpiration{Days: aws.Int32(30)},
 			}},
 		},
+		TransitionDefaultMinimumObjectSize: types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k,
 	}); err != nil {
 		t.Fatalf("PutBucketLifecycleConfiguration: %v", err)
 	}
@@ -157,6 +164,47 @@ func TestSDKBucketLifecycleRoundTrip(t *testing.T) {
 	}
 	if got.Rules[0].Expiration == nil || aws.ToInt32(got.Rules[0].Expiration.Days) != 30 {
 		t.Fatalf("lifecycle expiration = %+v, want 30 days", got.Rules[0].Expiration)
+	}
+	if got.TransitionDefaultMinimumObjectSize != types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k {
+		t.Fatalf("TransitionDefaultMinimumObjectSize = %q, want %q",
+			got.TransitionDefaultMinimumObjectSize, types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k)
+	}
+}
+
+// TestSDKBucketLifecycleTransitionMinSizeDefault covers the case where the
+// client omits TransitionDefaultMinimumObjectSize entirely (e.g. aws-cli/boto3,
+// which never sends this header): real S3 still reports a default value for a
+// general purpose bucket on the subsequent read.
+func TestSDKBucketLifecycleTransitionMinSizeDefault(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "lc-default-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	if _, err := client.PutBucketLifecycleConfiguration(ctx, &awss3.PutBucketLifecycleConfigurationInput{
+		Bucket: aws.String(bucket),
+		LifecycleConfiguration: &types.BucketLifecycleConfiguration{
+			Rules: []types.LifecycleRule{{
+				ID:         aws.String("expire-all"),
+				Status:     types.ExpirationStatusEnabled,
+				Filter:     &types.LifecycleRuleFilter{Prefix: aws.String("")},
+				Expiration: &types.LifecycleExpiration{Days: aws.Int32(7)},
+			}},
+		},
+	}); err != nil {
+		t.Fatalf("PutBucketLifecycleConfiguration: %v", err)
+	}
+
+	got, err := client.GetBucketLifecycleConfiguration(ctx, &awss3.GetBucketLifecycleConfigurationInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatalf("GetBucketLifecycleConfiguration: %v", err)
+	}
+	if got.TransitionDefaultMinimumObjectSize != types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k {
+		t.Fatalf("TransitionDefaultMinimumObjectSize = %q, want default %q",
+			got.TransitionDefaultMinimumObjectSize, types.TransitionDefaultMinimumObjectSizeAllStorageClasses128k)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Deep real-user e2e audit of AWS S3 (aws-cli s3api/s3, Terraform, aws-sdk-go-v2) against the standalone `cloudemu serve` wire server.
- Fixes the one confirmed, cohesive divergence found: `PutBucketLifecycleConfiguration`/`GetBucketLifecycleConfiguration` silently dropped `TransitionDefaultMinimumObjectSize`. Real S3 carries this field as the `X-Amz-Transition-Default-Minimum-Object-Size` request/response header (not XML body), so the previous byte-for-byte raw-body echo never captured it and always read it back empty.
- Impact: the Terraform AWS provider's `aws_s3_bucket_lifecycle_configuration` resource defaults this attribute and polls the read comparing the full rule set (including this field) until it matches, so `terraform apply` for this resource hung for its full 3-minute timeout and then failed — this is one of the most common S3 Terraform resources.
- `server/aws/s3/bucket_config.go`: capture the header on PUT (defaulting to `all_storage_classes_128K` for a general purpose bucket when omitted, matching real S3), persist it alongside the raw document via the existing opaque `RawBucketConfig` store, echo it back on PUT/GET responses, and clean it up on delete.
- Verified end-to-end against a real `cloudemu serve` process with `terraform apply` / `plan` / `destroy` for a bucket + versioning + lifecycle + objects config — apply now converges in ~55s (matching the AWS provider's own consecutive-poll wait) with no perpetual diff.
- Added SDK-level regression tests covering both an explicit value and the omitted-header default.
- Other divergences surveyed (bucket naming, versioning, delete markers, multipart, conditional GET/range, object lock/retention, copy semantics, tagging, policy/ACL/public-access-block) matched real AWS behavior and are not filed as bugs, except one filed-but-not-fixed medium finding (CopyObject preserving a multipart-style ETag suffix instead of recomputing a plain MD5) that needs an architectural decision before touching.

## Test plan
- [x] `go build ./...`
- [x] `go test ./providers/aws/s3/... ./server/aws/s3/... -race`
- [x] `gofmt -l` clean
- [x] `golangci-lint run ./server/aws/s3/...` — no new findings (pre-existing findings only in untouched `handler.go`)
- [x] Real `cloudemu serve` + `terraform apply/plan/destroy` against a bucket+versioning+lifecycle+objects config