### PR TITLE
fix(azure-mysql): round-trip sku tier and backup on flexible servers

### DIFF
--- a/providers/azure/mysqlflex/mysqlflex.go
+++ b/providers/azure/mysqlflex/mysqlflex.go
@@ -31,6 +31,8 @@ const (
 	defaultStorageGB      = 20
 	defaultStorageType    = "Premium_LRS"
 	defaultSKU            = "Standard_B1ms"
+	defaultSKUTier        = "Burstable" // pairs with defaultSKU (a B-series compute)
+	defaultBackupDays     = 7           // Azure Flexible Server default backup retention
 	defaultEngine         = "MySQL"
 	resourceGroupTag      = "cloud-mock"
 	providerNamespace     = "Microsoft.DBforMySQL"
@@ -219,9 +221,19 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		storageType = defaultStorageType
 	}
 
-	tier := cfg.InstanceClass
-	if tier == "" {
-		tier = defaultSKU
+	sku := cfg.InstanceClass
+	if sku == "" {
+		sku = defaultSKU
+	}
+
+	skuTier := cfg.SKUTier
+	if skuTier == "" {
+		skuTier = defaultSKUTier
+	}
+
+	backupDays := cfg.BackupRetentionPeriod
+	if backupDays == 0 {
+		backupDays = defaultBackupDays
 	}
 
 	region := cfg.Location
@@ -234,7 +246,9 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		ARN:                     m.armResourceID(cfg.ID),
 		Engine:                  cfg.Engine,
 		EngineVersion:           cfg.EngineVersion,
-		InstanceClass:           tier,
+		InstanceClass:           sku,
+		SKUTier:                 skuTier,
+		BackupRetentionPeriod:   backupDays,
 		AllocatedStorage:        storage,
 		StorageType:             storageType,
 		MasterUsername:          cfg.MasterUsername,
@@ -336,37 +350,7 @@ func (m *Mock) ModifyInstance(
 		return nil, err
 	}
 
-	if input.InstanceClass != "" {
-		inst.InstanceClass = input.InstanceClass
-	}
-
-	if input.AllocatedStorage > 0 {
-		inst.AllocatedStorage = input.AllocatedStorage
-	}
-
-	if input.EngineVersion != "" {
-		inst.EngineVersion = input.EngineVersion
-	}
-
-	if input.MultiAZ != nil {
-		inst.MultiAZ = *input.MultiAZ
-	}
-
-	if input.HighAvailabilityMode != "" {
-		inst.HighAvailabilityMode = input.HighAvailabilityMode
-		inst.MultiAZ = rdsdriver.HAEnabled(input.HighAvailabilityMode)
-		// Disabling HA tears down the standby, so its zone no longer applies;
-		// enabling it records the requested standby zone.
-		if inst.MultiAZ {
-			inst.StandbyAvailabilityZone = input.StandbyAvailabilityZone
-		} else {
-			inst.StandbyAvailabilityZone = ""
-		}
-	}
-
-	if input.Tags != nil {
-		inst.Tags = copyTags(input.Tags)
-	}
+	applyModify(&inst, &input)
 
 	m.instances.Set(id, inst)
 
@@ -379,6 +363,59 @@ func (m *Mock) ModifyInstance(
 	out.State = m.settleState(id, out.State)
 
 	return &out, nil
+}
+
+// applyModify overlays the non-empty fields of input onto inst; a zero-valued
+// field means "no change". Split out of ModifyInstance so each side stays under
+// the cyclomatic-complexity budget.
+func applyModify(inst *rdsdriver.Instance, input *rdsdriver.ModifyInstanceInput) {
+	if input.InstanceClass != "" {
+		inst.InstanceClass = input.InstanceClass
+	}
+
+	if input.SKUTier != "" {
+		inst.SKUTier = input.SKUTier
+	}
+
+	if input.AllocatedStorage > 0 {
+		inst.AllocatedStorage = input.AllocatedStorage
+	}
+
+	if input.BackupRetentionPeriod > 0 {
+		inst.BackupRetentionPeriod = input.BackupRetentionPeriod
+	}
+
+	if input.EngineVersion != "" {
+		inst.EngineVersion = input.EngineVersion
+	}
+
+	if input.MultiAZ != nil {
+		inst.MultiAZ = *input.MultiAZ
+	}
+
+	applyModifyHA(inst, input)
+
+	if input.Tags != nil {
+		inst.Tags = copyTags(input.Tags)
+	}
+}
+
+// applyModifyHA applies a high-availability mode change: an empty mode is left
+// untouched, disabling HA clears the standby zone, and enabling it records the
+// requested one.
+func applyModifyHA(inst *rdsdriver.Instance, input *rdsdriver.ModifyInstanceInput) {
+	if input.HighAvailabilityMode == "" {
+		return
+	}
+
+	inst.HighAvailabilityMode = input.HighAvailabilityMode
+	inst.MultiAZ = rdsdriver.HAEnabled(input.HighAvailabilityMode)
+
+	if inst.MultiAZ {
+		inst.StandbyAvailabilityZone = input.StandbyAvailabilityZone
+	} else {
+		inst.StandbyAvailabilityZone = ""
+	}
 }
 
 // DeleteInstance removes a server.
@@ -633,6 +670,8 @@ func (m *Mock) DeleteSnapshot(_ context.Context, id string) error {
 }
 
 // RestoreInstanceFromSnapshot creates a new server from a portable backup.
+//
+//nolint:gocritic // input matches the driver interface signature.
 func (m *Mock) RestoreInstanceFromSnapshot(
 	_ context.Context, input rdsdriver.RestoreInstanceInput,
 ) (*rdsdriver.Instance, error) {
@@ -653,27 +692,34 @@ func (m *Mock) RestoreInstanceFromSnapshot(
 			"MySQL Flexible Server %q already exists", input.NewInstanceID)
 	}
 
-	tier := input.InstanceClass
-	if tier == "" {
-		tier = defaultSKU
+	sku := input.InstanceClass
+	if sku == "" {
+		sku = defaultSKU
+	}
+
+	skuTier := input.SKUTier
+	if skuTier == "" {
+		skuTier = defaultSKUTier
 	}
 
 	now := m.opts.Clock.Now().UTC()
 
 	inst := rdsdriver.Instance{
-		ID:               input.NewInstanceID,
-		ARN:              m.armResourceID(input.NewInstanceID),
-		Engine:           snap.Engine,
-		EngineVersion:    snap.EngineVersion,
-		InstanceClass:    tier,
-		AllocatedStorage: snap.AllocatedStorage,
-		StorageType:      defaultStorageType,
-		Endpoint:         input.NewInstanceID + endpointSuffix,
-		Port:             defaultPort,
-		State:            rdsdriver.StateAvailable,
-		Location:         m.opts.Region,
-		CreatedAt:        now,
-		Tags:             copyTags(input.Tags),
+		ID:                    input.NewInstanceID,
+		ARN:                   m.armResourceID(input.NewInstanceID),
+		Engine:                snap.Engine,
+		EngineVersion:         snap.EngineVersion,
+		InstanceClass:         sku,
+		SKUTier:               skuTier,
+		BackupRetentionPeriod: defaultBackupDays,
+		AllocatedStorage:      snap.AllocatedStorage,
+		StorageType:           defaultStorageType,
+		Endpoint:              input.NewInstanceID + endpointSuffix,
+		Port:                  defaultPort,
+		State:                 rdsdriver.StateAvailable,
+		Location:              m.opts.Region,
+		CreatedAt:             now,
+		Tags:                  copyTags(input.Tags),
 	}
 
 	m.instances.Set(input.NewInstanceID, inst)

--- a/server/azure/mysqlflex/operations.go
+++ b/server/azure/mysqlflex/operations.go
@@ -71,40 +71,11 @@ func (h *Handler) createServer(w http.ResponseWriter, r *http.Request, rp *azure
 		return
 	}
 
-	cfg := rdsdriver.InstanceConfig{
-		ID:       rp.ResourceName,
-		Engine:   "MySQL",
-		Location: body.Location,
-		Tags:     body.Tags,
-		Scope:    requestScope(rp),
-	}
-
-	if body.SKU != nil {
-		cfg.InstanceClass = body.SKU.Name
-	}
-
-	if body.Properties != nil {
-		cfg.MasterUsername = body.Properties.AdministratorLogin
-		cfg.MasterUserPassword = body.Properties.AdministratorLoginPassword
-		cfg.EngineVersion = body.Properties.Version
-		cfg.AvailabilityZone = body.Properties.AvailabilityZone
-
-		if body.Properties.Storage != nil {
-			cfg.AllocatedStorage = body.Properties.Storage.StorageSizeGB
-			cfg.StorageType = body.Properties.Storage.StorageSKU
-		}
-
-		if ha := body.Properties.HighAvailability; ha != nil {
-			cfg.HighAvailabilityMode = ha.Mode
-			cfg.StandbyAvailabilityZone = ha.StandbyAvailabilityZone
-		}
-	}
-
 	// ARM PUT of a new resource returns 201 Created; an in-place update of an
 	// existing one returns 200.
 	status := http.StatusCreated
 
-	inst, err := h.db.CreateInstance(r.Context(), cfg)
+	inst, err := h.db.CreateInstance(r.Context(), instanceConfigFromBody(&body, rp))
 	if err != nil {
 		if !cerrors.IsAlreadyExists(err) {
 			azurearm.WriteCErr(w, err)
@@ -120,6 +91,49 @@ func (h *Handler) createServer(w http.ResponseWriter, r *http.Request, rp *azure
 	}
 
 	azurearm.WriteJSON(w, status, toARMServer(inst, rp.Subscription, rp.ResourceGroup))
+}
+
+// instanceConfigFromBody maps a MySQL Flex server PUT body to the portable
+// create config. Split out of createServer so the handler stays under the
+// cyclomatic-complexity budget.
+func instanceConfigFromBody(body *armServer, rp *azurearm.ResourcePath) rdsdriver.InstanceConfig {
+	cfg := rdsdriver.InstanceConfig{
+		ID:       rp.ResourceName,
+		Engine:   "MySQL",
+		Location: body.Location,
+		Tags:     body.Tags,
+		Scope:    requestScope(rp),
+	}
+
+	if body.SKU != nil {
+		cfg.InstanceClass = body.SKU.Name
+		cfg.SKUTier = body.SKU.Tier
+	}
+
+	if body.Properties == nil {
+		return cfg
+	}
+
+	cfg.MasterUsername = body.Properties.AdministratorLogin
+	cfg.MasterUserPassword = body.Properties.AdministratorLoginPassword
+	cfg.EngineVersion = body.Properties.Version
+	cfg.AvailabilityZone = body.Properties.AvailabilityZone
+
+	if body.Properties.Storage != nil {
+		cfg.AllocatedStorage = body.Properties.Storage.StorageSizeGB
+		cfg.StorageType = body.Properties.Storage.StorageSKU
+	}
+
+	if b := body.Properties.Backup; b != nil && b.BackupRetentionDays > 0 {
+		cfg.BackupRetentionPeriod = b.BackupRetentionDays
+	}
+
+	if ha := body.Properties.HighAvailability; ha != nil {
+		cfg.HighAvailabilityMode = ha.Mode
+		cfg.StandbyAvailabilityZone = ha.StandbyAvailabilityZone
+	}
+
+	return cfg
 }
 
 // upsertOnNameCollision resolves a PUT whose server name is already taken.
@@ -160,6 +174,7 @@ func modifyInputFromBody(body *armServer) rdsdriver.ModifyInstanceInput {
 
 	if body.SKU != nil {
 		input.InstanceClass = body.SKU.Name
+		input.SKUTier = body.SKU.Tier
 	}
 
 	if body.Properties != nil {
@@ -167,6 +182,10 @@ func modifyInputFromBody(body *armServer) rdsdriver.ModifyInstanceInput {
 
 		if body.Properties.Storage != nil && body.Properties.Storage.StorageSizeGB > 0 {
 			input.AllocatedStorage = body.Properties.Storage.StorageSizeGB
+		}
+
+		if b := body.Properties.Backup; b != nil && b.BackupRetentionDays > 0 {
+			input.BackupRetentionPeriod = b.BackupRetentionDays
 		}
 
 		if ha := body.Properties.HighAvailability; ha != nil {

--- a/server/azure/mysqlflex/sdk_roundtrip_test.go
+++ b/server/azure/mysqlflex/sdk_roundtrip_test.go
@@ -115,6 +115,19 @@ func TestSDKMySQLFlexLifecycle(t *testing.T) {
 		t.Fatalf("expected SKU Standard_D2ds_v4, got %v", got.Server.SKU)
 	}
 
+	// The SKU tier must round-trip: terraform-provider-azurerm reconstructs
+	// sku_name from name+tier and drops it entirely when tier is missing,
+	// producing perpetual plan drift. Both halves must come back.
+	if got.Server.SKU.Tier == nil || *got.Server.SKU.Tier != armmysqlflexibleservers.SKUTierGeneralPurpose {
+		t.Fatalf("expected sku tier GeneralPurpose, got %v", got.Server.SKU.Tier)
+	}
+
+	// Real Azure always returns properties.backup with a default retention of 7.
+	if got.Server.Properties.Backup == nil || got.Server.Properties.Backup.BackupRetentionDays == nil ||
+		*got.Server.Properties.Backup.BackupRetentionDays != 7 {
+		t.Fatalf("expected default backupRetentionDays 7, got %+v", got.Server.Properties.Backup)
+	}
+
 	// PATCH (resize SKU + storage).
 	patchPoller, err := servers.BeginUpdate(ctx, "rg-1", "srv1", armmysqlflexibleservers.ServerForUpdate{
 		SKU: &armmysqlflexibleservers.SKU{Name: to.Ptr("Standard_D4ds_v4")},
@@ -141,6 +154,12 @@ func TestSDKMySQLFlexLifecycle(t *testing.T) {
 		t.Fatalf("expected sku Standard_D4ds_v4 after patch")
 	}
 
+	// PATCH carried no tier, so the stored GeneralPurpose tier must be preserved
+	// (empty means "no change") rather than blanked, which would drift.
+	if got.Server.SKU.Tier == nil || *got.Server.SKU.Tier != armmysqlflexibleservers.SKUTierGeneralPurpose {
+		t.Fatalf("expected sku tier GeneralPurpose preserved after patch, got %v", got.Server.SKU.Tier)
+	}
+
 	// List under the resource group.
 	pager := servers.NewListByResourceGroupPager("rg-1", nil)
 
@@ -164,6 +183,77 @@ func TestSDKMySQLFlexLifecycle(t *testing.T) {
 
 	if _, err := servers.Get(ctx, "rg-1", "srv1", nil); err == nil {
 		t.Fatal("expected NotFound after Delete")
+	}
+}
+
+// TestSDKMySQLFlexSkuTierDefaultAndBackup covers the default path: a create that
+// sends only a Burstable-class sku name (no tier) and no backup block must read
+// back tier Burstable and the default retention of 7, and a non-default
+// retention must survive create->get so a terraform plan reports no drift on
+// sku_name / backup_retention_days.
+func TestSDKMySQLFlexSkuTierDefaultAndBackup(t *testing.T) {
+	servers := newSDKClient(t)
+	ctx := context.Background()
+
+	// No SKU at all: defaults to Standard_B1ms / Burstable, backup 7.
+	poller, err := servers.BeginCreate(ctx, "rg-1", "def1", armmysqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	got, err := servers.Get(ctx, "rg-1", "def1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Server.SKU == nil || got.Server.SKU.Tier == nil ||
+		*got.Server.SKU.Tier != armmysqlflexibleservers.SKUTierBurstable {
+		t.Fatalf("expected default tier Burstable, got %+v", got.Server.SKU)
+	}
+
+	if got.Server.Properties.Backup == nil || got.Server.Properties.Backup.BackupRetentionDays == nil ||
+		*got.Server.Properties.Backup.BackupRetentionDays != 7 {
+		t.Fatalf("expected default backupRetentionDays 7, got %+v", got.Server.Properties.Backup)
+	}
+
+	// The synthetic FQDN must be the real <name>.mysql.database.azure.com shape.
+	if got.Server.Properties.FullyQualifiedDomainName == nil ||
+		*got.Server.Properties.FullyQualifiedDomainName != "def1.mysql.database.azure.com" {
+		t.Fatalf("expected fqdn def1.mysql.database.azure.com, got %v",
+			got.Server.Properties.FullyQualifiedDomainName)
+	}
+
+	// A configured non-default retention must round-trip unchanged.
+	poller2, err := servers.BeginCreate(ctx, "rg-1", "bk1", armmysqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+		Properties: &armmysqlflexibleservers.ServerProperties{
+			Backup: &armmysqlflexibleservers.Backup{
+				BackupRetentionDays: to.Ptr(int32(21)),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate(bk1): %v", err)
+	}
+
+	if _, err := poller2.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("PollUntilDone(bk1): %v", err)
+	}
+
+	gotBk, err := servers.Get(ctx, "rg-1", "bk1", nil)
+	if err != nil {
+		t.Fatalf("Get(bk1): %v", err)
+	}
+
+	if gotBk.Server.Properties.Backup == nil || gotBk.Server.Properties.Backup.BackupRetentionDays == nil ||
+		*gotBk.Server.Properties.Backup.BackupRetentionDays != 21 {
+		t.Fatalf("expected backupRetentionDays 21, got %+v", gotBk.Server.Properties.Backup)
 	}
 }
 

--- a/server/azure/mysqlflex/types.go
+++ b/server/azure/mysqlflex/types.go
@@ -38,6 +38,7 @@ type armServerProps struct {
 	State                      string               `json:"state,omitempty"`
 	FullyQualifiedDomainName   string               `json:"fullyQualifiedDomainName,omitempty"`
 	Storage                    *armStorage          `json:"storage,omitempty"`
+	Backup                     *armBackup           `json:"backup,omitempty"`
 	AvailabilityZone           string               `json:"availabilityZone,omitempty"`
 	HighAvailability           *armHighAvailability `json:"highAvailability,omitempty"`
 }
@@ -68,6 +69,15 @@ type armStorage struct {
 	Iops          int    `json:"iops,omitempty"`
 }
 
+// armBackup mirrors properties.backup on a MySQL Flexible Server. Real Azure
+// always returns this block; backupRetentionDays defaults to 7 (range 1-35) and
+// geoRedundantBackup is Disabled/Enabled. geoRedundantBackup is preserved by the
+// generic unmodeled-property overlay, so only the retention days — which real
+// Azure defaults and which terraform-provider-azurerm reads back — is modeled.
+type armBackup struct {
+	BackupRetentionDays int `json:"backupRetentionDays,omitempty"`
+}
+
 // armList is the ARM list-response envelope.
 type armList[T any] struct {
 	Value    []T    `json:"value"`
@@ -76,6 +86,23 @@ type armList[T any] struct {
 
 // toARMServer converts a portable Instance to ARM JSON.
 func toARMServer(inst *rdsdriver.Instance, subscription, resourceGroup string) armServer {
+	props := &armServerProps{
+		AdministratorLogin:       inst.MasterUsername,
+		Version:                  inst.EngineVersion,
+		State:                    serverState(inst.State),
+		FullyQualifiedDomainName: inst.Endpoint,
+		AvailabilityZone:         inst.AvailabilityZone,
+		HighAvailability:         highAvailability(inst),
+		Storage: &armStorage{
+			StorageSizeGB: inst.AllocatedStorage,
+			StorageSKU:    inst.StorageType,
+		},
+	}
+
+	if inst.BackupRetentionPeriod > 0 {
+		props.Backup = &armBackup{BackupRetentionDays: inst.BackupRetentionPeriod}
+	}
+
 	return armServer{
 		ID:       armServerID(subscription, resourceGroup, inst.ID),
 		Name:     inst.ID,
@@ -84,19 +111,9 @@ func toARMServer(inst *rdsdriver.Instance, subscription, resourceGroup string) a
 		Tags:     inst.Tags,
 		SKU: &armSKU{
 			Name: inst.InstanceClass,
+			Tier: inst.SKUTier,
 		},
-		Properties: &armServerProps{
-			AdministratorLogin:       inst.MasterUsername,
-			Version:                  inst.EngineVersion,
-			State:                    serverState(inst.State),
-			FullyQualifiedDomainName: inst.Endpoint,
-			AvailabilityZone:         inst.AvailabilityZone,
-			HighAvailability:         highAvailability(inst),
-			Storage: &armStorage{
-				StorageSizeGB: inst.AllocatedStorage,
-				StorageSKU:    inst.StorageType,
-			},
-		},
+		Properties: props,
 	}
 }
 


### PR DESCRIPTION
Mirrors #1159 (PostgreSQL Flexible Server) for **Microsoft.DBforMySQL/flexibleServers**.

### Feature
- `sku.tier` now round-trips on MySQL Flexible Servers. It is a **top-level ARM field**, so the generic unmodeled-property overlay (which only covers `properties.*`) could never reach it — the tier was silently dropped on read and only `sku.name` was echoed. terraform-provider-azurerm's `flattenFlexibleServerSku` returns an empty `sku_name` when `sku.tier` is missing, causing `azurerm_mysql_flexible_server` to perma-drift on every `terraform plan`. The tier is now persisted and echoed, defaulting to **Burstable** to pair with the default `Standard_B1ms` compute.
- `properties.backup.backupRetentionDays` was also gapped (not modeled). Real Azure always returns this block; it now defaults to **7** (range 1-35) and round-trips a caller-supplied value, so `backup_retention_days` reads back correctly.

### Enhancement
- Reuses the `SKUTier` driver field already added to `services/relationaldb/driver` in #1159 (no re-add).
- Tier and backup default on create, round-trip on GET/List, and are preserved on PATCH when the request omits them ("empty means no change"); tier also flows through restore-from-snapshot.
- SDK round-trip regression tests assert the configured GeneralPurpose tier + custom retention and the Burstable/7 defaults, plus the `<name>.mysql.database.azure.com` FQDN.
