### PR TITLE
fix(apigateway): real-user e2e divergences from AWS

### DIFF
--- a/docs/coverage/README.md
+++ b/docs/coverage/README.md
@@ -12,7 +12,7 @@ code does not implement. Machine-readable: [`coverage.json`](./coverage.json).
 | --- | --- | --- | --- | --- | --- |
 | `acm` | [ACM](./aws/acm.md) | — | — | — | 17 |
 | `aks` | — | [AKS](./azure/aks.md) | — | — | 18 |
-| `apigateway` | [APIGateway](./aws/apigateway.md) | — | — | — | 15 |
+| `apigateway` | [APIGateway](./aws/apigateway.md) | — | — | — | 23 |
 | `azureai` | — | [AI](./azure/ai.md) | — | — | 92 |
 | `azuresearch` | — | [Search](./azure/search.md) | — | — | 53 |
 | `bedrock` | [Bedrock](./aws/bedrock.md) | — | — | — | 65 |

--- a/docs/coverage/aws/README.md
+++ b/docs/coverage/aws/README.md
@@ -6,7 +6,7 @@ Services cloudemu emulates for AWS, by native name. Back to the [cross-provider 
 | AWS service | Portable service | Operations |
 | --- | --- | --- |
 | [ACM](./acm.md) | `acm` | 17 |
-| [APIGateway](./apigateway.md) | `apigateway` | 15 |
+| [APIGateway](./apigateway.md) | `apigateway` | 23 |
 | [Bedrock](./bedrock.md) | `bedrock` | 65 |
 | [BedrockAgent](./bedrockagent.md) | `bedrockagent` | 29 |
 | [BedrockAgentRuntime](./bedrockagentruntime.md) | `bedrockagentruntime` | 3 |

--- a/docs/coverage/aws/apigateway.md
+++ b/docs/coverage/aws/apigateway.md
@@ -3,7 +3,7 @@
 
 AWS's `apigateway` service · portable interface `driver.APIGateway` · [AWS index](./README.md)
 
-## Operations (15)
+## Operations (23)
 
 | Operation | Description |
 | --- | --- |
@@ -11,7 +11,14 @@ AWS's `apigateway` service · portable interface `driver.APIGateway` · [AWS ind
 | `CreateResource` |  |
 | `CreateRestAPI` |  |
 | `CreateStage` |  |
+| `DeleteDeployment` | DeleteDeployment removes a deployment. It fails with a FailedPrecondition |
+| `DeleteIntegration` |  |
+| `DeleteMethod` |  |
+| `DeleteResource` | DeleteResource removes a resource and its whole descendant subtree, as |
 | `DeleteRestAPI` |  |
+| `DeleteStage` |  |
+| `GetDeployment` |  |
+| `GetDeployments` |  |
 | `GetIntegration` |  |
 | `GetMethod` |  |
 | `GetResource` |  |
@@ -19,6 +26,7 @@ AWS's `apigateway` service · portable interface `driver.APIGateway` · [AWS ind
 | `GetRestAPI` |  |
 | `GetRestAPIs` |  |
 | `GetStage` |  |
+| `GetStages` |  |
 | `InvokeRoute` | InvokeRoute resolves req.HTTPMethod+req.Path against the deployed stage's |
 | `PutIntegration` |  |
 | `PutMethod` |  |

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -139,7 +139,30 @@
         "name": "CreateStage"
       },
       {
+        "name": "DeleteDeployment",
+        "doc": "DeleteDeployment removes a deployment. It fails with a FailedPrecondition"
+      },
+      {
+        "name": "DeleteIntegration"
+      },
+      {
+        "name": "DeleteMethod"
+      },
+      {
+        "name": "DeleteResource",
+        "doc": "DeleteResource removes a resource and its whole descendant subtree, as"
+      },
+      {
         "name": "DeleteRestAPI"
+      },
+      {
+        "name": "DeleteStage"
+      },
+      {
+        "name": "GetDeployment"
+      },
+      {
+        "name": "GetDeployments"
       },
       {
         "name": "GetIntegration"
@@ -161,6 +184,9 @@
       },
       {
         "name": "GetStage"
+      },
+      {
+        "name": "GetStages"
       },
       {
         "name": "InvokeRoute",

--- a/providers/aws/apigateway/apigateway_test.go
+++ b/providers/aws/apigateway/apigateway_test.go
@@ -367,3 +367,132 @@ func TestCreateResourceRejectsSecondVariableSibling(t *testing.T) {
 		t.Fatalf("CreateResource(pets) alongside {id}: %v", err)
 	}
 }
