### PR TITLE
fix(sqs): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/sqs/snapshot.go
+++ b/providers/aws/sqs/snapshot.go
@@ -39,6 +39,10 @@ type queueSnapshot struct {
 	RedriveAllowPolicy string                   `json:"redriveAllowPolicy,omitempty"`
 	Policy             string                   `json:"policy,omitempty"`
 	KMSMasterKeyID     string                   `json:"kmsMasterKeyId,omitempty"`
+	KMSDataKeyReuse    int                      `json:"kmsDataKeyReuse,omitempty"`
+	SqsManagedSSE      bool                     `json:"sqsManagedSse,omitempty"`
+	DeduplicationScope string                   `json:"deduplicationScope,omitempty"`
+	FifoThroughputLim  string                   `json:"fifoThroughputLimit,omitempty"`
 	CreatedAt          time.Time                `json:"createdAt"`
 	LastModifiedAt     time.Time                `json:"lastModifiedAt"`
 	DeduplicationIndex map[string]time.Time     `json:"deduplicationIndex,omitempty"`
@@ -123,7 +127,9 @@ func snapshotQueue(qd *queueData) *queueSnapshot {
 		MaxMessageSize: qd.maxMessageSize, MessageRetention: qd.messageRetention,
 		ReceiveWaitTime: qd.receiveWaitTime, ContentBasedDedup: qd.contentBasedDedup,
 		RedrivePolicy: qd.redrivePolicy, RedriveAllowPolicy: qd.redriveAllowPolicy,
-		Policy: qd.policy, KMSMasterKeyID: qd.kmsMasterKeyID, CreatedAt: qd.createdAt,
+		Policy: qd.policy, KMSMasterKeyID: qd.kmsMasterKeyID, KMSDataKeyReuse: qd.kmsDataKeyReuse,
+		SqsManagedSSE: qd.sqsManagedSSE, DeduplicationScope: qd.deduplicationScope,
+		FifoThroughputLim: qd.fifoThroughputLim, CreatedAt: qd.createdAt,
 		LastModifiedAt: qd.lastModifiedAt, DeduplicationIndex: qd.deduplicationIndex,
 		DLQConfig: qd.dlqConfig, SeqCounter: qd.seqCounter.Load(),
 	}
@@ -180,7 +186,9 @@ func restoreQueue(qs *queueSnapshot) *queueData {
 		maxMessageSize: qs.MaxMessageSize, messageRetention: qs.MessageRetention,
 		receiveWaitTime: qs.ReceiveWaitTime, contentBasedDedup: qs.ContentBasedDedup,
 		redrivePolicy: qs.RedrivePolicy, redriveAllowPolicy: qs.RedriveAllowPolicy,
-		policy: qs.Policy, kmsMasterKeyID: qs.KMSMasterKeyID, createdAt: qs.CreatedAt,
+		policy: qs.Policy, kmsMasterKeyID: qs.KMSMasterKeyID, kmsDataKeyReuse: qs.KMSDataKeyReuse,
+		sqsManagedSSE: qs.SqsManagedSSE, deduplicationScope: qs.DeduplicationScope,
+		fifoThroughputLim: qs.FifoThroughputLim, createdAt: qs.CreatedAt,
 		lastModifiedAt: qs.LastModifiedAt, deduplicationIndex: qs.DeduplicationIndex,
 		dlqConfig: qs.DLQConfig,
 	}

--- a/providers/aws/sqs/sqs.go
+++ b/providers/aws/sqs/sqs.go
@@ -30,6 +30,9 @@ const (
 	defaultVisibilityTimeout = 30
 	defaultMaxMessageSize    = 262144
 	defaultMessageRetention  = 345600
+	defaultKmsDataKeyReuse   = 300
+	dedupScopeQueue          = "queue"
+	fifoThroughputPerQueue   = "perQueue"
 	maxReceiveMessages       = 10
 	deduplicationWindow      = 5 * time.Minute
 	maxReceiveWaitSeconds    = 20
@@ -74,6 +77,10 @@ type queueData struct {
 	redriveAllowPolicy string
 	policy             string
 	kmsMasterKeyID     string
+	kmsDataKeyReuse    int
+	sqsManagedSSE      bool
+	deduplicationScope string
+	fifoThroughputLim  string
 	createdAt          time.Time
 	lastModifiedAt     time.Time
 	deduplicationIndex map[string]time.Time
@@ -230,6 +237,12 @@ func (m *Mock) CreateQueue(ctx context.Context, cfg driver.QueueConfig) (*driver
 		messageRetention:   messageRetention,
 		receiveWaitTime:    cfg.ReceiveMessageWaitTimeSeconds,
 		contentBasedDedup:  cfg.ContentBasedDeduplication,
+		policy:             cfg.Policy,
+		kmsMasterKeyID:     cfg.KmsMasterKeyID,
+		kmsDataKeyReuse:    resolveKmsDataKeyReuse(&cfg),
+		sqsManagedSSE:      cfg.SqsManagedSseEnabled && cfg.KmsMasterKeyID == "",
+		deduplicationScope: resolveDedupScope(&cfg),
+		fifoThroughputLim:  resolveFifoThroughputLimit(&cfg),
 		createdAt:          now,
 		lastModifiedAt:     now,
 		deduplicationIndex: make(map[string]time.Time),
@@ -280,6 +293,44 @@ func queueSizeDefaults(cfg *driver.QueueConfig) (maxSize, retention int) {
 	return maxSize, retention
 }
 
+// resolveKmsDataKeyReuse applies the SQS default of 300 when the data-key reuse
+// period was left unset.
+func resolveKmsDataKeyReuse(cfg *driver.QueueConfig) int {
+	if cfg.KmsDataKeyReusePeriodSeconds == 0 {
+		return defaultKmsDataKeyReuse
+	}
+
+	return cfg.KmsDataKeyReusePeriodSeconds
+}
+
+// resolveDedupScope applies the FIFO default DeduplicationScope of "queue".
+// It is meaningful only for FIFO queues; a standard queue stores "".
+func resolveDedupScope(cfg *driver.QueueConfig) string {
+	if !cfg.FIFO {
+		return ""
+	}
+
+	if cfg.DeduplicationScope == "" {
+		return dedupScopeQueue
+	}
+
+	return cfg.DeduplicationScope
+}
+
+// resolveFifoThroughputLimit applies the FIFO default FifoThroughputLimit of
+// "perQueue". It is meaningful only for FIFO queues; a standard queue stores "".
+func resolveFifoThroughputLimit(cfg *driver.QueueConfig) string {
+	if !cfg.FIFO {
+		return ""
+	}
+
+	if cfg.FifoThroughputLimit == "" {
+		return fifoThroughputPerQueue
+	}
+
+	return cfg.FifoThroughputLimit
+}
+
 // sameQueueConfig reports whether an existing queue's stored attributes match
 // the incoming CreateQueue config exactly, which is what makes CreateQueue
 // idempotent (identical re-create returns the existing URL).
@@ -297,7 +348,13 @@ func sameQueueConfig(existing *queueData, cfg *driver.QueueConfig) bool {
 		existing.receiveWaitTime == cfg.ReceiveMessageWaitTimeSeconds &&
 		existing.contentBasedDedup == cfg.ContentBasedDeduplication &&
 		existing.redrivePolicy == cfg.RedrivePolicy &&
-		existing.redriveAllowPolicy == cfg.RedriveAllowPolicy
+		existing.redriveAllowPolicy == cfg.RedriveAllowPolicy &&
+		existing.policy == cfg.Policy &&
+		existing.kmsMasterKeyID == cfg.KmsMasterKeyID &&
+		existing.kmsDataKeyReuse == resolveKmsDataKeyReuse(cfg) &&
+		existing.sqsManagedSSE == (cfg.SqsManagedSseEnabled && cfg.KmsMasterKeyID == "") &&
+		existing.deduplicationScope == resolveDedupScope(cfg) &&
+		existing.fifoThroughputLim == resolveFifoThroughputLimit(cfg)
 }
 
 // parseRedrivePolicy resolves an SQS RedrivePolicy JSON document into a
@@ -1263,6 +1320,10 @@ func (m *Mock) GetQueueAttributes(
 		ReceiveMessageWaitTimeSeconds: qd.receiveWaitTime,
 		Policy:                        qd.policy,
 		KmsMasterKeyID:                qd.kmsMasterKeyID,
+		KmsDataKeyReusePeriodSeconds:  qd.kmsDataKeyReuse,
+		SqsManagedSseEnabled:          qd.sqsManagedSSE,
+		DeduplicationScope:            qd.deduplicationScope,
+		FifoThroughputLimit:           qd.fifoThroughputLim,
 	}, nil
 }
 
@@ -1351,13 +1412,50 @@ func (m *Mock) SetQueueAttributesRaw(_ context.Context, queue string, attrs map[
 		qd.policy = v
 	}
 
-	if v, ok := attrs["KmsMasterKeyId"]; ok {
-		qd.kmsMasterKeyID = v
-	}
+	applyEncryptionAttrs(qd, attrs)
+	applyFifoThroughputAttrs(qd, attrs)
 
 	qd.lastModifiedAt = m.opts.Clock.Now()
 
 	return nil
+}
+
+// applyEncryptionAttrs applies the SSE-KMS / SSE-SQS attributes, enforcing the
+// SQS rule that the two encryption options are mutually exclusive: setting a
+// KMS key disables SSE-SQS, and enabling SSE-SQS clears any KMS key. Caller
+// holds qd.mu.
+func applyEncryptionAttrs(qd *queueData, attrs map[string]string) {
+	if v, ok := attrs["KmsMasterKeyId"]; ok {
+		qd.kmsMasterKeyID = v
+		if v != "" {
+			qd.sqsManagedSSE = false
+		}
+	}
+
+	if v, ok := attrs["KmsDataKeyReusePeriodSeconds"]; ok {
+		if n, err := strconv.Atoi(v); err == nil {
+			qd.kmsDataKeyReuse = n
+		}
+	}
+
+	if v, ok := attrs["SqsManagedSseEnabled"]; ok {
+		qd.sqsManagedSSE = v == "true"
+		if qd.sqsManagedSSE {
+			qd.kmsMasterKeyID = ""
+		}
+	}
+}
+
+// applyFifoThroughputAttrs applies the FIFO high-throughput attributes. Caller
+// holds qd.mu.
+func applyFifoThroughputAttrs(qd *queueData, attrs map[string]string) {
+	if v, ok := attrs["DeduplicationScope"]; ok {
+		qd.deduplicationScope = v
+	}
+
+	if v, ok := attrs["FifoThroughputLimit"]; ok {
+		qd.fifoThroughputLim = v
+	}
 }
 
 // parseNumericAttrs extracts the integer-valued queue attributes from a raw

--- a/providers/aws/sqs/sqs.go
+++ b/providers/aws/sqs/sqs.go
@@ -33,6 +33,7 @@ const (
 	defaultKmsDataKeyReuse   = 300
 	dedupScopeQueue          = "queue"
 	fifoThroughputPerQueue   = "perQueue"
+	attrTrue                 = "true"
 	maxReceiveMessages       = 10
 	deduplicationWindow      = 5 * time.Minute
 	maxReceiveWaitSeconds    = 20
@@ -347,13 +348,34 @@ func sameQueueConfig(existing *queueData, cfg *driver.QueueConfig) bool {
 		existing.delaySeconds == cfg.DelaySeconds &&
 		existing.receiveWaitTime == cfg.ReceiveMessageWaitTimeSeconds &&
 		existing.contentBasedDedup == cfg.ContentBasedDeduplication &&
-		existing.redrivePolicy == cfg.RedrivePolicy &&
+		samePolicyConfig(existing, cfg) &&
+		sameSSEConfig(existing, cfg) &&
+		sameFIFOConfig(existing, cfg)
+}
+
+// samePolicyConfig reports whether the redrive and access-policy documents on an
+// existing queue match the requested configuration. The caller must hold
+// existing.mu.
+func samePolicyConfig(existing *queueData, cfg *driver.QueueConfig) bool {
+	return existing.redrivePolicy == cfg.RedrivePolicy &&
 		existing.redriveAllowPolicy == cfg.RedriveAllowPolicy &&
-		existing.policy == cfg.Policy &&
-		existing.kmsMasterKeyID == cfg.KmsMasterKeyID &&
+		existing.policy == cfg.Policy
+}
+
+// sameSSEConfig reports whether the server-side encryption settings on an
+// existing queue match the requested configuration. The caller must hold
+// existing.mu.
+func sameSSEConfig(existing *queueData, cfg *driver.QueueConfig) bool {
+	return existing.kmsMasterKeyID == cfg.KmsMasterKeyID &&
 		existing.kmsDataKeyReuse == resolveKmsDataKeyReuse(cfg) &&
-		existing.sqsManagedSSE == (cfg.SqsManagedSseEnabled && cfg.KmsMasterKeyID == "") &&
-		existing.deduplicationScope == resolveDedupScope(cfg) &&
+		existing.sqsManagedSSE == (cfg.SqsManagedSseEnabled && cfg.KmsMasterKeyID == "")
+}
+
+// sameFIFOConfig reports whether the FIFO deduplication scope and throughput
+// limit on an existing queue match the requested configuration. The caller must
+// hold existing.mu.
+func sameFIFOConfig(existing *queueData, cfg *driver.QueueConfig) bool {
+	return existing.deduplicationScope == resolveDedupScope(cfg) &&
 		existing.fifoThroughputLim == resolveFifoThroughputLimit(cfg)
 }
 
@@ -1405,7 +1427,7 @@ func (m *Mock) SetQueueAttributesRaw(_ context.Context, queue string, attrs map[
 	}
 
 	if v, ok := attrs["ContentBasedDeduplication"]; ok {
-		qd.contentBasedDedup = v == "true"
+		qd.contentBasedDedup = v == attrTrue
 	}
 
 	if v, ok := attrs["Policy"]; ok {
@@ -1439,7 +1461,7 @@ func applyEncryptionAttrs(qd *queueData, attrs map[string]string) {
 	}
 
 	if v, ok := attrs["SqsManagedSseEnabled"]; ok {
-		qd.sqsManagedSSE = v == "true"
+		qd.sqsManagedSSE = v == attrTrue
 		if qd.sqsManagedSSE {
 			qd.kmsMasterKeyID = ""
 		}

--- a/providers/aws/sqs/sqs_test.go
+++ b/providers/aws/sqs/sqs_test.go
@@ -682,3 +682,77 @@ func assertGreaterThan(t *testing.T, actual, threshold int) {
 		t.Errorf("expected > %d, got %d", threshold, actual)
 	}
 }
+
+// TestQueueEncryptionAndFifoThroughputAttributes verifies the SSE and FIFO
+// high-throughput attributes round-trip through CreateQueue and
+// SetQueueAttributesRaw, with SQS defaults applied and the SSE-KMS/SSE-SQS
+// mutual exclusivity enforced.
+func TestQueueEncryptionAndFifoThroughputAttributes(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	// SSE-SQS + Policy at create.
+	sse, err := m.CreateQueue(ctx, driver.QueueConfig{
+		Name:                 "sse",
+		SqsManagedSseEnabled: true,
+		Policy:               `{"Version":"2012-10-17"}`,
+	})
+	requireNoError(t, err)
+
+	attrs, err := m.GetQueueAttributes(ctx, sse.URL)
+	requireNoError(t, err)
+	assertEqual(t, true, attrs.SqsManagedSseEnabled)
+	assertEqual(t, `{"Version":"2012-10-17"}`, attrs.Policy)
+
+	// SSE-KMS at create disables SSE-SQS and defaults the reuse period to 300.
+	kms, err := m.CreateQueue(ctx, driver.QueueConfig{
+		Name:                 "kms",
+		KmsMasterKeyID:       "alias/aws/sqs",
+		SqsManagedSseEnabled: true, // must be overridden by the KMS key
+	})
+	requireNoError(t, err)
+
+	attrs, err = m.GetQueueAttributes(ctx, kms.URL)
+	requireNoError(t, err)
+	assertEqual(t, "alias/aws/sqs", attrs.KmsMasterKeyID)
+	assertEqual(t, 300, attrs.KmsDataKeyReusePeriodSeconds)
+	assertEqual(t, false, attrs.SqsManagedSseEnabled)
+
+	// FIFO defaults.
+	fifo, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "q.fifo", FIFO: true})
+	requireNoError(t, err)
+
+	attrs, err = m.GetQueueAttributes(ctx, fifo.URL)
+	requireNoError(t, err)
+	assertEqual(t, "queue", attrs.DeduplicationScope)
+	assertEqual(t, "perQueue", attrs.FifoThroughputLimit)
+
+	// SetQueueAttributesRaw round-trip: enabling SSE-SQS on the KMS queue clears
+	// the KMS key; set FIFO high-throughput on the FIFO queue.
+	requireNoError(t, m.SetQueueAttributesRaw(ctx, kms.URL, map[string]string{
+		"SqsManagedSseEnabled": "true",
+	}))
+
+	attrs, err = m.GetQueueAttributes(ctx, kms.URL)
+	requireNoError(t, err)
+	assertEqual(t, true, attrs.SqsManagedSseEnabled)
+	assertEqual(t, "", attrs.KmsMasterKeyID)
+
+	requireNoError(t, m.SetQueueAttributesRaw(ctx, fifo.URL, map[string]string{
+		"DeduplicationScope":  "messageGroup",
+		"FifoThroughputLimit": "perMessageGroupId",
+	}))
+
+	attrs, err = m.GetQueueAttributes(ctx, fifo.URL)
+	requireNoError(t, err)
+	assertEqual(t, "messageGroup", attrs.DeduplicationScope)
+	assertEqual(t, "perMessageGroupId", attrs.FifoThroughputLimit)
+
+	// Standard queue reports neither FIFO high-throughput attribute.
+	std := createStdQueue(m, "plain")
+
+	attrs, err = m.GetQueueAttributes(ctx, std.URL)
+	requireNoError(t, err)
+	assertEqual(t, "", attrs.DeduplicationScope)
+	assertEqual(t, "", attrs.FifoThroughputLimit)
+}

--- a/server/aws/sqs/batch_validation_test.go
+++ b/server/aws/sqs/batch_validation_test.go
@@ -161,6 +161,54 @@ func TestSDKSetQueueAttributesOutOfRange(t *testing.T) {
 	}
 }
 
+// TestSDKKmsDataKeyReusePeriodRange guards fix #8: KmsDataKeyReusePeriodSeconds
+// must reject values outside [60, 86400] with InvalidAttributeValue and accept the
+// boundaries, on both CreateQueue and SetQueueAttributes.
+func TestSDKKmsDataKeyReusePeriodRange(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		value   string
+		wantErr bool
+	}{
+		{"59", true},
+		{"60", false},
+		{"86400", false},
+		{"86401", true},
+	}
+
+	for _, tc := range cases {
+		attrs := map[string]string{"KmsDataKeyReusePeriodSeconds": tc.value}
+
+		_, createErr := client.CreateQueue(ctx, &awssqs.CreateQueueInput{
+			QueueName:  aws.String(fmt.Sprintf("kms-create-%s", tc.value)),
+			Attributes: attrs,
+		})
+		if tc.wantErr {
+			if code := apiErrorCode(t, createErr); code != "InvalidAttributeValue" {
+				t.Fatalf("CreateQueue KmsDataKeyReusePeriodSeconds=%s: code = %q, want InvalidAttributeValue", tc.value, code)
+			}
+		} else if createErr != nil {
+			t.Fatalf("CreateQueue KmsDataKeyReusePeriodSeconds=%s: unexpected error %v", tc.value, createErr)
+		}
+
+		url := mustCreateQueue(t, client, fmt.Sprintf("kms-set-%s", tc.value))
+
+		_, setErr := client.SetQueueAttributes(ctx, &awssqs.SetQueueAttributesInput{
+			QueueUrl:   aws.String(url),
+			Attributes: attrs,
+		})
+		if tc.wantErr {
+			if code := apiErrorCode(t, setErr); code != "InvalidAttributeValue" {
+				t.Fatalf("SetQueueAttributes KmsDataKeyReusePeriodSeconds=%s: code = %q, want InvalidAttributeValue", tc.value, code)
+			}
+		} else if setErr != nil {
+			t.Fatalf("SetQueueAttributes KmsDataKeyReusePeriodSeconds=%s: unexpected error %v", tc.value, setErr)
+		}
+	}
+}
+
 // TestSDKSetQueueAttributesInRange guards the happy path: valid values still apply.
 func TestSDKSetQueueAttributesInRange(t *testing.T) {
 	client, _ := newSDKClient(t)

--- a/server/aws/sqs/handler.go
+++ b/server/aws/sqs/handler.go
@@ -154,6 +154,12 @@ func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request) {
 		ContentBasedDeduplication:     req.Attributes["ContentBasedDeduplication"] == attrTrue,
 		RedrivePolicy:                 req.Attributes["RedrivePolicy"],
 		RedriveAllowPolicy:            req.Attributes["RedriveAllowPolicy"],
+		Policy:                        req.Attributes["Policy"],
+		KmsMasterKeyID:                req.Attributes["KmsMasterKeyId"],
+		KmsDataKeyReusePeriodSeconds:  atoiAttr(req.Attributes, "KmsDataKeyReusePeriodSeconds"),
+		SqsManagedSseEnabled:          req.Attributes["SqsManagedSseEnabled"] == attrTrue,
+		DeduplicationScope:            req.Attributes["DeduplicationScope"],
+		FifoThroughputLimit:           req.Attributes["FifoThroughputLimit"],
 	}
 
 	info, err := h.mq.CreateQueue(r.Context(), cfg)
@@ -1036,13 +1042,22 @@ func (h *Handler) getQueueAttributes(w http.ResponseWriter, r *http.Request) {
 		"ReceiveMessageWaitTimeSeconds":         strconv.Itoa(attrs.ReceiveMessageWaitTimeSeconds),
 		"CreatedTimestamp":                      strconv.FormatInt(attrs.CreatedAt.Unix(), 10),
 		"LastModifiedTimestamp":                 strconv.FormatInt(attrs.LastModifiedAt.Unix(), 10),
-		"SqsManagedSseEnabled":                  "false",
+		"SqsManagedSseEnabled":                  strconv.FormatBool(attrs.SqsManagedSseEnabled),
 	}
 
-	// SQS returns FifoQueue/ContentBasedDeduplication only for FIFO queues.
+	// SQS returns FifoQueue/ContentBasedDeduplication and the high-throughput
+	// attributes only for FIFO queues.
 	if attrs.FifoQueue {
 		all["FifoQueue"] = attrTrue
 		all["ContentBasedDeduplication"] = strconv.FormatBool(attrs.ContentBasedDeduplication)
+		all["DeduplicationScope"] = attrs.DeduplicationScope
+		all["FifoThroughputLimit"] = attrs.FifoThroughputLimit
+	}
+
+	// SSE-KMS attributes appear only when a KMS key is configured, matching real
+	// SQS (a plain or SSE-SQS queue omits them).
+	if attrs.KmsMasterKeyID != "" {
+		all["KmsDataKeyReusePeriodSeconds"] = strconv.Itoa(attrs.KmsDataKeyReusePeriodSeconds)
 	}
 
 	if attrs.RedrivePolicy != "" {

--- a/server/aws/sqs/request_validation.go
+++ b/server/aws/sqs/request_validation.go
@@ -24,6 +24,8 @@ const (
 	maxMessageSizeBytes  = 1048576
 	minWaitTimeSeconds   = 0
 	maxWaitTimeSeconds   = 20
+	minKmsDataKeyReuse   = 60
+	maxKmsDataKeyReuse   = 86400
 )
 
 // validateBatchEntryIDs enforces the structural constraints SQS applies to every
@@ -76,6 +78,7 @@ func validateQueueAttributeRanges(w http.ResponseWriter, attrs map[string]string
 		{"MessageRetentionPeriod", minRetentionPeriod, maxRetentionPeriod},
 		{"MaximumMessageSize", minMessageSizeBytes, maxMessageSizeBytes},
 		{"ReceiveMessageWaitTimeSeconds", minWaitTimeSeconds, maxWaitTimeSeconds},
+		{"KmsDataKeyReusePeriodSeconds", minKmsDataKeyReuse, maxKmsDataKeyReuse},
 	}
 
 	for _, rng := range ranges {

--- a/server/aws/sqs/sdk_roundtrip_attributes_test.go
+++ b/server/aws/sqs/sdk_roundtrip_attributes_test.go
@@ -100,6 +100,158 @@ func TestSDKSQSRedriveAllowPolicyOnCreate(t *testing.T) {
 	}
 }
 
+// TestSDKSQSEncryptionAttributesRoundTrip confirms the server-side-encryption
+// attributes (SqsManagedSseEnabled for SSE-SQS, and KmsMasterKeyId /
+// KmsDataKeyReusePeriodSeconds for SSE-KMS) persist through CreateQueue and are
+// echoed by GetQueueAttributes(All), matching real SQS. terraform-provider-aws
+// reads these on every refresh, so a dropped attribute is perpetual drift.
+func TestSDKSQSEncryptionAttributesRoundTrip(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	// SSE-SQS queue.
+	sse, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{
+		QueueName: aws.String("sse-sqs-q"),
+		Attributes: map[string]string{
+			string(sqstypes.QueueAttributeNameSqsManagedSseEnabled): "true",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue (SSE-SQS): %v", err)
+	}
+
+	got, err := client.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       sse.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameAll},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes (SSE-SQS): %v", err)
+	}
+
+	if v := got.Attributes["SqsManagedSseEnabled"]; v != "true" {
+		t.Fatalf("SqsManagedSseEnabled = %q, want true", v)
+	}
+
+	// SSE-KMS queue: KmsMasterKeyId set, so SqsManagedSseEnabled must read false
+	// and KmsDataKeyReusePeriodSeconds must round-trip.
+	kms, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{
+		QueueName: aws.String("sse-kms-q"),
+		Attributes: map[string]string{
+			string(sqstypes.QueueAttributeNameKmsMasterKeyId):               "alias/aws/sqs",
+			string(sqstypes.QueueAttributeNameKmsDataKeyReusePeriodSeconds): "600",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue (SSE-KMS): %v", err)
+	}
+
+	got, err = client.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       kms.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameAll},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes (SSE-KMS): %v", err)
+	}
+
+	if v := got.Attributes["KmsMasterKeyId"]; v != "alias/aws/sqs" {
+		t.Fatalf("KmsMasterKeyId = %q, want alias/aws/sqs", v)
+	}
+
+	if v := got.Attributes["KmsDataKeyReusePeriodSeconds"]; v != "600" {
+		t.Fatalf("KmsDataKeyReusePeriodSeconds = %q, want 600", v)
+	}
+
+	if v := got.Attributes["SqsManagedSseEnabled"]; v != "false" {
+		t.Fatalf("SqsManagedSseEnabled = %q, want false (mutually exclusive with SSE-KMS)", v)
+	}
+}
+
+// TestSDKSQSFifoThroughputAttributesRoundTrip confirms the FIFO high-throughput
+// attributes DeduplicationScope and FifoThroughputLimit persist through
+// CreateQueue and are echoed only for FIFO queues, with the SQS defaults
+// (queue / perQueue) applied when unset. Matches real SQS.
+func TestSDKSQSFifoThroughputAttributesRoundTrip(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	ht, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{
+		QueueName: aws.String("ht-q.fifo"),
+		Attributes: map[string]string{
+			string(sqstypes.QueueAttributeNameFifoQueue):           "true",
+			string(sqstypes.QueueAttributeNameDeduplicationScope):  "messageGroup",
+			string(sqstypes.QueueAttributeNameFifoThroughputLimit): "perMessageGroupId",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue (HT FIFO): %v", err)
+	}
+
+	got, err := client.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       ht.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameAll},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes (HT FIFO): %v", err)
+	}
+
+	if v := got.Attributes["DeduplicationScope"]; v != "messageGroup" {
+		t.Fatalf("DeduplicationScope = %q, want messageGroup", v)
+	}
+
+	if v := got.Attributes["FifoThroughputLimit"]; v != "perMessageGroupId" {
+		t.Fatalf("FifoThroughputLimit = %q, want perMessageGroupId", v)
+	}
+
+	// A default FIFO queue reports the SQS defaults.
+	def, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{
+		QueueName: aws.String("def-q.fifo"),
+		Attributes: map[string]string{
+			string(sqstypes.QueueAttributeNameFifoQueue): "true",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue (default FIFO): %v", err)
+	}
+
+	got, err = client.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       def.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameAll},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes (default FIFO): %v", err)
+	}
+
+	if v := got.Attributes["DeduplicationScope"]; v != "queue" {
+		t.Fatalf("default DeduplicationScope = %q, want queue", v)
+	}
+
+	if v := got.Attributes["FifoThroughputLimit"]; v != "perQueue" {
+		t.Fatalf("default FifoThroughputLimit = %q, want perQueue", v)
+	}
+
+	// A standard queue must not report the FIFO-only attributes.
+	std, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{QueueName: aws.String("std-noht-q")})
+	if err != nil {
+		t.Fatalf("CreateQueue (standard): %v", err)
+	}
+
+	got, err = client.GetQueueAttributes(ctx, &awssqs.GetQueueAttributesInput{
+		QueueUrl:       std.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameAll},
+	})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes (standard): %v", err)
+	}
+
+	if _, ok := got.Attributes["DeduplicationScope"]; ok {
+		t.Fatal("standard queue must not report DeduplicationScope")
+	}
+
+	if _, ok := got.Attributes["FifoThroughputLimit"]; ok {
+		t.Fatal("standard queue must not report FifoThroughputLimit")
+	}
+}
+
 // TestSDKSQSAWSTraceHeaderSystemAttribute confirms SendMessage accepts the
 // AWSTraceHeader message system attribute, returns MD5OfMessageSystemAttributes,
 // and ReceiveMessage returns AWSTraceHeader in the message Attributes map when

