### PR TITLE
fix(gcp): 404 unknown operations instead of fake success

### DIFF
--- a/server/gcp/alloydb/handler.go
+++ b/server/gcp/alloydb/handler.go
@@ -81,7 +81,15 @@ func (h *Handler) SetOperationRegistry(reg *lro.Registry) { h.ops = reg }
 // Matches claims /v1/projects/{p}/locations/{l}/{clusters|backups|operations}
 // paths. Everything else under /v1/projects/ falls through to other GCP
 // handlers.
-func (*Handler) Matches(r *http.Request) bool {
+//
+// An /operations/{op} path is claimed only when this handler has no shared LRO
+// registry (a standalone package server, which must answer its own polls). In
+// an assembled server h.ops is the same *lro.Registry the shared poller
+// consults, and that poller is registered ahead of this handler, so it always
+// wins first-match-wins routing for every verb (GET/cancel/DELETE) on every
+// operation name, known or not — this handler never needs to (and, per this
+// guard, no longer does) answer for operations it didn't create.
+func (h *Handler) Matches(r *http.Request) bool {
 	if !strings.HasPrefix(r.URL.Path, pathPrefix) {
 		return false
 	}
@@ -94,7 +102,9 @@ func (*Handler) Matches(r *http.Request) bool {
 	}
 
 	switch collectionOf(parts[idxCollection]) {
-	case collectionClusters, collectionBackups, collectionOperations:
+	case collectionOperations:
+		return h.ops == nil
+	case collectionClusters, collectionBackups:
 		return true
 	default:
 		return false

--- a/server/gcp/alloydb/matches_test.go
+++ b/server/gcp/alloydb/matches_test.go
@@ -1,0 +1,78 @@
+// Matches-scoping guard for the operations claim: a named operations-path
+// request (any of GET/POST :cancel/DELETE) is claimed by this handler only
+// when it has no shared LRO registry (a standalone package server). When an
+// assembled server wires the shared registry via SetOperationRegistry, this
+// handler must stop claiming the operations path entirely and defer to the
+// shared lro.Handler — which is registered ahead of it and, unlike this
+// handler previously did for non-GET verbs, 404s an operation name it never
+// created instead of rejecting it as method-not-allowed. See server/gcp/lro
+// for the shared handler.
+
+package alloydb_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/server/gcp/alloydb"
+	"github.com/stackshy/cloudemu/v2/server/gcp/lro"
+)
+
+func TestHandlerStopsClaimingOperationsWhenRegistryWired(t *testing.T) {
+	h := alloydb.New(nil)
+	h.SetOperationRegistry(lro.NewRegistry())
+
+	const base = "/v1/projects/demo/locations/us/operations/bogus-op"
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"get", http.MethodGet, base},
+		{"cancel", http.MethodPost, base + ":cancel"},
+		{"delete", http.MethodDelete, base},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(tc.method, tc.path, http.NoBody)
+			if h.Matches(req) {
+				t.Errorf("Matches(%s %s) = true, want false: a wired shared registry means the shared lro handler "+
+					"owns this path, not this handler", tc.method, tc.path)
+			}
+		})
+	}
+
+	// The clusters collection is unaffected by the operations-claim guard.
+	req, _ := http.NewRequest(http.MethodGet, "/v1/projects/demo/locations/us/clusters", http.NoBody)
+	if !h.Matches(req) {
+		t.Fatalf("Matches(clusters) = false, want true")
+	}
+}
+
+func TestHandlerClaimsOperationsWhenStandalone(t *testing.T) {
+	h := alloydb.New(nil)
+
+	const base = "/v1/projects/demo/locations/us/operations/op-1"
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"get", http.MethodGet, base},
+		{"cancel", http.MethodPost, base + ":cancel"},
+		{"delete", http.MethodDelete, base},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(tc.method, tc.path, http.NoBody)
+			if !h.Matches(req) {
+				t.Errorf("Matches(%s %s) = false, want true: a standalone handler (no shared registry) "+
+					"must keep answering its own operation polls", tc.method, tc.path)
+			}
+		})
+	}
+}

