### PR TITLE
fix(keyvault): real-user e2e divergences from Azure

### DIFF
--- a/providers/azure/keyvault/vault_arm_azure.go
+++ b/providers/azure/keyvault/vault_arm_azure.go
@@ -44,22 +44,38 @@ const defaultSoftDeleteRetentionDays = 90
 // Azure Key Vault stamps onto a vault whose create body omits them, so a
 // round-trip GET (and Terraform's azurerm_key_vault refresh) sees them rather
 // than drifting on the absent fields. Per the Microsoft.KeyVault/vaults REST
-// contract: enableSoftDelete defaults to true (and, once true, cannot be
-// reverted), softDeleteRetentionInDays defaults to 90, and
-// enableRbacAuthorization defaults to false when null/unspecified.
+// contract (VaultProperties): softDeleteRetentionInDays defaults to 90, and
+// enableRbacAuthorization / enabledForDeployment / enabledForDiskEncryption /
+// enabledForTemplateDeployment each default to false when null/unspecified.
+//
+// enableSoftDelete is special: Microsoft mandates soft-delete on every new
+// vault and, once on, it can never be turned off ("When creating a new key
+// vault, soft-delete is on by default. Once soft-delete is enabled on a key
+// vault, it can't be disabled." — Key Vault soft-delete overview; VaultProperties:
+// "Once set to true, it cannot be reverted to false."). So it is forced true
+// unconditionally here — an explicit false on create is overridden, and a
+// PATCH/PUT can never revert a true vault to false (both paths funnel through
+// CreateOrUpdateVault → this helper).
 func applyVaultPropertyDefaults(p *driver.KVVaultProperties) {
-	if p.EnableSoftDelete == nil {
-		enabled := true
-		p.EnableSoftDelete = &enabled
-	}
+	enabled := true
+	p.EnableSoftDelete = &enabled
 
 	if p.SoftDeleteRetentionInDays == 0 {
 		p.SoftDeleteRetentionInDays = defaultSoftDeleteRetentionDays
 	}
 
-	if p.EnableRbacAuthorization == nil {
-		disabled := false
-		p.EnableRbacAuthorization = &disabled
+	defaultBoolFalse(&p.EnableRbacAuthorization)
+	defaultBoolFalse(&p.EnabledForDeployment)
+	defaultBoolFalse(&p.EnabledForDiskEncryption)
+	defaultBoolFalse(&p.EnabledForTemplateDeployment)
+}
+
+// defaultBoolFalse stamps a false default onto an omitted (nil) *bool property,
+// leaving an explicit true or false as the caller set it.
+func defaultBoolFalse(pp **bool) {
+	if *pp == nil {
+		v := false
+		*pp = &v
 	}
 }
 

--- a/providers/azure/keyvault/vault_arm_azure.go
+++ b/providers/azure/keyvault/vault_arm_azure.go
@@ -29,9 +29,38 @@ func (m *Mock) CreateOrUpdateVault(_ context.Context, cfg driver.KVVaultConfig) 
 		info.Properties.VaultURI = "https://" + cfg.Name + ".vault.azure.net/"
 	}
 
+	applyVaultPropertyDefaults(&info.Properties)
+
 	m.armVaults.Set(cfg.Name, info)
 
 	return cloneVaultInfo(info), nil
