### PR TITLE
fix(acr): real-user e2e divergences from Azure

### DIFF
--- a/providers/azure/acr/acr.go
+++ b/providers/azure/acr/acr.go
@@ -187,8 +187,9 @@ func (m *Mock) GetRepository(_ context.Context, name string) (*driver.Repository
 }
 
 // ListRepositories lists all ACR repositories whose listEnabled attribute is
-// not locked. A read-locked or write-locked repository still appears here;
-// only listEnabled hides a repository from the catalog.
+// not locked, sorted by name for a stable, deterministic list order across
+// calls. A read-locked or write-locked repository still appears here; only
+// listEnabled hides a repository from the catalog.
 func (m *Mock) ListRepositories(_ context.Context) ([]driver.Repository, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -205,6 +206,8 @@ func (m *Mock) ListRepositories(_ context.Context) ([]driver.Repository, error) 
 		repo.ImageCount = rd.images.Len()
 		repos = append(repos, repo)
 	}
+
+	sort.Slice(repos, func(i, j int) bool { return repos[i].Name < repos[j].Name })
 
 	return repos, nil
 }
@@ -260,6 +263,7 @@ func (m *Mock) PutImage(_ context.Context, manifest *driver.ImageManifest) (*dri
 		SizeBytes:  manifest.SizeBytes,
 		PushedAt:   now,
 		MediaType:  mediaType,
+		Manifest:   manifest.Manifest,
 	}
 
 	img := &imageData{detail: detail, layers: manifest.Layers, attrs: attrs}
@@ -302,8 +306,9 @@ func (m *Mock) GetImage(_ context.Context, repository, reference string) (*drive
 }
 
 // ListImages lists all images in an ACR repository whose listEnabled
-// attribute is not locked. A read-locked or write-locked manifest still
-// appears here; only listEnabled hides a manifest from the listing.
+// attribute is not locked, sorted by digest for a stable, deterministic list
+// order across calls. A read-locked or write-locked manifest still appears
+// here; only listEnabled hides a manifest from the listing.
 func (m *Mock) ListImages(_ context.Context, repository string) ([]driver.ImageDetail, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -323,6 +328,8 @@ func (m *Mock) ListImages(_ context.Context, repository string) ([]driver.ImageD
 
 		images = append(images, img.detail)
 	}
+
+	sort.Slice(images, func(i, j int) bool { return images[i].Digest < images[j].Digest })
 
 	return images, nil
 }

