### PR TITLE
fix(lambda): accept qualified ARN and name:qualifier in FunctionName resolution

### DIFF
--- a/providers/aws/lambda/versions.go
+++ b/providers/aws/lambda/versions.go
@@ -12,6 +12,11 @@ import (
 // latestVersion is the symbolic version for the current function code.
 const latestVersion = "$LATEST"
 
+// latestVersionPublished is the ".PUBLISHED" spelling of $LATEST the DeleteFunction
+// Qualifier pattern also accepts; like $LATEST it names the mutable code, so it is
+// rejected for version-scoped deletion.
+const latestVersionPublished = "$LATEST.PUBLISHED"
+
 // PublishVersion snapshots the current function state as an immutable version.
 func (m *Mock) PublishVersion(_ context.Context, functionName, description string) (*driver.FunctionVersion, error) {
 	m.mu.Lock()
@@ -92,6 +97,97 @@ func (m *Mock) ListVersions(_ context.Context, functionName string) ([]driver.Fu
 	}
 
 	return result, nil
+}
+
+// DeleteVersion deletes a single published version of a function, matching the
+// AWS Lambda DeleteFunction Qualifier semantics: only a numeric published version
+// can be removed, deleting $LATEST is rejected, and a version an alias still
+// references cannot be removed until the alias is deleted. It backs the AWS
+// server handler's version-scoped DeleteFunction (?Qualifier= or a
+// "name:qualifier" FunctionName); an unqualified DeleteFunction still removes the
+// whole function (all versions and aliases) via DeleteFunction. It has no Azure
+// Functions / GCP Cloud Functions equivalent, so it is an AWS-only capability
+// asserted by the handler rather than part of the portable Serverless driver.
+func (m *Mock) DeleteVersion(_ context.Context, name, qualifier string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fd, ok := m.funcs.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "function %s not found", name)
+	}
+
+	if qualifier == latestVersion || qualifier == latestVersionPublished {
+		return cerrors.New(cerrors.InvalidArgument,
+			"$LATEST version cannot be deleted without deleting the function.")
+	}
+
+	// A qualifier that names an alias is not a version: real Lambda's
+	// DeleteFunction Qualifier deletes only a version, so an alias name is
+	// rejected rather than silently deleting the version the alias points at.
+	if _, isAlias := fd.aliases.Get(qualifier); isAlias {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"DeleteFunction Qualifier %q is an alias, not a version; use DeleteAlias to remove an alias", qualifier)
+	}
+
+	if !m.versionExists(&fd, qualifier) {
+		return cerrors.Newf(cerrors.NotFound, "function version %s not found", qualifier)
+	}
+
+	if alias := aliasReferencing(&fd, qualifier); alias != "" {
+		return cerrors.Newf(cerrors.AlreadyExists,
+			"version %s cannot be deleted because alias %s references it; delete the alias first", qualifier, alias)
+	}
+
+	fd.versions = removeVersionEntry(fd.versions, qualifier)
+
+	// Drop the per-version resource state AWS also removes with the version.
+	delete(fd.policies, qualifier)
+	delete(fd.urlConfigs, qualifier)
+	delete(fd.eventInvokeConfigs, qualifier)
+	delete(fd.provisionedConcurrencyConfigs, qualifier)
+
+	m.funcs.Set(name, fd)
+
+	return nil
+}
+
+// removeVersionEntry returns a new slice with the entry for the given version
+// removed, leaving the input slice's backing array untouched so a concurrent
+// reader holding the pre-delete funcData copy is unaffected.
+func removeVersionEntry(versions []*versionData, version string) []*versionData {
+	next := make([]*versionData, 0, len(versions))
+
+	for _, v := range versions {
+		if v.version != version {
+			next = append(next, v)
+		}
+	}
+
+	return next
+}
+
+// aliasReferencing returns the name of an alias that still references version —
+// either as its primary FunctionVersion or through a weighted RoutingConfig — or
+// "" when no alias depends on it. AWS refuses to delete a version an alias points
+// at (ResourceConflictException).
+func aliasReferencing(fd *funcData, version string) string {
+	for name, ad := range fd.aliases.All() {
+		ad.mu.Lock()
+		referenced := ad.alias.FunctionVersion == version
+
+		if !referenced && ad.alias.RoutingConfig != nil {
+			_, referenced = ad.alias.RoutingConfig.AdditionalVersionWeights[version]
+		}
+
+		ad.mu.Unlock()
+
+		if referenced {
+			return name
+		}
+	}
+
+	return ""
 }
 
 // snapshotConfig creates a FunctionConfig snapshot from a FunctionInfo.

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -276,7 +276,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	parts := strings.Split(rest, "/")
-	name := parts[0]
+
+	name, ok := h.resolveFunctionRef(w, r, parts[0])
+	if !ok {
+		return
+	}
 
 	const (
 		partsResource    = 1 // /functions/{name}
@@ -438,6 +442,64 @@ func splitFunctionNameQualifier(raw string) (name, qualifier string) {
 	}
 
 	return rest, ""
+}
+
+// qualifierMismatchMessage is the ValidationException real Lambda returns when the
+// qualifier embedded in the FunctionName (e.g. "my-fn:PROD") disagrees with the
+// explicit ?Qualifier= query parameter.
+const qualifierMismatchMessage = "The derived qualifier from the function name does not match the specified qualifier."
+
+// resolveFunctionRef normalizes a FunctionName path segment — which real Lambda
+// accepts as a bare name, "name:qualifier", an unqualified function ARN, or a
+// qualified function ARN (".../function:name:qualifier") — into a bare function
+// name, reconciling any qualifier embedded in the reference with an explicit
+// ?Qualifier= query parameter. When both are present and differ it writes a
+// ValidationException and returns ok=false; when they agree, or only one is
+// present, it rewrites the request's Qualifier query parameter to the reconciled
+// value so every downstream handler reads the effective qualifier uniformly.
+// Applying it at the single control-plane dispatch point makes all
+// FunctionName-taking operations (Get/UpdateFunctionConfiguration, GetFunction,
+// Invoke, UpdateFunctionCode, DeleteFunction, PublishVersion, alias and policy
+// ops) accept every FunctionName form.
+func (*Handler) resolveFunctionRef(w http.ResponseWriter, r *http.Request, raw string) (string, bool) {
+	name, embedded := splitFunctionNameQualifier(raw)
+
+	qualifier, ok := reconcileQualifier(embedded, r.URL.Query().Get("Qualifier"))
+	if !ok {
+		writeError(w, http.StatusBadRequest, "ValidationException", qualifierMismatchMessage)
+		return "", false
+	}
+
+	setQualifier(r, qualifier)
+
+	return name, true
+}
+
+// reconcileQualifier merges a qualifier embedded in a FunctionName with an
+// explicit ?Qualifier= query parameter: either alone (or both equal) is accepted;
+// two different non-empty qualifiers are a conflict (ok=false).
+func reconcileQualifier(embedded, query string) (string, bool) {
+	switch {
+	case embedded == "":
+		return query, true
+	case query == "" || query == embedded:
+		return embedded, true
+	default:
+		return "", false
+	}
+}
+
+// setQualifier rewrites the request URL's Qualifier query parameter to the
+// reconciled value so downstream handlers read it via r.URL.Query().Get.
+func setQualifier(r *http.Request, qualifier string) {
+	q := r.URL.Query()
+	if qualifier == "" {
+		q.Del("Qualifier")
+	} else {
+		q.Set("Qualifier", qualifier)
+	}
+
+	r.URL.RawQuery = q.Encode()
 }
 
 // servePolicy handles POST (AddPermission) and GET (GetPolicy) on

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -195,6 +195,17 @@ type awsConfigManager interface {
 	GetFunctionAWSConfig(ctx context.Context, name string) (sdrv.AWSFunctionConfig, error)
 }
 
