### PR TITLE
fix(azure): real-user e2e divergences (RG + storage)

### DIFF
--- a/server/azure/resourcegroups/handler.go
+++ b/server/azure/resourcegroups/handler.go
@@ -168,8 +168,10 @@ func (h *Handler) serveGroup(w http.ResponseWriter, r *http.Request, sub, name s
 		h.put(w, r, sub, name)
 	case http.MethodPatch:
 		h.patch(w, r, sub, name)
-	case http.MethodGet, http.MethodHead:
+	case http.MethodGet:
 		h.get(w, sub, name)
+	case http.MethodHead:
+		h.checkExistence(w, sub, name)
 	case http.MethodDelete:
 		h.remove(w, r, sub, name)
 	default:
@@ -260,6 +262,24 @@ func (h *Handler) get(w http.ResponseWriter, sub, name string) {
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, group)
+}
+
+// checkExistence answers a HEAD request (armresources'
+// ResourceGroupsClient.CheckExistence): real ARM replies 204 with no body
+// when the group exists and 404 with no body otherwise — the SDK's response
+// handler only accepts those two codes and errors on any other status,
+// including a 200 carrying a JSON body.
+func (h *Handler) checkExistence(w http.ResponseWriter, sub, name string) {
+	h.mu.RLock()
+	_, ok := h.groups[sub][strings.ToLower(name)]
+	h.mu.RUnlock()
+
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) list(w http.ResponseWriter, sub string) {

--- a/server/azure/storageaccount/handler.go
+++ b/server/azure/storageaccount/handler.go
@@ -34,12 +34,16 @@ import (
 )
 
 const (
-	providerName    = "Microsoft.Storage"
-	resourceType    = "storageAccounts"
-	defaultLocation = "eastus"
+	providerName        = "Microsoft.Storage"
+	resourceType        = "storageAccounts"
+	checkNameActionType = "checkNameAvailability"
+	defaultLocation     = "eastus"
 
 	skuStandardPrefix = "Standard"
 	skuPremiumPrefix  = "Premium"
+
+	minAccountNameLen = 3
+	maxAccountNameLen = 24
 )
 
 // attrBackend is the optional storage-account attribute capability. The Azure
@@ -87,17 +91,22 @@ func New(b storagedriver.Bucket) *Handler {
 	return h
 }
 
-// Matches claims only the ARM management path for storage accounts. It never
-// claims the blob data-plane path (blob.core.windows.net-style URLs never start
-// with /subscriptions/), so blob routing is undisturbed.
+// Matches claims the ARM management path for storage accounts plus the
+// subscription-scoped checkNameAvailability action. It never claims the blob
+// data-plane path (blob.core.windows.net-style URLs never start with
+// /subscriptions/), so blob routing is undisturbed.
 func (*Handler) Matches(r *http.Request) bool {
 	rp, ok := azurearm.ParsePath(r.URL.Path)
 	if !ok {
 		return false
 	}
 
-	return strings.EqualFold(rp.Provider, providerName) &&
-		strings.EqualFold(rp.ResourceType, resourceType)
+	if !strings.EqualFold(rp.Provider, providerName) {
+		return false
+	}
+
+	return strings.EqualFold(rp.ResourceType, resourceType) ||
+		strings.EqualFold(rp.ResourceType, checkNameActionType)
 }
 
 // ServeHTTP routes the request based on path shape and method.
@@ -108,29 +117,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// An empty resource name is a collection path — a subscription- or
-	// resource-group-scoped list (…/storageAccounts). Route it to the list
-	// handler rather than rejecting it, so a management-plane inventory sees
-	// accounts created by PUT (matching real Azure and the disks/vnet handlers).
-	if rp.ResourceName == "" {
-		h.serveCollection(w, r, &rp)
-		return
-	}
-
-	// GET/PUT .../storageAccounts/{name}/blobServices/default —
-	// BlobServicesClient GetServiceProperties/SetServiceProperties. This is a
-	// distinct sub-resource from the account itself: it must never fall through
-	// to createOrUpdate, which would silently wipe the account's SKU/properties
-	// on every "enable versioning" call.
-	if strings.EqualFold(rp.SubResource, "blobServices") {
-		h.serveBlobService(w, r, &rp)
-		return
-	}
-
-	// POST .../storageAccounts/{name}/{action} — key management (listKeys,
-	// regenerateKey). These carry a sub-resource action segment.
-	if r.Method == http.MethodPost && rp.SubResource != "" {
-		h.serveAction(w, r, &rp)
+	if h.serveNonAccountRoute(w, r, &rp) {
 		return
 	}
 
@@ -146,6 +133,67 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
+}
+
+// serveNonAccountRoute handles the request shapes that are not a plain
+// create/get/update/delete on the account resource itself: the
+// checkNameAvailability action, the account collection (list), the
+// blobServices/default sub-resource, and the listKeys/regenerateKey POST
+// actions. Reports whether it handled the request (the caller must not fall
+// through to the account-resource switch when true).
+func (h *Handler) serveNonAccountRoute(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) bool {
+	// POST /subscriptions/{sub}/providers/Microsoft.Storage/checkNameAvailability
+	// — AccountsClient.CheckNameAvailability. Subscription-scoped, no resource
+	// group or account name in the path.
+	if strings.EqualFold(rp.ResourceType, checkNameActionType) {
+		h.checkNameAvailability(w, r)
+		return true
+	}
+
+	// An empty resource name is a collection path — a subscription- or
+	// resource-group-scoped list (…/storageAccounts). Route it to the list
+	// handler rather than rejecting it, so a management-plane inventory sees
+	// accounts created by PUT (matching real Azure and the disks/vnet handlers).
+	if rp.ResourceName == "" {
+		h.serveCollection(w, r, rp)
+		return true
+	}
+
+	// GET/PUT .../storageAccounts/{name}/blobServices/default —
+	// BlobServicesClient GetServiceProperties/SetServiceProperties.
+	if strings.EqualFold(rp.SubResource, "blobServices") {
+		h.serveBlobServiceRoute(w, r, rp)
+		return true
+	}
+
+	// POST .../storageAccounts/{name}/{action} — key management (listKeys,
+	// regenerateKey). These carry a sub-resource action segment.
+	if r.Method == http.MethodPost && rp.SubResource != "" {
+		h.serveAction(w, r, rp)
+		return true
+	}
+
+	return false
+}
+
+// serveBlobServiceRoute serves .../storageAccounts/{name}/blobServices/default,
+// the BlobServicesClient GetServiceProperties/SetServiceProperties
+// sub-resource — a distinct resource from the account itself that must never
+// fall through to createOrUpdate, which would silently wipe the account's
+// SKU/properties on every "enable versioning" call. A path that continues
+// past .../default (e.g. .../blobServices/default/containers/{name}, the ARM
+// BlobContainers sub-resource) is not this resource and must not be silently
+// treated as a blob-service-properties write — that would fake success on an
+// unimplemented resource instead of reporting it as missing.
+func (h *Handler) serveBlobServiceRoute(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if rp.SubResourceAction != "" {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound",
+			"the sub-resource '"+rp.SubResourceAction+"' is not supported")
+
+		return
+	}
+
+	h.serveBlobService(w, r, rp)
 }
 
 // serveAction routes the POST action sub-resources (listKeys, regenerateKey).
