### PR TITLE
fix(azure-routetable): real-user e2e divergences from Azure Route Table

### DIFF
--- a/docs/coverage/azure/vnet.md
+++ b/docs/coverage/azure/vnet.md
@@ -118,6 +118,7 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | --- | --- |
 | `DeleteAzureNSGMetadata` |  |
 | `DeleteAzureNSGRule` | DeleteAzureNSGRule removes a single custom security rule by name, leaving |
+| `DeleteAzureRoute` | DeleteAzureRoute removes a single route by name from the route table with |
 | `DeleteAzureRouteTableMetadata` | DeleteAzureRouteTableMetadata drops the stored metadata for id (called when |
 | `DeleteAzureVNetMetadata` |  |
 | `DeleteAzureVNetPeering` | DeleteAzureVNetPeering removes a single peering by name, leaving every |
@@ -133,6 +134,7 @@ AzureNetworkMetadata is an OPTIONAL, type-asserted capability. The Azure
 | `UpdateAzureNATGateway` | UpdateAzureNATGateway re-applies the mutable fields of an existing NAT |
 | `UpdateAzurePublicIP` | UpdateAzurePublicIP overwrites the mutable fields of an existing public IP |
 | `UpsertAzureNSGRule` | UpsertAzureNSGRule creates or replaces a single custom security rule by |
+| `UpsertAzureRoute` | UpsertAzureRoute creates or replaces a single route by name in the route |
 | `UpsertAzureVNetPeering` | UpsertAzureVNetPeering creates or replaces a single virtualNetworkPeerings |
 
 ### AzureNetworkTagReplacer

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -8000,6 +8000,10 @@
             "doc": "DeleteAzureNSGRule removes a single custom security rule by name, leaving"
           },
           {
+            "name": "DeleteAzureRoute",
+            "doc": "DeleteAzureRoute removes a single route by name from the route table with"
+          },
+          {
             "name": "DeleteAzureRouteTableMetadata",
             "doc": "DeleteAzureRouteTableMetadata drops the stored metadata for id (called when"
           },
