### PR TITLE
fix(s3): real-user e2e divergences from AWS S3

### DIFF
--- a/server/aws/s3/bucket_config.go
+++ b/server/aws/s3/bucket_config.go
@@ -52,11 +52,13 @@ var notConfiguredErr = map[string]string{
 	"website":           "NoSuchWebsiteConfiguration",
 	subLifecycle:        "NoSuchLifecycleConfiguration",
 	"replication":       "ReplicationConfigurationNotFoundError",
-	"encryption":        "ServerSideEncryptionConfigurationNotFoundError",
 	"object-lock":       "ObjectLockConfigurationNotFoundError",
 	"publicAccessBlock": "NoSuchPublicAccessBlockConfiguration",
 	"ownershipControls": "OwnershipControlsNotFoundError",
 }
+
+// subEncryption is the ?encryption sub-resource key (Get/PutBucketEncryption).
+const subEncryption = "encryption"
 
 // configSubresources are the read-only bucket configuration sub-resource query
 // keys the handler answers (order irrelevant — at most one is present).
@@ -221,6 +223,16 @@ func writeRawBucketConfig(w http.ResponseWriter, sub string, body []byte) {
 // sub-resource: a "not configured" error for the persistable ones, or the
 // service default for the always-present ones (location, request payment, …).
 func writeConfigDefault(w http.ResponseWriter, sub string) {
+	// Since January 2023 every S3 bucket has default encryption: a bucket with no
+	// explicit configuration answers GetBucketEncryption with 200 and the SSE-S3
+	// (AES256) base rule, not ServerSideEncryptionConfigurationNotFoundError.
+	// Returning the old error caused the Terraform AWS provider to see perpetual
+	// drift on buckets with no customer-defined encryption.
+	if sub == subEncryption {
+		wire.WriteXML(w, http.StatusOK, defaultEncryptionConfig())
+		return
+	}
+
 	if code, ok := notConfiguredErr[sub]; ok {
 		writeError(w, http.StatusNotFound, code, "The "+sub+" configuration does not exist")
 		return
@@ -270,4 +282,39 @@ type policyStatusXML struct {
 	XMLName  xml.Name `xml:"PolicyStatus"`
 	Xmlns    string   `xml:"xmlns,attr"`
 	IsPublic bool     `xml:"IsPublic"`
+}
+
+// serverSideEncryptionConfigXML is the GetBucketEncryption response body. Only
+// the fields needed to render the SSE-S3 default are modeled; a bucket that has
+// its own configuration persisted echoes the stored document verbatim instead.
+type serverSideEncryptionConfigXML struct {
+	XMLName xml.Name                   `xml:"ServerSideEncryptionConfiguration"`
+	Xmlns   string                     `xml:"xmlns,attr"`
+	Rules   []serverSideEncryptionRule `xml:"Rule"`
+}
+
+type serverSideEncryptionRule struct {
+	ApplyDefault     applyServerSideEncryptionByDefault `xml:"ApplyServerSideEncryptionByDefault"`
+	BucketKeyEnabled bool                               `xml:"BucketKeyEnabled"`
+}
+
+type applyServerSideEncryptionByDefault struct {
+	SSEAlgorithm string `xml:"SSEAlgorithm"`
+}
+
+// sseAlgorithmAES256 is the SSE-S3 algorithm name S3 reports for its default
+// bucket encryption.
+const sseAlgorithmAES256 = "AES256"
+
+// defaultEncryptionConfig returns the SSE-S3 (AES256) base encryption rule that
+// real S3 reports for a bucket with no explicit configuration, with bucket keys
+// disabled — matching a freshly created bucket.
+func defaultEncryptionConfig() serverSideEncryptionConfigXML {
+	return serverSideEncryptionConfigXML{
+		Xmlns: xmlns,
+		Rules: []serverSideEncryptionRule{{
+			ApplyDefault:     applyServerSideEncryptionByDefault{SSEAlgorithm: sseAlgorithmAES256},
+			BucketKeyEnabled: false,
+		}},
+	}
 }

--- a/server/aws/s3/bucket_config_test.go
+++ b/server/aws/s3/bucket_config_test.go
@@ -2,13 +2,93 @@ package s3_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 )
+
+// TestSDKBucketEncryptionDefaultAES256 covers the real-S3 behavior (since
+// January 2023) that every bucket has default encryption: GetBucketEncryption on
+// a bucket with no explicit configuration returns the SSE-S3 (AES256) base rule
+// with bucket keys disabled, NOT ServerSideEncryptionConfigurationNotFoundError.
+// Returning the old error caused perpetual Terraform drift on buckets with no
+// customer-defined encryption.
+func TestSDKBucketEncryptionDefaultAES256(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "enc-default-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	got, err := client.GetBucketEncryption(ctx, &awss3.GetBucketEncryptionInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		t.Fatalf("GetBucketEncryption on a fresh bucket: %v", err)
+	}
+
+	if got.ServerSideEncryptionConfiguration == nil || len(got.ServerSideEncryptionConfiguration.Rules) != 1 {
+		t.Fatalf("default encryption config = %+v, want 1 rule", got.ServerSideEncryptionConfiguration)
+	}
+
+	rule := got.ServerSideEncryptionConfiguration.Rules[0]
+	if rule.ApplyServerSideEncryptionByDefault == nil ||
+		rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm != types.ServerSideEncryptionAes256 {
+		t.Fatalf("default SSEAlgorithm = %+v, want AES256", rule.ApplyServerSideEncryptionByDefault)
+	}
+
+	if aws.ToBool(rule.BucketKeyEnabled) {
+		t.Fatal("default BucketKeyEnabled = true, want false")
+	}
+}
+
+// TestSDKBucketTaggingNoSuchTagSet covers the real-S3 special error: a bucket
+// with no tags configured answers GetBucketTagging with 404 NoSuchTagSet, not an
+// empty <TagSet/> with 200. It also confirms the error returns again after the
+// tag set is deleted.
+func TestSDKBucketTaggingNoSuchTagSet(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "tag-absent-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	assertNoSuchTagSet := func(when string) {
+		t.Helper()
+
+		_, err := client.GetBucketTagging(ctx, &awss3.GetBucketTaggingInput{Bucket: aws.String(bucket)})
+		if err == nil {
+			t.Fatalf("GetBucketTagging %s: expected NoSuchTagSet, got nil", when)
+		}
+
+		var apiErr smithy.APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("GetBucketTagging %s error = %T %v, want smithy.APIError", when, err, err)
+		}
+
+		if apiErr.ErrorCode() != "NoSuchTagSet" {
+			t.Fatalf("GetBucketTagging %s code = %q, want NoSuchTagSet", when, apiErr.ErrorCode())
+		}
+	}
+
+	assertNoSuchTagSet("on a fresh bucket")
+
+	if _, err := client.PutBucketTagging(ctx, &awss3.PutBucketTaggingInput{
+		Bucket:  aws.String(bucket),
+		Tagging: &types.Tagging{TagSet: []types.Tag{{Key: aws.String("env"), Value: aws.String("prod")}}},
+	}); err != nil {
+		t.Fatalf("PutBucketTagging: %v", err)
+	}
+
+	if _, err := client.DeleteBucketTagging(ctx, &awss3.DeleteBucketTaggingInput{Bucket: aws.String(bucket)}); err != nil {
+		t.Fatalf("DeleteBucketTagging: %v", err)
+	}
+
+	assertNoSuchTagSet("after DeleteBucketTagging")
+}
 
 // TestSDKBucketPolicyRoundTrip covers the config-persistence gap for
 // PutBucketPolicy: the JSON document must read back byte-for-byte (previously a

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -317,6 +317,15 @@ func (h *Handler) bucketTaggingOp(w http.ResponseWriter, r *http.Request, bucket
 			return
 		}
 
