### PR TITLE
feat(aws-dynamodb): complete the control-plane op surface

### DIFF
--- a/docs/coverage/aws/dynamodb.md
+++ b/docs/coverage/aws/dynamodb.md
@@ -49,6 +49,38 @@ Backuper is an OPTIONAL capability, discovered by type assertion (like the
 | `RestoreTableFromBackup` | RestoreTableFromBackup creates targetTable from the backup's schema and |
 | `RestoreTableToPointInTime` | RestoreTableToPointInTime creates targetTable from sourceTable. The |
 
+### ContributorInsighter
+
+ContributorInsighter is an OPTIONAL capability, discovered by type assertion
+
+| Operation | Description |
+| --- | --- |
+| `DescribeContributorInsights` | DescribeContributorInsights returns the Contributor Insights status of the |
+| `ListContributorInsights` | ListContributorInsights returns a summary for every table/index that has a |
+| `UpdateContributorInsights` | UpdateContributorInsights enables or disables Contributor Insights for the |
+
+### GlobalTabler
+
+GlobalTabler is an OPTIONAL capability, discovered by type assertion (like
+
+| Operation | Description |
+| --- | --- |
+| `CreateGlobalTable` | CreateGlobalTable creates a global table named after an existing table with |
+| `DescribeGlobalTable` | DescribeGlobalTable returns the global table identified by name. |
+| `ListGlobalTables` | ListGlobalTables returns every global table ordered by name, optionally |
+| `UpdateGlobalTable` | UpdateGlobalTable adds and/or removes replica regions, returning the |
+
+### KinesisStreamer
+
+KinesisStreamer is an OPTIONAL capability, discovered by type assertion (like
+
+| Operation | Description |
+| --- | --- |
+| `DescribeKinesisStreamingDestination` | DescribeKinesisStreamingDestination returns every destination attached to |
+| `DisableKinesisStreamingDestination` | DisableKinesisStreamingDestination marks the table's streamArn destination |
+| `EnableKinesisStreamingDestination` | EnableKinesisStreamingDestination attaches streamArn to the table (or |
+| `UpdateKinesisStreamingDestination` | UpdateKinesisStreamingDestination changes the precision of the table's |
+
 ## Not in scope
 
 _Not documented yet. See the [emulator boundary](../../../README.md) for cloudemu-wide non-goals._

--- a/docs/coverage/coverage.json
+++ b/docs/coverage/coverage.json
@@ -5038,6 +5038,68 @@
         ]
       },
       {
+        "name": "ContributorInsighter",
+        "doc": "ContributorInsighter is an OPTIONAL capability, discovered by type assertion",
+        "operations": [
+          {
+            "name": "DescribeContributorInsights",
+            "doc": "DescribeContributorInsights returns the Contributor Insights status of the"
+          },
+          {
+            "name": "ListContributorInsights",
+            "doc": "ListContributorInsights returns a summary for every table/index that has a"
+          },
+          {
+            "name": "UpdateContributorInsights",
+            "doc": "UpdateContributorInsights enables or disables Contributor Insights for the"
+          }
+        ]
+      },
+      {
+        "name": "GlobalTabler",
+        "doc": "GlobalTabler is an OPTIONAL capability, discovered by type assertion (like",
+        "operations": [
+          {
+            "name": "CreateGlobalTable",
+            "doc": "CreateGlobalTable creates a global table named after an existing table with"
+          },
+          {
+            "name": "DescribeGlobalTable",
+            "doc": "DescribeGlobalTable returns the global table identified by name."
+          },
+          {
+            "name": "ListGlobalTables",
+            "doc": "ListGlobalTables returns every global table ordered by name, optionally"
+          },
+          {
+            "name": "UpdateGlobalTable",
+            "doc": "UpdateGlobalTable adds and/or removes replica regions, returning the"
+          }
+        ]
+      },
+      {
+        "name": "KinesisStreamer",
+        "doc": "KinesisStreamer is an OPTIONAL capability, discovered by type assertion (like",
+        "operations": [
+          {
+            "name": "DescribeKinesisStreamingDestination",
+            "doc": "DescribeKinesisStreamingDestination returns every destination attached to"
+          },
+          {
+            "name": "DisableKinesisStreamingDestination",
+            "doc": "DisableKinesisStreamingDestination marks the table's streamArn destination"
+          },
+          {
+            "name": "EnableKinesisStreamingDestination",
+            "doc": "EnableKinesisStreamingDestination attaches streamArn to the table (or"
+          },
+          {
+            "name": "UpdateKinesisStreamingDestination",
+            "doc": "UpdateKinesisStreamingDestination changes the precision of the table's"
+          }
+        ]
+      },
+      {
         "name": "TableAttributes",
         "doc": "TableAttributes is an OPTIONAL capability, discovered by type assertion (like",
         "operations": [

--- a/providers/aws/dynamodb/contributorinsights.go
+++ b/providers/aws/dynamodb/contributorinsights.go
@@ -1,0 +1,98 @@
+package dynamodb
+
+import (
+	"context"
+	"sort"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+var _ driver.ContributorInsighter = (*Mock)(nil)
+
+// UpdateContributorInsights enables or disables Contributor Insights for the
+// table (index empty) or one of its GSIs, landing the new status immediately.
+func (m *Mock) UpdateContributorInsights(_ context.Context, table, index string, enable bool) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return "", cerrors.Newf(cerrors.NotFound, "Table not found: %s", table)
+	}
+
+	if index != "" {
+		if !td.config.HasGSI(index) {
+			return "", cerrors.Newf(cerrors.NotFound, "Index not found: %s", index)
+		}
+	}
+
+	status := driver.ContributorInsightsDisabled
+	if enable {
+		status = driver.ContributorInsightsEnabled
+	}
+
+	if td.ci == nil {
+		td.ci = make(map[string]ciRecord)
+	}
+
+	td.ci[index] = ciRecord{status: status, lastUpdateUnix: float64(m.opts.Clock.Now().Unix())}
+
+	return status, nil
+}
+
+// DescribeContributorInsights returns the Contributor Insights status of the
+// table or index (DISABLED when never enabled).
+func (m *Mock) DescribeContributorInsights(_ context.Context,
+	table, index string) (status string, lastUpdateUnix float64, err error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return "", 0, cerrors.Newf(cerrors.NotFound, "Table not found: %s", table)
+	}
+
+	if index != "" {
+		if !td.config.HasGSI(index) {
+			return "", 0, cerrors.Newf(cerrors.NotFound, "Index not found: %s", index)
+		}
+	}
+
+	rec, ok := td.ci[index]
+	if !ok {
+		return driver.ContributorInsightsDisabled, 0, nil
+	}
+
+	return rec.status, rec.lastUpdateUnix, nil
+}
+
+// ListContributorInsights returns a summary for every table/index that has a
+// Contributor Insights record, ordered by table then index. When table is
+// non-empty only that table's records are returned.
+func (m *Mock) ListContributorInsights(_ context.Context, table string) ([]driver.ContributorInsightsSummary, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var out []driver.ContributorInsightsSummary
+
+	for name, td := range m.tables {
+		if table != "" && name != table {
+			continue
+		}
+
+		for index, rec := range td.ci {
+			out = append(out, driver.ContributorInsightsSummary{Table: name, Index: index, Status: rec.status})
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Table != out[j].Table {
+			return out[i].Table < out[j].Table
+		}
+
+		return out[i].Index < out[j].Index
+	})
+
+	return out, nil
+}

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -75,6 +75,11 @@ type tableData struct {
 	seqCounter    atomic.Int64
 	tags          map[string]string
 	pitrEnabled   bool
+	// kinesisDests holds the table's Kinesis Data Streams destinations, keyed
+	// by StreamArn (see kinesis.go). ci holds its Contributor Insights records,
+	// keyed by index name ("" for the table itself; see contributorinsights.go).
+	kinesisDests map[string]driver.KinesisDestination
+	ci           map[string]ciRecord
 }
 
 // DynamoDB table/GSI lifecycle states and their settle durations. A real table
@@ -126,6 +131,16 @@ type Mock struct {
 	// replays them into a new table regardless of later mutations. Guarded by
 	// m.mu; see backup.go.
 	backups map[string]*backupData
+	// globalTables holds version-2017 global tables keyed by name, each with its
+	// replication group (see globaltable.go). Guarded by m.mu.
+	globalTables map[string]*driver.GlobalTableInfo
+}
+
+// ciRecord is one table/index Contributor Insights record: its current status
+// and the Unix-seconds time of the last status change (0 when never changed).
+type ciRecord struct {
+	status         string
+	lastUpdateUnix float64
 }
 
 // StreamEventInvoker delivers a DynamoDB Streams event batch to whatever Lambda
@@ -174,6 +189,7 @@ func New(opts *config.Options) *Mock {
 		opts:          opts,
 		txIdempotency: make(map[string]txIdempotencyRecord),
 		backups:       make(map[string]*backupData),
+		globalTables:  make(map[string]*driver.GlobalTableInfo),
 		tableSettle:   settle.NewSet(),
 		gsiSettle:     settle.NewSet(),
 	}

--- a/providers/aws/dynamodb/globaltable.go
+++ b/providers/aws/dynamodb/globaltable.go
@@ -1,0 +1,155 @@
+package dynamodb
+
+import (
+	"context"
+	"sort"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+var _ driver.GlobalTabler = (*Mock)(nil)
+
+// CreateGlobalTable creates a version-2017 global table named after an existing
+// table with the given replica regions, landing ACTIVE immediately.
+func (m *Mock) CreateGlobalTable(_ context.Context, name string, regions []string) (driver.GlobalTableInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.tables[name]; !exists {
+		return driver.GlobalTableInfo{}, cerrors.Newf(cerrors.NotFound, "Table not found: %s", name)
+	}
+
+	if _, exists := m.globalTables[name]; exists {
+		return driver.GlobalTableInfo{}, cerrors.Newf(cerrors.AlreadyExists, "Global table already exists: %s", name)
+	}
+
+	info := &driver.GlobalTableInfo{
+		Name:        name,
+		Arn:         idgen.AWSARN("dynamodb", m.opts.Region, m.opts.AccountID, "global-table/"+name),
+		Status:      driver.GlobalTableStatusActive,
+		CreatedUnix: float64(m.opts.Clock.Now().Unix()),
+		Regions:     dedupRegions(regions),
+	}
+	m.globalTables[name] = info
+
+	return copyGlobalTable(info), nil
+}
+
+// DescribeGlobalTable returns the global table identified by name.
+func (m *Mock) DescribeGlobalTable(_ context.Context, name string) (driver.GlobalTableInfo, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	info, ok := m.globalTables[name]
+	if !ok {
+		return driver.GlobalTableInfo{}, cerrors.Newf(cerrors.NotFound, "Global table not found: %s", name)
+	}
+
+	return copyGlobalTable(info), nil
+}
+
+// UpdateGlobalTable adds and/or removes replica regions.
+func (m *Mock) UpdateGlobalTable(_ context.Context,
+	name string, addRegions, removeRegions []string) (driver.GlobalTableInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	info, ok := m.globalTables[name]
+	if !ok {
+		return driver.GlobalTableInfo{}, cerrors.Newf(cerrors.NotFound, "Global table not found: %s", name)
+	}
+
+	present := make(map[string]bool, len(info.Regions))
+	for _, r := range info.Regions {
+		present[r] = true
+	}
+
+	for _, r := range addRegions {
+		if present[r] {
+			// AlreadyExists here is a duplicate replica (rendered as
+			// ReplicaAlreadyExistsException); the global-table-exists case is
+			// caught by CreateGlobalTable, so update never conflates them.
+			return driver.GlobalTableInfo{}, cerrors.Newf(cerrors.AlreadyExists, "Replica already exists: %s", r)
+		}
+
+		present[r] = true
+	}
+
+	for _, r := range removeRegions {
+		if !present[r] {
+			// FailedPrecondition distinguishes a missing replica (rendered as
+			// ReplicaNotFoundException) from a missing global table (NotFound,
+			// rendered as GlobalTableNotFoundException).
+			return driver.GlobalTableInfo{}, cerrors.Newf(cerrors.FailedPrecondition, "Replica not found: %s", r)
+		}
+
+		delete(present, r)
+	}
+
+	info.Regions = sortedKeys(present)
+
+	return copyGlobalTable(info), nil
+}
+
+// ListGlobalTables returns every global table ordered by name, optionally
+// filtered to those with a replica in regionFilter.
+func (m *Mock) ListGlobalTables(_ context.Context, regionFilter string) ([]driver.GlobalTableInfo, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	out := make([]driver.GlobalTableInfo, 0, len(m.globalTables))
+
+	for _, info := range m.globalTables {
+		if regionFilter != "" && !containsRegion(info.Regions, regionFilter) {
+			continue
+		}
+
+		out = append(out, copyGlobalTable(info))
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+
+	return out, nil
+}
+
+// copyGlobalTable deep-copies a stored global table so callers never alias the
+// provider's region slice.
+func copyGlobalTable(info *driver.GlobalTableInfo) driver.GlobalTableInfo {
+	out := *info
+	out.Regions = append([]string(nil), info.Regions...)
+
+	return out
+}
+
+// dedupRegions returns regions with duplicates removed, in stable sorted order.
+func dedupRegions(regions []string) []string {
+	seen := make(map[string]bool, len(regions))
+	for _, r := range regions {
+		seen[r] = true
+	}
+
+	return sortedKeys(seen)
+}
+
+func sortedKeys(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+
+	sort.Strings(out)
+
+	return out
+}
+
+func containsRegion(regions []string, target string) bool {
+	for _, r := range regions {
+		if r == target {
+			return true
+		}
+	}
+
+	return false
+}

--- a/providers/aws/dynamodb/kinesis.go
+++ b/providers/aws/dynamodb/kinesis.go
@@ -1,0 +1,109 @@
+package dynamodb
+
+import (
+	"context"
+	"sort"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+var _ driver.KinesisStreamer = (*Mock)(nil)
+
+// EnableKinesisStreamingDestination attaches streamArn to the table (or
+// re-activates an existing destination) and lands it ACTIVE immediately.
+func (m *Mock) EnableKinesisStreamingDestination(_ context.Context,
+	table, streamArn, precision string) (driver.KinesisDestination, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return driver.KinesisDestination{}, cerrors.Newf(cerrors.NotFound, "Table not found: %s", table)
+	}
+
+	if td.kinesisDests == nil {
+		td.kinesisDests = make(map[string]driver.KinesisDestination)
+	}
+
+	dest := driver.KinesisDestination{StreamArn: streamArn, Status: driver.KinesisStatusActive, Precision: precision}
+	td.kinesisDests[streamArn] = dest
+
+	return dest, nil
+}
+
+// DisableKinesisStreamingDestination marks the table's streamArn destination
+// DISABLED.
+func (m *Mock) DisableKinesisStreamingDestination(_ context.Context,
+	table, streamArn string) (driver.KinesisDestination, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	dest, err := m.kinesisDest(table, streamArn)
+	if err != nil {
+		return driver.KinesisDestination{}, err
+	}
+
+	dest.Status = driver.KinesisStatusDisabled
+	m.tables[table].kinesisDests[streamArn] = dest
+
+	return dest, nil
+}
+
+// UpdateKinesisStreamingDestination changes the precision of the table's
+// streamArn destination.
+func (m *Mock) UpdateKinesisStreamingDestination(_ context.Context,
+	table, streamArn, precision string) (driver.KinesisDestination, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	dest, err := m.kinesisDest(table, streamArn)
+	if err != nil {
+		return driver.KinesisDestination{}, err
+	}
+
+	dest.Precision = precision
+	m.tables[table].kinesisDests[streamArn] = dest
+
+	return dest, nil
+}
+
+// DescribeKinesisStreamingDestination returns every destination attached to the
+// table, ordered by StreamArn.
+func (m *Mock) DescribeKinesisStreamingDestination(_ context.Context, table string) ([]driver.KinesisDestination, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return nil, cerrors.Newf(cerrors.NotFound, "Table not found: %s", table)
+	}
+
+	out := make([]driver.KinesisDestination, 0, len(td.kinesisDests))
+	for _, d := range td.kinesisDests {
+		out = append(out, d)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].StreamArn < out[j].StreamArn })
+
+	return out, nil
+}
+
+// kinesisDest returns a copy of the table's streamArn destination under the
+// caller-held lock, or a not-found error. A missing table is TableNotFound; a
+// missing destination is also reported as not-found so callers map it to the
+// same ResourceNotFoundException DynamoDB returns.
+func (m *Mock) kinesisDest(table, streamArn string) (driver.KinesisDestination, error) {
+	td, exists := m.tables[table]
+	if !exists {
+		return driver.KinesisDestination{}, cerrors.Newf(cerrors.NotFound, "Table not found: %s", table)
+	}
+
+	dest, ok := td.kinesisDests[streamArn]
+	if !ok {
+		return driver.KinesisDestination{}, cerrors.Newf(cerrors.NotFound,
+			"Kinesis streaming destination not found for table %s: %s", table, streamArn)
+	}
+
+	return dest, nil
+}

--- a/providers/aws/dynamodb/op_surface_test.go
+++ b/providers/aws/dynamodb/op_surface_test.go
@@ -1,0 +1,175 @@
+package dynamodb
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+// TestKinesisStreamingDestinationLifecycle covers enable/describe/update/disable
+// and the not-found guards for a missing table and a missing destination.
+func TestKinesisStreamingDestinationLifecycle(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	createTestTable(m, "events")
+
+	const arn = "arn:aws:kinesis:us-east-1:000000000000:stream/s"
+
+	dest, err := m.EnableKinesisStreamingDestination(ctx, "events", arn, "MILLISECOND")
+	requireNoError(t, err)
+	assertEqual(t, driver.KinesisStatusActive, dest.Status)
+	assertEqual(t, "MILLISECOND", dest.Precision)
+
+	updated, err := m.UpdateKinesisStreamingDestination(ctx, "events", arn, "MICROSECOND")
+	requireNoError(t, err)
+	assertEqual(t, "MICROSECOND", updated.Precision)
+
+	dests, err := m.DescribeKinesisStreamingDestination(ctx, "events")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(dests))
+	assertEqual(t, "MICROSECOND", dests[0].Precision)
+
+	disabled, err := m.DisableKinesisStreamingDestination(ctx, "events", arn)
+	requireNoError(t, err)
+	assertEqual(t, driver.KinesisStatusDisabled, disabled.Status)
+
+	_, err = m.EnableKinesisStreamingDestination(ctx, "ghost", arn, "")
+	assertTrueT(t, cerrors.IsNotFound(err), "enable on missing table should be NotFound")
+
+	_, err = m.DisableKinesisStreamingDestination(ctx, "events", "arn:aws:kinesis:us-east-1:0:stream/other")
+	assertTrueT(t, cerrors.IsNotFound(err), "disable of missing destination should be NotFound")
+}
+
+// TestContributorInsightsLifecycle covers enable/describe/list/disable plus the
+// missing-index and missing-table guards.
+func TestContributorInsightsLifecycle(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	createTestTable(m, "metrics")
+
+	status, err := m.UpdateContributorInsights(ctx, "metrics", "", true)
+	requireNoError(t, err)
+	assertEqual(t, driver.ContributorInsightsEnabled, status)
+
+	got, lastUpdate, err := m.DescribeContributorInsights(ctx, "metrics", "")
+	requireNoError(t, err)
+	assertEqual(t, driver.ContributorInsightsEnabled, got)
+	assertTrueT(t, lastUpdate > 0, "enabled record should carry a last-update time")
+
+	summaries, err := m.ListContributorInsights(ctx, "")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(summaries))
+	assertEqual(t, "metrics", summaries[0].Table)
+
+	status, err = m.UpdateContributorInsights(ctx, "metrics", "", false)
+	requireNoError(t, err)
+	assertEqual(t, driver.ContributorInsightsDisabled, status)
+
+	// A never-touched table reads DISABLED, not an error.
+	createTestTable(m, "fresh")
+	got, _, err = m.DescribeContributorInsights(ctx, "fresh", "")
+	requireNoError(t, err)
+	assertEqual(t, driver.ContributorInsightsDisabled, got)
+
+	_, err = m.UpdateContributorInsights(ctx, "metrics", "no-index", true)
+	assertTrueT(t, cerrors.IsNotFound(err), "unknown index should be NotFound")
+
+	_, _, err = m.DescribeContributorInsights(ctx, "ghost", "")
+	assertTrueT(t, cerrors.IsNotFound(err), "missing table should be NotFound")
+}
+
+// TestGlobalTableLifecycle covers create/describe/list/update and the guards for
+// a missing underlying table, a duplicate global table, a missing global table,
+// a duplicate replica and a missing replica.
+func TestGlobalTableLifecycle(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	createTestTable(m, "sessions")
+
+	info, err := m.CreateGlobalTable(ctx, "sessions", []string{"us-east-1"})
+	requireNoError(t, err)
+	assertEqual(t, driver.GlobalTableStatusActive, info.Status)
+	assertEqual(t, 1, len(info.Regions))
+	assertNotEmpty(t, info.Arn)
+
+	desc, err := m.DescribeGlobalTable(ctx, "sessions")
+	requireNoError(t, err)
+	assertEqual(t, "sessions", desc.Name)
+
+	all, err := m.ListGlobalTables(ctx, "")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(all))
+
+	upd, err := m.UpdateGlobalTable(ctx, "sessions", []string{"us-west-2"}, nil)
+	requireNoError(t, err)
+	assertEqual(t, 2, len(upd.Regions))
+
+	rem, err := m.UpdateGlobalTable(ctx, "sessions", nil, []string{"us-west-2"})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(rem.Regions))
+
+	filtered, err := m.ListGlobalTables(ctx, "eu-west-1")
+	requireNoError(t, err)
+	assertEqual(t, 0, len(filtered))
+
+	_, err = m.CreateGlobalTable(ctx, "ghost", []string{"us-east-1"})
+	assertTrueT(t, cerrors.IsNotFound(err), "create over missing table should be NotFound")
+
+	_, err = m.CreateGlobalTable(ctx, "sessions", []string{"us-east-1"})
+	assertTrueT(t, cerrors.IsAlreadyExists(err), "duplicate global table should be AlreadyExists")
+
+	_, err = m.DescribeGlobalTable(ctx, "nope")
+	assertTrueT(t, cerrors.IsNotFound(err), "describe of missing global table should be NotFound")
+
+	_, err = m.UpdateGlobalTable(ctx, "sessions", []string{"us-east-1"}, nil)
+	assertTrueT(t, cerrors.IsAlreadyExists(err), "duplicate replica should be AlreadyExists")
+
+	_, err = m.UpdateGlobalTable(ctx, "sessions", nil, []string{"ap-south-1"})
+	assertTrueT(t, cerrors.IsFailedPrecondition(err), "missing replica should be FailedPrecondition")
+}
+
+// TestOpSurfaceSnapshotRoundTrip verifies the new state (Kinesis destinations,
+// Contributor Insights records, global tables) survives a Snapshot/Restore.
+func TestOpSurfaceSnapshotRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	createTestTable(m, "orders")
+
+	const arn = "arn:aws:kinesis:us-east-1:000000000000:stream/s"
+	requireNoError(t, mustDest(m.EnableKinesisStreamingDestination(ctx, "orders", arn, "MILLISECOND")))
+	requireNoError(t, mustStatus(m.UpdateContributorInsights(ctx, "orders", "", true)))
+	_, err := m.CreateGlobalTable(ctx, "orders", []string{"us-east-1", "us-west-2"})
+	requireNoError(t, err)
+
+	data, err := m.Snapshot(ctx, true)
+	requireNoError(t, err)
+
+	restored := newTestMock()
+	requireNoError(t, restored.Restore(ctx, data))
+
+	dests, err := restored.DescribeKinesisStreamingDestination(ctx, "orders")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(dests))
+	assertEqual(t, "MILLISECOND", dests[0].Precision)
+
+	status, _, err := restored.DescribeContributorInsights(ctx, "orders", "")
+	requireNoError(t, err)
+	assertEqual(t, driver.ContributorInsightsEnabled, status)
+
+	gt, err := restored.DescribeGlobalTable(ctx, "orders")
+	requireNoError(t, err)
+	assertEqual(t, 2, len(gt.Regions))
+}
+
+func mustDest(_ driver.KinesisDestination, err error) error { return err }
+func mustStatus(_ string, err error) error                  { return err }
+
+func assertTrueT(t *testing.T, cond bool, msg string) {
+	t.Helper()
+
+	if !cond {
+		t.Fatalf("expected true: %s", msg)
+	}
+}

