### PR TITLE
fix(elbv2): real-user e2e divergences from AWS

### DIFF
--- a/docs/coverage/aws/elb.md
+++ b/docs/coverage/aws/elb.md
@@ -48,6 +48,15 @@ LBNetworkModifier is implemented by drivers that can replace the security
 | `SetSecurityGroups` |  |
 | `SetSubnets` |  |
 
+### ListenerAttributeStore
+
+ListenerAttributeStore is implemented by drivers that store per-listener
+
+| Operation | Description |
+| --- | --- |
+| `GetListenerAttributes` |  |
+| `ModifyListenerAttributes` |  |
+
 ### ListenerGetter
 
 ListenerGetter is implemented by drivers that can fetch a single listener by
@@ -55,6 +64,14 @@ ListenerGetter is implemented by drivers that can fetch a single listener by
 | Operation | Description |
 | --- | --- |
 | `GetListener` |  |
+
+### RuleGetter
+
+RuleGetter is implemented by drivers that can fetch a single listener rule
+
+| Operation | Description |
+| --- | --- |
+| `GetRule` |  |
 
 ### RuleModifier
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -6770,11 +6770,32 @@
         ]
       },
       {
+        "name": "ListenerAttributeStore",
+        "doc": "ListenerAttributeStore is implemented by drivers that store per-listener",
+        "operations": [
+          {
+            "name": "GetListenerAttributes"
+          },
+          {
+            "name": "ModifyListenerAttributes"
+          }
+        ]
+      },
+      {
         "name": "ListenerGetter",
         "doc": "ListenerGetter is implemented by drivers that can fetch a single listener by",
         "operations": [
           {
             "name": "GetListener"
+          }
+        ]
+      },
+      {
+        "name": "RuleGetter",
+        "doc": "RuleGetter is implemented by drivers that can fetch a single listener rule",
+        "operations": [
+          {
+            "name": "GetRule"
           }
         ]
       },

--- a/providers/aws/elbv2/az_resolution_test.go
+++ b/providers/aws/elbv2/az_resolution_test.go
@@ -1,0 +1,102 @@
+package elbv2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/aws/vpc"
+	"github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// TestCreateLoadBalancerResolvesSubnetAZs proves a load balancer's SubnetAZs
+// reflects each member subnet's real availability zone rather than a single
+// stand-in zone repeated for every subnet. Real ELBv2 reports the actual AZ a
+// subnet sits in, which matters for a multi-AZ load balancer spanning
+// different zones: reporting the same zone for every subnet is a divergence
+// Terraform's aws_lb resource surfaces as a perpetual plan diff.
+func TestCreateLoadBalancerResolvesSubnetAZs(t *testing.T) {
+	opts := config.NewOptions(config.WithRegion("us-east-1"), config.WithAccountID("123456789012"))
+	ctx := context.Background()
+
+	vpcMock := vpc.New(opts)
+	m := New(opts)
+	m.SetSubnetResolver(vpcMock)
+
+	v, err := vpcMock.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	requireNoError(t, err)
+
+	sn1, err := vpcMock.CreateSubnet(ctx, netdriver.SubnetConfig{
+		VPCID: v.ID, CIDRBlock: "10.0.1.0/24", AvailabilityZone: "us-east-1a",
+	})
+	requireNoError(t, err)
+
+	sn2, err := vpcMock.CreateSubnet(ctx, netdriver.SubnetConfig{
+		VPCID: v.ID, CIDRBlock: "10.0.2.0/24", AvailabilityZone: "us-east-1b",
+	})
+	requireNoError(t, err)
+
+	lb, err := m.CreateLoadBalancer(ctx, driver.LBConfig{
+		Name: "az-lb", Type: "application", Subnets: []string{sn1.ID, sn2.ID},
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "us-east-1a", lb.SubnetAZs[sn1.ID])
+	assertEqual(t, "us-east-1b", lb.SubnetAZs[sn2.ID])
+}
+
+// TestCreateLoadBalancerNoResolverLeavesSubnetAZsNil proves the field stays
+// nil (not a crash) when no subnet resolver is wired.
+func TestCreateLoadBalancerNoResolverLeavesSubnetAZsNil(t *testing.T) {
+	m := newTestMock()
+
+	lb, err := m.CreateLoadBalancer(context.Background(),
+		driver.LBConfig{Name: "no-resolver-lb", Subnets: []string{"subnet-1"}})
+	requireNoError(t, err)
+
+	if lb.SubnetAZs != nil {
+		t.Fatalf("SubnetAZs = %v, want nil with no resolver wired", lb.SubnetAZs)
+	}
+}
+
+// TestSetSubnetsResolvesSubnetAZs proves SetSubnets re-resolves SubnetAZs for
+// the replacement subnet list, not just the original set from create time.
+func TestSetSubnetsResolvesSubnetAZs(t *testing.T) {
+	opts := config.NewOptions(config.WithRegion("us-east-1"), config.WithAccountID("123456789012"))
+	ctx := context.Background()
+
+	vpcMock := vpc.New(opts)
+	m := New(opts)
+	m.SetSubnetResolver(vpcMock)
+
+	v, err := vpcMock.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	requireNoError(t, err)
+
+	sn1, err := vpcMock.CreateSubnet(ctx, netdriver.SubnetConfig{
+		VPCID: v.ID, CIDRBlock: "10.0.1.0/24", AvailabilityZone: "us-east-1a",
+	})
+	requireNoError(t, err)
+
+	sn2, err := vpcMock.CreateSubnet(ctx, netdriver.SubnetConfig{
+		VPCID: v.ID, CIDRBlock: "10.0.2.0/24", AvailabilityZone: "us-east-1c",
+	})
+	requireNoError(t, err)
+
+	lb, err := m.CreateLoadBalancer(ctx, driver.LBConfig{
+		Name: "set-subnets-lb", Type: "application", Subnets: []string{sn1.ID},
+	})
+	requireNoError(t, err)
+
+	_, err = m.SetSubnets(ctx, lb.ARN, []string{sn1.ID, sn2.ID})
+	requireNoError(t, err)
+
+	lbs, err := m.DescribeLoadBalancers(ctx, []string{lb.ARN})
+	requireNoError(t, err)
+	if len(lbs) != 1 {
+		t.Fatalf("DescribeLoadBalancers = %d results, want 1", len(lbs))
+	}
+
+	assertEqual(t, "us-east-1a", lbs[0].SubnetAZs[sn1.ID])
+	assertEqual(t, "us-east-1c", lbs[0].SubnetAZs[sn2.ID])
+}

--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -25,7 +25,9 @@ var (
 	_ driver.RuleModifier              = (*Mock)(nil)
 	_ driver.LBNetworkModifier         = (*Mock)(nil)
 	_ driver.ListenerGetter            = (*Mock)(nil)
+	_ driver.RuleGetter                = (*Mock)(nil)
 	_ driver.TargetGroupAttributeStore = (*Mock)(nil)
+	_ driver.ListenerAttributeStore    = (*Mock)(nil)
 )
 
 // defaultIdleTimeoutSec is the default idle timeout for load balancers in seconds.
@@ -107,6 +109,9 @@ type Mock struct {
 	tgAttrsMu sync.RWMutex
 	tgAttrs   map[string]map[string]string // tgARN -> attribute overrides
 
+	listenerAttrsMu sync.RWMutex
+	listenerAttrs   map[string]map[string]string // listenerARN -> attribute overrides
+
 	// subnetResolver derives a load balancer's VpcId from its subnets. Real
 	// ELBv2 infers VpcId rather than taking it as input; without the resolver
 	// wired in the field is simply left empty.
@@ -116,18 +121,19 @@ type Mock struct {
 // New creates a new ELB mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		lbs:          memstore.New[driver.LBInfo](),
-		lbSettle:     memstore.New[settle.Window](),
-		tgs:          memstore.New[driver.TargetGroupInfo](),
-		listeners:    memstore.New[driver.ListenerInfo](),
-		rules:        memstore.New[driver.RuleInfo](),
-		opts:         opts,
-		health:       make(map[string]map[targetKey]*driver.TargetHealth),
-		healthSettle: settle.NewSet(),
-		drainSettle:  settle.NewSet(),
-		healthArmed:  make(map[string]struct{}),
-		attrs:        make(map[string]driver.LBAttributes),
-		tgAttrs:      make(map[string]map[string]string),
+		lbs:           memstore.New[driver.LBInfo](),
+		lbSettle:      memstore.New[settle.Window](),
+		tgs:           memstore.New[driver.TargetGroupInfo](),
+		listeners:     memstore.New[driver.ListenerInfo](),
+		rules:         memstore.New[driver.RuleInfo](),
+		opts:          opts,
+		health:        make(map[string]map[targetKey]*driver.TargetHealth),
+		healthSettle:  settle.NewSet(),
+		drainSettle:   settle.NewSet(),
+		healthArmed:   make(map[string]struct{}),
+		attrs:         make(map[string]driver.LBAttributes),
+		tgAttrs:       make(map[string]map[string]string),
+		listenerAttrs: make(map[string]map[string]string),
 	}
 }
 
@@ -183,6 +189,7 @@ func (m *Mock) CreateLoadBalancer(ctx context.Context, cfg driver.LBConfig) (*dr
 		IPAddressType:         ipType,
 		CanonicalHostedZoneID: canonicalHostedZoneID(m.opts.Region),
 		VPCID:                 m.resolveVPCID(ctx, cfg.Subnets),
+		SubnetAZs:             m.resolveAZs(ctx, cfg.Subnets),
 		CreatedTime:           now,
 		Tags:                  tags,
 	}
@@ -276,6 +283,10 @@ func (m *Mock) DeleteLoadBalancer(_ context.Context, arn string) error {
 		}
 
 		m.listeners.Delete(key)
+
+		m.listenerAttrsMu.Lock()
+		delete(m.listenerAttrs, listenerARN)
+		m.listenerAttrsMu.Unlock()
 	}
 
 	// Drop the stored load-balancer attributes so a recreated ARN does not