+
+// TestDeleteMethodAndIntegration proves DeleteIntegration clears just the
+// integration (the method survives), and a subsequent DeleteMethod removes the
+// method entirely — the lifecycle a Terraform destroy of
+// aws_api_gateway_integration then aws_api_gateway_method drives.
+func TestDeleteMethodAndIntegration(t *testing.T) {
+	m := newMock(t)
+	apiID, _, resID := deployProxyAPI(t, m, "hello", "GET", lambdaURI)
+
+	if err := m.DeleteIntegration(ctx(), apiID, resID, "GET"); err != nil {
+		t.Fatalf("DeleteIntegration: %v", err)
+	}
+
+	if _, err := m.GetIntegration(ctx(), apiID, resID, "GET"); !errors.IsNotFound(err) {
+		t.Fatalf("GetIntegration after delete: %v, want NotFound", err)
+	}
+
+	if _, err := m.GetMethod(ctx(), apiID, resID, "GET"); err != nil {
+		t.Fatalf("GetMethod should still exist after DeleteIntegration: %v", err)
+	}
+
+	if err := m.DeleteMethod(ctx(), apiID, resID, "GET"); err != nil {
+		t.Fatalf("DeleteMethod: %v", err)
+	}
+
+	if _, err := m.GetMethod(ctx(), apiID, resID, "GET"); !errors.IsNotFound(err) {
+		t.Fatalf("GetMethod after delete: %v, want NotFound", err)
+	}
+}
+
+// TestDeleteIntegrationMissingIsNotFound proves deleting a nonexistent
+// integration is a NotFound (real API Gateway returns NotFoundException).
+func TestDeleteIntegrationMissingIsNotFound(t *testing.T) {
+	m := newMock(t)
+	api, _ := m.CreateRestAPI(ctx(), &driver.CreateRestAPIInput{Name: "x"})
+	res, _ := m.CreateResource(ctx(), api.ID, api.RootResourceID, "pets")
+
+	if _, err := m.PutMethod(ctx(), api.ID, res.ID, "GET", driver.PutMethodInput{}); err != nil {
+		t.Fatalf("PutMethod: %v", err)
+	}
+
+	if err := m.DeleteIntegration(ctx(), api.ID, res.ID, "GET"); !errors.IsNotFound(err) {
+		t.Fatalf("DeleteIntegration with no integration: %v, want NotFound", err)
+	}
+}
+
+// TestDeleteResourceCascadesToChildren proves deleting a resource removes its
+// whole descendant subtree, matching real API Gateway.
+func TestDeleteResourceCascadesToChildren(t *testing.T) {
+	m := newMock(t)
+	api, _ := m.CreateRestAPI(ctx(), &driver.CreateRestAPIInput{Name: "x"})
+
+	parent, err := m.CreateResource(ctx(), api.ID, api.RootResourceID, "orders")
+	if err != nil {
+		t.Fatalf("CreateResource(orders): %v", err)
+	}
+
+	child, err := m.CreateResource(ctx(), api.ID, parent.ID, "{id}")
+	if err != nil {
+		t.Fatalf("CreateResource({id}): %v", err)
+	}
+
+	if err := m.DeleteResource(ctx(), api.ID, parent.ID); err != nil {
+		t.Fatalf("DeleteResource: %v", err)
+	}
+
+	if _, err := m.GetResource(ctx(), api.ID, parent.ID); !errors.IsNotFound(err) {
+		t.Fatalf("GetResource(parent) after delete: %v, want NotFound", err)
+	}
+
+	if _, err := m.GetResource(ctx(), api.ID, child.ID); !errors.IsNotFound(err) {
+		t.Fatalf("GetResource(child) after parent delete: %v, want NotFound", err)
+	}
+}
+
+// TestDeleteResourceRejectsRoot proves the API's root resource cannot be
+// deleted, matching real API Gateway's "Cannot remove the root resource"
+// BadRequestException.
+func TestDeleteResourceRejectsRoot(t *testing.T) {
+	m := newMock(t)
+	api, _ := m.CreateRestAPI(ctx(), &driver.CreateRestAPIInput{Name: "x"})
+
+	if err := m.DeleteResource(ctx(), api.ID, api.RootResourceID); !errors.IsInvalidArgument(err) {
+		t.Fatalf("DeleteResource(root): %v, want InvalidArgument", err)
+	}
+}
+
+// TestDeploymentAndStageLifecycle exercises GetDeployment(s), GetStages,
+// DeleteStage and DeleteDeployment end to end, including the guard that a
+// deployment referenced by a stage cannot be deleted.
+func TestDeploymentAndStageLifecycle(t *testing.T) {
+	m := newMock(t)
+	apiID, _, _ := deployProxyAPI(t, m, "hello", "GET", lambdaURI)
+
+	deps, err := m.GetDeployments(ctx(), apiID)
+	if err != nil || len(deps) != 1 {
+		t.Fatalf("GetDeployments = %+v, %v; want 1 deployment", deps, err)
+	}
+
+	dep, err := m.GetDeployment(ctx(), apiID, deps[0].ID)
+	if err != nil {
+		t.Fatalf("GetDeployment: %v", err)
+	}
+
+	stages, err := m.GetStages(ctx(), apiID)
+	if err != nil || len(stages) != 1 || stages[0].StageName != "prod" {
+		t.Fatalf("GetStages = %+v, %v; want [prod]", stages, err)
+	}
+
+	if err := m.DeleteDeployment(ctx(), apiID, dep.ID); !errors.IsFailedPrecondition(err) {
+		t.Fatalf("DeleteDeployment while stage active: %v, want FailedPrecondition", err)
+	}
+
+	if err := m.DeleteStage(ctx(), apiID, "prod"); err != nil {
+		t.Fatalf("DeleteStage: %v", err)
+	}
+
+	if _, err := m.GetStage(ctx(), apiID, "prod"); !errors.IsNotFound(err) {
+		t.Fatalf("GetStage after delete: %v, want NotFound", err)
+	}
+
+	if err := m.DeleteDeployment(ctx(), apiID, dep.ID); err != nil {
+		t.Fatalf("DeleteDeployment after stage removed: %v", err)
+	}
+
+	if _, err := m.GetDeployment(ctx(), apiID, dep.ID); !errors.IsNotFound(err) {
+		t.Fatalf("GetDeployment after delete: %v, want NotFound", err)
+	}
+}

