### PR TITLE
fix(efs): real-user e2e divergences from AWS EFS

### DIFF
--- a/providers/aws/efs/mount_targets.go
+++ b/providers/aws/efs/mount_targets.go
@@ -224,10 +224,13 @@ func (m *Mock) allocateIP(explicit, subnetID string, subnet *netdriver.SubnetInf
 }
 
 // nextIP hands out a globally-unique fallback address (10.0.x.y) when no subnet
-// CIDR is available to allocate an in-range address from.
+// CIDR is available to allocate an in-range address from. The counter is offset
+// by mtFirstHost so the first address is 10.0.0.4, never the 10.0.0.0 network
+// address (nor the reserved low hosts) — real EFS/EC2 never assigns those to a
+// mount target.
 func (m *Mock) nextIP() string {
 	m.ipMu.Lock()
-	n := m.ipCounters[""]
+	n := m.ipCounters[""] + mtFirstHost
 	m.ipCounters[""]++
 	m.ipMu.Unlock()
 


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of AWS EFS (`aws_efs_file_system`, `aws_efs_mount_target`, `aws_efs_access_point`) against the real `aws-sdk-go-v2`/`aws` CLI and Terraform, run against a live `cloudemu serve` endpoint.

The EFS surface is already broad and high-fidelity (27 ops, per-resource typed exceptions, LifeCycleState=available on create, correct defaults, tag/backup/lifecycle round-trips, ClientToken/CreationToken idempotency). The full create → describe → Terraform no-drift → update → destroy lifecycle is clean with no hangs and no drift.

## What was fixed

One genuine, reachable divergence: when a mount target's subnet cannot be resolved (a common SDK/serve path where the caller passes a `subnet-id` that was never created in the emulator), the synthetic fallback IP allocator returned `10.0.0.0` as its first address — a network/reserved address that real EFS/EC2 never assigns to a mount target. The counter is now offset by `mtFirstHost`, so fallback addresses start at `10.0.0.4`, matching the in-subnet allocation path and staying unique.

## Evidence

- CLI + Terraform full lifecycle green: create reaches `available`, `terraform plan` reports **No changes** (no drift) before and after an in-place throughput update, `terraform destroy` clean.
- Error-code fidelity verified live: `FileSystemNotFound`, `MountTargetNotFound`, `AccessPointNotFound`, `FileSystemAlreadyExists`.
- Fallback IP after fix: `10.0.0.4`, `10.0.0.5` (was `10.0.0.0`).

## Gates

`go build ./...`, `go vet`, `gofmt -l`, `go test -race ./providers/aws/efs/ ./server/aws/efs/`, and `golangci-lint` on the changed package all green. `go generate` produces no docs diff (no interface change).