### PR TITLE
fix(emr): real-user e2e divergences from AWS EMR

### DIFF
--- a/docs/coverage/README.md
+++ b/docs/coverage/README.md
@@ -49,7 +49,7 @@ code does not implement. Machine-readable: [`coverage.json`](./coverage.json).
 | `ecs` | [ECS](./aws/ecs.md) | — | — | — | 37 |
 | `efs` | [EFS](./aws/efs.md) | — | — | — | 27 |
 | `eks` | [EKS](./aws/eks.md) | — | — | — | 29 |
-| `emr` | [EMR](./aws/emr.md) | — | — | — | 13 |
+| `emr` | [EMR](./aws/emr.md) | — | — | — | 19 |
 | `eventbus` | [EventBridge](./aws/eventbridge.md) | [EventGrid](./azure/eventgrid.md) | [Eventarc](./gcp/eventarc.md) | — | 16 |
 | `eventhub` | — | [Eventhub](./azure/eventhub.md) | — | — | 14 |
 | `gke` | — | — | [GKE](./gcp/gke.md) | — | 18 |

--- a/docs/coverage/aws/README.md
+++ b/docs/coverage/aws/README.md
@@ -25,7 +25,7 @@ Services cloudemu emulates for AWS, by native name. Back to the [cross-provider 
 | [EFS](./efs.md) | `efs` | 27 |
 | [EKS](./eks.md) | — (provider-native) | 29 |
 | [ELB](./elb.md) | `loadbalancer` | 19 |
-| [EMR](./emr.md) | — (provider-native) | 13 |
+| [EMR](./emr.md) | — (provider-native) | 19 |
 | [ElastiCache](./elasticache.md) | `cache` | 17 |
 | [EventBridge](./eventbridge.md) | `eventbus` | 16 |
 | [Glue](./glue.md) | `glue` | 299 |

--- a/docs/coverage/aws/emr.md
+++ b/docs/coverage/aws/emr.md
@@ -3,21 +3,27 @@
 
 provider-native `emr` wire service (AWS-only) · no portable driver · [AWS index](./README.md)
 
-## Operations (13)
+## Operations (19)
 
 | Operation | Description |
 | --- | --- |
 | `AddInstanceGroups` |  |
 | `AddJobFlowSteps` |  |
+| `AddTags` |  |
 | `CancelSteps` |  |
+| `CreateSecurityConfiguration` |  |
+| `DeleteSecurityConfiguration` |  |
 | `DescribeCluster` |  |
+| `DescribeSecurityConfiguration` |  |
 | `DescribeStep` |  |
 | `ListBootstrapActions` |  |
 | `ListClusters` |  |
 | `ListInstanceGroups` |  |
 | `ListInstances` |  |
+| `ListSecurityConfigurations` |  |
 | `ListSteps` |  |
 | `ModifyInstanceGroups` |  |
+| `RemoveTags` |  |
 | `RunJobFlow` |  |
 | `TerminateJobFlows` |  |
 

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -4611,10 +4611,22 @@
         "name": "AddJobFlowSteps"
       },
       {
+        "name": "AddTags"
+      },
+      {
         "name": "CancelSteps"
       },
       {
+        "name": "CreateSecurityConfiguration"
+      },
+      {
+        "name": "DeleteSecurityConfiguration"
+      },
+      {
         "name": "DescribeCluster"
+      },
+      {
+        "name": "DescribeSecurityConfiguration"
       },
       {
         "name": "DescribeStep"
@@ -4632,10 +4644,16 @@
         "name": "ListInstances"
       },
       {
+        "name": "ListSecurityConfigurations"
+      },
+      {
         "name": "ListSteps"
       },
       {
         "name": "ModifyInstanceGroups"
+      },
+      {
+        "name": "RemoveTags"
       },
       {
         "name": "RunJobFlow"

--- a/internal/coveragegen/wireops.go
+++ b/internal/coveragegen/wireops.go
@@ -43,9 +43,11 @@ var nativeWireOperations = map[string][]string{ //nolint:gochecknoglobals // gen
 		"RequestServiceQuotaIncrease",
 	},
 	"aws/emr": {
-		"AddInstanceGroups", "AddJobFlowSteps", "CancelSteps", "DescribeCluster",
-		"DescribeStep", "ListBootstrapActions", "ListClusters", "ListInstanceGroups",
-		"ListInstances", "ListSteps", "ModifyInstanceGroups", "RunJobFlow",
+		"AddInstanceGroups", "AddJobFlowSteps", "AddTags", "CancelSteps",
+		"CreateSecurityConfiguration", "DeleteSecurityConfiguration", "DescribeCluster",
+		"DescribeSecurityConfiguration", "DescribeStep", "ListBootstrapActions",
+		"ListClusters", "ListInstanceGroups", "ListInstances", "ListSecurityConfigurations",
+		"ListSteps", "ModifyInstanceGroups", "RemoveTags", "RunJobFlow",
 		"TerminateJobFlows",
 	},
 	"aws/savingsplans": {

--- a/server/aws/emr/emr_roundtrip_test.go
+++ b/server/aws/emr/emr_roundtrip_test.go
@@ -92,6 +92,61 @@ func runCluster(t *testing.T, c *emr.Client) string {
 	return aws.ToString(out.JobFlowId)
 }
 
+// TestSDKVisibleToAllUsersExplicitFalse guards that an explicit
+// VisibleToAllUsers=false round-trips as false rather than being dropped and
+// defaulting back to true — the classic explicit-zero drift a Terraform
+// aws_emr_cluster with visible_to_all_users=false would otherwise hit.
+func TestSDKVisibleToAllUsersExplicitFalse(t *testing.T) {
+	ctx := context.Background()
+	c := newEMRClient(t)
+
+	out, err := c.RunJobFlow(ctx, &emr.RunJobFlowInput{
+		Name:              aws.String("private-cluster"),
+		ReleaseLabel:      aws.String("emr-6.15.0"),
+		VisibleToAllUsers: aws.Bool(false),
+		Instances: &emrtypes.JobFlowInstancesConfig{
+			InstanceCount:               aws.Int32(1),
+			MasterInstanceType:          aws.String("m5.xlarge"),
+			KeepJobFlowAliveWhenNoSteps: aws.Bool(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunJobFlow: %v", err)
+	}
+
+	desc, err := c.DescribeCluster(ctx, &emr.DescribeClusterInput{ClusterId: out.JobFlowId})
+	if err != nil {
+		t.Fatalf("DescribeCluster: %v", err)
+	}
+
+	if desc.Cluster.VisibleToAllUsers == nil || aws.ToBool(desc.Cluster.VisibleToAllUsers) {
+		t.Fatalf("VisibleToAllUsers = %v, want explicit false", desc.Cluster.VisibleToAllUsers)
+	}
+
+	// A cluster that omits the field defaults to true (real EMR default).
+	def, err := c.RunJobFlow(ctx, &emr.RunJobFlowInput{
+		Name:         aws.String("default-cluster"),
+		ReleaseLabel: aws.String("emr-6.15.0"),
+		Instances: &emrtypes.JobFlowInstancesConfig{
+			InstanceCount:               aws.Int32(1),
+			MasterInstanceType:          aws.String("m5.xlarge"),
+			KeepJobFlowAliveWhenNoSteps: aws.Bool(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunJobFlow(default): %v", err)
+	}
+
+	descDef, err := c.DescribeCluster(ctx, &emr.DescribeClusterInput{ClusterId: def.JobFlowId})
+	if err != nil {
+		t.Fatalf("DescribeCluster(default): %v", err)
+	}
+
+	if !aws.ToBool(descDef.Cluster.VisibleToAllUsers) {
+		t.Fatalf("default VisibleToAllUsers = %v, want true", descDef.Cluster.VisibleToAllUsers)
+	}
+}
+
 func TestSDKRunJobFlowAndDescribeCluster(t *testing.T) {
 	ctx := context.Background()
 	c := newEMRClient(t)

--- a/server/aws/emr/emr_roundtrip_test.go
+++ b/server/aws/emr/emr_roundtrip_test.go
@@ -420,6 +420,206 @@ func TestSDKCancelSteps(t *testing.T) {
 	}
 }
 
+func TestSDKEc2AttributesAndSecurityConfigRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c := newEMRClient(t)
+
+	out, err := c.RunJobFlow(ctx, &emr.RunJobFlowInput{
+		Name:                  aws.String("secured"),
+		ReleaseLabel:          aws.String("emr-6.15.0"),
+		JobFlowRole:           aws.String("EMR_EC2_DefaultRole"),
+		ServiceRole:           aws.String("EMR_DefaultRole"),
+		SecurityConfiguration: aws.String("my-sec-config"),
+		Instances: &emrtypes.JobFlowInstancesConfig{
+			InstanceCount:               aws.Int32(2),
+			MasterInstanceType:          aws.String("m5.xlarge"),
+			Ec2SubnetId:                 aws.String("subnet-abc"),
+			Ec2KeyName:                  aws.String("my-key"),
+			KeepJobFlowAliveWhenNoSteps: aws.Bool(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunJobFlow: %v", err)
+	}
+
+	got, err := c.DescribeCluster(ctx, &emr.DescribeClusterInput{ClusterId: out.JobFlowId})
+	if err != nil {
+		t.Fatalf("DescribeCluster: %v", err)
+	}
+
+	cl := got.Cluster
+
+	// instance_profile round-trip: terraform reads ec2_attributes.instance_profile
+	// from Ec2InstanceAttributes.IamInstanceProfile — a drift source if dropped.
+	if cl.Ec2InstanceAttributes == nil ||
+		aws.ToString(cl.Ec2InstanceAttributes.IamInstanceProfile) != "EMR_EC2_DefaultRole" {
+		t.Fatalf("IamInstanceProfile = %+v, want EMR_EC2_DefaultRole", cl.Ec2InstanceAttributes)
+	}
+
+	if aws.ToString(cl.Ec2InstanceAttributes.Ec2KeyName) != "my-key" {
+		t.Fatalf("Ec2KeyName = %q, want my-key", aws.ToString(cl.Ec2InstanceAttributes.Ec2KeyName))
+	}
+
+	if aws.ToString(cl.SecurityConfiguration) != "my-sec-config" {
+		t.Fatalf("SecurityConfiguration = %q, want my-sec-config", aws.ToString(cl.SecurityConfiguration))
+	}
+
+	if aws.ToString(cl.MasterPublicDnsName) == "" {
+		t.Fatal("MasterPublicDnsName is empty, want the master node DNS")
+	}
+}
+
+func TestSDKSecurityConfigurationLifecycle(t *testing.T) {
+	ctx := context.Background()
+	c := newEMRClient(t)
+
+	const (
+		name = "encryption-at-rest"
+		body = `{"EncryptionConfiguration":{"EnableInTransitEncryption":false,"EnableAtRestEncryption":true}}`
+	)
+
+	created, err := c.CreateSecurityConfiguration(ctx, &emr.CreateSecurityConfigurationInput{
+		Name:                  aws.String(name),
+		SecurityConfiguration: aws.String(body),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecurityConfiguration: %v", err)
+	}
+
+	if aws.ToString(created.Name) != name || created.CreationDateTime == nil {
+		t.Fatalf("create out = %+v, want name/creation set", created)
+	}
+
+	// Duplicate name is rejected.
+	if _, err := c.CreateSecurityConfiguration(ctx, &emr.CreateSecurityConfigurationInput{
+		Name: aws.String(name), SecurityConfiguration: aws.String(body),
+	}); err == nil {
+		t.Fatal("duplicate CreateSecurityConfiguration: want error, got nil")
+	}
+
+	desc, err := c.DescribeSecurityConfiguration(ctx, &emr.DescribeSecurityConfigurationInput{Name: aws.String(name)})
+	if err != nil {
+		t.Fatalf("DescribeSecurityConfiguration: %v", err)
+	}
+
+	if aws.ToString(desc.Name) != name || aws.ToString(desc.SecurityConfiguration) != body {
+		t.Fatalf("describe = %q/%q, want %q/<body>", aws.ToString(desc.Name), aws.ToString(desc.SecurityConfiguration), name)
+	}
+
+	if desc.CreationDateTime == nil {
+		t.Fatal("describe CreationDateTime is nil")
+	}
+
+	list, err := c.ListSecurityConfigurations(ctx, &emr.ListSecurityConfigurationsInput{})
+	if err != nil {
+		t.Fatalf("ListSecurityConfigurations: %v", err)
+	}
+
+	if len(list.SecurityConfigurations) != 1 || aws.ToString(list.SecurityConfigurations[0].Name) != name {
+		t.Fatalf("list = %+v, want one %q", list.SecurityConfigurations, name)
+	}
+
+	if _, err := c.DeleteSecurityConfiguration(ctx,
+		&emr.DeleteSecurityConfigurationInput{Name: aws.String(name)}); err != nil {
+		t.Fatalf("DeleteSecurityConfiguration: %v", err)
+	}
+
+	if _, err := c.DescribeSecurityConfiguration(ctx,
+		&emr.DescribeSecurityConfigurationInput{Name: aws.String(name)}); err == nil {
+		t.Fatal("DescribeSecurityConfiguration after delete: want error, got nil")
+	}
+}
+
+func TestSDKClusterTagsAddRemove(t *testing.T) {
+	ctx := context.Background()
+	c := newEMRClient(t)
+
+	out, err := c.RunJobFlow(ctx, &emr.RunJobFlowInput{
+		Name:         aws.String("tagged"),
+		ReleaseLabel: aws.String("emr-6.15.0"),
+		Instances: &emrtypes.JobFlowInstancesConfig{
+			MasterInstanceType:          aws.String("m5.xlarge"),
+			KeepJobFlowAliveWhenNoSteps: aws.Bool(true),
+		},
+		Tags: []emrtypes.Tag{{Key: aws.String("env"), Value: aws.String("dev")}},
+	})
+	if err != nil {
+		t.Fatalf("RunJobFlow: %v", err)
+	}
+
+	id := aws.ToString(out.JobFlowId)
+
+	// AddTags upserts: new key + updated value on the existing key.
+	if _, err := c.AddTags(ctx, &emr.AddTagsInput{
+		ResourceId: aws.String(id),
+		Tags: []emrtypes.Tag{
+			{Key: aws.String("env"), Value: aws.String("prod")},
+			{Key: aws.String("team"), Value: aws.String("data")},
+		},
+	}); err != nil {
+		t.Fatalf("AddTags: %v", err)
+	}
+
+	got := tagMap(t, c, id)
+	if got["env"] != "prod" || got["team"] != "data" {
+		t.Fatalf("tags after add = %v, want env=prod team=data", got)
+	}
+
+	if _, err := c.RemoveTags(ctx, &emr.RemoveTagsInput{
+		ResourceId: aws.String(id), TagKeys: []string{"team"},
+	}); err != nil {
+		t.Fatalf("RemoveTags: %v", err)
+	}
+
+	got = tagMap(t, c, id)
+	if _, ok := got["team"]; ok || got["env"] != "prod" {
+		t.Fatalf("tags after remove = %v, want only env=prod", got)
+	}
+}
+
+func TestSDKModifyInstanceGroupsTerminatedGuard(t *testing.T) {
+	ctx := context.Background()
+	c := newEMRClient(t)
+	id := runCluster(t, c)
+
+	groups, err := c.ListInstanceGroups(ctx, &emr.ListInstanceGroupsInput{ClusterId: aws.String(id)})
+	if err != nil {
+		t.Fatalf("ListInstanceGroups: %v", err)
+	}
+
+	coreID := aws.ToString(groups.InstanceGroups[0].Id)
+
+	if _, err := c.TerminateJobFlows(ctx, &emr.TerminateJobFlowsInput{JobFlowIds: []string{id}}); err != nil {
+		t.Fatalf("TerminateJobFlows: %v", err)
+	}
+
+	// Resizing a group on a terminated cluster must fail, matching real EMR.
+	_, err = c.ModifyInstanceGroups(ctx, &emr.ModifyInstanceGroupsInput{
+		InstanceGroups: []emrtypes.InstanceGroupModifyConfig{{
+			InstanceGroupId: aws.String(coreID), InstanceCount: aws.Int32(4),
+		}},
+	})
+	if err == nil {
+		t.Fatal("ModifyInstanceGroups on terminated cluster: want error, got nil")
+	}
+}
+
+func tagMap(t *testing.T, c *emr.Client, id string) map[string]string {
+	t.Helper()
+
+	out, err := c.DescribeCluster(context.Background(), &emr.DescribeClusterInput{ClusterId: aws.String(id)})
+	if err != nil {
+		t.Fatalf("DescribeCluster: %v", err)
+	}
+
+	m := map[string]string{}
+	for _, tg := range out.Cluster.Tags {
+		m[aws.ToString(tg.Key)] = aws.ToString(tg.Value)
+	}
+
+	return m
+}
+
 func containsCluster(clusters []emrtypes.ClusterSummary, id string) bool {
 	for i := range clusters {
 		if aws.ToString(clusters[i].Id) == id {

--- a/server/aws/emr/handler.go
+++ b/server/aws/emr/handler.go
@@ -47,6 +47,13 @@ func New(accountID, region string, clock config.Clock) *Handler {
 		"ListInstanceGroups":   h.listInstanceGroups,
 		"ListInstances":        h.listInstances,
 		"ListBootstrapActions": h.listBootstrapActions,
+		"AddTags":              h.addTagsHandler,
+		"RemoveTags":           h.removeTagsHandler,
+
+		"CreateSecurityConfiguration":   h.createSecurityConfiguration,
+		"DescribeSecurityConfiguration": h.describeSecurityConfiguration,
+		"DeleteSecurityConfiguration":   h.deleteSecurityConfiguration,
+		"ListSecurityConfigurations":    h.listSecurityConfigurations,
 	}
 
 	return h

--- a/server/aws/emr/instances.go
+++ b/server/aws/emr/instances.go
@@ -135,6 +135,23 @@ func (s *store) fillInstances(c *cluster, g *instanceGroup, now time.Time) {
 	}
 }
 
+// masterPublicDNS returns the DNS name EMR reports for a cluster's master node,
+// taken from the first instance of the MASTER group. Clusters on a private
+// subnet report the private DNS name; the emulator always runs on private
+// addressing, so it echoes the master instance's private DNS (empty when the
+// cluster has no master instance).
+func masterPublicDNS(c *cluster) string {
+	for _, g := range c.instanceGroups {
+		if g.groupType != "MASTER" || len(g.instances) == 0 {
+			continue
+		}
+
+		return g.instances[0].privateDNS
+	}
+
+	return ""
+}
+
 // countInstances returns the total instance count across a cluster's groups.
 func countInstances(c *cluster) int {
 	total := 0
@@ -200,6 +217,12 @@ func (s *store) modifyInstanceGroups(configs []instanceGroupModifyInput) error {
 				"Instance group id '%s' is not valid.", deref(cfg.InstanceGroupID))
 		}
 
+		c := s.clusterOf(g.id)
+		if c != nil && isTerminal(c.state) {
+			return cerrors.Newf(cerrors.FailedPrecondition,
+				"Instance group '%s' cannot be modified because the cluster is terminated.", g.id)
+		}
+
 		if cfg.InstanceCount == nil {
 			continue
 		}
@@ -207,7 +230,7 @@ func (s *store) modifyInstanceGroups(configs []instanceGroupModifyInput) error {
 		g.requested = *cfg.InstanceCount
 		g.running = *cfg.InstanceCount
 
-		if c := s.clusterOf(g.id); c != nil {
+		if c != nil {
 			s.fillInstances(c, g, now)
 		}
 	}

--- a/server/aws/emr/securityconfig.go
+++ b/server/aws/emr/securityconfig.go
@@ -1,0 +1,194 @@
+package emr
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// securityConfig is a named, JSON-bodied EMR security configuration. It is a
+// standalone control-plane object (not owned by any cluster): CreateSecurityConfiguration
+// stores one, RunJobFlow references it by name via Cluster.SecurityConfiguration.
+type securityConfig struct {
+	name    string
+	config  string
+	created time.Time
+}
+
+// --- wire shapes ---
+
+// createSecurityConfigurationInput mirrors the SDK CreateSecurityConfigurationInput.
+type createSecurityConfigurationInput struct {
+	Name                  *string `json:"Name"`
+	SecurityConfiguration *string `json:"SecurityConfiguration"`
+}
+
+// createSecurityConfigurationOutput mirrors the SDK CreateSecurityConfigurationOutput.
+type createSecurityConfigurationOutput struct {
+	Name             string   `json:"Name"`
+	CreationDateTime *float64 `json:"CreationDateTime"`
+}
+
+// describeSecurityConfigurationInput mirrors the SDK DescribeSecurityConfigurationInput.
+type describeSecurityConfigurationInput struct {
+	Name *string `json:"Name"`
+}
+
+// describeSecurityConfigurationOutput mirrors the SDK DescribeSecurityConfigurationOutput.
+type describeSecurityConfigurationOutput struct {
+	Name                  string   `json:"Name"`
+	SecurityConfiguration string   `json:"SecurityConfiguration"`
+	CreationDateTime      *float64 `json:"CreationDateTime"`
+}
+
+// deleteSecurityConfigurationInput mirrors the SDK DeleteSecurityConfigurationInput.
+type deleteSecurityConfigurationInput struct {
+	Name *string `json:"Name"`
+}
+
+// listSecurityConfigurationsOutput mirrors the SDK ListSecurityConfigurationsOutput.
+type listSecurityConfigurationsOutput struct {
+	SecurityConfigurations []securityConfigurationSummaryWire `json:"SecurityConfigurations"`
+}
+
+// securityConfigurationSummaryWire mirrors the SDK SecurityConfigurationSummary.
+type securityConfigurationSummaryWire struct {
+	Name             string   `json:"Name"`
+	CreationDateTime *float64 `json:"CreationDateTime"`
+}
+
+// --- store methods ---
+
+// createSecurityConfig stores a new security configuration. A duplicate name or
+// missing name/body is rejected with the InvalidRequestException EMR returns.
+func (s *store) createSecurityConfig(name, config string) (time.Time, error) {
+	if name == "" {
+		return time.Time{}, cerrors.New(cerrors.InvalidArgument, "The security configuration name is required.")
+	}
+
+	if config == "" {
+		return time.Time{}, cerrors.New(cerrors.InvalidArgument, "The security configuration is required.")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.secConfig[name]; ok {
+		return time.Time{}, cerrors.Newf(cerrors.InvalidArgument,
+			"Security configuration with name '%s' already exists.", name)
+	}
+
+	now := s.clock.Now().UTC()
+	s.secConfig[name] = &securityConfig{name: name, config: config, created: now}
+	s.secOrder = append(s.secOrder, name)
+
+	return now, nil
+}
+
+// describeSecurityConfig returns a security configuration by name.
+func (s *store) describeSecurityConfig(name string) (*securityConfig, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	sc, ok := s.secConfig[name]
+	if !ok {
+		return nil, secConfigNotFound(name)
+	}
+
+	return sc, nil
+}
+
+// deleteSecurityConfig removes a security configuration by name.
+func (s *store) deleteSecurityConfig(name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.secConfig[name]; !ok {
+		return secConfigNotFound(name)
+	}
+
+	delete(s.secConfig, name)
+
+	for i, n := range s.secOrder {
+		if n == name {
+			s.secOrder = append(s.secOrder[:i], s.secOrder[i+1:]...)
+
+			break
+		}
+	}
+
+	return nil
+}
+
+// listSecurityConfigs returns configuration summaries newest-first.
+func (s *store) listSecurityConfigs() []securityConfigurationSummaryWire {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]securityConfigurationSummaryWire, 0, len(s.secOrder))
+
+	for i := len(s.secOrder) - 1; i >= 0; i-- {
+		sc := s.secConfig[s.secOrder[i]]
+		out = append(out, securityConfigurationSummaryWire{Name: sc.name, CreationDateTime: epoch(sc.created)})
+	}
+
+	return out
+}
+
+// secConfigNotFound builds the InvalidRequestException EMR returns for an
+// unknown security configuration. terraform-provider-aws matches the
+// "does not exist" phrasing to treat a delete of a missing config as a no-op.
+func secConfigNotFound(name string) error {
+	return cerrors.Newf(cerrors.InvalidArgument,
+		"Security configuration with name '%s' does not exist.", name)
+}
+
+// --- handlers ---
+
+// createSecurityConfiguration handles CreateSecurityConfiguration.
+func (h *Handler) createSecurityConfiguration(w http.ResponseWriter, r *http.Request) {
+	dispatch(h, w, r, func(h *Handler, _ context.Context, in *createSecurityConfigurationInput) (any, error) {
+		created, err := h.store.createSecurityConfig(deref(in.Name), deref(in.SecurityConfiguration))
+		if err != nil {
+			return nil, err
+		}
+
+		return createSecurityConfigurationOutput{Name: deref(in.Name), CreationDateTime: epoch(created)}, nil
+	})
+}
+
+// describeSecurityConfiguration handles DescribeSecurityConfiguration.
+func (h *Handler) describeSecurityConfiguration(w http.ResponseWriter, r *http.Request) {
+	dispatch(h, w, r, func(h *Handler, _ context.Context, in *describeSecurityConfigurationInput) (any, error) {
+		sc, err := h.store.describeSecurityConfig(deref(in.Name))
+		if err != nil {
+			return nil, err
+		}
+
+		return describeSecurityConfigurationOutput{
+			Name:                  sc.name,
+			SecurityConfiguration: sc.config,
+			CreationDateTime:      epoch(sc.created),
+		}, nil
+	})
+}
+
+// deleteSecurityConfiguration handles DeleteSecurityConfiguration.
+func (h *Handler) deleteSecurityConfiguration(w http.ResponseWriter, r *http.Request) {
+	dispatch(h, w, r, func(h *Handler, _ context.Context, in *deleteSecurityConfigurationInput) (any, error) {
+		if err := h.store.deleteSecurityConfig(deref(in.Name)); err != nil {
+			return nil, err
+		}
+
+		return struct{}{}, nil
+	})
+}
+
+// listSecurityConfigurations handles ListSecurityConfigurations.
+func (h *Handler) listSecurityConfigurations(w http.ResponseWriter, r *http.Request) {
+	dispatch(h, w, r, func(h *Handler, _ context.Context, _ *struct{}) (any, error) {
+		return listSecurityConfigurationsOutput{SecurityConfigurations: h.store.listSecurityConfigs()}, nil
+	})
+}

--- a/server/aws/emr/store.go
+++ b/server/aws/emr/store.go
@@ -89,32 +89,34 @@ type step struct {
 // cluster is a JobFlow: the unit RunJobFlow creates and TerminateJobFlows tears
 // down.
 type cluster struct {
-	id                   string
-	name                 string
-	arn                  string
-	releaseLabel         string
-	logURI               string
-	serviceRole          string
-	jobFlowRole          string
-	ec2SubnetID          string
-	ec2KeyName           string
-	masterInstanceType   string
-	instanceCount        int32
-	keepAlive            bool
-	terminationProtected bool
-	visibleToAll         bool
-	autoTerminate        bool
-	state                string
-	stateChangeCode      string
-	stateChangeMessage   string
-	creation             time.Time
-	ready                time.Time
-	end                  *time.Time
-	applications         []application
-	tags                 []tag
-	steps                []*step
-	instanceGroups       []*instanceGroup
-	bootstrapActions     []bootstrapAction
+	id                    string
+	name                  string
+	arn                   string
+	releaseLabel          string
+	logURI                string
+	serviceRole           string
+	jobFlowRole           string
+	securityConfiguration string
+	masterPublicDNS       string
+	ec2SubnetID           string
+	ec2KeyName            string
+	masterInstanceType    string
+	instanceCount         int32
+	keepAlive             bool
+	terminationProtected  bool
+	visibleToAll          bool
+	autoTerminate         bool
+	state                 string
+	stateChangeCode       string
+	stateChangeMessage    string
+	creation              time.Time
+	ready                 time.Time
+	end                   *time.Time
+	applications          []application
+	tags                  []tag
+	steps                 []*step
+	instanceGroups        []*instanceGroup
+	bootstrapActions      []bootstrapAction
 }
 
 // store is the in-memory backing state for the EMR wire handler. EMR clusters
@@ -127,8 +129,10 @@ type store struct {
 	accountID string
 	region    string
 	clusters  map[string]*cluster
-	order     []string                  // cluster ids in creation order (ListClusters returns newest first)
-	groups    map[string]*instanceGroup // instance-group id -> group, for ModifyInstanceGroups lookup
+	order     []string                   // cluster ids in creation order (ListClusters returns newest first)
+	groups    map[string]*instanceGroup  // instance-group id -> group, for ModifyInstanceGroups lookup
+	secConfig map[string]*securityConfig // security-configuration name -> config
+	secOrder  []string                   // security-configuration names in creation order
 	nextID    int64
 }
 
@@ -144,6 +148,7 @@ func newStore(accountID, region string, clock config.Clock) *store {
 		region:    region,
 		clusters:  map[string]*cluster{},
 		groups:    map[string]*instanceGroup{},
+		secConfig: map[string]*securityConfig{},
 	}
 }
 
@@ -170,23 +175,25 @@ func (s *store) runJobFlow(in *runJobFlowInput) *cluster {
 	id := s.newID("j-")
 
 	c := &cluster{
-		id:                 id,
-		name:               deref(in.Name),
-		arn:                idgen.AWSARN("elasticmapreduce", s.region, s.accountID, "cluster/"+id),
-		releaseLabel:       deref(in.ReleaseLabel),
-		logURI:             deref(in.LogURI),
-		serviceRole:        deref(in.ServiceRole),
-		jobFlowRole:        deref(in.JobFlowRole),
-		state:              stateWaiting,
-		stateChangeMessage: "Cluster ready to run steps.",
-		creation:           now,
-		ready:              now,
-		visibleToAll:       derefBool(in.VisibleToAllUsers, true),
+		id:                    id,
+		name:                  deref(in.Name),
+		arn:                   idgen.AWSARN("elasticmapreduce", s.region, s.accountID, "cluster/"+id),
+		releaseLabel:          deref(in.ReleaseLabel),
+		logURI:                deref(in.LogURI),
+		serviceRole:           deref(in.ServiceRole),
+		jobFlowRole:           deref(in.JobFlowRole),
+		securityConfiguration: deref(in.SecurityConfiguration),
+		state:                 stateWaiting,
+		stateChangeMessage:    "Cluster ready to run steps.",
+		creation:              now,
+		ready:                 now,
+		visibleToAll:          derefBool(in.VisibleToAllUsers, true),
 	}
 
 	applyInstances(c, in.Instances)
 	c.autoTerminate = !c.keepAlive
 	s.buildInstanceGroups(c, in.Instances, now)
+	c.masterPublicDNS = masterPublicDNS(c)
 	recordBootstrap(c, in.BootstrapActions)
 
 	for _, a := range in.Applications {

--- a/server/aws/emr/tags.go
+++ b/server/aws/emr/tags.go
@@ -1,0 +1,99 @@
+package emr
+
+import (
+	"context"
+	"net/http"
+)
+
+// addTagsInput mirrors the SDK AddTagsInput.
+type addTagsInput struct {
+	ResourceID *string    `json:"ResourceId"`
+	Tags       []tagInput `json:"Tags"`
+}
+
+// removeTagsInput mirrors the SDK RemoveTagsInput.
+type removeTagsInput struct {
+	ResourceID *string  `json:"ResourceId"`
+	TagKeys    []string `json:"TagKeys"`
+}
+
+// addTags upserts tags on a cluster by key (AddTags). terraform-provider-aws
+// calls this to reconcile tag changes on an existing cluster.
+func (s *store) addTags(clusterID string, tags []tagInput) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	c, ok := s.clusters[clusterID]
+	if !ok {
+		return notFound(clusterID)
+	}
+
+	for _, t := range tags {
+		c.setTag(deref(t.Key), deref(t.Value))
+	}
+
+	return nil
+}
+
+// removeTags deletes tags from a cluster by key (RemoveTags).
+func (s *store) removeTags(clusterID string, keys []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	c, ok := s.clusters[clusterID]
+	if !ok {
+		return notFound(clusterID)
+	}
+
+	for _, k := range keys {
+		c.deleteTag(k)
+	}
+
+	return nil
+}
+
+// setTag upserts a single tag, replacing the value when the key already exists.
+func (c *cluster) setTag(key, value string) {
+	for i := range c.tags {
+		if c.tags[i].key == key {
+			c.tags[i].value = value
+
+			return
+		}
+	}
+
+	c.tags = append(c.tags, tag{key: key, value: value})
+}
+
+// deleteTag removes a tag by key, if present.
+func (c *cluster) deleteTag(key string) {
+	for i := range c.tags {
+		if c.tags[i].key == key {
+			c.tags = append(c.tags[:i], c.tags[i+1:]...)
+
+			return
+		}
+	}
+}
+
+// addTagsHandler handles AddTags.
+func (h *Handler) addTagsHandler(w http.ResponseWriter, r *http.Request) {
+	dispatch(h, w, r, func(h *Handler, _ context.Context, in *addTagsInput) (any, error) {
+		if err := h.store.addTags(deref(in.ResourceID), in.Tags); err != nil {
+			return nil, err
+		}
+
+		return struct{}{}, nil
+	})
+}
+
+// removeTagsHandler handles RemoveTags.
+func (h *Handler) removeTagsHandler(w http.ResponseWriter, r *http.Request) {
+	dispatch(h, w, r, func(h *Handler, _ context.Context, in *removeTagsInput) (any, error) {
+		if err := h.store.removeTags(deref(in.ResourceID), in.TagKeys); err != nil {
+			return nil, err
+		}
+
+		return struct{}{}, nil
+	})
+}

--- a/server/aws/emr/types.go
+++ b/server/aws/emr/types.go
@@ -7,17 +7,18 @@ import "time"
 // runJobFlowInput mirrors the members of the SDK RunJobFlowInput this handler
 // reads.
 type runJobFlowInput struct {
-	Name              *string                      `json:"Name"`
-	ReleaseLabel      *string                      `json:"ReleaseLabel"`
-	LogURI            *string                      `json:"LogUri"`
-	ServiceRole       *string                      `json:"ServiceRole"`
-	JobFlowRole       *string                      `json:"JobFlowRole"`
-	VisibleToAllUsers *bool                        `json:"VisibleToAllUsers"`
-	Instances         *jobFlowInstancesConfig      `json:"Instances"`
-	Applications      []applicationInput           `json:"Applications"`
-	Tags              []tagInput                   `json:"Tags"`
-	Steps             []stepConfig                 `json:"Steps"`
-	BootstrapActions  []bootstrapActionConfigInput `json:"BootstrapActions"`
+	Name                  *string                      `json:"Name"`
+	ReleaseLabel          *string                      `json:"ReleaseLabel"`
+	LogURI                *string                      `json:"LogUri"`
+	ServiceRole           *string                      `json:"ServiceRole"`
+	JobFlowRole           *string                      `json:"JobFlowRole"`
+	SecurityConfiguration *string                      `json:"SecurityConfiguration"`
+	VisibleToAllUsers     *bool                        `json:"VisibleToAllUsers"`
+	Instances             *jobFlowInstancesConfig      `json:"Instances"`
+	Applications          []applicationInput           `json:"Applications"`
+	Tags                  []tagInput                   `json:"Tags"`
+	Steps                 []stepConfig                 `json:"Steps"`
+	BootstrapActions      []bootstrapActionConfigInput `json:"BootstrapActions"`
 }
 
 // jobFlowInstancesConfig mirrors the read members of the SDK
@@ -292,8 +293,9 @@ type statusWire struct {
 
 // ec2AttributesWire mirrors the read members of the SDK Ec2InstanceAttributes.
 type ec2AttributesWire struct {
-	Ec2SubnetID string `json:"Ec2SubnetId,omitempty"`
-	Ec2KeyName  string `json:"Ec2KeyName,omitempty"`
+	Ec2SubnetID        string `json:"Ec2SubnetId,omitempty"`
+	Ec2KeyName         string `json:"Ec2KeyName,omitempty"`
+	IamInstanceProfile string `json:"IamInstanceProfile,omitempty"`
 }
 
 // applicationWire mirrors the SDK Application on the response path.
@@ -317,6 +319,8 @@ type clusterWire struct {
 	ReleaseLabel            string             `json:"ReleaseLabel,omitempty"`
 	LogURI                  string             `json:"LogUri,omitempty"`
 	ServiceRole             string             `json:"ServiceRole,omitempty"`
+	SecurityConfiguration   string             `json:"SecurityConfiguration,omitempty"`
+	MasterPublicDNSName     string             `json:"MasterPublicDnsName,omitempty"`
 	Status                  statusWire         `json:"Status"`
 	Ec2InstanceAttributes   *ec2AttributesWire `json:"Ec2InstanceAttributes,omitempty"`
 	InstanceCollectionType  string             `json:"InstanceCollectionType,omitempty"`
@@ -493,6 +497,8 @@ func toClusterWire(c *cluster) *clusterWire {
 		ReleaseLabel:            c.releaseLabel,
 		LogURI:                  c.logURI,
 		ServiceRole:             c.serviceRole,
+		SecurityConfiguration:   c.securityConfiguration,
+		MasterPublicDNSName:     c.masterPublicDNS,
 		Status:                  toStatusWire(c),
 		InstanceCollectionType:  "INSTANCE_GROUP",
 		AutoTerminate:           c.autoTerminate,
@@ -501,8 +507,12 @@ func toClusterWire(c *cluster) *clusterWire {
 		NormalizedInstanceHours: 0,
 	}
 
-	if c.ec2SubnetID != "" || c.ec2KeyName != "" {
-		out.Ec2InstanceAttributes = &ec2AttributesWire{Ec2SubnetID: c.ec2SubnetID, Ec2KeyName: c.ec2KeyName}
+	if c.ec2SubnetID != "" || c.ec2KeyName != "" || c.jobFlowRole != "" {
+		out.Ec2InstanceAttributes = &ec2AttributesWire{
+			Ec2SubnetID:        c.ec2SubnetID,
+			Ec2KeyName:         c.ec2KeyName,
+			IamInstanceProfile: c.jobFlowRole,
+		}
 	}
 
 	for _, a := range c.applications {


### PR DESCRIPTION
Real-user e2e audit of AWS EMR against Terraform + aws-sdk-go-v2 + aws-cli.

## Fixes
- **Security configurations** — CreateSecurityConfiguration/DescribeSecurityConfiguration/DeleteSecurityConfiguration/ListSecurityConfigurations were unhandled; `aws_emr_security_configuration` now round-trips (name, JSON, creation time).
- **DescribeCluster fields** — populate `MasterPublicDnsName` and surface `VisibleToAllUsers` (`*bool`) + `SecurityConfiguration`, which the provider reads back.
- **Cluster tags** — TagResource/UntagResource add and remove tags correctly.
- **ModifyInstanceGroups terminated-cluster guard** — reject a resize against a terminated cluster (previously unguarded).

## Tests
TestSDKEc2AttributesAndSecurityConfigRoundTrip, TestSDKSecurityConfigurationLifecycle, TestSDKClusterTagsAddRemove, TestSDKModifyInstanceGroupsTerminatedGuard.

## Gates
go build ./...; go test -race ./server/aws/emr/...; root go test .; go vet; gofmt; golangci-lint --new-from-rev 0 issues; go generate (no docs/coverage diff).