### PR TITLE
fix(ecr): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/ecr/ecr.go
+++ b/providers/aws/ecr/ecr.go
@@ -23,6 +23,10 @@ const (
 	mutableTag         = "MUTABLE"
 	immutableTag       = "IMMUTABLE"
 	scanStatusComplete = "COMPLETE"
+
+	encryptionAES256  = "AES256"
+	encryptionKMS     = "KMS"
+	encryptionKMSDSSE = "KMS_DSSE"
 )
 
 // Compile-time check that Mock implements driver.ContainerRegistry.
@@ -98,6 +102,11 @@ func (m *Mock) CreateRepository(ctx context.Context, cfg driver.RepositoryConfig
 	uri := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", m.opts.AccountID, region, cfg.Name)
 	arn := fmt.Sprintf("arn:aws:ecr:%s:%s:repository/%s", region, m.opts.AccountID, cfg.Name)
 
+	encType, kmsKey, err := resolveEncryption(cfg.Encryption, region, m.opts.AccountID, cfg.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	info := driver.Repository{
 		Name:               cfg.Name,
 		URI:                uri,
@@ -108,6 +117,8 @@ func (m *Mock) CreateRepository(ctx context.Context, cfg driver.RepositoryConfig
 		RegistryID:         m.opts.AccountID,
 		ImageTagMutability: mutability,
 		ScanOnPush:         cfg.ImageScanOnPush,
+		EncryptionType:     encType,
+		KmsKey:             kmsKey,
 	}
 
 	rd := &repoData{
@@ -123,6 +134,54 @@ func (m *Mock) CreateRepository(ctx context.Context, cfg driver.RepositoryConfig
 	result := info
 
 	return &result, nil
+}
+
+// resolveEncryption validates and resolves a repository's encryption
+// configuration, matching AWS ECR defaults: an omitted encryptionType defaults
+// to AES256, and a KMS repository created without an explicit key is backed by
+// the account's default AWS-managed ECR key, whose ARN ECR then reports. Real
+// ECR always surfaces an encryptionConfiguration on every repository, so a
+// non-empty encryptionType is always returned.
+func resolveEncryption(enc *driver.EncryptionConfig, region, accountID, repo string) (encType, kmsKey string, err error) {
+	var (
+		reqType string
+		reqKey  string
+	)
+
+	if enc != nil {
+		reqType = enc.Type
+		reqKey = enc.KmsKey
+	}
+
+	switch reqType {
+	case "", encryptionAES256:
+		if reqKey != "" {
+			return "", "", errors.New(errors.InvalidArgument,
+				"kmsKey should not be specified with AES256 encryption")
+		}
+
+		return encryptionAES256, "", nil
+	case encryptionKMS, encryptionKMSDSSE:
+		if reqKey != "" {
+			return reqType, reqKey, nil
+		}
+
+		return reqType, defaultKMSKeyARN(region, accountID, repo), nil
+	default:
+		return "", "", errors.Newf(errors.InvalidArgument,
+			"invalid encryptionType %q; expected AES256, KMS, or KMS_DSSE", reqType)
+	}
+}
+
+// defaultKMSKeyARN synthesizes a stable ARN for the AWS-managed ECR key that
+// backs a KMS repository created without an explicit key. It is derived from the
+// repository name so every DescribeRepositories read reports the same value
+// (matching real ECR, which returns the resolved CMK ARN).
+func defaultKMSKeyARN(region, accountID, repo string) string {
+	sum := sha256.Sum256([]byte(region + accountID + repo))
+	id := fmt.Sprintf("%x-%x-%x-%x-%x", sum[0:4], sum[4:6], sum[6:8], sum[8:10], sum[10:16])
+
+	return fmt.Sprintf("arn:aws:kms:%s:%s:key/%s", region, accountID, id)
 }
 
 // PutImageTagMutability updates a repository's image tag mutability setting.

--- a/providers/aws/ecr/ecr_test.go
+++ b/providers/aws/ecr/ecr_test.go
@@ -107,6 +107,88 @@ func TestCreateRepository(t *testing.T) {
 	}
 }
 
+func TestCreateRepositoryEncryption(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        driver.RepositoryConfig
+		wantType   string
+		wantKeySet bool
+		expectErr  bool
+	}{
+		{
+			name:     "default is AES256",
+			cfg:      driver.RepositoryConfig{Name: "enc-default"},
+			wantType: "AES256",
+		},
+		{
+			name:     "explicit AES256",
+			cfg:      driver.RepositoryConfig{Name: "enc-aes", Encryption: &driver.EncryptionConfig{Type: "AES256"}},
+			wantType: "AES256",
+		},
+		{
+			name:       "KMS without key synthesizes a key ARN",
+			cfg:        driver.RepositoryConfig{Name: "enc-kms", Encryption: &driver.EncryptionConfig{Type: "KMS"}},
+			wantType:   "KMS",
+			wantKeySet: true,
+		},
+		{
+			name: "KMS with explicit key echoes it",
+			cfg: driver.RepositoryConfig{
+				Name:       "enc-kms-key",
+				Encryption: &driver.EncryptionConfig{Type: "KMS", KmsKey: "arn:aws:kms:us-east-1:123:key/abc"},
+			},
+			wantType:   "KMS",
+			wantKeySet: true,
+		},
+		{
+			name: "AES256 with a key is rejected",
+			cfg: driver.RepositoryConfig{
+				Name:       "bad-aes",
+				Encryption: &driver.EncryptionConfig{Type: "AES256", KmsKey: "arn:aws:kms:x"},
+			},
+			expectErr: true,
+		},
+		{
+			name:      "invalid encryption type is rejected",
+			cfg:       driver.RepositoryConfig{Name: "bad-type", Encryption: &driver.EncryptionConfig{Type: "ROT13"}},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			repo, err := m.CreateRepository(context.Background(), tc.cfg)
+			if tc.expectErr {
+				require.Error(t, err)
+				assert.True(t, cerrors.IsInvalidArgument(err), "want InvalidArgument, got %v", err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantType, repo.EncryptionType)
+
+			if tc.wantKeySet {
+				assert.NotEmpty(t, repo.KmsKey)
+			} else {
+				assert.Empty(t, repo.KmsKey)
+			}
+
+			if tc.cfg.Encryption != nil && tc.cfg.Encryption.KmsKey != "" {
+				assert.Equal(t, tc.cfg.Encryption.KmsKey, repo.KmsKey)
+			}
+
+			// The value must survive a read.
+			got, err := m.GetRepository(context.Background(), tc.cfg.Name)
+			require.NoError(t, err)
+			assert.Equal(t, repo.EncryptionType, got.EncryptionType)
+			assert.Equal(t, repo.KmsKey, got.KmsKey)
+		})
+	}
+}
+
 func TestDeleteRepository(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/server/aws/ecr/operations.go
+++ b/server/aws/ecr/operations.go
@@ -20,12 +20,20 @@ func (h *Handler) createRepository(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	repo, err := h.registry.CreateRepository(r.Context(), crdriver.RepositoryConfig{
+	cfg := crdriver.RepositoryConfig{
 		Name:               req.RepositoryName,
 		Tags:               tagsToMap(req.Tags),
 		ImageScanOnPush:    req.ImageScanningConfiguration.ScanOnPush,
 		ImageTagMutability: req.ImageTagMutability,
-	})
+	}
+	if req.EncryptionConfiguration != nil {
+		cfg.Encryption = &crdriver.EncryptionConfig{
+			Type:   req.EncryptionConfiguration.EncryptionType,
+			KmsKey: req.EncryptionConfiguration.KmsKey,
+		}
+	}
+
+	repo, err := h.registry.CreateRepository(r.Context(), cfg)
 	if err != nil {
 		writeErr(w, err)
 		return

--- a/server/aws/ecr/repository_config_test.go
+++ b/server/aws/ecr/repository_config_test.go
@@ -177,6 +177,81 @@ func TestSDKECRPutImageScanningConfiguration(t *testing.T) {
 	}
 }
 
+// TestSDKECRCreateRepositoryEncryptionConfiguration exercises the
+// encryptionConfiguration round-trip Terraform's aws_ecr_repository depends on:
+// real ECR reports an encryptionConfiguration on every repository (default
+// AES256), and re-reads it on every refresh. Omitting it made an explicit
+// encryption_configuration block drift and force replacement on every apply.
+func TestSDKECRCreateRepositoryEncryptionConfiguration(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	// Default: no encryptionConfiguration in the request → AES256, no kmsKey.
+	def, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("enc-default"),
+	})
+	if err != nil {
+		t.Fatalf("CreateRepository(default): %v", err)
+	}
+
+	assertEnc(t, "create default", def.Repository.EncryptionConfiguration, ecrtypes.EncryptionTypeAes256, "")
+
+	// KMS without an explicit key → KMS with a synthesized (non-empty) key ARN.
+	kms, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("enc-kms"),
+		EncryptionConfiguration: &ecrtypes.EncryptionConfiguration{
+			EncryptionType: ecrtypes.EncryptionTypeKms,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateRepository(KMS): %v", err)
+	}
+
+	kmsKey := aws.ToString(kms.Repository.EncryptionConfiguration.KmsKey)
+	if kms.Repository.EncryptionConfiguration.EncryptionType != ecrtypes.EncryptionTypeKms || kmsKey == "" {
+		t.Fatalf("CreateRepository(KMS) enc = %+v, want KMS with non-empty kmsKey",
+			kms.Repository.EncryptionConfiguration)
+	}
+
+	// The values must survive DescribeRepositories unchanged (the refresh path).
+	desc, err := client.DescribeRepositories(ctx, &awsecr.DescribeRepositoriesInput{
+		RepositoryNames: []string{"enc-default", "enc-kms"},
+	})
+	if err != nil {
+		t.Fatalf("DescribeRepositories: %v", err)
+	}
+
+	for i := range desc.Repositories {
+		switch aws.ToString(desc.Repositories[i].RepositoryName) {
+		case "enc-default":
+			assertEnc(t, "describe default", desc.Repositories[i].EncryptionConfiguration,
+				ecrtypes.EncryptionTypeAes256, "")
+		case "enc-kms":
+			assertEnc(t, "describe kms", desc.Repositories[i].EncryptionConfiguration,
+				ecrtypes.EncryptionTypeKms, kmsKey)
+		}
+	}
+}
+
+// assertEnc fails unless enc reports the wanted type and key.
+func assertEnc(t *testing.T, where string, enc *ecrtypes.EncryptionConfiguration,
+	wantType ecrtypes.EncryptionType, wantKey string,
+) {
+	t.Helper()
+
+	if enc == nil {
+		t.Fatalf("%s: encryptionConfiguration is nil, want %s", where, wantType)
+	}
+
+	if enc.EncryptionType != wantType {
+		t.Fatalf("%s: encryptionType = %q, want %q", where, enc.EncryptionType, wantType)
+	}
+
+	if aws.ToString(enc.KmsKey) != wantKey {
+		t.Fatalf("%s: kmsKey = %q, want %q", where, aws.ToString(enc.KmsKey), wantKey)
+	}
+}
+
 // TestSDKECRPutImageTagMutabilityMissingRepo asserts the operation surfaces
 // RepositoryNotFoundException for an unknown repository.
 func TestSDKECRPutImageTagMutabilityMissingRepo(t *testing.T) {

--- a/server/aws/ecr/types.go
+++ b/server/aws/ecr/types.go
@@ -15,6 +15,15 @@ type imageScanningConfigJSON struct {
 	ScanOnPush bool `json:"scanOnPush"`
 }
 
+// encryptionConfigJSON mirrors ECR's EncryptionConfiguration object. Real ECR
+// reports an encryptionConfiguration on every repository (default AES256), and
+// Terraform's aws_ecr_repository reads it back on every refresh — omitting it
+// makes an explicit encryption_configuration block drift and force replacement.
+type encryptionConfigJSON struct {
+	EncryptionType string `json:"encryptionType"`
+	KmsKey         string `json:"kmsKey,omitempty"`
+}
+
 type repositoryJSON struct {
 	RepositoryArn              string                   `json:"repositoryArn,omitempty"`
 	RepositoryName             string                   `json:"repositoryName"`
@@ -23,6 +32,7 @@ type repositoryJSON struct {
 	CreatedAt                  float64                  `json:"createdAt,omitempty"`
 	ImageTagMutability         string                   `json:"imageTagMutability,omitempty"`
 	ImageScanningConfiguration *imageScanningConfigJSON `json:"imageScanningConfiguration,omitempty"`
+	EncryptionConfiguration    *encryptionConfigJSON    `json:"encryptionConfiguration,omitempty"`
 }
 
 type imageIDJSON struct {
@@ -68,6 +78,7 @@ type createRepositoryRequest struct {
 	Tags                       []tagJSON               `json:"tags"`
 	ImageScanningConfiguration imageScanningConfigJSON `json:"imageScanningConfiguration"`
 	ImageTagMutability         string                  `json:"imageTagMutability"`
+	EncryptionConfiguration    *encryptionConfigJSON   `json:"encryptionConfiguration"`
 }
 
 type describeRepositoriesRequest struct {
@@ -169,7 +180,21 @@ func toRepositoryJSON(r *crdriver.Repository) repositoryJSON {
 		CreatedAt:                  epochSeconds(r.CreatedAt),
 		ImageTagMutability:         r.ImageTagMutability,
 		ImageScanningConfiguration: &imageScanningConfigJSON{ScanOnPush: r.ScanOnPush},
+		EncryptionConfiguration:    toEncryptionConfigJSON(r),
 	}
+}
+
+// toEncryptionConfigJSON renders a repository's encryption configuration. Real
+// ECR always reports one, defaulting to AES256 for repositories created before
+// the field was modeled, so a repository with no stored type is reported as
+// AES256 rather than omitted.
+func toEncryptionConfigJSON(r *crdriver.Repository) *encryptionConfigJSON {
+	encType := r.EncryptionType
+	if encType == "" {
+		encType = "AES256"
+	}
+
+	return &encryptionConfigJSON{EncryptionType: encType, KmsKey: r.KmsKey}
 }
 
 func toImageDetailJSON(d *crdriver.ImageDetail) imageDetailJSON {

--- a/services/containerregistry/driver/driver.go
+++ b/services/containerregistry/driver/driver.go
@@ -25,6 +25,13 @@ type Repository struct {
 	ImageTagMutability string
 	// ScanOnPush reflects the repository's scan-on-push configuration.
 	ScanOnPush bool
+	// EncryptionType is the at-rest encryption mode (AWS ECR): "AES256" (the
+	// default) or "KMS". Real ECR always reports an encryptionConfiguration on
+	// every repository, so the AWS provider populates this for every repository.
+	EncryptionType string
+	// KmsKey is the KMS key ARN backing a KMS-encrypted repository (AWS ECR);
+	// empty for AES256 repositories.
+	KmsKey string
 }
 
 // ImmutableTagsReservedTag is the reserved Repository.Tags key GCP Artifact
@@ -45,6 +52,19 @@ type RepositoryConfig struct {
 	Tags               map[string]string
 	ImageScanOnPush    bool
 	ImageTagMutability string // "MUTABLE" or "IMMUTABLE"
+	// Encryption is the optional at-rest encryption configuration (AWS ECR). Nil
+	// means the provider's default (ECR: AES256). Ignored by providers that do
+	// not model encryption configuration.
+	Encryption *EncryptionConfig
+}
+
+// EncryptionConfig is a repository's at-rest encryption configuration (AWS ECR).
+type EncryptionConfig struct {
+	// Type is the encryption mode: "AES256" (the default when empty), "KMS", or
+	// "KMS_DSSE".
+	Type string
+	// KmsKey is the optional KMS key ARN/id for a KMS-encrypted repository.
+	KmsKey string
 }
 
 // ImageDetail describes a container image.


### PR DESCRIPTION
## Summary

Real-user e2e audit of AWS ECR (SDK v2 + aws-cli + Terraform `aws_ecr_repository`) against the official AWS ECR API found one genuine, high-impact divergence: cloudemu never modeled a repository's **encryptionConfiguration**.

Real ECR reports an `encryptionConfiguration` on *every* repository (default `AES256`) and re-reads it on each refresh. cloudemu:
- omitted the field from `CreateRepository`/`DescribeRepositories`/`DeleteRepository` responses entirely, and
- silently dropped an `encryptionConfiguration` supplied on `CreateRepository`.

Because Terraform's `aws_ecr_repository` reads `encryption_configuration` back on every plan (and the block is `ForceNew`), an explicit block drifted and **forced replacement on every apply**.

### Reproduction (before)
`terraform apply` of a repo with `encryption_configuration { encryption_type = "KMS" }` (or `"AES256"`), then `terraform plan`:
```
# aws_ecr_repository.kms must be replaced
+ encryption_configuration { # forces replacement
    + encryption_type = "KMS" # forces replacement
Plan: 2 to add, 0 to change, 2 to destroy.
```

### After
```
No changes. Your infrastructure matches the configuration.
```

## What changed
- `containerregistry` driver: `RepositoryConfig.Encryption` (a small `*EncryptionConfig`) and `Repository.EncryptionType`/`KmsKey`.
- AWS ECR provider `CreateRepository`: defaults to `AES256`; for `KMS`/`KMS_DSSE` without an explicit key, synthesizes a stable AWS-managed key ARN (matching real ECR, which returns the resolved CMK ARN); rejects a `kmsKey` with `AES256` and unknown encryption types with `InvalidParameterException`.
- ECR wire layer: parses `encryptionConfiguration` on `CreateRepository` and always emits it on the repository response (defaulting a legacy/unset repository to `AES256`).
- Snapshot/restore carries the new fields automatically (they live on `driver.Repository`).

## Verification
- `aws-cli` and `aws-sdk-go-v2`: default → `AES256`; KMS (no key) → `KMS` + synthesized ARN; KMS (explicit key) → echoed; `AES256`+kmsKey → `InvalidParameterException`; values survive `DescribeRepositories`.
- Terraform `aws_ecr_repository` (AES256 + KMS), `aws_ecr_lifecycle_policy`, `aws_ecr_repository_policy`: apply → re-plan `No changes` → clean destroy.
- Gates: `go build ./...`, `go test -race` (providers/aws/ecr, server/aws/ecr, containerregistry, persist), `go vet`, `gofmt`, `golangci-lint` (full-package on changed pkgs + `--new-from-rev`) all clean; `go generate ./...` leaves `docs/coverage` unchanged (no new operations).