### PR TITLE
fix(s3): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -30,6 +30,9 @@ const (
 	s3DefaultMaxKeys       = 1000
 	s3TimeFormat           = "2006-01-02T15:04:05Z"
 	hoursPerDay            = 24
+	// s3DefaultContentType is the Content-Type S3 assigns when a CopyObject with
+	// REPLACE metadata supplies none. Real S3 uses "binary/octet-stream".
+	s3DefaultContentType = "binary/octet-stream"
 )
 
 var (
@@ -1095,7 +1098,7 @@ func (m *Mock) CopyObjectV2(ctx context.Context, req *driver.CopyObjectRequest) 
 		contentType = req.ContentType
 
 		if contentType == "" {
-			contentType = "application/octet-stream"
+			contentType = s3DefaultContentType
 		}
 	}
 

--- a/server/aws/s3/fidelity_test.go
+++ b/server/aws/s3/fidelity_test.go
@@ -19,6 +19,53 @@ import (
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
 )
 
+// TestDefaultContentType verifies an object uploaded with no Content-Type header
+// is stored and returned as "binary/octet-stream" — the default real S3 assigns
+// (not "application/octet-stream"). aws-cli and other clients send no
+// Content-Type on PutObject, so the server default is what a real user reads
+// back on GetObject/HeadObject.
+func TestDefaultContentType(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{S3: cloud.S3})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	if req, err := http.NewRequest(http.MethodPut, ts.URL+"/ct-bucket", nil); err == nil {
+		if _, err = http.DefaultClient.Do(req); err != nil {
+			t.Fatalf("CreateBucket: %v", err)
+		}
+	} else {
+		t.Fatalf("new create-bucket request: %v", err)
+	}
+
+	// PutObject with the Content-Type header explicitly removed so the server's
+	// default applies (Go's http.Client would otherwise not add one anyway).
+	putReq, err := http.NewRequest(http.MethodPut, ts.URL+"/ct-bucket/obj", strings.NewReader("payload"))
+	if err != nil {
+		t.Fatalf("new put request: %v", err)
+	}
+	putReq.Header.Del("Content-Type")
+
+	putResp, err := http.DefaultClient.Do(putReq)
+	if err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+	_ = putResp.Body.Close()
+	if putResp.StatusCode != http.StatusOK {
+		t.Fatalf("PutObject status = %d, want 200", putResp.StatusCode)
+	}
+
+	headResp, err := http.DefaultClient.Head(ts.URL + "/ct-bucket/obj")
+	if err != nil {
+		t.Fatalf("HeadObject: %v", err)
+	}
+	_ = headResp.Body.Close()
+
+	if got := headResp.Header.Get("Content-Type"); got != "binary/octet-stream" {
+		t.Fatalf("default Content-Type = %q, want %q", got, "binary/octet-stream")
+	}
+}
+
 // TestSDKListParts covers #266: ListParts now reports the parts buffered so
 // far (ordered by part number) instead of an empty list, so resumable-upload
 // tooling can reconstruct its state.

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -37,6 +37,10 @@ const (
 	// storageClassStandard is S3's default storage class; it is never emitted in
 	// the x-amz-storage-class response header (real S3 omits it for STANDARD).
 	storageClassStandard = "STANDARD"
+	// defaultContentType is the Content-Type S3 assigns to an object uploaded
+	// without one. Real S3 uses "binary/octet-stream" (not the more common
+	// "application/octet-stream"), and returns it on GET/HeadObject.
+	defaultContentType = "binary/octet-stream"
 )
 
 // Handler serves S3 REST requests against a storage.Bucket driver.
@@ -653,7 +657,7 @@ func (h *Handler) putObject(w http.ResponseWriter, r *http.Request, bucket, key 
 
 	contentType := r.Header.Get("Content-Type")
 	if contentType == "" {
-		contentType = "application/octet-stream"
+		contentType = defaultContentType
 	}
 
 	metadata := extractMetadata(r.Header)
@@ -1748,7 +1752,7 @@ type multipartTagger interface {
 func (h *Handler) createMultipartUpload(w http.ResponseWriter, r *http.Request, bucket, key string) {
 	contentType := r.Header.Get("Content-Type")
 	if contentType == "" {
-		contentType = "application/octet-stream"
+		contentType = defaultContentType
 	}
 
 	mp, err := h.beginMultipartUpload(r, bucket, key, contentType)


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of AWS S3 (SDK + aws-cli + Terraform against `cloudemu serve`) surfaced one genuine cloud-vs-cloudemu divergence, fixed here.

### Fix: default object Content-Type

Real S3 assigns **`binary/octet-stream`** (not `application/octet-stream`) to an object uploaded without a `Content-Type`, and returns it on GET/HeadObject. `aws s3api put-object` (botocore) and `aws_s3_object` (without `content_type`) both send no Content-Type, so a real user reads back `binary/octet-stream`.

Corrected the three emulation points:
- `putObject` (single PUT) — `server/aws/s3/handler.go`
- `createMultipartUpload` — `server/aws/s3/handler.go`
- `CopyObject` with REPLACE metadata directive — `providers/aws/s3/s3.go`

Added `TestDefaultContentType` (raw HTTP PUT with no Content-Type → Head returns `binary/octet-stream`). Scoped to AWS S3 only — GCS/Azure blob legitimately default to `application/octet-stream` and are untouched.

## Verified correct (no change needed)

Live evidence via aws-cli + curl + Terraform 1.14 (AWS provider v5):

- **ETag** — PutObject/Get/Head/List return quoted MD5 hex; **multipart ETag = `md5(concat of part MD5s)`-`<partcount>`** matched a computed reference exactly.
- **GetBucketLocation** — us-east-1 returns empty `LocationConstraint` (null); eu-west-1 returns `eu-west-1`.
- **Versioning** — Status round-trip, VersionId assignment, delete markers, IsLatest transitions, versioned GET/DELETE.
- **Sub-config round-trips** — versioning / acl / cors / lifecycle / encryption / public_access_block / policy all persist and read back; correct not-configured error codes (NoSuchBucketPolicy, NoSuchCORSConfiguration, etc.).
- **Terraform no-drift** — full `aws_s3_bucket` + all split sub-config resources apply, and a follow-up `terraform plan` reports **"No changes"** (zero perpetual drift).
- ListObjectsV2 lexicographic sort + CommonPrefixes + pagination, ListBuckets name-sorted, clean `<Error><Code>` XML with correct HTTP status, BucketNotEmpty guard, Range/conditional GET, tagging, CopyObject, storage-class round-trip.

## Gates

- `go build ./...`, `go test -race` (server/aws/s3, providers/aws/s3, services/storage), `go vet`, `gofmt` — all green.
- `golangci-lint --new-from-rev=origin/development` on changed packages: 0 new issues.
- `go generate ./...` — no `docs/coverage` diff (no driver-interface change).
