### PR TITLE
fix(cloudwatch): real-user e2e divergences from AWS CloudWatch

### DIFF
--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -753,57 +753,80 @@ func (m *Mock) SetAlarmActionsEnabled(_ context.Context, names []string, enabled
 	return nil
 }
 
-// AddAlarmTags merges tags onto the named alarm, backing TagResource.
-func (m *Mock) AddAlarmTags(_ context.Context, alarmName string, tags map[string]string) error {
-	a, ok := m.alarms.Get(alarmName)
-	if !ok {
-		return errors.Newf(errors.NotFound, "alarm %q not found", alarmName)
+// alarmTagsOf resolves an alarm name to its tag map. Metric and composite
+// alarms share the same ARN shape (arn:...:alarm:NAME), so a TagResource /
+// ListTagsForResource call carries no hint of which store holds the alarm; this
+// looks in both, matching real CloudWatch where one tagging API serves both
+// alarm types. When ensure is true a nil map is initialized in place (through
+// the store's struct pointer) so the returned map is safe to write to.
+func (m *Mock) alarmTagsOf(name string, ensure bool) (map[string]string, bool) {
+	if a, ok := m.alarms.Get(name); ok {
+		if a.Tags == nil && ensure {
+			a.Tags = map[string]string{}
+		}
+
+		return a.Tags, true
 	}
 
+	if c, ok := m.compositeAlarms.Get(name); ok {
+		if c.Tags == nil && ensure {
+			c.Tags = map[string]string{}
+		}
+
+		return c.Tags, true
+	}
+
+	return nil, false
+}
+
+// AddAlarmTags merges tags onto the named alarm (metric or composite), backing
+// TagResource.
+func (m *Mock) AddAlarmTags(_ context.Context, alarmName string, tags map[string]string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if a.Tags == nil {
-		a.Tags = make(map[string]string, len(tags))
+	target, ok := m.alarmTagsOf(alarmName, true)
+	if !ok {
+		return errors.Newf(errors.NotFound, "alarm %q not found", alarmName)
 	}
 
 	for k, v := range tags {
-		a.Tags[k] = v
+		target[k] = v
 	}
 
 	return nil
 }
 
-// RemoveAlarmTags deletes the given tag keys from the named alarm, backing
-// UntagResource.
+// RemoveAlarmTags deletes the given tag keys from the named alarm (metric or
+// composite), backing UntagResource.
 func (m *Mock) RemoveAlarmTags(_ context.Context, alarmName string, keys []string) error {
-	a, ok := m.alarms.Get(alarmName)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	target, ok := m.alarmTagsOf(alarmName, false)
 	if !ok {
 		return errors.Newf(errors.NotFound, "alarm %q not found", alarmName)
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	for _, k := range keys {
-		delete(a.Tags, k)
+		delete(target, k)
 	}
 
 	return nil
 }
 
-// AlarmTags returns a copy of the named alarm's tags, backing
-// ListTagsForResource.
+// AlarmTags returns a copy of the named alarm's tags (metric or composite),
+// backing ListTagsForResource.
 func (m *Mock) AlarmTags(_ context.Context, alarmName string) (map[string]string, error) {
-	a, ok := m.alarms.Get(alarmName)
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	target, ok := m.alarmTagsOf(alarmName, false)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "alarm %q not found", alarmName)
 	}
 
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	return copyDims(a.Tags), nil
+	return copyDims(target), nil
 }
 
 func toAlarmInfo(a *alarmData) driver.AlarmInfo {

--- a/server/aws/cloudwatch/handler.go
+++ b/server/aws/cloudwatch/handler.go
@@ -57,6 +57,8 @@ const (
 	opTagResource          = "TagResource"
 	opUntagResource        = "UntagResource"
 	opListTagsForResource  = "ListTagsForResource"
+	opEnableAlarmActions   = "EnableAlarmActions"
+	opDisableAlarmActions  = "DisableAlarmActions"
 )
 
 // Handler serves CloudWatch rpc-v2-cbor requests against a monitoring driver.
@@ -164,9 +166,9 @@ func (h *Handler) dispatch(w http.ResponseWriter, r *http.Request, op string, bo
 		h.startMetricStreams(w, r, body)
 	case opStopMetricStreams:
 		h.stopMetricStreams(w, r, body)
-	case "EnableAlarmActions":
+	case opEnableAlarmActions:
 		h.setAlarmActionsEnabled(w, r, body, true)
-	case "DisableAlarmActions":
+	case opDisableAlarmActions:
 		h.setAlarmActionsEnabled(w, r, body, false)
 	case opTagResource:
 		h.tagResource(w, r, body)

--- a/server/aws/cloudwatch/query.go
+++ b/server/aws/cloudwatch/query.go
@@ -59,12 +59,18 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request) {
 		h.queryGetMetricStatistics(w, r)
 	case opPutMetricAlarm:
 		h.queryPutMetricAlarm(w, r)
+	case opPutCompositeAlarm:
+		h.queryPutCompositeAlarm(w, r)
 	case opDescribeAlarms:
 		h.queryDescribeAlarms(w, r)
 	case opDeleteAlarms:
 		h.queryDeleteAlarms(w, r)
 	case opSetAlarmState:
 		h.querySetAlarmState(w, r)
+	case opEnableAlarmActions:
+		h.querySetAlarmActionsEnabled(w, r, true)
+	case opDisableAlarmActions:
+		h.querySetAlarmActionsEnabled(w, r, false)
 	case opDescribeAlarmHistory:
 		h.queryDescribeAlarmHistory(w, r)
 	case opPutDashboard:
@@ -433,16 +439,78 @@ func toCompositeAlarmMemberXMLs(rows []compositeAlarmCBR) []compositeAlarmMember
 }
 
 func (h *Handler) queryDeleteAlarms(w http.ResponseWriter, r *http.Request) {
+	names := queryStringList(r, "AlarmNames.member.")
+
 	// AWS tolerates incorrect alarm names: valid ones are still deleted and no
 	// ResourceNotFound is returned.
-	for _, name := range queryStringList(r, "AlarmNames.member.") {
+	for _, name := range names {
 		if err := h.monitoring.DeleteAlarm(r.Context(), name); err != nil && !cerrors.IsNotFound(err) {
 			writeQueryDriverErr(w, err)
 			return
 		}
 	}
 
+	// DeleteAlarms accepts both metric and composite alarm names in one call; a
+	// name that isn't a metric alarm (tolerated above) may be a composite alarm.
+	if store, ok := h.monitoring.(compositeAlarmStore); ok {
+		if err := store.DeleteCompositeAlarms(r.Context(), names); err != nil {
+			writeQueryDriverErr(w, err)
+			return
+		}
+	}
+
 	writeQueryResponse(w, "DeleteAlarmsResponse", nil)
+}
+
+// queryPutCompositeAlarm is the query-protocol twin of putCompositeAlarm,
+// backing `aws cloudwatch put-composite-alarm` and the Terraform
+// aws_cloudwatch_composite_alarm resource (both speak the query protocol).
+func (h *Handler) queryPutCompositeAlarm(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.monitoring.(compositeAlarmStore)
+	if !ok {
+		writeQueryError(w, http.StatusBadRequest, "InvalidAction", "composite alarms not supported")
+		return
+	}
+
+	err := store.PutCompositeAlarm(r.Context(), mondriver.CompositeAlarmConfig{
+		Name:                    r.Form.Get("AlarmName"),
+		AlarmRule:               r.Form.Get("AlarmRule"),
+		AlarmDescription:        r.Form.Get("AlarmDescription"),
+		ActionsEnabled:          queryOptBool(r, "ActionsEnabled"),
+		AlarmActions:            queryStringList(r, "AlarmActions.member."),
+		OKActions:               queryStringList(r, "OKActions.member."),
+		InsufficientDataActions: queryStringList(r, "InsufficientDataActions.member."),
+		Tags:                    queryTagPairs(r, "Tags.member."),
+	})
+	if err != nil {
+		writeQueryDriverErr(w, err)
+		return
+	}
+
+	writeQueryResponse(w, "PutCompositeAlarmResponse", nil)
+}
+
+// querySetAlarmActionsEnabled is the query-protocol twin of
+// setAlarmActionsEnabled, backing `aws cloudwatch enable-alarm-actions` /
+// `disable-alarm-actions`.
+func (h *Handler) querySetAlarmActionsEnabled(w http.ResponseWriter, r *http.Request, enabled bool) {
+	toggler, ok := h.monitoring.(alarmActionsToggler)
+	if !ok {
+		writeQueryError(w, http.StatusBadRequest, "InvalidAction", "alarm actions toggle not supported")
+		return
+	}
+
+	if err := toggler.SetAlarmActionsEnabled(r.Context(), queryStringList(r, "AlarmNames.member."), enabled); err != nil {
+		writeQueryDriverErr(w, err)
+		return
+	}
+
+	root := "EnableAlarmActionsResponse"
+	if !enabled {
+		root = "DisableAlarmActionsResponse"
+	}
+
+	writeQueryResponse(w, root, nil)
 }
 
 func (h *Handler) querySetAlarmState(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/cloudwatch/query_composite_alarm_test.go
+++ b/server/aws/cloudwatch/query_composite_alarm_test.go
@@ -1,0 +1,134 @@
+package cloudwatch_test
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestQueryCompositeAlarmLifecycle exercises the composite-alarm operations over
+// the query protocol (the path `aws cloudwatch put-composite-alarm` and the
+// Terraform aws_cloudwatch_composite_alarm resource use): PutCompositeAlarm →
+// DescribeAlarms surfaces it in CompositeAlarms → DeleteAlarms removes it. These
+// were previously missing from the query dispatch, breaking the resource end to
+// end.
+func TestQueryCompositeAlarmLifecycle(t *testing.T) {
+	post := newQueryPoster(t)
+
+	rule := `ALARM("cpu-high")`
+
+	if code, body := post(url.Values{
+		"Action": {"PutCompositeAlarm"}, "AlarmName": {"app-unhealthy"}, "AlarmRule": {rule},
+		"AlarmDescription": {"app is unhealthy"}, "AlarmActions.member.1": {"arn:aws:sns:us-east-1:000000000000:ops"},
+	}); code != 200 || !strings.Contains(body, "PutCompositeAlarmResponse") {
+		t.Fatalf("PutCompositeAlarm: code=%d body=%s", code, body)
+	}
+
+	code, body := post(url.Values{"Action": {"DescribeAlarms"}, "AlarmTypes.member.1": {"CompositeAlarm"}})
+	if code != 200 {
+		t.Fatalf("DescribeAlarms: code=%d body=%s", code, body)
+	}
+
+	for _, want := range []string{
+		"<CompositeAlarms>", "<AlarmName>app-unhealthy</AlarmName>",
+		"<AlarmRule>ALARM(&#34;cpu-high&#34;)</AlarmRule>",
+		"<StateValue>INSUFFICIENT_DATA</StateValue>",
+		"arn:aws:sns:us-east-1:000000000000:ops",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("DescribeAlarms body missing %q: %s", want, body)
+		}
+	}
+
+	if code, _ := post(url.Values{"Action": {"DeleteAlarms"}, "AlarmNames.member.1": {"app-unhealthy"}}); code != 200 {
+		t.Fatalf("DeleteAlarms: code=%d", code)
+	}
+
+	code, body = post(url.Values{"Action": {"DescribeAlarms"}, "AlarmTypes.member.1": {"CompositeAlarm"}})
+	if code != 200 || strings.Contains(body, "app-unhealthy") {
+		t.Fatalf("composite alarm still present after DeleteAlarms: code=%d body=%s", code, body)
+	}
+}
+
+// TestQueryAlarmTagsRoundTrip confirms TagResource / ListTagsForResource work
+// over the query protocol for both metric and composite alarms, which share the
+// arn:...:alarm:NAME shape. Terraform calls ListTagsForResource on every read,
+// so an unrecognized composite-alarm ARN left the resource unusable.
+func TestQueryAlarmTagsRoundTrip(t *testing.T) {
+	post := newQueryPoster(t)
+
+	cases := []struct {
+		name   string
+		create url.Values
+		arn    string
+	}{
+		{
+			name: "metric",
+			create: url.Values{
+				"Action": {"PutMetricAlarm"}, "AlarmName": {"m1"}, "Namespace": {"MyApp"}, "MetricName": {"Requests"},
+				"ComparisonOperator": {"GreaterThanThreshold"}, "EvaluationPeriods": {"1"}, "Period": {"60"},
+				"Threshold": {"10"}, "Statistic": {"Average"},
+			},
+			arn: "arn:aws:cloudwatch:us-east-1:000000000000:alarm:m1",
+		},
+		{
+			name: "composite",
+			create: url.Values{
+				"Action": {"PutCompositeAlarm"}, "AlarmName": {"c1"}, "AlarmRule": {`ALARM("m1")`},
+			},
+			arn: "arn:aws:cloudwatch:us-east-1:000000000000:alarm:c1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if code, body := post(tc.create); code != 200 {
+				t.Fatalf("create: code=%d body=%s", code, body)
+			}
+
+			if code, body := post(url.Values{
+				"Action": {"TagResource"}, "ResourceARN": {tc.arn},
+				"Tags.member.1.Key": {"Env"}, "Tags.member.1.Value": {"prod"},
+			}); code != 200 {
+				t.Fatalf("TagResource: code=%d body=%s", code, body)
+			}
+
+			code, body := post(url.Values{"Action": {"ListTagsForResource"}, "ResourceARN": {tc.arn}})
+			if code != 200 || !strings.Contains(body, "<Key>Env</Key>") || !strings.Contains(body, "<Value>prod</Value>") {
+				t.Fatalf("ListTagsForResource: code=%d body=%s", code, body)
+			}
+		})
+	}
+}
+
+// TestQueryEnableDisableAlarmActions confirms the query-protocol
+// EnableAlarmActions / DisableAlarmActions operations toggle ActionsEnabled.
+func TestQueryEnableDisableAlarmActions(t *testing.T) {
+	post := newQueryPoster(t)
+
+	if code, body := post(url.Values{
+		"Action": {"PutMetricAlarm"}, "AlarmName": {"a1"}, "Namespace": {"MyApp"}, "MetricName": {"Requests"},
+		"ComparisonOperator": {"GreaterThanThreshold"}, "EvaluationPeriods": {"1"}, "Period": {"60"},
+		"Threshold": {"10"}, "Statistic": {"Average"},
+	}); code != 200 {
+		t.Fatalf("PutMetricAlarm: code=%d body=%s", code, body)
+	}
+
+	if code, _ := post(url.Values{"Action": {"DisableAlarmActions"}, "AlarmNames.member.1": {"a1"}}); code != 200 {
+		t.Fatalf("DisableAlarmActions: code=%d", code)
+	}
+
+	code, body := post(url.Values{"Action": {"DescribeAlarms"}, "AlarmNames.member.1": {"a1"}})
+	if code != 200 || !strings.Contains(body, "<ActionsEnabled>false</ActionsEnabled>") {
+		t.Fatalf("after Disable: code=%d body=%s", code, body)
+	}
+
+	if code, _ := post(url.Values{"Action": {"EnableAlarmActions"}, "AlarmNames.member.1": {"a1"}}); code != 200 {
+		t.Fatalf("EnableAlarmActions: code=%d", code)
+	}
+
+	code, body = post(url.Values{"Action": {"DescribeAlarms"}, "AlarmNames.member.1": {"a1"}})
+	if code != 200 || !strings.Contains(body, "<ActionsEnabled>true</ActionsEnabled>") {
+		t.Fatalf("after Enable: code=%d body=%s", code, body)
+	}
+}


### PR DESCRIPTION
## Summary

Real-user e2e audit of AWS CloudWatch alarms/dashboards found that `aws_cloudwatch_composite_alarm` was completely broken over the wire, even though the SDK (rpc-v2-cbor) path supported it. The AWS CLI and the Terraform AWS provider both speak CloudWatch's classic **query protocol**, and several composite-alarm operations were missing there.

### Divergences fixed

1. **`PutCompositeAlarm` missing from the query dispatch** — `aws cloudwatch put-composite-alarm` and `aws_cloudwatch_composite_alarm` returned `InvalidAction: unsupported CloudWatch action: PutCompositeAlarm`. The resource could never be created.
2. **`DeleteAlarms` did not delete composite alarms over the query protocol** — the cbor path deleted both metric and composite alarms; the query path only deleted metric alarms, so `terraform destroy` left composite alarms behind.
3. **`ListTagsForResource` / `TagResource` failed for composite alarms** — metric and composite alarms share the `arn:aws:cloudwatch:region:acct:alarm:NAME` ARN shape, but the alarm tag methods only looked in the metric-alarm store, so Terraform's per-read `ListTagsForResource` on a composite alarm returned `ResourceNotFound` and broke every plan/apply/destroy.
4. **`EnableAlarmActions` / `DisableAlarmActions` missing from the query dispatch** (parity with the cbor path).

### Changes

- Added `queryPutCompositeAlarm`, `querySetAlarmActionsEnabled`, and composite deletion in `queryDeleteAlarms`.
- Made the provider's `AddAlarmTags` / `RemoveAlarmTags` / `AlarmTags` fall back to the composite-alarm store (both alarm types are served by one tagging API in real CloudWatch).
- Extracted `EnableAlarmActions` / `DisableAlarmActions` operation-name constants shared by both dispatch switches.

### Verified (live serve + real clients)

- **Terraform** full lifecycle against `cloudemu serve`: `aws_cloudwatch_metric_alarm` + `aws_cloudwatch_dashboard` + `aws_cloudwatch_composite_alarm` (with tags) — apply → **plan with no drift** → destroy, all clean. Before: apply failed at the composite alarm.
- **AWS CLI**: put/describe/delete composite alarm, tag round-trip, dashboard put/get/list, set-alarm-state.
- New query-protocol tests for the composite-alarm lifecycle, alarm tag round-trip (metric + composite), and enable/disable actions.
- Gates: `go build ./...`, `go test -race` (server + provider cloudwatch), root `go test .`, `go vet`, `gofmt`, `golangci-lint --new-from-rev` (0 new issues), `go generate` (no docs drift) — all green.
