### PR TITLE
fix(azure-storagequeue): real-user e2e divergences from Azure Queue Storage

### DIFF
--- a/server/azure/cosmosdb/handler.go
+++ b/server/azure/cosmosdb/handler.go
@@ -309,6 +309,13 @@ func (h *Handler) Matches(r *http.Request) bool {
 		return false
 	}
 
+	// A root "GET /?comp=list" is a Storage service call (list queues / list
+	// containers), not a Cosmos account probe (which carries no query). Decline
+	// it so the Queue and Blob handlers, registered after this one, serve it.
+	if rest == "/" && r.URL.Query().Get("comp") == "list" {
+		return false
+	}
+
 	return rest == "/" || rest == "/dbs" || strings.HasPrefix(rest, "/dbs/") ||
 		rest == offersPath || strings.HasPrefix(rest, offersPathPrefix)
 }

--- a/server/azure/queue/handler.go
+++ b/server/azure/queue/handler.go
@@ -397,10 +397,10 @@ func (h *Handler) enqueue(w http.ResponseWriter, r *http.Request, queue string) 
 	now := time.Now().UTC()
 	resp := messagesList{Messages: []messageXML{{
 		MessageID:       out.MessageID,
-		InsertionTime:   now.Format(time.RFC1123),
-		ExpirationTime:  displayExpiry(out.ExpiresAt).UTC().Format(time.RFC1123),
+		InsertionTime:   now.Format(http.TimeFormat),
+		ExpirationTime:  displayExpiry(out.ExpiresAt).UTC().Format(http.TimeFormat),
 		PopReceipt:      out.PopReceipt,
-		TimeNextVisible: now.Add(time.Duration(visTimeout) * time.Second).Format(time.RFC1123),
+		TimeNextVisible: now.Add(time.Duration(visTimeout) * time.Second).Format(http.TimeFormat),
 	}}}
 
 	writeXML(w, http.StatusCreated, resp)
@@ -436,15 +436,15 @@ func (h *Handler) dequeue(w http.ResponseWriter, r *http.Request, queue string) 
 		effectiveVis = defaultVisibilityTimeoutSeconds
 	}
 
