### PR TITLE
fix(kms): real-user e2e divergences from AWS KMS

### DIFF
--- a/providers/aws/kms/management.go
+++ b/providers/aws/kms/management.go
@@ -169,6 +169,14 @@ func (m *Mock) EnableKeyRotation(_ context.Context, keyID string, rotationPeriod
 			return driver.ErrUnsupportedOperation
 		}
 
+		// A rotatable (symmetric, AWS_KMS-origin) key still must be in a usable
+		// state: a disabled key reports DisabledException and a pending-deletion
+		// key reports KMSInvalidStateException, matching real KMS's key-state
+		// table. Real KMS silently no-ops none of these — it rejects them.
+		if err := requireUsable(kd); err != nil {
+			return err
+		}
+
 		kd.rotationEnabled = true
 		kd.rotationPeriodDays = days
 
@@ -179,6 +187,14 @@ func (m *Mock) EnableKeyRotation(_ context.Context, keyID string, rotationPeriod
 // DisableKeyRotation turns off automatic rotation.
 func (m *Mock) DisableKeyRotation(_ context.Context, keyID string) error {
 	return m.mutateKey(keyID, func(kd *keyData) error {
+		if kd.meta.KeySpec != driver.SpecSymmetricDefault || kd.meta.Origin == driver.OriginExternal {
+			return driver.ErrUnsupportedOperation
+		}
+
+		if err := requireUsable(kd); err != nil {
+			return err
+		}
+
 		kd.rotationEnabled = false
 
 		return nil
@@ -232,6 +248,10 @@ func (m *Mock) RotateKeyOnDemand(_ context.Context, keyID string) error {
 	return m.mutateKey(keyID, func(kd *keyData) error {
 		if kd.meta.KeySpec != driver.SpecSymmetricDefault || kd.meta.Origin == driver.OriginExternal {
 			return driver.ErrUnsupportedOperation
+		}
+
+		if err := requireUsable(kd); err != nil {
+			return err
 		}
 
 		mat, err := generateMaterial(kd.meta.KeySpec)

--- a/server/aws/kms/review_fixes_sdk_test.go
+++ b/server/aws/kms/review_fixes_sdk_test.go
@@ -265,3 +265,72 @@ func TestSDKMultiRegionKeyIDHasMRKPrefix(t *testing.T) {
 		t.Fatalf("DescribeKey KeyId = %q, want %q", aws.ToString(desc.KeyMetadata.KeyId), keyID)
 	}
 }
+
+// e2e audit: rotation operations must honor the key state. Real KMS rejects
+// EnableKeyRotation/DisableKeyRotation/RotateKeyOnDemand on a disabled key with
+// DisabledException (per the key-state table) rather than silently succeeding.
+func TestSDKRotationOnDisabledKeyRejected(t *testing.T) {
+	ctx := context.Background()
+	c := newKMSClient(t)
+
+	key, err := c.CreateKey(ctx, &awskms.CreateKeyInput{})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	keyID := key.KeyMetadata.KeyId
+	if _, err := c.DisableKey(ctx, &awskms.DisableKeyInput{KeyId: keyID}); err != nil {
+		t.Fatalf("DisableKey: %v", err)
+	}
+
+	assertDisabled := func(op string, err error) {
+		t.Helper()
+
+		if err == nil {
+			t.Fatalf("%s on a disabled key should fail", op)
+		}
+
+		var disabled *kmstypes.DisabledException
+		if !errors.As(err, &disabled) {
+			t.Fatalf("%s: want DisabledException, got %v", op, err)
+		}
+	}
+
+	_, err = c.EnableKeyRotation(ctx, &awskms.EnableKeyRotationInput{KeyId: keyID})
+	assertDisabled("EnableKeyRotation", err)
+
+	_, err = c.DisableKeyRotation(ctx, &awskms.DisableKeyRotationInput{KeyId: keyID})
+	assertDisabled("DisableKeyRotation", err)
+
+	_, err = c.RotateKeyOnDemand(ctx, &awskms.RotateKeyOnDemandInput{KeyId: keyID})
+	assertDisabled("RotateKeyOnDemand", err)
+}
+
+// e2e audit: EnableKeyRotation on a key that is pending deletion must reject
+// with KMSInvalidStateException, matching real KMS's key-state table.
+func TestSDKRotationOnPendingDeletionKeyRejected(t *testing.T) {
+	ctx := context.Background()
+	c := newKMSClient(t)
+
+	key, err := c.CreateKey(ctx, &awskms.CreateKeyInput{})
+	if err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+
+	keyID := key.KeyMetadata.KeyId
+	if _, err := c.ScheduleKeyDeletion(ctx, &awskms.ScheduleKeyDeletionInput{
+		KeyId: keyID, PendingWindowInDays: aws.Int32(7),
+	}); err != nil {
+		t.Fatalf("ScheduleKeyDeletion: %v", err)
+	}
+
+	_, err = c.EnableKeyRotation(ctx, &awskms.EnableKeyRotationInput{KeyId: keyID})
+	if err == nil {
+		t.Fatal("EnableKeyRotation on a pending-deletion key should fail")
+	}
+
+	var invalidState *kmstypes.KMSInvalidStateException
+	if !errors.As(err, &invalidState) {
+		t.Fatalf("want KMSInvalidStateException, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Real-user e2e audit of AWS KMS (aws_kms_key + aws_kms_alias, key policy, rotation, tags) against `cloudemu serve`, exercised with aws-cli, aws-sdk-go-v2, and Terraform (hashicorp/aws ~>5). The common path is solid — full Terraform lifecycle (create → plan no-drift → update → plan no-drift → destroy) is clean, and KeyMetadata defaults, the default key policy JSON, rotation status, aliases, tags, and crypto round-trips all match real KMS.

One genuine divergence found and fixed.

## Bug

`EnableKeyRotation`, `DisableKeyRotation`, and `RotateKeyOnDemand` did not honor key state. On a **disabled** key they silently succeeded (HTTP 200 / empty body), and on a **pending-deletion** key they silently succeeded, instead of erroring.

Real KMS rejects these operations by key state:
- Disabled key → `DisabledException`
- PendingDeletion / PendingImport → `KMSInvalidStateException`

Per `API_EnableKeyRotation` (DisabledException = "the specified KMS key is not enabled"; KMSInvalidStateException = "the state of the specified resource is not valid") and the developer-guide key-state table rows for EnableKeyRotation/DisableKeyRotation/RotateKeyOnDemand. `GetKeyRotationStatus` (a read) succeeds in those states and is left unguarded, matching AWS.

## Fix

Applies the existing `requireUsable(kd)` state guard (already used by the crypto ops) to the three rotation mutators, ordered **after** the spec/origin `UnsupportedOperationException` check so that asymmetric/HMAC/EXTERNAL keys still report UnsupportedOperationException (including PendingImport external keys).

Regression tests added: `TestSDKRotationOnDisabledKeyRejected`, `TestSDKRotationOnPendingDeletionKeyRejected`.

## Verification

- Live via aws-cli against `cloudemu serve`: RED before (empty success), GREEN after (DisabledException / KMSInvalidStateException).
- `go build ./...`, `go vet`, `gofmt -l`, `go test -race ./providers/aws/kms/... ./server/aws/kms/...`, root `go test .`, `golangci-lint` (new-from-rev + full changed packages) — all green.
- `go generate ./...` — no docs/coverage diff (no interface change).
- Terraform no-drift re-verified with the fixed binary.
