### PR TITLE
fix(security): resolve CodeQL high-severity alerts (allocation bounds + RSA key floor)

### DIFF
--- a/providers/aws/acm/certificate_gen.go
+++ b/providers/aws/acm/certificate_gen.go
@@ -121,9 +121,11 @@ func rsaKeyMaterial(bits int) (signer crypto.Signer, keyPEM, sigAlg string, err 
 	// legacy RSA_1024 algorithm: a sub-2048 RSA key is rejected by modern TLS
 	// stacks and flagged as weak crypto. The emulator issues a fake cert, so the
 	// exact bit count carries no semantic weight — floor it to the safe minimum
-	// in a single max() the GenerateKey call reads directly, so no path can reach
-	// it with fewer than 2048 bits.
-	bits = max(bits, rsaBits2048)
+	// with an explicit comparison immediately before the GenerateKey call, so no
+	// path can reach it with fewer than 2048 bits.
+	if bits < rsaBits2048 {
+		bits = rsaBits2048
+	}
 
 	key, err := rsa.GenerateKey(rand.Reader, bits)
 	if err != nil {

--- a/providers/aws/acm/keyalg_validation_test.go
+++ b/providers/aws/acm/keyalg_validation_test.go
@@ -2,12 +2,96 @@ package acm_test
 
 import (
 	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"strings"
 	"testing"
 
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/acm/driver"
 )
+
+// minRSAKeyBits is the floor real ACM (and modern TLS stacks) enforce on RSA
+// keys, regardless of the legacy KeyAlgorithm a caller requests.
+const minRSAKeyBits = 2048
+
+// TestRequestLegacyRSA1024FloorsToStrongKey proves that requesting the legacy
+// RSA_1024 algorithm still yields a >=2048-bit key: the certificate's own
+// reported KeyAlgorithm mirrors what the caller asked for, but the actual
+// generated key material must never be weak.
+func TestRequestLegacyRSA1024FloorsToStrongKey(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	arn, err := m.RequestCertificate(ctx, driver.RequestCertificateInput{
+		DomainName:   "legacy.example.com",
+		KeyAlgorithm: driver.KeyAlgRSA1024,
+	})
+	if err != nil {
+		t.Fatalf("RequestCertificate(RSA_1024): %v", err)
+	}
+
+	certPEM, _, err := m.GetCertificate(ctx, arn)
+	if err != nil {
+		t.Fatalf("GetCertificate: %v", err)
+	}
+
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		t.Fatalf("certificate PEM did not decode")
+	}
+
+	leaf, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+
+	pub, ok := leaf.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		t.Fatalf("public key type = %T, want *rsa.PublicKey", leaf.PublicKey)
+	}
+
+	if pub.N.BitLen() < minRSAKeyBits {
+		t.Fatalf("generated RSA key = %d bits, want >= %d", pub.N.BitLen(), minRSAKeyBits)
+	}
+}
+
+// TestRequestRSA2048StillGenerates2048 pins that a normal, already-strong
+// request is unaffected by the floor: it still generates exactly the
+// requested key size, not something larger.
+func TestRequestRSA2048StillGenerates2048(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	arn, err := m.RequestCertificate(ctx, driver.RequestCertificateInput{
+		DomainName:   "normal.example.com",
+		KeyAlgorithm: driver.KeyAlgRSA2048,
+	})
+	if err != nil {
+		t.Fatalf("RequestCertificate(RSA_2048): %v", err)
+	}
+
+	certPEM, _, err := m.GetCertificate(ctx, arn)
+	if err != nil {
+		t.Fatalf("GetCertificate: %v", err)
+	}
+
+	block, _ := pem.Decode([]byte(certPEM))
+	leaf, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+
+	pub, ok := leaf.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		t.Fatalf("public key type = %T, want *rsa.PublicKey", leaf.PublicKey)
+	}
+
+	if pub.N.BitLen() != minRSAKeyBits {
+		t.Fatalf("generated RSA key = %d bits, want exactly %d", pub.N.BitLen(), minRSAKeyBits)
+	}
+}
 
 func TestRequestECKeyAlgorithmReflected(t *testing.T) {
 	ctx := context.Background()

--- a/providers/aws/ec2/ec2_test.go
+++ b/providers/aws/ec2/ec2_test.go
@@ -1922,6 +1922,18 @@ func TestRequestSpotInstances(t *testing.T) {
 		assertError(t, err, true)
 	})
 
