### PR TITLE
fix(storageaccount): real-user e2e divergences from Azure

### DIFF
--- a/server/azure/storageaccount/account_security_properties_test.go
+++ b/server/azure/storageaccount/account_security_properties_test.go
@@ -1,0 +1,172 @@
+package storageaccount_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSDKStorageAccountSecurityDefaults proves an account created WITHOUT the
+// security toggles reads back the real-Azure defaults (minimum TLS 1.2, public
+// network access Enabled, HTTPS-only true, blob public access false, shared-key
+// access true). Before the fix these all came back nil, so a raw SDK/CLI read
+// (az storage account show) or a Terraform refresh saw missing attributes.
+func TestSDKStorageAccountSecurityDefaults(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acctdef", armstorage.AccountCreateParameters{
+		Location: to.Ptr("westus2"),
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	got, err := client.GetProperties(ctx, "rg-1", "acctdef", nil)
+	require.NoError(t, err)
+	props := got.Properties
+	require.NotNil(t, props)
+
+	require.NotNil(t, props.MinimumTLSVersion)
+	assert.Equal(t, armstorage.MinimumTLSVersionTLS12, *props.MinimumTLSVersion)
+	require.NotNil(t, props.PublicNetworkAccess)
+	assert.Equal(t, armstorage.PublicNetworkAccessEnabled, *props.PublicNetworkAccess)
+	require.NotNil(t, props.EnableHTTPSTrafficOnly)
+	assert.True(t, *props.EnableHTTPSTrafficOnly, "supportsHttpsTrafficOnly defaults to true")
+	require.NotNil(t, props.AllowBlobPublicAccess)
+	assert.False(t, *props.AllowBlobPublicAccess, "allowBlobPublicAccess defaults to false")
+	require.NotNil(t, props.AllowSharedKeyAccess)
+	assert.True(t, *props.AllowSharedKeyAccess, "allowSharedKeyAccess defaults to true")
+}
+
+// TestSDKStorageAccountSecurityExplicitFalse proves the explicitly-false
+// security booleans survive create -> get. The echo-properties overlay drops
+// zero-valued scalars it doesn't model, so a Terraform user setting
+// https_traffic_only_enabled/shared_access_key_enabled/allow_nested_items_to_be_public
+// to false previously saw perpetual drift (the value read back as nil/absent).
+func TestSDKStorageAccountSecurityExplicitFalse(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acctsec", armstorage.AccountCreateParameters{
+		Location: to.Ptr("westus2"),
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+		Properties: &armstorage.AccountPropertiesCreateParameters{
+			EnableHTTPSTrafficOnly: to.Ptr(false),
+			AllowBlobPublicAccess:  to.Ptr(false),
+			AllowSharedKeyAccess:   to.Ptr(false),
+			MinimumTLSVersion:      to.Ptr(armstorage.MinimumTLSVersionTLS10),
+			PublicNetworkAccess:    to.Ptr(armstorage.PublicNetworkAccessDisabled),
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+	assertSecurity(t, created.Properties, false, false, false,
+		armstorage.MinimumTLSVersionTLS10, armstorage.PublicNetworkAccessDisabled)
+
+	got, err := client.GetProperties(ctx, "rg-1", "acctsec", nil)
+	require.NoError(t, err)
+	assertSecurity(t, got.Properties, false, false, false,
+		armstorage.MinimumTLSVersionTLS10, armstorage.PublicNetworkAccessDisabled)
+}
+
+// TestSDKStorageAccountSecurityPatchPreserve proves a PATCH that only changes
+// tags leaves the security toggles untouched (partial-update semantics), and a
+// PATCH that flips one toggle changes only that one.
+func TestSDKStorageAccountSecurityPatchPreserve(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acctpatch", armstorage.AccountCreateParameters{
+		Location: to.Ptr("westus2"),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+		Properties: &armstorage.AccountPropertiesCreateParameters{
+			EnableHTTPSTrafficOnly: to.Ptr(false),
+			AllowSharedKeyAccess:   to.Ptr(false),
+		},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	_, err = client.Update(ctx, "rg-1", "acctpatch", armstorage.AccountUpdateParameters{
+		Tags: map[string]*string{"env": to.Ptr("prod")},
+	}, nil)
+	require.NoError(t, err)
+
+	got, err := client.GetProperties(ctx, "rg-1", "acctpatch", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.Properties.EnableHTTPSTrafficOnly)
+	assert.False(t, *got.Properties.EnableHTTPSTrafficOnly, "tags-only PATCH must not reset httpsOnly")
+	require.NotNil(t, got.Properties.AllowSharedKeyAccess)
+	assert.False(t, *got.Properties.AllowSharedKeyAccess, "tags-only PATCH must not reset sharedKey")
+
+	_, err = client.Update(ctx, "rg-1", "acctpatch", armstorage.AccountUpdateParameters{
+		Properties: &armstorage.AccountPropertiesUpdateParameters{
+			EnableHTTPSTrafficOnly: to.Ptr(true),
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	got2, err := client.GetProperties(ctx, "rg-1", "acctpatch", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got2.Properties.EnableHTTPSTrafficOnly)
+	assert.True(t, *got2.Properties.EnableHTTPSTrafficOnly, "PATCH must flip httpsOnly to true")
+	require.NotNil(t, got2.Properties.AllowSharedKeyAccess)
+	assert.False(t, *got2.Properties.AllowSharedKeyAccess, "PATCH of one toggle must not touch the other")
+}
+
+// TestSDKStorageAccountSecurityReplaceResetsDefaults proves a re-PUT that omits
+// a previously-set toggle resets it to the real-Azure default (create-or-update
+// is full-replace, mirroring how sku/kind/tags already behave on this handler).
+func TestSDKStorageAccountSecurityReplaceResetsDefaults(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	create := func(props *armstorage.AccountPropertiesCreateParameters) {
+		poller, err := client.BeginCreate(ctx, "rg-1", "acctrep", armstorage.AccountCreateParameters{
+			Location:   to.Ptr("westus2"),
+			SKU:        &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+			Properties: props,
+		}, nil)
+		require.NoError(t, err)
+		_, err = poller.PollUntilDone(ctx, nil)
+		require.NoError(t, err)
+	}
+
+	create(&armstorage.AccountPropertiesCreateParameters{EnableHTTPSTrafficOnly: to.Ptr(false)})
+	create(nil) // re-PUT without the toggle
+
+	got, err := client.GetProperties(ctx, "rg-1", "acctrep", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.Properties.EnableHTTPSTrafficOnly)
+	assert.True(t, *got.Properties.EnableHTTPSTrafficOnly, "re-PUT omitting the toggle resets to default true")
+}
+
+func assertSecurity(
+	t *testing.T, props *armstorage.AccountProperties,
+	httpsOnly, blobPublic, sharedKey bool,
+	tls armstorage.MinimumTLSVersion, pna armstorage.PublicNetworkAccess,
+) {
+	t.Helper()
+	require.NotNil(t, props)
+	require.NotNil(t, props.EnableHTTPSTrafficOnly)
+	assert.Equal(t, httpsOnly, *props.EnableHTTPSTrafficOnly)
+	require.NotNil(t, props.AllowBlobPublicAccess)
+	assert.Equal(t, blobPublic, *props.AllowBlobPublicAccess)
+	require.NotNil(t, props.AllowSharedKeyAccess)
+	assert.Equal(t, sharedKey, *props.AllowSharedKeyAccess)
+	require.NotNil(t, props.MinimumTLSVersion)
+	assert.Equal(t, tls, *props.MinimumTLSVersion)
+	require.NotNil(t, props.PublicNetworkAccess)
+	assert.Equal(t, pna, *props.PublicNetworkAccess)
+}

--- a/server/azure/storageaccount/handler.go
+++ b/server/azure/storageaccount/handler.go
@@ -44,6 +44,17 @@ const (
 
 	minAccountNameLen = 3
 	maxAccountNameLen = 24
+
+	// Real-Azure defaults reported for a new account that omits these toggles:
+	// minimum TLS 1.2, public network access enabled, HTTPS-only on, blob public
+	// access off, shared-key access on. Modeled here (rather than left to the
+	// echo-properties overlay) so an explicitly-false value survives round-trip
+	// and a create that omits them still reads back real defaults.
+	defaultMinTLSVersion       = "TLS1_2"
+	defaultPublicNetworkAccess = "Enabled"
+	defaultHTTPSTrafficOnly    = true
+	defaultBlobPublicAccess    = false
+	defaultSharedKeyAccess     = true
 )
 
 // attrBackend is the optional storage-account attribute capability. The Azure
@@ -390,6 +401,11 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azu
 
 	if body.Properties != nil {
 		attrs.AccessTier = body.Properties.AccessTier
+		attrs.MinimumTLSVersion = body.Properties.MinimumTLSVersion
+		attrs.PublicNetworkAccess = body.Properties.PublicNetworkAccess
+		attrs.EnableHTTPSTrafficOnly = body.Properties.SupportsHTTPSTrafficOnly
+		attrs.AllowBlobPublicAccess = body.Properties.AllowBlobPublicAccess
+		attrs.AllowSharedKeyAccess = body.Properties.AllowSharedKeyAccess
 		encryption = fromARMEncryptionReq(body.Properties.Encryption)
 	}
 
@@ -481,8 +497,34 @@ func applyAccountUpdate(cur *storagedriver.AccountAttributes, body *armAccountUp
 		cur.Tags = body.Tags
 	}
 
-	if body.Properties != nil && body.Properties.AccessTier != "" {
+	if body.Properties == nil {
+		return
+	}
+
+	if body.Properties.AccessTier != "" {
 		cur.AccessTier = body.Properties.AccessTier
+	}
+
+	if body.Properties.MinimumTLSVersion != "" {
+		cur.MinimumTLSVersion = body.Properties.MinimumTLSVersion
+	}
+
+	if body.Properties.PublicNetworkAccess != "" {
+		cur.PublicNetworkAccess = body.Properties.PublicNetworkAccess
+	}
+
+	// The security toggles PATCH-merge on presence: a non-nil pointer overwrites
+	// (including an explicit false), a nil one leaves the stored value untouched.
+	if body.Properties.SupportsHTTPSTrafficOnly != nil {
+		cur.EnableHTTPSTrafficOnly = body.Properties.SupportsHTTPSTrafficOnly
+	}
+
+	if body.Properties.AllowBlobPublicAccess != nil {
+		cur.AllowBlobPublicAccess = body.Properties.AllowBlobPublicAccess
+	}
+
+	if body.Properties.AllowSharedKeyAccess != nil {
+		cur.AllowSharedKeyAccess = body.Properties.AllowSharedKeyAccess
 	}
 }
 
@@ -586,13 +628,18 @@ func (h *Handler) toARMAccount(ctx context.Context, rp *azurearm.ResourcePath) a
 	}
 
 	props := &armAccountProps{
-		AccessTier:        attrs.AccessTier,
-		ProvisioningState: "Succeeded",
-		PrimaryLocation:   location,
-		StatusOfPrimary:   "available",
-		CreationTime:      h.accountCreatedAt(ctx, rp.ResourceName),
-		PrimaryEndpoints:  accountEndpoints(rp.ResourceName),
-		Encryption:        armEncryptionFor(encryption),
+		AccessTier:               attrs.AccessTier,
+		ProvisioningState:        "Succeeded",
+		PrimaryLocation:          location,
+		StatusOfPrimary:          "available",
+		CreationTime:             h.accountCreatedAt(ctx, rp.ResourceName),
+		PrimaryEndpoints:         accountEndpoints(rp.ResourceName),
+		Encryption:               armEncryptionFor(encryption),
+		MinimumTLSVersion:        strOr(attrs.MinimumTLSVersion, defaultMinTLSVersion),
+		PublicNetworkAccess:      strOr(attrs.PublicNetworkAccess, defaultPublicNetworkAccess),
+		SupportsHTTPSTrafficOnly: boolOr(attrs.EnableHTTPSTrafficOnly, defaultHTTPSTrafficOnly),
+		AllowBlobPublicAccess:    boolOr(attrs.AllowBlobPublicAccess, defaultBlobPublicAccess),
+		AllowSharedKeyAccess:     boolOr(attrs.AllowSharedKeyAccess, defaultSharedKeyAccess),
 	}
 
 	// GRS/RA-GRS/GZRS/RA-GZRS replicate to a documented paired region;
@@ -764,6 +811,26 @@ func (h *Handler) accountCreatedAt(ctx context.Context, name string) string {
 	}
 
 	return fallback
+}
+
+// strOr returns v when non-empty, else the real-Azure default def.
+func strOr(v, def string) string {
+	if v == "" {
+		return def
+	}
+
+	return v
+}
+
+// boolOr dereferences p when set, else returns the real-Azure default def —
+// letting an explicitly-stored false survive while an unset toggle reads back
+// its documented default.
+func boolOr(p *bool, def bool) bool {
+	if p == nil {
+		return def
+	}
+
+	return *p
 }
 
 // skuTier derives the read-only SKU tier from the SKU name (Standard_LRS ->

--- a/server/azure/storageaccount/handler.go
+++ b/server/azure/storageaccount/handler.go
@@ -50,6 +50,11 @@ const (
 	// access off, shared-key access on. Modeled here (rather than left to the
 	// echo-properties overlay) so an explicitly-false value survives round-trip
 	// and a create that omits them still reads back real defaults.
+	// The REST reference's property text calls TLS 1.0 the "default
+	// interpretation", but its own GetProperties sample response reports
+	// "TLS1_2", and the azurerm provider always sends min_tls_version=TLS1_2
+	// explicitly — so TLS1_2 matches the documented example, causes no Terraform
+	// drift, and reflects modern Azure hardening.
 	defaultMinTLSVersion       = "TLS1_2"
 	defaultPublicNetworkAccess = "Enabled"
 	defaultHTTPSTrafficOnly    = true
@@ -513,18 +518,23 @@ func applyAccountUpdate(cur *storagedriver.AccountAttributes, body *armAccountUp
 		cur.PublicNetworkAccess = body.Properties.PublicNetworkAccess
 	}
 
-	// The security toggles PATCH-merge on presence: a non-nil pointer overwrites
-	// (including an explicit false), a nil one leaves the stored value untouched.
-	if body.Properties.SupportsHTTPSTrafficOnly != nil {
-		cur.EnableHTTPSTrafficOnly = body.Properties.SupportsHTTPSTrafficOnly
+	applySecurityToggles(cur, body.Properties)
+}
+
+// applySecurityToggles PATCH-merges the *bool security toggles on presence: a
+// non-nil pointer overwrites the stored value (including an explicit false), a
+// nil one leaves it untouched.
+func applySecurityToggles(cur *storagedriver.AccountAttributes, props *armAccountPropsReq) {
+	if props.SupportsHTTPSTrafficOnly != nil {
+		cur.EnableHTTPSTrafficOnly = props.SupportsHTTPSTrafficOnly
 	}
 
-	if body.Properties.AllowBlobPublicAccess != nil {
-		cur.AllowBlobPublicAccess = body.Properties.AllowBlobPublicAccess
+	if props.AllowBlobPublicAccess != nil {
+		cur.AllowBlobPublicAccess = props.AllowBlobPublicAccess
 	}
 
-	if body.Properties.AllowSharedKeyAccess != nil {
-		cur.AllowSharedKeyAccess = body.Properties.AllowSharedKeyAccess
+	if props.AllowSharedKeyAccess != nil {
+		cur.AllowSharedKeyAccess = props.AllowSharedKeyAccess
 	}
 }
 

--- a/server/azure/storageaccount/types.go
+++ b/server/azure/storageaccount/types.go
@@ -27,6 +27,17 @@ type armAccountUpdate struct {
 type armAccountPropsReq struct {
 	AccessTier string            `json:"accessTier,omitempty"`
 	Encryption *armEncryptionReq `json:"encryption,omitempty"`
+	// MinimumTLSVersion / PublicNetworkAccess are string toggles; empty means the
+	// request omitted them.
+	MinimumTLSVersion   string `json:"minimumTlsVersion,omitempty"`
+	PublicNetworkAccess string `json:"publicNetworkAccess,omitempty"`
+	// SupportsHTTPSTrafficOnly / AllowBlobPublicAccess / AllowSharedKeyAccess are
+	// pointers so a PATCH can tell "omitted" (nil) from "explicitly false" — the
+	// distinction the echo-properties overlay drops for zero-valued scalars, which
+	// is why these must be modeled here rather than left to the overlay.
+	SupportsHTTPSTrafficOnly *bool `json:"supportsHttpsTrafficOnly,omitempty"`
+	AllowBlobPublicAccess    *bool `json:"allowBlobPublicAccess,omitempty"`
+	AllowSharedKeyAccess     *bool `json:"allowSharedKeyAccess,omitempty"`
 }
 
 // armEncryptionReq is the request-side encryption block: keySource selects
@@ -72,6 +83,15 @@ type armAccountProps struct {
 	PrimaryEndpoints  *armEndpoints `json:"primaryEndpoints,omitempty"`
 	PrimaryLocation   string        `json:"primaryLocation,omitempty"`
 	StatusOfPrimary   string        `json:"statusOfPrimary,omitempty"`
+	// The account security toggles are always rendered (with real-Azure defaults
+	// when unset) so a create that omits them still reads back the values real
+	// Azure reports, and an explicit "false" is never dropped. The bools carry no
+	// omitempty — false is a meaningful, must-be-serialized value here.
+	MinimumTLSVersion        string `json:"minimumTlsVersion,omitempty"`
+	PublicNetworkAccess      string `json:"publicNetworkAccess,omitempty"`
+	SupportsHTTPSTrafficOnly bool   `json:"supportsHttpsTrafficOnly"`
+	AllowBlobPublicAccess    bool   `json:"allowBlobPublicAccess"`
+	AllowSharedKeyAccess     bool   `json:"allowSharedKeyAccess"`
 	// SecondaryLocation/StatusOfSecondary are populated for GRS/RA-GRS/GZRS/
 	// RA-GZRS SKUs; SecondaryEndpoints only for the read-access (RA-*) variants
 	// — matching real Azure (see armstorage AccountProperties doc comments).

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -53,6 +53,23 @@ type AccountAttributes struct {
 	// Tags are the ARM resource tags submitted on create-or-update, round-tripped
 	// back on GET / list.
 	Tags map[string]string
+	// MinimumTLSVersion is the account's minimum permitted TLS version
+	// (minimumTlsVersion — e.g. TLS1_0/TLS1_1/TLS1_2). Empty means unset; the
+	// handler renders the real-Azure default (TLS1_2) instead.
+	MinimumTLSVersion string
+	// PublicNetworkAccess gates public endpoint reachability (publicNetworkAccess
+	// — Enabled/Disabled/SecuredByPerimeter). Empty means unset; the handler
+	// renders the real-Azure default (Enabled).
+	PublicNetworkAccess string
+	// EnableHTTPSTrafficOnly, AllowBlobPublicAccess and AllowSharedKeyAccess are
+	// the account's security toggles (supportsHttpsTrafficOnly,
+	// allowBlobPublicAccess, allowSharedKeyAccess). They are pointers so an ARM
+	// PATCH can distinguish "field omitted" (leave as-is) from "explicitly set to
+	// false" — a distinction the value form would lose. Nil means unset; the
+	// handler renders the real-Azure default (true / false / true respectively).
+	EnableHTTPSTrafficOnly *bool
+	AllowBlobPublicAccess  *bool
+	AllowSharedKeyAccess   *bool
 }
 
 // AccountEncryption is the storage-account encryption configuration requested


### PR DESCRIPTION
## Summary

Real-user e2e audit of the Azure Storage Account control plane (`Microsoft.Storage/storageAccounts` — the `azurerm_storage_account` surface). Two genuine real-cloud-vs-cloudemu divergences found and fixed, both in the security/network properties that Terraform reads on every refresh.

## Divergences fixed

1. **Explicit-false security toggles dropped (High).** Setting `supportsHttpsTrafficOnly`, `allowBlobPublicAccess`, or `allowSharedKeyAccess` to `false` on create was silently discarded and read back as nil/absent. The handler did not model these fields, so they fell to the `echo_properties` overlay — which swallows zero-valued scalars (`false`/`""`/`0`). A Terraform user setting `https_traffic_only_enabled = false` / `shared_access_key_enabled = false` / `allow_nested_items_to_be_public = false` saw perpetual drift.

2. **Missing defaults on read (High).** An account created without these toggles returned none of `minimumTlsVersion`, `supportsHttpsTrafficOnly`, `allowBlobPublicAccess`, `allowSharedKeyAccess`, `publicNetworkAccess`. Real Azure returns documented defaults; a raw SDK/CLI read (`az storage account show`) or a Terraform refresh saw missing attributes.

Both are fixed by modeling the fields on the ARM request/response and on `AccountAttributes`, rendered always with real-Azure defaults (TLS1_2 / Enabled / `true` / `false` / `true`). Create is full-replace; PATCH is partial-merge — a nil pointer preserves the stored value, an explicit `false` overwrites it.

Non-zero string values (`minimumTlsVersion:"TLS1_2"`, `publicNetworkAccess:"Disabled"`, `networkAcls`) already round-tripped via the overlay and were not broken; they are now modeled properly so PATCH and defaults are correct rather than overlay-dependent. Storage account keys remain output-only (never leaked by the overlay).

## Evidence

Validated end-to-end with the real `armstorage` AccountsClient through the full azureserver + `echo_properties` overlay stack (`account_security_properties_test.go`): explicit-false round-trips, defaults read back correctly, PATCH-tags-only preserves toggles, PATCH-flip changes only the flipped one, re-PUT resets to default.

Docs citations: `GET storage-accounts` REST reference — `allowBlobPublicAccess` default false; `allowSharedKeyAccess` default null ≡ true; `supportsHttpsTrafficOnly` default true (since 2019-04-01); `minimumTlsVersion` TLS1_2; `publicNetworkAccess` Enabled/Disabled/SecuredByPerimeter.

## Filed, not fixed

- **azurerm Terraform auth wall (cross-cutting infra, not storage-account-specific).** The `azurerm` provider fails at provider configuration — it needs `/metadata/endpoints` and an AAD OAuth2 token endpoint (plus CA trust), none of which the emulator serves; this blocks Terraform e2e for all Azure resources equally. Verified via the `armstorage` SDK (the exact HTTP client azurerm's storage resources use) instead.
- **Unmodeled storage-account surface (backlog):** management policies/lifecycle, private endpoints, blob container ARM CRUD, SAS policy, routingPreference, file identity-based auth, largeFileSharesState.

## Gates
`go build ./...`, `go vet`, `gofmt -l`, `golangci-lint --new-from-rev=origin/development` (0 issues), `go generate ./...` (no coverage diff), and `-race` tests on server/azure/..., providers/azure/blobstorage, services/storage, persist — all green.