### PR TITLE
fix(secretsmanager): real-user e2e divergences from AWS Secrets Manager

### DIFF
--- a/providers/aws/secretsmanager/secretsmanager.go
+++ b/providers/aws/secretsmanager/secretsmanager.go
@@ -191,29 +191,20 @@ func (m *Mock) CreateSecret(ctx context.Context, cfg driver.SecretConfig, value 
 		KMSKeyID:    cfg.KMSKeyID,
 	}
 
-	stored, err := m.encrypt(ctx, cfg.KMSKeyID, value)
-	if err != nil {
-		return nil, err
-	}
+	sd := &secretData{info: info, stages: map[string]string{}}
 
-	// AWS uses the ClientRequestToken as the version id (a UUID); absent one, it
-	// generates a UUID itself.
-	versionID := cfg.ClientRequestToken
-	if versionID == "" {
-		versionID = idgen.UUID()
-	}
-
-	version := driver.SecretVersion{
-		VersionID: versionID,
-		Value:     stored,
-		CreatedAt: now,
-		Current:   true,
-	}
-
-	sd := &secretData{
-		info:     info,
-		versions: []driver.SecretVersion{version},
-		stages:   map[string]string{stageCurrent: versionID},
+	// SecretString/SecretBinary are optional on CreateSecret. Real Secrets Manager
+	// creates an initial version (carrying AWSCURRENT) only when a value is
+	// supplied; a metadata-only secret has no versions until PutSecretValue adds
+	// one. This matters for the common Terraform pattern, where
+	// aws_secretsmanager_secret creates the secret with no value and a separate
+	// aws_secretsmanager_secret_version adds the first version — creating a phantom
+	// empty version here would demote that first real version's predecessor to a
+	// spurious AWSPREVIOUS.
+	if value != nil {
+		if err := m.seedInitialVersion(ctx, sd, cfg, value, now); err != nil {
+			return nil, err
+		}
 	}
 
 	m.secrets.Set(cfg.Name, sd)
@@ -221,6 +212,36 @@ func (m *Mock) CreateSecret(ctx context.Context, cfg driver.SecretConfig, value 
 	result := info
 
 	return &result, nil
+}
+
+// seedInitialVersion appends the CreateSecret initial version to a freshly built
+// secret and gives it the AWSCURRENT label. The version id is the caller's
+// ClientRequestToken when set (AWS reuses it as the version id), else a fresh
+// UUID.
+//
+//nolint:gocritic // hugeParam: cfg matches the CreateSecret call site.
+func (m *Mock) seedInitialVersion(
+	ctx context.Context, sd *secretData, cfg driver.SecretConfig, value []byte, now string,
+) error {
+	stored, err := m.encrypt(ctx, cfg.KMSKeyID, value)
+	if err != nil {
+		return err
+	}
+
+	versionID := cfg.ClientRequestToken
+	if versionID == "" {
+		versionID = idgen.UUID()
+	}
+
+	sd.versions = []driver.SecretVersion{{
+		VersionID: versionID,
+		Value:     stored,
+		CreatedAt: now,
+		Current:   true,
+	}}
+	sd.stages[stageCurrent] = versionID
+
+	return nil
 }
 
 // createSecretConflict handles CreateSecret when a secret already exists under

--- a/providers/aws/secretsmanager/secretsmanager_test.go
+++ b/providers/aws/secretsmanager/secretsmanager_test.go
@@ -75,6 +75,33 @@ func TestCreateSecret(t *testing.T) {
 	}
 }
 
+func TestCreateSecretWithoutValueHasNoVersion(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	// CreateSecret with neither SecretString nor SecretBinary is metadata-only:
+	// real Secrets Manager creates no initial version, so there is nothing to
+	// read and no AWSCURRENT until PutSecretValue adds a version.
+	_, err := m.CreateSecret(ctx, driver.SecretConfig{Name: "meta-only"}, nil)
+	require.NoError(t, err)
+
+	versions, err := m.ListSecretVersions(ctx, "meta-only")
+	require.NoError(t, err)
+	assert.Empty(t, versions)
+
+	_, err = m.GetSecretValue(ctx, "meta-only", "")
+	require.Error(t, err)
+
+	// The first PutSecretValue becomes AWSCURRENT with no AWSPREVIOUS: a phantom
+	// initial version would have wrongly become the previous.
+	first, err := m.PutSecretValue(ctx, "meta-only", []byte("v1"))
+	require.NoError(t, err)
+
+	stages, err := m.SecretVersionStages(ctx, "meta-only")
+	require.NoError(t, err)
+	assert.Equal(t, map[string][]string{first.VersionID: {stageCurrent}}, stages)
+}
+
 func TestCreateSecretValidatesKMSKey(t *testing.T) {
 	ctx := context.Background()
 	m := newTestMock()

--- a/server/aws/secretsmanager/lifecycle_test.go
+++ b/server/aws/secretsmanager/lifecycle_test.go
@@ -80,6 +80,52 @@ func TestSDKDescribeSecretVersionStages(t *testing.T) {
 	}
 }
 
