### PR TITLE
fix(eventhub): real-user e2e divergences from Azure

### DIFF
--- a/server/azure/eventhub/consumergroup.go
+++ b/server/azure/eventhub/consumergroup.go
@@ -95,6 +95,14 @@ func (h *Handler) deleteConsumerGroup(w http.ResponseWriter, ep ehPath, eh, name
 		return
 	}
 
+	// The built-in $Default consumer group cannot be deleted; real Azure rejects
+	// the request rather than removing it.
+	if eq(name, defaultConsumerGroup) {
+		azurearm.WriteError(w, http.StatusBadRequest, "BadRequest",
+			"The default consumer group '$Default' cannot be deleted.")
+		return
+	}
+
 	if _, ok := rec.ConsumerGroups[name]; !ok {
 		w.WriteHeader(http.StatusNoContent)
 		return

--- a/server/azure/eventhub/eventhub.go
+++ b/server/azure/eventhub/eventhub.go
@@ -1,6 +1,7 @@
 package eventhub
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -64,6 +65,13 @@ func (h *Handler) createEventHub(w http.ResponseWriter, r *http.Request, ep ehPa
 	if !ok {
 		h.mu.Unlock()
 		writeNSNotFound(w, ep.namespace)
+
+		return
+	}
+
+	if msg := eventHubPropsError(&req.Properties, ns.SKU.Tier); msg != "" {
+		h.mu.Unlock()
+		azurearm.WriteError(w, http.StatusBadRequest, "BadRequest", msg)
 
 		return
 	}
@@ -166,6 +174,65 @@ func (h *Handler) withEventHub(w http.ResponseWriter, ep ehPath, name string, fn
 	}
 
 	fn(rec)
+}
+
+// eventHubPropsError validates client-supplied event-hub properties against the
+// namespace tier's limits, returning a non-empty ARM error message when a
+// provided value is out of range. Omitted (nil) values are left to
+// buildEventHubProps to default. Higher tiers (Premium/Dedicated) use a
+// retentionDescription and larger partition ceilings, so only the lower bounds
+// are enforced for them.
+func eventHubPropsError(props *eventHubProperties, tier string) string {
+	if pc := props.PartitionCount; pc != nil {
+		if *pc < minPartitionCount {
+			return fmt.Sprintf("partitionCount must be at least %d", minPartitionCount)
+		}
+
+		if boundedTier(tier) && *pc > maxPartitionCount {
+			return fmt.Sprintf("partitionCount %d exceeds the maximum of %d for the %s tier",
+				*pc, maxPartitionCount, tierLabel(tier))
+		}
+	}
+
+	if rd := props.MessageRetentionInDays; rd != nil {
+		if *rd < minRetentionDays {
+			return fmt.Sprintf("messageRetentionInDays must be at least %d", minRetentionDays)
+		}
+
+		if maxDays, ok := maxRetentionForTier(tier); ok && *rd > maxDays {
+			return fmt.Sprintf("messageRetentionInDays %d exceeds the maximum of %d for the %s tier",
+				*rd, maxDays, tierLabel(tier))
+		}
+	}
+
+	return ""
+}
+
+// boundedTier reports whether tier caps partitionCount at maxPartitionCount. The
+// Basic and Standard tiers do; higher tiers allow more partitions.
+func boundedTier(tier string) bool {
+	return eq(tier, "Basic") || eq(tier, "Standard") || tier == ""
+}
+
+// maxRetentionForTier returns the messageRetentionInDays ceiling for a tier. ok
+// is false for tiers whose retention is not bounded here (Premium/Dedicated).
+func maxRetentionForTier(tier string) (int64, bool) {
+	switch {
+	case eq(tier, "Basic"):
+		return maxRetentionBasic, true
+	case eq(tier, "Standard") || tier == "":
+		return maxRetentionStandard, true
+	default:
+		return 0, false
+	}
+}
+
+func tierLabel(tier string) string {
+	if tier == "" {
+		return "Standard"
+	}
+
+	return tier
 }
 
 // buildEventHubProps synthesizes the server-computed fields and defaults a real

--- a/server/azure/eventhub/eventhub_divergence_test.go
+++ b/server/azure/eventhub/eventhub_divergence_test.go
@@ -1,0 +1,192 @@
+package eventhub_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub"
+)
+
+// TestSDKNamespaceSKUCapacityDefault checks that a namespace created without an
+// explicit sku.capacity reports capacity 1, matching real Azure (which always
+// returns a capacity and defaults it to 1). An omitted capacity causes read-back
+// drift for SDK/CLI/Terraform.
+func TestSDKNamespaceSKUCapacityDefault(t *testing.T) {
+	ts := newServer(t)
+	ctx := context.Background()
+
+	c, err := armeventhub.NewNamespacesClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewNamespacesClient: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		sku  *armeventhub.SKU
+	}{
+		{"standard-no-capacity", &armeventhub.SKU{Name: to.Ptr(armeventhub.SKUNameStandard)}},
+		{"no-sku-at-all", nil},
+	}
+
+	for i, tc := range cases {
+		ns := nsName + "-cap"
+		if i == 1 {
+			ns += "2"
+		}
+
+		poller, err := c.BeginCreateOrUpdate(ctx, rgName, ns, armeventhub.EHNamespace{
+			Location: to.Ptr("eastus"),
+			SKU:      tc.sku,
+		}, nil)
+		if err != nil {
+			t.Fatalf("%s: BeginCreateOrUpdate: %v", tc.name, err)
+		}
+
+		if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+			t.Fatalf("%s: poll create: %v", tc.name, err)
+		}
+
+		got, err := c.Get(ctx, rgName, ns, nil)
+		if err != nil {
+			t.Fatalf("%s: Get: %v", tc.name, err)
+		}
+
+		if got.SKU == nil || got.SKU.Capacity == nil {
+			t.Fatalf("%s: sku.capacity = nil, want 1", tc.name)
+		}
+
+		if *got.SKU.Capacity != 1 {
+			t.Fatalf("%s: sku.capacity = %d, want 1", tc.name, *got.SKU.Capacity)
+		}
+	}
+}
+
+// TestSDKDefaultConsumerGroupNotDeletable checks that the built-in $Default
+// consumer group cannot be deleted, matching real Azure (which rejects the
+// request). This is a well-known Terraform pain point.
+func TestSDKDefaultConsumerGroupNotDeletable(t *testing.T) {
+	ts := newServer(t)
+	ctx := context.Background()
+
+	seedEventHub(t, ctx, ts)
+
+	cgClient, err := armeventhub.NewConsumerGroupsClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewConsumerGroupsClient: %v", err)
+	}
+
+	_, err = cgClient.Delete(ctx, rgName, nsName, ehName, "$Default", nil)
+	if err == nil {
+		t.Fatal("Delete $Default consumer group returned nil error, want BadRequest")
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("Delete $Default error = %v, want HTTP 400", err)
+	}
+
+	// $Default must still be present after the rejected delete.
+	if _, err := cgClient.Get(ctx, rgName, nsName, ehName, "$Default", nil); err != nil {
+		t.Fatalf("$Default consumer group Get after rejected delete: %v", err)
+	}
+
+	// A non-default consumer group is still deletable.
+	if _, err := cgClient.CreateOrUpdate(ctx, rgName, nsName, ehName, "workers",
+		armeventhub.ConsumerGroup{}, nil); err != nil {
+		t.Fatalf("CreateOrUpdate workers consumer group: %v", err)
+	}
+
+	if _, err := cgClient.Delete(ctx, rgName, nsName, ehName, "workers", nil); err != nil {
+		t.Fatalf("Delete workers consumer group: %v", err)
+	}
+}
+
+// TestSDKEventHubPropertyValidation checks that out-of-range partitionCount and
+// messageRetentionInDays are rejected on a Standard-tier namespace, matching real
+// Azure's BadRequest, while in-range values succeed.
+func TestSDKEventHubPropertyValidation(t *testing.T) {
+	ts := newServer(t)
+	ctx := context.Background()
+
+	createStandardNamespace(t, ctx, ts)
+
+	ehClient, err := armeventhub.NewEventHubsClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewEventHubsClient: %v", err)
+	}
+
+	bad := []struct {
+		name  string
+		props *armeventhub.Properties
+	}{
+		{"partition-count-too-high", &armeventhub.Properties{PartitionCount: to.Ptr[int64](100)}},
+		{"partition-count-zero", &armeventhub.Properties{PartitionCount: to.Ptr[int64](0)}},
+		{"retention-too-high", &armeventhub.Properties{MessageRetentionInDays: to.Ptr[int64](30)}},
+	}
+
+	for _, tc := range bad {
+		_, err := ehClient.CreateOrUpdate(ctx, rgName, nsName, "eh-"+tc.name,
+			armeventhub.Eventhub{Properties: tc.props}, nil)
+		if err == nil {
+			t.Fatalf("%s: CreateOrUpdate returned nil error, want BadRequest", tc.name)
+		}
+
+		var respErr *azcore.ResponseError
+		if !errors.As(err, &respErr) || respErr.StatusCode != http.StatusBadRequest {
+			t.Fatalf("%s: error = %v, want HTTP 400", tc.name, err)
+		}
+	}
+
+	// In-range values on Standard succeed (32 partitions, 7-day retention).
+	if _, err := ehClient.CreateOrUpdate(ctx, rgName, nsName, "eh-valid", armeventhub.Eventhub{
+		Properties: &armeventhub.Properties{
+			PartitionCount:         to.Ptr[int64](32),
+			MessageRetentionInDays: to.Ptr[int64](7),
+		},
+	}, nil); err != nil {
+		t.Fatalf("CreateOrUpdate valid event hub: %v", err)
+	}
+}
+
+func createStandardNamespace(t *testing.T, ctx context.Context, ts *httptest.Server) {
+	t.Helper()
+
+	c, err := armeventhub.NewNamespacesClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewNamespacesClient: %v", err)
+	}
+
+	poller, err := c.BeginCreateOrUpdate(ctx, rgName, nsName, armeventhub.EHNamespace{
+		Location: to.Ptr("eastus"),
+		SKU:      &armeventhub.SKU{Name: to.Ptr(armeventhub.SKUNameStandard)},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate namespace: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll namespace create: %v", err)
+	}
+}
+
+func seedEventHub(t *testing.T, ctx context.Context, ts *httptest.Server) {
+	t.Helper()
+
+	createStandardNamespace(t, ctx, ts)
+
+	ehClient, err := armeventhub.NewEventHubsClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewEventHubsClient: %v", err)
+	}
+
+	if _, err := ehClient.CreateOrUpdate(ctx, rgName, nsName, ehName, armeventhub.Eventhub{
+		Properties: &armeventhub.Properties{PartitionCount: to.Ptr[int64](4)},
+	}, nil); err != nil {
+		t.Fatalf("CreateOrUpdate event hub: %v", err)
+	}
+}