--- a/server/gcp/artifactregistry/handler.go
+++ b/server/gcp/artifactregistry/handler.go
@@ -180,9 +180,25 @@ func splitVerb(seg string) (resource, verb string) {
 
 // Matches claims artifactregistry v1 repository paths. Disjoint from the IAM
 // handler (which matches serviceAccounts|roles at the same prefix).
-func (*Handler) Matches(r *http.Request) bool {
-	_, ok := parseRoute(r.URL.Path)
-	return ok
+//
+// An /operations/{op} path is claimed only when this handler has no shared
+// LRO registry (a standalone package server, which must answer its own polls).
+// In an assembled server h.ops is the same *lro.Registry the shared poller
+// consults, and that poller is registered ahead of this handler, so it always
+// wins first-match-wins routing for every verb (GET/cancel/DELETE) on every
+// operation name, known or not — this handler never needs to (and, per this
+// guard, no longer does) answer for operations it didn't create.
+func (h *Handler) Matches(r *http.Request) bool {
+	rt, ok := parseRoute(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	if rt.operation != "" && h.ops != nil {
+		return false
+	}
+
+	return true
 }
 
 // ServeHTTP dispatches on method and path shape.

--- a/server/gcp/artifactregistry/matches_test.go
+++ b/server/gcp/artifactregistry/matches_test.go
@@ -1,0 +1,77 @@
+// Matches-scoping guard for the operations claim: a named operations-path
+// request (any of GET/POST :cancel/DELETE) is claimed by this handler only
+// when it has no shared LRO registry (a standalone package server). When an
+// assembled server wires the shared registry via SetOperationRegistry, this
+// handler must stop claiming the operations path entirely and defer to the
+// shared lro.Handler — which is registered ahead of it and, unlike this
+// handler previously did, 404s an operation name it never created instead of
+// fabricating success. See server/gcp/lro for the shared handler.
+
+package artifactregistry_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/server/gcp/artifactregistry"
+	"github.com/stackshy/cloudemu/v2/server/gcp/lro"
+)
+
+func TestHandlerStopsClaimingOperationsWhenRegistryWired(t *testing.T) {
+	h := artifactregistry.New(nil)
+	h.SetOperationRegistry(lro.NewRegistry())
+
+	const base = "/v1/projects/demo/locations/us/operations/bogus-op"
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"get", http.MethodGet, base},
+		{"cancel", http.MethodPost, base + ":cancel"},
+		{"delete", http.MethodDelete, base},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(tc.method, tc.path, http.NoBody)
+			if h.Matches(req) {
+				t.Errorf("Matches(%s %s) = true, want false: a wired shared registry means the shared lro handler "+
+					"owns this path, not this handler", tc.method, tc.path)
+			}
+		})
+	}
+
+	// The repositories collection is unaffected by the operations-claim guard.
+	req, _ := http.NewRequest(http.MethodGet, "/v1/projects/demo/locations/us/repositories", http.NoBody)
+	if !h.Matches(req) {
+		t.Fatalf("Matches(repositories) = false, want true")
+	}
+}
+
+func TestHandlerClaimsOperationsWhenStandalone(t *testing.T) {
+	h := artifactregistry.New(nil)
+
+	const base = "/v1/projects/demo/locations/us/operations/op-1"
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"get", http.MethodGet, base},
+		{"cancel", http.MethodPost, base + ":cancel"},
+		{"delete", http.MethodDelete, base},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(tc.method, tc.path, http.NoBody)
+			if !h.Matches(req) {
+				t.Errorf("Matches(%s %s) = false, want true: a standalone handler (no shared registry) "+
+					"must keep answering its own operation polls", tc.method, tc.path)
+			}
+		})
+	}
+}

--- a/server/gcp/eventarc/handler.go
+++ b/server/gcp/eventarc/handler.go
@@ -148,9 +148,25 @@ func parseRoute(urlPath string) (route, bool) {
 
 // Matches claims Eventarc v1 trigger paths. Disjoint from the other
 // /v1/projects/ GCP handlers, so registration order is unconstrained.
-func (*Handler) Matches(r *http.Request) bool {
-	_, ok := parseRoute(r.URL.Path)
-	return ok
+//
+// An /operations/{op} path is claimed only when this handler has no shared
+// LRO registry (a standalone package server, which must answer its own polls).
+// In an assembled server h.ops is the same *lro.Registry the shared poller
+// consults, and that poller is registered ahead of this handler, so it always
+// wins first-match-wins routing for every verb (GET/cancel/DELETE) on every
+// operation name, known or not — this handler never needs to (and, per this
+// guard, no longer does) answer for operations it didn't create.
+func (h *Handler) Matches(r *http.Request) bool {
+	rt, ok := parseRoute(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	if rt.operation != "" && h.ops != nil {
+		return false
+	}
+
+	return true
 }
 
 // ServeHTTP dispatches on method and path shape.

--- a/server/gcp/eventarc/matches_test.go
+++ b/server/gcp/eventarc/matches_test.go
@@ -1,0 +1,77 @@
+// Matches-scoping guard for the operations claim: a named operations-path
+// request (any of GET/POST :cancel/DELETE) is claimed by this handler only
+// when it has no shared LRO registry (a standalone package server). When an
+// assembled server wires the shared registry via SetOperationRegistry, this
+// handler must stop claiming the operations path entirely and defer to the
+// shared lro.Handler — which is registered ahead of it and, unlike this
+// handler previously did, 404s an operation name it never created instead of
+// fabricating success. See server/gcp/lro for the shared handler.
+
+package eventarc_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/server/gcp/eventarc"
+	"github.com/stackshy/cloudemu/v2/server/gcp/lro"
+)
+
+func TestHandlerStopsClaimingOperationsWhenRegistryWired(t *testing.T) {
+	h := eventarc.New(nil)
+	h.SetOperationRegistry(lro.NewRegistry())
+
+	const base = "/v1/projects/demo/locations/us/operations/bogus-op"
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"get", http.MethodGet, base},
+		{"cancel", http.MethodPost, base + ":cancel"},
+		{"delete", http.MethodDelete, base},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(tc.method, tc.path, http.NoBody)
+			if h.Matches(req) {
+				t.Errorf("Matches(%s %s) = true, want false: a wired shared registry means the shared lro handler "+
+					"owns this path, not this handler", tc.method, tc.path)
+			}
+		})
+	}
+
+	// The triggers collection is unaffected by the operations-claim guard.
+	req, _ := http.NewRequest(http.MethodGet, "/v1/projects/demo/locations/us/triggers", http.NoBody)
+	if !h.Matches(req) {
+		t.Fatalf("Matches(triggers) = false, want true")
+	}
+}
+
+func TestHandlerClaimsOperationsWhenStandalone(t *testing.T) {
+	h := eventarc.New(nil)
+
+	const base = "/v1/projects/demo/locations/us/operations/op-1"
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"get", http.MethodGet, base},
+		{"cancel", http.MethodPost, base + ":cancel"},
+		{"delete", http.MethodDelete, base},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(tc.method, tc.path, http.NoBody)
+			if !h.Matches(req) {
+				t.Errorf("Matches(%s %s) = false, want true: a standalone handler (no shared registry) "+
+					"must keep answering its own operation polls", tc.method, tc.path)
+			}
+		})
+	}
+}

