### PR TITLE
fix(gcp): return canonical google.rpc.Code status names in REST errors

### DIFF
--- a/server/gcp/compute/compute_test.go
+++ b/server/gcp/compute/compute_test.go
@@ -143,8 +143,8 @@ func TestGetInstanceNotFound(t *testing.T) {
 	_ = json.NewDecoder(resp.Body).Decode(&env)
 
 	body, _ := env["error"].(map[string]any)
-	if body["status"] != "notFound" {
-		t.Errorf("status=%v want notFound", body["status"])
+	if body["status"] != "NOT_FOUND" {
+		t.Errorf("status=%v want NOT_FOUND", body["status"])
 	}
 }
 

--- a/server/gcp/vertexai/sdk_roundtrip_test.go
+++ b/server/gcp/vertexai/sdk_roundtrip_test.go
@@ -152,18 +152,51 @@ func doErr(t *testing.T, method, url string, body any) int {
 	return resp.StatusCode
 }
 
+// doErrBody issues a request expecting a non-2xx status and returns the HTTP
+// code plus the decoded JSON body, so callers can assert the error envelope.
+func doErrBody(t *testing.T, method, url string, body any) (int, map[string]any) {
+	t.Helper()
+
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(method, url, bytes.NewReader(b))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+
+	out := map[string]any{}
+	if len(bytes.TrimSpace(raw)) > 0 {
+		require.NoError(t, json.Unmarshal(raw, &out), "body=%s", raw)
+	}
+
+	return resp.StatusCode, out
+}
+
 // TestPredictNoDeployedModels: :predict on an endpoint with no deployed models
-// is a 400 FAILED_PRECONDITION, not a 200 echo.
+// is a 400 FAILED_PRECONDITION, not a 200 echo. The body must carry the
+// canonical google.rpc.Code NAME in the top-level status field — a regression
+// guard for the shared gcprest codec dropping a canonical uppercase reason.
 func TestPredictNoDeployedModels(t *testing.T) {
 	url := newServer(t)
 
 	op := do(t, http.MethodPost, url+base+"/endpoints", map[string]any{"displayName": "ep"})
 	epName := op["response"].(map[string]any)["name"].(string)
 
-	code := doErr(t, http.MethodPost, url+"/v1/"+epName+":predict", map[string]any{
+	code, body := doErrBody(t, http.MethodPost, url+"/v1/"+epName+":predict", map[string]any{
 		"instances": []any{map[string]any{"x": 1}},
 	})
 	assert.Equal(t, http.StatusBadRequest, code)
+
+	errObj, ok := body["error"].(map[string]any)
+	require.Truef(t, ok, "error object missing: %+v", body)
+	assert.Equalf(t, "FAILED_PRECONDITION", errObj["status"],
+		"top-level status must be canonical (present, not dropped): %+v", errObj)
 }
 
 // TestDeployUnknownModel: deploying a model resource that was never uploaded is

--- a/server/wire/gcprest/gcprest.go
+++ b/server/wire/gcprest/gcprest.go
@@ -216,13 +216,51 @@ type errorDetail struct {
 	Reason  string `json:"reason"`
 }
 
-// WriteError writes a GCP-style JSON error response.
+// canonicalStatus maps a Google JSON-API error `reason` (the camelCase token
+// carried in errors[].reason, e.g. "notFound") to the canonical
+// google.rpc.Code enum NAME real GCP returns in the top-level `status` field
+// (all-caps SNAKE_CASE, e.g. "NOT_FOUND"). See
+// https://cloud.google.com/apis/design/errors and the google.rpc.Code enum.
+// Reasons without a canonical code (e.g. HTTP 405 "methodNotAllowed", which has
+// no google.rpc.Code) return "" so the omitempty `status` field is dropped —
+// matching real GCP, which omits `status` for those responses.
+func canonicalStatus(reason string) string {
+	const statusInvalidArgument = "INVALID_ARGUMENT"
+
+	switch reason {
+	case "notFound":
+		return "NOT_FOUND"
+	case "alreadyExists":
+		return "ALREADY_EXISTS"
+	case "invalid", "invalidArgument", statusInvalidArgument, "badRequest", "required":
+		return statusInvalidArgument
+	case "conditionNotMet", "failedPrecondition", "resourceInUseByAnotherResource",
+		"containerNotEmpty", "cnameResourceRecordSetConflict":
+		return "FAILED_PRECONDITION"
+	case "forbidden":
+		return "PERMISSION_DENIED"
+	case "rateLimitExceeded":
+		return "RESOURCE_EXHAUSTED"
+	case "notImplemented":
+		return "UNIMPLEMENTED"
+	case "backendError":
+		return "UNAVAILABLE"
+	case "internalError":
+		return "INTERNAL"
+	default:
+		return ""
+	}
+}
+
+// WriteError writes a GCP-style JSON error response. reason is the Google
+// JSON-API camelCase token surfaced in errors[].reason; the top-level `status`
+// field carries the canonical google.rpc.Code NAME derived from it.
 func WriteError(w http.ResponseWriter, status int, reason, msg string) {
 	WriteJSON(w, status, errorEnvelope{
 		Error: errorBody{
 			Code:    status,
 			Message: msg,
-			Status:  reason,
+			Status:  canonicalStatus(reason),
 			Errors:  []errorDetail{{Message: msg, Reason: reason}},
 		},
 	})

--- a/server/wire/gcprest/gcprest.go
+++ b/server/wire/gcprest/gcprest.go
@@ -216,6 +216,21 @@ type errorDetail struct {
 	Reason  string `json:"reason"`
 }
 
+// google.rpc.Code enum NAMEs used by the mapping below. Kept as named
+// constants because they are referenced from both canonicalStatus (as the
+// mapped result) and isCanonicalCode (as the already-canonical passthrough set).
+const (
+	codeInvalidArgument    = "INVALID_ARGUMENT"
+	codeNotFound           = "NOT_FOUND"
+	codeAlreadyExists      = "ALREADY_EXISTS"
+	codeFailedPrecondition = "FAILED_PRECONDITION"
+	codePermissionDenied   = "PERMISSION_DENIED"
+	codeResourceExhausted  = "RESOURCE_EXHAUSTED"
+	codeUnimplemented      = "UNIMPLEMENTED"
+	codeUnavailable        = "UNAVAILABLE"
+	codeInternal           = "INTERNAL"
+)
+
 // canonicalStatus maps a Google JSON-API error `reason` (the camelCase token
 // carried in errors[].reason, e.g. "notFound") to the canonical
 // google.rpc.Code enum NAME real GCP returns in the top-level `status` field
@@ -225,30 +240,58 @@ type errorDetail struct {
 // no google.rpc.Code) return "" so the omitempty `status` field is dropped —
 // matching real GCP, which omits `status` for those responses.
 func canonicalStatus(reason string) string {
-	const statusInvalidArgument = "INVALID_ARGUMENT"
+	// Some callers (e.g. eventarc, fcm, vertexai) already pass a canonical
+	// google.rpc.Code NAME as the reason. Return it unchanged so a canonical
+	// input is never silently dropped by the camelCase mapping below.
+	if isCanonicalCode(reason) {
+		return reason
+	}
 
+	return camelReasonToCode(reason)
+}
+
+// camelReasonToCode maps a camelCase JSON-API reason token to its canonical
+// google.rpc.Code NAME, or "" when the reason has no canonical code.
+func camelReasonToCode(reason string) string {
 	switch reason {
 	case "notFound":
-		return "NOT_FOUND"
+		return codeNotFound
 	case "alreadyExists":
-		return "ALREADY_EXISTS"
-	case "invalid", "invalidArgument", statusInvalidArgument, "badRequest", "required":
-		return statusInvalidArgument
+		return codeAlreadyExists
+	case "invalid", "invalidArgument", "badRequest", "required":
+		return codeInvalidArgument
 	case "conditionNotMet", "failedPrecondition", "resourceInUseByAnotherResource",
 		"containerNotEmpty", "cnameResourceRecordSetConflict":
-		return "FAILED_PRECONDITION"
+		return codeFailedPrecondition
 	case "forbidden":
-		return "PERMISSION_DENIED"
+		return codePermissionDenied
 	case "rateLimitExceeded":
-		return "RESOURCE_EXHAUSTED"
+		return codeResourceExhausted
 	case "notImplemented":
-		return "UNIMPLEMENTED"
+		return codeUnimplemented
 	case "backendError":
-		return "UNAVAILABLE"
+		return codeUnavailable
 	case "internalError":
-		return "INTERNAL"
+		return codeInternal
 	default:
 		return ""
+	}
+}
+
+// isCanonicalCode reports whether s is already one of the google.rpc.Code enum
+// NAMEs (all-caps SNAKE_CASE). The set is explicit so a typo'd or garbage
+// reason cannot pass through as if it were canonical. See
+// https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto.
+func isCanonicalCode(s string) bool {
+	switch s {
+	//nolint:misspell // google.rpc.Code enum name is CANCELLED (two Ls)
+	case "OK", "CANCELLED", "UNKNOWN", codeInvalidArgument, "DEADLINE_EXCEEDED",
+		codeNotFound, codeAlreadyExists, codePermissionDenied, codeResourceExhausted,
+		codeFailedPrecondition, "ABORTED", "OUT_OF_RANGE", codeUnimplemented,
+		codeInternal, codeUnavailable, "DATA_LOSS", "UNAUTHENTICATED":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/server/wire/gcprest/gcprest_test.go
+++ b/server/wire/gcprest/gcprest_test.go
@@ -2,6 +2,7 @@ package gcprest_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -109,16 +110,20 @@ func TestNewDoneOperationGlobal(t *testing.T) {
 
 func TestWriteCErrMapping(t *testing.T) {
 	cases := []struct {
-		name   string
-		err    error
-		status int
+		name string
+		err  error
+		code int
+		// reason is the Google JSON-API camelCase token in errors[].reason.
 		reason string
+		// status is the canonical google.rpc.Code NAME in the top-level
+		// error.status field, matching what real GCP returns.
+		status string
 	}{
-		{"NotFound", cerrors.New(cerrors.NotFound, "missing"), http.StatusNotFound, "notFound"},
-		{"AlreadyExists", cerrors.New(cerrors.AlreadyExists, "dup"), http.StatusConflict, "alreadyExists"},
-		{"InvalidArgument", cerrors.New(cerrors.InvalidArgument, "bad"), http.StatusBadRequest, "invalid"},
-		{"FailedPrecondition", cerrors.New(cerrors.FailedPrecondition, "fp"), http.StatusConflict, "conditionNotMet"},
-		{"Unknown", errors.New("boom"), http.StatusInternalServerError, "internalError"},
+		{"NotFound", cerrors.New(cerrors.NotFound, "missing"), http.StatusNotFound, "notFound", "NOT_FOUND"},
+		{"AlreadyExists", cerrors.New(cerrors.AlreadyExists, "dup"), http.StatusConflict, "alreadyExists", "ALREADY_EXISTS"},
+		{"InvalidArgument", cerrors.New(cerrors.InvalidArgument, "bad"), http.StatusBadRequest, "invalid", "INVALID_ARGUMENT"},
+		{"FailedPrecondition", cerrors.New(cerrors.FailedPrecondition, "fp"), http.StatusConflict, "conditionNotMet", "FAILED_PRECONDITION"},
+		{"Unknown", errors.New("boom"), http.StatusInternalServerError, "internalError", "INTERNAL"},
 	}
 
 	for _, c := range cases {
@@ -126,12 +131,34 @@ func TestWriteCErrMapping(t *testing.T) {
 			rec := httptest.NewRecorder()
 			gcprest.WriteCErr(rec, c.err)
 
-			if rec.Code != c.status {
-				t.Errorf("status=%d want %d", rec.Code, c.status)
+			if rec.Code != c.code {
+				t.Errorf("http code=%d want %d", rec.Code, c.code)
 			}
 
-			if !strings.Contains(rec.Body.String(), c.reason) {
-				t.Errorf("body=%q does not contain %q", rec.Body.String(), c.reason)
+			var env struct {
+				Error struct {
+					Code    int    `json:"code"`
+					Status  string `json:"status"`
+					Message string `json:"message"`
+					Errors  []struct {
+						Reason string `json:"reason"`
+					} `json:"errors"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+				t.Fatalf("decode body: %v (body=%q)", err, rec.Body.String())
+			}
+
+			if env.Error.Status != c.status {
+				t.Errorf("error.status=%q want canonical %q", env.Error.Status, c.status)
+			}
+
+			if env.Error.Code != c.code {
+				t.Errorf("error.code=%d want %d", env.Error.Code, c.code)
+			}
+
+			if len(env.Error.Errors) == 0 || env.Error.Errors[0].Reason != c.reason {
+				t.Errorf("errors[].reason=%+v want %q", env.Error.Errors, c.reason)
 			}
 		})
 	}

--- a/server/wire/gcprest/gcprest_test.go
+++ b/server/wire/gcprest/gcprest_test.go
@@ -164,6 +164,62 @@ func TestWriteCErrMapping(t *testing.T) {
 	}
 }
 
+// TestWriteErrorCanonicalReasonPassthrough guards a regression: some callers
+// (vertexai's predict-no-models path, eventarc, fcm) pass an already-canonical
+// google.rpc.Code NAME as the reason arg. WriteError must surface that NAME in
+// the top-level status field verbatim (not drop it via omitempty). Before the
+// isCanonicalCode passthrough, only "INVALID_ARGUMENT" had an alias case and
+// "FAILED_PRECONDITION" fell through to "" — silently dropping the status of a
+// previously-correct response.
+func TestWriteErrorCanonicalReasonPassthrough(t *testing.T) {
+	canonical := []string{
+		"FAILED_PRECONDITION", "INVALID_ARGUMENT", "NOT_FOUND", "ALREADY_EXISTS",
+		"PERMISSION_DENIED", "RESOURCE_EXHAUSTED", "UNIMPLEMENTED", "UNAVAILABLE",
+		"INTERNAL", "UNAUTHENTICATED", "ABORTED", "OUT_OF_RANGE", "DATA_LOSS",
+		"DEADLINE_EXCEEDED", "CANCELLED", "UNKNOWN",
+	}
+
+	for _, code := range canonical {
+		t.Run(code, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			gcprest.WriteError(rec, http.StatusBadRequest, code, "boom")
+
+			var env struct {
+				Error struct {
+					Status string `json:"status"`
+					Errors []struct {
+						Reason string `json:"reason"`
+					} `json:"errors"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+				t.Fatalf("decode body: %v (body=%q)", err, rec.Body.String())
+			}
+
+			if env.Error.Status != code {
+				t.Errorf("error.status=%q want canonical %q (dropped?)", env.Error.Status, code)
+			}
+
+			if len(env.Error.Errors) == 0 || env.Error.Errors[0].Reason != code {
+				t.Errorf("errors[].reason=%+v want %q", env.Error.Errors, code)
+			}
+		})
+	}
+}
+
+// TestWriteErrorReasonWithoutCanonicalCode confirms reasons with no
+// google.rpc.Code (e.g. HTTP 405 "methodNotAllowed") drop the status field,
+// matching real GCP.
+func TestWriteErrorReasonWithoutCanonicalCode(t *testing.T) {
+	rec := httptest.NewRecorder()
+	gcprest.WriteError(rec, http.StatusMethodNotAllowed, "methodNotAllowed", "nope")
+
+	body := rec.Body.String()
+	if strings.Contains(body, `"status"`) {
+		t.Errorf("body=%q should omit status for a reason with no canonical code", body)
+	}
+}
+
 // TestWriteCErrOmitsCodePrefix guards against the wire message leaking the
 // cloudemu internal error-taxonomy code prefix (cerrors.Error() renders
 // "NotFound: instance x not found") into the message an SDK surfaces to the


### PR DESCRIPTION
## Summary

The shared GCP REST wire codec (`server/wire/gcprest/gcprest.go`) wrote the **wrong `status` string** in error bodies. It put the Google JSON-API camelCase `reason` token (`notFound`, `invalid`, `conditionNotMet`, `internalError`) into the top-level `error.status` field, whereas real GCP returns the canonical **`google.rpc.Code` enum NAME** (all-caps SNAKE_CASE, e.g. `NOT_FOUND`). This is fixed by decoupling `status` from `reason` inside `WriteError`.

**Scope (accurate):** this canonicalizes `status` **only for the 14 GCP services that route through the shared `gcprest` codec** (via `gcprest.WriteError` / `gcprest.WriteCErr`):

`artifactregistry`, `bigtable`, `cloudbilling`, `clouddns`, `cloudlogging`, `compute`, `eventarc`, `fcm`, `loadbalancer`, `lro`, `memorystore`, `secretmanager`, `vertexai`, `vpc`.

The other ~13 GCP server packages build their **own** error envelopes and do **not** route through `gcprest` — they are unaffected by this change: `cloudfunctions`, `firestore`, `cloudrun`, `iam`, `gke`, `cloudasset`, `cloudsql`, `pubsub`, `monitoring`, `alloydb`, `gcs`, `servicenetworking`. (Most of these already emit a canonical uppercase string in their own `status` field; `gcs` is a known follow-up — see below.)

Source: https://cloud.google.com/apis/design/errors and the `google.rpc.Code` enum — the Google API error model carries the Code NAME in `status`, while the older JSON-API `errors[].reason` field stays camelCase.

## The fix — decouple `status` from `reason`

The two fields are decoupled inside the shared `WriteError` via `canonicalStatus(reason)`:

- **`error.status`** → canonical `google.rpc.Code` NAME (e.g. `NOT_FOUND`)
- **`error.errors[].reason`** → unchanged Google JSON-API camelCase token (e.g. `notFound`)

**HTTP numeric status codes are unchanged** — only the `status` string changes.

### Regression fix: already-canonical reasons pass through

Some callers pass an **already-canonical** `google.rpc.Code` NAME as the `reason` arg — `eventarc` and `fcm` send `"INVALID_ARGUMENT"`, and `vertexai`'s predict-on-endpoint-with-no-deployed-models path sends `"FAILED_PRECONDITION"`. The initial mapping only aliased `"INVALID_ARGUMENT"`, so `"FAILED_PRECONDITION"` fell to the `default` `""` and the top-level `status` was silently dropped from a previously-correct response.

`canonicalStatus` now checks an explicit `google.rpc.Code` set first (`isCanonicalCode`) and returns a canonical reason **verbatim**; only camelCase reasons go through the mapping. This is robust to both reason styles and cannot silently drop a canonical input, while a typo'd/garbage reason still yields no `status` (dropped via `omitempty`, matching real GCP for reasons with no `google.rpc.Code`, e.g. HTTP 405 `methodNotAllowed`).

## Mapping table (JSON-API reason → canonical status)

| reason (`errors[].reason`) | HTTP | canonical `status` |
|---|---|---|
| notFound | 404 | NOT_FOUND |
| alreadyExists | 409 | ALREADY_EXISTS |
| invalid / invalidArgument / badRequest / required | 400 | INVALID_ARGUMENT |
| conditionNotMet / failedPrecondition / resourceInUseByAnotherResource / containerNotEmpty / cnameResourceRecordSetConflict | 400/409 (unchanged) | FAILED_PRECONDITION |
| forbidden | 403 | PERMISSION_DENIED |
| rateLimitExceeded | 429 | RESOURCE_EXHAUSTED |
| notImplemented | 501 | UNIMPLEMENTED |
| backendError | 503 | UNAVAILABLE |
| internalError | 500 | INTERNAL |
| *(an already-canonical `google.rpc.Code` NAME)* | (unchanged) | *(returned verbatim)* |
| methodNotAllowed (405, no `google.rpc.Code`) | 405 | *(omitted — `omitempty`; matches real GCP)* |

## Tests

- `server/wire/gcprest/gcprest_test.go`
  - `TestWriteCErrMapping` (existing) — asserts canonical `error.status` and preserved `errors[].reason`.
  - `TestWriteErrorCanonicalReasonPassthrough` (**new**, regression guard) — every `google.rpc.Code` NAME passed as reason (incl. `FAILED_PRECONDITION`) is surfaced verbatim in `status`. Fails on the previous HEAD (status dropped), passes now.
  - `TestWriteErrorReasonWithoutCanonicalCode` (**new**) — a reason with no `google.rpc.Code` (`methodNotAllowed`) omits `status`.
- `server/gcp/vertexai/sdk_roundtrip_test.go` — `TestPredictNoDeployedModels` extended to assert the 400 body carries `status:"FAILED_PRECONDITION"` (not just the HTTP code).

## Known follow-up (out of this PR's scope)

`gcs` builds its own bespoke error envelope and still couples `status` to `reason` (deleting a non-empty bucket returns `status:"notEmpty"`). Canonicalizing it is **not** a contained change: the GCS storage JSON API uses the legacy error format (whose top-level `status` the real Go SDK `googleapi.Error` ignores), the exact reason string is disputed across sources (existing tests assert `"notEmpty"`), and GCS has many bespoke error shapes. Filed as a follow-up envelope audit rather than half-fixed here.

## Gates

- `go build ./...` — ok
- `go test -race -count=1 ./server/wire/gcprest/... ./server/gcp/...` — all GCP packages pass
- `go vet`, `gofmt -l` — clean
- `golangci-lint run --new-from-rev=origin/development` — 0 issues
- `go generate ./...` — no `docs/coverage` diff
