### PR TITLE
fix(dynamodb): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -548,6 +548,14 @@ func (m *Mock) DeleteTable(_ context.Context, name string) error {
 		return cerrors.Newf(cerrors.NotFound, "table %s not found", name)
 	}
 
+	// Real DynamoDB refuses to delete a table with deletion protection on; a
+	// client must disable it first. Without this a protected table deletes
+	// silently, diverging from AWS.
+	if td.config.DeletionProtectionEnabled {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"Table '%s' can't be deleted while DeletionProtectionEnabled is set to True", name)
+	}
+
 	m.tableSettle.Clear(name)
 
 	for _, gsi := range td.config.GSIs {
@@ -1312,6 +1320,32 @@ func (m *Mock) UpdateThroughput(_ context.Context, table, billingMode string, rc
 
 	if wcu > 0 {
 		td.config.WriteCapacityUnits = wcu
+	}
+
+	m.tableSettle.Begin(table, statusUpdating, m.opts.Clock.Now(), m.opts.SettleDuration(settleTableUpdate))
+
+	return nil
+}
+
+// UpdateTableSettings changes a table's metadata settings (table class and/or
+// deletion protection) as part of UpdateTable. An empty tableClass or nil
+// deletionProtection leaves that field untouched. AWS-specific capability,
+// discovered by the wire handler via type assertion.
+func (m *Mock) UpdateTableSettings(_ context.Context, table, tableClass string, deletionProtection *bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	if tableClass != "" {
+		td.config.TableClass = tableClass
+	}
+
+	if deletionProtection != nil {
+		td.config.DeletionProtectionEnabled = *deletionProtection
 	}
 
 	m.tableSettle.Begin(table, statusUpdating, m.opts.Clock.Now(), m.opts.SettleDuration(settleTableUpdate))

--- a/providers/aws/dynamodb/table_settings_test.go
+++ b/providers/aws/dynamodb/table_settings_test.go
@@ -1,0 +1,68 @@
+package dynamodb
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+func TestUpdateTableSettings(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateTable(ctx, driver.TableConfig{
+		Name:                      "t",
+		PartitionKey:              "pk",
+		DeletionProtectionEnabled: true,
+		TableClass:                "STANDARD_INFREQUENT_ACCESS",
+	}))
+
+	cfg, err := m.DescribeTable(ctx, "t")
+	requireNoError(t, err)
+	assertEqual(t, true, cfg.DeletionProtectionEnabled)
+	assertEqual(t, "STANDARD_INFREQUENT_ACCESS", cfg.TableClass)
+
+	// A change to one setting leaves the other untouched.
+	off := false
+	requireNoError(t, m.UpdateTableSettings(ctx, "t", "", &off))
+
+	cfg, err = m.DescribeTable(ctx, "t")
+	requireNoError(t, err)
+	assertEqual(t, false, cfg.DeletionProtectionEnabled)
+	assertEqual(t, "STANDARD_INFREQUENT_ACCESS", cfg.TableClass)
+
+	requireNoError(t, m.UpdateTableSettings(ctx, "t", "STANDARD", nil))
+	cfg, err = m.DescribeTable(ctx, "t")
+	requireNoError(t, err)
+	assertEqual(t, "STANDARD", cfg.TableClass)
+	assertEqual(t, false, cfg.DeletionProtectionEnabled)
+}
+
+func TestUpdateTableSettingsMissingTable(t *testing.T) {
+	m := newTestMock()
+	err := m.UpdateTableSettings(context.Background(), "nope", "STANDARD", nil)
+	if !cerrors.IsNotFound(err) {
+		t.Fatalf("expected NotFound, got %v", err)
+	}
+}
+
+func TestDeleteTableDeletionProtection(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	requireNoError(t, m.CreateTable(ctx, driver.TableConfig{
+		Name:                      "t",
+		PartitionKey:              "pk",
+		DeletionProtectionEnabled: true,
+	}))
+
+	if err := m.DeleteTable(ctx, "t"); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("expected InvalidArgument on protected delete, got %v", err)
+	}
+
+	on := false
+	requireNoError(t, m.UpdateTableSettings(ctx, "t", "", &on))
+	requireNoError(t, m.DeleteTable(ctx, "t"))
+}

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -33,6 +33,7 @@ const (
 	statusDisabled       = "DISABLED"
 	billingProvisioned   = "PROVISIONED"
 	billingPayPerRequest = "PAY_PER_REQUEST"
+	tableClassStandard   = "STANDARD"
 )
 
 // minProvisionedCapacity is the lowest ReadCapacityUnits/WriteCapacityUnits AWS
