### PR TITLE
fix(ecs): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/ecs/ecs_test.go
+++ b/providers/aws/ecs/ecs_test.go
@@ -218,6 +218,118 @@ func TestListTaskDefinitionsNumericRevisionOrder(t *testing.T) {
 	assert.Equal(t, 1, desc[11].Revision)
 }
 
+// TestListTaskDefinitionsDefaultsToActive verifies ECS's documented default:
+// with no status filter only ACTIVE revisions are listed, hiding deregistered
+// (INACTIVE) ones unless the caller explicitly asks for INACTIVE.
+func TestListTaskDefinitionsDefaultsToActive(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	in := driver.RegisterTaskDefinitionInput{
+		Family:               "web",
+		ContainerDefinitions: []driver.ContainerDefinition{{Name: "c", Image: "img"}},
+	}
+
+	_, err := m.RegisterTaskDefinition(ctx, in)
+	require.NoError(t, err)
+	_, err = m.RegisterTaskDefinition(ctx, in)
+	require.NoError(t, err)
+
+	_, err = m.DeregisterTaskDefinition(ctx, "web:1")
+	require.NoError(t, err)
+
+	// Empty status defaults to ACTIVE: only the live revision 2 is listed.
+	def, err := m.ListTaskDefinitions(ctx, "", "", "")
+	require.NoError(t, err)
+	require.Len(t, def, 1)
+	assert.Equal(t, 2, def[0].Revision)
+	assert.Equal(t, statusActive, def[0].Status)
+
+	// Explicit ACTIVE matches the default.
+	active, err := m.ListTaskDefinitions(ctx, "", statusActive, "")
+	require.NoError(t, err)
+	require.Len(t, active, 1)
+	assert.Equal(t, 2, active[0].Revision)
+
+	// INACTIVE surfaces the deregistered revision.
+	inactive, err := m.ListTaskDefinitions(ctx, "", statusInactive, "")
+	require.NoError(t, err)
+	require.Len(t, inactive, 1)
+	assert.Equal(t, 1, inactive[0].Revision)
+	assert.Equal(t, statusInactive, inactive[0].Status)
+}
+
+// TestCreateServiceDeploymentConfigDefaults verifies the rolling-update defaults
+// ECS reports on a service when the caller omits (or only partially supplies) a
+// deploymentConfiguration: 200/100 for REPLICA, 100/0 for DAEMON, a disabled
+// circuit breaker, and supplied fields preserved.
+func TestCreateServiceDeploymentConfigDefaults(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, driver.CreateClusterInput{Name: "prod"})
+	require.NoError(t, err)
+	registerFargate(t, m, "256", "512")
+
+	netCfg := &driver.NetworkConfiguration{AwsVpcConfiguration: &driver.AwsVpcConfiguration{Subnets: []string{"subnet-1"}}}
+
+	// REPLICA (default) with no deploymentConfiguration -> 200 / 100 + breaker.
+	replica, err := m.CreateService(ctx, driver.CreateServiceInput{
+		ServiceName:          "r",
+		Cluster:              "prod",
+		TaskDefinition:       "fg:1",
+		DesiredCount:         1,
+		LaunchType:           launchFargate,
+		NetworkConfiguration: netCfg,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, replica.DeploymentConfiguration)
+	require.NotNil(t, replica.DeploymentConfiguration.MaximumPercent)
+	require.NotNil(t, replica.DeploymentConfiguration.MinimumHealthyPercent)
+	assert.Equal(t, replicaMaxPercent, *replica.DeploymentConfiguration.MaximumPercent)
+	assert.Equal(t, replicaMinHealthyPercent, *replica.DeploymentConfiguration.MinimumHealthyPercent)
+	require.NotNil(t, replica.DeploymentConfiguration.DeploymentCircuitBreaker)
+	assert.False(t, replica.DeploymentConfiguration.DeploymentCircuitBreaker.Enable)
+	assert.False(t, replica.DeploymentConfiguration.DeploymentCircuitBreaker.Rollback)
+
+	// The default survives a describe round-trip.
+	found, _, err := m.DescribeServices(ctx, "prod", []string{"r"})
+	require.NoError(t, err)
+	require.Len(t, found, 1)
+	require.NotNil(t, found[0].DeploymentConfiguration.MaximumPercent)
+	assert.Equal(t, replicaMaxPercent, *found[0].DeploymentConfiguration.MaximumPercent)
+
+	// DAEMON defaults to 100 / 0.
+	daemon, err := m.CreateService(ctx, driver.CreateServiceInput{
+		ServiceName:          "d",
+		Cluster:              "prod",
+		TaskDefinition:       "fg:1",
+		LaunchType:           launchFargate,
+		SchedulingStrategy:   schedDaemon,
+		NetworkConfiguration: netCfg,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, daemon.DeploymentConfiguration.MaximumPercent)
+	assert.Equal(t, daemonMaxPercent, *daemon.DeploymentConfiguration.MaximumPercent)
+	assert.Equal(t, daemonMinHealthyPercent, *daemon.DeploymentConfiguration.MinimumHealthyPercent)
+
+	// A caller-supplied field is preserved; the omitted field is filled.
+	custom := 150
+	partial, err := m.CreateService(ctx, driver.CreateServiceInput{
+		ServiceName:             "p",
+		Cluster:                 "prod",
+		TaskDefinition:          "fg:1",
+		DesiredCount:            1,
+		LaunchType:              launchFargate,
+		NetworkConfiguration:    netCfg,
+		DeploymentConfiguration: &driver.DeploymentConfiguration{MaximumPercent: &custom},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, custom, *partial.DeploymentConfiguration.MaximumPercent)
+	require.NotNil(t, partial.DeploymentConfiguration.MinimumHealthyPercent)
+	assert.Equal(t, replicaMinHealthyPercent, *partial.DeploymentConfiguration.MinimumHealthyPercent)
+}
+
 func TestRegisterTaskDefinitionRequiresFamily(t *testing.T) {
 	m := newTestMock()
 

--- a/providers/aws/ecs/services.go
+++ b/providers/aws/ecs/services.go
@@ -25,6 +25,17 @@ const (
 
 	deployControllerECS = "ECS"
 
+	// Rolling-update deployment defaults ECS applies when the caller omits a
+	// deploymentConfiguration on a service using the ECS (rolling update)
+	// deployment controller. A REPLICA service defaults to 200/100, a DAEMON
+	// service to 100/0 (the CLI/SDK/API default). Real ECS always echoes these
+	// on Create/DescribeServices, so a caller reading maximumPercent /
+	// minimumHealthyPercent back never sees a missing field.
+	replicaMaxPercent        = 200
+	replicaMinHealthyPercent = 100
+	daemonMaxPercent         = 100
+	daemonMinHealthyPercent  = 0
+
 	// azRebalancingDisabled is the default availabilityZoneRebalancing value a
 	// service is created with when the caller doesn't specify one, matching
 	// real ECS.
@@ -161,7 +172,7 @@ func serviceFromInput(
 		// Clone reference-typed fields so the stored record never aliases the
 		// caller's input slices/pointers (a caller mutating what it passed must
 		// not corrupt the store).
-		DeploymentConfiguration:  cloneDeploymentConfig(in.DeploymentConfiguration),
+		DeploymentConfiguration:  defaultDeploymentConfig(sched, controller, in.DeploymentConfiguration),
 		NetworkConfiguration:     cloneNetworkConfig(in.NetworkConfiguration),
 		CapacityProviderStrategy: append([]driver.CapacityProviderStrategyItem(nil), in.CapacityProviderStrategy...),
 		LoadBalancers:            append([]driver.LoadBalancer(nil), in.LoadBalancers...),
@@ -169,6 +180,48 @@ func serviceFromInput(
 		Tags:                     copyTags(in.Tags),
 	}
 }
+
+// defaultDeploymentConfig returns the deployment configuration ECS reports for a
+// service, filling the rolling-update defaults AWS applies when the caller omits
+// them: maximumPercent/minimumHealthyPercent of 200/100 for a REPLICA service
+// and 100/0 for a DAEMON service, plus a disabled circuit breaker. These
+// defaults apply only to the ECS (rolling update) deployment controller;
+// CODE_DEPLOY / EXTERNAL controllers carry no rolling-update defaults, so their
+// configuration is echoed back unchanged.
+func defaultDeploymentConfig(
+	sched, controller string, in *driver.DeploymentConfiguration,
+) *driver.DeploymentConfiguration {
+	out := cloneDeploymentConfig(in)
+	if controller != deployControllerECS {
+		return out
+	}
+
+	if out == nil {
+		out = &driver.DeploymentConfiguration{}
+	}
+
+	maxPct, minPct := replicaMaxPercent, replicaMinHealthyPercent
+	if sched == schedDaemon {
+		maxPct, minPct = daemonMaxPercent, daemonMinHealthyPercent
+	}
+
+	if out.MaximumPercent == nil {
+		out.MaximumPercent = ptrInt(maxPct)
+	}
+
+	if out.MinimumHealthyPercent == nil {
+		out.MinimumHealthyPercent = ptrInt(minPct)
+	}
+
+	if out.DeploymentCircuitBreaker == nil {
+		out.DeploymentCircuitBreaker = &driver.DeploymentCircuitBreaker{}
+	}
+
+	return out
+}
+
+// ptrInt returns a pointer to v.
+func ptrInt(v int) *int { return &v }
 
 // reserveServiceName claims the service name in the store before convergence.
 // An ACTIVE service blocks the name; a lingering INACTIVE (deleted) tombstone is

--- a/providers/aws/ecs/taskdefs.go
+++ b/providers/aws/ecs/taskdefs.go
@@ -145,6 +145,12 @@ func (m *Mock) nextRevision(family string) int {
 func (m *Mock) ListTaskDefinitions(
 	_ context.Context, familyPrefix, status, sortOrder string,
 ) ([]driver.TaskDefinition, error) {
+	// ECS filters to ACTIVE task definitions by default: deregistered (INACTIVE)
+	// revisions are hidden unless the caller explicitly asks for INACTIVE.
+	if status == "" {
+		status = statusActive
+	}
+
 	all := m.taskDefs.SortedValues()
 
 	out := make([]driver.TaskDefinition, 0, len(all))


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of the AWS ECS control plane (SDK + AWS CLI + Terraform against `cloudemu serve`). The surface is broadly faithful — cluster/task-definition/service create, task-def revision auto-increment, service stabilization, delete guards, tags, and full Terraform `aws_ecs_cluster` / `aws_ecs_task_definition` / `aws_ecs_service` create→update→destroy all round-trip cleanly with no drift. Two genuine divergences were found and fixed.

## Fixes

**ListTaskDefinitions default status** — With no `status` filter, ECS lists only `ACTIVE` task definitions ("By default, only ACTIVE task definitions are listed." — [ListTaskDefinitions API ref](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ListTaskDefinitions.html)). cloudemu returned every revision, so deregistered (INACTIVE) revisions leaked into the default listing. Empty status now defaults to `ACTIVE`; explicit `ACTIVE`/`INACTIVE` are unaffected. (`ListTaskDefinitionFamilies`, whose documented default is *both* ACTIVE and INACTIVE, was already correct and is left unchanged.)

**Service deploymentConfiguration defaults** — Real ECS always echoes a `deploymentConfiguration` on Create/DescribeServices, filling rolling-update defaults when the caller omits them: `maximumPercent`/`minimumHealthyPercent` of 200/100 for a REPLICA service and 100/0 for a DAEMON service, plus a disabled circuit breaker ([DeploymentConfiguration API ref](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DeploymentConfiguration.html)). cloudemu returned no `deploymentConfiguration` at all when unspecified, so an SDK caller reading these fields back saw nothing. CreateService now populates the strategy-appropriate defaults (ECS deployment controller only), preserving any caller-supplied values and filling only omitted fields. Terraform shows no drift with the added object.

## Tests

- `TestListTaskDefinitionsDefaultsToActive` — empty status hides a deregistered revision; ACTIVE/INACTIVE filters still work.
- `TestCreateServiceDeploymentConfigDefaults` — REPLICA 200/100, DAEMON 100/0, disabled circuit breaker, describe round-trip, and partial-config fill.

Gates: `go build ./...`, `go test -race` (providers/aws/ecs, server/aws/ecs, services/ecs), `go vet`, `gofmt`, `golangci-lint` (new-from-rev + full-package) all green; `go generate ./...` produces no docs diff (behavior-only change, no interface change).
