### PR TITLE
fix(servicebus): real-user e2e divergences from Azure

### DIFF
--- a/server/azure/servicebus/subscription.go
+++ b/server/azure/servicebus/subscription.go
@@ -255,6 +255,21 @@ func buildSubProps(in *subscriptionProperties, created, updated time.Time) subsc
 		out.MaxDeliveryCount = defaultMaxDeliveryCount
 	}
 
+	if out.AutoDeleteOnIdle == "" {
+		out.AutoDeleteOnIdle = maxTimeToLive
+	}
+
+	if out.EnableBatchedOperations == nil {
+		out.EnableBatchedOperations = defaultBatchedOps()
+	}
+
+	// deadLetteringOnFilterEvaluationExceptions defaults to true in real Service
+	// Bus; a pointer keeps an explicit "false" from being overwritten.
+	if out.DeadLetteringOnFilterError == nil {
+		on := true
+		out.DeadLetteringOnFilterError = &on
+	}
+
 	out.CountDetails = &countDetails{}
 	out.CreatedAt = &created
 	out.UpdatedAt = &updated

--- a/server/azure/servicebus/subscription_defaults_sdk_test.go
+++ b/server/azure/servicebus/subscription_defaults_sdk_test.go
@@ -1,0 +1,147 @@
+package servicebus_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2"
+)
+
+// maxSBTimeToLive is Service Bus' TimeSpan.MaxValue default for
+// defaultMessageTimeToLive / autoDeleteOnIdle when the client omits them.
+const maxSBTimeToLive = "P10675199DT2H48M5.4775807S"
+
+// TestSDKSubscriptionCreateDefaults asserts a subscription created with only the
+// required maxDeliveryCount reads back Azure's server-side defaults, so a
+// Terraform azurerm_servicebus_subscription with defaults does not drift:
+//   - enableBatchedOperations = true
+//   - deadLetteringOnFilterEvaluationExceptions = true
+//   - autoDeleteOnIdle = TimeSpan.Max
+//   - defaultMessageTimeToLive = TimeSpan.Max
+//   - lockDuration = PT1M
+func TestSDKSubscriptionCreateDefaults(t *testing.T) {
+	ts := pubsubServer(t)
+	cf := newClientFactory(t, ts)
+	ctx := context.Background()
+
+	createNS(t, cf.NewNamespacesClient(), rgName, nsName, nil)
+
+	if _, err := cf.NewTopicsClient().CreateOrUpdate(ctx, rgName, nsName, "orders",
+		armservicebus.SBTopic{}, nil); err != nil {
+		t.Fatalf("topic CreateOrUpdate: %v", err)
+	}
+
+	sub, err := cf.NewSubscriptionsClient().CreateOrUpdate(ctx, rgName, nsName, "orders", "all",
+		armservicebus.SBSubscription{Properties: &armservicebus.SBSubscriptionProperties{}}, nil)
+	if err != nil {
+		t.Fatalf("subscription CreateOrUpdate: %v", err)
+	}
+
+	p := sub.Properties
+	if p == nil {
+		t.Fatal("nil properties")
+	}
+
+	if p.EnableBatchedOperations == nil || !*p.EnableBatchedOperations {
+		t.Errorf("enableBatchedOperations = %v, want true (default)", p.EnableBatchedOperations)
+	}
+
+	if p.DeadLetteringOnFilterEvaluationExceptions == nil || !*p.DeadLetteringOnFilterEvaluationExceptions {
+		t.Errorf("deadLetteringOnFilterEvaluationExceptions = %v, want true (default)",
+			p.DeadLetteringOnFilterEvaluationExceptions)
+	}
+
+	if p.AutoDeleteOnIdle == nil || *p.AutoDeleteOnIdle != maxSBTimeToLive {
+		t.Errorf("autoDeleteOnIdle = %v, want %s (default)", p.AutoDeleteOnIdle, maxSBTimeToLive)
+	}
+
+	if p.DefaultMessageTimeToLive == nil || *p.DefaultMessageTimeToLive != maxSBTimeToLive {
+		t.Errorf("defaultMessageTimeToLive = %v, want %s (default)", p.DefaultMessageTimeToLive, maxSBTimeToLive)
+	}
+
+	if p.LockDuration == nil || *p.LockDuration != "PT1M" {
+		t.Errorf("lockDuration = %v, want PT1M (default)", p.LockDuration)
+	}
+}
+
+// TestSDKSubscriptionExplicitRoundTrip asserts explicit non-default subscription
+// properties survive create -> Get, so an azurerm_servicebus_subscription that
+// sets these does not perpetually drift.
+func TestSDKSubscriptionExplicitRoundTrip(t *testing.T) {
+	ts := pubsubServer(t)
+	cf := newClientFactory(t, ts)
+	ctx := context.Background()
+
+	createNS(t, cf.NewNamespacesClient(), rgName, nsName, nil)
+
+	if _, err := cf.NewTopicsClient().CreateOrUpdate(ctx, rgName, nsName, "orders",
+		armservicebus.SBTopic{}, nil); err != nil {
+		t.Fatalf("topic CreateOrUpdate: %v", err)
+	}
+
+	subs := cf.NewSubscriptionsClient()
+
+	if _, err := subs.CreateOrUpdate(ctx, rgName, nsName, "orders", "all", armservicebus.SBSubscription{
+		Properties: &armservicebus.SBSubscriptionProperties{
+			MaxDeliveryCount:                          to.Ptr[int32](5),
+			EnableBatchedOperations:                   to.Ptr(false),
+			AutoDeleteOnIdle:                          to.Ptr("PT5M"),
+			DeadLetteringOnFilterEvaluationExceptions: to.Ptr(false),
+		},
+	}, nil); err != nil {
+		t.Fatalf("subscription CreateOrUpdate: %v", err)
+	}
+
+	got, err := subs.Get(ctx, rgName, nsName, "orders", "all", nil)
+	if err != nil {
+		t.Fatalf("subscription Get: %v", err)
+	}
+
+	p := got.Properties
+	if p.EnableBatchedOperations == nil || *p.EnableBatchedOperations {
+		t.Errorf("enableBatchedOperations = %v, want false", p.EnableBatchedOperations)
+	}
+
+	if p.AutoDeleteOnIdle == nil || *p.AutoDeleteOnIdle != "PT5M" {
+		t.Errorf("autoDeleteOnIdle = %v, want PT5M", p.AutoDeleteOnIdle)
+	}
+
+	if p.DeadLetteringOnFilterEvaluationExceptions == nil || *p.DeadLetteringOnFilterEvaluationExceptions {
+		t.Errorf("deadLetteringOnFilterEvaluationExceptions = %v, want false", p.DeadLetteringOnFilterEvaluationExceptions)
+	}
+}
+
+// TestSDKQueueForwardDeadLetteredRoundTrip asserts a queue's
+// forwardDeadLetteredMessagesTo survives create -> Get, so an
+// azurerm_servicebus_queue that sets forward_dead_lettered_messages_to does not
+// drift.
+func TestSDKQueueForwardDeadLetteredRoundTrip(t *testing.T) {
+	ts := pubsubServer(t)
+	cf := newClientFactory(t, ts)
+	ctx := context.Background()
+
+	createNS(t, cf.NewNamespacesClient(), rgName, nsName, nil)
+
+	queues := cf.NewQueuesClient()
+
+	if _, err := queues.CreateOrUpdate(ctx, rgName, nsName, "dead", armservicebus.SBQueue{}, nil); err != nil {
+		t.Fatalf("create target queue: %v", err)
+	}
+
+	if _, err := queues.CreateOrUpdate(ctx, rgName, nsName, "src", armservicebus.SBQueue{
+		Properties: &armservicebus.SBQueueProperties{ForwardDeadLetteredMessagesTo: to.Ptr("dead")},
+	}, nil); err != nil {
+		t.Fatalf("create src queue: %v", err)
+	}
+
+	got, err := queues.Get(ctx, rgName, nsName, "src", nil)
+	if err != nil {
+		t.Fatalf("queue Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.ForwardDeadLetteredMessagesTo == nil ||
+		*got.Properties.ForwardDeadLetteredMessagesTo != "dead" {
+		t.Errorf("forwardDeadLetteredMessagesTo = %v, want dead", got.Properties.ForwardDeadLetteredMessagesTo)
+	}
+}

--- a/server/azure/servicebus/types.go
+++ b/server/azure/servicebus/types.go
@@ -55,6 +55,7 @@ type queueProperties struct {
 	AutoDeleteOnIdle                    string        `json:"autoDeleteOnIdle,omitempty"`
 	DuplicateDetectionHistoryTimeWindow string        `json:"duplicateDetectionHistoryTimeWindow,omitempty"`
 	ForwardTo                           string        `json:"forwardTo,omitempty"`
+	ForwardDeadLetteredTo               string        `json:"forwardDeadLetteredMessagesTo,omitempty"`
 	RequiresDuplicateDetection          bool          `json:"requiresDuplicateDetection"`
 	RequiresSession                     bool          `json:"requiresSession"`
 	DeadLetteringOnExpiration           bool          `json:"deadLetteringOnMessageExpiration"`
@@ -116,9 +117,11 @@ type subscriptionProperties struct {
 	MaxDeliveryCount           int32         `json:"maxDeliveryCount,omitempty"`
 	LockDuration               string        `json:"lockDuration,omitempty"`
 	DefaultMessageTimeToLive   string        `json:"defaultMessageTimeToLive,omitempty"`
+	AutoDeleteOnIdle           string        `json:"autoDeleteOnIdle,omitempty"`
 	RequiresSession            bool          `json:"requiresSession"`
 	DeadLetteringOnExpiration  bool          `json:"deadLetteringOnMessageExpiration"`
-	DeadLetteringOnFilterError bool          `json:"deadLetteringOnFilterEvaluationExceptions"`
+	DeadLetteringOnFilterError *bool         `json:"deadLetteringOnFilterEvaluationExceptions,omitempty"`
+	EnableBatchedOperations    *bool         `json:"enableBatchedOperations,omitempty"`
 	ForwardTo                  string        `json:"forwardTo,omitempty"`
 	ForwardDeadLetteredTo      string        `json:"forwardDeadLetteredMessagesTo,omitempty"`
 	CreatedAt                  *time.Time    `json:"createdAt,omitempty"`


### PR DESCRIPTION
Real-user e2e audit of the Microsoft.ServiceBus ARM control plane, driven by the real `armservicebus/v2` SDK against an in-process TLS server. Found and fixed genuine Terraform/SDK-vs-Azure divergences.

## Findings (fixed)

| Sev | Resource | Divergence | Fix |
|-----|----------|-----------|-----|
| High | subscription | `enableBatchedOperations` had no struct field, and the generic unmodeled-property overlay swallows an explicit `false` — so an explicit `false` was dropped and a create defaulted to absent -> `azurerm_servicebus_subscription` drift (real ARM default true) | Added `EnableBatchedOperations *bool`; default true; explicit false now round-trips |
| High | subscription | `autoDeleteOnIdle` had no struct field and no default -> absent on Get for a defaults-only subscription -> drift (real ARM default TimeSpan.Max) | Added `AutoDeleteOnIdle string`; default `P10675199DT2H48M5.4775807S` |
| Med | subscription | `deadLetteringOnFilterEvaluationExceptions` was a bare `bool` always serialized `false`; real ARM default is true, and a bare bool cannot represent omitted vs explicit false (the overlay swallows explicit false) | Changed to `*bool`; default true when omitted, explicit false round-trips |
| Low | queue | `forwardDeadLetteredMessagesTo` was not explicitly modeled | Added `ForwardDeadLetteredTo string` for explicitness. Note: this non-zero string already round-tripped via the generic unmodeled-property overlay, so this is defensive/explicit modeling rather than a fix for an observed drop — the added test guards the round-trip going forward |

The three subscription fixes were reproduced RED via the real SDK before the fix and re-verified GREEN after (see `subscription_defaults_sdk_test.go`). The `*bool` conversions specifically address the case the generic overlay cannot: an explicit `false` (the overlay treats zero-values as already-modeled and does not echo them).

## Verified clean

Deterministic list ordering (no drift), no cerrors prefix leak, namespace PATCH tags REPLACE, provisioningState=Succeeded on create (no azurerm waiter hang), RG/subscription scope enforcement, queue/topic create defaults, listKeys connection-string format, delete idempotency.

## Filed (not fixed)

SKU-tier validation gap: creating a topic/subscription on a Basic-tier namespace succeeds in cloudemu but real Azure rejects it (Basic supports queues only). Not fixed because the exact ARM error wire shape needs live-doc confirmation; details in the audit ledger. This is over-permissive (accepts an invalid config), not a Terraform-drift source on the common Standard/Premium path.

## Gates

`go build ./...`, `go test -race` (server/azure/servicebus + providers/azure/servicebus), `go vet`, `gofmt`, `golangci-lint --new-from-rev=origin/development` (0 issues), `go generate ./...` (no docs/coverage diff) — all green.