--- a/server/gcp/lro/handler.go
+++ b/server/gcp/lro/handler.go
@@ -1,24 +1,28 @@
 // Package lro provides a shared long-running-operation poller for GCP
-// location-scoped operations: GET /v1/projects/{p}/locations/{l}/operations/{op}.
+// location-scoped operations: GET, POST …:cancel, and DELETE on
+// /v1/projects/{p}/locations/{l}/operations/{op}.
 //
 // In real GCP each service exposes its own operations endpoint on its own API
 // host (alloydb.googleapis.com, artifactregistry.googleapis.com, …). CloudEmu
 // collapses every service onto one HTTP server, so those per-service operation
 // paths become indistinguishable by URL alone — whichever handler is registered
-// first (alloydb/gke) would greedily answer every location operation poll and
-// 404 the ones it didn't create, shadowing artifactregistry, eventarc,
-// memorystore, etc. This one handler, registered ahead of the service handlers,
-// owns all location-scoped operation polls uniformly.
+// first (alloydb/gke) would greedily answer every location operation request
+// and fabricate success for the ones it didn't create, shadowing
+// artifactregistry, eventarc, memorystore, etc. This one handler, registered
+// ahead of the service handlers, owns all location-scoped operation traffic —
+// Get, Cancel, and Delete alike — uniformly.
 //
 // Every CloudEmu mutation completes synchronously, but a client that polls the
-// returned operation name still expects two real-GCP behaviors the handler
-// must reproduce: the completed operation carries the typed result in its
-// `response`, and an operation name that was never created is 404 NOT_FOUND (not
-// masked as "done"). To do that the handler consults a shared Registry that each
-// service populates when it creates an operation. A handler built without a
-// Registry falls back to the legacy always-done response, so standalone
-// per-service package servers (which register their own operations handler) are
-// unaffected.
+// returned operation name still expects real-GCP behaviors the handler must
+// reproduce: the completed operation carries the typed result in its
+// `response`, an operation name that was never created is 404 NOT_FOUND (not
+// masked as done or fabricated success on cancel/delete), Cancel flips a done
+// operation's terminal state to canceled, and Delete removes the completed
+// operation's record so a later poll 404s. To do that the handler consults a
+// shared Registry that each service populates when it creates an operation. A
+// handler built without a Registry falls back to the legacy always-succeed
+// response on every verb, so standalone per-service package servers (which
+// register their own operations handler) are unaffected.
 package lro
 
 import (
@@ -33,20 +37,33 @@ const (
 	pathPrefix    = "/v1/projects/"
 	locationsSeg  = "locations"
 	operationsSeg = "operations"
+	cancelVerb    = "cancel"
+
+	// canceledCode is the numeric google.rpc.Code value (1) a canceled
+	// operation's error carries.
+	canceledCode = 1
 )
 
-// Registry records the completed operations services create, keyed by the
-// operation resource name (e.g. "projects/p/locations/l/operations/op-1"), so
-// the shared poller can replay the typed response and 404 unknown names. It is
-// safe for concurrent use: services register operations while polls read them.
+// entry is the recorded state of one operation: the typed response a done
+// poll replays, and whether Cancel has since been called on it.
+type entry struct {
+	response any
+	canceled bool
+}
+
+// Registry records the operations services create, keyed by the operation
+// resource name (e.g. "projects/p/locations/l/operations/op-1"), so the
+// shared poller can replay the typed response, 404 unknown names, and honor
+// Cancel/Delete against a real operation. It is safe for concurrent use:
+// services register operations while polls read and mutate them.
 type Registry struct {
 	mu  sync.RWMutex
-	ops map[string]any
+	ops map[string]entry
 }
 
 // NewRegistry returns an empty operation registry.
 func NewRegistry() *Registry {
-	return &Registry{ops: make(map[string]any)}
+	return &Registry{ops: make(map[string]entry)}
 }
 
 // Register records a completed operation under its resource name together with
@@ -61,46 +78,95 @@ func (r *Registry) Register(name string, response any) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.ops[name] = response
+	r.ops[name] = entry{response: response}
 }
 
