### PR TITLE
fix(eks): real-user e2e divergences from AWS EKS

### DIFF
--- a/providers/aws/eks/driver/driver.go
+++ b/providers/aws/eks/driver/driver.go
@@ -162,6 +162,18 @@ type Taint struct {
 	Effect string
 }
 
+// NodegroupUpdateConfig captures a managed node group's rolling-update
+// concurrency. Real EKS surfaces exactly one of MaxUnavailable (an absolute
+// node count) or MaxUnavailablePercentage; the two are mutually exclusive, and
+// a zero value on both means "unset". EKS defaults a created nodegroup to
+// MaxUnavailable=1 when the caller omits updateConfig entirely, so
+// DescribeNodegroup always reports a value and Terraform's update_config block
+// stops drifting.
+type NodegroupUpdateConfig struct {
+	MaxUnavailable           int
+	MaxUnavailablePercentage int
+}
+
 // NodegroupConfig configures a new managed node group.
 type NodegroupConfig struct {
 	ClusterName    string
@@ -175,6 +187,7 @@ type NodegroupConfig struct {
 	Version        string
 	ReleaseVersion string
 	ScalingConfig  NodegroupScalingConfig
+	UpdateConfig   NodegroupUpdateConfig
 	Labels         map[string]string
 	Taints         []Taint
 	Tags           map[string]string
@@ -194,6 +207,7 @@ type Nodegroup struct {
 	Version        string
 	ReleaseVersion string
 	ScalingConfig  NodegroupScalingConfig
+	UpdateConfig   NodegroupUpdateConfig
 	Status         string
 	Labels         map[string]string
 	Taints         []Taint
@@ -210,6 +224,7 @@ type Nodegroup struct {
 // add/update and remove deltas, matching the real EKS request shape.
 type NodegroupConfigUpdate struct {
 	Scaling           *NodegroupScalingConfig
+	UpdateConfig      *NodegroupUpdateConfig
 	AddOrUpdateLabels map[string]string
 	RemoveLabels      []string
 	AddOrUpdateTaints []Taint

--- a/providers/aws/eks/eks.go
+++ b/providers/aws/eks/eks.go
@@ -43,6 +43,10 @@ const (
 	defaultNodegroupInstanceType = "t3.medium"
 	defaultNodegroupAmiType      = "AL2_x86_64"
 	defaultNodegroupDiskSize     = 20
+	// EKS defaults a managed nodegroup's rolling-update concurrency to
+	// maxUnavailable=1 when the caller omits updateConfig, so DescribeNodegroup
+	// always reports one and Terraform's update_config block does not drift.
+	defaultNodegroupMaxUnavailable = 1
 
 	// Cluster networking and access-config defaults real EKS applies when the
 	// caller omits them. authenticationMode defaults to CONFIG_MAP on the
@@ -447,6 +451,58 @@ func validateScaling(s eksdriver.NodegroupScalingConfig) error {
 	}
 
 	return nil
+}
+
+// validateUpdateConfig rejects a nodegroup updateConfig that sets both
+// maxUnavailable and maxUnavailablePercentage, matching real EKS
+// (InvalidParameterException): the two knobs are mutually exclusive. Negative
+// values are also rejected. An all-zero config (updateConfig omitted) is valid
+// and left to the create-time default.
+func validateUpdateConfig(u eksdriver.NodegroupUpdateConfig) error {
+	if u.MaxUnavailable < 0 || u.MaxUnavailablePercentage < 0 {
+		return cerrors.New(cerrors.InvalidArgument,
+			"updateConfig maxUnavailable and maxUnavailablePercentage must not be negative")
+	}
+
+	if u.MaxUnavailable > 0 && u.MaxUnavailablePercentage > 0 {
+		return cerrors.New(cerrors.InvalidArgument,
+			"updateConfig may set only one of maxUnavailable or maxUnavailablePercentage")
+	}
+
+	return nil
+}
+
+// resolveUpdateConfig applies the EKS default (maxUnavailable=1) when the caller
+// supplies no updateConfig, so a created nodegroup always reports one.
+func resolveUpdateConfig(u eksdriver.NodegroupUpdateConfig) eksdriver.NodegroupUpdateConfig {
+	if u.MaxUnavailable == 0 && u.MaxUnavailablePercentage == 0 {
+		return eksdriver.NodegroupUpdateConfig{MaxUnavailable: defaultNodegroupMaxUnavailable}
+	}
+
+	return u
+}
+
+// nodegroupDefaults resolves the managed-nodegroup fields real EKS fills in when
+// the caller omits them: instance types (t3.medium), AMI type (AL2_x86_64), and
+// disk size (20 GiB). Extracted from CreateNodegroup to keep that path within
+// the cyclomatic-complexity budget.
+func nodegroupDefaults(cfg *eksdriver.NodegroupConfig) (instanceTypes []string, amiType string, diskSize int) {
+	instanceTypes = copyStrings(cfg.InstanceTypes)
+	if len(instanceTypes) == 0 {
+		instanceTypes = []string{defaultNodegroupInstanceType}
+	}
+
+	amiType = cfg.AmiType
+	if amiType == "" {
+		amiType = defaultNodegroupAmiType
+	}
+
+	diskSize = cfg.DiskSize
+	if diskSize == 0 {
+		diskSize = defaultNodegroupDiskSize
+	}
+
+	return instanceTypes, amiType, diskSize
 }
 
 func (m *Mock) emitClusterMetrics(name string) {
@@ -860,22 +916,13 @@ func (m *Mock) CreateNodegroup(_ context.Context, cfg eksdriver.NodegroupConfig)
 		return nil, err
 	}
 
+	if err := validateUpdateConfig(cfg.UpdateConfig); err != nil {
+		return nil, err
+	}
+
 	now := m.opts.Clock.Now().UTC()
 
-	instanceTypes := copyStrings(cfg.InstanceTypes)
-	if len(instanceTypes) == 0 {
-		instanceTypes = []string{defaultNodegroupInstanceType}
-	}
-
-	amiType := cfg.AmiType
-	if amiType == "" {
-		amiType = defaultNodegroupAmiType
-	}
-
-	diskSize := cfg.DiskSize
-	if diskSize == 0 {
-		diskSize = defaultNodegroupDiskSize
-	}
+	instanceTypes, amiType, diskSize := nodegroupDefaults(&cfg)
 
 	ng := eksdriver.Nodegroup{
 		ClusterName:    cfg.ClusterName,
@@ -890,6 +937,7 @@ func (m *Mock) CreateNodegroup(_ context.Context, cfg eksdriver.NodegroupConfig)
 		Version:        cfg.Version,
 		ReleaseVersion: cfg.ReleaseVersion,
 		ScalingConfig:  cfg.ScalingConfig,
+		UpdateConfig:   resolveUpdateConfig(cfg.UpdateConfig),
 		Status:         eksdriver.NodegroupStatusActive,
 		Labels:         copyTags(cfg.Labels),
 		Taints:         copyTaints(cfg.Taints),
@@ -983,6 +1031,14 @@ func (m *Mock) UpdateNodegroupConfig(
 		}
 
 		ng.ScalingConfig = *upd.Scaling
+	}
+
+	if upd.UpdateConfig != nil {
+		if err := validateUpdateConfig(*upd.UpdateConfig); err != nil {
+			return nil, err
+		}
+
+		ng.UpdateConfig = *upd.UpdateConfig
 	}
 
 	ng.Labels = mergeLabels(ng.Labels, upd.AddOrUpdateLabels, upd.RemoveLabels)

--- a/providers/aws/eks/nodegroup_update_config_test.go
+++ b/providers/aws/eks/nodegroup_update_config_test.go
@@ -1,0 +1,116 @@
+package eks
+
+import (
+	"context"
+	"testing"
+
+	eksdriver "github.com/stackshy/cloudemu/v2/providers/aws/eks/driver"
+)
+
+// mustCluster creates an ACTIVE cluster the nodegroup tests can attach to.
+func mustCluster(t *testing.T, m *Mock, name string) {
+	t.Helper()
+
+	if _, err := m.CreateCluster(context.Background(), eksdriver.ClusterConfig{
+		Name:    name,
+		RoleArn: "arn:aws:iam::123456789012:role/eks-cluster",
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+}
+
+// TestCreateNodegroupUpdateConfigDefault verifies a nodegroup created without an
+// updateConfig reports maxUnavailable=1 — the real EKS default — so Terraform's
+// update_config block does not drift after create.
+func TestCreateNodegroupUpdateConfigDefault(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "c1")
+
+	created, err := m.CreateNodegroup(ctx, eksdriver.NodegroupConfig{ClusterName: "c1", NodegroupName: "ng1"})
+	requireNoError(t, err)
+	assertEqual(t, 1, created.UpdateConfig.MaxUnavailable)
+	assertEqual(t, 0, created.UpdateConfig.MaxUnavailablePercentage)
+
+	got, err := m.DescribeNodegroup(ctx, "c1", "ng1")
+	requireNoError(t, err)
+	assertEqual(t, 1, got.UpdateConfig.MaxUnavailable)
+}
+
+// TestCreateNodegroupUpdateConfigExplicit verifies an explicit updateConfig
+// round-trips, and that the percentage variant leaves maxUnavailable unset.
+func TestCreateNodegroupUpdateConfigExplicit(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "c1")
+
+	_, err := m.CreateNodegroup(ctx, eksdriver.NodegroupConfig{
+		ClusterName:   "c1",
+		NodegroupName: "count",
+		UpdateConfig:  eksdriver.NodegroupUpdateConfig{MaxUnavailable: 3},
+	})
+	requireNoError(t, err)
+
+	got, err := m.DescribeNodegroup(ctx, "c1", "count")
+	requireNoError(t, err)
+	assertEqual(t, 3, got.UpdateConfig.MaxUnavailable)
+	assertEqual(t, 0, got.UpdateConfig.MaxUnavailablePercentage)
+
+	_, err = m.CreateNodegroup(ctx, eksdriver.NodegroupConfig{
+		ClusterName:   "c1",
+		NodegroupName: "pct",
+		UpdateConfig:  eksdriver.NodegroupUpdateConfig{MaxUnavailablePercentage: 25},
+	})
+	requireNoError(t, err)
+
+	pct, err := m.DescribeNodegroup(ctx, "c1", "pct")
+	requireNoError(t, err)
+	assertEqual(t, 0, pct.UpdateConfig.MaxUnavailable)
+	assertEqual(t, 25, pct.UpdateConfig.MaxUnavailablePercentage)
+}
+
+// TestCreateNodegroupUpdateConfigMutualExclusion verifies setting both knobs is
+// rejected, matching real EKS (InvalidParameterException).
+func TestCreateNodegroupUpdateConfigMutualExclusion(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "c1")
+
+	_, err := m.CreateNodegroup(ctx, eksdriver.NodegroupConfig{
+		ClusterName:   "c1",
+		NodegroupName: "bad",
+		UpdateConfig:  eksdriver.NodegroupUpdateConfig{MaxUnavailable: 1, MaxUnavailablePercentage: 50},
+	})
+	assertError(t, err, true)
+}
+
+// TestUpdateNodegroupConfigUpdateConfig verifies UpdateNodegroupConfig applies a
+// new updateConfig and leaves it in place when the request omits it.
+func TestUpdateNodegroupConfigUpdateConfig(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "c1")
+
+	_, err := m.CreateNodegroup(ctx, eksdriver.NodegroupConfig{ClusterName: "c1", NodegroupName: "ng1"})
+	requireNoError(t, err)
+
+	uc := eksdriver.NodegroupUpdateConfig{MaxUnavailable: 4}
+	if _, err = m.UpdateNodegroupConfig(ctx, "c1", "ng1",
+		eksdriver.NodegroupConfigUpdate{UpdateConfig: &uc}); err != nil {
+		t.Fatalf("UpdateNodegroupConfig: %v", err)
+	}
+
+	got, err := m.DescribeNodegroup(ctx, "c1", "ng1")
+	requireNoError(t, err)
+	assertEqual(t, 4, got.UpdateConfig.MaxUnavailable)
+
+	// A later config update that omits updateConfig must leave it untouched.
+	if _, err = m.UpdateNodegroupConfig(ctx, "c1", "ng1",
+		eksdriver.NodegroupConfigUpdate{AddOrUpdateLabels: map[string]string{"k": "v"}}); err != nil {
+		t.Fatalf("UpdateNodegroupConfig (labels): %v", err)
+	}
+
+	got, err = m.DescribeNodegroup(ctx, "c1", "ng1")
+	requireNoError(t, err)
+	assertEqual(t, 4, got.UpdateConfig.MaxUnavailable)
+}

--- a/server/aws/eks/operations.go
+++ b/server/aws/eks/operations.go
@@ -40,7 +40,15 @@ func paginateNames(
 		return nil, "", false
 	}
 
-	return page.Items, page.NextPageToken, true
+	// Real EKS list operations serialize an empty result as [] (a JSON array),
+	// never null. The shared paginator returns a nil slice for an empty page, so
+	// normalize it here to keep the wire shape faithful for strict consumers.
+	items = page.Items
+	if items == nil {
+		items = []string{}
+	}
+
+	return items, page.NextPageToken, true
 }
 
 // safeInt32 narrows an int to int32, clamping at math.MaxInt32 / math.MinInt32.
@@ -236,6 +244,10 @@ func (h *Handler) createNodegroup(w http.ResponseWriter, r *http.Request, cluste
 		cfg.ScalingConfig = scalingFromJSON(body.ScalingConfig)
 	}
 
+	if body.UpdateConfig != nil {
+		cfg.UpdateConfig = updateConfigFromJSON(body.UpdateConfig)
+	}
+
 	ng, err := h.eks.CreateNodegroup(r.Context(), cfg)
 	if err != nil {
 		writeErr(w, err)
@@ -295,6 +307,11 @@ func (h *Handler) updateNodegroupConfig(w http.ResponseWriter, r *http.Request, 
 		merged := cur.ScalingConfig
 		mergeScaling(&merged, body.ScalingConfig)
 		update.Scaling = &merged
+	}
+
+	if body.UpdateConfig != nil {
+		uc := updateConfigFromJSON(body.UpdateConfig)
+		update.UpdateConfig = &uc
 	}
 
 	if body.Labels != nil {
@@ -600,6 +617,43 @@ func taintsToJSON(in []eksdriver.Taint) []taintJSON {
 	return out
 }
 
+// updateConfigFromJSON converts the wire updateConfig to the driver shape. A
+// nil field is treated as unset (0); the two knobs are mutually exclusive on
+// the wire, and the provider validates that.
+func updateConfigFromJSON(u *nodegroupUpdateConfigJSON) eksdriver.NodegroupUpdateConfig {
+	out := eksdriver.NodegroupUpdateConfig{}
+
+	if u.MaxUnavailable != nil {
+		out.MaxUnavailable = int(*u.MaxUnavailable)
+	}
+
+	if u.MaxUnavailablePercentage != nil {
+		out.MaxUnavailablePercentage = int(*u.MaxUnavailablePercentage)
+	}
+
+	return out
+}
+
+// updateConfigToJSON renders the driver updateConfig to the wire response shape,
+// surfacing exactly one of maxUnavailable / maxUnavailablePercentage (the count
+// takes precedence, matching how real EKS reports a nodegroup created with the
+// maxUnavailable=1 default). Returns nil when neither is set so the field is
+// omitted.
+func updateConfigToJSON(u eksdriver.NodegroupUpdateConfig) *nodegroupUpdateConfigJSON {
+	switch {
+	case u.MaxUnavailable > 0:
+		v := safeInt32(u.MaxUnavailable)
+
+		return &nodegroupUpdateConfigJSON{MaxUnavailable: &v}
+	case u.MaxUnavailablePercentage > 0:
+		v := safeInt32(u.MaxUnavailablePercentage)
+
+		return &nodegroupUpdateConfigJSON{MaxUnavailablePercentage: &v}
+	default:
+		return nil
+	}
+}
+
 func scalingFromJSON(s *nodegroupScalingConfigJSON) eksdriver.NodegroupScalingConfig {
 	out := eksdriver.NodegroupScalingConfig{}
 
@@ -717,6 +771,7 @@ func toNodegroupJSON(n *eksdriver.Nodegroup) nodegroupJSON {
 			MaxSize:     &maxSize,
 			DesiredSize: &desired,
 		},
+		UpdateConfig:  updateConfigToJSON(n.UpdateConfig),
 		InstanceTypes: n.InstanceTypes,
 		Subnets:       n.Subnets,
 		AmiType:       n.AmiType,

--- a/server/aws/eks/sdk_nodegroup_update_config_test.go
+++ b/server/aws/eks/sdk_nodegroup_update_config_test.go
@@ -1,0 +1,80 @@
+package eks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+)
+
+// TestSDKEKSNodegroupUpdateConfig verifies a nodegroup's updateConfig round-trips
+// through the real SDK: a default create reports maxUnavailable=1, an explicit
+// value is echoed, and UpdateNodegroupConfig applies a new one. Terraform's
+// aws_eks_node_group update_config block otherwise drifts on every plan because
+// DescribeNodegroup omits the field.
+func TestSDKEKSNodegroupUpdateConfig(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awseks.CreateClusterInput{
+		Name:               aws.String("c1"),
+		RoleArn:            aws.String("arn:aws:iam::123456789012:role/eks-cluster"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{SubnetIds: []string{"subnet-1"}},
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	// Default: no updateConfig in the request -> maxUnavailable=1 on describe.
+	def, err := client.CreateNodegroup(ctx, &awseks.CreateNodegroupInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("def"),
+		NodeRole:      aws.String("arn:aws:iam::123456789012:role/eks-node"),
+		Subnets:       []string{"subnet-1"},
+	})
+	if err != nil {
+		t.Fatalf("CreateNodegroup(default): %v", err)
+	}
+
+	if def.Nodegroup.UpdateConfig == nil || aws.ToInt32(def.Nodegroup.UpdateConfig.MaxUnavailable) != 1 {
+		t.Fatalf("default updateConfig = %+v, want maxUnavailable=1", def.Nodegroup.UpdateConfig)
+	}
+
+	// Explicit maxUnavailable echoes back.
+	exp, err := client.CreateNodegroup(ctx, &awseks.CreateNodegroupInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("exp"),
+		NodeRole:      aws.String("arn:aws:iam::123456789012:role/eks-node"),
+		Subnets:       []string{"subnet-1"},
+		UpdateConfig:  &ekstypes.NodegroupUpdateConfig{MaxUnavailable: aws.Int32(2)},
+	})
+	if err != nil {
+		t.Fatalf("CreateNodegroup(explicit): %v", err)
+	}
+
+	if aws.ToInt32(exp.Nodegroup.UpdateConfig.MaxUnavailable) != 2 {
+		t.Fatalf("explicit updateConfig = %+v, want maxUnavailable=2", exp.Nodegroup.UpdateConfig)
+	}
+
+	// UpdateNodegroupConfig applies a new value that describe reflects.
+	if _, err = client.UpdateNodegroupConfig(ctx, &awseks.UpdateNodegroupConfigInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("exp"),
+		UpdateConfig:  &ekstypes.NodegroupUpdateConfig{MaxUnavailable: aws.Int32(5)},
+	}); err != nil {
+		t.Fatalf("UpdateNodegroupConfig: %v", err)
+	}
+
+	got, err := client.DescribeNodegroup(ctx, &awseks.DescribeNodegroupInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("exp"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeNodegroup: %v", err)
+	}
+
+	if aws.ToInt32(got.Nodegroup.UpdateConfig.MaxUnavailable) != 5 {
+		t.Fatalf("post-update updateConfig = %+v, want maxUnavailable=5", got.Nodegroup.UpdateConfig)
+	}
+}

--- a/server/aws/eks/types.go
+++ b/server/aws/eks/types.go
@@ -110,6 +110,15 @@ type nodegroupScalingConfigJSON struct {
 	DesiredSize *int32 `json:"desiredSize,omitempty"`
 }
 
+// nodegroupUpdateConfigJSON mirrors the SDK NodegroupUpdateConfig shape: the
+// rolling-update concurrency, expressed as exactly one of an absolute node
+// count or a percentage. Used on CreateNodegroup, DescribeNodegroup, and
+// UpdateNodegroupConfig.
+type nodegroupUpdateConfigJSON struct {
+	MaxUnavailable           *int32 `json:"maxUnavailable,omitempty"`
+	MaxUnavailablePercentage *int32 `json:"maxUnavailablePercentage,omitempty"`
+}
+
 // taintJSON mirrors the SDK Taint shape (key, value, effect) used on
 // CreateNodegroup, DescribeNodegroup, and UpdateNodegroupConfig.
 type taintJSON struct {
@@ -130,6 +139,7 @@ type nodegroupJSON struct {
 	Status         string                      `json:"status"`
 	CapacityType   string                      `json:"capacityType,omitempty"`
 	ScalingConfig  *nodegroupScalingConfigJSON `json:"scalingConfig,omitempty"`
+	UpdateConfig   *nodegroupUpdateConfigJSON  `json:"updateConfig,omitempty"`
 	InstanceTypes  []string                    `json:"instanceTypes,omitempty"`
 	Subnets        []string                    `json:"subnets,omitempty"`
 	AmiType        string                      `json:"amiType,omitempty"`
@@ -241,6 +251,7 @@ type createNodegroupRequest struct {
 	Version        string                      `json:"version,omitempty"`
 	ReleaseVersion string                      `json:"releaseVersion,omitempty"`
 	ScalingConfig  *nodegroupScalingConfigJSON `json:"scalingConfig,omitempty"`
+	UpdateConfig   *nodegroupUpdateConfigJSON  `json:"updateConfig,omitempty"`
 	Labels         map[string]string           `json:"labels,omitempty"`
 	Taints         []taintJSON                 `json:"taints,omitempty"`
 	Tags           map[string]string           `json:"tags,omitempty"`
@@ -248,6 +259,7 @@ type createNodegroupRequest struct {
 
 type updateNodegroupConfigRequest struct {
 	ScalingConfig *nodegroupScalingConfigJSON `json:"scalingConfig,omitempty"`
+	UpdateConfig  *nodegroupUpdateConfigJSON  `json:"updateConfig,omitempty"`
 	Labels        *labelsUpdate               `json:"labels,omitempty"`
 	Taints        *taintsUpdate               `json:"taints,omitempty"`
 }


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of AWS EKS (aws_eks_cluster + aws_eks_node_group + aws_eks_addon) against the real cloud, exercised with the real aws-sdk-go-v2 client, aws-cli, and Terraform pointed at `cloudemu serve`. Two genuine cloud-vs-cloudemu divergences found and fixed.

### 1. Nodegroup `updateConfig` was unmodeled (HIGH — perpetual Terraform drift)
`DescribeNodegroup` never returned an `updateConfig` field. Real EKS always reports one, defaulting a created nodegroup to `maxUnavailable: 1`. As a result any `aws_eks_node_group` with an `update_config {}` block (or none — the field is Optional+Computed) drifted on **every** `terraform plan` ("0 to add, 1 to change").

Fix models `NodegroupUpdateConfig` (`maxUnavailable` / `maxUnavailablePercentage`) end-to-end — driver, provider, and REST/JSON wire:
- Defaults a created nodegroup to `maxUnavailable=1` when the caller omits `updateConfig`.
- Round-trips it on Create / Describe / UpdateNodegroupConfig.
- Rejects setting both knobs at once (`InvalidParameterException`), matching real EKS.

### 2. List operations serialized empty results as `null` instead of `[]` (LOW — fidelity)
`ListClusters` / `ListNodegroups` / `ListFargateProfiles` / `ListAddons` / `ListUpdates` returned `{"clusters": null}` for an empty result; real EKS returns `[]`. Normalized in the shared EKS `paginateNames` helper (the shared paginator returns a nil slice for an empty page).

## Verification
- Terraform apply of a rich config (cluster + nodegroup with `update_config`/`taints`/`capacity_type`/`disk_size`/tags + addon): both resources reach ACTIVE with no hang; `terraform plan` after apply reports **no drift** (previously drifted on `update_config`).
- Terraform update of `max_unavailable` (1→2) applies and re-plans clean; destroy is clean.
- Real aws-sdk-go-v2 + aws-cli round-trips for cluster/nodegroup, error-code fidelity (ResourceNotFoundException / ResourceInUseException), and the new updateConfig path.
- Gates: `go build ./...`, `go test -race` (providers/aws/eks + server/aws/eks), root `go test`, `go vet`, `gofmt`, `golangci-lint` (new-from-rev clean), `go generate` (no docs/coverage change) — all green.