### PR TITLE
fix(gcp): eliminate internal error-string prefix leaks across all handlers

### DIFF
--- a/server/gcp/alloydb/helpers.go
+++ b/server/gcp/alloydb/helpers.go
@@ -36,17 +36,19 @@ func writeError(w http.ResponseWriter, status int, gcpStatus, msg string) {
 
 // writeCErr maps a CloudEmu canonical error to the matching GCP HTTP status.
 func writeCErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+		writeError(w, http.StatusNotFound, "NOT_FOUND", msg)
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "ALREADY_EXISTS", err.Error())
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", msg)
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", msg)
 	case cerrors.IsFailedPrecondition(err):
-		writeError(w, http.StatusBadRequest, "FAILED_PRECONDITION", err.Error())
+		writeError(w, http.StatusBadRequest, "FAILED_PRECONDITION", msg)
 	default:
-		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+		writeError(w, http.StatusInternalServerError, "INTERNAL", msg)
 	}
 }
 

--- a/server/gcp/alloydb/sdk_roundtrip_test.go
+++ b/server/gcp/alloydb/sdk_roundtrip_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -221,6 +222,47 @@ func assertStatus(t *testing.T, err error, want int) {
 
 	if gerr.Code != want {
 		t.Errorf("status: got %d, want %d", gerr.Code, want)
+	}
+}
+
+// TestSDKAlloyDBErrorMessagesOmitCodePrefix guards writeCErr
+// (server/gcp/alloydb) against baking cloudemu's internal cerrors code name
+// (e.g. "NotFound: ...", "AlreadyExists: ...") into the wire error message an
+// SDK caller sees. Real AlloyDB never prefixes its error messages with an
+// internal error-taxonomy name.
+func TestSDKAlloyDBErrorMessagesOmitCodePrefix(t *testing.T) {
+	svc := newSDKClient(t)
+	ctx := context.Background()
+
+	t.Run("NotFound Clusters.Get", func(t *testing.T) {
+		_, err := svc.Projects.Locations.Clusters.Get(parent() + "/clusters/ghost-msg").Context(ctx).Do()
+		assertNoCodePrefixOnAPIError(t, err)
+	})
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(), &alloydb.Cluster{}).
+		ClusterId("dup-msg").Context(ctx).Do(); err != nil {
+		t.Fatalf("Clusters.Create: %v", err)
+	}
+
+	t.Run("AlreadyExists Clusters.Create duplicate", func(t *testing.T) {
+		_, err := svc.Projects.Locations.Clusters.Create(parent(), &alloydb.Cluster{}).
+			ClusterId("dup-msg").Context(ctx).Do()
+		assertNoCodePrefixOnAPIError(t, err)
+	})
+}
+
+func assertNoCodePrefixOnAPIError(t *testing.T, err error) {
+	t.Helper()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) {
+		t.Fatalf("expected a googleapi.Error, got %T: %v", err, err)
+	}
+
+	for _, prefix := range []string{"NotFound:", "AlreadyExists:", "InvalidArgument:", "FailedPrecondition:", "Internal:"} {
+		if strings.Contains(gerr.Message, prefix) {
+			t.Errorf("wire error message %q leaks internal code prefix %q", gerr.Message, prefix)
+		}
 	}
 }
 

--- a/server/gcp/cloudasset/handler.go
+++ b/server/gcp/cloudasset/handler.go
@@ -1013,13 +1013,15 @@ func writeError(w http.ResponseWriter, status int, code, msg string) {
 }
 
 func writeCErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+		writeError(w, http.StatusNotFound, "NOT_FOUND", msg)
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", msg)
 	default:
-		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+		writeError(w, http.StatusInternalServerError, "INTERNAL", msg)
 	}
 }
 

--- a/server/gcp/cloudasset/sdk_test.go
+++ b/server/gcp/cloudasset/sdk_test.go
@@ -5,6 +5,7 @@ package cloudasset_test
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/cloudasset/v1"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 
 	"github.com/stackshy/cloudemu/v2"
