### PR TITLE
fix(rds): snapshot restore reproduces captured state instead of defaults

### DIFF
--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -1274,6 +1274,9 @@ func (m *Mock) CreateSnapshot(_ context.Context, cfg rdsdriver.SnapshotConfig) (
 		MasterUsername: inst.MasterUsername,
 		DBName:         inst.DBName,
 		Port:           inst.Port,
+		InstanceClass:  inst.InstanceClass,
+		StorageType:    inst.StorageType,
+		Iops:           inst.Iops,
 	}
 
 	now := m.opts.Clock.Now()
@@ -1361,12 +1364,7 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "DB instance %q already exists", input.NewInstanceID)
 	}
 
-	instanceClass := input.InstanceClass
-	if instanceClass == "" {
-		instanceClass = defaultInstanceClass
-	}
-
-	username, dbName, port := m.restoreAttrsFromSnapshot(&snap, input.Port)
+	defaults := m.restoreAttrsFromSnapshot(&snap, &input)
 
 	password := m.rootPasswords[snap.InstanceID]
 
@@ -1376,13 +1374,14 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 		ARN:                        instanceARN(region, m.opts.AccountID, input.NewInstanceID),
 		Engine:                     snap.Engine,
 		EngineVersion:              snap.EngineVersion,
-		InstanceClass:              instanceClass,
+		InstanceClass:              defaults.instanceClass,
 		AllocatedStorage:           snap.AllocatedStorage,
-		StorageType:                defaultStorageType,
-		MasterUsername:             username,
-		DBName:                     dbName,
+		StorageType:                defaults.storageType,
+		Iops:                       defaults.iops,
+		MasterUsername:             defaults.username,
+		DBName:                     defaults.dbName,
 		Endpoint:                   endpointFor(input.NewInstanceID, region, "abcd1234"),
-		Port:                       port,
+		Port:                       defaults.port,
 		State:                      rdsdriver.StateAvailable,
 		DbiResourceID:              resourceID("db-", input.NewInstanceID),
 		BackupRetentionPeriod:      defaultBackupRetention,
@@ -1403,7 +1402,7 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 	restoreCfg := rdsdriver.InstanceConfig{
 		ID:                 input.NewInstanceID,
 		Engine:             snap.Engine,
-		MasterUsername:     username,
+		MasterUsername:     defaults.username,
 		MasterUserPassword: password,
 	}
 	if err := dbengine.Provision(ctx, m.opts.DatabaseEngine, &inst, &restoreCfg); err != nil {
@@ -1420,58 +1419,116 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 	return &out, nil
 }
 
