### PR TITLE
fix(sns): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -37,6 +37,9 @@ const (
 	messageAttrTypeString = "String"
 )
 
+// fifoSuffix is the mandatory topic-name suffix for a FIFO SNS topic.
+const fifoSuffix = ".fifo"
+
 // SNS delivery-outcome metric names.
 const (
 	metricNotificationsDelivered = "NumberOfNotificationsDelivered"
@@ -175,6 +178,11 @@ func (m *Mock) CreateTopic(ctx context.Context, cfg driver.TopicConfig) (*driver
 		return nil, errors.New(errors.InvalidArgument, "topic name is required")
 	}
 
+	if cfg.FifoTopic && !strings.HasSuffix(cfg.Name, fifoSuffix) {
+		return nil, errors.New(errors.InvalidArgument,
+			"Invalid parameter: Name Reason: FIFO Topic Names must end with .fifo")
+	}
+
 	if m.topics.Has(cfg.Name) {
 		return nil, errors.Newf(errors.AlreadyExists, "topic %q already exists", cfg.Name)
 	}
@@ -299,6 +307,18 @@ func (m *Mock) UpdateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 		td.info.Policy = cfg.Policy
 	}
 
+	if cfg.DeliveryPolicy != "" {
+		td.info.DeliveryPolicy = cfg.DeliveryPolicy
+	}
+
+	if cfg.KmsMasterKeyID != "" {
+		td.info.KmsMasterKeyID = cfg.KmsMasterKeyID
+	}
+
+	if cfg.ContentBasedDeduplicationSet {
+		td.info.ContentBasedDeduplication = cfg.ContentBasedDeduplication
+	}
+
 	if !cfg.Scope.IsZero() {
 		td.info.Scope = cfg.Scope
 	}
@@ -406,6 +426,10 @@ func (m *Mock) Publish(ctx context.Context, input driver.PublishInput) (*driver.
 		return nil, errors.New(errors.InvalidArgument, "message is required")
 	}
 
+	if err := validateFIFOPublish(&td.info, &input); err != nil {
+		return nil, err
+	}
+
 	if err := validateMessageStructure(&input); err != nil {
 		return nil, err
 	}
@@ -460,6 +484,32 @@ func arnResource(arn string) string {
 	}
 
 	return arn
+}
+
+// validateFIFOPublish enforces the two FIFO-topic Publish requirements real SNS
+// rejects when missing: every message to a FIFO topic must carry a
+// MessageGroupId, and it must carry a MessageDeduplicationId unless the topic
+// has ContentBasedDeduplication enabled (in which case SNS derives one from the
+// message body). Standard topics accept MessageGroupId optionally (forwarded to
+// SQS standard subscriptions for fair-queue routing) and never require dedup ids,
+// so this only applies to FIFO topics.
+func validateFIFOPublish(info *driver.TopicInfo, input *driver.PublishInput) error {
+	if !info.FifoTopic {
+		return nil
+	}
+
+	if input.MessageGroupID == "" {
+		return errors.New(errors.InvalidArgument,
+			"Invalid parameter: The MessageGroupId parameter is required for FIFO topics")
+	}
+
+	if input.MessageDeduplicationID == "" && !info.ContentBasedDeduplication {
+		return errors.New(errors.InvalidArgument,
+			"Invalid parameter: The topic should either have ContentBasedDeduplication set, "+
+				"or the Publish request should provide a MessageDeduplicationId")
+	}
+
+	return nil
 }
 
 // validateMessageStructure enforces the SNS rules for a MessageStructure=json

