### PR TITLE
fix(azure-redis): real-user e2e divergences from Azure Cache for Redis

### DIFF
--- a/providers/azure/cache/cache.go
+++ b/providers/azure/cache/cache.go
@@ -243,11 +243,14 @@ func (m *Mock) UpdateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 		updated.info.NodeType = cfg.NodeType
 	}
 
+	// The ARM SKU is atomic: a request carries name+family+capacity together. A
+	// wire update records the family whenever it supplies a SKU, so treat family
+	// presence as "a SKU was supplied" and apply the capacity alongside it —
+	// including capacity 0, so a scale down to the Basic/Standard C0 tier is not
+	// silently dropped. A family-less update (no SKU supplied) leaves both fields
+	// unchanged.
 	if cfg.SKUFamily != "" {
 		updated.info.SKUFamily = cfg.SKUFamily
-	}
-
-	if cfg.SKUCapacity > 0 {
 		updated.info.SKUCapacity = cfg.SKUCapacity
 	}
 

--- a/server/azure/cache/sdk_roundtrip_test.go
+++ b/server/azure/cache/sdk_roundtrip_test.go
@@ -285,3 +285,86 @@ func TestSDKAzureCacheRejectsClusteringOnStandard(t *testing.T) {
 		t.Fatal("expected an error for clustering on a Standard SKU, got nil")
 	}
 }
