### PR TITLE
fix(azure-vnet): real-user e2e divergences from Azure

### DIFF
--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -150,7 +150,11 @@ func New(opts *config.Options) *Mock {
 // describeResources is a generic helper for Describe* methods that list or filter by IDs.
 func describeResources[T any, R any](store *memstore.Store[T], ids []string, toInfo func(T) R) []R {
 	if len(ids) == 0 {
-		all := store.All()
+		// SortedValues (not All) so list ordering is deterministic across
+		// identical calls: Go map iteration is random, and real ARM list
+		// endpoints return a stable order. This mirrors ListNetworkInterfaces,
+		// which already iterates SortedValues for the same reason.
+		all := store.SortedValues()
 		result := make([]R, 0, len(all))
 
 		for _, item := range all {

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -78,6 +78,19 @@ const (
 	// subnet is associated with (set via the subnet's own routeTable property),
 	// mirroring armSubnetNSGTag.
 	armSubnetRouteTableTag = "cloudemu:azureSubnetRouteTable"
+	// armSubnetPENPTag / armSubnetPLSNPTag store a subnet's
+	// privateEndpointNetworkPolicies / privateLinkServiceNetworkPolicies
+	// settings. Real ARM always reports both on a subnet GET, defaulting to
+	// Disabled / Enabled respectively when a create omits them (verified against
+	// the Subnets REST reference), so a subnet stored without either tag reports
+	// the default rather than a dropped field.
+	armSubnetPENPTag  = "cloudemu:azureSubnetPENP"
+	armSubnetPLSNPTag = "cloudemu:azureSubnetPLSNP"
+	// defaultPENP / defaultPLSNP are the ARM defaults for a subnet's
+	// privateEndpointNetworkPolicies / privateLinkServiceNetworkPolicies when a
+	// create omits them.
+	defaultPENP  = "Disabled"
+	defaultPLSNP = "Enabled"
 	// armRouteTableTag / armRouteTableRGTag record a route table's ARM name and
 	// resource group on its driver anchor so it is addressable by (rg, name), the
 	// same way armNSGTag / armNSGRGTag scope network security groups.
@@ -522,9 +535,12 @@ func (h *Handler) updateInlineSubnet(
 	nsgID := inlineRefID(sub.Properties.NetworkSecurityGroup)
 	routeTableID := inlineRefID(sub.Properties.RouteTable)
 
-	_, err := h.updateExistingSubnet(ctx, existing, cidr, natID, nsgID, routeTableID)
+	updated, err := h.updateExistingSubnet(ctx, existing, cidr, natID, nsgID, routeTableID)
+	if err != nil {
+		return err
+	}
 
-	return err
+	return h.applySubnetPolicies(ctx, updated, &sub.Properties)
 }
 
 // inlineRefID returns an armIDRef's id, or "" when the reference is nil (the
@@ -552,6 +568,14 @@ func inlineSubnetTags(sub *subnetRequest) map[string]string {
 
 	if sub.Properties.RouteTable != nil {
 		tags = mergeTags(tags, armSubnetRouteTableTag, sub.Properties.RouteTable.ID)
+	}
+
+	if sub.Properties.PrivateEndpointNetworkPolicies != "" {
+		tags = mergeTags(tags, armSubnetPENPTag, sub.Properties.PrivateEndpointNetworkPolicies)
+	}
+
+	if sub.Properties.PrivateLinkServiceNetworkPolicies != "" {
+		tags = mergeTags(tags, armSubnetPLSNPTag, sub.Properties.PrivateLinkServiceNetworkPolicies)
 	}
 
 	return tags
@@ -910,6 +934,11 @@ func (h *Handler) createSubnet(w http.ResponseWriter, r *http.Request, rp azurea
 		return
 	}
 
+	if err := h.applySubnetPolicies(r.Context(), info, &req.Properties); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
 	body := toSubnetResponse(info, rp)
 
 	writeAcceptedAsync(w, r, rp.Subscription, "subnet-create-"+rp.SubResourceName, body)
@@ -1072,6 +1101,19 @@ func (h *Handler) replaceSubnetAssociation(ctx context.Context, existing *netdri
 	existing.Tags = tagsWithout(existing.Tags, tagKey)
 
 	return nil
+}
+
+// applySubnetPolicies stores a subnet's privateEndpointNetworkPolicies /
+// privateLinkServiceNetworkPolicies from a PUT body with full-replace semantics:
+// an omitted value clears the tag so the response falls back to the ARM default
+// (Disabled / Enabled), matching SubnetsClient.BeginCreateOrUpdate. existing.Tags
+// is updated in place so a response built from it reflects the change.
+func (h *Handler) applySubnetPolicies(ctx context.Context, existing *netdriver.SubnetInfo, props *subnetRequestProps) error {
+	if err := h.replaceSubnetAssociation(ctx, existing, armSubnetPENPTag, props.PrivateEndpointNetworkPolicies); err != nil {
+		return err
+	}
+
+	return h.replaceSubnetAssociation(ctx, existing, armSubnetPLSNPTag, props.PrivateLinkServiceNetworkPolicies)
 }
 
 // tagsWithout returns a copy of in with key removed.
@@ -1790,8 +1832,10 @@ func toSubnetResponse(info *netdriver.SubnetInfo, rp azurearm.ResourcePath) subn
 		Name: name,
 		Etag: etagOf(id),
 		Properties: subnetResponseProps{
-			ProvisioningState: "Succeeded",
-			AddressPrefix:     info.CIDRBlock,
+			ProvisioningState:                 "Succeeded",
+			AddressPrefix:                     info.CIDRBlock,
+			PrivateEndpointNetworkPolicies:    tagOr(info.Tags, armSubnetPENPTag, defaultPENP),
+			PrivateLinkServiceNetworkPolicies: tagOr(info.Tags, armSubnetPLSNPTag, defaultPLSNP),
 		},
 	}
 

--- a/server/azure/vnet/list_order_determinism_test.go
+++ b/server/azure/vnet/list_order_determinism_test.go
@@ -1,0 +1,65 @@
+package vnet_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// TestSDKListOrderDeterministic confirms repeated identical LIST calls return
+// the virtual networks in the same order every time. Real ARM list endpoints
+// return a stable order; before the driver iterated SortedValues (not the
+// random-order map All()), each call reshuffled the result, which a Terraform
+// refresh or a paging client reads as spurious drift.
+func TestSDKListOrderDeterministic(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	client, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, n := range []string{"alpha", "bravo", "charlie", "delta", "echo", "foxtrot"} {
+		p, cerr := client.BeginCreateOrUpdate(ctx, "rg-1", n, armnetwork.VirtualNetwork{
+			Location: to.Ptr("eastus"),
+			Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+				AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+			},
+		}, nil)
+		if cerr != nil {
+			t.Fatalf("create %s: %v", n, cerr)
+		}
+
+		pollDone(t, p)
+	}
+
+	listOnce := func() []string {
+		var out []string
+
+		pager := client.NewListPager("rg-1", nil)
+		for pager.More() {
+			page, perr := pager.NextPage(ctx)
+			if perr != nil {
+				t.Fatalf("list: %v", perr)
+			}
+
+			for _, v := range page.Value {
+				out = append(out, *v.Name)
+			}
+		}
+
+		return out
+	}
+
+	first := fmt.Sprint(listOnce())
+
+	for i := 0; i < 20; i++ {
+		if got := fmt.Sprint(listOnce()); got != first {
+			t.Fatalf("LIST order nondeterministic: call0=%s callN=%s", first, got)
+		}
+	}
+}

--- a/server/azure/vnet/subnet_policy_defaults_test.go
+++ b/server/azure/vnet/subnet_policy_defaults_test.go
@@ -1,0 +1,162 @@
+package vnet_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// TestSDKSubnetNetworkPolicyDefaults confirms a subnet created without either
+// network-policy field reports the ARM defaults on GET —
+// privateEndpointNetworkPolicies=Disabled and
+// privateLinkServiceNetworkPolicies=Enabled (Subnets REST reference) — and that
+// explicit values round-trip and a subsequent PUT that omits them resets to the
+// defaults (full-replace CreateOrUpdate semantics).
+func TestSDKSubnetNetworkPolicyDefaults(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	vnets, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subnets, err := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vp, err := vnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-pol", armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pollDone(t, vp)
+
+	// Bare subnet, no policy fields set: GET must report the ARM defaults.
+	sp, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-pol", "bare", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.0/24")},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pollDone(t, sp)
+
+	assertPolicies(t, subnets, "bare",
+		armnetwork.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled,
+		armnetwork.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled)
+
+	// Explicit values round-trip.
+	sp2, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-pol", "explicit", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix:                     to.Ptr("10.0.2.0/24"),
+			PrivateEndpointNetworkPolicies:    to.Ptr(armnetwork.VirtualNetworkPrivateEndpointNetworkPoliciesEnabled),
+			PrivateLinkServiceNetworkPolicies: to.Ptr(armnetwork.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pollDone(t, sp2)
+
+	assertPolicies(t, subnets, "explicit",
+		armnetwork.VirtualNetworkPrivateEndpointNetworkPoliciesEnabled,
+		armnetwork.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled)
+
+	// A follow-up PUT that omits the fields resets to defaults (full replace).
+	sp3, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-pol", "explicit", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.2.0/24")},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pollDone(t, sp3)
+
+	assertPolicies(t, subnets, "explicit",
+		armnetwork.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled,
+		armnetwork.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled)
+}
+
+// TestSDKInlineSubnetPolicyDefaults confirms an inline subnet (created through a
+// vnet PUT, a distinct code path from the standalone SubnetsClient) also reports
+// the ARM network-policy defaults on the vnet GET.
+func TestSDKInlineSubnetPolicyDefaults(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	vnets, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vp, err := vnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-inline-pol", armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+			Subnets: []*armnetwork.Subnet{{
+				Name:       to.Ptr("inline"),
+				Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefix: to.Ptr("10.0.1.0/24")},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pollDone(t, vp)
+
+	got, err := vnets.Get(ctx, "rg-1", "vnet-inline-pol", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got.Properties.Subnets) != 1 {
+		t.Fatalf("want 1 inline subnet, got %d", len(got.Properties.Subnets))
+	}
+
+	p := got.Properties.Subnets[0].Properties
+	if p == nil || p.PrivateEndpointNetworkPolicies == nil ||
+		*p.PrivateEndpointNetworkPolicies != armnetwork.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled {
+		t.Errorf("inline privateEndpointNetworkPolicies = %v, want Disabled", policyOf(subPolicy(p)))
+	}
+
+	if p == nil || p.PrivateLinkServiceNetworkPolicies == nil ||
+		*p.PrivateLinkServiceNetworkPolicies != armnetwork.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled {
+		t.Errorf("inline privateLinkServiceNetworkPolicies = %v, want Enabled", p.PrivateLinkServiceNetworkPolicies)
+	}
+}
+
+func assertPolicies(
+	t *testing.T, subnets *armnetwork.SubnetsClient, name string,
+	wantPENP armnetwork.VirtualNetworkPrivateEndpointNetworkPolicies,
+	wantPLSNP armnetwork.VirtualNetworkPrivateLinkServiceNetworkPolicies,
+) {
+	t.Helper()
+
+	got, err := subnets.Get(context.Background(), "rg-1", "vnet-pol", name, nil)
+	if err != nil {
+		t.Fatalf("get %s: %v", name, err)
+	}
+
+	if got.Properties == nil || got.Properties.PrivateEndpointNetworkPolicies == nil ||
+		*got.Properties.PrivateEndpointNetworkPolicies != wantPENP {
+		t.Errorf("%s privateEndpointNetworkPolicies = %v, want %v",
+			name, policyOf(subPolicy(got.Properties)), wantPENP)
+	}
+
+	if got.Properties == nil || got.Properties.PrivateLinkServiceNetworkPolicies == nil ||
+		*got.Properties.PrivateLinkServiceNetworkPolicies != wantPLSNP {
+		t.Errorf("%s privateLinkServiceNetworkPolicies = %v, want %v",
+			name, got.Properties.PrivateLinkServiceNetworkPolicies, wantPLSNP)
+	}
+}