--- a/providers/azure/acr/list_ordering_test.go
+++ b/providers/azure/acr/list_ordering_test.go
@@ -1,0 +1,127 @@
+package acr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListRegistriesSortedByName confirms ListRegistries returns a stable,
+// alphabetically sorted order rather than the randomized order of the
+// underlying map iteration real callers would otherwise observe across
+// repeated calls.
+func TestListRegistriesSortedByName(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zreg", "areg", "mreg"} {
+		_, _, err := m.CreateOrUpdateRegistry(ctx, "rg-1", name, driver.AzureRegistryConfig{Location: "eastus"})
+		require.NoError(t, err)
+	}
+
+	got, err := m.ListRegistries(ctx, "rg-1")
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	names := []string{got[0].Name, got[1].Name, got[2].Name}
+	assert.Equal(t, []string{"areg", "mreg", "zreg"}, names)
+}
+
+// TestListWebhooksSortedByName mirrors TestListRegistriesSortedByName for
+// webhook sub-resources.
+func TestListWebhooksSortedByName(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, _, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "reg1", driver.AzureRegistryConfig{Location: "eastus"})
+	require.NoError(t, err)
+
+	for _, name := range []string{"whc", "wha", "whb"} {
+		_, _, err := m.CreateOrUpdateWebhook(ctx, "rg-1", "reg1", name, driver.AzureWebhookConfig{Location: "eastus"})
+		require.NoError(t, err)
+	}
+
+	got, err := m.ListWebhooks(ctx, "rg-1", "reg1")
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	names := []string{got[0].Name, got[1].Name, got[2].Name}
+	assert.Equal(t, []string{"wha", "whb", "whc"}, names)
+}
+
+// TestListReplicationsSortedByName mirrors TestListRegistriesSortedByName for
+// replication sub-resources.
+func TestListReplicationsSortedByName(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, _, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "reg1", driver.AzureRegistryConfig{Location: "eastus"})
+	require.NoError(t, err)
+
+	for _, loc := range []string{"westus", "eastasia", "westeurope"} {
+		_, _, err := m.CreateOrUpdateReplication(ctx, "rg-1", "reg1", loc, driver.AzureReplicationConfig{Location: loc})
+		require.NoError(t, err)
+	}
+
+	got, err := m.ListReplications(ctx, "rg-1", "reg1")
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	names := []string{got[0].Name, got[1].Name, got[2].Name}
+	assert.Equal(t, []string{"eastasia", "westeurope", "westus"}, names)
+}
+
+// TestListRepositoriesSortedByName confirms the data-plane catalog is sorted,
+// matching the ARM-side list-ordering guarantee above.
+func TestListRepositoriesSortedByName(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zapp", "aapp", "mapp"} {
+		_, err := m.CreateRepository(ctx, driver.RepositoryConfig{Name: name})
+		require.NoError(t, err)
+	}
+
+	got, err := m.ListRepositories(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	// Repository.Name holds the full Azure resource ID
+	// (".../registries/{name}"); the shared prefix is identical for all three
+	// here, so sorting by the full ID is equivalent to sorting by the bare
+	// trailing name.
+	names := []string{got[0].Name, got[1].Name, got[2].Name}
+	assert.Equal(t, []string{
+		"/subscriptions/123456789012/resourceGroups/cloudemu-rg/providers/Microsoft.ContainerRegistry/registries/aapp",
+		"/subscriptions/123456789012/resourceGroups/cloudemu-rg/providers/Microsoft.ContainerRegistry/registries/mapp",
+		"/subscriptions/123456789012/resourceGroups/cloudemu-rg/providers/Microsoft.ContainerRegistry/registries/zapp",
+	}, names)
+}
+
+// TestListImagesSortedByDigest confirms the manifest listing behind
+// /_manifests and /_tags is sorted for a stable order across calls.
+func TestListImagesSortedByDigest(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "app")
+
+	var digests []string
+
+	for _, tag := range []string{"v1", "v2", "v3"} {
+		img, err := m.PutImage(ctx, &driver.ImageManifest{Repository: "app", Tag: tag, SizeBytes: 1})
+		require.NoError(t, err)
+		digests = append(digests, img.Digest)
+	}
+
+	got, err := m.ListImages(ctx, "app")
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	for i := 1; i < len(got); i++ {
+		assert.LessOrEqual(t, got[i-1].Digest, got[i].Digest, "ListImages must be sorted by digest")
+	}
+}

--- a/providers/azure/acr/registry.go
+++ b/providers/azure/acr/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"sort"
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/errors"
@@ -232,7 +233,8 @@ func (m *Mock) DeleteRegistry(_ context.Context, rg, name string) error {
 }
 
 // ListRegistries returns registries in a resource group, or across the whole
-// subscription when rg is empty.
+// subscription when rg is empty, sorted by name for a stable, deterministic
+// list order across calls (map iteration order is otherwise randomized).
 func (m *Mock) ListRegistries(_ context.Context, rg string) ([]driver.AzureRegistry, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -247,6 +249,8 @@ func (m *Mock) ListRegistries(_ context.Context, rg string) ([]driver.AzureRegis
 
 		out = append(out, rd.reg)
 	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 
 	return out, nil
 }
@@ -312,24 +316,53 @@ func (m *Mock) RegenerateRegistryCredential(
 	}, nil
 }
 
