### PR TITLE
fix(sfn): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/sfn/executions.go
+++ b/providers/aws/sfn/executions.go
@@ -3,6 +3,7 @@ package sfn
 import (
 	"context"
 	"encoding/json"
+	"sort"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
@@ -262,6 +263,10 @@ func abortHistory(events []driver.HistoryEvent, now time.Time, errCode, cause st
 	})
 }
 
+// ListExecutions returns the executions of stateMachineArn ordered the way
+// real Step Functions does: most recently started first (ties broken by ARN
+// for deterministic output when two executions share a start timestamp, e.g.
+// under FakeClock).
 func (m *Mock) ListExecutions(_ context.Context, stateMachineArn, statusFilter string) ([]driver.Execution, error) {
 	if _, err := m.getSM(stateMachineArn); err != nil {
 		return nil, err
@@ -287,6 +292,14 @@ func (m *Mock) ListExecutions(_ context.Context, stateMachineArn, statusFilter s
 
 		out = append(out, exec)
 	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if !out[i].StartDate.Equal(out[j].StartDate) {
+			return out[i].StartDate.After(out[j].StartDate)
+		}
+
+		return out[i].ARN < out[j].ARN
+	})
 
 	return out, nil
 }

--- a/providers/aws/sfn/sfn.go
+++ b/providers/aws/sfn/sfn.go
@@ -6,9 +6,8 @@
 // and records the per-state event list GetExecutionHistory returns. Execution is
 // synchronous; the settle overlay keeps RUNNING observable under AsyncSettle.
 // ctx is threaded end-to-end so the Task->Lambda seam carries recursionguard
-// depth. Pass, Choice, Wait, Succeed, Fail and Task (Lambda, with Retry/Catch)
-// are supported; Parallel and Map parse but fail loudly at run time until their
-// handlers land.
+// depth. Pass, Choice, Wait, Succeed, Fail, Task (Lambda, with Retry/Catch),
+// Parallel and Map are all supported.
 package sfn
 
 import (

--- a/providers/aws/sfn/sfn_test.go
+++ b/providers/aws/sfn/sfn_test.go
@@ -611,3 +611,68 @@ func TestAsyncSettleSyncExecutionAndHistory(t *testing.T) {
 		t.Fatalf("settled history len = %d, want 4 ending ExecutionSucceeded", len(hist))
 	}
 }
+
+// TestListStateMachinesOrderedNewestFirst pins that ListStateMachines returns
+// state machines most-recently-created first (real Step Functions order),
+// not alphabetically by name/ARN. Names are chosen so the two orders disagree.
+func TestListStateMachinesOrderedNewestFirst(t *testing.T) {
+	fc := config.NewFakeClock(time.Unix(0, 0))
+	m := sfn.New(config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"),
+		config.WithAccountID("000000000000")))
+	ctx := context.Background()
+
+	for _, n := range []string{"zzz-first", "aaa-second", "mmm-third"} {
+		createSM(t, m, n)
+		fc.Advance(time.Second)
+	}
+
+	got, err := m.ListStateMachines(ctx)
+	if err != nil {
+		t.Fatalf("ListStateMachines: %v", err)
+	}
+
+	want := []string{"mmm-third", "aaa-second", "zzz-first"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d state machines, want %d", len(got), len(want))
+	}
+
+	for i, w := range want {
+		if got[i].Name != w {
+			t.Fatalf("position %d = %q, want %q", i, got[i].Name, w)
+		}
+	}
+}
+
+// TestListExecutionsOrderedNewestFirst pins that ListExecutions returns
+// executions most-recently-started first (real Step Functions order), not
+// alphabetically by execution name/ARN.
+func TestListExecutionsOrderedNewestFirst(t *testing.T) {
+	fc := config.NewFakeClock(time.Unix(0, 0))
+	m := sfn.New(config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"),
+		config.WithAccountID("000000000000")))
+	ctx := context.Background()
+	arn := createSM(t, m, "sm")
+
+	for _, n := range []string{"zzz-first", "aaa-second", "mmm-third"} {
+		if _, err := m.StartExecution(ctx, driver.StartExecutionInput{StateMachineArn: arn, Name: n, Input: "{}"}); err != nil {
+			t.Fatalf("StartExecution(%s): %v", n, err)
+		}
+		fc.Advance(time.Second)
+	}
+
+	got, err := m.ListExecutions(ctx, arn, "")
+	if err != nil {
+		t.Fatalf("ListExecutions: %v", err)
+	}
+
+	want := []string{"mmm-third", "aaa-second", "zzz-first"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d executions, want %d", len(got), len(want))
+	}
+
+	for i, w := range want {
+		if got[i].Name != w {
+			t.Fatalf("position %d = %q, want %q", i, got[i].Name, w)
+		}
+	}
+}

