### PR TITLE
fix(gcs): real-user e2e divergences from GCP

### DIFF
--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -77,6 +77,13 @@ const (
 	subresIAM = "iam"
 	// subresNotificationConfigs is the /b/{bucket}/notificationConfigs segment.
 	subresNotificationConfigs = "notificationConfigs"
+	// subresAnywhereCaches is the /b/{bucket}/anywhereCaches sub-collection
+	// segment. cloudemu does not model Anywhere Cache instances, but the list
+	// endpoint must answer 200 with an empty set: the Terraform google provider
+	// lists anywhere caches during force_destroy and aborts its object cleanup
+	// (leaving the bucket non-empty) if that call errors instead of returning a
+	// list.
+	subresAnywhereCaches = "anywhereCaches"
 	// defaultLocation / defaultStorageClass are the GCS defaults a bucket reads
 	// back when none was set at create.
 	defaultLocation     = "US"
@@ -284,6 +291,8 @@ func (h *Handler) serveBucketSubcollection(w http.ResponseWriter, r *http.Reques
 		h.bucketIAM(w, r, parts[1])
 	case subresNotificationConfigs:
 		h.notificationCollection(w, r, parts[1])
+	case subresAnywhereCaches:
+		h.listAnywhereCaches(w, r, parts[1])
 	case "lockRetentionPolicy":
 		h.lockRetentionPolicy(w, r, parts[1])
 	default:
@@ -299,6 +308,11 @@ func (h *Handler) serveBucketSubresource(w http.ResponseWriter, r *http.Request,
 		h.objectOp(w, r, parts[1], strings.Join(parts[3:], "/"))
 	case parts[2] == subresIAM && parts[3] == "testPermissions":
 		h.testIAMPermissions(w, r, parts[1])
+	case parts[2] == subresAnywhereCaches && parts[3] == "":
+		// The Go storage client appends a trailing slash to the list URL
+		// (b/{bucket}/anywhereCaches/), which splits into a trailing empty
+		// segment; route it to the same empty-list handler.
+		h.listAnywhereCaches(w, r, parts[1])
 	case parts[2] == subresNotificationConfigs:
 		h.notificationResourceOp(w, r, parts[1], parts[3])
 	default:
@@ -640,6 +654,25 @@ func (h *Handler) deleteBucket(w http.ResponseWriter, r *http.Request, name stri
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// listAnywhereCaches serves GET /b/{bucket}/anywhereCaches. cloudemu does not
+// model Anywhere Cache instances, so it always reports an empty list — the
+// correct response for a bucket that has no caches, and enough for the Terraform
+// google provider's force_destroy path (which lists caches before deleting a
+// bucket's objects and aborts that cleanup if the call errors) to proceed.
+func (h *Handler) listAnywhereCaches(w http.ResponseWriter, r *http.Request, name string) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+		return
+	}
+
+	if !h.bucketExists(r, name) {
+		writeError(w, http.StatusNotFound, "notFound", "bucket "+name+" not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, anywhereCachesListResponse{Kind: "storage#anywhereCaches"})
+}
+
 // bucketIAM serves /b/{bucket}/iam — GET returns the bucket's IAM policy (a
 // default empty policy when none was set), PUT/POST replaces it.
 func (h *Handler) bucketIAM(w http.ResponseWriter, r *http.Request, name string) {
@@ -824,11 +857,10 @@ func (h *Handler) upload(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) initResumable(w http.ResponseWriter, r *http.Request, bucket string) {
 	meta := h.readResumableInitMetadata(r)
 
-	name := meta.Name
-	if name == "" {
-		name = r.URL.Query().Get("name")
-	}
-
+	// The `name` query parameter overrides the metadata name when both are
+	// present (GCS Objects: insert contract), and is the sole source when the
+	// init body carries no metadata name.
+	name := firstNonEmpty(r.URL.Query().Get("name"), meta.Name)
 	if name == "" {
 		writeError(w, http.StatusBadRequest, "invalid", "name required for resumable upload")
 		return
@@ -1262,8 +1294,16 @@ func (h *Handler) uploadMultipart(w http.ResponseWriter, r *http.Request, bucket
 		return
 	}
 
-	if meta.Name == "" {
-		writeError(w, http.StatusBadRequest, "invalid", "metadata.name required")
+	// The object name may come from the metadata part or the `name` query
+	// parameter; per the GCS Objects: insert contract the query parameter
+	// "Overrides the object metadata's name value, if any" and is "Not required
+	// if the request body contains object metadata that includes a name value".
+	// The Terraform google provider and gcloud/gsutil put the name in the query
+	// string and omit it from the metadata part, so consulting only the metadata
+	// name (as before) rejected every such upload.
+	name := firstNonEmpty(r.URL.Query().Get("name"), meta.Name)
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "Required parameter: name")
 		return
 	}
 
@@ -1271,7 +1311,7 @@ func (h *Handler) uploadMultipart(w http.ResponseWriter, r *http.Request, bucket
 		payloadCT = contentTypeBinary
 	}
 
-	h.storeObject(w, r, bucket, meta.Name, payloadCT, payload, meta.Metadata, &storagedriver.GCSObjectAttrs{
+	h.storeObject(w, r, bucket, name, payloadCT, payload, meta.Metadata, &storagedriver.GCSObjectAttrs{
 		CacheControl:       meta.CacheControl,
 		ContentEncoding:    meta.ContentEncoding,
 		ContentDisposition: meta.ContentDisposition,

--- a/server/gcp/gcs/terraform_compat_test.go
+++ b/server/gcp/gcs/terraform_compat_test.go
@@ -1,0 +1,235 @@
+package gcs_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"cloud.google.com/go/storage"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// newRawServer boots a fresh emulator + GCP HTTP server and returns its base
+// URL and an *http.Client, for tests that need to inspect the exact wire bytes
+// the way the Terraform google provider / gcloud do (rather than through the
+// SDK, which can mask a wire-shape gap).
+func newRawServer(t *testing.T) (string, *http.Client) {
+	t.Helper()
+
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Storage: cloudP.GCS})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts.URL, ts.Client()
+}
+
+// TestMultipartUploadNameFromQueryParam reproduces the exact request the
+// Terraform google provider (and gcloud/gsutil) send for
+// google_storage_bucket_object: a multipart/related upload whose metadata part
+// carries no name, with the object name supplied only via the ?name= query
+// parameter. Per the GCS Objects: insert contract the query parameter "Overrides
+// the object metadata's name value, if any" and is "Not required if the request
+// body contains object metadata that includes a name value" — so the name may
+// come from the query alone. cloudemu previously rejected this with
+// "metadata.name required", breaking every Terraform object upload.
+func TestMultipartUploadNameFromQueryParam(t *testing.T) {
+	base, hc := newRawServer(t)
+	ctx := context.Background()
+
+	mkBucket(t, base, hc, "tf-bucket")
+
+	const boundary = "cloudemu-boundary"
+
+	body := "--" + boundary + "\r\n" +
+		"Content-Type: application/json\r\n\r\n" +
+		`{"bucket":"tf-bucket","contentType":"text/plain"}` + "\r\n" +
+		"--" + boundary + "\r\n" +
+		"Content-Type: text/plain\r\n\r\n" +
+		"hello world\r\n" +
+		"--" + boundary + "--\r\n"
+
+	url := base + "/upload/storage/v1/b/tf-bucket/o?uploadType=multipart&name=hello.txt"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader([]byte(body)))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "multipart/related; boundary="+boundary)
+
+	resp, err := hc.Do(req)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("upload status = %d, want 200; body: %s", resp.StatusCode, raw)
+	}
+
+	var obj struct {
+		Name        string `json:"name"`
+		Bucket      string `json:"bucket"`
+		Size        string `json:"size"`
+		ContentType string `json:"contentType"`
+	}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("decode object: %v; body: %s", err, raw)
+	}
+
+	if obj.Name != "hello.txt" {
+		t.Errorf("object name = %q, want hello.txt (from query param)", obj.Name)
+	}
+
+	if obj.Size != "11" {
+		t.Errorf("object size = %q, want 11", obj.Size)
+	}
+
+	if obj.ContentType != "text/plain" {
+		t.Errorf("contentType = %q, want text/plain", obj.ContentType)
+	}
+
+	// The uploaded object must be independently retrievable under the
+	// query-supplied name, confirming it was actually stored (not just echoed).
+	got := getMediaBytes(t, base, hc, "tf-bucket", "hello.txt")
+	if string(got) != "hello world" {
+		t.Errorf("stored content = %q, want %q", got, "hello world")
+	}
+}
+
+// TestAnywhereCachesListReturnsEmpty covers the Buckets anywhereCaches: list
+// endpoint the Terraform google provider calls before force_destroy. cloudemu
+// does not model Anywhere Cache instances, but the endpoint must answer 200 with
+// an empty list (a bucket with no caches) — not a 404. When it errored, the
+// provider aborted its object cleanup and failed the bucket delete with 409
+// "not empty". Both the SDK's trailing-slash URL and the bare path are checked.
+func TestAnywhereCachesListReturnsEmpty(t *testing.T) {
+	base, hc := newRawServer(t)
+
+	mkBucket(t, base, hc, "cache-bucket")
+
+	for _, path := range []string{
+		"/storage/v1/b/cache-bucket/anywhereCaches",
+		"/storage/v1/b/cache-bucket/anywhereCaches/",
+	} {
+		resp, err := hc.Get(base + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+
+		raw, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET %s status = %d, want 200; body: %s", path, resp.StatusCode, raw)
+		}
+
+		var list struct {
+			Kind  string `json:"kind"`
+			Items []any  `json:"items"`
+		}
+		if err := json.Unmarshal(raw, &list); err != nil {
+			t.Fatalf("decode %s: %v; body: %s", path, err, raw)
+		}
+
+		if list.Kind != "storage#anywhereCaches" {
+			t.Errorf("GET %s kind = %q, want storage#anywhereCaches", path, list.Kind)
+		}
+
+		if len(list.Items) != 0 {
+			t.Errorf("GET %s items = %v, want empty", path, list.Items)
+		}
+	}
+}
+
+// TestForceDestroyVersionedBucketViaSDK exercises the full clear-then-delete
+// sequence the Terraform provider performs during force_destroy on a
+// versioning-enabled bucket: overwrite an object (archiving a noncurrent
+// version), list every version, delete each by generation, then delete the now
+// empty bucket. This must succeed end to end.
+func TestForceDestroyVersionedBucketViaSDK(t *testing.T) {
+	ctx, client := newStorageClient(t)
+
+	bkt := client.Bucket("fd-bucket")
+	if err := bkt.Create(ctx, e2eProject, &storage.BucketAttrs{VersioningEnabled: true}); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	writeObject(t, ctx, bkt, "k", "v1")
+	writeObject(t, ctx, bkt, "k", "v2") // archives v1 as a noncurrent version
+
+	// Delete every version, mirroring the provider's versions=true sweep.
+	it := bkt.Objects(ctx, &storage.Query{Versions: true})
+	for {
+		attrs, err := it.Next()
+		if err != nil {
+			break
+		}
+
+		if err := bkt.Object(attrs.Name).Generation(attrs.Generation).Delete(ctx); err != nil {
+			t.Fatalf("delete %s@%d: %v", attrs.Name, attrs.Generation, err)
+		}
+	}
+
+	if err := bkt.Delete(ctx); err != nil {
+		t.Fatalf("delete emptied bucket: %v", err)
+	}
+}
+
+func mkBucket(t *testing.T, base string, hc *http.Client, name string) {
+	t.Helper()
+
+	body := `{"name":"` + name + `"}`
+
+	resp, err := hc.Post(base+"/storage/v1/b?project="+e2eProject, "application/json", bytes.NewReader([]byte(body)))
+	if err != nil {
+		t.Fatalf("create bucket %q: %v", name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create bucket %q status = %d; body: %s", name, resp.StatusCode, raw)
+	}
+}
+
+func getMediaBytes(t *testing.T, base string, hc *http.Client, bucket, key string) []byte {
+	t.Helper()
+
+	resp, err := hc.Get(base + "/storage/v1/b/" + bucket + "/o/" + key + "?alt=media")
+	if err != nil {
+		t.Fatalf("get media %s/%s: %v", bucket, key, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("get media status = %d; body: %s", resp.StatusCode, raw)
+	}
+
+	raw, _ := io.ReadAll(resp.Body)
+
+	return raw
+}
+
+func writeObject(t *testing.T, ctx context.Context, bkt *storage.BucketHandle, key, content string) {
+	t.Helper()
+
+	w := bkt.Object(key).NewWriter(ctx)
+	if _, err := io.WriteString(w, content); err != nil {
+		t.Fatalf("write %s: %v", key, err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close %s: %v", key, err)
+	}
+}

--- a/server/gcp/gcs/types.go
+++ b/server/gcp/gcs/types.go
@@ -85,6 +85,15 @@ type bucketsListResponse struct {
 	Items []bucketResource `json:"items"`
 }
 
+// anywhereCachesListResponse is the Buckets anywhereCaches: list response. Its
+// items are always empty because cloudemu does not model Anywhere Cache
+// instances; the empty list is what a bucket with no caches returns.
+type anywhereCachesListResponse struct {
+	Kind          string `json:"kind"`
+	Items         []any  `json:"items,omitempty"`
+	NextPageToken string `json:"nextPageToken,omitempty"`
+}
+
 type objectResource struct {
 	Kind                    string            `json:"kind"`
 	ID                      string            `json:"id"`


### PR DESCRIPTION
Deep real-user e2e audit of Google Cloud Storage driving the **real Terraform `hashicorp/google` provider (v6.50.0)** and the `cloud.google.com/go/storage` SDK against `cloudemu serve`. Terraform was never exercised in the earlier GCS pilot; it surfaced two genuine, high-impact divergences.

## Findings fixed

| # | Sev | Divergence |
|---|-----|-----------|
| 5 | HIGH | `uploadType=multipart` rejected the object name when supplied only via the `?name=` query parameter (400 `metadata.name required`). The Terraform provider, gcloud and gsutil all send the name in the query and omit it from the metadata part, so **every `google_storage_bucket_object` upload failed**. |
| 6 | HIGH | `GET /b/{bucket}/anywhereCaches` returned 404. The provider lists anywhere caches during `force_destroy` and aborts its object-clearing loop if that call errors, then fails the bucket delete with 409 "not empty" — so **`terraform destroy` failed on any bucket containing objects**. |

## Fixes
- `uploadMultipart`: object name = query `name` (overrides metadata name) then metadata name, per the GCS *Objects: insert* contract ("Not required if the request body contains object metadata that includes a name value"; "Overrides the object metadata's name value, if any"). `initResumable` aligned to the same precedence.
- New `listAnywhereCaches` handler returns `200 {"kind":"storage#anywhereCaches"}` (empty list — the correct response for a bucket with no caches; cloudemu does not model Anywhere Cache). Routed for both the bare and SDK trailing-slash path forms.

## Verification
- `terraform apply` -> `terraform plan` (no drift) -> `terraform destroy` now succeeds end-to-end, including a versioning-enabled bucket holding an object and an advanced bucket (region location, NEARLINE, uniform_bucket_level_access, two lifecycle rules, `google_storage_bucket_iam_member`).
- Object content/md5Hash/crc32c/size round-trip; error envelopes (404 notFound, 409 notEmpty/conflict) correct.
- Regression tests added (`server/gcp/gcs/terraform_compat_test.go`): multipart name-from-query, anywhereCaches empty list (both path forms), full force-destroy of a versioned bucket via the SDK.
- Gates: `go build ./...`, `go vet`, `gofmt -l`, `golangci-lint run --new-from-rev=origin/development` (0 issues), `go test -race` on server/gcp/gcs + providers/gcp/gcs + services/storage — all green. `go generate ./...` — no docs/coverage change (no driver interface change).

## Filed, not fixed (fidelity gaps, no Terraform drift today)
`rpo` and `softDeletePolicy` bucket defaults absent (soft delete is a whole subsystem — not half-built); `iamConfiguration.uniformBucketLevelAccess` omitted when disabled; the inert top-level `error.status` envelope field (unverifiable without live GCS).