### PR TITLE
fix(azure-aks): real-user e2e divergences

### DIFF
--- a/providers/azure/aks/aks.go
+++ b/providers/azure/aks/aks.go
@@ -843,7 +843,8 @@ func (m *Mock) DeleteCluster(_ context.Context, rg, name string) error {
 	return nil
 }
 
-// ListClustersByResourceGroup returns all clusters in a resource group.
+// ListClustersByResourceGroup returns all clusters in a resource group,
+// sorted by name for a stable listing order (see sortClustersByName).
 func (m *Mock) ListClustersByResourceGroup(_ context.Context, rg string) ([]ManagedCluster, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -858,10 +859,14 @@ func (m *Mock) ListClustersByResourceGroup(_ context.Context, rg string) ([]Mana
 		out = append(out, c)
 	}
 
+	sortClustersByName(out)
+
 	return out, nil
 }
 
-// ListClusters returns all managed clusters across all resource groups.
+// ListClusters returns all managed clusters across all resource groups,
+// sorted by resource group then name for a stable listing order (see
+// sortClustersByName).
 func (m *Mock) ListClusters(_ context.Context) ([]ManagedCluster, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -874,7 +879,25 @@ func (m *Mock) ListClusters(_ context.Context) ([]ManagedCluster, error) {
 		out = append(out, c)
 	}
 
+	sortClustersByName(out)
+
 	return out, nil
+}
+
+// sortClustersByName orders a cluster list deterministically by resource
+// group then name. memstore.Store.Filter/All return a Go map, whose
+// iteration order is randomized on every call; without this sort, two GET
+// calls with no intervening writes could return the same clusters in a
+// different order, which real ARM listings never do and which looks like
+// spurious drift to a caller diffing successive reads (e.g. Terraform).
+func sortClustersByName(clusters []ManagedCluster) {
+	sort.Slice(clusters, func(i, j int) bool {
+		if clusters[i].ResourceGroup != clusters[j].ResourceGroup {
+			return clusters[i].ResourceGroup < clusters[j].ResourceGroup
+		}
+
+		return clusters[i].Name < clusters[j].Name
+	})
 }
 
 // RotateClusterCertificates is a stub that simply marks the cluster updated.
@@ -1067,7 +1090,10 @@ func (m *Mock) systemPoolCount(rg, cluster string) int {
 	return len(all)
 }
 
