### PR TITLE
fix(azure): eliminate internal error-string prefix leak across all ARM handlers

### DIFF
--- a/server/azure/acr/handler.go
+++ b/server/azure/acr/handler.go
@@ -213,12 +213,12 @@ func writeErr(w http.ResponseWriter, status int, code, msg string) {
 func writeCErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
-		writeErr(w, http.StatusNotFound, "NAME_UNKNOWN", err.Error())
+		writeErr(w, http.StatusNotFound, "NAME_UNKNOWN", cerrors.Message(err))
 	case cerrors.IsInvalidArgument(err):
-		writeErr(w, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
+		writeErr(w, http.StatusBadRequest, "INVALID_REQUEST", cerrors.Message(err))
 	case cerrors.IsFailedPrecondition(err):
-		writeErr(w, http.StatusConflict, "DENIED", err.Error())
+		writeErr(w, http.StatusConflict, "DENIED", cerrors.Message(err))
 	default:
-		writeErr(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+		writeErr(w, http.StatusInternalServerError, "INTERNAL", cerrors.Message(err))
 	}
 }

--- a/server/azure/ai/dataplane.go
+++ b/server/azure/ai/dataplane.go
@@ -340,12 +340,12 @@ func codeForStatus(status int) string {
 func dpCErr(w http.ResponseWriter, err error) {
 	switch {
 	case errors.IsNotFound(err):
-		dpErr(w, http.StatusNotFound, err.Error())
+		dpErr(w, http.StatusNotFound, errors.Message(err))
 	case errors.IsInvalidArgument(err):
-		dpErr(w, http.StatusBadRequest, err.Error())
+		dpErr(w, http.StatusBadRequest, errors.Message(err))
 	case errors.IsAlreadyExists(err), errors.IsFailedPrecondition(err):
-		dpErr(w, http.StatusConflict, err.Error())
+		dpErr(w, http.StatusConflict, errors.Message(err))
 	default:
-		dpErr(w, http.StatusInternalServerError, err.Error())
+		dpErr(w, http.StatusInternalServerError, errors.Message(err))
 	}
 }

--- a/server/azure/blobstorage/handler.go
+++ b/server/azure/blobstorage/handler.go
@@ -1450,14 +1450,14 @@ func writeErr(w http.ResponseWriter, err error) {
 
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "BlobNotFound", err.Error())
+		writeError(w, http.StatusNotFound, "BlobNotFound", cerrors.Message(err))
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "ContainerAlreadyExists", err.Error())
+		writeError(w, http.StatusConflict, "ContainerAlreadyExists", cerrors.Message(err))
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "InvalidInput", err.Error())
+		writeError(w, http.StatusBadRequest, "InvalidInput", cerrors.Message(err))
 	case cerrors.IsFailedPrecondition(err):
-		writeError(w, http.StatusConflict, "Conflict", err.Error())
+		writeError(w, http.StatusConflict, "Conflict", cerrors.Message(err))
 	default:
-		writeError(w, http.StatusInternalServerError, "InternalError", err.Error())
+		writeError(w, http.StatusInternalServerError, "InternalError", cerrors.Message(err))
 	}
 }

--- a/server/azure/cosmosdb/handler.go
+++ b/server/azure/cosmosdb/handler.go
@@ -1425,14 +1425,14 @@ func writeError(w http.ResponseWriter, status int, code, msg string) {
 func writeErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "NotFound", err.Error())
+		writeError(w, http.StatusNotFound, "NotFound", cerrors.Message(err))
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "Conflict", err.Error())
+		writeError(w, http.StatusConflict, "Conflict", cerrors.Message(err))
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "BadRequest", err.Error())
+		writeError(w, http.StatusBadRequest, "BadRequest", cerrors.Message(err))
 	case cerrors.IsFailedPrecondition(err):
-		writeError(w, http.StatusPreconditionFailed, "PreconditionFailed", err.Error())
+		writeError(w, http.StatusPreconditionFailed, "PreconditionFailed", cerrors.Message(err))
 	default:
-		writeError(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+		writeError(w, http.StatusInternalServerError, "InternalServerError", cerrors.Message(err))
 	}
 }

