### PR TITLE
fix(route53): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/route53/route53.go
+++ b/providers/aws/route53/route53.go
@@ -276,6 +276,27 @@ func (m *Mock) UpdateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 	return &result, nil
 }
 
+// UpdateZoneComment updates a hosted zone's Comment by id — the AWS-only
+// UpdateHostedZoneComment operation, addressed by id rather than name (unlike
+// UpdateZone's ARM-style match-by-name). The server package picks this method
+// up via an optional interface assertion, the same pattern DeleteRecordSet
+// uses for its AWS-only SetIdentifier-addressed delete.
+func (m *Mock) UpdateZoneComment(_ context.Context, id, comment string) (*driver.ZoneInfo, error) {
+	if _, ok := m.zones.Get(id); !ok {
+		return nil, errors.Newf(errors.NotFound, "zone %q not found", id)
+	}
+
+	m.zones.Update(id, func(z driver.ZoneInfo) driver.ZoneInfo {
+		z.Comment = comment
+		return z
+	})
+
+	updated, _ := m.zones.Get(id)
+	result := updated
+
+	return &result, nil
+}
+
 // AssociateVPC adds an Amazon VPC to a private hosted zone's association list.
 // It is idempotent: associating an already-associated VPC is a no-op. Caller
 // validation (the zone must be private) is done at the wire layer, which has

--- a/server/aws/route53/handler.go
+++ b/server/aws/route53/handler.go
@@ -191,6 +191,8 @@ func (h *Handler) serveZone(w http.ResponseWriter, r *http.Request, id string) {
 		h.getHostedZone(w, r, id)
 	case http.MethodDelete:
 		h.deleteHostedZone(w, r, id)
+	case http.MethodPost:
+		h.updateHostedZoneComment(w, r, id)
 	default:
 		writeMethodNotAllowed(w)
 	}

--- a/server/aws/route53/health_check.go
+++ b/server/aws/route53/health_check.go
@@ -263,11 +263,11 @@ func toHealthCheckXML(info *dnsdriver.HealthCheckInfo) healthCheckXML {
 func writeHealthCheckErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "NoSuchHealthCheck", err.Error())
+		writeError(w, http.StatusNotFound, "NoSuchHealthCheck", cleanMsg(err))
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "InvalidInput", err.Error())
+		writeError(w, http.StatusBadRequest, "InvalidInput", cleanMsg(err))
 	default:
-		writeError(w, http.StatusInternalServerError, "InternalError", err.Error())
+		writeError(w, http.StatusInternalServerError, "InternalError", cleanMsg(err))
 	}
 }
 

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -74,7 +74,7 @@ func (h *Handler) createHostedZone(w http.ResponseWriter, r *http.Request) {
 		Xmlns:         xmlns,
 		HostedZone:    hz,
 		ChangeInfo:    newChangeInfo(),
-		DelegationSet: delegationSetXML{NameServers: nameServers},
+		DelegationSet: delegationSetXML{NameServers: delegationSetNameServers(nameServers, info.Private)},
 	}
 
 	// A private zone created with a VPC echoes that VPC back at the top level.
@@ -95,8 +95,35 @@ func (h *Handler) seedZoneRecords(r *http.Request, zoneID, zoneName string, name
 		ZoneID: zoneID, Name: zoneName, Type: "SOA", TTL: soaTTL, Values: []string{soaValue},
 	})
 	_, _ = h.dns.CreateRecord(r.Context(), dnsdriver.RecordConfig{
-		ZoneID: zoneID, Name: zoneName, Type: "NS", TTL: nsTTL, Values: nameServers,
+		ZoneID: zoneID, Name: zoneName, Type: "NS", TTL: nsTTL, Values: dottedNameServers(nameServers),
 	})