--- a/providers/aws/apigateway/deploy.go
+++ b/providers/aws/apigateway/deploy.go
@@ -38,6 +38,73 @@ func (m *Mock) CreateDeployment(
 	return &out, nil
 }
 
+// GetDeployments lists every deployment of a REST API.
+func (m *Mock) GetDeployments(_ context.Context, restAPIID string) ([]driver.Deployment, error) {
+	ad, err := m.getAPI(restAPIID)
+	if err != nil {
+		return nil, err
+	}
+
+	ad.mu.RLock()
+	defer ad.mu.RUnlock()
+
+	out := make([]driver.Deployment, 0, len(ad.deployments))
+	for _, d := range ad.deployments {
+		out = append(out, *d)
+	}
+
+	return out, nil
+}
+
+// GetDeployment returns a single deployment by id.
+func (m *Mock) GetDeployment(_ context.Context, restAPIID, deploymentID string) (*driver.Deployment, error) {
+	ad, err := m.getAPI(restAPIID)
+	if err != nil {
+		return nil, err
+	}
+
+	ad.mu.RLock()
+	defer ad.mu.RUnlock()
+
+	d, ok := ad.deployments[deploymentID]
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "Invalid deployment identifier specified %s", deploymentID)
+	}
+
+	out := *d
+
+	return &out, nil
+}
+
+// DeleteDeployment removes a deployment. It is rejected with a
+// FailedPrecondition error while any stage still points at it, matching real
+// API Gateway ("Active stages pointing to this deployment must be moved or
+// deleted").
+func (m *Mock) DeleteDeployment(_ context.Context, restAPIID, deploymentID string) error {
+	ad, err := m.getAPI(restAPIID)
+	if err != nil {
+		return err
+	}
+
+	ad.mu.Lock()
+	defer ad.mu.Unlock()
+
+	if _, ok := ad.deployments[deploymentID]; !ok {
+		return cerrors.Newf(cerrors.NotFound, "Invalid deployment identifier specified %s", deploymentID)
+	}
+
+	for _, st := range ad.stages {
+		if st.DeploymentID == deploymentID {
+			return cerrors.New(cerrors.FailedPrecondition,
+				"Active stages pointing to this deployment must be moved or deleted")
+		}
+	}
+
+	delete(ad.deployments, deploymentID)
+
+	return nil
+}
+
 // CreateStage points a named stage at an existing deployment.
 func (m *Mock) CreateStage(_ context.Context, restAPIID string, in driver.CreateStageInput) (*driver.Stage, error) {
 	if in.StageName == "" {
@@ -73,6 +140,43 @@ func (m *Mock) CreateStage(_ context.Context, restAPIID string, in driver.Create
 	out := copyStage(st)
 
 	return &out, nil
+}
+
+// GetStages lists every stage of a REST API.
+func (m *Mock) GetStages(_ context.Context, restAPIID string) ([]driver.Stage, error) {
+	ad, err := m.getAPI(restAPIID)
+	if err != nil {
+		return nil, err
+	}
+
+	ad.mu.RLock()
+	defer ad.mu.RUnlock()
+
+	out := make([]driver.Stage, 0, len(ad.stages))
+	for _, s := range ad.stages {
+		out = append(out, copyStage(s))
+	}
+
+	return out, nil
+}
+
+// DeleteStage removes a named stage.
+func (m *Mock) DeleteStage(_ context.Context, restAPIID, stageName string) error {
+	ad, err := m.getAPI(restAPIID)
+	if err != nil {
+		return err
+	}
+
+	ad.mu.Lock()
+	defer ad.mu.Unlock()
+
+	if _, ok := ad.stages[stageName]; !ok {
+		return cerrors.Newf(cerrors.NotFound, "Invalid stage identifier specified %s", stageName)
+	}
+
+	delete(ad.stages, stageName)
+
+	return nil
 }
 
 // GetStage returns a named stage.

--- a/providers/aws/apigateway/methods.go
+++ b/providers/aws/apigateway/methods.go
@@ -51,6 +51,32 @@ func (m *Mock) GetMethod(_ context.Context, restAPIID, resourceID, httpMethod st
 	return mth, nil
 }
 
+// DeleteMethod removes a resource's configured method (and its integration,
+// if any).
+func (m *Mock) DeleteMethod(_ context.Context, restAPIID, resourceID, httpMethod string) error {
+	ad, err := m.getAPI(restAPIID)
+	if err != nil {
+		return err
+	}
+
+	ad.mu.Lock()
+	defer ad.mu.Unlock()
+
+	res, ok := ad.resources[resourceID]
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "Invalid resource identifier specified %s", resourceID)
+	}
+
+	method := normalizeMethod(httpMethod)
+	if _, ok := res.Methods[method]; !ok {
+		return cerrors.Newf(cerrors.NotFound, "Invalid method identifier specified %s", method)
+	}
+
+	delete(res.Methods, method)
+
+	return nil
+}
+
 // PutIntegration wires a method to a backend integration (AWS_PROXY/AWS to a
 // Lambda invocation ARN, or another supported type).
 func (m *Mock) PutIntegration(
@@ -105,6 +131,37 @@ func (m *Mock) GetIntegration(_ context.Context, restAPIID, resourceID, httpMeth
 	}
 
 	return mth.Integration, nil
+}
+
+// DeleteIntegration removes a method's integration.
+func (m *Mock) DeleteIntegration(_ context.Context, restAPIID, resourceID, httpMethod string) error {
+	ad, err := m.getAPI(restAPIID)
+	if err != nil {
+		return err
+	}
+
+	ad.mu.Lock()
+	defer ad.mu.Unlock()
+
+	res, ok := ad.resources[resourceID]
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "Invalid resource identifier specified %s", resourceID)
+	}
+
+	method := normalizeMethod(httpMethod)
+
+	mth, ok := res.Methods[method]
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "Invalid method identifier specified %s", method)
+	}
+
+	if mth.Integration == nil {
+		return cerrors.New(cerrors.NotFound, "No integration defined for method")
+	}
+
+	mth.Integration = nil
+
+	return nil
 }
 
 // lookupMethod resolves a method and returns a deep copy safe to use after the

