### PR TITLE
fix(gcp-compute): real-user e2e divergences (GCE)

### DIFF
--- a/server/gcp/compute/handler.go
+++ b/server/gcp/compute/handler.go
@@ -12,7 +12,8 @@
 //	POST   /compute/v1/projects/{p}/zones/{z}/instances/{name}/start — start
 //	POST   /compute/v1/projects/{p}/zones/{z}/instances/{name}/stop  — stop
 //	POST   /compute/v1/projects/{p}/zones/{z}/instances/{name}/reset — reset
-//	POST   /compute/v1/projects/{p}/zones/{z}/instances/{name}/{verb} — setLabels/setMetadata/setTags/setMachineType/attachDisk/detachDisk
+//	POST   /compute/v1/projects/{p}/zones/{z}/instances/{name}/{verb} — setLabels/setMetadata/setTags/
+//	  setMachineType/attachDisk/detachDisk/addAccessConfig/deleteAccessConfig/setDeletionProtection
 //	GET    /compute/v1/projects/{p}/aggregated/instances             — aggregatedList (grouped by zone)
 //	GET    /compute/v1/projects/{p}/zones/{z}/operations/{name}      — get operation (always DONE)
 package compute
@@ -309,17 +310,34 @@ func (h *Handler) serveInstanceAction(w http.ResponseWriter, r *http.Request, rp
 }
 
 // dispatchInstanceVerb routes the POST instance verbs (lifecycle + GCP-specific
-// mutations) to their handlers.
+// mutations) to their handlers. Split across two switches (lifecycle, then
+// GCP-specific mutations) to keep either one's cyclomatic complexity low as
+// the verb set grows.
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) dispatchInstanceVerb(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
-	switch strings.ToLower(rp.Action) {
+	action := strings.ToLower(rp.Action)
+
+	switch action {
 	case "start":
 		h.startInstance(w, r, rp)
 	case "stop":
 		h.stopInstance(w, r, rp)
 	case "reset":
 		h.resetInstance(w, r, rp)
+	default:
+		h.dispatchInstanceMutationVerb(w, r, rp, action)
+	}
+}
+
+// dispatchInstanceMutationVerb routes the GCP-specific instance mutation verbs
+// (as opposed to the AWS-style lifecycle verbs dispatchInstanceVerb handles
+// directly): label/metadata/tag/machine-type updates, disk attach/detach,
+// external-IP accessConfig add/delete, and deletion-protection toggling.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) dispatchInstanceMutationVerb(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath, action string) {
+	switch action {
 	case actionSetLabels:
 		h.setLabels(w, r, rp)
 	case "setmetadata":
@@ -332,6 +350,12 @@ func (h *Handler) dispatchInstanceVerb(w http.ResponseWriter, r *http.Request, r
 		h.attachDisk(w, r, rp)
 	case "detachdisk":
 		h.detachDisk(w, r, rp)
+	case "addaccessconfig":
+		h.addAccessConfig(w, r, rp)
+	case "deleteaccessconfig":
+		h.deleteAccessConfig(w, r, rp)
+	case "setdeletionprotection":
+		h.setDeletionProtection(w, r, rp)
 	default:
 		writeNotImplemented(w, "action: "+rp.Action)
 	}

--- a/server/gcp/compute/instance_actions.go
+++ b/server/gcp/compute/instance_actions.go
@@ -224,6 +224,104 @@ func (h *Handler) detachDriverVolume(
 	return h.compute.DetachVolume(ctx, vol.ID, instanceID, d.DeviceName)
 }
 
+// addAccessConfig handles POST .../instances/{name}/addAccessConfig?
+// networkInterface=nic0, appending an external-IP accessConfig to the
+// instance's network interface. CloudEmu models a single nic0, so
+// networkInterface is accepted (and validated when non-empty) but not used to
+// select among multiple NICs. Server-side defaults (type/name/networkTier,
+// and a synthesized ephemeral natIP when the caller left it empty) are filled
+// the same way instances.insert fills them, so a client that adds an
+// accessConfig with no natIP gets one back on the next Get.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) addAccessConfig(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	var body accessConfig
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	inst, err := findInZone(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	existing := decodeAccessConfigs(inst.Tags)
+	updated := append(existing, fillAccessConfigDefaults(&body, rp.ResourceName, len(existing)))
+
+	h.applyMutation(w, r, rp, inst.ID, "addAccessConfig",
+		map[string]string{keyAccessConfigs: encodeJSON(updated)}, nil, "")
+}
+
+// deleteAccessConfig handles POST .../instances/{name}/deleteAccessConfig?
+// accessConfig={name}&networkInterface=nic0, removing the named external-IP
+// accessConfig from the instance's network interface. Once removed, a natIP
+// that named a reserved google_compute_address reads back RESERVED again (the
+// address's IN_USE status is derived live from every instance's accessConfigs,
+// not stored on the address).
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteAccessConfig(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	name := r.URL.Query().Get("accessConfig")
+	if name == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "accessConfig is required")
+		return
+	}
+
+	inst, err := findInZone(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	current := decodeAccessConfigs(inst.Tags)
+	kept := make([]accessConfig, 0, len(current))
+
+	found := false
+
+	for i := range current {
+		if current[i].Name == name {
+			found = true
+			continue
+		}
+
+		kept = append(kept, current[i])
+	}
+
+	if !found {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "no accessConfig named "+name)
+		return
+	}
+
+	h.applyMutation(w, r, rp, inst.ID, "deleteAccessConfig",
+		map[string]string{keyAccessConfigs: encodeJSON(kept)}, nil, "")
+}
+
+// setDeletionProtection handles POST .../instances/{name}/
+// setDeletionProtection?deletionProtection=true|false, toggling whether
+// instances.delete refuses to remove the instance.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) setDeletionProtection(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	inst, err := findInZone(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	set := map[string]string{}
+
+	var remove []string
+
+	if r.URL.Query().Get("deletionProtection") == tagValueTrue {
+		set[keyDeletionProtection] = tagValueTrue
+	} else {
+		remove = append(remove, keyDeletionProtection)
+	}
+
+	h.applyMutation(w, r, rp, inst.ID, "setDeletionProtection", set, remove, "")
+}
+
 // applyMutation runs a GCP-specific instance mutation through the mutator
 // capability and returns a DONE Operation.
 //

