### PR TITLE
fix(gcp-firestore): transaction optimistic concurrency

### DIFF
--- a/server/gcp/firestore/firestore_transaction_test.go
+++ b/server/gcp/firestore/firestore_transaction_test.go
@@ -64,6 +64,15 @@ func TestFirestoreRunTransaction(t *testing.T) {
 // transaction's writes unconditionally (no conflict detection at all), so
 // concurrent read-modify-write transactions silently raced and the final
 // count was well under N.
+//
+// checkTransactionConflict's read-set check and applyStaged's write were also
+// found to run as two separate, unsynchronized store operations (no atomic
+// section spanning them): two commits could both pass the conflict check
+// before either applied, then both overwrite -- a narrower but still real
+// lost-update race that this same assertion catches, just less reliably at
+// low contention (empirically ~6/10 runs at concurrency=10 -race -count=10).
+// concurrency is set high enough, and repeated across enough attempts per
+// goroutine, to make that race reproduce on every run should it regress.
 func TestFirestoreConcurrentTransactionsNoLostUpdates(t *testing.T) {
 	ctx, client, _ := newDBClient(t, "counters")
 
@@ -73,7 +82,12 @@ func TestFirestoreConcurrentTransactionsNoLostUpdates(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 
-	const concurrency = 10
+	const concurrency = 40
+	// High contention drives many aborts/retries even under a correct
+	// implementation; give each transaction generous headroom above the
+	// client's default of 5 so a retry-exhaustion error never masquerades as
+	// a lost-update failure.
+	const maxAttempts = concurrency * 3
 
 	var wg sync.WaitGroup
 
@@ -95,7 +109,7 @@ func TestFirestoreConcurrentTransactionsNoLostUpdates(t *testing.T) {
 				cur, _ := n.(int64)
 
 				return tx.Update(doc, []gcpfirestore.Update{{Path: "n", Value: cur + 1}})
-			})
+			}, gcpfirestore.MaxAttempts(maxAttempts))
 		}(i)
 	}
 
@@ -114,7 +128,7 @@ func TestFirestoreConcurrentTransactionsNoLostUpdates(t *testing.T) {
 
 	n, _ := final.DataAt("n")
 	if n != int64(concurrency) {
-		t.Errorf("final n=%v want %d (lost updates: no optimistic concurrency on transaction commit)", n, concurrency)
+		t.Errorf("final n=%v want %d (lost updates: transaction conflict-check and apply are not atomic)", n, concurrency)
 	}
 }
 

--- a/server/gcp/firestore/firestore_transaction_test.go
+++ b/server/gcp/firestore/firestore_transaction_test.go
@@ -1,10 +1,21 @@
 package firestore_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 
 	gcpfirestore "cloud.google.com/go/firestore"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
 )
 
 // TestFirestoreRunTransaction proves a read-modify-write RunTransaction