@@ -510,5 +512,72 @@ func TestSDKCloudAsset_BatchGetAssetsHistory(t *testing.T) {
 	for _, a := range out.Assets {
 		require.NotNil(t, a.Window, "each TemporalAsset must carry a window")
 		assert.NotEmpty(t, a.Window.StartTime)
+	}
+}
+
+// TestSDKCloudAssetErrorMessagesOmitCodePrefix guards against the wire error
+// message leaking cloudemu's internal cerrors code name (e.g. "NotFound: ...",
+// "AlreadyExists: ...") into the message an SDK caller sees. Real Cloud Asset
+// never prefixes its error messages with an internal error-taxonomy name.
+func TestSDKCloudAssetErrorMessagesOmitCodePrefix(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewGCP()
+	const projectID = "errmsg-project"
+
+	srv := gcpserver.New(gcpserver.Drivers{
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		ProjectID:         projectID,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := cloudasset.NewService(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	require.NoError(t, err)
+
+	scope := "projects/" + projectID
+	feedID := "errmsg-feed"
+	feedName := scope + "/feeds/" + feedID
+
+	t.Run("NotFound Feeds.Get", func(t *testing.T) {
+		_, err := client.Feeds.Get(feedName).Do()
+		require.Error(t, err)
+
+		var gErr *googleapi.Error
+		require.True(t, errors.As(err, &gErr), "expected a googleapi.Error, got %T", err)
+		assertNoCodePrefix(t, gErr.Message)
+	})
+
+	t.Run("AlreadyExists Feeds.Create", func(t *testing.T) {
+		_, err := client.Feeds.Create(scope, &cloudasset.CreateFeedRequest{
+			FeedId: feedID,
+			Feed:   &cloudasset.Feed{},
+		}).Do()
+		require.NoError(t, err)
+
+		_, err = client.Feeds.Create(scope, &cloudasset.CreateFeedRequest{
+			FeedId: feedID,
+			Feed:   &cloudasset.Feed{},
+		}).Do()
+		require.Error(t, err)
+
+		var gErr *googleapi.Error
+		require.True(t, errors.As(err, &gErr), "expected a googleapi.Error, got %T", err)
+		assertNoCodePrefix(t, gErr.Message)
+	})
+}
+
+// assertNoCodePrefix fails if msg contains one of cloudemu's internal
+// canonical error-code names followed by a colon (the shape err.Error()
+// produces via *cerrors.Error, as opposed to cerrors.Message(err)).
+func assertNoCodePrefix(t *testing.T, msg string) {
+	t.Helper()
+
+	for _, prefix := range []string{"NotFound:", "AlreadyExists:", "InvalidArgument:", "FailedPrecondition:", "Internal:"} {
+		if strings.Contains(msg, prefix) {
+			t.Errorf("wire error message %q leaks internal code prefix %q", msg, prefix)
+		}
 	}
 }

--- a/server/gcp/cloudfunctions/error_message_test.go
+++ b/server/gcp/cloudfunctions/error_message_test.go
@@ -1,0 +1,68 @@
+package cloudfunctions_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/cloudfunctions/v1"
+	"google.golang.org/api/googleapi"
+)
+
+// TestSDKCloudFunctionsErrorMessagesOmitCodePrefix guards writeErr
+// (server/gcp/cloudfunctions) against baking cloudemu's internal cerrors code
+// name (e.g. "NotFound: ...", "AlreadyExists: ...") into the wire error
+// message an SDK caller sees. Real Cloud Functions never prefixes its error
+// messages with an internal error-taxonomy name.
+func TestSDKCloudFunctionsErrorMessagesOmitCodePrefix(t *testing.T) {
+	svc := newGCPSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+
+	t.Run("NotFound Functions.Get", func(t *testing.T) {
+		_, err := svc.Projects.Locations.Functions.Get(parent + "/functions/no-such-fn").Context(ctx).Do()
+
+		var gErr *googleapi.Error
+		if !errors.As(err, &gErr) {
+			t.Fatalf("expected a googleapi.Error, got %T: %v", err, err)
+		}
+		assertNoCodePrefix(t, gErr.Message)
+	})
+
+	t.Run("AlreadyExists Functions.Create duplicate", func(t *testing.T) {
+		fn := &cloudfunctions.CloudFunction{
+			Name:              parent + "/functions/errmsg-dupe",
+			Runtime:           "go121",
+			EntryPoint:        "Hello",
+			AvailableMemoryMb: 128,
+			Timeout:           "60s",
+		}
+
+		if _, err := svc.Projects.Locations.Functions.Create(parent, fn).Context(ctx).Do(); err != nil {
+			t.Fatalf("first Create: %v", err)
+		}
+
+		_, err := svc.Projects.Locations.Functions.Create(parent, fn).Context(ctx).Do()
+
+		var gErr *googleapi.Error
+		if !errors.As(err, &gErr) {
+			t.Fatalf("expected a googleapi.Error, got %T: %v", err, err)
+		}
+		assertNoCodePrefix(t, gErr.Message)
+	})
+}
+
+// assertNoCodePrefix fails if msg contains one of cloudemu's internal
+// canonical error-code names followed by a colon — the shape err.Error()
+// produces for a *cerrors.Error, as opposed to cerrors.Message(err).
+func assertNoCodePrefix(t *testing.T, msg string) {
+	t.Helper()
+
+	for _, prefix := range []string{"NotFound:", "AlreadyExists:", "InvalidArgument:", "FailedPrecondition:", "Internal:"} {
+		if strings.Contains(msg, prefix) {
+			t.Errorf("wire error message %q leaks internal code prefix %q", msg, prefix)
+		}
+	}
+}

--- a/server/gcp/cloudfunctions/handler.go
+++ b/server/gcp/cloudfunctions/handler.go
@@ -883,14 +883,16 @@ func writeError(w http.ResponseWriter, status int, reason, msg string) {
 }
 
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+		writeError(w, http.StatusNotFound, "NOT_FOUND", msg)
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "ALREADY_EXISTS", err.Error())
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", msg)
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", msg)
 	default:
-		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+		writeError(w, http.StatusInternalServerError, "INTERNAL", msg)
 	}
 }

