### PR TITLE
fix(kinesis): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/kinesis/consumers.go
+++ b/providers/aws/kinesis/consumers.go
@@ -25,11 +25,12 @@ func (m *Mock) RegisterStreamConsumer(ctx context.Context, streamARN, consumerNa
 		return nil, errInUse("consumer %q already exists on the stream", consumerName)
 	}
 
+	createdAt := m.now()
 	c := &driver.Consumer{
 		ConsumerName:              consumerName,
-		ConsumerARN:               m.consumerARN(ctx, sd.desc.StreamName, consumerName),
+		ConsumerARN:               m.consumerARN(ctx, sd.desc.StreamName, consumerName, createdAt),
 		ConsumerStatus:            driver.ConsumerActive,
-		ConsumerCreationTimestamp: m.now(),
+		ConsumerCreationTimestamp: createdAt,
 		StreamARN:                 sd.desc.StreamARN,
 	}
 	sd.consumers[consumerName] = c

--- a/providers/aws/kinesis/consumers.go
+++ b/providers/aws/kinesis/consumers.go
@@ -25,7 +25,7 @@ func (m *Mock) RegisterStreamConsumer(ctx context.Context, streamARN, consumerNa
 		return nil, errInUse("consumer %q already exists on the stream", consumerName)
 	}
 
