### PR TITLE
fix(cloudlogging): real-user e2e divergences from GCP

### DIFF
--- a/providers/gcp/cloudlogging/gcp_resources.go
+++ b/providers/gcp/cloudlogging/gcp_resources.go
@@ -83,27 +83,52 @@ func (m *Mock) ListSinks(_ context.Context, project string) ([]driver.LogSink, e
 	return sinks, nil
 }
 
-// UpdateSink replaces the mutable fields of an existing sink (identity and
-// createTime are preserved).
-func (m *Mock) UpdateSink(_ context.Context, project string, sink *driver.LogSink) (*driver.LogSink, error) {
-	key := resourceKey(project, sink.Name)
+// UpdateSink applies a partial (updateMask-driven) update to an existing sink.
+// Only fields whose Set* flag is true are overwritten; the sink's name and
+// createTime are always preserved, and its writer identity is preserved unless
+// the update carries a replacement. The read-modify-write runs under the store's
+// lock (via Update) so a concurrent GetSink can never observe a torn write.
+func (m *Mock) UpdateSink(_ context.Context, project, name string, update *driver.SinkUpdate) (*driver.LogSink, error) {
+	key := resourceKey(project, name)
 
-	existing, ok := m.sinks.Get(key)
-	if !ok {
-		return nil, errors.Newf(errors.NotFound, "sink %q not found", sink.Name)
+	var result driver.LogSink
+
+	found := m.sinks.Update(key, func(existing *driver.LogSink) *driver.LogSink {
+		updated := *existing
+
+		if update.SetDestination {
+			updated.Destination = update.Destination
+		}
+
+		if update.SetFilter {
+			updated.Filter = update.Filter
+		}
+
+		if update.SetDescription {
+			updated.Description = update.Description
+		}
+
+		if update.SetDisabled {
+			updated.Disabled = update.Disabled
+		}
+
+		if update.SetIncludeChildren {
+			updated.IncludeChildren = update.IncludeChildren
+		}
+
+		if update.WriterIdentity != "" {
+			updated.WriterIdentity = update.WriterIdentity
+		}
+
+		updated.UpdatedAt = m.opts.Clock.Now().UTC()
+		result = updated
+
+		return &updated
+	})
+
+	if !found {
+		return nil, errors.Newf(errors.NotFound, "sink %q not found", name)
 	}
-
-	updated := *existing
-	updated.Destination = sink.Destination
-	updated.Filter = sink.Filter
-	updated.Description = sink.Description
-	updated.Disabled = sink.Disabled
-	updated.IncludeChildren = sink.IncludeChildren
-	updated.UpdatedAt = m.opts.Clock.Now().UTC()
-
-	m.sinks.Set(key, &updated)
-
-	result := updated
 
 	return &result, nil
 }

--- a/providers/gcp/cloudlogging/gcp_resources_test.go
+++ b/providers/gcp/cloudlogging/gcp_resources_test.go
@@ -1,0 +1,100 @@
+package cloudlogging
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/logging/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testProject = "demo"
+
+// TestCreateSinkWriterIdentity guards that a sink with no caller-supplied writer
+// identity falls back to the shared non-unique account, and a caller-supplied
+// one (unique/custom, resolved by the wire layer) is stored verbatim.
+func TestCreateSinkWriterIdentity(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("default shared account", func(t *testing.T) {
+		m := newTestMock()
+
+		s, err := m.CreateSink(ctx, testProject, &driver.LogSink{
+			Name:        "s1",
+			Destination: "storage.googleapis.com/b",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, defaultSinkWriterIdentity, s.WriterIdentity)
+	})
+
+	t.Run("caller-supplied identity preserved", func(t *testing.T) {
+		m := newTestMock()
+
+		s, err := m.CreateSink(ctx, testProject, &driver.LogSink{
+			Name:           "s2",
+			Destination:    "storage.googleapis.com/b",
+			WriterIdentity: "serviceAccount:service-demo@gcp-sa-logging.iam.gserviceaccount.com",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "serviceAccount:service-demo@gcp-sa-logging.iam.gserviceaccount.com", s.WriterIdentity)
+	})
+}
+
+// TestUpdateSinkPartialMask guards that a masked update touches only the fields
+// whose Set* flag is set, leaving every other field (including the writer
+// identity) unchanged — the semantics of a Cloud Logging updateMask patch.
+func TestUpdateSinkPartialMask(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateSink(ctx, testProject, &driver.LogSink{
+		Name:        "s",
+		Destination: "storage.googleapis.com/keep",
+		Filter:      "severity>=ERROR",
+		Description: "keep me",
+	})
+	require.NoError(t, err)
+
+	// Update only the filter.
+	updated, err := m.UpdateSink(ctx, testProject, "s", &driver.SinkUpdate{
+		Filter:    "severity>=WARNING",
+		SetFilter: true,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "severity>=WARNING", updated.Filter, "filter updated")
+	assert.Equal(t, "storage.googleapis.com/keep", updated.Destination, "destination preserved")
+	assert.Equal(t, "keep me", updated.Description, "description preserved")
+	assert.Equal(t, defaultSinkWriterIdentity, updated.WriterIdentity, "writer identity preserved")
+}
+
+// TestUpdateSinkWriterIdentityReplace guards that a non-empty WriterIdentity on
+// the update replaces the stored one (a uniqueWriterIdentity/customWriterIdentity
+// transition), while an empty one leaves it unchanged.
+func TestUpdateSinkWriterIdentityReplace(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateSink(ctx, testProject, &driver.LogSink{Name: "s", Destination: "storage.googleapis.com/b"})
+	require.NoError(t, err)
+
+	const unique = "serviceAccount:service-demo@gcp-sa-logging.iam.gserviceaccount.com"
+
+	replaced, err := m.UpdateSink(ctx, testProject, "s", &driver.SinkUpdate{WriterIdentity: unique})
+	require.NoError(t, err)
+	assert.Equal(t, unique, replaced.WriterIdentity)
+
+	// Empty identity leaves it unchanged.
+	kept, err := m.UpdateSink(ctx, testProject, "s", &driver.SinkUpdate{Filter: "x", SetFilter: true})
+	require.NoError(t, err)
+	assert.Equal(t, unique, kept.WriterIdentity)
+}
+
+// TestUpdateSinkNotFound guards the not-found path.
+func TestUpdateSinkNotFound(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.UpdateSink(context.Background(), testProject, "nope", &driver.SinkUpdate{})
+	require.Error(t, err)
+}

--- a/server/gcp/cloudlogging/sinks.go
+++ b/server/gcp/cloudlogging/sinks.go
@@ -132,9 +132,22 @@ func createSink(w http.ResponseWriter, r *http.Request, gcp logdriver.GCPLogging
 		return
 	}
 
-	s, err := gcp.CreateSink(r.Context(), project, body.toDriver(body.Name))
+	sink := body.toDriver(body.Name)
+
+	// writerIdentity is output-only: its value is chosen by query params, never
+	// the request body — a unique per-parent service agent
+	// (uniqueWriterIdentity=true) or an explicit one (customWriterIdentity). When
+	// neither is set this is "" and the provider fills the shared, non-unique
+	// account.
+	sink.WriterIdentity = sinkWriterIdentity(project, r)
+
+	s, err := gcp.CreateSink(r.Context(), project, sink)
 	writeSink(w, s, err)
 }
+
+// defaultSinkUpdateMask is the field set an updateMask-less sink PATCH touches,
+// matching real Cloud Logging's documented backwards-compatible default.
+const defaultSinkUpdateMask = "destination,filter,includeChildren"
 
 func updateSink(w http.ResponseWriter, r *http.Request, gcp logdriver.GCPLogging, project, sinkID string) {
 	var body logSinkJSON
@@ -142,8 +155,53 @@ func updateSink(w http.ResponseWriter, r *http.Request, gcp logdriver.GCPLogging
 		return
 	}
 
-	s, err := gcp.UpdateSink(r.Context(), project, body.toDriver(sinkID))
+	mask := r.URL.Query().Get("updateMask")
+	if mask == "" {
+		mask = defaultSinkUpdateMask
+	}
+
+	update := &logdriver.SinkUpdate{
+		Destination:        body.Destination,
+		SetDestination:     maskHas(mask, "destination"),
+		Filter:             body.Filter,
+		SetFilter:          maskHas(mask, "filter"),
+		Description:        body.Description,
+		SetDescription:     maskHas(mask, "description"),
+		Disabled:           body.Disabled,
+		SetDisabled:        maskHas(mask, "disabled"),
+		IncludeChildren:    body.IncludeChildren,
+		SetIncludeChildren: maskHas(mask, "includeChildren") || maskHas(mask, "include_children"),
+		WriterIdentity:     sinkWriterIdentity(project, r),
+	}
+
+	s, err := gcp.UpdateSink(r.Context(), project, sinkID, update)
 	writeSink(w, s, err)
+}
+
+// sinkWriterIdentity resolves the writerIdentity a create/patch requests via
+// query params. customWriterIdentity wins; uniqueWriterIdentity=true yields a
+// per-parent Cloud Logging service agent; otherwise "" (the provider fills the
+// shared non-unique account and a patch leaves the stored identity unchanged).
+func sinkWriterIdentity(project string, r *http.Request) string {
+	if custom := r.URL.Query().Get("customWriterIdentity"); custom != "" {
+		return custom
+	}
+
+	if r.URL.Query().Get("uniqueWriterIdentity") == "true" {
+		return uniqueWriterIdentityFor(project)
+	}
+
+	return ""
+}
+
+// uniqueWriterIdentityFor returns the deterministic per-parent Logging service
+// agent used when a sink requests a unique writer identity. Real Cloud Logging
+// keys this on the project number; the emulator has no project number, so it
+// derives a stable, realistically-shaped agent from the project id. It differs
+// from the shared non-unique account, which is what SDK/Terraform callers check
+// to infer unique_writer_identity.
+func uniqueWriterIdentityFor(project string) string {
+	return "serviceAccount:service-" + project + "@gcp-sa-logging.iam.gserviceaccount.com"
 }
 
 func listSinks(w http.ResponseWriter, r *http.Request, gcp logdriver.GCPLogging, project string) {

--- a/server/gcp/cloudlogging/sinks_sdk_test.go
+++ b/server/gcp/cloudlogging/sinks_sdk_test.go
@@ -78,6 +78,91 @@ func TestSDKSinksLifecycle(t *testing.T) {
 	}
 }
 
+// TestSDKSinksWriterIdentity guards the writer-identity contract a real
+// Terraform/gcloud user depends on: uniqueWriterIdentity=true yields an identity
+// distinct from the shared non-unique account (so terraform-google infers
+// unique_writer_identity=true and sees no drift), the default yields the shared
+// account, and customWriterIdentity is honored verbatim.
+func TestSDKSinksWriterIdentity(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+	parent := "projects/" + testProject
+
+	const nonUnique = "serviceAccount:cloud-logs@system.gserviceaccount.com"
+
+	unique, err := svc.Projects.Sinks.Create(parent, &logging.LogSink{
+		Name: "uniq", Destination: "storage.googleapis.com/b",
+	}).UniqueWriterIdentity(true).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Sinks.Create unique: %v", err)
+	}
+
+	if unique.WriterIdentity == "" || unique.WriterIdentity == nonUnique {
+		t.Errorf("unique writerIdentity = %q, want a distinct non-shared account", unique.WriterIdentity)
+	}
+
+	shared, err := svc.Projects.Sinks.Create(parent, &logging.LogSink{
+		Name: "shared", Destination: "storage.googleapis.com/b",
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Sinks.Create shared: %v", err)
+	}
+
+	if shared.WriterIdentity != nonUnique {
+		t.Errorf("shared writerIdentity = %q, want %q", shared.WriterIdentity, nonUnique)
+	}
+
+	custom, err := svc.Projects.Sinks.Create(parent, &logging.LogSink{
+		Name: "cust", Destination: "storage.googleapis.com/b",
+	}).CustomWriterIdentity("serviceAccount:me@x.iam.gserviceaccount.com").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Sinks.Create custom: %v", err)
+	}
+
+	if custom.WriterIdentity != "serviceAccount:me@x.iam.gserviceaccount.com" {
+		t.Errorf("custom writerIdentity = %q", custom.WriterIdentity)
+	}
+}
+
+// TestSDKSinksMaskedPatch guards updateMask partial semantics: a patch naming
+// only "filter" updates the filter and must leave destination, description and
+// writerIdentity untouched (a full-replace would silently clear them — the bug
+// this test locks down).
+func TestSDKSinksMaskedPatch(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+	parent := "projects/" + testProject
+	sinkName := parent + "/sinks/patch-sink"
+
+	if _, err := svc.Projects.Sinks.Create(parent, &logging.LogSink{
+		Name:        "patch-sink",
+		Destination: "storage.googleapis.com/keep",
+		Filter:      "severity>=ERROR",
+		Description: "keep me",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Sinks.Create: %v", err)
+	}
+
+	updated, err := svc.Projects.Sinks.Patch(sinkName, &logging.LogSink{
+		Filter: "severity>=WARNING",
+	}).UpdateMask("filter").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Sinks.Patch: %v", err)
+	}
+
+	if updated.Filter != "severity>=WARNING" {
+		t.Errorf("filter = %q, want severity>=WARNING", updated.Filter)
+	}
+
+	if updated.Destination != "storage.googleapis.com/keep" {
+		t.Errorf("destination cleared by masked patch: %q", updated.Destination)
+	}
+
+	if updated.Description != "keep me" {
+		t.Errorf("description cleared by masked patch: %q", updated.Description)
+	}
+}
+
 // TestSDKSinksGetMissing guards a not-found error for an unknown sink.
 func TestSDKSinksGetMissing(t *testing.T) {
 	svc := newLoggingService(t)

--- a/services/logging/driver/gcp.go
+++ b/services/logging/driver/gcp.go
@@ -55,6 +55,28 @@ type LogBucket struct {
 	UpdatedAt      time.Time
 }
 
+// SinkUpdate describes a partial update (PATCH) to an export sink's mutable
+// fields. Each Set* flag mirrors whether the wire layer's updateMask named that
+// field, so a field the caller did not name is left unchanged rather than reset
+// to its Go zero value (a masked patch must never silently clear the sink's
+// destination, filter, or description).
+type SinkUpdate struct {
+	Destination        string
+	SetDestination     bool
+	Filter             string
+	SetFilter          bool
+	Description        string
+	SetDescription     bool
+	Disabled           bool
+	SetDisabled        bool
+	IncludeChildren    bool
+	SetIncludeChildren bool
+	// WriterIdentity, when non-empty, replaces the sink's writer identity — a
+	// uniqueWriterIdentity or customWriterIdentity transition requested on the
+	// wire. Empty leaves the stored identity unchanged.
+	WriterIdentity string
+}
+
 // BucketUpdate describes a partial update (PATCH) to a log bucket's mutable
 // fields. Each Set* flag mirrors whether the wire layer's updateMask (or, for a
 // mask-less caller, a presence heuristic) named that field, so a field the
@@ -77,7 +99,7 @@ type GCPLogging interface {
 	CreateSink(ctx context.Context, project string, sink *LogSink) (*LogSink, error)
 	GetSink(ctx context.Context, project, name string) (*LogSink, error)
 	ListSinks(ctx context.Context, project string) ([]LogSink, error)
-	UpdateSink(ctx context.Context, project string, sink *LogSink) (*LogSink, error)
+	UpdateSink(ctx context.Context, project, name string, update *SinkUpdate) (*LogSink, error)
 	DeleteSink(ctx context.Context, project, name string) error
 
 	CreateLogMetric(ctx context.Context, project string, metric *LogBasedMetric) (*LogBasedMetric, error)


### PR DESCRIPTION
Real-user e2e audit of GCP Cloud Logging against the real `google.golang.org/api/logging/v2` SDK and Terraform `hashicorp/google` v6.50.0 (via `cloudemu serve -providers=gcp`). Two genuine cloud-vs-cloudemu divergences a real Terraform/gcloud user hits, both fixed.

## Fixes

**1. Sink `writerIdentity` ignored `uniqueWriterIdentity` / `customWriterIdentity`**
`projects.sinks.create` and `.patch` always returned the shared account `serviceAccount:cloud-logs@system.gserviceaccount.com`, ignoring the query params that choose the identity kind. `google_logging_project_sink { unique_writer_identity = true }` read back the shared account, so terraform-google inferred `unique=false` → permanent plan drift on every apply. The wire layer now resolves the identity from the query params (custom > unique per-parent agent > shared default); the unique agent is a deterministic, realistically-shaped `serviceAccount:service-{project}@gcp-sa-logging.iam.gserviceaccount.com`.

**2. Masked sink `patch` did a full replace, clearing unlisted fields**
`projects.sinks.patch` ignored `updateMask` and overwrote every mutable field from the body, so a masked patch naming only `filter` silently wiped `destination` and `description` — data loss. A Terraform filter change sends `PATCH ...?updateMask=exclusions,filter` (no destination), so the export destination was cleared server-side. Added `driver.SinkUpdate` (Set* flags, mirroring the existing `BucketUpdate`); the provider `UpdateSink` is now a copy-on-write masked update under the store lock; the wire layer parses the mask (defaulting to the documented `destination,filter,includeChildren`).

## Verification
- Real SDK: create/get/list/patch/delete + writer-identity + masked-patch (new tests in `sinks_sdk_test.go`, provider-level guards in `gcp_resources_test.go`).
- Terraform: apply of unique + shared sinks → distinct unique vs shared `writer_identity`, `terraform plan` = No changes; filter change triggers `PATCH ...&uniqueWriterIdentity=true&updateMask=exclusions%2Cfilter`, destination/identity preserved, re-plan clean; destroy clean.
- Gates: `go build ./...`, `go test -race` (logging + gcp/cloudlogging + server/gcp/cloudlogging), `go vet`, `gofmt`, `golangci-lint --new-from-rev` all green; `go generate` no docs/coverage drift.

## Filed, not fixed (broader scope)
- `google_logging_metric` custom-endpoint path-prefix mismatch: the handwritten sink resource emits `/v2/projects/.../sinks` while MMv1 `google_logging_metric` emits `/projects/.../metrics` (no `/v2/`), so a single `logging_custom_endpoint` cannot serve both against a strict `/v2/`-only handler. The metric backend itself is correct via `/v2/`. Belongs in the terraform-compat backlog (likely spans multiple MMv1-vs-handwritten GCP services).
- No auto-provisioned `_Default`/`_Required` sinks & buckets; advanced filter syntax not evaluated (substring only).
