### PR TITLE
fix(route53): real-user e2e divergences from AWS

### DIFF
--- a/server/aws/route53/id_format_test.go
+++ b/server/aws/route53/id_format_test.go
@@ -1,0 +1,71 @@
+package route53_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
+)
+
+// TestSDKHostedZoneIDIsPrefixed pins the two halves of the AWS wire contract
+// that a regression could silently drop: HostedZone.Id carries the
+// "/hostedzone/" prefix (as real AWS returns), while the pagination
+// Marker/NextMarker stay bare (no prefix). Asserting the literal wire format
+// here is what makes the fix regression-proof — comparing the value against
+// itself would pass even if the prefix were removed.
+func TestSDKHostedZoneIDIsPrefixed(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	out, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+		Name:            aws.String("id-format.example.com."),
+		CallerReference: aws.String("id-format-ref-1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+
+	id := aws.ToString(out.HostedZone.Id)
+	if !strings.HasPrefix(id, "/hostedzone/") {
+		t.Errorf("HostedZone.Id = %q, want /hostedzone/ prefix (real AWS format)", id)
+	}
+	// The change id keeps its own /change/ prefix, not /hostedzone/.
+	if ci := aws.ToString(out.ChangeInfo.Id); strings.Contains(ci, "/hostedzone/") {
+		t.Errorf("ChangeInfo.Id = %q, must not carry /hostedzone/", ci)
+	}
+
+	if getOut, err := client.GetHostedZone(ctx, &awsr53.GetHostedZoneInput{Id: out.HostedZone.Id}); err != nil {
+		t.Errorf("GetHostedZone by prefixed id %q: %v", id, err)
+	} else if gid := aws.ToString(getOut.HostedZone.Id); !strings.HasPrefix(gid, "/hostedzone/") {
+		t.Errorf("GetHostedZone.Id = %q, want /hostedzone/ prefix", gid)
+	}
+}
+
+// TestSDKListHostedZonesMarkerIsBare pins that NextMarker is returned bare
+// (no /hostedzone/ prefix), matching the AWS ListHostedZones response.
+func TestSDKListHostedZonesMarkerIsBare(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	for _, n := range []string{"marker-a.example.com.", "marker-b.example.com."} {
+		if _, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+			Name:            aws.String(n),
+			CallerReference: aws.String("marker-ref-" + n),
+		}); err != nil {
+			t.Fatalf("CreateHostedZone %s: %v", n, err)
+		}
+	}
+
+	out, err := client.ListHostedZones(ctx, &awsr53.ListHostedZonesInput{MaxItems: aws.Int32(1)})
+	if err != nil {
+		t.Fatalf("ListHostedZones: %v", err)
+	}
+	if !out.IsTruncated {
+		t.Fatal("expected a truncated first page with MaxItems=1 and >1 zone")
+	}
+	if nm := aws.ToString(out.NextMarker); nm == "" || strings.Contains(nm, "/hostedzone/") {
+		t.Errorf("NextMarker = %q, want a bare zone id with no /hostedzone/ prefix", nm)
+	}
+}

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -190,7 +190,11 @@ func (h *Handler) listHostedZones(w http.ResponseWriter, r *http.Request) {
 
 	marker := r.URL.Query().Get("marker")
 	maxItems := parseMaxItems(r.URL.Query().Get("maxitems"))
-	page, next := markerPage(zones, marker, maxItems, func(z hostedZoneXML) string { return z.Id })
+	// Paginate on the bare zone id: HostedZone.Id now carries the "/hostedzone/"
+	// prefix, but ListHostedZones' Marker/NextMarker are bare zone ids (matching
+	// real Route 53 and the marker a client echoes back), so the paginator must
+	// key on the trimmed id.
+	page, next := markerPage(zones, marker, maxItems, func(z hostedZoneXML) string { return trimZonePrefix(z.Id) })
 
 	wire.WriteXML(w, http.StatusOK, listHostedZonesResponse{
 		Xmlns:       xmlns,

--- a/server/aws/route53/types.go
+++ b/server/aws/route53/types.go
@@ -299,15 +299,19 @@ func trimZonePrefix(id string) string {
 }
 
 // toHostedZoneXML converts a driver zone into its Route 53 element. The zone id
-// is returned bare (not "/hostedzone/{id}"): the SDK binds the id straight into
-// the request URL path with no prefix stripping, so echoing the bare driver id
-// keeps Get/Delete round-trips addressing the same resource.
+// is returned in real Route 53's "/hostedzone/{id}" form (matching
+// GetHostedZone/CreateHostedZone/ListHostedZones on the wire, and the
+// already-prefixed ChangeInfo.Id): a raw SDK/CLI caller reading HostedZone.Id
+// must see the same value AWS returns. Round-trips still work because the SDK's
+// Route53:SanitizeURL serialize middleware (and botocore's equivalent) strips the
+// "/hostedzone/" prefix from the id before binding it into the request path, and
+// trimZonePrefix strips it server-side for any client that does not.
 //
 // CallerReference is the caller-supplied idempotency token, persisted on create
 // and returned verbatim here so Get/List round-trip faithfully.
 func toHostedZoneXML(info *dnsdriver.ZoneInfo) hostedZoneXML {
 	return hostedZoneXML{
-		Id:              info.ID,
+		Id:              "/hostedzone/" + info.ID,
 		Name:            info.Name,
 		CallerReference: info.CallerReference,
 		Config: &hostedZoneConfigXML{

--- a/server/aws/route53/vpc_association_test.go
+++ b/server/aws/route53/vpc_association_test.go
@@ -4,12 +4,21 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
 	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 )
+
+// bareZoneID strips the "/hostedzone/" prefix that HostedZone.Id carries so a
+// self-resource id (Create/Get/List HostedZone.Id) can be compared to a
+// cross-reference id like HostedZoneSummary.HostedZoneId, which real Route 53
+// returns bare.
+func bareZoneID(id string) string {
+	return strings.TrimPrefix(id, "/hostedzone/")
+}
 
 // createPrivateZone creates a private hosted zone associated with one VPC and
 // returns its id.
@@ -285,9 +294,8 @@ func TestSDKListHostedZonesByVPC(t *testing.T) {
 		t.Fatalf("got %d summaries, want 1", len(out.HostedZoneSummaries))
 	}
 
-	if aws.ToString(out.HostedZoneSummaries[0].HostedZoneId) != shared {
-		t.Errorf("summary zone id = %q, want %q",
-			aws.ToString(out.HostedZoneSummaries[0].HostedZoneId), shared)
+	if got := aws.ToString(out.HostedZoneSummaries[0].HostedZoneId); got != bareZoneID(shared) {
+		t.Errorf("summary zone id = %q, want %q", got, bareZoneID(shared))
 	}
 
 	if out.HostedZoneSummaries[0].Owner == nil ||
@@ -309,7 +317,8 @@ func TestSDKListHostedZonesByVPCPaginates(t *testing.T) {
 	for i := range total {
 		id := createPrivateZone(t, client,
 			fmt.Sprintf("vpczone-%d.internal.", i), fmt.Sprintf("vpc-page-ref-%d", i), "vpc-page")
-		want[id] = 0
+		// The summaries carry the bare HostedZoneId; HostedZone.Id is prefixed.
+		want[bareZoneID(id)] = 0
 	}
 
 	got := make(map[string]int, total)


### PR DESCRIPTION
## Summary

Real-user e2e audit of AWS Route 53 (hosted zones + resource record sets) against the live AWS Route 53 REST/XML contract, exercised through the aws-sdk-go-v2 Route53 client, the AWS CLI, and Terraform (`aws_route53_zone` + `aws_route53_record`) pointed at `cloudemu serve`.

One genuine cloud-vs-cloudemu divergence was found and fixed.

## Divergence fixed

**`HostedZone.Id` was returned bare instead of `/hostedzone/{id}`.**

Real Route 53 returns `HostedZone.Id` in the `/hostedzone/Z...` form on `CreateHostedZone`, `GetHostedZone`, `ListHostedZones` and `ListHostedZonesByName` — consistent with the `ChangeInfo.Id` (`/change/C...`) the same handler already returned prefixed. cloudemu returned the bare `Z...`, so a raw SDK or CLI caller reading `HostedZone.Id` got a value that differs from AWS.

Round-trips were never the reason for the bare form: the aws-sdk-go-v2 `Route53:SanitizeURL` serialize middleware (and botocore's equivalent) strips the `/hostedzone/` prefix from the id before binding it into the request path, and the handler's own `trimZonePrefix` strips it server-side for any client that does not. The prior code comment asserting "the SDK binds the id straight into the request URL path with no prefix stripping" was incorrect.

`ListHostedZones` `Marker`/`NextMarker` remain bare zone ids (matching AWS and the marker a client echoes back); the paginator now keys on the trimmed id so the pagination contract is unchanged.

Two `ListHostedZonesByVPC` tests were updated: `HostedZoneSummary.HostedZoneId` is a cross-reference id that real Route 53 returns bare (like `AliasTarget.HostedZoneId`), so they now compare against the trimmed zone id rather than the now-prefixed `HostedZone.Id`.

## Live evidence

- **SDK / CLI**: `CreateHostedZone`/`GetHostedZone` now return `Id="/hostedzone/Z..."`; `ChangeResourceRecordSets`, UPSERT and DELETE round-trip with the prefixed id.
- **Wire**: `ListHostedZones?maxitems=1` returns `<Id>/hostedzone/Z...</Id>` with a bare `<NextMarker>Z...</NextMarker>`; marker resume verified.
- **Terraform**: full lifecycle clean — `apply` (zone + A/CNAME/TXT/MX records, `name_servers` read from the auto-created NS record), `plan` reports no drift, `destroy` removes everything.

## Audited and confirmed correct (no change needed)

Auto-created apex SOA + NS records on zone create (RRSetCount=2); NS/SOA list ordering; `ListResourceRecordSets` reversed-label DNS name ordering; error codes `NoSuchHostedZone` / `InvalidChangeBatch` / `HostedZoneNotEmpty` with correct HTTP status and clean XML (no code prefix leak); duplicate-CREATE, DELETE-nonexistent, apex-CNAME rejection; trailing-dot normalization; TXT/MX/multi-value round-trip; delete-not-empty guard.

## Gates

`go build ./...`; `go test -race` on `server/aws/route53`, `providers/aws/route53`, `services/dns`, and `server/aws`; scoped root DNS/topology tests; `go vet`; `gofmt -l`; `golangci-lint --new-from-rev=origin/development` (0 new issues); `go generate ./...` (no `docs/coverage` diff). All green.