--- a/server/gcp/cloudsql/sdk_roundtrip_test.go
+++ b/server/gcp/cloudsql/sdk_roundtrip_test.go
@@ -2,9 +2,12 @@ package cloudsql_test
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 	sqladmin "google.golang.org/api/sqladmin/v1"
 
@@ -243,3 +246,60 @@ func strconvAtoi64(s string) (int64, error) {
 type parseErr struct{ s string }
 
 func (e *parseErr) Error() string { return "not a number: " + e.s }
+
+// TestSDKCloudSQLErrorMessagesOmitCodePrefix guards writeErr
+// (server/gcp/cloudsql) against baking cloudemu's internal cerrors code name
+// (e.g. "NotFound: ...", "AlreadyExists: ...") into the wire error message an
+// SDK caller sees. Real Cloud SQL never prefixes its error messages with an
+// internal error-taxonomy name.
+func TestSDKCloudSQLErrorMessagesOmitCodePrefix(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	t.Run("NotFound Instances.Get", func(t *testing.T) {
+		_, err := svc.Instances.Get(project, "no-such-instance").Context(ctx).Do()
+
+		var gErr *googleapi.Error
+		if !errors.As(err, &gErr) {
+			t.Fatalf("expected a googleapi.Error, got %T: %v", err, err)
+		}
+		assertNoCodePrefix(t, gErr.Message)
+	})
+
+	t.Run("AlreadyExists Instances.Insert duplicate", func(t *testing.T) {
+		dupInstance := &sqladmin.DatabaseInstance{
+			Name:            "errmsg-dupe",
+			DatabaseVersion: "POSTGRES_15",
+			Region:          "us-central1",
+			Settings: &sqladmin.Settings{
+				Tier:           "db-custom-2-8192",
+				DataDiskSizeGb: 50,
+			},
+		}
+
+		if _, err := svc.Instances.Insert(project, dupInstance).Context(ctx).Do(); err != nil {
+			t.Fatalf("first Insert: %v", err)
+		}
+
+		_, err := svc.Instances.Insert(project, dupInstance).Context(ctx).Do()
+
+		var gErr *googleapi.Error
+		if !errors.As(err, &gErr) {
+			t.Fatalf("expected a googleapi.Error, got %T: %v", err, err)
+		}
+		assertNoCodePrefix(t, gErr.Message)
+	})
+}
+
+// assertNoCodePrefix fails if msg contains one of cloudemu's internal
+// canonical error-code names followed by a colon — the shape err.Error()
+// produces for a *cerrors.Error, as opposed to cerrors.Message(err).
+func assertNoCodePrefix(t *testing.T, msg string) {
+	t.Helper()
+
+	for _, prefix := range []string{"NotFound:", "AlreadyExists:", "InvalidArgument:", "FailedPrecondition:", "Internal:"} {
+		if strings.Contains(msg, prefix) {
+			t.Errorf("wire error message %q leaks internal code prefix %q", msg, prefix)
+		}
+	}
+}

--- a/server/gcp/cloudsql/types.go
+++ b/server/gcp/cloudsql/types.go
@@ -328,18 +328,20 @@ func writeError(w http.ResponseWriter, status int, reason, msg string) {
 }
 
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+		writeError(w, http.StatusNotFound, "NOT_FOUND", msg)
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "ALREADY_EXISTS", err.Error())
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", msg)
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", msg)
 	case cerrors.IsFailedPrecondition(err):
 		// Google's canonical error mapping puts FAILED_PRECONDITION at HTTP 400
 		// (e.g. Cloud SQL's deletion-protection guard), not 409.
-		writeError(w, http.StatusBadRequest, "FAILED_PRECONDITION", err.Error())
+		writeError(w, http.StatusBadRequest, "FAILED_PRECONDITION", msg)
 	default:
-		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+		writeError(w, http.StatusInternalServerError, "INTERNAL", msg)
 	}
 }

