### PR TITLE
fix(cloudsql): real-user e2e divergences from GCP Cloud SQL

### DIFF
--- a/providers/gcp/cloudsql/cloudsql.go
+++ b/providers/gcp/cloudsql/cloudsql.go
@@ -319,6 +319,7 @@ func (m *Mock) newInstance(cfg rdsdriver.InstanceConfig) rdsdriver.Instance {
 		GCPDatabaseFlags:     cfg.GCPDatabaseFlags,
 		GCPBackupConfig:      cfg.GCPBackupConfig,
 		GCPIPConfig:          cfg.GCPIPConfig,
+		GCPSettingsExtra:     cfg.GCPSettingsExtra,
 		GCPStorageAutoResize: autoResize,
 	}
 }
@@ -486,6 +487,10 @@ func applyGCPSettings(inst *rdsdriver.Instance, input *rdsdriver.ModifyInstanceI
 
 	if input.GCPIPConfig != "" {
 		inst.GCPIPConfig = input.GCPIPConfig
+	}
+
+	if input.GCPSettingsExtra != "" {
+		inst.GCPSettingsExtra = input.GCPSettingsExtra
 	}
 
 	if input.GCPStorageAutoResize != nil {

--- a/providers/gcp/cloudsql/cloudsql.go
+++ b/providers/gcp/cloudsql/cloudsql.go
@@ -10,6 +10,7 @@ package cloudsql
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -490,12 +491,49 @@ func applyGCPSettings(inst *rdsdriver.Instance, input *rdsdriver.ModifyInstanceI
 	}
 
 	if input.GCPSettingsExtra != "" {
-		inst.GCPSettingsExtra = input.GCPSettingsExtra
+		if input.GCPSettingsExtraMerge {
+			inst.GCPSettingsExtra = mergeSettingsExtra(inst.GCPSettingsExtra, input.GCPSettingsExtra)
+		} else {
+			inst.GCPSettingsExtra = input.GCPSettingsExtra
+		}
 	}
 
 	if input.GCPStorageAutoResize != nil {
 		inst.GCPStorageAutoResize = *input.GCPStorageAutoResize
 	}
+}
+
+// mergeSettingsExtra overlays the incoming Cloud SQL settings extra-blob onto the
+// stored one so a PATCH naming one unmodeled sub-field leaves the siblings it
+// omits intact (incoming keys win per-key). Both blobs are already stripped of
+// modeled and server-managed keys by the wire layer, so no such key is
+// reintroduced. The result is serialized with sorted keys (json.Marshal of a
+// map) for determinism; a missing stored blob or a malformed blob falls back to
+// the incoming value.
+func mergeSettingsExtra(stored, incoming string) string {
+	if stored == "" {
+		return incoming
+	}
+
+	var base, patch map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stored), &base); err != nil {
+		return incoming
+	}
+
+	if err := json.Unmarshal([]byte(incoming), &patch); err != nil {
+		return incoming
+	}
+
+	for k, v := range patch {
+		base[k] = v
+	}
+
+	out, err := json.Marshal(base)
+	if err != nil {
+		return incoming
+	}
+
+	return string(out)
 }
 
 // DeleteInstance removes an instance, unlinks it from any replica relationship,

--- a/server/gcp/cloudsql/operations.go
+++ b/server/gcp/cloudsql/operations.go
@@ -91,6 +91,9 @@ func modifyInputFromBody(body *sqlInstance, replace bool) rdsdriver.ModifyInstan
 	input.GCPBackupConfig = string(s.BackupConfiguration)
 	input.GCPIPConfig = string(s.IPConfiguration)
 	input.GCPSettingsExtra = settingsExtraJSON(s)
+	// A PATCH merges the named extra sub-fields onto the stored blob (siblings
+	// survive); a PUT wholesale replaces it.
+	input.GCPSettingsExtraMerge = !replace
 
 	applyModifySettings(&input, s, replace)
 

