### PR TITLE
fix(azure-sql): real-user e2e divergences from Azure SQL

### DIFF
--- a/providers/azure/sql/databases.go
+++ b/providers/azure/sql/databases.go
@@ -136,9 +136,7 @@ func withDatabaseDefaults(cfg *rdsdriver.DatabaseConfig) {
 		cfg.SKUName = "GP_Gen5_2"
 	}
 
-	if cfg.SKUTier == "" {
-		cfg.SKUTier = "GeneralPurpose"
-	}
+	deriveDatabaseSKU(cfg)
 
 	if cfg.Collation == "" {
 		cfg.Collation = defaultCollation
@@ -154,6 +152,25 @@ func withDatabaseDefaults(cfg *rdsdriver.DatabaseConfig) {
 
 	if cfg.ReadScale == "" {
 		cfg.ReadScale = defaultReadScale
+	}
+}
+
+// deriveDatabaseSKU fills the tier and vCore capacity implied by the database's
+// service-objective (SKU) name, so a create/update that supplies only the name
+// (e.g. azurerm's sku_name) stores — and therefore reads back and reports to
+// Resource Graph — the tier real Azure derives from it. The name is
+// authoritative: "S0" is Standard, not the old hardcoded GeneralPurpose. An
+// unrecognized name (e.g. an elastic-pool sku) derives nothing and leaves the
+// caller's values intact.
+func deriveDatabaseSKU(cfg *rdsdriver.DatabaseConfig) {
+	tier, _, capacity := rdsdriver.ParseAzureSQLSKU(cfg.SKUName)
+
+	if tier != "" {
+		cfg.SKUTier = tier
+	}
+
+	if capacity != 0 {
+		cfg.SKUCapacity = capacity
 	}
 }
 
@@ -218,6 +235,11 @@ func (m *Mock) UpdateDatabase(_ context.Context, cfg rdsdriver.DatabaseConfig) (
 	if cfg.Server == "" || cfg.Name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "server and database name are required")
 	}
+
+	// A PATCH that changes the service-objective (SKU) name must re-derive the
+	// tier/capacity from the new name; otherwise a resize (e.g. S0 → P2) would
+	// keep the stale tier merged over from the stored record.
+	deriveDatabaseSKU(&cfg)
 
 	var updated rdsdriver.Database
 

--- a/providers/azure/sql/sku_derivation_test.go
+++ b/providers/azure/sql/sku_derivation_test.go
@@ -1,0 +1,80 @@
+package sql
+
+import (
+	"context"
+	"testing"
+
+	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+)
+
+// TestCreateDatabaseDerivesTierFromSKUName verifies a create that supplies only
+// the service-objective (SKU) name stores the tier real Azure derives from it —
+// a DTU S0 is Standard (not the old hardcoded GeneralPurpose) — and fills the
+// vCore capacity encoded in the name.
+func TestCreateDatabaseDerivesTierFromSKUName(t *testing.T) {
+	tests := []struct {
+		name         string
+		sku          string
+		wantTier     string
+		wantCapacity int
+	}{
+		{name: "dtu standard", sku: "S0", wantTier: "Standard"},
+		{name: "dtu basic", sku: "Basic", wantTier: "Basic"},
+		{name: "dtu premium", sku: "P2", wantTier: "Premium"},
+		{name: "vcore general purpose", sku: "GP_Gen5_4", wantTier: "GeneralPurpose", wantCapacity: 4},
+		{name: "vcore business critical", sku: "BC_Gen5_8", wantTier: "BusinessCritical", wantCapacity: 8},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			ctx := context.Background()
+			mustServer(t, m, "srv1")
+
+			db, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "srv1", Name: "db1", SKUName: tc.sku})
+			requireNoError(t, err)
+
+			assertEqual(t, tc.sku, db.SKUName)
+			assertEqual(t, tc.wantTier, db.SKUTier)
+			assertEqual(t, tc.wantCapacity, db.SKUCapacity)
+		})
+	}
+}
+
+// TestCreateDatabaseDefaultSKUCapacity verifies the no-SKU default (GP_Gen5_2)
+// carries the vCore capacity the name encodes, not a bare zero.
+func TestCreateDatabaseDefaultSKUCapacity(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustServer(t, m, "srv1")
+
+	db, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "srv1", Name: "db1"})
+	requireNoError(t, err)
+
+	assertEqual(t, "GP_Gen5_2", db.SKUName)
+	assertEqual(t, "GeneralPurpose", db.SKUTier)
+	assertEqual(t, 2, db.SKUCapacity)
+}
+
+// TestUpdateDatabaseRedeivesTierOnResize verifies a PATCH that changes the SKU
+// name re-derives the tier/capacity from the new name rather than keeping the
+// stale stored tier (S0 Standard → P2 Premium).
+func TestUpdateDatabaseRedeivesTierOnResize(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustServer(t, m, "srv1")
+
+	if _, err := m.CreateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "srv1", Name: "db1", SKUName: "S0"}); err != nil {
+		t.Fatalf("CreateDatabase: %v", err)
+	}
+
+	upd, err := m.UpdateDatabase(ctx, rdsdriver.DatabaseConfig{Server: "srv1", Name: "db1", SKUName: "P2"})
+	requireNoError(t, err)
+
+	assertEqual(t, "P2", upd.SKUName)
+	assertEqual(t, "Premium", upd.SKUTier)
+
+	got, err := m.GetDatabase(ctx, "srv1", "db1")
+	requireNoError(t, err)
+	assertEqual(t, "Premium", got.SKUTier)
+}

