### PR TITLE
fix(redshift): real-user e2e divergences from AWS Redshift

### DIFF
--- a/providers/aws/redshift/redshift.go
+++ b/providers/aws/redshift/redshift.go
@@ -29,6 +29,19 @@ const (
 	defaultEngine   = "redshift"
 	defaultPort     = 5439
 	singleNodeCount = 1
+	// defaultDatabaseName is the initial database Redshift creates when
+	// CreateCluster omits DBName (AWS: "a database named dev was created by
+	// default"). DescribeClusters returns it for the life of the cluster.
+	defaultDatabaseName = "dev"
+	// defaultSnapshotRetentionDays is the AutomatedSnapshotRetentionPeriod AWS
+	// assigns when CreateCluster omits it; it matches the Terraform
+	// aws_redshift_cluster schema default, so an unset value never drifts.
+	defaultSnapshotRetentionDays = 1
+	// defaultMaintenanceWindow is a deterministic weekly UTC window used when
+	// CreateCluster omits PreferredMaintenanceWindow (real Redshift assigns a
+	// random one). Terraform's preferred_maintenance_window is computed, so any
+	// stable valid window is drift-free.
+	defaultMaintenanceWindow = "sat:05:30-sat:06:00"
 	// defaultKMSKeyAlias is the account-default Redshift KMS key real AWS fills in
 	// when a cluster is created encrypted without an explicit KmsKeyId.
 	defaultKMSKeyAlias = "alias/aws/redshift"
@@ -573,27 +586,39 @@ func (m *Mock) reserveCluster(cfg rdbdriver.ClusterConfig) (rdbdriver.Cluster, e
 		parameterGroup = defaultParameterGroupName
 	}
 
+	databaseName := cfg.DatabaseName
+	if databaseName == "" {
+		databaseName = defaultDatabaseName
+	}
+
+	maintenanceWindow := cfg.PreferredMaintenanceWindow
+	if maintenanceWindow == "" {
+		maintenanceWindow = defaultMaintenanceWindow
+	}
+
 	cluster := rdbdriver.Cluster{
-		ID:                          cfg.ID,
-		ARN:                         clusterARN(m.opts.Region, m.opts.AccountID, cfg.ID),
-		Engine:                      engine,
-		EngineVersion:               cfg.EngineVersion,
-		MasterUsername:              cfg.MasterUsername,
-		DatabaseName:                cfg.DatabaseName,
-		Endpoint:                    endpointFor(cfg.ID),
-		Port:                        port,
-		State:                       rdbdriver.StateAvailable,
-		VPCSecurityGroups:           append([]string(nil), cfg.VPCSecurityGroups...),
-		SubnetGroupName:             cfg.SubnetGroupName,
-		DBClusterParameterGroupName: parameterGroup,
-		NodeType:                    cfg.NodeType,
-		NumberOfNodes:               numberOfNodes,
-		Encrypted:                   cfg.Encrypted,
-		KmsKeyID:                    resolveKMSKeyID(cfg.Encrypted, cfg.KmsKeyID),
-		PubliclyAccessible:          cfg.PubliclyAccessible,
-		AvailabilityZone:            cfg.AvailabilityZone,
-		CreatedAt:                   m.opts.Clock.Now().UTC(),
-		Tags:                        copyTags(cfg.Tags),
+		ID:                               cfg.ID,
+		ARN:                              clusterARN(m.opts.Region, m.opts.AccountID, cfg.ID),
+		Engine:                           engine,
+		EngineVersion:                    cfg.EngineVersion,
+		MasterUsername:                   cfg.MasterUsername,
+		DatabaseName:                     databaseName,
+		Endpoint:                         endpointFor(cfg.ID),
+		Port:                             port,
+		State:                            rdbdriver.StateAvailable,
+		VPCSecurityGroups:                append([]string(nil), cfg.VPCSecurityGroups...),
+		SubnetGroupName:                  cfg.SubnetGroupName,
+		DBClusterParameterGroupName:      parameterGroup,
+		NodeType:                         cfg.NodeType,
+		NumberOfNodes:                    numberOfNodes,
+		Encrypted:                        cfg.Encrypted,
+		KmsKeyID:                         resolveKMSKeyID(cfg.Encrypted, cfg.KmsKeyID),
+		PubliclyAccessible:               cfg.PubliclyAccessible,
+		AvailabilityZone:                 cfg.AvailabilityZone,
+		AutomatedSnapshotRetentionPeriod: cfg.AutomatedSnapshotRetentionPeriod,
+		PreferredMaintenanceWindow:       maintenanceWindow,
+		CreatedAt:                        m.opts.Clock.Now().UTC(),
+		Tags:                             copyTags(cfg.Tags),
 	}
 
 	m.clusters.Set(cfg.ID, cluster)
@@ -712,6 +737,16 @@ func (m *Mock) ModifyCluster(
 	}
 
 	applyResize(&cluster, &input)
+
+	if input.PreferredMaintenanceWindow != "" {
+		cluster.PreferredMaintenanceWindow = input.PreferredMaintenanceWindow
+	}
+
+	// Retention is a pointer so a modify that sets it to 0 (disable automated
+	// snapshots) is distinguished from a modify that leaves it unchanged.
+	if input.AutomatedSnapshotRetentionPeriod != nil {
+		cluster.AutomatedSnapshotRetentionPeriod = *input.AutomatedSnapshotRetentionPeriod
+	}
 
 	if input.Tags != nil {
 		cluster.Tags = copyTags(input.Tags)
@@ -1032,23 +1067,30 @@ func (m *Mock) RestoreClusterFromSnapshot(
 		numberOfNodes = singleNodeCount
 	}
 
+	databaseName := snap.DatabaseName
+	if databaseName == "" {
+		databaseName = defaultDatabaseName
+	}
+
 	cluster := rdbdriver.Cluster{
-		ID:                          input.NewClusterID,
-		ARN:                         clusterARN(m.opts.Region, m.opts.AccountID, input.NewClusterID),
-		Engine:                      snap.Engine,
-		EngineVersion:               snap.EngineVersion,
-		MasterUsername:              snap.MasterUsername,
-		DatabaseName:                snap.DatabaseName,
-		Endpoint:                    endpointFor(input.NewClusterID),
-		Port:                        defaultPort,
-		State:                       rdbdriver.StateAvailable,
-		DBClusterParameterGroupName: defaultParameterGroupName,
-		NodeType:                    snap.NodeType,
-		NumberOfNodes:               numberOfNodes,
-		Encrypted:                   snap.Encrypted,
-		KmsKeyID:                    restoredKMSKeyID(snap.Encrypted, snap.KmsKeyID, input.KmsKeyID),
-		CreatedAt:                   now,
-		Tags:                        copyTags(input.Tags),
+		ID:                               input.NewClusterID,
+		ARN:                              clusterARN(m.opts.Region, m.opts.AccountID, input.NewClusterID),
+		Engine:                           snap.Engine,
+		EngineVersion:                    snap.EngineVersion,
+		MasterUsername:                   snap.MasterUsername,
+		DatabaseName:                     databaseName,
+		Endpoint:                         endpointFor(input.NewClusterID),
+		Port:                             defaultPort,
+		State:                            rdbdriver.StateAvailable,
+		DBClusterParameterGroupName:      defaultParameterGroupName,
+		NodeType:                         snap.NodeType,
+		NumberOfNodes:                    numberOfNodes,
+		Encrypted:                        snap.Encrypted,
+		KmsKeyID:                         restoredKMSKeyID(snap.Encrypted, snap.KmsKeyID, input.KmsKeyID),
+		AutomatedSnapshotRetentionPeriod: defaultSnapshotRetentionDays,
+		PreferredMaintenanceWindow:       defaultMaintenanceWindow,
+		CreatedAt:                        now,
+		Tags:                             copyTags(input.Tags),
 	}
 
 	m.clusters.Set(input.NewClusterID, cluster)

--- a/server/aws/redshift/cluster_resize_sdk_roundtrip_test.go
+++ b/server/aws/redshift/cluster_resize_sdk_roundtrip_test.go
@@ -150,6 +150,41 @@ func TestSDKRedshiftDefaultRetentionAndDBName(t *testing.T) {
 	}
 }
 
+// TestSDKRedshiftExplicitZeroRetention proves an explicit
+// AutomatedSnapshotRetentionPeriod of 0 (which disables automated snapshots) is
+// preserved as 0 rather than collapsed to the default of 1. A presence-check
+// (not a zero-value check) is required so Terraform's non-computed schema
+// default does not drift a user who deliberately disabled snapshots.
+func TestSDKRedshiftExplicitZeroRetention(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:                aws.String("nosnap"),
+		MasterUsername:                   aws.String("admin"),
+		MasterUserPassword:               aws.String("Sup3rSecret!"),
+		NodeType:                         aws.String("dc2.large"),
+		AutomatedSnapshotRetentionPeriod: aws.Int32(0),
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if got := aws.ToInt32(out.Cluster.AutomatedSnapshotRetentionPeriod); got != 0 {
+		t.Fatalf("create AutomatedSnapshotRetentionPeriod=%d, want 0 (explicit disable)", got)
+	}
+
+	desc, err := client.DescribeClusters(ctx, &awsredshift.DescribeClustersInput{
+		ClusterIdentifier: aws.String("nosnap"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeClusters: %v", err)
+	}
+	if got := aws.ToInt32(desc.Clusters[0].AutomatedSnapshotRetentionPeriod); got != 0 {
+		t.Fatalf("describe AutomatedSnapshotRetentionPeriod=%d, want 0 (explicit disable)", got)
+	}
+}
+
 // TestSDKRedshiftModifyClusterSingleNode proves ClusterType single-node forces
 // NumberOfNodes to 1 on resize.
 func TestSDKRedshiftModifyClusterSingleNode(t *testing.T) {

--- a/server/aws/redshift/cluster_resize_sdk_roundtrip_test.go
+++ b/server/aws/redshift/cluster_resize_sdk_roundtrip_test.go
@@ -54,6 +54,102 @@ func TestSDKRedshiftModifyClusterResize(t *testing.T) {
 	}
 }
 
+// TestSDKRedshiftRetentionAndMaintenanceRoundTrip proves a user-set
+// AutomatedSnapshotRetentionPeriod and PreferredMaintenanceWindow round-trip
+// through create → describe and a later modify, rather than always reporting
+// the create-time default. Terraform's aws_redshift_cluster reads both back
+// (retention has a non-computed schema default of 1, the window is computed),
+// so a value that is not stored drifts on the next plan.
+func TestSDKRedshiftRetentionAndMaintenanceRoundTrip(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	// Create with explicit non-default values.
+	out, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:                aws.String("retain"),
+		MasterUsername:                   aws.String("admin"),
+		MasterUserPassword:               aws.String("Sup3rSecret!"),
+		NodeType:                         aws.String("dc2.large"),
+		AutomatedSnapshotRetentionPeriod: aws.Int32(7),
+		PreferredMaintenanceWindow:       aws.String("wed:03:00-wed:03:30"),
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if got := aws.ToInt32(out.Cluster.AutomatedSnapshotRetentionPeriod); got != 7 {
+		t.Fatalf("create AutomatedSnapshotRetentionPeriod=%d, want 7", got)
+	}
+	if got := aws.ToString(out.Cluster.PreferredMaintenanceWindow); got != "wed:03:00-wed:03:30" {
+		t.Fatalf("create PreferredMaintenanceWindow=%q, want wed:03:00-wed:03:30", got)
+	}
+
+	// Describe must reflect the same stored values (no drift).
+	desc, err := client.DescribeClusters(ctx, &awsredshift.DescribeClustersInput{
+		ClusterIdentifier: aws.String("retain"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeClusters: %v", err)
+	}
+	if got := aws.ToInt32(desc.Clusters[0].AutomatedSnapshotRetentionPeriod); got != 7 {
+		t.Fatalf("describe AutomatedSnapshotRetentionPeriod=%d, want 7", got)
+	}
+	if got := aws.ToString(desc.Clusters[0].PreferredMaintenanceWindow); got != "wed:03:00-wed:03:30" {
+		t.Fatalf("describe PreferredMaintenanceWindow=%q, want wed:03:00-wed:03:30", got)
+	}
+
+	// Modify both, and confirm the change is applied and persisted.
+	if _, err := client.ModifyCluster(ctx, &awsredshift.ModifyClusterInput{
+		ClusterIdentifier:                aws.String("retain"),
+		AutomatedSnapshotRetentionPeriod: aws.Int32(14),
+		PreferredMaintenanceWindow:       aws.String("mon:01:00-mon:01:30"),
+	}); err != nil {
+		t.Fatalf("ModifyCluster: %v", err)
+	}
+
+	desc, err = client.DescribeClusters(ctx, &awsredshift.DescribeClustersInput{
+		ClusterIdentifier: aws.String("retain"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeClusters after modify: %v", err)
+	}
+	if got := aws.ToInt32(desc.Clusters[0].AutomatedSnapshotRetentionPeriod); got != 14 {
+		t.Fatalf("after modify AutomatedSnapshotRetentionPeriod=%d, want 14", got)
+	}
+	if got := aws.ToString(desc.Clusters[0].PreferredMaintenanceWindow); got != "mon:01:00-mon:01:30" {
+		t.Fatalf("after modify PreferredMaintenanceWindow=%q, want mon:01:00-mon:01:30", got)
+	}
+}
+
+// TestSDKRedshiftDefaultRetentionAndDBName proves a create that omits
+// AutomatedSnapshotRetentionPeriod and DBName reports the AWS defaults
+// (retention 1, database "dev"), matching the Terraform schema so an
+// unconfigured cluster does not drift.
+func TestSDKRedshiftDefaultRetentionAndDBName(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateCluster(ctx, &awsredshift.CreateClusterInput{
+		ClusterIdentifier:  aws.String("defaults"),
+		MasterUsername:     aws.String("admin"),
+		MasterUserPassword: aws.String("Sup3rSecret!"),
+		NodeType:           aws.String("dc2.large"),
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if got := aws.ToInt32(out.Cluster.AutomatedSnapshotRetentionPeriod); got != 1 {
+		t.Fatalf("default AutomatedSnapshotRetentionPeriod=%d, want 1", got)
+	}
+	if got := aws.ToString(out.Cluster.DBName); got != "dev" {
+		t.Fatalf("default DBName=%q, want dev", got)
+	}
+	if aws.ToString(out.Cluster.PreferredMaintenanceWindow) == "" {
+		t.Fatal("default PreferredMaintenanceWindow is empty, want an assigned window")
+	}
+}
+
 // TestSDKRedshiftModifyClusterSingleNode proves ClusterType single-node forces
 // NumberOfNodes to 1 on resize.
 func TestSDKRedshiftModifyClusterSingleNode(t *testing.T) {

--- a/server/aws/redshift/operations.go
+++ b/server/aws/redshift/operations.go
@@ -22,25 +22,40 @@ const (
 
 // clusterConfigFromForm pulls the relevant Cluster fields out of a form. Used
 // by CreateCluster.
+// defaultAutomatedSnapshotRetention is the AutomatedSnapshotRetentionPeriod
+// Redshift assigns when CreateCluster omits it. It matches the provider and the
+// Terraform aws_redshift_cluster schema default so an unset value never drifts.
+const defaultAutomatedSnapshotRetention = 1
+
 func clusterConfigFromForm(form url.Values) rdbdriver.ClusterConfig {
+	// AutomatedSnapshotRetentionPeriod defaults to 1 only when the client omits
+	// it; an explicit "0" (disable automated snapshots) is preserved, so presence
+	// is checked rather than treating 0 as "unset".
+	retention := defaultAutomatedSnapshotRetention
+	if form.Has("AutomatedSnapshotRetentionPeriod") {
+		retention = formInt(form.Get("AutomatedSnapshotRetentionPeriod"))
+	}
+
 	return rdbdriver.ClusterConfig{
-		ID:                          form.Get("ClusterIdentifier"),
-		Engine:                      "redshift",
-		EngineVersion:               form.Get("ClusterVersion"),
-		MasterUsername:              form.Get("MasterUsername"),
-		MasterUserPassword:          form.Get("MasterUserPassword"),
-		DatabaseName:                form.Get("DBName"),
-		Port:                        formInt(form.Get("Port")),
-		VPCSecurityGroups:           awsquery.ListStrings(form, "VpcSecurityGroupIds.VpcSecurityGroupId"),
-		SubnetGroupName:             form.Get("ClusterSubnetGroupName"),
-		DBClusterParameterGroupName: form.Get("ClusterParameterGroupName"),
-		NodeType:                    form.Get("NodeType"),
-		NumberOfNodes:               formInt(form.Get("NumberOfNodes")),
-		Encrypted:                   formBool(form.Get("Encrypted")),
-		KmsKeyID:                    form.Get("KmsKeyId"),
-		PubliclyAccessible:          formBool(form.Get("PubliclyAccessible")),
-		AvailabilityZone:            form.Get("AvailabilityZone"),
-		Tags:                        parseRedshiftTags(form),
+		ID:                               form.Get("ClusterIdentifier"),
+		Engine:                           "redshift",
+		EngineVersion:                    form.Get("ClusterVersion"),
+		MasterUsername:                   form.Get("MasterUsername"),
+		MasterUserPassword:               form.Get("MasterUserPassword"),
+		DatabaseName:                     form.Get("DBName"),
+		Port:                             formInt(form.Get("Port")),
+		VPCSecurityGroups:                awsquery.ListStrings(form, "VpcSecurityGroupIds.VpcSecurityGroupId"),
+		SubnetGroupName:                  form.Get("ClusterSubnetGroupName"),
+		DBClusterParameterGroupName:      form.Get("ClusterParameterGroupName"),
+		NodeType:                         form.Get("NodeType"),
+		NumberOfNodes:                    formInt(form.Get("NumberOfNodes")),
+		Encrypted:                        formBool(form.Get("Encrypted")),
+		KmsKeyID:                         form.Get("KmsKeyId"),
+		PubliclyAccessible:               formBool(form.Get("PubliclyAccessible")),
+		AvailabilityZone:                 form.Get("AvailabilityZone"),
+		AutomatedSnapshotRetentionPeriod: retention,
+		PreferredMaintenanceWindow:       form.Get("PreferredMaintenanceWindow"),
+		Tags:                             parseRedshiftTags(form),
 	}
 }
 
@@ -127,12 +142,20 @@ func (h *Handler) modifyCluster(w http.ResponseWriter, r *http.Request) {
 	id := form.Get("ClusterIdentifier")
 
 	input := rdbdriver.ModifyInstanceInput{
-		EngineVersion:      form.Get("ClusterVersion"),
-		MasterUserPassword: form.Get("MasterUserPassword"),
-		NodeType:           form.Get("NodeType"),
-		NumberOfNodes:      formInt(form.Get("NumberOfNodes")),
-		ClusterType:        form.Get("ClusterType"),
-		Tags:               parseRedshiftTags(form),
+		EngineVersion:              form.Get("ClusterVersion"),
+		MasterUserPassword:         form.Get("MasterUserPassword"),
+		NodeType:                   form.Get("NodeType"),
+		NumberOfNodes:              formInt(form.Get("NumberOfNodes")),
+		ClusterType:                form.Get("ClusterType"),
+		PreferredMaintenanceWindow: form.Get("PreferredMaintenanceWindow"),
+		Tags:                       parseRedshiftTags(form),
+	}
+
+	// Retention is applied only when the client sends it; a pointer preserves an
+	// explicit 0 (disable automated snapshots) as distinct from "unchanged".
+	if form.Has("AutomatedSnapshotRetentionPeriod") {
+		retention := formInt(form.Get("AutomatedSnapshotRetentionPeriod"))
+		input.AutomatedSnapshotRetentionPeriod = &retention
 	}
 
 	cluster, err := h.db.ModifyCluster(r.Context(), id, input)

--- a/server/aws/redshift/xml.go
+++ b/server/aws/redshift/xml.go
@@ -49,11 +49,16 @@ type clusterXML struct {
 	// resolve to "enabled"/"disabled", so an unset value hangs the waiter.
 	AvailabilityZoneRelocationStatus string `xml:"AvailabilityZoneRelocationStatus"`
 	MultiAZ                          string `xml:"MultiAZ"`
-	// AllowVersionUpgrade / Automated- / ManualSnapshotRetentionPeriod are not
-	// modeled and always report the AWS account defaults; terraform reads them
-	// back into its schema (whose defaults match), so omitting them drifts.
-	AllowVersionUpgrade              bool                       `xml:"AllowVersionUpgrade"`
+	// AllowVersionUpgrade / ManualSnapshotRetentionPeriod are not modeled and
+	// always report the AWS account defaults; terraform reads them back into its
+	// schema (whose defaults match), so omitting them drifts.
+	AllowVersionUpgrade bool `xml:"AllowVersionUpgrade"`
+	// AutomatedSnapshotRetentionPeriod / PreferredMaintenanceWindow carry the
+	// cluster's stored values so a user-set retention or maintenance window
+	// round-trips instead of always reporting the create-time default (which
+	// would drift the moment terraform changes either attribute).
 	AutomatedSnapshotRetentionPeriod int                        `xml:"AutomatedSnapshotRetentionPeriod"`
+	PreferredMaintenanceWindow       string                     `xml:"PreferredMaintenanceWindow,omitempty"`
 	ManualSnapshotRetentionPeriod    int                        `xml:"ManualSnapshotRetentionPeriod"`
 	MaintenanceTrackName             string                     `xml:"MaintenanceTrackName"`
 	ClusterVersion                   string                     `xml:"ClusterVersion,omitempty"`
@@ -260,7 +265,6 @@ const (
 	// AWS cluster defaults reported for unmodeled attributes so terraform's
 	// matching schema defaults do not perpetually drift.
 	defaultAllowVersionUpgrade      = true
-	defaultAutomatedSnapshotRetain  = 1
 	defaultManualSnapshotRetainNone = -1
 	// defaultMaintenanceTrack is the maintenance track a cluster runs on by
 	// default; terraform's maintenance_track_name defaults to the same value.
@@ -298,7 +302,8 @@ func toClusterXML(cluster *rdbdriver.Cluster) clusterXML {
 		AvailabilityZoneRelocationStatus: azRelocationDisabled,
 		MultiAZ:                          multiAZDisabled,
 		AllowVersionUpgrade:              defaultAllowVersionUpgrade,
-		AutomatedSnapshotRetentionPeriod: defaultAutomatedSnapshotRetain,
+		AutomatedSnapshotRetentionPeriod: cluster.AutomatedSnapshotRetentionPeriod,
+		PreferredMaintenanceWindow:       cluster.PreferredMaintenanceWindow,
 		ManualSnapshotRetentionPeriod:    defaultManualSnapshotRetainNone,
 		MaintenanceTrackName:             defaultMaintenanceTrack,
 		ClusterVersion:                   cluster.EngineVersion,

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -300,6 +300,12 @@ type ModifyInstanceInput struct {
 	NodeType      string
 	NumberOfNodes int
 	ClusterType   string
+	// AutomatedSnapshotRetentionPeriod is the Redshift ModifyCluster retention
+	// input; nil means "no change". A pointer (not a plain int) because 0 is a
+	// valid value that disables automated snapshots, distinct from "not sent".
+	// RDS/Aurora ignore it (they use BackupRetentionPeriod). Redshift's
+	// PreferredMaintenanceWindow reuses the shared field above.
+	AutomatedSnapshotRetentionPeriod *int
 	// GCPDatabaseFlags / GCPBackupConfig / GCPIPConfig update the Cloud SQL
 	// settings sub-objects (opaque JSON); empty means "no change". Cloud SQL-only;
 	// RDS/Redshift ignore them.
@@ -393,6 +399,12 @@ type ClusterConfig struct {
 	Encrypted          bool
 	PubliclyAccessible bool
 	AvailabilityZone   string
+	// AutomatedSnapshotRetentionPeriod is the number of days Redshift retains
+	// automatic snapshots (AWS default 1; 0 disables them). PreferredMaintenanceWindow
+	// is the weekly UTC window Redshift schedules maintenance in (AWS assigns one
+	// when unset). Both are Redshift-specific; zero for RDS/Aurora/Azure/GCP.
+	AutomatedSnapshotRetentionPeriod int
+	PreferredMaintenanceWindow       string
 	// Location is the Azure region an Azure SQL logical server lives in (ARM
 	// top-level "location"). Empty for AWS/GCP.
 	Location string
@@ -448,6 +460,12 @@ type Cluster struct {
 	PubliclyAccessible bool
 	AvailabilityZone   string
 	VpcID              string
+	// AutomatedSnapshotRetentionPeriod / PreferredMaintenanceWindow echo the
+	// Redshift cluster attributes on read so Terraform's matching schema values
+	// (retention default 1; a computed maintenance window) do not drift. Zero for
+	// RDS/Aurora/Azure/GCP.
+	AutomatedSnapshotRetentionPeriod int
+	PreferredMaintenanceWindow       string
 	// Location is the Azure region an Azure SQL logical server lives in (ARM
 	// top-level "location"), echoed on read. Empty for AWS/GCP.
 	Location  string


### PR DESCRIPTION
## Summary

Deep real-user e2e audit of AWS Redshift (aws_redshift_cluster + aws_redshift_parameter_group + aws_redshift_subnet_group) against the real cloud via aws-sdk-go-v2, aws-cli, and hashicorp/aws Terraform on a live `cloudemu serve`. The control-plane surface is broad and mostly faithful; this fixes three read-surface divergences that cause Terraform drift.

## Divergences fixed

1. **`automated_snapshot_retention_period` did not round-trip.** DescribeClusters/CreateCluster reported this field from a hardcoded constant (always the default), so a cluster that set a non-default retention drifted on every plan. Terraform's schema default (1) is *not* computed, so the field is always compared. Now stored per-cluster and applied on ModifyCluster (presence-checked so an explicit `0` — disable automated snapshots — is preserved, distinct from "unchanged").

2. **`preferred_maintenance_window` was never emitted.** The attribute was absent from the cluster XML entirely, so setting it (or changing it via ModifyCluster) drifted forever. Now parsed on create/modify, defaulted to a deterministic window when unset (the field is computed in Terraform), and echoed on Describe.

3. **`DBName` returned empty when omitted.** AWS creates a database named `dev` by default and returns it for the life of the cluster; cloudemu returned empty. Now defaults to `dev` on create and restore.

## Changes

- `services/relationaldb/driver/driver.go` — carry `AutomatedSnapshotRetentionPeriod` / `PreferredMaintenanceWindow` on `Cluster` and `ClusterConfig`; add `AutomatedSnapshotRetentionPeriod *int` (pointer preserves explicit 0) to `ModifyInstanceInput` (`PreferredMaintenanceWindow` already existed).
- `providers/aws/redshift/redshift.go` — store/apply the fields on create, modify, and restore; default DBName to `dev` and assign a maintenance window when unset.
- `server/aws/redshift/operations.go` — parse both fields from the query form on CreateCluster/ModifyCluster (retention presence-checked).
- `server/aws/redshift/xml.go` — emit the stored retention and maintenance window instead of a constant.
- `server/aws/redshift/cluster_resize_sdk_roundtrip_test.go` — SDK round-trip tests for the create→describe→modify round-trip and the create-time defaults.

## Live evidence

- Terraform full lifecycle on a live `cloudemu serve`: apply (cluster + parameter group + subnet group + VPC/subnets) → `plan` **no drift** → in-place update of retention (3→8) and maintenance window → `plan` **no drift** → destroy, all exit 0.
- aws-cli + aws-sdk-go-v2: create/modify/describe round-trip retention, window, DBName, and endpoint; ClusterNotFound error envelope correct.

## Gates

`go build ./...`, `go vet`, `gofmt -l`, scoped `go test -race` (providers/aws/redshift, server/aws/redshift, root, server/aws, dbengine), `golangci-lint --new-from-rev` (0 new issues), and `go generate` (no docs/coverage change) all green.