-	timeNextVisible := now.Add(time.Duration(effectiveVis) * time.Second).Format(time.RFC1123)
+	timeNextVisible := now.Add(time.Duration(effectiveVis) * time.Second).Format(http.TimeFormat)
 	out := messagesList{}
 
 	for i := range msgs {
 		m := &msgs[i]
 		out.Messages = append(out.Messages, messageXML{
 			MessageID:       m.MessageID,
-			InsertionTime:   m.InsertedAt.UTC().Format(time.RFC1123),
-			ExpirationTime:  displayExpiry(m.ExpiresAt).UTC().Format(time.RFC1123),
+			InsertionTime:   m.InsertedAt.UTC().Format(http.TimeFormat),
+			ExpirationTime:  displayExpiry(m.ExpiresAt).UTC().Format(http.TimeFormat),
 			PopReceipt:      m.ReceiptHandle,
 			TimeNextVisible: timeNextVisible,
 			DequeueCount:    int64(m.ReceiveCount),
@@ -500,8 +500,8 @@ func (h *Handler) peek(w http.ResponseWriter, r *http.Request, queue string) {
 	for _, m := range msgs {
 		out.Messages = append(out.Messages, peekMessageXML{
 			MessageID:      m.MessageID,
-			InsertionTime:  m.InsertedAt.UTC().Format(time.RFC1123),
-			ExpirationTime: displayExpiry(m.ExpiresAt).UTC().Format(time.RFC1123),
+			InsertionTime:  m.InsertedAt.UTC().Format(http.TimeFormat),
+			ExpirationTime: displayExpiry(m.ExpiresAt).UTC().Format(http.TimeFormat),
 			DequeueCount:   int64(m.ReceiveCount),
 			MessageText:    m.Body,
 		})
@@ -617,7 +617,7 @@ func (h *Handler) updateMessage(w http.ResponseWriter, r *http.Request, queue, m
 	}
 
 	w.Header().Set("x-ms-popreceipt", res.PopReceipt)
-	w.Header().Set("x-ms-time-next-visible", res.TimeNextVisible.UTC().Format(time.RFC1123))
+	w.Header().Set("x-ms-time-next-visible", res.TimeNextVisible.UTC().Format(http.TimeFormat))
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/server/azure/queue/timestamp_format_test.go
+++ b/server/azure/queue/timestamp_format_test.go
@@ -1,0 +1,81 @@
+package queue_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestQueueTimestampsUseGMTSuffix asserts the RFC1123 timestamps in the Queue
+// Storage wire responses carry the "GMT" zone suffix real Azure emits, not Go's
+// default "UTC" suffix from time.RFC1123. Strict non-Go SDK date parsers (Python,
+// .NET, Java) reject "UTC" and require "GMT"; the Blob handler already uses the
+// GMT-only http.TimeFormat, so the Queue handler must match.
+func TestQueueTimestampsUseGMTSuffix(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{QueueStorage: cloudP.QueueStorage})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	// Create queue.
+	put(t, ts, http.MethodPut, "/q1", "")
+
+	// Enqueue: the response XML carries InsertionTime/ExpirationTime/TimeNextVisible.
+	enqBody := put(t, ts, http.MethodPost, "/q1/messages",
+		"<QueueMessage><MessageText>aGVsbG8=</MessageText></QueueMessage>")
+	assertNoUTCSuffix(t, "enqueue", enqBody)
+
+	// Dequeue: the response XML carries the same timestamp elements.
+	deqBody := get(t, ts, "/q1/messages")
+	assertNoUTCSuffix(t, "dequeue", deqBody)
+}
+
+func assertNoUTCSuffix(t *testing.T, op, body string) {
+	t.Helper()
+
+	if strings.Contains(body, " UTC<") {
+		t.Errorf("%s response has a Go-style \" UTC\" timestamp suffix (Azure emits \"GMT\"): %s", op, body)
+	}
+
+	if !strings.Contains(body, " GMT<") {
+		t.Errorf("%s response is missing a \"GMT\" timestamp suffix: %s", op, body)
+	}
+}
+
+func put(t *testing.T, ts *httptest.Server, method, path, body string) string {
+	t.Helper()
+
+	req, err := http.NewRequest(method, ts.URL+path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, _ := io.ReadAll(resp.Body)
+
+	return string(data)
+}
+
+func get(t *testing.T, ts *httptest.Server, path string) string {
+	t.Helper()
+
+	resp, err := ts.Client().Get(ts.URL + path)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, _ := io.ReadAll(resp.Body)
+
+	return string(data)
+}

--- a/server/azure/queue_servicebus_routing_test.go
+++ b/server/azure/queue_servicebus_routing_test.go
@@ -199,6 +199,47 @@ func TestQueueStoragePlaneAliveOnFullServer(t *testing.T) {
 	}
 }
 
+// TestListQueuesRoutesToQueueHandlerOnFullServer guards the root-path collision
+// between "GET /?comp=list" (List Queues) and the Cosmos DB data-plane account
+// probe ("GET /"). The Cosmos handler is registered long before the Queue
+// handler, and its account probe also lives at the root path; without an explicit
+// carve-out it swallows List Queues and returns a Cosmos account JSON document,
+// so azqueue's list pager sees no queues. This asserts the real azqueue list
+// pager finds the queues it created on the full server.
+func TestListQueuesRoutesToQueueHandlerOnFullServer(t *testing.T) {
+	ts := newFullAzureServer(t)
+	ctx := context.Background()
+
+	createStorageQueue(t, ts, "alpha")
+	createStorageQueue(t, ts, "beta")
+
+	svc, err := azqueue.NewServiceClientWithNoCredential(ts.URL+"/",
+		&azqueue.ClientOptions{ClientOptions: anonOpts(ts)})
+	if err != nil {
+		t.Fatalf("new service client: %v", err)
+	}
+
+	seen := map[string]bool{}
+
+	pager := svc.NewListQueuesPager(nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListQueues: %v", err)
+		}
+
+		for _, q := range page.Queues {
+			if q.Name != nil {
+				seen[*q.Name] = true
+			}
+		}
+	}
+
+	if !seen["alpha"] || !seen["beta"] {
+		t.Fatalf("List Queues on the full server did not return both queues: %v", seen)
+	}
+}
+
 // TestServiceBusUnaffectedOnFullServer confirms a Service Bus flat-queue
 // send/receive round-trip still works end-to-end on the full server.
 func TestServiceBusUnaffectedOnFullServer(t *testing.T) {


### PR DESCRIPTION
## Summary

Real-user e2e audit of Azure Storage Queue (`azurerm_storage_queue` + the Queue Storage data plane) against the real `azqueue` SDK and live `cloudemu serve`. Two genuine divergences from real Azure Queue Storage found and fixed.

## Findings

### 1. RFC1123 timestamps emit `UTC` suffix instead of Azure's `GMT`
The Queue handler formatted `InsertionTime`, `ExpirationTime`, `TimeNextVisible` (in XML) and the `x-ms-time-next-visible` header with `time.RFC1123`. Go's `time.RFC1123` renders a UTC time with a `UTC` zone suffix (e.g. `Sun, 06 Sep 2026 09:08:10 UTC`), but real Azure Queue Storage always emits `GMT` — as the sibling Blob handler already does via `http.TimeFormat`. Strict non-Go SDK date parsers (Python, .NET, Java) reject `UTC` and require `GMT`. Switched all five sites to `http.TimeFormat`.

### 2. List Queues collides with the Cosmos DB account probe on the full server
`GET /?comp=list` (List Queues) shares the root path with the Cosmos DB data-plane account probe (`GET /`). The Cosmos handler is registered long before the Queue handler and its `Matches` claimed any root request, so on a full `cloudemu serve` List Queues returned a Cosmos account JSON document — `azqueue`'s list pager failed with `unmarshalling ... EOF`. The Cosmos handler already cedes bare-account-with-query to Blob; extended that carve-out to decline the Storage `comp=list` marker at the root so the Queue/Blob handlers serve it. The Cosmos account probe (root `GET /` with no query) is unaffected.

## Evidence
- Live `serve` (Azure HTTPS): create queue (201) → put message → peek (non-destructive) → dequeue (pop receipt + `DequeueCount` + `TimeNextVisible`) → delete with wrong pop receipt (404 MessageNotFound) → delete with correct pop receipt (204) → set/get metadata (`x-ms-meta-*` + `x-ms-approximate-messages-count`) → list queues (EnumerationResults XML, prefix filter) → delete queue (204) → put to deleted queue (404 QueueNotFound). All timestamps now emit `GMT`.
- Real `azqueue` SDK round-trips (in-process, full server) green.

## Tests
- `server/azure/queue/timestamp_format_test.go` — asserts wire timestamps carry `GMT`, not `UTC` (RED before, GREEN after).
- `TestListQueuesRoutesToQueueHandlerOnFullServer` in `server/azure/queue_servicebus_routing_test.go` — real `azqueue` list pager against the full server (RED: `unmarshalling ... EOF` before the Cosmos carve-out, GREEN after).

## Gates
`go build ./...`, `go test -race` (server/azure, queue, cosmosdb, servicebus), `go vet`, `gofmt`, `golangci-lint --new-from-rev` (0 new issues), `go generate` (no docs diff), root `go test .` — all green.
