### PR TITLE
fix(elasticache): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/elasticache/auto_minor_version_test.go
+++ b/providers/aws/elasticache/auto_minor_version_test.go
@@ -1,0 +1,52 @@
+package elasticache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAutoMinorVersionUpgradeRoundTrip guards the perpetual-diff bug: real
+// ElastiCache defaults AutoMinorVersionUpgrade to true and terraform-provider-aws
+// shares that schema default, so an absent-then-unset read leaves terraform
+// forever wanting to change it. The flag must default to true, round-trip an
+// explicit false, and be updatable via ModifyCache.
+func TestAutoMinorVersionUpgradeRoundTrip(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	// Omitted → default true.
+	info, err := m.CreateCache(ctx, driver.CacheConfig{Name: "def", Engine: "redis"})
+	require.NoError(t, err)
+	assert.True(t, info.AutoMinorVersionUpgrade)
+
+	got, err := m.GetCache(ctx, "def")
+	require.NoError(t, err)
+	assert.True(t, got.AutoMinorVersionUpgrade)
+
+	// Explicit false round-trips.
+	off := false
+	info, err = m.CreateCache(ctx, driver.CacheConfig{
+		Name: "off", Engine: "redis", AutoMinorVersionUpgrade: &off,
+	})
+	require.NoError(t, err)
+	assert.False(t, info.AutoMinorVersionUpgrade)
+
+	got, err = m.GetCache(ctx, "off")
+	require.NoError(t, err)
+	assert.False(t, got.AutoMinorVersionUpgrade)
+
+	// Modify flips it back on.
+	on := true
+	mod, err := m.ModifyCache(ctx, driver.ModifyCacheConfig{Name: "off", AutoMinorVersionUpgrade: &on})
+	require.NoError(t, err)
+	assert.True(t, mod.AutoMinorVersionUpgrade)
+
+	// Modify that omits the flag leaves the stored value unchanged.
+	mod, err = m.ModifyCache(ctx, driver.ModifyCacheConfig{Name: "off", NodeType: "cache.m5.large"})
+	require.NoError(t, err)
+	assert.True(t, mod.AutoMinorVersionUpgrade)
+}

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -282,6 +282,14 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 		return nil, errors.Newf(errors.AlreadyExists, "cache %q already exists", cfg.Name)
 	}
 
+	// A replication group's member nodes ("<groupId>-001", …) are describable as
+	// single-node cache clusters without being backed by m.caches, so guard the
+	// same id space here — real ElastiCache rejects a create colliding with a
+	// member id with CacheClusterAlreadyExists.
+	if _, member := m.lookupMember(cfg.Name); member {
+		return nil, errors.Newf(errors.AlreadyExists, "cache %q already exists", cfg.Name)
+	}
+
 	// A restore (SnapshotName set) seeds the unset config fields from the
 	// snapshot before defaults are applied, so the new cluster reproduces the
 	// source's engine/version/node-type/count/port.

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -147,6 +148,16 @@ func cloneTags(in map[string]string) map[string]string {
 	}
 
 	return out
+}
+
+// boolOrDefault returns *p when p is non-nil, otherwise def. It resolves an
+// optional wire flag (nil = caller omitted it) to a concrete stored value.
+func boolOrDefault(p *bool, def bool) bool {
+	if p != nil {
+		return *p
+	}
+
+	return def
 }
 
 // cacheARN builds an ElastiCache cluster ARN in the given region.
@@ -308,19 +319,20 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 	tags := cloneTags(cfg.Tags)
 
 	info := driver.CacheInfo{
-		Name:               cfg.Name,
-		Scope:              cfg.Scope,
-		NodeType:           nodeType,
-		Engine:             engine,
-		EngineVersion:      engineVersion,
-		Status:             statusAvailable,
-		Endpoint:           endpoint,
-		ARN:                m.cacheARN(region, cfg.Name),
-		CreatedAt:          m.opts.Clock.Now().UTC().Format(time.RFC3339),
-		Tags:               tags,
-		NumCacheNodes:      numNodes,
-		SubnetGroupName:    cfg.SubnetGroupName,
-		ParameterGroupName: cfg.ParameterGroupName,
+		Name:                    cfg.Name,
+		Scope:                   cfg.Scope,
+		NodeType:                nodeType,
+		Engine:                  engine,
+		EngineVersion:           engineVersion,
+		Status:                  statusAvailable,
+		Endpoint:                endpoint,
+		ARN:                     m.cacheARN(region, cfg.Name),
+		CreatedAt:               m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:                    tags,
+		NumCacheNodes:           numNodes,
+		SubnetGroupName:         cfg.SubnetGroupName,
+		ParameterGroupName:      cfg.ParameterGroupName,
+		AutoMinorVersionUpgrade: boolOrDefault(cfg.AutoMinorVersionUpgrade, true),
 	}
 
 	// Opt-in: back the cache with a real server, replacing the synthetic
