### PR TITLE
fix(sns): real-user e2e divergences from AWS

### DIFF
--- a/server/aws/sns/subscription_attribute_fidelity_sdk_test.go
+++ b/server/aws/sns/subscription_attribute_fidelity_sdk_test.go
@@ -1,0 +1,157 @@
+package sns_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
+)
+
+// TestSDKSNSConfirmationWasAuthenticated asserts GetSubscriptionAttributes
+// reports ConfirmationWasAuthenticated="true" for a subscription confirmed as
+// part of the authenticated Subscribe call (sqs and the other auto-confirm
+// protocols), and "false" for a still-pending confirmation-required protocol.
+// Real SNS documents ConfirmationWasAuthenticated as "true if the subscription
+// confirmation request was authenticated".
+func TestSDKSNSConfirmationWasAuthenticated(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("cwa-topic")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	topicArn := aws.ToString(created.TopicArn)
+
+	// SQS auto-confirms via the authenticated Subscribe API -> "true".
+	sqsSub, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn:              aws.String(topicArn),
+		Protocol:              aws.String("sqs"),
+		Endpoint:              aws.String("arn:aws:sqs:us-east-1:000000000000:q"),
+		ReturnSubscriptionArn: true,
+	})
+	if err != nil {
+		t.Fatalf("Subscribe(sqs): %v", err)
+	}
+
+	got, err := client.GetSubscriptionAttributes(ctx, &awssns.GetSubscriptionAttributesInput{
+		SubscriptionArn: sqsSub.SubscriptionArn,
+	})
+	if err != nil {
+		t.Fatalf("GetSubscriptionAttributes(sqs): %v", err)
+	}
+
+	if got.Attributes["ConfirmationWasAuthenticated"] != "true" {
+		t.Fatalf("sqs ConfirmationWasAuthenticated = %q, want true",
+			got.Attributes["ConfirmationWasAuthenticated"])
+	}
+
+	// email requires out-of-band confirmation and stays pending -> "false".
+	emailSub, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn:              aws.String(topicArn),
+		Protocol:              aws.String("email"),
+		Endpoint:              aws.String("dev@example.com"),
+		ReturnSubscriptionArn: true,
+	})
+	if err != nil {
+		t.Fatalf("Subscribe(email): %v", err)
+	}
+
+	gotEmail, err := client.GetSubscriptionAttributes(ctx, &awssns.GetSubscriptionAttributesInput{
+		SubscriptionArn: emailSub.SubscriptionArn,
+	})
+	if err != nil {
+		t.Fatalf("GetSubscriptionAttributes(email): %v", err)
+	}
+
+	if gotEmail.Attributes["ConfirmationWasAuthenticated"] != "false" {
+		t.Fatalf("pending email ConfirmationWasAuthenticated = %q, want false",
+			gotEmail.Attributes["ConfirmationWasAuthenticated"])
+	}
+}
+
+// TestSDKSNSFilterPolicyScopeDefault asserts GetSubscriptionAttributes surfaces
+// the documented default FilterPolicyScope="MessageAttributes" for a
+// subscription that has a FilterPolicy but no explicit scope, does not surface
+// the scope at all when there is no FilterPolicy, and never overrides an
+// explicitly set MessageBody scope.
+func TestSDKSNSFilterPolicyScopeDefault(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("fps-topic")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	topicArn := aws.ToString(created.TopicArn)
+
+	// No filter policy -> no FilterPolicyScope emitted at all.
+	bare, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn:              aws.String(topicArn),
+		Protocol:              aws.String("sqs"),
+		Endpoint:              aws.String("arn:aws:sqs:us-east-1:000000000000:bare"),
+		ReturnSubscriptionArn: true,
+	})
+	if err != nil {
+		t.Fatalf("Subscribe(bare): %v", err)
+	}
+
+	gotBare, err := client.GetSubscriptionAttributes(ctx, &awssns.GetSubscriptionAttributesInput{
+		SubscriptionArn: bare.SubscriptionArn,
+	})
+	if err != nil {
+		t.Fatalf("GetSubscriptionAttributes(bare): %v", err)
+	}
+
+	if v, ok := gotBare.Attributes["FilterPolicyScope"]; ok {
+		t.Fatalf("FilterPolicyScope present without a FilterPolicy: %q", v)
+	}
+
+	// Filter policy without an explicit scope -> default "MessageAttributes".
+	withPolicy, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn:              aws.String(topicArn),
+		Protocol:              aws.String("sqs"),
+		Endpoint:              aws.String("arn:aws:sqs:us-east-1:000000000000:policy"),
+		ReturnSubscriptionArn: true,
+		Attributes:            map[string]string{"FilterPolicy": `{"color":["red"]}`},
+	})
+	if err != nil {
+		t.Fatalf("Subscribe(withPolicy): %v", err)
+	}
+
+	gotPolicy, err := client.GetSubscriptionAttributes(ctx, &awssns.GetSubscriptionAttributesInput{
+		SubscriptionArn: withPolicy.SubscriptionArn,
+	})
+	if err != nil {
+		t.Fatalf("GetSubscriptionAttributes(withPolicy): %v", err)
+	}
+
+	if gotPolicy.Attributes["FilterPolicyScope"] != "MessageAttributes" {
+		t.Fatalf("default FilterPolicyScope = %q, want MessageAttributes",
+			gotPolicy.Attributes["FilterPolicyScope"])
+	}
+
+	// An explicit MessageBody scope is preserved, not clobbered by the default.
+	if _, err := client.SetSubscriptionAttributes(ctx, &awssns.SetSubscriptionAttributesInput{
+		SubscriptionArn: withPolicy.SubscriptionArn,
+		AttributeName:   aws.String("FilterPolicyScope"),
+		AttributeValue:  aws.String("MessageBody"),
+	}); err != nil {
+		t.Fatalf("SetSubscriptionAttributes(scope): %v", err)
+	}
+
+	gotBody, err := client.GetSubscriptionAttributes(ctx, &awssns.GetSubscriptionAttributesInput{
+		SubscriptionArn: withPolicy.SubscriptionArn,
+	})
+	if err != nil {
+		t.Fatalf("GetSubscriptionAttributes(body scope): %v", err)
+	}
+
+	if gotBody.Attributes["FilterPolicyScope"] != "MessageBody" {
+		t.Fatalf("explicit FilterPolicyScope = %q, want MessageBody (default must not override)",
+			gotBody.Attributes["FilterPolicyScope"])
+	}
+}

