### PR TITLE
fix(azure-appservice): real-user e2e divergences from Azure

### DIFF
--- a/providers/azure/functions/site_meta.go
+++ b/providers/azure/functions/site_meta.go
@@ -117,15 +117,23 @@ type SiteFunction struct {
 // It is stored alongside the portable function so a Microsoft.Web/sites request
 // can reconstruct the full ARM site resource.
 type SiteMeta struct {
-	Name              string
-	Subscription      string
-	ResourceGroup     string
-	Location          string
-	Kind              string
-	ServerFarmID      string
-	HTTPSOnly         bool
-	Reserved          bool
-	LinuxFxVersion    string
+	Name           string
+	Subscription   string
+	ResourceGroup  string
+	Location       string
+	Kind           string
+	ServerFarmID   string
+	HTTPSOnly      bool
+	Reserved       bool
+	LinuxFxVersion string
+	// AlwaysOn is the site_config always_on flag. It is a *bool so an explicit
+	// false round-trips distinctly from "never set" (nil), matching real Azure
+	// and Terraform's azurerm_linux_web_app.
+	AlwaysOn *bool
+	// FtpsState and MinTLSVersion are site_config knobs real Azure returns from
+	// GetConfiguration (config/web); stored here so they survive a round-trip.
+	FtpsState         string
+	MinTLSVersion     string
 	ProvisioningState string
 	// State is the running state reported on the ARM site ("Running" on create,
 	// "Stopped" after a stop). Start/stop toggle it; a plain update leaves it.
@@ -143,6 +151,7 @@ type SiteMeta struct {
 // clone returns a deep copy safe to hand outside the store lock.
 func (s *SiteMeta) clone() *SiteMeta {
 	out := *s
+	out.AlwaysOn = cloneBoolPtr(s.AlwaysOn)
 	out.AppSettings = maps.Clone(s.AppSettings)
 	out.HostFunctionKeys = maps.Clone(s.HostFunctionKeys)
 	out.SystemKeys = maps.Clone(s.SystemKeys)
@@ -182,6 +191,9 @@ func (m *Mock) UpsertSiteMeta(_ context.Context, in SiteMeta) (*SiteMeta, error)
 		existing.HTTPSOnly = in.HTTPSOnly
 		existing.Reserved = in.Reserved
 		existing.LinuxFxVersion = in.LinuxFxVersion
+		existing.AlwaysOn = cloneBoolPtr(in.AlwaysOn)
+		existing.FtpsState = in.FtpsState
+		existing.MinTLSVersion = in.MinTLSVersion
 		existing.AppSettings = maps.Clone(in.AppSettings)
 
 		// An empty in.Kind means the request omitted kind, so the existing kind
@@ -229,6 +241,11 @@ type SiteMetaPatch struct {
 	HTTPSOnly      *bool
 	Reserved       *bool
 	LinuxFxVersion *string
+	// AlwaysOn/FtpsState/MinTLSVersion, when non-nil, replace the stored value;
+	// nil preserves it (PATCH partial-update semantics).
+	AlwaysOn      *bool
+	FtpsState     *string
+	MinTLSVersion *string
 	// Identity, when non-nil, replaces the attached identity (a Type of "None"
 	// detaches it, matching `az functionapp identity remove`); nil preserves the
 	// current identity.
@@ -241,6 +258,8 @@ type SiteMetaPatch struct {
 // GetSiteMeta, preserving every field the patch leaves nil (unlike UpsertSiteMeta,
 // which is a full replace suited to PUT). Generated keys, deployed functions and
 // the running state are untouched.
+//
+//nolint:gocritic // patch is the by-value request payload, applied under the lock.
 func (m *Mock) PatchSiteMeta(
 	_ context.Context, subscription, resourceGroup, name string, patch SiteMetaPatch,
 ) (*SiteMeta, error) {
@@ -259,6 +278,8 @@ func (m *Mock) PatchSiteMeta(
 }
 
 // applySiteMetaPatch overlays the supplied (non-nil) patch fields onto meta.
+//
+//nolint:gocritic // patch is the by-value request payload, applied under the lock.
 func applySiteMetaPatch(meta *SiteMeta, patch SiteMetaPatch) {
 	if patch.Location != nil {
 		meta.Location = *patch.Location
@@ -284,12 +305,33 @@ func applySiteMetaPatch(meta *SiteMeta, patch SiteMetaPatch) {
 		meta.LinuxFxVersion = *patch.LinuxFxVersion
 	}
 
+	applySiteConfigPatch(meta, patch)
+
 	if patch.Identity != nil {
 		meta.Identity = resolveSiteIdentity(patch.Identity, identitySeed(meta))
 	}
 
 	if patch.AppSettings != nil {
 		meta.AppSettings = maps.Clone(*patch.AppSettings)
+	}
+}
+
+// applySiteConfigPatch overlays the supplied site_config knobs (AlwaysOn,
+// FtpsState, MinTLSVersion) onto meta, each preserved when the patch leaves it
+// nil. Split out of applySiteMetaPatch to keep that function's branch count low.
+//
+//nolint:gocritic // patch mirrors applySiteMetaPatch's by-value payload.
+func applySiteConfigPatch(meta *SiteMeta, patch SiteMetaPatch) {
+	if patch.AlwaysOn != nil {
+		meta.AlwaysOn = cloneBoolPtr(patch.AlwaysOn)
+	}
+
+	if patch.FtpsState != nil {
+		meta.FtpsState = *patch.FtpsState
+	}
+
+	if patch.MinTLSVersion != nil {
+		meta.MinTLSVersion = *patch.MinTLSVersion
 	}
 }
 
@@ -550,6 +592,18 @@ func (m *Mock) lookupFunction(site, name string) (*SiteFunction, error) {
 	}
 
 	return fn, nil
+}
+
+// cloneBoolPtr returns an independent copy of a *bool so a stored SiteMeta never
+// aliases the caller's pointer (COW safety).
+func cloneBoolPtr(b *bool) *bool {
+	if b == nil {
+		return nil
+	}
+
+	v := *b
+
+	return &v
 }
 
 // generateKey returns a URL-safe base64 secret used for host and function keys.

--- a/providers/azure/functions/site_meta_test.go
+++ b/providers/azure/functions/site_meta_test.go
@@ -322,3 +322,98 @@ func TestUpdateAppSettingsScoped(t *testing.T) {
 		t.Fatalf("wrong-rg update leaked through: %+v", unchanged.AppSettings)
 	}
 }
+
+// boolPtr is a *bool literal helper for the site_config tests.
+func boolPtr(b bool) *bool { return &b }
+
+// strPtr is a *string literal helper for the site_config PATCH tests.
+func strPtr(s string) *string { return &s }
+
+// TestSiteMetaConfigTrioRoundTrip covers the site_config trio (AlwaysOn,
+// FtpsState, MinTLSVersion): PUT stores them (including an explicit AlwaysOn
+// false), and a scoped GET reads them back unchanged.
+func TestSiteMetaConfigTrioRoundTrip(t *testing.T) {
+	m := newMetaMock()
+	ctx := context.Background()
+
+	created, err := m.UpsertSiteMeta(ctx, SiteMeta{
+		Name: "cfg1", Subscription: "sub1", ResourceGroup: "rgA", Location: "eastus",
+		AlwaysOn: boolPtr(false), FtpsState: "Disabled", MinTLSVersion: "1.2",
+	})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	if created.AlwaysOn == nil || *created.AlwaysOn {
+		t.Fatalf("AlwaysOn = %v, want explicit false", created.AlwaysOn)
+	}
+
+	got, err := m.GetSiteMeta(ctx, "sub1", "rgA", "cfg1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.AlwaysOn == nil || *got.AlwaysOn || got.FtpsState != "Disabled" || got.MinTLSVersion != "1.2" {
+		t.Fatalf("trio not preserved: alwaysOn=%v ftps=%q tls=%q", got.AlwaysOn, got.FtpsState, got.MinTLSVersion)
+	}
+
+	// The stored copy must not alias the returned pointer (COW safety).
+	*got.AlwaysOn = true
+
+	again, err := m.GetSiteMeta(ctx, "sub1", "rgA", "cfg1")
+	if err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+
+	if again.AlwaysOn == nil || *again.AlwaysOn {
+		t.Fatalf("mutating a returned AlwaysOn leaked into the store: %v", again.AlwaysOn)
+	}
+}
+
+// TestPatchSiteMetaConfigTrio covers PATCH partial semantics for the trio: a
+// PATCH that sets one field leaves the others untouched, and a PATCH that omits
+// the trio preserves all three.
+func TestPatchSiteMetaConfigTrio(t *testing.T) {
+	m := newMetaMock()
+	ctx := context.Background()
+
+	if _, err := m.UpsertSiteMeta(ctx, SiteMeta{
+		Name: "cfg2", Subscription: "sub1", ResourceGroup: "rgA", Location: "eastus",
+		AlwaysOn: boolPtr(false), FtpsState: "Disabled", MinTLSVersion: "1.2",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// PATCH AlwaysOn -> true only; ftps/minTls preserved.
+	patched, err := m.PatchSiteMeta(ctx, "sub1", "rgA", "cfg2", SiteMetaPatch{AlwaysOn: boolPtr(true)})
+	if err != nil {
+		t.Fatalf("patch alwaysOn: %v", err)
+	}
+
+	if patched.AlwaysOn == nil || !*patched.AlwaysOn || patched.FtpsState != "Disabled" || patched.MinTLSVersion != "1.2" {
+		t.Fatalf("partial patch clobbered siblings: alwaysOn=%v ftps=%q tls=%q",
+			patched.AlwaysOn, patched.FtpsState, patched.MinTLSVersion)
+	}
+
+	// PATCH ftps only; alwaysOn/minTls preserved.
+	patched, err = m.PatchSiteMeta(ctx, "sub1", "rgA", "cfg2", SiteMetaPatch{FtpsState: strPtr("FtpsOnly")})
+	if err != nil {
+		t.Fatalf("patch ftps: %v", err)
+	}
+
+	if patched.AlwaysOn == nil || !*patched.AlwaysOn || patched.FtpsState != "FtpsOnly" || patched.MinTLSVersion != "1.2" {
+		t.Fatalf("ftps patch clobbered siblings: alwaysOn=%v ftps=%q tls=%q",
+			patched.AlwaysOn, patched.FtpsState, patched.MinTLSVersion)
+	}
+
+	// PATCH with the trio omitted preserves everything.
+	patched, err = m.PatchSiteMeta(ctx, "sub1", "rgA", "cfg2", SiteMetaPatch{Location: strPtr("westus2")})
+	if err != nil {
+		t.Fatalf("patch location: %v", err)
+	}
+
+	if patched.AlwaysOn == nil || !*patched.AlwaysOn || patched.FtpsState != "FtpsOnly" || patched.MinTLSVersion != "1.2" {
+		t.Fatalf("trio-omitting patch dropped a field: alwaysOn=%v ftps=%q tls=%q",
+			patched.AlwaysOn, patched.FtpsState, patched.MinTLSVersion)
+	}
+}

--- a/server/azure/functions/handler.go
+++ b/server/azure/functions/handler.go
@@ -331,6 +331,9 @@ func (h *Handler) upsertSiteMeta(
 		HTTPSOnly:      req.Properties.HTTPSOnly,
 		Reserved:       req.Properties.Reserved,
 		LinuxFxVersion: req.Properties.SiteConfig.LinuxFxVersion,
+		AlwaysOn:       req.Properties.SiteConfig.AlwaysOn,
+		FtpsState:      req.Properties.SiteConfig.FtpsState,
+		MinTLSVersion:  req.Properties.SiteConfig.MinTLSVersion,
 		Identity:       toSiteMetaIdentity(req.Identity),
 		AppSettings:    appSettingsToMap(settings),
 	})
@@ -444,6 +447,9 @@ func (h *Handler) patchSiteMeta(
 
 		if req.Properties.SiteConfig != nil {
 			patch.LinuxFxVersion = req.Properties.SiteConfig.LinuxFxVersion
+			patch.AlwaysOn = req.Properties.SiteConfig.AlwaysOn
+			patch.FtpsState = req.Properties.SiteConfig.FtpsState
+			patch.MinTLSVersion = req.Properties.SiteConfig.MinTLSVersion
 		}
 	}
 
@@ -916,12 +922,19 @@ func toSiteResource(rp azurearm.ResourcePath, info *sdrv.FunctionInfo, meta *azf
 
 	var identity *siteIdentity
 
+	var alwaysOn *bool
+
+	var ftpsState, minTLSVersion string
+
 	if meta != nil {
 		location = meta.Location
 		provisioningState = meta.ProvisioningState
 		serverFarmID = meta.ServerFarmID
 		httpsOnly = meta.HTTPSOnly
 		reserved = meta.Reserved
+		alwaysOn = meta.AlwaysOn
+		ftpsState = meta.FtpsState
+		minTLSVersion = meta.MinTLSVersion
 		identity = fromSiteMetaIdentity(meta.Identity)
 
 		if meta.Kind != "" {
@@ -957,6 +970,9 @@ func toSiteResource(rp azurearm.ResourcePath, info *sdrv.FunctionInfo, meta *azf
 			// GET. The values are read only via config/appsettings/list.
 			SiteConfig: siteConfig{
 				LinuxFxVersion: info.Runtime,
+				AlwaysOn:       alwaysOn,
+				FtpsState:      ftpsState,
+				MinTLSVersion:  minTLSVersion,
 			},
 			ServerFarmID:        serverFarmID,
 			HTTPSOnly:           httpsOnly,

--- a/server/azure/functions/sites_config_sdk_test.go
+++ b/server/azure/functions/sites_config_sdk_test.go
@@ -1,0 +1,154 @@
+package functions_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3"
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKSiteConfigTrioRoundTrip pins the site_config knobs Terraform's
+// azurerm_linux_web_app compares on every plan — always_on, ftps_state and
+// minimum_tls_version — round-tripping through GetConfiguration (config/web)
+// and the site resource, not just the generic property echo. An explicit
+// always_on=false (required on Basic/Free tiers) must survive distinctly from
+// "unset", or the provider sees perpetual drift.
+func TestSDKSiteConfigTrioRoundTrip(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	ts := httptest.NewTLSServer(azureserver.New(azureserver.Drivers{Functions: cloudP.Functions}))
+	t.Cleanup(ts.Close)
+
+	client := newWebAppsClient(t, ts)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rgName, "sdk-cfg",
+		armappservice.Site{
+			Kind:     to.Ptr("app,linux"),
+			Location: to.Ptr("eastus"),
+			Properties: &armappservice.SiteProperties{
+				Reserved: to.Ptr(true),
+				SiteConfig: &armappservice.SiteConfig{
+					LinuxFxVersion: to.Ptr("NODE|18-lts"),
+					AlwaysOn:       to.Ptr(false),
+					FtpsState:      to.Ptr(armappservice.FtpsStateDisabled),
+					MinTLSVersion:  to.Ptr(armappservice.SupportedTLSVersionsOne2),
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err = poller.PollUntilDone(ctx, &runtimePollerOptions); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	// GetConfiguration is the call azurerm reads site_config back from.
+	cfg, err := client.GetConfiguration(ctx, rgName, "sdk-cfg", nil)
+	if err != nil {
+		t.Fatalf("GetConfiguration: %v", err)
+	}
+
+	assertTrio(t, "GetConfiguration", cfg.Properties, false, armappservice.FtpsStateDisabled, armappservice.SupportedTLSVersionsOne2)
+
+	// The site resource itself must carry the same values.
+	got, err := client.Get(ctx, rgName, "sdk-cfg", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	assertTrio(t, "Get", got.Properties.SiteConfig, false, armappservice.FtpsStateDisabled, armappservice.SupportedTLSVersionsOne2)
+
+	// Update (PATCH) only always_on -> true; ftps/minTls must be preserved.
+	if _, err = client.Update(ctx, rgName, "sdk-cfg", armappservice.SitePatchResource{
+		Properties: &armappservice.SitePatchResourceProperties{
+			SiteConfig: &armappservice.SiteConfig{AlwaysOn: to.Ptr(true)},
+		},
+	}, nil); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	cfg, err = client.GetConfiguration(ctx, rgName, "sdk-cfg", nil)
+	if err != nil {
+		t.Fatalf("GetConfiguration after patch: %v", err)
+	}
+
+	assertTrio(t, "afterPatch", cfg.Properties, true, armappservice.FtpsStateDisabled, armappservice.SupportedTLSVersionsOne2)
+}
+
+// assertTrio asserts the site_config always_on/ftps_state/min_tls_version trio.
+func assertTrio(
+	t *testing.T, where string, cfg *armappservice.SiteConfig,
+	wantAlwaysOn bool, wantFtps armappservice.FtpsState, wantTLS armappservice.SupportedTLSVersions,
+) {
+	t.Helper()
+
+	if cfg == nil {
+		t.Fatalf("%s: siteConfig is nil", where)
+	}
+
+	if cfg.AlwaysOn == nil || *cfg.AlwaysOn != wantAlwaysOn {
+		t.Fatalf("%s: alwaysOn = %v, want %v", where, cfg.AlwaysOn, wantAlwaysOn)
+	}
+
+	if cfg.FtpsState == nil || *cfg.FtpsState != wantFtps {
+		t.Fatalf("%s: ftpsState = %v, want %v", where, cfg.FtpsState, wantFtps)
+	}
+
+	if cfg.MinTLSVersion == nil || *cfg.MinTLSVersion != wantTLS {
+		t.Fatalf("%s: minTlsVersion = %v, want %v", where, cfg.MinTLSVersion, wantTLS)
+	}
+}
+
+// TestSDKSiteConfigUnsetOmitsTrio confirms a site created without the trio does
+// not synthesize phantom values: the fields stay absent (nil) so a caller that
+// never set them reads them as unset, matching "explicit-only" round-trip.
+func TestSDKSiteConfigUnsetOmitsTrio(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	ts := httptest.NewTLSServer(azureserver.New(azureserver.Drivers{Functions: cloudP.Functions}))
+	t.Cleanup(ts.Close)
+
+	client := newWebAppsClient(t, ts)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rgName, "sdk-cfg-bare",
+		armappservice.Site{
+			Kind:     to.Ptr("app,linux"),
+			Location: to.Ptr("eastus"),
+			Properties: &armappservice.SiteProperties{
+				SiteConfig: &armappservice.SiteConfig{LinuxFxVersion: to.Ptr("PYTHON|3.11")},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err = poller.PollUntilDone(ctx, &runtimePollerOptions); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	cfg, err := client.GetConfiguration(ctx, rgName, "sdk-cfg-bare", nil)
+	if err != nil {
+		t.Fatalf("GetConfiguration: %v", err)
+	}
+
+	if cfg.Properties == nil {
+		t.Fatal("siteConfig properties nil")
+	}
+
+	if cfg.Properties.AlwaysOn != nil {
+		t.Fatalf("alwaysOn = %v, want nil (unset)", *cfg.Properties.AlwaysOn)
+	}
+
+	if cfg.Properties.FtpsState != nil {
+		t.Fatalf("ftpsState = %v, want nil (unset)", *cfg.Properties.FtpsState)
+	}
+
+	if cfg.Properties.MinTLSVersion != nil {
+		t.Fatalf("minTlsVersion = %v, want nil (unset)", *cfg.Properties.MinTLSVersion)
+	}
+}

--- a/server/azure/functions/sites_subroutes.go
+++ b/server/azure/functions/sites_subroutes.go
@@ -112,6 +112,9 @@ func getConfigWeb(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePa
 		Type: configResourceType,
 		Properties: siteConfig{
 			LinuxFxVersion: meta.LinuxFxVersion,
+			AlwaysOn:       meta.AlwaysOn,
+			FtpsState:      meta.FtpsState,
+			MinTLSVersion:  meta.MinTLSVersion,
 			AppSettings:    appSettingsSlice(meta.AppSettings),
 		},
 	})

--- a/server/azure/functions/types.go
+++ b/server/azure/functions/types.go
@@ -60,6 +60,18 @@ type siteProperties struct {
 type siteConfig struct {
 	LinuxFxVersion      string `json:"linuxFxVersion,omitempty"`
 	NetFrameworkVersion string `json:"netFrameworkVersion,omitempty"`
+	// AlwaysOn keeps the app's process warm. It is a *bool so an explicit
+	// false (required on Basic/Free/Consumption tiers, and what azurerm sends
+	// for those) round-trips distinctly from "unset" (nil, field omitted) —
+	// real Azure returns an explicit boolean here, and Terraform's
+	// azurerm_linux_web_app compares site_config.always_on against it.
+	AlwaysOn *bool `json:"alwaysOn,omitempty"`
+	// FtpsState (AllAllowed / FtpsOnly / Disabled) and MinTLSVersion
+	// (1.0 / 1.1 / 1.2 / 1.3) are core site_config knobs Terraform tracks.
+	// Real Azure returns them from GetConfiguration (config/web), so they must
+	// round-trip there and on the site resource, not just via the property echo.
+	FtpsState     string `json:"ftpsState,omitempty"`
+	MinTLSVersion string `json:"minTlsVersion,omitempty"`
 	// AppSettings has no omitempty: a plain site GET emits it as null so the
 	// server's unmodeled-property echo does not reflect the request's app
 	// settings (secret values included) back onto the response. The dedicated
@@ -96,6 +108,9 @@ type createSiteProperties struct {
 
 type createSiteConfig struct {
 	LinuxFxVersion string      `json:"linuxFxVersion"`
+	AlwaysOn       *bool       `json:"alwaysOn"`
+	FtpsState      string      `json:"ftpsState"`
+	MinTLSVersion  string      `json:"minTlsVersion"`
 	AppSettings    []nameValue `json:"appSettings"`
 }
 
@@ -120,6 +135,12 @@ type patchSiteProperties struct {
 
 type patchSiteConfig struct {
 	LinuxFxVersion *string `json:"linuxFxVersion"`
+	// AlwaysOn/FtpsState/MinTLSVersion are pointers so an omitted field (nil)
+	// preserves the stored value while an explicit one (including alwaysOn=false)
+	// replaces it — PATCH partial-update semantics.
+	AlwaysOn      *bool   `json:"alwaysOn"`
+	FtpsState     *string `json:"ftpsState"`
+	MinTLSVersion *string `json:"minTlsVersion"`
 	// AppSettings is nil when the PATCH omitted the block (settings preserved) and
 	// non-nil (possibly empty) when it supplied one (settings replaced).
 	AppSettings []nameValue `json:"appSettings"`


### PR DESCRIPTION
## Summary

Real-user e2e audit of the Azure App Service surface (Microsoft.Web/serverfarms + Microsoft.Web/sites, served by the `functions` handler) against real Azure, driven by `cloudemu serve` + raw ARM and the `armappservice` SDK.

One genuine divergence found and fixed: **the site_config trio `alwaysOn` / `ftpsState` / `minTlsVersion` supplied on create was dropped from `GetConfiguration` (config/web) and the site resource.**

Real Azure returns these from GetConfiguration; `azurerm_linux_web_app` / `azurerm_windows_web_app` read `site_config` from that call and diff `always_on`, `ftps_state`, `minimum_tls_version` on every plan — so the drop produced perpetual Terraform drift. An explicit `always_on = false` (required on Basic/Free/Consumption tiers) was lost entirely.

## What changed

- Model `AlwaysOn` (*bool), `FtpsState`, `MinTLSVersion` on the provider `SiteMeta`, wired through create (PUT), PATCH (partial-update semantics), `config/web`, and the site resource response.
- `AlwaysOn` is a `*bool` so an explicit `false` round-trips distinctly from unset (nil → field omitted), matching real Azure and Terraform.
- COW-safe pointer clone for the new `*bool`.

## Verified

- Live `cloudemu serve` + raw ARM: config/web now returns the trio incl. `alwaysOn=false`; site GET matches; PATCH of one field preserves siblings; a site created without the trio omits the fields (no phantom values).
- `armappservice` SDK round-trip test (create incl. always_on=false → GetConfiguration/Get → Update patch → re-read) + provider-level unit tests.
- Plan surface (serverfarms) confirmed already correct: SKU tier derivation, reserved echo, capacity default, delete-when-assigned 409, clean ARM 404 envelopes.

## Gates

`go build ./...`, `go vet`, `gofmt -l` clean; `go test -race` scoped providers/azure/functions + full server/azure suite green; root integration + persist completeness green; `golangci-lint` 0 issues (scoped + full-package on changed pkgs); `go generate ./...` no docs/coverage diff.