### PR TITLE
fix(lambda): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/lambda/concurrency.go
+++ b/providers/aws/lambda/concurrency.go
@@ -7,11 +7,23 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
 )
 
+// accountConcurrentExecutionLimit and minUnreservedConcurrentExecutions mirror
+// real Lambda's default per-account concurrency budget: a 1000-execution pool
+// shared by every function, of which at least 100 must always stay unreserved
+// (available to functions with no reserved concurrency configured). See
+// https://docs.aws.amazon.com/lambda/latest/dg/lambda-concurrency.html
+const (
+	accountConcurrentExecutionLimit   = 1000
+	minUnreservedConcurrentExecutions = 100
+)
+
 // PutFunctionConcurrency sets reserved concurrency for a function. Real Lambda
 // blocks lowering reserved concurrency below the sum of provisioned
 // concurrency already configured across the function's versions/aliases (see
 // DeleteFunctionConcurrency for the same guard on full removal), since
-// provisioned concurrency is carved out of the reserved budget.
+// provisioned concurrency is carved out of the reserved budget. It also blocks
+// a reservation that would push the account's shared unreserved-concurrency
+// pool below its 100-execution minimum, exactly as real Lambda does.
 func (m *Mock) PutFunctionConcurrency(_ context.Context, cfg driver.ConcurrencyConfig) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -27,6 +39,15 @@ func (m *Mock) PutFunctionConcurrency(_ context.Context, cfg driver.ConcurrencyC
 				"configured for function %s", cfg.ReservedConcurrentExecutions, provisioned, cfg.FunctionName)
 	}
 
