### PR TITLE
fix(cloudrun): real-user e2e divergences from GCP

### DIFF
--- a/providers/gcp/cloudrun/cloudrun.go
+++ b/providers/gcp/cloudrun/cloudrun.go
@@ -114,8 +114,8 @@ func (m *Mock) CreateJob(_ context.Context, cfg driver.JobConfig) (*driver.Job, 
 		Containers:           cloneContainers(cfg.Containers),
 		Labels:               cloneMap(cfg.Labels),
 		Annotations:          cloneMap(cfg.Annotations),
-		Conditions:           []driver.Condition{{Type: condReady, State: stateSucceeded, Reason: "Ready"}},
-		TerminalCondition:    &driver.Condition{Type: condReady, State: stateSucceeded, Reason: "Ready"},
+		Conditions:           []driver.Condition{{Type: condReady, State: stateSucceeded}},
+		TerminalCondition:    &driver.Condition{Type: condReady, State: stateSucceeded},
 		Etag:                 newEtag(now, 1),
 	}
 

--- a/providers/gcp/cloudrun/engine.go
+++ b/providers/gcp/cloudrun/engine.go
@@ -168,7 +168,7 @@ func aggregateExecution(exec *driver.Execution, tasks []driver.Task, succeeded i
 	exec.LogURI = logURI(exec)
 
 	if exec.FailedCount == 0 {
-		exec.Conditions = []driver.Condition{{Type: condCompleted, State: stateSucceeded, Reason: "Completed"}}
+		exec.Conditions = []driver.Condition{{Type: condCompleted, State: stateSucceeded}}
 
 		return
 	}
@@ -247,7 +247,7 @@ func (m *Mock) failureMessage(
 func markSucceeded(exec *driver.Execution, cstats []driver.ContainerStatus) {
 	exec.Tasks = buildTasks(exec.TaskCount, taskSucceeded, 0, cstats)
 	exec.SucceededCount = exec.TaskCount
-	exec.Conditions = []driver.Condition{{Type: condCompleted, State: stateSucceeded, Reason: "Completed"}}
+	exec.Conditions = []driver.Condition{{Type: condCompleted, State: stateSucceeded}}
 	exec.LogURI = logURI(exec)
 }
 

--- a/providers/gcp/cloudrun/services.go
+++ b/providers/gcp/cloudrun/services.go
@@ -424,7 +424,7 @@ func (m *Mock) materializeRevision(svc *driver.Service, now time.Time) *driver.R
 		ExecutionEnvironment: svc.ExecutionEnvironment,
 		VPCAccess:            cloneVPCAccess(svc.VPCAccess),
 		Scaling:              cloneScaling(svc.Scaling),
-		Conditions:           []driver.Condition{{Type: condReady, State: stateSucceeded, Reason: "Ready"}},
+		Conditions:           []driver.Condition{{Type: condReady, State: stateSucceeded}},
 		Etag:                 newEtag(now, svc.Generation),
 	}
 
@@ -461,8 +461,8 @@ func reconcileStatus(svc *driver.Service, now time.Time, region string) {
 	}
 
 	svc.TrafficStatuses = trafficStatuses(svc)
-	svc.TerminalCondition = &driver.Condition{Type: condReady, State: stateSucceeded, Reason: "Ready"}
-	svc.Conditions = []driver.Condition{{Type: condReady, State: stateSucceeded, Reason: "Ready"}}
+	svc.TerminalCondition = &driver.Condition{Type: condReady, State: stateSucceeded}
+	svc.Conditions = []driver.Condition{{Type: condReady, State: stateSucceeded}}
 }
 
 // regionOrDefault falls back to a canonical region when the path carried none.

--- a/server/gcp/cloudrun/cloudrun_test.go
+++ b/server/gcp/cloudrun/cloudrun_test.go
@@ -82,6 +82,17 @@ func postJSON(t *testing.T, url string, body any) map[string]any {
 	return decode(t, resp)
 }
 
