### PR TITLE
fix(elbv2): real-user e2e divergences from AWS ELBv2

### DIFF
--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -356,7 +356,7 @@ func (m *Mock) CreateTargetGroup(_ context.Context, cfg driver.TargetGroupConfig
 		targetType = "instance"
 	}
 
-	hc := defaultHealthCheck(cfg)
+	hc := defaultHealthCheck(cfg, targetType)
 
 	tg := driver.TargetGroupInfo{
 		ID:          id,
@@ -387,13 +387,30 @@ func (m *Mock) CreateTargetGroup(_ context.Context, cfg driver.TargetGroupConfig
 // unset.
 const (
 	defaultHCIntervalSec   = 30
-	defaultHCTimeoutSec    = 5
 	defaultHCHealthyCount  = 5
 	defaultHCUnhealthyCoun = 2
 	defaultHCMatcher       = "200"
 	defaultHCPort          = "traffic-port"
 	defaultHCPath          = "/"
 	protocolHTTP           = "HTTP"
+
+	// Health-check timeout defaults ELBv2 applies per target-group protocol and
+	// target type (CreateTargetGroup API reference, HealthCheckTimeoutSeconds).
+	// HTTP is 6, HTTPS/TCP/TLS (and the other TCP-family protocols, whose health
+	// check runs over TCP) is 10, GENEVE is 5, and a lambda target group is 30.
+	timeoutHTTPSec   = 6
+	timeoutTCPSec    = 10
+	timeoutGENEVESec = 5
+	timeoutLambdaSec = 30
+
+	// Health-check defaults specific to a lambda target group (CreateTargetGroup
+	// API reference): the interval defaults to 35 (not 30), and both threshold
+	// counts default to 5. A lambda target group carries no health-check protocol,
+	// port, or path — health checks are disabled by default — so those are left
+	// unset rather than defaulted the way an instance/ip group's are.
+	intervalLambdaSec = 35
+	thresholdLambda   = 5
+	targetTypeLambda  = "lambda"
 )
 
 // isHTTPProtocol reports whether p is an HTTP-family protocol (which carries a
@@ -418,11 +435,37 @@ func defaultHealthCheckProtocol(tgProtocol string) string {
 	return "TCP"
 }
 
+// defaultHealthCheckTimeout reports the HealthCheckTimeoutSeconds ELBv2 defaults
+// to for a target group of the given protocol and target type. Per the
+// CreateTargetGroup API reference: a lambda target group defaults to 30; among
+// the rest, an HTTP target group defaults to 6, a GENEVE (Gateway Load Balancer)
+// target group to 5, and every other protocol — HTTPS, TCP, TLS, UDP, TCP_UDP,
+// QUIC, TCP_QUIC, whose health check runs over TCP — to 10. The prior flat 5
+// under-reported the timeout real AWS returns for every non-GENEVE protocol.
+func defaultHealthCheckTimeout(tgProtocol, targetType string) int {
+	if targetType == targetTypeLambda {
+		return timeoutLambdaSec
+	}
+
+	switch tgProtocol {
+	case protocolHTTP:
+		return timeoutHTTPSec
+	case "GENEVE":
+		return timeoutGENEVESec
+	default:
+		return timeoutTCPSec
+	}
+}
+
 // defaultHealthCheck fills a target group's health-check settings, applying the
 // ELBv2 protocol-derived defaults for any field the caller left unset.
 //
 //nolint:gocritic // hugeParam: called once per create, copy cost is irrelevant.
-func defaultHealthCheck(cfg driver.TargetGroupConfig) driver.HealthCheck {
+func defaultHealthCheck(cfg driver.TargetGroupConfig, targetType string) driver.HealthCheck {
+	if targetType == targetTypeLambda {
+		return defaultLambdaHealthCheck(cfg.HealthCheck)
+	}
+
 	hc := cfg.HealthCheck
 
 	if hc.Protocol == "" {
@@ -433,19 +476,43 @@ func defaultHealthCheck(cfg driver.TargetGroupConfig) driver.HealthCheck {
 		hc.Port = defaultHCPort
 	}
 
-	if hc.Path == "" && isHTTPProtocol(hc.Protocol) {
-		hc.Path = cfg.HealthPath
+	applyHTTPHealthCheckDefaults(&hc, cfg.HealthPath)
+	applyHealthCheckNumericDefaults(&hc, defaultHealthCheckTimeout(cfg.Protocol, targetType))
+
+	return hc
+}
+
+// applyHTTPHealthCheckDefaults fills the path and matcher an HTTP/HTTPS health
+// check defaults to (ping path "/", success code "200"); a non-HTTP health
+// check carries neither, so it is left untouched.
+func applyHTTPHealthCheckDefaults(hc *driver.HealthCheck, configuredPath string) {
+	if !isHTTPProtocol(hc.Protocol) {
+		return
+	}
+
+	if hc.Path == "" {
+		hc.Path = configuredPath
 		if hc.Path == "" {
 			hc.Path = defaultHCPath
 		}
 	}
 
+	if hc.Matcher == "" {
+		hc.Matcher = defaultHCMatcher
+	}
+}
+
+// applyHealthCheckNumericDefaults fills the interval, timeout, and threshold
+// counts a health check defaults to when the caller left them unset. timeout is
+// passed in because its default depends on the target group's protocol and
+// target type (see defaultHealthCheckTimeout).
+func applyHealthCheckNumericDefaults(hc *driver.HealthCheck, timeout int) {
 	if hc.IntervalSeconds == 0 {
 		hc.IntervalSeconds = defaultHCIntervalSec
 	}
 
 	if hc.TimeoutSeconds == 0 {
-		hc.TimeoutSeconds = defaultHCTimeoutSec
+		hc.TimeoutSeconds = timeout
 	}
 
 	if hc.HealthyThreshold == 0 {
@@ -455,9 +522,32 @@ func defaultHealthCheck(cfg driver.TargetGroupConfig) driver.HealthCheck {
 	if hc.UnhealthyThreshold == 0 {
 		hc.UnhealthyThreshold = defaultHCUnhealthyCoun
 	}
+}
 
-	if hc.Matcher == "" && isHTTPProtocol(hc.Protocol) {
-		hc.Matcher = defaultHCMatcher
+// defaultLambdaHealthCheck fills the health-check defaults for a lambda target
+// group. Unlike an instance/ip group, a lambda group defaults with health checks
+// disabled and so carries no protocol, port, or path — real ELBv2 returns none,
+// and returning a protocol makes Terraform reject the group with "health_check
+// .protocol cannot be specified when target_type is lambda". Only the numeric
+// defaults (interval 35, timeout 30, both thresholds 5) are applied; an
+// explicitly supplied field is preserved.
+//
+//nolint:gocritic // hugeParam: called once per create, copy cost is irrelevant.
+func defaultLambdaHealthCheck(hc driver.HealthCheck) driver.HealthCheck {
+	if hc.IntervalSeconds == 0 {
+		hc.IntervalSeconds = intervalLambdaSec
+	}
+
+	if hc.TimeoutSeconds == 0 {
+		hc.TimeoutSeconds = timeoutLambdaSec
+	}
+
+	if hc.HealthyThreshold == 0 {
+		hc.HealthyThreshold = thresholdLambda
+	}
+
+	if hc.UnhealthyThreshold == 0 {
+		hc.UnhealthyThreshold = thresholdLambda
 	}
 
 	return hc

--- a/providers/aws/elbv2/health_check_defaults_test.go
+++ b/providers/aws/elbv2/health_check_defaults_test.go
@@ -70,3 +70,71 @@ func TestDefaultHealthCheckProtocolExplicitOverride(t *testing.T) {
 
 	assertEqual(t, "HTTPS", tg.HealthCheck.Protocol)
 }
+
+// TestDefaultHealthCheckTimeoutByProtocol proves HealthCheckTimeoutSeconds
+// defaults per the CreateTargetGroup API reference: HTTP is 6, HTTPS/TCP/TLS
+// (and the other TCP-family protocols) are 10, and GENEVE is 5. The prior flat
+// 5 under-reported the timeout real AWS returns for every non-GENEVE protocol.
+func TestDefaultHealthCheckTimeoutByProtocol(t *testing.T) {
+	cases := []struct {
+		protocol string
+		want     int
+	}{
+		{"HTTP", 6},
+		{"HTTPS", 10},
+		{"TCP", 10},
+		{"TLS", 10},
+		{"UDP", 10},
+		{"TCP_UDP", 10},
+	}
+
+	for _, c := range cases {
+		m := newTestMock()
+
+		tg, err := m.CreateTargetGroup(context.Background(), driver.TargetGroupConfig{
+			Name: "to-tg-" + c.protocol, Protocol: c.protocol, Port: 80, TargetType: "instance",
+		})
+		requireNoError(t, err)
+
+		if tg.HealthCheck.TimeoutSeconds != c.want {
+			t.Errorf("protocol %s: timeout = %d, want %d", c.protocol, tg.HealthCheck.TimeoutSeconds, c.want)
+		}
+	}
+}
+
+// TestDefaultHealthCheckTimeoutExplicit proves an explicitly supplied timeout is
+// preserved rather than overwritten by the protocol default.
+func TestDefaultHealthCheckTimeoutExplicit(t *testing.T) {
+	m := newTestMock()
+
+	tg, err := m.CreateTargetGroup(context.Background(), driver.TargetGroupConfig{
+		Name: "to-explicit", Protocol: "TCP", Port: 80, TargetType: "instance",
+		HealthCheck: driver.HealthCheck{TimeoutSeconds: 8},
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, 8, tg.HealthCheck.TimeoutSeconds)
+}
+
+// TestDefaultHealthCheckLambda proves a lambda target group defaults with no
+// health-check protocol, port, or path (health checks are disabled by default),
+// and with the lambda-specific numeric defaults: interval 35, timeout 30, and
+// both threshold counts 5. Returning a protocol here made Terraform reject the
+// group with "health_check.protocol cannot be specified when target_type is
+// lambda".
+func TestDefaultHealthCheckLambda(t *testing.T) {
+	m := newTestMock()
+
+	tg, err := m.CreateTargetGroup(context.Background(), driver.TargetGroupConfig{
+		Name: "lambda-tg", TargetType: "lambda",
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "", tg.HealthCheck.Protocol)
+	assertEqual(t, "", tg.HealthCheck.Port)
+	assertEqual(t, "", tg.HealthCheck.Path)
+	assertEqual(t, 35, tg.HealthCheck.IntervalSeconds)
+	assertEqual(t, 30, tg.HealthCheck.TimeoutSeconds)
+	assertEqual(t, 5, tg.HealthCheck.HealthyThreshold)
+	assertEqual(t, 5, tg.HealthCheck.UnhealthyThreshold)
+}

--- a/server/aws/elbv2/error_message_sdk_test.go
+++ b/server/aws/elbv2/error_message_sdk_test.go
@@ -1,0 +1,84 @@
+package elbv2_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	"github.com/aws/smithy-go"
+)
+
+// apiError extracts the smithy API error, failing the test if err is not one.
+func apiError(t *testing.T, err error) smithy.APIError {
+	t.Helper()
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want API error, got %v", err)
+	}
+
+	return apiErr
+}
+
+// TestSDKErrorMessageHasNoCodePrefix proves the ELBv2 error <Message> carries
+// only the human-readable text, never the internal cloudemu error-taxonomy name
+// (e.g. "NotFound:" / "AlreadyExists:"). Real AWS never leaks such a prefix into
+// its message, and a user asserting on the message text — or simply reading it —
+// must not see one. The error Code still classifies the fault; only the Message
+// is checked here.
+func TestSDKErrorMessageHasNoCodePrefix(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	// NotFound path: describe a load balancer that does not exist.
+	_, err := client.DescribeLoadBalancers(ctx, &elb.DescribeLoadBalancersInput{
+		Names: []string{"does-not-exist"},
+	})
+	if err == nil {
+		t.Fatal("DescribeLoadBalancers: want error, got nil")
+	}
+
+	apiErr := apiError(t, err)
+	if apiErr.ErrorCode() != "LoadBalancerNotFound" {
+		t.Errorf("code = %q, want LoadBalancerNotFound", apiErr.ErrorCode())
+	}
+
+	assertNoCodePrefix(t, apiErr.ErrorMessage())
+
+	// AlreadyExists path: create a load balancer twice.
+	name := aws.String("dup-message-lb")
+	if _, err := client.CreateLoadBalancer(ctx, &elb.CreateLoadBalancerInput{
+		Name: name, Subnets: []string{"subnet-a"},
+	}); err != nil {
+		t.Fatalf("first CreateLoadBalancer: %v", err)
+	}
+
+	_, err = client.CreateLoadBalancer(ctx, &elb.CreateLoadBalancerInput{
+		Name: name, Subnets: []string{"subnet-a"},
+	})
+	if err == nil {
+		t.Fatal("second CreateLoadBalancer: want error, got nil")
+	}
+
+	dupErr := apiError(t, err)
+	if dupErr.ErrorCode() != "DuplicateLoadBalancerName" {
+		t.Errorf("code = %q, want DuplicateLoadBalancerName", dupErr.ErrorCode())
+	}
+
+	assertNoCodePrefix(t, dupErr.ErrorMessage())
+}
+
+// assertNoCodePrefix fails if msg begins with a canonical cloudemu error-code
+// prefix like "NotFound: " that err.Error() would prepend.
+func assertNoCodePrefix(t *testing.T, msg string) {
+	t.Helper()
+
+	for _, prefix := range []string{"NotFound:", "AlreadyExists:", "InvalidArgument:", "FailedPrecondition:"} {
+		if strings.HasPrefix(msg, prefix) {
+			t.Errorf("message %q leaks internal code prefix %q", msg, prefix)
+		}
+	}
+}

--- a/server/aws/elbv2/handler.go
+++ b/server/aws/elbv2/handler.go
@@ -188,19 +188,24 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// writeErr maps cloudemu errors to ELBv2 XML error responses.
+// writeErr maps cloudemu errors to ELBv2 XML error responses. The <Message> is
+// the human-readable text only: real AWS never leaks an internal error-taxonomy
+// name into it, so cerrors.Message strips the canonical code prefix that
+// err.Error() would otherwise prepend (e.g. "NotFound: load balancer ...").
 func writeErr(w http.ResponseWriter, err error) {
+	msg := cerrors.Message(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, notFoundCode(err), err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, notFoundCode(err), msg)
 	case cerrors.IsAlreadyExists(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, duplicateNameCode(err), err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, duplicateNameCode(err), msg)
 	case cerrors.IsInvalidArgument(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "ValidationError", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "ValidationError", msg)
 	case cerrors.IsFailedPrecondition(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, failedPreconditionCode(err), err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, failedPreconditionCode(err), msg)
 	default:
-		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", err.Error())
+		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", msg)
 	}
 }
 

--- a/server/aws/elbv2/health_check_protocol_sdk_test.go
+++ b/server/aws/elbv2/health_check_protocol_sdk_test.go
@@ -68,3 +68,48 @@ func TestSDKTCPTargetGroupDefaultsHealthCheckToTCP(t *testing.T) {
 		t.Errorf("HealthCheckProtocol = %q, want TCP", out.TargetGroups[0].HealthCheckProtocol)
 	}
 }
+
+// TestSDKLambdaTargetGroupHealthCheck proves a lambda target group reports
+// HealthCheckEnabled=false and carries no health-check protocol — real ELBv2
+// disables health checks for a lambda group by default and returns no protocol,
+// so returning one makes Terraform reject the group with "health_check.protocol
+// cannot be specified when target_type is lambda". The lambda-specific numeric
+// defaults (interval 35, timeout 30, thresholds 5/5) are also asserted.
+func TestSDKLambdaTargetGroupHealthCheck(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateTargetGroup(ctx, &elb.CreateTargetGroupInput{
+		Name:       aws.String("lambda-hc-tg"),
+		TargetType: elbtypes.TargetTypeEnumLambda,
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	tg := out.TargetGroups[0]
+
+	if aws.ToBool(tg.HealthCheckEnabled) {
+		t.Error("HealthCheckEnabled = true, want false for a lambda target group")
+	}
+
+	if tg.HealthCheckProtocol != "" {
+		t.Errorf("HealthCheckProtocol = %q, want empty for a lambda target group", tg.HealthCheckProtocol)
+	}
+
+	if got := aws.ToInt32(tg.HealthCheckIntervalSeconds); got != 35 {
+		t.Errorf("HealthCheckIntervalSeconds = %d, want 35", got)
+	}
+
+	if got := aws.ToInt32(tg.HealthCheckTimeoutSeconds); got != 30 {
+		t.Errorf("HealthCheckTimeoutSeconds = %d, want 30", got)
+	}
+
+	if got := aws.ToInt32(tg.HealthyThresholdCount); got != 5 {
+		t.Errorf("HealthyThresholdCount = %d, want 5", got)
+	}
+
+	if got := aws.ToInt32(tg.UnhealthyThresholdCount); got != 5 {
+		t.Errorf("UnhealthyThresholdCount = %d, want 5", got)
+	}
+}

--- a/server/aws/elbv2/types.go
+++ b/server/aws/elbv2/types.go
@@ -426,16 +426,20 @@ func toTargetGroupXML(tg *lbdriver.TargetGroupInfo) targetGroupXML {
 	}
 
 	out := targetGroupXML{
-		TargetGroupArn:             tg.ARN,
-		TargetGroupName:            tg.Name,
-		Protocol:                   tg.Protocol,
-		Port:                       tg.Port,
-		VpcID:                      tg.VPCID,
-		TargetType:                 targetType,
-		HealthCheckProtocol:        tg.HealthCheck.Protocol,
-		HealthCheckPort:            tg.HealthCheck.Port,
-		HealthCheckPath:            tg.HealthPath,
-		HealthCheckEnabled:         true,
+		TargetGroupArn:      tg.ARN,
+		TargetGroupName:     tg.Name,
+		Protocol:            tg.Protocol,
+		Port:                tg.Port,
+		VpcID:               tg.VPCID,
+		TargetType:          targetType,
+		HealthCheckProtocol: tg.HealthCheck.Protocol,
+		HealthCheckPort:     tg.HealthCheck.Port,
+		HealthCheckPath:     tg.HealthPath,
+		// A lambda target group defaults with health checks disabled; every other
+		// target type always has them enabled (real ELBv2 never lets them be
+		// turned off). The provider leaves a lambda group's HealthCheck protocol
+		// and port empty, so those are omitted for it too.
+		HealthCheckEnabled:         targetType != "lambda",
 		HealthCheckIntervalSeconds: tg.HealthCheck.IntervalSeconds,
 		HealthCheckTimeoutSeconds:  tg.HealthCheck.TimeoutSeconds,
 		HealthyThresholdCount:      tg.HealthCheck.HealthyThreshold,


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of AWS ELBv2 (aws_lb / aws_lb_target_group / aws_lb_listener + rules) against real aws-cli, aws-sdk-go-v2, and Terraform pointed at a live \`cloudemu serve\`. The ALB/NLB create → describe → register-targets → health → attribute round-trip → delete paths were already solid (Terraform apply reaches \`active\` and \`plan\` shows no drift). This PR fixes three genuine cloud-vs-cloudemu divergences a real user hits.

## Fixes

**1. Error \`<Message>\` leaked the internal error-code prefix.**
ELBv2's \`writeErr\` passed \`err.Error()\` (which is \`"<Code>: <message>"\`) as the XML message, so a real user saw \`NotFound: load balancer "x" not found\` / \`AlreadyExists: target group "x" already exists\`. Real AWS never puts its error-taxonomy name in the message. Switched to \`cerrors.Message(err)\`, matching every other AWS wire handler. The error Code (LoadBalancerNotFound, DuplicateLoadBalancerName, ...) is unchanged.

**2. HealthCheckTimeoutSeconds defaulted to a flat 5 for every protocol.**
Per the CreateTargetGroup API reference (confirmed against the Terraform AWS provider docs), the default is HTTP 6, HTTPS/TCP/TLS (and the other TCP-family protocols) 10, GENEVE 5, and lambda 30. The emulator returned 5 for all, so an NLB TCP target group reported 5 where real AWS returns 10. Now protocol/target-type aware.

**3. A lambda target group returned a health-check protocol and HealthCheckEnabled=true.**
Real AWS disables health checks for a lambda target group by default and returns no HealthCheckProtocol/Port/Path. Because the emulator returned a protocol, Terraform rejected any \`aws_lb_target_group\` with \`target_type = "lambda"\` with *"health_check.protocol cannot be specified when target_type is lambda"*. Lambda groups now report HealthCheckEnabled=false, no protocol/port/path, and the lambda numeric defaults (interval 35, timeout 30, thresholds 5/5).

## Evidence

- Terraform apply of a full ALB (redirect + fixed-response listeners, listener rule with multiple conditions, stickiness, LB attributes) and an NLB reaches \`active\` and \`terraform plan\` reports **no changes** — before and after the fixes.
- The lambda target-group Terraform warning is gone; \`plan\` is clean with no warnings.
- register-targets → DescribeTargetHealth returns \`healthy\`; TG/LB attribute modify→describe round-trips; deregister drains to empty; destroy succeeds.
- aws-cli confirms per-protocol timeouts (HTTP 6, HTTPS/TCP 10, lambda 30) and lambda HealthCheckEnabled=false with no protocol.

## Tests

- \`providers/aws/elbv2\`: per-protocol timeout defaults, explicit-timeout preservation, and lambda health-check defaults.
- \`server/aws/elbv2\`: SDK round-trip asserting error messages carry no code prefix, and lambda target-group HealthCheckEnabled/protocol/defaults.

Gates: \`go build ./...\`, \`go test -race\` (providers/aws/elbv2 + server/aws/elbv2), \`go test\` (services/loadbalancer + root), \`go vet\`, \`gofmt\`, \`golangci-lint --new-from-rev=origin/development\` (0 new issues), \`go generate\` (no docs/coverage diff) — all green.