### PR TITLE
fix(azure-keyvault): real-user e2e divergences

### DIFF
--- a/server/azure/keyvault/vault_arm_handler.go
+++ b/server/azure/keyvault/vault_arm_handler.go
@@ -13,6 +13,7 @@
 //
 //	PUT    .../providers/Microsoft.KeyVault/vaults/{name}   — Vaults.BeginCreateOrUpdate (LRO, completes inline)
 //	GET    .../providers/Microsoft.KeyVault/vaults/{name}   — Vaults.Get
+//	PATCH  .../providers/Microsoft.KeyVault/vaults/{name}   — Vaults.Update (partial merge, not a full replace)
 //	DELETE .../providers/Microsoft.KeyVault/vaults/{name}   — Vaults.Delete
 //	GET    .../resourceGroups/{rg}/providers/Microsoft.KeyVault/vaults — Vaults.ListByResourceGroup
 //	GET    .../subscriptions/{sub}/providers/Microsoft.KeyVault/vaults  — Vaults.ListBySubscription
@@ -75,6 +76,8 @@ func (h *VaultARMHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.getVault(w, r, &rp)
 	case http.MethodDelete:
 		h.deleteVault(w, r, &rp)
+	case http.MethodPatch:
+		h.updateVault(w, r, &rp)
 	default:
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}

--- a/server/azure/keyvault/vault_arm_handler_test.go
+++ b/server/azure/keyvault/vault_arm_handler_test.go
@@ -212,6 +212,133 @@ func TestVaultARMScopeMismatch(t *testing.T) {
 	}
 }
 
+// TestVaultARMUpdatePartialMerge exercises PATCH — Vaults.Update. Unlike PUT,
+// a PATCH carrying only one property must merge onto the stored vault rather
+// than replacing it: every other property (tenantId, sku, accessPolicies,
+// soft-delete flags) must survive untouched.
+func TestVaultARMUpdatePartialMerge(t *testing.T) {
+	ts := newVaultServer(t)
+	base := ts.URL
+
+	status, _ := doJSON(t, http.MethodPut, vaultURL(base, vaultSub, vaultRG, "vault-patch"), vaultCreateBody())
+	if status != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201", status)
+	}
+
+	patchBody := map[string]any{
+		"properties": map[string]any{
+			"enabledForDeployment": true,
+		},
+	}
+
+	status, patched := doJSON(t, http.MethodPatch, vaultURL(base, vaultSub, vaultRG, "vault-patch"), patchBody)
+	if status != http.StatusOK {
+		t.Fatalf("patch status = %d, want 200; body=%v", status, patched)
+	}
+
+	props, _ := patched["properties"].(map[string]any)
+	if props == nil {
+		t.Fatalf("no properties in patch response: %v", patched)
+	}
+
+	if props["enabledForDeployment"] != true {
+		t.Errorf("enabledForDeployment = %v, want true", props["enabledForDeployment"])
+	}
+
+	// Fields the PATCH body never mentioned must be untouched.
+	if props["tenantId"] != "11111111-1111-1111-1111-111111111111" {
+		t.Errorf("patch dropped tenantId: %v", props["tenantId"])
+	}
+
+	if sku, _ := props["sku"].(map[string]any); sku == nil || sku["name"] != "premium" {
+		t.Errorf("patch dropped sku: %v", props["sku"])
+	}
+
+	if pol, _ := props["accessPolicies"].([]any); len(pol) != 1 {
+		t.Errorf("patch dropped accessPolicies: %v", props["accessPolicies"])
+	}
+
+	if props["enablePurgeProtection"] != true {
+		t.Errorf("patch dropped enablePurgeProtection: %v", props["enablePurgeProtection"])
+	}
+
+	if tags, _ := patched["tags"].(map[string]any); tags["env"] != "test" {
+		t.Errorf("patch dropped untouched tags: %v", patched["tags"])
+	}
+
+	// A GET afterward must reflect the same merged state.
+	status, got := doJSON(t, http.MethodGet, vaultURL(base, vaultSub, vaultRG, "vault-patch"), nil)
+	if status != http.StatusOK {
+		t.Fatalf("get status = %d, want 200", status)
+	}
+
+	gp, _ := got["properties"].(map[string]any)
+	if gp["enabledForDeployment"] != true {
+		t.Errorf("get after patch enabledForDeployment = %v, want true", gp["enabledForDeployment"])
+	}
+}
+
+// TestVaultARMUpdateTagsFullReplace confirms a PATCH carrying tags replaces
+// the whole tag set (real ARM PATCH semantics), while properties it does not
+// mention stay untouched.
+func TestVaultARMUpdateTagsFullReplace(t *testing.T) {
+	ts := newVaultServer(t)
+	base := ts.URL
+
+	status, _ := doJSON(t, http.MethodPut, vaultURL(base, vaultSub, vaultRG, "vault-tags"), vaultCreateBody())
+	if status != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201", status)
+	}
+
+	status, patched := doJSON(t, http.MethodPatch, vaultURL(base, vaultSub, vaultRG, "vault-tags"),
+		map[string]any{"tags": map[string]any{"team": "core"}})
+	if status != http.StatusOK {
+		t.Fatalf("patch status = %d, want 200", status)
+	}
+
+	tags, _ := patched["tags"].(map[string]any)
+	if len(tags) != 1 || tags["team"] != "core" {
+		t.Fatalf("patched tags = %v, want exactly {team: core}", patched["tags"])
+	}
+
+	props, _ := patched["properties"].(map[string]any)
+	if props["tenantId"] != "11111111-1111-1111-1111-111111111111" {
+		t.Errorf("tags-only patch dropped tenantId: %v", props["tenantId"])
+	}
+}
+
+// TestVaultARMUpdateMissingVaultIs404 confirms PATCH on a vault name that was
+// never created 404s the same way GET/DELETE do.
+func TestVaultARMUpdateMissingVaultIs404(t *testing.T) {
+	ts := newVaultServer(t)
+	base := ts.URL
+
+	status, _ := doJSON(t, http.MethodPatch, vaultURL(base, vaultSub, vaultRG, "no-such-vault"),
+		map[string]any{"tags": map[string]any{"a": "b"}})
+	if status != http.StatusNotFound {
+		t.Errorf("patch-missing status = %d, want 404", status)
+	}
+}
+
+// TestVaultARMUpdateScopeMismatchIs404 mirrors TestVaultARMScopeMismatch for
+// PATCH: a vault addressed through the wrong resource group must 404 rather
+// than silently updating (or relocating) it.
+func TestVaultARMUpdateScopeMismatchIs404(t *testing.T) {
+	ts := newVaultServer(t)
+	base := ts.URL
+
+	status, _ := doJSON(t, http.MethodPut, vaultURL(base, vaultSub, vaultRG, "vault-scope-patch"), vaultCreateBody())
+	if status != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201", status)
+	}
+
+	status, _ = doJSON(t, http.MethodPatch, vaultURL(base, vaultSub, "other-rg", "vault-scope-patch"),
+		map[string]any{"tags": map[string]any{"a": "b"}})
+	if status != http.StatusNotFound {
+		t.Errorf("cross-rg patch status = %d, want 404", status)
+	}
+}
+
 // TestVaultARMUnmodeledPropertyPreserved exercises #409 gap #4 through the vault
 // resource: an unmodeled request property under properties survives PUT->GET via
 // the server's echoUnmodeledProperties overlay.