+}
+
+// dottedNameServers returns nameServers as FQDNs (trailing dot) — the form real
+// Route 53 stores an NS record set's ResourceRecord VALUES in. This is distinct
+// from DelegationSet.NameServers (and the CreateHostedZone/GetHostedZone
+// response), which real Route 53 returns without a trailing dot for a public
+// zone, so the two lists must not share a slice.
+func dottedNameServers(nameServers []string) []string {
+	out := make([]string, len(nameServers))
+	for i, ns := range nameServers {
+		out[i] = ensureTrailingDot(ns)
+	}
+
+	return out
+}
+
+// delegationSetNameServers returns the DelegationSet.NameServers real Route 53
+// exposes for a hosted zone: bare hostnames for a public zone, FQDNs (trailing
+// dot) for a private one. This asymmetry is a real, if inconsistent, Route 53
+// quirk (hashicorp/terraform-provider-aws#14863) that practitioners specifically
+// work around, not a normalization cloudemu should smooth over.
+func delegationSetNameServers(nameServers []string, private bool) []string {
+	if !private {
+		return nameServers
+	}
+
+	return dottedNameServers(nameServers)
 }
 
 func (h *Handler) getHostedZone(w http.ResponseWriter, r *http.Request, id string) {
@@ -109,9 +136,40 @@ func (h *Handler) getHostedZone(w http.ResponseWriter, r *http.Request, id strin
 	wire.WriteXML(w, http.StatusOK, getHostedZoneResponse{
 		Xmlns:         xmlns,
 		HostedZone:    toHostedZoneXML(info),
-		DelegationSet: delegationSetXML{NameServers: nameServersFor(info.ID)},
+		DelegationSet: delegationSetXML{NameServers: delegationSetNameServers(nameServersFor(info.ID), info.Private)},
 		VPCs:          toVPCsXML(info.VPCs),
 	})
+}
+
+// zoneCommentUpdater is the AWS-only extension a Route 53 backend implements to
+// update a hosted zone's Comment by id (UpdateHostedZoneComment). Backends
+// without it report the operation as unsupported, the same fallback pattern
+// deleteRecordSet uses for the SetIdentifier-addressed DeleteRecordSet.
+type zoneCommentUpdater interface {
+	UpdateZoneComment(ctx context.Context, id, comment string) (*dnsdriver.ZoneInfo, error)
+}
+
+// updateHostedZoneComment answers UpdateHostedZoneComment, real Route 53's
+// POST /hostedzone/{id} operation that edits only the zone's Comment.
+func (h *Handler) updateHostedZoneComment(w http.ResponseWriter, r *http.Request, id string) {
+	var req updateHostedZoneCommentRequest
+	if !decodeXML(w, r, &req) {
+		return
+	}
+
+	updater, ok := h.dns.(zoneCommentUpdater)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "InternalError", "UpdateHostedZoneComment is not supported by this backend")
+		return
+	}
+
+	info, err := updater.UpdateZoneComment(r.Context(), trimZonePrefix(id), req.Comment)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteXML(w, http.StatusOK, updateHostedZoneCommentResponse{Xmlns: xmlns, HostedZone: toHostedZoneXML(info)})
 }
 
 // listHostedZones answers ListHostedZones. Hosted zones are account-global, so
@@ -782,13 +840,13 @@ func writeErr(w http.ResponseWriter, err error) {
 	case cerrors.IsNotFound(err):
 		writeError(w, http.StatusNotFound, "NoSuchHostedZone", cleanMsg(err))
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "HostedZoneAlreadyExists", err.Error())
+		writeError(w, http.StatusConflict, "HostedZoneAlreadyExists", cleanMsg(err))
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "InvalidInput", err.Error())
+		writeError(w, http.StatusBadRequest, "InvalidInput", cleanMsg(err))
 	case cerrors.IsFailedPrecondition(err):
-		writeError(w, http.StatusBadRequest, "InvalidChangeBatch", err.Error())
+		writeError(w, http.StatusBadRequest, "InvalidChangeBatch", cleanMsg(err))
 	default:
-		writeError(w, http.StatusInternalServerError, "InternalError", err.Error())
+		writeError(w, http.StatusInternalServerError, "InternalError", cleanMsg(err))
 	}
 }
 
@@ -799,10 +857,10 @@ func writeErr(w http.ResponseWriter, err error) {
 func writeChangeErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err), cerrors.IsAlreadyExists(err), cerrors.IsFailedPrecondition(err):
-		writeError(w, http.StatusBadRequest, "InvalidChangeBatch", err.Error())
+		writeError(w, http.StatusBadRequest, "InvalidChangeBatch", cleanMsg(err))
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "InvalidInput", err.Error())
+		writeError(w, http.StatusBadRequest, "InvalidInput", cleanMsg(err))
 	default:
-		writeError(w, http.StatusInternalServerError, "InternalError", err.Error())
+		writeError(w, http.StatusInternalServerError, "InternalError", cleanMsg(err))
 	}
 }

--- a/server/aws/route53/types.go
+++ b/server/aws/route53/types.go
@@ -106,6 +106,12 @@ type createHostedZoneRequest struct {
 	VPC              *vpcXML              `xml:"VPC"`
 }
 
