### PR TITLE
feat(cloudwatch): metric stream lifecycle

### DIFF
--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -57,6 +57,7 @@ type Mock struct {
 	alarms          *memstore.Store[*alarmData]
 	compositeAlarms *memstore.Store[*compositeAlarmData]
 	dashboards      *memstore.Store[*storedDashboard]
+	metricStreams   *memstore.Store[*storedMetricStream]
 	channels        *memstore.Store[*driver.NotificationChannelInfo]
 	history         []driver.AlarmHistoryEntry
 	opts            *config.Options
@@ -103,6 +104,7 @@ func New(opts *config.Options) *Mock {
 		alarms:          memstore.New[*alarmData](),
 		compositeAlarms: memstore.New[*compositeAlarmData](),
 		dashboards:      memstore.New[*storedDashboard](),
+		metricStreams:   memstore.New[*storedMetricStream](),
 		channels:        memstore.New[*driver.NotificationChannelInfo](),
 		opts:            opts,
 	}

--- a/providers/aws/cloudwatch/metric_streams.go
+++ b/providers/aws/cloudwatch/metric_streams.go
@@ -1,0 +1,271 @@
+package cloudwatch
+
+// This file implements CloudWatch metric-stream operations (PutMetricStream,
+// GetMetricStream, ListMetricStreams, DeleteMetricStream, StartMetricStreams,
+// StopMetricStreams, and their tags), backing the aws_cloudwatch_metric_stream
+// Terraform resource. The store is an AWS-local optional capability so the
+// shared Monitoring interface — and the Azure/GCP providers — stay unchanged.
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// validMetricStreamOutputFormats is the closed OutputFormat enum documented by
+// PutMetricStream. A value outside this set is rejected, matching AWS, rather
+// than silently stored.
+//
+//nolint:gochecknoglobals // fixed lookup table for a closed enum.
+var validMetricStreamOutputFormats = map[string]bool{
+	"json":             true,
+	"opentelemetry1.0": true,
+	"opentelemetry0.7": true,
+}
+
+const (
+	metricStreamStateRunning = "running"
+	metricStreamStateStopped = "stopped"
+)
+
+// storedMetricStream is a persisted CloudWatch metric stream.
+type storedMetricStream struct {
+	Name                         string
+	ARN                          string
+	FirehoseARN                  string
+	RoleARN                      string
+	OutputFormat                 string
+	State                        string
+	IncludeFilters               []driver.MetricStreamFilter
+	ExcludeFilters               []driver.MetricStreamFilter
+	StatisticsConfigurations     []driver.MetricStreamStatisticsConfig
+	IncludeLinkedAccountsMetrics bool
+	Tags                         map[string]string
+	CreationDate                 time.Time
+	LastUpdateDate               time.Time
+}
+
+// PutMetricStream creates or updates a metric stream. Creating a new stream
+// starts it in the "running" state (real CloudWatch semantics); updating an
+// existing one leaves its State unchanged. Tags are applied only when the
+// stream is being created — an update's Tags are ignored, matching the real
+// PutMetricStream API (use TagResource/UntagResource to retag an existing
+// stream). It returns the stream's ARN.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) PutMetricStream(_ context.Context, cfg driver.MetricStreamConfig) (string, error) {
+	if err := validateMetricStreamConfig(&cfg); err != nil {
+		return "", err
+	}
+
+	arn := idgen.AWSARN("cloudwatch", m.opts.Region, m.opts.AccountID, "metric-stream/"+cfg.Name)
+	now := m.opts.Clock.Now()
+
+	state := metricStreamStateRunning
+	created := now
+	tags := copyDims(cfg.Tags)
+
+	if existing, ok := m.metricStreams.Get(cfg.Name); ok {
+		state = existing.State
+		created = existing.CreationDate
+		tags = existing.Tags
+	}
+
+	stream := &storedMetricStream{
+		Name:                         cfg.Name,
+		ARN:                          arn,
+		FirehoseARN:                  cfg.FirehoseARN,
+		RoleARN:                      cfg.RoleARN,
+		OutputFormat:                 cfg.OutputFormat,
+		State:                        state,
+		IncludeFilters:               append([]driver.MetricStreamFilter{}, cfg.IncludeFilters...),
+		ExcludeFilters:               append([]driver.MetricStreamFilter{}, cfg.ExcludeFilters...),
+		StatisticsConfigurations:     append([]driver.MetricStreamStatisticsConfig{}, cfg.StatisticsConfigurations...),
+		IncludeLinkedAccountsMetrics: cfg.IncludeLinkedAccountsMetrics,
+		Tags:                         tags,
+		CreationDate:                 created,
+		LastUpdateDate:               now,
+	}
+
+	m.metricStreams.Set(cfg.Name, stream)
+
+	return arn, nil
+}
+
+// validateMetricStreamConfig checks the required fields and closed enums that
+// real PutMetricStream validates server-side.
+func validateMetricStreamConfig(cfg *driver.MetricStreamConfig) error {
+	if cfg.Name == "" {
+		return errors.Newf(errors.InvalidArgument, "metric stream name is required")
+	}
+
+	if cfg.FirehoseARN == "" {
+		return errors.Newf(errors.InvalidArgument, "FirehoseArn is required")
+	}
+
+	if cfg.RoleARN == "" {
+		return errors.Newf(errors.InvalidArgument, "RoleArn is required")
+	}
+
+	if !validMetricStreamOutputFormats[cfg.OutputFormat] {
+		return errors.Newf(errors.InvalidArgument, "invalid OutputFormat %q", cfg.OutputFormat)
+	}
+
+	if len(cfg.IncludeFilters) > 0 && len(cfg.ExcludeFilters) > 0 {
+		return errors.Newf(errors.InvalidArgument, "cannot include IncludeFilters and ExcludeFilters in the same operation")
+	}
+
+	return nil
+}
+
+// GetMetricStream returns the named metric stream, or NotFound (the
+// CloudWatch ResourceNotFoundException) when it does not exist.
+func (m *Mock) GetMetricStream(_ context.Context, name string) (*driver.MetricStreamInfo, error) {
+	s, ok := m.metricStreams.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "metric stream %q not found", name)
+	}
+
+	return toMetricStreamInfo(s), nil
+}
+
+// ListMetricStreams returns every stored metric stream as a summary entry,
+// sorted by name.
+func (m *Mock) ListMetricStreams(_ context.Context) ([]driver.MetricStreamEntry, error) {
+	all := m.metricStreams.All()
+	out := make([]driver.MetricStreamEntry, 0, len(all))
+
+	for _, s := range all {
+		out = append(out, driver.MetricStreamEntry{
+			Name:           s.Name,
+			ARN:            s.ARN,
+			FirehoseARN:    s.FirehoseARN,
+			OutputFormat:   s.OutputFormat,
+			State:          s.State,
+			CreationDate:   s.CreationDate,
+			LastUpdateDate: s.LastUpdateDate,
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+
+	return out, nil
+}
+
+// DeleteMetricStream permanently deletes the named metric stream. Like real
+// CloudWatch (whose DeleteMetricStream documents no not-found error), deleting
+// an unknown name is a no-op rather than an error.
+func (m *Mock) DeleteMetricStream(_ context.Context, name string) error {
+	m.metricStreams.Delete(name)
+
+	return nil
+}
+
+// StartMetricStreams sets the named streams to the "running" state. Unknown
+// names are silently skipped, matching real StartMetricStreams (which
+// documents no not-found error).
+func (m *Mock) StartMetricStreams(ctx context.Context, names []string) error {
+	return m.setMetricStreamState(ctx, names, metricStreamStateRunning)
+}
+
+// StopMetricStreams sets the named streams to the "stopped" state. Unknown
+// names are silently skipped, matching real StopMetricStreams.
+func (m *Mock) StopMetricStreams(ctx context.Context, names []string) error {
+	return m.setMetricStreamState(ctx, names, metricStreamStateStopped)
+}
+
+func (m *Mock) setMetricStreamState(_ context.Context, names []string, state string) error {
+	now := m.opts.Clock.Now()
+
+	for _, name := range names {
+		m.metricStreams.Update(name, func(s *storedMetricStream) *storedMetricStream {
+			cp := *s
+			cp.State = state
+			cp.LastUpdateDate = now
+
+			return &cp
+		})
+	}
+
+	return nil
+}
+
+// AddMetricStreamTags merges tags onto the named metric stream, backing
+// TagResource for a metric-stream ARN.
+func (m *Mock) AddMetricStreamTags(_ context.Context, name string, tags map[string]string) error {
+	ok := m.metricStreams.Update(name, func(s *storedMetricStream) *storedMetricStream {
+		cp := *s
+		cp.Tags = make(map[string]string, len(s.Tags)+len(tags))
+
+		for k, v := range s.Tags {
+			cp.Tags[k] = v
+		}
+
+		for k, v := range tags {
+			cp.Tags[k] = v
+		}
+
+		return &cp
+	})
+	if !ok {
+		return errors.Newf(errors.NotFound, "metric stream %q not found", name)
+	}
+
+	return nil
+}
+
+// RemoveMetricStreamTags deletes the given tag keys from the named metric
+// stream, backing UntagResource for a metric-stream ARN.
+func (m *Mock) RemoveMetricStreamTags(_ context.Context, name string, keys []string) error {
+	ok := m.metricStreams.Update(name, func(s *storedMetricStream) *storedMetricStream {
+		cp := *s
+		cp.Tags = make(map[string]string, len(s.Tags))
+
+		for k, v := range s.Tags {
+			cp.Tags[k] = v
+		}
+
+		for _, k := range keys {
+			delete(cp.Tags, k)
+		}
+
+		return &cp
+	})
+	if !ok {
+		return errors.Newf(errors.NotFound, "metric stream %q not found", name)
+	}
+
+	return nil
+}
+
+// MetricStreamTags returns a copy of the named metric stream's tags, backing
+// ListTagsForResource for a metric-stream ARN.
+func (m *Mock) MetricStreamTags(_ context.Context, name string) (map[string]string, error) {
+	s, ok := m.metricStreams.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "metric stream %q not found", name)
+	}
+
+	return copyDims(s.Tags), nil
+}
+
+func toMetricStreamInfo(s *storedMetricStream) *driver.MetricStreamInfo {
+	return &driver.MetricStreamInfo{
+		Name:                         s.Name,
+		ARN:                          s.ARN,
+		FirehoseARN:                  s.FirehoseARN,
+		RoleARN:                      s.RoleARN,
+		OutputFormat:                 s.OutputFormat,
+		State:                        s.State,
+		IncludeFilters:               append([]driver.MetricStreamFilter{}, s.IncludeFilters...),
+		ExcludeFilters:               append([]driver.MetricStreamFilter{}, s.ExcludeFilters...),
+		StatisticsConfigurations:     append([]driver.MetricStreamStatisticsConfig{}, s.StatisticsConfigurations...),
+		IncludeLinkedAccountsMetrics: s.IncludeLinkedAccountsMetrics,
+		CreationDate:                 s.CreationDate,
+		LastUpdateDate:               s.LastUpdateDate,
+	}
+}

--- a/providers/aws/cloudwatch/metric_streams_test.go
+++ b/providers/aws/cloudwatch/metric_streams_test.go
@@ -1,0 +1,216 @@
+package cloudwatch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+func validStreamConfig(name string) driver.MetricStreamConfig {
+	return driver.MetricStreamConfig{
+		Name:         name,
+		FirehoseARN:  "arn:aws:firehose:us-east-1:123456789098:deliverystream/MyFirehose",
+		RoleARN:      "arn:aws:iam::123456789098:role/MyFirehoseWriteAccessRole",
+		OutputFormat: "json",
+		IncludeFilters: []driver.MetricStreamFilter{
+			{Namespace: "AWS/EC2"},
+		},
+	}
+}
+
+func TestPutGetMetricStream(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	t.Run("put valid then get", func(t *testing.T) {
+		arn, err := m.PutMetricStream(ctx, validStreamConfig("my-stream"))
+		requireNoError(t, err)
+		if arn == "" {
+			t.Fatal("expected a non-empty ARN")
+		}
+
+		s, err := m.GetMetricStream(ctx, "my-stream")
+		requireNoError(t, err)
+		assertEqual(t, "my-stream", s.Name)
+		assertEqual(t, arn, s.ARN)
+		assertEqual(t, "arn:aws:firehose:us-east-1:123456789098:deliverystream/MyFirehose", s.FirehoseARN)
+		assertEqual(t, "json", s.OutputFormat)
+		assertEqual(t, "running", s.State)
+		assertEqual(t, 1, len(s.IncludeFilters))
+		if s.CreationDate.IsZero() {
+			t.Fatal("expected a non-zero CreationDate")
+		}
+	})
+
+	t.Run("missing name is rejected", func(t *testing.T) {
+		cfg := validStreamConfig("")
+		_, err := m.PutMetricStream(ctx, cfg)
+		assertError(t, err, true)
+	})
+
+	t.Run("missing FirehoseArn is rejected", func(t *testing.T) {
+		cfg := validStreamConfig("no-firehose")
+		cfg.FirehoseARN = ""
+		_, err := m.PutMetricStream(ctx, cfg)
+		assertError(t, err, true)
+	})
+
+	t.Run("missing RoleArn is rejected", func(t *testing.T) {
+		cfg := validStreamConfig("no-role")
+		cfg.RoleARN = ""
+		_, err := m.PutMetricStream(ctx, cfg)
+		assertError(t, err, true)
+	})
+
+	t.Run("invalid OutputFormat is rejected", func(t *testing.T) {
+		cfg := validStreamConfig("bad-format")
+		cfg.OutputFormat = "csv"
+		_, err := m.PutMetricStream(ctx, cfg)
+		assertError(t, err, true)
+	})
+
+	t.Run("include and exclude filters together is rejected", func(t *testing.T) {
+		cfg := validStreamConfig("both-filters")
+		cfg.ExcludeFilters = []driver.MetricStreamFilter{{Namespace: "AWS/ELB"}}
+		_, err := m.PutMetricStream(ctx, cfg)
+		assertError(t, err, true)
+	})
+
+	t.Run("get unknown is not found", func(t *testing.T) {
+		_, err := m.GetMetricStream(ctx, "missing")
+		assertError(t, err, true)
+	})
+
+	t.Run("update preserves state and creation date", func(t *testing.T) {
+		_, err := m.PutMetricStream(ctx, validStreamConfig("persist"))
+		requireNoError(t, err)
+
+		requireNoError(t, m.StartMetricStreams(ctx, []string{"persist"}))
+		requireNoError(t, m.StopMetricStreams(ctx, []string{"persist"}))
+
+		before, err := m.GetMetricStream(ctx, "persist")
+		requireNoError(t, err)
+		assertEqual(t, "stopped", before.State)
+
+		cfg := validStreamConfig("persist")
+		cfg.OutputFormat = "opentelemetry1.0"
+		_, err = m.PutMetricStream(ctx, cfg)
+		requireNoError(t, err)
+
+		after, err := m.GetMetricStream(ctx, "persist")
+		requireNoError(t, err)
+		assertEqual(t, "stopped", after.State) // state survives an update
+		assertEqual(t, before.CreationDate, after.CreationDate)
+		assertEqual(t, "opentelemetry1.0", after.OutputFormat)
+	})
+}
+
+func TestListMetricStreams(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.PutMetricStream(ctx, validStreamConfig("b-stream"))
+	requireNoError(t, err)
+	_, err = m.PutMetricStream(ctx, validStreamConfig("a-stream"))
+	requireNoError(t, err)
+
+	entries, err := m.ListMetricStreams(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 2, len(entries))
+	assertEqual(t, "a-stream", entries[0].Name)
+	assertEqual(t, "b-stream", entries[1].Name)
+	if entries[0].ARN == "" {
+		t.Fatal("expected a non-empty ARN on the list entry")
+	}
+}
+
+func TestDeleteMetricStream(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.PutMetricStream(ctx, validStreamConfig("gone-soon"))
+	requireNoError(t, err)
+
+	requireNoError(t, m.DeleteMetricStream(ctx, "gone-soon"))
+
+	_, err = m.GetMetricStream(ctx, "gone-soon")
+	assertError(t, err, true)
+
+	t.Run("deleting an unknown name is a no-op, matching real CloudWatch", func(t *testing.T) {
+		requireNoError(t, m.DeleteMetricStream(ctx, "never-existed"))
+	})
+}
+
+func TestStartStopMetricStreams(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.PutMetricStream(ctx, validStreamConfig("toggle"))
+	requireNoError(t, err)
+
+	requireNoError(t, m.StopMetricStreams(ctx, []string{"toggle"}))
+	s, err := m.GetMetricStream(ctx, "toggle")
+	requireNoError(t, err)
+	assertEqual(t, "stopped", s.State)
+
+	requireNoError(t, m.StartMetricStreams(ctx, []string{"toggle"}))
+	s, err = m.GetMetricStream(ctx, "toggle")
+	requireNoError(t, err)
+	assertEqual(t, "running", s.State)
+
+	t.Run("unknown names are silently skipped", func(t *testing.T) {
+		requireNoError(t, m.StartMetricStreams(ctx, []string{"never-existed"}))
+		requireNoError(t, m.StopMetricStreams(ctx, []string{"never-existed"}))
+	})
+}
+
+func TestMetricStreamTags(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cfg := validStreamConfig("tagged")
+	cfg.Tags = map[string]string{"env": "prod"}
+	_, err := m.PutMetricStream(ctx, cfg)
+	requireNoError(t, err)
+
+	tags, err := m.MetricStreamTags(ctx, "tagged")
+	requireNoError(t, err)
+	assertEqual(t, "prod", tags["env"])
+
+	requireNoError(t, m.AddMetricStreamTags(ctx, "tagged", map[string]string{"team": "sre"}))
+	tags, err = m.MetricStreamTags(ctx, "tagged")
+	requireNoError(t, err)
+	assertEqual(t, "prod", tags["env"])
+	assertEqual(t, "sre", tags["team"])
+
+	requireNoError(t, m.RemoveMetricStreamTags(ctx, "tagged", []string{"env"}))
+	tags, err = m.MetricStreamTags(ctx, "tagged")
+	requireNoError(t, err)
+	if _, ok := tags["env"]; ok {
+		t.Fatal("expected env tag to be removed")
+	}
+	assertEqual(t, "sre", tags["team"])
+
+	t.Run("an update ignores Tags (real PutMetricStream semantics)", func(t *testing.T) {
+		again := validStreamConfig("tagged")
+		again.Tags = map[string]string{"ignored": "yes"}
+		_, err := m.PutMetricStream(ctx, again)
+		requireNoError(t, err)
+
+		tags, err := m.MetricStreamTags(ctx, "tagged")
+		requireNoError(t, err)
+		if _, ok := tags["ignored"]; ok {
+			t.Fatal("expected update Tags to be ignored")
+		}
+		assertEqual(t, "sre", tags["team"])
+	})
+
+	t.Run("tag operations on unknown stream are not found", func(t *testing.T) {
+		_, err := m.MetricStreamTags(ctx, "missing")
+		assertError(t, err, true)
+
+		assertError(t, m.AddMetricStreamTags(ctx, "missing", map[string]string{"a": "b"}), true)
+		assertError(t, m.RemoveMetricStreamTags(ctx, "missing", []string{"a"}), true)
+	})
+}

--- a/providers/aws/cloudwatch/snapshot.go
+++ b/providers/aws/cloudwatch/snapshot.go
@@ -13,17 +13,19 @@ import (
 var _ snapshot.Snapshottable = (*Mock)(nil)
 
 // cwSnapshot is the full serialized state of the CloudWatch mock. The alarm,
-// composite-alarm, dashboard, and notification-channel stores hold value types
-// whose fields are all exported, so they round-trip through the generic memstore
-// helper. The metric buffer is keyed by a struct (metricKey) — which json cannot
-// serialize as a map key — so it is promoted to a deterministically-ordered
-// slice. The alarm-history slice is captured in order. The mutex, the wired SNS
+// composite-alarm, dashboard, metric-stream, and notification-channel stores
+// hold value types whose fields are all exported, so they round-trip through
+// the generic memstore helper. The metric buffer is keyed by a struct
+// (metricKey) — which json cannot serialize as a map key — so it is promoted
+// to a deterministically-ordered slice. The alarm-history slice is captured
+// in order. The mutex, the wired SNS
 // action publisher, and *config.Options are intentionally not captured.
 type cwSnapshot struct {
 	Metrics         []metricEntrySnapshot      `json:"metrics,omitempty"`
 	Alarms          json.RawMessage            `json:"alarms,omitempty"`
 	CompositeAlarms json.RawMessage            `json:"compositeAlarms,omitempty"`
 	Dashboards      json.RawMessage            `json:"dashboards,omitempty"`
+	MetricStreams   json.RawMessage            `json:"metricStreams,omitempty"`
 	Channels        json.RawMessage            `json:"channels,omitempty"`
 	History         []driver.AlarmHistoryEntry `json:"history,omitempty"`
 }
@@ -92,6 +94,7 @@ func (m *Mock) snapshotStores(snap *cwSnapshot) error {
 		{&snap.Alarms, m.alarms.Snapshot},
 		{&snap.CompositeAlarms, m.compositeAlarms.Snapshot},
 		{&snap.Dashboards, m.dashboards.Snapshot},
+		{&snap.MetricStreams, m.metricStreams.Snapshot},
 		{&snap.Channels, m.channels.Snapshot},
 	}
 
@@ -138,6 +141,7 @@ func (m *Mock) restoreStores(snap *cwSnapshot) error {
 		{snap.Alarms, m.alarms.LoadSnapshot},
 		{snap.CompositeAlarms, m.compositeAlarms.LoadSnapshot},
 		{snap.Dashboards, m.dashboards.LoadSnapshot},
+		{snap.MetricStreams, m.metricStreams.LoadSnapshot},
 		{snap.Channels, m.channels.LoadSnapshot},
 	}
 

--- a/server/aws/cloudwatch/handler.go
+++ b/server/aws/cloudwatch/handler.go
@@ -47,6 +47,15 @@ const (
 	opGetDashboard        = "GetDashboard"
 	opListDashboards      = "ListDashboards"
 	opDeleteDashboards    = "DeleteDashboards"
+	opPutMetricStream     = "PutMetricStream"
+	opGetMetricStream     = "GetMetricStream"
+	opListMetricStreams   = "ListMetricStreams"
+	opDeleteMetricStream  = "DeleteMetricStream"
+	opStartMetricStreams  = "StartMetricStreams"
+	opStopMetricStreams   = "StopMetricStreams"
+	opTagResource         = "TagResource"
+	opUntagResource       = "UntagResource"
+	opListTagsForResource = "ListTagsForResource"
 )
 
 // Handler serves CloudWatch rpc-v2-cbor requests against a monitoring driver.
@@ -142,15 +151,27 @@ func (h *Handler) dispatch(w http.ResponseWriter, r *http.Request, op string, bo
 		h.listDashboards(w, r, body)
 	case opDeleteDashboards:
 		h.deleteDashboards(w, r, body)
+	case opPutMetricStream:
+		h.putMetricStream(w, r, body)
+	case opGetMetricStream:
+		h.getMetricStream(w, r, body)
+	case opListMetricStreams:
+		h.listMetricStreams(w, r, body)
+	case opDeleteMetricStream:
+		h.deleteMetricStream(w, r, body)
+	case opStartMetricStreams:
+		h.startMetricStreams(w, r, body)
+	case opStopMetricStreams:
+		h.stopMetricStreams(w, r, body)
 	case "EnableAlarmActions":
 		h.setAlarmActionsEnabled(w, r, body, true)
 	case "DisableAlarmActions":
 		h.setAlarmActionsEnabled(w, r, body, false)
-	case "TagResource":
+	case opTagResource:
 		h.tagResource(w, r, body)
-	case "UntagResource":
+	case opUntagResource:
 		h.untagResource(w, r, body)
-	case "ListTagsForResource":
+	case opListTagsForResource:
 		h.listTagsForResource(w, r, body)
 	default:
 		writeCBORError(w, http.StatusBadRequest,

--- a/server/aws/cloudwatch/metric_data_ops.go
+++ b/server/aws/cloudwatch/metric_data_ops.go
@@ -456,6 +456,23 @@ func (h *Handler) tagResource(w http.ResponseWriter, r *http.Request, body []byt
 		return
 	}
 
+	if name, ok := metricStreamNameFromARN(in.ResourceARN); ok {
+		tagger, ok := h.monitoring.(metricStreamTagger)
+		if !ok {
+			writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "tagging not supported")
+			return
+		}
+
+		if err := tagger.AddMetricStreamTags(r.Context(), name, tagsToMap(in.Tags)); err != nil {
+			writeDriverErr(w, err)
+			return
+		}
+
+		writeCBORResponse(w, struct{}{})
+
+		return
+	}
+
 	tagger, ok := h.monitoring.(alarmTagger)
 	if !ok {
 		writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "tagging not supported")
@@ -477,6 +494,23 @@ func (h *Handler) untagResource(w http.ResponseWriter, r *http.Request, body []b
 		return
 	}
 
+	if name, ok := metricStreamNameFromARN(in.ResourceARN); ok {
+		tagger, ok := h.monitoring.(metricStreamTagger)
+		if !ok {
+			writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "tagging not supported")
+			return
+		}
+
+		if err := tagger.RemoveMetricStreamTags(r.Context(), name, in.TagKeys); err != nil {
+			writeDriverErr(w, err)
+			return
+		}
+
+		writeCBORResponse(w, struct{}{})
+
+		return
+	}
+
 	tagger, ok := h.monitoring.(alarmTagger)
 	if !ok {
 		writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "tagging not supported")
@@ -495,6 +529,24 @@ func (h *Handler) listTagsForResource(w http.ResponseWriter, r *http.Request, bo
 	var in listTagsForResourceInput
 	if err := cbor.Unmarshal(body, &in); err != nil {
 		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	if name, ok := metricStreamNameFromARN(in.ResourceARN); ok {
+		tagger, ok := h.monitoring.(metricStreamTagger)
+		if !ok {
+			writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "tagging not supported")
+			return
+		}
+
+		tags, err := tagger.MetricStreamTags(r.Context(), name)
+		if err != nil {
+			writeDriverErr(w, err)
+			return
+		}
+
+		writeCBORResponse(w, listTagsForResourceOutput{Tags: mapToTags(tags)})
+
 		return
 	}
 

--- a/server/aws/cloudwatch/metric_streams.go
+++ b/server/aws/cloudwatch/metric_streams.go
@@ -1,0 +1,408 @@
+package cloudwatch
+
+// This file implements the CloudWatch metric-stream operations (PutMetricStream,
+// GetMetricStream, ListMetricStreams, DeleteMetricStream, StartMetricStreams,
+// StopMetricStreams) over the rpc-v2-cbor protocol, backing the
+// aws_cloudwatch_metric_stream Terraform resource. The store is an AWS-local
+// optional capability so the shared Monitoring interface — and the Azure/GCP
+// providers — stay unchanged.
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// metricStreamStore is the AWS-local capability behind the metric-stream
+// operations.
+type metricStreamStore interface {
+	PutMetricStream(ctx context.Context, cfg mondriver.MetricStreamConfig) (string, error)
+	GetMetricStream(ctx context.Context, name string) (*mondriver.MetricStreamInfo, error)
+	ListMetricStreams(ctx context.Context) ([]mondriver.MetricStreamEntry, error)
+	DeleteMetricStream(ctx context.Context, name string) error
+	StartMetricStreams(ctx context.Context, names []string) error
+	StopMetricStreams(ctx context.Context, names []string) error
+}
+
+// metricStreamTagger is the AWS-local capability behind the metric-stream tag
+// operations, routed to from TagResource/UntagResource/ListTagsForResource by
+// ARN shape (see metricStreamNameFromARN).
+type metricStreamTagger interface {
+	AddMetricStreamTags(ctx context.Context, name string, tags map[string]string) error
+	RemoveMetricStreamTags(ctx context.Context, name string, keys []string) error
+	MetricStreamTags(ctx context.Context, name string) (map[string]string, error)
+}
+
+// metricStreamFilterCBR mirrors the wire shape of a MetricStreamFilter.
+type metricStreamFilterCBR struct {
+	Namespace   string   `cbor:"Namespace,omitempty"`
+	MetricNames []string `cbor:"MetricNames,omitempty"`
+}
+
+type metricStreamStatisticsMetricCBR struct {
+	Namespace  string `cbor:"Namespace,omitempty"`
+	MetricName string `cbor:"MetricName,omitempty"`
+}
+
+type metricStreamStatisticsConfigCBR struct {
+	IncludeMetrics       []metricStreamStatisticsMetricCBR `cbor:"IncludeMetrics,omitempty"`
+	AdditionalStatistics []string                          `cbor:"AdditionalStatistics,omitempty"`
+}
+
+type putMetricStreamInput struct {
+	Name                         string                            `cbor:"Name"`
+	FirehoseArn                  string                            `cbor:"FirehoseArn"`
+	RoleArn                      string                            `cbor:"RoleArn"`
+	OutputFormat                 string                            `cbor:"OutputFormat"`
+	IncludeFilters               []metricStreamFilterCBR           `cbor:"IncludeFilters,omitempty"`
+	ExcludeFilters               []metricStreamFilterCBR           `cbor:"ExcludeFilters,omitempty"`
+	StatisticsConfigurations     []metricStreamStatisticsConfigCBR `cbor:"StatisticsConfigurations,omitempty"`
+	IncludeLinkedAccountsMetrics bool                              `cbor:"IncludeLinkedAccountsMetrics,omitempty"`
+	Tags                         []tagCBR                          `cbor:"Tags,omitempty"`
+}
+
+type putMetricStreamOutput struct {
+	Arn string `cbor:"Arn"`
+}
+
+func (h *Handler) putMetricStream(w http.ResponseWriter, r *http.Request, body []byte) {
+	store, ok := h.monitoring.(metricStreamStore)
+	if !ok {
+		writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "metric streams not supported")
+		return
+	}
+
+	var in putMetricStreamInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	arn, err := store.PutMetricStream(r.Context(), mondriver.MetricStreamConfig{
+		Name:                         in.Name,
+		FirehoseARN:                  in.FirehoseArn,
+		RoleARN:                      in.RoleArn,
+		OutputFormat:                 in.OutputFormat,
+		IncludeFilters:               fromMetricStreamFilterCBRs(in.IncludeFilters),
+		ExcludeFilters:               fromMetricStreamFilterCBRs(in.ExcludeFilters),
+		StatisticsConfigurations:     fromMetricStreamStatisticsConfigCBRs(in.StatisticsConfigurations),
+		IncludeLinkedAccountsMetrics: in.IncludeLinkedAccountsMetrics,
+		Tags:                         tagsToMap(in.Tags),
+	})
+	if err != nil {
+		writeMetricStreamDriverErr(w, err)
+		return
+	}
+
+	writeCBORResponse(w, putMetricStreamOutput{Arn: arn})
+}
+
+type getMetricStreamInput struct {
+	Name string `cbor:"Name"`
+}
+
+type getMetricStreamOutput struct {
+	Arn                          string                            `cbor:"Arn,omitempty"`
+	Name                         string                            `cbor:"Name,omitempty"`
+	FirehoseArn                  string                            `cbor:"FirehoseArn,omitempty"`
+	RoleArn                      string                            `cbor:"RoleArn,omitempty"`
+	OutputFormat                 string                            `cbor:"OutputFormat,omitempty"`
+	State                        string                            `cbor:"State,omitempty"`
+	IncludeFilters               []metricStreamFilterCBR           `cbor:"IncludeFilters,omitempty"`
+	ExcludeFilters               []metricStreamFilterCBR           `cbor:"ExcludeFilters,omitempty"`
+	StatisticsConfigurations     []metricStreamStatisticsConfigCBR `cbor:"StatisticsConfigurations,omitempty"`
+	IncludeLinkedAccountsMetrics bool                              `cbor:"IncludeLinkedAccountsMetrics,omitempty"`
+	CreationDate                 time.Time                         `cbor:"CreationDate,omitempty"`
+	LastUpdateDate               time.Time                         `cbor:"LastUpdateDate,omitempty"`
+}
+
+func (h *Handler) getMetricStream(w http.ResponseWriter, r *http.Request, body []byte) {
+	store, ok := h.monitoring.(metricStreamStore)
+	if !ok {
+		writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "metric streams not supported")
+		return
+	}
+
+	var in getMetricStreamInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	s, err := store.GetMetricStream(r.Context(), in.Name)
+	if err != nil {
+		writeMetricStreamDriverErr(w, err)
+		return
+	}
+
+	writeCBORResponse(w, getMetricStreamOutput{
+		Arn:                          s.ARN,
+		Name:                         s.Name,
+		FirehoseArn:                  s.FirehoseARN,
+		RoleArn:                      s.RoleARN,
+		OutputFormat:                 s.OutputFormat,
+		State:                        s.State,
+		IncludeFilters:               toMetricStreamFilterCBRs(s.IncludeFilters),
+		ExcludeFilters:               toMetricStreamFilterCBRs(s.ExcludeFilters),
+		StatisticsConfigurations:     toMetricStreamStatisticsConfigCBRs(s.StatisticsConfigurations),
+		IncludeLinkedAccountsMetrics: s.IncludeLinkedAccountsMetrics,
+		CreationDate:                 s.CreationDate.UTC(),
+		LastUpdateDate:               s.LastUpdateDate.UTC(),
+	})
+}
+
+type listMetricStreamsInput struct {
+	MaxResults int    `cbor:"MaxResults,omitempty"`
+	NextToken  string `cbor:"NextToken,omitempty"`
+}
+
+type metricStreamEntryCBR struct {
+	Arn            string    `cbor:"Arn,omitempty"`
+	Name           string    `cbor:"Name,omitempty"`
+	FirehoseArn    string    `cbor:"FirehoseArn,omitempty"`
+	OutputFormat   string    `cbor:"OutputFormat,omitempty"`
+	State          string    `cbor:"State,omitempty"`
+	CreationDate   time.Time `cbor:"CreationDate,omitempty"`
+	LastUpdateDate time.Time `cbor:"LastUpdateDate,omitempty"`
+}
+
+type listMetricStreamsOutput struct {
+	Entries   []metricStreamEntryCBR `cbor:"Entries"`
+	NextToken string                 `cbor:"NextToken,omitempty"`
+}
+
+// listMetricStreamsPageSize is the number of metric-stream entries returned
+// per page, matching real CloudWatch's documented MaxResults ceiling.
+const listMetricStreamsPageSize = 500
+
+func (h *Handler) listMetricStreams(w http.ResponseWriter, r *http.Request, body []byte) {
+	store, ok := h.monitoring.(metricStreamStore)
+	if !ok {
+		writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "metric streams not supported")
+		return
+	}
+
+	var in listMetricStreamsInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	entries, err := store.ListMetricStreams(r.Context())
+	if err != nil {
+		writeMetricStreamDriverErr(w, err)
+		return
+	}
+
+	size := listMetricStreamsPageSize
+	if in.MaxResults > 0 && in.MaxResults < size {
+		size = in.MaxResults
+	}
+
+	from, to, next := pageWindow(len(entries), decodeOffsetToken(in.NextToken), size)
+
+	rows := make([]metricStreamEntryCBR, 0, to-from)
+
+	for i := from; i < to; i++ {
+		e := &entries[i]
+		rows = append(rows, metricStreamEntryCBR{
+			Arn:            e.ARN,
+			Name:           e.Name,
+			FirehoseArn:    e.FirehoseARN,
+			OutputFormat:   e.OutputFormat,
+			State:          e.State,
+			CreationDate:   e.CreationDate.UTC(),
+			LastUpdateDate: e.LastUpdateDate.UTC(),
+		})
+	}
+
+	resp := listMetricStreamsOutput{Entries: rows}
+	if next > 0 {
+		resp.NextToken = encodeOffsetToken(next)
+	}
+
+	writeCBORResponse(w, resp)
+}
+
+type deleteMetricStreamInput struct {
+	Name string `cbor:"Name"`
+}
+
+// deleteMetricStream is structurally identical to deleteDashboards (unmarshal
+// a single-field input, call the matching AWS-local store method, write an
+// empty success response) — the two resources' delete semantics genuinely
+// share this shape, so the duplication is inherent rather than a missed
+// abstraction.
+//
+//nolint:dupl // structurally identical to deleteDashboards; see comment above.
+func (h *Handler) deleteMetricStream(w http.ResponseWriter, r *http.Request, body []byte) {
+	store, ok := h.monitoring.(metricStreamStore)
+	if !ok {
+		writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "metric streams not supported")
+		return
+	}
+
+	var in deleteMetricStreamInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	if err := store.DeleteMetricStream(r.Context(), in.Name); err != nil {
+		writeMetricStreamDriverErr(w, err)
+		return
+	}
+
+	writeCBORResponse(w, struct{}{})
+}
+
+type metricStreamNamesInput struct {
+	Names []string `cbor:"Names,omitempty"`
+}
+
+func (h *Handler) startMetricStreams(w http.ResponseWriter, r *http.Request, body []byte) {
+	h.setMetricStreamsRunning(w, r, body, true)
+}
+
+func (h *Handler) stopMetricStreams(w http.ResponseWriter, r *http.Request, body []byte) {
+	h.setMetricStreamsRunning(w, r, body, false)
+}
+
+func (h *Handler) setMetricStreamsRunning(w http.ResponseWriter, r *http.Request, body []byte, running bool) {
+	store, ok := h.monitoring.(metricStreamStore)
+	if !ok {
+		writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "metric streams not supported")
+		return
+	}
+
+	var in metricStreamNamesInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	var err error
+	if running {
+		err = store.StartMetricStreams(r.Context(), in.Names)
+	} else {
+		err = store.StopMetricStreams(r.Context(), in.Names)
+	}
+
+	if err != nil {
+		writeMetricStreamDriverErr(w, err)
+		return
+	}
+
+	writeCBORResponse(w, struct{}{})
+}
+
+// writeMetricStreamDriverErr maps a metric-stream driver error to the real
+// CloudWatch error shape names these operations document — ResourceNotFoundException
+// (GetMetricStream) and InvalidParameterValueException (PutMetricStream) —
+// which carry the "Exception" suffix that the shared writeDriverErr's shorter
+// names (used by the older alarm operations) drop. The exact name matters: an
+// SDK/Terraform delete-waiter matches on the deserialized error code, and a
+// mismatched name looks like an unexpected failure rather than a signal that
+// the resource is gone.
+func writeMetricStreamDriverErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeCBORError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeCBORError(w, http.StatusBadRequest, "InvalidParameterValueException", err.Error())
+	default:
+		writeDriverErr(w, err)
+	}
+}
+
+// metricStreamNameFromARN extracts a metric stream's name from an ARN of the
+// form arn:aws:cloudwatch:region:account:metric-stream/NAME. It reports false
+// for any ARN that doesn't carry that resource segment (including a bare
+// alarm name or an alarm ARN), so TagResource/UntagResource/ListTagsForResource
+// can fall back to alarm tag routing.
+func metricStreamNameFromARN(arn string) (string, bool) {
+	const marker = ":metric-stream/"
+
+	i := strings.Index(arn, marker)
+	if i < 0 {
+		return "", false
+	}
+
+	return arn[i+len(marker):], true
+}
+
+func fromMetricStreamFilterCBRs(in []metricStreamFilterCBR) []mondriver.MetricStreamFilter {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]mondriver.MetricStreamFilter, 0, len(in))
+	for _, f := range in {
+		out = append(out, mondriver.MetricStreamFilter{Namespace: f.Namespace, MetricNames: f.MetricNames})
+	}
+
+	return out
+}
+
+func toMetricStreamFilterCBRs(in []mondriver.MetricStreamFilter) []metricStreamFilterCBR {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]metricStreamFilterCBR, 0, len(in))
+	for _, f := range in {
+		out = append(out, metricStreamFilterCBR{Namespace: f.Namespace, MetricNames: f.MetricNames})
+	}
+
+	return out
+}
+
+func fromMetricStreamStatisticsConfigCBRs(in []metricStreamStatisticsConfigCBR) []mondriver.MetricStreamStatisticsConfig {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]mondriver.MetricStreamStatisticsConfig, 0, len(in))
+
+	for _, c := range in {
+		metrics := make([]mondriver.MetricStreamStatisticsMetric, 0, len(c.IncludeMetrics))
+		for _, mtr := range c.IncludeMetrics {
+			metrics = append(metrics, mondriver.MetricStreamStatisticsMetric{Namespace: mtr.Namespace, MetricName: mtr.MetricName})
+		}
+
+		out = append(out, mondriver.MetricStreamStatisticsConfig{
+			IncludeMetrics:       metrics,
+			AdditionalStatistics: c.AdditionalStatistics,
+		})
+	}
+
+	return out
+}
+
+func toMetricStreamStatisticsConfigCBRs(in []mondriver.MetricStreamStatisticsConfig) []metricStreamStatisticsConfigCBR {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]metricStreamStatisticsConfigCBR, 0, len(in))
+
+	for _, c := range in {
+		metrics := make([]metricStreamStatisticsMetricCBR, 0, len(c.IncludeMetrics))
+		for _, mtr := range c.IncludeMetrics {
+			metrics = append(metrics, metricStreamStatisticsMetricCBR{Namespace: mtr.Namespace, MetricName: mtr.MetricName})
+		}
+
+		out = append(out, metricStreamStatisticsConfigCBR{
+			IncludeMetrics:       metrics,
+			AdditionalStatistics: c.AdditionalStatistics,
+		})
+	}
+
+	return out
+}

