### PR TITLE
fix(sqs): real-user e2e divergences from AWS SQS

### DIFF
--- a/server/aws/sqs/handler.go
+++ b/server/aws/sqs/handler.go
@@ -363,6 +363,15 @@ func (h *Handler) receiveMessage(w http.ResponseWriter, r *http.Request) {
 
 	sysNames := append(append([]string{}, req.AttributeNames...), req.MessageSystemAttrs...)
 
+	// Real SQS omits the Messages field entirely when no messages are returned
+	// (the AwsJson1_0 body is {}), rather than emitting an empty array. Match
+	// that so clients that distinguish an absent field from an empty list — and
+	// wire-level snapshots — see identical bytes.
+	if len(msgs) == 0 {
+		wire.WriteJSON(w, map[string]any{})
+		return
+	}
+
 	out := make([]map[string]any, 0, len(msgs))
 	for i := range msgs {
 		out = append(out, buildReceiveEntry(&msgs[i], sysNames, req.MessageAttributeNames))
@@ -436,7 +445,7 @@ func (h *Handler) changeMessageVisibility(w http.ResponseWriter, r *http.Request
 // missing queue keeps the standard QueueDoesNotExist mapping.
 func writeReceiptErr(w http.ResponseWriter, err error) {
 	if cerrors.IsFailedPrecondition(err) {
-		wire.WriteJSONError(w, http.StatusBadRequest, "ReceiptHandleIsInvalid", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ReceiptHandleIsInvalid", cerrors.Message(err))
 		return
 	}
 
@@ -474,7 +483,7 @@ func (h *Handler) changeMessageVisibilityBatch(w http.ResponseWriter, r *http.Re
 		if err != nil {
 			failed = append(failed, map[string]any{
 				"Id": req.Entries[i].ID, "Code": "ReceiptHandleIsInvalid",
-				"Message": err.Error(), "SenderFault": true,
+				"Message": cerrors.Message(err), "SenderFault": true,
 			})
 
 			continue
@@ -928,14 +937,14 @@ func moveTaskResult(t *mqdriver.MessageMoveTask) map[string]any {
 func writeMoveTaskErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", cerrors.Message(err))
 	case cerrors.IsFailedPrecondition(err):
 		wire.WriteJSONErrorQueryCompat(w, http.StatusBadRequest,
-			"UnsupportedOperation", errQueryCodeUnsupportedOperation, err.Error())
+			"UnsupportedOperation", errQueryCodeUnsupportedOperation, cerrors.Message(err))
 	case cerrors.IsInvalidArgument(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterValue", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterValue", cerrors.Message(err))
 	default:
-		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalError", err.Error())
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalError", cerrors.Message(err))
 	}
 }
 
@@ -1174,12 +1183,12 @@ func (h *Handler) purgeQueue(w http.ResponseWriter, r *http.Request) {
 func writeErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONErrorQueryCompat(w, http.StatusBadRequest, errNonExistentQueue, errQueryCodeNonExistentQueue, err.Error())
+		wire.WriteJSONErrorQueryCompat(w, http.StatusBadRequest, errNonExistentQueue, errQueryCodeNonExistentQueue, cerrors.Message(err))
 	case cerrors.IsAlreadyExists(err):
-		wire.WriteJSONErrorQueryCompat(w, http.StatusBadRequest, "QueueNameExists", errQueryCodeQueueAlreadyExists, err.Error())
+		wire.WriteJSONErrorQueryCompat(w, http.StatusBadRequest, "QueueNameExists", errQueryCodeQueueAlreadyExists, cerrors.Message(err))
 	case cerrors.IsInvalidArgument(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterValue", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterValue", cerrors.Message(err))
 	default:
-		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalError", err.Error())
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalError", cerrors.Message(err))
 	}
 }

--- a/server/aws/sqs/sqs_test.go
+++ b/server/aws/sqs/sqs_test.go
@@ -251,6 +251,49 @@ func TestQueueTagging(t *testing.T) {
 	}
 }
 
+// TestReceiveMessageEmptyOmitsMessagesField pins the wire fidelity that real SQS
+// returns a bare {} for an empty ReceiveMessage rather than {"Messages":[]}.
+func TestReceiveMessageEmptyOmitsMessagesField(t *testing.T) {
+	srv, _ := newServer(t)
+
+	create := postJSON(t, srv, "AmazonSQS.CreateQueue", `{"QueueName":"empty-q"}`)
+	qurl := extractQueueURL(t, create)
+
+	resp := postJSON(t, srv, "AmazonSQS.ReceiveMessage", `{"QueueUrl":"`+qurl+`"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("receive status = %d", resp.StatusCode)
+	}
+
+	body := readBody(t, resp)
+	if strings.Contains(body, "Messages") {
+		t.Fatalf("empty ReceiveMessage must omit the Messages field, got %s", body)
+	}
+}
+
+// TestErrorMessageOmitsCanonicalCodePrefix guards against leaking the internal
+// cloudemu error-taxonomy name (e.g. "InvalidArgument: ") into the wire message,
+// which real SQS never does.
+func TestErrorMessageOmitsCanonicalCodePrefix(t *testing.T) {
+	srv, _ := newServer(t)
+
+	resp := postJSON(t, srv, "AmazonSQS.CreateQueue",
+		`{"QueueName":"badfifo","Attributes":{"FifoQueue":"true"}}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+
+	body := readBody(t, resp)
+	if !strings.Contains(body, "InvalidParameterValue") {
+		t.Fatalf("error code = %s, want InvalidParameterValue", body)
+	}
+
+	for _, leak := range []string{"InvalidArgument:", "NotFound:", "AlreadyExists:", "FailedPrecondition:"} {
+		if strings.Contains(body, leak) {
+			t.Fatalf("wire message leaked canonical code prefix %q: %s", leak, body)
+		}
+	}
+}
+
 func postJSON(t *testing.T, srv *httptest.Server, target, body string) *http.Response {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

Real-user e2e audit of AWS SQS (standard + FIFO, attributes/policy/redrive/tags, message ops) against real aws-cli, aws-sdk-go-v2, and Terraform pointed at `cloudemu serve`. Two genuine wire-fidelity divergences found and fixed; the rest of the surface verified correct.

## Fixes

- **Error message prefix leak (high):** every SQS error path returned the internal cloudemu error-taxonomy name inside the wire `message` (e.g. `InvalidArgument: FIFO queue name must end with .fifo`). Real SQS never puts an internal code name in the message. The SQS handler was the only AWS handler using `err.Error()` instead of `cerrors.Message(err)`; all 10 sites (`writeErr`, `writeMoveTaskErr`, `writeReceiptErr`, batch-visibility failure entry) now strip the prefix.
- **Empty ReceiveMessage shape:** an empty receive returned `{"Messages":[]}`; real SQS omits the field and returns a bare `{}`. Now emits `{}`, so wire bytes and strict clients match real SQS (aws-cli now prints nothing on an empty receive).

## Tests

Added wire-level regression tests: `TestReceiveMessageEmptyOmitsMessagesField`, `TestErrorMessageOmitsCanonicalCodePrefix`.

## Verification

- Terraform `aws_sqs_queue` (standard + FIFO + `redrive_policy` DLQ + tags) and `aws_sqs_queue_policy`: apply -> `terraform plan` = **no drift**; attribute update + tag change -> apply -> plan = no drift; destroy clean.
- All GetQueueAttributes defaults match real SQS (VisibilityTimeout 30, MessageRetentionPeriod 345600, MaximumMessageSize 262144, DelaySeconds/ReceiveMessageWaitTimeSeconds 0, epoch-second timestamps, FIFO-only attrs gated).
- FIFO content-based dedup (same MessageId, no new SequenceNumber), MessageGroupId required, `.fifo` suffix validation; MD5OfMessageBody real MD5; SendMessageBatch; visibility timeout reappearance; nonexistent-queue legacy code `AWS.SimpleQueueService.NonExistentQueue` + typed `QueueDoesNotExist`.

Gates: `go build ./...`, `go test -race` (server/aws/sqs, providers/aws/sqs, services/messagequeue), root `go test`, `go vet`, `gofmt -l`, `golangci-lint` (0 issues), `go generate ./...` (no docs/coverage drift) — all green.