@@ -379,6 +391,10 @@ func (m *Mock) ModifyCache(_ context.Context, cfg driver.ModifyCacheConfig) (*dr
 		cd.info.NumCacheNodes = cfg.NumCacheNodes
 	}
 
+	if cfg.AutoMinorVersionUpgrade != nil {
+		cd.info.AutoMinorVersionUpgrade = *cfg.AutoMinorVersionUpgrade
+	}
+
 	m.caches.Set(cfg.Name, cd)
 
 	// Under AsyncSettle a modified cluster briefly reports modifying before
@@ -429,9 +445,19 @@ func (m *Mock) DeleteCache(ctx context.Context, name string) error {
 }
 
 // GetCache retrieves information about an ElastiCache cluster.
+//
+// A name that is not a standalone cluster may still be a member node of a
+// replication group ("<groupId>-001", …); real ElastiCache describes those as
+// single-node cache clusters, so fall back to synthesizing the member from its
+// group before reporting not-found. IaC that manages a replication group reads
+// each member back this way.
 func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, error) {
 	cd, ok := m.caches.Get(name)
 	if !ok {
+		if info, found := m.lookupMember(name); found {
+			return &info, nil
+		}
+
 		return nil, errors.Newf(errors.NotFound, "cache %q not found", name)
 	}
 
@@ -441,7 +467,63 @@ func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, erro
 	return &result, nil
 }
 
