### PR TITLE
fix(azure-sql): real-user e2e divergences from Azure

### DIFF
--- a/providers/azure/sql/databases.go
+++ b/providers/azure/sql/databases.go
@@ -21,6 +21,14 @@ const (
 	// databases carry no row data, so there is no historical state to rewind to.
 	createModeCopy = "Copy"
 	createModePITR = "PointInTimeRestore"
+
+	// Azure SQL database defaults synthesized when a create omits them, so a read
+	// round-trips like real Azure SQL (see
+	// https://learn.microsoft.com/en-us/rest/api/sql/databases/create-or-update).
+	defaultCollation        = "SQL_Latin1_General_CP1_CI_AS"
+	defaultMaxSizeBytes     = int64(34359738368) // 32 GB, the General Purpose default.
+	defaultBackupRedundancy = "Geo"
+	defaultReadScale        = "Disabled"
 )
 
 // isSourceCopyMode reports whether a createMode provisions a database from an
@@ -79,29 +87,24 @@ func (m *Mock) CreateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 		return nil, err
 	}
 
-	skuName := cfg.SKUName
-	if skuName == "" {
-		skuName = "GP_Gen5_2"
-	}
-
-	skuTier := cfg.SKUTier
-	if skuTier == "" {
-		skuTier = "GeneralPurpose"
-	}
+	withDatabaseDefaults(&cfg)
 
 	db := rdsdriver.Database{
-		Server:        cfg.Server,
-		Name:          cfg.Name,
-		Charset:       cfg.Charset,
-		Collation:     cfg.Collation,
-		ARN:           serverDatabaseResourceID(m.opts.Region, cfg.Server, cfg.Name),
-		Location:      orDefault(cfg.Location, server.Location),
-		Tags:          copyTags(cfg.Tags),
-		SKUName:       skuName,
-		SKUTier:       skuTier,
-		SKUCapacity:   cfg.SKUCapacity,
-		ZoneRedundant: cfg.ZoneRedundant,
-		ElasticPoolID: cfg.ElasticPoolID,
+		Server:                  cfg.Server,
+		Name:                    cfg.Name,
+		Charset:                 cfg.Charset,
+		Collation:               cfg.Collation,
+		ARN:                     serverDatabaseResourceID(m.opts.Region, cfg.Server, cfg.Name),
+		Location:                orDefault(cfg.Location, server.Location),
+		Tags:                    copyTags(cfg.Tags),
+		SKUName:                 cfg.SKUName,
+		SKUTier:                 cfg.SKUTier,
+		SKUCapacity:             cfg.SKUCapacity,
+		ZoneRedundant:           cfg.ZoneRedundant,
+		ElasticPoolID:           cfg.ElasticPoolID,
+		MaxSizeBytes:            cfg.MaxSizeBytes,
+		BackupStorageRedundancy: cfg.BackupStorageRedundancy,
+		ReadScale:               cfg.ReadScale,
 	}
 	m.databases.Set(key, db)
 
@@ -123,6 +126,35 @@ func (m *Mock) CreateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 	out := db
 
 	return &out, nil
+}
+
+// withDatabaseDefaults fills the Azure SQL database properties a create left
+// unset with Azure's documented defaults, so a read round-trips like real Azure
+// SQL. Mutating cfg in place keeps CreateDatabase's branch count low.
+func withDatabaseDefaults(cfg *rdsdriver.DatabaseConfig) {
+	if cfg.SKUName == "" {
+		cfg.SKUName = "GP_Gen5_2"
+	}
+
+	if cfg.SKUTier == "" {
+		cfg.SKUTier = "GeneralPurpose"
+	}
+
+	if cfg.Collation == "" {
+		cfg.Collation = defaultCollation
+	}
+
+	if cfg.MaxSizeBytes == 0 {
+		cfg.MaxSizeBytes = defaultMaxSizeBytes
+	}
+
+	if cfg.BackupStorageRedundancy == "" {
+		cfg.BackupStorageRedundancy = defaultBackupRedundancy
+	}
+
+	if cfg.ReadScale == "" {
+		cfg.ReadScale = defaultReadScale
+	}
 }
 
 // applyCopySource resolves the copy/restore source database named by
@@ -199,6 +231,9 @@ func (m *Mock) UpdateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 		db.SKUCapacity = cfg.SKUCapacity
 		db.ZoneRedundant = cfg.ZoneRedundant
 		db.ElasticPoolID = cfg.ElasticPoolID
+		db.MaxSizeBytes = cfg.MaxSizeBytes
+		db.BackupStorageRedundancy = cfg.BackupStorageRedundancy
+		db.ReadScale = cfg.ReadScale
 		updated = db
 
 		return db

