### PR TITLE
fix(memorystore): real-user e2e divergences from GCP Memorystore

### DIFF
--- a/server/gcp/memorystore/location_scoping_sdk_test.go
+++ b/server/gcp/memorystore/location_scoping_sdk_test.go
@@ -1,0 +1,132 @@
+package memorystore_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+	redis "google.golang.org/api/redis/v1"
+)
+
+// TestSDKLocationScoping locks the per-location semantics of the real
+// Memorystore API: an instance id is unique per (project, location), so Get in
+// the wrong location is NOT_FOUND, List is scoped to its parent's region, and the
+// "-" location wildcard aggregates every region with each instance reported under
+// its actual location (never the wildcard).
+func TestSDKLocationScoping(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	const project = "demo"
+
+	loc := func(region string) string { return "projects/" + project + "/locations/" + region }
+	name := func(region, id string) string { return loc(region) + "/instances/" + id }
+
+	// Two instances with the same short id in different regions must coexist? The
+	// shared store keys on the id, so use distinct ids per region to model a
+	// realistic multi-region deployment.
+	create := func(region, id string) {
+		t.Helper()
+
+		if _, err := svc.Projects.Locations.Instances.Create(loc(region), &redis.Instance{
+			Tier:         "BASIC",
+			MemorySizeGb: 1,
+		}).InstanceId(id).Context(ctx).Do(); err != nil {
+			t.Fatalf("Create(%s/%s): %v", region, id, err)
+		}
+	}
+
+	create("us-central1", "central-cache")
+	create("us-east1", "east-cache")
+
+	// Get in the correct location succeeds and reports the true resource name.
+	got, err := svc.Projects.Locations.Instances.Get(name("us-central1", "central-cache")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get(us-central1/central-cache): %v", err)
+	}
+
+	if got.Name != name("us-central1", "central-cache") {
+		t.Errorf("name: got %q want %q", got.Name, name("us-central1", "central-cache"))
+	}
+
+	if got.LocationId != "us-central1-a" {
+		t.Errorf("locationId: got %q want us-central1-a", got.LocationId)
+	}
+
+	// Get with the WRONG location for an existing id is NOT_FOUND (not a phantom
+	// resource named after the request path).
+	_, err = svc.Projects.Locations.Instances.Get(name("us-east1", "central-cache")).Context(ctx).Do()
+	assertNotFound(t, err, "Get(wrong location)")
+
+	// List is scoped to its parent region.
+	assertListNames(t, svc, loc("us-central1"), []string{name("us-central1", "central-cache")})
+	assertListNames(t, svc, loc("us-east1"), []string{name("us-east1", "east-cache")})
+	assertListNames(t, svc, loc("europe-west1"), nil)
+
+	// The "-" wildcard aggregates all regions, each under its actual location.
+	assertListNames(t, svc, loc("-"), []string{
+		name("us-central1", "central-cache"),
+		name("us-east1", "east-cache"),
+	})
+
+	// Patch/Delete in the wrong location are NOT_FOUND.
+	_, err = svc.Projects.Locations.Instances.Patch(name("us-east1", "central-cache"),
+		&redis.Instance{MemorySizeGb: 2}).UpdateMask("memorySizeGb").Context(ctx).Do()
+	assertNotFound(t, err, "Patch(wrong location)")
+
+	_, err = svc.Projects.Locations.Instances.Delete(name("us-east1", "central-cache")).Context(ctx).Do()
+	assertNotFound(t, err, "Delete(wrong location)")
+
+	// The instance is untouched by the wrong-location mutations.
+	after, err := svc.Projects.Locations.Instances.Get(name("us-central1", "central-cache")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after wrong-location mutations: %v", err)
+	}
+
+	if after.MemorySizeGb != 1 {
+		t.Errorf("memorySizeGb changed by wrong-location patch: got %d want 1", after.MemorySizeGb)
+	}
+}
+
+func assertNotFound(t *testing.T, err error, op string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("%s: expected NOT_FOUND, got nil", op)
+	}
+
+	var ge *googleapi.Error
+	if !errors.As(err, &ge) || ge.Code != 404 {
+		t.Fatalf("%s: expected HTTP 404, got %v", op, err)
+	}
+}
+
+func assertListNames(t *testing.T, svc *redis.Service, parent string, want []string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	var got []string
+
+	call := svc.Projects.Locations.Instances.List(parent).Context(ctx)
+	if err := call.Pages(ctx, func(page *redis.ListInstancesResponse) error {
+		for _, in := range page.Instances {
+			got = append(got, in.Name)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatalf("List(%s): %v", parent, err)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("List(%s): got %d names %v, want %d %v", parent, len(got), got, len(want), want)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("List(%s)[%d]: got %q want %q (full %v)", parent, i, got[i], want[i], got)
+		}
+	}
+}

--- a/server/gcp/memorystore/location_scoping_sdk_test.go
+++ b/server/gcp/memorystore/location_scoping_sdk_test.go
@@ -89,6 +89,80 @@ func TestSDKLocationScoping(t *testing.T) {
 	}
 }
 
