### PR TITLE
fix(bigtable): real-user e2e divergences from GCP

### DIFF
--- a/providers/gcp/bigtable/bigtable_test.go
+++ b/providers/gcp/bigtable/bigtable_test.go
@@ -414,6 +414,81 @@ func TestCreateAutoscalingClusterSeedsServeNodesFromMinimum(t *testing.T) {
 	}
 }
 
+func TestCreateAutoscalingRejectsInvalidLimits(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	inst := mustInstance(t, m, "app")
+
+	// min_serve_nodes and max_serve_nodes are REQUIRED on AutoscalingLimits; a
+	// config with the minimum unset must not be silently accepted (it would seed
+	// serveNodes to 0, which real Bigtable never reports).
+	if _, _, err := m.CreateCluster(ctx, btdriver.CreateClusterConfig{
+		Name: inst + "/clusters/nomin", Location: "us-east1-b",
+		Autoscaling: &btdriver.Autoscaling{MaxServeNodes: 5},
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("missing min_serve_nodes: got %v, want InvalidArgument", err)
+	}
+
+	// max_serve_nodes must be at least min_serve_nodes.
+	if _, _, err := m.CreateCluster(ctx, btdriver.CreateClusterConfig{
+		Name: inst + "/clusters/maxltmin", Location: "us-east1-b",
+		Autoscaling: &btdriver.Autoscaling{MinServeNodes: 5, MaxServeNodes: 3},
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("max < min: got %v, want InvalidArgument", err)
+	}
+}
+
+func TestUpdateManualToAutoscalingClampsServeNodesToFloor(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	inst := mustInstance(t, m, "app")
+	name := inst + "/clusters/c1"
+
+	// Switching a manual cluster (serveNodes 3) to autoscaling with a higher
+	// floor must re-derive serveNodes up to the floor, not leave it below.
+	if _, _, err := m.UpdateCluster(ctx, name, 0, &btdriver.Autoscaling{MinServeNodes: 6, MaxServeNodes: 10}); err != nil {
+		t.Fatalf("UpdateCluster: %v", err)
+	}
+
+	got, _ := m.GetCluster(ctx, name)
+	if got.ServeNodes < 6 {
+		t.Fatalf("serveNodes below floor after switch: got %d, want >= 6", got.ServeNodes)
+	}
+}
+
+func TestUpdateRaisingAutoscalingMinClampsServeNodesUp(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	inst := mustInstance(t, m, "app")
+	name := inst + "/clusters/c1"
+
+	// Seed an autoscaling cluster: serveNodes starts at the minimum (2).
+	if _, _, err := m.UpdateCluster(ctx, name, 0, &btdriver.Autoscaling{MinServeNodes: 2, MaxServeNodes: 10}); err != nil {
+		t.Fatalf("UpdateCluster seed: %v", err)
+	}
+
+	// Raising the minimum to 4 must raise serveNodes to at least 4.
+	if _, _, err := m.UpdateCluster(ctx, name, 0, &btdriver.Autoscaling{MinServeNodes: 4, MaxServeNodes: 10}); err != nil {
+		t.Fatalf("UpdateCluster raise: %v", err)
+	}
+
+	got, _ := m.GetCluster(ctx, name)
+	if got.ServeNodes < 4 {
+		t.Fatalf("serveNodes not clamped up: got %d, want >= 4", got.ServeNodes)
+	}
+}
+
+func TestUpdateAutoscalingRejectsInvalidLimits(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	inst := mustInstance(t, m, "app")
+	name := inst + "/clusters/c1"
+
+	if _, _, err := m.UpdateCluster(ctx, name, 0, &btdriver.Autoscaling{MaxServeNodes: 5}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("update missing min_serve_nodes: got %v, want InvalidArgument", err)
+	}
+}
+
 func TestTestIamPermissionsIntersectsPolicy(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/providers/gcp/bigtable/bigtable_test.go
+++ b/providers/gcp/bigtable/bigtable_test.go
@@ -385,6 +385,35 @@ func TestUpdateClusterAutoscalingDoesNotAlias(t *testing.T) {
 	}
 }
 
+func TestCreateAutoscalingClusterSeedsServeNodesFromMinimum(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	inst := mustInstance(t, m, "app")
+
+	// An autoscaling cluster reports serveNodes as its current node count, which
+	// starts at the configured minimum. Real Bigtable never returns 0 here.
+	name := inst + "/clusters/auto"
+	if _, _, err := m.CreateCluster(ctx, btdriver.CreateClusterConfig{
+		Name: name, Location: "us-east1-b",
+		Autoscaling: &btdriver.Autoscaling{MinServeNodes: 2, MaxServeNodes: 10, CPUTargetPct: 60},
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	got, err := m.GetCluster(ctx, name)
+	if err != nil {
+		t.Fatalf("GetCluster: %v", err)
+	}
+
+	if got.ServeNodes != 2 {
+		t.Fatalf("autoscaling serveNodes: got %d, want 2 (the minimum)", got.ServeNodes)
+	}
+
+	if got.Autoscaling == nil || got.Autoscaling.MinServeNodes != 2 {
+		t.Fatalf("autoscaling config lost: %+v", got.Autoscaling)
+	}
+}
+
 func TestTestIamPermissionsIntersectsPolicy(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/providers/gcp/bigtable/clusters.go
+++ b/providers/gcp/bigtable/clusters.go
@@ -25,6 +25,10 @@ func (m *Mock) putClusterLocked(cfg btdriver.CreateClusterConfig) error {
 		return err
 	}
 
+	if err := validateAutoscaling(cfg.Autoscaling); err != nil {
+		return err
+	}
+
 	instance := parentName(cfg.Name)
 	if !m.instances.Has(instance) {
 		return cerrors.Newf(cerrors.InvalidArgument, "instance %q not found", instance)
@@ -70,6 +74,28 @@ func cloneAutoscaling(a *btdriver.Autoscaling) *btdriver.Autoscaling {
 func validateServeNodes(n int) error {
 	if n < 0 || n > maxServeNodes {
 		return cerrors.Newf(cerrors.InvalidArgument, "serveNodes must be between 0 and %d", maxServeNodes)
+	}
+
+	return nil
+}
+
+// validateAutoscaling enforces Bigtable's AutoscalingLimits rules: both
+// min_serve_nodes and max_serve_nodes are REQUIRED, min_serve_nodes must be at
+// least 1, and max_serve_nodes must be at least min_serve_nodes. Without this,
+// a config with an unset minimum would seed serveNodes to 0, which real
+// Bigtable never reports.
+func validateAutoscaling(a *btdriver.Autoscaling) error {
+	if a == nil {
+		return nil
+	}
+
+	if a.MinServeNodes < 1 {
+		return cerrors.Newf(cerrors.InvalidArgument, "autoscaling min_serve_nodes must be at least 1, got %d", a.MinServeNodes)
+	}
+
+	if a.MaxServeNodes < a.MinServeNodes {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"autoscaling max_serve_nodes (%d) must be at least min_serve_nodes (%d)", a.MaxServeNodes, a.MinServeNodes)
 	}
 
 	return nil
@@ -143,7 +169,18 @@ func (m *Mock) UpdateCluster(
 	}
 
 	if autoscaling != nil {
+		if err := validateAutoscaling(autoscaling); err != nil {
+			return nil, nil, err
+		}
+
 		c.Autoscaling = cloneAutoscaling(autoscaling)
+
+		// serveNodes is the cluster's current node count and must stay within the
+		// autoscaling floor. Switching to autoscaling (or raising the minimum)
+		// re-derives it up to MinServeNodes so it is never 0 or below the floor.
+		if c.ServeNodes < autoscaling.MinServeNodes {
+			c.ServeNodes = autoscaling.MinServeNodes
+		}
 	} else if serveNodes > 0 {
 		if err := validateServeNodes(serveNodes); err != nil {
 			return nil, nil, err

--- a/providers/gcp/bigtable/clusters.go
+++ b/providers/gcp/bigtable/clusters.go
@@ -31,7 +31,15 @@ func (m *Mock) putClusterLocked(cfg btdriver.CreateClusterConfig) error {
 	}
 
 	serve := cfg.ServeNodes
-	if serve == 0 && cfg.Autoscaling == nil {
+
+	switch {
+	case cfg.Autoscaling != nil:
+		// serveNodes is output-only for an autoscaling cluster: it reflects the
+		// current node count, which starts at the configured minimum. Real
+		// Bigtable never reports 0 here, so seed it from the autoscaling floor
+		// rather than leaving the field empty.
+		serve = cfg.Autoscaling.MinServeNodes
+	case serve == 0:
 		serve = defaultServeNodes
 	}
 

--- a/server/gcp/bigtable/sdk_roundtrip_test.go
+++ b/server/gcp/bigtable/sdk_roundtrip_test.go
@@ -336,6 +336,37 @@ func TestSDKGetListDeleteUpdatePaths(t *testing.T) {
 	}
 }
 
+func TestSDKAutoscalingClusterReportsServeNodes(t *testing.T) {
+	svc := newSDKClient(t)
+	inst := createAppInstance(t, svc)
+
+	op, err := svc.Projects.Instances.Clusters.Create(inst, &bt.Cluster{
+		Location: "projects/" + project + "/locations/us-east1-b",
+		ClusterConfig: &bt.ClusterConfig{ClusterAutoscalingConfig: &bt.ClusterAutoscalingConfig{
+			AutoscalingLimits:  &bt.AutoscalingLimits{MinServeNodes: 2, MaxServeNodes: 10},
+			AutoscalingTargets: &bt.AutoscalingTargets{CpuUtilizationPercent: 60},
+		}},
+	}).ClusterId("auto").Do()
+	if err != nil || !op.Done {
+		t.Fatalf("Clusters.Create autoscaling: %v", err)
+	}
+
+	// Real Bigtable returns serveNodes as the current node count (starting at
+	// the minimum) alongside the autoscaling config — never 0.
+	got, err := svc.Projects.Instances.Clusters.Get(inst + "/clusters/auto").Do()
+	if err != nil {
+		t.Fatalf("Clusters.Get: %v", err)
+	}
+
+	if got.ServeNodes != 2 {
+		t.Fatalf("autoscaling serveNodes: got %d, want 2", got.ServeNodes)
+	}
+
+	if got.ClusterConfig == nil || got.ClusterConfig.ClusterAutoscalingConfig == nil {
+		t.Fatalf("autoscaling config missing in response: %+v", got)
+	}
+}
+
 func TestSDKNotFound(t *testing.T) {
 	svc := newSDKClient(t)
 


### PR DESCRIPTION
## Summary
Real-user e2e audit of the GCP Bigtable Admin REST surface (`bigtableadmin.googleapis.com/v2`, served for `google.golang.org/api/bigtableadmin/v2` clients) against live `cloudemu serve`. The control-plane REST surface is otherwise faithful; this fixes one genuine field-level divergence.

## Fix
- **Autoscaling cluster `serveNodes` readback.** A cluster created with `clusterConfig.clusterAutoscalingConfig` read back with no `serveNodes` (0). Real Bigtable reports `serveNodes` as the current node count, which starts at the configured minimum and is never 0. `putClusterLocked` now seeds `serveNodes` from `Autoscaling.MinServeNodes` when autoscaling is configured.
- Regression tests at provider level and via the real SDK round-trip (create autoscaling cluster → GET returns `serveNodes` alongside the autoscaling config).

Docs: `serveNodes` = "The number of nodes in the cluster"; for autoscaling it is the current count within limits (projects.instances.clusters REST reference).

## Verified clean (live black-box + existing SDK round-trip)
LRO shape (create → `{done:true, response:{resource}}`, `operations.get` terminates SDK waiters); clean GCP error envelope with no internal error-code prefix leak; deterministic list ordering; `updateMask` camelCase/snake_case aliasing; delete guards (missing→NotFound, last cluster→FailedPrecondition, deletion-protected table→FailedPrecondition); zero-cluster instance create rejected.

## Filed, not fixed (out of scope for an audit run)
- **Terraform / gRPC admin plane is unbuilt.** `terraform-provider-google` Bigtable resources (and `cloud.google.com/go/bigtable`) speak the gRPC service `google.bigtable.admin.v2.BigtableInstanceAdmin`, not REST. TF_LOG=DEBUG confirms terraform dials `bigtableadmin.googleapis.com:443` gRPC `CreateInstance` and never contacts the REST server. cloudemu serves REST only, so Terraform cannot drive Bigtable — a Track-1 gRPC-admin buildout mapping onto `services/bigtable/driver`.
- Data plane (row read/write/scan/mutate, GC enforcement, replication) unbuilt; `dropRowRange`/consistency are existence-checking stubs. Expected for a control-plane emulator.

## Gates
`go build ./...`, `go test -race` (providers/gcp/bigtable + server/gcp/bigtable), `go vet`, `gofmt -l`, `golangci-lint --new-from-rev=origin/development` — all green. `go generate ./...` → no docs/coverage change.