### PR TITLE
fix(azure-vnet): real-user e2e divergences from Azure Virtual Network

### DIFF
--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -86,6 +86,14 @@ const (
 	// the default rather than a dropped field.
 	armSubnetPENPTag  = "cloudemu:azureSubnetPENP"
 	armSubnetPLSNPTag = "cloudemu:azureSubnetPLSNP"
+	// armSubnetPrefixesTag records the full addressPrefixes list (comma-joined)
+	// a subnet was created/updated with via the plural addressPrefixes form —
+	// the form the azurerm provider always sends. The driver only stores a
+	// single CIDRBlock, so this tag preserves the multi-prefix list and the
+	// plural response form; its presence is what makes a subnet's GET echo
+	// addressPrefixes (plural) instead of addressPrefix (singular), matching
+	// real ARM's round-trip of whichever form the caller used.
+	armSubnetPrefixesTag = "cloudemu:azureSubnetPrefixes"
 	// defaultPENP / defaultPLSNP are the ARM defaults for a subnet's
 	// privateEndpointNetworkPolicies / privateLinkServiceNetworkPolicies when a
 	// create omits them.
@@ -405,6 +413,71 @@ func vnetPrefixes(req *vnetRequest) []string {
 	return req.Properties.AddressSpace.AddressPrefixes
 }
 
+// addressPrefixList returns a subnet request's address prefixes, accepting both
+// the singular addressPrefix and the plural addressPrefixes (the form the
+// azurerm provider always sends, for both inline and standalone subnets). The
+// plural form takes precedence when both are present, matching ARM; empty
+// entries are dropped.
+func (p *subnetRequestProps) addressPrefixList() []string {
+	if len(p.AddressPrefixes) > 0 {
+		out := make([]string, 0, len(p.AddressPrefixes))
+
+		for _, s := range p.AddressPrefixes {
+			if s != "" {
+				out = append(out, s)
+			}
+		}
+
+		return out
+	}
+
+	if p.AddressPrefix != "" {
+		return []string{p.AddressPrefix}
+	}
+
+	return nil
+}
+
+// primaryPrefix returns the first prefix in a list, or "" for an empty list —
+// the single CIDR the cross-cloud driver stores for a subnet.
+func primaryPrefix(prefixes []string) string {
+	if len(prefixes) > 0 {
+		return prefixes[0]
+	}
+
+	return ""
+}
+
+// pluralPrefixTag returns the comma-joined value for armSubnetPrefixesTag when a
+// subnet request used the plural addressPrefixes form, or "" when it used the
+// singular form (or none). An empty return clears the tag on update so a subnet
+// switched back to the singular form echoes addressPrefix again.
+func (p *subnetRequestProps) pluralPrefixTag() string {
+	list := p.addressPrefixList()
+	if len(p.AddressPrefixes) == 0 || len(list) == 0 {
+		return ""
+	}
+
+	return strings.Join(list, ",")
+}
+
+// validateSubnetCIDRs validates every candidate prefix a subnet request carries
+// (real ARM validates each), preserving the single-prefix error for a request
+// that carries none.
+func (h *Handler) validateSubnetCIDRs(ctx context.Context, vpcID, subnetName string, prefixes []string) error {
+	if len(prefixes) == 0 {
+		return h.validateSubnetCIDR(ctx, vpcID, subnetName, "")
+	}
+
+	for _, cidr := range prefixes {
+		if err := h.validateSubnetCIDR(ctx, vpcID, subnetName, cidr); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // upsertVNet reuses an existing virtual network of the same name (so a repeated
 // PUT updates in place rather than creating a duplicate) or creates a new one.
 func (h *Handler) upsertVNet(ctx context.Context, rg, name string, prefixes []string,
@@ -500,13 +573,15 @@ func (h *Handler) upsertWantedSubnets(
 			continue
 		}
 
-		if verr := h.validateSubnetCIDR(ctx, vpcID, subs[i].Name, subs[i].Properties.AddressPrefix); verr != nil {
+		prefixes := subs[i].Properties.addressPrefixList()
+
+		if verr := h.validateSubnetCIDRs(ctx, vpcID, subs[i].Name, prefixes); verr != nil {
 			return nil, verr
 		}
 
 		if _, err := h.net.CreateSubnet(ctx, netdriver.SubnetConfig{
 			VPCID:     vpcID,
-			CIDRBlock: subs[i].Properties.AddressPrefix,
+			CIDRBlock: primaryPrefix(prefixes),
 			Tags:      inlineSubnetTags(&subs[i]),
 		}); err != nil {
 			return nil, err
@@ -524,9 +599,11 @@ func (h *Handler) upsertWantedSubnets(
 func (h *Handler) updateInlineSubnet(
 	ctx context.Context, vpcID string, sub *subnetRequest, existing *netdriver.SubnetInfo,
 ) error {
-	cidr := sub.Properties.AddressPrefix
+	prefixes := sub.Properties.addressPrefixList()
+	cidr := primaryPrefix(prefixes)
+
 	if cidr != "" && cidr != existing.CIDRBlock {
-		if verr := h.validateSubnetCIDR(ctx, vpcID, sub.Name, cidr); verr != nil {
+		if verr := h.validateSubnetCIDRs(ctx, vpcID, sub.Name, prefixes); verr != nil {
 			return verr
 		}
 	}
@@ -535,7 +612,7 @@ func (h *Handler) updateInlineSubnet(
 	nsgID := inlineRefID(sub.Properties.NetworkSecurityGroup)
 	routeTableID := inlineRefID(sub.Properties.RouteTable)
 
-	updated, err := h.updateExistingSubnet(ctx, existing, cidr, natID, nsgID, routeTableID)
+	updated, err := h.updateExistingSubnet(ctx, existing, cidr, sub.Properties.pluralPrefixTag(), natID, nsgID, routeTableID)
 	if err != nil {
 		return err
 	}
@@ -557,6 +634,10 @@ func inlineRefID(ref *armIDRef) string {
 // whole-VNet PUT body, carrying over its NAT gateway / NSG references.
 func inlineSubnetTags(sub *subnetRequest) map[string]string {
 	tags := mergeTags(nil, armSubnetTag, sub.Name)
+
+	if pt := sub.Properties.pluralPrefixTag(); pt != "" {
+		tags = mergeTags(tags, armSubnetPrefixesTag, pt)
+	}
 
 	if sub.Properties.NatGateway != nil {
 		tags = mergeTags(tags, armSubnetNATTag, sub.Properties.NatGateway.ID)
@@ -922,13 +1003,15 @@ func (h *Handler) createSubnet(w http.ResponseWriter, r *http.Request, rp azurea
 		return
 	}
 
-	if verr := h.validateSubnetCIDR(r.Context(), vnet.ID, rp.SubResourceName, req.Properties.AddressPrefix); verr != nil {
+	prefixes := req.Properties.addressPrefixList()
+
+	if verr := h.validateSubnetCIDRs(r.Context(), vnet.ID, rp.SubResourceName, prefixes); verr != nil {
 		writeSubnetValidationError(w, verr)
 		return
 	}
 
 	info, err := h.upsertSubnet(r.Context(), vnet.ID, rp.SubResourceName,
-		req.Properties.AddressPrefix, natGatewayID, nsgID, routeTableID)
+		primaryPrefix(prefixes), req.Properties.pluralPrefixTag(), natGatewayID, nsgID, routeTableID)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -1017,13 +1100,17 @@ func (*Handler) resolveSubnetRef(
 // association. Both associations live on the subnet's own natGateway /
 // networkSecurityGroup properties.
 func (h *Handler) upsertSubnet(
-	ctx context.Context, vpcID, name, cidr, natGatewayID, nsgID, routeTableID string,
+	ctx context.Context, vpcID, name, cidr, prefixTag, natGatewayID, nsgID, routeTableID string,
 ) (*netdriver.SubnetInfo, error) {
 	if existing, err := findSubnetInVNet(ctx, h.net, vpcID, name); err == nil {
-		return h.updateExistingSubnet(ctx, existing, cidr, natGatewayID, nsgID, routeTableID)
+		return h.updateExistingSubnet(ctx, existing, cidr, prefixTag, natGatewayID, nsgID, routeTableID)
 	}
 
 	tags := mergeTags(nil, armSubnetTag, name)
+	if prefixTag != "" {
+		tags = mergeTags(tags, armSubnetPrefixesTag, prefixTag)
+	}
+
 	if natGatewayID != "" {
 		tags = mergeTags(tags, armSubnetNATTag, natGatewayID)
 	}
@@ -1048,7 +1135,7 @@ func (h *Handler) upsertSubnet(
 // gateway associations from the request body (an omitted reference — empty id —
 // clears that association, matching ARM's full-replacement semantics).
 func (h *Handler) updateExistingSubnet(
-	ctx context.Context, existing *netdriver.SubnetInfo, cidr, natGatewayID, nsgID, routeTableID string,
+	ctx context.Context, existing *netdriver.SubnetInfo, cidr, prefixTag, natGatewayID, nsgID, routeTableID string,
 ) (*netdriver.SubnetInfo, error) {
 	if cidr != "" && cidr != existing.CIDRBlock {
 		if u, ok := h.net.(netdriver.SubnetCIDRUpdater); ok {
@@ -1058,6 +1145,12 @@ func (h *Handler) updateExistingSubnet(
 
 			existing.CIDRBlock = cidr
 		}
+	}
+
+	// Full-replace the plural-form prefix list: an update that used the singular
+	// form (empty prefixTag) clears the tag so the subnet echoes addressPrefix.
+	if err := h.replaceSubnetAssociation(ctx, existing, armSubnetPrefixesTag, prefixTag); err != nil {
+		return nil, err
 	}
 
 	if err := h.replaceSubnetAssociation(ctx, existing, armSubnetNSGTag, nsgID); err != nil {
@@ -1168,6 +1261,15 @@ func (h *Handler) getSubnet(w http.ResponseWriter, r *http.Request, rp azurearm.
 
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) listSubnets(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	// SubnetsClient.List is scoped to a single virtual network: resolve the
+	// parent vnet (within the request's resource group) and return only its
+	// subnets, not every subnet in the subscription.
+	vnet, err := findVNetInGroup(r.Context(), h.net, rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
 	infos, err := h.net.DescribeSubnets(r.Context(), nil)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
@@ -1177,6 +1279,10 @@ func (h *Handler) listSubnets(w http.ResponseWriter, r *http.Request, rp azurear
 	out := subnetListResponse{}
 
 	for i := range infos {
+		if infos[i].VPCID != vnet.ID {
+			continue
+		}
+
 		scope := rp
 		scope.SubResourceName = tagOr(infos[i].Tags, armSubnetTag, infos[i].ID)
 		out.Value = append(out.Value, toSubnetResponse(&infos[i], scope))
@@ -1833,10 +1939,18 @@ func toSubnetResponse(info *netdriver.SubnetInfo, rp azurearm.ResourcePath) subn
 		Etag: etagOf(id),
 		Properties: subnetResponseProps{
 			ProvisioningState:                 "Succeeded",
-			AddressPrefix:                     info.CIDRBlock,
 			PrivateEndpointNetworkPolicies:    tagOr(info.Tags, armSubnetPENPTag, defaultPENP),
 			PrivateLinkServiceNetworkPolicies: tagOr(info.Tags, armSubnetPLSNPTag, defaultPLSNP),
 		},
+	}
+
+	// Echo back whichever address-prefix form the caller used: the plural
+	// addressPrefixes (recorded in armSubnetPrefixesTag by a request that used
+	// it — the azurerm provider always does) or the singular addressPrefix.
+	if raw := tagOr(info.Tags, armSubnetPrefixesTag, ""); raw != "" {
+		out.Properties.AddressPrefixes = strings.Split(raw, ",")
+	} else {
+		out.Properties.AddressPrefix = info.CIDRBlock
 	}
 
 	if ngID := tagOr(info.Tags, armSubnetNATTag, ""); ngID != "" {

--- a/server/azure/vnet/subnet_address_prefixes_test.go
+++ b/server/azure/vnet/subnet_address_prefixes_test.go
@@ -1,0 +1,210 @@
+package vnet_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// createVNetForSubnet creates a parent vnet used by the standalone-subnet tests.
+func createVNetForSubnet(t *testing.T, vnets *armnetwork.VirtualNetworksClient, name, space string) {
+	t.Helper()
+
+	p, err := vnets.BeginCreateOrUpdate(context.Background(), "rg-1", name, armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr(space)}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create vnet %s: %v", name, err)
+	}
+
+	pollDone(t, p)
+}
+
+// TestSDKStandaloneSubnetAddressPrefixes drives the exact shape the azurerm
+// provider sends for azurerm_subnet: the plural addressPrefixes form, with the
+// singular addressPrefix left unset. Before the fix the handler read only
+// addressPrefix, so validateSubnetCIDR saw an empty CIDR and rejected the PUT —
+// azurerm_subnet apply failed outright. The create must succeed and the GET must
+// round-trip addressPrefixes.
+func TestSDKStandaloneSubnetAddressPrefixes(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	vnets, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createVNetForSubnet(t, vnets, "vnet-1", "10.0.0.0/16")
+
+	subnets, err := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := subnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-1", "internal", armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefixes: []*string{to.Ptr("10.0.1.0/24")},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create subnet with plural addressPrefixes: %v", err)
+	}
+
+	created := pollDone(t, p)
+	assertPluralPrefix(t, created.Properties, "10.0.1.0/24")
+
+	got, err := subnets.Get(ctx, "rg-1", "vnet-1", "internal", nil)
+	if err != nil {
+		t.Fatalf("get subnet: %v", err)
+	}
+
+	assertPluralPrefix(t, got.Properties, "10.0.1.0/24")
+
+	// The parent vnet GET must also carry the subnet with its plural prefix.
+	vnet, err := vnets.Get(ctx, "rg-1", "vnet-1", nil)
+	if err != nil {
+		t.Fatalf("get vnet: %v", err)
+	}
+
+	if vnet.Properties == nil || len(vnet.Properties.Subnets) != 1 {
+		t.Fatalf("vnet should report 1 subnet, got %+v", vnet.Properties)
+	}
+
+	assertPluralPrefix(t, vnet.Properties.Subnets[0].Properties, "10.0.1.0/24")
+}
+
+// TestSDKInlineSubnetAddressPrefixes drives the shape azurerm_virtual_network
+// sends for an inline subnet block: the plural addressPrefixes form. Before the
+// fix the whole vnet PUT failed because the inline subnet's CIDR read empty.
+func TestSDKInlineSubnetAddressPrefixes(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	vnets, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := vnets.BeginCreateOrUpdate(ctx, "rg-1", "vnet-inline", armnetwork.VirtualNetwork{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")}},
+			Subnets: []*armnetwork.Subnet{
+				{
+					Name: to.Ptr("web"),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						AddressPrefixes: []*string{to.Ptr("10.0.1.0/24")},
+					},
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create vnet with inline plural subnet: %v", err)
+	}
+
+	created := pollDone(t, p)
+	if created.Properties == nil || len(created.Properties.Subnets) != 1 {
+		t.Fatalf("expected 1 inline subnet, got %+v", created.Properties)
+	}
+
+	assertPluralPrefix(t, created.Properties.Subnets[0].Properties, "10.0.1.0/24")
+
+	subnets, err := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := subnets.Get(ctx, "rg-1", "vnet-inline", "web", nil)
+	if err != nil {
+		t.Fatalf("get inline subnet: %v", err)
+	}
+
+	assertPluralPrefix(t, got.Properties, "10.0.1.0/24")
+}
+
+// TestSDKSubnetListScopedToVNet confirms SubnetsClient.List returns only the
+// queried virtual network's subnets. Before the fix the handler returned every
+// subnet in the subscription, re-scoped under the requested vnet — a paging
+// client would see phantom subnets from unrelated vnets.
+func TestSDKSubnetListScopedToVNet(t *testing.T) {
+	ts := newVNetServer(t)
+
+	vnets, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subnets, err := armnetwork.NewSubnetsClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createVNetForSubnet(t, vnets, "vnet-a", "10.0.0.0/16")
+	createVNetForSubnet(t, vnets, "vnet-b", "10.1.0.0/16")
+
+	putSubnet(t, subnets, "vnet-a", "a-sub", "10.0.1.0/24")
+	putSubnet(t, subnets, "vnet-b", "b-sub1", "10.1.1.0/24")
+	putSubnet(t, subnets, "vnet-b", "b-sub2", "10.1.2.0/24")
+
+	names := listSubnetNames(t, subnets, "vnet-a")
+	if len(names) != 1 || names["a-sub"] == 0 {
+		t.Fatalf("vnet-a should list exactly its own subnet [a-sub], got %v", names)
+	}
+
+	names = listSubnetNames(t, subnets, "vnet-b")
+	if len(names) != 2 || names["b-sub1"] == 0 || names["b-sub2"] == 0 {
+		t.Fatalf("vnet-b should list exactly [b-sub1 b-sub2], got %v", names)
+	}
+}
+
+func putSubnet(t *testing.T, subnets *armnetwork.SubnetsClient, vnet, name, cidr string) {
+	t.Helper()
+
+	p, err := subnets.BeginCreateOrUpdate(context.Background(), "rg-1", vnet, name, armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{AddressPrefixes: []*string{to.Ptr(cidr)}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create subnet %s/%s: %v", vnet, name, err)
+	}
+
+	pollDone(t, p)
+}
+
+func listSubnetNames(t *testing.T, subnets *armnetwork.SubnetsClient, vnet string) map[string]int {
+	t.Helper()
+
+	names := map[string]int{}
+
+	pager := subnets.NewListPager("rg-1", vnet, nil)
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			t.Fatalf("list subnets %s: %v", vnet, err)
+		}
+
+		for _, s := range page.Value {
+			names[*s.Name]++
+		}
+	}
+
+	return names
+}
+
+func assertPluralPrefix(t *testing.T, props *armnetwork.SubnetPropertiesFormat, want string) {
+	t.Helper()
+
+	if props == nil {
+		t.Fatal("subnet properties nil")
+	}
+
+	if len(props.AddressPrefixes) != 1 || props.AddressPrefixes[0] == nil || *props.AddressPrefixes[0] != want {
+		t.Fatalf("addressPrefixes = %v, want [%s]", props.AddressPrefixes, want)
+	}
+}

--- a/server/azure/vnet/types.go
+++ b/server/azure/vnet/types.go
@@ -47,6 +47,7 @@ type subnetRequest struct {
 
 type subnetRequestProps struct {
 	AddressPrefix                     string    `json:"addressPrefix,omitempty"`
+	AddressPrefixes                   []string  `json:"addressPrefixes,omitempty"`
 	NatGateway                        *armIDRef `json:"natGateway,omitempty"`
 	NetworkSecurityGroup              *armIDRef `json:"networkSecurityGroup,omitempty"`
 	RouteTable                        *armIDRef `json:"routeTable,omitempty"`
@@ -64,6 +65,7 @@ type subnetResponse struct {
 type subnetResponseProps struct {
 	ProvisioningState                 string    `json:"provisioningState"`
 	AddressPrefix                     string    `json:"addressPrefix,omitempty"`
+	AddressPrefixes                   []string  `json:"addressPrefixes,omitempty"`
 	NatGateway                        *armIDRef `json:"natGateway,omitempty"`
 	NetworkSecurityGroup              *armIDRef `json:"networkSecurityGroup,omitempty"`
 	RouteTable                        *armIDRef `json:"routeTable,omitempty"`


### PR DESCRIPTION
## Summary

Real-user e2e audit of Microsoft.Network/virtualNetworks against the azurerm provider and azure-sdk-for-go (armnetwork). Two genuine cloud-vs-cloudemu divergences fixed.

### 1. Subnet `addressPrefixes` (plural) rejected on write (critical)

The azurerm provider ALWAYS sends the plural `addressPrefixes` form (and leaves the singular `addressPrefix` unset) for **both** inline subnets in `azurerm_virtual_network` and the standalone `azurerm_subnet` resource. The handler only read singular `addressPrefix`, so the effective CIDR was empty and `validateSubnetCIDR` rejected the request — a real `azurerm_subnet` apply failed outright, and any `azurerm_virtual_network` with an inline subnet failed entirely.

Fix: model `addressPrefixes` on the subnet request/response, use the effective prefix list across all write paths (inline + standalone, create + update), preserve the plural list (and multi-prefix subnets) via an internal tag, and echo back whichever form the caller used — matching real ARM's round-trip.

### 2. `SubnetsClient.List` not scoped to its parent vnet

`GET .../virtualNetworks/{vnet}/subnets` returned every subnet in the subscription, re-scoped under the requested vnet, so a paging client saw phantom subnets from unrelated vnets. Fix: resolve the parent vnet and filter subnets by it.

## Verification

- Live `cloudemu serve` (Azure HTTPS): vnet + inline plural subnet PUT -> 200 Succeeded; `addressSpace.addressPrefixes`, `dhcpOptions.dnsServers`, `resourceGuid` round-trip; standalone subnet with plural `addressPrefixes` + `serviceEndpoints` round-trips; subnet LIST scoped correctly across two vnets.
- New armnetwork SDK tests cover standalone plural, inline plural, and cross-vnet list scoping.
- `go build`, `go vet`, `gofmt`, full `go test -race ./server/azure/...`, `go test -race ./providers/azure/vnet/...` all green; `golangci-lint --new-from-rev=origin/development` 0 issues; `go generate` produces no docs/coverage diff (driver interfaces unchanged).
