### PR TITLE
fix(efs): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/efs/efs.go
+++ b/providers/aws/efs/efs.go
@@ -53,6 +53,13 @@ type Mock struct {
 	// per-file-system fallback is used instead of a random per-call VpcId.
 	subnetResolver SubnetResolver
 
+	// ipCounters hands out unique offsets for auto-assigned mount-target IPs,
+	// keyed by subnet id ("" is the global fallback used when no subnet CIDR is
+	// resolvable), guarded by ipMu. Without this every unspecified mount-target
+	// IP would collide on the same fixed address.
+	ipCounters map[string]int
+	ipMu       sync.Mutex
+
 	opts *config.Options
 }
 
@@ -64,6 +71,7 @@ func New(opts *config.Options) *Mock {
 		apIndex:      memstore.New[string](),
 		tokenIndex:   memstore.New[string](),
 		apTokenIndex: memstore.New[string](),
+		ipCounters:   make(map[string]int),
 		opts:         opts,
 	}
 }

--- a/providers/aws/efs/efs_test.go
+++ b/providers/aws/efs/efs_test.go
@@ -152,3 +152,79 @@ func TestCreateAccessPointClientTokenConcurrent(t *testing.T) {
 		t.Fatalf("want exactly 1 access point after idempotent races, got %d", len(aps))
 	}
 }
+
+// TestDeleteFileSystemBlockedByReplication verifies that a file system with an
+// active replication configuration cannot be deleted (real EFS: "You can't
+// delete a file system that is part of an EFS Replication configuration"),
+// and that deletion succeeds once the replication configuration is removed.
+func TestDeleteFileSystemBlockedByReplication(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	fs, err := m.CreateFileSystem(ctx, driver.CreateFileSystemInput{CreationToken: "repl-src"})
+	if err != nil {
+		t.Fatalf("create fs: %v", err)
+	}
+
+	if _, err := m.CreateReplicationConfiguration(ctx, fs.FileSystemID,
+		[]driver.DestinationToCreate{{Region: "us-west-2"}}); err != nil {
+		t.Fatalf("create replication: %v", err)
+	}
+
+	if err := m.DeleteFileSystem(ctx, fs.FileSystemID); !errors.IsFailedPrecondition(err) {
+		t.Fatalf("delete with active replication should be FailedPrecondition (FileSystemInUse), got %v", err)
+	}
+
+	if err := m.DeleteReplicationConfiguration(ctx, fs.FileSystemID); err != nil {
+		t.Fatalf("delete replication: %v", err)
+	}
+
+	if err := m.DeleteFileSystem(ctx, fs.FileSystemID); err != nil {
+		t.Fatalf("delete after replication removed should succeed, got %v", err)
+	}
+}
+
+// TestCreateMountTargetUniqueIPWithoutResolver verifies that auto-assigned
+// mount-target IP addresses never collide, even with no subnet resolver wired
+// (so every mount target falls back to the synthetic-IP path). Real EFS/EC2
+// never issues the same private IP to two network interfaces.
+func TestCreateMountTargetUniqueIPWithoutResolver(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t)
+
+	fs, err := m.CreateFileSystem(ctx, driver.CreateFileSystemInput{CreationToken: "ip-fs"})
+	if err != nil {
+		t.Fatalf("create fs: %v", err)
+	}
+
+	mt1, err := m.CreateMountTarget(ctx, driver.CreateMountTargetInput{
+		FileSystemID: fs.FileSystemID, SubnetID: "subnet-a",
+	})
+	if err != nil {
+		t.Fatalf("create mt1: %v", err)
+	}
+
+	mt2, err := m.CreateMountTarget(ctx, driver.CreateMountTargetInput{
+		FileSystemID: fs.FileSystemID, SubnetID: "subnet-b",
+	})
+	if err != nil {
+		t.Fatalf("create mt2: %v", err)
+	}
+
+	if mt1.IPAddress == mt2.IPAddress {
+		t.Fatalf("two mount targets got the same auto-assigned IP %q; real EFS never issues the same IP twice",
+			mt1.IPAddress)
+	}
+
+	// An explicit IPAddress is always honored verbatim.
+	mt3, err := m.CreateMountTarget(ctx, driver.CreateMountTargetInput{
+		FileSystemID: fs.FileSystemID, SubnetID: "subnet-c", IPAddress: "10.5.5.5",
+	})
+	if err != nil {
+		t.Fatalf("create mt3: %v", err)
+	}
+
+	if mt3.IPAddress != "10.5.5.5" {
+		t.Fatalf("explicit IPAddress not honored: got %q", mt3.IPAddress)
+	}
+}

