### PR TITLE
fix(azure-aks): real-user e2e divergence from Azure AKS (FQDN format)

### DIFF
--- a/providers/azure/aks/aks.go
+++ b/providers/azure/aks/aks.go
@@ -12,6 +12,7 @@ package aks
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"sort"
 	"strings"
 	"sync"
@@ -514,7 +515,19 @@ func resolveClusterFields(cluster *ManagedCluster, input ClusterInput, existing 
 
 	resolveClusterIdentity(cluster, input, existing)
 
-	cluster.FQDN = cluster.DNSPrefix + ".hcp." + defaultIfEmpty(cluster.Location, "eastus") + ".azmk8s.io"
+	cluster.FQDN = clusterFQDN(cluster.DNSPrefix, cluster.ResourceGroup, cluster.Name, cluster.Location)
+}
+
+// clusterFQDN builds the public API-server FQDN the real AKS service assigns a
+// managed cluster: "<dnsPrefix>-<hash>.hcp.<region>.azmk8s.io". Real AKS
+// generates the 8-hex host segment randomly at creation; the emulator derives
+// it deterministically from the cluster identity so it is stable across reads
+// and updates while matching the real format a caller parsing the FQDN expects.
+func clusterFQDN(dnsPrefix, rg, name, location string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(rg + "/" + name))
+
+	return fmt.Sprintf("%s-%08x.hcp.%s.azmk8s.io", dnsPrefix, h.Sum32(), defaultIfEmpty(location, "eastus"))
 }
 
 // mergeStr resolves a string field: the submitted value wins when non-empty;

--- a/providers/azure/aks/aks_test.go
+++ b/providers/azure/aks/aks_test.go
@@ -41,6 +41,11 @@ func TestClusterLifecycle(t *testing.T) {
 	assertEqual(t, "Succeeded", cluster.ProvisioningState)
 	assertEqual(t, "Running", cluster.PowerState)
 	assertNotEmpty(t, cluster.FQDN)
+	// Real AKS FQDN shape: <dnsPrefix>-<8hexhash>.hcp.<region>.azmk8s.io.
+	if !strings.HasPrefix(cluster.FQDN, "k8s-prod-dns-") ||
+		!strings.HasSuffix(cluster.FQDN, ".hcp.eastus.azmk8s.io") {
+		t.Fatalf("unexpected FQDN shape: %q", cluster.FQDN)
+	}
 	assertEqual(t, 1, len(cluster.AgentPoolNames))
 
 	got, err := m.GetCluster(ctx, "rg-1", "k8s-prod")
@@ -461,4 +466,58 @@ func assertNotEmpty(t *testing.T, s string) {
 
 func int32Ptr(v int32) *int32 {
 	return &v
+}
+
+// TestClusterFQDNFormat verifies the FQDN carries the real AKS
+// "<dnsPrefix>-<8hexhash>.hcp.<region>.azmk8s.io" host segment and that the hash
+// is a stable 8-hex string that does not change across an in-place update.
+func TestClusterFQDNFormat(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	c, err := m.CreateOrUpdateCluster(ctx, ClusterInput{
+		Subscription:  "sub-1",
+		ResourceGroup: "rg-1",
+		Name:          "k8s-1",
+		Location:      "westus2",
+		DNSPrefix:     "myprefix",
+	})
+	requireNoError(t, err)
+
+	const wantSuffix = ".hcp.westus2.azmk8s.io"
+	if !strings.HasSuffix(c.FQDN, wantSuffix) {
+		t.Fatalf("FQDN suffix: got %q, want ...%s", c.FQDN, wantSuffix)
+	}
+
+	host := strings.TrimSuffix(c.FQDN, wantSuffix)
+
+	prefixAndHash := strings.TrimPrefix(host, "myprefix-")
+	if prefixAndHash == host {
+		t.Fatalf("FQDN missing dnsPrefix-hash segment: %q", c.FQDN)
+	}
+
+	if len(prefixAndHash) != 8 {
+		t.Fatalf("FQDN hash segment length: got %d (%q), want 8", len(prefixAndHash), prefixAndHash)
+	}
+
+	for _, r := range prefixAndHash {
+		if !strings.ContainsRune("0123456789abcdef", r) {
+			t.Fatalf("FQDN hash segment not lowercase hex: %q", prefixAndHash)
+		}
+	}
+
+	// An in-place update (e.g. a tag change) must not renumber the FQDN.
+	updated, err := m.CreateOrUpdateCluster(ctx, ClusterInput{
+		Subscription:  "sub-1",
+		ResourceGroup: "rg-1",
+		Name:          "k8s-1",
+		Location:      "westus2",
+		DNSPrefix:     "myprefix",
+		Tags:          map[string]string{"env": "prod"},
+	})
+	requireNoError(t, err)
+
+	if updated.FQDN != c.FQDN {
+		t.Fatalf("FQDN changed across update: %q -> %q", c.FQDN, updated.FQDN)
+	}
 }


### PR DESCRIPTION
## Summary

Real-user e2e audit of Azure AKS (`Microsoft.ContainerService/managedClusters`) driven through the real `armcontainerservice/v6` SDK and covering the `azurerm_kubernetes_cluster` control-plane surface.

The surface is otherwise at real-cloud parity — LRO create settles to `provisioningState=Succeeded` (no waiter hang), `nodeResourceGroup` uses the `MC_<rg>_<name>_<region>` format, `networkProfile` defaults/round-trip, identity, `enableRBAC` (*bool), inline+standalone `agentPoolProfiles` round-trip (mode/type/osType/scale-to-zero/upgradeSettings/tags/FIPS), `sku` Base/Free, tags PATCH-as-replace, `ResourceNotFound` 404 envelope, deterministic list order, and `listClusterAdminCredentials` kubeconfig were all verified correct against the SDK.

One genuine divergence was found and fixed.

### Fixed

- **Cluster FQDN format.** The emulator returned `<dnsPrefix>.hcp.<region>.azmk8s.io`, dropping the host-hash segment real AKS always includes. GET now returns the real `<dnsPrefix>-<hash>.hcp.<region>.azmk8s.io` shape. The 8-hex host segment is derived deterministically from the cluster identity so it is stable across reads and in-place updates (real AKS assigns it randomly at creation but never changes it thereafter). A caller that parses or pattern-validates the FQDN now sees the real format.

### Tests

- Strengthened the FQDN assertion in the cluster-lifecycle test to check the real prefix/suffix shape.
- Added `TestClusterFQDNFormat`: asserts the `-<8hexhash>` host segment (lowercase hex, length 8) and that the FQDN is stable across an in-place update.