+func encodeBody(t *testing.T, body any) *bytes.Buffer {
+	t.Helper()
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(body); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	return &buf
+}
+
 func getJSON(t *testing.T, url string) (map[string]any, int) {
 	t.Helper()
 

--- a/server/gcp/cloudrun/enums.go
+++ b/server/gcp/cloudrun/enums.go
@@ -1,0 +1,145 @@
+package cloudrun
+
+import "encoding/json"
+
+// The Cloud Run v2 GAPIC REST client (cloud.google.com/go/run/apiv2) marshals
+// request bodies with protojson's UseEnumNumbers option, so every enum field —
+// ingress, launchStage, executionEnvironment, vpcAccess.egress, traffic.type,
+// condition.state — arrives on the wire as its integer value rather than its
+// canonical name. Real Cloud Run's protojson-based server accepts both forms;
+// string clients (Terraform's google provider, gcloud) send the names. To match
+// the server for every client, normalizeEnumNumbers rewrites any integer enum
+// value back to its canonical name before the body is decoded, so the driver
+// stores and echoes the same names regardless of which client wrote them.
+//
+// Only fields whose names uniquely identify a Cloud Run enum are rewritten, and
+// only when their value is a JSON number, so genuine numeric fields (ports,
+// task counts, traffic percent, instance counts, generations) are left intact.
+func normalizeEnumNumbers(raw []byte) []byte {
+	var root any
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return raw // let the strict decode surface the parse error
+	}
+
+	walkEnums(root)
+
+	out, err := json.Marshal(root)
+	if err != nil {
+		return raw
+	}
+
+	return out
+}
+
+// walkEnums recursively rewrites integer enum values to their canonical names.
+func walkEnums(v any) {
+	switch t := v.(type) {
+	case map[string]any:
+		for k, val := range t {
+			if n, ok := val.(float64); ok {
+				if name, ok := enumName(k, int(n)); ok {
+					t[k] = name
+				}
+
+				continue
+			}
+
+			walkEnums(val)
+		}
+	case []any:
+		for _, e := range t {
+			walkEnums(e)
+		}
+	}
+}
+
+// enumName maps a (field, integer) pair to the canonical enum name, returning
+// ok=false when the field is not a known Cloud Run enum (so the value is left
+// untouched). Each table is indexed by the enum's proto integer value — index 0
+// is the UNSPECIFIED default and is never emitted, so it maps to no name — and
+// mirrors google.cloud.run.v2 / google.api.LaunchStage exactly.
+func enumName(field string, n int) (string, bool) {
+	switch field {
+	case "ingress":
+		return byIndex(ingressNames(), n)
+	case "launchStage":
+		return byIndex(launchStageNames(), n)
+	case "executionEnvironment":
+		return byIndex(execEnvNames(), n)
+	case "egress":
+		return byIndex(egressNames(), n)
+	case "type":
+		return byIndex(trafficTypeNames(), n)
+	case "state":
+		return byIndex(conditionStateNames(), n)
+	default:
+		return "", false
+	}
+}
+
+// byIndex resolves an enum's integer value against its ordinal name table,
+// returning ok=false for the unspecified/out-of-range default.
+func byIndex(names []string, n int) (string, bool) {
+	if n <= 0 || n >= len(names) || names[n] == "" {
+		return "", false
+	}
+
+	return names[n], true
+}
+
+func ingressNames() []string {
+	return []string{
+		"", // INGRESS_TRAFFIC_UNSPECIFIED
+		"INGRESS_TRAFFIC_ALL",
+		"INGRESS_TRAFFIC_INTERNAL_ONLY",
+		"INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER",
+		"INGRESS_TRAFFIC_NONE",
+	}
+}
+
+func launchStageNames() []string {
+	return []string{
+		"", // LAUNCH_STAGE_UNSPECIFIED
+		"EARLY_ACCESS",
+		"ALPHA",
+		"BETA",
+		"GA",
+		"DEPRECATED",
+		"UNIMPLEMENTED",
+		"PRELAUNCH",
+	}
+}
+
+func execEnvNames() []string {
+	return []string{
+		"", // EXECUTION_ENVIRONMENT_UNSPECIFIED
+		"EXECUTION_ENVIRONMENT_GEN1",
+		"EXECUTION_ENVIRONMENT_GEN2",
+	}
+}
+
+func egressNames() []string {
+	return []string{
+		"", // VPC_EGRESS_UNSPECIFIED
+		"ALL_TRAFFIC",
+		"PRIVATE_RANGES_ONLY",
+	}
+}
+
+func trafficTypeNames() []string {
+	return []string{
+		"", // TRAFFIC_TARGET_ALLOCATION_TYPE_UNSPECIFIED
+		"TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST",
+		"TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION",
+	}
+}
+
+func conditionStateNames() []string {
+	return []string{
+		"", // STATE_UNSPECIFIED
+		"CONDITION_PENDING",
+		"CONDITION_RECONCILING",
+		"CONDITION_FAILED",
+		"CONDITION_SUCCEEDED",
+	}
+}

