### PR TITLE
fix(kms): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/kms/kms.go
+++ b/providers/aws/kms/kms.go
@@ -98,9 +98,18 @@ func New(opts *config.Options) *Mock {
 
 // newKeyID returns a UUID-shaped key identifier. It is derived from the shared
 // id counter, so it is unique and deterministic under a fake clock/reset.
-func newKeyID() string {
+// Multi-Region keys use real KMS's "mrk-" convention: the same UUID with its
+// dashes removed and an "mrk-" prefix, so callers that branch on the prefix
+// (a common real-world pattern for detecting multi-Region keys) see it.
+func newKeyID(multiRegion bool) string {
 	n := idgen.GenerateID("")
-	return fmt.Sprintf("%s-0000-4000-8000-%012s", n, n)
+	id := fmt.Sprintf("%s-0000-4000-8000-%012s", n, n)
+
+	if multiRegion {
+		return "mrk-" + strings.ReplaceAll(id, "-", "")
+	}
+
+	return id
 }
 
 func (m *Mock) keyARN(ctx context.Context, keyID string) string {

--- a/providers/aws/kms/lifecycle.go
+++ b/providers/aws/kms/lifecycle.go
@@ -40,7 +40,7 @@ func (m *Mock) CreateKey(ctx context.Context, in driver.CreateKeyInput) (*driver
 		origin = driver.OriginAWSKMS
 	}
 
-	id := newKeyID()
+	id := newKeyID(in.MultiRegion)
 	now := m.now()
 
 	kd := &keyData{

--- a/providers/aws/kms/management.go
+++ b/providers/aws/kms/management.go
@@ -165,8 +165,8 @@ func (m *Mock) EnableKeyRotation(_ context.Context, keyID string, rotationPeriod
 	}
 
 	return m.mutateKey(keyID, func(kd *keyData) error {
-		if kd.meta.KeySpec != driver.SpecSymmetricDefault {
-			return errors.New(errors.InvalidArgument, "only symmetric keys support rotation")
+		if kd.meta.KeySpec != driver.SpecSymmetricDefault || kd.meta.Origin == driver.OriginExternal {
+			return driver.ErrUnsupportedOperation
 		}
 
 		kd.rotationEnabled = true
@@ -230,12 +230,8 @@ func (m *Mock) ListKeyRotations(_ context.Context, keyID string) ([]driver.Rotat
 // RotateKeyOnDemand rotates the key material now and records the rotation.
 func (m *Mock) RotateKeyOnDemand(_ context.Context, keyID string) error {
 	return m.mutateKey(keyID, func(kd *keyData) error {
-		if kd.meta.KeySpec != driver.SpecSymmetricDefault {
-			return errors.New(errors.InvalidArgument, "only symmetric keys support on-demand rotation")
-		}
-
-		if kd.meta.Origin == driver.OriginExternal {
-			return errors.New(errors.InvalidArgument, "keys with imported material cannot be rotated")
+		if kd.meta.KeySpec != driver.SpecSymmetricDefault || kd.meta.Origin == driver.OriginExternal {
+			return driver.ErrUnsupportedOperation
 		}
 
 		mat, err := generateMaterial(kd.meta.KeySpec)

--- a/server/aws/kms/review_fixes_sdk_test.go
+++ b/server/aws/kms/review_fixes_sdk_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -148,5 +149,119 @@ func TestSDKDoubleScheduleDeletionRejected(t *testing.T) {
 	var invalidState *kmstypes.KMSInvalidStateException
 	if !errors.As(err, &invalidState) {
 		t.Fatalf("want KMSInvalidStateException, got %v", err)
+	}
+}
+
+// e2e audit: EnableKeyRotation on an asymmetric key must reject with
+// UnsupportedOperationException, matching real KMS — not a generic
+// ValidationException.
+func TestSDKEnableRotationOnAsymmetricKeyRejected(t *testing.T) {
+	ctx := context.Background()
+	c := newKMSClient(t)
+
+	key, err := c.CreateKey(ctx, &awskms.CreateKeyInput{
+		KeySpec: kmstypes.KeySpecRsa2048, KeyUsage: kmstypes.KeyUsageTypeSignVerify,
+	})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	_, err = c.EnableKeyRotation(ctx, &awskms.EnableKeyRotationInput{KeyId: key.KeyMetadata.KeyId})
+	if err == nil {
+		t.Fatal("EnableKeyRotation on an asymmetric key should fail")
+	}
+
+	var unsupported *kmstypes.UnsupportedOperationException
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("want UnsupportedOperationException, got %v", err)
+	}
+}
+
+// e2e audit: RotateKeyOnDemand on an asymmetric key must reject with
+// UnsupportedOperationException, matching real KMS.
+func TestSDKRotateOnDemandOnAsymmetricKeyRejected(t *testing.T) {
+	ctx := context.Background()
+	c := newKMSClient(t)
+
+	key, err := c.CreateKey(ctx, &awskms.CreateKeyInput{
+		KeySpec: kmstypes.KeySpecEccNistP256, KeyUsage: kmstypes.KeyUsageTypeSignVerify,
+	})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	_, err = c.RotateKeyOnDemand(ctx, &awskms.RotateKeyOnDemandInput{KeyId: key.KeyMetadata.KeyId})
+	if err == nil {
+		t.Fatal("RotateKeyOnDemand on an asymmetric key should fail")
+	}
+
+	var unsupported *kmstypes.UnsupportedOperationException
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("want UnsupportedOperationException, got %v", err)
+	}
+}
+
+// e2e audit: EnableKeyRotation on a key with imported key material (Origin
+// EXTERNAL) must also reject with UnsupportedOperationException.
+func TestSDKEnableRotationOnImportedKeyRejected(t *testing.T) {
+	ctx := context.Background()
+	c := newKMSClient(t)
+
+	key, err := c.CreateKey(ctx, &awskms.CreateKeyInput{Origin: kmstypes.OriginTypeExternal})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	_, err = c.EnableKeyRotation(ctx, &awskms.EnableKeyRotationInput{KeyId: key.KeyMetadata.KeyId})
+	if err == nil {
+		t.Fatal("EnableKeyRotation on an imported-material key should fail")
+	}
+
+	var unsupported *kmstypes.UnsupportedOperationException
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("want UnsupportedOperationException, got %v", err)
+	}
+}
+
+// e2e audit: real KMS key IDs (and ARNs) for multi-Region keys begin with the
+// "mrk-" prefix (the rest of the identifier is the UUID with dashes
+// removed) — callers commonly branch on this prefix to detect multi-Region
+// keys. See https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-id.
+func TestSDKMultiRegionKeyIDHasMRKPrefix(t *testing.T) {
+	ctx := context.Background()
+	c := newKMSClient(t)
+
+	key, err := c.CreateKey(ctx, &awskms.CreateKeyInput{MultiRegion: aws.Bool(true)})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	keyID := aws.ToString(key.KeyMetadata.KeyId)
+	if !strings.HasPrefix(keyID, "mrk-") {
+		t.Fatalf("multi-Region KeyId = %q, want mrk- prefix", keyID)
+	}
+
+	if arn := aws.ToString(key.KeyMetadata.Arn); !strings.Contains(arn, "key/mrk-") {
+		t.Fatalf("multi-Region key Arn = %q, want key/mrk- segment", arn)
+	}
+
+	// A single-Region key must NOT get the prefix.
+	single, err := c.CreateKey(ctx, &awskms.CreateKeyInput{})
+	if err != nil {
+		t.Fatalf("CreateKey (single-Region): %v", err)
+	}
+
+	if strings.HasPrefix(aws.ToString(single.KeyMetadata.KeyId), "mrk-") {
+		t.Fatalf("single-Region key unexpectedly has mrk- prefix: %q", aws.ToString(single.KeyMetadata.KeyId))
+	}
+
+	// DescribeKey by the mrk- KeyId must still resolve.
+	desc, err := c.DescribeKey(ctx, &awskms.DescribeKeyInput{KeyId: aws.String(keyID)})
+	if err != nil {
+		t.Fatalf("DescribeKey by mrk- id: %v", err)
+	}
+
+	if aws.ToString(desc.KeyMetadata.KeyId) != keyID {
+		t.Fatalf("DescribeKey KeyId = %q, want %q", aws.ToString(desc.KeyMetadata.KeyId), keyID)
 	}
 }


### PR DESCRIPTION
## Summary
- Deep real-user black-box e2e audit of AWS KMS (aws-cli, boto3, aws-sdk-go-v2, Terraform `aws_kms_key`/`aws_kms_alias`/`aws_kms_grant`) against `cloudemu serve -providers=aws`. Full key/alias/grant/crypto lifecycle, KeyState guards, Encrypt/Decrypt round-trip (incl. EncryptionContext), rotation, ScheduleKeyDeletion/CancelKeyDeletion, Sign/Verify, GenerateDataKey(Pair), ImportKeyMaterial, and Terraform apply/plan/destroy were exercised.
- Found and fixed 3 genuine divergences from real AWS KMS:
  1. `EnableKeyRotation` on an asymmetric/HMAC key (or a key with imported material) returned `ValidationException`; real KMS returns `UnsupportedOperationException` ([docs](https://docs.aws.amazon.com/kms/latest/APIReference/API_EnableKeyRotation.html)). Also now correctly rejects imported-key-material keys, which weren't rejected at all before.
  2. `RotateKeyOnDemand` had the same wrong-exception-type bug ([docs](https://docs.aws.amazon.com/kms/latest/APIReference/API_RotateKeyOnDemand.html)).
  3. Multi-Region key IDs/ARNs were plain UUIDs instead of using real KMS's `mrk-` prefix convention ([docs](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-id)), which application code commonly relies on to detect multi-Region keys.

## Test plan
- [x] `go build ./...`
- [x] `go test ./providers/aws/kms/... ./server/aws/kms/... ./providers/aws/kmscrypto/... -race` — pass, includes 4 new regression tests (one per fix, plus a paired asymmetric/imported-material case)
- [x] `go test ./...` (full suite) — pass, no regressions
- [x] `gofmt -l` and `golangci-lint run` on changed packages — clean
- [x] `go generate ./...` — `docs/coverage` unchanged (no driver-interface surface change)
- [x] Black-box re-verification of each fix against a rebuilt `cloudemu serve` binary via aws-cli:
  - `aws kms enable-key-rotation` on an RSA_2048 SIGN_VERIFY key now returns `UnsupportedOperationException` (was `ValidationException`)
  - `aws kms rotate-key-on-demand` on the same key now returns `UnsupportedOperationException`
  - `aws kms create-key --multi-region` now returns `KeyId`/`Arn` with the `mrk-` prefix (e.g. `mrk-00000010000040008000000000000010`); single-Region keys are unaffected
- [x] Terraform `aws_kms_key`/`aws_kms_alias`/`aws_kms_grant` apply → plan produced zero diff