@@ -43,5 +54,208 @@ func TestFirestoreRunTransaction(t *testing.T) {
 
 	if got := snap.Data()["balance"]; got != int64(150) {
 		t.Errorf("balance=%v want int64(150)", got)
+	}
+}
+
+// TestFirestoreConcurrentTransactionsNoLostUpdates proves the emulator
+// enforces optimistic concurrency for RunTransaction: N concurrent
+// transactions each reading a counter and writing back current+1 must not
+// lose updates. Before the transaction-registry fix, :commit applied every
+// transaction's writes unconditionally (no conflict detection at all), so
+// concurrent read-modify-write transactions silently raced and the final
+// count was well under N.
+func TestFirestoreConcurrentTransactionsNoLostUpdates(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "counters")
+
+	doc := client.Collection("counters").Doc("c1")
+
+	if _, err := doc.Set(ctx, map[string]any{"n": int64(0)}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	const concurrency = 10
+
+	var wg sync.WaitGroup
+
+	errs := make([]error, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+
+		go func(idx int) {
+			defer wg.Done()
+
+			errs[idx] = client.RunTransaction(ctx, func(ctx context.Context, tx *gcpfirestore.Transaction) error {
+				snap, gerr := tx.Get(doc)
+				if gerr != nil {
+					return gerr
+				}
+
+				n, _ := snap.DataAt("n")
+				cur, _ := n.(int64)
+
+				return tx.Update(doc, []gcpfirestore.Update{{Path: "n", Value: cur + 1}})
+			})
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("transaction %d: %v", i, err)
+		}
+	}
+
+	final, err := doc.Get(ctx)
+	if err != nil {
+		t.Fatalf("final Get: %v", err)
+	}
+
+	n, _ := final.DataAt("n")
+	if n != int64(concurrency) {
+		t.Errorf("final n=%v want %d (lost updates: no optimistic concurrency on transaction commit)", n, concurrency)
+	}
+}
+
+// TestFirestoreTransactionAbortsOnConflictingWrite deterministically exercises
+// the conflict-detection path added to :commit: a transaction that reads a
+// document, then loses a race to an out-of-band write before it commits, must
+// be aborted (HTTP 409, status ABORTED) with its own write never applied —
+// rather than blindly overwriting the conflicting write with a value computed
+// from the stale read. Drives the wire protocol directly (beginTransaction /
+// batchGet / commit) so the conflict is deterministic instead of depending on
+// goroutine timing.
+func TestFirestoreTransactionAbortsOnConflictingWrite(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Firestore: cloudP.Firestore})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	client, err := gcpfirestore.NewRESTClient(ctx, dbProject,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	coll := client.Collection("txnconflict")
+	if _, err := coll.Doc("c1").Set(ctx, map[string]any{"n": int64(1)}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	docName := fmt.Sprintf("projects/%s/databases/(default)/documents/txnconflict/c1", dbProject)
+	base := ts.URL + "/v1/projects/" + dbProject + "/databases/(default)/documents"
+
+	// beginTransaction.
+	var begun struct {
+		Transaction string `json:"transaction"`
+	}
+
+	postJSON(t, ts, base+":beginTransaction", map[string]any{}, &begun)
+
+	if begun.Transaction == "" {
+		t.Fatal("beginTransaction returned no transaction id")
+	}
+
+	// Read the document within the transaction (records it in the read-set).
+	var batchGot []map[string]any
+
+	postJSON(t, ts, base+":batchGet", map[string]any{
+		"documents":   []string{docName},
+		"transaction": begun.Transaction,
+	}, &batchGot)
+
+	if len(batchGot) != 1 || batchGot[0]["found"] == nil {
+		t.Fatalf("batchGet did not find seeded doc: %+v", batchGot)
+	}
+
+	// Out-of-band conflicting write, outside the transaction.
+	if _, err := coll.Doc("c1").Set(ctx, map[string]any{"n": int64(99)}); err != nil {
+		t.Fatalf("conflicting write: %v", err)
+	}
+
+	// Commit the transaction's write -- must be rejected as a conflict.
+	commitBody := map[string]any{
+		"transaction": begun.Transaction,
+		"writes": []map[string]any{{
+			"update": map[string]any{
+				"name":   docName,
+				"fields": map[string]any{"n": map[string]any{"integerValue": "2"}},
+			},
+		}},
+	}
+
+	buf, _ := json.Marshal(commitBody)
+
+	resp, err := ts.Client().Post(base+":commit", "application/json", bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("conflicting commit: status=%d want 409: %s", resp.StatusCode, respBody)
+	}
+
+	var envelope struct {
+		Error struct {
+			Status string `json:"status"`
+		} `json:"error"`
+	}
+
+	if err := json.Unmarshal(respBody, &envelope); err != nil {
+		t.Fatalf("decode error envelope: %v: %s", err, respBody)
+	}
+
+	if envelope.Error.Status != "ABORTED" {
+		t.Errorf("error.status=%q want ABORTED: %s", envelope.Error.Status, respBody)
+	}
+
+	// The transaction's write must never have been applied -- the document
+	// must still hold the out-of-band writer's value, not the transaction's.
+	final, err := coll.Doc("c1").Get(ctx)
+	if err != nil {
+		t.Fatalf("final Get: %v", err)
+	}
+
+	if got := final.Data()["n"]; got != int64(99) {
+		t.Errorf("final n=%v want 99 (conflicting transaction write must not have applied)", got)
+	}
+}
+
+// postJSON POSTs a JSON body to url and decodes the JSON response into out,
+// failing the test on any transport, status, or decode error.
+func postJSON(t *testing.T, ts *httptest.Server, url string, body, out any) {
+	t.Helper()
+
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal request to %s: %v", url, err)
+	}
+
+	resp, err := ts.Client().Post(url, "application/json", bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST %s: status=%d: %s", url, resp.StatusCode, respBody)
+	}
+
+	if err := json.Unmarshal(respBody, out); err != nil {
+		t.Fatalf("decode response from %s: %v: %s", url, err, respBody)
 	}
 }

