### PR TITLE
fix(ec2): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -1379,7 +1379,7 @@ const (
 // SourceDestCheck) that real EC2 permits on a running instance and that are not
 // part of the portable Compute driver. Unlike ModifyInstance it does not
 // require the instance to be stopped.
-func (m *Mock) SetInstanceAttribute(_ context.Context, instanceID, name, value string) error {
+func (m *Mock) SetInstanceAttribute(ctx context.Context, instanceID, name, value string) error {
 	inst, ok := m.instances.Get(instanceID)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
@@ -1392,7 +1392,15 @@ func (m *Mock) SetInstanceAttribute(_ context.Context, instanceID, name, value s
 	case attrDisableAPITermination:
 		inst.disableAPITermination = parseBool(value)
 	case attrSourceDestCheck:
-		inst.sourceDestCheck = parseBool(value)
+		sourceDestCheck := parseBool(value)
+		inst.sourceDestCheck = sourceDestCheck
+
+		// The networking mock's primary-ENI copy of this flag is what
+		// DescribeInstances/DescribeNetworkInterfaces actually report; keep
+		// it in step so the two describe paths never disagree.
+		if m.networking != nil {
+			_ = m.networking.SetPrimaryNetworkInterfaceSourceDestCheck(ctx, instanceID, sourceDestCheck)
+		}
 	case attrEbsOptimized:
 		inst.ebsOptimized = parseBool(value)
 	case attrDisableAPIStop:
@@ -1654,7 +1662,7 @@ func (m *Mock) AttachVolume(_ context.Context, volumeID, instanceID, device stri
 
 	if state := inst.readState(); state != compute.StateRunning && state != compute.StateStopped {
 		return cerrors.Newf(cerrors.FailedPrecondition,
-			"IncorrectInstanceState: instance %q is in state %q; a volume can only attach to a running or stopped instance",
+			"instance %q is in state %q; a volume can only attach to a running or stopped instance",
 			instanceID, state)
 	}
 
@@ -1673,7 +1681,7 @@ func (m *Mock) AttachVolume(_ context.Context, volumeID, instanceID, device stri
 	found := m.volumes.Update(volumeID, func(v *driver.VolumeInfo) *driver.VolumeInfo {
 		if v.State == stateInUse {
 			attachErr = cerrors.Newf(cerrors.FailedPrecondition,
-				"VolumeInUse: volume %q is attached to instance %q", volumeID, v.AttachedTo)
+				"volume %q is already attached to instance %q", volumeID, v.AttachedTo)
 
 			return v
 		}
@@ -1682,7 +1690,7 @@ func (m *Mock) AttachVolume(_ context.Context, volumeID, instanceID, device stri
 		// (real EC2 InvalidVolume.ZoneMismatch); an explicit cross-AZ volume mismatches.
 		if v.AvailabilityZone != "" && v.AvailabilityZone != instZone {
 			attachErr = cerrors.Newf(cerrors.FailedPrecondition,
-				"ZoneMismatch: volume %q is in availability zone %q but instance %q is in %q",
+				"volume %q is in availability zone %q but instance %q is in %q",
 				volumeID, v.AvailabilityZone, instanceID, instZone)
 
 			return v
@@ -1718,7 +1726,7 @@ func (m *Mock) DetachVolume(_ context.Context, volumeID, instanceID, device stri
 
 		if (instanceID != "" && instanceID != v.AttachedTo) || (device != "" && device != v.Device) {
 			detachErr = cerrors.Newf(cerrors.NotFound,
-				"InvalidAttachment.NotFound: volume %q is not attached to instance %q as device %q",
+				"volume %q is not attached to instance %q as device %q",
 				volumeID, instanceID, device)
 
 			return v

--- a/providers/aws/ec2/networking.go
+++ b/providers/aws/ec2/networking.go
@@ -15,6 +15,14 @@ type Networking interface {
 	// unassociated — matching real EC2, which disassociates (does not release)
 	// an instance's EIPs when it is terminated.
 	DisassociateInstanceAddresses(ctx context.Context, instanceID string) error
+	// SetPrimaryNetworkInterfaceSourceDestCheck mirrors
+	// ModifyInstanceAttribute(SourceDestCheck) onto the instance's primary
+	// (eth0) ENI. Real EC2 has exactly one source/dest-check flag, reported
+	// both by DescribeInstanceAttribute and embedded in
+	// DescribeInstances/DescribeNetworkInterfaces; without this the two
+	// stores diverge and a NAT-instance-shaped Terraform config never
+	// converges. A no-op when the instance has no primary ENI to update.
+	SetPrimaryNetworkInterfaceSourceDestCheck(ctx context.Context, instanceID string, value bool) error
 }
 
 // SetNetworking wires the networking mock in. Without it an instance launches

--- a/providers/aws/vpc/network_interface.go
+++ b/providers/aws/vpc/network_interface.go
@@ -30,11 +30,6 @@ const (
 	macHashPrime = 131
 	bitsPerByte  = 8
 
-	// eniInUseErrPrefix marks the delete-while-attached precondition so the wire
-	// layer can emit InvalidNetworkInterface.InUse rather than the generic
-	// DependencyViolation.
-	eniInUseErrPrefix = "InvalidNetworkInterface.InUse: "
-
 	// primaryDeviceIndex is the device index EC2 gives an instance's primary
 	// (eth0) network interface — always 0.
 	primaryDeviceIndex = 0
@@ -182,6 +177,27 @@ func (m *Mock) ReleaseInstanceNetworkInterfaces(_ context.Context, instanceID st
 	return nil
 }
 
+// SetPrimaryNetworkInterfaceSourceDestCheck mirrors a
+// ModifyInstanceAttribute(SourceDestCheck) write onto the instance's primary
+// (device index 0) ENI, so DescribeNetworkInterfaces / the instance's embedded
+// networkInterfaceSet report the same flag ModifyNetworkInterfaceAttribute
+// would set directly on the interface. A no-op when the instance has no
+// primary ENI (e.g. a launch with no subnet).
+func (m *Mock) SetPrimaryNetworkInterfaceSourceDestCheck(_ context.Context, instanceID string, value bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, eni := range m.enis.All() {
+		if eni.InstanceID == instanceID && eni.DeviceIndex == primaryDeviceIndex {
+			eni.SourceDestCheck = value
+
+			return nil
+		}
+	}
+
+	return nil
+}
+
 // DescribeNetworkInterfaces returns ENIs matching the given IDs, or all if empty.
 //
 // An explicitly named ID that does not exist is NotFound rather than an empty
@@ -218,7 +234,7 @@ func (m *Mock) AttachNetworkInterface(
 
 	if eni.AttachmentID != "" {
 		return "", errors.Newf(errors.FailedPrecondition,
-			"InvalidNetworkInterface.InUse: network interface %q is already attached to instance %q",
+			"network interface %q is already attached to instance %q",
 			networkInterfaceID, eni.InstanceID)
 	}
 
@@ -271,7 +287,7 @@ func (m *Mock) DeleteNetworkInterface(_ context.Context, id string) error {
 
 	if eni.AttachmentID != "" {
 		return errors.Newf(errors.FailedPrecondition,
-			"%snetwork interface %q is currently in use and cannot be deleted", eniInUseErrPrefix, id)
+			"network interface %q is currently in use and cannot be deleted", id)
 	}
 
 	m.enis.Delete(id)

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -904,7 +904,7 @@ func (m *Mock) DeleteSecurityGroup(_ context.Context, id string) error {
 
 	if sg.IsDefault {
 		return errors.Newf(errors.FailedPrecondition,
-			"CannotDelete: default security group %q cannot be deleted", id)
+			"default security group %q cannot be deleted", id)
 	}
 
 	// Real EC2 refuses to delete a security group that is still attached to a

--- a/server/aws/ec2/address.go
+++ b/server/aws/ec2/address.go
@@ -53,6 +53,24 @@ type describeAddressesResponseXML struct {
 	AddressSet []addressXML `xml:"addressesSet>item"`
 }
 
+// addressAttributeXML mirrors real EC2's per-address entry in
+// DescribeAddressesAttributeResponse. CloudEmu does not model reverse-DNS
+// (PTR record) state, so PtrRecord is always omitted — matching a real
+// address that has never had one set.
+type addressAttributeXML struct {
+	AllocationID string `xml:"allocationId"`
+	PublicIP     string `xml:"publicIp"`
+	PtrRecord    string `xml:"ptrRecord,omitempty"`
+}
+
+type describeAddressesAttributeResponseXML struct {
+	XMLName   xml.Name              `xml:"DescribeAddressesAttributeResponse"`
+	Xmlns     string                `xml:"xmlns,attr"`
+	RequestID string                `xml:"requestId"`
+	Addresses []addressAttributeXML `xml:"addressSet>item"`
+	NextToken string                `xml:"nextToken,omitempty"`
+}
+
 // domainVPC is the only domain modern accounts allocate in — EC2-Classic was
 // retired in 2022. Reporting it unconditionally matches what real AWS returns
 // and keeps callers from branching on a value that can no longer vary.
@@ -148,6 +166,37 @@ func (h *Handler) describeAddresses(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, describeAddressesResponseXML{
 		Xmlns: awsquery.Namespace, RequestID: awsquery.RequestID, AddressSet: out,
+	})
+}
+
+// describeAddressesAttribute answers Attribute=domain-name (the only
+// attribute real EC2 currently supports) for a set of allocations, reporting
+// each address's reverse-DNS (PTR record) configuration. CloudEmu does not
+// model PTR records, so every address is reported with none set — the same
+// shape a real, never-configured address has. Terraform's aws_eip resource
+// calls this on every read, so leaving the action unhandled ("unknown
+// action") breaks that resource outright.
+func (h *Handler) describeAddressesAttribute(w http.ResponseWriter, r *http.Request) {
+	ids := awsquery.ListStrings(r.Form, "AllocationId")
+
+	eips, err := h.vpc.DescribeAddresses(r.Context(), ids)
+	if err != nil {
+		writeVPCErr(w, err)
+		return
+	}
+
+	out := make([]addressAttributeXML, 0, len(eips))
+	for i := range eips {
+		out = append(out, addressAttributeXML{
+			AllocationID: eips[i].AllocationID,
+			PublicIP:     eips[i].PublicIP,
+		})
+	}
+
+	awsquery.WriteXMLResponse(w, describeAddressesAttributeResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Addresses: out,
 	})
 }
 
@@ -268,12 +317,12 @@ func (h *Handler) associateAddress(w http.ResponseWriter, r *http.Request) {
 // unknown allocation -> InvalidAllocationID.NotFound.
 func writeAssociateAddressErr(w http.ResponseWriter, err error) {
 	if cerrors.IsNotFound(err) && strings.Contains(err.Error(), "network interface") {
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidNetworkInterfaceID.NotFound", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidNetworkInterfaceID.NotFound", cerrors.Message(err))
 		return
 	}
 
 	if cerrors.IsAlreadyExists(err) {
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "Resource.AlreadyAssociated", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "Resource.AlreadyAssociated", cerrors.Message(err))
 		return
 	}
 

--- a/server/aws/ec2/address.go
+++ b/server/aws/ec2/address.go
@@ -36,14 +36,15 @@ type releaseAddressResponseXML struct {
 }
 
 type addressXML struct {
-	PublicIP                string `xml:"publicIp"`
-	AllocationID            string `xml:"allocationId"`
-	AssociationID           string `xml:"associationId,omitempty"`
-	InstanceID              string `xml:"instanceId,omitempty"`
-	NetworkInterfaceID      string `xml:"networkInterfaceId,omitempty"`
-	NetworkInterfaceOwnerID string `xml:"networkInterfaceOwnerId,omitempty"`
-	PrivateIPAddress        string `xml:"privateIpAddress,omitempty"`
-	Domain                  string `xml:"domain"`
+	PublicIP                string    `xml:"publicIp"`
+	AllocationID            string    `xml:"allocationId"`
+	AssociationID           string    `xml:"associationId,omitempty"`
+	InstanceID              string    `xml:"instanceId,omitempty"`
+	NetworkInterfaceID      string    `xml:"networkInterfaceId,omitempty"`
+	NetworkInterfaceOwnerID string    `xml:"networkInterfaceOwnerId,omitempty"`
+	PrivateIPAddress        string    `xml:"privateIpAddress,omitempty"`
+	Domain                  string    `xml:"domain"`
+	Tags                    []tagItem `xml:"tagSet>item,omitempty"`
 }
 
 type describeAddressesResponseXML struct {
@@ -152,6 +153,7 @@ func (h *Handler) describeAddresses(w http.ResponseWriter, r *http.Request) {
 			NetworkInterfaceID: eips[i].NetworkInterfaceID,
 			PrivateIPAddress:   eips[i].PrivateIP,
 			Domain:             domainVPC,
+			Tags:               toTagItems(eips[i].Tags),
 		}
 
 		// networkInterfaceOwnerId only surfaces for an ENI-bound EIP; it is the

--- a/server/aws/ec2/endpoint.go
+++ b/server/aws/ec2/endpoint.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
@@ -81,7 +82,7 @@ func (h *Handler) deleteVPCEndpoints(w http.ResponseWriter, r *http.Request) {
 		if err := h.vpc.DeleteVPCEndpoint(r.Context(), id); err != nil {
 			item := unsuccessfulItemXML{ResourceID: id}
 			item.Error.Code = "InvalidVpcEndpointId.NotFound"
-			item.Error.Message = err.Error()
+			item.Error.Message = cerrors.Message(err)
 			unsuccessful = append(unsuccessful, item)
 		}
 	}

--- a/server/aws/ec2/error_shape_test.go
+++ b/server/aws/ec2/error_shape_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	smithy "github.com/aws/smithy-go"
 )
 
@@ -181,6 +182,81 @@ func TestEC2ErrorMessagesHaveNoInternalPrefix(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("DeleteInternetGateway on a missing gateway: want error, got nil")
+	}
+
+	assertNoLeakedPrefix(t, apiMessage(t, err))
+}
+
+// TestDeleteVolumeAttachedNoLeakedPrefix pins that DeleteVolume on an
+// attached volume answers VolumeInUse with a clean message — no
+// "FailedPrecondition:" prefix leaked from the internal error type.
+func TestDeleteVolumeAttachedNoLeakedPrefix(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	_, subnetID := mkVPCSubnet(t, c)
+
+	run, err := c.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-12345678"),
+		InstanceType: ec2types.InstanceTypeT2Micro,
+		SubnetId:     aws.String(subnetID),
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	instanceID := aws.ToString(run.Instances[0].InstanceId)
+
+	vol, err := c.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(10),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+
+	volumeID := aws.ToString(vol.VolumeId)
+
+	if _, err := c.AttachVolume(ctx, &ec2.AttachVolumeInput{
+		VolumeId:   aws.String(volumeID),
+		InstanceId: aws.String(instanceID),
+		Device:     aws.String("/dev/sdf"),
+	}); err != nil {
+		t.Fatalf("AttachVolume: %v", err)
+	}
+
+	_, err = c.DeleteVolume(ctx, &ec2.DeleteVolumeInput{VolumeId: aws.String(volumeID)})
+	if err == nil {
+		t.Fatal("DeleteVolume on an attached volume: want error, got nil")
+	}
+
+	if got := apiCode(t, err); got != "VolumeInUse" {
+		t.Errorf("error code = %q, want VolumeInUse", got)
+	}
+
+	assertNoLeakedPrefix(t, apiMessage(t, err))
+}
+
+// TestCreateKeyPairDuplicateNoLeakedPrefix pins that a duplicate CreateKeyPair
+// answers InvalidKeyPair.Duplicate with a clean message — no "AlreadyExists:"
+// prefix leaked from the internal error type.
+func TestCreateKeyPairDuplicateNoLeakedPrefix(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+
+	if _, err := c.CreateKeyPair(ctx, &ec2.CreateKeyPairInput{KeyName: aws.String("dup-key")}); err != nil {
+		t.Fatalf("CreateKeyPair: %v", err)
+	}
+
+	_, err := c.CreateKeyPair(ctx, &ec2.CreateKeyPairInput{KeyName: aws.String("dup-key")})
+	if err == nil {
+		t.Fatal("CreateKeyPair duplicate: want error, got nil")
+	}
+
+	if got := apiCode(t, err); got != "InvalidKeyPair.Duplicate" {
+		t.Errorf("error code = %q, want InvalidKeyPair.Duplicate", got)
 	}
 
 	assertNoLeakedPrefix(t, apiMessage(t, err))

--- a/server/aws/ec2/error_shape_test.go
+++ b/server/aws/ec2/error_shape_test.go
@@ -23,6 +23,18 @@ var leakedPrefixes = []string{ //nolint:gochecknoglobals // shared test fixture
 	"DependencyViolation:",
 	"PermissionDenied:",
 	"Internal:",
+	// Driver-baked sub-codes: some wire handlers used to match on a
+	// substring the driver embedded in the message itself (rather than the
+	// canonical cerrors.Code) to pick the exact AWS error CODE, and left
+	// that substring sitting in the human-facing message too. The AWS code
+	// is set separately at the wire layer, so none of these should ever
+	// appear in <Message>.
+	"ZoneMismatch:",
+	"VolumeInUse:",
+	"IncorrectInstanceState:",
+	"InvalidAttachment.NotFound:",
+	"CannotDelete:",
+	"InvalidNetworkInterface.InUse:",
 }
 
 func apiMessage(t *testing.T, err error) string {

--- a/server/aws/ec2/flow_log.go
+++ b/server/aws/ec2/flow_log.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
@@ -85,7 +86,7 @@ func (h *Handler) deleteFlowLogs(w http.ResponseWriter, r *http.Request) {
 		if err := h.vpc.DeleteFlowLog(r.Context(), id); err != nil {
 			item := unsuccessfulItemXML{ResourceID: id}
 			item.Error.Code = "InvalidFlowLogId.NotFound"
-			item.Error.Message = err.Error()
+			item.Error.Message = cerrors.Message(err)
 			unsuccessful = append(unsuccessful, item)
 		}
 	}

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -472,7 +472,11 @@ func (h *Handler) routeVPC(w http.ResponseWriter, r *http.Request, action string
 		return true
 	}
 
-	return h.routeVPCRouteTable(w, r, action)
+	if h.routeVPCRouteTable(w, r, action) {
+		return true
+	}
+
+	return h.routeVPCAddress(w, r, action)
 }
 
 func (h *Handler) routeVPCResource(w http.ResponseWriter, r *http.Request, action string) bool {
@@ -489,12 +493,25 @@ func (h *Handler) routeVPCResource(w http.ResponseWriter, r *http.Request, actio
 		h.describeVpcs(w, r)
 	case "DescribeAvailabilityZones":
 		h.describeAvailabilityZones(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// routeVPCAddress dispatches Elastic IP actions. Split out of
+// routeVPCResource to keep that dispatch table's cyclomatic complexity down.
+func (h *Handler) routeVPCAddress(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
 	case "AllocateAddress":
 		h.allocateAddress(w, r)
 	case "ReleaseAddress":
 		h.releaseAddress(w, r)
 	case "DescribeAddresses":
 		h.describeAddresses(w, r)
+	case "DescribeAddressesAttribute":
+		h.describeAddressesAttribute(w, r)
 	case "AssociateAddress":
 		h.associateAddress(w, r)
 	case "DisassociateAddress":

--- a/server/aws/ec2/image.go
+++ b/server/aws/ec2/image.go
@@ -220,7 +220,7 @@ func parseImageBlockDeviceMappings(r *http.Request) []computedriver.ImageBlockDe
 // is InvalidSnapshot.NotFound (RegisterImage never reports InvalidAMIID).
 func writeRegisterImageErr(w http.ResponseWriter, err error) {
 	if cerrors.IsAlreadyExists(err) {
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAMIName.Duplicate", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAMIName.Duplicate", cerrors.Message(err))
 		return
 	}
 

--- a/server/aws/ec2/key_pair.go
+++ b/server/aws/ec2/key_pair.go
@@ -172,7 +172,7 @@ func toKeyPairSummaryXML(kp *computedriver.KeyPairInfo) keyPairSummaryXML {
 // the generic ResourceAlreadyExists; other codes use the shared mapping.
 func writeKeyPairErr(w http.ResponseWriter, err error) {
 	if cerrors.IsAlreadyExists(err) {
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidKeyPair.Duplicate", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidKeyPair.Duplicate", cerrors.Message(err))
 		return
 	}
 

--- a/server/aws/ec2/launch_template.go
+++ b/server/aws/ec2/launch_template.go
@@ -354,7 +354,7 @@ func toLaunchTemplateDataXML(cfg computedriver.InstanceConfig) launchTemplateDat
 func writeLaunchTemplateErr(w http.ResponseWriter, err error) {
 	if cerrors.IsAlreadyExists(err) {
 		awsquery.WriteXMLError(w, http.StatusBadRequest,
-			"InvalidLaunchTemplateName.AlreadyExistsException", err.Error())
+			"InvalidLaunchTemplateName.AlreadyExistsException", cerrors.Message(err))
 
 		return
 	}

--- a/server/aws/ec2/network_acl.go
+++ b/server/aws/ec2/network_acl.go
@@ -264,13 +264,13 @@ func writeNetworkACLAssocErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsInvalidArgument(err):
 		// Cross-VPC association attempt.
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", cerrors.Message(err))
 	case cerrors.IsNotFound(err) && !strings.Contains(err.Error(), "network ACL association"):
 		// A missing ACL, not a missing association. Matching the contiguous fixed
 		// phrase "network ACL association" is robust: the ACL-not-found message is
 		// `network ACL "<id>" not found`, so a caller-supplied id containing
 		// "association" cannot forge the phrase (the quote breaks it).
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidNetworkAclID.NotFound", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidNetworkAclID.NotFound", cerrors.Message(err))
 	default:
 		writeErrWithNotFound(w, err, "InvalidAssociationID.NotFound", "DependencyViolation")
 	}

--- a/server/aws/ec2/network_interface.go
+++ b/server/aws/ec2/network_interface.go
@@ -139,6 +139,36 @@ func eniFilterField(eni *netdriver.NetworkInterface, name string) (string, bool)
 		// preflight (Terraform lists group-id ENIs before dropping a group)
 		// needs: no interface uses the group, so the delete proceeds.
 		return "", true
+	case "source-dest-check":
+		return boolFilterValue(eni.SourceDestCheck), true
+	default:
+		if strings.HasPrefix(name, "attachment.") {
+			return eniAttachmentFilterField(eni, name)
+		}
+
+		return "", false
+	}
+}
+
+// eniAttachmentFilterField answers the attachment.* filters, which all read
+// off the interface's attachment record.
+func eniAttachmentFilterField(eni *netdriver.NetworkInterface, name string) (string, bool) {
+	switch name {
+	case "attachment.instance-id":
+		return eni.InstanceID, true
+	case "attachment.device-index":
+		return strconv.Itoa(eni.DeviceIndex), true
+	case "attachment.attachment-id":
+		return eni.AttachmentID, true
+	case "attachment.status":
+		// CloudEmu attaches synchronously, so an interface with an instance
+		// attachment is always "attached" — there is no transient
+		// attaching/detaching window to report.
+		if eni.InstanceID == "" {
+			return "", true
+		}
+
+		return "attached", true
 	default:
 		return "", false
 	}
@@ -259,7 +289,7 @@ func (h *Handler) attachNetworkInterface(w http.ResponseWriter, r *http.Request)
 // (real EC2's code), falling back to the shared ENI error mapping otherwise.
 func writeENIAttachErr(w http.ResponseWriter, err error) {
 	if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "InvalidNetworkInterface.InUse:") {
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidNetworkInterface.InUse", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidNetworkInterface.InUse", cerrors.Message(err))
 		return
 	}
 
@@ -349,7 +379,7 @@ func (h *Handler) modifyNetworkInterfaceAttribute(w http.ResponseWriter, r *http
 // error mapping otherwise.
 func writeENIDeleteErr(w http.ResponseWriter, err error) {
 	if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "InvalidNetworkInterface.InUse:") {
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidNetworkInterface.InUse", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidNetworkInterface.InUse", cerrors.Message(err))
 		return
 	}
 

--- a/server/aws/ec2/network_interface.go
+++ b/server/aws/ec2/network_interface.go
@@ -287,8 +287,10 @@ func (h *Handler) attachNetworkInterface(w http.ResponseWriter, r *http.Request)
 
 // writeENIAttachErr maps an already-attached interface to InvalidNetworkInterface.InUse
 // (real EC2's code), falling back to the shared ENI error mapping otherwise.
+// Matched on the driver's clean message text — "is already attached to
+// instance" appears only in this case.
 func writeENIAttachErr(w http.ResponseWriter, err error) {
-	if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "InvalidNetworkInterface.InUse:") {
+	if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "is already attached to instance") {
 		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidNetworkInterface.InUse", cerrors.Message(err))
 		return
 	}
@@ -376,9 +378,10 @@ func (h *Handler) modifyNetworkInterfaceAttribute(w http.ResponseWriter, r *http
 
 // writeENIDeleteErr maps a delete-while-attached interface to
 // InvalidNetworkInterface.InUse (real EC2's code), falling back to the shared ENI
-// error mapping otherwise.
+// error mapping otherwise. Matched on the driver's clean message text —
+// "is currently in use and cannot be deleted" appears only in this case.
 func writeENIDeleteErr(w http.ResponseWriter, err error) {
-	if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "InvalidNetworkInterface.InUse:") {
+	if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "is currently in use and cannot be deleted") {
 		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidNetworkInterface.InUse", cerrors.Message(err))
 		return
 	}

--- a/server/aws/ec2/network_interface_attribute_test.go
+++ b/server/aws/ec2/network_interface_attribute_test.go
@@ -193,4 +193,58 @@ func TestDeleteAttachedNetworkInterfaceCode(t *testing.T) {
 	if got := apiCode(t, err); got != "InvalidNetworkInterface.InUse" {
 		t.Errorf("code = %q, want InvalidNetworkInterface.InUse", got)
 	}
+
+	assertNoLeakedPrefix(t, apiMessage(t, err))
+}
+
+// TestReattachNetworkInterfaceCode pins that attaching an ENI that is already
+// attached to an instance answers InvalidNetworkInterface.InUse with a clean
+// message — no "InvalidNetworkInterface.InUse:" prefix leaked from the
+// internal error type.
+func TestReattachNetworkInterfaceCode(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	_, subnetID := mkVPCSubnet(t, c)
+
+	run, err := c.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId: aws.String("ami-12345"), InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount: aws.Int32(1), MaxCount: aws.Int32(1), SubnetId: aws.String(subnetID),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	instanceID := aws.ToString(run.Instances[0].InstanceId)
+
+	created, err := c.CreateNetworkInterface(ctx, &ec2.CreateNetworkInterfaceInput{
+		SubnetId: aws.String(subnetID),
+	})
+	if err != nil {
+		t.Fatalf("CreateNetworkInterface: %v", err)
+	}
+
+	eniID := aws.ToString(created.NetworkInterface.NetworkInterfaceId)
+
+	if _, err := c.AttachNetworkInterface(ctx, &ec2.AttachNetworkInterfaceInput{
+		NetworkInterfaceId: aws.String(eniID),
+		InstanceId:         aws.String(instanceID),
+		DeviceIndex:        aws.Int32(1),
+	}); err != nil {
+		t.Fatalf("AttachNetworkInterface: %v", err)
+	}
+
+	_, err = c.AttachNetworkInterface(ctx, &ec2.AttachNetworkInterfaceInput{
+		NetworkInterfaceId: aws.String(eniID),
+		InstanceId:         aws.String(instanceID),
+		DeviceIndex:        aws.Int32(2),
+	})
+	if err == nil {
+		t.Fatal("AttachNetworkInterface(already attached) succeeded, want an error")
+	}
+
+	if got := apiCode(t, err); got != "InvalidNetworkInterface.InUse" {
+		t.Errorf("code = %q, want InvalidNetworkInterface.InUse", got)
+	}
+
+	assertNoLeakedPrefix(t, apiMessage(t, err))
 }

--- a/server/aws/ec2/network_interface_test.go
+++ b/server/aws/ec2/network_interface_test.go
@@ -160,7 +160,7 @@ func TestDescribeNetworkInterfacesRejectsUnknownFilter(t *testing.T) {
 
 	resp := do(t, h, http.MethodPost, "/", url.Values{
 		"Action":        {"DescribeNetworkInterfaces"},
-		"Filter.1.Name": {"attachment.instance-id"}, "Filter.1.Value.1": {"i-whatever"},
+		"Filter.1.Name": {"requester-managed"}, "Filter.1.Value.1": {"true"},
 	})
 	if resp.Code == http.StatusOK {
 		t.Errorf("an unimplemented filter must not be silently ignored: %s", resp.Body.String())
@@ -172,5 +172,83 @@ func TestDescribeNetworkInterfacesRejectsUnknownFilter(t *testing.T) {
 	})
 	if ok.Code != http.StatusOK {
 		t.Errorf("supported filter = %d: %s", ok.Code, ok.Body.String())
+	}
+}
+
+// TestDescribeNetworkInterfacesAttachmentFilters pins support for the
+// attachment.instance-id / attachment.device-index / source-dest-check
+// filters real EC2 documents for DescribeNetworkInterfaces. Terraform's
+// aws_instance resource looks up an instance's primary ENI by
+// attachment.instance-id to read source_dest_check; rejecting that filter
+// (as "invalid") broke every read of that attribute and caused a perpetual
+// plan diff.
+func TestDescribeNetworkInterfacesAttachmentFilters(t *testing.T) {
+	h := newFullHandler()
+
+	_, subnetID := mkVPCAndSubnet(t, h)
+
+	runResp := do(t, h, http.MethodPost, "/", url.Values{
+		"Action": {"RunInstances"}, "ImageId": {"ami-12345678"}, "InstanceType": {"t2.micro"},
+		"SubnetId": {subnetID}, "MinCount": {"1"}, "MaxCount": {"1"},
+	})
+	if runResp.Code != http.StatusOK {
+		t.Fatalf("RunInstances = %d: %s", runResp.Code, runResp.Body.String())
+	}
+
+	instanceID := extractFirstInstanceID(runResp.Body.String())
+
+	createResp := do(t, h, http.MethodPost, "/", url.Values{
+		"Action": {"CreateNetworkInterface"}, "SubnetId": {subnetID},
+	})
+	if createResp.Code != http.StatusOK {
+		t.Fatalf("CreateNetworkInterface = %d: %s", createResp.Code, createResp.Body.String())
+	}
+
+	eniID := between(createResp.Body.String(), "<networkInterfaceId>", "</networkInterfaceId>")
+	if eniID == "" {
+		t.Fatalf("CreateNetworkInterface returned no id: %s", createResp.Body.String())
+	}
+
+	attachResp := do(t, h, http.MethodPost, "/", url.Values{
+		"Action": {"AttachNetworkInterface"}, "NetworkInterfaceId": {eniID},
+		"InstanceId": {instanceID}, "DeviceIndex": {"1"},
+	})
+	if attachResp.Code != http.StatusOK {
+		t.Fatalf("AttachNetworkInterface = %d: %s", attachResp.Code, attachResp.Body.String())
+	}
+
+	resp := do(t, h, http.MethodPost, "/", url.Values{
+		"Action":        {"DescribeNetworkInterfaces"},
+		"Filter.1.Name": {"attachment.instance-id"}, "Filter.1.Value.1": {instanceID},
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("attachment.instance-id filter = %d: %s", resp.Code, resp.Body.String())
+	}
+
+	body := resp.Body.String()
+	if !strings.Contains(body, "<networkInterfaceId>"+eniID+"</networkInterfaceId>") {
+		t.Errorf("expected the attached ENI %q in the result, got: %s", eniID, body)
+	}
+
+	if !strings.Contains(body, "<sourceDestCheck>true</sourceDestCheck>") {
+		t.Errorf("expected sourceDestCheck true on the attached ENI, got: %s", body)
+	}
+
+	// attachment.device-index and source-dest-check are documented alongside
+	// attachment.instance-id; pin them too so the whole filter set stays wired.
+	idxResp := do(t, h, http.MethodPost, "/", url.Values{
+		"Action":        {"DescribeNetworkInterfaces"},
+		"Filter.1.Name": {"attachment.device-index"}, "Filter.1.Value.1": {"1"},
+	})
+	if idxResp.Code != http.StatusOK || !strings.Contains(idxResp.Body.String(), eniID) {
+		t.Errorf("attachment.device-index filter = %d: %s", idxResp.Code, idxResp.Body.String())
+	}
+
+	sdcResp := do(t, h, http.MethodPost, "/", url.Values{
+		"Action":        {"DescribeNetworkInterfaces"},
+		"Filter.1.Name": {"source-dest-check"}, "Filter.1.Value.1": {"true"},
+	})
+	if sdcResp.Code != http.StatusOK || !strings.Contains(sdcResp.Body.String(), eniID) {
+		t.Errorf("source-dest-check filter = %d: %s", sdcResp.Code, sdcResp.Body.String())
 	}
 }

--- a/server/aws/ec2/operations.go
+++ b/server/aws/ec2/operations.go
@@ -461,7 +461,7 @@ func (h *Handler) terminateInstances(w http.ResponseWriter, r *http.Request) {
 		// Termination protection surfaces as OperationNotPermitted, not the
 		// generic instance-state error.
 		if cerrors.IsPermissionDenied(err) {
-			awsquery.WriteXMLError(w, http.StatusBadRequest, "OperationNotPermitted", err.Error())
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "OperationNotPermitted", cerrors.Message(err))
 			return
 		}
 
@@ -992,6 +992,7 @@ func instanceENIs(inst *computedriver.Instance, groups []groupItem, enis []netdr
 			MacAddress:         eni.MacAddress,
 			PrivateIP:          eni.PrivateIP,
 			Status:             eni.Status,
+			SourceDestCheck:    eni.SourceDestCheck,
 			Groups:             itemGroups,
 			Attachment: instanceENIAttachmentXML{
 				AttachmentID: eni.AttachmentID,
@@ -1013,11 +1014,12 @@ func synthesizedPrimaryENI(inst *computedriver.Instance, groups []groupItem) *in
 	}
 
 	return &instanceENIXML{
-		SubnetID:   inst.SubnetID,
-		VPCID:      inst.VPCID,
-		PrivateIP:  inst.PrivateIP,
-		Groups:     groups,
-		Attachment: instanceENIAttachmentXML{DeviceIndex: primaryDeviceIndex, Status: eniAttachedStatus},
+		SubnetID:        inst.SubnetID,
+		VPCID:           inst.VPCID,
+		PrivateIP:       inst.PrivateIP,
+		SourceDestCheck: true,
+		Groups:          groups,
+		Attachment:      instanceENIAttachmentXML{DeviceIndex: primaryDeviceIndex, Status: eniAttachedStatus},
 	}
 }
 

--- a/server/aws/ec2/operations.go
+++ b/server/aws/ec2/operations.go
@@ -909,6 +909,16 @@ func instanceXMLFor(
 	}
 
 	xi.NetworkInterfaces = instanceENIs(inst, xi.Groups, enis)
+	// Real EC2 mirrors the primary interface's source/dest-check flag at the
+	// top level of the Instance element too; aws-sdk-go-v2 and
+	// terraform-provider-aws read that top-level field, not the nested
+	// networkInterfaceSet entry. instanceENIs orders eth0 (device index 0)
+	// first, so [0] is always the primary interface when one exists.
+	xi.SourceDestCheck = true
+	if len(xi.NetworkInterfaces) > 0 {
+		xi.SourceDestCheck = xi.NetworkInterfaces[0].SourceDestCheck
+	}
+
 	xi.BlockDeviceMappings = instanceBlockDevices(vols)
 
 	for k, v := range inst.Tags {

--- a/server/aws/ec2/placement_group.go
+++ b/server/aws/ec2/placement_group.go
@@ -113,7 +113,7 @@ func toPlacementGroupXML(pg *computedriver.PlacementGroup) placementGroupXML {
 
 func writePlacementGroupErr(w http.ResponseWriter, err error) {
 	if cerrors.IsAlreadyExists(err) {
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidPlacementGroup.Duplicate", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidPlacementGroup.Duplicate", cerrors.Message(err))
 		return
 	}
 

--- a/server/aws/ec2/security_group.go
+++ b/server/aws/ec2/security_group.go
@@ -170,7 +170,7 @@ func (h *Handler) createSecurityGroup(w http.ResponseWriter, r *http.Request) {
 // InvalidGroup.Duplicate code, falling back to the shared SG error mapping.
 func writeCreateSGErr(w http.ResponseWriter, err error) {
 	if cerrors.IsAlreadyExists(err) {
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidGroup.Duplicate", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidGroup.Duplicate", cerrors.Message(err))
 		return
 	}
 
@@ -190,7 +190,7 @@ func (h *Handler) deleteSecurityGroup(w http.ResponseWriter, r *http.Request) {
 		// The default security group is non-deletable: EC2 answers a distinct
 		// Client.CannotDelete code rather than the generic DependencyViolation.
 		if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "CannotDelete:") {
-			awsquery.WriteXMLError(w, http.StatusBadRequest, "Client.CannotDelete", err.Error())
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "Client.CannotDelete", cerrors.Message(err))
 			return
 		}
 
@@ -1100,7 +1100,7 @@ func parseRuleDescriptions(form url.Values) []ruleDescription {
 // group-level SG error mapping for everything else.
 func writeSGRuleErr(w http.ResponseWriter, err error) {
 	if cerrors.IsNotFound(err) && strings.Contains(err.Error(), "rule") {
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSecurityGroupRuleId.NotFound", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSecurityGroupRuleId.NotFound", cerrors.Message(err))
 		return
 	}
 

--- a/server/aws/ec2/security_group.go
+++ b/server/aws/ec2/security_group.go
@@ -189,7 +189,10 @@ func (h *Handler) deleteSecurityGroup(w http.ResponseWriter, r *http.Request) {
 	if err := h.vpc.DeleteSecurityGroup(r.Context(), id); err != nil {
 		// The default security group is non-deletable: EC2 answers a distinct
 		// Client.CannotDelete code rather than the generic DependencyViolation.
-		if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "CannotDelete:") {
+		// Matched on the driver's clean message text — "cannot be deleted"
+		// appears only in this case (the in-use/referenced case says "is in
+		// use by", not "cannot be deleted").
+		if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "cannot be deleted") {
 			awsquery.WriteXMLError(w, http.StatusBadRequest, "Client.CannotDelete", cerrors.Message(err))
 			return
 		}

--- a/server/aws/ec2/security_group_test.go
+++ b/server/aws/ec2/security_group_test.go
@@ -99,6 +99,8 @@ func TestDefaultSecurityGroupOverWire(t *testing.T) {
 	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "Client.CannotDelete" {
 		t.Fatalf("delete error = %v, want Client.CannotDelete", err)
 	}
+
+	assertNoLeakedPrefix(t, apiErr.ErrorMessage())
 }
 
 // TestCreateSecurityGroupReturnsTags pins that CreateSecurityGroup echoes the

--- a/server/aws/ec2/snapshot.go
+++ b/server/aws/ec2/snapshot.go
@@ -119,7 +119,7 @@ func (h *Handler) deleteSnapshot(w http.ResponseWriter, r *http.Request) {
 		// A snapshot referenced by a registered AMI cannot be deleted until the
 		// AMI is deregistered; real EC2 answers InvalidSnapshot.InUse.
 		if cerrors.IsFailedPrecondition(err) {
-			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSnapshot.InUse", err.Error())
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSnapshot.InUse", cerrors.Message(err))
 			return
 		}
 

--- a/server/aws/ec2/subnet.go
+++ b/server/aws/ec2/subnet.go
@@ -248,7 +248,7 @@ func writeSubnetErr(w http.ResponseWriter, err error) {
 // shared subnet error mapping otherwise.
 func writeCreateSubnetErr(w http.ResponseWriter, err error) {
 	if cerrors.IsAlreadyExists(err) {
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSubnet.Conflict", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSubnet.Conflict", cerrors.Message(err))
 		return
 	}
 

--- a/server/aws/ec2/volume.go
+++ b/server/aws/ec2/volume.go
@@ -33,6 +33,10 @@ const (
 	filterName               = "name"
 	filterRootDeviceType     = "root-device-type"
 	filterVirtualizationType = "virtualization-type"
+	filterAttachmentDevice   = "attachment.device"
+	filterAttachmentInstance = "attachment.instance-id"
+	filterAttachmentStatus   = "attachment.status"
+	filterAttachmentDOT      = "attachment.delete-on-termination"
 )
 
 type volumeAttachmentXML struct {
@@ -146,7 +150,7 @@ func (h *Handler) deleteVolume(w http.ResponseWriter, r *http.Request) {
 		// An attached volume cannot be deleted; real EC2 answers VolumeInUse
 		// rather than the generic IncorrectState.
 		if cerrors.IsFailedPrecondition(err) {
-			awsquery.WriteXMLError(w, http.StatusBadRequest, "VolumeInUse", err.Error())
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "VolumeInUse", cerrors.Message(err))
 			return
 		}
 
@@ -204,7 +208,8 @@ func validateVolumeFilters(filters []awsquery.Filter) error {
 
 		switch f.Name {
 		case filterVolumeID, filterStatus, filterAvailabilityZone, filterVolumeType,
-			filterEncrypted, filterSnapshotID, filterSize:
+			filterEncrypted, filterSnapshotID, filterSize,
+			filterAttachmentDevice, filterAttachmentInstance, filterAttachmentStatus, filterAttachmentDOT:
 		default:
 			return newInvalidParameterErr("The filter '" + f.Name + "' is invalid")
 		}
@@ -243,6 +248,30 @@ func volumeMatchesFilter(v *computedriver.VolumeInfo, f awsquery.Filter) bool {
 		return containsString(f.Values, v.SnapshotID)
 	case filterSize:
 		return containsString(f.Values, strconv.Itoa(v.Size))
+	case filterAttachmentDevice, filterAttachmentInstance, filterAttachmentStatus, filterAttachmentDOT:
+		return volumeMatchesAttachmentFilter(v, f)
+	default:
+		return false
+	}
+}
+
+// volumeMatchesAttachmentFilter matches the attachment.* filters, which all
+// share the precondition that the volume must actually be attached — an
+// unattached volume matches none of them.
+func volumeMatchesAttachmentFilter(v *computedriver.VolumeInfo, f awsquery.Filter) bool {
+	if v.AttachedTo == "" {
+		return false
+	}
+
+	switch f.Name {
+	case filterAttachmentDevice:
+		return containsString(f.Values, v.Device)
+	case filterAttachmentInstance:
+		return containsString(f.Values, v.AttachedTo)
+	case filterAttachmentStatus:
+		return containsString(f.Values, "attached")
+	case filterAttachmentDOT:
+		return containsString(f.Values, boolFilterValue(v.DeleteOnTermination))
 	default:
 		return false
 	}
@@ -257,21 +286,21 @@ func (h *Handler) attachVolume(w http.ResponseWriter, r *http.Request) {
 		// A volume and the instance it attaches to must share an Availability
 		// Zone; real EC2 answers InvalidVolume.ZoneMismatch for a cross-AZ attach.
 		if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "ZoneMismatch:") {
-			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidVolume.ZoneMismatch", err.Error())
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidVolume.ZoneMismatch", cerrors.Message(err))
 			return
 		}
 
 		// A volume already attached to an instance cannot be re-attached; real
 		// EC2 answers VolumeInUse rather than the generic IncorrectState.
 		if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "VolumeInUse:") {
-			awsquery.WriteXMLError(w, http.StatusBadRequest, "VolumeInUse", err.Error())
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "VolumeInUse", cerrors.Message(err))
 			return
 		}
 
 		// A volume can only attach to a running/stopped instance; attaching to a
 		// terminated or pending instance is IncorrectInstanceState.
 		if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "IncorrectInstanceState:") {
-			awsquery.WriteXMLError(w, http.StatusBadRequest, "IncorrectInstanceState", err.Error())
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "IncorrectInstanceState", cerrors.Message(err))
 			return
 		}
 
@@ -309,7 +338,7 @@ func (h *Handler) detachVolume(w http.ResponseWriter, r *http.Request) {
 		// The named instance/device did not match the volume's actual
 		// attachment; real EC2 answers InvalidAttachment.NotFound.
 		if cerrors.IsNotFound(err) && strings.Contains(err.Error(), "InvalidAttachment.NotFound:") {
-			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAttachment.NotFound", err.Error())
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAttachment.NotFound", cerrors.Message(err))
 			return
 		}
 

--- a/server/aws/ec2/volume.go
+++ b/server/aws/ec2/volume.go
@@ -285,21 +285,23 @@ func (h *Handler) attachVolume(w http.ResponseWriter, r *http.Request) {
 	if err := h.compute.AttachVolume(r.Context(), volID, instID, device); err != nil {
 		// A volume and the instance it attaches to must share an Availability
 		// Zone; real EC2 answers InvalidVolume.ZoneMismatch for a cross-AZ attach.
-		if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "ZoneMismatch:") {
+		// Matched on the driver's clean message text (no internal code prefix) —
+		// "is in availability zone" appears only in this case.
+		if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "is in availability zone") {
 			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidVolume.ZoneMismatch", cerrors.Message(err))
 			return
 		}
 
 		// A volume already attached to an instance cannot be re-attached; real
 		// EC2 answers VolumeInUse rather than the generic IncorrectState.
-		if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "VolumeInUse:") {
+		if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "is already attached to instance") {
 			awsquery.WriteXMLError(w, http.StatusBadRequest, "VolumeInUse", cerrors.Message(err))
 			return
 		}
 
 		// A volume can only attach to a running/stopped instance; attaching to a
 		// terminated or pending instance is IncorrectInstanceState.
-		if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "IncorrectInstanceState:") {
+		if cerrors.IsFailedPrecondition(err) && strings.Contains(err.Error(), "can only attach to a running or stopped instance") {
 			awsquery.WriteXMLError(w, http.StatusBadRequest, "IncorrectInstanceState", cerrors.Message(err))
 			return
 		}
@@ -336,8 +338,11 @@ func (h *Handler) detachVolume(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.compute.DetachVolume(r.Context(), volID, instID, device); err != nil {
 		// The named instance/device did not match the volume's actual
-		// attachment; real EC2 answers InvalidAttachment.NotFound.
-		if cerrors.IsNotFound(err) && strings.Contains(err.Error(), "InvalidAttachment.NotFound:") {
+		// attachment; real EC2 answers InvalidAttachment.NotFound. Matched on
+		// the driver's clean message text — "is not attached to instance"
+		// appears only in this case (distinct from the plain "is not
+		// attached" DetachVolume uses when the volume isn't attached at all).
+		if cerrors.IsNotFound(err) && strings.Contains(err.Error(), "is not attached to instance") {
 			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidAttachment.NotFound", cerrors.Message(err))
 			return
 		}

--- a/server/aws/ec2/volume_test.go
+++ b/server/aws/ec2/volume_test.go
@@ -316,6 +316,8 @@ func TestAttachVolumeCrossAZRejected(t *testing.T) {
 	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidVolume.ZoneMismatch" {
 		t.Fatalf("cross-AZ AttachVolume error = %v, want InvalidVolume.ZoneMismatch", err)
 	}
+
+	assertNoLeakedPrefix(t, apiErr.ErrorMessage())
 }
 
 // TestDeleteAttachedVolumeReturnsVolumeInUse pins that deleting an attached
@@ -359,6 +361,8 @@ func TestDeleteAttachedVolumeReturnsVolumeInUse(t *testing.T) {
 	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "VolumeInUse" {
 		t.Fatalf("DeleteVolume(attached) error = %v, want VolumeInUse", err)
 	}
+
+	assertNoLeakedPrefix(t, apiErr.ErrorMessage())
 }
 
 // TestAttachAlreadyAttachedVolumeReturnsVolumeInUse pins that attaching a volume
@@ -407,4 +411,107 @@ func TestAttachAlreadyAttachedVolumeReturnsVolumeInUse(t *testing.T) {
 	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "VolumeInUse" {
 		t.Fatalf("AttachVolume(already attached) error = %v, want VolumeInUse", err)
 	}
+
+	assertNoLeakedPrefix(t, apiErr.ErrorMessage())
+}
+
+// TestAttachVolumeToTerminatedInstanceRejected pins that attaching a volume to
+// a terminated instance is rejected with IncorrectInstanceState (a volume can
+// only attach to a running or stopped instance), with a clean message — no
+// "IncorrectInstanceState:" prefix leaked from the internal error type.
+func TestAttachVolumeToTerminatedInstanceRejected(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:  aws.String("ami-123"),
+		MinCount: aws.Int32(1),
+		MaxCount: aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	instID := aws.ToString(run.Instances[0].InstanceId)
+
+	if _, err := client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+		InstanceIds: []string{instID},
+	}); err != nil {
+		t.Fatalf("TerminateInstances: %v", err)
+	}
+
+	vol, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(10),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+
+	_, err = client.AttachVolume(ctx, &ec2.AttachVolumeInput{
+		VolumeId:   vol.VolumeId,
+		InstanceId: aws.String(instID),
+		Device:     aws.String("/dev/sdf"),
+	})
+	if err == nil {
+		t.Fatal("AttachVolume(terminated instance) succeeded, want error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "IncorrectInstanceState" {
+		t.Fatalf("AttachVolume(terminated instance) error = %v, want IncorrectInstanceState", err)
+	}
+
+	assertNoLeakedPrefix(t, apiErr.ErrorMessage())
+}
+
+// TestDetachVolumeWrongInstanceRejected pins that detaching a volume while
+// naming an instance it isn't actually attached to is rejected with
+// InvalidAttachment.NotFound, with a clean message — no
+// "InvalidAttachment.NotFound:" prefix leaked from the internal error type.
+func TestDetachVolumeWrongInstanceRejected(t *testing.T) {
+	ctx := context.Background()
+	client := newEC2(t)
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:  aws.String("ami-123"),
+		MinCount: aws.Int32(1),
+		MaxCount: aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	instID := aws.ToString(run.Instances[0].InstanceId)
+
+	vol, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(10),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+
+	if _, err := client.AttachVolume(ctx, &ec2.AttachVolumeInput{
+		VolumeId:   vol.VolumeId,
+		InstanceId: aws.String(instID),
+		Device:     aws.String("/dev/sdf"),
+	}); err != nil {
+		t.Fatalf("AttachVolume: %v", err)
+	}
+
+	_, err = client.DetachVolume(ctx, &ec2.DetachVolumeInput{
+		VolumeId:   vol.VolumeId,
+		InstanceId: aws.String("i-doesnotexist"),
+	})
+	if err == nil {
+		t.Fatal("DetachVolume(wrong instance) succeeded, want error")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidAttachment.NotFound" {
+		t.Fatalf("DetachVolume(wrong instance) error = %v, want InvalidAttachment.NotFound", err)
+	}
+
+	assertNoLeakedPrefix(t, apiErr.ErrorMessage())
 }

--- a/server/aws/ec2/xml.go
+++ b/server/aws/ec2/xml.go
@@ -108,6 +108,7 @@ type instanceENIXML struct {
 	MacAddress         string                   `xml:"macAddress,omitempty"`
 	PrivateIP          string                   `xml:"privateIpAddress,omitempty"`
 	Status             string                   `xml:"status,omitempty"`
+	SourceDestCheck    bool                     `xml:"sourceDestCheck"`
 	Groups             []groupItem              `xml:"groupSet>item,omitempty"`
 	Attachment         instanceENIAttachmentXML `xml:"attachment"`
 }

--- a/server/aws/ec2/xml.go
+++ b/server/aws/ec2/xml.go
@@ -144,18 +144,23 @@ type operatorXML struct {
 // DescribeInstances responses. We populate only the fields the SDK reliably
 // consumes and real apps actually read; unused AWS fields are omitted.
 type instanceXML struct {
-	InstanceID          string                   `xml:"instanceId"`
-	ImageID             string                   `xml:"imageId"`
-	State               instanceState            `xml:"instanceState"`
-	InstanceType        string                   `xml:"instanceType"`
-	LaunchTime          string                   `xml:"launchTime,omitempty"`
-	SubnetID            string                   `xml:"subnetId,omitempty"`
-	VPCID               string                   `xml:"vpcId,omitempty"`
-	PrivateIP           string                   `xml:"privateIpAddress,omitempty"`
-	PublicIP            string                   `xml:"ipAddress,omitempty"`
-	PrivateDNSName      string                   `xml:"privateDnsName,omitempty"`
-	PublicDNSName       string                   `xml:"dnsName,omitempty"`
-	KeyName             string                   `xml:"keyName,omitempty"`
+	InstanceID     string        `xml:"instanceId"`
+	ImageID        string        `xml:"imageId"`
+	State          instanceState `xml:"instanceState"`
+	InstanceType   string        `xml:"instanceType"`
+	LaunchTime     string        `xml:"launchTime,omitempty"`
+	SubnetID       string        `xml:"subnetId,omitempty"`
+	VPCID          string        `xml:"vpcId,omitempty"`
+	PrivateIP      string        `xml:"privateIpAddress,omitempty"`
+	PublicIP       string        `xml:"ipAddress,omitempty"`
+	PrivateDNSName string        `xml:"privateDnsName,omitempty"`
+	PublicDNSName  string        `xml:"dnsName,omitempty"`
+	KeyName        string        `xml:"keyName,omitempty"`
+	// SourceDestCheck mirrors the primary network interface's flag at the
+	// top level too — real EC2 reports it both places, and
+	// aws-sdk-go-v2/terraform-provider-aws read the top-level field, not
+	// the nested networkInterfaceSet entry.
+	SourceDestCheck     bool                     `xml:"sourceDestCheck"`
 	AmiLaunchIndex      int                      `xml:"amiLaunchIndex"`
 	Architecture        string                   `xml:"architecture,omitempty"`
 	RootDeviceType      string                   `xml:"rootDeviceType,omitempty"`


### PR DESCRIPTION
## Summary
Found via a black-box audit driving cloudemu (real `serve` process) through the aws CLI and Terraform (hashicorp/aws ~> 5.0), then comparing against documented real AWS EC2/VPC behavior.

- Wire error messages leaked the internal cloudemu error-taxonomy code as a prefix (e.g. `AlreadyExists: key pair "x" already exists` instead of the clean human message real EC2 returns). Fixed ~20 call sites across the ec2 handlers to use `cerrors.Message(err)` instead of `err.Error()`.
- `DescribeVolumes` rejected the `attachment.*` filters (`attachment.device`, `attachment.instance-id`, `attachment.status`, `attachment.delete-on-termination`), breaking Terraform's `aws_volume_attachment` resource outright.
- `DescribeNetworkInterfaces` rejected `attachment.instance-id`, `attachment.device-index`, `attachment.attachment-id`, `attachment.status`, and `source-dest-check`, breaking `aws_instance`'s primary-ENI lookup.
- `DescribeAddressesAttribute` was entirely unimplemented ("unknown action"), breaking Terraform's `aws_eip` resource outright.
- `NetworkInterfaces[].SourceDestCheck` was always missing from `DescribeInstances`/`RunInstances` responses even though the underlying ENI record carries it.

## Test plan
- [x] `go build ./...`
- [x] `go test ./providers/aws/ec2/... ./providers/aws/vpc/... ./server/aws/ec2/... -race`
- [x] `go test ./...` (full suite, no regressions)
- [x] `gofmt -l` clean on changed files
- [x] `golangci-lint run` — 0 new issues (pre-existing baseline issues unchanged/reduced)
- [x] Reproduced each bug live against `cloudemu serve` with aws-cli and Terraform, and confirmed the fix with a full `terraform init/apply/destroy` cycle (VPC + subnet + IGW + route table + security group + key pair + instance + EBS volume + attachment + EIP)
- [x] Added regression tests: `TestDeleteVolumeAttachedNoLeakedPrefix`, `TestCreateKeyPairDuplicateNoLeakedPrefix`, `TestDescribeNetworkInterfacesAttachmentFilters`