--- a/server/azure/databricks/dataplane.go
+++ b/server/azure/databricks/dataplane.go
@@ -226,15 +226,15 @@ func dpError(w http.ResponseWriter, status int, code, msg string) {
 func dpWriteErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
-		dpError(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST", err.Error())
+		dpError(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST", cerrors.Message(err))
 	case cerrors.IsAlreadyExists(err):
-		dpError(w, http.StatusConflict, "RESOURCE_ALREADY_EXISTS", err.Error())
+		dpError(w, http.StatusConflict, "RESOURCE_ALREADY_EXISTS", cerrors.Message(err))
 	case cerrors.IsInvalidArgument(err):
-		dpError(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", err.Error())
+		dpError(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", cerrors.Message(err))
 	case cerrors.IsFailedPrecondition(err):
-		dpError(w, http.StatusBadRequest, "INVALID_STATE", err.Error())
+		dpError(w, http.StatusBadRequest, "INVALID_STATE", cerrors.Message(err))
 	default:
-		dpError(w, http.StatusInternalServerError, "INTERNAL_ERROR", err.Error())
+		dpError(w, http.StatusInternalServerError, "INTERNAL_ERROR", cerrors.Message(err))
 	}
 }
 

--- a/server/azure/dns/operations.go
+++ b/server/azure/dns/operations.go
@@ -186,7 +186,7 @@ func (h *Handler) createOrUpdateRecordSet(w http.ResponseWriter, r *http.Request
 			// HTTP 412, not the 409 azurearm.WriteCErr maps FailedPrecondition to
 			// for other ARM resources — real Azure DNS, and the armdns SDK's
 			// poller, expect 412 specifically for a stale/mismatched etag.
-			azurearm.WriteError(w, http.StatusPreconditionFailed, "PreconditionFailed", err.Error())
+			azurearm.WriteError(w, http.StatusPreconditionFailed, "PreconditionFailed", cerrors.Message(err))
 			return
 		}
 
@@ -374,7 +374,7 @@ func (h *Handler) deleteRecordSet(w http.ResponseWriter, r *http.Request, rp *az
 		if cerrors.IsFailedPrecondition(derr) {
 			// See createOrUpdateRecordSet: an etag precondition failure is 412,
 			// not the 409 azurearm.WriteCErr maps FailedPrecondition to.
-			azurearm.WriteError(w, http.StatusPreconditionFailed, "PreconditionFailed", derr.Error())
+			azurearm.WriteError(w, http.StatusPreconditionFailed, "PreconditionFailed", cerrors.Message(derr))
 			return
 		}
 

--- a/server/azure/iam/error_prefix_test.go
+++ b/server/azure/iam/error_prefix_test.go
@@ -1,0 +1,57 @@
+package iam_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	azureiam "github.com/stackshy/cloudemu/v2/providers/azure/iam"
+	"github.com/stackshy/cloudemu/v2/server/azure/iam"
+)
+
+// TestDeleteRoleDefinitionNotFoundMessageHasNoInternalPrefix guards the local
+// writeCErr helper in operations.go: deleting a role definition that does not
+// exist must surface a clean message, not the internal "NotFound: " taxonomy
+// prefix that err.Error() on a *cerrors.Error carries.
+func TestDeleteRoleDefinitionNotFoundMessageHasNoInternalPrefix(t *testing.T) {
+	drv := azureiam.New(config.NewOptions())
+	h := iam.New(drv)
+
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+
+	url := ts.URL + testScope + "/providers/Microsoft.Authorization/roleDefinitions/missing-role-id"
+
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status=%d want %d", resp.StatusCode, http.StatusNotFound)
+	}
+
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if strings.Contains(body.Error.Message, "NotFound:") {
+		t.Errorf("message=%q leaks internal error-code prefix", body.Error.Message)
+	}
+}

--- a/server/azure/iam/operations.go
+++ b/server/azure/iam/operations.go
@@ -351,7 +351,7 @@ func (h *Handler) createRoleAssignment(
 	})
 	if err != nil {
 		if cerrors.IsAlreadyExists(err) {
-			writeARMError(w, http.StatusConflict, "RoleAssignmentExists", err.Error())
+			writeARMError(w, http.StatusConflict, "RoleAssignmentExists", cerrors.Message(err))
 			return
 		}
 
@@ -604,12 +604,12 @@ func decodeJSONBody(w http.ResponseWriter, r *http.Request, v any) bool {
 func writeCErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
-		writeARMError(w, http.StatusNotFound, "ResourceNotFound", err.Error())
+		writeARMError(w, http.StatusNotFound, "ResourceNotFound", cerrors.Message(err))
 	case cerrors.IsAlreadyExists(err):
-		writeARMError(w, http.StatusConflict, "ResourceAlreadyExists", err.Error())
+		writeARMError(w, http.StatusConflict, "ResourceAlreadyExists", cerrors.Message(err))
 	case cerrors.IsInvalidArgument(err):
-		writeARMError(w, http.StatusBadRequest, "InvalidArgument", err.Error())
+		writeARMError(w, http.StatusBadRequest, "InvalidArgument", cerrors.Message(err))
 	default:
-		writeARMError(w, http.StatusInternalServerError, "InternalError", err.Error())
+		writeARMError(w, http.StatusInternalServerError, "InternalError", cerrors.Message(err))
 	}
 }

--- a/server/azure/keyvault/certs_operations.go
+++ b/server/azure/keyvault/certs_operations.go
@@ -29,15 +29,15 @@ func writeJSONStatus(w http.ResponseWriter, status int, v any) {
 func writeCertErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
-		writeErr(w, http.StatusNotFound, "CertificateNotFound", err.Error())
+		writeErr(w, http.StatusNotFound, "CertificateNotFound", cerrors.Message(err))
 	case cerrors.IsAlreadyExists(err) && strings.Contains(err.Error(), "deleted but recoverable"):
-		writeErrInner(w, http.StatusConflict, "Conflict", err.Error(), "ObjectIsDeletedButRecoverable")
+		writeErrInner(w, http.StatusConflict, "Conflict", cerrors.Message(err), "ObjectIsDeletedButRecoverable")
 	case cerrors.IsAlreadyExists(err):
-		writeErr(w, http.StatusConflict, "Conflict", err.Error())
+		writeErr(w, http.StatusConflict, "Conflict", cerrors.Message(err))
 	case cerrors.IsInvalidArgument(err):
-		writeErr(w, http.StatusBadRequest, "BadParameter", err.Error())
+		writeErr(w, http.StatusBadRequest, "BadParameter", cerrors.Message(err))
 	default:
-		writeErr(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+		writeErr(w, http.StatusInternalServerError, "InternalServerError", cerrors.Message(err))
 	}
 }
 

--- a/server/azure/keyvault/error_prefix_test.go
+++ b/server/azure/keyvault/error_prefix_test.go
@@ -1,0 +1,63 @@
+package keyvault_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	azurekeyvault "github.com/stackshy/cloudemu/v2/providers/azure/keyvault"
+	"github.com/stackshy/cloudemu/v2/server/azure/keyvault"
+)
+
+// TestGetSecretNotFoundMessageHasNoInternalPrefix guards the data-plane
+// writeCErr helper in handler.go: fetching a secret that does not exist must
+// surface a clean message, not the internal "NotFound: " taxonomy prefix that
+// err.Error() on a *cerrors.Error carries.
+func TestGetSecretNotFoundMessageHasNoInternalPrefix(t *testing.T) {
+	mock := azurekeyvault.New(config.NewOptions())
+	h := keyvault.New(mock)
+
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+
+	url := ts.URL + "/myvault/secrets/missing-secret?api-version=7.4"
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer fake-token")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status=%d want %d", resp.StatusCode, http.StatusNotFound)
+	}
+
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if body.Error.Code != "SecretNotFound" {
+		t.Errorf("code=%q want SecretNotFound", body.Error.Code)
+	}
+
+	if strings.Contains(body.Error.Message, "NotFound:") {
+		t.Errorf("message=%q leaks internal error-code prefix", body.Error.Message)
+	}
+}