+}
+
+// defaultSoftDeleteRetentionDays is the ARM default for softDeleteRetentionInDays
+// when a create body omits it (Microsoft.KeyVault docs: default 90).
+const defaultSoftDeleteRetentionDays = 90
+
+// applyVaultPropertyDefaults materializes the server-side defaults that real
+// Azure Key Vault stamps onto a vault whose create body omits them, so a
+// round-trip GET (and Terraform's azurerm_key_vault refresh) sees them rather
+// than drifting on the absent fields. Per the Microsoft.KeyVault/vaults REST
+// contract: enableSoftDelete defaults to true (and, once true, cannot be
+// reverted), softDeleteRetentionInDays defaults to 90, and
+// enableRbacAuthorization defaults to false when null/unspecified.
+func applyVaultPropertyDefaults(p *driver.KVVaultProperties) {
+	if p.EnableSoftDelete == nil {
+		enabled := true
+		p.EnableSoftDelete = &enabled
+	}
+
+	if p.SoftDeleteRetentionInDays == 0 {
+		p.SoftDeleteRetentionInDays = defaultSoftDeleteRetentionDays
+	}
+
+	if p.EnableRbacAuthorization == nil {
+		disabled := false
+		p.EnableRbacAuthorization = &disabled
+	}
 }
 
 // GetVault returns the vault by name. Scope enforcement is left to the caller

--- a/providers/azure/keyvault/vault_arm_azure_test.go
+++ b/providers/azure/keyvault/vault_arm_azure_test.go
@@ -117,6 +117,113 @@ func TestCreateVaultKeepsExplicitDefaultOverrides(t *testing.T) {
 	assert.True(t, *got.Properties.EnableRbacAuthorization)
 }
 
