### PR TITLE
fix(gcp-cloudsql): real-user e2e divergences

### DIFF
--- a/providers/gcp/cloudsql/cloudsql.go
+++ b/providers/gcp/cloudsql/cloudsql.go
@@ -773,6 +773,7 @@ func (m *Mock) DescribeSnapshots(
 
 	out := make([]rdsdriver.Snapshot, 0, len(all))
 
+	//nolint:gocritic // materializing the result slice requires copying each value; pointers/indexing would leak store internals.
 	for _, snap := range all {
 		if instanceID != "" && snap.InstanceID != instanceID {
 			continue

--- a/providers/gcp/cloudsql/cloudsql.go
+++ b/providers/gcp/cloudsql/cloudsql.go
@@ -766,12 +766,13 @@ func (m *Mock) DescribeSnapshots(
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	all := m.snapshots.All()
+	// SortedValues, not All: map iteration order is random, and BackupRuns.list
+	// must return a deterministic order like every other Cloud SQL list verb.
+	all := m.snapshots.SortedValues()
 	idSet := stringSet(ids)
 
 	out := make([]rdsdriver.Snapshot, 0, len(all))
 
-	//nolint:gocritic // map values are sized for accuracy; copy is unavoidable when materializing the result slice.
 	for _, snap := range all {
 		if instanceID != "" && snap.InstanceID != instanceID {
 			continue

--- a/providers/gcp/cloudsql/cloudsql_test.go
+++ b/providers/gcp/cloudsql/cloudsql_test.go
@@ -696,6 +696,49 @@ func TestDescribeInstancesResultDoesNotAliasStore(t *testing.T) {
 	}
 }
 
+// TestDescribeSnapshotsOrderIsDeterministic guards against DescribeSnapshots
+// iterating the raw memstore map (random Go iteration order) instead of a
+// sorted view. Backup runs are inserted in a non-lexicographic order so a
+// stray return to map iteration would surface intermittently rather than
+// deterministically, but the correct behavior — sorted by id — must hold on
+// every call.
+func TestDescribeSnapshotsOrderIsDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "src", Engine: "POSTGRES_15"}); err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+
+	for _, id := range []string{"snap-c", "snap-a", "snap-d", "snap-b"} {
+		if _, err := m.CreateSnapshot(ctx, rdsdriver.SnapshotConfig{ID: id, InstanceID: "src"}); err != nil {
+			t.Fatalf("CreateSnapshot %q: %v", id, err)
+		}
+	}
+
+	want := []string{"snap-a", "snap-b", "snap-c", "snap-d"}
+
+	for attempt := 0; attempt < 5; attempt++ {
+		snaps, err := m.DescribeSnapshots(ctx, nil, "src")
+		requireNoError(t, err)
+
+		if len(snaps) != len(want) {
+			t.Fatalf("attempt %d: got %d snapshots, want %d", attempt, len(snaps), len(want))
+		}
+
+		for i, snap := range snaps {
+			if snap.ID != want[i] {
+				got := make([]string, len(snaps))
+				for j, s := range snaps {
+					got[j] = s.ID
+				}
+
+				t.Fatalf("attempt %d: snapshot order = %v, want %v", attempt, got, want)
+			}
+		}
+	}
+}
+
 func TestChildNameRejectsSlash(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/server/gcp/cloudsql/handler.go
+++ b/server/gcp/cloudsql/handler.go
@@ -31,6 +31,8 @@ package cloudsql
 
 import (
 	"net/http"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -67,12 +69,20 @@ func isSubResource(seg string) bool {
 type Handler struct {
 	db rdsdriver.RelationalDB
 
-	// mu guards ops. Mutating endpoints complete inline (status=DONE) and record
-	// the resulting Operation here so a later Operations.Get returns the real
-	// CREATE/UPDATE/DELETE record — pointing at the affected resource — rather
-	// than a synthetic stand-in.
+	// mu guards ops and opSeq. Mutating endpoints complete inline (status=DONE)
+	// and record the resulting Operation here so a later Operations.Get returns
+	// the real CREATE/UPDATE/DELETE record — pointing at the affected resource —
+	// rather than a synthetic stand-in.
 	mu  sync.RWMutex
 	ops map[string]operation
+	// opSeq makes every recorded operation name unique. Several call sites build
+	// their base name from a fixed action tag or an instance/resource id (e.g.
+	// "patch-{instance}", or the globally-shared "insert-db"/"clone"/"promote"),
+	// so two calls of the same kind — even against different instances — would
+	// otherwise collide on the same map key and silently overwrite each other's
+	// Operation record. Real Cloud SQL always hands back a distinct operation
+	// name per call.
+	opSeq int64
 }
 
 // New returns a Cloud SQL handler backed by db.
@@ -84,14 +94,16 @@ func New(db rdsdriver.RelationalDB) *Handler {
 }
 
 // buildOp builds the DONE operation for a finished mutation and records it
-// keyed by name, so a later Operations.Get serves the same record. It returns
+// under a unique name, so a later Operations.Get serves this exact record
+// instead of whatever the next same-kind call overwrote it with. It returns
 // the operation for callers that embed it in a larger response (e.g.
 // sslCerts.insert).
 func (h *Handler) buildOp(project, name, opType, resourceType, target string) operation {
-	op := doneOperationWithTarget(project, name, opType, resourceType, target)
-
 	h.mu.Lock()
-	h.ops[name] = op
+	h.opSeq++
+	uniqueName := name + "-" + strconv.FormatInt(h.opSeq, 10)
+	op := doneOperationWithTarget(project, uniqueName, opType, resourceType, target)
+	h.ops[uniqueName] = op
 	h.mu.Unlock()
 
 	return op
@@ -329,7 +341,7 @@ func (h *Handler) serveOperation(w http.ResponseWriter, r *http.Request, p *sqlP
 	}
 
 	if p.name == "" {
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "operation name required")
+		h.listOperations(w, r, p)
 		return
 	}
 
@@ -345,6 +357,69 @@ func (h *Handler) serveOperation(w http.ResponseWriter, r *http.Request, p *sqlP
 	}
 
 	writeJSON(w, http.StatusOK, op)
+}
+
+// listOperations serves GET /v1/projects/{p}/operations — the operations.list
+// verb. Real Cloud SQL scopes the collection to the project and, when an
+// "instance" query parameter is given, to that instance's operations only,
+// returned in reverse-chronological order.
+func (h *Handler) listOperations(w http.ResponseWriter, r *http.Request, p *sqlPath) {
+	instance := r.URL.Query().Get("instance")
+
+	h.mu.RLock()
+	ops := make([]operation, 0, len(h.ops))
+
+	//nolint:gocritic // map values are sized for accuracy; copy is unavoidable when materializing the result slice.
+	for _, op := range h.ops {
+		ops = append(ops, op)
+	}
+
+	h.mu.RUnlock()
+
+	out := make([]operation, 0, len(ops))
+
+	for i := range ops {
+		op := &ops[i]
+
+		if op.TargetProject != p.project {
+			continue
+		}
+
+		if instance != "" && operationInstance(op) != instance {
+			continue
+		}
+
+		out = append(out, *op)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].InsertTime != out[j].InsertTime {
+			return out[i].InsertTime > out[j].InsertTime
+		}
+
+		return out[i].Name > out[j].Name
+	})
+
+	writeJSON(w, http.StatusOK, operationsList{Kind: "sql#operationsList", Items: out})
+}
+
+// operationInstance extracts the instance name an operation's targetLink
+// refers to — e.g. ".../instances/foo" or ".../instances/foo/backupRuns/123"
+// both yield "foo" — or "" when the operation doesn't target an
+// instance-scoped resource.
+func operationInstance(op *operation) string {
+	prefix := selfLinkBase + op.TargetProject + "/instances/"
+
+	if !strings.HasPrefix(op.TargetLink, prefix) {
+		return ""
+	}
+
+	rest := strings.TrimPrefix(op.TargetLink, prefix)
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		return rest[:i]
+	}
+
+	return rest
 }
 
 func writeMethodNotAllowed(w http.ResponseWriter) {

--- a/server/gcp/cloudsql/operations_list_sdk_test.go
+++ b/server/gcp/cloudsql/operations_list_sdk_test.go
@@ -1,0 +1,184 @@
+package cloudsql_test
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+	sqladmin "google.golang.org/api/sqladmin/v1"
+)
+
+// Finding: writeErr rendered the wire error.message from err.Error(), which
+// for a cloudemu *errors.Error prepends the internal code-name taxonomy (e.g.
+// "NotFound: Cloud SQL instance ... not found") — real Cloud SQL never leaks
+// that prefix into the message a client sees.
+func TestSDKCloudSQLErrorMessageHasNoCodePrefix(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := svc.Instances.Get(project, "does-not-exist").Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !isGoogleAPIError(err, &gerr) {
+		t.Fatalf("expected *googleapi.Error, got %T: %v", err, err)
+	}
+
+	for _, prefix := range []string{"NotFound:", "AlreadyExists:", "InvalidArgument:", "FailedPrecondition:"} {
+		if strings.HasPrefix(gerr.Message, prefix) {
+			t.Fatalf("error message %q leaks the internal code-name prefix %q", gerr.Message, prefix)
+		}
+	}
+
+	if !strings.Contains(gerr.Message, "does-not-exist") {
+		t.Fatalf("error message %q should still mention the missing instance", gerr.Message)
+	}
+}
+
+func isGoogleAPIError(err error, out **googleapi.Error) bool {
+	gerr, ok := err.(*googleapi.Error)
+	if ok {
+		*out = gerr
+	}
+
+	return ok
+}
+
+// Finding: buildOp keyed every recorded Operation on a caller-supplied name
+// that was often a fixed action tag (e.g. "insert-db", "clone", "patch-{id}")
+// shared across every call of that kind — a second patch of the SAME
+// instance, or even an unrelated instance's database insert, silently
+// overwrote the first Operation's record at the same map key. Real Cloud SQL
+// hands back a distinct operation name per call.
+func TestSDKCloudSQLOperationNamesAreUnique(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	insertInstance(t, svc, project, "collide")
+
+	op1, err := svc.Instances.Patch(project, "collide", &sqladmin.DatabaseInstance{
+		Settings: &sqladmin.Settings{Tier: "db-custom-2-8192"},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Patch 1: %v", err)
+	}
+
+	op2, err := svc.Instances.Patch(project, "collide", &sqladmin.DatabaseInstance{
+		Settings: &sqladmin.Settings{Tier: "db-custom-4-16384"},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Patch 2: %v", err)
+	}
+
+	if op1.Name == op2.Name {
+		t.Fatalf("two patches on the same instance got the same operation name %q", op1.Name)
+	}
+
+	// The first operation's record must still be independently retrievable —
+	// not clobbered by the second patch sharing its map key.
+	if _, err := svc.Operations.Get(project, op1.Name).Context(ctx).Do(); err != nil {
+		t.Fatalf("Operations.Get(op1.Name): %v", err)
+	}
+
+	if _, err := svc.Operations.Get(project, op2.Name).Context(ctx).Do(); err != nil {
+		t.Fatalf("Operations.Get(op2.Name): %v", err)
+	}
+}
+
+// Finding: GET /v1/projects/{p}/operations (operations.list, with no
+// operation name) always 400'd with "operation name required" — real Cloud
+// SQL supports listing the project's operations, optionally scoped to one
+// instance via ?instance=.
+func TestSDKCloudSQLOperationsList(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	insertInstance(t, svc, project, "opslist-a")
+	insertInstance(t, svc, project, "opslist-b")
+
+	if _, err := svc.Instances.Patch(project, "opslist-a", &sqladmin.DatabaseInstance{
+		Settings: &sqladmin.Settings{Tier: "db-custom-4-16384"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch opslist-a: %v", err)
+	}
+
+	all, err := svc.Operations.List(project).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Operations.List (project-wide): %v", err)
+	}
+
+	if len(all.Items) < 3 {
+		t.Fatalf("project-wide Operations.List returned %d items, want at least 3 (2 creates + 1 patch)", len(all.Items))
+	}
+
+	scoped, err := svc.Operations.List(project).Instance("opslist-a").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Operations.List (instance-scoped): %v", err)
+	}
+
+	if len(scoped.Items) != 2 {
+		t.Fatalf("instance-scoped Operations.List returned %d items, want 2 (create + patch of opslist-a)", len(scoped.Items))
+	}
+
+	for _, op := range scoped.Items {
+		if op.OperationType != "CREATE" && op.OperationType != "UPDATE" {
+			t.Fatalf("unexpected operationType %q in opslist-a's scoped list", op.OperationType)
+		}
+	}
+}
+
+// Finding: BackupRuns.list iterated the provider's raw memstore map (random
+// Go iteration order) instead of a sorted view, so the reported order of
+// backup runs was nondeterministic across calls — every other Cloud SQL list
+// verb in this package returns a stable order.
+func TestSDKCloudSQLBackupRunsListOrderIsDeterministic(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	insertInstance(t, svc, project, "bkorder")
+
+	const n = 6
+
+	var inserted []int64
+
+	for i := 0; i < n; i++ {
+		op, err := svc.BackupRuns.Insert(project, "bkorder", &sqladmin.BackupRun{}).Context(ctx).Do()
+		if err != nil {
+			t.Fatalf("BackupRuns.Insert %d: %v", i, err)
+		}
+
+		id, err := strconv.ParseInt(op.TargetId, 10, 64)
+		if err != nil {
+			t.Fatalf("backup id %q not numeric: %v", op.TargetId, err)
+		}
+
+		inserted = append(inserted, id)
+	}
+
+	for attempt := 0; attempt < 5; attempt++ {
+		list, err := svc.BackupRuns.List(project, "bkorder").Context(ctx).Do()
+		if err != nil {
+			t.Fatalf("BackupRuns.List (attempt %d): %v", attempt, err)
+		}
+
+		if len(list.Items) != n {
+			t.Fatalf("attempt %d: got %d backup runs, want %d", attempt, len(list.Items), n)
+		}
+
+		for i, item := range list.Items {
+			if item.Id != inserted[i] {
+				t.Fatalf("attempt %d: backup run order = %v, want insertion order %v", attempt, idsOf(list.Items), inserted)
+			}
+		}
+	}
+}
+
+func idsOf(items []*sqladmin.BackupRun) []int64 {
+	out := make([]int64, 0, len(items))
+	for _, it := range items {
+		out = append(out, it.Id)
+	}
+
+	return out
+}

--- a/server/gcp/cloudsql/types.go
+++ b/server/gcp/cloudsql/types.go
@@ -141,6 +141,12 @@ type operation struct {
 	SelfLink      string `json:"selfLink,omitempty"`
 }
 
+// operationsList is the Cloud SQL Admin operations.list response envelope.
+type operationsList struct {
+	Kind  string      `json:"kind,omitempty"`
+	Items []operation `json:"items,omitempty"`
+}
+
 // doneOperationWithTarget builds a DONE operation that carries the full record
 // a real Cloud SQL operation exposes: the affected resource (targetId /
 // targetLink), the acting user, insert/start/end timestamps, and its own
@@ -328,18 +334,23 @@ func writeError(w http.ResponseWriter, status int, reason, msg string) {
 }
 
 func writeErr(w http.ResponseWriter, err error) {
+	// cerrors.Message strips the internal code-name prefix (e.g. "NotFound: ")
+	// that Error() prepends — real Cloud SQL never leaks its error taxonomy into
+	// the wire message, only the human-readable text.
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+		writeError(w, http.StatusNotFound, "NOT_FOUND", msg)
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "ALREADY_EXISTS", err.Error())
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", msg)
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", msg)
 	case cerrors.IsFailedPrecondition(err):
 		// Google's canonical error mapping puts FAILED_PRECONDITION at HTTP 400
 		// (e.g. Cloud SQL's deletion-protection guard), not 409.
-		writeError(w, http.StatusBadRequest, "FAILED_PRECONDITION", err.Error())
+		writeError(w, http.StatusBadRequest, "FAILED_PRECONDITION", msg)
 	default:
-		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+		writeError(w, http.StatusInternalServerError, "INTERNAL", msg)
 	}
 }


### PR DESCRIPTION
## Summary

Real-user black-box e2e audit of GCP Cloud SQL (sqladmin v1 — instances,
databases, users, backup runs, operations) driven via the real
`google.golang.org/api/sqladmin/v1` SDK against `cloudemu serve`. Found and
fixed 4 genuine divergences from real Cloud SQL:

- **Error message leak**: `writeErr` rendered `error.message` from
  `err.Error()` on an internal `*errors.Error`, leaking the code-name prefix
  (e.g. `"NotFound: Cloud SQL instance ... not found"`) onto the wire. Fixed
  to use `cerrors.Message(err)`, matching the same fix already applied once
  each to GCS/GCE/Pub/Sub/GKE.
- **Nondeterministic `BackupRuns.list` order**: `DescribeSnapshots` iterated
  the raw memstore map instead of `SortedValues()`, unlike every other list
  verb in the package. Verified black-box: insertion order and list order
  diverged across 8 inserted backups.
- **`operations.list` always 400'd**: `GET /v1/projects/{p}/operations` (no
  operation name) is a valid SDK call (`Operations.List(project)`, optionally
  `.Instance(name)`) but was rejected with `"operation name required"`. Now
  serves the recorded operations, filtered by project and optional instance.
