### PR TITLE
fix(gcs): real-user e2e divergences from GCP Cloud Storage

### DIFF
--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -96,10 +96,14 @@ type bucketMeta struct {
 	lifecycle  *driver.LifecycleConfig
 	multiparts *memstore.Store[*gcsMultipartUpload]
 	versioning bool
-	policy     *driver.BucketPolicy
-	corsConfig *driver.CORSConfig
-	encryption *driver.EncryptionConfig
-	tags       map[string]string
+	// versioningSet records whether versioning has ever been explicitly
+	// configured, so the GCS wire layer can return {enabled:false} for a bucket
+	// that was disabled versus omitting the field for one never configured.
+	versioningSet bool
+	policy        *driver.BucketPolicy
+	corsConfig    *driver.CORSConfig
+	encryption    *driver.EncryptionConfig
+	tags          map[string]string
 
 	// mu guards the GCS-specific mutable fields below (location/storageClass,
 	// metageneration/updated, iamPolicy, lifecycle, and the archived version
@@ -1177,6 +1181,7 @@ func (m *Mock) SetBucketVersioning(_ context.Context, bucket string, enabled boo
 	}
 
 	bkt.versioning = enabled
+	bkt.versioningSet = true
 
 	return nil
 }
@@ -1626,7 +1631,9 @@ func (m *Mock) SetBucketAttrsGCS(_ context.Context, bucket, location, storageCla
 	defer bkt.mu.Unlock()
 
 	if location != "" {
-		bkt.location = location
+		// Real GCS normalizes and returns bucket locations in upper case
+		// (e.g. "US-CENTRAL1", "EU"), regardless of the case supplied at create.
+		bkt.location = strings.ToUpper(location)
 	}
 
 	if storageClass != "" {
@@ -1651,6 +1658,8 @@ func (m *Mock) BucketAttrsGCS(_ context.Context, bucket string) (driver.GCSBucke
 		StorageClass:   bkt.storageClass,
 		Metageneration: bkt.metageneration,
 		Updated:        bkt.updated,
+		Versioning:     bkt.versioning,
+		VersioningSet:  bkt.versioningSet,
 	}, nil
 }
 

--- a/providers/gcp/gcs/snapshot.go
+++ b/providers/gcp/gcs/snapshot.go
@@ -29,6 +29,7 @@ type bucketSnapshot struct {
 	Region                 string                                  `json:"region,omitempty"`
 	CreatedAt              string                                  `json:"createdAt,omitempty"`
 	Versioning             bool                                    `json:"versioning,omitempty"`
+	VersioningSet          bool                                    `json:"versioningSet,omitempty"`
 	Lifecycle              *driver.LifecycleConfig                 `json:"lifecycle,omitempty"`
 	LifecycleRaw           []byte                                  `json:"lifecycleRaw,omitempty"`
 	Policy                 *driver.BucketPolicy                    `json:"policy,omitempty"`
@@ -106,7 +107,8 @@ func (m *Mock) Snapshot(_ context.Context, includeAssets bool) (json.RawMessage,
 func snapshotBucket(bkt *bucketMeta, includeAssets bool) *bucketSnapshot {
 	bs := &bucketSnapshot{
 		Name: bkt.Name, Region: bkt.Region, CreatedAt: bkt.CreatedAt,
-		Versioning: bkt.versioning, Lifecycle: bkt.lifecycle, LifecycleRaw: bkt.gcsLifecycleRaw, Policy: bkt.policy,
+		Versioning: bkt.versioning, VersioningSet: bkt.versioningSet,
+		Lifecycle: bkt.lifecycle, LifecycleRaw: bkt.gcsLifecycleRaw, Policy: bkt.policy,
 		CORS: bkt.corsConfig, Encryption: bkt.encryption, Tags: bkt.tags,
 		Location: bkt.location, StorageClass: bkt.storageClass,
 		Metageneration: bkt.metageneration, Updated: bkt.updated, IAMPolicy: bkt.iamPolicy,
@@ -215,8 +217,8 @@ func restoreBucket(bs *bucketSnapshot) *bucketMeta {
 		Name: bs.Name, Region: bs.Region, CreatedAt: bs.CreatedAt,
 		objects:    memstore.New[*gcsObject](),
 		multiparts: memstore.New[*gcsMultipartUpload](),
-		versioning: bs.Versioning,
-		lifecycle:  bs.Lifecycle, gcsLifecycleRaw: bs.LifecycleRaw, policy: bs.Policy, corsConfig: bs.CORS,
+		versioning: bs.Versioning, versioningSet: bs.VersioningSet,
+		lifecycle: bs.Lifecycle, gcsLifecycleRaw: bs.LifecycleRaw, policy: bs.Policy, corsConfig: bs.CORS,
 		encryption: bs.Encryption, tags: bs.Tags,
 		location: bs.Location, storageClass: bs.StorageClass,
 		metageneration: metagen, updated: bs.Updated, iamPolicy: bs.IAMPolicy,

--- a/server/gcp/gcs/cors.go
+++ b/server/gcp/gcs/cors.go
@@ -1,0 +1,49 @@
+package gcs
+
+import (
+	"context"
+
+	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// putCORS applies a bucket's cors[] configuration. An empty (but present) rule
+// set clears the configuration, mirroring real GCS where a Buckets patch with
+// "cors":[] removes all CORS rules.
+func (h *Handler) putCORS(ctx context.Context, bucket string, rules []corsRule) error {
+	if len(rules) == 0 {
+		return h.bucket.DeleteCORSConfig(ctx, bucket)
+	}
+
+	cfg := storagedriver.CORSConfig{Rules: make([]storagedriver.CORSRule, 0, len(rules))}
+	for _, rule := range rules {
+		cfg.Rules = append(cfg.Rules, storagedriver.CORSRule{
+			AllowedOrigins: rule.Origin,
+			AllowedMethods: rule.Method,
+			ExposeHeaders:  rule.ResponseHeader,
+			MaxAgeSeconds:  rule.MaxAgeSeconds,
+		})
+	}
+
+	return h.bucket.PutCORSConfig(ctx, bucket, cfg)
+}
+
+// corsView renders the stored CORS configuration for a bucket as the GCS cors[]
+// array, or nil when none is set.
+func (h *Handler) corsView(ctx context.Context, bucket string) []corsRule {
+	cfg, err := h.bucket.GetCORSConfig(ctx, bucket)
+	if err != nil || cfg == nil || len(cfg.Rules) == 0 {
+		return nil
+	}
+
+	out := make([]corsRule, 0, len(cfg.Rules))
+	for _, rule := range cfg.Rules {
+		out = append(out, corsRule{
+			Origin:         rule.AllowedOrigins,
+			Method:         rule.AllowedMethods,
+			ResponseHeader: rule.ExposeHeaders,
+			MaxAgeSeconds:  rule.MaxAgeSeconds,
+		})
+	}
+
+	return out
+}

--- a/server/gcp/gcs/gcs_bucket_roundtrip_test.go
+++ b/server/gcp/gcs/gcs_bucket_roundtrip_test.go
@@ -1,0 +1,238 @@
+package gcs_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// TestGCSBucketCORSRoundTrip proves a bucket's cors[] configuration set at
+// create is read back, and that a patch replaces it — real GCS persists the
+// cors field (google_storage_bucket's cors block), which was previously
+// accepted-and-dropped by the wire layer.
+func TestGCSBucketCORSRoundTrip(t *testing.T) {
+	ctx, client := newStorageClient(t)
+
+	bkt := client.Bucket("cors-cfg")
+	if err := bkt.Create(ctx, e2eProject, &storage.BucketAttrs{
+		CORS: []storage.CORS{{
+			MaxAge:          time.Hour,
+			Methods:         []string{"GET", "HEAD"},
+			Origins:         []string{"*"},
+			ResponseHeaders: []string{"Content-Type"},
+		}},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	a, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs: %v", err)
+	}
+
+	if len(a.CORS) != 1 {
+		t.Fatalf("CORS rules = %d, want 1 (cors dropped on round-trip)", len(a.CORS))
+	}
+
+	rule := a.CORS[0]
+	if rule.MaxAge != time.Hour {
+		t.Errorf("MaxAge = %v, want 1h", rule.MaxAge)
+	}
+
+	if len(rule.Methods) != 2 || rule.Methods[0] != "GET" || rule.Methods[1] != "HEAD" {
+		t.Errorf("Methods = %v, want [GET HEAD]", rule.Methods)
+	}
+
+	if len(rule.Origins) != 1 || rule.Origins[0] != "*" {
+		t.Errorf("Origins = %v, want [*]", rule.Origins)
+	}
+
+	if len(rule.ResponseHeaders) != 1 || rule.ResponseHeaders[0] != "Content-Type" {
+		t.Errorf("ResponseHeaders = %v, want [Content-Type]", rule.ResponseHeaders)
+	}
+
+	// A patch replaces the rule set.
+	if _, err := bkt.Update(ctx, storage.BucketAttrsToUpdate{
+		CORS: []storage.CORS{{
+			MaxAge:  2 * time.Hour,
+			Methods: []string{"PUT"},
+			Origins: []string{"https://example.com"},
+		}},
+	}); err != nil {
+		t.Fatalf("Update CORS: %v", err)
+	}
+
+	a2, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs after update: %v", err)
+	}
+
+	if len(a2.CORS) != 1 || a2.CORS[0].MaxAge != 2*time.Hour || a2.CORS[0].Methods[0] != "PUT" {
+		t.Errorf("CORS after patch = %+v, want the replaced rule", a2.CORS)
+	}
+}
+
+// TestGCSBucketLocationUppercased proves a lower-case location supplied at
+// create is normalized to upper case on read, matching real GCS (which always
+// returns e.g. "US-CENTRAL1").
+func TestGCSBucketLocationUppercased(t *testing.T) {
+	ctx, client := newStorageClient(t)
+
+	bkt := client.Bucket("loc-lower")
+	if err := bkt.Create(ctx, e2eProject, &storage.BucketAttrs{Location: "us-central1"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	a, err := bkt.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("Attrs: %v", err)
+	}
+
+	if a.Location != "US-CENTRAL1" {
+		t.Errorf("Location = %q, want US-CENTRAL1 (GCS uppercases locations)", a.Location)
+	}
+}
+
+// TestGCSBucketLabelMergePatch proves a Buckets.patch merges labels rather than
+// replacing them, and that a label mapped to null is deleted — the semantics the
+// SDK/Terraform rely on (SetLabel/DeleteLabel send only the changed keys, with a
+// deleted key encoded as JSON null).
+func TestGCSBucketLabelMergePatch(t *testing.T) {
+	ctx, client := newStorageClient(t)
+
+	bkt := client.Bucket("labels-merge")
+	if err := bkt.Create(ctx, e2eProject, &storage.BucketAttrs{
+		Labels: map[string]string{"env": "test", "team": "platform", "region": "us"},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	upd := storage.BucketAttrsToUpdate{}
+	upd.SetLabel("env", "prod")
+	upd.DeleteLabel("team")
+
+	a, err := bkt.Update(ctx, upd)
+	if err != nil {
+		t.Fatalf("Update labels: %v", err)
+	}
+
+	want := map[string]string{"env": "prod", "region": "us"}
+	if len(a.Labels) != len(want) {
+		t.Fatalf("Labels = %v, want %v", a.Labels, want)
+	}
+
+	for k, v := range want {
+		if a.Labels[k] != v {
+			t.Errorf("Labels[%q] = %q, want %q", k, a.Labels[k], v)
+		}
+	}
+
+	if _, ok := a.Labels["team"]; ok {
+		t.Errorf("label 'team' should have been deleted by a null patch, got %q", a.Labels["team"])
+	}
+}
+
+// TestGCSBucketVersioningDisabledWireField proves the wire distinction Terraform
+// depends on: a bucket that never configured versioning omits the versioning
+// field entirely, while a bucket whose versioning was explicitly disabled
+// returns {"enabled":false}. At the SDK level both read as VersioningEnabled ==
+// false, so the presence/absence of the field — which drives whether a
+// `versioning { enabled = false }` block perpetually diffs — is asserted on the
+// raw JSON.
+func TestGCSBucketVersioningDisabledWireField(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Storage: cloudP.GCS})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx,
+		option.WithEndpoint(ts.URL+"/storage/v1/"),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("storage.NewClient: %v", err)
+	}
+	client.SetRetry(storage.WithPolicy(storage.RetryNever))
+	t.Cleanup(func() { _ = client.Close() })
+
+	// A bucket that never configured versioning must omit the field.
+	if err := client.Bucket("ver-plain").Create(ctx, e2eProject, nil); err != nil {
+		t.Fatalf("create plain: %v", err)
+	}
+
+	if _, present := bucketVersioningField(t, ts, "ver-plain"); present {
+		t.Errorf("versioning field present on a never-configured bucket, want omitted")
+	}
+
+	// A bucket disabled after being enabled must return {enabled:false}.
+	bkt := client.Bucket("ver-toggle")
+	if err := bkt.Create(ctx, e2eProject, nil); err != nil {
+		t.Fatalf("create toggle: %v", err)
+	}
+
+	if _, err := bkt.Update(ctx, storage.BucketAttrsToUpdate{VersioningEnabled: true}); err != nil {
+		t.Fatalf("enable versioning: %v", err)
+	}
+
+	if _, err := bkt.Update(ctx, storage.BucketAttrsToUpdate{VersioningEnabled: false}); err != nil {
+		t.Fatalf("disable versioning: %v", err)
+	}
+
+	enabled, present := bucketVersioningField(t, ts, "ver-toggle")
+	if !present {
+		t.Fatalf("versioning field omitted after an explicit disable, want {enabled:false}")
+	}
+
+	if enabled {
+		t.Errorf("versioning.enabled = true after disable, want false")
+	}
+}
+
+// bucketVersioningField GETs the raw bucket JSON and reports the versioning
+// block's enabled value and whether the versioning field was present at all.
+func bucketVersioningField(t *testing.T, ts *httptest.Server, name string) (enabled, present bool) {
+	t.Helper()
+
+	resp, err := ts.Client().Get(ts.URL + "/storage/v1/b/" + name)
+	if err != nil {
+		t.Fatalf("GET bucket %q: %v", name, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read bucket %q body: %v", name, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET bucket %q status = %d: %s", name, resp.StatusCode, body)
+	}
+
+	var doc struct {
+		Versioning *struct {
+			Enabled bool `json:"enabled"`
+		} `json:"versioning"`
+	}
+
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("unmarshal bucket %q: %v", name, err)
+	}
+
+	if doc.Versioning == nil {
+		return false, false
+	}
+
+	return doc.Versioning.Enabled, true
+}

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -366,8 +366,8 @@ func (h *Handler) createBucket(w http.ResponseWriter, r *http.Request) {
 		_ = h.bucket.PutBucketTagging(r.Context(), body.Name, body.Labels)
 	}
 
-	if body.Versioning != nil && body.Versioning.Enabled {
-		_ = h.bucket.SetBucketVersioning(r.Context(), body.Name, true)
+	if body.Versioning != nil {
+		_ = h.bucket.SetBucketVersioning(r.Context(), body.Name, body.Versioning.Enabled)
 	}
 
 	if h.ext != nil {
@@ -376,6 +376,10 @@ func (h *Handler) createBucket(w http.ResponseWriter, r *http.Request) {
 
 	if body.Lifecycle != nil {
 		_ = h.putLifecycle(r.Context(), body.Name, body.Lifecycle)
+	}
+
+	if body.Cors != nil {
+		_ = h.putCORS(r.Context(), body.Name, body.Cors)
 	}
 
 	_ = h.applyIAMConfig(r.Context(), body.Name, body.IamConfiguration)
@@ -439,8 +443,8 @@ func (h *Handler) bucketView(r *http.Request, name, created string) bucketResour
 		IamConfiguration: h.iamConfigView(r.Context(), name),
 	}
 
-	if enabled, err := h.bucket.GetBucketVersioning(r.Context(), name); err == nil && enabled {
-		res.Versioning = &bucketVersioning{Enabled: true}
+	if v := h.versioningView(r.Context(), name); v != nil {
+		res.Versioning = v
 	}
 
 	if labels, err := h.bucket.GetBucketTagging(r.Context(), name); err == nil && len(labels) > 0 {
@@ -453,6 +457,10 @@ func (h *Handler) bucketView(r *http.Request, name, created string) bucketResour
 
 	if rp := h.retentionView(r.Context(), name); rp != nil {
 		res.RetentionPolicy = rp
+	}
+
+	if cors := h.corsView(r.Context(), name); cors != nil {
+		res.Cors = cors
 	}
 
 	return res
@@ -494,6 +502,28 @@ func (h *Handler) resolveBucketAttrs(
 	return location, storageClass, metageneration, updated
 }
 
+// versioningView renders the bucket's versioning sub-resource, or nil when it
+// should be omitted. Real GCS omits versioning entirely for a bucket that has
+// never had it configured, but returns {enabled:false} once it has been
+// disabled — so a Terraform `versioning { enabled = false }` block does not
+// perpetually diff. The GCSExtensions capability tracks the "ever set" bit; the
+// fallback path (no capability) can only emit when versioning is enabled.
+func (h *Handler) versioningView(ctx context.Context, name string) *bucketVersioning {
+	if h.ext != nil {
+		if attrs, err := h.ext.BucketAttrsGCS(ctx, name); err == nil && attrs.VersioningSet {
+			return &bucketVersioning{Enabled: attrs.Versioning}
+		}
+
+		return nil
+	}
+
+	if enabled, err := h.bucket.GetBucketVersioning(ctx, name); err == nil && enabled {
+		return &bucketVersioning{Enabled: true}
+	}
+
+	return nil
+}
+
 // locationType classifies a GCS location as a multi-region or a region, which
 // real GCS reports in the locationType field.
 func locationType(location string) string {
@@ -505,17 +535,29 @@ func locationType(location string) string {
 	}
 }
 
-// patchBucket applies a bucket configuration update (versioning + labels),
-// which real clients set via Buckets.Patch/Update. Without this the driver's
-// versioning/label capabilities are unreachable over the wire.
+// patchBucket applies a bucket configuration update (versioning, labels,
+// lifecycle, IAM config, retention, CORS), which real clients set via
+// Buckets.Patch/Update. Without this the driver's mutable capabilities are
+// unreachable over the wire.
 func (h *Handler) patchBucket(w http.ResponseWriter, r *http.Request, name string) {
+	raw, ok := readBody(w, r)
+	if !ok {
+		return
+	}
+
 	var body bucketResource
-	if !decodeJSON(w, r, &body) {
+	if err := json.Unmarshal(raw, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid", err.Error())
 		return
 	}
 
 	if err := h.checkBucketMetagenerationPrecondition(r, name); err != nil {
 		writePreconditionOrErr(w, err)
+		return
+	}
+
+	if err := h.applyLabelPatch(r.Context(), name, raw); err != nil {
+		writeErr(w, err)
 		return
 	}
 
@@ -533,6 +575,57 @@ func (h *Handler) patchBucket(w http.ResponseWriter, r *http.Request, name strin
 	}
 
 	writeJSON(w, http.StatusOK, h.bucketView(r, name, ""))
+}
+
+// applyLabelPatch merges the labels field of a Buckets.patch body into the
+// bucket's existing labels using GCS merge-patch semantics: a key mapped to a
+// value is set/overwritten, a key mapped to JSON null is removed, and keys not
+// present in the patch are left untouched. The labels field is decoded from the
+// raw body separately (map[string]*string) so a null value is distinguishable
+// from an empty string — the SDK/Terraform delete a label by sending null.
+func (h *Handler) applyLabelPatch(ctx context.Context, name string, raw []byte) error {
+	var patch struct {
+		Labels map[string]*string `json:"labels"`
+	}
+
+	if err := json.Unmarshal(raw, &patch); err != nil {
+		return err
+	}
+
+	if patch.Labels == nil {
+		return nil
+	}
+
+	merged := map[string]string{}
+
+	if existing, err := h.bucket.GetBucketTagging(ctx, name); err == nil {
+		for k, v := range existing {
+			merged[k] = v
+		}
+	}
+
+	for k, v := range patch.Labels {
+		if v == nil {
+			delete(merged, k)
+			continue
+		}
+
+		merged[k] = *v
+	}
+
+	return h.bucket.PutBucketTagging(ctx, name, merged)
+}
+
+// readBody reads and returns the request body (bounded), writing a 400 and
+// returning ok=false on a read error.
+func readBody(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+	raw, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxPutBodyBytes))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid", "could not read body")
+		return nil, false
+	}
+
+	return raw, true
 }
 
 // checkBucketMetagenerationPrecondition evaluates the Buckets.patch/update
@@ -584,10 +677,12 @@ func (h *Handler) bucketMetageneration(ctx context.Context, name string) int64 {
 }
 
 // applyBucketConfig applies the mutable configuration fields present in a
-// Buckets.patch/update body (versioning, labels, lifecycle, iamConfiguration,
-// retentionPolicy), each only when supplied. It returns the first error
-// encountered. Each field is guarded by a small closure so adding another
-// configuration field does not raise the function's cyclomatic complexity.
+// Buckets.patch/update body (versioning, lifecycle, iamConfiguration,
+// retentionPolicy, cors), each only when supplied. Labels are handled
+// separately by applyLabelPatch (merge-patch with null-delete). It returns the
+// first error encountered. Each field is guarded by a small closure so adding
+// another configuration field does not raise the function's cyclomatic
+// complexity.
 func (h *Handler) applyBucketConfig(ctx context.Context, name string, body *bucketResource) error {
 	appliers := []func() error{
 		func() error {
@@ -596,13 +691,6 @@ func (h *Handler) applyBucketConfig(ctx context.Context, name string, body *buck
 			}
 
 			return h.bucket.SetBucketVersioning(ctx, name, body.Versioning.Enabled)
-		},
-		func() error {
-			if body.Labels == nil {
-				return nil
-			}
-
-			return h.bucket.PutBucketTagging(ctx, name, body.Labels)
 		},
 		func() error {
 			if body.Lifecycle == nil {
@@ -624,6 +712,13 @@ func (h *Handler) applyBucketConfig(ctx context.Context, name string, body *buck
 			}
 
 			return h.applyRetention(ctx, name, body.RetentionPolicy)
+		},
+		func() error {
+			if body.Cors == nil {
+				return nil
+			}
+
+			return h.putCORS(ctx, name, body.Cors)
 		},
 	}
 

--- a/server/gcp/gcs/types.go
+++ b/server/gcp/gcs/types.go
@@ -17,10 +17,22 @@ type bucketResource struct {
 	Lifecycle        *bucketLifecycle  `json:"lifecycle,omitempty"`
 	IamConfiguration *iamConfiguration `json:"iamConfiguration,omitempty"`
 	RetentionPolicy  *retentionPolicy  `json:"retentionPolicy,omitempty"`
+	Cors             []corsRule        `json:"cors,omitempty"`
 	Metageneration   string            `json:"metageneration,omitempty"`
 	Etag             string            `json:"etag,omitempty"`
 	TimeCreated      string            `json:"timeCreated,omitempty"`
 	Updated          string            `json:"updated,omitempty"`
+}
+
+// corsRule is one entry of the bucket cors[] array
+// (https://cloud.google.com/storage/docs/json_api/v1/buckets#cors). Field names
+// match the GCS wire format the SDK/gcloud/Terraform emit: origin, method,
+// responseHeader, maxAgeSeconds.
+type corsRule struct {
+	Origin         []string `json:"origin,omitempty"`
+	Method         []string `json:"method,omitempty"`
+	ResponseHeader []string `json:"responseHeader,omitempty"`
+	MaxAgeSeconds  int      `json:"maxAgeSeconds,omitempty"`
 }
 
 type bucketVersioning struct {

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -1148,6 +1148,14 @@ type GCSBucketMeta struct {
 	StorageClass   string
 	Metageneration int64
 	Updated        string
+	// Versioning is the bucket's current versioning-enabled state, and
+	// VersioningSet reports whether versioning has ever been explicitly
+	// configured. Real GCS omits the versioning field on a bucket that has never
+	// had it set but returns {enabled:false} once it has been disabled, so the
+	// wire layer needs the two apart to avoid a perpetual Terraform diff on a
+	// `versioning { enabled = false }` block.
+	Versioning    bool
+	VersioningSet bool
 }
 
 // GCSExtensions is an OPTIONAL GCS-specific capability, discovered by type


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of GCP Cloud Storage (`google_storage_bucket` + object CRUD) driving `cloudemu serve` with the real `cloud.google.com/go/storage` SDK and the Terraform `hashicorp/google` provider. Fixes four genuine cloud-vs-cloudemu divergences a real gcloud/SDK/Terraform user hits. All verified with `terraform apply` -> `terraform plan` = no drift.

## Divergences fixed

1. **Bucket `cors[]` dropped.** The provider stored CORS (`PutCORSConfig`/`GetCORSConfig`), but the GCS REST handler never read or wrote it, so a `cors` block was accepted-and-dropped — perpetual Terraform drift. The handler now round-trips `cors[]` on create and patch (`origin`/`method`/`responseHeader`/`maxAgeSeconds`); an empty array clears it.

2. **Bucket `location` not upper-cased.** Real GCS returns locations upper-cased (e.g. `US-CENTRAL1`); cloudemu echoed the supplied case. Normalized on store so SDK/gcloud reads match.

3. **`Buckets.patch` labels replaced instead of merged, and null not deleted.** The SDK/Terraform send only the changed labels, with a deleted label encoded as JSON `null`. cloudemu replaced the whole map (losing untouched labels) and stored a null value as an empty string (leaving a ghost label). Patch now merges into existing labels and deletes null-valued keys.

4. **Disabled versioning omitted from the wire.** cloudemu emitted `versioning` only when enabled, so a `versioning { enabled = false }` block perpetually diffed under Terraform. It now returns `{enabled:false}` once versioning has been explicitly set, while still omitting the field for a bucket that never configured it (tracked via a new `versioningSet` bit on the bucket, plumbed through `GCSBucketMeta` and snapshot).

## Testing

- New `server/gcp/gcs/gcs_bucket_roundtrip_test.go`: CORS round-trip (create + patch), location upper-casing, label merge/null-delete, and a raw-JSON assertion for the versioning omitted-vs-`{enabled:false}` distinction.
- `go build ./...`, `go test -race` on `server/gcp/gcs`, `providers/gcp/gcs`, `services/storage`, root integration + `persist` tests, `go vet`, `gofmt`, `golangci-lint` (0 new issues), `go generate` (no coverage diff — no new driver methods).
- Terraform: `google_storage_bucket` with location/storage_class/uniform_bucket_level_access/versioning/lifecycle_rule/cors/labels — apply then plan clean; update (labels remove/add, versioning toggle, CORS change) then plan clean; plus a plain bucket (no versioning block) to confirm no false-positive.