### PR TITLE
fix(azure-disk): real-user e2e divergences from Azure Managed Disk

### DIFF
--- a/server/azure/disks/creationdata_test.go
+++ b/server/azure/disks/creationdata_test.go
@@ -202,6 +202,48 @@ func TestDiskCreateOrUpdateCrossRGIsolation(t *testing.T) {
 	}
 }
 
+// TestDiskZoneRoundTrip verifies a zonal disk's top-level zones array survives
+// create → get → list. zones is a top-level Disk field (not a property), so the
+// properties-only echo overlay does not preserve it; without the handler's own
+// round-trip azurerm_managed_disk's `zone` would drift every plan.
+func TestDiskZoneRoundTrip(t *testing.T) {
+	ts := newDisksServer(t)
+
+	putResp := putDisk(t, ts, "rg-1", "disk-zonal", `{
+		"location":"eastus",
+		"sku":{"name":"Premium_LRS"},
+		"zones":["2"],
+		"properties":{"creationData":{"createOption":"Empty"},"diskSizeGB":64}
+	}`)
+
+	assertSingleZone(t, "create", putResp, "2")
+	assertSingleZone(t, "get", getDisk(t, ts, "rg-1", "disk-zonal"), "2")
+
+	// A regional (non-zonal) disk must omit zones entirely, not report an empty
+	// or phantom zone.
+	putDisk(t, ts, "rg-1", "disk-regional", `{
+		"location":"eastus","sku":{"name":"Premium_LRS"},
+		"properties":{"creationData":{"createOption":"Empty"},"diskSizeGB":64}
+	}`)
+
+	if z, present := getDisk(t, ts, "rg-1", "disk-regional")["zones"]; present {
+		t.Errorf("regional disk reported zones=%v, want field omitted", z)
+	}
+}
+
+func assertSingleZone(t *testing.T, stage string, body map[string]any, want string) {
+	t.Helper()
+
+	zones, ok := body["zones"].([]any)
+	if !ok || len(zones) != 1 {
+		t.Fatalf("%s: zones=%v want single-element [%q]", stage, body["zones"], want)
+	}
+
+	if zones[0] != want {
+		t.Errorf("%s: zones[0]=%v want %q", stage, zones[0], want)
+	}
+}
+
 // TestDiskListResourceGroupScope verifies list does not leak other RGs' disks.
 func TestDiskListResourceGroupScope(t *testing.T) {
 	ts := newDisksServer(t)

--- a/server/azure/disks/handler.go
+++ b/server/azure/disks/handler.go
@@ -254,13 +254,14 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 	}
 
 	cfg := computedriver.VolumeConfig{
-		Size:       size,
-		VolumeType: skuName(req.SKU),
-		IOPS:       req.Properties.DiskIOPSReadWrite,
-		Throughput: req.Properties.DiskMBpsReadWrite,
-		Tier:       diskTier(req.Properties.Tier, skuTier(req.SKU)),
-		Location:   req.Location,
-		Tags:       mergeDiskTags(req.Tags, rp.ResourceName, rp.ResourceGroup, createOption, sourceID),
+		Size:             size,
+		VolumeType:       skuName(req.SKU),
+		IOPS:             req.Properties.DiskIOPSReadWrite,
+		Throughput:       req.Properties.DiskMBpsReadWrite,
+		Tier:             diskTier(req.Properties.Tier, skuTier(req.SKU)),
+		Location:         req.Location,
+		AvailabilityZone: firstZone(req.Zones),
+		Tags:             mergeDiskTags(req.Tags, rp.ResourceName, rp.ResourceGroup, createOption, sourceID),
 	}
 
 	// ARM CreateOrUpdate is idempotent: an existing disk is updated in place —
