### PR TITLE
fix(ssm): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/ssm/ssm.go
+++ b/providers/aws/ssm/ssm.go
@@ -304,21 +304,23 @@ func validateParameterName(name string) error {
 	return nil
 }
 
-// PutParameter creates a new parameter or, when Overwrite is set, appends a new
-// version to an existing one.
+// validatePutParameter checks the tier-independent PutParameter inputs (name,
+// Overwrite/Tags conflict, Type, and AllowedPattern) up front, before any store
+// lookup or tier resolution. Value size is validated separately once the tier
+// is known.
 //
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
-func (m *Mock) PutParameter(ctx context.Context, cfg driver.PutConfig) (int64, string, error) {
+//nolint:gocritic // hugeParam: mirrors the PutParameter signature.
+func validatePutParameter(cfg driver.PutConfig) error {
 	if cfg.Name == "" {
-		return 0, "", errors.New(errors.InvalidArgument, "parameter name is required")
+		return errors.New(errors.InvalidArgument, "parameter name is required")
 	}
 
 	if err := validateParameterName(cfg.Name); err != nil {
-		return 0, "", err
+		return err
 	}
 
 	if cfg.Overwrite && len(cfg.Tags) > 0 {
-		return 0, "", driver.ErrTagsWithOverwrite
+		return driver.ErrTagsWithOverwrite
 	}
 
 	// An explicitly set Type must be one AWS recognizes; an unrecognized value
@@ -326,12 +328,24 @@ func (m *Mock) PutParameter(ctx context.Context, cfg driver.PutConfig) (int64, s
 	// omitted Type is allowed here: it defaults to String on create and retains
 	// the existing type on Overwrite.
 	if cfg.Type != "" && !validType(cfg.Type) {
-		return 0, "", driver.ErrUnsupportedType
+		return driver.ErrUnsupportedType
 	}
 
 	// AllowedPattern (if set) must be a valid regexp and the Value must match it.
 	// This is independent of the parameter type, so validate it up front.
 	if err := validateAllowedPattern(cfg.AllowedPattern, cfg.Value); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// PutParameter creates a new parameter or, when Overwrite is set, appends a new
+// version to an existing one.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) PutParameter(ctx context.Context, cfg driver.PutConfig) (int64, string, error) {
+	if err := validatePutParameter(cfg); err != nil {
 		return 0, "", err
 	}
 

--- a/providers/aws/ssm/ssm.go
+++ b/providers/aws/ssm/ssm.go
@@ -93,7 +93,10 @@ func (m *Mock) sealValue(ctx context.Context, effectiveType, keyID, plaintext st
 
 	blob, err := m.kmsCrypto.Encrypt(ctx, keyID, []byte(plaintext))
 	if err != nil {
-		return "", err
+		// Whatever KMS failure prevented sealing (disabled/deleted key, etc.),
+		// real Parameter Store surfaces it as the distinct InvalidKeyId client
+		// error, not a 500 that leaks the underlying KMS message.
+		return "", driver.ErrInvalidKeyID
 	}
 
 	return base64.StdEncoding.EncodeToString(blob), nil
@@ -114,7 +117,11 @@ func (m *Mock) revealValue(ctx context.Context, v *version, withDecryption bool)
 
 	plaintext, err := m.kmsCrypto.Decrypt(ctx, blob)
 	if err != nil {
-		return "", err
+		// Mirrors sealValue: a disabled/deleted key (or any other KMS unwrap
+		// failure) is reported as InvalidKeyId, matching real Parameter Store's
+		// documented GetParameter/GetParameters/GetParametersByPath/
+		// GetParameterHistory error shape instead of a generic 500.
+		return "", driver.ErrInvalidKeyID
 	}
 
 	return string(plaintext), nil
@@ -232,6 +239,71 @@ func resolveOverwriteType(existing *paramData, requested string) (string, error)
 	return "", driver.ErrTypeMismatch
 }
 
+// Parameter tiers, matching AWS SSM Parameter Store.
+const (
+	tierStandard    = "Standard"
+	tierAdvanced    = "Advanced"
+	tierIntelligent = "Intelligent-Tiering"
+)
+
+// resolveOverwriteTier decides the tier of a new version appended to an
+// existing parameter. A tier isn't required when updating: omitting it
+// retains the existing tier, rather than resetting to Standard. Explicitly
+// requesting Standard on a parameter that is currently Advanced is rejected —
+// real Parameter Store never lets an Advanced parameter revert to Standard.
+func resolveOverwriteTier(existing *paramData, requested string) (string, error) {
+	existingTier := existing.tier
+	if existingTier == "" {
+		existingTier = tierStandard
+	}
+
+	if requested == "" {
+		return existingTier, nil
+	}
+
+	if existingTier == tierAdvanced && requested == tierStandard {
+		return "", driver.ErrCannotRevertTier
+	}
+
+	return requested, nil
+}
+
+// maxValueBytes is the value-size limit for tier: 8 KB for Advanced (and for
+// Intelligent-Tiering, which self-selects up to the Advanced ceiling), 4 KB
+// for Standard (the default when Tier is omitted).
+func maxValueBytes(tier string) int {
+	if tier == tierAdvanced || tier == tierIntelligent {
+		return driver.AdvancedTierMaxValueBytes
+	}
+
+	return driver.StandardTierMaxValueBytes
+}
+
+// validateValueSize rejects a Value that exceeds tier's size limit, matching
+// real Parameter Store's ValidationException instead of silently accepting
+// (or silently truncating) an over-limit value.
+func validateValueSize(tier, value string) error {
+	if len(value) > maxValueBytes(tier) {
+		return driver.ErrValueTooLarge
+	}
+
+	return nil
+}
+
+// validateParameterName rejects a Name whose leading path segment (after
+// stripping an optional leading "/") is "aws" or "ssm" (case-insensitive).
+// Real Parameter Store reserves that namespace for AWS-published parameters
+// and rejects a customer PutParameter there with ValidationException.
+func validateParameterName(name string) error {
+	lower := strings.ToLower(strings.TrimPrefix(name, "/"))
+
+	if strings.HasPrefix(lower, "aws") || strings.HasPrefix(lower, "ssm") {
+		return driver.ErrReservedNamePrefix
+	}
+
+	return nil
+}
+
 // PutParameter creates a new parameter or, when Overwrite is set, appends a new
 // version to an existing one.
 //
@@ -239,6 +311,10 @@ func resolveOverwriteType(existing *paramData, requested string) (string, error)
 func (m *Mock) PutParameter(ctx context.Context, cfg driver.PutConfig) (int64, string, error) {
 	if cfg.Name == "" {
 		return 0, "", errors.New(errors.InvalidArgument, "parameter name is required")
+	}
+
+	if err := validateParameterName(cfg.Name); err != nil {
+		return 0, "", err
 	}
 
 	if cfg.Overwrite && len(cfg.Tags) > 0 {
@@ -259,11 +335,6 @@ func (m *Mock) PutParameter(ctx context.Context, cfg driver.PutConfig) (int64, s
 		return 0, "", err
 	}
 
-	tier := cfg.Tier
-	if tier == "" {
-		tier = "Standard"
-	}
-
 	dataType := cfg.DataType
 	if dataType == "" {
 		dataType = "text"
@@ -272,7 +343,16 @@ func (m *Mock) PutParameter(ctx context.Context, cfg driver.PutConfig) (int64, s
 	now := m.now()
 
 	if existing, ok := m.params.Get(cfg.Name); ok {
-		return m.overwriteParameter(ctx, existing, &cfg, tier, dataType, now)
+		return m.overwriteParameter(ctx, existing, &cfg, dataType, now)
+	}
+
+	tier := cfg.Tier
+	if tier == "" {
+		tier = tierStandard
+	}
+
+	if err := validateValueSize(tier, cfg.Value); err != nil {
+		return 0, "", err
 	}
 
 	return m.createParameter(ctx, &cfg, tier, dataType, now)
@@ -282,7 +362,7 @@ func (m *Mock) PutParameter(ctx context.Context, cfg driver.PutConfig) (int64, s
 // Overwrite path). Overwrite without the flag is rejected, and changing the
 // type is rejected via resolveOverwriteType.
 func (m *Mock) overwriteParameter(
-	ctx context.Context, existing *paramData, cfg *driver.PutConfig, tier, dataType, now string,
+	ctx context.Context, existing *paramData, cfg *driver.PutConfig, dataType, now string,
 ) (ver int64, assignedTier string, err error) {
 	existing.mu.Lock()
 	defer existing.mu.Unlock()
@@ -295,6 +375,15 @@ func (m *Mock) overwriteParameter(
 	newType, err := resolveOverwriteType(existing, cfg.Type)
 	if err != nil {
 		return 0, "", err
+	}
+
+	tier, err := resolveOverwriteTier(existing, cfg.Tier)
+	if err != nil {
+		return 0, "", err
+	}
+
+	if sizeErr := validateValueSize(tier, cfg.Value); sizeErr != nil {
+		return 0, "", sizeErr
 	}
 
 	keyID, err := resolveKeyID(newType, cfg.KeyID)
@@ -442,12 +531,16 @@ func (m *Mock) toParameter(
 	}, nil
 }
 
+// selectorFor renders the SDK's Selector response field: empty when no
+// version/label was requested, otherwise ":<version-or-label>" — real
+// Parameter Store includes the colon (e.g. ":2" or ":prod"), not just the
+// bare version/label text.
 func selectorFor(requested, base string) string {
 	if requested == base {
 		return ""
 	}
 
-	return strings.TrimPrefix(requested, base+":")
+	return ":" + strings.TrimPrefix(requested, base+":")
 }
 
 // GetParameter retrieves a single parameter by name, honoring an optional
@@ -523,6 +616,10 @@ func (m *Mock) GetParameters(
 
 		found = append(found, p)
 	}
+
+	// Real GetParameters always returns Parameters in alphabetical order by
+	// name, regardless of the order Names was requested in.
+	sort.Slice(found, func(i, j int) bool { return found[i].Name < found[j].Name })
 
 	return found, invalid, nil
 }

--- a/providers/aws/ssm/ssm_test.go
+++ b/providers/aws/ssm/ssm_test.go
@@ -376,3 +376,239 @@ func TestDeleteParameters(t *testing.T) {
 		t.Fatalf("invalid = %v, want [/d/missing]", invalid)
 	}
 }
+
+// TestGetParameterSelectorIncludesColon covers a real-user e2e finding: real
+// Parameter Store's GetParameter/GetParameters Selector field is ":<version>"
+// or ":<label>" (colon included), not the bare version/label text.
+func TestGetParameterSelectorIncludesColon(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{Name: "/sel/p", Value: "v1", Type: driver.TypeString}); err != nil {
+		t.Fatalf("Put v1: %v", err)
+	}
+
+	if _, _, err := m.LabelParameterVersion(ctx, "/sel/p", 1, []string{"prod"}); err != nil {
+		t.Fatalf("LabelParameterVersion: %v", err)
+	}
+
+	byVersion, err := m.GetParameter(ctx, "/sel/p:1", false)
+	if err != nil {
+		t.Fatalf("GetParameter(:1): %v", err)
+	}
+
+	if byVersion.Selector != ":1" {
+		t.Fatalf("Selector = %q, want %q", byVersion.Selector, ":1")
+	}
+
+	byLabel, err := m.GetParameter(ctx, "/sel/p:prod", false)
+	if err != nil {
+		t.Fatalf("GetParameter(:prod): %v", err)
+	}
+
+	if byLabel.Selector != ":prod" {
+		t.Fatalf("Selector = %q, want %q", byLabel.Selector, ":prod")
+	}
+
+	latest, err := m.GetParameter(ctx, "/sel/p", false)
+	if err != nil {
+		t.Fatalf("GetParameter(latest): %v", err)
+	}
+
+	if latest.Selector != "" {
+		t.Fatalf("Selector = %q, want empty for an unselectored read", latest.Selector)
+	}
+}
+
+// TestGetParametersAlphabeticalOrder covers a real-user e2e finding: real
+// GetParameters always returns results in alphabetical order by name,
+// regardless of the order Names was requested in.
+func TestGetParametersAlphabeticalOrder(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"/zzz/p", "/aaa/p", "/mid/p"} {
+		if _, _, err := m.PutParameter(ctx, driver.PutConfig{Name: name, Value: "v", Type: driver.TypeString}); err != nil {
+			t.Fatalf("Put %s: %v", name, err)
+		}
+	}
+
+	found, _, err := m.GetParameters(ctx, []string{"/zzz/p", "/aaa/p", "/mid/p"}, false)
+	if err != nil {
+		t.Fatalf("GetParameters: %v", err)
+	}
+
+	got := paramNamesOf(found)
+	want := []string{"/aaa/p", "/mid/p", "/zzz/p"}
+
+	if len(got) != len(want) {
+		t.Fatalf("names = %v, want %v", got, want)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("names = %v, want %v (alphabetical)", got, want)
+		}
+	}
+}
+
+// TestPutParameterValueSizeLimitByTier covers a real-user e2e finding: real
+// Parameter Store rejects a Value over 4 KB on the (default) Standard tier and
+// over 8 KB on the Advanced tier with ValidationException, instead of
+// silently accepting an over-limit value.
+func TestPutParameterValueSizeLimitByTier(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	standardOversized := make([]byte, driver.StandardTierMaxValueBytes+1)
+	advancedOversized := make([]byte, driver.AdvancedTierMaxValueBytes+1)
+	advancedFits := make([]byte, driver.StandardTierMaxValueBytes+1) // over Standard, under Advanced
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/size/std", Value: string(standardOversized), Type: driver.TypeString,
+	}); !errors.Is(err, driver.ErrValueTooLarge) {
+		t.Fatalf("Standard-tier oversized Put: want ErrValueTooLarge, got %v", err)
+	}
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/size/adv", Value: string(advancedFits), Type: driver.TypeString, Tier: "Advanced",
+	}); err != nil {
+		t.Fatalf("Advanced-tier Put within limit: %v", err)
+	}
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/size/adv2", Value: string(advancedOversized), Type: driver.TypeString, Tier: "Advanced",
+	}); !errors.Is(err, driver.ErrValueTooLarge) {
+		t.Fatalf("Advanced-tier oversized Put: want ErrValueTooLarge, got %v", err)
+	}
+}
+
+// TestPutParameterReservedNamePrefixRejected covers a real-user e2e finding:
+// real Parameter Store rejects a customer parameter name whose leading path
+// segment is "aws" or "ssm" (case-insensitive) — that namespace is reserved
+// for AWS-published parameters.
+func TestPutParameterReservedNamePrefixRejected(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"aws.reserved", "/aws/reserved", "SSM.reserved", "/Ssm/reserved"} {
+		if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+			Name: name, Value: "v", Type: driver.TypeString,
+		}); !errors.Is(err, driver.ErrReservedNamePrefix) {
+			t.Fatalf("PutParameter(%q): want ErrReservedNamePrefix, got %v", name, err)
+		}
+	}
+
+	// A name that merely contains "aws"/"ssm" past the leading segment is fine.
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/app/aws-region", Value: "v", Type: driver.TypeString,
+	}); err != nil {
+		t.Fatalf("PutParameter(/app/aws-region): %v", err)
+	}
+}
+
+// TestPutOverwriteRetainsTierWhenOmittedAndRejectsDowngrade covers a
+// real-user e2e finding: real Parameter Store retains an Advanced parameter's
+// tier across an Overwrite that omits Tier (mirroring Type retention), and
+// never lets an Advanced parameter silently revert to Standard.
+func TestPutOverwriteRetainsTierWhenOmittedAndRejectsDowngrade(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	if _, tier, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/tier/p", Value: "v1", Type: driver.TypeString, Tier: "Advanced",
+	}); err != nil || tier != "Advanced" {
+		t.Fatalf("create: tier=%q err=%v, want Advanced, nil", tier, err)
+	}
+
+	// Overwrite without Tier must retain Advanced, not reset to Standard.
+	if _, tier, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/tier/p", Value: "v2", Type: driver.TypeString, Overwrite: true,
+	}); err != nil || tier != "Advanced" {
+		t.Fatalf("overwrite (no Tier): tier=%q err=%v, want Advanced, nil", tier, err)
+	}
+
+	// Explicitly requesting Standard on a currently-Advanced parameter is rejected.
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/tier/p", Value: "v3", Type: driver.TypeString, Tier: "Standard", Overwrite: true,
+	}); !errors.Is(err, driver.ErrCannotRevertTier) {
+		t.Fatalf("overwrite (explicit Standard downgrade): want ErrCannotRevertTier, got %v", err)
+	}
+
+	// The tier must still be Advanced after the rejected downgrade attempt.
+	got, err := m.GetParameter(ctx, "/tier/p", false)
+	if err != nil {
+		t.Fatalf("GetParameter: %v", err)
+	}
+
+	if got.Value != "v2" || got.Version != 2 {
+		t.Fatalf("after rejected downgrade: value=%q version=%d, want v2/2 (unchanged)", got.Value, got.Version)
+	}
+}
+
+// toggleKMSCrypto is a minimal reversible KMSCrypto fake: Encrypt/Decrypt are
+// identity transforms (so a value sealed while working can be unsealed later),
+// but both fail once fail is set — modeling a key that becomes disabled after
+// a value was already sealed under it.
+type toggleKMSCrypto struct {
+	fail bool
+}
+
+func (k *toggleKMSCrypto) Encrypt(_ context.Context, _ string, plaintext []byte) ([]byte, error) {
+	if k.fail {
+		return nil, cerrors.New(cerrors.FailedPrecondition, "key is disabled")
+	}
+
+	return plaintext, nil
+}
+
+func (k *toggleKMSCrypto) Decrypt(_ context.Context, ciphertext []byte) ([]byte, error) {
+	if k.fail {
+		return nil, cerrors.New(cerrors.FailedPrecondition, "key is disabled")
+	}
+
+	return ciphertext, nil
+}
+
+// TestSecureStringUnusableKMSKeyIsInvalidKeyID covers a real-user e2e finding:
+// when the KMS key behind a SecureString can't be used, real Parameter Store
+// surfaces the distinct InvalidKeyId error on PutParameter and on a decrypting
+// GetParameter/GetParameterHistory read — not a generic internal error
+// carrying the raw KMS failure message.
+func TestSecureStringUnusableKMSKeyIsInvalidKeyID(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	kms := &toggleKMSCrypto{}
+	m.SetKMSCrypto(kms)
+
+	// Seal successfully while the key still works.
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/secure/p", Value: "s1", Type: driver.TypeSecureString,
+	}); err != nil {
+		t.Fatalf("PutParameter(create): %v", err)
+	}
+
+	// The key becomes unusable (e.g. disabled) after the value was sealed.
+	kms.fail = true
+
+	if _, err := m.GetParameter(ctx, "/secure/p", true); !errors.Is(err, driver.ErrInvalidKeyID) {
+		t.Fatalf("GetParameter(WithDecryption) with disabled key: want ErrInvalidKeyID, got %v", err)
+	}
+
+	// Reading without decryption is unaffected — it never calls into KMS.
+	if _, err := m.GetParameter(ctx, "/secure/p", false); err != nil {
+		t.Fatalf("GetParameter(no decryption) with disabled key: %v", err)
+	}
+
+	if _, err := m.GetParameterHistory(ctx, "/secure/p", true); !errors.Is(err, driver.ErrInvalidKeyID) {
+		t.Fatalf("GetParameterHistory(WithDecryption) with disabled key: want ErrInvalidKeyID, got %v", err)
+	}
+
+	// A brand-new SecureString can't even be sealed while the key is unusable.
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{
+		Name: "/secure/new", Value: "s2", Type: driver.TypeSecureString,
+	}); !errors.Is(err, driver.ErrInvalidKeyID) {
+		t.Fatalf("PutParameter with disabled key: want ErrInvalidKeyID, got %v", err)
+	}
+}

