### PR TITLE
fix(clouddns): real-user e2e divergence from GCP Cloud DNS

### DIFF
--- a/server/gcp/clouddns/sdk_roundtrip_test.go
+++ b/server/gcp/clouddns/sdk_roundtrip_test.go
@@ -3,6 +3,7 @@ package clouddns_test
 import (
 	"context"
 	"errors"
+	"math"
 	"net/http/httptest"
 	"strconv"
 	"testing"
@@ -233,6 +234,42 @@ func TestSDKCloudDNSUpdateRecord(t *testing.T) {
 	user := userRrsets(rrsets.Rrsets)
 	if len(user) != 1 || user[0].Ttl != 600 || user[0].Rrdatas[0] != "192.0.2.2" {
 		t.Fatalf("after update rrsets=%+v want single 600/192.0.2.2", user)
+	}
+}
+
+// TestSDKCloudDNSZoneIDFitsInt64 guards against the managed-zone id overflowing
+// a signed int64. Real Cloud DNS ids fit in int64, and Terraform's google
+// provider reads managed_zone_id as an int (its flatten runs
+// strconv.ParseInt(id, 10, 64)); a fold that produced a full-range uint64
+// broke the managed-zone read with "expected type 'int', got unconvertible
+// type 'string'". The id must stay a non-zero value within [1, math.MaxInt64].
+func TestSDKCloudDNSZoneIDFitsInt64(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	// Several distinct zones so a range of folded ids is exercised, not one.
+	for _, name := range []string{"id-zone-a", "id-zone-b", "id-zone-c", "id-zone-d"} {
+		zone, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+			Name:    name,
+			DnsName: name + ".example.com.",
+		}).Context(ctx).Do()
+		if err != nil {
+			t.Fatalf("ManagedZones.Create(%s): %v", name, err)
+		}
+
+		if zone.Id == 0 {
+			t.Fatalf("zone %s: id is 0, want a non-zero managed-zone id", name)
+		}
+
+		if zone.Id > math.MaxInt64 {
+			t.Fatalf("zone %s: id %d exceeds math.MaxInt64 (%d) — Terraform reads it as int64 and would fail",
+				name, zone.Id, int64(math.MaxInt64))
+		}
+
+		// Mirror the provider's parse to prove the wire string round-trips to int64.
+		if _, perr := strconv.ParseInt(strconv.FormatUint(zone.Id, 10), 10, 64); perr != nil {
+			t.Fatalf("zone %s: id %d does not parse as int64: %v", name, zone.Id, perr)
+		}
 	}
 }
 

--- a/server/gcp/clouddns/types.go
+++ b/server/gcp/clouddns/types.go
@@ -3,6 +3,7 @@ package clouddns
 import (
 	"context"
 	"hash/fnv"
+	"math"
 	"strconv"
 	"strings"
 
@@ -230,11 +231,24 @@ func privateFor(visibility string) bool {
 
 // numericID folds the driver's zone-<uuid> id into a stable numeric string,
 // which is what the SDK's uint64 `id` field requires on the wire.
+//
+// The fold is masked to 63 bits so the value always fits in a signed int64.
+// Real Cloud DNS ids fit in int64, and Terraform's google provider reads
+// managed_zone_id as an int (its flatten does strconv.ParseInt(id, 10, 64));
+// a full-range uint64 that overflows int64 fails that parse and breaks the
+// managed-zone read ("expected type 'int', got unconvertible type 'string'").
+// Masking never yields 0 for a real zone id, but guard it so the id is always
+// a non-zero value an SDK caller can treat as present.
 func numericID(id string) string {
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(id))
 
-	return strconv.FormatUint(h.Sum64(), 10)
+	n := h.Sum64() & math.MaxInt64
+	if n == 0 {
+		n = 1
+	}
+
+	return strconv.FormatUint(n, 10)
 }
 
 func toManagedZoneJSON(info *dnsdriver.ZoneInfo) managedZoneJSON {


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of GCP Cloud DNS (`google_dns_managed_zone` + `google_dns_record_set`) driving `cloudemu serve` with the real `google.golang.org/api/dns/v1` client, `gcloud`, and Terraform. Found and fixed one genuine cloud-vs-cloudemu divergence.

## Divergence fixed

**Managed zone id could overflow int64, breaking Terraform.** The wire layer folds the driver's `zone-<uuid>` id into the numeric `ManagedZone.id` via FNV-64a, which can produce a value above `math.MaxInt64`. Terraform's google provider reads `managed_zone_id` as an int (its flatten runs `strconv.ParseInt(id, 10, 64)`); an overflowing value failed to parse and left the raw string, so `terraform apply` aborted at zone creation with:

```
Error reading ManagedZone: managed_zone_id: '' expected type 'int',
got unconvertible type 'string', value: '9548839514720346545'
```

Real Cloud DNS ids fit in int64. Fix: mask the fold to 63 bits so the id is always a positive int64 (with a zero-guard). The value is still emitted as a JSON string, which the typed SDK's `,string` field requires and real Cloud DNS returns.

## Evidence

- Terraform (`hashicorp/google` v5.45.2) via `dns_custom_endpoint`: apply of a zone + A/CNAME/TXT/MX record sets → `terraform plan` **no drift**; record-set update (delete+add Change) → **no drift**; `terraform destroy` clean. `name_servers` output populated, `zone_id` within int64.
- Round-trip verified exact: TXT quoting, MX priorities, CNAME trailing dot, apex NS + SOA auto-created, Change status reaches `done`.
- Real `dns/v1` SDK and `gcloud dns` (zone describe + record-sets transaction) both green; new regression test `TestSDKCloudDNSZoneIDFitsInt64` guards the bound.

## Gates

`go build ./...`, scoped `go test -race`, root `go test`, `go vet`, `gofmt`, `golangci-lint --new-from-rev` (0 new issues), `go generate` (no coverage drift) — all green.