### PR TITLE
fix(cost): real-user e2e divergences from AWS

### DIFF
--- a/server/aws/costexplorer/operations.go
+++ b/server/aws/costexplorer/operations.go
@@ -59,7 +59,7 @@ func (h *Handler) doGetCostAndUsage(ctx context.Context, in *getCostAndUsageInpu
 // Groups (and an empty Total, matching real Cost Explorer), ungrouped requests
 // carry only the aggregate Total.
 func buildResult(iv dateInterval, gran string, metrics []string, byService map[string]float64, grouped bool) resultByTime {
-	res := resultByTime{TimePeriod: iv, Estimated: true, Total: map[string]metricValue{}}
+	res := resultByTime{TimePeriod: iv, Estimated: true, Total: map[string]metricValue{}, Groups: []group{}}
 
 	if grouped {
 		res.Groups = groupsByService(gran, metrics, byService)
@@ -104,7 +104,10 @@ func (h *Handler) doGetCostForecast(ctx context.Context, in *getCostForecastInpu
 		return nil, cerrors.New(cerrors.InvalidArgument, "TimePeriod is required")
 	}
 
-	gran := forecastGranularity(in.Granularity)
+	gran, err := forecastGranularity(in.Granularity)
+	if err != nil {
+		return nil, err
+	}
 
 	ivs, err := buckets(*in.TimePeriod, gran)
 	if err != nil {
@@ -315,14 +318,20 @@ func granularityOrDefault(g string) string {
 	}
 }
 
-// forecastGranularity restricts to the DAILY/MONTHLY granularities forecasts
-// support, defaulting to MONTHLY.
-func forecastGranularity(g string) string {
-	if strings.EqualFold(g, granularityDaily) {
-		return granularityDaily
+// forecastGranularity restricts to the DAILY/MONTHLY granularities
+// GetCostForecast supports (unlike GetCostAndUsage, it does not accept
+// HOURLY), rejecting anything else with a ValidationException — matching AWS,
+// which errors rather than silently substituting a different granularity.
+func forecastGranularity(g string) (string, error) {
+	switch {
+	case strings.EqualFold(g, granularityDaily):
+		return granularityDaily, nil
+	case strings.EqualFold(g, granularityMonthly):
+		return granularityMonthly, nil
+	default:
+		return "", cerrors.Newf(cerrors.InvalidArgument,
+			"Granularity %q is not supported for a forecast; use DAILY or MONTHLY", g)
 	}
-
-	return granularityMonthly
 }
 
 // wantsServiceGroup reports whether the request asks to group by the SERVICE

--- a/server/aws/costexplorer/sdk_roundtrip_test.go
+++ b/server/aws/costexplorer/sdk_roundtrip_test.go
@@ -2,6 +2,7 @@ package costexplorer_test
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"strconv"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	ce "github.com/aws/aws-sdk-go-v2/service/costexplorer"
 	cetypes "github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
+	"github.com/aws/smithy-go"
 
 	cloudemu "github.com/stackshy/cloudemu/v2"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
@@ -148,6 +150,53 @@ func TestSDKGetCostForecast(t *testing.T) {
 
 	if len(out.ForecastResultsByTime) != 3 {
 		t.Fatalf("ForecastResultsByTime = %d, want 3 months", len(out.ForecastResultsByTime))
+	}
+}
+
+// TestSDKGetCostForecastRejectsHourly proves GetCostForecast rejects the
+// HOURLY granularity with a ValidationException: unlike GetCostAndUsage, AWS
+// only supports DAILY and MONTHLY forecasts.
+func TestSDKGetCostForecastRejectsHourly(t *testing.T) {
+	ctx := context.Background()
+	c := newCostExplorerClient(t)
+
+	_, err := c.GetCostForecast(ctx, &ce.GetCostForecastInput{
+		Granularity: cetypes.GranularityHourly,
+		Metric:      cetypes.MetricUnblendedCost,
+		TimePeriod:  &cetypes.DateInterval{Start: aws.String("2024-01-01"), End: aws.String("2024-01-02")},
+	})
+	if err == nil {
+		t.Fatal("expected error for HOURLY forecast granularity")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ValidationException" {
+		t.Fatalf("HOURLY forecast error = %v, want ValidationException", err)
+	}
+}
+
+// TestSDKGetCostAndUsageUngroupedGroupsIsEmpty proves an ungrouped
+// GetCostAndUsage result carries an empty Groups list (matching real Cost
+// Explorer), not a nil/absent one.
+func TestSDKGetCostAndUsageUngroupedGroupsIsEmpty(t *testing.T) {
+	ctx := context.Background()
+	c := newCostExplorerClient(t)
+
+	out, err := c.GetCostAndUsage(ctx, &ce.GetCostAndUsageInput{
+		Granularity: cetypes.GranularityMonthly,
+		Metrics:     []string{"UnblendedCost"},
+		TimePeriod:  &cetypes.DateInterval{Start: aws.String("2024-01-01"), End: aws.String("2024-02-01")},
+	})
+	if err != nil {
+		t.Fatalf("GetCostAndUsage: %v", err)
+	}
+
+	if len(out.ResultsByTime) != 1 {
+		t.Fatalf("ResultsByTime = %d, want 1", len(out.ResultsByTime))
+	}
+
+	if out.ResultsByTime[0].Groups == nil {
+		t.Fatal("ungrouped ResultByTime.Groups is nil, want an empty (non-nil) slice")
 	}
 }
 

--- a/server/aws/savingsplans/handler.go
+++ b/server/aws/savingsplans/handler.go
@@ -211,10 +211,20 @@ func (h *Handler) describeOfferingRates(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	ids := toSet(req.SavingsPlanOfferingIDs)
+
 	rates := make([]map[string]any, 0, len(h.store.offerings))
 
 	for i := range h.store.offerings {
-		rates = append(rates, offeringRateToWire(&h.store.offerings[i]))
+		o := &h.store.offerings[i]
+
+		if len(ids) > 0 {
+			if _, ok := ids[o.id]; !ok {
+				continue
+			}
+		}
+
+		rates = append(rates, offeringRateToWire(o))
 	}
 
 	wire.WriteJSON(w, map[string]any{"searchResults": rates})

--- a/server/aws/savingsplans/rates.go
+++ b/server/aws/savingsplans/rates.go
@@ -11,7 +11,7 @@ const sampleRate = "0.0464"
 // offering. The rate quotes the offering's discounted hourly price alongside the
 // parent offering's terms.
 func offeringRateToWire(o *offering) map[string]any {
-	return map[string]any{
+	out := map[string]any{
 		"operation":   o.operation,
 		"productType": firstProduct(o.productTypes),
 		"rate":        sampleRate,
@@ -26,10 +26,18 @@ func offeringRateToWire(o *offering) map[string]any {
 			"durationSeconds": o.durationSecs,
 			"currency":        currencyUSD,
 		},
-		"properties": []map[string]any{
-			{"name": "instanceFamily", "value": o.ec2Family},
-		},
 	}
+
+	// instanceFamily only applies to EC2Instance-type offerings; Compute and
+	// SageMaker offerings carry no instance family, so the property is omitted
+	// rather than emitted with an empty value.
+	if o.ec2Family != "" {
+		out["properties"] = []map[string]any{
+			{"name": "instanceFamily", "value": o.ec2Family},
+		}
+	}
+
+	return out
 }
 
 // planRatesFor renders a representative SavingsPlanRate set for a purchased plan.

--- a/server/aws/savingsplans/savingsplans_roundtrip_test.go
+++ b/server/aws/savingsplans/savingsplans_roundtrip_test.go
@@ -2,6 +2,7 @@ package savingsplans_test
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/savingsplans"
 	sptypes "github.com/aws/aws-sdk-go-v2/service/savingsplans/types"
+	"github.com/aws/smithy-go"
 
 	"github.com/stackshy/cloudemu/v2/config"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
@@ -274,5 +276,51 @@ func TestTagsRoundTrip(t *testing.T) {
 
 	if after.Tags["team"] != "cost" {
 		t.Fatalf("team tag should survive untag: %v", after.Tags)
+	}
+}
+
+// TestCreateSavingsPlanUnknownOfferingIsNotFound proves CreateSavingsPlan
+// against an unknown savingsPlanOfferingId raises ResourceNotFoundException
+// (the error CreateSavingsPlan documents for this case), not a generic
+// ValidationException.
+func TestCreateSavingsPlanUnknownOfferingIsNotFound(t *testing.T) {
+	c, _ := newClient(t)
+
+	_, err := c.CreateSavingsPlan(context.Background(), &savingsplans.CreateSavingsPlanInput{
+		SavingsPlanOfferingId: aws.String("does-not-exist"),
+		Commitment:            aws.String("1.000"),
+	})
+	if err == nil {
+		t.Fatal("expected error creating a plan against an unknown offering")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ResourceNotFoundException" {
+		t.Fatalf("unknown offering error = %v, want ResourceNotFoundException", err)
+	}
+}
+
+// TestDescribeOfferingRatesFiltersByOfferingID proves
+// DescribeSavingsPlansOfferingRates honors the savingsPlanOfferingIds filter
+// instead of always returning every seeded offering's rate.
+func TestDescribeOfferingRatesFiltersByOfferingID(t *testing.T) {
+	c, _ := newClient(t)
+
+	const sageMakerOfferingID = "sp-offering-sagemaker-1yr-no"
+
+	out, err := c.DescribeSavingsPlansOfferingRates(context.Background(),
+		&savingsplans.DescribeSavingsPlansOfferingRatesInput{
+			SavingsPlanOfferingIds: []string{sageMakerOfferingID},
+		})
+	if err != nil {
+		t.Fatalf("DescribeSavingsPlansOfferingRates: %v", err)
+	}
+
+	if len(out.SearchResults) != 1 {
+		t.Fatalf("filtered rates = %d, want 1 (got %+v)", len(out.SearchResults), out.SearchResults)
+	}
+
+	if got := aws.ToString(out.SearchResults[0].SavingsPlanOffering.OfferingId); got != sageMakerOfferingID {
+		t.Fatalf("filtered rate offering id = %q, want %q", got, sageMakerOfferingID)
 	}
 }

--- a/server/aws/savingsplans/store.go
+++ b/server/aws/savingsplans/store.go
@@ -172,7 +172,9 @@ func (s *store) findOffering(id string) (*offering, bool) {
 func (s *store) create(in *createInput) (string, error) {
 	off, ok := s.findOffering(in.savingsPlanOfferingID)
 	if !ok {
-		return "", cerrors.Newf(cerrors.InvalidArgument, "offering not found: %s", in.savingsPlanOfferingID)
+		// CreateSavingsPlan documents ResourceNotFoundException (not
+		// ValidationException) for an unknown savingsPlanOfferingId.
+		return "", cerrors.Newf(cerrors.NotFound, "offering not found: %s", in.savingsPlanOfferingID)
 	}
 
 	if in.commitment == "" {

--- a/services/cost/lineitem_test.go
+++ b/services/cost/lineitem_test.go
@@ -146,8 +146,8 @@ func TestLineItems_FractionalCoverageDivergenceCase(t *testing.T) {
 	}
 
 	hourly := pricing.Monthly("azure", "compute", "Instance", "Standard_D2s_v3", "eastus", nil) / hoursPerMonth
-	lineCost := hourly * 24               // each VM's cost for the 24h bucket
-	budget := 1.5 * lineCost              // covers vm-a fully + half of vm-b
+	lineCost := hourly * 24  // each VM's cost for the 24h bucket
+	budget := 1.5 * lineCost // covers vm-a fully + half of vm-b
 	commitments := []Commitment{{ID: "c-1", Kind: KindSavingsPlan, HourlyCommitmentUSD: 1.5 * hourly, Start: start, End: end}}
 
 	lines, err := LineItems(context.Background(), fakeInventory{res: res}, commitments, start, end, 24*time.Hour)


### PR DESCRIPTION
## Summary

Real-user e2e audit of the AWS Cost family (Cost Explorer, Savings Plans, Service Quotas) via aws-cli + aws-sdk-go-v2 against `cloudemu serve`, verified against official AWS API docs. Fixes 5 confirmed divergences:

- **DescribeSavingsPlansOfferingRates** ignored the `savingsPlanOfferingIds` filter — always returned rates for all seeded offerings regardless of the request.
- **CreateSavingsPlan** on an unknown offering returned `ValidationException`; AWS documents `ResourceNotFoundException` for this case (the offering id is the only referenceable resource in the request).
- **GetCostForecast** silently accepted `Granularity=HOURLY` and returned a monthly-rate forecast. AWS only supports DAILY/MONTHLY for forecasts (unlike GetCostAndUsage) — now rejected with `ValidationException`.
- **GetCostAndUsage** (ungrouped) serialized `Groups` as JSON `null` instead of `[]`, diverging from real Cost Explorer's shape.
- **Savings Plan offering rates** leaked an empty `instanceFamily` property for Compute/SageMaker offerings that have no EC2 instance family.

Also fixes a pre-existing `gofmt` alignment issue in `services/cost/lineitem_test.go` (unrelated whitespace-only diff, fixed to keep the lint gate clean).

Service Quotas and the rest of Cost Explorer/Savings Plans were verified live and found correct (state-aware billing on stop/terminate, quota codes/defaults, error shapes, lifecycle transitions) — no changes needed there.

**Follow-up (not in this PR):** `GetReservationCoverage`/`GetReservationUtilization`/`GetSavingsPlansCoverage`/`GetSavingsPlansUtilization` are entirely unimplemented, even though the backing amortization engine (`services/cost.Coverage`/`Utilization`/`Combine`) and both commitment sources (EC2 Reserved Instances, Savings Plans) already exist for exactly this purpose. This is a real, sizeable gap but needs new wire shapes + wiring across `server/aws/aws.go`, so it's tracked separately rather than half-built here.

## Test plan
- [x] New regression tests: `TestDescribeOfferingRatesFiltersByOfferingID`, `TestCreateSavingsPlanUnknownOfferingIsNotFound`, `TestSDKGetCostForecastRejectsHourly`, `TestSDKGetCostAndUsageUngroupedGroupsIsEmpty`
- [x] Live-verified each fix via aws-cli against a running `cloudemu serve -providers=aws` instance
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./server/aws/... ./services/cost/... ./providers/aws/... -race -count=1` all green
- [x] `gofmt -l` clean, `golangci-lint --new-from-rev=origin/development` 0 new issues
- [x] `go mod tidy` no-op
- [x] `go generate ./...` — `docs/coverage` unchanged (already current)