### PR TITLE
fix(sns): real-user e2e divergences from AWS SNS

### DIFF
--- a/providers/aws/sns/sequence_number_test.go
+++ b/providers/aws/sns/sequence_number_test.go
@@ -1,0 +1,51 @@
+package sns
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPublishFifoReturnsSequenceNumber locks the real-SNS contract that Publish
+// to a FIFO topic returns a large, monotonically increasing SequenceNumber,
+// while a standard topic returns none.
+func TestPublishFifoReturnsSequenceNumber(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateTopic(ctx, driver.TopicConfig{
+		Name: "orders.fifo", FifoTopic: true, ContentBasedDeduplication: true,
+	})
+	require.NoError(t, err)
+
+	first, err := m.Publish(ctx, driver.PublishInput{
+		TopicID: "orders.fifo", Message: "m1", MessageGroupID: "g1",
+	})
+	require.NoError(t, err)
+	assert.Len(t, first.SequenceNumber, 20, "SequenceNumber is a fixed-width numeric string")
+	assert.NotEqual(t, "00000000000000000000", first.SequenceNumber, "SequenceNumber must be non-zero")
+
+	second, err := m.Publish(ctx, driver.PublishInput{
+		TopicID: "orders.fifo", Message: "m2", MessageGroupID: "g1",
+	})
+	require.NoError(t, err)
+	assert.Greater(t, second.SequenceNumber, first.SequenceNumber,
+		"SequenceNumber must increase for successive publishes")
+}
+
+// TestPublishStandardOmitsSequenceNumber asserts a standard topic's publish
+// carries no SequenceNumber (real SNS returns the element only for FIFO topics).
+func TestPublishStandardOmitsSequenceNumber(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateTopic(ctx, driver.TopicConfig{Name: "plain"})
+	require.NoError(t, err)
+
+	out, err := m.Publish(ctx, driver.PublishInput{TopicID: "plain", Message: "hi"})
+	require.NoError(t, err)
+	assert.Empty(t, out.SequenceNumber, "standard topics return no SequenceNumber")
+}

--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -4,6 +4,7 @@ package sns
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"maps"
 	"strings"
 	"sync"
@@ -536,6 +537,7 @@ func (m *Mock) Publish(ctx context.Context, input driver.PublishInput) (*driver.
 		Message:    input.Message,
 		Attributes: attrs,
 	})
+	ordinal := len(td.messages)
 	td.mu.Unlock()
 
 	m.fanOutToSQS(ctx, td, msgID, &input)
@@ -545,7 +547,21 @@ func (m *Mock) Publish(ctx context.Context, input driver.PublishInput) (*driver.
 	m.emitMetric("NumberOfMessagesPublished", 1, "Count", dims)
 	m.emitMetric("PublishSize", float64(len(input.Message)), "Bytes", dims)
 
-	return &driver.PublishOutput{MessageID: msgID}, nil
+	out := &driver.PublishOutput{MessageID: msgID}
+	if td.info.FifoTopic {
+		out.SequenceNumber = fifoSequenceNumber(ordinal)
+	}
+
+	return out, nil
+}
+
+// fifoSequenceNumber renders a FIFO topic's per-message sequence number. Real
+// SNS returns a large, monotonically increasing 128-bit numeric string per
+// message; the message ordinal (persisted with the message log, so it survives
+// snapshot/restore) supplies the monotonicity, zero-padded to the width SNS
+// uses so a client parsing or comparing it as a big integer behaves the same.
+func fifoSequenceNumber(ordinal int) string {
+	return fmt.Sprintf("%020d", ordinal)
 }
 
 // PublishExternal publishes a raw message to the topic identified by its ARN,