@@ -382,12 +393,29 @@ const (
 	defaultHCMatcher       = "200"
 	defaultHCPort          = "traffic-port"
 	defaultHCPath          = "/"
+	protocolHTTP           = "HTTP"
 )
 
 // isHTTPProtocol reports whether p is an HTTP-family protocol (which carries a
 // path and an HTTP matcher on its health check).
 func isHTTPProtocol(p string) bool {
-	return p == "HTTP" || p == "HTTPS"
+	return p == protocolHTTP || p == "HTTPS"
+}
+
+// defaultHealthCheckProtocol reports the HealthCheckProtocol ELBv2 defaults to
+// for a target group of the given protocol. Per the CreateTargetGroup API
+// reference, this is NOT the target group's own protocol mirrored back: an
+// Application Load Balancer target group (HTTP or HTTPS) always defaults to
+// HTTP, and a Network or Gateway Load Balancer target group (TCP, TLS, UDP,
+// TCP_UDP, GENEVE, QUIC, TCP_QUIC) always defaults to TCP — the GENEVE, TLS,
+// UDP, TCP_UDP, QUIC, and TCP_QUIC protocols are not themselves supported as a
+// health check protocol.
+func defaultHealthCheckProtocol(tgProtocol string) string {
+	if isHTTPProtocol(tgProtocol) {
+		return protocolHTTP
+	}
+
+	return "TCP"
 }
 
 // defaultHealthCheck fills a target group's health-check settings, applying the
@@ -398,7 +426,7 @@ func defaultHealthCheck(cfg driver.TargetGroupConfig) driver.HealthCheck {
 	hc := cfg.HealthCheck
 
 	if hc.Protocol == "" {
-		hc.Protocol = cfg.Protocol
+		hc.Protocol = defaultHealthCheckProtocol(cfg.Protocol)
 	}
 
 	if hc.Port == "" {
@@ -620,6 +648,7 @@ func (m *Mock) CreateListener(_ context.Context, cfg driver.ListenerConfig) (*dr
 		DefaultActions: cloneActions(cfg.DefaultActions),
 		SslPolicy:      cfg.SslPolicy,
 		Certificates:   cloneCertificates(cfg.Certificates),
+		Tags:           copyStringMap(cfg.Tags),
 	}
 
 	m.listeners.Set(arn, li)
@@ -715,6 +744,10 @@ func (m *Mock) DeleteListener(_ context.Context, arn string) error {
 		}
 	}
 
+	m.listenerAttrsMu.Lock()
+	delete(m.listenerAttrs, arn)
+	m.listenerAttrsMu.Unlock()
+
 	return nil
 }
 
@@ -742,6 +775,8 @@ func (m *Mock) DescribeListeners(_ context.Context, lbARN string) ([]driver.List
 }
 
 // CreateRule creates a new listener rule.
+//
+//nolint:gocritic // hugeParam: interface method signature is fixed.
 func (m *Mock) CreateRule(_ context.Context, cfg driver.RuleConfig) (*driver.RuleInfo, error) {
 	if _, ok := m.listeners.Get(cfg.ListenerARN); !ok {
 		return nil, errors.Newf(errors.NotFound, "listener %q not found", cfg.ListenerARN)
@@ -780,6 +815,7 @@ func (m *Mock) CreateRule(_ context.Context, cfg driver.RuleConfig) (*driver.Rul
 		Conditions:  conditions,
 		Actions:     actions,
 		IsDefault:   false,
+		Tags:        copyStringMap(cfg.Tags),
 	}
 
 	m.rules.Set(arn, rule)
@@ -812,6 +848,18 @@ func (m *Mock) DeleteRule(_ context.Context, ruleARN string) error {
 	}
 
 	return nil
+}
+
+// GetRule returns a single listener rule by ARN.
+func (m *Mock) GetRule(_ context.Context, ruleARN string) (*driver.RuleInfo, error) {
+	r, ok := m.rules.Get(ruleARN)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "rule %q not found", ruleARN)
+	}
+
+	result := r
+
+	return &result, nil
 }
 
 // DescribeRules returns all rules for the specified listener.