--- a/server/aws/cloudwatch/metric_streams_test.go
+++ b/server/aws/cloudwatch/metric_streams_test.go
@@ -1,0 +1,199 @@
+package cloudwatch_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awscw "github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+)
+
+// TestSDKMetricStreamLifecycle drives the aws-sdk-go-v2 client through the
+// aws_cloudwatch_metric_stream flow: PutMetricStream, GetMetricStream,
+// ListMetricStreams, StopMetricStreams/StartMetricStreams, tagging via
+// TagResource/ListTagsForResource/UntagResource, and DeleteMetricStream.
+func TestSDKMetricStreamLifecycle(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	firehoseARN := "arn:aws:firehose:us-east-1:123456789098:deliverystream/MyFirehose"
+	roleARN := "arn:aws:iam::123456789098:role/MyFirehoseWriteAccessRole"
+
+	put, err := client.PutMetricStream(ctx, &awscw.PutMetricStreamInput{
+		Name:         aws.String("my-stream"),
+		FirehoseArn:  aws.String(firehoseARN),
+		RoleArn:      aws.String(roleARN),
+		OutputFormat: cwtypes.MetricStreamOutputFormatJson,
+		IncludeFilters: []cwtypes.MetricStreamFilter{
+			{Namespace: aws.String("AWS/EC2")},
+		},
+		Tags: []cwtypes.Tag{{Key: aws.String("env"), Value: aws.String("prod")}},
+	})
+	if err != nil {
+		t.Fatalf("PutMetricStream: %v", err)
+	}
+	if aws.ToString(put.Arn) == "" {
+		t.Fatal("PutMetricStream: empty Arn")
+	}
+
+	got, err := client.GetMetricStream(ctx, &awscw.GetMetricStreamInput{Name: aws.String("my-stream")})
+	if err != nil {
+		t.Fatalf("GetMetricStream: %v", err)
+	}
+	if aws.ToString(got.Name) != "my-stream" {
+		t.Fatalf("Name = %q, want my-stream", aws.ToString(got.Name))
+	}
+	if aws.ToString(got.FirehoseArn) != firehoseARN {
+		t.Fatalf("FirehoseArn = %q, want %q", aws.ToString(got.FirehoseArn), firehoseARN)
+	}
+	if aws.ToString(got.State) != "running" {
+		t.Fatalf("State = %q, want running (newly created streams start running)", aws.ToString(got.State))
+	}
+	if len(got.IncludeFilters) != 1 || aws.ToString(got.IncludeFilters[0].Namespace) != "AWS/EC2" {
+		t.Fatalf("IncludeFilters = %+v, want one AWS/EC2 filter", got.IncludeFilters)
+	}
+
+	// A second stream so ListMetricStreams has more than one entry.
+	if _, err := client.PutMetricStream(ctx, &awscw.PutMetricStreamInput{
+		Name:         aws.String("other-stream"),
+		FirehoseArn:  aws.String(firehoseARN),
+		RoleArn:      aws.String(roleARN),
+		OutputFormat: cwtypes.MetricStreamOutputFormatJson,
+	}); err != nil {
+		t.Fatalf("PutMetricStream other: %v", err)
+	}
+
+	list, err := client.ListMetricStreams(ctx, &awscw.ListMetricStreamsInput{})
+	if err != nil {
+		t.Fatalf("ListMetricStreams: %v", err)
+	}
+	if len(list.Entries) != 2 {
+		t.Fatalf("Entries = %d, want 2", len(list.Entries))
+	}
+
+	// Tag lifecycle: ListTagsForResource, TagResource, UntagResource.
+	tags, err := client.ListTagsForResource(ctx, &awscw.ListTagsForResourceInput{ResourceARN: put.Arn})
+	if err != nil {
+		t.Fatalf("ListTagsForResource: %v", err)
+	}
+	if len(tags.Tags) != 1 || aws.ToString(tags.Tags[0].Key) != "env" || aws.ToString(tags.Tags[0].Value) != "prod" {
+		t.Fatalf("Tags = %+v, want [env=prod]", tags.Tags)
+	}
+
+	if _, err := client.TagResource(ctx, &awscw.TagResourceInput{
+		ResourceARN: put.Arn,
+		Tags:        []cwtypes.Tag{{Key: aws.String("team"), Value: aws.String("sre")}},
+	}); err != nil {
+		t.Fatalf("TagResource: %v", err)
+	}
+
+	tags, err = client.ListTagsForResource(ctx, &awscw.ListTagsForResourceInput{ResourceARN: put.Arn})
+	if err != nil {
+		t.Fatalf("ListTagsForResource after tag: %v", err)
+	}
+	if len(tags.Tags) != 2 {
+		t.Fatalf("Tags after TagResource = %d, want 2", len(tags.Tags))
+	}
+
+	if _, err := client.UntagResource(ctx, &awscw.UntagResourceInput{
+		ResourceARN: put.Arn,
+		TagKeys:     []string{"env"},
+	}); err != nil {
+		t.Fatalf("UntagResource: %v", err)
+	}
+
+	tags, err = client.ListTagsForResource(ctx, &awscw.ListTagsForResourceInput{ResourceARN: put.Arn})
+	if err != nil {
+		t.Fatalf("ListTagsForResource after untag: %v", err)
+	}
+	if len(tags.Tags) != 1 || aws.ToString(tags.Tags[0].Key) != "team" {
+		t.Fatalf("Tags after UntagResource = %+v, want [team=sre]", tags.Tags)
+	}
+
+	// Stop then start.
+	if _, err := client.StopMetricStreams(ctx, &awscw.StopMetricStreamsInput{
+		Names: []string{"my-stream"},
+	}); err != nil {
+		t.Fatalf("StopMetricStreams: %v", err)
+	}
+
+	got, err = client.GetMetricStream(ctx, &awscw.GetMetricStreamInput{Name: aws.String("my-stream")})
+	if err != nil {
+		t.Fatalf("GetMetricStream after stop: %v", err)
+	}
+	if aws.ToString(got.State) != "stopped" {
+		t.Fatalf("State after stop = %q, want stopped", aws.ToString(got.State))
+	}
+
+	if _, err := client.StartMetricStreams(ctx, &awscw.StartMetricStreamsInput{
+		Names: []string{"my-stream"},
+	}); err != nil {
+		t.Fatalf("StartMetricStreams: %v", err)
+	}
+
+	got, err = client.GetMetricStream(ctx, &awscw.GetMetricStreamInput{Name: aws.String("my-stream")})
+	if err != nil {
+		t.Fatalf("GetMetricStream after start: %v", err)
+	}
+	if aws.ToString(got.State) != "running" {
+		t.Fatalf("State after start = %q, want running", aws.ToString(got.State))
+	}
+
+	// Delete then confirm.
+	if _, err := client.DeleteMetricStream(ctx, &awscw.DeleteMetricStreamInput{
+		Name: aws.String("my-stream"),
+	}); err != nil {
+		t.Fatalf("DeleteMetricStream: %v", err)
+	}
+
+	if _, err := client.GetMetricStream(ctx, &awscw.GetMetricStreamInput{Name: aws.String("my-stream")}); err == nil {
+		t.Fatal("GetMetricStream after delete: expected error, got nil")
+	}
+}
+
+// TestSDKPutMetricStreamValidation confirms server-side validation of the
+// closed OutputFormat enum and the mutually-exclusive IncludeFilters /
+// ExcludeFilters combination, matching real PutMetricStream.
+func TestSDKPutMetricStreamValidation(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	firehoseARN := "arn:aws:firehose:us-east-1:123456789098:deliverystream/MyFirehose"
+	roleARN := "arn:aws:iam::123456789098:role/MyFirehoseWriteAccessRole"
+
+	t.Run("invalid OutputFormat is rejected", func(t *testing.T) {
+		_, err := client.PutMetricStream(ctx, &awscw.PutMetricStreamInput{
+			Name:         aws.String("bad-format"),
+			FirehoseArn:  aws.String(firehoseARN),
+			RoleArn:      aws.String(roleARN),
+			OutputFormat: cwtypes.MetricStreamOutputFormat("csv"),
+		})
+		if err == nil {
+			t.Fatal("expected error for invalid OutputFormat, got nil")
+		}
+	})
+
+	t.Run("include and exclude filters together is rejected", func(t *testing.T) {
+		_, err := client.PutMetricStream(ctx, &awscw.PutMetricStreamInput{
+			Name:           aws.String("both-filters"),
+			FirehoseArn:    aws.String(firehoseARN),
+			RoleArn:        aws.String(roleARN),
+			OutputFormat:   cwtypes.MetricStreamOutputFormatJson,
+			IncludeFilters: []cwtypes.MetricStreamFilter{{Namespace: aws.String("AWS/EC2")}},
+			ExcludeFilters: []cwtypes.MetricStreamFilter{{Namespace: aws.String("AWS/ELB")}},
+		})
+		if err == nil {
+			t.Fatal("expected error for IncludeFilters+ExcludeFilters, got nil")
+		}
+	})
+}
+
+// TestSDKGetMetricStreamNotFound confirms an unknown metric stream is a
+// client error.
+func TestSDKGetMetricStreamNotFound(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	if _, err := client.GetMetricStream(ctx, &awscw.GetMetricStreamInput{
+		Name: aws.String("missing"),
+	}); err == nil {
+		t.Fatal("GetMetricStream for unknown name: expected error, got nil")
+	}
+}