--- a/server/gcp/firestore/aggregation.go
+++ b/server/gcp/firestore/aggregation.go
@@ -131,7 +131,7 @@ func (h *Handler) aggregationMatches(r *http.Request, base string, q *structured
 
 	node, ferr := buildFilterNode(q.Where)
 	if ferr != nil {
-		return nil, cerrors.New(cerrors.InvalidArgument, ferr.Error())
+		return nil, cerrors.New(cerrors.InvalidArgument, cerrors.Message(ferr))
 	}
 
 	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: p.tableKey(), Limit: allResults})

--- a/server/gcp/firestore/error_message_test.go
+++ b/server/gcp/firestore/error_message_test.go
@@ -1,0 +1,127 @@
+package firestore_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// TestFirestoreRunQueryInvalidFilterOmitsCodePrefix guards against the wire
+// error message for an unsupported structured-query filter operator leaking
+// cloudemu's internal cerrors code name (e.g. "InvalidArgument: ...") into the
+// message a Firestore client sees. Real Firestore never prefixes its error
+// messages with an internal error-taxonomy name.
+func TestFirestoreRunQueryInvalidFilterOmitsCodePrefix(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+
+	srv := gcpserver.New(gcpserver.Drivers{Firestore: cloudP.Firestore})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	body := `{
+		"structuredQuery": {
+			"from": [{"collectionId": "users"}],
+			"where": {
+				"fieldFilter": {
+					"field": {"fieldPath": "age"},
+					"op": "BOGUS_OP",
+					"value": {"integerValue": "1"}
+				}
+			}
+		}
+	}`
+
+	url := ts.URL + "/v1/projects/" + testProject + "/databases/(default)/documents:runQuery"
+
+	resp, err := http.Post(url, "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("POST runQuery: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	var out struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	assertNoCodePrefix(t, out.Error.Message)
+}
+
+// TestFirestoreAggregationQueryInvalidFilterOmitsCodePrefix is the
+// runAggregationQuery counterpart: aggregationMatches wraps buildFilterNode's
+// error into a NEW cerrors.Error before returning it to writeErr, so the fix
+// there is baking the filter error's already-clean Message into the wrapper's
+// Message field, not calling ferr.Error() into it.
+func TestFirestoreAggregationQueryInvalidFilterOmitsCodePrefix(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+
+	srv := gcpserver.New(gcpserver.Drivers{Firestore: cloudP.Firestore})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	body := `{
+		"structuredAggregationQuery": {
+			"structuredQuery": {
+				"from": [{"collectionId": "users"}],
+				"where": {
+					"fieldFilter": {
+						"field": {"fieldPath": "age"},
+						"op": "BOGUS_OP",
+						"value": {"integerValue": "1"}
+					}
+				}
+			},
+			"aggregations": [{"alias": "count", "count": {}}]
+		}
+	}`
+
+	url := ts.URL + "/v1/projects/" + testProject + "/databases/(default)/documents:runAggregationQuery"
+
+	resp, err := http.Post(url, "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("POST runAggregationQuery: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	var out struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	assertNoCodePrefix(t, out.Error.Message)
+}
+
+// assertNoCodePrefix fails if msg contains one of cloudemu's internal
+// canonical error-code names followed by a colon — the shape err.Error()
+// produces for a *cerrors.Error, as opposed to cerrors.Message(err).
+func assertNoCodePrefix(t *testing.T, msg string) {
+	t.Helper()
+
+	for _, prefix := range []string{"NotFound:", "AlreadyExists:", "InvalidArgument:", "FailedPrecondition:", "Internal:"} {
+		if strings.Contains(msg, prefix) {
+			t.Errorf("wire error message %q leaks internal code prefix %q", msg, prefix)
+		}
+	}
+}

--- a/server/gcp/firestore/handler.go
+++ b/server/gcp/firestore/handler.go
@@ -1044,7 +1044,7 @@ func (h *Handler) runQuery(w http.ResponseWriter, r *http.Request, base string) 
 
 	node, ferr := buildFilterNode(req.StructuredQuery.Where)
 	if ferr != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", ferr.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", cerrors.Message(ferr))
 		return
 	}
 