@@ -8053,6 +8057,10 @@
           {
             "name": "UpsertAzureNSGRule",
             "doc": "UpsertAzureNSGRule creates or replaces a single custom security rule by"
+          },
+          {
+            "name": "UpsertAzureRoute",
+            "doc": "UpsertAzureRoute creates or replaces a single route by name in the route"
           },
           {
             "name": "UpsertAzureVNetPeering",

--- a/providers/azure/vnet/azure_network_metadata.go
+++ b/providers/azure/vnet/azure_network_metadata.go
@@ -173,6 +173,81 @@ func (m *Mock) DeleteAzureRouteTableMetadata(_ context.Context, id string) {
 	m.azureRouteTableMeta.Delete(id)
 }
 
+// UpsertAzureRoute creates or replaces a single route by name via an atomic
+// read-modify-write on the stored route-table metadata, leaving every sibling
+// route (and the table's other fields) untouched — the routes sub-resource
+// CRUD's mutation.
+//
+//nolint:dupl // parallels UpsertAzureNSGRule: the same COW clone-and-mutate-one-subresource shape over a distinct metadata type by design.
+func (m *Mock) UpsertAzureRoute(_ context.Context, id string, route driver.AzureRoute) (driver.AzureRouteTableMetadata, error) {
+	var updated driver.AzureRouteTableMetadata
+
+	ok := m.azureRouteTableMeta.Update(id, func(meta driver.AzureRouteTableMetadata) driver.AzureRouteTableMetadata {
+		routes := append([]driver.AzureRoute(nil), meta.Routes...)
+
+		replaced := false
+
+		for i := range routes {
+			if routes[i].Name == route.Name {
+				routes[i] = route
+				replaced = true
+
+				break
+			}
+		}
+
+		if !replaced {
+			routes = append(routes, route)
+		}
+
+		meta.Routes = routes
+		updated = cloneRouteTableMeta(meta)
+
+		return meta
+	})
+	if !ok {
+		return driver.AzureRouteTableMetadata{}, cerrors.Newf(cerrors.NotFound, "route table %q not found", id)
+	}
+
+	return updated, nil
+}
+
+// DeleteAzureRoute removes a single route by name via an atomic
+// read-modify-write, leaving every sibling route untouched.
+func (m *Mock) DeleteAzureRoute(_ context.Context, id, routeName string) error {
+	routeMissing := false
+
+	ok := m.azureRouteTableMeta.Update(id, func(meta driver.AzureRouteTableMetadata) driver.AzureRouteTableMetadata {
+		idx := -1
+
+		for i := range meta.Routes {
+			if meta.Routes[i].Name == routeName {
+				idx = i
+				break
+			}
+		}
+
+		if idx == -1 {
+			routeMissing = true
+
+			return meta
+		}
+
+		meta.Routes = append(append([]driver.AzureRoute(nil), meta.Routes[:idx]...), meta.Routes[idx+1:]...)
+
+		return meta
+	})
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "route table %q not found", id)
+	}
+
+	if routeMissing {
+		return cerrors.Newf(cerrors.NotFound, "route %q not found", routeName)
+	}
+
+	return nil
+}
+
 // cloneRouteTableMeta deep-copies the route slice and tag map so stored and
 // returned values never alias a caller's slice/map.
 func cloneRouteTableMeta(meta driver.AzureRouteTableMetadata) driver.AzureRouteTableMetadata {
@@ -183,6 +258,11 @@ func cloneRouteTableMeta(meta driver.AzureRouteTableMetadata) driver.AzureRouteT
 
 	if len(meta.Tags) > 0 {
 		out.Tags = copyTags(meta.Tags)
+	}
+
+	if meta.DisableBgpRoutePropagation != nil {
+		v := *meta.DisableBgpRoutePropagation
+		out.DisableBgpRoutePropagation = &v
 	}
 
 	return out

--- a/providers/azure/vnet/azure_network_metadata.go
+++ b/providers/azure/vnet/azure_network_metadata.go
@@ -79,7 +79,7 @@ func (m *Mock) DeleteAzureNSGMetadata(_ context.Context, id string) {
 // name via an atomic read-modify-write on the stored metadata, leaving every
 // sibling rule untouched — the SecurityRules sub-resource CRUD's mutation.
 //
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+//nolint:gocritic,dupl // hugeParam: fixed interface sig; dupl: parallels UpsertAzureRoute's COW clone-one-subresource shape by design.
 func (m *Mock) UpsertAzureNSGRule(_ context.Context, id string, rule driver.AzureNSGRule) (driver.AzureNSGMetadata, error) {
 	var updated driver.AzureNSGMetadata
 

--- a/server/azure/vnet/handler.go
+++ b/server/azure/vnet/handler.go
@@ -107,6 +107,7 @@ const (
 	defaultLoc          = "eastus"
 	subResSubnets       = "subnets"
 	subResSecurityRules = "securityRules"
+	subResRoutes        = "routes"
 	subResVNetPeerings  = "virtualNetworkPeerings"
 	subResCheckIPAvail  = "CheckIPAddressAvailability"
 )
@@ -320,7 +321,7 @@ func (h *Handler) routeSubnet(w http.ResponseWriter, r *http.Request, rp azurear
 	}
 }
 
-//nolint:gocritic // rp is a request-scoped value
+//nolint:gocritic,dupl // rp is request-scoped; per-resource routers are the same method switch over a distinct type by design
 func (h *Handler) routeNSG(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	if rp.ResourceName == "" {
 		h.listNSGs(w, r, rp)

--- a/server/azure/vnet/route_subresource.go
+++ b/server/azure/vnet/route_subresource.go
@@ -1,0 +1,187 @@
+package vnet
+
+import (
+	"context"
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// Microsoft.Network route next-hop types (RouteNextHopType). VirtualApplianceEcmp
+// is intentionally omitted: it requires the nextHop.nextHopIpAddresses ECMP shape
+// that azurerm_route does not model, and is tracked as a build-out gap.
+const (
+	nextHopVirtualNetworkGateway = "VirtualNetworkGateway"
+	nextHopVnetLocal             = "VnetLocal"
+	nextHopInternet              = "Internet"
+	nextHopVirtualAppliance      = "VirtualAppliance"
+	nextHopNone                  = "None"
+)
+
+// routeRoute serves the RoutesClient / azurerm_route sub-resource surface:
+// PUT/GET/DELETE .../routeTables/{rt}/routes/{route} and GET .../routeTables/{rt}/routes
+// (list). Registered from routeRouteTable before any whole-route-table handler
+// sees the request, so a standalone route op mutates only the addressed route and
+// preserves siblings (mirrors routeSecurityRule).
+//
+//nolint:gocritic,dupl // rp is request-scoped; mirrors routeSecurityRule over a distinct sub-resource by design
+func (h *Handler) routeRoute(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.SubResourceName == "" {
+		if r.Method != http.MethodGet {
+			azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+			return
+		}
+
+		h.listRoutes(w, r, rp)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.putRoute(w, r, rp)
+	case http.MethodGet:
+		h.getRoute(w, r, rp)
+	case http.MethodDelete:
+		h.deleteRoute(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listRoutes(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	info, err := h.findRouteTableInGroup(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	rtID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeRouteTable, rp.ResourceName)
+
+	azurearm.WriteJSON(w, http.StatusOK, routeListResponse{Value: fromAzureRoutes(rtID, h.storedRoutes(r.Context(), info.ID))})
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getRoute(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	info, err := h.findRouteTableInGroup(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	rtID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeRouteTable, rp.ResourceName)
+
+	for _, rt := range h.storedRoutes(r.Context(), info.ID) {
+		if rt.Name == rp.SubResourceName {
+			azurearm.WriteJSON(w, http.StatusOK, fromAzureRoutes(rtID, []netdriver.AzureRoute{rt})[0])
+			return
+		}
+	}
+
+	azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "route "+rp.SubResourceName+" not found")
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) putRoute(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	meta, ok := h.azureMeta()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"route tables are not supported by this networking driver")
+
+		return
+	}
+
+	info, err := h.findRouteTableInGroup(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	var body route
+
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	// The URL name is authoritative, matching ARM's PUT-by-name semantics.
+	body.Name = rp.SubResourceName
+
+	rt := toAzureRoutes([]route{body})[0]
+
+	if verr := validateAzureRoute(rt); verr != nil {
+		azurearm.WriteCErr(w, verr)
+		return
+	}
+
+	if _, err := meta.UpsertAzureRoute(r.Context(), info.ID, rt); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	rtID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeRouteTable, rp.ResourceName)
+
+	writeAcceptedAsync(w, r, rp.Subscription, "route-create-"+rp.ResourceName+"-"+rp.SubResourceName,
+		fromAzureRoutes(rtID, []netdriver.AzureRoute{rt})[0])
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteRoute(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	meta, ok := h.azureMeta()
+	if !ok {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"route tables are not supported by this networking driver")
+
+		return
+	}
+
+	info, err := h.findRouteTableInGroup(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if err := meta.DeleteAzureRoute(r.Context(), info.ID, rp.SubResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "route-delete-"+rp.ResourceName+"-"+rp.SubResourceName, nil)
+}
+
+// storedRoutes returns the routes stored for the route table with the given
+// driver id (empty when the driver carries no Azure metadata or the table has
+// none yet).
+func (h *Handler) storedRoutes(ctx context.Context, rtDriverID string) []netdriver.AzureRoute {
+	meta, ok := h.azureMeta()
+	if !ok {
+		return nil
+	}
+
+	md, found := meta.GetAzureRouteTableMetadata(ctx, rtDriverID)
+	if !found {
+		return nil
+	}
+
+	return md.Routes
+}
+
+// validateAzureRoute checks a route the way real ARM does before storing it:
+// nextHopType must be one of the RouteNextHopType values, and a nextHopIpAddress
+// is only accepted when nextHopType is VirtualAppliance.
+func validateAzureRoute(rt netdriver.AzureRoute) error {
+	switch rt.NextHopType {
+	case nextHopVirtualNetworkGateway, nextHopVnetLocal, nextHopInternet, nextHopVirtualAppliance, nextHopNone:
+	default:
+		return cerrors.Newf(cerrors.InvalidArgument, "invalid nextHopType %q", rt.NextHopType)
+	}
+
+	if rt.NextHopIPAddress != "" && rt.NextHopType != nextHopVirtualAppliance {
+		return cerrors.Newf(cerrors.InvalidArgument,
+			"nextHopIpAddress is only allowed when nextHopType is %s", nextHopVirtualAppliance)
+	}
+
+	return nil
+}

--- a/server/azure/vnet/route_subresource_regression_test.go
+++ b/server/azure/vnet/route_subresource_regression_test.go
@@ -1,0 +1,226 @@
+package vnet_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+)
+
+// TestSDKStandaloneRouteSubresource drives the real armnetwork RoutesClient
+// (the azurerm_route resource) through create/get/delete against a route table
+// that already carries an inline route — the standalone route must coexist with
+// the inline one on the whole-table GET, be independently gettable, and DELETE
+// must remove only itself. Guards the sub-resource round-trip fix.
+func TestSDKStandaloneRouteSubresource(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	rtClient, err := armnetwork.NewRouteTablesClient(rtSubID, fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Route table created with one inline route.
+	cp, err := rtClient.BeginCreateOrUpdate(ctx, "rg-1", "rt-sub", armnetwork.RouteTable{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.RouteTablePropertiesFormat{
+			Routes: []*armnetwork.Route{{
+				Name: to.Ptr("inline"),
+				Properties: &armnetwork.RoutePropertiesFormat{
+					AddressPrefix: to.Ptr("10.0.0.0/16"),
+					NextHopType:   to.Ptr(armnetwork.RouteNextHopTypeVnetLocal),
+				},
+			}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("route table create: %v", err)
+	}
+
+	pollDone(t, cp)
+
+	routes, err := armnetwork.NewRoutesClient(rtSubID, fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a standalone route via the sub-resource path.
+	rp, err := routes.BeginCreateOrUpdate(ctx, "rg-1", "rt-sub", "standalone", armnetwork.Route{
+		Properties: &armnetwork.RoutePropertiesFormat{
+			AddressPrefix:    to.Ptr("192.168.0.0/24"),
+			NextHopType:      to.Ptr(armnetwork.RouteNextHopTypeVirtualAppliance),
+			NextHopIPAddress: to.Ptr("10.0.0.4"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("standalone route create: %v", err)
+	}
+
+	pollDone(t, rp)
+
+	// Direct GET of the standalone route round-trips its fields.
+	sg, err := routes.Get(ctx, "rg-1", "rt-sub", "standalone", nil)
+	if err != nil {
+		t.Fatalf("standalone route get: %v", err)
+	}
+
+	if sg.Properties == nil || *sg.Properties.AddressPrefix != "192.168.0.0/24" ||
+		*sg.Properties.NextHopType != armnetwork.RouteNextHopTypeVirtualAppliance ||
+		*sg.Properties.NextHopIPAddress != "10.0.0.4" {
+		t.Fatalf("standalone route round-trip=%+v", sg.Properties)
+	}
+
+	// Whole-table GET shows BOTH the inline and the standalone route.
+	whole, err := rtClient.Get(ctx, "rg-1", "rt-sub", nil)
+	if err != nil {
+		t.Fatalf("route table get: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, r := range whole.Properties.Routes {
+		got[*r.Name] = true
+	}
+
+	if !got["inline"] || !got["standalone"] {
+		t.Fatalf("whole-table routes=%v want inline+standalone", got)
+	}
+
+	// DELETE removes only the standalone route; the inline route survives.
+	dp, err := routes.BeginDelete(ctx, "rg-1", "rt-sub", "standalone", nil)
+	if err != nil {
+		t.Fatalf("standalone route delete: %v", err)
+	}
+
+	pollDone(t, dp)
+
+	after, err := rtClient.Get(ctx, "rg-1", "rt-sub", nil)
+	if err != nil {
+		t.Fatalf("route table get after delete: %v", err)
+	}
+
+	if len(after.Properties.Routes) != 1 || *after.Properties.Routes[0].Name != "inline" {
+		t.Fatalf("after delete routes=%v want [inline]", after.Properties.Routes)
+	}
+}
+
+// TestSDKRouteDisableBgpPropagation guards that disableBgpRoutePropagation is a
+// *bool that round-trips an explicit false (the echo overlay would otherwise
+// swallow the zero value) and survives a tags PATCH.
+func TestSDKRouteDisableBgpPropagation(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	rtClient, err := armnetwork.NewRouteTablesClient(rtSubID, fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{{"rt-bgp-false", false}, {"rt-bgp-true", true}} {
+		cp, cerr := rtClient.BeginCreateOrUpdate(ctx, "rg-1", tc.name, armnetwork.RouteTable{
+			Location: to.Ptr("eastus"),
+			Properties: &armnetwork.RouteTablePropertiesFormat{
+				DisableBgpRoutePropagation: to.Ptr(tc.want),
+			},
+		}, nil)
+		if cerr != nil {
+			t.Fatalf("%s create: %v", tc.name, cerr)
+		}
+
+		pollDone(t, cp)
+
+		got, gerr := rtClient.Get(ctx, "rg-1", tc.name, nil)
+		if gerr != nil {
+			t.Fatalf("%s get: %v", tc.name, gerr)
+		}
+
+		if got.Properties == nil || got.Properties.DisableBgpRoutePropagation == nil ||
+			*got.Properties.DisableBgpRoutePropagation != tc.want {
+			t.Fatalf("%s disableBgpRoutePropagation=%v want %v", tc.name, got.Properties.DisableBgpRoutePropagation, tc.want)
+		}
+
+		// A tags PATCH must preserve the flag.
+		if _, uerr := rtClient.UpdateTags(ctx, "rg-1", tc.name, armnetwork.TagsObject{
+			Tags: map[string]*string{"env": to.Ptr("test")},
+		}, nil); uerr != nil {
+			t.Fatalf("%s update tags: %v", tc.name, uerr)
+		}
+
+		after, aerr := rtClient.Get(ctx, "rg-1", tc.name, nil)
+		if aerr != nil {
+			t.Fatalf("%s get after tags: %v", tc.name, aerr)
+		}
+
+		if after.Properties.DisableBgpRoutePropagation == nil ||
+			*after.Properties.DisableBgpRoutePropagation != tc.want {
+			t.Fatalf("%s disableBgpRoutePropagation after tags=%v want %v",
+				tc.name, after.Properties.DisableBgpRoutePropagation, tc.want)
+		}
+	}
+}
+
+// TestSDKRouteNextHopTypeValidation guards the nextHopType validation on the
+// standalone route path: an unknown next-hop type is rejected, and a
+// nextHopIpAddress is only permitted when the type is VirtualAppliance.
+func TestSDKRouteNextHopTypeValidation(t *testing.T) {
+	ts := newVNetServer(t)
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	rtClient, err := armnetwork.NewRouteTablesClient(rtSubID, fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cp, err := rtClient.BeginCreateOrUpdate(ctx, "rg-1", "rt-valid", armnetwork.RouteTable{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("route table create: %v", err)
+	}
+
+	pollDone(t, cp)
+
+	routes, err := armnetwork.NewRoutesClient(rtSubID, fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		props *armnetwork.RoutePropertiesFormat
+	}{
+		{
+			name: "unknown-next-hop",
+			props: &armnetwork.RoutePropertiesFormat{
+				AddressPrefix: to.Ptr("10.0.0.0/16"),
+				NextHopType:   to.Ptr(armnetwork.RouteNextHopType("BogusHop")),
+			},
+		},
+		{
+			name: "ip-on-non-virtual-appliance",
+			props: &armnetwork.RoutePropertiesFormat{
+				AddressPrefix:    to.Ptr("10.0.0.0/16"),
+				NextHopType:      to.Ptr(armnetwork.RouteNextHopTypeInternet),
+				NextHopIPAddress: to.Ptr("10.0.0.4"),
+			},
+		},
+	} {
+		_, rerr := routes.BeginCreateOrUpdate(ctx, "rg-1", "rt-valid", tc.name, armnetwork.Route{
+			Properties: tc.props,
+		}, nil)
+
+		var respErr *azcore.ResponseError
+		if !errors.As(rerr, &respErr) || respErr.StatusCode != 400 {
+			t.Fatalf("%s: want 400, got %v", tc.name, rerr)
+		}
+	}
+}

--- a/server/azure/vnet/route_table.go
+++ b/server/azure/vnet/route_table.go
@@ -23,6 +23,17 @@ func (h *Handler) routeRouteTable(w http.ResponseWriter, r *http.Request, rp azu
 		return
 	}
 
+	// Route sub-resource (RoutesClient / azurerm_route):
+	// SubResource="routes", SubResourceName="{routeName}". Routed before the
+	// whole-route-table method switch below so a standalone route PUT/GET/DELETE
+	// never hits createRouteTable/getRouteTable/deleteRouteTable, which are scoped
+	// to rp.ResourceName (the route table's own name) — without this a route
+	// DELETE deletes the entire route table and a route PUT wipes its route list.
+	if rp.SubResource == subResRoutes {
+		h.routeRoute(w, r, rp)
+		return
+	}
+
 	switch r.Method {
 	case http.MethodPut:
 		h.createRouteTable(w, r, rp)
@@ -50,6 +61,14 @@ func (h *Handler) createRouteTable(w http.ResponseWriter, r *http.Request, rp az
 		return
 	}
 
+	azRoutes := toAzureRoutes(req.Properties.Routes)
+	for i := range azRoutes {
+		if verr := validateAzureRoute(azRoutes[i]); verr != nil {
+			azurearm.WriteCErr(w, verr)
+			return
+		}
+	}
+
 	info, err := h.upsertRouteTable(r.Context(), rp.ResourceGroup, rp.ResourceName)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
@@ -63,9 +82,10 @@ func (h *Handler) createRouteTable(w http.ResponseWriter, r *http.Request, rp az
 
 	if meta, ok := h.azureMeta(); ok {
 		_ = meta.PutAzureRouteTableMetadata(r.Context(), info.ID, netdriver.AzureRouteTableMetadata{
-			Location: loc,
-			Routes:   toAzureRoutes(req.Properties.Routes),
-			Tags:     req.Tags,
+			Location:                   loc,
+			Routes:                     azRoutes,
+			Tags:                       req.Tags,
+			DisableBgpRoutePropagation: req.Properties.DisableBgpRoutePropagation,
 		})
 	}
 
@@ -247,8 +267,9 @@ func (h *Handler) routeTableResponse(ctx context.Context, info *netdriver.RouteT
 	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeRouteTable, rp.ResourceName)
 
 	var (
-		routes []route
-		tags   map[string]string
+		routes     []route
+		tags       map[string]string
+		disableBGP bool
 	)
 
 	if meta, ok := h.azureMeta(); ok {
@@ -259,6 +280,10 @@ func (h *Handler) routeTableResponse(ctx context.Context, info *netdriver.RouteT
 
 			routes = fromAzureRoutes(id, md.Routes)
 			tags = md.Tags
+
+			if md.DisableBgpRoutePropagation != nil {
+				disableBGP = *md.DisableBgpRoutePropagation
+			}
 		}
 	}
 
@@ -274,9 +299,10 @@ func (h *Handler) routeTableResponse(ctx context.Context, info *netdriver.RouteT
 		Etag:     etagOf(id),
 		Tags:     tags,
 		Properties: routeTableResponseProps{
-			ProvisioningState: provisioningSucceeded,
-			Routes:            routes,
-			Subnets:           h.routeTableAssociatedSubnets(ctx, id),
+			ProvisioningState:          provisioningSucceeded,
+			DisableBgpRoutePropagation: disableBGP,
+			Routes:                     routes,
+			Subnets:                    h.routeTableAssociatedSubnets(ctx, id),
 		},
 	}
 }

--- a/server/azure/vnet/types.go
+++ b/server/azure/vnet/types.go
@@ -288,6 +288,9 @@ type routeTableRequest struct {
 
 type routeTableRequestProps struct {
 	Routes []route `json:"routes,omitempty"`
+	// DisableBgpRoutePropagation is a pointer so an explicit false is preserved
+	// distinctly from an omitted field (azurerm always sends it, default false).
+	DisableBgpRoutePropagation *bool `json:"disableBgpRoutePropagation,omitempty"`
 }
 
 type route struct {
@@ -314,8 +317,9 @@ type routeTableResponse struct {
 }
 
 type routeTableResponseProps struct {
-	ProvisioningState string  `json:"provisioningState"`
-	Routes            []route `json:"routes"`
+	ProvisioningState          string  `json:"provisioningState"`
+	DisableBgpRoutePropagation bool    `json:"disableBgpRoutePropagation"`
+	Routes                     []route `json:"routes"`
 	// Subnets is the read-only back-reference real ARM reports on a routeTables
 	// GET once the route table is associated with a subnet (mirrors
 	// nsgResponseProps.Subnets).
@@ -324,4 +328,8 @@ type routeTableResponseProps struct {
 
 type routeTableListResponse struct {
 	Value []routeTableResponse `json:"value"`
+}
+
+type routeListResponse struct {
+	Value []route `json:"value"`
 }

--- a/services/networking/driver/azure_network_metadata.go
+++ b/services/networking/driver/azure_network_metadata.go
@@ -96,6 +96,11 @@ type AzureRouteTableMetadata struct {
 	Location string
 	Routes   []AzureRoute
 	Tags     map[string]string
+	// DisableBgpRoutePropagation is Microsoft.Network's
+	// disableBgpRoutePropagation flag (default false). Kept as a pointer so an
+	// explicit false round-trips distinctly from "unset" and a repeat PUT that
+	// omits it does not silently flip the stored value.
+	DisableBgpRoutePropagation *bool
 }
 
 // Azure virtual-network peering states, matching Microsoft.Network's
@@ -192,6 +197,17 @@ type AzureNetworkMetadata interface {
 	// DeleteAzureRouteTableMetadata drops the stored metadata for id (called when
 	// the route table is deleted).
 	DeleteAzureRouteTableMetadata(ctx context.Context, id string)
+	// UpsertAzureRoute creates or replaces a single route by name in the route
+	// table with the given driver id, via an atomic read-modify-write on the
+	// stored metadata that leaves every sibling route (and the table's other
+	// fields) untouched — the routes sub-resource CRUD's (azurerm_route)
+	// mutation. Returns NotFound when no route table has that id.
+	UpsertAzureRoute(ctx context.Context, id string, route AzureRoute) (AzureRouteTableMetadata, error)
+	// DeleteAzureRoute removes a single route by name from the route table with
+	// the given driver id via an atomic read-modify-write, leaving every sibling
+	// route untouched. Returns NotFound when the route table or the route is
+	// missing.
+	DeleteAzureRoute(ctx context.Context, id, routeName string) error
 
 	// UpdateAzureNATGateway re-applies the mutable fields of an existing NAT
 	// gateway (its bound public-IP allocation and tags), keyed by its id, so a


### PR DESCRIPTION
## Summary

Real-user e2e audit of Azure Route Table (Microsoft.Network/routeTables). Found and fixed control-plane divergences that cause `azurerm_route_table` / `azurerm_route` drift.

## Findings (fixed)

| Sev | Divergence | Fix |
|-----|-----------|-----|
| High | Standalone `azurerm_route` (SecurityRulesClient-style separate resource) had no handler — a route created via the standalone `Routes` client was lost from the whole-route-table GET → drift | New `route_subresource.go`: put/get/delete/list route handlers that update the parent route table's route list (mirrors the NSG securityRules sub-resource pattern) |
| High | `disableBgpRoutePropagation` (explicit false) dropped on read — the properties-only echo overlay can't represent an explicit zero | Modeled as `*bool`; explicit false round-trips |
| Med | `nextHopType` unvalidated + `nextHopIpAddress` accepted for non-VirtualAppliance hops | `validateAzureRoute`: nextHopType must be a valid RouteNextHopType; nextHopIpAddress only when VirtualAppliance |

## Verification

Real `armnetwork` RouteTables + Routes clients + raw ARM against a live `serve`: inline routes + standalone `azurerm_route` round-trip (name/address_prefix/next_hop_type/next_hop_in_ip_address); `disable_bgp_route_propagation` explicit-false round-trips; per-route + table provisioningState Succeeded (no LRO hang). (azurerm Terraform not run — documented macOS SSL_CERT_FILE cert-distrust; the armnetwork SDK exercises the identical wire path.)

## Gates

`go build ./...`, `go test -race` (providers/azure/vnet + services/networking), full `server/azure` suite (echo overlay, since a field was modeled), root, persist, `go vet`, `gofmt`, `golangci-lint --new-from-rev` (0 net-new), `go generate` (docs/coverage/azure/vnet.md regenerated) — all green.