### PR TITLE
fix(ec2): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -1589,17 +1589,13 @@ func (m *Mock) SetManagedResourceVisibility(v string) error {
 	return nil
 }
 
-// CreateVolume creates a new EBS volume.
-//
 // ebsPerformanceDefaults returns the IOPS and throughput a volume of the given
 // type and size reports when the caller provisioned none, matching real AWS: gp3
 // baselines at 3000 IOPS / 125 MiB/s, gp2 derives IOPS from size (3/GiB, clamped
 // to [100,16000]) and has no throughput field. Explicitly provisioned values are
 // preserved. Other types (io1/io2 require a user-supplied IOPS; st1/sc1/standard
 // have none) pass through unchanged.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
-func ebsPerformanceDefaults(volType string, size, iops, throughput int) (int, int) {
+func ebsPerformanceDefaults(volType string, size, iops, throughput int) (resolvedIOPS, resolvedThroughput int) {
 	switch volType {
 	case defaultVolumeType: // gp3
 		if iops == 0 {
@@ -1627,6 +1623,9 @@ func ebsPerformanceDefaults(volType string, size, iops, throughput int) (int, in
 	return iops, throughput
 }
 
+// CreateVolume creates a new EBS volume.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver.VolumeInfo, error) {
 	id := fmt.Sprintf("vol-%012d", m.volCounter.Add(1))
 

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -74,6 +74,17 @@ const (
 	// defaultVolumeType is the EBS volume type used for a launch-materialized
 	// volume that names none (matching the CreateVolume default).
 	defaultVolumeType = "gp3"
+
+	// EBS performance defaults real AWS reports for a volume created without
+	// explicit provisioning. gp3 baselines at 3000 IOPS / 125 MiB/s; gp2 derives
+	// its IOPS from size at 3 IOPS/GiB, floored at 100 and capped at 16000. SDK
+	// clients and terraform read these back, so a created volume must carry them.
+	volumeTypeGP2        = "gp2"
+	gp3DefaultIOPS       = 3000
+	gp3DefaultThroughput = 125
+	gp2IOPSPerGiB        = 3
+	gp2MinIOPS           = 100
+	gp2MaxIOPS           = 16000
 	// rsaKeyBits is the modulus size for generated RSA key pairs.
 	rsaKeyBits = 2048
 	// keyTypeRSA / keyTypeEd25519 are the two key-pair algorithms the mock
@@ -781,6 +792,8 @@ func (m *Mock) materializeInstanceVolumes(cfg driver.InstanceConfig, instanceID 
 func (m *Mock) createAttachedVolume(instanceID, device, volType string, size int, deleteOnTermination bool, az, now string) {
 	id := fmt.Sprintf("vol-%012d", m.volCounter.Add(1))
 
+	iops, throughput := ebsPerformanceDefaults(volType, size, 0, 0)
+
 	m.volumes.Set(id, &driver.VolumeInfo{
 		ID:                  id,
 		Size:                size,
@@ -791,6 +804,8 @@ func (m *Mock) createAttachedVolume(instanceID, device, volType string, size int
 		Device:              device,
 		CreatedAt:           now,
 		DeleteOnTermination: deleteOnTermination,
+		IOPS:                iops,
+		Throughput:          throughput,
 	})
 }
 
@@ -1576,7 +1591,42 @@ func (m *Mock) SetManagedResourceVisibility(v string) error {
 
 // CreateVolume creates a new EBS volume.
 //
+// ebsPerformanceDefaults returns the IOPS and throughput a volume of the given
+// type and size reports when the caller provisioned none, matching real AWS: gp3
+// baselines at 3000 IOPS / 125 MiB/s, gp2 derives IOPS from size (3/GiB, clamped
+// to [100,16000]) and has no throughput field. Explicitly provisioned values are
+// preserved. Other types (io1/io2 require a user-supplied IOPS; st1/sc1/standard
+// have none) pass through unchanged.
+//
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func ebsPerformanceDefaults(volType string, size, iops, throughput int) (int, int) {
+	switch volType {
+	case defaultVolumeType: // gp3
+		if iops == 0 {
+			iops = gp3DefaultIOPS
+		}
+
+		if throughput == 0 {
+			throughput = gp3DefaultThroughput
+		}
+	case volumeTypeGP2:
+		if iops == 0 {
+			iops = size * gp2IOPSPerGiB
+			if iops < gp2MinIOPS {
+				iops = gp2MinIOPS
+			}
+
+			if iops > gp2MaxIOPS {
+				iops = gp2MaxIOPS
+			}
+		}
+
+		throughput = 0
+	}
+
+	return iops, throughput
+}
+
 func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver.VolumeInfo, error) {
 	id := fmt.Sprintf("vol-%012d", m.volCounter.Add(1))
 
@@ -1584,6 +1634,8 @@ func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver
 	if volType == "" {
 		volType = "gp3"
 	}
+
+	iops, throughput := ebsPerformanceDefaults(volType, cfg.Size, cfg.IOPS, cfg.Throughput)
 
 	az := cfg.AvailabilityZone
 	if az == "" {
@@ -1603,8 +1655,8 @@ func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver
 		AvailabilityZone: az,
 		CreatedAt:        m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
 		Tags:             copyTags(cfg.Tags),
-		IOPS:             cfg.IOPS,
-		Throughput:       cfg.Throughput,
+		IOPS:             iops,
+		Throughput:       throughput,
 		Tier:             cfg.Tier,
 		Encrypted:        cfg.Encrypted,
 		SnapshotID:       cfg.SnapshotID,

--- a/providers/aws/ec2/ec2_test.go
+++ b/providers/aws/ec2/ec2_test.go
@@ -994,6 +994,76 @@ func TestImportKeyPairEd25519Fingerprint(t *testing.T) {
 	}
 }
 
+// TestCreateVolumePerformanceDefaults pins the IOPS/throughput real AWS reports
+// for a volume created without explicit provisioning: gp3 baselines at 3000 IOPS
+// / 125 MiB/s, gp2 derives IOPS from size (3/GiB, clamped) and has no throughput,
+// and explicitly provisioned values override the defaults. SDK/terraform read
+// these back, so a missing default shows up as spurious drift.
+func TestCreateVolumePerformanceDefaults(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cases := []struct {
+		name           string
+		cfg            driver.VolumeConfig
+		wantIOPS       int
+		wantThroughput int
+	}{
+		{"gp3 defaults", driver.VolumeConfig{Size: 10, VolumeType: "gp3"}, 3000, 125},
+		{"gp3 explicit", driver.VolumeConfig{Size: 10, VolumeType: "gp3", IOPS: 5000, Throughput: 250}, 5000, 250},
+		{"empty type defaults to gp3", driver.VolumeConfig{Size: 10}, 3000, 125},
+		{"gp2 derives from size", driver.VolumeConfig{Size: 100, VolumeType: "gp2"}, 300, 0},
+		{"gp2 floors at 100", driver.VolumeConfig{Size: 10, VolumeType: "gp2"}, 100, 0},
+		{"gp2 caps at 16000", driver.VolumeConfig{Size: 20000, VolumeType: "gp2"}, 16000, 0},
+		{"io1 passes through", driver.VolumeConfig{Size: 100, VolumeType: "io1", IOPS: 2000}, 2000, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vol, err := m.CreateVolume(ctx, tc.cfg)
+			requireNoError(t, err)
+			assertEqual(t, tc.wantIOPS, vol.IOPS)
+			assertEqual(t, tc.wantThroughput, vol.Throughput)
+		})
+	}
+}
+
+// TestLaunchRootVolumePerformanceDefaults pins that the root EBS volume
+// materialized at launch also carries the gp3 performance defaults, so
+// DescribeVolumes / an instance's root_block_device report them.
+func TestLaunchRootVolumePerformanceDefaults(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	insts, err := m.RunInstances(ctx, driver.InstanceConfig{
+		ImageID:      "ami-123",
+		InstanceType: "t3.micro",
+		BlockDeviceMappings: []driver.BlockDeviceMapping{
+			{DeviceName: defaultRootDeviceName, Boot: true, AutoDelete: true},
+		},
+	}, 1)
+	requireNoError(t, err)
+
+	vols, err := m.DescribeVolumes(ctx, nil)
+	requireNoError(t, err)
+
+	var root *driver.VolumeInfo
+
+	for i := range vols {
+		if vols[i].AttachedTo == insts[0].ID {
+			root = &vols[i]
+		}
+	}
+
+	if root == nil {
+		t.Fatalf("no root volume attached to %s", insts[0].ID)
+	}
+
+	assertEqual(t, "gp3", root.VolumeType)
+	assertEqual(t, 3000, root.IOPS)
+	assertEqual(t, 125, root.Throughput)
+}
+
 // TestModifyVolumeGrowsAndValidates pins that ModifyVolume captures originals,
 // mutates the stored volume, rejects shrink, and reports NotFound for a missing
 // volume.

--- a/server/aws/ec2/instance_describe_test.go
+++ b/server/aws/ec2/instance_describe_test.go
@@ -42,8 +42,18 @@ func TestDescribeInstanceReportsHardwareDetail(t *testing.T) {
 		t.Errorf("rootDeviceType = %q, want ebs", inst.RootDeviceType)
 	}
 
-	if aws.ToString(inst.RootDeviceName) != "/dev/xvda" {
-		t.Errorf("rootDeviceName = %q, want /dev/xvda", aws.ToString(inst.RootDeviceName))
+	// The reported root device name must equal the device the boot volume is
+	// attached at (both derive from the launch AMI's root device, defaulting to
+	// /dev/sda1 for the unknown test AMI), so terraform classifies the root
+	// volume as root_block_device rather than an ebs_block_device.
+	if aws.ToString(inst.RootDeviceName) != "/dev/sda1" {
+		t.Errorf("rootDeviceName = %q, want /dev/sda1", aws.ToString(inst.RootDeviceName))
+	}
+
+	if len(inst.BlockDeviceMappings) != 1 ||
+		aws.ToString(inst.BlockDeviceMappings[0].DeviceName) != aws.ToString(inst.RootDeviceName) {
+		t.Errorf("boot block-device deviceName must equal rootDeviceName %q, got %+v",
+			aws.ToString(inst.RootDeviceName), inst.BlockDeviceMappings)
 	}
 
 	if inst.Placement == nil || aws.ToString(inst.Placement.AvailabilityZone) == "" {

--- a/server/aws/ec2/operations.go
+++ b/server/aws/ec2/operations.go
@@ -48,13 +48,12 @@ const reservationPrefix = "r-"
 // emulator launches. They are fixed rather than modeled because no cloudemu
 // behavior depends on them, but SDK clients and IaC read them.
 const (
-	archX86            = "x86_64"
-	hypervisorXen      = "xen"
-	virtualizationHVM  = "hvm"
-	rootDeviceTypeEBS  = "ebs"
-	rootDeviceNameXVDA = "/dev/xvda"
-	tenancyDefault     = "default"
-	defaultZone        = "us-east-1a"
+	archX86           = "x86_64"
+	hypervisorXen     = "xen"
+	virtualizationHVM = "hvm"
+	rootDeviceTypeEBS = "ebs"
+	tenancyDefault    = "default"
+	defaultZone       = "us-east-1a"
 	// eniAttachedStatus / primaryDeviceIndex describe the primary ENI's
 	// attachment.
 	eniAttachedStatus  = "attached"
@@ -804,11 +803,26 @@ func (h *Handler) toInstanceXMLs(ctx context.Context, instances []computedriver.
 	volsByInstance := h.volumesByInstance(ctx)
 	eipByInstance := h.eipByInstance(ctx)
 
+	// The instance's reported root device name must equal the device its boot
+	// volume is attached at, so terraform (which matches the block-device mapping
+	// whose deviceName == rootDeviceName to populate root_block_device) classifies
+	// the root volume correctly. Both derive from the launch AMI's root device, so
+	// resolve it once per distinct image.
+	rootDevices := make(map[string]string, len(instances))
+
 	out := make([]instanceXML, 0, len(instances))
 
 	for i := range instances {
 		inst := &instances[i]
-		out = append(out, instanceXMLFor(inst, names, enisByInstance[inst.ID], volsByInstance[inst.ID], eipByInstance[inst.ID]))
+
+		rootDevice, ok := rootDevices[inst.ImageID]
+		if !ok {
+			rootDevice = h.rootDeviceName(ctx, inst.ImageID)
+			rootDevices[inst.ImageID] = rootDevice
+		}
+
+		out = append(out, instanceXMLFor(inst, rootDevice, names,
+			enisByInstance[inst.ID], volsByInstance[inst.ID], eipByInstance[inst.ID]))
 	}
 
 	return out
@@ -892,7 +906,7 @@ func (h *Handler) eipByInstance(ctx context.Context) map[string]*netdriver.Elast
 // instanceXMLFor builds the wire shape for one instance, including the static
 // facts and derived placement / DNS / primary-ENI fields real EC2 reports.
 func instanceXMLFor(
-	inst *computedriver.Instance, names map[string]string,
+	inst *computedriver.Instance, rootDevice string, names map[string]string,
 	enis []netdriver.NetworkInterface, vols []computedriver.VolumeInfo, eip *netdriver.ElasticIP,
 ) instanceXML {
 	// An associated elastic IP is what gives an instance its public address;
@@ -919,7 +933,7 @@ func instanceXMLFor(
 		AmiLaunchIndex:     0,
 		Architecture:       archX86,
 		RootDeviceType:     rootDeviceTypeEBS,
-		RootDeviceName:     rootDeviceNameXVDA,
+		RootDeviceName:     rootDevice,
 		VirtualizationType: virtualizationHVM,
 		Hypervisor:         hypervisorXen,
 		Placement:          &placementXML{AvailabilityZone: instanceZone(inst), Tenancy: tenancyDefault},


### PR DESCRIPTION
## Summary

Real-user (SDK + CLI + Terraform) e2e audit of the AWS EC2 control plane (instances, EBS volumes, AMIs, key pairs). Two genuine real-cloud-vs-cloudemu divergences were found and fixed.

### 1. Instance root device name mismatch (Terraform drift)

`DescribeInstances`/`RunInstances` reported `RootDeviceName=/dev/xvda`, hardcoded, while the launch-materialized boot volume attaches at `/dev/sda1` (the provider/AMI default used everywhere else). Real EC2 always reports the same device in both places.

terraform-provider-aws populates `root_block_device` by matching the block-device mapping whose `device_name == root_device_name`. The mismatch left `root_block_device` empty and misclassified the 8 GiB launch root volume into `ebs_block_device` — so adding a `root_block_device {}` block to a config could not manage the real root volume.

Fix: the instance's reported `RootDeviceName` now derives from the launch AMI's root device (via the same resolver used to place the boot volume; defaults to `/dev/sda1` for an unknown AMI), so it always equals the boot volume's device.

### 2. EBS volumes missing default IOPS/throughput

`CreateVolume` (and the volumes materialized at launch) stored IOPS/throughput verbatim, so a gp3 volume created without provisioning reported `iops=0, throughput=0`; a gp2 volume reported `iops=0`. Real AWS assigns gp3 a 3000 IOPS / 125 MiB/s baseline and gp2 `3 * size` IOPS (clamped to 100..16000).

Fix: a shared `ebsPerformanceDefaults` helper fills the type-based defaults when the caller provisions none, applied in both `CreateVolume` and the root/data volumes created at launch. Explicit values are preserved.

## Evidence

- CLI: `RootDeviceName` now equals the root BDM device; gp3 -> Iops 3000 / Throughput 125; gp2 size 100 -> Iops 300.
- Terraform (aws_instance + aws_ebs_volume + aws_volume_attachment + aws_key_pair): apply clean, `terraform plan` shows no drift, state has `root_block_device` populated (iops 3000, throughput 125) and `ebs_block_device` empty; adding a `root_block_device` block yields "No changes"; destroy clean.
- Lifecycle (run->stop->start->terminate), error codes (InvalidInstanceID.NotFound, IncorrectInstanceState), key-pair create/import, tags, volume attach/detach verified unchanged and correct.

## Tests

- Updated `TestDescribeInstanceReportsHardwareDetail` to pin `RootDeviceName == boot BDM device`.
- Added `TestCreateVolumePerformanceDefaults` and `TestLaunchRootVolumePerformanceDefaults`.