-// ListRegistryUsages returns the registry's quota usages.
+// ListRegistryUsages returns the registry's quota usages, using the included
+// storage and webhook-count limits for the registry's actual SKU tier (see
+// https://learn.microsoft.com/azure/container-registry/container-registry-skus):
+// Basic 10 GiB / 2 webhooks, Standard 100 GiB / 10 webhooks, Premium 500 GiB /
+// 500 webhooks.
 func (m *Mock) ListRegistryUsages(_ context.Context, rg, name string) ([]driver.AzureRegistryUsage, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if !m.registries.Has(registryStoreKey(rg, name)) {
+	rd, ok := m.registries.Get(registryStoreKey(rg, name))
+	if !ok {
 		return nil, errors.Newf(errors.NotFound, "registry %q not found in resource group %q", name, rg)
 	}
 
-	const storageLimitBytes = 536870912000 // 500 GiB, the Standard-SKU included storage.
+	storageLimit, webhookLimit := skuUsageLimits(rd.reg.SKUName)
 
 	return []driver.AzureRegistryUsage{
-		{Name: "Size", Limit: storageLimitBytes, CurrentValue: 0, Unit: "Bytes"},
-		{Name: "Webhooks", Limit: webhookQuota, CurrentValue: int64(m.countSubResources(m.webhooks.Keys(), rg, name)), Unit: "Count"},
+		{Name: "Size", Limit: storageLimit, CurrentValue: 0, Unit: "Bytes"},
+		{Name: "Webhooks", Limit: webhookLimit, CurrentValue: int64(m.countSubResources(m.webhooks.Keys(), rg, name)), Unit: "Count"},
 	}, nil
 }
 
-const webhookQuota = 100
+const (
+	gibBytes = 1 << 30
+
+	basicStorageLimitGiB    = 10
+	standardStorageLimitGiB = 100
+	premiumStorageLimitGiB  = 500
+
+	basicWebhookLimit    = 2
+	standardWebhookLimit = 10
+	premiumWebhookLimit  = 500
+)
+
+// skuUsageLimits returns the included storage (bytes) and webhook-count
+// limits for a registry's SKU. An unrecognized SKU falls back to Standard's
+// limits, matching defaultRegistrySKU.
+func skuUsageLimits(sku string) (storageBytes, webhookLimit int64) {
+	switch sku {
+	case "Basic":
+		return basicStorageLimitGiB * gibBytes, basicWebhookLimit
+	case "Premium":
+		return premiumStorageLimitGiB * gibBytes, premiumWebhookLimit
+	default:
+		return standardStorageLimitGiB * gibBytes, standardWebhookLimit
+	}
+}
 
 func (*Mock) countSubResources(keys []string, rg, registry string) int {
 	prefix := rg + "/" + registry + "/"
@@ -476,7 +509,8 @@ func (m *Mock) DeleteWebhook(_ context.Context, rg, registry, name string) error
 	return nil
 }
 
-// ListWebhooks returns all webhooks on a registry.
+// ListWebhooks returns all webhooks on a registry, sorted by name for a
+// stable, deterministic list order across calls.
 //
 //nolint:dupl // webhook and replication sub-resource lists are intentionally typed; sharing via generics adds noise.
 func (m *Mock) ListWebhooks(_ context.Context, rg, registry string) ([]driver.AzureWebhook, error) {
@@ -496,6 +530,8 @@ func (m *Mock) ListWebhooks(_ context.Context, rg, registry string) ([]driver.Az
 			out = append(out, *wh)
 		}
 	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 
 	return out, nil
 }
@@ -596,7 +632,8 @@ func (m *Mock) DeleteReplication(_ context.Context, rg, registry, name string) e
 	return nil
 }
 
-// ListReplications returns all replications on a registry.
+// ListReplications returns all replications on a registry, sorted by name for
+// a stable, deterministic list order across calls.
 //
 //nolint:dupl // webhook and replication sub-resource lists are intentionally typed; sharing via generics adds noise.
 func (m *Mock) ListReplications(_ context.Context, rg, registry string) ([]driver.AzureReplication, error) {
@@ -616,6 +653,8 @@ func (m *Mock) ListReplications(_ context.Context, rg, registry string) ([]drive
 			out = append(out, *rep)
 		}
 	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 
 	return out, nil
 }

