### PR TITLE
fix(azure-cache): real-user e2e divergences

### DIFF
--- a/server/azure/cache/idempotent_delete_sdk_test.go
+++ b/server/azure/cache/idempotent_delete_sdk_test.go
@@ -1,0 +1,157 @@
+package cache_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
+)
+
+const (
+	otherRG = "rg-other"
+)
+
+// TestSDKAzureCacheDeleteMissingIsIdempotent confirms deleting a cache name
+// that was never created succeeds (real ARM DELETE is idempotent — a missing
+// resource is a no-op success, not an error), matching every other Azure
+// handler in this codebase.
+func TestSDKAzureCacheDeleteMissingIsIdempotent(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	poller, err := client.BeginDelete(ctx, testRG, "never-existed", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete of a never-created cache should be a no-op, got: %v", err)
+	}
+}
+
+// TestSDKAzureCacheUpdateMissingIs404 confirms PATCH (Redis.Update) on a name
+// that was never created fails with 404 rather than silently creating the
+// cache — real Azure's Update requires the resource to already exist.
+func TestSDKAzureCacheUpdateMissingIs404(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	poller, err := client.BeginUpdate(ctx, testRG, "patch-never-created", armredis.UpdateParameters{
+		Tags: map[string]*string{"env": to.Ptr("prod")},
+	}, nil)
+
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("Update(never-created): got %v, want 404", err)
+	}
+}
+
+// TestSDKAzureCacheDeleteWrongResourceGroupIsNoop confirms a DELETE issued
+// against a URL naming a DIFFERENT resource group than the one a cache was
+// actually created in leaves that cache untouched — it must not be reachable,
+// let alone deletable, via a resource group it doesn't belong to.
+func TestSDKAzureCacheDeleteWrongResourceGroupIsNoop(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	createRedis(t, client, testRG, "cross-rg-delete", nil)
+
+	poller, err := client.BeginDelete(ctx, otherRG, "cross-rg-delete", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete(wrong rg): %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete via wrong resource group should be a no-op, got: %v", err)
+	}
+
+	got, err := client.Get(ctx, testRG, "cross-rg-delete", nil)
+	if err != nil {
+		t.Fatalf("cache should still exist in its real resource group: %v", err)
+	}
+
+	if got.Name == nil || *got.Name != "cross-rg-delete" {
+		t.Fatalf("Get after wrong-rg delete = %v, want cross-rg-delete intact", got.Name)
+	}
+}
+
+// TestSDKAzureCacheUpdateWrongResourceGroupNotFound confirms a PATCH issued
+// against a URL naming a DIFFERENT resource group than the one a cache
+// actually belongs to is a 404 — it must not silently re-parent (steal) the
+// cache into the URL's resource group.
+func TestSDKAzureCacheUpdateWrongResourceGroupNotFound(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	createRedis(t, client, testRG, "cross-rg-update", nil)
+
+	poller, err := client.BeginUpdate(ctx, otherRG, "cross-rg-update", armredis.UpdateParameters{
+		Tags: map[string]*string{"hijacked": to.Ptr("true")},
+	}, nil)
+
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("Update via wrong resource group: got %v, want 404", err)
+	}
+
+	got, err := client.Get(ctx, testRG, "cross-rg-update", nil)
+	if err != nil {
+		t.Fatalf("Get in real resource group: %v", err)
+	}
+
+	if _, ok := got.Tags["hijacked"]; ok {
+		t.Fatal("cache was mutated by a PATCH issued against a different resource group")
+	}
+}
+
+// TestSDKAzureCachePutWrongResourceGroupConflict confirms a PUT (BeginCreate)
+// for a name already taken by a DIFFERENT resource group's cache is rejected
+// as a conflict — Redis cache names are globally unique (they get a public DNS
+// hostname), so this scope cannot "adopt" another group's cache by re-PUTting
+// its name.
+func TestSDKAzureCachePutWrongResourceGroupConflict(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	createRedis(t, client, testRG, "cross-rg-put", nil)
+
+	poller, err := client.BeginCreate(ctx, otherRG, "cross-rg-put", armredis.CreateParameters{
+		Location: to.Ptr("eastus"),
+		Properties: &armredis.CreateProperties{
+			SKU: &armredis.SKU{
+				Name:     to.Ptr(armredis.SKUNameStandard),
+				Family:   to.Ptr(armredis.SKUFamilyC),
+				Capacity: to.Ptr(int32(1)),
+			},
+		},
+	}, nil)
+
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 409 {
+		t.Fatalf("Create via wrong resource group for a taken name: got %v, want 409", err)
+	}
+
+	got, err := client.Get(ctx, testRG, "cross-rg-put", nil)
+	if err != nil {
+		t.Fatalf("Get in real resource group: %v", err)
+	}
+
+	if got.Name == nil || *got.Name != "cross-rg-put" {
+		t.Fatalf("original cache should be untouched, got %v", got.Name)
+	}
+}