-// restoreAttrsFromSnapshot resolves the master login, DBName, and port for an
-// instance being restored from snap, preferring the snapshot's own captured
-// metadata over a live source-instance lookup. This matches real RDS: a
-// snapshot is a self-contained point-in-time image, so a restore reflects the
-// source's shape AT SNAPSHOT TIME even if the source instance has since been
-// deleted or modified. Older snapshots taken before these fields were
-// captured fall back to a live source-instance lookup, then engine defaults.
-// requestedPort is the caller-supplied Port input, which always wins when set.
-func (m *Mock) restoreAttrsFromSnapshot(snap *rdsdriver.Snapshot, requestedPort int) (username, dbName string, port int) {
-	username = snap.MasterUsername
-	dbName = snap.DBName
-	port = requestedPort
-
-	if port == 0 {
-		port = snap.Port
-	}
-
-	if username == "" || dbName == "" || port == 0 {
-		username, dbName, port = m.fallbackRestoreAttrsFromSource(snap.InstanceID, username, dbName, port)
-	}
-
-	if port == 0 {
-		port = defaultPortFor(snap.Engine)
-	}
-
-	return username, dbName, port
+// restoreDefaults holds the per-instance attributes a snapshot restore
+// resolves: the caller's request override wins, else the snapshot's own
+// captured value, else (for snapshots predating that capture) a live
+// source-instance lookup, else an engine/global default.
+type restoreDefaults struct {
+	username      string
+	dbName        string
+	port          int
+	instanceClass string
+	storageType   string
+	iops          int
 }
 
-// fallbackRestoreAttrsFromSource fills in any still-missing username/dbName/port
-// from a live lookup of the snapshot's source instance, for snapshots taken
-// before that metadata was captured on the snapshot itself.
-func (m *Mock) fallbackRestoreAttrsFromSource(
-	sourceID, username, dbName string, port int,
-) (resolvedUsername, resolvedDBName string, resolvedPort int) {
+// restoreAttrsFromSnapshot resolves the master login, DBName, port,
+// instance class, storage type, and IOPS for an instance being restored from
+// snap, preferring the snapshot's own captured metadata over a live
+// source-instance lookup. This matches real RDS: a snapshot is a
+// self-contained point-in-time image, so a restore reflects the source's
+// shape AT SNAPSHOT TIME even if the source instance has since been deleted
+// or modified — e.g. the RestoreDBInstanceFromDBSnapshot docs default
+// DBInstanceClass to "the same DBInstanceClass as the original DB instance"
+// and Iops to "the IOPS value ... taken from the backup" when omitted. Older
+// snapshots taken before these fields were captured fall back to a live
+// source-instance lookup, then engine/global defaults. Fields explicitly set
+// on input always win.
+func (m *Mock) restoreAttrsFromSnapshot(snap *rdsdriver.Snapshot, input *rdsdriver.RestoreInstanceInput) restoreDefaults {
+	d := restoreDefaults{
+		username:      snap.MasterUsername,
+		dbName:        snap.DBName,
+		port:          input.Port,
+		instanceClass: input.InstanceClass,
+		storageType:   input.StorageType,
+		iops:          input.Iops,
+	}
+
+	d.fillFromSnapshot(snap)
+
+	if d.username == "" || d.dbName == "" || d.port == 0 || d.instanceClass == "" {
+		m.fallbackRestoreAttrsFromSource(snap.InstanceID, &d)
+	}
+
+	d.fillDefaults(snap.Engine)
+
+	return d
+}
+
+// fillFromSnapshot backfills any still-zero-valued field from the snapshot's
+// own captured metadata.
+func (d *restoreDefaults) fillFromSnapshot(snap *rdsdriver.Snapshot) {
+	if d.port == 0 {
+		d.port = snap.Port
+	}
+
+	if d.instanceClass == "" {
+		d.instanceClass = snap.InstanceClass
+	}
+
+	if d.storageType == "" {
+		d.storageType = snap.StorageType
+	}
+
+	if d.iops == 0 {
+		d.iops = snap.Iops
+	}
+}
+
+// fillDefaults backfills any still-zero-valued field with the emulator's
+// engine/global defaults, the last resort after the snapshot capture and the
+// live-source fallback have both been tried.
+func (d *restoreDefaults) fillDefaults(engine string) {
+	if d.port == 0 {
+		d.port = defaultPortFor(engine)
+	}
+
+	if d.instanceClass == "" {
+		d.instanceClass = defaultInstanceClass
+	}
+
+	if d.storageType == "" {
+		d.storageType = defaultStorageType
+	}
+}
+
+// fallbackRestoreAttrsFromSource fills in any still-missing
+// username/dbName/port/instanceClass from a live lookup of the snapshot's
+// source instance, for snapshots taken before that metadata was captured on
+// the snapshot itself. storageType/iops are NOT backfilled from a live
+// source lookup: real RDS ties both to the backup captured AT SNAPSHOT TIME,
+// and a since-modified live source is not that backup.
+func (m *Mock) fallbackRestoreAttrsFromSource(sourceID string, d *restoreDefaults) {
 	src, ok := m.instances.Get(sourceID)
 	if !ok {
-		return username, dbName, port
+		return
 	}
 
-	if username == "" {
-		username = src.MasterUsername
+	if d.username == "" {
+		d.username = src.MasterUsername
 	}
 
-	if dbName == "" {
-		dbName = src.DBName
+	if d.dbName == "" {
+		d.dbName = src.DBName
 	}
 
-	if port == 0 {
-		port = src.Port
+	if d.port == 0 {
+		d.port = src.Port
 	}
 
-	return username, dbName, port
+	if d.instanceClass == "" {
+		d.instanceClass = src.InstanceClass
+	}
 }
 
 // CreateClusterSnapshot snapshots a cluster.
@@ -1503,6 +1560,11 @@ func (m *Mock) CreateClusterSnapshot(
 		State:         rdsdriver.SnapshotAvailable,
 		CreatedAt:     m.opts.Clock.Now().UTC(),
 		Tags:          copyTags(cfg.Tags),
+		// Captured so the snapshot is a self-contained restore point: without
+		// it, RestoreClusterFromSnapshot would leave the restored cluster with
+		// the Go zero value instead of the source's actual shape.
+		AllocatedStorage: cluster.AllocatedStorage,
+		EngineMode:       cluster.EngineMode,
 	}
 
 	m.clusterSnapshots.Set(cfg.ID, snap)
@@ -1581,19 +1643,36 @@ func (m *Mock) RestoreClusterFromSnapshot(
 	// database is reachable and future members provision consistently.
 	creds := m.clusterCreds[snap.ClusterID]
 
+	// AllocatedStorage/EngineMode fall back to CreateCluster's own defaults for
+	// snapshots taken before these fields were captured, rather than leaving
+	// the restored cluster with the Go zero value.
+	allocatedStorage := snap.AllocatedStorage
+	if allocatedStorage == 0 {
+		allocatedStorage = auroraAllocatedStorage
+	}
+
+	engineMode := snap.EngineMode
+	if engineMode == "" {
+		engineMode = defaultEngineMode
+	}
+
 	region := regionctx.RegionOr(ctx, m.opts.Region)
 	cluster := rdsdriver.Cluster{
-		ID:             input.NewClusterID,
-		ARN:            clusterARN(region, m.opts.AccountID, input.NewClusterID),
-		Engine:         snap.Engine,
-		EngineVersion:  snap.EngineVersion,
-		MasterUsername: creds.user,
-		Endpoint:       endpointFor(input.NewClusterID, region, "cluster"),
-		ReaderEndpoint: endpointFor(input.NewClusterID, region, "cluster-ro"),
-		Port:           defaultPortFor(snap.Engine),
-		State:          rdsdriver.StateAvailable,
-		CreatedAt:      m.opts.Clock.Now().UTC(),
-		Tags:           copyTags(input.Tags),
+		ID:                  input.NewClusterID,
+		ARN:                 clusterARN(region, m.opts.AccountID, input.NewClusterID),
+		Engine:              snap.Engine,
+		EngineVersion:       snap.EngineVersion,
+		MasterUsername:      creds.user,
+		Endpoint:            endpointFor(input.NewClusterID, region, "cluster"),
+		ReaderEndpoint:      endpointFor(input.NewClusterID, region, "cluster-ro"),
+		Port:                defaultPortFor(snap.Engine),
+		State:               rdsdriver.StateAvailable,
+		AllocatedStorage:    allocatedStorage,
+		EngineMode:          engineMode,
+		DBClusterResourceID: resourceID("cluster-", input.NewClusterID),
+		AvailabilityZones:   availabilityZones(region),
+		CreatedAt:           m.opts.Clock.Now().UTC(),
+		Tags:                copyTags(input.Tags),
 	}
 
 	// Provision the shared database keyed and named by the new cluster id (an

--- a/providers/aws/rds/rds_test.go
+++ b/providers/aws/rds/rds_test.go
@@ -262,6 +262,114 @@ func TestRestoreFromSnapshotAfterSourceDeleted(t *testing.T) {
 	assertEqual(t, nonDefaultPort, restored.Port)
 }
 
+// TestRestoreFromSnapshotReproducesCapturedInstanceShape guards that
+// RestoreDBInstanceFromDBSnapshot reproduces the source instance's
+// DBInstanceClass, StorageType, and Iops from the snapshot rather than
+// falling back to the emulator's generic defaults. Per the AWS API docs,
+// DBInstanceClass "Default: The same DBInstanceClass as the original DB
+// instance" and Iops "If this parameter isn't specified, the IOPS value is
+// taken from the backup." Before this fix, a restore always reported
+// defaultInstanceClass/defaultStorageType/zero Iops regardless of what the
+// source instance actually had.
+func TestRestoreFromSnapshotReproducesCapturedInstanceShape(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	const nonDefaultIops = 3000
+
+	_, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{
+		ID:               "shape-src",
+		Engine:           "mysql",
+		InstanceClass:    "db.m5.large", // deliberately NOT the emulator default (db.t3.micro)
+		AllocatedStorage: 200,
+		StorageType:      "io1",
+	})
+	requireNoError(t, err)
+
+	// Iops is a ModifyDBInstance-only attribute (CreateDBInstance's own path
+	// doesn't model it separately from StorageType).
+	_, err = m.ModifyInstance(ctx, "shape-src", rdsdriver.ModifyInstanceInput{Iops: nonDefaultIops, ApplyImmediately: true})
+	requireNoError(t, err)
+
+	_, err = m.CreateSnapshot(ctx, rdsdriver.SnapshotConfig{
+		ID:         "shape-snap",
+		InstanceID: "shape-src",
+	})
+	requireNoError(t, err)
+
+	// The source instance being deleted first pins that the snapshot itself
+	// (not a live source lookup) captured the shape.
+	requireNoError(t, m.DeleteInstance(ctx, "shape-src"))
+
+	restored, err := m.RestoreInstanceFromSnapshot(ctx, rdsdriver.RestoreInstanceInput{
+		NewInstanceID: "shape-restored",
+		SnapshotID:    "shape-snap",
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "db.m5.large", restored.InstanceClass)
+	assertEqual(t, "io1", restored.StorageType)
+	assertEqual(t, nonDefaultIops, restored.Iops)
+	assertEqual(t, 200, restored.AllocatedStorage)
+
+	// An explicit restore-request override still wins over the snapshot.
+	_, err = m.CreateInstance(ctx, rdsdriver.InstanceConfig{
+		ID:               "shape-src2",
+		Engine:           "mysql",
+		InstanceClass:    "db.m5.large",
+		AllocatedStorage: 200,
+	})
+	requireNoError(t, err)
+
+	_, err = m.CreateSnapshot(ctx, rdsdriver.SnapshotConfig{ID: "shape-snap2", InstanceID: "shape-src2"})
+	requireNoError(t, err)
+
+	overridden, err := m.RestoreInstanceFromSnapshot(ctx, rdsdriver.RestoreInstanceInput{
+		NewInstanceID: "shape-restored2",
+		SnapshotID:    "shape-snap2",
+		InstanceClass: "db.r5.xlarge",
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "db.r5.xlarge", overridden.InstanceClass)
+}
+
+// TestClusterRestoreFromSnapshotReproducesCapturedShape guards that
+// RestoreDBClusterFromSnapshot reproduces the source cluster's
+// AllocatedStorage and EngineMode from the snapshot instead of leaving the
+// restored cluster with the Go zero value.
+func TestClusterRestoreFromSnapshotReproducesCapturedShape(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	const nonDefaultStorage = 123
+
+	_, err := m.CreateCluster(ctx, rdsdriver.ClusterConfig{
+		ID:               "shape-src-cluster",
+		Engine:           "aurora-postgresql",
+		EngineMode:       "serverless",
+		AllocatedStorage: nonDefaultStorage,
+	})
+	requireNoError(t, err)
+
+	_, err = m.CreateClusterSnapshot(ctx, rdsdriver.ClusterSnapshotConfig{
+		ID:        "shape-csnap",
+		ClusterID: "shape-src-cluster",
+	})
+	requireNoError(t, err)
+
+	requireNoError(t, m.DeleteCluster(ctx, "shape-src-cluster"))
+
+	restored, err := m.RestoreClusterFromSnapshot(ctx, rdsdriver.RestoreClusterInput{
+		NewClusterID: "shape-restored-cluster",
+		SnapshotID:   "shape-csnap",
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, nonDefaultStorage, restored.AllocatedStorage)
+	assertEqual(t, "serverless", restored.EngineMode)
+}
+
 func TestClusterSnapshotAndRestore(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/server/aws/rds/operations.go
+++ b/server/aws/rds/operations.go
@@ -777,6 +777,8 @@ func (h *Handler) restoreInstanceFromSnapshot(w http.ResponseWriter, r *http.Req
 		PubliclyAccessible:      formBool(form.Get("PubliclyAccessible")),
 		DeletionProtection:      formBool(form.Get("DeletionProtection")),
 		SubnetGroupName:         form.Get("DBSubnetGroupName"),
+		StorageType:             form.Get("StorageType"),
+		Iops:                    formInt(form.Get("Iops")),
 	}
 
 	inst, err := h.db.RestoreInstanceFromSnapshot(r.Context(), input)

--- a/server/aws/rds/restore_replica_inherit_sdk_roundtrip_test.go
+++ b/server/aws/rds/restore_replica_inherit_sdk_roundtrip_test.go
@@ -90,3 +90,58 @@ func TestSDKRDSRestoreFromSnapshotInheritsSourceAttributes(t *testing.T) {
 			restored.DBInstance.Endpoint)
 	}
 }
+
+// TestSDKRDSRestoreFromSnapshotInheritsInstanceClassAndStorage guards that
+// RestoreDBInstanceFromDBSnapshot reproduces the source instance's
+// DBInstanceClass and AllocatedStorage from the snapshot rather than
+// defaulting them, matching the API docs: DBInstanceClass "Default: The same
+// DBInstanceClass as the original DB instance." Before this fix, a restore
+// always came back with the emulator's generic default class (db.t3.micro)
+// regardless of what the source instance actually used.
+func TestSDKRDSRestoreFromSnapshotInheritsInstanceClassAndStorage(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("restore-class-src"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.m5.large"), // NOT the emulator default
+		AllocatedStorage:     aws.Int32(250),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	if _, err := client.CreateDBSnapshot(ctx, &awsrds.CreateDBSnapshotInput{
+		DBSnapshotIdentifier: aws.String("restore-class-snap"),
+		DBInstanceIdentifier: aws.String("restore-class-src"),
+	}); err != nil {
+		t.Fatalf("CreateDBSnapshot: %v", err)
+	}
+
+	// The snapshot must be a self-contained restore point, independent of the
+	// live source instance.
+	if _, err := client.DeleteDBInstance(ctx, &awsrds.DeleteDBInstanceInput{
+		DBInstanceIdentifier:   aws.String("restore-class-src"),
+		SkipFinalSnapshot:      aws.Bool(true),
+		DeleteAutomatedBackups: aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("DeleteDBInstance: %v", err)
+	}
+
+	restored, err := client.RestoreDBInstanceFromDBSnapshot(ctx,
+		&awsrds.RestoreDBInstanceFromDBSnapshotInput{
+			DBInstanceIdentifier: aws.String("restore-class-restored"),
+			DBSnapshotIdentifier: aws.String("restore-class-snap"),
+		})
+	if err != nil {
+		t.Fatalf("RestoreDBInstanceFromDBSnapshot: %v", err)
+	}
+
+	if got := aws.ToString(restored.DBInstance.DBInstanceClass); got != "db.m5.large" {
+		t.Fatalf("restored DBInstanceClass = %q, want db.m5.large (inherited from the snapshot)", got)
+	}
+
+	if got := aws.ToInt32(restored.DBInstance.AllocatedStorage); got != 250 {
+		t.Fatalf("restored AllocatedStorage = %d, want 250 (inherited from the snapshot)", got)
+	}
+}

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -446,6 +446,16 @@ type Snapshot struct {
 	// AWS API docs). cloudemu models only same-account/same-region copies, so
 	// this stays empty on every snapshot, including ones made by CopyDBSnapshot.
 	SourceDBSnapshotIdentifier string
+	// InstanceClass / StorageType / Iops capture the source instance's shape at
+	// snapshot time so RestoreInstanceFromSnapshot can reproduce it, matching the
+	// AWS RestoreDBInstanceFromDBSnapshot docs: DBInstanceClass "Default: The
+	// same DBInstanceClass as the original DB instance" and Iops "If this
+	// parameter isn't specified, the IOPS value is taken from the backup."
+	// Empty/zero on snapshots created before this capture existed; restore falls
+	// back to a live source-instance lookup in that case.
+	InstanceClass string
+	StorageType   string
+	Iops          int
 }
 
 // ClusterSnapshotConfig configures a cluster snapshot.
@@ -482,6 +492,14 @@ type ClusterSnapshot struct {
 	DatabaseName   string
 	CreatedAt      time.Time
 	Tags           map[string]string
+	// AllocatedStorage / EngineMode capture the source cluster's shape at
+	// snapshot time so RestoreDBClusterFromSnapshot can reproduce it instead of
+	// leaving the restored cluster with the Go zero value. Zero/empty on
+	// snapshots created before this capture existed; restore falls back to the
+	// same defaults CreateCluster applies. AllocatedStorage is RDS/Aurora-only
+	// (echoes the AWS Aurora DBCluster attribute); zero for Redshift.
+	AllocatedStorage int
+	EngineMode       string
 }
 
 // RestoreInstanceInput configures restoring an instance from a snapshot.
@@ -506,6 +524,11 @@ type RestoreInstanceInput struct {
 	// SubnetGroupName is the AWS RDS RestoreDBInstanceFromDBSnapshot
 	// DBSubnetGroupName attribute; empty means the account/region default VPC.
 	SubnetGroupName string
+	// StorageType / Iops override the snapshot-captured values when set. Real
+	// RDS docs: Iops "If this parameter isn't specified, the IOPS value is
+	// taken from the backup."
+	StorageType string
+	Iops        int
 }
 
 // RestoreClusterInput configures restoring a cluster from a snapshot.


### PR DESCRIPTION
## Bug

`RestoreDBInstanceFromDBSnapshot` built the restored instance almost entirely from scratch instead of reproducing the snapshot's captured shape. `DBInstanceClass` always fell back to the emulator's generic default (`db.t3.micro`), `StorageType` always fell back to a hardcoded default (`gp2`), and `Iops` was never restored at all (always came back `0`) — even when the source instance used a completely different class or had provisioned IOPS storage. Per the AWS API docs, `DBInstanceClass` "Default: The same DBInstanceClass as the original DB instance" and `Iops` "If this parameter isn't specified, the IOPS value is taken from the backup."

The analogous cluster path (`RestoreDBClusterFromSnapshot`) had the same class of bug for Aurora clusters: the restored cluster's `AllocatedStorage` and `EngineMode` were left at the Go zero value (`0` / `""`) instead of the source cluster's actual values, because `CreateDBClusterSnapshot` never captured them in the first place.

`RestoreDBInstanceToPointInTime` / `RestoreDBClusterToPointInTime` were already correct — they copy the full source struct — so no changes were needed there.

## Fix

- `Snapshot` now captures `InstanceClass`, `StorageType`, and `Iops` from the source instance at `CreateDBSnapshot` time.
- `ClusterSnapshot` now captures `AllocatedStorage` and `EngineMode` from the source cluster at `CreateDBClusterSnapshot` time.
- `RestoreDBInstanceFromDBSnapshot` now resolves instance class / storage type / IOPS in priority order: explicit restore-request override → the snapshot's captured value → (for snapshots taken before this capture existed) a live source-instance lookup → the emulator's engine/global default. `RestoreInstanceInput` gained `StorageType`/`Iops` override fields, matching the real API surface.
- `RestoreDBClusterFromSnapshot` now applies the snapshot's captured `AllocatedStorage`/`EngineMode` (falling back to `CreateCluster`'s own defaults for old snapshots), and also sets `DBClusterResourceID`/`AvailabilityZones` on the restored cluster, which were previously left blank.

## Evidence (black-box, real AWS CLI against `cloudemu serve`)

Before:
```
restore-db-instance-from-db-snapshot → DBInstanceClass: db.t3.micro   (source was db.m5.large)
restore-db-cluster-from-snapshot     → AllocatedStorage: null, EngineMode: null
```

After:
```
restore-db-instance-from-db-snapshot → DBInstanceClass: db.m5.large, StorageType: io1, Iops: 4000
restore-db-cluster-from-snapshot     → AllocatedStorage: 1, EngineMode: provisioned
```

An explicit override on the restore request (e.g. a caller picking a bigger instance class) still wins over the snapshot's captured value.

## Test plan

- Added `TestRestoreFromSnapshotReproducesCapturedInstanceShape` and `TestClusterRestoreFromSnapshotReproducesCapturedShape` (provider-level, would fail pre-fix).
- Added `TestSDKRDSRestoreFromSnapshotInheritsInstanceClassAndStorage` (SDK/wire-level).
- `go build ./...`, `go test ./providers/aws/... ./server/aws/... -count=1`, `-race` on the RDS + persist packages, `golangci-lint` (0 new issues), `gofmt -l` clean, `go generate ./...` (no `docs/coverage` drift), `go mod tidy` (no-op).