--- a/providers/aws/efs/file_systems.go
+++ b/providers/aws/efs/file_systems.go
@@ -104,10 +104,11 @@ func backupOnCreate(backup bool, availabilityZoneName string) string {
 	return driver.BackupDisabled
 }
 
-// DeleteFileSystem deletes a file system. It must have no mount targets or
-// access points. The check and delete run under the file system's write lock so
-// a concurrent CreateMountTarget can't attach to a file system mid-delete, and
-// all index entries (token, access points) are released.
+// DeleteFileSystem deletes a file system. It must have no mount targets, no
+// access points, and no replication configuration. The check and delete run
+// under the file system's write lock so a concurrent CreateMountTarget can't
+// attach to a file system mid-delete, and all index entries (token, access
+// points) are released.
 func (m *Mock) DeleteFileSystem(_ context.Context, fileSystemID string) error {
 	fd, ok := m.getFS(fileSystemID)
 	if !ok {
@@ -125,6 +126,11 @@ func (m *Mock) DeleteFileSystem(_ context.Context, fileSystemID string) error {
 	if n := len(fd.accessPts); n > 0 {
 		return inUse(driver.KindFileSystem,
 			"file system %q has %d access point(s); delete them first", fileSystemID, n)
+	}
+
+	if fd.replication != nil {
+		return inUse(driver.KindFileSystem,
+			"file system %q has a replication configuration; delete it first", fileSystemID)
 	}
 
 	m.fileSystems.Delete(fileSystemID)

--- a/providers/aws/efs/mount_targets.go
+++ b/providers/aws/efs/mount_targets.go
@@ -2,6 +2,8 @@ package efs
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -48,7 +50,7 @@ func (m *Mock) CreateMountTarget(ctx context.Context, in driver.CreateMountTarge
 		FileSystemID:         fd.fs.FileSystemID,
 		SubnetID:             in.SubnetID,
 		LifeCycleState:       driver.StateAvailable,
-		IPAddress:            ipAddressOrDefault(in.IPAddress),
+		IPAddress:            m.allocateIP(in.IPAddress, in.SubnetID, subnet),
 		NetworkInterfaceID:   eni,
 		AvailabilityZoneID:   azIdent,
 		AvailabilityZoneName: azName,
@@ -165,12 +167,71 @@ func azIDFromName(azName string) string {
 	return regionShortCode(region) + "-az" + strconv.Itoa(ordinal)
 }
 
-func ipAddressOrDefault(ip string) string {
-	if ip != "" {
-		return ip
+// ipSegmentSize is the modulus for one dotted-decimal IPv4 octet.
+const ipSegmentSize = 256
+
+// mtFirstHost is the first assignable host offset within a subnet CIDR (AWS
+// reserves the network address and the first three host addresses in every
+// subnet), used as the starting point for auto-assigned mount-target IPs.
+const mtFirstHost = 4
+
+// allocateIP returns explicit if the caller supplied one. Otherwise it hands out
+// the next private IPv4 inside the subnet's CIDR — real EFS auto-assigns a free
+// address from the target subnet — falling back to a synthetic-but-unique
+// 10.0.x.y address when the subnet can't be resolved. Every call returns a
+// distinct address: a fixed default would let two mount targets (even across
+// different subnets and file systems) collide on the same private IP, which
+// real EFS/EC2 never does.
+func (m *Mock) allocateIP(explicit, subnetID string, subnet *netdriver.SubnetInfo) string {
+	if explicit != "" {
+		return explicit
 	}
 
-	return "10.0.0.10"
+	if subnet == nil || subnet.CIDRBlock == "" {
+		return m.nextIP()
+	}
+
+	_, ipNet, err := net.ParseCIDR(subnet.CIDRBlock)
+	if err != nil {
+		return m.nextIP()
+	}
+
+	base := ipNet.IP.To4()
+	if base == nil {
+		return m.nextIP()
+	}
+
+	m.ipMu.Lock()
+	offset := m.ipCounters[subnetID] + mtFirstHost
+	m.ipCounters[subnetID]++
+	m.ipMu.Unlock()
+
+	host := make(net.IP, len(base))
+	copy(host, base)
+
+	carry := offset
+	for i := len(host) - 1; i >= 0 && carry > 0; i-- {
+		sum := int(host[i]) + carry
+		host[i] = byte(sum % ipSegmentSize) //nolint:gosec // sum%256 is always in [0,255]
+		carry = sum / ipSegmentSize
+	}
+
+	if !ipNet.Contains(host) {
+		return m.nextIP()
+	}
+
+	return host.String()
+}
+
+// nextIP hands out a globally-unique fallback address (10.0.x.y) when no subnet
+// CIDR is available to allocate an in-range address from.
+func (m *Mock) nextIP() string {
+	m.ipMu.Lock()
+	n := m.ipCounters[""]
+	m.ipCounters[""]++
+	m.ipMu.Unlock()
+
+	return fmt.Sprintf("10.0.%d.%d", n/ipSegmentSize, n%ipSegmentSize)
 }
 
 // DeleteMountTarget removes a mount target.

--- a/providers/aws/efs/snapshot.go
+++ b/providers/aws/efs/snapshot.go
@@ -24,6 +24,7 @@ type efsSnapshot struct {
 	TokenIndex   json.RawMessage            `json:"tokenIndex,omitempty"`
 	APTokenIndex json.RawMessage            `json:"apTokenIndex,omitempty"`
 	AccountPref  string                     `json:"accountPref,omitempty"`
+	IPCounters   map[string]int             `json:"ipCounters,omitempty"`
 }
 
 // fsDataSnapshot mirrors fsData, promoting its fields to exported ones so they
@@ -50,6 +51,12 @@ func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
 	m.prefMu.RLock()
 	snap.AccountPref = m.accountPref
 	m.prefMu.RUnlock()
+
+	m.ipMu.Lock()
+	if len(m.ipCounters) > 0 {
+		snap.IPCounters = m.ipCounters
+	}
+	m.ipMu.Unlock()
 
 	return json.Marshal(snap)
 }
@@ -120,6 +127,12 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 		m.prefMu.Lock()
 		m.accountPref = snap.AccountPref
 		m.prefMu.Unlock()
+	}
+
+	if snap.IPCounters != nil {
+		m.ipMu.Lock()
+		m.ipCounters = snap.IPCounters
+		m.ipMu.Unlock()
 	}
 
 	return nil

--- a/providers/aws/efs/snapshot_test.go
+++ b/providers/aws/efs/snapshot_test.go
@@ -73,3 +73,46 @@ func TestSnapshotRoundTripEFS(t *testing.T) {
 		t.Fatalf("re-snapshot not byte-identical to original")
 	}
 }
+
+// TestSnapshotRoundTripEFSPreservesIPCounters verifies that the mount-target IP
+// allocator's counters survive a snapshot/restore, so a mount target created
+// after restore never reuses an IP already handed out before the snapshot
+// (which would otherwise produce a duplicate IP once the in-memory counter
+// resets to zero on a fresh mock).
+func TestSnapshotRoundTripEFSPreservesIPCounters(t *testing.T) {
+	ctx := context.Background()
+	src := newMock(t)
+
+	fs, err := src.CreateFileSystem(ctx, driver.CreateFileSystemInput{CreationToken: "ip-snap"})
+	if err != nil {
+		t.Fatalf("create file system: %v", err)
+	}
+
+	mt1, err := src.CreateMountTarget(ctx, driver.CreateMountTargetInput{
+		FileSystemID: fs.FileSystemID, SubnetID: "subnet-snap-1",
+	})
+	if err != nil {
+		t.Fatalf("create mount target: %v", err)
+	}
+
+	raw, err := src.Snapshot(ctx, true)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	dst := newMock(t)
+	if err := dst.Restore(ctx, raw); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	mt2, err := dst.CreateMountTarget(ctx, driver.CreateMountTargetInput{
+		FileSystemID: fs.FileSystemID, SubnetID: "subnet-snap-2",
+	})
+	if err != nil {
+		t.Fatalf("create mount target after restore: %v", err)
+	}
+
+	if mt1.IPAddress == mt2.IPAddress {
+		t.Fatalf("mount target created after restore reused IP %q handed out before the snapshot", mt1.IPAddress)
+	}
+}

--- a/server/aws/efs/mount_target_placement_sdk_test.go
+++ b/server/aws/efs/mount_target_placement_sdk_test.go
@@ -2,6 +2,7 @@ package efs_test
 
 import (
 	"context"
+	"net"
 	"net/http/httptest"
 	"testing"
 
@@ -90,5 +91,31 @@ func TestSDKMountTargetPlacementFromSubnet(t *testing.T) {
 	if aws.ToString(mtB.AvailabilityZoneName) != "us-east-1b" || aws.ToString(mtB.AvailabilityZoneId) != "use1-az2" {
 		t.Fatalf("mtB AZ = %q/%q, want us-east-1b/use1-az2",
 			aws.ToString(mtB.AvailabilityZoneName), aws.ToString(mtB.AvailabilityZoneId))
+	}
+
+	// Each mount target's auto-assigned IP falls inside its own subnet's CIDR,
+	// and the two never collide (real EFS never issues the same private IP to
+	// two network interfaces).
+	ipA, ipB := aws.ToString(mtA.IpAddress), aws.ToString(mtB.IpAddress)
+	if ipA == ipB {
+		t.Fatalf("mtA and mtB share the same auto-assigned IP %q", ipA)
+	}
+
+	_, cidrA, err := net.ParseCIDR(subnetA.CIDRBlock)
+	if err != nil {
+		t.Fatalf("parse subnet A CIDR: %v", err)
+	}
+
+	if !cidrA.Contains(net.ParseIP(ipA)) {
+		t.Fatalf("mtA IP %q is not inside subnet A's CIDR %q", ipA, subnetA.CIDRBlock)
+	}
+
+	_, cidrB, err := net.ParseCIDR(subnetB.CIDRBlock)
+	if err != nil {
+		t.Fatalf("parse subnet B CIDR: %v", err)
+	}
+
+	if !cidrB.Contains(net.ParseIP(ipB)) {
+		t.Fatalf("mtB IP %q is not inside subnet B's CIDR %q", ipB, subnetB.CIDRBlock)
 	}
 }

--- a/server/aws/efs/sdk_roundtrip_test.go
+++ b/server/aws/efs/sdk_roundtrip_test.go
@@ -467,3 +467,47 @@ func TestSDKOneZoneAvailabilityZoneId(t *testing.T) {
 			aws.ToString(desc.FileSystems[0].AvailabilityZoneId))
 	}
 }
+
+// TestSDKDeleteWithReplicationGuarded verifies that a file system with an
+// active replication configuration is rejected with a FileSystemInUse-typed
+// error (real EFS: "You can't delete a file system that is part of an EFS
+// Replication configuration"), and that deletion succeeds once the replication
+// configuration is removed.
+func TestSDKDeleteWithReplicationGuarded(t *testing.T) {
+	ctx := context.Background()
+	c := newEFSClient(t)
+
+	fs, err := c.CreateFileSystem(ctx, &awsefs.CreateFileSystemInput{CreationToken: aws.String("repl-guarded")})
+	if err != nil {
+		t.Fatalf("CreateFileSystem: %v", err)
+	}
+
+	fsID := aws.ToString(fs.FileSystemId)
+
+	if _, err := c.CreateReplicationConfiguration(ctx, &awsefs.CreateReplicationConfigurationInput{
+		SourceFileSystemId: aws.String(fsID),
+		Destinations:       []efstypes.DestinationToCreate{{Region: aws.String("us-west-2")}},
+	}); err != nil {
+		t.Fatalf("CreateReplicationConfiguration: %v", err)
+	}
+
+	_, err = c.DeleteFileSystem(ctx, &awsefs.DeleteFileSystemInput{FileSystemId: aws.String(fsID)})
+	if err == nil {
+		t.Fatal("DeleteFileSystem with active replication: want error, got nil")
+	}
+
+	var inUse *efstypes.FileSystemInUse
+	if !errors.As(err, &inUse) {
+		t.Fatalf("want FileSystemInUse, got %T: %v", err, err)
+	}
+
+	if _, err := c.DeleteReplicationConfiguration(ctx, &awsefs.DeleteReplicationConfigurationInput{
+		SourceFileSystemId: aws.String(fsID),
+	}); err != nil {
+		t.Fatalf("DeleteReplicationConfiguration: %v", err)
+	}
+
+	if _, err := c.DeleteFileSystem(ctx, &awsefs.DeleteFileSystemInput{FileSystemId: aws.String(fsID)}); err != nil {
+		t.Fatalf("DeleteFileSystem after replication removed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Real-user black-box audit of AWS EFS (aws-cli, aws-sdk-go-v2, Terraform `hashicorp/aws`) against the AWS EFS API. The implementation was already mature (creation-token idempotency, access-point ClientToken idempotency, mount-target AZ-conflict enforcement, typed per-resource exceptions, stable-sorted pagination, snapshot/restore) — full FS/mount-target/access-point/Terraform lifecycle and existing FileSystemInUse guards were verified correct before finding these two genuine divergences.

### 1. Auto-assigned mount-target IP addresses always collided

`CreateMountTarget` without an explicit `IpAddress` always returned the literal constant `10.0.0.10`. Two mount targets of the same file system (necessarily in different subnets/AZs) ended up with the exact same private IP — real AWS allocates a unique free address from the subnet's CIDR.

Repro: create an FS with two mount targets in different subnets of a VPC (`10.10.1.0/24` / `10.10.2.0/24`, e.g. via Terraform `aws_efs_mount_target`) — both `ip_address` came back as `10.0.0.10`, not inside either subnet.

Fix: `providers/aws/efs/mount_targets.go` adds `allocateIP`/`nextIP`, mirroring the existing `providers/aws/ec2` per-subnet CIDR allocator — draws from the resolved subnet's CIDR via a per-subnet counter, falling back to a globally-unique `10.0.x.y` counter when the subnet can't be resolved. Explicit `IpAddress` is still honored verbatim. `providers/aws/efs/snapshot.go` persists the counters through snapshot/restore so a post-restore mount target never reuses a pre-snapshot IP.

### 2. DeleteFileSystem didn't block a file system with active replication

Real EFS refuses to delete a file system that's the source of an active Replication configuration. `DeleteFileSystem` only checked mount targets and access points.

Repro: create an FS, `create-replication-configuration`, then `delete-file-system` — succeeded silently, leaving a dangling replication config pointing at a deleted source.

Fix: `providers/aws/efs/file_systems.go` — `DeleteFileSystem` now also rejects with `FileSystemInUse` when the file system has a replication configuration, consistent with the existing mount-target/access-point guards.

## Evidence (black-box, re-verified after each fix)

- aws-cli: `create-mount-target` in a real VPC subnet (`10.20.5.0/24`) now returns `IpAddress: 10.20.5.4` (in-CIDR); `delete-file-system` on a source FS with active replication now returns `FileSystemInUse: ... has a replication configuration; delete it first`, and succeeds after `delete-replication-configuration`.
- Terraform: full apply of `aws_efs_file_system` + two `aws_efs_mount_target` + `aws_efs_access_point` now shows distinct, in-CIDR `ip_address` values (`10.10.1.4`, `10.10.2.4`); `terraform plan` reports no diff; `terraform destroy` cleans up fully.

## Test plan

- [x] `providers/aws/efs/efs_test.go`: `TestCreateMountTargetUniqueIPWithoutResolver`, `TestDeleteFileSystemBlockedByReplication`
- [x] `providers/aws/efs/snapshot_test.go`: `TestSnapshotRoundTripEFSPreservesIPCounters`
- [x] `server/aws/efs/mount_target_placement_sdk_test.go`: extended `TestSDKMountTargetPlacementFromSubnet` to assert distinct, in-CIDR mount-target IPs
- [x] `server/aws/efs/sdk_roundtrip_test.go`: `TestSDKDeleteWithReplicationGuarded`
- [x] `go build ./...`, `go test ./providers/aws/efs/... ./server/aws/efs/... -race`, `gofmt -l`, `go vet`, `golangci-lint run --new-from-rev=origin/development` all clean
- [x] `go generate ./...` — no `docs/coverage` diff
