### PR TITLE
fix(sns): subscribe idempotency, topic-attribute round-trip, non-fifo dedup guard

### DIFF
--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -209,6 +209,8 @@ func (m *Mock) CreateTopic(ctx context.Context, cfg driver.TopicConfig) (*driver
 		Tags:                      tags,
 	}
 
+	applyCreateFeedbackAttrs(&info, &cfg)
+
 	td := &topicData{
 		info:          info,
 		subscriptions: memstore.New[driver.SubscriptionInfo](),
@@ -316,8 +318,16 @@ func (m *Mock) UpdateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 	}
 
 	if cfg.ContentBasedDeduplicationSet {
+		if !td.info.FifoTopic {
+			return nil, errors.New(errors.InvalidArgument,
+				"Invalid parameter: Attributes Reason: ContentBasedDeduplication attribute "+
+					"is not applicable for standard topics")
+		}
+
 		td.info.ContentBasedDeduplication = cfg.ContentBasedDeduplication
 	}
+
+	applyUpdateFeedbackAttrs(&td.info, &cfg)
 
 	if !cfg.Scope.IsZero() {
 		td.info.Scope = cfg.Scope
@@ -328,6 +338,67 @@ func (m *Mock) UpdateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 	result := td.withCounts()
 
 	return &result, nil
+}
+
+// applyCreateFeedbackAttrs copies SignatureVersion, TracingConfig,
+// ArchivePolicy, and the per-protocol delivery-status feedback attributes from
+// a CreateTopic config onto the new topic's info, unconditionally (a create
+// always applies the field exactly as given, including its zero value).
+func applyCreateFeedbackAttrs(info *driver.TopicInfo, cfg *driver.TopicConfig) {
+	info.SignatureVersion = cfg.SignatureVersion
+	info.TracingConfig = cfg.TracingConfig
+	info.ArchivePolicy = cfg.ArchivePolicy
+	info.ApplicationSuccessFeedbackRoleArn = cfg.ApplicationSuccessFeedbackRoleArn
+	info.ApplicationFailureFeedbackRoleArn = cfg.ApplicationFailureFeedbackRoleArn
+	info.ApplicationSuccessFeedbackSampleRate = cfg.ApplicationSuccessFeedbackSampleRate
+	info.HTTPSuccessFeedbackRoleArn = cfg.HTTPSuccessFeedbackRoleArn
+	info.HTTPFailureFeedbackRoleArn = cfg.HTTPFailureFeedbackRoleArn
+	info.HTTPSuccessFeedbackSampleRate = cfg.HTTPSuccessFeedbackSampleRate
+	info.LambdaSuccessFeedbackRoleArn = cfg.LambdaSuccessFeedbackRoleArn
+	info.LambdaFailureFeedbackRoleArn = cfg.LambdaFailureFeedbackRoleArn
+	info.LambdaSuccessFeedbackSampleRate = cfg.LambdaSuccessFeedbackSampleRate
+	info.SQSSuccessFeedbackRoleArn = cfg.SQSSuccessFeedbackRoleArn
+	info.SQSFailureFeedbackRoleArn = cfg.SQSFailureFeedbackRoleArn
+	info.SQSSuccessFeedbackSampleRate = cfg.SQSSuccessFeedbackSampleRate
+	info.FirehoseSuccessFeedbackRoleArn = cfg.FirehoseSuccessFeedbackRoleArn
+	info.FirehoseFailureFeedbackRoleArn = cfg.FirehoseFailureFeedbackRoleArn
+	info.FirehoseSuccessFeedbackSampleRate = cfg.FirehoseSuccessFeedbackSampleRate
+}
+
+// setIfNonEmpty assigns src to *dst only when src is non-empty, mirroring the
+// no-clear-via-empty-string convention UpdateTopic already applies to
+// DeliveryPolicy/KmsMasterKeyID: SetTopicAttributes sets one attribute per
+// call, so an update config only ever carries an opinion on the attribute(s)
+// the caller actually named.
+func setIfNonEmpty(dst *string, src string) {
+	if src != "" {
+		*dst = src
+	}
+}
+
+// applyUpdateFeedbackAttrs merges SignatureVersion, TracingConfig,
+// ArchivePolicy, and the per-protocol delivery-status feedback attributes from
+// an UpdateTopic (SetTopicAttributes) config onto an existing topic's info,
+// leaving any attribute the caller didn't name (empty in cfg) unchanged.
+func applyUpdateFeedbackAttrs(info *driver.TopicInfo, cfg *driver.TopicConfig) {
+	setIfNonEmpty(&info.SignatureVersion, cfg.SignatureVersion)
+	setIfNonEmpty(&info.TracingConfig, cfg.TracingConfig)
+	setIfNonEmpty(&info.ArchivePolicy, cfg.ArchivePolicy)
+	setIfNonEmpty(&info.ApplicationSuccessFeedbackRoleArn, cfg.ApplicationSuccessFeedbackRoleArn)
+	setIfNonEmpty(&info.ApplicationFailureFeedbackRoleArn, cfg.ApplicationFailureFeedbackRoleArn)
+	setIfNonEmpty(&info.ApplicationSuccessFeedbackSampleRate, cfg.ApplicationSuccessFeedbackSampleRate)
+	setIfNonEmpty(&info.HTTPSuccessFeedbackRoleArn, cfg.HTTPSuccessFeedbackRoleArn)
+	setIfNonEmpty(&info.HTTPFailureFeedbackRoleArn, cfg.HTTPFailureFeedbackRoleArn)
+	setIfNonEmpty(&info.HTTPSuccessFeedbackSampleRate, cfg.HTTPSuccessFeedbackSampleRate)
+	setIfNonEmpty(&info.LambdaSuccessFeedbackRoleArn, cfg.LambdaSuccessFeedbackRoleArn)
+	setIfNonEmpty(&info.LambdaFailureFeedbackRoleArn, cfg.LambdaFailureFeedbackRoleArn)
+	setIfNonEmpty(&info.LambdaSuccessFeedbackSampleRate, cfg.LambdaSuccessFeedbackSampleRate)
+	setIfNonEmpty(&info.SQSSuccessFeedbackRoleArn, cfg.SQSSuccessFeedbackRoleArn)
+	setIfNonEmpty(&info.SQSFailureFeedbackRoleArn, cfg.SQSFailureFeedbackRoleArn)
+	setIfNonEmpty(&info.SQSSuccessFeedbackSampleRate, cfg.SQSSuccessFeedbackSampleRate)
+	setIfNonEmpty(&info.FirehoseSuccessFeedbackRoleArn, cfg.FirehoseSuccessFeedbackRoleArn)
+	setIfNonEmpty(&info.FirehoseFailureFeedbackRoleArn, cfg.FirehoseFailureFeedbackRoleArn)
+	setIfNonEmpty(&info.FirehoseSuccessFeedbackSampleRate, cfg.FirehoseSuccessFeedbackSampleRate)
 }
 
 // Subscribe creates a subscription to an SNS topic.
