### PR TITLE
fix(azure-eventhub): real-user e2e divergences from Azure Event Hubs

### DIFF
--- a/server/azure/eventhub/eventhub_divergence_test.go
+++ b/server/azure/eventhub/eventhub_divergence_test.go
@@ -218,6 +218,121 @@ func TestSDKNamespaceUpdateAppliesProperties(t *testing.T) {
 	}
 }
 
+// TestSDKNamespaceUpdateAppliesExplicitFalse checks that a PATCH which flips a
+// boolean property from true to an EXPLICIT false (and a numeric property from a
+// non-zero value to 0) is actually applied — the change-to-default case a naive
+// echo-of-request cannot handle. Real Azure's Namespaces - Update applies the
+// values the caller sends, so isAutoInflateEnabled=false and
+// maximumThroughputUnits=0 must be read back after the PATCH, not the stale
+// creation-time values. The SDK sends *bool/*int32 fields, so a pointer to
+// false/0 is serialized on the wire (omitempty only drops a nil pointer), making
+// the explicit-false intent observable to the server.
+func TestSDKNamespaceUpdateAppliesExplicitFalse(t *testing.T) {
+	ts := newServer(t)
+	ctx := context.Background()
+
+	c, err := armeventhub.NewNamespacesClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewNamespacesClient: %v", err)
+	}
+
+	// Create the namespace with AutoInflate ON, a non-zero throughput ceiling and
+	// zoneRedundant/disableLocalAuth ON, so the PATCH below has true values to
+	// clear rather than fields that were never set.
+	poller, err := c.BeginCreateOrUpdate(ctx, rgName, nsName, armeventhub.EHNamespace{
+		Location: to.Ptr("eastus"),
+		SKU:      &armeventhub.SKU{Name: to.Ptr(armeventhub.SKUNameStandard)},
+		Properties: &armeventhub.EHNamespaceProperties{
+			IsAutoInflateEnabled:   to.Ptr(true),
+			MaximumThroughputUnits: to.Ptr[int32](10),
+			ZoneRedundant:          to.Ptr(true),
+			DisableLocalAuth:       to.Ptr(true),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate namespace: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll namespace create: %v", err)
+	}
+
+	// Sanity: the creation values are present before the clearing PATCH.
+	got, err := c.Get(ctx, rgName, nsName, nil)
+	if err != nil {
+		t.Fatalf("Get after create: %v", err)
+	}
+
+	if got.Properties.IsAutoInflateEnabled == nil || !*got.Properties.IsAutoInflateEnabled ||
+		got.Properties.MaximumThroughputUnits == nil || *got.Properties.MaximumThroughputUnits != 10 {
+		t.Fatalf("pre-PATCH read-back = autoInflate:%v maxTU:%v, want true/10",
+			got.Properties.IsAutoInflateEnabled, got.Properties.MaximumThroughputUnits)
+	}
+
+	// PATCH the booleans to EXPLICIT false and the ceiling to 0. Because these are
+	// scalar zero values the request-echo overlay deliberately does not capture
+	// (it treats a zero scalar the response omits as a modeled default, matching
+	// the PATCH-to-clear guard), so read-back can only return them if the handler
+	// itself merged the request properties onto the stored state.
+	if _, err := c.Update(ctx, rgName, nsName, armeventhub.EHNamespace{
+		Properties: &armeventhub.EHNamespaceProperties{
+			IsAutoInflateEnabled:   to.Ptr(false),
+			MaximumThroughputUnits: to.Ptr[int32](0),
+			ZoneRedundant:          to.Ptr(false),
+			DisableLocalAuth:       to.Ptr(false),
+		},
+	}, nil); err != nil {
+		t.Fatalf("Update namespace (clear): %v", err)
+	}
+
+	got, err = c.Get(ctx, rgName, nsName, nil)
+	if err != nil {
+		t.Fatalf("Get after clearing update: %v", err)
+	}
+
+	if got.Properties.IsAutoInflateEnabled == nil || *got.Properties.IsAutoInflateEnabled {
+		t.Fatalf("read-back isAutoInflateEnabled = %v, want false (explicit-false applied)",
+			got.Properties.IsAutoInflateEnabled)
+	}
+
+	if got.Properties.MaximumThroughputUnits == nil || *got.Properties.MaximumThroughputUnits != 0 {
+		t.Fatalf("read-back maximumThroughputUnits = %v, want 0 (explicit-zero applied)",
+			got.Properties.MaximumThroughputUnits)
+	}
+
+	if got.Properties.ZoneRedundant == nil || *got.Properties.ZoneRedundant {
+		t.Fatalf("read-back zoneRedundant = %v, want false", got.Properties.ZoneRedundant)
+	}
+
+	if got.Properties.DisableLocalAuth == nil || *got.Properties.DisableLocalAuth {
+		t.Fatalf("read-back disableLocalAuth = %v, want false", got.Properties.DisableLocalAuth)
+	}
+
+	// A later tags-only PATCH omits every property; the just-cleared false must be
+	// preserved (omitted-field partial-update merge), not resurrected to its
+	// creation-time true.
+	if _, err := c.Update(ctx, rgName, nsName, armeventhub.EHNamespace{
+		Tags: map[string]*string{"team": to.Ptr("data")},
+	}, nil); err != nil {
+		t.Fatalf("tags-only Update: %v", err)
+	}
+
+	got, err = c.Get(ctx, rgName, nsName, nil)
+	if err != nil {
+		t.Fatalf("Get after tags-only update: %v", err)
+	}
+
+	if got.Properties.IsAutoInflateEnabled == nil || *got.Properties.IsAutoInflateEnabled {
+		t.Fatalf("isAutoInflateEnabled after tags-only PATCH = %v, want it preserved as false",
+			got.Properties.IsAutoInflateEnabled)
+	}
+
+	if got.Properties.MaximumThroughputUnits == nil || *got.Properties.MaximumThroughputUnits != 0 {
+		t.Fatalf("maximumThroughputUnits after tags-only PATCH = %v, want it preserved as 0",
+			got.Properties.MaximumThroughputUnits)
+	}
+}
+
 func createStandardNamespace(t *testing.T, ctx context.Context, ts *httptest.Server) {
 	t.Helper()
 

--- a/server/azure/eventhub/eventhub_divergence_test.go
+++ b/server/azure/eventhub/eventhub_divergence_test.go
@@ -153,6 +153,71 @@ func TestSDKEventHubPropertyValidation(t *testing.T) {
 	}
 }
 
+// TestSDKNamespaceUpdateAppliesProperties checks that the ARM Namespaces - Update
+// (PATCH) operation applies the properties in the request body as a partial
+// update, matching real Azure. A caller that PATCHes isAutoInflateEnabled and
+// maximumThroughputUnits must read those values back; silently dropping them
+// causes read-back drift for the SDK, the Azure CLI (az eventhubs namespace
+// update) and any tool that uses PATCH rather than PUT.
+func TestSDKNamespaceUpdateAppliesProperties(t *testing.T) {
+	ts := newServer(t)
+	ctx := context.Background()
+
+	c, err := armeventhub.NewNamespacesClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewNamespacesClient: %v", err)
+	}
+
+	createStandardNamespace(t, ctx, ts)
+
+	// PATCH: turn AutoInflate on and set a maximum throughput unit ceiling.
+	updated, err := c.Update(ctx, rgName, nsName, armeventhub.EHNamespace{
+		Properties: &armeventhub.EHNamespaceProperties{
+			IsAutoInflateEnabled:   to.Ptr(true),
+			MaximumThroughputUnits: to.Ptr[int32](10),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Update namespace: %v", err)
+	}
+
+	if updated.Properties == nil || updated.Properties.IsAutoInflateEnabled == nil ||
+		!*updated.Properties.IsAutoInflateEnabled {
+		t.Fatalf("PATCH response isAutoInflateEnabled = %v, want true", updated.Properties)
+	}
+
+	got, err := c.Get(ctx, rgName, nsName, nil)
+	if err != nil {
+		t.Fatalf("Get after update: %v", err)
+	}
+
+	if got.Properties.IsAutoInflateEnabled == nil || !*got.Properties.IsAutoInflateEnabled {
+		t.Fatalf("read-back isAutoInflateEnabled = %v, want true", got.Properties.IsAutoInflateEnabled)
+	}
+
+	if got.Properties.MaximumThroughputUnits == nil || *got.Properties.MaximumThroughputUnits != 10 {
+		t.Fatalf("read-back maximumThroughputUnits = %v, want 10", got.Properties.MaximumThroughputUnits)
+	}
+
+	// A PATCH that omits a property must leave it unchanged (partial update): a
+	// tags-only update must not reset isAutoInflateEnabled to false.
+	if _, err := c.Update(ctx, rgName, nsName, armeventhub.EHNamespace{
+		Tags: map[string]*string{"team": to.Ptr("data")},
+	}, nil); err != nil {
+		t.Fatalf("tags-only Update: %v", err)
+	}
+
+	got, err = c.Get(ctx, rgName, nsName, nil)
+	if err != nil {
+		t.Fatalf("Get after tags-only update: %v", err)
+	}
+
+	if got.Properties.IsAutoInflateEnabled == nil || !*got.Properties.IsAutoInflateEnabled {
+		t.Fatalf("isAutoInflateEnabled after tags-only PATCH = %v, want it preserved as true",
+			got.Properties.IsAutoInflateEnabled)
+	}
+}
+
 func createStandardNamespace(t *testing.T, ctx context.Context, ts *httptest.Server) {
 	t.Helper()
 

--- a/server/azure/eventhub/namespace.go
+++ b/server/azure/eventhub/namespace.go
@@ -107,11 +107,41 @@ func (h *Handler) updateNamespace(w http.ResponseWriter, r *http.Request, ep ehP
 		ns.SKU = normalizeSKU(req.SKU)
 	}
 
+	mergeNamespaceProperties(&ns.Properties, &req.Properties)
+
 	ns.UpdatedAt = time.Now().UTC()
 	resource := toNamespaceResource(ns)
 	h.mu.Unlock()
 
 	azurearm.WriteJSON(w, http.StatusOK, resource)
+}
+
+// mergeNamespaceProperties applies the client-settable properties present in src
+// onto dst, leaving unset (nil) fields unchanged. This matches the ARM
+// Namespaces - Update (PATCH) partial-update semantics: only the properties the
+// caller includes in the request body are modified (the computed fields —
+// provisioningState, status, serviceBusEndpoint, metricId, timestamps — are
+// re-derived on every read by toNamespaceResource, so they are not merged here).
+func mergeNamespaceProperties(dst, src *namespaceProperties) {
+	if src.IsAutoInflateEnabled != nil {
+		dst.IsAutoInflateEnabled = src.IsAutoInflateEnabled
+	}
+
+	if src.MaximumThroughputUnits != nil {
+		dst.MaximumThroughputUnits = src.MaximumThroughputUnits
+	}
+
+	if src.KafkaEnabled != nil {
+		dst.KafkaEnabled = src.KafkaEnabled
+	}
+
+	if src.ZoneRedundant != nil {
+		dst.ZoneRedundant = src.ZoneRedundant
+	}
+
+	if src.DisableLocalAuth != nil {
+		dst.DisableLocalAuth = src.DisableLocalAuth
+	}
 }
 
 func (h *Handler) getNamespace(w http.ResponseWriter, ep ehPath) {


### PR DESCRIPTION
## Summary

Real-user e2e audit of the Azure Event Hubs (`Microsoft.EventHub`) ARM control plane against the official REST API. The surface (namespaces + event hubs + consumer groups + authorization rules + listKeys/regenerateKeys) is already comprehensively built and correct; this PR fixes the one genuine divergence found.

## Fix

**`Namespaces - Update` (PATCH) silently dropped every property change.** `updateNamespace` applied `location`, `tags` and `sku` but ignored the request body's `properties` entirely. A caller that PATCHed `isAutoInflateEnabled`, `maximumThroughputUnits`, `kafkaEnabled`, `zoneRedundant` or `disableLocalAuth` read back the stale create-time values — a read-back drift for the azure-sdk-for-go `NamespacesClient.Update`, the Azure CLI (`az eventhubs namespace update`), and any tool that uses PATCH rather than PUT.

The official docs confirm PATCH is a partial create-or-update that applies the supplied properties. `updateNamespace` now merges the client-settable pointer properties from the request onto the stored namespace, leaving omitted fields unchanged (partial-update semantics) and re-deriving the computed fields (`provisioningState`, `status`, `serviceBusEndpoint`, `metricId`, timestamps) on read as before.

## Verification

- New SDK test `TestSDKNamespaceUpdateAppliesProperties`: PATCH applies `isAutoInflateEnabled`/`maximumThroughputUnits`, read-back matches, and a subsequent tags-only PATCH preserves the earlier property values.
- Live `cloudemu serve` (Azure HTTPS) end-to-end: full CRUD for namespace/event hub/consumer group/authorization rule, `listKeys` connection strings (with `EntityPath` at hub scope), `$Default` auto-creation, `partitionIds` generation, and the PATCH round-trip — all correct.
- Gates: `go build ./...`, `go vet`, `gofmt`, `go test -race` (full `server/azure/...`), `golangci-lint` (0 issues), `go generate ./...` (docs/coverage unchanged — no interface change).