--- a/providers/aws/apigateway/resources.go
+++ b/providers/aws/apigateway/resources.go
@@ -74,6 +74,51 @@ func (m *Mock) GetResources(_ context.Context, restAPIID string) ([]driver.Resou
 	return out, nil
 }
 
+// DeleteResource removes a resource and its whole descendant subtree, as real
+// API Gateway does. The API's root resource cannot be deleted.
+func (m *Mock) DeleteResource(_ context.Context, restAPIID, resourceID string) error {
+	ad, err := m.getAPI(restAPIID)
+	if err != nil {
+		return err
+	}
+
+	ad.mu.Lock()
+	defer ad.mu.Unlock()
+
+	if _, ok := ad.resources[resourceID]; !ok {
+		return cerrors.Newf(cerrors.NotFound, "Invalid resource identifier specified %s", resourceID)
+	}
+
+	if resourceID == ad.api.RootResourceID {
+		return cerrors.New(cerrors.InvalidArgument, "Cannot remove the root resource of the RestApi")
+	}
+
+	for _, id := range descendants(ad.resources, resourceID) {
+		delete(ad.resources, id)
+	}
+
+	return nil
+}
+
+// descendants returns resourceID plus every resource beneath it in the tree
+// (its children, grandchildren, ...), so DeleteResource can remove the whole
+// subtree in one pass.
+func descendants(resources map[string]*driver.Resource, resourceID string) []string {
+	out := []string{resourceID}
+
+	for i := 0; i < len(out); i++ {
+		parent := out[i]
+
+		for id, r := range resources {
+			if r.ParentID == parent {
+				out = append(out, id)
+			}
+		}
+	}
+
+	return out
+}
+
 // GetResource returns a single resource by id.
 func (m *Mock) GetResource(_ context.Context, restAPIID, resourceID string) (*driver.Resource, error) {
 	ad, err := m.getAPI(restAPIID)

--- a/server/aws/apigateway/apigateway_e2e_test.go
+++ b/server/aws/apigateway/apigateway_e2e_test.go
@@ -206,6 +206,87 @@ func TestE2E_UndefinedRouteForbidden(t *testing.T) {
 	}
 }
 
