### PR TITLE
fix(azure-storage): real-user e2e divergences from Azure Storage Account

### DIFF
--- a/server/azure/storageaccount/account_identity_test.go
+++ b/server/azure/storageaccount/account_identity_test.go
@@ -1,0 +1,140 @@
+package storageaccount_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSDKStorageAccountIdentitySystemAssigned proves a system-assigned managed
+// identity survives create -> get with a synthesized principalId/tenantId. The
+// identity block is a top-level ARM sibling of properties, which the
+// echo-properties overlay (properties-only) does not preserve — so before it
+// was modeled here a Terraform user with identity { type = "SystemAssigned" }
+// saw the block vanish on every refresh (perpetual drift).
+func TestSDKStorageAccountIdentitySystemAssigned(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acctident", armstorage.AccountCreateParameters{
+		Location: to.Ptr("westus2"),
+		Kind:     to.Ptr(armstorage.KindStorageV2),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+		Identity: &armstorage.Identity{Type: to.Ptr(armstorage.IdentityTypeSystemAssigned)},
+	}, nil)
+	require.NoError(t, err)
+	created, err := poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, created.Identity)
+	require.Equal(t, armstorage.IdentityTypeSystemAssigned, *created.Identity.Type)
+	require.NotEmpty(t, *created.Identity.PrincipalID)
+	require.NotEmpty(t, *created.Identity.TenantID)
+
+	got, err := client.GetProperties(ctx, "rg-1", "acctident", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.Identity)
+	assert.Equal(t, armstorage.IdentityTypeSystemAssigned, *got.Identity.Type)
+	assert.Equal(t, *created.Identity.PrincipalID, *got.Identity.PrincipalID, "principalId is stable across reads")
+	assert.Equal(t, *created.Identity.TenantID, *got.Identity.TenantID)
+}
+
+// TestSDKStorageAccountIdentityUserAssigned proves a user-assigned identity
+// round-trips: the attached identity resource ID is echoed back with a
+// synthesized principal/client pair, as real Azure reports it.
+func TestSDKStorageAccountIdentityUserAssigned(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+	uaID := "/subscriptions/sub-1/resourceGroups/rg-1/providers/" +
+		"Microsoft.ManagedIdentity/userAssignedIdentities/uai1"
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acctua", armstorage.AccountCreateParameters{
+		Location: to.Ptr("westus2"),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+		Identity: &armstorage.Identity{
+			Type:                   to.Ptr(armstorage.IdentityTypeUserAssigned),
+			UserAssignedIdentities: map[string]*armstorage.UserAssignedIdentity{uaID: {}},
+		},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	got, err := client.GetProperties(ctx, "rg-1", "acctua", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.Identity)
+	assert.Equal(t, armstorage.IdentityTypeUserAssigned, *got.Identity.Type)
+	require.Contains(t, got.Identity.UserAssignedIdentities, uaID)
+	entry := got.Identity.UserAssignedIdentities[uaID]
+	require.NotNil(t, entry)
+	require.NotNil(t, entry.PrincipalID)
+	require.NotNil(t, entry.ClientID)
+	assert.NotEmpty(t, *entry.PrincipalID)
+	assert.NotEmpty(t, *entry.ClientID)
+}
+
+// TestSDKStorageAccountIdentityPatch proves a PATCH can add an identity, that a
+// tags-only PATCH preserves it (partial-update semantics), and that a PATCH to
+// type None clears the block.
+func TestSDKStorageAccountIdentityPatch(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acctpi", armstorage.AccountCreateParameters{
+		Location: to.Ptr("westus2"),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	_, err = client.Update(ctx, "rg-1", "acctpi", armstorage.AccountUpdateParameters{
+		Identity: &armstorage.Identity{Type: to.Ptr(armstorage.IdentityTypeSystemAssigned)},
+	}, nil)
+	require.NoError(t, err)
+	added, err := client.GetProperties(ctx, "rg-1", "acctpi", nil)
+	require.NoError(t, err)
+	require.NotNil(t, added.Identity)
+	assert.Equal(t, armstorage.IdentityTypeSystemAssigned, *added.Identity.Type)
+	principal := *added.Identity.PrincipalID
+
+	_, err = client.Update(ctx, "rg-1", "acctpi", armstorage.AccountUpdateParameters{
+		Tags: map[string]*string{"env": to.Ptr("prod")},
+	}, nil)
+	require.NoError(t, err)
+	preserved, err := client.GetProperties(ctx, "rg-1", "acctpi", nil)
+	require.NoError(t, err)
+	require.NotNil(t, preserved.Identity, "tags-only PATCH must not drop identity")
+	assert.Equal(t, principal, *preserved.Identity.PrincipalID, "principalId stays stable across PATCH")
+
+	_, err = client.Update(ctx, "rg-1", "acctpi", armstorage.AccountUpdateParameters{
+		Identity: &armstorage.Identity{Type: to.Ptr(armstorage.IdentityTypeNone)},
+	}, nil)
+	require.NoError(t, err)
+	cleared, err := client.GetProperties(ctx, "rg-1", "acctpi", nil)
+	require.NoError(t, err)
+	assert.Nil(t, cleared.Identity, "identity type None clears the block")
+}
+
+// TestSDKStorageAccountNoIdentityByDefault proves an account created without an
+// identity block reports none (real Azure omits identity entirely rather than
+// returning type None).
+func TestSDKStorageAccountNoIdentityByDefault(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	poller, err := client.BeginCreate(ctx, "rg-1", "acctnoid", armstorage.AccountCreateParameters{
+		Location: to.Ptr("westus2"),
+		SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNameStandardLRS)},
+	}, nil)
+	require.NoError(t, err)
+	_, err = poller.PollUntilDone(ctx, nil)
+	require.NoError(t, err)
+
+	got, err := client.GetProperties(ctx, "rg-1", "acctnoid", nil)
+	require.NoError(t, err)
+	assert.Nil(t, got.Identity)
+}