@@ -203,6 +251,68 @@ func (h *Handler) regenerateKey(w http.ResponseWriter, r *http.Request, rp *azur
 	azurearm.WriteJSON(w, http.StatusOK, toARMKeyList(keys))
 }
 
+// checkNameAvailability serves POST
+// .../providers/Microsoft.Storage/checkNameAvailability (AccountsClient.
+// CheckNameAvailability): real Azure validates the name's charset/length and,
+// only when that passes, checks it against every storage account name already
+// taken anywhere in Azure. The emulator is single-estate, so "taken" means an
+// account of that name already exists here.
+func (h *Handler) checkNameAvailability(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	var body armCheckNameAvailabilityReq
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	if msg, ok := accountNameError(body.Name); !ok {
+		azurearm.WriteJSON(w, http.StatusOK, armCheckNameAvailabilityResult{
+			NameAvailable: false, Reason: "AccountNameInvalid", Message: msg,
+		})
+
+		return
+	}
+
+	if h.bucketExists(r.Context(), body.Name) {
+		azurearm.WriteJSON(w, http.StatusOK, armCheckNameAvailabilityResult{
+			NameAvailable: false, Reason: "AlreadyExists",
+			Message: "The storage account named " + body.Name + " is already taken.",
+		})
+
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armCheckNameAvailabilityResult{NameAvailable: true})
+}
+
+// accountNameError reports whether name satisfies real Azure's storage
+// account naming rule (3-24 characters, lower-case letters and numbers only),
+// returning ok=false and the exact real-Azure AccountNameInvalid message
+// otherwise.
+func accountNameError(name string) (msg string, ok bool) {
+	if len(name) < minAccountNameLen || len(name) > maxAccountNameLen || !isLowerAlnum(name) {
+		return name + " is not a valid storage account name. Storage account name must be between 3 and 24 " +
+			"characters in length and use numbers and lower-case letters only.", false
+	}
+
+	return "", true
+}
+
+// isLowerAlnum reports whether s consists only of lower-case ASCII letters and
+// digits — the character set real Azure enforces for a storage account name.
+func isLowerAlnum(s string) bool {
+	for _, c := range s {
+		if (c < 'a' || c > 'z') && (c < '0' || c > '9') {
+			return false
+		}
+	}
+
+	return true
+}
+
 // toARMKeyList maps driver keys to the ARM StorageAccountListKeysResult shape.
 func toARMKeyList(keys []storagedriver.AccountKey) armKeyList {
 	out := armKeyList{Keys: make([]armKey, 0, len(keys))}
@@ -256,6 +366,11 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azu
 	}
 
 	name := rp.ResourceName
+
+	if msg, ok := accountNameError(name); !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "AccountNameInvalid", msg)
+		return
+	}
 
 	// Upsert: an existing account (bucket) re-applies its cost attributes rather
 	// than erroring, matching real Azure's create-or-update semantics.

