### PR TITLE
fix(rediscache): real-user e2e divergences from Azure

### DIFF
--- a/providers/azure/cache/cache.go
+++ b/providers/azure/cache/cache.go
@@ -22,6 +22,18 @@ import (
 
 const defaultRedisSSLPort = 6380
 
+// Azure Cache for Redis create-time defaults. Real Azure persists and returns
+// these on every cache even when the create request omits them, so a client
+// that reads them back (or an SDK caller dereferencing the pointer) sees the
+// same values it would against the real service rather than a null.
+const (
+	// defaultEnableNonSSLPort is the enableNonSslPort default (false — the
+	// non-SSL 6379 port is disabled unless explicitly enabled).
+	defaultEnableNonSSLPort = false
+	// defaultPublicNetworkAccess is the publicNetworkAccess default (Enabled).
+	defaultPublicNetworkAccess = "Enabled"
+)
+
 // accessKeyBytes is the byte length of a generated Redis access key before
 // base64 encoding; 32 bytes encodes to the 44-character key real Azure returns.
 const accessKeyBytes = 32
@@ -113,6 +125,20 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 		tags[k] = v
 	}
 
+	// Apply Azure create-time defaults for fields the request omitted, so a
+	// minimal create reads back the same values real Azure would return instead
+	// of a null (matching the ARM RedisResource schema defaults).
+	enableNonSSLPort := cfg.EnableNonSSLPort
+	if enableNonSSLPort == nil {
+		v := defaultEnableNonSSLPort
+		enableNonSSLPort = &v
+	}
+
+	publicNetworkAccess := cfg.PublicNetworkAccess
+	if publicNetworkAccess == "" {
+		publicNetworkAccess = defaultPublicNetworkAccess
+	}
+
 	info := driver.CacheInfo{
 		Name:                cfg.Name,
 		Scope:               cfg.Scope,
@@ -128,9 +154,9 @@ func (m *Mock) CreateCache(ctx context.Context, cfg driver.CacheConfig) (*driver
 		ShardCount:          cfg.ShardCount,
 		ReplicasPerPrimary:  cfg.ReplicasPerPrimary,
 		RedisConfiguration:  cloneStringMap(cfg.RedisConfiguration),
-		EnableNonSSLPort:    cfg.EnableNonSSLPort,
+		EnableNonSSLPort:    enableNonSSLPort,
 		MinimumTLSVersion:   cfg.MinimumTLSVersion,
-		PublicNetworkAccess: cfg.PublicNetworkAccess,
+		PublicNetworkAccess: publicNetworkAccess,
 		RedisVersion:        cfg.RedisVersion,
 		PrimaryKey:          generateAccessKey(),
 		SecondaryKey:        generateAccessKey(),

--- a/providers/azure/cache/cache_test.go
+++ b/providers/azure/cache/cache_test.go
@@ -496,3 +496,39 @@ func TestIncrPreservesTTL(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, ttl > 0)
 }
+
+func TestCreateCacheAppliesAzureDefaults(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	// A create that omits enableNonSslPort and publicNetworkAccess must persist
+	// the Azure schema defaults (false / "Enabled"), not leave them unset — real
+	// Azure returns them on every cache.
+	info, err := m.CreateCache(ctx, driver.CacheConfig{Name: "defaults"})
+	require.NoError(t, err)
+	require.NotNil(t, info.EnableNonSSLPort)
+	assert.False(t, *info.EnableNonSSLPort)
+	assert.Equal(t, "Enabled", info.PublicNetworkAccess)
+
+	got, err := m.GetCache(ctx, "defaults")
+	require.NoError(t, err)
+	require.NotNil(t, got.EnableNonSSLPort)
+	assert.False(t, *got.EnableNonSSLPort)
+	assert.Equal(t, "Enabled", got.PublicNetworkAccess)
+}
+
+func TestCreateCacheKeepsExplicitProperties(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	enabled := true
+	info, err := m.CreateCache(ctx, driver.CacheConfig{
+		Name:                "explicit",
+		EnableNonSSLPort:    &enabled,
+		PublicNetworkAccess: "Disabled",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, info.EnableNonSSLPort)
+	assert.True(t, *info.EnableNonSSLPort)
+	assert.Equal(t, "Disabled", info.PublicNetworkAccess)
+}

--- a/server/azure/cache/properties_sdk_test.go
+++ b/server/azure/cache/properties_sdk_test.go
@@ -157,6 +157,36 @@ func TestSDKAzureCacheRedisPropertiesRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSDKAzureCacheOmittedPropertiesDefaults verifies a create that omits
+// enableNonSslPort and publicNetworkAccess reads back the Azure defaults
+// (enableNonSslPort=false, publicNetworkAccess=Enabled) rather than a null —
+// real Azure persists and returns these on every cache, so an SDK caller that
+// dereferences the pointer must not hit a nil.
+func TestSDKAzureCacheOmittedPropertiesDefaults(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	createCache(t, client, "defaults-cache")
+
+	got, err := client.Get(ctx, testRG, "defaults-cache", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	props := got.Properties
+	if props == nil {
+		t.Fatal("expected properties on response")
+	}
+
+	if props.EnableNonSSLPort == nil || *props.EnableNonSSLPort {
+		t.Errorf("enableNonSslPort = %v, want false (default)", props.EnableNonSSLPort)
+	}
+
+	if props.PublicNetworkAccess == nil || *props.PublicNetworkAccess != armredis.PublicNetworkAccessEnabled {
+		t.Errorf("publicNetworkAccess = %v, want Enabled (default)", props.PublicNetworkAccess)
+	}
+}
+
 // assertRedisConfig checks both a typed key (maxmemory-policy) and an
 // unmodeled passthrough key (maxmemory-reserved, decoded into
 // AdditionalProperties) survive the round-trip.


### PR DESCRIPTION
## Summary
Real-user e2e audit of the Azure Cache for Redis (Microsoft.Cache/redis) control plane, driven against a running server with the real `armredis` SDK and the standalone `serve` binary, reconciled to the ARM REST reference (Redis Get, api-version 2024-11-01).

## Fixed divergence
A create that **omits** `enableNonSslPort` and `publicNetworkAccess` read them back as `null`. Real Azure persists and returns the ARM `RedisResource` schema defaults on every cache — `enableNonSslPort: false` and `publicNetworkAccess: "Enabled"` — so an SDK caller dereferencing the pointer got a nil instead of the value it would see against the real service.

The defaults are applied at create time in the Azure provider, so they:
- persist and appear on create / get / list,
- survive a partial (tags/scale-only) PATCH via the existing nil-mask in `UpdateCache`,
- never override an explicit request value.

Verified black-box before/after via curl through the HTTPS `serve` listener and via the real `armredis` SDK (`enableNonSslPort=<nil>` -> `false`, `publicNetworkAccess=<nil>` -> `Enabled`). Existing lifecycle, provisioningState->Succeeded waiter, ports, hostName, SKU/clustering round-trip, listKeys/regenerateKey, and idempotent DELETE (200 then 204) all continue to pass.

## Tests
- `providers/azure/cache`: `TestCreateCacheAppliesAzureDefaults`, `TestCreateCacheKeepsExplicitProperties`.
- `server/azure/cache`: `TestSDKAzureCacheOmittedPropertiesDefaults` (real SDK Get asserts the defaults).

## Filed, not fixed (precise loci in the branch findings ledger)
- `type`/`id` casing: emulator emits `Microsoft.Cache/redis` where real Azure returns `Microsoft.Cache/Redis` (capital R) in `type`/`id` while the URL segment stays lowercase. Cosmetic (Terraform parses IDs case-insensitively). Not fixed here because capitalizing the response `id` desyncs the shared property-overlay keys (capture keys off the response `id`, DELETE-evict off the lowercase URL segment) — a correct fix must touch `server/azure/echo_properties.go`, out of this scoped audit.
- Child-resource / feature gaps: `firewallRules`, `patchSchedules`, `linkedServers` (geo-replication) are unbuilt (Terraform `azurerm_redis_firewall_rule` / `patch_schedule` / `azurerm_redis_linked_server`); SKU capacity-range validation (C 0-6 / P 1-4) absent. Not half-built.

## Gates
`go build ./...`; `go test -race` on providers/azure/cache + server/azure/cache + services/cache; `go vet`; `gofmt -l` clean; `golangci-lint --new-from-rev=origin/development` 0 issues; `go generate ./...` no docs/coverage diff.