--- a/providers/aws/dynamodb/snapshot.go
+++ b/providers/aws/dynamodb/snapshot.go
@@ -19,8 +19,9 @@ var _ snapshot.Snapshottable = (*Mock)(nil)
 // flag. Items are keyed by their internal store key so they restore under the
 // same identity.
 type dynamoSnapshot struct {
-	Tables  map[string]*tableSnapshot  `json:"tables,omitempty"`
-	Backups map[string]*backupSnapshot `json:"backups,omitempty"`
+	Tables       map[string]*tableSnapshot          `json:"tables,omitempty"`
+	Backups      map[string]*backupSnapshot         `json:"backups,omitempty"`
+	GlobalTables map[string]*driver.GlobalTableInfo `json:"globalTables,omitempty"`
 }
 
 // backupSnapshot is one on-demand backup's serialized state: its description
@@ -31,14 +32,22 @@ type backupSnapshot struct {
 }
 
 type tableSnapshot struct {
-	Config        driver.TableConfig        `json:"config"`
-	Items         map[string]map[string]any `json:"items,omitempty"`
-	TTLConfig     driver.TTLConfig          `json:"ttlConfig,omitempty"`
-	StreamConfig  driver.StreamConfig       `json:"streamConfig,omitempty"`
-	StreamRecords []driver.StreamRecord     `json:"streamRecords,omitempty"`
-	SeqCounter    int64                     `json:"seqCounter,omitempty"`
-	Tags          map[string]string         `json:"tags,omitempty"`
-	PITREnabled   bool                      `json:"pitrEnabled,omitempty"`
+	Config        driver.TableConfig                   `json:"config"`
+	Items         map[string]map[string]any            `json:"items,omitempty"`
+	TTLConfig     driver.TTLConfig                     `json:"ttlConfig,omitempty"`
+	StreamConfig  driver.StreamConfig                  `json:"streamConfig,omitempty"`
+	StreamRecords []driver.StreamRecord                `json:"streamRecords,omitempty"`
+	SeqCounter    int64                                `json:"seqCounter,omitempty"`
+	Tags          map[string]string                    `json:"tags,omitempty"`
+	PITREnabled   bool                                 `json:"pitrEnabled,omitempty"`
+	KinesisDests  map[string]driver.KinesisDestination `json:"kinesisDests,omitempty"`
+	CI            map[string]ciSnapshot                `json:"contributorInsights,omitempty"`
+}
+
+// ciSnapshot is one table/index Contributor Insights record's serialized state.
+type ciSnapshot struct {
+	Status         string  `json:"status"`
+	LastUpdateUnix float64 `json:"lastUpdateUnix,omitempty"`
 }
 
 // Snapshot captures every table's full state as JSON. includeAssets is unused —