--- a/server/aws/ssm/invalid_keyid_test.go
+++ b/server/aws/ssm/invalid_keyid_test.go
@@ -118,6 +118,90 @@ func TestSDKGetParameterDisabledKMSKeyIsInvalidKeyID(t *testing.T) {
 	}
 }
 
+// TestSDKGetParametersBatchDisabledKMSKeyIsInvalidKeyID is a real-user e2e
+// regression: the batch GetParameters read of a SecureString whose KMS key has
+// been disabled must surface the distinct InvalidKeyId client error (400), the
+// same as the single GetParameter path, not a generic 500 leaking the KMS
+// failure message.
+func TestSDKGetParametersBatchDisabledKMSKeyIsInvalidKeyID(t *testing.T) {
+	ssmClient, kmsClient := newSSMAndKMSClients(t)
+	ctx := context.Background()
+
+	key, err := kmsClient.CreateKey(ctx, &awskms.CreateKeyInput{})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	keyID := aws.ToString(key.KeyMetadata.KeyId)
+
+	if _, err := ssmClient.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name:  aws.String("/secure/batch"),
+		Value: aws.String("s1"),
+		Type:  ssmtypes.ParameterTypeSecureString,
+		KeyId: aws.String(keyID),
+	}); err != nil {
+		t.Fatalf("PutParameter: %v", err)
+	}
+
+	if _, err := kmsClient.DisableKey(ctx, &awskms.DisableKeyInput{KeyId: aws.String(keyID)}); err != nil {
+		t.Fatalf("DisableKey: %v", err)
+	}
+
+	_, err = ssmClient.GetParameters(ctx, &awsssm.GetParametersInput{
+		Names:          []string{"/secure/batch"},
+		WithDecryption: aws.Bool(true),
+	})
+	if err == nil {
+		t.Fatal("GetParameters(WithDecryption) with disabled key: expected error, got nil")
+	}
+
+	if code := apiErrorCode(t, err); code != "InvalidKeyId" {
+		t.Fatalf("error code = %q, want InvalidKeyId", code)
+	}
+}
+
+// TestSDKGetParametersByPathDisabledKMSKeyIsInvalidKeyID is a real-user e2e
+// regression: a recursive GetParametersByPath read that decrypts a SecureString
+// whose KMS key has been disabled must surface the distinct InvalidKeyId client
+// error (400), not a generic 500 leaking the KMS failure message.
+func TestSDKGetParametersByPathDisabledKMSKeyIsInvalidKeyID(t *testing.T) {
+	ssmClient, kmsClient := newSSMAndKMSClients(t)
+	ctx := context.Background()
+
+	key, err := kmsClient.CreateKey(ctx, &awskms.CreateKeyInput{})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	keyID := aws.ToString(key.KeyMetadata.KeyId)
+
+	if _, err := ssmClient.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name:  aws.String("/secure/tree/leaf"),
+		Value: aws.String("s1"),
+		Type:  ssmtypes.ParameterTypeSecureString,
+		KeyId: aws.String(keyID),
+	}); err != nil {
+		t.Fatalf("PutParameter: %v", err)
+	}
+
+	if _, err := kmsClient.DisableKey(ctx, &awskms.DisableKeyInput{KeyId: aws.String(keyID)}); err != nil {
+		t.Fatalf("DisableKey: %v", err)
+	}
+
+	_, err = ssmClient.GetParametersByPath(ctx, &awsssm.GetParametersByPathInput{
+		Path:           aws.String("/secure/tree"),
+		Recursive:      aws.Bool(true),
+		WithDecryption: aws.Bool(true),
+	})
+	if err == nil {
+		t.Fatal("GetParametersByPath(WithDecryption) with disabled key: expected error, got nil")
+	}
+
+	if code := apiErrorCode(t, err); code != "InvalidKeyId" {
+		t.Fatalf("error code = %q, want InvalidKeyId", code)
+	}
+}
+
 // TestSDKListTagsForResourceStableOrder is a real-user e2e regression: real
 // ListTagsForResource returns a stable tag order across repeated reads of
 // unchanged state. Before the fix, ranging the tags map directly (unsorted)