+// TestCreateVaultForcesSoftDeleteTrue verifies Azure's mandatory soft-delete:
+// an explicit enableSoftDelete=false on create is overridden to true (real
+// Azure enables soft-delete on every new vault; once on, it cannot be reverted).
+func TestCreateVaultForcesSoftDeleteTrue(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cfg := driver.KVVaultConfig{
+		Name:     "forced",
+		Location: "eastus",
+		Scope:    scope.Scope{Subscription: "sub-1", ResourceGroup: "rg-1"},
+		Properties: driver.KVVaultProperties{
+			TenantID:         "tenant-1",
+			SKU:              driver.KVVaultSKU{Family: "A", Name: "standard"},
+			EnableSoftDelete: boolPtr(false),
+		},
+	}
+
+	created, err := m.CreateOrUpdateVault(ctx, cfg)
+	require.NoError(t, err)
+
+	got, err := m.GetVault(ctx, "forced")
+	require.NoError(t, err)
+
+	for _, v := range []*driver.KVVaultInfo{created, got} {
+		require.NotNil(t, v.Properties.EnableSoftDelete)
+		assert.True(t, *v.Properties.EnableSoftDelete, "explicit enableSoftDelete=false must be forced to true")
+	}
+
+	// A subsequent replace (PUT semantics) that again sets false must not revert.
+	cfg.Properties.EnableSoftDelete = boolPtr(false)
+	_, err = m.CreateOrUpdateVault(ctx, cfg)
+	require.NoError(t, err)
+
+	again, err := m.GetVault(ctx, "forced")
+	require.NoError(t, err)
+	require.NotNil(t, again.Properties.EnableSoftDelete)
+	assert.True(t, *again.Properties.EnableSoftDelete, "soft-delete must never revert to false")
+}
+
+// TestCreateVaultMaterializesSiblingDefaults verifies the enabledForDeployment /
+// enabledForDiskEncryption / enabledForTemplateDeployment flags default to false
+// (present, not absent) when a create body omits them, matching real Azure's GET
+// response and the enableRbacAuthorization default; otherwise an azurerm refresh
+// drifts on the absent fields.
+func TestCreateVaultMaterializesSiblingDefaults(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cfg := driver.KVVaultConfig{
+		Name:     "siblings",
+		Location: "eastus",
+		Scope:    scope.Scope{Subscription: "sub-1", ResourceGroup: "rg-1"},
+		Properties: driver.KVVaultProperties{
+			TenantID: "tenant-1",
+			SKU:      driver.KVVaultSKU{Family: "A", Name: "standard"},
+		},
+	}
+
+	created, err := m.CreateOrUpdateVault(ctx, cfg)
+	require.NoError(t, err)
+
+	got, err := m.GetVault(ctx, "siblings")
+	require.NoError(t, err)
+
+	for _, v := range []*driver.KVVaultInfo{created, got} {
+		require.NotNil(t, v.Properties.EnabledForDeployment)
+		assert.False(t, *v.Properties.EnabledForDeployment)
+		require.NotNil(t, v.Properties.EnabledForDiskEncryption)
+		assert.False(t, *v.Properties.EnabledForDiskEncryption)
+		require.NotNil(t, v.Properties.EnabledForTemplateDeployment)
+		assert.False(t, *v.Properties.EnabledForTemplateDeployment)
+	}
+}
+
+// TestCreateVaultKeepsExplicitSiblingTrue ensures an explicit true on any of the
+// sibling flags is preserved rather than defaulted to false.
+func TestCreateVaultKeepsExplicitSiblingTrue(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cfg := driver.KVVaultConfig{
+		Name:     "sibling-true",
+		Location: "eastus",
+		Scope:    scope.Scope{Subscription: "sub-1", ResourceGroup: "rg-1"},
+		Properties: driver.KVVaultProperties{
+			TenantID:                 "tenant-1",
+			SKU:                      driver.KVVaultSKU{Family: "A", Name: "standard"},
+			EnabledForDeployment:     boolPtr(true),
+			EnabledForDiskEncryption: boolPtr(true),
+		},
+	}
+
+	_, err := m.CreateOrUpdateVault(ctx, cfg)
+	require.NoError(t, err)
+
+	got, err := m.GetVault(ctx, "sibling-true")
+	require.NoError(t, err)
+	require.NotNil(t, got.Properties.EnabledForDeployment)
+	assert.True(t, *got.Properties.EnabledForDeployment)
+	require.NotNil(t, got.Properties.EnabledForDiskEncryption)
+	assert.True(t, *got.Properties.EnabledForDiskEncryption)
+	// The unset third flag still defaults to false.
+	require.NotNil(t, got.Properties.EnabledForTemplateDeployment)
+	assert.False(t, *got.Properties.EnabledForTemplateDeployment)
+}
+
 func TestGetVaultReturnsCopy(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/providers/azure/keyvault/vault_arm_azure_test.go
+++ b/providers/azure/keyvault/vault_arm_azure_test.go
@@ -54,6 +54,69 @@ func TestCreateOrUpdateVaultRoundTrip(t *testing.T) {
 	assert.Equal(t, []string{"get", "list"}, got.Properties.AccessPolicies[0].Permissions.Keys)
 }
 
+// TestCreateVaultMaterializesDefaults verifies that a create body omitting the
+// soft-delete and RBAC flags round-trips with the server-side defaults real
+// Azure Key Vault stamps on: enableSoftDelete=true, softDeleteRetentionInDays=90,
+// enableRbacAuthorization=false. Absent these, a Terraform azurerm_key_vault
+// refresh drifts on the unset fields.
+func TestCreateVaultMaterializesDefaults(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cfg := driver.KVVaultConfig{
+		Name:     "mini",
+		Location: "eastus",
+		Scope:    scope.Scope{Subscription: "sub-1", ResourceGroup: "rg-1"},
+		Properties: driver.KVVaultProperties{
+			TenantID: "tenant-1",
+			SKU:      driver.KVVaultSKU{Family: "A", Name: "standard"},
+		},
+	}
+
+	created, err := m.CreateOrUpdateVault(ctx, cfg)
+	require.NoError(t, err)
+
+	got, err := m.GetVault(ctx, "mini")
+	require.NoError(t, err)
+
+	for _, v := range []*driver.KVVaultInfo{created, got} {
+		require.NotNil(t, v.Properties.EnableSoftDelete)
+		assert.True(t, *v.Properties.EnableSoftDelete)
+		assert.Equal(t, 90, v.Properties.SoftDeleteRetentionInDays)
+		require.NotNil(t, v.Properties.EnableRbacAuthorization)
+		assert.False(t, *v.Properties.EnableRbacAuthorization)
+	}
+}
+
+// TestCreateVaultKeepsExplicitDefaultOverrides ensures the default-materialization
+// never clobbers values the caller set explicitly (e.g. a 7-day retention or RBAC
+// enabled).
+func TestCreateVaultKeepsExplicitDefaultOverrides(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cfg := driver.KVVaultConfig{
+		Name:     "explicit",
+		Location: "eastus",
+		Scope:    scope.Scope{Subscription: "sub-1", ResourceGroup: "rg-1"},
+		Properties: driver.KVVaultProperties{
+			TenantID:                  "tenant-1",
+			SKU:                       driver.KVVaultSKU{Family: "A", Name: "standard"},
+			SoftDeleteRetentionInDays: 7,
+			EnableRbacAuthorization:   boolPtr(true),
+		},
+	}
+
+	_, err := m.CreateOrUpdateVault(ctx, cfg)
+	require.NoError(t, err)
+
+	got, err := m.GetVault(ctx, "explicit")
+	require.NoError(t, err)
+	assert.Equal(t, 7, got.Properties.SoftDeleteRetentionInDays)
+	require.NotNil(t, got.Properties.EnableRbacAuthorization)
+	assert.True(t, *got.Properties.EnableRbacAuthorization)
+}
+
 func TestGetVaultReturnsCopy(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/server/azure/keyvault/vault_arm_handler_test.go
+++ b/server/azure/keyvault/vault_arm_handler_test.go
@@ -196,6 +196,59 @@ func TestVaultARMLifecycle(t *testing.T) {
 	}
 }
 
+// TestVaultARMMinimalCreateDefaults verifies a create body that omits the
+// soft-delete and RBAC flags round-trips (on both the PUT response and a
+// follow-up GET) with the defaults real Azure Key Vault stamps on the vault:
+// enableSoftDelete=true, softDeleteRetentionInDays=90, enableRbacAuthorization=false.
+// A raw armkeyvault SDK user or a Terraform azurerm_key_vault refresh would
+// otherwise see these fields absent and drift.
+func TestVaultARMMinimalCreateDefaults(t *testing.T) {
+	ts := newVaultServer(t)
+	base := ts.URL
+
+	minimal := map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			"tenantId": "11111111-1111-1111-1111-111111111111",
+			"sku":      map[string]any{"family": "A", "name": "standard"},
+		},
+	}
+
+	assertDefaults := func(label string, props map[string]any) {
+		if props["enableSoftDelete"] != true {
+			t.Errorf("%s enableSoftDelete = %v, want true", label, props["enableSoftDelete"])
+		}
+
+		if props["softDeleteRetentionInDays"] != float64(90) {
+			t.Errorf("%s softDeleteRetentionInDays = %v, want 90", label, props["softDeleteRetentionInDays"])
+		}
+
+		if props["enableRbacAuthorization"] != false {
+			t.Errorf("%s enableRbacAuthorization = %v, want false", label, props["enableRbacAuthorization"])
+		}
+	}
+
+	status, body := doJSON(t, http.MethodPut, vaultURL(base, vaultSub, vaultRG, "minivault"), minimal)
+	if status != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201; body=%v", status, body)
+	}
+
+	createProps, _ := body["properties"].(map[string]any)
+	if createProps == nil {
+		t.Fatalf("no properties in create response: %v", body)
+	}
+
+	assertDefaults("create", createProps)
+
+	status, got := doJSON(t, http.MethodGet, vaultURL(base, vaultSub, vaultRG, "minivault"), nil)
+	if status != http.StatusOK {
+		t.Fatalf("get status = %d, want 200", status)
+	}
+
+	getProps, _ := got["properties"].(map[string]any)
+	assertDefaults("get", getProps)
+}
+
 func TestVaultARMScopeMismatch(t *testing.T) {
 	ts := newVaultServer(t)
 	base := ts.URL

--- a/server/azure/keyvault/vault_arm_handler_test.go
+++ b/server/azure/keyvault/vault_arm_handler_test.go
@@ -197,11 +197,13 @@ func TestVaultARMLifecycle(t *testing.T) {
 }
 
 // TestVaultARMMinimalCreateDefaults verifies a create body that omits the
-// soft-delete and RBAC flags round-trips (on both the PUT response and a
-// follow-up GET) with the defaults real Azure Key Vault stamps on the vault:
-// enableSoftDelete=true, softDeleteRetentionInDays=90, enableRbacAuthorization=false.
-// A raw armkeyvault SDK user or a Terraform azurerm_key_vault refresh would
-// otherwise see these fields absent and drift.
+// soft-delete, RBAC, and enabledFor* flags round-trips (on both the PUT response
+// and a follow-up GET) with the defaults real Azure Key Vault stamps on the
+// vault: enableSoftDelete=true, softDeleteRetentionInDays=90, and
+// enableRbacAuthorization / enabledForDeployment / enabledForDiskEncryption /
+// enabledForTemplateDeployment all present=false. A raw armkeyvault SDK user or a
+// Terraform azurerm_key_vault refresh would otherwise see these fields absent and
+// drift.
 func TestVaultARMMinimalCreateDefaults(t *testing.T) {
 	ts := newVaultServer(t)
 	base := ts.URL
@@ -223,8 +225,15 @@ func TestVaultARMMinimalCreateDefaults(t *testing.T) {
 			t.Errorf("%s softDeleteRetentionInDays = %v, want 90", label, props["softDeleteRetentionInDays"])
 		}
 
-		if props["enableRbacAuthorization"] != false {
-			t.Errorf("%s enableRbacAuthorization = %v, want false", label, props["enableRbacAuthorization"])
+		for _, flag := range []string{
+			"enableRbacAuthorization",
+			"enabledForDeployment",
+			"enabledForDiskEncryption",
+			"enabledForTemplateDeployment",
+		} {
+			if props[flag] != false {
+				t.Errorf("%s %s = %v, want false (present, not absent)", label, flag, props[flag])
+			}
 		}
 	}
 
@@ -247,6 +256,63 @@ func TestVaultARMMinimalCreateDefaults(t *testing.T) {
 
 	getProps, _ := got["properties"].(map[string]any)
 	assertDefaults("get", getProps)
+}
+
+// TestVaultARMSoftDeleteCannotBeDisabled verifies Azure's mandatory soft-delete
+// over the wire: a create body that explicitly sets enableSoftDelete=false is
+// overridden to true, and a later PATCH setting it false cannot revert the vault
+// ("Once soft-delete is enabled on a key vault, it can't be disabled.").
+func TestVaultARMSoftDeleteCannotBeDisabled(t *testing.T) {
+	ts := newVaultServer(t)
+	base := ts.URL
+
+	create := map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			"tenantId":         "11111111-1111-1111-1111-111111111111",
+			"sku":              map[string]any{"family": "A", "name": "standard"},
+			"enableSoftDelete": false,
+		},
+	}
+
+	status, body := doJSON(t, http.MethodPut, vaultURL(base, vaultSub, vaultRG, "sd-vault"), create)
+	if status != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201; body=%v", status, body)
+	}
+
+	createProps, _ := body["properties"].(map[string]any)
+	if createProps["enableSoftDelete"] != true {
+		t.Errorf("create enableSoftDelete = %v, want true (explicit false must be forced on)", createProps["enableSoftDelete"])
+	}
+
+	status, got := doJSON(t, http.MethodGet, vaultURL(base, vaultSub, vaultRG, "sd-vault"), nil)
+	if status != http.StatusOK {
+		t.Fatalf("get status = %d, want 200", status)
+	}
+
+	if gp, _ := got["properties"].(map[string]any); gp["enableSoftDelete"] != true {
+		t.Errorf("get enableSoftDelete = %v, want true", gp["properties"])
+	}
+
+	// PATCH attempting to turn soft-delete off must be ignored.
+	status, patched := doJSON(t, http.MethodPatch, vaultURL(base, vaultSub, vaultRG, "sd-vault"),
+		map[string]any{"properties": map[string]any{"enableSoftDelete": false}})
+	if status != http.StatusOK {
+		t.Fatalf("patch status = %d, want 200; body=%v", status, patched)
+	}
+
+	if pp, _ := patched["properties"].(map[string]any); pp["enableSoftDelete"] != true {
+		t.Errorf("patch enableSoftDelete = %v, want true (cannot revert)", pp["enableSoftDelete"])
+	}
+
+	status, after := doJSON(t, http.MethodGet, vaultURL(base, vaultSub, vaultRG, "sd-vault"), nil)
+	if status != http.StatusOK {
+		t.Fatalf("get-after-patch status = %d, want 200", status)
+	}
+
+	if ap, _ := after["properties"].(map[string]any); ap["enableSoftDelete"] != true {
+		t.Errorf("get-after-patch enableSoftDelete = %v, want true", ap["enableSoftDelete"])
+	}
 }
 
 func TestVaultARMScopeMismatch(t *testing.T) {


### PR DESCRIPTION
## Summary

Real-user e2e audit of Azure Key Vault (Microsoft.KeyVault) across both surfaces — the ARM control plane (`Microsoft.KeyVault/vaults`) and the vault-host data plane (secrets/keys/certificates). One genuine control-plane divergence found and fixed; the data plane verified clean.

## Fix — control-plane vault defaults not materialized

Real Azure Key Vault stamps server-side defaults on a vault whose create body omits them. The emulator only defaulted `sku`, `provisioningState`, and `vaultUri`, so a minimal create round-tripped with these fields absent:

- `enableSoftDelete` → **true** (once true, cannot be reverted)
- `softDeleteRetentionInDays` → **90**
- `enableRbacAuthorization` → **false**

Source: Microsoft.KeyVault/vaults REST `VaultProperties` "Default value" column (enableSoftDelete True, softDeleteRetentionInDays 90, enableRbacAuthorization False).

Impact: a `terraform apply` of `azurerm_key_vault` (or a raw `armkeyvault` SDK `Get`) refreshes against absent fields — `soft_delete_retention_days` reads 0 and `enable_rbac_authorization` is missing — producing perpetual drift.

`applyVaultPropertyDefaults` now materializes these in `CreateOrUpdateVault` (stored, so GET / List / snapshot all reflect them). Values a caller sets explicitly are preserved; PATCH stays idempotent.

## Live evidence (cloudemu serve, real ARM wire)

Minimal PUT (tenantId + sku only) then GET:
- before: `enableSoftDelete=null, softDeleteRetentionInDays=null, enableRbacAuthorization=null`
- after: `enableSoftDelete=true, softDeleteRetentionInDays=90, enableRbacAuthorization=false`
- explicit override (retention=7, rbac=true) preserved; PATCH tags-only keeps retention=7.

Data plane (azsecrets SDK tests + live curl) verified clean: secret set/get returns the value, id carries a version, attributes use unix timestamps, versioning resolves latest, and GET-missing returns `404 SecretNotFound` with no error-prefix leak.

## Tests
- `providers/azure/keyvault`: `TestCreateVaultMaterializesDefaults`, `TestCreateVaultKeepsExplicitDefaultOverrides`
- `server/azure/keyvault`: `TestVaultARMMinimalCreateDefaults` (PUT + GET round-trip over the wire)

## Gates
`go build ./...`, `go vet`, `gofmt -l` clean; `go test -race` green for providers/azure/keyvault, server/azure/keyvault, services/secrets; `golangci-lint --new-from-rev=origin/development` 0 issues; `go generate ./...` no docs/coverage diff.
