### PR TITLE
fix(azure-cosmosdb): real-user e2e divergence in Cosmos DB account consistency policy

### DIFF
--- a/server/azure/cosmosaccount/handler.go
+++ b/server/azure/cosmosaccount/handler.go
@@ -41,6 +41,14 @@ const (
 	providerName    = "Microsoft.DocumentDB"
 	resourceType    = "databaseAccounts"
 	defaultLocation = "eastus"
+
+	// Real Azure always returns a consistencyPolicy with these staleness bounds,
+	// regardless of the level: for every non-BoundedStaleness account they are
+	// the meaningless-but-present defaults (5 seconds / 100 operations), and a
+	// BoundedStaleness account overrides them. A client that reads the account
+	// back (armcosmos, azurerm) sees them populated on every account.
+	defaultMaxIntervalSeconds int32 = 5
+	defaultMaxStalenessPrefix int64 = 100
 )
 
 // attrBackend is the optional Cosmos-account attribute capability. The Azure
@@ -463,21 +471,33 @@ func renderAccount(subscription, base, name string, attrs dbdriver.AccountAttrib
 
 // renderConsistencyPolicy echoes the stored consistency policy, defaulting to
 // Cosmos's Session level when none was submitted (matching real Azure, which
-// always returns a consistencyPolicy). The staleness bounds are surfaced only
-// for BoundedStaleness, where they are meaningful.
+// always returns a consistencyPolicy). Real Azure also always returns the
+// staleness bounds — meaningful only for BoundedStaleness, but present on every
+// account as the 5s/100-op defaults — so they are surfaced unconditionally, each
+// falling back to its Azure default when the account carries none. Emitting them
+// for every level is what makes an armcosmos GET read back the same bounds real
+// Azure returns instead of a zero value.
 func renderConsistencyPolicy(cp dbdriver.ConsistencyPolicy) *armConsistencyPolicy {
 	level := cp.DefaultConsistencyLevel
 	if level == "" {
 		level = "Session"
 	}
 
-	out := &armConsistencyPolicy{DefaultConsistencyLevel: level}
-	if strings.EqualFold(level, "BoundedStaleness") {
-		out.MaxIntervalInSeconds = cp.MaxIntervalInSeconds
-		out.MaxStalenessPrefix = cp.MaxStalenessPrefix
+	interval := cp.MaxIntervalInSeconds
+	if interval == 0 {
+		interval = defaultMaxIntervalSeconds
 	}
 
-	return out
+	staleness := cp.MaxStalenessPrefix
+	if staleness == 0 {
+		staleness = defaultMaxStalenessPrefix
+	}
+
+	return &armConsistencyPolicy{
+		DefaultConsistencyLevel: level,
+		MaxIntervalInSeconds:    interval,
+		MaxStalenessPrefix:      staleness,
+	}
 }
 
 // toAccountLocations converts the ARM create-request locations into the

--- a/server/azure/cosmosaccount/sdk_test.go
+++ b/server/azure/cosmosaccount/sdk_test.go
@@ -329,6 +329,13 @@ func TestSDKDatabaseAccountConsistencyPolicy(t *testing.T) {
 	require.NotNil(t, def.Properties.ConsistencyPolicy)
 	require.NotNil(t, def.Properties.ConsistencyPolicy.DefaultConsistencyLevel)
 	assert.Equal(t, armcosmos.DefaultConsistencyLevelSession, *def.Properties.ConsistencyPolicy.DefaultConsistencyLevel)
+
+	// Real Azure always returns the staleness bounds on every account, defaulting
+	// to 5s / 100 ops for a non-BoundedStaleness level — not a null value.
+	require.NotNil(t, def.Properties.ConsistencyPolicy.MaxIntervalInSeconds)
+	assert.Equal(t, int32(5), *def.Properties.ConsistencyPolicy.MaxIntervalInSeconds)
+	require.NotNil(t, def.Properties.ConsistencyPolicy.MaxStalenessPrefix)
+	assert.Equal(t, int64(100), *def.Properties.ConsistencyPolicy.MaxStalenessPrefix)
 }
 
 func assertBoundedStaleness(t *testing.T, props *armcosmos.DatabaseAccountGetProperties) {


### PR DESCRIPTION
## Summary

Real-user e2e audit of Azure Cosmos DB (`Microsoft.DocumentDB/databaseAccounts`) against the live azure-sdk-for-go `armcosmos` client and the ARM wire.

Found one genuine real-cloud divergence: the account GET/create response emitted `consistencyPolicy.maxIntervalInSeconds` / `maxStalenessPrefix` **only for BoundedStaleness**. Real Azure always returns them on every account — for a non-BoundedStaleness level they are the meaningless-but-present defaults (5 seconds / 100 operations). An `armcosmos` GET on a Session account (the default, most-common case) therefore read back a null bound instead of `5`/`100`.

Verified against the official Microsoft REST reference (Database Accounts - Get), whose Session example returns `{defaultConsistencyLevel: Session, maxIntervalInSeconds: 5, maxStalenessPrefix: 100}`.

## Change

`renderConsistencyPolicy` now surfaces both bounds for every consistency level, each falling back to its Azure default (5 / 100) when the account stored none. A BoundedStaleness account still round-trips its explicit bounds.

## Evidence

- Live `cloudemu serve` (Azure HTTPS): PUT + GET a Session account and a no-consistency-policy account both read back `maxIntervalInSeconds: 5, maxStalenessPrefix: 100`; `provisioningState: Succeeded` (no LRO waiter hang), `documentEndpoint`/`offerType`/`kind` correct.
- Extended the existing `armcosmos` SDK round-trip test to assert the Session-default account reads back 5/100.
- Gates: `go build ./...`, `go test -race` (cosmosaccount, cosmosdb provider, full server/azure), `go vet`, `gofmt`, `golangci-lint` (0 issues), `go generate` (no docs/coverage change) — all green.

## Note

This is a correctness divergence a raw `armcosmos`/azure-sdk-for-go user hits. It does not cause `azurerm` Terraform drift, because `azurerm`'s `consistency_policy` staleness fields carry a DiffSuppressFunc that suppresses them for non-BoundedStaleness levels.