### PR TITLE
fix(azure-cosmosdb): real-user e2e divergences

### DIFF
--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -89,6 +89,32 @@ func (m *Mock) SetTableAttributes(table string, attrs driver.AccountAttributes) 
 	m.accountAttrs[table] = attrs
 }
 
+// UpdateTableAttributes atomically applies fn to a table's stored Cosmos-account
+// attributes (Azure databaseAccounts PATCH — DatabaseAccountsClient.Update),
+// seeding the common defaults (GlobalDocumentDB/Standard offer) first if none
+// were set yet. Routed through the same mutex as Set/Get rather than a
+// Get-then-Set pair, so a concurrent PATCH/create can never lose an update.
+func (m *Mock) UpdateTableAttributes(
+	_ context.Context, table string, fn func(driver.AccountAttributes) driver.AccountAttributes,
+) (driver.AccountAttributes, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.accountAttrs == nil {
+		m.accountAttrs = make(map[string]driver.AccountAttributes)
+	}
+
+	cur, ok := m.accountAttrs[table]
+	if !ok {
+		cur = driver.AccountAttributes{Kind: "GlobalDocumentDB", OfferType: "Standard"}
+	}
+
+	updated := fn(cur)
+	m.accountAttrs[table] = updated
+
+	return updated, nil
+}
+
 // AccountTables returns the names of tables that have been registered as Cosmos
 // DB accounts (i.e. had account attributes seeded through SetTableAttributes),
 // sorted for a deterministic listing. Data-plane containers, which never carry

