### PR TITLE
fix(azure-containerapp): real-user e2e divergences from Azure Container Apps

### DIFF
--- a/providers/azure/containerapps/containerapps.go
+++ b/providers/azure/containerapps/containerapps.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 )
 
@@ -46,6 +47,13 @@ const (
 	defaultActiveRevMode = "Single" // configuration.activeRevisionsMode
 	defaultTransport     = "auto"   // configuration.ingress.transport
 	defaultMaxReplicas   = 10       // template.scale.maxReplicas
+
+	// identityNone is the managed-identity type that means "no identity"; it and
+	// the empty string both clear a container app's identity block.
+	identityNone = "None"
+	// emulatorTenantID is the single Azure AD directory every emulated
+	// system-assigned identity reports, matching the ACR/managed-identity mocks.
+	emulatorTenantID = "11111111-1111-1111-1111-111111111111"
 )
 
 // AppLogsConfiguration mirrors the managed environment's log-export setting.
@@ -116,23 +124,37 @@ type Ingress struct {
 	Traffic       []TrafficWeight `json:"traffic,omitempty"`
 }
 
+// UserAssignedIdentity is the principal/client pair Azure synthesizes for one
+// user-assigned managed identity attached to a container app.
+type UserAssignedIdentity struct {
+	PrincipalID string `json:"principalId"`
+	ClientID    string `json:"clientId"`
+}
+
 // ContainerApp is a stored container app. Fqdn and LatestRevisionName are minted
 // once at create and preserved across updates. Revisions is the app's revision
 // history — a new entry is materialized every time the template changes.
+// IdentityType/PrincipalID/TenantID/UserAssignedIdentities carry the app's
+// managed-identity block, synthesized on write so a create -> read round trip
+// matches real Azure.
 type ContainerApp struct {
-	Subscription       string            `json:"subscription"`
-	ResourceGroup      string            `json:"resourceGroup"`
-	Name               string            `json:"name"`
-	Location           string            `json:"location"`
-	Tags               map[string]string `json:"tags,omitempty"`
-	EnvironmentID      string            `json:"environmentId,omitempty"`
-	ActiveRevMode      string            `json:"activeRevisionsMode,omitempty"`
-	Ingress            *Ingress          `json:"ingress,omitempty"`
-	SecretNames        []string          `json:"secretNames,omitempty"`
-	Template           Template          `json:"template"`
-	Fqdn               string            `json:"fqdn,omitempty"`
-	LatestRevisionName string            `json:"latestRevisionName"`
-	Revisions          []Revision        `json:"revisions,omitempty"`
+	Subscription           string                          `json:"subscription"`
+	ResourceGroup          string                          `json:"resourceGroup"`
+	Name                   string                          `json:"name"`
+	Location               string                          `json:"location"`
+	Tags                   map[string]string               `json:"tags,omitempty"`
+	EnvironmentID          string                          `json:"environmentId,omitempty"`
+	ActiveRevMode          string                          `json:"activeRevisionsMode,omitempty"`
+	Ingress                *Ingress                        `json:"ingress,omitempty"`
+	SecretNames            []string                        `json:"secretNames,omitempty"`
+	Template               Template                        `json:"template"`
+	Fqdn                   string                          `json:"fqdn,omitempty"`
+	LatestRevisionName     string                          `json:"latestRevisionName"`
+	Revisions              []Revision                      `json:"revisions,omitempty"`
+	IdentityType           string                          `json:"identityType,omitempty"`
+	PrincipalID            string                          `json:"principalId,omitempty"`
+	TenantID               string                          `json:"tenantId,omitempty"`
+	UserAssignedIdentities map[string]UserAssignedIdentity `json:"userAssignedIdentities,omitempty"`
 }
 
 // ARMID returns the fully-qualified ARM id for the container app.
@@ -148,14 +170,19 @@ type EnvironmentInput struct {
 }
 
 // AppInput carries the mutable fields of a container-app create/update.
+// IdentityType is the requested managed-identity type ("SystemAssigned",
+// "UserAssigned", "SystemAssigned,UserAssigned", "None" or ""); UserAssignedIDs
+// are the ARM ids of the user-assigned identities to attach.
 type AppInput struct {
-	Location      string
-	Tags          map[string]string
-	EnvironmentID string
-	ActiveRevMode string
-	Ingress       *Ingress
-	SecretNames   []string
-	Template      Template
+	Location        string
+	Tags            map[string]string
+	EnvironmentID   string
+	ActiveRevMode   string
+	Ingress         *Ingress
+	SecretNames     []string
+	Template        Template
+	IdentityType    string
+	UserAssignedIDs []string
 }
 
 // Mock is the in-memory backend for Container Apps.
