### PR TITLE
fix(gce): real-user e2e divergences from GCP

### DIFF
--- a/providers/gcp/compute/gce.go
+++ b/providers/gcp/compute/gce.go
@@ -659,9 +659,12 @@ func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver
 	id := fmt.Sprintf("projects/%s/zones/%s/disks/disk-%d",
 		m.opts.ProjectID, m.opts.Region, m.volCounter.Add(1))
 
+	// GCP's disks.insert default type when the caller names none is pd-standard
+	// (not pd-ssd); a raw SDK/gcloud disk or a boot disk with no diskType reads
+	// back pd-standard on real GCP.
 	volType := cfg.VolumeType
 	if volType == "" {
-		volType = "pd-ssd"
+		volType = "pd-standard"
 	}
 
 	vol := &driver.VolumeInfo{

--- a/server/gcp/compute/disks.go
+++ b/server/gcp/compute/disks.go
@@ -22,8 +22,7 @@ const gcpDiskSourceImageTag = "cloudemu:gcpDiskSourceImage"
 // diskRequest mirrors the subset of GCP compute#disk we accept on insert.
 type diskRequest struct {
 	Name        string            `json:"name"`
-	SizeGb      int               `json:"sizeGb,string,omitempty"`
-	SizeGbInt   int               `json:"-"`
+	SizeGb      flexInt           `json:"sizeGb,omitempty"`
 	Type        string            `json:"type,omitempty"`
 	SourceImage string            `json:"sourceImage,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty"`
@@ -77,7 +76,7 @@ func (h *Handler) insertDisk(w http.ResponseWriter, r *http.Request, rp gcprest.
 	}
 
 	cfg := computedriver.VolumeConfig{
-		Size:             pickSize(req.SizeGb, req.SizeGbInt),
+		Size:             int(req.SizeGb),
 		VolumeType:       lastSegment(req.Type),
 		AvailabilityZone: rp.ScopeName,
 		Tags:             mergeDiskTags(req.Labels, req.Name, req.SourceImage),
@@ -173,11 +172,11 @@ func (h *Handler) deleteDisk(w http.ResponseWriter, r *http.Request, rp gcprest.
 	gcprest.WriteJSON(w, http.StatusOK, op)
 }
 
-// diskResizeRequest is the compute#disksResizeRequest body (sizeGb arrives as a
-// JSON string from the protobuf clients).
+// diskResizeRequest is the compute#disksResizeRequest body. sizeGb arrives as a
+// quoted string from the typed clients and as a bare number from the Terraform
+// provider, so flexInt accepts either.
 type diskResizeRequest struct {
-	SizeGb    int `json:"sizeGb,string,omitempty"`
-	SizeGbInt int `json:"-"`
+	SizeGb flexInt `json:"sizeGb,omitempty"`
 }
 
 // volumeResizer is the GCP-local grow-a-disk capability the GCE Mock implements;
@@ -202,7 +201,7 @@ func (h *Handler) resizeDisk(w http.ResponseWriter, r *http.Request, rp gcprest.
 		return
 	}
 
-	newSize := pickSize(req.SizeGb, req.SizeGbInt)
+	newSize := int(req.SizeGb)
 	if newSize < vol.Size {
 		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "disk size cannot be reduced")
 		return
@@ -547,15 +546,6 @@ func conflictIfExists(w http.ResponseWriter, findErr error, msg string) bool {
 	default:
 		return false
 	}
-}
-
-// pickSize chooses sizeGb from the alternate fields the SDK might use.
-func pickSize(sFromString, sInt int) int {
-	if sFromString > 0 {
-		return sFromString
-	}
-
-	return sInt
 }
 
 // lastSegment returns the trailing path segment of a self-link or full URL.

--- a/server/gcp/compute/handler.go
+++ b/server/gcp/compute/handler.go
@@ -84,7 +84,22 @@ func (*Handler) Matches(r *http.Request) bool {
 		return true
 	}
 
+	// A bare zone/region path (.../zones/{z} or .../regions/{r}, no resource
+	// type) is the zones.get / regions.get endpoint — Terraform resolves the
+	// zone via zones.get before creating an instance.
+	if isScopeResource(&rp) {
+		return true
+	}
+
 	return false
+}
+
+// isScopeResource reports whether rp addresses a zone or region resource
+// itself (".../zones/{z}" / ".../regions/{r}" with no trailing resource type),
+// i.e. the zones.get / regions.get endpoint.
+func isScopeResource(rp *gcprest.ResourcePath) bool {
+	return rp.ResourceType == "" && rp.ResourceName == "" && rp.Action == "" &&
+		rp.ScopeName != "" && (rp.Scope == gcprest.ScopeZones || rp.Scope == gcprest.ScopeRegions)
 }
 
 // ServeHTTP routes the parsed path to the matching operation.
@@ -97,6 +112,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if rp.Scope == gcprest.ScopeAggregated {
 		h.serveAggregated(w, r, rp)
+		return
+	}
+
+	if isScopeResource(&rp) {
+		serveScopeResource(w, r, rp)
 		return
 	}
 

--- a/server/gcp/compute/images.go
+++ b/server/gcp/compute/images.go
@@ -28,7 +28,7 @@ type imageRequest struct {
 	SourceDisk     string            `json:"sourceDisk,omitempty"`
 	SourceSnapshot string            `json:"sourceSnapshot,omitempty"`
 	Family         string            `json:"family,omitempty"`
-	DiskSizeGb     int               `json:"diskSizeGb,string,omitempty"`
+	DiskSizeGb     flexInt           `json:"diskSizeGb,omitempty"`
 	Labels         map[string]string `json:"labels,omitempty"`
 }
 
@@ -269,7 +269,7 @@ func (h *Handler) mergeImageTags(ctx context.Context, in map[string]string, req 
 // when given, otherwise the size of the source disk it is built from.
 func (h *Handler) imageDiskSizeGb(ctx context.Context, req *imageRequest) string {
 	if req.DiskSizeGb > 0 {
-		return strconv.Itoa(req.DiskSizeGb)
+		return strconv.Itoa(int(req.DiskSizeGb))
 	}
 
 	if req.SourceDisk == "" {

--- a/server/gcp/compute/instance_response.go
+++ b/server/gcp/compute/instance_response.go
@@ -47,7 +47,7 @@ func (h *Handler) toInstanceResponse(ctx context.Context, inst *computedriver.In
 		},
 		Metadata:               metadataResponse(metaItems),
 		Scheduling:             defaultScheduling(),
-		ServiceAccounts:        serviceAccountsFor(inst.Tags),
+		ServiceAccounts:        serviceAccountsFor(inst.Tags, project),
 		ShieldedInstanceConfig: defaultShieldedConfig(),
 	}
 
@@ -250,18 +250,34 @@ func defaultScheduling() *scheduling {
 // serviceAccountsFor reflects the serviceAccounts[] the client attached at
 // insert time (email + scopes, round-tripped exactly). When the client omitted
 // them, it falls back to the default compute service account real GCP attaches.
-func serviceAccountsFor(tags map[string]string) []serviceAccount {
+func serviceAccountsFor(tags map[string]string, project string) []serviceAccount {
 	if sas := decodeServiceAccounts(tags); len(sas) > 0 {
 		return sas
 	}
 
-	return defaultServiceAccounts()
+	return defaultServiceAccounts(project)
 }
 
-func defaultServiceAccounts() []serviceAccount {
+// defaultComputeSAScopes are the scopes real GCP grants the default compute
+// service account when an instance is created without a serviceAccounts block
+// (the "default access" set), not the full cloud-platform scope.
+var defaultComputeSAScopes = []string{ //nolint:gochecknoglobals // static lookup table
+	"https://www.googleapis.com/auth/devstorage.read_only",
+	"https://www.googleapis.com/auth/logging.write",
+	"https://www.googleapis.com/auth/monitoring.write",
+	"https://www.googleapis.com/auth/service.management.readonly",
+	"https://www.googleapis.com/auth/servicecontrol",
+	"https://www.googleapis.com/auth/trace.append",
+}
+
+// defaultServiceAccounts returns the default compute service account GCP attaches
+// to an instance created without one. Real GCP resolves the account to the
+// project's compute SA email (never the literal "default", which is only a
+// request-side shorthand) with the default-access scope set.
+func defaultServiceAccounts(project string) []serviceAccount {
 	return []serviceAccount{{
-		Email:  "default",
-		Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
+		Email:  project + "-compute@developer.gserviceaccount.com",
+		Scopes: defaultComputeSAScopes,
 	}}
 }
 

--- a/server/gcp/compute/networkip_sdk_test.go
+++ b/server/gcp/compute/networkip_sdk_test.go
@@ -52,12 +52,16 @@ func TestSDKInstanceServiceAccountsRoundTrip(t *testing.T) {
 	def := getSDKInstance(t, client, "default-sa-vm")
 
 	dsas := def.GetServiceAccounts()
-	if len(dsas) != 1 || dsas[0].GetEmail() != "default" {
-		t.Fatalf("default-sa-vm serviceAccounts=%v want single email=default", dsas)
+
+	wantEmail := testProject + "-compute@developer.gserviceaccount.com"
+	if len(dsas) != 1 || dsas[0].GetEmail() != wantEmail {
+		t.Fatalf("default-sa-vm serviceAccounts=%v want single email=%q", dsas, wantEmail)
 	}
 
-	if len(dsas[0].GetScopes()) != 1 || dsas[0].GetScopes()[0] != "https://www.googleapis.com/auth/cloud-platform" {
-		t.Errorf("default SA scopes=%v want [cloud-platform]", dsas[0].GetScopes())
+	// Real GCP grants the default compute SA the default-access scope set, not
+	// the full cloud-platform scope.
+	if len(dsas[0].GetScopes()) != 6 || dsas[0].GetScopes()[0] != "https://www.googleapis.com/auth/devstorage.read_only" {
+		t.Errorf("default SA scopes=%v want the 6-scope default-access set", dsas[0].GetScopes())
 	}
 }
 

--- a/server/gcp/compute/types.go
+++ b/server/gcp/compute/types.go
@@ -1,5 +1,44 @@
 package compute
 
+import (
+	"bytes"
+	"strconv"
+)
+
+// flexInt decodes an integer that GCP clients may send as either a quoted
+// string ("20") or a bare JSON number (20). Real GCP's compute API accepts both
+// for size fields (sizeGb, diskSizeGb): the typed google.golang.org/api client
+// marshals int64 ",string" fields as quoted strings, while the Terraform google
+// provider builds its request bodies from a map[string]interface{} and marshals
+// the raw number unquoted. A plain `int` with a `,string` struct tag rejects the
+// unquoted form ("invalid use of ,string struct tag"), so the emulator must
+// accept either encoding.
+type flexInt int
+
+// UnmarshalJSON accepts a JSON number, a quoted numeric string, or null/empty.
+func (f *flexInt) UnmarshalJSON(b []byte) error {
+	b = bytes.TrimSpace(b)
+	if len(b) == 0 || bytes.Equal(b, []byte("null")) {
+		*f = 0
+		return nil
+	}
+
+	s := string(bytes.Trim(b, `"`))
+	if s == "" {
+		*f = 0
+		return nil
+	}
+
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return err
+	}
+
+	*f = flexInt(n)
+
+	return nil
+}
+
 // GCP REST JSON shapes for compute#instance.
 //
 // Modeled on the public schema (https://cloud.google.com/compute/docs/reference/rest/v1/instances).

--- a/server/gcp/compute/zones.go
+++ b/server/gcp/compute/zones.go
@@ -1,0 +1,100 @@
+package compute
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+)
+
+// zoneResponse mirrors the subset of compute#zone clients read. Terraform's
+// google_compute_instance calls zones.get to resolve (and validate) the zone
+// before creating an instance, so the emulator must answer it with a live
+// (status UP) zone rather than 501.
+type zoneResponse struct {
+	Kind                  string   `json:"kind"`
+	ID                    string   `json:"id"`
+	Name                  string   `json:"name"`
+	Description           string   `json:"description,omitempty"`
+	Status                string   `json:"status"`
+	Region                string   `json:"region"`
+	SelfLink              string   `json:"selfLink"`
+	AvailableCPUPlatforms []string `json:"availableCpuPlatforms,omitempty"`
+	SupportsPzs           bool     `json:"supportsPzs"`
+}
+
+// regionResponse mirrors the subset of compute#region clients read.
+type regionResponse struct {
+	Kind        string   `json:"kind"`
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Status      string   `json:"status"`
+	SelfLink    string   `json:"selfLink"`
+	Zones       []string `json:"zones,omitempty"`
+	SupportsPzs bool     `json:"supportsPzs"`
+}
+
+// statusUp is GCP's compute#zone / compute#region "operational" status.
+const statusUp = "UP"
+
+// regionZoneSuffixes are the zone letters GCP publishes for a typical region;
+// used to synthesize a region's zones[] list.
+var regionZoneSuffixes = []string{"a", "b", "c"} //nolint:gochecknoglobals // static lookup table
+
+// serveScopeResource answers zones.get / regions.get for a bare zone/region
+// path. CloudEmu is project-and-zone agnostic, so any well-formed zone or
+// region name is reported UP (matching an emulator's "any region works"
+// posture); only GET is supported.
+//
+//nolint:gocritic // rp is a request-scoped value
+func serveScopeResource(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if r.Method != http.MethodGet {
+		writeNotImplemented(w, r.Method+" "+r.URL.Path)
+		return
+	}
+
+	host := hostFromRequest(r)
+
+	if rp.Scope == gcprest.ScopeRegions {
+		gcprest.WriteJSON(w, http.StatusOK, toRegionResponse(rp, host))
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toZoneResponse(rp, host))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func toZoneResponse(rp gcprest.ResourcePath, host string) zoneResponse {
+	region := regionFromZone(rp.ScopeName)
+
+	return zoneResponse{
+		Kind:                  "compute#zone",
+		ID:                    numericID("zone/" + rp.ScopeName),
+		Name:                  rp.ScopeName,
+		Description:           rp.ScopeName,
+		Status:                statusUp,
+		Region:                host + "/compute/v1/projects/" + rp.Project + "/regions/" + region,
+		SelfLink:              host + "/compute/v1/projects/" + rp.Project + "/zones/" + rp.ScopeName,
+		AvailableCPUPlatforms: []string{defaultCPUPlatform},
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func toRegionResponse(rp gcprest.ResourcePath, host string) regionResponse {
+	base := host + "/compute/v1/projects/" + rp.Project
+
+	zones := make([]string, 0, len(regionZoneSuffixes))
+	for _, s := range regionZoneSuffixes {
+		zones = append(zones, base+"/zones/"+rp.ScopeName+"-"+s)
+	}
+
+	return regionResponse{
+		Kind:        "compute#region",
+		ID:          numericID("region/" + rp.ScopeName),
+		Name:        rp.ScopeName,
+		Description: rp.ScopeName,
+		Status:      statusUp,
+		SelfLink:    base + "/regions/" + rp.ScopeName,
+		Zones:       zones,
+	}
+}

--- a/server/gcp/compute/zones_test.go
+++ b/server/gcp/compute/zones_test.go
@@ -1,0 +1,170 @@
+package compute_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestZonesGet covers zones.get: Terraform's google_compute_instance resolves
+// the zone via GET .../zones/{zone} before creating an instance, so the endpoint
+// must return a live (status UP) compute#zone rather than 501.
+func TestZonesGet(t *testing.T) {
+	ts := newGCPTestServer(t)
+
+	resp, err := ts.Client().Get(ts.URL + "/compute/v1/projects/" + testProject + "/zones/" + testZone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("zones.get status=%d body=%s", resp.StatusCode, dump)
+	}
+
+	var got map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+
+	if got["kind"] != "compute#zone" {
+		t.Errorf("kind=%v want compute#zone", got["kind"])
+	}
+
+	if got["name"] != testZone {
+		t.Errorf("name=%v want %s", got["name"], testZone)
+	}
+
+	if got["status"] != "UP" {
+		t.Errorf("status=%v want UP", got["status"])
+	}
+
+	region, _ := got["region"].(string)
+	if !strings.HasSuffix(region, "/regions/us-central1") {
+		t.Errorf("region=%s want .../regions/us-central1", region)
+	}
+
+	self, _ := got["selfLink"].(string)
+	if !strings.HasSuffix(self, "/zones/"+testZone) {
+		t.Errorf("selfLink=%s", self)
+	}
+}
+
+// TestRegionsGet covers regions.get returning a live compute#region with a
+// zones[] list.
+func TestRegionsGet(t *testing.T) {
+	ts := newGCPTestServer(t)
+
+	resp, err := ts.Client().Get(ts.URL + "/compute/v1/projects/" + testProject + "/regions/us-central1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("regions.get status=%d body=%s", resp.StatusCode, dump)
+	}
+
+	var got struct {
+		Kind   string   `json:"kind"`
+		Name   string   `json:"name"`
+		Status string   `json:"status"`
+		Zones  []string `json:"zones"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Kind != "compute#region" || got.Name != "us-central1" || got.Status != "UP" {
+		t.Errorf("region=%+v", got)
+	}
+
+	if len(got.Zones) == 0 {
+		t.Errorf("region zones empty, want the region's zones listed")
+	}
+}
+
+// TestDiskInsertUnquotedSizeGb reproduces the Terraform google provider's disk
+// create: it marshals its request body from a map[string]interface{}, so sizeGb
+// arrives as a BARE JSON number (20), not the quoted "20" the typed SDK sends. A
+// strict `,string` decode rejected it with 400; the endpoint must accept either.
+func TestDiskInsertUnquotedSizeGb(t *testing.T) {
+	ts := newGCPTestServer(t)
+
+	body := strings.NewReader(`{
+		"name": "tf-disk",
+		"sizeGb": 20,
+		"type": "projects/p-1/zones/us-central1-a/diskTypes/pd-balanced"
+	}`)
+
+	resp, err := ts.Client().Post(ts.URL+zonesPath("/disks"), "application/json", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("disk insert (unquoted sizeGb) status=%d body=%s", resp.StatusCode, dump)
+	}
+
+	// Confirm the size round-tripped (not silently dropped to 0).
+	get, err := ts.Client().Get(ts.URL + zonesPath("/disks/tf-disk"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer get.Body.Close()
+
+	var disk map[string]any
+	if err := json.NewDecoder(get.Body).Decode(&disk); err != nil {
+		t.Fatal(err)
+	}
+
+	if disk["sizeGb"] != "20" {
+		t.Errorf("sizeGb=%v want \"20\"", disk["sizeGb"])
+	}
+}
+
+// TestDefaultServiceAccountRealistic verifies that an instance created without a
+// serviceAccounts block reads back the default compute SA with a realistic
+// project-scoped email (never the literal "default") and the default-access
+// scope set — matching real GCP.
+func TestDefaultServiceAccountRealistic(t *testing.T) {
+	ts := newGCPTestServer(t)
+	_ = insertInstance(t, ts, "vm-defsa")
+
+	resp, err := ts.Client().Get(ts.URL + zonesPath("/instances/vm-defsa"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var got struct {
+		ServiceAccounts []struct {
+			Email  string   `json:"email"`
+			Scopes []string `json:"scopes"`
+		} `json:"serviceAccounts"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got.ServiceAccounts) != 1 {
+		t.Fatalf("serviceAccounts=%+v want 1", got.ServiceAccounts)
+	}
+
+	wantEmail := testProject + "-compute@developer.gserviceaccount.com"
+	if got.ServiceAccounts[0].Email != wantEmail {
+		t.Errorf("default SA email=%q want %q", got.ServiceAccounts[0].Email, wantEmail)
+	}
+
+	if len(got.ServiceAccounts[0].Scopes) != 6 {
+		t.Errorf("default SA scopes=%v want the 6 default-access scopes", got.ServiceAccounts[0].Scopes)
+	}
+}

--- a/server/gcp/vpc/handler.go
+++ b/server/gcp/vpc/handler.go
@@ -56,6 +56,7 @@ const (
 	netDescTag          = "cloudemu:gcpNetDesc"
 	netRoutingModeTag   = "cloudemu:gcpNetRoutingMode"
 	netMtuTag           = "cloudemu:gcpNetMtu"
+	netFwOrderTag       = "cloudemu:gcpNetFwOrder"
 	subnetPurposeTag    = "cloudemu:gcpSubnetPurpose"
 	subnetStackTag      = "cloudemu:gcpSubnetStack"
 	subnetPGATag        = "cloudemu:gcpSubnetPGA"
@@ -355,6 +356,10 @@ func networkStorage(req *networkRequest) (cidr string, tags map[string]string) {
 
 	if req.Mtu > 0 {
 		tags[netMtuTag] = strconv.Itoa(int(req.Mtu))
+	}
+
+	if req.NetworkFirewallPolicyEnforcementOrder != "" {
+		tags[netFwOrderTag] = req.NetworkFirewallPolicyEnforcementOrder
 	}
 
 	return cidr, tags
@@ -1330,13 +1335,14 @@ func toNetworkResponse(info *netdriver.VPCInfo, rp gcprest.ResourcePath, host st
 	name := tagOr(info.Tags, netNameTag, info.ID)
 
 	resp := networkResponse{
-		Kind:                  "compute#network",
-		ID:                    numericID(info.ID),
-		Name:                  name,
-		Description:           info.Tags[netDescTag],
-		AutoCreateSubnetworks: info.Tags[autoSubnetTag] == trueValue,
-		CreationTimestamp:     info.Tags[createdAtTag],
-		SelfLink:              gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "networks", name),
+		Kind:                                  "compute#network",
+		ID:                                    numericID(info.ID),
+		Name:                                  name,
+		Description:                           info.Tags[netDescTag],
+		AutoCreateSubnetworks:                 info.Tags[autoSubnetTag] == trueValue,
+		CreationTimestamp:                     info.Tags[createdAtTag],
+		SelfLink:                              gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "networks", name),
+		NetworkFirewallPolicyEnforcementOrder: fwPolicyOrderOr(info.Tags[netFwOrderTag]),
 	}
 
 	if rm := info.Tags[netRoutingModeTag]; rm != "" {
@@ -1357,6 +1363,16 @@ func toNetworkResponse(info *netdriver.VPCInfo, rp gcprest.ResourcePath, host st
 	}
 
 	return resp
+}
+
+// fwPolicyOrderOr returns the stored networkFirewallPolicyEnforcementOrder,
+// defaulting to GCP's AFTER_CLASSIC_FIREWALL when the network did not record one.
+func fwPolicyOrderOr(stored string) string {
+	if stored != "" {
+		return stored
+	}
+
+	return defaultFwPolicyOrder
 }
 
 // lastSegment returns the final path/URL segment (e.g. a network self-link or

--- a/server/gcp/vpc/networks_test.go
+++ b/server/gcp/vpc/networks_test.go
@@ -286,3 +286,46 @@ func TestSDKFirewallRoundTrip(t *testing.T) {
 		t.Errorf("Delete wait: %v", err)
 	}
 }
+
+// TestSDKNetworkFirewallPolicyEnforcementOrderDefault covers the perpetual-diff
+// finding that networks.get omitted networkFirewallPolicyEnforcementOrder.
+// Terraform's google_compute_network defaults the attribute to
+// AFTER_CLASSIC_FIREWALL, so a network read that omits it drives an endless plan
+// diff wanting to set it. The endpoint must return the default on read.
+func TestSDKNetworkFirewallPolicyEnforcementOrderDefault(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewNetworksRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewNetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	insertOp, err := client.Insert(ctx, &computepb.InsertNetworkRequest{
+		Project: testProject,
+		NetworkResource: &computepb.Network{
+			Name:                  ptrStr("fw-order-net"),
+			AutoCreateSubnetworks: func() *bool { b := false; return &b }(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetNetworkRequest{Project: testProject, Network: "fw-order-net"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetNetworkFirewallPolicyEnforcementOrder() != "AFTER_CLASSIC_FIREWALL" {
+		t.Errorf("networkFirewallPolicyEnforcementOrder=%q want AFTER_CLASSIC_FIREWALL",
+			got.GetNetworkFirewallPolicyEnforcementOrder())
+	}
+}

--- a/server/gcp/vpc/types.go
+++ b/server/gcp/vpc/types.go
@@ -10,26 +10,34 @@ type networkRoutingConfig struct {
 	RoutingMode string `json:"routingMode,omitempty"`
 }
 
+// defaultFwPolicyOrder is GCP's default networkFirewallPolicyEnforcementOrder
+// for a new network. networks.get always returns this field, so the emulator
+// must too — else Terraform's google_compute_network (which defaults the
+// attribute to this value) shows a perpetual diff wanting to set it.
+const defaultFwPolicyOrder = "AFTER_CLASSIC_FIREWALL"
+
 type networkRequest struct {
-	Name                  string                `json:"name"`
-	Description           string                `json:"description,omitempty"`
-	IPv4Range             string                `json:"IPv4Range,omitempty"`
-	AutoCreateSubnetworks *bool                 `json:"autoCreateSubnetworks,omitempty"`
-	RoutingConfig         *networkRoutingConfig `json:"routingConfig,omitempty"`
-	Mtu                   int32                 `json:"mtu,omitempty"`
+	Name                                  string                `json:"name"`
+	Description                           string                `json:"description,omitempty"`
+	IPv4Range                             string                `json:"IPv4Range,omitempty"`
+	AutoCreateSubnetworks                 *bool                 `json:"autoCreateSubnetworks,omitempty"`
+	RoutingConfig                         *networkRoutingConfig `json:"routingConfig,omitempty"`
+	Mtu                                   int32                 `json:"mtu,omitempty"`
+	NetworkFirewallPolicyEnforcementOrder string                `json:"networkFirewallPolicyEnforcementOrder,omitempty"`
 }
 
 type networkResponse struct {
-	Kind                  string                `json:"kind"`
-	ID                    string                `json:"id"`
-	Name                  string                `json:"name"`
-	Description           string                `json:"description,omitempty"`
-	SelfLink              string                `json:"selfLink"`
-	IPv4Range             string                `json:"IPv4Range,omitempty"`
-	AutoCreateSubnetworks bool                  `json:"autoCreateSubnetworks"`
-	RoutingConfig         *networkRoutingConfig `json:"routingConfig,omitempty"`
-	Mtu                   int32                 `json:"mtu,omitempty"`
-	CreationTimestamp     string                `json:"creationTimestamp,omitempty"`
+	Kind                                  string                `json:"kind"`
+	ID                                    string                `json:"id"`
+	Name                                  string                `json:"name"`
+	Description                           string                `json:"description,omitempty"`
+	SelfLink                              string                `json:"selfLink"`
+	IPv4Range                             string                `json:"IPv4Range,omitempty"`
+	AutoCreateSubnetworks                 bool                  `json:"autoCreateSubnetworks"`
+	RoutingConfig                         *networkRoutingConfig `json:"routingConfig,omitempty"`
+	Mtu                                   int32                 `json:"mtu,omitempty"`
+	NetworkFirewallPolicyEnforcementOrder string                `json:"networkFirewallPolicyEnforcementOrder,omitempty"`
+	CreationTimestamp                     string                `json:"creationTimestamp,omitempty"`
 }
 
 type networkListResponse struct {


### PR DESCRIPTION
## Summary

Deep real-user e2e audit of the GCE (compute.googleapis.com) control plane, driven live against `cloudemu serve` with the real `google.golang.org/api/compute/v1` SDK **and** Terraform (`hashicorp/google` v6.50.0). Fixes the genuine cloud-vs-cloudemu divergences a real SDK/CLI/Terraform user hits when standing up the `google_compute_instance` + network/subnetwork/disk/firewall stack.

Before this change, `terraform apply` of a `google_compute_instance` **hard-failed** (zone resolution 501) and `google_compute_disk` **failed** (400 on the disk body). After it, the full `network -> subnetwork -> disk -> firewall -> instance (RUNNING) -> update -> destroy` cycle applies cleanly and is idempotent.

## Divergences fixed

| # | Sev | Divergence | Fix |
|---|-----|-----------|-----|
| 1 | Blocker | `zones.get` / `regions.get` returned 501; Terraform resolves the zone before instance create, so instance apply failed with `Error loading zone` | New `server/gcp/compute/zones.go` serving zones.get/regions.get as a live (status `UP`) resource, wired via `Handler.Matches`/`ServeHTTP` |
| 2 | Blocker | `google_compute_disk` create returned 400 `invalid use of ,string struct tag` — Terraform marshals `sizeGb` as a bare number, our strict `,string` int rejected it (same on disk resize + image create) | `flexInt` decoder that accepts a quoted string or a bare number; removed dead `SizeGbInt`/`pickSize` |
| 3 | Medium | `networks.get` omitted `networkFirewallPolicyEnforcementOrder`, so `google_compute_network` showed a perpetual plan diff | Return it (default `AFTER_CLASSIC_FIREWALL`, round-tripped when set) |
| 4 | Medium | Default compute service account read back as `email: "default"` + `[cloud-platform]` — real GCP never returns the literal `default` and grants the 6 default-access scopes | Realistic `<project>-compute@developer.gserviceaccount.com` email + the default-access scope set |
| 5 | Low | Disk created without a type read back `pd-ssd`; real GCP defaults to `pd-standard` | Default to `pd-standard` in the GCE driver `CreateVolume` |

## Verification

- Live SDK harness: full instance lifecycle (insert -> Operation DONE + RUNNING, get/list/aggregatedList, setLabels/setMetadata with fingerprint incl. stale -> 412, stop/start, setMachineType-when-stopped, delete + idempotency, canonical 404).
- Terraform: `apply` of the whole chain succeeds (instance reaches RUNNING via the insert-Operation waiter); `plan` is clean/idempotent; in-place metadata/label update; `destroy` clean.
- Gates: `go build ./...`, `go test -race` on `server/gcp/...` + `providers/gcp/compute/...`, `go vet`, `gofmt`, `golangci-lint` (full-package + `--new-from-rev`, 0 new issues), `go generate ./...` (no docs/coverage change — driver interfaces unchanged).

## Not fixed (faithful behavior / out of scope)

- `service_account` block showing a diff when omitted from the Terraform config is the standard provider gotcha (real GCP attaches a default SA too); the values are now realistic. With an explicit `service_account` block the plan is fully clean.
- Real VM boot, InstanceGroupManager/MIG, autoscalers: known larger surfaces, left untouched.
