### PR TITLE
fix(sfn): real-user e2e divergences from AWS

### DIFF
--- a/server/aws/sfn/operations.go
+++ b/server/aws/sfn/operations.go
@@ -13,6 +13,8 @@ func (h *Handler) createStateMachine(w http.ResponseWriter, r *http.Request) {
 		arn, versionArn, created, err := h.sfn.CreateStateMachine(ctx, sfndriver.CreateStateMachineInput{
 			Name: req.Name, Definition: req.Definition, RoleArn: req.RoleArn, Type: req.Type,
 			Description: req.Description, Publish: req.Publish, Tags: tagsToMap(req.Tags),
+			LoggingConfigJSON: rawJSON(req.LoggingConfiguration),
+			TracingConfigJSON: rawJSON(req.TracingConfiguration),
 		})
 		if err != nil {
 			return nil, err
@@ -46,6 +48,8 @@ func (h *Handler) updateStateMachine(w http.ResponseWriter, r *http.Request) {
 		res, err := h.sfn.UpdateStateMachine(ctx, sfndriver.UpdateStateMachineInput{
 			ARN: req.StateMachineArn, Definition: req.Definition, RoleArn: req.RoleArn,
 			Publish: req.Publish, VersionDesc: req.VersionDescription,
+			LoggingConfigJSON: rawJSON(req.LoggingConfiguration),
+			TracingConfigJSON: rawJSON(req.TracingConfiguration),
 		})
 		if err != nil {
 			return nil, err

--- a/server/aws/sfn/sdk_roundtrip_test.go
+++ b/server/aws/sfn/sdk_roundtrip_test.go
@@ -521,6 +521,80 @@ func TestSDKDescribeStateMachineConfigs(t *testing.T) {
 	}
 }
 
+// TestSDKLoggingTracingRoundTrip guards that a loggingConfiguration and
+// tracingConfiguration supplied to CreateStateMachine (and later mutated by
+// UpdateStateMachine) survive DescribeStateMachine verbatim. A wire layer that
+// drops these on the way in makes DescribeStateMachine report the OFF/disabled
+// defaults, which shows up as permanent Terraform drift on every plan.
+func TestSDKLoggingTracingRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c := newSFNClient(t)
+
+	logDest := "arn:aws:logs:us-east-1:123456789012:log-group:/aws/sfn/rt:*"
+	out, err := c.CreateStateMachine(ctx, &awssfn.CreateStateMachineInput{
+		Name:       aws.String("logtrace"),
+		Definition: aws.String(definition),
+		RoleArn:    aws.String("arn:aws:iam::123456789012:role/svc"),
+		LoggingConfiguration: &sfntypes.LoggingConfiguration{
+			Level:                sfntypes.LogLevelAll,
+			IncludeExecutionData: true,
+			Destinations: []sfntypes.LogDestination{{
+				CloudWatchLogsLogGroup: &sfntypes.CloudWatchLogsLogGroup{LogGroupArn: aws.String(logDest)},
+			}},
+		},
+		TracingConfiguration: &sfntypes.TracingConfiguration{Enabled: true},
+	})
+	if err != nil {
+		t.Fatalf("CreateStateMachine: %v", err)
+	}
+
+	arn := aws.ToString(out.StateMachineArn)
+
+	desc, err := c.DescribeStateMachine(ctx, &awssfn.DescribeStateMachineInput{StateMachineArn: aws.String(arn)})
+	if err != nil {
+		t.Fatalf("DescribeStateMachine: %v", err)
+	}
+
+	if desc.LoggingConfiguration.Level != sfntypes.LogLevelAll {
+		t.Fatalf("logging level = %s, want ALL", desc.LoggingConfiguration.Level)
+	}
+
+	if !desc.LoggingConfiguration.IncludeExecutionData {
+		t.Fatal("includeExecutionData = false, want true")
+	}
+
+	if len(desc.LoggingConfiguration.Destinations) != 1 ||
+		aws.ToString(desc.LoggingConfiguration.Destinations[0].CloudWatchLogsLogGroup.LogGroupArn) != logDest {
+		t.Fatalf("logging destinations not round-tripped: %+v", desc.LoggingConfiguration.Destinations)
+	}
+
+	if desc.TracingConfiguration == nil || !desc.TracingConfiguration.Enabled {
+		t.Fatal("tracing enabled = false, want true")
+	}
+
+	// UpdateStateMachine carries new logging/tracing config too.
+	if _, err = c.UpdateStateMachine(ctx, &awssfn.UpdateStateMachineInput{
+		StateMachineArn:      aws.String(arn),
+		LoggingConfiguration: &sfntypes.LoggingConfiguration{Level: sfntypes.LogLevelError, IncludeExecutionData: false},
+		TracingConfiguration: &sfntypes.TracingConfiguration{Enabled: false},
+	}); err != nil {
+		t.Fatalf("UpdateStateMachine: %v", err)
+	}
+
+	desc2, err := c.DescribeStateMachine(ctx, &awssfn.DescribeStateMachineInput{StateMachineArn: aws.String(arn)})
+	if err != nil {
+		t.Fatalf("DescribeStateMachine after update: %v", err)
+	}
+
+	if desc2.LoggingConfiguration.Level != sfntypes.LogLevelError {
+		t.Fatalf("post-update logging level = %s, want ERROR", desc2.LoggingConfiguration.Level)
+	}
+
+	if desc2.TracingConfiguration.Enabled {
+		t.Fatal("post-update tracing enabled = true, want false")
+	}
+}
+
 func TestSDKListStateMachinesPaginates(t *testing.T) {
 	ctx := context.Background()
 	c := newSFNClient(t)

--- a/server/aws/sfn/types.go
+++ b/server/aws/sfn/types.go
@@ -87,15 +87,25 @@ func mapToTags(m map[string]string) []tag {
 // --- request shapes ---
 
 type createStateMachineRequest struct {
-	Name                 string `json:"name"`
-	Definition           string `json:"definition"`
-	RoleArn              string `json:"roleArn"`
-	Type                 string `json:"type"`
-	Description          string `json:"versionDescription"`
-	Publish              bool   `json:"publish"`
-	Tags                 []tag  `json:"tags"`
-	LoggingConfiguration any    `json:"loggingConfiguration"`
-	TracingConfiguration any    `json:"tracingConfiguration"`
+	Name                 string          `json:"name"`
+	Definition           string          `json:"definition"`
+	RoleArn              string          `json:"roleArn"`
+	Type                 string          `json:"type"`
+	Description          string          `json:"versionDescription"`
+	Publish              bool            `json:"publish"`
+	Tags                 []tag           `json:"tags"`
+	LoggingConfiguration json.RawMessage `json:"loggingConfiguration"`
+	TracingConfiguration json.RawMessage `json:"tracingConfiguration"`
+}
+
+// rawJSON renders an optional JSON-object request field as the verbatim string
+// the driver stores, treating an absent field or an explicit null as unset.
+func rawJSON(m json.RawMessage) string {
+	if len(m) == 0 || string(m) == "null" {
+		return ""
+	}
+
+	return string(m)
 }
 
 type stateMachineArnRequest struct {
@@ -103,11 +113,13 @@ type stateMachineArnRequest struct {
 }
 
 type updateStateMachineRequest struct {
-	StateMachineArn    string `json:"stateMachineArn"`
-	Definition         string `json:"definition"`
-	RoleArn            string `json:"roleArn"`
-	Publish            bool   `json:"publish"`
-	VersionDescription string `json:"versionDescription"`
+	StateMachineArn      string          `json:"stateMachineArn"`
+	Definition           string          `json:"definition"`
+	RoleArn              string          `json:"roleArn"`
+	Publish              bool            `json:"publish"`
+	VersionDescription   string          `json:"versionDescription"`
+	LoggingConfiguration json.RawMessage `json:"loggingConfiguration"`
+	TracingConfiguration json.RawMessage `json:"tracingConfiguration"`
 }
 
 type startExecutionRequest struct {


### PR DESCRIPTION
## Summary

Real-user e2e audit of AWS Step Functions surfaced a Terraform-drift divergence in the
wire layer: `loggingConfiguration` and `tracingConfiguration` were never round-tripped.

- `CreateStateMachine` captured `loggingConfiguration`/`tracingConfiguration` as `any` and
  never passed them to the driver, so `DescribeStateMachine` always returned the OFF/disabled
  defaults. A `aws_sfn_state_machine` resource with a `logging_configuration` or
  `tracing_configuration` block showed permanent drift on every `terraform plan`.
- `UpdateStateMachine`'s wire request had no logging/tracing fields at all, so those blocks
  could not be updated (and a config-only update hit `MissingRequiredParameter`).

The driver already stored `LoggingConfigJSON`/`TracingConfigJSON` and `DescribeStateMachine`
already emitted them (with correct defaults). The fix is purely at the wire layer: capture
both config objects as `json.RawMessage` and forward the verbatim JSON on create and update.

Verified against the official CreateStateMachine / DescribeStateMachine / UpdateStateMachine
API references.

## Changes

- `server/aws/sfn/types.go`: `loggingConfiguration`/`tracingConfiguration` typed as
  `json.RawMessage` on create; added to the update request; `rawJSON` helper.
- `server/aws/sfn/operations.go`: forward both configs to the driver on create and update.
- `server/aws/sfn/sdk_roundtrip_test.go`: regression test covering create + update round-trip
  (level, includeExecutionData, destinations, tracing enabled).

## Evidence (live: serve + real SDK, aws CLI, Terraform)

- SDK: create with logging=ALL/includeExecutionData=true + tracing enabled now describes back
  identically; config-only update (logging ERROR, tracing off) persists.
- CLI: `describe-state-machine` returns the full loggingConfiguration incl. destinations.
- Terraform `aws_sfn_state_machine` with `logging_configuration` + `tracing_configuration`:
  `terraform plan` after apply reports "No changes" (detailed-exitcode 0); an in-place update
  of the logging level re-plans clean.

Gates: `go build ./...`, `go test -race` (server/aws/sfn, providers/aws/sfn), `go vet`,
`gofmt`, `golangci-lint` (new-from-rev + full-package server/aws/sfn) all green;
`go generate ./...` leaves `docs/coverage` unchanged.
