### PR TITLE
fix(azure-vm): real-user e2e divergences from Azure Virtual Machines

### DIFF
--- a/features/chaos/wrappers_test.go
+++ b/features/chaos/wrappers_test.go
@@ -432,6 +432,7 @@ type computeConfigCompat = struct {
 	IamInstanceProfileARN  string
 	IamInstanceProfileName string
 	Identity               *computedriver.ManagedIdentity
+	Plan                   *computedriver.MarketplacePlan
 	NetworkInterfaces      []computedriver.AzureNICRef
 	PrivateIP              string
 	BlockDeviceMappings    []computedriver.BlockDeviceMapping

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -168,6 +168,9 @@ type instanceData struct {
 	// Identity is the resolved managed-identity block, nil when no identity
 	// is attached.
 	Identity *driver.ManagedIdentity
+	// Plan is the marketplace purchase plan the VM was created from
+	// (VirtualMachine.plan), nil for a first-party image. Immutable after create.
+	Plan *driver.MarketplacePlan
 	// engineBacked is true when a real config.ComputeEngine backs this
 	// instance, so Terminate deprovisions it and console output is read from
 	// the engine rather than synthesized.
@@ -339,7 +342,20 @@ func toInstance(d *instanceData) driver.Instance {
 		PowerState:  d.PowerState,
 		Generalized: d.Generalized,
 		Identity:    copyIdentity(d.Identity),
+		Plan:        copyPlan(d.Plan),
 	}
+}
+
+// copyPlan deep-copies a MarketplacePlan so a caller holding the returned
+// driver.Instance cannot mutate the stored instanceData through it.
+func copyPlan(in *driver.MarketplacePlan) *driver.MarketplacePlan {
+	if in == nil {
+		return nil
+	}
+
+	out := *in
+
+	return &out
 }
 
 // copyIdentity deep-copies a ManagedIdentity so a caller holding the returned
@@ -445,6 +461,7 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 		}
 
 		inst.Identity = resolveIdentity(cfg.Identity, id)
+		inst.Plan = copyPlan(cfg.Plan)
 
 		// Back the instance with a real compute engine when one is configured.
 		// The engine runs the decoded customData as the boot script and may
@@ -809,6 +826,12 @@ func applyMutableConfig(inst *instanceData, cfg driver.InstanceConfig, instanceI
 
 	if cfg.Identity != nil {
 		inst.Identity = resolveIdentity(cfg.Identity, instanceID)
+	}
+
+	// Plan is immutable in real Azure: a re-PUT that resends it is a no-op, and
+	// an omitted plan preserves the existing one (mirroring Identity above).
+	if cfg.Plan != nil {
+		inst.Plan = copyPlan(cfg.Plan)
 	}
 }
 

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -116,6 +116,7 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 		Region:            req.Location,
 		ResourceGroup:     rp.ResourceGroup,
 		Identity:          toDriverIdentity(req.Identity),
+		Plan:              toDriverPlan(req.Plan),
 		NetworkInterfaces: nicRefs,
 	}
 
@@ -1372,6 +1373,39 @@ func fromDriverIdentity(in *computedriver.ManagedIdentity) *identity {
 	return out
 }
 
