### PR TITLE
fix(gcp-router): real-user e2e divergences from Cloud Router/NAT

### DIFF
--- a/server/gcp/vpc/routers.go
+++ b/server/gcp/vpc/routers.go
@@ -131,7 +131,8 @@ func (h *Handler) insertRouter(w http.ResponseWriter, r *http.Request, rp gcpres
 		return
 	}
 
-	h.routers.put(rp.Project, rp.ScopeName, req.Name, body)
+	h.routers.put(rp.Project, rp.ScopeName, req.Name,
+		enrichRouter(body, rp, hostOf(r), req.Name, nil))
 
 	op := h.ops.RecordDone(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
 		resourceRouters, req.Name, "insert")
@@ -160,15 +161,19 @@ func (h *Handler) listRouters(w http.ResponseWriter, r *http.Request, rp gcprest
 	})
 }
 
-// patchRouter replaces the stored body.
+// patchRouter merges the patch into the stored router, matching real Compute's
+// field-level PATCH semantics.
 //
-// Real Compute merges the patch into the resource, but a caller adding NAT
-// sends the whole router back, and storing what it sent is what makes the
-// subsequent read agree with it.
+// Terraform's google_compute_router_nat adds NAT with a partial patch that
+// carries only {nats:[...]} — no name, network, or bgp — so replacing the
+// stored body would drop those and make the next google_compute_router read
+// diff (a forced replacement). Merging top-level fields, patch wins, keeps the
+// router's other settings while the caller's nats array replaces the old one.
 //
 //nolint:gocritic // rp is a request-scoped value
 func (h *Handler) patchRouter(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
-	if _, ok := h.routers.get(rp.Project, rp.ScopeName, rp.ResourceName); !ok {
+	prior, ok := h.routers.get(rp.Project, rp.ScopeName, rp.ResourceName)
+	if !ok {
 		gcprest.WriteError(w, http.StatusNotFound, "notFound",
 			"router "+rp.ResourceName+" not found")
 
@@ -180,7 +185,8 @@ func (h *Handler) patchRouter(w http.ResponseWriter, r *http.Request, rp gcprest
 		return
 	}
 
-	h.routers.put(rp.Project, rp.ScopeName, rp.ResourceName, body)
+	h.routers.put(rp.Project, rp.ScopeName, rp.ResourceName,
+		enrichRouter(mergeRouterPatch(prior, body), rp, hostOf(r), rp.ResourceName, prior))
 
 	op := h.ops.RecordDone(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
 		resourceRouters, rp.ResourceName, "patch")
@@ -201,6 +207,131 @@ func (h *Handler) deleteRouter(w http.ResponseWriter, r *http.Request, rp gcpres
 		resourceRouters, rp.ResourceName, "delete")
 
 	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// NAT idle-timeout defaults real Compute stamps on every nat block that omits
+// them. A caller (Terraform's google_compute_router_nat, gcloud) reads these
+// back, so filling them is what stops a create from perpetually diffing against
+// an empty read.
+const (
+	natUDPIdleTimeoutDefault            = 30
+	natTCPEstablishedIdleTimeoutDefault = 1200
+	natTCPTransitoryIdleTimeoutDefault  = 30
+	natICMPIdleTimeoutDefault           = 30
+)
+
+// mergeRouterPatch overlays the caller's patch onto the prior stored body at
+// the top level (patch fields win), reproducing real Compute's partial-PATCH
+// merge so a patch that omits a field leaves the stored value intact. A nats or
+// bgp block in the patch replaces the prior one wholesale, matching the API. If
+// either side is unparseable the patch is returned unchanged (replace).
+func mergeRouterPatch(prior, patch json.RawMessage) json.RawMessage {
+	var base, over map[string]any
+	if err := json.Unmarshal(prior, &base); err != nil || base == nil {
+		return patch
+	}
+
+	if err := json.Unmarshal(patch, &over); err != nil || over == nil {
+		return patch
+	}
+
+	for k, v := range over {
+		base[k] = v
+	}
+
+	merged, err := json.Marshal(base)
+	if err != nil {
+		return patch
+	}
+
+	return merged
+}
+
+// enrichRouter stamps the server-assigned fields (kind, id, selfLink, region,
+// creationTimestamp) real Compute returns on a router, and fills the NAT
+// idle-timeout defaults on each nat block, while preserving everything the
+// caller sent (bgp, nats, interfaces). Without selfLink a Get returns a body
+// the Terraform google_compute_router provider dereferences unconditionally,
+// crashing its Read; without the timeout defaults a google_compute_router_nat
+// create never stops diffing. On patch, prior carries the stored body so the
+// original creationTimestamp survives a read-modify-write (adding a NAT).
+//
+//nolint:gocritic // rp is a request-scoped value
+func enrichRouter(raw json.RawMessage, rp gcprest.ResourcePath, host, name string, prior json.RawMessage) json.RawMessage {
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil || body == nil {
+		return raw
+	}
+
+	body["kind"] = "compute#router"
+	body["id"] = numericID(rp.Project + "/" + rp.ScopeName + "/routers/" + name)
+	body["selfLink"] = gcprest.SelfLink(host, rp.Project, gcprest.ScopeRegions, rp.ScopeName, resourceRouters, name)
+	body["region"] = host + "/compute/v1/projects/" + rp.Project + "/regions/" + rp.ScopeName
+	body["creationTimestamp"] = routerCreationTimestamp(body, prior)
+
+	qualifyGlobalRef(body, "network", host, rp.Project, "networks")
+	applyNatDefaults(body)
+
+	enriched, err := json.Marshal(body)
+	if err != nil {
+		return raw
+	}
+
+	return enriched
+}
+
+// routerCreationTimestamp keeps the creationTimestamp stable across a patch:
+// the caller's read-modify-write echoes the value we returned, and any stored
+// prior wins over it, so only a first insert stamps a fresh time.
+func routerCreationTimestamp(body map[string]any, prior json.RawMessage) string {
+	if prior != nil {
+		var p map[string]any
+		if err := json.Unmarshal(prior, &p); err == nil {
+			if ts, ok := p["creationTimestamp"].(string); ok && ts != "" {
+				return ts
+			}
+		}
+	}
+
+	if ts, ok := body["creationTimestamp"].(string); ok && ts != "" {
+		return ts
+	}
+
+	return nowRFC3339()
+}
+
+// applyNatDefaults fills the idle-timeout fields real Compute defaults on each
+// nat block that omits them, leaving any caller-supplied value untouched.
+func applyNatDefaults(body map[string]any) {
+	nats, ok := body["nats"].([]any)
+	if !ok {
+		return
+	}
+
+	for _, n := range nats {
+		nat, ok := n.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		setDefaultInt(nat, "udpIdleTimeoutSec", natUDPIdleTimeoutDefault)
+		setDefaultInt(nat, "tcpEstablishedIdleTimeoutSec", natTCPEstablishedIdleTimeoutDefault)
+		setDefaultInt(nat, "tcpTransitoryIdleTimeoutSec", natTCPTransitoryIdleTimeoutDefault)
+		setDefaultInt(nat, "icmpIdleTimeoutSec", natICMPIdleTimeoutDefault)
+	}
+}
+
+// setDefaultInt assigns v to m[key] only when the key is absent or holds the
+// zero value, so a caller that sent an explicit timeout keeps it.
+func setDefaultInt(m map[string]any, key string, v int) {
+	switch cur := m[key].(type) {
+	case nil:
+		m[key] = v
+	case float64:
+		if cur == 0 {
+			m[key] = v
+		}
+	}
 }
 
 // decodeRouter reads the request body once, returning both the raw bytes to

--- a/server/gcp/vpc/routers_test.go
+++ b/server/gcp/vpc/routers_test.go
@@ -1,0 +1,169 @@
+package vpc_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/option"
+)
+
+func newRoutersClient(t *testing.T, ts *httptest.Server) *gcpcompute.RoutersClient {
+	t.Helper()
+
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewRoutersRESTClient(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewRoutersRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+// TestSDKRouterRoundTrip covers a region-scoped router insert/get: the server
+// must stamp kind, selfLink, region and creationTimestamp (the Terraform
+// google_compute_router provider dereferences selfLink unconditionally and
+// crashes when it is absent) and round-trip the nested BGP block.
+func TestSDKRouterRoundTrip(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+	client := newRoutersClient(t, ts)
+
+	insertOp, err := client.Insert(ctx, &computepb.InsertRouterRequest{
+		Project: testProject,
+		Region:  testRegion,
+		RouterResource: &computepb.Router{
+			Name:    ptrStr("r1"),
+			Network: ptrStr("projects/" + testProject + "/global/networks/default"),
+			Bgp: &computepb.RouterBgp{
+				Asn:           func() *uint32 { a := uint32(64514); return &a }(),
+				AdvertiseMode: ptrStr("DEFAULT"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetRouterRequest{
+		Project: testProject, Region: testRegion, Router: "r1",
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetName() != "r1" {
+		t.Errorf("name=%s want r1", got.GetName())
+	}
+
+	if got.GetKind() != "compute#router" || got.GetSelfLink() == "" {
+		t.Errorf("kind=%q selfLink=%q want compute#router and non-empty", got.GetKind(), got.GetSelfLink())
+	}
+
+	if got.GetCreationTimestamp() == "" {
+		t.Error("creationTimestamp is empty")
+	}
+
+	if got.GetBgp().GetAsn() != 64514 {
+		t.Errorf("bgp.asn=%d want 64514", got.GetBgp().GetAsn())
+	}
+}
+
+// TestSDKRouterNatPartialPatchPreservesBgp is the core regression: Terraform's
+// google_compute_router_nat adds NAT with a partial patch carrying only nats[]
+// (no name/network/bgp). The server must merge that onto the stored router so
+// bgp survives, and must fill the NAT idle-timeout defaults real Compute stamps.
+func TestSDKRouterNatPartialPatchPreservesBgp(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+	client := newRoutersClient(t, ts)
+
+	insertOp, err := client.Insert(ctx, &computepb.InsertRouterRequest{
+		Project: testProject,
+		Region:  testRegion,
+		RouterResource: &computepb.Router{
+			Name:    ptrStr("r2"),
+			Network: ptrStr("projects/" + testProject + "/global/networks/default"),
+			Bgp: &computepb.RouterBgp{
+				Asn:           func() *uint32 { a := uint32(64515); return &a }(),
+				AdvertiseMode: ptrStr("CUSTOM"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	// Partial patch: only name + nats, exactly what google_compute_router_nat
+	// sends. bgp/network are intentionally omitted.
+	patchOp, err := client.Patch(ctx, &computepb.PatchRouterRequest{
+		Project: testProject,
+		Region:  testRegion,
+		Router:  "r2",
+		RouterResource: &computepb.Router{
+			Name: ptrStr("r2"),
+			Nats: []*computepb.RouterNat{{
+				Name:                          ptrStr("nat1"),
+				NatIpAllocateOption:           ptrStr("AUTO_ONLY"),
+				SourceSubnetworkIpRangesToNat: ptrStr("ALL_SUBNETWORKS_ALL_IP_RANGES"),
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	if err := patchOp.Wait(ctx); err != nil {
+		t.Fatalf("Patch wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetRouterRequest{
+		Project: testProject, Region: testRegion, Router: "r2",
+	})
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	// bgp and network must survive the partial patch (the regression).
+	if got.GetBgp().GetAsn() != 64515 {
+		t.Errorf("bgp.asn=%d want 64515 (bgp dropped by partial patch)", got.GetBgp().GetAsn())
+	}
+
+	if got.GetNetwork() == "" {
+		t.Error("network dropped by partial patch")
+	}
+
+	if len(got.GetNats()) != 1 || got.GetNats()[0].GetName() != "nat1" {
+		t.Fatalf("nats=%v want single nat1", got.GetNats())
+	}
+
+	nat := got.GetNats()[0]
+	if nat.GetUdpIdleTimeoutSec() != 30 || nat.GetTcpEstablishedIdleTimeoutSec() != 1200 ||
+		nat.GetTcpTransitoryIdleTimeoutSec() != 30 || nat.GetIcmpIdleTimeoutSec() != 30 {
+		t.Errorf("NAT timeout defaults not applied: udp=%d tcpEst=%d tcpTrans=%d icmp=%d",
+			nat.GetUdpIdleTimeoutSec(), nat.GetTcpEstablishedIdleTimeoutSec(),
+			nat.GetTcpTransitoryIdleTimeoutSec(), nat.GetIcmpIdleTimeoutSec())
+	}
+
+	// creationTimestamp must be stable across the patch (not re-stamped).
+	if got.GetCreationTimestamp() == "" {
+		t.Error("creationTimestamp lost after patch")
+	}
+}

--- a/server/gcp/vpc/routers_test.go
+++ b/server/gcp/vpc/routers_test.go
@@ -167,3 +167,72 @@ func TestSDKRouterNatPartialPatchPreservesBgp(t *testing.T) {
 		t.Error("creationTimestamp lost after patch")
 	}
 }
+
+// TestSDKRouterNatPatchReplacesNatList proves the nats field is replaced
+// wholesale by a patch rather than merged element-wise: a router created with
+// two NATs, patched to a single NAT, must end with exactly that one — so a NAT
+// can be removed. This guards the shallow per-field merge against a future
+// refactor that appended or key-merged the repeated field.
+func TestSDKRouterNatPatchReplacesNatList(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+	client := newRoutersClient(t, ts)
+
+	nat := func(name string) *computepb.RouterNat {
+		return &computepb.RouterNat{
+			Name:                          ptrStr(name),
+			NatIpAllocateOption:           ptrStr("AUTO_ONLY"),
+			SourceSubnetworkIpRangesToNat: ptrStr("ALL_SUBNETWORKS_ALL_IP_RANGES"),
+		}
+	}
+
+	insertOp, err := client.Insert(ctx, &computepb.InsertRouterRequest{
+		Project: testProject,
+		Region:  testRegion,
+		RouterResource: &computepb.Router{
+			Name:    ptrStr("r3"),
+			Network: ptrStr("projects/" + testProject + "/global/networks/default"),
+			Bgp:     &computepb.RouterBgp{Asn: func() *uint32 { a := uint32(64516); return &a }()},
+			Nats:    []*computepb.RouterNat{nat("nat1"), nat("nat2")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	// Patch down to a single NAT.
+	patchOp, err := client.Patch(ctx, &computepb.PatchRouterRequest{
+		Project: testProject,
+		Region:  testRegion,
+		Router:  "r3",
+		RouterResource: &computepb.Router{
+			Name: ptrStr("r3"),
+			Nats: []*computepb.RouterNat{nat("nat2")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	if err := patchOp.Wait(ctx); err != nil {
+		t.Fatalf("Patch wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetRouterRequest{
+		Project: testProject, Region: testRegion, Router: "r3",
+	})
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	if len(got.GetNats()) != 1 || got.GetNats()[0].GetName() != "nat2" {
+		t.Fatalf("nats=%v want exactly [nat2] (list replaced, nat1 removed)", got.GetNats())
+	}
+
+	// bgp/network still survive the NAT-only patch.
+	if got.GetBgp().GetAsn() != 64516 || got.GetNetwork() == "" {
+		t.Errorf("bgp/network dropped: asn=%d network=%q", got.GetBgp().GetAsn(), got.GetNetwork())
+	}
+}


### PR DESCRIPTION
## Summary

Real-user e2e audit (Terraform `hashicorp/google` v5 against `cloudemu serve`) of `google_compute_router` + `google_compute_router_nat`. Found and fixed two divergences from real GCP Compute — one a hard provider crash, one perpetual drift/replacement.

## Divergences found & fixed

**1. Router Get missing server-assigned fields → Terraform provider crash.**
The router Get echoed only the caller's body — no `selfLink`, `kind`, `region`, `id` or `creationTimestamp`. The `google_compute_router` provider does `ConvertSelfLinkToV1(res["selfLink"].(string))` in its Read, which panics (`interface conversion: interface {} is nil, not string`) when `selfLink` is absent. `terraform apply` crashed the provider plugin outright. Fixed by stamping the fields real Compute returns (mirrors the existing `enrichRoute`/`enrichAddress` pattern), plus filling the NAT idle-timeout defaults (`udpIdleTimeoutSec=30`, `tcpEstablishedIdleTimeoutSec=1200`, `tcpTransitoryIdleTimeoutSec=30`, `icmpIdleTimeoutSec=30`).

**2. Router PATCH replaced the whole body → BGP/network dropped → forced replacement.**
`google_compute_router_nat` adds NAT with a *partial* PATCH carrying only `{name, nats[]}` (no network/bgp). The handler replaced the stored body wholesale, so after the NAT was created the router lost its `network` and `bgp`, and the next `google_compute_router` refresh showed `-/+ must be replaced`. Real Compute does a field-level merge. Fixed `patchRouter` to merge the patch onto the stored router (patch fields win, `nats`/`bgp` blocks replace wholesale), and to preserve the original `creationTimestamp` across the read-modify-write.

## Live evidence (Terraform against serve, unique port 17610)

- Before: `terraform apply` → provider plugin crash at `resource_compute_router.go:396`.
- After: full lifecycle GREEN — create → `terraform plan` **No changes** → update (2nd NAT + `advertise_mode=CUSTOM` + `advertised_groups` + `min_ports_per_vm=128`) → **No changes** → destroy (4 destroyed). BGP nested block, `nats[]`, NAT timeout defaults, region-scoped LRO all round-trip with no drift.

## Tests
Added `server/gcp/vpc/routers_test.go` (real GCP `RoutersRESTClient`): router round-trip stamps kind/selfLink/creationTimestamp/bgp; and the core regression — a partial NAT patch preserves bgp/network and applies the timeout defaults.

## Gates
`go build ./...`, `go vet`, `gofmt`, `go test -race ./server/gcp/vpc/ ./server/gcp/compute/ ./providers/gcp/...`, root `go test .`, `golangci-lint --new-from-rev` (0 new), `go generate` (no docs/coverage diff) — all green.