--- a/server/aws/cloudwatch/query.go
+++ b/server/aws/cloudwatch/query.go
@@ -63,6 +63,24 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request) {
 		h.queryDeleteAlarms(w, r)
 	case opSetAlarmState:
 		h.querySetAlarmState(w, r)
+	case opPutMetricStream:
+		h.queryPutMetricStream(w, r)
+	case opGetMetricStream:
+		h.queryGetMetricStream(w, r)
+	case opListMetricStreams:
+		h.queryListMetricStreams(w, r)
+	case opDeleteMetricStream:
+		h.queryDeleteMetricStream(w, r)
+	case opStartMetricStreams:
+		h.queryStartMetricStreams(w, r)
+	case opStopMetricStreams:
+		h.queryStopMetricStreams(w, r)
+	case opTagResource:
+		h.queryTagResource(w, r)
+	case opUntagResource:
+		h.queryUntagResource(w, r)
+	case opListTagsForResource:
+		h.queryListTagsForResource(w, r)
 	default:
 		writeQueryError(w, http.StatusBadRequest, "InvalidAction", "unsupported CloudWatch action: "+r.Form.Get("Action"))
 	}

--- a/server/aws/cloudwatch/query_metric_streams.go
+++ b/server/aws/cloudwatch/query_metric_streams.go
@@ -1,0 +1,508 @@
+package cloudwatch
+
+// This file adds the classic AWS query-protocol path (form-encoded POST,
+// Action=..., XML responses) for the CloudWatch metric-stream operations and
+// their tags, so `aws cloudwatch ...` and Terraform's aws_cloudwatch_metric_stream
+// resource — both of which still speak query protocol for CloudWatch, unlike
+// the modern rpc-v2-cbor path used by current aws-sdk-go-v2 — work against the
+// emulator. See query.go for the shared query-protocol plumbing.
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+// writeMetricStreamQueryDriverErr is the query-protocol counterpart of
+// writeMetricStreamDriverErr (see metric_streams.go): it maps a metric-stream
+// driver error to CloudWatch's real ResourceNotFoundException /
+// InvalidParameterValueException error codes rather than the shorter names
+// the shared writeQueryDriverErr uses for the older alarm operations.
+func writeMetricStreamQueryDriverErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeQueryError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeQueryError(w, http.StatusBadRequest, "InvalidParameterValueException", err.Error())
+	default:
+		writeQueryDriverErr(w, err)
+	}
+}
+
+func (h *Handler) queryPutMetricStream(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.monitoring.(metricStreamStore)
+	if !ok {
+		writeQueryError(w, http.StatusBadRequest, "InvalidAction", "metric streams not supported")
+		return
+	}
+
+	arn, err := store.PutMetricStream(r.Context(), mondriver.MetricStreamConfig{
+		Name:                         r.Form.Get("Name"),
+		FirehoseARN:                  r.Form.Get("FirehoseArn"),
+		RoleARN:                      r.Form.Get("RoleArn"),
+		OutputFormat:                 r.Form.Get("OutputFormat"),
+		IncludeFilters:               queryMetricStreamFilters(r, "IncludeFilters.member."),
+		ExcludeFilters:               queryMetricStreamFilters(r, "ExcludeFilters.member."),
+		StatisticsConfigurations:     queryMetricStreamStatisticsConfigs(r, "StatisticsConfigurations.member."),
+		IncludeLinkedAccountsMetrics: r.Form.Get("IncludeLinkedAccountsMetrics") == "true",
+		Tags:                         queryTagPairs(r, "Tags.member."),
+	})
+	if err != nil {
+		writeMetricStreamQueryDriverErr(w, err)
+		return
+	}
+
+	writeQueryResponse(w, "PutMetricStreamResponse", putMetricStreamResultXML{Arn: arn})
+}
+
+func (h *Handler) queryGetMetricStream(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.monitoring.(metricStreamStore)
+	if !ok {
+		writeQueryError(w, http.StatusBadRequest, "InvalidAction", "metric streams not supported")
+		return
+	}
+
+	s, err := store.GetMetricStream(r.Context(), r.Form.Get("Name"))
+	if err != nil {
+		writeMetricStreamQueryDriverErr(w, err)
+		return
+	}
+
+	writeQueryResponse(w, "GetMetricStreamResponse", getMetricStreamResultXML{
+		Arn:                          s.ARN,
+		Name:                         s.Name,
+		FirehoseArn:                  s.FirehoseARN,
+		RoleArn:                      s.RoleARN,
+		OutputFormat:                 s.OutputFormat,
+		State:                        s.State,
+		IncludeFilters:               toMetricStreamFilterMembers(s.IncludeFilters),
+		ExcludeFilters:               toMetricStreamFilterMembers(s.ExcludeFilters),
+		StatisticsConfigurations:     toMetricStreamStatisticsConfigMembers(s.StatisticsConfigurations),
+		IncludeLinkedAccountsMetrics: s.IncludeLinkedAccountsMetrics,
+		CreationDate:                 s.CreationDate.UTC().Format(time.RFC3339),
+		LastUpdateDate:               s.LastUpdateDate.UTC().Format(time.RFC3339),
+	})
+}
+
+func (h *Handler) queryListMetricStreams(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.monitoring.(metricStreamStore)
+	if !ok {
+		writeQueryError(w, http.StatusBadRequest, "InvalidAction", "metric streams not supported")
+		return
+	}
+
+	entries, err := store.ListMetricStreams(r.Context())
+	if err != nil {
+		writeMetricStreamQueryDriverErr(w, err)
+		return
+	}
+
+	size := listMetricStreamsPageSize
+	if v, _ := strconv.Atoi(r.Form.Get("MaxResults")); v > 0 && v < size {
+		size = v
+	}
+
+	from, to, next := pageWindow(len(entries), decodeOffsetToken(r.Form.Get("NextToken")), size)
+
+	members := make([]metricStreamEntryXML, 0, to-from)
+
+	for i := from; i < to; i++ {
+		e := &entries[i]
+		members = append(members, metricStreamEntryXML{
+			Arn:            e.ARN,
+			Name:           e.Name,
+			FirehoseArn:    e.FirehoseARN,
+			OutputFormat:   e.OutputFormat,
+			State:          e.State,
+			CreationDate:   e.CreationDate.UTC().Format(time.RFC3339),
+			LastUpdateDate: e.LastUpdateDate.UTC().Format(time.RFC3339),
+		})
+	}
+
+	result := listMetricStreamsResultXML{Entries: members}
+	if next > 0 {
+		result.NextToken = encodeOffsetToken(next)
+	}
+
+	writeQueryResponse(w, "ListMetricStreamsResponse", result)
+}
+
+func (h *Handler) queryDeleteMetricStream(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.monitoring.(metricStreamStore)
+	if !ok {
+		writeQueryError(w, http.StatusBadRequest, "InvalidAction", "metric streams not supported")
+		return
+	}
+
+	if err := store.DeleteMetricStream(r.Context(), r.Form.Get("Name")); err != nil {
+		writeMetricStreamQueryDriverErr(w, err)
+		return
+	}
+
+	writeQueryResponse(w, "DeleteMetricStreamResponse", emptyQueryResult("DeleteMetricStreamResult"))
+}
+
+func (h *Handler) queryStartMetricStreams(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.monitoring.(metricStreamStore)
+	if !ok {
+		writeQueryError(w, http.StatusBadRequest, "InvalidAction", "metric streams not supported")
+		return
+	}
+
+	if err := store.StartMetricStreams(r.Context(), queryStringList(r, "Names.member.")); err != nil {
+		writeMetricStreamQueryDriverErr(w, err)
+		return
+	}
+
+	writeQueryResponse(w, "StartMetricStreamsResponse", emptyQueryResult("StartMetricStreamsResult"))
+}
+
+func (h *Handler) queryStopMetricStreams(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.monitoring.(metricStreamStore)
+	if !ok {
+		writeQueryError(w, http.StatusBadRequest, "InvalidAction", "metric streams not supported")
+		return
+	}
+
+	if err := store.StopMetricStreams(r.Context(), queryStringList(r, "Names.member.")); err != nil {
+		writeMetricStreamQueryDriverErr(w, err)
+		return
+	}
+
+	writeQueryResponse(w, "StopMetricStreamsResponse", emptyQueryResult("StopMetricStreamsResult"))
+}
+
+// errTaggingUnsupported signals that the monitoring backend behind h doesn't
+// implement the tag capability a routed-to ARN needs (alarmTagger or
+// metricStreamTagger).
+var errTaggingUnsupported = errors.New("tagging not supported")
+
+// queryTagResource, queryUntagResource, and queryListTagsForResource route to
+// the metric-stream tagger when ResourceARN names a metric stream, and to the
+// alarm tagger otherwise — mirroring the rpc-v2-cbor tagResource/untagResource/
+// listTagsForResource dispatch in metric_data_ops.go. Each delegates to a
+// small ARN-routing helper so the two resource kinds' near-identical bodies
+// aren't duplicated per operation.
+func (h *Handler) queryTagResource(w http.ResponseWriter, r *http.Request) {
+	arn := r.Form.Get("ResourceARN")
+
+	if err := h.addResourceTagsByARN(r.Context(), arn, queryTagPairs(r, "Tags.member.")); err != nil {
+		writeTagRouteQueryErr(w, arn, err)
+		return
+	}
+
+	writeQueryResponse(w, "TagResourceResponse", emptyQueryResult("TagResourceResult"))
+}
+
+func (h *Handler) queryUntagResource(w http.ResponseWriter, r *http.Request) {
+	arn := r.Form.Get("ResourceARN")
+
+	if err := h.removeResourceTagsByARN(r.Context(), arn, queryStringList(r, "TagKeys.member.")); err != nil {
+		writeTagRouteQueryErr(w, arn, err)
+		return
+	}
+
+	writeQueryResponse(w, "UntagResourceResponse", emptyQueryResult("UntagResourceResult"))
+}
+
+func (h *Handler) queryListTagsForResource(w http.ResponseWriter, r *http.Request) {
+	arn := r.Form.Get("ResourceARN")
+
+	tags, err := h.resourceTagsByARN(r.Context(), arn)
+	if err != nil {
+		writeTagRouteQueryErr(w, arn, err)
+		return
+	}
+
+	writeQueryResponse(w, "ListTagsForResourceResponse", listTagsForResourceResultXML{Tags: toTagMemberXMLs(tags)})
+}
+
+// addResourceTagsByARN, removeResourceTagsByARN, and resourceTagsByARN route
+// arn to the metric-stream tagger when it names a metric stream, and to the
+// alarm tagger otherwise (including a bare alarm name, for backward
+// compatibility). They return errTaggingUnsupported when the monitoring
+// backend doesn't implement the needed capability.
+func (h *Handler) addResourceTagsByARN(ctx context.Context, arn string, tags map[string]string) error {
+	if name, ok := metricStreamNameFromARN(arn); ok {
+		tagger, ok := h.monitoring.(metricStreamTagger)
+		if !ok {
+			return errTaggingUnsupported
+		}
+
+		return tagger.AddMetricStreamTags(ctx, name, tags)
+	}
+
+	tagger, ok := h.monitoring.(alarmTagger)
+	if !ok {
+		return errTaggingUnsupported
+	}
+
+	return tagger.AddAlarmTags(ctx, alarmNameFromARN(arn), tags)
+}
+
+func (h *Handler) removeResourceTagsByARN(ctx context.Context, arn string, keys []string) error {
+	if name, ok := metricStreamNameFromARN(arn); ok {
+		tagger, ok := h.monitoring.(metricStreamTagger)
+		if !ok {
+			return errTaggingUnsupported
+		}
+
+		return tagger.RemoveMetricStreamTags(ctx, name, keys)
+	}
+
+	tagger, ok := h.monitoring.(alarmTagger)
+	if !ok {
+		return errTaggingUnsupported
+	}
+
+	return tagger.RemoveAlarmTags(ctx, alarmNameFromARN(arn), keys)
+}
+
+func (h *Handler) resourceTagsByARN(ctx context.Context, arn string) (map[string]string, error) {
+	if name, ok := metricStreamNameFromARN(arn); ok {
+		tagger, ok := h.monitoring.(metricStreamTagger)
+		if !ok {
+			return nil, errTaggingUnsupported
+		}
+
+		return tagger.MetricStreamTags(ctx, name)
+	}
+
+	tagger, ok := h.monitoring.(alarmTagger)
+	if !ok {
+		return nil, errTaggingUnsupported
+	}
+
+	return tagger.AlarmTags(ctx, alarmNameFromARN(arn))
+}
+
+// writeTagRouteQueryErr writes the query-protocol response for a tag-routing
+// error: an unsupported-capability error becomes InvalidAction, and any other
+// error is mapped by the metric-stream or alarm driver-error mapper depending
+// on which resource kind arn routed to.
+func writeTagRouteQueryErr(w http.ResponseWriter, arn string, err error) {
+	if errors.Is(err, errTaggingUnsupported) {
+		writeQueryError(w, http.StatusBadRequest, "InvalidAction", err.Error())
+		return
+	}
+
+	if _, ok := metricStreamNameFromARN(arn); ok {
+		writeMetricStreamQueryDriverErr(w, err)
+		return
+	}
+
+	writeQueryDriverErr(w, err)
+}
+
+// ---- form parsing helpers ----
+
+// queryMetricStreamFilters parses a MetricStreamFilter list (Namespace +
+// nested MetricNames) at the given "Xxx.member." prefix.
+func queryMetricStreamFilters(r *http.Request, prefix string) []mondriver.MetricStreamFilter {
+	var out []mondriver.MetricStreamFilter
+
+	for i := 1; ; i++ {
+		p := prefix + strconv.Itoa(i) + "."
+
+		ns := r.Form.Get(p + "Namespace")
+		names := queryStringList(r, p+"MetricNames.member.")
+
+		if ns == "" && len(names) == 0 {
+			break
+		}
+
+		out = append(out, mondriver.MetricStreamFilter{Namespace: ns, MetricNames: names})
+	}
+
+	return out
+}
+
+// queryMetricStreamStatisticsConfigs parses a MetricStreamStatisticsConfiguration
+// list at the given "Xxx.member." prefix.
+func queryMetricStreamStatisticsConfigs(r *http.Request, prefix string) []mondriver.MetricStreamStatisticsConfig {
+	var out []mondriver.MetricStreamStatisticsConfig
+
+	for i := 1; ; i++ {
+		p := prefix + strconv.Itoa(i) + "."
+
+		additional := queryStringList(r, p+"AdditionalStatistics.member.")
+
+		var metrics []mondriver.MetricStreamStatisticsMetric
+
+		for j := 1; ; j++ {
+			mp := p + "IncludeMetrics.member." + strconv.Itoa(j) + "."
+
+			ns := r.Form.Get(mp + "Namespace")
+			name := r.Form.Get(mp + "MetricName")
+
+			if ns == "" && name == "" {
+				break
+			}
+
+			metrics = append(metrics, mondriver.MetricStreamStatisticsMetric{Namespace: ns, MetricName: name})
+		}
+
+		if len(metrics) == 0 && len(additional) == 0 {
+			break
+		}
+
+		out = append(out, mondriver.MetricStreamStatisticsConfig{IncludeMetrics: metrics, AdditionalStatistics: additional})
+	}
+
+	return out
+}
+
+// queryTagPairs parses a Tag{Key,Value} list at the given "Xxx.member." prefix.
+func queryTagPairs(r *http.Request, prefix string) map[string]string {
+	var out map[string]string
+
+	for i := 1; ; i++ {
+		p := prefix + strconv.Itoa(i) + "."
+
+		key := r.Form.Get(p + "Key")
+		if key == "" {
+			break
+		}
+
+		if out == nil {
+			out = map[string]string{}
+		}
+
+		out[key] = r.Form.Get(p + "Value")
+	}
+
+	return out
+}
+
+func toTagMemberXMLs(tags map[string]string) []tagMemberXML {
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	out := make([]tagMemberXML, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, tagMemberXML{Key: k, Value: tags[k]})
+	}
+
+	return out
+}
+
+// ---- XML request/response shapes (query protocol, 2010-08-01) ----
+
+// emptyQueryResult renders a nameless <XxxResult/> element for an operation
+// whose response carries no fields. The query-protocol deserializer still
+// requires that element to be present — e.g. DeleteMetricStream fails to
+// deserialize a response with no DeleteMetricStreamResult node at all — even
+// though the operation returns no data.
+func emptyQueryResult(name string) any {
+	return struct {
+		XMLName xml.Name
+	}{XMLName: xml.Name{Local: name}}
+}
+
+type putMetricStreamResultXML struct {
+	XMLName xml.Name `xml:"PutMetricStreamResult"`
+	Arn     string   `xml:"Arn"`
+}
+
+type metricStreamFilterMemberXML struct {
+	Namespace   string   `xml:"Namespace,omitempty"`
+	MetricNames []string `xml:"MetricNames>member,omitempty"`
+}
+
+type metricStreamStatisticsMetricMemberXML struct {
+	Namespace  string `xml:"Namespace,omitempty"`
+	MetricName string `xml:"MetricName,omitempty"`
+}
+
+type metricStreamStatisticsConfigMemberXML struct {
+	IncludeMetrics       []metricStreamStatisticsMetricMemberXML `xml:"IncludeMetrics>member,omitempty"`
+	AdditionalStatistics []string                                `xml:"AdditionalStatistics>member,omitempty"`
+}
+
+type getMetricStreamResultXML struct {
+	XMLName                      xml.Name                                `xml:"GetMetricStreamResult"`
+	Arn                          string                                  `xml:"Arn,omitempty"`
+	Name                         string                                  `xml:"Name,omitempty"`
+	FirehoseArn                  string                                  `xml:"FirehoseArn,omitempty"`
+	RoleArn                      string                                  `xml:"RoleArn,omitempty"`
+	OutputFormat                 string                                  `xml:"OutputFormat,omitempty"`
+	State                        string                                  `xml:"State,omitempty"`
+	IncludeFilters               []metricStreamFilterMemberXML           `xml:"IncludeFilters>member,omitempty"`
+	ExcludeFilters               []metricStreamFilterMemberXML           `xml:"ExcludeFilters>member,omitempty"`
+	StatisticsConfigurations     []metricStreamStatisticsConfigMemberXML `xml:"StatisticsConfigurations>member,omitempty"`
+	IncludeLinkedAccountsMetrics bool                                    `xml:"IncludeLinkedAccountsMetrics,omitempty"`
+	CreationDate                 string                                  `xml:"CreationDate,omitempty"`
+	LastUpdateDate               string                                  `xml:"LastUpdateDate,omitempty"`
+}
+
+type metricStreamEntryXML struct {
+	Arn            string `xml:"Arn,omitempty"`
+	Name           string `xml:"Name,omitempty"`
+	FirehoseArn    string `xml:"FirehoseArn,omitempty"`
+	OutputFormat   string `xml:"OutputFormat,omitempty"`
+	State          string `xml:"State,omitempty"`
+	CreationDate   string `xml:"CreationDate,omitempty"`
+	LastUpdateDate string `xml:"LastUpdateDate,omitempty"`
+}
+
+type listMetricStreamsResultXML struct {
+	XMLName   xml.Name               `xml:"ListMetricStreamsResult"`
+	Entries   []metricStreamEntryXML `xml:"Entries>member"`
+	NextToken string                 `xml:"NextToken,omitempty"`
+}
+
+type tagMemberXML struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
+}
+
+type listTagsForResourceResultXML struct {
+	XMLName xml.Name       `xml:"ListTagsForResourceResult"`
+	Tags    []tagMemberXML `xml:"Tags>member"`
+}
+
+func toMetricStreamFilterMembers(in []mondriver.MetricStreamFilter) []metricStreamFilterMemberXML {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]metricStreamFilterMemberXML, 0, len(in))
+	for _, f := range in {
+		out = append(out, metricStreamFilterMemberXML{Namespace: f.Namespace, MetricNames: f.MetricNames})
+	}
+
+	return out
+}
+
+func toMetricStreamStatisticsConfigMembers(in []mondriver.MetricStreamStatisticsConfig) []metricStreamStatisticsConfigMemberXML {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make([]metricStreamStatisticsConfigMemberXML, 0, len(in))
+
+	for _, c := range in {
+		metrics := make([]metricStreamStatisticsMetricMemberXML, 0, len(c.IncludeMetrics))
+		for _, mtr := range c.IncludeMetrics {
+			metrics = append(metrics, metricStreamStatisticsMetricMemberXML{Namespace: mtr.Namespace, MetricName: mtr.MetricName})
+		}
+
+		out = append(out, metricStreamStatisticsConfigMemberXML{
+			IncludeMetrics:       metrics,
+			AdditionalStatistics: c.AdditionalStatistics,
+		})
+	}
+
+	return out
+}