@@ -1050,13 +1098,14 @@ func (m *Mock) SetSecurityGroups(_ context.Context, lbARN string, securityGroups
 
 // SetSubnets replaces the subnets a load balancer is attached to and returns
 // the resulting subnet list.
-func (m *Mock) SetSubnets(_ context.Context, lbARN string, subnets []string) ([]string, error) {
+func (m *Mock) SetSubnets(ctx context.Context, lbARN string, subnets []string) ([]string, error) {
 	lb, ok := m.lbs.Get(lbARN)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "load balancer %q not found", lbARN)
 	}
 
 	lb.Subnets = append([]string(nil), subnets...)
+	lb.SubnetAZs = m.resolveAZs(ctx, subnets)
 	m.lbs.Set(lbARN, lb)
 
 	return lb.Subnets, nil
@@ -1211,6 +1260,90 @@ func (m *Mock) ModifyTargetGroupAttributes(
 func mergedTargetGroupAttributes(overrides map[string]string) map[string]string {
 	out := make(map[string]string, len(defaultTargetGroupAttributes)+len(overrides))
 	for k, v := range defaultTargetGroupAttributes {
+		out[k] = v
+	}
+
+	for k, v := range overrides {
+		out[k] = v
+	}
+
+	return out
+}
+
+// defaultListenerAttributes returns the attribute defaults ELBv2 reports for a
+// freshly created listener before any ModifyListenerAttributes call. Per the
+// ListenerAttribute API reference, tcp.idle_timeout.seconds (default 350) only
+// applies to Network and Gateway Load Balancer listeners; an Application Load
+// Balancer listener has no attribute with a documented default, so it starts
+// with an empty set.
+func defaultListenerAttributes(lbType string) map[string]string {
+	if lbType == "network" || lbType == "gateway" {
+		return map[string]string{"tcp.idle_timeout.seconds": "350"}
+	}
+
+	return map[string]string{}
+}
+
+// GetListenerAttributes returns the full attribute set for a listener: the
+// ELBv2 defaults (derived from its load balancer's type) overlaid with any
+// stored overrides.
+func (m *Mock) GetListenerAttributes(_ context.Context, listenerARN string) (map[string]string, error) {
+	li, ok := m.listeners.Get(listenerARN)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "listener %q not found", listenerARN)
+	}
+
+	m.listenerAttrsMu.RLock()
+	defer m.listenerAttrsMu.RUnlock()
+
+	return mergedListenerAttributes(m.lbType(li.LBARN), m.listenerAttrs[listenerARN]), nil
+}
+
+// ModifyListenerAttributes merges updates into the listener's stored overrides
+// and returns the resulting full attribute set.
+func (m *Mock) ModifyListenerAttributes(
+	_ context.Context, listenerARN string, updates map[string]string,
+) (map[string]string, error) {
+	li, ok := m.listeners.Get(listenerARN)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "listener %q not found", listenerARN)
+	}
+
+	m.listenerAttrsMu.Lock()
+	defer m.listenerAttrsMu.Unlock()
+
+	overrides := m.listenerAttrs[listenerARN]
+	if overrides == nil {
+		overrides = make(map[string]string, len(updates))
+	}
+
+	for k, v := range updates {
+		overrides[k] = v
+	}
+
+	m.listenerAttrs[listenerARN] = overrides
+
+	return mergedListenerAttributes(m.lbType(li.LBARN), overrides), nil
+}
+
+// lbType returns the Type ("application", "network", "gateway") of the load
+// balancer at arn, or "" if it cannot be resolved.
+func (m *Mock) lbType(lbARN string) string {
+	lb, ok := m.lbs.Get(lbARN)
+	if !ok {
+		return ""
+	}
+
+	return lb.Type
+}
+
+// mergedListenerAttributes returns a fresh map of the type-derived defaults
+// overlaid with overrides, so the caller never aliases stored state.
+func mergedListenerAttributes(lbType string, overrides map[string]string) map[string]string {
+	defaults := defaultListenerAttributes(lbType)
+
+	out := make(map[string]string, len(defaults)+len(overrides))
+	for k, v := range defaults {
 		out[k] = v
 	}
 

--- a/providers/aws/elbv2/health_check_defaults_test.go
+++ b/providers/aws/elbv2/health_check_defaults_test.go
@@ -1,0 +1,72 @@
+package elbv2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
+)
+
+// TestDefaultHealthCheckProtocolHTTPS proves an HTTPS target group's health
+// check defaults to HTTP, not HTTPS. Per the CreateTargetGroup API reference,
+// ELBv2 never mirrors the target group's own protocol back onto the health
+// check: an Application Load Balancer target group (HTTP or HTTPS) always
+// defaults its health check to HTTP. Mirroring the protocol instead (the prior
+// behavior) produced a health check protocol real AWS never returns —
+// surfacing as a perpetual Terraform plan diff on any aws_lb_target_group with
+// protocol = "HTTPS" and no explicit health_check block.
+func TestDefaultHealthCheckProtocolHTTPS(t *testing.T) {
+	m := newTestMock()
+
+	tg, err := m.CreateTargetGroup(context.Background(), driver.TargetGroupConfig{
+		Name: "https-tg", Protocol: "HTTPS", Port: 443, TargetType: "instance",
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "HTTP", tg.HealthCheck.Protocol)
+}
+
+// TestDefaultHealthCheckProtocolHTTP proves an HTTP target group's health
+// check protocol defaults to HTTP, same as before this fix.
+func TestDefaultHealthCheckProtocolHTTP(t *testing.T) {
+	m := newTestMock()
+
+	tg, err := m.CreateTargetGroup(context.Background(), driver.TargetGroupConfig{
+		Name: "http-tg", Protocol: "HTTP", Port: 80, TargetType: "instance",
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "HTTP", tg.HealthCheck.Protocol)
+}
+
+// TestDefaultHealthCheckProtocolTCPFamily proves the TCP-family protocols
+// (TCP, TLS, UDP, TCP_UDP) all default their health check to TCP, matching
+// the Network/Gateway Load Balancer default in the API reference.
+func TestDefaultHealthCheckProtocolTCPFamily(t *testing.T) {
+	for _, proto := range []string{"TCP", "TLS", "UDP", "TCP_UDP"} {
+		m := newTestMock()
+
+		tg, err := m.CreateTargetGroup(context.Background(), driver.TargetGroupConfig{
+			Name: "tcp-tg-" + proto, Protocol: proto, Port: 80, TargetType: "instance",
+		})
+		requireNoError(t, err)
+
+		if tg.HealthCheck.Protocol != "TCP" {
+			t.Errorf("protocol %s: health check protocol = %q, want TCP", proto, tg.HealthCheck.Protocol)
+		}
+	}
+}
+
+// TestDefaultHealthCheckProtocolExplicitOverride proves an explicitly supplied
+// HealthCheck.Protocol is still honored rather than overridden by the default.
+func TestDefaultHealthCheckProtocolExplicitOverride(t *testing.T) {
+	m := newTestMock()
+
+	tg, err := m.CreateTargetGroup(context.Background(), driver.TargetGroupConfig{
+		Name: "explicit-tg", Protocol: "HTTPS", Port: 443, TargetType: "instance",
+		HealthCheck: driver.HealthCheck{Protocol: "HTTPS"},
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "HTTPS", tg.HealthCheck.Protocol)
+}

--- a/providers/aws/elbv2/listener_attributes_test.go
+++ b/providers/aws/elbv2/listener_attributes_test.go
@@ -1,0 +1,85 @@
+package elbv2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
+)
+
+// mkListenerOfType creates a load balancer of the given type plus one
+// listener on it, returning the listener ARN.
+func mkListenerOfType(t *testing.T, m *Mock, lbType string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	lb, err := m.CreateLoadBalancer(ctx, driver.LBConfig{Name: "attr-lb-" + lbType, Type: lbType})
+	requireNoError(t, err)
+
+	li, err := m.CreateListener(ctx, driver.ListenerConfig{LBARN: lb.ARN, Protocol: "TCP", Port: 80})
+	requireNoError(t, err)
+
+	return li.ARN
+}
+
+// TestGetListenerAttributesDefaultsByLBType proves DescribeListenerAttributes
+// derives its defaults from the parent load balancer's type: a Network or
+// Gateway Load Balancer listener defaults tcp.idle_timeout.seconds to 350, per
+// the ListenerAttribute API reference, while an Application Load Balancer
+// listener has no documented default and starts with an empty attribute set.
+// Before this fix the emulator had no listener attribute surface at all.
+func TestGetListenerAttributesDefaultsByLBType(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	nlbListener := mkListenerOfType(t, m, "network")
+	attrs, err := m.GetListenerAttributes(ctx, nlbListener)
+	requireNoError(t, err)
+	assertEqual(t, "350", attrs["tcp.idle_timeout.seconds"])
+
+	gwlbListener := mkListenerOfType(t, m, "gateway")
+	attrs, err = m.GetListenerAttributes(ctx, gwlbListener)
+	requireNoError(t, err)
+	assertEqual(t, "350", attrs["tcp.idle_timeout.seconds"])
+
+	albListener := mkListenerOfType(t, m, "application")
+	attrs, err = m.GetListenerAttributes(ctx, albListener)
+	requireNoError(t, err)
+	if len(attrs) != 0 {
+		t.Fatalf("application listener attributes = %v, want empty", attrs)
+	}
+}
+
+// TestModifyListenerAttributesMerges proves ModifyListenerAttributes merges
+// updates into the stored overrides (rather than replacing the whole set) and
+// that a subsequent Get reflects the merge.
+func TestModifyListenerAttributesMerges(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	listenerARN := mkListenerOfType(t, m, "network")
+
+	merged, err := m.ModifyListenerAttributes(ctx, listenerARN, map[string]string{
+		"tcp.idle_timeout.seconds": "60",
+	})
+	requireNoError(t, err)
+	assertEqual(t, "60", merged["tcp.idle_timeout.seconds"])
+
+	got, err := m.GetListenerAttributes(ctx, listenerARN)
+	requireNoError(t, err)
+	assertEqual(t, "60", got["tcp.idle_timeout.seconds"])
+}
+
+// TestGetListenerAttributesUnknownARN proves an unknown listener ARN reports
+// NotFound.
+func TestGetListenerAttributesUnknownARN(t *testing.T) {
+	m := newTestMock()
+
+	if _, err := m.GetListenerAttributes(context.Background(), "arn:nope"); err == nil {
+		t.Fatal("GetListenerAttributes(unknown ARN) = nil error, want NotFound")
+	}
+
+	if _, err := m.ModifyListenerAttributes(context.Background(), "arn:nope", map[string]string{"k": "v"}); err == nil {
+		t.Fatal("ModifyListenerAttributes(unknown ARN) = nil error, want NotFound")
+	}
+}

--- a/providers/aws/elbv2/listener_rule_tags_test.go
+++ b/providers/aws/elbv2/listener_rule_tags_test.go
@@ -1,0 +1,140 @@
+package elbv2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
+)
+
+// mkListenerForTags creates a load balancer and listener, returning both ARNs.
+func mkListenerForTags(t *testing.T, m *Mock, tags map[string]string) (lbARN, listenerARN string) {
+	t.Helper()
+	ctx := context.Background()
+
+	lb, err := m.CreateLoadBalancer(ctx, driver.LBConfig{Name: "tag-lb", Type: "application"})
+	requireNoError(t, err)
+
+	li, err := m.CreateListener(ctx, driver.ListenerConfig{
+		LBARN: lb.ARN, Protocol: "HTTP", Port: 80, Tags: tags,
+	})
+	requireNoError(t, err)
+
+	return lb.ARN, li.ARN
+}
+
+// TestCreateListenerStoresTags proves a listener created with Tags reports
+// them back on the returned ListenerInfo and on a subsequent describe — before
+// this fix ListenerInfo had no Tags field at all, so listener tags set at
+// create time were silently dropped.
+func TestCreateListenerStoresTags(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, listenerARN := mkListenerForTags(t, m, map[string]string{"env": "prod"})
+
+	li, err := m.GetListener(ctx, listenerARN)
+	requireNoError(t, err)
+	assertEqual(t, "prod", li.Tags["env"])
+}
+
+// TestCreateRuleStoresTags and TestGetRule prove a rule created with Tags
+// reports them back via the new GetRule accessor — required because ELBv2
+// DescribeTags accepts listener-rule ARNs directly, and DescribeRules only
+// looks up by parent listener ARN.
+func TestCreateRuleStoresTags(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, listenerARN := mkListenerForTags(t, m, nil)
+
+	rule, err := m.CreateRule(ctx, driver.RuleConfig{
+		ListenerARN: listenerARN,
+		Priority:    1,
+		Conditions:  []driver.RuleCondition{{Field: "path-pattern", Values: []string{"/api/*"}}},
+		Tags:        map[string]string{"team": "platform"},
+	})
+	requireNoError(t, err)
+	assertEqual(t, "platform", rule.Tags["team"])
+
+	got, err := m.GetRule(ctx, rule.ARN)
+	requireNoError(t, err)
+	assertEqual(t, "platform", got.Tags["team"])
+}
+
+// TestGetRuleNotFound proves an unknown rule ARN reports NotFound rather than
+// panicking or returning a zero-value rule.
+func TestGetRuleNotFound(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.GetRule(context.Background(), "arn:nope")
+	if err == nil {
+		t.Fatal("GetRule(unknown ARN) = nil error, want NotFound")
+	}
+}
+
+// TestAddResourceTagsAppliesToListener and TestAddResourceTagsAppliesToRule
+// prove AddResourceTags/RemoveResourceTags — generalized to operate over any
+// of the four taggable ELBv2 resource kinds — reach listeners and rules, not
+// just load balancers and target groups.
+func TestAddResourceTagsAppliesToListener(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, listenerARN := mkListenerForTags(t, m, nil)
+
+	requireNoError(t, m.AddResourceTags(ctx, listenerARN, map[string]string{"owner": "team-a"}))
+
+	li, err := m.GetListener(ctx, listenerARN)
+	requireNoError(t, err)
+	assertEqual(t, "team-a", li.Tags["owner"])
+
+	requireNoError(t, m.RemoveResourceTags(ctx, listenerARN, []string{"owner"}))
+
+	li, err = m.GetListener(ctx, listenerARN)
+	requireNoError(t, err)
+
+	if _, ok := li.Tags["owner"]; ok {
+		t.Fatalf("tag survived RemoveResourceTags: %v", li.Tags)
+	}
+}
+
+func TestAddResourceTagsAppliesToRule(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, listenerARN := mkListenerForTags(t, m, nil)
+
+	rule, err := m.CreateRule(ctx, driver.RuleConfig{
+		ListenerARN: listenerARN,
+		Priority:    5,
+		Conditions:  []driver.RuleCondition{{Field: "path-pattern", Values: []string{"/x"}}},
+	})
+	requireNoError(t, err)
+
+	requireNoError(t, m.AddResourceTags(ctx, rule.ARN, map[string]string{"owner": "team-b"}))
+
+	got, err := m.GetRule(ctx, rule.ARN)
+	requireNoError(t, err)
+	assertEqual(t, "team-b", got.Tags["owner"])
+
+	requireNoError(t, m.RemoveResourceTags(ctx, rule.ARN, []string{"owner"}))
+
+	got, err = m.GetRule(ctx, rule.ARN)
+	requireNoError(t, err)
+
+	if _, ok := got.Tags["owner"]; ok {
+		t.Fatalf("tag survived RemoveResourceTags: %v", got.Tags)
+	}
+}
+
+// TestAddResourceTagsUnknownARNIsNoOp proves AddResourceTags/RemoveResourceTags
+// still tolerate an ARN that resolves against none of the four resource kinds,
+// matching AWS's tolerance for a mixed multi-resource-kind call.
+func TestAddResourceTagsUnknownARNIsNoOp(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.AddResourceTags(ctx, "arn:nope", map[string]string{"k": "v"}))
+	requireNoError(t, m.RemoveResourceTags(ctx, "arn:nope", []string{"k"}))
+}

--- a/providers/aws/elbv2/snapshot.go
+++ b/providers/aws/elbv2/snapshot.go
@@ -21,13 +21,14 @@ var _ snapshot.Snapshottable = (*Mock)(nil)
 // and *config.Options are intentionally not serialized: a restored load balancer
 // reports its stored (final) state immediately.
 type elbSnapshot struct {
-	LBs       json.RawMessage                   `json:"lbs,omitempty"`
-	TargetGrp json.RawMessage                   `json:"targetGroups,omitempty"`
-	Listeners json.RawMessage                   `json:"listeners,omitempty"`
-	Rules     json.RawMessage                   `json:"rules,omitempty"`
-	Health    map[string][]targetHealthSnapshot `json:"health,omitempty"`
-	Attrs     map[string]driver.LBAttributes    `json:"attrs,omitempty"`
-	TGAttrs   map[string]map[string]string      `json:"tgAttrs,omitempty"`
+	LBs          json.RawMessage                   `json:"lbs,omitempty"`
+	TargetGrp    json.RawMessage                   `json:"targetGroups,omitempty"`
+	Listeners    json.RawMessage                   `json:"listeners,omitempty"`
+	Rules        json.RawMessage                   `json:"rules,omitempty"`
+	Health       map[string][]targetHealthSnapshot `json:"health,omitempty"`
+	Attrs        map[string]driver.LBAttributes    `json:"attrs,omitempty"`
+	TGAttrs      map[string]map[string]string      `json:"tgAttrs,omitempty"`
+	ListenerAttr map[string]map[string]string      `json:"listenerAttrs,omitempty"`
 }
 
 // targetHealthSnapshot promotes one (targetKey -> *TargetHealth) entry to an
