### PR TITLE
fix(aws-vpc): real-user e2e divergences from AWS

### DIFF
--- a/server/aws/ec2/error_shape_test.go
+++ b/server/aws/ec2/error_shape_test.go
@@ -35,6 +35,8 @@ var leakedPrefixes = []string{ //nolint:gochecknoglobals // shared test fixture
 	"InvalidAttachment.NotFound:",
 	"CannotDelete:",
 	"InvalidNetworkInterface.InUse:",
+	"InvalidSubnet.Range:",
+	"InvalidSubnet.Conflict:",
 }
 
 func apiMessage(t *testing.T, err error) string {

--- a/server/aws/ec2/networking_common.go
+++ b/server/aws/ec2/networking_common.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 )
 
@@ -114,6 +115,29 @@ func tagFilterMatch(name string, values []string, tags map[string]string) (match
 	default:
 		return false, false
 	}
+}
+
+// stripCodePrefix removes the internal "<Code>: " routing marker some driver
+// messages carry (used by the wire layer to pick the right EC2 error code) so it
+// never leaks into the user-facing <Message>. Real EC2 messages carry no such
+// prefix. The prefix is only trimmed when present, leaving other messages as-is.
+func stripCodePrefix(msg, prefix string) string {
+	return strings.TrimPrefix(msg, prefix)
+}
+
+// writeInvalidVPCIfMissing reports whether err is the driver's "referenced VPC
+// does not exist" NotFound and, if so, answers InvalidVpcID.NotFound. The
+// Create{Subnet,SecurityGroup,RouteTable} actions all take a VpcId; when that
+// VPC is absent real EC2 reports InvalidVpcID.NotFound (the VPC is the missing
+// resource) rather than the created resource's own NotFound code, which would
+// wrongly tell the caller the not-yet-created subnet/group/table is missing.
+func writeInvalidVPCIfMissing(w http.ResponseWriter, err error) bool {
+	if cerrors.IsNotFound(err) && strings.Contains(strings.ToLower(cerrors.Message(err)), "vpc ") {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidVpcID.NotFound", cerrors.Message(err))
+		return true
+	}
+
+	return false
 }
 
 // writeReturnTrue writes the common EC2 "<return>true</return>" acknowledgement

--- a/server/aws/ec2/networking_error_codes_test.go
+++ b/server/aws/ec2/networking_error_codes_test.go
@@ -179,6 +179,33 @@ func TestSubnetOutOfVPCRangeCode(t *testing.T) {
 	if got := apiCode(t, err); got != "InvalidSubnet.Range" {
 		t.Errorf("code = %q, want InvalidSubnet.Range", got)
 	}
+
+	// The internal "InvalidSubnet.Range:" routing marker must never leak into the
+	// user-facing message — real EC2 messages carry no code prefix.
+	assertNoLeakedPrefix(t, apiMessage(t, err))
+}
+
+// TestSubnetConflictCleanMessage pins that an overlapping-CIDR CreateSubnet
+// answers InvalidSubnet.Conflict without leaking the internal code prefix into
+// the message.
+func TestSubnetConflictCleanMessage(t *testing.T) {
+	ctx := context.Background()
+	c := newRoutingEdgeEC2(t)
+	vpcID, _ := mkVPCSubnet(t, c) // creates a 10.0.1.0/24 subnet in a 10.0.0.0/16 VPC
+
+	_, err := c.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+		VpcId:     aws.String(vpcID),
+		CidrBlock: aws.String("10.0.1.0/24"),
+	})
+	if err == nil {
+		t.Fatal("CreateSubnet(overlapping CIDR) succeeded, want an error")
+	}
+
+	if got := apiCode(t, err); got != "InvalidSubnet.Conflict" {
+		t.Errorf("code = %q, want InvalidSubnet.Conflict", got)
+	}
+
+	assertNoLeakedPrefix(t, apiMessage(t, err))
 }
 
 // TestReleaseBogusAllocationCode pins that releasing an unknown allocation id