-// ListCaches lists all ElastiCache clusters.
+// lookupMember returns the synthesized cache-cluster view of a replication-group
+// member node named memberID, together with whether any group owns it. Members
+// are derived from their group on the fly rather than stored, so the view stays
+// consistent as the group is modified or deleted.
+func (m *Mock) lookupMember(memberID string) (driver.CacheInfo, bool) {
+	groups := m.replicationGroups.SortedValues()
+	for i := range groups {
+		if slices.Contains(groups[i].MemberClusters, memberID) {
+			return m.memberCacheInfo(&groups[i], memberID), true
+		}
+	}
+
+	return driver.CacheInfo{}, false
+}
+
+// memberCacheInfo synthesizes the CacheCluster view of a replication-group
+// member node. It carries the group's engine/version/node-type, its own per-node
+// endpoint, and a back-reference to the group, matching how real ElastiCache
+// exposes a replication group's members through DescribeCacheClusters.
+func (m *Mock) memberCacheInfo(rg *driver.ReplicationGroup, memberID string) driver.CacheInfo {
+	region := arnRegion(rg.ARN, m.opts.Region)
+
+	engine := rg.Engine
+	if engine == "" {
+		engine = defaultEngine
+	}
+
+	engineVersion := rg.EngineVersion
+	if engineVersion == "" {
+		engineVersion = defaultEngineVersion(engine)
+	}
+
+	port := rg.PrimaryPort
+	if port == 0 {
+		port = defaultRedisPort
+	}
+
+	return driver.CacheInfo{
+		Name:                    memberID,
+		NodeType:                rg.NodeType,
+		Engine:                  engine,
+		EngineVersion:           engineVersion,
+		Status:                  m.settleRGStatus(rg.ID, rg.Status),
+		Endpoint:                clusterEndpoint(memberID, region, engine, port),
+		ARN:                     m.cacheARN(region, memberID),
+		NumCacheNodes:           1,
+		SubnetGroupName:         rg.SubnetGroupName,
+		ReplicationGroupID:      rg.ID,
+		AutoMinorVersionUpgrade: true,
+	}
+}
+
+// ListCaches lists all ElastiCache clusters. Replication-group member nodes are
+// included as individual single-node cache clusters, matching real ElastiCache
+// (DescribeCacheClusters returns them alongside standalone clusters). The result
+// is sorted by cluster id so the wire order is deterministic (no map-iteration
+// randomness) and matches the id-ordered listing AWS returns.
 func (m *Mock) ListCaches(_ context.Context, filter scope.Scope) ([]driver.CacheInfo, error) {
 	all := m.caches.SortedValues()
 
@@ -456,6 +538,22 @@ func (m *Mock) ListCaches(_ context.Context, filter scope.Scope) ([]driver.Cache
 		info.Status = m.settleCacheStatus(info.Name, info.Status)
 		caches = append(caches, info)
 	}
+
+	groups := m.replicationGroups.SortedValues()
+	for i := range groups {
+		for _, memberID := range groups[i].MemberClusters {
+			member := m.memberCacheInfo(&groups[i], memberID)
+			if !member.Scope.Matches(filter) {
+				continue
+			}
+
+			caches = append(caches, member)
+		}
+	}
+
+	slices.SortFunc(caches, func(a, b driver.CacheInfo) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	return caches, nil
 }

--- a/providers/aws/elasticache/member_cluster_test.go
+++ b/providers/aws/elasticache/member_cluster_test.go
@@ -70,6 +70,40 @@ func TestReplicationGroupMembersDescribable(t *testing.T) {
 	assert.Equal(t, []string{"aaa-standalone"}, names)
 }
 
+// TestCreateCacheRejectsMemberIDCollision guards that a create whose id collides
+// with an existing replication-group member node ("<groupId>-001", …) is rejected
+// with AlreadyExists — real ElastiCache returns CacheClusterAlreadyExists. Without
+// the guard the standalone cluster and the synthesized member share an id and both
+// surface through DescribeCacheClusters (a duplicate).
+func TestCreateCacheRejectsMemberIDCollision(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateReplicationGroup(ctx, driver.ReplicationGroupConfig{
+		ID: "rg-test", Engine: "redis", NodeType: "cache.t3.micro", NumCacheNodes: 3,
+	})
+	require.NoError(t, err)
+
+	_, err = m.CreateCache(ctx, driver.CacheConfig{Name: "rg-test-001"})
+	require.Error(t, err, "create colliding with a member id must be rejected")
+	assert.True(t, errors.IsAlreadyExists(err))
+
+	// The member is still described exactly once (no duplicate leaked in).
+	list, err := m.ListCaches(ctx, scope.Scope{})
+	require.NoError(t, err)
+	count := 0
+	for i := range list {
+		if list[i].Name == "rg-test-001" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "rg-test-001 should appear exactly once")
+
+	// A genuinely new, non-colliding id still creates successfully.
+	_, err = m.CreateCache(ctx, driver.CacheConfig{Name: "totally-new"})
+	require.NoError(t, err)
+}
+
 // TestReplicationGroupMemberCountFollowsModify checks that rescaling a group
 // changes which member clusters are describable.
 func TestReplicationGroupMemberCountFollowsModify(t *testing.T) {

--- a/providers/aws/elasticache/member_cluster_test.go
+++ b/providers/aws/elasticache/member_cluster_test.go
@@ -1,0 +1,94 @@
+package elasticache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReplicationGroupMembersDescribable guards that each member node of a
+// replication group is describable as a single-node cache cluster (real
+// ElastiCache exposes them through DescribeCacheClusters). Terraform reads every
+// member back by id after creating a replication group, so a member that 404s
+// aborts `terraform apply`.
+func TestReplicationGroupMembersDescribable(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateReplicationGroup(ctx, driver.ReplicationGroupConfig{
+		ID: "rg", Engine: "redis", NodeType: "cache.t3.micro", NumCacheNodes: 2,
+	})
+	require.NoError(t, err)
+
+	for _, id := range []string{"rg-001", "rg-002"} {
+		info, err := m.GetCache(ctx, id)
+		require.NoError(t, err, "member %s should be describable", id)
+		assert.Equal(t, id, info.Name)
+		assert.Equal(t, "rg", info.ReplicationGroupID)
+		assert.Equal(t, "redis", info.Engine)
+		assert.Equal(t, 1, info.NumCacheNodes)
+		assert.True(t, info.AutoMinorVersionUpgrade)
+		assert.NotEmpty(t, info.Endpoint)
+		assert.NotEmpty(t, info.ARN)
+	}
+
+	// Members appear in the list alongside standalone clusters, sorted by id.
+	createTestCache(t, m, "aaa-standalone")
+
+	list, err := m.ListCaches(ctx, scope.Scope{})
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(list))
+	for i := range list {
+		names = append(names, list[i].Name)
+	}
+
+	assert.Equal(t, []string{"aaa-standalone", "rg-001", "rg-002"}, names)
+
+	// A genuinely unknown id still reports not-found.
+	_, err = m.GetCache(ctx, "no-such-cluster")
+	require.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+
+	// Deleting the group removes the synthesized members (no leak).
+	require.NoError(t, m.DeleteReplicationGroup(ctx, "rg", driver.DeleteReplicationGroupOptions{}))
+
+	_, err = m.GetCache(ctx, "rg-001")
+	require.Error(t, err)
+
+	list, err = m.ListCaches(ctx, scope.Scope{})
+	require.NoError(t, err)
+	names = names[:0]
+	for i := range list {
+		names = append(names, list[i].Name)
+	}
+	assert.Equal(t, []string{"aaa-standalone"}, names)
+}
+
+// TestReplicationGroupMemberCountFollowsModify checks that rescaling a group
+// changes which member clusters are describable.
+func TestReplicationGroupMemberCountFollowsModify(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateReplicationGroup(ctx, driver.ReplicationGroupConfig{
+		ID: "rg", Engine: "redis", NumCacheNodes: 1,
+	})
+	require.NoError(t, err)
+
+	_, err = m.GetCache(ctx, "rg-002")
+	require.Error(t, err, "rg-002 should not exist before scale-up")
+
+	_, err = m.ModifyReplicationGroup(ctx, "rg", 3)
+	require.NoError(t, err)
+
+	for _, id := range []string{"rg-001", "rg-002", "rg-003"} {
+		_, err := m.GetCache(ctx, id)
+		require.NoError(t, err, "member %s should exist after scale-up", id)
+	}
+}

--- a/providers/aws/elasticache/replication_group.go
+++ b/providers/aws/elasticache/replication_group.go
@@ -292,16 +292,17 @@ func (m *Mock) retainPrimaryCluster(rg *cachedriver.ReplicationGroup) {
 	}
 
 	info := cachedriver.CacheInfo{
-		Name:            rg.ID,
-		NodeType:        rg.NodeType,
-		Engine:          rg.Engine,
-		EngineVersion:   rg.EngineVersion,
-		Status:          statusAvailable,
-		Endpoint:        net.JoinHostPort(rg.PrimaryAddress, strconv.Itoa(rg.PrimaryPort)),
-		ARN:             m.cacheARN(arnRegion(rg.ARN, m.opts.Region), rg.ID),
-		CreatedAt:       m.opts.Clock.Now().UTC().Format(time.RFC3339),
-		NumCacheNodes:   1,
-		SubnetGroupName: rg.SubnetGroupName,
+		Name:                    rg.ID,
+		NodeType:                rg.NodeType,
+		Engine:                  rg.Engine,
+		EngineVersion:           rg.EngineVersion,
+		Status:                  statusAvailable,
+		Endpoint:                net.JoinHostPort(rg.PrimaryAddress, strconv.Itoa(rg.PrimaryPort)),
+		ARN:                     m.cacheARN(arnRegion(rg.ARN, m.opts.Region), rg.ID),
+		CreatedAt:               m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		NumCacheNodes:           1,
+		SubnetGroupName:         rg.SubnetGroupName,
+		AutoMinorVersionUpgrade: true,
 	}
 
 	m.caches.Set(rg.ID, &cacheData{info: info, items: memstore.New[cacheItem]()})

--- a/server/aws/elasticache/cachenode_fields_sdk_roundtrip_test.go
+++ b/server/aws/elasticache/cachenode_fields_sdk_roundtrip_test.go
@@ -1,0 +1,80 @@
+package elasticache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+)
+
+// TestSDKCacheNodeCarriesAvailabilityZone guards the Terraform-breaking bug: the
+// AWS provider dereferences CacheNode.CustomerAvailabilityZone unconditionally
+// when flattening a cluster's nodes and aborts `terraform apply` with
+// "Unexpected nil pointer" if it is absent. Every emitted node must carry a
+// non-empty AZ. AutoMinorVersionUpgrade must also be reported (default true) so
+// the provider does not see a perpetual diff against its own schema default.
+func TestSDKCacheNodeCarriesAvailabilityZone(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("mc"), Engine: aws.String("memcached"),
+		CacheNodeType: aws.String("cache.t3.micro"), NumCacheNodes: aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("CreateCacheCluster: %v", err)
+	}
+
+	if !aws.ToBool(created.CacheCluster.AutoMinorVersionUpgrade) {
+		t.Fatalf("AutoMinorVersionUpgrade default = false, want true")
+	}
+
+	got, err := client.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{
+		CacheClusterId: aws.String("mc"), ShowCacheNodeInfo: aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheClusters: %v", err)
+	}
+
+	nodes := got.CacheClusters[0].CacheNodes
+	if len(nodes) != 2 {
+		t.Fatalf("CacheNodes = %d, want 2", len(nodes))
+	}
+
+	for _, n := range nodes {
+		if aws.ToString(n.CustomerAvailabilityZone) == "" {
+			t.Fatalf("CacheNode %s has empty CustomerAvailabilityZone", aws.ToString(n.CacheNodeId))
+		}
+	}
+}
+
+// TestSDKAutoMinorVersionUpgradeRoundTrip guards that an explicit false is
+// preserved rather than coerced back to the default true.
+func TestSDKAutoMinorVersionUpgradeRoundTrip(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("off"), Engine: aws.String("redis"),
+		NumCacheNodes: aws.Int32(1), AutoMinorVersionUpgrade: aws.Bool(false),
+	})
+	if err != nil {
+		t.Fatalf("CreateCacheCluster: %v", err)
+	}
+
+	if aws.ToBool(created.CacheCluster.AutoMinorVersionUpgrade) {
+		t.Fatalf("AutoMinorVersionUpgrade = true, want the explicit false to round-trip")
+	}
+
+	got, err := client.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{
+		CacheClusterId: aws.String("off"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheClusters: %v", err)
+	}
+
+	if aws.ToBool(got.CacheClusters[0].AutoMinorVersionUpgrade) {
+		t.Fatalf("persisted AutoMinorVersionUpgrade = true, want false")
+	}
+}

