### PR TITLE
fix(azure-publicip): real-user e2e divergences from Azure Public IP

### DIFF
--- a/providers/azure/vnet/elastic_ip.go
+++ b/providers/azure/vnet/elastic_ip.go
@@ -15,6 +15,8 @@ type eipData struct {
 	InstanceID         string
 	Tags               map[string]string
 	SKU                string
+	SKUTier            string
+	IPVersion          string
 	AllocationMethod   string
 	Zones              []string
 	IdleTimeoutMinutes int
@@ -33,6 +35,47 @@ type eipData struct {
 // deterministic without threading location through ElasticIPConfig.
 const defaultFQDNRegion = "eastus"
 
+// Azure public-IP defaults applied when a request omits the field, matching the
+// values a real publicIPAddresses GET reports: Standard SKU, Regional tier,
+// Static allocation, IPv4 address family and a 4-minute TCP idle timeout.
+const (
+	defaultPublicIPSKU       = "Standard"
+	defaultPublicIPSKUTier   = "Regional"
+	defaultPublicIPAllocMeth = "Static"
+	defaultPublicIPVersion   = "IPv4"
+	defaultIdleTimeoutMin    = 4
+)
+
+// applyPublicIPDefaults fills the Azure public-IP fields ARM defaults when the
+// request omits them, so both AllocateAddress and UpdateAzurePublicIP surface
+// the same GET-visible values (sku.name, sku.tier, publicIPAllocationMethod,
+// publicIPAddressVersion, idleTimeoutInMinutes) that real Azure reports.
+//
+//nolint:gocritic // hugeParam: cfg mirrors AllocateAddress's driver signature.
+func applyPublicIPDefaults(cfg driver.ElasticIPConfig) driver.ElasticIPConfig {
+	if cfg.SKU == "" {
+		cfg.SKU = defaultPublicIPSKU
+	}
+
+	if cfg.SKUTier == "" {
+		cfg.SKUTier = defaultPublicIPSKUTier
+	}
+
+	if cfg.AllocationMethod == "" {
+		cfg.AllocationMethod = defaultPublicIPAllocMeth
+	}
+
+	if cfg.IPVersion == "" {
+		cfg.IPVersion = defaultPublicIPVersion
+	}
+
+	if cfg.IdleTimeoutMinutes == 0 {
+		cfg.IdleTimeoutMinutes = defaultIdleTimeoutMin
+	}
+
+	return cfg
+}
+
 // AllocateAddress allocates a new public IP address.
 //
 //nolint:gocritic // hugeParam: cfg is passed by value to satisfy the Networking driver interface.
@@ -41,24 +84,18 @@ func (m *Mock) AllocateAddress(
 ) (*driver.ElasticIP, error) {
 	allocID := idgen.GenerateID("ipalloc-")
 
-	// Real Azure defaults a public IP to the Standard SKU with Static allocation
-	// when the request omits them.
-	sku := cfg.SKU
-	if sku == "" {
-		sku = "Standard"
-	}
-
-	allocMethod := cfg.AllocationMethod
-	if allocMethod == "" {
-		allocMethod = "Static"
-	}
+	// Real Azure fills omitted fields with its own defaults (Standard/Regional
+	// SKU, Static allocation, IPv4, 4-minute idle timeout) and reports them on GET.
+	cfg = applyPublicIPDefaults(cfg)
 
 	eip := &eipData{
 		AllocationID:       allocID,
 		PublicIP:           mockPublicIP(allocID),
 		Tags:               copyTags(cfg.Tags),
-		SKU:                sku,
-		AllocationMethod:   allocMethod,
+		SKU:                cfg.SKU,
+		SKUTier:            cfg.SKUTier,
+		IPVersion:          cfg.IPVersion,
+		AllocationMethod:   cfg.AllocationMethod,
 		Zones:              append([]string(nil), cfg.Zones...),
 		IdleTimeoutMinutes: cfg.IdleTimeoutMinutes,
 		DNSDomainNameLabel: cfg.DNSDomainNameLabel,
@@ -84,21 +121,15 @@ func (m *Mock) AllocateAddress(
 //
 //nolint:gocritic // hugeParam: cfg mirrors AllocateAddress's driver signature.
 func (m *Mock) UpdateAzurePublicIP(_ context.Context, allocationID string, cfg driver.ElasticIPConfig) error {
-	sku := cfg.SKU
-	if sku == "" {
-		sku = "Standard"
-	}
-
-	allocMethod := cfg.AllocationMethod
-	if allocMethod == "" {
-		allocMethod = "Static"
-	}
+	cfg = applyPublicIPDefaults(cfg)
 
 	found := m.eips.Update(allocationID, func(e *eipData) *eipData {
 		cp := *e
 		cp.Tags = copyTags(cfg.Tags)
-		cp.SKU = sku
-		cp.AllocationMethod = allocMethod
+		cp.SKU = cfg.SKU
+		cp.SKUTier = cfg.SKUTier
+		cp.IPVersion = cfg.IPVersion
+		cp.AllocationMethod = cfg.AllocationMethod
 		cp.IdleTimeoutMinutes = cfg.IdleTimeoutMinutes
 		cp.DNSDomainNameLabel = cfg.DNSDomainNameLabel
 
@@ -248,6 +279,8 @@ func toEIPInfo(eip *eipData) driver.ElasticIP {
 		InstanceID:         eip.InstanceID,
 		Tags:               copyTags(eip.Tags),
 		SKU:                eip.SKU,
+		SKUTier:            eip.SKUTier,
+		IPVersion:          eip.IPVersion,
 		AllocationMethod:   eip.AllocationMethod,
 		Zones:              append([]string(nil), eip.Zones...),
 		IdleTimeoutMinutes: eip.IdleTimeoutMinutes,

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -1580,9 +1580,10 @@ func (h *Handler) createPublicIP(w http.ResponseWriter, r *http.Request, rp azur
 		return
 	}
 
-	sku := ""
+	sku, skuTier := "", ""
 	if req.SKU != nil {
 		sku = req.SKU.Name
+		skuTier = req.SKU.Tier
 	}
 
 	tags := mergeTags(req.Tags, armPublicIPTag, rp.ResourceName)
@@ -1597,6 +1598,8 @@ func (h *Handler) createPublicIP(w http.ResponseWriter, r *http.Request, rp azur
 
 	cfg := netdriver.ElasticIPConfig{
 		SKU:                sku,
+		SKUTier:            skuTier,
+		IPVersion:          req.Properties.PublicIPAddressVersion,
 		AllocationMethod:   req.Properties.PublicIPAllocationMethod,
 		Tags:               tags,
 		Zones:              req.Zones,
@@ -2131,6 +2134,7 @@ func (h *Handler) toPublicIPResponse(
 		Properties: publicIPRespProps{
 			ProvisioningState:        "Succeeded",
 			PublicIPAllocationMethod: info.AllocationMethod,
+			PublicIPAddressVersion:   orDefault(info.IPVersion, "IPv4"),
 			IPAddress:                info.PublicIP,
 			IdleTimeoutInMinutes:     info.IdleTimeoutMinutes,
 			ResourceGUID:             info.ResourceGUID,
@@ -2138,7 +2142,7 @@ func (h *Handler) toPublicIPResponse(
 	}
 
 	if info.SKU != "" {
-		out.SKU = &publicIPSKU{Name: info.SKU}
+		out.SKU = &publicIPSKU{Name: info.SKU, Tier: orDefault(info.SKUTier, "Regional")}
 	}
 
 	if info.DNSDomainNameLabel != "" {
@@ -2257,6 +2261,17 @@ func tagOr(m map[string]string, key, fallback string) string {
 	}
 
 	return fallback
+}
+
+// orDefault returns v, or fallback when v is empty — used to surface the ARM
+// defaults (IPv4, Regional) a real GET always reports for a public IP whose
+// stored record predates the field being modeled.
+func orDefault(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+
+	return v
 }
 
 func stripInternal(in map[string]string) map[string]string {

--- a/server/azure/vnet/public_ip_test.go
+++ b/server/azure/vnet/public_ip_test.go
@@ -216,6 +216,82 @@ func TestSDKPublicIPFieldsRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSDKPublicIPSKUTierAndVersionRoundTrip guards sku.tier and
+// publicIPAddressVersion — both dropped before — round-tripping on GET, so
+// azurerm's sku_tier and ip_version do not perpetually diff. An explicit
+// tier/version is echoed back verbatim; an omitted one reports the ARM defaults
+// (Regional, IPv4) rather than an empty string.
+func TestSDKPublicIPSKUTierAndVersionRoundTrip(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+
+	pips, err := armnetwork.NewPublicIPAddressesClient("sub-1", fakeCred{}, clientOpts(ts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Explicit SKU (name+tier) and IP version echo back verbatim.
+	p, err := pips.BeginCreateOrUpdate(ctx, "rg-1", "pip-sku", armnetwork.PublicIPAddress{
+		Location: to.Ptr("eastus"),
+		SKU: &armnetwork.PublicIPAddressSKU{
+			Name: to.Ptr(armnetwork.PublicIPAddressSKUNameStandard),
+			Tier: to.Ptr(armnetwork.PublicIPAddressSKUTierRegional),
+		},
+		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+			PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv4),
+			PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	pollDone(t, p)
+
+	got, err := pips.Get(ctx, "rg-1", "pip-sku", nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.SKU == nil || got.SKU.Tier == nil || *got.SKU.Tier != armnetwork.PublicIPAddressSKUTierRegional {
+		t.Errorf("sku.tier=%v want Regional", got.SKU)
+	}
+
+	if got.Properties == nil || got.Properties.PublicIPAddressVersion == nil ||
+		*got.Properties.PublicIPAddressVersion != armnetwork.IPVersionIPv4 {
+		t.Errorf("publicIPAddressVersion=%v want IPv4", got.Properties)
+	}
+
+	// Omitting SKU/version/idleTimeout still reports the ARM defaults, not empty.
+	dp, err := pips.BeginCreateOrUpdate(ctx, "rg-1", "pip-defaults", armnetwork.PublicIPAddress{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create defaults: %v", err)
+	}
+
+	pollDone(t, dp)
+
+	def, err := pips.Get(ctx, "rg-1", "pip-defaults", nil)
+	if err != nil {
+		t.Fatalf("get defaults: %v", err)
+	}
+
+	if def.SKU == nil || def.SKU.Tier == nil || *def.SKU.Tier != armnetwork.PublicIPAddressSKUTierRegional {
+		t.Errorf("default sku.tier=%v want Regional", def.SKU)
+	}
+
+	if def.Properties == nil || def.Properties.PublicIPAddressVersion == nil ||
+		*def.Properties.PublicIPAddressVersion != armnetwork.IPVersionIPv4 {
+		t.Errorf("default publicIPAddressVersion=%v want IPv4", def.Properties)
+	}
+
+	if def.Properties == nil || def.Properties.IdleTimeoutInMinutes == nil ||
+		*def.Properties.IdleTimeoutInMinutes != 4 {
+		t.Errorf("default idleTimeoutInMinutes=%v want 4", def.Properties)
+	}
+}
+
 // TestSDKPublicIPIPConfigurationBackref guards the missing ipConfiguration
 // back-reference: once a NIC attaches a public IP, a Get on that address must
 // report the NIC's ipConfiguration id.

--- a/server/azure/vnet/types.go
+++ b/server/azure/vnet/types.go
@@ -186,10 +186,12 @@ type publicIPRequest struct {
 
 type publicIPSKU struct {
 	Name string `json:"name,omitempty"`
+	Tier string `json:"tier,omitempty"`
 }
 
 type publicIPReqProps struct {
 	PublicIPAllocationMethod string                  `json:"publicIPAllocationMethod,omitempty"`
+	PublicIPAddressVersion   string                  `json:"publicIPAddressVersion,omitempty"`
 	IdleTimeoutInMinutes     int                     `json:"idleTimeoutInMinutes,omitempty"`
 	DNSSettings              *publicIPDNSSettingsReq `json:"dnsSettings,omitempty"`
 	// PublicIPPrefix is the optional prefix a public IP is drawn from. The mock
@@ -216,6 +218,7 @@ type publicIPResponse struct {
 type publicIPRespProps struct {
 	ProvisioningState        string               `json:"provisioningState"`
 	PublicIPAllocationMethod string               `json:"publicIPAllocationMethod,omitempty"`
+	PublicIPAddressVersion   string               `json:"publicIPAddressVersion,omitempty"`
 	IPAddress                string               `json:"ipAddress,omitempty"`
 	IdleTimeoutInMinutes     int                  `json:"idleTimeoutInMinutes,omitempty"`
 	DNSSettings              *publicIPDNSSettings `json:"dnsSettings,omitempty"`

--- a/services/networking/driver/driver.go
+++ b/services/networking/driver/driver.go
@@ -308,6 +308,11 @@ type ElasticIPConfig struct {
 	Zones              []string
 	IdleTimeoutMinutes int
 	DNSDomainNameLabel string
+	// SKUTier is the Azure public-IP SKU tier (Regional/Global), echoed as
+	// sku.tier. IPVersion is the address family (IPv4/IPv6), echoed as
+	// properties.publicIPAddressVersion. Empty for AWS and GCP.
+	SKUTier   string
+	IPVersion string
 }
 
 // ElasticIP represents an elastic IP address.
@@ -334,6 +339,11 @@ type ElasticIP struct {
 	IdleTimeoutMinutes int
 	DNSDomainNameLabel string
 	DNSFQDN            string
+	// SKUTier (Regional/Global) and IPVersion (IPv4/IPv6) round-trip the
+	// Azure-only public-IP fields set in ElasticIPConfig; the provider defaults
+	// them to Regional/IPv4. Empty for AWS and GCP.
+	SKUTier   string
+	IPVersion string
 	// ResourceGUID is the Azure-only persisted identifier ARM reports as
 	// properties.resourceGuid on a publicIPAddresses resource — stable for the
 	// address's lifetime, regenerated only on release + re-allocation. Empty


### PR DESCRIPTION
## Summary

Real-user e2e audit of `azurerm_public_ip` / `Microsoft.Network/publicIPAddresses` against the official Azure REST spec and armnetwork SDK found that a public IP GET dropped two fields Terraform reads back, causing a perpetual plan diff (both are ForceNew, so the diff schedules a destroy/recreate):

- **`sku.tier`** — request/response only modeled `sku.name`; the tier (default `Regional`) was never stored or echoed. azurerm reads `sku_tier` back as empty -> drift.
- **`properties.publicIPAddressVersion`** — not modeled at all. azurerm reads `ip_version` (default `IPv4`) back as empty -> drift. (Under `properties`, the echo overlay masked this only when the client happened to send it; a plain GET or a client relying on the default still saw nothing.)
- **`idleTimeoutInMinutes`** — never defaulted; a create that omitted it stored 0, whereas real Azure reports 4.

## Fix

Modeled both fields end to end — driver (`ElasticIPConfig`/`ElasticIP`), Azure provider (`eipData` + `applyPublicIPDefaults`), and the wire request/response types — and applied the ARM defaults a real GET always reports: Standard/Regional SKU, Static allocation, IPv4, 4-minute idle timeout. Existing behavior (zones, dnsSettings.fqdn, ipAddress assignment, ipConfiguration back-ref, re-PUT idempotency, LRO Succeeded) is unchanged.

## Evidence

Live `serve` on Azure HTTPS :17330, raw ARM REST (azurerm-on-macOS cert distrust fallback):
- Explicit create -> GET round-trips `sku.tier=Regional`, `publicIPAddressVersion=IPv4`, zones, fqdn, `ipAddress` (Static), `provisioningState=Succeeded` (no LRO hang).
- Minimal create (no sku/version/idleTimeout) -> GET reports `sku.tier=Regional`, `publicIPAddressVersion=IPv4`, `idleTimeoutInMinutes=4`.

New SDK test `TestSDKPublicIPSKUTierAndVersionRoundTrip` covers both the explicit and default paths.

## Gates

go build, go vet, gofmt, `go test -race` (providers/azure/vnet + full server/azure + root + services/networking), golangci-lint (0 new issues), go generate (no docs/coverage drift) — all green.