### PR TITLE
fix(firestore): real-user e2e divergences from GCP

### DIFF
--- a/server/gcp/firestore/aggregation.go
+++ b/server/gcp/firestore/aggregation.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
-	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 )
 
 // runAggregationQueryRequest mirrors google.firestore.v1.RunAggregationQueryRequest:
@@ -126,24 +125,32 @@ func (h *Handler) aggregationMatches(r *http.Request, base string, q *structured
 		return nil, cerrors.New(cerrors.InvalidArgument, perr.Error())
 	}
 
-	p.collection = joinPath(p.parentPath(), q.From[0].CollectionID)
-	p.documentID = ""
-
 	node, ferr := buildFilterNode(q.Where)
 	if ferr != nil {
 		return nil, cerrors.New(cerrors.InvalidArgument, cerrors.Message(ferr))
 	}
 
-	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: p.tableKey(), Limit: allResults})
-	if err != nil {
-		if cerrors.IsNotFound(err) {
-			return nil, nil
-		}
+	// A collection-group aggregation (allDescendants) counts/sums across every
+	// collection with the given id at any depth, not just the one directly under
+	// the parent; otherwise it scans the single collection under the parent.
+	var (
+		items []map[string]any
+		serr  error
+	)
 
-		return nil, err
+	if q.From[0].AllDescendants {
+		items, serr = h.scanCollectionGroup(r.Context(), p, q.From[0].CollectionID)
+	} else {
+		p.collection = joinPath(p.parentPath(), q.From[0].CollectionID)
+		p.documentID = ""
+		items, serr = h.scanCollectionItems(r.Context(), p.tableKey())
 	}
 
-	matched, merr := filterDocuments(result.Items, node)
+	if serr != nil {
+		return nil, serr
+	}
+
+	matched, merr := filterDocuments(items, node)
 	if merr != nil {
 		return nil, merr
 	}

--- a/server/gcp/firestore/firestore_collectiongroup_test.go
+++ b/server/gcp/firestore/firestore_collectiongroup_test.go
@@ -1,0 +1,136 @@
+package firestore_test
+
+import (
+	"testing"
+
+	gcpfirestore "cloud.google.com/go/firestore"
+)
+
+// TestFirestoreCollectionGroupQuery proves a collection-group query
+// (from.allDescendants=true) matches documents in every collection sharing the
+// group's id at any depth — not just a top-level collection of that name. The
+// audit finding: runQuery/runAggregationQuery ignored allDescendants and scanned
+// only the single collection directly under the request parent, so a real
+// CollectionGroup query silently returned an empty (or wrong) result set.
+func TestFirestoreCollectionGroupQuery(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "cities")
+
+	cities := client.Collection("cities")
+
+	// Landmarks live under three different parent documents at the same depth.
+	seed := []struct {
+		city, id, name string
+		rank           int64
+	}{
+		{"SF", "gg", "Golden Gate", 1},
+		{"SF", "ferry", "Ferry Building", 3},
+		{"LA", "hollywood", "Hollywood Sign", 5},
+	}
+
+	for _, s := range seed {
+		lm := cities.Doc(s.city).Collection("landmarks").Doc(s.id)
+		if _, err := lm.Set(ctx, map[string]any{"name": s.name, "rank": s.rank}); err != nil {
+			t.Fatalf("Set %s/landmarks/%s: %v", s.city, s.id, err)
+		}
+	}
+
+	// A same-named collection at the ROOT must NOT be included: the group id is
+	// "landmarks" as a nested collection; a root "landmarks" doc still counts
+	// because collection-group matches the id at ANY depth including the root.
+	// To keep the assertion crisp we instead add an unrelated root collection.
+	if _, err := client.Collection("parks").Doc("central").Set(ctx, map[string]any{"name": "Central Park"}); err != nil {
+		t.Fatalf("Set parks/central: %v", err)
+	}
+
+	// 1. Bare collection-group query returns all three landmarks.
+	all := collectDocIDs(t, client.CollectionGroup("landmarks").Documents(ctx))
+	if len(all) != 3 || all[0] != "ferry" || all[1] != "gg" || all[2] != "hollywood" {
+		t.Errorf("CollectionGroup(landmarks) = %v, want [ferry gg hollywood]", all)
+	}
+
+	// 2. Each returned document carries its own subcollection resource path, so
+	// the SDK can resolve its parent. Verify one full path.
+	found := map[string]string{}
+
+	it := client.CollectionGroup("landmarks").Documents(ctx)
+
+	for {
+		snap, err := it.Next()
+		if err != nil {
+			break
+		}
+
+		found[snap.Ref.ID] = snap.Ref.Parent.Path
+	}
+
+	if p := found["hollywood"]; p == "" {
+		t.Errorf("hollywood not returned by collection-group query")
+	}
+
+	// 3. Collection-group WHERE filter narrows across all subcollections.
+	filtered := collectDocIDs(t, client.CollectionGroup("landmarks").
+		Where("rank", ">=", int64(3)).Documents(ctx))
+	if len(filtered) != 2 || filtered[0] != "ferry" || filtered[1] != "hollywood" {
+		t.Errorf("CollectionGroup(landmarks).Where(rank>=3) = %v, want [ferry hollywood]", filtered)
+	}
+
+	// 4. OrderBy across the group is honored.
+	ordered := client.CollectionGroup("landmarks").OrderBy("rank", gcpfirestore.Desc).Documents(ctx)
+
+	var order []string
+
+	for {
+		snap, err := ordered.Next()
+		if err != nil {
+			break
+		}
+
+		order = append(order, snap.Ref.ID)
+	}
+
+	if len(order) != 3 || order[0] != "hollywood" || order[2] != "gg" {
+		t.Errorf("CollectionGroup(landmarks).OrderBy(rank desc) = %v, want [hollywood ferry gg]", order)
+	}
+}
+
+// TestFirestoreCollectionGroupAggregation proves a collection-group aggregation
+// (COUNT/SUM) spans every matching subcollection, not just one collection under
+// the parent.
+func TestFirestoreCollectionGroupAggregation(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "cities")
+
+	cities := client.Collection("cities")
+
+	writes := []struct {
+		city, id string
+		rank     int64
+	}{
+		{"SF", "gg", 1},
+		{"SF", "ferry", 3},
+		{"LA", "hollywood", 5},
+	}
+
+	for _, wr := range writes {
+		if _, err := cities.Doc(wr.city).Collection("landmarks").Doc(wr.id).
+			Set(ctx, map[string]any{"rank": wr.rank}); err != nil {
+			t.Fatalf("Set %s/%s: %v", wr.city, wr.id, err)
+		}
+	}
+
+	res, err := client.CollectionGroup("landmarks").
+		NewAggregationQuery().
+		WithCount("total").
+		WithSum("rank", "rank_sum").
+		Get(ctx)
+	if err != nil {
+		t.Fatalf("collection-group aggregation: %v", err)
+	}
+
+	if got := aggInteger(t, res, "total"); got != 3 {
+		t.Errorf("collection-group COUNT = %d, want 3", got)
+	}
+
+	if got := aggInteger(t, res, "rank_sum"); got != 9 {
+		t.Errorf("collection-group SUM(rank) = %d, want 9", got)
+	}
+}

