### PR TITLE
fix(azure): narrow Functions /api/ dispatch so it stops swallowing other data planes

### DIFF
--- a/server/azure/functions/handler.go
+++ b/server/azure/functions/handler.go
@@ -125,7 +125,7 @@ func (h *Handler) siteStore() (azureFunctionApps, bool) {
 // Matches accepts ARM Microsoft.Web/sites paths plus the non-ARM /api/{name}
 // invoke shape.
 func (*Handler) Matches(r *http.Request) bool {
-	if strings.HasPrefix(r.URL.Path, invokePathPrefix) {
+	if isInvokeRequest(r) {
 		return true
 	}
 
@@ -139,6 +139,54 @@ func (*Handler) Matches(r *http.Request) bool {
 	}
 
 	return rp.ResourceType == resourceType || strings.EqualFold(rp.ResourceType, serverFarmsType)
+}
+
+// isInvokeRequest reports whether r addresses the Functions HTTP-invoke surface
+// at /api/{functionName} (real Azure: POST <app>.azurewebsites.net/api/<name>).
+//
+// The first path segment after /api/ must be a function name, not a REST API
+// version token: Azure function-app names must start with a letter, whereas
+// other Azure data planes served under /api/ version themselves numerically
+// (e.g. Databricks /api/2.1/clusters/create, /api/2.0/jobs/...). Excluding a
+// numeric-version first segment keeps this matcher from swallowing those data
+// planes, which — being registered after Functions — lose the first-match race
+// and become unreachable through `cloudemu serve`.
+func isInvokeRequest(r *http.Request) bool {
+	if !strings.HasPrefix(r.URL.Path, invokePathPrefix) {
+		return false
+	}
+
+	first := strings.TrimPrefix(r.URL.Path, invokePathPrefix)
+	if i := strings.IndexByte(first, '/'); i >= 0 {
+		first = first[:i]
+	}
+
+	if first == "" {
+		return false
+	}
+
+	return !looksLikeAPIVersion(first)
+}
+
+// looksLikeAPIVersion reports whether seg is a REST API version token such as
+// "2.0" or "2.1" — the shape a versioned data-plane API puts right after /api/.
+// A token qualifies only if it is made up solely of digits and dots and carries
+// at least one digit, so it never collides with a real function name (which
+// starts with a letter).
+func looksLikeAPIVersion(seg string) bool {
+	hasDigit := false
+
+	for _, c := range seg {
+		switch {
+		case c >= '0' && c <= '9':
+			hasDigit = true
+		case c == '.':
+		default:
+			return false
+		}
+	}
+
+	return hasDigit
 }
 
 // ServeHTTP routes requests by URL shape.

--- a/server/azure/functions/handler.go
+++ b/server/azure/functions/handler.go
@@ -191,7 +191,7 @@ func looksLikeAPIVersion(seg string) bool {
 
 // ServeHTTP routes requests by URL shape.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if strings.HasPrefix(r.URL.Path, invokePathPrefix) {
+	if isInvokeRequest(r) {
 		h.serveInvoke(w, r)
 		return
 	}

--- a/server/azure/functions_databricks_dispatch_test.go
+++ b/server/azure/functions_databricks_dispatch_test.go
@@ -1,0 +1,140 @@
+// Regression tests for the Functions-vs-other-data-plane dispatch boundary on
+// the shared standalone listener. NewFromProvider mounts the Functions invoke
+// handler AND the Databricks workspace data plane on one server; both are
+// reached under /api/. The Functions invoke matcher used to claim ANY /api/
+// path, so — registering before Databricks — it swallowed every Databricks
+// data-plane call (/api/2.1/clusters/create, /api/2.0/jobs/...), making the
+// whole Databricks data plane unreachable through `cloudemu serve`.
+//
+// These tests drive the fully-assembled server and prove Databricks /api/{ver}/
+// calls reach the Databricks handler while a genuine Functions invoke
+// (/api/{name}) still reaches Functions.
+package azure_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	databricks "github.com/databricks/databricks-sdk-go"
+	dbxconfig "github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/service/compute"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestDatabricksDataPlaneNotSwallowedByFunctions proves a real databricks-sdk-go
+// client can create a cluster (POST /api/2.1/clusters/create) against the shared
+// stack where Functions is also mounted. The version-shaped first path segment
+// ("2.1") must route to Databricks, not the Functions invoke handler.
+//
+// Fail-when-reverted: on the old over-broad Matches, Functions claims
+// /api/2.1/clusters/create, tries to invoke a function literally named
+// "2.1/clusters/create", 404s, and the SDK Create fails here.
+func TestDatabricksDataPlaneNotSwallowedByFunctions(t *testing.T) {
+	provider := cloudemu.NewAzure()
+	srv := azureserver.NewFromProvider(provider)
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:        ts.URL,
+		Token:       "test-token",
+		Credentials: dbxconfig.PatCredentials{},
+	})
+	if err != nil {
+		t.Fatalf("new workspace client: %v", err)
+	}
+
+	ctx := context.Background()
+
+	wait, err := w.Clusters.Create(ctx, compute.CreateCluster{
+		ClusterName:  "cluster-1",
+		SparkVersion: "13.3.x-scala2.12",
+		NodeTypeId:   "Standard_DS3_v2",
+		NumWorkers:   2,
+	})
+	if err != nil {
+		t.Fatalf("Clusters.Create routed away from the Databricks data plane "+
+			"(Functions swallowed /api/2.1/clusters/create): %v", err)
+	}
+
+	if wait.ClusterId == "" {
+		t.Fatal("expected a cluster id from the Databricks data plane")
+	}
+
+	got, err := w.Clusters.GetByClusterId(ctx, wait.ClusterId)
+	if err != nil {
+		t.Fatalf("Clusters.Get (GET /api/2.1/clusters/get): %v", err)
+	}
+
+	if got.State != compute.StateRunning {
+		t.Fatalf("cluster state = %q, want RUNNING", got.State)
+	}
+}
+
+// TestFunctionsInvokeStillRoutesToFunctions is the no-regression guard: a
+// genuine Functions invoke (/api/{functionName}, a non-version first segment)
+// on the same shared stack still reaches the Functions invoke handler and runs
+// the registered handler.
+func TestFunctionsInvokeStillRoutesToFunctions(t *testing.T) {
+	provider := cloudemu.NewAzure()
+	srv := azureserver.NewFromProvider(provider)
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	// Provision the site so the invoke target exists, then register its handler.
+	sitePath := ts.URL + "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Web/sites/echo" +
+		"?api-version=2022-03-01"
+	putBody := `{"kind":"functionapp","location":"eastus","properties":{"siteConfig":{}}}`
+
+	putReq, err := http.NewRequestWithContext(context.Background(), http.MethodPut, sitePath, strings.NewReader(putBody))
+	if err != nil {
+		t.Fatalf("new PUT request: %v", err)
+	}
+
+	putResp, err := ts.Client().Do(putReq)
+	if err != nil {
+		t.Fatalf("PUT site: %v", err)
+	}
+
+	_, _ = io.Copy(io.Discard, putResp.Body)
+	_ = putResp.Body.Close()
+
+	if putResp.StatusCode != http.StatusOK {
+		t.Fatalf("PUT site = %d, want 200", putResp.StatusCode)
+	}
+
+	provider.Functions.RegisterHandler("echo", func(_ context.Context, payload []byte) ([]byte, error) {
+		return append([]byte(`{"got":`), append(payload, '}')...), nil
+	})
+
+	invReq, err := http.NewRequestWithContext(context.Background(), http.MethodPost, ts.URL+"/api/echo",
+		strings.NewReader(`"hello"`))
+	if err != nil {
+		t.Fatalf("new invoke request: %v", err)
+	}
+
+	invResp, err := ts.Client().Do(invReq)
+	if err != nil {
+		t.Fatalf("POST /api/echo: %v", err)
+	}
+
+	defer invResp.Body.Close()
+
+	body, _ := io.ReadAll(invResp.Body)
+
+	if invResp.StatusCode != http.StatusOK {
+		t.Fatalf("invoke status = %d, want 200 (body %q)", invResp.StatusCode, body)
+	}
+
+	if string(body) != `{"got":"hello"}` {
+		t.Fatalf("invoke body = %q, want {\"got\":\"hello\"} — request did not reach the Functions handler", body)
+	}
+}


### PR DESCRIPTION
## Problem

The Azure Functions wire handler's `Matches()` claimed **any** path prefixed `/api/` unconditionally. Dispatch is first-match-wins (`server/server.go`), and `functions.New` registers at `server/azure/azure.go:499` — **before** the Databricks data plane (`registerDatabricksDataPlane`, L568). So every Databricks data-plane REST call fell into the Functions invoke handler:

```
POST /api/2.1/clusters/create
  -> {"error":{"code":"ResourceNotFound","message":"function 2.1/clusters/create not found"}}
```

Through `cloudemu serve` (the primary run mode) the **entire Databricks data plane was unreachable**.

## Collision map

- **eventgrid** publish `/api/events` (POST-only, exact) registers at L465, *before* Functions -> already wins, unaffected.
- **functions** invoke `/api/{name}` -> L499, over-broad.
- **Databricks data plane** (all register *after* Functions, all shaped `/api/{numeric-ver}/...`) -> swallowed:
  - `dataplane.go` `/api/{ver}/{instance-pools,clusters,jobs,permissions,policies,libraries}/...`
  - `secrets`, `token`, `git-credentials`, `repos`, `dbfs`, `workspace` (wsfs), `sql/warehouses`, `sql/history/queries`, `pipelines`, `serving-endpoints`, `unity-catalog` (unitycatalog + ucstorage), `preview/scim/v2` — all `/api/{ver}/...`
  - `hostmeta` is `/.well-known/databricks-config` — no `/api/` collision.

All 14 Databricks `/api/` sub-handlers use a **numeric version** segment right after `/api/`.

## Fix — path-shape narrowing

`Matches()` now claims the invoke path `/api/{first}` only when `{first}` is **not** a numeric REST API-version token (`looksLikeAPIVersion`: digits-and-dots with at least one digit).

**Why not host-based:** infeasible here. Both a Databricks client and a Functions-invoke client address the standalone `serve` endpoint with `Host = localhost` — databricks-sdk-go sets `Config.Host = ts.URL`. Unlike EventGrid/Search (which carry a service-specific Host), the invoke path has no host signal, so host cannot separate them.

**Why this rule:** it is decoupled and grounded in a real invariant — Azure function-app names must start with a letter, while versioned REST data planes use numeric version segments. It frees the **whole class** of `/api/{version}/...` data planes (all 14 Databricks sub-handlers, plus any future numerically-versioned one), not just Databricks, while preserving real Functions invoke (`/api/echo` locally and `<app>.azurewebsites.net/api/<name>`). Registration order is left unchanged (reordering is order-fragile and would not cover a future `/api/{ver}` handler added after Functions).

## Live before/after (standalone binary, `serve --azure-port ... --providers=azure`, HTTPS)

- **Databricks (fixed):** `POST /api/2.1/clusters/create` -> `{"cluster_id":"cluster-00000001"}` (before: `function 2.1/clusters/create not found`).
- **Functions invoke (no regression):** `POST /api/echo` -> served by Functions (`function echo not found`, 404 — correct, no function created via the binary; the message proves Functions handled it). A full successful invoke round-trip (`{"got":"hello"}`) is proven in-process by the new test.

## Tests

New `server/azure/functions_databricks_dispatch_test.go` on the fully-assembled `NewFromProvider` stack (Functions + Databricks both mounted):
- `TestDatabricksDataPlaneNotSwallowedByFunctions` — real databricks-sdk-go `Clusters.Create`/`Get` succeed.
- `TestFunctionsInvokeStillRoutesToFunctions` — genuine invoke still round-trips through Functions.

**Fail-when-reverted:** with `Matches` restored to the over-broad `return true`, `TestDatabricksDataPlaneNotSwallowedByFunctions` fails with the exact bug message `function 2.1/clusters/create not found`.

## Gates

`go build ./...`, `go test -race ./server/azure/... ./providers/azure/functions/... ./providers/azure/databricks/...` (all ok), `go vet`, `gofmt -l`, `golangci-lint --new-from-rev=origin/development` (0 issues), `go generate ./... && git diff docs/coverage` (no change) — all green.