+		// Real S3 has no "empty tag set" state: a bucket with no tags configured
+		// answers GetBucketTagging with 404 NoSuchTagSet, not an empty <TagSet/>.
+		// Returning an empty 200 diverged from the documented special error and
+		// tripped SDK callers that key off NoSuchTagSet to detect absence.
+		if len(tags) == 0 {
+			writeError(w, http.StatusNotFound, "NoSuchTagSet", "The TagSet does not exist")
+			return
+		}
+
 		resp := tagging{Xmlns: xmlns}
 
 		keys := make([]string, 0, len(tags))


### PR DESCRIPTION
## Summary

Real-user e2e audit of AWS S3 (aws-cli + aws-sdk-go-v2 + Terraform against `cloudemu serve`) surfaced two genuine divergences from real S3 behavior in the S3 wire handler. Both are fixed here.

### 1. GetBucketEncryption returned an error for the default case
Since January 2023 every S3 bucket has default encryption. `GetBucketEncryption` on a bucket with no explicit configuration returns HTTP 200 with the SSE-S3 (`AES256`) base rule and `BucketKeyEnabled: false` — **not** `ServerSideEncryptionConfigurationNotFoundError`.

cloudemu returned the error, which is the exact case AWS documents as causing perpetual Terraform drift ("HashiCorp Terraform users ... might see an unexpected drift after creating new S3 buckets with no customer defined encryption configuration"). A bucket with an explicit configuration still echoes its stored document verbatim, and the default is returned again after `DeleteBucketEncryption`, matching real S3.

### 2. GetBucketTagging returned empty instead of NoSuchTagSet
A bucket with no tags configured now answers `GetBucketTagging` with 404 `NoSuchTagSet` ("The TagSet does not exist"), the documented special error SDK callers use to detect absence. cloudemu previously returned an empty `<TagSet/>` with 200. The populated round-trip and the post-`DeleteBucketTagging` case both behave correctly.

## Scope of the audit (verified, no divergence found)
CreateBucket idempotency, HeadBucket, GetBucketLocation (us-east-1 empty constraint), versioning enable/suspend + version-id round-trip + delete markers, object PUT/GET/HEAD/DELETE, ETag (quoted MD5 hex), ListObjectsV2 lexicographic ordering, pagination (MaxKeys + continuation token), CommonPrefixes with delimiter, default Content-Type (`binary/octet-stream`), metadata round-trip, NoSuchKey/NoSuchBucket, and a full Terraform multi-resource apply (bucket + versioning + encryption + public_access_block + ownership_controls + lifecycle + cors + policy + object) that produces **no drift** on a subsequent `terraform plan`.

## Tests
Added `TestSDKBucketEncryptionDefaultAES256` and `TestSDKBucketTaggingNoSuchTagSet` in `server/aws/s3/bucket_config_test.go`. All `server/aws/s3` and `providers/aws/s3` tests pass under `-race`; root integration, storage service, and resourcegroupstaggingapi tests pass; `go generate` produces no `docs/coverage` changes.