--- a/server/azure/sql/sku_family_sdk_test.go
+++ b/server/azure/sql/sku_family_sdk_test.go
@@ -1,0 +1,69 @@
+package sql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
+)
+
+// TestSDKAzureSQLDatabaseSKUFamilyAndTier verifies that a database create which
+// supplies only the service-objective (SKU) name reads back the tier, hardware
+// family and vCore capacity real Azure derives from it — so armsql / az CLI /
+// Resource Graph see a vCore GP_Gen5_2 as GeneralPurpose/Gen5/2 and a DTU S0 as
+// Standard (not the old hardcoded GeneralPurpose for every database).
+func TestSDKAzureSQLDatabaseSKUFamilyAndTier(t *testing.T) {
+	servers, dbs := newSDKClients(t)
+	ctx := context.Background()
+
+	createServer(ctx, t, servers, "srv1")
+
+	// vCore: name alone must yield tier + family + capacity.
+	createDB(ctx, t, dbs, "srv1", "vcdb", &armsql.SKU{Name: to.Ptr("GP_Gen5_2")})
+
+	got, err := dbs.Get(ctx, "rg-1", "srv1", "vcdb", nil)
+	if err != nil {
+		t.Fatalf("Get vcdb: %v", err)
+	}
+
+	assertSKU(t, got.Database.SKU, "GeneralPurpose", "Gen5", 2)
+	assertSKU(t, got.Database.Properties.CurrentSKU, "GeneralPurpose", "Gen5", 2)
+
+	// DTU: S0 is Standard tier, no hardware family.
+	createDB(ctx, t, dbs, "srv1", "dtudb", &armsql.SKU{Name: to.Ptr("S0")})
+
+	gotDTU, err := dbs.Get(ctx, "rg-1", "srv1", "dtudb", nil)
+	if err != nil {
+		t.Fatalf("Get dtudb: %v", err)
+	}
+
+	if gotDTU.Database.SKU == nil || gotDTU.Database.SKU.Tier == nil || *gotDTU.Database.SKU.Tier != "Standard" {
+		t.Fatalf("dtu sku.tier = %v, want Standard", gotDTU.Database.SKU)
+	}
+
+	if gotDTU.Database.SKU.Family != nil {
+		t.Fatalf("dtu sku.family = %v, want unset", *gotDTU.Database.SKU.Family)
+	}
+}
+
+// assertSKU checks a returned armsql SKU's tier/family/capacity.
+func assertSKU(t *testing.T, sku *armsql.SKU, tier, family string, capacity int32) {
+	t.Helper()
+
+	if sku == nil {
+		t.Fatal("sku is nil")
+	}
+
+	if sku.Tier == nil || *sku.Tier != tier {
+		t.Errorf("sku.tier = %v, want %s", sku.Tier, tier)
+	}
+
+	if sku.Family == nil || *sku.Family != family {
+		t.Errorf("sku.family = %v, want %s", sku.Family, family)
+	}
+
+	if sku.Capacity == nil || *sku.Capacity != capacity {
+		t.Errorf("sku.capacity = %v, want %d", sku.Capacity, capacity)
+	}
+}