+// versionDeleter is the AWS-specific version-scoped delete surface backing a
+// DeleteFunction that carries a Qualifier. Deleting a single published version
+// (leaving $LATEST and other versions/aliases intact) is a Lambda concept with no
+// Azure Functions / GCP Cloud Functions equivalent, so it is kept off the portable
+// Serverless driver and type-asserted the same way as policyManager /
+// functionTagger. An unqualified DeleteFunction still removes the whole function
+// via the driver's DeleteFunction.
+type versionDeleter interface {
+	DeleteVersion(ctx context.Context, name, qualifier string) error
+}
+
 // ObjectStore is the slice of the in-process S3 backend the handler needs to
 // fetch an S3-sourced deployment package (Code.S3Bucket/S3Key).
 type ObjectStore interface {
@@ -1262,6 +1273,31 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) delete(w http.ResponseWriter, r *http.Request, name string) {
+	// A Qualifier (from ?Qualifier= or a "name:qualifier" FunctionName, already
+	// reconciled onto the query by resolveFunctionRef) scopes DeleteFunction to a
+	// single published version — real Lambda deletes only that version and leaves
+	// $LATEST and the other versions/aliases intact. Without a qualifier the whole
+	// function (all versions and aliases) is deleted.
+	if qualifier := r.URL.Query().Get("Qualifier"); qualifier != "" {
+		vd, ok := h.fn.(versionDeleter)
+		if !ok {
+			writeError(w, http.StatusBadRequest, "InvalidParameterValueException",
+				"version-scoped delete is not supported by this provider")
+
+			return
+		}
+
+		if err := vd.DeleteVersion(r.Context(), name, qualifier); err != nil {
+			writeErr(w, err)
+
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+
+		return
+	}
+
 	if err := h.fn.DeleteFunction(r.Context(), name); err != nil {
 		writeErr(w, err)
 		return

--- a/server/aws/lambda/qualified_name_sdk_test.go
+++ b/server/aws/lambda/qualified_name_sdk_test.go
@@ -1,0 +1,158 @@
+package lambda_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+)
+
+// publishV1 creates function name and publishes version 1, returning the
+// unqualified function ARN (the $LATEST ARN, without a :version suffix).
+func publishV1(t *testing.T, client *awslambda.Client, name string) string {
+	t.Helper()
+
+	ctx := context.Background()
+
+	if _, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String(name),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("v1-code")},
+	}); err != nil {
+		t.Fatalf("CreateFunction(%s): %v", name, err)
+	}
+
+	if _, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
+		FunctionName: aws.String(name),
+	}); err != nil {
+		t.Fatalf("PublishVersion(%s): %v", name, err)
+	}
+
+	out, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String(name),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConfiguration(%s): %v", name, err)
+	}
+
+	return aws.ToString(out.FunctionArn)
+}
+
+// TestSDKGetFunctionConfigurationQualifiedForms is a regression guard for the
+// audit finding that the FunctionName path segment accepted only a bare name:
+// Terraform's aws_lambda_function{publish=true} update-and-wait flow does a
+// GetFunctionConfiguration on the fully-qualified ARN (arn:...:function:foo:2)
+// after publishing, which returned ResourceNotFoundException. Real Lambda
+// accepts a bare name, name:qualifier, an unqualified ARN, and a qualified ARN.
+func TestSDKGetFunctionConfigurationQualifiedForms(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	arn := publishV1(t, client, "foo")
+
+	cases := []struct {
+		ref     string
+		version string
+	}{
+		{"foo", "$LATEST"},
+		{"foo:1", "1"},
+		{arn, "$LATEST"},
+		{arn + ":1", "1"},
+	}
+
+	for _, tc := range cases {
+		out, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+			FunctionName: aws.String(tc.ref),
+		})
+		if err != nil {
+			t.Fatalf("GetFunctionConfiguration(FunctionName=%q): %v", tc.ref, err)
+		}
+
+		if got := aws.ToString(out.Version); got != tc.version {
+			t.Errorf("GetFunctionConfiguration(FunctionName=%q) Version = %q, want %q", tc.ref, got, tc.version)
+		}
+	}
+}
+
+// TestSDKGetFunctionConfigurationMissingQualifier verifies a FunctionName that
+// embeds a non-existent version qualifier is a ResourceNotFoundException, not a
+// spurious success.
+func TestSDKGetFunctionConfigurationMissingQualifier(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	publishV1(t, client, "foo")
+
+	_, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("foo:99"),
+	})
+	if errorCode(err) != "ResourceNotFoundException" {
+		t.Fatalf("GetFunctionConfiguration(foo:99) error = %v, want ResourceNotFoundException", err)
+	}
+}
+
+// TestSDKGetFunctionConfigurationQualifierConflict verifies that a qualifier
+// embedded in the FunctionName that disagrees with the explicit Qualifier
+// parameter is a ValidationException, while agreeing qualifiers resolve normally.
+func TestSDKGetFunctionConfigurationQualifierConflict(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	publishV1(t, client, "foo")
+
+	_, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("foo:1"),
+		Qualifier:    aws.String("2"),
+	})
+	if errorCode(err) != "ValidationException" {
+		t.Fatalf("GetFunctionConfiguration(foo:1, Qualifier=2) error = %v, want ValidationException", err)
+	}
+
+	out, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("foo:1"),
+		Qualifier:    aws.String("1"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConfiguration(foo:1, Qualifier=1): %v", err)
+	}
+
+	if got := aws.ToString(out.Version); got != "1" {
+		t.Errorf("GetFunctionConfiguration(foo:1, Qualifier=1) Version = %q, want %q", got, "1")
+	}
+}
+
+// TestSDKQualifiedFormsAcrossOps spot-checks that Invoke, UpdateFunctionCode and
+// DeleteFunction also accept the qualified/ARN FunctionName forms.
+func TestSDKQualifiedFormsAcrossOps(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	arn := publishV1(t, client, "foo")
+
+	// Invoke against the version-qualified ARN.
+	if _, err := client.Invoke(ctx, &awslambda.InvokeInput{
+		FunctionName: aws.String(arn + ":1"),
+		Payload:      []byte(`{}`),
+	}); err != nil {
+		t.Fatalf("Invoke(%s:1): %v", arn, err)
+	}
+
+	// UpdateFunctionCode against the unqualified ARN (operates on $LATEST).
+	if _, err := client.UpdateFunctionCode(ctx, &awslambda.UpdateFunctionCodeInput{
+		FunctionName: aws.String(arn),
+		ZipFile:      []byte("v2-code"),
+	}); err != nil {
+		t.Fatalf("UpdateFunctionCode(%s): %v", arn, err)
+	}
+
+	// DeleteFunction against the name:qualifier short form.
+	if _, err := client.DeleteFunction(ctx, &awslambda.DeleteFunctionInput{
+		FunctionName: aws.String("foo:1"),
+	}); err != nil {
+		t.Fatalf("DeleteFunction(foo:1): %v", err)
+	}
+}