--- a/server/aws/ssm/invalid_keyid_test.go
+++ b/server/aws/ssm/invalid_keyid_test.go
@@ -1,0 +1,180 @@
+package ssm_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	awsssm "github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/aws/smithy-go"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// newSSMAndKMSClients wires SSM and KMS from the same provider instance, so
+// SSM's SecureString values are sealed through real KMS envelope encryption
+// (matching how cmd/cloudemu wires them) — needed to exercise a KMS key
+// becoming unusable underneath an already-created SecureString parameter.
+func newSSMAndKMSClients(t *testing.T) (*awsssm.Client, *awskms.Client) {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{SSM: cloud.SSM, KMS: cloud.KMS})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	ssmClient := awsssm.NewFromConfig(cfg, func(o *awsssm.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+	kmsClient := awskms.NewFromConfig(cfg, func(o *awskms.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+
+	return ssmClient, kmsClient
+}
+
+func apiErrorCode(t *testing.T, err error) string {
+	t.Helper()
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not an API error: %v", err)
+	}
+
+	return apiErr.ErrorCode()
+}
+
+// TestSDKGetParameterDisabledKMSKeyIsInvalidKeyID is a real-user e2e
+// regression: decrypting a SecureString whose KMS key has been disabled must
+// surface the distinct InvalidKeyId client error (400), not a generic 500
+// InternalServerError leaking the KMS failure message.
+func TestSDKGetParameterDisabledKMSKeyIsInvalidKeyID(t *testing.T) {
+	ssmClient, kmsClient := newSSMAndKMSClients(t)
+	ctx := context.Background()
+
+	key, err := kmsClient.CreateKey(ctx, &awskms.CreateKeyInput{})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	keyID := aws.ToString(key.KeyMetadata.KeyId)
+
+	if _, err := ssmClient.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name:  aws.String("/secure/p"),
+		Value: aws.String("s1"),
+		Type:  ssmtypes.ParameterTypeSecureString,
+		KeyId: aws.String(keyID),
+	}); err != nil {
+		t.Fatalf("PutParameter: %v", err)
+	}
+
+	if _, err := kmsClient.DisableKey(ctx, &awskms.DisableKeyInput{KeyId: aws.String(keyID)}); err != nil {
+		t.Fatalf("DisableKey: %v", err)
+	}
+
+	_, err = ssmClient.GetParameter(ctx, &awsssm.GetParameterInput{
+		Name:           aws.String("/secure/p"),
+		WithDecryption: aws.Bool(true),
+	})
+	if err == nil {
+		t.Fatal("GetParameter(WithDecryption) with disabled key: expected error, got nil")
+	}
+
+	if code := apiErrorCode(t, err); code != "InvalidKeyId" {
+		t.Fatalf("error code = %q, want InvalidKeyId", code)
+	}
+
+	// PutParameter against a new SecureString with the disabled key fails the
+	// same way.
+	_, err = ssmClient.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name:  aws.String("/secure/new"),
+		Value: aws.String("s2"),
+		Type:  ssmtypes.ParameterTypeSecureString,
+		KeyId: aws.String(keyID),
+	})
+	if err == nil {
+		t.Fatal("PutParameter with disabled key: expected error, got nil")
+	}
+
+	if code := apiErrorCode(t, err); code != "InvalidKeyId" {
+		t.Fatalf("error code = %q, want InvalidKeyId", code)
+	}
+}
+
+// TestSDKListTagsForResourceStableOrder is a real-user e2e regression: real
+// ListTagsForResource returns a stable tag order across repeated reads of
+// unchanged state. Before the fix, ranging the tags map directly (unsorted)
+// made the order vary from call to call.
+func TestSDKListTagsForResourceStableOrder(t *testing.T) {
+	client := newSSMClient(t)
+	ctx := context.Background()
+
+	if _, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name:  aws.String("/app/multitag"),
+		Value: aws.String("v"),
+		Type:  ssmtypes.ParameterTypeString,
+		Tags: []ssmtypes.Tag{
+			{Key: aws.String("A"), Value: aws.String("1")},
+			{Key: aws.String("B"), Value: aws.String("2")},
+			{Key: aws.String("C"), Value: aws.String("3")},
+			{Key: aws.String("D"), Value: aws.String("4")},
+			{Key: aws.String("E"), Value: aws.String("5")},
+		},
+	}); err != nil {
+		t.Fatalf("PutParameter: %v", err)
+	}
+
+	var first []string
+
+	for i := 0; i < 5; i++ {
+		out, err := client.ListTagsForResource(ctx, &awsssm.ListTagsForResourceInput{
+			ResourceType: ssmtypes.ResourceTypeForTaggingParameter,
+			ResourceId:   aws.String("/app/multitag"),
+		})
+		if err != nil {
+			t.Fatalf("ListTagsForResource: %v", err)
+		}
+
+		keys := make([]string, 0, len(out.TagList))
+		for _, tag := range out.TagList {
+			keys = append(keys, aws.ToString(tag.Key))
+		}
+
+		if i == 0 {
+			first = keys
+
+			if !sort.StringsAreSorted(first) {
+				t.Fatalf("TagList order = %v, want alphabetically sorted", first)
+			}
+
+			continue
+		}
+
+		if len(keys) != len(first) {
+			t.Fatalf("call %d: TagList = %v, want %v", i, keys, first)
+		}
+
+		for j := range keys {
+			if keys[j] != first[j] {
+				t.Fatalf("call %d: TagList = %v, want stable order %v", i, keys, first)
+			}
+		}
+	}
+}

