### PR TITLE
fix(cloudsql): real-user e2e divergences from GCP (Terraform/gcloud REST prefixes + computed setting defaults)

### DIFF
--- a/providers/gcp/cloudsql/cloudsql.go
+++ b/providers/gcp/cloudsql/cloudsql.go
@@ -283,6 +283,13 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		region = m.opts.Region
 	}
 
+	// storageAutoResize defaults to true on a real Cloud SQL instance; an omitted
+	// (nil) request field resolves to that default so a Get always reports it.
+	autoResize := true
+	if cfg.GCPStorageAutoResize != nil {
+		autoResize = *cfg.GCPStorageAutoResize
+	}
+
 	return rdsdriver.Instance{
 		ID:               cfg.ID,
 		ARN:              idgen.GCPID(m.opts.ProjectID, "instances", cfg.ID),
@@ -297,21 +304,22 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		// carries the reachable host reported as the PRIMARY ipAddress. Without a
 		// real engine this is a synthetic IP; dbengine.Provision overrides it with
 		// the real host:port when one is wired in.
-		ConnectionName:     instanceConnectionName(m.opts.ProjectID, region, cfg.ID),
-		Endpoint:           syntheticPrivateIP,
-		Port:               port,
-		State:              rdsdriver.StateAvailable,
-		MultiAZ:            cfg.MultiAZ,
-		DeletionProtection: cfg.DeletionProtection,
-		PubliclyAccessible: cfg.PubliclyAccessible,
-		VPCSecurityGroups:  append([]string(nil), cfg.VPCSecurityGroups...),
-		SubnetGroupName:    cfg.SubnetGroupName,
-		AvailabilityZone:   region,
-		CreatedAt:          m.opts.Clock.Now().UTC(),
-		Tags:               copyTags(cfg.Tags),
-		GCPDatabaseFlags:   cfg.GCPDatabaseFlags,
-		GCPBackupConfig:    cfg.GCPBackupConfig,
-		GCPIPConfig:        cfg.GCPIPConfig,
+		ConnectionName:       instanceConnectionName(m.opts.ProjectID, region, cfg.ID),
+		Endpoint:             syntheticPrivateIP,
+		Port:                 port,
+		State:                rdsdriver.StateAvailable,
+		MultiAZ:              cfg.MultiAZ,
+		DeletionProtection:   cfg.DeletionProtection,
+		PubliclyAccessible:   cfg.PubliclyAccessible,
+		VPCSecurityGroups:    append([]string(nil), cfg.VPCSecurityGroups...),
+		SubnetGroupName:      cfg.SubnetGroupName,
+		AvailabilityZone:     region,
+		CreatedAt:            m.opts.Clock.Now().UTC(),
+		Tags:                 copyTags(cfg.Tags),
+		GCPDatabaseFlags:     cfg.GCPDatabaseFlags,
+		GCPBackupConfig:      cfg.GCPBackupConfig,
+		GCPIPConfig:          cfg.GCPIPConfig,
+		GCPStorageAutoResize: autoResize,
 	}
 }
 
@@ -478,6 +486,10 @@ func applyGCPSettings(inst *rdsdriver.Instance, input *rdsdriver.ModifyInstanceI
 
 	if input.GCPIPConfig != "" {
 		inst.GCPIPConfig = input.GCPIPConfig
+	}
+
+	if input.GCPStorageAutoResize != nil {
+		inst.GCPStorageAutoResize = *input.GCPStorageAutoResize
 	}
 }
 
