### PR TITLE
fix(dynamodb): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/dynamodb/conditional.go
+++ b/providers/aws/dynamodb/conditional.go
@@ -164,7 +164,7 @@ func (m *Mock) DeleteItemConditional(
 		return nil, cerrors.Newf(cerrors.NotFound, "table %s not found", table)
 	}
 
-	if err := validateKeyMapNotEmpty(td.config.PartitionKey, td.config.SortKey, key); err != nil {
+	if err := validateKeySchema(td.config, key); err != nil {
 		m.mu.Unlock()
 		return nil, err
 	}
@@ -209,7 +209,7 @@ func (m *Mock) UpdateItemConditional(
 		return nil, nil, cerrors.Newf(cerrors.NotFound, "table %s not found", input.Table)
 	}
 
-	if verr := validateKeyMapNotEmpty(td.config.PartitionKey, td.config.SortKey, input.Key); verr != nil {
+	if verr := validateKeySchema(td.config, input.Key); verr != nil {
 		m.mu.Unlock()
 		return nil, nil, verr
 	}
@@ -397,7 +397,7 @@ func validateTransactOp(td *tableData, op *driver.TransactOp) error {
 		return validateItemSize(op.Item)
 	}
 
-	return validateKeyMapNotEmpty(td.config.PartitionKey, td.config.SortKey, op.Key)
+	return validateKeySchema(td.config, op.Key)
 }
 
 // opKeySource returns the attributes that identify an operation's target item:

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -47,6 +47,15 @@ const (
 	defaultStreamLimit = 100
 )
 
+// streamShardID is the emulator's single, always-open DynamoDB Streams shard.
+// AWS's real ShardId shape enforces a minimum length of 28 characters
+// ("shardId-<20-digit-epoch-ms>-<8-hex-char-suffix>"); a shorter placeholder
+// (e.g. "shard-000") is rejected client-side by the AWS SDK/CLI's own request
+// validation before the request is ever sent, so GetShardIterator can never be
+// called against it. The value mirrors real DynamoDB's format and length; it
+// must match server/aws/dynamodb's streamShardID constant.
+const streamShardID = "shardId-00000001700000000000-00000001"
+
 // Secondary-index projection types.
 const (
 	projectionAll      = "ALL"
@@ -200,6 +209,58 @@ func validateItemKeys(cfg driver.TableConfig, item map[string]any) error {
 		}
 	}
 
+	return validateIndexKeyTypes(cfg, item)
+}
+
+// validateIndexKeyTypes checks every GSI/LSI key attribute present in item
+// against its declared AttributeDefinition type. Unlike the table's own
+// primary key, an index key attribute is optional on an item — an item that
+// omits it simply doesn't appear in that index — but AWS still rejects a type
+// mismatch on one that IS present with a ValidationException naming the index.
+func validateIndexKeyTypes(cfg driver.TableConfig, item map[string]any) error {
+	for _, gsi := range cfg.GSIs {
+		for _, keyName := range []string{gsi.PartitionKey, gsi.SortKey} {
+			if err := validateIndexKeyType(cfg, gsi.Name, keyName, item); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, lsi := range cfg.LSIs {
+		if err := validateIndexKeyType(cfg, lsi.Name, lsi.SortKey, item); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateIndexKeyType checks one index key attribute's value, when the item
+// carries it, against its AttributeDefinition type.
+func validateIndexKeyType(cfg driver.TableConfig, indexName, keyName string, item map[string]any) error {
+	if keyName == "" {
+		return nil
+	}
+
+	val, present := item[keyName]
+	if !present {
+		return nil
+	}
+
+	for _, def := range cfg.Attributes {
+		if def.Name != keyName {
+			continue
+		}
+
+		if actual := expr.TypeCode(val); actual != def.Type {
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"One or more parameter values were invalid: Type mismatch for Index Key %s Expected: %s Actual: %s IndexName: %s",
+				keyName, def.Type, actual, indexName)
+		}
+
+		return nil
+	}
+
 	return nil
 }
 
@@ -320,23 +381,51 @@ func collectionSize(val any) int {
 	}
 }
 
-// validateKeyMapNotEmpty rejects an empty-string/binary value on any key
-// attribute supplied in a Key map (UpdateItem, DeleteItem), matching the same
-// AWS rule PutItem enforces on the full item.
-func validateKeyMapNotEmpty(partitionKey, sortKey string, key map[string]any) error {
-	for _, keyName := range []string{partitionKey, sortKey} {
-		if keyName == "" {
-			continue
+// validateKeySchema enforces that a standalone Key parameter — GetItem,
+// DeleteItem, UpdateItem, BatchGetItem, TransactGetItems/TransactWriteItems —
+// names exactly the table's key schema attributes (the partition key, and the
+// sort key when the table has one): no fewer, no more, each with a non-empty
+// value of the declared type. Real DynamoDB collapses a missing or an
+// unrecognized key attribute into one ValidationException; the wire layer
+// otherwise silently looks up the wrong (or no) item instead of rejecting the
+// call the way real DynamoDB does.
+func validateKeySchema(cfg driver.TableConfig, key map[string]any) error {
+	want := map[string]struct{}{}
+	if cfg.PartitionKey != "" {
+		want[cfg.PartitionKey] = struct{}{}
+	}
+
+	if cfg.SortKey != "" {
+		want[cfg.SortKey] = struct{}{}
+	}
+
+	if len(key) != len(want) {
+		return newKeySchemaMismatch()
+	}
+
+	for name, val := range key {
+		if _, ok := want[name]; !ok {
+			return newKeySchemaMismatch()
 		}
 
-		if val, present := key[keyName]; present {
-			if err := validateKeyNotEmpty(keyName, val); err != nil {
-				return err
-			}
+		if err := validateKeyNotEmpty(name, val); err != nil {
+			return err
+		}
+
+		if err := validateKeyType(cfg, name, val); err != nil {
+			return err
 		}
 	}
 
 	return nil
+}
+
+// newKeySchemaMismatch is the ValidationException AWS returns for a Key
+// parameter that omits a schema key attribute or names one the schema doesn't
+// have, verbatim across every DynamoDB operation that takes a standalone Key.
+func newKeySchemaMismatch() error {
+	return cerrors.New(cerrors.InvalidArgument,
+		"One or more parameter values were invalid: The provided key element does not match the schema")
 }
 
 // validateKeyType checks a present key attribute's type against the matching
@@ -511,6 +600,10 @@ func (m *Mock) GetItem(_ context.Context, table string, key map[string]any) (map
 
 	if !exists {
 		return nil, cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	if err := validateKeySchema(td.config, key); err != nil {
+		return nil, err
 	}
 
 	k := itemKey(td.config, key)
@@ -1034,6 +1127,12 @@ func (m *Mock) BatchGetItems(_ context.Context, table string, keys []map[string]
 		return nil, cerrors.Newf(cerrors.NotFound, "table %s not found", table)
 	}
 
+	for _, key := range keys {
+		if err := validateKeySchema(td.config, key); err != nil {
+			return nil, err
+		}
+	}
+
 	var results []map[string]any
 
 	for _, key := range keys {
@@ -1296,7 +1395,7 @@ func filterStreamRecords(records []driver.StreamRecord, limit int, token string)
 	}
 
 	return &driver.StreamIterator{
-		ShardID:   "shard-000",
+		ShardID:   streamShardID,
 		Records:   result,
 		NextToken: nextToken,
 	}
@@ -1328,7 +1427,7 @@ func (m *Mock) TransactWriteItems(
 	}
 
 	for _, key := range deletes {
-		if err := validateKeyMapNotEmpty(td.config.PartitionKey, td.config.SortKey, key); err != nil {
+		if err := validateKeySchema(td.config, key); err != nil {
 			return err
 		}
 	}

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -47,14 +47,15 @@ const (
 	defaultStreamLimit = 100
 )
 
-// streamShardID is the emulator's single, always-open DynamoDB Streams shard.
+// StreamShardID is the emulator's single, always-open DynamoDB Streams shard.
 // AWS's real ShardId shape enforces a minimum length of 28 characters
 // ("shardId-<20-digit-epoch-ms>-<8-hex-char-suffix>"); a shorter placeholder
 // (e.g. "shard-000") is rejected client-side by the AWS SDK/CLI's own request
 // validation before the request is ever sent, so GetShardIterator can never be
-// called against it. The value mirrors real DynamoDB's format and length; it
-// must match server/aws/dynamodb's streamShardID constant.
-const streamShardID = "shardId-00000001700000000000-00000001"
+// called against it. The value mirrors real DynamoDB's format and length.
+// Exported so server/aws/dynamodb can reference the same value instead of
+// keeping its own copy in sync by convention.
+const StreamShardID = "shardId-00000001700000000000-00000001"
 
 // Secondary-index projection types.
 const (
@@ -1395,7 +1396,7 @@ func filterStreamRecords(records []driver.StreamRecord, limit int, token string)
 	}
 
 	return &driver.StreamIterator{
-		ShardID:   streamShardID,
+		ShardID:   StreamShardID,
 		Records:   result,
 		NextToken: nextToken,
 	}

--- a/providers/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/providers/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -691,8 +691,8 @@ func TestStreams(t *testing.T) {
 		it, err := m.GetStreamRecords(ctx, "events", 100, "")
 		e2eRequireNoErr(t, err)
 
-		if it.ShardID != "shard-000" {
-			t.Fatalf("ShardID = %q, want shard-000", it.ShardID)
+		if it.ShardID != streamShardID {
+			t.Fatalf("ShardID = %q, want %q", it.ShardID, streamShardID)
 		}
 
 		if len(it.Records) != 4 {

--- a/providers/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/providers/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -691,8 +691,8 @@ func TestStreams(t *testing.T) {
 		it, err := m.GetStreamRecords(ctx, "events", 100, "")
 		e2eRequireNoErr(t, err)
 
-		if it.ShardID != streamShardID {
-			t.Fatalf("ShardID = %q, want %q", it.ShardID, streamShardID)
+		if it.ShardID != StreamShardID {
+			t.Fatalf("ShardID = %q, want %q", it.ShardID, StreamShardID)
 		}
 
 		if len(it.Records) != 4 {

--- a/server/aws/dynamodb/dynamodb_key_schema_test.go
+++ b/server/aws/dynamodb/dynamodb_key_schema_test.go
@@ -1,0 +1,201 @@
+// dynamodb_key_schema_test.go — real aws-sdk-go-v2 round-trips proving that
+// GetItem/DeleteItem/UpdateItem/BatchGetItem/TransactGetItems reject a Key
+// parameter that doesn't name exactly the table's key schema (missing the
+// sort key, or an extra unrecognized attribute), on both a hash-only and a
+// composite (hash+range) table — and that the exact correct key still
+// succeeds, and that Query/Scan (which take no standalone Key map) are
+// unaffected by this validation.
+package dynamodb_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// keySchemaOp is one of the five operations that take a standalone Key
+// parameter (as opposed to Query/Scan, which resolve keys from a
+// KeyConditionExpression or not at all).
+type keySchemaOp struct {
+	name string
+	run  func(ctx context.Context, client *dynamodb.Client, table string, key map[string]ddbtypes.AttributeValue) error
+}
+
+// allKeySchemaOps returns the five operations under test, freshly built per
+// call so none of them is a mutable package-level global.
+func allKeySchemaOps() []keySchemaOp {
+	return []keySchemaOp{
+		{
+			name: "GetItem",
+			run: func(ctx context.Context, client *dynamodb.Client, table string, key map[string]ddbtypes.AttributeValue) error {
+				_, err := client.GetItem(ctx, &dynamodb.GetItemInput{TableName: aws.String(table), Key: key})
+				return err
+			},
+		},
+		{
+			name: "DeleteItem",
+			run: func(ctx context.Context, client *dynamodb.Client, table string, key map[string]ddbtypes.AttributeValue) error {
+				_, err := client.DeleteItem(ctx, &dynamodb.DeleteItemInput{TableName: aws.String(table), Key: key})
+				return err
+			},
+		},
+		{
+			name: "UpdateItem",
+			run: func(ctx context.Context, client *dynamodb.Client, table string, key map[string]ddbtypes.AttributeValue) error {
+				_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName:                 aws.String(table),
+					Key:                       key,
+					UpdateExpression:          aws.String("SET extra = :v"),
+					ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":v": sAttr("x")},
+				})
+				return err
+			},
+		},
+		{
+			name: "BatchGetItem",
+			run: func(ctx context.Context, client *dynamodb.Client, table string, key map[string]ddbtypes.AttributeValue) error {
+				_, err := client.BatchGetItem(ctx, &dynamodb.BatchGetItemInput{
+					RequestItems: map[string]ddbtypes.KeysAndAttributes{
+						table: {Keys: []map[string]ddbtypes.AttributeValue{key}},
+					},
+				})
+				return err
+			},
+		},
+		{
+			name: "TransactGetItems",
+			run: func(ctx context.Context, client *dynamodb.Client, table string, key map[string]ddbtypes.AttributeValue) error {
+				_, err := client.TransactGetItems(ctx, &dynamodb.TransactGetItemsInput{
+					TransactItems: []ddbtypes.TransactGetItem{{Get: &ddbtypes.Get{TableName: aws.String(table), Key: key}}},
+				})
+				return err
+			},
+		},
+	}
+}
+
+// TestDDBKeySchemaValidation drives every keySchemaOp against a hash-only and
+// a composite table with an exact-correct key (must succeed), a key missing
+// the sort key (composite only; must be rejected), and a key carrying an
+// extra unrecognized attribute (both table kinds; must be rejected).
+func TestDDBKeySchemaValidation(t *testing.T) {
+	type tableKind struct {
+		name   string
+		pk, sk string
+	}
+
+	tableKinds := []tableKind{
+		{name: "hash-only", pk: "pk", sk: ""},
+		{name: "composite", pk: "pk", sk: "sk"},
+	}
+
+	type variant struct {
+		name          string
+		compositeOnly bool
+		key           func(pk, sk string) map[string]ddbtypes.AttributeValue
+		wantErr       bool
+	}
+
+	variants := []variant{
+		{
+			name: "exact key succeeds",
+			key: func(pk, sk string) map[string]ddbtypes.AttributeValue {
+				k := map[string]ddbtypes.AttributeValue{pk: sAttr("k1")}
+				if sk != "" {
+					k[sk] = sAttr("s1")
+				}
+
+				return k
+			},
+			wantErr: false,
+		},
+		{
+			name:          "missing range key rejected",
+			compositeOnly: true,
+			key: func(pk, _ string) map[string]ddbtypes.AttributeValue {
+				return map[string]ddbtypes.AttributeValue{pk: sAttr("k1")}
+			},
+			wantErr: true,
+		},
+		{
+			name: "extra attribute rejected",
+			key: func(pk, sk string) map[string]ddbtypes.AttributeValue {
+				k := map[string]ddbtypes.AttributeValue{pk: sAttr("k1"), "bogus": sAttr("x")}
+				if sk != "" {
+					k[sk] = sAttr("s1")
+				}
+
+				return k
+			},
+			wantErr: true,
+		},
+	}
+
+	idx := 0
+
+	for _, tk := range tableKinds {
+		for _, v := range variants {
+			if v.compositeOnly && tk.sk == "" {
+				continue
+			}
+
+			for _, op := range allKeySchemaOps() {
+				idx++
+
+				t.Run(tk.name+"/"+v.name+"/"+op.name, func(t *testing.T) {
+					client, _ := newSuiteDDBEnv(t)
+					ctx := context.Background()
+					table := fmt.Sprintf("kst%d", idx)
+
+					suiteDDBCreateTable(t, client, table, tk.pk, tk.sk)
+
+					item := map[string]ddbtypes.AttributeValue{tk.pk: sAttr("k1")}
+					if tk.sk != "" {
+						item[tk.sk] = sAttr("s1")
+					}
+
+					suiteDDBPut(t, client, table, item)
+
+					err := op.run(ctx, client, table, v.key(tk.pk, tk.sk))
+
+					if v.wantErr {
+						require.Error(t, err)
+						assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+						assert.Contains(t, err.Error(), "does not match the schema")
+					} else {
+						assert.NoError(t, err)
+					}
+				})
+			}
+		}
+	}
+}
+
+// TestDDBKeySchemaValidationDoesNotAffectQueryOrScan guards against the
+// GetItem/DeleteItem/UpdateItem/BatchGetItem/TransactGetItems key-schema
+// validation leaking into Query/Scan, which resolve keys from a
+// KeyConditionExpression (or take no key at all) rather than a standalone Key
+// map, and so must never be key-schema validated the same way.
+func TestDDBKeySchemaValidationDoesNotAffectQueryOrScan(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "kst_qs", "pk", "sk")
+	suiteDDBPut(t, client, "kst_qs", map[string]ddbtypes.AttributeValue{"pk": sAttr("a"), "sk": sAttr("b")})
+
+	_, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:                 aws.String("kst_qs"),
+		KeyConditionExpression:    aws.String("pk = :p"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":p": sAttr("a")},
+	})
+	require.NoError(t, err)
+
+	_, err = client.Scan(ctx, &dynamodb.ScanInput{TableName: aws.String("kst_qs")})
+	require.NoError(t, err)
+}

--- a/server/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/server/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -1076,7 +1076,7 @@ func TestDDBStreams(t *testing.T) {
 
 	it, err := provider.DynamoDB.GetStreamRecords(ctx, "events", 100, "")
 	require.NoError(t, err)
-	assert.Equal(t, "shard-000", it.ShardID)
+	assert.Equal(t, "shardId-00000001700000000000-00000001", it.ShardID)
 	require.Len(t, it.Records, 4)
 
 	types := make([]string, 0, len(it.Records))

--- a/server/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/server/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -31,6 +31,7 @@ import (
 	emuconfig "github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	awsprovider "github.com/stackshy/cloudemu/v2/providers/aws"
+	ddbprovider "github.com/stackshy/cloudemu/v2/providers/aws/dynamodb"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 	"github.com/stretchr/testify/assert"
@@ -1076,7 +1077,7 @@ func TestDDBStreams(t *testing.T) {
 
 	it, err := provider.DynamoDB.GetStreamRecords(ctx, "events", 100, "")
 	require.NoError(t, err)
-	assert.Equal(t, "shardId-00000001700000000000-00000001", it.ShardID)
+	assert.Equal(t, ddbprovider.StreamShardID, it.ShardID)
 	require.Len(t, it.Records, 4)
 
 	types := make([]string, 0, len(it.Records))

--- a/server/aws/dynamodb/dynamodb_validation_test.go
+++ b/server/aws/dynamodb/dynamodb_validation_test.go
@@ -291,3 +291,246 @@ func TestDDBUpdateTableAddGSIWithoutAttrDef(t *testing.T) {
 
 	assert.Equal(t, "ValidationException", apiErrorCode(t, err))
 }
+
+// TestDDBCreateTableBillingThroughput: CreateTable's cross-field rule between
+// BillingMode and ProvisionedThroughput — PROVISIONED requires a valid (>=1)
+// RCU/WCU, PAY_PER_REQUEST forbids either being set, and PAY_PER_REQUEST with
+// no throughput at all (the ordinary on-demand case) must NOT be rejected.
+func TestDDBCreateTableBillingThroughput(t *testing.T) {
+	cases := []struct {
+		name        string
+		billingMode ddbtypes.BillingMode
+		throughput  *ddbtypes.ProvisionedThroughput
+		wantErr     bool
+	}{
+		{
+			name:        "provisioned with valid throughput succeeds",
+			billingMode: ddbtypes.BillingModeProvisioned,
+			throughput:  &ddbtypes.ProvisionedThroughput{ReadCapacityUnits: aws.Int64(5), WriteCapacityUnits: aws.Int64(5)},
+			wantErr:     false,
+		},
+		{
+			name:        "provisioned with zero throughput rejected",
+			billingMode: ddbtypes.BillingModeProvisioned,
+			throughput:  &ddbtypes.ProvisionedThroughput{ReadCapacityUnits: aws.Int64(0), WriteCapacityUnits: aws.Int64(0)},
+			wantErr:     true,
+		},
+		{
+			name:        "provisioned with no throughput rejected",
+			billingMode: ddbtypes.BillingModeProvisioned,
+			throughput:  nil,
+			wantErr:     true,
+		},
+		{
+			name:        "pay-per-request with no throughput succeeds",
+			billingMode: ddbtypes.BillingModePayPerRequest,
+			throughput:  nil,
+			wantErr:     false,
+		},
+		{
+			name:        "pay-per-request with explicit throughput rejected",
+			billingMode: ddbtypes.BillingModePayPerRequest,
+			throughput:  &ddbtypes.ProvisionedThroughput{ReadCapacityUnits: aws.Int64(5), WriteCapacityUnits: aws.Int64(5)},
+			wantErr:     true,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, _ := newSuiteDDBEnv(t)
+			ctx := context.Background()
+			table := fmt.Sprintf("billing_ct_%d", i)
+
+			_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+				TableName:   aws.String(table),
+				BillingMode: tc.billingMode,
+				KeySchema:   []ddbtypes.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash}},
+				AttributeDefinitions: []ddbtypes.AttributeDefinition{
+					{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+				},
+				ProvisionedThroughput: tc.throughput,
+			})
+
+			if tc.wantErr {
+				assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestDDBUpdateTableBillingThroughput: UpdateTable's cross-field rule between
+// BillingMode and ProvisionedThroughput, on both directions of a billing-mode
+// switch. Each case first creates the table in its starting billing mode, then
+// applies the UpdateTable under test.
+func TestDDBUpdateTableBillingThroughput(t *testing.T) {
+	type step struct {
+		billingMode ddbtypes.BillingMode
+		throughput  *ddbtypes.ProvisionedThroughput
+	}
+
+	cases := []struct {
+		name    string
+		initial step
+		update  step
+		wantErr bool
+	}{
+		{
+			name:    "pay-per-request to provisioned with valid throughput succeeds",
+			initial: step{billingMode: ddbtypes.BillingModePayPerRequest},
+			update: step{
+				billingMode: ddbtypes.BillingModeProvisioned,
+				throughput:  &ddbtypes.ProvisionedThroughput{ReadCapacityUnits: aws.Int64(5), WriteCapacityUnits: aws.Int64(5)},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "pay-per-request to provisioned with missing throughput rejected",
+			initial: step{billingMode: ddbtypes.BillingModePayPerRequest},
+			update:  step{billingMode: ddbtypes.BillingModeProvisioned},
+			wantErr: true,
+		},
+		{
+			name: "provisioned to pay-per-request succeeds",
+			initial: step{
+				billingMode: ddbtypes.BillingModeProvisioned,
+				throughput:  &ddbtypes.ProvisionedThroughput{ReadCapacityUnits: aws.Int64(5), WriteCapacityUnits: aws.Int64(5)},
+			},
+			update:  step{billingMode: ddbtypes.BillingModePayPerRequest},
+			wantErr: false,
+		},
+		{
+			name: "provisioned to pay-per-request with explicit throughput rejected",
+			initial: step{
+				billingMode: ddbtypes.BillingModeProvisioned,
+				throughput:  &ddbtypes.ProvisionedThroughput{ReadCapacityUnits: aws.Int64(5), WriteCapacityUnits: aws.Int64(5)},
+			},
+			update: step{
+				billingMode: ddbtypes.BillingModePayPerRequest,
+				throughput:  &ddbtypes.ProvisionedThroughput{ReadCapacityUnits: aws.Int64(5), WriteCapacityUnits: aws.Int64(5)},
+			},
+			wantErr: true,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, _ := newSuiteDDBEnv(t)
+			ctx := context.Background()
+			table := fmt.Sprintf("billing_ut_%d", i)
+
+			_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+				TableName:   aws.String(table),
+				BillingMode: tc.initial.billingMode,
+				KeySchema:   []ddbtypes.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash}},
+				AttributeDefinitions: []ddbtypes.AttributeDefinition{
+					{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+				},
+				ProvisionedThroughput: tc.initial.throughput,
+			})
+			require.NoError(t, err)
+
+			_, err = client.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+				TableName:             aws.String(table),
+				BillingMode:           tc.update.billingMode,
+				ProvisionedThroughput: tc.update.throughput,
+			})
+
+			if tc.wantErr {
+				assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestDDBUpdateTableAddGSIOnProvisionedTableSucceeds: adding a GSI via
+// UpdateTable without touching BillingMode/ProvisionedThroughput at all must
+// still succeed on an already-valid PROVISIONED table — the billing/throughput
+// validation must not fire for an unrelated field.
+func TestDDBUpdateTableAddGSIOnProvisionedTableSucceeds(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:   aws.String("gsi_add_prov"),
+		BillingMode: ddbtypes.BillingModeProvisioned,
+		KeySchema:   []ddbtypes.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash}},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		ProvisionedThroughput: &ddbtypes.ProvisionedThroughput{ReadCapacityUnits: aws.Int64(5), WriteCapacityUnits: aws.Int64(5)},
+	})
+	require.NoError(t, err)
+
+	_, err = client.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+		TableName: aws.String("gsi_add_prov"),
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("gk"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		GlobalSecondaryIndexUpdates: []ddbtypes.GlobalSecondaryIndexUpdate{{
+			Create: &ddbtypes.CreateGlobalSecondaryIndexAction{
+				IndexName:             aws.String("gsi1"),
+				KeySchema:             []ddbtypes.KeySchemaElement{{AttributeName: aws.String("gk"), KeyType: ddbtypes.KeyTypeHash}},
+				Projection:            &ddbtypes.Projection{ProjectionType: ddbtypes.ProjectionTypeAll},
+				ProvisionedThroughput: &ddbtypes.ProvisionedThroughput{ReadCapacityUnits: aws.Int64(5), WriteCapacityUnits: aws.Int64(5)},
+			},
+		}},
+	})
+
+	require.NoError(t, err)
+}
+
+// TestDDBPutItemGSIKeyTypeValidation: PutItem validates a GSI key attribute's
+// type when the item carries it, names the offending index, but does NOT
+// require the attribute to be present at all — a sparse GSI (an item that
+// omits the GSI key attribute) is a normal, valid write.
+func TestDDBPutItemGSIKeyTypeValidation(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:   aws.String("gsi_type"),
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+		KeySchema:   []ddbtypes.KeySchemaElement{{AttributeName: aws.String("pk"), KeyType: ddbtypes.KeyTypeHash}},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("gk"), AttributeType: ddbtypes.ScalarAttributeTypeN},
+		},
+		GlobalSecondaryIndexes: []ddbtypes.GlobalSecondaryIndex{{
+			IndexName:  aws.String("by-gk"),
+			KeySchema:  []ddbtypes.KeySchemaElement{{AttributeName: aws.String("gk"), KeyType: ddbtypes.KeyTypeHash}},
+			Projection: &ddbtypes.Projection{ProjectionType: ddbtypes.ProjectionTypeAll},
+		}},
+	})
+	require.NoError(t, err)
+
+	t.Run("correctly typed GSI key succeeds", func(t *testing.T) {
+		_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName: aws.String("gsi_type"),
+			Item:      map[string]ddbtypes.AttributeValue{"pk": sAttr("k1"), "gk": nAttr("42")},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("wrong typed GSI key rejected naming the index", func(t *testing.T) {
+		_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName: aws.String("gsi_type"),
+			Item:      map[string]ddbtypes.AttributeValue{"pk": sAttr("k2"), "gk": sAttr("not-a-number")},
+		})
+		require.Error(t, err)
+		assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+		assert.Contains(t, err.Error(), "Type mismatch for Index Key gk")
+		assert.Contains(t, err.Error(), "IndexName: by-gk")
+	})
+
+	t.Run("item omitting the GSI key attribute (sparse GSI) succeeds", func(t *testing.T) {
+		_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName: aws.String("gsi_type"),
+			Item:      map[string]ddbtypes.AttributeValue{"pk": sAttr("k3")},
+		})
+		require.NoError(t, err)
+	})
+}

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -25,14 +25,56 @@ const targetPrefix = "DynamoDB_20120810."
 const listTablesMaxPageSize = 100
 
 const (
-	keyTypeHash        = "HASH"
-	keyTypeRange       = "RANGE"
-	projectionAll      = "ALL"
-	projectionInclude  = "INCLUDE"
-	statusEnabled      = "ENABLED"
-	statusDisabled     = "DISABLED"
-	billingProvisioned = "PROVISIONED"
+	keyTypeHash          = "HASH"
+	keyTypeRange         = "RANGE"
+	projectionAll        = "ALL"
+	projectionInclude    = "INCLUDE"
+	statusEnabled        = "ENABLED"
+	statusDisabled       = "DISABLED"
+	billingProvisioned   = "PROVISIONED"
+	billingPayPerRequest = "PAY_PER_REQUEST"
 )
+
+// minProvisionedCapacity is the lowest ReadCapacityUnits/WriteCapacityUnits AWS
+// accepts on a PROVISIONED table or index.
+const minProvisionedCapacity = 1
+
+// validateProvisionedThroughput enforces AWS's cross-field rule between an
+// already-defaulted BillingMode and the ProvisionedThroughput that would result
+// from applying a request: PROVISIONED requires both RCU and WCU to be at
+// least 1, and PAY_PER_REQUEST forbids either being set. AWS rejects a
+// violation with a ValidationException carrying the wording matched here.
+func validateProvisionedThroughput(billingMode string, rcu, wcu int64) error {
+	if billingMode == billingPayPerRequest {
+		if rcu != 0 || wcu != 0 {
+			return cerrors.New(cerrors.InvalidArgument,
+				"One or more parameter values were invalid: "+
+					"Neither ReadCapacityUnits nor WriteCapacityUnits can be specified when BillingMode is PAY_PER_REQUEST")
+		}
+
+		return nil
+	}
+
+	if rcu == 0 && wcu == 0 {
+		return cerrors.New(cerrors.InvalidArgument,
+			"One or more parameter values were invalid: "+
+				"ProvisionedThroughput must be specified when BillingMode is not PAY_PER_REQUEST")
+	}
+
+	if rcu < minProvisionedCapacity {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"1 validation error detected: Value '%d' at 'provisionedThroughput.readCapacityUnits' "+
+				"failed to satisfy constraint: Member must have value greater than or equal to 1", rcu)
+	}
+
+	if wcu < minProvisionedCapacity {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"1 validation error detected: Value '%d' at 'provisionedThroughput.writeCapacityUnits' "+
+				"failed to satisfy constraint: Member must have value greater than or equal to 1", wcu)
+	}
+
+	return nil
+}
 
 // Query/Scan Select modes controlling which attributes (or only the counts) the
 // result carries.
