### PR TITLE
fix(secretsmanager): real-user e2e divergences from AWS

### DIFF
--- a/internal/idgen/idgen.go
+++ b/internal/idgen/idgen.go
@@ -49,19 +49,28 @@ const suffixAlphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123
 // secretARNSuffixLen is the length of the ARN suffix AWS appends.
 const secretARNSuffixLen = 6
 
-// SecretARNSuffix derives a deterministic 6-character alphanumeric suffix from
-// seed, matching the trailing "-XXXXXX" AWS adds to a Secrets Manager ARN. It is
-// deterministic per seed so the same secret keeps a stable ARN across a run
-// (and under a FakeClock), while distinct secrets get distinct suffixes.
-func SecretARNSuffix(seed string) string {
-	h := fnv.New64a()
-	_, _ = h.Write([]byte(seed))
-	n := h.Sum64()
-
+// SecretARNSuffix returns a fresh random 6-character alphanumeric suffix,
+// matching the trailing "-XXXXXX" AWS adds to a Secrets Manager ARN's resource
+// segment. Real Secrets Manager draws a new suffix on every CreateSecret call —
+// including when a secret is deleted and recreated under the same name — so
+// the old ARN never accidentally resolves to the new secret; callers must
+// generate it once at creation time and persist the resulting ARN (it is not
+// re-derivable from the name). It draws from crypto/rand; a random source
+// failure falls back to an all-'a' suffix so the function never panics.
+func SecretARNSuffix() string {
 	out := make([]byte, secretARNSuffixLen)
-	for i := range out {
-		out[i] = suffixAlphabet[n%uint64(len(suffixAlphabet))]
-		n /= uint64(len(suffixAlphabet))
+
+	b := make([]byte, secretARNSuffixLen)
+	if _, err := rand.Read(b); err != nil {
+		for i := range out {
+			out[i] = suffixAlphabet[0]
+		}
+
+		return string(out)
+	}
+
+	for i, v := range b {
+		out[i] = suffixAlphabet[int(v)%len(suffixAlphabet)]
 	}
 
 	return string(out)

--- a/internal/idgen/idgen_test.go
+++ b/internal/idgen/idgen_test.go
@@ -196,11 +196,8 @@ func TestUUID(t *testing.T) {
 }
 
 func TestSecretARNSuffix(t *testing.T) {
-	// Deterministic per seed.
-	assert.Equal(t, SecretARNSuffix("my-secret"), SecretARNSuffix("my-secret"))
-
 	// Six alphanumeric characters.
-	suffix := SecretARNSuffix("us-east-1:123456789012:db")
+	suffix := SecretARNSuffix()
 	require.Len(t, suffix, 6)
 
 	for _, c := range suffix {
@@ -208,6 +205,8 @@ func TestSecretARNSuffix(t *testing.T) {
 		assert.True(t, isAlnum, "suffix char %q must be alphanumeric", c)
 	}
 
-	// Distinct seeds generally differ.
-	assert.NotEqual(t, SecretARNSuffix("secret-a"), SecretARNSuffix("secret-b"))
+	// Fresh per call (real Secrets Manager draws a new suffix on every
+	// CreateSecret, including a recreate under the same name), so two calls
+	// almost never collide.
+	assert.NotEqual(t, SecretARNSuffix(), SecretARNSuffix())
 }

--- a/providers/aws/secretsmanager/secretsmanager.go
+++ b/providers/aws/secretsmanager/secretsmanager.go
@@ -163,23 +163,16 @@ func (m *Mock) CreateSecret(ctx context.Context, cfg driver.SecretConfig, value 
 	}
 
 	if existing, ok := m.secrets.Get(cfg.Name); ok {
-		existing.mu.RLock()
-		scheduledForDeletion := !existing.deletedAt.IsZero()
-		existing.mu.RUnlock()
-
-		if scheduledForDeletion {
-			return nil, errors.New(errors.FailedPrecondition,
-				"a secret with this name is already scheduled for deletion")
-		}
-
-		return nil, errors.Newf(errors.AlreadyExists, "secret %q already exists", cfg.Name)
+		return m.createSecretConflict(ctx, existing, cfg, value)
 	}
 
 	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
-	// The ARN resource segment ends with a deterministic 6-char suffix
-	// (:secret:<name>-<suffix>), matching real Secrets Manager. resolveSecretID
-	// on the wire side strips it, so lookups by the friendly name still resolve.
-	suffix := idgen.SecretARNSuffix(m.opts.Region + ":" + m.opts.AccountID + ":" + cfg.Name)
+	// The ARN resource segment ends with a fresh random 6-char suffix
+	// (:secret:<name>-<suffix>), matching real Secrets Manager: a secret deleted
+	// and recreated under the same name gets a different ARN, so a reference to
+	// the old ARN never resolves to the new secret. resolveSecretID on the wire
+	// side strips it, so lookups by the friendly name still resolve.
+	suffix := idgen.SecretARNSuffix()
 	arn := idgen.AWSARN("secretsmanager", m.opts.Region, m.opts.AccountID, "secret:"+cfg.Name+"-"+suffix)
 
 	tags := make(map[string]string, len(cfg.Tags))
@@ -226,6 +219,66 @@ func (m *Mock) CreateSecret(ctx context.Context, cfg driver.SecretConfig, value 
 	m.secrets.Set(cfg.Name, sd)
 
 	result := info
+
+	return &result, nil
+}
+
+// createSecretConflict handles CreateSecret when a secret already exists under
+// cfg.Name: a retry sharing the same ClientRequestToken and content as the
+// existing secret's initial version is an idempotent no-op (see
+// idempotentCreateSecret); otherwise it reports the name collision, as
+// FailedPrecondition when the existing secret is scheduled for deletion and
+// AlreadyExists otherwise.
+func (m *Mock) createSecretConflict(
+	ctx context.Context, existing *secretData, cfg driver.SecretConfig, value []byte, //nolint:gocritic // hugeParam
+) (*driver.SecretInfo, error) {
+	existing.mu.Lock()
+	scheduledForDeletion := !existing.deletedAt.IsZero()
+
+	// A retry of this same CreateSecret call — the same ClientRequestToken
+	// naming the secret's already-created initial version — is a no-op that
+	// returns the existing secret rather than erroring, matching real Secrets
+	// Manager's SDK-retry-safety contract (the whole reason a client token
+	// exists: a lost response must not turn a successful create into a hard
+	// failure on retry).
+	if !scheduledForDeletion && cfg.ClientRequestToken != "" {
+		if ver, found := existing.versionByID(cfg.ClientRequestToken); found {
+			info, err := m.idempotentCreateSecret(ctx, existing, ver, value)
+			existing.mu.Unlock()
+
+			return info, err
+		}
+	}
+
+	existing.mu.Unlock()
+
+	if scheduledForDeletion {
+		return nil, errors.New(errors.FailedPrecondition,
+			"a secret with this name is already scheduled for deletion")
+	}
+
+	return nil, errors.Newf(errors.AlreadyExists, "secret %q already exists", cfg.Name)
+}
+
+// idempotentCreateSecret handles a CreateSecret call whose ClientRequestToken
+// names a version that already exists on the secret found under the requested
+// name (i.e. a retried CreateSecret): with identical content it returns the
+// existing secret unchanged (idempotent no-op); with different content the
+// existing version can't be modified in place, so it reports the same
+// AlreadyExists a plain name collision would. Callers must hold existing.mu.
+func (m *Mock) idempotentCreateSecret(
+	ctx context.Context, existing *secretData, ver *driver.SecretVersion, value []byte,
+) (*driver.SecretInfo, error) {
+	existingPlain, err := m.decrypt(ctx, ver.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	if !bytes.Equal(existingPlain, value) {
+		return nil, errors.Newf(errors.AlreadyExists, "secret %q already exists", existing.info.Name)
+	}
+
+	result := existing.info
 
 	return &result, nil
 }

--- a/providers/aws/secretsmanager/staging.go
+++ b/providers/aws/secretsmanager/staging.go
@@ -365,6 +365,16 @@ func (m *Mock) RotateSecret(
 			"secret is scheduled for deletion, so this operation is not allowed")
 	}
 
+	// A secret that has never had a rotation Lambda configured, and whose
+	// caller didn't supply one in this call, can't rotate: real Secrets
+	// Manager rejects it rather than silently advancing the version with
+	// nothing to actually generate a new value.
+	if rotationLambdaARN == "" && sd.rotationLambdaARN == "" {
+		return nil, errors.New(errors.FailedPrecondition,
+			"you tried to enable rotation on a secret that doesn't already have a Lambda function ARN configured "+
+				"and you didn't include such an ARN as a parameter in this call")
+	}
+
 	now := m.opts.Clock.Now().UTC()
 	sd.applyRotationConfig(rotationLambdaARN, rules, now)
 

--- a/server/aws/secretsmanager/lifecycle_test.go
+++ b/server/aws/secretsmanager/lifecycle_test.go
@@ -3,6 +3,7 @@ package secretsmanager_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -168,6 +169,7 @@ func TestSDKRotateSecret(t *testing.T) {
 
 	rot, err := client.RotateSecret(ctx, &awssm.RotateSecretInput{
 		SecretId: aws.String("torotate"), RotateImmediately: aws.Bool(true),
+		RotationLambdaARN: aws.String("arn:aws:lambda:us-east-1:123456789012:function:rotate"),
 	})
 	if err != nil {
 		t.Fatalf("RotateSecret: %v", err)
@@ -228,6 +230,41 @@ func TestSDKRotateSecretConfig(t *testing.T) {
 
 	if desc.NextRotationDate == nil {
 		t.Fatal("NextRotationDate is nil with AutomaticallyAfterDays set")
+	}
+}
+
+// TestSDKRotateSecretRequiresLambdaARN guards a real-user e2e finding:
+// RotateSecret on a secret that has never had a rotation Lambda configured,
+// and whose call doesn't supply one either, is rejected — real Secrets
+// Manager refuses to advance the version with nothing to actually generate a
+// new value. Supplying the ARN in the same call (first-time configure) still
+// works.
+func TestSDKRotateSecretRequiresLambdaARN(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("rotnolambda"), SecretString: aws.String("v"),
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	_, err := client.RotateSecret(ctx, &awssm.RotateSecretInput{
+		SecretId: aws.String("rotnolambda"), RotateImmediately: aws.Bool(true),
+	})
+
+	var invalid *smtypes.InvalidRequestException
+	if !errors.As(err, &invalid) {
+		t.Fatalf("RotateSecret with no lambda ever configured: got %v, want InvalidRequestException", err)
+	}
+
+	// Supplying RotationLambdaARN in the same call configures it and succeeds.
+	if _, err := client.RotateSecret(ctx, &awssm.RotateSecretInput{
+		SecretId:          aws.String("rotnolambda"),
+		RotationLambdaARN: aws.String("arn:aws:lambda:us-east-1:123456789012:function:rotate"),
+		RotateImmediately: aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("RotateSecret with RotationLambdaARN supplied: %v", err)
 	}
 }
 

--- a/server/aws/secretsmanager/operations.go
+++ b/server/aws/secretsmanager/operations.go
@@ -372,6 +372,15 @@ func (h *Handler) putSecretValue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Real Secrets Manager requires exactly one of SecretString/SecretBinary —
+	// PutSecretValue exists only to add a new version's content.
+	if req.SecretString == "" && len(req.SecretBinary) == 0 {
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"InvalidParameterException", "You must provide a value for either SecretString or SecretBinary")
+
+		return
+	}
+
 	name := resolveSecretID(req.SecretID)
 
 	info, err := h.secrets.GetSecret(r.Context(), name)

--- a/server/aws/secretsmanager/sdk_roundtrip_test.go
+++ b/server/aws/secretsmanager/sdk_roundtrip_test.go
@@ -299,6 +299,28 @@ func TestSDKSecretErrors(t *testing.T) {
 	}
 }
 
+// TestSDKPutSecretValueRequiresPayload guards a real-user e2e finding:
+// PutSecretValue with neither SecretString nor SecretBinary set must be
+// rejected — real Secrets Manager requires exactly one, since the whole point
+// of the call is to add a new version's content.
+func TestSDKPutSecretValueRequiresPayload(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("emptyput"), SecretString: aws.String("v1"),
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	_, err := client.PutSecretValue(ctx, &awssm.PutSecretValueInput{SecretId: aws.String("emptyput")})
+
+	var invalid *smtypes.InvalidParameterException
+	if !errors.As(err, &invalid) {
+		t.Fatalf("PutSecretValue with no payload: got %v, want InvalidParameterException", err)
+	}
+}
+
 // TestSDKGetResourcePolicy guards the read path the aws_secretsmanager_secret
 // resource uses: GetResourcePolicy must return the secret's ARN/Name and no
 // ResourcePolicy (none is modeled), which the SDK reads as "no policy".

--- a/server/aws/secretsmanager/staging_versioning_test.go
+++ b/server/aws/secretsmanager/staging_versioning_test.go
@@ -89,6 +89,69 @@ func TestSDKClientRequestTokenIdempotent(t *testing.T) {
 	}
 }
 
+// TestSDKCreateSecretClientRequestTokenIdempotent guards a real-user e2e
+// finding: a CreateSecret call retried with the same ClientRequestToken and
+// identical content (e.g. an SDK auto-retry after a lost response) must be a
+// no-op that returns the already-created secret, not ResourceExistsException —
+// the whole reason the client token exists is to make CreateSecret safe to
+// retry. Retrying with the same token but different content must still fail,
+// since the already-created version can't be modified in place.
+func TestSDKCreateSecretClientRequestTokenIdempotent(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	const token = "22222222-2222-2222-2222-222222222222"
+
+	first, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("create-idem"), SecretString: aws.String("v1"),
+		ClientRequestToken: aws.String(token),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret(first): %v", err)
+	}
+
+	// Retry: same name, same token, same content -> idempotent no-op, same ARN
+	// and VersionId.
+	second, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("create-idem"), SecretString: aws.String("v1"),
+		ClientRequestToken: aws.String(token),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret(retry): %v", err)
+	}
+
+	if aws.ToString(second.ARN) != aws.ToString(first.ARN) {
+		t.Fatalf("retry ARN = %q, want the original %q", aws.ToString(second.ARN), aws.ToString(first.ARN))
+	}
+
+	if aws.ToString(second.VersionId) != token {
+		t.Fatalf("retry VersionId = %q, want the ClientRequestToken %q", aws.ToString(second.VersionId), token)
+	}
+
+	// Only one version was created (the retry did not append a second).
+	list, err := client.ListSecretVersionIds(ctx, &awssm.ListSecretVersionIdsInput{
+		SecretId: aws.String("create-idem"), IncludeDeprecated: aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("ListSecretVersionIds: %v", err)
+	}
+
+	if len(list.Versions) != 1 {
+		t.Fatalf("version count = %d, want 1 (idempotent retry did not add a version)", len(list.Versions))
+	}
+
+	// Same token, different content: a genuine conflict, still ResourceExistsException.
+	_, err = client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("create-idem"), SecretString: aws.String("different"),
+		ClientRequestToken: aws.String(token),
+	})
+
+	var exists *smtypes.ResourceExistsException
+	if !errors.As(err, &exists) {
+		t.Fatalf("reused token + different content: got %v, want ResourceExistsException", err)
+	}
+}
+
 // TestSDKVersionIdIsUUID guards F9: version ids are 36-char UUIDs, not counter
 // ids.
 func TestSDKVersionIdIsUUID(t *testing.T) {
@@ -371,6 +434,50 @@ func TestSDKSecretARNSuffixResolvesByName(t *testing.T) {
 
 	if aws.ToString(byARN.SecretString) != "v" {
 		t.Fatalf("value by ARN = %q, want v", aws.ToString(byARN.SecretString))
+	}
+}
+
+// TestSDKRecreatedSecretGetsFreshARN guards a real-user e2e finding: real
+// Secrets Manager draws a new random ARN suffix on every CreateSecret, so a
+// secret force-deleted and recreated under the same name gets a different ARN
+// (the whole point of the suffix — an old ARN a caller cached, e.g. in an IAM
+// policy or Terraform state, must never resolve to the unrelated new secret).
+func TestSDKRecreatedSecretGetsFreshARN(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	first, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("recreate-me"), SecretString: aws.String("v1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret(first): %v", err)
+	}
+
+	if _, err := client.DeleteSecret(ctx, &awssm.DeleteSecretInput{
+		SecretId: aws.String("recreate-me"), ForceDeleteWithoutRecovery: aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+
+	second, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name: aws.String("recreate-me"), SecretString: aws.String("v2"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret(second): %v", err)
+	}
+
+	if aws.ToString(first.ARN) == aws.ToString(second.ARN) {
+		t.Fatalf("recreated secret kept the same ARN %q, want a fresh suffix", aws.ToString(second.ARN))
+	}
+
+	// The new secret is reachable by its own fresh ARN.
+	byNewARN, err := client.GetSecretValue(ctx, &awssm.GetSecretValueInput{SecretId: second.ARN})
+	if err != nil {
+		t.Fatalf("GetSecretValue(new ARN): %v", err)
+	}
+
+	if aws.ToString(byNewARN.SecretString) != "v2" {
+		t.Fatalf("value by new ARN = %q, want v2", aws.ToString(byNewARN.SecretString))
 	}
 }
 


### PR DESCRIPTION
## Summary

Deep black-box real-user e2e audit of AWS Secrets Manager (aws-cli + aws-sdk-go-v2 + Terraform against a running `cloudemu serve`), driving the full secret + version-staging-label lifecycle (AWSCURRENT/AWSPREVIOUS/AWSPENDING), soft-delete/restore, and rotation config. Four genuine divergences found and fixed; one larger cross-cutting gap filed but not fixed.

- **CreateSecret ARN uniqueness**: the ARN's 6-char suffix was derived deterministically from `region:account:name`, so force-deleting a secret and recreating it under the same name produced the *identical* ARN. Real Secrets Manager draws a fresh random suffix on every `CreateSecret` specifically so a cached old ARN (IAM policy, Terraform state, env var) can never resolve to the new, unrelated secret. `idgen.SecretARNSuffix()` now draws from `crypto/rand` per call.
- **CreateSecret ClientRequestToken idempotency**: a retried `CreateSecret` call (same token, same content — e.g. an SDK auto-retry after a lost response) returned `ResourceExistsException` instead of the existing secret. `PutSecretValue` already implements this contract; `CreateSecret` now does too.
- **RotateSecret without a configured Lambda**: rotating a secret that has never had a `RotationLambdaARN` (and none supplied in the call) silently advanced the version instead of the documented `InvalidRequestException`.
- **PutSecretValue with no payload**: a call with neither `SecretString` nor `SecretBinary` silently created an empty version instead of `InvalidParameterException`.

## Filed, not fixed

`resolveSecretID` accepts any ARN-shaped `SecretId` with the right name prefix and strips the suffix without checking it matches the live secret's actual ARN (no secondary index by ARN). After the ARN-uniqueness fix above, a stale ARN cached from before a force-delete+recreate now silently resolves to the new secret instead of `ResourceNotFoundException`. Fixing this correctly touches ~14 call sites across the handler and is scoped as its own PR.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -race` (full repo, clean)
- [x] `golangci-lint run --timeout=9m` on touched packages (0 issues)
- [x] `gofmt -l` clean
- [x] `go generate ./...` — no `docs/coverage` drift
- [x] Regression test per fix (`TestSDKRecreatedSecretGetsFreshARN`, `TestSDKCreateSecretClientRequestTokenIdempotent`, `TestSDKRotateSecretRequiresLambdaARN`, `TestSDKPutSecretValueRequiresPayload`)
- [x] Each fix re-verified black-box against a rebuilt `cloudemu serve` binary via aws-cli, including a full Terraform `aws_secretsmanager_secret`/`aws_secretsmanager_secret_version` apply → plan (no diff) → destroy → recreate cycle confirming the new ARN