### PR TITLE
feat(serve): gRPC transport foundation (health + reflection, off by default)

### DIFF
--- a/server/grpc/grpc.go
+++ b/server/grpc/grpc.go
@@ -1,0 +1,96 @@
+// Package grpc is the standalone emulator's gRPC transport foundation.
+//
+// It wraps a *grpc.Server preconfigured with only the two transport-level
+// services every gRPC endpoint should expose — the standard health service
+// (grpc.health.v1.Health) and server reflection — plus a listener lifecycle
+// (Serve/Shutdown) shaped like the *http.Server one serverkit already drives,
+// so a gRPC endpoint can sit beside the REST endpoints on its own TCP port
+// without duplicating the bind/serve/shutdown loop.
+//
+// It registers NO application (cloud service) servers. Those are layered on top
+// by callers via Register, once a service's proto stubs and driver adapter
+// exist — this package is the transport only.
+package grpc
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+)
+
+// Server is a gRPC transport endpoint: a *grpc.Server with the health and
+// reflection services registered, ready to Serve on a net.Listener.
+type Server struct {
+	srv    *grpc.Server
+	health *health.Server
+}
+
+// New builds a gRPC server with the health and reflection services registered
+// and the overall serving status set to SERVING. It registers no application
+// services; callers add those with Register.
+func New(opts ...grpc.ServerOption) *Server {
+	srv := grpc.NewServer(opts...)
+
+	h := health.NewServer()
+	// The empty service name is the server-wide health of the whole endpoint,
+	// which a bare `grpc_health_v1.Health/Check` (no service field) queries.
+	h.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	healthpb.RegisterHealthServer(srv, h)
+
+	reflection.Register(srv)
+
+	return &Server{srv: srv, health: h}
+}
+
+// Register exposes the underlying grpc.ServiceRegistrar so callers can attach
+// application service servers on top of this transport. It is the single seam
+// PR-2 (Bigtable Admin over gRPC) wires its generated server stubs through.
+func (s *Server) Register(desc *grpc.ServiceDesc, impl any) {
+	s.srv.RegisterService(desc, impl)
+}
+
+// SetServingStatus updates the health status reported for a service name (empty
+// name = the whole server), letting a caller mark a service NOT_SERVING while it
+// warms up. The transport itself starts SERVING.
+func (s *Server) SetServingStatus(service string, status healthpb.HealthCheckResponse_ServingStatus) {
+	s.health.SetServingStatus(service, status)
+}
+
+// Serve runs the gRPC server on ln until Shutdown (or Stop). A clean stop is
+// reported as nil — mirroring how the HTTP path treats http.ErrServerClosed — so
+// serverkit's serve loop never surfaces an ordinary shutdown as a fatal error.
+func (s *Server) Serve(ln net.Listener) error {
+	if err := s.srv.Serve(ln); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+		return err
+	}
+
+	return nil
+}
+
+// Shutdown gracefully stops the server, honoring ctx: it waits for in-flight
+// RPCs to drain, but hard-stops (grpc.Server.Stop) if ctx is canceled or its
+// deadline passes first, so a slow client cannot outlast the shutdown grace
+// period. It returns ctx.Err() only when the hard-stop path was taken.
+func (s *Server) Shutdown(ctx context.Context) error {
+	done := make(chan struct{})
+
+	go func() {
+		s.srv.GracefulStop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		s.srv.Stop()
+		<-done // GracefulStop returns once Stop has unblocked it
+
+		return ctx.Err()
+	}
+}

