### PR TITLE
fix(azure-monitor): real-user e2e divergences from Azure

### DIFF
--- a/server/azure/monitor/handler.go
+++ b/server/azure/monitor/handler.go
@@ -129,7 +129,7 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azu
 
 	res := &armResource{Location: req.Location, Tags: req.Tags, Properties: req.Properties}
 	if kind == typeAlerts {
-		res.Properties = withProvisioningState(res.Properties)
+		res.Properties = withMetricAlertDefaults(res.Properties)
 	}
 
 	if err := h.applySideEffects(r, rp, kind, res.Properties); err != nil {
@@ -240,7 +240,7 @@ func (h *Handler) patch(w http.ResponseWriter, r *http.Request, rp *azurearm.Res
 
 	merged := mergeResource(existing, &req)
 	if kind == typeAlerts {
-		merged.Properties = withProvisioningState(merged.Properties)
+		merged.Properties = withMetricAlertDefaults(merged.Properties)
 	}
 
 	if err := h.applySideEffects(r, rp, kind, merged.Properties); err != nil {

--- a/server/azure/monitor/resources_test.go
+++ b/server/azure/monitor/resources_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -121,6 +122,42 @@ func TestMetricAlertPersistence(t *testing.T) {
 
 	if tags, _ := got["tags"].(map[string]any); tags["team"] != "sre" {
 		t.Errorf("tags dropped: %+v", got["tags"])
+	}
+}
+
+// TestMetricAlertAutoMitigateDefaultsTrue covers the missing-default finding: a
+// metricAlert created without autoMitigate must read back autoMitigate=true, the
+// documented Azure default (Metric Alerts - Create Or Update returns
+// "autoMitigate": true when the request omits it), not an absent field. An
+// explicit false must be preserved.
+func TestMetricAlertAutoMitigateDefaultsTrue(t *testing.T) {
+	ts, _ := newMonitorServer(t)
+
+	base := `{"location":"global","properties":{"severity":3,"enabled":true,
+		"scopes":["/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines/vm1"],
+		"windowSize":"PT5M","criteria":{"allOf":[{"metricName":"Percentage CPU","operator":"GreaterThan",
+		"threshold":80,"timeAggregation":"Average"}]}%s}}`
+
+	// Omitted autoMitigate -> defaults to true on both the PUT response and a
+	// subsequent GET.
+	omitURL := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Insights/metricAlerts/am-default" + apiVer
+
+	_, put := doJSON(t, ts, http.MethodPut, omitURL, fmt.Sprintf(base, ""))
+	if props, _ := put["properties"].(map[string]any); props["autoMitigate"] != true {
+		t.Fatalf("PUT autoMitigate = %v, want true (default not applied)", put["properties"])
+	}
+
+	_, got := doJSON(t, ts, http.MethodGet, omitURL, "")
+	if props, _ := got["properties"].(map[string]any); props["autoMitigate"] != true {
+		t.Fatalf("GET autoMitigate = %v, want true (default not persisted)", got["properties"])
+	}
+
+	// Explicit autoMitigate:false is preserved, not overwritten by the default.
+	falseURL := "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Insights/metricAlerts/am-false" + apiVer
+
+	_, putFalse := doJSON(t, ts, http.MethodPut, falseURL, fmt.Sprintf(base, `,"autoMitigate":false`))
+	if props, _ := putFalse["properties"].(map[string]any); props["autoMitigate"] != false {
+		t.Fatalf("explicit autoMitigate:false = %v, want false (default clobbered it)", putFalse["properties"])
 	}
 }
 

--- a/server/azure/monitor/types.go
+++ b/server/azure/monitor/types.go
@@ -49,16 +49,27 @@ func toResourceJSON(rp *azurearm.ResourcePath, kind string, res *armResource) re
 	}
 }
 
-// withProvisioningState injects a terminal provisioningState into a metric
-// alert's properties (real metricAlerts carry provisioningState=Succeeded), so a
-// state-refresh read sees a settled resource.
-func withProvisioningState(props map[string]any) map[string]any {
+// withMetricAlertDefaults injects the server-applied defaults a real metric
+// alert carries into its properties when the caller omitted them, so a
+// state-refresh read sees the same settled resource Azure returns:
+//   - provisioningState=Succeeded (a metricAlert create is synchronous), so a
+//     refresh sees a terminal state.
+//   - autoMitigate=true — the documented default for a metricAlert whose request
+//     omits it (Metric Alerts - Create Or Update returns "autoMitigate": true).
+//     A raw armmonitor client that never set AutoMitigate reads it back as true
+//     against real Azure, so the emulator must apply the same default rather than
+//     leaving the field absent (nil).
+func withMetricAlertDefaults(props map[string]any) map[string]any {
 	if props == nil {
 		props = map[string]any{}
 	}
 
 	if _, ok := props["provisioningState"]; !ok {
 		props["provisioningState"] = "Succeeded"
+	}
+
+	if _, ok := props["autoMitigate"]; !ok {
+		props["autoMitigate"] = true
 	}
 
 	return props


### PR DESCRIPTION
## Summary

Real-user e2e audit of Azure Monitor (Microsoft.Insights) against the official ARM REST reference and a live `cloudemu serve` + raw ARM client. Fixes one genuine cloud-vs-cloudemu divergence found.

## Divergence fixed

**`metricAlerts` drop the `autoMitigate` default.** A metric alert created without `autoMitigate` was echoed back with the field absent. Real Azure applies the documented default and returns `"autoMitigate": true` (Metric Alerts - Create Or Update). A raw armmonitor client that never set `AutoMitigate` reads it back as `true` against Azure but `nil` against the emulator.

The wire handler now injects `autoMitigate=true` for metric alerts when the caller omits it (alongside the existing `provisioningState` default), on both `PUT` and `PATCH`. An explicit `autoMitigate:false` is preserved.

## Evidence (live `cloudemu serve`, raw ARM PUT)

- Before: `PUT metricAlerts/... {…no autoMitigate…}` -> response omits `autoMitigate`.
- After: omit -> `autoMitigate=true`, `provisioningState=Succeeded`; explicit `false` -> `autoMitigate=false` (preserved).

Docs: Metric Alerts - Create Or Update REST reference (`autoMitigate` default `true`, returned in the response).

## Audit scope (no other divergences fixed)

Reviewed metricAlerts / actionGroups / activityLogAlerts / autoscaleSettings CRUD, diagnosticSettings, the metrics data API, and Activity Log. These were already correct: 200-on-create for metricAlerts (armmonitor only accepts 200), full property round-trip, resource-group/subscription-scoped store, deterministic list order, idempotent (204) delete, action-group reference validation and in-use delete guard, PATCH tags-replace semantics, and per-resource metrics isolation. Minor cosmetic differences left as-is because no SDK/Terraform user reads them (email/sms receiver `status: Enabled` normalization; hardcoded metric `unit: Count`; response `cost` field) — the armmonitor SDK tolerates their absence and neither azurerm resource tracks them.

## Tests

`TestMetricAlertAutoMitigateDefaultsTrue` covers omit->true (PUT + GET) and explicit-false preservation.

Gates: `go build ./...`; `go test -race` scoped monitor packages; full `go test ./server/azure/...`; `go vet`; `gofmt`; `golangci-lint` (new-from-rev + full-package, 0 issues); `go generate ./...` (no docs/coverage change).
