### PR TITLE
fix(apigateway): real-user e2e divergences from AWS API Gateway v1 REST

### DIFF
--- a/docs/coverage/README.md
+++ b/docs/coverage/README.md
@@ -13,7 +13,7 @@ code does not implement. Machine-readable: [`coverage.json`](./coverage.json).
 | `aad` | — | [Aad](./azure/aad.md) | — | — | 2 |
 | `acm` | [ACM](./aws/acm.md) | — | — | — | 17 |
 | `aks` | — | [AKS](./azure/aks.md) | — | — | 18 |
-| `apigateway` | [APIGateway](./aws/apigateway.md) | — | — | — | 23 |
+| `apigateway` | [APIGateway](./aws/apigateway.md) | — | — | — | 29 |
 | `apigatewayv2` | [APIGatewayV2](./aws/apigatewayv2.md) | — | — | — | 20 |
 | `azureai` | — | [AI](./azure/ai.md) | — | — | 92 |
 | `azuresearch` | — | [Search](./azure/search.md) | — | — | 53 |

--- a/docs/coverage/aws/README.md
+++ b/docs/coverage/aws/README.md
@@ -6,7 +6,7 @@ Services cloudemu emulates for AWS, by native name. Back to the [cross-provider 
 | AWS service | Portable service | Operations |
 | --- | --- | --- |
 | [ACM](./acm.md) | `acm` | 17 |
-| [APIGateway](./apigateway.md) | `apigateway` | 23 |
+| [APIGateway](./apigateway.md) | `apigateway` | 29 |
 | [APIGatewayV2](./apigatewayv2.md) | `apigatewayv2` | 20 |
 | [Bedrock](./bedrock.md) | `bedrock` | 65 |
 | [BedrockAgent](./bedrockagent.md) | `bedrockagent` | 29 |

--- a/docs/coverage/aws/apigateway.md
+++ b/docs/coverage/aws/apigateway.md
@@ -3,7 +3,7 @@
 
 AWS's `apigateway` service · portable interface `driver.APIGateway` · [AWS index](./README.md)
 
-## Operations (23)
+## Operations (29)
 
 | Operation | Description |
 | --- | --- |
@@ -30,6 +30,12 @@ AWS's `apigateway` service · portable interface `driver.APIGateway` · [AWS ind
 | `InvokeRoute` | InvokeRoute resolves req.HTTPMethod+req.Path against the deployed stage's |
 | `PutIntegration` |  |
 | `PutMethod` |  |
+| `UpdateDeployment` | UpdateDeployment applies a patchOperations document to a deployment |
+| `UpdateIntegration` | UpdateIntegration applies a patchOperations document to an integration. |
+| `UpdateMethod` | UpdateMethod applies a patchOperations document to a method. |
+| `UpdateResource` | UpdateResource applies a patchOperations document to a resource (rename via |
+| `UpdateRestAPI` | UpdateRestAPI applies a patchOperations document to a REST API and returns |
+| `UpdateStage` | UpdateStage applies a patchOperations document to a stage (/description, |
 
 ## Not in scope
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -212,6 +212,30 @@
       },
       {
         "name": "PutMethod"
+      },
+      {
+        "name": "UpdateDeployment",
+        "doc": "UpdateDeployment applies a patchOperations document to a deployment"
+      },
+      {
+        "name": "UpdateIntegration",
+        "doc": "UpdateIntegration applies a patchOperations document to an integration."
+      },
+      {
+        "name": "UpdateMethod",
+        "doc": "UpdateMethod applies a patchOperations document to a method."
+      },
+      {
+        "name": "UpdateResource",
+        "doc": "UpdateResource applies a patchOperations document to a resource (rename via"
+      },
+      {
+        "name": "UpdateRestAPI",
+        "doc": "UpdateRestAPI applies a patchOperations document to a REST API and returns"
+      },
+      {
+        "name": "UpdateStage",
+        "doc": "UpdateStage applies a patchOperations document to a stage (/description,"
       }
     ],
     "providers": {

--- a/providers/aws/apigateway/apigateway.go
+++ b/providers/aws/apigateway/apigateway.go
@@ -10,6 +10,7 @@ package apigateway
 import (
 	"context"
 	"crypto/rand"
+	"sort"
 	"sync"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -120,6 +121,9 @@ func (m *Mock) CreateRestAPI(_ context.Context, in *driver.CreateRestAPIInput) (
 		Tags:                       copyStrMap(in.Tags),
 		BinaryMediaTypes:           append([]string(nil), in.BinaryMediaTypes...),
 		EndpointConfigurationTypes: endpointTypes(in.EndpointConfigurationTypes),
+		DisableExecuteAPIEndpoint:  in.DisableExecuteAPIEndpoint,
+		MinimumCompressionSize:     copyIntPtr(in.MinimumCompressionSize),
+		Policy:                     in.Policy,
 	}
 
 	m.apis.Set(apiID, &apiData{
@@ -144,6 +148,16 @@ func (m *Mock) GetRestAPIs(_ context.Context) ([]driver.RestAPI, error) {
 		out = append(out, copyAPI(&ad.api))
 		ad.mu.RUnlock()
 	}
+
+	// Deterministic order: oldest first, ties broken by id (the backing map
+	// iterates randomly).
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CreatedDate != out[j].CreatedDate {
+			return out[i].CreatedDate < out[j].CreatedDate
+		}
+
+		return out[i].ID < out[j].ID
+	})
 
 	return out, nil
 }
@@ -219,6 +233,18 @@ func copyAPI(a *driver.RestAPI) driver.RestAPI {
 	out.Tags = copyStrMap(a.Tags)
 	out.BinaryMediaTypes = append([]string(nil), a.BinaryMediaTypes...)
 	out.EndpointConfigurationTypes = append([]string(nil), a.EndpointConfigurationTypes...)
+	out.MinimumCompressionSize = copyIntPtr(a.MinimumCompressionSize)
 
 	return out
+}
+
+// copyIntPtr returns an independent copy of an *int (nil stays nil).
+func copyIntPtr(p *int) *int {
+	if p == nil {
+		return nil
+	}
+
+	v := *p
+
+	return &v
 }

--- a/providers/aws/apigateway/apigateway_test.go
+++ b/providers/aws/apigateway/apigateway_test.go
@@ -628,6 +628,38 @@ func TestUpdateResourceRenameRecomputesSubtree(t *testing.T) {
 	}
 }
 
+func TestUpdateResourceParentIdCycleRejected(t *testing.T) {
+	m := newMock(t)
+
+	api, _ := m.CreateRestAPI(ctx(), &driver.CreateRestAPIInput{Name: "x"})
+	foo, _ := m.CreateResource(ctx(), api.ID, api.RootResourceID, "foo")
+	bar, _ := m.CreateResource(ctx(), api.ID, foo.ID, "bar")
+
+	// Moving a resource under itself must be rejected, not loop forever.
+	if _, err := m.UpdateResource(ctx(), api.ID, foo.ID, []driver.PatchOperation{
+		{Op: "replace", Path: "/parentId", Value: foo.ID},
+	}); err == nil {
+		t.Fatal("self-parent move should be rejected")
+	}
+
+	// Moving a resource into its own subtree (foo -> under bar) must be rejected.
+	if _, err := m.UpdateResource(ctx(), api.ID, foo.ID, []driver.PatchOperation{
+		{Op: "replace", Path: "/parentId", Value: bar.ID},
+	}); err == nil {
+		t.Fatal("move into own subtree should be rejected")
+	}
+
+	// The tree is unchanged after the rejected moves: foo still under root.
+	got, err := m.GetResource(ctx(), api.ID, foo.ID)
+	if err != nil {
+		t.Fatalf("GetResource: %v", err)
+	}
+
+	if got.ParentID != api.RootResourceID {
+		t.Fatalf("foo parent mutated by a rejected move: %s", got.ParentID)
+	}
+}
+
 func TestUpdateMethodAndIntegrationPatches(t *testing.T) {
 	m := newMock(t)
 	apiID, _, resID := deployProxyAPI(t, m, "hello", "GET", lambdaURI)

--- a/providers/aws/apigateway/apigateway_test.go
+++ b/providers/aws/apigateway/apigateway_test.go
@@ -537,3 +537,216 @@ func TestDeploymentAndStageLifecycle(t *testing.T) {
 		t.Fatalf("GetDeployment after delete: %v, want NotFound", err)
 	}
 }
+
+func TestCreateRestAPIStoresExtendedFields(t *testing.T) {
+	m := newMock(t)
+	size := 4096
+
+	api, err := m.CreateRestAPI(ctx(), &driver.CreateRestAPIInput{
+		Name: "x", DisableExecuteAPIEndpoint: true, MinimumCompressionSize: &size, Policy: `{"p":1}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateRestAPI: %v", err)
+	}
+
+	got, err := m.GetRestAPI(ctx(), api.ID)
+	if err != nil {
+		t.Fatalf("GetRestAPI: %v", err)
+	}
+
+	if !got.DisableExecuteAPIEndpoint || got.MinimumCompressionSize == nil ||
+		*got.MinimumCompressionSize != size || got.Policy != `{"p":1}` {
+		t.Fatalf("extended fields not round-tripped: %+v", got)
+	}
+}
+
+func TestUpdateRestAPIPatches(t *testing.T) {
+	m := newMock(t)
+
+	api, err := m.CreateRestAPI(ctx(), &driver.CreateRestAPIInput{Name: "orig"})
+	if err != nil {
+		t.Fatalf("CreateRestAPI: %v", err)
+	}
+
+	got, err := m.UpdateRestAPI(ctx(), api.ID, []driver.PatchOperation{
+		{Op: "replace", Path: "/name", Value: "renamed"},
+		{Op: "replace", Path: "/description", Value: "desc"},
+		{Op: "replace", Path: "/disableExecuteApiEndpoint", Value: "true"},
+		{Op: "replace", Path: "/minimumCompressionSize", Value: "1024"},
+		{Op: "replace", Path: "/apiKeySource", Value: "AUTHORIZER"},
+		{Op: "replace", Path: "/endpointConfiguration/types/0", Value: "REGIONAL"},
+		{Op: "add", Path: "/binaryMediaTypes/image~1png", Value: "image/png"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateRestAPI: %v", err)
+	}
+
+	if got.Name != "renamed" || got.Description != "desc" || !got.DisableExecuteAPIEndpoint ||
+		got.MinimumCompressionSize == nil || *got.MinimumCompressionSize != 1024 ||
+		got.APIKeySource != "AUTHORIZER" || got.EndpointConfigurationTypes[0] != "REGIONAL" {
+		t.Fatalf("UpdateRestAPI patch not applied: %+v", got)
+	}
+
+	if len(got.BinaryMediaTypes) != 1 || got.BinaryMediaTypes[0] != "image/png" {
+		t.Fatalf("binaryMediaTypes add not applied: %v", got.BinaryMediaTypes)
+	}
+
+	// Removing the compression-size sentinel disables it (nil).
+	got, err = m.UpdateRestAPI(ctx(), api.ID, []driver.PatchOperation{
+		{Op: "remove", Path: "/minimumCompressionSize"},
+		{Op: "remove", Path: "/binaryMediaTypes/image~1png"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateRestAPI remove: %v", err)
+	}
+
+	if got.MinimumCompressionSize != nil || len(got.BinaryMediaTypes) != 0 {
+		t.Fatalf("remove ops not applied: %+v", got)
+	}
+}
+
+func TestUpdateResourceRenameRecomputesSubtree(t *testing.T) {
+	m := newMock(t)
+
+	api, _ := m.CreateRestAPI(ctx(), &driver.CreateRestAPIInput{Name: "x"})
+	foo, _ := m.CreateResource(ctx(), api.ID, api.RootResourceID, "foo")
+	bar, _ := m.CreateResource(ctx(), api.ID, foo.ID, "bar")
+
+	if _, err := m.UpdateResource(ctx(), api.ID, foo.ID, []driver.PatchOperation{
+		{Op: "replace", Path: "/pathPart", Value: "renamed"},
+	}); err != nil {
+		t.Fatalf("UpdateResource: %v", err)
+	}
+
+	child, err := m.GetResource(ctx(), api.ID, bar.ID)
+	if err != nil {
+		t.Fatalf("GetResource: %v", err)
+	}
+
+	if child.Path != "/renamed/bar" {
+		t.Fatalf("subtree path not recomputed: %s, want /renamed/bar", child.Path)
+	}
+}
+
+func TestUpdateMethodAndIntegrationPatches(t *testing.T) {
+	m := newMock(t)
+	apiID, _, resID := deployProxyAPI(t, m, "hello", "GET", lambdaURI)
+
+	mth, err := m.UpdateMethod(ctx(), apiID, resID, "GET", []driver.PatchOperation{
+		{Op: "replace", Path: "/authorizationType", Value: "AWS_IAM"},
+		{Op: "replace", Path: "/apiKeyRequired", Value: "true"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateMethod: %v", err)
+	}
+
+	if mth.AuthorizationType != "AWS_IAM" || !mth.APIKeyRequired {
+		t.Fatalf("UpdateMethod not applied: %+v", mth)
+	}
+
+	ig, err := m.UpdateIntegration(ctx(), apiID, resID, "GET", []driver.PatchOperation{
+		{Op: "replace", Path: "/uri", Value: "newuri"},
+		{Op: "replace", Path: "/timeoutInMillis", Value: "5000"},
+		{Op: "replace", Path: "/passthroughBehavior", Value: "NEVER"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateIntegration: %v", err)
+	}
+
+	if ig.URI != "newuri" || ig.TimeoutInMillis != 5000 || ig.PassthroughBehavior != "NEVER" {
+		t.Fatalf("UpdateIntegration not applied: %+v", ig)
+	}
+}
+
+func TestUpdateStagePatches(t *testing.T) {
+	m := newMock(t)
+	apiID, _, _ := deployProxyAPI(t, m, "hello", "GET", lambdaURI)
+
+	st, err := m.UpdateStage(ctx(), apiID, "prod", []driver.PatchOperation{
+		{Op: "replace", Path: "/description", Value: "updated"},
+		{Op: "add", Path: "/variables/env", Value: "staging"},
+		{Op: "replace", Path: "/variables/tier", Value: "gold"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateStage: %v", err)
+	}
+
+	if st.Description != "updated" || st.Variables["env"] != "staging" || st.Variables["tier"] != "gold" {
+		t.Fatalf("UpdateStage not applied: %+v", st)
+	}
+
+	st, err = m.UpdateStage(ctx(), apiID, "prod", []driver.PatchOperation{
+		{Op: "remove", Path: "/variables/env"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateStage remove: %v", err)
+	}
+
+	if _, ok := st.Variables["env"]; ok {
+		t.Fatalf("variable not removed: %+v", st.Variables)
+	}
+}
+
+func TestUpdateStageInvalidDeploymentIsNotFound(t *testing.T) {
+	m := newMock(t)
+	apiID, _, _ := deployProxyAPI(t, m, "hello", "GET", lambdaURI)
+
+	_, err := m.UpdateStage(ctx(), apiID, "prod", []driver.PatchOperation{
+		{Op: "replace", Path: "/deploymentId", Value: "nope"},
+	})
+	if !errors.IsNotFound(err) {
+		t.Fatalf("UpdateStage bad deploymentId: %v, want NotFound", err)
+	}
+}
+
+func TestUpdateDeploymentDescription(t *testing.T) {
+	m := newMock(t)
+	apiID, _, _ := deployProxyAPI(t, m, "hello", "GET", lambdaURI)
+
+	deps, _ := m.GetDeployments(ctx(), apiID)
+
+	got, err := m.UpdateDeployment(ctx(), apiID, deps[0].ID, []driver.PatchOperation{
+		{Op: "replace", Path: "/description", Value: "v2"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateDeployment: %v", err)
+	}
+
+	if got.Description != "v2" {
+		t.Fatalf("UpdateDeployment not applied: %+v", got)
+	}
+}
+
+func TestGetResourcesDeterministicOrder(t *testing.T) {
+	m := newMock(t)
+
+	api, _ := m.CreateRestAPI(ctx(), &driver.CreateRestAPIInput{Name: "x"})
+	foo, _ := m.CreateResource(ctx(), api.ID, api.RootResourceID, "foo")
+	if _, err := m.CreateResource(ctx(), api.ID, foo.ID, "bar"); err != nil {
+		t.Fatalf("CreateResource: %v", err)
+	}
+
+	want := []string{"/", "/foo", "/foo/bar"}
+
+	for i := 0; i < 5; i++ {
+		res, err := m.GetResources(ctx(), api.ID)
+		if err != nil {
+			t.Fatalf("GetResources: %v", err)
+		}
+
+		for j, r := range res {
+			if r.Path != want[j] {
+				t.Fatalf("iteration %d: order = %v, want %v", i, paths(res), want)
+			}
+		}
+	}
+}
+
+func paths(res []driver.Resource) []string {
+	out := make([]string, len(res))
+	for i, r := range res {
+		out[i] = r.Path
+	}
+
+	return out
+}

--- a/providers/aws/apigateway/deploy.go
+++ b/providers/aws/apigateway/deploy.go
@@ -2,6 +2,7 @@ package apigateway
 
 import (
 	"context"
+	"sort"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/services/apigateway/driver"
@@ -52,6 +53,16 @@ func (m *Mock) GetDeployments(_ context.Context, restAPIID string) ([]driver.Dep
 	for _, d := range ad.deployments {
 		out = append(out, *d)
 	}
+
+	// Deterministic order: oldest first, ties broken by id (the backing map
+	// iterates randomly).
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CreatedDate != out[j].CreatedDate {
+			return out[i].CreatedDate < out[j].CreatedDate
+		}
+
+		return out[i].ID < out[j].ID
+	})
 
 	return out, nil
 }
@@ -143,6 +154,8 @@ func (m *Mock) CreateStage(_ context.Context, restAPIID string, in driver.Create
 }
 
 // GetStages lists every stage of a REST API.
+//
+//nolint:dupl // mirrors the sibling GetResources list-and-sort by design
 func (m *Mock) GetStages(_ context.Context, restAPIID string) ([]driver.Stage, error) {
 	ad, err := m.getAPI(restAPIID)
 	if err != nil {
@@ -156,6 +169,9 @@ func (m *Mock) GetStages(_ context.Context, restAPIID string) ([]driver.Stage, e
 	for _, s := range ad.stages {
 		out = append(out, copyStage(s))
 	}
+
+	// Deterministic order by stage name (the backing map iterates randomly).
+	sort.Slice(out, func(i, j int) bool { return out[i].StageName < out[j].StageName })
 
 	return out, nil
 }

--- a/providers/aws/apigateway/patch.go
+++ b/providers/aws/apigateway/patch.go
@@ -117,8 +117,21 @@ func (m *Mock) UpdateResource(
 		case "/pathPart":
 			res.PathPart = op.Value
 		case "/parentId":
+			if op.Value == resourceID {
+				return nil, cerrors.New(cerrors.InvalidArgument, "A resource cannot be its own parent")
+			}
+
 			if _, ok := ad.resources[op.Value]; !ok {
 				return nil, cerrors.Newf(cerrors.NotFound, "Invalid resource identifier specified %s", op.Value)
+			}
+
+			// Reject a move into the resource's own subtree: the target must not
+			// be a descendant, or the tree would become cyclic and path
+			// recomputation would never terminate. Check before mutating.
+			for _, id := range descendants(ad.resources, resourceID) {
+				if id == op.Value {
+					return nil, cerrors.New(cerrors.InvalidArgument, "Cannot move a resource into its own subtree")
+				}
 			}
 
 			res.ParentID = op.Value

--- a/providers/aws/apigateway/patch.go
+++ b/providers/aws/apigateway/patch.go
@@ -1,0 +1,376 @@
+package apigateway
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/apigateway/driver"
+)
+
+// opReplace, opAdd and opRemove are the JSON Patch ops API Gateway's
+// patchOperations documents use.
+const (
+	opReplace = "replace"
+	opAdd     = "add"
+	opRemove  = "remove"
+)
+
+// pathDescription is the JSON Pointer for the /description field, shared by the
+// RestApi, Stage and Deployment patch appliers.
+const pathDescription = "/description"
+
+// UpdateRestAPI applies a patchOperations document to a REST API.
+func (m *Mock) UpdateRestAPI(_ context.Context, id string, ops []driver.PatchOperation) (*driver.RestAPI, error) {
+	ad, err := m.getAPI(id)
+	if err != nil {
+		return nil, err
+	}
+
+	ad.mu.Lock()
+	defer ad.mu.Unlock()
+
+	for _, op := range ops {
+		applyRestAPIPatch(&ad.api, op)
+	}
+
+	out := copyAPI(&ad.api)
+
+	return &out, nil
+}
+
+// applyRestAPIPatch applies one patch op to a RestAPI, ignoring paths the model
+// does not track (matching how a client only patches fields it manages).
+func applyRestAPIPatch(api *driver.RestAPI, op driver.PatchOperation) {
+	switch op.Path {
+	case "/name":
+		api.Name = op.Value
+	case pathDescription:
+		api.Description = op.Value
+	case "/apiKeySource":
+		api.APIKeySource = op.Value
+	case "/policy":
+		api.Policy = op.Value
+	case "/disableExecuteApiEndpoint":
+		api.DisableExecuteAPIEndpoint = parseBool(op.Value)
+	case "/minimumCompressionSize":
+		api.MinimumCompressionSize = parseCompressionSize(op)
+	default:
+		applyRestAPIListPatch(api, op)
+	}
+}
+
+// applyRestAPIListPatch handles the slice-valued RestAPI patch paths
+// (binaryMediaTypes add/remove and endpointConfiguration/types/<i> replace).
+func applyRestAPIListPatch(api *driver.RestAPI, op driver.PatchOperation) {
+	switch {
+	case strings.HasPrefix(op.Path, "/binaryMediaTypes/"):
+		mediaType := unescapePointer(strings.TrimPrefix(op.Path, "/binaryMediaTypes/"))
+		api.BinaryMediaTypes = patchStringSlice(api.BinaryMediaTypes, op.Op, mediaType)
+	case strings.HasPrefix(op.Path, "/endpointConfiguration/types/"):
+		if op.Op == opReplace {
+			idx, err := strconv.Atoi(strings.TrimPrefix(op.Path, "/endpointConfiguration/types/"))
+			if err == nil && idx >= 0 && idx < len(api.EndpointConfigurationTypes) {
+				api.EndpointConfigurationTypes[idx] = op.Value
+			}
+		}
+	}
+}
+
+// parseCompressionSize maps a /minimumCompressionSize op to the stored pointer:
+// remove (or a negative sentinel) disables compression (nil); a non-negative
+// value enables it.
+func parseCompressionSize(op driver.PatchOperation) *int {
+	if op.Op == opRemove {
+		return nil
+	}
+
+	n, err := strconv.Atoi(op.Value)
+	if err != nil || n < 0 {
+		return nil
+	}
+
+	return &n
+}
+
+// UpdateResource applies a patch document to a resource: /pathPart renames it
+// and /parentId moves it, in both cases recomputing the affected subtree paths.
+func (m *Mock) UpdateResource(
+	_ context.Context, restAPIID, resourceID string, ops []driver.PatchOperation,
+) (*driver.Resource, error) {
+	ad, err := m.getAPI(restAPIID)
+	if err != nil {
+		return nil, err
+	}
+
+	ad.mu.Lock()
+	defer ad.mu.Unlock()
+
+	res, ok := ad.resources[resourceID]
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "Invalid resource identifier specified %s", resourceID)
+	}
+
+	for _, op := range ops {
+		switch op.Path {
+		case "/pathPart":
+			res.PathPart = op.Value
+		case "/parentId":
+			if _, ok := ad.resources[op.Value]; !ok {
+				return nil, cerrors.Newf(cerrors.NotFound, "Invalid resource identifier specified %s", op.Value)
+			}
+
+			res.ParentID = op.Value
+		}
+	}
+
+	recomputePaths(ad.resources, resourceID)
+
+	out := copyResource(res)
+
+	return &out, nil
+}
+
+// recomputePaths rebuilds the Path of resourceID and every descendant from the
+// current parent chain, after a rename or move.
+func recomputePaths(resources map[string]*driver.Resource, resourceID string) {
+	for _, id := range descendants(resources, resourceID) {
+		r := resources[id]
+		if r.ParentID == "" {
+			continue
+		}
+
+		if parent, ok := resources[r.ParentID]; ok {
+			r.Path = joinPath(parent.Path, r.PathPart)
+		}
+	}
+}
+
+// UpdateMethod applies a patch document to a method.
+func (m *Mock) UpdateMethod(
+	_ context.Context, restAPIID, resourceID, httpMethod string, ops []driver.PatchOperation,
+) (*driver.Method, error) {
+	ad, err := m.getAPI(restAPIID)
+	if err != nil {
+		return nil, err
+	}
+
+	ad.mu.Lock()
+	defer ad.mu.Unlock()
+
+	res, ok := ad.resources[resourceID]
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "Invalid resource identifier specified %s", resourceID)
+	}
+
+	mth, ok := res.Methods[normalizeMethod(httpMethod)]
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "Invalid method identifier specified %s", httpMethod)
+	}
+
+	for _, op := range ops {
+		switch op.Path {
+		case "/authorizationType":
+			mth.AuthorizationType = op.Value
+		case "/apiKeyRequired":
+			mth.APIKeyRequired = parseBool(op.Value)
+		}
+	}
+
+	out := copyMethod(mth)
+
+	return &out, nil
+}
+
+// UpdateIntegration applies a patch document to a method's integration.
+func (m *Mock) UpdateIntegration(
+	_ context.Context, restAPIID, resourceID, httpMethod string, ops []driver.PatchOperation,
+) (*driver.Integration, error) {
+	ad, err := m.getAPI(restAPIID)
+	if err != nil {
+		return nil, err
+	}
+
+	ad.mu.Lock()
+	defer ad.mu.Unlock()
+
+	res, ok := ad.resources[resourceID]
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "Invalid resource identifier specified %s", resourceID)
+	}
+
+	mth, ok := res.Methods[normalizeMethod(httpMethod)]
+	if !ok || mth.Integration == nil {
+		return nil, cerrors.New(cerrors.NotFound, "No integration defined for method")
+	}
+
+	for _, op := range ops {
+		applyIntegrationPatch(mth.Integration, op)
+	}
+
+	out := *mth.Integration
+
+	return &out, nil
+}
+
+// applyIntegrationPatch applies one patch op to an Integration.
+func applyIntegrationPatch(ig *driver.Integration, op driver.PatchOperation) {
+	switch op.Path {
+	case "/uri":
+		ig.URI = op.Value
+	case "/type":
+		ig.Type = op.Value
+	case "/integrationHttpMethod":
+		ig.IntegrationHTTPMethod = op.Value
+	case "/passthroughBehavior":
+		ig.PassthroughBehavior = op.Value
+	case "/timeoutInMillis":
+		if n, err := strconv.Atoi(op.Value); err == nil {
+			ig.TimeoutInMillis = n
+		}
+	}
+}
+
+// UpdateDeployment applies a patch document to a deployment (only /description
+// is mutable).
+func (m *Mock) UpdateDeployment(
+	_ context.Context, restAPIID, deploymentID string, ops []driver.PatchOperation,
+) (*driver.Deployment, error) {
+	ad, err := m.getAPI(restAPIID)
+	if err != nil {
+		return nil, err
+	}
+
+	ad.mu.Lock()
+	defer ad.mu.Unlock()
+
+	dep, ok := ad.deployments[deploymentID]
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "Invalid deployment identifier specified %s", deploymentID)
+	}
+
+	for _, op := range ops {
+		if op.Path == pathDescription {
+			dep.Description = op.Value
+		}
+	}
+
+	out := *dep
+
+	return &out, nil
+}
+
+// UpdateStage applies a patch document to a stage.
+func (m *Mock) UpdateStage(
+	_ context.Context, restAPIID, stageName string, ops []driver.PatchOperation,
+) (*driver.Stage, error) {
+	ad, err := m.getAPI(restAPIID)
+	if err != nil {
+		return nil, err
+	}
+
+	ad.mu.Lock()
+	defer ad.mu.Unlock()
+
+	st, ok := ad.stages[stageName]
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "Invalid stage identifier specified %s", stageName)
+	}
+
+	for _, op := range ops {
+		if err := applyStagePatch(ad, st, op); err != nil {
+			return nil, err
+		}
+	}
+
+	out := copyStage(st)
+
+	return &out, nil
+}
+
+// applyStagePatch applies one patch op to a Stage, validating a /deploymentId
+// re-point against the API's deployments.
+func applyStagePatch(ad *apiData, st *driver.Stage, op driver.PatchOperation) error {
+	switch {
+	case op.Path == pathDescription:
+		st.Description = op.Value
+	case op.Path == "/deploymentId":
+		if _, ok := ad.deployments[op.Value]; !ok {
+			return cerrors.Newf(cerrors.NotFound, "Invalid deployment identifier specified %s", op.Value)
+		}
+
+		st.DeploymentID = op.Value
+	case strings.HasPrefix(op.Path, "/variables/"):
+		key := unescapePointer(strings.TrimPrefix(op.Path, "/variables/"))
+		if op.Op == opRemove {
+			delete(st.Variables, key)
+
+			return nil
+		}
+
+		if st.Variables == nil {
+			st.Variables = map[string]string{}
+		}
+
+		st.Variables[key] = op.Value
+	}
+
+	return nil
+}
+
+// patchStringSlice adds or removes v from a string slice (used for the
+// add/remove-valued list paths such as binaryMediaTypes).
+func patchStringSlice(s []string, op, v string) []string {
+	switch op {
+	case opAdd, opReplace:
+		for _, e := range s {
+			if e == v {
+				return s
+			}
+		}
+
+		return append(s, v)
+	case opRemove:
+		out := s[:0:0]
+
+		for _, e := range s {
+			if e != v {
+				out = append(out, e)
+			}
+		}
+
+		return out
+	default:
+		return s
+	}
+}
+
+// copyMethod returns a deep copy of a method and its integration.
+func copyMethod(mth *driver.Method) driver.Method {
+	out := *mth
+
+	if mth.Integration != nil {
+		ig := *mth.Integration
+		out.Integration = &ig
+	}
+
+	return out
+}
+
+// parseBool reports whether an on-the-wire patch value (always a string) is
+// true.
+func parseBool(v string) bool {
+	b, _ := strconv.ParseBool(v)
+
+	return b
+}
+
+// unescapePointer decodes a single JSON Pointer reference token ("~1" -> "/",
+// "~0" -> "~"), so a map key or media type carrying those characters round-trips.
+func unescapePointer(tok string) string {
+	tok = strings.ReplaceAll(tok, "~1", "/")
+	tok = strings.ReplaceAll(tok, "~0", "~")
+
+	return tok
+}

--- a/providers/aws/apigateway/resources.go
+++ b/providers/aws/apigateway/resources.go
@@ -2,6 +2,7 @@ package apigateway
 
 import (
 	"context"
+	"sort"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -57,6 +58,8 @@ func (m *Mock) CreateResource(_ context.Context, restAPIID, parentID, pathPart s
 }
 
 // GetResources lists every resource of a REST API.
+//
+//nolint:dupl // mirrors the sibling GetStages list-and-sort by design
 func (m *Mock) GetResources(_ context.Context, restAPIID string) ([]driver.Resource, error) {
 	ad, err := m.getAPI(restAPIID)
 	if err != nil {
@@ -70,6 +73,10 @@ func (m *Mock) GetResources(_ context.Context, restAPIID string) ([]driver.Resou
 	for _, r := range ad.resources {
 		out = append(out, copyResource(r))
 	}
+
+	// Deterministic order (root "/" first, then tree order) — the backing map
+	// iterates randomly, which would make GetResources non-deterministic.
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
 
 	return out, nil
 }

--- a/providers/aws/apigateway/resources.go
+++ b/providers/aws/apigateway/resources.go
@@ -112,12 +112,17 @@ func (m *Mock) DeleteResource(_ context.Context, restAPIID, resourceID string) e
 // subtree in one pass.
 func descendants(resources map[string]*driver.Resource, resourceID string) []string {
 	out := []string{resourceID}
+	seen := map[string]bool{resourceID: true}
 
 	for i := 0; i < len(out); i++ {
 		parent := out[i]
 
 		for id, r := range resources {
-			if r.ParentID == parent {
+			// seen guards against a malformed cyclic tree so the walk always
+			// terminates, even though callers reject cycles up front.
+			if r.ParentID == parent && !seen[id] {
+				seen[id] = true
+
 				out = append(out, id)
 			}
 		}

--- a/server/aws/apigateway/apigateway_e2e_test.go
+++ b/server/aws/apigateway/apigateway_e2e_test.go
@@ -311,3 +311,55 @@ func TestE2E_ControlPlaneRoundTrip(t *testing.T) {
 		t.Fatalf("GetRestApis returned no items: %v", list)
 	}
 }
+
+// TestE2E_UpdatePatchRoundTrip exercises the PATCH (Update*) verbs across the
+// control plane the way Terraform does: a patchOperations document per object,
+// then a GET to confirm the mutation round-trips.
+func TestE2E_UpdatePatchRoundTrip(t *testing.T) {
+	srv := newE2E(t)
+	base := srv.URL
+
+	api := doJSON(t, http.MethodPost, base+"/restapis", `{"name":"orig"}`)
+	apiID, _ := api["id"].(string)
+	rootID, _ := api["rootResourceId"].(string)
+
+	// UpdateRestApi: rename + toggle disableExecuteApiEndpoint + set compression.
+	upd := doJSON(t, http.MethodPatch, base+"/restapis/"+apiID,
+		`{"patchOperations":[{"op":"replace","path":"/name","value":"renamed"},`+
+			`{"op":"replace","path":"/disableExecuteApiEndpoint","value":"true"},`+
+			`{"op":"replace","path":"/minimumCompressionSize","value":"1024"}]}`)
+	if upd["name"] != "renamed" || upd["disableExecuteApiEndpoint"] != true ||
+		upd["minimumCompressionSize"].(float64) != 1024 {
+		t.Fatalf("UpdateRestApi round-trip: %v", upd)
+	}
+
+	res := doJSON(t, http.MethodPost, base+"/restapis/"+apiID+"/resources/"+rootID, `{"pathPart":"pets"}`)
+	resID, _ := res["id"].(string)
+
+	doJSON(t, http.MethodPut, base+"/restapis/"+apiID+"/resources/"+resID+"/methods/GET", `{"authorizationType":"NONE"}`)
+	doJSON(t, http.MethodPut, base+"/restapis/"+apiID+"/resources/"+resID+"/methods/GET/integration", `{"type":"MOCK"}`)
+
+	// UpdateMethod + UpdateIntegration.
+	m := doJSON(t, http.MethodPatch, base+"/restapis/"+apiID+"/resources/"+resID+"/methods/GET",
+		`{"patchOperations":[{"op":"replace","path":"/apiKeyRequired","value":"true"}]}`)
+	if m["apiKeyRequired"] != true {
+		t.Fatalf("UpdateMethod round-trip: %v", m)
+	}
+
+	ig := doJSON(t, http.MethodPatch, base+"/restapis/"+apiID+"/resources/"+resID+"/methods/GET/integration",
+		`{"patchOperations":[{"op":"replace","path":"/timeoutInMillis","value":"5000"}]}`)
+	if ig["timeoutInMillis"].(float64) != 5000 {
+		t.Fatalf("UpdateIntegration round-trip: %v", ig)
+	}
+
+	// UpdateStage variables + description.
+	doJSON(t, http.MethodPost, base+"/restapis/"+apiID+"/deployments", `{"stageName":"prod"}`)
+
+	st := doJSON(t, http.MethodPatch, base+"/restapis/"+apiID+"/stages/prod",
+		`{"patchOperations":[{"op":"replace","path":"/description","value":"live"},`+
+			`{"op":"add","path":"/variables/env","value":"staging"}]}`)
+	vars, _ := st["variables"].(map[string]any)
+	if st["description"] != "live" || vars["env"] != "staging" {
+		t.Fatalf("UpdateStage round-trip: %v", st)
+	}
+}

--- a/server/aws/apigateway/handler.go
+++ b/server/aws/apigateway/handler.go
@@ -144,6 +144,8 @@ func (h *Handler) createRestAPI(w http.ResponseWriter, r *http.Request) {
 	in := driver.CreateRestAPIInput{
 		Name: req.Name, Description: req.Description, Version: req.Version,
 		APIKeySource: req.APIKeySource, Tags: req.Tags, BinaryMediaTypes: req.BinaryMediaTypes,
+		DisableExecuteAPIEndpoint: req.DisableExecuteAPIEndpoint,
+		MinimumCompressionSize:    req.MinimumCompressionSize, Policy: req.Policy,
 	}
 	if req.EndpointConfiguration != nil {
 		in.EndpointConfigurationTypes = req.EndpointConfiguration.Types
@@ -158,8 +160,18 @@ func (h *Handler) createRestAPI(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, toRestAPIResponse(api))
 }
 
-// serveAPI handles /restapis/{id}: GET=GetRestApi, DELETE=DeleteRestApi.
+// serveAPI handles /restapis/{id}: GET=GetRestApi, PATCH=UpdateRestApi,
+// DELETE=DeleteRestApi.
 func (h *Handler) serveAPI(w http.ResponseWriter, r *http.Request, id string) {
+	if servePatch(w, r,
+		func(ops []driver.PatchOperation) (*driver.RestAPI, error) {
+			return h.ag.UpdateRestAPI(r.Context(), id, ops)
+		},
+		toRestAPIResponse,
+	) {
+		return
+	}
+
 	switch r.Method {
 	case http.MethodGet:
 		api, err := h.ag.GetRestAPI(r.Context(), id)
@@ -179,6 +191,34 @@ func (h *Handler) serveAPI(w http.ResponseWriter, r *http.Request, id string) {
 	default:
 		writeMethodNotAllowed(w)
 	}
+}
+
+// servePatch handles the PATCH verb shared by every Update* route: it decodes
+// the patchOperations body, applies it via update, and renders the result. It
+// reports whether it handled the request (true for any PATCH); a non-PATCH
+// request is left for the caller's own verb switch.
+func servePatch[T, R any](
+	w http.ResponseWriter, r *http.Request,
+	update func(ops []driver.PatchOperation) (T, error), render func(T) R,
+) bool {
+	if r.Method != http.MethodPatch {
+		return false
+	}
+
+	var req patchRequest
+	if !decodeJSON(w, r, &req) {
+		return true
+	}
+
+	v, err := update(toPatchOps(req.PatchOperations))
+	if err != nil {
+		writeErr(w, err)
+		return true
+	}
+
+	writeJSON(w, http.StatusOK, render(v))
+
+	return true
 }
 
 // serveAPISub handles /restapis/{id}/{resources|deployments|stages}.
@@ -258,8 +298,18 @@ func (h *Handler) getResources(w http.ResponseWriter, r *http.Request, id string
 }
 
 // serveResourceItem handles /restapis/{id}/resources/{resourceId}:
-// GET=GetResource, POST=CreateResource (child under {resourceId}).
+// GET=GetResource, POST=CreateResource (child under {resourceId}),
+// PATCH=UpdateResource.
 func (h *Handler) serveResourceItem(w http.ResponseWriter, r *http.Request, id, resourceID string) {
+	if servePatch(w, r,
+		func(ops []driver.PatchOperation) (*driver.Resource, error) {
+			return h.ag.UpdateResource(r.Context(), id, resourceID, ops)
+		},
+		toResourceResponse,
+	) {
+		return
+	}
+
 	switch r.Method {
 	case http.MethodGet:
 		res, err := h.ag.GetResource(r.Context(), id, resourceID)
@@ -295,9 +345,18 @@ func (h *Handler) serveResourceItem(w http.ResponseWriter, r *http.Request, id, 
 }
 
 // serveMethod handles /restapis/{id}/resources/{rid}/methods/{httpMethod}:
-// PUT=PutMethod, GET=GetMethod.
+// PUT=PutMethod, GET=GetMethod, PATCH=UpdateMethod.
 func (h *Handler) serveMethod(w http.ResponseWriter, r *http.Request, segs []string) {
 	id, resourceID, httpMethod := segs[0], segs[2], segs[4]
+
+	if servePatch(w, r,
+		func(ops []driver.PatchOperation) (*driver.Method, error) {
+			return h.ag.UpdateMethod(r.Context(), id, resourceID, httpMethod, ops)
+		},
+		toMethodResponse,
+	) {
+		return
+	}
 
 	switch r.Method {
 	case http.MethodPut:
@@ -345,6 +404,15 @@ func (h *Handler) serveIntegration(w http.ResponseWriter, r *http.Request, segs 
 	}
 
 	id, resourceID, httpMethod := segs[0], segs[2], segs[4]
+
+	if servePatch(w, r,
+		func(ops []driver.PatchOperation) (*driver.Integration, error) {
+			return h.ag.UpdateIntegration(r.Context(), id, resourceID, httpMethod, ops)
+		},
+		toIntegrationResponse,
+	) {
+		return
+	}
 
 	switch r.Method {
 	case http.MethodPut:
@@ -400,9 +468,14 @@ func (h *Handler) getDeployments(w http.ResponseWriter, r *http.Request, id stri
 }
 
 // serveDeploymentItem handles /restapis/{id}/deployments/{deploymentId}:
-// GET=GetDeployment, DELETE=DeleteDeployment.
+// GET=GetDeployment, PATCH=UpdateDeployment, DELETE=DeleteDeployment.
+//
+//nolint:dupl // parallel item router for deployments vs stages; the shared serveItem shape is intentional
 func (h *Handler) serveDeploymentItem(w http.ResponseWriter, r *http.Request, id, deploymentID string) {
-	serveGetDelete(w, r,
+	serveItem(w, r,
+		func(ops []driver.PatchOperation) (*driver.Deployment, error) {
+			return h.ag.UpdateDeployment(r.Context(), id, deploymentID, ops)
+		},
 		func() (*driver.Deployment, error) { return h.ag.GetDeployment(r.Context(), id, deploymentID) },
 		func() error { return h.ag.DeleteDeployment(r.Context(), id, deploymentID) },
 		toDeploymentResponse,
@@ -470,21 +543,32 @@ func (h *Handler) getStages(w http.ResponseWriter, r *http.Request, id string) {
 }
 
 // serveStageItem handles /restapis/{id}/stages/{stageName}: GET=GetStage,
-// DELETE=DeleteStage.
+// PATCH=UpdateStage, DELETE=DeleteStage.
+//
+//nolint:dupl // parallel item router for stages vs deployments; the shared serveItem shape is intentional
 func (h *Handler) serveStageItem(w http.ResponseWriter, r *http.Request, id, stageName string) {
-	serveGetDelete(w, r,
+	serveItem(w, r,
+		func(ops []driver.PatchOperation) (*driver.Stage, error) {
+			return h.ag.UpdateStage(r.Context(), id, stageName, ops)
+		},
 		func() (*driver.Stage, error) { return h.ag.GetStage(r.Context(), id, stageName) },
 		func() error { return h.ag.DeleteStage(r.Context(), id, stageName) },
 		toStageResponse,
 	)
 }
 
-// serveGetDelete handles the common GET-one/DELETE-one shape shared by the
-// deployment and stage item routes: GET renders get()'s result with render,
-// DELETE calls del(), and any other method is rejected.
-func serveGetDelete[T, R any](
-	w http.ResponseWriter, r *http.Request, get func() (T, error), del func() error, render func(T) R,
+// serveItem handles the PATCH/GET/DELETE-one shape shared by the deployment and
+// stage item routes: PATCH applies update(), GET renders get()'s result, DELETE
+// calls del(), and any other method is rejected.
+func serveItem[T, R any](
+	w http.ResponseWriter, r *http.Request,
+	update func(ops []driver.PatchOperation) (T, error),
+	get func() (T, error), del func() error, render func(T) R,
 ) {
+	if servePatch(w, r, update, render) {
+		return
+	}
+
 	switch r.Method {
 	case http.MethodGet:
 		v, err := get()

--- a/server/aws/apigateway/types.go
+++ b/server/aws/apigateway/types.go
@@ -4,13 +4,41 @@ import "github.com/stackshy/cloudemu/v2/services/apigateway/driver"
 
 // createRestAPIRequest is the CreateRestApi request body (restJson1).
 type createRestAPIRequest struct {
-	Name                  string                 `json:"name"`
-	Description           string                 `json:"description"`
-	Version               string                 `json:"version"`
-	APIKeySource          string                 `json:"apiKeySource"`
-	BinaryMediaTypes      []string               `json:"binaryMediaTypes"`
-	Tags                  map[string]string      `json:"tags"`
-	EndpointConfiguration *endpointConfiguration `json:"endpointConfiguration"`
+	Name                      string                 `json:"name"`
+	Description               string                 `json:"description"`
+	Version                   string                 `json:"version"`
+	APIKeySource              string                 `json:"apiKeySource"`
+	BinaryMediaTypes          []string               `json:"binaryMediaTypes"`
+	Tags                      map[string]string      `json:"tags"`
+	EndpointConfiguration     *endpointConfiguration `json:"endpointConfiguration"`
+	DisableExecuteAPIEndpoint bool                   `json:"disableExecuteApiEndpoint"`
+	MinimumCompressionSize    *int                   `json:"minimumCompressionSize"`
+	Policy                    string                 `json:"policy"`
+}
+
+// patchRequest is the shared update request body: an AWS patchOperations
+// (JSON Patch) document sent to any Update* operation.
+type patchRequest struct {
+	PatchOperations []patchOperation `json:"patchOperations"`
+}
+
+// patchOperation is one JSON Patch op. Value is decoded as a raw string because
+// API Gateway always encodes patch values as strings, even for bool/int fields.
+type patchOperation struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value string `json:"value"`
+	From  string `json:"from"`
+}
+
+// toPatchOps converts decoded wire patch ops to the driver's type.
+func toPatchOps(in []patchOperation) []driver.PatchOperation {
+	out := make([]driver.PatchOperation, 0, len(in))
+	for _, op := range in {
+		out = append(out, driver.PatchOperation{Op: op.Op, Path: op.Path, Value: op.Value, From: op.From})
+	}
+
+	return out
 }
 
 type endpointConfiguration struct {
@@ -53,16 +81,19 @@ type createStageRequest struct {
 
 // restAPIResponse is the RestApi wire object.
 type restAPIResponse struct {
-	ID                    string                 `json:"id"`
-	Name                  string                 `json:"name"`
-	Description           string                 `json:"description,omitempty"`
-	Version               string                 `json:"version,omitempty"`
-	CreatedDate           int64                  `json:"createdDate"`
-	RootResourceID        string                 `json:"rootResourceId"`
-	APIKeySource          string                 `json:"apiKeySource,omitempty"`
-	Tags                  map[string]string      `json:"tags,omitempty"`
-	BinaryMediaTypes      []string               `json:"binaryMediaTypes,omitempty"`
-	EndpointConfiguration *endpointConfiguration `json:"endpointConfiguration,omitempty"`
+	ID                        string                 `json:"id"`
+	Name                      string                 `json:"name"`
+	Description               string                 `json:"description,omitempty"`
+	Version                   string                 `json:"version,omitempty"`
+	CreatedDate               int64                  `json:"createdDate"`
+	RootResourceID            string                 `json:"rootResourceId"`
+	APIKeySource              string                 `json:"apiKeySource,omitempty"`
+	Tags                      map[string]string      `json:"tags,omitempty"`
+	BinaryMediaTypes          []string               `json:"binaryMediaTypes,omitempty"`
+	EndpointConfiguration     *endpointConfiguration `json:"endpointConfiguration,omitempty"`
+	DisableExecuteAPIEndpoint bool                   `json:"disableExecuteApiEndpoint"`
+	MinimumCompressionSize    *int                   `json:"minimumCompressionSize,omitempty"`
+	Policy                    string                 `json:"policy,omitempty"`
 }
 
 // listRestAPIsResponse is the GetRestApis wire object.
@@ -132,6 +163,8 @@ func toRestAPIResponse(a *driver.RestAPI) restAPIResponse {
 		ID: a.ID, Name: a.Name, Description: a.Description, Version: a.Version,
 		CreatedDate: a.CreatedDate, RootResourceID: a.RootResourceID,
 		APIKeySource: a.APIKeySource, Tags: a.Tags, BinaryMediaTypes: a.BinaryMediaTypes,
+		DisableExecuteAPIEndpoint: a.DisableExecuteAPIEndpoint,
+		MinimumCompressionSize:    a.MinimumCompressionSize, Policy: a.Policy,
 	}
 	if len(a.EndpointConfigurationTypes) > 0 {
 		resp.EndpointConfiguration = &endpointConfiguration{Types: a.EndpointConfigurationTypes}

--- a/services/apigateway/driver/driver.go
+++ b/services/apigateway/driver/driver.go
@@ -38,6 +38,24 @@ type RestAPI struct {
 	Tags                       map[string]string
 	BinaryMediaTypes           []string
 	EndpointConfigurationTypes []string
+	DisableExecuteAPIEndpoint  bool
+	// MinimumCompressionSize is nil when unset (compression disabled); a non-nil
+	// value in [0,10485760] enables payload compression above that byte size.
+	MinimumCompressionSize *int
+	Policy                 string
+}
+
+// PatchOperation is one entry of an AWS API Gateway update request's
+// patchOperations array (a JSON Patch operation). Op is "replace", "add",
+// "remove" or "copy"; Path is a "/"-rooted pointer to the target field
+// (e.g. "/name", "/variables/env"); Value carries the new value (always a
+// string on the wire, even for bool/int fields). From is the source pointer
+// for a "copy" op.
+type PatchOperation struct {
+	Op    string
+	Path  string
+	Value string
+	From  string
 }
 
 // Resource is a node in a REST API's path tree. Path is the fully-resolved
@@ -100,6 +118,9 @@ type CreateRestAPIInput struct {
 	Tags                       map[string]string
 	BinaryMediaTypes           []string
 	EndpointConfigurationTypes []string
+	DisableExecuteAPIEndpoint  bool
+	MinimumCompressionSize     *int
+	Policy                     string
 }
 
 // PutMethodInput carries the fields PutMethod accepts.
@@ -167,26 +188,39 @@ type APIGateway interface {
 	CreateRestAPI(ctx context.Context, in *CreateRestAPIInput) (*RestAPI, error)
 	GetRestAPIs(ctx context.Context) ([]RestAPI, error)
 	GetRestAPI(ctx context.Context, id string) (*RestAPI, error)
+	// UpdateRestAPI applies a patchOperations document to a REST API and returns
+	// the updated object, matching the real UpdateRestApi.
+	UpdateRestAPI(ctx context.Context, id string, ops []PatchOperation) (*RestAPI, error)
 	DeleteRestAPI(ctx context.Context, id string) error
 
 	CreateResource(ctx context.Context, restAPIID, parentID, pathPart string) (*Resource, error)
 	GetResources(ctx context.Context, restAPIID string) ([]Resource, error)
 	GetResource(ctx context.Context, restAPIID, resourceID string) (*Resource, error)
+	// UpdateResource applies a patchOperations document to a resource (rename via
+	// /pathPart, move via /parentId), recomputing the affected subtree paths.
+	UpdateResource(ctx context.Context, restAPIID, resourceID string, ops []PatchOperation) (*Resource, error)
 	// DeleteResource removes a resource and its whole descendant subtree, as
 	// real API Gateway does. Deleting the API's root resource is rejected.
 	DeleteResource(ctx context.Context, restAPIID, resourceID string) error
 
 	PutMethod(ctx context.Context, restAPIID, resourceID, httpMethod string, in PutMethodInput) (*Method, error)
 	GetMethod(ctx context.Context, restAPIID, resourceID, httpMethod string) (*Method, error)
+	// UpdateMethod applies a patchOperations document to a method.
+	UpdateMethod(ctx context.Context, restAPIID, resourceID, httpMethod string, ops []PatchOperation) (*Method, error)
 	DeleteMethod(ctx context.Context, restAPIID, resourceID, httpMethod string) error
 
 	PutIntegration(ctx context.Context, restAPIID, resourceID, httpMethod string, in PutIntegrationInput) (*Integration, error)
 	GetIntegration(ctx context.Context, restAPIID, resourceID, httpMethod string) (*Integration, error)
+	// UpdateIntegration applies a patchOperations document to an integration.
+	UpdateIntegration(ctx context.Context, restAPIID, resourceID, httpMethod string, ops []PatchOperation) (*Integration, error)
 	DeleteIntegration(ctx context.Context, restAPIID, resourceID, httpMethod string) error
 
 	CreateDeployment(ctx context.Context, restAPIID string, in CreateDeploymentInput) (*Deployment, error)
 	GetDeployments(ctx context.Context, restAPIID string) ([]Deployment, error)
 	GetDeployment(ctx context.Context, restAPIID, deploymentID string) (*Deployment, error)
+	// UpdateDeployment applies a patchOperations document to a deployment
+	// (only /description is mutable).
+	UpdateDeployment(ctx context.Context, restAPIID, deploymentID string, ops []PatchOperation) (*Deployment, error)
 	// DeleteDeployment removes a deployment. It fails with a FailedPrecondition
 	// error when a stage still points at it, matching real API Gateway (a
 	// deployment referenced by a stage must have that stage moved or deleted
@@ -196,6 +230,9 @@ type APIGateway interface {
 	CreateStage(ctx context.Context, restAPIID string, in CreateStageInput) (*Stage, error)
 	GetStages(ctx context.Context, restAPIID string) ([]Stage, error)
 	GetStage(ctx context.Context, restAPIID, stageName string) (*Stage, error)
+	// UpdateStage applies a patchOperations document to a stage (/description,
+	// /variables/<key> add|replace|remove, /deploymentId).
+	UpdateStage(ctx context.Context, restAPIID, stageName string, ops []PatchOperation) (*Stage, error)
 	DeleteStage(ctx context.Context, restAPIID, stageName string) error
 
 	// InvokeRoute resolves req.HTTPMethod+req.Path against the deployed stage's


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of AWS API Gateway **v1 (REST APIs)** against live Terraform (`hashicorp/aws` 5.100), aws-sdk-go-v2 and aws-cli, run over `cloudemu serve`. The v1 control plane (RestApi -> Resource -> Method -> Integration -> Deployment -> Stage) was built and mostly correct on create/get/delete, but the audit surfaced three divergences from real AWS.

## Divergences fixed

1. **Update (PATCH) surface entirely unimplemented.** `UpdateRestApi`, `UpdateStage`, `UpdateMethod`, `UpdateIntegration`, `UpdateDeployment` and `UpdateResource` all returned HTTP 405, so every Terraform in-place change failed to apply (`UpdateRestApi ... StatusCode: 405`). Implemented the restJson1 `patchOperations` (JSON Patch) contract across all six control-plane objects, wired driver -> provider -> handler. Values arrive as strings on the wire (even for bool/int), and `/variables/<key>` / `/binaryMediaTypes/<type>` honor JSON-Pointer escaping.

2. **RestApi fields silently dropped.** `disableExecuteApiEndpoint`, `minimumCompressionSize` and `policy` were neither stored nor echoed, so a config setting `disable_execute_api_endpoint = true` or `minimum_compression_size = N` drifted forever. They now round-trip on create and via PATCH; `minimumCompressionSize` is a nullable pointer (omitted when disabled, matching real AWS).

3. **Non-deterministic list order.** `GetResources`, `GetStages`, `GetDeployments` and `GetRestApis` returned map-iteration order, which varied call-to-call. They are now deterministically sorted (resources by path so root `/` is first; deployments/apis by created-date then id; stages by name).

## Verification

Live over `cloudemu serve` (unique port), against real Terraform + SDK + CLI:

- Full lifecycle `aws_api_gateway_rest_api` -> `resource` -> `method` -> `integration` (MOCK) -> `deployment` -> `stage`: **create -> plan (no drift) -> in-place update (rest-api attrs, stage variables/description) -> plan (no drift) -> destroy**, all clean. `root_resource_id`, computed `resource.path` (`/foo/bar`), `endpoint_configuration.types`, and the method/integration chain all round-trip with no drift.
- restJson1 error envelope confirmed (404 `NotFoundException`, 409 `ConflictException` with `x-amzn-errortype`).
- Unit + wire tests added for every new Update op, field round-trip, subtree-rename path recompute, and list determinism.

Gates: `go build ./...`, `go test -race` (providers/aws/apigateway + server/aws/apigateway), `go vet`, `gofmt`, `golangci-lint` (0 issues), and `go generate` docs (coverage 23 -> 29 ops) all green.