--- a/server/aws/ssm/operations.go
+++ b/server/aws/ssm/operations.go
@@ -51,6 +51,13 @@ func (h *Handler) putParameter(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// A KeyId that can't be used to encrypt (disabled/deleted key, etc.) is
+		// the distinct InvalidKeyId, not a generic ValidationException or 500.
+		if errors.Is(err, ssmdriver.ErrInvalidKeyID) {
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidKeyId", cerrors.Message(err))
+			return
+		}
+
 		writeErr(w, err)
 		return
 	}
@@ -72,6 +79,14 @@ func (h *Handler) getParameter(w http.ResponseWriter, r *http.Request) {
 			wire.WriteJSONError(w, http.StatusBadRequest, "ParameterVersionNotFound", cerrors.Message(err))
 			return
 		}
+
+		// Decrypting through an unusable KMS key (disabled/deleted) is the
+		// distinct InvalidKeyId, not a 500 that leaks the KMS failure message.
+		if errors.Is(err, ssmdriver.ErrInvalidKeyID) {
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidKeyId", cerrors.Message(err))
+			return
+		}
+
 		writeErr(w, err)
 		return
 	}
@@ -87,6 +102,11 @@ func (h *Handler) getParameters(w http.ResponseWriter, r *http.Request) {
 
 	found, invalid, err := h.store.GetParameters(r.Context(), req.Names, req.WithDecryption)
 	if err != nil {
+		if errors.Is(err, ssmdriver.ErrInvalidKeyID) {
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidKeyId", cerrors.Message(err))
+			return
+		}
+
 		writeErr(w, err)
 		return
 	}
@@ -121,6 +141,11 @@ func (h *Handler) getParametersByPath(w http.ResponseWriter, r *http.Request) {
 
 		if errors.Is(err, ssmdriver.ErrInvalidFilterOption) {
 			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidFilterOption", cerrors.Message(err))
+			return
+		}
+
+		if errors.Is(err, ssmdriver.ErrInvalidKeyID) {
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidKeyId", cerrors.Message(err))
 			return
 		}
 
@@ -234,6 +259,11 @@ func (h *Handler) getParameterHistory(w http.ResponseWriter, r *http.Request) {
 
 	history, err := h.store.GetParameterHistory(r.Context(), req.Name, req.WithDecryption)
 	if err != nil {
+		if errors.Is(err, ssmdriver.ErrInvalidKeyID) {
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidKeyId", cerrors.Message(err))
+			return
+		}
+
 		writeErr(w, err)
 		return
 	}

--- a/server/aws/ssm/tags.go
+++ b/server/aws/ssm/tags.go
@@ -3,6 +3,7 @@ package ssm
 import (
 	"context"
 	"net/http"
+	"sort"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire"
@@ -102,6 +103,11 @@ func (h *Handler) listTagsForResource(w http.ResponseWriter, r *http.Request) {
 	for k, v := range tags {
 		out = append(out, ssmTag{Key: k, Value: v})
 	}
+
+	// Go map iteration order is randomized, so without sorting this list's
+	// order would vary from call to call for the same parameter. Real
+	// ListTagsForResource returns a stable order.
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
 
 	wire.WriteJSON(w, map[string]any{"TagList": out})
 }

--- a/services/parameterstore/driver/driver.go
+++ b/services/parameterstore/driver/driver.go
@@ -82,6 +82,56 @@ var ErrValuePatternMismatch = errors.New(errors.InvalidArgument,
 	"Parameter value "+
 		"doesn't match the allowed pattern.")
 
+// ErrInvalidKeyID is returned by PutParameter/GetParameter/GetParameters/
+// GetParametersByPath/GetParameterHistory when encrypting or decrypting a
+// SecureString value fails because the resolved KMS key can't be used (e.g.
+// it's disabled, pending deletion, or otherwise unusable). Real Parameter
+// Store surfaces this as the distinct client error InvalidKeyId — not a 500 —
+// regardless of which underlying KMS failure caused it. It carries
+// InvalidArgument so generic handling still treats it as a bad request, while
+// the SDK-compat layer matches it with errors.Is to return InvalidKeyId.
+//
+//nolint:revive // exact AWS InvalidKeyId wording, surfaced verbatim to the SDK
+var ErrInvalidKeyID = errors.New(errors.InvalidArgument, "The query key ID isn't valid.")
+
+// ErrReservedNamePrefix is returned by PutParameter when Name (after stripping
+// a leading "/") starts with "aws" or "ssm" (case-insensitive). Real Parameter
+// Store reserves that namespace for AWS-published parameters and rejects a
+// customer-created parameter there with ValidationException.
+//
+//nolint:revive // exact AWS ValidationException wording, surfaced verbatim to the SDK
+var ErrReservedNamePrefix = errors.New(errors.InvalidArgument,
+	"Parameter name: can't be prefixed with \"aws\" or \"ssm\" (case-insensitive).")
+
+// ErrValueTooLarge is returned by PutParameter when Value exceeds the size
+// limit of the parameter's tier: 4 KB for Standard, 8 KB for Advanced. Real
+// Parameter Store rejects an over-limit Standard-tier value with
+// ValidationException instead of silently accepting it or auto-upgrading the
+// tier (auto-upgrade only happens under the Intelligent-Tiering account
+// default, which isn't modeled here).
+//
+//nolint:revive // ValidationException wording, surfaced verbatim to the SDK
+var ErrValueTooLarge = errors.New(errors.InvalidArgument,
+	"Parameter value exceeds the allowed size for this parameter tier.")
+
+// StandardTierMaxValueBytes and AdvancedTierMaxValueBytes are the value-size
+// limits Real Parameter Store enforces per tier.
+const (
+	StandardTierMaxValueBytes = 4096
+	AdvancedTierMaxValueBytes = 8192
+)
+
+// ErrCannotRevertTier is returned by PutParameter when an Overwrite=true
+// update explicitly sets Tier to Standard on a parameter that is currently
+// Advanced. Real Parameter Store never lets an Advanced parameter revert to
+// Standard — doing so would truncate its value and drop any policies — so
+// this is rejected with ValidationException. Omitting Tier on an Overwrite
+// update is unaffected: it retains the existing tier rather than reverting.
+var ErrCannotRevertTier = errors.New(errors.InvalidArgument,
+	"Reverting an advanced parameter to a standard parameter would result in data loss. "+
+		"This is not a supported operation. If you still want to proceed, "+
+		"please remove the parameter and recreate it as a standard parameter.")
+
 // DefaultSecureStringKeyID is the KMS key Parameter Store assigns to a
 // SecureString parameter when PutParameter omits KeyId — the AWS-managed
 // default key alias.


### PR DESCRIPTION
## Summary

Deep black-box real-user e2e audit of AWS SSM Parameter Store (aws-cli, aws-sdk-go-v2, Terraform `aws_ssm_parameter`) against a running `cloudemu serve -providers=aws` instance. Every finding was verified against the official AWS SSM API reference/userguide before filing, and every fix was re-verified black-box after the change.

## Findings & fixes

1. **Selector field missing leading colon.** Real AWS returns `Selector: ":2"` / `":prod"` for a version/label-addressed GetParameter/GetParameters read; cloudemu returned the bare `"2"` / `"prod"`. Fixed in `selectorFor()`.

2. **SecureString KMS failure leaked a 500 with the raw internal message instead of the documented 400 InvalidKeyId.** When a SecureString's KMS key becomes unusable (e.g. disabled), `PutParameter`, `GetParameter`, `GetParameters`, `GetParametersByPath`, and `GetParameterHistory` all document a distinct 400 `InvalidKeyId` — cloudemu returned `InternalServerError` (500) carrying the raw KMS error text ("key is disabled"), both the wrong error shape and an error-string leak. Added `driver.ErrInvalidKeyID` sentinel; `sealValue`/`revealValue` now translate any KMS failure into it, and the 5 wire handlers map it to `InvalidKeyId`/400.

3. **GetParameters result order.** AWS's API reference states results are "listed in alphabetical order" regardless of request order; cloudemu returned them in request order. Now sorted by name, matching `GetParametersByPath`/`DescribeParameters`.

4. **ListTagsForResource nondeterministic tag order.** Tags were ranged directly off a Go map with no sort, so repeated calls against the same unmodified parameter returned tags in different orders (verified: 5 identical calls, 2 different orderings observed). Now sorted by key.

5. **No Standard (4 KB) / Advanced (8 KB) value size enforcement.** PutParameter silently accepted values of any size regardless of tier; real Parameter Store rejects an over-limit value with `ValidationException`. Added the documented per-tier limits.

6. **Reserved "aws"/"ssm" name prefix not enforced.** Real Parameter Store rejects a customer parameter name prefixed with "aws" or "ssm" (case-insensitive) — that namespace is reserved for AWS-published parameters. Mirrors the same rule already enforced for parameter labels.

7. **Overwrite without Tier silently reverted Advanced → Standard.** Real Parameter Store never lets an Advanced parameter revert to Standard (would truncate the value/drop policies). cloudemu unconditionally defaulted an omitted Tier to Standard on every Put, including Overwrite. Added `resolveOverwriteTier()` (parallel to the existing `resolveOverwriteType()`): omitted Tier now retains the current tier; an explicit downgrade attempt is rejected.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite, no failures)
- [x] `go test ./providers/aws/ssm/... ./server/aws/ssm/... -race`
- [x] `gofmt -l` clean on all changed files
- [x] `golangci-lint run --new-from-rev=origin/development` — 0 new issues
- [x] `go generate ./...` — `docs/coverage` unchanged (no driver interface signature changes)
- [x] Regression test added per fix (`ssm_test.go`: Selector colon, alphabetical order, value-size limits, reserved name prefix, tier retention/downgrade-reject, KMS-unusable→InvalidKeyId; `invalid_keyid_test.go`: SDK-level disabled-KMS-key → InvalidKeyId, stable ListTagsForResource order)
- [x] Every finding re-verified black-box via aws-cli after the fix (disabled KMS key, oversized values, reserved names, tier retention, selector format, tag/parameter ordering)
- [x] Terraform `aws_ssm_parameter` (String/SecureString/StringList + tags): apply → `plan` clean (no diff) → destroy, both before and after all fixes