### PR TITLE
fix(iam): real-user e2e divergences from AWS

### DIFF
--- a/server/aws/iam/account_authorization_details.go
+++ b/server/aws/iam/account_authorization_details.go
@@ -381,7 +381,7 @@ func (h *Handler) buildRoleDetails(ctx context.Context) []roleDetailXML {
 			RoleID:                   role.ID,
 			Arn:                      role.ARN,
 			CreateDate:               role.CreatedAt,
-			AssumeRolePolicyDocument: role.AssumeRolePolicyDoc,
+			AssumeRolePolicyDocument: encodePolicyDocument(role.AssumeRolePolicyDoc),
 			InstanceProfileList:      roleInstanceProfiles(role, profiles),
 			RolePolicyList:           policyDetailListXML{Member: h.roleInlinePolicies(ctx, role.Name)},
 			AttachedManagedPolicies:  attachedPoliciesFromARNs(arns),
@@ -431,7 +431,7 @@ func inlinePolicyDetails(ctx context.Context, owner string,
 			continue
 		}
 
-		out = append(out, policyDetailXML{PolicyName: name, PolicyDocument: doc})
+		out = append(out, policyDetailXML{PolicyName: name, PolicyDocument: encodePolicyDocument(doc)})
 	}
 
 	return out

--- a/server/aws/iam/account_authorization_details_test.go
+++ b/server/aws/iam/account_authorization_details_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/url"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -165,9 +166,16 @@ func assertRoleDetail(t *testing.T, roles []iamtypes.RoleDetail, policyArn strin
 		t.Fatalf("role RolePolicyList = %+v, want one inline-s3", r.RolePolicyList)
 	}
 
-	// The inline document must round-trip back to valid JSON via the SDK.
+	// Real IAM URL-encodes policy documents on every read path; the SDK does not
+	// decode this for the caller, so the document must be unescaped before it is
+	// valid JSON again.
+	decoded, err := url.QueryUnescape(aws.ToString(r.RolePolicyList[0].PolicyDocument))
+	if err != nil {
+		t.Fatalf("inline RolePolicy document not URL-decodable: %v", err)
+	}
+
 	var obj map[string]any