--- a/server/azure/keyvault/handler.go
+++ b/server/azure/keyvault/handler.go
@@ -316,22 +316,22 @@ func writeErr(w http.ResponseWriter, status int, code, msg string) {
 func writeCErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
-		writeErr(w, http.StatusNotFound, "SecretNotFound", err.Error())
+		writeErr(w, http.StatusNotFound, "SecretNotFound", cerrors.Message(err))
 	case cerrors.IsAlreadyExists(err) && strings.Contains(err.Error(), "deleted but recoverable"):
 		// Real Key Vault answers a set/create against a soft-deleted name with
 		// 409 Conflict and inner error code ObjectIsDeletedButRecoverable.
-		writeErrInner(w, http.StatusConflict, "Conflict", err.Error(), "ObjectIsDeletedButRecoverable")
+		writeErrInner(w, http.StatusConflict, "Conflict", cerrors.Message(err), "ObjectIsDeletedButRecoverable")
 	case cerrors.IsAlreadyExists(err):
-		writeErr(w, http.StatusConflict, "Conflict", err.Error())
+		writeErr(w, http.StatusConflict, "Conflict", cerrors.Message(err))
 	case cerrors.IsInvalidArgument(err):
-		writeErr(w, http.StatusBadRequest, "BadParameter", err.Error())
+		writeErr(w, http.StatusBadRequest, "BadParameter", cerrors.Message(err))
 	case cerrors.IsPermissionDenied(err):
 		// A disabled, not-yet-valid or expired secret version: real Key Vault
 		// answers get with 403 Forbidden rather than falling back to an older
 		// usable version.
-		writeErr(w, http.StatusForbidden, "Forbidden", err.Error())
+		writeErr(w, http.StatusForbidden, "Forbidden", cerrors.Message(err))
 	default:
-		writeErr(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+		writeErr(w, http.StatusInternalServerError, "InternalServerError", cerrors.Message(err))
 	}
 }
 

--- a/server/azure/keyvault/keys_handler.go
+++ b/server/azure/keyvault/keys_handler.go
@@ -260,18 +260,18 @@ func (h *KeysHandler) routeDeleted(w http.ResponseWriter, r *http.Request, tail 
 func writeKeyErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
-		writeErr(w, http.StatusNotFound, "KeyNotFound", err.Error())
+		writeErr(w, http.StatusNotFound, "KeyNotFound", cerrors.Message(err))
 	case cerrors.IsAlreadyExists(err) && strings.Contains(err.Error(), "deleted but recoverable"):
-		writeErrInner(w, http.StatusConflict, "Conflict", err.Error(), "ObjectIsDeletedButRecoverable")
+		writeErrInner(w, http.StatusConflict, "Conflict", cerrors.Message(err), "ObjectIsDeletedButRecoverable")
 	case cerrors.IsAlreadyExists(err):
-		writeErr(w, http.StatusConflict, "Conflict", err.Error())
+		writeErr(w, http.StatusConflict, "Conflict", cerrors.Message(err))
 	case cerrors.IsInvalidArgument(err):
-		writeErr(w, http.StatusBadRequest, "BadParameter", err.Error())
+		writeErr(w, http.StatusBadRequest, "BadParameter", cerrors.Message(err))
 	case cerrors.IsPermissionDenied(err):
-		writeErr(w, http.StatusForbidden, "Forbidden", err.Error())
+		writeErr(w, http.StatusForbidden, "Forbidden", cerrors.Message(err))
 	case cerrors.IsFailedPrecondition(err):
-		writeErr(w, http.StatusForbidden, "Forbidden", err.Error())
+		writeErr(w, http.StatusForbidden, "Forbidden", cerrors.Message(err))
 	default:
-		writeErr(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+		writeErr(w, http.StatusInternalServerError, "InternalServerError", cerrors.Message(err))
 	}
 }

--- a/server/azure/kusto/dataplane_mgmt.go
+++ b/server/azure/kusto/dataplane_mgmt.go
@@ -267,10 +267,10 @@ func unquoteName(name string) string {
 func writeMgmtError(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
-		writeDataError(w, http.StatusNotFound, "EntityNotFound", err.Error())
+		writeDataError(w, http.StatusNotFound, "EntityNotFound", cerrors.Message(err))
 	case cerrors.IsAlreadyExists(err):
-		writeDataError(w, http.StatusConflict, "EntityAlreadyExists", err.Error())
+		writeDataError(w, http.StatusConflict, "EntityAlreadyExists", cerrors.Message(err))
 	default:
-		writeDataError(w, http.StatusBadRequest, "BadRequest", err.Error())
+		writeDataError(w, http.StatusBadRequest, "BadRequest", cerrors.Message(err))
 	}
 }

--- a/server/azure/notificationhubs/registrations.go
+++ b/server/azure/notificationhubs/registrations.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
 )
 