--- a/server/aws/elasticache/operations.go
+++ b/server/aws/elasticache/operations.go
@@ -12,6 +12,24 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
+// optionalBool reads a boolean form flag, returning nil when the caller omitted
+// it entirely so the backend can apply the real ElastiCache default rather than
+// coercing an absent flag to false. A present but unparseable value is treated
+// as false, matching how the query protocol coerces malformed booleans.
+func optionalBool(form url.Values, key string) *bool {
+	raw := form.Get(key)
+	if raw == "" {
+		return nil
+	}
+
+	b, err := strconv.ParseBool(raw)
+	if err != nil {
+		b = false
+	}
+
+	return &b
+}
+
 // parseTags parses ElastiCache-style Tags.Tag.N.{Key,Value} entries.
 func parseTags(form url.Values) map[string]string {
 	indices := awsquery.CollectIndices(form, "Tags.Tag")
@@ -47,17 +65,18 @@ func (h *Handler) createCacheCluster(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cfg := cachedriver.CacheConfig{
-		Name:               form.Get("CacheClusterId"),
-		NodeType:           form.Get("CacheNodeType"),
-		Engine:             form.Get("Engine"),
-		EngineVersion:      form.Get("EngineVersion"),
-		NumCacheNodes:      nodes,
-		Port:               port,
-		SubnetGroupName:    form.Get("CacheSubnetGroupName"),
-		ParameterGroupName: form.Get("CacheParameterGroupName"),
-		Tags:               parseTags(form),
-		SnapshotName:       form.Get("SnapshotName"),
-		SnapshotArns:       awsquery.ListStrings(form, "SnapshotArns.SnapshotArn"),
+		Name:                    form.Get("CacheClusterId"),
+		NodeType:                form.Get("CacheNodeType"),
+		Engine:                  form.Get("Engine"),
+		EngineVersion:           form.Get("EngineVersion"),
+		NumCacheNodes:           nodes,
+		Port:                    port,
+		SubnetGroupName:         form.Get("CacheSubnetGroupName"),
+		ParameterGroupName:      form.Get("CacheParameterGroupName"),
+		Tags:                    parseTags(form),
+		SnapshotName:            form.Get("SnapshotName"),
+		SnapshotArns:            awsquery.ListStrings(form, "SnapshotArns.SnapshotArn"),
+		AutoMinorVersionUpgrade: optionalBool(form, "AutoMinorVersionUpgrade"),
 	}
 
 	info, err := h.cache.CreateCache(r.Context(), cfg)
@@ -93,10 +112,11 @@ func (h *Handler) modifyCacheCluster(w http.ResponseWriter, r *http.Request) {
 	}
 
 	info, err := mod.ModifyCache(r.Context(), cachedriver.ModifyCacheConfig{
-		Name:          r.Form.Get("CacheClusterId"),
-		NodeType:      r.Form.Get("CacheNodeType"),
-		EngineVersion: r.Form.Get("EngineVersion"),
-		NumCacheNodes: nodes,
+		Name:                    r.Form.Get("CacheClusterId"),
+		NodeType:                r.Form.Get("CacheNodeType"),
+		EngineVersion:           r.Form.Get("EngineVersion"),
+		NumCacheNodes:           nodes,
+		AutoMinorVersionUpgrade: optionalBool(r.Form, "AutoMinorVersionUpgrade"),
 	})
 	if err != nil {
 		writeErr(w, err)

--- a/server/aws/elasticache/replicationgroup_members_sdk_roundtrip_test.go
+++ b/server/aws/elasticache/replicationgroup_members_sdk_roundtrip_test.go
@@ -1,0 +1,52 @@
+package elasticache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+)
+
+// TestSDKReplicationGroupMembersDescribable guards the Terraform-breaking bug:
+// after CreateReplicationGroup, terraform-provider-aws reads every member cache
+// cluster back by id (DescribeCacheClusters). A member that returns
+// CacheClusterNotFound aborts `terraform apply`. Each member must be describable
+// as a single-node cache cluster carrying the ReplicationGroupId back-reference
+// and a well-formed node (with a non-nil CustomerAvailabilityZone).
+func TestSDKReplicationGroupMembersDescribable(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateReplicationGroup(ctx, &awselasticache.CreateReplicationGroupInput{
+		ReplicationGroupId:          aws.String("rg"),
+		ReplicationGroupDescription: aws.String("t"),
+		Engine:                      aws.String("redis"),
+		CacheNodeType:               aws.String("cache.t3.micro"),
+		NumCacheClusters:            aws.Int32(2),
+	}); err != nil {
+		t.Fatalf("CreateReplicationGroup: %v", err)
+	}
+
+	for _, id := range []string{"rg-001", "rg-002"} {
+		out, err := client.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{
+			CacheClusterId: aws.String(id), ShowCacheNodeInfo: aws.Bool(true),
+		})
+		if err != nil {
+			t.Fatalf("DescribeCacheClusters(%s): %v", id, err)
+		}
+
+		cc := out.CacheClusters[0]
+		if aws.ToString(cc.ReplicationGroupId) != "rg" {
+			t.Fatalf("member %s ReplicationGroupId = %q, want rg", id, aws.ToString(cc.ReplicationGroupId))
+		}
+
+		if aws.ToString(cc.Engine) != "redis" {
+			t.Fatalf("member %s Engine = %q, want redis", id, aws.ToString(cc.Engine))
+		}
+
+		if len(cc.CacheNodes) != 1 || aws.ToString(cc.CacheNodes[0].CustomerAvailabilityZone) == "" {
+			t.Fatalf("member %s missing a well-formed CacheNode", id)
+		}
+	}
+}

--- a/server/aws/elasticache/types.go
+++ b/server/aws/elasticache/types.go
@@ -37,10 +37,18 @@ type endpointXML struct {
 // cacheNodeXML mirrors AWS's CacheNode. The SDK reads the per-node Endpoint to
 // populate CacheCluster.CacheNodes[].Endpoint; that is where a single-node
 // Redis cluster's connection address lives.
+//
+// CustomerAvailabilityZone is mandatory in practice: the Terraform AWS provider
+// dereferences it unconditionally when flattening a cluster's nodes and aborts
+// with "Unexpected nil pointer" if it is absent, so every emitted node must
+// carry one. CacheNodeCreateTime is included for fidelity (real AWS always sets
+// it) even though the provider does not validate it.
 type cacheNodeXML struct {
-	CacheNodeID     string       `xml:"CacheNodeId"`
-	CacheNodeStatus string       `xml:"CacheNodeStatus"`
-	Endpoint        *endpointXML `xml:"Endpoint,omitempty"`
+	CacheNodeID              string       `xml:"CacheNodeId"`
+	CacheNodeStatus          string       `xml:"CacheNodeStatus"`
+	CacheNodeCreateTime      string       `xml:"CacheNodeCreateTime,omitempty"`
+	Endpoint                 *endpointXML `xml:"Endpoint,omitempty"`
+	CustomerAvailabilityZone string       `xml:"CustomerAvailabilityZone"`
 }
 
 type cacheNodesXML struct {
@@ -55,17 +63,19 @@ type cacheParameterGroupStatusXML struct {
 }
 
 type cacheClusterXML struct {
-	CacheClusterID       string                        `xml:"CacheClusterId"`
-	CacheClusterStatus   string                        `xml:"CacheClusterStatus"`
-	CacheNodeType        string                        `xml:"CacheNodeType,omitempty"`
-	Engine               string                        `xml:"Engine,omitempty"`
-	EngineVersion        string                        `xml:"EngineVersion,omitempty"`
-	NumCacheNodes        int                           `xml:"NumCacheNodes,omitempty"`
-	CacheClusterCreateAt string                        `xml:"CacheClusterCreateTime,omitempty"`
-	ARN                  string                        `xml:"ARN,omitempty"`
-	CacheParameterGroup  *cacheParameterGroupStatusXML `xml:"CacheParameterGroup,omitempty"`
-	ConfigurationEndpt   *endpointXML                  `xml:"ConfigurationEndpoint,omitempty"`
-	CacheNodes           *cacheNodesXML                `xml:"CacheNodes,omitempty"`
+	CacheClusterID          string                        `xml:"CacheClusterId"`
+	CacheClusterStatus      string                        `xml:"CacheClusterStatus"`
+	ReplicationGroupID      string                        `xml:"ReplicationGroupId,omitempty"`
+	AutoMinorVersionUpgrade bool                          `xml:"AutoMinorVersionUpgrade"`
+	CacheNodeType           string                        `xml:"CacheNodeType,omitempty"`
+	Engine                  string                        `xml:"Engine,omitempty"`
+	EngineVersion           string                        `xml:"EngineVersion,omitempty"`
+	NumCacheNodes           int                           `xml:"NumCacheNodes,omitempty"`
+	CacheClusterCreateAt    string                        `xml:"CacheClusterCreateTime,omitempty"`
+	ARN                     string                        `xml:"ARN,omitempty"`
+	CacheParameterGroup     *cacheParameterGroupStatusXML `xml:"CacheParameterGroup,omitempty"`
+	ConfigurationEndpt      *endpointXML                  `xml:"ConfigurationEndpoint,omitempty"`
+	CacheNodes              *cacheNodesXML                `xml:"CacheNodes,omitempty"`
 }
 
 // --- response envelopes, one per Action ---
@@ -232,6 +242,26 @@ func defaultParamGroupName(engine, version string) string {
 	return "default." + family
 }
 
+// fallbackRegion is used when a cluster's ARN is missing or malformed and its
+// region cannot be read; it is the AWS default region.
+const fallbackRegion = "us-east-1"
+
+// clusterAZ derives a plausible availability zone (the region's first AZ,
+// "<region>a") for a node from the cluster's ARN
+// (arn:aws:elasticache:<region>:<account>:...). The emulator does not model
+// per-node AZ placement, but the field must be present and non-empty.
+func clusterAZ(arn string) string {
+	const regionField = 3
+
+	region := fallbackRegion
+
+	if parts := strings.Split(arn, ":"); len(parts) > regionField && parts[regionField] != "" {
+		region = parts[regionField]
+	}
+
+	return region + "a"
+}
+
 // splitEndpoint separates the driver's "host:port" endpoint into an Address and
 // Port. Falls back to the default Redis port when no ":port" suffix is present.
 func splitEndpoint(endpoint string) *endpointXML {
@@ -272,14 +302,16 @@ func toCacheClusterXML(info *cachedriver.CacheInfo) cacheClusterXML {
 	}
 
 	out := cacheClusterXML{
-		CacheClusterID:       info.Name,
-		CacheClusterStatus:   info.Status,
-		CacheNodeType:        info.NodeType,
-		Engine:               info.Engine,
-		EngineVersion:        info.EngineVersion,
-		NumCacheNodes:        numNodes,
-		CacheClusterCreateAt: info.CreatedAt,
-		ARN:                  info.ARN,
+		CacheClusterID:          info.Name,
+		CacheClusterStatus:      info.Status,
+		ReplicationGroupID:      info.ReplicationGroupID,
+		AutoMinorVersionUpgrade: info.AutoMinorVersionUpgrade,
+		CacheNodeType:           info.NodeType,
+		Engine:                  info.Engine,
+		EngineVersion:           info.EngineVersion,
+		NumCacheNodes:           numNodes,
+		CacheClusterCreateAt:    info.CreatedAt,
+		ARN:                     info.ARN,
 	}
 
 	if info.Engine != "" {
@@ -304,12 +336,21 @@ func toCacheClusterXML(info *cachedriver.CacheInfo) cacheClusterXML {
 			out.ConfigurationEndpt = ep
 		}
 
+		// Every node must carry a non-empty CustomerAvailabilityZone or the
+		// Terraform provider aborts reading the cluster (see cacheNodeXML). The
+		// emulator does not place nodes in specific AZs, so report the first AZ of
+		// the cluster's region (region + "a"), which is what a single-AZ cluster
+		// looks like to a client.
+		az := clusterAZ(info.ARN)
+
 		nodes := make([]cacheNodeXML, 0, numNodes)
 		for i := 1; i <= numNodes; i++ {
 			nodes = append(nodes, cacheNodeXML{
-				CacheNodeID:     fmt.Sprintf("%04d", i),
-				CacheNodeStatus: info.Status,
-				Endpoint:        ep,
+				CacheNodeID:              fmt.Sprintf("%04d", i),
+				CacheNodeStatus:          info.Status,
+				CacheNodeCreateTime:      info.CreatedAt,
+				Endpoint:                 ep,
+				CustomerAvailabilityZone: az,
 			})
 		}
 

--- a/services/cache/driver/driver.go
+++ b/services/cache/driver/driver.go
@@ -63,6 +63,20 @@ type CacheInfo struct {
 	NumCacheNodes   int
 	SubnetGroupName string
 
+	// ReplicationGroupID is set on a cache cluster that is a member node of an
+	// AWS ElastiCache replication group ("<groupId>-001", "<groupId>-002", …);
+	// empty for a standalone cluster. Real ElastiCache exposes each member as a
+	// describable single-node cache cluster carrying this back-reference, so IaC
+	// that manages a replication group can read the members. AWS-only.
+	ReplicationGroupID string
+
+	// AutoMinorVersionUpgrade is the AWS ElastiCache flag controlling automatic
+	// minor engine upgrades, echoed back on Describe. Real ElastiCache defaults
+	// it to true, and terraform-provider-aws's schema default is also true, so
+	// the backend must resolve and report it or the caller sees a perpetual diff
+	// (config true vs. an absent/false read). AWS-only.
+	AutoMinorVersionUpgrade bool
+
 	// ParameterGroupName is the custom AWS ElastiCache cache parameter group
 	// attached to the cluster, echoed back on Describe so IaC that references a
 	// custom group converges. Empty means the backend reports the engine's
@@ -128,6 +142,12 @@ type CacheConfig struct {
 	// 6379, Memcached 11211). AWS-only and left zero by other callers.
 	Port int
 
+	// AutoMinorVersionUpgrade requests the AWS ElastiCache automatic-minor-upgrade
+	// flag. A pointer so an omitted parameter (nil) can be defaulted to the real
+	// ElastiCache default (true) rather than coerced to false. AWS-only and left
+	// nil by other callers.
+	AutoMinorVersionUpgrade *bool
+
 	// ParameterGroupName names a custom AWS ElastiCache cache parameter group
 	// to attach; empty means the backend reports the engine's default
 	// (default.<family>). AWS-only and left empty by other callers.
@@ -176,6 +196,10 @@ type ModifyCacheConfig struct {
 	// NumCacheNodes rescales a Memcached cluster; zero leaves the node count
 	// unchanged. The backend re-validates it against the cluster's engine.
 	NumCacheNodes int
+
+	// AutoMinorVersionUpgrade updates the automatic-minor-upgrade flag; nil
+	// leaves the stored value unchanged.
+	AutoMinorVersionUpgrade *bool
 }
 
 // Cache is the interface that cache provider implementations must satisfy.


### PR DESCRIPTION
## Summary

Live black-box real-user e2e of AWS ElastiCache (aws-cli + aws-sdk-go-v2 + Terraform `aws_elasticache_cluster` / `aws_elasticache_replication_group` / `aws_elasticache_subnet_group`) against `cloudemu serve`. Found and fixed three genuine cloud-vs-cloudemu divergences that broke real IaC users. Each was reproduced black-box before the fix and re-verified after (full `terraform apply → plan (no drift) → destroy` cycle now completes).

## Divergences fixed

**1. CacheNode missing `CustomerAvailabilityZone` — broke every `terraform apply` (High).**
The Terraform AWS provider dereferences `CacheNode.CustomerAvailabilityZone` unconditionally when flattening a cluster's nodes and aborts with `Unexpected nil pointer` if it is absent. The emulator never emitted it, so creating any `aws_elasticache_cluster` failed on read-back. Each node now carries a non-empty AZ (region's first AZ, derived from the cluster ARN) plus `CacheNodeCreateTime` for fidelity.

**2. Replication-group member clusters not describable — broke `aws_elasticache_replication_group` (High).**
After `CreateReplicationGroup`, Terraform reads every member cache cluster (`<id>-001`, `<id>-002`) back by id via `DescribeCacheClusters`. Members were never registered, so the read returned `CacheClusterNotFound` and the apply failed. Real ElastiCache exposes each member as a single-node cache cluster. Members are now synthesized from their group on the fly (single source of truth — no create/modify/delete sync bugs), describable individually and in the list, each carrying the `ReplicationGroupId` back-reference.

**3. `AutoMinorVersionUpgrade` never reported — perpetual Terraform diff (Medium).**
AWS defaults this flag to `true`, as does the Terraform schema. The emulator omitted it, so the provider read `false` and every plan wanted to change it (infrastructure never converged). The flag is now round-tripped: defaults to `true` when omitted, preserves an explicit `false`, and is updatable via `ModifyCacheCluster`.

## Live-test evidence

- `terraform apply` (memcached cluster + redis replication group) → both reach `available`; `terraform plan` reports no drift; `terraform destroy` completes.
- aws-cli: `describe-cache-clusters --cache-cluster-id <rg>-001` returns the member with `ReplicationGroupId`, engine, `AutoMinorVersionUpgrade`, and a node `CustomerAvailabilityZone`.
- `--no-auto-minor-version-upgrade` round-trips as `false`; omitted defaults to `true`.

## Tests

- `providers/aws/elasticache`: member-cluster describability (Get/List, scale-up, delete cleanup) and `AutoMinorVersionUpgrade` round-trip.
- `server/aws/elasticache`: real-SDK roundtrip asserting node `CustomerAvailabilityZone`, `AutoMinorVersionUpgrade` default/false, and member describability with the group back-reference.

## Gates

`go build ./...`, `go vet`, `gofmt -l`, scoped `go test -race`, and `golangci-lint --new-from-rev=origin/development` all green. `go generate ./...` produces no `docs/coverage` diff (driver method set unchanged).