### PR TITLE
fix(artifactregistry): real-user e2e divergences from GCP Artifact Registry

### DIFF
--- a/server/gcp/artifactregistry/gapic_lro_test.go
+++ b/server/gcp/artifactregistry/gapic_lro_test.go
@@ -40,7 +40,7 @@ func TestGAPICCreateRepositoryWait(t *testing.T) {
 	op, err := client.CreateRepository(ctx, &artifactregistrypb.CreateRepositoryRequest{
 		Parent:       "projects/demo/locations/us",
 		RepositoryId: "gapic-repo",
-		Repository:   &artifactregistrypb.Repository{Description: "gapic"},
+		Repository:   &artifactregistrypb.Repository{Format: artifactregistrypb.Repository_DOCKER, Description: "gapic"},
 	})
 	if err != nil {
 		t.Fatalf("CreateRepository: %v", err)

--- a/server/gcp/artifactregistry/operations.go
+++ b/server/gcp/artifactregistry/operations.go
@@ -20,6 +20,17 @@ func (h *Handler) createRepository(w http.ResponseWriter, r *http.Request, rt *r
 		return
 	}
 
+	// format is required and immutable: real Artifact Registry rejects a create
+	// whose format is missing, FORMAT_UNSPECIFIED, or an unknown enum with
+	// INVALID_ARGUMENT. Defaulting a missing format to DOCKER (as this handler
+	// once did) masked that client error.
+	if !isKnownFormat(string(body.Format)) {
+		gcprest.WriteError(w, http.StatusBadRequest, "required",
+			"format is required and must be a valid enum (e.g. DOCKER, MAVEN, NPM, PYTHON, GO, GENERIC)")
+
+		return
+	}
+
 	repo, err := h.registry.CreateRepository(r.Context(), crdriver.RepositoryConfig{
 		Name: repoID,
 		Tags: reservedTagsFrom(&body),
@@ -483,7 +494,12 @@ func pageSize(r *http.Request) int {
 // the same done operation (with its typed response) in the full server.
 func (h *Handler) doneOperation(rt *route, id string, response any) operationJSON {
 	name := "projects/" + rt.project + "/locations/" + rt.location + "/operations/op-" + id
-	h.ops.Register(name, response)
+
+	// A standalone package server (New without SetOperationRegistry) has no shared
+	// poller and answers its own /operations/ polls, so only register when wired.
+	if h.ops != nil {
+		h.ops.Register(name, response)
+	}
 
 	return operationJSON{
 		Name:     name,

--- a/server/gcp/artifactregistry/repository_create_format_test.go
+++ b/server/gcp/artifactregistry/repository_create_format_test.go
@@ -1,0 +1,74 @@
+package artifactregistry_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	ar "google.golang.org/api/artifactregistry/v1"
+	"google.golang.org/api/googleapi"
+)
+
+// TestCreateRepositoryFormatRequired guards the real-user divergence that a
+// create with a missing, FORMAT_UNSPECIFIED, or unknown format must fail with
+// INVALID_ARGUMENT (HTTP 400) — real Artifact Registry requires a concrete,
+// valid format, which is also immutable. The handler previously defaulted a
+// missing format to DOCKER and stored an unknown format verbatim, silently
+// masking the client error and diverging from GCP.
+func TestCreateRepositoryFormatRequired(t *testing.T) {
+	svc, _ := newARService(t)
+
+	cases := []struct {
+		name string
+		repo *ar.Repository
+	}{
+		{"missing", &ar.Repository{}},
+		{"unspecified", &ar.Repository{Format: "FORMAT_UNSPECIFIED"}},
+		{"unknown", &ar.Repository{Format: "NOT_A_FORMAT"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.Projects.Locations.Repositories.
+				Create(testParent, tc.repo).RepositoryId("repo-" + tc.name).Do()
+			if err == nil {
+				t.Fatalf("create with %s format: got nil error, want INVALID_ARGUMENT", tc.name)
+			}
+
+			var gerr *googleapi.Error
+			if !errors.As(err, &gerr) {
+				t.Fatalf("create with %s format: error %v is not a googleapi.Error", tc.name, err)
+			}
+
+			if gerr.Code != http.StatusBadRequest {
+				t.Fatalf("create with %s format: code=%d want %d", tc.name, gerr.Code, http.StatusBadRequest)
+			}
+		})
+	}
+}
+
+// TestCreateRepositoryFormatAccepted confirms the validation does not reject a
+// valid format (the common real-user path); a DOCKER create still succeeds and
+// round-trips its format on get.
+func TestCreateRepositoryFormatAccepted(t *testing.T) {
+	svc, _ := newARService(t)
+
+	op, err := svc.Projects.Locations.Repositories.
+		Create(testParent, &ar.Repository{Format: "DOCKER"}).RepositoryId("ok").Do()
+	if err != nil {
+		t.Fatalf("create with DOCKER format: %v", err)
+	}
+
+	if !op.Done {
+		t.Fatalf("create operation not done")
+	}
+
+	got, err := svc.Projects.Locations.Repositories.Get(testParent + "/repositories/ok").Do()
+	if err != nil {
+		t.Fatalf("get after create: %v", err)
+	}
+
+	if got.Format != "DOCKER" {
+		t.Fatalf("format=%q want DOCKER", got.Format)
+	}
+}

--- a/server/gcp/artifactregistry/types.go
+++ b/server/gcp/artifactregistry/types.go
@@ -20,7 +20,7 @@ type repoFormat string
 //
 //nolint:gochecknoglobals // static enum lookup table, not mutable state.
 var formatNames = map[int]string{
-	0:  "FORMAT_UNSPECIFIED",
+	0:  formatUnspecified,
 	1:  "DOCKER",
 	2:  "MAVEN",
 	3:  "NPM",
@@ -30,6 +30,20 @@ var formatNames = map[int]string{
 	9:  "KFP",
 	10: "GO",
 	11: "GENERIC",
+}
+
+// isKnownFormat reports whether name is a settable Repository.format enum value,
+// i.e. a known name other than FORMAT_UNSPECIFIED. Real Artifact Registry
+// requires a concrete format on create and rejects an unknown or unspecified one
+// with INVALID_ARGUMENT.
+func isKnownFormat(name string) bool {
+	for _, known := range formatNames {
+		if known == name {
+			return name != formatUnspecified
+		}
+	}
+
+	return false
 }
 
 // UnmarshalJSON accepts the format as a JSON string or a numeric enum.
@@ -168,6 +182,7 @@ type operationJSON struct {
 
 const (
 	dockerFormat      = "DOCKER"
+	formatUnspecified = "FORMAT_UNSPECIFIED"
 	standardMode      = "STANDARD_REPOSITORY"
 	formatTag         = "cloudemu:gcpArFormat"
 	descriptionTag    = "cloudemu:gcpArDescription"


### PR DESCRIPTION
## Summary

Real-user e2e re-audit of GCP Artifact Registry (`google_artifact_registry_repository`) via `cloudemu serve`, the raw `google.golang.org/api/artifactregistry/v1` client, the GAPIC `apiv1` REST client, and Terraform. The control-plane path is otherwise solid (LRO reaches done, full resource names, format int/string enum, mode default, labels/description/dockerConfig/cleanupPolicies round-trip, query-param `updateMask`, IAM etag, deterministic list, GCP error envelope). One real-cloud divergence was found and fixed.

## What changed

- **`format` is now required and validated on create.** Real Artifact Registry rejects a repository create whose `format` is missing, `FORMAT_UNSPECIFIED`, or an unknown enum with `INVALID_ARGUMENT`. The wire handler instead silently defaulted a missing format to `DOCKER` and stored an unknown value verbatim, masking the client error. The handler now validates the format against the known enum set and returns `INVALID_ARGUMENT` (HTTP 400) otherwise. Numeric enums (GAPIC `UseEnumNumbers`) and all valid string formats still create normally.
- **Nil-poller guard in `doneOperation`.** The handler doc states a standalone package server (constructed via `New` without `SetOperationRegistry`) answers its own `/operations/` polls, but `doneOperation` unconditionally called `h.ops.Register`, which would panic on that path. It now registers only when the shared poller is wired.

## Why

`format` being required + immutable is a documented Artifact Registry rule; defaulting it hid genuine client errors and diverged from real GCP. No real-user surface (Terraform, gcloud, SDKs) omits `format`, so the common create/update/delete path is unaffected.

## Evidence

- Terraform full lifecycle green against `serve`: create (LRO done, no hang) → plan no drift → update labels+description (query-param `updateMask`) → plan no drift → destroy.
- Wire: missing/`FORMAT_UNSPECIFIED`/unknown format → 400 `INVALID_ARGUMENT`; `DOCKER` and numeric enum `3` (NPM) → 200.
- Gates: `go build ./...`, `go vet`, `gofmt -l`, `golangci-lint` (0 issues), `go test -race ./server/gcp/artifactregistry/ ./providers/gcp/artifactregistry/ ./server/gcp/ ./compat/gcp/`, `go generate` (no docs diff) all pass.
