### PR TITLE
fix(apigateway): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/apigateway/apigateway.go
+++ b/providers/aws/apigateway/apigateway.go
@@ -29,6 +29,11 @@ const idLen = 10
 // idAlphabet is the character set REST API ids draw from.
 const idAlphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
 
+// defaultIntegrationTimeoutMillis is the integration timeout API Gateway applies
+// when PutIntegration omits timeoutInMillis (29 seconds), returned verbatim by
+// GetIntegration so clients (e.g. Terraform) see no drift.
+const defaultIntegrationTimeoutMillis = 29000
+
 // LambdaInvoker is the cross-service seam API Gateway uses to invoke a Lambda
 // function synchronously for an AWS_PROXY/AWS integration. It is deliberately
 // the recursion-guarded InvokeSync shape (same as the Step Functions
@@ -170,6 +175,15 @@ func (m *Mock) DeleteRestAPI(_ context.Context, id string) error {
 // orDefault returns v when non-empty, else def.
 func orDefault(v, def string) string {
 	if v == "" {
+		return def
+	}
+
+	return v
+}
+
+// orDefaultInt returns v when non-zero, else def.
+func orDefaultInt(v, def int) int {
+	if v == 0 {
 		return def
 	}
 

--- a/providers/aws/apigateway/apigateway_test.go
+++ b/providers/aws/apigateway/apigateway_test.go
@@ -155,6 +155,47 @@ func TestPutGetMethodAndIntegration(t *testing.T) {
 	if ig.URI != lambdaURI {
 		t.Fatalf("unexpected integration uri: %s", ig.URI)
 	}
+
+	// PutIntegration omitted timeoutInMillis, so it defaults to the AWS 29s
+	// value and round-trips through GetIntegration (no Terraform drift).
+	const defaultTimeout = 29000
+	if ig.TimeoutInMillis != defaultTimeout {
+		t.Fatalf("default timeout = %d, want %d", ig.TimeoutInMillis, defaultTimeout)
+	}
+}
+
+// TestPutIntegrationCustomTimeout proves an explicit timeoutInMillis is stored
+// verbatim rather than being overridden by the default.
+func TestPutIntegrationCustomTimeout(t *testing.T) {
+	m := newMock(t)
+	api, _ := m.CreateRestAPI(ctx(), &driver.CreateRestAPIInput{Name: "t"})
+	res, _ := m.CreateResource(ctx(), api.ID, api.RootResourceID, "x")
+
+	if _, err := m.PutMethod(ctx(), api.ID, res.ID, "GET", driver.PutMethodInput{}); err != nil {
+		t.Fatalf("PutMethod: %v", err)
+	}
+
+	const custom = 5000
+
+	ig, err := m.PutIntegration(ctx(), api.ID, res.ID, "GET", driver.PutIntegrationInput{
+		Type: driver.IntegrationMock, TimeoutInMillis: custom,
+	})
+	if err != nil {
+		t.Fatalf("PutIntegration: %v", err)
+	}
+
+	if ig.TimeoutInMillis != custom {
+		t.Fatalf("PutIntegration timeout = %d, want %d", ig.TimeoutInMillis, custom)
+	}
+
+	got, err := m.GetIntegration(ctx(), api.ID, res.ID, "GET")
+	if err != nil {
+		t.Fatalf("GetIntegration: %v", err)
+	}
+
+	if got.TimeoutInMillis != custom {
+		t.Fatalf("GetIntegration timeout = %d, want %d", got.TimeoutInMillis, custom)
+	}
 }
 
 func TestCreateDeploymentAutoCreatesStage(t *testing.T) {

--- a/providers/aws/apigateway/methods.go
+++ b/providers/aws/apigateway/methods.go
@@ -111,6 +111,7 @@ func (m *Mock) PutIntegration(
 		IntegrationHTTPMethod: in.IntegrationHTTPMethod,
 		URI:                   in.URI,
 		PassthroughBehavior:   orDefault(in.PassthroughBehavior, "WHEN_NO_MATCH"),
+		TimeoutInMillis:       orDefaultInt(in.TimeoutInMillis, defaultIntegrationTimeoutMillis),
 	}
 	mth.Integration = ig
 

--- a/server/aws/apigateway/apigateway_e2e_test.go
+++ b/server/aws/apigateway/apigateway_e2e_test.go
@@ -222,7 +222,13 @@ func TestE2E_DeleteLifecycle(t *testing.T) {
 	resID, _ := res["id"].(string)
 
 	doJSON(t, http.MethodPut, base+"/restapis/"+apiID+"/resources/"+resID+"/methods/GET", `{"authorizationType":"NONE"}`)
-	doJSON(t, http.MethodPut, base+"/restapis/"+apiID+"/resources/"+resID+"/methods/GET/integration", `{"type":"MOCK"}`)
+
+	ig := doJSON(t, http.MethodPut, base+"/restapis/"+apiID+"/resources/"+resID+"/methods/GET/integration", `{"type":"MOCK"}`)
+	// PutIntegration without timeoutInMillis defaults to AWS's 29s and returns
+	// it on the wire, so a Terraform refresh sees no drift on that attribute.
+	if to, _ := ig["timeoutInMillis"].(float64); to != 29000 {
+		t.Fatalf("integration timeoutInMillis = %v, want 29000", ig["timeoutInMillis"])
+	}
 
 	dep := doJSON(t, http.MethodPost, base+"/restapis/"+apiID+"/deployments", `{"stageName":"prod"}`)
 	depID, _ := dep["id"].(string)

--- a/server/aws/apigateway/handler.go
+++ b/server/aws/apigateway/handler.go
@@ -356,6 +356,7 @@ func (h *Handler) serveIntegration(w http.ResponseWriter, r *http.Request, segs 
 		ig, err := h.ag.PutIntegration(r.Context(), id, resourceID, httpMethod, driver.PutIntegrationInput{
 			Type: req.Type, IntegrationHTTPMethod: req.IntegrationHTTPMethod,
 			URI: req.URI, PassthroughBehavior: req.PassthroughBehavior,
+			TimeoutInMillis: req.TimeoutInMillis,
 		})
 		if err != nil {
 			writeErr(w, err)

--- a/server/aws/apigateway/types.go
+++ b/server/aws/apigateway/types.go
@@ -34,6 +34,7 @@ type putIntegrationRequest struct {
 	IntegrationHTTPMethod string `json:"integrationHttpMethod"`
 	URI                   string `json:"uri"`
 	PassthroughBehavior   string `json:"passthroughBehavior"`
+	TimeoutInMillis       int    `json:"timeoutInMillis"`
 }
 
 // createDeploymentRequest is the CreateDeployment request body.
@@ -97,6 +98,7 @@ type integrationResponse struct {
 	HTTPMethod          string `json:"httpMethod,omitempty"`
 	URI                 string `json:"uri,omitempty"`
 	PassthroughBehavior string `json:"passthroughBehavior,omitempty"`
+	TimeoutInMillis     int    `json:"timeoutInMillis,omitempty"`
 }
 
 // deploymentResponse is the Deployment wire object.
@@ -169,6 +171,7 @@ func toIntegrationResponse(ig *driver.Integration) integrationResponse {
 	return integrationResponse{
 		Type: ig.Type, HTTPMethod: ig.IntegrationHTTPMethod,
 		URI: ig.URI, PassthroughBehavior: ig.PassthroughBehavior,
+		TimeoutInMillis: ig.TimeoutInMillis,
 	}
 }
 

--- a/services/apigateway/driver/driver.go
+++ b/services/apigateway/driver/driver.go
@@ -70,6 +70,7 @@ type Integration struct {
 	IntegrationHTTPMethod string
 	URI                   string
 	PassthroughBehavior   string
+	TimeoutInMillis       int
 }
 
 // Deployment is a point-in-time snapshot of a REST API published to a stage.
@@ -107,12 +108,14 @@ type PutMethodInput struct {
 	APIKeyRequired    bool
 }
 
-// PutIntegrationInput carries the fields PutIntegration accepts.
+// PutIntegrationInput carries the fields PutIntegration accepts. TimeoutInMillis
+// of 0 selects the AWS default (29000ms); a non-zero value is stored verbatim.
 type PutIntegrationInput struct {
 	Type                  string
 	IntegrationHTTPMethod string
 	URI                   string
 	PassthroughBehavior   string
+	TimeoutInMillis       int
 }
 
 // CreateDeploymentInput carries the fields CreateDeployment accepts. A non-empty


### PR DESCRIPTION
## Summary

Real-user e2e audit of AWS API Gateway (REST API v1) via the AWS CLI, aws-sdk-go-v2 wire protocol, and Terraform (`aws_api_gateway_rest_api` + resource/method/integration/deployment/stage). One genuine real-cloud-vs-cloudemu divergence found and fixed; the rest of the control-plane surface reconciled clean.

## Divergence fixed

**`aws_api_gateway_integration` perpetual Terraform drift on `timeout_milliseconds` (0 -> 29000).**

`PutIntegration` dropped the request's `timeoutInMillis`, and `GetIntegration` never returned it. Terraform sends `timeout_milliseconds = 29000` (its default, matching AWS) on create, then on refresh reads back `0`, producing an unremovable `~ timeout_milliseconds = 0 -> 29000` in-place update on every `terraform plan`.

Real AWS: `timeoutInMillis` defaults to 29000 (29s) and is always returned in the Integration object (per the PutIntegration / GetIntegration API reference).

Fix:
- Add `TimeoutInMillis` to `driver.Integration` and `driver.PutIntegrationInput`.
- Default to 29000 when unset; store an explicit value verbatim.
- Parse `timeoutInMillis` from the PutIntegration body and emit it in the integration wire response.

## Evidence

- CLI: `put-integration` (no timeout) then `get-integration` -> `29000`; `--timeout-in-millis 5000` round-trips as `5000`.
- Terraform: full `apply` of rest_api + resource + method + integration + deployment + stage, then `plan` -> **"No changes"** (was `Plan: 0 to add, 1 to change` before the fix); clean `destroy`.

## Clean (no divergence)

RestApi defaults (`apiKeySource=HEADER`, `endpointConfiguration.types=[EDGE]`, auto-created `rootResourceId`, `createdDate`), resource tree round-trip, method/deployment/stage lifecycle, delete idempotency, error codes (NotFoundException/ConflictException/BadRequestException with correct HTTP status), and list order (stable) all verified against the real CLI and Terraform.
