### PR TITLE
fix(gcp-clouddns): real-user e2e divergences

### DIFF
--- a/server/gcp/clouddns/changes_atomicity_sdk_test.go
+++ b/server/gcp/clouddns/changes_atomicity_sdk_test.go
@@ -1,0 +1,64 @@
+package clouddns_test
+
+import (
+	"context"
+	"testing"
+
+	dns "google.golang.org/api/dns/v1"
+)
+
+// TestSDKChangesCreateDuplicateDeletionRejectedAtomically guards a real-user
+// e2e finding: a batch naming the same (name,type) twice in its deletions
+// used to fail with a 404 on the SECOND occurrence, but only after the FIRST
+// occurrence had already deleted the record — a half-applied "atomic" change.
+// Cloud DNS's changes.create is documented as all-or-nothing, so such a batch
+// must be rejected up front, before any mutation, leaving the record intact.
+func TestSDKChangesCreateDuplicateDeletionRejectedAtomically(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	createZone(t, svc, &dns.ManagedZone{Name: "dupdel-zone", DnsName: "dupdel.example.com."})
+
+	rr := &dns.ResourceRecordSet{Name: "www.dupdel.example.com.", Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1"}}
+	if err := addRecord(t, svc, "dupdel-zone", rr); err != nil {
+		t.Fatalf("seed addRecord: %v", err)
+	}
+
+	_, err := svc.Changes.Create(testProject, "dupdel-zone", &dns.Change{
+		Deletions: []*dns.ResourceRecordSet{rr, rr},
+	}).Context(ctx).Do()
+	if code := apiCode(t, err); code != 400 {
+		t.Fatalf("duplicate deletion in one batch: got %v, want 400", err)
+	}
+
+	rec := findRecord(t, svc, ctx, "dupdel-zone", "www.dupdel.example.com.")
+	if rec == nil {
+		t.Fatal("record was deleted despite the batch being rejected — non-atomic partial apply")
+	}
+}
+
+// TestSDKChangesCreateDuplicateAdditionRejectedAtomically is the additions-side
+// counterpart: two additions for the same (name,type) in one batch used to let
+// the first SetIfAbsent succeed and only the second fail with 409, again
+// leaving a mutation behind a batch that reported failure.
+func TestSDKChangesCreateDuplicateAdditionRejectedAtomically(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	createZone(t, svc, &dns.ManagedZone{Name: "dupadd-zone", DnsName: "dupadd.example.com."})
+
+	_, err := svc.Changes.Create(testProject, "dupadd-zone", &dns.Change{
+		Additions: []*dns.ResourceRecordSet{
+			{Name: "www.dupadd.example.com.", Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1"}},
+			{Name: "www.dupadd.example.com.", Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.2"}},
+		},
+	}).Context(ctx).Do()
+	if code := apiCode(t, err); code != 400 {
+		t.Fatalf("duplicate addition in one batch: got %v, want 400", err)
+	}
+
+	rec := findRecord(t, svc, ctx, "dupadd-zone", "www.dupadd.example.com.")
+	if rec != nil {
+		t.Fatalf("record was created despite the batch being rejected — non-atomic partial apply: %+v", rec)
+	}
+}

--- a/server/gcp/clouddns/operations.go
+++ b/server/gcp/clouddns/operations.go
@@ -80,11 +80,14 @@ func validateZoneCreate(w http.ResponseWriter, req *managedZoneJSON) bool {
 	return true
 }
 
+// maxZoneNameLength is Cloud DNS's managed-zone name length cap.
+const maxZoneNameLength = 63
+
 // isValidZoneName reports whether name matches Cloud DNS's managed-zone name
 // grammar [a-z]([-a-z0-9]*[a-z0-9])?: a lowercase-letter start, lowercase
-// alphanumeric or hyphen body, and no trailing hyphen.
+// alphanumeric or hyphen body, no trailing hyphen, and at most 63 characters.
 func isValidZoneName(name string) bool {
-	if name == "" || name[0] < 'a' || name[0] > 'z' {
+	if name == "" || len(name) > maxZoneNameLength || name[0] < 'a' || name[0] > 'z' {
 		return false
 	}
 
@@ -173,9 +176,19 @@ func (h *Handler) listZones(w http.ResponseWriter, r *http.Request, rt route) {
 		return
 	}
 
+	// Cloud DNS's managedZones.list accepts a ?dnsName= filter restricting the
+	// result to zones with exactly that DNS name.
+	dnsNameFilter := r.URL.Query().Get("dnsName")
+
 	out := make([]managedZoneJSON, 0, len(infos))
+
 	for i := range infos {
-		out = append(out, toManagedZoneJSON(&infos[i]))
+		j := toManagedZoneJSON(&infos[i])
+		if dnsNameFilter != "" && j.DNSName != dnsNameFilter {
+			continue
+		}
+
+		out = append(out, j)
 	}
 
 	page, next, ok := paginate(w, r, len(out))
@@ -357,12 +370,31 @@ func (h *Handler) createChange(w http.ResponseWriter, r *http.Request, rt route)
 		return
 	}
 
+	// A batch that names the same (name,type) twice within its own additions or
+	// deletions can never apply cleanly: the driver has no multi-key primitive,
+	// so the first occurrence would land (mutating the zone) before the second
+	// fails — a half-applied "atomic" change. Reject such a batch outright,
+	// before any check that reads store state, so nothing is ever mutated.
+	if name, rtype, dup := duplicateRRSet(req.Deletions); dup {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid",
+			"the change's deletions list the resource record set "+name+" ("+rtype+") more than once")
+		return
+	}
+
+	if name, rtype, dup := duplicateRRSet(req.Additions); dup {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid",
+			"the change's additions list the resource record set "+name+" ("+rtype+") more than once")
+		return
+	}
+
+	dnsName := apexDNSName(info)
+
 	// Cloud DNS applies a change atomically: validate the whole batch up front —
 	// deletions resolve and don't strip the apex, additions don't collide, and no
 	// name is left with a CNAME beside another type — before any mutation, so a
 	// bad batch fails cleanly without half-applying.
-	if !h.checkDeletions(w, r, id, apexDNSName(info), &req) ||
-		!h.checkAdditions(w, r, id, &req) ||
+	if !h.checkDeletions(w, r, id, dnsName, &req) ||
+		!h.checkAdditions(w, r, id, dnsName, &req) ||
 		!h.checkCNAME(w, r, id, &req) {
 		return
 	}
@@ -451,7 +483,7 @@ func rrsetDeletionMatches(rec *dnsdriver.RecordInfo, d *resourceRecordSetJSON) b
 // a new one with the SAME name+type in one batch; such an addition is not a real
 // conflict — it replaces a record this same change removes — so exempt additions
 // whose (name,type) also appears in the deletions.
-func (h *Handler) checkAdditions(w http.ResponseWriter, r *http.Request, id string, req *changeJSON) bool {
+func (h *Handler) checkAdditions(w http.ResponseWriter, r *http.Request, id, dnsName string, req *changeJSON) bool {
 	deleting := make(map[string]bool, len(req.Deletions))
 	for i := range req.Deletions {
 		deleting[rrsetKey(req.Deletions[i].Name, req.Deletions[i].Type)] = true
@@ -464,9 +496,17 @@ func (h *Handler) checkAdditions(w http.ResponseWriter, r *http.Request, id stri
 		// has no batch primitive, so a malformed addition caught only at apply
 		// time would land after the deletions — reject it up front so the batch
 		// fails cleanly and the zone is left untouched.
-		if a.Name == "" || a.Type == "" || len(a.Rrdatas) == 0 {
+		if a.Name == "" || a.Type == "" || len(a.Rrdatas) == 0 || a.TTL < 0 {
 			gcprest.WriteError(w, http.StatusBadRequest, "invalid",
-				"an addition must have a name, type, and at least one rrdata")
+				"an addition must have a name, type, a non-negative ttl, and at least one rrdata")
+			return false
+		}
+
+		// Cloud DNS requires every record set's name to be the zone's own DNS
+		// name or a subdomain of it; a name from an unrelated domain is rejected.
+		if !isWithinZone(a.Name, dnsName) {
+			gcprest.WriteError(w, http.StatusBadRequest, "invalid",
+				"the resource record set name "+a.Name+" is not within the managed zone's DNS name "+dnsName)
 			return false
 		}
 
@@ -482,6 +522,34 @@ func (h *Handler) checkAdditions(w http.ResponseWriter, r *http.Request, id stri
 	}
 
 	return true
+}
+
+// isWithinZone reports whether name is the zone's own DNS name or a subdomain
+// of it, matched on label boundaries (not a raw string suffix) so an unrelated
+// domain that merely ends with the same letters — e.g. "evilexample.com."
+// against zone dnsName "example.com." — is correctly rejected.
+func isWithinZone(name, dnsName string) bool {
+	return name == dnsName || strings.HasSuffix(name, "."+dnsName)
+}
+
+// duplicateRRSet returns the name and type of the first (name,type) pair that
+// appears more than once in sets, so a caller can reject a batch whose
+// additions or deletions name the same record set twice — applying such a
+// batch would half-succeed, since the driver has no way to apply two writes to
+// the same key as a single operation.
+func duplicateRRSet(sets []resourceRecordSetJSON) (name, rtype string, dup bool) {
+	seen := make(map[string]bool, len(sets))
+
+	for i := range sets {
+		k := rrsetKey(sets[i].Name, sets[i].Type)
+		if seen[k] {
+			return sets[i].Name, sets[i].Type, true
+		}
+
+		seen[k] = true
+	}
+
+	return "", "", false
 }
 
 // checkCNAME rejects a change that would leave any name with a CNAME record set

--- a/server/gcp/clouddns/zone_record_scope_sdk_test.go
+++ b/server/gcp/clouddns/zone_record_scope_sdk_test.go
@@ -1,0 +1,125 @@
+package clouddns_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	dns "google.golang.org/api/dns/v1"
+)
+
+// TestSDKAdditionOutsideZoneDNSNameRejected guards a real-user e2e finding: a
+// record set whose name is unrelated to the zone's dnsName used to be accepted
+// silently. Real Cloud DNS requires every record set's name to be the zone's
+// own DNS name or a subdomain of it.
+func TestSDKAdditionOutsideZoneDNSNameRejected(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	createZone(t, svc, &dns.ManagedZone{Name: "outside-zone", DnsName: "outside.example.com."})
+
+	err := addRecord(t, svc, "outside-zone", &dns.ResourceRecordSet{
+		Name: "www.totally-different-domain.com.", Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1"},
+	})
+	if code := apiCode(t, err); code != 400 {
+		t.Fatalf("out-of-zone addition: got %v, want 400", err)
+	}
+
+	if rec := findRecord(t, svc, ctx, "outside-zone", "www.totally-different-domain.com."); rec != nil {
+		t.Fatalf("out-of-zone record must not have been created: %+v", rec)
+	}
+}
+
+// TestSDKAdditionOutsideZoneDNSNameRejectsLabelBoundary asserts the within-zone
+// check matches on label boundaries rather than a raw string suffix: a name
+// that merely ends with the same letters as the zone's dnsName (but isn't
+// actually a subdomain of it) must still be rejected.
+func TestSDKAdditionOutsideZoneDNSNameRejectsLabelBoundary(t *testing.T) {
+	svc := newDNSService(t)
+
+	createZone(t, svc, &dns.ManagedZone{Name: "boundary-zone", DnsName: "example.com."})
+
+	err := addRecord(t, svc, "boundary-zone", &dns.ResourceRecordSet{
+		Name: "evilexample.com.", Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1"},
+	})
+	if code := apiCode(t, err); code != 400 {
+		t.Fatalf("label-boundary-violating addition: got %v, want 400", err)
+	}
+}
+
+// TestSDKAdditionAtZoneApexAndSubdomainAccepted is the negative control: a
+// record set exactly at the zone's dnsName, and one on a genuine subdomain,
+// must both be accepted.
+func TestSDKAdditionAtZoneApexAndSubdomainAccepted(t *testing.T) {
+	svc := newDNSService(t)
+
+	createZone(t, svc, &dns.ManagedZone{Name: "valid-zone", DnsName: "valid.example.com."})
+
+	if err := addRecord(t, svc, "valid-zone", &dns.ResourceRecordSet{
+		Name: "valid.example.com.", Type: "TXT", Ttl: 300, Rrdatas: []string{`"apex"`},
+	}); err != nil {
+		t.Fatalf("apex addition rejected: %v", err)
+	}
+
+	if err := addRecord(t, svc, "valid-zone", &dns.ResourceRecordSet{
+		Name: "www.valid.example.com.", Type: "A", Ttl: 300, Rrdatas: []string{"192.0.2.1"},
+	}); err != nil {
+		t.Fatalf("subdomain addition rejected: %v", err)
+	}
+}
+
+// TestSDKNegativeTTLRejected guards the finding that a negative ttl was
+// accepted; Cloud DNS TTLs are non-negative.
+func TestSDKNegativeTTLRejected(t *testing.T) {
+	svc := newDNSService(t)
+
+	createZone(t, svc, &dns.ManagedZone{Name: "negttl-zone", DnsName: "negttl.example.com."})
+
+	err := addRecord(t, svc, "negttl-zone", &dns.ResourceRecordSet{
+		Name: "www.negttl.example.com.", Type: "A", Ttl: -5, Rrdatas: []string{"192.0.2.1"},
+	})
+	if code := apiCode(t, err); code != 400 {
+		t.Fatalf("negative ttl: got %v, want 400", err)
+	}
+}
+
+// TestSDKZoneNameTooLongRejected guards the finding that Cloud DNS's 63-char
+// managed-zone name cap was not enforced.
+func TestSDKZoneNameTooLongRejected(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	_, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+		Name: strings.Repeat("a", 64), DnsName: "toolong.example.com.",
+	}).Context(ctx).Do()
+	if code := apiCode(t, err); code != 400 {
+		t.Fatalf("64-char zone name: got %v, want 400", err)
+	}
+
+	// A name at exactly the 63-char limit must still be accepted.
+	if _, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+		Name: strings.Repeat("a", 63), DnsName: "exactly63.example.com.",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("63-char zone name rejected: %v", err)
+	}
+}
+
+// TestSDKManagedZonesListDNSNameFilter guards the finding that
+// managedZones.list ignored the ?dnsName= query filter and always returned
+// every zone in the project.
+func TestSDKManagedZonesListDNSNameFilter(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	createZone(t, svc, &dns.ManagedZone{Name: "dnf-a", DnsName: "dnf-a.example.com."})
+	createZone(t, svc, &dns.ManagedZone{Name: "dnf-b", DnsName: "dnf-b.example.com."})
+
+	list, err := svc.ManagedZones.List(testProject).DnsName("dnf-a.example.com.").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List(dnsName filter): %v", err)
+	}
+
+	if len(list.ManagedZones) != 1 || list.ManagedZones[0].Name != "dnf-a" {
+		t.Fatalf("dnsName filter = %+v, want exactly [dnf-a]", list.ManagedZones)
+	}
+}