--- a/server/aws/cloudwatch/query_metric_streams_test.go
+++ b/server/aws/cloudwatch/query_metric_streams_test.go
@@ -1,0 +1,252 @@
+package cloudwatch_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cwprovider "github.com/stackshy/cloudemu/v2/providers/aws/cloudwatch"
+	cwserver "github.com/stackshy/cloudemu/v2/server/aws/cloudwatch"
+)
+
+var arnResultPattern = regexp.MustCompile(`<Arn>([^<]+)</Arn>`)
+
+// TestQueryMetricStreamLifecycle drives the classic AWS query protocol
+// (form-encoded POST, Action=..., XML response) — what aws-cli and
+// terraform-provider-aws actually speak for CloudWatch — through the full
+// metric-stream lifecycle: PutMetricStream, GetMetricStream, ListMetricStreams,
+// Stop/StartMetricStreams, Tag/ListTags/UntagResource, and DeleteMetricStream.
+//
+// It specifically guards the PR's two query-protocol wire fixes:
+//  1. empty-result operations (Delete/Start/Stop/Tag/Untag) must emit an
+//     explicit <XxxResult/> element (via emptyQueryResult) so botocore /
+//     aws-sdk-go can deserialize the response instead of erroring on a missing
+//     result node.
+//  2. GetMetricStream on an unknown name must return ResourceNotFoundException
+//     (not the shorter ResourceNotFound the older alarm operations use), which
+//     is what terraform's delete-waiter matches on to treat the resource as gone.
+func TestQueryMetricStreamLifecycle(t *testing.T) {
+	h := cwserver.New(cwprovider.New(config.NewOptions()))
+	ts := httptest.NewServer(h)
+
+	t.Cleanup(ts.Close)
+
+	post := func(form url.Values) (int, string) {
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Authorization", monitoringAuth)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		defer resp.Body.Close()
+
+		b, _ := io.ReadAll(resp.Body)
+
+		return resp.StatusCode, string(b)
+	}
+
+	firehoseARN := "arn:aws:firehose:us-east-1:123456789098:deliverystream/MyFirehose"
+	roleARN := "arn:aws:iam::123456789098:role/MyFirehoseWriteAccessRole"
+
+	// PutMetricStream → 200 + PutMetricStreamResponse carrying an Arn.
+	code, body := post(url.Values{
+		"Action":                            {"PutMetricStream"},
+		"Name":                              {"my-stream"},
+		"FirehoseArn":                       {firehoseARN},
+		"RoleArn":                           {roleARN},
+		"OutputFormat":                      {"json"},
+		"IncludeFilters.member.1.Namespace": {"AWS/EC2"},
+		"IncludeFilters.member.1.MetricNames.member.1": {"CPUUtilization"},
+		"Tags.member.1.Key":                            {"env"},
+		"Tags.member.1.Value":                          {"prod"},
+	})
+	if code != http.StatusOK || !strings.Contains(body, "PutMetricStreamResponse") {
+		t.Fatalf("PutMetricStream: code=%d body=%s", code, body)
+	}
+
+	m := arnResultPattern.FindStringSubmatch(body)
+	if len(m) != 2 || m[1] == "" {
+		t.Fatalf("PutMetricStream: no Arn in response: %s", body)
+	}
+
+	streamARN := m[1]
+
+	// GetMetricStream → correct XML shape, State=running for a newly-created stream.
+	code, body = post(url.Values{"Action": {"GetMetricStream"}, "Name": {"my-stream"}})
+	if code != http.StatusOK {
+		t.Fatalf("GetMetricStream: code=%d body=%s", code, body)
+	}
+
+	for _, want := range []string{
+		"<Name>my-stream</Name>",
+		"<FirehoseArn>" + firehoseARN + "</FirehoseArn>",
+		"<RoleArn>" + roleARN + "</RoleArn>",
+		"<State>running</State>",
+		"<Namespace>AWS/EC2</Namespace>",
+		"<GetMetricStreamResult>",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("GetMetricStream body missing %q: %s", want, body)
+		}
+	}
+
+	// A second stream so ListMetricStreams has more than one entry.
+	if code, body := post(url.Values{
+		"Action":       {"PutMetricStream"},
+		"Name":         {"other-stream"},
+		"FirehoseArn":  {firehoseARN},
+		"RoleArn":      {roleARN},
+		"OutputFormat": {"json"},
+	}); code != http.StatusOK {
+		t.Fatalf("PutMetricStream other: code=%d body=%s", code, body)
+	}
+
+	code, body = post(url.Values{"Action": {"ListMetricStreams"}})
+	if code != http.StatusOK || !strings.Contains(body, "ListMetricStreamsResult") {
+		t.Fatalf("ListMetricStreams: code=%d body=%s", code, body)
+	}
+	if strings.Count(body, "<member>") != 2 {
+		t.Fatalf("ListMetricStreams: want 2 entries, body=%s", body)
+	}
+	if !strings.Contains(body, "<Name>my-stream</Name>") || !strings.Contains(body, "<Name>other-stream</Name>") {
+		t.Fatalf("ListMetricStreams: missing an entry, body=%s", body)
+	}
+
+	// StopMetricStreams — the empty-result response must deserialize: assert
+	// the explicit <StopMetricStreamsResult> element (wire fix #1), not just a
+	// bare ResponseMetadata envelope.
+	code, body = post(url.Values{"Action": {"StopMetricStreams"}, "Names.member.1": {"my-stream"}})
+	if code != http.StatusOK {
+		t.Fatalf("StopMetricStreams: code=%d body=%s", code, body)
+	}
+	if !strings.Contains(body, "<StopMetricStreamsResult></StopMetricStreamsResult>") {
+		t.Fatalf("StopMetricStreams: missing explicit empty result element (emptyQueryResult regression), body=%s", body)
+	}
+
+	code, body = post(url.Values{"Action": {"GetMetricStream"}, "Name": {"my-stream"}})
+	if code != http.StatusOK || !strings.Contains(body, "<State>stopped</State>") {
+		t.Fatalf("GetMetricStream after stop: code=%d body=%s", code, body)
+	}
+
+	// StartMetricStreams — same empty-result assertion.
+	code, body = post(url.Values{"Action": {"StartMetricStreams"}, "Names.member.1": {"my-stream"}})
+	if code != http.StatusOK {
+		t.Fatalf("StartMetricStreams: code=%d body=%s", code, body)
+	}
+	if !strings.Contains(body, "<StartMetricStreamsResult></StartMetricStreamsResult>") {
+		t.Fatalf("StartMetricStreams: missing explicit empty result element (emptyQueryResult regression), body=%s", body)
+	}
+
+	code, body = post(url.Values{"Action": {"GetMetricStream"}, "Name": {"my-stream"}})
+	if code != http.StatusOK || !strings.Contains(body, "<State>running</State>") {
+		t.Fatalf("GetMetricStream after start: code=%d body=%s", code, body)
+	}
+
+	// TagResource / ListTagsForResource / UntagResource on the metric-stream ARN.
+	code, body = post(url.Values{
+		"Action":              {"TagResource"},
+		"ResourceARN":         {streamARN},
+		"Tags.member.1.Key":   {"team"},
+		"Tags.member.1.Value": {"sre"},
+	})
+	if code != http.StatusOK {
+		t.Fatalf("TagResource: code=%d body=%s", code, body)
+	}
+	if !strings.Contains(body, "<TagResourceResult></TagResourceResult>") {
+		t.Fatalf("TagResource: missing explicit empty result element, body=%s", body)
+	}
+
+	code, body = post(url.Values{"Action": {"ListTagsForResource"}, "ResourceARN": {streamARN}})
+	if code != http.StatusOK || !strings.Contains(body, "ListTagsForResourceResult") {
+		t.Fatalf("ListTagsForResource: code=%d body=%s", code, body)
+	}
+	if !strings.Contains(body, "<Key>env</Key>") || !strings.Contains(body, "<Key>team</Key>") {
+		t.Fatalf("ListTagsForResource: want env and team tags, body=%s", body)
+	}
+
+	code, body = post(url.Values{"Action": {"UntagResource"}, "ResourceARN": {streamARN}, "TagKeys.member.1": {"env"}})
+	if code != http.StatusOK {
+		t.Fatalf("UntagResource: code=%d body=%s", code, body)
+	}
+	if !strings.Contains(body, "<UntagResourceResult></UntagResourceResult>") {
+		t.Fatalf("UntagResource: missing explicit empty result element, body=%s", body)
+	}
+
+	code, body = post(url.Values{"Action": {"ListTagsForResource"}, "ResourceARN": {streamARN}})
+	if code != http.StatusOK || strings.Contains(body, "<Key>env</Key>") || !strings.Contains(body, "<Key>team</Key>") {
+		t.Fatalf("ListTagsForResource after untag: want only team tag, body=%s", body)
+	}
+
+	// DeleteMetricStream — empty-result assertion again.
+	code, body = post(url.Values{"Action": {"DeleteMetricStream"}, "Name": {"my-stream"}})
+	if code != http.StatusOK {
+		t.Fatalf("DeleteMetricStream: code=%d body=%s", code, body)
+	}
+	if !strings.Contains(body, "<DeleteMetricStreamResult></DeleteMetricStreamResult>") {
+		t.Fatalf("DeleteMetricStream: missing explicit empty result element (emptyQueryResult regression), body=%s", body)
+	}
+
+	// GetMetricStream on the now-deleted name — the exact wire fix: the error
+	// code must be the full "ResourceNotFoundException", not the shorter
+	// "ResourceNotFound" the older alarm operations return.
+	code, body = post(url.Values{"Action": {"GetMetricStream"}, "Name": {"my-stream"}})
+	if code != http.StatusNotFound {
+		t.Fatalf("GetMetricStream after delete: code=%d, want 404, body=%s", code, body)
+	}
+	if !strings.Contains(body, "<Code>ResourceNotFoundException</Code>") {
+		t.Fatalf("GetMetricStream after delete: want <Code>ResourceNotFoundException</Code>, body=%s", body)
+	}
+	if strings.Contains(body, "<Code>ResourceNotFound</Code>") {
+		t.Fatalf("GetMetricStream after delete: got the shorter ResourceNotFound code, body=%s", body)
+	}
+}
+
+// TestQueryPutMetricStreamValidation confirms the query-protocol path rejects
+// IncludeFilters and ExcludeFilters supplied together with the real
+// InvalidParameterValueException error name (not the shorter
+// InvalidParameterValue the older alarm operations return).
+func TestQueryPutMetricStreamValidation(t *testing.T) {
+	h := cwserver.New(cwprovider.New(config.NewOptions()))
+	ts := httptest.NewServer(h)
+
+	t.Cleanup(ts.Close)
+
+	post := func(form url.Values) (int, string) {
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Authorization", monitoringAuth)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		defer resp.Body.Close()
+
+		b, _ := io.ReadAll(resp.Body)
+
+		return resp.StatusCode, string(b)
+	}
+
+	code, body := post(url.Values{
+		"Action":                            {"PutMetricStream"},
+		"Name":                              {"both-filters"},
+		"FirehoseArn":                       {"arn:aws:firehose:us-east-1:123456789098:deliverystream/MyFirehose"},
+		"RoleArn":                           {"arn:aws:iam::123456789098:role/MyFirehoseWriteAccessRole"},
+		"OutputFormat":                      {"json"},
+		"IncludeFilters.member.1.Namespace": {"AWS/EC2"},
+		"ExcludeFilters.member.1.Namespace": {"AWS/ELB"},
+	})
+	if code != http.StatusBadRequest {
+		t.Fatalf("PutMetricStream with both filters: code=%d, want 400, body=%s", code, body)
+	}
+	if !strings.Contains(body, "<Code>InvalidParameterValueException</Code>") {
+		t.Fatalf("PutMetricStream with both filters: want <Code>InvalidParameterValueException</Code>, body=%s", body)
+	}
+}

