### PR TITLE
fix(elasticache): real-user e2e divergences from AWS ElastiCache

### DIFF
--- a/server/aws/elasticache/handler.go
+++ b/server/aws/elasticache/handler.go
@@ -60,6 +60,8 @@ var elastiCacheActions = map[string]struct{}{ //nolint:gochecknoglobals // stati
 	"CreateReplicationGroup":       {},
 	"DescribeReplicationGroups":    {},
 	"ModifyReplicationGroup":       {},
+	"IncreaseReplicaCount":         {},
+	"DecreaseReplicaCount":         {},
 	"DeleteReplicationGroup":       {},
 	"CreateSnapshot":               {},
 	"DescribeSnapshots":            {},
@@ -172,6 +174,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.describeReplicationGroups(w, r)
 	case "ModifyReplicationGroup":
 		h.modifyReplicationGroup(w, r)
+	case "IncreaseReplicaCount":
+		h.increaseReplicaCount(w, r)
+	case "DecreaseReplicaCount":
+		h.decreaseReplicaCount(w, r)
 	case "DeleteReplicationGroup":
 		h.deleteReplicationGroup(w, r)
 	case "DeleteCacheCluster":

--- a/server/aws/elasticache/replication_group.go
+++ b/server/aws/elasticache/replication_group.go
@@ -65,6 +65,20 @@ type deleteReplicationGroupResponse struct {
 	Metadata responseMetadata       `xml:"ResponseMetadata"`
 }
 
+type increaseReplicaCountResponse struct {
+	XMLName  xml.Name               `xml:"IncreaseReplicaCountResponse"`
+	Xmlns    string                 `xml:"xmlns,attr"`
+	Result   replicationGroupResult `xml:"IncreaseReplicaCountResult"`
+	Metadata responseMetadata       `xml:"ResponseMetadata"`
+}
+
+type decreaseReplicaCountResponse struct {
+	XMLName  xml.Name               `xml:"DecreaseReplicaCountResponse"`
+	Xmlns    string                 `xml:"xmlns,attr"`
+	Result   replicationGroupResult `xml:"DecreaseReplicaCountResult"`
+	Metadata responseMetadata       `xml:"ResponseMetadata"`
+}
+
 type replicationGroupsList struct {
 	ReplicationGroups []replicationGroupXML `xml:"ReplicationGroups>ReplicationGroup"`
 }
@@ -173,6 +187,70 @@ func (h *Handler) modifyReplicationGroup(w http.ResponseWriter, r *http.Request)
 	awsquery.WriteXMLResponse(w, modifyReplicationGroupResponse{
 		Xmlns:    Namespace,
 		Result:   replicationGroupResult{ReplicationGroup: toReplicationGroupXML(rg)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// applyReplicaCount is the shared core of Increase/DecreaseReplicaCount. Both
+// carry NewReplicaCount — the desired number of read replicas per node group.
+// The emulator models a single (cluster-mode-disabled) node group, so the total
+// member-cluster count is the primary plus NewReplicaCount. This is the path the
+// Terraform AWS provider uses to scale a replication group's num_cache_clusters
+// (it calls Increase/DecreaseReplicaCount, not ModifyReplicationGroup). When
+// NewReplicaCount is absent (the cluster-mode ReplicaConfiguration path, out of
+// scope), the member count is left unchanged.
+func (h *Handler) applyReplicaCount(w http.ResponseWriter, r *http.Request) (replicationGroupXML, bool) {
+	store, ok := h.replicationGroups()
+	if !ok {
+		writeUnsupported(w, "replication groups")
+		return replicationGroupXML{}, false
+	}
+
+	// 0 means "leave the member count unchanged" for the driver.
+	total := 0
+
+	if raw := r.Form.Get("NewReplicaCount"); raw != "" {
+		replicas, err := parseNodeCount("NewReplicaCount", raw)
+		if err != nil {
+			writeErr(w, err)
+			return replicationGroupXML{}, false
+		}
+
+		// Total member clusters = the primary plus the requested replicas.
+		total = replicas + 1
+	}
+
+	rg, err := store.ModifyReplicationGroup(r.Context(), r.Form.Get("ReplicationGroupId"), total)
+	if err != nil {
+		writeErr(w, err)
+		return replicationGroupXML{}, false
+	}
+
+	return toReplicationGroupXML(rg), true
+}
+
+func (h *Handler) increaseReplicaCount(w http.ResponseWriter, r *http.Request) {
+	rg, ok := h.applyReplicaCount(w, r)
+	if !ok {
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, increaseReplicaCountResponse{
+		Xmlns:    Namespace,
+		Result:   replicationGroupResult{ReplicationGroup: rg},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) decreaseReplicaCount(w http.ResponseWriter, r *http.Request) {
+	rg, ok := h.applyReplicaCount(w, r)
+	if !ok {
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, decreaseReplicaCountResponse{
+		Xmlns:    Namespace,
+		Result:   replicationGroupResult{ReplicationGroup: rg},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/elasticache/replicationgroup_sdk_roundtrip_test.go
+++ b/server/aws/elasticache/replicationgroup_sdk_roundtrip_test.go
@@ -290,6 +290,64 @@ func TestModifyReplicationGroup(t *testing.T) {
 	}
 }
 
+// TestReplicaCountScaling covers the Increase/DecreaseReplicaCount path the
+// Terraform AWS provider uses to change a replication group's num_cache_clusters
+// (it does NOT call ModifyReplicationGroup for node-count changes). NewReplicaCount
+// is replicas-per-node-group, so the resulting member count is the primary plus
+// that many replicas.
+func TestReplicaCountScaling(t *testing.T) {
+	ctx := context.Background()
+	c := newReplicationGroupClient(t)
+
+	if _, err := c.CreateReplicationGroup(ctx, &awselasticache.CreateReplicationGroupInput{
+		ReplicationGroupId:          aws.String("rc-rg"),
+		ReplicationGroupDescription: aws.String("scale replicas"),
+		CacheNodeType:               aws.String("cache.t3.micro"),
+		Engine:                      aws.String("redis"),
+		NumCacheClusters:            aws.Int32(2),
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Increase to 2 replicas -> 3 members (primary + 2).
+	inc, err := c.IncreaseReplicaCount(ctx, &awselasticache.IncreaseReplicaCountInput{
+		ReplicationGroupId: aws.String("rc-rg"),
+		ApplyImmediately:   aws.Bool(true),
+		NewReplicaCount:    aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("IncreaseReplicaCount: %v", err)
+	}
+
+	if got := len(inc.ReplicationGroup.MemberClusters); got != 3 {
+		t.Fatalf("after increase MemberClusters = %d, want 3", got)
+	}
+
+	// Decrease to 1 replica -> 2 members (primary + 1).
+	dec, err := c.DecreaseReplicaCount(ctx, &awselasticache.DecreaseReplicaCountInput{
+		ReplicationGroupId: aws.String("rc-rg"),
+		ApplyImmediately:   aws.Bool(true),
+		NewReplicaCount:    aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("DecreaseReplicaCount: %v", err)
+	}
+
+	if got := len(dec.ReplicationGroup.MemberClusters); got != 2 {
+		t.Fatalf("after decrease MemberClusters = %d, want 2", got)
+	}
+
+	// A count change on an unknown group must surface ReplicationGroupNotFoundFault.
+	var missing *cachetypes.ReplicationGroupNotFoundFault
+	if _, err := c.IncreaseReplicaCount(ctx, &awselasticache.IncreaseReplicaCountInput{
+		ReplicationGroupId: aws.String("nope"),
+		ApplyImmediately:   aws.Bool(true),
+		NewReplicaCount:    aws.Int32(1),
+	}); !errors.As(err, &missing) {
+		t.Errorf("increase on missing group must surface ReplicationGroupNotFoundFault, got %T: %v", err, err)
+	}
+}
+
 // Same reasoning as RDS: the SDK matches on the error CODE, not the message.
 // A caller checking for ReplicationGroupAlreadyExistsFault would not have
 // matched a generic CacheClusterAlreadyExists.


### PR DESCRIPTION
## Summary

Deep real-user e2e audit of AWS ElastiCache (aws_elasticache_cluster memcached + single-node redis, aws_elasticache_replication_group, subnet group, parameter group) driven through the live `cloudemu serve` wire server with the real `hashicorp/aws` Terraform provider, `aws-cli`, and `aws-sdk-go-v2`.

The ElastiCache surface is already very complete and passed the full create -> describe -> no-drift -> destroy cycle for all four resource types, plus per-engine port/endpoint defaults, ConfigurationEndpoint (memcached), CacheNodes[].Endpoint, ReplicationGroup NodeGroups PrimaryEndpoint/ReaderEndpoint, MemberClusters, AutoMinorVersionUpgrade default, and parameter-group round-trip. One genuine divergence surfaced during the update phase.

## Divergence found and fixed

Terraform's `aws_elasticache_replication_group` scales `num_cache_clusters` by calling **IncreaseReplicaCount / DecreaseReplicaCount**, not ModifyReplicationGroup. Those two actions were not registered on the ElastiCache handler, so any replica-count change failed with `InvalidAction: unknown action: IncreaseReplicaCount` and aborted `terraform apply`.

Fix: register both actions and map them to the existing `ModifyReplicationGroup` driver call. Per the AWS API, `NewReplicaCount` is the desired replicas per node group; for a cluster-mode-disabled group (single node group) the resulting member count is the primary plus that many replicas. When `NewReplicaCount` is absent (the cluster-mode ReplicaConfiguration path, out of scope for the in-memory single-node-group model) the member count is left unchanged.

## Evidence

- RED before: `terraform apply` scaling num_cache_clusters 2 -> 3 failed with InvalidAction on IncreaseReplicaCount.
- GREEN after: full apply -> plan (no drift) -> update (scale nodes + replicas + parameter) -> destroy all clean; MemberClusters correctly went 2 -> 3 -> 2 across increase/decrease.
- Added an SDK-roundtrip regression test (`TestReplicaCountScaling`) covering increase, decrease, and the NotFoundFault path.

## Gates

go build, go vet, gofmt, `go test -race` (server/aws/elasticache + providers/aws/elasticache), root `go test .`, full `go test ./server/aws/...`, golangci-lint `--new-from-rev` (0 new issues), and `go generate` (no docs/coverage change — no driver-interface change) all green.