### PR TITLE
fix(cloudwatch): real-user e2e divergences from AWS

### DIFF
--- a/providers/aws/cloudwatch/dashboards.go
+++ b/providers/aws/cloudwatch/dashboards.go
@@ -34,9 +34,11 @@ func (m *Mock) PutDashboard(_ context.Context, name, body string) error {
 	}
 
 	d := &storedDashboard{
-		Name:         name,
-		Body:         body,
-		ARN:          idgen.AWSARN("cloudwatch", m.opts.Region, m.opts.AccountID, "dashboard/"+name),
+		Name: name,
+		Body: body,
+		// CloudWatch dashboards are a global resource: their ARN carries an empty
+		// region (arn:aws:cloudwatch::account:dashboard/name), unlike alarms.
+		ARN:          idgen.AWSARN("cloudwatch", "", m.opts.AccountID, "dashboard/"+name),
 		LastModified: m.opts.Clock.Now(),
 		Size:         len(body),
 	}

--- a/server/aws/cloudwatch/handler.go
+++ b/server/aws/cloudwatch/handler.go
@@ -35,27 +35,28 @@ const (
 
 // Operation names shared by the rpc-v2-cbor and query dispatch switches.
 const (
-	opPutMetricData       = "PutMetricData"
-	opGetMetricStatistics = "GetMetricStatistics"
-	opListMetrics         = "ListMetrics"
-	opPutMetricAlarm      = "PutMetricAlarm"
-	opDescribeAlarms      = "DescribeAlarms"
-	opDeleteAlarms        = "DeleteAlarms"
-	opSetAlarmState       = "SetAlarmState"
-	opPutCompositeAlarm   = "PutCompositeAlarm"
-	opPutDashboard        = "PutDashboard"
-	opGetDashboard        = "GetDashboard"
-	opListDashboards      = "ListDashboards"
-	opDeleteDashboards    = "DeleteDashboards"
-	opPutMetricStream     = "PutMetricStream"
-	opGetMetricStream     = "GetMetricStream"
-	opListMetricStreams   = "ListMetricStreams"
-	opDeleteMetricStream  = "DeleteMetricStream"
-	opStartMetricStreams  = "StartMetricStreams"
-	opStopMetricStreams   = "StopMetricStreams"
-	opTagResource         = "TagResource"
-	opUntagResource       = "UntagResource"
-	opListTagsForResource = "ListTagsForResource"
+	opPutMetricData        = "PutMetricData"
+	opGetMetricStatistics  = "GetMetricStatistics"
+	opListMetrics          = "ListMetrics"
+	opPutMetricAlarm       = "PutMetricAlarm"
+	opDescribeAlarms       = "DescribeAlarms"
+	opDescribeAlarmHistory = "DescribeAlarmHistory"
+	opDeleteAlarms         = "DeleteAlarms"
+	opSetAlarmState        = "SetAlarmState"
+	opPutCompositeAlarm    = "PutCompositeAlarm"
+	opPutDashboard         = "PutDashboard"
+	opGetDashboard         = "GetDashboard"
+	opListDashboards       = "ListDashboards"
+	opDeleteDashboards     = "DeleteDashboards"
+	opPutMetricStream      = "PutMetricStream"
+	opGetMetricStream      = "GetMetricStream"
+	opListMetricStreams    = "ListMetricStreams"
+	opDeleteMetricStream   = "DeleteMetricStream"
+	opStartMetricStreams   = "StartMetricStreams"
+	opStopMetricStreams    = "StopMetricStreams"
+	opTagResource          = "TagResource"
+	opUntagResource        = "UntagResource"
+	opListTagsForResource  = "ListTagsForResource"
 )
 
 // Handler serves CloudWatch rpc-v2-cbor requests against a monitoring driver.
@@ -135,7 +136,7 @@ func (h *Handler) dispatch(w http.ResponseWriter, r *http.Request, op string, bo
 		h.describeAlarms(w, r, body)
 	case "DescribeAlarmsForMetric":
 		h.describeAlarmsForMetric(w, r, body)
-	case "DescribeAlarmHistory":
+	case opDescribeAlarmHistory:
 		h.describeAlarmHistory(w, r, body)
 	case opDeleteAlarms:
 		h.deleteAlarms(w, r, body)

--- a/server/aws/cloudwatch/ops.go
+++ b/server/aws/cloudwatch/ops.go
@@ -723,6 +723,7 @@ func anyActionHasPrefix(a *mondriver.AlarmInfo, prefix string) bool {
 	return false
 }
 
+//nolint:dupl // parallel to query.go toAlarmMemberXML but a distinct CBOR wire shape.
 func toMetricAlarmCBR(a *mondriver.AlarmInfo) metricAlarmCBR {
 	m := metricAlarmCBR{
 		AlarmName:               a.Name,

--- a/server/aws/cloudwatch/query.go
+++ b/server/aws/cloudwatch/query.go
@@ -42,6 +42,8 @@ func isQueryRequest(r *http.Request) bool {
 }
 
 // serveQuery handles a CloudWatch query-protocol request.
+//
+//nolint:gocyclo // first-match dispatch over many CloudWatch query actions.
 func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		writeQueryError(w, http.StatusBadRequest, "MalformedQueryString", err.Error())
@@ -63,6 +65,16 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request) {
 		h.queryDeleteAlarms(w, r)
 	case opSetAlarmState:
 		h.querySetAlarmState(w, r)
+	case opDescribeAlarmHistory:
+		h.queryDescribeAlarmHistory(w, r)
+	case opPutDashboard:
+		h.queryPutDashboard(w, r)
+	case opGetDashboard:
+		h.queryGetDashboard(w, r)
+	case opListDashboards:
+		h.queryListDashboards(w, r)
+	case opDeleteDashboards:
+		h.queryDeleteDashboards(w, r)
 	case opPutMetricStream:
 		h.queryPutMetricStream(w, r)
 	case opGetMetricStream:
@@ -255,7 +267,11 @@ func (h *Handler) queryPutMetricAlarm(w http.ResponseWriter, r *http.Request) {
 		Threshold: threshold, Period: period, EvaluationPeriods: evalPeriods, DatapointsToAlarm: datapointsToAlarm,
 		Stat: r.Form.Get("Statistic"), ExtendedStatistic: r.Form.Get("ExtendedStatistic"),
 		Unit: r.Form.Get("Unit"), TreatMissingData: r.Form.Get("TreatMissingData"),
-		AlarmActions: queryStringList(r, "AlarmActions.member."), OKActions: queryStringList(r, "OKActions.member."),
+		AlarmDescription: r.Form.Get("AlarmDescription"), ActionsEnabled: queryOptBool(r, "ActionsEnabled"),
+		AlarmActions:            queryStringList(r, "AlarmActions.member."),
+		OKActions:               queryStringList(r, "OKActions.member."),
+		InsufficientDataActions: queryStringList(r, "InsufficientDataActions.member."),
+		Tags:                    queryTagPairs(r, "Tags.member."),
 	})
 	if err != nil {
 		writeQueryDriverErr(w, err)
@@ -265,36 +281,155 @@ func (h *Handler) queryPutMetricAlarm(w http.ResponseWriter, r *http.Request) {
 	writeQueryResponse(w, "PutMetricAlarmResponse", nil)
 }
 
+// queryDescribeAlarms mirrors the rpc-v2-cbor describeAlarms: it renders the
+// full MetricAlarm shape (not just a handful of fields), honors the
+// AlarmNamePrefix / StateValue / ActionPrefix / AlarmTypes filters, and returns
+// composite alarms alongside metric alarms. The query protocol is what the AWS
+// CLI and the Terraform AWS provider actually speak to CloudWatch, so a
+// truncated reply here left aws_cloudwatch_metric_alarm in perpetual drift.
 func (h *Handler) queryDescribeAlarms(w http.ResponseWriter, r *http.Request) {
-	alarms, err := h.monitoring.DescribeAlarms(r.Context(), queryStringList(r, "AlarmNames.member."))
-	if err != nil {
-		writeQueryDriverErr(w, err)
-		return
+	in := describeAlarmsInput{
+		AlarmNames:      queryStringList(r, "AlarmNames.member."),
+		AlarmNamePrefix: r.Form.Get("AlarmNamePrefix"),
+		AlarmTypes:      queryStringList(r, "AlarmTypes.member."),
+		StateValue:      r.Form.Get("StateValue"),
+		ActionPrefix:    r.Form.Get("ActionPrefix"),
 	}
 
-	sort.SliceStable(alarms, func(i, j int) bool { return alarms[i].Name < alarms[j].Name })
+	members := make([]alarmMemberXML, 0)
+
+	if wantsAlarmType(in.AlarmTypes, alarmTypeMetric) {
+		alarms, err := h.monitoring.DescribeAlarms(r.Context(), in.AlarmNames)
+		if err != nil {
+			writeQueryDriverErr(w, err)
+			return
+		}
+
+		for i := range alarms {
+			if !alarmMatchesFilters(&alarms[i], &in) {
+				continue
+			}
+
+			members = append(members, toAlarmMemberXML(&alarms[i]))
+		}
+	}
+
+	sort.SliceStable(members, func(i, j int) bool { return members[i].AlarmName < members[j].AlarmName })
 
 	size := maxAlarmPageSize
 	if v, _ := strconv.Atoi(r.Form.Get("MaxRecords")); v > 0 {
 		size = v
 	}
 
-	from, to, next := pageWindow(len(alarms), decodeOffsetToken(r.Form.Get("NextToken")), size)
+	offset := decodeOffsetToken(r.Form.Get("NextToken"))
+	from, to, next := pageWindow(len(members), offset, size)
 
-	members := make([]alarmMemberXML, 0, to-from)
-	for i := from; i < to; i++ {
-		members = append(members, alarmMemberXML{
-			AlarmName: alarms[i].Name, Namespace: alarms[i].Namespace, MetricName: alarms[i].MetricName,
-			StateValue: alarms[i].State, ComparisonOperator: alarms[i].ComparisonOperator, Threshold: alarms[i].Threshold,
-		})
-	}
-
-	result := describeAlarmsResultXML{MetricAlarms: members}
+	result := describeAlarmsResultXML{MetricAlarms: members[from:to]}
 	if next > 0 {
 		result.NextToken = encodeOffsetToken(next)
 	}
 
+	// Composite alarms are a small, separate collection returned in full on the
+	// first page so they aren't duplicated across metric-alarm pages.
+	if offset == 0 && wantsAlarmType(in.AlarmTypes, alarmTypeComposite) {
+		composites, err := h.compositeAlarmRows(r, &in)
+		if err != nil {
+			writeQueryDriverErr(w, err)
+			return
+		}
+
+		result.CompositeAlarms = toCompositeAlarmMemberXMLs(composites)
+	}
+
 	writeQueryResponse(w, "DescribeAlarmsResponse", result)
+}
+
+// toAlarmMemberXML renders an AlarmInfo as the full query-protocol MetricAlarm
+// member, matching every field the rpc-v2-cbor path returns so a Terraform read
+// round-trips without drift.
+//
+//nolint:dupl // parallel to ops.go toMetricAlarmCBR but a distinct XML wire shape.
+func toAlarmMemberXML(a *mondriver.AlarmInfo) alarmMemberXML {
+	m := alarmMemberXML{
+		AlarmName:               a.Name,
+		AlarmArn:                a.AlarmArn,
+		AlarmDescription:        a.AlarmDescription,
+		Namespace:               a.Namespace,
+		MetricName:              a.MetricName,
+		Dimensions:              dimsToXML(a.Dimensions),
+		StateValue:              a.State,
+		StateReason:             a.StateReason,
+		ComparisonOperator:      a.ComparisonOperator,
+		Threshold:               a.Threshold,
+		Period:                  a.Period,
+		EvaluationPeriods:       a.EvaluationPeriods,
+		DatapointsToAlarm:       a.DatapointsToAlarm,
+		Statistic:               a.Statistic,
+		ExtendedStatistic:       a.ExtendedStatistic,
+		Unit:                    a.Unit,
+		TreatMissingData:        a.TreatMissingData,
+		ActionsEnabled:          a.ActionsEnabled,
+		AlarmActions:            a.AlarmActions,
+		OKActions:               a.OKActions,
+		InsufficientDataActions: a.InsufficientDataActions,
+	}
+
+	if !a.StateUpdatedTimestamp.IsZero() {
+		m.StateUpdatedTimestamp = a.StateUpdatedTimestamp.UTC().Format(time.RFC3339)
+	}
+
+	return m
+}
+
+// dimsToXML renders a dimension map as sorted wire dimensions for stable output.
+func dimsToXML(dims map[string]string) []dimensionXML {
+	if len(dims) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(dims))
+	for k := range dims {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	out := make([]dimensionXML, 0, len(dims))
+	for _, k := range keys {
+		out = append(out, dimensionXML{Name: k, Value: dims[k]})
+	}
+
+	return out
+}
+
+// toCompositeAlarmMemberXMLs converts the shared composite-alarm rows to their
+// query-protocol XML members.
+func toCompositeAlarmMemberXMLs(rows []compositeAlarmCBR) []compositeAlarmMemberXML {
+	out := make([]compositeAlarmMemberXML, 0, len(rows))
+
+	for i := range rows {
+		row := &rows[i]
+		m := compositeAlarmMemberXML{
+			AlarmName:               row.AlarmName,
+			AlarmArn:                row.AlarmArn,
+			AlarmRule:               row.AlarmRule,
+			AlarmDescription:        row.AlarmDescription,
+			StateValue:              row.StateValue,
+			StateReason:             row.StateReason,
+			ActionsEnabled:          row.ActionsEnabled,
+			AlarmActions:            row.AlarmActions,
+			OKActions:               row.OKActions,
+			InsufficientDataActions: row.InsufficientDataActions,
+		}
+
+		if row.StateUpdatedTimestamp != nil {
+			m.StateUpdatedTimestamp = row.StateUpdatedTimestamp.UTC().Format(time.RFC3339)
+		}
+
+		out = append(out, m)
+	}
+
+	return out
 }
 
 func (h *Handler) queryDeleteAlarms(w http.ResponseWriter, r *http.Request) {
@@ -375,6 +510,23 @@ func queryFloatList(r *http.Request, prefix string) []float64 {
 	return out
 }
 
+// queryOptBool returns a *bool for a form field that AWS treats as optional
+// with a default (e.g. ActionsEnabled defaults to true when absent). An absent
+// or unparseable value yields nil so the backend applies its own default.
+func queryOptBool(r *http.Request, field string) *bool {
+	raw := r.Form.Get(field)
+	if raw == "" {
+		return nil
+	}
+
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		return nil
+	}
+
+	return &v
+}
+
 func queryStringList(r *http.Request, prefix string) []string {
 	var out []string
 
@@ -434,19 +586,55 @@ type getStatsResultXML struct {
 	Datapoints []datapointXML `xml:"Datapoints>member"`
 }
 
+type dimensionXML struct {
+	Name  string `xml:"Name"`
+	Value string `xml:"Value"`
+}
+
 type alarmMemberXML struct {
-	AlarmName          string  `xml:"AlarmName"`
-	Namespace          string  `xml:"Namespace"`
-	MetricName         string  `xml:"MetricName"`
-	StateValue         string  `xml:"StateValue"`
-	ComparisonOperator string  `xml:"ComparisonOperator"`
-	Threshold          float64 `xml:"Threshold"`
+	AlarmName               string         `xml:"AlarmName"`
+	AlarmArn                string         `xml:"AlarmArn,omitempty"`
+	AlarmDescription        string         `xml:"AlarmDescription,omitempty"`
+	Namespace               string         `xml:"Namespace,omitempty"`
+	MetricName              string         `xml:"MetricName,omitempty"`
+	Dimensions              []dimensionXML `xml:"Dimensions>member,omitempty"`
+	StateValue              string         `xml:"StateValue"`
+	StateReason             string         `xml:"StateReason,omitempty"`
+	StateUpdatedTimestamp   string         `xml:"StateUpdatedTimestamp,omitempty"`
+	ComparisonOperator      string         `xml:"ComparisonOperator"`
+	Threshold               float64        `xml:"Threshold"`
+	Period                  int            `xml:"Period,omitempty"`
+	EvaluationPeriods       int            `xml:"EvaluationPeriods,omitempty"`
+	DatapointsToAlarm       int            `xml:"DatapointsToAlarm,omitempty"`
+	Statistic               string         `xml:"Statistic,omitempty"`
+	ExtendedStatistic       string         `xml:"ExtendedStatistic,omitempty"`
+	Unit                    string         `xml:"Unit,omitempty"`
+	TreatMissingData        string         `xml:"TreatMissingData,omitempty"`
+	ActionsEnabled          bool           `xml:"ActionsEnabled"`
+	AlarmActions            []string       `xml:"AlarmActions>member,omitempty"`
+	OKActions               []string       `xml:"OKActions>member,omitempty"`
+	InsufficientDataActions []string       `xml:"InsufficientDataActions>member,omitempty"`
+}
+
+type compositeAlarmMemberXML struct {
+	AlarmName               string   `xml:"AlarmName"`
+	AlarmArn                string   `xml:"AlarmArn,omitempty"`
+	AlarmRule               string   `xml:"AlarmRule"`
+	AlarmDescription        string   `xml:"AlarmDescription,omitempty"`
+	StateValue              string   `xml:"StateValue"`
+	StateReason             string   `xml:"StateReason,omitempty"`
+	StateUpdatedTimestamp   string   `xml:"StateUpdatedTimestamp,omitempty"`
+	ActionsEnabled          bool     `xml:"ActionsEnabled"`
+	AlarmActions            []string `xml:"AlarmActions>member,omitempty"`
+	OKActions               []string `xml:"OKActions>member,omitempty"`
+	InsufficientDataActions []string `xml:"InsufficientDataActions>member,omitempty"`
 }
 
 type describeAlarmsResultXML struct {
-	XMLName      xml.Name         `xml:"DescribeAlarmsResult"`
-	MetricAlarms []alarmMemberXML `xml:"MetricAlarms>member"`
-	NextToken    string           `xml:"NextToken,omitempty"`
+	XMLName         xml.Name                  `xml:"DescribeAlarmsResult"`
+	MetricAlarms    []alarmMemberXML          `xml:"MetricAlarms>member"`
+	CompositeAlarms []compositeAlarmMemberXML `xml:"CompositeAlarms>member,omitempty"`
+	NextToken       string                    `xml:"NextToken,omitempty"`
 }
 
 // writeQueryResponse writes an AWS query-protocol XML envelope. result may be

--- a/server/aws/cloudwatch/query_dashboards.go
+++ b/server/aws/cloudwatch/query_dashboards.go
@@ -1,0 +1,201 @@
+package cloudwatch
+
+// The AWS CLI and the Terraform AWS provider speak CloudWatch's classic query
+// protocol (form-encoded POST, XML responses). This file adds the query-protocol
+// dashboard operations (backing aws_cloudwatch_dashboard) and DescribeAlarmHistory
+// so those clients work — the rpc-v2-cbor twins live in dashboards.go and
+// metric_data_ops.go.
+
+import (
+	"encoding/xml"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+func (h *Handler) queryPutDashboard(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.monitoring.(dashboardStore)
+	if !ok {
+		writeQueryError(w, http.StatusBadRequest, "InvalidAction", "dashboards not supported")
+		return
+	}
+
+	if err := store.PutDashboard(r.Context(), r.Form.Get("DashboardName"), r.Form.Get("DashboardBody")); err != nil {
+		writeQueryDriverErr(w, err)
+		return
+	}
+
+	writeQueryResponse(w, "PutDashboardResponse", putDashboardResultXML{})
+}
+
+func (h *Handler) queryGetDashboard(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.monitoring.(dashboardStore)
+	if !ok {
+		writeQueryError(w, http.StatusBadRequest, "InvalidAction", "dashboards not supported")
+		return
+	}
+
+	d, err := store.GetDashboard(r.Context(), r.Form.Get("DashboardName"))
+	if err != nil {
+		writeQueryDriverErr(w, err)
+		return
+	}
+
+	writeQueryResponse(w, "GetDashboardResponse", getDashboardResultXML{
+		DashboardArn:  d.ARN,
+		DashboardName: d.Name,
+		DashboardBody: d.Body,
+	})
+}
+
+func (h *Handler) queryListDashboards(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.monitoring.(dashboardStore)
+	if !ok {
+		writeQueryError(w, http.StatusBadRequest, "InvalidAction", "dashboards not supported")
+		return
+	}
+
+	entries, err := store.ListDashboards(r.Context(), r.Form.Get("DashboardNamePrefix"))
+	if err != nil {
+		writeQueryDriverErr(w, err)
+		return
+	}
+
+	from, to, next := pageWindow(len(entries), decodeOffsetToken(r.Form.Get("NextToken")), dashboardPageSize)
+
+	rows := make([]dashboardEntryXML, 0, to-from)
+	for _, e := range entries[from:to] {
+		rows = append(rows, dashboardEntryXML{
+			DashboardName: e.Name,
+			DashboardArn:  e.ARN,
+			LastModified:  e.LastModified.UTC().Format(time.RFC3339),
+			Size:          int64(e.Size),
+		})
+	}
+
+	result := listDashboardsResultXML{DashboardEntries: rows}
+	if next > 0 {
+		result.NextToken = encodeOffsetToken(next)
+	}
+
+	writeQueryResponse(w, "ListDashboardsResponse", result)
+}
+
+func (h *Handler) queryDeleteDashboards(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.monitoring.(dashboardStore)
+	if !ok {
+		writeQueryError(w, http.StatusBadRequest, "InvalidAction", "dashboards not supported")
+		return
+	}
+
+	if err := store.DeleteDashboards(r.Context(), queryStringList(r, "DashboardNames.member.")); err != nil {
+		writeQueryDriverErr(w, err)
+		return
+	}
+
+	writeQueryResponse(w, "DeleteDashboardsResponse", deleteDashboardsResultXML{})
+}
+
+// queryDescribeAlarmHistory is the query-protocol twin of describeAlarmHistory,
+// reusing the shared filter/paging helpers so ordering and MaxRecords behave
+// identically to the rpc-v2-cbor path.
+func (h *Handler) queryDescribeAlarmHistory(w http.ResponseWriter, r *http.Request) {
+	in := describeAlarmHistoryInput{
+		AlarmName:       r.Form.Get("AlarmName"),
+		HistoryItemType: r.Form.Get("HistoryItemType"),
+		ScanBy:          r.Form.Get("ScanBy"),
+		StartDate:       queryOptTime(r, "StartDate"),
+		EndDate:         queryOptTime(r, "EndDate"),
+		NextToken:       r.Form.Get("NextToken"),
+	}
+	if v, _ := strconv.Atoi(r.Form.Get("MaxRecords")); v > 0 {
+		in.MaxRecords = v
+	}
+
+	entries, err := h.monitoring.GetAlarmHistory(r.Context(), in.AlarmName, 0)
+	if err != nil {
+		writeQueryDriverErr(w, err)
+		return
+	}
+
+	items, next := pageAlarmHistory(filterAlarmHistory(entries, &in), &in)
+
+	members := make([]alarmHistoryMemberXML, 0, len(items))
+	for i := range items {
+		members = append(members, alarmHistoryMemberXML{
+			AlarmName:       items[i].AlarmName,
+			Timestamp:       items[i].Timestamp.UTC().Format(time.RFC3339),
+			HistoryItemType: items[i].HistoryItemType,
+			HistorySummary:  items[i].HistorySummary,
+			HistoryData:     items[i].HistoryData,
+		})
+	}
+
+	result := describeAlarmHistoryResultXML{AlarmHistoryItems: members}
+	if next != "" {
+		result.NextToken = next
+	}
+
+	writeQueryResponse(w, "DescribeAlarmHistoryResponse", result)
+}
+
+// queryOptTime parses an ISO8601 timestamp form field, returning nil when absent
+// or unparseable so callers treat it as an open bound.
+func queryOptTime(r *http.Request, field string) *time.Time {
+	raw := r.Form.Get(field)
+	if raw == "" {
+		return nil
+	}
+
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return nil
+	}
+
+	return &t
+}
+
+// ---- XML response shapes (query protocol, 2010-08-01) ----
+
+type putDashboardResultXML struct {
+	XMLName                     xml.Name `xml:"PutDashboardResult"`
+	DashboardValidationMessages struct{} `xml:"DashboardValidationMessages"`
+}
+
+type getDashboardResultXML struct {
+	XMLName       xml.Name `xml:"GetDashboardResult"`
+	DashboardArn  string   `xml:"DashboardArn"`
+	DashboardName string   `xml:"DashboardName"`
+	DashboardBody string   `xml:"DashboardBody"`
+}
+
+type dashboardEntryXML struct {
+	DashboardName string `xml:"DashboardName"`
+	DashboardArn  string `xml:"DashboardArn"`
+	LastModified  string `xml:"LastModified"`
+	Size          int64  `xml:"Size"`
+}
+
+type listDashboardsResultXML struct {
+	XMLName          xml.Name            `xml:"ListDashboardsResult"`
+	DashboardEntries []dashboardEntryXML `xml:"DashboardEntries>member"`
+	NextToken        string              `xml:"NextToken,omitempty"`
+}
+
+type deleteDashboardsResultXML struct {
+	XMLName xml.Name `xml:"DeleteDashboardsResult"`
+}
+
+type alarmHistoryMemberXML struct {
+	AlarmName       string `xml:"AlarmName"`
+	Timestamp       string `xml:"Timestamp"`
+	HistoryItemType string `xml:"HistoryItemType"`
+	HistorySummary  string `xml:"HistorySummary,omitempty"`
+	HistoryData     string `xml:"HistoryData,omitempty"`
+}
+
+type describeAlarmHistoryResultXML struct {
+	XMLName           xml.Name                `xml:"DescribeAlarmHistoryResult"`
+	AlarmHistoryItems []alarmHistoryMemberXML `xml:"AlarmHistoryItems>member"`
+	NextToken         string                  `xml:"NextToken,omitempty"`
+}

--- a/server/aws/cloudwatch/query_fidelity_test.go
+++ b/server/aws/cloudwatch/query_fidelity_test.go
@@ -1,0 +1,170 @@
+package cloudwatch_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cwprovider "github.com/stackshy/cloudemu/v2/providers/aws/cloudwatch"
+	cwserver "github.com/stackshy/cloudemu/v2/server/aws/cloudwatch"
+)
+
+// newQueryPoster returns a helper that POSTs a CloudWatch query-protocol form to
+// a fresh handler-backed test server and returns the status code and body.
+func newQueryPoster(t *testing.T) func(url.Values) (int, string) {
+	t.Helper()
+
+	h := cwserver.New(cwprovider.New(config.NewOptions()))
+	ts := httptest.NewServer(h)
+	t.Cleanup(ts.Close)
+
+	return func(form url.Values) (int, string) {
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Authorization", monitoringAuth)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		defer resp.Body.Close()
+
+		b, _ := io.ReadAll(resp.Body)
+
+		return resp.StatusCode, string(b)
+	}
+}
+
+// TestQueryDescribeAlarmsFullFidelity guards against the Terraform-drift bug
+// where the query-protocol DescribeAlarms returned only a handful of fields:
+// aws_cloudwatch_metric_alarm reads DescribeAlarms on every refresh, so a
+// missing field looks like drift and never converges.
+func TestQueryDescribeAlarmsFullFidelity(t *testing.T) {
+	post := newQueryPoster(t)
+
+	if code, body := post(url.Values{
+		"Action": {"PutMetricAlarm"}, "AlarmName": {"cpu"}, "Namespace": {"AWS/EC2"}, "MetricName": {"CPUUtilization"},
+		"ComparisonOperator": {"GreaterThanThreshold"}, "EvaluationPeriods": {"3"}, "DatapointsToAlarm": {"2"},
+		"Period": {"60"}, "Threshold": {"75"}, "Statistic": {"Average"}, "Unit": {"Percent"},
+		"TreatMissingData": {"notBreaching"}, "AlarmDescription": {"desc"}, "ActionsEnabled": {"false"},
+		"Dimensions.member.1.Name": {"InstanceId"}, "Dimensions.member.1.Value": {"i-abc"},
+		"AlarmActions.member.1":            {"arn:aws:sns:us-east-1:123456789012:t1"},
+		"InsufficientDataActions.member.1": {"arn:aws:sns:us-east-1:123456789012:t2"},
+	}); code != 200 {
+		t.Fatalf("PutMetricAlarm: code=%d body=%s", code, body)
+	}
+
+	code, body := post(url.Values{"Action": {"DescribeAlarms"}, "AlarmNames.member.1": {"cpu"}})
+	if code != 200 {
+		t.Fatalf("DescribeAlarms: code=%d body=%s", code, body)
+	}
+
+	for _, want := range []string{
+		"<AlarmArn>arn:aws:cloudwatch:us-east-1:123456789012:alarm:cpu</AlarmArn>",
+		"<AlarmDescription>desc</AlarmDescription>",
+		"<Period>60</Period>",
+		"<EvaluationPeriods>3</EvaluationPeriods>",
+		"<DatapointsToAlarm>2</DatapointsToAlarm>",
+		"<Statistic>Average</Statistic>",
+		"<Unit>Percent</Unit>",
+		"<TreatMissingData>notBreaching</TreatMissingData>",
+		"<ComparisonOperator>GreaterThanThreshold</ComparisonOperator>",
+		"<ActionsEnabled>false</ActionsEnabled>",
+		"<Name>InstanceId</Name>",
+		"<Value>i-abc</Value>",
+		"arn:aws:sns:us-east-1:123456789012:t1",
+		"arn:aws:sns:us-east-1:123456789012:t2",
+		"<StateValue>INSUFFICIENT_DATA</StateValue>",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("DescribeAlarms missing %q\nbody: %s", want, body)
+		}
+	}
+}
+
+// TestQueryDescribeAlarmsFilters verifies the query DescribeAlarms honors the
+// AlarmNamePrefix, StateValue, and AlarmTypes filters like the rpc-v2-cbor path.
+func TestQueryDescribeAlarmsFilters(t *testing.T) {
+	post := newQueryPoster(t)
+
+	for _, name := range []string{"prod-a", "prod-b", "dev-a"} {
+		post(url.Values{
+			"Action": {"PutMetricAlarm"}, "AlarmName": {name}, "Namespace": {"AWS/EC2"}, "MetricName": {"CPUUtilization"},
+			"ComparisonOperator": {"GreaterThanThreshold"}, "EvaluationPeriods": {"1"}, "Period": {"60"}, "Threshold": {"1"},
+			"Statistic": {"Average"},
+		})
+	}
+
+	_, body := post(url.Values{"Action": {"DescribeAlarms"}, "AlarmNamePrefix": {"prod-"}})
+	if !strings.Contains(body, "prod-a") || !strings.Contains(body, "prod-b") || strings.Contains(body, "dev-a") {
+		t.Fatalf("AlarmNamePrefix filter failed: %s", body)
+	}
+
+	// AlarmTypes=CompositeAlarm must exclude all metric alarms.
+	_, body = post(url.Values{"Action": {"DescribeAlarms"}, "AlarmTypes.member.1": {"CompositeAlarm"}})
+	if strings.Contains(body, "<AlarmName>prod-a</AlarmName>") {
+		t.Fatalf("AlarmTypes=CompositeAlarm should exclude metric alarms: %s", body)
+	}
+}
+
+// TestQueryDashboards verifies the query-protocol dashboard operations that back
+// the aws_cloudwatch_dashboard Terraform resource and the AWS CLI.
+func TestQueryDashboards(t *testing.T) {
+	post := newQueryPoster(t)
+
+	if code, body := post(url.Values{
+		"Action": {"PutDashboard"}, "DashboardName": {"ops"}, "DashboardBody": {`{"widgets":[]}`},
+	}); code != 200 || !strings.Contains(body, "PutDashboardResult") {
+		t.Fatalf("PutDashboard: code=%d body=%s", code, body)
+	}
+
+	code, body := post(url.Values{"Action": {"GetDashboard"}, "DashboardName": {"ops"}})
+	if code != 200 || !strings.Contains(body, `<DashboardBody>{&#34;widgets&#34;:[]}</DashboardBody>`) {
+		t.Fatalf("GetDashboard: code=%d body=%s", code, body)
+	}
+	// Dashboards are global: the ARN carries an empty region.
+	if !strings.Contains(body, "<DashboardArn>arn:aws:cloudwatch::123456789012:dashboard/ops</DashboardArn>") {
+		t.Fatalf("GetDashboard ARN not region-less: %s", body)
+	}
+
+	if code, body := post(url.Values{"Action": {"ListDashboards"}}); code != 200 ||
+		!strings.Contains(body, "<DashboardName>ops</DashboardName>") {
+		t.Fatalf("ListDashboards: code=%d body=%s", code, body)
+	}
+
+	if code, body := post(url.Values{"Action": {"DeleteDashboards"}, "DashboardNames.member.1": {"ops"}}); code != 200 {
+		t.Fatalf("DeleteDashboards: code=%d body=%s", code, body)
+	}
+
+	// Deleting a missing dashboard is a ResourceNotFound (all-or-nothing).
+	if code, body := post(url.Values{"Action": {"GetDashboard"}, "DashboardName": {"ops"}}); code != 404 {
+		t.Fatalf("GetDashboard after delete should be 404: code=%d body=%s", code, body)
+	}
+}
+
+// TestQueryDescribeAlarmHistory verifies the query-protocol DescribeAlarmHistory
+// surfaces the transition recorded by SetAlarmState.
+func TestQueryDescribeAlarmHistory(t *testing.T) {
+	post := newQueryPoster(t)
+
+	post(url.Values{
+		"Action": {"PutMetricAlarm"}, "AlarmName": {"h1"}, "Namespace": {"AWS/EC2"}, "MetricName": {"CPUUtilization"},
+		"ComparisonOperator": {"GreaterThanThreshold"}, "EvaluationPeriods": {"1"}, "Period": {"60"}, "Threshold": {"1"},
+		"Statistic": {"Average"},
+	})
+	post(url.Values{"Action": {"SetAlarmState"}, "AlarmName": {"h1"}, "StateValue": {"ALARM"}, "StateReason": {"boom"}})
+
+	code, body := post(url.Values{"Action": {"DescribeAlarmHistory"}, "AlarmName": {"h1"}})
+	if code != 200 {
+		t.Fatalf("DescribeAlarmHistory: code=%d body=%s", code, body)
+	}
+
+	if !strings.Contains(body, "<AlarmName>h1</AlarmName>") ||
+		!strings.Contains(body, "<HistoryItemType>StateUpdate</HistoryItemType>") {
+		t.Fatalf("DescribeAlarmHistory missing entry: %s", body)
+	}
+}


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of AWS CloudWatch (metrics + alarms + dashboards) against the AWS CLI and Terraform (`aws_cloudwatch_metric_alarm`, `aws_cloudwatch_dashboard`).

Key finding: **both the AWS CLI (v2.31) and the Terraform AWS provider (v5.100, aws-sdk-go-v2) speak CloudWatch's classic query protocol** (form POST + XML), not rpc-v2-cbor. The query path was significantly less complete than the CBOR path, causing real, reproducible divergences from AWS.

## Divergences fixed

| # | Severity | Divergence | Fix |
|---|----------|-----------|-----|
| 1 | High | `DescribeAlarms` (query) returned only 6 fields → `aws_cloudwatch_metric_alarm` in **perpetual Terraform drift** (period, evaluation_periods, statistic, dimensions, actions_enabled, datapoints_to_alarm, alarm_description, tags all re-applied every plan) | Full MetricAlarm XML (arn, description, dimensions, period, evaluation_periods, datapoints_to_alarm, statistic/extended_statistic, unit, treat_missing_data, actions_enabled, all action lists, state_reason, state_updated_timestamp) + composite alarms + AlarmNamePrefix/StateValue/ActionPrefix/AlarmTypes filters |
| 2 | High | `PutDashboard`/`GetDashboard`/`ListDashboards`/`DeleteDashboards` (query) → `InvalidAction`; `aws_cloudwatch_dashboard` **failed to create** | Added the query-protocol dashboard operations |
| 3 | Med | `PutMetricAlarm` (query) dropped ActionsEnabled, AlarmDescription, InsufficientDataActions, Tags | Parse them (ActionsEnabled via optional bool → AWS default true) |
| 4 | Med | `DescribeAlarmHistory` (query) → `InvalidAction` (`aws cloudwatch describe-alarm-history`) | Added query-protocol handler reusing the shared filter/paging helpers |
| 5 | Low | Dashboard ARN carried a region; real CloudWatch dashboards are global | ARN is now region-less: `arn:aws:cloudwatch::acct:dashboard/name` |

## Verification (live)

- Terraform `apply` then `plan` → **No changes** (drift eliminated); `destroy` clean.
- AWS CLI: `describe-alarms` returns full objects; `describe-alarm-history`, `put/get/list/delete-dashboard` all work.
- EC2/S3 auto-metric emission (root integration test) unaffected.

Gates: `go build ./...`, `go test -race` (server/aws/cloudwatch, providers/aws/cloudwatch, services/monitoring), root `go test`, `go vet`, `gofmt`, `golangci-lint --new-from-rev=origin/development` (0 new issues), `go generate ./...` (no coverage diff).