--- a/server/gcp/cloudrun/handler.go
+++ b/server/gcp/cloudrun/handler.go
@@ -41,6 +41,7 @@ package cloudrun
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -68,6 +69,7 @@ const (
 	jobTypeURL         = "type.googleapis.com/google.cloud.run.v2.Job"
 	execTypeURL        = "type.googleapis.com/google.cloud.run.v2.Execution"
 	serviceTypeURL     = "type.googleapis.com/google.cloud.run.v2.Service"
+	revisionTypeURL    = "type.googleapis.com/google.cloud.run.v2.Revision"
 	defaultPageSize    = 100
 )
 
@@ -245,13 +247,26 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, p *crPath) {
 	writeJSON(w, http.StatusOK, listJobsResponse{Jobs: items, NextPageToken: next})
 }
 
+// deleteJob inlines the deleted job in the LRO response, matching real Cloud
+// Run's Jobs.Delete (whose operation resolves to the removed Job, as the GAPIC
+// DeleteJobOperation.Wait expects).
 func (h *Handler) deleteJob(w http.ResponseWriter, r *http.Request, p *crPath) {
+	job, err := h.cr.GetJob(r.Context(), p.name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	if err := h.cr.DeleteJob(r.Context(), p.name); err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	writeJSON(w, http.StatusOK, operation{Name: opName(p, "delete-"+p.name), Done: true})
+	writeJSON(w, http.StatusOK, operation{
+		Name:     opName(p, "delete-"+p.name),
+		Done:     true,
+		Response: asResponse(toJobResource(job, p), jobTypeURL),
+	})
 }
 
 func (h *Handler) run(w http.ResponseWriter, r *http.Request, p *crPath) {
@@ -521,7 +536,18 @@ func asResponse(v any, typeURL string) map[string]any {
 func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
 
-	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "invalid JSON: "+err.Error())
+		return false
+	}
+
+	// The GAPIC v2 REST client sends enum fields as integers (protojson
+	// UseEnumNumbers); rewrite them to their canonical names so the body decodes
+	// the same way a string-based client's (Terraform, gcloud) does.
+	raw = normalizeEnumNumbers(raw)
+
+	if err := json.Unmarshal(raw, v); err != nil {
 		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "invalid JSON: "+err.Error())
 		return false
 	}

--- a/server/gcp/cloudrun/services.go
+++ b/server/gcp/cloudrun/services.go
@@ -224,13 +224,27 @@ func (h *Handler) listServices(w http.ResponseWriter, r *http.Request, p *crPath
 	writeJSON(w, http.StatusOK, listServicesResponse{Services: items, NextPageToken: next})
 }
 