+// TestE2E_DeleteLifecycle drives the full destroy path a Terraform
+// `terraform destroy` performs against a REST API: delete the integration, the
+// method, the stage, the deployment, and finally the resource — verifying each
+// step over the wire and that a re-GET afterward 404s.
+func TestE2E_DeleteLifecycle(t *testing.T) {
+	srv := newE2E(t)
+	base := srv.URL
+
+	api := doJSON(t, http.MethodPost, base+"/restapis", `{"name":"petstore"}`)
+	apiID, _ := api["id"].(string)
+	rootID, _ := api["rootResourceId"].(string)
+
+	res := doJSON(t, http.MethodPost, base+"/restapis/"+apiID+"/resources/"+rootID, `{"pathPart":"pets"}`)
+	resID, _ := res["id"].(string)
+
+	doJSON(t, http.MethodPut, base+"/restapis/"+apiID+"/resources/"+resID+"/methods/GET", `{"authorizationType":"NONE"}`)
+	doJSON(t, http.MethodPut, base+"/restapis/"+apiID+"/resources/"+resID+"/methods/GET/integration", `{"type":"MOCK"}`)
+
+	dep := doJSON(t, http.MethodPost, base+"/restapis/"+apiID+"/deployments", `{"stageName":"prod"}`)
+	depID, _ := dep["id"].(string)
+
+	// GetDeployment / GetDeployments / GetStages round-trip before teardown.
+	got := doJSON(t, http.MethodGet, base+"/restapis/"+apiID+"/deployments/"+depID, "")
+	if got["id"] != depID {
+		t.Fatalf("GetDeployment mismatch: %v", got)
+	}
+
+	deps := doJSON(t, http.MethodGet, base+"/restapis/"+apiID+"/deployments", "")
+	if items, _ := deps["item"].([]any); len(items) != 1 {
+		t.Fatalf("GetDeployments = %v, want 1 item", deps)
+	}
+
+	stages := doJSON(t, http.MethodGet, base+"/restapis/"+apiID+"/stages", "")
+	if items, _ := stages["item"].([]any); len(items) != 1 {
+		t.Fatalf("GetStages = %v, want 1 item", stages)
+	}
+
+	deleteOK(t, base+"/restapis/"+apiID+"/resources/"+resID+"/methods/GET/integration")
+	deleteOK(t, base+"/restapis/"+apiID+"/resources/"+resID+"/methods/GET")
+	deleteOK(t, base+"/restapis/"+apiID+"/stages/prod")
+	deleteOK(t, base+"/restapis/"+apiID+"/deployments/"+depID)
+	deleteOK(t, base+"/restapis/"+apiID+"/resources/"+resID)
+
+	if status := doStatus(t, http.MethodGet, base+"/restapis/"+apiID+"/resources/"+resID); status != http.StatusNotFound {
+		t.Fatalf("GetResource after delete status = %d, want 404", status)
+	}
+}
+
+func deleteOK(t *testing.T, url string) {
+	t.Helper()
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodDelete, url, nil)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE %s: %v", url, err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("DELETE %s -> %d, want 202: %s", url, resp.StatusCode, body)
+	}
+}
+
+func doStatus(t *testing.T, method, url string) int {
+	t.Helper()
+
+	req, _ := http.NewRequestWithContext(context.Background(), method, url, nil)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+
+	defer resp.Body.Close()
+
+	return resp.StatusCode
+}
+
 // TestE2E_ControlPlaneRoundTrip verifies the management API list/get after create.
 func TestE2E_ControlPlaneRoundTrip(t *testing.T) {
 	srv := newE2E(t)

--- a/server/aws/apigateway/handler.go
+++ b/server/aws/apigateway/handler.go
@@ -187,24 +187,51 @@ func (h *Handler) serveAPISub(w http.ResponseWriter, r *http.Request, id, sub st
 	case subResources:
 		h.getResources(w, r, id)
 	case subDeployments:
-		h.createDeployment(w, r, id)
+		h.serveDeployments(w, r, id)
 	case subStages:
-		h.createStage(w, r, id)
+		h.serveStages(w, r, id)
 	default:
 		writeError(w, http.StatusNotFound, "NotFoundException", "unsupported API Gateway path")
 	}
 }
 
