### PR TITLE
fix(azure-eventgrid): real-user e2e divergences from Azure Event Grid

### DIFF
--- a/server/azure/eventgrid/event_subscriptions.go
+++ b/server/azure/eventgrid/event_subscriptions.go
@@ -111,8 +111,9 @@ func (h *Handler) regenerateTopicKey(w http.ResponseWriter, r *http.Request, rp 
 }
 
 // enrichSubscriptionProperties parses stored properties, stamps the read-only
-// topic id and provisioning state, and re-marshals. When props is empty a
-// minimal object with just those read-only fields is produced.
+// topic id and provisioning state, fills the read-only Event Grid defaults the
+// caller omitted (retryPolicy, eventDeliverySchema), and re-marshals. When props
+// is empty a minimal object with just those read-only fields is produced.
 func enrichSubscriptionProperties(props []byte, topicID string) json.RawMessage {
 	obj := map[string]any{}
 	if len(props) > 0 {
@@ -121,6 +122,7 @@ func enrichSubscriptionProperties(props []byte, topicID string) json.RawMessage 
 
 	obj["topic"] = topicID
 	obj["provisioningState"] = subscriptionProvisionedGood
+	stampSubscriptionDefaults(obj)
 
 	out, err := json.Marshal(obj)
 	if err != nil {
@@ -128,6 +130,41 @@ func enrichSubscriptionProperties(props []byte, topicID string) json.RawMessage 
 	}
 
 	return out
+}
+
+// stampSubscriptionDefaults fills the read-only defaults Event Grid reports for
+// an event subscription when the caller did not set them: eventDeliverySchema
+// (EventGridSchema) and a retryPolicy of 30 delivery attempts / 1440-minute
+// event TTL. Caller-supplied values are preserved — only absent fields are
+// filled, matching real Azure's GET response, so a subscription created with an
+// explicit retry policy or delivery schema round-trips unchanged while one
+// created without still reports the documented defaults.
+func stampSubscriptionDefaults(obj map[string]any) {
+	if _, ok := obj["eventDeliverySchema"]; !ok {
+		obj["eventDeliverySchema"] = defaultEventDeliverySchema
+	}
+
+	obj["retryPolicy"] = retryPolicyWithDefaults(obj["retryPolicy"])
+}
+
+// retryPolicyWithDefaults returns the retry policy to report: the caller's, with
+// each unset field filled from Event Grid's defaults (30 attempts, 1440-minute
+// TTL). A missing or non-object retryPolicy yields the full default policy.
+func retryPolicyWithDefaults(existing any) map[string]any {
+	rp, _ := existing.(map[string]any)
+	if rp == nil {
+		rp = map[string]any{}
+	}
+
+	if _, ok := rp["maxDeliveryAttempts"]; !ok {
+		rp["maxDeliveryAttempts"] = defaultMaxDeliveryAttempts
+	}
+
+	if _, ok := rp["eventTimeToLiveInMinutes"]; !ok {
+		rp["eventTimeToLiveInMinutes"] = defaultEventTTLMinutes
+	}
+
+	return rp
 }
 
 func subscriptionID(rp *azurearm.ResourcePath) string {

--- a/server/azure/eventgrid/subscription_defaults_sdk_test.go
+++ b/server/azure/eventgrid/subscription_defaults_sdk_test.go
@@ -1,0 +1,96 @@
+package eventgrid_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+)
+
+// TestSDKEventSubscriptionDefaultsStamped proves that an event subscription
+// created without a retry policy or delivery schema reports Event Grid's
+// documented read-only defaults on GET — retryPolicy 30 attempts / 1440-minute
+// TTL and eventDeliverySchema EventGridSchema — matching real Azure. A real user
+// reading the subscription back (az CLI, SDK, Terraform state) sees these
+// populated on Azure, so the emulator must populate them too.
+func TestSDKEventSubscriptionDefaultsStamped(t *testing.T) {
+	client := newEventGridFactory(t).NewEventSubscriptionsClient()
+	ctx := context.Background()
+
+	scope := "/subscriptions/" + testSub + "/resourceGroups/" + testRG
+
+	createEventSubscription(t, client, scope, "defaults-sub", "/blobs")
+
+	got, err := client.Get(ctx, scope, "defaults-sub", nil)
+	if err != nil {
+		t.Fatalf("Get defaults-sub: %v", err)
+	}
+
+	props := got.Properties
+	if props == nil || props.RetryPolicy == nil {
+		t.Fatalf("retryPolicy not stamped: %+v", props)
+	}
+
+	if props.RetryPolicy.MaxDeliveryAttempts == nil || *props.RetryPolicy.MaxDeliveryAttempts != 30 {
+		t.Fatalf("MaxDeliveryAttempts = %v, want 30", props.RetryPolicy.MaxDeliveryAttempts)
+	}
+
+	if props.RetryPolicy.EventTimeToLiveInMinutes == nil || *props.RetryPolicy.EventTimeToLiveInMinutes != 1440 {
+		t.Fatalf("EventTimeToLiveInMinutes = %v, want 1440", props.RetryPolicy.EventTimeToLiveInMinutes)
+	}
+
+	if props.EventDeliverySchema == nil || *props.EventDeliverySchema != armeventgrid.EventDeliverySchemaEventGridSchema {
+		t.Fatalf("EventDeliverySchema = %v, want EventGridSchema", props.EventDeliverySchema)
+	}
+}
+
+// TestSDKEventSubscriptionExplicitRetryPolicyPreserved proves that caller-set
+// retry policy and delivery schema are round-tripped unchanged — the default
+// stamping fills only absent fields and never overrides an explicit value.
+func TestSDKEventSubscriptionExplicitRetryPolicyPreserved(t *testing.T) {
+	client := newEventGridFactory(t).NewEventSubscriptionsClient()
+	ctx := context.Background()
+
+	scope := "/subscriptions/" + testSub + "/resourceGroups/" + testRG
+
+	sub := armeventgrid.EventSubscription{
+		Properties: &armeventgrid.EventSubscriptionProperties{
+			Destination: &armeventgrid.WebHookEventSubscriptionDestination{
+				EndpointType: to.Ptr(armeventgrid.EndpointTypeWebHook),
+				Properties: &armeventgrid.WebHookEventSubscriptionDestinationProperties{
+					EndpointURL: to.Ptr("https://example.test/hook"),
+				},
+			},
+			EventDeliverySchema: to.Ptr(armeventgrid.EventDeliverySchemaCloudEventSchemaV10),
+			RetryPolicy: &armeventgrid.RetryPolicy{
+				MaxDeliveryAttempts:      to.Ptr(int32(5)),
+				EventTimeToLiveInMinutes: to.Ptr(int32(60)),
+			},
+		},
+	}
+
+	poller, err := client.BeginCreateOrUpdate(ctx, scope, "explicit-sub", sub, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+	if _, err = poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("CreateOrUpdate PollUntilDone: %v", err)
+	}
+
+	got, err := client.Get(ctx, scope, "explicit-sub", nil)
+	if err != nil {
+		t.Fatalf("Get explicit-sub: %v", err)
+	}
+
+	props := got.Properties
+	if props == nil || props.RetryPolicy == nil ||
+		props.RetryPolicy.MaxDeliveryAttempts == nil || *props.RetryPolicy.MaxDeliveryAttempts != 5 ||
+		props.RetryPolicy.EventTimeToLiveInMinutes == nil || *props.RetryPolicy.EventTimeToLiveInMinutes != 60 {
+		t.Fatalf("explicit retryPolicy not preserved: %+v", props.RetryPolicy)
+	}
+
+	if props.EventDeliverySchema == nil || *props.EventDeliverySchema != armeventgrid.EventDeliverySchemaCloudEventSchemaV10 {
+		t.Fatalf("EventDeliverySchema = %v, want CloudEventSchemaV1_0", props.EventDeliverySchema)
+	}
+}

--- a/server/azure/eventgrid/subscription_defaults_sdk_test.go
+++ b/server/azure/eventgrid/subscription_defaults_sdk_test.go
@@ -94,3 +94,56 @@ func TestSDKEventSubscriptionExplicitRetryPolicyPreserved(t *testing.T) {
 		t.Fatalf("EventDeliverySchema = %v, want CloudEventSchemaV1_0", props.EventDeliverySchema)
 	}
 }