+	t.Run("count exceeds maximum", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+			InstanceConfig: defaultConfig(),
+			MaxPrice:       0.05,
+			Count:          maxSpotInstances + 1,
+		})
+		assertError(t, err, true)
+	})
+
 	t.Run("zero max price", func(t *testing.T) {
 		m := newTestMock()
 		ctx := context.Background()

--- a/providers/aws/ec2/spot.go
+++ b/providers/aws/ec2/spot.go
@@ -14,11 +14,12 @@ const (
 	spotStatusCanceled = "canceled"
 	spotTypeOneTime    = "one-time"
 	timeFormat         = "2006-01-02T15:04:05Z"
-	// maxSpotRequests bounds the capacity hint for the results slice so a tainted
-	// cfg.Count can never size an unbounded allocation. It mirrors the per-call
-	// instance ceiling RunInstances enforces (a larger count errors out there
-	// before this point), so the bound never changes a valid request's behavior.
-	maxSpotRequests = 1000
+	// maxSpotInstances bounds a spot request's instance count so a
+	// request-controlled cfg.Count can never size an unbounded allocation,
+	// either the results slice below or the one RunInstances performs. It
+	// mirrors the per-call ceiling RunInstances enforces on its own count
+	// parameter, so a request already valid there is never rejected here.
+	maxSpotInstances = 1000
 )
 
 // RequestSpotInstances creates spot instance requests and immediately fulfills them.
@@ -31,6 +32,10 @@ func (m *Mock) RequestSpotInstances(
 		return nil, cerrors.New(cerrors.InvalidArgument, "count must be greater than 0")
 	}
 
+	if cfg.Count > maxSpotInstances {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "count %d exceeds the maximum of %d per call", cfg.Count, maxSpotInstances)
+	}
+
 	if cfg.MaxPrice <= 0 {
 		return nil, cerrors.New(cerrors.InvalidArgument, "max price must be greater than 0")
 	}
@@ -40,7 +45,7 @@ func (m *Mock) RequestSpotInstances(
 		return nil, err
 	}
 
-	results := make([]driver.SpotInstanceRequest, 0, min(cfg.Count, maxSpotRequests))
+	results := make([]driver.SpotInstanceRequest, 0, cfg.Count)
 	now := m.opts.Clock.Now().UTC().Format(timeFormat)
 
 	for _, inst := range instances {

--- a/providers/aws/elasticache/replication_group.go
+++ b/providers/aws/elasticache/replication_group.go
@@ -118,13 +118,15 @@ func memberClusters(id string, nodes int) []string {
 	}
 
 	// Defensive clamp: the count originates from caller input (NumCacheNodes), so
-	// bound it in the same expression that sizes the allocation regardless of the
-	// call path. Valid provisions stay far under the ceiling, so this is a no-op
-	// for them.
-	bounded := min(nodes, maxReplicationGroupNodes)
+	// bound it with an explicit comparison immediately before the allocation it
+	// sizes, regardless of the call path. Valid provisions stay far under the
+	// ceiling, so this is a no-op for them.
+	if nodes > maxReplicationGroupNodes {
+		nodes = maxReplicationGroupNodes
+	}
 
-	members := make([]string, 0, bounded)
-	for i := 1; i <= bounded; i++ {
+	members := make([]string, 0, nodes)
+	for i := 1; i <= nodes; i++ {
 		members = append(members, fmt.Sprintf("%s-%03d", id, i))
 	}
 

--- a/providers/aws/elasticache/replication_group_test.go
+++ b/providers/aws/elasticache/replication_group_test.go
@@ -1,0 +1,51 @@
+package elasticache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+)
+
+// TestMemberClustersBounded proves memberClusters never sizes its allocation
+// beyond maxReplicationGroupNodes, regardless of how large or negative the
+// caller-supplied node count is.
+func TestMemberClustersBounded(t *testing.T) {
+	tests := []struct {
+		name  string
+		nodes int
+		want  int
+	}{
+		{name: "typical", nodes: 3, want: 3},
+		{name: "negative clamps to zero", nodes: -1, want: 0},
+		{name: "over ceiling clamps to max", nodes: maxReplicationGroupNodes + 1000000, want: maxReplicationGroupNodes},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			members := memberClusters("rg", tt.nodes)
+			if len(members) != tt.want {
+				t.Fatalf("memberClusters(%d) len = %d, want %d", tt.nodes, len(members), tt.want)
+			}
+		})
+	}
+}
+
+// TestCreateReplicationGroupPathologicalNodeCount proves a pathological
+// NumCacheNodes on CreateReplicationGroup can't drive an unbounded
+// MemberClusters allocation; the request still succeeds, just clamped.
+func TestCreateReplicationGroupPathologicalNodeCount(t *testing.T) {
+	m := New(config.NewOptions())
+
+	rg, err := m.CreateReplicationGroup(context.Background(), driver.ReplicationGroupConfig{
+		ID: "rg-huge", Engine: "redis", NumCacheNodes: maxReplicationGroupNodes + 1000000,
+	})
+	if err != nil {
+		t.Fatalf("CreateReplicationGroup: %v", err)
+	}
+
+	if len(rg.MemberClusters) != maxReplicationGroupNodes {
+		t.Fatalf("MemberClusters len = %d, want %d", len(rg.MemberClusters), maxReplicationGroupNodes)
+	}
+}