-// lookup returns the recorded response for name and whether it was registered.
-func (r *Registry) lookup(name string) (response any, found bool) {
+// lookup returns the recorded entry for name and whether it was registered.
+func (r *Registry) lookup(name string) (e entry, found bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	response, found = r.ops[name]
+	e, found = r.ops[name]
 
-	return response, found
+	return e, found
 }
 
-// Handler answers GET on location-scoped operation names.
+// cancel marks a recorded operation canceled, matching real GCP's
+// best-effort Operations.Cancel: since CloudEmu completes every mutation
+// synchronously, the operation is already done, so canceling only flips its
+// terminal state for a subsequent Get. Reports whether name was registered.
+func (r *Registry) cancel(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	e, ok := r.ops[name]
+	if !ok {
+		return false
+	}
+
+	e.canceled = true
+	r.ops[name] = e
+
+	return true
+}
+
+// delete removes a recorded operation, matching real GCP's Operations.Delete
+// (only valid on a completed operation, which every CloudEmu operation already
+// is). Reports whether name was registered.
+func (r *Registry) delete(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.ops[name]; !ok {
+		return false
+	}
+
+	delete(r.ops, name)
+
+	return true
+}
+
+// Handler answers GET, POST …:cancel, and DELETE on location-scoped operation
+// names.
 type Handler struct {
 	reg *Registry
 }
 
 // New returns the shared location-operations handler. When reg is non-nil the
 // handler resolves only operations that were registered (404ing unknown names
-// and echoing the registered response); when reg is nil it answers every poll
-// with a bare done operation (legacy standalone behavior).
+// on every verb, and applying Get/Cancel/Delete against the registered
+// entry); when reg is nil it answers every request with unconditional success
+// (legacy standalone behavior).
 func New(reg *Registry) *Handler { return &Handler{reg: reg} }
 
-// Matches claims GET /v1/projects/{p}/locations/{l}/operations/{op}.
+// Matches claims GET, POST /v1/projects/{p}/locations/{l}/operations/{op}:cancel,
+// and DELETE /v1/projects/{p}/locations/{l}/operations/{op} — every verb the
+// google.longrunning.Operations service exposes on a location-scoped
+// operation. Claiming all three verbs (not just GET) is what keeps the
+// operations-minting handlers (artifactregistry, eventarc, memorystore,
+// alloydb) from greedily answering a cancel/delete on an operation they never
+// created; see the package doc.
 func (*Handler) Matches(r *http.Request) bool {
-	if r.Method != http.MethodGet {
+	_, _, op, cancel, ok := parse(r.URL.Path)
+	if !ok {
 		return false
 	}
 
-	_, _, op, ok := parse(r.URL.Path)
-
-	return ok && op != ""
+	switch r.Method {
+	case http.MethodGet, http.MethodDelete:
+		return op != "" && !cancel
+	case http.MethodPost:
+		return op != "" && cancel
+	default:
+		return false
+	}
 }
 
-// ServeHTTP returns the polled operation as a completed google.longrunning
-// Operation, carrying the registered typed response. An operation name that was
-// never registered is 404 NOT_FOUND, matching real GCP.
+// ServeHTTP dispatches Get/Cancel/Delete for a location-scoped operation. An
+// operation name that was never registered is 404 NOT_FOUND on every verb,
+// matching real GCP instead of fabricating success.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	project, location, op, ok := parse(r.URL.Path)
+	project, location, op, cancel, ok := parse(r.URL.Path)
 	if !ok {
 		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "malformed operation path")
 		return
@@ -109,49 +175,115 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	name := "projects/" + project + "/locations/" + location + "/operations/" + op
 
 	if h.reg == nil {
-		writeDone(w, name, nil)
+		writeLegacy(w, name, cancel, r.Method)
 		return
 	}
 
-	response, found := h.reg.lookup(name)
+	switch {
+	case cancel:
+		h.serveCancel(w, name)
+	case r.Method == http.MethodDelete:
+		h.serveDelete(w, name)
+	default:
+		h.serveGet(w, name)
+	}
+}
+
+// serveGet implements Operations.Get.
+func (h *Handler) serveGet(w http.ResponseWriter, name string) {
+	e, found := h.reg.lookup(name)
 	if !found {
-		gcprest.WriteError(w, http.StatusNotFound, "notFound", "operation "+name+" not found")
+		notFound(w, name)
 		return
 	}
 
-	writeDone(w, name, response)
+	writeDone(w, name, e.response, e.canceled)
+}
+
+// serveCancel implements Operations.Cancel. Real GCP makes a best-effort
+// cancel and returns an empty success body even when the operation has
+// already completed; CloudEmu's operations are always already complete, so
+// cancel just flips the terminal state a later Get reports.
+func (h *Handler) serveCancel(w http.ResponseWriter, name string) {
+	if !h.reg.cancel(name) {
+		notFound(w, name)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, map[string]any{})
+}
+
+// serveDelete implements Operations.Delete: removes a completed operation's
+// record, so a subsequent poll 404s — matching real GCP.
+func (h *Handler) serveDelete(w http.ResponseWriter, name string) {
+	if !h.reg.delete(name) {
+		notFound(w, name)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, map[string]any{})
+}
+
+// notFound writes the NOT_FOUND envelope for an operation name that was never
+// registered (or was already deleted).
+func notFound(w http.ResponseWriter, name string) {
+	gcprest.WriteError(w, http.StatusNotFound, "notFound", "operation "+name+" not found")
+}
+
+// writeLegacy answers a nil-registry (standalone) handler: every verb
+// succeeds unconditionally, matching CloudEmu's pre-registry behavior.
+func writeLegacy(w http.ResponseWriter, name string, cancel bool, method string) {
+	if cancel || method == http.MethodDelete {
+		gcprest.WriteJSON(w, http.StatusOK, map[string]any{})
+		return
+	}
+
+	writeDone(w, name, nil, false)
 }
 
 // writeDone writes a completed operation. It returns a superset that satisfies
 // both operation schemas served here: google.longrunning.Operation reads `done`
 // (artifactregistry, eventarc, memorystore, alloydb) while GKE's
 // container.Operation reads `status`.
-func writeDone(w http.ResponseWriter, name string, response any) {
+func writeDone(w http.ResponseWriter, name string, response any, canceled bool) {
 	body := map[string]any{
 		"name":   name,
 		"done":   true,
 		"status": "DONE",
 	}
 
-	if response != nil {
+	switch {
+	case canceled:
+		body["error"] = map[string]any{"code": canceledCode, "message": "Operation was canceled"}
+	case response != nil:
 		body["response"] = response
 	}
 
 	gcprest.WriteJSON(w, http.StatusOK, body)
 }
 
-// parse splits /v1/projects/{p}/locations/{l}/operations/{op}.
-func parse(urlPath string) (project, location, op string, ok bool) {
+// parse splits /v1/projects/{p}/locations/{l}/operations/{op}[:cancel].
+func parse(urlPath string) (project, location, op string, cancel, ok bool) {
 	if len(urlPath) < len(pathPrefix) || urlPath[:len(pathPrefix)] != pathPrefix {
-		return "", "", "", false
+		return "", "", "", false, false
 	}
 
 	parts := strings.Split(urlPath[len(pathPrefix):], "/")
-	// [project, locations, {l}, operations, {op}]
+	// [project, locations, {l}, operations, {op}[:cancel]]
 	const want = 5
 	if len(parts) != want || parts[1] != locationsSeg || parts[3] != operationsSeg {
-		return "", "", "", false
+		return "", "", "", false, false
 	}
 
-	return parts[0], parts[2], parts[4], true
+	last := parts[4]
+
+	if idx := strings.LastIndex(last, ":"); idx >= 0 {
+		if last[idx+1:] != cancelVerb {
+			return "", "", "", false, false
+		}
+
+		return parts[0], parts[2], last[:idx], true, true
+	}
+
+	return parts[0], parts[2], last, false, true
 }

--- a/server/gcp/lro/handler_test.go
+++ b/server/gcp/lro/handler_test.go
@@ -11,13 +11,19 @@ import (
 )
 
 const opPath = "/v1/projects/p/locations/us/operations/op-1"
+const cancelPath = opPath + ":cancel"
 
 func get(t *testing.T, h *lro.Handler, path string) (int, string) {
 	t.Helper()
+	return do(t, h, http.MethodGet, path)
+}
 
-	r := httptest.NewRequest(http.MethodGet, path, nil)
+func do(t *testing.T, h *lro.Handler, method, path string) (int, string) {
+	t.Helper()
+
+	r := httptest.NewRequest(method, path, nil)
 	if !h.Matches(r) {
-		t.Fatalf("handler does not match %s", path)
+		t.Fatalf("handler does not match %s %s", method, path)
 	}
 
 	w := httptest.NewRecorder()
@@ -64,6 +70,88 @@ func TestNilRegistryLegacyDone(t *testing.T) {
 	code, body := get(t, lro.New(nil), opPath)
 	if code != http.StatusOK || !strings.Contains(body, `"done":true`) {
 		t.Fatalf("code=%d body=%s (want 200 done:true)", code, body)
+	}
+}
+
+// TestUnknownOperationCancelIs404 verifies POST …:cancel on an operation name
+// that was never registered is 404 NOT_FOUND, not a fabricated success — the
+// cross-cutting bug this package closes: a bogus operation must 404 on every
+// verb, not just GET.
+func TestUnknownOperationCancelIs404(t *testing.T) {
+	code, body := do(t, lro.New(lro.NewRegistry()), http.MethodPost, cancelPath)
+	if code != http.StatusNotFound {
+		t.Fatalf("code=%d body=%s (want 404)", code, body)
+	}
+}
+
+// TestUnknownOperationDeleteIs404 verifies DELETE on an operation name that
+// was never registered is 404 NOT_FOUND, not a fabricated success.
+func TestUnknownOperationDeleteIs404(t *testing.T) {
+	code, body := do(t, lro.New(lro.NewRegistry()), http.MethodDelete, opPath)
+	if code != http.StatusNotFound {
+		t.Fatalf("code=%d body=%s (want 404)", code, body)
+	}
+}
+
+// TestCancelRegisteredOperationMarksCanceled verifies Cancel on a real,
+// registered operation succeeds and a subsequent Get reports it canceled.
+func TestCancelRegisteredOperationMarksCanceled(t *testing.T) {
+	reg := lro.NewRegistry()
+	reg.Register("projects/p/locations/us/operations/op-1", map[string]any{"ok": true})
+	h := lro.New(reg)
+
+	code, body := do(t, h, http.MethodPost, cancelPath)
+	if code != http.StatusOK {
+		t.Fatalf("cancel: code=%d body=%s (want 200)", code, body)
+	}
+
+	code, body = get(t, h, opPath)
+	if code != http.StatusOK {
+		t.Fatalf("post-cancel get: code=%d body=%s (want 200)", code, body)
+	}
+
+	for _, want := range []string{`"done":true`, `"error"`} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("post-cancel get body %s missing %q", body, want)
+		}
+	}
+
+	if strings.Contains(body, `"response"`) {
+		t.Fatalf("canceled operation should not carry a response: %s", body)
+	}
+}
+
+// TestDeleteRegisteredOperationRemovesIt verifies Delete on a real, registered
+// operation succeeds and a subsequent Get 404s, matching real GCP's
+// Operations.Delete semantics.
+func TestDeleteRegisteredOperationRemovesIt(t *testing.T) {
+	reg := lro.NewRegistry()
+	reg.Register("projects/p/locations/us/operations/op-1", map[string]any{"ok": true})
+	h := lro.New(reg)
+
+	code, body := do(t, h, http.MethodDelete, opPath)
+	if code != http.StatusOK {
+		t.Fatalf("delete: code=%d body=%s (want 200)", code, body)
+	}
+
+	code, body = get(t, h, opPath)
+	if code != http.StatusNotFound {
+		t.Fatalf("post-delete get: code=%d body=%s (want 404)", code, body)
+	}
+}
+
+// TestNilRegistryLegacyCancelAndDelete verifies a handler built without a
+// registry keeps unconditional success on cancel/delete too (standalone
+// package servers), matching its GET legacy fallback.
+func TestNilRegistryLegacyCancelAndDelete(t *testing.T) {
+	h := lro.New(nil)
+
+	if code, body := do(t, h, http.MethodPost, cancelPath); code != http.StatusOK {
+		t.Fatalf("cancel: code=%d body=%s (want 200)", code, body)
+	}
+
+	if code, body := do(t, h, http.MethodDelete, opPath); code != http.StatusOK {
+		t.Fatalf("delete: code=%d body=%s (want 200)", code, body)
 	}
 }
 

--- a/server/gcp/memorystore/handler.go
+++ b/server/gcp/memorystore/handler.go
@@ -110,9 +110,25 @@ func parseRoute(urlPath string) (route, bool) {
 // Matches claims /v1/projects/{p}/locations/{l}/{instances|operations}[/...]
 // paths. The {instances|operations} guard keeps it disjoint from the other
 // /v1/projects/ handlers (functions, clusters, secrets, databases, …).
-func (*Handler) Matches(r *http.Request) bool {
-	_, ok := parseRoute(r.URL.Path)
-	return ok
+//
+// An /operations/{op} path is claimed only when this handler has no shared
+// LRO registry (a standalone package server, which must answer its own polls).
+// In an assembled server h.ops is the same *lro.Registry the shared poller
+// consults, and that poller is registered ahead of this handler, so it always
+// wins first-match-wins routing for every verb (GET/cancel/DELETE) on every
+// operation name, known or not — this handler never needs to (and, per this
+// guard, no longer does) answer for operations it didn't create.
+func (h *Handler) Matches(r *http.Request) bool {
+	rt, ok := parseRoute(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	if rt.resource == operationsSeg && h.ops != nil {
+		return false
+	}
+
+	return true
 }
 
 // ServeHTTP routes on the parsed path and method.

--- a/server/gcp/memorystore/matches_test.go
+++ b/server/gcp/memorystore/matches_test.go
@@ -1,0 +1,78 @@
+// Matches-scoping guard for the operations claim: a named operations-path
+// request (any of GET/POST :cancel/DELETE) is claimed by this handler only
+// when it has no shared LRO registry (a standalone package server). When an
+// assembled server wires the shared registry via SetOperationRegistry, this
+// handler must stop claiming the operations path entirely and defer to the
+// shared lro.Handler — which is registered ahead of it and, unlike this
+// handler previously did for non-GET verbs, 404s an operation name it never
+// created instead of rejecting it as an unsupported method. See
+// server/gcp/lro for the shared handler.
+
+package memorystore_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/server/gcp/lro"
+	"github.com/stackshy/cloudemu/v2/server/gcp/memorystore"
+)
+
+func TestHandlerStopsClaimingOperationsWhenRegistryWired(t *testing.T) {
+	h := memorystore.New(nil)
+	h.SetOperationRegistry(lro.NewRegistry())
+
+	const base = "/v1/projects/demo/locations/us/operations/bogus-op"
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"get", http.MethodGet, base},
+		{"cancel", http.MethodPost, base + ":cancel"},
+		{"delete", http.MethodDelete, base},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(tc.method, tc.path, http.NoBody)
+			if h.Matches(req) {
+				t.Errorf("Matches(%s %s) = true, want false: a wired shared registry means the shared lro handler "+
+					"owns this path, not this handler", tc.method, tc.path)
+			}
+		})
+	}
+
+	// The instances collection is unaffected by the operations-claim guard.
+	req, _ := http.NewRequest(http.MethodGet, "/v1/projects/demo/locations/us/instances", http.NoBody)
+	if !h.Matches(req) {
+		t.Fatalf("Matches(instances) = false, want true")
+	}
+}
+
+func TestHandlerClaimsOperationsWhenStandalone(t *testing.T) {
+	h := memorystore.New(nil)
+
+	const base = "/v1/projects/demo/locations/us/operations/op-1"
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"get", http.MethodGet, base},
+		{"cancel", http.MethodPost, base + ":cancel"},
+		{"delete", http.MethodDelete, base},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(tc.method, tc.path, http.NoBody)
+			if !h.Matches(req) {
+				t.Errorf("Matches(%s %s) = false, want true: a standalone handler (no shared registry) "+
+					"must keep answering its own operation polls", tc.method, tc.path)
+			}
+		})
+	}
+}

