### PR TITLE
fix(dynamodb): real-user e2e divergences from AWS DynamoDB

### DIFF
--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -1745,6 +1745,86 @@ func (m *Mock) DeleteIndex(_ context.Context, table, indexName string) error {
 	return cerrors.Newf(cerrors.NotFound, "index %s not found", indexName)
 }
 
+// SyncAttributeDefinitions reconciles a table's attribute definitions after an
+// UpdateTable that adds or removes secondary indexes. It merges the request's
+// AttributeDefinitions (which carry the type of any newly indexed attribute)
+// and then prunes the set to exactly those the table key or a surviving index
+// still references. Real DynamoDB keeps AttributeDefinitions equal to the
+// attributes used by the table plus its indexes: adding a GSI grows the set,
+// deleting one shrinks it. Without this an added GSI's key attribute never
+// appears in DescribeTable and an IaC client sees a perpetual diff.
+func (m *Mock) SyncAttributeDefinitions(_ context.Context, table string, defs []driver.AttributeDef) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	types := make(map[string]string, len(td.config.Attributes)+len(defs))
+	for _, a := range td.config.Attributes {
+		types[a.Name] = a.Type
+	}
+
+	for _, a := range defs {
+		types[a.Name] = a.Type
+	}
+
+	referenced := referencedAttributes(&td.config)
+	merged := make([]driver.AttributeDef, 0, len(referenced))
+
+	appendAttr := func(name string) {
+		if _, want := referenced[name]; !want {
+			return
+		}
+
+		merged = append(merged, driver.AttributeDef{Name: name, Type: types[name]})
+		delete(referenced, name)
+	}
+
+	for _, a := range td.config.Attributes {
+		appendAttr(a.Name)
+	}
+
+	for _, a := range defs {
+		appendAttr(a.Name)
+	}
+
+	td.config.Attributes = merged
+
+	return nil
+}
+
+// referencedAttributes returns the set of attribute names the table key schema
+// and every current secondary index key schema reference — the attributes a
+// real table's AttributeDefinitions must contain, no more and no less.
+func referencedAttributes(cfg *driver.TableConfig) map[string]struct{} {
+	ref := make(map[string]struct{})
+
+	for _, name := range []string{cfg.PartitionKey, cfg.SortKey} {
+		if name != "" {
+			ref[name] = struct{}{}
+		}
+	}
+
+	for _, g := range cfg.GSIs {
+		for _, name := range []string{g.PartitionKey, g.SortKey} {
+			if name != "" {
+				ref[name] = struct{}{}
+			}
+		}
+	}
+
+	for _, l := range cfg.LSIs {
+		if l.SortKey != "" {
+			ref[l.SortKey] = struct{}{}
+		}
+	}
+
+	return ref
+}
+
 // DescribeIndex returns information about a Global Secondary Index.
 func (m *Mock) DescribeIndex(_ context.Context, table, indexName string) (*driver.IndexInfo, error) {
 	m.mu.RLock()

--- a/server/aws/dynamodb/update_table.go
+++ b/server/aws/dynamodb/update_table.go
@@ -24,6 +24,13 @@ type pitrController interface {
 	GetPITR(ctx context.Context, table string) (bool, error)
 }
 
+// attributeDefinitionSyncer is the optional provider capability UpdateTable uses
+// to reconcile a table's attribute definitions after a GSI add/delete. Only the
+// AWS mock implements it, so it stays off the cross-cloud Database interface.
+type attributeDefinitionSyncer interface {
+	SyncAttributeDefinitions(ctx context.Context, table string, defs []dbdriver.AttributeDef) error
+}
+
 // tableSettingsUpdater is the optional provider capability UpdateTable needs to
 // change a table's metadata settings (table class, deletion protection).
 // Discovered by type assertion so it stays off the cross-cloud Database
@@ -73,7 +80,8 @@ func (h *Handler) updateTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.applyGSIUpdates(r.Context(), req.TableName, req.GlobalSecondaryIndexUpdates); err != nil {
+	if err := h.applyIndexUpdates(
+		r.Context(), req.TableName, req.GlobalSecondaryIndexUpdates, req.AttributeDefinitions); err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -100,6 +108,19 @@ func (h *Handler) updateTable(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, map[string]any{"TableDescription": h.describeTableShape(full)})
 }
 
+// applyIndexUpdates applies an UpdateTable's GSI create/delete entries and then
+// reconciles the table's attribute definitions to match the resulting index set,
+// as a single step so the caller has one error path to handle.
+func (h *Handler) applyIndexUpdates(
+	ctx context.Context, table string, updates []gsiUpdateJSON, defs []attrDefJSON,
+) error {
+	if err := h.applyGSIUpdates(ctx, table, updates); err != nil {
+		return err
+	}
+
+	return h.syncAttributeDefinitions(ctx, table, updates, defs)
+}
+
 // applyGSIUpdates applies every GlobalSecondaryIndexUpdates entry (each a GSI
 // create or delete) on an UpdateTable request, stopping at the first failure.
 func (h *Handler) applyGSIUpdates(ctx context.Context, table string, updates []gsiUpdateJSON) error {
@@ -110,6 +131,31 @@ func (h *Handler) applyGSIUpdates(ctx context.Context, table string, updates []g
 	}
 
 	return nil
+}
+
+// syncAttributeDefinitions reconciles the table's attribute definitions after
+// GSI create/delete updates so DescribeTable surfaces exactly the attributes the
+// table key and its surviving indexes reference — matching real DynamoDB. It is
+// a no-op when the request touches neither indexes nor attribute definitions, or
+// when the provider does not expose the capability.
+func (h *Handler) syncAttributeDefinitions(
+	ctx context.Context, table string, updates []gsiUpdateJSON, defs []attrDefJSON,
+) error {
+	if len(updates) == 0 && len(defs) == 0 {
+		return nil
+	}
+
+	syncer, ok := h.db.(attributeDefinitionSyncer)
+	if !ok {
+		return nil
+	}
+
+	converted := make([]dbdriver.AttributeDef, 0, len(defs))
+	for _, d := range defs {
+		converted = append(converted, dbdriver.AttributeDef{Name: d.AttributeName, Type: d.AttributeType})
+	}
+
+	return syncer.SyncAttributeDefinitions(ctx, table, converted)
 }
 
 func indexDeleteName(del *struct {

--- a/server/aws/dynamodb/update_table_attribute_defs_sdk_test.go
+++ b/server/aws/dynamodb/update_table_attribute_defs_sdk_test.go
@@ -1,0 +1,121 @@
+// update_table_attribute_defs_sdk_test.go — real aws-sdk-go-v2 coverage of the
+// attribute-definition reconciliation an UpdateTable must perform when it adds
+// or removes a GSI. Real DynamoDB keeps AttributeDefinitions equal to exactly
+// the attributes the table key and its surviving indexes reference: adding a GSI
+// grows the set with the new index's key attribute, deleting one prunes any
+// attribute no remaining index uses. Without it DescribeTable omits a newly
+// indexed attribute (or keeps a stale one) and an IaC client sees a perpetual
+// diff.
+package dynamodb_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func attrNames(defs []ddbtypes.AttributeDefinition) []string {
+	names := make([]string, 0, len(defs))
+	for _, d := range defs {
+		names = append(names, aws.ToString(d.AttributeName))
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+func TestUpdateTableAddGSIMergesAttributeDefinitions(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:   aws.String("orders"),
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("OrderId"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("OrderId"), KeyType: ddbtypes.KeyTypeHash},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = client.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+		TableName: aws.String("orders"),
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("CustomerId"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		GlobalSecondaryIndexUpdates: []ddbtypes.GlobalSecondaryIndexUpdate{
+			{Create: &ddbtypes.CreateGlobalSecondaryIndexAction{
+				IndexName: aws.String("CustomerIndex"),
+				KeySchema: []ddbtypes.KeySchemaElement{
+					{AttributeName: aws.String("CustomerId"), KeyType: ddbtypes.KeyTypeHash},
+				},
+				Projection: &ddbtypes.Projection{ProjectionType: ddbtypes.ProjectionTypeAll},
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	desc, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("orders")})
+	require.NoError(t, err)
+	// The newly indexed attribute must now be part of AttributeDefinitions, with
+	// its declared type preserved.
+	assert.Equal(t, []string{"CustomerId", "OrderId"}, attrNames(desc.Table.AttributeDefinitions))
+
+	for _, d := range desc.Table.AttributeDefinitions {
+		assert.Equal(t, ddbtypes.ScalarAttributeTypeS, d.AttributeType,
+			"attribute %s type", aws.ToString(d.AttributeName))
+	}
+}
+
+func TestUpdateTableDeleteGSIPrunesAttributeDefinitions(t *testing.T) {
+	t.Parallel()
+
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:   aws.String("orders2"),
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("OrderId"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("Status"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("OrderId"), KeyType: ddbtypes.KeyTypeHash},
+		},
+		GlobalSecondaryIndexes: []ddbtypes.GlobalSecondaryIndex{
+			{
+				IndexName: aws.String("StatusIndex"),
+				KeySchema: []ddbtypes.KeySchemaElement{
+					{AttributeName: aws.String("Status"), KeyType: ddbtypes.KeyTypeHash},
+				},
+				Projection: &ddbtypes.Projection{ProjectionType: ddbtypes.ProjectionTypeKeysOnly},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = client.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+		TableName: aws.String("orders2"),
+		GlobalSecondaryIndexUpdates: []ddbtypes.GlobalSecondaryIndexUpdate{
+			{Delete: &ddbtypes.DeleteGlobalSecondaryIndexAction{IndexName: aws.String("StatusIndex")}},
+		},
+	})
+	require.NoError(t, err)
+
+	desc, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("orders2")})
+	require.NoError(t, err)
+	// Status was only referenced by the deleted index, so it must be pruned.
+	assert.Equal(t, []string{"OrderId"}, attrNames(desc.Table.AttributeDefinitions))
+}


### PR DESCRIPTION
## Summary

`UpdateTable` adding a GSI decoded `AttributeDefinitions` for validation but never merged the new index-key attribute into the table, so `DescribeTable` omitted it — causing perpetual `terraform plan` drift (re-adds the `attribute` block every plan). Symmetric gap on GSI delete: an orphaned attribute was never pruned.

## Fix

- `providers/aws/dynamodb`: `SyncAttributeDefinitions` + `referencedAttributes` reconcile the table's `AttributeDefinitions` to exactly what the table key + surviving indexes reference (merge new typed defs on add, prune orphans on delete) — the invariant real DynamoDB maintains.
- `server/aws/dynamodb`: optional `attributeDefinitionSyncer` capability invoked from `updateTable` after index add/delete.
- Real aws-sdk-go-v2 regression tests for the merge (add) and prune (delete) paths.

## Verification

Real Terraform 1.14.3 + aws-cli against `cloudemu serve`: create full-surface table (hash+range, GSI, TTL, PITR, stream, tags, deletion_protection) → apply ACTIVE → plan exit 0; add a 2nd GSI → apply → plan exit 0 (previously exit 2 drift); delete GSI+attribute → apply → plan exit 0. Item ops (Query-on-GSI, conditional writes, ReturnValues) verified.

## Enhancement

Nil-safe optional capability; DescribeTable AttributeDefinitions now always match the AWS invariant after any GSI change.