--- a/server/gcp/compute/instance_e2e_findings_sdk_test.go
+++ b/server/gcp/compute/instance_e2e_findings_sdk_test.go
@@ -1,0 +1,200 @@
+package compute_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"cloud.google.com/go/compute/apiv1/computepb"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// TestSDKDiskResizeReflectedOnInstance guards a real-user e2e finding: after
+// disks.resize grows a boot/data disk, a subsequent instances.get must report
+// the disk's CURRENT size in disks[].diskSizeGb, not the size it had at
+// instance-insert time (real GCP's instance view is live, not a snapshot).
+func TestSDKDiskResizeReflectedOnInstance(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Compute: cloudP.GCE})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	instances := newSDKInstancesClient(t, ts)
+	disks := newDisksSDKClient(t, ts)
+	ctx := context.Background()
+
+	name := "resize-reflect-vm"
+	mustInsert(t, instances, testZone, &computepb.Instance{
+		Name:        ptrStr(name),
+		MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+		Disks: []*computepb.AttachedDisk{{
+			Boot:       ptrBool(true),
+			AutoDelete: ptrBool(true),
+			InitializeParams: &computepb.AttachedDiskInitializeParams{
+				SourceImage: ptrStr("projects/debian-cloud/global/images/family/debian-12"),
+				DiskSizeGb:  ptrInt64(20),
+			},
+		}},
+	})
+
+	got := mustGet(t, instances, testZone, name)
+	if got.GetDisks()[0].GetDiskSizeGb() != 20 {
+		t.Fatalf("initial diskSizeGb=%d want 20", got.GetDisks()[0].GetDiskSizeGb())
+	}
+
+	resizeOp, err := disks.Resize(ctx, &computepb.ResizeDiskRequest{
+		Project: testProject, Zone: testZone, Disk: name,
+		DisksResizeRequestResource: &computepb.DisksResizeRequest{SizeGb: ptrInt64(50)},
+	})
+	if err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+
+	if err := resizeOp.Wait(ctx); err != nil {
+		t.Fatalf("Resize wait: %v", err)
+	}
+
+	got2 := mustGet(t, instances, testZone, name)
+	if size := got2.GetDisks()[0].GetDiskSizeGb(); size != 50 {
+		t.Errorf("diskSizeGb after resize=%d want 50 (instance view is stale)", size)
+	}
+}
+
+// TestSDKAddDeleteAccessConfig guards a real-user e2e finding: instances.
+// addAccessConfig/deleteAccessConfig (used by "gcloud compute instances
+// add-access-config"/"delete-access-config" to attach/detach an ephemeral
+// external IP post-creation) returned 501 not implemented.
+func TestSDKAddDeleteAccessConfig(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Compute: cloudP.GCE, Networking: cloudP.VPC})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	instances := newSDKInstancesClient(t, ts)
+	ctx := context.Background()
+
+	name := "accessconfig-vm"
+	mustInsert(t, instances, testZone, &computepb.Instance{
+		Name:        ptrStr(name),
+		MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+		NetworkInterfaces: []*computepb.NetworkInterface{
+			{Network: ptrStr("global/networks/default")},
+		},
+	})
+
+	got := mustGet(t, instances, testZone, name)
+	if acs := got.GetNetworkInterfaces()[0].GetAccessConfigs(); len(acs) != 0 {
+		t.Fatalf("fresh instance has %d accessConfigs, want 0", len(acs))
+	}
+
+	addOp, err := instances.AddAccessConfig(ctx, &computepb.AddAccessConfigInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: name, NetworkInterface: "nic0",
+		AccessConfigResource: &computepb.AccessConfig{},
+	})
+	if err != nil {
+		t.Fatalf("AddAccessConfig: %v", err)
+	}
+
+	if err := addOp.Wait(ctx); err != nil {
+		t.Fatalf("AddAccessConfig wait: %v", err)
+	}
+
+	got2 := mustGet(t, instances, testZone, name)
+	acs := got2.GetNetworkInterfaces()[0].GetAccessConfigs()
+
+	if len(acs) != 1 {
+		t.Fatalf("accessConfigs after add=%d want 1", len(acs))
+	}
+
+	if acs[0].GetNatIP() == "" {
+		t.Error("added accessConfig has no synthesized natIP")
+	}
+
+	if acs[0].GetType() != "ONE_TO_ONE_NAT" {
+		t.Errorf("accessConfig type=%q want ONE_TO_ONE_NAT", acs[0].GetType())
+	}
+
+	name0 := acs[0].GetName()
+
+	delOp, err := instances.DeleteAccessConfig(ctx, &computepb.DeleteAccessConfigInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: name,
+		AccessConfig: name0, NetworkInterface: "nic0",
+	})
+	if err != nil {
+		t.Fatalf("DeleteAccessConfig: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Fatalf("DeleteAccessConfig wait: %v", err)
+	}
+
+	got3 := mustGet(t, instances, testZone, name)
+	if acs := got3.GetNetworkInterfaces()[0].GetAccessConfigs(); len(acs) != 0 {
+		t.Errorf("accessConfigs after delete=%d want 0", len(acs))
+	}
+}
+
+// TestSDKDeletionProtection guards a real-user e2e finding: deletionProtection
+// was silently dropped on insert (always read back false) and never enforced,
+// so instances.delete succeeded on a protected instance. It should round-trip,
+// block delete with a 400 while true, and instances.setDeletionProtection
+// should be able to clear it so delete then succeeds.
+func TestSDKDeletionProtection(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Compute: cloudP.GCE})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	instances := newSDKInstancesClient(t, ts)
+	ctx := context.Background()
+
+	name := "delprotect-vm"
+	mustInsert(t, instances, testZone, &computepb.Instance{
+		Name:               ptrStr(name),
+		MachineType:        ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+		DeletionProtection: ptrBool(true),
+	})
+
+	got := mustGet(t, instances, testZone, name)
+	if !got.GetDeletionProtection() {
+		t.Fatal("deletionProtection not round-tripped from insert")
+	}
+
+	if _, err := instances.Delete(ctx, &computepb.DeleteInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: name,
+	}); err == nil {
+		t.Error("Delete of a deletionProtection=true instance succeeded, want an error")
+	}
+
+	// Instance must still exist.
+	mustGet(t, instances, testZone, name)
+
+	clearOp, err := instances.SetDeletionProtection(ctx, &computepb.SetDeletionProtectionInstanceRequest{
+		Project: testProject, Zone: testZone, Resource: name, DeletionProtection: ptrBool(false),
+	})
+	if err != nil {
+		t.Fatalf("SetDeletionProtection: %v", err)
+	}
+
+	if err := clearOp.Wait(ctx); err != nil {
+		t.Fatalf("SetDeletionProtection wait: %v", err)
+	}
+
+	got2 := mustGet(t, instances, testZone, name)
+	if got2.GetDeletionProtection() {
+		t.Error("deletionProtection still true after setDeletionProtection(false)")
+	}
+
+	delOp, err := instances.Delete(ctx, &computepb.DeleteInstanceRequest{
+		Project: testProject, Zone: testZone, Instance: name,
+	})
+	if err != nil {
+		t.Fatalf("Delete after clearing protection: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Fatalf("Delete wait: %v", err)
+	}
+}

