### PR TITLE
fix(kinesis): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/kinesis/kinesis_test.go
+++ b/providers/aws/kinesis/kinesis_test.go
@@ -112,6 +112,55 @@ func TestGetRecordsAdvancesIterator(t *testing.T) {
 	}
 }
 
+// TestGetRecordsReportsMillisBehindLatest verifies MillisBehindLatest reflects
+// the gap between the tip of the shard and the last record a GetRecords call
+// returned, matching real Kinesis: 0 once caught up, positive while records
+// remain unread.
+func TestGetRecordsReportsMillisBehindLatest(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newMockClock(t)
+
+	if err := m.CreateStream(ctx, driver.CreateStreamInput{StreamName: "s", ShardCount: 1}); err != nil {
+		t.Fatalf("CreateStream: %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := m.PutRecord(ctx, driver.PutRecordInput{StreamName: "s", PartitionKey: "k", Data: []byte{byte(i)}}); err != nil {
+			t.Fatalf("PutRecord %d: %v", i, err)
+		}
+
+		clk.Advance(time.Second)
+	}
+
+	desc, err := m.DescribeStream(ctx, "s", "", 0, "")
+	if err != nil {
+		t.Fatalf("DescribeStream: %v", err)
+	}
+
+	it := trimHorizonIterator(t, ctx, m, desc.Shards[0].ShardID)
+
+	// Reading only the first of 3 records (spaced 1s apart) leaves 2s behind the
+	// tip of the shard.
+	out, err := m.GetRecords(ctx, it, 1)
+	if err != nil {
+		t.Fatalf("GetRecords: %v", err)
+	}
+
+	if want := (2 * time.Second).Milliseconds(); out.MillisBehindLatest != want {
+		t.Fatalf("MillisBehindLatest = %d, want %d", out.MillisBehindLatest, want)
+	}
+
+	// Draining the rest catches the iterator up to the tip: 0.
+	out2, err := m.GetRecords(ctx, out.NextShardIterator, 10)
+	if err != nil {
+		t.Fatalf("GetRecords(2): %v", err)
+	}
+
+	if out2.MillisBehindLatest != 0 {
+		t.Fatalf("MillisBehindLatest after catching up = %d, want 0", out2.MillisBehindLatest)
+	}
+}
+
 func TestRetentionGuards(t *testing.T) {
 	ctx := context.Background()
 	m := newMock(t)

--- a/providers/aws/kinesis/records.go
+++ b/providers/aws/kinesis/records.go
@@ -393,7 +393,7 @@ func (m *Mock) GetRecords(_ context.Context, shardIterator string, limit int32) 
 	out := &driver.GetRecordsOutput{
 		Records:            recs,
 		NextShardIterator:  m.encodeFreshIterator(tok.StreamName, tok.ShardID, end),
-		MillisBehindLatest: 0,
+		MillisBehindLatest: millisBehindLatest(shard.records, end),
 	}
 
 	// A drained, closed shard reports its children and a nil iterator (end of shard).
@@ -403,6 +403,33 @@ func (m *Mock) GetRecords(_ context.Context, shardIterator string, limit int32) 
 	}
 
 	return out, nil
