### PR TITLE
feat(azure-acr): changeableAttributes lock for repositories, tags, and manifests

### DIFF
--- a/docs/coverage/azure/acr.md
+++ b/docs/coverage/azure/acr.md
@@ -59,6 +59,12 @@ AzureRepositoryWriter is the Azure-specific ACR data-plane surface for
 | Operation | Description |
 | --- | --- |
 | `DeleteTag` |  |
+| `GetManifestAttributes` |  |
+| `GetRepositoryAttributes` |  |
+| `GetTagAttributes` |  |
+| `UpdateManifestAttributes` |  |
+| `UpdateRepositoryAttributes` |  |
+| `UpdateTagAttributes` |  |
 
 ## Not in scope
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -3163,6 +3163,24 @@
         "operations": [
           {
             "name": "DeleteTag"
+          },
+          {
+            "name": "GetManifestAttributes"
+          },
+          {
+            "name": "GetRepositoryAttributes"
+          },
+          {
+            "name": "GetTagAttributes"
+          },
+          {
+            "name": "UpdateManifestAttributes"
+          },
+          {
+            "name": "UpdateRepositoryAttributes"
+          },
+          {
+            "name": "UpdateTagAttributes"
           }
         ]
       }

--- a/providers/azure/acr/acr.go
+++ b/providers/azure/acr/acr.go
@@ -35,6 +35,9 @@ var _ driver.ContainerRegistry = (*Mock)(nil)
 type imageData struct {
 	detail driver.ImageDetail
 	layers []driver.LayerInfo
+	// attrs is the manifest's changeableAttributes (deleteEnabled/writeEnabled/
+	// listEnabled/readEnabled), set via PATCH /acr/v1/{name}/_manifests/{digest}.
+	attrs changeableAttrs
 }
 
 type repoData struct {
@@ -44,6 +47,12 @@ type repoData struct {
 	policy        *driver.LifecyclePolicy
 	scanOnPush    bool
 	tagMutability string
+	// attrs is the repository's changeableAttributes, set via PATCH
+	// /acr/v1/{name}.
+	attrs changeableAttrs
+	// tagAttrs holds each tag's changeableAttributes, set via PATCH
+	// /acr/v1/{name}/_tags/{tag}. A tag absent from this map is fully enabled.
+	tagAttrs map[string]changeableAttrs
 }
 
 // Mock is an in-memory mock implementation of the Azure Container Registry service.
@@ -131,6 +140,7 @@ func (m *Mock) CreateRepository(_ context.Context, cfg driver.RepositoryConfig) 
 		scans:         memstore.New[*driver.ScanResult](),
 		scanOnPush:    cfg.ImageScanOnPush,
 		tagMutability: mutability,
+		attrs:         defaultChangeableAttrs(),
 	}
 
 	m.repos.Set(cfg.Name, rd)
