### PR TITLE
fix(dynamodb): validate GSI ProvisionedThroughput per billing mode

### DIFF
--- a/server/aws/dynamodb/dynamodb_validation_test.go
+++ b/server/aws/dynamodb/dynamodb_validation_test.go
@@ -483,6 +483,190 @@ func TestDDBUpdateTableAddGSIOnProvisionedTableSucceeds(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestDDBCreateTableGSIThroughput: CreateTable's cross-field rule between the
+// table's BillingMode and each GSI's own ProvisionedThroughput — a PROVISIONED
+// table requires every GSI to declare a valid (>=1) RCU/WCU, and a
+// PAY_PER_REQUEST table forbids any GSI from declaring throughput at all. The
+// ordinary on-demand case (PAY_PER_REQUEST, GSI with no throughput) must NOT
+// be rejected.
+func TestDDBCreateTableGSIThroughput(t *testing.T) {
+	cases := []struct {
+		name        string
+		billingMode ddbtypes.BillingMode
+		throughput  *ddbtypes.ProvisionedThroughput
+		wantErr     bool
+	}{
+		{
+			name:        "provisioned table, gsi with valid throughput succeeds",
+			billingMode: ddbtypes.BillingModeProvisioned,
+			throughput:  &ddbtypes.ProvisionedThroughput{ReadCapacityUnits: aws.Int64(5), WriteCapacityUnits: aws.Int64(5)},
+			wantErr:     false,
+		},
+		{
+			name:        "provisioned table, gsi missing throughput rejected",
+			billingMode: ddbtypes.BillingModeProvisioned,
+			throughput:  nil,
+			wantErr:     true,
+		},
+		{
+			name:        "provisioned table, gsi with zero throughput rejected",
+			billingMode: ddbtypes.BillingModeProvisioned,
+			throughput:  &ddbtypes.ProvisionedThroughput{ReadCapacityUnits: aws.Int64(0), WriteCapacityUnits: aws.Int64(0)},
+			wantErr:     true,
+		},
+		{
+			name:        "pay-per-request table, gsi with no throughput succeeds",
+			billingMode: ddbtypes.BillingModePayPerRequest,
+			throughput:  nil,
+			wantErr:     false,
+		},
+		{
+			name:        "pay-per-request table, gsi with throughput rejected",
+			billingMode: ddbtypes.BillingModePayPerRequest,
+			throughput:  &ddbtypes.ProvisionedThroughput{ReadCapacityUnits: aws.Int64(5), WriteCapacityUnits: aws.Int64(5)},
+			wantErr:     true,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, _ := newSuiteDDBEnv(t)
+			ctx := context.Background()
+			table := fmt.Sprintf("gsi_throughput_ct_%d", i)
+
+			var tableThroughput *ddbtypes.ProvisionedThroughput
+			if tc.billingMode == ddbtypes.BillingModeProvisioned {
+				tableThroughput = &ddbtypes.ProvisionedThroughput{ReadCapacityUnits: aws.Int64(5), WriteCapacityUnits: aws.Int64(5)}
+			}
+
+			_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+				TableName:   aws.String(table),
+				BillingMode: tc.billingMode,
+				KeySchema:   []ddbtypes.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash}},
+				AttributeDefinitions: []ddbtypes.AttributeDefinition{
+					{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+					{AttributeName: aws.String("gk"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+				},
+				ProvisionedThroughput: tableThroughput,
+				GlobalSecondaryIndexes: []ddbtypes.GlobalSecondaryIndex{{
+					IndexName:             aws.String("gsi1"),
+					KeySchema:             []ddbtypes.KeySchemaElement{{AttributeName: aws.String("gk"), KeyType: ddbtypes.KeyTypeHash}},
+					Projection:            &ddbtypes.Projection{ProjectionType: ddbtypes.ProjectionTypeAll},
+					ProvisionedThroughput: tc.throughput,
+				}},
+			})
+
+			if tc.wantErr {
+				assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestDDBCreateTableLSINeverRequiresThroughput: an LSI shares the base
+// table's throughput and never declares its own — a CreateTable with a
+// PROVISIONED table and an LSI (no per-index throughput field exists on an
+// LSI) must succeed.
+func TestDDBCreateTableLSINeverRequiresThroughput(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String("lsi_no_throughput"),
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash},
+			{AttributeName: aws.String("sk"), KeyType: ddbtypes.KeyTypeRange},
+		},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("sk"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("lsk"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		BillingMode:           ddbtypes.BillingModeProvisioned,
+		ProvisionedThroughput: &ddbtypes.ProvisionedThroughput{ReadCapacityUnits: aws.Int64(5), WriteCapacityUnits: aws.Int64(5)},
+		LocalSecondaryIndexes: []ddbtypes.LocalSecondaryIndex{{
+			IndexName:  aws.String("lsi1"),
+			KeySchema:  []ddbtypes.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash}, {AttributeName: aws.String("lsk"), KeyType: ddbtypes.KeyTypeRange}},
+			Projection: &ddbtypes.Projection{ProjectionType: ddbtypes.ProjectionTypeAll},
+		}},
+	})
+
+	require.NoError(t, err)
+}
+
+// TestDDBUpdateTableAddGSIThroughput: UpdateTable's GSI-Create path enforces
+// the same per-GSI throughput rule as CreateTable — a newly-added GSI on a
+// PROVISIONED table must declare valid throughput, and on a PAY_PER_REQUEST
+// table must declare none.
+func TestDDBUpdateTableAddGSIThroughput(t *testing.T) {
+	cases := []struct {
+		name        string
+		billingMode ddbtypes.BillingMode
+		throughput  *ddbtypes.ProvisionedThroughput
+		wantErr     bool
+	}{
+		{
+			name:        "provisioned table, gsi missing throughput rejected",
+			billingMode: ddbtypes.BillingModeProvisioned,
+			throughput:  nil,
+			wantErr:     true,
+		},
+		{
+			name:        "pay-per-request table, gsi with throughput rejected",
+			billingMode: ddbtypes.BillingModePayPerRequest,
+			throughput:  &ddbtypes.ProvisionedThroughput{ReadCapacityUnits: aws.Int64(5), WriteCapacityUnits: aws.Int64(5)},
+			wantErr:     true,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, _ := newSuiteDDBEnv(t)
+			ctx := context.Background()
+			table := fmt.Sprintf("gsi_throughput_ut_%d", i)
+
+			var tableThroughput *ddbtypes.ProvisionedThroughput
+			if tc.billingMode == ddbtypes.BillingModeProvisioned {
+				tableThroughput = &ddbtypes.ProvisionedThroughput{ReadCapacityUnits: aws.Int64(5), WriteCapacityUnits: aws.Int64(5)}
+			}
+
+			_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+				TableName:   aws.String(table),
+				BillingMode: tc.billingMode,
+				KeySchema:   []ddbtypes.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash}},
+				AttributeDefinitions: []ddbtypes.AttributeDefinition{
+					{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+				},
+				ProvisionedThroughput: tableThroughput,
+			})
+			require.NoError(t, err)
+
+			_, err = client.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+				TableName: aws.String(table),
+				AttributeDefinitions: []ddbtypes.AttributeDefinition{
+					{AttributeName: aws.String("gk"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+				},
+				GlobalSecondaryIndexUpdates: []ddbtypes.GlobalSecondaryIndexUpdate{{
+					Create: &ddbtypes.CreateGlobalSecondaryIndexAction{
+						IndexName:             aws.String("gsi1"),
+						KeySchema:             []ddbtypes.KeySchemaElement{{AttributeName: aws.String("gk"), KeyType: ddbtypes.KeyTypeHash}},
+						Projection:            &ddbtypes.Projection{ProjectionType: ddbtypes.ProjectionTypeAll},
+						ProvisionedThroughput: tc.throughput,
+					},
+				}},
+			})
+
+			if tc.wantErr {
+				assert.Equal(t, "ValidationException", apiErrorCode(t, err))
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 // TestDDBPutItemGSIKeyTypeValidation: PutItem validates a GSI key attribute's
 // type when the item carries it, names the offending index, but does NOT
 // require the attribute to be present at all — a sparse GSI (an item that

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -348,6 +348,13 @@ func (h *Handler) createTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	for i := range req.GlobalSecondaryIndexes {
+		if err := validateGSIThroughput(effectiveBilling, &req.GlobalSecondaryIndexes[i]); err != nil {
+			writeErr(w, err)
+			return
+		}
+	}
+
 	if err := h.db.CreateTable(r.Context(), buildCreateConfig(&req)); err != nil {
 		writeErr(w, err)
 		return
@@ -474,6 +481,9 @@ func keySchemaKeys(req *createTableRequest) (partitionKey, sortKey string) {
 }
 
 // secondaryIndexJSON is the shared wire shape of a GSI or LSI on CreateTable.
+// ProvisionedThroughput is only meaningful for a GSI (an LSI always shares the
+// base table's throughput and never carries its own) — validateGSIThroughput
+// is the only reader of this field.
 type secondaryIndexJSON struct {
 	IndexName string `json:"IndexName"`
 	KeySchema []struct {
@@ -484,6 +494,20 @@ type secondaryIndexJSON struct {
 		ProjectionType   string   `json:"ProjectionType"`
 		NonKeyAttributes []string `json:"NonKeyAttributes"`
 	} `json:"Projection"`
+	ProvisionedThroughput struct {
+		ReadCapacityUnits  int64 `json:"ReadCapacityUnits"`
+		WriteCapacityUnits int64 `json:"WriteCapacityUnits"`
+	} `json:"ProvisionedThroughput"`
+}
+
+// validateGSIThroughput enforces the same PROVISIONED/PAY_PER_REQUEST
+// throughput rule as validateProvisionedThroughput, but per GSI: on a
+// PROVISIONED table each GSI must declare its own valid (>=1) RCU/WCU, and on
+// a PAY_PER_REQUEST table no GSI may declare any. LSIs are never checked —
+// callers must not pass one here.
+func validateGSIThroughput(billingMode string, gsi *secondaryIndexJSON) error {
+	return validateProvisionedThroughput(billingMode,
+		gsi.ProvisionedThroughput.ReadCapacityUnits, gsi.ProvisionedThroughput.WriteCapacityUnits)
 }
 
 // indexKeys extracts the HASH/RANGE attribute names from an index key schema.

--- a/server/aws/dynamodb/update_table.go
+++ b/server/aws/dynamodb/update_table.go
@@ -53,6 +53,11 @@ func (h *Handler) updateTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := h.validateGSICreateThroughputs(r.Context(), req.TableName, req.BillingMode, req.GlobalSecondaryIndexUpdates); err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	if err := h.applyThroughput(r.Context(), req.TableName, req.BillingMode, req.ProvisionedThroughput); err != nil {
 		writeErr(w, err)
 		return
@@ -160,6 +165,55 @@ func (h *Handler) validateThroughputChange(ctx context.Context, table, billingMo
 	}
 
 	return validateProvisionedThroughput(effectiveMode, effRCU, effWCU)
+}
+
+// validateGSICreateThroughputs enforces the per-GSI PROVISIONED/PAY_PER_REQUEST
+// throughput rule (validateGSIThroughput) against every GSI Create in an
+// UpdateTable request. The effective billing mode is the request's own
+// BillingMode when it changes it, otherwise the table's current stored mode —
+// the same resolution validateThroughputChange uses — so adding a GSI without
+// touching billing is checked against the table as it stands today. A request
+// with no GSI creates skips the DescribeTable lookup entirely.
+func (h *Handler) validateGSICreateThroughputs(
+	ctx context.Context, table, billingMode string, updates []gsiUpdateJSON,
+) error {
+	hasCreate := false
+
+	for i := range updates {
+		if updates[i].Create != nil {
+			hasCreate = true
+			break
+		}
+	}
+
+	if !hasCreate {
+		return nil
+	}
+
+	effectiveMode := billingMode
+	if effectiveMode == "" {
+		current, err := h.db.DescribeTable(ctx, table)
+		if err != nil {
+			return err
+		}
+
+		effectiveMode = current.BillingMode
+		if effectiveMode == "" {
+			effectiveMode = billingProvisioned
+		}
+	}
+
+	for i := range updates {
+		if updates[i].Create == nil {
+			continue
+		}
+
+		if err := validateGSIThroughput(effectiveMode, updates[i].Create); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // attrDefJSON is one AttributeDefinitions entry on an UpdateTable request.


### PR DESCRIPTION
## Summary

Real DynamoDB requires each GlobalSecondaryIndex to carry its own ProvisionedThroughput on a PROVISIONED table (RCU/WCU >= 1), and forbids it entirely on a PAY_PER_REQUEST table. CreateTable/UpdateTable previously accepted a GSI missing throughput on a PROVISIONED table (silently inheriting the base table's capacity) and accepted a GSI with throughput on a PAY_PER_REQUEST table — both diverge from real AWS.

This reuses the existing `validateProvisionedThroughput` helper (added in #1042 for the base table) per-GSI:
- CreateTable validates every `GlobalSecondaryIndexes[]` entry against the table's effective billing mode.
- UpdateTable validates every `GlobalSecondaryIndexUpdates[].Create` against the effective billing mode (the request's own `BillingMode` if it's changing, otherwise the table's current stored mode).
- LSIs are untouched — they never carry their own throughput in the AWS API.

## Real-user re-verification (aws-cli against `cloudemu serve`)

- (a) PROVISIONED table + GSI with valid throughput → **succeeded**
- (b) PROVISIONED table + GSI missing throughput → **ValidationException**
- (c) PAY_PER_REQUEST table + GSI with no throughput (the ordinary on-demand case) → **succeeded**
- (d) PAY_PER_REQUEST table + GSI with throughput → **ValidationException**

## Test plan

- [x] Table-driven tests in `server/aws/dynamodb/dynamodb_validation_test.go` covering both directions on CreateTable and UpdateTable's GSI-Create path, plus an LSI-never-requires-throughput case
- [x] `go test ./providers/aws/dynamodb/... ./server/aws/dynamodb/... ./persist/... -race`
- [x] `go test ./providers/aws/... ./server/aws/...`
- [x] `gofmt -l`, `golangci-lint` (no new issues)
- [x] `go generate ./...` — no diff in docs/coverage