### PR TITLE
fix(security): bound request-sized allocations, clamp cert key bits, set nosniff on proxied responses (CodeQL high-sev)

### DIFF
--- a/features/vcr/vcr.go
+++ b/features/vcr/vcr.go
@@ -184,6 +184,15 @@ func writeRecorded(w http.ResponseWriter, resp Response) {
 		}
 	}
 
+	// The body is a recorded response echoed verbatim. Serve it with a concrete
+	// content type (falling back to a non-active default) and disable MIME sniffing
+	// so a browser cannot reinterpret the bytes as active HTML.
+	if w.Header().Get("Content-Type") == "" {
+		w.Header().Set("Content-Type", "application/octet-stream")
+	}
+
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
 	status := resp.Status
 	if status == 0 {
 		status = http.StatusOK

--- a/features/vcr/vcr_test.go
+++ b/features/vcr/vcr_test.go
@@ -111,6 +111,12 @@ func TestRecordThenReplay(t *testing.T) {
 		t.Fatalf("replay GET must return recorded headers, got %q", resp.Header.Get("X-Echo"))
 	}
 
+	// The replayed body is served with sniffing disabled so it cannot be
+	// reinterpreted as active HTML by a browser.
+	if got := resp.Header.Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("replay X-Content-Type-Options = %q, want nosniff", got)
+	}
+
 	if body := readBody(t, doRequest(t, replayed, http.MethodPost, "/things?x=1", "payload")); body != "live:POST:/things:payload" {
 		t.Fatalf("replay POST body = %q", body)
 	}

--- a/providers/aws/acm/certificate_gen.go
+++ b/providers/aws/acm/certificate_gen.go
@@ -127,6 +127,12 @@ func rsaKeyMaterial(bits int) (signer crypto.Signer, keyPEM, sigAlg string, err 
 		bits = rsaBits2048
 	}
 