--- a/services/monitoring/driver/metricstream.go
+++ b/services/monitoring/driver/metricstream.go
@@ -1,0 +1,71 @@
+package driver
+
+import "time"
+
+// MetricStreamFilter names a metric namespace to include in, or exclude from,
+// a metric stream, optionally narrowed to specific metric names within it. An
+// empty MetricNames means "every metric in Namespace".
+type MetricStreamFilter struct {
+	Namespace   string
+	MetricNames []string
+}
+
+// MetricStreamStatisticsMetric identifies one metric (by namespace + name) that
+// an entry in MetricStreamConfig.StatisticsConfigurations applies to.
+type MetricStreamStatisticsMetric struct {
+	Namespace  string
+	MetricName string
+}
+
+// MetricStreamStatisticsConfig requests extra statistics — beyond the stream's
+// always-sent MAX/MIN/SUM/SAMPLECOUNT — for a set of metrics.
+type MetricStreamStatisticsConfig struct {
+	IncludeMetrics       []MetricStreamStatisticsMetric
+	AdditionalStatistics []string
+}
+
+// MetricStreamConfig describes a metric stream to create or update.
+// IncludeFilters and ExcludeFilters are mutually exclusive: at most one may be
+// set, matching the real PutMetricStream validation. Tags apply only when
+// creating a new stream; PutMetricStream ignores Tags on an update (use
+// TagResource/UntagResource for an existing stream, matching real CloudWatch).
+type MetricStreamConfig struct {
+	Name                         string
+	FirehoseARN                  string
+	RoleARN                      string
+	OutputFormat                 string // "json", "opentelemetry1.0", "opentelemetry0.7"
+	IncludeFilters               []MetricStreamFilter
+	ExcludeFilters               []MetricStreamFilter
+	StatisticsConfigurations     []MetricStreamStatisticsConfig
+	IncludeLinkedAccountsMetrics bool
+	Tags                         map[string]string
+}
+
+// MetricStreamInfo describes a stored metric stream, as returned by
+// GetMetricStream.
+type MetricStreamInfo struct {
+	Name                         string
+	ARN                          string
+	FirehoseARN                  string
+	RoleARN                      string
+	OutputFormat                 string
+	State                        string // "running" or "stopped"
+	IncludeFilters               []MetricStreamFilter
+	ExcludeFilters               []MetricStreamFilter
+	StatisticsConfigurations     []MetricStreamStatisticsConfig
+	IncludeLinkedAccountsMetrics bool
+	CreationDate                 time.Time
+	LastUpdateDate               time.Time
+}
+
+// MetricStreamEntry is a ListMetricStreams summary row — a metric stream's
+// identity and state, without its filters or statistics configuration.
+type MetricStreamEntry struct {
+	Name           string
+	ARN            string
+	FirehoseARN    string
+	OutputFormat   string
+	State          string
+	CreationDate   time.Time
+	LastUpdateDate time.Time
+}


