### PR TITLE
fix(redshift): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/redshift/redshift.go
+++ b/providers/aws/redshift/redshift.go
@@ -31,13 +31,18 @@ const (
 	singleNodeCount = 1
 	// defaultKMSKeyAlias is the account-default Redshift KMS key real AWS fills in
 	// when a cluster is created encrypted without an explicit KmsKeyId.
-	defaultKMSKeyAlias       = "alias/aws/redshift"
-	snapshotBackupSizeMB     = 100.0
-	cpuUtilizationRunning    = 25.0
-	databaseConnectionsRun   = 5.0
-	readIOPSRunning          = 10.0
-	writeIOPSRunning         = 5.0
-	networkReceiveThroughput = 1024.0
+	defaultKMSKeyAlias = "alias/aws/redshift"
+	// defaultParameterGroupName is the parameter group a cluster is associated
+	// with when CreateCluster names none. Real Redshift always attaches one (the
+	// family default), and clients rely on it: terraform's aws_redshift_cluster
+	// reads ClusterParameterGroups[0] unconditionally and panics on an empty list.
+	defaultParameterGroupName = "default.redshift-1.0"
+	snapshotBackupSizeMB      = 100.0
+	cpuUtilizationRunning     = 25.0
+	databaseConnectionsRun    = 5.0
+	readIOPSRunning           = 10.0
+	writeIOPSRunning          = 5.0
+	networkReceiveThroughput  = 1024.0
 )
 
 // errInstanceOpsUnsupported is the canonical error returned for instance-level
@@ -563,6 +568,11 @@ func (m *Mock) reserveCluster(cfg rdbdriver.ClusterConfig) (rdbdriver.Cluster, e
 		numberOfNodes = singleNodeCount
 	}
 
