### PR TITLE
fix(lambda): real-user e2e divergences from AWS Lambda

### DIFF
--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -139,6 +139,7 @@ const (
 // (the /tmp size) to 512 MB.
 const (
 	archX8664                 = "x86_64"
+	archArm64                 = "arm64"
 	defaultEphemeralStorageMB = 512
 )
 
@@ -646,6 +647,11 @@ func (h *Handler) serveConfiguration(w http.ResponseWriter, r *http.Request, nam
 		return
 	}
 
+	if err := validateEphemeralStorage(req.EphemeralStorage); err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	cfg := sdrv.FunctionConfig{
 		Name:        name,
 		Runtime:     req.Runtime,
@@ -669,6 +675,7 @@ func (h *Handler) serveConfiguration(w http.ResponseWriter, r *http.Request, nam
 		VPCConfig:        toDriverVPCConfig(req.VpcConfig),
 		DeadLetterConfig: toDriverDeadLetter(req.DeadLetterConfig),
 		TracingConfig:    toDriverTracing(req.TracingConfig),
+		EphemeralStorage: toDriverEphemeral(req.EphemeralStorage),
 		Layers:           h.resolveLayers(req.Layers),
 	}, false)
 
@@ -708,6 +715,11 @@ func (h *Handler) serveCode(w http.ResponseWriter, r *http.Request, name string)
 		return
 	}
 
+	if err := validateArchitectures(req.Architectures); err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	code, err := h.resolveCode(r.Context(), &functionCode{
 		ZipFile: req.ZipFile, S3Bucket: req.S3Bucket, S3Key: req.S3Key,
 	})
@@ -734,7 +746,7 @@ func (h *Handler) serveCode(w http.ResponseWriter, r *http.Request, name string)
 		return
 	}
 
-	awsCfg := h.awsFnConfig(r.Context(), name)
+	awsCfg := h.codeAWSConfig(r.Context(), name, req.Architectures)
 
 	if req.Publish {
 		h.writePublished(r.Context(), w, http.StatusOK, name, info, awsCfg)
@@ -742,6 +754,25 @@ func (h *Handler) serveCode(w http.ResponseWriter, r *http.Request, name string)
 	}
 
 	writeJSON(w, http.StatusOK, toConfiguration(info, awsCfg))
+}
+
+// codeAWSConfig returns the function's stored AWS-only config, first persisting
+// any Architectures change carried on the UpdateFunctionCode request — that is
+// the API that carries the instruction set (the code must match the target
+// architecture), so without this GetFunction keeps reporting the create-time
+// architecture and Terraform re-plans it forever. It falls back to the current
+// stored config for a non-AWS backend (applyAWSConfig returns nil there).
+func (h *Handler) codeAWSConfig(ctx context.Context, name string, arch []string) *sdrv.AWSFunctionConfig {
+	awsCfg := h.awsFnConfig(ctx, name)
+	if len(arch) == 0 {
+		return awsCfg
+	}
+
+	if applied := h.applyAWSConfig(ctx, name, sdrv.AWSFunctionConfig{Architectures: arch}, false); applied != nil {
+		return applied
+	}
+
+	return awsCfg
 }
 
 // serveVersions handles POST (PublishVersion) and GET (ListVersionsByFunction)
@@ -1042,7 +1073,26 @@ func validateCreateRequest(req *createFunctionRequest) error {
 		}
 	}
 
+	if err := validateArchitectures(req.Architectures); err != nil {
+		return err
+	}
+
 	return validateEphemeralStorage(req.EphemeralStorage)
+}
+
+// validateArchitectures rejects an Architectures value outside the AWS enum
+// (x86_64, arm64), matching real Lambda, which fails such a request with
+// InvalidParameterValueException rather than silently accepting it.
+func validateArchitectures(arch []string) error {
+	for _, a := range arch {
+		if a != archX8664 && a != archArm64 {
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"value '%s' at 'architectures' failed to satisfy constraint: "+
+					"Member must satisfy enum value set: [%s, %s]", a, archX8664, archArm64)
+		}
+	}
+
+	return nil
 }
 
 // validateEphemeralStorage rejects a /tmp size outside the AWS 512–10240 MB range.