- **Operation-name collisions**: several call sites recorded operations under
  a base name that's either reused across repeated calls on the same instance
  (`"patch-"+id`) or a global constant shared by *every* instance
  (`"insert-db"`, `"clone"`, `"promote"`, etc.), so a second call of the same
  kind silently overwrote the first call's LRO record. `buildOp` now appends a
  monotonic sequence number to guarantee unique operation names.

Prior world-case work already covers settings round-trip, deletion-protection
guard, read-replica delete/stop guards, databases.update, serverCaCert,
connectionName-by-request-project, absolute selfLinks, and list
pagination/filter — re-verified as still correct, not re-filed. AsyncSettle-off
instant operations and no-real-SQL-engine-by-default were treated as by-design
per the audit brief.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./providers/gcp/cloudsql/... ./server/gcp/cloudsql/... -race` — all pass
- [x] `gofmt -l` clean
- [x] `golangci-lint run --new-from-rev=origin/development` on both packages — 0 issues
- [x] `go generate ./... && git diff --exit-code docs/coverage` — no diff
- [x] Each fix re-verified black-box against a rebuilt `cloudemu serve` with the real SDK
- [x] New regression tests: `TestSDKCloudSQLErrorMessageHasNoCodePrefix`,
      `TestSDKCloudSQLBackupRunsListOrderIsDeterministic`,
      `TestSDKCloudSQLOperationsList`, `TestSDKCloudSQLOperationNamesAreUnique`
      (server/gcp/cloudsql), `TestDescribeSnapshotsOrderIsDeterministic`
      (providers/gcp/cloudsql)