### PR TITLE
feat(aws-ecr): complete the control-plane op surface

### DIFF
--- a/providers/aws/ecr/ecr.go
+++ b/providers/aws/ecr/ecr.go
@@ -55,6 +55,17 @@ type Mock struct {
 	repos      *memstore.Store[*repoData]
 	opts       *config.Options
 	monitoring mondriver.Monitoring
+
+	// Registry-level (not per-repository) state. These back the AWS ECR
+	// registry-scoped operations (replication, pull-through cache, registry
+	// scanning configuration, registry policy, account settings), all guarded by
+	// mu. They are plain fields rather than memstore.Store because the surface is
+	// small and singular per registry.
+	registryPolicy  string
+	replication     *driver.ReplicationConfiguration
+	pullThrough     map[string]*driver.PullThroughCacheRule
+	registryScan    *driver.RegistryScanningConfiguration
+	accountSettings map[string]string
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -76,8 +87,10 @@ func (m *Mock) emitMetric(metricName string, value float64, dims map[string]stri
 // New creates a new ECR mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		repos: memstore.New[*repoData](),
-		opts:  opts,
+		repos:           memstore.New[*repoData](),
+		opts:            opts,
+		pullThrough:     make(map[string]*driver.PullThroughCacheRule),
+		accountSettings: make(map[string]string),
 	}
 }
 

--- a/providers/aws/ecr/errors.go
+++ b/providers/aws/ecr/errors.go
@@ -15,6 +15,9 @@ const (
 	excRepositoryPolicyNotFound = "RepositoryPolicyNotFoundException"
 	excLifecyclePolicyNotFound  = "LifecyclePolicyNotFoundException"
 	excImageAlreadyExists       = "ImageAlreadyExistsException"
+	excRegistryPolicyNotFound   = "RegistryPolicyNotFoundException"
+	excPullThroughRuleNotFound  = "PullThroughCacheRuleNotFoundException"
+	excPullThroughRuleExists    = "PullThroughCacheRuleAlreadyExistsException"
 )
 
 // apiError pairs a canonical cloudemu error with the precise ECR exception name

