### PR TITLE
fix(gce): real-user e2e divergences from GCP Compute Engine

### DIFF
--- a/server/gcp/compute/compute_test.go
+++ b/server/gcp/compute/compute_test.go
@@ -270,6 +270,58 @@ func TestGetOperationAlwaysDone(t *testing.T) {
 	}
 }
 
+func TestOperationWaitReturnsDone(t *testing.T) {
+	ts := newGCPTestServer(t)
+	op := insertInstance(t, ts, "vm-wait")
+
+	selfLink, _ := op["selfLink"].(string)
+	if selfLink == "" {
+		t.Fatal("missing selfLink")
+	}
+
+	// gcloud and the typed google clients confirm every mutation with
+	// zoneOperations.wait — a POST to <operation>/wait that blocks until the
+	// operation is DONE and returns it. Without this the CLI reports a failure
+	// even though the mutation applied.
+	resp, err := ts.Client().Post(selfLink+"/wait", "application/json", http.NoBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		dump, _ := io.ReadAll(resp.Body)
+		t.Fatalf("operation wait: status=%d body=%s", resp.StatusCode, dump)
+	}
+
+	var got map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&got)
+
+	if got["status"] != "DONE" {
+		t.Errorf("operation status=%v want DONE", got["status"])
+	}
+
+	if got["kind"] != "compute#operation" {
+		t.Errorf("kind=%v want compute#operation", got["kind"])
+	}
+}
+
+func TestOperationWaitUnknownIs404(t *testing.T) {
+	ts := newGCPTestServer(t)
+
+	resp, err := ts.Client().Post(
+		ts.URL+zonesPath("/operations/operation-bogus/wait"),
+		"application/json", http.NoBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status=%d want 404", resp.StatusCode)
+	}
+}
+
 func TestRejectsNonComputePaths(t *testing.T) {
 	ts := newGCPTestServer(t)
 

--- a/server/gcp/compute/handler.go
+++ b/server/gcp/compute/handler.go
@@ -392,15 +392,21 @@ func (h *Handler) dispatchInstanceMutationVerb(w http.ResponseWriter, r *http.Re
 	}
 }
 
-// serveOperations handles GET on operations/{name}. Since the mock executes
-// synchronously, a known operation always reads back DONE. An operation name
-// that was never minted (a bogus poll, `gcloud compute operations describe
-// <bogus>`) is 404, matching real GCP, rather than a fabricated DONE — provided
-// a shared registry is wired (a nil registry keeps the legacy allow-all).
+// serveOperations handles GET on operations/{name} and the POST
+// operations/{name}/wait verb. Since the mock executes synchronously, a known
+// operation always reads back DONE. gcloud and the typed google clients confirm
+// every mutation by calling zoneOperations.wait (a POST that blocks until the
+// operation is DONE, then returns it) rather than polling GET, so without wait
+// support `gcloud compute instances stop/start` (and every other mutation)
+// reports a failure even though the state changed. An operation name that was
+// never minted (a bogus poll, `gcloud compute operations describe <bogus>`) is
+// 404, matching real GCP, rather than a fabricated DONE — provided a shared
+// registry is wired (a nil registry keeps the legacy allow-all).
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) serveOperations(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
-	if r.Method != http.MethodGet {
+	isWait := r.Method == http.MethodPost && strings.EqualFold(rp.Action, "wait")
+	if r.Method != http.MethodGet && !isWait {
 		writeNotImplemented(w, r.Method+" "+r.URL.Path)
 		return
 	}


### PR DESCRIPTION
## Summary

Real-user e2e audit of GCP Compute Engine (`google_compute_instance`) surfaced one genuine cloud-vs-cloudemu divergence: **`zoneOperations.wait` was not implemented**.

gcloud and the typed google clients (`cloud.google.com/go/compute/apiv1` `.Wait()`) confirm every compute mutation by calling `operations.wait` — a `POST .../operations/{name}/wait` that blocks until the operation is DONE and returns it — instead of polling `GET`. The operations route only handled `GET`, so `wait` fell through to `501 UNIMPLEMENTED`. The underlying mutation applied (state changed), but gcloud reported the command as **failed**:

```
ERROR: (gcloud.compute.instances.stop) UNIMPLEMENTED: not implemented: POST .../operations/operation-.../wait
```

This broke `gcloud compute instances create/stop/start/delete` (and every other compute mutation) against the emulator. Terraform was unaffected because the google provider sees the already-DONE operation in the insert response and skips polling.

## Change

`serveOperations` now accepts the `POST .../operations/{name}/wait` verb. Since the emulator executes synchronously (operations are always DONE), `wait` returns the same DONE operation as `GET`, still 404ing an operation name that was never minted. The route is scope-agnostic, so this covers zone, region, and global compute operations (instances, disks, networks, load balancing, MIGs).

## Evidence

Live `cloudemu serve` (GCP :16560) driven with real gcloud:
- Before: `gcloud compute instances stop/start` → `....failed. UNIMPLEMENTED`
- After: `gcloud compute instances create/stop/start/delete` → `....done.` full lifecycle green

Terraform full lifecycle (create → LRO DONE → `plan` no drift → update labels/metadata/tags/machine_type → no drift → destroy → 404) verified clean, including boot disk, a separately-created attached disk, and network_interface round-trip.

## Feature

- `zoneOperations.wait` / `regionOperations.wait` / `globalOperations.wait` for compute operations.