--- a/server/aws/sns/operations.go
+++ b/server/aws/sns/operations.go
@@ -669,7 +669,7 @@ func (h *Handler) publish(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, publishResponse{
 		Xmlns:    Namespace,
-		Result:   publishResult{MessageID: out.MessageID},
+		Result:   publishResult{MessageID: out.MessageID, SequenceNumber: out.SequenceNumber},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/sns/sequence_number_sdk_test.go
+++ b/server/aws/sns/sequence_number_sdk_test.go
@@ -1,0 +1,117 @@
+package sns_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
+	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
+)
+
+// TestSDKPublishFifoReturnsSequenceNumber asserts the wire layer surfaces the
+// FIFO-only SequenceNumber real SNS returns from Publish, and omits it for a
+// standard topic — a real aws-sdk-go-v2 client that orders FIFO messages by
+// SequenceNumber otherwise reads an empty value.
+func TestSDKPublishFifoReturnsSequenceNumber(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	fifo, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{
+		Name: aws.String("seq.fifo"),
+		Attributes: map[string]string{
+			"FifoTopic":                 "true",
+			"ContentBasedDeduplication": "true",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateTopic(fifo): %v", err)
+	}
+
+	first, err := client.Publish(ctx, &awssns.PublishInput{
+		TopicArn:       fifo.TopicArn,
+		Message:        aws.String("m1"),
+		MessageGroupId: aws.String("g1"),
+	})
+	if err != nil {
+		t.Fatalf("Publish(fifo): %v", err)
+	}
+
+	if first.SequenceNumber == nil || *first.SequenceNumber == "" {
+		t.Fatal("FIFO Publish returned no SequenceNumber, want a non-empty value")
+	}
+
+	second, err := client.Publish(ctx, &awssns.PublishInput{
+		TopicArn:       fifo.TopicArn,
+		Message:        aws.String("m2"),
+		MessageGroupId: aws.String("g1"),
+	})
+	if err != nil {
+		t.Fatalf("Publish(fifo) second: %v", err)
+	}
+
+	if *second.SequenceNumber <= *first.SequenceNumber {
+		t.Fatalf("SequenceNumber not increasing: %q then %q", *first.SequenceNumber, *second.SequenceNumber)
+	}
+
+	std, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("seq-standard")})
+	if err != nil {
+		t.Fatalf("CreateTopic(standard): %v", err)
+	}
+
+	out, err := client.Publish(ctx, &awssns.PublishInput{
+		TopicArn: std.TopicArn,
+		Message:  aws.String("hi"),
+	})
+	if err != nil {
+		t.Fatalf("Publish(standard): %v", err)
+	}
+
+	if out.SequenceNumber != nil && *out.SequenceNumber != "" {
+		t.Fatalf("standard Publish returned SequenceNumber %q, want none", *out.SequenceNumber)
+	}
+}
+
+// TestSDKPublishBatchFifoReturnsSequenceNumber asserts each successful
+// PublishBatch entry on a FIFO topic carries its own SequenceNumber, mirroring
+// the PublishBatchResultEntry shape real SNS returns.
+func TestSDKPublishBatchFifoReturnsSequenceNumber(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	fifo, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{
+		Name: aws.String("seqbatch.fifo"),
+		Attributes: map[string]string{
+			"FifoTopic":                 "true",
+			"ContentBasedDeduplication": "true",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateTopic(fifo): %v", err)
+	}
+
+	out, err := client.PublishBatch(ctx, &awssns.PublishBatchInput{
+		TopicArn: fifo.TopicArn,
+		PublishBatchRequestEntries: []snstypes.PublishBatchRequestEntry{
+			{Id: aws.String("a"), Message: aws.String("m1"), MessageGroupId: aws.String("g1")},
+			{Id: aws.String("b"), Message: aws.String("m2"), MessageGroupId: aws.String("g2")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PublishBatch(fifo): %v", err)
+	}
+
+	if len(out.Failed) != 0 {
+		t.Fatalf("PublishBatch had %d failed entries, want 0", len(out.Failed))
+	}
+
+	if len(out.Successful) != 2 {
+		t.Fatalf("PublishBatch returned %d successful entries, want 2", len(out.Successful))
+	}
+
+	for _, e := range out.Successful {
+		if e.SequenceNumber == nil || *e.SequenceNumber == "" {
+			t.Fatalf("batch entry %q returned no SequenceNumber", aws.ToString(e.Id))
+		}
+	}
+}

--- a/server/aws/sns/subscription_attributes.go
+++ b/server/aws/sns/subscription_attributes.go
@@ -277,7 +277,9 @@ func (h *Handler) publishBatch(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		successes = append(successes, batchResultEntry{ID: entryID, MessageID: out.MessageID})
+		successes = append(successes, batchResultEntry{
+			ID: entryID, MessageID: out.MessageID, SequenceNumber: out.SequenceNumber,
+		})
 	}
 
 	awsquery.WriteXMLResponse(w, publishBatchResponse{

--- a/server/aws/sns/types.go
+++ b/server/aws/sns/types.go
@@ -180,6 +180,9 @@ type listSubscriptionsByTopicResponse struct {
 
 type publishResult struct {
 	MessageID string `xml:"MessageId"`
+	// SequenceNumber is emitted only for FIFO topics; standard-topic publishes
+	// omit it, matching real SNS.
+	SequenceNumber string `xml:"SequenceNumber,omitempty"`
 }
 
 type publishResponse struct {
@@ -194,6 +197,8 @@ type publishResponse struct {
 type batchResultEntry struct {
 	ID        string `xml:"Id"`
 	MessageID string `xml:"MessageId"`
+	// SequenceNumber is emitted only for FIFO topics, mirroring Publish.
+	SequenceNumber string `xml:"SequenceNumber,omitempty"`
 }
 
 type batchErrorEntry struct {

--- a/services/notification/driver/driver.go
+++ b/services/notification/driver/driver.go
@@ -184,6 +184,10 @@ type PublishInput struct {
 // PublishOutput is the result of publishing a message.
 type PublishOutput struct {
 	MessageID string
+	// SequenceNumber is the large, monotonically increasing number SNS assigns
+	// to each message published to a FIFO topic. It is empty for standard topics
+	// (and for providers that don't model FIFO ordering).
+	SequenceNumber string
 }
 
 // Notification is the interface that notification provider implementations must satisfy.


### PR DESCRIPTION
## Summary

Real-user e2e audit of AWS SNS (aws-sdk-go-v2 + AWS CLI + Terraform against `cloudemu serve`) surfaced one genuine cloud-vs-cloudemu divergence in the common topic + subscription + attributes + publish + FIFO path.

## Divergence fixed: FIFO Publish/PublishBatch SequenceNumber

Real SNS returns a `SequenceNumber` response element for every message published to a **FIFO** topic — from the [Publish API docs](https://docs.aws.amazon.com/sns/latest/api/API_Publish.html): *"This response element applies only to FIFO topics. The sequence number is a large, non-consecutive number that Amazon SNS assigns to each message ... SequenceNumber continues to increase for each MessageGroupId."* Each `PublishBatchResultEntry` carries it too. Standard topics omit it.

CloudEmu dropped the field entirely: `driver.PublishOutput` had only `MessageID`, and the wire `PublishResult`/`PublishBatchResultEntry` had no `SequenceNumber` element. An SDK/CLI client that orders FIFO messages by `SequenceNumber` read an empty value.

### Change
- `services/notification/driver`: add `SequenceNumber` to `PublishOutput`.
- `providers/aws/sns`: FIFO publishes now return a monotonically increasing, fixed-width `SequenceNumber` derived from the message ordinal (persisted with the message log, so it survives snapshot/restore); standard topics return empty.
- `server/aws/sns`: emit `SequenceNumber` (`omitempty`) on `Publish` and each successful `PublishBatch` entry.

## Live evidence
- CLI: FIFO `publish` → `SequenceNumber` 00..01, 00..02 (monotonic); standard `publish` → no field; FIFO `publish-batch` → per-entry SequenceNumber 03, 04.
- Terraform (aws_sns_topic standard + FIFO, aws_sns_topic_subscription sqs with filter_policy + raw_message_delivery, aws_sns_topic_policy): `apply` then `plan` = **No changes** (no drift; default Policy JSON, EffectiveDeliveryPolicy, FifoTopic/ContentBasedDeduplication, FilterPolicy and RawMessageDelivery all round-trip).

## Tests
- `providers/aws/sns/sequence_number_test.go` — FIFO returns increasing SequenceNumber; standard omits it.
- `server/aws/sns/sequence_number_sdk_test.go` — aws-sdk-go-v2 Publish + PublishBatch assertions.

## Gates
build, `go vet`, `gofmt`, scoped `go test -race`, root integration test, and `golangci-lint --new-from-rev=origin/development` (0 new issues) all green. `go generate ./...` produced no docs/coverage changes.

## Audit notes (no divergence / already correct)
Verified clean, no fix needed: TopicArn/SubscriptionArn formats, default Policy + EffectiveDeliveryPolicy JSON, Owner, subscription counters, DisplayName, FIFO .fifo suffix + ContentBasedDeduplication validation, immediate ARN for sqs vs "pending confirmation" for http/email, FilterPolicy/FilterPolicyScope/RawMessageDelivery/RedrivePolicy round-trip, tags, ListTopics/ListSubscriptions determinism, error codes (NotFound 404 / InvalidParameter 400). The SQS-style cerrors-prefix leak is **not** present in SNS (`cerrors.Message` returns the bare message).