@@ -127,6 +128,15 @@ func (m *Mock) snapshotAttrs(snap *elbSnapshot) {
 		}
 	}
 	m.tgAttrsMu.RUnlock()
+
+	m.listenerAttrsMu.RLock()
+	if len(m.listenerAttrs) > 0 {
+		snap.ListenerAttr = make(map[string]map[string]string, len(m.listenerAttrs))
+		for k, v := range m.listenerAttrs {
+			snap.ListenerAttr[k] = v
+		}
+	}
+	m.listenerAttrsMu.RUnlock()
 }
 
 // Restore rebuilds the mock's state under the original identities: every ARN and
@@ -205,5 +215,13 @@ func (m *Mock) restoreAttrs(snap *elbSnapshot) {
 			m.tgAttrs[k] = v
 		}
 		m.tgAttrsMu.Unlock()
+	}
+
+	if len(snap.ListenerAttr) > 0 {
+		m.listenerAttrsMu.Lock()
+		for k, v := range snap.ListenerAttr {
+			m.listenerAttrs[k] = v
+		}
+		m.listenerAttrsMu.Unlock()
 	}
 }

--- a/providers/aws/elbv2/snapshot_test.go
+++ b/providers/aws/elbv2/snapshot_test.go
@@ -91,6 +91,53 @@ func TestSnapshotRestoreRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSnapshotRestoreRoundTripListenerAttrsAndTags proves listener attribute
+// overrides and listener/rule tags — both added after the original snapshot
+// shape was fixed — survive a snapshot/restore round-trip too, not just the
+// four fields covered by seedELB above.
+func TestSnapshotRestoreRoundTripListenerAttrsAndTags(t *testing.T) {
+	ctx := context.Background()
+
+	src := newTestMock()
+
+	lb, err := src.CreateLoadBalancer(ctx, driver.LBConfig{Name: "attr-lb", Type: "network"})
+	requireNoError(t, err)
+
+	li, err := src.CreateListener(ctx, driver.ListenerConfig{
+		LBARN: lb.ARN, Protocol: "TCP", Port: 80, Tags: map[string]string{"env": "prod"},
+	})
+	requireNoError(t, err)
+
+	rule, err := src.CreateRule(ctx, driver.RuleConfig{
+		ListenerARN: li.ARN,
+		Priority:    1,
+		Conditions:  []driver.RuleCondition{{Field: "path-pattern", Values: []string{"/x"}}},
+		Tags:        map[string]string{"team": "platform"},
+	})
+	requireNoError(t, err)
+
+	_, err = src.ModifyListenerAttributes(ctx, li.ARN, map[string]string{"tcp.idle_timeout.seconds": "60"})
+	requireNoError(t, err)
+
+	data, err := src.Snapshot(ctx, true)
+	requireNoError(t, err)
+
+	dst := newTestMock()
+	requireNoError(t, dst.Restore(ctx, data))
+
+	gotListener, err := dst.GetListener(ctx, li.ARN)
+	requireNoError(t, err)
+	assertEqual(t, "prod", gotListener.Tags["env"])
+
+	gotRule, err := dst.GetRule(ctx, rule.ARN)
+	requireNoError(t, err)
+	assertEqual(t, "platform", gotRule.Tags["team"])
+
+	gotAttrs, err := dst.GetListenerAttributes(ctx, li.ARN)
+	requireNoError(t, err)
+	assertEqual(t, "60", gotAttrs["tcp.idle_timeout.seconds"])
+}
+
 // TestSnapshotEmpty confirms a fresh mock snapshots and restores without error.
 func TestSnapshotEmpty(t *testing.T) {
 	ctx := context.Background()

--- a/providers/aws/elbv2/subnet_resolver.go
+++ b/providers/aws/elbv2/subnet_resolver.go
@@ -41,3 +41,30 @@ func (m *Mock) resolveVPCID(ctx context.Context, subnetIDs []string) string {
 
 	return ""
 }
+
+// resolveAZs maps each of the given subnet IDs to its availability zone, real
+// ELBv2 reports the AZ each member subnet actually sits in — a multi-AZ load
+// balancer's AvailabilityZones must reflect the real placement, not a single
+// stand-in zone repeated for every subnet. A subnet the resolver can't place
+// (no resolver wired, or the subnet is unknown) is simply absent from the
+// result; the caller falls back to a placeholder zone for it.
+func (m *Mock) resolveAZs(ctx context.Context, subnetIDs []string) map[string]string {
+	if m.subnetResolver == nil || len(subnetIDs) == 0 {
+		return nil
+	}
+
+	subnets, err := m.subnetResolver.DescribeSubnets(ctx, subnetIDs)
+	if err != nil || len(subnets) == 0 {
+		return nil
+	}
+
+	azs := make(map[string]string, len(subnets))
+
+	for i := range subnets {
+		if subnets[i].AvailabilityZone != "" {
+			azs[subnets[i].ID] = subnets[i].AvailabilityZone
+		}
+	}
+
+	return azs
+}

--- a/providers/aws/elbv2/tags.go
+++ b/providers/aws/elbv2/tags.go
@@ -1,60 +1,103 @@
 package elbv2
 
-import "context"
+import (
+	"context"
 
-// AddResourceTags adds or overwrites tags on a load balancer or target group
-// identified by ARN (ELBv2 AddTags). Unknown ARNs are ignored, matching AWS's
-// tolerance for a mixed multi-resource AddTags call.
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
+)
+
+// AddResourceTags adds or overwrites tags on a load balancer, target group,
+// listener, or rule identified by ARN (ELBv2 AddTags). Unknown ARNs are
+// ignored, matching AWS's tolerance for a mixed multi-resource AddTags call.
 func (m *Mock) AddResourceTags(_ context.Context, arn string, tags map[string]string) error {
-	if lb, ok := m.lbs.Get(arn); ok {
-		if lb.Tags == nil {
-			lb.Tags = map[string]string{}
-		}
-
-		for k, v := range tags {
-			lb.Tags[k] = v
-		}
-
-		m.lbs.Set(arn, lb)
-
-		return nil
-	}
-
-	if tg, ok := m.tgs.Get(arn); ok {
-		if tg.Tags == nil {
-			tg.Tags = map[string]string{}
-		}
-
-		for k, v := range tags {
-			tg.Tags[k] = v
-		}
-
-		m.tgs.Set(arn, tg)
+	switch {
+	case addTagsToStore(m.lbs, arn, tags, lbTagsGet, lbTagsSet):
+	case addTagsToStore(m.tgs, arn, tags, tgTagsGet, tgTagsSet):
+	case addTagsToStore(m.listeners, arn, tags, listenerTagsGet, listenerTagsSet):
+	case addTagsToStore(m.rules, arn, tags, ruleTagsGet, ruleTagsSet):
 	}
 
 	return nil
 }
 
-// RemoveResourceTags removes tags by key from a load balancer or target group
-// identified by ARN (ELBv2 RemoveTags).
+// RemoveResourceTags removes tags by key from a load balancer, target group,
+// listener, or rule identified by ARN (ELBv2 RemoveTags).
 func (m *Mock) RemoveResourceTags(_ context.Context, arn string, keys []string) error {
-	if lb, ok := m.lbs.Get(arn); ok {
-		for _, k := range keys {
-			delete(lb.Tags, k)
-		}
-
-		m.lbs.Set(arn, lb)
-
-		return nil
-	}
-
-	if tg, ok := m.tgs.Get(arn); ok {
-		for _, k := range keys {
-			delete(tg.Tags, k)
-		}
-
-		m.tgs.Set(arn, tg)
+	switch {
+	case removeTagsFromStore(m.lbs, arn, keys, lbTagsGet):
+	case removeTagsFromStore(m.tgs, arn, keys, tgTagsGet):
+	case removeTagsFromStore(m.listeners, arn, keys, listenerTagsGet):
+	case removeTagsFromStore(m.rules, arn, keys, ruleTagsGet):
 	}
 
 	return nil
+}
+
+// The four ELBv2 resource kinds AddTags/RemoveTags accept all carry their tags
+// on the same field shape (map[string]string); these get/set pairs let
+// addTagsToStore/removeTagsFromStore below operate generically over whichever
+// store the ARN resolves against. Both sides take a pointer so a heavy
+// resource struct (LBInfo, TargetGroupInfo) is never copied by value into the
+// getter.
+func lbTagsGet(v *driver.LBInfo) map[string]string          { return v.Tags }
+func lbTagsSet(v *driver.LBInfo, tags map[string]string)    { v.Tags = tags }
+func tgTagsGet(v *driver.TargetGroupInfo) map[string]string { return v.Tags }
+func tgTagsSet(v *driver.TargetGroupInfo, tags map[string]string) {
+	v.Tags = tags
+}
+func listenerTagsGet(v *driver.ListenerInfo) map[string]string { return v.Tags }
+func listenerTagsSet(v *driver.ListenerInfo, tags map[string]string) {
+	v.Tags = tags
+}
+func ruleTagsGet(v *driver.RuleInfo) map[string]string       { return v.Tags }
+func ruleTagsSet(v *driver.RuleInfo, tags map[string]string) { v.Tags = tags }
+
+// addTagsToStore merges tags into the tag map of the value stored at arn in
+// store (initializing a nil map first), reporting false (a no-op) when arn
+// does not resolve in this store — letting AddResourceTags try the next
+// resource kind, matching AWS's tolerance for a mixed multi-resource-kind
+// AddTags call.
+func addTagsToStore[T any](
+	store *memstore.Store[T], arn string, tags map[string]string,
+	get func(*T) map[string]string, set func(*T, map[string]string),
+) bool {
+	v, ok := store.Get(arn)
+	if !ok {
+		return false
+	}
+
+	existing := get(&v)
+	if existing == nil {
+		existing = map[string]string{}
+		set(&v, existing)
+	}
+
+	for k, val := range tags {
+		existing[k] = val
+	}
+
+	store.Set(arn, v)
+
+	return true
+}
+
+// removeTagsFromStore deletes keys from the tag map of the value stored at arn
+// in store, reporting false (a no-op) when arn does not resolve in this store.
+func removeTagsFromStore[T any](
+	store *memstore.Store[T], arn string, keys []string, get func(*T) map[string]string,
+) bool {
+	v, ok := store.Get(arn)
+	if !ok {
+		return false
+	}
+
+	tags := get(&v)
+	for _, k := range keys {
+		delete(tags, k)
+	}
+
+	store.Set(arn, v)
+
+	return true
 }

--- a/server/aws/elbv2/attributes.go
+++ b/server/aws/elbv2/attributes.go
@@ -172,6 +172,68 @@ func (h *Handler) modifyTargetGroupAttributes(w http.ResponseWriter, r *http.Req
 	})
 }
 
+type describeListenerAttributesResponse struct {
+	XMLName  xml.Name           `xml:"DescribeListenerAttributesResponse"`
+	Xmlns    string             `xml:"xmlns,attr"`
+	Result   lbAttributesResult `xml:"DescribeListenerAttributesResult"`
+	Metadata responseMetadata   `xml:"ResponseMetadata"`
+}
+
+type modifyListenerAttributesResponse struct {
+	XMLName  xml.Name           `xml:"ModifyListenerAttributesResponse"`
+	Xmlns    string             `xml:"xmlns,attr"`
+	Result   lbAttributesResult `xml:"ModifyListenerAttributesResult"`
+	Metadata responseMetadata   `xml:"ResponseMetadata"`
+}
+
+// describeListenerAttributes returns the listener's attribute set (ELBv2
+// defaults, derived from its load balancer's type, overlaid with any prior
+// modifications).
+func (h *Handler) describeListenerAttributes(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.lb.(lbdriver.ListenerAttributeStore)
+	if !ok {
+		writeUnsupported(w, "DescribeListenerAttributes")
+		return
+	}
+
+	attrs, err := store.GetListenerAttributes(r.Context(), r.Form.Get("ListenerArn"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, describeListenerAttributesResponse{
+		Xmlns:    Namespace,
+		Result:   lbAttributesResult{Attributes: attributeMapToXML(attrs)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// modifyListenerAttributes merges the supplied attributes into the listener's
+// set and echoes the merged result, matching ELBv2's partial-update semantics.
+//
+//nolint:dupl // structurally mirrors modifyTargetGroupAttributes by design.
+func (h *Handler) modifyListenerAttributes(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.lb.(lbdriver.ListenerAttributeStore)
+	if !ok {
+		writeUnsupported(w, "ModifyListenerAttributes")
+		return
+	}
+
+	merged, err := store.ModifyListenerAttributes(
+		r.Context(), r.Form.Get("ListenerArn"), parseAttributeMembers(r))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, modifyListenerAttributesResponse{
+		Xmlns:    Namespace,
+		Result:   lbAttributesResult{Attributes: attributeMapToXML(merged)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
 // attributeMapToXML renders a flat attribute map as ELBv2 Key/Value members.
 func attributeMapToXML(attrs map[string]string) []lbAttributeXML {
 	out := make([]lbAttributeXML, 0, len(attrs))

--- a/server/aws/elbv2/availability_zones_sdk_test.go
+++ b/server/aws/elbv2/availability_zones_sdk_test.go
@@ -1,0 +1,166 @@
+package elbv2_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newSDKClientsWithEC2 wires EC2 (for real subnets/AZs), VPC, and ELBv2 behind
+// one server and returns clients for both, so a test can create subnets with
+// a known AvailabilityZone and then point a load balancer at them.
+func newSDKClientsWithEC2(t *testing.T) (*elb.Client, *awsec2.Client) {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{ELB: cloud.ELB, EC2: cloud.EC2, VPC: cloud.VPC})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	elbClient := elb.NewFromConfig(cfg, func(o *elb.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+	ec2Client := awsec2.NewFromConfig(cfg, func(o *awsec2.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+
+	return elbClient, ec2Client
+}
+
+// mkVPCAndSubnetsInZones creates a VPC and one subnet per given AZ, returning
+// the subnet IDs in the same order as zones.
+func mkVPCAndSubnetsInZones(t *testing.T, ec2Client *awsec2.Client, zones ...string) []string {
+	t.Helper()
+	ctx := context.Background()
+
+	vpcOut, err := ec2Client.CreateVpc(ctx, &awsec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	vpcID := aws.ToString(vpcOut.Vpc.VpcId)
+
+	ids := make([]string, len(zones))
+
+	for i, zone := range zones {
+		subOut, err := ec2Client.CreateSubnet(ctx, &awsec2.CreateSubnetInput{
+			VpcId:            aws.String(vpcID),
+			CidrBlock:        aws.String("10.0." + strconv.Itoa(i) + ".0/24"),
+			AvailabilityZone: aws.String(zone),
+		})
+		if err != nil {
+			t.Fatalf("CreateSubnet(%s): %v", zone, err)
+		}
+
+		ids[i] = aws.ToString(subOut.Subnet.SubnetId)
+	}
+
+	return ids
+}
+
+// TestDescribeLoadBalancersReportsRealSubnetAZs proves a load balancer's
+// AvailabilityZones reflects each member subnet's actual zone, resolved via
+// EC2, rather than the same placeholder zone repeated for every subnet. Real
+// ELBv2 reports the true per-subnet AZ, and Terraform's aws_lb resource reads
+// this back — a multi-AZ load balancer reporting one zone for every subnet is
+// a perpetual plan diff.
+func TestDescribeLoadBalancersReportsRealSubnetAZs(t *testing.T) {
+	elbClient, ec2Client := newSDKClientsWithEC2(t)
+	ctx := context.Background()
+
+	subnetIDs := mkVPCAndSubnetsInZones(t, ec2Client, "us-east-1a", "us-east-1b")
+
+	out, err := elbClient.CreateLoadBalancer(ctx, &elb.CreateLoadBalancerInput{
+		Name:    aws.String("real-az-alb"),
+		Subnets: subnetIDs,
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer: %v", err)
+	}
+
+	zoneBySubnet := map[string]string{}
+	for _, az := range out.LoadBalancers[0].AvailabilityZones {
+		zoneBySubnet[aws.ToString(az.SubnetId)] = aws.ToString(az.ZoneName)
+	}
+
+	if zoneBySubnet[subnetIDs[0]] != "us-east-1a" {
+		t.Errorf("zone for %s = %q, want us-east-1a", subnetIDs[0], zoneBySubnet[subnetIDs[0]])
+	}
+
+	if zoneBySubnet[subnetIDs[1]] != "us-east-1b" {
+		t.Errorf("zone for %s = %q, want us-east-1b", subnetIDs[1], zoneBySubnet[subnetIDs[1]])
+	}
+
+	// Survives a Describe round-trip too.
+	desc, err := elbClient.DescribeLoadBalancers(ctx, &elb.DescribeLoadBalancersInput{
+		LoadBalancerArns: []string{aws.ToString(out.LoadBalancers[0].LoadBalancerArn)},
+	})
+	if err != nil {
+		t.Fatalf("DescribeLoadBalancers: %v", err)
+	}
+
+	zoneBySubnet = map[string]string{}
+	for _, az := range desc.LoadBalancers[0].AvailabilityZones {
+		zoneBySubnet[aws.ToString(az.SubnetId)] = aws.ToString(az.ZoneName)
+	}
+
+	if zoneBySubnet[subnetIDs[0]] == zoneBySubnet[subnetIDs[1]] {
+		t.Errorf("subnets in different AZs reported the same zone: %v", zoneBySubnet)
+	}
+}
+
+// TestSetSubnetsReportsRealSubnetAZs proves SetSubnets' response also carries
+// the real per-subnet AZ for the replacement subnet list.
+func TestSetSubnetsReportsRealSubnetAZs(t *testing.T) {
+	elbClient, ec2Client := newSDKClientsWithEC2(t)
+	ctx := context.Background()
+
+	subnetIDs := mkVPCAndSubnetsInZones(t, ec2Client, "us-east-1a", "us-east-1c")
+
+	lbOut, err := elbClient.CreateLoadBalancer(ctx, &elb.CreateLoadBalancerInput{
+		Name:    aws.String("set-subnets-real-az"),
+		Subnets: []string{subnetIDs[0]},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer: %v", err)
+	}
+
+	lbARN := aws.ToString(lbOut.LoadBalancers[0].LoadBalancerArn)
+
+	setOut, err := elbClient.SetSubnets(ctx, &elb.SetSubnetsInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Subnets:         subnetIDs,
+	})
+	if err != nil {
+		t.Fatalf("SetSubnets: %v", err)
+	}
+
+	zoneBySubnet := map[string]string{}
+	for _, az := range setOut.AvailabilityZones {
+		zoneBySubnet[aws.ToString(az.SubnetId)] = aws.ToString(az.ZoneName)
+	}
+
+	if zoneBySubnet[subnetIDs[0]] != "us-east-1a" {
+		t.Errorf("zone for %s = %q, want us-east-1a", subnetIDs[0], zoneBySubnet[subnetIDs[0]])
+	}
+
+	if zoneBySubnet[subnetIDs[1]] != "us-east-1c" {
+		t.Errorf("zone for %s = %q, want us-east-1c", subnetIDs[1], zoneBySubnet[subnetIDs[1]])
+	}
+}

--- a/server/aws/elbv2/handler.go
+++ b/server/aws/elbv2/handler.go
@@ -51,6 +51,8 @@ var elbActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup
 	"DescribeListeners":              {},
 	"DeleteListener":                 {},
 	"ModifyListener":                 {},
+	"DescribeListenerAttributes":     {},
+	"ModifyListenerAttributes":       {},
 	"CreateRule":                     {},
 	"DescribeRules":                  {},
 	"DeleteRule":                     {},
@@ -156,6 +158,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.deleteListener(w, r)
 	case "ModifyListener":
 		h.modifyListener(w, r)
+	case "DescribeListenerAttributes":
+		h.describeListenerAttributes(w, r)
+	case "ModifyListenerAttributes":
+		h.modifyListenerAttributes(w, r)
 	case "CreateRule":
 		h.createRule(w, r)
 	case "DescribeRules":

--- a/server/aws/elbv2/health_check_protocol_sdk_test.go
+++ b/server/aws/elbv2/health_check_protocol_sdk_test.go
@@ -1,0 +1,70 @@
+package elbv2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+)
+
+// TestSDKHTTPSTargetGroupDefaultsHealthCheckToHTTP proves an HTTPS target
+// group with no explicit health_check block defaults HealthCheckProtocol to
+// HTTP, not HTTPS. Real ELBv2 never mirrors a target group's own protocol
+// onto its health check (see the CreateTargetGroup API reference); mirroring
+// it — the prior emulator behavior — surfaced as a perpetual Terraform plan
+// diff on any aws_lb_target_group with protocol = "HTTPS".
+func TestSDKHTTPSTargetGroupDefaultsHealthCheckToHTTP(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateTargetGroup(ctx, &elb.CreateTargetGroupInput{
+		Name:     aws.String("https-hc-tg"),
+		Protocol: elbtypes.ProtocolEnumHttps,
+		Port:     aws.Int32(443),
+		VpcId:    aws.String("vpc-1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	tg := out.TargetGroups[0]
+
+	if tg.HealthCheckProtocol != elbtypes.ProtocolEnumHttp {
+		t.Errorf("HealthCheckProtocol = %q, want HTTP", tg.HealthCheckProtocol)
+	}
+
+	// Survives a describe round-trip too.
+	desc, err := client.DescribeTargetGroups(ctx, &elb.DescribeTargetGroupsInput{
+		TargetGroupArns: []string{aws.ToString(tg.TargetGroupArn)},
+	})
+	if err != nil {
+		t.Fatalf("DescribeTargetGroups: %v", err)
+	}
+
+	if desc.TargetGroups[0].HealthCheckProtocol != elbtypes.ProtocolEnumHttp {
+		t.Errorf("describe: HealthCheckProtocol = %q, want HTTP", desc.TargetGroups[0].HealthCheckProtocol)
+	}
+}
+
+// TestSDKTCPTargetGroupDefaultsHealthCheckToTCP proves a Network Load
+// Balancer target group (TCP) still defaults its health check to TCP.
+func TestSDKTCPTargetGroupDefaultsHealthCheckToTCP(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateTargetGroup(ctx, &elb.CreateTargetGroupInput{
+		Name:     aws.String("tcp-hc-tg"),
+		Protocol: elbtypes.ProtocolEnumTcp,
+		Port:     aws.Int32(80),
+		VpcId:    aws.String("vpc-1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	if out.TargetGroups[0].HealthCheckProtocol != elbtypes.ProtocolEnumTcp {
+		t.Errorf("HealthCheckProtocol = %q, want TCP", out.TargetGroups[0].HealthCheckProtocol)
+	}
+}

--- a/server/aws/elbv2/listener_attributes_sdk_test.go
+++ b/server/aws/elbv2/listener_attributes_sdk_test.go
@@ -1,0 +1,127 @@
+package elbv2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+)
+
+// mkListenerOfType creates a load balancer of the given SDK type and a
+// listener on it, returning the listener ARN.
+func mkListenerOfType(t *testing.T, client *elb.Client, lbType elbtypes.LoadBalancerTypeEnum) string {
+	t.Helper()
+	ctx := context.Background()
+
+	lbOut, err := client.CreateLoadBalancer(ctx, &elb.CreateLoadBalancerInput{
+		Name:    aws.String("attr-lb-" + string(lbType)),
+		Type:    lbType,
+		Subnets: []string{"subnet-a"},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer: %v", err)
+	}
+
+	tgOut, err := client.CreateTargetGroup(ctx, &elb.CreateTargetGroupInput{
+		Name:     aws.String("attr-tg-" + string(lbType)),
+		Protocol: elbtypes.ProtocolEnumTcp,
+		Port:     aws.Int32(80),
+		VpcId:    aws.String("vpc-1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	liOut, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: lbOut.LoadBalancers[0].LoadBalancerArn,
+		Protocol:        elbtypes.ProtocolEnumTcp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: tgOut.TargetGroups[0].TargetGroupArn,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	return aws.ToString(liOut.Listeners[0].ListenerArn)
+}
+
+// TestDescribeListenerAttributesDefaults proves DescribeListenerAttributes —
+// entirely unsupported before this fix — now returns the ELBv2 defaults
+// derived from the parent load balancer's type: a Network Load Balancer
+// listener defaults tcp.idle_timeout.seconds to 350, matching the
+// ListenerAttribute API reference.
+func TestDescribeListenerAttributesDefaults(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	listenerARN := mkListenerOfType(t, client, elbtypes.LoadBalancerTypeEnumNetwork)
+
+	got, err := client.DescribeListenerAttributes(ctx,
+		&elb.DescribeListenerAttributesInput{ListenerArn: aws.String(listenerARN)})
+	if err != nil {
+		t.Fatalf("DescribeListenerAttributes: %v", err)
+	}
+
+	attrs := map[string]string{}
+	for _, a := range got.Attributes {
+		attrs[aws.ToString(a.Key)] = aws.ToString(a.Value)
+	}
+
+	if attrs["tcp.idle_timeout.seconds"] != "350" {
+		t.Errorf("tcp.idle_timeout.seconds = %q, want 350: %+v", attrs["tcp.idle_timeout.seconds"], got.Attributes)
+	}
+}
+
+// TestModifyListenerAttributesRoundTrip proves ModifyListenerAttributes
+// persists an update that DescribeListenerAttributes then reflects.
+func TestModifyListenerAttributesRoundTrip(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	listenerARN := mkListenerOfType(t, client, elbtypes.LoadBalancerTypeEnumNetwork)
+
+	modOut, err := client.ModifyListenerAttributes(ctx, &elb.ModifyListenerAttributesInput{
+		ListenerArn: aws.String(listenerARN),
+		Attributes: []elbtypes.ListenerAttribute{
+			{Key: aws.String("tcp.idle_timeout.seconds"), Value: aws.String("60")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ModifyListenerAttributes: %v", err)
+	}
+
+	found := ""
+
+	for _, a := range modOut.Attributes {
+		if aws.ToString(a.Key) == "tcp.idle_timeout.seconds" {
+			found = aws.ToString(a.Value)
+		}
+	}
+
+	if found != "60" {
+		t.Fatalf("ModifyListenerAttributes response tcp.idle_timeout.seconds = %q, want 60", found)
+	}
+
+	got, err := client.DescribeListenerAttributes(ctx,
+		&elb.DescribeListenerAttributesInput{ListenerArn: aws.String(listenerARN)})
+	if err != nil {
+		t.Fatalf("DescribeListenerAttributes: %v", err)
+	}
+
+	found = ""
+
+	for _, a := range got.Attributes {
+		if aws.ToString(a.Key) == "tcp.idle_timeout.seconds" {
+			found = aws.ToString(a.Value)
+		}
+	}
+
+	if found != "60" {
+		t.Fatalf("after modify, tcp.idle_timeout.seconds = %q, want 60", found)
+	}
+}

--- a/server/aws/elbv2/listener_rule_tags_sdk_test.go
+++ b/server/aws/elbv2/listener_rule_tags_sdk_test.go
@@ -1,0 +1,217 @@
+package elbv2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+)
+
+// mkListenerWithRule creates a load balancer, target group, listener (with
+// Tags), and a rule on that listener (with Tags), returning their ARNs.
+func mkListenerWithRule(t *testing.T, client *elb.Client) (listenerARN, ruleARN string) {
+	t.Helper()
+	ctx := context.Background()
+
+	lbARN, tgARN := setupLBAndTG(t, client, "tag-lb", "tag-tg")
+
+	liOut, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+		Tags: []elbtypes.Tag{{Key: aws.String("env"), Value: aws.String("prod")}},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	listenerARN = aws.ToString(liOut.Listeners[0].ListenerArn)
+
+	ruleOut, err := client.CreateRule(ctx, &elb.CreateRuleInput{
+		ListenerArn: aws.String(listenerARN),
+		Priority:    aws.Int32(10),
+		Conditions: []elbtypes.RuleCondition{{
+			Field: aws.String("path-pattern"),
+			PathPatternConfig: &elbtypes.PathPatternConditionConfig{
+				Values: []string{"/api/*"},
+			},
+		}},
+		Actions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+		Tags: []elbtypes.Tag{{Key: aws.String("team"), Value: aws.String("platform")}},
+	})
+	if err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	ruleARN = aws.ToString(ruleOut.Rules[0].RuleArn)
+
+	return listenerARN, ruleARN
+}
+
+// TestDescribeTagsResolvesListenerTags proves DescribeTags called with a
+// listener ARN returns the tags supplied at CreateListener time. Before this
+// fix ListenerInfo carried no Tags field at all, so a listener's tags were
+// dropped at create time and DescribeTags reported ListenerNotFound for its
+// ARN — breaking Terraform's aws_lb_listener resource, whose Read always
+// fetches tags after create/refresh.
+func TestDescribeTagsResolvesListenerTags(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	listenerARN, _ := mkListenerWithRule(t, client)
+
+	got, err := client.DescribeTags(ctx, &elb.DescribeTagsInput{ResourceArns: []string{listenerARN}})
+	if err != nil {
+		t.Fatalf("DescribeTags(listener): %v", err)
+	}
+
+	if len(got.TagDescriptions) != 1 {
+		t.Fatalf("tag descriptions = %d, want 1", len(got.TagDescriptions))
+	}
+
+	found := false
+
+	for _, tag := range got.TagDescriptions[0].Tags {
+		if aws.ToString(tag.Key) == "env" && aws.ToString(tag.Value) == "prod" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Errorf("listener tags not returned: %+v", got.TagDescriptions[0].Tags)
+	}
+}
+
+// TestDescribeTagsResolvesRuleTags proves DescribeTags called with a listener
+// rule's ARN returns the tags supplied at CreateRule time. DescribeRules only
+// looks up by parent ListenerArn, so this exercises the new RuleGetter path
+// DescribeTags falls back to for a rule ARN.
+func TestDescribeTagsResolvesRuleTags(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, ruleARN := mkListenerWithRule(t, client)
+
+	got, err := client.DescribeTags(ctx, &elb.DescribeTagsInput{ResourceArns: []string{ruleARN}})
+	if err != nil {
+		t.Fatalf("DescribeTags(rule): %v", err)
+	}
+
+	if len(got.TagDescriptions) != 1 {
+		t.Fatalf("tag descriptions = %d, want 1", len(got.TagDescriptions))
+	}
+
+	found := false
+
+	for _, tag := range got.TagDescriptions[0].Tags {
+		if aws.ToString(tag.Key) == "team" && aws.ToString(tag.Value) == "platform" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Errorf("rule tags not returned: %+v", got.TagDescriptions[0].Tags)
+	}
+}
+
+// TestAddAndRemoveTagsOnListenerAndRule proves AddTags/RemoveTags — the
+// mutating counterpart to DescribeTags — also reach listener and rule ARNs,
+// not just load balancers and target groups.
+func TestAddAndRemoveTagsOnListenerAndRule(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	listenerARN, ruleARN := mkListenerWithRule(t, client)
+
+	if _, err := client.AddTags(ctx, &elb.AddTagsInput{
+		ResourceArns: []string{listenerARN, ruleARN},
+		Tags:         []elbtypes.Tag{{Key: aws.String("owner"), Value: aws.String("team-a")}},
+	}); err != nil {
+		t.Fatalf("AddTags: %v", err)
+	}
+
+	got, err := client.DescribeTags(ctx, &elb.DescribeTagsInput{ResourceArns: []string{listenerARN, ruleARN}})
+	if err != nil {
+		t.Fatalf("DescribeTags after AddTags: %v", err)
+	}
+
+	byARN := map[string]map[string]string{}
+
+	for _, td := range got.TagDescriptions {
+		m := map[string]string{}
+		for _, tag := range td.Tags {
+			m[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+		}
+
+		byARN[aws.ToString(td.ResourceArn)] = m
+	}
+
+	if byARN[listenerARN]["owner"] != "team-a" {
+		t.Errorf("listener owner tag = %q, want team-a", byARN[listenerARN]["owner"])
+	}
+
+	if byARN[ruleARN]["owner"] != "team-a" {
+		t.Errorf("rule owner tag = %q, want team-a", byARN[ruleARN]["owner"])
+	}
+
+	if _, err := client.RemoveTags(ctx, &elb.RemoveTagsInput{
+		ResourceArns: []string{listenerARN, ruleARN}, TagKeys: []string{"owner"},
+	}); err != nil {
+		t.Fatalf("RemoveTags: %v", err)
+	}
+
+	got, err = client.DescribeTags(ctx, &elb.DescribeTagsInput{ResourceArns: []string{listenerARN, ruleARN}})
+	if err != nil {
+		t.Fatalf("DescribeTags after RemoveTags: %v", err)
+	}
+
+	for _, td := range got.TagDescriptions {
+		for _, tag := range td.Tags {
+			if aws.ToString(tag.Key) == "owner" {
+				t.Errorf("owner tag survived RemoveTags on %s", aws.ToString(td.ResourceArn))
+			}
+		}
+	}
+}
+
+// TestDescribeRulesByRuleArnsWithoutListenerArn proves DescribeRules resolves
+// rules directly by RuleArns when called without a ListenerArn — the shape
+// Terraform's aws_lb_listener_rule data source and resource refresh use.
+// Before this fix an empty ListenerArn fell through to the listener-exists
+// check and errored instead of resolving the requested rules.
+func TestDescribeRulesByRuleArnsWithoutListenerArn(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, ruleARN := mkListenerWithRule(t, client)
+
+	got, err := client.DescribeRules(ctx, &elb.DescribeRulesInput{RuleArns: []string{ruleARN}})
+	if err != nil {
+		t.Fatalf("DescribeRules(RuleArns only): %v", err)
+	}
+
+	if len(got.Rules) != 1 || aws.ToString(got.Rules[0].RuleArn) != ruleARN {
+		t.Fatalf("DescribeRules(RuleArns) = %+v, want [%s]", got.Rules, ruleARN)
+	}
+}
+
+// TestDescribeRulesByUnknownRuleArn proves an unknown rule ARN still reports a
+// proper error rather than an empty success.
+func TestDescribeRulesByUnknownRuleArn(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.DescribeRules(ctx, &elb.DescribeRulesInput{RuleArns: []string{"arn:nope"}})
+	if err == nil {
+		t.Fatal("DescribeRules(unknown RuleArn) = nil error, want an error")
+	}
+}

--- a/server/aws/elbv2/modify.go
+++ b/server/aws/elbv2/modify.go
@@ -203,16 +203,26 @@ func (h *Handler) setSubnets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	subnets := awsquery.ListStrings(r.Form, "Subnets.member")
+	lbARN := r.Form.Get("LoadBalancerArn")
 
-	got, err := mod.SetSubnets(r.Context(), r.Form.Get("LoadBalancerArn"), subnets)
+	got, err := mod.SetSubnets(r.Context(), lbARN, subnets)
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
+	// Re-read the load balancer for the per-subnet zone mapping SetSubnets just
+	// resolved: the driver method returns only the subnet id list, so the zone
+	// each one sits in comes from the stored LBInfo, the same source
+	// DescribeLoadBalancers reports it from.
+	var subnetAZs map[string]string
+	if lbs, dErr := h.lb.DescribeLoadBalancers(r.Context(), []string{lbARN}); dErr == nil && len(lbs) > 0 {
+		subnetAZs = lbs[0].SubnetAZs
+	}
+
 	az := &availabilityZonesXML{}
 	for _, s := range got {
-		az.Member = append(az.Member, availabilityZoneXML{ZoneName: zoneNameForSubnet(), SubnetID: s})
+		az.Member = append(az.Member, availabilityZoneXML{ZoneName: zoneNameForSubnet(subnetAZs, s), SubnetID: s})
 	}
 
 	awsquery.WriteXMLResponse(w, setSubnetsResponse{

--- a/server/aws/elbv2/operations.go
+++ b/server/aws/elbv2/operations.go
@@ -245,6 +245,7 @@ func (h *Handler) createListener(w http.ResponseWriter, r *http.Request) {
 		DefaultActions: parseActions(form, "DefaultActions.member"),
 		SslPolicy:      form.Get("SslPolicy"),
 		Certificates:   parseCertificates(form, "Certificates.member"),
+		Tags:           awsquery.FlatTags(form, "Tags.member"),
 	}
 
 	li, err := h.lb.CreateListener(r.Context(), cfg)
@@ -333,6 +334,7 @@ func (h *Handler) createRule(w http.ResponseWriter, r *http.Request) {
 		Priority:    formInt(form.Get("Priority")),
 		Conditions:  parseConditions(form, "Conditions.member"),
 		Actions:     parseActions(form, "Actions.member"),
+		Tags:        awsquery.FlatTags(form, "Tags.member"),
 	}
 
 	rule, err := h.lb.CreateRule(r.Context(), cfg)
@@ -348,10 +350,30 @@ func (h *Handler) createRule(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+//nolint:dupl // structurally mirrors describeListeners' ARN/filter pattern by design.
 func (h *Handler) describeRules(w http.ResponseWriter, r *http.Request) {
 	listenerARN := r.Form.Get("ListenerArn")
+	wanted := awsquery.ListStrings(r.Form, "RuleArns.member")
 
-	rules, err := h.lb.DescribeRules(r.Context(), listenerARN)
+	// ListenerArn and RuleArns are alternative, both-optional filters (mirroring
+	// DescribeListeners' LoadBalancerArn/ListenerArns pair above). A
+	// DescribeRules called with only RuleArns — as Terraform's
+	// aws_lb_listener_rule read does — must resolve those rules directly by
+	// ARN, not fall through to a listener existence check on an empty ARN.
+	var (
+		rules []lbdriver.RuleInfo
+		err   error
+	)
+
+	if listenerARN == "" && len(wanted) > 0 {
+		rules, err = h.rulesByARN(r.Context(), wanted)
+	} else {
+		rules, err = h.lb.DescribeRules(r.Context(), listenerARN)
+		if err == nil && len(wanted) > 0 {
+			rules = filterRules(rules, wanted)
+		}
+	}
+
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -774,6 +796,47 @@ func filterListeners(lis []lbdriver.ListenerInfo, wanted []string) []lbdriver.Li
 	for i := range lis {
 		if _, ok := set[lis[i].ARN]; ok {
 			out = append(out, lis[i])
+		}
+	}
+
+	return out
+}
+
+// rulesByARN resolves the named rules directly by ARN (used when DescribeRules
+// is called with RuleArns and no ListenerArn). A rule ARN that does not exist
+// yields RuleNotFound.
+func (h *Handler) rulesByARN(ctx context.Context, arns []string) ([]lbdriver.RuleInfo, error) {
+	getter, ok := h.lb.(lbdriver.RuleGetter)
+	if !ok {
+		return nil, cerrors.New(cerrors.NotFound, "rule lookup by ARN is not supported")
+	}
+
+	out := make([]lbdriver.RuleInfo, 0, len(arns))
+
+	for _, arn := range arns {
+		rule, err := getter.GetRule(ctx, arn)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, *rule)
+	}
+
+	return out, nil
+}
+
+// filterRules keeps only rules whose ARN is in wanted.
+func filterRules(rules []lbdriver.RuleInfo, wanted []string) []lbdriver.RuleInfo {
+	set := make(map[string]struct{}, len(wanted))
+	for _, w := range wanted {
+		set[w] = struct{}{}
+	}
+
+	out := rules[:0]
+
+	for i := range rules {
+		if _, ok := set[rules[i].ARN]; ok {
+			out = append(out, rules[i])
 		}
 	}
 

--- a/server/aws/elbv2/tags.go
+++ b/server/aws/elbv2/tags.go
@@ -7,6 +7,7 @@ import (
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	lbdriver "github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
 )
 
 // tagMutator is the AWS-specific ELBv2 tag-write surface, asserted against the
@@ -139,11 +140,23 @@ func (h *Handler) describeTags(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// collectTags resolves each ARN against load balancers and target groups.
+// collectTags resolves each ARN against load balancers, target groups,
+// listeners, and rules.
 //
-// Both collections are listed unfiltered and matched locally rather than
-// queried per ARN, because a by-ARN describe reports not-found for a resource
-// of the other kind — which is a correct answer to the wrong question here.
+// Load balancers and target groups are listed unfiltered and matched locally
+// rather than queried per ARN, because a by-ARN describe reports not-found for
+// a resource of the other kind — which is a correct answer to the wrong
+// question here. Listeners and rules have no such bulk listing in the driver
+// interface (DescribeListeners/DescribeRules both require the parent ARN), so
+// any ARN still unresolved after the LB/TG pass is looked up directly via the
+// optional ListenerGetter/RuleGetter extensions.
+//
+// Every ARN that resolves to a real resource gets an entry here — even one
+// with no tags set (nil map, ranges to zero Tags members) — because a listener
+// or rule with no tags is still a taggable resource DescribeTags must report
+// on, not one to omit: an SDK reading DescribeTags back right after creating a
+// listener expects one TagDescription per requested ARN and indexes the first
+// entry unconditionally.
 func (h *Handler) collectTags(
 	r *http.Request, arns []string,
 ) (map[string]map[string]string, error) {
@@ -176,5 +189,36 @@ func (h *Handler) collectTags(
 		}
 	}
 
+	h.collectListenerAndRuleTags(r, arns, out)
+
 	return out, nil
+}
+
+// collectListenerAndRuleTags resolves any ARN not already present in out
+// against listeners and rules, via the optional ListenerGetter/RuleGetter
+// driver extensions.
+func (h *Handler) collectListenerAndRuleTags(
+	r *http.Request, arns []string, out map[string]map[string]string,
+) {
+	lg, hasListeners := h.lb.(lbdriver.ListenerGetter)
+	rg, hasRules := h.lb.(lbdriver.RuleGetter)
+
+	for _, arn := range arns {
+		if _, ok := out[arn]; ok {
+			continue
+		}
+
+		if hasListeners {
+			if li, err := lg.GetListener(r.Context(), arn); err == nil {
+				out[arn] = li.Tags
+				continue
+			}
+		}
+
+		if hasRules {
+			if rule, err := rg.GetRule(r.Context(), arn); err == nil {
+				out[arn] = rule.Tags
+			}
+		}
+	}
 }

--- a/server/aws/elbv2/types.go
+++ b/server/aws/elbv2/types.go
@@ -390,7 +390,7 @@ func toLoadBalancerXML(lb *lbdriver.LBInfo) loadBalancerXML {
 		az := &availabilityZonesXML{}
 		for _, s := range lb.Subnets {
 			az.Member = append(az.Member, availabilityZoneXML{
-				ZoneName: zoneNameForSubnet(),
+				ZoneName: zoneNameForSubnet(lb.SubnetAZs, s),
 				SubnetID: s,
 			})
 		}
@@ -405,10 +405,16 @@ func toLoadBalancerXML(lb *lbdriver.LBInfo) loadBalancerXML {
 	return out
 }
 
-// zoneNameForSubnet returns the availability-zone name reported for a subnet.
-// The emulator does not model subnet placement, so it reports the region's
-// first zone — enough to populate the non-empty ZoneName real ELBv2 returns.
-func zoneNameForSubnet() string {
+// zoneNameForSubnet returns the availability-zone name reported for subnet s.
+// When the networking driver resolved s's real zone (azs, keyed by subnet ID)
+// it is used; otherwise this falls back to the region's first zone — enough to
+// populate the non-empty ZoneName real ELBv2 returns even with no resolver
+// wired.
+func zoneNameForSubnet(azs map[string]string, s string) string {
+	if zone, ok := azs[s]; ok && zone != "" {
+		return zone
+	}
+
 	return defaultAvailabilityZone
 }
 

--- a/services/loadbalancer/driver/driver.go
+++ b/services/loadbalancer/driver/driver.go
@@ -38,6 +38,11 @@ type LBInfo struct {
 	CanonicalHostedZoneID string
 	// VPCID is the VPC the load balancer's subnets belong to.
 	VPCID string
+	// SubnetAZs maps each entry in Subnets to the availability zone it sits in,
+	// resolved from the networking driver at create/SetSubnets time. A subnet
+	// with no resolvable zone (resolver not wired, or subnet unknown) is absent
+	// from the map.
+	SubnetAZs map[string]string
 	// CreatedTime is when the load balancer was created.
 	CreatedTime time.Time
 	Tags        map[string]string
@@ -124,6 +129,7 @@ type ListenerConfig struct {
 	// SslPolicy and Certificates apply to TLS-terminating (HTTPS/TLS) listeners.
 	SslPolicy    string
 	Certificates []Certificate
+	Tags         map[string]string
 }
 
 // ListenerInfo describes a listener. See ListenerConfig for the relationship
@@ -137,6 +143,7 @@ type ListenerInfo struct {
 	DefaultActions []RuleAction
 	SslPolicy      string
 	Certificates   []Certificate
+	Tags           map[string]string
 }
 
 // Certificate is a server certificate bound to an HTTPS/TLS listener. The
@@ -249,6 +256,7 @@ type RuleConfig struct {
 	Priority    int
 	Conditions  []RuleCondition
 	Actions     []RuleAction
+	Tags        map[string]string
 }
 
 // RuleInfo describes a listener rule.
@@ -259,6 +267,7 @@ type RuleInfo struct {
 	Conditions  []RuleCondition
 	Actions     []RuleAction
 	IsDefault   bool
+	Tags        map[string]string
 }
 
 // ModifyListenerInput describes modifications to apply to a listener. A
@@ -364,6 +373,14 @@ type ListenerGetter interface {
 	GetListener(ctx context.Context, listenerARN string) (*ListenerInfo, error)
 }
 
+// RuleGetter is implemented by drivers that can fetch a single listener rule
+// by ARN, letting a handler resolve a rule's tags (ELBv2 DescribeTags accepts
+// listener-rule ARNs, and DescribeRules only looks up by parent listener ARN,
+// not by the rule's own ARN).
+type RuleGetter interface {
+	GetRule(ctx context.Context, ruleARN string) (*RuleInfo, error)
+}
+
 // LBNetworkModifier is implemented by drivers that can replace the security
 // groups or subnets of an existing load balancer (ELBv2 SetSecurityGroups /
 // SetSubnets). SetSubnets returns the resulting subnet list.
@@ -381,5 +398,18 @@ type TargetGroupAttributeStore interface {
 	GetTargetGroupAttributes(ctx context.Context, targetGroupARN string) (map[string]string, error)
 	ModifyTargetGroupAttributes(
 		ctx context.Context, targetGroupARN string, updates map[string]string,
+	) (map[string]string, error)
+}
+
+// ListenerAttributeStore is implemented by drivers that store per-listener
+// key/value attributes (ELBv2 DescribeListenerAttributes /
+// ModifyListenerAttributes). Both methods return the full attribute set,
+// load-balancer-type-derived defaults included, so a caller reads back exactly
+// what real ELBv2 reports. ModifyListenerAttributes merges updates over the
+// stored set.
+type ListenerAttributeStore interface {
+	GetListenerAttributes(ctx context.Context, listenerARN string) (map[string]string, error)
+	ModifyListenerAttributes(
+		ctx context.Context, listenerARN string, updates map[string]string,
 	) (map[string]string, error)
 }


### PR DESCRIPTION
## Summary

Real-user e2e audit of AWS ELBv2 (Terraform + aws-cli against the wire server) found six divergences from real AWS behavior, all fixed:

1. **Listener tags dropped entirely** — `ListenerInfo`/`ListenerConfig` had no `Tags` field; `CreateListener` silently discarded tags, and `AddTags`/`RemoveTags`/`DescribeTags` never reached listener ARNs. Caused a perpetual Terraform plan diff (or false drift) on `aws_lb_listener` with a `tags` block.
2. **Listener-rule tags dropped entirely** — same shape as (1) for `RuleInfo`/`RuleConfig`. A new optional driver interface `RuleGetter` (`GetRule`) lets the server resolve a rule's tags by its own ARN, since `DescribeRules` only looks up by parent listener ARN.
3. **`DescribeRules` couldn't resolve by `RuleArns` alone** — Terraform's `aws_lb_listener_rule` refresh sends `RuleArns` with no `ListenerArn`; the handler always required a listener ARN and errored.
4. **Load balancer `AvailabilityZones` always reported one fake zone** — every subnet reported the hardcoded `us-east-1a` regardless of its real AZ. `LBInfo` gained `SubnetAZs`, resolved via the existing `SubnetResolver` (EC2/VPC) at `CreateLoadBalancer` and `SetSubnets` time.
5. **Target-group health-check protocol default was wrong** — defaulted to mirror the target group's own protocol (`HTTPS` → `HTTPS`), but real AWS always defaults an ALB target group's health check to `HTTP` and an NLB/GWLB target group's to `TCP`, per the CreateTargetGroup API reference. Caused a perpetual diff on any `aws_lb_target_group` with `protocol = "HTTPS"` and no explicit `health_check` block.
6. **`DescribeListenerAttributes`/`ModifyListenerAttributes` entirely unsupported** — returned an unsupported-action error for every listener. Added a new optional driver interface `ListenerAttributeStore`, with type-derived defaults (`tcp.idle_timeout.seconds = 350` for NLB/GWLB, empty for ALB) plus stored overrides.

All `services/loadbalancer/driver/driver.go` changes are additive: new struct fields on existing structs, plus two new **optional** interfaces (`RuleGetter`, `ListenerAttributeStore`) type-asserted at the server layer — Azure (`azurelb`) and GCP (`gcplb`) need no changes and build unmodified.

## Regression tests

Provider-level (`providers/aws/elbv2`): listener/rule tag round-trip + `AddResourceTags`/`RemoveResourceTags` reaching all 4 resource kinds, `GetRule`, subnet-AZ resolution at create and `SetSubnets`, health-check-protocol defaults (HTTP/HTTPS family vs TCP family, explicit override preserved), listener-attribute type-derived defaults + merge semantics, and a snapshot/restore round-trip covering the new state.

Server-level (`server/aws/elbv2`, aws-sdk-go-v2 + httptest): `DescribeTags`/`AddTags`/`RemoveTags` on listener & rule ARNs, `DescribeRules` by `RuleArns` without `ListenerArn`, real per-subnet AZs via EC2+VPC+ELBv2 wired together (create + `SetSubnets`), `DescribeListenerAttributes`/`ModifyListenerAttributes` round-trip, and the HTTPS→HTTP / TCP→TCP health-check-default full-stack cases.

## Black-box re-verification

Rebuilt the `cloudemu` binary and ran `serve -aws-port 14722 -k8s-port "" -providers=aws`.

**aws-cli**: `describe-load-balancers` on an ALB with 2 subnets in different AZs returned distinct real zones (`us-east-1a`/`us-east-1b`), not the old hardcoded zone. `describe-target-groups` on an HTTPS target group returned `HealthCheckProtocol = HTTP`. `describe-tags` on a tagged listener and a tagged rule both returned their tags. `describe-rules --rule-arns <arn>` (no `--listener-arn`) resolved correctly. `describe-listener-attributes` returned `{}` for an ALB listener and `tcp.idle_timeout.seconds = 350` for an NLB listener, with `modify-listener-attributes` round-tripping to `60`.

**Terraform** (`hashicorp/aws ~> 5.0`): `aws_vpc` + 2× `aws_subnet` (different AZs) + `aws_security_group` + `aws_lb` (application) + `aws_lb_target_group` (HTTPS) + `aws_lb_listener` (with `tags`) + `aws_lb_listener_rule` (with `tags`) + `aws_lb_target_group_attachment` → `terraform apply` (9 created) → `terraform plan -detailed-exitcode` → **exit code 0, "No changes."** — confirmed by `terraform show -json` that the applied state actually carries the fixed tag/AZ values, not an accidental empty-vs-empty match. `terraform destroy` clean (9 destroyed). Server process killed after the run; no orphan listener left on the port.

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers/aws/elbv2/... ./server/aws/elbv2/... ./services/loadbalancer/... ./persist/... -race -count=1`
- [x] `go test ./providers/aws/... ./server/aws/... -count=1`
- [x] `golangci-lint run --new-from-rev=origin/development --timeout=9m ./providers/aws/elbv2/... ./server/aws/elbv2/... ./services/loadbalancer/...` — 0 issues
- [x] `go generate ./...` — regenerated `docs/coverage` for the two new optional interfaces, included in this PR
- [x] `go mod tidy` — no-op
- [x] Black-box re-verify via Terraform + aws-cli against the real `cloudemu serve` binary (see above)