--- a/server/gcp/operations_ownership_test.go
+++ b/server/gcp/operations_ownership_test.go
@@ -1,0 +1,148 @@
+package gcp_test
+
+// Regression coverage for the operations-ownership bug: a POST or DELETE
+// (operations.cancel / operations.delete) against the shared location
+// operations path with an UNKNOWN operation name used to fall through the
+// shared lro handler (which only claimed GET) onto whichever of
+// artifactregistry / eventarc / memorystore / alloydb registered next, and
+// each of those greedily answered `{"done":true}` for ANY operation id
+// regardless of whether it created it. Real GCP 404s an operation name that
+// doesn't exist, on every verb. These tests drive the FULL assembled server
+// (as `cloudemu serve` does) so the actual dispatch order — not just the lro
+// package in isolation — is what's under test.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// TestFullServerBogusOperationIs404OnEveryVerb is the core regression: GET,
+// POST :cancel, and DELETE on an operation name nobody ever created must all
+// 404, not fabricate success.
+func TestFullServerBogusOperationIs404OnEveryVerb(t *testing.T) {
+	ts := fullServer(t)
+
+	const base = "/v1/projects/demo/locations/us/operations/never-created-this-op"
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"get", http.MethodGet, base},
+		{"cancel", http.MethodPost, base + ":cancel"},
+		{"delete", http.MethodDelete, base},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, body := do(t, ts, tc.method, tc.path, "")
+			if code != http.StatusNotFound {
+				t.Fatalf("%s %s = %d %s, want 404 NOT_FOUND", tc.method, tc.path, code, body)
+			}
+
+			if strings.Contains(body, `"done":true`) {
+				t.Fatalf("%s %s fabricated success instead of 404: %s", tc.method, tc.path, body)
+			}
+		})
+	}
+}
+
+// opName reads the "name" field out of a create response body.
+func opName(t *testing.T, body string) string {
+	t.Helper()
+
+	var v struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(body), &v); err != nil || v.Name == "" {
+		t.Fatalf("cannot read operation name from %s (err=%v)", body, err)
+	}
+
+	return v.Name
+}
+
+// TestFullServerRealOperationsStillResolveAfterFix guards the fix's main
+// regression risk: closing the fake-success hole must not break polling a
+// REAL operation. artifactregistry and memorystore are a representative
+// subset of the four operations-minting handlers — they share the identical
+// doneOperation -> h.ops.Register mechanism eventarc and alloydb use (see
+// server/gcp/{eventarc,alloydb} which the standalone Matches-gating tests in
+// each package cover directly).
+func TestFullServerRealOperationsStillResolveAfterFix(t *testing.T) {
+	ts := fullServer(t)
+
+	// artifactregistry: create, poll (done), cancel (no-op success on an
+	// already-done op, matching real GCP), then delete (removes the record so
+	// a later poll 404s).
+	_, createBody := do(t, ts, http.MethodPost,
+		"/v1/projects/demo/locations/us/repositories?repositoryId=r1", `{"format":"MAVEN"}`)
+	arOp := "/v1/" + opName(t, createBody)
+
+	if code, body := do(t, ts, http.MethodGet, arOp, ""); code != http.StatusOK || !strings.Contains(body, `"done":true`) {
+		t.Fatalf("AR op GET: code=%d body=%s (want 200 done:true)", code, body)
+	}
+
+	if code, body := do(t, ts, http.MethodPost, arOp+":cancel", ""); code != http.StatusOK {
+		t.Fatalf("AR op cancel: code=%d body=%s (want 200)", code, body)
+	}
+
+	if code, body := do(t, ts, http.MethodDelete, arOp, ""); code != http.StatusOK {
+		t.Fatalf("AR op delete: code=%d body=%s (want 200)", code, body)
+	}
+
+	if code, _ := do(t, ts, http.MethodGet, arOp, ""); code != http.StatusNotFound {
+		t.Fatalf("AR op GET after delete: code=%d (want 404)", code)
+	}
+
+	// memorystore: create and poll (done). Only Get is exercised on this one
+	// (cancel/delete already proven end to end above via artifactregistry —
+	// the shared lro handler applies identically to every registered name).
+	_, msBody := do(t, ts, http.MethodPost,
+		"/v1/projects/demo/locations/us/instances?instanceId=cache1", `{}`)
+	msOp := "/v1/" + opName(t, msBody)
+
+	if code, body := do(t, ts, http.MethodGet, msOp, ""); code != http.StatusOK || !strings.Contains(body, `"done":true`) {
+		t.Fatalf("Memorystore op GET: code=%d body=%s (want 200 done:true)", code, body)
+	}
+}
+
+// TestAlloyDBServerOperationOwnership covers the fourth handler (AlloyDB),
+// which can't be enabled alongside GKE in fullServer (identical REST paths),
+// so it gets its own minimal server via DriversFromWithAlloyDB.
+func TestAlloyDBServerOperationOwnership(t *testing.T) {
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.DriversFromWithAlloyDB(cloud))
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	// A bogus operation 404s on every verb.
+	const base = "/v1/projects/demo/locations/us/operations/never-created-this-op"
+
+	if code, _ := do(t, ts, http.MethodGet, base, ""); code != http.StatusNotFound {
+		t.Fatalf("bogus op GET: code=%d, want 404", code)
+	}
+
+	if code, _ := do(t, ts, http.MethodPost, base+":cancel", ""); code != http.StatusNotFound {
+		t.Fatalf("bogus op cancel: code=%d, want 404", code)
+	}
+
+	if code, _ := do(t, ts, http.MethodDelete, base, ""); code != http.StatusNotFound {
+		t.Fatalf("bogus op delete: code=%d, want 404", code)
+	}
+
+	// A real AlloyDB cluster-create operation still resolves.
+	_, createBody := do(t, ts, http.MethodPost,
+		"/v1/projects/demo/locations/us/clusters?clusterId=c1", `{}`)
+	op := "/v1/" + opName(t, createBody)
+
+	if code, body := do(t, ts, http.MethodGet, op, ""); code != http.StatusOK || !strings.Contains(body, `"done":true`) {
+		t.Fatalf("AlloyDB op GET: code=%d body=%s (want 200 done:true)", code, body)
+	}
+}


