### PR TITLE
fix(stepfunctions): real-user e2e divergences from AWS Step Functions (control plane)

### DIFF
--- a/providers/aws/sfn/encryption_idempotency_test.go
+++ b/providers/aws/sfn/encryption_idempotency_test.go
@@ -1,0 +1,64 @@
+package sfn_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
+)
+
+// TestInvalidDefinitionMessageHasNoCodePrefix guards against the canonical
+// error-code taxonomy leaking into an InvalidDefinition message. Real Step
+// Functions never prefixes its message with an internal code like
+// "InvalidArgument:".
+func TestInvalidDefinitionMessageHasNoCodePrefix(t *testing.T) {
+	m := newMock(t)
+
+	_, _, _, err := m.CreateStateMachine(context.Background(), driver.CreateStateMachineInput{
+		Name: "bad", Definition: `{"not":"asl"}`, RoleArn: "arn:aws:iam::000000000000:role/r",
+	})
+	if err == nil {
+		t.Fatal("expected InvalidDefinition for a definition without StartAt")
+	}
+
+	if got := exceptionOf(err); got != driver.ExInvalidDefinition {
+		t.Fatalf("exception = %q, want %q", got, driver.ExInvalidDefinition)
+	}
+
+	if msg := errors.Message(err); strings.Contains(msg, "InvalidArgument") {
+		t.Fatalf("message leaks the code taxonomy: %q", msg)
+	}
+}
+
+// TestCreateIdempotencyFoldsEncryptionConfig verifies the CreateStateMachine
+// idempotency check treats a differing encryptionConfiguration as a conflict
+// (StateMachineAlreadyExists), matching real Step Functions which folds
+// EncryptionConfiguration into its idempotency comparison.
+func TestCreateIdempotencyFoldsEncryptionConfig(t *testing.T) {
+	m := newMock(t)
+	ctx := context.Background()
+
+	base := driver.CreateStateMachineInput{
+		Name: "sm", Definition: definition, RoleArn: "arn:aws:iam::000000000000:role/r",
+		EncryptionCfgJSON: `{"type":"AWS_OWNED_KEY"}`,
+	}
+	if _, _, _, err := m.CreateStateMachine(ctx, base); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+
+	// Identical request (including encryption) is idempotent.
+	if _, _, _, err := m.CreateStateMachine(ctx, base); err != nil {
+		t.Fatalf("idempotent re-create should succeed, got %v", err)
+	}
+
+	// Same name, different encryption config -> StateMachineAlreadyExists.
+	diff := base
+	diff.EncryptionCfgJSON = `{"type":"CUSTOMER_MANAGED_KMS_KEY","kmsKeyId":"arn:aws:kms:us-east-1:000000000000:key/abc"}`
+
+	_, _, _, err := m.CreateStateMachine(ctx, diff)
+	if got := exceptionOf(err); got != driver.ExStateMachineAlreadyExists {
+		t.Fatalf("differing encryption config: exception = %q, want %q", got, driver.ExStateMachineAlreadyExists)
+	}
+}

--- a/providers/aws/sfn/statemachines.go
+++ b/providers/aws/sfn/statemachines.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/regionctx"
 	"github.com/stackshy/cloudemu/v2/providers/aws/sfn/asl"