--- a/server/azure/eventhub/namespace.go
+++ b/server/azure/eventhub/namespace.go
@@ -205,7 +205,7 @@ func (h *Handler) checkNameAvailability(w http.ResponseWriter, r *http.Request) 
 
 func normalizeSKU(in *ehSKU) ehSKU {
 	if in == nil || in.Name == "" {
-		return ehSKU{Name: "Standard", Tier: "Standard"}
+		return ehSKU{Name: "Standard", Tier: "Standard", Capacity: defaultCapacity()}
 	}
 
 	out := *in
@@ -213,7 +213,19 @@ func normalizeSKU(in *ehSKU) ehSKU {
 		out.Tier = out.Name
 	}
 
+	// Real Azure always reports a capacity (defaulting to 1 throughput unit); an
+	// omitted capacity in the response causes read-back drift for SDK/CLI/Terraform.
+	if out.Capacity == nil {
+		out.Capacity = defaultCapacity()
+	}
+
 	return out
+}
+
+func defaultCapacity() *int32 {
+	c := int32(defaultSKUCapacity)
+
+	return &c
 }
 
 func toNamespaceResource(ns *namespaceState) namespaceResource {

--- a/server/azure/eventhub/state.go
+++ b/server/azure/eventhub/state.go
@@ -26,6 +26,18 @@ const (
 	// defaultRetentionDays is Event Hubs' default message retention (Standard tier
 	// tops out at 7 days) reported when a create request omits it.
 	defaultRetentionDays = 7
+	// defaultSKUCapacity is the throughput-unit capacity a namespace reports when a
+	// create request omits sku.capacity; real Azure always returns 1.
+	defaultSKUCapacity = 1
+	// Event-hub property bounds enforced at create time. partitionCount is 1..32 on
+	// the Basic and Standard tiers; messageRetentionInDays is 1 day on Basic and up
+	// to 7 on Standard (higher tiers use retentionDescription and are left
+	// unbounded here).
+	minPartitionCount    = 1
+	maxPartitionCount    = 32
+	minRetentionDays     = 1
+	maxRetentionBasic    = 1
+	maxRetentionStandard = 7
 	// listPageSize is how many entities a list returns before emitting a nextLink.
 	listPageSize = 100
 	// skipParam is the query parameter a paged list request carries to resume at


### PR DESCRIPTION
## Summary

Real-user e2e audit of the Azure Event Hubs (Microsoft.EventHub) ARM control-plane handler (`server/azure/eventhub/`) against the official Microsoft docs (api-version 2026-01-01), driving it with the real `armeventhub` SDK and curl over the HTTPS `cloudemu serve` listener. Three genuine cloud-vs-cloudemu divergences fixed.

## Findings fixed

| Severity | Divergence | Fix |
| --- | --- | --- |
| High | Namespace responses omitted `sku.capacity` when the client omitted it; real Azure always reports a capacity (default 1), so SDK/CLI/Terraform read-back drifted. | `normalizeSKU` defaults capacity to 1. |
| High | The built-in `$Default` consumer group was deletable; real Azure rejects the request (well-known `azurerm` Terraform pain, provider #17575). | `deleteConsumerGroup` returns BadRequest for `$Default`. |
| Med | No range enforcement on `partitionCount` or `messageRetentionInDays`; out-of-range values were silently accepted/defaulted instead of Azure's BadRequest. | `createEventHub` validates partitionCount (1-32 Basic/Standard) and retention (Basic 1, Standard 7); higher tiers keep only the lower bound. |

## Verified matching real Azure (no change)

Type-field casing, event hub create returning 200, deterministic list ordering, clean ARM error envelopes (no cerrors prefix leak), subscription+RG scope enforcement, PATCH-tags-replace semantics, namespace delete cascade, and listKeys/regenerateKeys connection strings.

## Tests / evidence

- New `eventhub_divergence_test.go`: real `armeventhub` SDK regression tests for all three fixes (capacity default, `$Default` protection, property validation).
- Black-box curl over `cloudemu serve` (HTTPS): confirmed `sku.capacity: 1`, `$Default` delete -> 400, partitionCount=100 -> 400, and that non-default consumer groups + in-range event hubs still succeed.
- Gates green: `go build`, `go vet`, `gofmt`, `golangci-lint --new-from-rev` (0 issues), `go test -race` (eventhub), `go generate` (no coverage diff).

## Filed, not fixed (scoped out)

- Basic-tier consumer-group quota (max 1).
- Namespace-name pattern validation (`^[a-zA-Z][a-zA-Z0-9-]{6,50}[a-zA-Z0-9]$`).
- AMQP/Kafka data plane, Capture, schema registry (control-plane-only handler boundary, same as Service Bus).