+// toDriverPlan maps an inbound ARM plan block onto the driver shape. Returns
+// nil when the request carried no plan (a VM from a first-party image), so the
+// create path records no plan and an idempotent re-PUT that omits it preserves
+// whatever plan is already recorded.
+func toDriverPlan(in *plan) *computedriver.MarketplacePlan {
+	if in == nil {
+		return nil
+	}
+
+	return &computedriver.MarketplacePlan{
+		Name:          in.Name,
+		Publisher:     in.Publisher,
+		Product:       in.Product,
+		PromotionCode: in.PromotionCode,
+	}
+}
+
+// fromDriverPlan builds the ARM plan response block from the recorded driver
+// plan. Returns nil when the VM has no plan, so the response omits the field
+// entirely (matching real Azure for first-party-image VMs).
+func fromDriverPlan(in *computedriver.MarketplacePlan) *plan {
+	if in == nil {
+		return nil
+	}
+
+	return &plan{
+		Name:          in.Name,
+		Publisher:     in.Publisher,
+		Product:       in.Product,
+		PromotionCode: in.PromotionCode,
+	}
+}
+
 func osTypeFromStorage(s *storageProfile) string {
 	if s == nil || s.OSDisk == nil {
 		return ""
@@ -1450,6 +1484,7 @@ func toVMResponse(inst *computedriver.Instance, rp azurearm.ResourcePath, req vm
 		Tags:     stripInternalTags(inst.Tags),
 		Zones:    inst.Zones,
 		Identity: fromDriverIdentity(inst.Identity),
+		Plan:     fromDriverPlan(inst.Plan),
 		Properties: vmResponseProps{
 			VMID:              vmGUID(inst.ID),
 			ProvisioningState: provisioningState,

--- a/server/azure/virtualmachines/plan_roundtrip_test.go
+++ b/server/azure/virtualmachines/plan_roundtrip_test.go
@@ -1,0 +1,146 @@
+package virtualmachines_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// TestSDKVMPlanRoundTrip verifies that a VM's top-level plan block (the
+// marketplace purchase plan, armcompute.VirtualMachine.Plan) survives a
+// create → get round-trip. plan is a sibling of properties, so the generic
+// property overlay cannot recover it — the handler must model it explicitly.
+// Without that, a marketplace-image VM read back through the Azure SDK (or
+// azurerm's Read) sees an empty plan and drifts/replaces on every plan.
+func TestSDKVMPlanRoundTrip(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newSDKClient(t, ts)
+	ctx := context.Background()
+
+	wantPlan := &armcompute.Plan{
+		Name:      to.Ptr("cloud-instance"),
+		Publisher: to.Ptr("cloudvendor"),
+		Product:   to.Ptr("vm-image"),
+	}
+
+	poller, err := client.BeginCreateOrUpdate(ctx, "rg-plan", "mkt-vm",
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Plan:     wantPlan,
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardF2),
+				},
+				StorageProfile: &armcompute.StorageProfile{
+					ImageReference: &armcompute.ImageReference{
+						Publisher: to.Ptr("cloudvendor"),
+						Offer:     to.Ptr("vm-image"),
+						SKU:       to.Ptr("cloud-instance"),
+						Version:   to.Ptr("latest"),
+					},
+					OSDisk: &armcompute.OSDisk{
+						Name:         to.Ptr("mkt-vm_osdisk"),
+						CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesFromImage),
+						OSType:       to.Ptr(armcompute.OperatingSystemTypesLinux),
+						ManagedDisk: &armcompute.ManagedDiskParameters{
+							StorageAccountType: to.Ptr(armcompute.StorageAccountTypesStandardLRS),
+						},
+					},
+				},
+				OSProfile: &armcompute.OSProfile{
+					ComputerName:  to.Ptr("mkt-vm"),
+					AdminUsername: to.Ptr("azureuser"),
+					LinuxConfiguration: &armcompute.LinuxConfiguration{
+						DisablePasswordAuthentication: to.Ptr(false),
+					},
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := pollUntilDone(ctx, poller)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate poll: %v", err)
+	}
+
+	assertPlan(t, "create", created.Plan, wantPlan)
+
+	createdVMID := ""
+	if created.Properties != nil && created.Properties.VMID != nil {
+		createdVMID = *created.Properties.VMID
+	}
+
+	if createdVMID == "" {
+		t.Fatal("create: properties.vmId is empty, want a stable GUID")
+	}
+
+	got, err := client.Get(ctx, "rg-plan", "mkt-vm", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	assertPlan(t, "get", got.Plan, wantPlan)
+
+	// vmId must be a stable GUID: a value that changes per GET makes Terraform's
+	// computed virtual_machine_id drift on every plan.
+	if got.Properties == nil || got.Properties.VMID == nil || *got.Properties.VMID != createdVMID {
+		t.Errorf("get vmId=%v, want stable %q", got.Properties.VMID, createdVMID)
+	}
+
+	assertGetRoundTrip(t, got.VirtualMachine)
+}
+
+// assertGetRoundTrip checks the storageProfile / osProfile fields that
+// Terraform reads back and drifts on when the emulator drops them: the OS
+// disk's managedDisk.storageAccountType, the imageReference, and the explicit
+// linuxConfiguration.disablePasswordAuthentication=false (a zero scalar the
+// overlay must still preserve because the whole osProfile is unmodeled).
+func assertGetRoundTrip(t *testing.T, vm armcompute.VirtualMachine) {
+	t.Helper()
+
+	sp := vm.Properties.StorageProfile
+	if sp == nil || sp.OSDisk == nil || sp.OSDisk.ManagedDisk == nil ||
+		sp.OSDisk.ManagedDisk.StorageAccountType == nil ||
+		*sp.OSDisk.ManagedDisk.StorageAccountType != armcompute.StorageAccountTypesStandardLRS {
+		t.Errorf("get osDisk.managedDisk.storageAccountType did not round-trip: %+v", sp)
+	}
+
+	if sp == nil || sp.ImageReference == nil || sp.ImageReference.SKU == nil ||
+		*sp.ImageReference.SKU != "cloud-instance" {
+		t.Errorf("get storageProfile.imageReference did not round-trip: %+v", sp)
+	}
+
+	op := vm.Properties.OSProfile
+	if op == nil || op.LinuxConfiguration == nil ||
+		op.LinuxConfiguration.DisablePasswordAuthentication == nil ||
+		*op.LinuxConfiguration.DisablePasswordAuthentication != false {
+		t.Errorf("get osProfile.linuxConfiguration.disablePasswordAuthentication=false did not round-trip: %+v", op)
+	}
+}
+
+func assertPlan(t *testing.T, stage string, got, want *armcompute.Plan) {
+	t.Helper()
+
+	if got == nil {
+		t.Fatalf("%s: plan is nil, want %+v", stage, want)
+	}
+
+	if derefStr(got.Name) != derefStr(want.Name) ||
+		derefStr(got.Publisher) != derefStr(want.Publisher) ||
+		derefStr(got.Product) != derefStr(want.Product) {
+		t.Errorf("%s: plan=%+v, want name=%s publisher=%s product=%s",
+			stage, got, derefStr(want.Name), derefStr(want.Publisher), derefStr(want.Product))
+	}
+}

--- a/server/azure/virtualmachines/types.go
+++ b/server/azure/virtualmachines/types.go
@@ -15,8 +15,24 @@ type vmRequest struct {
 	// resource root (armcompute.VirtualMachine.Identity). Omitted (nil) means
 	// the request did not touch identity; real Azure then preserves whatever
 	// identity is already attached rather than clearing it.
-	Identity   *identity      `json:"identity,omitempty"`
+	Identity *identity `json:"identity,omitempty"`
+	// Plan is the marketplace purchase plan block, a top-level sibling of
+	// properties (armcompute.VirtualMachine.Plan). It is required for VMs from a
+	// third-party (paid/BYOL) marketplace image and immutable after create. The
+	// property overlay cannot reach top-level fields, so the handler models it
+	// explicitly (as it does zones/identity) to round-trip it on GET.
+	Plan       *plan          `json:"plan,omitempty"`
 	Properties vmRequestProps `json:"properties"`
+}
+
+// plan is the ARM VirtualMachine.plan block (armcompute.Plan): the marketplace
+// image's purchase plan — its offer name, publisher, product, and optional
+// promotion code.
+type plan struct {
+	Name          string `json:"name,omitempty"`
+	Publisher     string `json:"publisher,omitempty"`
+	Product       string `json:"product,omitempty"`
+	PromotionCode string `json:"promotionCode,omitempty"`
 }
 
 // identity is the ARM managed-service-identity envelope
@@ -158,7 +174,10 @@ type vmResponse struct {
 	Zones    []string          `json:"zones,omitempty"`
 	// Identity echoes the managed-identity block attached to the VM, nil when
 	// none is attached.
-	Identity   *identity       `json:"identity,omitempty"`
+	Identity *identity `json:"identity,omitempty"`
+	// Plan echoes the marketplace purchase plan the VM was created from, nil
+	// for a VM from a first-party image.
+	Plan       *plan           `json:"plan,omitempty"`
 	Properties vmResponseProps `json:"properties"`
 }
 

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -48,6 +48,11 @@ type InstanceConfig struct {
 	// meaningful on input — PrincipalID/TenantID/ClientID are provider-
 	// synthesized output, ignored here. Ignored by AWS/GCP.
 	Identity *ManagedIdentity
+	// Plan is the ARM marketplace purchase plan to record on the VM at launch
+	// (Azure VirtualMachine.plan), when the image is a third-party marketplace
+	// offering. Carried through to the Instance so GET/List echo it. Immutable
+	// after create. Ignored by AWS/GCP.
+	Plan *MarketplacePlan
 	// NetworkInterfaces are the NICs referenced by the VM's
 	// networkProfile.networkInterfaces (Azure), resolved from each entry's ARM
 	// resource id down to the (resourceGroup, name) pair the networking mock
@@ -191,6 +196,22 @@ type Instance struct {
 	// Identity is the resolved managed-identity block (Azure), nil when no
 	// identity is attached (identity.type "None" or unset).
 	Identity *ManagedIdentity
+	// Plan is the marketplace purchase plan the VM was created from (Azure
+	// VirtualMachine.plan), nil for a VM from a first-party image and for
+	// AWS/GCP.
+	Plan *MarketplacePlan
+}
+
+// MarketplacePlan is the ARM VirtualMachine.plan block: the marketplace
+// purchase plan for a third-party (BYOL / paid marketplace) image. It is a
+// top-level sibling of properties on the VM resource, immutable after create.
+// Azure-only; nil for AWS/GCP and for VMs launched from first-party (Azure)
+// images.
+type MarketplacePlan struct {
+	Name          string
+	Publisher     string
+	Product       string
+	PromotionCode string
 }
 
 // MetadataOptions is an instance's IMDS (instance metadata service)
@@ -778,8 +799,10 @@ type AzureVMController interface {
 type AzureVMPatch struct {
 	// VMSize, when non-empty, resizes the VM (hardwareProfile.vmSize).
 	VMSize string
-	// Tags, when non-nil, are merged into the existing tags (a PATCH adds or
-	// overwrites the supplied keys and leaves omitted keys in place).
+	// Tags, when non-nil, REPLACE the existing tags wholesale — real Azure's VM
+	// PATCH tags is a full replace, not a merge, despite PATCH otherwise reading
+	// as a merge-patch (a well-documented Azure Compute quirk). A nil map leaves
+	// the existing tags untouched.
 	Tags map[string]string
 	// Identity, when non-nil, replaces the managed identity block.
 	Identity *ManagedIdentity


### PR DESCRIPTION
## Summary

Real-user e2e audit of Azure Virtual Machines (`Microsoft.Compute/virtualMachines`) via the standalone `serve` HTTPS endpoint with real ARM JSON clients. The VM control-plane round-trip is otherwise solid (a property overlay replays every dropped `properties.*` field), but one **top-level** field slipped through.

### Bug: top-level `plan` block dropped

The Azure property overlay only reaches `properties.*`. The VM's `plan` block (the marketplace purchase plan) is a **top-level** sibling of `properties`, so the handler modeled neither request nor response and the overlay could not recover it. A marketplace-image VM created with `plan {}` came back with `plan: null` on both the create response and every GET/List — so `azurerm_linux_virtual_machine` / `azurerm_windows_virtual_machine` (where `plan` is `ForceNew`) reads back an empty plan and drifts/replaces on every apply.

**Fix:** model `plan` explicitly, exactly as the already-modeled top-level `zones`/`identity` blocks are — carry it through `InstanceConfig` → `Instance` and echo it on the response. `plan` is immutable in Azure, so an omitting PATCH or idempotent re-PUT preserves the recorded value.

Confirmed against the official [Virtual Machines - Create Or Update](https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/create-or-update) REST reference: `plan` is a top-level property with `name`/`publisher`/`product`/`promotionCode`.

### Doc correction

`AzureVMPatch.Tags` claimed a VM PATCH *merges* tags; the implementation (and real Azure) *replace* the tag set wholesale. Corrected the comment to match — behavior was already correct.

## Live evidence (serve on :17680, raw ARM)

Before: `PUT`/`GET` a VM with a `plan` block → `plan = null` on both.
After: `plan = {name, publisher, product}` round-trips on create response and GET; persists across a `PATCH` (resize + tags); a first-party-image VM correctly omits `plan`; `vmId` stable across create/GET/PATCH.

(`terraform` with the `azurerm` provider cannot be pointed at a custom endpoint without an AAD/metadata shim — a known azurerm limitation unrelated to this fix — so the durable regression guard uses the `armcompute` SDK, matching the existing `sdk_roundtrip_test.go`.)

## Tests / gates

- New `TestSDKVMPlanRoundTrip` (armcompute SDK): asserts plan round-trips on create + GET, `vmId` is a stable GUID, and `osDisk.managedDisk.storageAccountType` / `imageReference` / explicit `disablePasswordAuthentication=false` all round-trip.
- `go build ./...`, `go vet`, `gofmt` clean; `go test -race` on the VM packages; full `server/azure`, `providers/azure`, `persist`, `services/compute` suites; root integration test — all green.
- `golangci-lint`: 0 issues on changed packages.
- `go generate` (coverage docs): no diff.
