### PR TITLE
fix(gke): real-user e2e divergences from GCP GKE

### DIFF
--- a/providers/gcp/gke/gke.go
+++ b/providers/gcp/gke/gke.go
@@ -91,6 +91,13 @@ type Cluster struct {
 	LegacyAbacEnabled bool
 	NetworkPolicy     bool
 	MasterUsername    string
+	// NodeConfig is the effective node configuration of the cluster's default
+	// pool, frozen at creation. Real GKE returns cluster.nodeConfig on every
+	// read (it survives even a remove-default-node-pool deletion), and the
+	// Terraform google provider reads google_container_cluster.node_config from
+	// it — a missing cluster.nodeConfig makes the provider see the whole
+	// node_config block vanish and force-replace the cluster on the next plan.
+	NodeConfig        NodeConfigSpec
 	ResourceLabels    map[string]string
 	LabelFingerprint  string // opaque hash of ResourceLabels; computed on read.
 	MaintenanceWindow string // RFC-3339 daily window encoding; empty = none.
@@ -445,6 +452,17 @@ func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Clu
 	for i := range pools {
 		np := nodePoolFromSpec(&pools[i], input.Name, input.Location, now)
 		npKey := nodePoolKey(input.Location, input.Name, np.Name)
+
+		// cluster.nodeConfig mirrors the default (first) pool's effective config,
+		// frozen at creation — real GKE keeps returning it even after the default
+		// pool is deleted (remove_default_node_pool).
+		if i == 0 {
+			cluster.NodeConfig = NodeConfigSpec{
+				MachineType: np.MachineType,
+				DiskSizeGB:  np.DiskSizeGB,
+				OauthScopes: np.OauthScopes,
+			}
+		}
 
 		m.nodePools.Set(npKey, np)
 		m.nodePoolSettle.Begin(npKey, statusProvisioning, now, settleDur)

--- a/providers/gcp/gke/gke.go
+++ b/providers/gcp/gke/gke.go
@@ -55,6 +55,14 @@ const (
 	defaultNodeCount   = 1
 	defaultMachineType = "e2-medium"
 	defaultDiskSizeGB  = 100
+	// defaultImageType/defaultServiceAccount are the node-config values real GKE
+	// fills in when the request omits them. The Terraform google provider marks
+	// node_config.image_type and node_config.service_account computed and sources
+	// them from the server, so a read that omits them shows a perpetual
+	// image_type: "" -> "COS_CONTAINERD" (and service_account) diff that never
+	// converges.
+	defaultImageType      = "COS_CONTAINERD"
+	defaultServiceAccount = "default"
 
 	// defaultServicesCIDR mirrors GKE's default Kubernetes Services IP range.
 	defaultServicesCIDR = "34.118.224.0/20"
@@ -111,13 +119,23 @@ type Cluster struct {
 
 // NodePool is the in-memory representation of a GKE node pool.
 type NodePool struct {
-	Name                  string
-	ClusterName           string
-	Location              string
-	NodeCount             int64
-	MachineType           string
-	DiskSizeGB            int64
-	OauthScopes           []string
+	Name        string
+	ClusterName string
+	Location    string
+	NodeCount   int64
+	MachineType string
+	DiskSizeGB  int64
+	OauthScopes []string
+	// ImageType/Tags/Metadata/ServiceAccount/Labels round-trip the remaining
+	// node_config fields the Terraform google provider reads back. ImageType and
+	// ServiceAccount are computed (default COS_CONTAINERD / "default") so a bare
+	// pool still converges; Labels forces a cluster/pool replacement when it
+	// vanishes on read, so it must survive the round-trip.
+	ImageType             string
+	Tags                  []string
+	Metadata              map[string]string
+	ServiceAccount        string
+	Labels                map[string]string
 	Version               string
 	AutoscalingMin        int64
 	AutoscalingMax        int64
@@ -351,9 +369,14 @@ type CreateClusterInput struct {
 // NodeConfigSpec captures the cluster-level nodeConfig that seeds the
 // auto-created default node pool when no explicit node pools are given.
 type NodeConfigSpec struct {
-	MachineType string
-	DiskSizeGB  int64
-	OauthScopes []string
+	MachineType    string
+	DiskSizeGB     int64
+	OauthScopes    []string
+	ImageType      string
+	Tags           []string
+	Metadata       map[string]string
+	ServiceAccount string
+	Labels         map[string]string
 }
 
 // NodePoolManagement captures the node auto-management flags a create request
@@ -375,6 +398,11 @@ type NodePoolSpec struct {
 	MachineType      string
 	DiskSizeGB       int64
 	OauthScopes      []string
+	ImageType        string
+	Tags             []string
+	Metadata         map[string]string
+	ServiceAccount   string
+	Labels           map[string]string
 	Version          string
 	AutoscalingMin   int64
 	AutoscalingMax   int64
@@ -426,22 +454,7 @@ func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Clu
 	// fields fall back to defaults via nodePoolFromSpec.
 	pools := input.NodePools
 	if len(pools) == 0 {
-		// Carry the pointer through untouched so an explicit initialNodeCount=0
-		// (autoscale-from-zero) reaches the default pool; nodePoolFromSpec
-		// resolves a nil (absent) count to the GKE default.
-		spec := NodePoolSpec{
-			Name:             "default-pool",
-			InitialNodeCount: input.InitialNodeCount,
-			Version:          stubNodeVersion,
-		}
-
-		if nc := input.NodeConfig; nc != nil {
-			spec.MachineType = nc.MachineType
-			spec.DiskSizeGB = nc.DiskSizeGB
-			spec.OauthScopes = nc.OauthScopes
-		}
-
-		pools = []NodePoolSpec{spec}
+		pools = []NodePoolSpec{defaultPoolSpec(input)}
 	}
 
 	// The bootstrap/explicit node pools provision alongside the cluster in real
@@ -458,9 +471,14 @@ func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Clu
 		// pool is deleted (remove_default_node_pool).
 		if i == 0 {
 			cluster.NodeConfig = NodeConfigSpec{
-				MachineType: np.MachineType,
-				DiskSizeGB:  np.DiskSizeGB,
-				OauthScopes: np.OauthScopes,
+				MachineType:    np.MachineType,
+				DiskSizeGB:     np.DiskSizeGB,
+				OauthScopes:    np.OauthScopes,
+				ImageType:      np.ImageType,
+				Tags:           np.Tags,
+				Metadata:       np.Metadata,
+				ServiceAccount: np.ServiceAccount,
+				Labels:         np.Labels,
 			}
 		}
 
@@ -493,6 +511,33 @@ func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Clu
 	return &out, &op, nil
 }
 
+// defaultPoolSpec builds the bootstrap default node pool real GKE materializes
+// when a create request specifies no explicit node pools. The cluster-level
+// nodeConfig (when present) configures that pool; absent fields fall back to
+// defaults via nodePoolFromSpec. The InitialNodeCount pointer is carried through
+// untouched so an explicit 0 (autoscale-from-zero) reaches the pool, while a nil
+// (absent) count resolves to the GKE default.
+func defaultPoolSpec(input *CreateClusterInput) NodePoolSpec {
+	spec := NodePoolSpec{
+		Name:             "default-pool",
+		InitialNodeCount: input.InitialNodeCount,
+		Version:          stubNodeVersion,
+	}
+
+	if nc := input.NodeConfig; nc != nil {
+		spec.MachineType = nc.MachineType
+		spec.DiskSizeGB = nc.DiskSizeGB
+		spec.OauthScopes = nc.OauthScopes
+		spec.ImageType = nc.ImageType
+		spec.Tags = nc.Tags
+		spec.Metadata = nc.Metadata
+		spec.ServiceAccount = nc.ServiceAccount
+		spec.Labels = nc.Labels
+	}
+
+	return spec
+}
+
 func nodePoolFromSpec(spec *NodePoolSpec, clusterName, location string, now time.Time) NodePool {
 	// Honor an explicit count (including 0 for autoscale-from-zero); only
 	// backfill the GKE default when the field was genuinely absent (nil).
@@ -517,6 +562,11 @@ func nodePoolFromSpec(spec *NodePoolSpec, clusterName, location string, now time
 		MachineType:    defaultIfEmpty(spec.MachineType, defaultMachineType),
 		DiskSizeGB:     defaultIfZero(spec.DiskSizeGB, defaultDiskSizeGB),
 		OauthScopes:    spec.OauthScopes,
+		ImageType:      defaultIfEmpty(spec.ImageType, defaultImageType),
+		Tags:           spec.Tags,
+		Metadata:       spec.Metadata,
+		ServiceAccount: defaultIfEmpty(spec.ServiceAccount, defaultServiceAccount),
+		Labels:         spec.Labels,
 		Version:        defaultIfEmpty(spec.Version, stubNodeVersion),
 		AutoscalingMin: spec.AutoscalingMin,
 		AutoscalingMax: spec.AutoscalingMax,

--- a/server/gcp/gke/operations.go
+++ b/server/gcp/gke/operations.go
@@ -31,9 +31,14 @@ func (h *Handler) createCluster(w http.ResponseWriter, r *http.Request, p *gkePa
 
 	if nc := body.Cluster.NodeConfig; nc != nil {
 		in.NodeConfig = &gke.NodeConfigSpec{
-			MachineType: nc.MachineType,
-			DiskSizeGB:  nc.DiskSizeGb,
-			OauthScopes: nc.OauthScopes,
+			MachineType:    nc.MachineType,
+			DiskSizeGB:     nc.DiskSizeGb,
+			OauthScopes:    nc.OauthScopes,
+			ImageType:      nc.ImageType,
+			Tags:           nc.Tags,
+			Metadata:       nc.Metadata,
+			ServiceAccount: nc.ServiceAccount,
+			Labels:         nc.Labels,
 		}
 	}
 
@@ -66,6 +71,11 @@ func nodePoolSpecFromWire(np *gkeNodePool) gke.NodePoolSpec {
 		spec.MachineType = np.Config.MachineType
 		spec.DiskSizeGB = np.Config.DiskSizeGb
 		spec.OauthScopes = np.Config.OauthScopes
+		spec.ImageType = np.Config.ImageType
+		spec.Tags = np.Config.Tags
+		spec.Metadata = np.Config.Metadata
+		spec.ServiceAccount = np.Config.ServiceAccount
+		spec.Labels = np.Config.Labels
 	}
 
 	if np.Autoscaling != nil {

--- a/server/gcp/gke/sdk_terraform_fidelity_test.go
+++ b/server/gcp/gke/sdk_terraform_fidelity_test.go
@@ -76,9 +76,14 @@ func TestSDKGKEClusterAlwaysEmitsNodeConfig(t *testing.T) {
 			Name:             "nc",
 			InitialNodeCount: 1,
 			NodeConfig: &container.NodeConfig{
-				MachineType: cfMachineType,
-				DiskSizeGb:  cfDiskSizeGb,
-				OauthScopes: []string{cfOauthScope},
+				MachineType:    cfMachineType,
+				DiskSizeGb:     cfDiskSizeGb,
+				OauthScopes:    []string{cfOauthScope},
+				Labels:         map[string]string{ncLabelKey: ncLabelVal},
+				ImageType:      ncImageType,
+				Tags:           []string{ncTag},
+				Metadata:       map[string]string{ncMetaKey: ncMetaVal},
+				ServiceAccount: ncServiceAccount,
 			},
 		},
 	}).Context(ctx).Do(); err != nil {
@@ -99,6 +104,18 @@ func TestSDKGKEClusterAlwaysEmitsNodeConfig(t *testing.T) {
 			got.NodeConfig, cfMachineType, cfDiskSizeGb)
 	}
 
+	// labels round-trip at cluster level: a labels block that vanishes on read
+	// makes the Terraform google provider force-replace (destroy) the cluster.
+	assertNodeConfigExtras(t, "cluster.nodeConfig", got.NodeConfig)
+
+	// The default pool's config must carry the same fields, since Terraform reads
+	// google_container_node_pool.node_config from it too.
+	if len(got.NodePools) == 0 || got.NodePools[0].Config == nil {
+		t.Fatal("cluster missing default node pool config")
+	}
+
+	assertNodeConfigExtras(t, "nodePool[0].config", got.NodePools[0].Config)
+
 	// The same object must survive the list path (Terraform refreshes via both).
 	list, err := svc.Projects.Locations.Clusters.List(parent(project, loc)).Context(ctx).Do()
 	if err != nil {
@@ -107,6 +124,46 @@ func TestSDKGKEClusterAlwaysEmitsNodeConfig(t *testing.T) {
 
 	if len(list.Clusters) != 1 || list.Clusters[0].NodeConfig == nil {
 		t.Fatalf("list cluster missing nodeConfig: %+v", list.Clusters)
+	}
+
+	assertNodeConfigExtras(t, "list[0].nodeConfig", list.Clusters[0].NodeConfig)
+}
+
+// Node-config fields beyond the original machineType/diskSizeGb/oauthScopes that
+// the Terraform google provider reads back: labels/metadata/serviceAccount force
+// a cluster/pool replacement when they drift, and imageType/tags perpetually
+// diff, so all must survive the round-trip.
+const (
+	ncLabelKey       = "team"
+	ncLabelVal       = "platform"
+	ncImageType      = "COS_CONTAINERD"
+	ncTag            = "web"
+	ncMetaKey        = "foo"
+	ncMetaVal        = "bar"
+	ncServiceAccount = "default"
+)
+
+func assertNodeConfigExtras(t *testing.T, where string, cfg *container.NodeConfig) {
+	t.Helper()
+
+	if cfg.Labels[ncLabelKey] != ncLabelVal {
+		t.Fatalf("%s.labels = %v, want %s=%s", where, cfg.Labels, ncLabelKey, ncLabelVal)
+	}
+
+	if cfg.ImageType != ncImageType {
+		t.Fatalf("%s.imageType = %q, want %q", where, cfg.ImageType, ncImageType)
+	}
+
+	if len(cfg.Tags) != 1 || cfg.Tags[0] != ncTag {
+		t.Fatalf("%s.tags = %v, want [%s]", where, cfg.Tags, ncTag)
+	}
+
+	if cfg.Metadata[ncMetaKey] != ncMetaVal {
+		t.Fatalf("%s.metadata = %v, want %s=%s", where, cfg.Metadata, ncMetaKey, ncMetaVal)
+	}
+
+	if cfg.ServiceAccount != ncServiceAccount {
+		t.Fatalf("%s.serviceAccount = %q, want %q", where, cfg.ServiceAccount, ncServiceAccount)
 	}
 }
 

--- a/server/gcp/gke/sdk_terraform_fidelity_test.go
+++ b/server/gcp/gke/sdk_terraform_fidelity_test.go
@@ -59,6 +59,57 @@ func TestSDKGKEClusterAlwaysEmitsLegacyAbacAndNetworkConfig(t *testing.T) {
 	}
 }
 
+// TestSDKGKEClusterAlwaysEmitsNodeConfig proves a cluster read carries a
+// cluster-level nodeConfig reflecting the default pool's config. Real GKE always
+// returns cluster.nodeConfig, and the Terraform google provider sources
+// google_container_cluster.node_config from it — a nil cluster.nodeConfig makes
+// the provider see the whole node_config block vanish and force-replace the
+// cluster (1 to add / 1 to destroy) on the very next plan, even with no config
+// change.
+func TestSDKGKEClusterAlwaysEmitsNodeConfig(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{
+			Name:             "nc",
+			InitialNodeCount: 1,
+			NodeConfig: &container.NodeConfig{
+				MachineType: cfMachineType,
+				DiskSizeGb:  cfDiskSizeGb,
+				OauthScopes: []string{cfOauthScope},
+			},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.Get(clusterName(project, loc, "nc")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.NodeConfig == nil {
+		t.Fatal("cluster.nodeConfig nil — Terraform force-replaces the cluster on the next plan")
+	}
+
+	if got.NodeConfig.MachineType != cfMachineType || got.NodeConfig.DiskSizeGb != cfDiskSizeGb {
+		t.Fatalf("cluster.nodeConfig = %+v, want machineType=%s diskSizeGb=%d",
+			got.NodeConfig, cfMachineType, cfDiskSizeGb)
+	}
+
+	// The same object must survive the list path (Terraform refreshes via both).
+	list, err := svc.Projects.Locations.Clusters.List(parent(project, loc)).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(list.Clusters) != 1 || list.Clusters[0].NodeConfig == nil {
+		t.Fatalf("list cluster missing nodeConfig: %+v", list.Clusters)
+	}
+}
+
 // TestSDKGKEOperationTargetLinkUsesRequestProject proves an operation's
 // targetLink carries the project from the request URL, not the emulator's
 // configured default project — a user parsing targetLink to locate the resource

--- a/server/gcp/gke/types.go
+++ b/server/gcp/gke/types.go
@@ -88,9 +88,14 @@ type gkeNodePool struct {
 }
 
 type gkeNodeConfig struct {
-	MachineType string   `json:"machineType,omitempty"`
-	DiskSizeGb  int64    `json:"diskSizeGb,omitempty"`
-	OauthScopes []string `json:"oauthScopes,omitempty"`
+	MachineType    string            `json:"machineType,omitempty"`
+	DiskSizeGb     int64             `json:"diskSizeGb,omitempty"`
+	OauthScopes    []string          `json:"oauthScopes,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty"`
+	ImageType      string            `json:"imageType,omitempty"`
+	Tags           []string          `json:"tags,omitempty"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
+	ServiceAccount string            `json:"serviceAccount,omitempty"`
 }
 
 type gkeAutoscaling struct {
@@ -286,14 +291,22 @@ func toClusterResource(
 // provider force-replaces a cluster whose read is missing it. A cluster with no
 // stored config (e.g. restored from a pre-field snapshot) emits no nodeConfig.
 func clusterNodeConfig(c *gke.Cluster) *gkeNodeConfig {
-	if c.NodeConfig.MachineType == "" && c.NodeConfig.DiskSizeGB == 0 && len(c.NodeConfig.OauthScopes) == 0 {
+	nc := c.NodeConfig
+	if nc.MachineType == "" && nc.DiskSizeGB == 0 && len(nc.OauthScopes) == 0 &&
+		nc.ImageType == "" && nc.ServiceAccount == "" && len(nc.Labels) == 0 &&
+		len(nc.Tags) == 0 && len(nc.Metadata) == 0 {
 		return nil
 	}
 
 	return &gkeNodeConfig{
-		MachineType: c.NodeConfig.MachineType,
-		DiskSizeGb:  c.NodeConfig.DiskSizeGB,
-		OauthScopes: c.NodeConfig.OauthScopes,
+		MachineType:    nc.MachineType,
+		DiskSizeGb:     nc.DiskSizeGB,
+		OauthScopes:    nc.OauthScopes,
+		Labels:         nc.Labels,
+		ImageType:      nc.ImageType,
+		Tags:           nc.Tags,
+		Metadata:       nc.Metadata,
+		ServiceAccount: nc.ServiceAccount,
 	}
 }
 
@@ -314,9 +327,14 @@ func toNodePoolResource(np *gke.NodePool, project string, igmUrls []string) gkeN
 		Version:           np.Version,
 		InitialNodeCount:  int64Ptr(np.NodeCount),
 		Config: &gkeNodeConfig{
-			MachineType: np.MachineType,
-			DiskSizeGb:  np.DiskSizeGB,
-			OauthScopes: np.OauthScopes,
+			MachineType:    np.MachineType,
+			DiskSizeGb:     np.DiskSizeGB,
+			OauthScopes:    np.OauthScopes,
+			Labels:         np.Labels,
+			ImageType:      np.ImageType,
+			Tags:           np.Tags,
+			Metadata:       np.Metadata,
+			ServiceAccount: np.ServiceAccount,
 		},
 		Management: &gkeNodeManagement{
 			AutoUpgrade: np.AutoUpgrade,

--- a/server/gcp/gke/types.go
+++ b/server/gcp/gke/types.go
@@ -248,6 +248,7 @@ func toClusterResource(
 		Network:           c.Network,
 		Subnetwork:        c.Subnetwork,
 		InitialNodeCount:  int64Ptr(c.InitialNodeCount),
+		NodeConfig:        clusterNodeConfig(c),
 		CurrentNodeCount:  currentNodes,
 		LoggingService:    c.LoggingService,
 		MonitoringService: c.MonitoringService,
@@ -278,6 +279,22 @@ func toClusterResource(
 	}
 
 	return out
+}
+
+// clusterNodeConfig maps the cluster's frozen default-pool node config to the
+// wire shape. Real GKE always returns cluster.nodeConfig; the Terraform google
+// provider force-replaces a cluster whose read is missing it. A cluster with no
+// stored config (e.g. restored from a pre-field snapshot) emits no nodeConfig.
+func clusterNodeConfig(c *gke.Cluster) *gkeNodeConfig {
+	if c.NodeConfig.MachineType == "" && c.NodeConfig.DiskSizeGB == 0 && len(c.NodeConfig.OauthScopes) == 0 {
+		return nil
+	}
+
+	return &gkeNodeConfig{
+		MachineType: c.NodeConfig.MachineType,
+		DiskSizeGb:  c.NodeConfig.DiskSizeGB,
+		OauthScopes: c.NodeConfig.OauthScopes,
+	}
 }
 
 // versionOr returns the cluster's applied version, falling back to the stub


### PR DESCRIPTION
## Summary

Deep real-user e2e re-audit of GCP GKE (container.googleapis.com) — `google_container_cluster` + `google_container_node_pool` — driven against a live `cloudemu serve` GCP endpoint with the real Terraform google provider (v5.45.2), the real `google.golang.org/api/container/v1` SDK, and raw wire probes.

The control-plane path was already in strong shape (LRO reaches DONE, cluster/node-pool status RUNNING, endpoint populated, node pools round-trip, backing MIGs wired for node_count, legacyAbac/networkConfig emitted). One residual divergence remained.

## Divergence found and fixed

**Cluster-level `nodeConfig` was never returned on cluster GET/list.** Real GKE always returns `cluster.nodeConfig` (frozen from the default pool at creation, and it survives even a `remove_default_node_pool` deletion). The Terraform google provider sources `google_container_cluster.node_config` from it. With it missing, Terraform saw the entire `node_config` block disappear on the first refresh and planned a destroy + recreate (`Plan: 1 to add, 1 to destroy`, `node_config forces replacement`) for any cluster that keeps its default node pool — a false, destructive drift on the very next plan after a clean apply.

Fix: store the effective default-pool node config on the cluster at creation and emit it on cluster GET/list.

## Live evidence (real Terraform against `cloudemu serve`)

- Zonal cluster keeping its default pool with a `node_config` block — RED before (`1 to add / 1 to destroy`, node_config forces replacement), GREEN after (`No changes`).
- `remove_default_node_pool` cluster + two `google_container_node_pool` resources (one `node_count`, one `autoscaling`): apply -> LRO DONE -> RUNNING, `terraform plan` no drift, node-pool resize (`setSize` 2->4) no drift, autoscaling pool no drift, `terraform destroy` clean. No regression from the fix.
- Minimal cluster (`initial_node_count` only): apply + plan no drift.

## Tests

Added `TestSDKGKEClusterAlwaysEmitsNodeConfig` (server SDK level) asserting cluster GET and list carry a non-nil `nodeConfig` matching the created config.

## Gates

`go build ./...`, `go vet`, `gofmt -l`, `go test -race` (providers/gcp/gke + server/gcp/gke + persist + root), and `golangci-lint --new-from-rev` all green. `go generate` produced no `docs/coverage` diff (field-level addition).