### PR TITLE
fix(lambda): real-user e2e divergences from AWS

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -4109,6 +4109,19 @@ func TestFunctionVersions(t *testing.T) {
 				t.Errorf("expected version 1, got %s", v1.Version)
 			}
 
+			// Change the function so the next publish is a genuinely new
+			// version (real AWS Lambda doesn't publish a version when code and
+			// configuration are unchanged since the last one).
+			if _, err := p.d.UpdateFunction(ctx, "version-func", serverlessdriver.FunctionConfig{
+				Name:    "version-func",
+				Runtime: "go1.x",
+				Handler: "main",
+				Memory:  256,
+				Timeout: 60,
+			}); err != nil {
+				t.Fatalf("UpdateFunction: %v", err)
+			}
+
 			// Publish another
 			v2, err := p.d.PublishVersion(ctx, "version-func", "second version")
 			if err != nil {

--- a/providers/aws/lambda/lambda_test.go
+++ b/providers/aws/lambda/lambda_test.go
@@ -3,6 +3,7 @@ package lambda
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -28,6 +29,15 @@ func defaultFuncConfig() driver.FunctionConfig {
 		Timeout: 30,
 		Tags:    map[string]string{"env": "test"},
 	}
+}
+
+// bumpAndPublish changes the function's code so the following PublishVersion cuts
+// a fresh version. Real Lambda doesn't publish a new version when nothing has
+// changed since the last one, so a test that needs a second distinct version must
+// mutate the function between publishes.
+func bumpAndPublish(ctx context.Context, m *Mock, name, desc string) {
+	_, _ = m.UpdateFunction(ctx, name, driver.FunctionConfig{Code: []byte(desc + "-code")})
+	_, _ = m.PublishVersion(ctx, name, desc)
 }
 
 func TestCreateFunction(t *testing.T) {
@@ -241,7 +251,16 @@ func TestPublishVersion(t *testing.T) {
 		assertNotEmpty(t, ver.CreatedAt)
 	})
 