--- a/server/azure/storageaccount/handler.go
+++ b/server/azure/storageaccount/handler.go
@@ -26,9 +26,11 @@ package storageaccount
 import (
 	"context"
 	"net/http"
+	"sort"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
 )
@@ -60,6 +62,13 @@ const (
 	defaultHTTPSTrafficOnly    = true
 	defaultBlobPublicAccess    = false
 	defaultSharedKeyAccess     = true
+
+	// identityNone is the managed-identity type that clears the identity block;
+	// emulatorTenantID is the single Azure AD directory every emulated resource
+	// reports (shared with the ACR/AKS/VM handlers).
+	identityNone     = "None"
+	systemAssigned   = "SystemAssigned"
+	emulatorTenantID = "11111111-1111-1111-1111-111111111111"
 )
 
 // attrBackend is the optional storage-account attribute capability. The Azure
@@ -414,6 +423,10 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azu
 		encryption = fromARMEncryptionReq(body.Properties.Encryption)
 	}
 
+	// Full-replace like the rest of create-or-update: an omitted identity block
+	// clears any previously attached managed identity.
+	applyIdentity(&attrs, body.Identity, rp.ResourceGroup, name)
+
 	if h.attrs != nil {
 		h.attrs.SetBucketAttributes(name, attrs)
 	}