--- a/server/grpc/grpc_test.go
+++ b/server/grpc/grpc_test.go
@@ -1,0 +1,133 @@
+package grpc_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	reflectpb "google.golang.org/grpc/reflection/grpc_reflection_v1"
+
+	cgrpc "github.com/stackshy/cloudemu/v2/server/grpc"
+)
+
+// serveEphemeral starts the transport on a loopback ephemeral port and returns
+// the dial address plus a cleanup that gracefully shuts the server down.
+func serveEphemeral(t *testing.T) (string, *cgrpc.Server) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	srv := cgrpc.New()
+
+	go func() {
+		if serr := srv.Serve(ln); serr != nil {
+			t.Errorf("Serve: %v", serr)
+		}
+	}()
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if serr := srv.Shutdown(ctx); serr != nil {
+			t.Errorf("Shutdown: %v", serr)
+		}
+	})
+
+	return ln.Addr().String(), srv
+}
+
+func dial(t *testing.T, addr string) *grpc.ClientConn {
+	t.Helper()
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial %s: %v", addr, err)
+	}
+
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return conn
+}
+
+// TestHealthCheck proves a real client can dial the transport and get SERVING
+// from the standard grpc.health.v1.Health service, for both the whole-server
+// (empty) name and a per-service status set by the caller.
+func TestHealthCheck(t *testing.T) {
+	addr, srv := serveEphemeral(t)
+	srv.SetServingStatus("bigtable.admin.v2.BigtableTableAdmin", healthpb.HealthCheckResponse_SERVING)
+
+	client := healthpb.NewHealthClient(dial(t, addr))
+
+	cases := []struct {
+		name    string
+		service string
+	}{
+		{name: "whole server", service: ""},
+		{name: "named service", service: "bigtable.admin.v2.BigtableTableAdmin"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			resp, err := client.Check(ctx, &healthpb.HealthCheckRequest{Service: tc.service})
+			if err != nil {
+				t.Fatalf("Check(%q): %v", tc.service, err)
+			}
+
+			if resp.GetStatus() != healthpb.HealthCheckResponse_SERVING {
+				t.Fatalf("Check(%q) status = %v, want SERVING", tc.service, resp.GetStatus())
+			}
+		})
+	}
+}
+
+// TestReflectionListsServices proves server reflection is registered and answers
+// a ListServices request that includes the health and reflection services.
+func TestReflectionListsServices(t *testing.T) {
+	addr, _ := serveEphemeral(t)
+
+	client := reflectpb.NewServerReflectionClient(dial(t, addr))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stream, err := client.ServerReflectionInfo(ctx)
+	if err != nil {
+		t.Fatalf("ServerReflectionInfo: %v", err)
+	}
+
+	if err := stream.Send(&reflectpb.ServerReflectionRequest{
+		MessageRequest: &reflectpb.ServerReflectionRequest_ListServices{ListServices: "*"},
+	}); err != nil {
+		t.Fatalf("send ListServices: %v", err)
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, s := range resp.GetListServicesResponse().GetService() {
+		got[s.GetName()] = true
+	}
+
+	for _, want := range []string{
+		"grpc.health.v1.Health",
+		"grpc.reflection.v1.ServerReflection",
+	} {
+		if !got[want] {
+			t.Errorf("reflection ListServices missing %q; got %v", want, got)
+		}
+	}
+}

--- a/server/serveflags/serveflags.go
+++ b/server/serveflags/serveflags.go
@@ -67,6 +67,7 @@ type CommonConfig struct {
 	AWSPort       string
 	AzurePort     string
 	GCPPort       string
+	GCPGRPCPort   string
 	OCIPort       string
 	K8sPort       string
 
@@ -119,6 +120,8 @@ func RegisterCommon(fs *flag.FlagSet, c *CommonConfig, getenv func(string) strin
 	fs.StringVar(&c.AWSPort, "aws-port", "4566", "port for the AWS endpoint (HTTP)")
 	fs.StringVar(&c.AzurePort, "azure-port", "4568", "port for the Azure endpoint (HTTPS)")
 	fs.StringVar(&c.GCPPort, "gcp-port", "4569", "port for the GCP endpoint (HTTP)")
+	fs.StringVar(&c.GCPGRPCPort, "gcp-grpc-port", "",
+		"port for the GCP gRPC transport (health+reflection; empty disables it). Point *_EMULATOR_HOST clients here")
 	fs.StringVar(&c.OCIPort, "oci-port", "4571", "port for the OCI endpoint (HTTP)")
 	fs.StringVar(&c.K8sPort, "k8s-port", "4570", "port for the shared Kubernetes data-plane (HTTPS); empty to disable")
 	fs.StringVar(&c.AccountID, "account-id", "000000000000", "AWS account ID (also GCP/OCI) reported by the emulator")
@@ -230,6 +233,7 @@ func (c *CommonConfig) ToServerkitConfig(providers []string) serverkit.Config {
 			"oci":   c.OCIPort,
 		},
 		K8sPort:                c.K8sPort,
+		GCPGRPCPort:            c.GCPGRPCPort,
 		AdvertiseHost:          c.AdvertiseHost,
 		K8sProgression:         c.K8sProgression,
 		K8sProgressionInterval: c.K8sProgressionInterval,

--- a/server/serveflags/serveflags_test.go
+++ b/server/serveflags/serveflags_test.go
@@ -24,7 +24,7 @@ func noEnv(string) string { return "" }
 //nolint:gochecknoglobals // test fixture: the pinned common-flag name set
 var commonFlagNames = []string{
 	"account-id", "admin", "advertise-host", "aws-port", "azure-port", "azure-subscription",
-	"endpoints-file", "enforce-auth", "gcp-port", "host", "init-dir", "k8s-nodes", "k8s-port",
+	"endpoints-file", "enforce-auth", "gcp-grpc-port", "gcp-port", "host", "init-dir", "k8s-nodes", "k8s-port",
 	"k8s-progression", "k8s-progression-interval", "latency", "log-requests", "oci-port",
 	"persist", "persist-interval", "persist-metadata-only", "persist-strategy", "project-id",
 	"providers", "quiet", "region", "shutdown-timeout", "state-file", "tls-cert", "tls-host",
@@ -91,9 +91,9 @@ func TestRegisterCommonDefaults(t *testing.T) {
 // defaults (contrib relies on an injectable getenv for its tests).
 func TestRegisterCommonEnvFallback(t *testing.T) {
 	env := map[string]string{
-		"CLOUDEMU_PERSIST_STRATEGY":       "on-request",
-		"CLOUDEMU_PERSIST_INTERVAL":       "2s",
-		"CLOUDEMU_K8S_PROGRESSION":        "true",
+		"CLOUDEMU_PERSIST_STRATEGY":         "on-request",
+		"CLOUDEMU_PERSIST_INTERVAL":         "2s",
+		"CLOUDEMU_K8S_PROGRESSION":          "true",
 		"CLOUDEMU_K8S_PROGRESSION_INTERVAL": "5s",
 	}
 	getenv := func(k string) string { return env[k] }

--- a/server/serverkit/endpoints.go
+++ b/server/serverkit/endpoints.go
@@ -18,6 +18,7 @@ type endpointSet struct {
 	AWS        string `json:"aws,omitempty"`
 	Azure      string `json:"azure,omitempty"`
 	GCP        string `json:"gcp,omitempty"`
+	GCPGRPC    string `json:"gcp_grpc,omitempty"`
 	OCI        string `json:"oci,omitempty"`
 	Kubernetes string `json:"kubernetes,omitempty"`
 }
@@ -38,6 +39,7 @@ func (e *endpointSet) banner() []struct{ label, url, note string } {
 		{"AWS", e.AWS, ""},
 		{"Azure", e.Azure, "   (self-signed TLS)"},
 		{"GCP", e.GCP, ""},
+		{"GCP gRPC", e.GCPGRPC, "   (set BIGTABLE_EMULATOR_HOST / PUBSUB_EMULATOR_HOST to this)"},
 		{"OCI", e.OCI, ""},
 		{"Kubernetes", e.Kubernetes, ""},
 	}

--- a/server/serverkit/grpc_serve_test.go
+++ b/server/serverkit/grpc_serve_test.go
@@ -1,0 +1,99 @@
+package serverkit
+
+import (
+	"io"
+	"testing"
+)
+
+// serverNames returns the label of every listenerServer buildServers produced,
+// so a test can assert the optional gRPC endpoint is present only when enabled.
+func serverNames(t *testing.T, cfg Config) []string {
+	t.Helper()
+
+	app := newTestApp(t, cfg)
+
+	servers, _, err := app.buildServers()
+	if err != nil {
+		t.Fatalf("buildServers: %v", err)
+	}
+
+	names := make([]string, len(servers))
+	for i, s := range servers {
+		names[i] = s.name()
+	}
+
+	return names
+}
+
+func hasName(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestGRPCListenerOptIn is the additive-wiring guard: the gRPC endpoint appears
+// in the server set exactly when --gcp-grpc-port is set, and the default serve
+// (port empty) binds no gRPC listener, so its behavior is unchanged.
+func TestGRPCListenerOptIn(t *testing.T) {
+	base := Config{
+		Providers: []string{"gcp"},
+		Host:      "127.0.0.1",
+		Ports:     map[string]string{"gcp": "0"},
+		Out:       io.Discard,
+	}
+
+	cases := []struct {
+		name     string
+		grpcPort string
+		wantGRPC bool
+	}{
+		{name: "off by default", grpcPort: "", wantGRPC: false},
+		{name: "enabled", grpcPort: "16331", wantGRPC: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base
+			cfg.GCPGRPCPort = tc.grpcPort
+
+			names := serverNames(t, cfg)
+
+			if got := hasName(names, "gcp-grpc"); got != tc.wantGRPC {
+				t.Fatalf("gcp-grpc listener present = %v, want %v (servers: %v)", got, tc.wantGRPC, names)
+			}
+
+			// The REST GCP endpoint is present regardless — the gRPC transport is
+			// additive, never a replacement.
+			if !hasName(names, "gcp") {
+				t.Fatalf("gcp REST listener missing (servers: %v)", names)
+			}
+		})
+	}
+}
+
+// TestGRPCEndpointAdvertised checks the resolved endpoint set carries the gRPC
+// bind address when enabled and omits it (empty) otherwise.
+func TestGRPCEndpointAdvertised(t *testing.T) {
+	cfg := Config{
+		Providers:   []string{"gcp"},
+		Host:        "127.0.0.1",
+		Ports:       map[string]string{"gcp": "0"},
+		GCPGRPCPort: "16331",
+		Out:         io.Discard,
+	}
+
+	app := newTestApp(t, cfg)
+
+	_, eps, err := app.buildServers()
+	if err != nil {
+		t.Fatalf("buildServers: %v", err)
+	}
+
+	if want := "127.0.0.1:16331"; eps.GCPGRPC != want {
+		t.Fatalf("eps.GCPGRPC = %q, want %q", eps.GCPGRPC, want)
+	}
+}

--- a/server/serverkit/serverkit.go
+++ b/server/serverkit/serverkit.go
@@ -41,6 +41,7 @@ import (
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
 	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
 	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+	cgrpc "github.com/stackshy/cloudemu/v2/server/grpc"
 	ociserver "github.com/stackshy/cloudemu/v2/server/oci"
 	"github.com/stackshy/cloudemu/v2/services/kubernetes"
 	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
@@ -89,6 +90,7 @@ type Config struct {
 	Host          string            // host/interface to bind
 	Ports         map[string]string // per-provider bind ports, keys aws/azure/gcp/oci (and optionally k8s)
 	K8sPort       string            // shared Kubernetes data-plane port; empty disables it
+	GCPGRPCPort   string            // GCP gRPC transport port (health+reflection); empty disables it
 	AdvertiseHost string            // host the Kubernetes endpoint is advertised at (default: derived from Host)
 
 	// K8sProgression enables KWOK-style staged Pod lifecycle on the data plane:
@@ -842,8 +844,8 @@ func (a *App) Serve(ctx context.Context) error {
 
 // buildServers assembles the per-provider (and Kubernetes) HTTP servers and the
 // endpoint set advertised to clients.
-func (a *App) buildServers() ([]*namedServer, endpointSet, error) {
-	var servers []*namedServer
+func (a *App) buildServers() ([]listenerServer, endpointSet, error) {
+	var servers []listenerServer
 
 	eps := endpointSet{}
 
@@ -877,8 +879,8 @@ func (a *App) buildServers() ([]*namedServer, endpointSet, error) {
 			eps.Azure = fmt.Sprintf("https://%s", addr)
 		}
 
-		servers = append(servers, &namedServer{
-			name: p,
+		servers = append(servers, &httpServer{
+			label: p,
 			srv: &http.Server{
 				Addr:              addr,
 				Handler:           a.handlerFor(a.backends[p], a.seedFor(p)),
@@ -900,8 +902,8 @@ func (a *App) buildServers() ([]*namedServer, endpointSet, error) {
 			return nil, eps, fmt.Errorf("kubernetes data-plane TLS: %w", err)
 		}
 
-		servers = append(servers, &namedServer{
-			name: "kubernetes",
+		servers = append(servers, &httpServer{
+			label: "kubernetes",
 			srv: &http.Server{
 				Addr:              addr,
 				Handler:           a.handlerFor(a.k8sBackend, nil),
@@ -914,6 +916,16 @@ func (a *App) buildServers() ([]*namedServer, endpointSet, error) {
 		eps.Kubernetes = fmt.Sprintf("https://%s", net.JoinHostPort(a.advertiseHost, a.k8sPort))
 	}
 
+	// Optional GCP gRPC transport on its own TCP port (off unless the port is
+	// set), served beside the REST endpoints. It carries only the health and
+	// reflection services for now — the foundation the emulator-env-var gRPC
+	// services (BIGTABLE_EMULATOR_HOST etc.) are layered on next.
+	if a.cfg.GCPGRPCPort != "" {
+		addr := net.JoinHostPort(a.cfg.Host, a.cfg.GCPGRPCPort)
+		servers = append(servers, &grpcServer{label: "gcp-grpc", bind: addr, srv: cgrpc.New()})
+		eps.GCPGRPC = addr
+	}
+
 	return servers, eps, nil
 }
 
@@ -921,7 +933,7 @@ func (a *App) buildServers() ([]*namedServer, endpointSet, error) {
 // they are quiescent (so no in-flight request can mutate state mid-read), and
 // only then closes the live providers — engines must stay readable through the
 // snapshot.
-func (a *App) shutdown(servers []*namedServer) error {
+func (a *App) shutdown(servers []listenerServer) error {
 	to := a.cfg.ShutdownTimeout
 	if to <= 0 {
 		to = defaultShutdownTimeout
@@ -932,7 +944,7 @@ func (a *App) shutdown(servers []*namedServer) error {
 
 	var shutErr error
 	for _, s := range servers {
-		if err := s.srv.Shutdown(ctx); err != nil && shutErr == nil {
+		if err := s.shutdown(ctx); err != nil && shutErr == nil {
 			shutErr = err
 		}
 	}
@@ -1019,29 +1031,72 @@ func (a *App) stopK8sTicker() {
 	a.k8sTickStop = nil
 }
 
-// namedServer is one endpoint's HTTP server plus how it is served.
-type namedServer struct {
-	name string
-	srv  *http.Server
-	tls  bool
+// listenerServer is one endpoint's serve/shutdown lifecycle, independent of the
+// wire protocol behind it. The HTTP endpoints (httpServer) and the optional gRPC
+// endpoint (grpcServer) both implement it, so bindListeners/serveAll/shutdown
+// drive every endpoint uniformly on its own TCP port. A clean shutdown must be
+// reported by serve() as nil (or, for HTTP, http.ErrServerClosed) so the serve
+// loop never treats an ordinary stop as a fatal error.
+type listenerServer interface {
+	name() string // endpoint label, used in bind/serve error messages
+	addr() string // host:port to bind
+	serve(net.Listener) error
+	shutdown(context.Context) error
 }
+
+// httpServer adapts the existing *http.Server path to listenerServer. It carries
+// the exact bind/serve/shutdown behavior the emulator has always used — TLS
+// endpoints ServeTLS with the cert already in the server's TLSConfig, plain ones
+// Serve — so wrapping it here changes nothing observable.
+type httpServer struct {
+	label string
+	srv   *http.Server
+	tls   bool
+}
+
+func (h *httpServer) name() string { return h.label }
+func (h *httpServer) addr() string { return h.srv.Addr }
+
+func (h *httpServer) serve(ln net.Listener) error {
+	if h.tls {
+		return h.srv.ServeTLS(ln, "", "")
+	}
+
+	return h.srv.Serve(ln)
+}
+
+func (h *httpServer) shutdown(ctx context.Context) error { return h.srv.Shutdown(ctx) }
+
+// grpcServer adapts the server/grpc transport wrapper to listenerServer, so the
+// optional gRPC endpoint binds and drains through the same loop as the HTTP
+// ones. Its serve() already maps a clean stop to nil (see server/grpc).
+type grpcServer struct {
+	label string
+	bind  string
+	srv   *cgrpc.Server
+}
+
+func (g *grpcServer) name() string                       { return g.label }
+func (g *grpcServer) addr() string                       { return g.bind }
+func (g *grpcServer) serve(ln net.Listener) error        { return g.srv.Serve(ln) }
+func (g *grpcServer) shutdown(ctx context.Context) error { return g.srv.Shutdown(ctx) }
 
 // bindListeners binds every listener up front so a port clash fails fast, before
 // a banner promises endpoints that never came up. A partial failure closes the
 // listeners already opened.
-func bindListeners(servers []*namedServer) ([]net.Listener, error) {
+func bindListeners(servers []listenerServer) ([]net.Listener, error) {
 	listeners := make([]net.Listener, len(servers))
 
 	var lc net.ListenConfig
 
 	for i, s := range servers {
-		ln, err := lc.Listen(context.Background(), "tcp", s.srv.Addr)
+		ln, err := lc.Listen(context.Background(), "tcp", s.addr())
 		if err != nil {
 			for _, l := range listeners[:i] {
 				l.Close()
 			}
 
-			return nil, fmt.Errorf("bind %s (%s): %w", s.name, s.srv.Addr, err)
+			return nil, fmt.Errorf("bind %s (%s): %w", s.name(), s.addr(), err)
 		}
 
 		listeners[i] = ln
@@ -1052,22 +1107,15 @@ func bindListeners(servers []*namedServer) ([]net.Listener, error) {
 
 // serveAll starts every bound listener in its own goroutine and returns a
 // channel reporting the first fatal serve error.
-func serveAll(servers []*namedServer, listeners []net.Listener) <-chan error {
+func serveAll(servers []listenerServer, listeners []net.Listener) <-chan error {
 	errCh := make(chan error, len(servers))
 
 	for i, s := range servers {
 		ln := listeners[i]
 
 		go func() {
-			var err error
-			if s.tls {
-				err = s.srv.ServeTLS(ln, "", "")
-			} else {
-				err = s.srv.Serve(ln)
-			}
-
-			if err != nil && !errors.Is(err, http.ErrServerClosed) {
-				errCh <- fmt.Errorf("%s: %w", s.name, err)
+			if err := s.serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				errCh <- fmt.Errorf("%s: %w", s.name(), err)
 			}
 		}()
 	}


### PR DESCRIPTION
## Summary

PR-1 of the phased gRPC transport plan. This is the transport **foundation only** — no cloud service handler. It lets `cloudemu serve` expose a gRPC endpoint on its own TCP port, ready for the emulator-env-var gRPC clients (`BIGTABLE_EMULATOR_HOST`, `PUBSUB_EMULATOR_HOST`, …), and unblocks #1102 (Bigtable Admin over gRPC) as PR-2.

## Feature

- **`server/grpc`** — a thin `grpc.Server` wrapper (`New`, `Register`, `SetServingStatus`, `Serve`, `Shutdown`) that registers **only** the standard gRPC `health` (`grpc.health.v1.Health`) and server `reflection` services. No application services. `Serve` maps a clean stop to `nil` (mirroring `http.ErrServerClosed`); `Shutdown` honors the context — graceful drain, hard-stop on deadline.
- **`--gcp-grpc-port`** serve flag, **default off** (empty = not bound). When set, a gRPC listener binds on that port and is served/drained beside the HTTP endpoints; the endpoint is advertised in the banner and endpoints JSON.

## Enhancement

- Generalized the serverkit listener lifecycle behind a small `listenerServer` seam (`name/addr/serve/shutdown`). The existing `*http.Server` path becomes one implementation (`httpServer`) and the gRPC endpoint another (`grpcServer`); `bindListeners`/`serveAll`/`shutdown` drive both uniformly. The refactor is confined to the listener lifecycle — provider construction and wiring are untouched.

## Notes

- **Default serve is byte-for-byte unchanged** when `--gcp-grpc-port` is unset: no gRPC listener, banner and endpoints identical.
- **No new dependencies**: `go.mod`/`go.sum` untouched — health and reflection ship inside the already-vendored `google.golang.org/grpc`. No proto-stub module is added (that lands with the service in PR-2).
- Own dedicated port, no multiplexing onto an HTTP listener (no cmux).

## Testing

- `server/grpc`: real client round-trip on an ephemeral port — dial (insecure) → `Health/Check` returns `SERVING` (whole-server and a per-service name); reflection `ListServices` returns the health + reflection services. `-race` clean.
- `server/serverkit`: the gRPC listener appears in the server set exactly when the port is set (off by default), the REST endpoint stays present, and the endpoint set advertises the bind address.