--- a/providers/aws/ecr/registry.go
+++ b/providers/aws/ecr/registry.go
@@ -1,0 +1,261 @@
+package ecr
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+const (
+	scanTypeBasic    = "BASIC"
+	scanTypeEnhanced = "ENHANCED"
+)
+
+// PutRegistryPolicy sets the registry-level permissions policy and echoes the
+// owning registryId. AWS-specific; reached by the ECR wire handler via type
+// assertion.
+func (m *Mock) PutRegistryPolicy(_ context.Context, policyText string) (registryID, policy string, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.registryPolicy = policyText
+
+	return m.opts.AccountID, m.registryPolicy, nil
+}
+
+// GetRegistryPolicy returns the registry policy and owning registryId, or
+// RegistryPolicyNotFoundException when none is set.
+func (m *Mock) GetRegistryPolicy(_ context.Context) (registryID, policy string, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.registryPolicy == "" {
+		return "", "", apiErrf(excRegistryPolicyNotFound, "no registry policy set")
+	}
+
+	return m.opts.AccountID, m.registryPolicy, nil
+}
+
+// DeleteRegistryPolicy removes the registry policy and returns the policy that
+// was deleted, or RegistryPolicyNotFoundException when none is set.
+func (m *Mock) DeleteRegistryPolicy(_ context.Context) (registryID, policy string, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.registryPolicy == "" {
+		return "", "", apiErrf(excRegistryPolicyNotFound, "no registry policy set")
+	}
+
+	policy = m.registryPolicy
+	m.registryPolicy = ""
+
+	return m.opts.AccountID, policy, nil
+}
+
+// PutReplicationConfiguration replaces the registry's replication configuration
+// and returns the stored configuration. AWS-specific.
+func (m *Mock) PutReplicationConfiguration(
+	_ context.Context, cfg driver.ReplicationConfiguration,
+) (driver.ReplicationConfiguration, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	stored := copyReplication(cfg)
+	m.replication = &stored
+
+	return copyReplication(stored), nil
+}
+
+// DescribeRegistry returns the owning registryId and the current replication
+// configuration. When none is configured it returns an empty (non-nil) rule
+// set, matching real ECR.
+func (m *Mock) DescribeRegistry(_ context.Context) (registryID string, cfg driver.ReplicationConfiguration, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.replication == nil {
+		return m.opts.AccountID, driver.ReplicationConfiguration{Rules: []driver.ReplicationRule{}}, nil
+	}
+
+	return m.opts.AccountID, copyReplication(*m.replication), nil
+}
+
+// CreatePullThroughCacheRule adds a pull-through cache rule keyed by its
+// repository prefix. A duplicate prefix is PullThroughCacheRuleAlreadyExists.
+func (m *Mock) CreatePullThroughCacheRule(
+	_ context.Context, rule *driver.PullThroughCacheRule,
+) (driver.PullThroughCacheRule, error) {
+	if rule.ECRRepositoryPrefix == "" {
+		return driver.PullThroughCacheRule{}, errors.New(errors.InvalidArgument, "ecrRepositoryPrefix is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.pullThrough[rule.ECRRepositoryPrefix]; ok {
+		return driver.PullThroughCacheRule{}, apiErrExistsf(excPullThroughRuleExists,
+			"pull through cache rule for prefix %q already exists", rule.ECRRepositoryPrefix)
+	}
+
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
+	stored := *rule
+	stored.RegistryID = m.opts.AccountID
+	stored.CreatedAt = now
+	stored.UpdatedAt = now
+
+	ruleCopy := stored
+	m.pullThrough[rule.ECRRepositoryPrefix] = &ruleCopy
+
+	return stored, nil
+}
+
+// UpdatePullThroughCacheRule updates the credential ARN of an existing rule.
+// A missing prefix is PullThroughCacheRuleNotFound.
+func (m *Mock) UpdatePullThroughCacheRule(
+	_ context.Context, prefix, credentialARN string,
+) (driver.PullThroughCacheRule, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rule, ok := m.pullThrough[prefix]
+	if !ok {
+		return driver.PullThroughCacheRule{}, apiErrf(excPullThroughRuleNotFound,
+			"pull through cache rule for prefix %q not found", prefix)
+	}
+
+	rule.CredentialARN = credentialARN
+	rule.UpdatedAt = m.opts.Clock.Now().UTC().Format(time.RFC3339)
+
+	return *rule, nil
+}
+
+// DescribePullThroughCacheRules returns the rules whose prefix is in prefixes,
+// or all rules when prefixes is empty, plus the owning registryId. A named
+// prefix that does not exist is PullThroughCacheRuleNotFound.
+func (m *Mock) DescribePullThroughCacheRules(
+	_ context.Context, prefixes []string,
+) (rules []driver.PullThroughCacheRule, registryID string, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(prefixes) == 0 {
+		return m.allPullThroughRules(), m.opts.AccountID, nil
+	}
+
+	rules = make([]driver.PullThroughCacheRule, 0, len(prefixes))
+
+	for _, prefix := range prefixes {
+		rule, ok := m.pullThrough[prefix]
+		if !ok {
+			return nil, "", apiErrf(excPullThroughRuleNotFound,
+				"pull through cache rule for prefix %q not found", prefix)
+		}
+
+		rules = append(rules, *rule)
+	}
+
+	return rules, m.opts.AccountID, nil
+}
+
+// allPullThroughRules returns every rule sorted by prefix for a stable order.
+func (m *Mock) allPullThroughRules() []driver.PullThroughCacheRule {
+	rules := make([]driver.PullThroughCacheRule, 0, len(m.pullThrough))
+	for _, rule := range m.pullThrough {
+		rules = append(rules, *rule)
+	}
+
+	sortPullThrough(rules)
+
+	return rules
+}
+
+// DeletePullThroughCacheRule removes a rule and returns the deleted rule, or
+// PullThroughCacheRuleNotFound when the prefix has no rule.
+func (m *Mock) DeletePullThroughCacheRule(_ context.Context, prefix string) (driver.PullThroughCacheRule, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rule, ok := m.pullThrough[prefix]
+	if !ok {
+		return driver.PullThroughCacheRule{}, apiErrf(excPullThroughRuleNotFound,
+			"pull through cache rule for prefix %q not found", prefix)
+	}
+
+	deleted := *rule
+
+	delete(m.pullThrough, prefix)
+
+	return deleted, nil
+}
+
+// PutRegistryScanningConfiguration replaces the registry scanning configuration
+// and returns the stored configuration plus the owning registryId. An unset or
+// empty scanType defaults to BASIC.
+func (m *Mock) PutRegistryScanningConfiguration(
+	_ context.Context, cfg driver.RegistryScanningConfiguration,
+) (stored driver.RegistryScanningConfiguration, registryID string, err error) {
+	if cfg.ScanType == "" {
+		cfg.ScanType = scanTypeBasic
+	}
+
+	if cfg.ScanType != scanTypeBasic && cfg.ScanType != scanTypeEnhanced {
+		return driver.RegistryScanningConfiguration{}, "", errors.Newf(errors.InvalidArgument,
+			"invalid scanType %q; expected BASIC or ENHANCED", cfg.ScanType)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	saved := copyScanConfig(cfg)
+	m.registryScan = &saved
+
+	return copyScanConfig(saved), m.opts.AccountID, nil
+}
+
+// GetRegistryScanningConfiguration returns the owning registryId and the
+// scanning configuration. When none is configured it returns the ECR default
+// (BASIC, no rules).
+func (m *Mock) GetRegistryScanningConfiguration(
+	_ context.Context,
+) (registryID string, cfg driver.RegistryScanningConfiguration, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.registryScan == nil {
+		return m.opts.AccountID, driver.RegistryScanningConfiguration{
+			ScanType: scanTypeBasic, Rules: []driver.RegistryScanningRule{},
+		}, nil
+	}
+
+	return m.opts.AccountID, copyScanConfig(*m.registryScan), nil
+}
+
+// PutAccountSetting stores a registry account-level setting (e.g.
+// BASIC_SCAN_TYPE_VERSION, REGISTRY_POLICY_SCOPE) and echoes it back.
+func (m *Mock) PutAccountSetting(_ context.Context, name, value string) (settingName, settingValue string, err error) {
+	if name == "" {
+		return "", "", errors.New(errors.InvalidArgument, "name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.accountSettings[name] = value
+
+	return name, value, nil
+}
+
+// GetAccountSetting returns a registry account-level setting. An unset name
+// reads back with an empty value, matching real ECR's default behavior.
+func (m *Mock) GetAccountSetting(_ context.Context, name string) (settingName, settingValue string, err error) {
+	if name == "" {
+		return "", "", errors.New(errors.InvalidArgument, "name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return name, m.accountSettings[name], nil
+}

--- a/providers/aws/ecr/registry_copy.go
+++ b/providers/aws/ecr/registry_copy.go
@@ -1,0 +1,51 @@
+package ecr
+
+import (
+	"sort"
+
+	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+// copyReplication deep-copies a replication configuration so stored state and
+// returned reads never share backing slices with the caller.
+func copyReplication(src driver.ReplicationConfiguration) driver.ReplicationConfiguration {
+	out := driver.ReplicationConfiguration{Rules: make([]driver.ReplicationRule, 0, len(src.Rules))}
+
+	for i := range src.Rules {
+		rule := &src.Rules[i]
+		dst := driver.ReplicationRule{
+			Destinations:      make([]driver.ReplicationDestination, len(rule.Destinations)),
+			RepositoryFilters: make([]driver.ReplicationFilter, len(rule.RepositoryFilters)),
+		}
+		copy(dst.Destinations, rule.Destinations)
+		copy(dst.RepositoryFilters, rule.RepositoryFilters)
+		out.Rules = append(out.Rules, dst)
+	}
+
+	return out
+}
+
+// copyScanConfig deep-copies a registry scanning configuration.
+func copyScanConfig(src driver.RegistryScanningConfiguration) driver.RegistryScanningConfiguration {
+	out := driver.RegistryScanningConfiguration{
+		ScanType: src.ScanType,
+		Rules:    make([]driver.RegistryScanningRule, 0, len(src.Rules)),
+	}
+
+	for i := range src.Rules {
+		rule := &src.Rules[i]
+		dst := driver.RegistryScanningRule{
+			ScanFrequency:     rule.ScanFrequency,
+			RepositoryFilters: make([]driver.ScanningRepositoryFilter, len(rule.RepositoryFilters)),
+		}
+		copy(dst.RepositoryFilters, rule.RepositoryFilters)
+		out.Rules = append(out.Rules, dst)
+	}
+
+	return out
+}
+
+// sortPullThrough orders rules by repository prefix for a stable read order.
+func sortPullThrough(rules []driver.PullThroughCacheRule) {
+	sort.Slice(rules, func(i, j int) bool { return rules[i].ECRRepositoryPrefix < rules[j].ECRRepositoryPrefix })
+}

--- a/providers/aws/ecr/registry_test.go
+++ b/providers/aws/ecr/registry_test.go
@@ -1,0 +1,208 @@
+package ecr
+
+import (
+	"context"
+	stderrors "errors"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ecrException extracts the tagged AWS exception name from a provider error.
+func ecrException(err error) string {
+	var ex interface{ ECRException() string }
+	if stderrors.As(err, &ex) {
+		return ex.ECRException()
+	}
+
+	return ""
+}
+
+func TestRegistryPolicyRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	_, _, err := m.GetRegistryPolicy(ctx)
+	require.Error(t, err)
+	assert.Equal(t, excRegistryPolicyNotFound, ecrException(err))
+
+	id, pol, err := m.PutRegistryPolicy(ctx, `{"a":1}`)
+	require.NoError(t, err)
+	assert.Equal(t, "123456789012", id)
+	assert.Equal(t, `{"a":1}`, pol)
+
+	_, pol, err = m.GetRegistryPolicy(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, `{"a":1}`, pol)
+
+	_, _, err = m.DeleteRegistryPolicy(ctx)
+	require.NoError(t, err)
+
+	_, _, err = m.DeleteRegistryPolicy(ctx)
+	require.Error(t, err)
+	assert.Equal(t, excRegistryPolicyNotFound, ecrException(err))
+}
+
+func TestReplicationConfigurationDefaultsAndStore(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	id, cfg, err := m.DescribeRegistry(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "123456789012", id)
+	assert.NotNil(t, cfg.Rules)
+	assert.Empty(t, cfg.Rules)
+
+	in := driver.ReplicationConfiguration{Rules: []driver.ReplicationRule{{
+		Destinations:      []driver.ReplicationDestination{{Region: "eu-west-1", RegistryID: "123456789012"}},
+		RepositoryFilters: []driver.ReplicationFilter{{Filter: "prod", FilterType: "PREFIX_MATCH"}},
+	}}}
+
+	stored, err := m.PutReplicationConfiguration(ctx, in)
+	require.NoError(t, err)
+	require.Len(t, stored.Rules, 1)
+
+	// Mutating the input after storing must not affect stored state (deep copy).
+	in.Rules[0].Destinations[0].Region = "MUTATED"
+
+	_, cfg, err = m.DescribeRegistry(ctx)
+	require.NoError(t, err)
+	require.Len(t, cfg.Rules, 1)
+	assert.Equal(t, "eu-west-1", cfg.Rules[0].Destinations[0].Region)
+}
+
+func TestPullThroughCacheRuleLifecycle(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	rule, err := m.CreatePullThroughCacheRule(ctx, &driver.PullThroughCacheRule{
+		ECRRepositoryPrefix: "ecr-public", UpstreamRegistryURL: "public.ecr.aws",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "123456789012", rule.RegistryID)
+	assert.NotEmpty(t, rule.CreatedAt)
+
+	// Duplicate prefix rejected with the precise exception.
+	_, err = m.CreatePullThroughCacheRule(ctx, &driver.PullThroughCacheRule{
+		ECRRepositoryPrefix: "ecr-public", UpstreamRegistryURL: "public.ecr.aws",
+	})
+	require.Error(t, err)
+	assert.Equal(t, excPullThroughRuleExists, ecrException(err))
+
+	updated, err := m.UpdatePullThroughCacheRule(ctx, "ecr-public", "arn:aws:secretsmanager:us-east-1:123456789012:secret:x")
+	require.NoError(t, err)
+	assert.Equal(t, "arn:aws:secretsmanager:us-east-1:123456789012:secret:x", updated.CredentialARN)
+
+	rules, id, err := m.DescribePullThroughCacheRules(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "123456789012", id)
+	require.Len(t, rules, 1)
+
+	// Named-prefix miss surfaces PullThroughCacheRuleNotFound.
+	_, _, err = m.DescribePullThroughCacheRules(ctx, []string{"missing"})
+	require.Error(t, err)
+	assert.Equal(t, excPullThroughRuleNotFound, ecrException(err))
+
+	_, err = m.DeletePullThroughCacheRule(ctx, "ecr-public")
+	require.NoError(t, err)
+
+	_, err = m.DeletePullThroughCacheRule(ctx, "ecr-public")
+	require.Error(t, err)
+	assert.Equal(t, excPullThroughRuleNotFound, ecrException(err))
+}
+
+func TestRegistryScanningConfiguration(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	id, cfg, err := m.GetRegistryScanningConfiguration(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "123456789012", id)
+	assert.Equal(t, scanTypeBasic, cfg.ScanType)
+	assert.Empty(t, cfg.Rules)
+
+	stored, _, err := m.PutRegistryScanningConfiguration(ctx, driver.RegistryScanningConfiguration{
+		ScanType: scanTypeEnhanced,
+		Rules: []driver.RegistryScanningRule{{
+			ScanFrequency:     "CONTINUOUS_SCAN",
+			RepositoryFilters: []driver.ScanningRepositoryFilter{{Filter: "*", FilterType: "WILDCARD"}},
+		}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, scanTypeEnhanced, stored.ScanType)
+
+	_, cfg, err = m.GetRegistryScanningConfiguration(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, scanTypeEnhanced, cfg.ScanType)
+	require.Len(t, cfg.Rules, 1)
+
+	// Invalid scanType rejected.
+	_, _, err = m.PutRegistryScanningConfiguration(ctx, driver.RegistryScanningConfiguration{ScanType: "BOGUS"})
+	require.Error(t, err)
+	assert.True(t, cerrors.IsInvalidArgument(err))
+}
+
+func TestAccountSettingRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	name, val, err := m.GetAccountSetting(ctx, "BASIC_SCAN_TYPE_VERSION")
+	require.NoError(t, err)
+	assert.Equal(t, "BASIC_SCAN_TYPE_VERSION", name)
+	assert.Empty(t, val)
+
+	_, _, err = m.PutAccountSetting(ctx, "BASIC_SCAN_TYPE_VERSION", "AWS_NATIVE")
+	require.NoError(t, err)
+
+	_, val, err = m.GetAccountSetting(ctx, "BASIC_SCAN_TYPE_VERSION")
+	require.NoError(t, err)
+	assert.Equal(t, "AWS_NATIVE", val)
+}
+
+// TestSnapshotRoundTripRegistryState proves registry-level state survives a
+// snapshot/restore round-trip.
+func TestSnapshotRoundTripRegistryState(t *testing.T) {
+	ctx := context.Background()
+	src, _ := newTestMock()
+
+	_, _, err := src.PutRegistryPolicy(ctx, `{"reg":true}`)
+	require.NoError(t, err)
+
+	_, err = src.PutReplicationConfiguration(ctx, driver.ReplicationConfiguration{Rules: []driver.ReplicationRule{{
+		Destinations: []driver.ReplicationDestination{{Region: "us-west-2", RegistryID: "123456789012"}},
+	}}})
+	require.NoError(t, err)
+
+	_, err = src.CreatePullThroughCacheRule(ctx, &driver.PullThroughCacheRule{
+		ECRRepositoryPrefix: "ecr-public", UpstreamRegistryURL: "public.ecr.aws",
+	})
+	require.NoError(t, err)
+
+	_, _, err = src.PutRegistryScanningConfiguration(ctx, driver.RegistryScanningConfiguration{ScanType: scanTypeEnhanced})
+	require.NoError(t, err)
+
+	raw, err := src.Snapshot(ctx, true)
+	require.NoError(t, err)
+
+	dst, _ := newTestMock()
+	require.NoError(t, dst.Restore(ctx, raw))
+
+	_, pol, err := dst.GetRegistryPolicy(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, `{"reg":true}`, pol)
+
+	_, cfg, err := dst.DescribeRegistry(ctx)
+	require.NoError(t, err)
+	require.Len(t, cfg.Rules, 1)
+
+	rules, _, err := dst.DescribePullThroughCacheRules(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+
+	_, scan, err := dst.GetRegistryScanningConfiguration(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, scanTypeEnhanced, scan.ScanType)
+}

--- a/providers/aws/ecr/snapshot.go
+++ b/providers/aws/ecr/snapshot.go
@@ -51,6 +51,9 @@ type imageSnapshot struct {
 // Snapshot captures every repository's state as JSON. includeAssets is unused —
 // ECR stores image manifests/metadata, not object bodies.
 func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	snap := ecrSnapshot{
 		RegistryPolicy: m.registryPolicy,
 		Replication:    m.replication,
@@ -112,6 +115,9 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 	if err := json.Unmarshal(data, &snap); err != nil {
 		return fmt.Errorf("ecr: parse snapshot: %w", err)
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	for name, rs := range snap.Repos {
 		rd, err := restoreRepo(rs)

--- a/providers/aws/ecr/snapshot.go
+++ b/providers/aws/ecr/snapshot.go
@@ -20,6 +20,12 @@ var _ snapshot.Snapshottable = (*Mock)(nil)
 // helper. The mutex and the wired deps (opts, monitoring) are not serialized.
 type ecrSnapshot struct {
 	Repos map[string]*repoSnapshot `json:"repos,omitempty"`
+	// Registry-level (not per-repository) state.
+	RegistryPolicy  string                                  `json:"registryPolicy,omitempty"`
+	Replication     *driver.ReplicationConfiguration        `json:"replication,omitempty"`
+	PullThrough     map[string]*driver.PullThroughCacheRule `json:"pullThrough,omitempty"`
+	RegistryScan    *driver.RegistryScanningConfiguration   `json:"registryScan,omitempty"`
+	AccountSettings map[string]string                       `json:"accountSettings,omitempty"`
 }
 
 // repoSnapshot mirrors repoData, promoting its unexported settings and nested
@@ -45,20 +51,31 @@ type imageSnapshot struct {
 // Snapshot captures every repository's state as JSON. includeAssets is unused —
 // ECR stores image manifests/metadata, not object bodies.
 func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
-	snap := ecrSnapshot{}
-	if m.repos.Len() == 0 {
-		return json.Marshal(snap)
+	snap := ecrSnapshot{
+		RegistryPolicy: m.registryPolicy,
+		Replication:    m.replication,
+		RegistryScan:   m.registryScan,
 	}
 
-	snap.Repos = make(map[string]*repoSnapshot, m.repos.Len())
+	if len(m.pullThrough) > 0 {
+		snap.PullThrough = m.pullThrough
+	}
 
-	for name, rd := range m.repos.All() {
-		rs, err := snapshotRepo(rd)
-		if err != nil {
-			return nil, err
+	if len(m.accountSettings) > 0 {
+		snap.AccountSettings = m.accountSettings
+	}
+
+	if m.repos.Len() > 0 {
+		snap.Repos = make(map[string]*repoSnapshot, m.repos.Len())
+
+		for name, rd := range m.repos.All() {
+			rs, err := snapshotRepo(rd)
+			if err != nil {
+				return nil, err
+			}
+
+			snap.Repos[name] = rs
 		}
-
-		snap.Repos[name] = rs
 	}
 
 	return json.Marshal(snap)
@@ -103,6 +120,18 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 		}
 
 		m.repos.Set(name, rd)
+	}
+
+	m.registryPolicy = snap.RegistryPolicy
+	m.replication = snap.Replication
+	m.registryScan = snap.RegistryScan
+
+	if snap.PullThrough != nil {
+		m.pullThrough = snap.PullThrough
+	}
+
+	if snap.AccountSettings != nil {
+		m.accountSettings = snap.AccountSettings
 	}
 
 	return nil

--- a/server/aws/ecr/handler.go
+++ b/server/aws/ecr/handler.go
@@ -62,9 +62,16 @@ func (*Handler) Matches(r *http.Request) bool {
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
 
-	if h.routeRepositories(w, r, op) || h.routeImages(w, r, op) ||
-		h.routeTags(w, r, op) || h.routeLifecycle(w, r, op) || h.routeScanning(w, r, op) {
-		return
+	routes := []func(http.ResponseWriter, *http.Request, string) bool{
+		h.routeRepositories, h.routeImages, h.routeTags, h.routeLifecycle, h.routeScanning,
+		h.routeRegistryPolicy, h.routeReplication, h.routePullThrough,
+		h.routeRegistryScanning, h.routeAccountSetting,
+	}
+
+	for _, route := range routes {
+		if route(w, r, op) {
+			return
+		}
 	}
 
 	wire.WriteJSONError(w, http.StatusBadRequest, "UnknownOperationException", "unknown ECR operation: "+op)

--- a/server/aws/ecr/pull_through.go
+++ b/server/aws/ecr/pull_through.go
@@ -1,0 +1,139 @@
+package ecr
+
+import (
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+func (h *Handler) pullThroughMgr(w http.ResponseWriter) (pullThroughManager, bool) {
+	mgr, ok := h.registry.(pullThroughManager)
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "pull through cache rules not supported"))
+	}
+
+	return mgr, ok
+}
+
+func (h *Handler) createPullThroughCacheRule(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.pullThroughMgr(w)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		ECRRepositoryPrefix string `json:"ecrRepositoryPrefix"`
+		UpstreamRegistryURL string `json:"upstreamRegistryUrl"`
+		UpstreamRegistry    string `json:"upstreamRegistry"`
+		CredentialARN       string `json:"credentialArn"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	rule, err := mgr.CreatePullThroughCacheRule(r.Context(), &crdriver.PullThroughCacheRule{
+		ECRRepositoryPrefix: req.ECRRepositoryPrefix,
+		UpstreamRegistryURL: req.UpstreamRegistryURL,
+		UpstreamRegistry:    req.UpstreamRegistry,
+		CredentialARN:       req.CredentialARN,
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writePullThroughRule(w, &rule)
+}
+
+func (h *Handler) updatePullThroughCacheRule(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.pullThroughMgr(w)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		ECRRepositoryPrefix string `json:"ecrRepositoryPrefix"`
+		CredentialARN       string `json:"credentialArn"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	rule, err := mgr.UpdatePullThroughCacheRule(r.Context(), req.ECRRepositoryPrefix, req.CredentialARN)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writePullThroughRule(w, &rule)
+}
+
+func (h *Handler) describePullThroughCacheRules(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.pullThroughMgr(w)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		ECRRepositoryPrefixes []string `json:"ecrRepositoryPrefixes"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	rules, registryID, err := mgr.DescribePullThroughCacheRules(r.Context(), req.ECRRepositoryPrefixes)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]pullThroughRuleJSON, 0, len(rules))
+	for i := range rules {
+		out = append(out, pullThroughToJSON(&rules[i]))
+	}
+
+	wire.WriteJSON(w, map[string]any{"pullThroughCacheRules": out, "registryId": registryID})
+}
+
+func (h *Handler) deletePullThroughCacheRule(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.pullThroughMgr(w)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		ECRRepositoryPrefix string `json:"ecrRepositoryPrefix"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	rule, err := mgr.DeletePullThroughCacheRule(r.Context(), req.ECRRepositoryPrefix)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writePullThroughRule(w, &rule)
+}
+
+// writePullThroughRule writes a single pull-through cache rule as the flat wire
+// object ECR returns from Create/Update/Delete.
+func writePullThroughRule(w http.ResponseWriter, rule *crdriver.PullThroughCacheRule) {
+	j := pullThroughToJSON(rule)
+	wire.WriteJSON(w, map[string]any{
+		"ecrRepositoryPrefix": j.ECRRepositoryPrefix,
+		"upstreamRegistryUrl": j.UpstreamRegistryURL,
+		"upstreamRegistry":    j.UpstreamRegistry,
+		"credentialArn":       j.CredentialARN,
+		"registryId":          j.RegistryID,
+		"createdAt":           j.CreatedAt,
+		"updatedAt":           j.UpdatedAt,
+	})
+}

--- a/server/aws/ecr/registry.go
+++ b/server/aws/ecr/registry.go
@@ -1,0 +1,315 @@
+package ecr
+
+import (
+	"context"
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+// The registry-scoped surfaces below are AWS-specific (Azure ACR and GCP
+// Artifact Registry have no registry-level replication / pull-through cache /
+// registry policy / registry scanning APIs), so they are asserted against the
+// provider rather than widening the shared ContainerRegistry driver.
+type (
+	registryPolicyManager interface {
+		PutRegistryPolicy(ctx context.Context, policyText string) (registryID, policy string, err error)
+		GetRegistryPolicy(ctx context.Context) (registryID, policy string, err error)
+		DeleteRegistryPolicy(ctx context.Context) (registryID, policy string, err error)
+	}
+
+	replicationManager interface {
+		PutReplicationConfiguration(
+			ctx context.Context, cfg crdriver.ReplicationConfiguration,
+		) (crdriver.ReplicationConfiguration, error)
+		DescribeRegistry(ctx context.Context) (registryID string, cfg crdriver.ReplicationConfiguration, err error)
+	}
+
+	pullThroughManager interface {
+		CreatePullThroughCacheRule(
+			ctx context.Context, rule *crdriver.PullThroughCacheRule,
+		) (crdriver.PullThroughCacheRule, error)
+		UpdatePullThroughCacheRule(
+			ctx context.Context, prefix, credentialARN string,
+		) (crdriver.PullThroughCacheRule, error)
+		DescribePullThroughCacheRules(
+			ctx context.Context, prefixes []string,
+		) (rules []crdriver.PullThroughCacheRule, registryID string, err error)
+		DeletePullThroughCacheRule(ctx context.Context, prefix string) (crdriver.PullThroughCacheRule, error)
+	}
+
+	registryScanManager interface {
+		PutRegistryScanningConfiguration(
+			ctx context.Context, cfg crdriver.RegistryScanningConfiguration,
+		) (stored crdriver.RegistryScanningConfiguration, registryID string, err error)
+		GetRegistryScanningConfiguration(
+			ctx context.Context,
+		) (registryID string, cfg crdriver.RegistryScanningConfiguration, err error)
+	}
+
+	accountSettingManager interface {
+		PutAccountSetting(ctx context.Context, name, value string) (settingName, settingValue string, err error)
+		GetAccountSetting(ctx context.Context, name string) (settingName, settingValue string, err error)
+	}
+)
+
+// assertMgr resolves the provider to the AWS-specific manager interface T,
+// writing an Unimplemented error and returning ok=false when the backing
+// provider does not implement it. It centralizes the type-assertion guard the
+// registry-scoped handlers share.
+func assertMgr[T any](h *Handler, w http.ResponseWriter, unsupported string) (T, bool) {
+	mgr, ok := any(h.registry).(T)
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, unsupported))
+	}
+
+	return mgr, ok
+}
+
+// routeRegistryPolicy dispatches the registry-level permissions-policy operations.
+func (h *Handler) routeRegistryPolicy(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "PutRegistryPolicy":
+		h.putRegistryPolicy(w, r)
+	case "GetRegistryPolicy":
+		h.runRegistryPolicyOp(w, r, registryPolicyManager.GetRegistryPolicy)
+	case "DeleteRegistryPolicy":
+		h.runRegistryPolicyOp(w, r, registryPolicyManager.DeleteRegistryPolicy)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// routeReplication dispatches the registry replication-configuration operations.
+func (h *Handler) routeReplication(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "PutReplicationConfiguration":
+		h.putReplicationConfiguration(w, r)
+	case "DescribeRegistry":
+		h.describeRegistry(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// routePullThrough dispatches the pull-through cache-rule operations.
+func (h *Handler) routePullThrough(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreatePullThroughCacheRule":
+		h.createPullThroughCacheRule(w, r)
+	case "UpdatePullThroughCacheRule":
+		h.updatePullThroughCacheRule(w, r)
+	case "DescribePullThroughCacheRules":
+		h.describePullThroughCacheRules(w, r)
+	case "DeletePullThroughCacheRule":
+		h.deletePullThroughCacheRule(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// routeRegistryScanning dispatches the registry scanning-configuration operations.
+func (h *Handler) routeRegistryScanning(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "PutRegistryScanningConfiguration":
+		h.putRegistryScanningConfiguration(w, r)
+	case "GetRegistryScanningConfiguration":
+		h.getRegistryScanningConfiguration(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// routeAccountSetting dispatches the registry account-setting operations.
+func (h *Handler) routeAccountSetting(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "PutAccountSetting":
+		h.putAccountSetting(w, r)
+	case "GetAccountSetting":
+		h.getAccountSetting(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) putRegistryPolicy(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := assertMgr[registryPolicyManager](h, w, "registry policy not supported")
+	if !ok {
+		return
+	}
+
+	var req struct {
+		PolicyText string `json:"policyText"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	registryID, policy, err := mgr.PutRegistryPolicy(r.Context(), req.PolicyText)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"registryId": registryID, "policyText": policy})
+}
+
+// runRegistryPolicyOp runs a body-less registry-policy read/delete and writes
+// the resulting registryId/policyText, sharing the guard and error mapping. The
+// provider tags a missing policy with RegistryPolicyNotFoundException.
+func (h *Handler) runRegistryPolicyOp(
+	w http.ResponseWriter, r *http.Request,
+	op func(registryPolicyManager, context.Context) (registryID, policy string, err error),
+) {
+	mgr, ok := assertMgr[registryPolicyManager](h, w, "registry policy not supported")
+	if !ok {
+		return
+	}
+
+	registryID, policy, err := op(mgr, r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"registryId": registryID, "policyText": policy})
+}
+
+func (h *Handler) putReplicationConfiguration(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := assertMgr[replicationManager](h, w, "replication configuration not supported")
+	if !ok {
+		return
+	}
+
+	var req struct {
+		ReplicationConfiguration replicationConfigJSON `json:"replicationConfiguration"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	stored, err := mgr.PutReplicationConfiguration(r.Context(), replicationToDriver(req.ReplicationConfiguration))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"replicationConfiguration": replicationToJSON(stored)})
+}
+
+func (h *Handler) describeRegistry(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := assertMgr[replicationManager](h, w, "replication configuration not supported")
+	if !ok {
+		return
+	}
+
+	registryID, cfg, err := mgr.DescribeRegistry(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"registryId":               registryID,
+		"replicationConfiguration": replicationToJSON(cfg),
+	})
+}
+
+func (h *Handler) putRegistryScanningConfiguration(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := assertMgr[registryScanManager](h, w, "registry scanning configuration not supported")
+	if !ok {
+		return
+	}
+
+	var req scanningConfigJSON
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	stored, _, err := mgr.PutRegistryScanningConfiguration(r.Context(), scanningToDriver(req))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"registryScanningConfiguration": scanningToJSON(stored)})
+}
+
+func (h *Handler) getRegistryScanningConfiguration(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := assertMgr[registryScanManager](h, w, "registry scanning configuration not supported")
+	if !ok {
+		return
+	}
+
+	registryID, cfg, err := mgr.GetRegistryScanningConfiguration(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"registryId":            registryID,
+		"scanningConfiguration": scanningToJSON(cfg),
+	})
+}
+
+func (h *Handler) putAccountSetting(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := assertMgr[accountSettingManager](h, w, "account settings not supported")
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	name, value, err := mgr.PutAccountSetting(r.Context(), req.Name, req.Value)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"name": name, "value": value})
+}
+
+func (h *Handler) getAccountSetting(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := assertMgr[accountSettingManager](h, w, "account settings not supported")
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Name string `json:"name"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	name, value, err := mgr.GetAccountSetting(r.Context(), req.Name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"name": name, "value": value})
+}

--- a/server/aws/ecr/registry_test.go
+++ b/server/aws/ecr/registry_test.go
@@ -1,0 +1,211 @@
+package ecr_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsecr "github.com/aws/aws-sdk-go-v2/service/ecr"
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+)
+
+// TestSDKECRRegistryPolicy round-trips the registry-level permissions policy and
+// asserts the NotFound guard: a GET/DELETE with no policy set surfaces
+// RegistryPolicyNotFoundException.
+func TestSDKECRRegistryPolicy(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.GetRegistryPolicy(ctx, &awsecr.GetRegistryPolicyInput{}); err == nil {
+		t.Fatal("GetRegistryPolicy with none set: expected error")
+	} else {
+		var nf *ecrtypes.RegistryPolicyNotFoundException
+		if !errors.As(err, &nf) {
+			t.Fatalf("GetRegistryPolicy error = %v, want RegistryPolicyNotFoundException", err)
+		}
+	}
+
+	const policy = `{"Version":"2012-10-17","Statement":[{"Sid":"r","Effect":"Allow","Principal":"*","Action":"ecr:ReplicateImage"}]}`
+
+	put, err := client.PutRegistryPolicy(ctx, &awsecr.PutRegistryPolicyInput{PolicyText: aws.String(policy)})
+	if err != nil {
+		t.Fatalf("PutRegistryPolicy: %v", err)
+	}
+
+	if aws.ToString(put.PolicyText) != policy || aws.ToString(put.RegistryId) != "123456789012" {
+		t.Fatalf("PutRegistryPolicy echoed policy=%q registryId=%q", aws.ToString(put.PolicyText), aws.ToString(put.RegistryId))
+	}
+
+	got, err := client.GetRegistryPolicy(ctx, &awsecr.GetRegistryPolicyInput{})
+	if err != nil {
+		t.Fatalf("GetRegistryPolicy: %v", err)
+	}
+
+	if aws.ToString(got.PolicyText) != policy {
+		t.Fatalf("GetRegistryPolicy = %q, want verbatim", aws.ToString(got.PolicyText))
+	}
+
+	if _, err := client.DeleteRegistryPolicy(ctx, &awsecr.DeleteRegistryPolicyInput{}); err != nil {
+		t.Fatalf("DeleteRegistryPolicy: %v", err)
+	}
+
+	if _, err := client.GetRegistryPolicy(ctx, &awsecr.GetRegistryPolicyInput{}); err == nil {
+		t.Fatal("GetRegistryPolicy after delete: expected RegistryPolicyNotFoundException")
+	}
+}
+
+// TestSDKECRReplicationConfiguration exercises the aws_ecr_replication_configuration
+// flow: DescribeRegistry defaults to an empty rule set, PutReplicationConfiguration
+// stores rules, and DescribeRegistry reflects them verbatim.
+func TestSDKECRReplicationConfiguration(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	desc, err := client.DescribeRegistry(ctx, &awsecr.DescribeRegistryInput{})
+	if err != nil {
+		t.Fatalf("DescribeRegistry(empty): %v", err)
+	}
+
+	if desc.ReplicationConfiguration == nil || len(desc.ReplicationConfiguration.Rules) != 0 {
+		t.Fatalf("DescribeRegistry empty: want 0 rules, got %+v", desc.ReplicationConfiguration)
+	}
+
+	cfg := ecrtypes.ReplicationConfiguration{Rules: []ecrtypes.ReplicationRule{{
+		Destinations: []ecrtypes.ReplicationDestination{{
+			Region: aws.String("us-west-2"), RegistryId: aws.String("123456789012"),
+		}},
+		RepositoryFilters: []ecrtypes.RepositoryFilter{{
+			Filter: aws.String("prod"), FilterType: ecrtypes.RepositoryFilterTypePrefixMatch,
+		}},
+	}}}
+
+	if _, err := client.PutReplicationConfiguration(ctx, &awsecr.PutReplicationConfigurationInput{
+		ReplicationConfiguration: &cfg,
+	}); err != nil {
+		t.Fatalf("PutReplicationConfiguration: %v", err)
+	}
+
+	desc, err = client.DescribeRegistry(ctx, &awsecr.DescribeRegistryInput{})
+	if err != nil {
+		t.Fatalf("DescribeRegistry: %v", err)
+	}
+
+	rules := desc.ReplicationConfiguration.Rules
+	if len(rules) != 1 || len(rules[0].Destinations) != 1 || len(rules[0].RepositoryFilters) != 1 {
+		t.Fatalf("DescribeRegistry rules = %+v", rules)
+	}
+
+	if aws.ToString(rules[0].Destinations[0].Region) != "us-west-2" {
+		t.Fatalf("destination region = %q", aws.ToString(rules[0].Destinations[0].Region))
+	}
+
+	if aws.ToString(rules[0].RepositoryFilters[0].Filter) != "prod" ||
+		rules[0].RepositoryFilters[0].FilterType != ecrtypes.RepositoryFilterTypePrefixMatch {
+		t.Fatalf("repository filter = %+v", rules[0].RepositoryFilters[0])
+	}
+}
+
+// TestSDKECRPullThroughCacheRule exercises the aws_ecr_pull_through_cache_rule
+// flow (create, describe, delete) and the PullThroughCacheRuleNotFound guard.
+func TestSDKECRPullThroughCacheRule(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreatePullThroughCacheRule(ctx, &awsecr.CreatePullThroughCacheRuleInput{
+		EcrRepositoryPrefix: aws.String("ecr-public"),
+		UpstreamRegistryUrl: aws.String("public.ecr.aws"),
+	})
+	if err != nil {
+		t.Fatalf("CreatePullThroughCacheRule: %v", err)
+	}
+
+	if aws.ToString(created.EcrRepositoryPrefix) != "ecr-public" ||
+		aws.ToString(created.UpstreamRegistryUrl) != "public.ecr.aws" ||
+		aws.ToString(created.RegistryId) != "123456789012" {
+		t.Fatalf("CreatePullThroughCacheRule echoed %+v", created)
+	}
+
+	// Duplicate prefix is rejected.
+	if _, err := client.CreatePullThroughCacheRule(ctx, &awsecr.CreatePullThroughCacheRuleInput{
+		EcrRepositoryPrefix: aws.String("ecr-public"),
+		UpstreamRegistryUrl: aws.String("public.ecr.aws"),
+	}); err == nil {
+		t.Fatal("duplicate CreatePullThroughCacheRule: expected error")
+	}
+
+	desc, err := client.DescribePullThroughCacheRules(ctx, &awsecr.DescribePullThroughCacheRulesInput{})
+	if err != nil {
+		t.Fatalf("DescribePullThroughCacheRules: %v", err)
+	}
+
+	if len(desc.PullThroughCacheRules) != 1 ||
+		aws.ToString(desc.PullThroughCacheRules[0].EcrRepositoryPrefix) != "ecr-public" {
+		t.Fatalf("DescribePullThroughCacheRules = %+v", desc.PullThroughCacheRules)
+	}
+
+	if _, err := client.DeletePullThroughCacheRule(ctx, &awsecr.DeletePullThroughCacheRuleInput{
+		EcrRepositoryPrefix: aws.String("ecr-public"),
+	}); err != nil {
+		t.Fatalf("DeletePullThroughCacheRule: %v", err)
+	}
+
+	// Deleting a missing rule surfaces PullThroughCacheRuleNotFoundException.
+	_, err = client.DeletePullThroughCacheRule(ctx, &awsecr.DeletePullThroughCacheRuleInput{
+		EcrRepositoryPrefix: aws.String("ecr-public"),
+	})
+	if err == nil {
+		t.Fatal("DeletePullThroughCacheRule missing: expected error")
+	}
+
+	var nf *ecrtypes.PullThroughCacheRuleNotFoundException
+	if !errors.As(err, &nf) {
+		t.Fatalf("DeletePullThroughCacheRule missing error = %v, want PullThroughCacheRuleNotFoundException", err)
+	}
+}
+
+// TestSDKECRRegistryScanningConfiguration exercises the
+// aws_ecr_registry_scanning_configuration flow: the default is BASIC with no
+// rules, and Put switches it to ENHANCED with a continuous-scan rule that Get
+// reflects.
+func TestSDKECRRegistryScanningConfiguration(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	got, err := client.GetRegistryScanningConfiguration(ctx, &awsecr.GetRegistryScanningConfigurationInput{})
+	if err != nil {
+		t.Fatalf("GetRegistryScanningConfiguration(default): %v", err)
+	}
+
+	if got.ScanningConfiguration == nil || got.ScanningConfiguration.ScanType != ecrtypes.ScanTypeBasic {
+		t.Fatalf("default scanType = %+v, want BASIC", got.ScanningConfiguration)
+	}
+
+	if _, err := client.PutRegistryScanningConfiguration(ctx, &awsecr.PutRegistryScanningConfigurationInput{
+		ScanType: ecrtypes.ScanTypeEnhanced,
+		Rules: []ecrtypes.RegistryScanningRule{{
+			ScanFrequency: ecrtypes.ScanFrequencyContinuousScan,
+			RepositoryFilters: []ecrtypes.ScanningRepositoryFilter{{
+				Filter: aws.String("*"), FilterType: ecrtypes.ScanningRepositoryFilterTypeWildcard,
+			}},
+		}},
+	}); err != nil {
+		t.Fatalf("PutRegistryScanningConfiguration: %v", err)
+	}
+
+	got, err = client.GetRegistryScanningConfiguration(ctx, &awsecr.GetRegistryScanningConfigurationInput{})
+	if err != nil {
+		t.Fatalf("GetRegistryScanningConfiguration: %v", err)
+	}
+
+	sc := got.ScanningConfiguration
+	if sc.ScanType != ecrtypes.ScanTypeEnhanced || len(sc.Rules) != 1 ||
+		sc.Rules[0].ScanFrequency != ecrtypes.ScanFrequencyContinuousScan {
+		t.Fatalf("GetRegistryScanningConfiguration = %+v", sc)
+	}
+
+	if len(sc.Rules[0].RepositoryFilters) != 1 ||
+		aws.ToString(sc.Rules[0].RepositoryFilters[0].Filter) != "*" {
+		t.Fatalf("scanning filter = %+v", sc.Rules[0].RepositoryFilters)
+	}
+}

--- a/server/aws/ecr/registry_types.go
+++ b/server/aws/ecr/registry_types.go
@@ -1,0 +1,158 @@
+package ecr
+
+import (
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+)
+
+// replicationConfigJSON models ECR's replicationConfiguration wire object,
+// mapped to and from the AWS-specific driver.ReplicationConfiguration.
+type replicationConfigJSON struct {
+	Rules []replicationRuleJSON `json:"rules"`
+}
+
+type replicationRuleJSON struct {
+	Destinations      []replicationDestJSON   `json:"destinations"`
+	RepositoryFilters []replicationFilterJSON `json:"repositoryFilters,omitempty"`
+}
+
+type replicationDestJSON struct {
+	Region     string `json:"region"`
+	RegistryID string `json:"registryId"`
+}
+
+type replicationFilterJSON struct {
+	Filter     string `json:"filter"`
+	FilterType string `json:"filterType"`
+}
+
+// scanningConfigJSON models ECR's registryScanningConfiguration wire object.
+type scanningConfigJSON struct {
+	ScanType string             `json:"scanType"`
+	Rules    []scanningRuleJSON `json:"rules"`
+}
+
+type scanningRuleJSON struct {
+	ScanFrequency     string               `json:"scanFrequency"`
+	RepositoryFilters []scanningFilterJSON `json:"repositoryFilters"`
+}
+
+type scanningFilterJSON struct {
+	Filter     string `json:"filter"`
+	FilterType string `json:"filterType"`
+}
+
+// pullThroughRuleJSON models ECR's pullThroughCacheRule wire object.
+type pullThroughRuleJSON struct {
+	ECRRepositoryPrefix string  `json:"ecrRepositoryPrefix"`
+	UpstreamRegistryURL string  `json:"upstreamRegistryUrl,omitempty"`
+	UpstreamRegistry    string  `json:"upstreamRegistry,omitempty"`
+	CredentialARN       string  `json:"credentialArn,omitempty"`
+	RegistryID          string  `json:"registryId,omitempty"`
+	CreatedAt           float64 `json:"createdAt,omitempty"`
+	UpdatedAt           float64 `json:"updatedAt,omitempty"`
+}
+
+func replicationToDriver(in replicationConfigJSON) crdriver.ReplicationConfiguration {
+	out := crdriver.ReplicationConfiguration{Rules: make([]crdriver.ReplicationRule, 0, len(in.Rules))}
+
+	for i := range in.Rules {
+		src := &in.Rules[i]
+		rule := crdriver.ReplicationRule{
+			Destinations:      make([]crdriver.ReplicationDestination, 0, len(src.Destinations)),
+			RepositoryFilters: make([]crdriver.ReplicationFilter, 0, len(src.RepositoryFilters)),
+		}
+
+		for _, d := range src.Destinations {
+			rule.Destinations = append(rule.Destinations, crdriver.ReplicationDestination{Region: d.Region, RegistryID: d.RegistryID})
+		}
+
+		for _, f := range src.RepositoryFilters {
+			rule.RepositoryFilters = append(rule.RepositoryFilters, crdriver.ReplicationFilter{Filter: f.Filter, FilterType: f.FilterType})
+		}
+
+		out.Rules = append(out.Rules, rule)
+	}
+
+	return out
+}
+
+func replicationToJSON(in crdriver.ReplicationConfiguration) replicationConfigJSON {
+	out := replicationConfigJSON{Rules: make([]replicationRuleJSON, 0, len(in.Rules))}
+
+	for i := range in.Rules {
+		src := &in.Rules[i]
+		rule := replicationRuleJSON{
+			Destinations:      make([]replicationDestJSON, 0, len(src.Destinations)),
+			RepositoryFilters: make([]replicationFilterJSON, 0, len(src.RepositoryFilters)),
+		}
+
+		for _, d := range src.Destinations {
+			rule.Destinations = append(rule.Destinations, replicationDestJSON{Region: d.Region, RegistryID: d.RegistryID})
+		}
+
+		for _, f := range src.RepositoryFilters {
+			rule.RepositoryFilters = append(rule.RepositoryFilters, replicationFilterJSON{Filter: f.Filter, FilterType: f.FilterType})
+		}
+
+		out.Rules = append(out.Rules, rule)
+	}
+
+	return out
+}
+
+func scanningToDriver(in scanningConfigJSON) crdriver.RegistryScanningConfiguration {
+	out := crdriver.RegistryScanningConfiguration{
+		ScanType: in.ScanType,
+		Rules:    make([]crdriver.RegistryScanningRule, 0, len(in.Rules)),
+	}
+
+	for i := range in.Rules {
+		src := &in.Rules[i]
+		rule := crdriver.RegistryScanningRule{
+			ScanFrequency:     src.ScanFrequency,
+			RepositoryFilters: make([]crdriver.ScanningRepositoryFilter, 0, len(src.RepositoryFilters)),
+		}
+
+		for _, f := range src.RepositoryFilters {
+			rule.RepositoryFilters = append(rule.RepositoryFilters, crdriver.ScanningRepositoryFilter{Filter: f.Filter, FilterType: f.FilterType})
+		}
+
+		out.Rules = append(out.Rules, rule)
+	}
+
+	return out
+}
+
+func scanningToJSON(in crdriver.RegistryScanningConfiguration) scanningConfigJSON {
+	out := scanningConfigJSON{ScanType: in.ScanType, Rules: make([]scanningRuleJSON, 0, len(in.Rules))}
+
+	for i := range in.Rules {
+		src := &in.Rules[i]
+		rule := scanningRuleJSON{
+			ScanFrequency:     src.ScanFrequency,
+			RepositoryFilters: make([]scanningFilterJSON, 0, len(src.RepositoryFilters)),
+		}
+
+		for _, f := range src.RepositoryFilters {
+			rule.RepositoryFilters = append(rule.RepositoryFilters, scanningFilterJSON{Filter: f.Filter, FilterType: f.FilterType})
+		}
+
+		out.Rules = append(out.Rules, rule)
+	}
+
+	return out
+}
+
+// pullThroughToJSON renders a driver rule as its wire object, converting the
+// stored RFC3339 timestamps to the epoch-seconds shape ECR uses on the wire.
+func pullThroughToJSON(in *crdriver.PullThroughCacheRule) pullThroughRuleJSON {
+	return pullThroughRuleJSON{
+		ECRRepositoryPrefix: in.ECRRepositoryPrefix,
+		UpstreamRegistryURL: in.UpstreamRegistryURL,
+		UpstreamRegistry:    in.UpstreamRegistry,
+		CredentialARN:       in.CredentialARN,
+		RegistryID:          in.RegistryID,
+		CreatedAt:           epochSeconds(in.CreatedAt),
+		UpdatedAt:           epochSeconds(in.UpdatedAt),
+	}
+}

--- a/services/containerregistry/driver/driver.go
+++ b/services/containerregistry/driver/driver.go
@@ -147,6 +147,70 @@ type ScanResult struct {
 	CompletedAt   string
 }
 
+// ReplicationConfiguration is an AWS ECR registry-level cross-region/cross-account
+// replication configuration. AWS-specific (Azure ACR and GCP Artifact Registry have
+// no equivalent registry-level replication API), so it is not part of the
+// ContainerRegistry interface below — the AWS provider exposes registry-level
+// methods the ECR wire handler reaches via type assertion, the same pattern used for
+// LifecyclePreviewResult.
+type ReplicationConfiguration struct {
+	Rules []ReplicationRule
+}
+
+// ReplicationRule is one replication rule: a set of destinations plus optional
+// repository filters that scope which repositories the rule replicates.
+type ReplicationRule struct {
+	Destinations      []ReplicationDestination
+	RepositoryFilters []ReplicationFilter
+}
+
+// ReplicationDestination is a replication target region/registry.
+type ReplicationDestination struct {
+	Region     string
+	RegistryID string
+}
+
+// ReplicationFilter scopes a replication rule to matching repositories.
+// FilterType is "PREFIX_MATCH".
+type ReplicationFilter struct {
+	Filter     string
+	FilterType string
+}
+
+// PullThroughCacheRule is an AWS ECR registry-level pull-through cache rule,
+// mapping a local repository prefix to an upstream registry. AWS-specific.
+type PullThroughCacheRule struct {
+	ECRRepositoryPrefix string
+	UpstreamRegistryURL string
+	UpstreamRegistry    string
+	CredentialARN       string
+	RegistryID          string
+	CreatedAt           string
+	UpdatedAt           string
+}
+
+// RegistryScanningConfiguration is an AWS ECR registry-level scanning
+// configuration. ScanType is "BASIC" (the default) or "ENHANCED". AWS-specific.
+type RegistryScanningConfiguration struct {
+	ScanType string
+	Rules    []RegistryScanningRule
+}
+
+// RegistryScanningRule is one registry scanning rule: a scan frequency plus the
+// repository filters it applies to. ScanFrequency is "SCAN_ON_PUSH",
+// "CONTINUOUS_SCAN", or "MANUAL".
+type RegistryScanningRule struct {
+	ScanFrequency     string
+	RepositoryFilters []ScanningRepositoryFilter
+}
+
+// ScanningRepositoryFilter scopes a registry scanning rule. FilterType is
+// "WILDCARD".
+type ScanningRepositoryFilter struct {
+	Filter     string
+	FilterType string
+}
+
 // ContainerRegistry is the interface that container registry providers must implement.
 type ContainerRegistry interface {
 	// Repository management


### PR DESCRIPTION
## Summary

Depth pass on the existing AWS ECR service: audited current-vs-real and added the genuinely-missing **registry-level** control-plane operations. All existing repository/image/lifecycle/repo-policy/scan/tag behavior is unchanged.

### Audit gap list (BEFORE → AFTER)

Already present: CreateRepository, DescribeRepositories, DeleteRepository, PutImageTagMutability, PutImageScanningConfiguration, PutImage, ListImages, DescribeImages, BatchDeleteImage, BatchGetImage, TagResource, UntagResource, ListTagsForResource, SetRepositoryPolicy, GetRepositoryPolicy, DeleteRepositoryPolicy, PutLifecyclePolicy, GetLifecyclePolicy, DeleteLifecyclePolicy, StartLifecyclePolicyPreview, GetLifecyclePolicyPreview, GetAuthorizationToken, StartImageScan, DescribeImageScanFindings.

Added (were missing):

- **Registry policy**: PutRegistryPolicy / GetRegistryPolicy / DeleteRegistryPolicy
- **Replication configuration**: PutReplicationConfiguration / DescribeRegistry (returns replicationConfiguration)
- **Pull-through cache rules**: CreatePullThroughCacheRule / DescribePullThroughCacheRules / DeletePullThroughCacheRule / UpdatePullThroughCacheRule
- **Registry scanning config**: PutRegistryScanningConfiguration / GetRegistryScanningConfiguration (BASIC/ENHANCED + scan filters)
- **Account settings**: PutAccountSetting / GetAccountSetting

### Design

- Registry-scoped ops are AWS-specific (Azure ACR / GCP Artifact Registry have no equivalents), so they follow the existing type-assertion pattern (like PutImageTagMutability / PreviewLifecyclePolicy) rather than widening the shared `ContainerRegistry` driver. New AWS-only data types live in the driver package alongside the existing `LifecyclePreviewResult` precedent.
- Registry-level state (policy, replication, pull-through rules, scanning config, account settings) is added to the `Mock` and fully snapshotted in `snapshot.go`; reads deep-copy the new blocks and mint no clock/random values.
- Realistic NotFound guards with exact exception names: `RegistryPolicyNotFoundException`, `PullThroughCacheRuleNotFoundException`, `PullThroughCacheRuleAlreadyExistsException` (plus the pre-existing lifecycle/repository-policy guards).

### Tests

- Provider-level: policy/replication/pull-through/scanning/account round-trips, deep-copy isolation, duplicate + NotFound guards, and a snapshot/restore round-trip of registry state.
- Server-level: real aws-sdk-go-v2 ECR client round-trips for registry policy, replication, pull-through cache, and registry scanning, including typed exception assertions.
- Live terraform-provider-aws e2e (aws_ecr_repository + lifecycle_policy + repository_policy + replication_configuration + pull_through_cache_rule + registry_scanning_configuration): apply → plan -detailed-exitcode exit 0 → in-place update → clean plan → destroy; NotFound guards verified directly on the wire.