@@ -348,6 +419,22 @@ func (m *Mock) Subscribe(_ context.Context, cfg driver.SubscriptionConfig) (*dri
 
 	if cfg.Endpoint == "" {
 		return nil, errors.New(errors.InvalidArgument, "endpoint is required")
+	}
+
+	// Subscribe is idempotent on (TopicArn, Protocol, Endpoint): real SNS
+	// returns the existing subscription (pending or confirmed) instead of
+	// creating a duplicate. td.mu serializes the scan-then-create so two
+	// concurrent identical Subscribe calls can't both observe "not found" and
+	// each create their own subscription.
+	td.mu.Lock()
+	defer td.mu.Unlock()
+
+	for _, s := range td.subscriptions.All() {
+		if s.Protocol == cfg.Protocol && s.Endpoint == cfg.Endpoint {
+			result := s
+
+			return &result, nil
+		}
 	}
 
 	subID := idgen.GenerateID("sub-")

--- a/providers/aws/sns/sns_test.go
+++ b/providers/aws/sns/sns_test.go
@@ -183,6 +183,38 @@ func TestUpdateTopicFIFOAndDeliveryAttributes(t *testing.T) {
 	assert.False(t, info.ContentBasedDeduplication)
 }
 
+// TestUpdateTopicContentBasedDeduplicationRejectedOnStandardTopic guards real
+// AWS's rule that ContentBasedDeduplication is only valid on a FIFO topic: a
+// SetTopicAttributes call naming it on a standard topic must be rejected
+// rather than silently accepted.
+func TestUpdateTopicContentBasedDeduplicationRejectedOnStandardTopic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateTopic(ctx, driver.TopicConfig{Name: "standard"})
+	require.NoError(t, err)
+
+	_, err = m.UpdateTopic(ctx, driver.TopicConfig{
+		Name: "standard", ContentBasedDeduplication: true, ContentBasedDeduplicationSet: true,
+	})
+	require.Error(t, err)
+
+	// The rejection must not have partially applied the attribute.
+	info, err := m.GetTopic(ctx, "standard")
+	require.NoError(t, err)
+	assert.False(t, info.ContentBasedDeduplication)
+
+	// The FIFO case must keep working: this is a regression guard, not a
+	// blanket rejection of the attribute.
+	_, err = m.CreateTopic(ctx, driver.TopicConfig{Name: "standard2.fifo", FifoTopic: true})
+	require.NoError(t, err)
+
+	_, err = m.UpdateTopic(ctx, driver.TopicConfig{
+		Name: "standard2.fifo", ContentBasedDeduplication: true, ContentBasedDeduplicationSet: true,
+	})
+	require.NoError(t, err)
+}
+
 // TestTagUntagTopic is a regression guard for issue #319: SNS TagResource /
 // UntagResource were unimplemented.
 func TestTagUntagTopic(t *testing.T) {
@@ -472,6 +504,60 @@ func TestMultipleSubscriptionsSameTopic(t *testing.T) {
 	subs, err := m.ListSubscriptions(ctx, topic.Name)
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(subs))
+}
+
+// TestSubscribeIdempotent guards real SNS's documented Subscribe semantics: a
+// repeat Subscribe call with the same (TopicArn, Protocol, Endpoint) returns
+// the existing subscription instead of creating a duplicate.
+func TestSubscribeIdempotent(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "idempotent-sub")
+
+	first, err := m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "sqs", Endpoint: "arn:aws:sqs:us-east-1:123456789012:q",
+	})
+	require.NoError(t, err)
+
+	second, err := m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "sqs", Endpoint: "arn:aws:sqs:us-east-1:123456789012:q",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, first.ID, second.ID)
+
+	subs, err := m.ListSubscriptions(ctx, topic.Name)
+	require.NoError(t, err)
+	assert.Len(t, subs, 1)
+}
+
+// TestSubscribeIdempotentPending guards the pending-confirmation case: a
+// repeat Subscribe on a protocol that starts pending (e.g. email) returns the
+// same pending subscription rather than minting a second confirmation token.
+func TestSubscribeIdempotentPending(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "idempotent-pending")
+
+	first, err := m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "email", Endpoint: "dev@example.com",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "pending", first.Status)
+
+	second, err := m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "email", Endpoint: "dev@example.com",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, first.ID, second.ID)
+	assert.Equal(t, first.ConfirmationToken, second.ConfirmationToken)
+
+	subs, err := m.ListSubscriptions(ctx, topic.Name)
+	require.NoError(t, err)
+	assert.Len(t, subs, 1)
 }
 
 func TestUnsubscribe(t *testing.T) {

--- a/server/aws/sns/content_based_dedup_test.go
+++ b/server/aws/sns/content_based_dedup_test.go
@@ -1,0 +1,66 @@
+package sns_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
+	smithy "github.com/aws/smithy-go"
+)
+
+// TestSDKSetTopicAttributesContentBasedDeduplicationRejectedOnStandardTopic
+// guards real AWS's rule that ContentBasedDeduplication is only valid on a
+// FIFO topic: SetTopicAttributes naming it on a standard topic must fail with
+// InvalidParameter, not silently succeed and leave a Terraform diff.
+func TestSDKSetTopicAttributesContentBasedDeduplicationRejectedOnStandardTopic(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	topic, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("standard-cbd")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	_, err = client.SetTopicAttributes(ctx, &awssns.SetTopicAttributesInput{
+		TopicArn:       topic.TopicArn,
+		AttributeName:  aws.String("ContentBasedDeduplication"),
+		AttributeValue: aws.String("true"),
+	})
+	if err == nil {
+		t.Fatal("SetTopicAttributes(ContentBasedDeduplication) on standard topic succeeded, want InvalidParameter")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not a smithy.APIError: %v", err)
+	}
+
+	if apiErr.ErrorCode() != "InvalidParameter" {
+		t.Fatalf("error code = %q, want InvalidParameter", apiErr.ErrorCode())
+	}
+}
+
+// TestSDKSetTopicAttributesContentBasedDeduplicationAllowedOnFifoTopic is the
+// positive counterpart: the same call on a .fifo topic must still succeed.
+func TestSDKSetTopicAttributesContentBasedDeduplicationAllowedOnFifoTopic(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	topic, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{
+		Name:       aws.String("fifo-cbd.fifo"),
+		Attributes: map[string]string{"FifoTopic": "true"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	if _, err := client.SetTopicAttributes(ctx, &awssns.SetTopicAttributesInput{
+		TopicArn:       topic.TopicArn,
+		AttributeName:  aws.String("ContentBasedDeduplication"),
+		AttributeValue: aws.String("true"),
+	}); err != nil {
+		t.Fatalf("SetTopicAttributes(ContentBasedDeduplication) on FIFO topic: %v", err)
+	}
+}

--- a/server/aws/sns/feedback_attributes_sdk_test.go
+++ b/server/aws/sns/feedback_attributes_sdk_test.go
@@ -1,0 +1,156 @@
+package sns_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
+)
+
+// TestSDKSetTopicAttributesSignatureVersionAndTracingConfig guards a
+// regression where SetTopicAttributes silently dropped SignatureVersion and
+// TracingConfig (no case in the attribute switch), causing a perpetual
+// Terraform diff on aws_sns_topic's signature_version / tracing_config.
+func TestSDKSetTopicAttributesSignatureVersionAndTracingConfig(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	topic, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("sig-tracing")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	if _, err := client.SetTopicAttributes(ctx, &awssns.SetTopicAttributesInput{
+		TopicArn:       topic.TopicArn,
+		AttributeName:  aws.String("SignatureVersion"),
+		AttributeValue: aws.String("2"),
+	}); err != nil {
+		t.Fatalf("SetTopicAttributes(SignatureVersion): %v", err)
+	}
+
+	if _, err := client.SetTopicAttributes(ctx, &awssns.SetTopicAttributesInput{
+		TopicArn:       topic.TopicArn,
+		AttributeName:  aws.String("TracingConfig"),
+		AttributeValue: aws.String("Active"),
+	}); err != nil {
+		t.Fatalf("SetTopicAttributes(TracingConfig): %v", err)
+	}
+
+	attrs := topicAttributes(t, client, aws.ToString(topic.TopicArn))
+
+	if attrs["SignatureVersion"] != "2" {
+		t.Fatalf("SignatureVersion = %q, want 2", attrs["SignatureVersion"])
+	}
+
+	if attrs["TracingConfig"] != "Active" {
+		t.Fatalf("TracingConfig = %q, want Active", attrs["TracingConfig"])
+	}
+}
+
+// TestSDKSetTopicAttributesSQSFeedbackFamily guards the delivery-status
+// feedback attributes Terraform's aws_sns_topic exposes as
+// sqs_success_feedback_role_arn / sqs_success_feedback_sample_rate /
+// sqs_failure_feedback_role_arn — previously dropped silently.
+func TestSDKSetTopicAttributesSQSFeedbackFamily(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	topic, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("sqs-feedback")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	sets := map[string]string{
+		"SQSSuccessFeedbackRoleArn":    "arn:aws:iam::123456789012:role/sns-feedback",
+		"SQSSuccessFeedbackSampleRate": "100",
+		"SQSFailureFeedbackRoleArn":    "arn:aws:iam::123456789012:role/sns-feedback",
+	}
+
+	for name, value := range sets {
+		if _, err := client.SetTopicAttributes(ctx, &awssns.SetTopicAttributesInput{
+			TopicArn:       topic.TopicArn,
+			AttributeName:  aws.String(name),
+			AttributeValue: aws.String(value),
+		}); err != nil {
+			t.Fatalf("SetTopicAttributes(%s): %v", name, err)
+		}
+	}
+
+	attrs := topicAttributes(t, client, aws.ToString(topic.TopicArn))
+
+	for name, want := range sets {
+		if got := attrs[name]; got != want {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestSDKCreateTopicFeedbackAttributes guards that the feedback family and
+// SignatureVersion/TracingConfig/ArchivePolicy can also be set at CreateTopic
+// time (real SNS accepts an Attributes map on create), not just via a later
+// SetTopicAttributes call.
+func TestSDKCreateTopicFeedbackAttributes(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	topic, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{
+		Name: aws.String("create-time-feedback"),
+		Attributes: map[string]string{
+			"SignatureVersion":                "2",
+			"TracingConfig":                   "Active",
+			"LambdaSuccessFeedbackRoleArn":    "arn:aws:iam::123456789012:role/sns-feedback",
+			"LambdaSuccessFeedbackSampleRate": "50",
+			"LambdaFailureFeedbackRoleArn":    "arn:aws:iam::123456789012:role/sns-feedback",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	attrs := topicAttributes(t, client, aws.ToString(topic.TopicArn))
+
+	want := map[string]string{
+		"SignatureVersion":                "2",
+		"TracingConfig":                   "Active",
+		"LambdaSuccessFeedbackRoleArn":    "arn:aws:iam::123456789012:role/sns-feedback",
+		"LambdaSuccessFeedbackSampleRate": "50",
+		"LambdaFailureFeedbackRoleArn":    "arn:aws:iam::123456789012:role/sns-feedback",
+	}
+
+	for name, wantVal := range want {
+		if got := attrs[name]; got != wantVal {
+			t.Fatalf("%s = %q, want %q", name, got, wantVal)
+		}
+	}
+}
+
+// TestSDKGetTopicAttributesOmitsUnsetFeedbackAttributes guards the AWS
+// response-inclusion rule: an attribute that was never set must be absent
+// from GetTopicAttributes entirely, not echoed as an empty string.
+func TestSDKGetTopicAttributesOmitsUnsetFeedbackAttributes(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	topic, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("no-feedback")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	attrs := topicAttributes(t, client, aws.ToString(topic.TopicArn))
+
+	unset := []string{
+		"SignatureVersion", "TracingConfig", "ArchivePolicy",
+		"SQSSuccessFeedbackRoleArn", "SQSFailureFeedbackRoleArn", "SQSSuccessFeedbackSampleRate",
+		"HTTPSuccessFeedbackRoleArn", "HTTPFailureFeedbackRoleArn", "HTTPSuccessFeedbackSampleRate",
+		"LambdaSuccessFeedbackRoleArn", "LambdaFailureFeedbackRoleArn", "LambdaSuccessFeedbackSampleRate",
+		"ApplicationSuccessFeedbackRoleArn", "ApplicationFailureFeedbackRoleArn", "ApplicationSuccessFeedbackSampleRate",
+		"FirehoseSuccessFeedbackRoleArn", "FirehoseFailureFeedbackRoleArn", "FirehoseSuccessFeedbackSampleRate",
+	}
+
+	for _, name := range unset {
+		if _, present := attrs[name]; present {
+			t.Fatalf("GetTopicAttributes includes unset attribute %q, want absent", name)
+		}
+	}
+}

--- a/server/aws/sns/operations.go
+++ b/server/aws/sns/operations.go
@@ -165,7 +165,7 @@ func (h *Handler) createTopic(w http.ResponseWriter, r *http.Request) {
 	name := r.Form.Get("Name")
 	attrs := parseSubscriptionAttributes(r.Form)
 
-	info, err := h.notif.CreateTopic(r.Context(), notifdriver.TopicConfig{
+	cfg := notifdriver.TopicConfig{
 		Name:                      name,
 		Tags:                      parseSNSTags(r.Form),
 		DisplayName:               attrs["DisplayName"],
@@ -174,7 +174,10 @@ func (h *Handler) createTopic(w http.ResponseWriter, r *http.Request) {
 		KmsMasterKeyID:            attrs["KmsMasterKeyId"],
 		FifoTopic:                 attrs["FifoTopic"] == attrTrue,
 		ContentBasedDeduplication: attrs["ContentBasedDeduplication"] == attrTrue,
-	})
+	}
+	applyFeedbackAttrs(&cfg, attrs)
+
+	info, err := h.notif.CreateTopic(r.Context(), cfg)
 	if err != nil {
 		if cerrors.IsAlreadyExists(err) {
 			if existing, gerr := h.notif.GetTopic(r.Context(), name); gerr == nil {
@@ -219,33 +222,21 @@ func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request) {
 // exposes the topic's ARN, display name, and subscription count as the standard
 // SNS attribute map.
 // setTopicAttributes maps SetTopicAttributes to Notification.UpdateTopic,
-// persisting DisplayName and Policy. Other attributes (DeliveryPolicy) are
-// accepted and dropped.
+// persisting every attribute real SetTopicAttributes accepts (DisplayName,
+// Policy, DeliveryPolicy, KmsMasterKeyId, ContentBasedDeduplication,
+// SignatureVersion, TracingConfig, ArchivePolicy, and the delivery-status
+// feedback family). An unrecognized attribute name is a no-op, matching real
+// SNS's behavior of ignoring attributes it doesn't own on this call.
 func (h *Handler) setTopicAttributes(w http.ResponseWriter, r *http.Request) {
 	name := topicNameFromARN(r.Form.Get("TopicArn"))
 
 	cfg := notifdriver.TopicConfig{Name: name}
 
+	attrName := r.Form.Get("AttributeName")
 	value := r.Form.Get("AttributeValue")
 
-	var apply bool
-
-	switch r.Form.Get("AttributeName") {
-	case "DisplayName":
-		cfg.DisplayName = value
-		apply = true
-	case "Policy":
-		cfg.Policy = value
-		apply = true
-	case "DeliveryPolicy":
-		cfg.DeliveryPolicy = value
-		apply = true
-	case "KmsMasterKeyId":
-		cfg.KmsMasterKeyID = value
-		apply = true
-	case "ContentBasedDeduplication":
-		cfg.ContentBasedDeduplication = value == attrTrue
-		cfg.ContentBasedDeduplicationSet = true
+	apply := applyCoreTopicAttribute(&cfg, attrName, value)
+	if applyFeedbackAttr(&cfg, attrName, value) {
 		apply = true
 	}
 
@@ -259,6 +250,124 @@ func (h *Handler) setTopicAttributes(w http.ResponseWriter, r *http.Request) {
 	awsquery.WriteXMLResponse(w, setTopicAttributesResponse{
 		Xmlns: Namespace, Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
+}
+
+// applyCoreTopicAttribute maps a single SetTopicAttributes AttributeName/Value
+// pair onto cfg for the pre-existing, non-feedback attributes. Reports whether
+// the name was recognized.
+func applyCoreTopicAttribute(cfg *notifdriver.TopicConfig, name, value string) bool {
+	switch name {
+	case "DisplayName":
+		cfg.DisplayName = value
+	case "Policy":
+		cfg.Policy = value
+	case "DeliveryPolicy":
+		cfg.DeliveryPolicy = value
+	case "KmsMasterKeyId":
+		cfg.KmsMasterKeyID = value
+	case "ContentBasedDeduplication":
+		cfg.ContentBasedDeduplication = value == attrTrue
+		cfg.ContentBasedDeduplicationSet = true
+	case "SignatureVersion":
+		cfg.SignatureVersion = value
+	case "TracingConfig":
+		cfg.TracingConfig = value
+	case "ArchivePolicy":
+		cfg.ArchivePolicy = value
+	default:
+		return false
+	}
+
+	return true
+}
+
+// applyFeedbackAttr maps a single SetTopicAttributes AttributeName/Value pair
+// onto cfg for the delivery-status feedback family. Reports whether the name
+// was recognized. Split across two per-protocol-group helpers to keep each
+// switch's cyclomatic complexity within the project's limit.
+func applyFeedbackAttr(cfg *notifdriver.TopicConfig, name, value string) bool {
+	if applyApplicationHTTPFeedbackAttr(cfg, name, value) {
+		return true
+	}
+
+	return applyLambdaSQSFirehoseFeedbackAttr(cfg, name, value)
+}
+
+// applyApplicationHTTPFeedbackAttr handles the Application/HTTP half of the
+// feedback family (see applyFeedbackAttr).
+func applyApplicationHTTPFeedbackAttr(cfg *notifdriver.TopicConfig, name, value string) bool {
+	switch name {
+	case "ApplicationSuccessFeedbackRoleArn":
+		cfg.ApplicationSuccessFeedbackRoleArn = value
+	case "ApplicationFailureFeedbackRoleArn":
+		cfg.ApplicationFailureFeedbackRoleArn = value
+	case "ApplicationSuccessFeedbackSampleRate":
+		cfg.ApplicationSuccessFeedbackSampleRate = value
+	case "HTTPSuccessFeedbackRoleArn":
+		cfg.HTTPSuccessFeedbackRoleArn = value
+	case "HTTPFailureFeedbackRoleArn":
+		cfg.HTTPFailureFeedbackRoleArn = value
+	case "HTTPSuccessFeedbackSampleRate":
+		cfg.HTTPSuccessFeedbackSampleRate = value
+	default:
+		return false
+	}
+
+	return true
+}
+
+// applyLambdaSQSFirehoseFeedbackAttr handles the Lambda/SQS/Firehose half of
+// the feedback family (see applyFeedbackAttr).
+func applyLambdaSQSFirehoseFeedbackAttr(cfg *notifdriver.TopicConfig, name, value string) bool {
+	switch name {
+	case "LambdaSuccessFeedbackRoleArn":
+		cfg.LambdaSuccessFeedbackRoleArn = value
+	case "LambdaFailureFeedbackRoleArn":
+		cfg.LambdaFailureFeedbackRoleArn = value
+	case "LambdaSuccessFeedbackSampleRate":
+		cfg.LambdaSuccessFeedbackSampleRate = value
+	case "SQSSuccessFeedbackRoleArn":
+		cfg.SQSSuccessFeedbackRoleArn = value
+	case "SQSFailureFeedbackRoleArn":
+		cfg.SQSFailureFeedbackRoleArn = value
+	case "SQSSuccessFeedbackSampleRate":
+		cfg.SQSSuccessFeedbackSampleRate = value
+	case "FirehoseSuccessFeedbackRoleArn":
+		cfg.FirehoseSuccessFeedbackRoleArn = value
+	case "FirehoseFailureFeedbackRoleArn":
+		cfg.FirehoseFailureFeedbackRoleArn = value
+	case "FirehoseSuccessFeedbackSampleRate":
+		cfg.FirehoseSuccessFeedbackSampleRate = value
+	default:
+		return false
+	}
+
+	return true
+}
+
+// applyFeedbackAttrs copies the delivery-status feedback family and
+// SignatureVersion/TracingConfig/ArchivePolicy from a CreateTopic Attributes
+// map onto cfg, mirroring the individual-attribute cases setTopicAttributes
+// applies one at a time. Real SNS accepts these at create time too.
+func applyFeedbackAttrs(cfg *notifdriver.TopicConfig, attrs map[string]string) {
+	cfg.SignatureVersion = attrs["SignatureVersion"]
+	cfg.TracingConfig = attrs["TracingConfig"]
+	cfg.ArchivePolicy = attrs["ArchivePolicy"]
+	cfg.ApplicationSuccessFeedbackRoleArn = attrs["ApplicationSuccessFeedbackRoleArn"]
+	cfg.ApplicationFailureFeedbackRoleArn = attrs["ApplicationFailureFeedbackRoleArn"]
+	cfg.ApplicationSuccessFeedbackSampleRate = attrs["ApplicationSuccessFeedbackSampleRate"]
+	cfg.HTTPSuccessFeedbackRoleArn = attrs["HTTPSuccessFeedbackRoleArn"]
+	cfg.HTTPFailureFeedbackRoleArn = attrs["HTTPFailureFeedbackRoleArn"]
+	cfg.HTTPSuccessFeedbackSampleRate = attrs["HTTPSuccessFeedbackSampleRate"]
+	cfg.LambdaSuccessFeedbackRoleArn = attrs["LambdaSuccessFeedbackRoleArn"]
+	cfg.LambdaFailureFeedbackRoleArn = attrs["LambdaFailureFeedbackRoleArn"]
+	cfg.LambdaSuccessFeedbackSampleRate = attrs["LambdaSuccessFeedbackSampleRate"]
+	cfg.SQSSuccessFeedbackRoleArn = attrs["SQSSuccessFeedbackRoleArn"]
+	cfg.SQSFailureFeedbackRoleArn = attrs["SQSFailureFeedbackRoleArn"]
+	cfg.SQSSuccessFeedbackSampleRate = attrs["SQSSuccessFeedbackSampleRate"]
+	cfg.FirehoseSuccessFeedbackRoleArn = attrs["FirehoseSuccessFeedbackRoleArn"]
+	cfg.FirehoseFailureFeedbackRoleArn = attrs["FirehoseFailureFeedbackRoleArn"]
+	cfg.FirehoseSuccessFeedbackSampleRate = attrs["FirehoseSuccessFeedbackSampleRate"]
 }
 
 func (h *Handler) listTagsForResource(w http.ResponseWriter, r *http.Request) {
@@ -323,14 +432,19 @@ func (h *Handler) getTopicAttributes(w http.ResponseWriter, r *http.Request) {
 }
 
 // optionalTopicAttributes returns the GetTopicAttributes entries SNS emits only
-// when set: DisplayName, DeliveryPolicy, KmsMasterKeyId, and — for a FIFO topic —
-// the FifoTopic / ContentBasedDeduplication flags.
+// when set: DisplayName, DeliveryPolicy, KmsMasterKeyId, SignatureVersion,
+// TracingConfig, ArchivePolicy, the delivery-status feedback family, and — for
+// a FIFO topic — the FifoTopic / ContentBasedDeduplication flags.
 func optionalTopicAttributes(info *notifdriver.TopicInfo) []attributeEntry {
 	var entries []attributeEntry
 
 	entries = appendNonEmptyAttr(entries, "DisplayName", info.DisplayName)
 	entries = appendNonEmptyAttr(entries, "DeliveryPolicy", info.DeliveryPolicy)
 	entries = appendNonEmptyAttr(entries, "KmsMasterKeyId", info.KmsMasterKeyID)
+	entries = appendNonEmptyAttr(entries, "SignatureVersion", info.SignatureVersion)
+	entries = appendNonEmptyAttr(entries, "TracingConfig", info.TracingConfig)
+	entries = appendNonEmptyAttr(entries, "ArchivePolicy", info.ArchivePolicy)
+	entries = append(entries, feedbackTopicAttributes(info)...)
 
 	if info.FifoTopic {
 		entries = append(entries,
@@ -341,6 +455,31 @@ func optionalTopicAttributes(info *notifdriver.TopicInfo) []attributeEntry {
 			},
 		)
 	}
+
+	return entries
+}
+
+// feedbackTopicAttributes returns the delivery-status feedback family's
+// GetTopicAttributes entries, each included only when set.
+func feedbackTopicAttributes(info *notifdriver.TopicInfo) []attributeEntry {
+	var entries []attributeEntry
+
+	entries = appendNonEmptyAttr(entries, "ApplicationSuccessFeedbackRoleArn", info.ApplicationSuccessFeedbackRoleArn)
+	entries = appendNonEmptyAttr(entries, "ApplicationFailureFeedbackRoleArn", info.ApplicationFailureFeedbackRoleArn)
+	entries = appendNonEmptyAttr(entries,
+		"ApplicationSuccessFeedbackSampleRate", info.ApplicationSuccessFeedbackSampleRate)
+	entries = appendNonEmptyAttr(entries, "HTTPSuccessFeedbackRoleArn", info.HTTPSuccessFeedbackRoleArn)
+	entries = appendNonEmptyAttr(entries, "HTTPFailureFeedbackRoleArn", info.HTTPFailureFeedbackRoleArn)
+	entries = appendNonEmptyAttr(entries, "HTTPSuccessFeedbackSampleRate", info.HTTPSuccessFeedbackSampleRate)
+	entries = appendNonEmptyAttr(entries, "LambdaSuccessFeedbackRoleArn", info.LambdaSuccessFeedbackRoleArn)
+	entries = appendNonEmptyAttr(entries, "LambdaFailureFeedbackRoleArn", info.LambdaFailureFeedbackRoleArn)
+	entries = appendNonEmptyAttr(entries, "LambdaSuccessFeedbackSampleRate", info.LambdaSuccessFeedbackSampleRate)
+	entries = appendNonEmptyAttr(entries, "SQSSuccessFeedbackRoleArn", info.SQSSuccessFeedbackRoleArn)
+	entries = appendNonEmptyAttr(entries, "SQSFailureFeedbackRoleArn", info.SQSFailureFeedbackRoleArn)
+	entries = appendNonEmptyAttr(entries, "SQSSuccessFeedbackSampleRate", info.SQSSuccessFeedbackSampleRate)
+	entries = appendNonEmptyAttr(entries, "FirehoseSuccessFeedbackRoleArn", info.FirehoseSuccessFeedbackRoleArn)
+	entries = appendNonEmptyAttr(entries, "FirehoseFailureFeedbackRoleArn", info.FirehoseFailureFeedbackRoleArn)
+	entries = appendNonEmptyAttr(entries, "FirehoseSuccessFeedbackSampleRate", info.FirehoseSuccessFeedbackSampleRate)
 
 	return entries
 }

--- a/server/aws/sns/subscribe_idempotency_sdk_test.go
+++ b/server/aws/sns/subscribe_idempotency_sdk_test.go
@@ -1,0 +1,92 @@
+package sns_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
+)
+
+// TestSDKSubscribeIdempotent guards real SNS's documented Subscribe semantics:
+// a repeat Subscribe with the same (TopicArn, Protocol, Endpoint) returns the
+// existing subscription's ARN instead of creating a duplicate.
+func TestSDKSubscribeIdempotent(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	topic, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("idempotent-sub-topic")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	first, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn: topic.TopicArn,
+		Protocol: aws.String("sqs"),
+		Endpoint: aws.String("arn:aws:sqs:us-east-1:123456789012:my-queue"),
+	})
+	if err != nil {
+		t.Fatalf("first Subscribe: %v", err)
+	}
+
+	second, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn: topic.TopicArn,
+		Protocol: aws.String("sqs"),
+		Endpoint: aws.String("arn:aws:sqs:us-east-1:123456789012:my-queue"),
+	})
+	if err != nil {
+		t.Fatalf("second Subscribe: %v", err)
+	}
+
+	if aws.ToString(first.SubscriptionArn) != aws.ToString(second.SubscriptionArn) {
+		t.Fatalf("Subscribe not idempotent: first ARN %q, second ARN %q",
+			aws.ToString(first.SubscriptionArn), aws.ToString(second.SubscriptionArn))
+	}
+
+	subs, err := client.ListSubscriptionsByTopic(ctx, &awssns.ListSubscriptionsByTopicInput{TopicArn: topic.TopicArn})
+	if err != nil {
+		t.Fatalf("ListSubscriptionsByTopic: %v", err)
+	}
+
+	if len(subs.Subscriptions) != 1 {
+		t.Fatalf("ListSubscriptionsByTopic returned %d subscriptions, want 1 (no duplicate)", len(subs.Subscriptions))
+	}
+}
+
+// TestSDKSubscribeIdempotentDistinctEndpoint guards the negative case: a
+// different endpoint on the same topic/protocol must still create a separate
+// subscription rather than being folded into the idempotency match.
+func TestSDKSubscribeIdempotentDistinctEndpoint(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	topic, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("distinct-sub-topic")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	if _, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn: topic.TopicArn,
+		Protocol: aws.String("sqs"),
+		Endpoint: aws.String("arn:aws:sqs:us-east-1:123456789012:queue-a"),
+	}); err != nil {
+		t.Fatalf("Subscribe queue-a: %v", err)
+	}
+
+	if _, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn: topic.TopicArn,
+		Protocol: aws.String("sqs"),
+		Endpoint: aws.String("arn:aws:sqs:us-east-1:123456789012:queue-b"),
+	}); err != nil {
+		t.Fatalf("Subscribe queue-b: %v", err)
+	}
+
+	subs, err := client.ListSubscriptionsByTopic(ctx, &awssns.ListSubscriptionsByTopicInput{TopicArn: topic.TopicArn})
+	if err != nil {
+		t.Fatalf("ListSubscriptionsByTopic: %v", err)
+	}
+
+	if len(subs.Subscriptions) != 2 {
+		t.Fatalf("ListSubscriptionsByTopic returned %d subscriptions, want 2 (distinct endpoints)", len(subs.Subscriptions))
+	}
+}

--- a/services/notification/driver/driver.go
+++ b/services/notification/driver/driver.go
@@ -33,6 +33,34 @@ type TopicConfig struct {
 	// always applies the field as given.
 	ContentBasedDeduplicationSet bool
 
+	// SignatureVersion ("1" or "2"), TracingConfig ("Active" or "PassThrough"),
+	// and ArchivePolicy (AWS SNS only) are persisted and echoed by
+	// GetTopicAttributes; a create/update omitting one leaves it unchanged
+	// (mirrors DeliveryPolicy/KmsMasterKeyID — empty means "no opinion").
+	SignatureVersion string
+	TracingConfig    string
+	ArchivePolicy    string
+
+	// The delivery-status feedback family (AWS SNS only) configures success/
+	// failure CloudWatch Logs sampling per delivery protocol. Each is persisted
+	// verbatim and echoed by GetTopicAttributes only when set; SampleRate is
+	// the literal "0"-"100" string SNS accepts, not validated further.
+	ApplicationSuccessFeedbackRoleArn    string
+	ApplicationFailureFeedbackRoleArn    string
+	ApplicationSuccessFeedbackSampleRate string
+	HTTPSuccessFeedbackRoleArn           string
+	HTTPFailureFeedbackRoleArn           string
+	HTTPSuccessFeedbackSampleRate        string
+	LambdaSuccessFeedbackRoleArn         string
+	LambdaFailureFeedbackRoleArn         string
+	LambdaSuccessFeedbackSampleRate      string
+	SQSSuccessFeedbackRoleArn            string
+	SQSFailureFeedbackRoleArn            string
+	SQSSuccessFeedbackSampleRate         string
+	FirehoseSuccessFeedbackRoleArn       string
+	FirehoseFailureFeedbackRoleArn       string
+	FirehoseSuccessFeedbackSampleRate    string
+
 	// Scope records where the resource lives (Azure subscription/resource
 	// group, GCP project). Zero for AWS and unscoped portable callers.
 	Scope scope.Scope
@@ -67,8 +95,32 @@ type TopicInfo struct {
 	// enforced.
 	FifoTopic                 bool
 	ContentBasedDeduplication bool
-	Tags                      map[string]string
-	Scope                     scope.Scope
+
+	// SignatureVersion, TracingConfig, ArchivePolicy, and the delivery-status
+	// feedback family mirror the TopicConfig fields of the same name — see
+	// there for what each means. Empty means unset; GetTopicAttributes omits an
+	// unset attribute rather than echoing "".
+	SignatureVersion                     string
+	TracingConfig                        string
+	ArchivePolicy                        string
+	ApplicationSuccessFeedbackRoleArn    string
+	ApplicationFailureFeedbackRoleArn    string
+	ApplicationSuccessFeedbackSampleRate string
+	HTTPSuccessFeedbackRoleArn           string
+	HTTPFailureFeedbackRoleArn           string
+	HTTPSuccessFeedbackSampleRate        string
+	LambdaSuccessFeedbackRoleArn         string
+	LambdaFailureFeedbackRoleArn         string
+	LambdaSuccessFeedbackSampleRate      string
+	SQSSuccessFeedbackRoleArn            string
+	SQSFailureFeedbackRoleArn            string
+	SQSSuccessFeedbackSampleRate         string
+	FirehoseSuccessFeedbackRoleArn       string
+	FirehoseFailureFeedbackRoleArn       string
+	FirehoseSuccessFeedbackSampleRate    string
+
+	Tags  map[string]string
+	Scope scope.Scope
 	// Region is the geographic location the resource was created in (Azure
 	// location). Empty for AWS and unscoped portable callers.
 	Region string


### PR DESCRIPTION
## Fix 1 — Subscribe idempotency

`Subscribe` created a new subscription on every call, even for an identical (TopicArn, Protocol, Endpoint) triple. Real SNS Subscribe is idempotent on that triple: a repeat call returns the existing subscription (pending or confirmed) instead of a duplicate.

`providers/aws/sns/sns.go` `Mock.Subscribe` now scans existing subscriptions for a (Protocol, Endpoint) match before creating one, under `topicData.mu` so two concurrent identical Subscribe calls can't race into two subscriptions.

**Re-verify (aws-cli against a rebuilt binary):** two `sns subscribe` calls with the same sqs endpoint returned the identical `SubscriptionArn` (`sub-00000012`), and `list-subscriptions-by-topic` showed exactly one subscription.

## Fix 2 — SetTopicAttributes silently dropped attributes

`setTopicAttributes` had no case for `SignatureVersion`, `TracingConfig`, `ArchivePolicy`, or the delivery-status feedback family (Application/HTTP/Lambda/SQS/Firehose success/failure role ARNs + sample rates). Each hit the no-op default, so `GetTopicAttributes` never echoed them back, causing a perpetual Terraform diff on `aws_sns_topic`.

These attributes are now persisted on `TopicInfo`/`TopicConfig` (additive fields, AWS-only) and echoed by `GetTopicAttributes` only when set, mirroring the existing `DeliveryPolicy`/`KmsMasterKeyId` round-trip pattern. They can also be set at `CreateTopic` time, matching real SNS.

**Re-verify (real terraform-provider-aws against a rebuilt binary):** applied an `aws_sns_topic` with `signature_version = 2`, `tracing_config = "Active"`, and the `sqs_*_feedback_*` attributes — `terraform plan -detailed-exitcode` exits **0** (no diff). Also round-tripped via aws-cli `set-topic-attributes` / `get-topic-attributes`.

## Fix 3 — UpdateTopic allowed ContentBasedDeduplication on a non-FIFO topic

Real AWS rejects `ContentBasedDeduplication` on a standard (non-FIFO) topic with `InvalidParameter`. `UpdateTopic` accepted it silently. Now rejected when `ContentBasedDeduplicationSet` is true and the topic isn't FIFO; the FIFO case is unaffected.

**Re-verify (aws-cli against a rebuilt binary):** `set-topic-attributes ContentBasedDeduplication=true` on a standard topic returned `InvalidParameter`; the same call on a `.fifo` topic succeeded.