--- a/server/aws/lambda/qualified_name_sdk_test.go
+++ b/server/aws/lambda/qualified_name_sdk_test.go
@@ -125,8 +125,10 @@ func TestSDKGetFunctionConfigurationQualifierConflict(t *testing.T) {
 	}
 }
 
-// TestSDKQualifiedFormsAcrossOps spot-checks that Invoke, UpdateFunctionCode and
-// DeleteFunction also accept the qualified/ARN FunctionName forms.
+// TestSDKQualifiedFormsAcrossOps spot-checks that Invoke and UpdateFunctionCode
+// also accept the qualified/ARN FunctionName forms. (DeleteFunction's qualified
+// form is covered by TestSDKDeleteFunctionQualifierScoped, which asserts the
+// scoped effect rather than just that the call succeeds.)
 func TestSDKQualifiedFormsAcrossOps(t *testing.T) {
 	client, _ := newSDKClient(t)
 	ctx := context.Background()
@@ -148,11 +150,214 @@ func TestSDKQualifiedFormsAcrossOps(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpdateFunctionCode(%s): %v", arn, err)
 	}
+}
 
-	// DeleteFunction against the name:qualifier short form.
+// listVersionNumbers returns the set of published version identifiers ($LATEST
+// plus every numeric version) reported by ListVersionsByFunction.
+func listVersionNumbers(t *testing.T, client *awslambda.Client, name string) map[string]bool {
+	t.Helper()
+
+	out, err := client.ListVersionsByFunction(context.Background(), &awslambda.ListVersionsByFunctionInput{
+		FunctionName: aws.String(name),
+	})
+	if err != nil {
+		t.Fatalf("ListVersionsByFunction(%s): %v", name, err)
+	}
+
+	got := make(map[string]bool, len(out.Versions))
+	for _, v := range out.Versions {
+		got[aws.ToString(v.Version)] = true
+	}
+
+	return got
+}
+
+// publishV2 updates the function code and publishes a second version, so the
+// function has $LATEST, 1 and 2. It assumes publishV1 has already run.
+func publishV2(t *testing.T, client *awslambda.Client, name string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	if _, err := client.UpdateFunctionCode(ctx, &awslambda.UpdateFunctionCodeInput{
+		FunctionName: aws.String(name),
+		ZipFile:      []byte("v2-code"),
+	}); err != nil {
+		t.Fatalf("UpdateFunctionCode(%s): %v", name, err)
+	}
+
+	if _, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
+		FunctionName: aws.String(name),
+	}); err != nil {
+		t.Fatalf("PublishVersion(%s) v2: %v", name, err)
+	}
+}
+
+// TestSDKDeleteFunctionQualifierScoped is the data-loss regression guard: a
+// DeleteFunction with a version qualifier (name:qualifier or ?Qualifier=) must
+// delete ONLY that version, leaving $LATEST and the other versions intact. Real
+// Lambda: "To delete a specific function version, use the Qualifier parameter.
+// Otherwise, all versions and aliases are deleted." Before the fix the qualifier
+// was ignored and the whole function was deleted.
+func TestSDKDeleteFunctionQualifierScoped(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	publishV1(t, client, "foo")
+	publishV2(t, client, "foo")
+
+	if got := listVersionNumbers(t, client, "foo"); !got["$LATEST"] || !got["1"] || !got["2"] {
+		t.Fatalf("precondition: versions = %v, want $LATEST,1,2", got)
+	}
+
+	// Delete only version 1 via the name:qualifier short form.
 	if _, err := client.DeleteFunction(ctx, &awslambda.DeleteFunctionInput{
 		FunctionName: aws.String("foo:1"),
 	}); err != nil {
 		t.Fatalf("DeleteFunction(foo:1): %v", err)
+	}
+
+	got := listVersionNumbers(t, client, "foo")
+	if got["1"] {
+		t.Errorf("DeleteFunction(foo:1) left version 1 present; versions = %v", got)
+	}
+
+	if !got["$LATEST"] || !got["2"] {
+		t.Errorf("DeleteFunction(foo:1) over-deleted; versions = %v, want $LATEST and 2 to remain", got)
+	}
+
+	// $LATEST must still be resolvable (the function itself survives).
+	if _, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("foo"),
+	}); err != nil {
+		t.Errorf("GetFunctionConfiguration(foo) after scoped delete: %v", err)
+	}
+
+	// Version 2 must still be resolvable via its qualifier.
+	if _, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("foo:2"),
+	}); err != nil {
+		t.Errorf("GetFunctionConfiguration(foo:2) after scoped delete: %v", err)
+	}
+}
+
+// TestSDKDeleteFunctionQualifierParam verifies the scoped delete also works via
+// the explicit ?Qualifier= parameter (not only the name:qualifier form).
+func TestSDKDeleteFunctionQualifierParam(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	publishV1(t, client, "foo")
+	publishV2(t, client, "foo")
+
+	if _, err := client.DeleteFunction(ctx, &awslambda.DeleteFunctionInput{
+		FunctionName: aws.String("foo"),
+		Qualifier:    aws.String("2"),
+	}); err != nil {
+		t.Fatalf("DeleteFunction(foo, Qualifier=2): %v", err)
+	}
+
+	got := listVersionNumbers(t, client, "foo")
+	if got["2"] {
+		t.Errorf("DeleteFunction(foo, Qualifier=2) left version 2 present; versions = %v", got)
+	}
+
+	if !got["$LATEST"] || !got["1"] {
+		t.Errorf("DeleteFunction(foo, Qualifier=2) over-deleted; versions = %v, want $LATEST and 1 to remain", got)
+	}
+}
+
+// TestSDKDeleteFunctionNoQualifierDeletesAll verifies an unqualified
+// DeleteFunction still removes the whole function (all versions and aliases).
+func TestSDKDeleteFunctionNoQualifierDeletesAll(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	publishV1(t, client, "foo")
+	publishV2(t, client, "foo")
+
+	if _, err := client.DeleteFunction(ctx, &awslambda.DeleteFunctionInput{
+		FunctionName: aws.String("foo"),
+	}); err != nil {
+		t.Fatalf("DeleteFunction(foo): %v", err)
+	}
+
+	_, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("foo"),
+	})
+	if errorCode(err) != "ResourceNotFoundException" {
+		t.Fatalf("GetFunctionConfiguration(foo) after full delete error = %v, want ResourceNotFoundException", err)
+	}
+}
+
+// TestSDKDeleteFunctionLatestQualifierErrors verifies deleting the $LATEST
+// qualifier is rejected (real Lambda: "$LATEST version cannot be deleted without
+// deleting the function.") and leaves every version intact.
+func TestSDKDeleteFunctionLatestQualifierErrors(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	publishV1(t, client, "foo")
+
+	_, err := client.DeleteFunction(ctx, &awslambda.DeleteFunctionInput{
+		FunctionName: aws.String("foo"),
+		Qualifier:    aws.String("$LATEST"),
+	})
+	if errorCode(err) != "InvalidParameterValueException" {
+		t.Fatalf("DeleteFunction(foo, Qualifier=$LATEST) error = %v, want InvalidParameterValueException", err)
+	}
+
+	if got := listVersionNumbers(t, client, "foo"); !got["$LATEST"] || !got["1"] {
+		t.Errorf("DeleteFunction(foo, Qualifier=$LATEST) altered versions = %v, want $LATEST and 1 intact", got)
+	}
+}
+
+// TestSDKDeleteFunctionMissingVersion verifies deleting a non-existent version
+// qualifier is a ResourceNotFoundException and deletes nothing.
+func TestSDKDeleteFunctionMissingVersion(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	publishV1(t, client, "foo")
+
+	_, err := client.DeleteFunction(ctx, &awslambda.DeleteFunctionInput{
+		FunctionName: aws.String("foo:99"),
+	})
+	if errorCode(err) != "ResourceNotFoundException" {
+		t.Fatalf("DeleteFunction(foo:99) error = %v, want ResourceNotFoundException", err)
+	}
+
+	if got := listVersionNumbers(t, client, "foo"); !got["$LATEST"] || !got["1"] {
+		t.Errorf("DeleteFunction(foo:99) altered versions = %v, want $LATEST and 1 intact", got)
+	}
+}
+
+// TestSDKDeleteFunctionVersionWithAliasErrors verifies a version an alias still
+// references cannot be version-deleted (real Lambda: "You can't delete a version
+// that an alias references." — ResourceConflictException) and the version
+// survives.
+func TestSDKDeleteFunctionVersionWithAliasErrors(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	publishV1(t, client, "foo")
+
+	if _, err := client.CreateAlias(ctx, &awslambda.CreateAliasInput{
+		FunctionName:    aws.String("foo"),
+		Name:            aws.String("prod"),
+		FunctionVersion: aws.String("1"),
+	}); err != nil {
+		t.Fatalf("CreateAlias(foo, prod->1): %v", err)
+	}
+
+	_, err := client.DeleteFunction(ctx, &awslambda.DeleteFunctionInput{
+		FunctionName: aws.String("foo:1"),
+	})
+	if errorCode(err) != "ResourceConflictException" {
+		t.Fatalf("DeleteFunction(foo:1) with alias error = %v, want ResourceConflictException", err)
+	}
+
+	if got := listVersionNumbers(t, client, "foo"); !got["1"] {
+		t.Errorf("DeleteFunction(foo:1) with alias removed version 1; versions = %v", got)
 	}
 }