-	t.Run("publish second version", func(t *testing.T) {
+	t.Run("republish without change returns existing version", func(t *testing.T) {
+		// AWS doesn't cut a new version when nothing changed since the last one.
+		ver, err := m.PublishVersion(ctx, "my-func", "second release")
+		requireNoError(t, err)
+		assertEqual(t, "1", ver.Version)
+	})
+
+	t.Run("publish second version after a change", func(t *testing.T) {
+		_, err := m.UpdateFunction(ctx, "my-func", driver.FunctionConfig{Code: []byte("v2-code")})
+		requireNoError(t, err)
 		ver, err := m.PublishVersion(ctx, "my-func", "second release")
 		requireNoError(t, err)
 		assertEqual(t, "2", ver.Version)
@@ -365,7 +384,7 @@ func TestUpdateAlias(t *testing.T) {
 	ctx := context.Background()
 	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
 	_, _ = m.PublishVersion(ctx, "my-func", "v1")
-	_, _ = m.PublishVersion(ctx, "my-func", "v2")
+	bumpAndPublish(ctx, m, "my-func", "v2")
 	_, _ = m.CreateAlias(ctx, driver.AliasConfig{
 		FunctionName: "my-func", Name: "prod", FunctionVersion: "1",
 	})
@@ -456,7 +475,7 @@ func TestAliasWeightedRouting(t *testing.T) {
 	ctx := context.Background()
 	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
 	_, _ = m.PublishVersion(ctx, "my-func", "v1")
-	_, _ = m.PublishVersion(ctx, "my-func", "v2")
+	bumpAndPublish(ctx, m, "my-func", "v2")
 
 	alias, err := m.CreateAlias(ctx, driver.AliasConfig{
 		FunctionName:    "my-func",
@@ -526,7 +545,7 @@ func TestAliasWeightedRoutingRejectsOutOfBoundsWeights(t *testing.T) {
 	ctx := context.Background()
 	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
 	_, _ = m.PublishVersion(ctx, "my-func", "v1")
-	_, _ = m.PublishVersion(ctx, "my-func", "v2")
+	bumpAndPublish(ctx, m, "my-func", "v2")
 
 	// A weight above 1.0 is rejected.
 	_, err := m.CreateAlias(ctx, driver.AliasConfig{
@@ -576,7 +595,7 @@ func TestAliasWeightedRoutingSplitsInvocations(t *testing.T) {
 	ctx := context.Background()
 	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
 	_, _ = m.PublishVersion(ctx, "my-func", "v1") // version "1"
-	_, _ = m.PublishVersion(ctx, "my-func", "v2") // version "2"
+	bumpAndPublish(ctx, m, "my-func", "v2")       // version "2"
 
 	_, err := m.CreateAlias(ctx, driver.AliasConfig{
 		FunctionName:    "my-func",
@@ -620,7 +639,7 @@ func TestAliasWeightedRoutingIsDeterministicPerPayload(t *testing.T) {
 	ctx := context.Background()
 	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
 	_, _ = m.PublishVersion(ctx, "my-func", "v1")
-	_, _ = m.PublishVersion(ctx, "my-func", "v2")
+	bumpAndPublish(ctx, m, "my-func", "v2")
 
 	_, err := m.CreateAlias(ctx, driver.AliasConfig{
 		FunctionName:    "my-func",
@@ -996,20 +1015,24 @@ func TestPublishVersionConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 
+	// Each goroutine changes the code before publishing so it has a chance to cut a
+	// distinct version (AWS dedups an unchanged publish). Interleaving makes the
+	// exact count nondeterministic; the invariant under -race is that no two
+	// published versions ever share a version number.
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 
-		go func() {
+		go func(n int) {
 			defer wg.Done()
+			_, _ = m.UpdateFunction(ctx, "my-func", driver.FunctionConfig{Code: []byte(strconv.Itoa(n) + "-code")})
 			_, _ = m.PublishVersion(ctx, "my-func", "concurrent")
-		}()
+		}(i)
 	}
 
 	wg.Wait()
 
 	versions, err := m.ListVersions(ctx, "my-func")
 	requireNoError(t, err)
-	assertEqual(t, 11, len(versions)) // $LATEST + 10 published
 
 	seen := make(map[string]bool)
 	for _, v := range versions {
@@ -1023,7 +1046,7 @@ func TestAliasRoutingConfigDeepCopy(t *testing.T) {
 	ctx := context.Background()
 	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
 	_, _ = m.PublishVersion(ctx, "my-func", "v1")
-	_, _ = m.PublishVersion(ctx, "my-func", "v2")
+	bumpAndPublish(ctx, m, "my-func", "v2")
 
 	rc := &driver.AliasRoutingConfig{
 		AdditionalVersionWeights: map[string]float64{"2": 0.5},
@@ -1055,7 +1078,7 @@ func TestConcurrentAliasRaceFree(t *testing.T) {
 	ctx := context.Background()
 	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
 	_, _ = m.PublishVersion(ctx, "my-func", "v1")
-	_, _ = m.PublishVersion(ctx, "my-func", "v2")
+	bumpAndPublish(ctx, m, "my-func", "v2")
 
 	_, err := m.CreateAlias(ctx, driver.AliasConfig{
 		FunctionName:    "my-func",

--- a/providers/aws/lambda/provisioned_concurrency_test.go
+++ b/providers/aws/lambda/provisioned_concurrency_test.go
@@ -2,6 +2,7 @@ package lambda
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -199,6 +200,10 @@ func TestProvisionedConcurrencyRejectsWeightedAlias(t *testing.T) {
 	ctx := context.Background()
 	ver := createPublishedFunc(t, m)
 
+	if _, err := m.UpdateFunction(ctx, "my-func", driver.FunctionConfig{Code: []byte("v2-code")}); err != nil {
+		t.Fatalf("UpdateFunction: %v", err)
+	}
+
 	ver2, err := m.PublishVersion(ctx, "my-func", "")
 	if err != nil {
 		t.Fatalf("PublishVersion: %v", err)
@@ -323,6 +328,12 @@ func TestProvisionedConcurrencyCOWIndependence(t *testing.T) {
 	vers := make([]*driver.FunctionVersion, 0, 3)
 
 	for i := 0; i < 3; i++ {
+		// Change the code before each publish so Lambda cuts a distinct version
+		// rather than deduping an unchanged one.
+		if _, err := m.UpdateFunction(ctx, "my-func", driver.FunctionConfig{Code: []byte(strconv.Itoa(i) + "-code")}); err != nil {
+			t.Fatalf("UpdateFunction: %v", err)
+		}
+
 		ver, err := m.PublishVersion(ctx, "my-func", "")
 		if err != nil {
 			t.Fatalf("PublishVersion: %v", err)

--- a/providers/aws/lambda/versions.go
+++ b/providers/aws/lambda/versions.go
@@ -22,6 +22,15 @@ func (m *Mock) PublishVersion(_ context.Context, functionName, description strin
 		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
 	}
 
+	// AWS Lambda doesn't publish a new version if the function's configuration and
+	// code haven't changed since the last version — it returns that existing
+	// version instead. Every configuration/code update mints a fresh $LATEST
+	// RevisionID, so a last-published version cut from the current $LATEST revision
+	// means nothing changed and no new version is created.
+	if n := len(fd.versions); n > 0 && fd.versions[n-1].revisionID == fd.info.RevisionID {
+		return versionResult(functionName, fd.versions[n-1], description), nil
+	}
+
 	verNum := fd.nextVersion
 	fd.nextVersion++
 
@@ -40,19 +49,27 @@ func (m *Mock) PublishVersion(_ context.Context, functionName, description strin
 	fd.versions = append(fd.versions, vd)
 	m.funcs.Set(functionName, fd)
 
+	return versionResult(functionName, vd, description), nil
+}
+
+// versionResult renders a published version's driver.FunctionVersion, used both
+// when a fresh version is cut and when a no-change PublishVersion returns the
+// existing version. description overrides the stored version description, matching
+// PublishVersion's Description parameter.
+func versionResult(functionName string, v *versionData, description string) *driver.FunctionVersion {
 	return &driver.FunctionVersion{
 		FunctionName: functionName,
-		Version:      verStr,
+		Version:      v.version,
 		Description:  description,
-		CodeSHA256:   sha,
-		RevisionID:   rev,
-		CreatedAt:    now,
-		Runtime:      fd.info.Runtime,
-		Handler:      fd.info.Handler,
-		Memory:       fd.info.Memory,
-		Timeout:      fd.info.Timeout,
-		Role:         fd.info.Role,
-	}, nil
+		CodeSHA256:   v.codeSHA,
+		RevisionID:   v.revisionID,
+		CreatedAt:    v.createdAt,
+		Runtime:      v.config.Runtime,
+		Handler:      v.config.Handler,
+		Memory:       v.config.Memory,
+		Timeout:      v.config.Timeout,
+		Role:         v.config.Role,
+	}
 }
 
 // ListVersions returns all published versions for a function.

--- a/server/aws/lambda/pagination_sdk_test.go
+++ b/server/aws/lambda/pagination_sdk_test.go
@@ -16,14 +16,7 @@ func TestSDKListVersionsByFunctionPagination(t *testing.T) {
 	client, _ := newSDKClient(t)
 	ctx := context.Background()
 	createBasicFunction(t, client, "vfn")
-
-	for range 2 {
-		if _, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
-			FunctionName: aws.String("vfn"),
-		}); err != nil {
-			t.Fatalf("PublishVersion: %v", err)
-		}
-	}
+	publishDistinctVersions(t, client, "vfn", 2)
 
 	page1, err := client.ListVersionsByFunction(ctx, &awslambda.ListVersionsByFunctionInput{
 		FunctionName: aws.String("vfn"), MaxItems: aws.Int32(2),

--- a/server/aws/lambda/sdk_roundtrip_test.go
+++ b/server/aws/lambda/sdk_roundtrip_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -33,6 +34,31 @@ func createBasicFunction(t *testing.T, client *awslambda.Client, name string) {
 		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("package-" + name)},
 	}); err != nil {
 		t.Fatalf("CreateFunction(%s): %v", name, err)
+	}
+}
+
+// publishDistinctVersions publishes n new versions of a function, changing its
+// code before each publish. Real Lambda does not cut a new version when nothing
+// has changed since the last one, so a test needing several distinct versions
+// must mutate the function between publishes.
+func publishDistinctVersions(t *testing.T, client *awslambda.Client, name string, n int) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	for i := range n {
+		if _, err := client.UpdateFunctionCode(ctx, &awslambda.UpdateFunctionCodeInput{
+			FunctionName: aws.String(name),
+			ZipFile:      []byte("package-" + name + "-" + strconv.Itoa(i)),
+		}); err != nil {
+			t.Fatalf("UpdateFunctionCode(%s): %v", name, err)
+		}
+
+		if _, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
+			FunctionName: aws.String(name),
+		}); err != nil {
+			t.Fatalf("PublishVersion(%s): %v", name, err)
+		}
 	}
 }
 
@@ -632,14 +658,7 @@ func TestSDKCreateAliasRoutingConfigValidation(t *testing.T) {
 	client, _ := newSDKClient(t)
 	ctx := context.Background()
 	createBasicFunction(t, client, "routed")
-
-	for range 2 {
-		if _, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
-			FunctionName: aws.String("routed"),
-		}); err != nil {
-			t.Fatalf("PublishVersion: %v", err)
-		}
-	}
+	publishDistinctVersions(t, client, "routed", 2)
 
 	// $LATEST in the weights is rejected with InvalidParameterValueException.
 	_, err := client.CreateAlias(ctx, &awslambda.CreateAliasInput{
@@ -770,20 +789,65 @@ func TestSDKVersionPerVersionAttributes(t *testing.T) {
 	}
 }
 
+// TestSDKPublishVersionDedupsUnchanged covers the AWS rule that PublishVersion
+// does not cut a new version when the function's code and configuration haven't
+// changed since the last version: it returns that existing version instead. Only
+// after a code/config change does a subsequent publish produce a new number.
+func TestSDKPublishVersionDedupsUnchanged(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "dedup")
+
+	first, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{FunctionName: aws.String("dedup")})
+	if err != nil {
+		t.Fatalf("PublishVersion(first): %v", err)
+	}
+	if aws.ToString(first.Version) != "1" {
+		t.Fatalf("first version = %q, want 1", aws.ToString(first.Version))
+	}
+
+	// Republishing an unchanged function returns the same version, not "2".
+	again, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{FunctionName: aws.String("dedup")})
+	if err != nil {
+		t.Fatalf("PublishVersion(again): %v", err)
+	}
+	if aws.ToString(again.Version) != "1" {
+		t.Fatalf("republish version = %q, want 1 (deduped)", aws.ToString(again.Version))
+	}
+
+	// A code change lets the next publish cut a distinct version.
+	if _, err := client.UpdateFunctionCode(ctx, &awslambda.UpdateFunctionCodeInput{
+		FunctionName: aws.String("dedup"), ZipFile: []byte("changed-code"),
+	}); err != nil {
+		t.Fatalf("UpdateFunctionCode: %v", err)
+	}
+
+	next, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{FunctionName: aws.String("dedup")})
+	if err != nil {
+		t.Fatalf("PublishVersion(next): %v", err)
+	}
+	if aws.ToString(next.Version) != "2" {
+		t.Fatalf("post-change version = %q, want 2", aws.ToString(next.Version))
+	}
+
+	list, err := client.ListVersionsByFunction(ctx, &awslambda.ListVersionsByFunctionInput{
+		FunctionName: aws.String("dedup"),
+	})
+	if err != nil {
+		t.Fatalf("ListVersionsByFunction: %v", err)
+	}
+	if len(list.Versions) != 3 { // $LATEST + versions 1 and 2
+		t.Fatalf("Versions = %d, want 3 ($LATEST + 1 + 2)", len(list.Versions))
+	}
+}
+
 // TestSDKAliasRevisionAndRouting covers CreateAlias/GetAlias/UpdateAlias missing
 // RevisionId and RoutingConfig.
 func TestSDKAliasRevisionAndRouting(t *testing.T) {
 	client, _ := newSDKClient(t)
 	ctx := context.Background()
 	createBasicFunction(t, client, "aliased")
-
-	for range 2 {
-		if _, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
-			FunctionName: aws.String("aliased"),
-		}); err != nil {
-			t.Fatalf("PublishVersion: %v", err)
-		}
-	}
+	publishDistinctVersions(t, client, "aliased", 2)
 
 	created, err := client.CreateAlias(ctx, &awslambda.CreateAliasInput{
 		FunctionName:    aws.String("aliased"),


### PR DESCRIPTION
## Summary

Real-user e2e audit of AWS Lambda found one genuine cloud-vs-cloudemu divergence: `PublishVersion` cut a brand-new version on every call, even when the function's code and configuration were unchanged since the last version.

Real AWS deduplicates. Per the [PublishVersion API docs](https://docs.aws.amazon.com/lambda/latest/api/API_PublishVersion.html):

> AWS Lambda doesn't publish a version if the function's configuration and code haven't changed since the last version.

A user (SDK, CLI, or a re-run CI script) calling `publish-version` repeatedly against an unchanged function got ever-incrementing version numbers (2, 3, 4, ...) instead of the same version, drifting from real cloud behavior.

## Change

`PublishVersion` now returns the existing last published version when the current `$LATEST` `RevisionId` matches the one the last version was cut from (every code/config update mints a fresh `RevisionId`, so a match means nothing changed). Only a real code/config change produces a new version number.

## Evidence

Live `cloudemu serve` + AWS CLI:
- 3 consecutive `publish-version` with no change -> all return `"1"` (was: 1, 2, 3)
- `update-function-code` then publish -> `"2"`
- publish again with no change -> stays `"2"`
- `list-versions-by-function` -> `$LATEST`, `1`, `2` (no spurious versions)

Terraform (`aws_lambda_function` publish=true + `aws_lambda_alias`): apply creates cleanly (state reaches Active), second `plan` reports "No changes" (no drift; defaults round-trip).

## Tests

- Added `TestSDKPublishVersionDedupsUnchanged` (wire/SDK) asserting the dedup and post-change increment.
- Reworked provider `TestPublishVersion` to assert dedup on no-change and a new version only after a change.
- Updated tests that relied on the old behavior (publishing multiple versions with no intervening change) to mutate the function between publishes, which is how real AWS produces distinct versions.

## Gates

`go build ./...`, `go vet`, `gofmt -l` (clean), `go test -race -count=1` on `providers/aws/lambda` and `server/aws/lambda` (green), `golangci-lint run` full-package on both changed packages (0 issues), `go generate ./...` (docs/coverage unchanged).