--- a/providers/azure/virtualmachines/spot.go
+++ b/providers/azure/virtualmachines/spot.go
@@ -13,11 +13,12 @@ const (
 	spotStatusCanceled = "canceled"
 	spotTypeOneTime    = "one-time"
 	timeFormat         = "2006-01-02T15:04:05Z"
-	// maxSpotRequests bounds the capacity hint for the results slice so a tainted
-	// cfg.Count can never size an unbounded allocation. It mirrors the per-call
-	// instance ceiling RunInstances enforces (a larger count errors out there
-	// before this point), so the bound never changes a valid request's behavior.
-	maxSpotRequests = 1000
+	// maxSpotInstances bounds a spot request's instance count so a
+	// request-controlled cfg.Count can never size an unbounded allocation,
+	// either the results slice below or the one RunInstances performs. It
+	// mirrors the per-call ceiling RunInstances enforces on its own count
+	// parameter, so a request already valid there is never rejected here.
+	maxSpotInstances = 1000
 )
 
 // RequestSpotInstances creates spot VM requests and immediately fulfills them.
@@ -30,6 +31,10 @@ func (m *Mock) RequestSpotInstances(
 		return nil, cerrors.New(cerrors.InvalidArgument, "count must be greater than 0")
 	}
 
+	if cfg.Count > maxSpotInstances {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "count %d exceeds the maximum of %d per call", cfg.Count, maxSpotInstances)
+	}
+
 	if cfg.MaxPrice <= 0 {
 		return nil, cerrors.New(cerrors.InvalidArgument, "max price must be greater than 0")
 	}
@@ -39,7 +44,7 @@ func (m *Mock) RequestSpotInstances(
 		return nil, err
 	}
 
-	results := make([]driver.SpotInstanceRequest, 0, min(cfg.Count, maxSpotRequests))
+	results := make([]driver.SpotInstanceRequest, 0, cfg.Count)
 	now := m.opts.Clock.Now().UTC().Format(timeFormat)
 
 	for _, inst := range instances {

--- a/providers/azure/virtualmachines/vm_test.go
+++ b/providers/azure/virtualmachines/vm_test.go
@@ -522,6 +522,14 @@ func TestRequestSpotInstances(t *testing.T) {
 			},
 			wantErr: true, errMsg: "max price must be greater than 0",
 		},
