### PR TITLE
fix(gcp-gke): real-user e2e divergences

### DIFF
--- a/providers/gcp/gke/gke.go
+++ b/providers/gcp/gke/gke.go
@@ -834,10 +834,16 @@ func (m *Mock) GetNodePool(_ context.Context, location, clusterName, name string
 	return &out, nil
 }
 
-// ListNodePools returns all node pools in a cluster.
+// ListNodePools returns all node pools in a cluster. Real GKE 404s
+// nodePools.list on a nonexistent cluster rather than answering an empty
+// collection, so the cluster's presence is checked first.
 func (m *Mock) ListNodePools(_ context.Context, location, clusterName string) ([]NodePool, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+
+	if !m.clusters.Has(clusterKey(location, clusterName)) {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found in %q", clusterName, location)
+	}
 
 	prefix := location + "/" + clusterName + "/"
 	all := m.nodePools.All()

--- a/providers/gcp/gke/gke_test.go
+++ b/providers/gcp/gke/gke_test.go
@@ -276,6 +276,32 @@ func TestNodePoolErrorPaths(t *testing.T) {
 	}
 }
 
+// TestListNodePoolsMissingCluster covers a real-user e2e divergence found via
+// black-box audit: ListNodePools on a cluster that doesn't exist used to
+// answer an empty collection (200) instead of 404, unlike GetCluster,
+// GetNodePool, CreateNodePool, and DeleteNodePool, which all correctly 404 on
+// a missing cluster/pool. Real GKE 404s nodePools.list on a nonexistent
+// cluster too.
+func TestListNodePoolsMissingCluster(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.ListNodePools(ctx, "us-central1", "does-not-exist"); err == nil {
+		t.Fatal("expected NotFound when listing node pools of a missing cluster")
+	}
+
+	// A real cluster's pools still list correctly once it exists.
+	_, _, err := m.CreateCluster(ctx, &CreateClusterInput{Name: "real", Location: "us-central1"})
+	requireNoError(t, err)
+
+	pools, err := m.ListNodePools(ctx, "us-central1", "real")
+	requireNoError(t, err)
+
+	if len(pools) != 1 {
+		t.Fatalf("got %d pools, want 1 (default-pool)", len(pools))
+	}
+}
+
 func TestOperations(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/server/gcp/gke/sdk_fidelity_test.go
+++ b/server/gcp/gke/sdk_fidelity_test.go
@@ -211,3 +211,58 @@ func TestSDKGKEGetServerConfig(t *testing.T) {
 		t.Fatal("validNodeVersions empty")
 	}
 }
+
+// TestSDKGKEErrorMessageOmitsCodePrefix proves a GKE error's wire message
+// carries only the human-readable text, not the internal cerrors code-name
+// prefix (e.g. "cluster ... not found", not "NotFound: cluster ... not
+// found") — real GKE never leaks its internal error taxonomy into the message
+// an SDK surfaces to the caller. A black-box audit found every case in
+// writeErr using err.Error() (which includes the "NotFound: "/"AlreadyExists:
+// "/etc. prefix from cerrors.Error.Error()) instead of cerrors.Message(err).
+func TestSDKGKEErrorMessageOmitsCodePrefix(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	_, err := svc.Projects.Locations.Clusters.Get(parent(project, loc) + "/clusters/does-not-exist").
+		Context(ctx).Do()
+	if err == nil {
+		t.Fatal("clusters.get (missing): want error, got success")
+	}
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != http.StatusNotFound {
+		t.Fatalf("clusters.get (missing): want 404, got %v", err)
+	}
+
+	for _, prefix := range []string{"NotFound:", "AlreadyExists:", "InvalidArgument:", "FailedPrecondition:", "Internal:"} {
+		if strings.Contains(gerr.Message, prefix) {
+			t.Fatalf("error message %q leaks internal code prefix %q", gerr.Message, prefix)
+		}
+	}
+
+	if gerr.Message != `cluster "does-not-exist" not found in "us-central1"` {
+		t.Fatalf("unexpected error message: %q", gerr.Message)
+	}
+}
+
+// TestSDKGKEListNodePoolsMissingClusterNotFound proves nodePools.list on a
+// cluster that doesn't exist 404s, matching real GKE and every other GKE
+// verb that reads a cluster/pool. A black-box audit found the wire handler
+// silently answering an empty collection (200) instead.
+func TestSDKGKEListNodePoolsMissingClusterNotFound(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	_, err := svc.Projects.Locations.Clusters.NodePools.List(
+		parent(project, loc) + "/clusters/does-not-exist").Context(ctx).Do()
+	if err == nil {
+		t.Fatal("nodePools.list (missing cluster): want 404, got success")
+	}
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != http.StatusNotFound {
+		t.Fatalf("nodePools.list (missing cluster): want 404, got %v", err)
+	}
+}