-// serveAPISubItem handles /restapis/{id}/resources/{resourceId} and
-// /restapis/{id}/stages/{stageName}.
+// serveDeployments handles /restapis/{id}/deployments: GET=GetDeployments,
+// POST=CreateDeployment.
+func (h *Handler) serveDeployments(w http.ResponseWriter, r *http.Request, id string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getDeployments(w, r, id)
+	case http.MethodPost:
+		h.createDeployment(w, r, id)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+// serveStages handles /restapis/{id}/stages: GET=GetStages, POST=CreateStage.
+func (h *Handler) serveStages(w http.ResponseWriter, r *http.Request, id string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getStages(w, r, id)
+	case http.MethodPost:
+		h.createStage(w, r, id)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+// serveAPISubItem handles /restapis/{id}/resources/{resourceId},
+// /restapis/{id}/deployments/{deploymentId} and /restapis/{id}/stages/{stageName}.
 func (h *Handler) serveAPISubItem(w http.ResponseWriter, r *http.Request, segs []string) {
 	id, sub, item := segs[0], segs[1], segs[2]
 
 	switch sub {
 	case subResources:
 		h.serveResourceItem(w, r, id, item)
+	case subDeployments:
+		h.serveDeploymentItem(w, r, id, item)
 	case subStages:
-		h.getStage(w, r, id, item)
+		h.serveStageItem(w, r, id, item)
 	default:
 		writeError(w, http.StatusNotFound, "NotFoundException", "unsupported API Gateway path")
 	}
@@ -255,6 +282,13 @@ func (h *Handler) serveResourceItem(w http.ResponseWriter, r *http.Request, id, 
 		}
 
 		writeJSON(w, http.StatusCreated, toResourceResponse(res))
+	case http.MethodDelete:
+		if err := h.ag.DeleteResource(r.Context(), id, resourceID); err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		w.WriteHeader(http.StatusAccepted)
 	default:
 		writeMethodNotAllowed(w)
 	}
@@ -289,6 +323,13 @@ func (h *Handler) serveMethod(w http.ResponseWriter, r *http.Request, segs []str
 		}
 
 		writeJSON(w, http.StatusOK, toMethodResponse(mth))
+	case http.MethodDelete:
+		if err := h.ag.DeleteMethod(r.Context(), id, resourceID, httpMethod); err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		w.WriteHeader(http.StatusAccepted)
 	default:
 		writeMethodNotAllowed(w)
 	}
@@ -330,9 +371,41 @@ func (h *Handler) serveIntegration(w http.ResponseWriter, r *http.Request, segs 
 		}
 
 		writeJSON(w, http.StatusOK, toIntegrationResponse(ig))
+	case http.MethodDelete:
+		if err := h.ag.DeleteIntegration(r.Context(), id, resourceID, httpMethod); err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		w.WriteHeader(http.StatusAccepted)
 	default:
 		writeMethodNotAllowed(w)
 	}