--- a/server/aws/lambda/types.go
+++ b/server/aws/lambda/types.go
@@ -85,6 +85,11 @@ type updateFunctionConfigurationRequest struct {
 	VpcConfig        *vpcConfigEnvelope        `json:"VpcConfig"`
 	DeadLetterConfig *deadLetterConfigEnvelope `json:"DeadLetterConfig"`
 	TracingConfig    *tracingConfigEnvelope    `json:"TracingConfig"`
+	// EphemeralStorage updates the function's /tmp size. UpdateFunctionConfiguration
+	// (not UpdateFunctionCode) is the API that carries it — dropping it here leaves
+	// GetFunction reporting the create-time size, so Terraform sees perpetual drift
+	// on every ephemeral_storage change.
+	EphemeralStorage *ephemeralStorageEnvelope `json:"EphemeralStorage"`
 	// Layers replaces the function's imported layer versions (their ARNs).
 	Layers []string `json:"Layers"`
 }
@@ -100,6 +105,12 @@ type updateFunctionCodeRequest struct {
 	S3Key           string   `json:"S3Key"`
 	S3ObjectVersion string   `json:"S3ObjectVersion"`
 	Layers          []string `json:"Layers"`
+	// Architectures updates the function's instruction set (["x86_64"] or
+	// ["arm64"]). UpdateFunctionCode (not UpdateFunctionConfiguration) is the API
+	// that carries it — the code must match the target architecture — so dropping
+	// it here leaves GetFunction reporting the create-time architecture and
+	// Terraform sees perpetual drift on every architectures change.
+	Architectures []string `json:"Architectures"`
 	// Publish, when true, cuts a new version from the updated code and returns
 	// that version's configuration (qualified ARN), matching AWS.
 	Publish bool `json:"Publish"`

--- a/server/aws/lambda/update_arch_ephemeral_sdk_test.go
+++ b/server/aws/lambda/update_arch_ephemeral_sdk_test.go
@@ -1,0 +1,92 @@
+package lambda_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/aws/smithy-go"
+)
+
+// TestSDKUpdateFunctionConfigurationEphemeralStorage covers EphemeralStorage
+// updates travelling through UpdateFunctionConfiguration (the API that carries
+// it) and persisting on a subsequent GetFunctionConfiguration. Before the fix
+// the field was dropped from the request, so GetFunction kept reporting the
+// create-time size and Terraform saw perpetual drift on ephemeral_storage.
+func TestSDKUpdateFunctionConfigurationEphemeralStorage(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "esupd")
+
+	if _, err := client.UpdateFunctionConfiguration(ctx, &awslambda.UpdateFunctionConfigurationInput{
+		FunctionName:     aws.String("esupd"),
+		EphemeralStorage: &lambdatypes.EphemeralStorage{Size: aws.Int32(3072)},
+	}); err != nil {
+		t.Fatalf("UpdateFunctionConfiguration(EphemeralStorage): %v", err)
+	}
+
+	got, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("esupd"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConfiguration: %v", err)
+	}
+	if es := got.EphemeralStorage; es == nil || aws.ToInt32(es.Size) != 3072 {
+		t.Fatalf("EphemeralStorage = %+v, want Size 3072", got.EphemeralStorage)
+	}
+
+	// An out-of-range size on update is rejected, like create.
+	_, err = client.UpdateFunctionConfiguration(ctx, &awslambda.UpdateFunctionConfigurationInput{
+		FunctionName:     aws.String("esupd"),
+		EphemeralStorage: &lambdatypes.EphemeralStorage{Size: aws.Int32(400)},
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValueException" {
+		t.Fatalf("UpdateFunctionConfiguration(size 400) err = %v, want InvalidParameterValueException", err)
+	}
+}
+
+// TestSDKUpdateFunctionCodeArchitectures covers Architectures updates travelling
+// through UpdateFunctionCode (the API that carries them — the code must match the
+// target instruction set) and persisting on a subsequent GetFunctionConfiguration.
+// Before the fix the field was dropped, so GetFunction kept reporting the
+// create-time architecture and Terraform saw perpetual drift on architectures.
+func TestSDKUpdateFunctionCodeArchitectures(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "archupd") // defaults to x86_64
+
+	if _, err := client.UpdateFunctionCode(ctx, &awslambda.UpdateFunctionCodeInput{
+		FunctionName:  aws.String("archupd"),
+		ZipFile:       []byte("new-code"),
+		Architectures: []lambdatypes.Architecture{lambdatypes.ArchitectureArm64},
+	}); err != nil {
+		t.Fatalf("UpdateFunctionCode(Architectures): %v", err)
+	}
+
+	got, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("archupd"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConfiguration: %v", err)
+	}
+	if archs := got.Architectures; len(archs) != 1 || archs[0] != lambdatypes.ArchitectureArm64 {
+		t.Fatalf("Architectures = %v, want [arm64]", got.Architectures)
+	}
+
+	// An unknown architecture on update is rejected.
+	_, err = client.UpdateFunctionCode(ctx, &awslambda.UpdateFunctionCodeInput{
+		FunctionName:  aws.String("archupd"),
+		ZipFile:       []byte("z"),
+		Architectures: []lambdatypes.Architecture{"sparc"},
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValueException" {
+		t.Fatalf("UpdateFunctionCode(arch sparc) err = %v, want InvalidParameterValueException", err)
+	}
+}


