### PR TITLE
fix(docdb): real-user e2e divergences from AWS DocumentDB

### DIFF
--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -1091,6 +1091,21 @@ func (m *Mock) CreateCluster(ctx context.Context, cfg rdsdriver.ClusterConfig) (
 		allocatedStorage = auroraAllocatedStorage
 	}
 
+	backupRetention := cfg.BackupRetentionPeriod
+	if backupRetention == 0 {
+		backupRetention = defaultBackupRetention
+	}
+
+	backupWindow := cfg.PreferredBackupWindow
+	if backupWindow == "" {
+		backupWindow = defaultBackupWindow
+	}
+
+	maintenanceWindow := cfg.PreferredMaintenanceWindow
+	if maintenanceWindow == "" {
+		maintenanceWindow = defaultMaintenanceWindow
+	}
+
 	region := regionctx.RegionOr(ctx, m.opts.Region)
 	cluster := rdsdriver.Cluster{
 		ID:                          cfg.ID,
@@ -1106,6 +1121,9 @@ func (m *Mock) CreateCluster(ctx context.Context, cfg rdsdriver.ClusterConfig) (
 		VPCSecurityGroups:           append([]string(nil), cfg.VPCSecurityGroups...),
 		SubnetGroupName:             cfg.SubnetGroupName,
 		DBClusterParameterGroupName: cfg.DBClusterParameterGroupName,
+		BackupRetentionPeriod:       backupRetention,
+		PreferredBackupWindow:       backupWindow,
+		PreferredMaintenanceWindow:  maintenanceWindow,
 		EngineMode:                  engineMode,
 		DBClusterResourceID:         resourceID("cluster-", cfg.ID),
 		AllocatedStorage:            allocatedStorage,
@@ -1183,6 +1201,18 @@ func (m *Mock) ModifyCluster(
 
 	if input.DBClusterParameterGroupName != "" {
 		cluster.DBClusterParameterGroupName = input.DBClusterParameterGroupName
+	}
+
+	if input.BackupRetentionPeriod > 0 {
+		cluster.BackupRetentionPeriod = input.BackupRetentionPeriod
+	}
+
+	if input.PreferredBackupWindow != "" {
+		cluster.PreferredBackupWindow = input.PreferredBackupWindow
+	}
+
+	if input.PreferredMaintenanceWindow != "" {
+		cluster.PreferredMaintenanceWindow = input.PreferredMaintenanceWindow
 	}
 
 	if input.DeletionProtection != nil {

--- a/server/aws/rds/docdb_sdk_roundtrip_test.go
+++ b/server/aws/rds/docdb_sdk_roundtrip_test.go
@@ -157,6 +157,74 @@ func TestSDKDocDBInstanceLifecycle(t *testing.T) {
 	}
 }
 
+// TestSDKDocDBClusterTerraformFields guards the DBCluster attributes Terraform's
+// aws_docdb_cluster reads back on refresh. A missing BackupRetentionPeriod
+// (Terraform default 1) or DBClusterParameterGroup produced perpetual drift, and
+// ModifyDBCluster dropped backup_retention_period / preferred_maintenance_window.
+func TestSDKDocDBClusterTerraformFields(t *testing.T) {
+	client := newDocDBSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateDBCluster(ctx, &awsdocdb.CreateDBClusterInput{
+		DBClusterIdentifier:         aws.String("tf-doc"),
+		Engine:                      aws.String("docdb"),
+		MasterUsername:              aws.String("admin"),
+		MasterUserPassword:          aws.String("supersecret"),
+		DBClusterParameterGroupName: aws.String("custom-pg"),
+	})
+	if err != nil {
+		t.Fatalf("CreateDBCluster: %v", err)
+	}
+
+	c := out.DBCluster
+	if c.BackupRetentionPeriod == nil || *c.BackupRetentionPeriod != 1 {
+		t.Fatalf("BackupRetentionPeriod = %v, want default 1", c.BackupRetentionPeriod)
+	}
+
+	if aws.ToString(c.DBClusterParameterGroup) != "custom-pg" {
+		t.Fatalf("DBClusterParameterGroup = %q, want custom-pg", aws.ToString(c.DBClusterParameterGroup))
+	}
+
+	if aws.ToString(c.ReaderEndpoint) == "" || aws.ToString(c.Endpoint) == "" {
+		t.Fatalf("Endpoint=%q ReaderEndpoint=%q, both must be set",
+			aws.ToString(c.Endpoint), aws.ToString(c.ReaderEndpoint))
+	}
+
+	if aws.ToString(c.PreferredBackupWindow) == "" || aws.ToString(c.PreferredMaintenanceWindow) == "" {
+		t.Fatal("PreferredBackupWindow/PreferredMaintenanceWindow must be populated")
+	}
+
+	mod, err := client.ModifyDBCluster(ctx, &awsdocdb.ModifyDBClusterInput{
+		DBClusterIdentifier:        aws.String("tf-doc"),
+		BackupRetentionPeriod:      aws.Int32(7),
+		PreferredMaintenanceWindow: aws.String("mon:03:00-mon:03:30"),
+	})
+	if err != nil {
+		t.Fatalf("ModifyDBCluster: %v", err)
+	}
+
+	if mod.DBCluster.BackupRetentionPeriod == nil || *mod.DBCluster.BackupRetentionPeriod != 7 {
+		t.Fatalf("post-modify BackupRetentionPeriod = %v, want 7", mod.DBCluster.BackupRetentionPeriod)
+	}
+
+	if aws.ToString(mod.DBCluster.PreferredMaintenanceWindow) != "mon:03:00-mon:03:30" {
+		t.Fatalf("post-modify PreferredMaintenanceWindow = %q, want mon:03:00-mon:03:30",
+			aws.ToString(mod.DBCluster.PreferredMaintenanceWindow))
+	}
+
+	// Confirm the modify persisted through a fresh describe (drift source).
+	desc, err := client.DescribeDBClusters(ctx, &awsdocdb.DescribeDBClustersInput{
+		DBClusterIdentifier: aws.String("tf-doc"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBClusters: %v", err)
+	}
+
+	if desc.DBClusters[0].BackupRetentionPeriod == nil || *desc.DBClusters[0].BackupRetentionPeriod != 7 {
+		t.Fatalf("described BackupRetentionPeriod = %v, want 7", desc.DBClusters[0].BackupRetentionPeriod)
+	}
+}
+
 func TestSDKDocDBClusterSnapshotAndRestore(t *testing.T) {
 	client := newDocDBSDKClient(t)
 	ctx := context.Background()

--- a/server/aws/rds/operations.go
+++ b/server/aws/rds/operations.go
@@ -490,6 +490,9 @@ func (h *Handler) createDBCluster(w http.ResponseWriter, r *http.Request) {
 		VPCSecurityGroups:           awsquery.ListStrings(form, "VpcSecurityGroupIds.VpcSecurityGroupId"),
 		SubnetGroupName:             form.Get("DBSubnetGroupName"),
 		DBClusterParameterGroupName: form.Get("DBClusterParameterGroupName"),
+		BackupRetentionPeriod:       formInt(form.Get("BackupRetentionPeriod")),
+		PreferredBackupWindow:       form.Get("PreferredBackupWindow"),
+		PreferredMaintenanceWindow:  form.Get("PreferredMaintenanceWindow"),
 		EngineMode:                  form.Get("EngineMode"),
 		StorageEncrypted:            formBool(form.Get("StorageEncrypted")),
 		KmsKeyID:                    form.Get("KmsKeyId"),
@@ -551,6 +554,9 @@ func (h *Handler) modifyDBCluster(w http.ResponseWriter, r *http.Request) {
 		EngineVersion:               form.Get("EngineVersion"),
 		MasterUserPassword:          form.Get("MasterUserPassword"),
 		DBClusterParameterGroupName: form.Get("DBClusterParameterGroupName"),
+		BackupRetentionPeriod:       formInt(form.Get("BackupRetentionPeriod")),
+		PreferredBackupWindow:       form.Get("PreferredBackupWindow"),
+		PreferredMaintenanceWindow:  form.Get("PreferredMaintenanceWindow"),
 		Tags:                        parseRDSTags(form),
 	}
 

--- a/server/aws/rds/xml.go
+++ b/server/aws/rds/xml.go
@@ -145,29 +145,38 @@ type dbClusterMembersXML struct {
 }
 
 type dbClusterXML struct {
-	DBClusterIdentifier string                `xml:"DBClusterIdentifier"`
-	DBClusterArn        string                `xml:"DBClusterArn"`
-	Engine              string                `xml:"Engine,omitempty"`
-	EngineVersion       string                `xml:"EngineVersion,omitempty"`
-	Status              string                `xml:"Status"`
-	MasterUsername      string                `xml:"MasterUsername,omitempty"`
-	DatabaseName        string                `xml:"DatabaseName,omitempty"`
-	Endpoint            string                `xml:"Endpoint,omitempty"`
-	ReaderEndpoint      string                `xml:"ReaderEndpoint,omitempty"`
-	Port                int                   `xml:"Port,omitempty"`
-	DBSubnetGroup       string                `xml:"DBSubnetGroup,omitempty"`
-	EngineMode          string                `xml:"EngineMode,omitempty"`
-	DBClusterResourceID string                `xml:"DbClusterResourceId,omitempty"`
-	AllocatedStorage    int                   `xml:"AllocatedStorage,omitempty"`
-	StorageEncrypted    bool                  `xml:"StorageEncrypted"`
-	KmsKeyID            string                `xml:"KmsKeyId,omitempty"`
-	DeletionProtection  bool                  `xml:"DeletionProtection"`
-	AvailabilityZones   *availabilityZonesXML `xml:"AvailabilityZones,omitempty"`
-	ClusterCreateTime   string                `xml:"ClusterCreateTime,omitempty"`
-	DBClusterMembers    *dbClusterMembersXML  `xml:"DBClusterMembers,omitempty"`
-	VpcSecurityGroups   *vpcSecurityGroupsXML `xml:"VpcSecurityGroups,omitempty"`
-	AssociatedRoles     *associatedRolesXML   `xml:"AssociatedRoles,omitempty"`
-	TagList             *tagListXML           `xml:"TagList,omitempty"`
+	DBClusterIdentifier string `xml:"DBClusterIdentifier"`
+	DBClusterArn        string `xml:"DBClusterArn"`
+	Engine              string `xml:"Engine,omitempty"`
+	EngineVersion       string `xml:"EngineVersion,omitempty"`
+	Status              string `xml:"Status"`
+	MasterUsername      string `xml:"MasterUsername,omitempty"`
+	DatabaseName        string `xml:"DatabaseName,omitempty"`
+	Endpoint            string `xml:"Endpoint,omitempty"`
+	ReaderEndpoint      string `xml:"ReaderEndpoint,omitempty"`
+	Port                int    `xml:"Port,omitempty"`
+	DBSubnetGroup       string `xml:"DBSubnetGroup,omitempty"`
+	// DBClusterParameterGroup is the cluster's parameter group name. Terraform's
+	// aws_docdb_cluster / aws_rds_cluster read it back, so it must round-trip.
+	DBClusterParameterGroup string `xml:"DBClusterParameterGroup,omitempty"`
+	// BackupRetentionPeriod is NOT omitempty: real RDS always emits the element
+	// (default 1) and Terraform's backup_retention_period default is 1, so a
+	// missing element reads as 0 and drifts.
+	BackupRetentionPeriod      int                   `xml:"BackupRetentionPeriod"`
+	PreferredBackupWindow      string                `xml:"PreferredBackupWindow,omitempty"`
+	PreferredMaintenanceWindow string                `xml:"PreferredMaintenanceWindow,omitempty"`
+	EngineMode                 string                `xml:"EngineMode,omitempty"`
+	DBClusterResourceID        string                `xml:"DbClusterResourceId,omitempty"`
+	AllocatedStorage           int                   `xml:"AllocatedStorage,omitempty"`
+	StorageEncrypted           bool                  `xml:"StorageEncrypted"`
+	KmsKeyID                   string                `xml:"KmsKeyId,omitempty"`
+	DeletionProtection         bool                  `xml:"DeletionProtection"`
+	AvailabilityZones          *availabilityZonesXML `xml:"AvailabilityZones,omitempty"`
+	ClusterCreateTime          string                `xml:"ClusterCreateTime,omitempty"`
+	DBClusterMembers           *dbClusterMembersXML  `xml:"DBClusterMembers,omitempty"`
+	VpcSecurityGroups          *vpcSecurityGroupsXML `xml:"VpcSecurityGroups,omitempty"`
+	AssociatedRoles            *associatedRolesXML   `xml:"AssociatedRoles,omitempty"`
+	TagList                    *tagListXML           `xml:"TagList,omitempty"`
 }
 
 type dbClusterRoleXML struct {
@@ -525,29 +534,33 @@ func toClusterXML(cluster *rdsdriver.Cluster) dbClusterXML {
 	}
 
 	return dbClusterXML{
-		DBClusterIdentifier: cluster.ID,
-		DBClusterArn:        cluster.ARN,
-		Engine:              cluster.Engine,
-		EngineVersion:       cluster.EngineVersion,
-		Status:              cluster.State,
-		MasterUsername:      cluster.MasterUsername,
-		DatabaseName:        cluster.DatabaseName,
-		Endpoint:            cluster.Endpoint,
-		ReaderEndpoint:      cluster.ReaderEndpoint,
-		Port:                cluster.Port,
-		DBSubnetGroup:       cluster.SubnetGroupName,
-		EngineMode:          cluster.EngineMode,
-		DBClusterResourceID: cluster.DBClusterResourceID,
-		AllocatedStorage:    cluster.AllocatedStorage,
-		StorageEncrypted:    cluster.StorageEncrypted,
-		KmsKeyID:            cluster.KmsKeyID,
-		DeletionProtection:  cluster.DeletionProtection,
-		AvailabilityZones:   toAvailabilityZonesXML(cluster.AvailabilityZones),
-		ClusterCreateTime:   cluster.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
-		DBClusterMembers:    &members,
-		VpcSecurityGroups:   toVpcSGsXML(cluster.VPCSecurityGroups),
-		AssociatedRoles:     toAssociatedRolesXML(cluster.AssociatedRoles),
-		TagList:             toTagListXML(cluster.Tags),
+		DBClusterIdentifier:        cluster.ID,
+		DBClusterArn:               cluster.ARN,
+		Engine:                     cluster.Engine,
+		EngineVersion:              cluster.EngineVersion,
+		Status:                     cluster.State,
+		MasterUsername:             cluster.MasterUsername,
+		DatabaseName:               cluster.DatabaseName,
+		Endpoint:                   cluster.Endpoint,
+		ReaderEndpoint:             cluster.ReaderEndpoint,
+		Port:                       cluster.Port,
+		DBSubnetGroup:              cluster.SubnetGroupName,
+		DBClusterParameterGroup:    cluster.DBClusterParameterGroupName,
+		BackupRetentionPeriod:      cluster.BackupRetentionPeriod,
+		PreferredBackupWindow:      cluster.PreferredBackupWindow,
+		PreferredMaintenanceWindow: cluster.PreferredMaintenanceWindow,
+		EngineMode:                 cluster.EngineMode,
+		DBClusterResourceID:        cluster.DBClusterResourceID,
+		AllocatedStorage:           cluster.AllocatedStorage,
+		StorageEncrypted:           cluster.StorageEncrypted,
+		KmsKeyID:                   cluster.KmsKeyID,
+		DeletionProtection:         cluster.DeletionProtection,
+		AvailabilityZones:          toAvailabilityZonesXML(cluster.AvailabilityZones),
+		ClusterCreateTime:          cluster.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
+		DBClusterMembers:           &members,
+		VpcSecurityGroups:          toVpcSGsXML(cluster.VPCSecurityGroups),
+		AssociatedRoles:            toAssociatedRolesXML(cluster.AssociatedRoles),
+		TagList:                    toTagListXML(cluster.Tags),
 	}
 }
 

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -378,6 +378,12 @@ type ClusterConfig struct {
 	VPCSecurityGroups           []string
 	SubnetGroupName             string
 	DBClusterParameterGroupName string
+	// BackupRetentionPeriod / PreferredBackupWindow are AWS RDS DBCluster create
+	// inputs shared by Aurora and DocumentDB/Neptune. The provider fills the
+	// documented defaults (retention 1; an assigned backup window) when unset so a
+	// read round-trips like real AWS. Zero/empty for non-AWS engines.
+	BackupRetentionPeriod int
+	PreferredBackupWindow string
 	// EngineMode is the AWS Aurora engine mode ("provisioned"/"serverless");
 	// empty defaults to "provisioned". StorageEncrypted / AllocatedStorage echo
 	// the corresponding create inputs. All default to zero for non-AWS engines.
@@ -436,6 +442,13 @@ type Cluster struct {
 	VPCSecurityGroups           []string
 	SubnetGroupName             string
 	DBClusterParameterGroupName string
+	// BackupRetentionPeriod / PreferredBackupWindow echo the AWS RDS DBCluster
+	// attributes on read (Aurora and DocumentDB/Neptune). AWS assigns a retention
+	// of 1 and a backup window when the create omits them, so Terraform's matching
+	// schema values (backup_retention_period default 1; a computed backup window)
+	// do not drift. Zero/empty for non-AWS engines.
+	BackupRetentionPeriod int
+	PreferredBackupWindow string
 	// EngineMode / DbClusterResourceId / AllocatedStorage / StorageEncrypted /
 	// AvailabilityZones echo AWS Aurora DBCluster attributes on read; they
 	// default to zero for non-AWS engines.


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of AWS DocumentDB (`aws_docdb_cluster`, `aws_docdb_cluster_instance`, `aws_docdb_subnet_group`, `aws_docdb_cluster_parameter_group`) driven through the live `serve` wire server with the real `hashicorp/aws` Terraform provider, `aws-sdk-go-v2/docdb`, and `aws-cli`. DocumentDB shares the RDS query-protocol handler (`docdb.amazonaws.com`, API `2014-10-31`), discriminated by `Engine=docdb` / port `27017`.

`DescribeDBClusters` omitted four attributes that `aws_docdb_cluster` reads back on refresh, producing **perpetual Terraform drift**:

- `BackupRetentionPeriod` was never emitted, so Terraform read it as `0` against its schema default of `1` → `backup_retention_period = 0 -> 1` on every plan.
- `DBClusterParameterGroup` was never emitted, so Terraform re-added `db_cluster_parameter_group_name` on every plan.
- `PreferredBackupWindow` / `PreferredMaintenanceWindow` were absent (no computed value round-tripping).

`ModifyDBCluster` additionally dropped `backup_retention_period`, `preferred_backup_window` and `preferred_maintenance_window` — an update silently no-op'd.

## Changes

- `CreateCluster` fills the documented AWS defaults when the create omits them: retention `1`, an assigned backup window and maintenance window.
- `ModifyCluster` now applies `BackupRetentionPeriod`, `PreferredBackupWindow`, `PreferredMaintenanceWindow`.
- Cluster XML emits all four fields (`BackupRetentionPeriod` non-`omitempty`, matching real RDS which always returns the element).
- Server `CreateDBCluster` / `ModifyDBCluster` parse the fields from the query form.
- Driver `Cluster` / `ClusterConfig` gain `BackupRetentionPeriod` / `PreferredBackupWindow` (`PreferredMaintenanceWindow` already existed). These are shared RDS fields, so Aurora (`aws_rds_cluster`) benefits from the same fix.

## Live evidence

Full `terraform apply` -> `plan` -> `apply` update -> `plan` -> `destroy` lifecycle against `serve` on an isolated port:

- After create: `terraform plan` = **No changes** (previously `backup_retention_period 0 -> 1` and `db_cluster_parameter_group_name` re-added).
- Update (`backup_retention_period = 7`, `preferred_maintenance_window`, add a second cluster instance) applies and `plan` after = **No changes**.
- `aws-cli describe-db-clusters` round-trips `Engine=docdb`, `Endpoint`, `ReaderEndpoint`, `Port=27017`, `Status=available`, `BackupRetentionPeriod`, `PreferredBackupWindow/MaintenanceWindow`, `DBClusterParameterGroup`, `DBClusterMembers` with `IsClusterWriter` (first `true`, second `false`), `AvailabilityZones`, `ClusterCreateTime`.
- `DBClusterNotFoundFault` error envelope intact for a missing cluster.

## Tests / gates

- New `TestSDKDocDBClusterTerraformFields` guards the drift-relevant fields (default retention `1`, param-group round-trip, endpoints populated, modify persistence through a fresh describe).
- `go build ./...`, `go vet`, `gofmt`, `go test -race ./server/aws/rds/... ./providers/aws/rds/...`, plus `persist`, `services/relationaldb/...`, `providers/aws/redshift/...` (shared struct) and root integration test all green.
- `golangci-lint --new-from-rev=origin/development` = 0 issues. `go generate ./...` produces no `docs/coverage` diff (struct-field-only change, no new actions).