### PR TITLE
fix(gcp-vpc): real-user e2e divergences from GCP

### DIFF
--- a/server/gcp/vpc/handler.go
+++ b/server/gcp/vpc/handler.go
@@ -75,6 +75,12 @@ const (
 
 	defaultFirewallDirection = "INGRESS"
 	defaultFirewallPriority  = 1000
+
+	// A modern (non-legacy) GCP network always reads back a routing mode and an
+	// MTU: a network created without them defaults to REGIONAL dynamic routing
+	// and a 1460-byte MTU. These are the values compute.googleapis.com returns.
+	defaultRoutingMode       = "REGIONAL"
+	defaultNetworkMTU  int32 = 1460
 )
 
 // nowRFC3339 returns the current time formatted the way GCP stamps
@@ -1345,21 +1351,28 @@ func toNetworkResponse(info *netdriver.VPCInfo, rp gcprest.ResourcePath, host st
 		NetworkFirewallPolicyEnforcementOrder: fwPolicyOrderOr(info.Tags[netFwOrderTag]),
 	}
 
-	if rm := info.Tags[netRoutingModeTag]; rm != "" {
-		resp.RoutingConfig = &networkRoutingConfig{RoutingMode: rm}
+	// IPv4Range belongs only to a legacy network; a modern auto/custom network
+	// omits it (emitting it would wrongly read as legacy and conflict with
+	// autoCreateSubnetworks). Legacy networks predate routingConfig/mtu, so they
+	// carry neither; a modern network always reads back both, defaulting to
+	// REGIONAL routing and a 1460-byte MTU when the insert omitted them — real
+	// GCP always populates them, so omitting the default reads as a perpetual
+	// Terraform diff on routing_mode/mtu.
+	if info.Tags[legacyNetTag] == trueValue {
+		resp.IPv4Range = info.CIDRBlock
+		return resp
 	}
+
+	resp.RoutingConfig = &networkRoutingConfig{
+		RoutingMode: tagOr(info.Tags, netRoutingModeTag, defaultRoutingMode),
+	}
+
+	resp.Mtu = defaultNetworkMTU
 
 	if m := info.Tags[netMtuTag]; m != "" {
 		if v, err := strconv.ParseInt(m, 10, 32); err == nil {
 			resp.Mtu = int32(v)
 		}
-	}
-
-	// IPv4Range belongs only to a legacy network; a modern auto/custom network
-	// omits it (emitting it would wrongly read as legacy and conflict with
-	// autoCreateSubnetworks).
-	if info.Tags[legacyNetTag] == trueValue {
-		resp.IPv4Range = info.CIDRBlock
 	}
 
 	return resp

--- a/server/gcp/vpc/networks_test.go
+++ b/server/gcp/vpc/networks_test.go
@@ -157,6 +157,52 @@ func TestSDKNetworkRoutingModeMtuDescription(t *testing.T) {
 	}
 }
 
+// TestSDKNetworkDefaultRoutingModeMtu covers the divergence that a network
+// created without routingConfig/mtu read back with no routing mode and mtu=0.
+// Real compute.googleapis.com always returns routingConfig.routingMode=REGIONAL
+// and mtu=1460 for a modern network, so Terraform google_compute_network sees a
+// perpetual diff on routing_mode/mtu when the defaults are omitted.
+func TestSDKNetworkDefaultRoutingModeMtu(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewNetworksRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewNetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	op, err := client.Insert(ctx, &computepb.InsertNetworkRequest{
+		Project: testProject,
+		NetworkResource: &computepb.Network{
+			Name:                  ptrStr("net-def"),
+			AutoCreateSubnetworks: func() *bool { b := false; return &b }(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetNetworkRequest{Project: testProject, Network: "net-def"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetRoutingConfig().GetRoutingMode() != "REGIONAL" {
+		t.Errorf("routingMode=%q want REGIONAL (default)", got.GetRoutingConfig().GetRoutingMode())
+	}
+
+	if got.GetMtu() != 1460 {
+		t.Errorf("mtu=%d want 1460 (default)", got.GetMtu())
+	}
+}
+
 // TestSDKFirewallMissingNetworkRejected covers the MED finding that a firewall
 // referencing an unknown network fabricated a phantom VPC that then leaked into
 // networks.list. Real GCP rejects the insert with 404; no VPC is created.


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of the GCP VPC control plane (google_compute_network / subnetwork / firewall / route) against live GCP semantics, driven by the real `google.golang.org/api/compute/v1` client and Terraform.

Found and fixed one genuine divergence:

**Network `routingConfig.routingMode` and `mtu` defaults were dropped on read.** A modern (non-legacy) network created without `routingConfig`/`mtu` read back with no routing mode and `mtu=0`. Real compute.googleapis.com always returns `routingConfig.routingMode=REGIONAL` and `mtu=1460` for such a network, so Terraform `google_compute_network` saw a perpetual plan diff on `routing_mode`/`mtu`, and SDK callers read wrong values.

Fix: default both on read for non-legacy networks in `toNetworkResponse` (legacy IPv4Range networks predate both fields and stay unset). Explicitly-set values still round-trip; patch still preserves the untouched field.

## Evidence

Live SDK (`google.golang.org/api/compute/v1` against `cloudemu serve`):
- before: `mtu=0 routingMode=<nil>`
- after: `mtu=1460 routingMode=REGIONAL`; explicit GLOBAL/1500 round-trips; patch to GLOBAL keeps mtu default.

Terraform (`google_compute_network`+`subnetwork`+`firewall`): apply → `net_mtu=1460`, `net_routing_mode=REGIONAL`, `sn_gateway=10.20.0.1`; `terraform plan` after apply = **No changes** (perpetual diff eliminated); destroy clean.

Also verified correct (no change needed): firewall priority=1000/direction=INGRESS defaults + allow tcp round-trip, subnetwork gatewayAddress/purpose/stackType/fingerprint/privateIpGoogleAccess, deterministic list order, LRO Operation→DONE waiter (global for networks/firewalls, regional for subnets), network delete-in-use → 400 resourceInUseByAnotherResource.

## Docs
`go generate ./...` produced no docs/coverage diff (behavioral default fix, no capability change).

## Tests
Added `TestSDKNetworkDefaultRoutingModeMtu`. Gates green: build, vet, gofmt, `go test -race` (server/gcp/... + providers/gcp/vpc), `golangci-lint --new-from-rev=origin/development` 0 issues.