### PR TITLE
fix(azure-compute): real-user e2e divergences (VMs)

### DIFF
--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -812,13 +812,17 @@ func applyMutableConfig(inst *instanceData, cfg driver.InstanceConfig, instanceI
 	}
 }
 
-// PatchInstance applies an ARM PATCH Update (BeginUpdate) merge-patch to an
-// existing instance. Only the fields the request supplied are applied: a
-// non-empty VMSize resizes the VM, a non-nil Tags map is MERGED into the
-// existing tags (adding/overwriting supplied keys, leaving omitted keys —
-// including the internal ARM-name tag — in place), and a non-nil Identity
-// replaces the identity block. Everything else (priority, licenseType, image,
-// zones, …) is left untouched, unlike UpdateInstance's full-config replace.
+// PatchInstance applies an ARM PATCH Update (BeginUpdate) to an existing
+// instance. Only the fields the request supplied are applied: a non-empty
+// VMSize resizes the VM, a non-nil Identity replaces the identity block, and a
+// non-nil Tags map REPLACES the existing tags wholesale — real Azure's PATCH
+// tags is a full replace, not a merge, despite PATCH otherwise reading as a
+// merge-patch (this is a well-documented Azure Compute quirk; see the sibling
+// SQL-VM UpdateTags). The internal ARM-name tag is preserved across the
+// replace since it is never part of the caller-supplied patch.Tags and
+// findByName depends on it surviving a tag PATCH. Everything else (priority,
+// licenseType, image, zones, …) is left untouched, unlike UpdateInstance's
+// full-config replace.
 func (m *Mock) PatchInstance(_ context.Context, instanceID string, patch driver.AzureVMPatch) error {
 	ok := m.instances.Update(instanceID, func(inst *instanceData) *instanceData {
 		if patch.VMSize != "" {
@@ -826,12 +830,11 @@ func (m *Mock) PatchInstance(_ context.Context, instanceID string, patch driver.
 		}
 
 		if patch.Tags != nil {
-			if inst.Tags == nil {
-				inst.Tags = make(map[string]string, len(patch.Tags))
-			}
+			armName := inst.Tags[armNameTag]
+			inst.Tags = copyTags(patch.Tags)
 
-			for k, v := range patch.Tags {
-				inst.Tags[k] = v
+			if armName != "" {
+				inst.Tags[armNameTag] = armName
 			}
 		}
 

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
@@ -774,6 +775,12 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, rp azurearm.Resou
 	out := make([]vmResponse, 0, len(instances))
 
 	for i := range instances {
+		// A deleted VM's record lingers in the shared compute driver (see
+		// findByName), but real Azure LIST never reports a deleted resource.
+		if instances[i].State == stateTerminated {
+			continue
+		}
+
 		if rp.ResourceGroup != "" && !strings.EqualFold(instances[i].ResourceGroup, rp.ResourceGroup) {
 			continue
 		}
@@ -1224,6 +1231,13 @@ func writeAcceptedAsync(w http.ResponseWriter, r *http.Request, subscription, op
 // findByName looks up a VM by its ARM resource name within a resource group.
 // An empty resourceGroup matches across all groups (subscription-scoped lookup).
 // Returns NotFound when no matching instance exists.
+//
+// A terminated instance never matches: the shared compute driver keeps a
+// terminated instance's record around (AWS EC2's DescribeInstances keeps
+// reporting a terminated instance for a while, which the driver models), but
+// real Azure ARM deletes the resource outright — a GET/PATCH/power-action/PUT
+// against a deleted VM's name gets a 404 ResourceNotFound, and a re-PUT of the
+// same name provisions a brand-new VM rather than resurrecting the old one.
 func findByName(ctx context.Context, c computedriver.Compute, resourceGroup, name string) (*computedriver.Instance, error) {
 	instances, err := c.DescribeInstances(ctx, nil, nil)
 	if err != nil {
@@ -1231,6 +1245,10 @@ func findByName(ctx context.Context, c computedriver.Compute, resourceGroup, nam
 	}
 
 	for i := range instances {
+		if instances[i].State == stateTerminated {
+			continue
+		}
+
 		// ARM resource names and resource-group names are case-insensitive, so a
 		// GET/LIST with differently-cased segments must still resolve the VM.
 		if !strings.EqualFold(tagOr(instances[i].Tags, armNameTag, ""), name) {
@@ -1433,7 +1451,7 @@ func toVMResponse(inst *computedriver.Instance, rp azurearm.ResourcePath, req vm
 		Zones:    inst.Zones,
 		Identity: fromDriverIdentity(inst.Identity),
 		Properties: vmResponseProps{
-			VMID:              inst.ID,
+			VMID:              vmGUID(inst.ID),
 			ProvisioningState: provisioningState,
 			HardwareProfile:   &hardwareProfile{VMSize: inst.InstanceType},
 			StorageProfile:    osDiskProfile(inst.OSType),
@@ -1476,6 +1494,15 @@ func defaultIfEmpty(v, fallback string) string {
 	}
 
 	return v
+}
+
+// vmGUID derives a stable GUID-shaped properties.vmId from the driver instance
+// id, mirroring the GUID Azure always assigns a VM (real ARM never returns the
+// emulator's internal "vm-XXXXXXXX" id shape here). Deterministic per instance
+// id so it stays stable across GET/LIST/PATCH, matching diskUniqueID's
+// analogous treatment of Microsoft.Compute/disks' properties.uniqueId.
+func vmGUID(instanceID string) string {
+	return idgen.SyntheticGUID("vmid/" + instanceID)
 }
 
 func stripInternalTags(in map[string]string) map[string]string {

--- a/server/azure/virtualmachines/vm_patch_update_test.go
+++ b/server/azure/virtualmachines/vm_patch_update_test.go
@@ -13,13 +13,16 @@ import (
 	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
 )
 
-// TestSDKVMPatchUpdateAppliesVMSizeAndMergesTags is the regression test for the
-// PATCH Update fix: a real armcompute BeginUpdate that supplies
-// hardwareProfile.vmSize (a resize) and a new tag must take effect — Get shows
-// the new size and the added tag — while a tag the PATCH omitted (set at create)
-// is preserved (ARM PATCH is RFC 7386 merge-patch). Before the fix update() only
-// reconciled data disks and silently dropped vmSize/tags.
-func TestSDKVMPatchUpdateAppliesVMSizeAndMergesTags(t *testing.T) {
+// TestSDKVMPatchUpdateAppliesVMSizeAndReplacesTags is the regression test for
+// the PATCH Update fix: a real armcompute BeginUpdate that supplies
+// hardwareProfile.vmSize (a resize) and a tags map must take effect — Get shows
+// the new size and the new tag set. Unlike a generic RFC 7386 merge-patch, real
+// Azure Compute's PATCH tags is a full replace: a tag set at create and omitted
+// from the PATCH body does NOT survive (this is a well-documented Azure quirk —
+// see providers/azure/sqlvirtualmachine's UpdateTags for the sibling case).
+// Before the underlying fix update() only reconciled data disks and silently
+// dropped vmSize/tags entirely.
+func TestSDKVMPatchUpdateAppliesVMSizeAndReplacesTags(t *testing.T) {
 	cloudP := cloudemu.NewAzure()
 	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
 
@@ -51,8 +54,8 @@ func TestSDKVMPatchUpdateAppliesVMSizeAndMergesTags(t *testing.T) {
 		t.Fatalf("CreateOrUpdate poll: %v", err)
 	}
 
-	// PATCH: resize to D4s_v3 and add a "team" tag. Neither the size nor the tag
-	// were touched by the create; "env" is not re-sent (merge-patch must keep it).
+	// PATCH: resize to D4s_v3 and set a "team" tag. "env" (set at create) is not
+	// re-sent, so real Azure's tags-replace semantics drop it.
 	updatePoller, err := client.BeginUpdate(ctx, "rg-1", "vm-patch",
 		armcompute.VirtualMachineUpdate{
 			Tags: map[string]*string{"team": to.Ptr("blue")},
@@ -81,13 +84,14 @@ func TestSDKVMPatchUpdateAppliesVMSizeAndMergesTags(t *testing.T) {
 		t.Errorf("vmSize=%v, want Standard_D4s_v3", vmSizeOf(got.VirtualMachine))
 	}
 
-	// New tag added AND pre-existing tag preserved (merge, not replace).
+	// New tag applied, but the tag set was replaced wholesale: the create-time
+	// "env" tag, omitted from the PATCH body, does not survive.
 	if v := tagVal(got.Tags, "team"); v != "blue" {
 		t.Errorf("tag team=%q, want blue", v)
 	}
 
-	if v := tagVal(got.Tags, "env"); v != "prod" {
-		t.Errorf("tag env=%q, want prod (PATCH must not drop an omitted existing tag)", v)
+	if _, ok := got.Tags["env"]; ok {
+		t.Errorf("tag env=%q survived PATCH; real Azure PATCH tags replaces the set wholesale", tagVal(got.Tags, "env"))
 	}
 }
 


### PR DESCRIPTION
## Summary
- PATCH `virtualMachines/{name}` now replaces the `tags` set wholesale instead of merging — matches real Azure Compute's documented PATCH-tags quirk (a full replace despite PATCH otherwise reading as merge-patch), same convention already used by the sibling SQL-VM `UpdateTags`. The internal ARM-name tracking tag is preserved across the replace.
- GET/LIST/PATCH/power-actions/PUT against a deleted VM's name no longer resurrect the terminated driver record: the shared compute driver keeps a terminated instance around (matching real AWS EC2's `DescribeInstances` behavior), but real Azure ARM deletes the resource outright. `findByName` and `list()` now skip `terminated` instances, so GET 404s, LIST omits it, and a re-PUT of the same name provisions a fresh VM instead of updating the dead one.
- `properties.vmId` is now a GUID-shaped, deterministic value (via `idgen.SyntheticGUID`) instead of the emulator's raw internal instance id, matching real Azure and the existing `Microsoft.Compute/disks` `uniqueId` convention.

## Test plan
- `go build ./...`
- `go test ./providers/azure/virtualmachines/... ./server/azure/virtualmachines/... -race` — pass (existing PATCH-tags test rewritten to assert real-Azure replace semantics)
- `go test ./...` — pass, 0 failures
- `golangci-lint run ./providers/azure/virtualmachines/... ./server/azure/virtualmachines/...` — 0 issues
- Black-box re-verify: real `azure-sdk-for-go` (armcompute/armnetwork/armresources) driving a full lifecycle (ResourceGroup → VNet → Subnet → NIC → VM create/get/patch/power-ops/delete) against `cloudemu serve -providers=azure` confirmed all three fixes: tags drop the omitted key after PATCH, `Get` after `Delete` returns 404, re-`PUT` after delete recreates cleanly with exactly one `vm-1` in `List`, and `vmId` is GUID-shaped and stable across create/GET/PATCH.