+
+// TestSDKEventSubscriptionPartialRetryPolicyFilled proves the default stamping
+// is per-subfield: a retry policy that sets only MaxDeliveryAttempts keeps that
+// value and has its absent EventTimeToLiveInMinutes filled with the 1440 default
+// — not an all-or-nothing fill that would either overwrite the caller's value or
+// leave the TTL empty.
+func TestSDKEventSubscriptionPartialRetryPolicyFilled(t *testing.T) {
+	client := newEventGridFactory(t).NewEventSubscriptionsClient()
+	ctx := context.Background()
+
+	scope := "/subscriptions/" + testSub + "/resourceGroups/" + testRG
+
+	sub := armeventgrid.EventSubscription{
+		Properties: &armeventgrid.EventSubscriptionProperties{
+			Destination: &armeventgrid.WebHookEventSubscriptionDestination{
+				EndpointType: to.Ptr(armeventgrid.EndpointTypeWebHook),
+				Properties: &armeventgrid.WebHookEventSubscriptionDestinationProperties{
+					EndpointURL: to.Ptr("https://example.test/hook"),
+				},
+			},
+			RetryPolicy: &armeventgrid.RetryPolicy{
+				MaxDeliveryAttempts: to.Ptr(int32(7)),
+			},
+		},
+	}
+
+	poller, err := client.BeginCreateOrUpdate(ctx, scope, "partial-sub", sub, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+	if _, err = poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("CreateOrUpdate PollUntilDone: %v", err)
+	}
+
+	got, err := client.Get(ctx, scope, "partial-sub", nil)
+	if err != nil {
+		t.Fatalf("Get partial-sub: %v", err)
+	}
+
+	props := got.Properties
+	if props == nil || props.RetryPolicy == nil {
+		t.Fatalf("retryPolicy missing: %+v", props)
+	}
+
+	// The caller's explicit attempts survive; only the absent TTL is defaulted.
+	if props.RetryPolicy.MaxDeliveryAttempts == nil || *props.RetryPolicy.MaxDeliveryAttempts != 7 {
+		t.Fatalf("MaxDeliveryAttempts = %v, want 7 (caller value preserved)", props.RetryPolicy.MaxDeliveryAttempts)
+	}
+
+	if props.RetryPolicy.EventTimeToLiveInMinutes == nil || *props.RetryPolicy.EventTimeToLiveInMinutes != 1440 {
+		t.Fatalf("EventTimeToLiveInMinutes = %v, want 1440 (absent subfield defaulted)", props.RetryPolicy.EventTimeToLiveInMinutes)
+	}
+}

