### PR TITLE
fix(gcp-bigtable): real-user e2e divergences from Bigtable Admin

### DIFF
--- a/server/grpc/bigtableadmin/app_profile.go
+++ b/server/grpc/bigtableadmin/app_profile.go
@@ -1,0 +1,108 @@
+package bigtableadmin
+
+import (
+	"context"
+	"strings"
+
+	adminpb "cloud.google.com/go/bigtable/admin/apiv2/adminpb"
+	longrunningpb "cloud.google.com/go/longrunning/autogen/longrunningpb"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// Bigtable app profiles on the instance-admin gRPC surface. Create/Get/List and
+// Delete are plain synchronous RPCs; UpdateAppProfile is long-running and, like
+// the other admin LROs here, completes synchronously (a done Operation carrying
+// the updated profile in Response), so the terraform google provider — which
+// drives these over BIGTABLE_EMULATOR_HOST — round-trips without hanging.
+
+func (s *instanceAdminServer) CreateAppProfile(
+	ctx context.Context, req *adminpb.CreateAppProfileRequest,
+) (*adminpb.AppProfile, error) {
+	cfg := fromProtoAppProfile(req.GetParent(), req.GetAppProfileId(), req.GetAppProfile())
+
+	a, err := s.resolve().CreateAppProfile(ctx, cfg)
+	if err != nil {
+		return nil, toStatus(err)
+	}
+
+	return toProtoAppProfile(a), nil
+}
+
+func (s *instanceAdminServer) GetAppProfile(
+	ctx context.Context, req *adminpb.GetAppProfileRequest,
+) (*adminpb.AppProfile, error) {
+	a, err := s.resolve().GetAppProfile(ctx, req.GetName())
+	if err != nil {
+		return nil, toStatus(err)
+	}
+
+	return toProtoAppProfile(a), nil
+}
+
+func (s *instanceAdminServer) ListAppProfiles(
+	ctx context.Context, req *adminpb.ListAppProfilesRequest,
+) (*adminpb.ListAppProfilesResponse, error) {
+	profiles, err := s.resolve().ListAppProfiles(ctx, req.GetParent())
+	if err != nil {
+		return nil, toStatus(err)
+	}
+
+	out := &adminpb.ListAppProfilesResponse{}
+	for i := range profiles {
+		out.AppProfiles = append(out.AppProfiles, toProtoAppProfile(&profiles[i]))
+	}
+
+	return out, nil
+}
+
+func (s *instanceAdminServer) UpdateAppProfile(
+	ctx context.Context, req *adminpb.UpdateAppProfileRequest,
+) (*longrunningpb.Operation, error) {
+	db := s.resolve()
+	in := req.GetAppProfile()
+	name := in.GetName()
+	parent, id := splitAppProfileName(name)
+
+	// With no mask the proto contract replaces every field from the body; with a
+	// mask, overlay only the named fields onto the current profile so an unmasked
+	// routing policy or description is preserved rather than wiped.
+	cfg := fromProtoAppProfile(parent, id, in)
+
+	if mask := newMaskSet(req.GetUpdateMask().GetPaths()); mask != nil {
+		cur, err := db.GetAppProfile(ctx, name)
+		if err != nil {
+			return nil, toStatus(err)
+		}
+
+		cfg = mergeAppProfileConfig(parent, id, cur, in, mask)
+	}
+
+	a, op, err := db.UpdateAppProfile(ctx, name, cfg)
+	if err != nil {
+		return nil, toStatus(err)
+	}
+
+	return doneOp(op, toProtoAppProfile(a))
+}
+
+func (s *instanceAdminServer) DeleteAppProfile(
+	ctx context.Context, req *adminpb.DeleteAppProfileRequest,
+) (*emptypb.Empty, error) {
+	if err := s.resolve().DeleteAppProfile(ctx, req.GetName()); err != nil {
+		return nil, toStatus(err)
+	}
+
+	return &emptypb.Empty{}, nil
+}
+
+// splitAppProfileName splits a full app-profile name into its parent instance
+// name and profile id: projects/p/instances/i/appProfiles/id ->
+// "projects/p/instances/i", "id".
+func splitAppProfileName(name string) (parent, id string) {
+	const sep = "/appProfiles/"
+	if i := strings.Index(name, sep); i >= 0 {
+		return name[:i], name[i+len(sep):]
+	}
+
+	return name, lastSegment(name)
+}

--- a/server/grpc/bigtableadmin/bigtableadmin.go
+++ b/server/grpc/bigtableadmin/bigtableadmin.go
@@ -123,6 +123,10 @@ func reconstructResponse(ctx context.Context, db btdriver.Admin, op *btdriver.Op
 		if t, err := db.GetTable(ctx, op.TargetName); err == nil {
 			return toProtoTable(t)
 		}
+	case strings.Contains(op.Type, "appprofile"):
+		if a, err := db.GetAppProfile(ctx, op.TargetName); err == nil {
+			return toProtoAppProfile(a)
+		}
 	}
 
 	return nil

--- a/server/grpc/bigtableadmin/bigtableadmin_test.go
+++ b/server/grpc/bigtableadmin/bigtableadmin_test.go
@@ -188,6 +188,29 @@ func TestClusterAndTableLifecycle(t *testing.T) {
 		t.Fatalf("ListClusters = %d, want 2", len(clusters.GetClusters()))
 	}
 
+	// PartialUpdateCluster (LRO) with a mask: change c1's node count to 5. This
+	// is the RPC the terraform provider uses to resize a cluster.
+	puOp, err := h.instances.PartialUpdateCluster(ctx, &adminpb.PartialUpdateClusterRequest{
+		Cluster:    &adminpb.Cluster{Name: inst.GetName() + "/clusters/c1", ServeNodes: 5},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"serve_nodes"}},
+	})
+	if err != nil {
+		t.Fatalf("PartialUpdateCluster: %v", err)
+	}
+
+	if !puOp.GetDone() {
+		t.Fatalf("PartialUpdateCluster not done synchronously")
+	}
+
+	c1, err := h.instances.GetCluster(ctx, &adminpb.GetClusterRequest{Name: inst.GetName() + "/clusters/c1"})
+	if err != nil {
+		t.Fatalf("GetCluster: %v", err)
+	}
+
+	if c1.GetServeNodes() != 5 {
+		t.Fatalf("serve nodes after PartialUpdateCluster = %d, want 5", c1.GetServeNodes())
+	}
+
 	// CreateTable is synchronous (returns the Table directly).
 	tbl, err := h.tables.CreateTable(ctx, &adminpb.CreateTableRequest{
 		Parent:  inst.GetName(),
@@ -246,6 +269,99 @@ func TestClusterAndTableLifecycle(t *testing.T) {
 
 	if _, err := h.tables.GetTable(ctx, &adminpb.GetTableRequest{Name: tbl.GetName()}); status.Code(err) != codes.NotFound {
 		t.Fatalf("GetTable after delete: code = %v, want NotFound", status.Code(err))
+	}
+}
+
+func TestAppProfileLifecycle(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+
+	inst := h.createInstance(t, ctx)
+
+	// Create with a single-cluster routing policy + allow_transactional_writes.
+	created, err := h.instances.CreateAppProfile(ctx, &adminpb.CreateAppProfileRequest{
+		Parent:       inst.GetName(),
+		AppProfileId: "ap1",
+		AppProfile: &adminpb.AppProfile{
+			Description: "primary",
+			RoutingPolicy: &adminpb.AppProfile_SingleClusterRouting_{
+				SingleClusterRouting: &adminpb.AppProfile_SingleClusterRouting{
+					ClusterId: "c1", AllowTransactionalWrites: true,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateAppProfile: %v", err)
+	}
+
+	if created.GetName() != inst.GetName()+"/appProfiles/ap1" {
+		t.Fatalf("app profile name = %q", created.GetName())
+	}
+
+	if scr := created.GetSingleClusterRouting(); scr == nil || scr.GetClusterId() != "c1" || !scr.GetAllowTransactionalWrites() {
+		t.Fatalf("single-cluster routing round-trip failed: %v", created.GetRoutingPolicy())
+	}
+
+	// Get round-trips description + routing.
+	got, err := h.instances.GetAppProfile(ctx, &adminpb.GetAppProfileRequest{Name: created.GetName()})
+	if err != nil {
+		t.Fatalf("GetAppProfile: %v", err)
+	}
+
+	if got.GetDescription() != "primary" {
+		t.Fatalf("description = %q, want primary", got.GetDescription())
+	}
+
+	list, err := h.instances.ListAppProfiles(ctx, &adminpb.ListAppProfilesRequest{Parent: inst.GetName()})
+	if err != nil {
+		t.Fatalf("ListAppProfiles: %v", err)
+	}
+
+	if len(list.GetAppProfiles()) != 1 {
+		t.Fatalf("ListAppProfiles = %d, want 1", len(list.GetAppProfiles()))
+	}
+
+	// Update (LRO) with a mask: switch to multi-cluster routing, keep description.
+	upOp, err := h.instances.UpdateAppProfile(ctx, &adminpb.UpdateAppProfileRequest{
+		AppProfile: &adminpb.AppProfile{
+			Name: created.GetName(),
+			RoutingPolicy: &adminpb.AppProfile_MultiClusterRoutingUseAny_{
+				MultiClusterRoutingUseAny: &adminpb.AppProfile_MultiClusterRoutingUseAny{},
+			},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"multi_cluster_routing_use_any"}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateAppProfile: %v", err)
+	}
+
+	if !upOp.GetDone() {
+		t.Fatalf("UpdateAppProfile operation not done synchronously")
+	}
+
+	var updated adminpb.AppProfile
+	if err := upOp.GetResponse().UnmarshalTo(&updated); err != nil {
+		t.Fatalf("unmarshal app profile from LRO response: %v", err)
+	}
+
+	if updated.GetMultiClusterRoutingUseAny() == nil {
+		t.Fatalf("update did not switch to multi-cluster routing: %v", updated.GetRoutingPolicy())
+	}
+
+	// The unmasked description must be preserved, not wiped.
+	if updated.GetDescription() != "primary" {
+		t.Fatalf("masked update wiped description: %q", updated.GetDescription())
+	}
+
+	if _, err := h.instances.DeleteAppProfile(ctx, &adminpb.DeleteAppProfileRequest{Name: created.GetName()}); err != nil {
+		t.Fatalf("DeleteAppProfile: %v", err)
+	}
+
+	if _, err := h.instances.GetAppProfile(
+		ctx, &adminpb.GetAppProfileRequest{Name: created.GetName()},
+	); status.Code(err) != codes.NotFound {
+		t.Fatalf("GetAppProfile after delete: code = %v, want NotFound", status.Code(err))
 	}
 }
 

--- a/server/grpc/bigtableadmin/convert.go
+++ b/server/grpc/bigtableadmin/convert.go
@@ -269,6 +269,13 @@ func lastSegment(name string) string {
 	return name
 }
 
+// normalizeMaskPath lowercases a single field-mask path and strips underscores,
+// so snake_case and camelCase spellings of the same path compare equal
+// ("display_name" and "displayName" both become "displayname").
+func normalizeMaskPath(s string) string {
+	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(s), "_", ""))
+}
+
 // normalizeMaskPaths lowercases each mask path and strips underscores, matching
 // the token form the bigtable store's UpdateInstanceConfig.UpdateMask expects
 // (so "display_name" and "displayName" both become "displayname").
@@ -276,10 +283,145 @@ func normalizeMaskPaths(paths []string) []string {
 	out := make([]string, 0, len(paths))
 
 	for _, p := range paths {
-		if n := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(p), "_", "")); n != "" {
+		if n := normalizeMaskPath(p); n != "" {
 			out = append(out, n)
 		}
 	}
 
 	return out
+}
+
+// ---- app profiles ----
+
+func appProfilePriority(s string) adminpb.AppProfile_Priority {
+	return adminpb.AppProfile_Priority(adminpb.AppProfile_Priority_value[s])
+}
+
+// toProtoAppProfile maps the driver's flat app profile to the proto oneofs. The
+// routing policy is exactly one of multi-cluster / single-cluster, and priority
+// is echoed through the modern standard_isolation field (what the real API
+// returns), so terraform reads back the routing + isolation it set.
+func toProtoAppProfile(a *btdriver.AppProfile) *adminpb.AppProfile {
+	out := &adminpb.AppProfile{Name: a.Name, Description: a.Description, Etag: a.Etag}
+
+	switch {
+	case a.MultiClusterRoutingAny:
+		out.RoutingPolicy = &adminpb.AppProfile_MultiClusterRoutingUseAny_{
+			MultiClusterRoutingUseAny: &adminpb.AppProfile_MultiClusterRoutingUseAny{ClusterIds: a.MultiClusterClusterIDs},
+		}
+	case a.SingleClusterID != "":
+		out.RoutingPolicy = &adminpb.AppProfile_SingleClusterRouting_{
+			SingleClusterRouting: &adminpb.AppProfile_SingleClusterRouting{
+				ClusterId: a.SingleClusterID, AllowTransactionalWrites: a.AllowTransactionalWrites,
+			},
+		}
+	}
+
+	if p := appProfilePriority(a.Priority); p != adminpb.AppProfile_PRIORITY_UNSPECIFIED {
+		out.Isolation = &adminpb.AppProfile_StandardIsolation_{
+			StandardIsolation: &adminpb.AppProfile_StandardIsolation{Priority: p},
+		}
+	}
+
+	return out
+}
+
+func fromProtoAppProfile(parent, id string, a *adminpb.AppProfile) btdriver.CreateAppProfileConfig {
+	cfg := btdriver.CreateAppProfileConfig{Parent: parent, AppProfileID: id, Description: a.GetDescription()}
+
+	if m := a.GetMultiClusterRoutingUseAny(); m != nil {
+		cfg.MultiClusterRoutingAny = true
+		cfg.MultiClusterClusterIDs = m.GetClusterIds()
+	}
+
+	if sc := a.GetSingleClusterRouting(); sc != nil {
+		cfg.SingleClusterID = sc.GetClusterId()
+		cfg.AllowTransactionalWrites = sc.GetAllowTransactionalWrites()
+	}
+
+	// Priority is read from the modern standard_isolation field (what the real
+	// API and terraform send); the deprecated top-level priority oneof is not
+	// consulted.
+	if si := a.GetStandardIsolation(); si != nil {
+		cfg.Priority = si.GetPriority().String()
+	}
+
+	return cfg
+}
+
+// maskSet is a normalized google.protobuf.FieldMask used to overlay only
+// the named fields of an app-profile update onto the current profile. A nil mask
+// means the caller sent none, so the update replaces every field from the body.
+type maskSet struct{ paths []string }
+
+func newMaskSet(paths []string) *maskSet {
+	norm := normalizeMaskPaths(paths)
+	if len(norm) == 0 {
+		return nil
+	}
+
+	return &maskSet{paths: norm}
+}
+
+// has reports whether the mask names field exactly or as the leading segment of
+// a dotted sub-path. field is normalized by this method.
+func (m *maskSet) has(field string) bool {
+	field = normalizeMaskPath(field)
+	for _, p := range m.paths {
+		if p == field || strings.HasPrefix(p, field+".") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// contains reports whether any masked path contains sub as a substring, used for
+// the routing/isolation paths whose exact spelling varies across clients. sub is
+// normalized by this method.
+func (m *maskSet) contains(sub string) bool {
+	sub = normalizeMaskPath(sub)
+	for _, p := range m.paths {
+		if strings.Contains(p, sub) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// mergeAppProfileConfig overlays the fields named by mask (from body) onto the
+// current profile, keeping every unmasked field at its current value. Routing is
+// treated as one unit: any routing path in the mask replaces the whole policy.
+func mergeAppProfileConfig(
+	parent, id string, cur *btdriver.AppProfile, body *adminpb.AppProfile, mask *maskSet,
+) btdriver.CreateAppProfileConfig {
+	cfg := btdriver.CreateAppProfileConfig{
+		Parent:                   parent,
+		AppProfileID:             id,
+		Description:              cur.Description,
+		MultiClusterRoutingAny:   cur.MultiClusterRoutingAny,
+		MultiClusterClusterIDs:   cur.MultiClusterClusterIDs,
+		SingleClusterID:          cur.SingleClusterID,
+		AllowTransactionalWrites: cur.AllowTransactionalWrites,
+		Priority:                 cur.Priority,
+	}
+
+	if mask.has("description") {
+		cfg.Description = body.GetDescription()
+	}
+
+	if mask.contains("routing") {
+		b := fromProtoAppProfile(parent, id, body)
+		cfg.MultiClusterRoutingAny = b.MultiClusterRoutingAny
+		cfg.MultiClusterClusterIDs = b.MultiClusterClusterIDs
+		cfg.SingleClusterID = b.SingleClusterID
+		cfg.AllowTransactionalWrites = b.AllowTransactionalWrites
+	}
+
+	if mask.contains("priority") || mask.contains("isolation") {
+		cfg.Priority = fromProtoAppProfile(parent, id, body).Priority
+	}
+
+	return cfg
 }

--- a/server/grpc/bigtableadmin/instance.go
+++ b/server/grpc/bigtableadmin/instance.go
@@ -12,9 +12,10 @@ import (
 )
 
 // instanceAdminServer serves google.bigtable.admin.v2.BigtableInstanceAdmin,
-// forwarding to the current bigtable Admin store. Embedding the generated
-// Unimplemented server keeps forward compatibility: RPCs outside this first cut
-// (app profiles, backups, logical/materialized views, hot tablets) report
+// forwarding to the current bigtable Admin store. Instances, clusters, app
+// profiles (see app_profile.go), and IAM are served here. Embedding the
+// generated Unimplemented server keeps forward compatibility: RPCs outside this
+// surface (backups, logical/materialized views, hot tablets) report
 // Unimplemented rather than failing the whole service.
 type instanceAdminServer struct {
 	adminpb.UnimplementedBigtableInstanceAdminServer
@@ -146,6 +147,46 @@ func (s *instanceAdminServer) ListClusters(
 	}
 
 	return out, nil
+}
+
+// UpdateCluster is the deprecated full-cluster update (a bare Cluster, no mask):
+// the caller's serve_nodes and autoscaling config replace the current scaling.
+func (s *instanceAdminServer) UpdateCluster(ctx context.Context, req *adminpb.Cluster) (*longrunningpb.Operation, error) {
+	c, op, err := s.resolve().UpdateCluster(ctx, req.GetName(), int(req.GetServeNodes()), fromProtoAutoscaling(req))
+	if err != nil {
+		return nil, toStatus(err)
+	}
+
+	return doneOp(op, toProtoCluster(c))
+}
+
+// PartialUpdateCluster applies only the masked scaling fields — this is the RPC
+// the terraform google provider uses to change a cluster's node count. An
+// unmasked serve_nodes/autoscaling is dropped so the store preserves it rather
+// than switching the cluster's scaling mode as a side effect.
+func (s *instanceAdminServer) PartialUpdateCluster(
+	ctx context.Context, req *adminpb.PartialUpdateClusterRequest,
+) (*longrunningpb.Operation, error) {
+	in := req.GetCluster()
+	serveNodes := int(in.GetServeNodes())
+	autoscaling := fromProtoAutoscaling(in)
+
+	if mask := newMaskSet(req.GetUpdateMask().GetPaths()); mask != nil {
+		if !mask.has("serveNodes") {
+			serveNodes = 0
+		}
+
+		if !mask.contains("autoscaling") {
+			autoscaling = nil
+		}
+	}
+
+	c, op, err := s.resolve().UpdateCluster(ctx, in.GetName(), serveNodes, autoscaling)
+	if err != nil {
+		return nil, toStatus(err)
+	}
+
+	return doneOp(op, toProtoCluster(c))
 }
 
 func (s *instanceAdminServer) DeleteCluster(ctx context.Context, req *adminpb.DeleteClusterRequest) (*emptypb.Empty, error) {


### PR DESCRIPTION
## Summary

Real-user e2e audit of the GCP Cloud Bigtable **admin control plane** (instances + clusters + tables + app profiles) driven by the real `hashicorp/google` terraform provider. Two genuine cloud-vs-cloudemu divergences on the **gRPC admin transport** (the transport `cloud.google.com/go/bigtable` admin clients — and therefore terraform's bigtable resources — reach via `BIGTABLE_EMULATOR_HOST`).

The gRPC `BigtableInstanceAdmin` server embedded `UnimplementedBigtableInstanceAdminServer` and only implemented instance / cluster-create / table RPCs. Missing RPCs returned `Unimplemented`:

1. **App profiles** — `CreateAppProfile` / `GetAppProfile` / `ListAppProfiles` / `UpdateAppProfile` / `DeleteAppProfile` were absent. Direct `cloud.google.com/go/bigtable` `InstanceAdminClient` app-profile calls got `Unimplemented` where real Bigtable succeeds.
2. **Cluster resize** — `UpdateCluster` / `PartialUpdateCluster` were absent. A terraform `num_nodes` change failed hard: `Error updating instance. UpdateCluster "c1" failed rpc error: code = Unimplemented desc = method PartialUpdateCluster not implemented`.

## Changes

- New `server/grpc/bigtableadmin/app_profile.go`: the five app-profile RPCs, delegating to the same bigtable `Admin` store the REST handler uses (single backend, no duplicated control-plane logic).
- `instance.go`: add `UpdateCluster` (deprecated full update) and `PartialUpdateCluster` (mask-aware resize).
- `convert.go`: `AppProfile` proto<->driver conversion (routing-policy oneof, priority via the modern `standard_isolation` field), a normalized field-mask helper reused by app-profile and cluster updates, and a mask-merge that preserves unmasked fields.
- LROs (`UpdateAppProfile`, cluster updates) complete synchronously — a done `Operation` carrying the resource — so SDK / terraform LRO waits terminate; `operations.get` reconstructs the app-profile response too.

## Behavior parity notes

- `google_bigtable_instance` / `google_bigtable_table` use gRPC (`BIGTABLE_EMULATOR_HOST`); `google_bigtable_app_profile` uses the **REST** admin transport (`bigtable_custom_endpoint`). Both hit the same in-memory store. The app-profile gRPC RPCs added here fix the divergence for direct gRPC SDK users.
- Data-plane (ReadRows/MutateRows), backups, and GC-policy internals remain out of scope for this admin audit.

## Tests / evidence

- `server/grpc/bigtableadmin/bigtableadmin_test.go`: new `TestAppProfileLifecycle` (create/get/list/masked-update/delete over a real gRPC round trip) and a `PartialUpdateCluster` resize assertion in the cluster/table test.
- Live real-user e2e: `cloudemu serve` + real terraform `hashicorp/google` — create -> update (num_nodes 4->6, display_name, +column_family, app-profile routing/description patch) -> `terraform plan` **no drift** -> destroy, all green. REST reads confirmed `serveNodes: 6`, multi-cluster routing, `state: READY`.
- Gates: `go build ./...`, `go test -race` (server/grpc, server/gcp, providers/gcp/bigtable), root `go test .`, `go vet`, `gofmt`, `golangci-lint` (0 issues), `go generate` (no docs/coverage delta).
