### PR TITLE
fix(eventbridge): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/eventbridge/eventbridge.go
+++ b/providers/aws/eventbridge/eventbridge.go
@@ -28,6 +28,10 @@ const (
 	maxEventHistory  = 1000
 	defaultRuleState = "ENABLED"
 	activeBusState   = "ACTIVE"
+
+	ruleStateEnabled               = "ENABLED"
+	ruleStateDisabled              = "DISABLED"
+	ruleStateEnabledWithCloudTrail = "ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS"
 )
 
 // Compile-time check that Mock implements driver.EventBus.
@@ -247,8 +251,8 @@ func (m *Mock) ListEventBuses(_ context.Context, filter scope.Scope) ([]driver.E
 
 // PutRule creates or updates a rule on an event bus.
 func (m *Mock) PutRule(_ context.Context, cfg *driver.RuleConfig) (*driver.Rule, error) {
-	if cfg.Name == "" {
-		return nil, errors.New(errors.InvalidArgument, "rule name is required")
+	if err := validateRuleInput(cfg); err != nil {
+		return nil, err
 	}
 
 	busName := cfg.EventBus
@@ -398,7 +402,7 @@ func (m *Mock) EnableRule(_ context.Context, eventBus, ruleName string) error {
 
 // DisableRule disables a rule on an event bus.
 func (m *Mock) DisableRule(_ context.Context, eventBus, ruleName string) error {
-	return m.setRuleState(eventBus, ruleName, "DISABLED")
+	return m.setRuleState(eventBus, ruleName, ruleStateDisabled)
 }
 
 func (m *Mock) setRuleState(eventBus, ruleName, state string) error {
@@ -924,7 +928,7 @@ func (m *Mock) MatchedRules(event *driver.Event) []driver.Rule {
 	var matched []driver.Rule
 
 	for _, rd := range bd.rules.All() {
-		if rd.rule.State != defaultRuleState {
+		if !ruleStateActive(rd.rule.State) {
 			continue
 		}
 

--- a/providers/aws/eventbridge/schedule.go
+++ b/providers/aws/eventbridge/schedule.go
@@ -1,0 +1,131 @@
+package eventbridge
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+)
+
+// scheduleExpressionInvalidMessage is the ValidationException detail real
+// EventBridge returns when PutRule is given a ScheduleExpression that is neither
+// a well-formed rate(...) nor cron(...) expression.
+const scheduleExpressionInvalidMessage = "Parameter ScheduleExpression is not valid."
+
+const (
+	rateExpressionFieldCount = 2 // rate(value unit)
+	cronExpressionFieldCount = 6 // cron(minutes hours day-of-month month day-of-week year)
+)
+
+// validateRuleInput validates the caller-supplied fields of a PutRule request
+// that EventBridge rejects up front: a missing name, a State outside the
+// documented enum, and a malformed ScheduleExpression. Bundling them keeps
+// PutRule's own control flow within the complexity budget.
+func validateRuleInput(cfg *driver.RuleConfig) error {
+	if cfg.Name == "" {
+		return errors.New(errors.InvalidArgument, "rule name is required")
+	}
+
+	if err := validateRuleState(cfg.State); err != nil {
+		return err
+	}
+
+	if cfg.ScheduleExpression != "" {
+		return validateScheduleExpression(cfg.ScheduleExpression)
+	}
+
+	return nil
+}
+
+// validateScheduleExpression validates an EventBridge ScheduleExpression. Real
+// EventBridge accepts only the rate(...) and cron(...) forms and rejects
+// anything else with a ValidationException. Without this check a typo'd
+// expression (e.g. "every 5 minutes", a bare "rate(5 hour)", or a 5-field Unix
+// cron) would store "successfully" and then never self-trigger — a silent
+// misconfiguration the caller never sees.
+func validateScheduleExpression(expr string) error {
+	switch {
+	case strings.HasPrefix(expr, "rate(") && strings.HasSuffix(expr, ")"):
+		return validateRateExpression(expr[len("rate(") : len(expr)-1])
+	case strings.HasPrefix(expr, "cron(") && strings.HasSuffix(expr, ")"):
+		return validateCronExpression(expr[len("cron(") : len(expr)-1])
+	default:
+		return errScheduleInvalid()
+	}
+}
+
+// validateRateExpression validates the body of a rate(...) expression:
+// "value unit", where value is a positive integer and unit is one of
+// minute(s)/hour(s)/day(s), with singular/plural agreement (value 1 is
+// singular, value >1 is plural) — the exact rule real EventBridge enforces.
+func validateRateExpression(body string) error {
+	fields := strings.Fields(body)
+	if len(fields) != rateExpressionFieldCount {
+		return errScheduleInvalid()
+	}
+
+	value, err := strconv.Atoi(fields[0])
+	if err != nil || value < 1 {
+		return errScheduleInvalid()
+	}
+
+	if !rateUnitMatchesValue(fields[1], value) {
+		return errScheduleInvalid()
+	}
+
+	return nil
+}
+
+// rateUnitMatchesValue reports whether a rate-expression unit is valid for the
+// given value: the singular units require a value of 1, the plural units a
+// value greater than 1.
+func rateUnitMatchesValue(unit string, value int) bool {
+	switch unit {
+	case "minute", "hour", "day":
+		return value == 1
+	case "minutes", "hours", "days":
+		return value > 1
+	default:
+		return false
+	}
+}
+
+// validateCronExpression validates the body of a cron(...) expression, which
+// EventBridge requires to have exactly six whitespace-separated fields
+// (minutes, hours, day-of-month, month, day-of-week, year) — a standard
+// five-field Unix cron is rejected. Per-field value validation is not modeled.
+func validateCronExpression(body string) error {
+	if len(strings.Fields(body)) != cronExpressionFieldCount {
+		return errScheduleInvalid()
+	}
+
+	return nil
+}
+
+func errScheduleInvalid() error {
+	return errors.New(errors.InvalidArgument, scheduleExpressionInvalidMessage)
+}
+
+// validateRuleState reports whether a PutRule State value is one EventBridge
+// accepts. An empty state defaults to ENABLED downstream; any other value
+// outside the documented enum is rejected with a ValidationException rather than
+// silently stored.
+func validateRuleState(state string) error {
+	switch state {
+	case "", ruleStateEnabled, ruleStateDisabled, ruleStateEnabledWithCloudTrail:
+		return nil
+	default:
+		return errors.Newf(errors.InvalidArgument,
+			"1 validation error detected: Value '%s' at 'state' failed to satisfy constraint: "+
+				"Member must satisfy enum value set: "+
+				"[ENABLED, DISABLED, ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS]", state)
+	}
+}
+
+// ruleStateActive reports whether a rule in the given state matches events.
+// Both ENABLED and ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS are active;
+// DISABLED is not.
+func ruleStateActive(state string) bool {
+	return state == ruleStateEnabled || state == ruleStateEnabledWithCloudTrail
+}

--- a/providers/aws/eventbridge/schedule_test.go
+++ b/providers/aws/eventbridge/schedule_test.go
@@ -1,0 +1,125 @@
+package eventbridge_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	ebprovider "github.com/stackshy/cloudemu/v2/providers/aws/eventbridge"
+	sqsprovider "github.com/stackshy/cloudemu/v2/providers/aws/sqs"
+	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+)
+
+func TestPutRuleScheduleExpressionValidation(t *testing.T) {
+	ctx := context.Background()
+	eb := ebprovider.New(config.NewOptions())
+
+	invalid := []string{
+		"every 5 minutes",
+		"rate 5 minutes",
+		"rate(1 minutes)",
+		"rate(5 minute)",
+		"rate(0 minutes)",
+		"rate(-1 minutes)",
+		"rate(five minutes)",
+		"rate(5 fortnights)",
+		"rate()",
+		"rate(5)",
+		"cron(0 12 * * ?)",
+		"cron()",
+	}
+
+	for _, expr := range invalid {
+		_, err := eb.PutRule(ctx, &ebdriver.RuleConfig{Name: "r", ScheduleExpression: expr})
+		if err == nil {
+			t.Fatalf("PutRule(%q) should fail", expr)
+		}
+
+		if !cerrors.IsInvalidArgument(err) {
+			t.Fatalf("PutRule(%q): want InvalidArgument, got %v", expr, err)
+		}
+	}
+
+	valid := []string{
+		"rate(1 minute)",
+		"rate(5 minutes)",
+		"rate(1 hour)",
+		"rate(3 hours)",
+		"rate(1 day)",
+		"rate(30 days)",
+		"cron(0 12 * * ? *)",
+		"cron(15 10 ? * 6L 2019-2022)",
+	}
+
+	for _, expr := range valid {
+		if _, err := eb.PutRule(ctx, &ebdriver.RuleConfig{Name: "r", ScheduleExpression: expr}); err != nil {
+			t.Fatalf("PutRule(%q) should succeed, got %v", expr, err)
+		}
+	}
+}
+
+func TestPutRuleStateValidation(t *testing.T) {
+	ctx := context.Background()
+	eb := ebprovider.New(config.NewOptions())
+
+	for _, state := range []string{"enabled", "Enabled", "FOO", "DISABLE"} {
+		_, err := eb.PutRule(ctx, &ebdriver.RuleConfig{
+			Name: "r", EventPattern: `{"source":["a"]}`, State: state,
+		})
+		if err == nil || !cerrors.IsInvalidArgument(err) {
+			t.Fatalf("PutRule(State=%q): want InvalidArgument, got %v", state, err)
+		}
+	}
+
+	for _, state := range []string{"", "ENABLED", "DISABLED", "ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS"} {
+		if _, err := eb.PutRule(ctx, &ebdriver.RuleConfig{
+			Name: "r", EventPattern: `{"source":["a"]}`, State: state,
+		}); err != nil {
+			t.Fatalf("PutRule(State=%q) should succeed, got %v", state, err)
+		}
+	}
+}
+
+// TestCloudTrailManagementStateDelivers verifies a rule in the
+// ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS state matches and delivers
+// events, like an ENABLED rule (and unlike a DISABLED one).
+func TestCloudTrailManagementStateDelivers(t *testing.T) {
+	ctx := context.Background()
+	opts := config.NewOptions()
+
+	sqs := sqsprovider.New(opts)
+	eb := ebprovider.New(opts)
+	eb.SetSQSDeliverer(sqs)
+
+	q, err := sqs.CreateQueue(ctx, mqdriver.QueueConfig{Name: "target"})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	if _, err := eb.PutRule(ctx, &ebdriver.RuleConfig{
+		Name:         "r",
+		EventPattern: `{"source":["a"]}`,
+		State:        "ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS",
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if err := eb.PutTargets(ctx, "", "r", []ebdriver.Target{{ID: "1", ARN: q.ARN}}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	if _, err := eb.PutEvents(ctx, []ebdriver.Event{{Source: "a", DetailType: "t", Detail: `{}`}}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	msgs, err := sqs.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{QueueURL: q.URL, MaxMessages: 10})
+	if err != nil {
+		t.Fatalf("ReceiveMessages: %v", err)
+	}
+
+	if len(msgs) != 1 {
+		t.Fatalf("delivered %d messages, want 1", len(msgs))
+	}
+}

--- a/server/aws/eventbridge/schedule_validation_sdk_test.go
+++ b/server/aws/eventbridge/schedule_validation_sdk_test.go
@@ -1,0 +1,137 @@
+package eventbridge_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKEventBridgePutRuleInvalidSchedule verifies PutRule rejects a malformed
+// ScheduleExpression with ValidationException, matching real EventBridge, rather
+// than storing an expression that would never self-trigger.
+func TestSDKEventBridgePutRuleInvalidSchedule(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		expr string
+	}{
+		{"natural-language", "every 5 minutes"},
+		{"missing-wrapper", "rate 5 minutes"},
+		{"rate-plural-mismatch", "rate(1 minutes)"},
+		{"rate-singular-mismatch", "rate(5 minute)"},
+		{"rate-zero", "rate(0 minutes)"},
+		{"rate-non-numeric", "rate(five minutes)"},
+		{"rate-bad-unit", "rate(5 fortnights)"},
+		{"cron-five-fields", "cron(0 12 * * ?)"},
+		{"empty-rate", "rate()"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := client.PutRule(ctx, &awseb.PutRuleInput{
+				Name:               aws.String("sched-" + tc.name),
+				ScheduleExpression: aws.String(tc.expr),
+			})
+			if err == nil {
+				t.Fatalf("PutRule(%q) should fail, got nil", tc.expr)
+			}
+
+			var apiErr smithy.APIError
+			if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ValidationException" {
+				t.Fatalf("want ValidationException, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+// TestSDKEventBridgePutRuleValidScheduleRoundTrip verifies valid rate() and
+// cron() expressions are accepted and echoed back verbatim by DescribeRule,
+// which Terraform reads on every refresh.
+func TestSDKEventBridgePutRuleValidScheduleRoundTrip(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	valid := []string{
+		"rate(1 minute)",
+		"rate(5 minutes)",
+		"rate(1 hour)",
+		"rate(2 hours)",
+		"rate(1 day)",
+		"cron(0 12 * * ? *)",
+		"cron(15 10 ? * 6L 2019-2022)",
+	}
+
+	for i, expr := range valid {
+		name := "good-sched-" + string(rune('a'+i))
+
+		if _, err := client.PutRule(ctx, &awseb.PutRuleInput{
+			Name:               aws.String(name),
+			ScheduleExpression: aws.String(expr),
+		}); err != nil {
+			t.Fatalf("PutRule(%q) should succeed, got %v", expr, err)
+		}
+
+		desc, err := client.DescribeRule(ctx, &awseb.DescribeRuleInput{Name: aws.String(name)})
+		if err != nil {
+			t.Fatalf("DescribeRule(%s): %v", name, err)
+		}
+
+		if aws.ToString(desc.ScheduleExpression) != expr {
+			t.Fatalf("ScheduleExpression = %q, want %q", aws.ToString(desc.ScheduleExpression), expr)
+		}
+	}
+}
+
+// TestSDKEventBridgePutRuleInvalidState verifies PutRule rejects a State value
+// outside the documented enum with ValidationException rather than silently
+// storing it.
+func TestSDKEventBridgePutRuleInvalidState(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	_, err := client.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("bad-state"),
+		EventPattern: aws.String(`{"source":["aws.ec2"]}`),
+		State:        ebtypes.RuleState("enabled"), // lowercase is not a valid enum value
+	})
+	if err == nil {
+		t.Fatal("PutRule with invalid State should fail, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ValidationException" {
+		t.Fatalf("want ValidationException, got %T: %v", err, err)
+	}
+}
+
+// TestSDKEventBridgePutRuleCloudTrailStateRoundTrip verifies the
+// ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS state is accepted and preserved
+// through DescribeRule.
+func TestSDKEventBridgePutRuleCloudTrailStateRoundTrip(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	if _, err := client.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("ct-rule"),
+		EventPattern: aws.String(`{"source":["aws.ec2"]}`),
+		State:        ebtypes.RuleStateEnabledWithAllCloudtrailManagementEvents,
+	}); err != nil {
+		t.Fatalf("PutRule with CloudTrail-management state: %v", err)
+	}
+
+	desc, err := client.DescribeRule(ctx, &awseb.DescribeRuleInput{Name: aws.String("ct-rule")})
+	if err != nil {
+		t.Fatalf("DescribeRule: %v", err)
+	}
+
+	if desc.State != ebtypes.RuleStateEnabledWithAllCloudtrailManagementEvents {
+		t.Fatalf("State = %q, want ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS", desc.State)
+	}
+}


### PR DESCRIPTION
## Summary

Real-user e2e audit of AWS EventBridge (SDK + aws-cli + Terraform against `cloudemu serve`). The surface is broadly complete and correct; this fixes two genuine input-validation divergences where cloudemu silently accepted input that real EventBridge rejects.

## Findings fixed

| # | Severity | Divergence | AWS behavior | Was |
|---|----------|-----------|--------------|-----|
| 1 | Medium | `PutRule` accepted any `ScheduleExpression` | Rejects a non-`rate()`/`cron()` form, a rate with singular/plural mismatch (`rate(1 minutes)`), a non-positive/non-numeric value, a bad unit, or a 5-field cron with `ValidationException: Parameter ScheduleExpression is not valid.` | Stored silently; rule never self-triggers |
| 2 | Low | `PutRule` accepted any `State` string | Rejects a value outside `ENABLED \| DISABLED \| ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS` with `ValidationException` | Stored silently |
| 2b | Low | `ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS` rules did not match events | Treated as an active (matching) state | Skipped in delivery |

Validation lives in the AWS provider `PutRule` (covers wire + library paths); the wire handler maps `InvalidArgument` to `ValidationException`.

## Verification

- Live `cloudemu serve` + aws-cli: invalid schedule/state -> `ValidationException` (exact AWS wording); valid `rate()`/`cron()` and the CloudTrail-management state round-trip through `DescribeRule`.
- Terraform (`aws_cloudwatch_event_bus`/`_rule`/`_target`): apply + second plan reports **no changes** (zero drift) confirming `DescribeRule`/`ListTargetsByRule`/EventPattern-normalization round-trip; clean destroy.
- New tests: provider-level validator + CloudTrail-state delivery; SDK-level (aws-sdk-go-v2) invalid/valid schedule and state round-trip.
- Gates: `go build ./...`, `go test -race` (providers/aws/eventbridge, server/aws/eventbridge, services/eventbus, root integration), `go vet`, `gofmt`, `golangci-lint --new-from-rev=origin/development` (0 issues), `go generate` (no docs/coverage diff).

## Not fixed (filed as gaps)

- Deep per-field cron validation (field value ranges, day-of-month vs day-of-week `?` mutual exclusion). Field-count is validated; full semantic cron validation is a larger surface.
- `PutTargets`: per-target `Id`/`Arn` required-field validation and the 5-targets-per-rule limit.
- Rule/bus `Name` length/charset pattern validation.