+	parameterGroup := cfg.DBClusterParameterGroupName
+	if parameterGroup == "" {
+		parameterGroup = defaultParameterGroupName
+	}
+
 	cluster := rdbdriver.Cluster{
 		ID:                          cfg.ID,
 		ARN:                         clusterARN(m.opts.Region, m.opts.AccountID, cfg.ID),
@@ -575,7 +585,7 @@ func (m *Mock) reserveCluster(cfg rdbdriver.ClusterConfig) (rdbdriver.Cluster, e
 		State:                       rdbdriver.StateAvailable,
 		VPCSecurityGroups:           append([]string(nil), cfg.VPCSecurityGroups...),
 		SubnetGroupName:             cfg.SubnetGroupName,
-		DBClusterParameterGroupName: cfg.DBClusterParameterGroupName,
+		DBClusterParameterGroupName: parameterGroup,
 		NodeType:                    cfg.NodeType,
 		NumberOfNodes:               numberOfNodes,
 		Encrypted:                   cfg.Encrypted,
@@ -1023,21 +1033,22 @@ func (m *Mock) RestoreClusterFromSnapshot(
 	}
 
 	cluster := rdbdriver.Cluster{
-		ID:             input.NewClusterID,
-		ARN:            clusterARN(m.opts.Region, m.opts.AccountID, input.NewClusterID),
-		Engine:         snap.Engine,
-		EngineVersion:  snap.EngineVersion,
-		MasterUsername: snap.MasterUsername,
-		DatabaseName:   snap.DatabaseName,
-		Endpoint:       endpointFor(input.NewClusterID),
-		Port:           defaultPort,
-		State:          rdbdriver.StateAvailable,
-		NodeType:       snap.NodeType,
-		NumberOfNodes:  numberOfNodes,
-		Encrypted:      snap.Encrypted,
-		KmsKeyID:       restoredKMSKeyID(snap.Encrypted, snap.KmsKeyID, input.KmsKeyID),
-		CreatedAt:      now,
-		Tags:           copyTags(input.Tags),
+		ID:                          input.NewClusterID,
+		ARN:                         clusterARN(m.opts.Region, m.opts.AccountID, input.NewClusterID),
+		Engine:                      snap.Engine,
+		EngineVersion:               snap.EngineVersion,
+		MasterUsername:              snap.MasterUsername,
+		DatabaseName:                snap.DatabaseName,
+		Endpoint:                    endpointFor(input.NewClusterID),
+		Port:                        defaultPort,
+		State:                       rdbdriver.StateAvailable,
+		DBClusterParameterGroupName: defaultParameterGroupName,
+		NodeType:                    snap.NodeType,
+		NumberOfNodes:               numberOfNodes,
+		Encrypted:                   snap.Encrypted,
+		KmsKeyID:                    restoredKMSKeyID(snap.Encrypted, snap.KmsKeyID, input.KmsKeyID),
+		CreatedAt:                   now,
+		Tags:                        copyTags(input.Tags),
 	}
 
 	m.clusters.Set(input.NewClusterID, cluster)

--- a/server/aws/redshift/handler.go
+++ b/server/aws/redshift/handler.go
@@ -43,6 +43,7 @@ var redshiftActions = map[string]struct{}{ //nolint:gochecknoglobals // static l
 	"DeleteClusterSnapshot":          {},
 	"RestoreFromClusterSnapshot":     {},
 	"GetClusterCredentials":          {},
+	"DescribeLoggingStatus":          {},
 	"PauseCluster":                   {},
 	"ResumeCluster":                  {},
 	"CreateClusterParameterGroup":    {},
@@ -173,6 +174,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.restoreFromClusterSnapshot(w, r)
 	case "GetClusterCredentials":
 		h.getClusterCredentials(w, r)
+	case "DescribeLoggingStatus":
+		h.describeLoggingStatus(w, r)
 	case "PauseCluster":
 		h.pauseCluster(w, r)
 	case "ResumeCluster":

--- a/server/aws/redshift/operations.go
+++ b/server/aws/redshift/operations.go
@@ -371,6 +371,27 @@ func (h *Handler) getClusterCredentials(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
+// describeLoggingStatus reports a cluster's audit-logging configuration.
+// Audit logging is not modeled, so an existing cluster always reports logging
+// disabled. Terraform's aws_redshift_cluster read calls this unconditionally to
+// populate its logging block, so a missing action fails the whole create.
+func (h *Handler) describeLoggingStatus(w http.ResponseWriter, r *http.Request) {
+	id := r.Form.Get("ClusterIdentifier")
+
+	// The cluster must exist; ClusterNotFound (404) otherwise, matching AWS.
+	clusters, err := h.db.DescribeClusters(r.Context(), []string{id})
+	if err != nil || len(clusters) == 0 {
+		writeErr(w, errClusterNotFound(id))
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, describeLoggingStatusResponse{
+		Xmlns:    Namespace,
+		Result:   loggingStatusResult{LoggingEnabled: false},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
 //nolint:dupl // structurally similar to resumeCluster but a distinct action + response type.
 func (h *Handler) pauseCluster(w http.ResponseWriter, r *http.Request) {
 	pauser, ok := h.db.(clusterPauser)

--- a/server/aws/redshift/parameter_group.go
+++ b/server/aws/redshift/parameter_group.go
@@ -186,8 +186,18 @@ func (h *Handler) describeClusterParameters(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Honor the optional Source filter ("user" | "engine-default"). Terraform's
+	// aws_redshift_parameter_group read requests Source=user to see only the
+	// parameters the user overrode; without the filter it stores every
+	// engine-default too and then plans to delete them on the next run.
+	source := r.Form.Get("Source")
+
 	out := make([]redshiftParameterXML, 0, len(params))
 	for i := range params {
+		if source != "" && params[i].Source != source {
+			continue
+		}
+
 		out = append(out, redshiftParameterXML{
 			ParameterName:  params[i].Name,
 			ParameterValue: params[i].Value,

--- a/server/aws/redshift/terraform_read_fields_sdk_roundtrip_test.go
+++ b/server/aws/redshift/terraform_read_fields_sdk_roundtrip_test.go
@@ -1,0 +1,196 @@
+package redshift_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsredshift "github.com/aws/aws-sdk-go-v2/service/redshift"
+	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
+	"github.com/aws/smithy-go"
+)
+
+// paramOverride builds a single-parameter override list for
+// ModifyClusterParameterGroup.
+func paramOverride(name, value string) []redshifttypes.Parameter {
+	return []redshifttypes.Parameter{
+		{ParameterName: aws.String(name), ParameterValue: aws.String(value)},
+	}
+}
+
+// TestSDKRedshiftTerraformReadFields asserts the cluster-read fields the real
+// aws_redshift_cluster resource depends on during its create/read cycle.
+// ClusterAvailabilityStatus drives the create/update waiters (target
+// "Available"); AvailabilityZoneRelocationStatus is waited on unconditionally;
+// MultiAZ is parsed as "Enabled"/"Disabled"; MaintenanceTrackName and the
+// snapshot-retention / version-upgrade defaults must match the provider schema
+// defaults or every plan drifts. Omitting any of these blocks Terraform.
+func TestSDKRedshiftTerraformReadFields(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:  aws.String("tf-fields"),
+		MasterUsername:     aws.String("admin"),
+		MasterUserPassword: aws.String("Sup3rSecret!"),
+		NodeType:           aws.String("dc2.large"),
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	cl := out.Cluster
+
+	if got := aws.ToString(cl.ClusterAvailabilityStatus); got != "Available" {
+		t.Fatalf("ClusterAvailabilityStatus=%q, want Available", got)
+	}
+
+	if got := aws.ToString(cl.AvailabilityZoneRelocationStatus); got != "disabled" {
+		t.Fatalf("AvailabilityZoneRelocationStatus=%q, want disabled", got)
+	}
+
+	if got := aws.ToString(cl.MultiAZ); got != "Disabled" {
+		t.Fatalf("MultiAZ=%q, want Disabled", got)
+	}
+
+	if got := aws.ToString(cl.MaintenanceTrackName); got != "current" {
+		t.Fatalf("MaintenanceTrackName=%q, want current", got)
+	}
+
+	if !aws.ToBool(cl.AllowVersionUpgrade) {
+		t.Fatal("AllowVersionUpgrade=false, want true (AWS default)")
+	}
+
+	if got := aws.ToInt32(cl.AutomatedSnapshotRetentionPeriod); got != 1 {
+		t.Fatalf("AutomatedSnapshotRetentionPeriod=%d, want 1", got)
+	}
+
+	if got := aws.ToInt32(cl.ManualSnapshotRetentionPeriod); got != -1 {
+		t.Fatalf("ManualSnapshotRetentionPeriod=%d, want -1", got)
+	}
+
+	// A cluster is always attached to a parameter group; the provider indexes
+	// ClusterParameterGroups[0] unconditionally, so an empty list crashes it.
+	if len(cl.ClusterParameterGroups) != 1 ||
+		aws.ToString(cl.ClusterParameterGroups[0].ParameterGroupName) != "default.redshift-1.0" {
+		t.Fatalf("ClusterParameterGroups=%+v, want one default.redshift-1.0 membership", cl.ClusterParameterGroups)
+	}
+}
+
+// TestSDKRedshiftSingleNodeNodeShape asserts a single-node cluster reports
+// exactly one SHARED node. Terraform derives cluster_type from
+// len(ClusterNodes) > 1, so a leader+compute pair would mislabel a single-node
+// cluster as multi-node and drift forever.
+func TestSDKRedshiftSingleNodeNodeShape(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:  aws.String("one-node"),
+		MasterUsername:     aws.String("admin"),
+		MasterUserPassword: aws.String("Sup3rSecret!"),
+		NodeType:           aws.String("dc2.large"),
+		NumberOfNodes:      aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	nodes := out.Cluster.ClusterNodes
+	if len(nodes) != 1 {
+		t.Fatalf("single-node ClusterNodes=%d, want 1", len(nodes))
+	}
+
+	if got := aws.ToString(nodes[0].NodeRole); got != "SHARED" {
+		t.Fatalf("single-node role=%q, want SHARED", got)
+	}
+}
+
+// TestSDKRedshiftDescribeLoggingStatus asserts DescribeLoggingStatus reports
+// logging disabled for an existing cluster (Terraform reads it on every cluster
+// read) and ClusterNotFound for an unknown one.
+func TestSDKRedshiftDescribeLoggingStatus(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:  aws.String("logged"),
+		MasterUsername:     aws.String("admin"),
+		MasterUserPassword: aws.String("Sup3rSecret!"),
+		NodeType:           aws.String("dc2.large"),
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	ls, err := client.DescribeLoggingStatus(ctx, &awsredshift.DescribeLoggingStatusInput{
+		ClusterIdentifier: aws.String("logged"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeLoggingStatus: %v", err)
+	}
+
+	if aws.ToBool(ls.LoggingEnabled) {
+		t.Fatal("LoggingEnabled=true, want false")
+	}
+
+	_, err = client.DescribeLoggingStatus(ctx, &awsredshift.DescribeLoggingStatusInput{
+		ClusterIdentifier: aws.String("ghost"),
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown cluster")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ClusterNotFound" {
+		t.Fatalf("DescribeLoggingStatus(missing) ErrorCode = %v, want ClusterNotFound", err)
+	}
+}
+
+// TestSDKRedshiftDescribeClusterParametersSourceFilter asserts the Source
+// filter is honored: Terraform's aws_redshift_parameter_group read requests
+// Source=user and expects only user-overridden parameters, otherwise it plans
+// to delete every engine default on the next run.
+func TestSDKRedshiftDescribeClusterParametersSourceFilter(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateClusterParameterGroup(ctx, &awsredshift.CreateClusterParameterGroupInput{
+		ParameterGroupName:   aws.String("filtpg"),
+		ParameterGroupFamily: aws.String("redshift-1.0"),
+		Description:          aws.String("filter pg"),
+	}); err != nil {
+		t.Fatalf("CreateClusterParameterGroup: %v", err)
+	}
+
+	// Before any override, a user-source query returns nothing.
+	userOnly, err := client.DescribeClusterParameters(ctx, &awsredshift.DescribeClusterParametersInput{
+		ParameterGroupName: aws.String("filtpg"),
+		Source:             aws.String("user"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeClusterParameters(user): %v", err)
+	}
+	if len(userOnly.Parameters) != 0 {
+		t.Fatalf("user params before override = %d, want 0", len(userOnly.Parameters))
+	}
+
+	if _, err := client.ModifyClusterParameterGroup(ctx, &awsredshift.ModifyClusterParameterGroupInput{
+		ParameterGroupName: aws.String("filtpg"),
+		Parameters:         paramOverride("require_ssl", "true"),
+	}); err != nil {
+		t.Fatalf("ModifyClusterParameterGroup: %v", err)
+	}
+
+	// After the override, only the one user parameter comes back under Source=user.
+	userOnly, err = client.DescribeClusterParameters(ctx, &awsredshift.DescribeClusterParametersInput{
+		ParameterGroupName: aws.String("filtpg"),
+		Source:             aws.String("user"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeClusterParameters(user after): %v", err)
+	}
+	if len(userOnly.Parameters) != 1 || aws.ToString(userOnly.Parameters[0].ParameterName) != "require_ssl" {
+		t.Fatalf("user params after override = %+v, want only require_ssl", userOnly.Parameters)
+	}
+}

--- a/server/aws/redshift/xml.go
+++ b/server/aws/redshift/xml.go
@@ -40,26 +40,39 @@ type vpcSecurityGroupsXML struct {
 }
 
 type clusterXML struct {
-	ClusterIdentifier      string                     `xml:"ClusterIdentifier"`
-	ClusterNamespaceArn    string                     `xml:"ClusterNamespaceArn"`
-	ClusterStatus          string                     `xml:"ClusterStatus"`
-	ClusterVersion         string                     `xml:"ClusterVersion,omitempty"`
-	MasterUsername         string                     `xml:"MasterUsername,omitempty"`
-	DBName                 string                     `xml:"DBName,omitempty"`
-	Endpoint               *endpointXML               `xml:"Endpoint,omitempty"`
-	ClusterCreateTime      string                     `xml:"ClusterCreateTime,omitempty"`
-	ClusterSubnetGroupName string                     `xml:"ClusterSubnetGroupName,omitempty"`
-	VpcSecurityGroups      *vpcSecurityGroupsXML      `xml:"VpcSecurityGroups,omitempty"`
-	Tags                   *tagsXML                   `xml:"Tags,omitempty"`
-	NodeType               string                     `xml:"NodeType,omitempty"`
-	NumberOfNodes          int                        `xml:"NumberOfNodes,omitempty"`
-	Encrypted              bool                       `xml:"Encrypted"`
-	KmsKeyID               string                     `xml:"KmsKeyId,omitempty"`
-	PubliclyAccessible     bool                       `xml:"PubliclyAccessible"`
-	AvailabilityZone       string                     `xml:"AvailabilityZone,omitempty"`
-	VpcID                  string                     `xml:"VpcId,omitempty"`
-	ClusterParameterGroups *clusterParameterGroupsXML `xml:"ClusterParameterGroups,omitempty"`
-	ClusterNodes           *clusterNodesXML           `xml:"ClusterNodes,omitempty"`
+	ClusterIdentifier         string `xml:"ClusterIdentifier"`
+	ClusterNamespaceArn       string `xml:"ClusterNamespaceArn"`
+	ClusterStatus             string `xml:"ClusterStatus"`
+	ClusterAvailabilityStatus string `xml:"ClusterAvailabilityStatus"`
+	// AvailabilityZoneRelocationStatus is always "disabled": AZ relocation is not
+	// modeled. Terraform's create/restore path unconditionally waits for this to
+	// resolve to "enabled"/"disabled", so an unset value hangs the waiter.
+	AvailabilityZoneRelocationStatus string `xml:"AvailabilityZoneRelocationStatus"`
+	MultiAZ                          string `xml:"MultiAZ"`
+	// AllowVersionUpgrade / Automated- / ManualSnapshotRetentionPeriod are not
+	// modeled and always report the AWS account defaults; terraform reads them
+	// back into its schema (whose defaults match), so omitting them drifts.
+	AllowVersionUpgrade              bool                       `xml:"AllowVersionUpgrade"`
+	AutomatedSnapshotRetentionPeriod int                        `xml:"AutomatedSnapshotRetentionPeriod"`
+	ManualSnapshotRetentionPeriod    int                        `xml:"ManualSnapshotRetentionPeriod"`
+	MaintenanceTrackName             string                     `xml:"MaintenanceTrackName"`
+	ClusterVersion                   string                     `xml:"ClusterVersion,omitempty"`
+	MasterUsername                   string                     `xml:"MasterUsername,omitempty"`
+	DBName                           string                     `xml:"DBName,omitempty"`
+	Endpoint                         *endpointXML               `xml:"Endpoint,omitempty"`
+	ClusterCreateTime                string                     `xml:"ClusterCreateTime,omitempty"`
+	ClusterSubnetGroupName           string                     `xml:"ClusterSubnetGroupName,omitempty"`
+	VpcSecurityGroups                *vpcSecurityGroupsXML      `xml:"VpcSecurityGroups,omitempty"`
+	Tags                             *tagsXML                   `xml:"Tags,omitempty"`
+	NodeType                         string                     `xml:"NodeType,omitempty"`
+	NumberOfNodes                    int                        `xml:"NumberOfNodes,omitempty"`
+	Encrypted                        bool                       `xml:"Encrypted"`
+	KmsKeyID                         string                     `xml:"KmsKeyId,omitempty"`
+	PubliclyAccessible               bool                       `xml:"PubliclyAccessible"`
+	AvailabilityZone                 string                     `xml:"AvailabilityZone,omitempty"`
+	VpcID                            string                     `xml:"VpcId,omitempty"`
+	ClusterParameterGroups           *clusterParameterGroupsXML `xml:"ClusterParameterGroups,omitempty"`
+	ClusterNodes                     *clusterNodesXML           `xml:"ClusterNodes,omitempty"`
 }
 
 type clusterParameterGroupStatusXML struct {
@@ -215,29 +228,96 @@ type getClusterCredentialsResponse struct {
 	Metadata responseMetadata         `xml:"ResponseMetadata"`
 }
 
+// loggingStatusResult mirrors the AWS LoggingStatus shape. Audit logging is not
+// modeled, so LoggingEnabled is always false and the S3/log-export fields stay
+// empty.
+type loggingStatusResult struct {
+	LoggingEnabled bool `xml:"LoggingEnabled"`
+}
+
+type describeLoggingStatusResponse struct {
+	XMLName  xml.Name            `xml:"DescribeLoggingStatusResponse"`
+	Xmlns    string              `xml:"xmlns,attr"`
+	Result   loggingStatusResult `xml:"DescribeLoggingStatusResult"`
+	Metadata responseMetadata    `xml:"ResponseMetadata"`
+}
+
+// ClusterAvailabilityStatus values (the availability of the cluster for
+// queries), distinct from ClusterStatus (the lifecycle state). Terraform's
+// aws_redshift_cluster create/update/delete waiters poll this field, not
+// ClusterStatus: the create/update waiters wait for "Available" and treat
+// "Modifying"/"Unavailable"/"Maintenance" as pending, so a cluster that never
+// reports ClusterAvailabilityStatus hangs the waiter to timeout.
+const (
+	availabilityAvailable   = "Available"
+	availabilityModifying   = "Modifying"
+	availabilityUnavailable = "Unavailable"
+
+	// azRelocationDisabled is the terminal AvailabilityZoneRelocationStatus for a
+	// cluster with AZ relocation off (the only mode modeled).
+	azRelocationDisabled = "disabled"
+
+	// AWS cluster defaults reported for unmodeled attributes so terraform's
+	// matching schema defaults do not perpetually drift.
+	defaultAllowVersionUpgrade      = true
+	defaultAutomatedSnapshotRetain  = 1
+	defaultManualSnapshotRetainNone = -1
+	// defaultMaintenanceTrack is the maintenance track a cluster runs on by
+	// default; terraform's maintenance_track_name defaults to the same value.
+	defaultMaintenanceTrack = "current"
+
+	// multiAZDisabled is the Redshift MultiAZ value for a single-AZ cluster — the
+	// only mode modeled. The field is an "Enabled"/"Disabled" string (not a bool);
+	// terraform rejects any other value, including an empty one.
+	multiAZDisabled = "Disabled"
+)
+
+// clusterAvailabilityStatus derives the ClusterAvailabilityStatus (query
+// availability) from the ClusterStatus (lifecycle state): an available cluster
+// is "Available"; transient lifecycle states (creating/modifying/deleting/…)
+// map to "Modifying" so terraform's waiter keeps polling; a paused or otherwise
+// non-serving cluster is "Unavailable".
+func clusterAvailabilityStatus(state string) string {
+	switch state {
+	case rdbdriver.StateAvailable:
+		return availabilityAvailable
+	case rdbdriver.StateCreating, rdbdriver.StateModifying, rdbdriver.StateDeleting:
+		return availabilityModifying
+	default:
+		return availabilityUnavailable
+	}
+}
+
 // toClusterXML converts a driver Cluster to its XML representation.
 func toClusterXML(cluster *rdbdriver.Cluster) clusterXML {
 	return clusterXML{
-		ClusterIdentifier:      cluster.ID,
-		ClusterNamespaceArn:    cluster.ARN,
-		ClusterStatus:          cluster.State,
-		ClusterVersion:         cluster.EngineVersion,
-		MasterUsername:         cluster.MasterUsername,
-		DBName:                 cluster.DatabaseName,
-		Endpoint:               &endpointXML{Address: cluster.Endpoint, Port: cluster.Port},
-		ClusterCreateTime:      cluster.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
-		ClusterSubnetGroupName: cluster.SubnetGroupName,
-		VpcSecurityGroups:      toVpcSGsXML(cluster.VPCSecurityGroups),
-		Tags:                   toTagsXML(cluster.Tags),
-		NodeType:               cluster.NodeType,
-		NumberOfNodes:          cluster.NumberOfNodes,
-		Encrypted:              cluster.Encrypted,
-		KmsKeyID:               cluster.KmsKeyID,
-		PubliclyAccessible:     cluster.PubliclyAccessible,
-		AvailabilityZone:       cluster.AvailabilityZone,
-		VpcID:                  cluster.VpcID,
-		ClusterParameterGroups: toClusterParameterGroupsXML(cluster.DBClusterParameterGroupName),
-		ClusterNodes:           toClusterNodesXML(cluster.NumberOfNodes),
+		ClusterIdentifier:                cluster.ID,
+		ClusterNamespaceArn:              cluster.ARN,
+		ClusterStatus:                    cluster.State,
+		ClusterAvailabilityStatus:        clusterAvailabilityStatus(cluster.State),
+		AvailabilityZoneRelocationStatus: azRelocationDisabled,
+		MultiAZ:                          multiAZDisabled,
+		AllowVersionUpgrade:              defaultAllowVersionUpgrade,
+		AutomatedSnapshotRetentionPeriod: defaultAutomatedSnapshotRetain,
+		ManualSnapshotRetentionPeriod:    defaultManualSnapshotRetainNone,
+		MaintenanceTrackName:             defaultMaintenanceTrack,
+		ClusterVersion:                   cluster.EngineVersion,
+		MasterUsername:                   cluster.MasterUsername,
+		DBName:                           cluster.DatabaseName,
+		Endpoint:                         &endpointXML{Address: cluster.Endpoint, Port: cluster.Port},
+		ClusterCreateTime:                cluster.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
+		ClusterSubnetGroupName:           cluster.SubnetGroupName,
+		VpcSecurityGroups:                toVpcSGsXML(cluster.VPCSecurityGroups),
+		Tags:                             toTagsXML(cluster.Tags),
+		NodeType:                         cluster.NodeType,
+		NumberOfNodes:                    cluster.NumberOfNodes,
+		Encrypted:                        cluster.Encrypted,
+		KmsKeyID:                         cluster.KmsKeyID,
+		PubliclyAccessible:               cluster.PubliclyAccessible,
+		AvailabilityZone:                 cluster.AvailabilityZone,
+		VpcID:                            cluster.VpcID,
+		ClusterParameterGroups:           toClusterParameterGroupsXML(cluster.DBClusterParameterGroupName),
+		ClusterNodes:                     toClusterNodesXML(cluster.NumberOfNodes),
 	}
 }
 
@@ -248,7 +328,9 @@ const (
 	computePrivateIPBase = 10
 	nodeRoleLeader       = "LEADER"
 	nodeRoleCompute      = "COMPUTE"
+	nodeRoleShared       = "SHARED"
 	parameterApplyInSync = "in-sync"
+	singleNodeNodeCount  = 1
 )
 
 func toClusterParameterGroupsXML(name string) *clusterParameterGroupsXML {
@@ -264,12 +346,21 @@ func toClusterParameterGroupsXML(name string) *clusterParameterGroupsXML {
 	}
 }
 
-// toClusterNodesXML synthesizes one LEADER node plus numberOfNodes COMPUTE
-// nodes with deterministic private IPs, matching the ClusterNodes list real
-// Redshift returns.
+// toClusterNodesXML synthesizes the ClusterNodes list real Redshift returns.
+// A single-node cluster reports exactly one node with role SHARED (it is both
+// leader and compute); a multi-node cluster reports one LEADER plus
+// numberOfNodes COMPUTE nodes. The count matters: terraform derives
+// cluster_type from len(ClusterNodes) > 1, so emitting a leader+compute pair
+// for a single-node cluster would make it read back as multi-node and drift.
 func toClusterNodesXML(numberOfNodes int) *clusterNodesXML {
 	if numberOfNodes <= 0 {
 		return nil
+	}
+
+	if numberOfNodes == singleNodeNodeCount {
+		return &clusterNodesXML{Member: []clusterNodeXML{
+			{NodeRole: nodeRoleShared, PrivateIPAddress: leaderPrivateIP},
+		}}
 	}
 
 	nodes := make([]clusterNodeXML, 0, numberOfNodes+1)


### PR DESCRIPTION
## Summary

Real-user e2e audit of AWS Redshift via the aws-sdk-go-v2 client, aws-cli, and the real
Terraform `hashicorp/aws` provider against `cloudemu serve`. The full Terraform
`aws_redshift_cluster` create -> available -> read -> destroy cycle was **broken** before this
change (waiter hangs, an unimplemented action, and a provider panic). It now completes cleanly
for both single-node and multi-node clusters with **zero drift** on re-plan.

Each fix was reproduced black-box before and re-verified after, and cross-checked against the
official Redshift API reference and the provider's waiter/read source.

## Divergences fixed

- **`ClusterAvailabilityStatus`** — the field the provider's create/update/delete waiters poll
  (target `Available`), not `ClusterStatus`. Omitting it hung `apply` to timeout
  (`unexpected state '', wanted target 'Available'`). Derived from the lifecycle state.
- **`AvailabilityZoneRelocationStatus`** — waited on unconditionally after create/restore; now
  reports `disabled`.
- **`DescribeLoggingStatus`** — implemented (was `InvalidAction`); the provider calls it on every
  cluster read. Reports logging disabled; `ClusterNotFound` for a missing cluster.
- **`MultiAZ`** — the provider parses it as `Enabled`/`Disabled`; empty crashed the read. Now `Disabled`.
- **Default parameter group** — a cluster created without one now attaches `default.redshift-1.0`,
  matching AWS. The provider indexes `ClusterParameterGroups[0]` unconditionally and **panicked**
  on the empty list (reproduced on a multi-node cluster).
- **Single-node node shape** — a single-node cluster now reports exactly one `SHARED` node. The
  provider derives `cluster_type` from `len(ClusterNodes) > 1`, so the previous leader+compute pair
  mislabeled single-node clusters as multi-node and drifted forever.
- **`DescribeClusterParameters` `Source` filter** — honored. The provider requests `Source=user`;
  without the filter it stored every engine default and then planned to delete all of them.
- **Cluster read defaults** — `AllowVersionUpgrade`, `AutomatedSnapshotRetentionPeriod`,
  `ManualSnapshotRetentionPeriod`, `MaintenanceTrackName` now emit the AWS defaults, which match
  the provider schema defaults, eliminating drift.

## Tests

New SDK round-trip tests (`terraform_read_fields_sdk_roundtrip_test.go`) cover the read fields, the
single-node `SHARED`-node shape, `DescribeLoggingStatus` (disabled + ClusterNotFound), and the
`Source=user` parameter filter. Verified live end-to-end with aws-cli and Terraform (single- and
multi-node apply/plan/destroy).

## Filed, not fixed (deferred)

Round-tripping **user-customized** values for the retention/version-upgrade fields, AZ relocation,
Multi-AZ, and audit logging needs new fields on the shared relationaldb driver + Create/Modify
plumbing; these are unmodeled and report AWS defaults today. Redshift Serverless, the Data API, a
real SQL data plane, and cross-region snapshot copy remain unbuilt (out of scope).
