### PR TITLE
fix(sqs): real-user e2e divergences from AWS

### DIFF
--- a/server/aws/sqs/batch_validation_test.go
+++ b/server/aws/sqs/batch_validation_test.go
@@ -36,8 +36,12 @@ func TestSDKSendMessageBatchDuplicateIDs(t *testing.T) {
 			{Id: aws.String("a"), MessageBody: aws.String("body-b")},
 		},
 	})
-	if code := apiErrorCode(t, err); code != "BatchEntryIdsNotDistinct" {
-		t.Fatalf("error code = %q, want BatchEntryIdsNotDistinct", code)
+	// SQS carries the "awsQueryCompatible" trait: aws-sdk-go-v2 overrides
+	// ErrorCode() to the legacy Query-protocol code from the X-Amzn-Query-Error
+	// header, not the AwsJson1_0 shape name.
+	const wantCode = "AWS.SimpleQueueService.BatchEntryIdsNotDistinct"
+	if code := apiErrorCode(t, err); code != wantCode {
+		t.Fatalf("error code = %q, want %s", code, wantCode)
 	}
 
 	// The batch must enqueue nothing.
@@ -73,8 +77,11 @@ func TestSDKSendMessageBatchTooManyEntries(t *testing.T) {
 		QueueUrl: aws.String(url),
 		Entries:  entries,
 	})
-	if code := apiErrorCode(t, err); code != "TooManyEntriesInBatchRequest" {
-		t.Fatalf("error code = %q, want TooManyEntriesInBatchRequest", code)
+	// See TestSDKSendMessageBatchDuplicateIDs: ErrorCode() resolves to the
+	// awsQueryCompatible legacy code, not the AwsJson1_0 shape name.
+	const wantCode = "AWS.SimpleQueueService.TooManyEntriesInBatchRequest"
+	if code := apiErrorCode(t, err); code != wantCode {
+		t.Fatalf("error code = %q, want %s", code, wantCode)
 	}
 }
 
