### PR TITLE
fix(azure-eventgrid): real-user e2e divergences

### DIFF
--- a/providers/azure/eventgrid/eventgrid.go
+++ b/providers/azure/eventgrid/eventgrid.go
@@ -707,6 +707,27 @@ func (m *Mock) UpdateEventBus(_ context.Context, cfg driver.EventBusConfig) (*dr
 	return &result, nil
 }
 
+// SetEventBusTags replaces a topic's tag set outright, including to empty.
+// It exists because EventBusConfig.Tags cannot carry the distinction the
+// wire layer needs for Topics.Update's resource-level tag PATCH: a nil map
+// there means both "no tags" and "caller supplied {}", so UpdateEventBus's
+// cfg.Tags != nil gate would silently no-op an explicit wipe to empty. This
+// is an Azure-specific capability (server/azure/eventgrid type-asserts for
+// it), not part of the shared driver.EventBus contract used by AWS/GCP.
+func (m *Mock) SetEventBusTags(_ context.Context, name string, tags map[string]string) (*driver.EventBusInfo, error) {
+	bd, ok := m.buses.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", name)
+	}
+
+	bd.info.Tags = maps.Clone(tags)
+	m.buses.Set(name, bd)
+
+	result := bd.info
+
+	return &result, nil
+}
+
 // MatchedRules returns the subscriptions on the event's own topic that match
 // it (exported for testing). Scoped to event.EventBus so a rule on one topic
 // never counts as matched for an event published to a different topic.

--- a/server/azure/eventgrid/domains.go
+++ b/server/azure/eventgrid/domains.go
@@ -238,10 +238,12 @@ type domainUpdateJSON struct {
 	} `json:"properties,omitempty"`
 }
 
