### PR TITLE
fix(msk): real-user e2e divergences from AWS MSK

### DIFF
--- a/providers/aws/kafka/cluster_updates.go
+++ b/providers/aws/kafka/cluster_updates.go
@@ -105,7 +105,7 @@ func (m *Mock) UpdateClusterConfiguration(
 	_ context.Context, arn, currentVersion string, body json.RawMessage,
 ) (*driver.ClusterOperation, error) {
 	return m.mutateCluster(arn, currentVersion, opTypeUpdateClusterConfig, func(c *driver.Cluster) {
-		setRawOption(c, "configurationInfo", body)
+		setRawOption(c, "configurationInfo", rawField(body, "configurationInfo", body))
 	})
 }
 

--- a/providers/aws/kafka/configurations.go
+++ b/providers/aws/kafka/configurations.go
@@ -35,11 +35,17 @@ func snapshotConfig(c driver.Configuration) driver.Configuration {
 	return out
 }
 
-// getConfig resolves a configuration by ARN, NotFoundException when absent.
+// getConfig resolves a configuration by ARN. A missing configuration is a
+// BadRequestException whose message contains "Configuration ARN does not exist"
+// — that is what real MSK returns for an unknown/deleted configuration ARN
+// (DescribeConfiguration does NOT surface a 404 NotFoundException here), and
+// clients rely on it: Terraform's aws_msk_configuration delete waiter treats a
+// configuration as gone only when it sees that exact BadRequestException, so a
+// 404 would hang/fail the destroy.
 func (m *Mock) getConfig(arn string) (*configData, error) {
 	cd, ok := m.configs.Get(arn)
 	if !ok {
-		return nil, notFound("configuration not found: %s", arn)
+		return nil, badRequest("Configuration ARN does not exist: %s", arn)
 	}
 
 	return cd, nil

--- a/providers/aws/kafka/kafka_test.go
+++ b/providers/aws/kafka/kafka_test.go
@@ -300,9 +300,16 @@ func TestDescribeMissingConfiguration(t *testing.T) {
 
 	_, err := m.DescribeConfiguration(context.Background(), "arn:aws:kafka:us-east-1:123456789012:configuration/nope/x")
 
+	// Real MSK reports a missing configuration ARN as a BadRequestException whose
+	// message contains "Configuration ARN does not exist" (not a 404); Terraform's
+	// delete waiter keys off exactly that.
 	var apiErr *driver.APIError
-	if !errors.As(err, &apiErr) || apiErr.Exception != driver.ExNotFound {
-		t.Fatalf("want NotFoundException, got %v", err)
+	if !errors.As(err, &apiErr) || apiErr.Exception != driver.ExBadRequest {
+		t.Fatalf("want BadRequestException, got %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "Configuration ARN does not exist") {
+		t.Fatalf("want message containing %q, got %v", "Configuration ARN does not exist", err)
 	}
 }
 
@@ -397,7 +404,7 @@ func TestCreateClusterV2Validation(t *testing.T) {
 }
 
 // TestUpdateMutatesRecordsOperation asserts UpdateBrokerCount mutates the
-// cluster, records a COMPLETED operation, bumps the version, and a later
+// cluster, records an UPDATE_COMPLETE operation, bumps the version, and a later
 // Describe reflects the new count.
 func TestUpdateMutatesRecordsOperation(t *testing.T) {
 	m := newMock(t)
@@ -413,7 +420,7 @@ func TestUpdateMutatesRecordsOperation(t *testing.T) {
 		t.Fatalf("UpdateBrokerCount: %v", err)
 	}
 
-	if op.ClusterARN != c.ClusterARN || op.OperationState != "COMPLETED" || op.OperationType != "UPDATE_BROKER_COUNT" {
+	if op.ClusterARN != c.ClusterARN || op.OperationState != "UPDATE_COMPLETE" || op.OperationType != "UPDATE_BROKER_COUNT" {
 		t.Fatalf("unexpected operation: %+v", op)
 	}
 

--- a/providers/aws/kafka/operations.go
+++ b/providers/aws/kafka/operations.go
@@ -8,9 +8,12 @@ import (
 )
 
 // Operation-state constants. The emulator completes every mutation immediately
-// and deterministically, so a recorded operation is always COMPLETED.
+// and deterministically, so a recorded cluster operation is terminal on return.
+// Real MSK reports UPDATE_COMPLETE (not a bare "COMPLETED") for a finished
+// cluster operation, and clients — notably Terraform's aws_msk_cluster update
+// waiter — poll DescribeClusterOperation for exactly that target state.
 const (
-	operationStateCompleted = "COMPLETED"
+	operationStateCompleted = "UPDATE_COMPLETE"
 )
 
 // copyOperation returns a deep copy of an operation record so a reader cannot

--- a/server/aws/kafka/sdk_roundtrip_test.go
+++ b/server/aws/kafka/sdk_roundtrip_test.go
@@ -149,6 +149,129 @@ func TestSDKDescribeClusterEncryptionDefault(t *testing.T) {
 	}
 }
 
+// TestSDKDescribeClusterEnhancedMonitoringDefault proves DescribeCluster always
+// returns EnhancedMonitoring (real MSK reports the DEFAULT level when the field
+// was not set), and a caller-set level round-trips unchanged. Without the
+// default a Terraform aws_msk_cluster reading enhanced_monitoring drifts.
+func TestSDKDescribeClusterEnhancedMonitoringDefault(t *testing.T) {
+	ctx := context.Background()
+	c := newKafkaClient(t)
+
+	// Cluster created without EnhancedMonitoring → describe reports DEFAULT.
+	unset, err := c.CreateCluster(ctx, &awskafka.CreateClusterInput{
+		ClusterName:         aws.String("mon-default"),
+		KafkaVersion:        aws.String("3.6.0"),
+		NumberOfBrokerNodes: aws.Int32(3),
+		BrokerNodeGroupInfo: &kafkatypes.BrokerNodeGroupInfo{
+			ClientSubnets: []string{"subnet-1", "subnet-2", "subnet-3"},
+			InstanceType:  aws.String("kafka.m5.large"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster(unset): %v", err)
+	}
+
+	descUnset, err := c.DescribeCluster(ctx, &awskafka.DescribeClusterInput{ClusterArn: unset.ClusterArn})
+	if err != nil {
+		t.Fatalf("DescribeCluster(unset): %v", err)
+	}
+	if descUnset.ClusterInfo.EnhancedMonitoring != kafkatypes.EnhancedMonitoringDefault {
+		t.Fatalf("EnhancedMonitoring = %q, want DEFAULT", descUnset.ClusterInfo.EnhancedMonitoring)
+	}
+
+	// A caller-set level is preserved, not clobbered by the default.
+	set, err := c.CreateCluster(ctx, &awskafka.CreateClusterInput{
+		ClusterName:         aws.String("mon-perbroker"),
+		KafkaVersion:        aws.String("3.6.0"),
+		NumberOfBrokerNodes: aws.Int32(3),
+		EnhancedMonitoring:  kafkatypes.EnhancedMonitoringPerBroker,
+		BrokerNodeGroupInfo: &kafkatypes.BrokerNodeGroupInfo{
+			ClientSubnets: []string{"subnet-1", "subnet-2", "subnet-3"},
+			InstanceType:  aws.String("kafka.m5.large"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster(set): %v", err)
+	}
+
+	descSet, err := c.DescribeCluster(ctx, &awskafka.DescribeClusterInput{ClusterArn: set.ClusterArn})
+	if err != nil {
+		t.Fatalf("DescribeCluster(set): %v", err)
+	}
+	if descSet.ClusterInfo.EnhancedMonitoring != kafkatypes.EnhancedMonitoringPerBroker {
+		t.Fatalf("EnhancedMonitoring = %q, want PER_BROKER", descSet.ClusterInfo.EnhancedMonitoring)
+	}
+}
+
+// TestSDKClusterConfigurationInfoRoundTrip proves a cluster's applied
+// configuration surfaces on DescribeCluster under
+// CurrentBrokerSoftwareInfo.{ConfigurationArn,ConfigurationRevision} — where the
+// Terraform provider reads configuration_info — and that a cluster created
+// without a configuration reports no ConfigurationArn (so it does not drift).
+func TestSDKClusterConfigurationInfoRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c := newKafkaClient(t)
+
+	cfg, err := c.CreateConfiguration(ctx, &awskafka.CreateConfigurationInput{
+		Name:             aws.String("cluster-cfg"),
+		KafkaVersions:    []string{"3.6.0"},
+		ServerProperties: []byte("auto.create.topics.enable=true"),
+	})
+	if err != nil {
+		t.Fatalf("CreateConfiguration: %v", err)
+	}
+
+	withCfg, err := c.CreateCluster(ctx, &awskafka.CreateClusterInput{
+		ClusterName:         aws.String("cfg-cluster"),
+		KafkaVersion:        aws.String("3.6.0"),
+		NumberOfBrokerNodes: aws.Int32(3),
+		ConfigurationInfo:   &kafkatypes.ConfigurationInfo{Arn: cfg.Arn, Revision: aws.Int64(1)},
+		BrokerNodeGroupInfo: &kafkatypes.BrokerNodeGroupInfo{
+			ClientSubnets: []string{"subnet-1", "subnet-2", "subnet-3"},
+			InstanceType:  aws.String("kafka.m5.large"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster(with cfg): %v", err)
+	}
+
+	desc, err := c.DescribeCluster(ctx, &awskafka.DescribeClusterInput{ClusterArn: withCfg.ClusterArn})
+	if err != nil {
+		t.Fatalf("DescribeCluster(with cfg): %v", err)
+	}
+
+	bsi := desc.ClusterInfo.CurrentBrokerSoftwareInfo
+	if bsi == nil {
+		t.Fatalf("CurrentBrokerSoftwareInfo nil, want the applied config")
+	}
+	if aws.ToString(bsi.ConfigurationArn) != aws.ToString(cfg.Arn) || aws.ToInt64(bsi.ConfigurationRevision) != 1 {
+		t.Fatalf("config info = arn %q rev %d, want %q rev 1",
+			aws.ToString(bsi.ConfigurationArn), aws.ToInt64(bsi.ConfigurationRevision), aws.ToString(cfg.Arn))
+	}
+
+	// A cluster created without a configuration must not report a bogus ARN.
+	noCfg, err := c.CreateCluster(ctx, &awskafka.CreateClusterInput{
+		ClusterName:         aws.String("nocfg-cluster"),
+		KafkaVersion:        aws.String("3.6.0"),
+		NumberOfBrokerNodes: aws.Int32(3),
+		BrokerNodeGroupInfo: &kafkatypes.BrokerNodeGroupInfo{
+			ClientSubnets: []string{"subnet-1", "subnet-2", "subnet-3"},
+			InstanceType:  aws.String("kafka.m5.large"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster(no cfg): %v", err)
+	}
+
+	descNo, err := c.DescribeCluster(ctx, &awskafka.DescribeClusterInput{ClusterArn: noCfg.ClusterArn})
+	if err != nil {
+		t.Fatalf("DescribeCluster(no cfg): %v", err)
+	}
+	if bsi := descNo.ClusterInfo.CurrentBrokerSoftwareInfo; bsi != nil && aws.ToString(bsi.ConfigurationArn) != "" {
+		t.Fatalf("no-config cluster reports ConfigurationArn %q, want empty", aws.ToString(bsi.ConfigurationArn))
+	}
+}
+
 func TestSDKConfigurationLifecycle(t *testing.T) {
 	ctx := context.Background()
 	c := newKafkaClient(t)

--- a/server/aws/kafka/types.go
+++ b/server/aws/kafka/types.go
@@ -118,17 +118,15 @@ func clusterToWire(c *driver.Cluster) map[string]json.RawMessage {
 		"creationTime":        timeRFC3339(c.CreationTime),
 	}
 
-	if c.KafkaVersion != "" {
-		base["currentBrokerSoftwareInfo"] = map[string]any{"kafkaVersion": c.KafkaVersion}
+	if bsi := currentBrokerSoftwareInfo(c); len(bsi) > 0 {
+		base["currentBrokerSoftwareInfo"] = bsi
 	}
 
 	if c.StorageMode != "" {
 		base["storageMode"] = c.StorageMode
 	}
 
-	if c.EnhancedMonitoring != "" {
-		base["enhancedMonitoring"] = c.EnhancedMonitoring
-	}
+	base["enhancedMonitoring"] = enhancedMonitoringOrDefault(c)
 
 	if c.Tags != nil {
 		base["tags"] = c.Tags
@@ -209,6 +207,58 @@ func defaultEncryptionInfo() map[string]any {
 	}
 }
 
+// enhancedMonitoringOrDefault returns the cluster's EnhancedMonitoring level,
+// falling back to MSK's DEFAULT. Real DescribeCluster always surfaces this enum
+// (never omits it), so a cluster created without one still reports "DEFAULT".
+func enhancedMonitoringOrDefault(c *driver.Cluster) string {
+	if c.EnhancedMonitoring != "" {
+		return c.EnhancedMonitoring
+	}
+
+	return "DEFAULT"
+}
+
+// currentBrokerSoftwareInfo renders the ClusterInfo.CurrentBrokerSoftwareInfo
+// block: the running Kafka version plus, when an MSK configuration is applied to
+// the cluster, its configurationArn/configurationRevision. Terraform's
+// aws_msk_cluster reads its configuration_info block from these fields, so
+// surfacing them here is what keeps a configured cluster drift-free.
+func currentBrokerSoftwareInfo(c *driver.Cluster) map[string]any {
+	info := map[string]any{}
+
+	if c.KafkaVersion != "" {
+		info["kafkaVersion"] = c.KafkaVersion
+	}
+
+	if arn, rev, ok := appliedConfiguration(c.RawOptions); ok {
+		info["configurationArn"] = arn
+		info["configurationRevision"] = rev
+	}
+
+	return info
+}
+
+// appliedConfiguration extracts the arn/revision of the MSK configuration applied
+// to a cluster from its stored configurationInfo raw block (set at create or by
+// UpdateClusterConfiguration), reporting whether one is present.
+func appliedConfiguration(raw map[string]json.RawMessage) (arn string, revision int64, ok bool) {
+	blk, present := raw["configurationInfo"]
+	if !present || len(blk) == 0 {
+		return "", 0, false
+	}
+
+	var ci struct {
+		Arn      string `json:"arn"`
+		Revision int64  `json:"revision"`
+	}
+
+	if err := json.Unmarshal(blk, &ci); err != nil || ci.Arn == "" {
+		return "", 0, false
+	}
+
+	return ci.Arn, ci.Revision, true
+}
+
 // clusterToWireV2 renders a driver cluster as the v2 clusterInfo (types.Cluster)
 // wire shape: a provisioned or serverless block nested under the common
 // top-level fields. A v1-created cluster renders here too (same store).
@@ -241,17 +291,15 @@ func provisionedBlock(c *driver.Cluster) map[string]any {
 		"numberOfBrokerNodes": c.NumberOfBrokerNodes,
 	}
 
-	if c.KafkaVersion != "" {
-		block["currentBrokerSoftwareInfo"] = map[string]any{"kafkaVersion": c.KafkaVersion}
+	if bsi := currentBrokerSoftwareInfo(c); len(bsi) > 0 {
+		block["currentBrokerSoftwareInfo"] = bsi
 	}
 
 	if c.StorageMode != "" {
 		block["storageMode"] = c.StorageMode
 	}
 
-	if c.EnhancedMonitoring != "" {
-		block["enhancedMonitoring"] = c.EnhancedMonitoring
-	}
+	block["enhancedMonitoring"] = enhancedMonitoringOrDefault(c)
 
 	if c.BrokerNodeGroupInfo != nil {
 		block["brokerNodeGroupInfo"] = bngToWire(c.BrokerNodeGroupInfo)


### PR DESCRIPTION
## Summary

Deep real-user e2e audit of AWS MSK (`aws_msk_cluster`, `aws_msk_configuration`) driven by real `hashicorp/aws` Terraform (provider 5.100.0), the `aws kafka` CLI, and `aws-sdk-go-v2/service/kafka` against `cloudemu serve`. The MSK surface is broad and already high-fidelity; this fixes three genuine divergences that broke the Terraform lifecycle plus one Describe-parity gap.

## Fixes

**1. `configuration_info` perpetual drift (create/update).** DescribeCluster stored the applied MSK configuration but never surfaced it under `CurrentBrokerSoftwareInfo.{ConfigurationArn,ConfigurationRevision}` — where the AWS provider reads `configuration_info`. Every `terraform plan` re-added the block. Now surfaced from the stored `configurationInfo`, and `UpdateClusterConfiguration` normalized to store just the nested block (consistent with `UpdateConnectivity`).

**2. Update apply error (`unexpected state 'COMPLETED', wanted 'UPDATE_COMPLETE'`).** Finished cluster operations reported `OperationState = "COMPLETED"`. Real MSK reports `UPDATE_COMPLETE`, which the aws_msk_cluster update waiter polls for. Any in-place update (broker count, storage, configuration) errored. Fixed the terminal state.

**3. Destroy error on configuration delete.** A missing configuration ARN returned a 404 `NotFoundException`. Real MSK returns a 400 `BadRequestException` containing `"Configuration ARN does not exist"`, and the provider's delete waiter treats the configuration as gone only on that exact error — so destroy surfaced the 404 as a hard failure. `getConfig` now returns that BadRequestException.

**4. `EnhancedMonitoring` omitted on Describe.** Real DescribeCluster always surfaces the enum; a cluster created without one now reports `DEFAULT` (v1 and v2 paths).

## Evidence (live, `cloudemu serve` + real Terraform/CLI/SDK)

- create -> `terraform plan`: **No changes** (nested `broker_node_group_info` / `storage_info` / `encryption_info`, `current_version`, `bootstrap_brokers_tls`, `zookeeper_connect_string`, `configuration_info` all stable).
- in-place update (broker count 6->9, volume 100->200, config revision 1->2): applies cleanly, no post-update resource drift.
- `terraform destroy`: both resources destroyed cleanly.
- `describe-cluster` / `describe-cluster-v2`: `CurrentBrokerSoftwareInfo` carries `ConfigurationArn`+`ConfigurationRevision`; `EnhancedMonitoring: DEFAULT`.

## Gates

`go build ./...`, `go test -race ./providers/aws/kafka/... ./server/aws/kafka/...`, root `go test .`, `go vet`, `gofmt -l`, `golangci-lint --new-from-rev` — all green. `go generate ./...` produced no `docs/coverage` diff (driver interfaces unchanged).