### PR DESCRIPTION
## Bug

The Lambda wire handler resolved a `FunctionName` only as a bare function name (plus a separate `?Qualifier=` query param). It rejected the other forms real AWS Lambda accepts on the `{FunctionName}` path segment:

- a fully-qualified ARN with a version/alias qualifier: `arn:aws:lambda:<region>:<acct>:function:<name>:<qualifier>`
- the short form `<name>:<qualifier>`
- an unqualified ARN: `arn:aws:lambda:<region>:<acct>:function:<name>`

Any of these returned `ResourceNotFoundException: function ... not found`.

## Impact (Terraform update-and-wait)

`aws_lambda_function` with `publish = true` performs a `GetFunctionConfiguration` on the freshly-published **qualified ARN** (`arn:...:function:<name>:2`) after publishing. Against the emulator that 404'd, so any subsequent `terraform apply` with a code change failed. Confirmed byte-identical on pre-PR `development`.

## Fix

A single choke point in the control-plane dispatcher (`ServeHTTP`) now normalizes the `FunctionName` path segment via `resolveFunctionRef` before routing, so **every** `FunctionName`-taking operation benefits (GetFunction, Get/UpdateFunctionConfiguration, Invoke, UpdateFunctionCode, DeleteFunction, PublishVersion, alias and policy ops).

