### PR TITLE
fix(gcp): real-user e2e divergences (GCS)

### DIFF
--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -71,6 +71,10 @@ type gcsObject struct {
 	// an eventBasedHold is released, restarting the retention clock. Empty falls
 	// back to Created.
 	RetentionRef string
+	// Deleted is the RFC3339 instant this generation became noncurrent (archived
+	// on overwrite, or archived by a live delete on a versioning-enabled bucket).
+	// Empty for the live generation.
+	Deleted string
 }
 
 type gcsMultipartUpload struct {
@@ -239,6 +243,7 @@ func toInfo(o *gcsObject, cloneMeta bool) driver.ObjectInfo {
 		ContentDisposition: o.ContentDisposition, ContentLanguage: o.ContentLanguage,
 		StorageClass:  o.StorageClass,
 		TemporaryHold: o.TemporaryHold, EventBasedHold: o.EventBasedHold,
+		Deleted: o.Deleted,
 	}
 }
 
@@ -353,11 +358,11 @@ func (m *Mock) putObject(
 		stored = nil
 	}
 
-	archiveVersion(bkt, key, current, exists)
+	now := m.opts.Clock.Now().UTC().Format(gcsTimeFormat)
+
+	archiveVersion(bkt, key, current, exists, now)
 
 	md5b64, crc32cb64 := checksums(data)