+		{
+			name: "count exceeds maximum",
+			cfg: driver.SpotRequestConfig{
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "t2"},
+				MaxPrice:       0.5, Count: maxSpotInstances + 1,
+			},
+			wantErr: true, errMsg: "exceeds the maximum",
+		},
 	}
 
 	for _, tt := range tests {

--- a/providers/gcp/compute/gce_test.go
+++ b/providers/gcp/compute/gce_test.go
@@ -603,6 +603,16 @@ func TestRequestSpotInstances(t *testing.T) {
 			wantErr:   true,
 			errSubstr: "greater than 0",
 		},
+		{
+			name: "count exceeds maximum",
+			cfg: driver.SpotRequestConfig{
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+				MaxPrice:       0.05,
+				Count:          maxSpotInstances + 1,
+			},
+			wantErr:   true,
+			errSubstr: "exceeds the maximum",
+		},
 	}
 
 	for _, tt := range tests {

--- a/providers/gcp/compute/spot.go
+++ b/providers/gcp/compute/spot.go
@@ -13,11 +13,12 @@ const (
 	spotStatusCanceled = "canceled"
 	spotTypeOneTime    = "one-time"
 	timeFormat         = "2006-01-02T15:04:05Z"
-	// maxSpotRequests bounds the capacity hint for the results slice so a tainted
-	// cfg.Count can never size an unbounded allocation. It mirrors the per-call
-	// instance ceiling RunInstances enforces (a larger count errors out there
-	// before this point), so the bound never changes a valid request's behavior.
-	maxSpotRequests = 1000
+	// maxSpotInstances bounds a spot request's instance count so a
+	// request-controlled cfg.Count can never size an unbounded allocation,
+	// either the results slice below or the one RunInstances performs. It
+	// mirrors the per-call ceiling RunInstances enforces on its own count
+	// parameter, so a request already valid there is never rejected here.
+	maxSpotInstances = 1000
 )
 
 // RequestSpotInstances creates preemptible VM requests and immediately fulfills them.
@@ -30,6 +31,10 @@ func (m *Mock) RequestSpotInstances(
 		return nil, cerrors.New(cerrors.InvalidArgument, "count must be greater than 0")
 	}
 
+	if cfg.Count > maxSpotInstances {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "count %d exceeds the maximum of %d per call", cfg.Count, maxSpotInstances)
+	}
+
 	if cfg.MaxPrice <= 0 {
 		return nil, cerrors.New(cerrors.InvalidArgument, "max price must be greater than 0")
 	}
@@ -39,7 +44,7 @@ func (m *Mock) RequestSpotInstances(
 		return nil, err
 	}
 
