### PR TITLE
fix(memorydb): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/memorydb/acls_users.go
+++ b/providers/aws/memorydb/acls_users.go
@@ -105,7 +105,7 @@ func (m *Mock) CreateACL(_ context.Context, name string, userNames []string, tag
 	users := dedupeStrings(userNames)
 
 	acl := mdbdriver.ACL{
-		Name: name, ARN: m.arn("acl", name), Status: mdbdriver.StatusAvailable,
+		Name: name, ARN: m.arn("acl", name), Status: mdbdriver.StatusActive,
 		MinimumEngineVersion: "6.2", UserNames: users, Tags: copyTags(tags),
 	}
 	m.acls.Set(name, acl)
@@ -197,6 +197,9 @@ func (m *Mock) DeleteACL(_ context.Context, name string) (*mdbdriver.ACL, error)
 
 	m.acls.Delete(name)
 
+	// The delete response reports the transient deleting status, mirroring
+	// DeleteCluster and real MemoryDB (the row itself is already removed).
+	acl.Status = mdbdriver.StatusDeleting
 	out := cloneACL(&acl)
 
 	return &out, nil
@@ -234,7 +237,7 @@ func (m *Mock) CreateUser(_ context.Context, cfg mdbdriver.CreateUserConfig) (*m
 	}
 
 	user := mdbdriver.User{
-		Name: cfg.Name, ARN: m.arn("user", cfg.Name), Status: mdbdriver.StatusAvailable,
+		Name: cfg.Name, ARN: m.arn("user", cfg.Name), Status: mdbdriver.StatusActive,
 		AccessString: cfg.AccessString, MinimumEngineVersion: "6.2",
 		Authentication: mdbdriver.Authentication{Type: authType(cfg.AuthenticationType), PasswordCount: len(cfg.Passwords)},
 		Tags:           copyTags(cfg.Tags),
@@ -297,6 +300,9 @@ func (m *Mock) DeleteUser(_ context.Context, name string) (*mdbdriver.User, erro
 
 	m.users.Delete(name)
 
+	// The delete response reports the transient deleting status, mirroring
+	// DeleteCluster and real MemoryDB (the row itself is already removed).
+	u.Status = mdbdriver.StatusDeleting
 	out := cloneUser(&u)
 
 	return &out, nil

--- a/providers/aws/memorydb/memorydb.go
+++ b/providers/aws/memorydb/memorydb.go
@@ -85,7 +85,7 @@ func New(opts *config.Options) *Mock {
 	// Account-default resources (present in every real MemoryDB account).
 	m.acls.Set("open-access", mdbdriver.ACL{
 		Name: "open-access", ARN: m.arn("acl", "open-access"),
-		Status: mdbdriver.StatusAvailable, MinimumEngineVersion: "6.2",
+		Status: mdbdriver.StatusActive, MinimumEngineVersion: "6.2",
 	})
 	m.parameterGroups.Set("default.memorydb-redis7", mdbdriver.ParameterGroup{
 		Name: "default.memorydb-redis7", ARN: m.arn("parametergroup", "default.memorydb-redis7"),

--- a/providers/aws/memorydb/memorydb_test.go
+++ b/providers/aws/memorydb/memorydb_test.go
@@ -329,12 +329,21 @@ func TestACLUserLinkage(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	if _, err := m.CreateUser(ctx, mdbdriver.CreateUserConfig{Name: "u1", AccessString: "on ~* +@all"}); err != nil {
-		t.Fatalf("CreateUser: %v", err)
+	user, err := m.CreateUser(ctx, mdbdriver.CreateUserConfig{Name: "u1", AccessString: "on ~* +@all"})
+	requireNoError(t, err)
+
+	// A user's terminal status is "active", not "available" (MemoryDB reserves
+	// "available" for clusters/snapshots); the Terraform user waiter requires it.
+	if user.Status != mdbdriver.StatusActive {
+		t.Fatalf("user status = %q, want %q", user.Status, mdbdriver.StatusActive)
 	}
 
 	acl, err := m.CreateACL(ctx, "acl1", []string{"u1"}, nil)
 	requireNoError(t, err)
+
+	if acl.Status != mdbdriver.StatusActive {
+		t.Fatalf("ACL status = %q, want %q", acl.Status, mdbdriver.StatusActive)
+	}
 
 	if len(acl.UserNames) != 1 {
 		t.Fatalf("ACL users: %+v", acl.UserNames)
@@ -364,8 +373,19 @@ func TestACLUserLinkage(t *testing.T) {
 		t.Fatalf("UpdateACL: %v", err)
 	}
 
-	if _, err := m.DeleteUser(ctx, "u1"); err != nil {
+	deleted, err := m.DeleteUser(ctx, "u1")
+	if err != nil {
 		t.Errorf("delete user after ACL removal: %v", err)
+	} else if deleted.Status != mdbdriver.StatusDeleting {
+		t.Errorf("delete-user status = %q, want %q", deleted.Status, mdbdriver.StatusDeleting)
+	}
+
+	// The default open-access ACL a real account ships with is reported "active".
+	acls, err := m.DescribeACLs(ctx, []string{"open-access"})
+	requireNoError(t, err)
+
+	if len(acls) != 1 || acls[0].Status != mdbdriver.StatusActive {
+		t.Fatalf("open-access ACL = %+v, want status %q", acls, mdbdriver.StatusActive)
 	}
 }
 

--- a/server/aws/memorydb/sdk_roundtrip_test.go
+++ b/server/aws/memorydb/sdk_roundtrip_test.go
@@ -377,8 +377,23 @@ func TestSDKACLUpdateDeleteAndUserUpdate(t *testing.T) {
 		t.Fatalf("expected 1 user on acl2, got %d", len(upd.ACL.UserNames))
 	}
 
-	if _, err := client.DeleteACL(ctx, &awsmemorydb.DeleteACLInput{ACLName: aws.String("acl2")}); err != nil {
+	// MemoryDB reports ACLs/users as "active" (not "available"), and the Terraform
+	// aws_memorydb_acl / aws_memorydb_user create waiters block until they observe it.
+	if got := aws.ToString(upd.ACL.Status); got != "active" {
+		t.Fatalf("ACL status = %q, want active", got)
+	}
+
+	if got := aws.ToString(users.Users[0].Status); got != "active" {
+		t.Fatalf("user status = %q, want active", got)
+	}
+
+	del, err := client.DeleteACL(ctx, &awsmemorydb.DeleteACLInput{ACLName: aws.String("acl2")})
+	if err != nil {
 		t.Fatalf("DeleteACL: %v", err)
+	}
+
+	if got := aws.ToString(del.ACL.Status); got != "deleting" {
+		t.Fatalf("DeleteACL status = %q, want deleting", got)
 	}
 }
 

--- a/services/memorydb/driver/driver.go
+++ b/services/memorydb/driver/driver.go
@@ -32,6 +32,11 @@ const (
 	StatusUpdating     = "updating"
 	StatusDeleting     = "deleting"
 	StatusSnapshotting = "snapshotting"
+	// StatusActive is the terminal status for ACLs and users. MemoryDB reports
+	// clusters and snapshots as "available" but ACLs/users as "active" (ACL:
+	// creating|active|modifying|deleting; User: active|modifying|deleting), which
+	// their Terraform waiters require.
+	StatusActive = "active"
 )
 
 // Endpoint is an address:port a client connects to.


### PR DESCRIPTION
## Summary

Real-user e2e audit (SDK + aws-cli + Terraform) of AWS MemoryDB against the
documented AWS behavior. MemoryDB is already fully built; this fixes genuine
control-plane divergences that break real Terraform users.

## Findings fixed

| # | Sev | Divergence | AWS docs | Fix |
|---|-----|-----------|----------|-----|
| 1 | HIGH | ACL terminal `Status` was `"available"`; MemoryDB uses `"active"`. Terraform's `aws_memorydb_acl` create waiter (target `active`) errors — `unexpected state 'available', wanted target 'active'` — which blocks every `aws_memorydb_cluster` apply that depends on an ACL. | `API_ACL.html`: Status ∈ `creating\|active\|modifying\|deleting` | new `StatusActive`; default open-access ACL + `CreateACL` → active |
| 2 | HIGH | User terminal `Status` was `"available"`; MemoryDB uses `"active"` (same Terraform waiter class). | `API_User.html`: Status ∈ `active\|modifying\|deleting` | `CreateUser` → active |
| 3 | LOW | `DeleteACL`/`DeleteUser` responses returned the stored `active`; MemoryDB (and `DeleteCluster` here) returns the transient `deleting`. | delete responses report `deleting` | returned copy `Status` → deleting |

Clusters and snapshots correctly keep `"available"` and are unchanged.

## Live evidence

- **Terraform:** full stack (`user` + `acl` + `parameter_group` + `subnet_group` + `cluster`) — before fix, apply aborted at the ACL waiter; after fix, apply (5 added) → clean plan → in-place update (replicas 1→2, tags) → clean plan → destroy (5 destroyed).
- **aws-cli:** open-access ACL = `active`, create user/acl = `active`, delete acl/user = `deleting`; error faults clean and correctly coded.
- **SDK:** existing + new roundtrip assertions green under `-race`.

## Filed, not fixed (out of scope; no genuine user break)

- **Timestamp marshaling:** `Node.CreateTime`, `ServiceUpdate.ReleaseDate/AutoUpdateStartDate`, `ReservedNode.StartTime` are omitted from wire responses because AWS JSON 1.1 encodes timestamps as epoch numbers while `encoding/json` emits RFC3339 for `time.Time` (which would break SDK deserialization). Correct fix is a custom epoch-seconds marshaler; no Terraform/CLI user reads these.
- **`ShowShardDetails` leniency:** `DescribeClusters` returns `Shards[]` regardless of the flag (AWS omits unless `true`). Leniency only; Terraform sets it `true`.
- **RESP data plane:** no Redis data plane unless `config.CacheEngine` is wired (the real-engine seam already exists).

## Gates

`go build ./...` · `go vet` · `gofmt -l` clean · `go test -race -count=1` (providers/aws/memorydb, server/aws/memorydb, services/memorydb) · `go generate ./...` (no docs/coverage diff) · `golangci-lint --new-from-rev=origin/development` = 0 issues.