-
-	now := m.opts.Clock.Now().UTC().Format(gcsTimeFormat)
 
 	obj := &gcsObject{
 		Key:                key,
@@ -449,10 +454,15 @@ func checkMetagenerationConditions(pre driver.GCSPrecondition, metagen int64, ex
 
 // archiveVersion retains the current object generation when versioning is
 // enabled, so a versions=true listing can still surface it after an overwrite.
-func archiveVersion(bkt *bucketMeta, key string, current *gcsObject, exists bool) {
+// deletedAt stamps the generation's GCS timeDeleted — the instant it became
+// noncurrent — the same way real GCS reports when a version was superseded or
+// explicitly deleted.
+func archiveVersion(bkt *bucketMeta, key string, current *gcsObject, exists bool, deletedAt string) {
 	if !exists || !bkt.versioning {
 		return
 	}
+
+	current.Deleted = deletedAt
 
 	bkt.mu.Lock()
 	defer bkt.mu.Unlock()
@@ -562,7 +572,8 @@ func (m *Mock) deleteObject(ctx context.Context, bucket, key string, generation 
 	// Versioning-enabled live delete archives the current generation (it becomes
 	// noncurrent) — real GCS retains it, listable via versions=true.
 	if bkt.versioning {
-		archiveVersion(bkt, key, current, true)
+		now := m.opts.Clock.Now().UTC().Format(gcsTimeFormat)
+		archiveVersion(bkt, key, current, true, now)
 		bkt.objects.Delete(key)
 		m.emitMetric(ctx, "api/request_count", 1, map[string]string{"bucket_name": bucket})
 
@@ -890,10 +901,10 @@ func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src dri
 		stored = nil
 	}
 
-	dstCurrent, dstExists := dstBkt.objects.Get(dstKey)
-	archiveVersion(dstBkt, dstKey, dstCurrent, dstExists)
-
 	copyNow := m.opts.Clock.Now().UTC().Format(gcsTimeFormat)
+
+	dstCurrent, dstExists := dstBkt.objects.Get(dstKey)
+	archiveVersion(dstBkt, dstKey, dstCurrent, dstExists, copyNow)
 
 	dstBkt.objects.Set(dstKey, &gcsObject{
 		Key: dstKey, Data: stored, Size: srcObj.Size, ContentType: srcObj.ContentType,
@@ -1078,9 +1089,9 @@ func (m *Mock) CompleteMultipartUpload(
 		}
 	}
 
-	archiveVersion(bkt, key, current, exists)
-
 	completeNow := m.opts.Clock.Now().UTC().Format(gcsTimeFormat)
+
+	archiveVersion(bkt, key, current, exists, completeNow)
 
 	bkt.objects.Set(key, &gcsObject{
 		Key:            key,

--- a/server/gcp/gcs/gcs_bucket_semantics_test.go
+++ b/server/gcp/gcs/gcs_bucket_semantics_test.go
@@ -1,9 +1,12 @@
 package gcs_test
 
 import (
+	"errors"
+	"net/http"
 	"testing"
 
 	"cloud.google.com/go/storage"
+	"google.golang.org/api/googleapi"
 )
 
 // TestGCSBucketLocationStorageClass proves a bucket created with a non-default
@@ -133,5 +136,69 @@ func TestGCSBucketMetageneration(t *testing.T) {
 
 	if a2.MetaGeneration <= a.MetaGeneration {
 		t.Errorf("MetaGeneration did not increase after a patch: %d -> %d", a.MetaGeneration, a2.MetaGeneration)
+	}
+}
+
+// TestGCSBucketProjectNumber proves the bucket resource carries a
+// projectNumber, a field real GCS always sets on every bucket (previously
+// absent from the wire response entirely).
+func TestGCSBucketProjectNumber(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "projnum")
+
+	a, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs: %v", err)
+	}
+
+	if a.ProjectNumber == 0 {
+		t.Errorf("ProjectNumber = 0, want a non-zero projectNumber")
+	}
+}
+
+// TestGCSBucketPatchMetagenerationPrecondition proves Buckets.patch/update
+// honors ifMetagenerationMatch/ifMetagenerationNotMatch (previously silently
+// ignored, applying the update regardless of a stale metageneration).
+func TestGCSBucketPatchMetagenerationPrecondition(t *testing.T) {
+	ctx, client := newStorageClient(t)
+	bkt := mustCreateBucket(t, ctx, client, "bucket-precond")
+
+	a, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs: %v", err)
+	}
+
+	// A stale ifMetagenerationMatch must fail with 412, and must not apply
+	// the update.
+	_, err = bkt.If(storage.BucketConditions{MetagenerationMatch: a.MetaGeneration + 1}).
+		Update(ctx, storage.BucketAttrsToUpdate{VersioningEnabled: true})
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != http.StatusPreconditionFailed {
+		t.Fatalf("stale ifMetagenerationMatch update: got %v, want googleapi.Error 412", err)
+	}
+
+	a2, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs after rejected update: %v", err)
+	}
+
+	if a2.VersioningEnabled {
+		t.Errorf("versioning enabled despite a rejected precondition")
+	}
+
+	// The correct metageneration must be accepted.
+	if _, err := bkt.If(storage.BucketConditions{MetagenerationMatch: a.MetaGeneration}).
+		Update(ctx, storage.BucketAttrsToUpdate{VersioningEnabled: true}); err != nil {
+		t.Fatalf("update with correct ifMetagenerationMatch: %v", err)
+	}
+
+	a3, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs after accepted update: %v", err)
+	}
+
+	if !a3.VersioningEnabled {
+		t.Errorf("versioning not enabled after a correctly preconditioned update")
 	}
 }

--- a/server/gcp/gcs/gcs_lifecycle_test.go
+++ b/server/gcp/gcs/gcs_lifecycle_test.go
@@ -516,12 +516,24 @@ func TestStorageBucketEdgeCases(t *testing.T) {
 		t.Fatalf("Delete of non-empty bucket succeeded, want error")
 	}
 
-	// Real GCS returns 409 conflict here; the emulator maps the driver's
-	// FailedPrecondition through its default branch. Record what the SDK sees.
-	if errors.As(err, &gerr) {
-		t.Logf("non-empty bucket delete surfaced as googleapi.Error code=%d (real GCS: 409)", gerr.Code)
-	} else {
-		t.Logf("non-empty bucket delete surfaced as %T: %v", err, err)
+	// Real GCS returns 409 with reason "notEmpty" and a fixed human message,
+	// not the generic "conflict" reason writeErr uses for FailedPrecondition
+	// elsewhere.
+	if !errors.As(err, &gerr) {
+		t.Fatalf("non-empty bucket delete surfaced as %T: %v, want *googleapi.Error", err, err)
+	}
+
+	if gerr.Code != http.StatusConflict {
+		t.Errorf("non-empty bucket delete code = %d, want 409", gerr.Code)
+	}
+
+	if len(gerr.Errors) != 1 || gerr.Errors[0].Reason != "notEmpty" {
+		t.Errorf("non-empty bucket delete reason = %+v, want a single errors[].reason=notEmpty", gerr.Errors)
+	}
+
+	const wantMsg = "The bucket you tried to delete was not empty."
+	if gerr.Message != wantMsg {
+		t.Errorf("non-empty bucket delete message = %q, want %q", gerr.Message, wantMsg)
 	}
 
 	if got := readObject(t, ctx, bkt, "keep.txt"); !bytes.Equal(got, []byte("keep")) {

--- a/server/gcp/gcs/gcs_object_semantics_test.go
+++ b/server/gcp/gcs/gcs_object_semantics_test.go
@@ -270,6 +270,14 @@ func TestGCSVersionedDeleteRetainsGenerations(t *testing.T) {
 
 		if a.Name == "k" {
 			gens = append(gens, a.Generation)
+
+			// Every noncurrent generation — the one superseded by the
+			// overwrite and the one archived by the live delete — must carry
+			// a timeDeleted the way real GCS stamps the instant a version
+			// became noncurrent (google-cloud-go decodes it into Deleted).
+			if a.Deleted.IsZero() {
+				t.Errorf("generation %d: Deleted is zero, want a timeDeleted stamp", a.Generation)
+			}
 		}
 	}
 

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -81,6 +81,14 @@ const (
 	// back when none was set at create.
 	defaultLocation     = "US"
 	defaultStorageClass = "STANDARD"
+
+	// defaultProjectNumber is the numeric project number every bucket reports.
+	// Real GCS always includes a non-zero projectNumber on the bucket resource;
+	// cloudemu doesn't model per-project numeric identifiers (buckets aren't
+	// project-scoped internally), so every bucket reports this fixed
+	// placeholder, mirroring the emulator's other fixed default account/project
+	// identifiers (e.g. config.Options.AccountID's "123456789012" default).
+	defaultProjectNumber = "123456789012"
 )
 
 // Handler serves GCS JSON REST requests against a storage.Bucket driver.
@@ -405,6 +413,7 @@ func (h *Handler) bucketView(r *http.Request, name, created string) bucketResour
 		Kind:             "storage#bucket",
 		ID:               name,
 		Name:             name,
+		ProjectNumber:    defaultProjectNumber,
 		SelfLink:         selfLink(r, "/storage/v1/b/"+name),
 		Location:         location,
 		LocationType:     locationType(location),
@@ -491,6 +500,11 @@ func (h *Handler) patchBucket(w http.ResponseWriter, r *http.Request, name strin
 		return
 	}
 
+	if err := h.checkBucketMetagenerationPrecondition(r, name); err != nil {
+		writePreconditionOrErr(w, err)
+		return
+	}
+
 	if err := h.applyBucketConfig(r.Context(), name, &body); err != nil {
 		writePreconditionOrErr(w, err)
 		return
@@ -505,6 +519,54 @@ func (h *Handler) patchBucket(w http.ResponseWriter, r *http.Request, name strin
 	}
 
 	writeJSON(w, http.StatusOK, h.bucketView(r, name, ""))
+}
+
+// checkBucketMetagenerationPrecondition evaluates the Buckets.patch/update
+// ifMetagenerationMatch/ifMetagenerationNotMatch query preconditions against
+// the bucket's current metageneration, mirroring the 412 conditionNotMet
+// semantics real GCS applies to bucket updates (the object write path already
+// enforces the equivalent generation/metageneration preconditions).
+func (h *Handler) checkBucketMetagenerationPrecondition(r *http.Request, name string) error {
+	q := r.URL.Query()
+
+	matchStr := q.Get("ifMetagenerationMatch")
+	notMatchStr := q.Get("ifMetagenerationNotMatch")
+
+	if matchStr == "" && notMatchStr == "" {
+		return nil
+	}
+
+	metageneration := h.bucketMetageneration(r.Context(), name)
+
+	if matchStr != "" {
+		if want, err := strconv.ParseInt(matchStr, 10, 64); err == nil && metageneration != want {
+			return &storagedriver.GCSPreconditionError{Message: "conditionNotMet: ifMetagenerationMatch"}
+		}
+	}
+
+	if notMatchStr != "" {
+		if want, err := strconv.ParseInt(notMatchStr, 10, 64); err == nil && metageneration == want {
+			return &storagedriver.GCSPreconditionError{Message: "conditionNotMet: ifMetagenerationNotMatch"}
+		}
+	}
+
+	return nil
+}
+
+// bucketMetageneration returns name's current metageneration, defaulting to 1
+// when the backing driver doesn't record one (the same fallback
+// resolveBucketAttrs uses for a fresh or driver-untracked bucket).
+func (h *Handler) bucketMetageneration(ctx context.Context, name string) int64 {
+	if h.ext == nil {
+		return 1
+	}
+
+	attrs, err := h.ext.BucketAttrsGCS(ctx, name)
+	if err != nil || attrs.Metageneration <= 0 {
+		return 1
+	}
+
+	return attrs.Metageneration
 }
 
 // applyBucketConfig applies the mutable configuration fields present in a
@@ -562,7 +624,16 @@ func (h *Handler) applyBucketConfig(ctx context.Context, name string, body *buck
 
 func (h *Handler) deleteBucket(w http.ResponseWriter, r *http.Request, name string) {
 	if err := h.bucket.DeleteBucket(r.Context(), name); err != nil {
+		// Real GCS answers a non-empty-bucket delete with 409 reason "notEmpty"
+		// and a fixed human message, not the generic "conflict" reason writeErr
+		// uses for FailedPrecondition elsewhere (e.g. the retention-lock path).
+		if cerrors.IsFailedPrecondition(err) {
+			writeError(w, http.StatusConflict, "notEmpty", "The bucket you tried to delete was not empty.")
+			return
+		}
+
 		writeErr(w, err)
+
 		return
 	}
 
@@ -1713,6 +1784,7 @@ func toObjectResource(info *storagedriver.ObjectInfo, bucket string, r *http.Req
 		ContentLanguage:         info.ContentLanguage,
 		TimeCreated:             created,
 		Updated:                 info.LastModified,
+		TimeDeleted:             info.Deleted,
 		Metadata:                info.Metadata,
 		TemporaryHold:           info.TemporaryHold,
 		EventBasedHold:          info.EventBasedHold,

--- a/server/gcp/gcs/types.go
+++ b/server/gcp/gcs/types.go
@@ -7,6 +7,7 @@ type bucketResource struct {
 	Kind             string            `json:"kind"`
 	ID               string            `json:"id"`
 	Name             string            `json:"name"`
+	ProjectNumber    string            `json:"projectNumber,omitempty"`
 	SelfLink         string            `json:"selfLink,omitempty"`
 	Location         string            `json:"location,omitempty"`
 	LocationType     string            `json:"locationType,omitempty"`
@@ -103,6 +104,7 @@ type objectResource struct {
 	ContentLanguage         string            `json:"contentLanguage,omitempty"`
 	TimeCreated             string            `json:"timeCreated,omitempty"`
 	Updated                 string            `json:"updated,omitempty"`
+	TimeDeleted             string            `json:"timeDeleted,omitempty"`
 	Metadata                map[string]string `json:"metadata,omitempty"`
 	TemporaryHold           bool              `json:"temporaryHold,omitempty"`
 	EventBasedHold          bool              `json:"eventBasedHold,omitempty"`

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -577,6 +577,11 @@ type ObjectInfo struct {
 	// retention policy. Empty when the bucket has no retention policy (or an
 	// eventBasedHold is currently pinning the object).
 	RetentionExpiration string
+	// Deleted is the GCS timeDeleted (RFC3339) — the instant a version became
+	// noncurrent, either archived by an overwrite or a live delete on a
+	// versioning-enabled bucket. Empty for a live version, or for providers that
+	// don't model versioning/generations.
+	Deleted string
 }
 
 // Object is an object with its data.


### PR DESCRIPTION
## Summary

First deep real-user black-box e2e audit of CloudEmu's GCP surface (harness-validation pilot, mirroring the AWS S3 and Azure RG/Storage pilots), scoped to Google Cloud Storage (GCS). Drove the real `cloud.google.com/go/storage` SDK against a real `cloudemu serve -providers=gcp` binary and fixed four genuine divergences found vs real GCS behavior:

- Non-empty bucket delete returned `reason: "conflict"` with a leaked internal Go error string as the message, instead of real GCS's `reason: "notEmpty"` and fixed human message.
- Bucket resources never carried `projectNumber` (a field real GCS always includes).
- `Buckets.patch`/`update` silently ignored `ifMetagenerationMatch`/`ifMetagenerationNotMatch` — a stale precondition still applied the update (object-level preconditions were already correctly enforced).
- Noncurrent object versions never carried `timeDeleted`, so a `versions=true` listing on a versioning-enabled bucket couldn't distinguish a live version from an archived one (`ObjectAttrs.Deleted` always decoded to the zero time).

Each fix was re-verified black-box against a freshly rebuilt binary via the exact SDK repro, and has a dedicated regression test.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./providers/gcp/gcs/... ./server/gcp/... ./services/storage/... -race`
- [x] `go test ./...` (full suite, zero FAIL)
- [x] `gofmt -l` clean on touched files
- [x] `golangci-lint run` on touched packages — same pre-existing issue count as `development` baseline, zero new issues
- [x] `go generate ./... && git diff --exit-code docs/coverage` — no drift (no interface surface changed)
- [x] Black-box re-verify of each fix: rebuilt `cloudemu serve -providers=gcp`, re-ran the exact `cloud.google.com/go/storage` SDK repro for each finding against the running binary