--- a/server/gcp/gcs/error_message_test.go
+++ b/server/gcp/gcs/error_message_test.go
@@ -1,0 +1,88 @@
+package gcs_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// TestGCSErrorMessagesOmitCodePrefix guards writeErr (server/gcp/gcs) against
+// baking cloudemu's internal cerrors code name (e.g. "notFound: ...",
+// "conflict: ...") into the wire error message an SDK caller sees. Real GCS
+// never prefixes its error messages with an internal error-taxonomy name.
+func TestGCSErrorMessagesOmitCodePrefix(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Storage: cloudP.GCS})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	t.Run("NotFound Get missing bucket", func(t *testing.T) {
+		resp, err := ts.Client().Get(ts.URL + "/storage/v1/b/does-not-exist")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("status=%d, want 404", resp.StatusCode)
+		}
+
+		assertGCSErrorHasNoCodePrefix(t, resp)
+	})
+
+	t.Run("AlreadyExists duplicate bucket create", func(t *testing.T) {
+		createURL := ts.URL + "/storage/v1/b?" + url.Values{"project": {"p1"}}.Encode()
+
+		body := strings.NewReader(`{"name": "errmsg-dupe"}`)
+		if resp, err := ts.Client().Post(createURL, "application/json", body); err != nil {
+			t.Fatal(err)
+		} else {
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("first create status=%d, want 200", resp.StatusCode)
+			}
+		}
+
+		resp, err := ts.Client().Post(createURL, "application/json", strings.NewReader(`{"name": "errmsg-dupe"}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusConflict {
+			t.Errorf("status=%d, want 409", resp.StatusCode)
+		}
+
+		assertGCSErrorHasNoCodePrefix(t, resp)
+	})
+}
+
+// assertGCSErrorHasNoCodePrefix decodes a GCS JSON error envelope and fails if
+// its message contains one of cloudemu's internal canonical error-code names
+// followed by a colon — the shape err.Error() produces for a *cerrors.Error,
+// as opposed to cerrors.Message(err).
+func assertGCSErrorHasNoCodePrefix(t *testing.T, resp *http.Response) {
+	t.Helper()
+
+	var out struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+
+	for _, prefix := range []string{"NotFound:", "AlreadyExists:", "InvalidArgument:", "FailedPrecondition:", "Internal:"} {
+		if strings.Contains(out.Error.Message, prefix) {
+			t.Errorf("wire error message %q leaks internal code prefix %q", out.Error.Message, prefix)
+		}
+	}
+}

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -1840,19 +1840,21 @@ func writeError(w http.ResponseWriter, status int, reason, msg string) {
 }
 
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "notFound", err.Error())
+		writeError(w, http.StatusNotFound, "notFound", msg)
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "conflict", err.Error())
+		writeError(w, http.StatusConflict, "conflict", msg)
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "invalid", err.Error())
+		writeError(w, http.StatusBadRequest, "invalid", msg)
 	case cerrors.IsFailedPrecondition(err):
 		// Real GCS refuses to delete a non-empty bucket with 409 conflict,
 		// not a 5xx (which would trigger client retry backoff).
-		writeError(w, http.StatusConflict, "conflict", err.Error())
+		writeError(w, http.StatusConflict, "conflict", msg)
 	default:
-		writeError(w, http.StatusInternalServerError, "internalError", err.Error())
+		writeError(w, http.StatusInternalServerError, "internalError", msg)
 	}
 }
 

--- a/server/gcp/iam/errors_sdk_test.go
+++ b/server/gcp/iam/errors_sdk_test.go
@@ -3,6 +3,7 @@ package iam_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"google.golang.org/api/googleapi"
@@ -38,6 +39,58 @@ func TestSDKGCPIAMRoleNotFoundIsTyped(t *testing.T) {
 	).Context(context.Background()).Do()
 
 	assertGoogleAPIError(t, err, 404)
+}
+
+// assertNoCodePrefix fails if msg contains one of cloudemu's internal
+// canonical error-code names followed by a colon — the shape err.Error()
+// produces for a *cerrors.Error, as opposed to cerrors.Message(err). Real IAM
+// never prefixes its error messages with an internal error-taxonomy name.
+func assertNoCodePrefix(t *testing.T, msg string) {
+	t.Helper()
+
+	for _, prefix := range []string{"NotFound:", "AlreadyExists:", "InvalidArgument:", "FailedPrecondition:", "Internal:"} {
+		if strings.Contains(msg, prefix) {
+			t.Errorf("wire error message %q leaks internal code prefix %q", msg, prefix)
+		}
+	}
+}
+
+// TestSDKGCPIAMErrorMessagesOmitCodePrefix guards writeCErr (server/gcp/iam)
+// against baking the internal cerrors code name into the wire message.
+func TestSDKGCPIAMErrorMessagesOmitCodePrefix(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	t.Run("NotFound role", func(t *testing.T) {
+		_, err := svc.Projects.Roles.Get(
+			"projects/" + testProject + "/roles/no-such-role",
+		).Context(ctx).Do()
+
+		var gErr *googleapi.Error
+		if !errors.As(err, &gErr) {
+			t.Fatalf("expected a googleapi.Error, got %T: %v", err, err)
+		}
+		assertNoCodePrefix(t, gErr.Message)
+	})
+
+	t.Run("AlreadyExists service account", func(t *testing.T) {
+		parent := "projects/" + testProject
+		if _, err := svc.Projects.ServiceAccounts.Create(parent, &iamv1.CreateServiceAccountRequest{
+			AccountId: "errmsg-dupe",
+		}).Context(ctx).Do(); err != nil {
+			t.Fatalf("first Create: %v", err)
+		}
+
+		_, err := svc.Projects.ServiceAccounts.Create(parent, &iamv1.CreateServiceAccountRequest{
+			AccountId: "errmsg-dupe",
+		}).Context(ctx).Do()
+
+		var gErr *googleapi.Error
+		if !errors.As(err, &gErr) {
+			t.Fatalf("expected a googleapi.Error, got %T: %v", err, err)
+		}
+		assertNoCodePrefix(t, gErr.Message)
+	})
 }
 
 func TestSDKGCPIAMKeyNotFoundIsTyped(t *testing.T) {

--- a/server/gcp/iam/operations.go
+++ b/server/gcp/iam/operations.go
@@ -737,14 +737,16 @@ func decodePageToken(tok string) int {
 
 // writeCErr maps canonical cloudemu errors to GCP JSON error envelopes.
 func writeCErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+		writeError(w, http.StatusNotFound, "NOT_FOUND", msg)
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "ALREADY_EXISTS", err.Error())
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", msg)
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", msg)
 	default:
-		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+		writeError(w, http.StatusInternalServerError, "INTERNAL", msg)
 	}
 }

--- a/server/gcp/monitoring/handler.go
+++ b/server/gcp/monitoring/handler.go
@@ -124,14 +124,16 @@ func writeError(w http.ResponseWriter, status int, statusCode, msg string) {
 }
 
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+		writeError(w, http.StatusNotFound, "NOT_FOUND", msg)
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "ALREADY_EXISTS", err.Error())
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", msg)
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", msg)
 	default:
-		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+		writeError(w, http.StatusInternalServerError, "INTERNAL", msg)
 	}
 }

--- a/server/gcp/monitoring/monitoring_test.go
+++ b/server/gcp/monitoring/monitoring_test.go
@@ -3,6 +3,7 @@ package monitoring_test
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -235,5 +236,72 @@ func TestMonitoringNonThresholdCondition(t *testing.T) {
 	c0, _ := conds[0].(map[string]any)
 	if _, ok := c0["conditionAbsent"]; !ok {
 		t.Errorf("conditionAbsent dropped on round-trip: %+v", c0)
+	}
+}
+
+// TestMonitoringErrorMessagesOmitCodePrefix guards writeErr (server/gcp/monitoring)
+// against baking cloudemu's internal cerrors code name (e.g. "NotFound: ...")
+// into the wire error message an SDK caller sees. Real Cloud Monitoring never
+// prefixes its error messages with an internal error-taxonomy name.
+func TestMonitoringErrorMessagesOmitCodePrefix(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Monitoring: cloudP.CloudMonitoring})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	const collURL = "/v3/projects/p1/alertPolicies"
+
+	t.Run("NotFound Get missing policy", func(t *testing.T) {
+		resp, err := ts.Client().Get(ts.URL + collURL + "/does-not-exist")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("status=%d, want 404", resp.StatusCode)
+		}
+
+		assertMonitoringErrorHasNoCodePrefix(t, resp.Body)
+	})
+
+	t.Run("NotFound Delete missing policy", func(t *testing.T) {
+		delReq, _ := http.NewRequest(http.MethodDelete, ts.URL+collURL+"/does-not-exist", http.NoBody)
+
+		resp, err := ts.Client().Do(delReq)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("status=%d, want 404", resp.StatusCode)
+		}
+
+		assertMonitoringErrorHasNoCodePrefix(t, resp.Body)
+	})
+}
+
+// assertMonitoringErrorHasNoCodePrefix decodes a Cloud Monitoring error
+// envelope and fails if its message contains one of cloudemu's internal
+// canonical error-code names followed by a colon — the shape err.Error()
+// produces for a *cerrors.Error, as opposed to cerrors.Message(err).
+func assertMonitoringErrorHasNoCodePrefix(t *testing.T, body io.Reader) {
+	t.Helper()
+
+	var out struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(body).Decode(&out); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+
+	for _, prefix := range []string{"NotFound:", "AlreadyExists:", "InvalidArgument:", "FailedPrecondition:", "Internal:"} {
+		if strings.Contains(out.Error.Message, prefix) {
+			t.Errorf("wire error message %q leaks internal code prefix %q", out.Error.Message, prefix)
+		}
 	}
 }

--- a/server/gcp/secretmanager/lifecycle_sdk_test.go
+++ b/server/gcp/secretmanager/lifecycle_sdk_test.go
@@ -196,17 +196,35 @@ func TestSDKDestroyedVersionLifecycleIs400(t *testing.T) {
 	if !errors.As(err, &gerr) || gerr.Code != 400 {
 		t.Fatalf("Destroy(destroyed): got %v, want 400 FAILED_PRECONDITION", err)
 	}
+	assertNoCodePrefix(t, gerr.Message)
 
 	// Disable a destroyed version → 400 FAILED_PRECONDITION.
 	_, err = svc.Projects.Secrets.Versions.Disable(v1.Name, &sm.DisableSecretVersionRequest{}).Context(ctx).Do()
 	if !errors.As(err, &gerr) || gerr.Code != 400 {
 		t.Fatalf("Disable(destroyed): got %v, want 400 FAILED_PRECONDITION", err)
 	}
+	assertNoCodePrefix(t, gerr.Message)
 
 	// Enable a destroyed version → 400 FAILED_PRECONDITION.
 	_, err = svc.Projects.Secrets.Versions.Enable(v1.Name, &sm.EnableSecretVersionRequest{}).Context(ctx).Do()
 	if !errors.As(err, &gerr) || gerr.Code != 400 {
 		t.Fatalf("Enable(destroyed): got %v, want 400 FAILED_PRECONDITION", err)
+	}
+	assertNoCodePrefix(t, gerr.Message)
+}
+
+// assertNoCodePrefix fails if msg contains one of cloudemu's internal
+// canonical error-code names followed by a colon — the shape err.Error()
+// produces for a *cerrors.Error, as opposed to cerrors.Message(err). Real
+// Secret Manager never prefixes its error messages with an internal
+// error-taxonomy name.
+func assertNoCodePrefix(t *testing.T, msg string) {
+	t.Helper()
+
+	for _, prefix := range []string{"NotFound:", "AlreadyExists:", "InvalidArgument:", "FailedPrecondition:", "Internal:"} {
+		if strings.Contains(msg, prefix) {
+			t.Errorf("wire error message %q leaks internal code prefix %q", msg, prefix)
+		}
 	}
 }
 

--- a/server/gcp/secretmanager/operations.go
+++ b/server/gcp/secretmanager/operations.go
@@ -458,7 +458,7 @@ func (h *Handler) mutateVersion(w http.ResponseWriter, r *http.Request, rt route
 		// shared gcprest mapping would turn it into 409, so answer 400 locally
 		// without altering that cross-cutting mapping.
 		if cerrors.IsFailedPrecondition(err) {
-			gcprest.WriteError(w, http.StatusBadRequest, "failedPrecondition", err.Error())
+			gcprest.WriteError(w, http.StatusBadRequest, "failedPrecondition", cerrors.Message(err))
 			return
 		}
 

--- a/server/gcp/vertexai/endpoints.go
+++ b/server/gcp/vertexai/endpoints.go
@@ -247,7 +247,7 @@ func (h *Handler) predict(w http.ResponseWriter, r *http.Request, endpoint strin
 		// has no deployed models; the shared codec maps FailedPrecondition to 409,
 		// so surface the 400 here to match the wire contract.
 		if cerrors.IsFailedPrecondition(err) {
-			writeError(w, http.StatusBadRequest, "FAILED_PRECONDITION", err.Error())
+			writeError(w, http.StatusBadRequest, "FAILED_PRECONDITION", cerrors.Message(err))
 
 			return
 		}

--- a/server/gcp/vertexai/error_message_test.go
+++ b/server/gcp/vertexai/error_message_test.go
@@ -1,0 +1,56 @@
+package vertexai_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestVertexAIErrorMessagesOmitCodePrefix guards the FAILED_PRECONDITION path
+// in server/gcp/vertexai (Predict on an endpoint with no deployed models)
+// against baking cloudemu's internal cerrors code name (e.g.
+// "FailedPrecondition: ...") into the wire error message an SDK caller sees.
+// Real Vertex AI never prefixes its error messages with an internal
+// error-taxonomy name.
+func TestVertexAIErrorMessagesOmitCodePrefix(t *testing.T) {
+	url := newServer(t)
+
+	op := do(t, http.MethodPost, url+base+"/endpoints", map[string]any{"displayName": "ep"})
+	epName := op["response"].(map[string]any)["name"].(string)
+
+	reqBody, err := json.Marshal(map[string]any{
+		"instances": []any{map[string]any{"x": 1}},
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, url+"/v1/"+epName+":predict", bytes.NewReader(reqBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var out struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &out), "body=%s", raw)
+
+	for _, prefix := range []string{"NotFound:", "AlreadyExists:", "InvalidArgument:", "FailedPrecondition:", "Internal:"} {
+		if strings.Contains(out.Error.Message, prefix) {
+			t.Errorf("wire error message %q leaks internal code prefix %q", out.Error.Message, prefix)
+		}
+	}
+}


### PR DESCRIPTION
## The bug class

A wire handler's error-dispatch function (`writeErr`/`writeCErr`) built the client-facing `error.message` from `err.Error()`. For a `*cerrors.Error`, `Error()` prepends the internal code-taxonomy name — `"NotFound: ..."`, `"AlreadyExists: ..."`, `"InvalidArgument: ..."`, `"FailedPrecondition: ..."`. Real GCP never prefixes its error messages this way. The fix (already established for `gcprest`, GKE, Cloud Run, and Pub/Sub) is `cerrors.Message(err)`, which reads the error's `Message` field directly via `errors.As` and falls back to `err.Error()` for non-cloudemu errors.

## Services fixed

- `server/gcp/cloudfunctions` — `writeErr` (NOT_FOUND/ALREADY_EXISTS/INVALID_ARGUMENT/INTERNAL)
- `server/gcp/firestore` — `runQuery`'s and `runAggregationQuery`'s filter-validation error path (`buildFilterNode` returns a `*cerrors.Error`; `runAggregationQuery` additionally re-wraps it into a new `cerrors.Error`, which was baking the prefix into that wrapper's own `Message` field)
- `server/gcp/iam` — `writeCErr`
- `server/gcp/cloudasset` — `writeCErr`
- `server/gcp/monitoring` — `writeErr`
- `server/gcp/cloudsql` — `writeErr`
- `server/gcp/alloydb` — `writeCErr`
- `server/gcp/gcs` — `writeErr`
- `server/gcp/secretmanager` — the `FAILED_PRECONDITION` branch of the version lifecycle verb handler (enable/disable/destroy)
- `server/gcp/vertexai` — the `FAILED_PRECONDITION` branch of the Predict handler

Already fixed prior to this PR (verified, left untouched): the shared `gcprest` codec, GKE, Cloud Run, Pub/Sub.

## Reviewed but correctly left alone

- Every `err.Error()` feeding a JSON-decode failure message (`json.NewDecoder(...).Decode` errors are plain Go errors, never `*cerrors.Error`)
- `firestore`'s `parseFirestorePath`/`splitDocumentName` parse errors (plain `fmt.Errorf`/sentinel errors, never cerrors)
- `iam`'s role-props JSON marshal/unmarshal encoding errors (plain encoding errors)
- `cloudasset`'s intentional `"REASON_CODE: message"` convention in its own `writeError` helper — a separate, pre-existing, documented, and already-tested design (substring-matchable reason code) distinct from the internal cerrors taxonomy leak
- Driver-level `BatchSendFailEntry.Message`/`InvokeResponse.Body` fields in `providers/gcp/pubsub`, `providers/gcp/cloudrun`, `providers/gcp/cloudfunctions` — these carry the registered handler's own error (or aren't reachable from any GCP wire route at all), not an internal cloudemu error

~150 `err.Error()` occurrences were reviewed across `server/gcp/` and `providers/gcp/`; 11 were genuine leaks (10 services, one with two independent sites), the rest were confirmed safe by tracing the concrete error source.

## Black-box verification (`cloudemu serve -gcp-port 14830 -providers=gcp`)

| Service | Request | Before (would be) | After |
|---|---|---|---|
| GCS | `GET /storage/v1/b/nope` | `"NotFound: bucket nope not found"` | `"bucket nope not found"` |
| IAM | `GET /v1/projects/demo/roles/no-such-role` | `"NotFound: role ..."` | `"role \"no-such-role\" not found"` |
| Cloud SQL | `GET /v1/projects/demo/instances/no-such-instance` | `"NotFound: ..."` | `"Cloud SQL instance \"no-such-instance\" not found"` |
| Monitoring | `GET /v3/projects/demo/alertPolicies/no-such-policy` | `"NotFound: ..."` | `"alertPolicy no-such-policy not found"` |
| AlloyDB | `GET .../clusters/no-such-cluster` | `"NotFound: ..."` | `"cluster \"no-such-cluster\" not found in \"us-central1\""` |
| Secret Manager | `GET /v1/projects/demo/secrets/no-such-secret` | `"NotFound: ..."` | `"secret \"no-such-secret\" not found"` |
| Firestore | invalid `runQuery` filter op | `"InvalidArgument: ..."` | `"IN / NOT_IN / ARRAY_CONTAINS_ANY require a non-empty array value"` |

## Tests

Added a focused regression test per fixed service asserting the wire error message carries no `NotFound:`/`AlreadyExists:`/`InvalidArgument:`/`FailedPrecondition:`/`Internal:` prefix — each verified to fail against the pre-fix code and pass after.

## Gates

- `go build ./...` clean
- `go test ./server/gcp/... ./providers/gcp/... -race -count=1` all green
- `gofmt -l` clean on all changed files
- `golangci-lint run --new-from-rev=origin/development ./server/gcp/...` 0 new issues
- `go generate ./...` — no `docs/coverage` diff
- `go mod tidy` no-op