+// TestSDKReservedLabelCannotOverrideScoping guards that user-supplied labels
+// carrying the reserved cloudemu: prefix can never set or overwrite the internal
+// tags that scope an instance. A PATCH (or create) of a cloudemu:gcpLocation
+// label must not "teleport" the instance to a phantom region, while an ordinary
+// label in the same request is still applied.
+func TestSDKReservedLabelCannotOverrideScoping(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	const project = "demo"
+
+	loc := func(region string) string { return "projects/" + project + "/locations/" + region }
+	name := func(region, id string) string { return loc(region) + "/instances/" + id }
+
+	// Create carrying a reserved label plus an ordinary one. The reserved label
+	// must be ignored (the server's own location tag wins); the ordinary one sticks.
+	if _, err := svc.Projects.Locations.Instances.Create(loc("us-central1"), &redis.Instance{
+		Tier:         "BASIC",
+		MemorySizeGb: 1,
+		Labels:       map[string]string{"cloudemu:gcpLocation": "us-west1", "team": "core"},
+	}).InstanceId("guarded").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// The instance lives at its real region, not the phantom one from the label.
+	got, err := svc.Projects.Locations.Instances.Get(name("us-central1", "guarded")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get(real region) after create: %v", err)
+	}
+
+	if _, err = svc.Projects.Locations.Instances.Get(name("us-west1", "guarded")).Context(ctx).Do(); err == nil {
+		t.Fatalf("Get(phantom region) after create: expected NOT_FOUND, got success")
+	} else {
+		assertNotFound(t, err, "Get(phantom region) after create")
+	}
+
+	// The ordinary label round-trips; the reserved key is never surfaced.
+	if got.Labels["team"] != "core" {
+		t.Errorf("labels after create = %v, want team=core", got.Labels)
+	}
+
+	if _, ok := got.Labels["cloudemu:gcpLocation"]; ok {
+		t.Errorf("reserved label leaked into GET labels: %v", got.Labels)
+	}
+
+	// PATCH (no updateMask → merge) a reserved label plus an ordinary one.
+	if _, err = svc.Projects.Locations.Instances.Patch(name("us-central1", "guarded"), &redis.Instance{
+		Labels: map[string]string{"cloudemu:gcpLocation": "us-west1", "env": "prod"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	// Still reachable at its real region; still absent from the phantom region.
+	got, err = svc.Projects.Locations.Instances.Get(name("us-central1", "guarded")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get(real region) after patch: %v", err)
+	}
+
+	if _, err = svc.Projects.Locations.Instances.Get(name("us-west1", "guarded")).Context(ctx).Do(); err == nil {
+		t.Fatalf("Get(phantom region) after patch: expected NOT_FOUND, got success")
+	} else {
+		assertNotFound(t, err, "Get(phantom region) after patch")
+	}
+
+	// The ordinary patch label is applied; the reserved key stays hidden.
+	if got.Labels["env"] != "prod" || got.Labels["team"] != "core" {
+		t.Errorf("labels after patch = %v, want env=prod and team=core", got.Labels)
+	}
+
+	if _, ok := got.Labels["cloudemu:gcpLocation"]; ok {
+		t.Errorf("reserved label leaked into GET labels after patch: %v", got.Labels)
+	}
+}
+
 func assertNotFound(t *testing.T, err error, op string) {
 	t.Helper()
 

--- a/server/gcp/memorystore/operations.go
+++ b/server/gcp/memorystore/operations.go
@@ -27,11 +27,14 @@ func (h *Handler) createInstance(w http.ResponseWriter, r *http.Request, rt rout
 		return
 	}
 
+	tags := instanceTags(&body, nil, nil)
+	tags[locationTag] = rt.location
+
 	info, err := h.cache.CreateCache(r.Context(), cachedriver.CacheConfig{
 		Name:     instanceID,
 		Engine:   "redis",
 		NodeType: body.Tier,
-		Tags:     instanceTags(&body, nil, nil),
+		Tags:     tags,
 		Scope:    scope.Scope{Project: rt.project},
 	})
 	if err != nil {
@@ -52,7 +55,9 @@ func (h *Handler) createInstance(w http.ResponseWriter, r *http.Request, rt rout
 	gcprest.WriteJSON(w, http.StatusOK, op)
 }
 
-// getInstance handles GET .../instances/{i} — Get.
+// getInstance handles GET .../instances/{i} — Get. The instance id is unique
+// per (project, location), so an id that exists in a different location or
+// project is reported as not found here rather than surfacing the wrong resource.
 func (h *Handler) getInstance(w http.ResponseWriter, r *http.Request, rt route) {
 	info, err := h.cache.GetCache(r.Context(), rt.name)
 	if err != nil {
@@ -60,7 +65,20 @@ func (h *Handler) getInstance(w http.ResponseWriter, r *http.Request, rt route) 
 		return
 	}
 
+	if !instanceInScope(info, rt.project, rt.location) {
+		writeInstanceNotFound(w, rt)
+		return
+	}
+
 	gcprest.WriteJSON(w, http.StatusOK, toInstanceJSON(rt.project, rt.location, rt.name, info))
+}
+
+// writeInstanceNotFound reports a location/project-scoped miss with the full
+// resource name, matching real Memorystore's NOT_FOUND for an id that isn't in
+// the addressed location.
+func writeInstanceNotFound(w http.ResponseWriter, rt route) {
+	gcprest.WriteError(w, http.StatusNotFound, "notFound",
+		"instance "+instanceResourceName(rt.project, rt.location, rt.name)+" not found")
 }
 
 // listInstances handles GET .../instances — List, scoped to the request's
@@ -78,10 +96,17 @@ func (h *Handler) listInstances(w http.ResponseWriter, r *http.Request, rt route
 
 	out := make([]instanceJSON, 0, len(infos))
 	for i := range infos {
-		// CacheInfo.Name carries the driver's own resource id; the short
-		// instance id (the map key) is recovered from its trailing segment.
+		// List is per-location: a specific location returns only that region's
+		// instances, while the "-" wildcard aggregates every region (each reported
+		// under its actual location). CacheInfo.Name carries the driver's own
+		// resource id; the short instance id (the map key) is its trailing segment.
+		loc := resolveLocation(rt.location, infos[i].Tags)
+		if rt.location != allLocations && rt.location != loc {
+			continue
+		}
+
 		id := shortInstanceID(infos[i].Name)
-		inst := toInstanceJSON(rt.project, rt.location, id, &infos[i])
+		inst := toInstanceJSON(rt.project, loc, id, &infos[i])
 
 		if matchesFilter(&inst, filter) {
 			out = append(out, inst)
@@ -190,6 +215,11 @@ func (h *Handler) patchInstance(w http.ResponseWriter, r *http.Request, rt route
 		return
 	}
 
+	if !instanceInScope(existing, rt.project, rt.location) {
+		writeInstanceNotFound(w, rt)
+		return
+	}
+
 	var body instanceJSON
 	if !gcprest.DecodeJSON(w, r, &body) {
 		return
@@ -227,6 +257,17 @@ func (h *Handler) patchInstance(w http.ResponseWriter, r *http.Request, rt route
 // deleteInstance handles DELETE .../instances/{i} — Delete. The operation
 // completes inline, so a done=true Operation with an empty response is returned.
 func (h *Handler) deleteInstance(w http.ResponseWriter, r *http.Request, rt route) {
+	existing, err := h.cache.GetCache(r.Context(), rt.name)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	if !instanceInScope(existing, rt.project, rt.location) {
+		writeInstanceNotFound(w, rt)
+		return
+	}
+
 	if err := h.cache.DeleteCache(r.Context(), rt.name); err != nil {
 		gcprest.WriteCErr(w, err)
 		return

--- a/server/gcp/memorystore/types.go
+++ b/server/gcp/memorystore/types.go
@@ -25,6 +25,10 @@ const (
 	// stateReady is Memorystore's terminal instance state; the mock provisions
 	// synchronously so every instance reports READY.
 	stateReady = "READY"
+	// allLocations is the location wildcard: a List parent of
+	// projects/{p}/locations/-/instances aggregates instances across every region
+	// (each reported under its actual location), matching real Memorystore.
+	allLocations = "-"
 )
 
 // instanceJSON mirrors the subset of google.golang.org/api/redis/v1 Instance
@@ -81,6 +85,35 @@ func operationResourceName(project, location, operationID string) string {
 	return "projects/" + project + "/locations/" + location + "/operations/" + operationID
 }
 
+// resolveLocation returns the instance's stored region (the create-time location
+// tag), falling back to the request-path location for instances created before
+// the tag existed (or restored snapshots that predate it).
+func resolveLocation(fallback string, tags map[string]string) string {
+	if v := tags[locationTag]; v != "" {
+		return v
+	}
+
+	return fallback
+}
+
+// instanceInScope reports whether an instance addressed by a project- and
+// location-qualified name actually lives in that project and location. Real
+// Memorystore names are unique per (project, location); the shared cache store is
+// keyed on the bare instance id, so a Get/Patch/Delete for the right id but the
+// wrong location or project must not resolve. A missing tag/scope (legacy or
+// snapshot-restored) is treated as in-scope so old state stays reachable.
+func instanceInScope(info *cachedriver.CacheInfo, project, location string) bool {
+	if loc := info.Tags[locationTag]; loc != "" && loc != location {
+		return false
+	}
+
+	if p := info.Scope.Project; p != "" && p != project {
+		return false
+	}
+
+	return true
+}
+
 // shortInstanceID recovers the driver's map key (the short instance id) from a
 // CacheInfo.Name. The Memorystore driver stamps info.Name as
 // "projects/{p}/instances/{id}" (its own resource id, without a location
@@ -126,6 +159,10 @@ func toInstanceJSON(project, location, instanceID string, info *cachedriver.Cach
 		tier = info.NodeType
 	}
 
+	// The instance's true location is authoritative for the resource name and zone
+	// (the request path may be a wildcard, or a scoping check that has already
+	// passed). Legacy instances without the tag fall back to the request location.
+	location = resolveLocation(location, info.Tags)
 	zone := zoneForLocation(location, info.Tags[locationIDTag])
 
 	inst := instanceJSON{
@@ -291,6 +328,11 @@ const (
 	transitEncryptionTag = "cloudemu:gcpTransitEncryptionMode"
 	replicaCountTag      = "cloudemu:gcpReplicaCount"
 	readReplicasModeTag  = "cloudemu:gcpReadReplicasMode"
+	// locationTag records the region (the path's location segment) the instance was
+	// created in, so Get/List scope by location and reconstruct the resource name
+	// from the instance's true location rather than the request path. Real
+	// Memorystore instance names are unique per (project, location).
+	locationTag = "cloudemu:gcpLocation"
 	// tagTrue is the stored value for a set boolean reserved tag.
 	tagTrue = "true"
 )

--- a/server/gcp/memorystore/types.go
+++ b/server/gcp/memorystore/types.go
@@ -447,13 +447,19 @@ func carryForwardTags(existing map[string]string, mask fieldMask) map[string]str
 
 // applyLabels overlays the request's labels. Merge and replace both overlay;
 // replace additionally dropped the existing labels in carryForwardTags. Preserve
-// applies nothing, leaving the carried-forward labels untouched.
+// applies nothing, leaving the carried-forward labels untouched. Reserved-prefix
+// keys in user labels are ignored so they can never set or overwrite the
+// cloudemu-internal tags (e.g. the location tag that scopes the instance).
 func applyLabels(out map[string]string, body *instanceJSON, mask fieldMask) {
 	if mask.mapMode("labels") == mapModePreserve {
 		return
 	}
 
 	for k, v := range body.Labels {
+		if strings.HasPrefix(k, reservedPrefix) { // don't let user labels overwrite reserved tags
+			continue
+		}
+
 		out[k] = v
 	}
 }


### PR DESCRIPTION
## Summary

Real-user e2e audit of GCP Memorystore for Redis (`redis.googleapis.com/v1` `projects.locations.instances`), driven end-to-end with the real `google.golang.org/api/redis/v1` client against `cloudemu serve`.

The instance control plane was already solid — the create/patch/delete LROs complete `done=true` with `state=READY` (no Terraform hang), `host`/`port` are populated, the full resource name is returned, tier/memorySizeGb/redisVersion/redisConfigs/labels round-trip, the PATCH query-param `updateMask` is honored (memory resize + redisConfigs replace, with unmasked fields preserved), defaults (`connectMode=DIRECT_PEERING`, authorizedNetwork, currentLocationId, persistenceIamIdentity) are set, and the GCP error envelope is correct.

One genuine divergence was found and fixed.

## Divergence fixed: location not enforced (drift + phantom resources)

Memorystore instance ids are unique per `(project, location)`, but the handler keyed reads on the bare instance id (the shared cache store's key) and rebuilt the resource name from the **request path** rather than the instance's true location. Result:

- `Get` on an existing id in the **wrong** region returned a phantom instance, its `name` rewritten to the wrong location — instead of `NOT_FOUND`.
- `List(projects/{p}/locations/{region})` returned instances from **every** region, each under a corrupted name — a multi-region user saw all their caches under every region's list, drifting Terraform.
- The `-` (all-locations) wildcard produced names/zones containing a literal `-` (`.../locations/-/instances/x`, `locationId=--a`).

Fix: persist the create-time region in a reserved tag and use it to
- scope `Get`/`Patch`/`Delete` — a mismatched location or project now returns `NOT_FOUND` with the full resource name;
- filter `List` by region, with `-` aggregating all regions, each reported under its **actual** location.

Verified against the official [instances.list](https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances/list) reference (single-region scoping; `-` wildcard aggregates all regions with real per-instance locations).

## Tests

Added `TestSDKLocationScoping` (real redis/v1 SDK): wrong-location Get/Patch/Delete are `NOT_FOUND`, List is region-scoped, and the `-` wildcard returns each instance under its true location. Full lifecycle, ordering, config round-trip, and provider `-race` suites stay green.