### PR DESCRIPTION
## Summary

Real-user e2e audit of AWS Lambda (SDK + AWS CLI + Terraform against `cloudemu serve`) surfaced two genuine Terraform-drift bugs on the update path. Both are fixed here.

## Divergences fixed

1. **UpdateFunctionConfiguration dropped `EphemeralStorage`.** The request type had no `EphemeralStorage` field and `serveConfiguration` never applied it, so `GetFunction` kept reporting the create-time `/tmp` size — Terraform re-planned `ephemeral_storage` on every apply. Per the [UpdateFunctionConfiguration API reference](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunctionConfiguration.html), `EphemeralStorage` is a request-body parameter (and `Architectures` is not). Now wired through with the same 512–10240 MB range validation as create.

2. **UpdateFunctionCode dropped `Architectures`.** The request type had no `Architectures` field and `serveCode` never persisted it, so `GetFunction` kept reporting the create-time architecture — Terraform re-planned `architectures` on every apply. Per the [UpdateFunctionCode API reference](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunctionCode.html), `Architectures` is a request-body parameter (x86_64|arm64) on that API (and `EphemeralStorage` is not). Now persisted, with enum validation added to both the update-code and create paths (rejected with `InvalidParameterValueException`, matching AWS).

## Evidence

`terraform apply` of an `aws_lambda_function` changing `architectures = ["arm64"]` + `ephemeral_storage { size = 1024 }`, then `terraform plan`:
- Before: plan showed both attributes re-planned forever (exit 2, drift).
- After: `No changes. Your infrastructure matches the configuration.` (exit 0).

Also verified via aws-cli that the two fields persist across get-function-configuration and that invalid values are rejected.

## Tests / gates

- New SDK regression tests: `TestSDKUpdateFunctionConfigurationEphemeralStorage`, `TestSDKUpdateFunctionCodeArchitectures`.
- `go build ./...`, `go test -race` on `server/aws/lambda/...` + `providers/aws/lambda/...`, root `go test .` (Lambda version behavior), `go vet`, `gofmt`, and `golangci-lint` (new-from-rev and full-package on the changed package) all green.
- `go generate ./...` produced no docs/coverage changes (no new operations).