### PR TITLE
fix(aws): DeleteSubnet drops the subnet's route-table associations

### DIFF
--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -762,6 +762,14 @@ func (m *Mock) DeleteSubnet(_ context.Context, id string) error {
 		}
 	}
 
+	// EC2 drops a subnet's route-table associations with the subnet; a stale
+	// one would make DeleteRouteTable refuse a table that is really free.
+	for assocID, a := range m.rtAssocs.All() {
+		if a.SubnetID == id && !a.Main {
+			m.rtAssocs.Delete(assocID)
+		}
+	}
+
 	return nil
 }
 

--- a/providers/aws/vpc/vpc_test.go
+++ b/providers/aws/vpc/vpc_test.go
@@ -1579,3 +1579,38 @@ func assertNotEmpty(t *testing.T, s string) {
 		t.Error("expected non-empty string")
 	}
 }
+
+// Real EC2 drops a subnet's route-table associations with the subnet, so the
+// standard teardown (delete subnets, then their route tables) must succeed.
+func TestDeleteSubnet_CascadesRouteTableAssociations(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+	s, _ := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+	rt, _ := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: v.ID})
+	assoc, err := m.AssociateRouteTable(ctx, rt.ID, s.ID)
+	requireNoError(t, err)
+
+	requireNoError(t, m.DeleteSubnet(ctx, s.ID))
+
+	t.Run("association is gone", func(t *testing.T) {
+		assertError(t, m.DisassociateRouteTable(ctx, assoc.ID), true)
+	})
+
+	t.Run("route table can now be deleted", func(t *testing.T) {
+		requireNoError(t, m.DeleteRouteTable(ctx, rt.ID))
+	})
+
+	t.Run("other subnets' associations survive", func(t *testing.T) {
+		s2, _ := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.2.0/24"})
+		s3, _ := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.3.0/24"})
+		rt2, _ := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: v.ID})
+		_, _ = m.AssociateRouteTable(ctx, rt2.ID, s2.ID)
+		keep, _ := m.AssociateRouteTable(ctx, rt2.ID, s3.ID)
+
+		requireNoError(t, m.DeleteSubnet(ctx, s2.ID))
+		// s3 is still associated, so the table must still refuse to go.
+		assertError(t, m.DeleteRouteTable(ctx, rt2.ID), true)
+		requireNoError(t, m.DisassociateRouteTable(ctx, keep.ID))
+	})
+}

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -276,6 +276,13 @@ func (m *Mock) DeleteSubnet(_ context.Context, id string) error {
 		return cerrors.Newf(cerrors.NotFound, "subnet %q not found", id)
 	}
 
+	// A route-table association belongs to the subnet and must not outlive it.
+	for assocID, a := range m.rtAssocs.All() {
+		if a.SubnetID == id {
+			m.rtAssocs.Delete(assocID)
+		}
+	}
+
 	return nil
 }
 

--- a/providers/azure/vnet/vnet_test.go
+++ b/providers/azure/vnet/vnet_test.go
@@ -1434,3 +1434,21 @@ func TestDeleteVPCCascadesSubnets(t *testing.T) {
 
 	require.Error(t, m.DeleteVPC(ctx, "vnet-missing"))
 }
+
+// A route-table association is a property of the subnet in Azure, so it must
+// not outlive the subnet.
+func TestDeleteSubnet_CascadesRouteTableAssociations(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	vpcID := createTestVPC(t, m)
+
+	s, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpcID, CIDRBlock: "10.0.1.0/24"})
+	require.NoError(t, err)
+	rt, err := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: vpcID})
+	require.NoError(t, err)
+	assoc, err := m.AssociateRouteTable(ctx, rt.ID, s.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, m.DeleteSubnet(ctx, s.ID))
+	require.Error(t, m.DisassociateRouteTable(ctx, assoc.ID), "association must die with the subnet")
+}

--- a/providers/gcp/vpc/vpc.go
+++ b/providers/gcp/vpc/vpc.go
@@ -196,6 +196,13 @@ func (m *Mock) DeleteSubnet(_ context.Context, id string) error {
 		return cerrors.Newf(cerrors.NotFound, "subnet %q not found", id)
 	}
 
+	// A route-table association belongs to the subnet and must not outlive it.
+	for assocID, a := range m.rtAssocs.All() {
+		if a.SubnetID == id {
+			m.rtAssocs.Delete(assocID)
+		}
+	}
+
 	return nil
 }
 

--- a/providers/gcp/vpc/vpc_test.go
+++ b/providers/gcp/vpc/vpc_test.go
@@ -1566,3 +1566,22 @@ func TestDeleteVPCInUseByChild(t *testing.T) {
 		require.NoError(t, m.DeleteVPC(ctx, vpc.ID))
 	})
 }
+
+// Portable-API parity with AWS/Azure: a route-table association must not
+// outlive its subnet.
+func TestDeleteSubnet_CascadesRouteTableAssociations(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	s, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpc.ID, CIDRBlock: "10.0.1.0/24"})
+	require.NoError(t, err)
+	rt, err := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: vpc.ID})
+	require.NoError(t, err)
+	assoc, err := m.AssociateRouteTable(ctx, rt.ID, s.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, m.DeleteSubnet(ctx, s.ID))
+	require.Error(t, m.DisassociateRouteTable(ctx, assoc.ID), "association must die with the subnet")
+}


### PR DESCRIPTION
Fixes #1261.

## What was wrong

EC2 removes a subnet's route-table associations when the subnet is deleted — the association has no existence apart from the subnet. The AWS mock kept the `rtAssocs` row, so the standard teardown order (delete subnets, then the route tables that served them) hit `DeleteRouteTable`'s dependency guard on a table that was actually free:

```
DependencyViolation: route table "rtb-0000009a" has a subnet association "rtbassoc-0000009d" and cannot be deleted
```

The same function already cascaded network ACL associations, so this was an oversight in the cascade, not a design choice. Found while running a full EKS provision-and-teardown lifecycle from a real provisioner against cloudemu: every other resource tore down cleanly, the route tables and therefore the VPC were left behind, and the run reported a failure that does not happen on AWS.

## Change

- **AWS** `(*Mock).DeleteSubnet`: after removing the subnet, drop every non-main `rtAssocs` entry whose `SubnetID` matches, mirroring the existing `aclAssocs` sweep. The main association carries no subnet and is left alone, so `DeleteRouteTable`'s main-table protection is unchanged.
- **Azure** and **GCP** `DeleteSubnet`: the same cascade, for portable-API parity per CONTRIBUTING. Neither guards `DeleteRouteTable` on associations so nothing was failing there, but a stale association to a deleted subnet lingered in their stores too. In Azure the association is literally a subnet property, so this also matches the real service.

No wire-layer change: the server handlers already call the mock.

## Tests

Per provider, `TestDeleteSubnet_CascadesRouteTableAssociations`, each watched failing before the fix:

- After `DeleteSubnet`, `DisassociateRouteTable(assoc)` returns not-found.
- **AWS additionally:** `DeleteRouteTable` on that table now succeeds; and a table still associated with a *different* live subnet keeps refusing deletion, so the guard is intact.

Verified at the wire level too: built `cmd/cloudemu`, ran `serve` on spare ports, and replayed the issue's five ec2query steps — `CreateVpc → CreateSubnet → CreateRouteTable → AssociateRouteTable → DeleteSubnet → DeleteRouteTable`. `DescribeRouteTables` shows no association after the subnet delete and `DeleteRouteTable` returns `<return>true</return>`.

`golangci-lint run --new-from-rev=development` on the three packages: 0 issues. `go test ./...` on the branch: no failures.