--- a/services/messagequeue/driver/driver.go
+++ b/services/messagequeue/driver/driver.go
@@ -48,6 +48,22 @@ type QueueConfig struct {
 	// (redrivePermission=allowAll|denyAll|byQueue + sourceQueueArns). It is
 	// persisted and echoed by GetQueueAttributes.
 	RedriveAllowPolicy string
+	// Policy is the queue's access-policy JSON document, accepted at CreateQueue
+	// and echoed by GetQueueAttributes.
+	Policy string
+	// KmsMasterKeyID selects SSE-KMS for the queue (the KMS key id/alias). Setting
+	// it is mutually exclusive with SqsManagedSseEnabled.
+	KmsMasterKeyID string
+	// KmsDataKeyReusePeriodSeconds is the SSE-KMS data-key reuse window in seconds
+	// (60-86400). Zero falls back to the SQS default of 300.
+	KmsDataKeyReusePeriodSeconds int
+	// SqsManagedSseEnabled selects SSE-SQS (SQS-owned keys). Mutually exclusive
+	// with KmsMasterKeyID.
+	SqsManagedSseEnabled bool
+	// DeduplicationScope (FIFO only) is "queue" (default) or "messageGroup".
+	DeduplicationScope string
+	// FifoThroughputLimit (FIFO only) is "perQueue" (default) or "perMessageGroupId".
+	FifoThroughputLimit string
 	// VisibilityTimeoutSet reports that VisibilityTimeout was supplied explicitly,
 	// so the AWS provider can distinguish an explicit 0 (kept as 0) from an
 	// omitted value (defaulted to 30). The wire handler sets it from attribute
@@ -231,6 +247,15 @@ type QueueAttributes struct {
 	ApproximateDelayedCount       int
 	Policy                        string
 	KmsMasterKeyID                string
+	// KmsDataKeyReusePeriodSeconds is the SSE-KMS data-key reuse window (seconds);
+	// meaningful only when KmsMasterKeyID is set.
+	KmsDataKeyReusePeriodSeconds int
+	// SqsManagedSseEnabled reports whether SSE-SQS (SQS-owned keys) is enabled.
+	SqsManagedSseEnabled bool
+	// DeduplicationScope and FifoThroughputLimit are FIFO-only high-throughput
+	// attributes ("queue"/"messageGroup" and "perQueue"/"perMessageGroupId").
+	DeduplicationScope  string
+	FifoThroughputLimit string
 }
 
 // MessageMoveTask describes an SQS dead-letter-queue redrive task, as reported


### PR DESCRIPTION
## Summary
Real-user e2e audit of AWS SQS found one high-impact class of divergence: several queue attributes were silently dropped or hardcoded, causing perpetual `terraform aws_sqs_queue` drift (Terraform reads `GetQueueAttributes` on every refresh). Fixed the full create/get/set round-trip.

## Divergences fixed (verified live: aws-cli + Terraform apply→plan = "No changes")
- `SqsManagedSseEnabled` — was hardcoded `"false"`; now round-trips (create + SetQueueAttributes).
- `KmsMasterKeyId` — was dropped at CreateQueue; now stored at create too.
- `KmsDataKeyReusePeriodSeconds` — was never stored/returned; now round-trips (default 300, emitted only when a KMS key is set), with range validation (60–86400 → InvalidAttributeValue).
- `Policy` — was dropped at CreateQueue; now stored at create.
- `DeduplicationScope` / `FifoThroughputLimit` (FIFO high-throughput) — were never stored/returned; now round-trip with defaults `queue` / `perQueue`, emitted only for FIFO queues.
- SSE-KMS / SSE-SQS are now mutually exclusive (setting a KMS key clears SSE-SQS and vice versa), matching "only one server-side encryption option per queue".

## Landing
- `services/messagequeue/driver/driver.go` — new QueueConfig + QueueAttributes fields.
- `providers/aws/sqs/{sqs,snapshot}.go` — store/default/return the attributes; snapshot completeness.
- `server/aws/sqs/{handler,request_validation}.go` — wire read/emit + range validation.

## Tests
- Provider-level `TestQueueEncryptionAndFifoThroughputAttributes`.
- Server SDK-level `TestSDKSQSEncryptionAttributesRoundTrip`, `TestSDKSQSFifoThroughputAttributesRoundTrip`.
- Gates: build, `go test -race` (providers/aws/sqs, server/aws/sqs, messagequeue, persist), vet, gofmt, golangci-lint (`--new-from-rev`, 0 issues), `go generate` (no docs/coverage diff — field-only change).