--- a/providers/azure/acr/usage_limits_test.go
+++ b/providers/azure/acr/usage_limits_test.go
@@ -1,0 +1,63 @@
+package acr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListRegistryUsagesPerSKU confirms the included-storage and
+// webhook-count limits reported by ListRegistryUsages follow the registry's
+// actual SKU tier (Basic 10 GiB / 2 webhooks, Standard 100 GiB / 10 webhooks,
+// Premium 500 GiB / 500 webhooks), per
+// https://learn.microsoft.com/azure/container-registry/container-registry-skus,
+// rather than a single hardcoded Premium-tier limit for every SKU.
+func TestListRegistryUsagesPerSKU(t *testing.T) {
+	cases := []struct {
+		sku              string
+		wantStorageGiB   int64
+		wantWebhookQuota int64
+	}{
+		{sku: "Basic", wantStorageGiB: 10, wantWebhookQuota: 2},
+		{sku: "Standard", wantStorageGiB: 100, wantWebhookQuota: 10},
+		{sku: "Premium", wantStorageGiB: 500, wantWebhookQuota: 500},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.sku, func(t *testing.T) {
+			m, _ := newTestMock()
+			ctx := context.Background()
+
+			_, _, err := m.CreateOrUpdateRegistry(ctx, "rg-1", "reg1", driver.AzureRegistryConfig{
+				Location: "eastus", SKUName: tc.sku,
+			})
+			require.NoError(t, err)
+
+			usages, err := m.ListRegistryUsages(ctx, "rg-1", "reg1")
+			require.NoError(t, err)
+			require.Len(t, usages, 2)
+
+			const gib = int64(1) << 30
+
+			var storage, webhooks *driver.AzureRegistryUsage
+
+			for i := range usages {
+				switch usages[i].Name {
+				case "Size":
+					storage = &usages[i]
+				case "Webhooks":
+					webhooks = &usages[i]
+				}
+			}
+
+			require.NotNil(t, storage)
+			require.NotNil(t, webhooks)
+
+			assert.Equal(t, tc.wantStorageGiB*gib, storage.Limit)
+			assert.Equal(t, tc.wantWebhookQuota, webhooks.Limit)
+		})
+	}
+}