--- a/server/aws/sns/subscription_attributes.go
+++ b/server/aws/sns/subscription_attributes.go
@@ -83,9 +83,19 @@ func subscriptionAttributeEntries(sub *notifdriver.SubscriptionInfo) []attribute
 		attributeEntry{Key: "Endpoint", Value: sub.Endpoint},
 		attributeEntry{Key: "Owner", Value: accountFromARN(sub.ID)},
 		attributeEntry{Key: "PendingConfirmation", Value: pending},
-		attributeEntry{Key: "ConfirmationWasAuthenticated", Value: attrFalse},
+		attributeEntry{Key: "ConfirmationWasAuthenticated", Value: confirmationWasAuthenticated(sub)},
 		attributeEntry{Key: "RawMessageDelivery", Value: rawMessageDelivery(sub)},
 	)
+
+	// A subscription with a filter policy but no explicit FilterPolicyScope reports
+	// the documented default "MessageAttributes" — real SNS always surfaces the
+	// scope alongside a policy, so an SDK reader never has to infer it.
+	if _, hasPolicy := sub.Attributes["FilterPolicy"]; hasPolicy {
+		if _, hasScope := sub.Attributes["FilterPolicyScope"]; !hasScope {
+			entries = append(entries,
+				attributeEntry{Key: "FilterPolicyScope", Value: filterPolicyScopeDefault})
+		}
+	}
 
 	// Emit caller-set attributes (FilterPolicy, RedrivePolicy, ...) in a stable
 	// order so successive reads don't churn.
@@ -106,6 +116,40 @@ func subscriptionAttributeEntries(sub *notifdriver.SubscriptionInfo) []attribute
 	}
 
 	return entries