+// deleteService inlines the deleted service in the LRO response — real Cloud
+// Run's Services.Delete returns the removed Service, and the GAPIC
+// DeleteServiceOperation.Wait unmarshals the operation response into a Service,
+// erroring on an empty payload.
 func (h *Handler) deleteService(w http.ResponseWriter, r *http.Request, p *crPath) {
+	svc, err := h.cr.GetService(r.Context(), p.name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	if err := h.cr.DeleteService(r.Context(), p.name); err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	writeJSON(w, http.StatusOK, operation{Name: opName(p, "delete-"+p.name), Done: true})
+	writeJSON(w, http.StatusOK, operation{
+		Name:     opName(p, "delete-"+p.name),
+		Done:     true,
+		Response: asResponse(toServiceResource(svc, p), serviceTypeURL),
+	})
 }
 
 func (h *Handler) listRevisions(w http.ResponseWriter, r *http.Request, p *crPath) {
@@ -252,13 +266,26 @@ func (h *Handler) getRevision(w http.ResponseWriter, r *http.Request, p *crPath)
 	writeJSON(w, http.StatusOK, toRevisionResource(rev, p))
 }
 
+// deleteRevision inlines the deleted revision in the LRO response, matching
+// real Cloud Run's Revisions.Delete (whose operation resolves to the removed
+// Revision, as the GAPIC DeleteRevisionOperation.Wait expects).
 func (h *Handler) deleteRevision(w http.ResponseWriter, r *http.Request, p *crPath) {
+	rev, err := h.cr.GetRevision(r.Context(), p.subName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	if err := h.cr.DeleteRevision(r.Context(), p.subName); err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	writeJSON(w, http.StatusOK, operation{Name: opName(p, "delete-rev-"+p.subName), Done: true})
+	writeJSON(w, http.StatusOK, operation{
+		Name:     opName(p, "delete-rev-"+p.subName),
+		Done:     true,
+		Response: asResponse(toRevisionResource(rev, p), revisionTypeURL),
+	})
 }
 
 // serviceConfigFromWire maps a wire Service body onto a driver.ServiceConfig.

--- a/server/gcp/cloudrun/services_enum_test.go
+++ b/server/gcp/cloudrun/services_enum_test.go
@@ -1,0 +1,166 @@
+package cloudrun_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+func servicesURL(base string) string {
+	return base + "/v2/projects/" + project + "/locations/" + location + "/services"
+}
+
+// numericEnumServiceBody mirrors what the Cloud Run v2 GAPIC REST client
+// (cloud.google.com/go/run/apiv2) puts on the wire: every enum field is a raw
+// integer (protojson UseEnumNumbers), not its canonical name.
+func numericEnumServiceBody() map[string]any {
+	return map[string]any{
+		"ingress":     1, // INGRESS_TRAFFIC_ALL
+		"launchStage": 4, // GA
+		"template": map[string]any{
+			"executionEnvironment": 2,                           // EXECUTION_ENVIRONMENT_GEN2
+			"vpcAccess":            map[string]any{"egress": 1}, // ALL_TRAFFIC
+			"containers":           []map[string]any{{"image": "busybox"}},
+		},
+		"traffic": []map[string]any{{"type": 1, "percent": 100}}, // ..._LATEST
+	}
+}
+
+// TestCreateServiceAcceptsNumericEnums proves the wire handler decodes the
+// integer enum values the GAPIC v2 REST client sends and echoes them back as
+// the canonical names every string client (Terraform, gcloud) expects.
+func TestCreateServiceAcceptsNumericEnums(t *testing.T) {
+	srv := newServer(t, nil)
+
+	createOp := postJSON(t, servicesURL(srv.URL)+"?serviceId=enum-svc", numericEnumServiceBody())
+	if done, _ := createOp["done"].(bool); !done {
+		t.Fatalf("create op not done (numeric enums rejected?): %+v", createOp)
+	}
+
+	got, code := getJSON(t, servicesURL(srv.URL)+"/enum-svc")
+	if code != http.StatusOK {
+		t.Fatalf("get service code = %d body = %+v", code, got)
+	}
+
+	if got["ingress"] != "INGRESS_TRAFFIC_ALL" {
+		t.Errorf("ingress = %v, want INGRESS_TRAFFIC_ALL", got["ingress"])
+	}
+
+	if got["launchStage"] != "GA" {
+		t.Errorf("launchStage = %v, want GA", got["launchStage"])
+	}
+
+	tmpl, _ := got["template"].(map[string]any)
+	if tmpl["executionEnvironment"] != "EXECUTION_ENVIRONMENT_GEN2" {
+		t.Errorf("executionEnvironment = %v, want EXECUTION_ENVIRONMENT_GEN2", tmpl["executionEnvironment"])
+	}
+
+	vpc, _ := tmpl["vpcAccess"].(map[string]any)
+	if vpc["egress"] != "ALL_TRAFFIC" {
+		t.Errorf("vpcAccess.egress = %v, want ALL_TRAFFIC", vpc["egress"])
+	}
+
+	traffic, _ := got["traffic"].([]any)
+	if len(traffic) != 1 {
+		t.Fatalf("traffic len = %d, want 1", len(traffic))
+	}
+
+	t0, _ := traffic[0].(map[string]any)
+	if t0["type"] != "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST" {
+		t.Errorf("traffic[0].type = %v, want ..._LATEST", t0["type"])
+	}
+}
+
+// TestUpdateServiceAcceptsNumericEnums proves the full-object round-trip the
+// GAPIC client performs on UpdateService — which re-sends every field it read,
+// including output-only enums (terminalCondition.state, trafficStatuses.type) —
+// decodes without a 400.
+func TestUpdateServiceAcceptsNumericEnums(t *testing.T) {
+	srv := newServer(t, nil)
+
+	postJSON(t, servicesURL(srv.URL)+"?serviceId=enum-svc", numericEnumServiceBody())
+
+	// A body carrying numeric output-only enums, as the client echoes on update.
+	patch := map[string]any{
+		"ingress":           1,
+		"launchStage":       4,
+		"terminalCondition": map[string]any{"type": "Ready", "state": 4}, // CONDITION_SUCCEEDED
+		"trafficStatuses":   []map[string]any{{"type": 1, "percent": 100}},
+		"template": map[string]any{
+			"executionEnvironment": 1, // GEN1
+			"containers":           []map[string]any{{"image": "busybox:v2"}},
+		},
+	}
+
+	req, _ := http.NewRequest(http.MethodPatch, servicesURL(srv.URL)+"/enum-svc", encodeBody(t, patch))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("update code = %d, want 200 (numeric enums rejected?)", resp.StatusCode)
+	}
+
+	got, _ := getJSON(t, servicesURL(srv.URL)+"/enum-svc")
+	tmpl, _ := got["template"].(map[string]any)
+	if tmpl["executionEnvironment"] != "EXECUTION_ENVIRONMENT_GEN1" {
+		t.Errorf("executionEnvironment after update = %v, want GEN1", tmpl["executionEnvironment"])
+	}
+}
+
+// TestDeleteServiceReturnsDeletedResource proves the delete LRO inlines the
+// removed Service in its response, as real Cloud Run does and the GAPIC
+// DeleteServiceOperation.Wait requires.
+func TestDeleteServiceReturnsDeletedResource(t *testing.T) {
+	srv := newServer(t, nil)
+
+	postJSON(t, servicesURL(srv.URL)+"?serviceId=del-svc",
+		map[string]any{"template": map[string]any{"containers": []map[string]any{{"image": "busybox"}}}})
+
+	req, _ := http.NewRequest(http.MethodDelete, servicesURL(srv.URL)+"/del-svc", nil)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+
+	delOp := decode(t, resp)
+	if done, _ := delOp["done"].(bool); !done {
+		t.Fatalf("delete op not done: %+v", delOp)
+	}
+
+	respObj, _ := delOp["response"].(map[string]any)
+	if respObj["@type"] != "type.googleapis.com/google.cloud.run.v2.Service" {
+		t.Fatalf("delete response @type = %v, want Service", respObj["@type"])
+	}
+
+	wantName := "projects/" + project + "/locations/" + location + "/services/del-svc"
+	if respObj["name"] != wantName {
+		t.Errorf("deleted service name = %v, want %v", respObj["name"], wantName)
+	}
+}
+
+// TestSuccessConditionOmitsReason proves a successful terminalCondition carries
+// no reason — real Cloud Run leaves reason unset on CONDITION_SUCCEEDED (reason
+// is a typed enum, and no value names "Ready").
+func TestSuccessConditionOmitsReason(t *testing.T) {
+	srv := newServer(t, nil)
+
+	postJSON(t, servicesURL(srv.URL)+"?serviceId=cond-svc",
+		map[string]any{"template": map[string]any{"containers": []map[string]any{{"image": "busybox"}}}})
+
+	got, _ := getJSON(t, servicesURL(srv.URL)+"/cond-svc")
+
+	tc, _ := got["terminalCondition"].(map[string]any)
+	if tc["state"] != "CONDITION_SUCCEEDED" {
+		t.Fatalf("terminalCondition.state = %v, want CONDITION_SUCCEEDED", tc["state"])
+	}
+
+	if _, ok := tc["reason"]; ok {
+		t.Errorf("terminalCondition unexpectedly carries reason = %v", tc["reason"])
+	}
+}


### PR DESCRIPTION
Real-user e2e audit of GCP Cloud Run (v2 Admin API) against the official Go SDK (cloud.google.com/go/run/apiv2 REST client) and Terraform (google_cloud_run_v2_service). Three genuine cloud-vs-cloudemu divergences found and fixed.

## Findings

**1. (HIGH) Official Go SDK cannot update/create with enums.** The v2 GAPIC REST client marshals requests with protojson `UseEnumNumbers: true`, so every enum field (ingress, launchStage, executionEnvironment, vpcAccess.egress, traffic.type, condition.state) is sent as an integer. Real Cloud Run's protojson server accepts both the integer and the name; the wire handler only accepted names, so UpdateService (and any create carrying an enum) failed with `400 cannot unmarshal number into ...ingress of type string`. Fixed with a `normalizeEnumNumbers` pre-pass in `decodeJSON` that rewrites integer enum values to their canonical names before decode (only known enum field-names with numeric values are touched; ports, counts, percent, generation are left intact).

**2. (HIGH) Delete LRO returned no resource.** `DeleteServiceOperation.Wait` / `DeleteJobOperation.Wait` / `DeleteRevisionOperation.Wait` failed with `unsupported result type <nil>` because the delete operation carried an empty response. Real Cloud Run's delete LRO resolves to the deleted resource; the handlers now GET the resource before deletion and inline it in the operation response.

**3. (LOW) Bogus reason on success conditions.** `terminalCondition`/`conditions` carried `reason:"Ready"` (executions `"Completed"`), but real Cloud Run omits `reason` on `CONDITION_SUCCEEDED` and no reason enum value names "Ready" (the GAPIC client decoded it as `COMMON_REASON_UNDEFINED`). Dropped the reason from success conditions.

## Verification
- Official Go SDK (run/apiv2 REST): full create -> LRO Wait -> get -> list -> update -> list revisions -> delete -> 404 lifecycle passes.
- Terraform (provider v8.1.0): create -> Ready (terminal_condition CONDITION_SUCCEEDED, no apply hang) -> plan clean (no drift) -> update (new revision) -> destroy passes.
- New wire tests cover numeric-enum create/update decode, delete-returns-resource, and reason omission.
- Gates: build, `go test -race` (providers/gcp/cloudrun + server/gcp/...), vet, gofmt, golangci-lint (new-from-development) all green; `go generate` produces no docs diff.