--- a/server/azure/sql/types.go
+++ b/server/azure/sql/types.go
@@ -46,6 +46,7 @@ type armDatabase struct {
 type armSKU struct {
 	Name     string `json:"name,omitempty"`
 	Tier     string `json:"tier,omitempty"`
+	Family   string `json:"family,omitempty"`
 	Capacity int    `json:"capacity,omitempty"`
 }
 
@@ -118,19 +119,21 @@ func toARMDatabase(db *rdsdriver.Database, rp *azurearm.ResourcePath, status str
 		elasticPoolID = &db.ElasticPoolID
 	}
 
+	sku := databaseSKU(db)
+
 	return armDatabase{
 		ID:       armDatabaseID(rp.Subscription, rp.ResourceGroup, db.Server, db.Name),
 		Name:     db.Name,
 		Type:     providerName + "/servers/databases",
 		Location: db.Location,
 		Tags:     db.Tags,
-		SKU:      &armSKU{Name: db.SKUName, Tier: db.SKUTier, Capacity: db.SKUCapacity},
+		SKU:      sku,
 		Properties: &armDatabaseProps{
 			Status:                           status,
 			Collation:                        db.Collation,
 			DatabaseID:                       databaseGUID(db),
 			CurrentServiceObjectiveName:      db.SKUName,
-			CurrentSKU:                       &armSKU{Name: db.SKUName, Tier: db.SKUTier, Capacity: db.SKUCapacity},
+			CurrentSKU:                       databaseSKU(db),
 			MaxSizeBytes:                     db.MaxSizeBytes,
 			ReadScale:                        db.ReadScale,
 			RequestedBackupStorageRedundancy: db.BackupStorageRedundancy,
@@ -138,6 +141,22 @@ func toARMDatabase(db *rdsdriver.Database, rp *azurearm.ResourcePath, status str
 			ZoneRedundant:                    &zoneRedundant,
 			ElasticPoolID:                    elasticPoolID,
 		},
+	}
+}
+
+// databaseSKU builds the ARM sku object for a database. The stored tier and
+// capacity are name-authoritative (set on create/update by the provider); the
+// hardware family (Gen5, Fsv2, …) is not stored, so it is derived from the sku
+// name here — real Azure reports family for vCore databases and omits it for the
+// DTU model.
+func databaseSKU(db *rdsdriver.Database) *armSKU {
+	_, family, _ := rdsdriver.ParseAzureSQLSKU(db.SKUName)
+
+	return &armSKU{
+		Name:     db.SKUName,
+		Tier:     db.SKUTier,
+		Family:   family,
+		Capacity: db.SKUCapacity,
 	}
 }
 

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -7,6 +7,7 @@ package driver
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"time"
 
@@ -997,6 +998,109 @@ func SourceDatabaseRef(id string) (server, database string, ok bool) {
 	}
 
 	return server, database, true
+}
+
+// ParseAzureSQLSKU derives the tier, hardware family and vCore/DTU capacity that
+// real Azure SQL reports for a database service-objective (SKU) name, so a create
+// that supplies only the name reads back the full sku object real Azure fills in.
+// The service-objective name is authoritative: Azure ignores a mismatched
+// tier/capacity in the request and returns the values the name implies.
+//
+//   - vCore names encode tier_[S_]family_capacity: "GP_Gen5_2" → GeneralPurpose,
+//     Gen5, 2; "GP_S_Gen5_2" (serverless) → GeneralPurpose, Gen5, 2;
+//     "BC_Gen5_4" → BusinessCritical, Gen5, 4; "HS_Gen5_2" → Hyperscale, Gen5, 2.
+//   - DTU names encode only the tier: "S0"/"S3" → Standard, "P1" → Premium,
+//     "Basic" → Basic (their fixed DTU capacity is not encoded in the name and is
+//     left to the caller).
+//
+// Returns zero values for an unrecognized name (e.g. an elastic-pool sku), so a
+// caller derives nothing and keeps whatever it already holds. Shared by the
+// provider (which stores the sku so Resource Graph discovery reports the right
+// tier) and the wire server (which echoes sku.family on read), so the two never
+// derive the sku differently.
+func ParseAzureSQLSKU(name string) (tier, family string, capacity int) {
+	if name == "" {
+		return "", "", 0
+	}
+
+	parts := strings.Split(name, "_")
+
+	switch parts[0] {
+	case "GP":
+		tier = "GeneralPurpose"
+	case "BC":
+		tier = "BusinessCritical"
+	case "HS":
+		tier = "Hyperscale"
+	}
+
+	if tier != "" {
+		family, capacity = vCoreFamilyCapacity(parts)
+		return tier, family, capacity
+	}
+
+	return dtuTier(name), "", 0
+}
+
+// vCorePartsWithFamily is the minimum "_"-split segment count of a vCore sku name
+// that carries a hardware family: tier_family_capacity (e.g. GP_Gen5_2). Fewer
+// segments (e.g. an elastic-pool "GP_Gen5") carry no family.
+const vCorePartsWithFamily = 3
+
+// vCoreFamilyCapacity extracts the hardware family and vCore count from the parts
+// of a vCore sku name split on "_". The capacity is the trailing integer segment;
+// the family is the segment before it (Gen5, Fsv2, DC, …). A name with no numeric
+// tail (e.g. an elastic-pool "GP_Gen5") yields no family/capacity. parts always
+// has at least one element (strings.Split never returns empty), so the trailing
+// index is safe; a name that is only a prefix fails the Atoi and yields nothing.
+func vCoreFamilyCapacity(parts []string) (family string, capacity int) {
+	n := len(parts)
+
+	c, err := strconv.Atoi(parts[n-1])
+	if err != nil {
+		return "", 0
+	}
+
+	capacity = c
+
+	if n >= vCorePartsWithFamily {
+		family = parts[n-2]
+	}
+
+	return family, capacity
+}
+
+// dtuTier maps a DTU service-objective name to its pricing tier. Basic, the
+// Standard series (S0–S12) and the Premium series (P1–P15) are the DTU purchasing
+// model; every other name is a non-DTU sku this helper does not classify.
+func dtuTier(name string) string {
+	const basic = "Basic" // sku name and its pricing tier share the literal
+
+	switch {
+	case name == basic:
+		return basic
+	case strings.HasPrefix(name, "S") && isAllDigits(name[1:]):
+		return "Standard"
+	case strings.HasPrefix(name, "P") && isAllDigits(name[1:]):
+		return "Premium"
+	default:
+		return ""
+	}
+}
+
+// isAllDigits reports whether s is non-empty and every byte is an ASCII digit.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+
+	return true
 }
 
 // FailoverGroupConfig describes a failover group to create (Azure SQL).