+	if bits > rsaBits4096 {
+		bits = rsaBits4096
+	}
+
+	// bits is now clamped into [rsaBits2048, rsaBits4096], so the emulator-generated
+	// cert material is never weaker than 2048 bits.
 	key, err := rsa.GenerateKey(rand.Reader, bits)
 	if err != nil {
 		return nil, "", "", errors.Newf(errors.Internal, "generate key: %v", err)

--- a/providers/azure/blobstorage/pageblob.go
+++ b/providers/azure/blobstorage/pageblob.go
@@ -17,6 +17,10 @@ const (
 	// created at a size that is a multiple of it and every Put Page / Clear Page
 	// range must be aligned to it.
 	pageSize = 512
+	// maxPageBlobBytes is Azure's documented page-blob ceiling (8 TiB). A caller
+	// controls the requested size via x-ms-blob-content-length, so bound it before
+	// allocating the backing buffer — a valid page blob stays far under this.
+	maxPageBlobBytes int64 = 8 << 40
 )
 
 // Compile-time check that Mock satisfies the optional AzurePageBlob capability
@@ -42,6 +46,15 @@ func (m *Mock) CreatePageBlob(
 		return nil, &driver.BlobOpError{
 			Status: http.StatusBadRequest, Code: "InvalidHeaderValue",
 			Message: "x-ms-blob-content-length must be a non-negative multiple of 512",
+		}
+	}
+
+	// Reject an oversized request before allocating the zeroed buffer, so a caller
+	// cannot drive an unbounded allocation with a huge content-length header.
+	if size > maxPageBlobBytes {
+		return nil, &driver.BlobOpError{
+			Status: http.StatusBadRequest, Code: "InvalidHeaderValue",
+			Message: "x-ms-blob-content-length exceeds the maximum page-blob size",
 		}
 	}
 

--- a/providers/azure/blobstorage/pageblob_test.go
+++ b/providers/azure/blobstorage/pageblob_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
 )
 
 func TestPageBlobCreateAndGetRanges(t *testing.T) {
@@ -45,6 +47,21 @@ func TestPageBlobCreateAndGetRanges(t *testing.T) {
 	assert.Equal(t, bytes.Repeat([]byte{1}, 512), obj.Data[0:512])
 	assert.Equal(t, make([]byte, 512), obj.Data[512:1024])
 	assert.Equal(t, bytes.Repeat([]byte{2}, 512), obj.Data[1024:1536])
+}
+
+func TestPageBlobRejectsOversizedRequest(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "c1"))
+
+	// A size above the documented ceiling (still page-aligned) is rejected with a
+	// wire error rather than driving an unbounded allocation.
+	_, err := m.CreatePageBlob(ctx, "c1", "pb", maxPageBlobBytes+pageSize, nil, nil)
+	require.Error(t, err)
+
+	var opErr *driver.BlobOpError
+	require.ErrorAs(t, err, &opErr)
+	assert.Equal(t, "InvalidHeaderValue", opErr.Code)
 }
 
 func TestPageBlobClearAndCoalesce(t *testing.T) {

--- a/providers/gcp/compute/gce.go
+++ b/providers/gcp/compute/gce.go
@@ -874,7 +874,17 @@ func setStoreLabels[T any](
 // keys deleted. src is never mutated (copy-on-write), so a reader still holding
 // it is unaffected. The result is always non-nil.
 func mergeTags(src, set map[string]string, remove []string) map[string]string {
-	out := make(map[string]string, len(src)+len(set))
+	// set originates from caller-supplied labels, so bound the map's pre-sized
+	// capacity before allocating it. This never drops entries (the map still grows
+	// to hold every key); it only caps the initial allocation hint.
+	const maxTagCap = 10000
+
+	capHint := len(src) + len(set)
+	if capHint > maxTagCap {
+		capHint = maxTagCap
+	}
+
+	out := make(map[string]string, capHint)
 
 	for k, v := range src {
 		out[k] = v

--- a/providers/gcp/dataproc/dataproc.go
+++ b/providers/gcp/dataproc/dataproc.go
@@ -319,6 +319,15 @@ func instanceNames(cluster, role string, count int64) []string {
 		return []string{cluster + "-m"}
 	}
 
+	// Bound the per-group instance count (originating from the request's
+	// NumInstances) with an explicit comparison immediately before the allocation
+	// it sizes. A real Dataproc cluster stays far under this; the ceiling only
+	// stops a pathological value from driving an unbounded slice.
+	const maxInstanceGroupSize = 10000
+	if count > maxInstanceGroupSize {
+		count = maxInstanceGroupSize
+	}
+
 	names := make([]string, 0, count)
 	for i := int64(0); i < count; i++ {
 		names = append(names, cluster+"-"+role+"-"+strconv.FormatInt(i, 10))

--- a/providers/gcp/dataproc/dataproc_test.go
+++ b/providers/gcp/dataproc/dataproc_test.go
@@ -308,6 +308,21 @@ func TestGetOperationUnknownIsDone(t *testing.T) {
 	}
 }
 
+func TestInstanceNamesBoundsAbsurdCount(t *testing.T) {
+	// A pathological instance count must be clamped, not drive an unbounded
+	// allocation. A normal count is returned in full.
+	const maxInstanceGroupSize = 10000
+
+	got := instanceNames("clus", "w", maxInstanceGroupSize+5)
+	if len(got) != maxInstanceGroupSize {
+		t.Fatalf("clamped names len = %d, want %d", len(got), maxInstanceGroupSize)
+	}
+
+	if n := instanceNames("clus", "w", 3); len(n) != 3 {
+		t.Fatalf("normal names len = %d, want 3", len(n))
+	}
+}
+
 func mustCreate(t *testing.T, m *Mock, name, region string) {
 	t.Helper()
 

--- a/server/gcp/cloudrun/invoke.go
+++ b/server/gcp/cloudrun/invoke.go
@@ -145,6 +145,15 @@ func writeInvokeResponse(w http.ResponseWriter, resp *driver.InvokeResponse) {
 		}
 	}
 
+	// The body is an invoked container's response echoed verbatim. Serve it with a
+	// concrete content type (falling back to a non-active default) and disable MIME
+	// sniffing so a browser cannot reinterpret the bytes as active HTML.
+	if w.Header().Get("Content-Type") == "" {
+		w.Header().Set("Content-Type", "application/octet-stream")
+	}
+
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
 	status := resp.StatusCode
 	if status == 0 {
 		status = http.StatusOK

--- a/server/gcp/cloudrun/invoke_sdk_test.go
+++ b/server/gcp/cloudrun/invoke_sdk_test.go
@@ -128,6 +128,27 @@ func TestServiceInvokeEchoesBody(t *testing.T) {
 	}
 }
 
+func TestServiceInvokeSetsNosniffAndContentType(t *testing.T) {
+	f := newInvokeFixture(t)
+	uri := f.createService(t, "sniff")
+
+	resp := f.invoke(t, uri, http.MethodPost, "/anything", strings.NewReader("<script>x</script>"), 0)
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q, want nosniff", got)
+	}
+
+	if resp.Header.Get("Content-Type") == "" {
+		t.Fatalf("Content-Type is empty, want a concrete type")
+	}
+
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != "<script>x</script>" {
+		t.Fatalf("body = %q, want verbatim echo", got)
+	}
+}
+
 func TestServiceInvokeNoBodyReturnsGreeting(t *testing.T) {
 	f := newInvokeFixture(t)
 	uri := f.createService(t, "greet")

--- a/server/gcp/metastore/wire.go
+++ b/server/gcp/metastore/wire.go
@@ -79,7 +79,17 @@ func decodeBody(w http.ResponseWriter, r *http.Request) (fields map[string]json.
 // verbatim body fields (including the seeded output-only and defaulted values)
 // with the computed name/createTime/updateTime output fields.
 func toResourceJSON(r *msdriver.Resource) (json.RawMessage, error) {
-	m := make(map[string]json.RawMessage, len(r.Fields)+minComputedFields)
+	// r.Fields is populated from the request body, so bound the map's pre-sized
+	// capacity before allocating it. This never drops fields (the map still grows
+	// to hold every entry); it only caps the initial allocation hint.
+	const maxResourceFields = 10000
+
+	capHint := len(r.Fields) + minComputedFields
+	if capHint > maxResourceFields {
+		capHint = maxResourceFields
+	}
+
+	m := make(map[string]json.RawMessage, capHint)
 	for k, v := range r.Fields {
 		m[k] = v
 	}

--- a/server/gcp/vpcaccess/wire.go
+++ b/server/gcp/vpcaccess/wire.go
@@ -75,7 +75,17 @@ func decodeBody(w http.ResponseWriter, r *http.Request) (fields map[string]json.
 // the verbatim body fields with the computed `name` output field. The real
 // Connector resource carries no createTime/updateTime, so none are injected.
 func toResourceJSON(r *vpcdriver.Resource) (json.RawMessage, error) {
-	m := make(map[string]json.RawMessage, len(r.Fields)+minComputedFields)
+	// r.Fields is populated from the request body, so bound the map's pre-sized
+	// capacity before allocating it. This never drops fields (the map still grows
+	// to hold every entry); it only caps the initial allocation hint.
+	const maxResourceFields = 10000
+
+	capHint := len(r.Fields) + minComputedFields
+	if capHint > maxResourceFields {
+		capHint = maxResourceFields
+	}
+
+	m := make(map[string]json.RawMessage, capHint)
 	for k, v := range r.Fields {
 		m[k] = v
 	}

--- a/server/gcp/workflows/wire.go
+++ b/server/gcp/workflows/wire.go
@@ -78,7 +78,17 @@ func decodeBody(w http.ResponseWriter, r *http.Request) (fields map[string]json.
 // toResourceJSON renders a driver resource as workflows/v1 wire JSON, merging the
 // verbatim body fields with the computed output-only fields.
 func toResourceJSON(r *wdriver.Resource) (json.RawMessage, error) {
-	m := make(map[string]json.RawMessage, len(r.Fields)+minComputedFields)
+	// r.Fields is populated from the request body, so bound the map's pre-sized
+	// capacity before allocating it. This never drops fields (the map still grows
+	// to hold every entry); it only caps the initial allocation hint.
+	const maxResourceFields = 10000
+
+	capHint := len(r.Fields) + minComputedFields
+	if capHint > maxResourceFields {
+		capHint = maxResourceFields
+	}
+
+	m := make(map[string]json.RawMessage, capHint)
 	for k, v := range r.Fields {
 		m[k] = v
 	}


### PR DESCRIPTION
## Summary

Security-hardening pass that closes the high-severity CodeQL alerts flagged on the release (development -> master) so CodeQL goes green legitimately — real defensive fixes, no dismissals/suppressions. These are false-positive-prone patterns in an in-memory emulator, but each fix genuinely closes the rule's data-flow.

### A) Allocation size (allocation-size-overflow / uncontrolled-allocation-size)

Every request-derived allocation now carries an explicit, named upper bound in the same function as the `make`, so the size handed to `make` is provably bounded. Happy-path behavior for valid values is unchanged.

- `providers/azure/blobstorage/pageblob.go` — reject a page-blob request above Azure's documented 8 TiB ceiling (`maxPageBlobBytes`) before allocating the zeroed buffer.
- `providers/gcp/dataproc/dataproc.go` — clamp the per-instance-group count (`maxInstanceGroupSize`) before sizing the names slice.
- `server/gcp/metastore/wire.go`, `server/gcp/vpcaccess/wire.go`, `server/gcp/workflows/wire.go` — clamp the pre-sized map capacity derived from request body fields (`maxResourceFields`); never drops fields, only caps the allocation hint.
- `providers/gcp/compute/gce.go` — clamp the merged-tags map capacity hint (`maxTagCap`).
- (ElastiCache `server/aws/elasticache/types.go` and `providers/aws/elasticache/replication_group.go` were already bounded on development.)

### B) Weak crypto key (weak-crypto-key)

- `providers/aws/acm/certificate_gen.go` — RSA key bits are now clamped into an explicit `[rsaBits2048, rsaBits4096]` range immediately before `rsa.GenerateKey`, so the value is provably >= 2048. Emulator-generated cert material only; nothing weakened (floor already existed, ceiling added to make the bound visible).

### C) Reflected XSS (reflected-xss)

Proxied/echoed response bodies are now served with a concrete content type (falling back to `application/octet-stream`) plus `X-Content-Type-Options: nosniff`, set before `WriteHeader`, so a browser cannot reinterpret the bytes as active HTML. Bytes are still passed through verbatim.

- `server/gcp/cloudrun/invoke.go` — Cloud Run invoke passthrough.
- `features/vcr/vcr.go` — VCR recorded-response replay.

## Tests

- Page-blob oversized request returns a wire error instead of an unbounded allocation.
- Dataproc instance-name count is clamped for an absurd count, unchanged for normal counts.
- Cloud Run invoke and VCR replay responses set `nosniff` + a content type.
- ACM key generation still yields a valid >= 2048-bit key (existing coverage).

Closes the CodeQL high-severity alerts (8 allocation-size, 1 weak-crypto, 2 reflected-XSS) on the pushed SHA.
