### PR TITLE
fix(azure-postgresql): real-user e2e divergences from Azure PostgreSQL Flexible Server

### DIFF
--- a/providers/azure/postgresflex/postgresflex.go
+++ b/providers/azure/postgresflex/postgresflex.go
@@ -35,6 +35,8 @@ const (
 	defaultStorageGB   = 32
 	defaultStorageType = "Premium_LRS"
 	defaultSKU         = "Standard_B1ms"
+	defaultSKUTier     = "Burstable" // pairs with defaultSKU (a B-series compute)
+	defaultBackupDays  = 7           // Azure Flexible Server default backup retention
 	defaultEngine      = "Postgres"
 	armProvider        = "Microsoft.DBforPostgreSQL"
 	armResourceType    = "flexibleServers"
@@ -235,6 +237,16 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		sku = defaultSKU
 	}
 
+	skuTier := cfg.SKUTier
+	if skuTier == "" {
+		skuTier = defaultSKUTier
+	}
+
+	backupDays := cfg.BackupRetentionPeriod
+	if backupDays == 0 {
+		backupDays = defaultBackupDays
+	}
+
 	region := cfg.Location
 	if region == "" {
 		region = m.opts.Region
@@ -246,6 +258,8 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		Engine:                  cfg.Engine,
 		EngineVersion:           cfg.EngineVersion,
 		InstanceClass:           sku,
+		SKUTier:                 skuTier,
+		BackupRetentionPeriod:   backupDays,
 		AllocatedStorage:        storage,
 		StorageType:             storageType,
 		MasterUsername:          cfg.MasterUsername,
@@ -346,37 +360,7 @@ func (m *Mock) ModifyInstance(
 		return nil, err
 	}
 
-	if input.InstanceClass != "" {
-		inst.InstanceClass = input.InstanceClass
-	}
-
-	if input.AllocatedStorage > 0 {
-		inst.AllocatedStorage = input.AllocatedStorage
-	}
-
-	if input.EngineVersion != "" {
-		inst.EngineVersion = input.EngineVersion
-	}
-
-	if input.MultiAZ != nil {
-		inst.MultiAZ = *input.MultiAZ
-	}
-
-	if input.HighAvailabilityMode != "" {
-		inst.HighAvailabilityMode = input.HighAvailabilityMode
-		inst.MultiAZ = rdsdriver.HAEnabled(input.HighAvailabilityMode)
-		// Disabling HA tears down the standby, so its zone no longer applies;
-		// enabling it records the requested standby zone.
-		if inst.MultiAZ {
-			inst.StandbyAvailabilityZone = input.StandbyAvailabilityZone
-		} else {
-			inst.StandbyAvailabilityZone = ""
-		}
-	}
-
-	if input.Tags != nil {
-		inst.Tags = copyTags(input.Tags)
-	}
+	applyModify(&inst, &input)
 
 	m.instances.Set(id, inst)
 
@@ -389,6 +373,59 @@ func (m *Mock) ModifyInstance(
 	out.State = m.settleState(id, out.State)
 
 	return &out, nil
+}
+
+// applyModify overlays the non-empty fields of input onto inst; a zero-valued
+// field means "no change". Split out of ModifyInstance so each side stays under
+// the cyclomatic-complexity budget.
+func applyModify(inst *rdsdriver.Instance, input *rdsdriver.ModifyInstanceInput) {
+	if input.InstanceClass != "" {
+		inst.InstanceClass = input.InstanceClass
+	}
+
+	if input.SKUTier != "" {
+		inst.SKUTier = input.SKUTier
+	}
+
+	if input.AllocatedStorage > 0 {
+		inst.AllocatedStorage = input.AllocatedStorage
+	}
+
+	if input.BackupRetentionPeriod > 0 {
+		inst.BackupRetentionPeriod = input.BackupRetentionPeriod
+	}
+
+	if input.EngineVersion != "" {
+		inst.EngineVersion = input.EngineVersion
+	}
+
+	if input.MultiAZ != nil {
+		inst.MultiAZ = *input.MultiAZ
+	}
+
+	applyModifyHA(inst, input)
+
+	if input.Tags != nil {
+		inst.Tags = copyTags(input.Tags)
+	}
+}
+
+// applyModifyHA applies a high-availability mode change: an empty mode is left
+// untouched, disabling HA clears the standby zone, and enabling it records the
+// requested one.
+func applyModifyHA(inst *rdsdriver.Instance, input *rdsdriver.ModifyInstanceInput) {
+	if input.HighAvailabilityMode == "" {
+		return
+	}
+
+	inst.HighAvailabilityMode = input.HighAvailabilityMode
+	inst.MultiAZ = rdsdriver.HAEnabled(input.HighAvailabilityMode)
+
+	if inst.MultiAZ {
+		inst.StandbyAvailabilityZone = input.StandbyAvailabilityZone
+	} else {
+		inst.StandbyAvailabilityZone = ""
+	}
 }
 
 // DeleteInstance removes a flexible server.
@@ -641,6 +678,8 @@ func (m *Mock) DeleteSnapshot(_ context.Context, id string) error {
 }
 
 // RestoreInstanceFromSnapshot creates a new flexible server from a snapshot.
+//
+//nolint:gocritic // input matches the driver interface signature.
 func (m *Mock) RestoreInstanceFromSnapshot(
 	_ context.Context, input rdsdriver.RestoreInstanceInput,
 ) (*rdsdriver.Instance, error) {
@@ -666,22 +705,29 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 		sku = defaultSKU
 	}
 
+	skuTier := input.SKUTier
+	if skuTier == "" {
+		skuTier = defaultSKUTier
+	}
+
 	now := m.opts.Clock.Now().UTC()
 
 	inst := rdsdriver.Instance{
-		ID:               input.NewInstanceID,
-		ARN:              flexibleServerResourceID(m.opts.Region, input.NewInstanceID),
-		Engine:           snap.Engine,
-		EngineVersion:    snap.EngineVersion,
-		InstanceClass:    sku,
-		AllocatedStorage: snap.AllocatedStorage,
-		StorageType:      defaultStorageType,
-		Endpoint:         flexibleServerEndpoint(input.NewInstanceID),
-		Port:             defaultPort,
-		State:            rdsdriver.StateAvailable,
-		Location:         m.opts.Region,
-		CreatedAt:        now,
-		Tags:             copyTags(input.Tags),
+		ID:                    input.NewInstanceID,
+		ARN:                   flexibleServerResourceID(m.opts.Region, input.NewInstanceID),
+		Engine:                snap.Engine,
+		EngineVersion:         snap.EngineVersion,
+		InstanceClass:         sku,
+		SKUTier:               skuTier,
+		BackupRetentionPeriod: defaultBackupDays,
+		AllocatedStorage:      snap.AllocatedStorage,
+		StorageType:           defaultStorageType,
+		Endpoint:              flexibleServerEndpoint(input.NewInstanceID),
+		Port:                  defaultPort,
+		State:                 rdsdriver.StateAvailable,
+		Location:              m.opts.Region,
+		CreatedAt:             now,
+		Tags:                  copyTags(input.Tags),
 	}
 
 	m.instances.Set(input.NewInstanceID, inst)

--- a/server/azure/postgresflex/operations.go
+++ b/server/azure/postgresflex/operations.go
@@ -71,6 +71,7 @@ func instanceFromBody(body *armServer, rp *azurearm.ResourcePath) rdsdriver.Inst
 
 	if body.SKU != nil {
 		cfg.InstanceClass = body.SKU.Name
+		cfg.SKUTier = body.SKU.Tier
 	}
 
 	if body.Properties != nil {
@@ -81,6 +82,10 @@ func instanceFromBody(body *armServer, rp *azurearm.ResourcePath) rdsdriver.Inst
 
 		if body.Properties.Storage != nil && body.Properties.Storage.StorageSizeGB > 0 {
 			cfg.AllocatedStorage = body.Properties.Storage.StorageSizeGB
+		}
+
+		if b := body.Properties.Backup; b != nil && b.BackupRetentionDays > 0 {
+			cfg.BackupRetentionPeriod = b.BackupRetentionDays
 		}
 
 		if ha := body.Properties.HighAvailability; ha != nil {
@@ -171,6 +176,7 @@ func modifyInputFromBody(body *armServer) rdsdriver.ModifyInstanceInput {
 
 	if body.SKU != nil {
 		input.InstanceClass = body.SKU.Name
+		input.SKUTier = body.SKU.Tier
 	}
 
 	if body.Properties != nil {
@@ -178,6 +184,10 @@ func modifyInputFromBody(body *armServer) rdsdriver.ModifyInstanceInput {
 
 		if body.Properties.Storage != nil && body.Properties.Storage.StorageSizeGB > 0 {
 			input.AllocatedStorage = body.Properties.Storage.StorageSizeGB
+		}
+
+		if b := body.Properties.Backup; b != nil && b.BackupRetentionDays > 0 {
+			input.BackupRetentionPeriod = b.BackupRetentionDays
 		}
 
 		if ha := body.Properties.HighAvailability; ha != nil {
@@ -198,6 +208,7 @@ func (h *Handler) restoreServer(w http.ResponseWriter, r *http.Request, rp *azur
 
 	if body.SKU != nil {
 		input.InstanceClass = body.SKU.Name
+		input.SKUTier = body.SKU.Tier
 	}
 
 	inst, err := h.db.RestoreInstanceFromSnapshot(r.Context(), input)

--- a/server/azure/postgresflex/sdk_roundtrip_test.go
+++ b/server/azure/postgresflex/sdk_roundtrip_test.go
@@ -115,6 +115,23 @@ func TestSDKPostgresFlexServerLifecycle(t *testing.T) {
 		t.Fatalf("expected state Ready, got %v", got.Server.Properties.State)
 	}
 
+	// The SKU tier must round-trip: terraform-provider-azurerm reconstructs
+	// sku_name from name+tier and drops it entirely when tier is missing,
+	// producing perpetual plan drift. Both halves must come back.
+	if got.Server.SKU == nil || got.Server.SKU.Name == nil || *got.Server.SKU.Name != "Standard_B1ms" {
+		t.Fatalf("expected sku name Standard_B1ms, got %+v", got.Server.SKU)
+	}
+
+	if got.Server.SKU.Tier == nil || *got.Server.SKU.Tier != armpostgresqlflexibleservers.SKUTierBurstable {
+		t.Fatalf("expected sku tier Burstable, got %v", got.Server.SKU.Tier)
+	}
+
+	// Real Azure always returns properties.backup with a default retention of 7.
+	if got.Server.Properties.Backup == nil || got.Server.Properties.Backup.BackupRetentionDays == nil ||
+		*got.Server.Properties.Backup.BackupRetentionDays != 7 {
+		t.Fatalf("expected default backupRetentionDays 7, got %+v", got.Server.Properties.Backup)
+	}
+
 	// List under the resource group.
 	pager := servers.NewListByResourceGroupPager("rg-1", nil)
 
@@ -236,6 +253,49 @@ func TestSDKPostgresFlexUpdateAndLifecycle(t *testing.T) {
 	if got.Server.Properties == nil || got.Server.Properties.State == nil ||
 		*got.Server.Properties.State != armpostgresqlflexibleservers.ServerStateReady {
 		t.Fatalf("expected state Ready after restart, got %v", got.Server.Properties.State)
+	}
+}
+
+// TestSDKPostgresFlexSkuAndBackupRoundTrip covers a GeneralPurpose SKU and a
+// non-default backup retention: both must survive create->get unchanged so a
+// terraform plan reports no drift on sku_name / backup_retention_days.
+func TestSDKPostgresFlexSkuAndBackupRoundTrip(t *testing.T) {
+	servers := newSDKClient(t)
+	ctx := context.Background()
+
+	poller, err := servers.BeginCreate(ctx, "rg-1", "gp1", armpostgresqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+		SKU: &armpostgresqlflexibleservers.SKU{
+			Name: to.Ptr("Standard_D2s_v3"),
+			Tier: to.Ptr(armpostgresqlflexibleservers.SKUTierGeneralPurpose),
+		},
+		Properties: &armpostgresqlflexibleservers.ServerProperties{
+			Backup: &armpostgresqlflexibleservers.Backup{
+				BackupRetentionDays: to.Ptr(int32(21)),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	got, err := servers.Get(ctx, "rg-1", "gp1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Server.SKU == nil || got.Server.SKU.Tier == nil ||
+		*got.Server.SKU.Tier != armpostgresqlflexibleservers.SKUTierGeneralPurpose {
+		t.Fatalf("expected tier GeneralPurpose, got %+v", got.Server.SKU)
+	}
+
+	if got.Server.Properties.Backup == nil || got.Server.Properties.Backup.BackupRetentionDays == nil ||
+		*got.Server.Properties.Backup.BackupRetentionDays != 21 {
+		t.Fatalf("expected backupRetentionDays 21, got %+v", got.Server.Properties.Backup)
 	}
 }
 

--- a/server/azure/postgresflex/types.go
+++ b/server/azure/postgresflex/types.go
@@ -41,6 +41,7 @@ type armServerProps struct {
 	State                      string               `json:"state,omitempty"`
 	FullyQualifiedDomainName   string               `json:"fullyQualifiedDomainName,omitempty"`
 	Storage                    *armStorage          `json:"storage,omitempty"`
+	Backup                     *armBackup           `json:"backup,omitempty"`
 	AvailabilityZone           string               `json:"availabilityZone,omitempty"`
 	HighAvailability           *armHighAvailability `json:"highAvailability,omitempty"`
 	CreateMode                 string               `json:"createMode,omitempty"`
@@ -58,6 +59,15 @@ type armHighAvailability struct {
 
 type armStorage struct {
 	StorageSizeGB int `json:"storageSizeGB,omitempty"`
+}
+
+// armBackup mirrors properties.backup on a PostgreSQL Flexible Server. Real
+// Azure always returns this block; backupRetentionDays defaults to 7 and
+// geoRedundantBackup is Disabled/Enabled. geoRedundantBackup is preserved by
+// the generic unmodeled-property overlay, so only the retention days — which
+// real Azure defaults and which a caller reads back — is modeled here.
+type armBackup struct {
+	BackupRetentionDays int `json:"backupRetentionDays,omitempty"`
 }
 
 // armList is the ARM list-response envelope.
@@ -81,6 +91,10 @@ func toARMServer(inst *rdsdriver.Instance, subscription, resourceGroup string) a
 		props.Storage = &armStorage{StorageSizeGB: inst.AllocatedStorage}
 	}
 
+	if inst.BackupRetentionPeriod > 0 {
+		props.Backup = &armBackup{BackupRetentionDays: inst.BackupRetentionPeriod}
+	}
+
 	return armServer{
 		ID:       azurearm.BuildResourceID(subscription, resourceGroup, providerName, resourceFlexibleServers, inst.ID),
 		Name:     inst.ID,
@@ -89,6 +103,7 @@ func toARMServer(inst *rdsdriver.Instance, subscription, resourceGroup string) a
 		Tags:     inst.Tags,
 		SKU: &armSKU{
 			Name: inst.InstanceClass,
+			Tier: inst.SKUTier,
 		},
 		Properties: props,
 	}

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -64,10 +64,15 @@ func ValidHAMode(mode string) bool {
 
 // InstanceConfig configures a managed database instance.
 type InstanceConfig struct {
-	ID                   string
-	Engine               string // "mysql", "postgres", "aurora-mysql", "aurora-postgresql", …
-	EngineVersion        string
-	InstanceClass        string // "db.t3.micro", …
+	ID            string
+	Engine        string // "mysql", "postgres", "aurora-mysql", "aurora-postgresql", …
+	EngineVersion string
+	InstanceClass string // "db.t3.micro", …
+	// SKUTier is the Azure Flexible Server compute tier
+	// ("Burstable"/"GeneralPurpose"/"MemoryOptimized") that pairs with
+	// InstanceClass (the compute SKU name) to form the ARM sku object. It is an
+	// Azure Flexible Server concept; empty for AWS/GCP, which have no tier split.
+	SKUTier              string
 	AllocatedStorage     int    // GiB
 	StorageType          string // "gp2", "io1", …
 	MasterUsername       string
@@ -151,11 +156,15 @@ type InstanceConfig struct {
 
 // Instance describes a managed database instance.
 type Instance struct {
-	ID               string
-	ARN              string
-	Engine           string
-	EngineVersion    string
-	InstanceClass    string
+	ID            string
+	ARN           string
+	Engine        string
+	EngineVersion string
+	InstanceClass string
+	// SKUTier echoes the Azure Flexible Server compute tier
+	// ("Burstable"/"GeneralPurpose"/"MemoryOptimized") on read; it pairs with
+	// InstanceClass to reconstruct the ARM sku object. Empty for AWS/GCP.
+	SKUTier          string
 	AllocatedStorage int
 	StorageType      string
 	MasterUsername   string
@@ -236,7 +245,11 @@ type Instance struct {
 // apply to instances; DBClusterParameterGroupName applies to clusters (the
 // same input type backs ModifyInstance and ModifyCluster).
 type ModifyInstanceInput struct {
-	InstanceClass               string
+	InstanceClass string
+	// SKUTier updates the Azure Flexible Server compute tier
+	// ("Burstable"/"GeneralPurpose"/"MemoryOptimized"); empty means "no change".
+	// Other engines ignore it.
+	SKUTier                     string
 	AllocatedStorage            int
 	EngineVersion               string
 	MasterUserPassword          string
@@ -539,6 +552,9 @@ type RestoreInstanceInput struct {
 	NewInstanceID string
 	SnapshotID    string
 	InstanceClass string
+	// SKUTier is the Azure Flexible Server compute tier for the restored server;
+	// empty falls back to the provider default. Unused by AWS/GCP.
+	SKUTier string
 	// Port overrides the restored instance's connection port. Zero means "no
 	// override": AWS falls back to the same port as the original DB instance
 	// the snapshot was taken from, not the engine default.


### PR DESCRIPTION
## Summary

Real-user e2e audit of Azure Database for PostgreSQL — Flexible Server (`Microsoft.DBforPostgreSQL/flexibleServers`) against the real `armpostgresqlflexibleservers` SDK and a live `cloudemu serve` ARM endpoint. Two genuine cloud-vs-cloudemu divergences that a `terraform-provider-azurerm` / azure-sdk-for-go user hits were found and fixed.

## Divergences fixed

### 1. `sku.tier` dropped on read → perpetual `sku_name` drift (high)
The ARM create/update path read only `sku.name` and the GET echoed only `sku.name`, discarding `sku.tier`. terraform-provider-azurerm's `flattenFlexibleServerSku` reconstructs `sku_name` from name **and** tier and returns an empty string when tier is missing, so `sku_name` went empty in state and drifted on every `terraform plan` (forced update/replace). The generic unmodeled-property overlay cannot rescue this because `sku` is a top-level ARM field and the overlay only preserves `properties.*`.

Fix: persist the SKU tier (new `SKUTier` driver field) and echo `sku.tier` on read. Defaults to `Burstable` to match the default `Standard_B1ms` compute.

### 2. `properties.backup` never returned → wrong `backup_retention_days` (medium)
Real Azure always returns `properties.backup` with `backupRetentionDays` (default 7). The handler modeled no backup block, so an unset retention read back as 0 instead of 7. Fix: model `backup.backupRetentionDays` (default 7, round-tripping a configured value), reusing the existing `BackupRetentionPeriod` field. `geoRedundantBackup` continues to round-trip through the existing unmodeled-property overlay.

## Verified already correct (no change)
Async LRO create completes (SDK `PollUntilDone` terminates, state `Ready`, no waiter hang); fqdn format; version/storage/zone round-trip; highAvailability round-trip on create and PATCH; cross-subscription/resource-group isolation.

## Tests / evidence
- New real-SDK assertions in `sdk_roundtrip_test.go` for tier + backup round-trip (default and configured).
- Live `cloudemu serve` (Azure HTTPS): ARM PUT→GET returns `sku.tier`, `backup.backupRetentionDays` for configured values and `Burstable`/`7` for defaults.
- Gates: `go build ./...`, full `server/azure` + `providers/azure/postgresflex` `-race`, root integration, `go vet`, `gofmt`, `golangci-lint` (0 issues), `go generate` (no docs/coverage diff).