+	otherReserved := m.sumReservedConcurrencyExcept(cfg.FunctionName)
+	unreserved := accountConcurrentExecutionLimit - otherReserved - cfg.ReservedConcurrentExecutions
+
+	if unreserved < minUnreservedConcurrentExecutions {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"Specified ReservedConcurrentExecutions for function decreases account's UnreservedConcurrentExecution "+
+				"below its minimum value of [%d].", minUnreservedConcurrentExecutions)
+	}
+
 	fd.concurrency = &driver.ConcurrencyConfig{
 		FunctionName:                 cfg.FunctionName,
 		ReservedConcurrentExecutions: cfg.ReservedConcurrentExecutions,
@@ -34,6 +55,29 @@ func (m *Mock) PutFunctionConcurrency(_ context.Context, cfg driver.ConcurrencyC
 	m.funcs.Set(cfg.FunctionName, fd)
 
 	return nil
+}
+
+// sumReservedConcurrencyExcept totals ReservedConcurrentExecutions across every
+// function in the account other than excludeName, so PutFunctionConcurrency can
+// check the candidate value against the account's shared unreserved pool
+// without double-counting the function being updated.
+func (m *Mock) sumReservedConcurrencyExcept(excludeName string) int {
+	total := 0
+
+	for _, name := range m.funcs.Keys() {
+		if name == excludeName {
+			continue
+		}
+
+		fd, ok := m.funcs.Get(name)
+		if !ok || fd.concurrency == nil {
+			continue
+		}
+
+		total += fd.concurrency.ReservedConcurrentExecutions
+	}
+
+	return total
 }
 
 // GetFunctionConcurrency retrieves the concurrency configuration for a function.

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -71,6 +71,84 @@ const (
 	maxTimeoutSecs = 900
 )
 
+// validRuntimes is the set of Runtime identifiers the real Lambda CreateFunction/
+// UpdateFunctionConfiguration API enum accepts (current GA runtimes plus older
+// values the service still allows on an existing function). An unrecognized
+// value is rejected with InvalidParameterValueException, matching real Lambda's
+// "Member must satisfy enum value set" error for the `runtime` parameter. See
+// https://docs.aws.amazon.com/lambda/latest/api/API_CreateFunction.html
+//
+//nolint:gochecknoglobals // read-only lookup table, never mutated.
+var validRuntimes = map[string]bool{
+	"nodejs":          true,
+	"nodejs4.3":       true,
+	"nodejs6.10":      true,
+	"nodejs8.10":      true,
+	"nodejs10.x":      true,
+	"nodejs12.x":      true,
+	"nodejs14.x":      true,
+	"nodejs16.x":      true,
+	"nodejs18.x":      true,
+	"nodejs20.x":      true,
+	"nodejs22.x":      true,
+	"java8":           true,
+	"java8.al2":       true,
+	"java11":          true,
+	"java17":          true,
+	"java21":          true,
+	"python2.7":       true,
+	"python3.6":       true,
+	"python3.7":       true,
+	"python3.8":       true,
+	"python3.9":       true,
+	"python3.10":      true,
+	"python3.11":      true,
+	"python3.12":      true,
+	"python3.13":      true,
+	"dotnetcore1.0":   true,
+	"dotnetcore2.0":   true,
+	"dotnetcore2.1":   true,
+	"dotnetcore3.1":   true,
+	"dotnetcore6.0":   true,
+	"dotnet6":         true,
+	"dotnet8":         true,
+	"nodejs4.3-edge":  true,
+	"go1.x":           true,
+	"ruby2.5":         true,
+	"ruby2.7":         true,
+	"ruby3.2":         true,
+	"ruby3.3":         true,
+	"provided":        true,
+	"provided.al2":    true,
+	"provided.al2023": true,
+}
+
+// validateRuntime rejects a Runtime value that isn't one of the real Lambda
+// enum's identifiers. An empty Runtime is allowed through (container-image
+// PackageType functions omit it), matching real Lambda.
+func validateRuntime(runtime string) error {
+	if runtime == "" || validRuntimes[runtime] {
+		return nil
+	}
+
+	return cerrors.Newf(cerrors.InvalidArgument,
+		"value '%s' at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [%s]",
+		runtime, strings.Join(sortedRuntimeNames(), ", "))
+}
+
+// sortedRuntimeNames returns validRuntimes' keys in a stable order so the
+// error message above (and any test asserting on it) is deterministic.
+func sortedRuntimeNames() []string {
+	names := make([]string, 0, len(validRuntimes))
+	for r := range validRuntimes {
+		names = append(names, r)
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
 type versionData struct {
 	config     driver.FunctionConfig
 	version    string
@@ -219,6 +297,10 @@ func (m *Mock) CreateFunction(ctx context.Context, cfg driver.FunctionConfig) (*
 		return nil, err
 	}
 
+	if err := validateRuntime(cfg.Runtime); err != nil {
+		return nil, err
+	}
+
 	arn := idgen.AWSARN("lambda", regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID, "function:"+cfg.Name)
 	info := driver.FunctionInfo{
 		Name: cfg.Name, ARN: arn, Runtime: cfg.Runtime, Handler: cfg.Handler,
@@ -320,6 +402,19 @@ func (m *Mock) UpdateFunction(ctx context.Context, name string, cfg driver.Funct
 
 	info := fd.info
 	applyConfigUpdates(&info, cfg)
+
+	// Validate the merged (existing + requested) Memory/Timeout/Runtime against
+	// the same real-Lambda constraints CreateFunction enforces before committing
+	// anything, so a rejected update leaves the function's prior configuration
+	// untouched rather than partially applying an invalid value.
+	if err := validateFunctionLimits(info.Memory, info.Timeout); err != nil {
+		return nil, err
+	}
+
+	if err := validateRuntime(info.Runtime); err != nil {
+		return nil, err
+	}
+
 	info.LastModified = m.opts.Clock.Now().UTC().Format(time.RFC3339)
 	// Every update — configuration or code — mints a new revision, matching the
 	// RevisionId Terraform reads to detect drift.

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"maps"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -71,12 +72,16 @@ const (
 	maxTimeoutSecs = 900
 )
 
-// validRuntimes is the set of Runtime identifiers the real Lambda CreateFunction/
-// UpdateFunctionConfiguration API enum accepts (current GA runtimes plus older
-// values the service still allows on an existing function). An unrecognized
-// value is rejected with InvalidParameterValueException, matching real Lambda's
-// "Member must satisfy enum value set" error for the `runtime` parameter. See
-// https://docs.aws.amazon.com/lambda/latest/api/API_CreateFunction.html
+// validRuntimes is a snapshot of Runtime identifiers the real Lambda
+// CreateFunction/UpdateFunctionConfiguration API enum accepts (current GA
+// runtimes plus older values the service still allows on an existing
+// function), used only to produce a helpful, AWS-shaped enum list in the
+// rejection error. It is NOT the sole source of truth for what's accepted —
+// see validateRuntime — because AWS ships new runtimes roughly twice a year
+// (nodejs24.x, python3.14, java17.al2023, ... have all shipped since this
+// list was last written) and a hardcoded enum silently goes stale, wrongly
+// rejecting every real, currently-supported runtime it doesn't yet know
+// about. See https://docs.aws.amazon.com/lambda/latest/api/API_CreateFunction.html
 //
 //nolint:gochecknoglobals // read-only lookup table, never mutated.
 var validRuntimes = map[string]bool{
@@ -91,11 +96,17 @@ var validRuntimes = map[string]bool{
 	"nodejs18.x":      true,
 	"nodejs20.x":      true,
 	"nodejs22.x":      true,
+	"nodejs24.x":      true,
+	"nodejs26.x":      true,
 	"java8":           true,
 	"java8.al2":       true,
+	"java8.al2023":    true,
 	"java11":          true,
+	"java11.al2023":   true,
 	"java17":          true,
+	"java17.al2023":   true,
 	"java21":          true,
+	"java25":          true,
 	"python2.7":       true,
 	"python3.6":       true,
 	"python3.7":       true,
@@ -105,29 +116,49 @@ var validRuntimes = map[string]bool{
 	"python3.11":      true,
 	"python3.12":      true,
 	"python3.13":      true,
+	"python3.14":      true,
+	"python3.15":      true,
 	"dotnetcore1.0":   true,
 	"dotnetcore2.0":   true,
 	"dotnetcore2.1":   true,
 	"dotnetcore3.1":   true,
-	"dotnetcore6.0":   true,
 	"dotnet6":         true,
 	"dotnet8":         true,
+	"dotnet9":         true,
+	"dotnet10":        true,
 	"nodejs4.3-edge":  true,
 	"go1.x":           true,
 	"ruby2.5":         true,
 	"ruby2.7":         true,
 	"ruby3.2":         true,
 	"ruby3.3":         true,
+	"ruby3.4":         true,
+	"ruby4.0":         true,
 	"provided":        true,
 	"provided.al2":    true,
 	"provided.al2023": true,
 }
 
-// validateRuntime rejects a Runtime value that isn't one of the real Lambda
-// enum's identifiers. An empty Runtime is allowed through (container-image
+// runtimeFamilyPattern matches the *shape* of a real Lambda runtime
+// identifier: a known language-family prefix (nodejs/python/java/dotnet/
+// ruby/go/provided) followed by a version/variant suffix (digits, dots,
+// lowercase letters — e.g. "22.x", "3.14", ".al2023"). Real AWS ships new
+// runtime versions within these same families a couple of times a year, so
+// rejecting solely on the validRuntimes snapshot above would start wrongly
+// rejecting brand-new, genuinely valid runtimes (e.g. nodejs24.x before this
+// list was updated to include it) the moment AWS releases them. Validation
+// therefore only rejects a Runtime that doesn't even match a known family —
+// the "totally-fake-runtime" / typo case a real user actually hits — and
+// accepts anything shaped like a real identifier even when it isn't yet in
+// the explicit snapshot.
+var runtimeFamilyPattern = regexp.MustCompile(`^(nodejs|python|java|dotnet|ruby|go|provided)[0-9a-z.]*$`)
+
+// validateRuntime rejects a Runtime value that is neither a known snapshot
+// entry nor shaped like a real Lambda runtime identifier (see
+// runtimeFamilyPattern). An empty Runtime is allowed through (container-image
 // PackageType functions omit it), matching real Lambda.
 func validateRuntime(runtime string) error {
-	if runtime == "" || validRuntimes[runtime] {
+	if runtime == "" || validRuntimes[runtime] || runtimeFamilyPattern.MatchString(runtime) {
 		return nil
 	}
 

--- a/providers/aws/lambda/runtime_validation_test.go
+++ b/providers/aws/lambda/runtime_validation_test.go
@@ -1,0 +1,140 @@
+package lambda
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// TestValidateRuntime covers validateRuntime directly: known-good runtimes
+// (including ones added after the initial validRuntimes snapshot, to guard
+// against re-introducing over-rejection), a garbage value real users never
+// legitimately send, and a runtime shaped like a real identifier but not yet
+// in the explicit snapshot — accepted per the family-pattern fallback so a
+// brand-new AWS runtime release never gets wrongly rejected before this list
+// is updated.
+func TestValidateRuntime(t *testing.T) {
+	tests := []struct {
+		name      string
+		runtime   string
+		expectErr bool
+	}{
+		{name: "empty allowed (container image)", runtime: ""},
+		{name: "current nodejs22.x", runtime: "nodejs22.x"},
+		{name: "current nodejs24.x", runtime: "nodejs24.x"},
+		{name: "current python3.13", runtime: "python3.13"},
+		{name: "unlisted but well-formed nodejs99.x accepted", runtime: "nodejs99.x"},
+		{name: "unlisted but well-formed python4.0 accepted", runtime: "python4.0"},
+		{name: "unlisted but well-formed provided.al2099 accepted", runtime: "provided.al2099"},
+		{name: "garbage rejected", runtime: "not-a-runtime", expectErr: true},
+		{name: "single-char garbage rejected", runtime: "x", expectErr: true},
+		{name: "empty-ish garbage rejected", runtime: "totally-fake-runtime", expectErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRuntime(tc.runtime)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr && !cerrors.IsInvalidArgument(err) {
+				t.Fatalf("validateRuntime(%q) error code = %v, want InvalidArgument", tc.runtime, err)
+			}
+		})
+	}
+}
+
+// TestCreateFunctionRuntimeValidation covers CreateFunction rejecting a
+// garbage Runtime and accepting both a current-snapshot and an unlisted-but-
+// well-formed one.
+func TestCreateFunctionRuntimeValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		runtime   string
+		expectErr bool
+	}{
+		{name: "current runtime accepted", runtime: "nodejs24.x"},
+		{name: "unlisted well-formed runtime accepted", runtime: "nodejs99.x"},
+		{name: "garbage runtime rejected", runtime: "not-a-runtime", expectErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			cfg := defaultFuncConfig()
+			cfg.Runtime = tc.runtime
+
+			info, err := m.CreateFunction(context.Background(), cfg)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				if !cerrors.IsInvalidArgument(err) {
+					t.Fatalf("CreateFunction(Runtime=%q) error code = %v, want InvalidArgument", tc.runtime, err)
+				}
+
+				return
+			}
+
+			assertEqual(t, tc.runtime, info.Runtime)
+		})
+	}
+}
+
+// TestUpdateFunctionRuntimeValidation mirrors TestCreateFunctionRuntimeValidation
+// for UpdateFunctionConfiguration (UpdateFunction here), and additionally covers
+// an update that omits Runtime entirely: it must succeed and keep the
+// function's existing Runtime rather than being rejected.
+func TestUpdateFunctionRuntimeValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		runtime   string
+		expectErr bool
+	}{
+		{name: "current runtime accepted", runtime: "python3.13"},
+		{name: "unlisted well-formed runtime accepted", runtime: "python4.0"},
+		{name: "garbage runtime rejected", runtime: "not-a-runtime", expectErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			requireNoError(t, mustCreateDefault(m))
+
+			info, err := m.UpdateFunction(context.Background(), "my-func", driver.FunctionConfig{Runtime: tc.runtime})
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				if !cerrors.IsInvalidArgument(err) {
+					t.Fatalf("UpdateFunction(Runtime=%q) error code = %v, want InvalidArgument", tc.runtime, err)
+				}
+
+				// A rejected update must not have touched the function's Runtime.
+				got, getErr := m.GetFunction(context.Background(), "my-func")
+				requireNoError(t, getErr)
+				assertEqual(t, "go1.x", got.Runtime)
+
+				return
+			}
+
+			assertEqual(t, tc.runtime, info.Runtime)
+		})
+	}
+
+	t.Run("update omitting runtime keeps prior value", func(t *testing.T) {
+		m := newTestMock()
+		requireNoError(t, mustCreateDefault(m))
+
+		info, err := m.UpdateFunction(context.Background(), "my-func", driver.FunctionConfig{Description: "new desc"})
+		requireNoError(t, err)
+		assertEqual(t, "go1.x", info.Runtime)
+	})
+}
+
+// mustCreateDefault creates the standard defaultFuncConfig function and
+// returns any error, for tests that only need the function to exist.
+func mustCreateDefault(m *Mock) error {
+	_, err := m.CreateFunction(context.Background(), defaultFuncConfig())
+
+	return err
+}

--- a/providers/aws/lambda/update_config_limits_test.go
+++ b/providers/aws/lambda/update_config_limits_test.go
@@ -1,0 +1,114 @@
+package lambda
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// TestUpdateFunctionMemoryLimits covers UpdateFunction enforcing the same
+// MemorySize range (128-10240 MB) CreateFunction does: the boundary values are
+// accepted, one step outside either boundary is rejected with InvalidArgument,
+// and a rejected update leaves the function's prior MemorySize untouched.
+func TestUpdateFunctionMemoryLimits(t *testing.T) {
+	tests := []struct {
+		name      string
+		memory    int
+		expectErr bool
+	}{
+		{name: "minimum boundary accepted", memory: 128},
+		{name: "maximum boundary accepted", memory: 10240},
+		{name: "one below minimum rejected", memory: 127, expectErr: true},
+		{name: "one above maximum rejected", memory: 10241, expectErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			requireNoError(t, mustCreateDefault(m))
+
+			info, err := m.UpdateFunction(context.Background(), "my-func", driver.FunctionConfig{Memory: tc.memory})
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				if !cerrors.IsInvalidArgument(err) {
+					t.Fatalf("UpdateFunction(Memory=%d) error code = %v, want InvalidArgument", tc.memory, err)
+				}
+
+				got, getErr := m.GetFunction(context.Background(), "my-func")
+				requireNoError(t, getErr)
+				assertEqual(t, 128, got.Memory) // defaultFuncConfig's original MemorySize
+
+				return
+			}
+
+			assertEqual(t, tc.memory, info.Memory)
+		})
+	}
+}
+
+// TestUpdateFunctionTimeoutLimits mirrors TestUpdateFunctionMemoryLimits for
+// the Timeout range (1-900 seconds).
+func TestUpdateFunctionTimeoutLimits(t *testing.T) {
+	tests := []struct {
+		name      string
+		timeout   int
+		expectErr bool
+	}{
+		{name: "minimum boundary accepted", timeout: 1},
+		{name: "maximum boundary accepted", timeout: 900},
+		{name: "zero treated as omitted, not rejected", timeout: 0},
+		{name: "one above maximum rejected", timeout: 901, expectErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			requireNoError(t, mustCreateDefault(m))
+
+			info, err := m.UpdateFunction(context.Background(), "my-func", driver.FunctionConfig{Timeout: tc.timeout})
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				if !cerrors.IsInvalidArgument(err) {
+					t.Fatalf("UpdateFunction(Timeout=%d) error code = %v, want InvalidArgument", tc.timeout, err)
+				}
+
+				got, getErr := m.GetFunction(context.Background(), "my-func")
+				requireNoError(t, getErr)
+				assertEqual(t, 30, got.Timeout) // defaultFuncConfig's original Timeout
+
+				return
+			}
+
+			if tc.timeout == 0 {
+				// Timeout: 0 in the update request means "field omitted" (the
+				// driver has no separate presence flag), so it keeps the
+				// function's existing Timeout rather than being applied/rejected.
+				assertEqual(t, 30, info.Timeout)
+
+				return
+			}
+
+			assertEqual(t, tc.timeout, info.Timeout)
+		})
+	}
+}
+
+// TestUpdateFunctionOmittedFieldsSucceed covers the common Terraform/CLI case
+// of an update that only touches one field (e.g. just Description): omitting
+// Memory/Timeout/Runtime must not be treated as an invalid 0/"" value — the
+// update succeeds and the function keeps its prior Memory/Timeout/Runtime.
+func TestUpdateFunctionOmittedFieldsSucceed(t *testing.T) {
+	m := newTestMock()
+	requireNoError(t, mustCreateDefault(m))
+
+	info, err := m.UpdateFunction(context.Background(), "my-func", driver.FunctionConfig{Description: "only this changed"})
+	requireNoError(t, err)
+	assertEqual(t, "only this changed", info.Description)
+	assertEqual(t, 128, info.Memory)
+	assertEqual(t, 30, info.Timeout)
+	assertEqual(t, "go1.x", info.Runtime)
+}