--- a/server/azure/keyvault/vault_arm_operations.go
+++ b/server/azure/keyvault/vault_arm_operations.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	"github.com/stackshy/cloudemu/v2/services/scope"
+	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
 )
 
 // createOrUpdateVault handles PUT — Vaults.BeginCreateOrUpdate. The LRO
@@ -87,6 +88,54 @@ func (h *VaultARMHandler) deleteVault(w http.ResponseWriter, r *http.Request, rp
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+// updateVault handles PATCH — Vaults.Update. Unlike PUT (a full replace), PATCH
+// merges: only fields present in the request body change, everything else on
+// the stored vault is left as-is. Real ARM answers 200 with the merged
+// resource; a vault that does not exist, or exists under a different resource
+// group, 404s the same way GET/DELETE do.
+func (h *VaultARMHandler) updateVault(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body vaultJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	existing, err := h.vaults.GetVault(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if !existing.Scope.Matches(scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}) {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound",
+			"vault "+rp.ResourceName+" not found in resource group "+rp.ResourceGroup)
+		return
+	}
+
+	cfg := secretsdriver.KVVaultConfig{
+		Name:       existing.Name,
+		Location:   existing.Location,
+		Scope:      existing.Scope,
+		Tags:       existing.Tags,
+		Properties: existing.Properties,
+	}
+
+	if body.Tags != nil {
+		cfg.Tags = body.Tags
+	}
+
+	if body.Properties != nil {
+		cfg.Properties = mergeVaultProperties(&existing.Properties, body.Properties)
+	}
+
+	info, err := h.vaults.CreateOrUpdateVault(r.Context(), cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toVaultJSON(rp, info))
 }
 
 // listVaults handles GET on the collection — Vaults.ListByResourceGroup /

--- a/server/azure/keyvault/vault_arm_types.go
+++ b/server/azure/keyvault/vault_arm_types.go
@@ -128,6 +128,89 @@ func vaultPropertiesFromJSON(p *vaultPropertiesJSON) secretsdriver.KVVaultProper
 	return out
 }
 
