### PR TITLE
fix(s3): CopyObject recomputes destination ETag (not source multipart ETag)

### DIFF
--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -1007,9 +1007,12 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 		meta[k] = v
 	}
 
+	// The destination is a fresh single-PUT object, not a multipart upload, so its
+	// ETag is always the plain MD5 of the copied bytes — even when the source's
+	// ETag carries a multipart "-N" suffix.
 	dstObj := &s3Object{
 		Key: dstKey, Data: dataCopy, Size: srcObj.Size, ContentType: srcObj.ContentType,
-		ETag: srcObj.ETag, LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
+		ETag: md5Hex(dataCopy), LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
 		Metadata: meta, Tags: maps.Clone(srcObj.Tags), SystemProps: srcObj.SystemProps,
 	}
 
@@ -1067,8 +1070,10 @@ func copyDstSystemProps(req *driver.CopyObjectRequest, src *copySrcSnapshot) dri
 // CopyObjectV2 performs a full-fidelity S3 server-side copy: it honors a
 // versioned source, the COPY/REPLACE metadata directive, and copy-source
 // preconditions (a failed precondition aborts with FailedPrecondition; a
-// delete-marker source version with InvalidArgument). The destination inherits
-// the source ETag exactly (COPY) unless REPLACE supplies new metadata.
+// delete-marker source version with InvalidArgument). The destination is
+// always a fresh single-PUT object, so its ETag is recomputed as the plain
+// MD5 of the copied bytes rather than inherited from the source — matching
+// real S3 even when the source was uploaded via multipart (a "...-N" ETag).
 func (m *Mock) CopyObjectV2(ctx context.Context, req *driver.CopyObjectRequest) (*driver.CopyObjectResult, error) {
 	src, err := m.resolveCopySource(ctx, req.Src, req.SrcVersionID)
 	if err != nil {
@@ -1104,9 +1109,13 @@ func (m *Mock) CopyObjectV2(ctx context.Context, req *driver.CopyObjectRequest) 
 		tags = req.Tags
 	}
 
+	// The destination is a fresh single-PUT object, not a multipart upload, so its
+	// ETag is always the plain MD5 of the copied bytes — even when the source's
+	// ETag carries a multipart "-N" suffix (copy-source preconditions above already
+	// matched against the source's own ETag, so this doesn't affect them).
 	dstObj := &s3Object{
 		Key: req.DstKey, Data: dataCopy, Size: src.size, ContentType: contentType,
-		ETag: src.etag, LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
+		ETag: md5Hex(dataCopy), LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
 		Metadata: maps.Clone(metadata), Tags: maps.Clone(tags), SystemProps: copyDstSystemProps(req, src),
 	}
 

--- a/server/aws/s3/copy_sdk_test.go
+++ b/server/aws/s3/copy_sdk_test.go
@@ -3,8 +3,11 @@ package s3_test
 import (
 	"bytes"
 	"context"
+	"crypto/md5" //nolint:gosec // S3 ETags are defined as MD5 digests, not a security primitive
+	"encoding/hex"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -391,6 +394,124 @@ func TestSDKCopyObjectSelfCopy(t *testing.T) {
 		Metadata:          map[string]string{"changed": "yes"},
 	}); err != nil {
 		t.Fatalf("self-copy with REPLACE: %v", err)
+	}
+}
+
+// TestSDKCopyObjectRecomputesMultipartSourceETag verifies real S3 semantics:
+// CopyObject's destination is always a fresh single-PUT object, so its ETag is
+// the plain 32-hex-char MD5 of the copied bytes — even when the source was
+// uploaded via multipart and therefore carries a "...-N" ETag. Without the
+// fix, cloudemu propagated the source's multipart ETag onto the destination,
+// which is observable to any tool comparing ETags after a copy.
+func TestSDKCopyObjectRecomputesMultipartSourceETag(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "mp-copy-etag"
+	const srcKey = "src"
+	const dstKey = "dst"
+
+	mustCreateBucket(t, client, bucket)
+
+	created, err := client.CreateMultipartUpload(ctx, &awss3.CreateMultipartUploadInput{
+		Bucket: aws.String(bucket), Key: aws.String(srcKey),
+	})
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+
+	uploadID := aws.ToString(created.UploadId)
+
+	part1 := bytes.Repeat([]byte("A"), 8)
+	part2 := bytes.Repeat([]byte("B"), 8)
+	full := append(append([]byte{}, part1...), part2...)
+
+	up1, err := client.UploadPart(ctx, &awss3.UploadPartInput{
+		Bucket: aws.String(bucket), Key: aws.String(srcKey), UploadId: aws.String(uploadID),
+		PartNumber: aws.Int32(1), Body: bytes.NewReader(part1),
+	})
+	if err != nil {
+		t.Fatalf("UploadPart 1: %v", err)
+	}
+
+	up2, err := client.UploadPart(ctx, &awss3.UploadPartInput{
+		Bucket: aws.String(bucket), Key: aws.String(srcKey), UploadId: aws.String(uploadID),
+		PartNumber: aws.Int32(2), Body: bytes.NewReader(part2),
+	})
+	if err != nil {
+		t.Fatalf("UploadPart 2: %v", err)
+	}
+
+	completed, err := client.CompleteMultipartUpload(ctx, &awss3.CompleteMultipartUploadInput{
+		Bucket: aws.String(bucket), Key: aws.String(srcKey), UploadId: aws.String(uploadID),
+		MultipartUpload: &types.CompletedMultipartUpload{Parts: []types.CompletedPart{
+			{ETag: up1.ETag, PartNumber: aws.Int32(1)},
+			{ETag: up2.ETag, PartNumber: aws.Int32(2)},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CompleteMultipartUpload: %v", err)
+	}
+
+	srcETag := strings.Trim(aws.ToString(completed.ETag), `"`)
+	if !strings.HasSuffix(srcETag, "-2") {
+		t.Fatalf("source ETag = %q, want a multipart ETag ending in -2", srcETag)
+	}
+
+	sum := md5.Sum(full) //nolint:gosec // S3 ETag is MD5 by spec, not a security control
+	wantDstETag := hex.EncodeToString(sum[:])
+
+	copyOut, err := client.CopyObject(ctx, &awss3.CopyObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String(dstKey),
+		CopySource: aws.String(bucket + "/" + srcKey),
+	})
+	if err != nil {
+		t.Fatalf("CopyObject: %v", err)
+	}
+
+	gotDstETag := strings.Trim(aws.ToString(copyOut.CopyObjectResult.ETag), `"`)
+	if gotDstETag != wantDstETag {
+		t.Fatalf("CopyObject dst ETag = %q, want plain MD5 %q (source multipart ETag was %q)",
+			gotDstETag, wantDstETag, srcETag)
+	}
+
+	if strings.Contains(gotDstETag, "-") {
+		t.Fatalf("CopyObject dst ETag = %q still carries a multipart suffix", gotDstETag)
+	}
+
+	head, err := client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: aws.String(bucket), Key: aws.String(dstKey)})
+	if err != nil {
+		t.Fatalf("HeadObject dst: %v", err)
+	}
+
+	if got := strings.Trim(aws.ToString(head.ETag), `"`); got != wantDstETag {
+		t.Fatalf("HeadObject dst ETag = %q, want %q", got, wantDstETag)
+	}
+
+	// A copy of a normally-uploaded (non-multipart) object is unchanged: its
+	// ETag was already a plain MD5, so recomputing it yields the same value.
+	putObject(t, client, bucket, "plain-src", "hello world", "", nil)
+
+	plainHead, err := client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: aws.String(bucket), Key: aws.String("plain-src")})
+	if err != nil {
+		t.Fatalf("HeadObject plain-src: %v", err)
+	}
+
+	if _, err := client.CopyObject(ctx, &awss3.CopyObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String("plain-dst"),
+		CopySource: aws.String(bucket + "/plain-src"),
+	}); err != nil {
+		t.Fatalf("CopyObject plain: %v", err)
+	}
+
+	plainDstHead, err := client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: aws.String(bucket), Key: aws.String("plain-dst")})
+	if err != nil {
+		t.Fatalf("HeadObject plain-dst: %v", err)
+	}
+
+	if aws.ToString(plainDstHead.ETag) != aws.ToString(plainHead.ETag) {
+		t.Fatalf("plain copy dst ETag = %q, want unchanged source ETag %q",
+			aws.ToString(plainDstHead.ETag), aws.ToString(plainHead.ETag))
 	}
 }
 


