### PR TITLE
feat(gce): InstanceGroupManager support + GKE node_count round-trip

### DIFF
--- a/providers/gcp/compute/gce.go
+++ b/providers/gcp/compute/gce.go
@@ -110,6 +110,7 @@ type Mock struct {
 	snapshots    *memstore.Store[*driver.SnapshotInfo]
 	images       *memstore.Store[*driver.ImageInfo]
 	keyPairs     *memstore.Store[*driver.KeyPairInfo]
+	migs         *memstore.Store[InstanceGroupManager]
 	sm           *statemachine.Machine
 	opts         *config.Options
 	ipCounter    atomic.Int64
@@ -230,6 +231,7 @@ func New(opts *config.Options) *Mock {
 		snapshots:    memstore.New[*driver.SnapshotInfo](),
 		images:       memstore.New[*driver.ImageInfo](),
 		keyPairs:     memstore.New[*driver.KeyPairInfo](),
+		migs:         memstore.New[InstanceGroupManager](),
 		sm:           statemachine.New(compute.VMTransitions()),
 		opts:         opts,
 	}

--- a/providers/gcp/compute/instancegroupmanager.go
+++ b/providers/gcp/compute/instancegroupmanager.go
@@ -1,0 +1,134 @@
+package compute
+
+import (
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// InstanceGroupManager is the in-memory record backing a zonal GCE managed
+// instance group (compute#instanceGroupManager). Only the fields the emulator
+// round-trips are modeled — targetSize is the load-bearing one, since the
+// Terraform google provider derives a GKE node pool's node_count by summing the
+// targetSize of the MIGs its instanceGroupUrls point at. Host-dependent links
+// (selfLink, zone URL, instanceGroup URL) are built by the wire handler from the
+// request host, so they are not stored here.
+type InstanceGroupManager struct {
+	Name             string `json:"name"`
+	Zone             string `json:"zone"`
+	TargetSize       int    `json:"targetSize"`
+	BaseInstanceName string `json:"baseInstanceName,omitempty"`
+	InstanceTemplate string `json:"instanceTemplate,omitempty"`
+	CreatedAt        string `json:"createdAt,omitempty"`
+}
+
+// migKey scopes a managed instance group by zone, since MIG names are unique
+// per-zone (the same name in two zones is two distinct groups).
+func migKey(zone, name string) string {
+	return zone + "/" + name
+}
+
+// CreateInstanceGroupManagerGCP registers a zonal MIG, rejecting a duplicate
+// name in the same zone. Used by the compute wire handler's insert route
+// (google_compute_instance_group_manager / instanceGroupManagers.insert).
+//
+//nolint:gocritic // hugeParam: value struct is the natural record shape here.
+func (m *Mock) CreateInstanceGroupManagerGCP(igm InstanceGroupManager) error {
+	if igm.Name == "" {
+		return cerrors.New(cerrors.InvalidArgument, "instance group manager name is required")
+	}
+
+	if igm.Zone == "" {
+		return cerrors.New(cerrors.InvalidArgument, "instance group manager zone is required")
+	}
+
+	if igm.CreatedAt == "" {
+		igm.CreatedAt = m.opts.Clock.Now().UTC().Format(timeFormat)
+	}
+
+	if !m.migs.SetIfAbsent(migKey(igm.Zone, igm.Name), igm) {
+		return cerrors.Newf(cerrors.AlreadyExists, "instance group manager %q already exists in zone %q", igm.Name, igm.Zone)
+	}
+
+	return nil
+}
+
+// UpsertInstanceGroupManagerGCP creates or overwrites a MIG, preserving the
+// original creation timestamp on an update. It is the idempotent write GKE uses
+// to keep a node pool's backing MIG targetSize in sync with the pool's node
+// count, so a repeated reconcile (cluster create, pool create, pool resize)
+// never errors on an already-present group.
+//
+//nolint:gocritic // hugeParam: value struct is the natural record shape here.
+func (m *Mock) UpsertInstanceGroupManagerGCP(igm InstanceGroupManager) {
+	if igm.Name == "" || igm.Zone == "" {
+		return
+	}
+
+	if existing, ok := m.migs.Get(migKey(igm.Zone, igm.Name)); ok && existing.CreatedAt != "" {
+		igm.CreatedAt = existing.CreatedAt
+	}
+
+	if igm.CreatedAt == "" {
+		igm.CreatedAt = m.opts.Clock.Now().UTC().Format(timeFormat)
+	}
+
+	m.migs.Set(migKey(igm.Zone, igm.Name), igm)
+}
+
+// GetInstanceGroupManagerGCP returns a MIG by zone and name.
+func (m *Mock) GetInstanceGroupManagerGCP(zone, name string) (InstanceGroupManager, bool) {
+	return m.migs.Get(migKey(zone, name))
+}
+
+// ListInstanceGroupManagersGCP returns every MIG in the given zone.
+func (m *Mock) ListInstanceGroupManagersGCP(zone string) []InstanceGroupManager {
+	all := m.migs.All()
+	out := make([]InstanceGroupManager, 0, len(all))
+
+	for _, igm := range all {
+		if igm.Zone == zone {
+			out = append(out, igm)
+		}
+	}
+
+	return out
+}
+
+// AllInstanceGroupManagersGCP returns every MIG across all zones, for
+// aggregatedList.
+func (m *Mock) AllInstanceGroupManagersGCP() []InstanceGroupManager {
+	all := m.migs.All()
+	out := make([]InstanceGroupManager, 0, len(all))
+
+	for _, igm := range all {
+		out = append(out, igm)
+	}
+
+	return out
+}
+
+// DeleteInstanceGroupManagerGCP removes a MIG. A missing group is a no-op for
+// GKE cleanup callers, but the wire delete route checks existence first and
+// returns 404 itself, so this never needs to surface NotFound.
+func (m *Mock) DeleteInstanceGroupManagerGCP(zone, name string) error {
+	m.migs.Delete(migKey(zone, name))
+	return nil
+}
+
+// ResizeInstanceGroupManagerGCP sets a MIG's targetSize (instanceGroupManagers.
+// resize / setTargetSize). Returns NotFound when the group does not exist.
+func (m *Mock) ResizeInstanceGroupManagerGCP(zone, name string, size int) error {
+	if size < 0 {
+		return cerrors.New(cerrors.InvalidArgument, "targetSize must be >= 0")
+	}
+
+	updated := m.migs.Update(migKey(zone, name), func(igm InstanceGroupManager) InstanceGroupManager {
+		igm.TargetSize = size
+		return igm
+	})
+
+	if !updated {
+		return cerrors.Newf(cerrors.NotFound, "instance group manager %q not found in zone %q", name, zone)
+	}
+
+	return nil
+}

--- a/providers/gcp/compute/instancegroupmanager_test.go
+++ b/providers/gcp/compute/instancegroupmanager_test.go
@@ -1,0 +1,92 @@
+package compute
+
+import (
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstanceGroupManagerCRUD(t *testing.T) {
+	m := newTestMock()
+
+	require.NoError(t, m.CreateInstanceGroupManagerGCP(InstanceGroupManager{
+		Name: "web-mig", Zone: "us-central1-a", TargetSize: 3, BaseInstanceName: "web",
+	}))
+
+	got, ok := m.GetInstanceGroupManagerGCP("us-central1-a", "web-mig")
+	require.True(t, ok)
+	assert.Equal(t, 3, got.TargetSize)
+	assert.Equal(t, "web", got.BaseInstanceName)
+	assert.NotEmpty(t, got.CreatedAt)
+
+	list := m.ListInstanceGroupManagersGCP("us-central1-a")
+	require.Len(t, list, 1)
+	assert.Equal(t, "web-mig", list[0].Name)
+
+	// A different zone is a distinct scope.
+	assert.Empty(t, m.ListInstanceGroupManagersGCP("us-central1-b"))
+
+	require.NoError(t, m.DeleteInstanceGroupManagerGCP("us-central1-a", "web-mig"))
+
+	_, ok = m.GetInstanceGroupManagerGCP("us-central1-a", "web-mig")
+	assert.False(t, ok)
+}
+
+func TestInstanceGroupManagerDuplicateAndValidation(t *testing.T) {
+	m := newTestMock()
+
+	require.NoError(t, m.CreateInstanceGroupManagerGCP(InstanceGroupManager{Name: "a", Zone: "z1", TargetSize: 1}))
+
+	err := m.CreateInstanceGroupManagerGCP(InstanceGroupManager{Name: "a", Zone: "z1"})
+	require.Error(t, err)
+	assert.True(t, cerrors.IsAlreadyExists(err))
+
+	// Same name in another zone is allowed.
+	require.NoError(t, m.CreateInstanceGroupManagerGCP(InstanceGroupManager{Name: "a", Zone: "z2", TargetSize: 1}))
+
+	assert.True(t, cerrors.IsInvalidArgument(m.CreateInstanceGroupManagerGCP(InstanceGroupManager{Zone: "z1"})))
+	assert.True(t, cerrors.IsInvalidArgument(m.CreateInstanceGroupManagerGCP(InstanceGroupManager{Name: "x"})))
+}
+
+func TestInstanceGroupManagerResize(t *testing.T) {
+	m := newTestMock()
+
+	require.NoError(t, m.CreateInstanceGroupManagerGCP(InstanceGroupManager{Name: "g", Zone: "z1", TargetSize: 1}))
+
+	require.NoError(t, m.ResizeInstanceGroupManagerGCP("z1", "g", 5))
+
+	got, ok := m.GetInstanceGroupManagerGCP("z1", "g")
+	require.True(t, ok)
+	assert.Equal(t, 5, got.TargetSize)
+
+	assert.True(t, cerrors.IsNotFound(m.ResizeInstanceGroupManagerGCP("z1", "missing", 2)))
+	assert.True(t, cerrors.IsInvalidArgument(m.ResizeInstanceGroupManagerGCP("z1", "g", -1)))
+}
+
+func TestInstanceGroupManagerUpsertPreservesCreatedAt(t *testing.T) {
+	m := newTestMock()
+
+	m.UpsertInstanceGroupManagerGCP(InstanceGroupManager{Name: "u", Zone: "z1", TargetSize: 2})
+	first, ok := m.GetInstanceGroupManagerGCP("z1", "u")
+	require.True(t, ok)
+
+	// A second upsert (e.g. a node-pool resize reconcile) updates targetSize but
+	// keeps the original creation timestamp.
+	m.UpsertInstanceGroupManagerGCP(InstanceGroupManager{Name: "u", Zone: "z1", TargetSize: 7})
+	second, ok := m.GetInstanceGroupManagerGCP("z1", "u")
+	require.True(t, ok)
+
+	assert.Equal(t, 7, second.TargetSize)
+	assert.Equal(t, first.CreatedAt, second.CreatedAt)
+}
+
+func TestAllInstanceGroupManagers(t *testing.T) {
+	m := newTestMock()
+
+	require.NoError(t, m.CreateInstanceGroupManagerGCP(InstanceGroupManager{Name: "a", Zone: "z1", TargetSize: 1}))
+	require.NoError(t, m.CreateInstanceGroupManagerGCP(InstanceGroupManager{Name: "b", Zone: "z2", TargetSize: 1}))
+
+	assert.Len(t, m.AllInstanceGroupManagersGCP(), 2)
+}

--- a/providers/gcp/compute/snapshot.go
+++ b/providers/gcp/compute/snapshot.go
@@ -24,6 +24,7 @@ type gceSnapshot struct {
 	Snapshots    json.RawMessage              `json:"snapshots,omitempty"`
 	Images       json.RawMessage              `json:"images,omitempty"`
 	KeyPairs     json.RawMessage              `json:"keyPairs,omitempty"`
+	Migs         json.RawMessage              `json:"migs,omitempty"`
 	ASGs         map[string]*asgSnapshot      `json:"asgs,omitempty"`
 	Counters     countersSnapshot             `json:"counters"`
 }
@@ -106,6 +107,7 @@ func (m *Mock) snapshotStores(snap *gceSnapshot) error {
 		{&snap.Snapshots, m.snapshots.Snapshot},
 		{&snap.Images, m.images.Snapshot},
 		{&snap.KeyPairs, m.keyPairs.Snapshot},
+		{&snap.Migs, m.migs.Snapshot},
 	}
 
 	for _, d := range dumps {
@@ -193,6 +195,7 @@ func (m *Mock) restoreStores(snap *gceSnapshot) error {
 		{snap.Snapshots, m.snapshots.LoadSnapshot},
 		{snap.Images, m.images.LoadSnapshot},
 		{snap.KeyPairs, m.keyPairs.LoadSnapshot},
+		{snap.Migs, m.migs.LoadSnapshot},
 	}
 
 	for _, l := range loads {

--- a/server/gcp/compute/handler.go
+++ b/server/gcp/compute/handler.go
@@ -35,11 +35,16 @@ const (
 	resourceSnapshots  = "snapshots"
 	resourceImages     = "images"
 	resourceMachineTyp = "machineTypes"
+	resourceMIGs       = "instanceGroupManagers"
 )
 
 // actionSetLabels is the lowercased setLabels verb, shared by the instance,
 // disk, image, and snapshot POST-action routers.
 const actionSetLabels = "setlabels"
+
+// actionResize is the lowercased resize verb, shared by the disk and instance-
+// group-manager POST-action routers.
+const actionResize = "resize"
 
 // Handler serves GCP Compute Engine REST requests for instances and zone
 // operations.
@@ -80,7 +85,8 @@ func (*Handler) Matches(r *http.Request) bool {
 	}
 
 	switch rp.ResourceType {
-	case resourceInstances, resourceOperations, resourceDisks, resourceSnapshots, resourceImages, resourceMachineTyp:
+	case resourceInstances, resourceOperations, resourceDisks, resourceSnapshots,
+		resourceImages, resourceMachineTyp, resourceMIGs:
 		return true
 	}
 
@@ -147,6 +153,9 @@ func (h *Handler) serveAggregated(w http.ResponseWriter, r *http.Request, rp gcp
 		case resourceDisks:
 			h.aggregatedListDisks(w, r, rp)
 			return
+		case resourceMIGs:
+			h.aggregatedListMIGs(w, r, rp)
+			return
 		}
 	}
 
@@ -169,6 +178,8 @@ func (h *Handler) routeResource(w http.ResponseWriter, r *http.Request, rp gcpre
 		h.serveImagesRoute(w, r, rp)
 	case resourceMachineTyp:
 		serveMachineTypesRoute(w, r, rp)
+	case resourceMIGs:
+		h.serveInstanceGroupManagersRoute(w, r, rp)
 	default:
 		return false
 	}
@@ -271,7 +282,7 @@ func (h *Handler) serveDisksRoute(w http.ResponseWriter, r *http.Request, rp gcp
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) serveDiskAction(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
 	switch strings.ToLower(rp.Action) {
-	case "resize":
+	case actionResize:
 		h.resizeDisk(w, r, rp)
 	case actionSetLabels:
 		h.setDiskLabels(w, r, rp)

--- a/server/gcp/compute/instancegroupmanager.go
+++ b/server/gcp/compute/instancegroupmanager.go
@@ -1,0 +1,343 @@
+package compute
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	gcecompute "github.com/stackshy/cloudemu/v2/providers/gcp/compute"
+	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
+)
+
+// migBackend is the GCP-local capability the GCE Mock implements to store zonal
+// managed instance groups (compute#instanceGroupManager). Reached via a type
+// assertion so the shared compute driver interface stays unchanged, mirroring
+// the volumeResizer / resourceLabelMutator pattern used for disks/images.
+type migBackend interface {
+	CreateInstanceGroupManagerGCP(igm gcecompute.InstanceGroupManager) error
+	GetInstanceGroupManagerGCP(zone, name string) (gcecompute.InstanceGroupManager, bool)
+	ListInstanceGroupManagersGCP(zone string) []gcecompute.InstanceGroupManager
+	AllInstanceGroupManagersGCP() []gcecompute.InstanceGroupManager
+	DeleteInstanceGroupManagerGCP(zone, name string) error
+	ResizeInstanceGroupManagerGCP(zone, name string, size int) error
+}
+
+// migRequest mirrors the subset of compute#instanceGroupManager we accept on
+// insert. targetSize is a flexInt so both the typed client (quoted) and the
+// Terraform provider (bare number) encodings decode.
+type migRequest struct {
+	Name             string  `json:"name"`
+	BaseInstanceName string  `json:"baseInstanceName,omitempty"`
+	InstanceTemplate string  `json:"instanceTemplate,omitempty"`
+	TargetSize       flexInt `json:"targetSize,omitempty"`
+}
+
+// migResponse mirrors the subset of compute#instanceGroupManager we return.
+type migResponse struct {
+	Kind              string             `json:"kind"`
+	ID                string             `json:"id"`
+	CreationTimestamp string             `json:"creationTimestamp,omitempty"`
+	Name              string             `json:"name"`
+	Zone              string             `json:"zone"`
+	BaseInstanceName  string             `json:"baseInstanceName,omitempty"`
+	InstanceTemplate  string             `json:"instanceTemplate,omitempty"`
+	InstanceGroup     string             `json:"instanceGroup"`
+	TargetSize        int                `json:"targetSize"`
+	Fingerprint       string             `json:"fingerprint,omitempty"`
+	CurrentActions    *migCurrentActions `json:"currentActions,omitempty"`
+	Status            *migStatus         `json:"status,omitempty"`
+	SelfLink          string             `json:"selfLink"`
+}
+
+// migCurrentActions is compute#instanceGroupManagerActionsSummary. The emulator
+// applies resizes synchronously, so every target is "none" (stable) — none
+// equals the target size and every transient counter is zero.
+type migCurrentActions struct {
+	None                   int `json:"none"`
+	Creating               int `json:"creating"`
+	CreatingWithoutRetries int `json:"creatingWithoutRetries"`
+	Deleting               int `json:"deleting"`
+	Abandoning             int `json:"abandoning"`
+	Restarting             int `json:"restarting"`
+	Refreshing             int `json:"refreshing"`
+	Verifying              int `json:"verifying"`
+	Recreating             int `json:"recreating"`
+}
+
+type migStatus struct {
+	IsStable bool `json:"isStable"`
+}
+
+type migListResponse struct {
+	Kind     string        `json:"kind"`
+	ID       string        `json:"id"`
+	Items    []migResponse `json:"items"`
+	SelfLink string        `json:"selfLink"`
+}
+
+// serveInstanceGroupManagersRoute dispatches the zonal instanceGroupManagers
+// resource. Registered ahead of the compute-space fallback so first-match-wins
+// keeps these paths here; disjoint from the load-balancing handler's
+// instanceGroups collection, so registration order is unconstrained.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) serveInstanceGroupManagersRoute(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	backend, ok := h.compute.(migBackend)
+	if !ok {
+		writeNotImplemented(w, "instanceGroupManagers")
+		return
+	}
+
+	if rp.ResourceName == "" {
+		switch r.Method {
+		case http.MethodPost:
+			h.insertMIG(w, r, rp, backend)
+		case http.MethodGet:
+			h.listMIGs(w, r, rp, backend)
+		default:
+			writeNotImplemented(w, r.Method+" "+r.URL.Path)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && rp.Action != "" {
+		h.serveMIGAction(w, r, rp, backend)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getMIG(w, r, rp, backend)
+	case http.MethodDelete:
+		h.deleteMIG(w, r, rp, backend)
+	default:
+		writeNotImplemented(w, r.Method+" "+r.URL.Path)
+	}
+}
+
+// serveMIGAction routes the POST MIG verbs. resize is the real zonal-MIG method
+// (size is a query parameter); setTargetSize is accepted as a body-carried
+// alias for clients that prefer it.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) serveMIGAction(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath, backend migBackend) {
+	switch strings.ToLower(rp.Action) {
+	case actionResize:
+		h.resizeMIG(w, r, rp, backend)
+	case "settargetsize":
+		h.setMIGTargetSize(w, r, rp, backend)
+	default:
+		writeNotImplemented(w, r.Method+" "+r.URL.Path)
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) insertMIG(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath, backend migBackend) {
+	if rp.Scope != gcprest.ScopeZones {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "instance group managers must be created in a zone")
+		return
+	}
+
+	var req migRequest
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.Name == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "instance group manager name required")
+		return
+	}
+
+	baseName := req.BaseInstanceName
+	if baseName == "" {
+		baseName = req.Name
+	}
+
+	err := backend.CreateInstanceGroupManagerGCP(gcecompute.InstanceGroupManager{
+		Name:             req.Name,
+		Zone:             rp.ScopeName,
+		TargetSize:       int(req.TargetSize),
+		BaseInstanceName: baseName,
+		InstanceTemplate: lastSegment(req.InstanceTemplate),
+	})
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := h.ops.RecordDone(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
+		"instanceGroupManagers", req.Name, "insert")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) getMIG(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath, backend migBackend) {
+	igm, ok := backend.GetInstanceGroupManagerGCP(rp.ScopeName, rp.ResourceName)
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound",
+			"The resource 'instanceGroupManagers/"+rp.ResourceName+"' was not found")
+
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toMIGResponse(&igm, rp.Project, hostFromRequest(r)))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) listMIGs(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath, backend migBackend) {
+	igms := backend.ListInstanceGroupManagersGCP(rp.ScopeName)
+	host := hostFromRequest(r)
+	out := make([]migResponse, 0, len(igms))
+
+	for i := range igms {
+		if !gcprest.NameMatches(r.URL.Query().Get("filter"), igms[i].Name) {
+			continue
+		}
+
+		out = append(out, toMIGResponse(&igms[i], rp.Project, host))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, migListResponse{
+		Kind:     "compute#instanceGroupManagerList",
+		ID:       "projects/" + rp.Project + "/zones/" + rp.ScopeName + "/instanceGroupManagers",
+		Items:    out,
+		SelfLink: gcprest.SelfLink(host, rp.Project, rp.Scope, rp.ScopeName, "instanceGroupManagers", ""),
+	})
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteMIG(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath, backend migBackend) {
+	if _, ok := backend.GetInstanceGroupManagerGCP(rp.ScopeName, rp.ResourceName); !ok {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound",
+			"The resource 'instanceGroupManagers/"+rp.ResourceName+"' was not found")
+
+		return
+	}
+
+	if err := backend.DeleteInstanceGroupManagerGCP(rp.ScopeName, rp.ResourceName); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := h.ops.RecordDone(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
+		"instanceGroupManagers", rp.ResourceName, "delete")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// resizeMIG handles POST .../instanceGroupManagers/{name}/resize?size=N, the
+// real zonal MIG resize where size is a required query parameter.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) resizeMIG(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath, backend migBackend) {
+	raw := r.URL.Query().Get("size")
+	if raw == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "size query parameter required")
+		return
+	}
+
+	size, err := strconv.Atoi(raw)
+	if err != nil {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "size must be an integer")
+		return
+	}
+
+	h.applyMIGResize(w, r, rp, backend, size)
+}
+
+// migTargetSizeRequest is the setTargetSize body alias.
+type migTargetSizeRequest struct {
+	TargetSize flexInt `json:"targetSize,omitempty"`
+}
+
+// setMIGTargetSize handles POST .../instanceGroupManagers/{name}/setTargetSize
+// with the target in the body — a convenience alias over resize.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) setMIGTargetSize(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath, backend migBackend) {
+	var req migTargetSizeRequest
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	h.applyMIGResize(w, r, rp, backend, int(req.TargetSize))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) applyMIGResize(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath, backend migBackend, size int) {
+	if err := backend.ResizeInstanceGroupManagerGCP(rp.ScopeName, rp.ResourceName, size); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := h.ops.RecordDone(hostFromRequest(r), rp.Project, rp.Scope, rp.ScopeName,
+		"instanceGroupManagers", rp.ResourceName, "resize")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// migScopedList is one zone's bucket in an aggregated MIG list.
+type migScopedList struct {
+	InstanceGroupManagers []migResponse      `json:"instanceGroupManagers,omitempty"`
+	Warning               *scopedListWarning `json:"warning,omitempty"`
+}
+
+type migAggregatedListResponse struct {
+	Kind     string                   `json:"kind"`
+	ID       string                   `json:"id"`
+	Items    map[string]migScopedList `json:"items"`
+	SelfLink string                   `json:"selfLink"`
+}
+
+// aggregatedListMIGs handles GET /aggregated/instanceGroupManagers, grouping
+// every MIG by its "zones/{zone}" scope.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) aggregatedListMIGs(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	backend, ok := h.compute.(migBackend)
+	if !ok {
+		writeNotImplemented(w, "instanceGroupManagers")
+		return
+	}
+
+	igms := backend.AllInstanceGroupManagersGCP()
+	host := hostFromRequest(r)
+	items := make(map[string]migScopedList)
+
+	for i := range igms {
+		key := "zones/" + igms[i].Zone
+		bucket := items[key]
+		bucket.InstanceGroupManagers = append(bucket.InstanceGroupManagers, toMIGResponse(&igms[i], rp.Project, host))
+		items[key] = bucket
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, migAggregatedListResponse{
+		Kind:     "compute#instanceGroupManagerAggregatedList",
+		ID:       "projects/" + rp.Project + "/aggregated/instanceGroupManagers",
+		Items:    items,
+		SelfLink: strings.TrimSuffix(host, "/") + "/compute/v1/projects/" + rp.Project + "/aggregated/instanceGroupManagers",
+	})
+}
+
+// toMIGResponse maps a stored MIG to compute#instanceGroupManager wire JSON.
+// The instanceGroup selfLink points at the same-named zonal instanceGroups
+// resource, as real GCP does (the managed group owns an unmanaged instance
+// group of the same name).
+func toMIGResponse(igm *gcecompute.InstanceGroupManager, project, host string) migResponse {
+	return migResponse{
+		Kind:              "compute#instanceGroupManager",
+		ID:                numericID(igm.Zone + "/" + igm.Name),
+		CreationTimestamp: igm.CreatedAt,
+		Name:              igm.Name,
+		Zone:              strings.TrimSuffix(host, "/") + "/compute/v1/projects/" + project + "/zones/" + igm.Zone,
+		BaseInstanceName:  igm.BaseInstanceName,
+		InstanceTemplate:  igm.InstanceTemplate,
+		InstanceGroup:     gcprest.SelfLink(host, project, gcprest.ScopeZones, igm.Zone, "instanceGroups", igm.Name),
+		TargetSize:        igm.TargetSize,
+		CurrentActions:    &migCurrentActions{None: igm.TargetSize},
+		Status:            &migStatus{IsStable: true},
+		SelfLink:          gcprest.SelfLink(host, project, gcprest.ScopeZones, igm.Zone, "instanceGroupManagers", igm.Name),
+	}
+}