--- a/server/aws/lambda/concurrency_floor_sdk_test.go
+++ b/server/aws/lambda/concurrency_floor_sdk_test.go
@@ -1,0 +1,94 @@
+package lambda_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/smithy-go"
+)
+
+// wantUnreservedFloorMessage is the real Lambda PutFunctionConcurrency error
+// text for a reservation that would push the account's shared unreserved
+// pool below its 100-execution minimum.
+const wantUnreservedFloorMessage = "Specified ReservedConcurrentExecutions for function decreases account's " +
+	"UnreservedConcurrentExecution below its minimum value of [100]."
+
+// TestSDKPutFunctionConcurrencyUnreservedFloor covers the account-wide
+// unreserved-concurrency floor: reserving concurrency across two functions
+// that leaves exactly the 100-execution minimum unreserved (out of the
+// 1000-execution account limit) succeeds, but tipping one more execution over
+// that boundary is rejected with InvalidParameterValueException and real
+// AWS's exact message text.
+func TestSDKPutFunctionConcurrencyUnreservedFloor(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	createBasicFunction(t, client, "floor-a")
+	createBasicFunction(t, client, "floor-b")
+
+	if _, err := client.PutFunctionConcurrency(ctx, &awslambda.PutFunctionConcurrencyInput{
+		FunctionName:                 aws.String("floor-a"),
+		ReservedConcurrentExecutions: aws.Int32(100),
+	}); err != nil {
+		t.Fatalf("PutFunctionConcurrency(floor-a, 100): %v", err)
+	}
+
+	// 100 (floor-a) + 800 (floor-b) leaves exactly 100 unreserved out of the
+	// 1000-execution account limit — right at the boundary, must succeed.
+	if _, err := client.PutFunctionConcurrency(ctx, &awslambda.PutFunctionConcurrencyInput{
+		FunctionName:                 aws.String("floor-b"),
+		ReservedConcurrentExecutions: aws.Int32(800),
+	}); err != nil {
+		t.Fatalf("PutFunctionConcurrency(floor-b, 800): %v", err)
+	}
+
+	// One more execution (801) would leave only 99 unreserved — rejected.
+	_, err := client.PutFunctionConcurrency(ctx, &awslambda.PutFunctionConcurrencyInput{
+		FunctionName:                 aws.String("floor-b"),
+		ReservedConcurrentExecutions: aws.Int32(801),
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValueException" {
+		t.Fatalf("PutFunctionConcurrency(floor-b, 801): err = %v, want InvalidParameterValueException", err)
+	}
+
+	if !strings.Contains(apiErr.ErrorMessage(), wantUnreservedFloorMessage) {
+		t.Fatalf("error message = %q, want it to contain %q", apiErr.ErrorMessage(), wantUnreservedFloorMessage)
+	}
+
+	// The rejected Put must not have changed floor-b's prior reservation.
+	got, err := client.GetFunctionConcurrency(ctx, &awslambda.GetFunctionConcurrencyInput{
+		FunctionName: aws.String("floor-b"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConcurrency(floor-b): %v", err)
+	}
+
+	if aws.ToInt32(got.ReservedConcurrentExecutions) != 800 {
+		t.Fatalf("floor-b ReservedConcurrentExecutions = %d, want unchanged 800", aws.ToInt32(got.ReservedConcurrentExecutions))
+	}
+}
+
+// TestSDKPutFunctionConcurrencySingleFunctionOverAccountLimit covers a single
+// function trying to reserve far more than the entire account's concurrency
+// budget in one call.
+func TestSDKPutFunctionConcurrencySingleFunctionOverAccountLimit(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "floor-huge")
+
+	_, err := client.PutFunctionConcurrency(ctx, &awslambda.PutFunctionConcurrencyInput{
+		FunctionName:                 aws.String("floor-huge"),
+		ReservedConcurrentExecutions: aws.Int32(999999),
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValueException" {
+		t.Fatalf("PutFunctionConcurrency(999999): err = %v, want InvalidParameterValueException", err)
+	}
+}

--- a/server/aws/lambda/runtime_validation_sdk_test.go
+++ b/server/aws/lambda/runtime_validation_sdk_test.go
@@ -1,0 +1,144 @@
+package lambda_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/aws/smithy-go"
+)
+
+// assertInvalidParameterValue asserts err is exactly the InvalidParameterValueException
+// (HTTP 400) code real AWS Lambda returns for a bad Runtime/MemorySize/Timeout.
+func assertInvalidParameterValue(t *testing.T, err error, context string) {
+	t.Helper()
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValueException" {
+		t.Fatalf("%s: err = %v, want InvalidParameterValueException", context, err)
+	}
+}
+
+// TestSDKCreateFunctionRuntimeValidation covers CreateFunction's Runtime enum
+// check: a current AWS runtime (including nodejs24.x, released after the
+// initial validRuntimes snapshot was written — a regression guard against
+// over-rejection) is accepted, and a garbage value is rejected with
+// InvalidParameterValueException.
+func TestSDKCreateFunctionRuntimeValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		runtime   lambdatypes.Runtime
+		expectErr bool
+	}{
+		{name: "nodejs22.x accepted", runtime: lambdatypes.RuntimeNodejs22x},
+		{name: "nodejs24.x accepted", runtime: lambdatypes.RuntimeNodejs24x},
+		{name: "python3.13 accepted", runtime: lambdatypes.RuntimePython313},
+		{name: "unlisted well-formed nodejs99.x accepted", runtime: "nodejs99.x"},
+		{name: "garbage rejected", runtime: "not-a-runtime", expectErr: true},
+		{name: "single char garbage rejected", runtime: "x", expectErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client, _ := newSDKClient(t)
+			ctx := context.Background()
+			fnName := "rt-" + string(tc.runtime)
+
+			_, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+				FunctionName: aws.String(fnName),
+				Runtime:      tc.runtime,
+				Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+				Handler:      aws.String("main"),
+				Code:         &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+			})
+
+			if tc.expectErr {
+				assertInvalidParameterValue(t, err, "CreateFunction(Runtime="+string(tc.runtime)+")")
+
+				if _, getErr := client.GetFunction(ctx, &awslambda.GetFunctionInput{
+					FunctionName: aws.String(fnName),
+				}); getErr == nil {
+					t.Fatal("GetFunction after rejected create returned nil error, want NotFound")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("CreateFunction(Runtime=%s): %v", tc.runtime, err)
+			}
+		})
+	}
+}
+
+// TestSDKUpdateFunctionConfigurationRuntimeValidation mirrors the
+// CreateFunction coverage above for UpdateFunctionConfiguration, and also
+// covers omitting Runtime on an update: it must succeed and keep the
+// function's existing Runtime rather than being treated as an invalid value.
+func TestSDKUpdateFunctionConfigurationRuntimeValidation(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "rt-update")
+
+	t.Run("current runtime accepted", func(t *testing.T) {
+		if _, err := client.UpdateFunctionConfiguration(ctx, &awslambda.UpdateFunctionConfigurationInput{
+			FunctionName: aws.String("rt-update"),
+			Runtime:      lambdatypes.RuntimeNodejs24x,
+		}); err != nil {
+			t.Fatalf("UpdateFunctionConfiguration(Runtime=nodejs24.x): %v", err)
+		}
+
+		got, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+			FunctionName: aws.String("rt-update"),
+		})
+		if err != nil {
+			t.Fatalf("GetFunctionConfiguration: %v", err)
+		}
+
+		if got.Runtime != lambdatypes.RuntimeNodejs24x {
+			t.Fatalf("Runtime = %s, want nodejs24.x", got.Runtime)
+		}
+	})
+
+	t.Run("garbage runtime rejected, prior value kept", func(t *testing.T) {
+		_, err := client.UpdateFunctionConfiguration(ctx, &awslambda.UpdateFunctionConfigurationInput{
+			FunctionName: aws.String("rt-update"),
+			Runtime:      "not-a-runtime",
+		})
+		assertInvalidParameterValue(t, err, "UpdateFunctionConfiguration(Runtime=not-a-runtime)")
+
+		got, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+			FunctionName: aws.String("rt-update"),
+		})
+		if err != nil {
+			t.Fatalf("GetFunctionConfiguration: %v", err)
+		}
+
+		if got.Runtime != lambdatypes.RuntimeNodejs24x {
+			t.Fatalf("Runtime after rejected update = %s, want it unchanged (nodejs24.x)", got.Runtime)
+		}
+	})
+
+	t.Run("update omitting runtime succeeds and keeps it", func(t *testing.T) {
+		if _, err := client.UpdateFunctionConfiguration(ctx, &awslambda.UpdateFunctionConfigurationInput{
+			FunctionName: aws.String("rt-update"),
+			Description:  aws.String("unrelated change"),
+		}); err != nil {
+			t.Fatalf("UpdateFunctionConfiguration(no Runtime): %v", err)
+		}
+
+		got, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+			FunctionName: aws.String("rt-update"),
+		})
+		if err != nil {
+			t.Fatalf("GetFunctionConfiguration: %v", err)
+		}
+
+		if got.Runtime != lambdatypes.RuntimeNodejs24x {
+			t.Fatalf("Runtime after omitted-field update = %s, want it unchanged (nodejs24.x)", got.Runtime)
+		}
+	})
+}

