### PR TITLE
fix(gcp-firestore): real-user e2e divergences from Firestore Admin

### DIFF
--- a/server/gcp/firestore/admin.go
+++ b/server/gcp/firestore/admin.go
@@ -46,9 +46,12 @@ const (
 	segOperations       = "operations"
 )
 
-// versionRetentionDefault is the retention window a database reports when
-// point-in-time recovery is disabled (1 hour), matching real Firestore.
-const versionRetentionDefault = "3600s"
+// Version-retention windows a database reports, in seconds: 7 days when
+// point-in-time recovery is enabled, otherwise 1 hour, matching real Firestore.
+const (
+	retentionDisabledSeconds = 3600
+	retentionEnabledSeconds  = 604800
+)
 
 // dbRecord is the stored metadata for one Firestore database. It carries only
 // admin-plane configuration; document data lives in the separate data-plane

--- a/server/gcp/firestore/admin_sdk_test.go
+++ b/server/gcp/firestore/admin_sdk_test.go
@@ -163,6 +163,66 @@ func patchDeleteProtection(t *testing.T, client *admin.FirestoreAdminClient, sta
 	}
 }
 
+// TestSDKFirestoreAdminVersionRetention verifies the output-only retention
+// fields track point-in-time recovery: 1 hour by default and 7 days once PITR is
+// enabled, with earliestVersionTime never before createTime (matching real
+// Firestore).
+func TestSDKFirestoreAdminVersionRetention(t *testing.T) {
+	_, client := newAdminTestServer(t)
+	ctx := context.Background()
+
+	const (
+		oneHourSecs  = 3600
+		sevenDaySecs = 604800
+	)
+
+	// PITR disabled -> 1 hour.
+	op, err := client.CreateDatabase(ctx, &adminpb.CreateDatabaseRequest{
+		Parent: "projects/rp", DatabaseId: "off",
+		Database: &adminpb.Database{Type: adminpb.Database_FIRESTORE_NATIVE, LocationId: "nam5"},
+	})
+	if err != nil {
+		t.Fatalf("CreateDatabase: %v", err)
+	}
+
+	off, err := op.Wait(ctx)
+	if err != nil {
+		t.Fatalf("CreateDatabase Wait: %v", err)
+	}
+
+	if got := off.GetVersionRetentionPeriod().GetSeconds(); got != oneHourSecs {
+		t.Errorf("PITR-disabled versionRetentionPeriod=%ds want %ds", got, oneHourSecs)
+	}
+
+	// earliestVersionTime must not precede createTime.
+	if off.GetEarliestVersionTime().AsTime().Before(off.GetCreateTime().AsTime()) {
+		t.Errorf("earliestVersionTime %v before createTime %v",
+			off.GetEarliestVersionTime().AsTime(), off.GetCreateTime().AsTime())
+	}
+
+	// PITR enabled -> 7 days.
+	op2, err := client.CreateDatabase(ctx, &adminpb.CreateDatabaseRequest{
+		Parent: "projects/rp", DatabaseId: "on",
+		Database: &adminpb.Database{
+			Type:                          adminpb.Database_FIRESTORE_NATIVE,
+			LocationId:                    "nam5",
+			PointInTimeRecoveryEnablement: adminpb.Database_POINT_IN_TIME_RECOVERY_ENABLED,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateDatabase: %v", err)
+	}
+
+	on, err := op2.Wait(ctx)
+	if err != nil {
+		t.Fatalf("CreateDatabase Wait: %v", err)
+	}
+
+	if got := on.GetVersionRetentionPeriod().GetSeconds(); got != sevenDaySecs {
+		t.Errorf("PITR-enabled versionRetentionPeriod=%ds want %ds", got, sevenDaySecs)
+	}
+}
+
 // TestSDKFirestoreAdminAndDataPlaneCoexist proves the routing disambiguation:
 // admin database ops and data-plane document ops both work on the SAME server.
 func TestSDKFirestoreAdminAndDataPlaneCoexist(t *testing.T) {

--- a/server/gcp/firestore/admin_types.go
+++ b/server/gcp/firestore/admin_types.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"strconv"
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -161,9 +162,29 @@ func assignEnums(rec *dbRecord, body map[string]any) error {
 	return nil
 }
 
+// versionRetention returns the version-retention window a database reports (7
+// days when point-in-time recovery is enabled, otherwise 1 hour) together with
+// the earliest readable version time (now - retention, but never before the
+// database was created), matching real Firestore's output-only fields.
+func versionRetention(rec *dbRecord) (string, time.Time) {
+	secs := retentionDisabledSeconds
+	if rec.pointInTimeRecovery == pitrEnabled {
+		secs = retentionEnabledSeconds
+	}
+
+	earliest := time.Now().UTC().Add(-time.Duration(secs) * time.Second)
+	if earliest.Before(rec.createTime) {
+		earliest = rec.createTime
+	}
+
+	return strconv.Itoa(secs) + "s", earliest
+}
+
 // renderDatabase builds the JSON map for a Database resource, emitting enums as
 // their canonical string names.
 func renderDatabase(rec *dbRecord) map[string]any {
+	retentionPeriod, earliest := versionRetention(rec)
+
 	return map[string]any{
 		"name":                          dbKey(rec.project, rec.databaseID),
 		"uid":                           rec.uid,
@@ -173,8 +194,8 @@ func renderDatabase(rec *dbRecord) map[string]any {
 		"pointInTimeRecoveryEnablement": rec.pointInTimeRecovery,
 		"deleteProtectionState":         rec.deleteProtection,
 		"locationId":                    rec.locationID,
-		"versionRetentionPeriod":        versionRetentionDefault,
-		"earliestVersionTime":           rec.updateTime.Format(time.RFC3339Nano),
+		"versionRetentionPeriod":        retentionPeriod,
+		"earliestVersionTime":           earliest.Format(time.RFC3339Nano),
 		"createTime":                    rec.createTime.Format(time.RFC3339Nano),
 		"updateTime":                    rec.updateTime.Format(time.RFC3339Nano),
 		"etag":                          rec.etag,


### PR DESCRIPTION
## Summary

Real-user e2e audit of the GCP Firestore **Admin/control plane** (projects.databases + collectionGroups.indexes) against the real `hashicorp/google` Terraform provider and the GAPIC admin REST client. The databases + indexes surface is already solid; this fixes one genuine cloud-vs-emulator divergence found during the sweep.

## Divergence fixed
`GetDatabase`/`ListDatabases` reported `versionRetentionPeriod` as a hardcoded `3600s` regardless of point-in-time recovery, and `earliestVersionTime` echoed `updateTime`.

Real Firestore (per the projects.databases REST reference): `versionRetentionPeriod` is **7 days (604800s) when PITR is enabled**, 1 hour otherwise; `earliestVersionTime` is **now - versionRetentionPeriod** (output-only). These are surfaced to SDK/gcloud readers.

Now computed from the database's PITR state, with `earliestVersionTime` clamped to never precede `createTime`.

## Verification
- Live `cloudemu serve` + real Terraform google provider v6: create `google_firestore_database` + `google_firestore_index` -> LROs resolve; `terraform plan` shows **no drift**; in-place update via `?updateMask=` + LRO; delete-protection guard surfaces the real FailedPrecondition; full destroy clean.
- curl edge cases: integer-enum (GAPIC `enum-encoding=int`) normalized and echoed as canonical strings; 409/404 status fidelity; `(default)` database id; LRO `metadata.index`.
- Added `TestSDKFirestoreAdminVersionRetention` (GAPIC admin REST client) asserting 1h/7d retention and the createTime clamp.

## Gates
go build ./... · go test -race (server/gcp/firestore, providers/gcp/firestore) · go vet · gofmt · golangci-lint --new-from-rev = 0 new issues · go generate (no docs/coverage delta — admin plane is wire-only).

## Follow-up (filed, not in this PR)
`google_firestore_field` (projects.databases.collectionGroups.fields — single-field index config + TTL) is unbuilt; `parseIndexPath` defers it. Spec filed to backlog.