-// ListAgentPools returns all pools attached to a cluster.
+// ListAgentPools returns all pools attached to a cluster, sorted by name for
+// a stable listing order. toARMCluster calls this on every cluster GET/List
+// to render properties.agentPoolProfiles, so an unstable order here would
+// also make the cluster's inline pool list reorder between reads.
 //
 //nolint:dupl // sub-resource lists are intentionally typed; sharing via generics adds noise.
 func (m *Mock) ListAgentPools(_ context.Context, rg, cluster string) ([]AgentPool, error) {
@@ -1087,6 +1113,8 @@ func (m *Mock) ListAgentPools(_ context.Context, rg, cluster string) ([]AgentPoo
 	for _, p := range all {
 		out = append(out, p)
 	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 
 	return out, nil
 }
@@ -1176,6 +1204,8 @@ func (m *Mock) ListMaintenanceConfigs(_ context.Context, rg, cluster string) ([]
 	for _, mc := range all {
 		out = append(out, mc)
 	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 
 	return out, nil
 }

--- a/providers/azure/aks/aks_test.go
+++ b/providers/azure/aks/aks_test.go
@@ -2,6 +2,7 @@ package aks
 
 import (
 	"context"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -353,6 +354,83 @@ func TestListClustersAcrossResourceGroups(t *testing.T) {
 	rgA, err := m.ListClustersByResourceGroup(ctx, "rg-a")
 	requireNoError(t, err)
 	assertEqual(t, 1, len(rgA))
+}
+
+// TestListOrderingIsDeterministic guards against memstore.Store's randomized
+// map iteration leaking into list responses: a caller GETting/Listing the
+// same unchanged state repeatedly must see agent pools, clusters, and
+// maintenance configs in the same order every time, matching real ARM
+// listings. Without the name-sort in ListAgentPools/ListClusters/
+// ListClustersByResourceGroup/ListMaintenanceConfigs, this reordered on
+// almost every call and looked like spurious drift to a caller diffing
+// successive reads (e.g. Terraform comparing agentPoolProfiles).
+func TestListOrderingIsDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateOrUpdateCluster(ctx, ClusterInput{ResourceGroup: "rg-a", Name: "zzz"})
+	requireNoError(t, err)
+	_, err = m.CreateOrUpdateCluster(ctx, ClusterInput{ResourceGroup: "rg-a", Name: "aaa"})
+	requireNoError(t, err)
+	_, err = m.CreateOrUpdateCluster(ctx, ClusterInput{ResourceGroup: "rg-b", Name: "mmm"})
+	requireNoError(t, err)
+
+	poolNames := []string{"pzzz", "paaa", "pmmm", "pbbb", "pyyy", "pccc"}
+	for _, n := range poolNames {
+		_, err := m.CreateOrUpdateAgentPool(ctx, "rg-a", "zzz", AgentPoolInput{Name: n, Mode: "User"})
+		requireNoError(t, err)
+	}
+
+	for _, n := range []string{"mzzz", "maaa", "mmmm"} {
+		_, err := m.CreateOrUpdateMaintenanceConfig(ctx, "rg-a", "zzz", n, nil)
+		requireNoError(t, err)
+	}
+
+	wantPoolOrder := sortedOrder(poolNames)
+	wantClusterOrder := "rg-a/aaa,rg-a/zzz,rg-b/mmm,"
+	wantRGClusterOrder := "aaa,zzz,"
+	wantMaintOrder := "maaa,mmmm,mzzz,"
+
+	for i := 0; i < 20; i++ {
+		pools, err := m.ListAgentPools(ctx, "rg-a", "zzz")
+		requireNoError(t, err)
+		assertEqual(t, wantPoolOrder, namesOf(pools, func(p AgentPool) string { return p.Name }))
+
+		clusters, err := m.ListClusters(ctx)
+		requireNoError(t, err)
+		assertEqual(t, wantClusterOrder,
+			namesOf(clusters, func(c ManagedCluster) string { return c.ResourceGroup + "/" + c.Name }))
+
+		rgClusters, err := m.ListClustersByResourceGroup(ctx, "rg-a")
+		requireNoError(t, err)
+		assertEqual(t, wantRGClusterOrder, namesOf(rgClusters, func(c ManagedCluster) string { return c.Name }))
+
+		configs, err := m.ListMaintenanceConfigs(ctx, "rg-a", "zzz")
+		requireNoError(t, err)
+		assertEqual(t, wantMaintOrder, namesOf(configs, func(c MaintenanceConfig) string { return c.Name }))
+	}
+}
+
+func sortedOrder(names []string) string {
+	sorted := make([]string, len(names))
+	copy(sorted, names)
+	sort.Strings(sorted)
+
+	var out string
+	for _, n := range sorted {
+		out += n + ","
+	}
+
+	return out
+}
+
+func namesOf[T any](items []T, key func(T) string) string {
+	var out string
+	for _, it := range items {
+		out += key(it) + ","
+	}
+
+	return out
 }
 
 // Hand-rolled helpers per CLAUDE.md.

--- a/server/azure/aks/operations.go
+++ b/server/azure/aks/operations.go
@@ -3,6 +3,7 @@ package aks
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/providers/azure/aks"
@@ -399,9 +400,24 @@ func (h *Handler) listClusterCredentials(w http.ResponseWriter, r *http.Request,
 
 	azurearm.WriteJSON(w, http.StatusOK, armCredentialResults{
 		Kubeconfigs: []armCredentialResult{
-			{Name: rp.SubResource, Value: kubeconfig},
+			{Name: credentialName(rp.SubResource), Value: kubeconfig},
 		},
 	})
+}
+
+// credentialName maps the listCluster*Credential action verb onto the
+// kubeconfig entry name real AKS returns in kubeconfigs[].name. Real Azure
+// uses the short "clusterAdmin" / "clusterUser" / "clusterMonitoringUser"
+// forms, not the ARM action-path segment itself.
+func credentialName(action string) string {
+	switch {
+	case strings.EqualFold(action, "listClusterAdminCredential"):
+		return "clusterAdmin"
+	case strings.EqualFold(action, "listClusterMonitoringUserCredential"):
+		return "clusterMonitoringUser"
+	default:
+		return "clusterUser"
+	}
 }
 
 func (h *Handler) rotateClusterCertificates(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {

--- a/server/azure/aks/sdk_listorder_test.go
+++ b/server/azure/aks/sdk_listorder_test.go
@@ -1,0 +1,124 @@
+package aks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
+)
+
+// TestSDKAKSAgentPoolProfilesOrderIsStable is a real-user e2e regression: a
+// cluster GET's properties.agentPoolProfiles (and a standalone agentPools
+// List) must return pools in the same order across repeated reads with no
+// intervening writes. ListAgentPools built its result from a Go map without
+// sorting, so consecutive real armcontainerservice Get calls against the
+// unchanged cluster observed the pools reordered on almost every poll — a
+// caller diffing successive reads (e.g. Terraform comparing state) would see
+// spurious drift that isn't a real state change.
+func TestSDKAKSAgentPoolProfilesOrderIsStable(t *testing.T) {
+	clusters, poolsClient, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+		Properties: &armcontainerservice.ManagedClusterProperties{
+			AgentPoolProfiles: []*armcontainerservice.ManagedClusterAgentPoolProfile{
+				{Name: to.Ptr("system"), Count: to.Ptr[int32](1), VMSize: to.Ptr("Standard_DS2_v2"),
+					Mode: to.Ptr(armcontainerservice.AgentPoolModeSystem)},
+			},
+		},
+	})
+
+	for _, n := range []string{"pzzz", "paaa", "pmmm", "pbbb", "pyyy", "pccc", "pxxx"} {
+		poller, err := poolsClient.BeginCreateOrUpdate(ctx, "rg-1", "k8s-1", n, armcontainerservice.AgentPool{
+			Properties: &armcontainerservice.ManagedClusterAgentPoolProfileProperties{
+				Count: to.Ptr[int32](1), VMSize: to.Ptr("Standard_DS2_v2"),
+				Mode: to.Ptr(armcontainerservice.AgentPoolModeUser),
+			},
+		}, nil)
+		if err != nil {
+			t.Fatalf("pool BeginCreateOrUpdate(%s): %v", n, err)
+		}
+
+		if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+			t.Fatalf("pool PollUntilDone(%s): %v", n, err)
+		}
+	}
+
+	const wantOrder = "paaa,pbbb,pccc,pmmm,pxxx,pyyy,pzzz,system,"
+
+	for i := 0; i < 10; i++ {
+		props := getClusterProps(t, clusters)
+
+		var order string
+		for _, p := range props.AgentPoolProfiles {
+			order += *p.Name + ","
+		}
+
+		if order != wantOrder {
+			t.Fatalf("cluster GET %d: agentPoolProfiles order = %q, want %q (unstable ordering)", i, order, wantOrder)
+		}
+
+		pager := poolsClient.NewListPager("rg-1", "k8s-1", nil)
+
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("pools List %d: %v", i, err)
+		}
+
+		var listOrder string
+		for _, p := range page.Value {
+			listOrder += *p.Name + ","
+		}
+
+		if listOrder != wantOrder {
+			t.Fatalf("pools List %d: order = %q, want %q (unstable ordering)", i, listOrder, wantOrder)
+		}
+	}
+}
+
+// TestSDKAKSCredentialNamesMatchRealAzure asserts the kubeconfigs[].name field
+// returned by List{Admin,User,MonitoringUser}Credentials matches the short
+// forms real AKS uses ("clusterAdmin" / "clusterUser" / "clusterMonitoringUser"),
+// not the literal ARM action-path segment ("listClusterAdminCredential" etc).
+func TestSDKAKSCredentialNamesMatchRealAzure(t *testing.T) {
+	clusters, _, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	createDriftCluster(t, clusters, armcontainerservice.ManagedCluster{Location: to.Ptr("eastus")})
+
+	admin, err := clusters.ListClusterAdminCredentials(ctx, "rg-1", "k8s-1", nil)
+	if err != nil {
+		t.Fatalf("ListClusterAdminCredentials: %v", err)
+	}
+
+	assertCredentialName(t, admin.CredentialResults, "clusterAdmin")
+
+	user, err := clusters.ListClusterUserCredentials(ctx, "rg-1", "k8s-1", nil)
+	if err != nil {
+		t.Fatalf("ListClusterUserCredentials: %v", err)
+	}
+
+	assertCredentialName(t, user.CredentialResults, "clusterUser")
+
+	mon, err := clusters.ListClusterMonitoringUserCredentials(ctx, "rg-1", "k8s-1", nil)
+	if err != nil {
+		t.Fatalf("ListClusterMonitoringUserCredentials: %v", err)
+	}
+
+	assertCredentialName(t, mon.CredentialResults, "clusterMonitoringUser")
+}
+
+func assertCredentialName(t *testing.T, results armcontainerservice.CredentialResults, want string) {
+	t.Helper()
+
+	if len(results.Kubeconfigs) != 1 {
+		t.Fatalf("got %d kubeconfigs, want 1", len(results.Kubeconfigs))
+	}
+
+	got := results.Kubeconfigs[0].Name
+	if got == nil || *got != want {
+		t.Fatalf("kubeconfig name: got %v, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Real-user black-box audit of the Azure AKS control-plane surface
(`Microsoft.ContainerService/managedClusters` + `agentPools`) via the real
`azure-sdk-for-go` `armcontainerservice` client against a running `cloudemu
serve`. This surface had already been through several prior audit rounds
(existing `sdk_*_test.go` coverage for cluster/pool CRUD, power start/stop,
PATCH-tags-replace, pool-reconcile-on-partial-PUT, cost fields, identity,
osDiskType/scale-to-zero round-trips, etc. — all reconfirmed green before this
pass). Two genuine divergences were found:

- **Non-deterministic list ordering.** `ListAgentPools`,
  `ListClustersByResourceGroup`, `ListClusters`, and `ListMaintenanceConfigs`
  built their result slices directly off a `memstore.Store` map without
  sorting. Go randomizes map iteration order, so a cluster's
  `properties.agentPoolProfiles` (and the standalone `agentPools` list)
  reordered on almost every `GET`/`List` call even with zero state changes in
  between — verified 10 distinct orderings across 10 identical reads
  pre-fix. This looks like spurious drift to any caller diffing successive
  reads (Terraform comparing `agentPoolProfiles`, or any other drift
  detector). Fixed by sorting each list by name, matching the convention
  already used by several other Azure providers in this codebase
  (`containerapps`, `functions`, `managedidentity`, `sqlvirtualmachine`,
  `vnet`).
- **Wrong kubeconfig credential name.**
  `ListCluster{Admin,User,MonitoringUser}Credentials` returned the literal ARM
  action-path segment (e.g. `"listClusterAdminCredential"`) as
  `kubeconfigs[].name` instead of the real AKS short form (`"clusterAdmin"` /
  `"clusterUser"` / `"clusterMonitoringUser"`).

Full findings writeup (including unmodeled-but-not-buggy sub-surfaces like
`BeginUpgradeNodeImageVersion` and `BeginResetServicePrincipalProfile`, which
correctly fail rather than silently misbehaving) available on request.

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers/azure/aks/... ./server/azure/aks/... -race` (all pass, including 2 new regression tests)
- [x] `go test ./...` (full suite, no failures)
- [x] `gofmt -l` clean, `golangci-lint run` 0 issues on both packages
- [x] `go generate ./...` — no `docs/coverage` diff (no driver-interface surface change)
- [x] Black-box re-verify via real armcontainerservice SDK against a rebuilt `cloudemu serve`:
      15 consecutive `Get`/`List` calls against an 8-pool cluster now return 1
      consistent order (was up to 10/10 distinct pre-fix); all three
      `ListCluster*Credentials` calls now return the correct short names.