### PR TITLE
fix(cloudmonitoring): real-user e2e divergences from GCP

### DIFF
--- a/server/gcp/monitoring/alertpolicies.go
+++ b/server/gcp/monitoring/alertpolicies.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sort"
 	"strconv"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -55,6 +56,14 @@ func (h *Handler) createPolicy(w http.ResponseWriter, r *http.Request, project s
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
 		return
+	}
+
+	// Cloud Monitoring treats an unset enabled on write as enabled, and always
+	// returns the field on read. Default it here so a create that omits enabled
+	// reads back as enabled:true (not the Go zero false).
+	if body.Enabled == nil {
+		t := true
+		body.Enabled = &t
 	}
 
 	// Real Cloud Monitoring assigns an opaque numeric id, not one derived from
@@ -124,9 +133,20 @@ func (h *Handler) getPolicy(w http.ResponseWriter, project, name string) {
 
 func (h *Handler) listPolicies(w http.ResponseWriter, _ *http.Request, project string) {
 	h.mu.RLock()
+
+	// Iterating the map directly yields a random order each call, which reads as
+	// perpetual drift to Terraform/clients that diff list output. Emit policies
+	// in stable creation order (ascending numeric id) so repeated lists match.
+	ids := make([]string, 0, len(h.policies))
+	for id := range h.policies {
+		ids = append(ids, id)
+	}
+
+	sort.Slice(ids, func(i, j int) bool { return policyIDLess(ids[i], ids[j]) })
+
 	out := alertPoliciesList{AlertPolicies: make([]alertPolicy, 0, len(h.policies))}
 
-	for id := range h.policies {
+	for _, id := range ids {
 		pol := h.policies[id]
 		pol.Name = policyResourceName(project, id)
 		out.AlertPolicies = append(out.AlertPolicies, pol)
@@ -134,6 +154,19 @@ func (h *Handler) listPolicies(w http.ResponseWriter, _ *http.Request, project s
 	h.mu.RUnlock()
 
 	writeJSON(w, http.StatusOK, out)
+}
+
+// policyIDLess orders opaque policy ids by their numeric value (creation order),
+// falling back to string order for any non-numeric id.
+func policyIDLess(a, b string) bool {
+	ai, aerr := strconv.ParseUint(a, 10, 64)
+	bi, berr := strconv.ParseUint(b, 10, 64)
+
+	if aerr == nil && berr == nil {
+		return ai < bi
+	}
+
+	return a < b
 }
 
 // patchPolicy applies a partial update. GCP scopes changes by updateMask; the
@@ -196,7 +229,7 @@ func (h *Handler) patchPolicy(w http.ResponseWriter, r *http.Request, project, n
 	}
 
 	if body.Enabled != nil {
-		cur.Enabled = *body.Enabled
+		cur.Enabled = body.Enabled
 	}
 
 	cur.MutationRecord = &mutationRecord{MutateTime: nowRFC3339(), MutatedBy: "cloudemu"}

--- a/server/gcp/monitoring/client_test.go
+++ b/server/gcp/monitoring/client_test.go
@@ -2,6 +2,8 @@ package monitoring_test
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -409,6 +411,218 @@ func equalStrings(a, b []string) bool {
 
 	for i := range a {
 		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// newMonServer spins the in-process GCP server over a fresh CloudMonitoring mock.
+func newMonServer(t *testing.T) (*monitoring.Service, *httptest.Server) {
+	t.Helper()
+
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Monitoring: cloudP.CloudMonitoring})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return newClient(t, ts), ts
+}
+
+// TestAlertPolicyEnabledDefaultsToTrue guards the enabled-default divergence: a
+// create that omits enabled must read back as enabled:true (Cloud Monitoring
+// treats an unset value on write as enabled and always returns the field). The
+// bug was `enabled` being a bool with omitempty — an omitted/false value was
+// dropped, so an omitting create read back as disabled.
+func TestAlertPolicyEnabledDefaultsToTrue(t *testing.T) {
+	svc, _ := newMonServer(t)
+
+	created, err := svc.Projects.AlertPolicies.Create("projects/p1", &monitoring.AlertPolicy{
+		DisplayName: "no-enabled",
+		Combiner:    "OR",
+	}).Do()
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if !created.Enabled {
+		t.Error("create omitting enabled read back disabled; want default enabled:true")
+	}
+
+	got, err := svc.Projects.AlertPolicies.Get(created.Name).Do()
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if !got.Enabled {
+		t.Error("get of an enabled-by-default policy returned enabled:false")
+	}
+}
+
+// TestAlertPolicyEnabledFalseRoundTrips guards that an explicit enabled:false
+// survives create→read as a literal false in the wire JSON (omitempty on a bool
+// would drop it, so a disabled policy would read back with no enabled field).
+func TestAlertPolicyEnabledFalseRoundTrips(t *testing.T) {
+	svc, ts := newMonServer(t)
+
+	created, err := svc.Projects.AlertPolicies.Create("projects/p1", &monitoring.AlertPolicy{
+		DisplayName:     "disabled",
+		Combiner:        "OR",
+		Enabled:         false,
+		ForceSendFields: []string{"Enabled"},
+	}).Do()
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if created.Enabled {
+		t.Fatal("explicit enabled:false read back as true")
+	}
+
+	// Inspect the raw GET body: enabled must be present and literally false, not
+	// omitted, matching real Cloud Monitoring which always returns the field.
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v3/"+created.Name, nil)
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("raw get: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var raw map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	v, ok := raw["enabled"]
+	if !ok {
+		t.Fatal("enabled field omitted from response; real Cloud Monitoring always returns it")
+	}
+
+	if b, _ := v.(bool); b {
+		t.Errorf("enabled=%v want false", v)
+	}
+}
+
+// TestAlertPoliciesListDeterministicOrder guards the list-order divergence:
+// alertPolicies.list must return a stable order across calls (creation order),
+// not the random map iteration order that reads as perpetual drift to Terraform.
+func TestAlertPoliciesListDeterministicOrder(t *testing.T) {
+	svc, _ := newMonServer(t)
+
+	const n = 12
+
+	created := make([]string, 0, n)
+
+	for i := 0; i < n; i++ {
+		pol, err := svc.Projects.AlertPolicies.Create("projects/p1", &monitoring.AlertPolicy{
+			DisplayName: "p",
+			Combiner:    "OR",
+		}).Do()
+		if err != nil {
+			t.Fatalf("create #%d: %v", i, err)
+		}
+
+		created = append(created, pol.Name)
+	}
+
+	first := listPolicyNames(t, svc)
+
+	if len(first) != n {
+		t.Fatalf("want %d policies, got %d", n, len(first))
+	}
+
+	// Order must equal creation order and be identical across repeated calls.
+	for i := range created {
+		if first[i] != created[i] {
+			t.Fatalf("list[%d]=%s want creation order %s", i, first[i], created[i])
+		}
+	}
+
+	for call := 0; call < 5; call++ {
+		got := listPolicyNames(t, svc)
+		for i := range got {
+			if got[i] != first[i] {
+				t.Fatalf("list order not stable on call %d at %d: %s != %s", call, i, got[i], first[i])
+			}
+		}
+	}
+}
+
+func listPolicyNames(t *testing.T, svc *monitoring.Service) []string {
+	t.Helper()
+
+	list, err := svc.Projects.AlertPolicies.List("projects/p1").Do()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	names := make([]string, 0, len(list.AlertPolicies))
+	for _, p := range list.AlertPolicies {
+		names = append(names, p.Name)
+	}
+
+	return names
+}
+
+// TestNotificationChannelsListDeterministicOrder guards that
+// notificationChannels.list returns a stable order (sorted by resource name)
+// across calls rather than the backing store's random map order.
+func TestNotificationChannelsListDeterministicOrder(t *testing.T) {
+	svc, _ := newMonServer(t)
+
+	const n = 12
+
+	for i := 0; i < n; i++ {
+		if _, err := svc.Projects.NotificationChannels.Create("projects/p1", &monitoring.NotificationChannel{
+			Type:        "email",
+			DisplayName: "c",
+			Labels:      map[string]string{"email_address": "a@example.com"},
+		}).Do(); err != nil {
+			t.Fatalf("create #%d: %v", i, err)
+		}
+	}
+
+	first := listChannelNames(t, svc)
+
+	if len(first) != n {
+		t.Fatalf("want %d channels, got %d", n, len(first))
+	}
+
+	if !sortedAscending(first) {
+		t.Errorf("channels not sorted by name: %v", first)
+	}
+
+	for call := 0; call < 5; call++ {
+		got := listChannelNames(t, svc)
+		for i := range got {
+			if got[i] != first[i] {
+				t.Fatalf("channel list order not stable on call %d at %d: %s != %s", call, i, got[i], first[i])
+			}
+		}
+	}
+}
+
+func listChannelNames(t *testing.T, svc *monitoring.Service) []string {
+	t.Helper()
+
+	list, err := svc.Projects.NotificationChannels.List("projects/p1").Do()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	names := make([]string, 0, len(list.NotificationChannels))
+	for _, c := range list.NotificationChannels {
+		names = append(names, c.Name)
+	}
+
+	return names
+}
+
+func sortedAscending(s []string) bool {
+	for i := 1; i < len(s); i++ {
+		if s[i-1] > s[i] {
 			return false
 		}
 	}

--- a/server/gcp/monitoring/notificationchannels.go
+++ b/server/gcp/monitoring/notificationchannels.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sort"
 
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
@@ -122,6 +123,12 @@ func (h *Handler) listChannels(w http.ResponseWriter, r *http.Request, project s
 	for i := range infos {
 		out.NotificationChannels = append(out.NotificationChannels, toChannelJSON(project, &infos[i]))
 	}
+
+	// The backing store returns channels in random map order; sort by resource
+	// name so repeated lists are stable and don't read as drift to clients.
+	sort.Slice(out.NotificationChannels, func(i, j int) bool {
+		return out.NotificationChannels[i].Name < out.NotificationChannels[j].Name
+	})
 
 	writeJSON(w, http.StatusOK, out)
 }

--- a/server/gcp/monitoring/types.go
+++ b/server/gcp/monitoring/types.go
@@ -3,16 +3,20 @@ package monitoring
 // GCP Cloud Monitoring REST shapes.
 
 type alertPolicy struct {
-	Name                 string            `json:"name,omitempty"`
-	DisplayName          string            `json:"displayName,omitempty"`
-	Documentation        any               `json:"documentation,omitempty"`
-	UserLabels           map[string]string `json:"userLabels,omitempty"`
-	Conditions           []alertCondition  `json:"conditions,omitempty"`
-	Combiner             string            `json:"combiner,omitempty"`
-	Enabled              bool              `json:"enabled,omitempty"`
-	NotificationChannels []string          `json:"notificationChannels,omitempty"`
-	CreationRecord       any               `json:"creationRecord,omitempty"`
-	MutationRecord       any               `json:"mutationRecord,omitempty"`
+	Name          string            `json:"name,omitempty"`
+	DisplayName   string            `json:"displayName,omitempty"`
+	Documentation any               `json:"documentation,omitempty"`
+	UserLabels    map[string]string `json:"userLabels,omitempty"`
+	Conditions    []alertCondition  `json:"conditions,omitempty"`
+	Combiner      string            `json:"combiner,omitempty"`
+	// Enabled is a pointer so an explicit false round-trips on read (a plain bool
+	// with omitempty drops enabled:false) and a create that omits it can be
+	// defaulted to true — Cloud Monitoring always returns enabled and treats an
+	// unset value on write as enabled.
+	Enabled              *bool    `json:"enabled,omitempty"`
+	NotificationChannels []string `json:"notificationChannels,omitempty"`
+	CreationRecord       any      `json:"creationRecord,omitempty"`
+	MutationRecord       any      `json:"mutationRecord,omitempty"`
 }
 
 // alertCondition round-trips every Cloud Monitoring condition variant, not just


### PR DESCRIPTION
Real-user e2e audit of the GCP Cloud Monitoring (Stackdriver) wire surface (server/gcp/monitoring), driven by the real google.golang.org/api/monitoring/v3 client plus raw HTTP against the serve binary, reconciled against the Cloud Monitoring v3 REST docs.

## Fixed divergences

- **alertPolicy `enabled` semantics.** `enabled` was a Go `bool` with `omitempty`. A create that omitted `enabled` read back as `enabled:false`, and an explicit `enabled:false` was dropped from responses entirely. Real Cloud Monitoring treats an unset `enabled` on write as **enabled** and **always returns the field**. Changed to a `*bool`, defaulted to `true` on create when omitted, so both an omitted create (`enabled:true`) and an explicit `enabled:false` round-trip correctly.
- **alertPolicies.list nondeterministic order.** The handler iterated the policy map directly, yielding a random order each call — perpetual drift for Terraform/clients that diff list output. Now sorted by numeric id (stable creation order).
- **notificationChannels.list nondeterministic order.** Backed by a memstore map iterated in random order. Now sorted by resource name for stable output.

## Verified already-correct
Error bodies are already clean `{error:{code,message,status}}` with no internal `NotFound:` taxonomy prefix (`writeErr` uses `cerrors.Message`). Opaque numeric ids, creationRecord/mutationRecord, condition names, self-link format, and patch updateMask field-scoping were re-verified via the existing client tests.

## Filed, not fixed (documented as backlog)
- `timeSeries.list` does not require/validate a `filter` (real GCP returns INVALID_ARGUMENT when absent) — behavioral-only, SDK always sends one.
- No real MQL/PromQL condition evaluation; `uptimeCheckConfigs` collection not served — large engine surface, left for a dedicated buildout.
- List endpoints ignore pageSize/pageToken (no pagination).

## Tests
Added black-box tests against the real monitoring/v3 client + raw HTTP: enabled default-to-true, enabled:false round-trip (raw JSON asserts the field is present and false), and cross-call stable ordering for both alertPolicies and notificationChannels. Gates: `go build ./...`, `go test -race` (server/gcp/monitoring, providers/gcp/monitoring, services/monitoring), `go vet`, `gofmt`, `golangci-lint --new-from-rev` (0 issues), `go generate` (no docs/coverage diff) all green.