### PR TITLE
fix(ecs): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/ecs/ecs.go
+++ b/providers/aws/ecs/ecs.go
@@ -53,6 +53,14 @@ type Mock struct {
 	placeMu    sync.Mutex // serializes container-instance capacity reserve/release
 	clusterMu  sync.Mutex // serializes CreateCluster name-reuse compare-and-set
 
+	// reconcileLock serializes reconcileServiceAfterStop per service (see
+	// service_reconcile_lock.go), closing the concurrent-StopTask over-launch
+	// race. It is always the outermost lock acquired in that path — taken
+	// before placeMu (via launchServiceReplacements -> launchTask -> reserve)
+	// and before m.services's own per-call lock (via Update) — so it can never
+	// deadlock against them.
+	reconcileLock *serviceReconcileLock
+
 	launcher ManagedInstanceLauncher // optional: provisions backing managed EC2 instances
 
 	// engineHandles maps a task ARN to the config.ContainerEngine handle backing
@@ -107,6 +115,7 @@ func New(opts *config.Options) *Mock {
 		attributes:    memstore.New[*driver.Attribute](),
 		engineHandles: memstore.New[string](),
 		taskSettle:    settle.NewSet(),
+		reconcileLock: newServiceReconcileLock(),
 		opts:          opts,
 	}
 }