--- a/server/azure/eventgrid/types.go
+++ b/server/azure/eventgrid/types.go
@@ -20,6 +20,14 @@ const (
 	actionListKeys              = "listKeys"
 	subscriptionResourceType    = "Microsoft.EventGrid/topics/eventSubscriptions"
 	subscriptionProvisionedGood = "Succeeded"
+	// defaultEventDeliverySchema and the retryPolicy defaults are the read-only
+	// values Event Grid reports for an event subscription created without them.
+	// A subscription created without a retry policy still reports 30 delivery
+	// attempts / 1440-minute event TTL on GET, and one created without an
+	// explicit delivery schema still reports EventGridSchema.
+	defaultEventDeliverySchema = "EventGridSchema"
+	defaultMaxDeliveryAttempts = 30
+	defaultEventTTLMinutes     = 1440
 )
 
 // topicProperties carries the read-only fields the SDK expects on a topic. The


### PR DESCRIPTION
## Summary

Real-user e2e audit of Azure Event Grid (`Microsoft.EventGrid/topics`,
`/systemTopics`, event subscriptions) against the official Azure REST API. The
topic control-plane round-trips cleanly (computed endpoint
`https://{name}.{region}-1.eventgrid.azure.net/api/events`, `inputSchema`
default `EventGridSchema`, `provisioningState=Succeeded`, `publicNetworkAccess`
default `Enabled`, tag REPLACE-not-merge on PATCH, listKeys) — all verified via
the wire protocol and matching the docs.

One genuine divergence was found and fixed on the **event subscription** read
path.

## Divergence

An event subscription created without a retry policy or delivery schema did not
report Event Grid's documented read-only defaults on GET. Real Azure returns:

- `retryPolicy` = `{ maxDeliveryAttempts: 30, eventTimeToLiveInMinutes: 1440 }`
- `eventDeliverySchema` = `EventGridSchema`

`enrichSubscriptionProperties` stamped only `topic` and `provisioningState`, so
a real user reading a subscription back (az CLI, SDK, Terraform state) saw these
populated on Azure but empty on the emulator.

Confirmed against the official docs (Event Subscriptions - Get, API
2025-02-15): the `RetryPolicy` definition lists defaults 30 / 1440 and
`EventDeliverySchema` defaults to `EventGridSchema`.

## Fix

`enrichSubscriptionProperties` now fills these defaults, filling **only absent
fields** so nothing is overridden:

- an explicit retry policy or delivery schema round-trips unchanged
- a partial `retryPolicy` (e.g. only `maxDeliveryAttempts`) has just its missing
  sub-field filled to the default

The fix lives in the single enrich function shared by all three subscription
paths (topic, system-topic, and scope-bound), so it applies uniformly.

## Testing

- New `subscription_defaults_sdk_test.go` (real `armeventgrid` SDK): asserts the
  30/1440 + `EventGridSchema` defaults on an omitted-policy subscription, and
  that an explicit `{5,60}` + `CloudEventSchemaV1_0` round-trips unchanged.
- Live wire verification via `cloudemu serve`: omitted case stamps defaults;
  explicit values preserved; partial `retryPolicy` fills only the missing TTL.
- Gates: `go build ./...`, `go test -race ./server/azure/eventgrid/...
  ./providers/azure/eventgrid/...`, full `go test ./server/azure/...`, `go vet`,
  `gofmt`, `golangci-lint --new-from-rev` (0 new issues), `go generate` (no
  `docs/coverage` change — no driver interface change).