### PR DESCRIPTION
## Summary

CloudWatch had alarms, composite alarms, and dashboards, but no metric-stream support — a real, current AWS CloudWatch API family (PutMetricStream/GetMetricStream/ListMetricStreams/DeleteMetricStream/StartMetricStreams/StopMetricStreams) backing the real `aws_cloudwatch_metric_stream` Terraform resource. This closes that gap.

- New AWS-local optional capability (`metricStreamStore`/`metricStreamTagger`) in `providers/aws/cloudwatch` and `server/aws/cloudwatch`, following the same pattern as the existing dashboards/composite-alarms features — the shared `services/monitoring/driver.Monitoring` interface (and Azure/GCP) is untouched.
- Full CRUD + start/stop lifecycle: create-or-update (tags applied only on create, matching real semantics), get, list, delete (idempotent on missing name, matching real CloudWatch), start/stop streaming state.
- Tags: `TagResource`/`UntagResource`/`ListTagsForResource` now route by ARN shape to either the alarm tagger or the new metric-stream tagger, on both the modern rpc-v2-cbor wire path and the classic AWS query protocol (used by aws-cli and Terraform's bundled SDK).
- Added the classic query-protocol path for the whole metric-stream + tag surface, since Terraform's vendored SDK and current aws-cli still speak query protocol for CloudWatch (only the very latest aws-sdk-go-v2 uses rpc-v2-cbor). Along the way, fixed two protocol-fidelity bugs the terraform/aws-cli verification surfaced: an empty-result operation (e.g. `DeleteMetricStream`) needs an explicit `<XxxResult/>` element or the SDK deserializer fails, and `GetMetricStream`'s not-found error must be `ResourceNotFoundException` (not the shorter `ResourceNotFound` the alarm operations use) or a Terraform delete-waiter treats it as an unexpected failure instead of "resource is gone."
- Snapshot/restore support added so metric-stream state survives a server restart, matching the other CloudWatch stores.

## Real-user verification

Ran `cloudemu serve -aws-port 14736 -providers=aws` and drove it as a real user via both Terraform and the AWS CLI.

**Terraform** (`aws_cloudwatch_metric_stream`, with `include_filter` and `tags`):
- `terraform apply` — creates cleanly, `Arn`/`State`/`creation_date` populated.
- `terraform plan -detailed-exitcode` — exit code 0, "No changes" (including tags — no perpetual diff).
- `terraform destroy` — destroys cleanly.

**AWS CLI**, full lifecycle against the same server: `put-metric-stream` → `get-metric-stream` → `list-metric-streams` → `stop-metric-streams` (State: stopped) → `start-metric-streams` (State: running) → `tag-resource` / `list-tags-for-resource` → `delete-metric-stream` → `get-metric-stream` correctly returns `ResourceNotFoundException`.

Also re-verified `aws_cloudwatch_metric_alarm` tagging (`tag-resource`/`list-tags-for-resource` via query protocol) still works after the tag-routing refactor — no regression.

## Tests

- `providers/aws/cloudwatch`: full lifecycle (create/get/list/delete/start/stop/tags), validation (missing required fields, invalid `OutputFormat`, mutually-exclusive `IncludeFilters`/`ExcludeFilters`), update semantics (state/creation-date preserved, Tags ignored on update).
- `server/aws/cloudwatch`: SDK-level (aws-sdk-go-v2) lifecycle test covering Put/Get/List/Stop/Start/Tag/Untag/Delete over the real wire protocol, plus validation and not-found tests.
- `go build ./...`, `go test ./providers/aws/cloudwatch/... ./server/aws/cloudwatch/... ./services/monitoring/... ./persist/... -race`, and the broader `./providers/aws/... ./server/aws/...` suite all pass.
- `golangci-lint run --new-from-rev=origin/development` clean on all touched packages.
- `go generate ./...` and `go mod tidy` are no-ops (metric streams are an AWS-local capability, same as dashboards/composite alarms, so they don't appear in the generated `docs/coverage`).