### PR TITLE
fix(sesv2): real-user e2e divergences from AWS SES v2

### DIFF
--- a/providers/aws/sesv2/configset_options.go
+++ b/providers/aws/sesv2/configset_options.go
@@ -144,12 +144,19 @@ func (m *Mock) PutConfigurationSetSuppressionOptions(_ context.Context, configSe
 	})
 }
 
-// PutConfigurationSetTrackingOptions sets the custom redirect domain.
-func (m *Mock) PutConfigurationSetTrackingOptions(_ context.Context, configSet, customRedirectDomain string) error {
-	return m.withConfigSet(configSet, func(cs *driver.ConfigurationSet) { cs.CustomRedirectDom = customRedirectDomain })
+// PutConfigurationSetTrackingOptions sets the custom redirect domain and HTTPS policy.
+func (m *Mock) PutConfigurationSetTrackingOptions(_ context.Context, configSet, customRedirectDomain, httpsPolicy string) error {
+	return m.withConfigSet(configSet, func(cs *driver.ConfigurationSet) {
+		cs.CustomRedirectDom = customRedirectDomain
+		cs.TrackingHTTPSPolicy = httpsPolicy
+	})
 }
 
-// PutConfigurationSetVdmOptions enables VDM on the config set.
-func (m *Mock) PutConfigurationSetVdmOptions(_ context.Context, configSet string) error {
-	return m.withConfigSet(configSet, func(cs *driver.ConfigurationSet) { cs.VdmEnabled = true })
+// PutConfigurationSetVdmOptions sets VDM dashboard and guardian options on the config set.
+func (m *Mock) PutConfigurationSetVdmOptions(_ context.Context, configSet, engagementMetrics, optimizedSharedDelivery string) error {
+	return m.withConfigSet(configSet, func(cs *driver.ConfigurationSet) {
+		cs.VdmEnabled = true
+		cs.VdmEngagement = engagementMetrics
+		cs.VdmGuardianDelivery = optimizedSharedDelivery
+	})
 }

--- a/providers/aws/sesv2/configsets.go
+++ b/providers/aws/sesv2/configsets.go
@@ -8,19 +8,27 @@ import (
 )
 
 // CreateConfigurationSet registers a configuration set.
+//
+//nolint:gocritic // in is passed by value to match the driver interface.
 func (m *Mock) CreateConfigurationSet(_ context.Context, in driver.CreateConfigurationSetInput) error {
 	if in.Name == "" {
 		return cerrors.New(cerrors.InvalidArgument, "ConfigurationSetName is required")
 	}
 
 	cs := driver.ConfigurationSet{
-		Name:           in.Name,
-		SendingEnabled: in.SendingEnabled,
-		ReputationOn:   in.ReputationOn,
-		TLSPolicy:      in.TLSPolicy,
-		SendingPoolN:   in.SendingPoolN,
-		CreatedAt:      m.now(),
-		Tags:           copyTags(in.Tags),
+		Name:                in.Name,
+		SendingEnabled:      in.SendingEnabled,
+		ReputationOn:        in.ReputationOn,
+		TLSPolicy:           in.TLSPolicy,
+		SendingPoolN:        in.SendingPoolN,
+		SuppressedReasons:   append([]string(nil), in.SuppressedReasons...),
+		CustomRedirectDom:   in.CustomRedirectDom,
+		TrackingHTTPSPolicy: in.TrackingHTTPSPolicy,
+		VdmEnabled:          in.VdmConfigured,
+		VdmEngagement:       in.VdmEngagement,
+		VdmGuardianDelivery: in.VdmGuardianDelivery,
+		CreatedAt:           m.now(),
+		Tags:                copyTags(in.Tags),
 	}
 
 	if !m.configSets.SetIfAbsent(in.Name, &configSetData{cs: cs}) {
@@ -42,6 +50,8 @@ func (m *Mock) GetConfigurationSet(_ context.Context, name string) (*driver.Conf
 
 	out := d.cs
 	out.Tags = copyTags(d.cs.Tags)
+	out.SuppressedReasons = append([]string(nil), d.cs.SuppressedReasons...)
+	out.EventDestinations = append([]driver.EventDestination(nil), d.cs.EventDestinations...)
 
 	return &out, nil
 }

--- a/providers/aws/sesv2/identities.go
+++ b/providers/aws/sesv2/identities.go
@@ -41,7 +41,7 @@ func (m *Mock) CreateEmailIdentity(_ context.Context, in driver.CreateIdentityIn
 
 	if isDomain {
 		id.DkimTokens = dkimTokens(in.EmailIdentity)
-		id.DkimSigningHostedZn = m.opts.Region
+		id.DkimSigningHostedZn = dkimSigningHostedZone
 	}
 
 	if !m.identities.SetIfAbsent(in.EmailIdentity, &identityData{id: id}) {

--- a/providers/aws/sesv2/sesv2.go
+++ b/providers/aws/sesv2/sesv2.go
@@ -158,11 +158,18 @@ func mergeTags(dst, src map[string]string) (map[string]string, error) {
 	return dst, nil
 }
 
-// dkimTokens returns deterministic-looking DKIM CNAME tokens for a domain.
-func dkimTokens(name string) []string {
+// dkimSigningHostedZone is the DNS zone that Easy DKIM CNAME records point to,
+// so a token maps to the CNAME target "<token>.dkim.amazonses.com".
+const dkimSigningHostedZone = "dkim.amazonses.com"
+
+// dkimTokens returns deterministic DKIM selector tokens. A token is a
+// domain-independent selector used to build a "<token>._domainkey.<domain>"
+// CNAME record (matching real SES Easy DKIM tokens, which never embed the
+// domain), so the name argument only seeds uniqueness.
+func dkimTokens(string) []string {
 	toks := make([]string, 0, dkimTokenCount)
 	for i := 0; i < dkimTokenCount; i++ {
-		toks = append(toks, idgen.GenerateID("")+"."+name)
+		toks = append(toks, idgen.GenerateID(""))
 	}
 
 	return toks

--- a/providers/aws/sesv2/sesv2_test.go
+++ b/providers/aws/sesv2/sesv2_test.go
@@ -2,6 +2,7 @@ package sesv2_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -54,6 +55,14 @@ func TestCreateDomainIdentityGetsDkimTokens(t *testing.T) {
 
 	if len(id.DkimTokens) != 3 {
 		t.Fatalf("domain identity should have 3 DKIM tokens, got %d", len(id.DkimTokens))
+	}
+
+	// DKIM tokens are domain-independent selectors and never embed the domain
+	// (real SES tokens are used to build "<token>._domainkey.<domain>" CNAMEs).
+	for _, tok := range id.DkimTokens {
+		if strings.Contains(tok, "example.com") || strings.Contains(tok, ".") {
+			t.Fatalf("DKIM token should be a bare selector, got %q", tok)
+		}
 	}
 }
 

--- a/server/aws/sesv2/configset_extras.go
+++ b/server/aws/sesv2/configset_extras.go
@@ -256,9 +256,26 @@ func (h *Handler) putTrackingOptions(w http.ResponseWriter, r *http.Request, nam
 		return
 	}
 
-	writeOK(w, h.ses.PutConfigurationSetTrackingOptions(r.Context(), name, req.CustomRedirectDomain))
+	writeOK(w, h.ses.PutConfigurationSetTrackingOptions(r.Context(), name, req.CustomRedirectDomain, req.HTTPSPolicy))
 }
 
 func (h *Handler) putVdmOptions(w http.ResponseWriter, r *http.Request, name string) {
-	writeOK(w, h.ses.PutConfigurationSetVdmOptions(r.Context(), name))
+	var req putVdmOptionsRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	var engagement, guardian string
+
+	if req.VdmOptions != nil {
+		if req.VdmOptions.DashboardOptions != nil {
+			engagement = req.VdmOptions.DashboardOptions.EngagementMetrics
+		}
+
+		if req.VdmOptions.GuardianOptions != nil {
+			guardian = req.VdmOptions.GuardianOptions.OptimizedSharedDelivery
+		}
+	}
+
+	writeOK(w, h.ses.PutConfigurationSetVdmOptions(r.Context(), name, engagement, guardian))
 }

--- a/server/aws/sesv2/configsets.go
+++ b/server/aws/sesv2/configsets.go
@@ -141,15 +141,22 @@ func (h *Handler) getConfigSet(w http.ResponseWriter, r *http.Request, name stri
 	})
 }
 
-// deliveryOptionsToJSON renders the config-set delivery options, or nil when
-// no TLS policy or sending pool is set, so an unconfigured set does not report
-// an empty delivery-options block (which drives IaC drift).
+// defaultTLSPolicy is the TLS policy SES reports for a configuration set that
+// was created without an explicit delivery block. Real SES v2 always returns a
+// DeliveryOptions block with TlsPolicy defaulted to OPTIONAL, so we emit the
+// same rather than omitting the block.
+const defaultTLSPolicy = "OPTIONAL"
+
+// deliveryOptionsToJSON renders the config-set delivery options. Like real SES,
+// the block is always present: an unconfigured set reports the OPTIONAL default
+// rather than an empty or absent block.
 func deliveryOptionsToJSON(cs *driver.ConfigurationSet) *deliveryOptionsJSON {
-	if cs.TLSPolicy == "" && cs.SendingPoolN == "" {
-		return nil
+	policy := cs.TLSPolicy
+	if policy == "" {
+		policy = defaultTLSPolicy
 	}
 
-	return &deliveryOptionsJSON{TLSPolicy: cs.TLSPolicy, SendingPoolName: cs.SendingPoolN}
+	return &deliveryOptionsJSON{TLSPolicy: policy, SendingPoolName: cs.SendingPoolN}
 }
 
 // suppressionOptionsToJSON renders the config-set suppression options, or nil

--- a/server/aws/sesv2/configsets.go
+++ b/server/aws/sesv2/configsets.go
@@ -61,10 +61,23 @@ func (h *Handler) createConfigSet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := h.ses.CreateConfigurationSet(r.Context(), configSetInputFromRequest(&req)); err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+// configSetInputFromRequest maps a create request, including its optional
+// nested option blocks, onto the driver input.
+func configSetInputFromRequest(req *createConfigurationSetRequest) driver.CreateConfigurationSetInput {
 	in := driver.CreateConfigurationSetInput{
 		Name: req.ConfigurationSetName,
 		Tags: tagsToMap(req.Tags),
 	}
+
 	if req.SendingOptions != nil {
 		in.SendingEnabled = req.SendingOptions.SendingEnabled
 	}
@@ -78,13 +91,34 @@ func (h *Handler) createConfigSet(w http.ResponseWriter, r *http.Request) {
 		in.SendingPoolN = req.DeliveryOptions.SendingPoolName
 	}
 
-	if err := h.ses.CreateConfigurationSet(r.Context(), in); err != nil {
-		writeErr(w, err)
+	if req.SuppressionOptions != nil {
+		in.SuppressedReasons = req.SuppressionOptions.SuppressedReasons
+	}
 
+	if req.TrackingOptions != nil {
+		in.CustomRedirectDom = req.TrackingOptions.CustomRedirectDomain
+		in.TrackingHTTPSPolicy = req.TrackingOptions.HTTPSPolicy
+	}
+
+	applyVdmToInput(&in, req.VdmOptions)
+
+	return in
+}
+
+// applyVdmToInput copies the VDM option block onto the driver input.
+func applyVdmToInput(in *driver.CreateConfigurationSetInput, vdm *vdmOptionsJSON) {
+	if vdm == nil {
 		return
 	}
 
-	writeJSON(w, struct{}{})
+	in.VdmConfigured = true
+	if vdm.DashboardOptions != nil {
+		in.VdmEngagement = vdm.DashboardOptions.EngagementMetrics
+	}
+
+	if vdm.GuardianOptions != nil {
+		in.VdmGuardianDelivery = vdm.GuardianOptions.OptimizedSharedDelivery
+	}
 }
 
 func (h *Handler) getConfigSet(w http.ResponseWriter, r *http.Request, name string) {
@@ -99,9 +133,62 @@ func (h *Handler) getConfigSet(w http.ResponseWriter, r *http.Request, name stri
 		ConfigurationSetName: cs.Name,
 		SendingOptions:       sendingOptionsJSON{SendingEnabled: cs.SendingEnabled},
 		ReputationOptions:    reputationOptionsJSON{ReputationMetricsEnabled: cs.ReputationOn},
-		DeliveryOptions:      deliveryOptionsJSON{TLSPolicy: cs.TLSPolicy, SendingPoolName: cs.SendingPoolN},
+		DeliveryOptions:      deliveryOptionsToJSON(cs),
+		SuppressionOptions:   suppressionOptionsToJSON(cs),
+		TrackingOptions:      trackingOptionsToJSON(cs),
+		VdmOptions:           vdmOptionsToJSON(cs),
 		Tags:                 mapToTags(cs.Tags),
 	})
+}
+
+// deliveryOptionsToJSON renders the config-set delivery options, or nil when
+// no TLS policy or sending pool is set, so an unconfigured set does not report
+// an empty delivery-options block (which drives IaC drift).
+func deliveryOptionsToJSON(cs *driver.ConfigurationSet) *deliveryOptionsJSON {
+	if cs.TLSPolicy == "" && cs.SendingPoolN == "" {
+		return nil
+	}
+
+	return &deliveryOptionsJSON{TLSPolicy: cs.TLSPolicy, SendingPoolName: cs.SendingPoolN}
+}
+
+// suppressionOptionsToJSON renders the config-set suppression options, or nil
+// when no suppressed reasons are set.
+func suppressionOptionsToJSON(cs *driver.ConfigurationSet) *suppressionOptionsJSON {
+	if len(cs.SuppressedReasons) == 0 {
+		return nil
+	}
+
+	return &suppressionOptionsJSON{SuppressedReasons: cs.SuppressedReasons}
+}
+
+// trackingOptionsToJSON renders the config-set tracking options, or nil when
+// no custom redirect domain or HTTPS policy is set.
+func trackingOptionsToJSON(cs *driver.ConfigurationSet) *trackingOptionsJSON {
+	if cs.CustomRedirectDom == "" && cs.TrackingHTTPSPolicy == "" {
+		return nil
+	}
+
+	return &trackingOptionsJSON{CustomRedirectDomain: cs.CustomRedirectDom, HTTPSPolicy: cs.TrackingHTTPSPolicy}
+}
+
+// vdmOptionsToJSON renders the config-set VDM options, or nil when VDM is not
+// configured on the set.
+func vdmOptionsToJSON(cs *driver.ConfigurationSet) *vdmOptionsJSON {
+	if !cs.VdmEnabled && cs.VdmEngagement == "" && cs.VdmGuardianDelivery == "" {
+		return nil
+	}
+
+	out := &vdmOptionsJSON{}
+	if cs.VdmEngagement != "" {
+		out.DashboardOptions = &vdmDashboardOptionsJSON{EngagementMetrics: cs.VdmEngagement}
+	}
+
+	if cs.VdmGuardianDelivery != "" {
+		out.GuardianOptions = &vdmGuardianOptionsJSON{OptimizedSharedDelivery: cs.VdmGuardianDelivery}
+	}
+
+	return out
 }
 
 func (h *Handler) deleteConfigSet(w http.ResponseWriter, r *http.Request, name string) {

--- a/server/aws/sesv2/errors.go
+++ b/server/aws/sesv2/errors.go
@@ -53,13 +53,13 @@ func exceptionFor(err error) (status int, errType string) {
 func writeErr(w http.ResponseWriter, err error) {
 	var apiErr *sesdriver.APIError
 	if errors.As(err, &apiErr) {
-		writeError(w, http.StatusBadRequest, apiErr.Exception, err.Error())
+		writeError(w, http.StatusBadRequest, apiErr.Exception, cerrors.Message(err))
 
 		return
 	}
 
 	status, errType := exceptionFor(err)
-	writeError(w, status, errType, err.Error())
+	writeError(w, status, errType, cerrors.Message(err))
 }
 
 func notFound(w http.ResponseWriter, path string) {

--- a/server/aws/sesv2/sdk_roundtrip_ext_test.go
+++ b/server/aws/sesv2/sdk_roundtrip_ext_test.go
@@ -343,7 +343,8 @@ func TestSDKConfigSetOptionsRoundTrip(t *testing.T) {
 		t.Fatalf("VDM options not round-tripped: %+v", got.VdmOptions)
 	}
 
-	// A set created without delivery options reports no delivery block.
+	// A set created without delivery options reports the OPTIONAL TLS-policy
+	// default, matching real SES (which always returns a DeliveryOptions block).
 	if _, err := c.CreateConfigurationSet(ctx, &awsses.CreateConfigurationSetInput{
 		ConfigurationSetName: aws.String("bare"),
 	}); err != nil {
@@ -355,8 +356,8 @@ func TestSDKConfigSetOptionsRoundTrip(t *testing.T) {
 		t.Fatalf("GetConfigurationSet(bare): %v", err)
 	}
 
-	if bare.DeliveryOptions != nil && bare.DeliveryOptions.TlsPolicy != "" {
-		t.Fatalf("bare set should report no delivery TLS policy, got %+v", bare.DeliveryOptions)
+	if bare.DeliveryOptions == nil || bare.DeliveryOptions.TlsPolicy != sestypes.TlsPolicyOptional {
+		t.Fatalf("bare set should report OPTIONAL TLS policy, got %+v", bare.DeliveryOptions)
 	}
 }
 

--- a/server/aws/sesv2/sdk_roundtrip_ext_test.go
+++ b/server/aws/sesv2/sdk_roundtrip_ext_test.go
@@ -298,6 +298,104 @@ func TestSDKConfigSetPutOptions(t *testing.T) {
 	}
 }
 
+// TestSDKConfigSetOptionsRoundTrip verifies the suppression, tracking, delivery
+// and VDM option blocks supplied to CreateConfigurationSet survive a
+// GetConfigurationSet round-trip (they were previously dropped), and that a
+// config set created without delivery options reports no delivery block.
+func TestSDKConfigSetOptionsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c := newSESClient(t)
+
+	if _, err := c.CreateConfigurationSet(ctx, &awsses.CreateConfigurationSetInput{
+		ConfigurationSetName: aws.String("full"),
+		DeliveryOptions:      &sestypes.DeliveryOptions{TlsPolicy: sestypes.TlsPolicyRequire},
+		SendingOptions:       &sestypes.SendingOptions{SendingEnabled: false},
+		SuppressionOptions:   &sestypes.SuppressionOptions{SuppressedReasons: []sestypes.SuppressionListReason{sestypes.SuppressionListReasonBounce}},
+		TrackingOptions:      &sestypes.TrackingOptions{CustomRedirectDomain: aws.String("click.example.com")},
+		VdmOptions: &sestypes.VdmOptions{
+			DashboardOptions: &sestypes.DashboardOptions{EngagementMetrics: sestypes.FeatureStatusEnabled},
+			GuardianOptions:  &sestypes.GuardianOptions{OptimizedSharedDelivery: sestypes.FeatureStatusEnabled},
+		},
+	}); err != nil {
+		t.Fatalf("CreateConfigurationSet: %v", err)
+	}
+
+	got, err := c.GetConfigurationSet(ctx, &awsses.GetConfigurationSetInput{ConfigurationSetName: aws.String("full")})
+	if err != nil {
+		t.Fatalf("GetConfigurationSet: %v", err)
+	}
+
+	if got.DeliveryOptions == nil || got.DeliveryOptions.TlsPolicy != sestypes.TlsPolicyRequire {
+		t.Fatalf("delivery TLS policy not round-tripped: %+v", got.DeliveryOptions)
+	}
+
+	if got.SuppressionOptions == nil || len(got.SuppressionOptions.SuppressedReasons) != 1 ||
+		got.SuppressionOptions.SuppressedReasons[0] != sestypes.SuppressionListReasonBounce {
+		t.Fatalf("suppressed reasons not round-tripped: %+v", got.SuppressionOptions)
+	}
+
+	if got.TrackingOptions == nil || aws.ToString(got.TrackingOptions.CustomRedirectDomain) != "click.example.com" {
+		t.Fatalf("tracking options not round-tripped: %+v", got.TrackingOptions)
+	}
+
+	if got.VdmOptions == nil || got.VdmOptions.DashboardOptions == nil ||
+		got.VdmOptions.DashboardOptions.EngagementMetrics != sestypes.FeatureStatusEnabled {
+		t.Fatalf("VDM options not round-tripped: %+v", got.VdmOptions)
+	}
+
+	// A set created without delivery options reports no delivery block.
+	if _, err := c.CreateConfigurationSet(ctx, &awsses.CreateConfigurationSetInput{
+		ConfigurationSetName: aws.String("bare"),
+	}); err != nil {
+		t.Fatalf("CreateConfigurationSet(bare): %v", err)
+	}
+
+	bare, err := c.GetConfigurationSet(ctx, &awsses.GetConfigurationSetInput{ConfigurationSetName: aws.String("bare")})
+	if err != nil {
+		t.Fatalf("GetConfigurationSet(bare): %v", err)
+	}
+
+	if bare.DeliveryOptions != nil && bare.DeliveryOptions.TlsPolicy != "" {
+		t.Fatalf("bare set should report no delivery TLS policy, got %+v", bare.DeliveryOptions)
+	}
+}
+
+// TestSDKPutVdmOptionsRoundTrip verifies PutConfigurationSetVdmOptions (whose
+// wire body wraps the options under VdmOptions) is decoded and surfaced by
+// GetConfigurationSet.
+func TestSDKPutVdmOptionsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c := newSESClient(t)
+
+	if _, err := c.CreateConfigurationSet(ctx, &awsses.CreateConfigurationSetInput{
+		ConfigurationSetName: aws.String("vdmcs"),
+	}); err != nil {
+		t.Fatalf("CreateConfigurationSet: %v", err)
+	}
+
+	if _, err := c.PutConfigurationSetVdmOptions(ctx, &awsses.PutConfigurationSetVdmOptionsInput{
+		ConfigurationSetName: aws.String("vdmcs"),
+		VdmOptions: &sestypes.VdmOptions{
+			DashboardOptions: &sestypes.DashboardOptions{EngagementMetrics: sestypes.FeatureStatusDisabled},
+			GuardianOptions:  &sestypes.GuardianOptions{OptimizedSharedDelivery: sestypes.FeatureStatusEnabled},
+		},
+	}); err != nil {
+		t.Fatalf("PutConfigurationSetVdmOptions: %v", err)
+	}
+
+	got, err := c.GetConfigurationSet(ctx, &awsses.GetConfigurationSetInput{ConfigurationSetName: aws.String("vdmcs")})
+	if err != nil {
+		t.Fatalf("GetConfigurationSet: %v", err)
+	}
+
+	if got.VdmOptions == nil || got.VdmOptions.DashboardOptions == nil ||
+		got.VdmOptions.DashboardOptions.EngagementMetrics != sestypes.FeatureStatusDisabled ||
+		got.VdmOptions.GuardianOptions == nil ||
+		got.VdmOptions.GuardianOptions.OptimizedSharedDelivery != sestypes.FeatureStatusEnabled {
+		t.Fatalf("put VDM options not surfaced by Get: %+v", got.VdmOptions)
+	}
+}
+
 func TestSDKDedicatedIpPoolLifecycle(t *testing.T) {
 	ctx := context.Background()
 	c := newSESClient(t)

--- a/server/aws/sesv2/types.go
+++ b/server/aws/sesv2/types.go
@@ -129,20 +129,48 @@ type deliveryOptionsJSON struct {
 	SendingPoolName string `json:"SendingPoolName,omitempty"`
 }
 
+type suppressionOptionsJSON struct {
+	SuppressedReasons []string `json:"SuppressedReasons"`
+}
+
+type trackingOptionsJSON struct {
+	CustomRedirectDomain string `json:"CustomRedirectDomain,omitempty"`
+	HTTPSPolicy          string `json:"HttpsPolicy,omitempty"`
+}
+
+type vdmDashboardOptionsJSON struct {
+	EngagementMetrics string `json:"EngagementMetrics,omitempty"`
+}
+
+type vdmGuardianOptionsJSON struct {
+	OptimizedSharedDelivery string `json:"OptimizedSharedDelivery,omitempty"`
+}
+
+type vdmOptionsJSON struct {
+	DashboardOptions *vdmDashboardOptionsJSON `json:"DashboardOptions,omitempty"`
+	GuardianOptions  *vdmGuardianOptionsJSON  `json:"GuardianOptions,omitempty"`
+}
+
 type createConfigurationSetRequest struct {
-	ConfigurationSetName string                 `json:"ConfigurationSetName"`
-	SendingOptions       *sendingOptionsJSON    `json:"SendingOptions"`
-	ReputationOptions    *reputationOptionsJSON `json:"ReputationOptions"`
-	DeliveryOptions      *deliveryOptionsJSON   `json:"DeliveryOptions"`
-	Tags                 []tag                  `json:"Tags"`
+	ConfigurationSetName string                  `json:"ConfigurationSetName"`
+	SendingOptions       *sendingOptionsJSON     `json:"SendingOptions"`
+	ReputationOptions    *reputationOptionsJSON  `json:"ReputationOptions"`
+	DeliveryOptions      *deliveryOptionsJSON    `json:"DeliveryOptions"`
+	SuppressionOptions   *suppressionOptionsJSON `json:"SuppressionOptions"`
+	TrackingOptions      *trackingOptionsJSON    `json:"TrackingOptions"`
+	VdmOptions           *vdmOptionsJSON         `json:"VdmOptions"`
+	Tags                 []tag                   `json:"Tags"`
 }
 
 type getConfigurationSetResponse struct {
-	ConfigurationSetName string                `json:"ConfigurationSetName"`
-	SendingOptions       sendingOptionsJSON    `json:"SendingOptions"`
-	ReputationOptions    reputationOptionsJSON `json:"ReputationOptions"`
-	DeliveryOptions      deliveryOptionsJSON   `json:"DeliveryOptions"`
-	Tags                 []tag                 `json:"Tags"`
+	ConfigurationSetName string                  `json:"ConfigurationSetName"`
+	SendingOptions       sendingOptionsJSON      `json:"SendingOptions"`
+	ReputationOptions    reputationOptionsJSON   `json:"ReputationOptions"`
+	DeliveryOptions      *deliveryOptionsJSON    `json:"DeliveryOptions,omitempty"`
+	SuppressionOptions   *suppressionOptionsJSON `json:"SuppressionOptions,omitempty"`
+	TrackingOptions      *trackingOptionsJSON    `json:"TrackingOptions,omitempty"`
+	VdmOptions           *vdmOptionsJSON         `json:"VdmOptions,omitempty"`
+	Tags                 []tag                   `json:"Tags"`
 }
 
 type listConfigurationSetsResponse struct {

--- a/server/aws/sesv2/types_ext.go
+++ b/server/aws/sesv2/types_ext.go
@@ -94,6 +94,11 @@ type putSuppressionOptionsRequest struct {
 
 type putTrackingOptionsRequest struct {
 	CustomRedirectDomain string `json:"CustomRedirectDomain"`
+	HTTPSPolicy          string `json:"HttpsPolicy"`
+}
+
+type putVdmOptionsRequest struct {
+	VdmOptions *vdmOptionsJSON `json:"VdmOptions"`
 }
 
 // --- contacts / contact lists ---

--- a/services/sesv2/driver/driver.go
+++ b/services/sesv2/driver/driver.go
@@ -81,11 +81,14 @@ type ConfigurationSet struct {
 	Tags           map[string]string
 
 	// Additional put-option state.
-	ArchiveARN        string
-	SuppressedReasons []string
-	CustomRedirectDom string
-	VdmEnabled        bool
-	EventDestinations []EventDestination
+	ArchiveARN          string
+	SuppressedReasons   []string
+	CustomRedirectDom   string
+	TrackingHTTPSPolicy string
+	VdmEnabled          bool
+	VdmEngagement       string
+	VdmGuardianDelivery string
+	EventDestinations   []EventDestination
 }
 
 // TemplateContent is the subject/HTML/text of an email template.
@@ -143,12 +146,18 @@ type CreateIdentityInput struct {
 
 // CreateConfigurationSetInput describes a configuration set to create.
 type CreateConfigurationSetInput struct {
-	Name           string
-	SendingEnabled bool
-	ReputationOn   bool
-	TLSPolicy      string
-	SendingPoolN   string
-	Tags           map[string]string
+	Name                string
+	SendingEnabled      bool
+	ReputationOn        bool
+	TLSPolicy           string
+	SendingPoolN        string
+	SuppressedReasons   []string
+	CustomRedirectDom   string
+	TrackingHTTPSPolicy string
+	VdmConfigured       bool
+	VdmEngagement       string
+	VdmGuardianDelivery string
+	Tags                map[string]string
 }
 
 // TemplateInput describes a template to create or update.
@@ -256,8 +265,8 @@ type SESV2 interface {
 	PutConfigurationSetReputationOptions(ctx context.Context, configSet string, reputationEnabled bool) error
 	PutConfigurationSetSendingOptions(ctx context.Context, configSet string, sendingEnabled bool) error
 	PutConfigurationSetSuppressionOptions(ctx context.Context, configSet string, suppressedReasons []string) error
-	PutConfigurationSetTrackingOptions(ctx context.Context, configSet, customRedirectDomain string) error
-	PutConfigurationSetVdmOptions(ctx context.Context, configSet string) error
+	PutConfigurationSetTrackingOptions(ctx context.Context, configSet, customRedirectDomain, httpsPolicy string) error
+	PutConfigurationSetVdmOptions(ctx context.Context, configSet, engagementMetrics, optimizedSharedDelivery string) error
 
 	// Dedicated IP pools and IPs.
 	CreateDedicatedIPPool(ctx context.Context, name, scalingMode string, tags map[string]string) error


### PR DESCRIPTION
## Summary

Deep real-user e2e audit of AWS SES v2 (`aws_sesv2_email_identity`, `aws_sesv2_configuration_set`, email-identity policies) against live `cloudemu serve` with the real `hashicorp/aws` Terraform provider, `aws-sdk-go-v2/sesv2`, and the `aws sesv2` CLI. Found and fixed genuine cloud-vs-cloudemu divergences; the primary one caused perpetual Terraform drift.

## Divergences fixed

- **Configuration-set nested option blocks dropped (Terraform drift).** `CreateConfigurationSet` ignored `SuppressionOptions`, `TrackingOptions`, and `VdmOptions`, and `GetConfigurationSet` never returned them, so `suppression_options`, `tracking_options`, and `vdm_options` drifted on every `terraform plan`. These are now stored on create and returned on get.
- **`PutConfigurationSetVdmOptions` body mis-decoded.** The real wire body wraps the options under `VdmOptions` (`{"VdmOptions":{"DashboardOptions":…,"GuardianOptions":…}}`); the handler expected them at the top level, so a `vdm_options` update was silently lost and only reconciled on a second apply. Now decoded correctly, making updates idempotent in a single apply.
- **Empty delivery-options block reported.** `GetConfigurationSet` always emitted a `DeliveryOptions` object, so a set created without delivery options drifted on `max_delivery_seconds`/`tls_policy`. It is now emitted only when a TLS policy or sending pool is set.
- **DKIM tokens embedded the domain.** Easy DKIM tokens are domain-independent selectors used to build `<token>._domainkey.<domain>` CNAMEs; they were returned as `<selector>.<domain>`. Fixed to bare selectors.
- **DKIM `SigningHostedZone` was the bare region.** Now returns `dkim.amazonses.com` (the Easy DKIM CNAME target zone).
- **restJson1 error messages leaked the canonical code prefix** (e.g. `NotFound: …`). Now use `cerrors.Message` (the same pattern as the OCI REST codec) so only the message is emitted; the `X-Amzn-Errortype` header already carried the correct exception.

## Evidence

- Terraform full lifecycle against `cloudemu serve`: create → `plan` no drift → update (toggling `sending_enabled`, `tls_policy`, suppression, and VDM) → single-apply idempotent, `plan` no drift → `destroy` clean, across domain identity, email-address identity, and configuration sets (with and without delivery options).
- AWS CLI: identity create/get round-trip, DKIM tokens as bare selectors, `NotFoundException` (404) and `AlreadyExistsException` (400) with clean messages.
- Added SDK round-trip tests for the config-set option blocks and the VDM PUT wrapper; extended the DKIM-token test to assert selectors.

## Gates

`go build ./...`, `go vet`, `go test -race` (server + provider sesv2), root `go test .`, `gofmt -l`, `golangci-lint` (changed packages), and `go generate` (no `docs/coverage` diff) all green.