### PR TITLE
fix(artifactregistry): real-user e2e divergences from GCP

### DIFF
--- a/server/gcp/artifactregistry/handler.go
+++ b/server/gcp/artifactregistry/handler.go
@@ -6,7 +6,8 @@
 //
 // Coverage (v1 REST):
 //
-//	POST   .../repositories?repositoryId={id}              — Create repo (async)
+//	POST   .../repositories?repositoryId={id}              — Create repo (async;
+//	                                                         repository_id alias)
 //	GET    .../repositories/{id}                           — Get repo
 //	GET    .../repositories                                — List repos (paged)
 //	PATCH  .../repositories/{id}                           — Update labels/description/mode

--- a/server/gcp/artifactregistry/operations.go
+++ b/server/gcp/artifactregistry/operations.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (h *Handler) createRepository(w http.ResponseWriter, r *http.Request, rt *route) {
-	repoID := r.URL.Query().Get("repositoryId")
+	repoID := repositoryIDParam(r)
 
 	var body repositoryJSON
 	if !gcprest.DecodeJSON(w, r, &body) {
@@ -31,6 +31,19 @@ func (h *Handler) createRepository(w http.ResponseWriter, r *http.Request, rt *r
 
 	gcprest.WriteJSON(w, http.StatusOK, h.doneOperation(rt, repoID,
 		typedResponse(repositoryTypeURL, toRepositoryJSON(rt.project, rt.location, repo, 0))))
+}
+
+// repositoryIDParam reads the create-repository id from the request query. The
+// google.golang.org/api client sends it as the JSON/camelCase name
+// (repositoryId); the Terraform google provider and gcloud send the proto
+// snake_case name (repository_id). Real Artifact Registry accepts either, so the
+// handler honors both, preferring camelCase when present.
+func repositoryIDParam(r *http.Request) string {
+	if id := r.URL.Query().Get("repositoryId"); id != "" {
+		return id
+	}
+
+	return r.URL.Query().Get("repository_id")
 }
 
 // reservedTagsFrom folds the GCP-only Repository fields (format, description,

--- a/server/gcp/artifactregistry/repository_create_id_test.go
+++ b/server/gcp/artifactregistry/repository_create_id_test.go
@@ -1,0 +1,77 @@
+package artifactregistry_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+	ar "google.golang.org/api/artifactregistry/v1"
+	"google.golang.org/api/option"
+)
+
+// TestCreateRepositoryIDParamAliases guards the HIGH finding: the Terraform
+// google provider and gcloud send the create-repository id as the proto
+// snake_case query parameter `repository_id`, whereas the
+// google.golang.org/api client sends the JSON camelCase `repositoryId`. Real
+// Artifact Registry accepts either; the handler previously read only
+// `repositoryId`, so every Terraform-driven create 400'd with
+// "repository name is required". Both aliases must now create the repository.
+func TestCreateRepositoryIDParamAliases(t *testing.T) {
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{ArtifactRegistry: cloud.ArtifactRegistry})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := ar.NewService(context.Background(),
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	for _, param := range []string{"repositoryId", "repository_id"} {
+		id := "tf-" + strings.ReplaceAll(param, "_", "")
+
+		url := ts.URL + "/v1/" + testParent + "/repositories?" + param + "=" + id
+		body := strings.NewReader(`{"format":"DOCKER"}`)
+
+		resp, err := http.Post(url, "application/json", body)
+		if err != nil {
+			t.Fatalf("[%s] POST: %v", param, err)
+		}
+
+		var op struct {
+			Done     bool `json:"done"`
+			Response struct {
+				Name string `json:"name"`
+			} `json:"response"`
+		}
+
+		if derr := json.NewDecoder(resp.Body).Decode(&op); derr != nil {
+			t.Fatalf("[%s] decode: %v", param, derr)
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("[%s] status=%d want 200", param, resp.StatusCode)
+		}
+
+		want := testParent + "/repositories/" + id
+		if op.Response.Name != want {
+			t.Fatalf("[%s] response name=%q want %q", param, op.Response.Name, want)
+		}
+
+		got, gerr := svc.Projects.Locations.Repositories.Get(want).Do()
+		if gerr != nil {
+			t.Fatalf("[%s] Get after create: %v", param, gerr)
+		}
+
+		if got.Format != "DOCKER" {
+			t.Fatalf("[%s] format=%q want DOCKER", param, got.Format)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of GCP Artifact Registry (SDK + Terraform + `cloudemu serve`) against the live GCP v1 REST API.

### Fixed

**HIGH — Terraform create was completely broken.** The google Terraform provider and `gcloud` send the create-repository id as the proto snake_case query param `repository_id`, while the `google.golang.org/api` SDK sends the JSON camelCase `repositoryId`. The handler read only `repositoryId`, so every Terraform `google_artifact_registry_repository` create failed with `400: repository name is required`. Real Artifact Registry accepts either alias. The handler now honors both (`repositoryIDParam`), preferring camelCase.

Captured via `TF_LOG=DEBUG`:
`POST /v1/projects/demo/locations/us-central1/repositories?alt=json&repository_id=tf-repo`

### Live verification (Terraform google v6.50.0 → `cloudemu serve`)

Full lifecycle now green: create → empty re-plan (no drift) → label+description update (PATCH updateMask) → empty post-update plan → destroy. A second config with a DOCKER repo (`docker_config { immutable_tags }` + `cleanup_policies`), a MAVEN repo, and `google_artifact_registry_repository_iam_member` applied with zero drift and destroyed cleanly. SDK camelCase path stays covered by existing tests.

Regression test: `TestCreateRepositoryIDParamAliases` (raw POST with each alias).

### Filed, not fixed (out of scope)

Real artifact blob data-plane (docker push / maven / npm upload) is not implemented — images arrive only via the driver's `PutImage`. Repository CRUD/list/IAM work end-to-end; wire-level artifact upload is a large deferred surface.