--- a/providers/azure/sql/sql.go
+++ b/providers/azure/sql/sql.go
@@ -45,6 +45,13 @@ const (
 	cpuMetricRunning   = 0.25
 	cpuMetricStopped   = 0.0
 	dtuRunning         = 50.0
+
+	// Azure SQL logical-server defaults synthesized when a create omits them, so
+	// a read round-trips like real Azure SQL. minimalTlsVersion defaults to "1.2",
+	// public endpoint access is Enabled, and outbound access is unrestricted.
+	defaultMinimalTLSVersion       = "1.2"
+	defaultPublicNetworkAccess     = "Enabled"
+	defaultRestrictOutboundNetwork = "Disabled"
 )
 
 var (
@@ -505,18 +512,21 @@ func (m *Mock) CreateCluster(_ context.Context, cfg rdsdriver.ClusterConfig) (*r
 	}
 
 	cluster := rdsdriver.Cluster{
-		ID:             cfg.ID,
-		ARN:            idgen.AzureID(m.opts.Region, m.opts.Region, armProvider, "servers", cfg.ID),
-		Engine:         "SQLServer",
-		EngineVersion:  cfg.EngineVersion,
-		MasterUsername: cfg.MasterUsername,
-		Endpoint:       cfg.ID + ".database.windows.net",
-		Port:           defaultPort,
-		State:          rdsdriver.StateAvailable,
-		Location:       orDefault(cfg.Location, m.opts.Region),
-		CreatedAt:      m.opts.Clock.Now().UTC(),
-		Tags:           copyTags(cfg.Tags),
-		Scope:          cfg.Scope,
+		ID:                            cfg.ID,
+		ARN:                           idgen.AzureID(m.opts.Region, m.opts.Region, armProvider, "servers", cfg.ID),
+		Engine:                        "SQLServer",
+		EngineVersion:                 cfg.EngineVersion,
+		MasterUsername:                cfg.MasterUsername,
+		Endpoint:                      cfg.ID + ".database.windows.net",
+		Port:                          defaultPort,
+		State:                         rdsdriver.StateAvailable,
+		Location:                      orDefault(cfg.Location, m.opts.Region),
+		CreatedAt:                     m.opts.Clock.Now().UTC(),
+		Tags:                          copyTags(cfg.Tags),
+		Scope:                         cfg.Scope,
+		MinimalTLSVersion:             orDefault(cfg.MinimalTLSVersion, defaultMinimalTLSVersion),
+		PublicNetworkAccess:           orDefault(cfg.PublicNetworkAccess, defaultPublicNetworkAccess),
+		RestrictOutboundNetworkAccess: orDefault(cfg.RestrictOutboundNetworkAccess, defaultRestrictOutboundNetwork),
 	}
 
 	m.clusters.Set(cfg.ID, cluster)
@@ -573,6 +583,18 @@ func (m *Mock) ModifyCluster(
 
 	if input.EngineVersion != "" {
 		cluster.EngineVersion = input.EngineVersion
+	}
+
+	if input.MinimalTLSVersion != "" {
+		cluster.MinimalTLSVersion = input.MinimalTLSVersion
+	}
+
+	if input.PublicNetworkAccess != "" {
+		cluster.PublicNetworkAccess = input.PublicNetworkAccess
+	}
+
+	if input.RestrictOutboundNetworkAccess != "" {
+		cluster.RestrictOutboundNetworkAccess = input.RestrictOutboundNetworkAccess
 	}
 
 	if input.Tags != nil {

--- a/server/azure/echo_properties_test.go
+++ b/server/azure/echo_properties_test.go
@@ -838,18 +838,19 @@ func TestEchoEvictsSubResourceOverlayOnDelete(t *testing.T) {
 	created := putJSON(t, c, dbURL, map[string]any{
 		"location": "eastus",
 		"properties": map[string]any{
-			// readScale is not modeled by the SQL database handler; the
-			// overlay is what makes it round-trip at all.
-			"readScale": "Enabled",
+			// catalogCollation is not modeled by the SQL database handler
+			// (distinct from the modeled collation); the overlay is what makes
+			// it round-trip at all.
+			"catalogCollation": "DATABASE_DEFAULT",
 		},
 	})
 
-	if props(t, created)["readScale"] != "Enabled" {
-		t.Fatal("unmodeled readScale was not preserved after create")
+	if props(t, created)["catalogCollation"] != "DATABASE_DEFAULT" {
+		t.Fatal("unmodeled catalogCollation was not preserved after create")
 	}
 
-	if props(t, getJSON(t, c, dbURL))["readScale"] != "Enabled" {
-		t.Fatal("unmodeled readScale not echoed on GET before delete")
+	if props(t, getJSON(t, c, dbURL))["catalogCollation"] != "DATABASE_DEFAULT" {
+		t.Fatal("unmodeled catalogCollation not echoed on GET before delete")
 	}
 
 	deleteOK(t, c, dbURL)
@@ -857,11 +858,11 @@ func TestEchoEvictsSubResourceOverlayOnDelete(t *testing.T) {
 	// Re-create the same database name with no unmodeled properties at all.
 	recreated := putJSON(t, c, dbURL, map[string]any{"location": "eastus"})
 
-	if v, ok := props(t, recreated)["readScale"]; ok {
-		t.Fatalf("recreated database resurrected stale readScale from the deleted one: %v", v)
+	if v, ok := props(t, recreated)["catalogCollation"]; ok {
+		t.Fatalf("recreated database resurrected stale catalogCollation from the deleted one: %v", v)
 	}
 
-	if v, ok := props(t, getJSON(t, c, dbURL))["readScale"]; ok {
-		t.Fatalf("GET on recreated database still carries the deleted database's readScale: %v", v)
+	if v, ok := props(t, getJSON(t, c, dbURL))["catalogCollation"]; ok {
+		t.Fatalf("GET on recreated database still carries the deleted database's catalogCollation: %v", v)
 	}
 }

--- a/server/azure/sql/defaults_roundtrip_sdk_test.go
+++ b/server/azure/sql/defaults_roundtrip_sdk_test.go
@@ -1,0 +1,222 @@
+package sql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
+)
+
+// TestSDKAzureSQLServerDefaults verifies a logical-server create that omits the
+// network properties reads back Azure's documented defaults (minimalTlsVersion
+// "1.2", publicNetworkAccess "Enabled", restrictOutboundNetworkAccess
+// "Disabled"), so a real SDK/CLI/Terraform read does not drift.
+func TestSDKAzureSQLServerDefaults(t *testing.T) {
+	cf := newFactory(t)
+	ctx := context.Background()
+
+	poller, err := cf.NewServersClient().BeginCreateOrUpdate(ctx, "rg-1", "srv1", armsql.Server{
+		Location: to.Ptr("eastus"),
+		Properties: &armsql.ServerProperties{
+			AdministratorLogin:         to.Ptr("admin"),
+			AdministratorLoginPassword: to.Ptr("Sup3rs3cret!"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("server create: %v", err)
+	}
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("server poll: %v", err)
+	}
+
+	got, err := cf.NewServersClient().Get(ctx, "rg-1", "srv1", nil)
+	if err != nil {
+		t.Fatalf("server get: %v", err)
+	}
+	p := got.Properties
+
+	if p.MinimalTLSVersion == nil || *p.MinimalTLSVersion != "1.2" {
+		t.Errorf("minimalTlsVersion = %v, want 1.2", ptr(p.MinimalTLSVersion))
+	}
+	if p.PublicNetworkAccess == nil || *p.PublicNetworkAccess != armsql.ServerNetworkAccessFlagEnabled {
+		t.Errorf("publicNetworkAccess = %v, want Enabled", p.PublicNetworkAccess)
+	}
+	if p.RestrictOutboundNetworkAccess == nil || *p.RestrictOutboundNetworkAccess != armsql.ServerNetworkAccessFlagDisabled {
+		t.Errorf("restrictOutboundNetworkAccess = %v, want Disabled", p.RestrictOutboundNetworkAccess)
+	}
+}
+
+// TestSDKAzureSQLServerNetworkPropsRoundTrip verifies explicit network props
+// survive create → get and that a PATCH updates only the fields it carries,
+// leaving the others intact (ARM partial update semantics).
+func TestSDKAzureSQLServerNetworkPropsRoundTrip(t *testing.T) {
+	cf := newFactory(t)
+	ctx := context.Background()
+	sc := cf.NewServersClient()
+
+	poller, err := sc.BeginCreateOrUpdate(ctx, "rg-1", "srv1", armsql.Server{
+		Location: to.Ptr("eastus"),
+		Properties: &armsql.ServerProperties{
+			AdministratorLogin:         to.Ptr("admin"),
+			AdministratorLoginPassword: to.Ptr("Sup3rs3cret!"),
+			MinimalTLSVersion:          to.Ptr("1.1"),
+			PublicNetworkAccess:        to.Ptr(armsql.ServerNetworkAccessFlagDisabled),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("server create: %v", err)
+	}
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("server poll: %v", err)
+	}
+
+	got, err := sc.Get(ctx, "rg-1", "srv1", nil)
+	if err != nil {
+		t.Fatalf("server get: %v", err)
+	}
+	if got.Properties.MinimalTLSVersion == nil || *got.Properties.MinimalTLSVersion != "1.1" {
+		t.Errorf("create: minimalTlsVersion = %v, want 1.1", ptr(got.Properties.MinimalTLSVersion))
+	}
+	if got.Properties.PublicNetworkAccess == nil || *got.Properties.PublicNetworkAccess != armsql.ServerNetworkAccessFlagDisabled {
+		t.Errorf("create: publicNetworkAccess = %v, want Disabled", got.Properties.PublicNetworkAccess)
+	}
+
+	// PATCH only minimalTlsVersion; publicNetworkAccess must be preserved.
+	pPoller, err := sc.BeginUpdate(ctx, "rg-1", "srv1", armsql.ServerUpdate{
+		Properties: &armsql.ServerProperties{MinimalTLSVersion: to.Ptr("1.2")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("server patch: %v", err)
+	}
+	if _, err := pPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("server patch poll: %v", err)
+	}
+
+	got, err = sc.Get(ctx, "rg-1", "srv1", nil)
+	if err != nil {
+		t.Fatalf("server get after patch: %v", err)
+	}
+	if got.Properties.MinimalTLSVersion == nil || *got.Properties.MinimalTLSVersion != "1.2" {
+		t.Errorf("patch: minimalTlsVersion = %v, want 1.2", ptr(got.Properties.MinimalTLSVersion))
+	}
+	if got.Properties.PublicNetworkAccess == nil || *got.Properties.PublicNetworkAccess != armsql.ServerNetworkAccessFlagDisabled {
+		t.Errorf("patch: publicNetworkAccess = %v, want preserved Disabled", got.Properties.PublicNetworkAccess)
+	}
+}
+
+// TestSDKAzureSQLDatabaseDefaults verifies a database create that omits
+// collation/maxSize/backup redundancy/readScale reads back Azure's documented
+// defaults, so azurerm_mssql_database does not drift on refresh.
+func TestSDKAzureSQLDatabaseDefaults(t *testing.T) {
+	cf := newFactory(t)
+	mustCreateSQLServer(t, cf)
+	ctx := context.Background()
+	dbs := cf.NewDatabasesClient()
+
+	poller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "appdb", armsql.Database{
+		Location: to.Ptr("eastus"),
+		SKU:      &armsql.SKU{Name: to.Ptr("GP_Gen5_2"), Tier: to.Ptr("GeneralPurpose")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("db create: %v", err)
+	}
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("db poll: %v", err)
+	}
+
+	got, err := dbs.Get(ctx, "rg-1", "srv1", "appdb", nil)
+	if err != nil {
+		t.Fatalf("db get: %v", err)
+	}
+	p := got.Properties
+
+	if p.Collation == nil || *p.Collation != "SQL_Latin1_General_CP1_CI_AS" {
+		t.Errorf("collation = %v, want SQL_Latin1_General_CP1_CI_AS", ptr(p.Collation))
+	}
+	if p.MaxSizeBytes == nil || *p.MaxSizeBytes != 34359738368 {
+		t.Errorf("maxSizeBytes = %v, want 34359738368", p.MaxSizeBytes)
+	}
+	if p.RequestedBackupStorageRedundancy == nil || *p.RequestedBackupStorageRedundancy != armsql.BackupStorageRedundancyGeo {
+		t.Errorf("requestedBackupStorageRedundancy = %v, want Geo", p.RequestedBackupStorageRedundancy)
+	}
+	if p.CurrentBackupStorageRedundancy == nil || *p.CurrentBackupStorageRedundancy != armsql.BackupStorageRedundancyGeo {
+		t.Errorf("currentBackupStorageRedundancy = %v, want Geo", p.CurrentBackupStorageRedundancy)
+	}
+	if p.ReadScale == nil || *p.ReadScale != armsql.DatabaseReadScaleDisabled {
+		t.Errorf("readScale = %v, want Disabled", p.ReadScale)
+	}
+}
+
+// TestSDKAzureSQLDatabasePropsRoundTrip verifies explicit maxSizeBytes / backup
+// redundancy / readScale survive create → get, and that a PATCH changing only
+// the SKU preserves them (ARM partial update), while a PATCH that carries a new
+// maxSizeBytes updates it.
+func TestSDKAzureSQLDatabasePropsRoundTrip(t *testing.T) {
+	cf := newFactory(t)
+	mustCreateSQLServer(t, cf)
+	ctx := context.Background()
+	dbs := cf.NewDatabasesClient()
+
+	const customMax = int64(107374182400) // 100 GB
+
+	poller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "appdb", armsql.Database{
+		Location: to.Ptr("eastus"),
+		SKU:      &armsql.SKU{Name: to.Ptr("GP_Gen5_2"), Tier: to.Ptr("GeneralPurpose")},
+		Properties: &armsql.DatabaseProperties{
+			MaxSizeBytes:                     to.Ptr(customMax),
+			RequestedBackupStorageRedundancy: to.Ptr(armsql.BackupStorageRedundancyZone),
+			ReadScale:                        to.Ptr(armsql.DatabaseReadScaleEnabled),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("db create: %v", err)
+	}
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("db poll: %v", err)
+	}
+
+	got, err := dbs.Get(ctx, "rg-1", "srv1", "appdb", nil)
+	if err != nil {
+		t.Fatalf("db get: %v", err)
+	}
+	if got.Properties.MaxSizeBytes == nil || *got.Properties.MaxSizeBytes != customMax {
+		t.Errorf("create: maxSizeBytes = %v, want %d", got.Properties.MaxSizeBytes, customMax)
+	}
+	if got.Properties.RequestedBackupStorageRedundancy == nil ||
+		*got.Properties.RequestedBackupStorageRedundancy != armsql.BackupStorageRedundancyZone {
+		t.Errorf("create: backup redundancy = %v, want Zone", got.Properties.RequestedBackupStorageRedundancy)
+	}
+
+	// PATCH only the SKU: maxSizeBytes/backup/readScale must be preserved.
+	pPoller, err := dbs.BeginUpdate(ctx, "rg-1", "srv1", "appdb", armsql.DatabaseUpdate{
+		SKU: &armsql.SKU{Name: to.Ptr("GP_Gen5_4"), Tier: to.Ptr("GeneralPurpose")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("db patch: %v", err)
+	}
+	if _, err := pPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("db patch poll: %v", err)
+	}
+
+	got, err = dbs.Get(ctx, "rg-1", "srv1", "appdb", nil)
+	if err != nil {
+		t.Fatalf("db get after patch: %v", err)
+	}
+	if got.SKU == nil || got.SKU.Name == nil || *got.SKU.Name != "GP_Gen5_4" {
+		t.Errorf("patch: sku.name = %v, want GP_Gen5_4", got.SKU)
+	}
+	if got.Properties.MaxSizeBytes == nil || *got.Properties.MaxSizeBytes != customMax {
+		t.Errorf("patch: maxSizeBytes = %v, want preserved %d", got.Properties.MaxSizeBytes, customMax)
+	}
+	if got.Properties.ReadScale == nil || *got.Properties.ReadScale != armsql.DatabaseReadScaleEnabled {
+		t.Errorf("patch: readScale = %v, want preserved Enabled", got.Properties.ReadScale)
+	}
+}
+
+func ptr(p *string) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return *p
+}

--- a/server/azure/sql/operations.go
+++ b/server/azure/sql/operations.go
@@ -19,6 +19,9 @@ func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, r
 	}
 
 	reqVersion := stringFrom(body.Properties, func(p *armServerProps) string { return p.Version })
+	reqTLS := stringFrom(body.Properties, func(p *armServerProps) string { return p.MinimalTLSVersion })
+	reqPNA := stringFrom(body.Properties, func(p *armServerProps) string { return p.PublicNetworkAccess })
+	reqRONA := stringFrom(body.Properties, func(p *armServerProps) string { return p.RestrictOutboundNetworkAccess })
 
 	cfg := rdsdriver.ClusterConfig{
 		ID:             rp.ResourceName,
@@ -28,9 +31,12 @@ func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, r
 		MasterUserPassword: stringFrom(body.Properties, func(p *armServerProps) string {
 			return p.AdministratorLoginPassword
 		}),
-		EngineVersion: reqVersion,
-		Tags:          body.Tags,
-		Scope:         scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
+		EngineVersion:                 reqVersion,
+		Tags:                          body.Tags,
+		Scope:                         scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
+		MinimalTLSVersion:             reqTLS,
+		PublicNetworkAccess:           reqPNA,
+		RestrictOutboundNetworkAccess: reqRONA,
 	}
 
 	// Azure SQL synthesizes version "12.0" when a server create omits it.
@@ -54,8 +60,11 @@ func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, r
 		// a PUT that omits version preserves the existing one (ModifyCluster
 		// guards empty), not the create-time "12.0" default.
 		cluster, err = h.db.ModifyCluster(r.Context(), rp.ResourceName, rdsdriver.ModifyInstanceInput{
-			EngineVersion: reqVersion,
-			Tags:          body.Tags,
+			EngineVersion:                 reqVersion,
+			Tags:                          body.Tags,
+			MinimalTLSVersion:             reqTLS,
+			PublicNetworkAccess:           reqPNA,
+			RestrictOutboundNetworkAccess: reqRONA,
 		})
 		if err != nil {
 			azurearm.WriteCErr(w, err)
@@ -75,8 +84,11 @@ func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azure
 	}
 
 	input := rdsdriver.ModifyInstanceInput{
-		EngineVersion: stringFrom(body.Properties, func(p *armServerProps) string { return p.Version }),
-		Tags:          body.Tags,
+		EngineVersion:                 stringFrom(body.Properties, func(p *armServerProps) string { return p.Version }),
+		Tags:                          body.Tags,
+		MinimalTLSVersion:             stringFrom(body.Properties, func(p *armServerProps) string { return p.MinimalTLSVersion }),
+		PublicNetworkAccess:           stringFrom(body.Properties, func(p *armServerProps) string { return p.PublicNetworkAccess }),
+		RestrictOutboundNetworkAccess: stringFrom(body.Properties, serverRestrictOutbound),
 	}
 
 	cluster, err := h.db.ModifyCluster(r.Context(), rp.ResourceName, input)
@@ -196,6 +208,9 @@ func dbCfgFromBody(body *armDatabase, rp *azurearm.ResourcePath) rdsdriver.Datab
 		}
 		cfg.CreateMode = body.Properties.CreateMode
 		cfg.SourceDatabaseID = body.Properties.SourceDatabaseID
+		cfg.MaxSizeBytes = body.Properties.MaxSizeBytes
+		cfg.BackupStorageRedundancy = body.Properties.RequestedBackupStorageRedundancy
+		cfg.ReadScale = body.Properties.ReadScale
 
 		if body.Properties.ZoneRedundant != nil {
 			cfg.ZoneRedundant = *body.Properties.ZoneRedundant
@@ -278,13 +293,10 @@ func (h *Handler) writeDatabaseNotFound(
 	azurearm.WriteError(w, http.StatusBadRequest, "TargetElasticPoolDoesNotExist", cerrors.Message(err))
 }
 
-// mergeDatabaseFields overlays the non-empty fields of cfg (and body's
-// pointer-only properties) onto existing, leaving fields the request omitted
-// untouched. Split out of replaceDatabase to keep that function's
-// cyclomatic complexity down — this is pure field merging, no I/O.
-func mergeDatabaseFields(existing *rdsdriver.Database, body *armDatabase, cfg *rdsdriver.DatabaseConfig) rdsdriver.Database {
-	merged := *existing
-
+// mergeDatabaseSKUAndProps overlays cfg's non-empty SKU and Azure-SQL property
+// fields onto merged, leaving fields the request omitted untouched. Split out of
+// mergeDatabaseFields to keep that function's cyclomatic complexity down.
+func mergeDatabaseSKUAndProps(merged *rdsdriver.Database, cfg *rdsdriver.DatabaseConfig) {
 	if cfg.SKUName != "" {
 		merged.SKUName = cfg.SKUName
 	}
@@ -300,6 +312,28 @@ func mergeDatabaseFields(existing *rdsdriver.Database, body *armDatabase, cfg *r
 	if cfg.Collation != "" {
 		merged.Collation = cfg.Collation
 	}
+
+	if cfg.MaxSizeBytes != 0 {
+		merged.MaxSizeBytes = cfg.MaxSizeBytes
+	}
+
+	if cfg.BackupStorageRedundancy != "" {
+		merged.BackupStorageRedundancy = cfg.BackupStorageRedundancy
+	}
+
+	if cfg.ReadScale != "" {
+		merged.ReadScale = cfg.ReadScale
+	}
+}
+
+// mergeDatabaseFields overlays the non-empty fields of cfg (and body's
+// pointer-only properties) onto existing, leaving fields the request omitted
+// untouched. Split out of replaceDatabase to keep that function's
+// cyclomatic complexity down — this is pure field merging, no I/O.
+func mergeDatabaseFields(existing *rdsdriver.Database, body *armDatabase, cfg *rdsdriver.DatabaseConfig) rdsdriver.Database {
+	merged := *existing
+
+	mergeDatabaseSKUAndProps(&merged, cfg)
 
 	if cfg.Location != "" {
 		merged.Location = cfg.Location
@@ -356,17 +390,20 @@ func replaceDatabase(
 	}
 
 	return updater.UpdateDatabase(ctx, rdsdriver.DatabaseConfig{
-		Server:        merged.Server,
-		Name:          merged.Name,
-		Charset:       merged.Charset,
-		Collation:     merged.Collation,
-		Location:      merged.Location,
-		Tags:          merged.Tags,
-		SKUName:       merged.SKUName,
-		SKUTier:       merged.SKUTier,
-		SKUCapacity:   merged.SKUCapacity,
-		ZoneRedundant: merged.ZoneRedundant,
-		ElasticPoolID: merged.ElasticPoolID,
+		Server:                  merged.Server,
+		Name:                    merged.Name,
+		Charset:                 merged.Charset,
+		Collation:               merged.Collation,
+		Location:                merged.Location,
+		Tags:                    merged.Tags,
+		SKUName:                 merged.SKUName,
+		SKUTier:                 merged.SKUTier,
+		SKUCapacity:             merged.SKUCapacity,
+		ZoneRedundant:           merged.ZoneRedundant,
+		ElasticPoolID:           merged.ElasticPoolID,
+		MaxSizeBytes:            merged.MaxSizeBytes,
+		BackupStorageRedundancy: merged.BackupStorageRedundancy,
+		ReadScale:               merged.ReadScale,
 	})
 }
 
@@ -429,6 +466,10 @@ func (h *Handler) listDatabases(
 
 	azurearm.WriteJSON(w, http.StatusOK, armList[armDatabase]{Value: out})
 }
+
+// serverRestrictOutbound extracts restrictOutboundNetworkAccess from server
+// props; a named func keeps the ModifyInstanceInput literal under the line limit.
+func serverRestrictOutbound(p *armServerProps) string { return p.RestrictOutboundNetworkAccess }
 
 // stringFrom returns f(p) when p is non-nil, else "". A small helper that
 // keeps body decoders compact when most fields are pointer-deref accesses.

--- a/server/azure/sql/types.go
+++ b/server/azure/sql/types.go
@@ -21,11 +21,14 @@ type armServer struct {
 }
 
 type armServerProps struct {
-	AdministratorLogin         string `json:"administratorLogin,omitempty"`
-	AdministratorLoginPassword string `json:"administratorLoginPassword,omitempty"`
-	Version                    string `json:"version,omitempty"`
-	State                      string `json:"state,omitempty"`
-	FullyQualifiedDomainName   string `json:"fullyQualifiedDomainName,omitempty"`
+	AdministratorLogin            string `json:"administratorLogin,omitempty"`
+	AdministratorLoginPassword    string `json:"administratorLoginPassword,omitempty"`
+	Version                       string `json:"version,omitempty"`
+	State                         string `json:"state,omitempty"`
+	FullyQualifiedDomainName      string `json:"fullyQualifiedDomainName,omitempty"`
+	MinimalTLSVersion             string `json:"minimalTlsVersion,omitempty"`
+	PublicNetworkAccess           string `json:"publicNetworkAccess,omitempty"`
+	RestrictOutboundNetworkAccess string `json:"restrictOutboundNetworkAccess,omitempty"`
 }
 
 // armDatabase is the JSON shape Azure ARM expects for
@@ -47,16 +50,19 @@ type armSKU struct {
 }
 
 type armDatabaseProps struct {
-	Status                      string  `json:"status,omitempty"`
-	CreateMode                  string  `json:"createMode,omitempty"`
-	SourceDatabaseID            string  `json:"sourceDatabaseId,omitempty"`
-	RestorePointInTime          string  `json:"restorePointInTime,omitempty"`
-	MaxSizeBytes                int64   `json:"maxSizeBytes,omitempty"`
-	Collation                   string  `json:"collation,omitempty"`
-	DatabaseID                  string  `json:"databaseId,omitempty"`
-	CurrentServiceObjectiveName string  `json:"currentServiceObjectiveName,omitempty"`
-	CurrentSKU                  *armSKU `json:"currentSku,omitempty"`
-	ZoneRedundant               *bool   `json:"zoneRedundant,omitempty"`
+	Status                           string  `json:"status,omitempty"`
+	CreateMode                       string  `json:"createMode,omitempty"`
+	SourceDatabaseID                 string  `json:"sourceDatabaseId,omitempty"`
+	RestorePointInTime               string  `json:"restorePointInTime,omitempty"`
+	MaxSizeBytes                     int64   `json:"maxSizeBytes,omitempty"`
+	Collation                        string  `json:"collation,omitempty"`
+	DatabaseID                       string  `json:"databaseId,omitempty"`
+	CurrentServiceObjectiveName      string  `json:"currentServiceObjectiveName,omitempty"`
+	CurrentSKU                       *armSKU `json:"currentSku,omitempty"`
+	ReadScale                        string  `json:"readScale,omitempty"`
+	RequestedBackupStorageRedundancy string  `json:"requestedBackupStorageRedundancy,omitempty"`
+	CurrentBackupStorageRedundancy   string  `json:"currentBackupStorageRedundancy,omitempty"`
+	ZoneRedundant                    *bool   `json:"zoneRedundant,omitempty"`
 	// ElasticPoolID is a pointer (not a plain string) so a PATCH can distinguish
 	// an omitted field from an explicit "" — real Azure SQL removes a database
 	// from its elastic pool when elasticPoolId is set to "" in the request body,
@@ -79,10 +85,13 @@ func toARMServer(cluster *rdsdriver.Cluster, subscription, resourceGroup string)
 		Location: cluster.Location,
 		Tags:     cluster.Tags,
 		Properties: &armServerProps{
-			AdministratorLogin:       cluster.MasterUsername,
-			Version:                  cluster.EngineVersion,
-			State:                    "Ready",
-			FullyQualifiedDomainName: cluster.Endpoint,
+			AdministratorLogin:            cluster.MasterUsername,
+			Version:                       cluster.EngineVersion,
+			State:                         "Ready",
+			FullyQualifiedDomainName:      cluster.Endpoint,
+			MinimalTLSVersion:             cluster.MinimalTLSVersion,
+			PublicNetworkAccess:           cluster.PublicNetworkAccess,
+			RestrictOutboundNetworkAccess: cluster.RestrictOutboundNetworkAccess,
 		},
 	}
 }
@@ -117,13 +126,17 @@ func toARMDatabase(db *rdsdriver.Database, rp *azurearm.ResourcePath, status str
 		Tags:     db.Tags,
 		SKU:      &armSKU{Name: db.SKUName, Tier: db.SKUTier, Capacity: db.SKUCapacity},
 		Properties: &armDatabaseProps{
-			Status:                      status,
-			Collation:                   db.Collation,
-			DatabaseID:                  databaseGUID(db),
-			CurrentServiceObjectiveName: db.SKUName,
-			CurrentSKU:                  &armSKU{Name: db.SKUName, Tier: db.SKUTier, Capacity: db.SKUCapacity},
-			ZoneRedundant:               &zoneRedundant,
-			ElasticPoolID:               elasticPoolID,
+			Status:                           status,
+			Collation:                        db.Collation,
+			DatabaseID:                       databaseGUID(db),
+			CurrentServiceObjectiveName:      db.SKUName,
+			CurrentSKU:                       &armSKU{Name: db.SKUName, Tier: db.SKUTier, Capacity: db.SKUCapacity},
+			MaxSizeBytes:                     db.MaxSizeBytes,
+			ReadScale:                        db.ReadScale,
+			RequestedBackupStorageRedundancy: db.BackupStorageRedundancy,
+			CurrentBackupStorageRedundancy:   db.BackupStorageRedundancy,
+			ZoneRedundant:                    &zoneRedundant,
+			ElasticPoolID:                    elasticPoolID,
 		},
 	}
 }

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -236,6 +236,12 @@ type ModifyInstanceInput struct {
 	OptionGroupName             string
 	DBClusterParameterGroupName string
 	ElasticPoolID               string
+	// MinimalTLSVersion / PublicNetworkAccess / RestrictOutboundNetworkAccess
+	// update the Azure SQL logical-server properties on a PATCH; empty means "no
+	// change". Other engines ignore them.
+	MinimalTLSVersion             string
+	PublicNetworkAccess           string
+	RestrictOutboundNetworkAccess string
 	// The fields below are AWS RDS ModifyDBInstance attributes; empty / zero /
 	// nil means "no change". NewInstanceID renames the instance (and its ARN).
 	NewInstanceID              string
@@ -347,6 +353,12 @@ type ClusterConfig struct {
 	// Scope records where an Azure SQL logical server lives (subscription/
 	// resource group). Zero for AWS/GCP and unscoped portable callers.
 	Scope scope.Scope
+	// MinimalTLSVersion / PublicNetworkAccess / RestrictOutboundNetworkAccess are
+	// Azure SQL logical-server inputs; empty means the request omitted them, so
+	// the Azure SQL provider fills the documented default. Empty for AWS/GCP.
+	MinimalTLSVersion             string
+	PublicNetworkAccess           string
+	RestrictOutboundNetworkAccess string
 }
 
 // Cluster describes an Aurora-style database cluster.
@@ -402,6 +414,14 @@ type Cluster struct {
 	// Scope records where an Azure SQL logical server lives (subscription/
 	// resource group). Zero for AWS/GCP and unscoped portable callers.
 	Scope scope.Scope
+	// MinimalTLSVersion / PublicNetworkAccess / RestrictOutboundNetworkAccess
+	// echo Azure SQL logical-server properties on read (minimalTlsVersion,
+	// publicNetworkAccess, restrictOutboundNetworkAccess). Azure SQL only; empty
+	// for AWS/GCP. Azure fills documented defaults ("1.2", "Enabled", "Disabled")
+	// on a create that omits them, so a read round-trips like real Azure SQL.
+	MinimalTLSVersion             string
+	PublicNetworkAccess           string
+	RestrictOutboundNetworkAccess string
 }
 
 // DBClusterRole is an IAM role associated with an Aurora DB cluster (AWS RDS
@@ -642,6 +662,13 @@ type DatabaseConfig struct {
 	// from: a full ARM database resource ID (".../servers/{s}/databases/{d}")
 	// or a bare database name on the same server. Ignored for a Default create.
 	SourceDatabaseID string
+	// MaxSizeBytes / BackupStorageRedundancy / ReadScale are Azure SQL database
+	// inputs (properties.maxSizeBytes, requestedBackupStorageRedundancy,
+	// readScale). Zero/empty means the request omitted them, so the Azure SQL
+	// provider fills the documented default. Other providers leave them zero.
+	MaxSizeBytes            int64
+	BackupStorageRedundancy string
+	ReadScale               string
 }
 
 // Database is a logical database hosted by a managed server (Azure MySQL /
@@ -667,6 +694,14 @@ type Database struct {
 	// ElasticPoolID echoes the elastic pool this database belongs to on read
 	// (properties.elasticPoolId); empty for a standalone database.
 	ElasticPoolID string
+	// MaxSizeBytes / BackupStorageRedundancy / ReadScale echo Azure SQL database
+	// properties on read (maxSizeBytes, requestedBackupStorageRedundancy /
+	// currentBackupStorageRedundancy, readScale). Azure SQL only; zero/empty for
+	// AWS/GCP. Azure fills documented defaults (32 GB, "Geo", "Disabled") on a
+	// create that omits them, so a read round-trips like real Azure SQL.
+	MaxSizeBytes            int64
+	BackupStorageRedundancy string
+	ReadScale               string
 }
 
 // Databases is an OPTIONAL capability for managing the logical databases inside


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of the Azure SQL (`Microsoft.Sql`) control plane — `azurerm_mssql_server` + `azurerm_mssql_database` surface — driven through the real `azure-sdk-for-go/armsql` `ServersClient`/`DatabasesClient` over the wire handler (identical ARM wire). Found and fixed six genuine cloud-vs-cloudemu default divergences a SDK/CLI/Terraform user hits on a create-that-omits + read-back.

Real Azure fills documented defaults on create; cloudemu previously returned empty/absent values, so a Terraform refresh drifts (or a poller reads a resource that looks unconfigured).

## Findings (all fixed)

| # | Resource | Property | Before | After (real Azure) | Severity |
|---|----------|----------|--------|--------------------|----------|
| 1 | database | `collation` | absent | `SQL_Latin1_General_CP1_CI_AS` | High |
| 2 | database | `maxSizeBytes` | absent | `34359738368` (32 GB, GP default) | High |
| 3 | database | `requestedBackupStorageRedundancy` / `currentBackupStorageRedundancy` | absent | `Geo` | High |
| 4 | database | `readScale` | absent | `Disabled` | Medium |
| 5 | server | `minimalTlsVersion` | absent | `1.2` | High |
| 6 | server | `publicNetworkAccess` / `restrictOutboundNetworkAccess` | absent | `Enabled` / `Disabled` | High |

Values a request sets explicitly now round-trip create→get, and a PATCH updates only the fields it carries while preserving the rest (ARM partial-update semantics).

Already-correct behaviors verified in passing: server `version` (12.0), `state` (Ready), `fullyQualifiedDomainName` (`<srv>.database.windows.net`); database `status` (Online), `currentServiceObjectiveName`, `databaseId` (stable GUID), async LRO settle to Succeeded/Online, delete idempotency.

## Docs cited
- Azure REST — Databases CreateOrUpdate (defaults: collation `SQL_Latin1_General_CP1_CI_AS`, status `Online`, `readScale` `Disabled`, `zoneRedundant` `false`, `requestedBackupStorageRedundancy` `Geo`): https://learn.microsoft.com/en-us/rest/api/sql/databases/create-or-update
- Terraform `azurerm_mssql_database` — `storage_account_type` defaults to `Geo`.

## Changes
- `services/relationaldb/driver/driver.go` — additive Azure-SQL-only fields on `Cluster`/`ClusterConfig`/`ModifyInstanceInput` (TLS/public-network/outbound) and `Database`/`DatabaseConfig` (maxSizeBytes/backupRedundancy/readScale). Zero/empty for AWS/GCP.
- `providers/azure/sql/{sql.go,databases.go}` — apply documented defaults on create; carry fields through modify/update.
- `server/azure/sql/{types.go,operations.go}` — decode the new request props, echo them (plus `currentBackupStorageRedundancy`) on read, merge them on PATCH.
- `server/azure/sql/defaults_roundtrip_sdk_test.go` — armsql round-trip tests: defaults, explicit-set, and PATCH partial-update for both server and database.

## Filed, not fixed (out of control-plane scope)
- `properties.creationDate` is not modeled (armsql Get returns nil); real Azure returns a create timestamp. Low impact (not a Terraform drift attribute).
- No real SQL Server (TDS) data plane — the shared DatabaseEngine speaks only Postgres/MySQL. Known gap; control-plane only here.

## Gates
- `go build ./...` clean; `go vet` clean; `gofmt -l` clean.
- `go test -race -count=1` green: `providers/azure/sql/...`, `server/azure/sql/...`, `services/relationaldb/...`; root integration `go test .` and `persist/...` green; cross-provider RDS/Cloud SQL/MySQL-flex green (additive struct change).
- `golangci-lint --new-from-rev=origin/development` = 0 issues; full-package on changed packages introduces 0 new issues (2 gocyclo regressions refactored away; remaining 3 are pre-existing on unchanged functions).
- `go generate ./...` — no `docs/coverage` diff (struct fields don't change interface-derived docs).