@@ -175,7 +176,7 @@ func (*RegistrationHandler) upsertRegistration(
 
 	stored, err := az.CreateRegistration(r.Context(), c.key, reg)
 	if err != nil {
-		writeRegError(w, http.StatusBadRequest, err.Error())
+		writeRegError(w, http.StatusBadRequest, cerrors.Message(err))
 		return
 	}
 
@@ -192,7 +193,7 @@ func (*RegistrationHandler) getRegistration(
 ) {
 	reg, err := az.GetRegistration(r.Context(), c.key, c.regID)
 	if err != nil {
-		writeRegError(w, http.StatusNotFound, err.Error())
+		writeRegError(w, http.StatusNotFound, cerrors.Message(err))
 		return
 	}
 
@@ -203,7 +204,7 @@ func (*RegistrationHandler) deleteRegistration(
 	w http.ResponseWriter, r *http.Request, az notifdriver.AzureNotificationHubs, c regContext,
 ) {
 	if err := az.DeleteRegistration(r.Context(), c.key, c.regID); err != nil {
-		writeRegError(w, http.StatusNotFound, err.Error())
+		writeRegError(w, http.StatusNotFound, cerrors.Message(err))
 		return
 	}
 
@@ -215,7 +216,7 @@ func (*RegistrationHandler) listRegistrations(
 ) {
 	regs, err := az.ListRegistrations(r.Context(), c.key)
 	if err != nil {
-		writeRegError(w, http.StatusInternalServerError, err.Error())
+		writeRegError(w, http.StatusInternalServerError, cerrors.Message(err))
 		return
 	}
 

--- a/server/azure/queue/handler.go
+++ b/server/azure/queue/handler.go
@@ -555,7 +555,7 @@ func (h *Handler) deleteMessage(w http.ResponseWriter, r *http.Request, queue st
 		// The queue was already resolved, so a NotFound here means the message or
 		// its pop receipt did not match — Azure returns 404 MessageNotFound.
 		if cerrors.IsNotFound(err) {
-			writeError(w, http.StatusNotFound, "MessageNotFound", err.Error())
+			writeError(w, http.StatusNotFound, "MessageNotFound", cerrors.Message(err))
 			return
 		}
 
@@ -607,7 +607,7 @@ func (h *Handler) updateMessage(w http.ResponseWriter, r *http.Request, queue, m
 		// The queue was already resolved, so a NotFound here means the message
 		// or its pop receipt did not match.
 		if cerrors.IsNotFound(err) {
-			writeError(w, http.StatusNotFound, "MessageNotFound", err.Error())
+			writeError(w, http.StatusNotFound, "MessageNotFound", cerrors.Message(err))
 			return
 		}
 
@@ -809,12 +809,12 @@ func writeQueryParameterRangeError(w http.ResponseWriter, name, value string, mi
 func writeErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
-		writeError(w, http.StatusNotFound, "QueueNotFound", err.Error())
+		writeError(w, http.StatusNotFound, "QueueNotFound", cerrors.Message(err))
 	case cerrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict, "QueueAlreadyExists", err.Error())
+		writeError(w, http.StatusConflict, "QueueAlreadyExists", cerrors.Message(err))
 	case cerrors.IsInvalidArgument(err):
-		writeError(w, http.StatusBadRequest, "InvalidInput", err.Error())
+		writeError(w, http.StatusBadRequest, "InvalidInput", cerrors.Message(err))
 	default:
-		writeError(w, http.StatusInternalServerError, "InternalError", err.Error())
+		writeError(w, http.StatusInternalServerError, "InternalError", cerrors.Message(err))
 	}
 }

--- a/server/azure/search/dataplane.go
+++ b/server/azure/search/dataplane.go
@@ -280,13 +280,13 @@ func dpMethodNotAllowed(w http.ResponseWriter) {
 func dpCErr(w http.ResponseWriter, err error) {
 	switch {
 	case errors.IsNotFound(err):
-		dpErr(w, http.StatusNotFound, err.Error())
+		dpErr(w, http.StatusNotFound, errors.Message(err))
 	case errors.IsInvalidArgument(err):
-		dpErr(w, http.StatusBadRequest, err.Error())
+		dpErr(w, http.StatusBadRequest, errors.Message(err))
 	case errors.IsAlreadyExists(err), errors.IsFailedPrecondition(err):
-		dpErr(w, http.StatusConflict, err.Error())
+		dpErr(w, http.StatusConflict, errors.Message(err))
 	default:
-		dpErr(w, http.StatusInternalServerError, err.Error())
+		dpErr(w, http.StatusInternalServerError, errors.Message(err))
 	}
 }
 

--- a/server/azure/servicebus/dataplane.go
+++ b/server/azure/servicebus/dataplane.go
@@ -703,7 +703,7 @@ func writeMessage(w http.ResponseWriter, msg *mqdriver.Message, status int) {
 func writeLockError(w http.ResponseWriter, err error) {
 	if cerrors.IsNotFound(err) {
 		// A lock that no longer exists maps to Gone in the Service Bus REST plane.
-		azurearm.WriteError(w, http.StatusGone, "MessageLockLost", err.Error())
+		azurearm.WriteError(w, http.StatusGone, "MessageLockLost", cerrors.Message(err))
 		return
 	}
 

--- a/server/azure/sql/operations.go
+++ b/server/azure/sql/operations.go
@@ -271,11 +271,11 @@ func (h *Handler) writeDatabaseNotFound(
 	// Server exists: a Copy/PointInTimeRestore whose sourceDatabaseId is set
 	// resolved the source before the pool check, so the NotFound is the source.
 	if cfg != nil && cfg.SourceDatabaseID != "" {
-		azurearm.WriteError(w, http.StatusNotFound, "SourceDatabaseNotFound", err.Error())
+		azurearm.WriteError(w, http.StatusNotFound, "SourceDatabaseNotFound", cerrors.Message(err))
 		return
 	}
 
-	azurearm.WriteError(w, http.StatusBadRequest, "TargetElasticPoolDoesNotExist", err.Error())
+	azurearm.WriteError(w, http.StatusBadRequest, "TargetElasticPoolDoesNotExist", cerrors.Message(err))
 }
 
 // mergeDatabaseFields overlays the non-empty fields of cfg (and body's

--- a/server/azure/tablestorage/batch.go
+++ b/server/azure/tablestorage/batch.go
@@ -309,7 +309,7 @@ func writeBatchFailure(w http.ResponseWriter, err error) {
 	status, code := mapErr(err)
 
 	cs := buildChangeset(func(cw *multipart.Writer) {
-		writeOpPart(cw, opErrorResponse(idx, status, code, err.Error()))
+		writeOpPart(cw, opErrorResponse(idx, status, code, cerrors.Message(err)))
 	})
 
 	writeBatchEnvelope(w, cs)

--- a/server/azure/tablestorage/batch.go
+++ b/server/azure/tablestorage/batch.go
@@ -41,7 +41,7 @@ func (h *Handler) batch(w http.ResponseWriter, r *http.Request) {
 
 	ops, table, err := parseBatch(w, r)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "InvalidInput", err.Error())
+		writeError(w, http.StatusBadRequest, "InvalidInput", cerrors.Message(err))
 		return
 	}
 

--- a/server/azure/tablestorage/error_prefix_test.go
+++ b/server/azure/tablestorage/error_prefix_test.go
@@ -1,0 +1,57 @@
+package tablestorage_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestBatchParseErrorHasNoInternalPrefix guards the $batch parse-failure path
+// (batch.go): a malformed batch must surface the plain OData error message, not
+// the internal cerrors code-taxonomy prefix ("InvalidArgument:"). aztables and
+// other clients read the message verbatim, so a leaked prefix is a real
+// divergence from Azure Table storage.
+func TestBatchParseErrorHasNoInternalPrefix(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{TableStorage: cloudP.TableStorage})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	// multipart/mixed without a boundary -> parseBatch returns a *cerrors.Error
+	// ("missing multipart boundary"), which flows through writeError at batch.go:44.
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/$batch", strings.NewReader("irrelevant body"))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "multipart/mixed")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	got := string(body)
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", resp.StatusCode, got)
+	}
+	for _, prefix := range []string{"InvalidArgument:", "NotFound:", "FailedPrecondition:", "AlreadyExists:"} {
+		if strings.Contains(got, prefix) {
+			t.Fatalf("batch parse error leaked internal prefix %q: %s", prefix, got)
+		}
+	}
+	// Sanity: the real message content still reaches the client.
+	if !strings.Contains(got, "boundary") {
+		t.Fatalf("expected the boundary error message in the response, got: %s", got)
+	}
+}

--- a/server/azure/tablestorage/handler.go
+++ b/server/azure/tablestorage/handler.go
@@ -161,7 +161,7 @@ func (h *Handler) createTable(w http.ResponseWriter, r *http.Request) {
 		// A duplicate table is TableAlreadyExists, distinct from the generic
 		// EntityAlreadyExists that a duplicate entity insert reports.
 		if cerrors.IsAlreadyExists(err) {
-			writeError(w, http.StatusConflict, "TableAlreadyExists", err.Error())
+			writeError(w, http.StatusConflict, "TableAlreadyExists", cerrors.Message(err))
 			return
 		}
 

--- a/server/azure/tablestorage/helpers.go
+++ b/server/azure/tablestorage/helpers.go
@@ -197,7 +197,7 @@ func writeError(w http.ResponseWriter, status int, code, msg string) {
 // writeErr maps CloudEmu canonical errors to Azure Table HTTP errors.
 func writeErr(w http.ResponseWriter, err error) {
 	status, code := mapErr(err)
-	writeError(w, status, code, err.Error())
+	writeError(w, status, code, cerrors.Message(err))
 }
 
 // mapErr maps a CloudEmu canonical error to its Azure Table HTTP status + code.

--- a/server/azure/virtualmachines/error_prefix_test.go
+++ b/server/azure/virtualmachines/error_prefix_test.go
@@ -1,0 +1,83 @@
+package virtualmachines_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	azurecompute "github.com/stackshy/cloudemu/v2/providers/azure/virtualmachines"
+	azurevnet "github.com/stackshy/cloudemu/v2/providers/azure/vnet"
+	"github.com/stackshy/cloudemu/v2/server/azure/virtualmachines"
+)
+
+// TestCreateVMMissingNICMessageHasNoInternalPrefix guards the NetworkInterfaceNotFound
+// error path in instances.go: creating a VM whose networkProfile references a NIC that
+// does not exist must surface a clean message, not the internal "InvalidArgument: "
+// taxonomy prefix that err.Error() on a *cerrors.Error carries.
+func TestCreateVMMissingNICMessageHasNoInternalPrefix(t *testing.T) {
+	opts := config.NewOptions(config.WithRegion("eastus"))
+	compute := azurecompute.New(opts)
+	net := azurevnet.New(opts)
+
+	h := virtualmachines.New(compute, net)
+
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+
+	url := ts.URL + "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines/vm1"
+
+	body := `{
+		"location": "eastus",
+		"properties": {
+			"hardwareProfile": {"vmSize": "Standard_D2s_v3"},
+			"storageProfile": {
+				"imageReference": {"publisher": "Canonical", "offer": "UbuntuServer", "sku": "22.04-LTS", "version": "latest"}
+			},
+			"osProfile": {"computerName": "vm1", "adminUsername": "azureuser"},
+			"networkProfile": {
+				"networkInterfaces": [
+					{"id": "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/networkInterfaces/missing-nic"}
+				]
+			}
+		}
+	}`
+
+	req, err := http.NewRequest(http.MethodPut, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	var respBody struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if respBody.Error.Code != "NetworkInterfaceNotFound" {
+		t.Errorf("code=%q want NetworkInterfaceNotFound", respBody.Error.Code)
+	}
+
+	if strings.Contains(respBody.Error.Message, "InvalidArgument:") {
+		t.Errorf("message=%q leaks internal error-code prefix", respBody.Error.Message)
+	}
+}

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -98,7 +98,7 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 	// silently succeeding.
 	nicRefs, err := h.validateNICs(r.Context(), req.Properties.NetworkProfile)
 	if err != nil {
-		azurearm.WriteError(w, http.StatusBadRequest, "NetworkInterfaceNotFound", err.Error())
+		azurearm.WriteError(w, http.StatusBadRequest, "NetworkInterfaceNotFound", cerrors.Message(err))
 		return
 	}
 

--- a/server/azure/vnet/error_prefix_test.go
+++ b/server/azure/vnet/error_prefix_test.go
@@ -1,0 +1,80 @@
+package vnet_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	azurevnet "github.com/stackshy/cloudemu/v2/providers/azure/vnet"
+	"github.com/stackshy/cloudemu/v2/server/azure/vnet"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// TestDeleteInUseNICMessageHasNoInternalPrefix guards the
+// InUseNetworkInterfaceCannotBeDeleted error path in network_interface.go:
+// deleting a NIC still attached to a VM must surface a clean message, not the
+// internal "FailedPrecondition: " taxonomy prefix that err.Error() on a
+// *cerrors.Error carries.
+func TestDeleteInUseNICMessageHasNoInternalPrefix(t *testing.T) {
+	opts := config.NewOptions(config.WithRegion("eastus"))
+	mock := azurevnet.New(opts)
+
+	ctx := context.Background()
+
+	if _, err := mock.CreateOrUpdateNetworkInterface(ctx, "rg-1", "nic-1", netdriver.AzureNICConfig{
+		Location:  "eastus",
+		IPConfigs: []netdriver.AzureIPConfig{{Name: "ipconfig1", Primary: true}},
+	}); err != nil {
+		t.Fatalf("create nic: %v", err)
+	}
+
+	if err := mock.AttachNetworkInterface(ctx, "rg-1", "nic-1",
+		"/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines/vm-1"); err != nil {
+		t.Fatalf("attach nic: %v", err)
+	}
+
+	h := vnet.New(mock)
+
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+
+	url := ts.URL + "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/networkInterfaces/nic-1"
+
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if body.Error.Code != "InUseNetworkInterfaceCannotBeDeleted" {
+		t.Errorf("code=%q want InUseNetworkInterfaceCannotBeDeleted", body.Error.Code)
+	}
+
+	if strings.Contains(body.Error.Message, "FailedPrecondition:") {
+		t.Errorf("message=%q leaks internal error-code prefix", body.Error.Message)
+	}
+}

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -371,7 +371,7 @@ func (h *Handler) createVNet(w http.ResponseWriter, r *http.Request, rp azurearm
 		// answers 400 InUseSubnetCannotBeDeleted, not the generic 409 WriteCErr
 		// would emit for FailedPrecondition.
 		if cerrors.IsFailedPrecondition(err) {
-			azurearm.WriteError(w, http.StatusBadRequest, "InUseSubnetCannotBeDeleted", err.Error())
+			azurearm.WriteError(w, http.StatusBadRequest, "InUseSubnetCannotBeDeleted", cerrors.Message(err))
 			return
 		}
 
@@ -1545,7 +1545,7 @@ func (h *Handler) deletePublicIP(w http.ResponseWriter, r *http.Request, rp azur
 		// A public IP still bound to a NIC/NAT gateway: ARM answers 400 with
 		// this specific code, not the generic 409 WriteCErr would emit.
 		if cerrors.IsFailedPrecondition(err) {
-			azurearm.WriteError(w, http.StatusBadRequest, "PublicIPAddressCannotBeDeleted", err.Error())
+			azurearm.WriteError(w, http.StatusBadRequest, "PublicIPAddressCannotBeDeleted", cerrors.Message(err))
 			return
 		}
 

--- a/server/azure/vnet/network_interface.go
+++ b/server/azure/vnet/network_interface.go
@@ -154,7 +154,7 @@ func (h *Handler) createNIC(w http.ResponseWriter, r *http.Request, rp azurearm.
 	ipConfigs, err := h.buildIPConfigs(r.Context(), rp.ResourceGroup, rp.ResourceName, req.Properties.IPConfigurations)
 	if err != nil {
 		if cerrors.IsFailedPrecondition(err) {
-			azurearm.WriteError(w, http.StatusBadRequest, "PublicIPAddressCannotBeAssignedToMultipleIpConfigs", err.Error())
+			azurearm.WriteError(w, http.StatusBadRequest, "PublicIPAddressCannotBeAssignedToMultipleIpConfigs", cerrors.Message(err))
 			return
 		}
 
@@ -218,7 +218,7 @@ func (*Handler) deleteNIC(w http.ResponseWriter, r *http.Request, rp azurearm.Re
 		// A NIC attached to a VM: ARM answers 400 with this specific code, which
 		// armnetwork clients switch on — not the generic 409 WriteCErr would emit.
 		if cerrors.IsFailedPrecondition(err) {
-			azurearm.WriteError(w, http.StatusBadRequest, "InUseNetworkInterfaceCannotBeDeleted", err.Error())
+			azurearm.WriteError(w, http.StatusBadRequest, "InUseNetworkInterfaceCannotBeDeleted", cerrors.Message(err))
 			return
 		}
 

--- a/server/wire/azurearm/azurearm.go
+++ b/server/wire/azurearm/azurearm.go
@@ -155,26 +155,28 @@ func WriteError(w http.ResponseWriter, status int, code, msg string) {
 // Azure returns when a child resource (e.g. a database under a server) is
 // created while its parent does not exist.
 func WriteParentNotFound(w http.ResponseWriter, err error) {
-	WriteError(w, http.StatusNotFound, "ParentResourceNotFound", err.Error())
+	WriteError(w, http.StatusNotFound, "ParentResourceNotFound", cerrors.Message(err))
 }
 
 // WriteCErr maps a CloudEmu canonical error to the matching ARM HTTP status
 // and code. Used by handlers so error mapping is consistent across services.
 func WriteCErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		WriteError(w, http.StatusNotFound, "ResourceNotFound", err.Error())
+		WriteError(w, http.StatusNotFound, "ResourceNotFound", msg)
 	case cerrors.IsAlreadyExists(err):
-		WriteError(w, http.StatusConflict, "Conflict", err.Error())
+		WriteError(w, http.StatusConflict, "Conflict", msg)
 	case cerrors.IsInvalidArgument(err):
-		WriteError(w, http.StatusBadRequest, "InvalidParameter", err.Error())
+		WriteError(w, http.StatusBadRequest, "InvalidParameter", msg)
 	case cerrors.IsFailedPrecondition(err):
-		WriteError(w, http.StatusConflict, "PreconditionFailed", err.Error())
+		WriteError(w, http.StatusConflict, "PreconditionFailed", msg)
 	case cerrors.GetCode(err) == cerrors.ResourceExhausted:
 		// e.g. a subnet with no free private IP — ARM answers 400, not 500.
-		WriteError(w, http.StatusBadRequest, "InvalidParameter", err.Error())
+		WriteError(w, http.StatusBadRequest, "InvalidParameter", msg)
 	default:
-		WriteError(w, http.StatusInternalServerError, "InternalError", err.Error())
+		WriteError(w, http.StatusInternalServerError, "InternalError", msg)
 	}
 }
 

--- a/server/wire/azurearm/azurearm_test.go
+++ b/server/wire/azurearm/azurearm_test.go
@@ -2,6 +2,7 @@ package azurearm_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -127,6 +128,91 @@ func TestWriteCErrMapping(t *testing.T) {
 				t.Errorf("body=%q does not contain %q", rec.Body.String(), c.code)
 			}
 		})
+	}
+}
+
+// TestWriteCErrMessageHasNoInternalPrefix guards against the internal
+// code-taxonomy prefix (e.g. "NotFound: ") leaking into the ARM error
+// envelope's message field. Real Azure never prefixes messages with the
+// cloudemu error taxonomy; only the `code` field should carry that
+// information.
+func TestWriteCErrMessageHasNoInternalPrefix(t *testing.T) {
+	cases := []struct {
+		name      string
+		err       error
+		wantCode  string
+		wantMsg   string
+		wantHTTP  int
+		badPrefix string
+	}{
+		{"NotFound", cerrors.New(cerrors.NotFound, "vm 'foo' not found"), "ResourceNotFound", "vm 'foo' not found", http.StatusNotFound, "NotFound:"},
+		{"AlreadyExists", cerrors.New(cerrors.AlreadyExists, "storage account 'bar' already exists"), "Conflict", "storage account 'bar' already exists", http.StatusConflict, "AlreadyExists:"},
+		{"InvalidArgument", cerrors.New(cerrors.InvalidArgument, "invalid sku"), "InvalidParameter", "invalid sku", http.StatusBadRequest, "InvalidArgument:"},
+		{"FailedPrecondition", cerrors.New(cerrors.FailedPrecondition, "resource in use"), "PreconditionFailed", "resource in use", http.StatusConflict, "FailedPrecondition:"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			azurearm.WriteCErr(rec, c.err)
+
+			if rec.Code != c.wantHTTP {
+				t.Errorf("status=%d want %d", rec.Code, c.wantHTTP)
+			}
+
+			var body struct {
+				Error struct {
+					Code    string `json:"code"`
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+
+			if body.Error.Code != c.wantCode {
+				t.Errorf("code=%q want %q", body.Error.Code, c.wantCode)
+			}
+
+			if body.Error.Message != c.wantMsg {
+				t.Errorf("message=%q want %q", body.Error.Message, c.wantMsg)
+			}
+
+			if strings.Contains(body.Error.Message, c.badPrefix) {
+				t.Errorf("message=%q leaks internal error-code prefix %q", body.Error.Message, c.badPrefix)
+			}
+		})
+	}
+}
+
+// TestWriteParentNotFoundMessageHasNoInternalPrefix guards WriteParentNotFound
+// the same way.
+func TestWriteParentNotFoundMessageHasNoInternalPrefix(t *testing.T) {
+	rec := httptest.NewRecorder()
+	azurearm.WriteParentNotFound(rec, cerrors.New(cerrors.NotFound, "resource group 'rg1' not found"))
+
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if body.Error.Code != "ParentResourceNotFound" {
+		t.Errorf("code=%q want ParentResourceNotFound", body.Error.Code)
+	}
+
+	if body.Error.Message != "resource group 'rg1' not found" {
+		t.Errorf("message=%q want clean message", body.Error.Message)
+	}
+
+	if strings.Contains(body.Error.Message, "NotFound:") {
+		t.Errorf("message=%q leaks internal error-code prefix", body.Error.Message)
 	}
 }
 


### PR DESCRIPTION
## The bug

The shared Azure ARM error codec (`server/wire/azurearm`) wrote `err.Error()` into the ARM error envelope's `message` field in `WriteCErr` and `WriteParentNotFound`. For a `*cerrors.Error`, `err.Error()` bakes in the internal code-taxonomy prefix (e.g. `"NotFound: vm 'foo' not found"`, `"AlreadyExists: ..."`). Real Azure never prefixes error messages this way — only the `code` field carries that information. `cerrors.Message` (which strips the prefix) had zero usages under `server/azure`.

Because `WriteCErr`/`WriteParentNotFound` are the shared error-dispatch helpers used by every Azure ARM handler, the leak was repo-wide across the 36 service packages that call them (acr, ai, aks, cache, containerapps, containerinstances, cosmosaccount, cosmosdb, cosmospostgresql, costmanagement, databricks, disks, dns, eventgrid, functions, images, keyvault, loadbalancer, loganalytics, managedcassandra, managedidentity, monitor, mysqlflex, notificationhubs, postgresflex, resourcegraph, resourcegroups, search, servicebus, snapshots, sql, sqlvirtualmachine, sshpublickeys, storageaccount, virtualmachines, vnet).

**A follow-up review found the shared-codec fix alone was incomplete**: several handlers have their own local `err.Error()`-based error mappers (a `writeCErr`/`writeErr`-style switch on `cerrors.IsNotFound`/`IsAlreadyExists`/etc.) that bypass the shared codec entirely, plus a few data-plane handlers with the same bug in a different envelope shape. Those still leaked the prefix. This PR closes that gap.

## The fix

`WriteCErr`/`WriteParentNotFound` in `server/wire/azurearm/azurearm.go` build the message with `cerrors.Message(err)` instead of `err.Error()`.

Additionally, every local ARM/data-plane error mapper that duplicated this switch-on-cerrors-code pattern now also uses `cerrors.Message(err)` instead of `err.Error()`:

- ARM local mappers: `iam/operations.go` (writeCErr helper, used by roleDefinitions/roleAssignments CRUD, plus the RoleAssignmentExists conflict path), `virtualmachines/instances.go` (NetworkInterfaceNotFound), `sql/operations.go` (SourceDatabaseNotFound / TargetElasticPoolDoesNotExist), `vnet/handler.go` (InUseSubnetCannotBeDeleted, PublicIPAddressCannotBeDeleted), `vnet/network_interface.go` (PublicIPAddressCannotBeAssignedToMultipleIpConfigs, InUseNetworkInterfaceCannotBeDeleted), `dns/operations.go` (etag PreconditionFailed on record-set PUT/DELETE), `notificationhubs/registrations.go`, `acr/handler.go`, `kusto/dataplane_mgmt.go`, `servicebus/dataplane.go` (MessageLockLost).
- Data-plane mappers (different envelope, same bug class): `keyvault/handler.go`, `keyvault/certs_operations.go`, `keyvault/keys_handler.go`, `blobstorage/handler.go`, `cosmosdb/handler.go`, `queue/handler.go`, `tablestorage/handler.go`/`batch.go`/`helpers.go`, `databricks/dataplane.go`, `search/dataplane.go`, `ai/dataplane.go`.

A full grep of every `err.Error()` call site under `server/azure/` was reviewed one-by-one to confirm this list is exhaustive. Everything left as `err.Error()` is either a plain JSON/body-decode error (no cerrors taxonomy involved), a substring-match branch condition (not a wire message), or a local sentinel error type (`vnet/subnet_validate.go`'s `azurearmSubnetErr`) whose `.Error()` is already a bare, non-cerrors message.

`code` field and HTTP status are untouched everywhere — only the human-readable `message` text changes.

## Tests

- `server/wire/azurearm/azurearm_test.go`: `TestWriteCErrMessageHasNoInternalPrefix`, `TestWriteParentNotFoundMessageHasNoInternalPrefix` (shared codec).
- New focused regression tests for the local-mapper fixes, each verified to fail before the fix and pass after: `server/azure/iam/error_prefix_test.go` (DELETE missing roleDefinition), `server/azure/virtualmachines/error_prefix_test.go` (VM create referencing a missing NIC), `server/azure/vnet/error_prefix_test.go` (delete a NIC still attached to a VM), `server/azure/keyvault/error_prefix_test.go` (GET missing secret, data-plane).

## Black-box verification

Built the binary and ran `serve -providers=azure` against real ARM + data-plane paths.

- IAM: `DELETE roleDefinitions/deadbeef` → `{"code":"ResourceNotFound","message":"role \"deadbeef\" not found"}` (was `"NotFound: role \"deadbeef\" not found"`)
- VM create with a `networkProfile` referencing a missing NIC → `{"code":"NetworkInterfaceNotFound","message":"networkProfile references network interface \"missing-nic\" which does not exist"}` (was prefixed `"InvalidArgument: "`)
- Key Vault data-plane `GET` missing secret → `{"code":"SecretNotFound","message":"secret \"missing-secret\" not found"}` (was prefixed `"NotFound: "`)
- Blob Storage `GET` missing blob → `<Code>BlobNotFound</Code><Message>container "mystorageacct" not found</Message>` (was prefixed `"NotFound: "`)
- vnet: delete a NIC still attached to a VM → `{"code":"InUseNetworkInterfaceCannotBeDeleted","message":"network interface \"nic-1\" cannot be deleted because it is attached to \"...\""}` (was prefixed `"FailedPrecondition: "`)

`code`/status unchanged in every case — only the message text lost its prefix.

## Gates

- `go build ./...`
- `go test ./server/azure/... ./server/wire/azurearm/... -race -count=1` — all green
- `go test ./providers/azure/... -count=1` — all green
- `gofmt -l` — clean on changed files
- `golangci-lint run --new-from-rev=origin/development ./server/wire/azurearm/... ./server/azure/...` — 0 new issues
- `go generate ./...` — no `docs/coverage` diff
- `go mod tidy` — no-op