@@ -59,6 +68,17 @@ func (m *Mock) Snapshot(_ context.Context, _ bool) (json.RawMessage, error) {
 			SeqCounter:    td.seqCounter.Load(),
 			Tags:          td.tags,
 			PITREnabled:   td.pitrEnabled,
+			KinesisDests:  td.kinesisDests,
+			CI:            ciToSnapshot(td.ci),
+		}
+	}
+
+	if len(m.globalTables) > 0 {
+		snap.GlobalTables = make(map[string]*driver.GlobalTableInfo, len(m.globalTables))
+
+		for name, info := range m.globalTables {
+			cp := copyGlobalTable(info)
+			snap.GlobalTables[name] = &cp
 		}
 	}
 
@@ -92,6 +112,8 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 			streamRecords: ts.StreamRecords,
 			tags:          ts.Tags,
 			pitrEnabled:   ts.PITREnabled,
+			kinesisDests:  ts.KinesisDests,
+			ci:            ciFromSnapshot(ts.CI),
 		}
 		td.seqCounter.Store(ts.SeqCounter)
 
@@ -111,5 +133,40 @@ func (m *Mock) Restore(_ context.Context, data json.RawMessage) error {
 		m.backups[arn] = &backupData{info: bs.Info, items: items}
 	}
 