+}
+
+// filterPolicyScopeDefault is the FilterPolicyScope SNS reports for a
+// subscription that carries a FilterPolicy without an explicit scope.
+const filterPolicyScopeDefault = "MessageAttributes"
+
+// autoConfirmProtocols is the set of SNS protocols whose subscriptions are
+// confirmed as part of the authenticated Subscribe call rather than by an
+// out-of-band token. For those, real SNS reports ConfirmationWasAuthenticated
+// = "true"; http/https/email confirm via an unauthenticated click-through link,
+// so they stay "false".
+var autoConfirmProtocols = map[string]struct{}{ //nolint:gochecknoglobals // static lookup table
+	"sqs":         {},
+	"lambda":      {},
+	"application": {},
+	"firehose":    {},
+	"sms":         {},
+}
+
+// confirmationWasAuthenticated reports SNS's ConfirmationWasAuthenticated value:
+// "true" only once a subscription is confirmed via the authenticated Subscribe
+// API (the auto-confirm protocols). A still-pending subscription, or one whose
+// confirmation happens through an unauthenticated link (http/https/email), is
+// "false".
+func confirmationWasAuthenticated(sub *notifdriver.SubscriptionInfo) string {
+	if sub.Status == statusPending {
+		return attrFalse
+	}
+
+	if _, ok := autoConfirmProtocols[sub.Protocol]; ok {
+		return attrTrue
+	}
+
+	return attrFalse
 }
 
 // idgenTopicARN reconstructs the topic ARN from the subscription ARN, which SNS


### PR DESCRIPTION
## Summary

Real-user e2e audit of AWS SNS (SDK + aws-cli + Terraform against `cloudemu serve`) found two genuine cloud-vs-cloudemu divergences in `GetSubscriptionAttributes`. Both are docs-verified and fixed at the wire-handler layer.

### Findings fixed

1. **`ConfirmationWasAuthenticated` was hard-coded to `false`.** Real SNS returns `true` for subscriptions confirmed as part of the authenticated `Subscribe` call (sqs/lambda/application/firehose/sms). Now derived from status + protocol: `true` when confirmed via an auto-confirm protocol; `false` for still-pending or click-through-confirmed (http/https/email). Ref: API_GetSubscriptionAttributes ("true if the subscription confirmation request was authenticated").

2. **`FilterPolicyScope` was omitted when a `FilterPolicy` was set without an explicit scope.** Real SNS always surfaces the documented default `MessageAttributes` alongside a policy. Now emitted when a FilterPolicy is present and no scope is set; an explicit `MessageBody` is preserved (never overridden or duplicated); nothing is emitted when there is no FilterPolicy. Ref: API_GetSubscriptionAttributes ("MessageAttributes (default)").

### Verified already-correct (no change)

- CreateTopic idempotency; FIFO validation (`.fifo` suffix, ContentBasedDeduplication).
- GetTopicAttributes: Owner, default Policy, EffectiveDeliveryPolicy, Subscriptions{Confirmed,Pending,Deleted}.
- Confirmation semantics: SQS/lambda auto-confirm to a real ARN; http/email return `pending confirmation` (and `PendingConfirmation` in list responses).
- Subscription attribute round-trip: FilterPolicy, RawMessageDelivery.
- Error codes: NotFound / InvalidParameter with correct HTTP status.
- SNS -> SQS and SNS -> Lambda fan-out (envelope, raw delivery, filter policies, FIFO group/dedup passthrough).
- Terraform apply -> plan shows no drift, before and after this change.

### Tests

`server/aws/sns/subscription_attribute_fidelity_sdk_test.go` — real aws-sdk-go-v2 client: `TestSDKSNSConfirmationWasAuthenticated` and `TestSDKSNSFilterPolicyScopeDefault`.

Gates: `go build ./...`, `go test -race` (server/aws/sns, providers/aws/sns, services/notification), `go vet`, `gofmt`, `golangci-lint --new-from-rev=origin/development` (0 issues), `go generate` (no docs/coverage diff) — all green.
