### PR TITLE
fix(azure-sql): PATCH can clear elasticPoolId

### DIFF
--- a/server/azure/echo_properties.go
+++ b/server/azure/echo_properties.go
@@ -481,6 +481,25 @@ func sanitizeUnmodeled(v any) any {
 	}
 }
 
+// isZeroScalarJSON reports whether v is the JSON zero value for a scalar type:
+// null, "", false, or 0. Only scalars are classified — maps and slices always
+// return false here (an empty object/array is a much rarer "clear" signal and
+// is left to the existing verbatim-capture behavior).
+func isZeroScalarJSON(v any) bool {
+	switch t := v.(type) {
+	case nil:
+		return true
+	case string:
+		return t == ""
+	case bool:
+		return !t
+	case float64:
+		return t == 0
+	default:
+		return false
+	}
+}
+
 // missingProperties returns the entries of req that resp does not already carry,
 // descending into nested objects — and, element-by-element, into arrays of
 // objects — so an unmodeled leaf under a modeled parent (or under a modeled
@@ -502,6 +521,21 @@ func missingProperties(req, resp map[string]any) map[string]any {
 
 		respVal, present := resp[k]
 		if !present {
+			// A request scalar at its JSON zero value (null/""/false/0) that the
+			// response doesn't echo is far more likely a field the handler DOES
+			// model — and correctly dropped via omitempty because a PATCH just
+			// set it back to its default — than genuinely unmodeled data worth
+			// preserving. Azure SQL's PATCH-to-clear elasticPoolId (set it to ""
+			// to remove a database from its elastic pool) is exactly this shape:
+			// without this guard, the overlay "helpfully" re-injected the
+			// just-cleared "" back into every future response, resurrecting pool
+			// membership the request explicitly removed. A non-zero scalar or a
+			// populated object/array is still captured verbatim below — this
+			// only narrows the false-positive case of a zero scalar.
+			if isZeroScalarJSON(reqVal) {
+				continue
+			}
+
 			// A wholly-unmodeled object is captured verbatim, so strip any
 			// write-only secret nested inside it — the per-key skip above only
 			// covers keys the loop visits directly, not those buried in a

--- a/server/azure/sql/cascade_elasticpool_sdk_test.go
+++ b/server/azure/sql/cascade_elasticpool_sdk_test.go
@@ -177,6 +177,84 @@ func TestSDKAzureSQLDatabaseElasticPoolMembership(t *testing.T) {
 	}
 }
 
+// TestSDKAzureSQLDatabasePatchClearsElasticPoolID is the HIGH regression: real
+// Azure SQL removes a database from its elastic pool when a PATCH sets
+// properties.elasticPoolId to "" (learn.microsoft.com/azure/azure-sql/database/
+// elastic-pool-overview — moving a database into/out of a pool). Before the
+// fix, the wire layer decoded elasticPoolId as a plain string, so an explicit
+// "" was indistinguishable from the field being omitted and the merge silently
+// kept the database's existing pool membership — the PATCH had no effect and
+// the pool could never be deleted afterward.
+func TestSDKAzureSQLDatabasePatchClearsElasticPoolID(t *testing.T) {
+	cf := newFactory(t)
+	ctx := context.Background()
+	mustCreateSQLServer(t, cf)
+
+	ep := cf.NewElasticPoolsClient()
+
+	epPoller, err := ep.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "pool1", armsql.ElasticPool{
+		Location: to.Ptr("eastus"),
+		SKU:      &armsql.SKU{Name: to.Ptr("StandardPool"), Tier: to.Ptr("Standard")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("pool BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := epPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("pool PollUntilDone: %v", err)
+	}
+
+	dbs := cf.NewDatabasesClient()
+
+	dbPoller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "pooleddb", armsql.Database{
+		Location:   to.Ptr("eastus"),
+		Properties: &armsql.DatabaseProperties{ElasticPoolID: to.Ptr("pool1")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("db BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := dbPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("db PollUntilDone: %v", err)
+	}
+
+	// PATCH: explicitly clear elasticPoolId to move the database out of the pool.
+	clearPoller, err := dbs.BeginUpdate(ctx, "rg-1", "srv1", "pooleddb", armsql.DatabaseUpdate{
+		Properties: &armsql.DatabaseUpdateProperties{ElasticPoolID: to.Ptr("")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("db BeginUpdate (clear pool): %v", err)
+	}
+
+	clearResp, err := clearPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("db PollUntilDone (clear pool): %v", err)
+	}
+
+	if clearResp.Database.Properties != nil && clearResp.Database.Properties.ElasticPoolID != nil {
+		t.Errorf("elasticPoolId not cleared on PATCH response: %+v", clearResp.Database.Properties)
+	}
+
+	got, err := dbs.Get(ctx, "rg-1", "srv1", "pooleddb", nil)
+	if err != nil {
+		t.Fatalf("Get after clearing pool: %v", err)
+	}
+
+	if got.Database.Properties != nil && got.Database.Properties.ElasticPoolID != nil {
+		t.Errorf("elasticPoolId not cleared on Get: %+v", got.Database.Properties)
+	}
+
+	// The pool is now empty, so it must delete cleanly.
+	delPoolPoller, err := ep.BeginDelete(ctx, "rg-1", "srv1", "pool1", nil)
+	if err != nil {
+		t.Fatalf("pool BeginDelete after clearing membership: %v", err)
+	}
+
+	if _, err := delPoolPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("pool PollUntilDone after clearing membership: %v", err)
+	}
+}
+
 // TestSDKAzureSQLDatabaseUpdateBadElasticPoolPreservesDatabase is the HIGH
 // regression: a PUT against an EXISTING database that references an
 // elasticPoolId which doesn't resolve must fail the request without deleting

--- a/server/azure/sql/operations.go
+++ b/server/azure/sql/operations.go
@@ -191,7 +191,9 @@ func dbCfgFromBody(body *armDatabase, rp *azurearm.ResourcePath) rdsdriver.Datab
 
 	if body.Properties != nil {
 		cfg.Collation = body.Properties.Collation
-		cfg.ElasticPoolID = body.Properties.ElasticPoolID
+		if body.Properties.ElasticPoolID != nil {
+			cfg.ElasticPoolID = *body.Properties.ElasticPoolID
+		}
 		cfg.CreateMode = body.Properties.CreateMode
 		cfg.SourceDatabaseID = body.Properties.SourceDatabaseID
 
@@ -307,7 +309,11 @@ func mergeDatabaseFields(existing *rdsdriver.Database, body *armDatabase, cfg *r
 		merged.Tags = cfg.Tags
 	}
 
-	if cfg.ElasticPoolID != "" {
+	// ElasticPoolID is merged on pointer presence, not on cfg's zero-value check:
+	// a request explicitly clearing the field (elasticPoolId: "") must remove the
+	// database from its pool, which "" == not-supplied would otherwise mask (see
+	// dbCfgFromBody, which only sets cfg.ElasticPoolID when the pointer is set).
+	if body.Properties != nil && body.Properties.ElasticPoolID != nil {
 		merged.ElasticPoolID = cfg.ElasticPoolID
 	}
 

--- a/server/azure/sql/types.go
+++ b/server/azure/sql/types.go
@@ -57,7 +57,11 @@ type armDatabaseProps struct {
 	CurrentServiceObjectiveName string  `json:"currentServiceObjectiveName,omitempty"`
 	CurrentSKU                  *armSKU `json:"currentSku,omitempty"`
 	ZoneRedundant               *bool   `json:"zoneRedundant,omitempty"`
-	ElasticPoolID               string  `json:"elasticPoolId,omitempty"`
+	// ElasticPoolID is a pointer (not a plain string) so a PATCH can distinguish
+	// an omitted field from an explicit "" — real Azure SQL removes a database
+	// from its elastic pool when elasticPoolId is set to "" in the request body,
+	// which must not be conflated with the field being absent (leave unchanged).
+	ElasticPoolID *string `json:"elasticPoolId,omitempty"`
 }
 
 // armList is the ARM list-response envelope.
@@ -97,6 +101,14 @@ func toARMDatabase(db *rdsdriver.Database, rp *azurearm.ResourcePath, status str
 		status = dbStatusOnline
 	}
 
+	// Echo elasticPoolId only when the database is actually in a pool, matching
+	// the historical omitempty-on-empty-string behavior: a standalone database's
+	// response carries no elasticPoolId field at all.
+	var elasticPoolID *string
+	if db.ElasticPoolID != "" {
+		elasticPoolID = &db.ElasticPoolID
+	}
+
 	return armDatabase{
 		ID:       armDatabaseID(rp.Subscription, rp.ResourceGroup, db.Server, db.Name),
 		Name:     db.Name,
@@ -111,7 +123,7 @@ func toARMDatabase(db *rdsdriver.Database, rp *azurearm.ResourcePath, status str
 			CurrentServiceObjectiveName: db.SKUName,
 			CurrentSKU:                  &armSKU{Name: db.SKUName, Tier: db.SKUTier, Capacity: db.SKUCapacity},
 			ZoneRedundant:               &zoneRedundant,
-			ElasticPoolID:               db.ElasticPoolID,
+			ElasticPoolID:               elasticPoolID,
 		},
 	}
 }


### PR DESCRIPTION
Deep real-user e2e audit of Azure SQL (real armsql SDK against a running \`cloudemu serve\`).

## Fix
**A Database PATCH could not remove a database from its elastic pool.** Setting \`elasticPoolId\` to \`""\` (the documented way to move a DB back to standalone) had no effect: the shared Azure "unmodeled property preserve" helper (\`server/azure/echo_properties.go\`, \`missingProperties\`) treated the empty-string \`elasticPoolId\` in the request — which the handler correctly drops via \`omitempty\` after clearing it — as unmodeled data and re-injected it into the response, so the pool membership never cleared.

Now \`missingProperties\` does not preserve a request **scalar at its JSON zero value** (null / "" / false / 0) that the response omits: such a value is far more likely a modeled field the handler intentionally cleared (and dropped via omitempty) than genuinely unmodeled data. Maps/arrays are unaffected (their empty forms stay verbatim-captured as before).

## Blast radius
\`echo_properties.go\` is shared across Azure handlers. The change is narrow — it only stops *re-adding* a request's zero-value scalar when the response omits it; non-zero scalars and all maps/arrays keep their existing preserve behavior. Full \`server/azure/...\` suite is the gate (CI).

## Verification
\`go build ./...\`, \`go test ./server/azure/sql/... -race\`, \`server/azure\` (echo_properties) tests, \`gofmt\`, \`golangci-lint --new-from-rev\` (0 new) — green. Regression test \`TestSDKAzureSQLDatabasePatchClearsElasticPoolID\`. TDE-not-reset-on-PATCH re-verified still correct (no regression).