@@ -322,7 +323,9 @@ type createTableRequest struct {
 		StreamEnabled  bool   `json:"StreamEnabled"`
 		StreamViewType string `json:"StreamViewType"`
 	} `json:"StreamSpecification"`
-	Tags []tagJSON `json:"Tags"`
+	DeletionProtectionEnabled bool      `json:"DeletionProtectionEnabled"`
+	TableClass                string    `json:"TableClass"`
+	Tags                      []tagJSON `json:"Tags"`
 }
 
 func (h *Handler) createTable(w http.ResponseWriter, r *http.Request) {
@@ -378,10 +381,12 @@ func (h *Handler) createTable(w http.ResponseWriter, r *http.Request) {
 // TableConfig (keys, attributes, secondary indexes and the stream spec).
 func buildCreateConfig(req *createTableRequest) dbdriver.TableConfig {
 	cfg := dbdriver.TableConfig{
-		Name:               req.TableName,
-		BillingMode:        req.BillingMode,
-		ReadCapacityUnits:  req.ProvisionedThroughput.ReadCapacityUnits,
-		WriteCapacityUnits: req.ProvisionedThroughput.WriteCapacityUnits,
+		Name:                      req.TableName,
+		BillingMode:               req.BillingMode,
+		ReadCapacityUnits:         req.ProvisionedThroughput.ReadCapacityUnits,
+		WriteCapacityUnits:        req.ProvisionedThroughput.WriteCapacityUnits,
+		DeletionProtectionEnabled: req.DeletionProtectionEnabled,
+		TableClass:                req.TableClass,
 	}
 
 	for _, gsi := range req.GlobalSecondaryIndexes {
@@ -581,6 +586,16 @@ func (h *Handler) describeTableShape(cfg *dbdriver.TableConfig) map[string]any {
 	return td
 }
 
+// tableClass resolves the stored table class to the value DescribeTable
+// reports, defaulting an unset class to STANDARD as real DynamoDB does.
+func tableClass(stored string) string {
+	if stored == "" {
+		return tableClassStandard
+	}
+
+	return stored
+}
+
 // tableDescription builds the DynamoDB TableDescription wire shape that both
 // CreateTable and DescribeTable return, including the fields an IaC client reads
 // back (ARN, creation time, attribute definitions, billing mode). It reports
@@ -613,6 +628,11 @@ func tableDescription(cfg *dbdriver.TableConfig) map[string]any {
 		"ItemCount":            0,
 		"TableSizeBytes":       0,
 		"BillingModeSummary":   map[string]any{"BillingMode": billing},
+		// Real DescribeTable always reports these two. Omitting them makes the
+		// Terraform provider read the default and, when the config sets a
+		// non-default value, produce a perpetual diff that never converges.
+		"DeletionProtectionEnabled": cfg.DeletionProtectionEnabled,
+		"TableClassSummary":         map[string]any{"TableClass": tableClass(cfg.TableClass)},
 	}
 
 	if billing == billingProvisioned {

--- a/server/aws/dynamodb/table_settings_test.go
+++ b/server/aws/dynamodb/table_settings_test.go
@@ -1,0 +1,134 @@
+// table_settings_test.go — real aws-sdk-go-v2 journeys covering the
+// DeletionProtectionEnabled and TableClass round-trip that IaC clients read
+// back on every refresh, plus the UpdateTable mutation of both and the
+// deletion-protection guard on DeleteTable.
+package dynamodb_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func settingsTable(name string) *dynamodb.CreateTableInput {
+	return &dynamodb.CreateTableInput{
+		TableName:   aws.String(name),
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash},
+		},
+	}
+}
+
+func TestTableSettingsCreateRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	in := settingsTable("settings-rt")
+	in.DeletionProtectionEnabled = aws.Bool(true)
+	in.TableClass = ddbtypes.TableClassStandardInfrequentAccess
+
+	_, err := client.CreateTable(ctx, in)
+	require.NoError(t, err)
+
+	desc, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("settings-rt")})
+	require.NoError(t, err)
+	assert.True(t, aws.ToBool(desc.Table.DeletionProtectionEnabled))
+	require.NotNil(t, desc.Table.TableClassSummary)
+	assert.Equal(t, ddbtypes.TableClassStandardInfrequentAccess, desc.Table.TableClassSummary.TableClass)
+}
+
+func TestTableSettingsDefaults(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, settingsTable("settings-default"))
+	require.NoError(t, err)
+
+	desc, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("settings-default")})
+	require.NoError(t, err)
+	// Real DynamoDB reports these on every table, defaulted; an absent value
+	// gives IaC a perpetual diff against a config that sets the default.
+	assert.False(t, aws.ToBool(desc.Table.DeletionProtectionEnabled))
+	require.NotNil(t, desc.Table.TableClassSummary)
+	assert.Equal(t, ddbtypes.TableClassStandard, desc.Table.TableClassSummary.TableClass)
+}
+
+func TestTableSettingsUpdate(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, settingsTable("settings-upd"))
+	require.NoError(t, err)
+
+	_, err = client.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+		TableName:                 aws.String("settings-upd"),
+		TableClass:                ddbtypes.TableClassStandardInfrequentAccess,
+		DeletionProtectionEnabled: aws.Bool(true),
+	})
+	require.NoError(t, err)
+
+	desc, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("settings-upd")})
+	require.NoError(t, err)
+	assert.True(t, aws.ToBool(desc.Table.DeletionProtectionEnabled))
+	require.NotNil(t, desc.Table.TableClassSummary)
+	assert.Equal(t, ddbtypes.TableClassStandardInfrequentAccess, desc.Table.TableClassSummary.TableClass)
+
+	// An UpdateTable that touches only an unrelated field must not reset either
+	// setting.
+	_, err = client.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+		TableName:   aws.String("settings-upd"),
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+	})
+	require.NoError(t, err)
+
+	desc, err = client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("settings-upd")})
+	require.NoError(t, err)
+	assert.True(t, aws.ToBool(desc.Table.DeletionProtectionEnabled))
+	assert.Equal(t, ddbtypes.TableClassStandardInfrequentAccess, desc.Table.TableClassSummary.TableClass)
+}
+
+func TestTableSettingsDeletionProtectionGuard(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	in := settingsTable("settings-guard")
+	in.DeletionProtectionEnabled = aws.Bool(true)
+	_, err := client.CreateTable(ctx, in)
+	require.NoError(t, err)
+
+	_, err = client.DeleteTable(ctx, &dynamodb.DeleteTableInput{TableName: aws.String("settings-guard")})
+	require.Error(t, err)
+
+	var apiErr smithy.APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, "ValidationException", apiErr.ErrorCode())
+
+	// Disabling protection must unblock the delete.
+	_, err = client.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+		TableName:                 aws.String("settings-guard"),
+		DeletionProtectionEnabled: aws.Bool(false),
+	})
+	require.NoError(t, err)
+
+	_, err = client.DeleteTable(ctx, &dynamodb.DeleteTableInput{TableName: aws.String("settings-guard")})
+	require.NoError(t, err)
+}