--- a/server/gcp/compute/instancegroupmanager_sdk_test.go
+++ b/server/gcp/compute/instancegroupmanager_sdk_test.go
@@ -1,0 +1,203 @@
+package compute_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// newMIGSDKClient builds a real google-cloud-go InstanceGroupManagersRESTClient
+// pointing at the given test server.
+func newMIGSDKClient(t *testing.T, ts *httptest.Server) *gcpcompute.InstanceGroupManagersClient {
+	t.Helper()
+
+	client, err := gcpcompute.NewInstanceGroupManagersRESTClient(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewInstanceGroupManagersRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+// TestSDKInstanceGroupManagerRoundTrip drives the zonal MIG lifecycle (insert →
+// get → list → resize → delete) with a real cloud.google.com/go client so the
+// wire shapes are SDK-compatible. targetSize is the load-bearing field: the
+// Terraform google provider reads a GKE node pool's node_count off it.
+func TestSDKInstanceGroupManagerRoundTrip(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Compute: cloudP.GCE})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newMIGSDKClient(t, ts)
+	ctx := context.Background()
+
+	insertOp, err := client.Insert(ctx, &computepb.InsertInstanceGroupManagerRequest{
+		Project: testProject,
+		Zone:    testZone,
+		InstanceGroupManagerResource: &computepb.InstanceGroupManager{
+			Name:             ptrStr("web-mig"),
+			BaseInstanceName: ptrStr("web"),
+			TargetSize:       ptrInt32(3),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetInstanceGroupManagerRequest{
+		Project: testProject, Zone: testZone, InstanceGroupManager: "web-mig",
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetName() != "web-mig" {
+		t.Errorf("name=%s want web-mig", got.GetName())
+	}
+
+	if got.GetTargetSize() != 3 {
+		t.Errorf("targetSize=%d want 3", got.GetTargetSize())
+	}
+
+	if got.GetBaseInstanceName() != "web" {
+		t.Errorf("baseInstanceName=%s want web", got.GetBaseInstanceName())
+	}
+
+	if !strings.HasSuffix(got.GetInstanceGroup(), "/instanceGroups/web-mig") {
+		t.Errorf("instanceGroup=%s want .../instanceGroups/web-mig", got.GetInstanceGroup())
+	}
+
+	if got.GetStatus() == nil || !got.GetStatus().GetIsStable() {
+		t.Error("status.isStable=false want true")
+	}
+
+	it := client.List(ctx, &computepb.ListInstanceGroupManagersRequest{Project: testProject, Zone: testZone})
+
+	found := false
+
+	for {
+		m, err := it.Next()
+		if err != nil {
+			break
+		}
+
+		if m.GetName() == "web-mig" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Error("List did not return web-mig")
+	}
+
+	resizeOp, err := client.Resize(ctx, &computepb.ResizeInstanceGroupManagerRequest{
+		Project: testProject, Zone: testZone, InstanceGroupManager: "web-mig", Size: 5,
+	})
+	if err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+
+	if err := resizeOp.Wait(ctx); err != nil {
+		t.Fatalf("Resize wait: %v", err)
+	}
+
+	after, err := client.Get(ctx, &computepb.GetInstanceGroupManagerRequest{
+		Project: testProject, Zone: testZone, InstanceGroupManager: "web-mig",
+	})
+	if err != nil {
+		t.Fatalf("Get after resize: %v", err)
+	}
+
+	if after.GetTargetSize() != 5 {
+		t.Errorf("targetSize after resize=%d want 5", after.GetTargetSize())
+	}
+
+	delOp, err := client.Delete(ctx, &computepb.DeleteInstanceGroupManagerRequest{
+		Project: testProject, Zone: testZone, InstanceGroupManager: "web-mig",
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Errorf("Delete wait: %v", err)
+	}
+
+	if _, err := client.Get(ctx, &computepb.GetInstanceGroupManagerRequest{
+		Project: testProject, Zone: testZone, InstanceGroupManager: "web-mig",
+	}); err == nil {
+		t.Error("Get after delete: expected NotFound")
+	}
+}
+
+// TestSDKInstanceGroupManagerAggregatedList proves aggregatedList groups MIGs by
+// their zones/{zone} scope.
+func TestSDKInstanceGroupManagerAggregatedList(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Compute: cloudP.GCE})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newMIGSDKClient(t, ts)
+	ctx := context.Background()
+
+	insertOp, err := client.Insert(ctx, &computepb.InsertInstanceGroupManagerRequest{
+		Project: testProject,
+		Zone:    testZone,
+		InstanceGroupManagerResource: &computepb.InstanceGroupManager{
+			Name:       ptrStr("agg-mig"),
+			TargetSize: ptrInt32(1),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	it := client.AggregatedList(ctx, &computepb.AggregatedListInstanceGroupManagersRequest{Project: testProject})
+
+	found := false
+
+	for {
+		pair, err := it.Next()
+		if err != nil {
+			break
+		}
+
+		for _, m := range pair.Value.GetInstanceGroupManagers() {
+			if m.GetName() == "agg-mig" && pair.Key == "zones/"+testZone {
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		t.Errorf("aggregatedList did not return agg-mig under zones/%s", testZone)
+	}
+}
+
+func ptrInt32(v int32) *int32 { return &v }

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -156,7 +156,16 @@ func New(d Drivers) *server.Server {
 	// the op was recorded by the GKE mock, so foreign location operations still
 	// fall through to lro below — no shadowing.
 	if d.GKE != nil {
-		srv.Register(gke.New(d.GKE))
+		gkeH := gke.New(d.GKE)
+		// Wire the compute-side MIG registrar (the GCE Mock) so node-pool
+		// lifecycle keeps a backing instanceGroupManager's targetSize == node
+		// count, letting the Terraform provider resolve node_count and stop the
+		// 0→N drift. Nil compute driver leaves node pools without MIG URLs.
+		if reg, ok := d.Compute.(gke.InstanceGroupManagerRegistrar); ok {
+			gkeH.SetInstanceGroupManagers(reg)
+		}
+
+		srv.Register(gkeH)
 	}
 
 	// Shared location-operations poller. Registered ahead of the remaining

--- a/server/gcp/gke/handler.go
+++ b/server/gcp/gke/handler.go
@@ -70,6 +70,10 @@ const (
 // Handler serves GKE container-API REST requests against a gke.Mock backend.
 type Handler struct {
 	gke *gke.Mock
+	// migs (optional) keeps each node pool's backing compute MIG in sync so the
+	// pool's instanceGroupUrls resolve to a targetSize == node count. Nil when no
+	// compute driver is wired.
+	migs InstanceGroupManagerRegistrar
 }
 
 // New returns a GKE handler backed by m.

--- a/server/gcp/gke/instancegroupmanager.go
+++ b/server/gcp/gke/instancegroupmanager.go
@@ -1,0 +1,141 @@
+package gke
+
+import (
+	"context"
+	"hash/fnv"
+	"net/http"
+	"strconv"
+
+	gcecompute "github.com/stackshy/cloudemu/v2/providers/gcp/compute"
+	"github.com/stackshy/cloudemu/v2/providers/gcp/gke"
+)
+
+// InstanceGroupManagerRegistrar is the compute-side capability the GKE handler
+// uses to keep a backing managed instance group (MIG) in sync with each node
+// pool's node count. The GCE Mock satisfies it; wiring is optional, so a GKE
+// server with no compute driver simply emits no instanceGroupUrls.
+//
+// This closes the cross-service gap that made google_container_node_pool's
+// node_count drift 0→N forever: the Terraform google provider derives node_count
+// by summing the targetSize of the MIGs a node pool's instanceGroupUrls point
+// at (via compute instanceGroupManagers.list). With no MIG behind the pool, that
+// sum was always 0.
+type InstanceGroupManagerRegistrar interface {
+	UpsertInstanceGroupManagerGCP(igm gcecompute.InstanceGroupManager)
+	DeleteInstanceGroupManagerGCP(zone, name string) error
+}
+
+// SetInstanceGroupManagers wires the compute-side MIG registrar. Called from the
+// GCP server factory with the GCE Mock so node-pool lifecycle keeps its backing
+// MIG's targetSize current.
+func (h *Handler) SetInstanceGroupManagers(reg InstanceGroupManagerRegistrar) { h.migs = reg }
+
+// migName derives the stable backing-MIG name for a node pool. Real GKE names
+// it "gke-<cluster>-<pool>-<hash>-grp"; the emulator uses a deterministic hash of
+// the pool's identity so the same pool always maps to the same MIG across reads.
+func migName(location, cluster, pool string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(location + "/" + cluster + "/" + pool))
+
+	return "gke-" + cluster + "-" + pool + "-" + strconv.FormatUint(uint64(h.Sum32()), 16) + "-grp"
+}
+
+// syncNodePoolMIG upserts the node pool's backing MIG with targetSize equal to
+// the pool's node count, in the pool's location (its zone). A no-op when no
+// compute registrar is wired.
+func (h *Handler) syncNodePoolMIG(np *gke.NodePool) {
+	if h.migs == nil || np == nil {
+		return
+	}
+
+	name := migName(np.Location, np.ClusterName, np.Name)
+	h.migs.UpsertInstanceGroupManagerGCP(gcecompute.InstanceGroupManager{
+		Name:             name,
+		Zone:             np.Location,
+		TargetSize:       int(np.NodeCount),
+		BaseInstanceName: "gke-" + np.ClusterName + "-" + np.Name,
+	})
+}
+
+// removeNodePoolMIG deletes a node pool's backing MIG. A no-op when no registrar
+// is wired.
+func (h *Handler) removeNodePoolMIG(location, cluster, pool string) {
+	if h.migs == nil {
+		return
+	}
+
+	_ = h.migs.DeleteInstanceGroupManagerGCP(location, migName(location, cluster, pool))
+}
+
+// reconcileClusterMIGs upserts a backing MIG for every node pool in a cluster.
+// Used after cluster creation, which materializes the default (and any
+// caller-specified) node pools in one call.
+func (h *Handler) reconcileClusterMIGs(ctx context.Context, location, cluster string) {
+	if h.migs == nil {
+		return
+	}
+
+	pools, err := h.gke.ListNodePools(ctx, location, cluster)
+	if err != nil {
+		return
+	}
+
+	for i := range pools {
+		h.syncNodePoolMIG(&pools[i])
+	}
+}
+
+// removeClusterMIGs deletes the backing MIGs of every node pool in a cluster.
+// Called before the cluster (and its pools) are torn down.
+func (h *Handler) removeClusterMIGs(ctx context.Context, location, cluster string) {
+	if h.migs == nil {
+		return
+	}
+
+	pools, err := h.gke.ListNodePools(ctx, location, cluster)
+	if err != nil {
+		return
+	}
+
+	for i := range pools {
+		h.removeNodePoolMIG(pools[i].Location, pools[i].ClusterName, pools[i].Name)
+	}
+}
+
+// instanceGroupUrls returns the node pool's instanceGroupUrls, pointing at its
+// backing zonal MIG. Terraform reads node_count off the targetSize of the MIG
+// these URLs resolve to. Empty when no compute registrar is wired (so no MIG
+// exists to resolve). host is the request scheme+host; the host prefix is
+// irrelevant to the provider's regex match (it keys on the
+// projects/.../instanceGroupManagers/<name> substring), but a real absolute URL
+// is emitted for fidelity.
+func (h *Handler) instanceGroupUrls(host, project, location, cluster, pool string) []string {
+	if h.migs == nil {
+		return nil
+	}
+
+	name := migName(location, cluster, pool)
+
+	return []string{
+		host + "/compute/v1/projects/" + project + "/zones/" + location + "/instanceGroupManagers/" + name,
+	}
+}
+
+// igmURLsFunc returns a closure that builds a node pool's instanceGroupUrls,
+// binding the request host and project. Passed to toClusterResource so each
+// embedded node pool carries its backing MIG URL.
+func (h *Handler) igmURLsFunc(host, project string) func(np *gke.NodePool) []string {
+	return func(np *gke.NodePool) []string {
+		return h.instanceGroupUrls(host, project, np.Location, np.ClusterName, np.Name)
+	}
+}
+
+// reqHost returns the scheme://host of the incoming request.
+func reqHost(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	return scheme + "://" + r.Host
+}

--- a/server/gcp/gke/nodepool_igm_sdk_test.go
+++ b/server/gcp/gke/nodepool_igm_sdk_test.go
@@ -1,0 +1,158 @@
+package gke_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/container/v1"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// TestSDKGKENodePoolNodeCountRoundTrip is the cross-service regression for GKE
+// node_count drift: the Terraform google provider reads a node pool's node_count
+// by summing the targetSize of the MIGs its instanceGroupUrls point at (via
+// compute instanceGroupManagers). With no backing MIG the sum was always 0, so
+// node_count drifted 0→N on every plan. This proves a created/resized pool emits
+// instanceGroupUrls that resolve, through the compute API, to targetSize == the
+// pool's node count.
+func TestSDKGKENodePoolNodeCountRoundTrip(t *testing.T) {
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{GKE: cloud.GKE, Compute: cloud.GCE})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	project, loc := "mock-project", "us-central1-a"
+
+	gkeSvc, err := container.NewService(ctx, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("container.NewService: %v", err)
+	}
+
+	migClient, err := gcpcompute.NewInstanceGroupManagersRESTClient(ctx,
+		option.WithEndpoint(ts.URL), option.WithoutAuthentication(), option.WithHTTPClient(ts.Client()))
+	if err != nil {
+		t.Fatalf("NewInstanceGroupManagersRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = migClient.Close() })
+
+	if _, err := gkeSvc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "host"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	parentClus := clusterName(project, loc, "host")
+	if _, err := gkeSvc.Projects.Locations.Clusters.NodePools.Create(parentClus, &container.CreateNodePoolRequest{
+		NodePool: &container.NodePool{Name: "pool", InitialNodeCount: 2},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create node pool: %v", err)
+	}
+
+	// The node pool must advertise instanceGroupUrls; node_count resolves through
+	// them, so an empty list is exactly the drift bug.
+	np, err := gkeSvc.Projects.Locations.Clusters.NodePools.Get(nodePoolName(project, loc, "host", "pool")).
+		Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("get node pool: %v", err)
+	}
+
+	if len(np.InstanceGroupUrls) != 1 {
+		t.Fatalf("instanceGroupUrls=%v want exactly 1", np.InstanceGroupUrls)
+	}
+
+	if got := resolveNodeCount(t, ctx, migClient, project, np.InstanceGroupUrls); got != 2 {
+		t.Fatalf("resolved node_count=%d want 2 (drift bug: MIG targetSize not tracking pool)", got)
+	}
+
+	// Resize the pool; node_count must follow through the same MIG read.
+	if _, err := gkeSvc.Projects.Locations.Clusters.NodePools.SetSize(nodePoolName(project, loc, "host", "pool"),
+		&container.SetNodePoolSizeRequest{NodeCount: 4}).Context(ctx).Do(); err != nil {
+		t.Fatalf("setSize: %v", err)
+	}
+
+	np, err = gkeSvc.Projects.Locations.Clusters.NodePools.Get(nodePoolName(project, loc, "host", "pool")).
+		Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("get node pool after resize: %v", err)
+	}
+
+	if got := resolveNodeCount(t, ctx, migClient, project, np.InstanceGroupUrls); got != 4 {
+		t.Fatalf("resolved node_count after resize=%d want 4", got)
+	}
+
+	// Deleting the pool removes its backing MIG (no orphan left behind).
+	if _, err := gkeSvc.Projects.Locations.Clusters.NodePools.Delete(nodePoolName(project, loc, "host", "pool")).
+		Context(ctx).Do(); err != nil {
+		t.Fatalf("delete node pool: %v", err)
+	}
+
+	zone, name := parseMIGURL(t, np.InstanceGroupUrls[0])
+	if _, err := migClient.Get(ctx, &computepb.GetInstanceGroupManagerRequest{
+		Project: project, Zone: zone, InstanceGroupManager: name,
+	}); err == nil {
+		t.Error("backing MIG still present after node pool delete")
+	}
+}
+
+// resolveNodeCount mirrors the Terraform google provider: sum the targetSize of
+// the MIGs the instanceGroupUrls point at, divided by the URL count.
+func resolveNodeCount(
+	t *testing.T, ctx context.Context, client *gcpcompute.InstanceGroupManagersClient,
+	project string, urls []string,
+) int {
+	t.Helper()
+
+	size := 0
+
+	for _, u := range urls {
+		zone, name := parseMIGURL(t, u)
+
+		igm, err := client.Get(ctx, &computepb.GetInstanceGroupManagerRequest{
+			Project: project, Zone: zone, InstanceGroupManager: name,
+		})
+		if err != nil {
+			t.Fatalf("MIG get for %s: %v", u, err)
+		}
+
+		size += int(igm.GetTargetSize())
+	}
+
+	if len(urls) == 0 {
+		return 0
+	}
+
+	return size / len(urls)
+}
+
+// parseMIGURL extracts the zone and name from a
+// .../zones/{zone}/instanceGroupManagers/{name} URL.
+func parseMIGURL(t *testing.T, u string) (zone, name string) {
+	t.Helper()
+
+	parts := strings.Split(u, "/")
+	for i := 0; i+1 < len(parts); i++ {
+		if parts[i] == "zones" {
+			zone = parts[i+1]
+		}
+
+		if parts[i] == "instanceGroupManagers" {
+			name = parts[i+1]
+		}
+	}
+
+	if zone == "" || name == "" {
+		t.Fatalf("could not parse MIG URL %q", u)
+	}
+
+	return zone, name
+}

--- a/server/gcp/gke/operations.go
+++ b/server/gcp/gke/operations.go
@@ -47,6 +47,11 @@ func (h *Handler) createCluster(w http.ResponseWriter, r *http.Request, p *gkePa
 		return
 	}
 
+	// Register a backing MIG for every node pool the cluster materialized (the
+	// default pool plus any caller-specified pools), so their node counts read
+	// back through compute instanceGroupManagers.
+	h.reconcileClusterMIGs(r.Context(), p.location, body.Cluster.Name)
+
 	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
 }
 
@@ -88,7 +93,8 @@ func (h *Handler) getCluster(w http.ResponseWriter, r *http.Request, p *gkePath)
 
 	pools, _ := h.gke.ListNodePools(r.Context(), p.location, p.name)
 
-	writeJSON(w, http.StatusOK, toClusterResource(c, p.project, h.gke.Endpoint(p.location, p.name), pools))
+	igmFor := h.igmURLsFunc(reqHost(r), p.project)
+	writeJSON(w, http.StatusOK, toClusterResource(c, p.project, h.gke.Endpoint(p.location, p.name), pools, igmFor))
 }
 
 func (h *Handler) listClusters(w http.ResponseWriter, r *http.Request, p *gkePath) {
@@ -99,11 +105,12 @@ func (h *Handler) listClusters(w http.ResponseWriter, r *http.Request, p *gkePat
 	}
 
 	out := listClustersResp{Clusters: make([]gkeCluster, 0, len(clusters))}
+	igmFor := h.igmURLsFunc(reqHost(r), p.project)
 
 	for i := range clusters {
 		pools, _ := h.gke.ListNodePools(r.Context(), clusters[i].Location, clusters[i].Name)
 		endpoint := h.gke.Endpoint(clusters[i].Location, clusters[i].Name)
-		out.Clusters = append(out.Clusters, toClusterResource(&clusters[i], p.project, endpoint, pools))
+		out.Clusters = append(out.Clusters, toClusterResource(&clusters[i], p.project, endpoint, pools, igmFor))
 	}
 
 	writeJSON(w, http.StatusOK, out)
@@ -136,6 +143,10 @@ func (h *Handler) updateCluster(w http.ResponseWriter, r *http.Request, p *gkePa
 }
 
 func (h *Handler) deleteCluster(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	// Remove the pools' backing MIGs before the cluster (and its pools) are torn
+	// down, while the pools are still enumerable.
+	h.removeClusterMIGs(r.Context(), p.location, p.name)
+
 	op, err := h.gke.DeleteCluster(r.Context(), p.location, p.name)
 	if err != nil {
 		writeErr(w, err)
@@ -333,11 +344,13 @@ func (h *Handler) createNodePool(w http.ResponseWriter, r *http.Request, p *gkeP
 
 	spec := nodePoolSpecFromWire(body.NodePool)
 
-	_, op, err := h.gke.CreateNodePool(r.Context(), p.location, p.name, &spec)
+	np, op, err := h.gke.CreateNodePool(r.Context(), p.location, p.name, &spec)
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
+
+	h.syncNodePoolMIG(np)
 
 	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
 }
@@ -349,7 +362,8 @@ func (h *Handler) getNodePool(w http.ResponseWriter, r *http.Request, p *gkePath
 		return
 	}
 
-	writeJSON(w, http.StatusOK, toNodePoolResource(np, p.project))
+	igmFor := h.igmURLsFunc(reqHost(r), p.project)
+	writeJSON(w, http.StatusOK, toNodePoolResource(np, p.project, igmFor(np)))
 }
 
 func (h *Handler) listNodePools(w http.ResponseWriter, r *http.Request, p *gkePath) {
@@ -359,9 +373,11 @@ func (h *Handler) listNodePools(w http.ResponseWriter, r *http.Request, p *gkePa
 		return
 	}
 
+	igmFor := h.igmURLsFunc(reqHost(r), p.project)
 	out := listNodePoolsResp{NodePools: make([]gkeNodePool, 0, len(pools))}
+
 	for i := range pools {
-		out.NodePools = append(out.NodePools, toNodePoolResource(&pools[i], p.project))
+		out.NodePools = append(out.NodePools, toNodePoolResource(&pools[i], p.project, igmFor(&pools[i])))
 	}
 
 	writeJSON(w, http.StatusOK, out)
@@ -394,6 +410,8 @@ func (h *Handler) deleteNodePool(w http.ResponseWriter, r *http.Request, p *gkeP
 		writeErr(w, err)
 		return
 	}
+
+	h.removeNodePoolMIG(p.location, p.name, p.subName)
 
 	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
 }
@@ -428,6 +446,10 @@ func (h *Handler) setNodePoolSize(w http.ResponseWriter, r *http.Request, p *gke
 	if err != nil {
 		writeErr(w, err)
 		return
+	}
+
+	if np, gerr := h.gke.GetNodePool(r.Context(), p.location, p.name, p.subName); gerr == nil {
+		h.syncNodePoolMIG(np)
 	}
 
 	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))

--- a/server/gcp/gke/types.go
+++ b/server/gcp/gke/types.go
@@ -81,6 +81,10 @@ type gkeNodePool struct {
 	Management       *gkeNodeManagement `json:"management,omitempty"`
 	Status           string             `json:"status,omitempty"`
 	SelfLink         string             `json:"selfLink,omitempty"`
+	// InstanceGroupUrls point at each backing zonal MIG. The Terraform google
+	// provider derives node_count from the targetSize of the MIGs these resolve
+	// to, so emitting them (with a matching MIG) is what stops node_count drift.
+	InstanceGroupUrls []string `json:"instanceGroupUrls,omitempty"`
 }
 
 type gkeNodeConfig struct {
@@ -227,7 +231,9 @@ func int64Ptr(v int64) *int64 { return &v }
 // endpoint argument is what the Mock reported via Endpoint(location, name) —
 // either the in-memory K8s data-plane URL when a data plane is wired, or the
 // cluster's synthesized control-plane IP.
-func toClusterResource(c *gke.Cluster, project, endpoint string, pools []gke.NodePool) gkeCluster {
+func toClusterResource(
+	c *gke.Cluster, project, endpoint string, pools []gke.NodePool, igmURLsFor func(np *gke.NodePool) []string,
+) gkeCluster {
 	var currentNodes int64
 	for i := range pools {
 		currentNodes += pools[i].NodeCount
@@ -268,7 +274,7 @@ func toClusterResource(c *gke.Cluster, project, endpoint string, pools []gke.Nod
 	}
 
 	for i := range pools {
-		out.NodePools = append(out.NodePools, toNodePoolResource(&pools[i], project))
+		out.NodePools = append(out.NodePools, toNodePoolResource(&pools[i], project, igmURLsFor(&pools[i])))
 	}
 
 	return out
@@ -284,11 +290,12 @@ func versionOr(v string) string {
 	return v
 }
 
-func toNodePoolResource(np *gke.NodePool, project string) gkeNodePool {
+func toNodePoolResource(np *gke.NodePool, project string, igmUrls []string) gkeNodePool {
 	out := gkeNodePool{
-		Name:             np.Name,
-		Version:          np.Version,
-		InitialNodeCount: int64Ptr(np.NodeCount),
+		InstanceGroupUrls: igmUrls,
+		Name:              np.Name,
+		Version:           np.Version,
+		InitialNodeCount:  int64Ptr(np.NodeCount),
 		Config: &gkeNodeConfig{
 			MachineType: np.MachineType,
 			DiskSizeGb:  np.DiskSizeGB,


### PR DESCRIPTION
## Summary

Adds a zonal GCE **instanceGroupManagers** (MIG) surface and wires GKE node pools to a backing MIG, closing the `google_container_node_pool` `node_count` drift filed by the #1123 GKE audit.

The Terraform google provider derives a node pool's `node_count` by summing the `targetSize` of the MIGs its `instanceGroupUrls` point at (via `compute.instanceGroupManagers.list`). CloudEmu had no instanceGroupManagers surface, so node pools carried no `instanceGroupUrls` and the sum was always 0 — every plan showed a perpetual `node_count` 0→N drift.

## What changed

**Compute instanceGroupManagers (server/gcp/compute + providers/gcp/compute)**
- New memstore-backed MIG store on the GCE Mock, reached from the wire handler via a GCP-local type assertion (same pattern as disk `volumeResizer` / `resourceLabelMutator`), so the shared compute driver interface is unchanged.
- Endpoints (all return a DONE Operation LRO like the other compute resources):
  - `POST   .../zones/{z}/instanceGroupManagers` — insert
  - `GET    .../zones/{z}/instanceGroupManagers` — list
  - `GET    .../zones/{z}/instanceGroupManagers/{name}` — get
  - `DELETE .../zones/{z}/instanceGroupManagers/{name}` — delete
  - `POST   .../zones/{z}/instanceGroupManagers/{name}/resize?size=N` — resize (real zonal method; `size` is a query param)
  - `POST   .../zones/{z}/instanceGroupManagers/{name}/setTargetSize` — body-carried alias
  - `GET    .../aggregated/instanceGroupManagers` — aggregatedList
- MIG state is added to the GCE snapshot/restore round-trip.

**GKE wiring (server/gcp/gke)**
- On node-pool lifecycle (cluster create, node-pool create, setSize, delete, cluster delete) the GKE handler reconciles a backing zonal MIG whose `targetSize` == the pool's node count, via an optional compute-side registrar (the GCE Mock), wired in the GCP server factory.
- Node pools now emit `instanceGroupUrls` pointing at that MIG, so the provider's `node_count` read resolves.

## Scope / filed-not-fixed

Minimal `targetSize`-focused zonal build, as scoped. Deliberately out of scope: regional MIGs / per-zone fan-out for regional clusters, autoscalers, instance-template deep modeling, and per-instance managed-instance listing. A regional node pool still round-trips its count (the location string is stored/emitted consistently), just not fanned out across the region's zones.

## Tests
- `TestSDKInstanceGroupManagerRoundTrip` / `TestSDKInstanceGroupManagerAggregatedList` — real `cloud.google.com/go/compute/apiv1` client, insert/get/list/resize/delete + aggregatedList.
- `TestSDKGKENodePoolNodeCountRoundTrip` — real container + compute clients: node pool emits `instanceGroupUrls`, resolving through `instanceGroupManagers.Get` to `targetSize == 2`, follows a resize to 4, and the MIG is removed on pool delete (mirrors the provider's node_count computation).
- Provider-level MIG CRUD/resize/upsert unit tests.

## Gates
`go build ./...`, `go vet`, `gofmt`, `go test -race` on changed packages, `golangci-lint` (0 issues), and `go generate ./...` (no `docs/coverage` change — MIG is a provider-local capability, not a driver-interface method) all green.
