### PR TITLE
fix(cloudfunctions): real-user e2e divergences from GCP

### DIFF
--- a/server/gcp/cloudfunctions/handler.go
+++ b/server/gcp/cloudfunctions/handler.go
@@ -72,6 +72,11 @@ const (
 	// gen1 defaults populated onto a v1 function's output-only metadata.
 	defaultIngress        = "ALLOW_ALL"
 	defaultDockerRegistry = "ARTIFACT_REGISTRY"
+	// gen1DefaultMemoryMb / gen1DefaultTimeoutSeconds are the values real gen1
+	// Cloud Functions assigns when create omits availableMemoryMb / timeout, so a
+	// client's Get reflects them (256MB, 60s) rather than a missing field.
+	gen1DefaultMemoryMb       = 256
+	gen1DefaultTimeoutSeconds = 60
 	// gen2ServiceAccountSuffix / gen1ServiceAccountSuffix are the default runtime
 	// service accounts real GCP assigns (compute default SA for gen2, App Engine
 	// default SA for gen1).
@@ -499,6 +504,8 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request, p functionPath)
 		Timeout:     parseTimeoutSeconds(body.Timeout),
 	}
 
+	applyGen1CreateDefaults(&cfg)
+
 	// A source deploy carries the code out-of-band. gen1 functions run under the
 	// functions-framework request/response contract with a bare entrypoint, which
 	// real Cloud Functions requires — reject a code deploy that omits it.
@@ -530,6 +537,20 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request, p functionPath)
 		Done:     true,
 		Response: resourceAsResponse(resource, "CloudFunction"),
 	})
+}
+
+// applyGen1CreateDefaults fills availableMemoryMb and timeout with the values
+// real gen1 Cloud Functions assigns (256MB, 60s) when the create omits them, so a
+// client's Get reads the same values it would from cloudfunctions.googleapis.com
+// rather than a missing field that surfaces as drift on a Terraform refresh.
+func applyGen1CreateDefaults(cfg *sdrv.FunctionConfig) {
+	if cfg.Memory == 0 {
+		cfg.Memory = gen1DefaultMemoryMb
+	}
+
+	if cfg.Timeout == 0 {
+		cfg.Timeout = gen1DefaultTimeoutSeconds
+	}
 }
 
 func (h *Handler) get(w http.ResponseWriter, r *http.Request, p functionPath) {

--- a/server/gcp/cloudfunctions/sdk_roundtrip_test.go
+++ b/server/gcp/cloudfunctions/sdk_roundtrip_test.go
@@ -115,6 +115,48 @@ func TestSDKCloudFunctionsCreateGetListDelete(t *testing.T) {
 	}
 }
 
+// TestSDKCloudFunctionsCreateDefaults verifies that a create which omits
+// availableMemoryMb and timeout reads back the values real gen1 Cloud Functions
+// assigns by default (256MB, 60s) rather than a missing field, which would show
+// up as drift on a Terraform refresh.
+func TestSDKCloudFunctionsCreateDefaults(t *testing.T) {
+	svc := newGCPSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+
+	op, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions.CloudFunction{
+		Name:         parent + "/functions/defaults",
+		Runtime:      "go121",
+		EntryPoint:   "Hello",
+		HttpsTrigger: &cloudfunctions.HttpsTrigger{},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if !op.Done {
+		t.Fatal("Create operation not done")
+	}
+
+	got, err := svc.Projects.Locations.Functions.Get(parent + "/functions/defaults").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.AvailableMemoryMb != 256 {
+		t.Fatalf("AvailableMemoryMb = %d, want default 256", got.AvailableMemoryMb)
+	}
+
+	if got.Timeout != "60s" {
+		t.Fatalf("Timeout = %q, want default 60s", got.Timeout)
+	}
+
+	if got.Status != "ACTIVE" {
+		t.Fatalf("Status = %q, want ACTIVE", got.Status)
+	}
+}
+
 func TestSDKCloudFunctionsCall(t *testing.T) {
 	cloud := cloudemu.NewGCP()
 	srv := gcpserver.New(gcpserver.Drivers{CloudFunctions: cloud.CloudFunctions})


### PR DESCRIPTION
## Summary

Real-user e2e audit of GCP Cloud Functions (Gen1, `google_cloudfunctions_function` / discovery client `google.golang.org/api/cloudfunctions/v1`) found one genuine cloud-vs-cloudemu divergence.

**Divergence — missing create-time defaults.** A create that omits `availableMemoryMb` and `timeout` stored 0 for both, so the v1 handler emitted neither field on Get/List (both are `omitempty`). Real gen1 Cloud Functions defaults `availableMemoryMb` to **256MB** and `timeout` to **60s** ([REST reference](https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions): "Defaults to 256MB." / "Defaults to 60 seconds."). A gcloud/SDK user relying on server defaults would see the fields absent, which surfaces as drift on a Terraform/refresh read.

## Fix

Apply the gen1 defaults (256 / 60s) at v1 create when the request omits them, mirroring what `ingressSettings` (ALLOW_ALL), `dockerRegistry` and `serviceAccountEmail` already do. Extracted `applyGen1CreateDefaults` to keep `create` under the gocyclo limit.

## Evidence

Live `cloudemu serve -gcp-port 4569 -providers=gcp`:

Before: create without memory/timeout → Get returns neither field.
After: create without memory/timeout → `availableMemoryMb=256`, `timeout=60s`, `status=ACTIVE`, `ingressSettings=ALLOW_ALL`. Explicit values still echo unchanged; a metadata-only PATCH preserves the defaulted timeout and bumps versionId.

Added `TestSDKCloudFunctionsCreateDefaults` (real `cloudfunctions/v1` SDK) asserting the 256/60s/ACTIVE round-trip.

## Verified clean (already correct, no change)
- Canonical `NOT_FOUND` on Get/Delete of a missing function (#1107)
- Delete of a missing function returns NOT_FOUND (matches real GCP; delete is not idempotent)
- Explicit memory/timeout echo; httpsTrigger.url format; versionId bump on update; deterministic list order

## Gates
- `go build ./...`, `go vet`, `gofmt -l` clean
- `go test -race -count=1 ./server/gcp/cloudfunctions/... ./providers/gcp/cloudfunctions/...` pass
- root `go test -run TestFunctionVersions .` pass
- `golangci-lint run` on changed package: 0 issues
- `go generate ./...`: no docs/coverage change (driver interfaces unchanged)