### PR TITLE
fix(eventbridge): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/eventbridge/eventbridge.go
+++ b/providers/aws/eventbridge/eventbridge.go
@@ -2,6 +2,7 @@
 package eventbridge
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
@@ -172,12 +173,13 @@ func (m *Mock) CreateEventBus(_ context.Context, cfg driver.EventBusConfig) (*dr
 	}
 
 	info := driver.EventBusInfo{
-		Name:      cfg.Name,
-		Scope:     cfg.Scope,
-		ARN:       busARN,
-		State:     activeBusState,
-		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
-		Tags:      tags,
+		Name:        cfg.Name,
+		Scope:       cfg.Scope,
+		ARN:         busARN,
+		State:       activeBusState,
+		CreatedAt:   m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:        tags,
+		Description: cfg.Description,
 	}
 
 	bd := &busData{
@@ -263,10 +265,17 @@ func (m *Mock) PutRule(_ context.Context, cfg *driver.RuleConfig) (*driver.Rule,
 	// typo'd pattern (e.g. a non-array leaf) would store "successfully" and then
 	// silently match nothing, so targets never fire — the worst failure mode for
 	// an event-driven app.
-	if cfg.EventPattern != "" {
-		if err := eventmatch.ValidatePattern(cfg.EventPattern); err != nil {
+	pattern := cfg.EventPattern
+	if pattern != "" {
+		if err := eventmatch.ValidatePattern(pattern); err != nil {
 			return nil, errors.New(errors.InvalidArgument, err.Error())
 		}
+		// Real EventBridge normalizes the stored pattern to compact JSON (no
+		// insignificant whitespace), so DescribeRule/ListRules echo it back
+		// reformatted rather than verbatim. compactPattern falls back to the
+		// original string on error, but ValidatePattern above already proved
+		// it's well-formed JSON.
+		pattern = compactPattern(pattern)
 	}
 
 	state := cfg.State
@@ -278,7 +287,7 @@ func (m *Mock) PutRule(_ context.Context, cfg *driver.RuleConfig) (*driver.Rule,
 		Name:               cfg.Name,
 		EventBus:           busName,
 		Description:        cfg.Description,
-		EventPattern:       cfg.EventPattern,
+		EventPattern:       pattern,
 		ScheduleExpression: cfg.ScheduleExpression,
 		RoleARN:            cfg.RoleARN,
 		State:              state,
@@ -692,9 +701,12 @@ func (m *Mock) reservedVars(rule *driver.Rule, event *driver.Event, envelope []b
 }
 
 // ruleARN builds the EventBridge rule ARN, matching the wire handler's format.
+// Real EventBridge omits the bus segment for a rule on the default bus
+// ("arn:...:rule/<rule>") and includes it only for a custom-bus rule
+// ("arn:...:rule/<bus>/<rule>") — see the PutRule API's sample response.
 func (m *Mock) ruleARN(bus, rule string) string {
-	if bus == "" {
-		bus = defaultBusName
+	if bus == "" || bus == defaultBusName {
+		return "arn:aws:events:" + m.opts.Region + ":" + m.opts.AccountID + ":rule/" + rule
 	}
 
 	return "arn:aws:events:" + m.opts.Region + ":" + m.opts.AccountID + ":rule/" + bus + "/" + rule
@@ -809,6 +821,20 @@ func generateEventID(event *driver.Event, now time.Time, index int) string {
 	hash := sha256.Sum256([]byte(data))
 
 	return fmt.Sprintf("%x", hash[:16])
+}
+
+// compactPattern strips insignificant whitespace from an event pattern JSON
+// string, matching real EventBridge's normalization of the stored pattern
+// (DescribeRule/ListRules echo it back compacted, not verbatim). Key order is
+// preserved — json.Compact only removes whitespace, it does not re-encode or
+// reorder. Falls back to the original string if it isn't valid JSON.
+func compactPattern(pattern string) string {
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, []byte(pattern)); err != nil {
+		return pattern
+	}
+
+	return buf.String()
 }
 
 // matchesPattern reports whether an event satisfies an EventBridge event

--- a/server/aws/eventbridge/event_bus_arn_param_sdk_test.go
+++ b/server/aws/eventbridge/event_bus_arn_param_sdk_test.go
@@ -1,0 +1,122 @@
+package eventbridge_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+)
+
+// TestSDKEventBridgeBusARNAcceptedByDescribeEventBus verifies that
+// DescribeEventBus's Name parameter accepts the bus's ARN, not just its bare
+// name (busNameOrDefault in server/aws/eventbridge/types.go).
+func TestSDKEventBridgeBusARNAcceptedByDescribeEventBus(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateEventBus(ctx, &awseb.CreateEventBusInput{Name: aws.String("arn-param-bus")})
+	if err != nil {
+		t.Fatalf("CreateEventBus: %v", err)
+	}
+
+	busARN := aws.ToString(created.EventBusArn)
+	if busARN == "" {
+		t.Fatal("CreateEventBus returned empty ARN")
+	}
+
+	desc, err := client.DescribeEventBus(ctx, &awseb.DescribeEventBusInput{Name: aws.String(busARN)})
+	if err != nil {
+		t.Fatalf("DescribeEventBus(ARN): %v", err)
+	}
+
+	if got := aws.ToString(desc.Name); got != "arn-param-bus" {
+		t.Fatalf("DescribeEventBus(ARN) resolved name = %q, want arn-param-bus", got)
+	}
+
+	if got := aws.ToString(desc.Arn); got != busARN {
+		t.Fatalf("DescribeEventBus(ARN) arn = %q, want %q", got, busARN)
+	}
+}
+
+// TestSDKEventBridgeBusARNAcceptedByPutRule verifies that PutRule's
+// EventBusName parameter accepts the bus's ARN, matching real EventBridge's
+// "The name or ARN of the event bus" contract for EventBusName-shaped params.
+func TestSDKEventBridgeBusARNAcceptedByPutRule(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateEventBus(ctx, &awseb.CreateEventBusInput{Name: aws.String("rule-arn-param-bus")})
+	if err != nil {
+		t.Fatalf("CreateEventBus: %v", err)
+	}
+
+	busARN := aws.ToString(created.EventBusArn)
+
+	if _, err := client.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventBusName: aws.String(busARN),
+		EventPattern: aws.String(`{"source":["app"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule(EventBusName=ARN): %v", err)
+	}
+
+	// The rule must be visible when listing rules on the bus by its plain
+	// name — i.e. it resolved to the same bus, not a distinct one keyed by
+	// the literal ARN string.
+	rules, err := client.ListRules(ctx, &awseb.ListRulesInput{EventBusName: aws.String("rule-arn-param-bus")})
+	if err != nil {
+		t.Fatalf("ListRules: %v", err)
+	}
+
+	if len(rules.Rules) != 1 || aws.ToString(rules.Rules[0].Name) != "r" {
+		t.Fatalf("ListRules(by name) = %+v, want one rule %q", rules.Rules, "r")
+	}
+}
+
+// TestSDKEventBridgeBusARNAcceptedByPutTargetsAndPutEvents verifies that
+// PutTargets and PutEvents accept the bus ARN in their EventBusName
+// parameter, and that doing so reaches the same bus as the plain name (a rule
+// created on the plain name receives events published via the ARN).
+func TestSDKEventBridgeBusARNAcceptedByPutTargetsAndPutEvents(t *testing.T) {
+	eb, sqs := newEBAndSQS(t)
+	ctx := context.Background()
+
+	created, err := eb.CreateEventBus(ctx, &awseb.CreateEventBusInput{Name: aws.String("targets-events-arn-bus")})
+	if err != nil {
+		t.Fatalf("CreateEventBus: %v", err)
+	}
+
+	busARN := aws.ToString(created.EventBusArn)
+
+	url, arn := makeQueue(t, sqs, "eb-arn-param-target")
+
+	if _, err := eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventBusName: aws.String("targets-events-arn-bus"),
+		EventPattern: aws.String(`{"source":["app"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	// PutTargets addresses the bus by ARN.
+	if _, err := eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule:         aws.String("r"),
+		EventBusName: aws.String(busARN),
+		Targets:      []ebtypes.Target{{Id: aws.String("1"), Arn: aws.String(arn)}},
+	}); err != nil {
+		t.Fatalf("PutTargets(EventBusName=ARN): %v", err)
+	}
+
+	// PutEvents also addresses the bus by ARN.
+	if _, err := eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("app"), DetailType: aws.String("t"), Detail: aws.String(`{}`), EventBusName: aws.String(busARN)},
+	}}); err != nil {
+		t.Fatalf("PutEvents(EventBusName=ARN): %v", err)
+	}
+
+	if _, count := receiveOne(t, sqs, url); count != 1 {
+		t.Fatalf("delivered %d messages, want 1 (bus ARN must resolve to the same bus as its name)", count)
+	}
+}

--- a/server/aws/eventbridge/event_bus_description_sdk_test.go
+++ b/server/aws/eventbridge/event_bus_description_sdk_test.go
@@ -1,0 +1,70 @@
+package eventbridge_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+)
+
+// TestSDKEventBridgeEventBusDescriptionRoundTrips verifies that a bus's
+// Description survives past the CreateEventBus response — it must also be
+// returned by DescribeEventBus and ListEventBuses, not just echoed back on
+// creation.
+func TestSDKEventBridgeEventBusDescriptionRoundTrips(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	const wantDescription = "orders event bus for the checkout service"
+
+	if _, err := client.CreateEventBus(ctx, &awseb.CreateEventBusInput{
+		Name:        aws.String("described-bus"),
+		Description: aws.String(wantDescription),
+	}); err != nil {
+		t.Fatalf("CreateEventBus: %v", err)
+	}
+
+	desc, err := client.DescribeEventBus(ctx, &awseb.DescribeEventBusInput{Name: aws.String("described-bus")})
+	if err != nil {
+		t.Fatalf("DescribeEventBus: %v", err)
+	}
+
+	if got := aws.ToString(desc.Description); got != wantDescription {
+		t.Fatalf("DescribeEventBus Description = %q, want %q", got, wantDescription)
+	}
+
+	list, err := client.ListEventBuses(ctx, &awseb.ListEventBusesInput{NamePrefix: aws.String("described-bus")})
+	if err != nil {
+		t.Fatalf("ListEventBuses: %v", err)
+	}
+
+	if len(list.EventBuses) != 1 {
+		t.Fatalf("ListEventBuses = %+v, want exactly one bus", list.EventBuses)
+	}
+
+	if got := aws.ToString(list.EventBuses[0].Description); got != wantDescription {
+		t.Fatalf("ListEventBuses Description = %q, want %q", got, wantDescription)
+	}
+}
+
+// TestSDKEventBridgeEventBusWithoutDescription verifies that a bus created
+// without a Description reports an empty one on Describe/List, rather than
+// echoing back the wrong value or erroring.
+func TestSDKEventBridgeEventBusWithoutDescription(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateEventBus(ctx, &awseb.CreateEventBusInput{Name: aws.String("undescribed-bus")}); err != nil {
+		t.Fatalf("CreateEventBus: %v", err)
+	}
+
+	desc, err := client.DescribeEventBus(ctx, &awseb.DescribeEventBusInput{Name: aws.String("undescribed-bus")})
+	if err != nil {
+		t.Fatalf("DescribeEventBus: %v", err)
+	}
+
+	if got := aws.ToString(desc.Description); got != "" {
+		t.Fatalf("DescribeEventBus Description = %q, want empty", got)
+	}
+}

--- a/server/aws/eventbridge/operations.go
+++ b/server/aws/eventbridge/operations.go
@@ -137,7 +137,7 @@ func (h *Handler) putRule(w http.ResponseWriter, r *http.Request) {
 
 	rule, err := h.bus.PutRule(r.Context(), &ebdriver.RuleConfig{
 		Name:               req.Name,
-		EventBus:           req.EventBusName,
+		EventBus:           busNameOrDefault(req.EventBusName),
 		Description:        req.Description,
 		EventPattern:       req.EventPattern,
 		ScheduleExpression: req.ScheduleExpression,

--- a/server/aws/eventbridge/operations.go
+++ b/server/aws/eventbridge/operations.go
@@ -29,8 +29,9 @@ func (h *Handler) createEventBus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	info, err := h.bus.CreateEventBus(r.Context(), ebdriver.EventBusConfig{
-		Name: req.Name,
-		Tags: tagsToMap(req.Tags),
+		Name:        req.Name,
+		Tags:        tagsToMap(req.Tags),
+		Description: req.Description,
 	})
 	if err != nil {
 		writeErr(w, err)
@@ -58,6 +59,7 @@ func (h *Handler) describeEventBus(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, describeEventBusResponse{
 		Arn:          info.ARN,
 		Name:         info.Name,
+		Description:  info.Description,
 		CreationTime: epochSeconds(info.CreatedAt),
 		Policy:       info.Policy,
 	})
@@ -84,6 +86,7 @@ func (h *Handler) listEventBuses(w http.ResponseWriter, r *http.Request) {
 		entries = append(entries, eventBusEntry{
 			Arn:          infos[i].ARN,
 			Name:         infos[i].Name,
+			Description:  infos[i].Description,
 			CreationTime: epochSeconds(infos[i].CreatedAt),
 		})
 	}
@@ -350,6 +353,7 @@ func (h *Handler) putEvents(w http.ResponseWriter, r *http.Request) {
 			Detail:     e.Detail,
 			EventBus:   busNameOrDefault(e.EventBusName),
 			Resources:  e.Resources,
+			Time:       entryTime(e.Time),
 		})
 	}
 

--- a/server/aws/eventbridge/put_events_time_sdk_test.go
+++ b/server/aws/eventbridge/put_events_time_sdk_test.go
@@ -1,0 +1,131 @@
+package eventbridge_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+)
+
+// TestSDKEventBridgePutEventsEntryTimeHonored verifies that a caller-supplied
+// PutEvents entry Time is threaded through to delivery: the delivered
+// envelope's "time" field must carry the backdated timestamp the caller
+// supplied, not the time of the PutEvents call. Before the fix, the wire
+// handler dropped the entry's Time entirely, so every delivered event carried
+// the call's own timestamp regardless of what the caller set.
+func TestSDKEventBridgePutEventsEntryTimeHonored(t *testing.T) {
+	eb, sqs := newEBAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := makeQueue(t, sqs, "eb-entry-time")
+
+	if _, err := eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventPattern: aws.String(`{"source":["app"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule:    aws.String("r"),
+		Targets: []ebtypes.Target{{Id: aws.String("1"), Arn: aws.String(arn)}},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	// A timestamp far in the past — nothing close to "now" — so honoring it
+	// is unambiguous even if the server clock drifts.
+	backdated := time.Date(2019, 6, 15, 8, 30, 0, 0, time.UTC)
+
+	if _, err := eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{
+			Source:     aws.String("app"),
+			DetailType: aws.String("t"),
+			Detail:     aws.String(`{}`),
+			Time:       aws.Time(backdated),
+		},
+	}}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	body, count := receiveOne(t, sqs, url)
+	if count != 1 {
+		t.Fatalf("delivered %d messages, want 1", count)
+	}
+
+	var env struct {
+		Time string `json:"time"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("envelope not JSON: %v (%s)", err, body)
+	}
+
+	gotTime, err := time.Parse(time.RFC3339, env.Time)
+	if err != nil {
+		t.Fatalf("envelope time %q not RFC3339: %v", env.Time, err)
+	}
+
+	if !gotTime.Equal(backdated) {
+		t.Fatalf("delivered envelope time = %s, want the caller-supplied %s (not PutEvents call time)",
+			gotTime, backdated)
+	}
+}
+
+// TestSDKEventBridgePutEventsOmittedTimeDefaultsToNow verifies the converse:
+// omitting Time still defaults to the PutEvents call's own time (never the
+// zero time), so the fix didn't regress the no-Time case.
+func TestSDKEventBridgePutEventsOmittedTimeDefaultsToNow(t *testing.T) {
+	eb, sqs := newEBAndSQS(t)
+	ctx := context.Background()
+
+	url, arn := makeQueue(t, sqs, "eb-no-entry-time")
+
+	if _, err := eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventPattern: aws.String(`{"source":["app"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule:    aws.String("r"),
+		Targets: []ebtypes.Target{{Id: aws.String("1"), Arn: aws.String(arn)}},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	before := time.Now().Add(-time.Minute)
+
+	if _, err := eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("app"), DetailType: aws.String("t"), Detail: aws.String(`{}`)},
+	}}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	after := time.Now().Add(time.Minute)
+
+	body, count := receiveOne(t, sqs, url)
+	if count != 1 {
+		t.Fatalf("delivered %d messages, want 1", count)
+	}
+
+	var env struct {
+		Time string `json:"time"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("envelope not JSON: %v (%s)", err, body)
+	}
+
+	gotTime, err := time.Parse(time.RFC3339, env.Time)
+	if err != nil {
+		t.Fatalf("envelope time %q not RFC3339: %v", env.Time, err)
+	}
+
+	if gotTime.Before(before) || gotTime.After(after) {
+		t.Fatalf("envelope time = %s, want within [%s, %s] (the PutEvents call time)", gotTime, before, after)
+	}
+}

--- a/server/aws/eventbridge/rule_arn_sdk_test.go
+++ b/server/aws/eventbridge/rule_arn_sdk_test.go
@@ -1,0 +1,203 @@
+package eventbridge_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// ruleARNTestAccountID and ruleARNTestRegion are threaded explicitly into
+// Drivers so the tests below can assert against an exact ARN string — the
+// package's other helpers (e.g. newEventBridgeClient) leave AccountID/Region
+// blank, which is fine for existence checks but not for exact-format ones.
+const (
+	ruleARNTestAccountID = "123456789012"
+	ruleARNTestRegion    = "us-east-1"
+)
+
+// newEBClientWithIdentity returns an EventBridge client backed by a server
+// with a fixed account ID and region, for exact-ARN assertions.
+func newEBClientWithIdentity(t *testing.T) *awseb.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{
+		EventBridge: cloud.EventBridge,
+		AccountID:   ruleARNTestAccountID,
+		Region:      ruleARNTestRegion,
+	})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion(ruleARNTestRegion),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return awseb.NewFromConfig(cfg, func(o *awseb.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+}
+
+// newEBAndSQSWithIdentity is like newEBAndSQS (delivery_sdk_test.go) but with
+// a fixed account ID and region, for tests that need to inspect an exact ARN
+// carried through delivery (e.g. the <aws.events.rule-arn> reserved
+// variable).
+func newEBAndSQSWithIdentity(t *testing.T) (*awseb.Client, *awssqs.Client) {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{
+		EventBridge: cloud.EventBridge,
+		SQS:         cloud.SQS,
+		AccountID:   ruleARNTestAccountID,
+		Region:      ruleARNTestRegion,
+	})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion(ruleARNTestRegion),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	eb := awseb.NewFromConfig(cfg, func(o *awseb.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+	sqs := awssqs.NewFromConfig(cfg, func(o *awssqs.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+
+	return eb, sqs
+}
+
+// TestSDKEventBridgeDefaultBusRuleARNOmitsBusSegment verifies that a rule on
+// the (implicit) default bus gets an ARN with no bus segment:
+// "arn:aws:events:<region>:<account>:rule/<rule>", not
+// "arn:aws:events:<region>:<account>:rule/default/<rule>".
+func TestSDKEventBridgeDefaultBusRuleARNOmitsBusSegment(t *testing.T) {
+	client := newEBClientWithIdentity(t)
+	ctx := context.Background()
+
+	rule, err := client.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("implicit-default"),
+		EventPattern: aws.String(`{"source":["app"]}`),
+	})
+	if err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	want := "arn:aws:events:us-east-1:123456789012:rule/implicit-default"
+	if got := aws.ToString(rule.RuleArn); got != want {
+		t.Fatalf("RuleArn = %q, want %q (no /default/ segment)", got, want)
+	}
+}
+
+// TestSDKEventBridgeExplicitDefaultBusRuleARNOmitsBusSegment is the same as
+// above but with EventBusName explicitly set to "default" — the fix's
+// bus == defaultBusName branch, distinct from the bus == "" branch.
+func TestSDKEventBridgeExplicitDefaultBusRuleARNOmitsBusSegment(t *testing.T) {
+	client := newEBClientWithIdentity(t)
+	ctx := context.Background()
+
+	rule, err := client.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("explicit-default"),
+		EventBusName: aws.String("default"),
+		EventPattern: aws.String(`{"source":["app"]}`),
+	})
+	if err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	want := "arn:aws:events:us-east-1:123456789012:rule/explicit-default"
+	if got := aws.ToString(rule.RuleArn); got != want {
+		t.Fatalf("RuleArn = %q, want %q (no /default/ segment)", got, want)
+	}
+}
+
+// TestSDKEventBridgeCustomBusRuleARNIncludesBusSegment verifies a rule on a
+// custom (non-default) bus still gets the bus segment in its ARN.
+func TestSDKEventBridgeCustomBusRuleARNIncludesBusSegment(t *testing.T) {
+	client := newEBClientWithIdentity(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateEventBus(ctx, &awseb.CreateEventBusInput{Name: aws.String("orders-bus")}); err != nil {
+		t.Fatalf("CreateEventBus: %v", err)
+	}
+
+	rule, err := client.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("on-custom-bus"),
+		EventBusName: aws.String("orders-bus"),
+		EventPattern: aws.String(`{"source":["app"]}`),
+	})
+	if err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	want := "arn:aws:events:us-east-1:123456789012:rule/orders-bus/on-custom-bus"
+	if got := aws.ToString(rule.RuleArn); got != want {
+		t.Fatalf("RuleArn = %q, want %q", got, want)
+	}
+}
+
+// TestSDKEventBridgeReservedRuleARNVarOmitsBusSegment guards the driver-side
+// ruleARN (providers/aws/eventbridge/eventbridge.go), which is exercised via
+// the <aws.events.rule-arn> reserved transformer variable rather than any API
+// response field. A default-bus rule's delivered rule-arn must carry no
+// "/default/" segment.
+func TestSDKEventBridgeReservedRuleARNVarOmitsBusSegment(t *testing.T) {
+	eb, sqs := newEBAndSQSWithIdentity(t)
+	ctx := context.Background()
+
+	url, arn := makeQueue(t, sqs, "eb-rule-arn-var")
+
+	if _, err := eb.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventPattern: aws.String(`{"source":["app"]}`),
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := eb.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule: aws.String("r"),
+		Targets: []ebtypes.Target{{
+			Id:  aws.String("1"),
+			Arn: aws.String(arn),
+			InputTransformer: &ebtypes.InputTransformer{
+				InputTemplate: aws.String(`"<aws.events.rule-arn>"`),
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	if _, err := eb.PutEvents(ctx, &awseb.PutEventsInput{Entries: []ebtypes.PutEventsRequestEntry{
+		{Source: aws.String("app"), DetailType: aws.String("t"), Detail: aws.String(`{"state":"ok"}`)},
+	}}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	body, count := receiveOne(t, sqs, url)
+	if count != 1 {
+		t.Fatalf("delivered %d messages, want 1", count)
+	}
+
+	want := "arn:aws:events:us-east-1:123456789012:rule/r"
+	if body != want {
+		t.Fatalf("delivered aws.events.rule-arn = %s, want %s (no /default/ segment)", body, want)
+	}
+}

--- a/server/aws/eventbridge/types.go
+++ b/server/aws/eventbridge/types.go
@@ -3,6 +3,7 @@ package eventbridge
 import (
 	"encoding/json"
 	"sort"
+	"strings"
 	"time"
 
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
@@ -93,6 +94,10 @@ type putEventsEntry struct {
 	Detail       string   `json:"Detail"`
 	EventBusName string   `json:"EventBusName"`
 	Resources    []string `json:"Resources"`
+	// Time is the caller-supplied event timestamp (Unix epoch seconds, the AWS
+	// JSON protocol's timestamp wire form). Real EventBridge uses the time of
+	// the PutEvents call when omitted, matching a nil pointer here.
+	Time *float64 `json:"Time"`
 }
 
 type putEventsRequest struct {
@@ -194,11 +199,22 @@ type testEventPatternResponse struct {
 
 // --- helpers ---
 
+// eventBusARNInfix is the fixed segment separating an event bus ARN's account
+// ID from the bus name, e.g. "arn:aws:events:us-east-1:123456789012:event-bus/my-bus".
+const eventBusARNInfix = ":event-bus/"
+
 // busNameOrDefault resolves an optional EventBusName to the driver-facing bus
-// name, mirroring the driver's default-bus behavior.
+// name, mirroring the driver's default-bus behavior. Real EventBridge accepts
+// either the bus name or its ARN in every EventBusName-shaped parameter (see
+// e.g. the DescribeEventBus API's Name parameter: "The name or ARN of the
+// event bus..."), so an ARN is resolved to the bus name it references.
 func busNameOrDefault(name string) string {
 	if name == "" {
 		return defaultBusName
+	}
+
+	if idx := strings.LastIndex(name, eventBusARNInfix); idx != -1 {
+		return name[idx+len(eventBusARNInfix):]
 	}
 
 	return name
@@ -230,12 +246,14 @@ func epochSeconds(iso string) float64 {
 
 // ruleARN synthesizes an EventBridge rule ARN. The driver's Rule carries no
 // ARN, so we derive a stable identifier the SDK can round-trip. Real
-// EventBridge rule ARNs are "arn:aws:events:<region>:<account>:rule/<bus>/<rule>";
-// region/account aren't threaded into this handler, so they're left as
-// placeholders that keep the ARN shape recognizable.
+// EventBridge omits the bus segment for a rule on the default bus
+// ("arn:aws:events:<region>:<account>:rule/<rule>") and includes it only for
+// a custom-bus rule ("arn:aws:events:<region>:<account>:rule/<bus>/<rule>") —
+// see the PutRule API's sample response, which has no bus segment for a
+// default-bus rule.
 func (h *Handler) ruleARN(bus, rule string) string {
-	if bus == "" {
-		bus = defaultBusName
+	if bus == "" || bus == defaultBusName {
+		return "arn:aws:events:" + h.region + ":" + h.accountID + ":rule/" + rule
 	}
 
 	return "arn:aws:events:" + h.region + ":" + h.accountID + ":rule/" + bus + "/" + rule
@@ -288,6 +306,18 @@ func isValidDetail(detail string) bool {
 	var obj map[string]json.RawMessage
 
 	return json.Unmarshal([]byte(detail), &obj) == nil
+}
+
+// entryTime converts a PutEvents entry's optional wire-form timestamp (Unix
+// epoch seconds) to a time.Time. A nil entry (the caller omitted Time) yields
+// the zero time, which the driver defaults to the PutEvents call's own time —
+// matching real EventBridge's "if no time stamp is provided" behavior.
+func entryTime(epochSeconds *float64) time.Time {
+	if epochSeconds == nil {
+		return time.Time{}
+	}
+
+	return time.Unix(int64(*epochSeconds), 0).UTC()
 }
 
 func toTargetJSON(t *ebdriver.Target) targetJSON {

--- a/services/eventbus/driver/driver.go
+++ b/services/eventbus/driver/driver.go
@@ -32,6 +32,11 @@ type EventBusInfo struct {
 	// and surfaced on DescribeEventBus. Empty when the bus has no policy, and for
 	// Azure and GCP.
 	Policy string
+	// Description is the caller-supplied free-text description of the event
+	// bus (EventBridge CreateEventBus's Description, echoed back on
+	// DescribeEventBus/ListEventBuses). Empty when none was set, and for
+	// Azure and GCP.
+	Description string
 }
 
 // PermissionCondition is an optional condition on an EventBridge event-bus
@@ -74,6 +79,9 @@ type EventBusConfig struct {
 	// public network (Azure Event Grid: "Enabled", "Disabled"). Empty for AWS
 	// and GCP, and for an Azure caller accepting the default.
 	PublicNetworkAccess string
+	// Description is the caller-supplied free-text description of the event
+	// bus (EventBridge CreateEventBus's Description). Empty for Azure and GCP.
+	Description string
 }
 
 // Rule defines an event routing rule with filtering.

--- a/services/eventbus/eventbus_test.go
+++ b/services/eventbus/eventbus_test.go
@@ -394,7 +394,8 @@ func TestGetRulePortable(t *testing.T) {
 	assert.Equal(t, "gr-bus", rule.EventBus)
 	assert.Equal(t, "test rule", rule.Description)
 	assert.Equal(t, "ENABLED", rule.State)
-	assert.Equal(t, `{"source": ["my.app"]}`, rule.EventPattern)
+	// EventPattern is stored compacted, matching real EventBridge normalization.
+	assert.Equal(t, `{"source":["my.app"]}`, rule.EventPattern)
 }
 
 func TestListRulesPortable(t *testing.T) {


### PR DESCRIPTION
Deep real-user e2e audit of AWS EventBridge (aws-cli + aws-sdk-go-v2 + Terraform against a running \`cloudemu serve\`). Four genuine divergences vs real AWS.

## Fixes
- **Default-bus rule ARN format** — \`ruleARN()\` always included the bus segment (\`rule/default/<rule>\`); real EventBridge omits it for default-bus rules (\`rule/<rule>\`), only custom-bus rules get the \`<bus>/\` prefix. Breaks IAM policy resource matching / ARN comparison.
- **Bus ARN accepted as EventBusName** — EventBusName-type params rejected the bus ARN form; real EventBridge accepts either the name or the ARN (common flow: store the ARN from CreateEventBus, pass it back into PutRule/PutTargets/PutEvents).
- **PutEvents entry Time** — the per-entry \`Time\` field was silently dropped; now honored (matters for event-time-based consumers).
- **EventBus Description** — accepted+echoed only on CreateEventBus; now persisted and echoed on DescribeEventBus/ListEventBuses. (Additive \`Description\` field on the shared eventbus driver structs — empty for Azure/GCP.)

EventPattern is now stored compacted, matching real EventBridge normalization (no Terraform perpetual diff — the aws provider uses JSON-equivalence diff suppression).

## Verified NOT bugs (checked against docs, not filed)
- A rule may carry BOTH EventPattern and ScheduleExpression (no XOR enforcement needed).

## Verification
\`go build ./...\`, \`go test ./providers/aws/eventbridge/... ./server/aws/eventbridge/... ./services/eventbus/... -race\`, \`gofmt\`, \`golangci-lint --new-from-rev\` (0 new) — all green. Shared eventbus driver change is additive (Description field).