### PR DESCRIPTION
## Bug

A POST or DELETE (e.g. `operations.cancel`, `operations.delete`) against the shared GCP LRO path `/v1/projects/{p}/locations/{l}/operations/{op}` on an **unknown** operation silently returned fake success `{"done":true}` (HTTP 200) instead of `404 NOT_FOUND`. Real GCP returns `NOT_FOUND` for an operation that doesn't exist, on every verb.

## Root cause

`server/gcp/lro` is the shared, registry-gated poller meant to own this path uniformly across services. Its `Matches()` only claimed `GET` — 404ing an unknown op correctly, but only for that one verb. `POST`/`DELETE` fell through, past `lro`, onto whichever of `artifactregistry`, `eventarc`, `memorystore`, or `alloydb` registered next in `server/gcp/gcp.go`. Each of those handlers' `Matches()` claimed the entire `/operations/{op}` path for *any* method regardless of whether it created that operation:

- `artifactregistry` and `eventarc`: their `ServeHTTP` returned a hardcoded `{"done":true}` for any operation id on any method — the exact fake-success bug.
- `memorystore` and `alloydb`: rejected non-GET with 400/405 (not fake success, but also not correct — a real `operations.cancel`/`operations.delete` on their own real ops never worked either).

## Fix

- `server/gcp/lro`: extended to own **GET, POST `:cancel`, and DELETE** on the operations path uniformly, all registry-gated. An unregistered name 404s on every verb. A registered operation now supports the full lifecycle: GET returns the typed response, `:cancel` flips it to a `CANCELED` terminal state (real GCP's best-effort cancel is a no-op on an already-done operation, which every CloudEmu operation is), and DELETE removes the record so a later poll 404s.
- `server/gcp/{artifactregistry,eventarc,memorystore,alloydb}`: `Matches()` now declines the operations path entirely whenever the handler has a shared LRO registry wired (`h.ops != nil`, i.e. every assembled server) — deferring fully to the shared `lro` handler, which is registered ahead of them. Each keeps its own legacy always-succeed operations fallback only for a standalone package server built without the shared registry (no such composition exists in the codebase today, but the option is preserved per the package's stated architecture).

## Tests

- `server/gcp/lro`: new/updated unit tests for GET/cancel/delete against unknown ops (404 on all three), the cancel/delete lifecycle against a real registered op, and the nil-registry legacy fallback.
- `server/gcp/{artifactregistry,eventarc,memorystore,alloydb}`: new `matches_test.go` per package proving `Matches()` now declines the operations path once a shared registry is wired, and still claims it standalone.
- `server/gcp`: new `operations_ownership_test.go` drives the **full assembled server** (as `cloudemu serve` does) — a bogus op 404s on GET/cancel/delete, and a representative subset of real operations (artifactregistry create→get→cancel→delete, memorystore create→get, and AlloyDB via its own server since it can't coexist with GKE) still resolve correctly end to end.

## Black-box re-verification

Built the binary and ran `serve -gcp-port 14798 -providers=gcp`:

```
GET    /v1/projects/demo/locations/us/operations/never-created-this-op        -> 404 notFound
POST   .../never-created-this-op:cancel                                        -> 404 notFound
DELETE /v1/projects/demo/locations/us/operations/never-created-this-op        -> 404 notFound
```

A real artifactregistry repository create → its operation resolves via GET (`done:true`, typed response), `:cancel` succeeds and flips it to a `CANCELED` error state on a later GET, DELETE removes the record and a subsequent GET 404s.

A real memorystore instance create → its operation resolves via GET (`done:true`, typed response) — confirming the fix does not break real async operations from the services that mint them.

Full gate matrix green: `go build ./...`, `go test ./server/gcp/... -race -count=1`, `go test ./providers/gcp/... -count=1`, `gofmt -l` clean, `golangci-lint run --new-from-rev=origin/development ./server/gcp/...` 0 issues, `go generate ./...` + `git diff docs/coverage` clean, `go mod tidy` no-op.