-	results := make([]driver.SpotInstanceRequest, 0, min(cfg.Count, maxSpotRequests))
+	results := make([]driver.SpotInstanceRequest, 0, cfg.Count)
 	now := m.opts.Clock.Now().UTC().Format(timeFormat)
 
 	for _, inst := range instances {

--- a/server/aws/elasticache/types.go
+++ b/server/aws/elasticache/types.go
@@ -265,9 +265,11 @@ func toCacheClusterXML(info *cachedriver.CacheInfo) cacheClusterXML {
 
 	// Defensive clamp to the real ElastiCache ceiling (Memcached tops out at 40
 	// nodes; Redis reports 1). The stored count is validated on create, but bound
-	// it here too — in a single min() the node allocation below reads directly —
-	// so a tainted value can never size an unbounded node allocation.
-	numNodes = min(numNodes, maxCacheNodesPerCluster)
+	// it here too — with an explicit comparison immediately before the node
+	// allocation below — so a tainted value can never size an unbounded allocation.
+	if numNodes > maxCacheNodesPerCluster {
+		numNodes = maxCacheNodesPerCluster
+	}
 
 	out := cacheClusterXML{
 		CacheClusterID:       info.Name,

--- a/server/aws/elasticache/types_test.go
+++ b/server/aws/elasticache/types_test.go
@@ -1,0 +1,46 @@
+package elasticache
+
+import (
+	"testing"
+
+	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+)
+
+// TestToCacheClusterXMLBoundsNodeAllocation proves toCacheClusterXML never
+// sizes its per-node allocation beyond maxCacheNodesPerCluster, even if a
+// stored CacheInfo somehow carries a pathological NumCacheNodes (the create
+// path already rejects that, but this is a defense-in-depth backstop on the
+// render path itself).
+func TestToCacheClusterXMLBoundsNodeAllocation(t *testing.T) {
+	tests := []struct {
+		name      string
+		numNodes  int
+		wantNodes int
+	}{
+		{name: "typical", numNodes: 3, wantNodes: 3},
+		{name: "zero defaults to one", numNodes: 0, wantNodes: 1},
+		{name: "over ceiling clamps to max", numNodes: maxCacheNodesPerCluster + 1000000, wantNodes: maxCacheNodesPerCluster},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := toCacheClusterXML(&cachedriver.CacheInfo{
+				Name: "c1", Engine: memcachedEngine, Endpoint: "c1.example.com:11211",
+				NumCacheNodes: tt.numNodes,
+			})
+
+			if out.NumCacheNodes != tt.wantNodes {
+				t.Fatalf("NumCacheNodes = %d, want %d", out.NumCacheNodes, tt.wantNodes)
+			}
+
+			if out.CacheNodes == nil || len(out.CacheNodes.CacheNode) != tt.wantNodes {
+				got := 0
+				if out.CacheNodes != nil {
+					got = len(out.CacheNodes.CacheNode)
+				}
+
+				t.Fatalf("len(CacheNodes) = %d, want %d", got, tt.wantNodes)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Clears the 6 open high-severity CodeQL alerts (5x `go/uncontrolled-allocation-size`, 1x `go/weak-crypto-key`) that are gating the release. The prior mitigation for these (#947) used Go's builtin `min()`/`max()` to clamp the tainted values; CodeQL's dataflow does not treat those builtins as sanitizing the taint, so the alerts stayed open even though the values were already bounded at runtime. This PR replaces every `min()`/`max()`-based clamp on a request-controlled allocation size with an explicit `if` comparison against a constant, immediately before the allocation/call — the pattern CodeQL's own remediation guidance documents and that its dataflow analysis follows.

### The 6 alerts and their fix

1. **`providers/aws/ec2/spot.go`** — `cfg.Count` flowed into `RunInstances` and into the local `results` slice unconstrained by an explicit check. Added `if cfg.Count > maxSpotInstances { return InvalidArgument }` before both the `RunInstances` call and the `make()`, replacing the `min(cfg.Count, maxSpotRequests)` capacity hint.
2. **`providers/azure/virtualmachines/spot.go`** — same pattern, same fix.
3. **`providers/gcp/compute/spot.go`** — same pattern, same fix.
4. **`providers/aws/elasticache/replication_group.go`** (`memberClusters`) — replaced `bounded := min(nodes, maxReplicationGroupNodes)` with `if nodes > maxReplicationGroupNodes { nodes = maxReplicationGroupNodes }` directly before `make()`.
5. **`server/aws/elasticache/types.go`** (`toCacheClusterXML`) — replaced `numNodes = min(numNodes, maxCacheNodesPerCluster)` with an explicit `if numNodes > maxCacheNodesPerCluster { numNodes = maxCacheNodesPerCluster }` before the per-node `make()`.
6. **`providers/aws/acm/certificate_gen.go`** (`rsaKeyMaterial`) — replaced `bits = max(bits, rsaBits2048)` with `if bits < rsaBits2048 { bits = rsaBits2048 }` immediately before `rsa.GenerateKey`.

All six are defense-in-depth backstops on paths that are already validated upstream in most cases (e.g. `RunInstances` already rejects counts over 1000, `CreateCacheCluster` already rejects >40 nodes) — this PR makes the bound explicit and CodeQL-followable at the specific allocation site itself, so a valid request is never affected.

## Test plan

- Added `count exceeds maximum` cases to `TestRequestSpotInstances` in all three spot-instance provider test files (AWS/Azure/GCP), confirming a normal count still succeeds and an oversized one is rejected without ever calling `RunInstances`.
- Added `providers/aws/elasticache/replication_group_test.go`: `memberClusters` unit test (typical/negative/over-ceiling) and a `CreateReplicationGroup` test with a pathological `NumCacheNodes`.
- Added `server/aws/elasticache/types_test.go`: `toCacheClusterXML` unit test (typical/zero/over-ceiling).
- Added RSA key-floor tests to `providers/aws/acm/keyalg_validation_test.go`: requesting `RSA_1024` yields a real >=2048-bit key (parsed from the issued certificate's public key), and requesting `RSA_2048` still generates exactly 2048 bits (no over-flooring).
- `go build ./...`, `go vet ./...`, `go test ./... -count=1` all green; targeted packages also pass with `-race`.
- `gofmt -l` clean; `golangci-lint run --new-from-rev=origin/development` on touched packages: 0 new issues.
- `go generate ./...` produces no `docs/coverage` diff; `go mod tidy` is a no-op.