+// mergeVaultProperties applies a PATCH request's properties onto a stored
+// vault's properties: only fields the request body actually carries replace
+// the existing value (a nil pointer, empty SKU/access-policy list, or empty
+// string leaves the stored field untouched), matching real ARM PATCH merge
+// semantics as opposed to PUT's full replace.
+func mergeVaultProperties(existing *secretsdriver.KVVaultProperties, p *vaultPropertiesJSON) secretsdriver.KVVaultProperties {
+	out := *existing
+
+	if p.TenantID != "" {
+		out.TenantID = p.TenantID
+	}
+
+	if p.SKU != nil {
+		out.SKU = secretsdriver.KVVaultSKU{Family: p.SKU.Family, Name: p.SKU.Name}
+	}
+
+	if p.AccessPolicies != nil {
+		out.AccessPolicies = accessPoliciesFromJSON(p.AccessPolicies)
+	}
+
+	if p.SoftDeleteRetentionInDays != 0 {
+		out.SoftDeleteRetentionInDays = p.SoftDeleteRetentionInDays
+	}
+
+	if p.PublicNetworkAccess != "" {
+		out.PublicNetworkAccess = p.PublicNetworkAccess
+	}
+
+	mergeVaultFlags(&out, p)
+
+	return out
+}
+
+// accessPoliciesFromJSON converts a PATCH/PUT request's access-policy list to
+// the driver shape.
+func accessPoliciesFromJSON(in []vaultAccessPolicyJSON) []secretsdriver.KVAccessPolicy {
+	out := make([]secretsdriver.KVAccessPolicy, 0, len(in))
+
+	for i := range in {
+		ap := &in[i]
+		out = append(out, secretsdriver.KVAccessPolicy{
+			TenantID: ap.TenantID,
+			ObjectID: ap.ObjectID,
+			Permissions: secretsdriver.KVAccessPermissions{
+				Keys:         ap.Permissions.Keys,
+				Secrets:      ap.Permissions.Secrets,
+				Certificates: ap.Permissions.Certificates,
+				Storage:      ap.Permissions.Storage,
+			},
+		})
+	}
+
+	return out
+}
+
+// mergeVaultFlags applies the pointer-bool feature flags of a PATCH request
+// onto out: a nil pointer in p leaves the corresponding stored flag untouched.
+func mergeVaultFlags(out *secretsdriver.KVVaultProperties, p *vaultPropertiesJSON) {
+	if p.EnableRbacAuthorization != nil {
+		out.EnableRbacAuthorization = p.EnableRbacAuthorization
+	}
+
+	if p.EnabledForDeployment != nil {
+		out.EnabledForDeployment = p.EnabledForDeployment
+	}
+
+	if p.EnabledForDiskEncryption != nil {
+		out.EnabledForDiskEncryption = p.EnabledForDiskEncryption
+	}
+
+	if p.EnabledForTemplateDeployment != nil {
+		out.EnabledForTemplateDeployment = p.EnabledForTemplateDeployment
+	}
+
+	if p.EnableSoftDelete != nil {
+		out.EnableSoftDelete = p.EnableSoftDelete
+	}
+
+	if p.EnablePurgeProtection != nil {
+		out.EnablePurgeProtection = p.EnablePurgeProtection
+	}
+}
+
 // toVaultJSON converts a stored driver record into its ARM element. Resources
 // without a recorded scope fall back to the request path's scope.
 func toVaultJSON(rp *azurearm.ResourcePath, info *secretsdriver.KVVaultInfo) vaultJSON {


### PR DESCRIPTION
## Summary
- Real-user black-box e2e audit of Azure Key Vault (management + data plane) via the real azure-sdk-for-go, driving the full secret versioning + soft-delete/recover/purge lifecycle plus key crypto/rotation and certificate CRUD.
- `Vaults.Update` (ARM PATCH on `Microsoft.KeyVault/vaults`) was unrouted and answered every real SDK/CLI/Terraform patch call with 405 — a real user updating just a tag or one property (without resending the whole vault) had no way to do so.
- Added PATCH support that merges onto the stored vault: tags are a full replace when present, properties merge field-by-field (a field the request omits stays untouched), matching real ARM PATCH semantics as opposed to PUT's full replace.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./providers/azure/keyvault/... ./server/azure/keyvault/... -race` — all pass, including 4 new regression tests (partial merge preserves untouched properties, tags-only patch fully replaces tags, missing-vault 404, cross-resource-group scope mismatch 404)
- [x] Re-verified black-box against a real `cloudemu serve -providers=azure` process with `curl` + real ARM JSON bodies: PUT create → PATCH one property → GET shows the merge preserved tenantId/sku/accessPolicies/soft-delete flags; tags-only PATCH fully replaces tags; PATCH on a nonexistent vault and PATCH via the wrong resource group both 404
- [x] `golangci-lint run` on touched packages: 0 new issues (3 pre-existing `hugeParam` findings unchanged, confirmed via before/after `git stash` comparison)
- [x] `go generate ./...` + `git diff --exit-code docs/coverage`: no diff (no driver-interface change)