### PR TITLE
fix(iam): real-user e2e divergences from AWS IAM

### DIFF
--- a/server/aws/iam/group_policy.go
+++ b/server/aws/iam/group_policy.go
@@ -141,6 +141,11 @@ func (h *Handler) putGroupPolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !validPolicyDocument(r.Form.Get("PolicyDocument")) {
+		writeMalformedPolicy(w, "The policy failed legacy parsing")
+		return
+	}
+
 	if err := pm.PutGroupPolicy(r.Context(),
 		r.Form.Get("GroupName"), r.Form.Get("PolicyName"), r.Form.Get("PolicyDocument")); err != nil {
 		writeErr(w, err)

--- a/server/aws/iam/handler.go
+++ b/server/aws/iam/handler.go
@@ -42,6 +42,7 @@ var iamActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup
 	"GetRole":                        {},
 	"ListRoles":                      {},
 	"UpdateRole":                     {},
+	"UpdateRoleDescription":          {},
 	"UpdateAssumeRolePolicy":         {},
 	"CreatePolicy":                   {},
 	"DeletePolicy":                   {},
@@ -227,6 +228,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.listRoles(w, r)
 	case "UpdateRole":
 		h.updateRole(w, r)
+	case "UpdateRoleDescription":
+		h.updateRoleDescription(w, r)
 	case "UpdateAssumeRolePolicy":
 		h.updateAssumeRolePolicy(w, r)
 	case "CreatePolicy":

--- a/server/aws/iam/operations.go
+++ b/server/aws/iam/operations.go
@@ -19,15 +19,24 @@ const codeMalformedPolicy = "MalformedPolicyDocument"
 
 // validPolicyDocument reports whether doc is acceptable as an IAM policy or
 // trust-policy document. An empty document is left to the driver's required-field
-// checks; a non-empty one must parse as a JSON object.
+// checks; a non-empty one must parse as a JSON object and carry the "Statement"
+// element. The IAM policy grammar defines a policy as
+// { <version_block?>, <id_block?>, <statement_block> } — only the statement
+// block is non-optional, so real IAM rejects a document without it (and any
+// non-JSON body) with MalformedPolicyDocument.
 func validPolicyDocument(doc string) bool {
 	if doc == "" {
 		return true
 	}
 
 	var obj map[string]any
+	if json.Unmarshal([]byte(doc), &obj) != nil {
+		return false
+	}
 
-	return json.Unmarshal([]byte(doc), &obj) == nil
+	stmt, ok := obj["Statement"]
+
+	return ok && stmt != nil
 }
 
 // writeMalformedPolicy emits the IAM MalformedPolicyDocument error (HTTP 400).
@@ -477,6 +486,11 @@ func (h *Handler) attachmentCount(ctx context.Context, policyARN string) int {
 }
 
 func (h *Handler) createPolicyVersion(w http.ResponseWriter, r *http.Request) {
+	if !validPolicyDocument(r.Form.Get("PolicyDocument")) {
+		writeMalformedPolicy(w, "Syntax errors in policy")
+		return
+	}
+
 	cfg := iamdriver.PolicyVersionConfig{
 		PolicyARN:      r.Form.Get("PolicyArn"),
 		PolicyDocument: r.Form.Get("PolicyDocument"),

--- a/server/aws/iam/policy_validation_test.go
+++ b/server/aws/iam/policy_validation_test.go
@@ -1,0 +1,134 @@
+package iam_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+// asMalformed reports whether err is IAM's MalformedPolicyDocumentException.
+func asMalformed(err error) bool {
+	var m *iamtypes.MalformedPolicyDocumentException
+
+	return errors.As(err, &m)
+}
+
+// TestSDKCreatePolicyRejectsMissingStatement proves a managed-policy document
+// that parses as JSON but omits the required Statement element is rejected with
+// MalformedPolicyDocument, matching the IAM policy grammar (Statement is the one
+// non-optional top-level block).
+func TestSDKCreatePolicyRejectsMissingStatement(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String("no-statement"),
+		PolicyDocument: aws.String(`{"Version":"2012-10-17"}`),
+	})
+	if !asMalformed(err) {
+		t.Fatalf("CreatePolicy without Statement: want MalformedPolicyDocumentException, got %v", err)
+	}
+}
+
+// TestSDKCreateRoleRejectsMissingStatement proves a trust policy without a
+// Statement element is rejected.
+func TestSDKCreateRoleRejectsMissingStatement(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("no-stmt-trust"),
+		AssumeRolePolicyDocument: aws.String(`{"Version":"2012-10-17"}`),
+	})
+	if !asMalformed(err) {
+		t.Fatalf("CreateRole with statement-less trust policy: want MalformedPolicyDocumentException, got %v", err)
+	}
+}
+
+// TestSDKPutRolePolicyRejectsMalformed proves an inline role policy that is not
+// valid JSON is rejected (previously accepted unvalidated).
+func TestSDKPutRolePolicyRejectsMalformed(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("inline-role"),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	_, err := client.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
+		RoleName:       aws.String("inline-role"),
+		PolicyName:     aws.String("bad"),
+		PolicyDocument: aws.String("not-json"),
+	})
+	if !asMalformed(err) {
+		t.Fatalf("PutRolePolicy with bad JSON: want MalformedPolicyDocumentException, got %v", err)
+	}
+}
+
+// TestSDKPutUserPolicyRejectsMalformed proves an inline user policy that omits
+// the Statement element is rejected.
+func TestSDKPutUserPolicyRejectsMalformed(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateUser(ctx, &iam.CreateUserInput{
+		UserName: aws.String("inline-user"),
+	}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	_, err := client.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
+		UserName:       aws.String("inline-user"),
+		PolicyName:     aws.String("bad"),
+		PolicyDocument: aws.String(`{"Version":"2012-10-17"}`),
+	})
+	if !asMalformed(err) {
+		t.Fatalf("PutUserPolicy without Statement: want MalformedPolicyDocumentException, got %v", err)
+	}
+}
+
+// TestSDKCreatePolicyVersionRejectsMalformed proves a new policy version whose
+// document is not valid JSON is rejected (previously accepted unvalidated).
+func TestSDKCreatePolicyVersionRejectsMalformed(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String("versioned"),
+		PolicyDocument: aws.String(samplePolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	_, err = client.CreatePolicyVersion(ctx, &iam.CreatePolicyVersionInput{
+		PolicyArn:      created.Policy.Arn,
+		PolicyDocument: aws.String("not-json"),
+	})
+	if !asMalformed(err) {
+		t.Fatalf("CreatePolicyVersion with bad JSON: want MalformedPolicyDocumentException, got %v", err)
+	}
+}
+
+// TestSDKPolicyAcceptsSingleStatementObject proves the validator accepts a
+// document whose Statement is a single object (not an array), which the IAM
+// grammar permits.
+func TestSDKPolicyAcceptsSingleStatementObject(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String("single-stmt"),
+		PolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"s3:*","Resource":"*"}}`),
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy with single Statement object: unexpected error %v", err)
+	}
+}

--- a/server/aws/iam/role_policy.go
+++ b/server/aws/iam/role_policy.go
@@ -57,6 +57,11 @@ func (h *Handler) putRolePolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !validPolicyDocument(r.Form.Get("PolicyDocument")) {
+		writeMalformedPolicy(w, "The policy failed legacy parsing")
+		return
+	}
+
 	if err := pm.PutRolePolicy(r.Context(),
 		r.Form.Get("RoleName"), r.Form.Get("PolicyName"), r.Form.Get("PolicyDocument")); err != nil {
 		writeErr(w, err)

--- a/server/aws/iam/role_update.go
+++ b/server/aws/iam/role_update.go
@@ -31,6 +31,20 @@ type updateAssumeRolePolicyResponse struct {
 	Metadata responseMetadata `xml:"ResponseMetadata"`
 }
 
+// updateRoleDescriptionResponse mirrors the real IAM UpdateRoleDescription
+// response, which — unlike UpdateRole — returns the modified role. Terraform's
+// aws_iam_role resource calls this action when only the description changes.
+type updateRoleDescriptionResponse struct {
+	XMLName  xml.Name                    `xml:"UpdateRoleDescriptionResponse"`
+	Xmlns    string                      `xml:"xmlns,attr"`
+	Result   updateRoleDescriptionResult `xml:"UpdateRoleDescriptionResult"`
+	Metadata responseMetadata            `xml:"ResponseMetadata"`
+}
+
+type updateRoleDescriptionResult struct {
+	Role roleXML `xml:"Role"`
+}
+
 func (h *Handler) roleUpdates() (roleUpdater, bool) {
 	u, ok := h.iam.(roleUpdater)
 
@@ -84,6 +98,34 @@ func optionalFormInt(r *http.Request, key string) *int {
 	}
 
 	return &n
+}
+
+func (h *Handler) updateRoleDescription(w http.ResponseWriter, r *http.Request) {
+	upd, ok := h.roleUpdates()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "role updates not supported"))
+		return
+	}
+
+	roleName := r.Form.Get("RoleName")
+	description := r.Form.Get("Description")
+
+	if err := upd.UpdateRole(r.Context(), roleName, &description, nil); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	role, err := h.iam.GetRole(r.Context(), roleName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, updateRoleDescriptionResponse{
+		Xmlns:    Namespace,
+		Result:   updateRoleDescriptionResult{Role: toRoleXML(role)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
 }
 
 func (h *Handler) updateAssumeRolePolicy(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/iam/role_update_test.go
+++ b/server/aws/iam/role_update_test.go
@@ -47,6 +47,66 @@ func TestSDKUpdateRole(t *testing.T) {
 	}
 }
 
+// TestSDKUpdateRoleDescription proves UpdateRoleDescription mutates only the
+// description and returns the modified role (Terraform's aws_iam_role calls this
+// action for a description-only change; previously undispatched → InvalidAction).
+func TestSDKUpdateRoleDescription(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("desc-role"),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+		Description:              aws.String("original"),
+		MaxSessionDuration:       aws.Int32(7200),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	out, err := client.UpdateRoleDescription(ctx, &iam.UpdateRoleDescriptionInput{
+		RoleName:    aws.String("desc-role"),
+		Description: aws.String("changed"),
+	})
+	if err != nil {
+		t.Fatalf("UpdateRoleDescription: %v", err)
+	}
+
+	if desc := aws.ToString(out.Role.Description); desc != "changed" {
+		t.Fatalf("returned Role.Description = %q, want %q", desc, "changed")
+	}
+
+	// MaxSessionDuration must be left untouched.
+	if d := aws.ToInt32(out.Role.MaxSessionDuration); d != 7200 {
+		t.Fatalf("returned Role.MaxSessionDuration = %d, want 7200", d)
+	}
+
+	got, err := client.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String("desc-role")})
+	if err != nil {
+		t.Fatalf("GetRole: %v", err)
+	}
+
+	if desc := aws.ToString(got.Role.Description); desc != "changed" {
+		t.Fatalf("Role.Description = %q, want %q", desc, "changed")
+	}
+}
+
+// TestSDKUpdateRoleDescriptionMissing proves a description update against an
+// unknown role is rejected with NoSuchEntity.
+func TestSDKUpdateRoleDescriptionMissing(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.UpdateRoleDescription(ctx, &iam.UpdateRoleDescriptionInput{
+		RoleName:    aws.String("ghost"),
+		Description: aws.String("x"),
+	})
+
+	var notFound *iamtypes.NoSuchEntityException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("UpdateRoleDescription on missing role: want NoSuchEntityException, got %v", err)
+	}
+}
+
 // TestSDKUpdateAssumeRolePolicy proves the trust policy is replaced in place
 // (previously undispatched → InvalidAction).
 func TestSDKUpdateAssumeRolePolicy(t *testing.T) {

--- a/server/aws/iam/user_policy.go
+++ b/server/aws/iam/user_policy.go
@@ -58,6 +58,11 @@ func (h *Handler) putUserPolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !validPolicyDocument(r.Form.Get("PolicyDocument")) {
+		writeMalformedPolicy(w, "The policy failed legacy parsing")
+		return
+	}
+
 	if err := pm.PutUserPolicy(r.Context(),
 		r.Form.Get("UserName"), r.Form.Get("PolicyName"), r.Form.Get("PolicyDocument")); err != nil {
 		writeErr(w, err)


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of AWS IAM (aws_iam_role / aws_iam_policy / aws_iam_role_policy_attachment / aws_iam_instance_profile / aws_iam_user + inline policies) driving the wire server with the real aws-cli, aws-sdk-go-v2, and Terraform. Fixes genuine cloud-vs-cloudemu divergences a real user hits.

### Divergences fixed

1. **`UpdateRoleDescription` was undispatched.** Terraform's `aws_iam_role` calls `UpdateRoleDescription` (a real IAM API) when only the role description changes. cloudemu returned `InvalidAction: unknown action`, breaking any `terraform apply` that edited a role's description. Added the action; it mutates the description via the existing `UpdateRole` path and returns the modified `Role` object (matching the real API response, which — unlike `UpdateRole` — returns the role). Missing role -> `NoSuchEntity`.

2. **Statement-less policy documents were accepted.** The IAM policy grammar defines a policy as `{ <version_block?>, <id_block?>, <statement_block> }` — only the statement block is non-optional. `CreatePolicy`, `CreateRole` (trust policy) and `UpdateAssumeRolePolicy` accepted `{"Version":"2012-10-17"}` (no `Statement`), where real IAM returns `MalformedPolicyDocument`. Strengthened the validator to require the `Statement` element (accepts both the single-object and array forms).

3. **Inline policies and policy versions weren't validated at all.** `PutRolePolicy`, `PutUserPolicy`, `PutGroupPolicy` and `CreatePolicyVersion` accepted non-JSON / statement-less documents outright; real IAM returns `MalformedPolicyDocument`. Added document validation to all four.

### Verification

- Full Terraform lifecycle (role with inline_policy + assume_role_policy, managed policy, role_policy_attachment, instance_profile, user): `apply` then `plan` = **no drift** (the URL-encoded policy-document round-trip survives Terraform's JSON normalization); update path (description + max_session_duration + assume policy change) applies cleanly and re-plans with no drift.
- aws-cli + aws-sdk-go-v2: create/get round-trip of RoleName/Arn/RoleId (AROA)/Path/AssumeRolePolicyDocument (url-encoded)/MaxSessionDuration/Tags; policy DefaultVersionId/Document/AttachmentCount; attachment list; instance-profile Roles round-trip; error fidelity (NoSuchEntity/EntityAlreadyExists/DeleteConflict/LimitExceeded/MalformedPolicyDocument with correct HTTP status).

### Tests

Added SDK-level tests for `UpdateRoleDescription` (success + NoSuchEntity) and for the document validation on CreatePolicy/CreateRole/PutRolePolicy/PutUserPolicy/CreatePolicyVersion, plus a positive test that a single-object `Statement` is accepted.