-	if err := json.Unmarshal([]byte(aws.ToString(r.RolePolicyList[0].PolicyDocument)), &obj); err != nil {
+	if err := json.Unmarshal([]byte(decoded), &obj); err != nil {
 		t.Fatalf("inline RolePolicy document not valid JSON: %v", err)
 	}
 

--- a/server/aws/iam/group_policy.go
+++ b/server/aws/iam/group_policy.go
@@ -171,7 +171,7 @@ func (h *Handler) getGroupPolicy(w http.ResponseWriter, r *http.Request) {
 	awsquery.WriteXMLResponse(w, getGroupPolicyResponse{
 		Xmlns: Namespace,
 		Result: getGroupPolicyResult{
-			GroupName: groupName, PolicyName: policyName, PolicyDocument: doc,
+			GroupName: groupName, PolicyName: policyName, PolicyDocument: encodePolicyDocument(doc),
 		},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})

--- a/server/aws/iam/role_policy.go
+++ b/server/aws/iam/role_policy.go
@@ -87,7 +87,7 @@ func (h *Handler) getRolePolicy(w http.ResponseWriter, r *http.Request) {
 	awsquery.WriteXMLResponse(w, getRolePolicyResponse{
 		Xmlns: Namespace,
 		Result: getRolePolicyResult{
-			RoleName: roleName, PolicyName: policyName, PolicyDocument: doc,
+			RoleName: roleName, PolicyName: policyName, PolicyDocument: encodePolicyDocument(doc),
 		},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})

--- a/server/aws/iam/sdk_roundtrip_test.go
+++ b/server/aws/iam/sdk_roundtrip_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -417,7 +418,9 @@ func TestSDKIAMPolicyVersionLifecycle(t *testing.T) {
 		t.Fatalf("expected new default v2, got %+v", created.PolicyVersion)
 	}
 
-	// GetPolicyVersion round-trips the stored document.
+	// GetPolicyVersion round-trips the stored document. Real IAM URL-encodes the
+	// document on every read path and the SDK does not decode it for the caller,
+	// so it must be unescaped before comparing against the plain JSON we sent.
 	gotVer, err := client.GetPolicyVersion(ctx, &iam.GetPolicyVersionInput{
 		PolicyArn: aws.String(arn), VersionId: aws.String("v2"),
 	})
@@ -425,8 +428,13 @@ func TestSDKIAMPolicyVersionLifecycle(t *testing.T) {
 		t.Fatalf("GetPolicyVersion: %v", err)
 	}
 
-	if aws.ToString(gotVer.PolicyVersion.Document) != docV2 {
-		t.Fatalf("GetPolicyVersion document mismatch: %q", aws.ToString(gotVer.PolicyVersion.Document))
+	gotDoc, err := url.QueryUnescape(aws.ToString(gotVer.PolicyVersion.Document))
+	if err != nil {
+		t.Fatalf("GetPolicyVersion document not URL-decodable: %v", err)
+	}
+
+	if gotDoc != docV2 {
+		t.Fatalf("GetPolicyVersion document mismatch: %q", gotDoc)
 	}
 
 	// GetPolicy reflects the new default, then tracks SetDefaultPolicyVersion.

--- a/server/aws/iam/user_policy.go
+++ b/server/aws/iam/user_policy.go
@@ -88,7 +88,7 @@ func (h *Handler) getUserPolicy(w http.ResponseWriter, r *http.Request) {
 	awsquery.WriteXMLResponse(w, getUserPolicyResponse{
 		Xmlns: Namespace,
 		Result: getUserPolicyResult{
-			UserName: userName, PolicyName: policyName, PolicyDocument: doc,
+			UserName: userName, PolicyName: policyName, PolicyDocument: encodePolicyDocument(doc),
 		},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})

--- a/server/aws/iam/xml.go
+++ b/server/aws/iam/xml.go
@@ -2,9 +2,30 @@ package iam
 
 import (
 	"encoding/xml"
+	"net/url"
+	"strings"
 
 	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
 )
+
+// encodePolicyDocument percent-encodes a policy/assume-role-policy JSON
+// document the way real IAM does on every read path (GetRole, ListRoles,
+// GetPolicyVersion, GetRolePolicy/GetUserPolicy/GetGroupPolicy,
+// GetAccountAuthorizationDetails, ...): RFC 3986 percent-encoding with the
+// space character escaped as %20 rather than "+". url.QueryEscape already
+// percent-encodes every byte outside the unreserved set, but — being tuned
+// for "application/x-www-form-urlencoded" query strings — represents space
+// as "+"; the trailing replace corrects that one divergence. Client SDKs
+// (e.g. botocore's json_decode_policies) undo this with a plain percent
+// decode, which does not treat "+" as space, so leaving it unescaped would
+// corrupt any document containing one.
+func encodePolicyDocument(doc string) string {
+	if doc == "" {
+		return doc
+	}
+
+	return strings.ReplaceAll(url.QueryEscape(doc), "+", "%20")
+}
 
 // Every IAM query-protocol response is wrapped in <FooResponse xmlns="..."> with a
 // <FooResult> child and a trailing <ResponseMetadata><RequestId>...</RequestId>
@@ -80,7 +101,7 @@ func toRoleXML(r *iamdriver.RoleInfo) roleXML {
 		Description:              r.Description,
 		CreateDate:               r.CreatedAt,
 		MaxSessionDuration:       r.MaxSessionDuration,
-		AssumeRolePolicyDocument: r.AssumeRolePolicyDoc,
+		AssumeRolePolicyDocument: encodePolicyDocument(r.AssumeRolePolicyDoc),
 		Tags:                     toTagsXML(r.Tags),
 	}
 }
@@ -148,7 +169,7 @@ func toPolicyVersionXML(v *iamdriver.PolicyVersionInfo, includeDocument bool) po
 	}
 
 	if includeDocument {
-		out.Document = v.PolicyDocument
+		out.Document = encodePolicyDocument(v.PolicyDocument)
 	}
 
 	return out


### PR DESCRIPTION
## Summary
- Real IAM URL-encodes (RFC 3986 percent-encoding) every policy document it returns on read: `AssumeRolePolicyDocument` (CreateRole/GetRole/ListRoles/GetAccountAuthorizationDetails), `PolicyVersion.Document` (CreatePolicyVersion/GetPolicyVersion), and inline `PolicyDocument` (GetRolePolicy/GetUserPolicy/GetGroupPolicy/GetAccountAuthorizationDetails). cloudemu was returning plain (XML-escaped only) JSON on all of these paths.
- This was masked for aws-cli/boto3 because botocore's `json_decode_policies` handler does `json.loads(unquote(value))` unconditionally, and unquoting already-plain JSON without a literal `%` is a no-op. But aws-sdk-go-v2 does **not** auto-decode IAM policy documents (well-known Go SDK behavior), so a Go caller reading `GetPolicyVersion().PolicyVersion.Document` got literal JSON from cloudemu instead of the percent-encoded string real AWS returns — a real wire-protocol/parity gap for Go tooling, and a correctness risk for any client that does its own decode-then-parse.
- Adds `encodePolicyDocument()` in `server/aws/iam/xml.go` and applies it at every response boundary that emits a policy document.

## Real-user re-verification (black-box)
- Raw wire (aws-sdk-go-v2 debug log): `AssumeRolePolicyDocument` now reads `%7B%22Version%22%3A%222012-10-17%22...` — matches real AWS's percent-encoded shape (previously `{&#34;Version&#34;:...` — XML-escaped only).
- `aws iam get-role` (CLI): unaffected — still displays the decoded JSON object (botocore decodes transparently).
- Terraform (`aws_iam_role`, `aws_iam_policy`, `aws_iam_role_policy` inline, `aws_iam_role_policy_attachment`, `aws_iam_instance_profile`, `aws_iam_user`, `aws_iam_user_policy_attachment`, `aws_iam_group`, `aws_iam_user_group_membership`, `aws_iam_access_key`, tags): `apply` (10 created) → `plan` → **"No changes."** → `destroy` (10 destroyed, correct dependency order) — clean both before and after the fix.
- `go test ./server/aws/iam/... -race` and full `go test ./...`: green. Two pre-existing tests asserted on the old raw-JSON behavior (`TestSDKGetAccountAuthorizationDetails`, `TestSDKIAMPolicyVersionLifecycle`); updated to `url.QueryUnescape` the returned document first, matching real AWS's actual (SDK-undecoded) contract.
- `gofmt -l` clean; `golangci-lint run ./server/aws/iam/...` shows the same 11 pre-existing issues as the `development` baseline (confirmed via `git stash`) — 0 new.
- `go generate ./...` — `docs/coverage` unchanged (wire-encoding only, no driver-interface surface change).

## Test plan
- [x] `go build ./...`
- [x] `go test ./server/aws/iam/... -race`
- [x] `go test ./...` (full suite)
- [x] `gofmt -l server/aws/iam/*.go`
- [x] `golangci-lint run ./server/aws/iam/...` (0 new issues vs baseline)
- [x] `go generate ./...` + `git diff --exit-code docs/coverage`
- [x] Black-box re-repro via aws-sdk-go-v2 debug wire log, aws CLI, and Terraform apply/plan/destroy against a locally built `cloudemu serve`