### PR TITLE
fix(pubsub): real-user e2e divergences from GCP

### DIFF
--- a/server/gcp/pubsub/model.go
+++ b/server/gcp/pubsub/model.go
@@ -12,6 +12,15 @@ import (
 
 const (
 	defaultAckDeadlineSeconds = 10
+	// defaultMessageRetentionDuration is Pub/Sub's server-assigned subscription
+	// message retention when the field is omitted on create: 7 days.
+	defaultMessageRetentionDuration = "604800s"
+	// defaultExpirationTTL is the ttl of the expirationPolicy Pub/Sub assigns a
+	// subscription created without one: 31 days.
+	defaultExpirationTTL = "2678400s"
+	// subscriptionStateActive is the output-only state real Pub/Sub reports for a
+	// healthy subscription.
+	subscriptionStateActive = "ACTIVE"
 	// defaultMaxDeliveryAttempts is Pub/Sub's default when a deadLetterPolicy
 	// sets a dead-letter topic but omits maxDeliveryAttempts.
 	defaultMaxDeliveryAttempts = 5

--- a/server/gcp/pubsub/sdk_defaults_test.go
+++ b/server/gcp/pubsub/sdk_defaults_test.go
@@ -1,0 +1,109 @@
+package pubsub_test
+
+import (
+	"context"
+	"testing"
+
+	pubsubv1 "google.golang.org/api/pubsub/v1"
+)
+
+// TestSDKPubSubSubscriptionCreateDefaults guards the #1 Terraform-drift source:
+// a subscription created with only the required Topic must read back GCP's
+// server-assigned defaults (ackDeadlineSeconds=10, messageRetentionDuration=
+// 604800s/7d, expirationPolicy.ttl=2678400s/31d, state=ACTIVE). If any default
+// is missing, `sub.Config()` and every Terraform plan diverge from real GCP.
+func TestSDKPubSubSubscriptionCreateDefaults(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/defs")
+
+	created, err := svc.Projects.Subscriptions.Create("projects/demo/subscriptions/defs",
+		&pubsubv1.Subscription{Topic: "projects/demo/topics/defs"}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	assertSubDefaults(t, "create", created)
+
+	got, err := svc.Projects.Subscriptions.Get("projects/demo/subscriptions/defs").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	assertSubDefaults(t, "get", got)
+}
+
+func assertSubDefaults(t *testing.T, stage string, s *pubsubv1.Subscription) {
+	t.Helper()
+
+	if s.AckDeadlineSeconds != 10 {
+		t.Errorf("%s: ackDeadlineSeconds=%d, want 10", stage, s.AckDeadlineSeconds)
+	}
+
+	if s.MessageRetentionDuration != "604800s" {
+		t.Errorf("%s: messageRetentionDuration=%q, want 604800s", stage, s.MessageRetentionDuration)
+	}
+
+	if s.ExpirationPolicy == nil || s.ExpirationPolicy.Ttl != "2678400s" {
+		t.Errorf("%s: expirationPolicy=%+v, want ttl 2678400s", stage, s.ExpirationPolicy)
+	}
+
+	if s.State != "ACTIVE" {
+		t.Errorf("%s: state=%q, want ACTIVE", stage, s.State)
+	}
+}
+
+// TestSDKPubSubExplicitNeverExpire guards that an explicitly-set empty
+// expirationPolicy ({} = never expire) is preserved verbatim and NOT clobbered
+// by the 31-day default.
+func TestSDKPubSubExplicitNeverExpire(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/never")
+
+	created, err := svc.Projects.Subscriptions.Create("projects/demo/subscriptions/never",
+		&pubsubv1.Subscription{
+			Topic:            "projects/demo/topics/never",
+			ExpirationPolicy: &pubsubv1.ExpirationPolicy{ForceSendFields: []string{"Ttl"}},
+		}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if created.ExpirationPolicy == nil || created.ExpirationPolicy.Ttl != "" {
+		t.Errorf("create: expirationPolicy=%+v, want empty ttl (never expire)", created.ExpirationPolicy)
+	}
+
+	got, err := svc.Projects.Subscriptions.Get("projects/demo/subscriptions/never").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.ExpirationPolicy == nil || got.ExpirationPolicy.Ttl != "" {
+		t.Errorf("get: expirationPolicy=%+v, want empty ttl (never expire)", got.ExpirationPolicy)
+	}
+}
+
+// TestSDKPubSubExplicitRetentionPreserved guards that an explicit
+// messageRetentionDuration is preserved, not overwritten by the 7-day default.
+func TestSDKPubSubExplicitRetentionPreserved(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	mustTopic(t, svc, "projects/demo/topics/ret")
+
+	created, err := svc.Projects.Subscriptions.Create("projects/demo/subscriptions/ret",
+		&pubsubv1.Subscription{
+			Topic:                    "projects/demo/topics/ret",
+			MessageRetentionDuration: "3600s",
+		}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if created.MessageRetentionDuration != "3600s" {
+		t.Errorf("create: messageRetentionDuration=%q, want 3600s", created.MessageRetentionDuration)
+	}
+}

--- a/server/gcp/pubsub/subscription.go
+++ b/server/gcp/pubsub/subscription.go
@@ -80,6 +80,8 @@ func (h *Handler) createSubscription(w http.ResponseWriter, r *http.Request, pro
 		return
 	}
 
+	applySubscriptionDefaults(&body)
+
 	filter, err := parseFilter(body.Filter)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, reasonInvalidArgument, "invalid filter: "+cerrors.Message(err))
@@ -102,6 +104,27 @@ func (h *Handler) createSubscription(w http.ResponseWriter, r *http.Request, pro
 	h.mu.Unlock()
 
 	writeJSON(w, http.StatusOK, cfg)
+}
+
+// defaultExpirationPolicyJSON is the expirationPolicy Pub/Sub assigns a
+// subscription created without one: a 31-day ttl.
+const defaultExpirationPolicyJSON = `{"ttl":"` + defaultExpirationTTL + `"}`
+
+// applySubscriptionDefaults fills in the server-assigned fields real Pub/Sub
+// returns for a subscription created with only its required fields, so a create
+// that omits them round-trips the same values on Get/List (the top Terraform
+// drift source). An explicitly-provided expirationPolicy — including an empty
+// one ({} = never expire) — is left untouched.
+func applySubscriptionDefaults(s *subscription) {
+	if s.MessageRetentionDuration == "" {
+		s.MessageRetentionDuration = defaultMessageRetentionDuration
+	}
+
+	if len(s.ExpirationPolicy) == 0 {
+		s.ExpirationPolicy = []byte(defaultExpirationPolicyJSON)
+	}
+
+	s.State = subscriptionStateActive
 }
 
 // patchSubscription applies subscriptions.patch: it merges only the fields named

--- a/server/gcp/pubsub/types.go
+++ b/server/gcp/pubsub/types.go
@@ -33,6 +33,9 @@ type subscription struct {
 	RetryPolicy               json.RawMessage   `json:"retryPolicy,omitempty"`
 	Detached                  bool              `json:"detached,omitempty"`
 	EnableExactlyOnceDelivery bool              `json:"enableExactlyOnceDelivery,omitempty"`
+	// State is output-only: real Pub/Sub always reports ACTIVE for a healthy
+	// subscription. It is server-assigned and ignored on create/patch input.
+	State string `json:"state,omitempty"`
 }
 
 // updateTopicRequest is PATCH topics/{name} (topics.patch): the topic fields to


### PR DESCRIPTION
## Summary

Real-user e2e audit of GCP Pub/Sub (SDK `google.golang.org/api/pubsub/v1` + Terraform `hashicorp/google` against a live `cloudemu serve`). One genuine real-cloud divergence found and fixed.

### Divergence: subscription create-time defaults not returned

A subscription created with only the required `topic` did not read back GCP's server-assigned defaults. Official Pub/Sub v1 REST docs (`projects.subscriptions`):
- `messageRetentionDuration` defaults to **604800s** (7 days)
- `expirationPolicy.ttl` defaults to **2678400s** (31 days)
- `state` is output-only and reports **ACTIVE** for a healthy subscription
- `ackDeadlineSeconds` defaults to 10 (already handled)

Before the fix, `sub.Config()` returned empty `messageRetentionDuration`, nil `expirationPolicy`, and empty `state` — diverging from real GCP and a Terraform drift source.

### Fix

`createSubscription` now fills these server-assigned defaults (new `applySubscriptionDefaults` helper) so they round-trip on create/Get/List. Explicit values are preserved, including an explicit empty `expirationPolicy` (`{}` = never expire) and an explicit `messageRetentionDuration`.

Files: `server/gcp/pubsub/{subscription.go,model.go,types.go}` + `sdk_defaults_test.go`.

### Live evidence
- Real SDK round-trip test reproduced the divergence, passes after fix.
- `cloudemu serve` + Terraform (`google_pubsub_topic` + `google_pubsub_subscription` with only required fields): `apply` then `plan` = **No changes** (no drift); `destroy` clean.

### Gates
`go build ./...`, `go vet`, `gofmt -l`, `golangci-lint --new-from-rev=origin/development` (0 issues), `go test -race` (server/gcp, providers/gcp/pubsub), `go generate` (no docs/coverage drift) — all green.

### Audited clean (no divergence)
List determinism (topics/subscriptions/snapshots sorted), error envelope `{error:{code,message,status}}` with no code-prefix leak, delete→NOT_FOUND guards, delete-topic→`_deleted-topic_`, patch updateMask semantics (immutable filter/topic/name rejected).