--- a/providers/aws/sns/sns_test.go
+++ b/providers/aws/sns/sns_test.go
@@ -63,6 +63,15 @@ func TestCreateTopic(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name:      "fifo topic without .fifo suffix is rejected",
+			cfg:       driver.TopicConfig{Name: "not-fifo-named", FifoTopic: true},
+			expectErr: true,
+		},
+		{
+			name: "fifo topic with .fifo suffix",
+			cfg:  driver.TopicConfig{Name: "properly-named.fifo", FifoTopic: true},
+		},
 	}
 
 	for _, tc := range tests {
@@ -124,6 +133,54 @@ func TestUpdateTopicDisplayName(t *testing.T) {
 	info, err := m.GetTopic(ctx, "t")
 	require.NoError(t, err)
 	assert.Equal(t, "My Topic", info.DisplayName)
+}
+
+// TestUpdateTopicFIFOAndDeliveryAttributes guards SetTopicAttributes's other
+// paths through UpdateTopic (DeliveryPolicy, KmsMasterKeyId,
+// ContentBasedDeduplication), which previously never made it past the wire
+// handler and caused a permanent Terraform diff on aws_sns_topic's
+// content_based_deduplication field.
+func TestUpdateTopicFIFOAndDeliveryAttributes(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateTopic(ctx, driver.TopicConfig{Name: "t.fifo", FifoTopic: true})
+	require.NoError(t, err)
+
+	_, err = m.UpdateTopic(ctx, driver.TopicConfig{
+		Name:                         "t.fifo",
+		DeliveryPolicy:               `{"http":{"defaultHealthyRetryPolicy":{"numRetries":5}}}`,
+		KmsMasterKeyID:               "alias/my-key",
+		ContentBasedDeduplication:    true,
+		ContentBasedDeduplicationSet: true,
+	})
+	require.NoError(t, err)
+
+	info, err := m.GetTopic(ctx, "t.fifo")
+	require.NoError(t, err)
+	assert.Contains(t, info.DeliveryPolicy, "numRetries")
+	assert.Equal(t, "alias/my-key", info.KmsMasterKeyID)
+	assert.True(t, info.ContentBasedDeduplication)
+
+	// An explicit false must also stick — this is exactly the bug: a plain
+	// zero-value bool couldn't previously be distinguished from "not set".
+	_, err = m.UpdateTopic(ctx, driver.TopicConfig{
+		Name: "t.fifo", ContentBasedDeduplication: false, ContentBasedDeduplicationSet: true,
+	})
+	require.NoError(t, err)
+
+	info, err = m.GetTopic(ctx, "t.fifo")
+	require.NoError(t, err)
+	assert.False(t, info.ContentBasedDeduplication)
+
+	// UpdateTopic with ContentBasedDeduplicationSet left false (no attribute
+	// named in the request) must leave the existing value untouched.
+	_, err = m.UpdateTopic(ctx, driver.TopicConfig{Name: "t.fifo", DisplayName: "unrelated change"})
+	require.NoError(t, err)
+
+	info, err = m.GetTopic(ctx, "t.fifo")
+	require.NoError(t, err)
+	assert.False(t, info.ContentBasedDeduplication)
 }
 
 // TestTagUntagTopic is a regression guard for issue #319: SNS TagResource /
@@ -555,4 +612,95 @@ func TestPublishReturnsUniqueMessageIDs(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotEqual(t, out1.MessageID, out2.MessageID)
+}
+
+// TestPublishFIFOValidation guards the two real-SNS FIFO Publish requirements:
+// every message needs a MessageGroupId, and needs a MessageDeduplicationId
+// unless the topic has ContentBasedDeduplication enabled. Standard topics are
+// unaffected — MessageGroupId there is optional (forwarded to SQS standard
+// subscriptions for fair-queue routing), never required or rejected.
+func TestPublishFIFOValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(*Mock) driver.PublishInput
+		expectErr bool
+	}{
+		{
+			name: "fifo topic missing MessageGroupId",
+			setup: func(m *Mock) driver.PublishInput {
+				_, err := m.CreateTopic(context.Background(), driver.TopicConfig{
+					Name: "grp.fifo", FifoTopic: true, ContentBasedDeduplication: true,
+				})
+				require.NoError(t, err)
+
+				return driver.PublishInput{TopicID: "grp.fifo", Message: "hi"}
+			},
+			expectErr: true,
+		},
+		{
+			name: "fifo topic missing MessageDeduplicationId without ContentBasedDeduplication",
+			setup: func(m *Mock) driver.PublishInput {
+				_, err := m.CreateTopic(context.Background(), driver.TopicConfig{
+					Name: "dedup.fifo", FifoTopic: true,
+				})
+				require.NoError(t, err)
+
+				return driver.PublishInput{TopicID: "dedup.fifo", Message: "hi", MessageGroupID: "g1"}
+			},
+			expectErr: true,
+		},
+		{
+			name: "fifo topic with group and dedup id succeeds",
+			setup: func(m *Mock) driver.PublishInput {
+				_, err := m.CreateTopic(context.Background(), driver.TopicConfig{
+					Name: "ok.fifo", FifoTopic: true,
+				})
+				require.NoError(t, err)
+
+				return driver.PublishInput{
+					TopicID: "ok.fifo", Message: "hi", MessageGroupID: "g1", MessageDeduplicationID: "d1",
+				}
+			},
+		},
+		{
+			name: "fifo topic with ContentBasedDeduplication skips dedup id requirement",
+			setup: func(m *Mock) driver.PublishInput {
+				_, err := m.CreateTopic(context.Background(), driver.TopicConfig{
+					Name: "cbd.fifo", FifoTopic: true, ContentBasedDeduplication: true,
+				})
+				require.NoError(t, err)
+
+				return driver.PublishInput{TopicID: "cbd.fifo", Message: "hi", MessageGroupID: "g1"}
+			},
+		},
+		{
+			name: "standard topic accepts MessageGroupId without a dedup id",
+			setup: func(m *Mock) driver.PublishInput {
+				info := createTopicHelper(m, "std-with-group")
+				return driver.PublishInput{TopicID: info.Name, Message: "hi", MessageGroupID: "g1"}
+			},
+		},
+		{
+			name: "standard topic requires neither MessageGroupId nor dedup id",
+			setup: func(m *Mock) driver.PublishInput {
+				info := createTopicHelper(m, "std-plain")
+				return driver.PublishInput{TopicID: info.Name, Message: "hi"}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			input := tc.setup(m)
+
+			_, err := m.Publish(context.Background(), input)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
 }

--- a/server/aws/sns/create_topic_attributes_sdk_test.go
+++ b/server/aws/sns/create_topic_attributes_sdk_test.go
@@ -68,3 +68,61 @@ func TestSDKSNSCreateTopicFifoFlags(t *testing.T) {
 		t.Fatalf("ContentBasedDeduplication = %q, want true", attrs["ContentBasedDeduplication"])
 	}
 }
+
+// TestSDKSNSCreateTopicFifoNameRequiresSuffix guards real SNS's documented
+// naming rule (API_CreateTopic.html: "For a FIFO topic, the name must end with
+// the .fifo suffix") — FifoTopic=true with a non-.fifo name must be rejected.
+func TestSDKSNSCreateTopicFifoNameRequiresSuffix(t *testing.T) {
+	sns := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := sns.CreateTopic(ctx, &awssns.CreateTopicInput{
+		Name:       aws.String("not-fifo-named"),
+		Attributes: map[string]string{"FifoTopic": "true"},
+	})
+	if err == nil {
+		t.Fatal("CreateTopic(FifoTopic=true, non-.fifo name) succeeded, want InvalidParameter")
+	}
+}
+
+// TestSDKSNSSetTopicAttributesContentBasedDeduplication is a regression guard:
+// SetTopicAttributes previously only forwarded DisplayName/Policy, silently
+// dropping ContentBasedDeduplication (and DeliveryPolicy/KmsMasterKeyId), which
+// caused aws_sns_topic's content_based_deduplication to perpetually diff under
+// Terraform since the value never persisted.
+func TestSDKSNSSetTopicAttributesContentBasedDeduplication(t *testing.T) {
+	sns := newSDKClient(t)
+	ctx := context.Background()
+
+	topic, err := sns.CreateTopic(ctx, &awssns.CreateTopicInput{
+		Name:       aws.String("cbd.fifo"),
+		Attributes: map[string]string{"FifoTopic": "true"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	if _, err := sns.SetTopicAttributes(ctx, &awssns.SetTopicAttributesInput{
+		TopicArn:       topic.TopicArn,
+		AttributeName:  aws.String("ContentBasedDeduplication"),
+		AttributeValue: aws.String("true"),
+	}); err != nil {
+		t.Fatalf("SetTopicAttributes(ContentBasedDeduplication): %v", err)
+	}
+
+	if got := topicAttributes(t, sns, aws.ToString(topic.TopicArn))["ContentBasedDeduplication"]; got != "true" {
+		t.Fatalf("ContentBasedDeduplication after SetTopicAttributes = %q, want true", got)
+	}
+
+	if _, err := sns.SetTopicAttributes(ctx, &awssns.SetTopicAttributesInput{
+		TopicArn:       topic.TopicArn,
+		AttributeName:  aws.String("DeliveryPolicy"),
+		AttributeValue: aws.String(`{"http":{"defaultHealthyRetryPolicy":{"numRetries":5}}}`),
+	}); err != nil {
+		t.Fatalf("SetTopicAttributes(DeliveryPolicy): %v", err)
+	}
+
+	if got := topicAttributes(t, sns, aws.ToString(topic.TopicArn))["DeliveryPolicy"]; got == "" {
+		t.Fatal("DeliveryPolicy after SetTopicAttributes is empty, want it persisted")
+	}
+}

--- a/server/aws/sns/fifo_fanout_sdk_test.go
+++ b/server/aws/sns/fifo_fanout_sdk_test.go
@@ -112,6 +112,78 @@ func TestSDKSNSFifoTopicToFifoQueueDelivers(t *testing.T) {
 	}
 }
 
+// TestSDKSNSFifoPublishRequiresGroupAndDedupIds is a regression guard for the
+// two FIFO Publish requirements real SNS enforces (API_Publish.html /
+// API_CreateTopic.html) that cloudemu previously accepted silently: every
+// message to a FIFO topic needs MessageGroupId, and needs
+// MessageDeduplicationId unless the topic has ContentBasedDeduplication set.
+func TestSDKSNSFifoPublishRequiresGroupAndDedupIds(t *testing.T) {
+	sns, _ := newSNSAndSQS(t)
+	ctx := context.Background()
+
+	strict, err := sns.CreateTopic(ctx, &awssns.CreateTopicInput{
+		Name:       aws.String("strict.fifo"),
+		Attributes: map[string]string{"FifoTopic": "true"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	if _, err := sns.Publish(ctx, &awssns.PublishInput{
+		TopicArn: strict.TopicArn, Message: aws.String("no group id"),
+	}); err == nil {
+		t.Fatal("Publish to FIFO topic without MessageGroupId succeeded, want InvalidParameter")
+	}
+
+	if _, err := sns.Publish(ctx, &awssns.PublishInput{
+		TopicArn: strict.TopicArn, Message: aws.String("no dedup id"), MessageGroupId: aws.String("g1"),
+	}); err == nil {
+		t.Fatal("Publish to FIFO topic (no ContentBasedDeduplication) without dedup id succeeded, want InvalidParameter")
+	}
+
+	// A fully-specified publish still succeeds.
+	if _, err := sns.Publish(ctx, &awssns.PublishInput{
+		TopicArn: strict.TopicArn, Message: aws.String("ok"),
+		MessageGroupId: aws.String("g1"), MessageDeduplicationId: aws.String("d1"),
+	}); err != nil {
+		t.Fatalf("Publish with group+dedup ids: %v", err)
+	}
+
+	// ContentBasedDeduplication=true relieves the dedup-id requirement.
+	auto, err := sns.CreateTopic(ctx, &awssns.CreateTopicInput{
+		Name:       aws.String("auto.fifo"),
+		Attributes: map[string]string{"FifoTopic": "true", "ContentBasedDeduplication": "true"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTopic(auto): %v", err)
+	}
+
+	if _, err := sns.Publish(ctx, &awssns.PublishInput{
+		TopicArn: auto.TopicArn, Message: aws.String("ok"), MessageGroupId: aws.String("g1"),
+	}); err != nil {
+		t.Fatalf("Publish with ContentBasedDeduplication and no dedup id: %v", err)
+	}
+
+	// A standard topic never requires either id, and MessageGroupId is optional
+	// there (forwarded to SQS standard subscriptions for fair-queue routing).
+	std, err := sns.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("standard-topic")})
+	if err != nil {
+		t.Fatalf("CreateTopic(standard): %v", err)
+	}
+
+	if _, err := sns.Publish(ctx, &awssns.PublishInput{
+		TopicArn: std.TopicArn, Message: aws.String("plain"),
+	}); err != nil {
+		t.Fatalf("Publish to standard topic with no ids: %v", err)
+	}
+
+	if _, err := sns.Publish(ctx, &awssns.PublishInput{
+		TopicArn: std.TopicArn, Message: aws.String("with group"), MessageGroupId: aws.String("g1"),
+	}); err != nil {
+		t.Fatalf("Publish to standard topic with MessageGroupId: %v", err)
+	}
+}
+
 // TestSDKSNSNumericAttributeFilterPolicy reproduces a numeric filter policy on a
 // message ATTRIBUTE: attribute values travel the wire as strings, so a numeric
 // operator must still match one that encodes a number. A matching message was

--- a/server/aws/sns/operations.go
+++ b/server/aws/sns/operations.go
@@ -226,14 +226,30 @@ func (h *Handler) setTopicAttributes(w http.ResponseWriter, r *http.Request) {
 
 	cfg := notifdriver.TopicConfig{Name: name}
 
+	value := r.Form.Get("AttributeValue")
+
+	var apply bool
+
 	switch r.Form.Get("AttributeName") {
 	case "DisplayName":
-		cfg.DisplayName = r.Form.Get("AttributeValue")
+		cfg.DisplayName = value
+		apply = true
 	case "Policy":
-		cfg.Policy = r.Form.Get("AttributeValue")
+		cfg.Policy = value
+		apply = true
+	case "DeliveryPolicy":
+		cfg.DeliveryPolicy = value
+		apply = true
+	case "KmsMasterKeyId":
+		cfg.KmsMasterKeyID = value
+		apply = true
+	case "ContentBasedDeduplication":
+		cfg.ContentBasedDeduplication = value == attrTrue
+		cfg.ContentBasedDeduplicationSet = true
+		apply = true
 	}
 
-	if cfg.DisplayName != "" || cfg.Policy != "" {
+	if apply {
 		if _, err := h.notif.UpdateTopic(r.Context(), cfg); err != nil {
 			writeErr(w, err)
 			return
@@ -519,17 +535,32 @@ func (h *Handler) publish(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// pendingConfirmationListArn is the literal SNS shows as SubscriptionArn in
+// ListSubscriptions/ListSubscriptionsByTopic for a still-unconfirmed
+// subscription. Distinct from Subscribe's own "pending confirmation" return
+// value (lowercase, with a space) — real SNS uses this different literal here.
+const pendingConfirmationListArn = "PendingConfirmation"
+
 // subscriptionMembers converts driver subscriptions into SNS XML members. The
 // driver's SubscriptionInfo.ID is already the subscription ARN; TopicArn is the
-// topic's resource ARN passed by the caller.
+// topic's resource ARN passed by the caller. A still-pending subscription's ARN
+// is masked as "PendingConfirmation", matching real SNS list responses (only
+// GetSubscriptionAttributes/Subscribe echo the real ARN before confirmation).
 func subscriptionMembers(topicArn string, subs []notifdriver.SubscriptionInfo) []subscriptionMember {
 	out := make([]subscriptionMember, 0, len(subs))
+
 	for i := range subs {
+		arn := subs[i].ID
+		if subs[i].Status == statusPending {
+			arn = pendingConfirmationListArn
+		}
+
 		out = append(out, subscriptionMember{
-			SubscriptionArn: subs[i].ID,
+			SubscriptionArn: arn,
 			TopicArn:        topicArn,
 			Protocol:        subs[i].Protocol,
 			Endpoint:        subs[i].Endpoint,
+			Owner:           accountFromARN(subs[i].ID),
 		})
 	}
 

--- a/server/aws/sns/pagination_sdk_test.go
+++ b/server/aws/sns/pagination_sdk_test.go
@@ -55,14 +55,22 @@ func TestSDKListSubscriptionsByTopicPagination(t *testing.T) {
 		t.Fatalf("page2 = %d subs token=%q, want 1 no token", len(page2.Subscriptions), aws.ToString(page2.NextToken))
 	}
 
+	// Every one of these subscriptions is still unconfirmed (email requires
+	// ConfirmSubscription), so real SNS masks SubscriptionArn as
+	// "PendingConfirmation" in list responses; Endpoint is the only
+	// per-subscription identifier left to walk uniqueness by.
 	seen := map[string]bool{}
 	for _, s := range append(page1.Subscriptions, page2.Subscriptions...) {
-		arn := aws.ToString(s.SubscriptionArn)
-		if seen[arn] {
-			t.Fatalf("subscription %q returned twice across pages", arn)
+		if arn := aws.ToString(s.SubscriptionArn); arn != "PendingConfirmation" {
+			t.Fatalf("subscription ARN = %q, want masked \"PendingConfirmation\" (still unconfirmed)", arn)
 		}
 
-		seen[arn] = true
+		endpoint := aws.ToString(s.Endpoint)
+		if seen[endpoint] {
+			t.Fatalf("subscription %q returned twice across pages", endpoint)
+		}
+
+		seen[endpoint] = true
 	}
 
 	if len(seen) != total {

--- a/server/aws/sns/sdk_roundtrip_test.go
+++ b/server/aws/sns/sdk_roundtrip_test.go
@@ -419,6 +419,64 @@ func TestSDKSNSPendingConfirmationCounts(t *testing.T) {
 	}
 }
 
+// TestSDKSNSListSubscriptionsMasksPendingArn is a regression guard: real SNS
+// masks SubscriptionArn as the literal "PendingConfirmation" in
+// ListSubscriptions/ListSubscriptionsByTopic for a still-unconfirmed
+// subscription (distinct from Subscribe's own "pending confirmation" return
+// value) and reports the owning account id in Owner — cloudemu previously
+// echoed the real internal ARN and left Owner empty for every subscription.
+func TestSDKSNSListSubscriptionsMasksPendingArn(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	topic, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("mask-topic")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	topicArn := aws.ToString(topic.TopicArn)
+
+	if _, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn: aws.String(topicArn), Protocol: aws.String("email"), Endpoint: aws.String("a@b.com"),
+	}); err != nil {
+		t.Fatalf("Subscribe(email): %v", err)
+	}
+
+	if _, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn: aws.String(topicArn), Protocol: aws.String("sqs"),
+		Endpoint: aws.String("arn:aws:sqs:us-east-1:000000000000:q"),
+	}); err != nil {
+		t.Fatalf("Subscribe(sqs): %v", err)
+	}
+
+	out, err := client.ListSubscriptionsByTopic(ctx,
+		&awssns.ListSubscriptionsByTopicInput{TopicArn: aws.String(topicArn)})
+	if err != nil {
+		t.Fatalf("ListSubscriptionsByTopic: %v", err)
+	}
+
+	if len(out.Subscriptions) != 2 {
+		t.Fatalf("got %d subscriptions, want 2", len(out.Subscriptions))
+	}
+
+	for _, s := range out.Subscriptions {
+		if aws.ToString(s.Owner) == "" {
+			t.Fatalf("subscription %s: Owner is empty, want the account id", aws.ToString(s.Protocol))
+		}
+
+		switch aws.ToString(s.Protocol) {
+		case "email":
+			if arn := aws.ToString(s.SubscriptionArn); arn != "PendingConfirmation" {
+				t.Fatalf("email SubscriptionArn = %q, want masked \"PendingConfirmation\"", arn)
+			}
+		case "sqs":
+			if arn := aws.ToString(s.SubscriptionArn); arn == "PendingConfirmation" || arn == "" {
+				t.Fatalf("sqs (auto-confirmed) SubscriptionArn = %q, want the real ARN", arn)
+			}
+		}
+	}
+}
+
 // TestSDKSNSConfirmSubscription drives a pending email subscription through
 // ConfirmSubscription (previously undispatched → InvalidAction) using the token
 // the mock generated, and asserts the subscription flips to confirmed.

--- a/services/notification/driver/driver.go
+++ b/services/notification/driver/driver.go
@@ -26,6 +26,12 @@ type TopicConfig struct {
 	// by GetTopicAttributes; FIFO publish ordering/dedup is not yet enforced.
 	FifoTopic                 bool
 	ContentBasedDeduplication bool
+	// ContentBasedDeduplicationSet reports that ContentBasedDeduplication was
+	// supplied explicitly on an UpdateTopic (SetTopicAttributes) call, so the AWS
+	// provider can distinguish an explicit false (applied) from a config with no
+	// opinion on the field (left unchanged). CreateTopic doesn't need it: a create
+	// always applies the field as given.
+	ContentBasedDeduplicationSet bool
 
 	// Scope records where the resource lives (Azure subscription/resource
 	// group, GCP project). Zero for AWS and unscoped portable callers.


### PR DESCRIPTION
## Summary

Real-user black-box e2e audit of AWS SNS (aws-cli, Terraform, aws-sdk-go-v2, raw wire) against a temporary `cloudemu serve` instance surfaced several divergences from real AWS SNS behavior, now fixed:

- **FIFO Publish validation**: real SNS requires `MessageGroupId` on every FIFO-topic publish, and requires `MessageDeduplicationId` unless the topic has `ContentBasedDeduplication` enabled. CloudEmu previously accepted FIFO publishes missing either, silently.
- **FIFO topic naming**: `CreateTopic` with `FifoTopic=true` now rejects a name that doesn't end in `.fifo`, matching the documented AWS naming rule.
- **`SetTopicAttributes` dropped attributes**: only `DisplayName`/`Policy` were ever forwarded to `UpdateTopic`; `DeliveryPolicy`, `KmsMasterKeyId`, and `ContentBasedDeduplication` were silently ignored. This caused a **permanent Terraform diff** on `aws_sns_topic`'s `content_based_deduplication` field, since Terraform sets it via `SetTopicAttributes` on create. Fixed at both the wire handler and the provider's `UpdateTopic`.
- **`ListSubscriptions`/`ListSubscriptionsByTopic` ARN masking**: real SNS shows the literal `"PendingConfirmation"` as `SubscriptionArn` for a still-unconfirmed subscription in these list responses (distinct from `Subscribe`'s own `"pending confirmation"` return value), and reports the owning account id in `Owner`. CloudEmu always echoed the real internal ARN and left `Owner` empty.

Also audited and confirmed correct (no change needed): SNS→SQS fan-out envelope shape, RawMessageDelivery, FilterPolicy (attribute + MessageBody scope), FIFO group/dedup carry-through to a FIFO SQS queue, `MessageStructure=json`, `PublishBatch`, tags round-trip, and that `MessageGroupId` is valid (optional) on standard topics per current AWS docs (fair-queue routing) — ruled out as a false finding.

One additional finding was filed but not fixed (deferred as a separate, more invasive change): `Subscribe` is not idempotent on `(topic, protocol, endpoint)` — real SNS returns the existing `SubscriptionArn` on a duplicate `Subscribe` call, cloudemu creates a new one.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... ` — 332 packages, 0 failures
- [x] `go test ./providers/aws/sns/... ./server/aws/sns/... -race` — all pass, including new regression tests for each fix
- [x] `gofmt -l` clean
- [x] `golangci-lint run --timeout=9m ./...` on affected packages — 0 new issues (9 pre-existing baseline issues unchanged)
- [x] `go generate ./...` — `docs/coverage` unchanged
- [x] Black-box re-verify via `cloudemu serve` + aws-cli + Terraform (hashicorp/aws):
  - FIFO publish without `MessageGroupId`/`MessageDeduplicationId` now returns `InvalidParameter`; standard-topic `MessageGroupId` still accepted.
  - `CreateTopic` with `FifoTopic=true` and a non-`.fifo` name now returns `InvalidParameter`.
  - `terraform apply` then `terraform plan` on an `aws_sns_topic` with `fifo_topic = true` + `content_based_deduplication = true` now shows **"No changes."** (was a perpetual diff before the fix).
  - `ListSubscriptionsByTopic` now shows `"PendingConfirmation"` for unconfirmed email/https subs and the real ARN for the auto-confirmed sqs sub, with `Owner` populated for all.
  - `terraform destroy` completes cleanly.