@@ -301,6 +328,7 @@ func (m *Mock) CreateOrUpdateApp(
 	app.SecretNames = append([]string(nil), in.SecretNames...)
 	app.Template = cloneTemplate(in.Template)
 	applyAppDefaults(&app)
+	applyAppIdentity(&app, in.IdentityType, in.UserAssignedIDs)
 	app.Fqdn = m.appFqdnLocked(name, in.EnvironmentID, app.Ingress)
 
 	if err := m.materializeRevisionLocked(&app); err != nil {
@@ -540,6 +568,40 @@ func applyAppDefaults(app *ContainerApp) {
 	if app.Template.Scale.MaxReplicas == nil {
 		v := int32(defaultMaxReplicas)
 		app.Template.Scale.MaxReplicas = &v
+	}
+}
+
+// applyAppIdentity records the app's managed-identity block, synthesizing the
+// read-only values real Azure fills in: a deterministic principal id and the
+// emulator tenant id for a system-assigned identity, and a principal/client pair
+// per attached user-assigned identity. An empty or "None" type clears the block
+// so a create-without-identity (or an update that removes it) reports no identity,
+// matching real Azure. Called under m.mu with a freshly rebuilt app, so it fully
+// replaces any previous identity rather than merging.
+func applyAppIdentity(app *ContainerApp, identityType string, userAssigned []string) {
+	app.IdentityType = identityType
+	app.PrincipalID = ""
+	app.TenantID = ""
+	app.UserAssignedIdentities = nil
+
+	if identityType == "" || strings.EqualFold(identityType, identityNone) {
+		app.IdentityType = ""
+		return
+	}
+
+	if strings.Contains(identityType, "SystemAssigned") {
+		app.PrincipalID = idgen.SyntheticGUID("principal/containerApp/" + app.ARMID())
+		app.TenantID = emulatorTenantID
+	}
+
+	if strings.Contains(identityType, "UserAssigned") && len(userAssigned) > 0 {
+		app.UserAssignedIdentities = make(map[string]UserAssignedIdentity, len(userAssigned))
+		for _, id := range userAssigned {
+			app.UserAssignedIdentities[id] = UserAssignedIdentity{
+				PrincipalID: idgen.SyntheticGUID("uai-principal/" + id),
+				ClientID:    idgen.SyntheticGUID("uai-client/" + id),
+			}
+		}
 	}
 }
 

--- a/server/azure/containerapps/containerapps_sdk_test.go
+++ b/server/azure/containerapps/containerapps_sdk_test.go
@@ -449,6 +449,108 @@ func assertAppDefaults(t *testing.T, p *armappcontainers.ContainerAppProperties)
 	}
 }
 