@@ -145,6 +155,10 @@ func (m *Mock) DeleteRepository(_ context.Context, name string, force bool) erro
 	rd, ok := m.repos.Get(name)
 	if !ok {
 		return errors.Newf(errors.NotFound, "repository %q not found", name)
+	}
+
+	if err := checkRepoDeletable(rd, name); err != nil {
+		return err
 	}
 
 	if !force && rd.images.Len() > 0 {
@@ -169,12 +183,18 @@ func (m *Mock) GetRepository(_ context.Context, name string) (*driver.Repository
 	return &result, nil
 }
 
-// ListRepositories lists all ACR repositories.
+// ListRepositories lists all ACR repositories whose listEnabled attribute is
+// not locked. A read-locked or write-locked repository still appears here;
+// only listEnabled hides a repository from the catalog.
 func (m *Mock) ListRepositories(_ context.Context) ([]driver.Repository, error) {
 	all := m.repos.All()
 	repos := make([]driver.Repository, 0, len(all))
 
 	for _, rd := range all {
+		if !rd.attrs.listEnabled {
+			continue
+		}
+
 		repo := rd.info
 		repo.ImageCount = rd.images.Len()
 		repos = append(repos, repo)
@@ -195,7 +215,15 @@ func (m *Mock) PutImage(_ context.Context, manifest *driver.ImageManifest) (*dri
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", manifest.Repository)
 	}
 
+	if err := checkRepoWritable(rd, manifest.Repository); err != nil {
+		return nil, err
+	}
+
 	if err := checkTagMutability(rd, manifest.Tag); err != nil {
+		return nil, err
+	}
+
+	if err := checkTagWritable(rd, manifest.Tag); err != nil {
 		return nil, err
 	}
 
@@ -209,9 +237,13 @@ func (m *Mock) PutImage(_ context.Context, manifest *driver.ImageManifest) (*dri
 	}
 
 	// Content-addressing parity: re-pushing the same digest under a new tag must
-	// preserve the pre-existing tags on that manifest rather than clobbering them.
+	// preserve the pre-existing tags on that manifest rather than clobbering them,
+	// and a manifest that was already PATCHed keeps its changeableAttributes.
+	attrs := defaultChangeableAttrs()
+
 	if existing, ok := rd.images.Get(digest); ok {
 		tags = unionTags(existing.detail.Tags, manifest.Tag)
+		attrs = existing.attrs
 	}
 
 	detail := driver.ImageDetail{
@@ -224,7 +256,7 @@ func (m *Mock) PutImage(_ context.Context, manifest *driver.ImageManifest) (*dri
 		MediaType:  mediaType,
 	}
 
-	img := &imageData{detail: detail, layers: manifest.Layers}
+	img := &imageData{detail: detail, layers: manifest.Layers, attrs: attrs}
 	rd.images.Set(digest, img)
 
 	if manifest.Tag != "" {
@@ -263,7 +295,9 @@ func (m *Mock) GetImage(_ context.Context, repository, reference string) (*drive
 	return &result, nil
 }
 
-// ListImages lists all images in an ACR repository.
+// ListImages lists all images in an ACR repository whose listEnabled
+// attribute is not locked. A read-locked or write-locked manifest still
+// appears here; only listEnabled hides a manifest from the listing.
 func (m *Mock) ListImages(_ context.Context, repository string) ([]driver.ImageDetail, error) {
 	rd, ok := m.repos.Get(repository)
 	if !ok {
@@ -274,6 +308,10 @@ func (m *Mock) ListImages(_ context.Context, repository string) ([]driver.ImageD
 	images := make([]driver.ImageDetail, 0, len(all))
 
 	for _, img := range all {
+		if !img.attrs.listEnabled {
+			continue
+		}
+
 		images = append(images, img.detail)
 	}
 
@@ -295,9 +333,17 @@ func (m *Mock) DeleteImage(_ context.Context, repository, reference string) erro
 		return errors.Newf(errors.NotFound, "image %q not found in repository %q", reference, repository)
 	}
 
+	if err := checkManifestDeletable(img); err != nil {
+		return err
+	}
+
 	rd.images.Delete(img.detail.Digest)
 	rd.scans.Delete(img.detail.Digest)
 	rd.info.ImageCount = rd.images.Len()
+
+	for _, tag := range img.detail.Tags {
+		forgetTag(rd, tag)
+	}
 
 	return nil
 }
@@ -325,6 +371,10 @@ func (m *Mock) TagImage(_ context.Context, repository, sourceRef, targetTag stri
 		return err
 	}
 
+	if err := checkTagWritable(rd, targetTag); err != nil {
+		return err
+	}
+
 	updateTagIndex(rd, img.detail.Digest, targetTag)
 	rd.info.ImageCount = rd.images.Len()
 
@@ -348,6 +398,15 @@ func (m *Mock) DeleteTag(_ context.Context, repository, tag string) error {
 		return errors.Newf(errors.NotFound, "repository %q not found", repository)
 	}
 
+	attrs, ok := tagAttrsOf(rd, tag)
+	if !ok {
+		return errors.Newf(errors.NotFound, "tag %q not found in repository %q", tag, repository)
+	}
+
+	if !attrs.deleteEnabled {
+		return errors.Newf(errors.FailedPrecondition, "tag %q is delete-locked (deleteEnabled=false)", tag)
+	}
+
 	all := rd.images.All()
 	for d, img := range all {
 		if !hasTag(img.detail.Tags, tag) {
@@ -356,6 +415,7 @@ func (m *Mock) DeleteTag(_ context.Context, repository, tag string) error {
 
 		img.detail.Tags = removeTag(img.detail.Tags, tag)
 		rd.images.Set(d, img)
+		forgetTag(rd, tag)
 
 		return nil
 	}

--- a/providers/azure/acr/acr.go
+++ b/providers/azure/acr/acr.go
@@ -152,6 +152,9 @@ func (m *Mock) CreateRepository(_ context.Context, cfg driver.RepositoryConfig) 
 
 // DeleteRepository deletes an ACR repository.
 func (m *Mock) DeleteRepository(_ context.Context, name string, force bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(name)
 	if !ok {
 		return errors.Newf(errors.NotFound, "repository %q not found", name)
@@ -187,6 +190,9 @@ func (m *Mock) GetRepository(_ context.Context, name string) (*driver.Repository
 // not locked. A read-locked or write-locked repository still appears here;
 // only listEnabled hides a repository from the catalog.
 func (m *Mock) ListRepositories(_ context.Context) ([]driver.Repository, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	all := m.repos.All()
 	repos := make([]driver.Repository, 0, len(all))
 
@@ -299,6 +305,9 @@ func (m *Mock) GetImage(_ context.Context, repository, reference string) (*drive
 // attribute is not locked. A read-locked or write-locked manifest still
 // appears here; only listEnabled hides a manifest from the listing.
 func (m *Mock) ListImages(_ context.Context, repository string) ([]driver.ImageDetail, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)

--- a/providers/azure/acr/attributes.go
+++ b/providers/azure/acr/attributes.go
@@ -1,0 +1,256 @@
+package acr
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+// Compile-time check that Mock implements the full Azure data-plane surface,
+// including the changeableAttributes lock.
+var _ driver.AzureRepositoryWriter = (*Mock)(nil)
+
+// changeableAttrs is the resolved (never-nil) form of a repository's, tag's, or
+// manifest's changeableAttributes. A resource that has never been PATCHed is
+// fully enabled, matching real ACR.
+type changeableAttrs struct {
+	deleteEnabled bool
+	writeEnabled  bool
+	listEnabled   bool
+	readEnabled   bool
+}
+
+func defaultChangeableAttrs() changeableAttrs {
+	return changeableAttrs{deleteEnabled: true, writeEnabled: true, listEnabled: true, readEnabled: true}
+}
+
+// merge applies the non-nil fields of upd onto a, leaving the rest unchanged —
+// the semantics of ACR's partial-update PATCH body.
+func (a changeableAttrs) merge(upd driver.AzureChangeableAttributes) changeableAttrs {
+	if upd.DeleteEnabled != nil {
+		a.deleteEnabled = *upd.DeleteEnabled
+	}
+
+	if upd.WriteEnabled != nil {
+		a.writeEnabled = *upd.WriteEnabled
+	}
+
+	if upd.ListEnabled != nil {
+		a.listEnabled = *upd.ListEnabled
+	}
+
+	if upd.ReadEnabled != nil {
+		a.readEnabled = *upd.ReadEnabled
+	}
+
+	return a
+}
+
+// toDriver resolves a into a fully-populated driver.AzureChangeableAttributes
+// (every pointer non-nil), the shape a Get call always returns.
+func (a changeableAttrs) toDriver() driver.AzureChangeableAttributes {
+	del, wr, ls, rd := a.deleteEnabled, a.writeEnabled, a.listEnabled, a.readEnabled
+
+	return driver.AzureChangeableAttributes{
+		DeleteEnabled: &del,
+		WriteEnabled:  &wr,
+		ListEnabled:   &ls,
+		ReadEnabled:   &rd,
+	}
+}
+
+// tagExists reports whether tag currently points at some image in rd.
+func tagExists(rd *repoData, tag string) bool {
+	for _, img := range rd.images.All() {
+		if hasTag(img.detail.Tags, tag) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// tagAttrsOf returns tag's changeableAttributes, defaulting to fully-enabled
+// for a tag that has never been PATCHed. ok is false when tag does not
+// currently point at any image.
+func tagAttrsOf(rd *repoData, tag string) (attrs changeableAttrs, ok bool) {
+	if !tagExists(rd, tag) {
+		return changeableAttrs{}, false
+	}
+
+	if a, found := rd.tagAttrs[tag]; found {
+		return a, true
+	}
+
+	return defaultChangeableAttrs(), true
+}
+
+// checkRepoDeletable returns FailedPrecondition when the repository's
+// deleteEnabled attribute is locked.
+func checkRepoDeletable(rd *repoData, name string) error {
+	if !rd.attrs.deleteEnabled {
+		return errors.Newf(errors.FailedPrecondition, "repository %q is delete-locked (deleteEnabled=false)", name)
+	}
+
+	return nil
+}
+
+// checkRepoWritable returns FailedPrecondition when the repository's
+// writeEnabled attribute is locked.
+func checkRepoWritable(rd *repoData, name string) error {
+	if !rd.attrs.writeEnabled {
+		return errors.Newf(errors.FailedPrecondition, "repository %q is write-locked (writeEnabled=false)", name)
+	}
+
+	return nil
+}
+
+// checkTagWritable returns FailedPrecondition when tag already exists and is
+// write-locked. A tag that does not yet exist is always writable (creating a
+// new tag is never an "overwrite").
+func checkTagWritable(rd *repoData, tag string) error {
+	attrs, ok := tagAttrsOf(rd, tag)
+	if !ok || attrs.writeEnabled {
+		return nil
+	}
+
+	return errors.Newf(errors.FailedPrecondition, "tag %q is write-locked (writeEnabled=false)", tag)
+}
+
+// checkManifestDeletable returns FailedPrecondition when img's deleteEnabled
+// attribute is locked.
+func checkManifestDeletable(img *imageData) error {
+	if !img.attrs.deleteEnabled {
+		return errors.Newf(errors.FailedPrecondition, "manifest %q is delete-locked (deleteEnabled=false)", img.detail.Digest)
+	}
+
+	return nil
+}
+
+// forgetTag drops tag's per-tag changeableAttributes once it no longer points
+// at any image, so a future tag pushed under the same name starts unlocked.
+func forgetTag(rd *repoData, tag string) {
+	delete(rd.tagAttrs, tag)
+}
+
+// GetRepositoryAttributes returns the repository-level changeableAttributes.
+func (m *Mock) GetRepositoryAttributes(_ context.Context, repository string) (driver.AzureChangeableAttributes, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return driver.AzureChangeableAttributes{}, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	return rd.attrs.toDriver(), nil
+}
+
+// UpdateRepositoryAttributes merges attrs onto the repository's
+// changeableAttributes (PATCH /acr/v1/{name}).
+func (m *Mock) UpdateRepositoryAttributes(
+	_ context.Context, repository string, attrs driver.AzureChangeableAttributes,
+) (driver.AzureChangeableAttributes, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return driver.AzureChangeableAttributes{}, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	rd.attrs = rd.attrs.merge(attrs)
+
+	return rd.attrs.toDriver(), nil
+}
+
+// GetTagAttributes returns tag's changeableAttributes.
+func (m *Mock) GetTagAttributes(_ context.Context, repository, tag string) (driver.AzureChangeableAttributes, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return driver.AzureChangeableAttributes{}, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	attrs, ok := tagAttrsOf(rd, tag)
+	if !ok {
+		return driver.AzureChangeableAttributes{}, errors.Newf(errors.NotFound, "tag %q not found in repository %q", tag, repository)
+	}
+
+	return attrs.toDriver(), nil
+}
+
+// UpdateTagAttributes merges attrs onto tag's changeableAttributes (PATCH
+// /acr/v1/{name}/_tags/{tag}).
+func (m *Mock) UpdateTagAttributes(
+	_ context.Context, repository, tag string, attrs driver.AzureChangeableAttributes,
+) (driver.AzureChangeableAttributes, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return driver.AzureChangeableAttributes{}, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	current, ok := tagAttrsOf(rd, tag)
+	if !ok {
+		return driver.AzureChangeableAttributes{}, errors.Newf(errors.NotFound, "tag %q not found in repository %q", tag, repository)
+	}
+
+	if rd.tagAttrs == nil {
+		rd.tagAttrs = make(map[string]changeableAttrs)
+	}
+
+	merged := current.merge(attrs)
+	rd.tagAttrs[tag] = merged
+
+	return merged.toDriver(), nil
+}
+
+// GetManifestAttributes returns the manifest's changeableAttributes.
+func (m *Mock) GetManifestAttributes(
+	_ context.Context, repository, digest string,
+) (driver.AzureChangeableAttributes, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return driver.AzureChangeableAttributes{}, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, digest)
+	if img == nil {
+		return driver.AzureChangeableAttributes{}, errors.Newf(errors.NotFound, "image %q not found in repository %q", digest, repository)
+	}
+
+	return img.attrs.toDriver(), nil
+}
+
+// UpdateManifestAttributes merges attrs onto the manifest's
+// changeableAttributes (PATCH /acr/v1/{name}/_manifests/{digest}).
+func (m *Mock) UpdateManifestAttributes(
+	_ context.Context, repository, digest string, attrs driver.AzureChangeableAttributes,
+) (driver.AzureChangeableAttributes, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return driver.AzureChangeableAttributes{}, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, digest)
+	if img == nil {
+		return driver.AzureChangeableAttributes{}, errors.Newf(errors.NotFound, "image %q not found in repository %q", digest, repository)
+	}
+
+	img.attrs = img.attrs.merge(attrs)
+	rd.images.Set(img.detail.Digest, img)
+
+	return img.attrs.toDriver(), nil
+}

--- a/providers/azure/acr/attributes_test.go
+++ b/providers/azure/acr/attributes_test.go
@@ -1,0 +1,316 @@
+package acr
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func falsePtr() *bool {
+	f := false
+
+	return &f
+}
+
+func truePtr() *bool {
+	t := true
+
+	return &t
+}
+
+func TestRepositoryAttributesRoundTrip(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "app")
+
+	attrs, err := m.GetRepositoryAttributes(ctx, "app")
+	require.NoError(t, err)
+	assert.True(t, *attrs.DeleteEnabled)
+	assert.True(t, *attrs.WriteEnabled)
+	assert.True(t, *attrs.ListEnabled)
+	assert.True(t, *attrs.ReadEnabled)
+
+	updated, err := m.UpdateRepositoryAttributes(ctx, "app", driver.AzureChangeableAttributes{DeleteEnabled: falsePtr()})
+	require.NoError(t, err)
+	assert.False(t, *updated.DeleteEnabled)
+	assert.True(t, *updated.WriteEnabled, "unspecified fields must be left unchanged")
+
+	_, err = m.GetRepositoryAttributes(ctx, "ghost")
+	require.Error(t, err)
+
+	_, err = m.UpdateRepositoryAttributes(ctx, "ghost", driver.AzureChangeableAttributes{})
+	require.Error(t, err)
+}
+
+func TestRepositoryDeleteEnabledBlocksDeleteRepository(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "locked")
+
+	_, err := m.UpdateRepositoryAttributes(ctx, "locked", driver.AzureChangeableAttributes{DeleteEnabled: falsePtr()})
+	require.NoError(t, err)
+
+	err = m.DeleteRepository(ctx, "locked", true)
+	require.Error(t, err)
+	assert.True(t, errors.IsFailedPrecondition(err))
+
+	_, err = m.UpdateRepositoryAttributes(ctx, "locked", driver.AzureChangeableAttributes{DeleteEnabled: truePtr()})
+	require.NoError(t, err)
+
+	require.NoError(t, m.DeleteRepository(ctx, "locked", true))
+}
+
+func TestRepositoryWriteEnabledBlocksPutImage(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "app")
+
+	_, err := m.UpdateRepositoryAttributes(ctx, "app", driver.AzureChangeableAttributes{WriteEnabled: falsePtr()})
+	require.NoError(t, err)
+
+	_, err = m.PutImage(ctx, &driver.ImageManifest{Repository: "app", Tag: "v1"})
+	require.Error(t, err)
+	assert.True(t, errors.IsFailedPrecondition(err))
+}
+
+func TestRepositoryListEnabledHidesFromListRepositories(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "hidden")
+	createTestRepo(t, m, "visible")
+
+	_, err := m.UpdateRepositoryAttributes(ctx, "hidden", driver.AzureChangeableAttributes{ListEnabled: falsePtr()})
+	require.NoError(t, err)
+
+	repos, err := m.ListRepositories(ctx)
+	require.NoError(t, err)
+
+	var names []string
+	for _, r := range repos {
+		names = append(names, r.Name)
+	}
+
+	hasSuffix := func(names []string, suffix string) bool {
+		for _, n := range names {
+			if strings.HasSuffix(n, "/"+suffix) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	assert.False(t, hasSuffix(names, "hidden"))
+	assert.True(t, hasSuffix(names, "visible"))
+
+	// Direct fetch still works: listEnabled only hides from listing.
+	_, err = m.GetRepository(ctx, "hidden")
+	require.NoError(t, err)
+}
+
+func TestTagAttributesRoundTrip(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "app")
+	pushTestImage(t, m, "app", "v1")
+
+	attrs, err := m.GetTagAttributes(ctx, "app", "v1")
+	require.NoError(t, err)
+	assert.True(t, *attrs.DeleteEnabled)
+
+	updated, err := m.UpdateTagAttributes(ctx, "app", "v1", driver.AzureChangeableAttributes{WriteEnabled: falsePtr()})
+	require.NoError(t, err)
+	assert.False(t, *updated.WriteEnabled)
+	assert.True(t, *updated.DeleteEnabled)
+
+	_, err = m.GetTagAttributes(ctx, "app", "ghost")
+	require.Error(t, err)
+
+	_, err = m.UpdateTagAttributes(ctx, "app", "ghost", driver.AzureChangeableAttributes{})
+	require.Error(t, err)
+
+	_, err = m.UpdateTagAttributes(ctx, "ghost-repo", "v1", driver.AzureChangeableAttributes{})
+	require.Error(t, err)
+}
+
+func TestTagDeleteEnabledBlocksDeleteTag(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "app")
+	pushTestImage(t, m, "app", "v1")
+
+	_, err := m.UpdateTagAttributes(ctx, "app", "v1", driver.AzureChangeableAttributes{DeleteEnabled: falsePtr()})
+	require.NoError(t, err)
+
+	err = m.DeleteTag(ctx, "app", "v1")
+	require.Error(t, err)
+	assert.True(t, errors.IsFailedPrecondition(err))
+
+	_, err = m.UpdateTagAttributes(ctx, "app", "v1", driver.AzureChangeableAttributes{DeleteEnabled: truePtr()})
+	require.NoError(t, err)
+
+	require.NoError(t, m.DeleteTag(ctx, "app", "v1"))
+}
+
+func TestTagWriteEnabledBlocksOverwriteAndRetag(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "app")
+	pushTestImage(t, m, "app", "v1")
+	pushTestImage(t, m, "app", "v2")
+
+	_, err := m.UpdateTagAttributes(ctx, "app", "v1", driver.AzureChangeableAttributes{WriteEnabled: falsePtr()})
+	require.NoError(t, err)
+
+	t.Run("PutImage overwrite blocked", func(t *testing.T) {
+		_, err := m.PutImage(ctx, &driver.ImageManifest{Repository: "app", Tag: "v1"})
+		require.Error(t, err)
+		assert.True(t, errors.IsFailedPrecondition(err))
+	})
+
+	t.Run("TagImage retag blocked", func(t *testing.T) {
+		err := m.TagImage(ctx, "app", "v2", "v1")
+		require.Error(t, err)
+		assert.True(t, errors.IsFailedPrecondition(err))
+	})
+
+	t.Run("new tag unaffected", func(t *testing.T) {
+		require.NoError(t, m.TagImage(ctx, "app", "v2", "latest"))
+	})
+}
+
+func TestTagListEnabledHidesFromListImagesTags(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "app")
+	pushTestImage(t, m, "app", "v1")
+	pushTestImage(t, m, "app", "v2")
+
+	_, err := m.UpdateTagAttributes(ctx, "app", "v1", driver.AzureChangeableAttributes{ListEnabled: falsePtr()})
+	require.NoError(t, err)
+
+	// ListImages is manifest-scoped, not tag-scoped: a tag-level list lock
+	// leaves the manifest (and its other tags) fully listed.
+	images, err := m.ListImages(ctx, "app")
+	require.NoError(t, err)
+	assert.Len(t, images, 2)
+}
+
+func TestForgetTagResetsAttributesOnRecreate(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "app")
+	pushTestImage(t, m, "app", "v1")
+
+	_, err := m.UpdateTagAttributes(ctx, "app", "v1", driver.AzureChangeableAttributes{DeleteEnabled: falsePtr(), WriteEnabled: falsePtr()})
+	require.NoError(t, err)
+
+	_, err = m.UpdateTagAttributes(ctx, "app", "v1", driver.AzureChangeableAttributes{DeleteEnabled: truePtr()})
+	require.NoError(t, err)
+	require.NoError(t, m.DeleteTag(ctx, "app", "v1"))
+
+	// A brand new tag pushed under the same name is a new resource: it must
+	// not inherit the deleted tag's writeEnabled=false lock.
+	pushTestImage(t, m, "app", "v1")
+
+	attrs, err := m.GetTagAttributes(ctx, "app", "v1")
+	require.NoError(t, err)
+	assert.True(t, *attrs.WriteEnabled)
+}
+
+func TestManifestAttributesRoundTrip(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "app")
+	detail := pushTestImage(t, m, "app", "v1")
+
+	attrs, err := m.GetManifestAttributes(ctx, "app", detail.Digest)
+	require.NoError(t, err)
+	assert.True(t, *attrs.DeleteEnabled)
+
+	updated, err := m.UpdateManifestAttributes(ctx, "app", detail.Digest, driver.AzureChangeableAttributes{ListEnabled: falsePtr()})
+	require.NoError(t, err)
+	assert.False(t, *updated.ListEnabled)
+
+	_, err = m.GetManifestAttributes(ctx, "app", "sha256:ghost")
+	require.Error(t, err)
+
+	_, err = m.UpdateManifestAttributes(ctx, "app", "sha256:ghost", driver.AzureChangeableAttributes{})
+	require.Error(t, err)
+}
+
+func TestManifestDeleteEnabledBlocksDeleteImage(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "app")
+	detail := pushTestImage(t, m, "app", "v1")
+
+	_, err := m.UpdateManifestAttributes(ctx, "app", detail.Digest, driver.AzureChangeableAttributes{DeleteEnabled: falsePtr()})
+	require.NoError(t, err)
+
+	err = m.DeleteImage(ctx, "app", detail.Digest)
+	require.Error(t, err)
+	assert.True(t, errors.IsFailedPrecondition(err))
+
+	_, err = m.UpdateManifestAttributes(ctx, "app", detail.Digest, driver.AzureChangeableAttributes{DeleteEnabled: truePtr()})
+	require.NoError(t, err)
+
+	require.NoError(t, m.DeleteImage(ctx, "app", detail.Digest))
+}
+
+func TestManifestListEnabledHidesFromListImages(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "app")
+	hidden := pushTestImage(t, m, "app", "v1")
+	pushTestImage(t, m, "app", "v2")
+
+	_, err := m.UpdateManifestAttributes(ctx, "app", hidden.Digest, driver.AzureChangeableAttributes{ListEnabled: falsePtr()})
+	require.NoError(t, err)
+
+	images, err := m.ListImages(ctx, "app")
+	require.NoError(t, err)
+	assert.Len(t, images, 1)
+	assert.Equal(t, "v2", images[0].Tags[0])
+
+	// Direct fetch still works: listEnabled only hides from listing.
+	_, err = m.GetImage(ctx, "app", hidden.Digest)
+	require.NoError(t, err)
+}
+
+func TestManifestAttributesPreservedAcrossRepush(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "app")
+	detail := pushTestImage(t, m, "app", "v1")
+
+	_, err := m.UpdateManifestAttributes(ctx, "app", detail.Digest, driver.AzureChangeableAttributes{ListEnabled: falsePtr()})
+	require.NoError(t, err)
+
+	// Re-pushing the exact same digest (e.g. re-tagging it) must not reset the
+	// manifest's changeableAttributes back to fully enabled.
+	_, err = m.PutImage(ctx, &driver.ImageManifest{Repository: "app", Digest: detail.Digest, Tag: "v2"})
+	require.NoError(t, err)
+
+	attrs, err := m.GetManifestAttributes(ctx, "app", detail.Digest)
+	require.NoError(t, err)
+	assert.False(t, *attrs.ListEnabled)
+}

--- a/providers/azure/acr/attributes_test.go
+++ b/providers/azure/acr/attributes_test.go
@@ -3,6 +3,7 @@ package acr
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stackshy/cloudemu/v2/errors"
@@ -313,4 +314,72 @@ func TestManifestAttributesPreservedAcrossRepush(t *testing.T) {
 	attrs, err := m.GetManifestAttributes(ctx, "app", detail.Digest)
 	require.NoError(t, err)
 	assert.False(t, *attrs.ListEnabled)
+}
+
+// TestConcurrentAttributeUpdatesRaceWithReads is a data-race regression test:
+// Update{Repository,Tag}Attributes mutate rd.attrs / img.attrs under m.mu, and
+// DeleteRepository/ListRepositories/ListImages must read those same fields
+// under the same lock, or -race flags an unsynchronized read racing the
+// concurrent write. It intentionally tolerates NotFound/FailedPrecondition
+// errors from the racing calls — the only thing under test is the absence of
+// a data race, not any particular interleaving's outcome.
+func TestConcurrentAttributeUpdatesRaceWithReads(t *testing.T) {
+	const (
+		workers    = 8
+		iterations = 200
+	)
+
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "app")
+	pushTestImage(t, m, "app", "v1")
+
+	var wg sync.WaitGroup
+
+	// Mutators: PATCH repository- and tag-level changeableAttributes.
+	for i := range workers {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			for j := range iterations {
+				enabled := (i+j)%2 == 0
+				_, _ = m.UpdateRepositoryAttributes(ctx, "app", driver.AzureChangeableAttributes{ListEnabled: &enabled})
+				_, _ = m.UpdateTagAttributes(ctx, "app", "v1", driver.AzureChangeableAttributes{ListEnabled: &enabled})
+			}
+		}(i)
+	}
+
+	// Readers: exactly the two call paths the fix guards.
+	for range workers {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range iterations {
+				_, _ = m.ListRepositories(ctx)
+				_, _ = m.ListImages(ctx, "app")
+			}
+		}()
+	}
+
+	// Deleter: races DeleteRepository's attrs read against the mutators above,
+	// recreating the repository on success so later iterations keep a target.
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for range iterations {
+			if m.DeleteRepository(ctx, "app", true) == nil {
+				_, _ = m.CreateRepository(ctx, driver.RepositoryConfig{Name: "app"})
+				_, _ = m.PutImage(ctx, &driver.ImageManifest{Repository: "app", Tag: "v1"})
+			}
+		}
+	}()
+
+	wg.Wait()
 }