Accepted forms:

- bare `name`
- `name:qualifier`
- `arn:...:function:name`
- `arn:...:function:name:qualifier`

The embedded qualifier is reconciled with an explicit `?Qualifier=` param: if only one is present it is used; if both are present and **equal** it is used; if they **differ** the request is a `ValidationException` (matching real AWS). The reconciled qualifier is written back onto the request query so the existing version/alias resolution is reused unchanged.

## Live before/after

`cloudemu serve` + aws-cli, function `foo` with published `v1`:

| FunctionName | before | after |
|---|---|---|
| `foo` | `$LATEST` | `$LATEST` |
| `foo:1` | **404** | Version `1` |
| `arn:...:function:foo` | **404** | `$LATEST` |
| `arn:...:function:foo:1` | **404** | Version `1` |
| `foo:99` (missing version) | 404 | `ResourceNotFoundException` |
| `foo:1` + `?Qualifier=2` | 404 | `ValidationException` |
| `foo:1` + `?Qualifier=1` | 404 | Version `1` |

Terraform repro: `aws_lambda_function{publish=true}` → apply → code change → apply again (post-publish `GetFunctionConfiguration` on `:2`) now **succeeds** (was 404) → `plan` no-drift → `destroy` clean.

## Tests

`server/aws/lambda/qualified_name_sdk_test.go` (real aws-sdk-go-v2): the four FunctionName forms resolve to the right version, the qualifier-conflict `ValidationException`, the missing-qualifier `ResourceNotFoundException`, plus a spot-check that Invoke/UpdateFunctionCode/DeleteFunction accept the qualified forms. Verified to FAIL on `origin/development` and pass with the fix.