--- a/server/gcp/compute/instance_response.go
+++ b/server/gcp/compute/instance_response.go
@@ -1,6 +1,7 @@
 package compute
 
 import (
+	"context"
 	"strconv"
 	"strings"
 
@@ -13,7 +14,11 @@ const defaultCPUPlatform = "Intel Broadwell"
 // toInstanceResponse maps a driver Instance back to GCP's REST shape, resolving
 // the GCP-specific state carried in the instance's internal tags (disks,
 // network tags, metadata, network self-link) and filling realistic defaults.
-func toInstanceResponse(inst *computedriver.Instance, project, host string) instanceResponse {
+// ctx/h are used to resolve each attached disk's CURRENT size from the disk
+// store (see resolveDisks), so a read reflects a disks.resize that happened
+// after the instance was created — matching real GCP, where instances.get's
+// disks[].diskSizeGb is the disk's live size, not a snapshot from attach time.
+func (h *Handler) toInstanceResponse(ctx context.Context, inst *computedriver.Instance, project, host string) instanceResponse {
 	name := tagOr(inst.Tags, gcpNameTag, "")
 	zone := tagOr(inst.Tags, keyZone, "")
 	labels := userLabels(inst.Tags)
@@ -30,8 +35,8 @@ func toInstanceResponse(inst *computedriver.Instance, project, host string) inst
 		SelfLink:           zoneLink(host, project, zone, "instances", name),
 		CreationTimestamp:  inst.LaunchTime,
 		CPUPlatform:        defaultCPUPlatform,
-		DeletionProtection: false,
-		Disks:              resolveDisks(inst, host, project, zone, name),
+		DeletionProtection: deletionProtection(inst.Tags),
+		Disks:              h.resolveDisks(ctx, inst, host, project, zone, name),
 		NetworkInterfaces:  instanceNICs(inst, host, project, zone),
 		Labels:             labels,
 		LabelFingerprint:   labelFingerprintFor(labels),
@@ -63,7 +68,11 @@ func zoneLink(host, project, zone, resourceType, name string) string {
 
 // resolveDisks turns the stored inbound disk descriptors into the full GCP
 // attachedDisk read shape (resolved source self-link, diskSizeGb, type, mode).
-func resolveDisks(inst *computedriver.Instance, host, project, zone, instanceName string) []attachedDisk {
+// diskSizeGb is refreshed from the backing Disk resource's CURRENT size when
+// one can be resolved (every wire-materialized disk has one — see
+// materializeInsertDisks), so a disks.resize after instance creation is
+// reflected on the next instances.get rather than the stale insert-time value.
+func (h *Handler) resolveDisks(ctx context.Context, inst *computedriver.Instance, host, project, zone, instanceName string) []attachedDisk {
 	disks := decodeDisks(inst.Tags)
 	if len(disks) == 0 {
 		return nil
@@ -96,10 +105,33 @@ func resolveDisks(inst *computedriver.Instance, host, project, zone, instanceNam
 			d.Source = zoneLink(host, project, zone, "disks", d.DeviceName)
 		}
 
+		if size, ok := h.currentDiskSizeGb(ctx, d.Source, zone); ok {
+			d.DiskSizeGb = size
+		}
+
 		out = append(out, d)
 	}
 
 	return out
+}
+
+// currentDiskSizeGb resolves the live sizeGb of the Disk resource named by a
+// disks[] entry's source self-link, so a resize after instance creation is
+// reflected on read. Returns ok=false when the disk can't be resolved (a
+// driver-direct instance with no matching Disk resource), leaving the
+// caller's insert-time value in place.
+func (h *Handler) currentDiskSizeGb(ctx context.Context, source, zone string) (string, bool) {
+	name := lastSegment(source)
+	if name == "" {
+		return "", false
+	}
+
+	vol, err := findDiskByName(ctx, h.compute, name, zone)
+	if err != nil {
+		return "", false
+	}
+
+	return strconv.Itoa(vol.Size), true
 }
 
 func deviceNameFor(boot bool, instanceName string, index int) string {

--- a/server/gcp/compute/instance_state.go
+++ b/server/gcp/compute/instance_state.go
@@ -17,14 +17,19 @@ import (
 // entries of the instance's tag map, keyed with the "cloudemu:gcp" prefix.
 // These keys are stripped from the emitted labels.
 const (
-	keyDisks         = "cloudemu:gcp:disks"
-	keyNetTags       = "cloudemu:gcp:nettags"
-	keyMetadata      = "cloudemu:gcp:metadata"
-	keyNetwork       = "cloudemu:gcp:network"
-	keyZone          = "cloudemu:gcp:zone"
-	keyAccessConfigs = "cloudemu:gcp:accessconfigs"
-	keyServiceAccts  = "cloudemu:gcp:serviceaccounts"
+	keyDisks              = "cloudemu:gcp:disks"
+	keyNetTags            = "cloudemu:gcp:nettags"
+	keyMetadata           = "cloudemu:gcp:metadata"
+	keyNetwork            = "cloudemu:gcp:network"
+	keyZone               = "cloudemu:gcp:zone"
+	keyAccessConfigs      = "cloudemu:gcp:accessconfigs"
+	keyServiceAccts       = "cloudemu:gcp:serviceaccounts"
+	keyDeletionProtection = "cloudemu:gcp:deletionprotection"
 )
+
+// tagValueTrue is the tag-map encoding of a boolean-true internal flag
+// (currently just keyDeletionProtection).
+const tagValueTrue = "true"
 
 // internalTagPrefix marks tag keys that carry CloudEmu-internal GCP state
 // rather than user labels. gcpNameTag ("cloudemu:gcpName") also matches.

--- a/server/gcp/compute/instances.go
+++ b/server/gcp/compute/instances.go
@@ -308,7 +308,7 @@ func (h *Handler) getInstance(w http.ResponseWriter, r *http.Request, rp gcprest
 		return
 	}
 
-	gcprest.WriteJSON(w, http.StatusOK, toInstanceResponse(inst, rp.Project, hostFromRequest(r)))
+	gcprest.WriteJSON(w, http.StatusOK, h.toInstanceResponse(r.Context(), inst, rp.Project, hostFromRequest(r)))
 }
 
 // listInstances handles GET .../instances. Scopes to the requested zone and
@@ -332,7 +332,7 @@ func (h *Handler) listInstances(w http.ResponseWriter, r *http.Request, rp gcpre
 			continue
 		}
 
-		resp := toInstanceResponse(&instances[i], rp.Project, host)
+		resp := h.toInstanceResponse(r.Context(), &instances[i], rp.Project, host)
 		if pred(&resp) {
 			out = append(out, resp)
 		}
@@ -372,7 +372,7 @@ func (h *Handler) aggregatedListInstances(w http.ResponseWriter, r *http.Request
 	items := make(map[string]instancesScopedList)
 
 	for i := range instances {
-		resp := toInstanceResponse(&instances[i], rp.Project, host)
+		resp := h.toInstanceResponse(r.Context(), &instances[i], rp.Project, host)
 		if !pred(&resp) {
 			continue
 		}
@@ -398,6 +398,17 @@ func (h *Handler) deleteInstance(w http.ResponseWriter, r *http.Request, rp gcpr
 	inst, err := findInZone(r.Context(), h.compute, rp.ResourceName, rp.ScopeName)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	// Real GCP refuses to delete an instance with deletionProtection set,
+	// returning 400 until the caller clears it (setDeletionProtection or a
+	// fresh instances.update).
+	if deletionProtection(inst.Tags) {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid",
+			"The instance '"+rp.ResourceName+"' has deletionProtection field set to true,"+
+				" please set it to false before performing this operation.")
+
 		return
 	}
 
@@ -560,7 +571,17 @@ func insertTags(req *instanceRequest, zone string) map[string]string {
 		out[keyServiceAccts] = encodeJSON(req.ServiceAccounts)
 	}
 
+	if req.DeletionProtection {
+		out[keyDeletionProtection] = tagValueTrue
+	}
+
 	return out
+}
+
+// deletionProtection reports whether the instance was created (or later set,
+// via setDeletionProtection) with deletionProtection enabled.
+func deletionProtection(tags map[string]string) bool {
+	return tags[keyDeletionProtection] == tagValueTrue
 }
 
 // accessConfig field defaults GCP stamps on an external-IP mapping.
@@ -585,31 +606,45 @@ func accessConfigsFor(nics []networkInterface, instanceName string) []accessConf
 		out := make([]accessConfig, 0, len(nics[i].AccessConfigs))
 
 		for j := range nics[i].AccessConfigs {
-			ac := nics[i].AccessConfigs[j]
-
-			if ac.Type == "" {
-				ac.Type = accessConfigOneToOneNAT
-			}
-
-			if ac.Name == "" {
-				ac.Name = accessConfigDefaultName
-			}
-
-			if ac.NetworkTier == "" {
-				ac.NetworkTier = accessConfigNetworkTier
-			}
-
-			if ac.NatIP == "" {
-				ac.NatIP = ephemeralExternalIP(instanceName, j)
-			}
-
-			out = append(out, ac)
+			out = append(out, fillAccessConfigDefaults(&nics[i].AccessConfigs[j], instanceName, j))
 		}
 
 		return out
 	}
 
 	return nil
+}
+
+// fillAccessConfigDefaults stamps GCP's server-side defaults onto an
+// accessConfig the caller may have left partially filled: type, name, and
+// network tier default to GCP's standard external-IP values, and a missing
+// natIP is synthesized as an ephemeral external IP (mirroring GCP auto-
+// assigning one) seeded on instanceName+index so repeated reads are stable.
+// An explicit natIP — a reserved google_compute_address — is preserved so that
+// address reads back IN_USE while this instance holds it. Shared by
+// instances.insert (accessConfigsFor) and instances.addAccessConfig. Takes ac
+// by pointer only to avoid copying the (small but not tiny) struct; it never
+// mutates through the caller's copy, since the filled-in value is returned.
+func fillAccessConfigDefaults(ac *accessConfig, instanceName string, index int) accessConfig {
+	filled := *ac
+
+	if filled.Type == "" {
+		filled.Type = accessConfigOneToOneNAT
+	}
+
+	if filled.Name == "" {
+		filled.Name = accessConfigDefaultName
+	}
+
+	if filled.NetworkTier == "" {
+		filled.NetworkTier = accessConfigNetworkTier
+	}
+
+	if filled.NatIP == "" {
+		filled.NatIP = ephemeralExternalIP(instanceName, index)
+	}
+
+	return filled
 }
 
 // findInZone looks up an instance by GCP name, scoped to zone. An instance with

--- a/server/gcp/compute/types.go
+++ b/server/gcp/compute/types.go
@@ -7,14 +7,15 @@ package compute
 
 // instanceRequest is the inbound shape for POST .../instances (Insert).
 type instanceRequest struct {
-	Name              string             `json:"name"`
-	MachineType       string             `json:"machineType"`
-	Disks             []attachedDisk     `json:"disks,omitempty"`
-	NetworkInterfaces []networkInterface `json:"networkInterfaces,omitempty"`
-	Tags              tagsBlock          `json:"tags,omitempty"`
-	Labels            map[string]string  `json:"labels,omitempty"`
-	Metadata          metadataBlock      `json:"metadata,omitempty"`
-	ServiceAccounts   []serviceAccount   `json:"serviceAccounts,omitempty"`
+	Name               string             `json:"name"`
+	MachineType        string             `json:"machineType"`
+	Disks              []attachedDisk     `json:"disks,omitempty"`
+	NetworkInterfaces  []networkInterface `json:"networkInterfaces,omitempty"`
+	Tags               tagsBlock          `json:"tags,omitempty"`
+	Labels             map[string]string  `json:"labels,omitempty"`
+	Metadata           metadataBlock      `json:"metadata,omitempty"`
+	ServiceAccounts    []serviceAccount   `json:"serviceAccounts,omitempty"`
+	DeletionProtection bool               `json:"deletionProtection,omitempty"`
 }
 
 // metadataBlock is GCP's instance metadata. The boot script is carried as a

--- a/server/wire/gcprest/gcprest.go
+++ b/server/wire/gcprest/gcprest.go
@@ -229,19 +229,25 @@ func WriteError(w http.ResponseWriter, status int, reason, msg string) {
 }
 
 // WriteCErr maps a CloudEmu canonical error to the matching GCP HTTP status
-// and reason.
+// and reason. The wire message is cerrors.Message(err) — the error's
+// human-readable text without the canonical code prefix (e.g. "instance x not
+// found", not "NotFound: instance x not found") — matching every other cloud's
+// wire handlers, which never leak the internal error-taxonomy name into the
+// message an SDK surfaces to the caller.
 func WriteCErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		WriteError(w, http.StatusNotFound, "notFound", err.Error())
+		WriteError(w, http.StatusNotFound, "notFound", msg)
 	case cerrors.IsAlreadyExists(err):
-		WriteError(w, http.StatusConflict, "alreadyExists", err.Error())
+		WriteError(w, http.StatusConflict, "alreadyExists", msg)
 	case cerrors.IsInvalidArgument(err):
-		WriteError(w, http.StatusBadRequest, "invalid", err.Error())
+		WriteError(w, http.StatusBadRequest, "invalid", msg)
 	case cerrors.IsFailedPrecondition(err):
-		WriteError(w, http.StatusConflict, "conditionNotMet", err.Error())
+		WriteError(w, http.StatusConflict, "conditionNotMet", msg)
 	default:
-		WriteError(w, http.StatusInternalServerError, "internalError", err.Error())
+		WriteError(w, http.StatusInternalServerError, "internalError", msg)
 	}
 }
 

--- a/server/wire/gcprest/gcprest_test.go
+++ b/server/wire/gcprest/gcprest_test.go
@@ -137,6 +137,25 @@ func TestWriteCErrMapping(t *testing.T) {
 	}
 }
 
+// TestWriteCErrOmitsCodePrefix guards against the wire message leaking the
+// cloudemu internal error-taxonomy code prefix (cerrors.Error() renders
+// "NotFound: instance x not found") into the message an SDK surfaces to the
+// caller. Real GCP (and every other cloud's wire handlers here) only ever
+// sends the human-readable text.
+func TestWriteCErrOmitsCodePrefix(t *testing.T) {
+	rec := httptest.NewRecorder()
+	gcprest.WriteCErr(rec, cerrors.Newf(cerrors.NotFound, "instance %s not found", "vm-1"))
+
+	body := rec.Body.String()
+	if strings.Contains(body, "NotFound:") {
+		t.Errorf("body=%q leaks the internal error code prefix", body)
+	}
+
+	if !strings.Contains(body, "instance vm-1 not found") {
+		t.Errorf("body=%q missing the human-readable message", body)
+	}
+}
+
 func TestDecodeJSONInvalid(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{not json`))


### PR DESCRIPTION
## Summary

Real-user black-box e2e audit of GCP Compute Engine (GCE) via the real `cloud.google.com/go/compute/apiv1` SDK against a running `cloudemu serve`. GCE already had ~11 prior audit/fix rounds behind it, so this pass targeted the edges of the surface (post-creation mutation verbs, resize-then-reread staleness) rather than basic CRUD, which held up.

- `gcprest.WriteCErr` used `err.Error()` for the wire error message, which for a cloudemu-internal error renders `"NotFound: instance x not found"` — leaking the internal error-taxonomy code prefix into the JSON `error.message` an SDK surfaces to callers. Switched to `cerrors.Message(err)`, matching every other cloud's wire handlers in this repo. Fixed in the shared `gcprest` package, so it benefits every GCP compute-family error path, not just GCE.
- `instances.addAccessConfig`/`instances.deleteAccessConfig` (used by `gcloud compute instances add-access-config`/`delete-access-config` to attach/detach an external IP on a running instance) returned 501 not implemented; only insert-time `accessConfigs[]` was supported. Implemented both, reusing the same tag storage and default-filling logic as insert-time accessConfigs, so the existing reserved-address IN_USE/RESERVED linkage keeps working with no extra plumbing.
- `deletionProtection` was accepted on `instances.insert` but silently discarded (`instances.get` always read back `false`) and never enforced, so a "protected" instance deleted anyway. Now round-trips, blocks `instances.delete` with GCP's real 400 message, and a new `instances.setDeletionProtection` verb lets a caller clear it.
- `instances.get`'s `disks[].diskSizeGb` stayed at the insert-time value after a `disks.resize` on the same disk — the instance's disk view was a snapshot from attach time rather than live. Now resolved from the current `Disk` resource's size when one can be found (every wire-materialized disk has one).

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers/gcp/compute/... ./server/gcp/... ./server/wire/gcprest/... -race` — all pass, including the whole GCP surface (gcprest is shared)
- [x] `gofmt -l` clean, `golangci-lint run` — 0 issues on touched packages
- [x] `go generate ./... && git diff docs/coverage` — no diff (wire-layer only, no driver interface changes)
- [x] Each fix has a regression test (`TestWriteCErrOmitsCodePrefix`, `TestSDKAddDeleteAccessConfig`, `TestSDKDeletionProtection`, `TestSDKDiskResizeReflectedOnInstance`) and was independently re-verified black-box against a rebuilt `cloudemu serve` binary + the real SDK before and after the fix