### PR TITLE
fix(gke): real-user e2e divergences from GCP

### DIFF
--- a/providers/gcp/gke/gke.go
+++ b/providers/gcp/gke/gke.go
@@ -464,7 +464,7 @@ func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Clu
 	m.clusterSettle.Begin(key, statusProvisioning, now, settleDur)
 
 	op := m.recordOperationAsync("CREATE_CLUSTER", input.Location,
-		"projects/"+m.opts.ProjectID+"/locations/"+input.Location+"/clusters/"+input.Name, now, settleDur)
+		"locations/"+input.Location+"/clusters/"+input.Name, now, settleDur)
 
 	m.emitClusterMetrics(input.Name)
 
@@ -547,6 +547,11 @@ func (m *Mock) ListClusters(_ context.Context, location string) ([]Cluster, erro
 		c.Status = m.clusterState(k, c.Status)
 		out = append(out, c)
 	}
+
+	// Deterministic order: map iteration is random, but real clients (gcloud
+	// container clusters list, SDK pagination, snapshot diffs) expect a stable
+	// listing. Sort by name.
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 
 	return out, nil
 }
@@ -657,7 +662,7 @@ func (m *Mock) DeleteCluster(_ context.Context, location, name string) (*Operati
 	}
 
 	op := m.recordOperation("DELETE_CLUSTER", location,
-		"projects/"+m.opts.ProjectID+"/locations/"+location+"/clusters/"+name)
+		"locations/"+location+"/clusters/"+name)
 
 	return &op, nil
 }
@@ -730,7 +735,7 @@ func (m *Mock) SetResourceLabels(
 	m.clusters.Set(key, c)
 
 	op := m.recordOperation("SET_LABELS", location,
-		"projects/"+m.opts.ProjectID+"/locations/"+location+"/clusters/"+name)
+		"locations/"+location+"/clusters/"+name)
 
 	return &op, nil
 }
@@ -767,7 +772,7 @@ func (m *Mock) mutateCluster(
 	m.clusters.Set(key, c)
 
 	op := m.recordOperation("UPDATE_CLUSTER", location,
-		"projects/"+m.opts.ProjectID+"/locations/"+location+"/clusters/"+name)
+		"locations/"+location+"/clusters/"+name)
 
 	return &op, nil
 }
@@ -807,7 +812,7 @@ func (m *Mock) CreateNodePool(
 	m.clusters.Set(cKey, cluster)
 
 	op := m.recordOperationAsync("CREATE_NODE_POOL", location,
-		"projects/"+m.opts.ProjectID+"/locations/"+location+"/clusters/"+clusterName+"/nodePools/"+spec.Name, now, settleDur)
+		"locations/"+location+"/clusters/"+clusterName+"/nodePools/"+spec.Name, now, settleDur)
 
 	out := np
 	out.Status = m.nodePoolState(npKey, out.Status)
@@ -858,6 +863,17 @@ func (m *Mock) ListNodePools(_ context.Context, location, clusterName string) ([
 		}
 	}
 
+	// Deterministic order matching real GKE, which lists pools in creation
+	// order (default-pool first, then added pools). Map iteration is random, so
+	// sort by creation time, breaking ties by name.
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].CreatedAt.Before(out[j].CreatedAt)
+		}
+
+		return out[i].Name < out[j].Name
+	})
+
 	return out, nil
 }
 
@@ -906,7 +922,7 @@ func (m *Mock) DeleteNodePool(_ context.Context, location, clusterName, name str
 	}
 
 	op := m.recordOperation("DELETE_NODE_POOL", location,
-		"projects/"+m.opts.ProjectID+"/locations/"+location+"/clusters/"+clusterName+"/nodePools/"+name)
+		"locations/"+location+"/clusters/"+clusterName+"/nodePools/"+name)
 
 	return &op, nil
 }
@@ -976,7 +992,7 @@ func (m *Mock) mutateNodePool(
 	m.nodePoolSettle.Begin(key, statusReconciling, now, settleDur)
 
 	op := m.recordOperationAsync(opType, location,
-		"projects/"+m.opts.ProjectID+"/locations/"+location+"/clusters/"+clusterName+"/nodePools/"+name, now, settleDur)
+		"locations/"+location+"/clusters/"+clusterName+"/nodePools/"+name, now, settleDur)
 	op.Status = m.opState(op.Name, op.Status)
 
 	return &op, nil
@@ -1028,6 +1044,16 @@ func (m *Mock) ListOperations(_ context.Context, location string) ([]Operation, 
 		op.Status = m.opState(op.Name, op.Status)
 		out = append(out, op)
 	}