--- a/server/azure/cache/operations.go
+++ b/server/azure/cache/operations.go
@@ -4,16 +4,24 @@ import (
 	"net/http"
 	"strconv"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
 	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
-// createOrUpdateCache handles PUT — Redis.BeginCreate. The LRO completes inline:
-// returning 201/200 with the resource body terminates the SDK's poller on the
-// first response. Create when absent, otherwise apply the request's mutable
-// fields (SKU, tags) via UpdateCache — ARM PUT semantics, so the caller's
-// changes are never silently discarded.
+// createOrUpdateCache handles PUT — Redis.BeginCreate — and PATCH — Redis.Update.
+// The LRO completes inline: returning 201/200 with the resource body terminates
+// the SDK's poller on the first response.
+//
+// A cache found by name is only treated as "this request's resource" when its
+// recorded scope matches the request path's subscription+resourceGroup — Redis
+// cache names are globally unique (they get a public DNS hostname), so a name
+// that already exists under a DIFFERENT resource group is not this scope's
+// cache. PATCH never creates: real Azure's Update requires the cache to
+// already exist here, so a missing or wrong-scope name is a 404. PUT keeps
+// upsert semantics; a wrong-scope name falls through to CreateCache, whose
+// existing AlreadyExists check already answers "name taken" (409 Conflict).
 func (h *Handler) createOrUpdateCache(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body redisJSON
 	if !azurearm.DecodeJSON(w, r, &body) {
@@ -24,32 +32,40 @@ func (h *Handler) createOrUpdateCache(w http.ResponseWriter, r *http.Request, rp
 		return
 	}
 
-	cfg := cachedriver.CacheConfig{
-		Name:     rp.ResourceName,
-		Engine:   "redis",
-		Location: body.Location,
-		NodeType: nodeTypeFromBody(&body),
-		Tags:     body.Tags,
-		Scope:    scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
+	reqScope := scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}
+
+	existing, err := h.cache.GetCache(r.Context(), rp.ResourceName)
+
+	switch {
+	case err == nil && existing.Scope.Matches(reqScope):
+		h.updateExistingCache(w, r, rp, &body)
+	case r.Method == http.MethodPatch:
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound",
+			"cache "+rp.ResourceName+" not found in resource group "+rp.ResourceGroup)
+	default:
+		h.createNewCache(w, r, rp, &body)
 	}
-	applySKUAndClustering(&cfg, &body)
-	applyRedisProperties(&cfg, &body)
+}
 
-	if _, err := h.cache.GetCache(r.Context(), rp.ResourceName); err == nil {
-		info, uerr := h.cache.UpdateCache(r.Context(), cfg)
-		if uerr != nil {
-			azurearm.WriteCErr(w, uerr)
-			return
-		}
-
-		resp := toRedisJSON(rp, info)
-		attachAccessKeys(&resp, info)
-		azurearm.WriteJSON(w, http.StatusOK, resp)
-
+// updateExistingCache applies body's mutable fields to a cache already
+// confirmed to exist in the request's resource-group scope.
+func (h *Handler) updateExistingCache(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, body *redisJSON) {
+	info, err := h.cache.UpdateCache(r.Context(), cacheConfigFromBody(rp, body))
+	if err != nil {
+		azurearm.WriteCErr(w, err)
 		return
 	}
 
-	info, err := h.cache.CreateCache(r.Context(), cfg)
+	resp := toRedisJSON(rp, info)
+	attachAccessKeys(&resp, info)
+	azurearm.WriteJSON(w, http.StatusOK, resp)
+}
+
+// createNewCache provisions a cache under the request's resource-group scope.
+// If the name is already taken (globally, by another scope), CreateCache's own
+// AlreadyExists check fires and maps to 409 Conflict.
+func (h *Handler) createNewCache(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, body *redisJSON) {
+	info, err := h.cache.CreateCache(r.Context(), cacheConfigFromBody(rp, body))
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -58,6 +74,22 @@ func (h *Handler) createOrUpdateCache(w http.ResponseWriter, r *http.Request, rp
 	resp := toRedisJSON(rp, info)
 	attachAccessKeys(&resp, info)
 	azurearm.WriteJSON(w, http.StatusCreated, resp)
+}
+
+// cacheConfigFromBody builds the driver config shared by create and update.
+func cacheConfigFromBody(rp *azurearm.ResourcePath, body *redisJSON) cachedriver.CacheConfig {
+	cfg := cachedriver.CacheConfig{
+		Name:     rp.ResourceName,
+		Engine:   "redis",
+		Location: body.Location,
+		NodeType: nodeTypeFromBody(body),
+		Tags:     body.Tags,
+		Scope:    scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
+	}
+	applySKUAndClustering(&cfg, body)
+	applyRedisProperties(&cfg, body)
+
+	return cfg
 }
 
 // attachAccessKeys adds the cache's access keys to a Create/Update response.
@@ -256,15 +288,43 @@ func (h *Handler) cacheInScope(w http.ResponseWriter, r *http.Request, rp *azure
 	return true
 }
 
-// deleteCache handles DELETE — Redis.BeginDelete. Returning 200 with an empty
-// body completes the SDK's poller on the first response.
+// deleteCache handles DELETE — Redis.BeginDelete. Returning 200/204 completes
+// the SDK's poller on the first response.
+//
+// A cache found by name but recorded under a DIFFERENT resource group than the
+// request path is, from this scope's perspective, not here: real ARM resource
+// IDs are scoped by subscription+resourceGroup, so a DELETE naming the wrong
+// group must not touch the resource that actually lives elsewhere — it is a
+// no-op success, exactly like deleting a name that never existed.
 func (h *Handler) deleteCache(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	if err := h.cache.DeleteCache(r.Context(), rp.ResourceName); err != nil {
-		azurearm.WriteCErr(w, err)
+	info, err := h.cache.GetCache(r.Context(), rp.ResourceName)
+	if err != nil {
+		writeDeleteStatus(w, err)
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	if !info.Scope.Matches(scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}) {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	writeDeleteStatus(w, h.cache.DeleteCache(r.Context(), rp.ResourceName))
+}
+
+// writeDeleteStatus maps a delete result to the ARM idempotent-DELETE
+// contract: success is 200, "already gone" (NotFound) is 204 No Content
+// rather than an error — the same convention every other Azure handler in
+// this codebase follows (acr, aks, containerapps, cosmosaccount, cosmosdb,
+// databricks, dns, eventgrid, eventhub, kusto, loganalytics, managedidentity).
+func writeDeleteStatus(w http.ResponseWriter, err error) {
+	switch {
+	case err == nil:
+		w.WriteHeader(http.StatusOK)
+	case cerrors.IsNotFound(err):
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		azurearm.WriteCErr(w, err)
+	}
 }
 
 // listCaches handles GET on the collection — Redis.ListByResourceGroup /


### PR DESCRIPTION
## Summary

Real-user e2e audit of Azure Cache for Redis (`Microsoft.Cache/redis`) driven black-box via the real `armredis` SDK against `cloudemu serve`. Found and fixed three genuine divergences from real Azure ARM behavior, all in `server/azure/cache/operations.go`:

1. **DELETE on a missing cache returned 404 instead of idempotent 204.** Real ARM DELETE is idempotent — this is the exact convention already followed by every other Azure handler in the codebase (acr, aks, containerapps, cosmosaccount, cosmosdb, databricks, dns, eventgrid, eventhub, kusto, loganalytics, managedidentity). `deleteCache` now uses a `writeDeleteStatus` helper mirroring that pattern.

2. **PATCH (`Redis.Update`) on a non-existent cache silently created it.** PUT and PATCH shared the same upsert code path with no method distinction. Real Azure's Update requires the resource to already exist. `createOrUpdateCache` now branches: PATCH on a missing/wrong-scope name is 404; PUT keeps upsert semantics.

3. **DELETE and PUT/PATCH did not check resource-group scope**, which allowed:
   - Deleting a cache that actually lived in a *different* resource group, by issuing DELETE against the wrong group's URL.
   - Silently "stealing"/re-parenting a cache into a different resource group via PATCH, since the handler always overwrote the stored scope from the request path whenever a cache with that name existed anywhere.

   Fix: both DELETE and PUT/PATCH now compare the cache's recorded scope against the request path's subscription+resourceGroup. A wrong-scope DELETE is a no-op (204). A wrong-scope PATCH is 404. A wrong-scope PUT for a name that's taken falls through to `CreateCache`, which already returns `AlreadyExists` (409 Conflict) — reusing the existing, already-tested driver error path rather than adding new error-shaping logic (Redis cache names are globally unique, like Storage Accounts/Key Vault).

## Evidence

Verified black-box against a live `cloudemu serve -providers=azure` instance with a scratch driver using the real `armredis` SDK, before and after the fix — full before/after transcripts in the audit notes. All existing tests in `providers/azure/cache/...` and `server/azure/cache/...` (lifecycle, Premium clustering, tags round-trip/PATCH-replace, list-order determinism, access keys, etc.) still pass unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers/azure/cache/... ./server/azure/cache/... -race` — all pass, including 5 new regression tests
- [x] `golangci-lint run --new-from-rev=origin/development ./server/azure/cache/... ./providers/azure/cache/...` — 0 issues
- [x] `go generate ./...` + `git diff docs/coverage` — no drift
- [x] Re-verified all 3 fixes black-box via the real SDK against a rebuilt server binary