### PR TITLE
fix(azure-monitor): real-user e2e divergences

### DIFF
--- a/server/azure/monitor/patch_test.go
+++ b/server/azure/monitor/patch_test.go
@@ -11,11 +11,16 @@ import (
 	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
 )
 
-// TestSDKMetricAlertPatchMergesAndPreserves is the load-bearing regression for
-// the PATCH BLOCKER: the armmonitor MetricAlertsClient.Update issues an HTTP
-// PATCH, which the handler used to reject with 405. It must return 200, apply
-// the supplied fields, and preserve fields the patch omits.
-func TestSDKMetricAlertPatchMergesAndPreserves(t *testing.T) {
+// TestSDKMetricAlertPatchPreservesPropertiesReplacesTags is the load-bearing
+// regression for two fixes: the PATCH BLOCKER (armmonitor MetricAlertsClient.
+// Update issues an HTTP PATCH, which the handler used to reject with 405, and
+// must apply supplied properties while preserving omitted ones) and the
+// tags-replace fix (real ARM resource-level PATCH SETS the tag collection
+// wholesale when the request carries a tags key — the same convention already
+// fixed for compute/network/loadbalancer Update and UpdateTags operations
+// elsewhere in this codebase — so a patch naming only "env" must drop the
+// pre-existing "team" tag, not merge alongside it).
+func TestSDKMetricAlertPatchPreservesPropertiesReplacesTags(t *testing.T) {
 	client := newInsightsServer(t).metricAlerts(t)
 	ctx := context.Background()
 
@@ -27,8 +32,9 @@ func TestSDKMetricAlertPatchMergesAndPreserves(t *testing.T) {
 		t.Fatalf("CreateOrUpdate: %v", err)
 	}
 
-	// PATCH only severity and one tag; description, scopes, criteria and the
-	// other tag must survive.
+	// PATCH severity and a tag set naming only "env"; description, scopes and
+	// criteria (properties the patch omits) must survive, but the tag set must
+	// become exactly what the patch supplied — "team" must NOT survive.
 	patched, err := client.Update(ctx, "rg-1", "cpu", armmonitor.MetricAlertResourcePatch{
 		Tags:       map[string]*string{"env": to.Ptr("staging")},
 		Properties: &armmonitor.MetricAlertPropertiesPatch{Severity: to.Ptr[int32](1)},
@@ -49,12 +55,39 @@ func TestSDKMetricAlertPatchMergesAndPreserves(t *testing.T) {
 		t.Fatal("criteria dropped by patch (omitted field not preserved)")
 	}
 
-	if got := deref(patched.Tags["team"]); got != "payments" {
-		t.Fatalf("tag team = %q, want preserved 'payments'", got)
+	if _, ok := patched.Tags["team"]; ok {
+		t.Fatalf("tags = %v, want wholesale replace (pre-existing 'team' must not survive)", patched.Tags)
 	}
 
 	if got := deref(patched.Tags["env"]); got != "staging" {
 		t.Fatalf("tag env = %q, want updated 'staging'", got)
+	}
+}
+
+// TestSDKMetricAlertPatchOmittedTagsPreserved covers the other half of the
+// tags-replace fix: a PATCH whose body carries no tags key at all (Tags left
+// nil) must leave the stored tag set untouched, distinguishing "omitted" from
+// an explicit empty replacement.
+func TestSDKMetricAlertPatchOmittedTagsPreserved(t *testing.T) {
+	client := newInsightsServer(t).metricAlerts(t)
+	ctx := context.Background()
+
+	create := metricAlertResource(80)
+	create.Tags = map[string]*string{"team": to.Ptr("payments")}
+
+	if _, err := client.CreateOrUpdate(ctx, "rg-1", "cpu", create, nil); err != nil {
+		t.Fatalf("CreateOrUpdate: %v", err)
+	}
+
+	patched, err := client.Update(ctx, "rg-1", "cpu", armmonitor.MetricAlertResourcePatch{
+		Properties: &armmonitor.MetricAlertPropertiesPatch{Severity: to.Ptr[int32](1)},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Update (PATCH): %v", err)
+	}
+
+	if got := deref(patched.Tags["team"]); got != "payments" {
+		t.Fatalf("tag team = %q, want preserved 'payments' (tags key omitted from PATCH body)", got)
 	}
 }
 

--- a/server/azure/monitor/types.go
+++ b/server/azure/monitor/types.go
@@ -64,15 +64,21 @@ func withProvisioningState(props map[string]any) map[string]any {
 	return props
 }
 
-// mergeResource applies a PATCH body over a stored resource under nil-mask
-// semantics: a top-level field the caller omits (location, tags, properties) is
-// preserved from the stored resource, while a supplied one is merged key-by-key
-// over the stored value. The merge is a fresh resource, so the stored one is not
+// mergeResource applies a PATCH body over a stored resource. location and
+// properties follow nil-mask semantics: a field the caller omits is preserved
+// from the stored resource, a supplied one applies (properties merged
+// key-by-key over the stored value). tags do not merge: real ARM resource-level
+// PATCH (metricAlerts/actionGroups/activityLogAlerts/autoscaleSettings Update,
+// same as the compute/network/loadbalancer Update and UpdateTags operations
+// already fixed elsewhere in this codebase) SETS the tag collection wholesale
+// when the request carries a tags key — a populated map replaces the stored
+// set, an explicit tags:{} wipes it, and an absent tags key leaves the stored
+// set untouched. The merge is a fresh resource, so the stored one is not
 // mutated until the caller commits it.
 func mergeResource(existing *armResource, patch *resourceRequest) *armResource {
 	merged := &armResource{
 		Location:   existing.Location,
-		Tags:       mergeStringMap(existing.Tags, patch.Tags),
+		Tags:       existing.Tags,
 		Properties: mergeAnyMap(existing.Properties, patch.Properties),
 	}
 
@@ -80,22 +86,23 @@ func mergeResource(existing *armResource, patch *resourceRequest) *armResource {
 		merged.Location = patch.Location
 	}
 
+	if patch.Tags != nil {
+		merged.Tags = replacementTags(patch.Tags)
+	}
+
 	return merged
 }
 
-// mergeStringMap overlays overlay onto a copy of base, preserving base keys the
-// overlay omits. Returns nil only when both are nil.
-func mergeStringMap(base, overlay map[string]string) map[string]string {
-	if base == nil && overlay == nil {
+// replacementTags normalizes a PATCH body's tags for wholesale replacement: a
+// populated map is cloned (so the store never aliases the request body), an
+// empty map ({}) wipes the stored set to nil.
+func replacementTags(in map[string]string) map[string]string {
+	if len(in) == 0 {
 		return nil
 	}
 
-	out := make(map[string]string, len(base)+len(overlay))
-	for k, v := range base {
-		out[k] = v
-	}
-
-	for k, v := range overlay {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
 		out[k] = v
 	}
 


### PR DESCRIPTION
## Summary

Real-user black-box e2e audit of Azure Monitor (`Microsoft.Insights`) — metric alerts, action groups, activity-log alerts, autoscale settings, diagnostic settings, metrics/metricDefinitions data plane — via the real `azure-sdk-for-go` `armmonitor` client against a running `cloudemu serve -providers=azure` instance.

## Finding fixed

**PATCH on metricAlerts/actionGroups/activityLogAlerts/autoscaleSettings merged `tags` instead of replacing them wholesale.**

Real ARM resource-level PATCH sets the tag collection wholesale when the request body carries a `tags` key — a populated map replaces the stored set, `tags:{}` wipes it, and only an entirely absent `tags` key leaves the stored set untouched. This matches the convention already fixed elsewhere in this codebase for compute/network/loadbalancer `Update`/`UpdateTags` operations (VMSS `BeginUpdate`, VNet gateways/ASG/Public IP Prefixes `UpdateTags`, LB `UpdateTags`).

Repro: `armmonitor.MetricAlertsClient.CreateOrUpdate` with tags `{"team":"payments","env":"prod"}`, then `.Update` (PATCH) with only `{"env":"staging"}`.

- Before: result tags = `{"team":"payments","env":"staging"}` (merged — wrong)
- After: result tags = `{"env":"staging"}` (`"team"` dropped — matches real Azure)

Fix: `server/azure/monitor/types.go` `mergeResource` — `location`/`properties` keep nil-mask (per-field) merge semantics, but `tags` now replaces wholesale via a new `replacementTags` helper, applied only when the PATCH body's `tags` key is present (JSON decode distinguishes an absent key, which leaves the field `nil`, from an explicit `{}`). Applies uniformly across all four `Microsoft.Insights` resource kinds since they share one PATCH handler.

## Sub-surfaces exercised (CRUD + PATCH via real SDK, no other divergences found)

- Metric alerts: CRUD, PATCH, list (RG + subscription scope), referential integrity vs action groups, delete idempotency, alarm→action-group breach firing.
- Action groups: CRUD, PATCH, all 11 receiver types round-trip, delete-in-use guard, 404 envelope.
- Activity-log alerts: CRUD, PATCH, 404, delete idempotency.
- Autoscale settings: CRUD, PATCH (profiles/rules/capacity round-trip).
- Diagnostic settings: PUT/GET/LIST/DELETE round-trip, delete idempotency (no PATCH — correctly matches the real API, which has no dedicated Update operation).
- Metrics data plane: per-resource isolation, aggregation mapping.

Gaps noted but not filed as bugs (by-design / broad codebase pattern, not monitor-specific): action-group breach *delivery* only fires for 4 of 11 receiver types (round-trip is correct for all 11); metricDefinitions is data-driven from pushed datapoints rather than a static per-resource-type catalog; no field-length validation on GroupShortName.

## Test plan

- [x] `go build ./...`
- [x] `go test ./server/azure/monitor/... ./providers/azure/monitor/... -race` — all pass
- [x] `gofmt -l` clean
- [x] `golangci-lint run ./server/azure/monitor/...` — 0 issues
- [x] `go generate ./...` — `docs/coverage` unchanged
- [x] Re-verified black-box against a rebuilt `cloudemu serve` binary with a real `armmonitor` client (scratch driver, deleted before commit): tags replace wholesale on PATCH, tags preserved when the PATCH body omits the `tags` key, other properties still merge/preserve correctly