### PR TITLE
fix(gcp-cloudrun): real-user e2e divergences

### DIFF
--- a/providers/gcp/cloudrun/services.go
+++ b/providers/gcp/cloudrun/services.go
@@ -196,18 +196,64 @@ func (m *Mock) GetRevision(_ context.Context, name string) (*driver.Revision, er
 	return cloneRevision(rev), nil
 }
 
-// DeleteRevision removes a single revision of a service.
+// DeleteRevision removes a single revision of a service. Real Cloud Run
+// refuses to delete a revision that is able to receive traffic, is the only
+// revision of its service, or is the service's latest revision — deleting any
+// of those would leave the service's own revision/traffic pointers dangling
+// at a revision that no longer exists. See
+// https://docs.cloud.google.com/run/docs/managing/revisions.
 func (m *Mock) DeleteRevision(_ context.Context, name string) error {
 	id := lastSegment(name)
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if !m.revisions.Has(id) {
+	rev, ok := m.revisions.Get(id)
+	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "revision %q not found", id)
 	}
 
+	if svc, ok := m.services.Get(rev.Service); ok {
+		siblings := 0
+
+		for _, r := range m.revisions.SortedValues() {
+			if r.Service == rev.Service {
+				siblings++
+			}
+		}
+
+		if err := checkRevisionDeletable(svc, id, siblings); err != nil {
+			return err
+		}
+	}
+
 	m.revisions.Delete(id)
+
+	return nil
+}
+
+// checkRevisionDeletable returns a FailedPrecondition error naming why id
+// cannot be deleted from svc — it is the service's only revision, its latest
+// revision, or it is currently allocated traffic — or nil when the delete may
+// proceed. siblingCount is the number of revisions svc currently has,
+// including id itself.
+func checkRevisionDeletable(svc *driver.Service, id string, siblingCount int) error {
+	if siblingCount <= 1 {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"revision %q is the only revision of service %q and cannot be deleted", id, svc.Name)
+	}
+
+	if id == svc.LatestReadyRevision || id == svc.LatestCreatedRevision {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"revision %q is the latest revision of service %q and cannot be deleted", id, svc.Name)
+	}
+
+	for _, t := range svc.TrafficStatuses {
+		if t.Revision == id && t.Percent > 0 {
+			return cerrors.Newf(cerrors.FailedPrecondition,
+				"revision %q is serving %d%% of traffic on service %q and cannot be deleted", id, t.Percent, svc.Name)
+		}
+	}
 
 	return nil
 }

--- a/server/gcp/cloudrun/handler.go
+++ b/server/gcp/cloudrun/handler.go
@@ -541,15 +541,23 @@ func writeError(w http.ResponseWriter, status int, reason, msg string) {
 	})
 }
 
+// writeErr maps a driver error to its wire envelope. The message is always
+// cerrors.Message(err), never err.Error() — the latter would bake cloudemu's
+// internal code-name prefix (e.g. "NotFound: ") into the message a real
+// client sees, which no real Cloud Run response ever does.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+		writeError(w, http.StatusNotFound, "NOT_FOUND", msg)
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "ALREADY_EXISTS", err.Error())
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", msg)
+	case cerrors.IsFailedPrecondition(err):
+		writeError(w, http.StatusBadRequest, "FAILED_PRECONDITION", msg)
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", msg)
 	default:
-		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+		writeError(w, http.StatusInternalServerError, "INTERNAL", msg)
 	}
 }

--- a/server/gcp/cloudrun/services_sdk_test.go
+++ b/server/gcp/cloudrun/services_sdk_test.go
@@ -3,9 +3,11 @@ package cloudrun_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
+	"google.golang.org/api/googleapi"
 	run "google.golang.org/api/run/v2"
 )
 
