### PR TITLE
fix(azure): stop echo overlay leaking container app secret values on GET

### DIFF
--- a/server/azure/echo_array_test.go
+++ b/server/azure/echo_array_test.go
@@ -19,7 +19,7 @@ func TestMissingArrayElementsRecursesPerElement(t *testing.T) {
 		map[string]any{"lun": float64(1), "caching": "None"},
 	}
 
-	got := missingArrayElements(req, resp)
+	got := missingArrayElements(req, resp, "")
 
 	want := []any{
 		map[string]any{"writeAcceleratorEnabled": true},
@@ -37,7 +37,7 @@ func TestMissingArrayElementsNoUnmodeled(t *testing.T) {
 	req := []any{map[string]any{"lun": float64(0), "caching": "ReadOnly"}}
 	resp := []any{map[string]any{"lun": float64(0), "caching": "ReadOnly"}}
 
-	if got := missingArrayElements(req, resp); got != nil {
+	if got := missingArrayElements(req, resp, ""); got != nil {
 		t.Fatalf("missingArrayElements = %#v, want nil", got)
 	}
 }
@@ -58,7 +58,7 @@ func TestMissingArrayElementsLengthMismatch(t *testing.T) {
 		map[string]any{"lun": float64(0)},
 	}
 
-	got := missingArrayElements(reqLong, respShort)
+	got := missingArrayElements(reqLong, respShort, "")
 	if len(got) != 1 {
 		t.Fatalf("request longer than response: got len %d, want 1 (no phantom elements)", len(got))
 	}
@@ -75,7 +75,7 @@ func TestMissingArrayElementsLengthMismatch(t *testing.T) {
 		map[string]any{"lun": float64(1)},
 	}
 
-	got = missingArrayElements(reqShort, respLong)
+	got = missingArrayElements(reqShort, respLong, "")
 	if len(got) != 1 || !reflect.DeepEqual(got[0], map[string]any{"extra": "keep0"}) {
 		t.Fatalf("request shorter than response: got = %#v, want [{extra:keep0}]", got)
 	}
@@ -86,15 +86,15 @@ func TestMissingArrayElementsLengthMismatch(t *testing.T) {
 // the handler (the wholly-unmodeled scalar array is captured verbatim by the
 // caller's !present branch, not here), and empty inputs yield nil.
 func TestMissingArrayElementsScalarsAndNil(t *testing.T) {
-	if got := missingArrayElements([]any{"a", "b"}, []any{"a", "b"}); got != nil {
+	if got := missingArrayElements([]any{"a", "b"}, []any{"a", "b"}, ""); got != nil {
 		t.Fatalf("scalar arrays: got %#v, want nil", got)
 	}
 
-	if got := missingArrayElements(nil, nil); got != nil {
+	if got := missingArrayElements(nil, nil, ""); got != nil {
 		t.Fatalf("nil arrays: got %#v, want nil", got)
 	}
 
-	if got := missingArrayElements([]any{}, []any{map[string]any{"x": 1}}); got != nil {
+	if got := missingArrayElements([]any{}, []any{map[string]any{"x": 1}}, ""); got != nil {
 		t.Fatalf("empty request: got %#v, want nil", got)
 	}
 }
@@ -187,7 +187,7 @@ func TestMissingPropertiesArrayEndToEnd(t *testing.T) {
 		},
 	}
 
-	unmodeled := missingProperties(req, resp)
+	unmodeled := missingProperties(req, resp, "")
 
 	merged := mergeProperties(resp, unmodeled)
 

--- a/server/azure/echo_properties.go
+++ b/server/azure/echo_properties.go
@@ -367,7 +367,7 @@ func captureUnmodeled(
 		return stored
 	}
 
-	fresh := missingProperties(reqProps, respProps)
+	fresh := missingProperties(reqProps, respProps, "")
 	if r.Method == http.MethodPatch {
 		fresh = mergeProperties(fresh, stored)
 	}
@@ -428,13 +428,29 @@ func captureUnmodeled(
 // via GetPnsCredentials, never the generic hub GET. Each is an object, so
 // denylisting the key skips the whole credential subtree.
 //
+// 3. Path-aware rule: a bare "value" key is write-only only when its immediate
+// containing key is "secrets" — Container Apps configuration.secrets[].value,
+// the one secret input whose owning handler models the secret (echoing its name)
+// but omits the value on read, exactly as real Azure does (values are served
+// only via listSecrets). toConfigResponse therefore returns {name} per secret,
+// so the overlay would otherwise see "value" as missing from the response and
+// re-inject the caller's cleartext secret on every later GET. Scoping the skip
+// to the "secrets" parent is deliberate: a global bare-"value" denylist would
+// over-match every unmodeled "value" elsewhere (env vars, DNS records, tags),
+// silently dropping legitimate round-tripped data.
+//
 // The rule is matched case-insensitively at any nesting depth (missingProperties
-// and sanitizeUnmodeled recurse into nested objects and arrays), and never
-// suppresses a field a handler legitimately returns.
-func writeOnlyProperty(key string) bool {
+// and sanitizeUnmodeled recurse into nested objects and arrays, threading the
+// containing key as parent), and never suppresses a field a handler legitimately
+// returns.
+func writeOnlyProperty(parent, key string) bool {
 	lower := strings.ToLower(key)
 
 	if strings.HasSuffix(lower, "password") || strings.HasSuffix(lower, "secret") {
+		return true
+	}
+
+	if lower == "value" && strings.EqualFold(parent, "secrets") {
 		return true
 	}
 
@@ -454,25 +470,28 @@ func writeOnlyProperty(key string) bool {
 // slip past the per-key denylist. Both objects (map[string]any) and arrays
 // ([]any, e.g. imageRegistryCredentials[].password) are recursed and deep-copied
 // so no request-owned map or slice is aliased into the overlay store; any other
-// value passes through unchanged.
-func sanitizeUnmodeled(v any) any {
+// value passes through unchanged. parent is the key of the object/array that
+// holds v, so the path-aware write-only rule (a "value" under "secrets") applies
+// inside verbatim-captured subtrees too; array elements inherit their array's
+// key as parent.
+func sanitizeUnmodeled(v any, parent string) any {
 	switch t := v.(type) {
 	case map[string]any:
 		out := make(map[string]any, len(t))
 
 		for k, val := range t {
-			if writeOnlyProperty(k) {
+			if writeOnlyProperty(parent, k) {
 				continue
 			}
 
-			out[k] = sanitizeUnmodeled(val)
+			out[k] = sanitizeUnmodeled(val, k)
 		}
 
 		return out
 	case []any:
 		out := make([]any, len(t))
 		for i, el := range t {
-			out[i] = sanitizeUnmodeled(el)
+			out[i] = sanitizeUnmodeled(el, parent)
 		}
 
 		return out
@@ -506,8 +525,10 @@ func isZeroScalarJSON(v any) bool {
 // array element, e.g. a vnet inline subnet or a VM data disk) is still captured.
 // A key present in both as scalars is considered modeled (the handler owns it)
 // and is omitted. Write-only secret keys (writeOnlyProperty) are skipped at
-// every level so they are never captured, persisted, or echoed.
-func missingProperties(req, resp map[string]any) map[string]any {
+// every level so they are never captured, persisted, or echoed. parent is the
+// key whose object req is (empty at the properties root), threaded so the
+// path-aware write-only rule can see a key's container.
+func missingProperties(req, resp map[string]any, parent string) map[string]any {
 	if len(req) == 0 {
 		return nil
 	}
@@ -515,52 +536,13 @@ func missingProperties(req, resp map[string]any) map[string]any {
 	out := map[string]any{}
 
 	for k, reqVal := range req {
-		if writeOnlyProperty(k) {
+		if writeOnlyProperty(parent, k) {
 			continue
 		}
 
 		respVal, present := resp[k]
-		if !present {
-			// A request scalar at its JSON zero value (null/""/false/0) that the
-			// response doesn't echo is far more likely a field the handler DOES
-			// model — and correctly dropped via omitempty because a PATCH just
-			// set it back to its default — than genuinely unmodeled data worth
-			// preserving. Azure SQL's PATCH-to-clear elasticPoolId (set it to ""
-			// to remove a database from its elastic pool) is exactly this shape:
-			// without this guard, the overlay "helpfully" re-injected the
-			// just-cleared "" back into every future response, resurrecting pool
-			// membership the request explicitly removed. A non-zero scalar or a
-			// populated object/array is still captured verbatim below — this
-			// only narrows the false-positive case of a zero scalar.
-			if isZeroScalarJSON(reqVal) {
-				continue
-			}
-
-			// A wholly-unmodeled object is captured verbatim, so strip any
-			// write-only secret nested inside it — the per-key skip above only
-			// covers keys the loop visits directly, not those buried in a
-			// subtree the handler dropped entirely (e.g. a VM osProfile the
-			// response omits, carrying adminPassword).
-			out[k] = sanitizeUnmodeled(reqVal)
-			continue
-		}
-
-		if reqChild, ok := reqVal.(map[string]any); ok {
-			if respChild, ok := respVal.(map[string]any); ok {
-				if nested := missingProperties(reqChild, respChild); len(nested) > 0 {
-					out[k] = nested
-				}
-			}
-
-			continue
-		}
-
-		if reqArr, ok := reqVal.([]any); ok {
-			if respArr, ok := respVal.([]any); ok {
-				if nested := missingArrayElements(reqArr, respArr); nested != nil {
-					out[k] = nested
-				}
-			}
+		if val, keep := missingEntry(k, reqVal, respVal, present); keep {
+			out[k] = val
 		}
 	}
 
@@ -569,6 +551,60 @@ func missingProperties(req, resp map[string]any) map[string]any {
 	}
 
 	return out
+}
+
+// missingEntry decides what a single request key k contributes to its object's
+// diff: it returns the value to store under k and whether to store it. Split out
+// of missingProperties so each shape (absent, nested object, nested array) reads
+// as one branch.
+func missingEntry(k string, reqVal, respVal any, present bool) (any, bool) {
+	if !present {
+		// A request scalar at its JSON zero value (null/""/false/0) that the
+		// response doesn't echo is far more likely a field the handler DOES
+		// model — and correctly dropped via omitempty because a PATCH just set it
+		// back to its default — than genuinely unmodeled data worth preserving.
+		// Azure SQL's PATCH-to-clear elasticPoolId (set it to "" to remove a
+		// database from its elastic pool) is exactly this shape: without this
+		// guard, the overlay "helpfully" re-injected the just-cleared "" back into
+		// every future response, resurrecting pool membership the request
+		// explicitly removed. A non-zero scalar or a populated object/array is
+		// still captured verbatim below — this only narrows the false-positive
+		// case of a zero scalar.
+		if isZeroScalarJSON(reqVal) {
+			return nil, false
+		}
+
+		// A wholly-unmodeled object is captured verbatim, so strip any write-only
+		// secret nested inside it — the per-key skip in the caller only covers
+		// keys the loop visits directly, not those buried in a subtree the handler
+		// dropped entirely (e.g. a VM osProfile the response omits, carrying
+		// adminPassword).
+		return sanitizeUnmodeled(reqVal, k), true
+	}
+
+	if reqChild, ok := reqVal.(map[string]any); ok {
+		respChild, ok := respVal.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+
+		nested := missingProperties(reqChild, respChild, k)
+
+		return nested, len(nested) > 0
+	}
+
+	if reqArr, ok := reqVal.([]any); ok {
+		respArr, ok := respVal.([]any)
+		if !ok {
+			return nil, false
+		}
+
+		nested := missingArrayElements(reqArr, respArr, k)
+
+		return nested, nested != nil
+	}
+
+	return nil, false
 }
 
 // missingArrayElements diffs a request array against the response array that a
@@ -586,8 +622,10 @@ func missingProperties(req, resp map[string]any) map[string]any {
 // request shorter than the response simply leaves the response tail unenriched.
 // Only object elements paired with object elements are diffed; a scalar element
 // present in both is left to the handler (a wholly-unmodeled scalar array is
-// captured verbatim by the caller's !present branch instead).
-func missingArrayElements(req, resp []any) []any {
+// captured verbatim by the caller's !present branch instead). parent is the key
+// this array is stored under, passed to each element's diff so a path-aware
+// write-only rule (a "value" under "secrets") sees the array's key.
+func missingArrayElements(req, resp []any, parent string) []any {
 	n := len(resp)
 	if len(req) < n {
 		n = len(req)
@@ -602,7 +640,7 @@ func missingArrayElements(req, resp []any) []any {
 		respEl, respOK := resp[i].(map[string]any)
 
 		if reqOK && respOK {
-			if nested := missingProperties(reqEl, respEl); len(nested) > 0 {
+			if nested := missingProperties(reqEl, respEl, parent); len(nested) > 0 {
 				out[i] = nested
 				found = true
 			}

--- a/server/azure/echo_properties_test.go
+++ b/server/azure/echo_properties_test.go
@@ -686,6 +686,107 @@ func TestEchoStillReflectsNonSecretProperty(t *testing.T) {
 	}
 }
 
+// getRawBody performs a GET and returns the raw response bytes so a test can
+// assert on the exact wire body (e.g. grep it for a leaked secret value), not
+// just the decoded map.
+func getRawBody(t *testing.T, c *http.Client, url string) []byte {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		t.Fatalf("GET %s: status %d: %s", url, resp.StatusCode, data)
+	}
+
+	return data
+}
+
+// TestEchoDoesNotLeakContainerAppSecretValue is the credential-leak regression:
+// the Container Apps handler models configuration.secrets and echoes each
+// secret's NAME on read but never its value (real Azure serves values only via
+// listSecrets). The generic overlay used to see the omitted "value" as an
+// unmodeled property and re-inject the caller's cleartext secret on the create
+// response and every later GET. The path-aware write-only rule (a "value" under
+// "secrets") must suppress it, while a non-secret sibling under the same secret
+// element (identity) and a non-secret unmodeled top-level property still echo —
+// proving the fix is precise, not a blanket bare-"value" denylist.
+func TestEchoDoesNotLeakContainerAppSecretValue(t *testing.T) {
+	ts, c := echoTestServer(t)
+	url := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.App/containerApps/leakapp?api-version=2023-05-01"
+
+	const secretValue = "supersecret-leak-canary"
+
+	created := putJSON(t, c, url, map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			// Non-secret unmodeled top-level property: must still round-trip.
+			"workloadProfileName": "canary-unmodeled",
+			"configuration": map[string]any{
+				"activeRevisionsMode": "Single",
+				"secrets": []any{
+					map[string]any{
+						"name":     "mysecret",
+						"value":    secretValue,
+						"identity": "system", // non-secret sibling, must still echo
+					},
+				},
+			},
+		},
+	})
+
+	if createdRaw, err := json.Marshal(created); err != nil {
+		t.Fatal(err)
+	} else if bytes.Contains(createdRaw, []byte(secretValue)) {
+		t.Fatalf("create response leaked the secret value: %s", createdRaw)
+	}
+
+	// Raw-wire security assertion: the secret value must be absent from the GET body.
+	raw := getRawBody(t, c, url)
+	if bytes.Contains(raw, []byte(secretValue)) {
+		t.Fatalf("GET leaked the container app secret value on the wire: %s", raw)
+	}
+
+	gp := props(t, getJSON(t, c, url))
+
+	if gp["workloadProfileName"] != "canary-unmodeled" {
+		t.Errorf("overlay dropped non-secret unmodeled workloadProfileName: %v", gp["workloadProfileName"])
+	}
+
+	cfg, ok := gp["configuration"].(map[string]any)
+	if !ok {
+		t.Fatalf("GET dropped configuration: %v", gp)
+	}
+
+	secrets, ok := cfg["secrets"].([]any)
+	if !ok || len(secrets) != 1 {
+		t.Fatalf("GET dropped configuration.secrets: %v", cfg["secrets"])
+	}
+
+	secret, _ := secrets[0].(map[string]any)
+
+	if _, leaked := secret["value"]; leaked {
+		t.Fatalf("GET leaked write-only secret value under configuration.secrets[]: %v", secret)
+	}
+
+	if secret["name"] != "mysecret" {
+		t.Errorf("GET dropped the modeled secret name: %v", secret["name"])
+	}
+
+	if secret["identity"] != "system" {
+		t.Errorf("path-aware rule over-suppressed the non-secret sibling identity: %v", secret["identity"])
+	}
+}
+
 func bytesReader(t *testing.T, v map[string]any) *bytes.Reader {
 	t.Helper()
 


### PR DESCRIPTION
## The leak

Azure Container Apps' handler correctly redacts secrets on read: `toConfigResponse` (`server/azure/containerapps/types.go`) returns each secret as `{name}` only, never the value — matching real Azure, where secret values are served exclusively via `listSecrets`.

But every ARM handler is wrapped in `echoUnmodeledProperties` (`server/azure/echo_properties.go`). Its overlay captures request `properties` fields the handler does not echo back and re-injects them into subsequent GET/PUT responses. When a caller PUTs `configuration.secrets=[{name, value}]`, the response omits `value`, so the overlay's diff (`missingArrayElements` → `missingProperties`) saw `value` as "missing from the response" and re-injected the raw cleartext secret on the create response and on **every later GET** — a HIGH-severity credential leak.

The prior `writeOnlyProperty` denylist only skipped keys ending in `password`/`secret` plus a few exact PNS-credential keys; it did not cover a bare `value` under `configuration.secrets[]`.

## The fix (path-aware, precise)

Thread the containing key as a `parent` argument through `missingProperties`, `missingArrayElements`, and `sanitizeUnmodeled`, and add one rule to `writeOnlyProperty`: a bare `value` is write-only **only when its immediate containing key is `secrets`**.

### Why not a global bare-`value` denylist

A blanket bare-`value` skip would over-match legitimate unmodeled `value` fields elsewhere (container env vars, DNS record sets, tags), silently dropping data the overlay is meant to round-trip. Scoping to the `secrets` parent suppresses only the genuinely write-only secret value while every other unmodeled property still echoes as before. A non-secret sibling under the same secret element (e.g. `identity`) also still round-trips.

## Other-services audit

Swept `server/azure` for the same class (redacts a secret/value on GET but relies on the overlay). Container Apps `configuration.secrets[].value` is the **only** overlay-mediated request-capture leak:
- servicebus / notificationhubs / cache / storage / cosmos keys — server-generated **output-only**, never sent in request `properties`, so never enter the capture path.
- SQL/MySQL/Postgres/VM admin passwords — already caught by the `password`/`secret` suffix rule.
- keyvault secrets, databricks secrets — served by **dedicated dataplane handlers not under `/subscriptions/`** (databricks uses `string_value`, no ARM `properties`), so the overlay never engages.
- keyvault accessPolicies `secrets`/`keys` — permission-string arrays that ARE legitimately returned.

Note: the Container Apps provider stores only secret **names** (`SecretNames []string`), never values, and there is no `listSecrets` endpoint — so post-fix the value is neither persisted nor retrievable anywhere (doubly safe). A real `listSecrets` is a separate fidelity feature, out of scope for this security fix.

## Live before/after (`serve -azure-port 14866 -k8s-port "" -providers=azure`, HTTPS)

PUT `configuration.secrets=[{name:mysecret, value:supersecret, identity:system}]`, plus a non-secret unmodeled `workloadProfileName`:

- **Before (origin/development):** create/GET body contains `"value":"supersecret"` — leak.
- **After:** create and GET return `secrets:[{identity:system, name:mysecret}]`; `grep supersecret` on both raw bodies → **ABSENT**. Non-secret `workloadProfileName` and the `identity` sibling both still echo.

## Regression test

`TestEchoDoesNotLeakContainerAppSecretValue` (`server/azure/echo_properties_test.go`) asserts the secret value is absent from the create response and the raw GET body, the secret `name` and the non-secret `identity` sibling round-trip, and a non-secret unmodeled top-level property still echoes. Confirmed it **FAILS on origin/development** (reproduces the leak) and passes after the fix.

## Gates

`go build ./...`, `go test -race ./server/azure/... ./providers/azure/containerapps/...`, `go vet`, `gofmt -l`, `golangci-lint --new-from-rev=origin/development`, `go generate ./...` (no `docs/coverage` diff) — all green.