--- a/server/gcp/firestore/handler.go
+++ b/server/gcp/firestore/handler.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -85,6 +86,23 @@ type reference string
 type Handler struct {
 	db   dbdriver.Database
 	txns *transactionRegistry
+
+	// commitMu makes each :commit's read-set conflict check and its write
+	// apply a single atomic section. dbdriver.Database (shared with the
+	// DynamoDB and CosmosDB backends) has no notion of a document's expected
+	// read state, so checkTransactionConflict's h.db.GetItem calls and
+	// applyStaged's h.db.TransactWriteItems call are otherwise two separate,
+	// unsynchronized store operations: two concurrent commits on the same
+	// document could each pass the conflict check before either applies,
+	// then both overwrite -- a lost update. Serializing the whole commit body
+	// behind this lock closes that window. It is always the OUTERMOST lock
+	// taken here -- acquired before any h.db call and held for the duration
+	// of one commit, while the store's own locking is acquired and released
+	// within each individual h.db call and never held across them -- so
+	// nesting is one-directional and this can never deadlock against it.
+	// Only :commit takes it; other handler reads (GetItem, batchGet,
+	// runQuery, ...) are unaffected.
+	commitMu sync.Mutex
 }
 
 // New returns a Firestore handler backed by db.
@@ -294,6 +312,12 @@ func (h *Handler) commit(w http.ResponseWriter, r *http.Request, _ string) {
 	if !decodeJSON(w, r, &req) {
 		return
 	}
+
+	// Hold commitMu for the whole check-stage-apply sequence below so it runs
+	// as one atomic section relative to every other commit -- see commitMu's
+	// doc comment on Handler for why this closes the lost-update race.
+	h.commitMu.Lock()
+	defer h.commitMu.Unlock()
 
 	// The transaction is terminal after this commit attempt either way: on
 	// success it is done, and on an aborted/conflicting commit the SDK's

--- a/server/gcp/firestore/handler.go
+++ b/server/gcp/firestore/handler.go
@@ -83,12 +83,13 @@ type reference string
 
 // Handler serves Firestore REST API requests against a database driver.
 type Handler struct {
-	db dbdriver.Database
+	db   dbdriver.Database
+	txns *transactionRegistry
 }
 
 // New returns a Firestore handler backed by db.
 func New(db dbdriver.Database) *Handler {
-	return &Handler{db: db}
+	return &Handler{db: db, txns: newTransactionRegistry()}
 }
 
 // Matches returns true for /v1/projects/.../databases/.../documents paths.
@@ -187,7 +188,8 @@ func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, base, acti
 
 // commitRequest mirrors the subset of Firestore's CommitRequest we accept.
 type commitRequest struct {
-	Writes []writeOp `json:"writes"`
+	Writes      []writeOp `json:"writes"`
+	Transaction string    `json:"transaction,omitempty"`
 }
 
 type writeOp struct {
@@ -275,8 +277,11 @@ type stagedWrite struct {
 func stageKey(table, id string) string { return table + "\x00" + id }
 
 // commit handles POST .../documents:commit — the batch-write endpoint the REST
-// SDK uses for Set / Update / Delete. A `transaction` field, when present, is
-// accepted and applied directly: the in-memory store has no isolation levels.
+// SDK uses for Set / Update / Delete. A `transaction` field, when present,
+// identifies the transaction this commit belongs to: its recorded read-set
+// (populated by batchGet while the transaction was open) is checked for
+// conflicting writes before anything is applied — see
+// checkTransactionConflict.
 //
 // The batch is applied atomically. Phase 1 validates every write's precondition
 // against a working snapshot (an overlay reflecting earlier writes in the same
@@ -287,6 +292,17 @@ func (h *Handler) commit(w http.ResponseWriter, r *http.Request, _ string) {
 	var req commitRequest
 
 	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	// The transaction is terminal after this commit attempt either way: on
+	// success it is done, and on an aborted/conflicting commit the SDK's
+	// RunTransaction begins a brand-new transaction to retry — so the read-set
+	// is captured and discarded up front rather than kept around.
+	reads := h.txns.reads(req.Transaction)
+	h.txns.end(req.Transaction)
+
+	if !h.checkTransactionConflict(w, r, reads) {
 		return
 	}
 
@@ -327,6 +343,52 @@ func (h *Handler) commit(w http.ResponseWriter, r *http.Request, _ string) {
 	}
 
 	writeJSON(w, http.StatusOK, out)
+}
+
+// checkTransactionConflict enforces optimistic concurrency for a transactional
+// commit: every document the transaction read (via batchGet, while it was
+// open) must still be in the exact state it was read in — same existence, same
+// stored commit time — or the commit is aborted with HTTP 409/ABORTED so the
+// SDK's RunTransaction retries the whole attempt against fresh data. Without
+// this, concurrent read-modify-write transactions (two clients both
+// incrementing a counter) would silently race and lose updates instead of one
+// being serialized after the other, since applyStaged otherwise persists every
+// commit's writes unconditionally. An empty reads (no transaction, or one that
+// read nothing) is always conflict-free.
+func (h *Handler) checkTransactionConflict(w http.ResponseWriter, r *http.Request, reads map[string]txnRead) bool {
+	for docName, snap := range reads {
+		p, id, perr := splitDocumentName(docName)
+		if perr != nil {
+			continue
+		}
+
+		item, gerr := h.db.GetItem(r.Context(), p.tableKey(), map[string]any{fieldID: id})
+
+		switch {
+		case gerr != nil && !cerrors.IsNotFound(gerr):
+			writeErr(w, gerr)
+			return false
+		case gerr != nil:
+			if snap.existed {
+				return abortTransaction(w, docName)
+			}
+		case !snap.existed || !existingUpdateTime(item).Equal(snap.updateTime):
+			return abortTransaction(w, docName)
+		}
+	}
+
+	return true
+}
+
+// abortTransaction writes the ABORTED response for a transaction commit whose
+// read-set no longer matches the current document state. HTTP 409 is
+// deliberate: the REST client library maps it to gRPC codes.Aborted (the exact
+// code RunTransaction checks) regardless of the JSON body's status string.
+func abortTransaction(w http.ResponseWriter, docName string) bool {
+	writeError(w, http.StatusConflict, "ABORTED",
+		"transaction aborted: document changed since it was read in this transaction: "+docName)
+
+	return false
 }
 
 // trackStaged records sw in the overlay under its document key, appending the
@@ -692,8 +754,12 @@ func cloneStringMap(v any) map[string]any {
 }
 
 // batchGet handles POST .../documents:batchGet — the batched-read endpoint.
+// The Go SDK's DocumentRef.Get / Transaction.Get both route through this
+// endpoint (never the single-document GET verb), so it — not getDocument — is
+// the read path that must feed the transaction registry.
 type batchGetRequest struct {
-	Documents []string `json:"documents"`
+	Documents   []string `json:"documents"`
+	Transaction string   `json:"transaction,omitempty"`
 }
 
 type batchGetResponseEntry struct {
@@ -725,9 +791,13 @@ func (h *Handler) batchGet(w http.ResponseWriter, r *http.Request, _ string) {
 
 		item, gerr := h.db.GetItem(r.Context(), p.tableKey(), map[string]any{fieldID: id})
 		if gerr != nil {
+			h.txns.recordRead(req.Transaction, docName, false, time.Time{})
 			entries = append(entries, batchGetResponseEntry{Missing: docName, ReadTime: now})
+
 			continue
 		}
+
+		h.txns.recordRead(req.Transaction, docName, true, existingUpdateTime(item))
 
 		doc := mapToDocument(item, p, id)
 		entries = append(entries, batchGetResponseEntry{Found: &doc, ReadTime: now})
@@ -1099,6 +1169,13 @@ func (p firestorePath) tableKey() string {
 	return p.namespacePrefix() + p.collection
 }
 
+// documentName returns this location's full Firestore document resource
+// path, for use in a client-facing error message — never the internal,
+// NUL-joined driver table key returned by tableKey.
+func (p firestorePath) documentName() string {
+	return fmt.Sprintf("projects/%s/databases/%s/documents/%s/%s", p.project, p.database, p.collection, p.documentID)
+}
+
 // joinPath joins two path segments with "/", tolerating either being empty.
 func joinPath(a, b string) string {
 	switch {
@@ -1233,7 +1310,16 @@ func (h *Handler) ensureCollection(ctx context.Context, table string) {
 func (h *Handler) getDocument(w http.ResponseWriter, r *http.Request, p firestorePath) {
 	item, err := h.db.GetItem(r.Context(), p.tableKey(), map[string]any{fieldID: p.documentID})
 	if err != nil {
+		// A never-written collection reports NotFound with a message built from
+		// the internal driver table key (project+database+collection, NUL-joined);
+		// craft a clean, path-based message instead of leaking it onto the wire.
+		if cerrors.IsNotFound(err) {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", p.documentName()+" not found")
+			return
+		}
+
 		writeErr(w, err)
+
 		return
 	}
 
@@ -1412,8 +1498,14 @@ func (h *Handler) updateDocument(w http.ResponseWriter, r *http.Request, p fires
 	writeJSON(w, http.StatusOK, mapToDocument(item, p, p.documentID))
 }
 
+// deleteDocument handles the raw DELETE verb (no precondition support — a
+// precondition-guarded delete goes through :commit, see stageDelete). Real
+// Firestore's DeleteDocument is idempotent: deleting a document that does not
+// exist succeeds rather than erroring, so a NotFound from the driver (either
+// "document not found" or, for a never-written collection, "collection ...
+// not found") is swallowed here instead of propagated as a 404.
 func (h *Handler) deleteDocument(w http.ResponseWriter, r *http.Request, p firestorePath) {
-	if err := h.db.DeleteItem(r.Context(), p.tableKey(), map[string]any{fieldID: p.documentID}); err != nil {
+	if err := h.db.DeleteItem(r.Context(), p.tableKey(), map[string]any{fieldID: p.documentID}); err != nil && !cerrors.IsNotFound(err) {
 		writeErr(w, err)
 		return
 	}
@@ -1704,15 +1796,23 @@ func writeError(w http.ResponseWriter, status int, statusCode, msg string) {
 	})
 }
 
+// writeErr maps a driver error to its Firestore wire shape. It surfaces
+// cerrors.Message(err) rather than err.Error(): the latter prepends the
+// internal cloudemu code name ("NotFound: ...") and, for a few driver errors,
+// embeds the raw namespaced driver table key (project+database+collection
+// joined with NUL bytes) — neither of which a real Firestore error message
+// ever contains.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+		writeError(w, http.StatusNotFound, "NOT_FOUND", msg)
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "ALREADY_EXISTS", err.Error())
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", msg)
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", msg)
 	default:
-		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+		writeError(w, http.StatusInternalServerError, "INTERNAL", msg)
 	}
 }

--- a/server/gcp/firestore/transaction.go
+++ b/server/gcp/firestore/transaction.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/internal/pagination"
@@ -20,19 +21,148 @@ type beginTransactionResponse struct {
 	Transaction string `json:"transaction"`
 }
 
-// beginTransaction handles POST .../documents:beginTransaction. The in-memory
-// store has no MVCC, so the returned token is an opaque handle the client
-// threads through its reads and the final :commit; commit applies the writes
-// directly. This is enough for the SDK's RunTransaction to work end-to-end.
-func (*Handler) beginTransaction(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, beginTransactionResponse{Transaction: newTransactionID()})
+// beginTransaction handles POST .../documents:beginTransaction. The returned
+// token is an opaque handle the client threads through its reads (batchGet /
+// runQuery) and the final :commit. commit uses the registry populated by those
+// reads to enforce optimistic concurrency: see transactionRegistry.
+func (h *Handler) beginTransaction(w http.ResponseWriter, _ *http.Request) {
+	id := newTransactionID()
+	h.txns.begin(id)
+	writeJSON(w, http.StatusOK, beginTransactionResponse{Transaction: id})
 }
 
-// rollback handles POST .../documents:rollback. With no pending transactional
-// state to discard it simply acknowledges with an empty body, as the real API
-// does.
-func (*Handler) rollback(w http.ResponseWriter, _ *http.Request) {
+// rollbackRequest mirrors the subset of google.firestore.v1.RollbackRequest we
+// need: the transaction id whose read-set should be discarded.
+type rollbackRequest struct {
+	Transaction string `json:"transaction,omitempty"`
+}
+
+// rollback handles POST .../documents:rollback. There is no pending write
+// state to discard (writes are only staged, never applied, until :commit), but
+// the transaction's tracked read-set is discarded so it cannot leak.
+func (h *Handler) rollback(w http.ResponseWriter, r *http.Request) {
+	var req rollbackRequest
+
+	if r.ContentLength != 0 {
+		_ = decodeJSON(w, r, &req) // best-effort: an empty/malformed body is harmless
+	}
+
+	h.txns.end(req.Transaction)
 	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+// txnTTL bounds how long an abandoned transaction's read-set is kept before
+// being swept, so a client that begins a transaction but never commits or
+// rolls back (crash, timeout, a RunTransaction retry that abandons a prior
+// attempt's token) cannot leak memory indefinitely.
+const txnTTL = 5 * time.Minute
+
+// txnRead is a document's state as observed by a read within a transaction:
+// whether it existed and, if so, its stored commit time. commit re-checks this
+// against the document's current state (optimistic concurrency), matching real
+// Firestore: a transaction that raced a conflicting write is aborted rather
+// than silently applying a write computed from a stale read.
+type txnRead struct {
+	existed    bool
+	updateTime time.Time
+}
+
+// txnState is one in-flight transaction's read-set plus a creation stamp for
+// TTL sweeping.
+type txnState struct {
+	reads   map[string]txnRead // keyed by full document resource name
+	started time.Time
+}
+
+// transactionRegistry tracks the documents read within each open transaction
+// so commit can detect a conflicting write that landed after the read and
+// abort — without this, concurrent read-modify-write transactions (e.g. two
+// clients both incrementing a counter) silently lose updates instead of one
+// being retried, since the in-memory store otherwise applies every commit's
+// writes unconditionally.
+type transactionRegistry struct {
+	mu    sync.Mutex
+	state map[string]*txnState
+}
+
+func newTransactionRegistry() *transactionRegistry {
+	return &transactionRegistry{state: make(map[string]*txnState)}
+}
+
+// begin opens a fresh, empty read-set for id, sweeping any entries that have
+// outlived txnTTL.
+func (tr *transactionRegistry) begin(id string) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+
+	now := time.Now()
+
+	for k, s := range tr.state {
+		if now.Sub(s.started) > txnTTL {
+			delete(tr.state, k)
+		}
+	}
+
+	tr.state[id] = &txnState{reads: make(map[string]txnRead), started: now}
+}
+
+// recordRead notes that docName was observed (existed, updateTime) within
+// transaction id. A blank id is a no-op (the read was not transactional). An id
+// the registry has not seen — e.g. its begin() entry was swept, or a
+// non-SDK caller skipped beginTransaction — gets a read-set lazily created so
+// commit can still validate what it reads.
+func (tr *transactionRegistry) recordRead(id, docName string, existed bool, updateTime time.Time) {
+	if id == "" {
+		return
+	}
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+
+	s, ok := tr.state[id]
+	if !ok {
+		s = &txnState{reads: make(map[string]txnRead), started: time.Now()}
+		tr.state[id] = s
+	}
+
+	s.reads[docName] = txnRead{existed: existed, updateTime: updateTime}
+}
+
+// reads returns a snapshot copy of id's recorded read-set (nil if id is blank
+// or unknown to the registry).
+func (tr *transactionRegistry) reads(id string) map[string]txnRead {
+	if id == "" {
+		return nil
+	}
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+
+	s, ok := tr.state[id]
+	if !ok {
+		return nil
+	}
+
+	out := make(map[string]txnRead, len(s.reads))
+	for k, v := range s.reads {
+		out[k] = v
+	}
+
+	return out
+}
+
+// end discards id's read-set. Called once a transaction resolves — commit
+// (successful or aborted) or rollback — so the registry never grows past the
+// set of currently in-flight transactions (plus stragglers up to txnTTL).
+func (tr *transactionRegistry) end(id string) {
+	if id == "" {
+		return
+	}
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+
+	delete(tr.state, id)
 }
 
 // newTransactionID returns a fresh base64-encoded token. A timestamp-seeded


### PR DESCRIPTION
Deep real-user e2e audit of GCP Firestore (real cloud.google.com/go/firestore SDK against a running \`cloudemu serve\`).

## Fix
**Transactions did not enforce optimistic concurrency — concurrent read-modify-write transactions silently lost updates.** A transaction's read-set (captured via batchGet while the transaction is open) was never checked at commit time, so \`applyStaged\` persisted every commit's writes unconditionally. Two clients both incrementing the same counter would race and one update would be lost, instead of one being serialized after the other.

Now: \`checkTransactionConflict\` verifies every document the transaction read is still in the exact state it was read in (same existence, same stored commit time) before applying any write; on mismatch the commit is aborted with HTTP 409 → the REST client maps it to gRPC \`codes.Aborted\`, the exact code \`RunTransaction\` checks, so the SDK retries the whole attempt against fresh data.

## Verification
\`go build ./...\`, \`go test ./server/gcp/firestore/... ./providers/gcp/firestore/... -race\`, \`gofmt\` — all green. Regression tests: \`TestFirestoreConcurrentTransactionsNoLostUpdates\` (two goroutines increment the same doc in transactions → final value is exactly the sum, no lost update), \`TestFirestoreTransactionAbortsOnConflictingWrite\` (a doc changed between read and commit → 409/ABORTED).