--- a/providers/aws/sfn/statemachines.go
+++ b/providers/aws/sfn/statemachines.go
@@ -2,6 +2,7 @@ package sfn
 
 import (
 	"context"
+	"sort"
 	"strconv"
 	"time"
 
@@ -234,6 +235,10 @@ func (m *Mock) DeleteStateMachine(_ context.Context, arn string) error {
 	return nil
 }
 
+// ListStateMachines returns every state machine ordered the way real Step
+// Functions does: most recently created first (ties broken by ARN for
+// deterministic output when two machines share a creation timestamp, e.g.
+// under FakeClock).
 func (m *Mock) ListStateMachines(_ context.Context) ([]driver.StateMachine, error) {
 	all := m.machines.SortedValues()
 	out := make([]driver.StateMachine, 0, len(all))
@@ -243,6 +248,14 @@ func (m *Mock) ListStateMachines(_ context.Context) ([]driver.StateMachine, erro
 		out = append(out, copySM(&sd.sm))
 		sd.mu.RUnlock()
 	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if !out[i].CreationDate.Equal(out[j].CreationDate) {
+			return out[i].CreationDate.After(out[j].CreationDate)
+		}
+
+		return out[i].ARN < out[j].ARN
+	})
 
 	return out, nil
 }

--- a/server/aws/sfn/list_order_test.go
+++ b/server/aws/sfn/list_order_test.go
@@ -1,0 +1,117 @@
+package sfn_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awssfn "github.com/aws/aws-sdk-go-v2/service/sfn"
+
+	"github.com/stackshy/cloudemu/v2"
+	cloudconfig "github.com/stackshy/cloudemu/v2/config"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// TestSDKListStateMachinesOrderedNewestFirst pins that ListStateMachines
+// returns state machines most-recently-created first, matching real Step
+// Functions — not alphabetical by name/ARN. The machine names are chosen so
+// alphabetical and chronological order disagree.
+func TestSDKListStateMachinesOrderedNewestFirst(t *testing.T) {
+	fc := cloudconfig.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	cloud := cloudemu.NewAWS(cloudconfig.WithClock(fc))
+	ts := httptest.NewServer(awsserver.New(awsserver.Drivers{SFN: cloud.SFN}))
+	t.Cleanup(ts.Close)
+
+	c := newOrderTestClient(t, ts.URL)
+	ctx := context.Background()
+
+	for _, n := range []string{"zzz-first", "aaa-second", "mmm-third"} {
+		if _, err := c.CreateStateMachine(ctx, &awssfn.CreateStateMachineInput{
+			Name: aws.String(n), Definition: aws.String(definition),
+			RoleArn: aws.String("arn:aws:iam::000000000000:role/r"),
+		}); err != nil {
+			t.Fatalf("CreateStateMachine(%s): %v", n, err)
+		}
+		fc.Advance(time.Second)
+	}
+
+	out, err := c.ListStateMachines(ctx, &awssfn.ListStateMachinesInput{})
+	if err != nil {
+		t.Fatalf("ListStateMachines: %v", err)
+	}
+
+	want := []string{"mmm-third", "aaa-second", "zzz-first"}
+	if len(out.StateMachines) != len(want) {
+		t.Fatalf("got %d state machines, want %d", len(out.StateMachines), len(want))
+	}
+
+	for i, w := range want {
+		if got := aws.ToString(out.StateMachines[i].Name); got != w {
+			t.Fatalf("position %d = %q, want %q", i, got, w)
+		}
+	}
+}
+
+// TestSDKListExecutionsOrderedNewestFirst pins that ListExecutions returns
+// executions most-recently-started first, matching real Step Functions — not
+// alphabetical by execution name/ARN.
+func TestSDKListExecutionsOrderedNewestFirst(t *testing.T) {
+	fc := cloudconfig.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	cloud := cloudemu.NewAWS(cloudconfig.WithClock(fc))
+	ts := httptest.NewServer(awsserver.New(awsserver.Drivers{SFN: cloud.SFN}))
+	t.Cleanup(ts.Close)
+
+	c := newOrderTestClient(t, ts.URL)
+	ctx := context.Background()
+
+	sm, err := c.CreateStateMachine(ctx, &awssfn.CreateStateMachineInput{
+		Name: aws.String("sm"), Definition: aws.String(definition),
+		RoleArn: aws.String("arn:aws:iam::000000000000:role/r"),
+	})
+	if err != nil {
+		t.Fatalf("CreateStateMachine: %v", err)
+	}
+
+	for _, n := range []string{"zzz-first", "aaa-second", "mmm-third"} {
+		if _, err := c.StartExecution(ctx, &awssfn.StartExecutionInput{
+			StateMachineArn: sm.StateMachineArn, Name: aws.String(n), Input: aws.String("{}"),
+		}); err != nil {
+			t.Fatalf("StartExecution(%s): %v", n, err)
+		}
+		fc.Advance(time.Second)
+	}
+
+	out, err := c.ListExecutions(ctx, &awssfn.ListExecutionsInput{StateMachineArn: sm.StateMachineArn})
+	if err != nil {
+		t.Fatalf("ListExecutions: %v", err)
+	}
+
+	want := []string{"mmm-third", "aaa-second", "zzz-first"}
+	if len(out.Executions) != len(want) {
+		t.Fatalf("got %d executions, want %d", len(out.Executions), len(want))
+	}
+
+	for i, w := range want {
+		if got := aws.ToString(out.Executions[i].Name); got != w {
+			t.Fatalf("position %d = %q, want %q", i, got, w)
+		}
+	}
+}
+
+func newOrderTestClient(t *testing.T, endpoint string) *awssfn.Client {
+	t.Helper()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return awssfn.NewFromConfig(cfg, func(o *awssfn.Options) { o.BaseEndpoint = aws.String(endpoint) })
+}


### PR DESCRIPTION
Deep real-user e2e audit of AWS Step Functions (aws-cli + aws-sdk-go-v2 + Terraform against a running \`cloudemu serve\`). The ASL interpreter is mature and verified correct end-to-end (Pass/Choice/Wait/Parallel/Map all execute correctly, error fidelity + ARN formats correct). Two ordering divergences found and fixed.

## Fixes
- **ListExecutions** returned alphabetical (by ARN) order; real AWS returns reverse-chronological (newest start date first). Now sorted by StartDate descending (ARN tiebreak for determinism).
- **ListStateMachines** returned alphabetical order; real AWS returns newest-created-first. Now sorted by CreationDate descending.
- Doc: corrected a stale package comment claiming Parallel/Map "fail loudly at run time" (they've shipped and execute correctly since #861/#865).

## Verification
\`go build ./...\`, \`go test ./providers/aws/sfn/... ./server/aws/sfn/... -race\`, \`gofmt\`, \`golangci-lint --new-from-rev\` (0 new) — green. Black-box re-verified (create zzz/aaa/mmm in order → list returns mmm,aaa,zzz newest-first). Terraform \`aws_sfn_state_machine\` plan-clean. Regression tests at provider + SDK-wire level (4 new).