### PR TITLE
fix(synapse): real-user e2e divergences from Azure

### DIFF
--- a/server/azure/synapse/sqlpool.go
+++ b/server/azure/synapse/sqlpool.go
@@ -22,8 +22,10 @@ func (h *Handler) serveSQLPool(w http.ResponseWriter, r *http.Request, rp *azure
 
 func (h *Handler) sqlPoolCRUD(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	switch r.Method {
-	case http.MethodPut, http.MethodPatch:
+	case http.MethodPut:
 		h.putSQLPool(w, r, rp)
+	case http.MethodPatch:
+		h.patchSQLPool(w, r, rp)
 	case http.MethodGet:
 		h.getSQLPool(w, rp)
 	case http.MethodDelete:
@@ -33,7 +35,10 @@ func (h *Handler) sqlPoolCRUD(w http.ResponseWriter, r *http.Request, rp *azurea
 	}
 }
 
-// putSQLPool serves the SQL-pool create/update LRO with a synchronous body.
+// putSQLPool serves the SQL-pool create/replace LRO (Sql-Pools/Create, PUT) with
+// a synchronous body. It is a full CreateOrUpdate: a missing pool is created and
+// an existing one is replaced wholesale. Partial updates arrive via PATCH
+// (patchSQLPool).
 func (h *Handler) putSQLPool(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var req sqlPoolRequest
 	if !azurearm.DecodeJSON(w, r, &req) {
@@ -70,6 +75,79 @@ func (h *Handler) putSQLPool(w http.ResponseWriter, r *http.Request, rp *azurear
 	// The armsynapse SQLPoolsClient.BeginCreate poller accepts a synchronous 200
 	// (or 202), not 201 — a 201 fails its initial-response status check.
 	azurearm.WriteJSON(w, http.StatusOK, resource)
+}
+
+// patchSQLPool serves the SQL-pool update LRO (Sql-Pools/Update, SqlPoolPatchInfo).
+// Unlike create, PATCH is a partial update: it never creates a missing pool (real
+// Azure answers 404) and preserves every field the request omits, applying only
+// the fields it carries. This mirrors the workspace patch semantics.
+func (h *Handler) patchSQLPool(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var req sqlPoolRequest
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	h.mu.Lock()
+
+	ws, ok := h.getWorkspace(rp)
+	if !ok {
+		h.mu.Unlock()
+		writeParentNotFound(w, rp.ResourceName)
+
+		return
+	}
+
+	pool, ok := ws.SQLPools[strings.ToLower(rp.SubResourceName)]
+	if !ok {
+		h.mu.Unlock()
+		writeSQLPoolNotFound(w, rp.SubResourceName)
+
+		return
+	}
+
+	mergeSQLPool(pool, &req)
+
+	resource := toSQLPoolResponse(ws, pool)
+	h.mu.Unlock()
+
+	azurearm.WriteJSON(w, http.StatusOK, resource)
+}
+
+// mergeSQLPool applies the non-omitted fields of a patch onto a stored SQL pool,
+// leaving unspecified fields untouched (ARM partial-update semantics).
+func mergeSQLPool(pool *sqlPoolState, req *sqlPoolRequest) {
+	if req.Location != "" {
+		pool.Location = req.Location
+	}
+
+	if req.Tags != nil {
+		pool.Tags = maps.Clone(req.Tags)
+	}
+
+	if req.SKU != nil {
+		pool.SKU = req.SKU
+	}
+
+	mergeSQLPoolProps(&pool.Props, &req.Properties)
+}
+
+// mergeSQLPoolProps overlays the non-empty properties of a patch onto stored props.
+func mergeSQLPoolProps(dst, src *sqlPoolReqProps) {
+	if src.Collation != "" {
+		dst.Collation = src.Collation
+	}
+
+	if src.MaxSizeBytes != nil {
+		dst.MaxSizeBytes = src.MaxSizeBytes
+	}
+
+	if src.CreateMode != "" {
+		dst.CreateMode = src.CreateMode
+	}
+
+	if src.StorageAccountType != "" {
+		dst.StorageAccountType = src.StorageAccountType
+	}
 }
 
 func (h *Handler) getSQLPool(w http.ResponseWriter, rp *azurearm.ResourcePath) {

--- a/server/azure/synapse/synapse_sdk_test.go
+++ b/server/azure/synapse/synapse_sdk_test.go
@@ -248,6 +248,86 @@ func sqlLifecycle(t *testing.T, ctx context.Context, ts *httptest.Server) {
 	}
 }
 
+// TestSDKSQLPoolPartialUpdate drives the real armsynapse SQLPoolsClient.BeginUpdate
+// (PATCH, SqlPoolPatchInfo) and asserts ARM partial-update semantics: a patch that
+// carries only tags must leave the SKU, collation and maxSizeBytes untouched, and a
+// patch of a pool that does not exist must be a 404, never an implicit create.
+func TestSDKSQLPoolPartialUpdate(t *testing.T) {
+	ts := newServer(t)
+	ctx := context.Background()
+
+	const poolName = "dwpool"
+
+	wsClient, err := armsynapse.NewWorkspacesClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewWorkspacesClient: %v", err)
+	}
+
+	createWorkspace(t, ctx, wsClient)
+
+	c, err := armsynapse.NewSQLPoolsClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewSQLPoolsClient: %v", err)
+	}
+
+	createPoller, err := c.BeginCreate(ctx, rgName, wsName, poolName, armsynapse.SQLPool{
+		Location: to.Ptr("eastus"),
+		SKU:      &armsynapse.SKU{Name: to.Ptr("DW100c"), Tier: to.Ptr("DataWarehouse")},
+		Properties: &armsynapse.SQLPoolResourceProperties{
+			Collation:    to.Ptr("SQL_Latin1_General_CP1_CI_AS"),
+			MaxSizeBytes: to.Ptr[int64](263882790666240),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate SQL pool: %v", err)
+	}
+
+	if _, err := createPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll SQL pool create: %v", err)
+	}
+
+	// PATCH with tags only: the SKU/collation/maxSizeBytes must survive.
+	updPoller, err := c.BeginUpdate(ctx, rgName, wsName, poolName, armsynapse.SQLPoolPatchInfo{
+		Tags: map[string]*string{"env": to.Ptr("prod")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate SQL pool: %v", err)
+	}
+
+	if _, err := updPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll SQL pool update: %v", err)
+	}
+
+	got, err := c.Get(ctx, rgName, wsName, poolName, nil)
+	if err != nil {
+		t.Fatalf("Get SQL pool: %v", err)
+	}
+
+	if got.SKU == nil || got.SKU.Name == nil || *got.SKU.Name != "DW100c" {
+		t.Fatalf("partial patch clobbered SKU: got %v, want DW100c preserved", got.SKU)
+	}
+
+	if got.Properties == nil || got.Properties.Collation == nil ||
+		*got.Properties.Collation != "SQL_Latin1_General_CP1_CI_AS" {
+		t.Fatalf("partial patch clobbered collation: got %v", got.Properties)
+	}
+
+	if got.Properties.MaxSizeBytes == nil || *got.Properties.MaxSizeBytes != 263882790666240 {
+		t.Fatalf("partial patch clobbered maxSizeBytes: got %v", got.Properties)
+	}
+
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" {
+		t.Fatalf("patch tags = %v, want env=prod", got.Tags)
+	}
+
+	// PATCH of a non-existent pool must be a 404, not an implicit create.
+	if _, err := c.BeginUpdate(ctx, rgName, wsName, "ghostpool", armsynapse.SQLPoolPatchInfo{
+		Tags: map[string]*string{"a": to.Ptr("b")},
+	}, nil); err == nil {
+		t.Fatal("BeginUpdate of a non-existent SQL pool returned nil error, want 404")
+	}
+}
+
 func pausePool(t *testing.T, ctx context.Context, c *armsynapse.SQLPoolsClient, name string) *string {
 	t.Helper()
 


### PR DESCRIPTION
Real-user e2e audit of Azure Synapse (Microsoft.Synapse) against the official ARM REST API (2021-06-01), driven with the real armsynapse SDK and raw ARM curl against a live \`cloudemu serve\`.

## Fixed

**SQL pool PATCH was a full-replace + implicit-create, not a partial update.**

Azure's \`Sql-Pools/Update\` is a PATCH \`SqlPoolPatchInfo\` — a *partial* update: fields the request omits are preserved, and a pool that does not exist is not created (404). The handler routed both PUT and PATCH to \`putSQLPool\`, which overwrote SKU/properties/tags/location wholesale and created the pool on a PATCH to a missing name.

Reproduced live: \`PATCH {tags:{env:prod}}\` on a DW100c pool wiped the SKU, collation, maxSizeBytes and location; a PATCH to a non-existent pool returned 200 (created) instead of 404.

Fix: PATCH now routes to a dedicated \`patchSQLPool\` that merges only the fields present and returns 404 when the workspace or pool is absent; PUT keeps full CreateOrUpdate. Added a real-SDK regression test (\`SQLPoolsClient.BeginUpdate\` with a tags-only \`SqlPoolPatchInfo\`) asserting SKU/collation/maxSizeBytes survive and a missing-pool PATCH is a 404.

Verified: full 4-resource SDK lifecycle still passes; \`go build\`, \`go vet\`, \`gofmt\`, \`-race\` tests, and \`golangci-lint --new-from-rev\` all green; no docs/coverage diff (wire-only handler, no driver interface).

## Filed, not fixed (low severity / out of scope)

- bigDataPools accepts PATCH as CreateOrUpdate — real API has no Spark-pool PATCH (would 405); no real client sends one, so harmless.
- integrationRuntimes PATCH replaces \`properties\` with the wrong shape — real IR Update body is \`{autoUpdate, updateDelayOffset}\`, a niche path.
- Workspace PATCH models only a subset of WorkspacePatchInfo (encryption / managedVirtualNetworkSettings / purviewConfiguration / git config are dropped); tags, identity and publicNetworkAccess round-trip.
- No required-field (\`location\`) validation on create.