+	for name, info := range snap.GlobalTables {
+		cp := copyGlobalTable(info)
+		m.globalTables[name] = &cp
+	}
+
 	return nil
+}
+
+// ciToSnapshot converts a table's in-memory Contributor Insights records to
+// their serialized form.
+func ciToSnapshot(ci map[string]ciRecord) map[string]ciSnapshot {
+	if len(ci) == 0 {
+		return nil
+	}
+
+	out := make(map[string]ciSnapshot, len(ci))
+	for index, rec := range ci {
+		out[index] = ciSnapshot{Status: rec.status, LastUpdateUnix: rec.lastUpdateUnix}
+	}
+
+	return out
+}
+
+// ciFromSnapshot rebuilds a table's Contributor Insights records from their
+// serialized form.
+func ciFromSnapshot(snap map[string]ciSnapshot) map[string]ciRecord {
+	if len(snap) == 0 {
+		return nil
+	}
+
+	out := make(map[string]ciRecord, len(snap))
+	for index, s := range snap {
+		out[index] = ciRecord{status: s.Status, lastUpdateUnix: s.LastUpdateUnix}
+	}
+
+	return out
 }

--- a/server/aws/dynamodb/contributorinsights.go
+++ b/server/aws/dynamodb/contributorinsights.go
@@ -1,0 +1,160 @@
+package dynamodb
+
+import (
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+const contributorInsightsActionEnable = "ENABLE"
+
+// routeContributorInsights dispatches the Contributor Insights operations.
+// Without them Update/Describe/ListContributorInsights return
+// UnknownOperationException.
+func (h *Handler) routeContributorInsights(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "UpdateContributorInsights":
+		h.updateContributorInsights(w, r)
+	case "DescribeContributorInsights":
+		h.describeContributorInsights(w, r)
+	case "ListContributorInsights":
+		h.listContributorInsights(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// contributorInsighter returns the driver's ContributorInsighter capability,
+// writing an error response and returning false when it is unsupported.
+func (h *Handler) contributorInsighter(w http.ResponseWriter) (dbdriver.ContributorInsighter, bool) {
+	c, ok := h.db.(dbdriver.ContributorInsighter)
+	if !ok {
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"UnknownOperationException", "contributor insights are not supported by this driver")
+
+		return nil, false
+	}
+
+	return c, true
+}
+
+func (h *Handler) updateContributorInsights(w http.ResponseWriter, r *http.Request) {
+	c, ok := h.contributorInsighter(w)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		TableName                 string `json:"TableName"`
+		IndexName                 string `json:"IndexName"`
+		ContributorInsightsAction string `json:"ContributorInsightsAction"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	enable := req.ContributorInsightsAction == contributorInsightsActionEnable
+
+	status, err := c.UpdateContributorInsights(r.Context(), req.TableName, req.IndexName, enable)
+	if err != nil {
+		writeContributorInsightsErr(w, err)
+		return
+	}
+
+	resp := map[string]any{"TableName": req.TableName, "ContributorInsightsStatus": status}
+	if req.IndexName != "" {
+		resp["IndexName"] = req.IndexName
+	}
+
+	wire.WriteJSON(w, resp)
+}
+
+func (h *Handler) describeContributorInsights(w http.ResponseWriter, r *http.Request) {
+	c, ok := h.contributorInsighter(w)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		TableName string `json:"TableName"`
+		IndexName string `json:"IndexName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	status, lastUpdate, err := c.DescribeContributorInsights(r.Context(), req.TableName, req.IndexName)
+	if err != nil {
+		writeContributorInsightsErr(w, err)
+		return
+	}
+
+	resp := map[string]any{
+		"TableName":                   req.TableName,
+		"ContributorInsightsStatus":   status,
+		"ContributorInsightsRuleList": []any{},
+	}
+	if req.IndexName != "" {
+		resp["IndexName"] = req.IndexName
+	}
+
+	if lastUpdate != 0 {
+		resp["LastUpdateDateTime"] = lastUpdate
+	}
+
+	wire.WriteJSON(w, resp)
+}
+
+func (h *Handler) listContributorInsights(w http.ResponseWriter, r *http.Request) {
+	c, ok := h.contributorInsighter(w)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		TableName string `json:"TableName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	summaries, err := c.ListContributorInsights(r.Context(), req.TableName)
+	if err != nil {
+		writeContributorInsightsErr(w, err)
+		return
+	}
+
+	rendered := make([]map[string]any, 0, len(summaries))
+
+	for i := range summaries {
+		block := map[string]any{
+			"TableName":                 summaries[i].Table,
+			"ContributorInsightsStatus": summaries[i].Status,
+		}
+		if summaries[i].Index != "" {
+			block["IndexName"] = summaries[i].Index
+		}
+
+		rendered = append(rendered, block)
+	}
+
+	wire.WriteJSON(w, map[string]any{"ContributorInsightsSummaries": rendered})
+}
+
+// writeContributorInsightsErr maps a provider not-found (missing table or index)
+// to ResourceNotFoundException.
+func writeContributorInsightsErr(w http.ResponseWriter, err error) {
+	if cerrors.IsNotFound(err) {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", errMessage(err))
+		return
+	}
+
+	writeErr(w, err)
+}

--- a/server/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/server/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -926,14 +926,25 @@ func TestDDBTypedErrors(t *testing.T) {
 	})
 
 	t.Run("unrouted operation is UnknownOperationException", func(t *testing.T) {
-		// DescribeLimits has no HTTP surface in the emulator.
-		_, err := client.DescribeLimits(ctx, &dynamodb.DescribeLimitsInput{})
+		// ExecuteStatement (PartiQL) has no HTTP surface in the emulator.
+		_, err := client.ExecuteStatement(ctx, &dynamodb.ExecuteStatementInput{
+			Statement: aws.String("SELECT * FROM errs"),
+		})
 		require.Error(t, err)
 
 		var apiErr smithy.APIError
 
 		require.True(t, errors.As(err, &apiErr))
 		assert.Equal(t, "UnknownOperationException", apiErr.ErrorCode())
+	})
+
+	t.Run("DescribeLimits reports account and table capacity ceilings", func(t *testing.T) {
+		out, err := client.DescribeLimits(ctx, &dynamodb.DescribeLimitsInput{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(80000), aws.ToInt64(out.AccountMaxReadCapacityUnits))
+		assert.Equal(t, int64(80000), aws.ToInt64(out.AccountMaxWriteCapacityUnits))
+		assert.Equal(t, int64(40000), aws.ToInt64(out.TableMaxReadCapacityUnits))
+		assert.Equal(t, int64(40000), aws.ToInt64(out.TableMaxWriteCapacityUnits))
 	})
 }
 

--- a/server/aws/dynamodb/dynamodb_op_surface_test.go
+++ b/server/aws/dynamodb/dynamodb_op_surface_test.go
@@ -1,0 +1,198 @@
+// dynamodb_op_surface_test.go — real-user-journey tests for the management
+// operations added to complete the DynamoDB control-plane surface: Kinesis
+// streaming destinations, Contributor Insights, version-2017 global tables,
+// and the account-level DescribeLimits/DescribeEndpoints. Each drives the
+// genuine aws-sdk-go-v2 DynamoDB client against the emulator's HTTP server.
+package dynamodb_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDDBKinesisStreamingDestination: enable a Kinesis destination on a table,
+// describe it (ACTIVE), disable it (DISABLED), and observe the typed 404 for a
+// missing table.
+func TestDDBKinesisStreamingDestination(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "events", "id", "")
+
+	const streamArn = "arn:aws:kinesis:us-east-1:000000000000:stream/events-stream"
+
+	en, err := client.EnableKinesisStreamingDestination(ctx, &dynamodb.EnableKinesisStreamingDestinationInput{
+		TableName: aws.String("events"),
+		StreamArn: aws.String(streamArn),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ddbtypes.DestinationStatusActive, en.DestinationStatus)
+	assert.Equal(t, streamArn, aws.ToString(en.StreamArn))
+
+	desc, err := client.DescribeKinesisStreamingDestination(ctx, &dynamodb.DescribeKinesisStreamingDestinationInput{
+		TableName: aws.String("events"),
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.KinesisDataStreamDestinations, 1)
+	assert.Equal(t, streamArn, aws.ToString(desc.KinesisDataStreamDestinations[0].StreamArn))
+	assert.Equal(t, ddbtypes.DestinationStatusActive, desc.KinesisDataStreamDestinations[0].DestinationStatus)
+
+	dis, err := client.DisableKinesisStreamingDestination(ctx, &dynamodb.DisableKinesisStreamingDestinationInput{
+		TableName: aws.String("events"),
+		StreamArn: aws.String(streamArn),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ddbtypes.DestinationStatusDisabled, dis.DestinationStatus)
+
+	var rnf *ddbtypes.ResourceNotFoundException
+	_, err = client.DescribeKinesisStreamingDestination(ctx, &dynamodb.DescribeKinesisStreamingDestinationInput{
+		TableName: aws.String("ghost"),
+	})
+	require.ErrorAs(t, err, &rnf)
+}
+
+// TestDDBContributorInsights: enable Contributor Insights for a table, describe
+// it (ENABLED), list it, disable it (DISABLED), and observe the typed 404 for a
+// missing table.
+func TestDDBContributorInsights(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "metrics", "id", "")
+
+	up, err := client.UpdateContributorInsights(ctx, &dynamodb.UpdateContributorInsightsInput{
+		TableName:                 aws.String("metrics"),
+		ContributorInsightsAction: ddbtypes.ContributorInsightsActionEnable,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ddbtypes.ContributorInsightsStatusEnabled, up.ContributorInsightsStatus)
+
+	desc, err := client.DescribeContributorInsights(ctx, &dynamodb.DescribeContributorInsightsInput{
+		TableName: aws.String("metrics"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ddbtypes.ContributorInsightsStatusEnabled, desc.ContributorInsightsStatus)
+
+	list, err := client.ListContributorInsights(ctx, &dynamodb.ListContributorInsightsInput{})
+	require.NoError(t, err)
+	require.Len(t, list.ContributorInsightsSummaries, 1)
+	assert.Equal(t, "metrics", aws.ToString(list.ContributorInsightsSummaries[0].TableName))
+
+	dis, err := client.UpdateContributorInsights(ctx, &dynamodb.UpdateContributorInsightsInput{
+		TableName:                 aws.String("metrics"),
+		ContributorInsightsAction: ddbtypes.ContributorInsightsActionDisable,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ddbtypes.ContributorInsightsStatusDisabled, dis.ContributorInsightsStatus)
+
+	var rnf *ddbtypes.ResourceNotFoundException
+	_, err = client.DescribeContributorInsights(ctx, &dynamodb.DescribeContributorInsightsInput{
+		TableName: aws.String("ghost"),
+	})
+	require.ErrorAs(t, err, &rnf)
+}
+
+// TestDDBGlobalTableLifecycle: create a version-2017 global table over an
+// existing table, describe/list it, add a replica via UpdateGlobalTable, and
+// observe the typed errors for a missing global table and a missing underlying
+// table.
+func TestDDBGlobalTableLifecycle(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "sessions", "id", "")
+
+	cr, err := client.CreateGlobalTable(ctx, &dynamodb.CreateGlobalTableInput{
+		GlobalTableName: aws.String("sessions"),
+		ReplicationGroup: []ddbtypes.Replica{
+			{RegionName: aws.String("us-east-1")},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "sessions", aws.ToString(cr.GlobalTableDescription.GlobalTableName))
+	require.Len(t, cr.GlobalTableDescription.ReplicationGroup, 1)
+
+	desc, err := client.DescribeGlobalTable(ctx, &dynamodb.DescribeGlobalTableInput{
+		GlobalTableName: aws.String("sessions"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ddbtypes.GlobalTableStatusActive, desc.GlobalTableDescription.GlobalTableStatus)
+
+	list, err := client.ListGlobalTables(ctx, &dynamodb.ListGlobalTablesInput{})
+	require.NoError(t, err)
+	require.Len(t, list.GlobalTables, 1)
+	assert.Equal(t, "sessions", aws.ToString(list.GlobalTables[0].GlobalTableName))
+
+	upd, err := client.UpdateGlobalTable(ctx, &dynamodb.UpdateGlobalTableInput{
+		GlobalTableName: aws.String("sessions"),
+		ReplicaUpdates: []ddbtypes.ReplicaUpdate{
+			{Create: &ddbtypes.CreateReplicaAction{RegionName: aws.String("us-west-2")}},
+		},
+	})
+	require.NoError(t, err)
+	assert.Len(t, upd.GlobalTableDescription.ReplicationGroup, 2)
+
+	// Describe on a global table that was never created is a typed 404.
+	var gtnf *ddbtypes.GlobalTableNotFoundException
+	_, err = client.DescribeGlobalTable(ctx, &dynamodb.DescribeGlobalTableInput{
+		GlobalTableName: aws.String("nope"),
+	})
+	require.ErrorAs(t, err, &gtnf)
+
+	// CreateGlobalTable over a table that does not exist is a typed
+	// TableNotFoundException.
+	var tnf *ddbtypes.TableNotFoundException
+	_, err = client.CreateGlobalTable(ctx, &dynamodb.CreateGlobalTableInput{
+		GlobalTableName:  aws.String("ghost"),
+		ReplicationGroup: []ddbtypes.Replica{{RegionName: aws.String("us-east-1")}},
+	})
+	require.ErrorAs(t, err, &tnf)
+
+	// A duplicate global table is a typed GlobalTableAlreadyExistsException.
+	var exists *ddbtypes.GlobalTableAlreadyExistsException
+	_, err = client.CreateGlobalTable(ctx, &dynamodb.CreateGlobalTableInput{
+		GlobalTableName:  aws.String("sessions"),
+		ReplicationGroup: []ddbtypes.Replica{{RegionName: aws.String("us-east-1")}},
+	})
+	require.ErrorAs(t, err, &exists)
+}
+
+// TestDDBDescribeEndpoints: DescribeEndpoints reports the emulator's own host so
+// an endpoint-discovery client keeps talking to it.
+func TestDDBDescribeEndpoints(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	out, err := client.DescribeEndpoints(ctx, &dynamodb.DescribeEndpointsInput{})
+	require.NoError(t, err)
+	require.Len(t, out.Endpoints, 1)
+	assert.NotEmpty(t, aws.ToString(out.Endpoints[0].Address))
+	assert.Positive(t, out.Endpoints[0].CachePeriodInMinutes)
+}
+
+// TestDDBContributorInsightsMissingIndex: Describe on a non-existent index of an
+// existing table is a typed ResourceNotFoundException.
+func TestDDBContributorInsightsMissingIndex(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "idxless", "id", "")
+
+	_, err := client.DescribeContributorInsights(ctx, &dynamodb.DescribeContributorInsightsInput{
+		TableName: aws.String("idxless"),
+		IndexName: aws.String("no-such-index"),
+	})
+	require.Error(t, err)
+
+	var apiErr smithy.APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, "ResourceNotFoundException", apiErr.ErrorCode())
+}

--- a/server/aws/dynamodb/globaltable.go
+++ b/server/aws/dynamodb/globaltable.go
@@ -1,0 +1,228 @@
+package dynamodb
+
+import (
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+// routeGlobalTables dispatches the version-2017 global-table operations. Without
+// them Create/Describe/Update/ListGlobalTables return UnknownOperationException
+// and the aws_dynamodb_global_table resource cannot be managed.
+func (h *Handler) routeGlobalTables(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateGlobalTable":
+		h.createGlobalTable(w, r)
+	case "DescribeGlobalTable":
+		h.describeGlobalTable(w, r)
+	case "UpdateGlobalTable":
+		h.updateGlobalTable(w, r)
+	case "ListGlobalTables":
+		h.listGlobalTables(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// globalTabler returns the driver's GlobalTabler capability, writing an error
+// response and returning false when it is unsupported.
+func (h *Handler) globalTabler(w http.ResponseWriter) (dbdriver.GlobalTabler, bool) {
+	g, ok := h.db.(dbdriver.GlobalTabler)
+	if !ok {
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"UnknownOperationException", "global tables are not supported by this driver")
+
+		return nil, false
+	}
+
+	return g, true
+}
+
+// replicaJSON is a Replica in a create/update replication group.
+type replicaJSON struct {
+	RegionName string `json:"RegionName"`
+}
+
+func (h *Handler) createGlobalTable(w http.ResponseWriter, r *http.Request) {
+	g, ok := h.globalTabler(w)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		GlobalTableName  string        `json:"GlobalTableName"`
+		ReplicationGroup []replicaJSON `json:"ReplicationGroup"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	info, err := g.CreateGlobalTable(r.Context(), req.GlobalTableName, regionNames(req.ReplicationGroup))
+	if err != nil {
+		// A missing underlying table is a TableNotFoundException on create.
+		writeGlobalTableErr(w, err, "TableNotFoundException")
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"GlobalTableDescription": globalTableDescription(&info)})
+}
+
+func (h *Handler) describeGlobalTable(w http.ResponseWriter, r *http.Request) {
+	g, ok := h.globalTabler(w)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		GlobalTableName string `json:"GlobalTableName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	info, err := g.DescribeGlobalTable(r.Context(), req.GlobalTableName)
+	if err != nil {
+		writeGlobalTableErr(w, err, "GlobalTableNotFoundException")
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"GlobalTableDescription": globalTableDescription(&info)})
+}
+
+func (h *Handler) updateGlobalTable(w http.ResponseWriter, r *http.Request) {
+	g, ok := h.globalTabler(w)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		GlobalTableName string `json:"GlobalTableName"`
+		ReplicaUpdates  []struct {
+			Create *replicaJSON `json:"Create"`
+			Delete *replicaJSON `json:"Delete"`
+		} `json:"ReplicaUpdates"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	var add, remove []string
+
+	for _, u := range req.ReplicaUpdates {
+		if u.Create != nil {
+			add = append(add, u.Create.RegionName)
+		}
+
+		if u.Delete != nil {
+			remove = append(remove, u.Delete.RegionName)
+		}
+	}
+
+	info, err := g.UpdateGlobalTable(r.Context(), req.GlobalTableName, add, remove)
+	if err != nil {
+		writeGlobalTableErr(w, err, "GlobalTableNotFoundException")
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"GlobalTableDescription": globalTableDescription(&info)})
+}
+
+func (h *Handler) listGlobalTables(w http.ResponseWriter, r *http.Request) {
+	g, ok := h.globalTabler(w)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		RegionName string `json:"RegionName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	tables, err := g.ListGlobalTables(r.Context(), req.RegionName)
+	if err != nil {
+		writeGlobalTableErr(w, err, "GlobalTableNotFoundException")
+		return
+	}
+
+	rendered := make([]map[string]any, 0, len(tables))
+	for i := range tables {
+		rendered = append(rendered, map[string]any{
+			"GlobalTableName":  tables[i].Name,
+			"ReplicationGroup": replicaGroup(tables[i].Regions),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"GlobalTables": rendered})
+}
+
+// globalTableDescription renders the GlobalTableDescription block common to the
+// create/describe/update responses.
+func globalTableDescription(info *dbdriver.GlobalTableInfo) map[string]any {
+	return map[string]any{
+		"GlobalTableName":   info.Name,
+		"GlobalTableArn":    info.Arn,
+		"GlobalTableStatus": info.Status,
+		"CreationDateTime":  info.CreatedUnix,
+		"ReplicationGroup":  replicaGroup(info.Regions),
+	}
+}
+
+// replicaGroup renders a replica list as ReplicationGroup entries.
+func replicaGroup(regions []string) []map[string]any {
+	group := make([]map[string]any, 0, len(regions))
+	for _, region := range regions {
+		group = append(group, map[string]any{"RegionName": region})
+	}
+
+	return group
+}
+
+// regionNames extracts the region names from a decoded replication group.
+func regionNames(replicas []replicaJSON) []string {
+	names := make([]string, 0, len(replicas))
+	for _, rep := range replicas {
+		names = append(names, rep.RegionName)
+	}
+
+	return names
+}
+
+// writeGlobalTableErr maps a provider error to the DynamoDB global-table
+// exception the caller expects. notFoundEx is the exception for a not-found
+// (TableNotFoundException on create, GlobalTableNotFoundException elsewhere);
+// an already-exists becomes GlobalTableAlreadyExistsException (create) or
+// ReplicaAlreadyExistsException (update), and a failed-precondition is a
+// missing replica on update (ReplicaNotFoundException).
+func writeGlobalTableErr(w http.ResponseWriter, err error, notFoundEx string) {
+	switch {
+	case cerrors.IsNotFound(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, notFoundEx, errMessage(err))
+	case cerrors.IsAlreadyExists(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, alreadyExistsEx(notFoundEx), errMessage(err))
+	case cerrors.IsFailedPrecondition(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ReplicaNotFoundException", errMessage(err))
+	default:
+		writeErr(w, err)
+	}
+}
+
+// alreadyExistsEx picks the already-exists exception for a global-table
+// operation: create conflicts on the global table itself, every other op's
+// conflict is a duplicate replica.
+func alreadyExistsEx(notFoundEx string) string {
+	if notFoundEx == "TableNotFoundException" {
+		return "GlobalTableAlreadyExistsException"
+	}
+
+	return "ReplicaAlreadyExistsException"
+}

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -231,7 +231,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
 
 	if h.routeTables(w, r, op) || h.routeItems(w, r, op) || h.routeBatch(w, r, op) ||
-		h.routeTags(w, r, op) || h.routeTTL(w, r, op) || h.routeBackups(w, r, op) {
+		h.routeTags(w, r, op) || h.routeTTL(w, r, op) || h.routeBackups(w, r, op) ||
+		h.routeGlobalTables(w, r, op) || h.routeKinesis(w, r, op) ||
+		h.routeContributorInsights(w, r, op) || h.routeLimits(w, r, op) {
 		return
 	}
 

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -230,11 +230,16 @@ func (*Handler) Matches(r *http.Request) bool {
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
 
-	if h.routeTables(w, r, op) || h.routeItems(w, r, op) || h.routeBatch(w, r, op) ||
-		h.routeTags(w, r, op) || h.routeTTL(w, r, op) || h.routeBackups(w, r, op) ||
-		h.routeGlobalTables(w, r, op) || h.routeKinesis(w, r, op) ||
-		h.routeContributorInsights(w, r, op) || h.routeLimits(w, r, op) {
-		return
+	routes := []func(http.ResponseWriter, *http.Request, string) bool{
+		h.routeTables, h.routeItems, h.routeBatch, h.routeTags, h.routeTTL,
+		h.routeBackups, h.routeGlobalTables, h.routeKinesis,
+		h.routeContributorInsights, h.routeLimits,
+	}
+
+	for _, route := range routes {
+		if route(w, r, op) {
+			return
+		}
 	}
 
 	wire.WriteJSONError(w, http.StatusBadRequest,

--- a/server/aws/dynamodb/kinesis.go
+++ b/server/aws/dynamodb/kinesis.go
@@ -1,0 +1,189 @@
+package dynamodb
+
+import (
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+// routeKinesis dispatches the Kinesis Data Streams streaming-destination
+// operations. Without them Enable/Disable/Update/DescribeKinesisStreamingDestination
+// return UnknownOperationException and the aws_dynamodb_kinesis_streaming_destination
+// resource cannot be managed.
+func (h *Handler) routeKinesis(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "EnableKinesisStreamingDestination":
+		h.enableKinesisStreamingDestination(w, r)
+	case "DisableKinesisStreamingDestination":
+		h.disableKinesisStreamingDestination(w, r)
+	case "UpdateKinesisStreamingDestination":
+		h.updateKinesisStreamingDestination(w, r)
+	case "DescribeKinesisStreamingDestination":
+		h.describeKinesisStreamingDestination(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// kinesisStreamer returns the driver's KinesisStreamer capability, writing an
+// error response and returning false when the driver does not implement it.
+func (h *Handler) kinesisStreamer(w http.ResponseWriter) (dbdriver.KinesisStreamer, bool) {
+	k, ok := h.db.(dbdriver.KinesisStreamer)
+	if !ok {
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"UnknownOperationException", "kinesis streaming destinations are not supported by this driver")
+
+		return nil, false
+	}
+
+	return k, true
+}
+
+// kinesisRequest is the shared wire shape for the enable/disable/update
+// streaming-destination operations.
+type kinesisRequest struct {
+	TableName                           string `json:"TableName"`
+	StreamArn                           string `json:"StreamArn"`
+	EnableKinesisStreamingConfiguration *struct {
+		ApproximateCreationDateTimePrecision string `json:"ApproximateCreationDateTimePrecision"`
+	} `json:"EnableKinesisStreamingConfiguration"`
+	UpdateKinesisStreamingConfiguration *struct {
+		ApproximateCreationDateTimePrecision string `json:"ApproximateCreationDateTimePrecision"`
+	} `json:"UpdateKinesisStreamingConfiguration"`
+}
+
+// kinesisAction performs one destination mutation identified by act, given the
+// decoded request; the enable/disable/update handlers differ only in act.
+type kinesisAction func(k dbdriver.KinesisStreamer, r *http.Request, req *kinesisRequest) (dbdriver.KinesisDestination, error)
+
+// mutateKinesisDestination is the shared body of the enable/disable/update
+// operations: resolve the capability, decode the request, apply act and render
+// the resulting destination.
+func (h *Handler) mutateKinesisDestination(w http.ResponseWriter, r *http.Request, act kinesisAction) {
+	k, ok := h.kinesisStreamer(w)
+	if !ok {
+		return
+	}
+
+	var req kinesisRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	dest, err := act(k, r, &req)
+	if err != nil {
+		writeKinesisErr(w, err)
+		return
+	}
+
+	writeKinesisDestination(w, req.TableName, dest)
+}
+
+func (h *Handler) enableKinesisStreamingDestination(w http.ResponseWriter, r *http.Request) {
+	h.mutateKinesisDestination(w, r, func(k dbdriver.KinesisStreamer,
+		r *http.Request, req *kinesisRequest) (dbdriver.KinesisDestination, error) {
+		precision := ""
+		if req.EnableKinesisStreamingConfiguration != nil {
+			precision = req.EnableKinesisStreamingConfiguration.ApproximateCreationDateTimePrecision
+		}
+
+		return k.EnableKinesisStreamingDestination(r.Context(), req.TableName, req.StreamArn, precision)
+	})
+}
+
+func (h *Handler) disableKinesisStreamingDestination(w http.ResponseWriter, r *http.Request) {
+	h.mutateKinesisDestination(w, r, func(k dbdriver.KinesisStreamer,
+		r *http.Request, req *kinesisRequest) (dbdriver.KinesisDestination, error) {
+		return k.DisableKinesisStreamingDestination(r.Context(), req.TableName, req.StreamArn)
+	})
+}
+
+func (h *Handler) updateKinesisStreamingDestination(w http.ResponseWriter, r *http.Request) {
+	h.mutateKinesisDestination(w, r, func(k dbdriver.KinesisStreamer,
+		r *http.Request, req *kinesisRequest) (dbdriver.KinesisDestination, error) {
+		precision := ""
+		if req.UpdateKinesisStreamingConfiguration != nil {
+			precision = req.UpdateKinesisStreamingConfiguration.ApproximateCreationDateTimePrecision
+		}
+
+		return k.UpdateKinesisStreamingDestination(r.Context(), req.TableName, req.StreamArn, precision)
+	})
+}
+
+func (h *Handler) describeKinesisStreamingDestination(w http.ResponseWriter, r *http.Request) {
+	k, ok := h.kinesisStreamer(w)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		TableName string `json:"TableName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	dests, err := k.DescribeKinesisStreamingDestination(r.Context(), req.TableName)
+	if err != nil {
+		writeKinesisErr(w, err)
+		return
+	}
+
+	rendered := make([]map[string]any, 0, len(dests))
+	for i := range dests {
+		rendered = append(rendered, kinesisDestinationBlock(&dests[i]))
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"TableName":                     req.TableName,
+		"KinesisDataStreamDestinations": rendered,
+	})
+}
+
+// writeKinesisDestination renders the response shared by the enable/disable/update
+// operations: the table, the stream and the resulting destination status.
+func writeKinesisDestination(w http.ResponseWriter, table string, dest dbdriver.KinesisDestination) {
+	resp := map[string]any{
+		"TableName":         table,
+		"StreamArn":         dest.StreamArn,
+		"DestinationStatus": dest.Status,
+	}
+	if dest.Precision != "" {
+		resp["EnableKinesisStreamingConfiguration"] = map[string]any{
+			"ApproximateCreationDateTimePrecision": dest.Precision,
+		}
+	}
+
+	wire.WriteJSON(w, resp)
+}
+
+// kinesisDestinationBlock renders one destination inside a
+// DescribeKinesisStreamingDestination response.
+func kinesisDestinationBlock(dest *dbdriver.KinesisDestination) map[string]any {
+	block := map[string]any{
+		"StreamArn":         dest.StreamArn,
+		"DestinationStatus": dest.Status,
+	}
+	if dest.Precision != "" {
+		block["ApproximateCreationDateTimePrecision"] = dest.Precision
+	}
+
+	return block
+}
+
+// writeKinesisErr maps a provider error to the DynamoDB exception the Kinesis
+// streaming operations return: a not-found (missing table or destination)
+// becomes ResourceNotFoundException.
+func writeKinesisErr(w http.ResponseWriter, err error) {
+	if cerrors.IsNotFound(err) {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", errMessage(err))
+		return
+	}
+
+	writeErr(w, err)
+}