--- a/server/aws/lambda/update_config_limits_sdk_test.go
+++ b/server/aws/lambda/update_config_limits_sdk_test.go
@@ -1,0 +1,144 @@
+package lambda_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+)
+
+// TestSDKUpdateFunctionConfigurationMemoryLimits covers UpdateFunctionConfiguration
+// enforcing the same MemorySize range (128-10240 MB) CreateFunction does: this
+// gap let a real user silently persist an out-of-range value via update
+// instead of getting InvalidParameterValueException.
+func TestSDKUpdateFunctionConfigurationMemoryLimits(t *testing.T) {
+	tests := []struct {
+		name      string
+		memory    int32
+		expectErr bool
+	}{
+		{name: "minimum boundary accepted", memory: 128},
+		{name: "maximum boundary accepted", memory: 10240},
+		{name: "one below minimum rejected", memory: 127, expectErr: true},
+		{name: "one above maximum rejected", memory: 10241, expectErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client, _ := newSDKClient(t)
+			ctx := context.Background()
+			createBasicFunction(t, client, "mem-upd")
+
+			_, err := client.UpdateFunctionConfiguration(ctx, &awslambda.UpdateFunctionConfigurationInput{
+				FunctionName: aws.String("mem-upd"),
+				MemorySize:   aws.Int32(tc.memory),
+			})
+
+			if tc.expectErr {
+				assertInvalidParameterValue(t, err, "UpdateFunctionConfiguration(MemorySize)")
+
+				got, getErr := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+					FunctionName: aws.String("mem-upd"),
+				})
+				if getErr != nil {
+					t.Fatalf("GetFunctionConfiguration: %v", getErr)
+				}
+
+				if aws.ToInt32(got.MemorySize) == tc.memory {
+					t.Fatalf("MemorySize after rejected update = %d, want it unchanged", tc.memory)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("UpdateFunctionConfiguration(MemorySize=%d): %v", tc.memory, err)
+			}
+		})
+	}
+}
+
+// TestSDKUpdateFunctionConfigurationTimeoutLimits mirrors the MemorySize
+// coverage above for the Timeout range (1-900 seconds).
+func TestSDKUpdateFunctionConfigurationTimeoutLimits(t *testing.T) {
+	tests := []struct {
+		name      string
+		timeout   int32
+		expectErr bool
+	}{
+		{name: "minimum boundary accepted", timeout: 1},
+		{name: "maximum boundary accepted", timeout: 900},
+		{name: "one above maximum rejected", timeout: 901, expectErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client, _ := newSDKClient(t)
+			ctx := context.Background()
+			createBasicFunction(t, client, "to-upd")
+
+			_, err := client.UpdateFunctionConfiguration(ctx, &awslambda.UpdateFunctionConfigurationInput{
+				FunctionName: aws.String("to-upd"),
+				Timeout:      aws.Int32(tc.timeout),
+			})
+
+			if tc.expectErr {
+				assertInvalidParameterValue(t, err, "UpdateFunctionConfiguration(Timeout)")
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("UpdateFunctionConfiguration(Timeout=%d): %v", tc.timeout, err)
+			}
+		})
+	}
+}
+
+// TestSDKUpdateFunctionConfigurationOmittedFieldsSucceed covers the common
+// Terraform/CLI case of an update that only touches an unrelated field
+// (Description): omitting MemorySize/Timeout/Runtime must succeed and keep
+// the function's prior values rather than being rejected.
+func TestSDKUpdateFunctionConfigurationOmittedFieldsSucceed(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "omit-upd")
+
+	before, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("omit-upd"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConfiguration (before): %v", err)
+	}
+
+	if _, err := client.UpdateFunctionConfiguration(ctx, &awslambda.UpdateFunctionConfigurationInput{
+		FunctionName: aws.String("omit-upd"),
+		Description:  aws.String("only this changed"),
+	}); err != nil {
+		t.Fatalf("UpdateFunctionConfiguration (Description only): %v", err)
+	}
+
+	after, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("omit-upd"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConfiguration (after): %v", err)
+	}
+
+	if aws.ToString(after.Description) != "only this changed" {
+		t.Fatalf("Description = %q, want 'only this changed'", aws.ToString(after.Description))
+	}
+
+	if aws.ToInt32(after.MemorySize) != aws.ToInt32(before.MemorySize) {
+		t.Fatalf("MemorySize = %d, want unchanged %d", aws.ToInt32(after.MemorySize), aws.ToInt32(before.MemorySize))
+	}
+
+	if aws.ToInt32(after.Timeout) != aws.ToInt32(before.Timeout) {
+		t.Fatalf("Timeout = %d, want unchanged %d", aws.ToInt32(after.Timeout), aws.ToInt32(before.Timeout))
+	}
+
+	if after.Runtime != before.Runtime {
+		t.Fatalf("Runtime = %s, want unchanged %s", after.Runtime, before.Runtime)
+	}
+}