+}
+
+// millisBehindLatest reports how far behind the tip of the shard a GetRecords
+// call left the iterator, matching Kinesis's MillisBehindLatest: the gap
+// between the newest record's arrival time and the last record returned in
+// this call. Zero once the iterator has caught up to the tip (end reaches the
+// end of the shard) or when the shard has no records at all.
+func millisBehindLatest(records []driver.Record, end int) int64 {
+	if end >= len(records) || len(records) == 0 {
+		return 0
+	}
+
+	latest := records[len(records)-1].ApproximateArrivalTimestamp
+
+	var reached time.Time
+	if end > 0 {
+		reached = records[end-1].ApproximateArrivalTimestamp
+	} else {
+		reached = records[0].ApproximateArrivalTimestamp
+	}
+
+	behind := latest.Sub(reached)
+	if behind < 0 {
+		return 0
+	}
+
+	return behind.Milliseconds()
 }
 
 func childShardsOf(shards []*shardState, parentID string) []driver.ChildShard {

--- a/server/aws/kinesis/admin_ops.go
+++ b/server/aws/kinesis/admin_ops.go
@@ -82,24 +82,41 @@ type monitoringRequest struct {
 
 func (h *Handler) enableMonitoring(w http.ResponseWriter, r *http.Request) {
 	dispatch(h, w, r, func(h *Handler, ctx context.Context, req *monitoringRequest) (any, error) {
-		before, after, err := h.kinesis.EnableEnhancedMonitoring(ctx, req.StreamName, req.StreamARN, req.ShardLevelMetrics)
-		if err != nil {
-			return nil, err
-		}
-
-		return monitoringResponse(req.StreamName, req.StreamARN, before, after), nil
+		return h.setMonitoring(ctx, req, true)
 	})
 }
 
 func (h *Handler) disableMonitoring(w http.ResponseWriter, r *http.Request) {
 	dispatch(h, w, r, func(h *Handler, ctx context.Context, req *monitoringRequest) (any, error) {
-		before, after, err := h.kinesis.DisableEnhancedMonitoring(ctx, req.StreamName, req.StreamARN, req.ShardLevelMetrics)
-		if err != nil {
-			return nil, err
-		}
-
-		return monitoringResponse(req.StreamName, req.StreamARN, before, after), nil
+		return h.setMonitoring(ctx, req, false)
 	})
+}
+
+// setMonitoring enables/disables shard-level metrics and builds the response,
+// resolving both StreamName and StreamARN from the stream itself so either
+// field is populated regardless of which identifier the request supplied.
+func (h *Handler) setMonitoring(ctx context.Context, req *monitoringRequest, enable bool) (any, error) {
+	var (
+		before, after []string
+		err           error
+	)
+
+	if enable {
+		before, after, err = h.kinesis.EnableEnhancedMonitoring(ctx, req.StreamName, req.StreamARN, req.ShardLevelMetrics)
+	} else {
+		before, after, err = h.kinesis.DisableEnhancedMonitoring(ctx, req.StreamName, req.StreamARN, req.ShardLevelMetrics)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	name, arn, err := h.resolveStreamIdentity(ctx, req.StreamName, req.StreamARN)
+	if err != nil {
+		return nil, err
+	}
+
+	return monitoringResponse(name, arn, before, after), nil
 }
 
 func monitoringResponse(name, arn string, before, after []string) map[string]any {

--- a/server/aws/kinesis/handler.go
+++ b/server/aws/kinesis/handler.go
@@ -94,6 +94,20 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"unsupported Kinesis operation: "+r.Header.Get("X-Amz-Target"))
 }
 
+// resolveStreamIdentity returns the canonical StreamName and StreamARN for a
+// stream identified by either field. Several Kinesis responses (UpdateShardCount,
+// Enable/DisableEnhancedMonitoring) always carry both identifiers regardless of
+// which one the caller supplied in the request, so callers resolve through the
+// stream itself rather than echoing back whatever the request happened to set.
+func (h *Handler) resolveStreamIdentity(ctx context.Context, name, arn string) (resolvedName, resolvedARN string, err error) {
+	s, err := h.kinesis.DescribeStreamSummary(ctx, name, arn)
+	if err != nil {
+		return "", "", err
+	}
+
+	return s.StreamName, s.StreamARN, nil
+}
+
 // dispatch decodes a JSON request of type Req, invokes call, and writes the
 // returned value as JSON (or maps the error).
 func dispatch[Req any](

--- a/server/aws/kinesis/sdk_roundtrip_test.go
+++ b/server/aws/kinesis/sdk_roundtrip_test.go
@@ -357,6 +357,94 @@ func TestSDKListStreamsPaginates(t *testing.T) {
 	}
 }
 
+// TestSDKUpdateShardCountResolvesIdentity verifies UpdateShardCount always
+// returns both StreamName and StreamARN, resolved from the stream, regardless
+// of which identifier the caller passed — matching real Kinesis, which never
+// leaves either field empty in the response.
+func TestSDKUpdateShardCountResolvesIdentity(t *testing.T) {
+	ctx := context.Background()
+	c := newKinesisClient(t)
+
+	mustCreate(t, c, "resize", 2)
+
+	// Called by StreamName only: StreamARN in the response must still resolve.
+	out, err := c.UpdateShardCount(ctx, &awskinesis.UpdateShardCountInput{
+		StreamName:       aws.String("resize"),
+		TargetShardCount: aws.Int32(4),
+		ScalingType:      kinesistypes.ScalingTypeUniformScaling,
+	})
+	if err != nil {
+		t.Fatalf("UpdateShardCount: %v", err)
+	}
+
+	if aws.ToString(out.StreamName) != "resize" {
+		t.Fatalf("StreamName = %q, want %q", aws.ToString(out.StreamName), "resize")
+	}
+
+	if aws.ToString(out.StreamARN) == "" {
+		t.Fatal("StreamARN empty when UpdateShardCount was called by StreamName")
+	}
+
+	// Called by StreamARN only: StreamName in the response must still resolve.
+	arn := aws.ToString(out.StreamARN)
+
+	out2, err := c.UpdateShardCount(ctx, &awskinesis.UpdateShardCountInput{
+		StreamARN:        aws.String(arn),
+		TargetShardCount: aws.Int32(6),
+		ScalingType:      kinesistypes.ScalingTypeUniformScaling,
+	})
+	if err != nil {
+		t.Fatalf("UpdateShardCount by ARN: %v", err)
+	}
+
+	if aws.ToString(out2.StreamName) != "resize" {
+		t.Fatalf("StreamName = %q, want %q when called by ARN", aws.ToString(out2.StreamName), "resize")
+	}
+
+	if aws.ToString(out2.StreamARN) != arn {
+		t.Fatalf("StreamARN = %q, want %q", aws.ToString(out2.StreamARN), arn)
+	}
+}
+
+// TestSDKEnhancedMonitoringResolvesIdentity verifies Enable/DisableEnhancedMonitoring
+// always return both StreamName and StreamARN, resolved from the stream.
+func TestSDKEnhancedMonitoringResolvesIdentity(t *testing.T) {
+	ctx := context.Background()
+	c := newKinesisClient(t)
+
+	mustCreate(t, c, "monitored", 1)
+
+	out, err := c.EnableEnhancedMonitoring(ctx, &awskinesis.EnableEnhancedMonitoringInput{
+		StreamName:        aws.String("monitored"),
+		ShardLevelMetrics: []kinesistypes.MetricsName{kinesistypes.MetricsNameIncomingBytes},
+	})
+	if err != nil {
+		t.Fatalf("EnableEnhancedMonitoring: %v", err)
+	}
+
+	if aws.ToString(out.StreamName) != "monitored" {
+		t.Fatalf("StreamName = %q, want %q", aws.ToString(out.StreamName), "monitored")
+	}
+
+	if aws.ToString(out.StreamARN) == "" {
+		t.Fatal("StreamARN empty when EnableEnhancedMonitoring was called by StreamName")
+	}
+
+	arn := aws.ToString(out.StreamARN)
+
+	disableOut, err := c.DisableEnhancedMonitoring(ctx, &awskinesis.DisableEnhancedMonitoringInput{
+		StreamARN:         aws.String(arn),
+		ShardLevelMetrics: []kinesistypes.MetricsName{kinesistypes.MetricsNameIncomingBytes},
+	})
+	if err != nil {
+		t.Fatalf("DisableEnhancedMonitoring: %v", err)
+	}
+
+	if aws.ToString(disableOut.StreamName) != "monitored" {
+		t.Fatalf("StreamName = %q, want %q when called by ARN", aws.ToString(disableOut.StreamName), "monitored")
+	}
+}
+
 func TestSDKGetRecordsMalformedIterator(t *testing.T) {
 	ctx := context.Background()
 	c := newKinesisClient(t)

--- a/server/aws/kinesis/streams_ops.go
+++ b/server/aws/kinesis/streams_ops.go
@@ -216,11 +216,16 @@ func (h *Handler) updateShardCount(w http.ResponseWriter, r *http.Request) {
 			return nil, err
 		}
 
+		name, arn, err := h.resolveStreamIdentity(ctx, req.StreamName, req.StreamARN)
+		if err != nil {
+			return nil, err
+		}
+
 		return map[string]any{
-			"StreamName":        req.StreamName,
+			"StreamName":        name,
 			"CurrentShardCount": current,
 			"TargetShardCount":  target,
-			"StreamARN":         req.StreamARN,
+			"StreamARN":         arn,
 		}, nil
 	})
 }


