### PR TITLE
fix(cloudfunctions): real-user e2e divergences from GCP Cloud Functions

### DIFF
--- a/server/gcp/cloudfunctions/gen2.go
+++ b/server/gcp/cloudfunctions/gen2.go
@@ -74,11 +74,15 @@ type gen2ServiceConfig struct {
 	// the real default rather than a missing field.
 	MaxInstanceRequestConcurrency int `json:"maxInstanceRequestConcurrency,omitempty"`
 	// AllTrafficOnLatestRevision reports whether 100% of traffic routes to the newest
-	// revision. Real gen2 always returns true for a freshly deployed function, and
-	// terraform's service_config.all_traffic_on_latest_revision defaults to true — so
-	// omitting it from the response makes terraform read false and diff true->false on
-	// every plan (perpetual drift). It is not omitempty: a true value must serialize.
-	AllTrafficOnLatestRevision bool `json:"allTrafficOnLatestRevision"`
+	// revision. Real gen2 defaults it to true, and terraform's
+	// service_config.all_traffic_on_latest_revision defaults to true too — so omitting
+	// it from the response makes terraform read false and diff true->false on every
+	// plan (perpetual drift). But false is a legitimate explicit value (GCF then honors
+	// the underlying Cloud Run service's existing traffic split), so it is modeled as a
+	// pointer: nil (unset) defaults to true, while an explicit true or false round-trips
+	// unchanged. It is not omitempty — after defaulting the pointer is always non-nil,
+	// so the field always serializes as a real bool (never null).
+	AllTrafficOnLatestRevision *bool `json:"allTrafficOnLatestRevision"`
 }
 
 type gen2EventTrigger struct {
@@ -656,12 +660,13 @@ func applyServiceConfigDefaults(sc *gen2ServiceConfig, p v2Path) {
 		sc.MaxInstanceRequestConcurrency = gen2DefaultConcurrency
 	}
 
-	// A newly reconciled gen2 function always routes all traffic to its latest
-	// revision, so real GCP reports allTrafficOnLatestRevision=true. Treat an
-	// unset/false request value as the default true (traffic splitting is a
-	// post-deploy operation the create/update path doesn't express).
-	if !sc.AllTrafficOnLatestRevision {
-		sc.AllTrafficOnLatestRevision = true
+	// Real gen2 defaults allTrafficOnLatestRevision to true, so an unset (nil)
+	// value reconciles to true. An explicit client value — true OR false — is
+	// preserved: false is legitimate (GCF then honors the underlying Cloud Run
+	// service's existing traffic split), and clobbering it to true would
+	// reintroduce perpetual terraform drift for that config.
+	if sc.AllTrafficOnLatestRevision == nil {
+		sc.AllTrafficOnLatestRevision = boolPtr(true)
 	}
 }
 
@@ -731,6 +736,11 @@ func cloneGen2(fn *gen2Function) *gen2Function {
 	if fn.ServiceConfig != nil {
 		sc := *fn.ServiceConfig
 		sc.EnvironmentVariables = cloneStringMap(fn.ServiceConfig.EnvironmentVariables)
+
+		if fn.ServiceConfig.AllTrafficOnLatestRevision != nil {
+			sc.AllTrafficOnLatestRevision = boolPtr(*fn.ServiceConfig.AllTrafficOnLatestRevision)
+		}
+
 		out.ServiceConfig = &sc
 	}
 
@@ -757,6 +767,11 @@ func cloneStringMap(m map[string]string) map[string]string {
 	}
 
 	return out
+}
+
+// boolPtr returns a pointer to b, for setting *bool fields to an explicit value.
+func boolPtr(b bool) *bool {
+	return &b
 }
 
 // randomToken returns a short random hex string for synthesized ids.

--- a/server/gcp/cloudfunctions/gen2.go
+++ b/server/gcp/cloudfunctions/gen2.go
@@ -68,6 +68,17 @@ type gen2ServiceConfig struct {
 	Revision             string            `json:"revision,omitempty"`
 	MaxInstanceCount     int               `json:"maxInstanceCount,omitempty"`
 	MinInstanceCount     int               `json:"minInstanceCount,omitempty"`
+	// MaxInstanceRequestConcurrency is the per-instance concurrent-request cap real
+	// gen2 defaults to 1; a client (terraform max_instance_request_concurrency) that
+	// sets it must read it back, and it must be present on GET so an unset value is
+	// the real default rather than a missing field.
+	MaxInstanceRequestConcurrency int `json:"maxInstanceRequestConcurrency,omitempty"`
+	// AllTrafficOnLatestRevision reports whether 100% of traffic routes to the newest
+	// revision. Real gen2 always returns true for a freshly deployed function, and
+	// terraform's service_config.all_traffic_on_latest_revision defaults to true — so
+	// omitting it from the response makes terraform read false and diff true->false on
+	// every plan (perpetual drift). It is not omitempty: a true value must serialize.
+	AllTrafficOnLatestRevision bool `json:"allTrafficOnLatestRevision"`
 }
 
 type gen2EventTrigger struct {
@@ -575,6 +586,8 @@ func mergeServiceConfig(dst *gen2Function, sc *gen2ServiceConfig, mask updateMas
 	applyMaskedStr(mask, "serviceConfig.ingressSettings", &d.IngressSettings, sc.IngressSettings)
 	applyMaskedInt(mask, "serviceConfig.maxInstanceCount", &d.MaxInstanceCount, sc.MaxInstanceCount)
 	applyMaskedInt(mask, "serviceConfig.minInstanceCount", &d.MinInstanceCount, sc.MinInstanceCount)
+	applyMaskedInt(mask, "serviceConfig.maxInstanceRequestConcurrency",
+		&d.MaxInstanceRequestConcurrency, sc.MaxInstanceRequestConcurrency)
 
 	if mask.covers("serviceConfig.environmentVariables") && (mask.explicit() || sc.EnvironmentVariables != nil) {
 		d.EnvironmentVariables = sc.EnvironmentVariables
@@ -637,6 +650,18 @@ func applyServiceConfigDefaults(sc *gen2ServiceConfig, p v2Path) {
 
 	if sc.IngressSettings == "" {
 		sc.IngressSettings = defaultIngress
+	}
+
+	if sc.MaxInstanceRequestConcurrency == 0 {
+		sc.MaxInstanceRequestConcurrency = gen2DefaultConcurrency
+	}
+
+	// A newly reconciled gen2 function always routes all traffic to its latest
+	// revision, so real GCP reports allTrafficOnLatestRevision=true. Treat an
+	// unset/false request value as the default true (traffic splitting is a
+	// post-deploy operation the create/update path doesn't express).
+	if !sc.AllTrafficOnLatestRevision {
+		sc.AllTrafficOnLatestRevision = true
 	}
 }
 

--- a/server/gcp/cloudfunctions/gen2_sdk_test.go
+++ b/server/gcp/cloudfunctions/gen2_sdk_test.go
@@ -168,6 +168,61 @@ func TestSDKGen2Patch(t *testing.T) {
 	}
 }
 
+// TestSDKGen2TrafficAndConcurrency reproduces the perpetual-drift finding: a gen2
+// function's serviceConfig must report allTrafficOnLatestRevision=true (real GCP's
+// default, which terraform's service_config default matches — omitting it diffs
+// true->false on every plan) and default maxInstanceRequestConcurrency to 1, and
+// an explicit maxInstanceRequestConcurrency must round-trip through create and a
+// masked patch.
+func TestSDKGen2TrafficAndConcurrency(t *testing.T) {
+	svc := newGCPV2Service(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+	name := parent + "/functions/traffic"
+
+	if _, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions2.Function{
+		BuildConfig:   &cloudfunctions2.BuildConfig{Runtime: "go121", EntryPoint: "Hello"},
+		ServiceConfig: &cloudfunctions2.ServiceConfig{AvailableMemory: "256M"},
+	}).FunctionId("traffic").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if !got.ServiceConfig.AllTrafficOnLatestRevision {
+		t.Fatal("allTrafficOnLatestRevision = false at create, want true (real GCP default)")
+	}
+
+	if got.ServiceConfig.MaxInstanceRequestConcurrency != 1 {
+		t.Fatalf("maxInstanceRequestConcurrency = %d at create, want default 1",
+			got.ServiceConfig.MaxInstanceRequestConcurrency)
+	}
+
+	if _, err := svc.Projects.Locations.Functions.Patch(name, &cloudfunctions2.Function{
+		ServiceConfig: &cloudfunctions2.ServiceConfig{MaxInstanceRequestConcurrency: 10},
+	}).UpdateMask("serviceConfig.maxInstanceRequestConcurrency").Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got2, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	if got2.ServiceConfig.MaxInstanceRequestConcurrency != 10 {
+		t.Fatalf("maxInstanceRequestConcurrency = %d after patch, want 10",
+			got2.ServiceConfig.MaxInstanceRequestConcurrency)
+	}
+
+	if !got2.ServiceConfig.AllTrafficOnLatestRevision {
+		t.Fatal("allTrafficOnLatestRevision = false after patch, want true preserved")
+	}
+}
+
 // TestSDKGen2GetMissing confirms a missing gen2 function 404s.
 func TestSDKGen2GetMissing(t *testing.T) {
 	svc := newGCPV2Service(t)

--- a/server/gcp/cloudfunctions/gen2_sdk_test.go
+++ b/server/gcp/cloudfunctions/gen2_sdk_test.go
@@ -223,6 +223,82 @@ func TestSDKGen2TrafficAndConcurrency(t *testing.T) {
 	}
 }
 
+// TestSDKGen2ExplicitAllTrafficFalse guards the drift regression in the other
+// direction: all_traffic_on_latest_revision=false is a legitimate config (real
+// GCF then honors the underlying Cloud Run service's existing traffic split), so
+// an explicit false must round-trip as false — not be clobbered to the default
+// true. A masked patch of an unrelated field must leave it false, and an explicit
+// true must still round-trip as true.
+func TestSDKGen2ExplicitAllTrafficFalse(t *testing.T) {
+	svc := newGCPV2Service(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+	name := parent + "/functions/traffic-false"
+
+	if _, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions2.Function{
+		BuildConfig: &cloudfunctions2.BuildConfig{Runtime: "go121", EntryPoint: "Hello"},
+		ServiceConfig: &cloudfunctions2.ServiceConfig{
+			AvailableMemory:            "256M",
+			AllTrafficOnLatestRevision: false,
+			ForceSendFields:            []string{"AllTrafficOnLatestRevision"},
+		},
+	}).FunctionId("traffic-false").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create (explicit false): %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.ServiceConfig.AllTrafficOnLatestRevision {
+		t.Fatal("allTrafficOnLatestRevision = true at create, want false preserved (explicit false is legitimate)")
+	}
+
+	// A masked patch of an unrelated field must not resurrect the default true.
+	if _, err := svc.Projects.Locations.Functions.Patch(name, &cloudfunctions2.Function{
+		ServiceConfig: &cloudfunctions2.ServiceConfig{AvailableMemory: "512M"},
+	}).UpdateMask("serviceConfig.availableMemory").Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got2, err := svc.Projects.Locations.Functions.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	if got2.ServiceConfig.AvailableMemory != "512M" {
+		t.Fatalf("availableMemory = %q, want 512M", got2.ServiceConfig.AvailableMemory)
+	}
+
+	if got2.ServiceConfig.AllTrafficOnLatestRevision {
+		t.Fatal("allTrafficOnLatestRevision = true after masked patch, want false preserved")
+	}
+
+	// An explicit true must still round-trip as true.
+	tname := parent + "/functions/traffic-true"
+	if _, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions2.Function{
+		BuildConfig: &cloudfunctions2.BuildConfig{Runtime: "go121", EntryPoint: "Hello"},
+		ServiceConfig: &cloudfunctions2.ServiceConfig{
+			AvailableMemory:            "256M",
+			AllTrafficOnLatestRevision: true,
+			ForceSendFields:            []string{"AllTrafficOnLatestRevision"},
+		},
+	}).FunctionId("traffic-true").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create (explicit true): %v", err)
+	}
+
+	gotTrue, err := svc.Projects.Locations.Functions.Get(tname).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get (explicit true): %v", err)
+	}
+
+	if !gotTrue.ServiceConfig.AllTrafficOnLatestRevision {
+		t.Fatal("allTrafficOnLatestRevision = false at create with explicit true, want true")
+	}
+}
+
 // TestSDKGen2GetMissing confirms a missing gen2 function 404s.
 func TestSDKGen2GetMissing(t *testing.T) {
 	svc := newGCPV2Service(t)

--- a/server/gcp/cloudfunctions/handler.go
+++ b/server/gcp/cloudfunctions/handler.go
@@ -80,10 +80,11 @@ const (
 	// gen2ServiceAccountSuffix / gen1ServiceAccountSuffix are the default runtime
 	// service accounts real GCP assigns (compute default SA for gen2, App Engine
 	// default SA for gen1).
-	gen2DefaultMemory  = "256M"
-	gen2DefaultCPU     = "0.1666"
-	gen2DefaultTimeout = 60
-	buildIDBytes       = 8
+	gen2DefaultMemory      = "256M"
+	gen2DefaultCPU         = "0.1666"
+	gen2DefaultTimeout     = 60
+	gen2DefaultConcurrency = 1
+	buildIDBytes           = 8
 )
 
 // ObjectStore is the slice of the in-process GCS backend the handler needs to


### PR DESCRIPTION
## Summary

Real-user e2e audit of GCP Cloud Functions gen2 (`google_cloudfunctions2_function`, cloudfunctions.googleapis.com/v2) driven with Terraform (google provider) and the `google.golang.org/api/cloudfunctions/v2` SDK against `cloudemu serve`. Found and fixed a genuine cloud-vs-cloudemu divergence that causes **perpetual Terraform drift** for every user of the resource.

## Divergence fixed

**serviceConfig.allTrafficOnLatestRevision was never returned (perpetual drift).** Real gen2 GCP always reports `allTrafficOnLatestRevision=true` for a freshly deployed function, and Terraform's `service_config.all_traffic_on_latest_revision` defaults to `true`. Because the handler omitted the field, Terraform read it back as `false` and planned `all_traffic_on_latest_revision = false -> true` on **every** `terraform plan` after a clean apply.

Also added `serviceConfig.maxInstanceRequestConcurrency`: real gen2 defaults it to `1`; the field was dropped, so a client that set `max_instance_request_concurrency` had it silently discarded. It now defaults to 1 and round-trips through create and a masked PATCH.

## Live evidence (serve + Terraform)

- Before fix: after `terraform apply`, `terraform plan` showed `~ all_traffic_on_latest_revision = false -> true` (Plan: 1 to change).
- After fix: create → LRO done → state ACTIVE → `terraform plan` = **No changes**; update (available_memory/timeout/max_instance_count/max_instance_request_concurrency via query-param updateMask) → apply → plan **No changes**; `terraform destroy` (delete LRO) clean.

## Tests / gates

- Added `TestSDKGen2TrafficAndConcurrency` (real v2 SDK) covering the default and masked-patch round-trip.
- `go build ./...`, `go vet`, `gofmt -l`, `go test -race` (server/gcp/... + providers/gcp/cloudfunctions), root `go test`, `golangci-lint` (0 issues), `go generate` (no coverage diff) — all green.