### PR TITLE
fix(kusto): real-user e2e divergences from Azure

### DIFF
--- a/server/azure/kusto/cluster.go
+++ b/server/azure/kusto/cluster.go
@@ -64,6 +64,7 @@ func (h *Handler) createCluster(w http.ResponseWriter, r *http.Request, kp kusto
 	c.Zones = slices.Clone(req.Zones)
 	c.SKU = normalizeSKU(req.SKU)
 	c.Properties = req.Properties
+	applyClusterDefaults(&c.Properties)
 	c.UpdatedAt = now
 	h.clusters.Set(clusterKey(kp.cluster), c)
 
@@ -214,6 +215,38 @@ func (h *Handler) listClusters(w http.ResponseWriter, r *http.Request, kp kustoP
 	azurearm.WriteJSON(w, http.StatusOK, paginate(r, resources))
 }
 
+// applyClusterDefaults fills the cluster property fields real Azure always
+// reports on GET but that a create request may omit, so the emulated cluster
+// echoes the same computed shape a real one does. Only unset fields are filled:
+// a value the caller supplied (including an explicit false) is preserved.
+func applyClusterDefaults(p *clusterProperties) {
+	if p.EngineType == "" {
+		p.EngineType = defaultEngineType
+	}
+
+	if p.PublicNetworkAccess == "" {
+		p.PublicNetworkAccess = publicNetworkAccessEnabled
+	}
+
+	if p.EnableAutoStop == nil {
+		p.EnableAutoStop = boolPtr(true)
+	}
+
+	if p.EnableStreamingIngest == nil {
+		p.EnableStreamingIngest = boolPtr(false)
+	}
+
+	if p.EnableDiskEncryption == nil {
+		p.EnableDiskEncryption = boolPtr(false)
+	}
+
+	if p.EnablePurge == nil {
+		p.EnablePurge = boolPtr(false)
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
 func normalizeSKU(in *kustoSKU) kustoSKU {
 	if in == nil || in.Name == "" {
 		return kustoSKU{Name: "Standard_D11_v2", Tier: "Standard"}
@@ -273,7 +306,7 @@ func toClusterResource(c *clusterState) clusterResource {
 	props.DataIngestionURI = "https://" + ingestPrefix + c.Name + "." + c.Location + kustoHost
 
 	return clusterResource{
-		ID:       azurearm.BuildResourceID(c.Subscription, c.ResourceGroup, providerName, segClusters, c.Name),
+		ID:       azurearm.BuildResourceID(c.Subscription, c.ResourceGroup, providerName, idSegClusters, c.Name),
 		Name:     c.Name,
 		Type:     clusterResourceType,
 		Location: c.Location,

--- a/server/azure/kusto/cluster.go
+++ b/server/azure/kusto/cluster.go
@@ -240,6 +240,10 @@ func applyClusterDefaults(p *clusterProperties) {
 		p.EnableDiskEncryption = boolPtr(false)
 	}
 
+	if p.EnableDoubleEncryption == nil {
+		p.EnableDoubleEncryption = boolPtr(false)
+	}
+
 	if p.EnablePurge == nil {
 		p.EnablePurge = boolPtr(false)
 	}

--- a/server/azure/kusto/database.go
+++ b/server/azure/kusto/database.go
@@ -220,7 +220,7 @@ func toDatabaseResource(c *clusterState, db *databaseState) databaseResource {
 	props := db.Properties
 	props.ProvisioningState = provisioningSucceeded
 
-	resourceType := segClusters + "/" + c.Name + "/" + segDatabases
+	resourceType := idSegClusters + "/" + c.Name + "/" + idSegDatabases
 
 	return databaseResource{
 		ID:         azurearm.BuildResourceID(c.Subscription, c.ResourceGroup, providerName, resourceType, db.Name),

--- a/server/azure/kusto/kusto_sdk_test.go
+++ b/server/azure/kusto/kusto_sdk_test.go
@@ -85,6 +85,72 @@ func TestSDKKustoLifecycle(t *testing.T) {
 	deleteCluster(t, ctx, clusters)
 }
 
+// TestSDKKustoClusterComputedDefaults verifies a cluster created without a
+// properties block still reports the computed property defaults real Azure
+// always echoes on GET (engineType=V3, publicNetworkAccess=Enabled,
+// enableAutoStop=true, enableStreamingIngest/DiskEncryption/Purge=false), and
+// that the returned resource id uses the capitalized Clusters segment.
+func TestSDKKustoClusterComputedDefaults(t *testing.T) {
+	ts := newServer(t)
+	ctx := context.Background()
+
+	clusters, err := armkusto.NewClustersClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewClustersClient: %v", err)
+	}
+
+	poller, err := clusters.BeginCreateOrUpdate(ctx, rgName, clusterName, armkusto.Cluster{
+		Location: to.Ptr("eastus"),
+		SKU: &armkusto.AzureSKU{
+			Name: to.Ptr(armkusto.AzureSKUNameStandardD11V2),
+			Tier: to.Ptr(armkusto.AzureSKUTierStandard),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate cluster: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll cluster create: %v", err)
+	}
+
+	got, err := clusters.Get(ctx, rgName, clusterName, nil)
+	if err != nil {
+		t.Fatalf("Get cluster: %v", err)
+	}
+
+	p := got.Properties
+	if p == nil {
+		t.Fatal("cluster properties nil")
+	}
+
+	if p.EngineType == nil || *p.EngineType != armkusto.EngineTypeV3 {
+		t.Errorf("engineType = %v, want V3", p.EngineType)
+	}
+
+	if p.PublicNetworkAccess == nil || *p.PublicNetworkAccess != armkusto.PublicNetworkAccessEnabled {
+		t.Errorf("publicNetworkAccess = %v, want Enabled", p.PublicNetworkAccess)
+	}
+
+	if p.EnableAutoStop == nil || !*p.EnableAutoStop {
+		t.Errorf("enableAutoStop = %v, want true", p.EnableAutoStop)
+	}
+
+	for name, ptr := range map[string]*bool{
+		"enableStreamingIngest": p.EnableStreamingIngest,
+		"enableDiskEncryption":  p.EnableDiskEncryption,
+		"enablePurge":           p.EnablePurge,
+	} {
+		if ptr == nil || *ptr {
+			t.Errorf("%s = %v, want false", name, ptr)
+		}
+	}
+
+	if got.ID == nil || !strings.Contains(*got.ID, "/Microsoft.Kusto/Clusters/") {
+		t.Errorf("cluster id = %v, want a capitalized /Microsoft.Kusto/Clusters/ segment", got.ID)
+	}
+}
+
 func createCluster(t *testing.T, ctx context.Context, c *armkusto.ClustersClient) {
 	t.Helper()
 
@@ -207,6 +273,10 @@ func createDatabase(t *testing.T, ctx context.Context, c *armkusto.DatabasesClie
 
 	if rw.Properties == nil || rw.Properties.SoftDeletePeriod == nil || *rw.Properties.SoftDeletePeriod != "P30D" {
 		t.Fatalf("softDeletePeriod = %v, want P30D", rw.Properties)
+	}
+
+	if rw.ID == nil || !strings.Contains(*rw.ID, "/Clusters/") || !strings.Contains(*rw.ID, "/Databases/") {
+		t.Fatalf("database id = %v, want capitalized /Clusters/.../Databases/ segments", rw.ID)
 	}
 }
 

--- a/server/azure/kusto/kusto_sdk_test.go
+++ b/server/azure/kusto/kusto_sdk_test.go
@@ -88,8 +88,8 @@ func TestSDKKustoLifecycle(t *testing.T) {
 // TestSDKKustoClusterComputedDefaults verifies a cluster created without a
 // properties block still reports the computed property defaults real Azure
 // always echoes on GET (engineType=V3, publicNetworkAccess=Enabled,
-// enableAutoStop=true, enableStreamingIngest/DiskEncryption/Purge=false), and
-// that the returned resource id uses the capitalized Clusters segment.
+// enableAutoStop=true, enableStreamingIngest/DiskEncryption/DoubleEncryption/
+// Purge=false), and that the returned id uses the capitalized Clusters segment.
 func TestSDKKustoClusterComputedDefaults(t *testing.T) {
 	ts := newServer(t)
 	ctx := context.Background()
@@ -137,9 +137,10 @@ func TestSDKKustoClusterComputedDefaults(t *testing.T) {
 	}
 
 	for name, ptr := range map[string]*bool{
-		"enableStreamingIngest": p.EnableStreamingIngest,
-		"enableDiskEncryption":  p.EnableDiskEncryption,
-		"enablePurge":           p.EnablePurge,
+		"enableStreamingIngest":  p.EnableStreamingIngest,
+		"enableDiskEncryption":   p.EnableDiskEncryption,
+		"enableDoubleEncryption": p.EnableDoubleEncryption,
+		"enablePurge":            p.EnablePurge,
 	} {
 		if ptr == nil || *ptr {
 			t.Errorf("%s = %v, want false", name, ptr)
@@ -148,6 +149,88 @@ func TestSDKKustoClusterComputedDefaults(t *testing.T) {
 
 	if got.ID == nil || !strings.Contains(*got.ID, "/Microsoft.Kusto/Clusters/") {
 		t.Errorf("cluster id = %v, want a capitalized /Microsoft.Kusto/Clusters/ segment", got.ID)
+	}
+}
+
+// TestSDKKustoClusterExplicitPropertiesPreserved verifies that explicit,
+// non-default property values supplied on create are preserved verbatim on the
+// create response AND a subsequent GET — never overwritten by the computed
+// defaults. This guards the pointer + omitempty "unset vs explicit false"
+// distinction across all seven property fields, including enableDoubleEncryption.
+func TestSDKKustoClusterExplicitPropertiesPreserved(t *testing.T) {
+	ts := newServer(t)
+	ctx := context.Background()
+
+	clusters, err := armkusto.NewClustersClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewClustersClient: %v", err)
+	}
+
+	poller, err := clusters.BeginCreateOrUpdate(ctx, rgName, clusterName, armkusto.Cluster{
+		Location: to.Ptr("eastus"),
+		SKU: &armkusto.AzureSKU{
+			Name: to.Ptr(armkusto.AzureSKUNameStandardD11V2),
+			Tier: to.Ptr(armkusto.AzureSKUTierStandard),
+		},
+		Properties: &armkusto.ClusterProperties{
+			EngineType:             to.Ptr(armkusto.EngineTypeV2),
+			PublicNetworkAccess:    to.Ptr(armkusto.PublicNetworkAccessDisabled),
+			EnableAutoStop:         to.Ptr(false),
+			EnableDiskEncryption:   to.Ptr(true),
+			EnablePurge:            to.Ptr(true),
+			EnableStreamingIngest:  to.Ptr(true),
+			EnableDoubleEncryption: to.Ptr(true),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate cluster: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("poll cluster create: %v", err)
+	}
+
+	assertExplicitProps(t, "create", created.Properties)
+
+	got, err := clusters.Get(ctx, rgName, clusterName, nil)
+	if err != nil {
+		t.Fatalf("Get cluster: %v", err)
+	}
+
+	assertExplicitProps(t, "get", got.Properties)
+}
+
+// assertExplicitProps checks that every property carries the explicit
+// non-default value supplied on create, proving defaults did not clobber it.
+func assertExplicitProps(t *testing.T, phase string, p *armkusto.ClusterProperties) {
+	t.Helper()
+
+	if p == nil {
+		t.Fatalf("%s: cluster properties nil", phase)
+	}
+
+	if p.EngineType == nil || *p.EngineType != armkusto.EngineTypeV2 {
+		t.Errorf("%s: engineType = %v, want V2", phase, p.EngineType)
+	}
+
+	if p.PublicNetworkAccess == nil || *p.PublicNetworkAccess != armkusto.PublicNetworkAccessDisabled {
+		t.Errorf("%s: publicNetworkAccess = %v, want Disabled", phase, p.PublicNetworkAccess)
+	}
+
+	if p.EnableAutoStop == nil || *p.EnableAutoStop {
+		t.Errorf("%s: enableAutoStop = %v, want false", phase, p.EnableAutoStop)
+	}
+
+	for name, ptr := range map[string]*bool{
+		"enableDiskEncryption":   p.EnableDiskEncryption,
+		"enablePurge":            p.EnablePurge,
+		"enableStreamingIngest":  p.EnableStreamingIngest,
+		"enableDoubleEncryption": p.EnableDoubleEncryption,
+	} {
+		if ptr == nil || !*ptr {
+			t.Errorf("%s: %s = %v, want true", phase, name, ptr)
+		}
 	}
 }
 

--- a/server/azure/kusto/state.go
+++ b/server/azure/kusto/state.go
@@ -28,6 +28,19 @@ const (
 	kustoHost = ".kusto.windows.net"
 	// ingestPrefix is prepended to the cluster host for the data-ingestion URI.
 	ingestPrefix = "ingest-"
+
+	// Real Azure always echoes these cluster property defaults on GET, even when a
+	// create request omits them, so an SDK/Terraform user reading engineType /
+	// publicNetworkAccess / enableAutoStop never sees an empty value.
+	defaultEngineType          = "V3"
+	publicNetworkAccessEnabled = "Enabled"
+
+	// idSegClusters / idSegDatabases are the resource-type segments as they appear
+	// in a returned ARM resource id. Real Azure spells them capitalized in the id
+	// and type (Microsoft.Kusto/Clusters, .../Databases) even though the request
+	// URL path uses lowercase.
+	idSegClusters  = "Clusters"
+	idSegDatabases = "Databases"
 )
 
 type clusterState struct {


### PR DESCRIPTION
## Summary

Real-user e2e audit (Track 2) of Azure Data Explorer / Kusto (Microsoft.Kusto). Drove the live `cloudemu serve` Azure port with wire probes plus the real armkusto / azure-kusto-go SDK clients and reconciled every field against the azurerekusto 2025-02-14 REST reference. Two genuine cloud-vs-emulator divergences found and fixed.

### Fixed

- **Missing computed cluster property defaults (MED).** Real Azure always echoes `engineType` (V3), `publicNetworkAccess` (Enabled), `enableAutoStop` (true), `enableStreamingIngest`/`enableDiskEncryption`/`enablePurge` (false) on a cluster GET even when the create request omits them; the emulator returned an empty `properties` block, so an SDK/Terraform user read nil. Defaults are now filled on create, preserving any value the caller supplied (an explicit `false`/`V2`/`Disabled` is kept).
- **Resource id segment casing (LOW).** The returned `id` used lowercase `clusters`/`databases`, but real Azure — and the emulator's own `type` field — spell them capitalized (`.../Microsoft.Kusto/Clusters/<c>/Databases/<db>`). Aligned so `id` and `type` are internally consistent and match the documented response.

### Verified correct (no change)

provisioningState=Succeeded/state=Running create (poller finalizes, no hang), start/stop transitions, PATCH tag replace-wholesale, PATCH-on-missing → 404, cross-RG isolation, subscription-scope list, delete idempotency (204/200), deterministic list order, data-plane `.create/.show/.drop table` v1 frames, and no cerrors prefix leak in the mgmt error path.

### Filed, not fixed (feature gaps / big rocks, out of scope for a divergence fix)

KQL query engine (`/v1|v2/rest/query` returns 501 — documented deferral, issue #163); ReadOnlyFollowing databases / attachedDatabaseConfigurations / dataConnections / principalAssignments; cluster `identity`, `optimizedAutoscale`, VNet/keyVault/privateEndpoint properties.

### Tests

`TestSDKKustoClusterComputedDefaults` (SDK read of the defaults + capitalized id), plus a database id-casing assertion in the lifecycle test. `go build ./...`, `go test -race ./server/azure/kusto/...`, vet, gofmt, `golangci-lint --new-from-rev` (0 issues), and `go generate` (no docs/coverage drift) all green.