+
+	// Deterministic order: oldest first (by start time), breaking ties by name,
+	// so operations.list is stable across identical calls.
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].StartTime.Equal(out[j].StartTime) {
+			return out[i].StartTime.Before(out[j].StartTime)
+		}
+
+		return out[i].Name < out[j].Name
+	})
 
 	return out, nil
 }

--- a/providers/gcp/gke/list_order_test.go
+++ b/providers/gcp/gke/list_order_test.go
@@ -1,0 +1,79 @@
+package gke
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestListClustersDeterministicOrder proves ListClusters sorts by name rather
+// than returning random map-iteration order.
+func TestListClustersDeterministicOrder(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"gamma", "alpha", "beta"} {
+		if _, _, err := m.CreateCluster(ctx, &CreateClusterInput{Name: name, Location: "us-central1"}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	got, err := m.ListClusters(ctx, "us-central1")
+	requireNoError(t, err)
+
+	names := make([]string, 0, len(got))
+	for i := range got {
+		names = append(names, got[i].Name)
+	}
+
+	assertEqual(t, "alpha,beta,gamma", strings.Join(names, ","))
+}
+
+// TestListNodePoolsDeterministicOrder proves ListNodePools returns a stable
+// order (default-pool first from cluster create, then by name for pools sharing
+// a creation timestamp under the fake clock).
+func TestListNodePoolsDeterministicOrder(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, _, err := m.CreateCluster(ctx, &CreateClusterInput{Name: "c", Location: "us-central1"}); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	for _, name := range []string{"zeta", "delta"} {
+		spec := NodePoolSpec{Name: name}
+		if _, _, err := m.CreateNodePool(ctx, "us-central1", "c", &spec); err != nil {
+			t.Fatalf("create pool %s: %v", name, err)
+		}
+	}
+
+	got, err := m.ListNodePools(ctx, "us-central1", "c")
+	requireNoError(t, err)
+
+	names := make([]string, 0, len(got))
+	for i := range got {
+		names = append(names, got[i].Name)
+	}
+
+	// default-pool from cluster create has the earliest timestamp; the two added
+	// pools share the fake clock's time and tie-break by name.
+	assertEqual(t, "default-pool,delta,zeta", strings.Join(names, ","))
+}
+
+// TestOperationTargetLinkStoredProjectRelative proves the operation's stored
+// TargetLink omits the project prefix, so the handler injects the request's
+// project when rendering the wire targetLink (not the mock's configured
+// default project).
+func TestOperationTargetLinkStoredProjectRelative(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, op, err := m.CreateCluster(ctx, &CreateClusterInput{Name: "prod", Location: "us-central1"})
+	requireNoError(t, err)
+
+	if strings.Contains(op.TargetLink, "projects/") {
+		t.Fatalf("stored TargetLink should be project-relative, got %q", op.TargetLink)
+	}
+
+	assertEqual(t, "locations/us-central1/clusters/prod", op.TargetLink)
+}

--- a/server/gcp/gke/sdk_terraform_fidelity_test.go
+++ b/server/gcp/gke/sdk_terraform_fidelity_test.go
@@ -1,0 +1,162 @@
+// Real-user e2e regression tests: the official Terraform google provider
+// (google_container_cluster / google_container_node_pool) dereferences
+// cluster.LegacyAbac.Enabled and cluster.NetworkConfig.Network/Subnetwork
+// unconditionally on read, so a cluster response missing either object panics
+// the provider on the first apply. These tests lock in that both objects are
+// always emitted, plus deterministic list ordering and a request-scoped
+// operation targetLink project.
+
+package gke_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/container/v1"
+)
+
+// TestSDKGKEClusterAlwaysEmitsLegacyAbacAndNetworkConfig proves a cluster read
+// always carries a non-nil legacyAbac and networkConfig (with network/
+// subnetwork), the fields the Terraform provider reads without a nil guard.
+func TestSDKGKEClusterAlwaysEmitsLegacyAbacAndNetworkConfig(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "tf", InitialNodeCount: 1},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.Get(clusterName(project, loc, "tf")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.LegacyAbac == nil {
+		t.Fatal("legacyAbac nil — Terraform provider would panic on cluster.LegacyAbac.Enabled")
+	}
+
+	if got.NetworkConfig == nil {
+		t.Fatal("networkConfig nil — Terraform provider would panic on cluster.NetworkConfig.Network")
+	}
+
+	if got.NetworkConfig.Network == "" || got.NetworkConfig.Subnetwork == "" {
+		t.Fatalf("networkConfig network/subnetwork empty: %q / %q",
+			got.NetworkConfig.Network, got.NetworkConfig.Subnetwork)
+	}
+
+	// The same objects must survive the list path (Terraform refreshes via both).
+	list, err := svc.Projects.Locations.Clusters.List(parent(project, loc)).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(list.Clusters) != 1 || list.Clusters[0].LegacyAbac == nil || list.Clusters[0].NetworkConfig == nil {
+		t.Fatalf("list cluster missing legacyAbac/networkConfig: %+v", list.Clusters)
+	}
+}
+
+// TestSDKGKEOperationTargetLinkUsesRequestProject proves an operation's
+// targetLink carries the project from the request URL, not the emulator's
+// configured default project — a user parsing targetLink to locate the resource
+// must see their own project.
+func TestSDKGKEOperationTargetLinkUsesRequestProject(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	op, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "proj"},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	want := "projects/" + project + "/locations/" + loc + "/clusters/proj"
+	if !strings.Contains(op.TargetLink, want) {
+		t.Fatalf("targetLink = %q, want it to contain %q", op.TargetLink, want)
+	}
+}
+
+// TestSDKGKENodePoolListDeterministicOrder proves nodePools.list returns pools
+// in a stable creation order (default-pool first, then added pools) rather than
+// random map-iteration order, so repeated reads and snapshots don't drift.
+func TestSDKGKENodePoolListDeterministicOrder(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "ord", InitialNodeCount: 1},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	for _, name := range []string{"pool-b", "pool-a"} {
+		if _, err := svc.Projects.Locations.Clusters.NodePools.Create(
+			clusterName(project, loc, "ord"),
+			&container.CreateNodePoolRequest{NodePool: &container.NodePool{Name: name, InitialNodeCount: 1}},
+		).Context(ctx).Do(); err != nil {
+			t.Fatalf("create node pool %s: %v", name, err)
+		}
+	}
+
+	var prev []string
+
+	for i := 0; i < 5; i++ {
+		resp, err := svc.Projects.Locations.Clusters.NodePools.List(clusterName(project, loc, "ord")).Context(ctx).Do()
+		if err != nil {
+			t.Fatalf("list node pools: %v", err)
+		}
+
+		names := make([]string, 0, len(resp.NodePools))
+		for _, np := range resp.NodePools {
+			names = append(names, np.Name)
+		}
+
+		if prev != nil && strings.Join(names, ",") != strings.Join(prev, ",") {
+			t.Fatalf("node pool order not stable: %v vs %v", prev, names)
+		}
+
+		prev = names
+	}
+
+	// default-pool was created first, so it must sort ahead of the later pools.
+	if len(prev) == 0 || prev[0] != "default-pool" {
+		t.Fatalf("expected default-pool first, got %v", prev)
+	}
+}
+
+// TestSDKGKEClusterListDeterministicOrder proves clusters.list returns clusters
+// sorted by name across repeated calls.
+func TestSDKGKEClusterListDeterministicOrder(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	for _, name := range []string{"gamma", "alpha", "beta"} {
+		if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+			Cluster: &container.Cluster{Name: name},
+		}).Context(ctx).Do(); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	resp, err := svc.Projects.Locations.Clusters.List(parent(project, loc)).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	got := make([]string, 0, len(resp.Clusters))
+	for _, c := range resp.Clusters {
+		got = append(got, c.Name)
+	}
+
+	want := "alpha,beta,gamma"
+	if strings.Join(got, ",") != want {
+		t.Fatalf("cluster order = %v, want %s", got, want)
+	}
+}

