### PR TITLE
fix(azure-keyvault): real-user e2e divergences from Azure Key Vault

### DIFF
--- a/providers/azure/keyvault/vault_arm_azure.go
+++ b/providers/azure/keyvault/vault_arm_azure.go
@@ -2,6 +2,7 @@ package keyvault
 
 import (
 	"context"
+	"sort"
 
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/scope"
@@ -103,6 +104,13 @@ func (m *Mock) ListVaults(_ context.Context, filter scope.Scope) ([]driver.KVVau
 
 		out = append(out, *cloneVaultInfo(info))
 	}
+
+	// Vaults are stored in a map, whose iteration order is randomized. Real ARM
+	// list responses (Vaults.ListByResourceGroup / ListBySubscription, and the
+	// azurerm_key_vaults data source that walks them) return a stable order, so
+	// sort by the globally unique vault name to keep GETs deterministic and free
+	// of Terraform plan churn.
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 
 	return out, nil
 }

--- a/providers/azure/keyvault/vault_arm_azure_test.go
+++ b/providers/azure/keyvault/vault_arm_azure_test.go
@@ -284,6 +284,31 @@ func TestListVaultsByScope(t *testing.T) {
 	assert.Len(t, bySub, 2)
 }
 
+// TestListVaultsSortedByName pins the deterministic list order real ARM
+// (Vaults.ListByResourceGroup / ListBySubscription and the azurerm_key_vaults
+// data source) exposes: vaults come back sorted by name regardless of creation
+// order, so pagers and Terraform refreshes never churn on randomized map order.
+func TestListVaultsSortedByName(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	// Insert in reverse-alphabetical order.
+	for _, name := range []string{"vault-c", "vault-a", "vault-b"} {
+		_, err := m.CreateOrUpdateVault(ctx, sampleVaultConfig(name, "sub-1", "rg-1"))
+		require.NoError(t, err)
+	}
+
+	got, err := m.ListVaults(ctx, scope.Scope{Subscription: "sub-1", ResourceGroup: "rg-1"})
+	require.NoError(t, err)
+
+	names := make([]string, len(got))
+	for i := range got {
+		names[i] = got[i].Name
+	}
+
+	assert.Equal(t, []string{"vault-a", "vault-b", "vault-c"}, names)
+}
+
 func TestDeleteVault(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Real-user e2e audit of the Azure Key Vault control plane (`Microsoft.KeyVault/vaults`) driven through `cloudemu serve` (Azure HTTPS) with the real ARM wire protocol. The vault ARM surface is otherwise complete and doc-faithful — this fixes the one genuine real-cloud divergence found.

## Divergence fixed

**Nondeterministic list order (Terraform plan churn / flaky pagination).** `ListVaults` returned vaults straight out of a Go map, whose iteration order is randomized. Real ARM `Vaults.ListByResourceGroup` / `Vaults.ListBySubscription` — and the `azurerm_key_vaults` data source that walks them, plus the azure-sdk-for-go pagers — return a stable order. The randomized order causes plan churn and flaky pager assertions. Now sorted by the globally unique vault name, matching the codebase convention for list results (e.g. Databricks access connectors).

## Verification

Live e2e via `serve` (Azure HTTPS) with the raw ARM protocol confirmed, both before and after:
- Create returns 201 with `provisioningState=Succeeded` (no azurerm poller hang)
- `vaultUri` = `https://<name>.vault.azure.net/` (trailing slash), `sku{family:A,name:standard}`, `tenantId` echoed
- `accessPolicies` deep round-trip incl. `permissions.{keys,secrets,certificates,storage}`
- Soft-delete defaults: `enableSoftDelete=true`, `softDeleteRetentionInDays=90`
- Explicit-false toggles round-trip (`enableRbacAuthorization=false`, `enabledForDeployment=false`)
- PATCH tag merge → 200; DELETE → 200
- List of `bbb-vault` then `aaa-vault` (reverse insertion) now returns `aaa-vault` before `bbb-vault`

Added `TestListVaultsSortedByName` to pin the ordering.

## Gates
- `go build ./...`, `go vet`, `gofmt -l` clean
- `go test -race -count=1 ./providers/azure/keyvault/... ./server/azure/keyvault/...` green
- `golangci-lint run --new-from-rev=origin/development` — 0 issues
- `go generate ./...` — no docs/coverage diff (behavioral change only)