--- a/providers/aws/ecs/service_reconcile_lock.go
+++ b/providers/aws/ecs/service_reconcile_lock.go
@@ -1,0 +1,40 @@
+package ecs
+
+import "sync"
+
+// serviceReconcileLock hands out one mutex per service key (cluster+name, see
+// serviceKey), created on first use. It serializes reconcileServiceAfterStop's
+// whole read-live-counts -> decide-shortfall -> launch-replacements -> commit
+// sequence for a single service, closing the TOCTOU that otherwise lets two
+// concurrent StopTask calls on two different tasks of the same service each
+// read the pre-replacement counts, each independently compute the full
+// shortfall, and each launch a replacement — over-provisioning the service
+// above desiredCount with nothing to ever scale it back down. Keying by
+// service (rather than one global lock) keeps unrelated services reconciling
+// concurrently.
+type serviceReconcileLock struct {
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func newServiceReconcileLock() *serviceReconcileLock {
+	return &serviceReconcileLock{locks: make(map[string]*sync.Mutex)}
+}
+
+// lock acquires the mutex for key and returns its unlock func. The returned
+// func must be called (typically via defer) to release the lock.
+func (l *serviceReconcileLock) lock(key string) func() {
+	l.mu.Lock()
+
+	m, ok := l.locks[key]
+	if !ok {
+		m = &sync.Mutex{}
+		l.locks[key] = m
+	}
+
+	l.mu.Unlock()
+
+	m.Lock()
+
+	return m.Unlock
+}

--- a/providers/aws/ecs/services.go
+++ b/providers/aws/ecs/services.go
@@ -379,6 +379,16 @@ func (m *Mock) launchServiceReplacements(ctx context.Context, svc *driver.Servic
 // A task with no owning service (Group doesn't start with "service:") is a
 // no-op, as is a service that's been deleted or is mid-delete (Status is no
 // longer ACTIVE) — DeleteService/drainService already own tearing that down.
+//
+// The whole read-decide-launch-commit sequence below runs under the service's
+// reconcileLock key: two concurrent StopTask calls on different tasks of the
+// same service must not both read the pre-replacement counts, both compute
+// the full shortfall, and both launch replacements — that would over-provision
+// the service above desiredCount with nothing to ever scale it back down. The
+// lock is per-service (keyed by cluster+name), so unrelated services still
+// reconcile concurrently, and it is acquired here — before stopTaskLocked's
+// placeMu has any chance to be re-taken by a replacement launch, and before
+// m.services's own per-call lock — making it the outermost lock in this path.
 func (m *Mock) reconcileServiceAfterStop(ctx context.Context, task *driver.Task) {
 	name, ok := serviceNameFromGroup(task.Group)
 	if !ok {
@@ -387,6 +397,9 @@ func (m *Mock) reconcileServiceAfterStop(ctx context.Context, task *driver.Task)
 
 	cluster := clusterNameFromARN(task.ClusterARN)
 	key := serviceKey(cluster, name)
+
+	unlock := m.reconcileLock.lock(key)
+	defer unlock()
 
 	svc, ok := m.services.Get(key)
 	if !ok || svc.Status != statusActive {

--- a/providers/aws/ecs/services.go
+++ b/providers/aws/ecs/services.go
@@ -25,6 +25,11 @@ const (
 
 	deployControllerECS = "ECS"
 
+	// azRebalancingDisabled is the default availabilityZoneRebalancing value a
+	// service is created with when the caller doesn't specify one, matching
+	// real ECS.
+	azRebalancingDisabled = "DISABLED"
+
 	// serviceStoppedReason is the StopTask reason used when the scheduler drains a
 	// superseded deployment or a deleted service.
 	serviceStoppedReason = "Service scheduler stopped task."
@@ -130,6 +135,11 @@ func serviceFromInput(
 		controller = deployControllerECS
 	}
 
+	azRebalancing := in.AvailabilityZoneRebalancing
+	if azRebalancing == "" {
+		azRebalancing = azRebalancingDisabled
+	}
+
 	return &driver.Service{
 		ARN:                           arn("service/" + cluster + "/" + in.ServiceName),
 		Name:                          in.ServiceName,
@@ -146,6 +156,7 @@ func serviceFromInput(
 		PropagateTags:                 in.PropagateTags,
 		EnableExecuteCommand:          in.EnableExecuteCommand,
 		HealthCheckGracePeriodSeconds: in.HealthCheckGracePeriodSeconds,
+		AvailabilityZoneRebalancing:   azRebalancing,
 		CreatedAt:                     now,
 		// Clone reference-typed fields so the stored record never aliases the
 		// caller's input slices/pointers (a caller mutating what it passed must
@@ -277,8 +288,133 @@ func (m *Mock) drainService(ctx context.Context, svc *driver.Service) {
 		}
 
 		m.deregisterTaskTargets(ctx, svc, t)
-		_, _ = m.StopTask(ctx, cluster, t.ARN, serviceStoppedReason)
+		// reconcile=false: this drain already owns and re-converges the whole
+		// service state itself (the caller launches the replacement tasks), so
+		// StopTask's own reconciliation would race it — see stopTask.
+		_, _ = m.stopTask(ctx, cluster, t.ARN, serviceStoppedReason, false)
 	}
+}
+
+// serviceNameFromGroup extracts the service name from a task's Group field
+// ("service:<name>"), the inverse of serviceGroup. It reports false for a task
+// with no owning service (an empty group, or one from RunTask/StartTask that
+// never carries the "service:" prefix).
+func serviceNameFromGroup(group string) (string, bool) {
+	const prefix = "service:"
+
+	if !strings.HasPrefix(group, prefix) {
+		return "", false
+	}
+
+	return strings.TrimPrefix(group, prefix), true
+}
+
+// primaryDeploymentID returns the id of the service's PRIMARY deployment, or
+// "" if none is recorded. An ACTIVE service always carries exactly one (see
+// convergeNewService/redeployService), so this only misses defensively.
+func primaryDeploymentID(deployments []driver.Deployment) string {
+	for i := range deployments {
+		if deployments[i].Status == deploymentPrimary {
+			return deployments[i].ID
+		}
+	}
+
+	return ""
+}
+
+// liveServiceTaskCounts recomputes a service's running/pending task counts by
+// scanning the task store directly, rather than trusting bookkeeping fields
+// that a concurrent StopTask/RunTask could have raced. Mirrors the same
+// group+cluster scoping drainService uses to find a service's tasks.
+func (m *Mock) liveServiceTaskCounts(cluster, group string) (running, pending int) {
+	for _, t := range m.tasks.All() {
+		if t.Group != group || clusterNameFromARN(t.ClusterARN) != cluster {
+			continue
+		}
+
+		switch t.LastStatus {
+		case statusRunning:
+			running++
+		case statusPending:
+			pending++
+		}
+	}
+
+	return running, pending
+}
+
+// launchServiceReplacements launches up to n replacement tasks for svc under
+// its existing PRIMARY deployment (no new deployment is minted for a
+// replacement, matching real ECS). A task definition that's since been
+// deregistered leaves the service short rather than erroring, same as a real
+// scheduler that can't resolve its target definition.
+func (m *Mock) launchServiceReplacements(ctx context.Context, svc *driver.Service, n int) {
+	td, ok := m.resolveTaskDef(svc.TaskDefinition)
+	if !ok {
+		return
+	}
+
+	spec := m.serviceTaskSpec(svc, td, primaryDeploymentID(svc.Deployments))
+
+	for range n {
+		t, _ := m.launchTask(ctx, &spec, true)
+		if t == nil {
+			continue
+		}
+
+		if t.LastStatus == statusRunning {
+			m.registerTaskTargets(ctx, svc, td, t)
+		}
+	}
+}
+
+// reconcileServiceAfterStop re-converges the stopped task's owning service (if
+// any): it recomputes the service's live running/pending counts from the task
+// store and, if short of desiredCount, launches replacement task(s) under the
+// existing PRIMARY deployment — mirroring real ECS's scheduler, which notices a
+// service-owned task died on its next reconciliation pass, reflects the drop
+// immediately, and launches a replacement to converge back. No new deployment
+// is minted; a single dead task doesn't roll a fresh one, matching real ECS.
+//
+// A task with no owning service (Group doesn't start with "service:") is a
+// no-op, as is a service that's been deleted or is mid-delete (Status is no
+// longer ACTIVE) — DeleteService/drainService already own tearing that down.
+func (m *Mock) reconcileServiceAfterStop(ctx context.Context, task *driver.Task) {
+	name, ok := serviceNameFromGroup(task.Group)
+	if !ok {
+		return
+	}
+
+	cluster := clusterNameFromARN(task.ClusterARN)
+	key := serviceKey(cluster, name)
+
+	svc, ok := m.services.Get(key)
+	if !ok || svc.Status != statusActive {
+		return
+	}
+
+	m.deregisterTaskTargets(ctx, svc, task)
+
+	running, pending := m.liveServiceTaskCounts(cluster, task.Group)
+	if shortfall := svc.DesiredCount - (running + pending); shortfall > 0 {
+		m.launchServiceReplacements(ctx, svc, shortfall)
+	}
+
+	m.services.Update(key, func(s *driver.Service) *driver.Service {
+		updated := cloneService(s)
+		updated.RunningCount, updated.PendingCount = m.liveServiceTaskCounts(cluster, task.Group)
+
+		for i := range updated.Deployments {
+			if updated.Deployments[i].Status == deploymentPrimary {
+				updated.Deployments[i].RunningCount = updated.RunningCount
+				updated.Deployments[i].PendingCount = updated.PendingCount
+				updated.Deployments[i].RolloutState = rolloutState(updated.RunningCount, updated.DesiredCount)
+				updated.Deployments[i].UpdatedAt = m.now()
+			}
+		}
+
+		return &updated
+	})
 }
 
 // deploymentID mints an ECS service deployment id ("ecs-svc/<id>"). Service
@@ -443,6 +579,10 @@ func applyServiceScalars(svc *driver.Service, in *driver.UpdateServiceInput) {
 
 	if in.HealthCheckGracePeriodSeconds != nil {
 		svc.HealthCheckGracePeriodSeconds = in.HealthCheckGracePeriodSeconds
+	}
+
+	if in.AvailabilityZoneRebalancing != "" {
+		svc.AvailabilityZoneRebalancing = in.AvailabilityZoneRebalancing
 	}
 }
 

--- a/providers/aws/ecs/services_test.go
+++ b/providers/aws/ecs/services_test.go
@@ -2,6 +2,7 @@ package ecs
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -184,4 +185,127 @@ func TestUpdateService_AvailabilityZoneRebalancing(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "ENABLED", updated.AvailabilityZoneRebalancing)
+}
+
+// TestStopTask_ConcurrentSameServiceNoOverLaunch guards the per-service
+// reconcile lock: reconcileServiceAfterStop's read-live-counts ->
+// decide-shortfall -> launch-replacements -> commit sequence must be atomic
+// per service, or two concurrent StopTask calls on two different RUNNING
+// tasks of the same service can each read the pre-replacement counts, each
+// independently compute the full shortfall, and each launch a replacement —
+// leaving the service permanently over-provisioned above desiredCount (with
+// nothing to ever scale it back down). Repeated iterations under -race make
+// this reliably catch a regression of the lock.
+func TestStopTask_ConcurrentSameServiceNoOverLaunch(t *testing.T) {
+	const iterations = 20
+
+	for iter := range iterations {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateCluster(ctx, driver.CreateClusterInput{Name: "prod"})
+		require.NoError(t, err)
+
+		_, err = m.RegisterTaskDefinition(ctx, driver.RegisterTaskDefinitionInput{
+			Family:               "web",
+			ContainerDefinitions: []driver.ContainerDefinition{{Name: "c", Image: "img"}},
+		})
+		require.NoError(t, err)
+
+		// Generous EC2 capacity so both the initial convergence and any
+		// replacement tasks always fit.
+		m.SeedContainerInstance("prod", "i-race", WithCapacity(81920, 163840))
+
+		svc, err := m.CreateService(ctx, driver.CreateServiceInput{
+			ServiceName:    "web-svc",
+			Cluster:        "prod",
+			TaskDefinition: "web:1",
+			DesiredCount:   2,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 2, svc.RunningCount)
+
+		tasks, err := m.ListTasks(ctx, "prod", "", "", "web-svc")
+		require.NoError(t, err)
+		require.Len(t, tasks, 2)
+
+		var wg sync.WaitGroup
+
+		wg.Add(len(tasks))
+
+		for _, task := range tasks {
+			go func(taskARN string) {
+				defer wg.Done()
+
+				_, stopErr := m.StopTask(ctx, "prod", taskARN, "concurrent stop")
+				assert.NoError(t, stopErr)
+			}(task.ARN)
+		}
+
+		wg.Wait()
+
+		running, err := m.ListTasks(ctx, "prod", "", statusRunning, "web-svc")
+		require.NoError(t, err)
+
+		pending, err := m.ListTasks(ctx, "prod", "", statusPending, "web-svc")
+		require.NoError(t, err)
+
+		assert.Equalf(t, 2, len(running)+len(pending),
+			"iteration %d: service must never over-launch above desiredCount=2 (got %d running + %d pending)",
+			iter, len(running), len(pending))
+
+		found, _, err := m.DescribeServices(ctx, "prod", []string{"web-svc"})
+		require.NoError(t, err)
+		require.Len(t, found, 1)
+		assert.Equalf(t, 2, found[0].RunningCount+found[0].PendingCount,
+			"iteration %d: service bookkeeping must match live counts", iter)
+	}
+}
+
+// TestStopTask_StandaloneTaskNoServiceGroupNoop guards the reconcile path for
+// a standalone task started via RunTask (no owning service, so no
+// "service:"-prefixed Group): serviceNameFromGroup must report false and
+// reconcileServiceAfterStop must no-op cleanly on StopTask — no crash, no
+// accidental relaunch, no phantom service.
+func TestStopTask_StandaloneTaskNoServiceGroupNoop(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, driver.CreateClusterInput{Name: "prod"})
+	require.NoError(t, err)
+
+	_, err = m.RegisterTaskDefinition(ctx, driver.RegisterTaskDefinitionInput{
+		Family:               "web",
+		ContainerDefinitions: []driver.ContainerDefinition{{Name: "c", Image: "img"}},
+	})
+	require.NoError(t, err)
+
+	m.SeedContainerInstance("prod", "i-standalone")
+
+	// A plain RunTask (no service) carries no "service:" Group.
+	tasks, failures, err := m.RunTask(ctx, driver.RunTaskInput{Cluster: "prod", TaskDefinition: "web"})
+	require.NoError(t, err)
+	require.Empty(t, failures)
+	require.Len(t, tasks, 1)
+	assert.Empty(t, tasks[0].Group)
+
+	stopped, err := m.StopTask(ctx, "prod", tasks[0].ARN, "standalone stop")
+	require.NoError(t, err)
+	assert.Equal(t, statusStopped, stopped.LastStatus)
+
+	// No service was created, so nothing to relaunch: exactly the one
+	// now-stopped task exists, and no service surfaces it.
+	all, err := m.ListTasks(ctx, "prod", "", "", "")
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+	assert.Equal(t, statusStopped, all[0].LastStatus)
+
+	svcs, err := m.ListServices(ctx, "prod")
+	require.NoError(t, err)
+	assert.Empty(t, svcs)
+
+	// A repeated StopTask on the already-stopped standalone task is also a
+	// clean no-op (the reconcile path's early return handles it both times).
+	_, err = m.StopTask(ctx, "prod", tasks[0].ARN, "standalone stop again")
+	require.NoError(t, err)
 }

--- a/providers/aws/ecs/services_test.go
+++ b/providers/aws/ecs/services_test.go
@@ -1,0 +1,187 @@
+package ecs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/services/ecs/driver"
+)
+
+// TestStopTask_ReconcilesOwningService guards the ECS "service-count-vs-overlay
+// divergence" fix: stopping a service-owned task directly (not via the
+// service's own drain) must reconcile the owning service's live counts and
+// launch a replacement to converge back to desiredCount, mirroring real ECS's
+// scheduler reconciliation pass.
+func TestStopTask_ReconcilesOwningService(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, driver.CreateClusterInput{Name: "prod"})
+	require.NoError(t, err)
+
+	_, err = m.RegisterTaskDefinition(ctx, driver.RegisterTaskDefinitionInput{
+		Family:               "web",
+		ContainerDefinitions: []driver.ContainerDefinition{{Name: "c", Image: "img"}},
+	})
+	require.NoError(t, err)
+
+	// Generous EC2 capacity so both the initial convergence and the
+	// replacement task launched by reconciliation always fit.
+	m.SeedContainerInstance("prod", "i-svc", WithCapacity(81920, 163840))
+
+	svc, err := m.CreateService(ctx, driver.CreateServiceInput{
+		ServiceName:    "web-svc",
+		Cluster:        "prod",
+		TaskDefinition: "web:1",
+		DesiredCount:   2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, svc.RunningCount)
+	require.Equal(t, 0, svc.PendingCount)
+
+	tasks, err := m.ListTasks(ctx, "prod", "", "", "web-svc")
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+
+	stopped, err := m.StopTask(ctx, "prod", tasks[0].ARN, "manual test stop")
+	require.NoError(t, err)
+	assert.Equal(t, statusStopped, stopped.LastStatus)
+
+	// The service must self-heal synchronously: a replacement task launches
+	// and the live counts converge back to desiredCount, exactly as real
+	// ECS's scheduler does on its next reconciliation pass.
+	found, _, err := m.DescribeServices(ctx, "prod", []string{"web-svc"})
+	require.NoError(t, err)
+	require.Len(t, found, 1)
+	assert.Equal(t, 2, found[0].DesiredCount)
+	assert.Equal(t, 2, found[0].RunningCount)
+	assert.Equal(t, 0, found[0].PendingCount)
+	require.Len(t, found[0].Deployments, 1)
+	assert.Equal(t, 2, found[0].Deployments[0].RunningCount)
+	assert.Equal(t, rolloutCompleted, found[0].Deployments[0].RolloutState)
+
+	// Exactly 2 tasks are actually RUNNING (the untouched original plus the
+	// replacement) — the stopped task must not still be counted.
+	running, err := m.ListTasks(ctx, "prod", "", statusRunning, "web-svc")
+	require.NoError(t, err)
+	assert.Len(t, running, 2)
+
+	all, err := m.ListTasks(ctx, "prod", "", "", "web-svc")
+	require.NoError(t, err)
+	assert.Len(t, all, 3, "the stopped task, the untouched original, and the replacement")
+
+	// A repeated StopTask on the already-stopped task is idempotent: it must
+	// not trigger a second reconciliation (which would over-converge).
+	_, err = m.StopTask(ctx, "prod", tasks[0].ARN, "second stop")
+	require.NoError(t, err)
+
+	found, _, err = m.DescribeServices(ctx, "prod", []string{"web-svc"})
+	require.NoError(t, err)
+	assert.Equal(t, 2, found[0].RunningCount)
+}
+
+// TestDeleteService_DrainDoesNotDoubleReconcile guards that DeleteService's
+// own drain (which stops every task itself) doesn't race StopTask's
+// reconciliation: drainService must not launch a replacement task for a
+// service that's being deliberately torn down.
+func TestDeleteService_DrainDoesNotDoubleReconcile(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, driver.CreateClusterInput{Name: "prod"})
+	require.NoError(t, err)
+
+	_, err = m.RegisterTaskDefinition(ctx, driver.RegisterTaskDefinitionInput{
+		Family:               "web",
+		ContainerDefinitions: []driver.ContainerDefinition{{Name: "c", Image: "img"}},
+	})
+	require.NoError(t, err)
+
+	m.SeedContainerInstance("prod", "i-svc", WithCapacity(81920, 163840))
+
+	_, err = m.CreateService(ctx, driver.CreateServiceInput{
+		ServiceName:    "web-svc",
+		Cluster:        "prod",
+		TaskDefinition: "web:1",
+		DesiredCount:   2,
+	})
+	require.NoError(t, err)
+
+	deleted, err := m.DeleteService(ctx, "prod", "web-svc", true)
+	require.NoError(t, err)
+	assert.Equal(t, statusInactive, deleted.Status)
+	assert.Equal(t, 0, deleted.RunningCount)
+
+	running, err := m.ListTasks(ctx, "prod", "", statusRunning, "web-svc")
+	require.NoError(t, err)
+	assert.Empty(t, running, "delete must not relaunch replacement tasks for a service being torn down")
+}
+
+// TestCreateService_AvailabilityZoneRebalancingDefaultsToDisabled guards that
+// a fresh service always echoes availabilityZoneRebalancing (real ECS never
+// leaves it unset), defaulting to "DISABLED" when the caller doesn't specify
+// one — this is what lets a Terraform apply immediately followed by a plan
+// come back clean instead of showing a perpetual 1-attribute diff.
+func TestCreateService_AvailabilityZoneRebalancingDefaultsToDisabled(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, driver.CreateClusterInput{Name: "prod"})
+	require.NoError(t, err)
+
+	_, err = m.RegisterTaskDefinition(ctx, driver.RegisterTaskDefinitionInput{
+		Family:               "web",
+		ContainerDefinitions: []driver.ContainerDefinition{{Name: "c", Image: "img"}},
+	})
+	require.NoError(t, err)
+
+	svc, err := m.CreateService(ctx, driver.CreateServiceInput{
+		ServiceName: "default-azr", Cluster: "prod", TaskDefinition: "web", DesiredCount: 0,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "DISABLED", svc.AvailabilityZoneRebalancing)
+
+	explicit, err := m.CreateService(ctx, driver.CreateServiceInput{
+		ServiceName: "explicit-azr", Cluster: "prod", TaskDefinition: "web", DesiredCount: 0,
+		AvailabilityZoneRebalancing: "ENABLED",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ENABLED", explicit.AvailabilityZoneRebalancing)
+}
+
+// TestUpdateService_AvailabilityZoneRebalancing guards that UpdateService
+// accepts and stores an explicit availabilityZoneRebalancing change, leaving
+// it untouched when the caller omits the field.
+func TestUpdateService_AvailabilityZoneRebalancing(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, driver.CreateClusterInput{Name: "prod"})
+	require.NoError(t, err)
+
+	_, err = m.RegisterTaskDefinition(ctx, driver.RegisterTaskDefinitionInput{
+		Family:               "web",
+		ContainerDefinitions: []driver.ContainerDefinition{{Name: "c", Image: "img"}},
+	})
+	require.NoError(t, err)
+
+	svc, err := m.CreateService(ctx, driver.CreateServiceInput{
+		ServiceName: "web-svc", Cluster: "prod", TaskDefinition: "web", DesiredCount: 0,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "DISABLED", svc.AvailabilityZoneRebalancing)
+
+	// Omitting the field on update leaves the current setting unchanged.
+	unchanged, err := m.UpdateService(ctx, driver.UpdateServiceInput{Service: "web-svc", Cluster: "prod"})
+	require.NoError(t, err)
+	assert.Equal(t, "DISABLED", unchanged.AvailabilityZoneRebalancing)
+
+	updated, err := m.UpdateService(ctx, driver.UpdateServiceInput{
+		Service: "web-svc", Cluster: "prod", AvailabilityZoneRebalancing: "ENABLED",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ENABLED", updated.AvailabilityZoneRebalancing)
+}

--- a/providers/aws/ecs/tasks.go
+++ b/providers/aws/ecs/tasks.go
@@ -472,7 +472,52 @@ func (m *Mock) networkBindingsFor(networkMode string, mappings []driver.PortMapp
 // way: a repeated StopTask on an already-stopped task must not restart it,
 // matching real ECS's idempotent StopTask (an already-stopped task is returned
 // as-is, never "un-stopping" back to a transient).
+//
+// When the stopped task belongs to a service, real ECS's scheduler notices on
+// its next reconciliation pass and both reflects the drop in the service's
+// running count and launches a replacement to converge back to desiredCount;
+// StopTask reconciles the owning service synchronously to mirror that (see
+// reconcile below).
 func (m *Mock) StopTask(ctx context.Context, cluster, task, reason string) (*driver.Task, error) {
+	return m.stopTask(ctx, cluster, task, reason, true)
+}
+
+// stopTask is StopTask's implementation, parameterized on whether to reconcile
+// the task's owning service afterward. drainService (the service scheduler's
+// own drain, used by DeleteService and UpdateService's redeploy) calls this
+// with reconcile=false: it already owns and re-converges the service's whole
+// state itself, so a second, independent reconciliation here would race it —
+// relaunching a replacement for a task the service is in the middle of
+// deliberately draining.
+func (m *Mock) stopTask(ctx context.Context, cluster, task, reason string, reconcile bool) (*driver.Task, error) {
+	updated, alreadyStopped, err := m.stopTaskLocked(ctx, cluster, task, reason)
+	if err != nil {
+		return nil, err
+	}
+
+	if !alreadyStopped {
+		m.beginStopSettle(updated)
+
+		if reconcile {
+			// Reconciliation may itself place a replacement task (taking
+			// placeMu via reserve), so it must run after stopTaskLocked has
+			// released placeMu below — calling it while still holding placeMu
+			// would deadlock on a non-reentrant mutex.
+			m.reconcileServiceAfterStop(ctx, updated)
+		}
+	}
+
+	out := cloneTask(updated)
+	m.overlayStatus(&out)
+
+	return &out, nil
+}
+
+// stopTaskLocked performs the placeMu-guarded core of stopTask: resolving the
+// task, tearing down its engine backing, releasing any reserved capacity, and
+// flipping it to STOPPED. It returns the stored (post-mutation) task and
+// whether it was already stopped before this call.
+func (m *Mock) stopTaskLocked(ctx context.Context, cluster, task, reason string) (*driver.Task, bool, error) {
 	m.placeMu.Lock()
 	defer m.placeMu.Unlock()
 
@@ -481,14 +526,14 @@ func (m *Mock) StopTask(ctx context.Context, cluster, task, reason string) (*dri
 	// ClusterNotFoundException + InvalidParameterException).
 	want := resolveClusterName(cluster)
 	if !m.clusterExists(want) {
-		return nil, apiErrf(errors.NotFound, excClusterNotFound, "cluster %q not found", want)
+		return nil, false, apiErrf(errors.NotFound, excClusterNotFound, "cluster %q not found", want)
 	}
 
 	// A task that resolves but lives in a different cluster is not visible to this
 	// StopTask, same as a task that does not exist at all: InvalidParameterException.
 	t, ok := m.resolveTask(task)
 	if !ok || clusterNameFromARN(t.ClusterARN) != want {
-		return nil, apiErrf(errors.NotFound, excInvalidParameter, "task %q not found", task)
+		return nil, false, apiErrf(errors.NotFound, excInvalidParameter, "task %q not found", task)
 	}
 
 	// Tear down the backing engine workload (if any) before flipping to STOPPED,
@@ -528,14 +573,7 @@ func (m *Mock) StopTask(ctx context.Context, cluster, task, reason string) (*dri
 
 	m.tasks.Set(updated.ARN, &updated)
 
-	if !alreadyStopped {
-		m.beginStopSettle(&updated)
-	}
-
-	out := cloneTask(&updated)
-	m.overlayStatus(&out)
-
-	return &out, nil
+	return &updated, alreadyStopped, nil
 }
 
 // ListTasks returns tasks in a cluster, optionally filtered by family, desired

--- a/server/aws/ecs/pagination.go
+++ b/server/aws/ecs/pagination.go
@@ -25,8 +25,17 @@ func paginateARNs(
 }
 
 // listResponse builds an ECS list response body under arnKey, adding nextToken
-// only when there are more results (real ECS omits it on the last page).
+// only when there are more results (real ECS omits it on the last page). arns
+// is normalized to a non-nil (possibly empty) slice: real ECS always returns an
+// array for a List op, never null, and internal/pagination.Paginate returns a
+// nil Items slice for an empty result, which encoding/json would otherwise
+// render as "null" instead of "[]" — breaking any caller (e.g. boto3) that
+// iterates the field unconditionally.
 func listResponse(arnKey string, arns []string, nextToken string) map[string]any {
+	if arns == nil {
+		arns = []string{}
+	}
+
 	out := map[string]any{arnKey: arns}
 	if nextToken != "" {
 		out["nextToken"] = nextToken

--- a/server/aws/ecs/pagination_test.go
+++ b/server/aws/ecs/pagination_test.go
@@ -1,0 +1,42 @@
+package ecs
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestListResponseEmptyArnsIsEmptyArrayNotNull guards that an empty (or nil)
+// arns slice serializes to a JSON "[]", never "null". Real ECS always returns
+// an array for a List op's ARN field, even when there are zero results; a
+// caller iterating the field unconditionally (e.g. boto3) breaks on null.
+// internal/pagination.Paginate returns a nil Items slice for an empty result,
+// so listResponse must normalize that before it reaches encoding/json.
+func TestListResponseEmptyArnsIsEmptyArrayNotNull(t *testing.T) {
+	for name, arns := range map[string][]string{"nil slice": nil, "empty slice": {}} {
+		t.Run(name, func(t *testing.T) {
+			body, err := json.Marshal(listResponse("clusterArns", arns, ""))
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+
+			got := string(body)
+			if got != `{"clusterArns":[]}` {
+				t.Fatalf("got %s, want {\"clusterArns\":[]}", got)
+			}
+		})
+	}
+}
+
+// TestListResponseNonEmptyArnsPassThrough guards that a populated arns slice
+// is unaffected by the nil-normalization.
+func TestListResponseNonEmptyArnsPassThrough(t *testing.T) {
+	body, err := json.Marshal(listResponse("clusterArns", []string{"arn:aws:ecs:us-east-1:000000000000:cluster/c1"}, ""))
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	want := `{"clusterArns":["arn:aws:ecs:us-east-1:000000000000:cluster/c1"]}`
+	if string(body) != want {
+		t.Fatalf("got %s, want %s", body, want)
+	}
+}

--- a/server/aws/ecs/services.go
+++ b/server/aws/ecs/services.go
@@ -46,6 +46,7 @@ func (h *Handler) createService(w http.ResponseWriter, r *http.Request) {
 		LoadBalancers                 []wireLoadBalancer                 `json:"loadBalancers"`
 		ServiceRegistries             []wireServiceRegistry              `json:"serviceRegistries"`
 		Tags                          []wireTag                          `json:"tags"`
+		AvailabilityZoneRebalancing   string                             `json:"availabilityZoneRebalancing"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -71,6 +72,7 @@ func (h *Handler) createService(w http.ResponseWriter, r *http.Request) {
 		LoadBalancers:                 toLoadBalancers(req.LoadBalancers),
 		ServiceRegistries:             toServiceRegistries(req.ServiceRegistries),
 		Tags:                          toTags(req.Tags),
+		AvailabilityZoneRebalancing:   req.AvailabilityZoneRebalancing,
 	})
 	if err != nil {
 		writeErr(w, err)
@@ -97,6 +99,7 @@ func (h *Handler) updateService(w http.ResponseWriter, r *http.Request) {
 		CapacityProviderStrategy      []wireCapacityProviderStrategyItem `json:"capacityProviderStrategy"`
 		LoadBalancers                 []wireLoadBalancer                 `json:"loadBalancers"`
 		ServiceRegistries             []wireServiceRegistry              `json:"serviceRegistries"`
+		AvailabilityZoneRebalancing   string                             `json:"availabilityZoneRebalancing"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -118,6 +121,7 @@ func (h *Handler) updateService(w http.ResponseWriter, r *http.Request) {
 		CapacityProviderStrategy:      toCapacityProviderStrategy(req.CapacityProviderStrategy),
 		LoadBalancers:                 toLoadBalancers(req.LoadBalancers),
 		ServiceRegistries:             toServiceRegistries(req.ServiceRegistries),
+		AvailabilityZoneRebalancing:   req.AvailabilityZoneRebalancing,
 	})
 	if err != nil {
 		writeErr(w, err)

--- a/server/aws/ecs/types.go
+++ b/server/aws/ecs/types.go
@@ -371,6 +371,9 @@ type wireService struct {
 	Events                        []wireServiceEvent           `json:"events,omitempty"`
 	CreatedAt                     float64                      `json:"createdAt,omitempty"`
 	Tags                          []wireTag                    `json:"tags,omitempty"`
+	// AvailabilityZoneRebalancing has no omitempty: real ECS always reports
+	// this field ("ENABLED"/"DISABLED"), even for services that never opted in.
+	AvailabilityZoneRebalancing string `json:"availabilityZoneRebalancing"`
 }
 
 // wireDeploymentController echoes the service's deployment controller type.
@@ -1300,6 +1303,7 @@ func serviceToWire(s *driver.Service) wireService {
 		Events:                        fromServiceEvents(s.Events),
 		CreatedAt:                     epoch(s.CreatedAt),
 		Tags:                          fromTags(s.Tags),
+		AvailabilityZoneRebalancing:   s.AvailabilityZoneRebalancing,
 	}
 	if s.DeploymentController != "" {
 		out.DeploymentController = &wireDeploymentController{Type: s.DeploymentController}

--- a/services/ecs/driver/driver.go
+++ b/services/ecs/driver/driver.go
@@ -428,6 +428,11 @@ type Service struct {
 	Deployments                   []Deployment
 	Events                        []ServiceEvent
 	Tags                          []Tag
+	// AvailabilityZoneRebalancing is "ENABLED" or "DISABLED". Real ECS always
+	// reports this field (defaulting new services to "DISABLED" when the
+	// caller doesn't specify it), so it is never left empty on a stored
+	// service.
+	AvailabilityZoneRebalancing string
 }
 
 // ContainerInstance is an EC2 instance registered into a cluster. It models a
@@ -522,6 +527,9 @@ type CreateServiceInput struct {
 	LoadBalancers                 []LoadBalancer
 	ServiceRegistries             []ServiceRegistry
 	Tags                          []Tag
+	// AvailabilityZoneRebalancing is "ENABLED" or "DISABLED"; an empty value
+	// defaults to "DISABLED" (matching real ECS).
+	AvailabilityZoneRebalancing string
 }
 
 // UpdateServiceInput describes mutations to an existing service. Nil pointers
@@ -542,6 +550,9 @@ type UpdateServiceInput struct {
 	CapacityProviderStrategy      []CapacityProviderStrategyItem
 	LoadBalancers                 []LoadBalancer
 	ServiceRegistries             []ServiceRegistry
+	// AvailabilityZoneRebalancing is "ENABLED" or "DISABLED"; an empty value
+	// leaves the service's current setting unchanged.
+	AvailabilityZoneRebalancing string
 }
 
 // RegisterContainerInstanceInput describes an EC2 container instance to register


### PR DESCRIPTION
## Summary

Real-user e2e audit (aws-cli + Terraform against `cloudemu serve`) of ECS found three divergences from real AWS, all fixed:

1. **List* ops return `null` instead of `[]` when empty.** `ListClusters`/`ListServices`/`ListTasks`/`ListTaskDefinitions`/`ListContainerInstances` return `null` for the ARN array on an empty result (root cause: `internal/pagination.Paginate` returns a nil `Items` slice, which `encoding/json` renders as `null`). Real AWS's JSON protocol always returns an array. This breaks boto3 (`TypeError: 'NoneType' object is not iterable`) and silently drops the field from aws-cli's output. Fixed by normalizing to `[]string{}` in `server/aws/ecs/pagination.go`'s `listResponse`, scoped to the ECS wire layer only.

2. **StopTask on a service-owned task doesn't reconcile the service ("service-count-vs-overlay divergence").** Stopping a task directly never updated the owning service's `runningCount`/`pendingCount`/deployment counts and never launched a replacement, so the service's reported state silently diverged from reality forever. Real ECS's scheduler notices on its next pass, drops the count, and launches a replacement to converge back to `desiredCount`. `StopTask` now reconciles synchronously (matching the existing synchronous-convergence pattern used by CreateService/UpdateService/DeleteService elsewhere in this codebase). `drainService` (the service scheduler's own drain, used by DeleteService/UpdateService's redeploy) now calls a new non-reconciling `stopTask` internal so it doesn't trigger a second, conflicting reconciliation mid-drain.

3. **`availabilityZoneRebalancing` missing from ECS Service — perpetual Terraform diff.** This field (GA since 2024, defaults to `DISABLED`) was entirely absent from the service surface, so a fresh `terraform apply` was immediately followed by a non-empty `terraform plan` forever. Added to `driver.Service`/`CreateServiceInput`/`UpdateServiceInput` and wired through the wire request/response shapes (always emitted, matching real AWS never omitting it).

## Black-box re-verification (aws-cli against a freshly rebuilt binary, `serve -aws-port 14752 -providers=aws`)

- `list-clusters` on empty cluster set → `{"clusterArns": []}`
- `create-service --desired-count 2` → `availabilityZoneRebalancing: DISABLED`
- `stop-task` on a service-owned task → `describe-services` immediately reports `[desiredCount, runningCount, pendingCount] = [2, 2, 0]` again (replacement launched), and `list-tasks --desired-status RUNNING` confirms exactly 2 live tasks
- `delete-service` without scaling to 0 → `InvalidParameterException` guard; after `update-service --desired-count 0`, delete succeeds and does not relaunch a replacement (drain doesn't double-reconcile)
- `delete-cluster` with an active service → `ClusterContainsServicesException`

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers/aws/ecs/... ./server/aws/ecs/... ./services/ecs/... ./persist/... -race -count=1`
- [x] `go test ./providers/aws/... ./server/aws/... -count=1`
- [x] `gofmt -l` clean on changed files
- [x] `golangci-lint run --new-from-rev=origin/development ./providers/aws/ecs/... ./server/aws/ecs/... ./services/ecs/...` — 0 issues
- [x] `go generate ./...` — no diff to `docs/coverage`
- [x] `go mod tidy` — no-op
- [x] Black-box re-verified all 3 fixes via real aws-cli against a rebuilt binary (see above)