+}
+
+func (h *Handler) getDeployments(w http.ResponseWriter, r *http.Request, id string) {
+	deps, err := h.ag.GetDeployments(r.Context(), id)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := listDeploymentsResponse{Item: make([]deploymentResponse, 0, len(deps))}
+	for i := range deps {
+		out.Item = append(out.Item, toDeploymentResponse(&deps[i]))
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+// serveDeploymentItem handles /restapis/{id}/deployments/{deploymentId}:
+// GET=GetDeployment, DELETE=DeleteDeployment.
+func (h *Handler) serveDeploymentItem(w http.ResponseWriter, r *http.Request, id, deploymentID string) {
+	serveGetDelete(w, r,
+		func() (*driver.Deployment, error) { return h.ag.GetDeployment(r.Context(), id, deploymentID) },
+		func() error { return h.ag.DeleteDeployment(r.Context(), id, deploymentID) },
+		toDeploymentResponse,
+	)
 }
 
 func (h *Handler) createDeployment(w http.ResponseWriter, r *http.Request, id string) {
@@ -354,9 +427,7 @@ func (h *Handler) createDeployment(w http.ResponseWriter, r *http.Request, id st
 		return
 	}
 
-	writeJSON(w, http.StatusCreated, deploymentResponse{
-		ID: dep.ID, Description: dep.Description, CreatedDate: dep.CreatedDate,
-	})
+	writeJSON(w, http.StatusCreated, toDeploymentResponse(dep))
 }
 
 func (h *Handler) createStage(w http.ResponseWriter, r *http.Request, id string) {
@@ -382,19 +453,56 @@ func (h *Handler) createStage(w http.ResponseWriter, r *http.Request, id string)
 	writeJSON(w, http.StatusCreated, toStageResponse(st))
 }
 
-func (h *Handler) getStage(w http.ResponseWriter, r *http.Request, id, stageName string) {
-	if r.Method != http.MethodGet {
-		writeMethodNotAllowed(w)
-		return
-	}
-
-	st, err := h.ag.GetStage(r.Context(), id, stageName)
+func (h *Handler) getStages(w http.ResponseWriter, r *http.Request, id string) {
+	stages, err := h.ag.GetStages(r.Context(), id)
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	writeJSON(w, http.StatusOK, toStageResponse(st))
+	out := listStagesResponse{Item: make([]stageResponse, 0, len(stages))}
+	for i := range stages {
+		out.Item = append(out.Item, toStageResponse(&stages[i]))
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+// serveStageItem handles /restapis/{id}/stages/{stageName}: GET=GetStage,
+// DELETE=DeleteStage.
+func (h *Handler) serveStageItem(w http.ResponseWriter, r *http.Request, id, stageName string) {
+	serveGetDelete(w, r,
+		func() (*driver.Stage, error) { return h.ag.GetStage(r.Context(), id, stageName) },
+		func() error { return h.ag.DeleteStage(r.Context(), id, stageName) },
+		toStageResponse,
+	)
+}
+
+// serveGetDelete handles the common GET-one/DELETE-one shape shared by the
+// deployment and stage item routes: GET renders get()'s result with render,
+// DELETE calls del(), and any other method is rejected.
+func serveGetDelete[T, R any](
+	w http.ResponseWriter, r *http.Request, get func() (T, error), del func() error, render func(T) R,
+) {
+	switch r.Method {
+	case http.MethodGet:
+		v, err := get()
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, render(v))
+	case http.MethodDelete:
+		if err := del(); err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+	default:
+		writeMethodNotAllowed(w)
+	}
 }
 
 func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
@@ -433,7 +541,7 @@ func writeErr(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusNotFound, "NotFoundException", msg)
 	case cerrors.IsAlreadyExists(err):
 		writeError(w, http.StatusConflict, "ConflictException", msg)
-	case cerrors.IsInvalidArgument(err):
+	case cerrors.IsInvalidArgument(err), cerrors.IsFailedPrecondition(err):
 		writeError(w, http.StatusBadRequest, "BadRequestException", msg)
 	default:
 		writeError(w, http.StatusInternalServerError, "ApiGatewayException", msg)

--- a/server/aws/apigateway/types.go
+++ b/server/aws/apigateway/types.go
@@ -106,6 +106,11 @@ type deploymentResponse struct {
 	CreatedDate int64  `json:"createdDate"`
 }
 
+// listDeploymentsResponse is the GetDeployments wire object.
+type listDeploymentsResponse struct {
+	Item []deploymentResponse `json:"item"`
+}
+
 // stageResponse is the Stage wire object.
 type stageResponse struct {
 	StageName    string            `json:"stageName"`
@@ -113,6 +118,11 @@ type stageResponse struct {
 	Description  string            `json:"description,omitempty"`
 	CreatedDate  int64             `json:"createdDate"`
 	Variables    map[string]string `json:"variables,omitempty"`
+}
+
+// listStagesResponse is the GetStages wire object.
+type listStagesResponse struct {
+	Item []stageResponse `json:"item"`
 }
 
 func toRestAPIResponse(a *driver.RestAPI) restAPIResponse {
@@ -160,6 +170,10 @@ func toIntegrationResponse(ig *driver.Integration) integrationResponse {
 		Type: ig.Type, HTTPMethod: ig.IntegrationHTTPMethod,
 		URI: ig.URI, PassthroughBehavior: ig.PassthroughBehavior,
 	}
+}
+
+func toDeploymentResponse(d *driver.Deployment) deploymentResponse {
+	return deploymentResponse{ID: d.ID, Description: d.Description, CreatedDate: d.CreatedDate}
 }
 
 func toStageResponse(s *driver.Stage) stageResponse {

--- a/services/apigateway/driver/driver.go
+++ b/services/apigateway/driver/driver.go
@@ -169,16 +169,31 @@ type APIGateway interface {
 	CreateResource(ctx context.Context, restAPIID, parentID, pathPart string) (*Resource, error)
 	GetResources(ctx context.Context, restAPIID string) ([]Resource, error)
 	GetResource(ctx context.Context, restAPIID, resourceID string) (*Resource, error)
+	// DeleteResource removes a resource and its whole descendant subtree, as
+	// real API Gateway does. Deleting the API's root resource is rejected.
+	DeleteResource(ctx context.Context, restAPIID, resourceID string) error
 
 	PutMethod(ctx context.Context, restAPIID, resourceID, httpMethod string, in PutMethodInput) (*Method, error)
 	GetMethod(ctx context.Context, restAPIID, resourceID, httpMethod string) (*Method, error)
+	DeleteMethod(ctx context.Context, restAPIID, resourceID, httpMethod string) error
 
 	PutIntegration(ctx context.Context, restAPIID, resourceID, httpMethod string, in PutIntegrationInput) (*Integration, error)
 	GetIntegration(ctx context.Context, restAPIID, resourceID, httpMethod string) (*Integration, error)
+	DeleteIntegration(ctx context.Context, restAPIID, resourceID, httpMethod string) error
 
 	CreateDeployment(ctx context.Context, restAPIID string, in CreateDeploymentInput) (*Deployment, error)
+	GetDeployments(ctx context.Context, restAPIID string) ([]Deployment, error)
+	GetDeployment(ctx context.Context, restAPIID, deploymentID string) (*Deployment, error)
+	// DeleteDeployment removes a deployment. It fails with a FailedPrecondition
+	// error when a stage still points at it, matching real API Gateway (a
+	// deployment referenced by a stage must have that stage moved or deleted
+	// first).
+	DeleteDeployment(ctx context.Context, restAPIID, deploymentID string) error
+
 	CreateStage(ctx context.Context, restAPIID string, in CreateStageInput) (*Stage, error)
+	GetStages(ctx context.Context, restAPIID string) ([]Stage, error)
 	GetStage(ctx context.Context, restAPIID, stageName string) (*Stage, error)
+	DeleteStage(ctx context.Context, restAPIID, stageName string) error
 
 	// InvokeRoute resolves req.HTTPMethod+req.Path against the deployed stage's
 	// resource tree ({proxy+} greedy paths and {param} placeholders supported)


### PR DESCRIPTION
## Summary

Real-user e2e audit of API Gateway REST API (v1) against aws-cli found the
control-plane CRUD surface was missing its D and part of its G:

- `DeleteResource`, `DeleteMethod`, `DeleteIntegration`, `DeleteStage`,
  `DeleteDeployment` did not exist anywhere — every DELETE to these paths
  returned `BadRequestException: method not allowed`. This breaks
  `terraform destroy` for every `aws_api_gateway_*` resource type, and
  `aws apigateway delete-*` CLI commands outright.
- `GetDeployment`, `GetDeployments`, `GetStages` were also missing — the
  first is unrouted entirely (`NotFoundException: unsupported API Gateway
  path`), the list ops 405. Terraform's `aws_api_gateway_deployment` /
  `aws_api_gateway_stage` resources call these during plan/refresh.
- `FailedPrecondition` errors fell through to a 500 `ApiGatewayException`
  instead of AWS's actual 400 `BadRequestException` shape.

## Changes

- `services/apigateway/driver/driver.go` — extend the `APIGateway` interface
  with the 8 missing operations.
- `providers/aws/apigateway/{resources,methods,deploy}.go` — implement them:
  - `DeleteResource` cascades to the whole descendant subtree (matching real
    API Gateway) and rejects deleting the API's root resource.
  - `DeleteDeployment` rejects with `FailedPrecondition` while any stage
    still points at it ("Active stages pointing to this deployment must be
    moved or deleted"), matching real AWS.
  - `GetDeployments`/`GetDeployment`/`GetStages` list/get the existing stores.
- `server/aws/apigateway/handler.go` — route all 8 over the wire; a small
  generic `serveGetDelete[T,R]` helper covers the shared GET-one/DELETE-one
  shape for deployment-item and stage-item routes; `writeErr` now maps
  `FailedPrecondition` to 400.
- `server/aws/apigateway/types.go` — `listDeploymentsResponse`,
  `listStagesResponse` wire shapes.
- `docs/coverage/**` — regenerated (`apigateway` now lists 23 operations, was 15).

Filed as build-out gaps (not attempted here, too large for a divergence fix):
API Gateway v2 (HTTP/WebSocket APIs) is entirely unimplemented; REST v1's
`Update*`/PATCH operations and `TagResource`/`UntagResource` don't exist yet.

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers/aws/apigateway/... ./server/aws/apigateway/... -race` (5 new provider tests, 1 new e2e test, all pass)
- [x] `go test ./...` — no regressions elsewhere
- [x] `gofmt -l` clean
- [x] `golangci-lint run --new-from-rev=origin/development` — 0 issues
- [x] `go generate ./...` — docs/coverage regenerated and committed
- [x] Black-box re-verification via aws-cli against a rebuilt `cloudemu serve`: full create→get→delete lifecycle for resource (incl. cascading child delete + root-resource rejection), method, integration, stage, and deployment (incl. the active-stage guard) all behave as real AWS does