-// updateDomain maps Domains.Update (PATCH) onto the wire-owned record: it merges
-// the supplied tags onto the existing tags and applies the mutable
-// publicNetworkAccess, preserving anything the caller omitted, and returns the
-// updated domain (200). 404 when the domain does not exist, before any write.
+// updateDomain maps Domains.Update (PATCH) onto the wire-owned record: a
+// resource-level tag PATCH replaces the tag set wholesale (matching real
+// Azure and this codebase's convention elsewhere), a caller who omits tags
+// entirely leaves the existing set untouched, and the mutable
+// publicNetworkAccess is applied. Returns the updated domain (200). 404 when
+// the domain does not exist, before any write.
 func (h *Handler) updateDomain(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body domainUpdateJSON
 	if !azurearm.DecodeJSON(w, r, &body) {
@@ -260,9 +262,7 @@ func (h *Handler) updateDomain(w http.ResponseWriter, r *http.Request, rp *azure
 		return
 	}
 
-	if body.Tags != nil {
-		rec.tags = mergeTags(rec.tags, tagsFromPtr(body.Tags))
-	}
+	rec.tags = replaceTagsIfPresent(rec.tags, body.Tags)
 
 	if body.Properties != nil && body.Properties.PublicNetworkAccess != "" {
 		rec.publicNetworkAccess = body.Properties.PublicNetworkAccess

--- a/server/azure/eventgrid/event_subscriptions.go
+++ b/server/azure/eventgrid/event_subscriptions.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 )
@@ -259,10 +260,13 @@ func (h *Handler) getEventSubscription(w http.ResponseWriter, r *http.Request, r
 	azurearm.WriteJSON(w, http.StatusOK, toEventSubscriptionJSON(rp, rule))
 }
 
-// deleteEventSubscription removes the subscription. The SDK's BeginDelete LRO
-// completes on a 200 first response.
+// deleteEventSubscription removes the subscription. Delete is idempotent,
+// matching real ARM and every other delete path in this package: deleting an
+// already-absent subscription (or one whose topic is already gone) still
+// succeeds rather than surfacing the driver's NotFound. The SDK's BeginDelete
+// LRO completes on a 200 first response.
 func (h *Handler) deleteEventSubscription(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	if err := h.bus.DeleteRule(r.Context(), rp.ResourceName, rp.SubResourceName); err != nil {
+	if err := h.bus.DeleteRule(r.Context(), rp.ResourceName, rp.SubResourceName); err != nil && !cerrors.IsNotFound(err) {
 		azurearm.WriteCErr(w, err)
 		return
 	}

--- a/server/azure/eventgrid/handler.go
+++ b/server/azure/eventgrid/handler.go
@@ -16,7 +16,7 @@
 // Coverage:
 //
 //	PUT/GET/DELETE .../topics/{t}                           — Topics CRUD (LRO, completes inline)
-//	PATCH          .../topics/{t}                           — Topics.Update (merge tags + mutable properties)
+//	PATCH          .../topics/{t}                           — Topics.Update (replace tags + mutable properties)
 //	GET            .../topics                               — Topics.ListBySubscription / ListByResourceGroup
 //	POST           .../topics/{t}/listKeys                  — Topics.ListSharedAccessKeys
 //	POST           .../topics/{t}/regenerateKey            — Topics.RegenerateKey
@@ -55,6 +55,11 @@ type Handler struct {
 	// Azure eventgrid.Mock provides it; nil for backends that don't). It isolates
 	// system-topic subscription rules from user-facing custom topics.
 	sysDelivery systemTopicDelivery
+	// tagWriter is the optional tag-write capability of bus (the Azure
+	// eventgrid.Mock provides it; nil for backends that don't). updateTopic uses
+	// it to apply an explicit "tags:{}" wipe that UpdateEventBus's cfg.Tags
+	// nil-gate cannot distinguish from "tags omitted."
+	tagWriter eventBusTagWriter
 
 	mu           sync.RWMutex
 	systemTopics map[string]*systemTopicRecord
@@ -93,6 +98,10 @@ func New(b ebdriver.EventBus) *Handler {
 
 	if sd, ok := b.(systemTopicDelivery); ok {
 		h.sysDelivery = sd
+	}
+
+	if tw, ok := b.(eventBusTagWriter); ok {
+		h.tagWriter = tw
 	}
 
 	return h

--- a/server/azure/eventgrid/operations.go
+++ b/server/azure/eventgrid/operations.go
@@ -3,6 +3,7 @@ package eventgrid
 import (
 	"net/http"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	"github.com/stackshy/cloudemu/v2/services/scope"
@@ -84,9 +85,11 @@ type topicUpdateJSON struct {
 	} `json:"properties,omitempty"`
 }
 
-// updateTopic maps Topics.Update (PATCH) onto UpdateEventBus: it merges the
-// supplied tags onto the topic's existing tags and applies the mutable
-// publicNetworkAccess, returning the updated topic (200).
+// updateTopic maps Topics.Update (PATCH) onto UpdateEventBus: a resource-level
+// tag PATCH replaces the tag set wholesale (matching real Azure and every
+// other resource's Update in this codebase — e.g. cosmosaccount, images), a
+// caller who omits tags entirely leaves the existing set untouched, and the
+// mutable publicNetworkAccess is applied. Returns the updated topic (200).
 func (h *Handler) updateTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body topicUpdateJSON
 	if !azurearm.DecodeJSON(w, r, &body) {
@@ -101,7 +104,7 @@ func (h *Handler) updateTopic(w http.ResponseWriter, r *http.Request, rp *azurea
 
 	cfg := ebdriver.EventBusConfig{
 		Name:                rp.ResourceName,
-		Tags:                mergeTags(current.Tags, tagsFromPtr(body.Tags)),
+		Tags:                replaceTagsIfPresent(current.Tags, body.Tags),
 		PublicNetworkAccess: updatePublicNetworkAccess(&body),
 	}
 
@@ -125,23 +128,18 @@ func updatePublicNetworkAccess(body *topicUpdateJSON) string {
 	return body.Properties.PublicNetworkAccess
 }
 
-// mergeTags overlays patch onto base, returning the merged set. A nil result
-// (both empty) leaves UpdateEventBus's existing tags untouched.
-func mergeTags(base, patch map[string]string) map[string]string {
-	if len(base) == 0 && len(patch) == 0 {
-		return nil
+// replaceTagsIfPresent implements Azure's resource-level tag PATCH semantics:
+// when the caller's body includes a tags key at all (even an empty object),
+// the new set REPLACES current wholesale — a tag omitted from the body is
+// dropped, not preserved. When the caller omits tags entirely (nil), current
+// is left untouched. This matches the convention already established
+// elsewhere in this codebase (cosmosaccount, images, storageaccount, ...).
+func replaceTagsIfPresent(current map[string]string, patch map[string]*string) map[string]string {
+	if patch == nil {
+		return current
 	}
 
-	out := make(map[string]string, len(base)+len(patch))
-	for k, v := range base {
-		out[k] = v
-	}
-
-	for k, v := range patch {
-		out[k] = v
-	}
-
-	return out
+	return tagsFromPtr(patch)
 }
 
 func (h *Handler) getTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
@@ -154,11 +152,15 @@ func (h *Handler) getTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.
 	azurearm.WriteJSON(w, http.StatusOK, toTopicJSON(rp, info))
 }
 
-// deleteTopic removes the topic. Topics.Delete is an LRO in the SDK whose
-// polling accepts 202/204; returning 204 with no body completes the poller on
-// the first response.
+// deleteTopic removes the topic. Delete is idempotent, matching real ARM and
+// every other delete path in this package (deleteDomain, deleteSystemTopic,
+// deleteDomainTopic, deleteScopedEventSubscription,
+// deleteSystemTopicSubscription): deleting an already-absent topic still
+// succeeds rather than surfacing the driver's NotFound. Topics.Delete is an
+// LRO in the SDK whose polling accepts 202/204; returning 204 with no body
+// completes the poller on the first response.
 func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	if err := h.bus.DeleteEventBus(r.Context(), rp.ResourceName); err != nil {
+	if err := h.bus.DeleteEventBus(r.Context(), rp.ResourceName); err != nil && !cerrors.IsNotFound(err) {
 		azurearm.WriteCErr(w, err)
 		return
 	}

--- a/server/azure/eventgrid/operations.go
+++ b/server/azure/eventgrid/operations.go
@@ -85,26 +85,27 @@ type topicUpdateJSON struct {
 	} `json:"properties,omitempty"`
 }
 
-// updateTopic maps Topics.Update (PATCH) onto UpdateEventBus: a resource-level
-// tag PATCH replaces the tag set wholesale (matching real Azure and every
-// other resource's Update in this codebase — e.g. cosmosaccount, images), a
-// caller who omits tags entirely leaves the existing set untouched, and the
-// mutable publicNetworkAccess is applied. Returns the updated topic (200).
+// updateTopic maps Topics.Update (PATCH) onto UpdateEventBus for the mutable
+// publicNetworkAccess, and — separately — onto the eventBusTagWriter
+// capability for tags: a resource-level tag PATCH replaces the tag set
+// wholesale (matching real Azure and every other resource's Update in this
+// codebase — e.g. cosmosaccount, images), a caller who omits tags entirely
+// leaves the existing set untouched, and a caller who supplies an explicit
+// empty tags object wipes it. Tags are routed around UpdateEventBus's
+// cfg.Tags != nil gate on purpose: tagsFromPtr collapses an empty-but-present
+// map to nil, which that gate cannot tell apart from "tags omitted" — so
+// funneling the wipe through cfg.Tags would silently no-op it (the bug this
+// fixes). body.Tags being non-nil (checked before tagsFromPtr) is what
+// distinguishes present-and-empty from absent. Returns the updated topic
+// (200).
 func (h *Handler) updateTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body topicUpdateJSON
 	if !azurearm.DecodeJSON(w, r, &body) {
 		return
 	}
 
-	current, err := h.bus.GetEventBus(r.Context(), rp.ResourceName)
-	if err != nil {
-		azurearm.WriteCErr(w, err)
-		return
-	}
-
 	cfg := ebdriver.EventBusConfig{
 		Name:                rp.ResourceName,
-		Tags:                replaceTagsIfPresent(current.Tags, body.Tags),
 		PublicNetworkAccess: updatePublicNetworkAccess(&body),
 	}
 
@@ -112,6 +113,14 @@ func (h *Handler) updateTopic(w http.ResponseWriter, r *http.Request, rp *azurea
 	if uerr != nil {
 		azurearm.WriteCErr(w, uerr)
 		return
+	}
+
+	if body.Tags != nil && h.tagWriter != nil {
+		info, uerr = h.tagWriter.SetEventBusTags(r.Context(), rp.ResourceName, tagsFromPtr(body.Tags))
+		if uerr != nil {
+			azurearm.WriteCErr(w, uerr)
+			return
+		}
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, toTopicJSON(rp, info))

--- a/server/azure/eventgrid/patch_sdk_test.go
+++ b/server/azure/eventgrid/patch_sdk_test.go
@@ -159,8 +159,10 @@ func TestSDKScopedEventSubscriptionPatch(t *testing.T) {
 	}
 }
 
-// TestSDKSystemTopicPatch drives SystemTopics.BeginUpdate (PATCH): the supplied
-// tag is merged while the pre-existing tag is preserved.
+// TestSDKSystemTopicPatch drives SystemTopics.BeginUpdate (PATCH): the
+// supplied tag set REPLACES the existing tags wholesale (real Azure
+// resource-level tag PATCH semantics), so a tag omitted from the PATCH body
+// is dropped, not preserved.
 func TestSDKSystemTopicPatch(t *testing.T) {
 	cf, _ := newEGFactory(t)
 	st := cf.NewSystemTopicsClient()
@@ -199,14 +201,14 @@ func TestSDKSystemTopicPatch(t *testing.T) {
 	if got.Tags["team"] == nil || *got.Tags["team"] != "a" {
 		t.Fatalf("PATCH did not apply supplied tag: %+v", got.Tags)
 	}
-	if got.Tags["env"] == nil || *got.Tags["env"] != "test" {
-		t.Fatalf("PATCH masked pre-existing tag (nil-mask): %+v", got.Tags)
+	if _, ok := got.Tags["env"]; ok {
+		t.Fatalf("PATCH should have replaced (not merged) the pre-existing tag: %+v", got.Tags)
 	}
 }
 
 // TestSDKDomainPatch drives Domains.BeginUpdate (PATCH): publicNetworkAccess is
-// updated and a supplied tag is merged, while the immutable inputSchema and the
-// pre-existing tag are preserved.
+// updated and the supplied tag set REPLACES the existing tags wholesale, while
+// the immutable inputSchema is preserved.
 func TestSDKDomainPatch(t *testing.T) {
 	cf, _ := newEGFactory(t)
 	dc := cf.NewDomainsClient()
@@ -254,8 +256,8 @@ func TestSDKDomainPatch(t *testing.T) {
 	if got.Tags["team"] == nil || *got.Tags["team"] != "a" {
 		t.Fatalf("PATCH did not apply supplied tag: %+v", got.Tags)
 	}
-	if got.Tags["env"] == nil || *got.Tags["env"] != "test" {
-		t.Fatalf("PATCH masked pre-existing tag (nil-mask): %+v", got.Tags)
+	if _, ok := got.Tags["env"]; ok {
+		t.Fatalf("PATCH should have replaced (not merged) the pre-existing tag: %+v", got.Tags)
 	}
 }
 

--- a/server/azure/eventgrid/system_topics.go
+++ b/server/azure/eventgrid/system_topics.go
@@ -173,10 +173,12 @@ type systemTopicUpdateJSON struct {
 	Tags map[string]*string `json:"tags,omitempty"`
 }
 
-// updateSystemTopic maps SystemTopics.Update (PATCH) onto the wire-owned record:
-// it merges the supplied tags onto the existing tags, preserving any the caller
-// omitted, and returns the updated system topic (200). 404 when the system topic
-// does not exist, before any write.
+// updateSystemTopic maps SystemTopics.Update (PATCH) onto the wire-owned
+// record: a resource-level tag PATCH replaces the tag set wholesale (matching
+// real Azure and this codebase's convention elsewhere), and a caller who
+// omits tags entirely leaves the existing set untouched. Returns the updated
+// system topic (200). 404 when the system topic does not exist, before any
+// write.
 func (h *Handler) updateSystemTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body systemTopicUpdateJSON
 	if !azurearm.DecodeJSON(w, r, &body) {
@@ -195,9 +197,7 @@ func (h *Handler) updateSystemTopic(w http.ResponseWriter, r *http.Request, rp *
 		return
 	}
 
-	if body.Tags != nil {
-		rec.tags = mergeTags(rec.tags, tagsFromPtr(body.Tags))
-	}
+	rec.tags = replaceTagsIfPresent(rec.tags, body.Tags)
 
 	out := rec.toJSON(rp)
 	h.mu.Unlock()

--- a/server/azure/eventgrid/tags_replace_delete_idempotent_sdk_test.go
+++ b/server/azure/eventgrid/tags_replace_delete_idempotent_sdk_test.go
@@ -73,6 +73,48 @@ func TestSDKDomainUpdatePatchReplacesTags(t *testing.T) {
 	}
 }
 
+// TestSDKDomainUpdatePatchEmptyTagsWipes verifies the third leg of the
+// resource-level tag PATCH contract: a body that carries an explicit empty
+// tags object ({}, not omitted) wipes the domain's tags entirely, rather than
+// leaving them untouched.
+func TestSDKDomainUpdatePatchEmptyTagsWipes(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	dc := cf.NewDomainsClient()
+	ctx := context.Background()
+
+	createPoller, err := dc.BeginCreateOrUpdate(ctx, testRG, "wipe-domain", armeventgrid.Domain{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("test")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Domains.BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := createPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("create PollUntilDone: %v", err)
+	}
+
+	updPoller, err := dc.BeginUpdate(ctx, testRG, "wipe-domain", armeventgrid.DomainUpdateParameters{
+		Tags: map[string]*string{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Domains.BeginUpdate: %v", err)
+	}
+
+	if _, err := updPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Update PollUntilDone: %v", err)
+	}
+
+	got, err := dc.Get(ctx, testRG, "wipe-domain", nil)
+	if err != nil {
+		t.Fatalf("Domains.Get: %v", err)
+	}
+
+	if len(got.Tags) != 0 {
+		t.Fatalf("PATCH tags:{} should wipe tags, got %+v", got.Tags)
+	}
+}
+
 // TestSDKSystemTopicUpdatePatchReplacesTags verifies SystemTopics.BeginUpdate
 // REPLACES the system topic's tag set wholesale.
 func TestSDKSystemTopicUpdatePatchReplacesTags(t *testing.T) {
@@ -125,6 +167,53 @@ func TestSDKSystemTopicUpdatePatchReplacesTags(t *testing.T) {
 
 	if len(got.Tags) != 1 || got.Tags["team"] == nil || *got.Tags["team"] != "data" {
 		t.Fatalf("Get after patch tags = %+v, want only {team: data}", got.Tags)
+	}
+}
+
+// TestSDKSystemTopicUpdatePatchEmptyTagsWipes verifies the third leg of the
+// resource-level tag PATCH contract: a body that carries an explicit empty
+// tags object ({}, not omitted) wipes the system topic's tags entirely.
+func TestSDKSystemTopicUpdatePatchEmptyTagsWipes(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	st := cf.NewSystemTopicsClient()
+	ctx := context.Background()
+
+	const source = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Storage/storageAccounts/acct"
+
+	createPoller, err := st.BeginCreateOrUpdate(ctx, testRG, "wipe-systopic", armeventgrid.SystemTopic{
+		Location: to.Ptr("global"),
+		Tags:     map[string]*string{"env": to.Ptr("test")},
+		Properties: &armeventgrid.SystemTopicProperties{
+			Source:    to.Ptr(source),
+			TopicType: to.Ptr("Microsoft.Storage.StorageAccounts"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("SystemTopics.BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := createPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("create PollUntilDone: %v", err)
+	}
+
+	updPoller, err := st.BeginUpdate(ctx, testRG, "wipe-systopic", armeventgrid.SystemTopicUpdateParameters{
+		Tags: map[string]*string{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("SystemTopics.BeginUpdate: %v", err)
+	}
+
+	if _, err := updPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Update PollUntilDone: %v", err)
+	}
+
+	got, err := st.Get(ctx, testRG, "wipe-systopic", nil)
+	if err != nil {
+		t.Fatalf("SystemTopics.Get: %v", err)
+	}
+
+	if len(got.Tags) != 0 {
+		t.Fatalf("PATCH tags:{} should wipe tags, got %+v", got.Tags)
 	}
 }
 

--- a/server/azure/eventgrid/tags_replace_delete_idempotent_sdk_test.go
+++ b/server/azure/eventgrid/tags_replace_delete_idempotent_sdk_test.go
@@ -1,0 +1,201 @@
+// Regression tests for two real-user e2e divergences found in a black-box
+// audit against the real armeventgrid SDK:
+//
+//   - Domains.Update / SystemTopics.Update (PATCH) merged the supplied tags
+//     onto the existing set instead of replacing it wholesale, diverging from
+//     real Azure's resource-level tag PATCH semantics (Topics.Update's own
+//     regression is covered in topic_network_regen_sdk_test.go).
+//   - Topics.Delete / TopicEventSubscriptions.Delete were not idempotent on
+//     an already-absent resource, diverging from real ARM and from every
+//     other delete path in this package (domains, system topics, domain
+//     topics, scoped/system-topic subscriptions).
+package eventgrid_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+)
+
+// TestSDKDomainUpdatePatchReplacesTags verifies Domains.BeginUpdate REPLACES
+// the domain's tag set wholesale (a pre-existing tag absent from the body is
+// dropped), matching real Azure and this codebase's tags-PATCH convention.
+func TestSDKDomainUpdatePatchReplacesTags(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	dc := cf.NewDomainsClient()
+	ctx := context.Background()
+
+	createPoller, err := dc.BeginCreateOrUpdate(ctx, testRG, "patch-domain", armeventgrid.Domain{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("test"), "owner": to.Ptr("alice")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Domains.BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := createPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("create PollUntilDone: %v", err)
+	}
+
+	updPoller, err := dc.BeginUpdate(ctx, testRG, "patch-domain", armeventgrid.DomainUpdateParameters{
+		Tags: map[string]*string{"team": to.Ptr("data")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Domains.BeginUpdate: %v", err)
+	}
+
+	updated, err := updPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("Update PollUntilDone: %v", err)
+	}
+
+	if _, ok := updated.Tags["env"]; ok {
+		t.Fatalf("replace PATCH should have dropped omitted tags: %+v", updated.Tags)
+	}
+
+	if _, ok := updated.Tags["owner"]; ok {
+		t.Fatalf("replace PATCH should have dropped omitted tags: %+v", updated.Tags)
+	}
+
+	if updated.Tags["team"] == nil || *updated.Tags["team"] != "data" {
+		t.Fatalf("update missing new tag team: %+v", updated.Tags)
+	}
+
+	got, err := dc.Get(ctx, testRG, "patch-domain", nil)
+	if err != nil {
+		t.Fatalf("Domains.Get: %v", err)
+	}
+
+	if len(got.Tags) != 1 || got.Tags["team"] == nil || *got.Tags["team"] != "data" {
+		t.Fatalf("Get after patch tags = %+v, want only {team: data}", got.Tags)
+	}
+}
+
+// TestSDKSystemTopicUpdatePatchReplacesTags verifies SystemTopics.BeginUpdate
+// REPLACES the system topic's tag set wholesale.
+func TestSDKSystemTopicUpdatePatchReplacesTags(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	st := cf.NewSystemTopicsClient()
+	ctx := context.Background()
+
+	const source = "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Storage/storageAccounts/acct"
+
+	createPoller, err := st.BeginCreateOrUpdate(ctx, testRG, "patch-systopic", armeventgrid.SystemTopic{
+		Location: to.Ptr("global"),
+		Tags:     map[string]*string{"env": to.Ptr("test")},
+		Properties: &armeventgrid.SystemTopicProperties{
+			Source:    to.Ptr(source),
+			TopicType: to.Ptr("Microsoft.Storage.StorageAccounts"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("SystemTopics.BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := createPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("create PollUntilDone: %v", err)
+	}
+
+	updPoller, err := st.BeginUpdate(ctx, testRG, "patch-systopic", armeventgrid.SystemTopicUpdateParameters{
+		Tags: map[string]*string{"team": to.Ptr("data")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("SystemTopics.BeginUpdate: %v", err)
+	}
+
+	updated, err := updPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("Update PollUntilDone: %v", err)
+	}
+
+	if _, ok := updated.Tags["env"]; ok {
+		t.Fatalf("replace PATCH should have dropped omitted env tag: %+v", updated.Tags)
+	}
+
+	if updated.Tags["team"] == nil || *updated.Tags["team"] != "data" {
+		t.Fatalf("update missing new tag team: %+v", updated.Tags)
+	}
+
+	got, err := st.Get(ctx, testRG, "patch-systopic", nil)
+	if err != nil {
+		t.Fatalf("SystemTopics.Get: %v", err)
+	}
+
+	if len(got.Tags) != 1 || got.Tags["team"] == nil || *got.Tags["team"] != "data" {
+		t.Fatalf("Get after patch tags = %+v, want only {team: data}", got.Tags)
+	}
+}
+
+// TestSDKTopicDeleteIdempotent verifies Topics.BeginDelete succeeds (not a
+// 404) when the topic never existed, matching real ARM's idempotent delete
+// semantics and every sibling delete path in this package.
+func TestSDKTopicDeleteIdempotent(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	topics := cf.NewTopicsClient()
+	ctx := context.Background()
+
+	poller, err := topics.BeginDelete(ctx, testRG, "never-existed-topic", nil)
+	if err != nil {
+		t.Fatalf("Topics.BeginDelete on a missing topic should not error: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("delete-missing PollUntilDone: %v", err)
+	}
+
+	// Deleting a topic that existed, then deleting it again, must also succeed.
+	mkTopicLoc(t, topics, "delete-twice", "eastus")
+
+	firstPoller, err := topics.BeginDelete(ctx, testRG, "delete-twice", nil)
+	if err != nil {
+		t.Fatalf("first Topics.BeginDelete: %v", err)
+	}
+
+	if _, err := firstPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("first delete PollUntilDone: %v", err)
+	}
+
+	secondPoller, err := topics.BeginDelete(ctx, testRG, "delete-twice", nil)
+	if err != nil {
+		t.Fatalf("second Topics.BeginDelete should not error: %v", err)
+	}
+
+	if _, err := secondPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("second delete PollUntilDone: %v", err)
+	}
+}
+
+// TestSDKTopicEventSubscriptionDeleteIdempotent verifies
+// TopicEventSubscriptions.BeginDelete succeeds when the subscription (or its
+// topic) never existed, matching real ARM's idempotent delete semantics.
+func TestSDKTopicEventSubscriptionDeleteIdempotent(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	ctx := context.Background()
+
+	topics := cf.NewTopicsClient()
+	mkTopicLoc(t, topics, "sub-delete-topic", "eastus")
+
+	subs := cf.NewTopicEventSubscriptionsClient()
+
+	// Missing subscription on an existing topic.
+	poller, err := subs.BeginDelete(ctx, testRG, "sub-delete-topic", "never-existed-sub", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete on a missing subscription should not error: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("delete-missing-sub PollUntilDone: %v", err)
+	}
+
+	// Missing subscription on a topic that never existed either.
+	poller2, err := subs.BeginDelete(ctx, testRG, "never-existed-topic-either", "whatever", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete on a missing topic+subscription should not error: %v", err)
+	}
+
+	if _, err := poller2.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("delete-missing-topic-and-sub PollUntilDone: %v", err)
+	}
+}

--- a/server/azure/eventgrid/topic_network_regen_sdk_test.go
+++ b/server/azure/eventgrid/topic_network_regen_sdk_test.go
@@ -72,10 +72,13 @@ func TestSDKTopicPublicNetworkAccessDefaultsToEnabled(t *testing.T) {
 	}
 }
 
-// TestSDKTopicUpdatePatchMergesTags locks B2: Topics.BeginUpdate (PATCH)
-// succeeds, merges the supplied tags onto the existing ones, and applies the
-// mutable publicNetworkAccess.
-func TestSDKTopicUpdatePatchMergesTags(t *testing.T) {
+// TestSDKTopicUpdatePatchReplacesTags locks B2 (revised): Topics.BeginUpdate
+// (PATCH) succeeds, REPLACES the topic's tag set wholesale with the supplied
+// tags (a pre-existing tag absent from the body is dropped, not merged —
+// matching real Azure's resource-level tag PATCH semantics and this
+// codebase's convention elsewhere, e.g. cosmosaccount/images), and applies
+// the mutable publicNetworkAccess.
+func TestSDKTopicUpdatePatchReplacesTags(t *testing.T) {
 	cf, _ := newEGFactory(t)
 	topics := cf.NewTopicsClient()
 	ctx := context.Background()
@@ -107,8 +110,8 @@ func TestSDKTopicUpdatePatchMergesTags(t *testing.T) {
 		t.Fatalf("Update PollUntilDone: %v", err)
 	}
 
-	if updated.Tags["env"] == nil || *updated.Tags["env"] != "test" {
-		t.Fatalf("update dropped existing tag env: %+v", updated.Tags)
+	if _, ok := updated.Tags["env"]; ok {
+		t.Fatalf("replace PATCH should have dropped the omitted env tag: %+v", updated.Tags)
 	}
 
 	if updated.Tags["team"] == nil || *updated.Tags["team"] != "data" {
@@ -120,13 +123,56 @@ func TestSDKTopicUpdatePatchMergesTags(t *testing.T) {
 		t.Fatalf("Get: %v", err)
 	}
 
-	if got.Tags["env"] == nil || got.Tags["team"] == nil {
-		t.Fatalf("Get after patch missing merged tags: %+v", got.Tags)
+	if _, ok := got.Tags["env"]; ok {
+		t.Fatalf("Get after patch should not see the dropped env tag: %+v", got.Tags)
+	}
+
+	if got.Tags["team"] == nil || *got.Tags["team"] != "data" {
+		t.Fatalf("Get after patch missing replaced tag team: %+v", got.Tags)
 	}
 
 	if got.Properties == nil || got.Properties.PublicNetworkAccess == nil ||
 		*got.Properties.PublicNetworkAccess != armeventgrid.PublicNetworkAccessDisabled {
 		t.Fatalf("patch did not apply publicNetworkAccess: %v", got.Properties)
+	}
+}
+
+// TestSDKTopicUpdatePatchOmittedTagsLeavesExisting verifies the other half of
+// the replace contract: a PATCH that omits tags entirely (nil, not an empty
+// map) must leave the topic's existing tags untouched.
+func TestSDKTopicUpdatePatchOmittedTagsLeavesExisting(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	topics := cf.NewTopicsClient()
+	ctx := context.Background()
+
+	createPoller, err := topics.BeginCreateOrUpdate(ctx, testRG, "patch-topic-notags", armeventgrid.Topic{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("test")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := createPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("create PollUntilDone: %v", err)
+	}
+
+	updPoller, err := topics.BeginUpdate(ctx, testRG, "patch-topic-notags", armeventgrid.TopicUpdateParameters{
+		Properties: &armeventgrid.TopicUpdateParameterProperties{
+			PublicNetworkAccess: to.Ptr(armeventgrid.PublicNetworkAccessDisabled),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Topics.BeginUpdate: %v", err)
+	}
+
+	updated, err := updPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("Update PollUntilDone: %v", err)
+	}
+
+	if updated.Tags["env"] == nil || *updated.Tags["env"] != "test" {
+		t.Fatalf("PATCH with no tags field should preserve existing tags: %+v", updated.Tags)
 	}
 }
 

--- a/server/azure/eventgrid/topic_network_regen_sdk_test.go
+++ b/server/azure/eventgrid/topic_network_regen_sdk_test.go
@@ -176,6 +176,56 @@ func TestSDKTopicUpdatePatchOmittedTagsLeavesExisting(t *testing.T) {
 	}
 }
 
+// TestSDKTopicUpdatePatchEmptyTagsWipes verifies the third leg of the
+// resource-level tag PATCH contract: a body that carries an explicit empty
+// tags object ({}, not omitted) wipes the topic's tags entirely, matching
+// Domains.Update and SystemTopics.Update. This is the regression case: an
+// empty-but-present map collapses to nil once decoded, and nil is also what
+// "tags omitted" decodes to, so a naive implementation that funnels tags
+// through UpdateEventBus's cfg.Tags != nil gate silently no-ops the wipe.
+func TestSDKTopicUpdatePatchEmptyTagsWipes(t *testing.T) {
+	cf, _ := newEGFactory(t)
+	topics := cf.NewTopicsClient()
+	ctx := context.Background()
+
+	createPoller, err := topics.BeginCreateOrUpdate(ctx, testRG, "wipe-topic", armeventgrid.Topic{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("test")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := createPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("create PollUntilDone: %v", err)
+	}
+
+	updPoller, err := topics.BeginUpdate(ctx, testRG, "wipe-topic", armeventgrid.TopicUpdateParameters{
+		Tags: map[string]*string{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Topics.BeginUpdate: %v", err)
+	}
+
+	updated, err := updPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("Update PollUntilDone: %v", err)
+	}
+
+	if len(updated.Tags) != 0 {
+		t.Fatalf("PATCH tags:{} should wipe tags in the update response, got %+v", updated.Tags)
+	}
+
+	got, err := topics.Get(ctx, testRG, "wipe-topic", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if len(got.Tags) != 0 {
+		t.Fatalf("Get after PATCH tags:{} should show wiped tags, got %+v", got.Tags)
+	}
+}
+
 // TestSDKTopicRegenerateKey locks B3: BeginRegenerateKey("key1") changes key1
 // but not key2, and ListSharedAccessKeys reflects the rotated value.
 func TestSDKTopicRegenerateKey(t *testing.T) {

--- a/server/azure/eventgrid/topic_tags.go
+++ b/server/azure/eventgrid/topic_tags.go
@@ -1,0 +1,21 @@
+package eventgrid
+
+import (
+	"context"
+
+	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+)
+
+// eventBusTagWriter is the optional tag-write capability of an event bus
+// backend (the Azure eventgrid.Mock provides it) that lets updateTopic set a
+// topic's tags to an explicit value, including empty. It exists because
+// EventBusConfig.Tags cannot carry the distinction Topics.Update needs: a nil
+// map means both "the request omitted tags" and "the request supplied an
+// empty tags object," and UpdateEventBus's cfg.Tags != nil gate collapses
+// both to "leave tags unchanged" — silently no-oping an explicit wipe to
+// empty. Routing the wipe through this capability instead keeps the fix
+// local to Azure Event Grid without changing the shared driver contract used
+// by AWS/GCP event-bus backends.
+type eventBusTagWriter interface {
+	SetEventBusTags(ctx context.Context, name string, tags map[string]string) (*ebdriver.EventBusInfo, error)
+}


### PR DESCRIPTION
## Summary

Real-user black-box audit of Azure Event Grid (topics, domains, system
topics, event subscriptions) via the real `armeventgrid/v2` SDK against a
live `cloudemu serve` instance. Two genuine divergences found and fixed;
one systemic finding filed (out of scope for this PR, see below).

## Findings fixed

**F1 — Topics/Domains/SystemTopics PATCH (Update) merged tags instead of
replacing them.** Real Azure's resource-level tag PATCH replaces the tag
set wholesale (a tag omitted from the PATCH body is dropped), matching the
convention already established elsewhere in this codebase (`cosmosaccount`,
`images`, `storageaccount`, `keyvault`). All three Event Grid resources
instead merged the patch onto the existing tags, so a stale tag survived a
PATCH meant to remove it. Fixed all three call sites (`operations.go`,
`domains.go`, `system_topics.go`); removed the now-dead `mergeTags` helper
in favor of `replaceTagsIfPresent` (replace when the body carries a `tags`
key at all, leave untouched when omitted).

**F2 — Topics.Delete / TopicEventSubscriptions.Delete were not
idempotent.** Deleting an already-absent topic or event subscription
returned 404 `ResourceNotFound` instead of succeeding, unlike every other
delete path in this same package (`deleteDomain`, `deleteSystemTopic`,
`deleteDomainTopic`, `deleteScopedEventSubscription`,
`deleteSystemTopicSubscription`), and unlike real ARM's idempotent-delete
semantics. Both now swallow a `NotFound` from the driver and answer
success.

## Filed, not fixed (systemic, out of scope)

The ARM error envelope's `message` field leaks the internal
`cerrors` code-taxonomy prefix (e.g. `"NotFound: topic ... not found"`)
because `server/wire/azurearm.WriteCErr`/`WriteParentNotFound` use
`err.Error()` instead of `cerrors.Message(err)`. This is not Event
Grid-specific — it's the shared ARM wire codec used by every Azure service
(`cerrors.Message` has zero usages anywhere under `server/azure/`). AWS
(#828) and GCP (#1083) already got dedicated systemic fixes for the
identical pattern; Azure needs the same treatment in its own PR since
fixing the shared helper requires re-verifying the full Azure test suite.

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers/azure/eventgrid/... ./server/azure/eventgrid/... -race` (all pass, including new regression tests)
- [x] `go test ./server/azure/... ./providers/azure/...` (full Azure surface green)
- [x] `gofmt` clean
- [x] `golangci-lint run --new-from-rev=origin/development` — 0 issues
- [x] `go generate ./...` — no `docs/coverage` drift
- [x] Re-verified both fixes black-box against a live `cloudemu serve -providers=azure` with the real armeventgrid SDK
- [x] Added `TestSDKTopicUpdatePatchOmittedTagsLeavesExisting`, `TestSDKDomainUpdatePatchReplacesTags`, `TestSDKSystemTopicUpdatePatchReplacesTags`, `TestSDKTopicDeleteIdempotent`, `TestSDKTopicEventSubscriptionDeleteIdempotent`; updated `TestSDKTopicUpdatePatchMergesTags` -> `TestSDKTopicUpdatePatchReplacesTags`, `TestSDKSystemTopicPatch`, `TestSDKDomainPatch` to assert replace semantics