--- a/server/gcp/gke/types.go
+++ b/server/gcp/gke/types.go
@@ -38,6 +38,29 @@ type gkeCluster struct {
 	CurrentMasterVer  string            `json:"currentMasterVersion,omitempty"`
 	CurrentNodeVer    string            `json:"currentNodeVersion,omitempty"`
 	CreateTime        string            `json:"createTime,omitempty"`
+	// LegacyAbac and NetworkConfig are ALWAYS emitted (non-omitempty pointers)
+	// because real GKE always returns them, and the official Terraform google
+	// provider dereferences cluster.LegacyAbac.Enabled and cluster.NetworkConfig.
+	// Network/Subnetwork unconditionally on read — a nil either one panics the
+	// provider on the very first google_container_cluster apply.
+	LegacyAbac    *gkeLegacyAbac    `json:"legacyAbac"`
+	NetworkConfig *gkeNetworkConfig `json:"networkConfig"`
+}
+
+// gkeLegacyAbac mirrors container/v1.LegacyAbac. Real GKE returns this object on
+// every cluster (an empty {} when disabled); the provider reads .Enabled off it
+// without a nil check.
+type gkeLegacyAbac struct {
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+// gkeNetworkConfig mirrors the subset of container/v1.NetworkConfig the Terraform
+// provider reads unconditionally. Real GKE always returns a networkConfig with
+// the resolved network/subnetwork; the provider sources the `network`/`subnetwork`
+// attributes from here (not the deprecated top-level fields).
+type gkeNetworkConfig struct {
+	Network    string `json:"network,omitempty"`
+	Subnetwork string `json:"subnetwork,omitempty"`
 }
 
 type gkeMasterAuth struct {
@@ -240,6 +263,8 @@ func toClusterResource(c *gke.Cluster, project, endpoint string, pools []gke.Nod
 		CurrentNodeVer:   versionOr(c.NodeVersion),
 		SelfLink:         selfLinkBase + "projects/" + project + "/locations/" + c.Location + "/clusters/" + c.Name,
 		CreateTime:       c.CreatedAt.Format("2006-01-02T15:04:05.000Z"),
+		LegacyAbac:       &gkeLegacyAbac{Enabled: c.LegacyAbacEnabled},
+		NetworkConfig:    &gkeNetworkConfig{Network: c.Network, Subnetwork: c.Subnetwork},
 	}
 
 	for i := range pools {
@@ -300,10 +325,13 @@ func toOperationResource(op *gke.Operation, project string) gkeOperation {
 		Status:        op.Status,
 		Location:      op.Location,
 		Zone:          op.Location,
-		TargetLink:    selfLinkBase + op.TargetLink,
-		StartTime:     op.StartTime.Format("2006-01-02T15:04:05.000Z"),
-		EndTime:       op.EndTime.Format("2006-01-02T15:04:05.000Z"),
-		SelfLink:      selfLinkBase + "projects/" + project + "/locations/" + op.Location + "/operations/" + op.Name,
+		// op.TargetLink is stored project-relative ("locations/.../clusters/...")
+		// so the full link carries the project from the request URL, not the
+		// emulator's configured default project.
+		TargetLink: selfLinkBase + "projects/" + project + "/" + op.TargetLink,
+		StartTime:  op.StartTime.Format("2006-01-02T15:04:05.000Z"),
+		EndTime:    op.EndTime.Format("2006-01-02T15:04:05.000Z"),
+		SelfLink:   selfLinkBase + "projects/" + project + "/locations/" + op.Location + "/operations/" + op.Name,
 	}
 }
 


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of the GKE control plane (container.googleapis.com/v1) via the official `google.golang.org/api/container/v1` SDK **and** the official Terraform `google` provider (`google_container_cluster` / `google_container_node_pool`). Fixes the genuine cloud-vs-cloudemu divergences a real SDK/CLI/Terraform user hits.

## Fixes

**Terraform provider panic on cluster create (HIGH).** The official provider dereferences `cluster.LegacyAbac.Enabled` and `cluster.NetworkConfig.Network`/`.Subnetwork` unconditionally on read, and real GKE always returns both objects. The emulator omitted them, so `cluster.LegacyAbac`/`cluster.NetworkConfig` were nil and the provider crashed (nil pointer) on the very first `google_container_cluster` apply. The cluster response now always emits `legacyAbac` and `networkConfig` (network/subnetwork). Note the provider sources the `network`/`subnetwork` attributes from `networkConfig`, not the deprecated top-level fields.

**Nondeterministic list order (MEDIUM).** `ListClusters`, `ListNodePools` and `ListOperations` returned map-iteration order, so identical calls drifted. Now deterministic: clusters by name, node pools by creation time then name (default-pool first, matching real GKE), operations by start time then name.

**Operation targetLink used the wrong project (LOW-MED).** `targetLink` embedded the emulator's configured default project instead of the project from the request URL. The target is now stored project-relative and the handler injects the request's project when rendering the wire link.

## Verification

- Official Terraform `google` provider v5.45.2: the common `remove_default_node_pool=true` + separate `google_container_node_pool` pattern now completes the full `apply` (cluster RUNNING + LRO DONE) and `destroy`. Before this change, `apply` crashed the provider.
- `container/v1` SDK: create/get/list/update/delete + node-pool add/list + delete idempotency (404 after delete).
- Regression tests added at both the wire (`server/gcp/gke/sdk_terraform_fidelity_test.go`) and provider (`providers/gcp/gke/list_order_test.go`) layers.
- Gates: `go build ./...`, `go test -race` (providers/gcp/gke + server/gcp/gke), `go vet`, `gofmt`, `golangci-lint --new-from-rev` all green. `go generate` produced no coverage-doc changes (no new capabilities).

## Known gap (filed, not fixed)

`google_container_node_pool` shows a perpetual `node_count: 0 -> 2` plan drift: the provider reads `node_count` from `instanceGroupUrls` -> Compute `instanceGroupManagers.Get` `TargetSize`, and the GCE compute backend has no InstanceGroupManager support. Apply/destroy still succeed. This is a cross-service subsystem build (register a backing MIG per node pool + emit `instanceGroupUrls` + add `instanceGroupManagers.Get/List` to the compute handler) and is out of scope for this GKE-local fix.