### PR TITLE
fix(azure-network): resourceGuid on VNet/NSG/Public IP

### DIFF
--- a/providers/azure/vnet/azure_network_metadata.go
+++ b/providers/azure/vnet/azure_network_metadata.go
@@ -11,9 +11,19 @@ import (
 var _ driver.AzureNetworkMetadata = (*Mock)(nil)
 
 // PutAzureVNetMetadata stores the Azure-only virtual-network fields (region and
-// full address-prefix list) for the VPC with the given driver id.
+// full address-prefix list) for the VPC with the given driver id. ResourceGUID
+// is assigned on first write and preserved across every later PUT (a repeat
+// ARM CreateOrUpdate is a full replace of the other fields, but the identity
+// GUID must survive), matching how network interfaces preserve theirs.
 func (m *Mock) PutAzureVNetMetadata(_ context.Context, id string, meta driver.AzureVNetMetadata) error {
+	if existing, ok := m.azureVNetMeta.Get(id); ok && existing.ResourceGUID != "" {
+		meta.ResourceGUID = existing.ResourceGUID
+	} else {
+		meta.ResourceGUID = generateGUID()
+	}
+
 	m.azureVNetMeta.Set(id, cloneVNetMeta(meta))
+
 	return nil
 }
 
@@ -35,8 +45,17 @@ func (m *Mock) DeleteAzureVNetMetadata(_ context.Context, id string) {
 
 // PutAzureNSGMetadata stores the Azure-only security-group fields (region and
 // custom security rules) for the security group with the given driver id.
+// ResourceGUID is assigned on first write and preserved across every later
+// PUT, matching PutAzureVNetMetadata.
 func (m *Mock) PutAzureNSGMetadata(_ context.Context, id string, meta driver.AzureNSGMetadata) error {
+	if existing, ok := m.azureNSGMeta.Get(id); ok && existing.ResourceGUID != "" {
+		meta.ResourceGUID = existing.ResourceGUID
+	} else {
+		meta.ResourceGUID = generateGUID()
+	}
+
 	m.azureNSGMeta.Set(id, cloneNSGMeta(meta))
+
 	return nil
 }
 
@@ -172,7 +191,7 @@ func cloneRouteTableMeta(meta driver.AzureRouteTableMetadata) driver.AzureRouteT
 // cloneVNetMeta deep-copies the address-prefix slice so stored and returned
 // values never alias a caller's slice.
 func cloneVNetMeta(meta driver.AzureVNetMetadata) driver.AzureVNetMetadata {
-	out := driver.AzureVNetMetadata{Location: meta.Location}
+	out := driver.AzureVNetMetadata{Location: meta.Location, ResourceGUID: meta.ResourceGUID}
 	if len(meta.AddressPrefixes) > 0 {
 		out.AddressPrefixes = append([]string(nil), meta.AddressPrefixes...)
 	}
@@ -183,7 +202,7 @@ func cloneVNetMeta(meta driver.AzureVNetMetadata) driver.AzureVNetMetadata {
 // cloneNSGMeta deep-copies the rule slice — and each rule's application-security-group
 // reference slices — so stored and returned values never alias a caller's slice.
 func cloneNSGMeta(meta driver.AzureNSGMetadata) driver.AzureNSGMetadata {
-	out := driver.AzureNSGMetadata{Location: meta.Location}
+	out := driver.AzureNSGMetadata{Location: meta.Location, ResourceGUID: meta.ResourceGUID}
 
 	if len(meta.SecurityRules) > 0 {
 		rules := append([]driver.AzureNSGRule(nil), meta.SecurityRules...)

--- a/providers/azure/vnet/elastic_ip.go
+++ b/providers/azure/vnet/elastic_ip.go
@@ -20,6 +20,11 @@ type eipData struct {
 	IdleTimeoutMinutes int
 	DNSDomainNameLabel string
 	DNSFQDN            string
+	// ResourceGUID is the Azure-only persisted identifier (ARM
+	// properties.resourceGuid), assigned once in AllocateAddress and preserved
+	// across every UpdateAzurePublicIP, matching how network interfaces
+	// preserve theirs.
+	ResourceGUID string
 }
 
 // defaultFQDNRegion is the region segment used to build a mock DNS FQDN for a
@@ -57,6 +62,7 @@ func (m *Mock) AllocateAddress(
 		Zones:              append([]string(nil), cfg.Zones...),
 		IdleTimeoutMinutes: cfg.IdleTimeoutMinutes,
 		DNSDomainNameLabel: cfg.DNSDomainNameLabel,
+		ResourceGUID:       generateGUID(),
 	}
 
 	if cfg.DNSDomainNameLabel != "" {
@@ -247,5 +253,6 @@ func toEIPInfo(eip *eipData) driver.ElasticIP {
 		IdleTimeoutMinutes: eip.IdleTimeoutMinutes,
 		DNSDomainNameLabel: eip.DNSDomainNameLabel,
 		DNSFQDN:            eip.DNSFQDN,
+		ResourceGUID:       eip.ResourceGUID,
 	}
 }

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -1699,6 +1699,7 @@ func findPublicIPByName(ctx context.Context, n netdriver.Networking, rg, name st
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) vnetResponse(ctx context.Context, info *netdriver.VPCInfo, rp azurearm.ResourcePath) vnetResponse {
 	location, prefixes := h.vnetLocationPrefixes(ctx, info)
+	resourceGUID := h.vnetResourceGUID(ctx, info)
 
 	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeVNet, rp.ResourceName)
 
@@ -1712,6 +1713,7 @@ func (h *Handler) vnetResponse(ctx context.Context, info *netdriver.VPCInfo, rp 
 		Properties: vnetResponseProps{
 			ProvisioningState: "Succeeded",
 			AddressSpace:      &addressSpace{AddressPrefixes: prefixes},
+			ResourceGUID:      resourceGUID,
 		},
 	}
 
@@ -1758,6 +1760,23 @@ func (h *Handler) vnetLocationPrefixes(ctx context.Context, info *netdriver.VPCI
 	return location, prefixes
 }
 
+// vnetResourceGUID returns the persisted properties.resourceGuid ARM reports
+// for a virtual network, or "" when no Azure metadata is stored for it (e.g.
+// the networking driver doesn't implement the optional metadata capability).
+func (h *Handler) vnetResourceGUID(ctx context.Context, info *netdriver.VPCInfo) string {
+	meta, ok := h.azureMeta()
+	if !ok {
+		return ""
+	}
+
+	md, found := meta.GetAzureVNetMetadata(ctx, info.ID)
+	if !found {
+		return ""
+	}
+
+	return md.ResourceGUID
+}
+
 //nolint:gocritic // rp is a request-scoped value
 func toSubnetResponse(info *netdriver.SubnetInfo, rp azurearm.ResourcePath) subnetResponse {
 	name := tagOr(info.Tags, armSubnetTag, rp.SubResourceName)
@@ -1799,6 +1818,8 @@ func (h *Handler) nsgResponse(ctx context.Context, info *netdriver.SecurityGroup
 
 	var rules []securityRule
 
+	var resourceGUID string
+
 	if meta, ok := h.azureMeta(); ok {
 		if md, found := meta.GetAzureNSGMetadata(ctx, info.ID); found {
 			if md.Location != "" {
@@ -1806,6 +1827,7 @@ func (h *Handler) nsgResponse(ctx context.Context, info *netdriver.SecurityGroup
 			}
 
 			rules = fromAzureNSGRules(id, md.SecurityRules)
+			resourceGUID = md.ResourceGUID
 		}
 	}
 
@@ -1822,6 +1844,7 @@ func (h *Handler) nsgResponse(ctx context.Context, info *netdriver.SecurityGroup
 			DefaultSecurityRules: defaultSecurityRules(id),
 			Subnets:              h.nsgAssociatedSubnets(ctx, id),
 			NetworkInterfaces:    h.nsgAssociatedNICs(ctx, id),
+			ResourceGUID:         resourceGUID,
 		},
 	}
 }
@@ -1952,6 +1975,7 @@ func (h *Handler) toPublicIPResponse(
 			PublicIPAllocationMethod: info.AllocationMethod,
 			IPAddress:                info.PublicIP,
 			IdleTimeoutInMinutes:     info.IdleTimeoutMinutes,
+			ResourceGUID:             info.ResourceGUID,
 		},
 	}
 

--- a/server/azure/vnet/resource_guid_test.go
+++ b/server/azure/vnet/resource_guid_test.go
@@ -1,0 +1,206 @@
+package vnet_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKVNetResourceGUID verifies that a virtual network carries a non-empty
+// properties.resourceGuid — the ARM-persisted identifier real Azure assigns on
+// create — and that it stays stable across a repeat PUT (the same resource
+// updated in place keeps its identity), while a differently-named vnet gets
+// its own distinct GUID.
+func TestSDKVNetResourceGUID(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Network: cloudP.VNet})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnetClient, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	create := func(name, cidr string) *string {
+		poller, cerr := vnetClient.BeginCreateOrUpdate(ctx, "rg-1", name,
+			armnetwork.VirtualNetwork{
+				Location: to.Ptr("eastus"),
+				Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+					AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr(cidr)}},
+				},
+			}, nil)
+		if cerr != nil {
+			t.Fatalf("vnet BeginCreateOrUpdate(%s): %v", name, cerr)
+		}
+
+		res, perr := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+		if perr != nil {
+			t.Fatalf("vnet poll(%s): %v", name, perr)
+		}
+
+		if res.Properties == nil || res.Properties.ResourceGUID == nil || *res.Properties.ResourceGUID == "" {
+			t.Fatalf("vnet %s: resourceGuid missing or empty, properties=%+v", name, res.Properties)
+		}
+
+		return res.Properties.ResourceGUID
+	}
+
+	first := *create("vnet-guid-1", "10.0.0.0/16")
+
+	// A repeat PUT (tag-only change) must preserve the same resourceGuid.
+	poller, err := vnetClient.BeginCreateOrUpdate(ctx, "rg-1", "vnet-guid-1",
+		armnetwork.VirtualNetwork{
+			Location: to.Ptr("eastus"),
+			Tags:     map[string]*string{"env": to.Ptr("test")},
+			Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+				AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("vnet update BeginCreateOrUpdate: %v", err)
+	}
+
+	updated, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	if err != nil {
+		t.Fatalf("vnet update poll: %v", err)
+	}
+
+	if updated.Properties == nil || updated.Properties.ResourceGUID == nil || *updated.Properties.ResourceGUID != first {
+		t.Errorf("resourceGuid not preserved across update: before=%s after=%+v", first, updated.Properties)
+	}
+
+	second := *create("vnet-guid-2", "10.1.0.0/16")
+	if second == first {
+		t.Errorf("two distinct vnets got the same resourceGuid %s", first)
+	}
+
+	// A GET independently reports the same stable value.
+	got, err := vnetClient.Get(ctx, "rg-1", "vnet-guid-1", nil)
+	if err != nil {
+		t.Fatalf("vnet Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.ResourceGUID == nil || *got.Properties.ResourceGUID != first {
+		t.Errorf("GET resourceGuid=%+v want %s", got.Properties, first)
+	}
+}
+
+// TestSDKNSGResourceGUID mirrors TestSDKVNetResourceGUID for network security
+// groups: non-empty on create, stable across a repeat PUT.
+func TestSDKNSGResourceGUID(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Network: cloudP.VNet})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	nsgClient, err := armnetwork.NewSecurityGroupsClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	poller, err := nsgClient.BeginCreateOrUpdate(ctx, "rg-1", "nsg-guid-1",
+		armnetwork.SecurityGroup{Location: to.Ptr("eastus")}, nil)
+	if err != nil {
+		t.Fatalf("nsg BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	if err != nil {
+		t.Fatalf("nsg poll: %v", err)
+	}
+
+	if created.Properties == nil || created.Properties.ResourceGUID == nil || *created.Properties.ResourceGUID == "" {
+		t.Fatalf("nsg resourceGuid missing or empty, properties=%+v", created.Properties)
+	}
+
+	first := *created.Properties.ResourceGUID
+
+	updatePoller, err := nsgClient.BeginCreateOrUpdate(ctx, "rg-1", "nsg-guid-1",
+		armnetwork.SecurityGroup{
+			Location: to.Ptr("eastus"),
+			Tags:     map[string]*string{"env": to.Ptr("test")},
+		}, nil)
+	if err != nil {
+		t.Fatalf("nsg update BeginCreateOrUpdate: %v", err)
+	}
+
+	updated, err := updatePoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	if err != nil {
+		t.Fatalf("nsg update poll: %v", err)
+	}
+
+	if updated.Properties == nil || updated.Properties.ResourceGUID == nil || *updated.Properties.ResourceGUID != first {
+		t.Errorf("nsg resourceGuid not preserved across update: before=%s after=%+v", first, updated.Properties)
+	}
+}
+
+// TestSDKPublicIPResourceGUID mirrors TestSDKVNetResourceGUID for public IP
+// addresses: non-empty on create, stable across a tags-only PATCH.
+func TestSDKPublicIPResourceGUID(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Network: cloudP.VNet})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	pipClient, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	poller, err := pipClient.BeginCreateOrUpdate(ctx, "rg-1", "pip-guid-1",
+		armnetwork.PublicIPAddress{
+			Location: to.Ptr("eastus"),
+			Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+				PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("publicIP BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	if err != nil {
+		t.Fatalf("publicIP poll: %v", err)
+	}
+
+	if created.Properties == nil || created.Properties.ResourceGUID == nil || *created.Properties.ResourceGUID == "" {
+		t.Fatalf("publicIP resourceGuid missing or empty, properties=%+v", created.Properties)
+	}
+
+	first := *created.Properties.ResourceGUID
+
+	if _, err := pipClient.UpdateTags(ctx, "rg-1", "pip-guid-1",
+		armnetwork.TagsObject{Tags: map[string]*string{"env": to.Ptr("test")}}, nil); err != nil {
+		t.Fatalf("publicIP UpdateTags: %v", err)
+	}
+
+	got, err := pipClient.Get(ctx, "rg-1", "pip-guid-1", nil)
+	if err != nil {
+		t.Fatalf("publicIP Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.ResourceGUID == nil || *got.Properties.ResourceGUID != first {
+		t.Errorf("publicIP resourceGuid not preserved across PATCH: before=%s after=%+v", first, got.Properties)
+	}
+}

--- a/server/azure/vnet/types.go
+++ b/server/azure/vnet/types.go
@@ -31,6 +31,9 @@ type vnetResponseProps struct {
 	ProvisioningState string           `json:"provisioningState"`
 	AddressSpace      *addressSpace    `json:"addressSpace,omitempty"`
 	Subnets           []subnetResponse `json:"subnets,omitempty"`
+	// ResourceGUID is ARM's persisted resource identifier, stable for the
+	// VNet's lifetime.
+	ResourceGUID string `json:"resourceGuid,omitempty"`
 }
 
 type vnetListResponse struct {
@@ -119,6 +122,9 @@ type nsgResponseProps struct {
 	// publicIPConfigurationRef's NIC scan).
 	Subnets           []armIDRef `json:"subnets,omitempty"`
 	NetworkInterfaces []armIDRef `json:"networkInterfaces,omitempty"`
+	// ResourceGUID is ARM's persisted resource identifier, stable for the
+	// NSG's lifetime.
+	ResourceGUID string `json:"resourceGuid,omitempty"`
 }
 
 // securityRuleListResponse is the collection envelope for the securityRules
@@ -209,6 +215,9 @@ type publicIPRespProps struct {
 	// PublicIPPrefix echoes the prefix this public IP was created from, when one
 	// was supplied on the create.
 	PublicIPPrefix *armIDRef `json:"publicIPPrefix,omitempty"`
+	// ResourceGUID is ARM's persisted resource identifier, stable for the
+	// address's lifetime.
+	ResourceGUID string `json:"resourceGuid,omitempty"`
 }
 
 type publicIPDNSSettings struct {

--- a/services/networking/driver/azure_network_metadata.go
+++ b/services/networking/driver/azure_network_metadata.go
@@ -17,6 +17,13 @@ import "context"
 type AzureVNetMetadata struct {
 	Location        string
 	AddressPrefixes []string
+	// ResourceGUID is the persisted identifier ARM reports as
+	// properties.resourceGuid — stable for the resource's lifetime and
+	// regenerated only if it is deleted and recreated. The provider assigns it
+	// on first PutAzureVNetMetadata and preserves it across every later PUT;
+	// callers building a metadata value to store should leave it empty and let
+	// the provider fill it in.
+	ResourceGUID string
 }
 
 // AzureNSGRule is one Azure network-security-group security rule, with the
@@ -49,6 +56,13 @@ type AzureNSGRule struct {
 type AzureNSGMetadata struct {
 	Location      string
 	SecurityRules []AzureNSGRule
+	// ResourceGUID is the persisted identifier ARM reports as
+	// properties.resourceGuid — stable for the resource's lifetime and
+	// regenerated only if it is deleted and recreated. The provider assigns it
+	// on first PutAzureNSGMetadata and preserves it across every later PUT;
+	// callers building a metadata value to store should leave it empty and let
+	// the provider fill it in.
+	ResourceGUID string
 }
 
 // AzureRoute is one Azure route-table route, with the name / next-hop shape the

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -334,6 +334,11 @@ type ElasticIP struct {
 	IdleTimeoutMinutes int
 	DNSDomainNameLabel string
 	DNSFQDN            string
+	// ResourceGUID is the Azure-only persisted identifier ARM reports as
+	// properties.resourceGuid on a publicIPAddresses resource — stable for the
+	// address's lifetime, regenerated only on release + re-allocation. Empty
+	// for AWS and GCP.
+	ResourceGUID string
 }
 
 // AssociateAddressInput carries the target of an AssociateAddress call. Exactly


### PR DESCRIPTION
Deep real-user e2e audit of the Azure Networking surface (VNet, Subnet, NSG, Public IP, NIC), driven black-box via the real azure-sdk-for-go against a running \`cloudemu serve -providers=azure\`.

## Fix
Microsoft.Network resources (\`virtualNetworks\`, \`networkSecurityGroups\`, \`publicIPAddresses\`) did not populate \`properties.resourceGuid\` — real Azure always returns a stable GUID there (generated once, preserved across updates, regenerated only on delete+recreate). Fixed by persisting a generated GUID on first PUT and preserving it across subsequent PUTs, following the existing NIC pattern. Regression test added (\`resource_guid_test.go\`) asserting presence, GUID shape, and stability across updates.

## Verified correct (no finding — exercised black-box, matched real Azure)
- NSG has exactly the 6 real-Azure default security rules (AllowVnetInBound, AllowAzureLoadBalancerInBound, DenyAllInBound, AllowVnetOutBound, AllowInternetOutBound, DenyAllOutBound).
- PATCH tags REPLACE (not merge), matching Azure resource-level UpdateTags semantics.
- Child-resource routing (subnets, security rules), cross-resource wiring (NIC→subnet, NIC→public IP), delete→404, and id casing all correct.

## Verification
\`go build ./...\`, \`go test ./providers/azure/vnet/... ./server/azure/vnet/... ./persist/... -race\`, \`gofmt\`, \`golangci-lint --new-from-rev\` (0 new) — all green. Fix re-verified black-box with the real SDK. Shared \`networking/driver\` change is an additive Azure-only \`ResourceGUID\` field (empty for AWS/GCP).