### PR TITLE
fix(sqs): query-compat error code for message-move-task operations

### DIFF
--- a/server/aws/sqs/handler.go
+++ b/server/aws/sqs/handler.go
@@ -41,11 +41,12 @@ const errNonExistentQueue = "QueueDoesNotExist"
 // "error.code" (botocore sqs/2012-11-05/service-2.json); "Sender" marks a
 // client-fault error, matching every code below.
 const (
-	errQueryCodeNonExistentQueue    = "AWS.SimpleQueueService.NonExistentQueue;Sender"
-	errQueryCodeQueueAlreadyExists  = "QueueAlreadyExists;Sender"
-	errQueryCodeEmptyBatchRequest   = "AWS.SimpleQueueService.EmptyBatchRequest;Sender"
-	errQueryCodeTooManyBatchEntries = "AWS.SimpleQueueService.TooManyEntriesInBatchRequest;Sender"
-	errQueryCodeBatchIDsNotDistinct = "AWS.SimpleQueueService.BatchEntryIdsNotDistinct;Sender"
+	errQueryCodeNonExistentQueue     = "AWS.SimpleQueueService.NonExistentQueue;Sender"
+	errQueryCodeQueueAlreadyExists   = "QueueAlreadyExists;Sender"
+	errQueryCodeEmptyBatchRequest    = "AWS.SimpleQueueService.EmptyBatchRequest;Sender"
+	errQueryCodeTooManyBatchEntries  = "AWS.SimpleQueueService.TooManyEntriesInBatchRequest;Sender"
+	errQueryCodeBatchIDsNotDistinct  = "AWS.SimpleQueueService.BatchEntryIdsNotDistinct;Sender"
+	errQueryCodeUnsupportedOperation = "AWS.SimpleQueueService.UnsupportedOperation;Sender"
 )
 
 // Handler serves SQS JSON-RPC requests against a messagequeue.MessageQueue
@@ -923,7 +924,8 @@ func writeMoveTaskErr(w http.ResponseWriter, err error) {
 	case cerrors.IsNotFound(err):
 		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", err.Error())
 	case cerrors.IsFailedPrecondition(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "UnsupportedOperation", err.Error())
+		wire.WriteJSONErrorQueryCompat(w, http.StatusBadRequest,
+			"UnsupportedOperation", errQueryCodeUnsupportedOperation, err.Error())
 	case cerrors.IsInvalidArgument(err):
 		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterValue", err.Error())
 	default:

--- a/server/aws/sqs/queue_semantics_test.go
+++ b/server/aws/sqs/queue_semantics_test.go
@@ -179,3 +179,22 @@ func TestSDKSQSSendMessageTooLong(t *testing.T) {
 		t.Fatalf("oversize SendMessage: error code = %q, want InvalidParameterValue", code)
 	}
 }
+
+// GetQueueUrl for a missing queue carries the "awsQueryCompatible" legacy
+// Query-protocol error code in the X-Amzn-Query-Error header, which
+// aws-sdk-go-v2 uses to resolve ErrorCode() -- pinning it here guards against
+// a regression to the AwsJson1_0 shape name ("QueueDoesNotExist") that
+// TestSDKSQSDeleteQueue separately checks via the typed exception.
+func TestSDKSQSGetQueueUrlNotFoundErrorCode(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.GetQueueUrl(ctx, &awssqs.GetQueueUrlInput{
+		QueueName: aws.String("does-not-exist"),
+	})
+
+	const wantCode = "AWS.SimpleQueueService.NonExistentQueue"
+	if code := apiErrorCode(t, err); code != wantCode {
+		t.Fatalf("GetQueueUrl on missing queue: error code = %q, want %s", code, wantCode)
+	}
+}


### PR DESCRIPTION
## Summary

Two follow-ups from #1045's awsQueryCompatible fix for SQS:

1. `writeMoveTaskErr()` in `server/aws/sqs/handler.go` (used by `StartMessageMoveTask`/`CancelMessageMoveTask`/`ListMessageMoveTasks`) emitted a bare `wire.WriteJSONError` for the `FailedPrecondition` -> `UnsupportedOperation` case, missing the `X-Amzn-Query-Error` header the other 5 error paths already carry. Switched it to `wire.WriteJSONErrorQueryCompat` with legacy code `AWS.SimpleQueueService.UnsupportedOperation;Sender`, matching the `UnsupportedOperation` shape's real SQS behavior and #1045's established pattern.
2. Added an SDK-level test (`TestSDKSQSGetQueueUrlNotFoundErrorCode` in `queue_semantics_test.go`) pinning `GetQueueUrl` on a missing queue to `smithy.APIError.ErrorCode() == "AWS.SimpleQueueService.NonExistentQueue"`, closing the gap where only the typed-exception path (`errors.As` against `*types.QueueDoesNotExist`) was covered.

## Re-verification

- `GetQueueUrl` on a missing queue still returns `X-Amzn-Query-Error: AWS.SimpleQueueService.NonExistentQueue;Sender` (confirmed via raw JSON API call against a running `cloudemu serve -providers=aws`).
- The `UnsupportedOperation`/`FailedPrecondition` branch in `writeMoveTaskErr` is currently unreachable from any real SQS input: `StartMessageMoveTask`'s `rejectActiveMoveTask` only rejects when an existing task's status is `RUNNING`, but cloudemu processes moves synchronously and only ever records tasks as `COMPLETED`/`FAILED` -- `RUNNING` is never assigned. Confirmed empirically with 20 concurrent `StartMessageMoveTask` calls against the same source ARN: all 20 succeeded, none hit the "already running" precondition. A scratch (uncommitted) unit test calling `writeMoveTaskErr` directly with a synthetic `FailedPrecondition` error confirmed the fix itself is correct: HTTP 400, `__type: "UnsupportedOperation"`, header `X-Amzn-Query-Error: AWS.SimpleQueueService.UnsupportedOperation;Sender`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./server/aws/sqs/... ./server/wire/... -race -count=1`
- [x] `gofmt -l` on changed files (clean)
- [x] `golangci-lint run --timeout=9m ./server/aws/sqs/... ./server/wire/...` (0 issues)
- [x] `go generate ./... && git diff --exit-code docs/coverage` (no diff)
- [x] `go mod tidy` (no-op)