--- a/server/aws/dynamodb/update_table.go
+++ b/server/aws/dynamodb/update_table.go
@@ -24,6 +24,14 @@ type pitrController interface {
 	GetPITR(ctx context.Context, table string) (bool, error)
 }
 
+// tableSettingsUpdater is the optional provider capability UpdateTable needs to
+// change a table's metadata settings (table class, deletion protection).
+// Discovered by type assertion so it stays off the cross-cloud Database
+// interface (only the AWS mock implements it).
+type tableSettingsUpdater interface {
+	UpdateTableSettings(ctx context.Context, table, tableClass string, deletionProtection *bool) error
+}
+
 // updateTable handles UpdateTable: billing/throughput changes, GSI create/delete
 // updates and stream enable/disable. It returns the refreshed TableDescription,
 // matching real DynamoDB. Without it the SDK sees UnknownOperationException and
@@ -42,6 +50,8 @@ func (h *Handler) updateTable(w http.ResponseWriter, r *http.Request) {
 			StreamEnabled  bool   `json:"StreamEnabled"`
 			StreamViewType string `json:"StreamViewType"`
 		} `json:"StreamSpecification"`
+		TableClass                string `json:"TableClass"`
+		DeletionProtectionEnabled *bool  `json:"DeletionProtectionEnabled"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -63,13 +73,9 @@ func (h *Handler) updateTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for i := range req.GlobalSecondaryIndexUpdates {
-		if err := h.applyGSIUpdate(r.Context(), req.TableName,
-			req.GlobalSecondaryIndexUpdates[i].Create,
-			indexDeleteName(req.GlobalSecondaryIndexUpdates[i].Delete)); err != nil {
-			writeErr(w, err)
-			return
-		}
+	if err := h.applyGSIUpdates(r.Context(), req.TableName, req.GlobalSecondaryIndexUpdates); err != nil {
+		writeErr(w, err)
+		return
 	}
 
 	if req.StreamSpecification != nil {
@@ -80,6 +86,11 @@ func (h *Handler) updateTable(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if err := h.applyTableSettings(r.Context(), req.TableName, req.TableClass, req.DeletionProtectionEnabled); err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	full, err := h.db.DescribeTable(r.Context(), req.TableName)
 	if err != nil {
 		writeErr(w, err)
@@ -87,6 +98,18 @@ func (h *Handler) updateTable(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wire.WriteJSON(w, map[string]any{"TableDescription": h.describeTableShape(full)})
+}
+
+// applyGSIUpdates applies every GlobalSecondaryIndexUpdates entry (each a GSI
+// create or delete) on an UpdateTable request, stopping at the first failure.
+func (h *Handler) applyGSIUpdates(ctx context.Context, table string, updates []gsiUpdateJSON) error {
+	for i := range updates {
+		if err := h.applyGSIUpdate(ctx, table, updates[i].Create, indexDeleteName(updates[i].Delete)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func indexDeleteName(del *struct {
@@ -125,6 +148,24 @@ func (h *Handler) applyThroughput(ctx context.Context, table, billingMode string
 	}
 
 	return updater.UpdateThroughput(ctx, table, billingMode, rcu, wcu)
+}
+
+// applyTableSettings applies a table-class and/or deletion-protection change
+// when one was requested. A field the request omits (an empty class, a nil
+// protection pointer) is left untouched, so re-affirming an unrelated
+// UpdateTable field never resets it. A provider that does not expose the
+// capability is a no-op.
+func (h *Handler) applyTableSettings(ctx context.Context, table, tableClass string, deletionProtection *bool) error {
+	if tableClass == "" && deletionProtection == nil {
+		return nil
+	}
+
+	updater, ok := h.db.(tableSettingsUpdater)
+	if !ok {
+		return nil
+	}
+
+	return updater.UpdateTableSettings(ctx, table, tableClass, deletionProtection)
 }
 
 // validateThroughputChange resolves the billing mode and capacity an

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -72,6 +72,15 @@ type TableConfig struct {
 	StreamViewType string
 	StreamArn      string
 	StreamLabel    string
+	// DeletionProtectionEnabled carries the deletion-protection toggle. A
+	// describe echoes it back (default false); once on, DeleteTable is rejected.
+	// An IaC client that sets it otherwise reads back nothing and sees a
+	// perpetual diff.
+	DeletionProtectionEnabled bool
+	// TableClass is "STANDARD" (default) or "STANDARD_INFREQUENT_ACCESS". A
+	// describe echoes it back as TableClassSummary; an IaC client that sets it
+	// otherwise sees a perpetual diff.
+	TableClass string
 	// TableArn, CreatedAtUnix and TableID are populated by the provider on
 	// create. TableID is a UUID a real table carries and IaC clients read back.
 	TableArn      string


### PR DESCRIPTION
## Summary

Real-user e2e audit of AWS DynamoDB surfaced a genuine Terraform perpetual-diff divergence: `aws_dynamodb_table` reads `DescribeTable` on every refresh, but the emulator dropped `DeletionProtectionEnabled` and `TableClassSummary`. A config that set `deletion_protection_enabled` or `table_class` therefore never converged — `terraform plan` reported an in-place update forever.

Reproduced with real Terraform + AWS provider v5 and the AWS CLI against `cloudemu serve`, fixed, and re-verified (second `plan` now reports "No changes").

## What changed

- `TableConfig` (services/database/driver) gains `DeletionProtectionEnabled` and `TableClass`.
- `CreateTable` parses both and echoes them; `DescribeTable`/`CreateTable` responses now always include `DeletionProtectionEnabled` (default `false`) and `TableClassSummary` (default `STANDARD`), matching real DynamoDB.
- `UpdateTable` mutates both via a new AWS-specific provider capability (`UpdateTableSettings`), leaving any field the request omits untouched.
- `DeleteTable` now rejects a table with deletion protection on (`ValidationException`), matching AWS — a client must disable protection first.

## Evidence

- Terraform: apply a table with `deletion_protection_enabled = true` + `table_class = STANDARD_INFREQUENT_ACCESS`; second `plan` is clean (was a perpetual `false -> true` / `STANDARD -> STANDARD_INFREQUENT_ACCESS` diff). In-place update of both converges; `destroy` is correctly blocked while protection is on and succeeds after disabling.
- AWS CLI / SDK: create/describe round-trip of both fields, default-value round-trip, `update-table` toggle, and the protected-delete `ValidationException`.

Tests added at the wire (real aws-sdk-go-v2) and provider levels.