@@ -841,21 +853,22 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 	password := m.rootPasswords[snap.InstanceID]
 
 	inst := rdsdriver.Instance{
-		ID:               input.NewInstanceID,
-		ARN:              idgen.GCPID(m.opts.ProjectID, "instances", input.NewInstanceID),
-		Engine:           snap.Engine,
-		EngineVersion:    snap.EngineVersion,
-		InstanceClass:    tier,
-		AllocatedStorage: snap.AllocatedStorage,
-		StorageType:      defaultStorageType,
-		MasterUsername:   username,
-		ConnectionName:   instanceConnectionName(m.opts.ProjectID, m.opts.Region, input.NewInstanceID),
-		Endpoint:         syntheticPrivateIP,
-		Port:             defaultPortFor(snap.Engine),
-		State:            rdsdriver.StateAvailable,
-		AvailabilityZone: m.opts.Region,
-		CreatedAt:        m.opts.Clock.Now().UTC(),
-		Tags:             copyTags(input.Tags),
+		ID:                   input.NewInstanceID,
+		ARN:                  idgen.GCPID(m.opts.ProjectID, "instances", input.NewInstanceID),
+		Engine:               snap.Engine,
+		EngineVersion:        snap.EngineVersion,
+		InstanceClass:        tier,
+		AllocatedStorage:     snap.AllocatedStorage,
+		StorageType:          defaultStorageType,
+		MasterUsername:       username,
+		ConnectionName:       instanceConnectionName(m.opts.ProjectID, m.opts.Region, input.NewInstanceID),
+		Endpoint:             syntheticPrivateIP,
+		Port:                 defaultPortFor(snap.Engine),
+		State:                rdsdriver.StateAvailable,
+		AvailabilityZone:     m.opts.Region,
+		CreatedAt:            m.opts.Clock.Now().UTC(),
+		Tags:                 copyTags(input.Tags),
+		GCPStorageAutoResize: true,
 	}
 
 	// Provision the restored instance's OWN database (keyed by the new id, so it

