### PR TITLE
fix(gcp-vertexai): real-user e2e divergences in Terraform-managed resources

### DIFF
--- a/docs/coverage/README.md
+++ b/docs/coverage/README.md
@@ -118,7 +118,7 @@ code does not implement. Machine-readable: [`coverage.json`](./coverage.json).
 | `tablestorage` | — | [TableStorage](./azure/tablestorage.md) | — | — | 9 |
 | `tags` | — | [Tags](./azure/tags.md) | — | — | 4 |
 | `tenants` | — | [Tenants](./azure/tenants.md) | — | — | 1 |
-| `vertexai` | — | — | [VertexAI](./gcp/vertexai.md) | — | 125 |
+| `vertexai` | — | — | [VertexAI](./gcp/vertexai.md) | — | 127 |
 | `vpclattice` | [VPCLattice](./aws/vpclattice.md) | — | — | — | 73 |
 | `wafv2` | [WAFv2](./aws/wafv2.md) | — | — | — | 39 |
 | `workrequest` | — | — | — | [Workrequest](./oci/workrequest.md) | 4 |

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -14638,6 +14638,12 @@
         "name": "PatchDataset"
       },
       {
+        "name": "PatchEndpoint"
+      },
+      {
+        "name": "PatchFeaturestore"
+      },
+      {
         "name": "PatchModel"
       },
       {

--- a/docs/coverage/gcp/README.md
+++ b/docs/coverage/gcp/README.md
@@ -39,4 +39,4 @@ Services cloudemu emulates for GCP, by native name. Back to the [cross-provider 
 | [Servicenetworking](./servicenetworking.md) | — (provider-native) | 3 |
 | [Spanner](./spanner.md) | `spanner` | 12 |
 | [VPC](./vpc.md) | `networking` | 57 |
-| [VertexAI](./vertexai.md) | `vertexai` | 125 |
+| [VertexAI](./vertexai.md) | `vertexai` | 127 |

--- a/docs/coverage/gcp/vertexai.md
+++ b/docs/coverage/gcp/vertexai.md
@@ -3,7 +3,7 @@
 
 GCP's `vertexai` service · portable interface `driver.VertexAI` · [GCP index](./README.md)
 
-## Operations (125)
+## Operations (127)
 
 | Operation | Description |
 | --- | --- |
@@ -118,6 +118,8 @@ GCP's `vertexai` service · portable interface `driver.VertexAI` · [GCP index](
 | `ListTrainingPipelines` |  |
 | `ListTuningJobs` |  |
 | `PatchDataset` |  |
+| `PatchEndpoint` |  |
+| `PatchFeaturestore` |  |
 | `PatchModel` |  |
 | `PauseSchedule` |  |
 | `Predict` |  |

--- a/providers/gcp/vertexai/clone.go
+++ b/providers/gcp/vertexai/clone.go
@@ -63,6 +63,13 @@ func cloneEndpoint(in *driver.Endpoint) *driver.Endpoint {
 	return &out
 }
 
+func cloneFeaturestore(in *driver.Featurestore) *driver.Featurestore {
+	out := *in
+	out.Labels = copyLabels(in.Labels)
+
+	return &out
+}
+
 func cloneIndexEndpoint(in *driver.IndexEndpoint) *driver.IndexEndpoint {
 	out := *in
 	if in.DeployedIndexes != nil {

--- a/providers/gcp/vertexai/datasets.go
+++ b/providers/gcp/vertexai/datasets.go
@@ -59,16 +59,21 @@ func (m *Mock) ListDatasets(_ context.Context, location string) ([]driver.Datase
 	return out, nil
 }
 
-func (m *Mock) PatchDataset(_ context.Context, name, displayName string) (*driver.Dataset, error) {
+func (m *Mock) PatchDataset(_ context.Context, name string, upd driver.DatasetUpdate) (*driver.Dataset, error) {
 	ds, ok := m.datasets.Get(name)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "dataset %q not found", name)
 	}
 
-	// Copy-then-Set: never mutate the stored pointer in place.
+	// Copy-then-Set: never mutate the stored pointer in place. Only fields the
+	// update mask named are touched.
 	updated := *ds
-	if displayName != "" {
-		updated.DisplayName = displayName
+	if upd.DisplayName != nil {
+		updated.DisplayName = *upd.DisplayName
+	}
+
+	if upd.SetLabels {
+		updated.Labels = copyLabels(upd.Labels)
 	}
 
 	updated.UpdateTime = m.now()

--- a/providers/gcp/vertexai/endpoints.go
+++ b/providers/gcp/vertexai/endpoints.go
@@ -8,22 +8,59 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/vertexai/driver"
 )
 
+//nolint:gocritic // cfg is passed by value to match the by-value Create* convention across the driver.
 func (m *Mock) CreateEndpoint(_ context.Context, cfg driver.EndpointConfig) (*driver.Operation, *driver.Endpoint, error) {
 	now := m.now()
-	name := m.resName(cfg.Location, "endpoints", m.newID())
+	// Endpoints carry a client-chosen numeric id (endpointId query param); the
+	// server assigns one only when the caller omits it. Terraform reads the
+	// resource back at the id it supplied, so honoring endpointId is required.
+	name := m.resName(cfg.Location, "endpoints", orID(cfg.EndpointID, m.newID()))
 	ep := &driver.Endpoint{
 		Name:         name,
 		DisplayName:  cfg.DisplayName,
 		Description:  cfg.Description,
+		Network:      cfg.Network,
 		TrafficSplit: map[string]int{},
 		Labels:       copyLabels(cfg.Labels),
 		CreateTime:   now,
 		UpdateTime:   now,
+		Etag:         m.newEtag(),
 	}
 	m.endpoints.Set(name, ep)
 	m.emitMetric("endpoint/count", 1, map[string]string{"location": orLocation(cfg.Location)})
 
 	return m.doneOp(cfg.Location, name), cloneEndpoint(ep), nil
+}
+
+func (m *Mock) PatchEndpoint(_ context.Context, name string, upd driver.EndpointUpdate) (*driver.Endpoint, error) {
+	ep, ok := m.endpoints.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", name)
+	}
+
+	// Copy-then-Set: only fields the update mask named are touched.
+	updated := cloneEndpoint(ep)
+	if upd.DisplayName != nil {
+		updated.DisplayName = *upd.DisplayName
+	}
+
+	if upd.Description != nil {
+		updated.Description = *upd.Description
+	}
+
+	if upd.Network != nil {
+		updated.Network = *upd.Network
+	}
+
+	if upd.SetLabels {
+		updated.Labels = copyLabels(upd.Labels)
+	}
+
+	updated.UpdateTime = m.now()
+	updated.Etag = m.newEtag()
+	m.endpoints.Set(name, updated)
+
+	return cloneEndpoint(updated), nil
 }
 
 func (m *Mock) GetEndpoint(_ context.Context, name string) (*driver.Endpoint, error) {

--- a/providers/gcp/vertexai/feature_store.go
+++ b/providers/gcp/vertexai/feature_store.go
@@ -211,13 +211,15 @@ func (m *Mock) FetchFeatureValues(_ context.Context, featureView, entityID strin
 // --- Classic Featurestore / EntityType (pre-FeatureGroup) ---
 
 func (m *Mock) CreateFeaturestore(_ context.Context, cfg driver.FeaturestoreConfig) (*driver.Operation, *driver.Featurestore, error) {
+	now := m.now()
 	name := m.resName(cfg.Location, "featurestores", orID(cfg.FeaturestoreID, m.newID()))
-	fs := &driver.Featurestore{Name: name, State: "STABLE", OnlineNodeCount: cfg.OnlineNodeCount, CreateTime: m.now()}
+	fs := &driver.Featurestore{
+		Name: name, State: "STABLE", OnlineNodeCount: cfg.OnlineNodeCount,
+		Labels: copyLabels(cfg.Labels), CreateTime: now, UpdateTime: now, Etag: m.newEtag(),
+	}
 	m.featurestores.Set(name, fs)
 
-	out := *fs
-
-	return m.doneOp(cfg.Location, name), &out, nil
+	return m.doneOp(cfg.Location, name), cloneFeaturestore(fs), nil
 }
 
 func (m *Mock) GetFeaturestore(_ context.Context, name string) (*driver.Featurestore, error) {
@@ -226,9 +228,7 @@ func (m *Mock) GetFeaturestore(_ context.Context, name string) (*driver.Features
 		return nil, errors.Newf(errors.NotFound, "featurestore %q not found", name)
 	}
 
-	out := *fs
-
-	return &out, nil
+	return cloneFeaturestore(fs), nil
 }
 
 func (m *Mock) ListFeaturestores(_ context.Context, location string) ([]driver.Featurestore, error) {
@@ -236,11 +236,39 @@ func (m *Mock) ListFeaturestores(_ context.Context, location string) ([]driver.F
 
 	for _, fs := range m.featurestores.All() {
 		if location == "" || locationOf(fs.Name) == location {
-			out = append(out, *fs)
+			out = append(out, *cloneFeaturestore(fs))
 		}
 	}
 
 	return out, nil
+}
+
+// PatchFeaturestore returns an already-done Operation because, unlike dataset
+// and endpoint updates (which return the resource directly), UpdateFeaturestore
+// is a long-running operation in real Vertex AI and callers poll it.
+func (m *Mock) PatchFeaturestore(
+	_ context.Context, name string, upd driver.FeaturestoreUpdate,
+) (*driver.Operation, *driver.Featurestore, error) {
+	fs, ok := m.featurestores.Get(name)
+	if !ok {
+		return nil, nil, errors.Newf(errors.NotFound, "featurestore %q not found", name)
+	}
+
+	// Copy-then-Set: only fields the update mask named are touched.
+	updated := cloneFeaturestore(fs)
+	if upd.OnlineNodeCount != nil {
+		updated.OnlineNodeCount = *upd.OnlineNodeCount
+	}
+
+	if upd.SetLabels {
+		updated.Labels = copyLabels(upd.Labels)
+	}
+
+	updated.UpdateTime = m.now()
+	updated.Etag = m.newEtag()
+	m.featurestores.Set(name, updated)
+
+	return m.doneOp(locationOf(name), name), cloneFeaturestore(updated), nil
 }
 
 func (m *Mock) DeleteFeaturestore(_ context.Context, name string) (*driver.Operation, error) {

--- a/providers/gcp/vertexai/vertexai.go
+++ b/providers/gcp/vertexai/vertexai.go
@@ -125,6 +125,13 @@ func (*Mock) newID() string {
 	return idgen.GenerateID("")
 }
 
+// newEtag returns a fresh opaque etag. Real Vertex resources return an etag that
+// changes on every mutation; the emulator does not enforce it as a
+// concurrency precondition but surfaces one so computed etag attributes populate.
+func (*Mock) newEtag() string {
+	return idgen.GenerateID("")
+}
+
 // doneOp records and returns an already-complete operation for the given
 // location, carrying the response resource name in its metadata.
 func (m *Mock) doneOp(location, resourceName string) *driver.Operation {

--- a/providers/gcp/vertexai/vertexai_test.go
+++ b/providers/gcp/vertexai/vertexai_test.go
@@ -305,3 +305,97 @@ func TestChildListingPrefixDelimiter(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, f10, 2)
 }
+
+// TestEndpointHonorsClientID guards that a client-supplied endpoint id (the
+// endpointId query param) becomes the resource name, so Terraform can read the
+// endpoint back at the id it chose instead of a server-assigned one.
+func TestEndpointHonorsClientID(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, ep, err := m.CreateEndpoint(ctx, driver.EndpointConfig{
+		Location: "us-central1", EndpointID: "1234567890", DisplayName: "ep",
+		Network: "projects/proj/global/networks/vpc1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "projects/proj/locations/us-central1/endpoints/1234567890", ep.Name)
+	assert.Equal(t, "projects/proj/global/networks/vpc1", ep.Network)
+	assert.NotEmpty(t, ep.Etag)
+
+	got, err := m.GetEndpoint(ctx, ep.Name)
+	require.NoError(t, err)
+	assert.Equal(t, "ep", got.DisplayName)
+}
+
+// TestPatchEndpointMaskSemantics guards that PATCH updates only masked fields
+// and never mutates a prior snapshot in place.
+func TestPatchEndpointMaskSemantics(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, ep, err := m.CreateEndpoint(ctx, driver.EndpointConfig{
+		Location: "us-central1", EndpointID: "42", DisplayName: "orig",
+		Description: "d0", Labels: map[string]string{"env": "dev"},
+	})
+	require.NoError(t, err)
+
+	snap, err := m.GetEndpoint(ctx, ep.Name)
+	require.NoError(t, err)
+
+	newName := "renamed"
+	updated, err := m.PatchEndpoint(ctx, ep.Name, driver.EndpointUpdate{
+		DisplayName: &newName,
+		Labels:      map[string]string{"env": "prod"},
+		SetLabels:   true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", updated.DisplayName)
+	assert.Equal(t, "prod", updated.Labels["env"])
+	assert.Equal(t, "d0", updated.Description, "unmasked description must be preserved")
+
+	assert.Equal(t, "orig", snap.DisplayName, "prior snapshot must be unaffected by PatchEndpoint")
+}
+
+// TestFeaturestoreLabelsAndPatch guards that a featurestore round-trips its
+// labels and that PatchFeaturestore returns a done Operation (real Vertex models
+// UpdateFeaturestore as an LRO) while touching only masked fields.
+func TestFeaturestoreLabelsAndPatch(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, fs, err := m.CreateFeaturestore(ctx, driver.FeaturestoreConfig{
+		Location: "us-central1", FeaturestoreID: "fs1", OnlineNodeCount: 2,
+		Labels: map[string]string{"env": "dev"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "dev", fs.Labels["env"])
+	assert.NotEmpty(t, fs.Etag)
+
+	count := 5
+	op, updated, err := m.PatchFeaturestore(ctx, fs.Name, driver.FeaturestoreUpdate{OnlineNodeCount: &count})
+	require.NoError(t, err)
+	require.NotNil(t, op)
+	assert.True(t, op.Done)
+	assert.Equal(t, 5, updated.OnlineNodeCount)
+	assert.Equal(t, "dev", updated.Labels["env"], "unmasked labels must be preserved")
+}
+
+// TestPatchDatasetLabels guards that a labels-only mask updates labels without
+// clearing the display name.
+func TestPatchDatasetLabels(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, ds, err := m.CreateDataset(ctx, driver.DatasetConfig{
+		Location: "us-central1", DisplayName: "keep", MetadataSchemaURI: "gs://x.yaml",
+	})
+	require.NoError(t, err)
+
+	updated, err := m.PatchDataset(ctx, ds.Name, driver.DatasetUpdate{
+		Labels:    map[string]string{"team": "ml"},
+		SetLabels: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ml", updated.Labels["team"])
+	assert.Equal(t, "keep", updated.DisplayName, "display name must be preserved when only labels are masked")
+}

--- a/server/gcp/vertexai/datasets.go
+++ b/server/gcp/vertexai/datasets.go
@@ -17,6 +17,7 @@ func datasetJSON(d *driver.Dataset) map[string]any {
 	}
 }
 
+//nolint:dupl // REST shim; the method-dispatch shape recurs across collections.
 func (h *Handler) serveDatasets(w http.ResponseWriter, r *http.Request, p *vPath) {
 	if p.name == "" {
 		switch r.Method {
@@ -74,7 +75,6 @@ func (h *Handler) datasetAction(w http.ResponseWriter, r *http.Request, p *vPath
 	writeOp(w, op)
 }
 
-//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
 func (h *Handler) createDataset(w http.ResponseWriter, r *http.Request, location string) {
 	var req struct {
 		DisplayName       string            `json:"displayName"`
@@ -128,14 +128,26 @@ func (h *Handler) listDatasets(w http.ResponseWriter, r *http.Request, location 
 
 func (h *Handler) patchDataset(w http.ResponseWriter, r *http.Request, name string) {
 	var req struct {
-		DisplayName string `json:"displayName"`
+		DisplayName string            `json:"displayName"`
+		Labels      map[string]string `json:"labels"`
 	}
 
 	if !decode(w, r, &req) {
 		return
 	}
 
-	ds, err := h.svc.PatchDataset(r.Context(), name, req.DisplayName)
+	mask := r.URL.Query().Get("updateMask")
+
+	var upd driver.DatasetUpdate
+	if maskWants(mask, "displayName") {
+		upd.DisplayName = &req.DisplayName
+	}
+
+	if maskWants(mask, "labels") {
+		upd.Labels, upd.SetLabels = req.Labels, true
+	}
+
+	ds, err := h.svc.PatchDataset(r.Context(), name, upd)
 	if err != nil {
 		writeCErr(w, err)
 

--- a/server/gcp/vertexai/endpoints.go
+++ b/server/gcp/vertexai/endpoints.go
@@ -42,7 +42,7 @@ func endpointJSON(e *driver.Endpoint) map[string]any {
 		traffic[k] = v
 	}
 
-	return map[string]any{
+	out := map[string]any{
 		"name":           e.Name,
 		"displayName":    e.DisplayName,
 		"description":    e.Description,
@@ -51,7 +51,13 @@ func endpointJSON(e *driver.Endpoint) map[string]any {
 		"labels":         e.Labels,
 		"createTime":     e.CreateTime,
 		"updateTime":     e.UpdateTime,
+		"etag":           e.Etag,
 	}
+	if e.Network != "" {
+		out["network"] = e.Network
+	}
+
+	return out
 }
 
 //nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
@@ -78,6 +84,8 @@ func (h *Handler) serveEndpoints(w http.ResponseWriter, r *http.Request, p *vPat
 	switch r.Method {
 	case http.MethodGet:
 		h.getEndpoint(w, r, p.name)
+	case http.MethodPatch:
+		h.patchEndpoint(w, r, p.name)
 	case http.MethodDelete:
 		h.deleteEndpoint(w, r, p.name)
 	default:
@@ -104,12 +112,12 @@ func (h *Handler) endpointAction(w http.ResponseWriter, r *http.Request, p *vPat
 	}
 }
 
-//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
 func (h *Handler) createEndpoint(w http.ResponseWriter, r *http.Request, location string) {
 	var req struct {
 		DisplayName string            `json:"displayName"`
 		Description string            `json:"description"`
 		Labels      map[string]string `json:"labels"`
+		Network     string            `json:"network"`
 	}
 
 	if !decode(w, r, &req) {
@@ -117,7 +125,8 @@ func (h *Handler) createEndpoint(w http.ResponseWriter, r *http.Request, locatio
 	}
 
 	op, ep, err := h.svc.CreateEndpoint(r.Context(), driver.EndpointConfig{
-		Location: location, DisplayName: req.DisplayName, Description: req.Description, Labels: req.Labels,
+		Location: location, EndpointID: r.URL.Query().Get("endpointId"),
+		DisplayName: req.DisplayName, Description: req.Description, Labels: req.Labels, Network: req.Network,
 	})
 	if err != nil {
 		writeCErr(w, err)
@@ -126,6 +135,47 @@ func (h *Handler) createEndpoint(w http.ResponseWriter, r *http.Request, locatio
 	}
 
 	writeResourceOp(w, op, endpointJSON(ep), "Endpoint")
+}
+
+func (h *Handler) patchEndpoint(w http.ResponseWriter, r *http.Request, name string) {
+	var req struct {
+		DisplayName string            `json:"displayName"`
+		Description string            `json:"description"`
+		Labels      map[string]string `json:"labels"`
+		Network     string            `json:"network"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	mask := r.URL.Query().Get("updateMask")
+
+	var upd driver.EndpointUpdate
+	if maskWants(mask, "displayName") {
+		upd.DisplayName = &req.DisplayName
+	}
+
+	if maskWants(mask, "description") {
+		upd.Description = &req.Description
+	}
+
+	if maskWants(mask, "network") {
+		upd.Network = &req.Network
+	}
+
+	if maskWants(mask, "labels") {
+		upd.Labels, upd.SetLabels = req.Labels, true
+	}
+
+	ep, err := h.svc.PatchEndpoint(r.Context(), name, upd)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, endpointJSON(ep))
 }
 
 func (h *Handler) getEndpoint(w http.ResponseWriter, r *http.Request, name string) {

--- a/server/gcp/vertexai/feature_store.go
+++ b/server/gcp/vertexai/feature_store.go
@@ -12,11 +12,13 @@ func featurestoreJSON(f *driver.Featurestore) map[string]any {
 	return map[string]any{
 		"name": f.Name, "state": f.State,
 		"onlineServingConfig": map[string]any{"fixedNodeCount": f.OnlineNodeCount},
+		"labels":              f.Labels,
 		"createTime":          f.CreateTime,
+		"updateTime":          f.UpdateTime,
+		"etag":                f.Etag,
 	}
 }
 
-//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
 func (h *Handler) serveFeaturestores(w http.ResponseWriter, r *http.Request, p *vPath) {
 	if p.subRes == "entityTypes" {
 		h.serveEntityTypes(w, r, p)
@@ -40,6 +42,8 @@ func (h *Handler) serveFeaturestores(w http.ResponseWriter, r *http.Request, p *
 	switch r.Method {
 	case http.MethodGet:
 		h.getFeaturestore(w, r, p.name)
+	case http.MethodPatch:
+		h.patchFeaturestore(w, r, p.name)
 	case http.MethodDelete:
 		h.deleteFeaturestore(w, r, p.name)
 	default:
@@ -52,6 +56,7 @@ func (h *Handler) createFeaturestore(w http.ResponseWriter, r *http.Request, loc
 		OnlineServingConfig struct {
 			FixedNodeCount int `json:"fixedNodeCount"`
 		} `json:"onlineServingConfig"`
+		Labels map[string]string `json:"labels"`
 	}
 
 	if !decode(w, r, &req) {
@@ -60,8 +65,41 @@ func (h *Handler) createFeaturestore(w http.ResponseWriter, r *http.Request, loc
 
 	op, fs, err := h.svc.CreateFeaturestore(r.Context(), driver.FeaturestoreConfig{
 		Location: location, FeaturestoreID: r.URL.Query().Get("featurestoreId"),
-		OnlineNodeCount: req.OnlineServingConfig.FixedNodeCount,
+		OnlineNodeCount: req.OnlineServingConfig.FixedNodeCount, Labels: req.Labels,
 	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeResourceOp(w, op, featurestoreJSON(fs), "Featurestore")
+}
+
+func (h *Handler) patchFeaturestore(w http.ResponseWriter, r *http.Request, name string) {
+	var req struct {
+		OnlineServingConfig struct {
+			FixedNodeCount int `json:"fixedNodeCount"`
+		} `json:"onlineServingConfig"`
+		Labels map[string]string `json:"labels"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	mask := r.URL.Query().Get("updateMask")
+
+	var upd driver.FeaturestoreUpdate
+	if maskWants(mask, "onlineServingConfig.fixedNodeCount") || maskWants(mask, "onlineServingConfig") {
+		upd.OnlineNodeCount = &req.OnlineServingConfig.FixedNodeCount
+	}
+
+	if maskWants(mask, "labels") {
+		upd.Labels, upd.SetLabels = req.Labels, true
+	}
+
+	op, fs, err := h.svc.PatchFeaturestore(r.Context(), name, upd)
 	if err != nil {
 		writeCErr(w, err)
 

--- a/server/gcp/vertexai/responses.go
+++ b/server/gcp/vertexai/responses.go
@@ -2,10 +2,28 @@ package vertexai
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	"github.com/stackshy/cloudemu/v2/services/vertexai/driver"
 )
+
+// maskWants reports whether a PATCH update mask names field. An empty mask means
+// the caller sent none, in which case GCP treats every field present in the body
+// as intended, so every field is considered wanted.
+func maskWants(mask, field string) bool {
+	if mask == "" {
+		return true
+	}
+
+	for _, f := range strings.Split(mask, ",") {
+		if strings.TrimSpace(f) == field {
+			return true
+		}
+	}
+
+	return false
+}
 
 func writeJSON(w http.ResponseWriter, v any) {
 	gcprest.WriteJSON(w, http.StatusOK, v)

--- a/server/gcp/vertexai/sdk_roundtrip_test.go
+++ b/server/gcp/vertexai/sdk_roundtrip_test.go
@@ -282,6 +282,52 @@ func TestDatasetCreate(t *testing.T) {
 	assert.Len(t, list["datasets"], 1)
 }
 
+// TestEndpointTerraformLifecycle mirrors the Terraform google_vertex_ai_endpoint
+// flow: create with a client-chosen numeric id (endpointId query param), read it
+// back at that id, then PATCH display_name/labels with an update mask.
+func TestEndpointTerraformLifecycle(t *testing.T) {
+	url := newServer(t)
+
+	op := do(t, http.MethodPost, url+base+"/endpoints?endpointId=1234567890",
+		map[string]any{"displayName": "ep", "network": "projects/mock-project/global/networks/vpc1"})
+	resp, _ := op["response"].(map[string]any)
+	require.NotNil(t, resp)
+	assert.Equal(t, "projects/mock-project/locations/us-central1/endpoints/1234567890", resp["name"],
+		"endpoint must be created under the client-chosen id")
+	assert.Equal(t, "projects/mock-project/global/networks/vpc1", resp["network"])
+
+	got := do(t, http.MethodGet, url+base+"/endpoints/1234567890", nil)
+	assert.Equal(t, "ep", got["displayName"])
+
+	patched := do(t, http.MethodPatch, url+base+"/endpoints/1234567890?updateMask=displayName,labels",
+		map[string]any{"displayName": "ep2", "labels": map[string]any{"env": "prod"}})
+	assert.Equal(t, "ep2", patched["displayName"])
+	assert.Equal(t, "projects/mock-project/global/networks/vpc1", patched["network"], "unmasked network preserved")
+}
+
+// TestFeaturestoreTerraformLifecycle mirrors the Terraform
+// google_vertex_ai_featurestore flow: create with labels + a fixed node count,
+// then PATCH the node count. The update must return a done Operation because
+// UpdateFeaturestore is a long-running operation Terraform polls.
+func TestFeaturestoreTerraformLifecycle(t *testing.T) {
+	url := newServer(t)
+
+	op := do(t, http.MethodPost, url+base+"/featurestores?featurestoreId=tf_fs",
+		map[string]any{"labels": map[string]any{"env": "dev"}, "onlineServingConfig": map[string]any{"fixedNodeCount": 2}})
+	resp, _ := op["response"].(map[string]any)
+	require.NotNil(t, resp)
+	labels, _ := resp["labels"].(map[string]any)
+	assert.Equal(t, "dev", labels["env"], "featurestore labels must round-trip")
+
+	patch := do(t, http.MethodPatch, url+base+"/featurestores/tf_fs?updateMask=onlineServingConfig.fixedNodeCount",
+		map[string]any{"onlineServingConfig": map[string]any{"fixedNodeCount": 5}})
+	assert.Equal(t, true, patch["done"], "featurestore update must be a done LRO")
+	pr, _ := patch["response"].(map[string]any)
+	require.NotNil(t, pr)
+	osc, _ := pr["onlineServingConfig"].(map[string]any)
+	assert.EqualValues(t, 5, osc["fixedNodeCount"])
+}
+
 func opName(t *testing.T, op map[string]any) string {
 	t.Helper()
 

--- a/services/vertexai/driver/datasets.go
+++ b/services/vertexai/driver/datasets.go
@@ -20,13 +20,22 @@ type Dataset struct {
 	UpdateTime        string
 }
 
+// DatasetUpdate carries the fields a PATCH names in its update mask. A nil
+// DisplayName (or SetLabels=false) means the field is absent from the mask and
+// must be left untouched, matching GCP's field-mask update semantics.
+type DatasetUpdate struct {
+	DisplayName *string
+	Labels      map[string]string
+	SetLabels   bool
+}
+
 // datasetsAPI covers dataset lifecycle plus import/export (modeled as
 // already-done operations).
 type datasetsAPI interface {
 	CreateDataset(ctx context.Context, cfg DatasetConfig) (*Operation, *Dataset, error)
 	GetDataset(ctx context.Context, name string) (*Dataset, error)
 	ListDatasets(ctx context.Context, location string) ([]Dataset, error)
-	PatchDataset(ctx context.Context, name, displayName string) (*Dataset, error)
+	PatchDataset(ctx context.Context, name string, upd DatasetUpdate) (*Dataset, error)
 	DeleteDataset(ctx context.Context, name string) (*Operation, error)
 	ImportData(ctx context.Context, name, gcsURI string) (*Operation, error)
 	ExportData(ctx context.Context, name, gcsOutputURI string) (*Operation, error)

--- a/services/vertexai/driver/endpoints.go
+++ b/services/vertexai/driver/endpoints.go
@@ -5,9 +5,22 @@ import "context"
 // EndpointConfig describes an endpoint to create.
 type EndpointConfig struct {
 	Location    string
+	EndpointID  string // client-chosen numeric id (endpointId query param); server-assigned when empty
 	DisplayName string
 	Description string
 	Labels      map[string]string
+	Network     string
+}
+
+// EndpointUpdate carries the fields a PATCH names in its update mask. A nil
+// pointer (or SetLabels=false) means the field is absent from the mask and must
+// be left untouched.
+type EndpointUpdate struct {
+	DisplayName *string
+	Description *string
+	Network     *string
+	Labels      map[string]string
+	SetLabels   bool
 }
 
 // DeployedModel is a model deployed to an endpoint.
@@ -26,11 +39,13 @@ type Endpoint struct {
 	Name           string // projects/{p}/locations/{l}/endpoints/{id}
 	DisplayName    string
 	Description    string
+	Network        string
 	DeployedModels []DeployedModel
 	TrafficSplit   map[string]int
 	Labels         map[string]string
 	CreateTime     string
 	UpdateTime     string
+	Etag           string
 }
 
 // PredictRequest is an online prediction request.
@@ -53,6 +68,7 @@ type endpointsAPI interface {
 	CreateEndpoint(ctx context.Context, cfg EndpointConfig) (*Operation, *Endpoint, error)
 	GetEndpoint(ctx context.Context, name string) (*Endpoint, error)
 	ListEndpoints(ctx context.Context, location string) ([]Endpoint, error)
+	PatchEndpoint(ctx context.Context, name string, upd EndpointUpdate) (*Endpoint, error)
 	DeleteEndpoint(ctx context.Context, name string) (*Operation, error)
 
 	DeployModel(ctx context.Context, endpoint string, dm DeployedModel) (*Operation, *Endpoint, error)

--- a/services/vertexai/driver/feature_store.go
+++ b/services/vertexai/driver/feature_store.go
@@ -63,6 +63,16 @@ type FeaturestoreConfig struct {
 	Location        string
 	FeaturestoreID  string
 	OnlineNodeCount int
+	Labels          map[string]string
+}
+
+// FeaturestoreUpdate carries the fields a PATCH names in its update mask. A nil
+// OnlineNodeCount (or SetLabels=false) means the field is absent from the mask
+// and must be left untouched.
+type FeaturestoreUpdate struct {
+	OnlineNodeCount *int
+	Labels          map[string]string
+	SetLabels       bool
 }
 
 // Featurestore is the classic Vertex AI Featurestore — a container of
@@ -71,7 +81,10 @@ type Featurestore struct {
 	Name            string // projects/{p}/locations/{l}/featurestores/{id}
 	State           string
 	OnlineNodeCount int
+	Labels          map[string]string
 	CreateTime      string
+	UpdateTime      string
+	Etag            string
 }
 
 // EntityType groups features within a classic Featurestore.
@@ -88,6 +101,7 @@ type featureStoreAPI interface {
 	CreateFeaturestore(ctx context.Context, cfg FeaturestoreConfig) (*Operation, *Featurestore, error)
 	GetFeaturestore(ctx context.Context, name string) (*Featurestore, error)
 	ListFeaturestores(ctx context.Context, location string) ([]Featurestore, error)
+	PatchFeaturestore(ctx context.Context, name string, upd FeaturestoreUpdate) (*Operation, *Featurestore, error)
 	DeleteFeaturestore(ctx context.Context, name string) (*Operation, error)
 
 	CreateEntityType(ctx context.Context, parent, entityTypeID, description string) (*Operation, *EntityType, error)

--- a/services/vertexai/wrappers_datasets.go
+++ b/services/vertexai/wrappers_datasets.go
@@ -24,9 +24,9 @@ func (v *VertexAI) ListDatasets(ctx context.Context, location string) ([]driver.
 	return cast[[]driver.Dataset](v.do(ctx, "ListDatasets", location, func() (any, error) { return v.drv.ListDatasets(ctx, location) }))
 }
 
-func (v *VertexAI) PatchDataset(ctx context.Context, name, displayName string) (*driver.Dataset, error) {
+func (v *VertexAI) PatchDataset(ctx context.Context, name string, upd driver.DatasetUpdate) (*driver.Dataset, error) {
 	return cast[*driver.Dataset](v.do(ctx, "PatchDataset", name, func() (any, error) {
-		return v.drv.PatchDataset(ctx, name, displayName)
+		return v.drv.PatchDataset(ctx, name, upd)
 	}))
 }
 

--- a/services/vertexai/wrappers_endpoints.go
+++ b/services/vertexai/wrappers_endpoints.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/vertexai/driver"
 )
 
+//nolint:gocritic // cfg is passed by value to match the by-value Create* convention across the driver.
 func (v *VertexAI) CreateEndpoint(ctx context.Context, cfg driver.EndpointConfig) (*driver.Operation, *driver.Endpoint, error) {
 	r, err := cast[opPair[*driver.Endpoint]](v.do(ctx, "CreateEndpoint", cfg, func() (any, error) {
 		op, ep, e := v.drv.CreateEndpoint(ctx, cfg)
@@ -22,6 +23,12 @@ func (v *VertexAI) GetEndpoint(ctx context.Context, name string) (*driver.Endpoi
 
 func (v *VertexAI) ListEndpoints(ctx context.Context, location string) ([]driver.Endpoint, error) {
 	return cast[[]driver.Endpoint](v.do(ctx, "ListEndpoints", location, func() (any, error) { return v.drv.ListEndpoints(ctx, location) }))
+}
+
+func (v *VertexAI) PatchEndpoint(ctx context.Context, name string, upd driver.EndpointUpdate) (*driver.Endpoint, error) {
+	return cast[*driver.Endpoint](v.do(ctx, "PatchEndpoint", name, func() (any, error) {
+		return v.drv.PatchEndpoint(ctx, name, upd)
+	}))
 }
 
 func (v *VertexAI) DeleteEndpoint(ctx context.Context, name string) (*driver.Operation, error) {

--- a/services/vertexai/wrappers_featurestore.go
+++ b/services/vertexai/wrappers_featurestore.go
@@ -30,6 +30,18 @@ func (v *VertexAI) ListFeaturestores(ctx context.Context, location string) ([]dr
 	}))
 }
 
+func (v *VertexAI) PatchFeaturestore(
+	ctx context.Context, name string, upd driver.FeaturestoreUpdate,
+) (*driver.Operation, *driver.Featurestore, error) {
+	r, err := cast[opPair[*driver.Featurestore]](v.do(ctx, "PatchFeaturestore", name, func() (any, error) {
+		op, fs, e := v.drv.PatchFeaturestore(ctx, name, upd)
+
+		return opPair[*driver.Featurestore]{op, fs}, e
+	}))
+
+	return r.op, r.res, err
+}
+
 func (v *VertexAI) DeleteFeaturestore(ctx context.Context, name string) (*driver.Operation, error) {
 	return cast[*driver.Operation](v.do(ctx, "DeleteFeaturestore", name, func() (any, error) {
 		return v.drv.DeleteFeaturestore(ctx, name)


### PR DESCRIPTION
## Summary

Real-user end-to-end audit (Terraform `hashicorp/google` provider pointed at `cloudemu serve` via `vertex_ai_custom_endpoint`) of the `aiplatform.googleapis.com` control-plane resources Terraform manages: `google_vertex_ai_dataset`, `google_vertex_ai_featurestore`, `google_vertex_ai_endpoint`. The Vertex AI surface was already substantially built; this fixes genuine cloud-vs-emulator divergences that broke the Terraform create/update lifecycle.

## Divergences fixed

- **Endpoint ignored the client-chosen `endpointId`.** Endpoints use a client-supplied numeric id (sent as the `endpointId` query param), and Terraform reads the resource back at that id. The emulator generated its own id instead, so the post-create read 404'd → apply failure. Now honored.
- **Endpoint & Featurestore PATCH returned 405.** Both support in-place updates (endpoint `display_name`/`description`/`labels`/`network`; featurestore `fixed_node_count`/`labels`). Added update-mask-aware PATCH handlers so only the fields named in `updateMask` are touched.
- **`UpdateFeaturestore` returned the bare resource instead of an LRO.** Unlike dataset/endpoint updates (which return the resource directly), real Vertex models `UpdateFeaturestore` as a long-running operation that Terraform polls. It now returns an already-done `Operation` (like create/delete), so the update no longer hangs/errors.
- **Featurestore dropped `labels` on create; dataset PATCH ignored `labels`.** Both now round-trip labels.
- **Computed fields:** surface `etag`/`update_time` on featurestore and endpoint, and round-trip endpoint `network`.

## Live evidence

Full Terraform lifecycle against `cloudemu serve` — create -> `plan` (no drift) -> update (`display_name`, `labels`, `fixed_node_count`) -> `plan` (no drift) -> destroy — all green for all three resources.

## Tests

- Provider-level: endpoint honors client id + network/etag; PATCH mask semantics (endpoint, dataset labels); featurestore labels round-trip + PATCH-as-LRO.
- Server-level: Terraform-style endpoint create-with-`endpointId` + PATCH; featurestore create-with-labels + PATCH returns a done LRO.
- Regenerated `docs/coverage` (adds `PatchEndpoint`, `PatchFeaturestore`).

Gates: `go build ./...`, `go test -race` (vertexai provider/server/service pkgs), root `go test .`, persist tests, `go vet`, `gofmt`, `golangci-lint` (0 issues) all green.