### PR DESCRIPTION
## Summary

Deep black-box real-user e2e audit of the AWS Kinesis Data Streams surface (aws-cli, aws-sdk-go-v2, Terraform `aws_kinesis_stream`) against a running `cloudemu serve -providers=aws`. Two genuine divergences from real AWS Kinesis found and fixed.

### 1. `UpdateShardCount` / `Enable`/`DisableEnhancedMonitoring` left one of StreamName/StreamARN empty in the response

Real Kinesis always returns both `StreamName` and `StreamARN` in these three responses, resolved server-side, regardless of which single identifier the caller passed (the API accepts either). cloudemu echoed back only whatever the request body happened to contain, so calling by StreamName alone left `StreamARN: ""`, and calling by StreamARN alone left `StreamName: ""` — breaking the common pattern of chaining a follow-up call off the returned identifier.

Fix: `server/aws/kinesis/handler.go` adds `Handler.resolveStreamIdentity`, resolving both fields via `DescribeStreamSummary` after the mutation succeeds; `updateShardCount` and a new shared `setMonitoring` helper (replacing duplicated enable/disable bodies) build their responses from the resolved identity.

### 2. `GetRecords` always reported `MillisBehindLatest: 0`

Hardcoded to 0 regardless of how far behind the tip of the shard a read left off. Real Kinesis reports the gap between the newest record's arrival time and the last record returned, which consumer applications (notably KCL) use to detect whether they've caught up. A hardcoded 0 made every read look caught-up even with a large unread backlog.