@@ -18,7 +19,10 @@ import (
 // QueryLanguage JSONata) with InvalidDefinition, matching real Step Functions.
 func validateASL(definition string) error {
 	if _, err := asl.Parse(definition); err != nil {
-		return invalidDefinition(err.Error())
+		// Use the human message only: err.Error() prepends the canonical code
+		// (e.g. "InvalidArgument: ..."), and real Step Functions never leaks an
+		// internal error-taxonomy name into an InvalidDefinition message.
+		return invalidDefinition(errors.Message(err))
 	}
 
 	return nil
@@ -95,6 +99,8 @@ func (m *Mock) CreateStateMachine(
 // with the same name whose definition, type, logging and tracing configuration
 // all match the existing machine returns that machine (HTTP 200) — a differing
 // roleArn or tags is ignored. Any other difference is StateMachineAlreadyExists.
+// The idempotency check mirrors real Step Functions, which also folds
+// encryptionConfiguration into the comparison.
 func (m *Mock) reconcileExisting(
 	arn string, want *driver.StateMachine,
 ) (resolvedArn, versionArn string, created time.Time, err error) {
@@ -109,7 +115,8 @@ func (m *Mock) reconcileExisting(
 	same := sd.sm.Definition == want.Definition &&
 		sd.sm.Type == want.Type &&
 		sd.sm.LoggingConfigJSON == want.LoggingConfigJSON &&
-		sd.sm.TracingConfigJSON == want.TracingConfigJSON
+		sd.sm.TracingConfigJSON == want.TracingConfigJSON &&
+		sd.sm.EncryptionCfgJSON == want.EncryptionCfgJSON
 	if !same {
 		return "", "", time.Time{}, smAlreadyExists(want.Name)
 	}

--- a/providers/aws/sfn/teststate.go
+++ b/providers/aws/sfn/teststate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/providers/aws/sfn/asl"
 	"github.com/stackshy/cloudemu/v2/services/sfn/driver"
 )
@@ -23,7 +24,7 @@ func (m *Mock) TestState(ctx context.Context, in driver.TestStateInput) (*driver
 		Input: in.Input, StartTime: m.now(), InvokeLambda: m.lambdaInvoker(),
 	})
 	if err != nil {
-		return nil, invalidDefinition(err.Error())
+		return nil, invalidDefinition(errors.Message(err))
 	}
 
 	return &driver.TestStateResult{
@@ -45,7 +46,7 @@ func (*Mock) ValidateStateMachineDefinition(
 	}
 
 	if _, err := asl.Parse(definition); err != nil {
-		return validationFail("SCHEMA_VALIDATION_FAILED", err.Error()), nil
+		return validationFail("SCHEMA_VALIDATION_FAILED", errors.Message(err)), nil
 	}
 
 	return &driver.ValidationResult{Result: driver.ValidationResultOK}, nil

--- a/server/aws/sfn/encryption_config_test.go
+++ b/server/aws/sfn/encryption_config_test.go
@@ -1,0 +1,113 @@
+package sfn_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssfn "github.com/aws/aws-sdk-go-v2/service/sfn"
+	sfntypes "github.com/aws/aws-sdk-go-v2/service/sfn/types"
+)
+
+// TestSDKEncryptionConfigRoundTrip verifies a customer-managed-key
+// encryptionConfiguration set at create time survives DescribeStateMachine.
+// Real Step Functions echoes encryptionConfiguration back; dropping it makes
+// Terraform's aws_sfn_state_machine drift perpetually.
+func TestSDKEncryptionConfigRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c := newSFNClient(t)
+
+	out, err := c.CreateStateMachine(ctx, &awssfn.CreateStateMachineInput{
+		Name:       aws.String("enc"),
+		Definition: aws.String(definition),
+		RoleArn:    aws.String("arn:aws:iam::123456789012:role/svc"),
+		EncryptionConfiguration: &sfntypes.EncryptionConfiguration{
+			Type:                         sfntypes.EncryptionTypeCustomerManagedKmsKey,
+			KmsKeyId:                     aws.String("arn:aws:kms:us-east-1:123456789012:key/abc"),
+			KmsDataKeyReusePeriodSeconds: aws.Int32(300),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateStateMachine: %v", err)
+	}
+
+	desc, err := c.DescribeStateMachine(ctx, &awssfn.DescribeStateMachineInput{
+		StateMachineArn: out.StateMachineArn,
+	})
+	if err != nil {
+		t.Fatalf("DescribeStateMachine: %v", err)
+	}
+
+	ec := desc.EncryptionConfiguration
+	if ec == nil {
+		t.Fatal("encryptionConfiguration missing from DescribeStateMachine")
+	}
+
+	if ec.Type != sfntypes.EncryptionTypeCustomerManagedKmsKey {
+		t.Fatalf("type = %s, want CUSTOMER_MANAGED_KMS_KEY", ec.Type)
+	}
+
+	if aws.ToString(ec.KmsKeyId) != "arn:aws:kms:us-east-1:123456789012:key/abc" {
+		t.Fatalf("kmsKeyId = %q", aws.ToString(ec.KmsKeyId))
+	}
+
+	if aws.ToInt32(ec.KmsDataKeyReusePeriodSeconds) != 300 {
+		t.Fatalf("kmsDataKeyReusePeriodSeconds = %d, want 300", aws.ToInt32(ec.KmsDataKeyReusePeriodSeconds))
+	}
+}
+
+// TestSDKEncryptionConfigDefault verifies a state machine created without an
+// encryptionConfiguration reports the AWS_OWNED_KEY default on describe, as real
+// Step Functions does.
+func TestSDKEncryptionConfigDefault(t *testing.T) {
+	ctx := context.Background()
+	c := newSFNClient(t)
+	arn := createSM(t, c, "plain-enc")
+
+	desc, err := c.DescribeStateMachine(ctx, &awssfn.DescribeStateMachineInput{
+		StateMachineArn: aws.String(arn),
+	})
+	if err != nil {
+		t.Fatalf("DescribeStateMachine: %v", err)
+	}
+
+	if desc.EncryptionConfiguration == nil {
+		t.Fatal("encryptionConfiguration missing; want AWS_OWNED_KEY default")
+	}
+
+	if desc.EncryptionConfiguration.Type != sfntypes.EncryptionTypeAwsOwnedKey {
+		t.Fatalf("type = %s, want AWS_OWNED_KEY", desc.EncryptionConfiguration.Type)
+	}
+}
+
+// TestSDKUpdateEncryptionConfig verifies UpdateStateMachine can change the
+// encryptionConfiguration and the change is observable on describe.
+func TestSDKUpdateEncryptionConfig(t *testing.T) {
+	ctx := context.Background()
+	c := newSFNClient(t)
+	arn := createSM(t, c, "upd-enc")
+
+	if _, err := c.UpdateStateMachine(ctx, &awssfn.UpdateStateMachineInput{
+		StateMachineArn: aws.String(arn),
+		EncryptionConfiguration: &sfntypes.EncryptionConfiguration{
+			Type:                         sfntypes.EncryptionTypeCustomerManagedKmsKey,
+			KmsKeyId:                     aws.String("arn:aws:kms:us-east-1:123456789012:key/xyz"),
+			KmsDataKeyReusePeriodSeconds: aws.Int32(600),
+		},
+	}); err != nil {
+		t.Fatalf("UpdateStateMachine: %v", err)
+	}
+
+	desc, err := c.DescribeStateMachine(ctx, &awssfn.DescribeStateMachineInput{
+		StateMachineArn: aws.String(arn),
+	})
+	if err != nil {
+		t.Fatalf("DescribeStateMachine: %v", err)
+	}
+
+	if desc.EncryptionConfiguration == nil ||
+		desc.EncryptionConfiguration.Type != sfntypes.EncryptionTypeCustomerManagedKmsKey ||
+		aws.ToString(desc.EncryptionConfiguration.KmsKeyId) != "arn:aws:kms:us-east-1:123456789012:key/xyz" {
+		t.Fatalf("encryptionConfiguration not updated: %+v", desc.EncryptionConfiguration)
+	}
+}

--- a/server/aws/sfn/operations.go
+++ b/server/aws/sfn/operations.go
@@ -15,6 +15,7 @@ func (h *Handler) createStateMachine(w http.ResponseWriter, r *http.Request) {
 			Description: req.Description, Publish: req.Publish, Tags: tagsToMap(req.Tags),
 			LoggingConfigJSON: rawJSON(req.LoggingConfiguration),
 			TracingConfigJSON: rawJSON(req.TracingConfiguration),
+			EncryptionCfgJSON: rawJSON(req.EncryptionConfiguration),
 		})
 		if err != nil {
 			return nil, err
@@ -37,8 +38,9 @@ func (h *Handler) describeStateMachine(w http.ResponseWriter, r *http.Request) {
 			StateMachineArn: sm.ARN, Name: sm.Name, Definition: sm.Definition, RoleArn: sm.RoleArn,
 			Type: sm.Type, Status: sm.Status, Description: sm.Description, RevisionID: sm.RevisionID,
 			CreationDate: epoch(sm.CreationDate), Label: sm.Label,
-			LoggingConfiguration: loggingConfigOrDefault(sm.LoggingConfigJSON),
-			TracingConfiguration: tracingConfigOrDefault(sm.TracingConfigJSON),
+			LoggingConfiguration:    loggingConfigOrDefault(sm.LoggingConfigJSON),
+			TracingConfiguration:    tracingConfigOrDefault(sm.TracingConfigJSON),
+			EncryptionConfiguration: encryptionConfigOrDefault(sm.EncryptionCfgJSON),
 		}, nil
 	})
 }
@@ -50,6 +52,7 @@ func (h *Handler) updateStateMachine(w http.ResponseWriter, r *http.Request) {
 			Publish: req.Publish, VersionDesc: req.VersionDescription,
 			LoggingConfigJSON: rawJSON(req.LoggingConfiguration),
 			TracingConfigJSON: rawJSON(req.TracingConfiguration),
+			EncryptionCfgJSON: rawJSON(req.EncryptionConfiguration),
 		})
 		if err != nil {
 			return nil, err

--- a/server/aws/sfn/types.go
+++ b/server/aws/sfn/types.go
@@ -87,15 +87,16 @@ func mapToTags(m map[string]string) []tag {
 // --- request shapes ---
 
 type createStateMachineRequest struct {
-	Name                 string          `json:"name"`
-	Definition           string          `json:"definition"`
-	RoleArn              string          `json:"roleArn"`
-	Type                 string          `json:"type"`
-	Description          string          `json:"versionDescription"`
-	Publish              bool            `json:"publish"`
-	Tags                 []tag           `json:"tags"`
-	LoggingConfiguration json.RawMessage `json:"loggingConfiguration"`
-	TracingConfiguration json.RawMessage `json:"tracingConfiguration"`
+	Name                    string          `json:"name"`
+	Definition              string          `json:"definition"`
+	RoleArn                 string          `json:"roleArn"`
+	Type                    string          `json:"type"`
+	Description             string          `json:"versionDescription"`
+	Publish                 bool            `json:"publish"`
+	Tags                    []tag           `json:"tags"`
+	LoggingConfiguration    json.RawMessage `json:"loggingConfiguration"`
+	TracingConfiguration    json.RawMessage `json:"tracingConfiguration"`
+	EncryptionConfiguration json.RawMessage `json:"encryptionConfiguration"`
 }
 
 // rawJSON renders an optional JSON-object request field as the verbatim string
@@ -113,13 +114,14 @@ type stateMachineArnRequest struct {
 }
 
 type updateStateMachineRequest struct {
-	StateMachineArn      string          `json:"stateMachineArn"`
-	Definition           string          `json:"definition"`
-	RoleArn              string          `json:"roleArn"`
-	Publish              bool            `json:"publish"`
-	VersionDescription   string          `json:"versionDescription"`
-	LoggingConfiguration json.RawMessage `json:"loggingConfiguration"`
-	TracingConfiguration json.RawMessage `json:"tracingConfiguration"`
+	StateMachineArn         string          `json:"stateMachineArn"`
+	Definition              string          `json:"definition"`
+	RoleArn                 string          `json:"roleArn"`
+	Publish                 bool            `json:"publish"`
+	VersionDescription      string          `json:"versionDescription"`
+	LoggingConfiguration    json.RawMessage `json:"loggingConfiguration"`
+	TracingConfiguration    json.RawMessage `json:"tracingConfiguration"`
+	EncryptionConfiguration json.RawMessage `json:"encryptionConfiguration"`
 }
 
 type startExecutionRequest struct {
@@ -278,18 +280,19 @@ type createStateMachineResponse struct {
 }
 
 type describeStateMachineResponse struct {
-	StateMachineArn      string          `json:"stateMachineArn"`
-	Name                 string          `json:"name"`
-	Definition           string          `json:"definition"`
-	RoleArn              string          `json:"roleArn"`
-	Type                 string          `json:"type"`
-	Status               string          `json:"status"`
-	Description          string          `json:"description,omitempty"`
-	RevisionID           string          `json:"revisionId,omitempty"`
-	CreationDate         *float64        `json:"creationDate"`
-	Label                string          `json:"label,omitempty"`
-	LoggingConfiguration json.RawMessage `json:"loggingConfiguration"`
-	TracingConfiguration json.RawMessage `json:"tracingConfiguration"`
+	StateMachineArn         string          `json:"stateMachineArn"`
+	Name                    string          `json:"name"`
+	Definition              string          `json:"definition"`
+	RoleArn                 string          `json:"roleArn"`
+	Type                    string          `json:"type"`
+	Status                  string          `json:"status"`
+	Description             string          `json:"description,omitempty"`
+	RevisionID              string          `json:"revisionId,omitempty"`
+	CreationDate            *float64        `json:"creationDate"`
+	Label                   string          `json:"label,omitempty"`
+	LoggingConfiguration    json.RawMessage `json:"loggingConfiguration"`
+	TracingConfiguration    json.RawMessage `json:"tracingConfiguration"`
+	EncryptionConfiguration json.RawMessage `json:"encryptionConfiguration"`
 }
 
 // defaultLoggingConfig / defaultTracingConfig are the values real
@@ -308,6 +311,17 @@ func tracingConfigOrDefault(raw string) json.RawMessage {
 	}
 
 	return json.RawMessage(`{"enabled":false}`)
+}
+
+// encryptionConfigOrDefault mirrors real DescribeStateMachine, which returns an
+// AWS_OWNED_KEY encryption configuration for a state machine created without a
+// customer-managed key.
+func encryptionConfigOrDefault(raw string) json.RawMessage {
+	if raw != "" {
+		return json.RawMessage(raw)
+	}
+
+	return json.RawMessage(`{"type":"AWS_OWNED_KEY"}`)
 }
 
 type updateStateMachineResponse struct {


### PR DESCRIPTION
## Summary

Real-user e2e audit of the AWS Step Functions **control plane** (`aws_sfn_state_machine` create/describe/update/delete/list/tags) against the official AWS Step Functions API, exercised live via `cloudemu serve` with the real `aws` CLI / `aws-sdk-go-v2` and Terraform's `aws_sfn_state_machine`.

The control plane was already comprehensive (CRUD, tags, versions, aliases, ASL definition round-trip, logging/tracing defaults, error-code fidelity). Two genuine divergences were found and fixed.

### 1. `encryptionConfiguration` dropped on the wire (Terraform drift)

The SFN driver already stored `encryptionConfiguration`, but the JSON 1.0 wire layer never read it on `CreateStateMachine`/`UpdateStateMachine` and never emitted it on `DescribeStateMachine`. A customer-managed key was silently discarded, so:

- SDK/CLI: a `CUSTOMER_MANAGED_KMS_KEY` config never came back from describe.
- Terraform: `aws_sfn_state_machine` with an `encryption_configuration` block drifted perpetually (`terraform plan` always wanted to re-add the block).

Fix: wire `encryptionConfiguration` through create, update and describe, and return the `AWS_OWNED_KEY` default when unset — mirroring real Step Functions (and matching the existing logging/tracing default handling). The `CreateStateMachine` idempotency check now also folds `encryptionConfiguration` in, as the AWS docs specify.

### 2. Error-code taxonomy leaked into `InvalidDefinition` messages

`InvalidDefinition` (and the `TestState`/`ValidateStateMachineDefinition` diagnostics) surfaced the internal code prefix, e.g. `InvalidArgument: definition is missing the required top-level 'StartAt' field`. Real Step Functions never leaks an internal error-taxonomy name into a message. Fixed to emit the human message only.

## Evidence

- Terraform `aws_sfn_state_machine` with an `encryption_configuration` block: `terraform plan` **before** = perpetual `1 to change`; **after** = `No changes. Your infrastructure matches the configuration.` (detailed-exitcode 0).
- CLI/SDK: `encryptionConfiguration` now round-trips (customer-managed) and defaults to `{"type":"AWS_OWNED_KEY"}`; update can change it; describe reflects it.
- `InvalidDefinition` message after fix: `definition is missing the required top-level 'StartAt' field` (no code prefix; `__type` still `InvalidDefinition`).

## Scope note

The ASL **execution** engine (StartExecution interpretation, Parallel/Map, GetExecutionHistory) is already built and passing; it was out of scope for this control-plane audit and needed no changes.

## Tests / gates

New tests: encryption round-trip + AWS_OWNED_KEY default + update (server SDK), and no-code-prefix + encryption idempotency (provider). All green with `-race`. `go build ./...`, `go vet`, `gofmt -l`, `golangci-lint` (0 issues) and `go generate` (no `docs/coverage` diff) all clean.