--- a/services/relationaldb/driver/parse_azure_sql_sku_test.go
+++ b/services/relationaldb/driver/parse_azure_sql_sku_test.go
@@ -1,0 +1,47 @@
+package driver
+
+import "testing"
+
+func TestParseAzureSQLSKU(t *testing.T) {
+	tests := []struct {
+		name         string
+		sku          string
+		wantTier     string
+		wantFamily   string
+		wantCapacity int
+	}{
+		{name: "vcore general purpose", sku: "GP_Gen5_2", wantTier: "GeneralPurpose", wantFamily: "Gen5", wantCapacity: 2},
+		{name: "vcore general purpose larger", sku: "GP_Gen5_8", wantTier: "GeneralPurpose", wantFamily: "Gen5", wantCapacity: 8},
+		{name: "vcore serverless", sku: "GP_S_Gen5_2", wantTier: "GeneralPurpose", wantFamily: "Gen5", wantCapacity: 2},
+		{name: "vcore business critical", sku: "BC_Gen5_4", wantTier: "BusinessCritical", wantFamily: "Gen5", wantCapacity: 4},
+		{name: "vcore hyperscale", sku: "HS_Gen5_2", wantTier: "Hyperscale", wantFamily: "Gen5", wantCapacity: 2},
+		{name: "vcore fsv2 family", sku: "GP_Fsv2_8", wantTier: "GeneralPurpose", wantFamily: "Fsv2", wantCapacity: 8},
+		{name: "elastic pool sku no capacity", sku: "GP_Gen5", wantTier: "GeneralPurpose"},
+		{name: "dtu standard S0", sku: "S0", wantTier: "Standard"},
+		{name: "dtu standard S3", sku: "S3", wantTier: "Standard"},
+		{name: "dtu premium P2", sku: "P2", wantTier: "Premium"},
+		{name: "dtu basic", sku: "Basic", wantTier: "Basic"},
+		{name: "empty", sku: ""},
+		{name: "unrecognized pool sku", sku: "StandardPool"},
+		{name: "premium without digits", sku: "Premium"},
+		{name: "bare vcore prefix", sku: "GP", wantTier: "GeneralPurpose"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tier, family, capacity := ParseAzureSQLSKU(tc.sku)
+
+			if tier != tc.wantTier {
+				t.Errorf("tier = %q, want %q", tier, tc.wantTier)
+			}
+
+			if family != tc.wantFamily {
+				t.Errorf("family = %q, want %q", family, tc.wantFamily)
+			}
+
+			if capacity != tc.wantCapacity {
+				t.Errorf("capacity = %d, want %d", capacity, tc.wantCapacity)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Real-user e2e audit (armsql SDK + `cloudemu serve` Azure HTTPS wire) of Azure SQL `Microsoft.Sql` servers + databases. The server surface and most of the database surface already round-trip correctly against real azurerm/armsql. One genuine divergence found and fixed.

### Divergence: database SKU tier/family/capacity not derived from the service-objective name

Every database reported `sku.tier` and `properties.currentSku.tier` = **GeneralPurpose** regardless of the SKU name. A DTU database (`S0`, `S2`, `Basic`, `P2`) therefore read back `GeneralPurpose` where real Azure returns `Standard` / `Basic` / `Premium`, and vCore SKUs omitted `sku.family` / `sku.capacity` (real Azure returns `family=Gen5`, `capacity=2` for `GP_Gen5_2`).

The wrong tier was user-visible three ways: the armsql SDK / `az sql db show` GET response, and Azure Resource Graph discovery (`providers/azure/azure.go` emits the stored `SKUTier` into `currentSku.tier`).

### Fix

- New shared pure helper `rdsdriver.ParseAzureSQLSKU(name) (tier, family, capacity)` — mirrors the existing `ElasticPoolName` / `SourceDatabaseRef` shared parsers so the provider and the wire never derive the SKU differently. The service-objective name is authoritative (matches real Azure).
- Provider (`providers/azure/sql`) stores the derived tier + capacity on create, and **re-derives on a PATCH resize** so changing `S0` → `P2` no longer keeps the stale tier.
- Wire (`server/azure/sql`) echoes the hardware `family` (not a stored field) on read for both `sku` and `currentSku`.

### Live evidence (serve :16790, post-fix)

- `S0` → `sku={name:S0, tier:Standard}` (was `GeneralPurpose`)
- `GP_Gen5_2` → `sku={name:GP_Gen5_2, tier:GeneralPurpose, family:Gen5, capacity:2}`
- `Basic` → `sku={name:Basic, tier:Basic}`
- PATCH `S0` → `P2` → `sku={name:P2, tier:Premium}`

### Tests

- `services/relationaldb/driver/parse_azure_sql_sku_test.go` — table-driven parser coverage.
- `providers/azure/sql/sku_derivation_test.go` — create-time tier/capacity derivation + PATCH re-derive.
- `server/azure/sql/sku_family_sdk_test.go` — armsql SDK round-trip of tier/family/capacity.

### Gates

`go build`, `go test -race` (providers/azure/sql, server/azure/sql, services/relationaldb), full `server/azure` (echo_properties + newly modeled `sku.family`), root `go test .`, providers/azure + persist, `go vet`, `gofmt`, `golangci-lint --new-from-rev=origin/development` (0 issues) — all green. `go generate` produced no `docs/coverage` diff.

### Out of scope (filed)

- DTU `sku.capacity` (e.g. S0=10) still omitted — not encoded in the name; azurerm does not read it. Low.
- PATCH on a nonexistent database creates it instead of returning 404; azurerm always uses PUT so it never hits this. Low.