--- a/providers/azure/acr/snapshot.go
+++ b/providers/azure/acr/snapshot.go
@@ -35,12 +35,59 @@ type repoDataSnapshot struct {
 	Policy        *driver.LifecyclePolicy       `json:"policy,omitempty"`
 	ScanOnPush    bool                          `json:"scanOnPush,omitempty"`
 	TagMutability string                        `json:"tagMutability,omitempty"`
+	// Attrs is the repository's changeableAttributes. A nil pointer (a
+	// snapshot taken before this field existed) restores to fully enabled.
+	Attrs *changeableAttrsSnapshot `json:"attrs,omitempty"`
+	// TagAttrs holds each PATCHed tag's changeableAttributes, keyed by tag
+	// name. A tag absent here restores to fully enabled.
+	TagAttrs map[string]changeableAttrsSnapshot `json:"tagAttrs,omitempty"`
 }
 
 // imageDataSnapshot is the exported form of imageData.
 type imageDataSnapshot struct {
 	Detail driver.ImageDetail `json:"detail"`
 	Layers []driver.LayerInfo `json:"layers,omitempty"`
+	// Attrs is the manifest's changeableAttributes. A nil pointer (a snapshot
+	// taken before this field existed) restores to fully enabled.
+	Attrs *changeableAttrsSnapshot `json:"attrs,omitempty"`
+}
+
+// changeableAttrsSnapshot is the exported, JSON-serializable form of
+// changeableAttrs.
+type changeableAttrsSnapshot struct {
+	DeleteEnabled bool `json:"deleteEnabled"`
+	WriteEnabled  bool `json:"writeEnabled"`
+	ListEnabled   bool `json:"listEnabled"`
+	ReadEnabled   bool `json:"readEnabled"`
+}
+
+func (a changeableAttrs) toSnapshot() changeableAttrsSnapshot {
+	return changeableAttrsSnapshot{
+		DeleteEnabled: a.deleteEnabled,
+		WriteEnabled:  a.writeEnabled,
+		ListEnabled:   a.listEnabled,
+		ReadEnabled:   a.readEnabled,
+	}
+}
+
+func (s changeableAttrsSnapshot) toInternal() changeableAttrs {
+	return changeableAttrs{
+		deleteEnabled: s.DeleteEnabled,
+		writeEnabled:  s.WriteEnabled,
+		listEnabled:   s.ListEnabled,
+		readEnabled:   s.ReadEnabled,
+	}
+}
+
+// attrsOrDefault resolves a possibly-absent snapshot pointer to fully enabled,
+// so restoring a snapshot taken before changeableAttributes existed does not
+// spuriously lock every resource.
+func attrsOrDefault(s *changeableAttrsSnapshot) changeableAttrs {
+	if s == nil {
+		return defaultChangeableAttrs()
+	}
+
+	return s.toInternal()
 }
 
 // registryDataSnapshot is the exported form of registryData.