### PR DESCRIPTION
## Summary

A deep e2e audit against a live `cloudemu serve` with `aws-sdk-go-v2`/`aws` CLI found that `CopyObject` returns the wrong destination ETag: it inherited the source object's ETag verbatim. When the source was uploaded via multipart, its ETag has the `"<hex>-N"` shape (hash-of-part-hashes + part count). Real S3 always computes the destination's ETag as the plain 32-hex-char MD5 of the copied bytes, since the destination of a `CopyObject` is a fresh single-PUT object, not a multipart upload.

## Fix

`CopyObject` and `CopyObjectV2` (`providers/aws/s3/s3.go`) now set the destination's ETag to `md5Hex(dataCopy)` instead of reusing the source's ETag. Copy-source preconditions (`x-amz-copy-source-if-match`/`if-none-match`) are unaffected — they already evaluate against the source's own ETag, which is untouched.

## Test plan

- Added `TestSDKCopyObjectRecomputesMultipartSourceETag` (`server/aws/s3/copy_sdk_test.go`) using real `aws-sdk-go-v2`: uploads a source object via multipart (ETag ends in `-2`), copies it, and asserts the destination's `CopyObjectResult.ETag` and a subsequent `HeadObject` both return the plain MD5 with no `-N` suffix; also verifies a copy of a normally-uploaded object still yields the correct MD5.
- `go test ./providers/aws/s3/... ./server/aws/s3/... ./persist/... -race` and the broader `./providers/aws/... ./server/aws/...` suite pass.
- Black-box verified against a real running `cloudemu serve` binary with the `aws` CLI: multipart-uploaded source ETag `"aa5730fefb1188e302ce0fe54e645f47-2"`, `copy-object` destination ETag `"6ccccda662b9b6ac695ac45f12cdbb85"` (plain MD5 of the 16 copied bytes, confirmed by `head-object`), and a plain-PutObject copy still returned its unchanged MD5.