### PR TITLE
fix(rds): real-user e2e divergences from AWS RDS

### DIFF
--- a/providers/aws/rds/instance_defaults_test.go
+++ b/providers/aws/rds/instance_defaults_test.go
@@ -1,0 +1,75 @@
+package rds
+
+import (
+	"context"
+	"testing"
+
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// TestCreateInstanceDefaultParameterGroup verifies real RDS's behavior of
+// assigning the account-default "default.<family>" DB parameter group when the
+// caller supplies none, while an explicit group is preserved.
+func TestCreateInstanceDefaultParameterGroup(t *testing.T) {
+	tests := []struct {
+		name       string
+		engine     string
+		paramGroup string
+		want       string
+	}{
+		{name: "mysql default", engine: "mysql", want: "default.mysql8.0"},
+		{name: "postgres default", engine: "postgres", want: "default.postgres16"},
+		{name: "aurora-mysql default", engine: "aurora-mysql", want: "default.aurora-mysql8.0"},
+		{name: "explicit preserved", engine: "mysql", paramGroup: "custom-pg", want: "custom-pg"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+
+			inst, err := m.CreateInstance(context.Background(), rdsdriver.InstanceConfig{
+				ID:                   "db1",
+				Engine:               tc.engine,
+				DBParameterGroupName: tc.paramGroup,
+			})
+			requireNoError(t, err)
+			assertEqual(t, tc.want, inst.DBParameterGroupName)
+
+			got, err := m.DescribeInstances(context.Background(), []string{"db1"})
+			requireNoError(t, err)
+			assertEqual(t, tc.want, got[0].DBParameterGroupName)
+		})
+	}
+}
+
+// TestCreateInstanceDefaultAvailabilityZone verifies real RDS's behavior of
+// placing a single-AZ instance in an Availability Zone (reported on Describe),
+// while a Multi-AZ instance's primary AZ is RDS-chosen and left unset and an
+// explicit AZ is preserved.
+func TestCreateInstanceDefaultAvailabilityZone(t *testing.T) {
+	tests := []struct {
+		name    string
+		multiAZ bool
+		az      string
+		want    string
+	}{
+		{name: "single-AZ defaults to first zone", want: "us-east-1a"},
+		{name: "explicit AZ preserved", az: "us-east-1c", want: "us-east-1c"},
+		{name: "multi-AZ leaves primary unset", multiAZ: true, want: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+
+			inst, err := m.CreateInstance(context.Background(), rdsdriver.InstanceConfig{
+				ID:               "db1",
+				Engine:           "mysql",
+				MultiAZ:          tc.multiAZ,
+				AvailabilityZone: tc.az,
+			})
+			requireNoError(t, err)
+			assertEqual(t, tc.want, inst.AvailabilityZone)
+		})
+	}
+}

--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -454,6 +454,16 @@ func (m *Mock) newInstance(ctx context.Context, cfg rdsdriver.InstanceConfig) rd
 		engineVersion = defaultEngineVersion(cfg.Engine)
 	}
 
+	// Real RDS assigns the account-default DB parameter group ("default.<family>")
+	// and places the instance in an Availability Zone when the caller supplies
+	// neither, and reports both back on every Describe. Default them here so an
+	// SDK/CLI caller reading DBParameterGroups / AvailabilityZone sees what real
+	// RDS returns rather than an empty element.
+	paramGroup := cfg.DBParameterGroupName
+	if paramGroup == "" {
+		paramGroup = defaultParameterGroupName(cfg.Engine)
+	}
+
 	// BackupRetentionPeriod is NOT defaulted here: unlike AllocatedStorage/
 	// StorageType/InstanceClass above, 0 is a meaningful explicit value (it
 	// disables automated backups). The wire layer, which can see whether the
@@ -489,10 +499,10 @@ func (m *Mock) newInstance(ctx context.Context, cfg rdsdriver.InstanceConfig) rd
 		PubliclyAccessible:         cfg.PubliclyAccessible,
 		VPCSecurityGroups:          append([]string(nil), cfg.VPCSecurityGroups...),
 		SubnetGroupName:            cfg.SubnetGroupName,
-		DBParameterGroupName:       cfg.DBParameterGroupName,
+		DBParameterGroupName:       paramGroup,
 		OptionGroupName:            cfg.OptionGroupName,
 		ClusterID:                  cfg.ClusterID,
-		AvailabilityZone:           cfg.AvailabilityZone,
+		AvailabilityZone:           defaultAvailabilityZone(cfg.AvailabilityZone, cfg.MultiAZ, region),
 		DbiResourceID:              resourceID("db-", cfg.ID),
 		BackupRetentionPeriod:      cfg.BackupRetentionPeriod,
 		PreferredBackupWindow:      backupWindow,