@@ -85,28 +92,32 @@ func TestSDKSendMessageBatchEmpty(t *testing.T) {
 	ctx := context.Background()
 	url := mustCreateQueue(t, client, "empty-batch")
 
+	// See TestSDKSendMessageBatchDuplicateIDs: ErrorCode() resolves to the
+	// awsQueryCompatible legacy code, not the AwsJson1_0 shape name.
+	const wantCode = "AWS.SimpleQueueService.EmptyBatchRequest"
+
 	_, sendErr := client.SendMessageBatch(ctx, &awssqs.SendMessageBatchInput{
 		QueueUrl: aws.String(url),
 		Entries:  []types.SendMessageBatchRequestEntry{},
 	})
-	if code := apiErrorCode(t, sendErr); code != "EmptyBatchRequest" {
-		t.Fatalf("SendMessageBatch error code = %q, want EmptyBatchRequest", code)
+	if code := apiErrorCode(t, sendErr); code != wantCode {
+		t.Fatalf("SendMessageBatch error code = %q, want %s", code, wantCode)
 	}
 
 	_, delErr := client.DeleteMessageBatch(ctx, &awssqs.DeleteMessageBatchInput{
 		QueueUrl: aws.String(url),
 		Entries:  []types.DeleteMessageBatchRequestEntry{},
 	})
-	if code := apiErrorCode(t, delErr); code != "EmptyBatchRequest" {
-		t.Fatalf("DeleteMessageBatch error code = %q, want EmptyBatchRequest", code)
+	if code := apiErrorCode(t, delErr); code != wantCode {
+		t.Fatalf("DeleteMessageBatch error code = %q, want %s", code, wantCode)
 	}
 
 	_, visErr := client.ChangeMessageVisibilityBatch(ctx, &awssqs.ChangeMessageVisibilityBatchInput{
 		QueueUrl: aws.String(url),
 		Entries:  []types.ChangeMessageVisibilityBatchRequestEntry{},
 	})
-	if code := apiErrorCode(t, visErr); code != "EmptyBatchRequest" {
-		t.Fatalf("ChangeMessageVisibilityBatch error code = %q, want EmptyBatchRequest", code)
+	if code := apiErrorCode(t, visErr); code != wantCode {
+		t.Fatalf("ChangeMessageVisibilityBatch error code = %q, want %s", code, wantCode)
 	}
 }
 

--- a/server/aws/sqs/handler.go
+++ b/server/aws/sqs/handler.go
@@ -22,15 +22,31 @@ import (
 
 const targetPrefix = "AmazonSQS."
 
-// errNonExistentQueue is the __type value for a missing queue. Modern SQS speaks
-// AwsJson1_0, where the SDK resolves the error shape from __type: "QueueDoesNotExist"
-// is the modeled shape name, so it deserializes into the typed sqs types
-// QueueDoesNotExist that the aws-sdk-go-v2 / Terraform delete waiter matches on
-// (via errs.IsA and ErrorCode()=="QueueDoesNotExist"). Do NOT change this to the
-// legacy query-protocol code "AWS.SimpleQueueService.NonExistentQueue" — as a JSON
-// __type it matches no modeled shape, dropping the SDK back to a generic error the
-// waiter does not recognize, so destroy hangs.
+// errNonExistentQueue is the __type value for a missing queue: "QueueDoesNotExist"
+// is the modeled AwsJson1_0 shape name, letting the SDK deserialize the body into
+// the typed sqs types.QueueDoesNotExist exception. SQS additionally carries the
+// "awsQueryCompatible" trait (it spoke the legacy Query/XML protocol before
+// migrating to AwsJson1_0), so aws-sdk-go-v2 also reads an X-Amzn-Query-Error
+// response header and uses it to override ErrorCode() back to the original
+// Query-protocol code. Tools that match on that legacy code — including
+// terraform-provider-aws's SQS delete/create waiters (errCodeQueueDoesNotExist =
+// "AWS.SimpleQueueService.NonExistentQueue") — need both: the __type for the SDK
+// to build the typed exception, and the header for ErrorCode() to resolve to the
+// code they actually check. See errQueryCodeNonExistentQueue.
 const errNonExistentQueue = "QueueDoesNotExist"
+
+// SQS's awsQueryCompatible legacy Query-protocol error codes, carried in the
+// X-Amzn-Query-Error response header alongside each JSON __type (see
+// errNonExistentQueue). Sourced from the SQS service model's per-shape
+// "error.code" (botocore sqs/2012-11-05/service-2.json); "Sender" marks a
+// client-fault error, matching every code below.
+const (
+	errQueryCodeNonExistentQueue    = "AWS.SimpleQueueService.NonExistentQueue;Sender"
+	errQueryCodeQueueAlreadyExists  = "QueueAlreadyExists;Sender"
+	errQueryCodeEmptyBatchRequest   = "AWS.SimpleQueueService.EmptyBatchRequest;Sender"
+	errQueryCodeTooManyBatchEntries = "AWS.SimpleQueueService.TooManyEntriesInBatchRequest;Sender"
+	errQueryCodeBatchIDsNotDistinct = "AWS.SimpleQueueService.BatchEntryIdsNotDistinct;Sender"
+)
 
 // Handler serves SQS JSON-RPC requests against a messagequeue.MessageQueue
 // driver.
@@ -170,8 +186,8 @@ func (h *Handler) getQueueURL(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	wire.WriteJSONError(w, http.StatusBadRequest,
-		errNonExistentQueue, "queue not found: "+req.QueueName)
+	wire.WriteJSONErrorQueryCompat(w, http.StatusBadRequest,
+		errNonExistentQueue, errQueryCodeNonExistentQueue, "queue not found: "+req.QueueName)
 }
 
 func (h *Handler) listQueues(w http.ResponseWriter, r *http.Request) {
@@ -1141,9 +1157,9 @@ func (h *Handler) purgeQueue(w http.ResponseWriter, r *http.Request) {
 func writeErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, errNonExistentQueue, err.Error())
+		wire.WriteJSONErrorQueryCompat(w, http.StatusBadRequest, errNonExistentQueue, errQueryCodeNonExistentQueue, err.Error())
 	case cerrors.IsAlreadyExists(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "QueueNameExists", err.Error())
+		wire.WriteJSONErrorQueryCompat(w, http.StatusBadRequest, "QueueNameExists", errQueryCodeQueueAlreadyExists, err.Error())
 	case cerrors.IsInvalidArgument(err):
 		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterValue", err.Error())
 	default:

--- a/server/aws/sqs/queue_semantics_test.go
+++ b/server/aws/sqs/queue_semantics_test.go
@@ -58,8 +58,13 @@ func TestSDKSQSCreateQueueIdempotent(t *testing.T) {
 		QueueName:  aws.String("idem-q"),
 		Attributes: map[string]string{"VisibilityTimeout": "99"},
 	})
-	if code := apiErrorCode(t, err); code != "QueueNameExists" {
-		t.Fatalf("re-create with different attributes: error code = %q, want QueueNameExists", code)
+	// SQS carries the "awsQueryCompatible" trait: aws-sdk-go-v2 overrides
+	// ErrorCode() to the legacy Query-protocol code ("QueueAlreadyExists") from
+	// the X-Amzn-Query-Error header, not the AwsJson1_0 shape name
+	// ("QueueNameExists").
+	const wantCode = "QueueAlreadyExists"
+	if code := apiErrorCode(t, err); code != wantCode {
+		t.Fatalf("re-create with different attributes: error code = %q, want %s", code, wantCode)
 	}
 }
 

--- a/server/aws/sqs/request_validation.go
+++ b/server/aws/sqs/request_validation.go
@@ -33,14 +33,14 @@ const (
 // and reports false when the batch is rejected, so callers enqueue nothing.
 func validateBatchEntryIDs(w http.ResponseWriter, ids []string) bool {
 	if len(ids) == 0 {
-		wire.WriteJSONError(w, http.StatusBadRequest, "EmptyBatchRequest",
+		wire.WriteJSONErrorQueryCompat(w, http.StatusBadRequest, "EmptyBatchRequest", errQueryCodeEmptyBatchRequest,
 			"The batch request doesn't contain any entries.")
 
 		return false
 	}
 
 	if len(ids) > maxBatchEntries {
-		wire.WriteJSONError(w, http.StatusBadRequest, "TooManyEntriesInBatchRequest",
+		wire.WriteJSONErrorQueryCompat(w, http.StatusBadRequest, "TooManyEntriesInBatchRequest", errQueryCodeTooManyBatchEntries,
 			fmt.Sprintf("Maximum number of entries per request are %d. You have sent %d.", maxBatchEntries, len(ids)))
 
 		return false
@@ -50,7 +50,7 @@ func validateBatchEntryIDs(w http.ResponseWriter, ids []string) bool {
 
 	for _, id := range ids {
 		if _, dup := seen[id]; dup {
-			wire.WriteJSONError(w, http.StatusBadRequest, "BatchEntryIdsNotDistinct",
+			wire.WriteJSONErrorQueryCompat(w, http.StatusBadRequest, "BatchEntryIdsNotDistinct", errQueryCodeBatchIDsNotDistinct,
 				fmt.Sprintf("Id %s repeated.", id))
 
 			return false

--- a/server/wire/wire.go
+++ b/server/wire/wire.go
@@ -57,6 +57,28 @@ func WriteJSONError(w http.ResponseWriter, status int, errType, msg string) {
 	})
 }
 
+// WriteJSONErrorQueryCompat writes a JSON error response like WriteJSONError,
+// plus the X-Amzn-Query-Error header that AWS services migrated from the
+// legacy Query protocol to AwsJson (the "awsQueryCompatible" Smithy trait)
+// emit on every error response. Real aws-sdk-go-v2 exception types read this
+// header to override their ErrorCode() back to the original Query-protocol
+// code (e.g. "AWS.SimpleQueueService.NonExistentQueue" instead of the JSON
+// shape name "QueueDoesNotExist"); tools that still match on the legacy code
+// — including terraform-provider-aws's SQS delete/create waiters — rely on
+// it, so omitting it leaves those SDK code paths unable to recognize the
+// error at all. queryCode must be "<legacy code>;Sender" or
+// "<legacy code>;Receiver", matching the header's documented format.
+func WriteJSONErrorQueryCompat(w http.ResponseWriter, status int, errType, queryCode, msg string) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+	w.Header().Set("x-amzn-query-error", queryCode)
+	w.WriteHeader(status)
+
+	json.NewEncoder(w).Encode(map[string]string{ //nolint:errcheck // best-effort response
+		"__type":  errType,
+		"Message": msg,
+	})
+}
+
 // WriteJSONErrorFields writes a JSON error response carrying additional
 // top-level members alongside __type and Message. DynamoDB uses this for
 // ConditionalCheckFailedException, which returns the conflicting item in an


### PR DESCRIPTION
## Summary
- SQS carries the "awsQueryCompatible" Smithy trait (kept for backward compatibility after migrating off the legacy Query/XML protocol): every error response should carry an `X-Amzn-Query-Error: <legacy-code>;Sender` header alongside the JSON `__type`. aws-sdk-go-v2's generated exception types read that header to resolve `ErrorCode()` back to the legacy code, and terraform-provider-aws's own SQS delete/create waiters (and `tfawserr`-style matchers generally) check exactly that legacy code, not the JSON shape name.
- CloudEmu never sent this header, so `ErrorCode()` always resolved to the bare AwsJson1_0 shape name instead — most visibly breaking `terraform destroy` on an `aws_sqs_queue` (the delete waiter never recognized "queue is gone" and errored out instead of completing).
- Adds `wire.WriteJSONErrorQueryCompat` and switches the affected SQS paths (`GetQueueUrl`/`GetQueueAttributes` NotFound, `CreateQueue` AlreadyExists, and the three batch-validation errors) to send the correct legacy code, matching each shape's `error.code` in the botocore SQS service model.

## Test plan
- [x] `go build ./...`
- [x] `go test ./providers/aws/sqs/... ./server/aws/sqs/... ./server/wire/... -race` (existing tests updated to assert the now-correct `ErrorCode()` values)
- [x] `GOMAXPROCS=3 go test ./...` — 332 packages, 0 failures
- [x] `gofmt -l` clean; `golangci-lint run ./server/aws/sqs/... ./server/wire/...` — 0 issues
- [x] Black-box re-verify against a rebuilt `cloudemu serve` binary:
  - `terraform apply` (standard + FIFO queue, DLQ redrive policy, tags) → `terraform plan` (no diff) → `terraform destroy -auto-approve`: now completes cleanly (`Destroy complete! Resources: 4 destroyed.`) in ~10s, vs. a hard failure before the fix (`Error: waiting for SQS Queue (...) delete: ... QueueDoesNotExist: NotFound: queue "..." not found`)
  - `aws sqs create-queue` twice with conflicting attributes: now reports `QueueAlreadyExists` (was `QueueNameExists`)
  - `aws sqs get-queue-url` for a missing queue: now reports `AWS.SimpleQueueService.NonExistentQueue` (was `QueueDoesNotExist`)
  - `aws sqs send-message-batch` with a duplicate entry Id: now reports `AWS.SimpleQueueService.BatchEntryIdsNotDistinct` (was `BatchEntryIdsNotDistinct`)