--- a/server/gcp/firestore/handler.go
+++ b/server/gcp/firestore/handler.go
@@ -17,6 +17,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"sort"
 	"strconv"
@@ -69,12 +70,17 @@ const (
 	fieldID         = "\x00id"
 	fieldCreateTime = "\x00createTime"
 	fieldUpdateTime = "\x00updateTime"
+	// fieldCollPath is a transient, never-persisted key set on a cloned item
+	// during a collection-group (allDescendants) query so the response can
+	// reconstruct each document's owning collection path — matched documents
+	// come from many different subcollections, not the query's base collection.
+	fieldCollPath = "\x00collPath"
 )
 
 // isReservedKey reports whether k is a handler-internal item key that must not
 // be emitted as a Firestore document field.
 func isReservedKey(k string) bool {
-	return k == fieldID || k == fieldCreateTime || k == fieldUpdateTime
+	return k == fieldID || k == fieldCreateTime || k == fieldUpdateTime || k == fieldCollPath
 }
 
 // reference is a Go carrier for a Firestore referenceValue: a document
@@ -841,7 +847,8 @@ type runQueryRequest struct {
 
 type structuredQuery struct {
 	From []struct {
-		CollectionID string `json:"collectionId"`
+		CollectionID   string `json:"collectionId"`
+		AllDescendants bool   `json:"allDescendants"`
 	} `json:"from"`
 	Where   *queryFilter    `json:"where"`
 	OrderBy []orderByClause `json:"orderBy"`
@@ -1039,14 +1046,24 @@ func (h *Handler) runQuery(w http.ResponseWriter, r *http.Request, base string) 
 		return
 	}
 
-	p.collection = joinPath(p.parentPath(), req.StructuredQuery.From[0].CollectionID)
-	p.documentID = ""
+	from := req.StructuredQuery.From[0]
 
 	node, ferr := buildFilterNode(req.StructuredQuery.Where)
 	if ferr != nil {
 		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", cerrors.Message(ferr))
 		return
 	}
+
+	// A collection-group query (allDescendants) matches every collection with the
+	// given id at any depth beneath the request's parent, not just the single
+	// collection directly under it, so it scans across driver tables.
+	if from.AllDescendants {
+		h.runGroupQuery(w, r, p, from.CollectionID, node, &req.StructuredQuery)
+		return
+	}
+
+	p.collection = joinPath(p.parentPath(), from.CollectionID)
+	p.documentID = ""
 
 	// Fetch the full collection and evaluate the where clause here with full
 	// grammar fidelity (type-aware, AND/OR/NOT, IN/array-contains, unary). A
@@ -1073,6 +1090,110 @@ func (h *Handler) runQuery(w http.ResponseWriter, r *http.Request, base string) 
 	matched = shapeResults(matched, &req.StructuredQuery)
 
 	streamQueryResults(w, matched, p)
+}
+
+// runGroupQuery serves a collection-group runQuery (from.allDescendants=true).
+// It scans every collection in the request's (project, database) namespace whose
+// final path segment equals collectionID and that is a descendant of the request
+// base, tags each matched document with its owning collection path, then filters,
+// shapes, and streams the combined set. base carries the project/database and the
+// parent path the group is scoped under (empty at the documents root).
+func (h *Handler) runGroupQuery(
+	w http.ResponseWriter, r *http.Request, base firestorePath,
+	collectionID string, node expr.Node, q *structuredQuery,
+) {
+	items, err := h.scanCollectionGroup(r.Context(), base, collectionID)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	matched, merr := filterDocuments(items, node)
+	if merr != nil {
+		writeErr(w, merr)
+		return
+	}
+
+	matched = shapeResults(matched, q)
+
+	streamGroupResults(w, matched, base.project, base.database)
+}
+
+// scanCollectionItems returns every document in a single collection table. A
+// never-written collection has no driver table; real Firestore treats that as an
+// empty result set rather than an error, so NotFound maps to no items.
+func (h *Handler) scanCollectionItems(ctx context.Context, table string) ([]map[string]any, error) {
+	result, err := h.db.Scan(ctx, dbdriver.ScanInput{Table: table, Limit: allResults})
+	if err != nil {
+		if cerrors.IsNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return result.Items, nil
+}
+
+// scanCollectionGroup gathers every document belonging to a collection whose id
+// (final path segment) equals collectionID and that is a descendant of base,
+// within base's (project, database) namespace. Each returned item is a clone
+// tagged with fieldCollPath (its owning collection path) so callers can rebuild
+// the document's resource name. A never-written collection is skipped.
+func (h *Handler) scanCollectionGroup(
+	ctx context.Context, base firestorePath, collectionID string,
+) ([]map[string]any, error) {
+	tables, err := h.db.ListTables(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	nsPrefix := base.namespacePrefix()
+	parent := base.parentPath()
+
+	var items []map[string]any
+
+	for _, t := range tables {
+		if !strings.HasPrefix(t, nsPrefix) {
+			continue
+		}
+
+		coll := t[len(nsPrefix):]
+		if lastPathSegment(coll) != collectionID {
+			continue
+		}
+
+		if parent != "" && !strings.HasPrefix(coll, parent+"/") {
+			continue
+		}
+
+		res, serr := h.db.Scan(ctx, dbdriver.ScanInput{Table: t, Limit: allResults})
+		if serr != nil {
+			if cerrors.IsNotFound(serr) {
+				continue
+			}
+
+			return nil, serr
+		}
+
+		for _, it := range res.Items {
+			tagged := maps.Clone(it)
+			tagged[fieldCollPath] = coll
+			items = append(items, tagged)
+		}
+	}
+
+	return items, nil
+}
+
+// lastPathSegment returns the final "/"-separated segment of a collection path,
+// i.e. its collection id ("cities/SF/landmarks" → "landmarks").
+func lastPathSegment(path string) string {
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		return path[i+1:]
+	}
+
+	return path
 }
 
 // filterDocuments keeps the items matching node (a nil node matches all).
@@ -1111,6 +1232,33 @@ func streamQueryResults(w http.ResponseWriter, items []map[string]any, p firesto
 		}
 
 		id, _ := item[fieldID].(string)
+		doc := mapToDocument(item, p, id)
+
+		_ = json.NewEncoder(w).Encode(runQueryResponseEntry{Document: &doc, ReadTime: now})
+	}
+
+	w.Write([]byte("]")) //nolint:errcheck // best-effort
+}
+
+// streamGroupResults streams collection-group query results. Each item was
+// tagged (in runGroupQuery) with fieldCollPath — its owning collection path —
+// so every document's resource name is rebuilt from its own subcollection
+// rather than a single shared collection.
+func streamGroupResults(w http.ResponseWriter, items []map[string]any, project, database string) {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("[")) //nolint:errcheck // best-effort streaming response
+
+	for i, item := range items {
+		if i > 0 {
+			w.Write([]byte(",")) //nolint:errcheck // best-effort
+		}
+
+		coll, _ := item[fieldCollPath].(string)
+		id, _ := item[fieldID].(string)
+		p := firestorePath{project: project, database: database, collection: coll}
 		doc := mapToDocument(item, p, id)
 
 		_ = json.NewEncoder(w).Encode(runQueryResponseEntry{Document: &doc, ReadTime: now})

--- a/server/gcp/firestore/queryshape.go
+++ b/server/gcp/firestore/queryshape.go
@@ -272,8 +272,10 @@ func selectDoc(item map[string]any, paths []*expr.PathOperand) map[string]any {
 	}
 
 	// Carry the reserved commit-timestamp keys through the projection so a
-	// selected document still reports stable createTime/updateTime.
-	for _, k := range []string{fieldCreateTime, fieldUpdateTime} {
+	// selected document still reports stable createTime/updateTime. fieldCollPath
+	// (set only during a collection-group query) rides along so the projected
+	// document still knows its owning collection path.
+	for _, k := range []string{fieldCreateTime, fieldUpdateTime, fieldCollPath} {
 		if v, ok := item[k]; ok {
 			projected[k] = v
 		}


### PR DESCRIPTION
## Summary

Real-user e2e audit of GCP Firestore (data-plane wire server) driving the real `cloud.google.com/go/firestore` REST client and `firestore/apiv1/admin` GAPIC client against `cloudemu serve`.

## Fixed

**Collection-group queries ignored `allDescendants` (HIGH).** `runQuery` and `runAggregationQuery` built the target as `joinPath(parentPath, from.collectionId)` and scanned that one driver table, ignoring `from.allDescendants`. A real `client.CollectionGroup("landmarks")` query (and its `.NewAggregationQuery()`) therefore silently returned an empty/wrong result set — it only ever saw a top-level collection of that name, never the `cities/*/landmarks` subcollections that collection-group queries exist to span.

Fix:
- `structuredQuery.From[]` gains `allDescendants`; `runQuery` branches to a group path when set.
- New `scanCollectionGroup`: lists driver tables, keeps those in the same project/database namespace whose final path segment == the group id and that are descendants of the request parent, scans each, and tags each document (a clone — never the live stored map) with its owning collection path via a reserved key.
- `streamGroupResults` rebuilds each document's resource name from its own collection path so subcollection docs report the correct parent.
- `aggregationMatches` reuses the same group scan for the aggregation path.
- Reserved key excluded from field output and carried through select projection.

Repro (black-box, real SDK): 3 landmarks under `cities/SF` + `cities/LA2` → `CollectionGroup("landmarks")` returned 1 (root only), now returns 3; `.Where("rank",">=",2)` → 2; `.NewAggregationQuery().WithCount` → 3, `WithSum("rank")` → 9. Verified by new tests in `firestore_collectiongroup_test.go`.

## Verified not a bug
- Data-plane enum carriers (`serverValue`, `direction`) already accept both the enum name and the protobuf integer, so the GAPIC integer-enum class does not bite the built surface.
- Create-dup surfaces as gRPC `Aborted` via the REST transport but carries HTTP 409 ALREADY_EXISTS — expected REST-transport folding, matches real Firestore.
- Value types, NotFound, idempotent delete, and precondition paths all correct.

## Filed, not fixed (large unbuilt surface)
The Firestore **Admin API** (projects.databases, databases.indexes, collectionGroups.fields) is entirely unbuilt — the admin GAPIC client's CreateDatabase/GetDatabase/ListDatabases/CreateIndex all 404 because the data-plane handler's `Matches` greedily claims every `/v1/projects/` path. Precise buildout spec (database LRO for terraform `google_firestore_database`, deleteProtection destroy guard, index LRO, int-enum decode, and tightening the data-plane `Matches`) recorded for a follow-up.

## Gates
`go build ./...`, `go vet`, `gofmt -l`, `go test -race` (server/gcp/firestore + providers/gcp/firestore), `golangci-lint --new-from-rev=origin/development` (0 issues), `go generate ./...` (no docs/coverage diff) — all green.