+// TestSDKMetadataOnlyCreateThenVersion guards the common Terraform pattern:
+// aws_secretsmanager_secret creates the secret with no value, then
+// aws_secretsmanager_secret_version adds the first version. Real Secrets Manager
+// creates no initial version when SecretString/SecretBinary are absent, so the
+// first PutSecretValue must be the sole AWSCURRENT with no phantom AWSPREVIOUS.
+func TestSDKMetadataOnlyCreateThenVersion(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{Name: aws.String("meta")})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	if aws.ToString(created.VersionId) != "" {
+		t.Fatalf("CreateSecret with no value returned VersionId %q, want empty", aws.ToString(created.VersionId))
+	}
+
+	// Reading before any version exists is ResourceNotFoundException.
+	_, err = client.GetSecretValue(ctx, &awssm.GetSecretValueInput{SecretId: aws.String("meta")})
+	var notFound *smtypes.ResourceNotFoundException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("GetSecretValue before first version = %v, want ResourceNotFoundException", err)
+	}
+
+	put, err := client.PutSecretValue(ctx, &awssm.PutSecretValueInput{
+		SecretId: aws.String("meta"), SecretString: aws.String("v1"),
+	})
+	if err != nil {
+		t.Fatalf("PutSecretValue: %v", err)
+	}
+
+	desc, err := client.DescribeSecret(ctx, &awssm.DescribeSecretInput{SecretId: aws.String("meta")})
+	if err != nil {
+		t.Fatalf("DescribeSecret: %v", err)
+	}
+
+	if len(desc.VersionIdsToStages) != 1 {
+		t.Fatalf("VersionIdsToStages = %+v, want exactly 1 entry (no phantom AWSPREVIOUS)", desc.VersionIdsToStages)
+	}
+
+	if got := desc.VersionIdsToStages[aws.ToString(put.VersionId)]; len(got) != 1 || got[0] != "AWSCURRENT" {
+		t.Fatalf("first version stages = %v, want [AWSCURRENT]", got)
+	}
+}
+
 // TestSDKGetSecretValueByStage guards VersionStage=AWSPREVIOUS returning the
 // superseded value rather than the current one.
 func TestSDKGetSecretValueByStage(t *testing.T) {


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of AWS Secrets Manager (SDK v2 + aws-cli + Terraform against a live `cloudemu serve`). One genuine cloud-vs-cloudemu divergence found and fixed; the rest of the surface (create/describe/get/put/version-staging/delete-recovery/restore/rotation/policy/tags/filters) round-trips correctly.

## Divergence fixed: phantom version on value-less CreateSecret

Per the AWS CreateSecret API reference: *"If you include `SecretString` or `SecretBinary` then Secrets Manager creates an initial secret version and automatically attaches the staging label `AWSCURRENT` to it."* Both fields are optional; with neither, the secret is created with **no version**.

The mock created an empty `AWSCURRENT` version unconditionally. This corrupts the state produced by the most common Terraform pattern:

- `aws_secretsmanager_secret` calls CreateSecret with no value → mock made a phantom empty version.
- `aws_secretsmanager_secret_version` then calls PutSecretValue → the real first version demoted the phantom to a spurious `AWSPREVIOUS`.

Observed before the fix: `describe-secret` reported two versions and `get-secret-value --version-stage AWSPREVIOUS` returned an empty phantom instead of `ResourceNotFoundException`.

After the fix, a value-less CreateSecret creates no version (response omits `VersionId`), the first PutSecretValue is the sole `AWSCURRENT`, and reads before any version return `ResourceNotFoundException` — matching real Secrets Manager.

## Verification

- Live `cloudemu serve` + aws-cli: full lifecycle, version staging (Put moves AWSCURRENT, demotes to AWSPREVIOUS), binary secrets, rotation configure/cancel, UpdateSecretVersionStage rotation-finish, resource policy, tags/filters, delete-recovery/restore/force-delete.
- Terraform `aws_secretsmanager_secret` + `aws_secretsmanager_secret_version`: apply succeeds and `plan` reports no drift; secret now carries exactly one version.
- New regression tests at provider and SDK-wire levels.
- Gates: `go build ./...`, `go test -race` (provider + server), root + portable + persist tests, `go vet`, `gofmt`, `golangci-lint` (0 issues), `go generate` (no docs/coverage change).