@@ -79,16 +126,27 @@ func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
 }
 
 func snapshotRepo(rd *repoData) (*repoDataSnapshot, error) {
+	attrs := rd.attrs.toSnapshot()
+
 	rs := &repoDataSnapshot{
 		Info:          rd.info,
 		Images:        make(map[string]*imageDataSnapshot, rd.images.Len()),
 		Policy:        rd.policy,
 		ScanOnPush:    rd.scanOnPush,
 		TagMutability: rd.tagMutability,
+		Attrs:         &attrs,
+	}
+
+	if len(rd.tagAttrs) > 0 {
+		rs.TagAttrs = make(map[string]changeableAttrsSnapshot, len(rd.tagAttrs))
+		for tag, a := range rd.tagAttrs {
+			rs.TagAttrs[tag] = a.toSnapshot()
+		}
 	}
 
 	for tag, img := range rd.images.All() {
-		rs.Images[tag] = &imageDataSnapshot{Detail: img.detail, Layers: img.layers}
+		imgAttrs := img.attrs.toSnapshot()
+		rs.Images[tag] = &imageDataSnapshot{Detail: img.detail, Layers: img.layers, Attrs: &imgAttrs}
 	}
 
 	scans, err := rd.scans.Snapshot()
@@ -150,10 +208,18 @@ func restoreRepo(rs *repoDataSnapshot) (*repoData, error) {
 		policy:        rs.Policy,
 		scanOnPush:    rs.ScanOnPush,
 		tagMutability: rs.TagMutability,
+		attrs:         attrsOrDefault(rs.Attrs),
+	}
+
+	if len(rs.TagAttrs) > 0 {
+		rd.tagAttrs = make(map[string]changeableAttrs, len(rs.TagAttrs))
+		for tag, a := range rs.TagAttrs {
+			rd.tagAttrs[tag] = a.toInternal()
+		}
 	}
 
 	for tag, is := range rs.Images {
-		rd.images.Set(tag, &imageData{detail: is.Detail, layers: is.Layers})
+		rd.images.Set(tag, &imageData{detail: is.Detail, layers: is.Layers, attrs: attrsOrDefault(is.Attrs)})
 	}
 
 	if len(rs.Scans) > 0 {

--- a/providers/azure/acr/snapshot_test.go
+++ b/providers/azure/acr/snapshot_test.go
@@ -21,10 +21,18 @@ func TestSnapshotRoundTripACR(t *testing.T) {
 	_, err = src.CreateRepository(ctx, driver.RepositoryConfig{Name: "app"})
 	require.NoError(t, err)
 
-	_, err = src.PutImage(ctx, &driver.ImageManifest{Repository: "app", Tag: "v1", SizeBytes: 1024})
+	detail, err := src.PutImage(ctx, &driver.ImageManifest{Repository: "app", Tag: "v1", SizeBytes: 1024})
 	require.NoError(t, err)
 
 	require.NoError(t, src.PutLifecyclePolicy(ctx, "app", driver.LifecyclePolicy{}))
+
+	no := false
+	_, err = src.UpdateRepositoryAttributes(ctx, "app", driver.AzureChangeableAttributes{DeleteEnabled: &no})
+	require.NoError(t, err)
+	_, err = src.UpdateTagAttributes(ctx, "app", "v1", driver.AzureChangeableAttributes{WriteEnabled: &no})
+	require.NoError(t, err)
+	_, err = src.UpdateManifestAttributes(ctx, "app", detail.Digest, driver.AzureChangeableAttributes{DeleteEnabled: &no})
+	require.NoError(t, err)
 
 	data, err := src.Snapshot(ctx, true)
 	require.NoError(t, err)
@@ -48,4 +56,45 @@ func TestSnapshotRoundTripACR(t *testing.T) {
 
 	_, err = dst.GetLifecyclePolicy(ctx, "app")
 	require.NoError(t, err)
+
+	repoAttrs, err := dst.GetRepositoryAttributes(ctx, "app")
+	require.NoError(t, err)
+	assert.False(t, *repoAttrs.DeleteEnabled, "repository deleteEnabled=false must survive the round trip")
+
+	tagAttrs, err := dst.GetTagAttributes(ctx, "app", "v1")
+	require.NoError(t, err)
+	assert.False(t, *tagAttrs.WriteEnabled, "tag writeEnabled=false must survive the round trip")
+
+	manifestAttrs, err := dst.GetManifestAttributes(ctx, "app", detail.Digest)
+	require.NoError(t, err)
+	assert.False(t, *manifestAttrs.DeleteEnabled, "manifest deleteEnabled=false must survive the round trip")
+}
+
+// TestSnapshotRestoreDefaultsMissingAttributesToEnabled proves a snapshot
+// taken before changeableAttributes existed (Attrs fields absent from the
+// JSON) restores every resource fully enabled rather than fully locked.
+func TestSnapshotRestoreDefaultsMissingAttributesToEnabled(t *testing.T) {
+	ctx := context.Background()
+	dst, _ := newTestMock()
+
+	legacy := `{"repos":{"app":{"info":{"name":"app","uri":"cloudemu.azurecr.io/app"},` +
+		`"images":{"sha256:legacy":{"detail":{"digest":"sha256:legacy","tags":["v1"]}}}}}}`
+
+	require.NoError(t, dst.Restore(ctx, []byte(legacy)))
+
+	repoAttrs, err := dst.GetRepositoryAttributes(ctx, "app")
+	require.NoError(t, err)
+	assert.True(t, *repoAttrs.DeleteEnabled)
+	assert.True(t, *repoAttrs.WriteEnabled)
+	assert.True(t, *repoAttrs.ListEnabled)
+	assert.True(t, *repoAttrs.ReadEnabled)
+
+	manifestAttrs, err := dst.GetManifestAttributes(ctx, "app", "sha256:legacy")
+	require.NoError(t, err)
+	assert.True(t, *manifestAttrs.DeleteEnabled)
+	assert.True(t, *manifestAttrs.WriteEnabled)
+
+	tagAttrs, err := dst.GetTagAttributes(ctx, "app", "v1")
+	require.NoError(t, err)
+	assert.True(t, *tagAttrs.DeleteEnabled)
 }

--- a/server/azure/acr/auth.go
+++ b/server/azure/acr/auth.go
@@ -1,0 +1,101 @@
+package acr
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Real ACR's data-plane requires challenge-based bearer auth: an unauthenticated
+// request gets a 401 with a WWW-Authenticate challenge, the client exchanges an
+// AAD token for an ACR refresh token at POST /oauth2/exchange, then a refresh
+// token for an ACR access token at POST /oauth2/token, and retries the original
+// request with the access token attached.
+//
+// azcontainerregistry's Client always performs this dance BEFORE sending the
+// real request body on the first call on a fresh Client: it clones the request
+// with its body stripped, sends that as the "challenge probe", and only resends
+// the original (with its body restored) if the probe comes back 401. Since the
+// mock does not verify credentials, it only needs to complete the round trip —
+// any bearer token is accepted — but it must actually perform it, or a
+// body-bearing call (PATCH) silently loses its body: the probe would otherwise
+// get the real 200 response and the SDK would never resend with the body.
+//
+// GET/DELETE requests have no body, so this round trip was invisible before
+// changeableAttributes added the first ACR data-plane writes with a request
+// body.
+const (
+	oauthExchangePath = "/oauth2/exchange"
+	oauthTokenPath    = "/oauth2/token" //nolint:gosec // not a credential: a URL path, flagged only because it contains "token"
+
+	// fakeAccessToken is the opaque bearer token minted by /oauth2/token. The
+	// mock never inspects it — any bearer token is accepted — it only needs to
+	// exist so the SDK's auth policy considers the challenge satisfied.
+	fakeAccessToken = "cloudemu-fake-acr-access-token" //nolint:gosec // not a credential: a fixed opaque mock token, never validated
+
+	// fakeRefreshTokenTTL is the "exp" claim minted into the fake refresh
+	// token. authentication_policy.go parses it as a real JWT and errors if it
+	// cannot find a future expiry, so it must be a well-formed (if fake) claim.
+	fakeRefreshTokenTTL = 24 * time.Hour
+
+	// maxOAuthFormBytes bounds the request body ParseForm reads for the two
+	// token endpoints, generously larger than any real token-exchange form.
+	maxOAuthFormBytes = 64 * 1024
+)
+
+// challenge writes a 401 with a WWW-Authenticate challenge for repo (or the
+// catalog when repo is empty), matching the header shape
+// authentication_policy.go's findServiceAndScope parses: comma-separated
+// key="value" pairs directly after "Bearer ", no spaces.
+func challenge(w http.ResponseWriter, repo string) {
+	scope := "registry:catalog:*"
+	if repo != "" {
+		scope = fmt.Sprintf("repository:%s:*", repo)
+	}
+
+	w.Header().Set("WWW-Authenticate", fmt.Sprintf(
+		`Bearer realm="https://%s/oauth2/token",service=%q,scope=%q`,
+		registryLoginServer, registryLoginServer, scope,
+	))
+	writeErr(w, http.StatusUnauthorized, "UNAUTHORIZED", "authentication required")
+}
+
+// serveOAuthExchange serves POST /oauth2/exchange (AAD access/refresh token ->
+// ACR refresh token). The mock does not verify the submitted AAD token; it
+// mints an opaque, well-formed refresh token unconditionally.
+func serveOAuthExchange(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxOAuthFormBytes)
+
+	if err := r.ParseForm(); err != nil {
+		writeErr(w, http.StatusBadRequest, "INVALID_REQUEST", "malformed oauth2/exchange form body")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"refresh_token": mintFakeRefreshToken()})
+}
+
+// serveOAuthToken serves POST /oauth2/token (ACR refresh token -> ACR access
+// token). The mock does not verify the submitted refresh token.
+func serveOAuthToken(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxOAuthFormBytes)
+
+	if err := r.ParseForm(); err != nil {
+		writeErr(w, http.StatusBadRequest, "INVALID_REQUEST", "malformed oauth2/token form body")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"access_token": fakeAccessToken})
+}
+
+// mintFakeRefreshToken builds an opaque but JWT-shaped (three dot-separated
+// base64url segments) token carrying a far-future "exp" claim, satisfying
+// authentication_policy.go's getJWTExpireTime without asserting anything about
+// a real credential.
+func mintFakeRefreshToken() string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	exp := time.Now().Add(fakeRefreshTokenTTL).Unix()
+	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"exp":%d}`, exp)))
+
+	return header + "." + payload + ".cloudemu"
+}

--- a/server/azure/acr/changeable_attributes_test.go
+++ b/server/azure/acr/changeable_attributes_test.go
@@ -1,0 +1,323 @@
+package acr_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	azacr "github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry"
+
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+// digestOf returns the digest of tag in repo via the driver, so tests can drive
+// PATCH /_manifests/{digest} without depending on push ordering.
+func digestOf(t *testing.T, reg crdriver.ContainerRegistry, repo, tag string) string {
+	t.Helper()
+
+	img, err := reg.GetImage(context.Background(), repo, tag)
+	if err != nil {
+		t.Fatalf("GetImage(%s:%s): %v", repo, tag, err)
+	}
+
+	return img.Digest
+}
+
+// TestSDKACRTagDeleteEnabledBlocksDeleteTag drives the real azcontainerregistry
+// SDK's UpdateTagProperties/DeleteTag: locking a tag's deleteEnabled blocks
+// untagging, and clearing the lock lets it through.
+func TestSDKACRTagDeleteEnabledBlocksDeleteTag(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "app"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	seedImage(t, reg, "app", "v1")
+
+	if _, err := client.UpdateTagProperties(ctx, "app", "v1", &azacr.ClientUpdateTagPropertiesOptions{
+		Value: &azacr.TagWriteableProperties{CanDelete: to.Ptr(false)},
+	}); err != nil {
+		t.Fatalf("UpdateTagProperties(deleteEnabled=false): %v", err)
+	}
+
+	_, err := client.DeleteTag(ctx, "app", "v1", nil)
+	assertResponseCode(t, err, http.StatusConflict)
+
+	if _, err := client.UpdateTagProperties(ctx, "app", "v1", &azacr.ClientUpdateTagPropertiesOptions{
+		Value: &azacr.TagWriteableProperties{CanDelete: to.Ptr(true)},
+	}); err != nil {
+		t.Fatalf("UpdateTagProperties(deleteEnabled=true): %v", err)
+	}
+
+	if _, err := client.DeleteTag(ctx, "app", "v1", nil); err != nil {
+		t.Fatalf("DeleteTag after unlock: %v", err)
+	}
+}
+
+// TestSDKACRTagWriteEnabledBlocksOverwrite locks a tag's writeEnabled and
+// proves a push that would move it to a new digest is rejected, while the
+// tag's existing digest is left untouched; clearing the lock lets the push
+// through. ACR's data plane has no push endpoint, so the push itself goes
+// through the driver directly, matching what `docker push` would do.
+func TestSDKACRTagWriteEnabledBlocksOverwrite(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "app"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	seedImage(t, reg, "app", "v1")
+	original := digestOf(t, reg, "app", "v1")
+
+	if _, err := client.UpdateTagProperties(ctx, "app", "v1", &azacr.ClientUpdateTagPropertiesOptions{
+		Value: &azacr.TagWriteableProperties{CanWrite: to.Ptr(false)},
+	}); err != nil {
+		t.Fatalf("UpdateTagProperties(writeEnabled=false): %v", err)
+	}
+
+	if _, err := reg.PutImage(ctx, &crdriver.ImageManifest{
+		Repository: "app",
+		Tag:        "v1",
+		SizeBytes:  4096,
+	}); err == nil {
+		t.Fatal("expected write-locked overwrite to be rejected")
+	}
+
+	if got := digestOf(t, reg, "app", "v1"); got != original {
+		t.Fatalf("tag digest changed under write lock: got %s, want %s", got, original)
+	}
+
+	if _, err := client.UpdateTagProperties(ctx, "app", "v1", &azacr.ClientUpdateTagPropertiesOptions{
+		Value: &azacr.TagWriteableProperties{CanWrite: to.Ptr(true)},
+	}); err != nil {
+		t.Fatalf("UpdateTagProperties(writeEnabled=true): %v", err)
+	}
+
+	if _, err := reg.PutImage(ctx, &crdriver.ImageManifest{
+		Repository: "app",
+		Tag:        "v1",
+		SizeBytes:  4096,
+	}); err != nil {
+		t.Fatalf("PutImage after unlock: %v", err)
+	}
+
+	if got := digestOf(t, reg, "app", "v1"); got == original {
+		t.Fatal("expected tag digest to move after unlock")
+	}
+}
+
+// TestSDKACRTagListEnabledHidesFromList proves a listEnabled=false tag drops
+// out of the _tags listing while remaining directly gettable by name.
+func TestSDKACRTagListEnabledHidesFromList(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "app"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	seedImage(t, reg, "app", "v1")
+	seedImage(t, reg, "app", "v2")
+
+	if _, err := client.UpdateTagProperties(ctx, "app", "v1", &azacr.ClientUpdateTagPropertiesOptions{
+		Value: &azacr.TagWriteableProperties{CanList: to.Ptr(false)},
+	}); err != nil {
+		t.Fatalf("UpdateTagProperties(listEnabled=false): %v", err)
+	}
+
+	var tags []string
+
+	pager := client.NewListTagsPager("app", nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListTags: %v", err)
+		}
+
+		for _, tag := range page.Tags {
+			tags = append(tags, *tag.Name)
+		}
+	}
+
+	if contains(tags, "v1") {
+		t.Fatalf("list-locked tag v1 should be hidden, tags=%v", tags)
+	}
+
+	if !contains(tags, "v2") {
+		t.Fatalf("tag v2 should still be listed, tags=%v", tags)
+	}
+
+	props, err := client.GetTagProperties(ctx, "app", "v1", nil)
+	if err != nil {
+		t.Fatalf("GetTagProperties(v1) should still succeed when only listEnabled is false: %v", err)
+	}
+
+	if props.Tag.ChangeableAttributes.CanList == nil || *props.Tag.ChangeableAttributes.CanList {
+		t.Fatal("expected reported listEnabled=false")
+	}
+}
+
+// TestSDKACRRepositoryAttributesLifecycle covers repository-level
+// changeableAttributes: listEnabled hides the repo from the catalog, and
+// deleteEnabled blocks DeleteRepository until cleared.
+func TestSDKACRRepositoryAttributesLifecycle(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "locked"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	if _, err := client.UpdateRepositoryProperties(ctx, "locked", &azacr.ClientUpdateRepositoryPropertiesOptions{
+		Value: &azacr.RepositoryWriteableProperties{CanList: to.Ptr(false), CanDelete: to.Ptr(false)},
+	}); err != nil {
+		t.Fatalf("UpdateRepositoryProperties: %v", err)
+	}
+
+	var names []string
+
+	pager := client.NewListRepositoriesPager(nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListRepositories: %v", err)
+		}
+
+		for _, n := range page.Repositories.Names {
+			names = append(names, *n)
+		}
+	}
+
+	if contains(names, "locked") {
+		t.Fatalf("list-locked repository should be hidden from catalog, names=%v", names)
+	}
+
+	if _, err := client.GetRepositoryProperties(ctx, "locked", nil); err != nil {
+		t.Fatalf("GetRepositoryProperties should still succeed when only listEnabled is false: %v", err)
+	}
+
+	_, err := client.DeleteRepository(ctx, "locked", nil)
+	assertResponseCode(t, err, http.StatusConflict)
+
+	if _, err := client.UpdateRepositoryProperties(ctx, "locked", &azacr.ClientUpdateRepositoryPropertiesOptions{
+		Value: &azacr.RepositoryWriteableProperties{CanDelete: to.Ptr(true)},
+	}); err != nil {
+		t.Fatalf("UpdateRepositoryProperties(deleteEnabled=true): %v", err)
+	}
+
+	if _, err := client.DeleteRepository(ctx, "locked", nil); err != nil {
+		t.Fatalf("DeleteRepository after unlock: %v", err)
+	}
+}
+
+// TestSDKACRRepositoryWriteEnabledBlocksPush proves a write-locked repository
+// rejects any push, tag-scoped or not.
+func TestSDKACRRepositoryWriteEnabledBlocksPush(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "app"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	if _, err := client.UpdateRepositoryProperties(ctx, "app", &azacr.ClientUpdateRepositoryPropertiesOptions{
+		Value: &azacr.RepositoryWriteableProperties{CanWrite: to.Ptr(false)},
+	}); err != nil {
+		t.Fatalf("UpdateRepositoryProperties(writeEnabled=false): %v", err)
+	}
+
+	if _, err := reg.PutImage(ctx, &crdriver.ImageManifest{Repository: "app", Tag: "v1", SizeBytes: 512}); err == nil {
+		t.Fatal("expected push to a write-locked repository to be rejected")
+	}
+}
+
+// TestSDKACRManifestAttributesLifecycle covers manifest-level
+// changeableAttributes: listEnabled hides the manifest from _manifests, and
+// deleteEnabled blocks deletion until cleared.
+func TestSDKACRManifestAttributesLifecycle(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "app"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	seedImage(t, reg, "app", "v1")
+	digest := digestOf(t, reg, "app", "v1")
+
+	if _, err := client.UpdateManifestProperties(ctx, "app", digest, &azacr.ClientUpdateManifestPropertiesOptions{
+		Value: &azacr.ManifestWriteableProperties{CanList: to.Ptr(false), CanDelete: to.Ptr(false)},
+	}); err != nil {
+		t.Fatalf("UpdateManifestProperties: %v", err)
+	}
+
+	var digests []string
+
+	pager := client.NewListManifestsPager("app", nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListManifests: %v", err)
+		}
+
+		for _, m := range page.Manifests.Attributes {
+			if m.Digest != nil {
+				digests = append(digests, *m.Digest)
+			}
+		}
+	}
+
+	if contains(digests, digest) {
+		t.Fatalf("list-locked manifest should be hidden from _manifests, digests=%v", digests)
+	}
+
+	if _, err := client.GetManifestProperties(ctx, "app", digest, nil); err != nil {
+		t.Fatalf("GetManifestProperties should still succeed when only listEnabled is false: %v", err)
+	}
+
+	if err := reg.DeleteImage(ctx, "app", digest); err == nil {
+		t.Fatal("expected delete of a delete-locked manifest to be rejected")
+	}
+
+	if _, err := client.UpdateManifestProperties(ctx, "app", digest, &azacr.ClientUpdateManifestPropertiesOptions{
+		Value: &azacr.ManifestWriteableProperties{CanDelete: to.Ptr(true)},
+	}); err != nil {
+		t.Fatalf("UpdateManifestProperties(deleteEnabled=true): %v", err)
+	}
+
+	if err := reg.DeleteImage(ctx, "app", digest); err != nil {
+		t.Fatalf("DeleteImage after unlock: %v", err)
+	}
+}
+
+// TestSDKACRUpdateAttributesNotFound proves PATCH on an unknown repository,
+// tag, or manifest 404s rather than silently creating a lock record.
+func TestSDKACRUpdateAttributesNotFound(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "app"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	seedImage(t, reg, "app", "v1")
+
+	_, err := client.UpdateRepositoryProperties(ctx, "ghost", &azacr.ClientUpdateRepositoryPropertiesOptions{
+		Value: &azacr.RepositoryWriteableProperties{CanDelete: to.Ptr(false)},
+	})
+	assertResponseCode(t, err, http.StatusNotFound)
+
+	_, err = client.UpdateTagProperties(ctx, "app", "ghost", &azacr.ClientUpdateTagPropertiesOptions{
+		Value: &azacr.TagWriteableProperties{CanDelete: to.Ptr(false)},
+	})
+	assertResponseCode(t, err, http.StatusNotFound)
+
+	_, err = client.UpdateManifestProperties(ctx, "app", "sha256:0000000000000000", &azacr.ClientUpdateManifestPropertiesOptions{
+		Value: &azacr.ManifestWriteableProperties{CanDelete: to.Ptr(false)},
+	})
+	assertResponseCode(t, err, http.StatusNotFound)
+}

--- a/server/azure/acr/handler.go
+++ b/server/azure/acr/handler.go
@@ -7,15 +7,30 @@
 //
 // ACR has no "create repository" data-plane call — repositories appear when an
 // image is pushed — so this handler is list/get/delete oriented. ACR uses
-// challenge-based auth; the mock serves anonymously, so the SDK never needs to
-// exchange a token.
+// challenge-based bearer auth (see auth.go): the mock accepts any credential,
+// but it completes the 401/oauth2 round trip for real, because
+// azcontainerregistry's Client always probes with the request body stripped
+// before it will send a body-bearing request (PATCH) for real.
 //
 // Coverage:
 //
-//	GET    /acr/v1/_catalog              — list repositories
-//	GET    /acr/v1/{name}                — repository properties
-//	DELETE /acr/v1/{name}                — delete repository
-//	GET    /acr/v1/{name}/_tags          — list tags
+//	GET    /acr/v1/_catalog                    — list repositories
+//	GET    /acr/v1/{name}                      — repository properties
+//	PATCH  /acr/v1/{name}                      — update repository changeableAttributes
+//	DELETE /acr/v1/{name}                      — delete repository
+//	GET    /acr/v1/{name}/_tags                — list tags
+//	GET    /acr/v1/{name}/_tags/{tag}          — tag properties
+//	PATCH  /acr/v1/{name}/_tags/{tag}          — update tag changeableAttributes
+//	DELETE /acr/v1/{name}/_tags/{tag}          — untag
+//	GET    /acr/v1/{name}/_manifests           — list manifests
+//	GET    /acr/v1/{name}/_manifests/{digest}  — manifest properties
+//	PATCH  /acr/v1/{name}/_manifests/{digest}  — update manifest changeableAttributes
+//	POST   /oauth2/exchange                    — AAD token -> ACR refresh token
+//	POST   /oauth2/token                       — ACR refresh token -> ACR access token
+//
+// The changeableAttributes lock (deleteEnabled/writeEnabled/listEnabled) is
+// enforced against mutations and listings; readEnabled is stored and reported
+// but not enforced (see providers/azure/acr for the rationale).
 package acr
 
 import (
@@ -46,15 +61,31 @@ func New(reg crdriver.ContainerRegistry) *Handler {
 	return &Handler{registry: reg}
 }
 
-// Matches claims /acr/v1/ data-plane requests. Disjoint from ARM
-// (/subscriptions/…) and registered before the blob storage REST fallback.
+// Matches claims /acr/v1/ data-plane requests and the two challenge-auth token
+// endpoints. Disjoint from ARM (/subscriptions/…) and registered before the
+// blob storage REST fallback.
 func (*Handler) Matches(r *http.Request) bool {
-	return strings.HasPrefix(r.URL.Path, pathPrefix)
+	return strings.HasPrefix(r.URL.Path, pathPrefix) ||
+		r.URL.Path == oauthExchangePath || r.URL.Path == oauthTokenPath
 }
 
 // ServeHTTP routes on the path tail and method.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case oauthExchangePath:
+		serveOAuthExchange(w, r)
+		return
+	case oauthTokenPath:
+		serveOAuthToken(w, r)
+		return
+	}
+
 	tail := strings.TrimPrefix(r.URL.Path, pathPrefix)
+
+	if r.Header.Get("Authorization") == "" {
+		challenge(w, repoFromTail(tail))
+		return
+	}
 
 	if tail == catalogSeg {
 		if r.Method == http.MethodGet {
@@ -97,10 +128,24 @@ func parseACRPath(tail string) (repo, resource, reference string) {
 	return tail, "", ""
 }
 
+// repoFromTail returns the repository the challenge should scope its
+// WWW-Authenticate "scope" to, or "" for the catalog-wide _catalog listing.
+func repoFromTail(tail string) string {
+	if tail == catalogSeg {
+		return ""
+	}
+
+	repo, _, _ := parseACRPath(tail)
+
+	return repo
+}
+
 func (h *Handler) serveRepository(w http.ResponseWriter, r *http.Request, repo string) {
 	switch r.Method {
 	case http.MethodGet:
 		h.getRepositoryProperties(w, r, repo)
+	case http.MethodPatch:
+		h.updateRepositoryProperties(w, r, repo)
 	case http.MethodDelete:
 		h.deleteRepository(w, r, repo)
 	default:
@@ -123,6 +168,8 @@ func (h *Handler) serveTags(w http.ResponseWriter, r *http.Request, repo, tag st
 	switch r.Method {
 	case http.MethodGet:
 		h.getTagProperties(w, r, repo, tag)
+	case http.MethodPatch:
+		h.updateTagProperties(w, r, repo, tag)
 	case http.MethodDelete:
 		h.deleteTag(w, r, repo, tag)
 	default:
@@ -131,17 +178,25 @@ func (h *Handler) serveTags(w http.ResponseWriter, r *http.Request, repo, tag st
 }
 
 func (h *Handler) serveManifests(w http.ResponseWriter, r *http.Request, repo, digest string) {
-	if r.Method != http.MethodGet {
-		writeErr(w, http.StatusMethodNotAllowed, "UNSUPPORTED", "unsupported ACR operation")
-		return
-	}
-
 	if digest == "" {
-		h.listManifests(w, r, repo)
+		if r.Method == http.MethodGet {
+			h.listManifests(w, r, repo)
+			return
+		}
+
+		writeErr(w, http.StatusMethodNotAllowed, "UNSUPPORTED", "unsupported ACR operation")
+
 		return
 	}
 
-	h.getManifestProperties(w, r, repo, digest)
+	switch r.Method {
+	case http.MethodGet:
+		h.getManifestProperties(w, r, repo, digest)
+	case http.MethodPatch:
+		h.updateManifestProperties(w, r, repo, digest)
+	default:
+		writeErr(w, http.StatusMethodNotAllowed, "UNSUPPORTED", "unsupported ACR operation")
+	}
 }
 
 // writeErr emits an ACR-style error body with the given HTTP status.

--- a/server/azure/acr/operations.go
+++ b/server/azure/acr/operations.go
@@ -1,6 +1,7 @@
 package acr
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -42,8 +43,30 @@ func (h *Handler) getRepositoryProperties(w http.ResponseWriter, r *http.Request
 		LastUpdateTime:       rp.CreatedAt,
 		ManifestCount:        len(images),
 		TagCount:             countTags(images),
-		ChangeableAttributes: allEnabled(),
+		ChangeableAttributes: h.repositoryAttrs(r.Context(), repo),
 	})
+}
+
+// updateRepositoryProperties serves PATCH /acr/v1/{name} (changeableAttributes
+// only — repository metadata such as name/createdTime is immutable).
+func (h *Handler) updateRepositoryProperties(w http.ResponseWriter, r *http.Request, repo string) {
+	writer, ok := h.registry.(crdriver.AzureRepositoryWriter)
+	if !ok {
+		writeErr(w, http.StatusNotImplemented, "UNSUPPORTED", "attribute updates are not supported by this registry driver")
+		return
+	}
+
+	patch, ok := decodeAttributesPatch(w, r)
+	if !ok {
+		return
+	}
+
+	if _, err := writer.UpdateRepositoryAttributes(r.Context(), repo, patch.toDriver()); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	h.getRepositoryProperties(w, r, repo)
 }
 
 func (h *Handler) listTags(w http.ResponseWriter, r *http.Request, repo string) {
@@ -53,10 +76,14 @@ func (h *Handler) listTags(w http.ResponseWriter, r *http.Request, repo string) 
 		return
 	}
 
+	ctx := r.Context()
+
 	writeJSON(w, http.StatusOK, tagListResponse{
 		Registry:  registryLoginServer,
 		ImageName: repo,
-		Tags:      toTagAttributes(images),
+		Tags: toTagAttributes(images, func(tag string) changeableAttributes {
+			return h.tagAttrs(ctx, repo, tag)
+		}),
 	})
 }
 
@@ -73,28 +100,14 @@ func (h *Handler) deleteRepository(w http.ResponseWriter, r *http.Request, repo 
 	})
 }
 
-// findTag locates the image carrying tag in repo and returns it, or ok=false.
-func findTag(images []crdriver.ImageDetail, tag string) (crdriver.ImageDetail, bool) {
-	for i := range images {
-		for _, t := range images[i].Tags {
-			if t == tag {
-				return images[i], true
-			}
-		}
-	}
-
-	return crdriver.ImageDetail{}, false
-}
-
 func (h *Handler) getTagProperties(w http.ResponseWriter, r *http.Request, repo, tag string) {
-	images, err := h.registry.ListImages(r.Context(), repo)
-	if err != nil {
+	if _, err := h.registry.GetRepository(r.Context(), repo); err != nil {
 		writeCErr(w, err)
 		return
 	}
 
-	img, ok := findTag(images, tag)
-	if !ok {
+	img, err := h.registry.GetImage(r.Context(), repo, tag)
+	if err != nil {
 		writeErr(w, http.StatusNotFound, "TAG_UNKNOWN", "tag "+tag+" not found in repository "+repo)
 		return
 	}
@@ -107,9 +120,30 @@ func (h *Handler) getTagProperties(w http.ResponseWriter, r *http.Request, repo,
 			Digest:               img.Digest,
 			CreatedTime:          img.PushedAt,
 			LastUpdateTime:       img.PushedAt,
-			ChangeableAttributes: allEnabled(),
+			ChangeableAttributes: h.tagAttrs(r.Context(), repo, tag),
 		},
 	})
+}
+
+// updateTagProperties serves PATCH /acr/v1/{name}/_tags/{tag}.
+func (h *Handler) updateTagProperties(w http.ResponseWriter, r *http.Request, repo, tag string) {
+	writer, ok := h.registry.(crdriver.AzureRepositoryWriter)
+	if !ok {
+		writeErr(w, http.StatusNotImplemented, "UNSUPPORTED", "attribute updates are not supported by this registry driver")
+		return
+	}
+
+	patch, ok := decodeAttributesPatch(w, r)
+	if !ok {
+		return
+	}
+
+	if _, err := writer.UpdateTagAttributes(r.Context(), repo, tag, patch.toDriver()); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	h.getTagProperties(w, r, repo, tag)
 }
 
 func (h *Handler) deleteTag(w http.ResponseWriter, r *http.Request, repo, tag string) {
@@ -135,10 +169,14 @@ func (h *Handler) listManifests(w http.ResponseWriter, r *http.Request, repo str
 		return
 	}
 
+	ctx := r.Context()
+
 	writeJSON(w, http.StatusOK, manifestList{
 		Registry:  registryLoginServer,
 		ImageName: repo,
-		Manifests: toManifestAttributes(images),
+		Manifests: toManifestAttributes(images, func(digest string) changeableAttributes {
+			return h.manifestAttrs(ctx, repo, digest)
+		}),
 	})
 }
 
@@ -152,8 +190,89 @@ func (h *Handler) getManifestProperties(w http.ResponseWriter, r *http.Request, 
 	writeJSON(w, http.StatusOK, manifestProperties{
 		Registry:  registryLoginServer,
 		ImageName: repo,
-		Manifest:  toManifestAttribute(img),
+		Manifest:  toManifestAttribute(img, h.manifestAttrs(r.Context(), repo, digest)),
 	})
+}
+
+// updateManifestProperties serves PATCH /acr/v1/{name}/_manifests/{digest}.
+func (h *Handler) updateManifestProperties(w http.ResponseWriter, r *http.Request, repo, digest string) {
+	writer, ok := h.registry.(crdriver.AzureRepositoryWriter)
+	if !ok {
+		writeErr(w, http.StatusNotImplemented, "UNSUPPORTED", "attribute updates are not supported by this registry driver")
+		return
+	}
+
+	patch, ok := decodeAttributesPatch(w, r)
+	if !ok {
+		return
+	}
+
+	if _, err := writer.UpdateManifestAttributes(r.Context(), repo, digest, patch.toDriver()); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	h.getManifestProperties(w, r, repo, digest)
+}
+
+// decodeAttributesPatch decodes a changeableAttributes PATCH body, writing a
+// 400 response and returning ok=false on malformed JSON.
+func decodeAttributesPatch(w http.ResponseWriter, r *http.Request) (changeableAttributesPatch, bool) {
+	var patch changeableAttributesPatch
+	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+		writeErr(w, http.StatusBadRequest, "INVALID_REQUEST", "malformed changeableAttributes body")
+		return changeableAttributesPatch{}, false
+	}
+
+	return patch, true
+}
+
+// repositoryAttrs resolves repo's changeableAttributes, defaulting to fully
+// enabled when the backing driver does not implement attribute storage.
+func (h *Handler) repositoryAttrs(ctx context.Context, repo string) changeableAttributes {
+	writer, ok := h.registry.(crdriver.AzureRepositoryWriter)
+	if !ok {
+		return allEnabled()
+	}
+
+	attrs, err := writer.GetRepositoryAttributes(ctx, repo)
+	if err != nil {
+		return allEnabled()
+	}
+
+	return toChangeableAttributes(attrs)
+}
+
+// tagAttrs resolves tag's changeableAttributes, defaulting to fully enabled
+// when the backing driver does not implement attribute storage.
+func (h *Handler) tagAttrs(ctx context.Context, repo, tag string) changeableAttributes {
+	writer, ok := h.registry.(crdriver.AzureRepositoryWriter)
+	if !ok {
+		return allEnabled()
+	}
+
+	attrs, err := writer.GetTagAttributes(ctx, repo, tag)
+	if err != nil {
+		return allEnabled()
+	}
+
+	return toChangeableAttributes(attrs)
+}
+
+// manifestAttrs resolves digest's changeableAttributes, defaulting to fully
+// enabled when the backing driver does not implement attribute storage.
+func (h *Handler) manifestAttrs(ctx context.Context, repo, digest string) changeableAttributes {
+	writer, ok := h.registry.(crdriver.AzureRepositoryWriter)
+	if !ok {
+		return allEnabled()
+	}
+
+	attrs, err := writer.GetManifestAttributes(ctx, repo, digest)
+	if err != nil {
+		return allEnabled()
+	}
+
+	return toChangeableAttributes(attrs)
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/server/azure/acr/types.go
+++ b/server/azure/acr/types.go
@@ -11,7 +11,7 @@ import (
 const registryLoginServer = "cloudemu.azurecr.io"
 
 // changeableAttributes mirrors ACR's RepositoryWriteableProperties /
-// TagWriteableProperties. The mock reports everything enabled.
+// TagWriteableProperties / ManifestWriteableProperties.
 type changeableAttributes struct {
 	DeleteEnabled bool `json:"deleteEnabled"`
 	WriteEnabled  bool `json:"writeEnabled"`
@@ -21,6 +21,47 @@ type changeableAttributes struct {
 
 func allEnabled() changeableAttributes {
 	return changeableAttributes{DeleteEnabled: true, WriteEnabled: true, ListEnabled: true, ReadEnabled: true}
+}
+
+// toChangeableAttributes converts the driver's always-resolved
+// AzureChangeableAttributes into the wire shape. A nil field defaults to
+// enabled, matching a registry that predates changeableAttributes tracking.
+func toChangeableAttributes(a crdriver.AzureChangeableAttributes) changeableAttributes {
+	return changeableAttributes{
+		DeleteEnabled: boolOrEnabled(a.DeleteEnabled),
+		WriteEnabled:  boolOrEnabled(a.WriteEnabled),
+		ListEnabled:   boolOrEnabled(a.ListEnabled),
+		ReadEnabled:   boolOrEnabled(a.ReadEnabled),
+	}
+}
+
+func boolOrEnabled(p *bool) bool {
+	if p == nil {
+		return true
+	}
+
+	return *p
+}
+
+// changeableAttributesPatch is the PATCH request body for
+// UpdateRepositoryProperties / UpdateTagProperties / UpdateManifestProperties:
+// the raw {Repository,Tag,Manifest}WriteableProperties object, unwrapped. Every
+// field is optional; an absent field leaves the corresponding attribute
+// unchanged.
+type changeableAttributesPatch struct {
+	DeleteEnabled *bool `json:"deleteEnabled"`
+	WriteEnabled  *bool `json:"writeEnabled"`
+	ListEnabled   *bool `json:"listEnabled"`
+	ReadEnabled   *bool `json:"readEnabled"`
+}
+
+func (p changeableAttributesPatch) toDriver() crdriver.AzureChangeableAttributes {
+	return crdriver.AzureChangeableAttributes{
+		DeleteEnabled: p.DeleteEnabled,
+		WriteEnabled:  p.WriteEnabled,
+		ListEnabled:   p.ListEnabled,
+		ReadEnabled:   p.ReadEnabled,
+	}
 }
 
 // catalogResponse is the GET /acr/v1/_catalog body.
@@ -93,7 +134,7 @@ type manifestProperties struct {
 	Manifest  manifestAttributes `json:"manifest"`
 }
 
-func toManifestAttribute(img *crdriver.ImageDetail) manifestAttributes {
+func toManifestAttribute(img *crdriver.ImageDetail, attrs changeableAttributes) manifestAttributes {
 	tags := img.Tags
 	if tags == nil {
 		tags = []string{}
@@ -106,14 +147,19 @@ func toManifestAttribute(img *crdriver.ImageDetail) manifestAttributes {
 		MediaType:            img.MediaType,
 		ImageSize:            img.SizeBytes,
 		Tags:                 tags,
-		ChangeableAttributes: allEnabled(),
+		ChangeableAttributes: attrs,
 	}
 }
 
-func toManifestAttributes(images []crdriver.ImageDetail) []manifestAttributes {
+// toManifestAttributes renders images (already filtered for listEnabled by the
+// driver's ListImages) into wire form, resolving each manifest's real
+// changeableAttributes via attrsFor.
+func toManifestAttributes(
+	images []crdriver.ImageDetail, attrsFor func(digest string) changeableAttributes,
+) []manifestAttributes {
 	out := make([]manifestAttributes, 0, len(images))
 	for i := range images {
-		out = append(out, toManifestAttribute(&images[i]))
+		out = append(out, toManifestAttribute(&images[i], attrsFor(images[i].Digest)))
 	}
 
 	return out
@@ -148,7 +194,13 @@ func countTags(images []crdriver.ImageDetail) int {
 	return n
 }
 
-func toTagAttributes(images []crdriver.ImageDetail) []tagAttributes {
+// toTagAttributes renders every tag on images (already filtered for
+// manifest-level listEnabled by the driver's ListImages) into wire form,
+// resolving each tag's real changeableAttributes via attrsFor and dropping any
+// tag whose own listEnabled is false.
+func toTagAttributes(
+	images []crdriver.ImageDetail, attrsFor func(tag string) changeableAttributes,
+) []tagAttributes {
 	out := make([]tagAttributes, 0, len(images))
 
 	for i := range images {
@@ -159,12 +211,17 @@ func toTagAttributes(images []crdriver.ImageDetail) []tagAttributes {
 				continue
 			}
 
+			attrs := attrsFor(tag)
+			if !attrs.ListEnabled {
+				continue
+			}
+
 			out = append(out, tagAttributes{
 				Name:                 tag,
 				Digest:               img.Digest,
 				CreatedTime:          img.PushedAt,
 				LastUpdateTime:       img.PushedAt,
-				ChangeableAttributes: allEnabled(),
+				ChangeableAttributes: attrs,
 			})
 		}
 	}

--- a/services/containerregistry/driver/azure.go
+++ b/services/containerregistry/driver/azure.go
@@ -200,10 +200,46 @@ type AzureRegistryManager interface {
 	ListReplications(ctx context.Context, rg, registry string) ([]AzureReplication, error)
 }
 
+// AzureChangeableAttributes mirrors ACR's Repository/Tag/ManifestWriteableProperties
+// (the data-plane "changeableAttributes" lock bits). Each field is a pointer so
+// a partial PATCH (UpdateRepositoryProperties / UpdateTagProperties /
+// UpdateManifestProperties) can leave an attribute unspecified: nil means
+// "leave unchanged" on an update. A Get call always returns every field
+// resolved (never nil).
+type AzureChangeableAttributes struct {
+	DeleteEnabled *bool
+	WriteEnabled  *bool
+	ListEnabled   *bool
+	ReadEnabled   *bool
+}
+
 // AzureRepositoryWriter is the Azure-specific ACR data-plane surface for
-// mutating a single tag or repository. DeleteTag removes one tag while leaving
-// the underlying manifest and any other tags intact (unlike DeleteImage, which
-// removes the whole manifest). The wire handler reaches it by type assertion.
+// mutating a single tag, manifest, or repository. DeleteTag removes one tag
+// while leaving the underlying manifest and any other tags intact (unlike
+// DeleteImage, which removes the whole manifest).
+//
+// The Get/Update*Attributes methods back ACR's changeableAttributes lock: a
+// repository, tag, or manifest with deleteEnabled=false rejects deletion,
+// writeEnabled=false rejects a push/re-tag that would overwrite it, and
+// listEnabled=false hides it from catalog/tag/manifest listings while leaving
+// it directly readable. The wire handler reaches all of this by type
+// assertion, mirroring the AzureNetworkInterfaces pattern in the networking
+// driver.
 type AzureRepositoryWriter interface {
 	DeleteTag(ctx context.Context, repository, tag string) error
+
+	GetRepositoryAttributes(ctx context.Context, repository string) (AzureChangeableAttributes, error)
+	UpdateRepositoryAttributes(
+		ctx context.Context, repository string, attrs AzureChangeableAttributes,
+	) (AzureChangeableAttributes, error)
+
+	GetTagAttributes(ctx context.Context, repository, tag string) (AzureChangeableAttributes, error)
+	UpdateTagAttributes(
+		ctx context.Context, repository, tag string, attrs AzureChangeableAttributes,
+	) (AzureChangeableAttributes, error)
+
+	GetManifestAttributes(ctx context.Context, repository, digest string) (AzureChangeableAttributes, error)
+	UpdateManifestAttributes(
+		ctx context.Context, repository, digest string, attrs AzureChangeableAttributes,
+	) (AzureChangeableAttributes, error)
 }


### PR DESCRIPTION
## Gap found

ACR's registry ARM control plane (registries, admin credentials, usages, webhooks, geo-replications) is mature. The data-plane catalog API (`/acr/v1/...`) was list/get/delete-oriented only: `changeableAttributes` (`deleteEnabled`/`writeEnabled`/`listEnabled`/`readEnabled`) on repositories, tags, and manifests was hardcoded to fully enabled with no PATCH surface at all — the real-cloud "lock a tag/manifest" feature was entirely missing.

## What's added

- `PATCH /acr/v1/{name}`, `.../_tags/{tag}`, `.../_manifests/{digest}` to update `changeableAttributes` (matches `azcontainerregistry`'s `UpdateRepositoryProperties`/`UpdateTagProperties`/`UpdateManifestProperties`). GET/list responses now report the real per-resource values instead of a constant.
- Enforcement in the driver (`providers/azure/acr`), so it applies uniformly whether reached through the wire server or the portable API:
  - `deleteEnabled=false` blocks `DeleteRepository` / `DeleteTag` / `DeleteImage`.
  - `writeEnabled=false` blocks `PutImage` from pushing into a locked repository or overwriting a locked tag, and blocks `TagImage` from retargeting a locked tag.
  - `listEnabled=false` hides a repository/tag/manifest from its listing (`_catalog`/`_tags`/`_manifests`) while it stays directly gettable by name/digest.
  - A tag's lock is forgotten once the tag is removed, so a new tag pushed under the same name starts unlocked.
- Persistence: repository/tag/manifest `changeableAttributes` round-trip through `Snapshot`/`Restore`; a pre-existing snapshot without the new fields restores to fully enabled.
- Completes ACR's data-plane challenge-auth round trip (401 + `WWW-Authenticate` + `POST /oauth2/exchange` + `POST /oauth2/token`). This turned out to be a prerequisite: `azcontainerregistry`'s SDK client always sends a body-stripped "challenge probe" first and only resends with the real body after a 401; the mock's prior anonymous-accept shortcut returned success to the stripped probe, so a real PATCH's body was silently dropped before this fix. GET/DELETE have no body, so this was invisible until PATCH was added.
- Note: the ACR data-plane now requires an `Authorization` header on ALL `/acr/v1/...` requests (previously served anonymously); this matches real ACR and is transparent to SDK clients, but is an externally-observable behavior change for a raw-curl client hitting the mock directly.

## Deferred / scoped out

- `readEnabled` is tracked, settable, and reported accurately, but not enforced — enforcing it would let a caller PATCH `readEnabled=false` and then be unable to read back the very object it just locked (no clean way to build the PATCH response without either bypassing the read gate or a bigger API change). Delete/write/list are the attributes real ACR usage actually depends on.
- Manifest deletion has no dedicated `DELETE /acr/v1/{name}/_manifests/{digest}` route: real ACR deletes manifests via the OCI distribution v2 API (`DELETE /v2/{name}/manifests/{digest}`), not the `acr/v1` catalog API, and that surface isn't implemented in this codebase. `deleteEnabled` on a manifest is still enforced at the driver level (`DeleteImage`), protecting programmatic/portable-API deletion.

## Testing

- New provider-level tests (`providers/azure/acr/attributes_test.go`): Get/Update round-trips, delete/write/list enforcement at all three levels, tag-attribute forgetting on delete/recreate, manifest attributes preserved across re-push.
- New real-SDK end-to-end tests (`server/azure/acr/changeable_attributes_test.go`) via `azure-sdk-for-go/sdk/containers/azcontainerregistry`: lock/unlock/delete-blocked/write-blocked/list-hidden flows for repository, tag, and manifest, plus PATCH-on-unknown-resource 404s.
- Snapshot round-trip test extended to cover the new attributes, plus a legacy-snapshot-defaults-to-enabled test.
- Full existing Azure provider/server/persist/compat suites pass unchanged.

## Fixed after review

- `DeleteRepository`, `ListRepositories`, and `ListImages` read the new `rd.attrs`/`img.attrs` fields without holding `m.mu`, while the `Update*Attributes` writers mutate them under `m.mu.Lock()` — a real data race between a concurrent PATCH and a DELETE/LIST on the same resource. Fixed by taking `m.mu.Lock()` in all three, matching the rest of the file. Added `TestConcurrentAttributeUpdatesRaceWithReads` (`providers/azure/acr/attributes_test.go`), which reproduces the race under `-race` on the pre-fix code and is clean at `-race -count=10` after.