--- a/server/azure/storageaccount/sdk_test.go
+++ b/server/azure/storageaccount/sdk_test.go
@@ -132,7 +132,7 @@ func TestSDKStorageAccountList(t *testing.T) {
 	ctx := context.Background()
 	client := newAccountsClient(t)
 
-	for _, name := range []string{"acctA", "acctB"} {
+	for _, name := range []string{"accta", "acctb"} {
 		poller, err := client.BeginCreate(ctx, "rg-1", name, armstorage.AccountCreateParameters{
 			Location: to.Ptr("eastus"),
 			Kind:     to.Ptr(armstorage.KindBlockBlobStorage),
@@ -168,7 +168,7 @@ func TestSDKStorageAccountList(t *testing.T) {
 		}
 		return out, nil
 	})
-	assert.ElementsMatch(t, []string{"acctA", "acctB"}, subNames, "subscription-scoped list must return both accounts")
+	assert.ElementsMatch(t, []string{"accta", "acctb"}, subNames, "subscription-scoped list must return both accounts")
 
 	// Resource-group-scoped list.
 	rgPager := client.NewListByResourceGroupPager("rg-1", nil)
@@ -183,7 +183,7 @@ func TestSDKStorageAccountList(t *testing.T) {
 		}
 		return out, nil
 	})
-	assert.ElementsMatch(t, []string{"acctA", "acctB"}, rgNames, "resource-group-scoped list must return both accounts")
+	assert.ElementsMatch(t, []string{"accta", "acctb"}, rgNames, "resource-group-scoped list must return both accounts")
 }
 
 // Storage account create-or-update is a long-running operation in the ARM SDK:
@@ -197,7 +197,7 @@ func TestSDKStorageAccountCreateReturns200LROContract(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	url := ts.URL + "/subscriptions/sub-1/resourceGroups/rg-1/providers/" +
-		"Microsoft.Storage/storageAccounts/acct-status?api-version=2023-01-01"
+		"Microsoft.Storage/storageAccounts/acctstatus?api-version=2023-01-01"
 	body := `{"location":"westus2","kind":"StorageV2","sku":{"name":"Standard_LRS"}}`
 
 	put := func() int {

--- a/server/azure/storageaccount/types.go
+++ b/server/azure/storageaccount/types.go
@@ -137,6 +137,23 @@ type armRegenerateKey struct {
 	KeyName string `json:"keyName"`
 }
 
+// armCheckNameAvailabilityReq is the checkNameAvailability request body:
+// armstorage's AccountCheckNameAvailabilityParameters marshals to these JSON
+// field names ("type" is always "Microsoft.Storage/storageAccounts" and
+// unused here).
+type armCheckNameAvailabilityReq struct {
+	Name string `json:"name"`
+	Type string `json:"type,omitempty"`
+}
+
+// armCheckNameAvailabilityResult is the checkNameAvailability response:
+// armstorage's CheckNameAvailabilityResult shape.
+type armCheckNameAvailabilityResult struct {
+	Message       string `json:"message,omitempty"`
+	NameAvailable bool   `json:"nameAvailable"`
+	Reason        string `json:"reason,omitempty"`
+}
+
 // armBlobServiceProperties is the ARM wire shape for the storage-account Blob
 // service properties sub-resource (…/blobServices/default), returned by both
 // BlobServicesClient.SetServiceProperties and .GetServiceProperties.


### PR DESCRIPTION
First deep real-user e2e audit of the Azure surface (RG + Storage Accounts), driven black-box via the real azure-sdk-for-go against a running \`cloudemu serve -providers=azure\`. Four genuine divergences vs real Azure ARM, each black-box re-verified (broken repro → fix → fixed repro) with the real SDK.

## Fixes
- **RG CheckExistence (HEAD)** returned 200+JSON instead of 204/404 — broke the real SDK's \`CheckExistence\` call. Now routes to a dedicated handler returning 204 (exists) / 404 (absent), no body.
- **Storage account name validation** — create accepted invalid names (uppercase/hyphens/wrong length). Now enforces real Azure's rule (3–24 lowercase letters+digits) with the exact \`AccountNameInvalid\` message.
- **checkNameAvailability** endpoint was unimplemented (501) — now implemented (AccountNameInvalid / AlreadyExists / available) matching the armstorage wire shape.
- **Blob-container ARM sub-path** silently mis-routed into blob-service-properties (faking 200 while doing nothing) — now a clean 404 for the unimplemented management-plane sub-path.

Two fixtures in \`sdk_test.go\` were renamed to valid names (they were invalid per real Azure and only passed because validation didn't exist).

## Verification
\`go build ./...\`, \`go vet\`, \`go test ./providers/azure/... ./server/azure/... -race\`, \`gofmt -l\`, \`golangci-lint\` (0 new), \`go generate\` (no docs/coverage drift) — all green. Each fix re-verified black-box with the real SDK client.

## Filed for follow-up (out of pilot scope)
- ARM BlobContainers management-plane CRUD (needs 2-level sub-path parsing + a new store).
- Storage account names not globally unique across resource groups (touches the upsert contract).