### PR TITLE
fix(opensearch): real-user e2e divergences from AWS OpenSearch

### DIFF
--- a/providers/aws/opensearch/domains.go
+++ b/providers/aws/opensearch/domains.go
@@ -63,7 +63,7 @@ func (m *Mock) CreateDomain(_ context.Context, in driver.CreateDomainInput) (*dr
 
 	now := m.now()
 	cfg := copyClusterConfig(in.ClusterConfig)
-	raw := copyRaw(in.RawOptions)
+	raw := fillDefaultOptionBlocks(copyRaw(in.RawOptions))
 
 	// A VPC-access domain (created with VPCOptions carrying subnets) has no
 	// public Endpoint; instead it exposes Endpoints["vpc"], and AWS enriches the
@@ -122,6 +122,37 @@ func (m *Mock) CreateDomain(_ context.Context, in driver.CreateDomainInput) (*dr
 	out := snapshotStatus(status)
 
 	return &out, nil
+}
+
+// defaultOptionBlocks are the option blocks real AWS OpenSearch always includes
+// in a DescribeDomain response, even when the caller omitted them at create.
+// They are materialized at create so a minimal domain round-trips like real AWS
+// — the terraform provider's read path dereferences CognitoOptions and
+// EBSOptions without a nil check and panics if they are absent.
+func defaultOptionBlocks() map[string]json.RawMessage {
+	return map[string]json.RawMessage{
+		"EBSOptions":                  json.RawMessage(`{"EBSEnabled":false}`),
+		"CognitoOptions":              json.RawMessage(`{"Enabled":false}`),
+		"EncryptionAtRestOptions":     json.RawMessage(`{"Enabled":false}`),
+		"NodeToNodeEncryptionOptions": json.RawMessage(`{"Enabled":false}`),
+	}
+}
+
+// fillDefaultOptionBlocks adds each always-present AWS option block to raw when
+// the caller did not supply it, so DescribeDomain reflects the same blocks real
+// AWS always returns. A caller-supplied block is never overwritten.
+func fillDefaultOptionBlocks(raw map[string]json.RawMessage) map[string]json.RawMessage {
+	if raw == nil {
+		raw = map[string]json.RawMessage{}
+	}
+
+	for k, v := range defaultOptionBlocks() {
+		if _, ok := raw[k]; !ok {
+			raw[k] = append(json.RawMessage(nil), v...)
+		}
+	}
+
+	return raw
 }
 
 // vpcInput is the subset of a request's VPCOptions the emulator reads to derive

--- a/server/aws/opensearch/sdk_roundtrip_test.go
+++ b/server/aws/opensearch/sdk_roundtrip_test.go
@@ -287,6 +287,50 @@ func TestSDKDescribeDomainConfigEnvelope(t *testing.T) {
 	}
 }
 
+// TestSDKMinimalDomainAlwaysReturnsOptionBlocks guards a real-user divergence:
+// the terraform aws_opensearch_domain read path flattens CognitoOptions and
+// EBSOptions without a nil check, so a domain created without them must still
+// echo the defaults real AWS always returns. Before the fix, DescribeDomain
+// omitted these blocks and the provider panicked with a nil dereference.
+func TestSDKMinimalDomainAlwaysReturnsOptionBlocks(t *testing.T) {
+	ctx := context.Background()
+	c := newOSClient(t)
+
+	create, err := c.CreateDomain(ctx, &awsos.CreateDomainInput{DomainName: aws.String("minimal-dom")})
+	if err != nil {
+		t.Fatalf("CreateDomain: %v", err)
+	}
+
+	assertAlwaysPresent := func(t *testing.T, ds *ostypes.DomainStatus, where string) {
+		t.Helper()
+
+		if ds.CognitoOptions == nil {
+			t.Fatalf("%s: CognitoOptions must always be present (real AWS returns {Enabled:false})", where)
+		}
+
+		if aws.ToBool(ds.CognitoOptions.Enabled) {
+			t.Fatalf("%s: CognitoOptions.Enabled should default to false, got true", where)
+		}
+
+		if ds.EBSOptions == nil {
+			t.Fatalf("%s: EBSOptions must always be present", where)
+		}
+
+		if ds.EncryptionAtRestOptions == nil || ds.NodeToNodeEncryptionOptions == nil {
+			t.Fatalf("%s: encryption option blocks must always be present", where)
+		}
+	}
+
+	assertAlwaysPresent(t, create.DomainStatus, "CreateDomain")
+
+	desc, err := c.DescribeDomain(ctx, &awsos.DescribeDomainInput{DomainName: aws.String("minimal-dom")})
+	if err != nil {
+		t.Fatalf("DescribeDomain: %v", err)
+	}
+
+	assertAlwaysPresent(t, desc.DomainStatus, "DescribeDomain")
+}
+
 func TestSDKVPCDomainEndpoints(t *testing.T) {
 	ctx := context.Background()
 	c := newOSClient(t)


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of AWS OpenSearch Service (`aws_opensearch_domain`) against real Terraform (`hashicorp/aws` v5.100), `aws-sdk-go-v2`, and `aws-cli`, run live against `cloudemu serve`.

### Divergence found & fixed

Creating a domain and then reading it back through the Terraform provider **panicked the provider** (nil pointer dereference in `resourceDomainRead` → `flattenCognitoOptions`). Root cause: real AWS `DescribeDomain` **always** returns `CognitoOptions` and `EBSOptions` (plus the encryption toggle blocks), even when the caller omitted them at create. The provider's read path flattens `CognitoOptions` and `EBSOptions` **without a nil check**, so cloudemu omitting them crashed any `plan`/`import`/`refresh`.

Fix: materialize the always-present option blocks (`CognitoOptions`, `EBSOptions`, `EncryptionAtRestOptions`, `NodeToNodeEncryptionOptions`) with their defaults at `CreateDomain` when the caller does not supply them. Caller-supplied blocks are never overwritten, so no round-trip values change.

### Live evidence

- `terraform import` + `plan`: **No changes** (no drift) for a domain with `cluster_config`, `ebs_options`, `node_to_node_encryption`, `encrypt_at_rest`, `domain_endpoint_options`, tags — endpoint/arn/domain_id all computed correctly.
- `terraform apply` update (instance_count 2→4, volume_size 20→50): applied cleanly, post-update `plan` shows no drift.
- Delete: domain removed server-side, `DescribeDomain` → 404, `ListDomainNames` empty.
- Before the fix the provider crashed on read; after, import/plan/apply/destroy all succeed.

Note: Terraform's own create/delete waiters carry a provider-hardcoded `WithDelay(10*time.Minute)` before the first poll — that latency is provider behavior identical against real AWS, not a cloudemu issue.

### Regression test

Added an SDK-level test asserting `CreateDomain`/`DescribeDomain` on a minimal domain always return non-nil `CognitoOptions` (defaulting to `Enabled:false`), `EBSOptions`, and the encryption blocks.

### Gates

build ./... · go vet · gofmt · `go test -race` (providers/aws/opensearch + server/aws/opensearch) · root `go test .` · golangci-lint `--new-from-rev` 0 issues · go generate docs (no diff).