### PR TITLE
fix(ec2): empty user_data, default VPC seeding, public EIP addresses

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -7615,14 +7615,15 @@ func TestInternetGatewayAWS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify gone.
+	// Verify gone: only the account/region's seeded default internet gateway
+	// (attached to the seeded default VPC) remains.
 	igws, err = p.VPC.DescribeInternetGateways(ctx, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(igws) != 0 {
-		t.Errorf("expected 0 igws, got %d", len(igws))
+	if len(igws) != 1 {
+		t.Errorf("expected 1 igw (the seeded default), got %d", len(igws))
 	}
 }
 

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -624,9 +624,11 @@ func (m *Mock) launchInstances(ctx context.Context, cfg driver.InstanceConfig, c
 	// One reservation groups every instance launched by this call (AWS r-xxxx).
 	reservationID := idgen.GenerateID(reservationPrefix)
 
-	// Resolve the target subnet once so both the VPC id and the CIDR-scoped
-	// private-IP allocation reuse a single lookup.
-	vpcID, subnetCIDR := m.resolveSubnet(ctx, cfg.SubnetID)
+	// Resolve the target subnet once so the resolved subnet id, the VPC id, and
+	// the CIDR-scoped private-IP allocation all reuse a single lookup. An empty
+	// cfg.SubnetID resolves to the account/region's default subnet, matching
+	// real EC2.
+	subnetID, vpcID, subnetCIDR := m.resolveSubnet(ctx, cfg.SubnetID)
 
 	// Resolve the IamInstanceProfile reference once for the whole batch; every
 	// instance launched by this call shares the same profile association. A
@@ -657,8 +659,8 @@ func (m *Mock) launchInstances(ctx context.Context, cfg driver.InstanceConfig, c
 
 		inst := &instanceData{
 			ID: id, ImageID: cfg.ImageID, InstanceType: cfg.InstanceType,
-			State: compute.StatePending, PrivateIP: m.allocatePrivateIP(cfg.SubnetID, subnetCIDR),
-			SubnetID: cfg.SubnetID, VPCID: vpcID,
+			State: compute.StatePending, PrivateIP: m.allocatePrivateIP(subnetID, subnetCIDR),
+			SubnetID: subnetID, VPCID: vpcID,
 			SecurityGroups: sg, Tags: tags,
 			LaunchTime:         m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
 			sourceDestCheck:    true,
@@ -719,7 +721,7 @@ func (m *Mock) launchInstances(ctx context.Context, cfg driver.InstanceConfig, c
 		// interface. vpcID is non-empty only when the subnet resolved, which is
 		// exactly when the networking mock can place the interface.
 		if vpcID != "" {
-			m.materializePrimaryENI(ctx, id, cfg.SubnetID, sg)
+			m.materializePrimaryENI(ctx, id, subnetID, sg)
 		}
 
 		// Materialize the instance's root EBS volume (and any client-supplied
@@ -808,20 +810,32 @@ func (m *Mock) renderInstancesByID(ids []string) []driver.Instance {
 	return out
 }
 
-// resolveSubnet returns the VPC that owns subnetID and the subnet's CIDR block
-// in a single resolver lookup. Both are "" when there is no subnet, no resolver,
-// or the subnet can't be found.
-func (m *Mock) resolveSubnet(ctx context.Context, subnetID string) (vpcID, cidr string) {
-	if subnetID == "" || m.subnetResolver == nil {
-		return "", ""
+// resolveSubnet returns the subnet a launch actually lands in, the VPC that
+// owns it, and its CIDR block, in a single resolver lookup. When subnetID is
+// "" it resolves to the account/region's default subnet, matching real EC2
+// (an instance launched with no SubnetId lands in the default VPC's default
+// subnet, not with a blank subnet/VPC). resolvedSubnetID, vpcID and cidr are
+// all "" when there is no resolver, no subnet/default subnet found.
+func (m *Mock) resolveSubnet(ctx context.Context, subnetID string) (resolvedSubnetID, vpcID, cidr string) {
+	if m.subnetResolver == nil {
+		return subnetID, "", ""
+	}
+
+	if subnetID == "" {
+		def, ok := m.defaultSubnet(ctx)
+		if !ok {
+			return "", "", ""
+		}
+
+		return def.ID, def.VPCID, def.CIDRBlock
 	}
 
 	subs, err := m.subnetResolver.DescribeSubnets(ctx, []string{subnetID})
 	if err != nil || len(subs) == 0 {
-		return "", ""
+		return subnetID, "", ""
 	}
 
-	return subs[0].VPCID, subs[0].CIDRBlock
+	return subnetID, subs[0].VPCID, subs[0].CIDRBlock
 }
 
 // materializePrimaryENI asks the networking mock to create the instance's eth0

--- a/providers/aws/ec2/subnet_resolver.go
+++ b/providers/aws/ec2/subnet_resolver.go
@@ -19,3 +19,33 @@ type SubnetResolver interface {
 func (m *Mock) SetSubnetResolver(r SubnetResolver) {
 	m.subnetResolver = r
 }
+
+// defaultSubnet returns the account/region's default subnet — the one a
+// RunInstances call with no SubnetId lands in, matching real EC2. Real EC2
+// picks a default subnet deterministically (its own internal ordering); this
+// picks the lowest subnet id among the default VPC's default subnets, which is
+// stable across calls for the same seeded state.
+func (m *Mock) defaultSubnet(ctx context.Context) (netdriver.SubnetInfo, bool) {
+	subs, err := m.subnetResolver.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return netdriver.SubnetInfo{}, false
+	}
+
+	var best *netdriver.SubnetInfo
+
+	for i := range subs {
+		if !subs[i].IsDefault {
+			continue
+		}
+
+		if best == nil || subs[i].ID < best.ID {
+			best = &subs[i]
+		}
+	}
+
+	if best == nil {
+		return netdriver.SubnetInfo{}, false
+	}
+
+	return *best, true
+}

--- a/providers/aws/vpc/elastic_ip.go
+++ b/providers/aws/vpc/elastic_ip.go
@@ -2,11 +2,38 @@ package vpc
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
+
+// eipPublicIPBase is the first octet pair of the RFC 2544 benchmarking range
+// (198.18.0.0/15) elastic IPs are allocated from. Real EIPs are publicly
+// routable addresses; unlike mockPublicIP (used for NAT gateways' private-side
+// address, which is deliberately RFC1918-looking), an Elastic IP must not look
+// like a private address to a caller inspecting it. 198.18.0.0/15 is reserved
+// by IANA for network-device benchmarking, so it is guaranteed non-RFC1918 and
+// safely non-routable, while still spanning enough addresses (two full /16s) to
+// keep the same two-octet spread mockPublicIP uses.
+const eipPublicIPBase = 18
+
+// mockElasticPublicIP deterministically derives a public-looking IPv4 address
+// for an Elastic IP from its allocation id, the same character-sum scheme
+// mockPublicIP uses for private-looking addresses.
+func mockElasticPublicIP(id string) string {
+	var sum int
+	for _, c := range id {
+		sum += int(c)
+	}
+
+	secondOctet := eipPublicIPBase + (sum/(maxOctetValue*maxOctetValue))%2
+	octet3 := (sum / maxOctetValue) % maxOctetValue
+	octet4 := sum % maxOctetValue
+
+	return fmt.Sprintf("198.%d.%d.%d", secondOctet, octet3, octet4)
+}
 
 type eipData struct {
 	AllocationID       string
@@ -28,7 +55,7 @@ func (m *Mock) AllocateAddress(
 
 	eip := &eipData{
 		AllocationID: allocID,
-		PublicIP:     mockPublicIP(allocID),
+		PublicIP:     mockElasticPublicIP(allocID),
 		Tags:         copyTags(cfg.Tags),
 	}
 	m.eips.Set(allocID, eip)

--- a/providers/aws/vpc/networking_parity_test.go
+++ b/providers/aws/vpc/networking_parity_test.go
@@ -660,9 +660,11 @@ func TestIPAMFullProvider(t *testing.T) {
 		t.Fatalf("CreateIpam default RD: %v %+v", err, ipam)
 	}
 
-	// Resource CIDRs + history derive from the VPC/subnet.
+	// Resource CIDRs + history derive from every VPC/subnet: the VPC+subnet
+	// created here, plus the seeded account/region default VPC and its 3
+	// default subnets (1+1 + 1+3 = 6).
 	rc, err := m.GetIpamResourceCidrs(ctx, ipam.PrivateDefaultScopeID, "")
-	if err != nil || len(rc) != 2 {
+	if err != nil || len(rc) != 6 {
 		t.Fatalf("GetIpamResourceCidrs: %v %+v", err, rc)
 	}
 
@@ -694,7 +696,8 @@ func TestIPAMFullProvider(t *testing.T) {
 		t.Fatalf("GetIpamDiscoveredAccounts: %+v", accts)
 	}
 
-	if dcidrs, _ := m.GetIpamDiscoveredResourceCidrs(ctx, ipam.DefaultResourceDiscoveryID, ""); len(dcidrs) != 2 {
+	// Same 6 resources as GetIpamResourceCidrs above (discovery is unfiltered).
+	if dcidrs, _ := m.GetIpamDiscoveredResourceCidrs(ctx, ipam.DefaultResourceDiscoveryID, ""); len(dcidrs) != 6 {
 		t.Fatalf("GetIpamDiscoveredResourceCidrs: %+v", dcidrs)
 	}
 

--- a/providers/aws/vpc/route_table.go
+++ b/providers/aws/vpc/route_table.go
@@ -12,7 +12,8 @@ import (
 
 // Route target type constants.
 const (
-	RouteTargetLocal = "local"
+	RouteTargetLocal   = "local"
+	RouteTargetGateway = "gateway"
 )
 
 // Route-target not-found markers. A CreateRoute pointing at a gateway / NAT /

--- a/providers/aws/vpc/snapshot.go
+++ b/providers/aws/vpc/snapshot.go
@@ -252,6 +252,16 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 		return fmt.Errorf("vpc: parse snapshot: %w", err)
 	}
 
+	// restoreStores merges the snapshot into each store's existing entries (see
+	// memstore.Store.LoadSnapshot), it does not replace them. New() already
+	// seeded this fresh Mock with an account/region default VPC (and its default
+	// subnets/SG/ACL/route table/IGW) before Restore is ever called, so without
+	// clearing that seed first, restoring a snapshot that itself carries a
+	// default VPC (every snapshotted Mock has one) would leave two. Every caller
+	// constructs a fresh Mock and restores into it immediately, so it is safe to
+	// drop the seed here: the snapshot is always the authoritative full state.
+	m.clearDefaultVPCSeed()
+
 	m.restoreENIs(snap.ENIs)
 
 	if err := m.restoreStores(&snap); err != nil {
@@ -261,6 +271,21 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 	m.restoreScalarState(&snap)
 
 	return nil
+}
+
+// clearDefaultVPCSeed empties exactly the stores seedDefaultVPC populates on a
+// fresh Mock (see New()), so Restore's merge-based restoreStores starts from
+// nothing for those stores instead of layering the snapshot's own default VPC
+// on top of this Mock's freshly-seeded one.
+func (m *Mock) clearDefaultVPCSeed() {
+	m.vpcs.Clear()
+	m.subnets.Clear()
+	m.securityGroups.Clear()
+	m.networkACLs.Clear()
+	m.aclAssocs.Clear()
+	m.routeTables.Clear()
+	m.rtAssocs.Clear()
+	m.igws.Clear()
 }
 
 // restoreENIs reinstates each ENI under its original id.

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -28,6 +28,9 @@ const (
 	// above any real subnet (the widest EC2 allows is a /16, 16 host bits) yet
 	// keeps 1<<hostBits within int range on every platform.
 	maxSubnetHostBits = 30
+	// stateAvailable is the "ready for use" state name shared by VPCs, subnets,
+	// and most VPC resources.
+	stateAvailable = "available"
 )
 
 // VPC IPv4 CIDR netmask bounds. EC2 requires a VPC block between a /16 and a
@@ -194,6 +197,9 @@ type vpcData struct {
 	EnableDNSHostnames bool
 	DhcpOptionsID      string
 	InstanceTenancy    string
+	// IsDefault marks the account/region's auto-created default VPC. See
+	// driver.VPCInfo.IsDefault.
+	IsDefault bool
 }
 
 type subnetData struct {
@@ -204,6 +210,9 @@ type subnetData struct {
 	State               string
 	Tags                map[string]string
 	MapPublicIPOnLaunch bool
+	// IsDefault marks a default subnet of the default VPC. See
+	// driver.SubnetInfo.IsDefault.
+	IsDefault bool
 }
 
 type sgData struct {
@@ -221,7 +230,7 @@ type sgData struct {
 
 // New creates a new VPC mock with the given configuration options.
 func New(opts *config.Options) *Mock {
-	return &Mock{
+	m := &Mock{
 		vpcs:           memstore.New[*vpcData](),
 		subnets:        memstore.New[*subnetData](),
 		securityGroups: memstore.New[*sgData](),
@@ -284,6 +293,91 @@ func New(opts *config.Options) *Mock {
 		eniIPCounters:         map[string]int{},
 
 		opts: opts,
+	}
+
+	m.seedDefaultVPC()
+
+	return m
+}
+
+// defaultVPCCIDR is the CIDR block real EC2 gives the default VPC it
+// auto-creates in every region on account creation.
+const defaultVPCCIDR = "172.31.0.0/16"
+
+// defaultSubnetCIDRs are the default VPC's per-AZ /20 default subnets, matching
+// real EC2's split of 172.31.0.0/16.
+//
+//nolint:gochecknoglobals // read-only seed data, never mutated after init
+var defaultSubnetCIDRs = []string{"172.31.0.0/20", "172.31.16.0/20", "172.31.32.0/20"}
+
+// defaultSubnetAZs names the zones the seeded default subnets land in.
+// cloudemu models a single implicit account/region per Mock rather than
+// partitioning state by region, and "us-east-1" is the fallback region already
+// used wherever a caller's request carries no explicit one (see
+// server/aws/ec2's regionFromRequest), so the default subnets reuse that
+// region's zone names for consistency with the rest of the emulator.
+//
+//nolint:gochecknoglobals // read-only seed data, never mutated after init
+var defaultSubnetAZs = []string{"us-east-1a", "us-east-1b", "us-east-1c"}
+
+// seedDefaultVPC gives the account/region its default VPC, matching what every
+// real AWS account has from creation: a 172.31.0.0/16 VPC with default=true,
+// one /20 default subnet per AZ (mapPublicIpOnLaunch on), a default security
+// group, a default network ACL, a main route table, and an attached internet
+// gateway with a 0.0.0.0/0 route (the default VPC is public by default, unlike
+// a VPC created via CreateVPC). Terraform's `data "aws_vpc" "default" {}` and a
+// RunInstances call that omits a subnet both depend on this existing without
+// the caller having to create it.
+//
+// Called once from New(), before the Mock is handed to any caller, so no
+// locking is needed here: nothing else can observe the stores mid-seed.
+func (m *Mock) seedDefaultVPC() {
+	vpcID := idgen.GenerateID("vpc-")
+
+	m.vpcs.Set(vpcID, &vpcData{
+		ID:               vpcID,
+		CIDRBlock:        defaultVPCCIDR,
+		State:            stateAvailable,
+		Tags:             map[string]string{},
+		EnableDNSSupport: true,
+		InstanceTenancy:  tenancyDefault,
+		IsDefault:        true,
+	})
+
+	m.createDefaultSecurityGroup(vpcID)
+	m.createDefaultNetworkACL(vpcID)
+	rtID := m.createMainRouteTable(vpcID, defaultVPCCIDR)
+
+	for i, cidr := range defaultSubnetCIDRs {
+		subID := idgen.GenerateID("subnet-")
+		m.subnets.Set(subID, &subnetData{
+			ID:                  subID,
+			VPCID:               vpcID,
+			CIDRBlock:           cidr,
+			AvailabilityZone:    defaultSubnetAZs[i],
+			State:               stateAvailable,
+			Tags:                map[string]string{},
+			MapPublicIPOnLaunch: true,
+			IsDefault:           true,
+		})
+		m.associateDefaultNetworkACL(vpcID, subID)
+	}
+
+	igwID := idgen.GenerateID("igw-")
+	m.igws.Set(igwID, &igwData{
+		ID:    igwID,
+		VpcID: vpcID,
+		State: IGWStateAttached,
+		Tags:  map[string]string{},
+	})
+
+	if rt, ok := m.routeTables.Get(rtID); ok {
+		rt.Routes = append(rt.Routes, driver.Route{
+			DestinationCIDR: "0.0.0.0/0",
+			TargetID:        igwID,
+			TargetType:      RouteTargetGateway,
+			State:           "active",
+		})
 	}
 }
 
@@ -351,10 +445,13 @@ func (m *Mock) createDefaultSecurityGroup(vpcID string) {
 }
 
 // createMainRouteTable gives the new VPC the route table EC2 creates for it,
-// carrying the local route and an implicit main association. Callers list a
-// VPC's route tables during teardown and skip the main one, so its absence is
-// visible: it makes every VPC look like it has one fewer table than it does.
-func (m *Mock) createMainRouteTable(vpcID, cidr string) {
+// carrying the local route and an implicit main association, and returns its
+// id so a caller that needs to add further routes (the default VPC's public
+// route to its internet gateway) does not have to look it back up. Callers
+// list a VPC's route tables during teardown and skip the main one, so its
+// absence is visible: it makes every VPC look like it has one fewer table than
+// it does.
+func (m *Mock) createMainRouteTable(vpcID, cidr string) string {
 	rtID := idgen.GenerateID("rtb-")
 
 	m.routeTables.Set(rtID, &routeTableData{
@@ -375,6 +472,8 @@ func (m *Mock) createMainRouteTable(vpcID, cidr string) {
 		RouteTableID: rtID,
 		Main:         true,
 	})
+
+	return rtID
 }
 
 // DeleteVPC deletes the VPC with the given ID.
@@ -1205,6 +1304,7 @@ func toVPCInfo(v *vpcData) driver.VPCInfo {
 		EnableDNSHostnames: v.EnableDNSHostnames,
 		DhcpOptionsID:      v.DhcpOptionsID,
 		InstanceTenancy:    v.InstanceTenancy,
+		IsDefault:          v.IsDefault,
 	}
 }
 
@@ -1217,6 +1317,7 @@ func toSubnetInfo(s *subnetData) driver.SubnetInfo {
 		State:               s.State,
 		Tags:                copyTags(s.Tags),
 		MapPublicIPOnLaunch: s.MapPublicIPOnLaunch,
+		IsDefault:           s.IsDefault,
 	}
 }
 

--- a/providers/aws/vpc/vpc_test.go
+++ b/providers/aws/vpc/vpc_test.go
@@ -2,6 +2,7 @@ package vpc
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
@@ -123,9 +124,19 @@ func TestDescribeVPCs(t *testing.T) {
 	v2 := createTestVPC(m)
 
 	t.Run("all", func(t *testing.T) {
+		// DescribeVPCs(nil) also returns the account/region's seeded default VPC,
+		// so this checks both created VPCs are present rather than an exact count.
 		vpcs, err := m.DescribeVPCs(ctx, nil)
 		requireNoError(t, err)
-		assertEqual(t, 2, len(vpcs))
+
+		ids := map[string]bool{}
+		for _, v := range vpcs {
+			ids[v.ID] = true
+		}
+
+		if !ids[v1.ID] || !ids[v2.ID] {
+			t.Fatalf("DescribeVPCs(nil) = %v, want both %s and %s present", vpcs, v1.ID, v2.ID)
+		}
 	})
 
 	t.Run("by ID", func(t *testing.T) {
@@ -201,12 +212,23 @@ func TestDescribeSubnets(t *testing.T) {
 	ctx := context.Background()
 	v := createTestVPC(m)
 	s1, _ := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
-	_, _ = m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.2.0/24"})
+	s2, _ := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.2.0/24"})
 
 	t.Run("all", func(t *testing.T) {
+		// DescribeSubnets(nil) also returns the seeded default VPC's default
+		// subnets, so this checks both created subnets are present rather than an
+		// exact count.
 		subnets, err := m.DescribeSubnets(ctx, nil)
 		requireNoError(t, err)
-		assertEqual(t, 2, len(subnets))
+
+		ids := map[string]bool{}
+		for _, s := range subnets {
+			ids[s.ID] = true
+		}
+
+		if !ids[s1.ID] || !ids[s2.ID] {
+			t.Fatalf("DescribeSubnets(nil) = %v, want both %s and %s present", subnets, s1.ID, s2.ID)
+		}
 	})
 
 	t.Run("by ID", func(t *testing.T) {
@@ -296,9 +318,11 @@ func TestCreateVPCCreatesDefaultSecurityGroup(t *testing.T) {
 	ctx := context.Background()
 	v := createTestVPC(m)
 
+	// One default SG for the VPC just created, plus one for the seeded default
+	// VPC every account/region starts with.
 	sgs, err := m.DescribeSecurityGroups(ctx, nil)
 	requireNoError(t, err)
-	assertEqual(t, 1, len(sgs))
+	assertEqual(t, 2, len(sgs))
 
 	sg := defaultSG(t, m, v.ID)
 	assertEqual(t, defaultSGName, sg.Name)
@@ -341,9 +365,11 @@ func TestDeleteVPCRemovesDefaultSecurityGroup(t *testing.T) {
 
 	requireNoError(t, m.DeleteVPC(ctx, v.ID))
 
+	// Only the seeded default VPC's own default SG remains; the deleted VPC's
+	// default SG went with it.
 	sgs, err := m.DescribeSecurityGroups(ctx, nil)
 	requireNoError(t, err)
-	assertEqual(t, 0, len(sgs))
+	assertEqual(t, 1, len(sgs))
 }
 
 // TestDeleteVPCBlocksOnDependencies walks the resource types real EC2 refuses to
@@ -459,8 +485,9 @@ func TestDescribeSecurityGroups(t *testing.T) {
 	t.Run("all", func(t *testing.T) {
 		sgs, err := m.DescribeSecurityGroups(ctx, nil)
 		requireNoError(t, err)
-		// sg1 + sg2 + the VPC's auto-created default security group.
-		assertEqual(t, 3, len(sgs))
+		// sg1 + sg2 + the VPC's auto-created default security group + the seeded
+		// default VPC's own default security group.
+		assertEqual(t, 4, len(sgs))
 	})
 
 	t.Run("by ID", func(t *testing.T) {
@@ -1144,6 +1171,11 @@ func TestInternetGateway(t *testing.T) {
 	ctx := context.Background()
 	v := createTestVPC(m)
 
+	// The seeded default VPC's own attached internet gateway also exists from
+	// Mock construction, so subtests below track this IGW by the id "create IGW"
+	// returns rather than indexing a bare describe-all list.
+	var igwID string
+
 	t.Run("create IGW", func(t *testing.T) {
 		igw, err := m.CreateInternetGateway(ctx, driver.InternetGatewayConfig{
 			Tags: map[string]string{"env": "test"},
@@ -1151,43 +1183,41 @@ func TestInternetGateway(t *testing.T) {
 		requireNoError(t, err)
 		assertNotEmpty(t, igw.ID)
 		assertEqual(t, "detached", igw.State)
+		igwID = igw.ID
 	})
 
 	t.Run("describe IGWs", func(t *testing.T) {
-		igws, err := m.DescribeInternetGateways(ctx, nil)
+		igws, err := m.DescribeInternetGateways(ctx, []string{igwID})
 		requireNoError(t, err)
 		assertEqual(t, 1, len(igws))
 		assertEqual(t, "detached", igws[0].State)
 	})
 
 	t.Run("attach IGW to VPC", func(t *testing.T) {
-		igws, _ := m.DescribeInternetGateways(ctx, nil)
-		err := m.AttachInternetGateway(ctx, igws[0].ID, v.ID)
+		err := m.AttachInternetGateway(ctx, igwID, v.ID)
 		requireNoError(t, err)
 
-		igws, _ = m.DescribeInternetGateways(ctx, []string{igws[0].ID})
+		igws, _ := m.DescribeInternetGateways(ctx, []string{igwID})
 		assertEqual(t, 1, len(igws))
 		assertEqual(t, "attached", igws[0].State)
 		assertEqual(t, v.ID, igws[0].VpcID)
 	})
 
 	t.Run("detach IGW from VPC", func(t *testing.T) {
-		igws, _ := m.DescribeInternetGateways(ctx, nil)
-		err := m.DetachInternetGateway(ctx, igws[0].ID, v.ID)
+		err := m.DetachInternetGateway(ctx, igwID, v.ID)
 		requireNoError(t, err)
 
-		igws, _ = m.DescribeInternetGateways(ctx, []string{igws[0].ID})
+		igws, _ := m.DescribeInternetGateways(ctx, []string{igwID})
 		assertEqual(t, 1, len(igws))
 		assertEqual(t, "detached", igws[0].State)
 	})
 
 	t.Run("delete IGW", func(t *testing.T) {
-		igws, _ := m.DescribeInternetGateways(ctx, nil)
-		err := m.DeleteInternetGateway(ctx, igws[0].ID)
+		err := m.DeleteInternetGateway(ctx, igwID)
 		requireNoError(t, err)
 
-		igws, _ = m.DescribeInternetGateways(ctx, nil)
-		assertEqual(t, 0, len(igws))
+		_, err = m.DescribeInternetGateways(ctx, []string{igwID})
+		assertError(t, err, true)
 	})
 
 	t.Run("delete nonexistent IGW", func(t *testing.T) {
@@ -1303,6 +1333,29 @@ func TestElasticIP(t *testing.T) {
 		requireNoError(t, err)
 		assertEqual(t, 0, len(eips))
 	})
+}
+
+// TestAllocateAddressPublicIPNotPrivate pins that an allocated Elastic IP looks
+// like a real public address, not an RFC1918 private one. Real EIPs are always
+// publicly routable; a caller inspecting AllocateAddress's PublicIp and seeing
+// 10./172.16-31./192.168.x sees an obviously wrong value.
+func TestAllocateAddressPublicIPNotPrivate(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for range 10 {
+		eip, err := m.AllocateAddress(ctx, driver.ElasticIPConfig{})
+		requireNoError(t, err)
+
+		ip := net.ParseIP(eip.PublicIP)
+		if ip == nil {
+			t.Fatalf("PublicIP %q is not a valid IP", eip.PublicIP)
+		}
+
+		if ip.IsPrivate() {
+			t.Fatalf("PublicIP %q is RFC1918 private, want a public-looking address", eip.PublicIP)
+		}
+	}
 }
 
 func TestAssociateAddressNetworkInterface(t *testing.T) {

--- a/server/aws/ec2/instance_attribute_test.go
+++ b/server/aws/ec2/instance_attribute_test.go
@@ -185,6 +185,70 @@ func TestModifyUserDataRoundTrips(t *testing.T) {
 	}
 }
 
+// TestDescribeInstanceAttributeUserDataEmptyWhenUnset pins that an instance
+// launched without UserData reports it as truly empty (Value nil, matching real
+// EC2's <userData/> with no nested <value>), not the empty string. This is the
+// terraform-provider-aws aws_instance real-user regression: its Read function
+// only re-hashes user_data into state when UserData.Value != nil, so a non-nil
+// empty string causes it to re-hash the already-hashed state value on every
+// refresh (SHA1(SHA1("")) != SHA1("")), producing a permanent plan diff for
+// every aws_instance that omits user_data.
+func TestDescribeInstanceAttributeUserDataEmptyWhenUnset(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+	id := runOneInstance(t, c)
+
+	got, err := c.DescribeInstanceAttribute(ctx, &ec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String(id),
+		Attribute:  ec2types.InstanceAttributeNameUserData,
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstanceAttribute(UserData): %v", err)
+	}
+
+	if got.UserData != nil && got.UserData.Value != nil {
+		t.Fatalf("userData for an instance with no UserData = %+v, want a nil Value", got.UserData)
+	}
+}
+
+// TestRunInstancesUserDataRoundTripsAsBase64 pins that UserData set at
+// RunInstances time is readable back via DescribeInstanceAttribute, base64
+// encoded exactly as real EC2 returns it (the SDK's ModifyInstanceAttribute path
+// already had this covered; RunInstances did not: the mock stored the decoded
+// plaintext but echoed it back unencoded instead of re-encoding).
+func TestRunInstancesUserDataRoundTripsAsBase64(t *testing.T) {
+	ctx := context.Background()
+	c := newEC2Client(t)
+
+	script := []byte("#!/bin/bash\necho hello")
+
+	run, err := c.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-123"),
+		InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+		UserData:     aws.String(base64.StdEncoding.EncodeToString(script)),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+
+	id := aws.ToString(run.Instances[0].InstanceId)
+
+	got, err := c.DescribeInstanceAttribute(ctx, &ec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String(id),
+		Attribute:  ec2types.InstanceAttributeNameUserData,
+	})
+	if err != nil {
+		t.Fatalf("DescribeInstanceAttribute(UserData): %v", err)
+	}
+
+	want := base64.StdEncoding.EncodeToString(script)
+	if got.UserData == nil || aws.ToString(got.UserData.Value) != want {
+		t.Fatalf("userData not round-tripped: got %+v want %q", got.UserData, want)
+	}
+}
+
 // TestModifyEbsOptimizedRoundTrips pins that
 // ModifyInstanceAttribute(EbsOptimized=true) is honored and read back via
 // DescribeInstanceAttribute.

--- a/server/aws/ec2/internet_gateway_test.go
+++ b/server/aws/ec2/internet_gateway_test.go
@@ -90,8 +90,14 @@ func TestInternetGatewayAttachmentStateFilter(t *testing.T) {
 		t.Fatalf("AttachInternetGateway: %v", err)
 	}
 
+	// attachment.vpc-id scopes the match to this test's own VPC: the
+	// account/region's seeded default VPC also has an attached (so
+	// attachment.state=available) internet gateway, and AWS filters are ANDed.
 	out, err := c.DescribeInternetGateways(ctx, &ec2.DescribeInternetGatewaysInput{
-		Filters: []ec2types.Filter{{Name: aws.String("attachment.state"), Values: []string{"available"}}},
+		Filters: []ec2types.Filter{
+			{Name: aws.String("attachment.state"), Values: []string{"available"}},
+			{Name: aws.String("attachment.vpc-id"), Values: []string{vpcID}},
+		},
 	})
 	if err != nil {
 		t.Fatalf("DescribeInternetGateways: %v", err)
@@ -119,14 +125,23 @@ func TestDescribeInternetGatewaysPaginatesAllOnce(t *testing.T) {
 		want[aws.ToString(igw.InternetGateway.InternetGatewayId)] = 0
 	}
 
+	// Scoped to just the 3 gateways created above by id: the account/region's
+	// seeded default VPC also has an internet gateway, which an unfiltered
+	// describe would otherwise page through too.
+	ids := make([]string, 0, len(want))
+	for id := range want {
+		ids = append(ids, id)
+	}
+
 	seen := map[string]int{}
 
 	var token *string
 
 	for {
 		out, err := c.DescribeInternetGateways(ctx, &ec2.DescribeInternetGatewaysInput{
-			MaxResults: aws.Int32(1),
-			NextToken:  token,
+			InternetGatewayIds: ids,
+			MaxResults:         aws.Int32(1),
+			NextToken:          token,
 		})
 		if err != nil {
 			t.Fatalf("DescribeInternetGateways: %v", err)

--- a/server/aws/ec2/launch_template.go
+++ b/server/aws/ec2/launch_template.go
@@ -300,11 +300,15 @@ func (h *Handler) getLaunchTemplateData(w http.ResponseWriter, r *http.Request) 
 // InstanceConfig. prefix is "LaunchTemplateData".
 func parseLaunchTemplateData(form url.Values, prefix string) computedriver.InstanceConfig {
 	return computedriver.InstanceConfig{
-		ImageID:        form.Get(prefix + ".ImageId"),
-		InstanceType:   form.Get(prefix + ".InstanceType"),
-		KeyName:        form.Get(prefix + ".KeyName"),
-		SubnetID:       form.Get(prefix + ".SubnetId"),
-		UserData:       form.Get(prefix + ".UserData"),
+		ImageID:      form.Get(prefix + ".ImageId"),
+		InstanceType: form.Get(prefix + ".InstanceType"),
+		KeyName:      form.Get(prefix + ".KeyName"),
+		SubnetID:     form.Get(prefix + ".SubnetId"),
+		// UserData arrives base64-encoded, same as RunInstances' UserData param;
+		// decode it so a template-launched instance stores the same raw content
+		// an explicit RunInstances call would, and GetLaunchTemplateData/
+		// DescribeLaunchTemplateVersions can re-encode it consistently.
+		UserData:       decodeUserData(form.Get(prefix + ".UserData")),
 		SecurityGroups: awsquery.ListStrings(form, prefix+".SecurityGroupId"),
 	}
 }
@@ -342,7 +346,7 @@ func toLaunchTemplateDataXML(cfg computedriver.InstanceConfig) launchTemplateDat
 		InstanceType:     cfg.InstanceType,
 		KeyName:          cfg.KeyName,
 		SubnetID:         cfg.SubnetID,
-		UserData:         cfg.UserData,
+		UserData:         encodeUserData(cfg.UserData),
 		SecurityGroupIDs: cfg.SecurityGroups,
 		TagSpec:          toTagItems(cfg.Tags),
 	}

--- a/server/aws/ec2/operations.go
+++ b/server/aws/ec2/operations.go
@@ -521,6 +521,13 @@ func (h *Handler) applyInstanceAttributes(r *http.Request, id string) error {
 		attrDisableAPIStop, attrInstanceInitiatedShutdownBehavior,
 	} {
 		if v := r.Form.Get(attrForm(name) + ".Value"); v != "" {
+			// UserData.Value arrives base64-encoded, same as RunInstances' UserData
+			// param; decode it so the mock always stores the raw content and
+			// DescribeInstanceAttribute's re-encode round-trips correctly.
+			if name == attrUserData {
+				v = decodeUserData(v)
+			}
+
 			if err := attributer.SetInstanceAttribute(r.Context(), id, name, v); err != nil {
 				return err
 			}
@@ -598,7 +605,11 @@ func setInstanceAttributeField(resp *describeInstanceAttributeResponse, attr, va
 	case attrInstanceType:
 		resp.InstanceType = &attributeValueXML{Value: val}
 	case attrUserData:
-		resp.UserData = &attributeValueXML{Value: val}
+		// Real EC2 returns UserData base64-encoded; the mock stores it decoded
+		// (matching RunInstances' UserData param), so re-encode at the wire
+		// boundary. An empty val leaves Value "" and omitempty drops the
+		// nested <value> element entirely (see attributeValueXML).
+		resp.UserData = &attributeValueXML{Value: encodeUserData(val)}
 	}
 }
 
@@ -683,6 +694,18 @@ func decodeUserData(s string) string {
 	}
 
 	return s
+}
+
+// encodeUserData base64-encodes decoded UserData for the wire, the inverse of
+// decodeUserData. An empty string stays empty rather than becoming the
+// (non-empty) base64 encoding of zero bytes, so an unset UserData still reports
+// as empty over the wire.
+func encodeUserData(s string) string {
+	if s == "" {
+		return ""
+	}
+
+	return base64.StdEncoding.EncodeToString([]byte(s))
 }
 
 // instanceCount returns how many instances RunInstances should launch.

--- a/server/aws/ec2/subnet.go
+++ b/server/aws/ec2/subnet.go
@@ -161,6 +161,7 @@ func (h *Handler) toSubnetXML(s *netdriver.SubnetInfo, region string) subnetXML 
 		AvailableIPCount:    s.AvailableIPAddressCount,
 		AvailabilityZone:    s.AvailabilityZone,
 		AvailabilityZoneID:  zoneIDFor(s.AvailabilityZone),
+		DefaultForAz:        s.IsDefault,
 		MapPublicIPOnLaunch: s.MapPublicIPOnLaunch,
 		OwnerID:             h.accountID,
 		Tags:                toTagItems(s.Tags),
@@ -230,7 +231,7 @@ func subnetFilterMatch(s *netdriver.SubnetInfo, f awsquery.Filter) (matched, kno
 	case filterState:
 		return containsString(f.Values, nonEmpty(s.State, stateAvailable)), true
 	case "default-for-az", "defaultForAz":
-		return containsString(f.Values, boolFilterValue(false)), true
+		return containsString(f.Values, boolFilterValue(s.IsDefault)), true
 	case "map-public-ip-on-launch":
 		return containsString(f.Values, boolFilterValue(s.MapPublicIPOnLaunch)), true
 	default:

--- a/server/aws/ec2/subnet_test.go
+++ b/server/aws/ec2/subnet_test.go
@@ -205,12 +205,21 @@ func TestDescribeSubnetsPaginatesAllOnce(t *testing.T) {
 		want[aws.ToString(mkSubnet(ctx, t, c, vpcID, cidr, "us-east-1a").SubnetId)] = 0
 	}
 
+	// Scoped to just the 3 subnets created above by id: the account/region's
+	// seeded default VPC also has default subnets, which an unfiltered describe
+	// would otherwise page through too.
+	ids := make([]string, 0, len(want))
+	for id := range want {
+		ids = append(ids, id)
+	}
+
 	seen := map[string]int{}
 
 	var token *string
 
 	for {
 		out, err := c.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
+			SubnetIds:  ids,
 			MaxResults: aws.Int32(1),
 			NextToken:  token,
 		})

--- a/server/aws/ec2/vpc.go
+++ b/server/aws/ec2/vpc.go
@@ -152,7 +152,7 @@ func (h *Handler) toVpcXML(v *netdriver.VPCInfo) vpcXML {
 		CidrBlock:               v.CIDRBlock,
 		DhcpOptionsID:           nonEmpty(v.DhcpOptionsID, dhcpDefault),
 		InstanceTenancy:         nonEmpty(v.InstanceTenancy, tenancyDefaultXML),
-		IsDefault:               false,
+		IsDefault:               v.IsDefault,
 		OwnerID:                 h.accountID,
 		CidrBlockAssociationSet: vpcCidrAssociationSet(v),
 		Tags:                    toTagItems(v.Tags),
@@ -213,7 +213,7 @@ func vpcFilterMatch(v *netdriver.VPCInfo, f awsquery.Filter) (matched, known boo
 	case filterDHCPOptionsID:
 		return containsString(f.Values, nonEmpty(v.DhcpOptionsID, dhcpDefault)), true
 	case "isDefault", "is-default":
-		return containsString(f.Values, boolFilterValue(false)), true
+		return containsString(f.Values, boolFilterValue(v.IsDefault)), true
 	default:
 		return tagFilterMatch(f.Name, f.Values, v.Tags)
 	}

--- a/server/aws/ec2/vpc_describe_test.go
+++ b/server/aws/ec2/vpc_describe_test.go
@@ -111,7 +111,14 @@ func TestDescribeVpcsPaginates(t *testing.T) {
 		want[mkVPC(ctx, t, c, cidr)] = true
 	}
 
-	first, err := c.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{MaxResults: aws.Int32(1)})
+	// Scoped to just the 3 VPCs created above by id: the account/region's seeded
+	// default VPC would otherwise also be paged through by an unfiltered describe.
+	ids := make([]string, 0, len(want))
+	for id := range want {
+		ids = append(ids, id)
+	}
+
+	first, err := c.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{VpcIds: ids, MaxResults: aws.Int32(1)})
 	if err != nil {
 		t.Fatalf("DescribeVpcs(page1): %v", err)
 	}
@@ -128,7 +135,7 @@ func TestDescribeVpcsPaginates(t *testing.T) {
 	token := first.NextToken
 
 	for token != nil && aws.ToString(token) != "" {
-		next, err := c.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{MaxResults: aws.Int32(1), NextToken: token})
+		next, err := c.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{VpcIds: ids, MaxResults: aws.Int32(1), NextToken: token})
 		if err != nil {
 			t.Fatalf("DescribeVpcs(page): %v", err)
 		}

--- a/server/aws/ec2/xml.go
+++ b/server/aws/ec2/xml.go
@@ -256,8 +256,15 @@ type attributeBooleanValueXML struct {
 	Value bool `xml:"value"`
 }
 
+// attributeValueXML carries a single string instance attribute. Value uses
+// omitempty so an empty attribute (notably userData that was never set) marshals
+// as a bare <userData></userData> with no nested <value> element — matching real
+// EC2, whose XML decoder then leaves the SDK's AttributeValue.Value pointer nil
+// rather than pointing at "". Without this, terraform-provider-aws's read path
+// (which only skips re-hashing user_data when Value is nil) re-hashes the
+// already-hashed state value on every refresh, producing a permanent plan diff.
 type attributeValueXML struct {
-	Value string `xml:"value"`
+	Value string `xml:"value,omitempty"`
 }
 
 // describeInstanceAttributeResponse carries exactly one requested attribute

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -29,6 +29,12 @@ type VPCInfo struct {
 	// InstanceTenancy is the default tenancy of instances launched into the VPC
 	// ("default" or "dedicated"). An AWS concept; Azure and GCP leave it empty.
 	InstanceTenancy string
+	// IsDefault marks the account/region's auto-created default VPC (AWS only;
+	// Azure and GCP have no equivalent concept and leave it false). Real EC2
+	// gives every region one on account creation, with `default = true` visible
+	// via DescribeVpcs and matched by tools like Terraform's
+	// `data "aws_vpc" "default"`.
+	IsDefault bool
 }
 
 // SubnetConfig describes a subnet to create.
@@ -59,6 +65,10 @@ type SubnetInfo struct {
 	// endpoints). Populated by the provider on Create/Describe; DescribeSubnets
 	// returns it as availableIpAddressCount, which IaC tools read for drift.
 	AvailableIPAddressCount int
+	// IsDefault marks a subnet auto-created in the account/region's default VPC
+	// (AWS only). Real EC2 reports this as defaultForAz on DescribeSubnets, and
+	// RunInstances with no SubnetId lands in a subnet where this is true.
+	IsDefault bool
 }
 
 // SecurityGroupConfig describes a security group to create.

--- a/services/resourcediscovery/engine_test.go
+++ b/services/resourcediscovery/engine_test.go
@@ -87,12 +87,24 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, ProviderAWS, eng.provider)
 }
 
+// TestListAllEmpty confirms an account with no user-created resources lists
+// only the account/region's seeded default VPC family (a VPC, its 3 default
+// subnets, default security group, main route table, and internet gateway) —
+// real EC2 never has a truly empty networking surface — and nothing from any
+// other service.
 func TestListAllEmpty(t *testing.T) {
 	f := newAWSFixture(t)
 
 	out, err := f.engine.ListAll(context.Background())
 	require.NoError(t, err)
-	assert.Empty(t, out)
+
+	byType := groupByType(out)
+	assert.Len(t, byType[TypeVPC], 1, "seeded default vpc")
+	assert.Len(t, byType[TypeSubnet], 3, "seeded default subnets")
+	assert.Len(t, byType[TypeSecurityGroup], 1, "seeded default security group")
+	assert.Len(t, byType[TypeRouteTable], 1, "seeded main route table")
+	assert.Len(t, byType[TypeInternetGateway], 1, "seeded default internet gateway")
+	assert.Len(t, out, 7, "no resources beyond the seeded default VPC family")
 }
 
 func TestListAllAcrossServices(t *testing.T) {
@@ -110,7 +122,8 @@ func TestListAllAcrossServices(t *testing.T) {
 
 	byType := groupByType(out)
 	assert.Len(t, byType[TypeInstance], 1, "compute instance")
-	assert.Len(t, byType[TypeVPC], 1, "vpc")
+	// 1 seeded account/region default VPC + the 1 created by seedVPC.
+	assert.Len(t, byType[TypeVPC], 2, "vpc")
 	assert.Len(t, byType[TypeBucket], 1, "bucket")
 	assert.Len(t, byType[TypeTable], 1, "table")
 	assert.Len(t, byType[TypeFunction], 1, "function")
@@ -211,6 +224,10 @@ func TestARNShapes(t *testing.T) {
 		case TypeVPC:
 			assert.True(t, strings.HasPrefix(r.ARN, "arn:aws:ec2:us-east-1:123456789012:vpc/"),
 				"unexpected VPC ARN: %s", r.ARN)
+		case TypeSubnet:
+			// The account/region's seeded default VPC surfaces its default subnets.
+			assert.True(t, strings.HasPrefix(r.ARN, "arn:aws:ec2:us-east-1:123456789012:subnet/"),
+				"unexpected subnet ARN: %s", r.ARN)
 		case TypeBucket:
 			assert.Equal(t, "arn:aws:s3:::my-bkt", r.ARN)
 		case TypeTable:


### PR DESCRIPTION
## What was wrong vs real AWS

1. **[HIGH] Omitted `user_data` never reported as truly empty.** `DescribeInstanceAttribute(UserData)` on an instance launched without `user_data` returned a non-nil, empty-string `Value`. terraform-provider-aws's read path only re-hashes `user_data` into state when the SDK's `Value` pointer is `nil`; a non-nil empty value made it re-hash the already-hashed state (`SHA1(SHA1(""))  != SHA1("")`), producing a permanent plan diff for every `aws_instance` that omits `user_data`. Fixed by marshaling `<value>` with `omitempty` and re-encoding `RunInstances`/launch-template `UserData` consistently to base64 on the wire.

2. **[MED-HIGH] No default VPC per account/region.** Real EC2 seeds every account/region with a default VPC (`172.31.0.0/16`, `isDefault=true`), default subnets (`defaultForAz=true`, `mapPublicIpOnLaunch=true`), a default security group, a main route table, and an attached internet gateway. cloudemu had none of this: `DescribeVpcs`/`DescribeSubnets` always reported `isDefault=false`/`defaultForAz=false`, `data "aws_vpc" "default" {}` never resolved, and `RunInstances` with no `SubnetId` launched the instance with a blank subnet/VPC instead of landing in the default subnet. Fixed by seeding the full default-VPC family in `vpc.New()` and resolving an empty `SubnetID` to the default subnet in EC2's launch path.

3. **[LOW] AllocateAddress returned an RFC1918 PublicIp.** `AllocateAddress`'s `PublicIp` was derived from the same mock-IP scheme used for NAT gateways' private-side address, landing in `10.x`/`172.16-31.x`/`192.168.x`. A real Elastic IP is always publicly routable. Fixed by deriving Elastic IP addresses from `198.18.0.0/15` (IANA-reserved for benchmarking, guaranteed non-RFC1918).

## Black-box re-verification (rebuilt binary, `cloudemu serve -providers=aws`)

**(1) user_data:** Terraform apply of a bare `aws_vpc`/`aws_subnet`/`aws_instance` with no `user_data` → `terraform plan -detailed-exitcode` → exit 0, "No changes." Then set `user_data = "hello"` → apply (`user_data = "aaf4c61d..."`, the SHA1 of `"hello"`) → `terraform plan -detailed-exitcode` again → exit 0, no diff.

**(2) default VPC:** `aws ec2 describe-vpcs --filters Name=isDefault,Values=true` returns `vpc-00000001`, `CidrBlock: 172.31.0.0/16`, `IsDefault: true`. Terraform `data "aws_vpc" "default" { default = true }` resolves to the same VPC/CIDR.

**(3) public EIP:** `aws ec2 allocate-address` × 5 → all `PublicIp` values in `198.18.x.x`/`198.19.x.x`, none in `10.`/`172.16-31.`/`192.168.`.

## Notes

Seeding a default VPC surfaced a latent bug in `vpc.Restore()`: `LoadSnapshot` merges into existing store state rather than replacing it, so restoring a snapshot into a freshly-seeded `Mock` produced a duplicate default VPC. Fixed by clearing the seeded default-VPC stores at the top of `Restore()` before merging in the snapshot (every caller restores into a fresh `Mock` immediately after construction, so this is safe). Also updated test assertions across `providers/aws/vpc`, `server/aws/ec2`, `services/resourcediscovery`, and the root integration test that assumed an empty/non-default VPC surface, to account for the now-present seeded default VPC family.