--- a/server/aws/ec2/route_table.go
+++ b/server/aws/ec2/route_table.go
@@ -125,7 +125,14 @@ func (h *Handler) createRouteTable(w http.ResponseWriter, r *http.Request) {
 
 	rt, err := h.vpc.CreateRouteTable(r.Context(), cfg)
 	if err != nil {
+		// A CreateRouteTable naming a VpcId that doesn't exist is a missing-VPC
+		// error, not a missing-route-table one (the table isn't created yet).
+		if writeInvalidVPCIfMissing(w, err) {
+			return
+		}
+
 		writeRouteTableErr(w, err)
+
 		return
 	}
 

--- a/server/aws/ec2/security_group.go
+++ b/server/aws/ec2/security_group.go
@@ -19,6 +19,12 @@ import (
 // presence of a tag key (as opposed to "tag:<key>", which matches a value).
 const tagKeyFilter = "tag-key"
 
+// allProtocols is the IpProtocol value EC2 uses for a rule that matches every
+// protocol. The two describe shapes report its ports differently: the
+// IpPermission shape omits fromPort/toPort, while the SecurityGroupRule shape
+// reports -1 for both.
+const allProtocols = "-1"
+
 // groupIDFilter and securityGroupRuleIDFilter are the filter names shared by
 // DescribeSecurityGroups and DescribeSecurityGroupRules.
 const (
@@ -63,8 +69,8 @@ type userIDGroupPairXML struct {
 
 type ipPermissionXML struct {
 	IPProtocol    string               `xml:"ipProtocol"`
-	FromPort      int                  `xml:"fromPort"`
-	ToPort        int                  `xml:"toPort"`
+	FromPort      *int                 `xml:"fromPort,omitempty"`
+	ToPort        *int                 `xml:"toPort,omitempty"`
 	IPRanges      []ipRangeXML         `xml:"ipRanges>item,omitempty"`
 	IPv6Ranges    []ipv6RangeXML       `xml:"ipv6Ranges>item,omitempty"`
 	PrefixListIDs []prefixListIDXML    `xml:"prefixListIds>item,omitempty"`
@@ -169,6 +175,12 @@ func (h *Handler) createSecurityGroup(w http.ResponseWriter, r *http.Request) {
 // (surfaced as AlreadyExists) to the CreateSecurityGroup-only
 // InvalidGroup.Duplicate code, falling back to the shared SG error mapping.
 func writeCreateSGErr(w http.ResponseWriter, err error) {
+	// A CreateSecurityGroup naming a VpcId that doesn't exist is a missing-VPC
+	// error, not a missing-group one (the group isn't created yet).
+	if writeInvalidVPCIfMissing(w, err) {
+		return
+	}
+
 	if cerrors.IsAlreadyExists(err) {
 		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidGroup.Duplicate", cerrors.Message(err))
 		return
@@ -585,6 +597,31 @@ func (h *Handler) writeAuthorizeSGResponse(w http.ResponseWriter, name, groupID 
 	})
 }
 
+// permPortPtr returns nil for the all-protocols ("-1") rule — whose port range
+// the IpPermission shape (DescribeSecurityGroups) omits — and a pointer to p for
+// every other protocol, so a real port (including 0) is still emitted.
+func permPortPtr(protocol string, p int) *int {
+	if protocol == allProtocols {
+		return nil
+	}
+
+	v := p
+
+	return &v
+}
+
+// rulePortValue returns the fromPort/toPort value the flat SecurityGroupRule
+// shape (DescribeSecurityGroupRules / Authorize) reports. AWS reports -1 for the
+// all-protocols ("-1") rule there — unlike the IpPermission shape, which omits
+// the ports entirely — so translate the stored value accordingly.
+func rulePortValue(protocol string, p int) int {
+	if protocol == allProtocols {
+		return -1
+	}
+
+	return p
+}
+
 // toSecurityGroupRuleXML maps one stored rule to the flat SecurityGroupRule
 // wire shape, emitting exactly the target element (cidrIpv4/cidrIpv6/
 // prefixListId/referencedGroupInfo) the rule carries.
@@ -595,8 +632,8 @@ func (h *Handler) toSecurityGroupRuleXML(groupID string, egress bool, rule *netd
 		GroupOwnerID:        h.accountID,
 		IsEgress:            egress,
 		IPProtocol:          rule.Protocol,
-		FromPort:            rule.FromPort,
-		ToPort:              rule.ToPort,
+		FromPort:            rulePortValue(rule.Protocol, rule.FromPort),
+		ToPort:              rulePortValue(rule.Protocol, rule.ToPort),
 		CidrIPv4:            rule.CIDR,
 		CidrIPv6:            rule.IPv6CIDR,
 		PrefixListID:        rule.PrefixListID,
@@ -813,8 +850,8 @@ func (h *Handler) toIPPermissionXMLs(rules []netdriver.SecurityRule) []ipPermiss
 		if !ok {
 			perm = &ipPermissionXML{
 				IPProtocol: rule.Protocol,
-				FromPort:   rule.FromPort,
-				ToPort:     rule.ToPort,
+				FromPort:   permPortPtr(rule.Protocol, rule.FromPort),
+				ToPort:     permPortPtr(rule.Protocol, rule.ToPort),
 			}
 			byKey[k] = perm
 

--- a/server/aws/ec2/subnet.go
+++ b/server/aws/ec2/subnet.go
@@ -248,15 +248,23 @@ func writeSubnetErr(w http.ResponseWriter, err error) {
 // InvalidSubnet.Range for a CIDR outside the VPC block, falling back to the
 // shared subnet error mapping otherwise.
 func writeCreateSubnetErr(w http.ResponseWriter, err error) {
+	// A CreateSubnet naming a VpcId that doesn't exist is a missing-VPC error,
+	// not a missing-subnet one (the subnet isn't created yet).
+	if writeInvalidVPCIfMissing(w, err) {
+		return
+	}
+
 	if cerrors.IsAlreadyExists(err) {
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSubnet.Conflict", cerrors.Message(err))
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSubnet.Conflict",
+			stripCodePrefix(cerrors.Message(err), "InvalidSubnet.Conflict: "))
 		return
 	}
 
 	// A subnet CIDR outside the VPC's CIDR block is InvalidSubnet.Range, not the
 	// generic InvalidParameterValue the shared mapper would emit.
 	if cerrors.IsInvalidArgument(err) && strings.Contains(err.Error(), "InvalidSubnet.Range:") {
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSubnet.Range", cerrors.Message(err))
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidSubnet.Range",
+			stripCodePrefix(cerrors.Message(err), "InvalidSubnet.Range: "))
 		return
 	}
 

--- a/server/aws/ec2/vpc_child_create_parity_test.go
+++ b/server/aws/ec2/vpc_child_create_parity_test.go
@@ -1,0 +1,170 @@
+package ec2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+const missingVPC = "vpc-00000000"
+
+// TestCreateChildMissingVPCCode pins that creating a subnet, security group, or
+// route table against a VpcId that does not exist reports InvalidVpcID.NotFound
+// — the VPC is the missing resource — rather than the created resource's own
+// NotFound code (InvalidSubnetID/InvalidGroup/InvalidRouteTableID.NotFound),
+// which would wrongly claim the not-yet-created child is absent. A user pointing
+// a subnet/SG/route table at a typo'd or wrong VPC must get the VPC error.
+func TestCreateChildMissingVPCCode(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+
+	t.Run("CreateSubnet", func(t *testing.T) {
+		_, err := c.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+			VpcId:     aws.String(missingVPC),
+			CidrBlock: aws.String("10.9.0.0/24"),
+		})
+		if err == nil {
+			t.Fatal("CreateSubnet(missing vpc) succeeded, want an error")
+		}
+
+		if got := apiCode(t, err); got != "InvalidVpcID.NotFound" {
+			t.Errorf("code = %q, want InvalidVpcID.NotFound", got)
+		}
+	})
+
+	t.Run("CreateSecurityGroup", func(t *testing.T) {
+		_, err := c.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+			GroupName:   aws.String("x"),
+			Description: aws.String("x"),
+			VpcId:       aws.String(missingVPC),
+		})
+		if err == nil {
+			t.Fatal("CreateSecurityGroup(missing vpc) succeeded, want an error")
+		}
+
+		if got := apiCode(t, err); got != "InvalidVpcID.NotFound" {
+			t.Errorf("code = %q, want InvalidVpcID.NotFound", got)
+		}
+	})
+
+	t.Run("CreateRouteTable", func(t *testing.T) {
+		_, err := c.CreateRouteTable(ctx, &ec2.CreateRouteTableInput{
+			VpcId: aws.String(missingVPC),
+		})
+		if err == nil {
+			t.Fatal("CreateRouteTable(missing vpc) succeeded, want an error")
+		}
+
+		if got := apiCode(t, err); got != "InvalidVpcID.NotFound" {
+			t.Errorf("code = %q, want InvalidVpcID.NotFound", got)
+		}
+	})
+}
+
+// TestAllProtocolsRulePortShapes pins how the two describe shapes report the
+// ports of an all-protocols ("-1") rule, which differ in real EC2: the
+// IpPermission shape (DescribeSecurityGroups) omits fromPort/toPort entirely,
+// while the SecurityGroupRule shape (DescribeSecurityGroupRules) reports -1 for
+// both. The default VPC security group's allow-all egress rule exercises both.
+func TestAllProtocolsRulePortShapes(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	vpcID := createSGTestVPC(t, ctx, c, "10.0.0.0/16")
+
+	sgs, err := c.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSecurityGroups: %v", err)
+	}
+
+	if len(sgs.SecurityGroups) != 1 || len(sgs.SecurityGroups[0].IpPermissionsEgress) != 1 {
+		t.Fatalf("want one default group with one egress rule, got %+v", sgs.SecurityGroups)
+	}
+
+	egress := sgs.SecurityGroups[0].IpPermissionsEgress[0]
+	if aws.ToString(egress.IpProtocol) != "-1" {
+		t.Fatalf("egress protocol = %q, want -1", aws.ToString(egress.IpProtocol))
+	}
+
+	// IpPermission shape: AWS omits the ports for -1, so the SDK sees nil.
+	if egress.FromPort != nil {
+		t.Errorf("IpPermission FromPort = %d, want nil (omitted for -1)", aws.ToInt32(egress.FromPort))
+	}
+
+	if egress.ToPort != nil {
+		t.Errorf("IpPermission ToPort = %d, want nil (omitted for -1)", aws.ToInt32(egress.ToPort))
+	}
+
+	groupID := aws.ToString(sgs.SecurityGroups[0].GroupId)
+
+	rules, err := c.DescribeSecurityGroupRules(ctx, &ec2.DescribeSecurityGroupRulesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("group-id"), Values: []string{groupID}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSecurityGroupRules: %v", err)
+	}
+
+	// SecurityGroupRule shape: AWS reports -1 for both ports on a -1 rule.
+	for _, rule := range rules.SecurityGroupRules {
+		if aws.ToString(rule.IpProtocol) != "-1" {
+			continue
+		}
+
+		if aws.ToInt32(rule.FromPort) != -1 {
+			t.Errorf("SecurityGroupRule FromPort = %d, want -1", aws.ToInt32(rule.FromPort))
+		}
+
+		if aws.ToInt32(rule.ToPort) != -1 {
+			t.Errorf("SecurityGroupRule ToPort = %d, want -1", aws.ToInt32(rule.ToPort))
+		}
+	}
+}
+
+// TestTCPRulePortsUnaffected guards the -1 special-casing against a regression:
+// a concrete TCP rule must still report its real ports (including in both
+// describe shapes), not be collapsed to nil or -1.
+func TestTCPRulePortsUnaffected(t *testing.T) {
+	ctx := context.Background()
+	c := newSGServer(t)
+	vpcID := createSGTestVPC(t, ctx, c, "10.0.0.0/16")
+
+	sg, err := c.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String("web"),
+		Description: aws.String("web"),
+		VpcId:       aws.String(vpcID),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecurityGroup: %v", err)
+	}
+
+	groupID := aws.ToString(sg.GroupId)
+
+	_, err = c.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: aws.String(groupID),
+		IpPermissions: []ec2types.IpPermission{{
+			IpProtocol: aws.String("tcp"),
+			FromPort:   aws.Int32(443),
+			ToPort:     aws.Int32(443),
+			IpRanges:   []ec2types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("AuthorizeSecurityGroupIngress: %v", err)
+	}
+
+	sgs, err := c.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+		GroupIds: []string{groupID},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSecurityGroups: %v", err)
+	}
+
+	perms := sgs.SecurityGroups[0].IpPermissions
+	if len(perms) != 1 || aws.ToInt32(perms[0].FromPort) != 443 || aws.ToInt32(perms[0].ToPort) != 443 {
+		t.Fatalf("IpPermission ports = %+v, want tcp 443-443", perms)
+	}
+}


### PR DESCRIPTION
## Summary

Real-user e2e audit (aws-sdk-go-v2 + aws-cli + Terraform against `cloudemu serve`) of the AWS VPC/networking control plane — VPCs, subnets, security groups, route tables, IGW. The core lifecycle and Terraform round-trip (apply → plan → destroy, no drift) were already solid; this fixes three genuine cloud-vs-cloudemu divergences a real SDK/CLI user hits.

## Changes

### 1. Child-create against a missing VPC returns the wrong error code
`CreateSubnet`, `CreateSecurityGroup`, and `CreateRouteTable` naming a `VpcId` that does not exist returned the created resource's own NotFound code (`InvalidSubnetID.NotFound` / `InvalidGroup.NotFound` / `InvalidRouteTableID.NotFound`). Real EC2 returns `InvalidVpcID.NotFound` — the VPC is the missing resource; the child isn't created yet. A shared `writeInvalidVPCIfMissing` helper maps these.

### 2. All-protocols ("-1") rule ports differ from AWS in both describe shapes
- `DescribeSecurityGroups` (IpPermission shape) emitted `fromPort=0/toPort=0` for a `-1` rule; real AWS omits them (SDK sees `nil`). Ports are now `*int` with `omitempty`, populated only for concrete protocols.
- `DescribeSecurityGroupRules` (SecurityGroupRule shape) emitted `0/0`; real AWS reports `-1/-1`.

This affects every default security group's allow-all egress rule and every Terraform `-1` egress rule.

### 3. Internal code marker leaked into CreateSubnet error message
The `InvalidSubnet.Range:` / `InvalidSubnet.Conflict:` routing markers baked into the driver message leaked into the user-facing `<Message>`. Now stripped; the AWS code is still set correctly. Both markers added to the `leakedPrefixes` test registry.

## Testing
- New `vpc_child_create_parity_test.go`: missing-VPC codes for all three creates; `-1` port shapes in both describe APIs; concrete-TCP-port regression guard.
- Extended range/conflict message tests to assert no leaked prefix.
- Live-verified via aws-cli, aws-sdk-go-v2, and a full Terraform apply/plan/destroy cycle (no drift) before and after.
- Gates: `go build ./...`, `go test -race ./server/aws/ec2/... ./providers/aws/vpc/... ./services/networking/...`, root integration test, `go vet`, `gofmt`, `golangci-lint --new-from-rev` (0 new issues), `go generate` (no coverage diff) — all green.