+// updateHostedZoneCommentRequest is the UpdateHostedZoneComment request body.
+type updateHostedZoneCommentRequest struct {
+	XMLName xml.Name `xml:"UpdateHostedZoneCommentRequest"`
+	Comment string   `xml:"Comment"`
+}
+
 // associateVPCRequest is the AssociateVPCWithHostedZone request body.
 type associateVPCRequest struct {
 	XMLName xml.Name `xml:"AssociateVPCWithHostedZoneRequest"`
@@ -145,6 +151,15 @@ type createHostedZoneResponse struct {
 	DelegationSet delegationSetXML `xml:"DelegationSet"`
 	// VPC is returned only for a private hosted zone created with a VPC.
 	VPC *vpcXML `xml:"VPC,omitempty"`
+}
+
+// updateHostedZoneCommentResponse carries the updated hosted zone back, the
+// same as GetHostedZone but without a DelegationSet — matching real Route 53's
+// UpdateHostedZoneComment response shape.
+type updateHostedZoneCommentResponse struct {
+	XMLName    xml.Name      `xml:"UpdateHostedZoneCommentResponse"`
+	Xmlns      string        `xml:"xmlns,attr"`
+	HostedZone hostedZoneXML `xml:"HostedZone"`
 }
 
 type getHostedZoneResponse struct {


### PR DESCRIPTION
## Summary
- Stop leaking cloudemu's internal error-code prefix (e.g. `FailedPrecondition: `) into Route 53 wire error messages — `writeErr`/`writeChangeErr`/`writeHealthCheckErr` now consistently use the existing `cleanMsg` helper instead of `err.Error()`.
- Auto-created NS record set values now carry the trailing dot real Route 53 stores FQDN resource-record values with; `DelegationSet.NameServers` stays undotted for public zones (unchanged).
- `DelegationSet.NameServers` now carries a trailing dot for private hosted zones, matching real Route 53's documented public/private asymmetry (hashicorp/terraform-provider-aws#14863).
- Implement `UpdateHostedZoneComment` (`POST /hostedzone/{id}`), previously entirely missing and returning 405 `InvalidInput` — this broke any Terraform apply that edited an existing zone's `comment` attribute.

## Verification (black-box, real-user)
All four fixes were re-verified against a freshly rebuilt `cloudemu serve` binary using aws-cli and Terraform (hashicorp/aws ~> 5.0) against `http://localhost:14702`, not just unit tests:

- Error messages: `change-resource-record-sets` with an apex CNAME now returns `RRSet of type CNAME with DNS name fixverify.com. is not permitted at apex in zone fixverify.com.` (no `FailedPrecondition:` prefix). Same for `GetHealthCheck` NotFound, DELETE value-mismatch, and missing-`SetIdentifier` cases.
- NS trailing dot: `create-hosted-zone` + `list-resource-record-sets` now shows `"ns-3047.awsdns-39.com."` in the NS record set while `DelegationSet.NameServers` on the same response stays undotted for a public zone.
- Private-zone dot asymmetry: created a public and private zone side by side — private zone's `DelegationSet.NameServers` carries trailing dots, public zone's doesn't.
- `UpdateHostedZoneComment`: created a zone via Terraform with `comment = "initial comment"`, changed it and re-applied — modification now succeeds (previously errored), and `terraform plan` afterward reports no changes.
- Full Terraform lifecycle (`aws_route53_zone` public+private with `vpc{}`, `aws_route53_record` A/AAAA/CNAME/MX/TXT + all 5 routing policies + alias, `aws_route53_health_check`) re-run end to end after the fixes: `terraform apply` → `terraform plan` shows **No changes** (no perpetual diff introduced), then clean `terraform destroy`.

`go build ./...`, `go test ./... -race` (full suite), `go vet`, `gofmt`, and `golangci-lint` all clean; `go generate ./...` produces no `docs/coverage` diff (no driver-interface surface changed).

## Test plan
- [x] `go build ./...`
- [x] `go test ./providers/aws/route53/... ./server/aws/route53/... -race`
- [x] `go test ./server/... ./providers/aws/... ./services/dns/... -race` (full suite)
- [x] `golangci-lint run` on changed packages — no new issues vs. base
- [x] `go generate ./...` — no `docs/coverage` diff
- [x] Black-box re-verify via aws-cli + Terraform against a rebuilt `cloudemu serve` binary (see above)