### PR TITLE
fix(azure-servicebus): real-user e2e divergences

### DIFF
--- a/server/azure/servicebus/queue.go
+++ b/server/azure/servicebus/queue.go
@@ -24,6 +24,20 @@ func (h *Handler) serveQueue(w http.ResponseWriter, r *http.Request, sp sbPath) 
 		return
 	}
 
+	// Anything beyond "queues/{name}" — e.g. a queue-scoped authorizationRules
+	// sub-resource, which real Service Bus exposes but this handler does not
+	// model — must be rejected explicitly. Falling through to the queue's own
+	// CRUD handlers below would otherwise treat the nested path as an
+	// operation on the queue itself: a PUT would silently reset the queue's
+	// properties to the sub-resource's request body, a GET would echo the
+	// queue's ARM resource instead of 404ing, and a DELETE would remove the
+	// whole queue. Topics/subscriptions/rules already dispatch on exact
+	// segment length for the same reason; queues must match.
+	if len(sp.segs) > namePairLen {
+		notImplemented(w)
+		return
+	}
+
 	switch r.Method {
 	case http.MethodPut:
 		h.createQueue(w, r, sp, name)

--- a/server/azure/servicebus/queue_authrule_route_test.go
+++ b/server/azure/servicebus/queue_authrule_route_test.go
@@ -1,0 +1,107 @@
+package servicebus_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestQueueScopedAuthorizationRuleDoesNotCorruptQueue is the regression for a
+// misrouting bug: a queue-scoped "authorizationRules" sub-path (a documented
+// real Service Bus operation exposed by QueuesClient.CreateOrUpdateAuthorizationRule
+// / GetAuthorizationRule / DeleteAuthorizationRule / ListAuthorizationRules) has
+// more path segments than "queues/{name}". serveQueue previously extracted the
+// queue name from segs[1] and dispatched on HTTP method regardless of any
+// trailing segments, so these calls fell through to the queue's own CRUD
+// handlers: a PUT silently reset the queue's properties to defaults (the
+// authorization-rule request body doesn't decode into queue properties), a GET
+// echoed the queue's own resource instead of 404ing, and a DELETE removed the
+// whole queue. The fix rejects any queue path deeper than "queues/{name}" with
+// 501 (mirroring how topics/subscriptions/rules already dispatch on exact
+// segment length), so the sub-resource is a clean gap rather than data loss.
+func TestQueueScopedAuthorizationRuleDoesNotCorruptQueue(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{ServiceBus: cloudP.ServiceBus})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	nsClient := newNamespacesClient(t, ts)
+	createNS(t, nsClient, rgName, nsName, nil)
+
+	qc := newQueuesClient(t, ts)
+	ctx := context.Background()
+
+	const queueName = "protected-q"
+
+	if _, err := qc.CreateOrUpdate(ctx, rgName, nsName, queueName, armservicebus.SBQueue{
+		Properties: &armservicebus.SBQueueProperties{
+			MaxSizeInMegabytes: to.Ptr[int32](5120),
+			LockDuration:       to.Ptr("PT45S"),
+			MaxDeliveryCount:   to.Ptr[int32](7),
+		},
+	}, nil); err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+
+	// CreateOrUpdateAuthorizationRule must not silently succeed by falling
+	// through to createQueue; it must fail explicitly.
+	if _, err := qc.CreateOrUpdateAuthorizationRule(ctx, rgName, nsName, queueName, "send-rule",
+		armservicebus.SBAuthorizationRule{
+			Properties: &armservicebus.SBAuthorizationRuleProperties{
+				Rights: []*armservicebus.AccessRights{to.Ptr(armservicebus.AccessRightsSend)},
+			},
+		}, nil); err == nil {
+		t.Fatal("CreateOrUpdateAuthorizationRule on a queue returned nil error, want a rejection")
+	}
+
+	// The queue's own properties must be untouched.
+	got, err := qc.Get(ctx, rgName, nsName, queueName, nil)
+	if err != nil {
+		t.Fatalf("Get queue after authrule call: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.MaxSizeInMegabytes == nil || *got.Properties.MaxSizeInMegabytes != 5120 {
+		t.Fatalf("queue MaxSizeInMegabytes corrupted: %+v", got.Properties)
+	}
+
+	if got.Properties.LockDuration == nil || *got.Properties.LockDuration != "PT45S" {
+		t.Fatalf("queue LockDuration corrupted: %+v", got.Properties)
+	}
+
+	if got.Properties.MaxDeliveryCount == nil || *got.Properties.MaxDeliveryCount != 7 {
+		t.Fatalf("queue MaxDeliveryCount corrupted: %+v", got.Properties)
+	}
+
+	// DeleteAuthorizationRule must not delete the queue itself.
+	if _, err := qc.DeleteAuthorizationRule(ctx, rgName, nsName, queueName, "send-rule", nil); err == nil {
+		t.Fatal("DeleteAuthorizationRule on a queue returned nil error, want a rejection")
+	}
+
+	if _, err := qc.Get(ctx, rgName, nsName, queueName, nil); err != nil {
+		t.Fatalf("queue must survive DeleteAuthorizationRule call, but Get failed: %v", err)
+	}
+
+	// GetAuthorizationRule must not echo the queue's own resource as if it
+	// were the auth rule.
+	if _, err := qc.GetAuthorizationRule(ctx, rgName, nsName, queueName, "does-not-exist", nil); err == nil {
+		t.Fatal("GetAuthorizationRule on a queue returned nil error, want a rejection")
+	}
+
+	// All of the above must surface as a real ARM error response (not, say, a
+	// transport-level failure), so a caller sees an explicit rejection.
+	var respErr *azcore.ResponseError
+	if _, err := qc.CreateOrUpdateAuthorizationRule(ctx, rgName, nsName, queueName, "send-rule",
+		armservicebus.SBAuthorizationRule{}, nil); err != nil {
+		if !errors.As(err, &respErr) {
+			t.Fatalf("expected an azcore.ResponseError, got %T: %v", err, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Real-user black-box e2e audit of Azure Service Bus (Microsoft.ServiceBus) ARM control plane using the real `azure-sdk-for-go` `armservicebus/v2` client against a live `cloudemu serve` instance. Namespaces, checkNameAvailability, listKeys/regenerateKeys, queues, topics, subscriptions, and rules all round-trip correctly, tags PATCH-replace correctly, and lists are sorted/stable — see full findings write-up for the complete pass/fail matrix.

One critical bug found and fixed:

- **`serveQueue` misrouted queue-scoped `authorizationRules` sub-paths into the queue's own CRUD handlers.** Unlike topics/subscriptions/rules (which dispatch on exact path-segment length), queue routing extracted the queue name and dispatched purely on HTTP method regardless of trailing segments. A PUT/GET/DELETE to `.../queues/{q}/authorizationRules/{rule}` (real, documented `QueuesClient.CreateOrUpdateAuthorizationRule`/`GetAuthorizationRule`/`DeleteAuthorizationRule` operations) fell through to `createQueue`/`getQueue`/`deleteQueue`:
  - PUT silently reset the queue's properties (MaxSizeInMegabytes, LockDuration, MaxDeliveryCount, etc.) to defaults, because the authorization-rule request body doesn't decode into queue properties.
  - GET echoed the queue's own ARM resource instead of 404ing.
  - DELETE deleted the entire queue.

  Fixed by rejecting any queue path deeper than `queues/{name}` with 501, matching how topics/subscriptions/rules already fail safe. Queue/topic-scoped authorization rules remain unimplemented (a real feature gap, not touched by this PR), but the routing can no longer corrupt or destroy unrelated queue data.

## Evidence

Repro/verification via a scratch `armservicebus` driver against a live `cloudemu serve -providers=azure` instance (deleted before this PR):

```go
qc.CreateOrUpdate(ctx, rg, ns, "protected-q", armservicebus.SBQueue{
    Properties: &armservicebus.SBQueueProperties{
        MaxSizeInMegabytes: to.Ptr[int32](5120), LockDuration: to.Ptr("PT45S"), MaxDeliveryCount: to.Ptr[int32](7),
    },
}, nil)

qc.CreateOrUpdateAuthorizationRule(ctx, rg, ns, "protected-q", "send-rule", armservicebus.SBAuthorizationRule{...}, nil)
// before fix: Get(rg, ns, "protected-q") now shows MaxSizeInMegabytes/LockDuration/MaxDeliveryCount reset to defaults

qc.DeleteAuthorizationRule(ctx, rg, ns, "protected-q", "send-rule", nil)
// before fix: Get(rg, ns, "protected-q") now 404s — the entire queue was deleted

// after fix: both calls return 501 NotImplemented; the queue's properties and existence are untouched
```

Re-verified black-box with raw HTTP and the SDK after the fix — all three methods (PUT/GET/DELETE) on the queue-scoped authorizationRules path now return `501 {"error":{"code":"NotImplemented","message":"unsupported path"}}`, and the queue survives unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go test ./server/azure/servicebus/... ./providers/azure/servicebus/... -race` — pass
- [x] `go test ./server/azure/... ./providers/azure/...` — pass (full Azure sweep, no regressions)
- [x] New regression test: `TestQueueScopedAuthorizationRuleDoesNotCorruptQueue` in `server/azure/servicebus/queue_authrule_route_test.go`
- [x] `gofmt -l` clean
- [x] `golangci-lint run --new-from-rev=origin/development ./server/azure/servicebus/...` — 0 issues
- [x] `go generate ./...` + `git diff docs/coverage` — no diff (routing fix only, no interface change)