### PR TITLE
fix(cosmosdb): real-user e2e divergences from Azure

### DIFF
--- a/server/azure/cosmosaccount/account_toggles_test.go
+++ b/server/azure/cosmosaccount/account_toggles_test.go
@@ -1,0 +1,147 @@
+// Real-user e2e regression test: the account-level boolean/network toggles
+// (enableAutomaticFailover, enableMultipleWriteLocations, publicNetworkAccess)
+// and enableFreeTier that Terraform's azurerm_cosmosdb_account reads back on
+// every refresh. They were not emitted by the handler and leaned on the generic
+// property-echo overlay, which swallows an explicit zero value (false / "") —
+// so an account created with multiple-write enabled and later PATCHed back to
+// disabled kept reporting enabled, a perpetual Terraform drift. These tests
+// drive the real armcosmos client and pin the fix: the toggles are authoritative
+// handler output, always present with their real value, and round-trip through
+// create, PATCH-to-false and GET.
+package cosmosaccount_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSDKDatabaseAccountToggleDefaults asserts an account created without the
+// toggles reports Azure's documented defaults (all false, publicNetworkAccess
+// Enabled) on both the create response and an independent GET, rather than
+// omitting them — Terraform reads each field and an absent value is drift-prone.
+func TestSDKDatabaseAccountToggleDefaults(t *testing.T) {
+	ctx := context.Background()
+	client := newDatabaseAccountsClient(t)
+	createAccount(t, client, "rg-1", "cosmos-def-tg", "eastus")
+
+	got, err := client.Get(ctx, "rg-1", "cosmos-def-tg", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.Properties)
+
+	p := got.Properties
+	require.NotNil(t, p.EnableAutomaticFailover)
+	assert.False(t, *p.EnableAutomaticFailover)
+	require.NotNil(t, p.EnableMultipleWriteLocations)
+	assert.False(t, *p.EnableMultipleWriteLocations)
+	require.NotNil(t, p.EnableFreeTier)
+	assert.False(t, *p.EnableFreeTier)
+	require.NotNil(t, p.PublicNetworkAccess)
+	assert.Equal(t, armcosmos.PublicNetworkAccessEnabled, *p.PublicNetworkAccess)
+}
+
+// TestSDKDatabaseAccountToggleRoundTrip asserts every toggle set at create time
+// survives create -> GET with its submitted value.
+func TestSDKDatabaseAccountToggleRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	client := newDatabaseAccountsClient(t)
+
+	poller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "cosmos-tg", armcosmos.DatabaseAccountCreateUpdateParameters{
+		Location: to.Ptr("eastus"),
+		Properties: &armcosmos.DatabaseAccountCreateUpdateProperties{
+			DatabaseAccountOfferType:     to.Ptr("Standard"),
+			EnableAutomaticFailover:      to.Ptr(true),
+			EnableMultipleWriteLocations: to.Ptr(true),
+			PublicNetworkAccess:          to.Ptr(armcosmos.PublicNetworkAccessDisabled),
+			Locations: []*armcosmos.Location{
+				{LocationName: to.Ptr("eastus"), FailoverPriority: to.Ptr[int32](0)},
+				{LocationName: to.Ptr("westus"), FailoverPriority: to.Ptr[int32](1)},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+	assertToggles(t, created.Properties, true, true, armcosmos.PublicNetworkAccessDisabled)
+	// multi-write means every declared region accepts writes.
+	require.Len(t, created.Properties.WriteLocations, 2)
+
+	got, err := client.Get(ctx, "rg-1", "cosmos-tg", nil)
+	require.NoError(t, err)
+	assertToggles(t, got.Properties, true, true, armcosmos.PublicNetworkAccessDisabled)
+	require.Len(t, got.Properties.WriteLocations, 2)
+}
+
+// TestSDKDatabaseAccountToggleDisableViaPatch is the core regression: an account
+// created with multiple-write enabled and then PATCHed back to disabled must
+// report disabled (writeLocations collapsing to the single priority-0 region),
+// and a toggle omitted from the PATCH body must be preserved.
+func TestSDKDatabaseAccountToggleDisableViaPatch(t *testing.T) {
+	ctx := context.Background()
+	client := newDatabaseAccountsClient(t)
+
+	poller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "cosmos-tg-off", armcosmos.DatabaseAccountCreateUpdateParameters{
+		Location: to.Ptr("eastus"),
+		Properties: &armcosmos.DatabaseAccountCreateUpdateProperties{
+			DatabaseAccountOfferType:     to.Ptr("Standard"),
+			EnableAutomaticFailover:      to.Ptr(true),
+			EnableMultipleWriteLocations: to.Ptr(true),
+			Locations: []*armcosmos.Location{
+				{LocationName: to.Ptr("eastus"), FailoverPriority: to.Ptr[int32](0)},
+				{LocationName: to.Ptr("westus"), FailoverPriority: to.Ptr[int32](1)},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	updPoller, err := client.BeginUpdate(ctx, "rg-1", "cosmos-tg-off", armcosmos.DatabaseAccountUpdateParameters{
+		Properties: &armcosmos.DatabaseAccountUpdateProperties{
+			EnableMultipleWriteLocations: to.Ptr(false),
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	updated, err := updPoller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, updated.Properties)
+	require.NotNil(t, updated.Properties.EnableMultipleWriteLocations)
+	assert.False(t, *updated.Properties.EnableMultipleWriteLocations,
+		"PATCH multiWrite=false must report false, not the stale created-with true")
+	// A single write region once multi-write is off.
+	require.Len(t, updated.Properties.WriteLocations, 1)
+	// A toggle omitted from the PATCH survives unchanged.
+	require.NotNil(t, updated.Properties.EnableAutomaticFailover)
+	assert.True(t, *updated.Properties.EnableAutomaticFailover)
+
+	// ... and the disabled value survives an independent GET (not resurrected by
+	// the overlay on a later read).
+	got, err := client.Get(ctx, "rg-1", "cosmos-tg-off", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.Properties.EnableMultipleWriteLocations)
+	assert.False(t, *got.Properties.EnableMultipleWriteLocations)
+	require.Len(t, got.Properties.WriteLocations, 1)
+	require.NotNil(t, got.Properties.EnableAutomaticFailover)
+	assert.True(t, *got.Properties.EnableAutomaticFailover)
+}
+
+func assertToggles(
+	t *testing.T, props *armcosmos.DatabaseAccountGetProperties,
+	autoFailover, multiWrite bool, pna armcosmos.PublicNetworkAccess,
+) {
+	t.Helper()
+
+	require.NotNil(t, props)
+	require.NotNil(t, props.EnableAutomaticFailover)
+	assert.Equal(t, autoFailover, *props.EnableAutomaticFailover)
+	require.NotNil(t, props.EnableMultipleWriteLocations)
+	assert.Equal(t, multiWrite, *props.EnableMultipleWriteLocations)
+	require.NotNil(t, props.PublicNetworkAccess)
+	assert.Equal(t, pna, *props.PublicNetworkAccess)
+}

--- a/server/azure/cosmosaccount/handler.go
+++ b/server/azure/cosmosaccount/handler.go
@@ -220,6 +220,8 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azu
 		attrs.Capabilities = capabilityNames(body.Properties.Capabilities)
 		attrs.Locations = toAccountLocations(body.Properties.Locations)
 		attrs.EnableMultipleWriteLocations = body.Properties.EnableMultipleWriteLocations
+		attrs.EnableAutomaticFailover = body.Properties.EnableAutomaticFailover
+		attrs.PublicNetworkAccess = body.Properties.PublicNetworkAccess
 
 		if cp := body.Properties.ConsistencyPolicy; cp != nil {
 			attrs.ConsistencyPolicy = dbdriver.ConsistencyPolicy{
@@ -250,7 +252,8 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp *azurearm.Resou
 // BeginUpdate), a non-destructive partial update: only the fields present in
 // the request body change — tags (full replace, matching how every other PATCH
 // handler in this codebase treats tags), consistencyPolicy, locations,
-// capabilities, and enableMultipleWriteLocations — everything else, including
+// capabilities, enableMultipleWriteLocations, enableAutomaticFailover and
+// publicNetworkAccess — everything else, including
 // kind (which real Azure's DatabaseAccountUpdateParameters has no field for;
 // it is immutable after creation), is preserved. The mutation runs through
 // attrBackend's atomic UpdateTableAttributes rather than a read-then-write
@@ -316,6 +319,14 @@ func applyAccountUpdate(cur *dbdriver.AccountAttributes, body *armAccountUpdate)
 
 	if p.EnableMultipleWriteLocations != nil {
 		cur.EnableMultipleWriteLocations = *p.EnableMultipleWriteLocations
+	}
+
+	if p.EnableAutomaticFailover != nil {
+		cur.EnableAutomaticFailover = *p.EnableAutomaticFailover
+	}
+
+	if p.PublicNetworkAccess != nil {
+		cur.PublicNetworkAccess = *p.PublicNetworkAccess
 	}
 
 	if p.ConsistencyPolicy != nil {
@@ -433,16 +444,19 @@ func renderAccount(subscription, base, name string, attrs dbdriver.AccountAttrib
 		Kind:     kindOrDefault(attrs.Kind),
 		Tags:     attrs.Tags,
 		Properties: &armAccountProps{
-			DatabaseAccountOfferType: offerOrDefault(attrs.OfferType),
-			EnableFreeTier:           attrs.EnableFreeTier,
-			Capabilities:             toCapabilities(attrs.Capabilities),
-			ProvisioningState:        "Succeeded",
-			DocumentEndpoint:         documentEndpoint(base, name),
-			Locations:                all,
-			ReadLocations:            all,
-			WriteLocations:           writeLocs,
-			FailoverPolicies:         toFailoverPolicies(name, locations),
-			ConsistencyPolicy:        renderConsistencyPolicy(attrs.ConsistencyPolicy),
+			DatabaseAccountOfferType:     offerOrDefault(attrs.OfferType),
+			EnableFreeTier:               attrs.EnableFreeTier,
+			EnableAutomaticFailover:      attrs.EnableAutomaticFailover,
+			EnableMultipleWriteLocations: attrs.EnableMultipleWriteLocations,
+			PublicNetworkAccess:          publicNetworkAccessOrDefault(attrs.PublicNetworkAccess),
+			Capabilities:                 toCapabilities(attrs.Capabilities),
+			ProvisioningState:            "Succeeded",
+			DocumentEndpoint:             documentEndpoint(base, name),
+			Locations:                    all,
+			ReadLocations:                all,
+			WriteLocations:               writeLocs,
+			FailoverPolicies:             toFailoverPolicies(name, locations),
+			ConsistencyPolicy:            renderConsistencyPolicy(attrs.ConsistencyPolicy),
 		},
 	}
 }
@@ -624,6 +638,17 @@ func offerOrDefault(offer string) string {
 	}
 
 	return offer
+}
+
+// publicNetworkAccessOrDefault echoes the stored publicNetworkAccess, defaulting
+// to Azure's "Enabled" when the account never set one (real Azure always returns
+// a value, and Terraform's public_network_access_enabled defaults to true).
+func publicNetworkAccessOrDefault(access string) string {
+	if access == "" {
+		return "Enabled"
+	}
+
+	return access
 }
 
 // accountRegion returns the first declared location's name, if any.

--- a/server/azure/cosmosaccount/types.go
+++ b/server/azure/cosmosaccount/types.go
@@ -16,6 +16,8 @@ type armAccountCreateProps struct {
 	Capabilities                 []armCapability       `json:"capabilities,omitempty"`
 	Locations                    []armLocation         `json:"locations,omitempty"`
 	EnableMultipleWriteLocations bool                  `json:"enableMultipleWriteLocations,omitempty"`
+	EnableAutomaticFailover      bool                  `json:"enableAutomaticFailover,omitempty"`
+	PublicNetworkAccess          string                `json:"publicNetworkAccess,omitempty"`
 	ConsistencyPolicy            *armConsistencyPolicy `json:"consistencyPolicy,omitempty"`
 }
 
@@ -50,6 +52,8 @@ type armAccountUpdateProps struct {
 	Capabilities                 []armCapability       `json:"capabilities,omitempty"`
 	Locations                    []armLocation         `json:"locations,omitempty"`
 	EnableMultipleWriteLocations *bool                 `json:"enableMultipleWriteLocations,omitempty"`
+	EnableAutomaticFailover      *bool                 `json:"enableAutomaticFailover,omitempty"`
+	PublicNetworkAccess          *string               `json:"publicNetworkAccess,omitempty"`
 	ConsistencyPolicy            *armConsistencyPolicy `json:"consistencyPolicy,omitempty"`
 }
 
@@ -65,16 +69,25 @@ type armAccount struct {
 }
 
 type armAccountProps struct {
-	DatabaseAccountOfferType string                `json:"databaseAccountOfferType,omitempty"`
-	EnableFreeTier           bool                  `json:"enableFreeTier,omitempty"`
-	Capabilities             []armCapability       `json:"capabilities,omitempty"`
-	ProvisioningState        string                `json:"provisioningState,omitempty"`
-	DocumentEndpoint         string                `json:"documentEndpoint,omitempty"`
-	Locations                []armLocation         `json:"locations,omitempty"`
-	ReadLocations            []armLocation         `json:"readLocations,omitempty"`
-	WriteLocations           []armLocation         `json:"writeLocations,omitempty"`
-	FailoverPolicies         []armFailover         `json:"failoverPolicies,omitempty"`
-	ConsistencyPolicy        *armConsistencyPolicy `json:"consistencyPolicy,omitempty"`
+	DatabaseAccountOfferType string `json:"databaseAccountOfferType,omitempty"`
+	// The boolean/network toggles carry no omitempty: real Azure always returns
+	// them (as false / "Enabled" defaults), and a caller — Terraform in
+	// particular — reads them back on every refresh. Emitting them from the
+	// handler makes them authoritative, so the property-echo overlay never has to
+	// synthesize them (and can no longer leave a stale value behind when one is
+	// PATCHed back to its zero value).
+	EnableFreeTier               bool                  `json:"enableFreeTier"`
+	EnableAutomaticFailover      bool                  `json:"enableAutomaticFailover"`
+	EnableMultipleWriteLocations bool                  `json:"enableMultipleWriteLocations"`
+	PublicNetworkAccess          string                `json:"publicNetworkAccess,omitempty"`
+	Capabilities                 []armCapability       `json:"capabilities,omitempty"`
+	ProvisioningState            string                `json:"provisioningState,omitempty"`
+	DocumentEndpoint             string                `json:"documentEndpoint,omitempty"`
+	Locations                    []armLocation         `json:"locations,omitempty"`
+	ReadLocations                []armLocation         `json:"readLocations,omitempty"`
+	WriteLocations               []armLocation         `json:"writeLocations,omitempty"`
+	FailoverPolicies             []armFailover         `json:"failoverPolicies,omitempty"`
+	ConsistencyPolicy            *armConsistencyPolicy `json:"consistencyPolicy,omitempty"`
 }
 
 // armLocation is a region entry in a database account's location arrays.

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -316,6 +316,13 @@ type AccountAttributes struct {
 	// EnableMultipleWriteLocations mirrors the ARM property of the same name:
 	// when true every declared location accepts writes, not just priority 0.
 	EnableMultipleWriteLocations bool
+	// EnableAutomaticFailover mirrors the ARM property of the same name: when
+	// true a single-write-region account fails over automatically to the next
+	// priority region. Default false.
+	EnableAutomaticFailover bool
+	// PublicNetworkAccess mirrors the ARM property of the same name (Enabled /
+	// Disabled). Empty means the account uses Azure's Enabled default.
+	PublicNetworkAccess string
 	// ConsistencyPolicy is the account's default consistency level (and, for
 	// BoundedStaleness, its staleness bounds). Empty DefaultConsistencyLevel
 	// means the account uses Cosmos's Session default.


### PR DESCRIPTION
## Summary

Real-user e2e audit of the Azure Cosmos DB account control plane
(`Microsoft.DocumentDB/databaseAccounts`, `azurerm_cosmosdb_account`) against
the live `armcosmos/v3` SDK found one genuine cloud-vs-cloudemu divergence.

The core account toggles `enableAutomaticFailover`, `enableMultipleWriteLocations`
and `publicNetworkAccess` (plus `enableFreeTier`) were never emitted by the
handler and leaned on the generic property-echo overlay. The overlay echoes a
non-zero unmodeled value but **swallows an explicit JSON zero-value** (`false`,
`""`). So an account created with `enableMultipleWriteLocations=true` and later
PATCHed back to `false` kept reporting `true` on the update response and on every
later GET — while `writeLocations` correctly collapsed to the single region. Real
Azure always returns these fields with their real value, and Terraform reads each
one on every refresh, so this was a perpetual `multiple_write_locations_enabled`
drift. A default create also omitted all three booleans entirely.

## Fix

Model the toggles as first-class account attributes so the handler is
authoritative and the overlay never has to synthesize them:

- `services/database/driver/driver.go`: `AccountAttributes` gains
  `EnableAutomaticFailover` and `PublicNetworkAccess`.
- `server/azure/cosmosaccount`: accept them on create and on PATCH (pointer
  fields, so a toggle omitted from a PATCH is preserved), and always emit
  `enableFreeTier` / `enableAutomaticFailover` / `enableMultipleWriteLocations`
  (no `omitempty`, matching real Azure) and `publicNetworkAccess` (defaulting to
  `Enabled`).

Because the fields are now present in the response, the overlay no longer
captures them, so a value PATCHed to its zero is never resurrected. Genuinely
unmodeled properties (e.g. `disableKeyBasedMetadataWriteAccess`,
`minimalTlsVersion`) still round-trip via the overlay.

## Tests

New `account_toggles_test.go` drives the real `armcosmos/v3` client end-to-end:
default values on create/GET, full toggle round-trip, and the PATCH-to-false
regression (including that an omitted toggle is preserved and the disabled value
survives a later GET).

## Verified non-issues

List order deterministic; delete idempotent (204); async create/update/delete
LRO pollers terminate; consistencyPolicy (incl. BoundedStaleness) round-trips and
defaults to Session; geo-location arrays derived and ordered by failover priority.

## Filed, not fixed (low severity)

- Account name validation (3-44 lowercase) is not enforced.
- 404 error message says "container" (driver abstraction leak); status code is
  correct.
- `virtualNetworkRules` / `backupPolicy` / `analyticalStorageConfiguration` are
  overlay-covered for non-zero values; a real vnet-rules build-out is a separate
  surface.