--- a/server/gcp/gke/types.go
+++ b/server/gcp/gke/types.go
@@ -349,17 +349,25 @@ func writeError(w http.ResponseWriter, status int, reason, msg string) {
 	})
 }
 
+// writeErr maps a CloudEmu canonical error to the matching GKE HTTP status and
+// reason. The wire message is cerrors.Message(err) — the error's
+// human-readable text without the canonical code prefix (e.g. "cluster x not
+// found", not "NotFound: cluster x not found") — matching every other GCP
+// wire handler, which never leaks the internal error-taxonomy name into the
+// message an SDK surfaces to the caller.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+		writeError(w, http.StatusNotFound, "NOT_FOUND", msg)
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "ALREADY_EXISTS", err.Error())
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", msg)
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", msg)
 	case cerrors.IsFailedPrecondition(err):
-		writeError(w, http.StatusConflict, "FAILED_PRECONDITION", err.Error())
+		writeError(w, http.StatusConflict, "FAILED_PRECONDITION", msg)
 	default:
-		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+		writeError(w, http.StatusInternalServerError, "INTERNAL", msg)
 	}
 }


### PR DESCRIPTION
## Summary
- `writeErr` in `server/gcp/gke/types.go` used `err.Error()` instead of `cerrors.Message(err)`, leaking the internal cloudemu error-taxonomy prefix (e.g. `"NotFound: cluster \"x\" not found"`) into every GKE error response's wire `error.message` — real GKE never leaks this. Same pattern already fixed once in the shared `gcprest.WriteCErr` and per-package in GCS/GCE/Pub/Sub; GKE has its own `writeErr` (different envelope shape) so it wasn't covered.
- `ListNodePools` (`providers/gcp/gke/gke.go`) didn't check that the parent cluster exists, so `nodePools.list` on a nonexistent cluster silently answered `200 {"nodePools":[]}` instead of `404 NOT_FOUND` — every other GKE read verb already 404s on a missing cluster.

Found via black-box real-user e2e audit: real `google.golang.org/api/container/v1` SDK driven against a running `cloudemu serve` (GCP-only listener), exercising the full cluster + node-pool lifecycle (create/get/list/update/delete, resize, autoscaling, resource labels + fingerprint enforcement, operations, cascading delete) plus error paths.

## Test plan
- [x] `go build ./...`
- [x] `go test ./providers/gcp/gke/... ./server/gcp/gke/... -race` (existing + 3 new regression tests)
- [x] `go test ./server/gcp/... -race` (full GCP server suite, no regressions)
- [x] `gofmt -l` clean on changed files
- [x] `golangci-lint run ./providers/gcp/gke/... ./server/gcp/gke/...` — 0 new issues (1 pre-existing `gocritic` finding on an unrelated line, confirmed present on `development` too)
- [x] `go generate ./... && git diff --exit-code docs/coverage` — no drift
- [x] Re-verified both fixes black-box against a rebuilt `cloudemu serve` binary via raw HTTP: missing-cluster error message no longer has the code prefix; `nodePools.list` on a missing cluster now 404s and still 200s for a real cluster; full create→resize→label→delete-cascade lifecycle re-run end-to-end post-fix