@@ -502,6 +503,7 @@ func (h *Handler) toDiskResponse(
 		Name:      name,
 		Type:      providerName + "/" + resourceType,
 		Location:  location,
+		Zones:     zonesFor(vol.AvailabilityZone),
 		SKU:       sku,
 		ManagedBy: h.managedByID(ctx, rp.Subscription, vol.AttachedTo),
 		Tags:      stripInternalDiskTags(vol.Tags),
@@ -573,6 +575,27 @@ func diskStateFor(state string) string {
 	}
 
 	return diskStateUnattached
+}
+
+// firstZone returns the single availability zone a zonal disk requests, or ""
+// when the request is regional. Azure managed disks are pinned to at most one
+// zone, so only the first entry is meaningful.
+func firstZone(zones []string) string {
+	if len(zones) == 0 {
+		return ""
+	}
+
+	return zones[0]
+}
+
+// zonesFor renders the top-level zones array for a disk: a single-element list
+// for a zonal disk, or nil (omitted) for a regional one.
+func zonesFor(zone string) []string {
+	if zone == "" {
+		return nil
+	}
+
+	return []string{zone}
 }
 
 func skuName(s *diskSKU) string {

--- a/server/azure/disks/types.go
+++ b/server/azure/disks/types.go
@@ -5,8 +5,13 @@ package disks
 // fields our mock exercises.
 
 type diskRequest struct {
-	Location   string            `json:"location"`
-	SKU        *diskSKU          `json:"sku,omitempty"`
+	Location string   `json:"location"`
+	SKU      *diskSKU `json:"sku,omitempty"`
+	// Zones is the (single-element) availability-zone list a zonal managed disk
+	// is pinned to. Like location it is a TOP-LEVEL Disk field, not a property,
+	// so the properties-only echo overlay never preserves it — the handler must
+	// round-trip it explicitly or azurerm_managed_disk's zone drifts every plan.
+	Zones      []string          `json:"zones,omitempty"`
 	Tags       map[string]string `json:"tags,omitempty"`
 	Properties diskRequestProps  `json:"properties"`
 }
@@ -36,6 +41,9 @@ type diskResponse struct {
 	Type     string   `json:"type"`
 	Location string   `json:"location"`
 	SKU      *diskSKU `json:"sku,omitempty"`
+	// Zones echoes the disk's availability zone (a top-level Disk field). Empty
+	// for a regional (non-zonal) disk; a zonal disk carries a single entry.
+	Zones []string `json:"zones,omitempty"`
 	// ManagedBy is the ARM resource ID of the VM the disk is attached to
 	// (armcompute.Disk.ManagedBy is a top-level, read-only field — not under
 	// properties). Empty when the disk is unattached.


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of Azure Managed Disk (`Microsoft.Compute/disks`) via the ARM wire server. Found and fixed a genuine `azurerm_managed_disk` drift: the disks handler dropped the disk's availability **zone**.

## Divergence

`zones` is a **top-level** Disk field (like `location`), not a property under `properties`. The disks handler never parsed it from the create request and never rendered it on GET/List. Because the server's echo overlay only preserves *unmodeled properties* (`properties.*`), a top-level field like `zones` was silently discarded.

Effect on real users: a zonal `azurerm_managed_disk` (`zone = "2"`) applied cleanly, but the next `terraform plan` saw `zone` change from `"2"` back to empty — perpetual drift on every plan.

The backing driver already round-trips `VolumeConfig.AvailabilityZone` / `VolumeInfo.AvailabilityZone`; only the wire handler was missing the mapping.

## Fix

- Parse the top-level `zones` array from the create request into `VolumeConfig.AvailabilityZone` (first element — Azure managed disks are pinned to at most one zone).
- Render `zones` back on the create/GET/List response, omitted entirely for a regional disk.

## Evidence

Live wire (`cloudemu serve`, raw ARM):
- PUT zonal disk -> 202 + `Azure-AsyncOperation`, body `"zones":["2"]`, `provisioningState:Succeeded`; async poll -> `Succeeded`.
- GET -> `"zones":["2"]` preserved.
- Regional disk -> `zones` field omitted (no phantom zone).

New test `TestDiskZoneRoundTrip` covers zonal round-trip + regional omission.

## Gates
- `go build ./...`
- `go test -race ./server/azure/... ./providers/azure/virtualmachines/...` green (incl. echo overlay tests)
- `go vet`, `gofmt -l`, `golangci-lint` (0 issues)
- `go generate` -> no `docs/coverage` diff (driver interfaces unchanged)