@@ -505,6 +515,37 @@ func (m *Mock) newInstance(ctx context.Context, cfg rdsdriver.InstanceConfig) rd
 		CreatedAt:                  m.opts.Clock.Now().UTC(),
 		Tags:                       copyTags(cfg.Tags),
 	}
+}
+
+// defaultParameterGroupName returns the DB parameter group real RDS assigns to
+// an instance whose caller supplied none: "default." + the engine's
+// parameter-group family (e.g. "default.mysql8.0"). An unknown engine has no
+// known family and so no default group, matching real RDS which only
+// auto-assigns one for a recognized engine.
+func defaultParameterGroupName(engine string) string {
+	family := engineFamily[engine]
+	if family == "" {
+		return ""
+	}
+
+	return "default." + family
+}
+
+// defaultAvailabilityZone returns the AZ real RDS reports for an instance. A
+// single-AZ instance is placed in one AZ (the caller's choice, else the first
+// AZ in the region); a Multi-AZ instance spans AZs with an RDS-chosen primary,
+// which is left unset here. region+"a" mirrors the AZ naming availabilityZones()
+// uses for Aurora clusters.
+func defaultAvailabilityZone(az string, multiAZ bool, region string) string {
+	if az != "" {
+		return az
+	}
+
+	if multiAZ || region == "" {
+		return ""
+	}
+
+	return region + "a"
 }
 
 // resolveKMSKeyID mirrors real RDS: when storage is encrypted and the caller
@@ -1393,6 +1434,8 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 		PubliclyAccessible:         input.PubliclyAccessible,
 		DeletionProtection:         input.DeletionProtection,
 		SubnetGroupName:            input.SubnetGroupName,
+		DBParameterGroupName:       defaultParameterGroupName(snap.Engine),
+		AvailabilityZone:           defaultAvailabilityZone("", input.MultiAZ, region),
 		CreatedAt:                  m.opts.Clock.Now().UTC(),
 		Tags:                       copyTags(input.Tags),
 	}


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of AWS RDS (aws_db_instance + Aurora aws_rds_cluster/aws_rds_cluster_instance) via the standalone wire server, exercised with the real aws-cli, aws-sdk, and Terraform 1.14 (hashicorp/aws v5).

The RDS surface is already very mature (status→available, endpoint/ARN/DbiResourceId round-trip, PendingModifiedValues, error-code fidelity, Aurora endpoints/members all verified correct with no Terraform drift on apply→plan→modify→plan for both a plain instance and an Aurora cluster+instance). One genuine field-fidelity divergence was found and fixed.

## Divergence fixed

Real RDS assigns and reports two attributes on **every** `DescribeDBInstances` even when the caller supplies neither:

- **`DBParameterGroups`** — the account-default `default.<family>` group (e.g. `default.mysql8.0`, `default.postgres16`, `default.aurora-mysql8.0`), status `in-sync`.
- **`AvailabilityZone`** — the zone the (single-AZ) instance is placed in.

`CreateDBInstance` / `RestoreDBInstanceFromDBSnapshot` left both empty, so an SDK/CLI caller reading `DBParameterGroups[0].DBParameterGroupName` (e.g. to then call `DescribeDBParameters`) or `AvailabilityZone` got an empty element instead of what real RDS returns.

### Fix

- `newInstance` defaults `DBParameterGroupName` to `default.<family>` (from the existing `engineFamily` table) when none is given, and defaults `AvailabilityZone` to the region's first zone for a single-AZ instance (Multi-AZ leaves the RDS-chosen primary unset; an explicit value always wins). The snapshot-restore path mirrors both.
- The XML layer already rendered `DBParameterGroups`/`AvailabilityZone`, so populating the driver fields flows through unchanged.

### Evidence
- CLI: `describe-db-instances` now returns `DBParameterGroups=[{default.mysql8.0, in-sync}]` and `AvailabilityZone=us-east-1a`.
- Terraform: `aws_db_instance` and `aws_rds_cluster`+`aws_rds_cluster_instance` apply → `plan` (no drift) → modify (`allocated_storage`) → apply → `plan` (no drift), before and after the fix — `parameter_group_name` / `availability_zone` are computed so the realistic values introduce no drift.

## Tests
New `providers/aws/rds/instance_defaults_test.go` covers the default/explicit/Multi-AZ cases across mysql, postgres, and aurora-mysql.

Gates: `go build ./...`, `go test -race` (providers/aws/rds + server/aws/rds), root `go test`, `go vet`, `gofmt`, `golangci-lint --new-from-rev` (0 new issues), `go generate ./...` (no docs/coverage change) — all green.