--- a/server/azure/acr/dataplane_manifest.go
+++ b/server/azure/acr/dataplane_manifest.go
@@ -1,0 +1,115 @@
+package acr
+
+import (
+	"net/http"
+	"strings"
+)
+
+// v2Prefix and v2ManifestsMarker locate the OCI-distribution manifest path
+// azcontainerregistry's Client.GetManifest / DeleteManifest / UploadManifest
+// actually issue requests against: "/v2/{name}/manifests/{reference}". This
+// is a *different* URL family from the "/acr/v1/{name}/_manifests/{digest}"
+// changeableAttributes path served by operations.go — real ACR exposes both:
+// /acr/v1 for catalog metadata (list/get/patch), /v2 for the manifest content
+// itself (get/delete/push), per the Docker Registry HTTP API V2 the ACR data
+// plane implements alongside its own /acr/v1 extension.
+const (
+	v2Prefix         = "/v2/"
+	v2ManifestMarker = "manifests"
+
+	// defaultManifestMediaType is used when an image was pushed without a
+	// media type, mirroring the provider's own fallback.
+	defaultManifestMediaType = "application/vnd.docker.distribution.manifest.v2+json"
+)
+
+// parseV2ManifestPath splits a /v2/{name}/manifests/{reference} path into the
+// repository name and reference (tag or digest). The repository name may be
+// hierarchical (e.g. "team/app"), so the split hinges on the "/manifests/"
+// marker segment rather than the first slash, mirroring parseACRPath.
+func parseV2ManifestPath(path string) (repo, reference string, ok bool) {
+	if !strings.HasPrefix(path, v2Prefix) {
+		return "", "", false
+	}
+
+	tail := strings.TrimPrefix(path, v2Prefix)
+
+	idx := strings.Index(tail, "/"+v2ManifestMarker+"/")
+	if idx < 0 {
+		return "", "", false
+	}
+
+	repo = tail[:idx]
+	reference = tail[idx+len(v2ManifestMarker)+2:]
+
+	if repo == "" || reference == "" {
+		return "", "", false
+	}
+
+	return repo, reference, true
+}
+
+// serveV2Manifest routes GET (fetch manifest content) and DELETE (delete
+// manifest) against the shared ContainerRegistry driver's already-modeled
+// GetImage/DeleteImage. PUT (push) is not modeled — cloudemu has no real OCI
+// blob storage — and answers a clean 405 instead of silently falling through
+// to an unrelated handler.
+func (h *Handler) serveV2Manifest(w http.ResponseWriter, r *http.Request, repo, reference string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getManifestContent(w, r, repo, reference)
+	case http.MethodDelete:
+		h.deleteManifestContent(w, r, repo, reference)
+	default:
+		writeErr(w, http.StatusMethodNotAllowed, "UNSUPPORTED", "unsupported ACR operation")
+	}
+}
+
+// getManifestContent serves GET /v2/{name}/manifests/{reference}, returning
+// the raw manifest document azcontainerregistry's GetManifest expects in the
+// response body with a Docker-Content-Digest header.
+func (h *Handler) getManifestContent(w http.ResponseWriter, r *http.Request, repo, reference string) {
+	if _, err := h.registry.GetRepository(r.Context(), repo); err != nil {
+		writeErr(w, http.StatusNotFound, "NAME_UNKNOWN", "repository "+repo+" not found")
+		return
+	}
+
+	img, err := h.registry.GetImage(r.Context(), repo, reference)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, "MANIFEST_UNKNOWN", "manifest "+reference+" not found in repository "+repo)
+		return
+	}
+
+	body := img.Manifest
+	if body == "" {
+		body = "{}"
+	}
+
+	mediaType := img.MediaType
+	if mediaType == "" {
+		mediaType = defaultManifestMediaType
+	}
+
+	w.Header().Set("Content-Type", mediaType)
+	w.Header().Set("Docker-Content-Digest", img.Digest)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(body)) //nolint:gosec // G705: manifest JSON/OCI document echoed with its own Content-Type, not an HTML sink.
+}
+
+// deleteManifestContent serves DELETE /v2/{name}/manifests/{reference}. Real
+// ACR (and azcontainerregistry's DeleteManifest, which treats both 202 and
+// 404 as success) answers 202 Accepted; a missing repository or manifest is
+// reported with the OCI-distribution NAME_UNKNOWN/MANIFEST_UNKNOWN error
+// codes rather than a generic 404.
+func (h *Handler) deleteManifestContent(w http.ResponseWriter, r *http.Request, repo, reference string) {
+	if _, err := h.registry.GetRepository(r.Context(), repo); err != nil {
+		writeErr(w, http.StatusNotFound, "NAME_UNKNOWN", "repository "+repo+" not found")
+		return
+	}
+
+	if err := h.registry.DeleteImage(r.Context(), repo, reference); err != nil {
+		writeErr(w, http.StatusNotFound, "MANIFEST_UNKNOWN", "manifest "+reference+" not found in repository "+repo)
+		return
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+}

--- a/server/azure/acr/dataplane_manifest_test.go
+++ b/server/azure/acr/dataplane_manifest_test.go
@@ -1,0 +1,129 @@
+package acr_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+// TestSDKACRGetManifestContent drives the real azcontainerregistry SDK's
+// GetManifest, which issues GET /v2/{name}/manifests/{reference} — a
+// different URL family from the /acr/v1/{name}/_manifests/{digest}
+// changeableAttributes path exercised elsewhere. It must return the raw
+// manifest document preserved from PutImage, not fall through to an
+// unrelated handler.
+func TestSDKACRGetManifestContent(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "app"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	const rawManifest = `{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json"}`
+
+	detail, err := reg.PutImage(ctx, &crdriver.ImageManifest{
+		Repository: "app",
+		Tag:        "v1",
+		MediaType:  "application/vnd.docker.distribution.manifest.v2+json",
+		SizeBytes:  512,
+		Manifest:   rawManifest,
+	})
+	if err != nil {
+		t.Fatalf("seed PutImage: %v", err)
+	}
+
+	resp, err := client.GetManifest(ctx, "app", "v1", nil)
+	if err != nil {
+		t.Fatalf("GetManifest: %v", err)
+	}
+
+	body, err := io.ReadAll(resp.ManifestData)
+	if err != nil {
+		t.Fatalf("read ManifestData: %v", err)
+	}
+
+	if string(body) != rawManifest {
+		t.Fatalf("got manifest body %q, want %q", body, rawManifest)
+	}
+
+	if resp.DockerContentDigest == nil || *resp.DockerContentDigest != detail.Digest {
+		t.Fatalf("got Docker-Content-Digest %v, want %s", resp.DockerContentDigest, detail.Digest)
+	}
+
+	// Fetching by digest must resolve to the same content as fetching by tag.
+	byDigest, err := client.GetManifest(ctx, "app", detail.Digest, nil)
+	if err != nil {
+		t.Fatalf("GetManifest(by digest): %v", err)
+	}
+
+	digestBody, err := io.ReadAll(byDigest.ManifestData)
+	if err != nil {
+		t.Fatalf("read ManifestData(by digest): %v", err)
+	}
+
+	if string(digestBody) != rawManifest {
+		t.Fatalf("got manifest body by digest %q, want %q", digestBody, rawManifest)
+	}
+}
+
+// TestSDKACRGetManifestContentNotFound confirms a nonexistent repository or
+// manifest gets a proper OCI-distribution error shape ({"errors":[...]}) from
+// the ACR handler, not the misleading BlobNotFound XML that blob storage's
+// broad {container}/{blob} fallback previously produced for an unclaimed
+// /v2/... path.
+func TestSDKACRGetManifestContentNotFound(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	_, err := client.GetManifest(ctx, "ghost", "v1", nil)
+	assertResponseCode(t, err, 404)
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "app"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	_, err = client.GetManifest(ctx, "app", "missing-tag", nil)
+	assertResponseCode(t, err, 404)
+}
+
+// TestSDKACRDeleteManifestContent drives the real SDK's DeleteManifest
+// (DELETE /v2/{name}/manifests/{digest}) and verifies the manifest is
+// actually removed — not just that the call returns success (the SDK treats
+// both 202 and 404 as success, so a wrong-handler 404 would previously mask
+// this divergence).
+func TestSDKACRDeleteManifestContent(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "app"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	detail, err := reg.PutImage(ctx, &crdriver.ImageManifest{
+		Repository: "app",
+		Tag:        "v1",
+		MediaType:  "application/vnd.docker.distribution.manifest.v2+json",
+		SizeBytes:  512,
+		Manifest:   `{"schemaVersion":2}`,
+	})
+	if err != nil {
+		t.Fatalf("seed PutImage: %v", err)
+	}
+
+	if _, err := client.DeleteManifest(ctx, "app", detail.Digest, nil); err != nil {
+		t.Fatalf("DeleteManifest: %v", err)
+	}
+
+	if _, err := reg.GetImage(ctx, "app", detail.Digest); err == nil {
+		t.Fatal("expected image to be gone after DeleteManifest")
+	}
+
+	// Deleting again (already gone) must still be reported success per real
+	// ACR / azcontainerregistry semantics (202 or 404 both treated as OK).
+	if _, err := client.DeleteManifest(ctx, "app", detail.Digest, nil); err != nil {
+		t.Fatalf("DeleteManifest (idempotent replay): %v", err)
+	}
+}

--- a/server/azure/acr/handler.go
+++ b/server/azure/acr/handler.go
@@ -25,12 +25,22 @@
 //	GET    /acr/v1/{name}/_manifests           — list manifests
 //	GET    /acr/v1/{name}/_manifests/{digest}  — manifest properties
 //	PATCH  /acr/v1/{name}/_manifests/{digest}  — update manifest changeableAttributes
+//	GET    /v2/{name}/manifests/{reference}    — manifest content (azcontainerregistry's
+//	                                              GetManifest hits this OCI-distribution path,
+//	                                              not /acr/v1 — see dataplane_manifest.go)
+//	DELETE /v2/{name}/manifests/{reference}    — delete manifest (azcontainerregistry's
+//	                                              DeleteManifest; same path family)
 //	POST   /oauth2/exchange                    — AAD token -> ACR refresh token
 //	POST   /oauth2/token                       — ACR refresh token -> ACR access token
 //
 // The changeableAttributes lock (deleteEnabled/writeEnabled/listEnabled) is
 // enforced against mutations and listings; readEnabled is stored and reported
 // but not enforced (see providers/azure/acr for the rationale).
+//
+// PUT /v2/{name}/manifests/{reference} (image push) is intentionally not
+// modeled: cloudemu has no real OCI blob storage, matching the same
+// documented boundary as AWS ECR / GCP Artifact Registry. It returns a clean
+// 405 rather than falling through to an unrelated handler.
 package acr
 
 import (
@@ -61,12 +71,20 @@ func New(reg crdriver.ContainerRegistry) *Handler {
 	return &Handler{registry: reg}
 }
 
-// Matches claims /acr/v1/ data-plane requests and the two challenge-auth token
-// endpoints. Disjoint from ARM (/subscriptions/…) and registered before the
-// blob storage REST fallback.
+// Matches claims /acr/v1/ data-plane requests, the OCI-distribution
+// /v2/{name}/manifests/{reference} manifest-content path, and the two
+// challenge-auth token endpoints. Disjoint from ARM (/subscriptions/…) and
+// registered before the blob storage REST fallback (whose broad
+// {container}/{blob}-shaped matching would otherwise silently swallow an
+// unclaimed /v2/… path and answer it with a nonsensical blob-storage error).
 func (*Handler) Matches(r *http.Request) bool {
-	return strings.HasPrefix(r.URL.Path, pathPrefix) ||
-		r.URL.Path == oauthExchangePath || r.URL.Path == oauthTokenPath
+	if strings.HasPrefix(r.URL.Path, pathPrefix) || r.URL.Path == oauthExchangePath || r.URL.Path == oauthTokenPath {
+		return true
+	}
+
+	_, _, ok := parseV2ManifestPath(r.URL.Path)
+
+	return ok
 }
 
 // ServeHTTP routes on the path tail and method.
@@ -77,6 +95,17 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	case oauthTokenPath:
 		serveOAuthToken(w, r)
+		return
+	}
+
+	if repo, reference, ok := parseV2ManifestPath(r.URL.Path); ok {
+		if r.Header.Get("Authorization") == "" {
+			challenge(w, repo)
+			return
+		}
+
+		h.serveV2Manifest(w, r, repo, reference)
+
 		return
 	}
 

--- a/server/azure/acr/types.go
+++ b/server/azure/acr/types.go
@@ -1,6 +1,7 @@
 package acr
 
 import (
+	"sort"
 	"strings"
 
 	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
@@ -153,7 +154,8 @@ func toManifestAttribute(img *crdriver.ImageDetail, attrs changeableAttributes) 
 
 // toManifestAttributes renders images (already filtered for listEnabled by the
 // driver's ListImages) into wire form, resolving each manifest's real
-// changeableAttributes via attrsFor.
+// changeableAttributes via attrsFor. The result is sorted by digest for a
+// stable, deterministic list order across calls.
 func toManifestAttributes(
 	images []crdriver.ImageDetail, attrsFor func(digest string) changeableAttributes,
 ) []manifestAttributes {
@@ -161,6 +163,8 @@ func toManifestAttributes(
 	for i := range images {
 		out = append(out, toManifestAttribute(&images[i], attrsFor(images[i].Digest)))
 	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Digest < out[j].Digest })
 
 	return out
 }
@@ -197,7 +201,8 @@ func countTags(images []crdriver.ImageDetail) int {
 // toTagAttributes renders every tag on images (already filtered for
 // manifest-level listEnabled by the driver's ListImages) into wire form,
 // resolving each tag's real changeableAttributes via attrsFor and dropping any
-// tag whose own listEnabled is false.
+// tag whose own listEnabled is false. The result is sorted by tag name for a
+// stable, deterministic list order across calls.
 func toTagAttributes(
 	images []crdriver.ImageDetail, attrsFor func(tag string) changeableAttributes,
 ) []tagAttributes {
@@ -225,6 +230,8 @@ func toTagAttributes(
 			})
 		}
 	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 
 	return out
 }


### PR DESCRIPTION
## Summary

Deep real-user e2e audit of Azure Container Registry (Microsoft.ContainerRegistry: registries + data-plane repositories/tags/manifests) via the real `azure-sdk-for-go` (`armcontainerregistry` + `azcontainerregistry`) against a running `cloudemu serve`. The surface was already mature (registries, admin credentials, quota usages, webhooks, geo-replications, and the `changeableAttributes` immutability lock from #1039 all correctly modeled with deep existing tests). Live black-box testing surfaced 4 real, fixable divergences, all fixed here.

## Findings & fixes

1. **HIGH — manifest GET/DELETE silently misrouted to blob storage.** The real `azcontainerregistry` SDK's `GetManifest`/`DeleteManifest` issue requests to `/v2/{name}/manifests/{reference}` (the OCI-distribution / Docker Registry HTTP API V2 path) — confirmed from the pinned SDK source (`azcontainerregistry@v0.2.3/client.go`), a *different* URL family from `/acr/v1/{name}/_manifests/{digest}` (changeableAttributes, already correctly served). cloudemu only claimed `/acr/v1/…`, so `/v2/…` fell through to the blob-storage handler's broad `{container}/{blob}` fallback, returning a misleading `BlobNotFound` XML error instead of an ACR-shaped one — even for a manifest the mock had modeled. Fixed by claiming and serving `/v2/{name}/manifests/{reference}` (GET/DELETE) in `server/azure/acr/dataplane_manifest.go`, backed by the already-modeled `GetImage`/`DeleteImage`. PUT (push) stays unmodeled (no real OCI blob storage, matching AWS ECR / GCP Artifact Registry) but now answers a clean 405 instead of leaking to blob storage.
2. **MEDIUM — `PutImage` dropped the raw manifest document (Azure-only).** `driver.ImageManifest.Manifest` was never copied onto the stored `ImageDetail.Manifest`, unlike both AWS ECR (`providers/aws/ecr/ecr.go`) and GCP Artifact Registry (`providers/gcp/artifactregistry/artifactregistry.go`), which do this correctly. Fixed in `providers/azure/acr/acr.go`.
3. **MEDIUM — nondeterministic list order.** `ListRegistries`/`ListWebhooks`/`ListReplications`/`ListRepositories`/`ListImages` all iterated an unordered Go map with no sort — confirmed live: two consecutive `NewListByResourceGroupPager` calls against the same 8 registries returned different orders. Every other Azure provider in this codebase sorts its list output (AKS, blob storage, …); ACR was the outlier. Fixed by sorting all five by name/digest.
4. **MEDIUM — `ListUsages` always reported Premium-tier limits.** Hardcoded storage (500 GiB) and webhook (100) limits regardless of the registry's actual SKU. Per [Azure Container Registry SKU limits](https://learn.microsoft.com/azure/container-registry/container-registry-skus): Basic 10 GiB/2 webhooks, Standard 100 GiB/10, Premium 500 GiB/500. Fixed with a per-SKU lookup in `providers/azure/acr/registry.go`.

## Gaps documented, not fixed (build-out)

- Webhook `ping` action — returns a clean `501 NotImplemented` rather than the real synthetic test-event response. Low value relative to effort.
- Real OCI push (`PUT /v2/.../manifests/...` + blob upload sessions) — no real blob storage, same documented boundary as AWS ECR / GCP Artifact Registry.
- Registry name length/charset validation (real ACR: 5–50 alphanumeric) is not enforced — consistent with cloudemu's broadly permissive validation elsewhere; noted, not filed as a bug.

## Verified, no divergence (not filed)

- PATCH-tags-REPLACE semantics (matches real ARM `tags` PATCH full-replace behavior).
- PATCH preserves untouched `adminUserEnabled`/SKU (already covered by existing tests).
- `getCallbackConfig` vs. plain `Get` webhook serviceUri exposure.
- Idempotent DELETE (204) for an already-gone registry/webhook/replication.

## Terraform (`azurerm_container_registry`)

Attempted and time-boxed per the established harness notes: `azurerm` v3.117.1 correctly discovers it must call the ARM environment-metadata endpoint (`/metadata/endpoints?api-version=2022-09-01`) for a custom `metadata_host`, but fails on the self-signed TLS cert (no provider-level skip-verify option) — and cloudemu doesn't implement `/metadata/endpoints` either. This is a pre-existing harness limitation (documented previously), not a product bug introduced or fixable in this PR. All findings were live-verified with the real Go SDK clients instead, which exercise the identical wire protocol.

## Tests

- `providers/azure/acr/list_ordering_test.go` — sort-order regression for registries/webhooks/replications/repositories/images.
- `providers/azure/acr/usage_limits_test.go` — table-driven per-SKU usage limits.
- `server/azure/acr/dataplane_manifest_test.go` — real-SDK `GetManifest`/`DeleteManifest` against `/v2/...`, including not-found shapes and an actual-deletion check (not just a success status code, since the SDK treats both 202 and 404 as success).
- Full existing ACR suite (provider + server) still green.

## Gates

- `go build ./...` — clean
- `go test -race -count=1 ./providers/azure/acr/... ./server/azure/acr/...` — pass
- `go vet` — clean
- `gofmt -l` — empty
- `golangci-lint run --new-from-rev=origin/development` — 0 new issues
- `go generate ./... && git diff docs/coverage` — no diff (interfaces unchanged)
- `go mod tidy` — no-op