@@ -343,5 +345,111 @@ func TestSDKServicesListPagination(t *testing.T) {
 
 	if len(page2.Services) != 1 || page2.NextPageToken != "" {
 		t.Fatalf("page2 services=%d token=%q", len(page2.Services), page2.NextPageToken)
+	}
+}
+
+// TestSDKErrorMessagesHaveNoCodePrefix covers a real-user e2e finding: a
+// NotFound/AlreadyExists error's wire message must be the plain human text,
+// never cloudemu's internal code-name ("NotFound: ", "AlreadyExists: ")
+// baked in — no real Cloud Run response ever leaks that internal taxonomy.
+func TestSDKErrorMessagesHaveNoCodePrefix(t *testing.T) {
+	svc := newRun(t, nil)
+	ctx := context.Background()
+
+	_, err := svc.Projects.Locations.Services.Get(parent + "/services/nope").Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 404 {
+		t.Fatalf("Get(missing): got %v, want 404", err)
+	}
+
+	if strings.HasPrefix(gerr.Message, "NotFound:") {
+		t.Errorf("message = %q, leaks internal code-name prefix", gerr.Message)
+	}
+
+	if _, err := svc.Projects.Locations.Services.Create(parent, sdkService()).
+		ServiceId("web").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	_, err = svc.Projects.Locations.Services.Create(parent, sdkService()).ServiceId("web").Context(ctx).Do()
+
+	gerr = nil
+	if !errors.As(err, &gerr) || gerr.Code != 409 {
+		t.Fatalf("duplicate Create: got %v, want 409", err)
+	}
+
+	if strings.HasPrefix(gerr.Message, "AlreadyExists:") {
+		t.Errorf("message = %q, leaks internal code-name prefix", gerr.Message)
+	}
+}
+
+// TestSDKRevisionDeleteBlockedWhileServingOrLatest covers a real-user e2e
+// finding: real Cloud Run refuses to delete a revision that is able to
+// receive traffic, is the only revision of its service, or is the service's
+// latest revision — deleting any of those would leave the service's own
+// latestReadyRevision/latestCreatedRevision/trafficStatuses pointers dangling
+// at a revision GetRevision then 404s on. See
+// https://docs.cloud.google.com/run/docs/managing/revisions.
+func TestSDKRevisionDeleteBlockedWhileServingOrLatest(t *testing.T) {
+	svc := newRun(t, nil)
+	ctx := context.Background()
+
+	op, err := svc.Projects.Locations.Services.Create(parent, sdkService()).ServiceId("web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var created run.GoogleCloudRunV2Service
+	decodeOpResponse(t, op, &created)
+
+	// The sole revision: it is the only revision, the latest revision, AND
+	// serving 100% of traffic — any one of those alone must block the delete.
+	_, err = svc.Projects.Locations.Services.Revisions.Delete(created.LatestReadyRevision).Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 400 {
+		t.Fatalf("delete sole revision: got %v, want 400 FAILED_PRECONDITION", err)
+	}
+
+	got, err := svc.Projects.Locations.Services.Get(parent + "/services/web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.LatestReadyRevision != created.LatestReadyRevision {
+		t.Fatalf("service's latestReadyRevision changed after a blocked delete: %q", got.LatestReadyRevision)
+	}
+
+	if _, err := svc.Projects.Locations.Services.Revisions.Get(created.LatestReadyRevision).Context(ctx).Do(); err != nil {
+		t.Fatalf("revision still resolvable after blocked delete: %v", err)
+	}
+
+	// Deploy a second revision: the first revision is now neither latest nor
+	// serving traffic, so deleting it must still succeed exactly as before.
+	updated := sdkService()
+	updated.Template.Containers[0].Image = "gcr.io/demo/web:v2"
+
+	if _, err := svc.Projects.Locations.Services.Patch(parent+"/services/web", updated).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Services.Revisions.Delete(created.LatestReadyRevision).
+		Context(ctx).Do(); err != nil {
+		t.Fatalf("delete superseded, non-serving revision: got %v, want success", err)
+	}
+
+	// The new latest revision, now the service's only remaining revision and
+	// serving 100% of traffic, must itself be blocked.
+	got, err = svc.Projects.Locations.Services.Get(parent + "/services/web").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	_, err = svc.Projects.Locations.Services.Revisions.Delete(got.LatestReadyRevision).Context(ctx).Do()
+
+	gerr = nil
+	if !errors.As(err, &gerr) || gerr.Code != 400 {
+		t.Fatalf("delete new latest/sole revision: got %v, want 400 FAILED_PRECONDITION", err)
 	}
 }


### PR DESCRIPTION
## Summary

Real-user black-box audit of GCP Cloud Run (services/revisions/jobs) via the
real `google.golang.org/api/run/v2` SDK against a running `cloudemu serve`.
Cloud Run had already been through 4 prior audit rounds (#649, #732, #782,
#1007); this pass found two remaining genuine divergences.

### 1. Internal error-taxonomy prefix leaked into every Cloud Run error message

`writeErr` used `err.Error()` on the internal `*cerrors.Error` instead of
`cerrors.Message(err)`, so wire error messages carried cloudemu's internal
code name baked in (e.g. `"NotFound: service \"x\" not found"` instead of
just `"service \"x\" not found"`). Same recurring pattern already fixed once
each in GCS/GCE/Pub/Sub/GKE. Also added a `FailedPrecondition` → 400
`FAILED_PRECONDITION` branch (used by the fix below), matching the
convention `server/gcp/pubsub/handler.go` already uses.

### 2. Revisions.Delete allowed deleting a service's only/latest/traffic-serving revision

Real Cloud Run refuses `revisions.delete` with `FAILED_PRECONDITION` when
the revision is able to receive traffic, is the only revision of the
service, or is the service's latest revision (see
https://docs.cloud.google.com/run/docs/managing/revisions). CloudEmu had no
such checks, so deleting a freshly created service's sole revision silently
succeeded and left the service's `latestReadyRevision` /
`latestCreatedRevision` / `trafficStatuses[].revision` pointing at a
revision that `Revisions.Get` then 404s on — a genuine data-integrity bug,
not just an error-fidelity nit.

`DeleteRevision` now checks: only-revision, latest-revision
(ready-or-created), and traffic-serving (`Percent > 0`) before deleting.
The pre-existing "delete an older, superseded, non-serving revision" path
is unaffected.

## Evidence (black-box, before/after)

Before:
```
$ curl .../services/does-not-exist
{"error":{"code":404,"message":"NotFound: service \"does-not-exist\" not found", ...}}

$ curl -X DELETE .../services/web/revisions/web-00001-xxxx   # sole/latest/100% revision
{"name":"...operations/delete-rev-...","done":true}           # silently succeeds
$ curl .../services/web
{"latestReadyRevision":"...web-00001-xxxx", ...}               # now dangling
$ curl .../services/web/revisions/web-00001-xxxx
{"error":{"code":404, ...}}                                    # confirms the dangle
```

After:
```
$ curl .../services/does-not-exist
{"error":{"code":404,"message":"service \"does-not-exist\" not found", ...}}

$ curl -X DELETE .../services/web/revisions/web-00001-xxxx
{"error":{"code":400,"message":"revision \"web-00001-xxxx\" is the only revision of service \"web\" and cannot be deleted","status":"FAILED_PRECONDITION"}}

# after a second deploy, deleting the now-superseded, non-serving revision still succeeds:
$ curl -X DELETE .../services/web/revisions/web-00001-xxxx
{"name":"...operations/delete-rev-...","done":true}
```

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers/gcp/cloudrun/... ./server/gcp/cloudrun/... -race`
- [x] `go test ./server/gcp/... ./providers/gcp/...` (full GCP surface, no regressions)
- [x] `gofmt -l`, `golangci-lint run --new-from-rev=origin/development` — 0 issues
- [x] `go generate ./...` — no `docs/coverage` diff
- [x] New regression tests: `TestSDKErrorMessagesHaveNoCodePrefix`,
      `TestSDKRevisionDeleteBlockedWhileServingOrLatest`
      (`server/gcp/cloudrun/services_sdk_test.go`)
- [x] Re-verified both fixes black-box against a running `cloudemu serve` binary