### PR TITLE
fix(containerapps): real-user e2e divergences from Azure

### DIFF
--- a/providers/azure/containerapps/containerapps.go
+++ b/providers/azure/containerapps/containerapps.go
@@ -40,6 +40,12 @@ const (
 	// synthesized domain label, revision suffix and static IP, so those minted
 	// values are stable per resource yet distinct between resources.
 	shortHashLen = 8
+
+	// Azure server-side defaults a create/update omits, applied so a read-back
+	// matches real Azure instead of reporting empty/nil.
+	defaultActiveRevMode = "Single" // configuration.activeRevisionsMode
+	defaultTransport     = "auto"   // configuration.ingress.transport
+	defaultMaxReplicas   = 10       // template.scale.maxReplicas
 )
 
 // AppLogsConfiguration mirrors the managed environment's log-export setting.
@@ -294,7 +300,8 @@ func (m *Mock) CreateOrUpdateApp(
 	app.Ingress = cloneIngress(in.Ingress)
 	app.SecretNames = append([]string(nil), in.SecretNames...)
 	app.Template = cloneTemplate(in.Template)
-	app.Fqdn = m.appFqdnLocked(name, in.EnvironmentID, in.Ingress)
+	applyAppDefaults(&app)
+	app.Fqdn = m.appFqdnLocked(name, in.EnvironmentID, app.Ingress)
 
 	if err := m.materializeRevisionLocked(&app); err != nil {
 		return ContainerApp{}, false, err
@@ -504,6 +511,36 @@ func staticIP(h string) string {
 	}
 
 	return "20." + strings.Join(octets, ".")
+}
+
+// applyAppDefaults fills the Azure server-side defaults a create/update omits, so
+// a read-back (GET/LIST/discover) matches real Azure: configuration.
+// activeRevisionsMode defaults to Single, an ingress's transport defaults to auto,
+// and a template with containers gets scale.maxReplicas 10. Applied before the
+// revision is materialized so the defaults are part of the content-addressed
+// template and survive a create -> discover round trip. app.Ingress/app.Template
+// are already deep-cloned copies, so mutating them here is safe.
+func applyAppDefaults(app *ContainerApp) {
+	if app.ActiveRevMode == "" {
+		app.ActiveRevMode = defaultActiveRevMode
+	}
+
+	if app.Ingress != nil && app.Ingress.Transport == "" {
+		app.Ingress.Transport = defaultTransport
+	}
+
+	if len(app.Template.Containers) == 0 {
+		return
+	}
+
+	if app.Template.Scale == nil {
+		app.Template.Scale = &Scale{}
+	}
+
+	if app.Template.Scale.MaxReplicas == nil {
+		v := int32(defaultMaxReplicas)
+		app.Template.Scale.MaxReplicas = &v
+	}
 }
 
 func cloneAppLogs(in *AppLogsConfiguration) *AppLogsConfiguration {

--- a/providers/azure/containerapps/containerapps_test.go
+++ b/providers/azure/containerapps/containerapps_test.go
@@ -104,6 +104,61 @@ func TestAppFqdnDerivedFromEnvironment(t *testing.T) {
 	}
 }
 
+// TestAppDefaultsFilled proves the provider fills the Azure server-side defaults
+// a create omits: activeRevisionsMode -> Single, ingress.transport -> auto, and
+// scale.maxReplicas -> 10 on a template with containers. These read back on
+// GET/LIST/discover, so an SDK/CLI user that leaves them unset matches real Azure.
+func TestAppDefaultsFilled(t *testing.T) {
+	m := newMock()
+	env := mustEnv(t, m)
+
+	app, _, err := m.CreateOrUpdateApp(context.Background(), sub, rg, appNm, &containerapps.AppInput{
+		Location:      region,
+		EnvironmentID: env.ARMID(),
+		Ingress:       &containerapps.Ingress{External: true, TargetPort: 80},
+		Template: containerapps.Template{
+			Containers: []containerapps.Container{{Name: "main", Image: "nginx"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateOrUpdateApp: %v", err)
+	}
+
+	if app.ActiveRevMode != "Single" {
+		t.Fatalf("activeRevMode = %q, want Single", app.ActiveRevMode)
+	}
+
+	if app.Ingress == nil || app.Ingress.Transport != "auto" {
+		t.Fatalf("ingress.transport = %v, want auto", app.Ingress)
+	}
+
+	if app.Template.Scale == nil || app.Template.Scale.MaxReplicas == nil || *app.Template.Scale.MaxReplicas != 10 {
+		t.Fatalf("scale.maxReplicas = %v, want 10", app.Template.Scale)
+	}
+
+	// minReplicas stays unset (real Azure omits it when 0).
+	if app.Template.Scale.MinReplicas != nil {
+		t.Fatalf("scale.minReplicas = %v, want unset", app.Template.Scale.MinReplicas)
+	}
+
+	// An explicit maxReplicas is preserved, not overwritten by the default.
+	app2, _, err := m.CreateOrUpdateApp(context.Background(), sub, rg, "app-2", &containerapps.AppInput{
+		Location:      region,
+		EnvironmentID: env.ARMID(),
+		Template: containerapps.Template{
+			Containers: []containerapps.Container{{Name: "main", Image: "nginx"}},
+			Scale:      &containerapps.Scale{MaxReplicas: ptr(int32(3))},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateOrUpdateApp app-2: %v", err)
+	}
+
+	if app2.Template.Scale == nil || *app2.Template.Scale.MaxReplicas != 3 {
+		t.Fatalf("explicit maxReplicas = %v, want 3 preserved", app2.Template.Scale)
+	}
+}
+
 func TestAppWithoutIngressHasNoFqdn(t *testing.T) {
 	m := newMock()
 	env := mustEnv(t, m)

--- a/server/azure/containerapps/containerapps_sdk_test.go
+++ b/server/azure/containerapps/containerapps_sdk_test.go
@@ -382,6 +382,73 @@ func TestSDKContainerAppRevisions(t *testing.T) {
 	assertRevisionErrors(t, ctx, revClient)
 }
 
+// TestSDKContainerAppDefaults proves a minimal create that omits
+// activeRevisionsMode, ingress.transport and scale.maxReplicas reads back the
+// Azure server-side defaults (Single / auto / 10) rather than empty values, so
+// an SDK or CLI user that leaves them unset does not drift against real Azure.
+func TestSDKContainerAppDefaults(t *testing.T) {
+	ts := newServer(t)
+	ctx := context.Background()
+
+	envClient, err := armappcontainers.NewManagedEnvironmentsClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewManagedEnvironmentsClient: %v", err)
+	}
+
+	envID := createEnvironment(t, ctx, envClient)
+
+	appClient, err := armappcontainers.NewContainerAppsClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewContainerAppsClient: %v", err)
+	}
+
+	poller, err := appClient.BeginCreateOrUpdate(ctx, rgName, "minimal", armappcontainers.ContainerApp{
+		Location: to.Ptr("eastus"),
+		Properties: &armappcontainers.ContainerAppProperties{
+			EnvironmentID: to.Ptr(envID),
+			Configuration: &armappcontainers.Configuration{
+				Ingress: &armappcontainers.Ingress{External: to.Ptr(true), TargetPort: to.Ptr[int32](80)},
+			},
+			Template: &armappcontainers.Template{
+				Containers: []*armappcontainers.Container{{Name: to.Ptr("main"), Image: to.Ptr("nginx")}},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate minimal app: %v", err)
+	}
+
+	if _, err = poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll minimal app create: %v", err)
+	}
+
+	got, err := appClient.Get(ctx, rgName, "minimal", nil)
+	if err != nil {
+		t.Fatalf("Get minimal app: %v", err)
+	}
+
+	assertAppDefaults(t, got.Properties)
+}
+
+func assertAppDefaults(t *testing.T, p *armappcontainers.ContainerAppProperties) {
+	t.Helper()
+
+	if p == nil || p.Configuration == nil || p.Configuration.ActiveRevisionsMode == nil ||
+		*p.Configuration.ActiveRevisionsMode != armappcontainers.ActiveRevisionsModeSingle {
+		t.Fatalf("activeRevisionsMode = %v, want Single", p)
+	}
+
+	if p.Configuration.Ingress == nil || p.Configuration.Ingress.Transport == nil ||
+		*p.Configuration.Ingress.Transport != armappcontainers.IngressTransportMethodAuto {
+		t.Fatalf("ingress.transport = %v, want auto", p.Configuration.Ingress)
+	}
+
+	if p.Template == nil || p.Template.Scale == nil || p.Template.Scale.MaxReplicas == nil ||
+		*p.Template.Scale.MaxReplicas != 10 {
+		t.Fatalf("scale.maxReplicas = %v, want 10", p.Template)
+	}
+}
+
 func seedRevisionEnv(t *testing.T, ctx context.Context, ts *httptest.Server) string {
 	t.Helper()
 


### PR DESCRIPTION
Real-user e2e audit of Azure Container Apps (Microsoft.App) driven by the real armappcontainers SDK. Found and fixed genuine create-vs-read-back divergences against real Azure defaults; the handler is fully modeled (no echo_properties overlay), so these are real, not overlay-masked.

## Divergences fixed
A minimal container app that omits these fields read back empty/nil instead of Azure's server-side defaults, drifting for any SDK/CLI user who leaves them unset:

- `configuration.activeRevisionsMode` -> defaults to `Single` (config was omitted entirely on a minimal create)
- `configuration.ingress.transport` -> defaults to `auto` when ingress is set
- `template.scale.maxReplicas` -> defaults to `10` when the template has containers

Confirmed against the ARM reference (learn.microsoft.com/azure/templates/microsoft.app/containerapps): activeRevisionsMode default Single, ingress transport default 'auto', maxReplicas "Defaults to 10 if not set". `minReplicas` is left unset (real Azure omits it when 0).

Fix lands in the provider (`applyAppDefaults` in providers/azure/containerapps/containerapps.go), applied before the revision is materialized so the defaults are part of the content-addressed revision template and read back consistently on GET/LIST/discover/snapshot. Explicit values are preserved, not overwritten; re-PUT stays idempotent.

## Verified correct (no change)
- provisioningState synchronous `Succeeded` — SDK poller (`PollUntilDone`) terminates for env + app; same mechanism the azurerm create waiter uses.
- Deterministic list order (sorted by name), delete idempotency (200/204), secret redaction on GET.
- Revision-on-template-update: a template change mints `<app>--<suffix>`, latestRevisionName advances, Single mode supersedes; traffic split validation (sum 100, known revisions).

## Filed, not fixed (out of scope, no half-build)
- ARM PATCH partial-merge: handler routes PATCH == PUT (full replace). azurerm/SDK use PUT so terraform is unaffected; only `az containerapp update` (PATCH) users hit it.
- Managed-environment unmodeled properties (zoneRedundant, vnetConfiguration, workloadProfiles) dropped on create->read — feature gap.
- Terraform azurerm can't target the emulator (no ARM /metadata/endpoints document, self-signed TLS) — a harness limitation across all Azure services, not a Container Apps divergence; the real-SDK-over-httptest path exercises the identical ARM wire + provisioningState polling.

## Tests
- New SDK e2e `TestSDKContainerAppDefaults` (real armappcontainers Get asserts Single/auto/10 defaults).
- New provider `TestAppDefaultsFilled` (defaults applied; minReplicas unset; explicit maxReplicas preserved).

## Gates
build / vet / gofmt clean; `go test -race` scoped providers+server green; golangci-lint --new-from-rev=origin/development 0 issues; go generate no docs/coverage diff.