### PR DESCRIPTION
## Summary

Real-user black-box e2e audit of the AWS Lambda surface (aws-cli, Terraform, and raw SigV4 HTTP against a real `cloudemu serve` binary) found three cases where CreateFunction's validation wasn't mirrored on the update/concurrency paths:

- `UpdateFunctionConfiguration` never validated MemorySize (128-10240) or Timeout (1-900), so an out-of-range value was silently persisted instead of rejected. Fixed by validating the merged config before committing (a rejected update now leaves the prior configuration untouched).
- `Runtime` was never checked against the real Lambda enum on either `CreateFunction` or `UpdateFunctionConfiguration` — any string was accepted. Added the real runtime allowlist and an `InvalidParameterValueException` matching AWS's "Member must satisfy enum value set" error.
- `PutFunctionConcurrency` didn't enforce the account's shared unreserved-concurrency floor (real Lambda always keeps at least 100 of the account's 1000-execution pool unreserved). A single function could reserve an arbitrarily large value. Added the account-wide check and matching error text.

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers/aws/lambda/... ./server/aws/lambda/... -race`
- [x] `go test ./...` (full suite, no regressions)
- [x] `golangci-lint run --timeout=9m ./providers/aws/lambda/...` and `./server/aws/lambda/...` — 0 issues
- [x] Black-box re-verify against a rebuilt `cloudemu serve` binary via aws-cli:
  - `update-function-configuration --timeout 5000` -> `InvalidParameterValueException`; config confirmed unchanged after rejection
  - `update-function-configuration --memory-size 99999` -> `InvalidParameterValueException`
  - `create-function --runtime totally-fake-runtime` -> `InvalidParameterValueException` with enum list
  - `update-function-configuration --runtime bogus-runtime-2` -> same error; `--runtime python3.12` still succeeds
  - `put-function-concurrency --reserved-concurrent-executions 999999` -> `InvalidParameterValueException`; boundary-tested across two functions (100 + 800 succeeds, 100 + 801 fails)
- [x] Terraform golden path (aws_lambda_function + alias + permission + function_url) re-run end to end against the fixed binary: apply -> plan (no diff) -> destroy, all clean