--- a/server/gcp/cloudsql/operations.go
+++ b/server/gcp/cloudsql/operations.go
@@ -54,6 +54,7 @@ func instanceFromBody(body *sqlInstance) rdsdriver.InstanceConfig {
 		cfg.GCPDatabaseFlags = string(s.DatabaseFlags)
 		cfg.GCPBackupConfig = string(s.BackupConfiguration)
 		cfg.GCPIPConfig = string(s.IPConfiguration)
+		cfg.GCPSettingsExtra = settingsExtraJSON(s)
 		// A nil StorageAutoResize is carried through so the provider applies the
 		// Cloud SQL default (true) rather than false.
 		cfg.GCPStorageAutoResize = s.StorageAutoResize
@@ -89,6 +90,7 @@ func modifyInputFromBody(body *sqlInstance, replace bool) rdsdriver.ModifyInstan
 	input.GCPDatabaseFlags = string(s.DatabaseFlags)
 	input.GCPBackupConfig = string(s.BackupConfiguration)
 	input.GCPIPConfig = string(s.IPConfiguration)
+	input.GCPSettingsExtra = settingsExtraJSON(s)
 
 	applyModifySettings(&input, s, replace)
 

--- a/server/gcp/cloudsql/settings_sdk_test.go
+++ b/server/gcp/cloudsql/settings_sdk_test.go
@@ -71,6 +71,78 @@ func TestSDKCloudSQLSettingsRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSDKCloudSQLUnmodeledSettingsRoundTrip reproduces the Terraform
+// perpetual-drift bug where settings sub-fields the wire layer does not model
+// explicitly — maintenanceWindow, insightsConfig, locationPreference and the
+// scalar connectorEnforcement — were silently dropped on Insert, so every
+// `terraform plan` after apply proposed re-adding them. They must all survive
+// the Insert->Get round-trip, and a Patch of one must be reflected on the
+// following Get.
+func TestSDKCloudSQLUnmodeledSettingsRoundTrip(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := svc.Instances.Insert(project, &sqladmin.DatabaseInstance{
+		Name:            "extras",
+		DatabaseVersion: "POSTGRES_15",
+		Region:          "us-central1",
+		Settings: &sqladmin.Settings{
+			Tier:                 "db-custom-2-8192",
+			ConnectorEnforcement: "NOT_REQUIRED",
+			MaintenanceWindow:    &sqladmin.MaintenanceWindow{Day: 7, Hour: 3, UpdateTrack: "stable"},
+			InsightsConfig: &sqladmin.InsightsConfig{
+				QueryInsightsEnabled: true,
+				QueryStringLength:    1024,
+			},
+			LocationPreference: &sqladmin.LocationPreference{Zone: "us-central1-a"},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Instances.Insert: %v", err)
+	}
+
+	got, err := svc.Instances.Get(project, "extras").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Instances.Get: %v", err)
+	}
+
+	if got.Settings.ConnectorEnforcement != "NOT_REQUIRED" {
+		t.Fatalf("connectorEnforcement = %q, want NOT_REQUIRED", got.Settings.ConnectorEnforcement)
+	}
+
+	if got.Settings.MaintenanceWindow == nil || got.Settings.MaintenanceWindow.Day != 7 ||
+		got.Settings.MaintenanceWindow.Hour != 3 || got.Settings.MaintenanceWindow.UpdateTrack != "stable" {
+		t.Fatalf("maintenanceWindow = %+v, want day=7 hour=3 stable", got.Settings.MaintenanceWindow)
+	}
+
+	if got.Settings.InsightsConfig == nil || !got.Settings.InsightsConfig.QueryInsightsEnabled ||
+		got.Settings.InsightsConfig.QueryStringLength != 1024 {
+		t.Fatalf("insightsConfig = %+v, want enabled queryStringLength=1024", got.Settings.InsightsConfig)
+	}
+
+	if got.Settings.LocationPreference == nil || got.Settings.LocationPreference.Zone != "us-central1-a" {
+		t.Fatalf("locationPreference = %+v, want zone=us-central1-a", got.Settings.LocationPreference)
+	}
+
+	// A Patch of the maintenance window must be reflected on the next Get.
+	if _, err := svc.Instances.Patch(project, "extras", &sqladmin.DatabaseInstance{
+		Settings: &sqladmin.Settings{
+			MaintenanceWindow: &sqladmin.MaintenanceWindow{Day: 1, Hour: 5, UpdateTrack: "canary"},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	patched, err := svc.Instances.Get(project, "extras").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get (after patch): %v", err)
+	}
+
+	if patched.Settings.MaintenanceWindow == nil || patched.Settings.MaintenanceWindow.Day != 1 ||
+		patched.Settings.MaintenanceWindow.Hour != 5 || patched.Settings.MaintenanceWindow.UpdateTrack != "canary" {
+		t.Fatalf("after patch maintenanceWindow = %+v, want day=1 hour=5 canary", patched.Settings.MaintenanceWindow)
+	}
+}
+
 // TestSDKCloudSQLPatchSettings verifies that a Patch of availabilityType and
 // databaseFlags is reflected on the following Get (default is ZONAL).
 func TestSDKCloudSQLPatchSettings(t *testing.T) {

--- a/server/gcp/cloudsql/settings_sdk_test.go
+++ b/server/gcp/cloudsql/settings_sdk_test.go
@@ -141,6 +141,68 @@ func TestSDKCloudSQLUnmodeledSettingsRoundTrip(t *testing.T) {
 		patched.Settings.MaintenanceWindow.Hour != 5 || patched.Settings.MaintenanceWindow.UpdateTrack != "canary" {
 		t.Fatalf("after patch maintenanceWindow = %+v, want day=1 hour=5 canary", patched.Settings.MaintenanceWindow)
 	}
+
+	// A PATCH of one unmodeled sub-field must MERGE, not replace: the siblings
+	// (insightsConfig, locationPreference) not named in the patch body must
+	// survive unchanged.
+	if patched.Settings.InsightsConfig == nil || !patched.Settings.InsightsConfig.QueryInsightsEnabled ||
+		patched.Settings.InsightsConfig.QueryStringLength != 1024 {
+		t.Fatalf("after patch insightsConfig = %+v, want preserved enabled queryStringLength=1024",
+			patched.Settings.InsightsConfig)
+	}
+
+	if patched.Settings.LocationPreference == nil || patched.Settings.LocationPreference.Zone != "us-central1-a" {
+		t.Fatalf("after patch locationPreference = %+v, want preserved zone=us-central1-a",
+			patched.Settings.LocationPreference)
+	}
+}
+
+// TestSDKCloudSQLUpdateReplacesUnmodeledSettings verifies PUT (Instances.Update)
+// full-replace semantics for the unmodeled settings blob: a PUT that names one
+// unmodeled sub-field drops the previously-set siblings it omits (unlike PATCH,
+// which merges).
+func TestSDKCloudSQLUpdateReplacesUnmodeledSettings(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := svc.Instances.Insert(project, &sqladmin.DatabaseInstance{
+		Name:            "putextras",
+		DatabaseVersion: "POSTGRES_15",
+		Region:          "us-central1",
+		Settings: &sqladmin.Settings{
+			Tier:               "db-custom-2-8192",
+			InsightsConfig:     &sqladmin.InsightsConfig{QueryInsightsEnabled: true, QueryStringLength: 1024},
+			LocationPreference: &sqladmin.LocationPreference{Zone: "us-central1-a"},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Instances.Insert: %v", err)
+	}
+
+	// PUT naming only insightsConfig drops the omitted locationPreference.
+	if _, err := svc.Instances.Update(project, "putextras", &sqladmin.DatabaseInstance{
+		DatabaseVersion: "POSTGRES_15",
+		Region:          "us-central1",
+		Settings: &sqladmin.Settings{
+			Tier:           "db-custom-2-8192",
+			InsightsConfig: &sqladmin.InsightsConfig{QueryInsightsEnabled: true, QueryStringLength: 2048},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Instances.Update (PUT): %v", err)
+	}
+
+	got, err := svc.Instances.Get(project, "putextras").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get (after update): %v", err)
+	}
+
+	if got.Settings.InsightsConfig == nil || got.Settings.InsightsConfig.QueryStringLength != 2048 {
+		t.Fatalf("after PUT insightsConfig = %+v, want queryStringLength=2048", got.Settings.InsightsConfig)
+	}
+
+	if got.Settings.LocationPreference != nil {
+		t.Fatalf("after PUT locationPreference = %+v, want nil (dropped by replace)",
+			got.Settings.LocationPreference)
+	}
 }
 
 // TestSDKCloudSQLPatchSettings verifies that a Patch of availabilityType and

--- a/server/gcp/cloudsql/types.go
+++ b/server/gcp/cloudsql/types.go
@@ -111,6 +111,88 @@ type sqlSettings struct {
 	DatabaseFlags       json.RawMessage `json:"databaseFlags,omitempty"`
 	BackupConfiguration json.RawMessage `json:"backupConfiguration,omitempty"`
 	IPConfiguration     json.RawMessage `json:"ipConfiguration,omitempty"`
+	// extra holds every other settings sub-field the wire type does not model
+	// explicitly (maintenanceWindow, insightsConfig, locationPreference,
+	// connectorEnforcement, passwordValidationPolicy, …). It is populated by
+	// UnmarshalJSON from an inbound request and re-inlined by MarshalJSON on a Get
+	// so those fields round-trip instead of being silently dropped — a perpetual
+	// Terraform drift source. It carries no json tag: the (Un)marshalers handle it.
+	extra map[string]json.RawMessage
+}
+
+// isModeledSettingsKey reports whether a settings JSON key is one this wire type
+// models with a typed field (and therefore must NOT be captured into extra).
+// settingsVersion and kind are stripped too: they are server-managed, so echoing
+// a client-supplied value would be wrong.
+func isModeledSettingsKey(k string) bool {
+	switch k {
+	case "tier", "activationPolicy", "dataDiskSizeGb", "dataDiskType",
+		"availabilityType", "pricingPlan", "userLabels", "storageAutoResize",
+		"deletionProtectionEnabled", "databaseFlags", "backupConfiguration",
+		"ipConfiguration", "settingsVersion", "kind":
+		return true
+	default:
+		return false
+	}
+}
+
+// MarshalJSON emits the typed settings fields and re-inlines every unmodeled
+// sub-field captured in extra, so fields like maintenanceWindow round-trip on a
+// Get. Typed fields win over an extra of the same name.
+func (s *sqlSettings) MarshalJSON() ([]byte, error) {
+	type alias sqlSettings // new type, no methods — avoids recursion
+
+	b, err := json.Marshal(alias(*s))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(s.extra) == 0 {
+		return b, nil
+	}
+
+	var merged map[string]json.RawMessage
+	if err := json.Unmarshal(b, &merged); err != nil {
+		return nil, err
+	}
+
+	for k, v := range s.extra {
+		if _, ok := merged[k]; !ok {
+			merged[k] = v
+		}
+	}
+
+	return json.Marshal(merged)
+}
+
+// UnmarshalJSON decodes the typed settings fields and captures every other
+// (unmodeled) sub-field into extra so it can round-trip on a later Get.
+func (s *sqlSettings) UnmarshalJSON(b []byte) error {
+	type alias sqlSettings
+
+	var a alias
+	if err := json.Unmarshal(b, &a); err != nil {
+		return err
+	}
+
+	*s = sqlSettings(a)
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+
+	for k := range raw {
+		if isModeledSettingsKey(k) {
+			delete(raw, k)
+		}
+	}
+
+	if len(raw) > 0 {
+		s.extra = raw
+	}
+
+	return nil
 }
 
 type ipMapping struct {
@@ -237,6 +319,7 @@ func toSQLInstance(inst *rdsdriver.Instance, project string) sqlInstance {
 			DatabaseFlags:             rawJSONOrNil(inst.GCPDatabaseFlags),
 			BackupConfiguration:       rawJSONOrNil(inst.GCPBackupConfig),
 			IPConfiguration:           rawJSONOrNil(inst.GCPIPConfig),
+			extra:                     settingsExtraMap(inst.GCPSettingsExtra),
 		},
 		ServerCaCert: serverCaCertFor(inst),
 		CreateTime:   inst.CreatedAt.UTC().Format(rfc3339Milli),
@@ -288,6 +371,38 @@ func rawJSONOrNil(s string) json.RawMessage {
 	}
 
 	return json.RawMessage(s)
+}
+
+// settingsExtraMap decodes the stored extra-settings JSON object back into the
+// map sqlSettings.MarshalJSON re-inlines. A malformed or empty value yields nil
+// so no extra fields are emitted.
+func settingsExtraMap(s string) map[string]json.RawMessage {
+	if s == "" {
+		return nil
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(s), &m); err != nil || len(m) == 0 {
+		return nil
+	}
+
+	return m
+}
+
+// settingsExtraJSON serializes a settings' captured extra sub-fields back to a
+// JSON object string for storage on the driver. It returns "" when there are
+// none, matching the "no change / omit" convention of the other GCP* blobs.
+func settingsExtraJSON(s *sqlSettings) string {
+	if s == nil || len(s.extra) == 0 {
+		return ""
+	}
+
+	b, err := json.Marshal(s.extra)
+	if err != nil {
+		return ""
+	}
+
+	return string(b)
 }
 
 // serverCaCertFor builds the synthetic server CA certificate Cloud SQL reports

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -143,6 +143,12 @@ type InstanceConfig struct {
 	GCPDatabaseFlags string
 	GCPBackupConfig  string
 	GCPIPConfig      string
+	// GCPSettingsExtra carries every other Cloud SQL settings sub-field the wire
+	// layer does not model explicitly (maintenanceWindow, insightsConfig,
+	// locationPreference, connectorEnforcement, passwordValidationPolicy, …) as one
+	// opaque JSON object, so they all round-trip on Insert->Get without the wire
+	// layer modeling each. Cloud SQL-only; AWS RDS / Redshift never set it.
+	GCPSettingsExtra string
 	// GCPStorageAutoResize is the Cloud SQL settings.storageAutoResize flag, which
 	// defaults to true on a real instance. A pointer so an omitted field means
 	// "use the default" (true) rather than false; Cloud SQL-only, ignored by
@@ -229,6 +235,11 @@ type Instance struct {
 	GCPDatabaseFlags string
 	GCPBackupConfig  string
 	GCPIPConfig      string
+	// GCPSettingsExtra echoes every other Cloud SQL settings sub-field the wire
+	// layer does not model explicitly (maintenanceWindow, insightsConfig,
+	// locationPreference, connectorEnforcement, …) as one opaque JSON object so
+	// they round-trip on read. Empty for AWS RDS / Redshift.
+	GCPSettingsExtra string
 	// GCPStorageAutoResize echoes the Cloud SQL settings.storageAutoResize flag on
 	// read. It is resolved to a concrete value on create (defaulting to true),
 	// so a Get always reports it. False/unused for AWS RDS / Redshift.
@@ -294,6 +305,11 @@ type ModifyInstanceInput struct {
 	GCPDatabaseFlags string
 	GCPBackupConfig  string
 	GCPIPConfig      string
+	// GCPSettingsExtra updates the opaque JSON object of Cloud SQL settings
+	// sub-fields the wire layer does not model explicitly (maintenanceWindow,
+	// insightsConfig, locationPreference, connectorEnforcement, …); empty means
+	// "no change". Cloud SQL-only; RDS/Redshift ignore it.
+	GCPSettingsExtra string
 	// GCPStorageAutoResize updates the Cloud SQL settings.storageAutoResize flag; a
 	// nil pointer means "no change". Cloud SQL-only; RDS/Redshift ignore it.
 	GCPStorageAutoResize *bool

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -310,6 +310,11 @@ type ModifyInstanceInput struct {
 	// insightsConfig, locationPreference, connectorEnforcement, …); empty means
 	// "no change". Cloud SQL-only; RDS/Redshift ignore it.
 	GCPSettingsExtra string
+	// GCPSettingsExtraMerge selects how GCPSettingsExtra is applied. On a PATCH
+	// (merge=true) the incoming sub-fields are overlaid per-key onto the stored
+	// blob so siblings the patch does not name survive; on a PUT (merge=false)
+	// GCPSettingsExtra wholesale replaces the stored blob (omitted keys drop).
+	GCPSettingsExtraMerge bool
 	// GCPStorageAutoResize updates the Cloud SQL settings.storageAutoResize flag; a
 	// nil pointer means "no change". Cloud SQL-only; RDS/Redshift ignore it.
 	GCPStorageAutoResize *bool


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of GCP Cloud SQL (`google_sql_database_instance`) driven with the real `sqladmin` SDK and Terraform against `cloudemu serve`. The full lifecycle (create → LRO DONE → RUNNABLE → get → update → destroy) was already correct, with clean `connectionName`, `selfLink`, `ipAddresses` and the common settings round-trip. This PR fixes one genuine divergence found during the sweep.

## Divergence fixed: settings sub-fields silently dropped → perpetual Terraform drift

The Cloud SQL wire layer modeled only a handful of `settings` sub-fields explicitly (`tier`, `dataDiskSizeGb`, `databaseFlags`, `backupConfiguration`, `ipConfiguration`, …) and **silently dropped every other sub-field** on insert/patch. A real user who set any of these hit a perpetual `terraform plan` diff after `apply`:

- `settings.maintenanceWindow`
- `settings.insightsConfig`
- `settings.locationPreference`
- `settings.connectorEnforcement`
- (and any other unmodeled sub-field, e.g. `passwordValidationPolicy`, `dataCacheConfig`)

### Fix

Mirror the existing opaque-blob pattern with a single catch-all passthrough. `sqlSettings` gains custom `(Un)marshalJSON` that captures every settings key it does not model into an `extra` map on insert/patch and re-inlines it on Get, persisted through a new `GCPSettingsExtra` field on the shared relationaldb driver (Cloud SQL-only; ignored by RDS/Azure). Server-managed keys (`settingsVersion`, `kind`) are stripped so no stale client value is echoed. This fixes all current and future settings round-trip drift, not just the four proven cases.

## Live evidence (Terraform + serve on :16620)

Before: `terraform plan` after `apply` proposed re-adding `maintenance_window`, `insights_config`, `location_preference`, `connector_enforcement` on every run.

After:
- `terraform apply` → instance + database + user created, insert LRO reaches `DONE`, state `RUNNABLE`
- `connection_name = test-proj:us-central1:orders-db`, `self_link` correct, `public_ip` present
- `terraform plan` after apply → **No changes** (zero drift) with the full settings block
- `terraform apply` update (tier, disk, database_flags, maintenance_window) → applied, then `plan` → **No changes**
- `terraform destroy` → all 3 resources destroyed, delete LRO `DONE`

## Tests

Added `TestSDKCloudSQLUnmodeledSettingsRoundTrip` (real `sqladmin` SDK): insert + patch of `maintenanceWindow`/`insightsConfig`/`locationPreference`/`connectorEnforcement` must survive the Get round-trip.

## Gates

`go build ./...`, `go vet`, `gofmt -l`, scoped `go test -race` (server/gcp/cloudsql, providers/gcp/cloudsql), broader relationaldb + persist tests, root integration test, and `golangci-lint --new-from-rev=origin/development` all green. `go generate ./...` produced no docs/coverage change (field addition, no new capability).