### PR TITLE
fix(neptune): real-user e2e divergences from AWS Neptune

### DIFF
--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -1108,31 +1108,32 @@ func (m *Mock) CreateCluster(ctx context.Context, cfg rdsdriver.ClusterConfig) (
 
 	region := regionctx.RegionOr(ctx, m.opts.Region)
 	cluster := rdsdriver.Cluster{
-		ID:                          cfg.ID,
-		ARN:                         clusterARN(region, m.opts.AccountID, cfg.ID),
-		Engine:                      cfg.Engine,
-		EngineVersion:               cfg.EngineVersion,
-		MasterUsername:              cfg.MasterUsername,
-		DatabaseName:                cfg.DatabaseName,
-		Endpoint:                    endpointFor(cfg.ID, region, "cluster"),
-		ReaderEndpoint:              endpointFor(cfg.ID, region, "cluster-ro"),
-		Port:                        port,
-		State:                       rdsdriver.StateAvailable,
-		VPCSecurityGroups:           append([]string(nil), cfg.VPCSecurityGroups...),
-		SubnetGroupName:             cfg.SubnetGroupName,
-		DBClusterParameterGroupName: cfg.DBClusterParameterGroupName,
-		BackupRetentionPeriod:       backupRetention,
-		PreferredBackupWindow:       backupWindow,
-		PreferredMaintenanceWindow:  maintenanceWindow,
-		EngineMode:                  engineMode,
-		DBClusterResourceID:         resourceID("cluster-", cfg.ID),
-		AllocatedStorage:            allocatedStorage,
-		StorageEncrypted:            cfg.StorageEncrypted,
-		KmsKeyID:                    resolveKMSKeyID(cfg.StorageEncrypted, cfg.KmsKeyID),
-		DeletionProtection:          cfg.DeletionProtection,
-		AvailabilityZones:           availabilityZones(region),
-		CreatedAt:                   m.opts.Clock.Now().UTC(),
-		Tags:                        copyTags(cfg.Tags),
+		ID:                               cfg.ID,
+		ARN:                              clusterARN(region, m.opts.AccountID, cfg.ID),
+		Engine:                           cfg.Engine,
+		EngineVersion:                    cfg.EngineVersion,
+		MasterUsername:                   cfg.MasterUsername,
+		DatabaseName:                     cfg.DatabaseName,
+		Endpoint:                         endpointFor(cfg.ID, region, "cluster"),
+		ReaderEndpoint:                   endpointFor(cfg.ID, region, "cluster-ro"),
+		Port:                             port,
+		State:                            rdsdriver.StateAvailable,
+		VPCSecurityGroups:                append([]string(nil), cfg.VPCSecurityGroups...),
+		SubnetGroupName:                  cfg.SubnetGroupName,
+		DBClusterParameterGroupName:      cfg.DBClusterParameterGroupName,
+		BackupRetentionPeriod:            backupRetention,
+		PreferredBackupWindow:            backupWindow,
+		PreferredMaintenanceWindow:       maintenanceWindow,
+		EngineMode:                       engineMode,
+		DBClusterResourceID:              resourceID("cluster-", cfg.ID),
+		AllocatedStorage:                 allocatedStorage,
+		StorageEncrypted:                 cfg.StorageEncrypted,
+		KmsKeyID:                         resolveKMSKeyID(cfg.StorageEncrypted, cfg.KmsKeyID),
+		DeletionProtection:               cfg.DeletionProtection,
+		IAMDatabaseAuthenticationEnabled: cfg.IAMDatabaseAuthenticationEnabled,
+		AvailabilityZones:                availabilityZones(region),
+		CreatedAt:                        m.opts.Clock.Now().UTC(),
+		Tags:                             copyTags(cfg.Tags),
 	}
 
 	m.clusters.Set(cfg.ID, cluster)
@@ -1174,27 +1175,12 @@ func (m *Mock) DescribeClusters(_ context.Context, ids []string) ([]rdsdriver.Cl
 	return out, nil
 }
 
-// ModifyCluster applies changes.
+// applyClusterModify overlays the non-empty ModifyDBCluster fields onto the
+// stored cluster. Split out of ModifyCluster to keep that method's branching
+// under the cyclomatic-complexity limit.
 //
 //nolint:gocritic // input matches the driver interface signature.
-func (m *Mock) ModifyCluster(
-	ctx context.Context, id string, input rdsdriver.ModifyInstanceInput,
-) (*rdsdriver.Cluster, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	cluster, ok := m.clusters.Get(id)
-	if !ok {
-		return nil, cerrors.Newf(cerrors.NotFound, "DB cluster %q not found", id)
-	}
-
-	// An Aurora cluster owns the shared database, so its master password is
-	// rotated at the cluster scope (instance-level rotation skips members). Rotate
-	// the shared engine role so the new credential AWS reports authenticates.
-	if err := m.rotateClusterPassword(ctx, id, cluster.Engine, input.MasterUserPassword); err != nil {
-		return nil, err
-	}
-
+func applyClusterModify(cluster *rdsdriver.Cluster, input rdsdriver.ModifyInstanceInput) {
 	if input.EngineVersion != "" {
 		cluster.EngineVersion = input.EngineVersion
 	}
@@ -1219,9 +1205,37 @@ func (m *Mock) ModifyCluster(
 		cluster.DeletionProtection = *input.DeletionProtection
 	}
 
+	if input.IAMDatabaseAuthenticationEnabled != nil {
+		cluster.IAMDatabaseAuthenticationEnabled = *input.IAMDatabaseAuthenticationEnabled
+	}
+
 	if input.Tags != nil {
 		cluster.Tags = copyTags(input.Tags)
 	}
+}
+
+// ModifyCluster applies changes.
+//
+//nolint:gocritic // input matches the driver interface signature.
+func (m *Mock) ModifyCluster(
+	ctx context.Context, id string, input rdsdriver.ModifyInstanceInput,
+) (*rdsdriver.Cluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cluster, ok := m.clusters.Get(id)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "DB cluster %q not found", id)
+	}
+
+	// An Aurora cluster owns the shared database, so its master password is
+	// rotated at the cluster scope (instance-level rotation skips members). Rotate
+	// the shared engine role so the new credential AWS reports authenticates.
+	if err := m.rotateClusterPassword(ctx, id, cluster.Engine, input.MasterUserPassword); err != nil {
+		return nil, err
+	}
+
+	applyClusterModify(&cluster, input)
 
 	m.clusters.Set(id, cluster)
 

--- a/server/aws/rds/neptune_sdk_roundtrip_test.go
+++ b/server/aws/rds/neptune_sdk_roundtrip_test.go
@@ -51,8 +51,9 @@ func TestSDKNeptuneClusterCRUD(t *testing.T) {
 	ctx := context.Background()
 
 	out, err := client.CreateDBCluster(ctx, &awsneptune.CreateDBClusterInput{
-		DBClusterIdentifier: aws.String("nep1"),
-		Engine:              aws.String("neptune"),
+		DBClusterIdentifier:             aws.String("nep1"),
+		Engine:                          aws.String("neptune"),
+		EnableIAMDatabaseAuthentication: aws.Bool(true),
 	})
 	if err != nil {
 		t.Fatalf("CreateDBCluster: %v", err)
@@ -71,6 +72,12 @@ func TestSDKNeptuneClusterCRUD(t *testing.T) {
 		t.Fatalf("got port %v, want 8182", out.DBCluster.Port)
 	}
 
+	// aws_neptune_cluster reads iam_database_authentication_enabled straight
+	// back; a create that enables it must echo true or Terraform drifts.
+	if !aws.ToBool(out.DBCluster.IAMDatabaseAuthenticationEnabled) {
+		t.Fatal("IAMDatabaseAuthenticationEnabled = false, want true")
+	}
+
 	desc, err := client.DescribeDBClusters(ctx, &awsneptune.DescribeDBClustersInput{
 		DBClusterIdentifier: aws.String("nep1"),
 	})
@@ -82,11 +89,28 @@ func TestSDKNeptuneClusterCRUD(t *testing.T) {
 		t.Fatalf("got %d clusters, want 1", len(desc.DBClusters))
 	}
 
+	if !aws.ToBool(desc.DBClusters[0].IAMDatabaseAuthenticationEnabled) {
+		t.Fatal("describe IAMDatabaseAuthenticationEnabled = false, want true")
+	}
+
 	if _, err := client.ModifyDBCluster(ctx, &awsneptune.ModifyDBClusterInput{
-		DBClusterIdentifier: aws.String("nep1"),
-		EngineVersion:       aws.String("1.2.1.0"),
+		DBClusterIdentifier:             aws.String("nep1"),
+		EngineVersion:                   aws.String("1.2.1.0"),
+		EnableIAMDatabaseAuthentication: aws.Bool(false),
 	}); err != nil {
 		t.Fatalf("ModifyDBCluster: %v", err)
+	}
+
+	// The toggle to false must round-trip too (explicit-false, not "unset").
+	reDesc, err := client.DescribeDBClusters(ctx, &awsneptune.DescribeDBClustersInput{
+		DBClusterIdentifier: aws.String("nep1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBClusters after modify: %v", err)
+	}
+
+	if aws.ToBool(reDesc.DBClusters[0].IAMDatabaseAuthenticationEnabled) {
+		t.Fatal("after ModifyDBCluster, IAMDatabaseAuthenticationEnabled = true, want false")
 	}
 
 	if _, err := client.DeleteDBCluster(ctx, &awsneptune.DeleteDBClusterInput{

--- a/server/aws/rds/operations.go
+++ b/server/aws/rds/operations.go
@@ -480,25 +480,26 @@ func (h *Handler) createDBCluster(w http.ResponseWriter, r *http.Request) {
 	form := r.Form
 
 	cfg := rdsdriver.ClusterConfig{
-		ID:                          form.Get("DBClusterIdentifier"),
-		Engine:                      form.Get("Engine"),
-		EngineVersion:               form.Get("EngineVersion"),
-		MasterUsername:              form.Get("MasterUsername"),
-		MasterUserPassword:          form.Get("MasterUserPassword"),
-		DatabaseName:                form.Get("DatabaseName"),
-		Port:                        formInt(form.Get("Port")),
-		VPCSecurityGroups:           awsquery.ListStrings(form, "VpcSecurityGroupIds.VpcSecurityGroupId"),
-		SubnetGroupName:             form.Get("DBSubnetGroupName"),
-		DBClusterParameterGroupName: form.Get("DBClusterParameterGroupName"),
-		BackupRetentionPeriod:       formInt(form.Get("BackupRetentionPeriod")),
-		PreferredBackupWindow:       form.Get("PreferredBackupWindow"),
-		PreferredMaintenanceWindow:  form.Get("PreferredMaintenanceWindow"),
-		EngineMode:                  form.Get("EngineMode"),
-		StorageEncrypted:            formBool(form.Get("StorageEncrypted")),
-		KmsKeyID:                    form.Get("KmsKeyId"),
-		AllocatedStorage:            formInt(form.Get("AllocatedStorage")),
-		DeletionProtection:          formBool(form.Get("DeletionProtection")),
-		Tags:                        parseRDSTags(form),
+		ID:                               form.Get("DBClusterIdentifier"),
+		Engine:                           form.Get("Engine"),
+		EngineVersion:                    form.Get("EngineVersion"),
+		MasterUsername:                   form.Get("MasterUsername"),
+		MasterUserPassword:               form.Get("MasterUserPassword"),
+		DatabaseName:                     form.Get("DatabaseName"),
+		Port:                             formInt(form.Get("Port")),
+		VPCSecurityGroups:                awsquery.ListStrings(form, "VpcSecurityGroupIds.VpcSecurityGroupId"),
+		SubnetGroupName:                  form.Get("DBSubnetGroupName"),
+		DBClusterParameterGroupName:      form.Get("DBClusterParameterGroupName"),
+		BackupRetentionPeriod:            formInt(form.Get("BackupRetentionPeriod")),
+		PreferredBackupWindow:            form.Get("PreferredBackupWindow"),
+		PreferredMaintenanceWindow:       form.Get("PreferredMaintenanceWindow"),
+		EngineMode:                       form.Get("EngineMode"),
+		StorageEncrypted:                 formBool(form.Get("StorageEncrypted")),
+		KmsKeyID:                         form.Get("KmsKeyId"),
+		AllocatedStorage:                 formInt(form.Get("AllocatedStorage")),
+		DeletionProtection:               formBool(form.Get("DeletionProtection")),
+		IAMDatabaseAuthenticationEnabled: formBool(form.Get("EnableIAMDatabaseAuthentication")),
+		Tags:                             parseRDSTags(form),
 	}
 
 	cluster, err := h.db.CreateCluster(r.Context(), cfg)
@@ -563,6 +564,11 @@ func (h *Handler) modifyDBCluster(w http.ResponseWriter, r *http.Request) {
 	if v := form.Get("DeletionProtection"); v != "" {
 		b := formBool(v)
 		input.DeletionProtection = &b
+	}
+
+	if v := form.Get("EnableIAMDatabaseAuthentication"); v != "" {
+		b := formBool(v)
+		input.IAMDatabaseAuthenticationEnabled = &b
 	}
 
 	cluster, err := h.db.ModifyCluster(r.Context(), id, input)

--- a/server/aws/rds/parameter_group.go
+++ b/server/aws/rds/parameter_group.go
@@ -210,6 +210,26 @@ func parseParameterNames(form url.Values) []string {
 	return names
 }
 
+// filterParamsBySource honors the DescribeDB(Cluster)Parameters "Source" request
+// filter. Real RDS returns only parameters whose Source matches (e.g. Terraform's
+// aws_neptune_cluster_parameter_group reads with Source="user" and expects the
+// engine-default set to be excluded). An empty filter returns every parameter.
+func filterParamsBySource(params []rdsdriver.Parameter, source string) []rdsdriver.Parameter {
+	if source == "" {
+		return params
+	}
+
+	out := make([]rdsdriver.Parameter, 0, len(params))
+
+	for i := range params {
+		if params[i].Source == source {
+			out = append(out, params[i])
+		}
+	}
+
+	return out
+}
+
 func toParameterGroupXML(pg *rdsdriver.ParameterGroup) dbParameterGroupXML {
 	return dbParameterGroupXML{
 		DBParameterGroupName:   pg.Name,
@@ -347,6 +367,7 @@ func (h *Handler) deleteDBParameterGroup(w http.ResponseWriter, r *http.Request)
 	})
 }
 
+//nolint:dupl // structurally mirrors describeDBClusterParameters by design.
 func (h *Handler) describeDBParameters(w http.ResponseWriter, r *http.Request) {
 	store, ok := h.parameterGroupsCap()
 	if !ok {
@@ -360,6 +381,8 @@ func (h *Handler) describeDBParameters(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	params = filterParamsBySource(params, r.Form.Get("Source"))
+
 	awsquery.WriteXMLResponse(w, describeDBParametersResponse{
 		Xmlns:    Namespace,
 		Result:   parametersList{Parameters: toParametersXML(params)},
@@ -367,7 +390,6 @@ func (h *Handler) describeDBParameters(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//nolint:dupl // structurally mirrors its sibling per-resource block by design.
 func (h *Handler) resetDBParameterGroup(w http.ResponseWriter, r *http.Request) {
 	store, ok := h.parameterGroupsCap()
 	if !ok {
@@ -517,6 +539,7 @@ func (h *Handler) deleteDBClusterParameterGroup(w http.ResponseWriter, r *http.R
 	})
 }
 
+//nolint:dupl // structurally mirrors describeDBParameters by design.
 func (h *Handler) describeDBClusterParameters(w http.ResponseWriter, r *http.Request) {
 	store, ok := h.parameterGroupsCap()
 	if !ok {
@@ -530,6 +553,8 @@ func (h *Handler) describeDBClusterParameters(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	params = filterParamsBySource(params, r.Form.Get("Source"))
+
 	awsquery.WriteXMLResponse(w, describeDBClusterParametersResponse{
 		Xmlns:    Namespace,
 		Result:   parametersList{Parameters: toParametersXML(params)},
@@ -537,7 +562,6 @@ func (h *Handler) describeDBClusterParameters(w http.ResponseWriter, r *http.Req
 	})
 }
 
-//nolint:dupl // structurally mirrors its sibling per-resource block by design.
 func (h *Handler) resetDBClusterParameterGroup(w http.ResponseWriter, r *http.Request) {
 	store, ok := h.parameterGroupsCap()
 	if !ok {

--- a/server/aws/rds/parametergroup_sdk_roundtrip_test.go
+++ b/server/aws/rds/parametergroup_sdk_roundtrip_test.go
@@ -149,6 +149,74 @@ func TestSDKRDSClusterParameterGroupLifecycle(t *testing.T) {
 	}
 }
 
+// TestSDKRDSClusterParametersSourceFilter pins that DescribeDBClusterParameters
+// honors the "Source" request filter. terraform-provider-aws reads a cluster
+// parameter group (aws_neptune_cluster_parameter_group / aws_rds_cluster_parameter_group)
+// with Source="user" and expects the engine-default set excluded — otherwise
+// every default surfaces as an unmanaged parameter block and the plan never
+// converges.
+func TestSDKRDSClusterParametersSourceFilter(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBClusterParameterGroup(ctx, &awsrds.CreateDBClusterParameterGroupInput{
+		DBClusterParameterGroupName: aws.String("cpg-src"),
+		DBParameterGroupFamily:      aws.String("neptune1.3"),
+		Description:                 aws.String("source filter"),
+	}); err != nil {
+		t.Fatalf("CreateDBClusterParameterGroup: %v", err)
+	}
+
+	// A brand-new group has no user-modified parameters, so Source="user" must
+	// return an empty list even though engine-defaults exist.
+	userOnly, err := client.DescribeDBClusterParameters(ctx, &awsrds.DescribeDBClusterParametersInput{
+		DBClusterParameterGroupName: aws.String("cpg-src"),
+		Source:                      aws.String("user"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBClusterParameters(user): %v", err)
+	}
+
+	if len(userOnly.Parameters) != 0 {
+		t.Fatalf("fresh group Source=user returned %d params, want 0", len(userOnly.Parameters))
+	}
+
+	// Modify one parameter; it becomes user-sourced and is the ONLY thing
+	// Source="user" returns.
+	if _, err := client.ModifyDBClusterParameterGroup(ctx, &awsrds.ModifyDBClusterParameterGroupInput{
+		DBClusterParameterGroupName: aws.String("cpg-src"),
+		Parameters: []awsrdstypes.Parameter{
+			{ParameterName: aws.String("max_connections"), ParameterValue: aws.String("300")},
+		},
+	}); err != nil {
+		t.Fatalf("ModifyDBClusterParameterGroup: %v", err)
+	}
+
+	userOnly, err = client.DescribeDBClusterParameters(ctx, &awsrds.DescribeDBClusterParametersInput{
+		DBClusterParameterGroupName: aws.String("cpg-src"),
+		Source:                      aws.String("user"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBClusterParameters(user) after modify: %v", err)
+	}
+
+	if len(userOnly.Parameters) != 1 || aws.ToString(userOnly.Parameters[0].ParameterName) != "max_connections" {
+		t.Fatalf("Source=user returned %d params, want only max_connections", len(userOnly.Parameters))
+	}
+
+	// No filter still returns the full set (engine-defaults included).
+	all, err := client.DescribeDBClusterParameters(ctx, &awsrds.DescribeDBClusterParametersInput{
+		DBClusterParameterGroupName: aws.String("cpg-src"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBClusterParameters(all): %v", err)
+	}
+
+	if len(all.Parameters) <= len(userOnly.Parameters) {
+		t.Fatalf("unfiltered describe returned %d params, want more than the user subset", len(all.Parameters))
+	}
+}
+
 func findSDKParam(params []awsrdstypes.Parameter, name string) *awsrdstypes.Parameter {
 	for i := range params {
 		if aws.ToString(params[i].ParameterName) == name {

--- a/server/aws/rds/xml.go
+++ b/server/aws/rds/xml.go
@@ -162,21 +162,26 @@ type dbClusterXML struct {
 	// BackupRetentionPeriod is NOT omitempty: real RDS always emits the element
 	// (default 1) and Terraform's backup_retention_period default is 1, so a
 	// missing element reads as 0 and drifts.
-	BackupRetentionPeriod      int                   `xml:"BackupRetentionPeriod"`
-	PreferredBackupWindow      string                `xml:"PreferredBackupWindow,omitempty"`
-	PreferredMaintenanceWindow string                `xml:"PreferredMaintenanceWindow,omitempty"`
-	EngineMode                 string                `xml:"EngineMode,omitempty"`
-	DBClusterResourceID        string                `xml:"DbClusterResourceId,omitempty"`
-	AllocatedStorage           int                   `xml:"AllocatedStorage,omitempty"`
-	StorageEncrypted           bool                  `xml:"StorageEncrypted"`
-	KmsKeyID                   string                `xml:"KmsKeyId,omitempty"`
-	DeletionProtection         bool                  `xml:"DeletionProtection"`
-	AvailabilityZones          *availabilityZonesXML `xml:"AvailabilityZones,omitempty"`
-	ClusterCreateTime          string                `xml:"ClusterCreateTime,omitempty"`
-	DBClusterMembers           *dbClusterMembersXML  `xml:"DBClusterMembers,omitempty"`
-	VpcSecurityGroups          *vpcSecurityGroupsXML `xml:"VpcSecurityGroups,omitempty"`
-	AssociatedRoles            *associatedRolesXML   `xml:"AssociatedRoles,omitempty"`
-	TagList                    *tagListXML           `xml:"TagList,omitempty"`
+	BackupRetentionPeriod      int    `xml:"BackupRetentionPeriod"`
+	PreferredBackupWindow      string `xml:"PreferredBackupWindow,omitempty"`
+	PreferredMaintenanceWindow string `xml:"PreferredMaintenanceWindow,omitempty"`
+	EngineMode                 string `xml:"EngineMode,omitempty"`
+	DBClusterResourceID        string `xml:"DbClusterResourceId,omitempty"`
+	AllocatedStorage           int    `xml:"AllocatedStorage,omitempty"`
+	StorageEncrypted           bool   `xml:"StorageEncrypted"`
+	KmsKeyID                   string `xml:"KmsKeyId,omitempty"`
+	DeletionProtection         bool   `xml:"DeletionProtection"`
+	// IAMDatabaseAuthenticationEnabled is NOT omitempty: real RDS always emits the
+	// element (default false) and Terraform's aws_neptune_cluster / aws_rds_cluster
+	// / aws_docdb_cluster read it back, so a missing element would drift a config
+	// that sets iam_database_authentication_enabled = true.
+	IAMDatabaseAuthenticationEnabled bool                  `xml:"IAMDatabaseAuthenticationEnabled"`
+	AvailabilityZones                *availabilityZonesXML `xml:"AvailabilityZones,omitempty"`
+	ClusterCreateTime                string                `xml:"ClusterCreateTime,omitempty"`
+	DBClusterMembers                 *dbClusterMembersXML  `xml:"DBClusterMembers,omitempty"`
+	VpcSecurityGroups                *vpcSecurityGroupsXML `xml:"VpcSecurityGroups,omitempty"`
+	AssociatedRoles                  *associatedRolesXML   `xml:"AssociatedRoles,omitempty"`
+	TagList                          *tagListXML           `xml:"TagList,omitempty"`
 }
 
 type dbClusterRoleXML struct {
@@ -534,33 +539,34 @@ func toClusterXML(cluster *rdsdriver.Cluster) dbClusterXML {
 	}
 
 	return dbClusterXML{
-		DBClusterIdentifier:        cluster.ID,
-		DBClusterArn:               cluster.ARN,
-		Engine:                     cluster.Engine,
-		EngineVersion:              cluster.EngineVersion,
-		Status:                     cluster.State,
-		MasterUsername:             cluster.MasterUsername,
-		DatabaseName:               cluster.DatabaseName,
-		Endpoint:                   cluster.Endpoint,
-		ReaderEndpoint:             cluster.ReaderEndpoint,
-		Port:                       cluster.Port,
-		DBSubnetGroup:              cluster.SubnetGroupName,
-		DBClusterParameterGroup:    cluster.DBClusterParameterGroupName,
-		BackupRetentionPeriod:      cluster.BackupRetentionPeriod,
-		PreferredBackupWindow:      cluster.PreferredBackupWindow,
-		PreferredMaintenanceWindow: cluster.PreferredMaintenanceWindow,
-		EngineMode:                 cluster.EngineMode,
-		DBClusterResourceID:        cluster.DBClusterResourceID,
-		AllocatedStorage:           cluster.AllocatedStorage,
-		StorageEncrypted:           cluster.StorageEncrypted,
-		KmsKeyID:                   cluster.KmsKeyID,
-		DeletionProtection:         cluster.DeletionProtection,
-		AvailabilityZones:          toAvailabilityZonesXML(cluster.AvailabilityZones),
-		ClusterCreateTime:          cluster.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
-		DBClusterMembers:           &members,
-		VpcSecurityGroups:          toVpcSGsXML(cluster.VPCSecurityGroups),
-		AssociatedRoles:            toAssociatedRolesXML(cluster.AssociatedRoles),
-		TagList:                    toTagListXML(cluster.Tags),
+		DBClusterIdentifier:              cluster.ID,
+		DBClusterArn:                     cluster.ARN,
+		Engine:                           cluster.Engine,
+		EngineVersion:                    cluster.EngineVersion,
+		Status:                           cluster.State,
+		MasterUsername:                   cluster.MasterUsername,
+		DatabaseName:                     cluster.DatabaseName,
+		Endpoint:                         cluster.Endpoint,
+		ReaderEndpoint:                   cluster.ReaderEndpoint,
+		Port:                             cluster.Port,
+		DBSubnetGroup:                    cluster.SubnetGroupName,
+		DBClusterParameterGroup:          cluster.DBClusterParameterGroupName,
+		BackupRetentionPeriod:            cluster.BackupRetentionPeriod,
+		PreferredBackupWindow:            cluster.PreferredBackupWindow,
+		PreferredMaintenanceWindow:       cluster.PreferredMaintenanceWindow,
+		EngineMode:                       cluster.EngineMode,
+		DBClusterResourceID:              cluster.DBClusterResourceID,
+		AllocatedStorage:                 cluster.AllocatedStorage,
+		StorageEncrypted:                 cluster.StorageEncrypted,
+		KmsKeyID:                         cluster.KmsKeyID,
+		DeletionProtection:               cluster.DeletionProtection,
+		IAMDatabaseAuthenticationEnabled: cluster.IAMDatabaseAuthenticationEnabled,
+		AvailabilityZones:                toAvailabilityZonesXML(cluster.AvailabilityZones),
+		ClusterCreateTime:                cluster.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
+		DBClusterMembers:                 &members,
+		VpcSecurityGroups:                toVpcSGsXML(cluster.VPCSecurityGroups),
+		AssociatedRoles:                  toAssociatedRolesXML(cluster.AssociatedRoles),
+		TagList:                          toTagListXML(cluster.Tags),
 	}
 }
 

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -285,6 +285,10 @@ type ModifyInstanceInput struct {
 	StorageType                string
 	Iops                       int
 	DeletionProtection         *bool
+	// IAMDatabaseAuthenticationEnabled toggles the AWS RDS DBCluster IAM database
+	// authentication attribute on ModifyDBCluster; nil means "no change". Cluster
+	// scope only (Aurora/Neptune/DocumentDB); instances ignore it.
+	IAMDatabaseAuthenticationEnabled *bool
 	// AutoMinorVersionUpgrade updates the AWS RDS DBInstance attribute; nil means
 	// "no change". Other engines ignore it.
 	AutoMinorVersionUpgrade *bool
@@ -398,6 +402,11 @@ type ClusterConfig struct {
 	// echoes the AWS RDS DBCluster attribute and defaults to false. Zero for
 	// non-AWS engines.
 	DeletionProtection bool
+	// IAMDatabaseAuthenticationEnabled maps to the AWS RDS DBCluster
+	// EnableIAMDatabaseAuthentication create input (Aurora/Neptune/DocumentDB).
+	// Defaults to false; echoed on read so Terraform's
+	// iam_database_authentication_enabled does not drift.
+	IAMDatabaseAuthenticationEnabled bool
 	// Redshift-specific create inputs carried on the shared config (following the
 	// Azure HighAvailabilityMode precedent); zero for RDS/Aurora/Azure/GCP.
 	NodeType           string
@@ -463,6 +472,10 @@ type Cluster struct {
 	// DeletionProtection guards the cluster from deletion while set; echoes the
 	// AWS RDS DBCluster attribute and defaults to false for non-AWS engines.
 	DeletionProtection bool
+	// IAMDatabaseAuthenticationEnabled echoes the AWS RDS DBCluster
+	// IAMDatabaseAuthenticationEnabled attribute (Aurora/Neptune/DocumentDB) on
+	// read; defaults to false for non-AWS engines.
+	IAMDatabaseAuthenticationEnabled bool
 	// NodeType / NumberOfNodes / Encrypted / PubliclyAccessible /
 	// AvailabilityZone / VpcID are Redshift-specific cluster attributes carried
 	// on the shared struct (Azure HighAvailabilityMode precedent); zero for


### PR DESCRIPTION
## Summary

Deep real-user e2e audit of AWS Neptune (`aws_neptune_cluster`, `aws_neptune_cluster_instance`, `aws_neptune_subnet_group`, `aws_neptune_cluster_parameter_group`) driven through the real `hashicorp/aws` Terraform provider, `aws-sdk-go-v2/service/neptune`, and `aws-cli` against a live `cloudemu serve`. Neptune shares the RDS query-XML wire (`rds.amazonaws.com`, API `2014-10-31`, `Engine=neptune`, port `8182`) and is RDS-routed by engine.

Most of the surface was already correct (Engine echoed, Port 8182, Endpoint/ReaderEndpoint, Status `available`, DBClusterMembers with `IsClusterWriter`, ClusterCreateTime, backup/window defaults). Two genuine divergences produced perpetual Terraform drift:

### 1. `IAMDatabaseAuthenticationEnabled` never round-tripped
`EnableIAMDatabaseAuthentication` on CreateDBCluster/ModifyDBCluster was dropped, and the describe response never emitted the element. A config with `iam_database_authentication_enabled = true` drifted on every `terraform plan` (`false -> true`). Now parsed, stored on the shared cluster state, and always emitted (default false). Also fixes `aws_rds_cluster` / `aws_docdb_cluster`.

### 2. `DescribeDB(Cluster)Parameters` ignored the `Source` filter
The terraform provider reads a cluster parameter group with `Source="user"` and expects the engine-default set excluded. cloudemu returned all params regardless, so a fresh `aws_neptune_cluster_parameter_group` surfaced every default (`max_connections`, `time_zone`) as an unmanaged `parameter` block the plan wanted to remove — never converging. Both describe handlers now honor the request `Source` filter.

## Evidence (live, port 17630)
- Terraform full lifecycle: create -> describe (no drift) -> update (toggle IAM auth, change backup_retention) -> `terraform plan` clean (`No changes`) -> destroy. Endpoint/reader_endpoint/port 8182/engine/cluster_members/iam_database_authentication_enabled all no-drift.
- aws-cli: cluster reports `neptune`/`8182`/`IAMDatabaseAuthenticationEnabled=true`/`available`; `describe-db-cluster-parameters --source user` returns 0 on a fresh group, full set unfiltered.
- Repro'd RED before, GREEN after.

## Tests
- `TestSDKNeptuneClusterCRUD` extended: IAM auth create-echo + modify-to-false round-trip.
- New `TestSDKRDSClusterParametersSourceFilter`: `Source=user` excludes engine-defaults, returns only user-modified params.

## Gates (GOMAXPROCS=3)
`go build ./...`, `go vet`, `gofmt -l` clean; `go test -race ./server/aws/rds/... ./providers/aws/rds/...` (Neptune + Aurora + DocumentDB share dispatch — all green); root `go test .`; `golangci-lint --new-from-rev=origin/development` 0 issues; `go generate ./...` no `docs/coverage` diff (fields only, no new driver methods).