### PR DESCRIPTION
## Summary

Real-user black-box e2e audit of GCP Cloud DNS (`google.golang.org/api/dns/v1` against a live `cloudemu serve -providers=gcp`). This service had already been through 8 prior fix passes (#253, #259, #321, #647, #737, #787, #1025) and was very mature; this pass found and fixed 5 additional divergences, all isolated to `server/gcp/clouddns/operations.go`.

### Fixes

1. **Changes.create was not atomic for a batch with a duplicate (name,type) key.** A batch listing the same rrset twice in `Additions` or `Deletions` let the first occurrence mutate the zone before the second failed — a half-applied "atomic" change reported to the caller as an error. Now rejected up front (400) with nothing mutated.
2. **`managedZones.list` ignored the `?dnsName=` filter.** Always returned every zone in the project regardless of the requested filter. Now honored.
3. **A record set name entirely outside the zone's DNS name was accepted.** e.g. adding `www.totally-different-domain.com.` inside a zone whose `dnsName` is `outside.example.com.` Now rejected 400, with a label-boundary-safe check (`evilexample.com.` is correctly not treated as a subdomain of `example.com.`).
4. **Managed-zone name length was not capped at 63 characters.** Now enforced alongside the existing character-grammar check.
5. **Negative TTL was accepted.** Now rejected.

### Filed, not fixed (larger scope)

- Cloud DNS Policies API (`dns/v1/projects/{p}/policies`) is not modeled — whole additional resource type.
- Forwarding/peering managed zones are not modeled (only public/private visibility).
- SOA serial number never increments after zone creation — moderate confidence this diverges from real Cloud DNS, flagged for a follow-up audit rather than fixed here (more invasive, touches the "protected" apex SOA record).

## Test plan

- [x] `go build ./...`
- [x] `go test ./server/gcp/clouddns/... ./providers/gcp/clouddns/... -race` — all green, including new regression tests
- [x] `go test ./...` (full suite) — no failures
- [x] `gofmt -l` clean
- [x] `golangci-lint run --new-from-rev=origin/development ./...` — 0 new issues
- [x] `go generate ./...` — no `docs/coverage` drift
- [x] Each fix re-verified black-box via the real SDK against a running `cloudemu serve` instance before writing its regression test