--- a/server/gcp/cloudsql/handler.go
+++ b/server/gcp/cloudsql/handler.go
@@ -45,6 +45,27 @@ const (
 	contentTypeJSON = "application/json"
 	maxBodyBytes    = 1 << 20
 
+	// pathPrefixBeta / pathFlagsBeta are the sql/v1beta4 REST paths. The Go
+	// sqladmin/v1 client hits /v1/projects/..., but gcloud and the Terraform
+	// google provider (via the embedded sqladmin client) hit
+	// /sql/v1beta4/projects/... — real Cloud SQL serves both surfaces, so the
+	// handler must accept either prefix or every gcloud/Terraform request gets a
+	// 501 and google_sql_database_instance can never be created.
+	pathPrefixBeta = "/sql/v1beta4/projects/"
+	pathFlagsBeta  = "/sql/v1beta4/flags"
+
+	// pathPrefixBare is the version-less /projects/ prefix. When a single
+	// sql_custom_endpoint (http://host:port/) is pointed at the emulator, the
+	// Terraform google provider's handwritten instance/user client prepends
+	// sql/v1beta4/ (→ pathPrefixBeta) while its generated google_sql_database /
+	// google_sql_user resources append projects/... straight onto the endpoint
+	// (→ this bare prefix). Accepting it lets one endpoint drive the full
+	// instance + database + user lifecycle. It is narrowed to the Cloud SQL
+	// resource segments (instances/operations/tiers), and cloudsql registers
+	// ahead of the greedy /v1/projects/ Firestore handler, so it never steals
+	// another service's traffic.
+	pathPrefixBare = "/projects/"
+
 	resourceInstances  = "instances"
 	resourceOperations = "operations"
 	resourceBackupRuns = "backupRuns"
@@ -114,20 +135,42 @@ func (h *Handler) completeOp(w http.ResponseWriter, project, name, opType, resou
 	writeJSON(w, http.StatusOK, h.buildOp(project, name, opType, resourceType, target))
 }
 
-// Matches accepts /v1/projects/{p}/{instances|operations|tiers}/... paths plus
-// the project-less /v1/flags catalog. Other resource types under /v1/projects/
-// (locations, topics, subscriptions, databases) belong to Cloud Functions,
-// Pub/Sub, or Firestore respectively and must fall through.
+// isFlagsPath reports whether urlPath is the project-less flags catalog on
+// either the v1 or v1beta4 surface.
+func isFlagsPath(urlPath string) bool {
+	return urlPath == pathFlags || urlPath == pathFlagsBeta
+}
+
+// trimProjectsPrefix strips the /v1/projects/ or /sql/v1beta4/projects/ prefix,
+// returning the "{project}/{resource}/..." remainder. ok is false when urlPath
+// carries neither prefix.
+func trimProjectsPrefix(urlPath string) (string, bool) {
+	for _, pfx := range [...]string{pathPrefix, pathPrefixBeta, pathPrefixBare} {
+		if rest, ok := strings.CutPrefix(urlPath, pfx); ok {
+			return rest, true
+		}
+	}
+
+	return "", false
+}
+
+// Matches accepts /v1/projects/{p}/{instances|operations|tiers}/... and the
+// equivalent /sql/v1beta4/projects/... paths (used by gcloud and the Terraform
+// google provider), plus the project-less flags catalog on either surface.
+// Other resource types under /v1/projects/ (locations, topics, subscriptions,
+// databases) belong to Cloud Functions, Pub/Sub, or Firestore respectively and
+// must fall through.
 func (*Handler) Matches(r *http.Request) bool {
-	if r.URL.Path == pathFlags {
+	if isFlagsPath(r.URL.Path) {
 		return true
 	}
 
-	if !strings.HasPrefix(r.URL.Path, pathPrefix) {
+	rest, ok := trimProjectsPrefix(r.URL.Path)
+	if !ok {
 		return false
 	}
 
-	parts := strings.Split(strings.TrimPrefix(r.URL.Path, pathPrefix), "/")
+	parts := strings.Split(rest, "/")
 
 	const idxResource = 1
 
@@ -169,7 +212,10 @@ func parsePath(urlPath string) (sqlPath, bool) {
 		idxSubName     = 4
 	)
 
-	rest := strings.TrimPrefix(urlPath, pathPrefix)
+	rest, ok := trimProjectsPrefix(urlPath)
+	if !ok {
+		return sqlPath{}, false
+	}
 
 	parts := strings.Split(rest, "/")
 	if len(parts) < minParts {
@@ -201,8 +247,8 @@ func parsePath(urlPath string) (sqlPath, bool) {
 
 // ServeHTTP routes the parsed path to the matching operation.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// /v1/flags is project-less, so it bypasses the project path parser.
-	if r.URL.Path == pathFlags {
+	// The flags catalog is project-less, so it bypasses the project path parser.
+	if isFlagsPath(r.URL.Path) {
 		serveFlags(w, r)
 		return
 	}

--- a/server/gcp/cloudsql/operations.go
+++ b/server/gcp/cloudsql/operations.go
@@ -54,6 +54,9 @@ func instanceFromBody(body *sqlInstance) rdsdriver.InstanceConfig {
 		cfg.GCPDatabaseFlags = string(s.DatabaseFlags)
 		cfg.GCPBackupConfig = string(s.BackupConfiguration)
 		cfg.GCPIPConfig = string(s.IPConfiguration)
+		// A nil StorageAutoResize is carried through so the provider applies the
+		// Cloud SQL default (true) rather than false.
+		cfg.GCPStorageAutoResize = s.StorageAutoResize
 	}
 
 	return cfg
@@ -87,6 +90,16 @@ func modifyInputFromBody(body *sqlInstance, replace bool) rdsdriver.ModifyInstan
 	input.GCPBackupConfig = string(s.BackupConfiguration)
 	input.GCPIPConfig = string(s.IPConfiguration)
 
+	applyModifySettings(&input, s, replace)
+
+	return input
+}
+
+// applyModifySettings copies the merge/replace-sensitive settings (labels,
+// availabilityType, deletionProtection, storageAutoResize) from s onto input.
+// On a PATCH an absent field means "no change"; on a PUT (replace) it reverts to
+// the Cloud SQL default.
+func applyModifySettings(input *rdsdriver.ModifyInstanceInput, s *sqlSettings, replace bool) {
 	// On replace an absent userLabels clears the labels (empty non-nil map),
 	// while on merge an absent map leaves them unchanged (nil).
 	switch {
@@ -108,7 +121,15 @@ func modifyInputFromBody(body *sqlInstance, replace bool) rdsdriver.ModifyInstan
 		input.DeletionProtection = &off
 	}
 
-	return input
+	// storageAutoResize: a present flag updates it; on a PUT (replace) an absent
+	// flag reverts to the Cloud SQL default (true), matching full-resource update.
+	switch {
+	case s.StorageAutoResize != nil:
+		input.GCPStorageAutoResize = s.StorageAutoResize
+	case replace:
+		on := true
+		input.GCPStorageAutoResize = &on
+	}
 }
 
 // orDefaultStr returns v, or def when v is empty and replace is set (a PUT

--- a/server/gcp/cloudsql/terraform_compat_sdk_test.go
+++ b/server/gcp/cloudsql/terraform_compat_sdk_test.go
@@ -1,0 +1,133 @@
+package cloudsql_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/api/option"
+	sqladmin "google.golang.org/api/sqladmin/v1"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// newTestServer returns the raw httptest server URL plus a v1-client bound to it,
+// so a test can both drive the SDK and probe the alternate REST prefixes gcloud
+// and Terraform use.
+func newTestServer(t *testing.T) (baseURL string, svc *sqladmin.Service) {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{CloudSQL: cloud.CloudSQL})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	var err error
+
+	svc, err = sqladmin.NewService(context.Background(),
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("sqladmin.NewService: %v", err)
+	}
+
+	return ts.URL, svc
+}
+
+// Finding: the handler only served /v1/projects/, so gcloud and the Terraform
+// google provider — which hit /sql/v1beta4/projects/ and, for the generated
+// database/user resources, the version-less /projects/ prefix — got a 501 and
+// could never create an instance. All three prefixes must be served.
+func TestCloudSQLServesAllRESTPrefixes(t *testing.T) {
+	baseURL, svc := newTestServer(t)
+	insertInstance(t, svc, "mock-project", "orders")
+
+	prefixes := []string{
+		"/v1/projects/mock-project/instances/orders",
+		"/sql/v1beta4/projects/mock-project/instances/orders",
+		"/projects/mock-project/instances/orders",
+	}
+
+	for _, p := range prefixes {
+		resp, err := http.Get(baseURL + p) //nolint:noctx // short-lived test request.
+		if err != nil {
+			t.Fatalf("GET %s: %v", p, err)
+		}
+
+		_ = resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET %s: status = %d, want 200", p, resp.StatusCode)
+		}
+	}
+}
+
+// Finding: a Get omitted settings.storageAutoResize and settings.pricingPlan and
+// the top-level instanceType/gceZone. Real Cloud SQL always reports them, so
+// Terraform saw a perpetual disk_autoresize false->true and pricing_plan diff.
+func TestCloudSQLGetReportsComputedDefaults(t *testing.T) {
+	_, svc := newTestServer(t)
+	ctx := context.Background()
+
+	insertInstance(t, svc, "mock-project", "orders")
+
+	got, err := svc.Instances.Get("mock-project", "orders").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.InstanceType != "CLOUD_SQL_INSTANCE" {
+		t.Fatalf("instanceType = %q, want CLOUD_SQL_INSTANCE", got.InstanceType)
+	}
+
+	if got.GceZone == "" {
+		t.Fatal("gceZone is empty, want a synthesized zone")
+	}
+
+	if got.Settings == nil {
+		t.Fatal("settings is nil")
+	}
+
+	if got.Settings.PricingPlan != "PER_USE" {
+		t.Fatalf("pricingPlan = %q, want PER_USE", got.Settings.PricingPlan)
+	}
+
+	// storageAutoResize defaults to true when the insert omits it.
+	if got.Settings.StorageAutoResize == nil || !*got.Settings.StorageAutoResize {
+		t.Fatalf("storageAutoResize = %v, want true", got.Settings.StorageAutoResize)
+	}
+}
+
+// storageAutoResize must round-trip: a request that turns it off is honored and
+// read back as false, rather than snapping back to the default.
+func TestCloudSQLStorageAutoResizeRoundTrip(t *testing.T) {
+	_, svc := newTestServer(t)
+	ctx := context.Background()
+
+	off := false
+	if _, err := svc.Instances.Insert("mock-project", &sqladmin.DatabaseInstance{
+		Name:            "noresize",
+		DatabaseVersion: "POSTGRES_15",
+		Region:          "us-central1",
+		Settings: &sqladmin.Settings{
+			Tier:              "db-custom-2-8192",
+			StorageAutoResize: &off,
+			// StorageAutoResize is a pointer bool; force it onto the wire even at
+			// the zero value.
+			ForceSendFields: []string{"StorageAutoResize"},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	got, err := svc.Instances.Get("mock-project", "noresize").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Settings.StorageAutoResize == nil || *got.Settings.StorageAutoResize {
+		t.Fatalf("storageAutoResize = %v, want false", got.Settings.StorageAutoResize)
+	}
+}

--- a/server/gcp/cloudsql/types.go
+++ b/server/gcp/cloudsql/types.go
@@ -23,6 +23,23 @@ const (
 	availabilityRegional = "REGIONAL"
 	availabilityZonal    = "ZONAL"
 
+	// pricingPlanPerUse is settings.pricingPlan. PER_USE is the only value valid
+	// for a second-gen instance (which is all the emulator mints — backendType
+	// SECOND_GEN), and it is what real Cloud SQL always returns; emitting it keeps
+	// Terraform, whose disk_ pricing_plan default is also PER_USE, from a perpetual
+	// diff.
+	pricingPlanPerUse = "PER_USE"
+
+	// instanceTypeCloudSQL / instanceTypeReadReplica are the settings-less
+	// top-level instanceType enum: a standalone primary vs a read replica. Real
+	// Cloud SQL always reports one; Terraform reads instance_type as computed.
+	instanceTypeCloudSQL    = "CLOUD_SQL_INSTANCE"
+	instanceTypeReadReplica = "READ_REPLICA_INSTANCE"
+
+	// gceZoneSuffix is appended to the region to synthesize a plausible compute
+	// zone for gceZone (e.g. us-central1 -> us-central1-a).
+	gceZoneSuffix = "-a"
+
 	// serverCaCertPEM is the placeholder PEM returned as the instance's
 	// serverCaCert. It is a well-formed shape for SDK round-trips, not a real CA.
 	serverCaCertPEM = "-----BEGIN CERTIFICATE-----\nMOCK\n-----END CERTIFICATE-----"
@@ -58,6 +75,8 @@ type sqlInstance struct {
 	DatabaseVersion    string       `json:"databaseVersion,omitempty"`
 	State              string       `json:"state,omitempty"`
 	BackendType        string       `json:"backendType,omitempty"`
+	InstanceType       string       `json:"instanceType,omitempty"`
+	GceZone            string       `json:"gceZone,omitempty"`
 	ConnectionName     string       `json:"connectionName,omitempty"`
 	SelfLink           string       `json:"selfLink,omitempty"`
 	RootPassword       string       `json:"rootPassword,omitempty"`
@@ -75,7 +94,13 @@ type sqlSettings struct {
 	DataDiskSizeGb   int               `json:"dataDiskSizeGb,string,omitempty"`
 	DataDiskType     string            `json:"dataDiskType,omitempty"`
 	AvailabilityType string            `json:"availabilityType,omitempty"`
+	PricingPlan      string            `json:"pricingPlan,omitempty"`
 	UserLabels       map[string]string `json:"userLabels,omitempty"`
+	// StorageAutoResize is settings.storageAutoResize (Terraform disk_autoresize),
+	// which real Cloud SQL defaults to true. A pointer so an absent field on a
+	// Patch means "no change" rather than clobbering to false; always populated on
+	// a Get so Terraform doesn't see a perpetual false->true diff.
+	StorageAutoResize *bool `json:"storageAutoResize,omitempty"`
 	// DeletionProtectionEnabled guards the instance from deletion while true. A
 	// pointer so an absent field on a Patch means "no change" (merge) rather than
 	// clobbering the current value to false; it is always populated on a Get.
@@ -181,6 +206,11 @@ func toSQLInstance(inst *rdsdriver.Instance, project string) sqlInstance {
 		DatabaseVersion: inst.Engine,
 		State:           sqlState(inst.State),
 		BackendType:     "SECOND_GEN",
+		InstanceType:    instanceTypeFor(inst),
+		// gceZone is the compute zone the primary runs in; real Cloud SQL always
+		// reports one. The emulator has no zone concept, so it derives a stable
+		// zone from the region (a computed, read-only attribute in Terraform).
+		GceZone: gceZoneFor(inst.AvailabilityZone),
 		// connectionName is keyed on the REQUEST project (from the URL), matching
 		// real Cloud SQL's {project}:{region}:{instance} — not the server's
 		// configured project, which the stored inst.ConnectionName carries.
@@ -201,6 +231,8 @@ func toSQLInstance(inst *rdsdriver.Instance, project string) sqlInstance {
 			UserLabels:                inst.Tags,
 			ActivationPolicy:          activationFromState(inst.State),
 			AvailabilityType:          availabilityType(inst.MultiAZ),
+			PricingPlan:               pricingPlanPerUse,
+			StorageAutoResize:         boolPtr(inst.GCPStorageAutoResize),
 			DeletionProtectionEnabled: boolPtr(inst.DeletionProtection),
 			DatabaseFlags:             rawJSONOrNil(inst.GCPDatabaseFlags),
 			BackupConfiguration:       rawJSONOrNil(inst.GCPBackupConfig),
@@ -209,6 +241,26 @@ func toSQLInstance(inst *rdsdriver.Instance, project string) sqlInstance {
 		ServerCaCert: serverCaCertFor(inst),
 		CreateTime:   inst.CreatedAt.UTC().Format(rfc3339Milli),
 	}
+}
+
+// instanceTypeFor reports the top-level instanceType: READ_REPLICA_INSTANCE when
+// the instance replicates from a primary, CLOUD_SQL_INSTANCE otherwise.
+func instanceTypeFor(inst *rdsdriver.Instance) string {
+	if inst.ReadReplicaSource != "" {
+		return instanceTypeReadReplica
+	}
+
+	return instanceTypeCloudSQL
+}
+
+// gceZoneFor synthesizes a compute zone from a region. An empty region yields an
+// empty zone so the field is omitted rather than reporting a bare suffix.
+func gceZoneFor(region string) string {
+	if region == "" {
+		return ""
+	}
+
+	return region + gceZoneSuffix
 }
 
 // availabilityType maps the portable MultiAZ flag to the Cloud SQL

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -138,7 +138,12 @@ type InstanceConfig struct {
 	GCPDatabaseFlags string
 	GCPBackupConfig  string
 	GCPIPConfig      string
-	Tags             map[string]string
+	// GCPStorageAutoResize is the Cloud SQL settings.storageAutoResize flag, which
+	// defaults to true on a real instance. A pointer so an omitted field means
+	// "use the default" (true) rather than false; Cloud SQL-only, ignored by
+	// AWS RDS / Redshift.
+	GCPStorageAutoResize *bool
+	Tags                 map[string]string
 	// Scope records where the resource lives (Azure subscription/resource
 	// group). Zero for AWS/GCP and unscoped portable callers.
 	Scope scope.Scope
@@ -215,6 +220,10 @@ type Instance struct {
 	GCPDatabaseFlags string
 	GCPBackupConfig  string
 	GCPIPConfig      string
+	// GCPStorageAutoResize echoes the Cloud SQL settings.storageAutoResize flag on
+	// read. It is resolved to a concrete value on create (defaulting to true),
+	// so a Get always reports it. False/unused for AWS RDS / Redshift.
+	GCPStorageAutoResize bool
 	// Scope records where the resource lives (Azure subscription/resource
 	// group), echoed from the InstanceConfig it was created with. Zero for
 	// AWS/GCP and unscoped portable callers — Scope.Matches treats a zero
@@ -266,7 +275,10 @@ type ModifyInstanceInput struct {
 	GCPDatabaseFlags string
 	GCPBackupConfig  string
 	GCPIPConfig      string
-	Tags             map[string]string
+	// GCPStorageAutoResize updates the Cloud SQL settings.storageAutoResize flag; a
+	// nil pointer means "no change". Cloud SQL-only; RDS/Redshift ignore it.
+	GCPStorageAutoResize *bool
+	Tags                 map[string]string
 	// ApplyImmediately controls when the deferrable changes above take effect
 	// (AWS RDS ModifyDBInstance ApplyImmediately, default false). When true the
 	// target fields are updated on the instance now and PendingModifiedValues is


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of the GCP Cloud SQL Admin control plane (`google_sql_database_instance` / `google_sql_database` / `google_sql_user`) against the real SQL Admin v1beta4 REST surface, driven with the real `google.golang.org/api/sqladmin/v1` SDK client and the real Terraform `hashicorp/google` provider (v5.45) pointed at `cloudemu serve`. Found and fixed genuine cloud-vs-cloudemu divergences.

### Divergences fixed

1. **Terraform/gcloud could not use Cloud SQL at all (HTTP 501).** The handler only served `/v1/projects/...` (the Go `sqladmin/v1` client path). gcloud and the Terraform provider hit `/sql/v1beta4/projects/...` (instances, users) and the version-less `/projects/...` (the generated database/user resources), all of which fell through to `no handler registered` (501). `terraform apply` failed immediately on instance create. The handler now accepts all three prefixes, narrowed to the Cloud SQL resource segments (`instances`/`operations`/`tiers`); it registers ahead of the greedy `/v1/projects/` Firestore matcher, so it never steals another service's traffic.

2. **Terraform perpetual diff on `disk_autoresize` (false -> true).** Real Cloud SQL defaults `settings.storageAutoResize` to true and always returns it; the emulator omitted it, so Terraform read false and planned a change on every run. Now modeled end-to-end (driver + provider + wire), defaulting to true and round-tripping a user-set false.

3. **Terraform perpetual diff on `pricing_plan`.** Real Cloud SQL returns `settings.pricingPlan: PER_USE` (the only valid value for a SECOND_GEN instance); the emulator omitted it. Now emitted.

4. **Missing computed fields `instanceType` and `gceZone`.** Real Cloud SQL always reports these (Terraform reads them as computed). Now emitted: `CLOUD_SQL_INSTANCE` / `READ_REPLICA_INSTANCE`, and a zone synthesized from the region.

### Live evidence

- Full `terraform apply` -> instance reaches `state=RUNNABLE` (insert Operation returns DONE, waiter completes) -> `google_sql_database` + `google_sql_user` created -> `terraform plan` reports **No changes** -> in-place update (tier + `disk_autoresize=false`) applies and re-plans clean -> `terraform destroy` tears all three down.
- Real `sqladmin/v1` SDK: insert/get/list/patch/delete + databases/users round-trip; canonical 404 on missing get and on double-delete.

## Test plan

- New `server/gcp/cloudsql/terraform_compat_sdk_test.go`: all three REST prefixes serve 200; Get reports the computed defaults; `storageAutoResize` round-trips a false.
- `go build ./...`; `go test -race` on `providers/gcp/cloudsql`, `server/gcp/cloudsql`, `services/relationaldb/...`, `providers/aws/rds|redshift`, `providers/azure/sql`, `providers/gcp/alloydb`, `persist`, all `server/gcp/...`, root + `cmd/cloudemu` — all green.
- `go vet`, `gofmt -l` clean; `golangci-lint --new-from-rev=origin/development` = 0; full-package lint on changed packages shows only pre-existing debt (unchanged from development).
- `go generate ./...` — no `docs/coverage` diff (no driver-method surface change).