+
+// TestSDKAzureCacheCapacityZeroRoundTrips covers the Basic/Standard C0 tier
+// (capacity 0) — the cheapest tier and the default in many azurerm_redis_cache
+// configs. Capacity 0 must round-trip verbatim on create, Get and update; a
+// backend that coerces 0 to 1 (or omits it) makes azurerm see a perpetual diff.
+func TestSDKAzureCacheCapacityZeroRoundTrips(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreate(ctx, testRG, "c0-cache", armredis.CreateParameters{
+		Location: to.Ptr("eastus"),
+		Properties: &armredis.CreateProperties{
+			SKU: &armredis.SKU{
+				Name:     to.Ptr(armredis.SKUNameBasic),
+				Family:   to.Ptr(armredis.SKUFamilyC),
+				Capacity: to.Ptr(int32(0)),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	assertCapacity := func(where string, props *armredis.Properties) {
+		t.Helper()
+
+		if props == nil || props.SKU == nil || props.SKU.Capacity == nil {
+			t.Fatalf("%s: expected sku.capacity to be present, got %+v", where, props)
+		}
+
+		if *props.SKU.Capacity != 0 {
+			t.Fatalf("%s: sku.capacity = %d, want 0 (C0 tier)", where, *props.SKU.Capacity)
+		}
+
+		if props.SKU.Name == nil || *props.SKU.Name != armredis.SKUNameBasic {
+			t.Fatalf("%s: sku.name = %v, want Basic", where, props.SKU.Name)
+		}
+
+		if props.SKU.Family == nil || *props.SKU.Family != armredis.SKUFamilyC {
+			t.Fatalf("%s: sku.family = %v, want C", where, props.SKU.Family)
+		}
+	}
+
+	assertCapacity("create", created.Properties)
+
+	got, err := client.Get(ctx, testRG, "c0-cache", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	assertCapacity("get", got.Properties)
+
+	// An update that resends the C0 SKU must keep capacity 0, not coerce it up.
+	upPoller, err := client.BeginCreate(ctx, testRG, "c0-cache", armredis.CreateParameters{
+		Location: to.Ptr("eastus"),
+		Properties: &armredis.CreateProperties{
+			SKU: &armredis.SKU{
+				Name:     to.Ptr(armredis.SKUNameBasic),
+				Family:   to.Ptr(armredis.SKUFamilyC),
+				Capacity: to.Ptr(int32(0)),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate (update): %v", err)
+	}
+
+	if _, err := upPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("PollUntilDone (update): %v", err)
+	}
+
+	reGot, err := client.Get(ctx, testRG, "c0-cache", nil)
+	if err != nil {
+		t.Fatalf("Get after update: %v", err)
+	}
+
+	assertCapacity("get-after-update", reGot.Properties)
+}

--- a/server/azure/cache/types.go
+++ b/server/azure/cache/types.go
@@ -24,9 +24,13 @@ const (
 // Family is C (Basic/Standard) or P (Premium), and Capacity is the size unit —
 // all recorded on the driver so the SDK round-trips the exact SKU it sent.
 type skuJSON struct {
-	Name     string `json:"name,omitempty"`
-	Family   string `json:"family,omitempty"`
-	Capacity int    `json:"capacity,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Family string `json:"family,omitempty"`
+	// Capacity has no omitempty: real Azure always returns the SKU capacity, and
+	// capacity 0 is the valid Basic/Standard C0 tier (the cheapest, and the
+	// default in many azurerm_redis_cache configs). Omitting a 0 would make a C0
+	// cache read back without a capacity, which azurerm reads as a drift source.
+	Capacity int `json:"capacity"`
 }
 
 // redisProperties mirrors the subset of armredis Properties the cache driver
@@ -179,24 +183,24 @@ func toRedisJSON(rp *azurearm.ResourcePath, info *cachedriver.CacheInfo) redisJS
 	}
 }
 
-// skuFromInfo builds the ARM SKU from the recorded driver fields. Family
-// defaults to "C" (Basic/Standard) and capacity to 1 only when the driver has
-// no recorded value — e.g. a cache created through the portable API, which
-// carries a node type but no SKU family/capacity.
+// skuFromInfo builds the ARM SKU from the recorded driver fields. A wire
+// create/update records the SKU family the request supplied, so when a family
+// is present the recorded capacity is authoritative and round-trips verbatim —
+// including capacity 0, the Basic/Standard C0 tier. Only a cache created
+// through the portable API records no SKU family; that case falls back to a
+// plausible C1 SKU so its Get still returns a well-formed sku.
 func skuFromInfo(info *cachedriver.CacheInfo) *skuJSON {
-	family := info.SKUFamily
-	if family == "" {
-		family = "C"
-	}
-
-	capacity := info.SKUCapacity
-	if capacity == 0 {
-		capacity = 1
+	if info.SKUFamily != "" {
+		return &skuJSON{
+			Name:     skuNameFromNodeType(info.NodeType),
+			Family:   info.SKUFamily,
+			Capacity: info.SKUCapacity,
+		}
 	}
 
 	return &skuJSON{
 		Name:     skuNameFromNodeType(info.NodeType),
-		Family:   family,
-		Capacity: capacity,
+		Family:   "C",
+		Capacity: 1,
 	}
 }


### PR DESCRIPTION
## Summary

Real-user e2e audit of Azure Cache for Redis (`Microsoft.Cache/redis`, `azurerm_redis_cache` / `armredis`) surfaced one genuine cloud-vs-cloudemu divergence: the **Basic/Standard C0 tier (SKU capacity 0)** did not round-trip.

The handler forced an SKU capacity of `0` up to `1` in `skuFromInfo`, and `skuJSON.Capacity` was `omitempty`. Since `capacity = 0` is the cheapest Basic/Standard tier — and the default in a large share of `azurerm_redis_cache` examples — a C0 create/apply read back as capacity `1` (or with no `capacity` at all). azurerm deeply compares `capacity`, so this is a **perpetual Terraform drift** on the most common minimal config. The echo-properties overlay could not heal it either: its zero-scalar guard deliberately skips a request scalar of `0`.

## Changes

- `server/azure/cache/types.go`
  - `skuFromInfo`: when the record carries an SKU family (every wire create/update supplies one), trust the recorded capacity verbatim, including `0`. Only portable-API creations (no SKU family) fall back to the C1 default.
  - `skuJSON.Capacity`: drop `omitempty` — real Azure always returns the SKU capacity, and `0` is a valid value that must be emitted explicitly.
- `providers/azure/cache/cache.go`
  - `UpdateCache`: the ARM SKU is atomic (name+family+capacity together). Apply capacity alongside family when a SKU is supplied instead of only when `capacity > 0`, so a PATCH scaling down to C0 is not silently dropped.
- `server/azure/cache/sdk_roundtrip_test.go`
  - New `TestSDKAzureCacheCapacityZeroRoundTrips` driving `armredis`: C0 capacity round-trips on create, Get, and update.

## Verification

- `go build ./...`; `go vet`; `gofmt -l` clean; `golangci-lint --new-from-rev=origin/development` 0 new issues.
- `go test -race` full `server/azure/...` + `providers/azure/cache/...` green (echo-overlay wraps the whole server); root `go test .` green; `go generate ./...` no docs/coverage diff.
- Live `serve` (Azure HTTPS) ARM round-trip confirmed: C0 create + Get return `sku.capacity: 0`, `hostName c0live.redis.cache.windows.net`, `port 6379`/`sslPort 6380`, `enableNonSslPort: false` (explicit), `redisConfiguration` map preserved, `provisioningState: Succeeded` (LRO terminates — no azurerm hang), `accessKeys` only on create, and `listKeys` returns primary/secondary keys.