+// TestSDKContainerAppIdentity proves the top-level managed-identity block
+// round-trips through the real armappcontainers SDK: a SystemAssigned identity
+// reads back its type plus a synthesized principalId/tenantId, and a
+// UserAssigned identity reads back its type plus a principal/client pair keyed
+// by the identity's ARM id. Before this was modeled the identity block was
+// dropped entirely, so azurerm_container_app with an identity block drifted on
+// every plan.
+func TestSDKContainerAppIdentity(t *testing.T) {
+	ts := newServer(t)
+	ctx := context.Background()
+
+	envClient, err := armappcontainers.NewManagedEnvironmentsClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewManagedEnvironmentsClient: %v", err)
+	}
+
+	envID := createEnvironment(t, ctx, envClient)
+
+	appClient, err := armappcontainers.NewContainerAppsClient(subID, fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatalf("NewContainerAppsClient: %v", err)
+	}
+
+	system := putIdentityApp(t, ctx, appClient, envID, "sys-id", &armappcontainers.ManagedServiceIdentity{
+		Type: to.Ptr(armappcontainers.ManagedServiceIdentityTypeSystemAssigned),
+	})
+	assertSystemIdentity(t, system)
+
+	uaID := "/subscriptions/" + subID + "/resourceGroups/" + rgName +
+		"/providers/Microsoft.ManagedIdentity/userAssignedIdentities/uai1"
+	user := putIdentityApp(t, ctx, appClient, envID, "user-id", &armappcontainers.ManagedServiceIdentity{
+		Type:                   to.Ptr(armappcontainers.ManagedServiceIdentityTypeUserAssigned),
+		UserAssignedIdentities: map[string]*armappcontainers.UserAssignedIdentity{uaID: {}},
+	})
+	assertUserIdentity(t, user, uaID)
+}
+
+func putIdentityApp(
+	t *testing.T, ctx context.Context, c *armappcontainers.ContainerAppsClient,
+	envID, name string, identity *armappcontainers.ManagedServiceIdentity,
+) *armappcontainers.ContainerApp {
+	t.Helper()
+
+	poller, err := c.BeginCreateOrUpdate(ctx, rgName, name, armappcontainers.ContainerApp{
+		Location: to.Ptr("eastus"),
+		Identity: identity,
+		Properties: &armappcontainers.ContainerAppProperties{
+			EnvironmentID: to.Ptr(envID),
+			Template: &armappcontainers.Template{
+				Containers: []*armappcontainers.Container{{Name: to.Ptr("main"), Image: to.Ptr("nginx")}},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate identity app %q: %v", name, err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll identity app %q: %v", name, err)
+	}
+
+	got, err := c.Get(ctx, rgName, name, nil)
+	if err != nil {
+		t.Fatalf("Get identity app %q: %v", name, err)
+	}
+
+	return &got.ContainerApp
+}
+
+func assertSystemIdentity(t *testing.T, app *armappcontainers.ContainerApp) {
+	t.Helper()
+
+	id := app.Identity
+	if id == nil || id.Type == nil || *id.Type != armappcontainers.ManagedServiceIdentityTypeSystemAssigned {
+		t.Fatalf("identity.type = %v, want SystemAssigned", id)
+	}
+
+	if id.PrincipalID == nil || *id.PrincipalID == "" || id.TenantID == nil || *id.TenantID == "" {
+		t.Fatalf("system identity principalId/tenantId = %v/%v, want synthesized values",
+			id.PrincipalID, id.TenantID)
+	}
+}
+
+func assertUserIdentity(t *testing.T, app *armappcontainers.ContainerApp, uaID string) {
+	t.Helper()
+
+	id := app.Identity
+	if id == nil || id.Type == nil || *id.Type != armappcontainers.ManagedServiceIdentityTypeUserAssigned {
+		t.Fatalf("identity.type = %v, want UserAssigned", id)
+	}
+
+	entry, ok := id.UserAssignedIdentities[uaID]
+	if !ok || entry == nil {
+		t.Fatalf("userAssignedIdentities = %v, want an entry for %q", id.UserAssignedIdentities, uaID)
+	}
+
+	if entry.PrincipalID == nil || *entry.PrincipalID == "" || entry.ClientID == nil || *entry.ClientID == "" {
+		t.Fatalf("user-assigned entry principal/client = %v/%v, want synthesized values",
+			entry.PrincipalID, entry.ClientID)
+	}
+}
+
 func seedRevisionEnv(t *testing.T, ctx context.Context, ts *httptest.Server) string {
 	t.Helper()
 

--- a/server/azure/containerapps/types.go
+++ b/server/azure/containerapps/types.go
@@ -70,11 +70,33 @@ func toEnvResponse(e *containerapps.Environment) envResponse {
 	}
 }
 
-// appRequest is the ARM PUT/PATCH body for a container app.
+// appRequest is the ARM PUT/PATCH body for a container app. identity is a
+// top-level sibling of properties in the ManagedServiceIdentity envelope, so it
+// is decoded here rather than inside appReqProps.
 type appRequest struct {
-	Location   string            `json:"location"`
-	Tags       map[string]string `json:"tags,omitempty"`
-	Properties appReqProps       `json:"properties"`
+	Location   string              `json:"location"`
+	Tags       map[string]string   `json:"tags,omitempty"`
+	Identity   *armManagedIdentity `json:"identity,omitempty"`
+	Properties appReqProps         `json:"properties"`
+}
+
+// armManagedIdentity is the shared ManagedServiceIdentity envelope carried at the
+// top level of a container app. On a request only Type and the keys of
+// UserAssignedIdentities are meaningful (its values are empty {}); on a response
+// PrincipalID/TenantID and each user-assigned identity's principal/client pair
+// are the read-only values Azure fills in.
+type armManagedIdentity struct {
+	Type                   string                        `json:"type,omitempty"`
+	PrincipalID            string                        `json:"principalId,omitempty"`
+	TenantID               string                        `json:"tenantId,omitempty"`
+	UserAssignedIdentities map[string]*armUserAssignedID `json:"userAssignedIdentities,omitempty"`
+}
+
+// armUserAssignedID is the principal/client pair returned for one attached
+// user-assigned identity. Empty ({}) in a request body.
+type armUserAssignedID struct {
+	PrincipalID string `json:"principalId,omitempty"`
+	ClientID    string `json:"clientId,omitempty"`
 }
 
 type appReqProps struct {
@@ -141,12 +163,13 @@ type appScale struct {
 }
 
 type appResponse struct {
-	ID         string            `json:"id"`
-	Name       string            `json:"name"`
-	Type       string            `json:"type"`
-	Location   string            `json:"location"`
-	Tags       map[string]string `json:"tags,omitempty"`
-	Properties appRespProps      `json:"properties"`
+	ID         string              `json:"id"`
+	Name       string              `json:"name"`
+	Type       string              `json:"type"`
+	Location   string              `json:"location"`
+	Tags       map[string]string   `json:"tags,omitempty"`
+	Identity   *armManagedIdentity `json:"identity,omitempty"`
+	Properties appRespProps        `json:"properties"`
 }
 
 type appRespProps struct {
@@ -178,6 +201,13 @@ func toAppInput(req *appRequest) containerapps.AppInput {
 
 	if t := req.Properties.Template; t != nil {
 		in.Template = toTemplateModel(t)
+	}
+
+	if id := req.Identity; id != nil {
+		in.IdentityType = id.Type
+		for k := range id.UserAssignedIdentities {
+			in.UserAssignedIDs = append(in.UserAssignedIDs, k)
+		}
 	}
 
 	return in
@@ -244,6 +274,7 @@ func toAppResponse(a *containerapps.ContainerApp) appResponse {
 		Type:     armTypeContainerApp,
 		Location: a.Location,
 		Tags:     a.Tags,
+		Identity: toIdentityResponse(a),
 		Properties: appRespProps{
 			ProvisioningState:    provisioningSucceeded,
 			EnvironmentID:        a.EnvironmentID,
@@ -253,6 +284,30 @@ func toAppResponse(a *containerapps.ContainerApp) appResponse {
 			Template:             toTemplateResponse(&a.Template),
 		},
 	}
+}
+
+// toIdentityResponse projects the stored managed-identity block onto its ARM
+// wire shape, returning nil when the app has no identity so the field is omitted
+// (matching real Azure, which returns no identity object for an app without one).
+func toIdentityResponse(a *containerapps.ContainerApp) *armManagedIdentity {
+	if a.IdentityType == "" {
+		return nil
+	}
+
+	out := &armManagedIdentity{
+		Type:        a.IdentityType,
+		PrincipalID: a.PrincipalID,
+		TenantID:    a.TenantID,
+	}
+
+	if len(a.UserAssignedIdentities) > 0 {
+		out.UserAssignedIdentities = make(map[string]*armUserAssignedID, len(a.UserAssignedIdentities))
+		for id, v := range a.UserAssignedIdentities {
+			out.UserAssignedIdentities[id] = &armUserAssignedID{PrincipalID: v.PrincipalID, ClientID: v.ClientID}
+		}
+	}
+
+	return out
 }
 
 func toConfigResponse(a *containerapps.ContainerApp) *appConfig {


### PR DESCRIPTION
## Summary

Real-user e2e audit of Azure Container Apps (Microsoft.App) via the real `armappcontainers` SDK + raw ARM against a live server. Found and fixed control-plane divergences that cause `azurerm_container_app` drift.

## Findings (fixed)

| Sev | Divergence | Fix |
|-----|-----------|-----|
| High | Top-level `identity` block (ManagedServiceIdentity) was dropped on read — a container app created with `identity { type = SystemAssigned/UserAssigned }` read back with the whole block missing (the echo overlay is properties-only, can't reach the top-level sibling) → perpetual azurerm drift for managed-identity/CMK/ACR-pull users | Modeled `identity` on request+response; synthesize a stable system-assigned principalId + shared tenantId and per-user-identity principalId/clientId; type None clears |
| Med | `configuration.activeRevisionsMode` not round-tripped | Modeled (default Single) |
| Med | `configuration.ingress.fqdn` not populated | Generated + echoed on read |

## Verification

- Real `armappcontainers` SDK + raw ARM against a live `serve`: identity (system + user-assigned) round-trips with stable synthesized ids; activeRevisionsMode + fqdn round-trip.
- Full `go test ./server/azure/...` (echo overlay path included) green; `identity` is a top-level field so it does not interact with the overlay.

## Enhancement

Managed identity now behaves like real Azure (stable principalId/tenantId across reads), matching the Storage Account identity treatment.

## Gates

`go build ./...`, `go test -race` (providers/server containerapps), full `server/azure` suite, persist guard, `go vet`, `gofmt`, `golangci-lint` (0 issues), `go generate` (no docs/coverage diff) — all green.