--- a/server/azure/cosmosaccount/account_update_test.go
+++ b/server/azure/cosmosaccount/account_update_test.go
@@ -1,0 +1,127 @@
+// Real-user e2e regression test: PATCH .../databaseAccounts/{name}
+// (DatabaseAccountsClient.BeginUpdate) was not routed at all — the handler's
+// ServeHTTP only handled PUT/GET/DELETE, so any real armcosmos client calling
+// Update (the path Terraform's azurerm_cosmosdb_account takes to change tags
+// or consistency without a full re-create) got a 405. These tests drive the
+// real armcosmos BeginUpdate LRO end-to-end and pin down the fix: PATCH is a
+// non-destructive partial update — only submitted fields change, tags are a
+// full replace (not a merge) when present, and immutable fields (kind) are
+// left untouched.
+package cosmosaccount_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSDKDatabaseAccountUpdateTags drives BeginUpdate to change tags only,
+// asserting the new tags fully replace the old set (not merge) and that
+// unrelated fields (kind, location) survive untouched.
+func TestSDKDatabaseAccountUpdateTags(t *testing.T) {
+	ctx := context.Background()
+	client := newDatabaseAccountsClient(t)
+
+	poller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "cosmos-upd", armcosmos.DatabaseAccountCreateUpdateParameters{
+		Location: to.Ptr("eastus"),
+		Kind:     to.Ptr(armcosmos.DatabaseAccountKindGlobalDocumentDB),
+		Properties: &armcosmos.DatabaseAccountCreateUpdateProperties{
+			DatabaseAccountOfferType: to.Ptr("Standard"),
+			Locations: []*armcosmos.Location{
+				{LocationName: to.Ptr("eastus"), FailoverPriority: to.Ptr[int32](0)},
+			},
+		},
+		Tags: map[string]*string{"env": to.Ptr("staging"), "owner": to.Ptr("team-a")},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	updPoller, err := client.BeginUpdate(ctx, "rg-1", "cosmos-upd", armcosmos.DatabaseAccountUpdateParameters{
+		Tags: map[string]*string{"env": to.Ptr("prod")},
+	}, nil)
+	require.NoError(t, err)
+
+	updated, err := updPoller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, updated.Tags["env"])
+	assert.Equal(t, "prod", *updated.Tags["env"])
+	// PATCH tags is a full replace, not a merge: "owner" must be gone.
+	assert.NotContains(t, updated.Tags, "owner")
+
+	require.NotNil(t, updated.Kind)
+	assert.Equal(t, armcosmos.DatabaseAccountKindGlobalDocumentDB, *updated.Kind)
+	require.NotNil(t, updated.Location)
+	assert.Equal(t, "eastus", *updated.Location)
+
+	// ... and the change survives an independent GET.
+	got, err := client.Get(ctx, "rg-1", "cosmos-upd", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.Tags["env"])
+	assert.Equal(t, "prod", *got.Tags["env"])
+	assert.NotContains(t, got.Tags, "owner")
+}
+
+// TestSDKDatabaseAccountUpdateConsistencyPolicy drives BeginUpdate to change
+// only the consistency policy, asserting it round-trips and a field omitted
+// from the PATCH body (tags) is preserved rather than reset to empty.
+func TestSDKDatabaseAccountUpdateConsistencyPolicy(t *testing.T) {
+	ctx := context.Background()
+	client := newDatabaseAccountsClient(t)
+
+	poller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "cosmos-upd-cp", armcosmos.DatabaseAccountCreateUpdateParameters{
+		Location: to.Ptr("westus2"),
+		Properties: &armcosmos.DatabaseAccountCreateUpdateProperties{
+			DatabaseAccountOfferType: to.Ptr("Standard"),
+			Locations: []*armcosmos.Location{
+				{LocationName: to.Ptr("westus2"), FailoverPriority: to.Ptr[int32](0)},
+			},
+		},
+		Tags: map[string]*string{"keep": to.Ptr("me")},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	updPoller, err := client.BeginUpdate(ctx, "rg-1", "cosmos-upd-cp", armcosmos.DatabaseAccountUpdateParameters{
+		Properties: &armcosmos.DatabaseAccountUpdateProperties{
+			ConsistencyPolicy: &armcosmos.ConsistencyPolicy{
+				DefaultConsistencyLevel: to.Ptr(armcosmos.DefaultConsistencyLevelStrong),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	updated, err := updPoller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, updated.Properties)
+	require.NotNil(t, updated.Properties.ConsistencyPolicy)
+	require.NotNil(t, updated.Properties.ConsistencyPolicy.DefaultConsistencyLevel)
+	assert.Equal(t, armcosmos.DefaultConsistencyLevelStrong, *updated.Properties.ConsistencyPolicy.DefaultConsistencyLevel)
+
+	// Tags were not part of this PATCH, so they must survive unchanged.
+	require.NotNil(t, updated.Tags["keep"])
+	assert.Equal(t, "me", *updated.Tags["keep"])
+}
+
+// TestSDKDatabaseAccountUpdateMissing asserts PATCHing a nonexistent account
+// 404s rather than silently creating one (PATCH is update-only, unlike PUT's
+// create-or-update).
+func TestSDKDatabaseAccountUpdateMissing(t *testing.T) {
+	ctx := context.Background()
+	client := newDatabaseAccountsClient(t)
+
+	// The emulator answers the initial PATCH synchronously (200/404, no async
+	// 202), so BeginUpdate's own initial request — not a later poll — is where
+	// the 404 surfaces.
+	_, err := client.BeginUpdate(ctx, "rg-1", "does-not-exist", armcosmos.DatabaseAccountUpdateParameters{
+		Tags: map[string]*string{"env": to.Ptr("prod")},
+	}, nil)
+	require.Error(t, err)
+}

--- a/server/azure/cosmosaccount/handler.go
+++ b/server/azure/cosmosaccount/handler.go
@@ -52,6 +52,12 @@ type attrBackend interface {
 	// returns only accounts and never the data-plane SQL containers that share
 	// this driver.
 	AccountTables() []string
+	// UpdateTableAttributes atomically applies fn to a table's stored
+	// attributes, backing PATCH (partial update — only the submitted fields
+	// change) without a racy read-then-write pair.
+	UpdateTableAttributes(
+		ctx context.Context, table string, fn func(dbdriver.AccountAttributes) dbdriver.AccountAttributes,
+	) (dbdriver.AccountAttributes, error)
 }
 
 // AccountPurger tears down a deleted account's full footprint in one step: its
@@ -124,6 +130,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.createOrUpdate(w, r, &rp)
 	case http.MethodGet:
 		h.get(w, r, &rp)
+	case http.MethodPatch:
+		h.update(w, r, &rp)
 	case http.MethodDelete:
 		h.deleteAccount(w, r, &rp)
 	default:
@@ -236,6 +244,87 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp *azurearm.Resou
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), requestBaseURL(r), rp))
+}
+
+// update serves PATCH .../databaseAccounts/{name} (DatabaseAccountsClient.
+// BeginUpdate), a non-destructive partial update: only the fields present in
+// the request body change — tags (full replace, matching how every other PATCH
+// handler in this codebase treats tags), consistencyPolicy, locations,
+// capabilities, and enableMultipleWriteLocations — everything else, including
+// kind (which real Azure's DatabaseAccountUpdateParameters has no field for;
+// it is immutable after creation), is preserved. The mutation runs through
+// attrBackend's atomic UpdateTableAttributes rather than a read-then-write
+// pair, so a concurrent PATCH never loses an update.
+//
+// Update is a long-running operation in real Azure; the emulator completes it
+// synchronously by returning 200 with the resource body inline so the SDK's
+// LRO poller terminates on the first response.
+func (h *Handler) update(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if _, err := h.db.DescribeTable(r.Context(), rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	var body armAccountUpdate
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	if h.attrs != nil {
+		if _, err := h.attrs.UpdateTableAttributes(r.Context(), rp.ResourceName, func(
+			cur dbdriver.AccountAttributes,
+		) dbdriver.AccountAttributes {
+			applyAccountUpdate(&cur, &body)
+
+			return cur
+		}); err != nil {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, h.toARMAccount(r.Context(), requestBaseURL(r), rp))
+}
+
+// applyAccountUpdate merges the fields present on a PATCH body onto cur in
+// place, leaving every field the request omitted untouched. Slice/pointer
+// fields use a nil check (not a length/zero check) to tell "omitted" apart
+// from "present but empty", so e.g. an explicit empty capabilities array can
+// still clear the account's capabilities.
+func applyAccountUpdate(cur *dbdriver.AccountAttributes, body *armAccountUpdate) {
+	if body.Tags != nil {
+		cur.Tags = body.Tags
+	}
+
+	if body.Location != "" {
+		cur.Location = body.Location
+	}
+
+	if body.Properties == nil {
+		return
+	}
+
+	p := body.Properties
+
+	if p.Capabilities != nil {
+		cur.Capabilities = capabilityNames(p.Capabilities)
+	}
+
+	if p.Locations != nil {
+		cur.Locations = toAccountLocations(p.Locations)
+	}
+
+	if p.EnableMultipleWriteLocations != nil {
+		cur.EnableMultipleWriteLocations = *p.EnableMultipleWriteLocations
+	}
+
+	if p.ConsistencyPolicy != nil {
+		cur.ConsistencyPolicy = dbdriver.ConsistencyPolicy{
+			DefaultConsistencyLevel: p.ConsistencyPolicy.DefaultConsistencyLevel,
+			MaxIntervalInSeconds:    p.ConsistencyPolicy.MaxIntervalInSeconds,
+			MaxStalenessPrefix:      p.ConsistencyPolicy.MaxStalenessPrefix,
+		}
+	}
 }
 
 // list serves the collection paths: GET .../databaseAccounts (subscription) and

--- a/server/azure/cosmosaccount/types.go
+++ b/server/azure/cosmosaccount/types.go
@@ -32,6 +32,27 @@ type armCapability struct {
 	Name string `json:"name,omitempty"`
 }
 
+// armAccountUpdate is the ARM databaseAccounts PATCH body
+// (DatabaseAccountUpdateParameters). Unlike armAccountCreate, every field must
+// be optional and distinguishable from "not present" on decode — real Azure's
+// update type has no "kind" field at all (kind is immutable after create), and
+// EnableMultipleWriteLocations/ConsistencyPolicy/etc. use pointers here so a
+// PATCH that omits them doesn't reset them.
+type armAccountUpdate struct {
+	Location   string                 `json:"location,omitempty"`
+	Tags       map[string]string      `json:"tags,omitempty"`
+	Properties *armAccountUpdateProps `json:"properties,omitempty"`
+}
+
+// armAccountUpdateProps is the settable subset of
+// DatabaseAccountUpdateProperties the emulator tracks.
+type armAccountUpdateProps struct {
+	Capabilities                 []armCapability       `json:"capabilities,omitempty"`
+	Locations                    []armLocation         `json:"locations,omitempty"`
+	EnableMultipleWriteLocations *bool                 `json:"enableMultipleWriteLocations,omitempty"`
+	ConsistencyPolicy            *armConsistencyPolicy `json:"consistencyPolicy,omitempty"`
+}
+
 // armAccount is the ARM databaseAccounts wire shape returned on create/get.
 type armAccount struct {
 	ID         string            `json:"id,omitempty"`


### PR DESCRIPTION
## Summary

Real-user black-box audit of the Azure Cosmos DB surface (ARM account plane, ARM SQL sqlDatabases/containers plane, and the data plane) driven with the real `azure-sdk-for-go` (`armcosmos/v3` + `azcosmos`) against a live `cloudemu serve -providers=azure` instance.

Found and fixed one real, IaC-blocking divergence:

- **`PATCH .../databaseAccounts/{name}` (`DatabaseAccountsClient.BeginUpdate`) was not routed at all** — the account handler's `ServeHTTP` only handled PUT/GET/DELETE, so any PATCH (the path Terraform's `azurerm_cosmosdb_account` takes to update tags/consistency policy without a full account recreate) returned `405 MethodNotAllowed`. Every other ARM account-shaped handler in the codebase (storage accounts, Key Vault, cache, MySQL flex, ...) already supports PATCH — Cosmos accounts was the one left behind.
  - Added PATCH routing + a non-destructive partial-update handler: only the fields present in the request change (tags — full replace, matching the codebase's established tags-replace-not-merge convention; consistencyPolicy; locations; capabilities; enableMultipleWriteLocations). `kind` is correctly left un-patchable, matching real Azure (`DatabaseAccountUpdateParameters` has no `kind` field).
  - Backed by a new atomic `UpdateTableAttributes` method on the cosmosdb `Mock` (mirrors `blobstorage.Mock.UpdateBucketAttributes`), so a concurrent PATCH/create can never lose an update.

Also confirmed during the audit that the ARM `sqlDatabases`/`containers` control plane (`azurerm_cosmosdb_sql_database`/`azurerm_cosmosdb_sql_container`'s IaC surface) is **already implemented and working** — a stale note suggested this was data-plane-only, which is no longer true.

## Test plan

- [x] `go build ./...`
- [x] `go test ./server/azure/cosmosaccount/... ./server/azure/cosmosdb/... ./providers/azure/cosmosdb/... -race` — all pass
- [x] `gofmt`, `go vet ./...` clean
- [x] `golangci-lint run` on touched packages — 0 new issues (7 pre-existing baseline issues unchanged)
- [x] `go generate ./...` — no `docs/coverage` diff
- [x] Black-box re-verify: a scratch driver using the real `armcosmos`/`azcosmos` SDKs against a live `cloudemu serve` binary confirmed `BeginUpdate` now returns 200, tags fully replace (not merge), `kind`/`location` are preserved, and the change survives an independent `Get` — before the fix this failed with 405
- [x] Regression tests added: `TestSDKDatabaseAccountUpdateTags`, `TestSDKDatabaseAccountUpdateConsistencyPolicy`, `TestSDKDatabaseAccountUpdateMissing` in `server/azure/cosmosaccount/account_update_test.go`