--- a/server/azure/vnet/types.go
+++ b/server/azure/vnet/types.go
@@ -46,10 +46,12 @@ type subnetRequest struct {
 }
 
 type subnetRequestProps struct {
-	AddressPrefix        string    `json:"addressPrefix,omitempty"`
-	NatGateway           *armIDRef `json:"natGateway,omitempty"`
-	NetworkSecurityGroup *armIDRef `json:"networkSecurityGroup,omitempty"`
-	RouteTable           *armIDRef `json:"routeTable,omitempty"`
+	AddressPrefix                     string    `json:"addressPrefix,omitempty"`
+	NatGateway                        *armIDRef `json:"natGateway,omitempty"`
+	NetworkSecurityGroup              *armIDRef `json:"networkSecurityGroup,omitempty"`
+	RouteTable                        *armIDRef `json:"routeTable,omitempty"`
+	PrivateEndpointNetworkPolicies    string    `json:"privateEndpointNetworkPolicies,omitempty"`
+	PrivateLinkServiceNetworkPolicies string    `json:"privateLinkServiceNetworkPolicies,omitempty"`
 }
 
 type subnetResponse struct {
@@ -60,11 +62,13 @@ type subnetResponse struct {
 }
 
 type subnetResponseProps struct {
-	ProvisioningState    string    `json:"provisioningState"`
-	AddressPrefix        string    `json:"addressPrefix,omitempty"`
-	NatGateway           *armIDRef `json:"natGateway,omitempty"`
-	NetworkSecurityGroup *armIDRef `json:"networkSecurityGroup,omitempty"`
-	RouteTable           *armIDRef `json:"routeTable,omitempty"`
+	ProvisioningState                 string    `json:"provisioningState"`
+	AddressPrefix                     string    `json:"addressPrefix,omitempty"`
+	NatGateway                        *armIDRef `json:"natGateway,omitempty"`
+	NetworkSecurityGroup              *armIDRef `json:"networkSecurityGroup,omitempty"`
+	RouteTable                        *armIDRef `json:"routeTable,omitempty"`
+	PrivateEndpointNetworkPolicies    string    `json:"privateEndpointNetworkPolicies,omitempty"`
+	PrivateLinkServiceNetworkPolicies string    `json:"privateLinkServiceNetworkPolicies,omitempty"`
 }
 
 type subnetListResponse struct {


### PR DESCRIPTION
## Summary

Real-user e2e audit of the Azure `Microsoft.Network` control plane (virtualNetworks, subnets, networkSecurityGroups, publicIPAddresses, networkInterfaces), driven by real `azure-sdk-for-go/armnetwork` clients against the in-process wire server. Two genuine cloud-vs-cloudemu divergences a real SDK/CLI/Terraform user hits, both fixed.

### 1. Non-deterministic list ordering (drift)

`describeResources` in the Azure networking driver iterated `store.All()` (a Go map), so identical repeated `LIST` calls returned resources in a different order each time. Real ARM list endpoints return a stable order; the churn reads as spurious drift on a Terraform refresh or a paging client, and is exactly what `memstore.SortedValues` (already used by `ListNetworkInterfaces`, with a doc comment mandating it for list endpoints) exists to prevent.

Fix: iterate `SortedValues()` instead of `All()`. One line, at the single shared helper — covers virtual networks, subnets, NSGs, public IPs, NAT gateways, route tables, peerings and the other networking Describe methods.

Repro (before): `LIST` returned `[charlie delta echo foxtrot alpha bravo]` then `[bravo charlie delta echo foxtrot alpha]` across identical calls. After: stable across 20 calls.

### 2. Subnet network-policy defaults dropped

A subnet `GET` omitted `privateEndpointNetworkPolicies` and `privateLinkServiceNetworkPolicies` when a create did not set them. Real ARM always reports both, defaulting to `Disabled` and `Enabled` respectively (Subnets REST reference). Terraform `azurerm_subnet` reads both back; a missing value is drift.

Fix: model both fields end to end — parsed from the PUT body, stored per-subnet, and emitted with the ARM defaults — across the standalone `SubnetsClient` path and the inline (vnet PUT) path, for both create and update, with full-replace `CreateOrUpdate` semantics (an omitted value on a later PUT resets to the default). User-sent values still round-trip (previously served by the echo overlay; now modeled by the handler).

## Docs citations

- Subnets - Get (REST, api-version 2025-07-01): `privateEndpointNetworkPolicies` default **Disabled**, `privateLinkServiceNetworkPolicies` default **Enabled**.

## Tests

- `list_order_determinism_test.go` — real `VirtualNetworksClient` LIST stable across 20 identical calls.
- `subnet_policy_defaults_test.go` — bare subnet reports the defaults; explicit values round-trip; a later PUT omitting them resets to defaults; inline (vnet PUT) subnet also reports the defaults.

## Gates

- `go build ./...` — clean
- `go test ./server/azure/...` (full, incl. echo-overlay suite) — pass
- `go test -race -count=1 ./providers/azure/vnet/... ./server/azure/vnet/...` — pass
- `go test ./services/networking/... ./features/topology/... ./persist/... ./seed/... ./compat/azure/...` and root integration — pass
- `go vet`, `gofmt -l` — clean
- `golangci-lint run --new-from-rev=origin/development` — 0 issues
- `go generate ./...` — no `docs/coverage` diff (no driver interface change)

## Audited clean (no divergence found)

vnet/NSG/publicIP `provisioningState=Succeeded`, addressSpace round-trip, LRO async completion, NSG 6 default rules, weak ETags, RG/subscription scoping, in-use delete guards (subnet/NSG/publicIP/vnet), idempotent PUT, subnet cascade on vnet delete, inline vs standalone subnet consistency, tags-replace PATCH — all already correct.