Fix: `providers/aws/kinesis/records.go` adds `millisBehindLatest`, computing the gap from `ApproximateArrivalTimestamp`s (0 once caught up or shard is empty). `SubscribeToShard` was checked and left as-is — it already always drains to the tip in one call, so 0 there is already correct.

## Re-verify evidence (black-box, rebuilt binary)

- `aws kinesis update-shard-count --stream-name test-stream ...` → `StreamARN` now populated (was `""`).
- `aws kinesis update-shard-count --stream-arn ...` → `StreamName` now populated (was `""`).
- `aws kinesis enable-enhanced-monitoring --stream-name ...` → `StreamARN` now populated.
- Seeded 3 records 1s apart, `GetRecords --limit 1` → `MillisBehindLatest: 2530` (was `0`); draining the rest → `MillisBehindLatest: 0`.
- Terraform `aws_kinesis_stream` create / in-place update (shard_count, retention_period) / destroy: all produce clean plans (`No changes` after apply) both before and after the fix.

Also audited and confirmed correct (no filing): stream CRUD, shard partitioning/resharding (UpdateShardCount, MergeShards, SplitShard), PutRecord/PutRecords → GetRecords round-trip, all 5 ShardIteratorType values, retention bounds, tags, consumer lifecycle, error-type fidelity (ResourceNotFoundException/ResourceInUseException/InvalidArgumentException/ValidationException).

One low-severity item filed but not fixed: enhanced fan-out `ConsumerARN` omits the trailing creation-timestamp suffix real AWS appends — treated as opaque by every SDK/Terraform, doesn't break any observed real-user flow, deferred as a separate ticket-worthy ARN-format change.

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers/aws/kinesis/... ./server/aws/kinesis/... -race` — all pass, including 3 new regression tests (`TestGetRecordsReportsMillisBehindLatest`, `TestSDKUpdateShardCountResolvesIdentity`, `TestSDKEnhancedMonitoringResolvesIdentity`)
- [x] `go test ./server/aws/... -race` — full server/aws tree green
- [x] `gofmt -l` clean, `golangci-lint run` — 0 issues
- [x] `go generate ./...` — no `docs/coverage` diff (no driver interface changes)
- [x] Black-box re-verification of both fixes via aws-cli against a rebuilt binary
- [x] Terraform `aws_kinesis_stream` apply/plan/destroy clean before and after