### PR TITLE
fix(oci): real-user e2e divergences

### DIFF
--- a/server/oci/identity/handler.go
+++ b/server/oci/identity/handler.go
@@ -329,7 +329,8 @@ func paginate[T any](items []T, r *http.Request) (window []T, next string) {
 	}
 
 	if offset >= len(items) {
-		return nil, ""
+		// items[:0] rather than nil: an empty page is [] on the wire, not null.
+		return items[:0], ""
 	}
 
 	end := min(offset+ocirest.Limit(r), len(items))

--- a/server/oci/identity/handler_test.go
+++ b/server/oci/identity/handler_test.go
@@ -255,6 +255,25 @@ func TestErrorResponses(t *testing.T) {
 	}
 }
 
+// TestEmptyListsAreEmptyArraysNotNull pins the OCI wire contract: a List
+// response with no results is `[]`, never `null`, for every identity
+// collection.
+func TestEmptyListsAreEmptyArraysNotNull(t *testing.T) {
+	ts := newServer(t)
+
+	for _, path := range []string{
+		usersPath + "?compartmentId=" + tenancy,
+		"/20160918/groups?compartmentId=" + tenancy,
+		"/20160918/userGroupMemberships?compartmentId=" + tenancy,
+		"/20160918/policies?compartmentId=" + tenancy,
+		compartmentsPath + "?compartmentId=" + tenancy,
+	} {
+		status, _, raw := call(t, ts, http.MethodGet, path, "")
+		require.Equal(t, http.StatusOK, status, path)
+		assert.Equal(t, "[]", strings.TrimSpace(string(raw)), "expected an empty JSON array for %s, got %q", path, raw)
+	}
+}
+
 func TestListsAreScopedToOneCompartment(t *testing.T) {
 	ts := newServer(t)
 

--- a/server/wire/ocirest/ocirest.go
+++ b/server/wire/ocirest/ocirest.go
@@ -64,7 +64,7 @@ func WriteError(w http.ResponseWriter, r *http.Request, status int, code, messag
 // WriteDriverError maps a driver error onto OCI's status and error code.
 func WriteDriverError(w http.ResponseWriter, r *http.Request, err error) {
 	status, code := statusFor(cerrors.GetCode(err))
-	WriteError(w, r, status, code, err.Error())
+	WriteError(w, r, status, code, cerrors.Message(err))
 }
 
 // statusFor maps a canonical error code onto OCI's HTTP status and error code.

--- a/server/wire/ocirest/ocirest_test.go
+++ b/server/wire/ocirest/ocirest_test.go
@@ -69,64 +69,74 @@ func TestWriteJSONNilBodyWritesNothing(t *testing.T) {
 
 func TestWriteDriverError(t *testing.T) {
 	tests := []struct {
-		name         string
-		err          error
-		expectStatus int
-		expectCode   string
+		name          string
+		err           error
+		expectStatus  int
+		expectCode    string
+		expectMessage string
 	}{
 		{
-			name:         "not found",
-			err:          cerrors.New(cerrors.NotFound, "no such bucket"),
-			expectStatus: http.StatusNotFound,
-			expectCode:   "NotAuthorizedOrNotFound",
+			name:          "not found",
+			err:           cerrors.New(cerrors.NotFound, "no such bucket"),
+			expectStatus:  http.StatusNotFound,
+			expectCode:    "NotAuthorizedOrNotFound",
+			expectMessage: "no such bucket",
 		},
 		{
-			name:         "permission denied is indistinguishable from not found",
-			err:          cerrors.New(cerrors.PermissionDenied, "denied"),
-			expectStatus: http.StatusNotFound,
-			expectCode:   "NotAuthorizedOrNotFound",
+			name:          "permission denied is indistinguishable from not found",
+			err:           cerrors.New(cerrors.PermissionDenied, "denied"),
+			expectStatus:  http.StatusNotFound,
+			expectCode:    "NotAuthorizedOrNotFound",
+			expectMessage: "denied",
 		},
 		{
-			name:         "already exists",
-			err:          cerrors.New(cerrors.AlreadyExists, "bucket exists"),
-			expectStatus: http.StatusConflict,
-			expectCode:   "Conflict",
+			name:          "already exists",
+			err:           cerrors.New(cerrors.AlreadyExists, "bucket exists"),
+			expectStatus:  http.StatusConflict,
+			expectCode:    "Conflict",
+			expectMessage: "bucket exists",
 		},
 		{
-			name:         "invalid argument",
-			err:          cerrors.New(cerrors.InvalidArgument, "bad name"),
-			expectStatus: http.StatusBadRequest,
-			expectCode:   "InvalidParameter",
+			name:          "invalid argument",
+			err:           cerrors.New(cerrors.InvalidArgument, "bad name"),
+			expectStatus:  http.StatusBadRequest,
+			expectCode:    "InvalidParameter",
+			expectMessage: "bad name",
 		},
 		{
-			name:         "failed precondition",
-			err:          cerrors.New(cerrors.FailedPrecondition, "not terminated"),
-			expectStatus: http.StatusConflict,
-			expectCode:   "IncorrectState",
+			name:          "failed precondition",
+			err:           cerrors.New(cerrors.FailedPrecondition, "not terminated"),
+			expectStatus:  http.StatusConflict,
+			expectCode:    "IncorrectState",
+			expectMessage: "not terminated",
 		},
 		{
-			name:         "throttled",
-			err:          cerrors.New(cerrors.Throttled, "slow down"),
-			expectStatus: http.StatusTooManyRequests,
-			expectCode:   "TooManyRequests",
+			name:          "throttled",
+			err:           cerrors.New(cerrors.Throttled, "slow down"),
+			expectStatus:  http.StatusTooManyRequests,
+			expectCode:    "TooManyRequests",
+			expectMessage: "slow down",
 		},
 		{
-			name:         "unimplemented",
-			err:          cerrors.New(cerrors.Unimplemented, "not yet"),
-			expectStatus: http.StatusNotImplemented,
-			expectCode:   "NotImplemented",
+			name:          "unimplemented",
+			err:           cerrors.New(cerrors.Unimplemented, "not yet"),
+			expectStatus:  http.StatusNotImplemented,
+			expectCode:    "NotImplemented",
+			expectMessage: "not yet",
 		},
 		{
-			name:         "unavailable",
-			err:          cerrors.New(cerrors.Unavailable, "down"),
-			expectStatus: http.StatusServiceUnavailable,
-			expectCode:   "ServiceUnavailable",
+			name:          "unavailable",
+			err:           cerrors.New(cerrors.Unavailable, "down"),
+			expectStatus:  http.StatusServiceUnavailable,
+			expectCode:    "ServiceUnavailable",
+			expectMessage: "down",
 		},
 		{
-			name:         "non-cloudemu error falls back to internal",
-			err:          assert.AnError,
-			expectStatus: http.StatusInternalServerError,
-			expectCode:   "InternalServerError",
+			name:          "non-cloudemu error falls back to internal",
+			err:           assert.AnError,
+			expectStatus:  http.StatusInternalServerError,
+			expectCode:    "InternalServerError",
+			expectMessage: assert.AnError.Error(),
 		},
 	}
 
@@ -142,7 +152,10 @@ func TestWriteDriverError(t *testing.T) {
 			var body ocirest.ErrorBody
 			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 			assert.Equal(t, tc.expectCode, body.Code)
-			assert.NotEmpty(t, body.Message)
+			// The message must be the bare driver message, never prefixed with
+			// the internal code taxonomy (e.g. "NotFound: ...") that
+			// cerrors.Error.Error() bakes in — real OCI never leaks that.
+			assert.Equal(t, tc.expectMessage, body.Message)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Real-user e2e audit of the OCI wire surface (identity, vcn, monitoring — driven live via raw REST against `cloudemu serve -providers=oci`, since no OCI Go SDK dependency exists in this repo) found two systemic wire-shape divergences from real OCI, both fixed here.

### 1. Identity list endpoints returned `null` instead of `[]` for empty results

`server/oci/identity/handler.go`'s `paginate()` explicitly returned a literal Go `nil` on its empty-page branch, discarding the driver's already-non-nil empty slice (every `List*` provider method uses `make([]T, 0, len(all))`). `encoding/json` marshals nil slices as `null`; real OCI's List operations always return a JSON array, even when empty. This affected every identity collection: users, groups, userGroupMemberships, policies, compartments.

The sibling `server/oci/vcn` package already guards against exactly this (`items[:0] rather than nil: an empty page is [] on the wire, not null`) — identity had regressed from that convention. Fixed identically.

### 2. OCI errors leaked the internal cerrors code-taxonomy prefix

`server/wire/ocirest/ocirest.go`'s `WriteDriverError` — the single choke point every OCI handler (identity, vcn, monitoring) funnels through — built the client-facing message with `err.Error()`, which for a `*cerrors.Error` bakes in the internal code name (e.g. `"NotFound: user \"...\" not found"`, `"FailedPrecondition: compartment \"...\" still contains compartment team"`). Real OCI never does this. This is the same systemic class just fixed for GCP in #1083; OCI hadn't received the equivalent fix yet. Switched to `cerrors.Message(err)`, which strips the prefix — already the established pattern elsewhere in the repo.

Full findings (including verified-correct behaviors and build-out gaps filed for later, not attempted here) are in the audit notes below.

## Evidence

Before (live `cloudemu serve -providers=oci`):
```
GET /20160918/users?compartmentId=<tenancy>
-> 200 {} null

GET /20160918/users/ocid1.user.oc1..missing
-> 404 {"code":"NotAuthorizedOrNotFound","message":"NotFound: user \"ocid1.user.oc1..missing\" not found"}
```

After:
```
GET /20160918/users?compartmentId=<tenancy>
-> 200 []

GET /20160918/users/ocid1.user.oc1..missing
-> 404 {"code":"NotAuthorizedOrNotFound","message":"user \"ocid1.user.oc1..missing\" not found"}
```

## Test plan

- [x] `TestEmptyListsAreEmptyArraysNotNull` (new, `server/oci/identity/handler_test.go`) — pins `[]` for all five identity collections
- [x] `TestWriteDriverError` (`server/wire/ocirest/ocirest_test.go`) — now asserts the exact expected message per error code (was only asserting non-empty), which would have caught the leaked prefix
- [x] `go build ./...`
- [x] `go test ./providers/oci/... ./server/oci/... ./server/wire/ocirest/... -race` — all green
- [x] `go test ./...` — full suite, 332 packages, green
- [x] `golangci-lint run --new-from-rev=<base> ./server/oci/... ./server/wire/ocirest/...` — 0 new issues
- [x] `go generate ./... && git diff --exit-code docs/coverage` — no drift
- [x] Re-verified both fixes black-box against a rebuilt `cloudemu serve -providers=oci` instance