--- a/server/aws/dynamodb/limits.go
+++ b/server/aws/dynamodb/limits.go
@@ -1,0 +1,55 @@
+package dynamodb
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+)
+
+// DynamoDB's default provisioned-capacity ceilings, reported by DescribeLimits.
+// These are the real per-account and per-table defaults an unmodified account
+// carries, so an SDK caller reading them sees the documented values.
+const (
+	accountMaxCapacityUnits = 80000
+	tableMaxCapacityUnits   = 40000
+)
+
+// endpointCachePeriodMinutes is the CachePeriodInMinutes DynamoDB advertises for
+// its endpoint-discovery entry.
+const endpointCachePeriodMinutes = 1440
+
+// routeLimits dispatches the account-level DescribeLimits and DescribeEndpoints
+// operations, which carry no per-table state.
+func (*Handler) routeLimits(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "DescribeLimits":
+		describeLimits(w)
+	case "DescribeEndpoints":
+		describeEndpoints(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// describeLimits reports the account's provisioned-capacity ceilings.
+func describeLimits(w http.ResponseWriter) {
+	wire.WriteJSON(w, map[string]any{
+		"AccountMaxReadCapacityUnits":  accountMaxCapacityUnits,
+		"AccountMaxWriteCapacityUnits": accountMaxCapacityUnits,
+		"TableMaxReadCapacityUnits":    tableMaxCapacityUnits,
+		"TableMaxWriteCapacityUnits":   tableMaxCapacityUnits,
+	})
+}
+
+// describeEndpoints reports the request's own host as the DynamoDB endpoint, so
+// an endpoint-discovery-enabled client keeps talking to the emulator.
+func describeEndpoints(w http.ResponseWriter, r *http.Request) {
+	wire.WriteJSON(w, map[string]any{
+		"Endpoints": []map[string]any{{
+			"Address":              r.Host,
+			"CachePeriodInMinutes": endpointCachePeriodMinutes,
+		}},
+	})
+}

--- a/services/database/driver/contributorinsights.go
+++ b/services/database/driver/contributorinsights.go
@@ -1,0 +1,37 @@
+package driver
+
+import "context"
+
+// Contributor Insights status constants. Enabling/disabling is synchronous in
+// the emulator, so an ENABLE lands ENABLED and a DISABLE lands DISABLED.
+const (
+	ContributorInsightsEnabled  = "ENABLED"
+	ContributorInsightsDisabled = "DISABLED"
+)
+
+// ContributorInsightsSummary describes the Contributor Insights state of one
+// table or table index. Index is empty for the table itself, otherwise the GSI
+// name. Status is ContributorInsightsEnabled / ContributorInsightsDisabled.
+type ContributorInsightsSummary struct {
+	Table  string
+	Index  string
+	Status string
+}
+
+// ContributorInsighter is an OPTIONAL capability, discovered by type assertion
+// (like Backuper): a provider whose tables report Contributor Insights state
+// implements it. Only the AWS DynamoDB mock does; Cosmos DB / Firestore don't,
+// so it stays off the cross-cloud Database interface.
+type ContributorInsighter interface {
+	// UpdateContributorInsights enables or disables Contributor Insights for the
+	// table (index empty) or one of its GSIs, returning the resulting status.
+	UpdateContributorInsights(ctx context.Context, table, index string, enable bool) (string, error)
+	// DescribeContributorInsights returns the Contributor Insights status of the
+	// table or index (DISABLED when never enabled), plus the last update time as
+	// a Unix-seconds value (0 when never changed).
+	DescribeContributorInsights(ctx context.Context, table, index string) (status string, lastUpdateUnix float64, err error)
+	// ListContributorInsights returns a summary for every table/index that has a
+	// Contributor Insights record, ordered by table then index. When table is
+	// non-empty only that table's records are returned.
+	ListContributorInsights(ctx context.Context, table string) ([]ContributorInsightsSummary, error)
+}

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -88,6 +88,17 @@ type TableConfig struct {
 	TableID       string
 }
 
+// HasGSI reports whether the table declares a Global Secondary Index named name.
+func (c *TableConfig) HasGSI(name string) bool {
+	for i := range c.GSIs {
+		if c.GSIs[i].Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
 // AttributeDef is a DynamoDB attribute definition (name + scalar type S/N/B).
 type AttributeDef struct {
 	Name string

--- a/services/database/driver/globaltable.go
+++ b/services/database/driver/globaltable.go
@@ -1,0 +1,38 @@
+package driver
+
+import "context"
+
+// Global table status constants. A global table is synchronous in the emulator,
+// so CreateGlobalTable lands ACTIVE immediately.
+const (
+	GlobalTableStatusActive = "ACTIVE"
+)
+
+// GlobalTableInfo describes a version-2017 global table: its name, ARN, status,
+// creation time (Unix seconds, minted once) and the ordered list of replica
+// region names in its replication group.
+type GlobalTableInfo struct {
+	Name        string
+	Arn         string
+	Status      string  // GlobalTableStatusActive
+	CreatedUnix float64 // creation time (Unix seconds), minted once
+	Regions     []string
+}
+
+// GlobalTabler is an OPTIONAL capability, discovered by type assertion (like
+// Backuper): a provider that models version-2017 DynamoDB global tables
+// implements it. Only the AWS DynamoDB mock does; Cosmos DB / Firestore don't,
+// so it stays off the cross-cloud Database interface.
+type GlobalTabler interface {
+	// CreateGlobalTable creates a global table named after an existing table with
+	// the given replica regions.
+	CreateGlobalTable(ctx context.Context, name string, regions []string) (GlobalTableInfo, error)
+	// DescribeGlobalTable returns the global table identified by name.
+	DescribeGlobalTable(ctx context.Context, name string) (GlobalTableInfo, error)
+	// UpdateGlobalTable adds and/or removes replica regions, returning the
+	// updated description.
+	UpdateGlobalTable(ctx context.Context, name string, addRegions, removeRegions []string) (GlobalTableInfo, error)
+	// ListGlobalTables returns every global table ordered by name, optionally
+	// filtered to those with a replica in regionFilter when it is non-empty.
+	ListGlobalTables(ctx context.Context, regionFilter string) ([]GlobalTableInfo, error)
+}

--- a/services/database/driver/kinesis.go
+++ b/services/database/driver/kinesis.go
@@ -1,0 +1,41 @@
+package driver
+
+import "context"
+
+// Kinesis streaming-destination status constants. A destination is synchronous
+// in the emulator, so an enable lands ACTIVE immediately and a disable lands
+// DISABLED immediately.
+const (
+	KinesisStatusActive   = "ACTIVE"
+	KinesisStatusDisabled = "DISABLED"
+)
+
+// KinesisDestination describes one Kinesis Data Streams destination attached to
+// a table by EnableKinesisStreamingDestination. StreamArn is supplied by the
+// caller and stored verbatim; Precision is the ApproximateCreationDateTimePrecision
+// ("MILLISECOND" or "MICROSECOND") the destination records with, empty when the
+// caller left it unset.
+type KinesisDestination struct {
+	StreamArn string
+	Status    string // KinesisStatusActive / KinesisStatusDisabled
+	Precision string // ApproximateCreationDateTimePrecision, optional
+}
+
+// KinesisStreamer is an OPTIONAL capability, discovered by type assertion (like
+// Backuper): a provider whose tables can stream item-level changes to Kinesis
+// Data Streams implements it. Only the AWS DynamoDB mock does; Cosmos DB /
+// Firestore don't, so it stays off the cross-cloud Database interface.
+type KinesisStreamer interface {
+	// EnableKinesisStreamingDestination attaches streamArn to the table (or
+	// re-activates it) and returns the resulting destination.
+	EnableKinesisStreamingDestination(ctx context.Context, table, streamArn, precision string) (KinesisDestination, error)
+	// DisableKinesisStreamingDestination marks the table's streamArn destination
+	// DISABLED and returns it.
+	DisableKinesisStreamingDestination(ctx context.Context, table, streamArn string) (KinesisDestination, error)
+	// UpdateKinesisStreamingDestination changes the precision of the table's
+	// streamArn destination and returns it.
+	UpdateKinesisStreamingDestination(ctx context.Context, table, streamArn, precision string) (KinesisDestination, error)
+	// DescribeKinesisStreamingDestination returns every destination attached to
+	// the table, ordered by StreamArn.
+	DescribeKinesisStreamingDestination(ctx context.Context, table string) ([]KinesisDestination, error)
+}


### PR DESCRIPTION
## Summary

Depth pass bringing the existing AWS **DynamoDB** service up to its full **control-plane** op surface. Audit-first: the item/table/GSI/Query/Scan data path, on-demand backups, PITR/continuous backups, TTL, tags and streams were already present and are **untouched**. This PR fills the genuinely-missing management ops.

### Audit — before → after (control-plane gap list)

Already present (unchanged): CreateTable/DescribeTable/UpdateTable/DeleteTable/ListTables, item CRUD, Query/Scan, Batch/Transact, GSI ops, Backups (Create/Describe/List/Delete/Restore), Continuous backups/PITR, TTL, Tags, Streams.

Missing before → added now:
- **Global tables (version-2017)**: CreateGlobalTable / DescribeGlobalTable / UpdateGlobalTable / ListGlobalTables
- **Kinesis streaming destinations**: Enable / Disable / Update / DescribeKinesisStreamingDestination
- **Contributor Insights**: Update / Describe / ListContributorInsights
- **Account-level**: DescribeLimits, DescribeEndpoints

### Design

New ops are added as **optional driver capabilities discovered by type assertion** (the same pattern as the existing `Backuper`), so Azure Cosmos DB and GCP Firestore are **not** forced to implement DynamoDB-only methods and the shared `database` interface stays cross-cloud. New handler routes are appended after the existing ones (first-match order preserved). New per-table/global state is snapshot round-tripped and deep-copied on read; ids/ARNs and creation times are minted once via `config.Clock` (byte-stable, no clock/random on read).

Exact exception names: missing table → `ResourceNotFoundException`; missing global table → `GlobalTableNotFoundException`; CreateGlobalTable over a missing table → `TableNotFoundException`; duplicate global table → `GlobalTableAlreadyExistsException`; duplicate/missing replica → `ReplicaAlreadyExistsException` / `ReplicaNotFoundException`.

### No regression

Existing DynamoDB tests, Cosmos DB and Firestore all stay green; the data path, auto-metrics wiring, FIFO/dedup and GSI behavior are unchanged. One existing assertion (that DescribeLimits was unrouted) was updated to reflect that DescribeLimits is now implemented — it now asserts the limits and uses PartiQL `ExecuteStatement` for the UnknownOperation check.

### Verification

- Live terraform-provider-aws (AWS provider v5) against `cloudemu serve`: `aws_dynamodb_table` with `ttl` + `point_in_time_recovery` + `tags`, `aws_kinesis_stream`, and `aws_dynamodb_kinesis_streaming_destination` → apply, `plan -detailed-exitcode` = 0 (no drift), update (toggle PITR off, change TTL attribute) → apply → plan clean → destroy.
- Backup lifecycle + guards via AWS CLI over the wire: CreateBackup → DescribeBackup(AVAILABLE) → ListBackups → RestoreTableFromBackup → DeleteBackup; DescribeBackup(missing) → `BackupNotFoundException`. Global tables + Contributor Insights exercised over the wire with the exact typed errors.
- Gates: build, full vet, gofmt, golangci-lint (new code 0 issues), `-race` DynamoDB pkgs, server/providers/database/persist/root tests, go mod tidy clean, go generate idempotent (coverage doc regenerated).