@@ -465,7 +478,7 @@ func (h *Handler) update(w http.ResponseWriter, r *http.Request, rp *azurearm.Re
 		if _, err := h.attrs.UpdateBucketAttributes(r.Context(), rp.ResourceName, func(
 			cur storagedriver.AccountAttributes,
 		) storagedriver.AccountAttributes {
-			applyAccountUpdate(&cur, &body)
+			applyAccountUpdate(&cur, &body, rp.ResourceGroup, rp.ResourceName)
 
 			return cur
 		}); err != nil {
@@ -488,8 +501,9 @@ func (h *Handler) update(w http.ResponseWriter, r *http.Request, rp *azurearm.Re
 }
 
 // applyAccountUpdate merges the fields present on a PATCH body onto cur in
-// place, leaving every field the request omitted untouched.
-func applyAccountUpdate(cur *storagedriver.AccountAttributes, body *armAccountUpdate) {
+// place, leaving every field the request omitted untouched. rg/name seed the
+// synthesized principal id when a PATCH turns on a system-assigned identity.
+func applyAccountUpdate(cur *storagedriver.AccountAttributes, body *armAccountUpdate, rg, name string) {
 	if body.Kind != "" {
 		cur.Kind = body.Kind
 	}
@@ -500,6 +514,13 @@ func applyAccountUpdate(cur *storagedriver.AccountAttributes, body *armAccountUp
 
 	if body.Tags != nil {
 		cur.Tags = body.Tags
+	}
+
+	// A PATCH that carries an identity block replaces the identity outright
+	// (the SDK sends the full desired type + user-assigned set); one that omits
+	// it leaves the attached identity untouched.
+	if body.Identity != nil {
+		applyIdentity(cur, body.Identity, rg, name)
 	}
 
 	if body.Properties == nil {
@@ -536,6 +557,96 @@ func applySecurityToggles(cur *storagedriver.AccountAttributes, props *armAccoun
 	if props.AllowSharedKeyAccess != nil {
 		cur.AllowSharedKeyAccess = props.AllowSharedKeyAccess
 	}
+}
+
+// applyIdentity stores the managed-identity block on attrs, synthesizing the
+// system-assigned principal/tenant ids the way real Azure returns them. A type
+// of "" or "None" clears the block; a system-assigned type keeps an already
+// synthesized principal id stable across updates. rg/name seed the deterministic
+// principal id so it is stable per account.
+func applyIdentity(attrs *storagedriver.AccountAttributes, id *armIdentity, rg, name string) {
+	if id == nil {
+		return
+	}
+
+	if id.Type == "" || strings.EqualFold(id.Type, identityNone) {
+		attrs.IdentityType = ""
+		attrs.UserAssignedIdentities = nil
+		attrs.IdentityPrincipalID = ""
+		attrs.IdentityTenantID = ""
+
+		return
+	}
+
+	attrs.IdentityType = id.Type
+	attrs.UserAssignedIdentities = identityKeys(id.UserAssignedIdentities)
+
+	if identityHasSystemAssigned(id.Type) {
+		if attrs.IdentityPrincipalID == "" {
+			attrs.IdentityPrincipalID = idgen.SyntheticGUID("principal/storageAccount/" + rg + "/" + name)
+		}
+
+		attrs.IdentityTenantID = emulatorTenantID
+
+		return
+	}
+
+	attrs.IdentityPrincipalID = ""
+	attrs.IdentityTenantID = ""
+}
+
+// identityHasSystemAssigned reports whether an identity type string includes the
+// system-assigned identity (covers "SystemAssigned" and the combined
+// "SystemAssigned,UserAssigned").
+func identityHasSystemAssigned(t string) bool {
+	return strings.Contains(t, systemAssigned)
+}
+
+// identityKeys returns the user-assigned identity resource IDs (the request map
+// keys) in deterministic order so synthesized pairs are stable.
+func identityKeys(m map[string]*armUserAssignedIdentity) []string {
+	if len(m) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+// armIdentityFor renders the account's managed-identity response block, or nil
+// when no identity is attached. Each user-assigned identity is echoed with a
+// synthesized principal/client pair keyed by its resource ID, matching real
+// Azure.
+func armIdentityFor(attrs *storagedriver.AccountAttributes) *armIdentity {
+	if attrs.IdentityType == "" || strings.EqualFold(attrs.IdentityType, identityNone) {
+		return nil
+	}
+
+	out := &armIdentity{
+		Type:        attrs.IdentityType,
+		PrincipalID: attrs.IdentityPrincipalID,
+		TenantID:    attrs.IdentityTenantID,
+	}
+
+	if len(attrs.UserAssignedIdentities) == 0 {
+		return out
+	}
+
+	out.UserAssignedIdentities = make(map[string]*armUserAssignedIdentity, len(attrs.UserAssignedIdentities))
+	for _, uaID := range attrs.UserAssignedIdentities {
+		out.UserAssignedIdentities[uaID] = &armUserAssignedIdentity{
+			PrincipalID: idgen.SyntheticGUID("uai-principal/" + uaID),
+			ClientID:    idgen.SyntheticGUID("uai-client/" + uaID),
+		}
+	}
+
+	return out
 }
 
 func (h *Handler) deleteAccount(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
@@ -673,6 +784,7 @@ func (h *Handler) toARMAccount(ctx context.Context, rp *azurearm.ResourcePath) a
 		Location:   location,
 		Kind:       attrs.Kind,
 		Tags:       attrs.Tags,
+		Identity:   armIdentityFor(&attrs),
 		SKU:        &armSKU{Name: attrs.SKU, Tier: skuTier(attrs.SKU)},
 		Properties: props,
 	}

--- a/server/azure/storageaccount/types.go
+++ b/server/azure/storageaccount/types.go
@@ -8,6 +8,7 @@ type armAccountCreate struct {
 	Kind       string              `json:"kind,omitempty"`
 	Tags       map[string]string   `json:"tags,omitempty"`
 	SKU        *armSKU             `json:"sku,omitempty"`
+	Identity   *armIdentity        `json:"identity,omitempty"`
 	Properties *armAccountPropsReq `json:"properties,omitempty"`
 }
 
@@ -18,7 +19,28 @@ type armAccountUpdate struct {
 	Kind       string              `json:"kind,omitempty"`
 	Tags       map[string]string   `json:"tags,omitempty"`
 	SKU        *armSKU             `json:"sku,omitempty"`
+	Identity   *armIdentity        `json:"identity,omitempty"`
 	Properties *armAccountPropsReq `json:"properties,omitempty"`
+}
+
+// armIdentity is the ARM managed-identity block — a top-level sibling of
+// properties/sku/kind on a storage account (armstorage.Identity). On a request
+// only Type and the userAssignedIdentities keys are meaningful; the response
+// synthesizes the system-assigned principal/tenant ids and each user-assigned
+// identity's principal/client pair, mirroring real Azure.
+type armIdentity struct {
+	Type                   string                              `json:"type,omitempty"`
+	PrincipalID            string                              `json:"principalId,omitempty"`
+	TenantID               string                              `json:"tenantId,omitempty"`
+	UserAssignedIdentities map[string]*armUserAssignedIdentity `json:"userAssignedIdentities,omitempty"`
+}
+
+// armUserAssignedIdentity is one entry of identity.userAssignedIdentities: the
+// principal/client pair Azure returns for an attached user-assigned identity.
+// On a request the value is an empty object; the response synthesizes the pair.
+type armUserAssignedIdentity struct {
+	PrincipalID string `json:"principalId,omitempty"`
+	ClientID    string `json:"clientId,omitempty"`
 }
 
 // armAccountPropsReq is the settable subset of properties on a create or
@@ -69,6 +91,7 @@ type armAccount struct {
 	Kind       string            `json:"kind,omitempty"`
 	Tags       map[string]string `json:"tags,omitempty"`
 	SKU        *armSKU           `json:"sku,omitempty"`
+	Identity   *armIdentity      `json:"identity,omitempty"`
 	Properties *armAccountProps  `json:"properties,omitempty"`
 }
 

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -70,6 +70,19 @@ type AccountAttributes struct {
 	EnableHTTPSTrafficOnly *bool
 	AllowBlobPublicAccess  *bool
 	AllowSharedKeyAccess   *bool
+	// IdentityType is the ARM managed-identity type attached to the account
+	// (None/SystemAssigned/UserAssigned/"SystemAssigned,UserAssigned"). Empty
+	// means the create/update carried no identity block, so the handler emits
+	// no identity object at all. IdentityPrincipalID/IdentityTenantID are the
+	// ids synthesized for a system-assigned identity (empty otherwise), and
+	// UserAssignedIdentities holds the attached user-assigned identity resource
+	// IDs. Modeled here (not left to the echo overlay) because the identity
+	// block is a top-level ARM sibling of properties — the overlay only echoes
+	// unmodeled keys under properties, so a bare identity would be dropped.
+	IdentityType           string
+	IdentityPrincipalID    string
+	IdentityTenantID       string
+	UserAssignedIdentities []string
 }
 
 // AccountEncryption is the storage-account encryption configuration requested


### PR DESCRIPTION
## Summary

Deep real-user e2e re-audit of `Microsoft.Storage/storageAccounts` (azurerm_storage_account / azure-sdk-for-go armstorage). The control plane was already very well swept in prior sessions (SKU split, LRO-Succeeded, primaryEndpoints, encryption/CMK, security toggles with explicit-false `*bool` modeling, GRS secondary endpoints, listKeys, checkNameAvailability, PATCH partial-update). This fixes the one remaining genuine divergence found.

## Divergence fixed: managed identity block dropped

The ARM `identity` block is a **top-level sibling of `properties`**. The Azure server's echo-properties overlay only preserves unmodeled keys under `properties`, so a storage account created with `identity { type = "SystemAssigned" }` (or UserAssigned) read back with the whole identity block missing — a real azurerm user (CMK, RBAC data-plane access) saw the identity vanish on every refresh, i.e. perpetual drift.

### Change
- Model `identity` on the storage-account handler (request + response), storing type / user-assigned ids on `AccountAttributes` (mirrors the ACR registry handler pattern).
- Synthesize a stable system-assigned `principalId` + shared emulator `tenantId`, and a per-identity `principalId`/`clientId` for each user-assigned identity, keyed by resource id — matching real Azure.
- Create-or-update is full-replace (omitted identity clears it); PATCH merges (tags-only PATCH preserves identity; `principalId` stays stable); type `None` clears the block.

## Live evidence (serve, Azure HTTPS)
PUT with `identity:SystemAssigned` + `Standard_RAGRS` + `supportsHttpsTrafficOnly:false` + `isHnsEnabled:true`, then GET: identity present with stable synthesized principalId/tenantId, explicit-false and HNS round-trip, RA-GRS secondaryEndpoints present, provisioningState Succeeded. listKeys returns key1/key2 (base64), checkNameAvailability rejects invalid names with the exact Azure message.

## Tests
`server/azure/storageaccount/account_identity_test.go` — real armstorage AccountsClient drives system-assigned, user-assigned, PATCH add/preserve/clear, and no-identity-by-default cases end-to-end.

## Gates
build ./... · go vet · gofmt · `go test -race` (storageaccount, full server/azure, blobstorage, services/storage) · persist · root integration · golangci-lint 0 issues · go generate (no docs delta — no interface methods changed).