### PR TITLE
fix(gcp-firewall): real-user e2e divergences from Compute Firewall

### DIFF
--- a/server/gcp/vpc/handler.go
+++ b/server/gcp/vpc/handler.go
@@ -920,8 +920,13 @@ func (h *Handler) insertFirewall(w http.ResponseWriter, r *http.Request, rp gcpr
 		req.Direction = defaultFirewallDirection
 	}
 
-	if req.Priority == 0 {
-		req.Priority = defaultFirewallPriority
+	// Priority 0 is a valid GCP value (highest precedence), so distinguish an
+	// omitted priority (nil) from an explicit 0 — only the former defaults to
+	// 1000. Forcing 0→1000 would silently alter rule precedence and drive a
+	// perpetual terraform diff.
+	if req.Priority == nil {
+		p := defaultFirewallPriority
+		req.Priority = &p
 	}
 
 	// Firewalls map onto driver SecurityGroups; the driver requires a VPC ID.
@@ -1105,8 +1110,8 @@ func mergeFirewallScalars(spec *firewallSpec, req *firewallRequest) {
 		spec.Direction = req.Direction
 	}
 
-	if req.Priority != 0 {
-		spec.Priority = req.Priority
+	if req.Priority != nil {
+		spec.Priority = *req.Priority
 	}
 
 	if req.LogConfig != nil {
@@ -1543,7 +1548,7 @@ func marshalFirewallSpec(req *firewallRequest) string {
 func specFromFirewallRequest(req *firewallRequest) firewallSpec {
 	return firewallSpec{
 		Network:               req.Network,
-		Priority:              req.Priority,
+		Priority:              derefInt(req.Priority),
 		Direction:             req.Direction,
 		Allowed:               req.Allowed,
 		Denied:                req.Denied,
@@ -1569,6 +1574,15 @@ func unmarshalFirewallSpec(s string) (firewallSpec, bool) {
 	}
 
 	return spec, true
+}
+
+// derefInt returns the pointed-to int, or 0 when the pointer is nil.
+func derefInt(p *int) int {
+	if p == nil {
+		return 0
+	}
+
+	return *p
 }
 
 func tagOr(m map[string]string, key, fallback string) string {

--- a/server/gcp/vpc/patch_test.go
+++ b/server/gcp/vpc/patch_test.go
@@ -336,3 +336,64 @@ func TestSDKFirewallEgressAdvancedFields(t *testing.T) {
 		t.Errorf("default priority=%d want 1000", mn.GetPriority())
 	}
 }
+
+// TestSDKFirewallExplicitPriorityZero covers the divergence where an explicit
+// priority 0 (a valid GCP value = highest precedence) was forced to the 1000
+// default, silently altering rule precedence and driving a perpetual diff. An
+// explicit 0 must survive both insert and a subsequent patch that omits it.
+func TestSDKFirewallExplicitPriorityZero(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	client := newFwClient(t, ts.URL, ts.Client())
+
+	insertOp, err := client.Insert(ctx, &computepb.InsertFirewallRequest{
+		Project: testProject,
+		FirewallResource: &computepb.Firewall{
+			Name:         ptrStr("fw-prio0"),
+			Priority:     ptrInt32(0),
+			Allowed:      []*computepb.Allowed{{IPProtocol: ptrStr("tcp"), Ports: []string{"22"}}},
+			SourceRanges: []string{"0.0.0.0/0"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetFirewallRequest{Project: testProject, Firewall: "fw-prio0"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetPriority() != 0 {
+		t.Fatalf("explicit priority 0 not preserved: got %d", got.GetPriority())
+	}
+
+	// A patch that omits priority must not resurrect the 1000 default.
+	patchOp, err := client.Patch(ctx, &computepb.PatchFirewallRequest{
+		Project: testProject, Firewall: "fw-prio0",
+		FirewallResource: &computepb.Firewall{
+			Allowed: []*computepb.Allowed{{IPProtocol: ptrStr("tcp"), Ports: []string{"443"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	if err := patchOp.Wait(ctx); err != nil {
+		t.Fatalf("Patch wait: %v", err)
+	}
+
+	got2, err := client.Get(ctx, &computepb.GetFirewallRequest{Project: testProject, Firewall: "fw-prio0"})
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	if got2.GetPriority() != 0 {
+		t.Errorf("priority 0 lost after patch: got %d", got2.GetPriority())
+	}
+}

--- a/server/gcp/vpc/types.go
+++ b/server/gcp/vpc/types.go
@@ -142,7 +142,7 @@ type firewallRequest struct {
 	Name                  string             `json:"name"`
 	Network               string             `json:"network,omitempty"`
 	Description           string             `json:"description,omitempty"`
-	Priority              int                `json:"priority,omitempty"`
+	Priority              *int               `json:"priority,omitempty"`
 	Direction             string             `json:"direction,omitempty"`
 	Allowed               []firewallRule     `json:"allowed,omitempty"`
 	Denied                []firewallRule     `json:"denied,omitempty"`
@@ -173,7 +173,7 @@ type firewallResponse struct {
 	Name                  string             `json:"name"`
 	Network               string             `json:"network,omitempty"`
 	Description           string             `json:"description,omitempty"`
-	Priority              int                `json:"priority,omitempty"`
+	Priority              int                `json:"priority"`
 	Direction             string             `json:"direction,omitempty"`
 	Allowed               []firewallRule     `json:"allowed,omitempty"`
 	Denied                []firewallRule     `json:"denied,omitempty"`


### PR DESCRIPTION
## Summary

Real-user end-to-end audit of GCP Compute Firewall (`google_compute_firewall`) via the live `serve` wire server + real `hashicorp/google` Terraform and the GAPIC `FirewallsRESTClient`. The firewall control plane (global-scoped insert/get/list/patch/delete with global-LRO polling, allowed/denied nested rules, direction/priority defaults, source/destination ranges, tags, service accounts, disabled, logConfig) is mature and Terraform-clean. One genuine divergence was found and fixed.

## Divergence fixed: explicit priority 0 not preserved

GCP firewall `priority` is a valid `0`-`65535` value where **0 is the highest precedence**. The handler treated priority `0` as "unset":

- `insertFirewall` forced `priority == 0` to the `1000` default.
- `mergeFirewallPatch` ignored a patch priority of `0`.
- `firewallResponse.priority` used `omitempty`, dropping a legitimate `0` from the read.

Net effect: a firewall created with `priority = 0` read back as `1000`, silently changing rule precedence and driving a perpetual Terraform diff.

### Fix
- `firewallRequest.Priority` is now `*int`, distinguishing an omitted priority (nil → default 1000) from an explicit `0`.
- Insert defaults only when nil; patch merges when non-nil.
- `firewallResponse.priority` always emitted (real GCP always returns priority).

## Evidence
- **RED (before):** wire insert with `priority:0` read back `priority:1000`.
- **GREEN (after):** wire insert with `priority:0` reads back `priority:0`; Terraform `google_compute_firewall` with `priority = 0` applies and re-plans with **no drift**. Base cases (default 1000, port/tag/disabled/priority updates, EGRESS + denied + destinationRanges + logConfig round-trip) all clean.
- Regression test `TestSDKFirewallExplicitPriorityZero` (insert + omitting-priority patch) added.

## Gates
- `go build ./...`, `go vet`, `gofmt` clean.
- `go test -race ./server/gcp/...` all pass.
- `golangci-lint --new-from-rev=origin/development ./server/gcp/vpc/...`: 0 new issues.
- `go generate ./...`: no `docs/coverage` change (wire-only fix).