-	createdAt := m.now()
+	createdAt := m.nextConsumerCreation()
 	c := &driver.Consumer{
 		ConsumerName:              consumerName,
 		ConsumerARN:               m.consumerARN(ctx, sd.desc.StreamName, consumerName, createdAt),

--- a/providers/aws/kinesis/kinesis.go
+++ b/providers/aws/kinesis/kinesis.go
@@ -85,6 +85,11 @@ type Mock struct {
 	settingsMu sync.RWMutex
 	settings   driver.AccountSettings
 
+	// consumerMu guards lastConsumerUnix, the strictly increasing Unix-seconds
+	// value handed to each consumer registration so every consumer ARN is unique.
+	consumerMu       sync.Mutex
+	lastConsumerUnix int64
+
 	// esmInvoker, when wired via SetLambdaInvoker, receives a Kinesis-shaped
 	// event batch on every PutRecord(s) so a mapped Lambda actually runs.
 	esmInvoker EventSourceInvoker
@@ -142,6 +147,30 @@ func (m *Mock) consumerARN(ctx context.Context, streamName, consumerName string,
 
 func (m *Mock) now() time.Time {
 	return m.opts.Clock.Now().UTC()
+}
+
+// nextConsumerCreation returns the creation time for a new consumer as a strictly
+// increasing whole-second value. Real Kinesis embeds the creation timestamp
+// (Unix seconds) in the consumer ARN and guarantees a delete+re-register yields a
+// distinct ARN; it avoids collisions only because registration passes through a
+// CREATING state over wall-clock time. cloudemu registers instantly, so two
+// same-second cycles for one name would otherwise mint identical ARNs. Advancing
+// the suffix to at least one second past the previously issued value preserves the
+// realistic ~10-digit seconds format while guaranteeing a unique, strictly greater
+// ARN per registration. The returned time is used for both the ARN suffix and
+// ConsumerCreationTimestamp so the two always agree.
+func (m *Mock) nextConsumerCreation() time.Time {
+	m.consumerMu.Lock()
+	defer m.consumerMu.Unlock()
+
+	unix := m.now().Unix()
+	if unix <= m.lastConsumerUnix {
+		unix = m.lastConsumerUnix + 1
+	}
+
+	m.lastConsumerUnix = unix
+
+	return time.Unix(unix, 0).UTC()
 }
 
 // resolve finds a stream by name or ARN (name takes precedence when both set).

--- a/providers/aws/kinesis/kinesis.go
+++ b/providers/aws/kinesis/kinesis.go
@@ -131,9 +131,13 @@ func (m *Mock) streamARN(ctx context.Context, name string) string {
 	return idgen.AWSARN("kinesis", regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID, "stream/"+name)
 }
 
-func (m *Mock) consumerARN(ctx context.Context, streamName, consumerName string) string {
+// consumerARN builds an enhanced-fan-out consumer ARN. Real Kinesis appends the
+// consumer's creation timestamp (Unix seconds) to the ARN — the documented
+// Consumer.ConsumerARN pattern ends in ":[0-9]+" — so that recreating a consumer
+// with the same name yields a distinct ARN.
+func (m *Mock) consumerARN(ctx context.Context, streamName, consumerName string, createdAt time.Time) string {
 	return idgen.AWSARN("kinesis", regionctx.RegionOr(ctx, m.opts.Region), m.opts.AccountID,
-		"stream/"+streamName+"/consumer/"+consumerName)
+		fmt.Sprintf("stream/%s/consumer/%s:%d", streamName, consumerName, createdAt.Unix()))
 }
 
 func (m *Mock) now() time.Time {

--- a/providers/aws/kinesis/kinesis_test.go
+++ b/providers/aws/kinesis/kinesis_test.go
@@ -412,3 +412,68 @@ func TestConsumerARNCarriesCreationTimestamp(t *testing.T) {
 		t.Fatalf("recreated consumer reused the ARN %q; real Kinesis mints a new one", c2.ConsumerARN)
 	}
 }
+
+// TestConsumerARNUniqueSameSecond drives register/deregister/re-register cycles
+// for one consumer name under the REAL wall-clock — the realistic case a fake
+// clock advanced a full minute never exercises. Because cloudemu registers
+// instantly, many cycles land in the same wall-clock second; every ARN must still
+// be distinct (and each a valid AWS consumer ARN), so IAM/terraform/e2e loops that
+// key off the ARN never see a stale reuse.
+func TestConsumerARNUniqueSameSecond(t *testing.T) {
+	ctx := context.Background()
+	m := newMock(t) // real clock: same-second cycles are the whole point
+
+	if err := m.CreateStream(ctx, driver.CreateStreamInput{StreamName: "s", ShardCount: 1}); err != nil {
+		t.Fatalf("CreateStream: %v", err)
+	}
+
+	sum, err := m.DescribeStreamSummary(ctx, "s", "")
+	if err != nil {
+		t.Fatalf("DescribeStreamSummary: %v", err)
+	}
+
+	arnPattern := regexp.MustCompile(`^arn:aws:kinesis:.*:\d{12}:stream/s/consumer/c:[0-9]+$`)
+	seen := make(map[string]struct{})
+
+	const cycles = 50
+
+	var prevSuffix int64
+
+	for i := 0; i < cycles; i++ {
+		c, regErr := m.RegisterStreamConsumer(ctx, sum.StreamARN, "c")
+		if regErr != nil {
+			t.Fatalf("RegisterStreamConsumer (cycle %d): %v", i, regErr)
+		}
+
+		if !arnPattern.MatchString(c.ConsumerARN) {
+			t.Fatalf("cycle %d: ConsumerARN %q does not match the AWS pattern", i, c.ConsumerARN)
+		}
+
+		if _, dup := seen[c.ConsumerARN]; dup {
+			t.Fatalf("cycle %d: duplicate ConsumerARN %q across same-second re-registrations", i, c.ConsumerARN)
+		}
+
+		seen[c.ConsumerARN] = struct{}{}
+
+		// The suffix (and thus ConsumerCreationTimestamp) must be strictly
+		// increasing so a delete+re-register always yields a greater ARN.
+		suffix := c.ConsumerCreationTimestamp.Unix()
+		if i > 0 && suffix <= prevSuffix {
+			t.Fatalf("cycle %d: suffix %d not strictly greater than previous %d", i, suffix, prevSuffix)
+		}
+
+		prevSuffix = suffix
+
+		if !strings.HasSuffix(c.ConsumerARN, ":"+strconv.FormatInt(suffix, 10)) {
+			t.Fatalf("cycle %d: ARN %q suffix disagrees with ConsumerCreationTimestamp %d", i, c.ConsumerARN, suffix)
+		}
+
+		if derErr := m.DeregisterStreamConsumer(ctx, sum.StreamARN, "c", ""); derErr != nil {
+			t.Fatalf("DeregisterStreamConsumer (cycle %d): %v", i, derErr)
+		}
+	}
+
+	if len(seen) != cycles {
+		t.Fatalf("expected %d distinct ARNs, got %d", cycles, len(seen))
+	}
+}

--- a/providers/aws/kinesis/kinesis_test.go
+++ b/providers/aws/kinesis/kinesis_test.go
@@ -2,6 +2,9 @@ package kinesis_test
 
 import (
 	"context"
+	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -355,5 +358,57 @@ func TestExpiredIteratorForMissingShard(t *testing.T) {
 	apiErr, ok := err.(*driver.APIError)
 	if !ok || apiErr.Exception != driver.ExExpiredIterator {
 		t.Fatalf("missing shard should be ExpiredIteratorException, got %v", err)
+	}
+}
+
+// TestConsumerARNCarriesCreationTimestamp verifies the enhanced-fan-out consumer
+// ARN ends with the creation timestamp (Unix seconds) as real Kinesis does — the
+// documented Consumer.ConsumerARN pattern requires a trailing ":[0-9]+" — and
+// that recreating a consumer with the same name at a later time yields a distinct
+// ARN.
+func TestConsumerARNCarriesCreationTimestamp(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newMockClock(t)
+
+	if err := m.CreateStream(ctx, driver.CreateStreamInput{StreamName: "s", ShardCount: 1}); err != nil {
+		t.Fatalf("CreateStream: %v", err)
+	}
+
+	sum, err := m.DescribeStreamSummary(ctx, "s", "")
+	if err != nil {
+		t.Fatalf("DescribeStreamSummary: %v", err)
+	}
+
+	arnPattern := regexp.MustCompile(`^arn:aws:kinesis:.*:\d{12}:stream/s/consumer/c:[0-9]+$`)
+
+	c1, err := m.RegisterStreamConsumer(ctx, sum.StreamARN, "c")
+	if err != nil {
+		t.Fatalf("RegisterStreamConsumer: %v", err)
+	}
+
+	if !arnPattern.MatchString(c1.ConsumerARN) {
+		t.Fatalf("ConsumerARN %q does not match the AWS pattern", c1.ConsumerARN)
+	}
+
+	wantSuffix := ":" + strconv.FormatInt(c1.ConsumerCreationTimestamp.Unix(), 10)
+	if !strings.HasSuffix(c1.ConsumerARN, wantSuffix) {
+		t.Fatalf("ConsumerARN %q should end with the creation timestamp %q", c1.ConsumerARN, wantSuffix)
+	}
+
+	// Deregister, advance the clock, and recreate the same-named consumer: the
+	// timestamp suffix must make the new ARN distinct.
+	if err := m.DeregisterStreamConsumer(ctx, sum.StreamARN, "c", ""); err != nil {
+		t.Fatalf("DeregisterStreamConsumer: %v", err)
+	}
+
+	clk.Advance(time.Minute)
+
+	c2, err := m.RegisterStreamConsumer(ctx, sum.StreamARN, "c")
+	if err != nil {
+		t.Fatalf("re-RegisterStreamConsumer: %v", err)
+	}
+
+	if c2.ConsumerARN == c1.ConsumerARN {
+		t.Fatalf("recreated consumer reused the ARN %q; real Kinesis mints a new one", c2.ConsumerARN)
 	}
 }

--- a/server/aws/kinesis/admin_ops.go
+++ b/server/aws/kinesis/admin_ops.go
@@ -120,12 +120,24 @@ func (h *Handler) setMonitoring(ctx context.Context, req *monitoringRequest, ena
 }
 
 func monitoringResponse(name, arn string, before, after []string) map[string]any {
+	// Kinesis models both metric fields as a ShardLevelMetricsList, always
+	// serialized as an array (empty when no metrics), never null.
 	return map[string]any{
 		"StreamName":               name,
-		"CurrentShardLevelMetrics": before,
-		"DesiredShardLevelMetrics": after,
+		"CurrentShardLevelMetrics": nonNilMetrics(before),
+		"DesiredShardLevelMetrics": nonNilMetrics(after),
 		"StreamARN":                arn,
 	}
+}
+
+// nonNilMetrics coerces a nil metric slice to an empty slice so the wire emits
+// a JSON array ([]) rather than null.
+func nonNilMetrics(m []string) []string {
+	if m == nil {
+		return []string{}
+	}
+
+	return m
 }
 
 // --- Tags ---

--- a/server/aws/kinesis/enhanced_monitoring_wire_test.go
+++ b/server/aws/kinesis/enhanced_monitoring_wire_test.go
@@ -1,0 +1,70 @@
+package kinesis_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// kinesisPost issues a raw Kinesis JSON 1.1 request against ts and returns the
+// decoded top-level response object.
+func kinesisPost(t *testing.T, url, target, body string) map[string]json.RawMessage {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	req.Header.Set("X-Amz-Target", "Kinesis_20131202."+target)
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do %s: %v", target, err)
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("%s: status %d body %s", target, resp.StatusCode, raw)
+	}
+
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode %s: %v (%s)", target, err, raw)
+	}
+
+	return out
+}
+
+// TestEnableEnhancedMonitoringEmitsMetricArrays checks that the shard-level
+// metric fields serialize as JSON arrays (empty when no metrics were previously
+// set) rather than null, matching Kinesis's ShardLevelMetricsList shape.
+func TestEnableEnhancedMonitoringEmitsMetricArrays(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{Kinesis: cloud.Kinesis})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	kinesisPost(t, ts.URL, "CreateStream", `{"StreamName":"m","ShardCount":1}`)
+
+	out := kinesisPost(t, ts.URL, "EnableEnhancedMonitoring",
+		`{"StreamName":"m","ShardLevelMetrics":["IncomingBytes"]}`)
+
+	if got := string(out["CurrentShardLevelMetrics"]); got != "[]" {
+		t.Fatalf("CurrentShardLevelMetrics = %s, want []", got)
+	}
+
+	if got := string(out["DesiredShardLevelMetrics"]); got != `["IncomingBytes"]` {
+		t.Fatalf("DesiredShardLevelMetrics = %s, want [\"IncomingBytes\"]", got)
+	}
+}


### PR DESCRIPTION
Real-user e2e audit (SDK/CLI + Terraform, live `cloudemu serve`) of AWS Kinesis Data Streams. Found and fixed two genuine cloud-vs-cloudemu divergences.

## Findings fixed

**Consumer ARN missing creation-timestamp suffix (moderate).** The documented `Consumer.ConsumerARN` pattern ends in `:[0-9]+` (a Unix-seconds creation timestamp), and AWS notes that recreating a same-named consumer must produce a *different* ARN precisely because of this suffix. CloudEmu emitted `.../consumer/<name>` with no timestamp, so recreated consumers reused the identical ARN and the ARN failed the AWS pattern. Now `consumerARN` appends `:createdAt.Unix()`; `DescribeStreamConsumer`/`DeregisterStreamConsumer`/`SubscribeToShard` continue to resolve by the stored ARN.

**Enhanced-monitoring metric lists serialized as `null` (low).** `EnableEnhancedMonitoring`/`DisableEnhancedMonitoring` returned `"CurrentShardLevelMetrics": null` when no metrics were previously set; real Kinesis always returns a `ShardLevelMetricsList` array (empty `[]`). Coerced nil → `[]` in the wire response.

## Verification
- aws-cli + raw JSON1.1 + Terraform `aws_kinesis_stream` (provisioned + on_demand): create → ACTIVE waiter → update shard count/retention → destroy, no drift.
- Terraform `aws_kinesis_stream_consumer`: create → plan (no drift) → destroy with the new timestamped ARN as its id.
- Record data plane round-trips byte-exact; error codes clean (`__type` + message, HTTP 400, no internal prefix leak).
- New regression tests: `TestConsumerARNCarriesCreationTimestamp`, `TestEnableEnhancedMonitoringEmitsMetricArrays`.
- Gates: `go build ./...`, `go vet`, `gofmt -l`, `go test -race` (providers/aws/kinesis + server/aws/kinesis + services), `golangci-lint --new-from-rev=origin/development` (0 issues), `go generate` (no docs/coverage drift) — all green.

## Filed, not fixed
`ListStreams` `StreamSummaries` carry a few fields not present in the real ListStreams `StreamSummary` shape (RetentionPeriodHours, OpenShardCount, ConsumerCount, EnhancedMonitoring). Purely additive; SDKs ignore unknown fields — no user-visible impact.