### PR TITLE
fix(glue): real-user e2e divergences from AWS Glue

### DIFF
--- a/server/aws/glue/sdk_roundtrip_test.go
+++ b/server/aws/glue/sdk_roundtrip_test.go
@@ -105,6 +105,34 @@ func TestSDKDatabaseTablePartitionCRUD(t *testing.T) {
 	}
 }
 
+func TestSDKDatabaseLocationUriRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	c := newGlueClient(t)
+
+	const loc = "s3://mybucket/db/"
+
+	_, err := c.CreateDatabase(ctx, &awsglue.CreateDatabaseInput{
+		DatabaseInput: &gluetypes.DatabaseInput{
+			Name:        aws.String("located"),
+			LocationUri: aws.String(loc),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateDatabase: %v", err)
+	}
+
+	getDB, err := c.GetDatabase(ctx, &awsglue.GetDatabaseInput{Name: aws.String("located")})
+	if err != nil {
+		t.Fatalf("GetDatabase: %v", err)
+	}
+
+	// The Glue wire key is "LocationUri"; a mismatched key (e.g. "LocationURI")
+	// leaves the SDK's LocationUri nil and drives Terraform into perpetual drift.
+	if got := aws.ToString(getDB.Database.LocationUri); got != loc {
+		t.Fatalf("LocationUri = %q, want %q", got, loc)
+	}
+}
+
 func TestSDKDuplicateDatabaseTypedError(t *testing.T) {
 	ctx := context.Background()
 	c := newGlueClient(t)

--- a/server/aws/glue/types.go
+++ b/server/aws/glue/types.go
@@ -141,7 +141,7 @@ type errorDetailJSON struct {
 type databaseInputJSON struct {
 	Name        string            `json:"Name"`
 	Description string            `json:"Description,omitempty"`
-	LocationURI string            `json:"LocationURI,omitempty"`
+	LocationURI string            `json:"LocationUri,omitempty"`
 	Parameters  map[string]string `json:"Parameters,omitempty"`
 }
 
@@ -149,7 +149,7 @@ type databaseJSON struct {
 	CatalogID   string            `json:"CatalogId,omitempty"`
 	Name        string            `json:"Name"`
 	Description string            `json:"Description,omitempty"`
-	LocationURI string            `json:"LocationURI,omitempty"`
+	LocationURI string            `json:"LocationUri,omitempty"`
 	Parameters  map[string]string `json:"Parameters,omitempty"`
 	CreateTime  *float64          `json:"CreateTime,omitempty"`
 }


### PR DESCRIPTION
## Summary

Deep real-user e2e re-audit of AWS Glue (`aws_glue_catalog_database`, `aws_glue_catalog_table`, `aws_glue_crawler`, `aws_glue_job`) exercised through the standalone `serve` wire server with the real `aws-sdk-go-v2` client, the `aws glue` CLI, and Terraform (hashicorp/aws v5).

One genuine divergence was found and fixed:

### Database `LocationUri` wire-key mismatch → Terraform perpetual drift
`GetDatabase`/`GetDatabases` serialized the database location under the JSON key `LocationURI`, but the Glue wire shape and the aws-sdk-go-v2 / botocore deserializers match `LocationUri` case-sensitively. The mismatched key was silently dropped on decode, so `location_uri` round-tripped as empty:

- **RED (before):** `aws glue get-database` returned no `LocationUri` field even though it was set on create.
- **GREEN (after):** the key is emitted correctly; `location_uri` survives create → get, and `terraform plan` reports no changes.

The create/update path was unaffected (Go's decoder matches incoming keys case-insensitively), so the bug only surfaced on read.

## Evidence
- Terraform full lifecycle for all 4 resources: create → `plan` (no drift) → update → `plan` (no drift) → destroy, all clean.
- Real SDK + CLI round-trips of Table StorageDescriptor/Columns/PartitionKeys, Job Command/DefaultArguments/defaults (Timeout 2880, GlueVersion), Crawler Targets/Schedule/SchemaChangePolicy/State READY — all correct.
- Error-code fidelity verified: EntityNotFoundException / AlreadyExistsException with no internal error-prefix leak.

## Tests
- Added `TestSDKDatabaseLocationUriRoundTrips` guarding the wire key through the real SDK.

## Gates
`go build ./...`, `go test -race` (server/aws/glue, providers/aws/glue), `go vet`, `gofmt -l`, `golangci-lint` (0 issues), and `go generate` (no docs/coverage drift) all green.