### PR TITLE
fix(ecr): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/ecr/ecr.go
+++ b/providers/aws/ecr/ecr.go
@@ -240,11 +240,12 @@ func (m *Mock) PutImage(_ context.Context, manifest *driver.ImageManifest) (*dri
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", manifest.Repository)
 	}
 
-	if err := checkTagMutability(rd, manifest.Tag); err != nil {
+	digest := resolveDigest(manifest)
+
+	if err := checkTagMutability(rd, manifest.Tag, digest); err != nil {
 		return nil, err
 	}
 
-	digest := resolveDigest(manifest)
 	img := m.storeImage(rd, manifest, digest)
 
 	rd.info.ImageCount = rd.images.Len()
@@ -386,7 +387,7 @@ func (m *Mock) TagImage(_ context.Context, repository, sourceRef, targetTag stri
 		return errors.Newf(errors.NotFound, "image %q not found in repository %q", sourceRef, repository)
 	}
 
-	if err := checkTagMutability(rd, targetTag); err != nil {
+	if err := checkTagMutability(rd, targetTag, img.detail.Digest); err != nil {
 		return err
 	}
 
@@ -583,26 +584,52 @@ func findImage(rd *repoData, reference string) *imageData {
 	return nil
 }
 
-// checkTagMutability validates that a tag can be overwritten.
-func checkTagMutability(rd *repoData, tag string) error {
-	if tag == "" || rd.tagMutability != immutableTag {
+// checkTagMutability validates that tag can be (re)assigned to digest.
+//
+// Real ECR distinguishes two cases when a tag is already in use:
+//   - the tag already points at this EXACT digest (a byte-identical re-push,
+//     or a redundant re-tag) — this is ImageAlreadyExistsException regardless
+//     of the repository's tag mutability setting, since nothing would change.
+//   - the tag points at a DIFFERENT digest — this only fails, with
+//     ImageTagAlreadyExistsException, on an IMMUTABLE repository; a MUTABLE
+//     repository allows the tag to move.
+func checkTagMutability(rd *repoData, tag, digest string) error {
+	if tag == "" {
 		return nil
 	}
 
+	existing := digestForTag(rd, tag)
+	if existing == "" {
+		return nil
+	}
+
+	if existing == digest {
+		return apiErrExistsf(excImageAlreadyExists,
+			"image already exists with tag %q in repository", tag)
+	}
+
+	if rd.tagMutability != immutableTag {
+		return nil
+	}
+
+	return errors.Newf(
+		errors.FailedPrecondition,
+		"tag %q already exists and repository has IMMUTABLE tag mutability",
+		tag,
+	)
+}
+
+// digestForTag returns the digest of the image currently carrying tag, or ""
+// if no image in the repository has that tag.
+func digestForTag(rd *repoData, tag string) string {
 	all := rd.images.All()
-	for _, img := range all {
-		for _, t := range img.detail.Tags {
-			if t == tag {
-				return errors.Newf(
-					errors.FailedPrecondition,
-					"tag %q already exists and repository has IMMUTABLE tag mutability",
-					tag,
-				)
-			}
+	for digest, img := range all {
+		if hasTag(img.detail.Tags, tag) {
+			return digest
 		}
 	}
 
-	return nil
+	return ""
 }
 
 // resolveDigest returns the image digest. When the client supplies an explicit

--- a/providers/aws/ecr/ecr_test.go
+++ b/providers/aws/ecr/ecr_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/providers/aws/cloudwatch"
 	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
 	"github.com/stretchr/testify/assert"
@@ -558,12 +559,12 @@ func TestImageTagMutability(t *testing.T) {
 		expectErr  bool
 	}{
 		{
-			name:       "MUTABLE allows duplicate tags",
+			name:       "MUTABLE allows moving a tag to different image content",
 			mutability: "MUTABLE",
 			expectErr:  false,
 		},
 		{
-			name:       "IMMUTABLE rejects duplicate tags",
+			name:       "IMMUTABLE rejects moving a tag to different image content",
 			mutability: "IMMUTABLE",
 			expectErr:  true,
 		},
@@ -580,20 +581,60 @@ func TestImageTagMutability(t *testing.T) {
 			})
 			require.NoError(t, err)
 
+			// Distinct manifest content so the two pushes content-address to
+			// distinct digests, exercising a genuine tag MOVE rather than a
+			// byte-identical re-push (which is ImageAlreadyExistsException
+			// regardless of mutability — see TestPutImageIdenticalRepush).
 			_, err = m.PutImage(ctx, &driver.ImageManifest{
-				Repository: "my-repo", Tag: "v1", SizeBytes: 100,
+				Repository: "my-repo", Tag: "v1", SizeBytes: 100, Manifest: `{"v":1}`,
 			})
 			require.NoError(t, err)
 
 			_, err = m.PutImage(ctx, &driver.ImageManifest{
-				Repository: "my-repo", Tag: "v1", SizeBytes: 200,
+				Repository: "my-repo", Tag: "v1", SizeBytes: 200, Manifest: `{"v":2}`,
 			})
 
 			if tc.expectErr {
 				require.Error(t, err)
+				assert.True(t, cerrors.IsFailedPrecondition(err))
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+// TestPutImageIdenticalRepush covers real ECR's ImageAlreadyExistsException: a
+// byte-identical re-push of a tag's current image is a no-op and is rejected
+// on BOTH mutability settings, since it is a distinct case from
+// ImageTagAlreadyExistsException (which only fires when the tag would move to
+// a different digest on an IMMUTABLE repository).
+func TestPutImageIdenticalRepush(t *testing.T) {
+	for _, mutability := range []string{"MUTABLE", "IMMUTABLE"} {
+		t.Run(mutability, func(t *testing.T) {
+			m, _ := newTestMock()
+			ctx := context.Background()
+
+			_, err := m.CreateRepository(ctx, driver.RepositoryConfig{
+				Name:               "my-repo",
+				ImageTagMutability: mutability,
+			})
+			require.NoError(t, err)
+
+			manifest := &driver.ImageManifest{
+				Repository: "my-repo", Tag: "v1", SizeBytes: 100, Manifest: `{"v":1}`,
+			}
+
+			_, err = m.PutImage(ctx, manifest)
+			require.NoError(t, err)
+
+			_, err = m.PutImage(ctx, manifest)
+			require.Error(t, err)
+			assert.True(t, cerrors.IsAlreadyExists(err))
+
+			var ex interface{ ECRException() string }
+			require.ErrorAs(t, err, &ex)
+			assert.Equal(t, "ImageAlreadyExistsException", ex.ECRException())
 		})
 	}
 }

--- a/providers/aws/ecr/errors.go
+++ b/providers/aws/ecr/errors.go
@@ -14,6 +14,7 @@ const (
 	excScanNotFound             = "ScanNotFoundException"
 	excRepositoryPolicyNotFound = "RepositoryPolicyNotFoundException"
 	excLifecyclePolicyNotFound  = "LifecyclePolicyNotFoundException"
+	excImageAlreadyExists       = "ImageAlreadyExistsException"
 )
 
 // apiError pairs a canonical cloudemu error with the precise ECR exception name
@@ -41,4 +42,11 @@ func (e *apiError) Unwrap() error { return e.err }
 // code is fixed; the exception argument carries the AWS distinction.
 func apiErrf(exception, format string, args ...any) error {
 	return &apiError{err: errors.Newf(errors.NotFound, format, args...), exception: exception}
+}
+
+// apiErrExistsf builds an AlreadyExists apiError with a formatted message, for
+// ECR exceptions (ImageAlreadyExistsException) that the generic code-based
+// mapping would otherwise collapse to RepositoryAlreadyExistsException.
+func apiErrExistsf(exception, format string, args ...any) error {
+	return &apiError{err: errors.Newf(errors.AlreadyExists, format, args...), exception: exception}
 }

--- a/providers/aws/ecr/repo_policy.go
+++ b/providers/aws/ecr/repo_policy.go
@@ -2,55 +2,58 @@ package ecr
 
 import "context"
 
-// SetRepositoryPolicy stores a repository's resource (permissions) policy.
-func (m *Mock) SetRepositoryPolicy(_ context.Context, repository, policyText string) (string, error) {
+// SetRepositoryPolicy stores a repository's resource (permissions) policy. It
+// returns the owning registryId alongside the policy text: real ECR echoes
+// registryId on every repository-policy response.
+func (m *Mock) SetRepositoryPolicy(_ context.Context, repository, policyText string) (registryID, policy string, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	rd, ok := m.repos.Get(repository)
 	if !ok {
-		return "", apiErrf(excRepositoryNotFound, "repository %q not found", repository)
+		return "", "", apiErrf(excRepositoryNotFound, "repository %q not found", repository)
 	}
 
 	rd.repoPolicy = policyText
 
-	return rd.repoPolicy, nil
+	return rd.info.RegistryID, rd.repoPolicy, nil
 }
 
-// GetRepositoryPolicy returns a repository's resource policy, or NotFound if
-// none is set.
-func (m *Mock) GetRepositoryPolicy(_ context.Context, repository string) (string, error) {
+// GetRepositoryPolicy returns a repository's resource policy and owning
+// registryId, or NotFound if none is set.
+func (m *Mock) GetRepositoryPolicy(_ context.Context, repository string) (registryID, policy string, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	rd, ok := m.repos.Get(repository)
 	if !ok {
-		return "", apiErrf(excRepositoryNotFound, "repository %q not found", repository)
+		return "", "", apiErrf(excRepositoryNotFound, "repository %q not found", repository)
 	}
 
 	if rd.repoPolicy == "" {
-		return "", apiErrf(excRepositoryPolicyNotFound, "no repository policy for %q", repository)
+		return "", "", apiErrf(excRepositoryPolicyNotFound, "no repository policy for %q", repository)
 	}
 
-	return rd.repoPolicy, nil
+	return rd.info.RegistryID, rd.repoPolicy, nil
 }
 
-// DeleteRepositoryPolicy removes a repository's resource policy.
-func (m *Mock) DeleteRepositoryPolicy(_ context.Context, repository string) (string, error) {
+// DeleteRepositoryPolicy removes a repository's resource policy and returns
+// the owning registryId alongside the policy that was deleted.
+func (m *Mock) DeleteRepositoryPolicy(_ context.Context, repository string) (registryID, policy string, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	rd, ok := m.repos.Get(repository)
 	if !ok {
-		return "", apiErrf(excRepositoryNotFound, "repository %q not found", repository)
+		return "", "", apiErrf(excRepositoryNotFound, "repository %q not found", repository)
 	}
 
 	if rd.repoPolicy == "" {
-		return "", apiErrf(excRepositoryPolicyNotFound, "no repository policy for %q", repository)
+		return "", "", apiErrf(excRepositoryPolicyNotFound, "no repository policy for %q", repository)
 	}
 
-	policy := rd.repoPolicy
+	policy = rd.repoPolicy
 	rd.repoPolicy = ""
 
-	return policy, nil
+	return rd.info.RegistryID, policy, nil
 }

--- a/server/aws/ecr/image_scan.go
+++ b/server/aws/ecr/image_scan.go
@@ -54,6 +54,7 @@ func (h *Handler) startImageScan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wire.WriteJSON(w, map[string]any{
+		"registryId":      h.registryIDFor(r, req.RepositoryName),
 		"repositoryName":  req.RepositoryName,
 		"imageId":         req.ImageID.response(),
 		"imageScanStatus": map[string]any{"status": res.Status},
@@ -73,6 +74,7 @@ func (h *Handler) describeImageScanFindings(w http.ResponseWriter, r *http.Reque
 	}
 
 	wire.WriteJSON(w, map[string]any{
+		"registryId":      h.registryIDFor(r, req.RepositoryName),
 		"repositoryName":  req.RepositoryName,
 		"imageId":         req.ImageID.response(),
 		"imageScanStatus": map[string]any{"status": res.Status},
@@ -80,4 +82,17 @@ func (h *Handler) describeImageScanFindings(w http.ResponseWriter, r *http.Reque
 			"findingSeverityCounts": res.FindingCounts,
 		},
 	})
+}
+
+// registryIDFor returns the owning registryId (real ECR echoes it on every
+// image-scanning response), or "" if the repository lookup fails — which
+// cannot happen here since StartImageScan/GetImageScanResults above already
+// succeeded against the same repository.
+func (h *Handler) registryIDFor(r *http.Request, repositoryName string) string {
+	repo, err := h.registry.GetRepository(r.Context(), repositoryName)
+	if err != nil {
+		return ""
+	}
+
+	return repo.RegistryID
 }

--- a/server/aws/ecr/image_scan_test.go
+++ b/server/aws/ecr/image_scan_test.go
@@ -111,6 +111,120 @@ func TestSDKStartImageScanMissingImage(t *testing.T) {
 	}
 }
 
+// TestSDKImageScanRegistryID guards that StartImageScan and
+// DescribeImageScanFindings echo registryId on success — real ECR includes it
+// on both responses (it was previously omitted, which surfaces to SDK callers
+// as a null/empty RegistryId field).
+func TestSDKImageScanRegistryID(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("scan-registryid-repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	if _, err := client.PutImage(ctx, &awsecr.PutImageInput{
+		RepositoryName: aws.String("scan-registryid-repo"),
+		ImageManifest:  aws.String(sampleManifest),
+		ImageTag:       aws.String("v1"),
+	}); err != nil {
+		t.Fatalf("PutImage: %v", err)
+	}
+
+	start, err := client.StartImageScan(ctx, &awsecr.StartImageScanInput{
+		RepositoryName: aws.String("scan-registryid-repo"),
+		ImageId:        &ecrtypes.ImageIdentifier{ImageTag: aws.String("v1")},
+	})
+	if err != nil {
+		t.Fatalf("StartImageScan: %v", err)
+	}
+
+	if aws.ToString(start.RegistryId) != "123456789012" {
+		t.Fatalf("StartImageScan registryId = %q, want 123456789012", aws.ToString(start.RegistryId))
+	}
+
+	findings, err := client.DescribeImageScanFindings(ctx, &awsecr.DescribeImageScanFindingsInput{
+		RepositoryName: aws.String("scan-registryid-repo"),
+		ImageId:        &ecrtypes.ImageIdentifier{ImageTag: aws.String("v1")},
+	})
+	if err != nil {
+		t.Fatalf("DescribeImageScanFindings: %v", err)
+	}
+
+	if aws.ToString(findings.RegistryId) != "123456789012" {
+		t.Fatalf("DescribeImageScanFindings registryId = %q, want 123456789012", aws.ToString(findings.RegistryId))
+	}
+}
+
+// TestSDKDescribeImagesScanStatus guards that DescribeImages includes
+// imageScanStatus once an image has scan results (scanOnPush or an explicit
+// StartImageScan), and omits it — matching real ECR, which models it as
+// optional — for an image that has never been scanned.
+func TestSDKDescribeImagesScanStatus(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("scan-status-repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	if _, err := client.PutImage(ctx, &awsecr.PutImageInput{
+		RepositoryName: aws.String("scan-status-repo"),
+		ImageManifest:  aws.String(sampleManifest),
+		ImageTag:       aws.String("scanned"),
+	}); err != nil {
+		t.Fatalf("PutImage scanned: %v", err)
+	}
+
+	if _, err := client.PutImage(ctx, &awsecr.PutImageInput{
+		RepositoryName: aws.String("scan-status-repo"),
+		ImageManifest:  aws.String(sampleManifest + " unscanned"),
+		ImageTag:       aws.String("unscanned"),
+	}); err != nil {
+		t.Fatalf("PutImage unscanned: %v", err)
+	}
+
+	if _, err := client.StartImageScan(ctx, &awsecr.StartImageScanInput{
+		RepositoryName: aws.String("scan-status-repo"),
+		ImageId:        &ecrtypes.ImageIdentifier{ImageTag: aws.String("scanned")},
+	}); err != nil {
+		t.Fatalf("StartImageScan: %v", err)
+	}
+
+	desc, err := client.DescribeImages(ctx, &awsecr.DescribeImagesInput{
+		RepositoryName: aws.String("scan-status-repo"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeImages: %v", err)
+	}
+
+	var scannedStatus, unscannedStatus *ecrtypes.ImageScanStatus
+
+	for i := range desc.ImageDetails {
+		d := &desc.ImageDetails[i]
+		for _, tag := range d.ImageTags {
+			switch tag {
+			case "scanned":
+				scannedStatus = d.ImageScanStatus
+			case "unscanned":
+				unscannedStatus = d.ImageScanStatus
+			}
+		}
+	}
+
+	if scannedStatus == nil || scannedStatus.Status != ecrtypes.ScanStatusComplete {
+		t.Fatalf("DescribeImages scanned image imageScanStatus = %+v, want COMPLETE", scannedStatus)
+	}
+
+	if unscannedStatus != nil {
+		t.Fatalf("DescribeImages unscanned image imageScanStatus = %+v, want omitted (nil)", unscannedStatus)
+	}
+}
+
 // TestSDKDeleteRepositoryPolicyNoPolicy guards that DeleteRepositoryPolicy on an
 // existing repository that has no policy set returns
 // RepositoryPolicyNotFoundException — consistent with GetRepositoryPolicy, and

--- a/server/aws/ecr/lifecycle_policy.go
+++ b/server/aws/ecr/lifecycle_policy.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
 )
@@ -107,7 +108,7 @@ func (h *Handler) writeLifecyclePolicyResult(
 			return
 		}
 
-		wire.WriteJSONError(w, http.StatusBadRequest, "LifecyclePolicyNotFoundException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "LifecyclePolicyNotFoundException", cerrors.Message(err))
 
 		return
 	}

--- a/server/aws/ecr/lifecycle_policy_test.go
+++ b/server/aws/ecr/lifecycle_policy_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -198,6 +199,35 @@ func TestSDKECRDeleteLifecyclePolicyNoPolicy(t *testing.T) {
 	var lcNotFound *ecrtypes.LifecyclePolicyNotFoundException
 	if !errors.As(err, &lcNotFound) {
 		t.Fatalf("delete with no policy: want LifecyclePolicyNotFoundException, got %v", err)
+	}
+}
+
+// TestSDKECRGetLifecyclePolicyNoPolicyMessage guards against the internal
+// cloudemu error-code taxonomy ("NotFound: ...") leaking into the exception
+// message ECR clients see. writeLifecyclePolicyResult must use the plain
+// human-readable message, matching every other ECR error path.
+func TestSDKECRGetLifecyclePolicyNoPolicyMessage(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("msg-lc-repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	_, err := client.GetLifecyclePolicy(ctx, &awsecr.GetLifecyclePolicyInput{
+		RepositoryName: aws.String("msg-lc-repo"),
+	})
+
+	var lcNotFound *ecrtypes.LifecyclePolicyNotFoundException
+	if !errors.As(err, &lcNotFound) {
+		t.Fatalf("GetLifecyclePolicy: want LifecyclePolicyNotFoundException, got %v", err)
+	}
+
+	msg := aws.ToString(lcNotFound.Message)
+	if strings.Contains(msg, "NotFound:") {
+		t.Fatalf("LifecyclePolicyNotFoundException message leaks internal code prefix: %q", msg)
 	}
 }
 

--- a/server/aws/ecr/operations.go
+++ b/server/aws/ecr/operations.go
@@ -230,7 +230,15 @@ func (h *Handler) describeImages(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		details = append(details, toImageDetailJSON(&images[i]))
+		detail := toImageDetailJSON(&images[i])
+
+		// Real ECR includes imageScanStatus once an image has scan results
+		// (scanOnPush or an explicit StartImageScan); it is omitted until then.
+		if scan, serr := h.registry.GetImageScanResults(r.Context(), req.RepositoryName, images[i].Digest); serr == nil {
+			detail.ImageScanStatus = &imageScanStatusJSON{Status: scan.Status}
+		}
+
+		details = append(details, detail)
 	}
 
 	page, err := pagination.PaginateSorted(details,

--- a/server/aws/ecr/repo_policy.go
+++ b/server/aws/ecr/repo_policy.go
@@ -10,10 +10,12 @@ import (
 
 // repoPolicyManager is the AWS-specific ECR repository-policy surface, asserted
 // against the provider (not part of the portable ContainerRegistry driver).
+// Each method returns the owning registryId alongside the policy text: real
+// ECR echoes registryId on every repository-policy response.
 type repoPolicyManager interface {
-	SetRepositoryPolicy(ctx context.Context, repository, policyText string) (string, error)
-	GetRepositoryPolicy(ctx context.Context, repository string) (string, error)
-	DeleteRepositoryPolicy(ctx context.Context, repository string) (string, error)
+	SetRepositoryPolicy(ctx context.Context, repository, policyText string) (registryID, policy string, err error)
+	GetRepositoryPolicy(ctx context.Context, repository string) (registryID, policy string, err error)
+	DeleteRepositoryPolicy(ctx context.Context, repository string) (registryID, policy string, err error)
 }
 
 func (h *Handler) repoPolicyMgr() (repoPolicyManager, bool) {
@@ -38,13 +40,15 @@ func (h *Handler) setRepositoryPolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	policy, err := mgr.SetRepositoryPolicy(r.Context(), req.RepositoryName, req.PolicyText)
+	registryID, policy, err := mgr.SetRepositoryPolicy(r.Context(), req.RepositoryName, req.PolicyText)
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	wire.WriteJSON(w, map[string]any{"repositoryName": req.RepositoryName, "policyText": policy})
+	wire.WriteJSON(w, map[string]any{
+		"registryId": registryID, "repositoryName": req.RepositoryName, "policyText": policy,
+	})
 }
 
 func (h *Handler) getRepositoryPolicy(w http.ResponseWriter, r *http.Request) {
@@ -62,10 +66,11 @@ func (h *Handler) deleteRepositoryPolicy(w http.ResponseWriter, r *http.Request)
 }
 
 // runRepoPolicyOp runs a repository-name-only policy operation (get or delete)
-// and writes the resulting policyText, sharing the manager guard, request
-// decode, and error mapping between the two handlers.
+// and writes the resulting registryId/policyText, sharing the manager guard,
+// request decode, and error mapping between the two handlers.
 func (h *Handler) runRepoPolicyOp(
-	w http.ResponseWriter, r *http.Request, op func(repoPolicyManager, context.Context, string) (string, error),
+	w http.ResponseWriter, r *http.Request,
+	op func(repoPolicyManager, context.Context, string) (registryID, policy string, err error),
 ) {
 	mgr, ok := h.repoPolicyMgr()
 	if !ok {
@@ -81,11 +86,13 @@ func (h *Handler) runRepoPolicyOp(
 		return
 	}
 
-	policy, err := op(mgr, r.Context(), req.RepositoryName)
+	registryID, policy, err := op(mgr, r.Context(), req.RepositoryName)
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	wire.WriteJSON(w, map[string]any{"repositoryName": req.RepositoryName, "policyText": policy})
+	wire.WriteJSON(w, map[string]any{
+		"registryId": registryID, "repositoryName": req.RepositoryName, "policyText": policy,
+	})
 }

--- a/server/aws/ecr/repository_config_test.go
+++ b/server/aws/ecr/repository_config_test.go
@@ -63,10 +63,14 @@ func TestSDKECRPutImageTagMutability(t *testing.T) {
 			desc.Repositories[0].ImageTagMutability)
 	}
 
-	// The setting takes effect: re-pushing an existing tag now fails.
+	// The setting takes effect: moving the tag to different image content now
+	// fails. (Re-pushing the byte-identical manifest is a distinct case — real
+	// ECR's ImageAlreadyExistsException, covered by
+	// TestSDKECRPutImageIdenticalRepushAlreadyExists below — since nothing
+	// would actually change.)
 	_, err = client.PutImage(ctx, &awsecr.PutImageInput{
 		RepositoryName: aws.String("mut-repo"),
-		ImageManifest:  aws.String(sampleManifest),
+		ImageManifest:  aws.String(sampleManifest + " "),
 		ImageTag:       aws.String("v1"),
 	})
 
@@ -75,7 +79,9 @@ func TestSDKECRPutImageTagMutability(t *testing.T) {
 		t.Fatalf("re-push to IMMUTABLE repo: want ImageTagAlreadyExistsException, got %v", err)
 	}
 
-	// Flip back to MUTABLE; re-push succeeds again.
+	// Flip back to MUTABLE; moving the tag to different image content succeeds
+	// again (the earlier IMMUTABLE push was rejected, so v1 still points at the
+	// original sampleManifest digest here — sampleManifest+" " is a new digest).
 	if _, err := client.PutImageTagMutability(ctx, &awsecr.PutImageTagMutabilityInput{
 		RepositoryName:     aws.String("mut-repo"),
 		ImageTagMutability: ecrtypes.ImageTagMutabilityMutable,
@@ -85,10 +91,46 @@ func TestSDKECRPutImageTagMutability(t *testing.T) {
 
 	if _, err := client.PutImage(ctx, &awsecr.PutImageInput{
 		RepositoryName: aws.String("mut-repo"),
-		ImageManifest:  aws.String(sampleManifest),
+		ImageManifest:  aws.String(sampleManifest + " "),
 		ImageTag:       aws.String("v1"),
 	}); err != nil {
 		t.Fatalf("re-push after MUTABLE: %v", err)
+	}
+}
+
+// TestSDKECRPutImageIdenticalRepushAlreadyExists exercises real ECR's
+// ImageAlreadyExistsException: re-pushing the byte-identical manifest under a
+// tag it already carries is a no-op push and is rejected, regardless of the
+// repository's tag mutability setting — it is distinct from
+// ImageTagAlreadyExistsException, which fires only when the tag is being
+// moved to a DIFFERENT digest on an IMMUTABLE repository.
+func TestSDKECRPutImageIdenticalRepushAlreadyExists(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("repush-repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	if _, err := client.PutImage(ctx, &awsecr.PutImageInput{
+		RepositoryName: aws.String("repush-repo"),
+		ImageManifest:  aws.String(sampleManifest),
+		ImageTag:       aws.String("v1"),
+	}); err != nil {
+		t.Fatalf("PutImage v1: %v", err)
+	}
+
+	_, err := client.PutImage(ctx, &awsecr.PutImageInput{
+		RepositoryName: aws.String("repush-repo"),
+		ImageManifest:  aws.String(sampleManifest),
+		ImageTag:       aws.String("v1"),
+	})
+
+	var already *ecrtypes.ImageAlreadyExistsException
+	if !errors.As(err, &already) {
+		t.Fatalf("identical re-push: want ImageAlreadyExistsException, got %v", err)
 	}
 }
 

--- a/server/aws/ecr/sdk_roundtrip_test.go
+++ b/server/aws/ecr/sdk_roundtrip_test.go
@@ -68,6 +68,11 @@ func TestSDKECRRepositoryPolicy(t *testing.T) {
 		t.Fatalf("SetRepositoryPolicy echoed %q", aws.ToString(set.PolicyText))
 	}
 
+	// Real ECR echoes registryId on every repository-policy response.
+	if aws.ToString(set.RegistryId) != "123456789012" {
+		t.Fatalf("SetRepositoryPolicy registryId = %q, want 123456789012", aws.ToString(set.RegistryId))
+	}
+
 	got, err := client.GetRepositoryPolicy(ctx, &awsecr.GetRepositoryPolicyInput{
 		RepositoryName: aws.String("policy-repo"),
 	})
@@ -79,10 +84,19 @@ func TestSDKECRRepositoryPolicy(t *testing.T) {
 		t.Fatalf("GetRepositoryPolicy = %q", aws.ToString(got.PolicyText))
 	}
 
-	if _, err := client.DeleteRepositoryPolicy(ctx, &awsecr.DeleteRepositoryPolicyInput{
+	if aws.ToString(got.RegistryId) != "123456789012" {
+		t.Fatalf("GetRepositoryPolicy registryId = %q, want 123456789012", aws.ToString(got.RegistryId))
+	}
+
+	del, err := client.DeleteRepositoryPolicy(ctx, &awsecr.DeleteRepositoryPolicyInput{
 		RepositoryName: aws.String("policy-repo"),
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("DeleteRepositoryPolicy: %v", err)
+	}
+
+	if aws.ToString(del.RegistryId) != "123456789012" {
+		t.Fatalf("DeleteRepositoryPolicy registryId = %q, want 123456789012", aws.ToString(del.RegistryId))
 	}
 }
 

--- a/server/aws/ecr/tags.go
+++ b/server/aws/ecr/tags.go
@@ -3,6 +3,7 @@ package ecr
 import (
 	"context"
 	"net/http"
+	"sort"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -119,6 +120,11 @@ func (h *Handler) listTagsForResource(w http.ResponseWriter, r *http.Request) {
 	for k, v := range tags {
 		out = append(out, ecrTag{Key: k, Value: v})
 	}
+
+	// Deterministic order: a Go map iterates in randomized order, so without
+	// this a repeat ListTagsForResource call on unchanged tags returns them in
+	// a different order every time.
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
 
 	wire.WriteJSON(w, map[string]any{"tags": out})
 }

--- a/server/aws/ecr/tags_test.go
+++ b/server/aws/ecr/tags_test.go
@@ -1,0 +1,65 @@
+package ecr_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsecr "github.com/aws/aws-sdk-go-v2/service/ecr"
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+)
+
+// TestSDKECRListTagsForResourceOrderDeterministic guards against
+// ListTagsForResource returning tags in randomized order (a Go map iterates
+// in randomized order, and the tag store is a map keyed by tag). A caller
+// diffing repeated reads of unchanged tags must see a stable order.
+func TestSDKECRListTagsForResourceOrderDeterministic(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	arn := "arn:aws:ecr:us-east-1:123456789012:repository/tag-order-repo"
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("tag-order-repo"),
+		Tags: []ecrtypes.Tag{
+			{Key: aws.String("a"), Value: aws.String("1")},
+			{Key: aws.String("b"), Value: aws.String("2")},
+			{Key: aws.String("c"), Value: aws.String("3")},
+			{Key: aws.String("d"), Value: aws.String("4")},
+			{Key: aws.String("e"), Value: aws.String("5")},
+		},
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	var first []string
+
+	for i := range 5 {
+		got, err := client.ListTagsForResource(ctx, &awsecr.ListTagsForResourceInput{
+			ResourceArn: aws.String(arn),
+		})
+		if err != nil {
+			t.Fatalf("ListTagsForResource[%d]: %v", i, err)
+		}
+
+		keys := make([]string, len(got.Tags))
+		for j, tag := range got.Tags {
+			keys[j] = aws.ToString(tag.Key)
+		}
+
+		if i == 0 {
+			first = keys
+			continue
+		}
+
+		if len(keys) != len(first) {
+			t.Fatalf("ListTagsForResource[%d] returned %d tags, want %d", i, len(keys), len(first))
+		}
+
+		for j := range keys {
+			if keys[j] != first[j] {
+				t.Fatalf("ListTagsForResource order is nondeterministic: call 0 = %v, call %d = %v", first, i, keys)
+			}
+		}
+	}
+}

--- a/server/aws/ecr/types.go
+++ b/server/aws/ecr/types.go
@@ -39,12 +39,20 @@ type imageJSON struct {
 }
 
 type imageDetailJSON struct {
-	RegistryID       string   `json:"registryId,omitempty"`
-	RepositoryName   string   `json:"repositoryName"`
-	ImageDigest      string   `json:"imageDigest"`
-	ImageTags        []string `json:"imageTags,omitempty"`
-	ImageSizeInBytes int64    `json:"imageSizeInBytes,omitempty"`
-	ImagePushedAt    float64  `json:"imagePushedAt,omitempty"`
+	RegistryID       string               `json:"registryId,omitempty"`
+	RepositoryName   string               `json:"repositoryName"`
+	ImageDigest      string               `json:"imageDigest"`
+	ImageTags        []string             `json:"imageTags,omitempty"`
+	ImageSizeInBytes int64                `json:"imageSizeInBytes,omitempty"`
+	ImagePushedAt    float64              `json:"imagePushedAt,omitempty"`
+	ImageScanStatus  *imageScanStatusJSON `json:"imageScanStatus,omitempty"`
+}
+
+// imageScanStatusJSON mirrors ECR's ImageScanStatus object, echoed on
+// DescribeImages once an image has scan results (from scanOnPush or an
+// explicit StartImageScan) — omitted, as in real ECR, when no scan has run.
+type imageScanStatusJSON struct {
+	Status string `json:"status"`
 }
 
 type imageFailureJSON struct {


### PR DESCRIPTION
## Summary

Deep black-box real-user e2e audit of the AWS ECR surface (aws-cli, aws-sdk-go-v2, Terraform) against a running `cloudemu serve`. Found and fixed 6 genuine divergences from real AWS ECR behavior.

- **PutImage**: a byte-identical re-push of a manifest under a tag it already carries now returns `ImageAlreadyExistsException` regardless of tag mutability (previously silently succeeded on MUTABLE, or returned the wrong `ImageTagAlreadyExistsException` on IMMUTABLE). This is distinct from `ImageTagAlreadyExistsException`, which still fires only when a tag would move to a *different* digest on an IMMUTABLE repo.
- **SetRepositoryPolicy/GetRepositoryPolicy/DeleteRepositoryPolicy**: now echo `registryId`, which real ECR always includes.
- **GetLifecyclePolicy**: the no-policy error message no longer leaks the internal `"NotFound:"` error-code prefix into the exception message.
- **StartImageScan/DescribeImageScanFindings**: now echo `registryId`.
- **DescribeImages**: now includes `imageScanStatus` once an image has scan results (scanOnPush or an explicit StartImageScan), omitted otherwise — matches real ECR's `ImageDetail.imageScanStatus`.
- **ListTagsForResource**: tags are now returned in stable sorted order instead of Go map iteration order (repeated calls previously returned different orderings of unchanged tags).

World-case #1036 (lifecycle-policy preview) was verified correct against real AWS semantics and not re-filed.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` (full repo, race included on the ECR packages) all green.
- `gofmt -l` clean; `golangci-lint run` on `providers/aws/ecr/...` and `server/aws/ecr/...`: 0 issues.
- `go generate ./...` + `git diff --exit-code docs/coverage`: no drift.
- Each fix re-verified black-box against a freshly rebuilt `cloudemu serve` binary via aws-cli, matching the exact repro from the audit.
- Terraform `aws_ecr_repository` (image_tag_mutability, image_scanning_configuration, tags) + `aws_ecr_lifecycle_policy` + `aws_ecr_repository_policy`: `apply` then `plan -detailed-exitcode` is clean (exit 0, "No changes"), before and after the fixes.
- Each fix has a dedicated regression test:
  - `TestPutImageIdenticalRepush`, `TestImageTagMutability` (provider-level)
  - `TestSDKECRPutImageIdenticalRepushAlreadyExists`, `TestSDKECRPutImageTagMutability`
  - `TestSDKECRRepositoryPolicy` (extended with registryId assertions)
  - `TestSDKECRGetLifecyclePolicyNoPolicyMessage`
  - `TestSDKImageScanRegistryID`
  - `TestSDKDescribeImagesScanStatus`
  - `TestSDKECRListTagsForResourceOrderDeterministic`