@@ -291,6 +333,17 @@ func (h *Handler) createTable(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := validateCreateTableSchema(&req); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	effectiveBilling := req.BillingMode
+	if effectiveBilling == "" {
+		effectiveBilling = billingProvisioned
+	}
+
+	if err := validateProvisionedThroughput(effectiveBilling,
+		req.ProvisionedThroughput.ReadCapacityUnits, req.ProvisionedThroughput.WriteCapacityUnits); err != nil {
 		writeErr(w, err)
 		return
 	}

--- a/server/aws/dynamodb/streams.go
+++ b/server/aws/dynamodb/streams.go
@@ -18,8 +18,14 @@ import (
 // predicate is disjoint from the control-plane DynamoDB_20120810.* handler.
 const streamsTargetPrefix = "DynamoDBStreams_20120810."
 
+// streamShardID must match providers/aws/dynamodb's streamShardID constant.
+// AWS's real ShardId shape enforces a minimum length of 28 characters
+// ("shardId-<20-digit-epoch-ms>-<8-hex-char-suffix>"); a shorter placeholder
+// is rejected client-side by the AWS SDK/CLI's own request validation before
+// the request is ever sent, so GetShardIterator can never be called against
+// it.
 const (
-	streamShardID     = "shard-000"
+	streamShardID     = "shardId-00000001700000000000-00000001"
 	streamEventSource = "aws:dynamodb"
 	streamEventVer    = "1.1"
 	defaultAWSRegion  = "us-east-1"

--- a/server/aws/dynamodb/streams.go
+++ b/server/aws/dynamodb/streams.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	ddbprovider "github.com/stackshy/cloudemu/v2/providers/aws/dynamodb"
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 )
@@ -18,14 +19,11 @@ import (
 // predicate is disjoint from the control-plane DynamoDB_20120810.* handler.
 const streamsTargetPrefix = "DynamoDBStreams_20120810."
 
-// streamShardID must match providers/aws/dynamodb's streamShardID constant.
-// AWS's real ShardId shape enforces a minimum length of 28 characters
-// ("shardId-<20-digit-epoch-ms>-<8-hex-char-suffix>"); a shorter placeholder
-// is rejected client-side by the AWS SDK/CLI's own request validation before
-// the request is ever sent, so GetShardIterator can never be called against
-// it.
+// streamShardID reuses providers/aws/dynamodb's exported StreamShardID so the
+// wire layer's advertised ShardId and the provider's own driver.StreamIterator
+// ShardID can never silently desync into two different values.
 const (
-	streamShardID     = "shardId-00000001700000000000-00000001"
+	streamShardID     = ddbprovider.StreamShardID
 	streamEventSource = "aws:dynamodb"
 	streamEventVer    = "1.1"
 	defaultAWSRegion  = "us-east-1"

--- a/server/aws/dynamodb/streams_test.go
+++ b/server/aws/dynamodb/streams_test.go
@@ -21,6 +21,7 @@ import (
 	streamtypes "github.com/aws/aws-sdk-go-v2/service/dynamodbstreams/types"
 	"github.com/aws/smithy-go"
 	"github.com/stackshy/cloudemu/v2"
+	ddbprovider "github.com/stackshy/cloudemu/v2/providers/aws/dynamodb"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -460,6 +461,39 @@ func TestStreamsRouteDisjointFromControlPlane(t *testing.T) {
 	ls, err := streams.ListStreams(context.Background(), &dynamodbstreams.ListStreamsInput{})
 	require.NoError(t, err)
 	require.Len(t, ls.Streams, 1)
+}
+
+// TestStreamsShardIDMeetsRealAWSShapeMinLength guards against a regression
+// where the emulator's ShardId is too short for the AWS SDK/CLI's own
+// client-side request-shape validation — real DynamoDB Streams requires a
+// ShardId of at least 28 characters
+// ("shardId-<20-digit-epoch-ms>-<8-hex-char-suffix>"). A too-short ShardId
+// round-trips fine through this in-process test (which, unlike a real
+// SDK/CLI, never runs client-side shape validation), but would silently make
+// GetShardIterator/GetRecords uncallable by any real caller. It also asserts
+// the wire-layer DescribeStream ShardId is the same exported
+// providers/aws/dynamodb.StreamShardID the provider's own
+// driver.StreamIterator.ShardID carries, so the two can never independently
+// drift apart again.
+func TestStreamsShardIDMeetsRealAWSShapeMinLength(t *testing.T) {
+	t.Parallel()
+
+	const minAWSShardIDLength = 28
+
+	ddb, streams := newStreamsEnv(t)
+	arn := createStreamTable(t, ddb, "orders", ddbtypes.StreamViewTypeNewImage)
+
+	desc, err := streams.DescribeStream(context.Background(), &dynamodbstreams.DescribeStreamInput{
+		StreamArn: aws.String(arn),
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.StreamDescription.Shards, 1)
+
+	shardID := aws.ToString(desc.StreamDescription.Shards[0].ShardId)
+	assert.GreaterOrEqual(t, len(shardID), minAWSShardIDLength,
+		"ShardId %q is shorter than AWS's real minimum length; the AWS SDK/CLI's "+
+			"own client-side validation would reject GetShardIterator before it is ever sent", shardID)
+	assert.Equal(t, ddbprovider.StreamShardID, shardID)
 }
 
 // assertS asserts a stream AttributeValue is a string with the expected value.

--- a/server/aws/dynamodb/update_table.go
+++ b/server/aws/dynamodb/update_table.go
@@ -115,7 +115,51 @@ func (h *Handler) applyThroughput(ctx context.Context, table, billingMode string
 		rcu, wcu = pt.ReadCapacityUnits, pt.WriteCapacityUnits
 	}
 
+	if err := h.validateThroughputChange(ctx, table, billingMode, rcu, wcu); err != nil {
+		return err
+	}
+
 	return updater.UpdateThroughput(ctx, table, billingMode, rcu, wcu)
+}
+
+// validateThroughputChange resolves the billing mode and capacity an
+// UpdateTable request would leave a table in — merging any field the request
+// omits with the table's current stored value — and enforces AWS's
+// PROVISIONED/PAY_PER_REQUEST throughput rule against the result. A field the
+// request explicitly supplies always overrides; an omitted one falls back to
+// the stored value so re-affirming an unrelated field (e.g. adding a GSI)
+// never manufactures a spurious minimum-capacity error on an already-valid
+// table. Switching to PAY_PER_REQUEST is instead checked against the caller's
+// raw values, since a merged fallback would hide a genuine conflict
+// (throughput given alongside a switch to PAY_PER_REQUEST).
+func (h *Handler) validateThroughputChange(ctx context.Context, table, billingMode string, rcu, wcu int64) error {
+	current, err := h.db.DescribeTable(ctx, table)
+	if err != nil {
+		return err
+	}
+
+	effectiveMode := billingMode
+	if effectiveMode == "" {
+		effectiveMode = current.BillingMode
+		if effectiveMode == "" {
+			effectiveMode = billingProvisioned
+		}
+	}
+
+	if effectiveMode == billingPayPerRequest {
+		return validateProvisionedThroughput(effectiveMode, rcu, wcu)
+	}
+
+	effRCU, effWCU := rcu, wcu
+	if effRCU == 0 {
+		effRCU = current.ReadCapacityUnits
+	}
+
+	if effWCU == 0 {
+		effWCU = current.WriteCapacityUnits
+	}
+
+	return validateProvisionedThroughput(effectiveMode, effRCU, effWCU)
 }
 
 // attrDefJSON is one AttributeDefinitions entry on an UpdateTable request.


### PR DESCRIPTION
## Summary
Real-user black-box audit of DynamoDB (aws-cli, Terraform, aws-sdk-go-v2, raw HTTP) against a locally-built `cloudemu serve` binary found four genuine behavioral divergences from real AWS DynamoDB. All four are fixed here and re-verified black-box (rebuilt binary, re-ran the exact repro).

- `CreateTable`/`UpdateTable` accepted `PROVISIONED` billing mode with 0 capacity (and `PAY_PER_REQUEST` combined with explicit throughput), instead of rejecting with `ValidationException` like real AWS.
- `GetItem`/`DeleteItem`/`UpdateItem`/`BatchGetItem`/`TransactGetItems` silently accepted a `Key` that didn't match the table's key schema (missing or extra attributes) instead of rejecting it.
- `PutItem` only validated the base table's own key attribute types against `AttributeDefinitions`, missing GSI/LSI key attribute type mismatches.
- DynamoDB Streams `ShardId` was 9 characters (`"shard-000"`); AWS's real shape requires >=28, so the AWS SDK/CLI's own client-side request validation rejected `GetShardIterator`/`GetRecords` calls before they ever reached the server — breaking the entire Streams-consumption workflow for any real client.

A fifth finding (a GSI created without its own `ProvisionedThroughput` silently inherits the base table's capacity instead of being rejected) was filed but not fixed — it's a defaulting behavior rather than a data-loss/wrong-error-code bug, and is a broader change than the four fixes here.

## Test plan
- `go build ./...`
- `go test ./providers/aws/dynamodb/... ./server/aws/dynamodb/... -race` — all pass
- `go test ./...` (full suite) — all pass
- `gofmt -l` on touched files — clean
- `golangci-lint run --timeout=9m ./providers/aws/dynamodb/... ./server/aws/dynamodb/...` — 5 issues, identical count/kind to the pre-existing baseline (0 new)
- `contrib/terraform` `TestTerraformApplyIsIdempotent` (basic/networking/core-services fixtures, apply→plan→destroy) — pass, no perpetual diff
- Black-box re-verification: rebuilt the `cloudemu` binary, ran a fresh `serve` instance, and re-drove each of the four repros via aws-cli — each now returns the correct `ValidationException`/works correctly, with sanity checks confirming the corresponding valid-input paths still succeed unaffected.